### PR TITLE
Misc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ rustc
 TAGS
 version.ml
 version.texi
+Makefile
+config.mk
+rt/
+rustllvm/
+test/

--- a/Makefile.in
+++ b/Makefile.in
@@ -695,9 +695,6 @@ TEST_XFAILS_STAGE0 := $(FLOAT_XFAILS) \
                         task-comm-15.rs \
                         task-comm-2.rs \
                         task-comm-3.rs \
-                        task-comm-4.rs \
-                        task-comm-5.rs \
-                        task-comm-6.rs \
                         task-comm-7.rs \
                         task-comm-8.rs \
                         task-comm-9.rs \

--- a/doc/rust.texi
+++ b/doc/rust.texi
@@ -1499,7 +1499,7 @@ messages. Ports receive messages from channels.
 A @dfn{channel} is a communication endpoint that can @emph{send}
 messages. Channels send messages to ports.
 
-Each port is implicitly boxed and mutable; as such a port has has a unique
+Each port is implicitly boxed and mutable; as such a port has a unique
 per-task identity and cannot be replicated or transmitted. If a port value is
 copied, both copies refer to the @emph{same} port. New ports can be
 constructed dynamically and stored in data structures.


### PR DESCRIPTION
Change .gitignore to ignore various artifacts from in-tree builds, fix a doc typo, and un-XFAIL some tests that got lost in the transition to the new build system.
