### PR TITLE
.gitignore corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,6 @@ version.ml
 version.texi
 Makefile
 config.mk
-rt/
-rustllvm/
-test/
+/rt/
+/rustllvm/
+/test/


### PR DESCRIPTION
My previous changes to .gitignore were overzealous. This un-ignores the src/rt, src/rustllvm and src/test directories.
