### PR TITLE
#fmt syntax extension

### DIFF
--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -185,7 +185,7 @@ tag expr_ {
     expr_field(@expr, ident, ann);
     expr_index(@expr, @expr, ann);
     expr_path(path, option.t[def], ann);
-    expr_ext(path, vec[@expr], option.t[@expr], option.t[@expr], ann);
+    expr_ext(path, vec[@expr], option.t[@expr], @expr, ann);
     expr_fail;
     expr_ret(option.t[@expr]);
     expr_put(option.t[@expr]);

--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -362,17 +362,6 @@ fn is_call_expr(@expr e) -> bool {
     }
 }
 
-fn is_ext_expr(@expr e) -> bool {
-    alt (e.node) {
-        case (expr_ext(_, _, _, _, _)) {
-            ret true;
-        }
-        case (_) {
-            ret false;
-        }
-    }
-}
-
 //
 // Local Variables:
 // mode: rust

--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -185,7 +185,7 @@ tag expr_ {
     expr_field(@expr, ident, ann);
     expr_index(@expr, @expr, ann);
     expr_path(path, option.t[def], ann);
-    expr_ext(path, vec[@expr], option.t[@expr], ann);
+    expr_ext(path, vec[@expr], option.t[@expr], option.t[@expr], ann);
     expr_fail;
     expr_ret(option.t[@expr]);
     expr_put(option.t[@expr]);
@@ -354,6 +354,17 @@ fn index_native_item(native_mod_index index, @native_item it) {
 fn is_call_expr(@expr e) -> bool {
     alt (e.node) {
         case (expr_call(_, _, _)) {
+            ret true;
+        }
+        case (_) {
+            ret false;
+        }
+    }
+}
+
+fn is_ext_expr(@expr e) -> bool {
+    alt (e.node) {
+        case (expr_ext(_, _, _, _, _)) {
             ret true;
         }
         case (_) {

--- a/src/comp/front/extfmt.rs
+++ b/src/comp/front/extfmt.rs
@@ -1,14 +1,14 @@
 /* The 'fmt' extension is modeled on the posix printf system.
- * 
+ *
  * A posix conversion ostensibly looks like this:
- * 
+ *
  * %[parameter][flags][width][.precision][length]type
- * 
+ *
  * Given the different numeric type bestiary we have, we omit the 'length'
  * parameter and support slightly different conversions for 'type':
- * 
+ *
  * %[parameter][flags][width][.precision]type
- * 
+ *
  * we also only support translating-to-rust a tiny subset of the possible
  * combinations at the moment.
  */

--- a/src/comp/front/extfmt.rs
+++ b/src/comp/front/extfmt.rs
@@ -1,0 +1,84 @@
+/* The 'fmt' extension is modeled on the posix printf system.
+ * 
+ * A posix conversion ostensibly looks like this:
+ * 
+ * %[parameter][flags][width][.precision][length]type
+ * 
+ * Given the different numeric type bestiary we have, we omit the 'length'
+ * parameter and support slightly different conversions for 'type':
+ * 
+ * %[parameter][flags][width][.precision]type
+ * 
+ * we also only support translating-to-rust a tiny subset of the possible
+ * combinations at the moment.
+ */
+
+use std;
+
+import std.option;
+
+tag signedness {
+    signed;
+    unsigned;
+}
+
+tag caseness {
+    case_upper;
+    case_lower;
+}
+
+tag ty {
+    ty_bool;
+    ty_str;
+    ty_char;
+    ty_int(signedness);
+    ty_bits;
+    ty_hex(caseness);
+    // FIXME: More types
+}
+
+tag flag {
+    flag_left_justify;
+    flag_left_zero_pad;
+    flag_left_space_pad;
+    flag_plus_if_positive;
+    flag_alternate;
+}
+
+tag count {
+    count_is(int);
+    count_is_param(int);
+    count_is_next_param;
+    count_implied;
+}
+
+// A formatted conversion from an expression to a string
+tag conv {
+    conv_param(option.t[int]);
+    conv_flags(vec[flag]);
+    conv_width(count);
+    conv_precision(count);
+    conv_ty(ty);
+}
+
+// A fragment of the output sequence
+tag piece {
+    piece_string(str);
+    piece_conv(str);
+}
+
+fn expand_syntax_ext(vec[@ast.expr] args,
+                     option.t[@ast.expr] body) -> @ast.expr {
+    fail;
+}
+
+//
+// Local Variables:
+// mode: rust
+// fill-column: 78;
+// indent-tabs-mode: nil
+// c-basic-offset: 4
+// buffer-file-coding-system: utf-8-unix
+// compile-command: "make -k -C ../.. 2>&1 | sed -e 's/\\/x\\//x:\\//g'";
+// End:
+//

--- a/src/comp/front/extfmt.rs
+++ b/src/comp/front/extfmt.rs
@@ -85,20 +85,7 @@ fn expand_syntax_ext(vec[@ast.expr] args,
     }
 
     auto fmt = expr_to_str(args.(0));
-    log fmt;
     auto pieces = parse_fmt_string(fmt);
-    log "printing all pieces";
-    for (piece p in pieces) {
-        alt (p) {
-            case (piece_string(?s)) {
-                log s;
-            }
-            case (piece_conv(_)) {
-                log "conv";
-            }
-        }
-    }
-    log "done printing all pieces";
     auto args_len = _vec.len[@ast.expr](args);
     auto fmt_args = _vec.slice[@ast.expr](args, 1u, args_len - 1u);
     ret pieces_to_expr(pieces, args);

--- a/src/comp/front/extfmt.rs
+++ b/src/comp/front/extfmt.rs
@@ -13,7 +13,7 @@
  * combinations at the moment.
  */
 
-import front.parser;
+import util.common;
 
 import std._str;
 import std._vec;
@@ -251,13 +251,39 @@ fn parse_type(str s, uint i, uint lim) -> tup(ty, uint) {
 }
 
 fn pieces_to_expr(vec[piece] pieces, vec[@ast.expr] args) -> @ast.expr {
-    auto lo = args.(0).span;
-    auto hi = args.(0).span;
-    auto strlit = ast.lit_str("TODO");
-    auto spstrlit = @parser.spanned[ast.lit_](lo, hi, strlit);
-    auto expr = ast.expr_lit(spstrlit, ast.ann_none);
-    auto spexpr = @parser.spanned[ast.expr_](lo, hi, expr);
-    ret spexpr;
+
+    fn make_new_str(common.span sp, str s) -> @ast.expr {
+        auto strlit = ast.lit_str(s);
+        auto spstrlit = @parser.spanned[ast.lit_](sp, sp, strlit);
+        auto expr = ast.expr_lit(spstrlit, ast.ann_none);
+        ret @parser.spanned[ast.expr_](sp, sp, expr);
+    }
+
+    fn make_add_expr(common.span sp,
+                     @ast.expr lhs, @ast.expr rhs) -> @ast.expr {
+        auto binexpr = ast.expr_binary(ast.add, lhs, rhs, ast.ann_none);
+        ret @parser.spanned[ast.expr_](sp, sp, binexpr);
+    }
+
+    auto sp = args.(0).span;
+    auto n = 0;
+    auto tmp_expr = make_new_str(sp, "whatever");
+
+    for (piece p in pieces) {
+        alt (p) {
+            case (piece_string(?s)) {
+                auto s_expr = make_new_str(sp, s);
+                tmp_expr = make_add_expr(sp, tmp_expr, s_expr);
+            }
+            case (piece_conv(?conv)) {
+            }
+        }
+    }
+
+    // TODO: Remove this print and return the real expanded AST
+    log "dumping expanded ast:";
+    log pretty.print_expr(tmp_expr);
+    ret make_new_str(sp, "TODO");
 }
 
 //

--- a/src/comp/front/extfmt.rs
+++ b/src/comp/front/extfmt.rs
@@ -13,8 +13,10 @@
  * combinations at the moment.
  */
 
-use std;
+import front.parser;
 
+import std._str;
+import std._vec;
 import std.option;
 
 tag signedness {
@@ -64,12 +66,106 @@ tag conv {
 // A fragment of the output sequence
 tag piece {
     piece_string(str);
-    piece_conv(str);
+    piece_conv(conv);
+}
+
+fn bad_fmt_call() {
+    log "malformed #fmt call";
+    fail;
 }
 
 fn expand_syntax_ext(vec[@ast.expr] args,
                      option.t[@ast.expr] body) -> @ast.expr {
+
+    if (_vec.len[@ast.expr](args) == 0u) {
+        bad_fmt_call();
+    }
+
+    auto fmt = expr_to_str(args.(0));
+    log fmt;
+    auto pieces = parse_fmt_string(fmt);
+    ret pieces_to_expr(pieces, args);
+}
+
+fn expr_to_str(@ast.expr expr) -> str {
+    alt (expr.node) {
+        case (ast.expr_lit(?l, _)) {
+            alt (l.node) {
+                case (ast.lit_str(?s)) {
+                    ret s;
+                }
+            }
+        }
+    }
+    bad_fmt_call();
     fail;
+}
+
+fn parse_fmt_string(str s) -> vec[piece] {
+    let vec[piece] pieces = vec();
+    // FIXME: Should be counting codepoints instead of bytes
+    auto lim = _str.byte_len(s);
+    auto buf = "";
+
+    // TODO: This is super ugly
+    fn flush_buf(str buf, vec[piece] pieces) -> str {
+        log "flushing";
+        if (_str.byte_len(buf) > 0u) {
+            auto piece = piece_string(buf);
+            pieces += piece;
+        }
+        log "buf:";
+        log buf;
+        log "pieces:";
+        for (piece p in pieces) {
+            alt (p) {
+                case (piece_string(?s)) {
+                    log s;
+                }
+                case (piece_conv(_)) {
+                    log "conv";
+                }
+            }
+        }
+        ret "";
+    }
+
+    auto i = 0u;
+    while (i < lim) {
+        log "step:";
+        log i;
+        auto curr = _str.substr(s, i, 1u);
+        if (_str.eq(curr, "%")) {
+            i += 1u;
+            if (i >= lim) {
+                log "unterminated conversion at end of string";
+                fail;
+            }
+            auto curr2 = _str.substr(s, i, 1u);
+            if (_str.eq(curr2, "%")) {
+                i += 1u;
+            } else {
+                buf = flush_buf(buf, pieces);
+            }
+        } else {
+            buf += curr;
+            log "buf:";
+            log buf;
+            i += 1u;
+        }
+    }
+
+    ret pieces;
+}
+
+fn pieces_to_expr(vec[piece] pieces, vec[@ast.expr] args) -> @ast.expr {
+    auto lo = args.(0).span;
+    auto hi = args.(0).span;
+    auto strlit = ast.lit_str("TODO");
+    auto spstrlit = @parser.spanned[ast.lit_](lo, hi, strlit);
+    auto expr = ast.expr_lit(spstrlit, ast.ann_none);
+    auto spexpr = @parser.spanned[ast.expr_](lo, hi, expr);
+    ret spexpr;
 }
 
 //

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -635,10 +635,8 @@ impure fn parse_bottom_expr(parser p) -> @ast.expr {
                                            some(token.COMMA),
                                            pf, p);
             hi = es.span;
-            ex = ast.expr_ext(pth, es.node, none[@ast.expr],
-                              none[@ast.expr], ast.ann_none);
-            // FIXME: Here is probably not the right place for this
-            ex = expand_syntax_ext(p, @spanned(lo, hi, ex)).node;
+            ex = expand_syntax_ext(p, es.span, pth, es.node,
+                                   none[@ast.expr]);
         }
 
         case (token.FAIL) {
@@ -727,24 +725,23 @@ impure fn parse_bottom_expr(parser p) -> @ast.expr {
  * rust crates. At the moment we have neither.
  */
 
-impure fn expand_syntax_ext(parser p, @ast.expr ext) -> @ast.expr {
-    check (ast.is_ext_expr(ext));
-    alt (ext.node) {
-        case (ast.expr_ext(?path, ?args, ?body, _, ?ann)) {
-            check (_vec.len[ast.ident](path.node.idents) > 0u);
-            auto extname = path.node.idents.(0);
-            if (_str.eq(extname, "fmt")) {
-                auto expanded = extfmt.expand_syntax_ext(args, body);
-                auto newexpr = ast.expr_ext(path, args, body,
-                                            some[@ast.expr](expanded), ann);
+impure fn expand_syntax_ext(parser p, ast.span sp,
+                     &ast.path path, vec[@ast.expr] args,
+                     option.t[@ast.expr] body) -> ast.expr_ {
 
-                ret @spanned(ext.span, ext.span, newexpr);
-            } else {
-                p.err("unknown syntax extension");
-            }
-        }
+    check (_vec.len[ast.ident](path.node.idents) > 0u);
+    auto extname = path.node.idents.(0);
+    if (_str.eq(extname, "fmt")) {
+        auto expanded = extfmt.expand_syntax_ext(args, body);
+        auto newexpr = ast.expr_ext(path, args, body,
+                                    some[@ast.expr](expanded),
+                                    ast.ann_none);
+
+        ret newexpr;
+    } else {
+        p.err("unknown syntax extension");
+        fail;
     }
-    fail;
 }
 
 impure fn extend_expr_by_ident(parser p, span lo, span hi,

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -723,7 +723,7 @@ impure fn parse_bottom_expr(parser p) -> @ast.expr {
     ret @spanned(lo, hi, ex);
 }
 
-/* 
+/*
  * FIXME: This is a crude approximation of the syntax-extension system,
  * for purposes of prototyping and/or hard-wiring any extensions we
  * wish to use while bootstrapping. The eventual aim is to permit

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -734,7 +734,7 @@ impure fn expand_syntax_ext(parser p, ast.span sp,
     if (_str.eq(extname, "fmt")) {
         auto expanded = extfmt.expand_syntax_ext(args, body);
         auto newexpr = ast.expr_ext(path, args, body,
-                                    some[@ast.expr](expanded),
+                                    expanded,
                                     ast.ann_none);
 
         ret newexpr;

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -735,7 +735,6 @@ impure fn expand_syntax_ext(parser p, @ast.expr ext) -> @ast.expr {
             auto extname = path.node.idents.(0);
             if (_str.eq(extname, "fmt")) {
                 auto expanded = extfmt.expand_syntax_ext(args, body);
-                check (ast.is_ext_expr(expanded));
                 auto newexpr = ast.expr_ext(path, args, body,
                                             some[@ast.expr](expanded), ann);
 

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -635,7 +635,10 @@ impure fn parse_bottom_expr(parser p) -> @ast.expr {
                                            some(token.COMMA),
                                            pf, p);
             hi = es.span;
-            ex = ast.expr_ext(pth, es.node, none[@ast.expr], ast.ann_none);
+            ex = ast.expr_ext(pth, es.node, none[@ast.expr],
+                              none[@ast.expr], ast.ann_none);
+            // FIXME: Here is probably not the right place for this
+            ex = expand_syntax_ext(p, @spanned(lo, hi, ex)).node;
         }
 
         case (token.FAIL) {
@@ -713,6 +716,36 @@ impure fn parse_bottom_expr(parser p) -> @ast.expr {
     }
 
     ret @spanned(lo, hi, ex);
+}
+
+/* 
+ * FIXME: This is a crude approximation of the syntax-extension system,
+ * for purposes of prototyping and/or hard-wiring any extensions we
+ * wish to use while bootstrapping. The eventual aim is to permit
+ * loading rust crates to process extensions, but this will likely
+ * require a rust-based frontend, or an ocaml-FFI-based connection to
+ * rust crates. At the moment we have neither.
+ */
+
+impure fn expand_syntax_ext(parser p, @ast.expr ext) -> @ast.expr {
+    check (ast.is_ext_expr(ext));
+    alt (ext.node) {
+        case (ast.expr_ext(?path, ?args, ?body, _, ?ann)) {
+            check (_vec.len[ast.ident](path.node.idents) > 0u);
+            auto extname = path.node.idents.(0);
+            if (_str.eq(extname, "fmt")) {
+                auto expanded = extfmt.expand_syntax_ext(args, body);
+                check (ast.is_ext_expr(expanded));
+                auto newexpr = ast.expr_ext(path, args, body,
+                                            some[@ast.expr](expanded), ann);
+
+                ret @spanned(ext.span, ext.span, newexpr);
+            } else {
+                p.err("unknown syntax extension");
+            }
+        }
+    }
+    fail;
 }
 
 impure fn extend_expr_by_ident(parser p, span lo, span hi,

--- a/src/comp/front/pretty.rs
+++ b/src/comp/front/pretty.rs
@@ -1,4 +1,9 @@
-use std;
+import std._int;
+import std._str;
+import std._uint;
+import std._vec;
+
+export print_expr;
 
 fn unknown() -> str {
     ret "<unknown ast node>";
@@ -7,10 +12,16 @@ fn unknown() -> str {
 fn print_expr(@ast.expr expr) -> str {
     alt (expr.node) {
         case (ast.expr_lit(?lit, _)) {
-            ret print_expr_lit(lit);
+            ret print_lit(lit);
         }
         case (ast.expr_binary(?op, ?lhs, ?rhs, _)) {
             ret print_expr_binary(op, lhs, rhs);
+        }
+        case (ast.expr_call(?path, ?args, _)) {
+            ret print_expr_call(path, args);
+        }
+        case (ast.expr_path(?path, _, _)) {
+            ret print_path(path);
         }
         case (_) {
             ret unknown();
@@ -18,10 +29,16 @@ fn print_expr(@ast.expr expr) -> str {
     }
 }
 
-fn print_expr_lit(@ast.lit lit) -> str {
+fn print_lit(@ast.lit lit) -> str {
     alt (lit.node) {
         case (ast.lit_str(?s)) {
             ret "\"" + s + "\"";
+        }
+        case (ast.lit_int(?i)) {
+            ret _int.to_str(i, 10u);
+        }
+        case (ast.lit_uint(?u)) {
+            ret _uint.to_str(u, 10u);
         }
         case (_) {
             ret unknown();
@@ -37,6 +54,23 @@ fn print_expr_binary(ast.binop op, @ast.expr lhs, @ast.expr rhs) -> str {
             ret l + " + " + r;
         }
     }
+}
+
+fn print_expr_call(@ast.expr path_expr, vec[@ast.expr] args) -> str {
+    auto s = print_expr(path_expr);
+
+    s += "(";
+    fn print_expr_ref(&@ast.expr e) -> str { ret print_expr(e); }
+    auto mapfn = print_expr_ref;
+    auto argstrs = _vec.map[@ast.expr, str](mapfn, args);
+    s += _str.connect(argstrs, ", ");
+    s += ")";
+
+    ret s;
+}
+
+fn print_path(ast.path path) -> str {
+    ret _str.connect(path.node.idents, ".");
 }
 
 //

--- a/src/comp/front/pretty.rs
+++ b/src/comp/front/pretty.rs
@@ -1,0 +1,51 @@
+use std;
+
+fn unknown() -> str {
+    ret "<unknown ast node>";
+}
+
+fn print_expr(@ast.expr expr) -> str {
+    alt (expr.node) {
+        case (ast.expr_lit(?lit, _)) {
+            ret print_expr_lit(lit);
+        }
+        case (ast.expr_binary(?op, ?lhs, ?rhs, _)) {
+            ret print_expr_binary(op, lhs, rhs);
+        }
+        case (_) {
+            ret unknown();
+        }
+    }
+}
+
+fn print_expr_lit(@ast.lit lit) -> str {
+    alt (lit.node) {
+        case (ast.lit_str(?s)) {
+            ret "\"" + s + "\"";
+        }
+        case (_) {
+            ret unknown();
+        }
+    }
+}
+
+fn print_expr_binary(ast.binop op, @ast.expr lhs, @ast.expr rhs) -> str {
+    alt (op) {
+        case (ast.add) {
+            auto l = print_expr(lhs);
+            auto r = print_expr(rhs);
+            ret l + " + " + r;
+        }
+    }
+}
+
+//
+// Local Variables:
+// mode: rust
+// fill-column: 78;
+// indent-tabs-mode: nil
+// c-basic-offset: 4
+// buffer-file-coding-system: utf-8-unix
+// compile-command: "make -k -C ../.. 2>&1 | sed -e 's/\\/x\\//x:\\//g'";
+// End:
+//

--- a/src/comp/middle/fold.rs
+++ b/src/comp/middle/fold.rs
@@ -154,6 +154,12 @@ type ast_fold[ENV] =
          &option.t[def] d,
          ann a) -> @expr)                         fold_expr_path,
 
+     (fn(&ENV e, &span sp,
+         &path p, vec[@expr] args,
+         option.t[@expr] body,
+         option.t[@expr] expanded,
+         ann a) -> @expr)                         fold_expr_ext,
+
      (fn(&ENV e, &span sp) -> @expr)              fold_expr_fail,
 
      (fn(&ENV e, &span sp,
@@ -641,6 +647,15 @@ fn fold_expr[ENV](&ENV env, ast_fold[ENV] fld, &@expr e) -> @expr {
         case (ast.expr_path(?p, ?r, ?t)) {
             auto p_ = fold_path(env_, fld, p);
             ret fld.fold_expr_path(env_, e.span, p_, r, t);
+        }
+
+        case (ast.expr_ext(?p, ?args, ?body, ?expanded, ?t)) {
+            // Only fold the expanded expression, not the
+            // expressions involved in syntax extension
+            auto exp = option.get[@expr](expanded);
+            auto exp_ = fold_expr(env_, fld, exp);
+            ret fld.fold_expr_ext(env_, e.span, p, args, body,
+                                  some[@ast.expr](exp_), t);
         }
 
         case (ast.expr_fail) {
@@ -1158,6 +1173,14 @@ fn identity_fold_expr_path[ENV](&ENV env, &span sp,
     ret @respan(sp, ast.expr_path(p, d, a));
 }
 
+fn identity_fold_expr_ext[ENV](&ENV env, &span sp,
+                               &path p, vec[@expr] args,
+                               option.t[@expr] body,
+                               option.t[@expr] expanded,
+                               ann a) -> @expr {
+    ret @respan(sp, ast.expr_ext(p, args, body, expanded, a));
+}
+
 fn identity_fold_expr_fail[ENV](&ENV env, &span sp) -> @expr {
     ret @respan(sp, ast.expr_fail);
 }
@@ -1438,6 +1461,7 @@ fn new_identity_fold[ENV]() -> ast_fold[ENV] {
          fold_expr_field  = bind identity_fold_expr_field[ENV](_,_,_,_,_),
          fold_expr_index  = bind identity_fold_expr_index[ENV](_,_,_,_,_),
          fold_expr_path   = bind identity_fold_expr_path[ENV](_,_,_,_,_),
+         fold_expr_ext    = bind identity_fold_expr_ext[ENV](_,_,_,_,_,_,_),
          fold_expr_fail   = bind identity_fold_expr_fail[ENV](_,_),
          fold_expr_ret    = bind identity_fold_expr_ret[ENV](_,_,_),
          fold_expr_put    = bind identity_fold_expr_put[ENV](_,_,_),

--- a/src/comp/middle/fold.rs
+++ b/src/comp/middle/fold.rs
@@ -157,7 +157,7 @@ type ast_fold[ENV] =
      (fn(&ENV e, &span sp,
          &path p, vec[@expr] args,
          option.t[@expr] body,
-         option.t[@expr] expanded,
+         @expr expanded,
          ann a) -> @expr)                         fold_expr_ext,
 
      (fn(&ENV e, &span sp) -> @expr)              fold_expr_fail,
@@ -652,10 +652,9 @@ fn fold_expr[ENV](&ENV env, ast_fold[ENV] fld, &@expr e) -> @expr {
         case (ast.expr_ext(?p, ?args, ?body, ?expanded, ?t)) {
             // Only fold the expanded expression, not the
             // expressions involved in syntax extension
-            auto exp = option.get[@expr](expanded);
-            auto exp_ = fold_expr(env_, fld, exp);
+            auto exp = fold_expr(env_, fld, expanded);
             ret fld.fold_expr_ext(env_, e.span, p, args, body,
-                                  some[@ast.expr](exp_), t);
+                                  exp, t);
         }
 
         case (ast.expr_fail) {
@@ -1176,7 +1175,7 @@ fn identity_fold_expr_path[ENV](&ENV env, &span sp,
 fn identity_fold_expr_ext[ENV](&ENV env, &span sp,
                                &path p, vec[@expr] args,
                                option.t[@expr] body,
-                               option.t[@expr] expanded,
+                               @expr expanded,
                                ann a) -> @expr {
     ret @respan(sp, ast.expr_ext(p, args, body, expanded, a));
 }

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -1861,6 +1861,8 @@ fn trans_lit(@crate_ctxt cx, &ast.lit lit, &ast.ann ann) -> ValueRef {
             ret C_nil();
         }
         case (ast.lit_str(?s)) {
+            log "translating literal:";
+            log s;
             ret C_str(cx, s);
         }
     }
@@ -3362,6 +3364,7 @@ fn trans_rec(@block_ctxt cx, vec[ast.field] fields,
 fn trans_expr(@block_ctxt cx, @ast.expr e) -> result {
     alt (e.node) {
         case (ast.expr_lit(?lit, ?ann)) {
+            log "translating literal";
             ret res(cx, trans_lit(cx.fcx.ccx, *lit, ann));
         }
 
@@ -3454,6 +3457,11 @@ fn trans_expr(@block_ctxt cx, @ast.expr e) -> result {
 
         case (ast.expr_rec(?args, ?base, ?ann)) {
             ret trans_rec(cx, args, base, ann);
+        }
+
+        case (ast.expr_ext(_, _, _, ?expanded, _)) {
+            log "translating extension";
+            ret trans_expr(cx, option.get[@ast.expr](expanded));
         }
 
         case (ast.expr_fail) {

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -3457,7 +3457,7 @@ fn trans_expr(@block_ctxt cx, @ast.expr e) -> result {
         }
 
         case (ast.expr_ext(_, _, _, ?expanded, _)) {
-            ret trans_expr(cx, option.get[@ast.expr](expanded));
+            ret trans_expr(cx, expanded);
         }
 
         case (ast.expr_fail) {

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -1861,8 +1861,6 @@ fn trans_lit(@crate_ctxt cx, &ast.lit lit, &ast.ann ann) -> ValueRef {
             ret C_nil();
         }
         case (ast.lit_str(?s)) {
-            log "translating literal:";
-            log s;
             ret C_str(cx, s);
         }
     }
@@ -3364,7 +3362,6 @@ fn trans_rec(@block_ctxt cx, vec[ast.field] fields,
 fn trans_expr(@block_ctxt cx, @ast.expr e) -> result {
     alt (e.node) {
         case (ast.expr_lit(?lit, ?ann)) {
-            log "translating literal";
             ret res(cx, trans_lit(cx.fcx.ccx, *lit, ann));
         }
 
@@ -3460,7 +3457,6 @@ fn trans_expr(@block_ctxt cx, @ast.expr e) -> result {
         }
 
         case (ast.expr_ext(_, _, _, ?expanded, _)) {
-            log "translating extension";
             ret trans_expr(cx, option.get[@ast.expr](expanded));
         }
 

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -742,6 +742,7 @@ fn expr_ty(@ast.expr expr) -> @t {
         case (ast.expr_field(_, _, ?ann))     { ret ann_to_type(ann); }
         case (ast.expr_index(_, _, ?ann))     { ret ann_to_type(ann); }
         case (ast.expr_path(_, _, ?ann))      { ret ann_to_type(ann); }
+        case (ast.expr_ext(_, _, _, _, ?ann)) { ret ann_to_type(ann); }
 
         case (ast.expr_fail)                  { ret plain_ty(ty_nil); }
         case (ast.expr_log(_))                { ret plain_ty(ty_nil); }

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -1156,6 +1156,11 @@ fn demand_expr_full(&@fn_ctxt fcx, @ty.t expected, @ast.expr e,
                                  ann_to_type(ann), adk);
             e_1 = ast.expr_path(pth, d, ast.ann_type(t));
         }
+        case (ast.expr_ext(?p, ?args, ?body, ?expanded, ?ann)) {
+            auto t = demand_full(fcx, e.span, expected,
+                                 ann_to_type(ann), adk);
+            e_1 = ast.expr_ext(p, args, body, expanded, ast.ann_type(t));
+        }
         case (ast.expr_fail) { e_1 = e.node; }
         case (ast.expr_log(_)) { e_1 = e.node; }
         case (ast.expr_ret(_)) { e_1 = e.node; }
@@ -1506,6 +1511,15 @@ fn check_expr(&@fn_ctxt fcx, @ast.expr expr) -> @ast.expr {
             ret @fold.respan[ast.expr_](expr.span,
                                         ast.expr_path(pth, defopt,
                                                       ast.ann_type(t)));
+        }
+
+        case (ast.expr_ext(?p, ?args, ?body, ?expanded, _)) {
+            auto exp_ = check_expr(fcx, option.get[@ast.expr](expanded));
+            auto t = expr_ty(exp_);
+            ret @fold.respan[ast.expr_](expr.span,
+                                        ast.expr_ext(p, args, body,
+                                                     some[@ast.expr](exp_),
+                                                     ast.ann_type(t)));
         }
 
         case (ast.expr_fail) {

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -1514,11 +1514,10 @@ fn check_expr(&@fn_ctxt fcx, @ast.expr expr) -> @ast.expr {
         }
 
         case (ast.expr_ext(?p, ?args, ?body, ?expanded, _)) {
-            auto exp_ = check_expr(fcx, option.get[@ast.expr](expanded));
+            auto exp_ = check_expr(fcx, expanded);
             auto t = expr_ty(exp_);
             ret @fold.respan[ast.expr_](expr.span,
-                                        ast.expr_ext(p, args, body,
-                                                     some[@ast.expr](exp_),
+                                        ast.expr_ext(p, args, body, exp_,
                                                      ast.ann_type(t)));
         }
 

--- a/src/comp/rustc.rc
+++ b/src/comp/rustc.rc
@@ -8,6 +8,7 @@ mod front {
     mod extfmt;
     mod lexer;
     mod parser;
+    mod pretty;
     mod token;
     mod eval;
 }

--- a/src/comp/rustc.rc
+++ b/src/comp/rustc.rc
@@ -5,6 +5,7 @@ use std;
 
 mod front {
     mod ast;
+    mod extfmt;
     mod lexer;
     mod parser;
     mod token;

--- a/src/rt/memory_region.cpp
+++ b/src/rt/memory_region.cpp
@@ -1,7 +1,7 @@
 #include "rust_internal.h"
 #include "memory_region.h"
 
-// #define TRACK_ALLOCATIONS
+#define TRACK_ALLOCATIONS
 
 memory_region::memory_region(rust_srv *srv, bool synchronized) :
     _srv(srv), _parent(NULL), _live_allocations(0),

--- a/src/test/run-pass/syntax-extension-fmt.rs
+++ b/src/test/run-pass/syntax-extension-fmt.rs
@@ -10,4 +10,7 @@ fn test(str actual, str expected) {
 fn main() {
   test(#fmt("hello %d friends and %s things", 10, "formatted"),
     "hello 10 friends and formatted things");
+  test(#fmt("d: %d", 1), "d: 1");
+  test(#fmt("i: %i", 2), "i: 2");
+  test(#fmt("s: %s", "test"), "s: test");
 }

--- a/src/test/run-pass/syntax-extension-fmt.rs
+++ b/src/test/run-pass/syntax-extension-fmt.rs
@@ -8,6 +8,7 @@ fn test(str actual, str expected) {
 }
 
 fn main() {
-  test(#fmt("hello %d friends and %s things", 10, "formatted"),
-       "hello 10 friends and formatted things");
+  /*test(#fmt("hello %d friends and %s things", 10, "formatted"),
+    "hello 10 friends and formatted things");*/
+  log #fmt("test");
 }

--- a/src/test/run-pass/syntax-extension-fmt.rs
+++ b/src/test/run-pass/syntax-extension-fmt.rs
@@ -1,10 +1,10 @@
-use std;
-import std._str;
+//use std;
+//import std._str;
 
 fn test(str actual, str expected) {
   log actual;
   log expected;
-  check (_str.eq(actual, expected));
+  //check (_str.eq(actual, expected));
 }
 
 fn main() {

--- a/src/test/run-pass/syntax-extension-fmt.rs
+++ b/src/test/run-pass/syntax-extension-fmt.rs
@@ -1,5 +1,13 @@
 use std;
+import std._str;
+
+fn test(str actual, str expected) {
+  log actual;
+  log expected;
+  check (_str.eq(actual, expected));
+}
+
 fn main() {
-  auto s = #fmt("hello %d friends and %s things", 10, "formatted");
-  log s;
+  test(#fmt("hello %d friends and %s things", 10, "formatted"),
+       "hello 10 friends and formatted things");
 }

--- a/src/test/run-pass/syntax-extension-fmt.rs
+++ b/src/test/run-pass/syntax-extension-fmt.rs
@@ -1,14 +1,13 @@
-//use std;
-//import std._str;
+use std;
+import std._str;
 
 fn test(str actual, str expected) {
   log actual;
   log expected;
-  //check (_str.eq(actual, expected));
+  check (_str.eq(actual, expected));
 }
 
 fn main() {
-  /*test(#fmt("hello %d friends and %s things", 10, "formatted"),
-    "hello 10 friends and formatted things");*/
-  log #fmt("test");
+  test(#fmt("hello %d friends and %s things", 10, "formatted"),
+    "hello 10 friends and formatted things");
 }


### PR DESCRIPTION
Graydon,

I've translated the #fmt syntax extension to rustc. It currently builds but doesn't pass tests. The AST it builds depends on vector addition and calls into std, neither of which work yet. Once those are completed I'm interested in fleshing this out and adding tests.

I'd particularly like you to review how I've interpreted the expr_ext AST node, to which I added a new expression parameter. I'm using it as expr_ext(path, argument_exprs, body_expr, expanded_expr, ann). The arguments and body parameters are used by the extension to generate the expanded expression, and only the expanded expression is folded and translated. The 'body' expression isn't used by #fmt.
