### PR TITLE
Build fix for gcc 4.5.1

### DIFF
--- a/src/rt/test/rust_test_runtime.cpp
+++ b/src/rt/test/rust_test_runtime.cpp
@@ -54,7 +54,7 @@ rust_task_test::worker::run() {
         kernel->create_domain(crate, "test");
     rust_dom *domain = handle->referent();
     domain->root_task->start(crate->get_exit_task_glue(),
-                             (uintptr_t)&task_entry, NULL, 0);
+                             (uintptr_t)&task_entry, (uintptr_t)NULL, 0);
     domain->start_main_loop();
     kernel->destroy_domain(domain);
 }


### PR DESCRIPTION
The runtime test harness fails to compile under gcc 4.5.1 on Fedora 14.

Add a cast to make the compiler happy.
