### PR TITLE
Fix "last" lookup bug

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -448,6 +448,7 @@ TEST_XFAILS_RUSTC := $(filter-out \
                         import4.rs \
                         import5.rs \
                         import6.rs \
+                        import7.rs \
                         item-name-overload.rs \
                         large-records.rs \
                         lazy-init.rs \

--- a/src/test/run-pass/import7.rs
+++ b/src/test/run-pass/import7.rs
@@ -1,0 +1,19 @@
+import bar.baz;
+import foo.zed;
+mod foo {
+  mod zed {
+    fn baz() {
+      log "baz";
+    }
+  }
+}
+mod bar {
+  import zed.baz;
+  mod foo {
+    mod zed {
+    }
+  }
+}
+fn main(vec[str] args) {
+  baz();
+}


### PR DESCRIPTION
I had to use a '@env' since using a plain 'env' was hitting a codegen bug in rustboot. It might be a better idea to use a ref counted pointer anyway.
