### PR TITLE
Add support for looking up a name introduced by an 'use'

### DIFF
--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -40,17 +40,6 @@ tag def {
 type crate = spanned[crate_];
 type crate_ = rec(_mod module);
 
-type use_node = spanned[use_node_];
-type use_node_ = rec(ident name, vec[@meta_item] metadata);
-
-type import_node = spanned[import_node_];
-type import_node_ = rec(vec[ident] identifiers);
-
-tag view_item {
-    view_item_use(@use_node);
-    view_item_import(@import_node);
-}
-
 type meta_item = spanned[meta_item_];
 type meta_item_ = rec(ident name, str value);
 
@@ -232,6 +221,12 @@ type _mod = rec(vec[@item] items,
 
 type variant_arg = rec(@ty ty, def_id id);
 type variant = rec(str name, vec[variant_arg] args, def_id id, ann ann);
+
+type view_item = spanned[view_item_];
+tag view_item_ {
+    view_item_use(ident, vec[@meta_item]);
+    view_item_import(vec[ident]);
+}
 
 type item = spanned[item_];
 tag item_ {

--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -46,9 +46,9 @@ type use_node_ = rec(ident name, vec[@meta_item] metadata);
 type import_node = spanned[import_node_];
 type import_node_ = rec(vec[ident] identifiers);
 
-tag use_or_import {
-    use_or_import_use(@use_node);
-    use_or_import_import(@import_node);
+tag view_item {
+    view_item_use(@use_node);
+    view_item_import(@import_node);
 }
 
 type meta_item = spanned[meta_item_];

--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -35,6 +35,7 @@ tag def {
     def_ty(def_id);
     def_ty_arg(def_id);
     def_binding(def_id);
+    def_use(def_id);
 }
 
 type crate = spanned[crate_];
@@ -212,20 +213,23 @@ type _obj = rec(vec[obj_field] fields,
 
 
 tag mod_index_entry {
+    mie_use(uint);
     mie_item(uint);
     mie_tag_variant(uint /* tag item index */, uint /* variant index */);
 }
 
-type _mod = rec(vec[@item] items,
-                hashmap[ident,mod_index_entry] index);
+type mod_index = hashmap[ident,mod_index_entry];
+type _mod = rec(vec[@view_item] view_items,
+                vec[@item] items,
+                mod_index index);
 
 type variant_arg = rec(@ty ty, def_id id);
 type variant = rec(str name, vec[variant_arg] args, def_id id, ann ann);
 
 type view_item = spanned[view_item_];
 tag view_item_ {
-    view_item_use(ident, vec[@meta_item]);
-    view_item_import(vec[ident]);
+    view_item_use(ident, vec[@meta_item], def_id);
+    view_item_import(vec[ident], def_id);
 }
 
 type item = spanned[item_];

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -1405,7 +1405,7 @@ impure fn parse_item_obj(parser p, ast.layer lyr) -> @ast.item {
 }
 
 impure fn parse_mod_items(parser p, token.token term) -> ast._mod {
-    parse_use_and_imports(p);
+    parse_view(p);
 
     let vec[@ast.item] items = vec();
     auto index = new_str_hash[ast.mod_index_entry]();
@@ -1721,15 +1721,15 @@ impure fn parse_import(parser p) -> @ast.import_node {
     fail;
 }
 
-impure fn parse_use_and_imports(parser p) -> vec[ast.use_or_import] {
-    let vec[ast.use_or_import] items = vec();
+impure fn parse_view(parser p) -> vec[ast.view_item] {
+    let vec[ast.view_item] items = vec();
     while (true) {
         alt (p.peek()) {
             case (token.USE) {
-                items += vec(ast.use_or_import_use(parse_use(p)));
+                items += vec(ast.view_item_use(parse_use(p)));
             }
             case (token.IMPORT) {
-                items += vec(ast.use_or_import_import(parse_import(p)));
+                items += vec(ast.view_item_import(parse_import(p)));
             }
             case (_) {
                 ret items;

--- a/src/comp/middle/resolve.rs
+++ b/src/comp/middle/resolve.rs
@@ -67,10 +67,24 @@ fn lookup_name(&env e, ast.ident i) -> option.t[def] {
         ret none[def];
     }
 
+    fn found_def_view(@ast.view_item i) -> option.t[def] {
+        alt (i.node) {
+            case (ast.view_item_use(_, _, ?id)) {
+                ret some[def](ast.def_use(id));
+            }
+            case (ast.view_item_import(_,?id)) {
+                fail;
+            }
+        }
+    }
+
     fn check_mod(ast.ident i, ast._mod m) -> option.t[def] {
         alt (m.index.find(i)) {
             case (some[ast.mod_index_entry](?ent)) {
                 alt (ent) {
+                    case (ast.mie_use(?ix)) {
+                        ret found_def_view(m.view_items.(ix));
+                    }
                     case (ast.mie_item(?ix)) {
                         ret found_def_item(m.items.(ix));
                     }


### PR DESCRIPTION
The main question in these patches is if we should add a def_use or use the existing def_mod. Since we intend to lazily read a crate, we agreed on IRC that it was better to add a def_use.
