### PR TITLE
Codegen for ports and channels

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -501,6 +501,7 @@ TASK_XFAILS := $(addprefix $(S)src/test/run-pass/, \
                  task-comm-12.rs \
                  task-comm-2.rs \
                  task-comm-9.rs \
+                 task-comm-chan-nil.rs \
                  task-life-0.rs \
                  alt-type-simple.rs \
                  many.rs)

--- a/src/Makefile
+++ b/src/Makefile
@@ -530,9 +530,6 @@ TEST_XFAILS_RUSTC := $(addprefix test/run-pass/, \
                         task-comm-15.rs \
                         task-comm-2.rs \
                         task-comm-3.rs \
-                        task-comm-4.rs \
-                        task-comm-5.rs \
-                        task-comm-6.rs \
                         task-comm-7.rs \
                         task-comm-8.rs \
                         task-comm-9.rs \

--- a/src/Makefile
+++ b/src/Makefile
@@ -434,6 +434,7 @@ TASK_XFAILS := test/run-pass/task-comm-8.rs \
                test/run-pass/task-comm-12.rs \
                test/run-pass/task-comm-2.rs \
                test/run-pass/task-comm-9.rs \
+               test/run-pass/task-comm-chan-nil.rs \
                test/run-pass/task-life-0.rs \
                test/run-pass/alt-type-simple.rs \
                test/run-pass/many.rs

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -4764,8 +4764,6 @@ fn trans_chan(@block_ctxt cx, @ast.expr e, ast.ann ann) -> result {
     auto dropref = clean(bind drop_ty(_, chan_val, chan_ty));
     find_scope_cx(bcx).cleanups += vec(dropref);
 
-    // TODO: Do I need to do anything with the port's refcount?
-
     ret res(bcx, chan_val);
 }
 

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -4793,7 +4793,8 @@ fn trans_send(@block_ctxt cx, @ast.expr lhs, @ast.expr rhs,
     auto data_tmp = copy_ty(bcx, INIT, data_alloc.val, data.val, unit_ty);
     bcx = data_tmp.bcx;
 
-    // TODO: Cleanups?
+    find_scope_cx(bcx).cleanups +=
+        vec(clean(bind drop_ty(_, data_alloc.val, unit_ty)));
 
     auto sub = trans_upcall(bcx, "upcall_send",
                             vec(vp2i(bcx, chn.val),
@@ -4823,7 +4824,7 @@ fn trans_recv(@block_ctxt cx, @ast.expr lhs, @ast.expr rhs,
     auto cp = copy_ty(bcx, DROP_EXISTING, data.res.val, data_load, unit_ty);
     bcx = cp.bcx;
 
-    // TODO: Cleanups?
+    // TODO: Any cleanup need to be done here?
 
     ret res(bcx, data.res.val);
 }

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -411,6 +411,8 @@ fn type_is_boxed(@t ty) -> bool {
         case (ty_str) { ret true; }
         case (ty_vec(_)) { ret true; }
         case (ty_box(_)) { ret true; }
+        case (ty_port(_)) { ret true; }
+        case (ty_chan(_)) { ret true; }
         case (_) { ret false; }
     }
     fail;
@@ -759,6 +761,10 @@ fn expr_ty(@ast.expr expr) -> @t {
         case (ast.expr_index(_, _, ?ann))     { ret ann_to_type(ann); }
         case (ast.expr_path(_, _, ?ann))      { ret ann_to_type(ann); }
         case (ast.expr_ext(_, _, _, _, ?ann)) { ret ann_to_type(ann); }
+        case (ast.expr_port(?ann))            { ret ann_to_type(ann); }
+        case (ast.expr_chan(_, ?ann))         { ret ann_to_type(ann); }
+        case (ast.expr_send(_, _, ?ann))      { ret ann_to_type(ann); }
+        case (ast.expr_recv(_, _, ?ann))      { ret ann_to_type(ann); }
 
         case (ast.expr_fail)                  { ret plain_ty(ty_nil); }
         case (ast.expr_log(_))                { ret plain_ty(ty_nil); }

--- a/src/test/run-pass/task-comm-16.rs
+++ b/src/test/run-pass/task-comm-16.rs
@@ -1,0 +1,105 @@
+// -*- rust -*-
+
+// Tests of ports and channels on various types
+
+impure fn test_rec() {
+  type r = rec(int val0, u8 val1, char val2);
+
+  let port[r] po = port();
+  let chan[r] ch = chan(po);
+  let r r0 = rec(val0 = 0, val1 = 1u8, val2 = '2');
+
+  ch <| r0;
+
+  let r r1;
+  r1 <- po;
+
+  check (r1.val0 == 0);
+  check (r1.val1 == 1u8);
+  check (r1.val2 == '2');
+}
+
+impure fn test_vec() {
+  let port[vec[int]] po = port();
+  let chan[vec[int]] ch = chan(po);
+  let vec[int] v0 = vec(0, 1, 2);
+
+  ch <| v0;
+
+  let vec[int] v1;
+  v1 <- po;
+
+  check (v1.(0) == 0);
+  check (v1.(1) == 1);
+  check (v1.(2) == 2);
+}
+
+impure fn test_tup() {
+  type t = tup(int, u8, char);
+
+  let port[t] po = port();
+  let chan[t] ch = chan(po);
+  let t t0 = tup(0, 1u8, '2');
+
+  ch <| t0;
+
+  let t t1;
+  t1 <- po;
+
+  check (t0._0 == 0);
+  check (t0._1 == 1u8);
+  check (t0._2 == '2');
+}
+
+impure fn test_tag() {
+  tag t {
+    tag1;
+    tag2(int);
+    tag3(int, u8, char);
+  }
+
+  let port[t] po = port();
+  let chan[t] ch = chan(po);
+
+  ch <| tag1;
+  ch <| tag2(10);
+  ch <| tag3(10, 11u8, 'A');
+
+  let t t1;
+
+  t1 <- po;
+  check (t1 == tag1);
+  t1 <- po;
+  check (t1 == tag2(10));
+  t1 <- po;
+  check (t1 == tag3(10, 11u8, 'A'));
+}
+
+impure fn test_chan() {
+  let port[chan[int]] po = port();
+  let chan[chan[int]] ch = chan(po);
+
+  let port[int] po0 = port();
+  let chan[int] ch0 = chan(po0);
+
+  ch <| ch0;
+
+  let chan[int] ch1;
+  ch1 <- po;
+
+  // Does the transmitted channel still work?
+  ch1 <| 10;
+
+  let int i;
+  i <- po0;
+
+  check (i == 10);
+}
+
+impure fn main() {
+  test_rec();
+  test_vec();
+  test_tup();
+  test_tag();
+  test_chan();
+}

--- a/src/test/run-pass/task-comm-16.rs
+++ b/src/test/run-pass/task-comm-16.rs
@@ -34,6 +34,22 @@ impure fn test_vec() {
   check (v1.(2) == 2);
 }
 
+impure fn test_str() {
+  let port[str] po = port();
+  let chan[str] ch = chan(po);
+  let str s0 = "test";
+
+  ch <| s0;
+
+  let str s1;
+  s1 <- po;
+
+  check (s1.(0) as u8 == 't' as u8);
+  check (s1.(1) as u8 == 'e' as u8);
+  check (s1.(2) as u8 == 's' as u8);
+  check (s1.(3) as u8 == 't' as u8);
+}
+
 impure fn test_tup() {
   type t = tup(int, u8, char);
 
@@ -99,6 +115,7 @@ impure fn test_chan() {
 impure fn main() {
   test_rec();
   test_vec();
+  test_str();
   test_tup();
   test_tag();
   test_chan();

--- a/src/test/run-pass/task-comm-chan-nil.rs
+++ b/src/test/run-pass/task-comm-chan-nil.rs
@@ -1,0 +1,17 @@
+// -*- rust -*-
+
+// rustboot can't transmit nils across channels because they don't have
+// any size, but rustc currently can because they do have size. Whether
+// or not this is desirable I don't know, but here's a regression test.
+
+impure fn main() {
+  let port[()] po = port();
+  let chan[()] ch = chan(po);
+
+  ch <| ();
+
+  let () n;
+  n <- po;
+
+  check (n == ());
+}


### PR DESCRIPTION
This patch set implements code generation for ports and channels. I think this is all pretty nice - the only thing I'm really concerned about is the refcounting. From what I can tell the refcounts are working correctly; I just don't exactly understand why. I expected trans_recv to require a cleanup for the received data but it has thus far rejected my efforts to do so.

I'm beginning to understand what's going on in trans.rs, but please give it a close look and see if there's anything I can improve. 

Next is implementing local declarations with receive, e.g. "let int x <- p", then on to spawning tasks.
