### PR TITLE
Record the ast of uses and imports

### DIFF
--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -39,6 +39,20 @@ tag def {
 type crate = spanned[crate_];
 type crate_ = rec(_mod module);
 
+type use_node = spanned[use_node_];
+type use_node_ = rec(ident name, vec[@meta_item] metadata);
+
+type import_node = spanned[import_node_];
+type import_node_ = rec(vec[ident] identifiers);
+
+tag use_or_import {
+    use_or_import_use(@use_node);
+    use_or_import_import(@import_node);
+}
+
+type meta_item = spanned[meta_item_];
+type meta_item_ = rec(ident name, str value);
+
 type block = spanned[block_];
 type block_ = rec(vec[@stmt] stmts,
                   option.t[@expr] expr,


### PR DESCRIPTION
Some points I would really like some feedback on
1) Do we have a better name for "use or import" than "use_or_import" :-)

2) Is

use foo;
import foo.bar;
use zed;

legal or should we require that all uses come first?

3) I did the same as the rustboot parser and do the "use foo;" -> "use foo(name = "foo");" conversion very early. Is that desirable or should I keep the ast closer to what the user typed?
