### PR TITLE
Pretty-printer improvements

### DIFF
--- a/src/comp/driver/rustc.rs
+++ b/src/comp/driver/rustc.rs
@@ -77,7 +77,7 @@ impure fn pretty_print_input(session.session sess,
     auto def = tup(0, 0);
     auto p = front.parser.new_parser(sess, env, def, input);
     auto crate = front.parser.parse_crate_from_source_file(p);
-    pretty.pprust.print_ast(crate.node.module, std.io.stdout());
+    pretty.pprust.print_file(crate.node.module, input, std.io.stdout());
 }
 
 fn warn_wrong_compiler() {

--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -385,7 +385,8 @@ type native_mod = rec(str native_name,
 type native_mod_index = hashmap[ident,native_mod_index_entry];
 
 type variant_arg = rec(@ty ty, def_id id);
-type variant = rec(str name, vec[variant_arg] args, def_id id, ann ann);
+type variant_ = rec(str name, vec[variant_arg] args, def_id id, ann ann);
+type variant = spanned[variant_];
 
 type view_item = spanned[view_item_];
 tag view_item_ {
@@ -451,7 +452,7 @@ fn index_item(mod_index index, @item it) {
             index.insert(id, ast.mie_item(it));
             let uint variant_idx = 0u;
             for (ast.variant v in variants) {
-                index.insert(v.name,
+                index.insert(v.node.name,
                              ast.mie_tag_variant(it, variant_idx));
                 variant_idx += 1u;
             }
@@ -509,7 +510,7 @@ fn index_stmt(block_index index, @stmt s) {
                             let uint vid = 0u;
                             for (ast.variant v in variants) {
                                 auto t = ast.bie_tag_variant(it, vid);
-                                index.insert(v.name, t);
+                                index.insert(v.node.name, t);
                                 vid += 1u;
                             }
                         }

--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -305,8 +305,7 @@ tag lit_ {
 type mt = rec(@ty ty, mutability mut);
 type ty_field = rec(ident ident, mt mt);
 type ty_arg = rec(mode mode, @ty ty);
-// TODO: effect
-type ty_method = rec(proto proto, ident ident,
+type ty_method = rec(effect effect, proto proto, ident ident,
                      vec[ty_arg] inputs, @ty output);
 type ty = spanned[ty_];
 tag ty_ {
@@ -324,7 +323,7 @@ tag ty_ {
     ty_chan(@ty);
     ty_tup(vec[mt]);
     ty_rec(vec[ty_field]);
-    ty_fn(proto, vec[ty_arg], @ty);        // TODO: effect
+    ty_fn(effect, proto, vec[ty_arg], @ty);
     ty_obj(vec[ty_method]);
     ty_path(path, option.t[def]);
     ty_type;

--- a/src/comp/front/lexer.rs
+++ b/src/comp/front/lexer.rs
@@ -282,7 +282,7 @@ impure fn consume_any_line_comment(reader rdr) {
     if (rdr.curr() == '/') {
         alt (rdr.next()) {
             case ('/') {
-                while (rdr.curr() != '\n') {
+                while (rdr.curr() != '\n' && !rdr.is_eof()) {
                     rdr.bump();
                 }
                 // Restart whitespace munch.
@@ -316,6 +316,10 @@ impure fn consume_block_comment(reader rdr) {
             } else {
                 rdr.bump();
             }
+        }
+        if (rdr.is_eof()) {
+            log "unterminated block comment";
+            fail;
         }
     }
     // restart whitespace munch.
@@ -800,9 +804,9 @@ impure fn consume_whitespace(reader rdr) -> uint {
 impure fn read_line_comment(reader rdr) -> cmnt {
     auto p = rdr.get_curr_pos();
     rdr.bump(); rdr.bump();
-    consume_whitespace(rdr);
+    while (rdr.curr() == ' ') {rdr.bump();}
     auto val = "";
-    while (rdr.curr() != '\n') {
+    while (rdr.curr() != '\n' && !rdr.is_eof()) {
         _str.push_char(val, rdr.curr());
         rdr.bump();
     }
@@ -814,7 +818,7 @@ impure fn read_line_comment(reader rdr) -> cmnt {
 impure fn read_block_comment(reader rdr) -> cmnt {
     auto p = rdr.get_curr_pos();
     rdr.bump(); rdr.bump();
-    consume_whitespace(rdr);
+    while (rdr.curr() == ' ') {rdr.bump();}
     let vec[str] lines = vec();
     auto val = "";
     auto level = 1;
@@ -837,6 +841,7 @@ impure fn read_block_comment(reader rdr) -> cmnt {
             _str.push_char(val, rdr.curr());
             rdr.bump();
         }
+        if (rdr.is_eof()) {fail;}
     }
     ret rec(val=cmnt_block(lines),
             pos=p,

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -116,6 +116,8 @@ impure fn new_parser(session.session sess,
     }
     auto srdr = io.file_reader(path);
     auto rdr = lexer.new_reader(srdr, path);
+    // Make sure npos points at first actual token.
+    lexer.consume_any_whitespace(rdr);
     auto npos = rdr.get_curr_pos();
     ret stdio_parser(sess, env, ftype, lexer.next_token(rdr),
                      npos, npos, initial_def._1, UNRESTRICTED, initial_def._0,
@@ -1748,8 +1750,8 @@ impure fn parse_block(parser p) -> ast.block {
         }
     }
 
-    p.bump();
     auto hi = p.get_span();
+    p.bump();
 
     auto bloc = index_block(stmts, expr);
     ret spanned[ast.block_](lo, hi, bloc);

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -1683,6 +1683,8 @@ fn stmt_ends_with_semi(@ast.stmt stmt) -> bool {
                 case (ast.expr_index(_,_,_))    { ret true; }
                 case (ast.expr_path(_,_,_))     { ret true; }
                 case (ast.expr_fail)            { ret true; }
+                case (ast.expr_break)           { ret true; }
+                case (ast.expr_cont)            { ret true; }
                 case (ast.expr_ret(_))          { ret true; }
                 case (ast.expr_put(_))          { ret true; }
                 case (ast.expr_be(_))           { ret true; }

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -451,7 +451,9 @@ impure fn parse_ty(parser p) -> @ast.ty {
         }
 
         case (token.IDENT(_)) {
-            t = ast.ty_path(parse_path(p, GREEDY), none[ast.def]);
+            auto path = parse_path(p, GREEDY);
+            t = ast.ty_path(path, none[ast.def]);
+            hi = path.span;
         }
 
         case (token.MUTABLE) {
@@ -2067,6 +2069,7 @@ impure fn parse_item_tag(parser p) -> @ast.item {
         auto tok = p.peek();
         alt (tok) {
             case (token.IDENT(?name)) {
+                auto vlo = p.get_span();
                 p.bump();
 
                 let vec[ast.variant_arg] args = vec();
@@ -2084,11 +2087,12 @@ impure fn parse_item_tag(parser p) -> @ast.item {
                     case (_) { /* empty */ }
                 }
 
+                auto vhi = p.get_span();
                 expect(p, token.SEMI);
 
                 auto id = p.next_def_id();
-                variants += vec(rec(name=name, args=args, id=id,
-                                    ann=ast.ann_none));
+                auto vr = rec(name=name, args=args, id=id, ann=ast.ann_none);
+                variants += vec(spanned[ast.variant_](vlo, vhi, vr));
             }
             case (token.RBRACE) { /* empty */ }
             case (_) {

--- a/src/comp/middle/fold.rs
+++ b/src/comp/middle/fold.rs
@@ -965,12 +965,13 @@ fn fold_item[ENV](&ENV env, ast_fold[ENV] fld, @item i) -> @item {
             let vec[ast.variant] new_variants = vec();
             for (ast.variant v in variants) {
                 let vec[ast.variant_arg] new_args = vec();
-                for (ast.variant_arg va in v.args) {
+                for (ast.variant_arg va in v.node.args) {
                     auto new_ty = fold_ty[ENV](env_, fld, va.ty);
                     new_args += vec(rec(ty=new_ty, id=va.id));
                 }
-                new_variants += vec(rec(name=v.name, args=new_args, id=v.id,
-                                        ann=v.ann));
+                auto new_v = rec(name=v.node.name, args=new_args,
+                                 id=v.node.id, ann=v.node.ann);
+                new_variants += vec(respan[ast.variant_](v.span, new_v));
             }
             ret fld.fold_item_tag(env_, i.span, ident, new_variants,
                                   ty_params, id);

--- a/src/comp/middle/metadata.rs
+++ b/src/comp/middle/metadata.rs
@@ -169,8 +169,8 @@ fn encode_def_id(&ebml.writer ebml_w, &ast.def_id id) {
 fn encode_tag_variant_paths(&ebml.writer ebml_w, vec[ast.variant] variants) {
     for (ast.variant variant in variants) {
         ebml.start_tag(ebml_w, tag_paths_item);
-        encode_name(ebml_w, variant.name);
-        encode_def_id(ebml_w, variant.id);
+        encode_name(ebml_w, variant.node.name);
+        encode_def_id(ebml_w, variant.node.id);
         ebml.end_tag(ebml_w);
     }
 }
@@ -314,14 +314,14 @@ fn encode_tag_variant_info(@trans.crate_ctxt cx, &ebml.writer ebml_w,
                            ast.def_id did, vec[ast.variant] variants) {
     for (ast.variant variant in variants) {
         ebml.start_tag(ebml_w, tag_items_item);
-        encode_def_id(ebml_w, variant.id);
+        encode_def_id(ebml_w, variant.node.id);
         encode_kind(ebml_w, 'v' as u8);
         encode_tag_id(ebml_w, did);
-        encode_type(ebml_w, trans.node_ann_type(cx, variant.ann));
-        if (_vec.len[ast.variant_arg](variant.args) > 0u) {
-            encode_symbol(cx, ebml_w, variant.id);
+        encode_type(ebml_w, trans.node_ann_type(cx, variant.node.ann));
+        if (_vec.len[ast.variant_arg](variant.node.args) > 0u) {
+            encode_symbol(cx, ebml_w, variant.node.id);
         }
-        encode_discriminant(cx, ebml_w, variant.id);
+        encode_discriminant(cx, ebml_w, variant.node.id);
         ebml.end_tag(ebml_w);
     }
 }

--- a/src/comp/middle/resolve.rs
+++ b/src/comp/middle/resolve.rs
@@ -389,7 +389,7 @@ fn lookup_name_wrapped(&env e, ast.ident i, namespace ns)
                     case (ast.mie_tag_variant(?item, ?variant_idx)) {
                         alt (item.node) {
                             case (ast.item_tag(_, ?variants, _, ?tid)) {
-                                auto vid = variants.(variant_idx).id;
+                                auto vid = variants.(variant_idx).node.id;
                                 auto t = ast.def_variant(tid, vid);
                                 ret some[def_wrap](def_wrap_other(t));
                             }
@@ -446,7 +446,7 @@ fn lookup_name_wrapped(&env e, ast.ident i, namespace ns)
     fn found_tag(@ast.item item, uint variant_idx) -> def_wrap {
         alt (item.node) {
             case (ast.item_tag(_, ?variants, _, ?tid)) {
-                auto vid = variants.(variant_idx).id;
+                auto vid = variants.(variant_idx).node.id;
                 auto t = ast.def_variant(tid, vid);
                 ret def_wrap_other(t);
             }

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -337,7 +337,7 @@ fn ast_ty_to_ty(ty_getter getter, &@ast.ty ast_ty) -> @ty.t {
             sty = ty.ty_rec(flds);
         }
 
-        case (ast.ty_fn(?proto, ?inputs, ?output)) {
+        case (ast.ty_fn(_, ?proto, ?inputs, ?output)) {
             auto f = bind ast_arg_to_arg(getter, _);
             auto i = _vec.map[ast.ty_arg, arg](f, inputs);
             sty = ty.ty_fn(proto, i, ast_ty_to_ty(getter, output));

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -656,7 +656,7 @@ fn collect_item_types(session.session sess, @ast.crate crate)
             // Nullary tag constructors get turned into constants; n-ary tag
             // constructors get turned into functions.
             auto result_ty;
-            if (_vec.len[ast.variant_arg](variant.args) == 0u) {
+            if (_vec.len[ast.variant_arg](variant.node.args) == 0u) {
                 result_ty = plain_ty(ty.ty_tag(tag_id, ty_param_tys));
             } else {
                 // As above, tell ast_ty_to_ty() that trans_ty_item_to_ty()
@@ -664,7 +664,7 @@ fn collect_item_types(session.session sess, @ast.crate crate)
                 auto f = bind getter(sess, id_to_ty_item, type_cache, _);
 
                 let vec[arg] args = vec();
-                for (ast.variant_arg va in variant.args) {
+                for (ast.variant_arg va in variant.node.args) {
                     auto arg_ty = ast_ty_to_ty(f, va.ty);
                     args += vec(rec(mode=ast.alias, ty=arg_ty));
                 }
@@ -673,13 +673,13 @@ fn collect_item_types(session.session sess, @ast.crate crate)
             }
 
             auto tpt = tup(params_opt, result_ty);
-            type_cache.insert(variant.id, tpt);
+            type_cache.insert(variant.node.id, tpt);
 
             auto variant_t = rec(
                 ann=ast.ann_type(result_ty, none[vec[@ty.t]])
-                with variant
+                with variant.node
             );
-            result += vec(variant_t);
+            result += vec(fold.respan[ast.variant_](variant.span, variant_t));
         }
 
         ret result;

--- a/src/comp/pretty/pp.rs
+++ b/src/comp/pretty/pp.rs
@@ -4,9 +4,11 @@ import std._str;
 
 tag boxtype {box_h; box_v; box_hv; box_align;}
 tag contexttype {cx_h; cx_v;}
+tag scantype {scan_hv; scan_h; scan_none;}
 
 tag token {
   brk(uint);
+  hardbrk;
   word(str);
   cword(str); // closing token
   open(boxtype, uint);
@@ -18,29 +20,45 @@ type context = rec(contexttype tp, uint indent);
 type ps = @rec(mutable vec[context] context,
                uint width,
                io.writer out,
-               mutable vec[token] buffered,
-               mutable uint scandepth,
-               mutable uint bufferedcol,
                mutable uint col,
-               mutable bool start_of_line);
+               mutable uint spaces,
+               mutable vec[token] buffered,
+               mutable scantype scanning,
+               mutable vec[boxtype] scandepth,
+               mutable uint scancol,
+               mutable bool start_of_line,
+               mutable bool start_of_box,
+               mutable bool potential_brk);
 
 fn mkstate(io.writer out, uint width) -> ps {
   let vec[context] stack = vec(rec(tp=cx_v, indent=0u));
   let vec[token] buff = vec();
+  let vec[boxtype] sd = vec();
   ret @rec(mutable context=stack,
            width=width,
            out=out,
-           mutable buffered=buff,
-           mutable scandepth=0u,
-           mutable bufferedcol=0u,
            mutable col=0u,
-           mutable start_of_line=true);
+           mutable spaces=0u,
+           mutable buffered=buff,
+           mutable scanning=scan_none,
+           mutable scandepth=sd,
+           mutable scancol=0u,
+           mutable start_of_line=true,
+           mutable start_of_box=true,
+           mutable potential_brk=false);
+}
+
+impure fn write_spaces(ps p, uint i) {
+  while (i > 0u) {
+    i -= 1u;
+    p.out.write_str(" ");
+  }
 }
 
 impure fn push_context(ps p, contexttype tp, uint indent) {
   before_print(p, false);
-  _vec.push[context](p.context, rec(tp=tp, indent=base_indent(p)
-                                    + indent));
+  _vec.push[context](p.context, rec(tp=tp, indent=indent));
+  p.start_of_box = true;
 }
 
 fn pop_context(ps p) {
@@ -49,15 +67,13 @@ fn pop_context(ps p) {
 
 impure fn add_token(ps p, token tok) {
   if (p.width == 0u) {direct_token(p, tok);}
-  else if (p.scandepth == 0u) {do_token(p, tok);}
+  else if (p.scanning == scan_none) {do_token(p, tok);}
   else {buffer_token(p, tok);}
 }
 
 impure fn direct_token(ps p, token tok) {
   alt (tok) {
-    case (brk(?sz)) {
-      while (sz > 0u) {p.out.write_str(" "); sz -= 1u;}
-    }
+    case (brk(?sz)) {write_spaces(p, sz);}
     case (word(?w)) {p.out.write_str(w);}
     case (cword(?w)) {p.out.write_str(w);}
     case (_) {}
@@ -66,78 +82,75 @@ impure fn direct_token(ps p, token tok) {
 
 impure fn buffer_token(ps p, token tok) {
   p.buffered += vec(tok);
-  p.bufferedcol += token_size(tok);
-  alt (p.buffered.(0)) {
-    case (brk(_)) {
-      alt (tok) {
-        case (brk(_)) {
-          if (p.scandepth == 1u) {finish_break_scan(p);}
-        }
-        case (open(box_h,_)) {p.scandepth += 1u;}
-        case (open(_,_)) {finish_break_scan(p);}
-        case (close) {
-          p.scandepth -= 1u;
-          if (p.scandepth == 0u) {finish_break_scan(p);}
-        }
-        case (_) {}
-      }
-    }
-    case (open(_,_)) {
-      if (p.bufferedcol > p.width) {finish_block_scan(p, cx_v);}
-      else {
-        alt (tok) {
-          case (open(_,_)) {p.scandepth += 1u;}
-          case (close) {
-            p.scandepth -= 1u;
-            if (p.scandepth == 0u) {finish_block_scan(p, cx_h);}
+  auto col = p.scancol;
+  p.scancol = col + token_size(tok);
+  if (p.scancol > p.width) {
+    finish_scan(p, false);
+  } else {
+    alt (tok) {
+      case (open(?tp,_)) {
+        _vec.push[boxtype](p.scandepth, tp);
+        if (p.scanning == scan_h) {
+          if (tp == box_h) {
+            check_potential_brk(p);
           }
-          case (_) {}
         }
       }
+      case (close) {
+        _vec.pop[boxtype](p.scandepth);
+        if (_vec.len[boxtype](p.scandepth) == 0u) {
+          finish_scan(p, true);
+        }
+      }
+      case (brk(_)) {
+        if (p.scanning == scan_h) {
+          if (p.scandepth.(_vec.len[boxtype](p.scandepth)-1u) == box_v) {
+            finish_scan(p, true);
+          }
+        }
+      }
+      case (_) {}
     }
   }
 }
 
-impure fn finish_block_scan(ps p, contexttype tp) {
+impure fn check_potential_brk(ps p) {
+  for (boxtype tp in p.scandepth) {
+    if (tp != box_h) {ret;}
+  }
+  p.potential_brk = true;
+}
+
+impure fn finish_scan(ps p, bool fits) {
   auto buf = p.buffered;
   auto front = _vec.shift[token](buf);
-  auto indent;
-  alt (front){
-    case (open(box_hv,?ind)) {
-      indent = ind;
+  auto chosen_tp = cx_h;
+  if (!fits) {chosen_tp = cx_v;}
+  alt (front) {
+    case (open(box_hv, ?ind)) {
+      push_context(p, chosen_tp, base_indent(p) + ind);
     }
     case (open(box_align, _)) {
-      indent = p.col - base_indent(p);
+      push_context(p, chosen_tp, p.col);
+    }
+    case (open(box_h, ?ind)) {
+      if (!fits && !p.start_of_box && !p.start_of_line && !p.potential_brk) {
+        line_break(p);
+      }
+      push_context(p, cx_h, base_indent(p) + ind);
     }
   }
-  p.scandepth = 0u;
-  p.buffered = vec();
-  push_context(p, tp, indent);
+  p.scandepth = vec();
+  p.scanning = scan_none;
   for (token t in buf) { add_token(p, t); }
 }
 
-impure fn finish_break_scan(ps p) {
-  auto buf = p.buffered;
-  auto front = _vec.shift[token](buf);
-  if (p.bufferedcol > p.width) {
-    line_break(p);
-  }
-  else {
-    auto width;
-    alt (front) {case(brk(?w)) {width = w;}}
-    auto i = 0u;
-    while (i < width) {p.out.write_str(" "); i+=1u;}
-    p.col += width;
-  }
-  p.scandepth = 0u;
+impure fn start_scan(ps p, token tok, scantype tp) {
   p.buffered = vec();
-  for (token t in buf) { add_token(p, t); }
-}
-
-impure fn start_scan(ps p, token tok) {
-  p.buffered = vec(tok);
-  p.scandepth = 1u;
-  p.bufferedcol = p.col;
+  p.scancol = p.col;
+  p.scanning = tp;
+  buffer_token(p, tok);
+  p.potential_brk = false;
 }
 
 fn cur_context(ps p) -> context {
@@ -152,64 +165,91 @@ fn base_indent(ps p) -> uint {
   }
 }
 
+fn cx_is(contexttype a, contexttype b) -> bool {
+  if (a == b) {ret true;}
+  else {ret false;}
+}
+fn box_is(boxtype a, boxtype b) -> bool {
+  if (a == b) {ret true;}
+  else {ret false;}
+}
+
 impure fn do_token(ps p, token tok) {
+  auto start_of_box = p.start_of_box;
+  p.start_of_box = false;
   alt (tok) {
     case (brk(?sz)) {
-      alt (cur_context(p).tp) {
-        case (cx_h) {
-          before_print(p, false);
-          start_scan(p, tok);
-        }
-        case (cx_v) {
-          line_break(p);
-        }
+      if (cx_is(cur_context(p).tp, cx_v) || sz + p.col > p.width) {
+        line_break(p);
+      }
+      else {
+        p.spaces += sz;
       }
     }
+    case (hardbrk) {
+      line_break(p);
+    }
     case (word(?w)) {
+      auto len = _str.char_len(w);
+      if (len + p.col + p.spaces > p.width && !start_of_box &&
+          !p.start_of_line) {
+        line_break(p);
+      }
       before_print(p, false);
       p.out.write_str(w);
-      p.col += _str.byte_len(w); // TODO char_len
+      p.col += len;
     }
     case (cword(?w)) {
       before_print(p, true);
       p.out.write_str(w);
-      p.col += _str.byte_len(w); // TODO char_len
+      p.col += _str.char_len(w);
     }
     case (open(?tp, ?indent)) {
-      alt (tp) {
-        case (box_hv) {start_scan(p, tok);}
-        case (box_align) {start_scan(p, tok);}
-        case (box_h) {push_context(p, cx_h, indent);}
-        case (box_v) {push_context(p, cx_v, indent);}
+      if (tp == box_v) {
+        push_context(p, cx_v, base_indent(p) + indent);
+      } else if (box_is(tp, box_h) && cx_is(cur_context(p).tp, cx_v)) {
+        push_context(p, cx_h, base_indent(p) + indent);
+      } else if (tp == box_h) {
+        p.start_of_box = start_of_box;
+        start_scan(p, tok, scan_h);
+      } else {
+        p.start_of_box = start_of_box;
+        start_scan(p, tok, scan_hv);
       }
     }
-    case (close) {pop_context(p);}
+    case (close) {
+      pop_context(p);
+    }
   }
 }
 
 impure fn line_break(ps p) {
   p.out.write_str("\n");
   p.col = 0u;
+  p.spaces = cur_context(p).indent;
   p.start_of_line = true;
 }
 
 impure fn before_print(ps p, bool closing) {
   if (p.start_of_line) {
     p.start_of_line = false;
-    auto ind;
-    if (closing) {ind = base_indent(p);}
-    else {ind = cur_context(p).indent;}
-    p.col = ind;
-    while (ind > 0u) {p.out.write_str(" "); ind -= 1u;}
+    if (closing) {p.spaces = base_indent(p);}
+    else {p.spaces = cur_context(p).indent;}
+  }
+  if (p.spaces > 0u) {
+    write_spaces(p, p.spaces);
+    p.col += p.spaces;
+    p.spaces = 0u;
   }
 }
 
 fn token_size(token tok) -> uint {
   alt (tok) {
     case (brk(?sz)) {ret sz;}
-    case (word(?w)) {ret _str.byte_len(w);}
-    case (cword(?w)) {ret _str.byte_len(w);}
-    case (open(_, _)) {ret 0u;} // TODO exception for V blocks?
+    case (hardbrk) {ret 0xFFFFFFu;}
+    case (word(?w)) {ret _str.char_len(w);}
+    case (cword(?w)) {ret _str.char_len(w);}
+    case (open(_, _)) {ret 0u;}
     case (close) {ret 0u;}
   }
 }
@@ -224,3 +264,4 @@ impure fn cwrd(ps p, str wrd) {add_token(p, cword(wrd));}
 impure fn space(ps p) {add_token(p, brk(1u));}
 impure fn spaces(ps p, uint n) {add_token(p, brk(n));}
 impure fn line(ps p) {add_token(p, brk(0u));}
+impure fn hardbreak(ps p) {add_token(p, hardbrk);}

--- a/src/comp/pretty/pprust.rs
+++ b/src/comp/pretty/pprust.rs
@@ -127,7 +127,7 @@ impure fn print_type(ps s, &@ast.ty ty) {
             bopen(s);
             for (ast.ty_method m in methods) {
                 hbox(s);
-                print_ty_fn(s, m.proto, option.some[str](m.ident),
+                print_ty_fn(s, m.effect, m.proto, option.some[str](m.ident),
                             m.inputs, m.output);
                 wrd(s.s, ";");
                 end(s.s);
@@ -135,8 +135,8 @@ impure fn print_type(ps s, &@ast.ty ty) {
             }
             bclose_c(s, ty.span);
         }
-        case (ast.ty_fn(?proto,?inputs,?output)) {
-            print_ty_fn(s, proto, option.none[str], inputs, output);
+        case (ast.ty_fn(?eff, ?proto,?inputs,?output)) {
+            print_ty_fn(s, eff, proto, option.none[str], inputs, output);
         }
         case (ast.ty_path(?path,_)) {
             print_path(s, path);
@@ -843,8 +843,13 @@ impure fn print_string(ps s, str st) {
     wrd(s.s, "\""); wrd(s.s, escape_str(st, '"')); wrd(s.s, "\"");
 }
 
-impure fn print_ty_fn(ps s, ast.proto proto, option.t[str] id,
+impure fn print_ty_fn(ps s, ast.effect eff, ast.proto proto, option.t[str] id,
                       vec[ast.ty_arg] inputs, @ast.ty output) {
+    alt (eff) {
+        case (ast.eff_impure) {wrd1(s, "impure");}
+        case (ast.eff_unsafe) {wrd1(s, "unsafe");}
+        case (_) {}
+    }
     if (proto == ast.proto_fn) {wrd(s.s, "fn");}
     else {wrd(s.s, "iter");}
     alt (id) {

--- a/src/comp/pretty/pprust.rs
+++ b/src/comp/pretty/pprust.rs
@@ -1,60 +1,833 @@
 import std._vec;
 import std._str;
+import std.io;
 import std.option;
 import front.ast;
-import pp.box; import pp.abox; import pp.vbox;
+import front.lexer;
 import pp.end; import pp.wrd; import pp.space; import pp.line;
-import pp.ps;
 
-import foo = std.io;
-
-const uint indent_unit = 2u;
+const uint indent_unit = 4u;
 const int as_prec = 5;
+const uint default_columns = 78u;
 
-impure fn print_ast(ast._mod _mod, std.io.writer out) {
-  auto s = pp.mkstate(out, 80u);
-  for (@ast.view_item vitem in _mod.view_items) {print_view_item(s, vitem);}
-  line(s);
-  for (@ast.item item in _mod.items) {print_item(s, item);}
+type ps = @rec(pp.ps s,
+               option.t[vec[lexer.cmnt]] comments,
+               mutable uint cur_cmnt);
+
+impure fn print_file(ast._mod _mod, str filename, io.writer out) {
+    auto cmnts = lexer.gather_comments(filename);
+    auto s = @rec(s=pp.mkstate(out, default_columns),
+                  comments=option.some[vec[lexer.cmnt]](cmnts),
+                  mutable cur_cmnt=0u);
+    print_mod(s, _mod);
 }
 
 fn ty_to_str(&@ast.ty ty) -> str {
-  auto writer = std.io.string_writer();
-  print_type(pp.mkstate(writer.get_writer(), 0u), ty);
-  ret writer.get_str();
+    auto writer = io.string_writer();
+    auto s = @rec(s=pp.mkstate(writer.get_writer(), 0u),
+                  comments=option.none[vec[lexer.cmnt]],
+                  mutable cur_cmnt=0u);
+    print_type(s, ty);
+    ret writer.get_str();
 }
 
 impure fn hbox(ps s) {
-  pp.hbox(s, indent_unit);
+    pp.hbox(s.s, indent_unit);
 }
 impure fn wrd1(ps s, str word) {
-  wrd(s, word);
-  space(s);
+    wrd(s.s, word);
+    space(s.s);
 }
 impure fn popen(ps s) {
-  wrd(s, "(");
-  abox(s);
+    wrd(s.s, "(");
+    pp.abox(s.s);
+}
+impure fn popen_h(ps s) {
+    wrd(s.s, "(");
+    pp.hbox(s.s, 0u);
 }
 impure fn pclose(ps s) {
-  end(s);
-  wrd(s, ")");
+    end(s.s);
+    wrd(s.s, ")");
 }
 impure fn bopen(ps s) {
-  wrd1(s, "{");
-  vbox(s, indent_unit);
-  line(s);
+    wrd(s.s, "{");
+    pp.vbox(s.s, indent_unit);
+    line(s.s);
 }
 impure fn bclose(ps s) {
-  end(s);
-  pp.cwrd(s, "}");
+    end(s.s);
+    pp.cwrd(s.s, "}");
+}
+impure fn bclose_c(ps s, util.common.span span) {
+    maybe_print_comment(s, span.hi);
+    bclose(s);
 }
 impure fn commasep[IN](ps s, vec[IN] elts, impure fn (ps, &IN) op) {
-  auto first = true;
-  for (IN elt in elts) {
-    if (first) {first = false;}
-    else {wrd1(s, ",");}
-    op(s, elt);
-  }
+    auto first = true;
+    for (IN elt in elts) {
+        if (first) {first = false;}
+        else {wrd1(s, ",");}
+        op(s, elt);
+    }
+}
+
+impure fn print_mod(ps s, ast._mod _mod) {
+    for (@ast.view_item vitem in _mod.view_items) {print_view_item(s, vitem);}
+    line(s.s);
+    for (@ast.item item in _mod.items) {print_item(s, item);}
+    print_remaining_comments(s);
+}
+
+impure fn print_type(ps s, &@ast.ty ty) {
+    maybe_print_comment(s, ty.span.lo);
+    hbox(s);
+    alt (ty.node) {
+        case (ast.ty_nil) {wrd(s.s, "()");}
+        case (ast.ty_bool) {wrd(s.s, "bool");}
+        case (ast.ty_int) {wrd(s.s, "int");}
+        case (ast.ty_uint) {wrd(s.s, "uint");}
+        case (ast.ty_machine(?tm)) {wrd(s.s, util.common.ty_mach_to_str(tm));}
+        case (ast.ty_char) {wrd(s.s, "char");}
+        case (ast.ty_str) {wrd(s.s, "str");}
+        case (ast.ty_box(?mt)) {wrd(s.s, "@"); print_mt(s, mt);}
+        case (ast.ty_vec(?mt)) {
+            wrd(s.s, "vec["); print_mt(s, mt); wrd(s.s, "]");
+        }
+        case (ast.ty_port(?t)) {
+            wrd(s.s, "port["); print_type(s, t); wrd(s.s, "]");
+        }
+        case (ast.ty_chan(?t)) {
+            wrd(s.s, "chan["); print_type(s, t); wrd(s.s, "]");
+        }
+        case (ast.ty_type) {wrd(s.s, "type");}
+        case (ast.ty_tup(?elts)) {
+            wrd(s.s, "tup");
+            popen(s);
+            auto f = print_mt;
+            commasep[ast.mt](s, elts, f);
+            pclose(s);
+        }
+        case (ast.ty_rec(?fields)) {
+            wrd(s.s, "rec");
+            popen(s);
+            impure fn print_field(ps s, &ast.ty_field f) {
+                hbox(s);
+                print_mt(s, f.mt);
+                space(s.s);
+                wrd(s.s, f.ident);
+                end(s.s);
+            }
+            auto f = print_field;
+            commasep[ast.ty_field](s, fields, f);
+            pclose(s);
+        }
+        case (ast.ty_obj(?methods)) {
+            wrd1(s, "obj");
+            bopen(s);
+            for (ast.ty_method m in methods) {
+                hbox(s);
+                print_ty_fn(s, m.proto, option.some[str](m.ident),
+                            m.inputs, m.output);
+                wrd(s.s, ";");
+                end(s.s);
+                line(s.s);
+            }
+            bclose_c(s, ty.span);
+        }
+        case (ast.ty_fn(?proto,?inputs,?output)) {
+            print_ty_fn(s, proto, option.none[str], inputs, output);
+        }
+        case (ast.ty_path(?path,_)) {
+            print_path(s, path);
+        }
+    }
+    end(s.s);
+}
+
+impure fn print_item(ps s, @ast.item item) {
+    maybe_print_comment(s, item.span.lo);
+    hbox(s);
+    alt (item.node) {
+        case (ast.item_const(?id, ?ty, ?expr, _, _)) {
+            wrd1(s, "const");
+            print_type(s, ty);
+            space(s.s);
+            wrd1(s, id);
+            wrd1(s, "=");
+            print_expr(s, expr);
+            wrd(s.s, ";");
+        }
+        case (ast.item_fn(?name,?_fn,?typarams,_,_)) {
+            print_fn(s, _fn.decl, name, typarams);
+            space(s.s);
+            print_block(s, _fn.body);
+        }
+        case (ast.item_mod(?id,?_mod,_)) {
+            wrd1(s, "mod");
+            wrd1(s, id);
+            bopen(s);
+            for (@ast.item itm in _mod.items) {print_item(s, itm);}
+            bclose_c(s, item.span);
+        }
+        case (ast.item_native_mod(?id,?nmod,_)) {
+            wrd1(s, "native");
+            alt (nmod.abi) {
+                case (ast.native_abi_rust) {wrd1(s, "\"rust\"");}
+                case (ast.native_abi_cdecl) {wrd1(s, "\"cdecl\"");}
+            }
+            wrd1(s, "mod");
+            wrd1(s, id);
+            bopen(s);
+            for (@ast.native_item item in nmod.items) {
+                hbox(s);
+                maybe_print_comment(s, item.span.lo);
+                alt (item.node) {
+                    case (ast.native_item_ty(?id,_)) {
+                        wrd1(s, "type");
+                        wrd(s.s, id);
+                    }
+                    case (ast.native_item_fn(?id,?lname,?decl,
+                                             ?typarams,_,_)) {
+                        print_fn(s, decl, id, typarams);
+                        alt (lname) {
+                            case (option.none[str]) {}
+                            case (option.some[str](?ss)) {
+                                print_string(s, ss);
+                            }
+                        }
+                    }
+                }
+                wrd(s.s, ";");
+                end(s.s);
+            }
+            bclose_c(s, item.span);
+        }
+        case (ast.item_ty(?id,?ty,?params,_,_)) {
+            wrd1(s, "type");
+            wrd(s.s, id);
+            print_type_params(s, params);
+            space(s.s);
+            wrd1(s, "=");
+            print_type(s, ty);
+            wrd(s.s, ";");
+        }
+        case (ast.item_tag(?id,?variants,?params,_)) {
+            wrd1(s, "tag");
+            wrd(s.s, id);
+            print_type_params(s, params);
+            space(s.s);
+            bopen(s);
+            for (ast.variant v in variants) {
+                wrd(s.s, v.name);
+                if (_vec.len[ast.variant_arg](v.args) > 0u) {
+                    popen(s);
+                    impure fn print_variant_arg(ps s, &ast.variant_arg arg) {
+                        print_type(s, arg.ty);
+                    }
+                    auto f = print_variant_arg;
+                    commasep[ast.variant_arg](s, v.args, f);
+                    pclose(s);
+                }
+                wrd(s.s, ";");
+                line(s.s);
+            }
+            bclose_c(s, item.span);
+        }
+        case (ast.item_obj(?id,?_obj,?params,_,_)) {
+            wrd1(s, "obj");
+            wrd(s.s, id);
+            print_type_params(s, params);
+            popen(s);
+            impure fn print_field(ps s, &ast.obj_field field) {
+                hbox(s);
+                print_type(s, field.ty);
+                space(s.s);
+                wrd(s.s, field.ident);
+                end(s.s);
+            }
+            auto f = print_field;
+            commasep[ast.obj_field](s, _obj.fields, f);
+            pclose(s);
+            space(s.s);
+            bopen(s);
+            for (@ast.method meth in _obj.methods) {
+                hbox(s);
+                let vec[ast.ty_param] typarams = vec();
+                maybe_print_comment(s, meth.span.lo);
+                print_fn(s, meth.node.meth.decl, meth.node.ident, typarams);
+                space(s.s);
+                print_block(s, meth.node.meth.body);
+                end(s.s);
+                line(s.s);
+            }
+            alt (_obj.dtor) {
+                case (option.some[ast.block](?dtor)) {
+                    hbox(s);
+                    wrd1(s, "close");
+                    print_block(s, dtor);
+                    end(s.s);
+                    line(s.s);
+                }
+                case (_) {}
+            }
+            bclose_c(s, item.span);
+        }
+    }
+    end(s.s);
+    line(s.s);
+    line(s.s);
+}
+
+impure fn print_block(ps s, ast.block blk) {
+    auto cur_line = 0u;
+    maybe_print_comment(s, blk.span.lo);
+    bopen(s);
+    for (@ast.stmt st in blk.node.stmts) {
+        if (cur_line != 0u && blk.span.lo.line > cur_line + 1u) {
+            line(s.s);
+        }
+        cur_line = blk.span.hi.line;
+        maybe_print_comment(s, st.span.lo);
+        alt (st.node) {
+            case (ast.stmt_decl(?decl)) {print_decl(s, decl);}
+            case (ast.stmt_expr(?expr)) {print_expr(s, expr);}
+        }
+        if (front.parser.stmt_ends_with_semi(st)) {wrd(s.s, ";");}
+        if (!maybe_print_stmt_comment(s, st.span)) {line(s.s);}
+    }
+    alt (blk.node.expr) {
+        case (option.some[@ast.expr](?expr)) {
+            if (cur_line != 0u && blk.span.lo.line > cur_line + 1u) {
+                line(s.s);
+            }
+            print_expr(s, expr);
+            if (!maybe_print_stmt_comment(s, expr.span)) {line(s.s);}
+        }
+        case (_) {}
+    }
+    bclose_c(s, blk.span);
+}
+
+impure fn print_literal(ps s, @ast.lit lit) {
+    maybe_print_comment(s, lit.span.lo);
+    alt (lit.node) {
+        case (ast.lit_str(?st)) {print_string(s, st);}
+        case (ast.lit_char(?ch)) {
+            wrd(s.s, "'" + escape_str(_str.from_bytes(vec(ch as u8)), '\'')
+                + "'");
+        }
+        case (ast.lit_int(?val)) {
+            wrd(s.s, util.common.istr(val));
+        }
+        case (ast.lit_uint(?val)) { // FIXME clipping? uistr?
+            wrd(s.s, util.common.istr(val as int) + "u");
+        }
+        case (ast.lit_float(?fstr)) {
+            wrd(s.s, fstr);
+        }
+        case (ast.lit_mach_int(?mach,?val)) {
+            wrd(s.s, util.common.istr(val as int));
+            wrd(s.s, util.common.ty_mach_to_str(mach));
+        }
+        case (ast.lit_nil) {wrd(s.s, "()");}
+        case (ast.lit_bool(?val)) {
+            if (val) {wrd(s.s, "true");} else {wrd(s.s, "false");}
+        }
+    }
+}
+
+impure fn print_expr(ps s, &@ast.expr expr) {
+    maybe_print_comment(s, expr.span.lo);
+    auto pe = print_expr;
+    hbox(s);
+    alt (expr.node) {
+        case (ast.expr_vec(?exprs,?mut,_)) {
+            if (mut == ast.mut) {
+                wrd1(s, "mutable");
+            }
+            wrd(s.s, "vec");
+            popen(s);
+            commasep[@ast.expr](s, exprs, pe);
+            pclose(s);
+        }
+        case (ast.expr_tup(?exprs,_)) {
+            impure fn printElt(ps s, &ast.elt elt) {
+                hbox(s);
+                if (elt.mut == ast.mut) {wrd1(s, "mutable");}
+                print_expr(s, elt.expr);
+                end(s.s);
+            }
+            wrd(s.s, "tup");
+            popen(s);
+            auto f = printElt;
+            commasep[ast.elt](s, exprs, f);
+            pclose(s);
+        }
+        case (ast.expr_rec(?fields,?wth,_)) {
+            impure fn print_field(ps s, &ast.field field) {
+                hbox(s);
+                if (field.mut == ast.mut) {wrd1(s, "mutable");}
+                wrd(s.s, field.ident);
+                wrd(s.s, "=");
+                print_expr(s, field.expr);
+                end(s.s);
+            }
+            wrd(s.s, "rec");
+            popen(s);
+            auto f = print_field;
+            commasep[ast.field](s, fields, f);
+            alt (wth) {
+                case (option.some[@ast.expr](?expr)) {
+                    if (_vec.len[ast.field](fields) > 0u) {space(s.s);}
+                    hbox(s);
+                    wrd1(s, "with");
+                    print_expr(s, expr);
+                    end(s.s);
+                }
+                case (_) {}
+            }
+            pclose(s);
+        }
+        case (ast.expr_call(?func,?args,_)) {
+            print_expr(s, func);
+            popen(s);
+            commasep[@ast.expr](s, args, pe);
+            pclose(s);
+        }
+        case (ast.expr_bind(?func,?args,_)) {
+            impure fn print_opt(ps s, &option.t[@ast.expr] expr) {
+                alt (expr) {
+                    case (option.some[@ast.expr](?expr)) {
+                        print_expr(s, expr);
+                    }
+                    case (_) {wrd(s.s, "_");}
+                }
+            }
+            wrd1(s, "bind");
+            print_expr(s, func);
+            popen(s);
+            auto f = print_opt;
+            commasep[option.t[@ast.expr]](s, args, f);
+            pclose(s);
+        }
+        case (ast.expr_binary(?op,?lhs,?rhs,_)) {
+            auto prec = operator_prec(op);
+            print_maybe_parens(s, lhs, prec);
+            space(s.s);
+            wrd1(s, ast.binop_to_str(op));
+            print_maybe_parens(s, rhs, prec + 1);
+        }
+        case (ast.expr_unary(?op,?expr,_)) {
+            wrd(s.s, ast.unop_to_str(op));
+            print_expr(s, expr);
+        }
+        case (ast.expr_lit(?lit,_)) {
+            print_literal(s, lit);
+        }
+        case (ast.expr_cast(?expr,?ty,_)) {
+            print_maybe_parens(s, expr, as_prec);
+            space(s.s);
+            wrd1(s, "as");
+            print_type(s, ty);
+        }
+        case (ast.expr_if(?test,?block,?elseopt,_)) {
+            wrd1(s, "if");
+            popen_h(s);
+            print_expr(s, test);
+            pclose(s);
+            space(s.s);
+            print_block(s, block);
+            alt (elseopt) {
+                case (option.some[@ast.expr](?_else)) {
+                    space(s.s);
+                    wrd1(s, "else");
+                    print_expr(s, _else);
+                }
+                case (_) { /* fall through */ }
+            }
+        }
+        case (ast.expr_while(?test,?block,_)) {
+            wrd1(s, "while");
+            popen_h(s);
+            print_expr(s, test);
+            pclose(s);
+            space(s.s);
+            print_block(s, block);
+        }
+        case (ast.expr_for(?decl,?expr,?block,_)) {
+            wrd1(s, "for");
+            popen_h(s);
+            print_for_decl(s, decl);
+            space(s.s);
+            wrd1(s, "in");
+            print_expr(s, expr);
+            pclose(s);
+            space(s.s);
+            print_block(s, block);
+        }
+        case (ast.expr_for_each(?decl,?expr,?block,_)) {
+            wrd1(s, "for each");
+            popen_h(s);
+            print_for_decl(s, decl);
+            space(s.s);
+            wrd1(s, "in");
+            print_expr(s, expr);
+            pclose(s);
+            space(s.s);
+            print_block(s, block);
+        }
+        case (ast.expr_do_while(?block,?expr,_)) {
+            wrd1(s, "do");
+            space(s.s);
+            print_block(s, block);
+            space(s.s);
+            wrd1(s, "while");
+            popen_h(s);
+            print_expr(s, expr);
+            pclose(s);
+        }
+        case (ast.expr_alt(?expr,?arms,_)) {
+            wrd1(s, "alt");
+            popen_h(s);
+            print_expr(s, expr);
+            pclose(s);
+            space(s.s);
+            bopen(s);
+            for (ast.arm arm in arms) {
+                hbox(s);
+                wrd1(s, "case");
+                popen_h(s);
+                print_pat(s, arm.pat);
+                pclose(s);
+                space(s.s);
+                print_block(s, arm.block);
+                end(s.s);
+                line(s.s);
+            }
+            bclose_c(s, expr.span);
+        }
+        case (ast.expr_block(?block,_)) {
+            print_block(s, block);
+        }
+        case (ast.expr_assign(?lhs,?rhs,_)) {
+            print_expr(s, lhs);
+            space(s.s);
+            wrd1(s, "=");
+            print_expr(s, rhs);
+        }
+        case (ast.expr_assign_op(?op,?lhs,?rhs,_)) {
+            print_expr(s, lhs);
+            space(s.s);
+            wrd(s.s, ast.binop_to_str(op));
+            wrd1(s, "=");
+            print_expr(s, rhs);
+        }
+        case (ast.expr_send(?lhs, ?rhs, _)) {
+            print_expr(s, lhs);
+            space(s.s);
+            wrd1(s, "<|");
+            print_expr(s, rhs);
+        }
+        case (ast.expr_recv(?lhs, ?rhs, _)) {
+            print_expr(s, lhs);
+            space(s.s);
+            wrd1(s, "<-");
+            print_expr(s, rhs);
+        }
+        case (ast.expr_field(?expr,?id,_)) {
+            print_expr(s, expr);
+            wrd(s.s, ".");
+            wrd(s.s, id);
+        }
+        case (ast.expr_index(?expr,?index,_)) {
+            print_expr(s, expr);
+            wrd(s.s, ".");
+            popen_h(s);
+            print_expr(s, index);
+            pclose(s);
+        }
+        case (ast.expr_path(?path,_,_)) {
+            print_path(s, path);
+        }
+        case (ast.expr_fail) {
+            wrd(s.s, "fail");
+        }
+        case (ast.expr_ret(?result)) {
+            wrd(s.s, "ret");
+            alt (result) {
+                case (option.some[@ast.expr](?expr)) {
+                    space(s.s);
+                    print_expr(s, expr);
+                }
+                case (_) {}
+            }
+        }
+        case (ast.expr_put(?result)) {
+            wrd(s.s, "put");
+            alt (result) {
+                case (option.some[@ast.expr](?expr)) {
+                    space(s.s);
+                    print_expr(s, expr);
+                }
+                case (_) {}
+            }
+        }
+        case (ast.expr_be(?result)) {
+            wrd1(s, "be");
+            print_expr(s, result);
+        }
+        case (ast.expr_log(?expr)) {
+            wrd1(s, "log");
+            print_expr(s, expr);
+        }
+        case (ast.expr_check_expr(?expr)) {
+            wrd1(s, "check");
+            popen_h(s);
+            print_expr(s, expr);
+            pclose(s);
+        }
+        case (ast.expr_ext(?path, ?args, ?body, _, _)) {
+            wrd(s.s, "#");
+            print_path(s, path);
+            if (_vec.len[@ast.expr](args) > 0u) {
+                popen(s);
+                commasep[@ast.expr](s, args, pe);
+                pclose(s);
+            }
+            // FIXME: extension 'body'
+        }
+        case (ast.expr_port(_)) {
+            wrd(s.s, "port");
+            popen_h(s);
+            pclose(s);
+        }
+        case (ast.expr_chan(?expr, _)) {
+            wrd(s.s, "chan");
+            popen_h(s);
+            print_expr(s, expr);
+            pclose(s);
+        }
+    }
+    end(s.s);
+}
+
+impure fn print_decl(ps s, @ast.decl decl) {
+    maybe_print_comment(s, decl.span.lo);
+    hbox(s);
+    alt (decl.node) {
+        case (ast.decl_local(?loc)) {
+            alt (loc.ty) {
+                case (option.some[@ast.ty](?ty)) {
+                    wrd1(s, "let");
+                    print_type(s, ty);
+                    space(s.s);
+                }
+                case (_) {
+                    wrd1(s, "auto");
+                }
+            }
+            wrd(s.s, loc.ident);
+            alt (loc.init) {
+                case (option.some[ast.initializer](?init)) {
+                    space(s.s);
+                    alt (init.op) {
+                        case (ast.init_assign) {
+                            wrd1(s, "=");
+                        }
+                        case (ast.init_recv) {
+                            wrd1(s, "<-");
+                        }
+                    }
+                    print_expr(s, init.expr);
+                }
+                case (_) {}
+            }
+        }
+        case (ast.decl_item(?item)) {
+            print_item(s, item);
+        }
+    }
+    end(s.s);
+}
+
+impure fn print_for_decl(ps s, @ast.decl decl) {
+    alt (decl.node) {
+        case (ast.decl_local(?loc)) {
+            print_type(s, option.get[@ast.ty](loc.ty));
+            space(s.s);
+            wrd(s.s, loc.ident);
+        }
+    }
+}
+
+impure fn print_path(ps s, ast.path path) {
+    maybe_print_comment(s, path.span.lo);
+    auto first = true;
+    for (str id in path.node.idents) {
+        if (first) {first = false;}
+        else {wrd(s.s, ".");}
+        wrd(s.s, id);
+    }
+    if (_vec.len[@ast.ty](path.node.types) > 0u) {
+        wrd(s.s, "[");
+        auto f = print_type;
+        commasep[@ast.ty](s, path.node.types, f);
+        wrd(s.s, "]");
+    }
+}
+
+impure fn print_pat(ps s, &@ast.pat pat) {
+    maybe_print_comment(s, pat.span.lo);
+    alt (pat.node) {
+        case (ast.pat_wild(_)) {wrd(s.s, "_");}
+        case (ast.pat_bind(?id,_,_)) {wrd(s.s, "?" + id);}
+        case (ast.pat_lit(?lit,_)) {print_literal(s, lit);}
+        case (ast.pat_tag(?path,?args,_,_)) {
+            print_path(s, path);
+            if (_vec.len[@ast.pat](args) > 0u) {
+                popen_h(s);
+                auto f = print_pat;
+                commasep[@ast.pat](s, args, f);
+                pclose(s);
+            }
+        }
+    }
+}
+
+impure fn print_fn(ps s, ast.fn_decl decl, str name,
+                   vec[ast.ty_param] typarams) {
+    alt (decl.effect) {
+        case (ast.eff_impure) {wrd1(s, "impure");}
+        case (ast.eff_unsafe) {wrd1(s, "unsafe");}
+        case (_) {}
+    }
+    wrd1(s, "fn");
+    wrd(s.s, name);
+    print_type_params(s, typarams);
+    popen(s);
+    impure fn print_arg(ps s, &ast.arg x) {
+        hbox(s);
+        if (x.mode == ast.alias) {wrd(s.s, "&");}
+        print_type(s, x.ty);
+        space(s.s);
+        wrd(s.s, x.ident);
+        end(s.s);
+    }
+    auto f = print_arg;
+    commasep[ast.arg](s, decl.inputs, f);
+    pclose(s);
+    maybe_print_comment(s, decl.output.span.lo);
+    if (decl.output.node != ast.ty_nil) {
+        space(s.s);
+        hbox(s);
+        wrd1(s, "->");
+        print_type(s, decl.output);
+        end(s.s);
+    }
+}
+
+impure fn print_type_params(ps s, vec[ast.ty_param] params) {
+    if (_vec.len[ast.ty_param](params) > 0u) {
+        wrd(s.s, "[");
+        impure fn printParam(ps s, &ast.ty_param param) {
+            wrd(s.s, param.ident);
+        }
+        auto f = printParam;
+        commasep[ast.ty_param](s, params, f);
+        wrd(s.s, "]");
+    }
+}
+
+impure fn print_view_item(ps s, @ast.view_item item) {
+    maybe_print_comment(s, item.span.lo);
+    hbox(s);
+    alt (item.node) {
+        case (ast.view_item_use(?id,?mta,_,_)) {
+            wrd1(s, "use");
+            wrd(s.s, id);
+            if (_vec.len[@ast.meta_item](mta) > 0u) {
+                popen(s);
+                impure fn print_meta(ps s, &@ast.meta_item item) {
+                    hbox(s);
+                    wrd1(s, item.node.name);
+                    wrd1(s, "=");
+                    print_string(s, item.node.value);
+                    end(s.s);
+                }
+                auto f = print_meta;
+                commasep[@ast.meta_item](s, mta, f);
+                pclose(s);
+            }
+        }
+        case (ast.view_item_import(?id,?ids,_,_)) {
+            wrd1(s, "import");
+            if (!_str.eq(id, ids.(_vec.len[str](ids)-1u))) {
+                wrd1(s, id);
+                wrd1(s, "=");
+            }
+            auto first = true;
+            for (str elt in ids) {
+                if (first) {first = false;}
+                else {wrd(s.s, ".");}
+                wrd(s.s, elt);
+            }
+        }
+        case (ast.view_item_export(?id)) {
+            wrd1(s, "export");
+            wrd(s.s, id);
+        }
+    }
+    end(s.s);
+    wrd(s.s, ";");
+    line(s.s);
+}
+
+// FIXME: The fact that this builds up the table anew for every call is
+// not good. Eventually, table should be a const.
+fn operator_prec(ast.binop op) -> int {
+    for (front.parser.op_spec spec in front.parser.prec_table()) {
+        if (spec.op == op) {ret spec.prec;}
+    }
+    fail;
+}
+
+impure fn print_maybe_parens(ps s, @ast.expr expr, int outer_prec) {
+    auto add_them;
+    alt (expr.node) {
+        case (ast.expr_binary(?op,_,_,_)) {
+            add_them = operator_prec(op) < outer_prec;
+        }
+        case (ast.expr_cast(_,_,_)) {
+            add_them = as_prec < outer_prec;
+        }
+        case (_) {
+            add_them = false;
+        }
+    }
+    if (add_them) {popen(s);}
+    print_expr(s, expr);
+    if (add_them) {pclose(s);}
+}
+
+fn escape_str(str st, char to_escape) -> str {
+    let str out = "";
+    auto len = _str.byte_len(st);
+    auto i = 0u;
+    while (i < len) {
+        alt (st.(i) as char) {
+            case ('\n') {out += "\\n";}
+            case ('\t') {out += "\\t";}
+            case ('\r') {out += "\\r";}
+            case ('\\') {out += "\\\\";}
+            case (?cur) {
+                if (cur == to_escape) {out += "\\";}
+                _str.push_byte(out, cur as u8);
+            }
+        }
+        i += 1u;
+    }
+    ret out;
 }
 
 impure fn print_mt(ps s, &ast.mt mt) {
@@ -66,735 +839,111 @@ impure fn print_mt(ps s, &ast.mt mt) {
     print_type(s, mt.ty);
 }
 
-impure fn print_type(ps s, &@ast.ty ty) {
-  hbox(s);
-  alt (ty.node) {
-    case (ast.ty_nil) {wrd(s, "()");}
-    case (ast.ty_bool) {wrd(s, "bool");}
-    case (ast.ty_int) {wrd(s, "int");}
-    case (ast.ty_uint) {wrd(s, "uint");}
-    case (ast.ty_machine(?tm)) {wrd(s, util.common.ty_mach_to_str(tm));}
-    case (ast.ty_char) {wrd(s, "char");}
-    case (ast.ty_str) {wrd(s, "str");}
-    case (ast.ty_box(?mt)) {wrd(s, "@"); print_mt(s, mt);}
-    case (ast.ty_vec(?mt)) {wrd(s, "vec["); print_mt(s, mt); wrd(s, "]");}
-    case (ast.ty_port(?t)) {wrd(s, "port["); print_type(s, t); wrd(s, "]");}
-    case (ast.ty_chan(?t)) {wrd(s, "chan["); print_type(s, t); wrd(s, "]");}
-    case (ast.ty_type) {wrd(s, "type");}
-    case (ast.ty_tup(?elts)) {
-      wrd(s, "tup");
-      popen(s);
-      auto f = print_mt;
-      commasep[ast.mt](s, elts, f);
-      pclose(s);
-    }
-    case (ast.ty_rec(?fields)) {
-      wrd(s, "rec");
-      popen(s);
-      impure fn print_field(ps s, &ast.ty_field f) {
-        hbox(s);
-        print_mt(s, f.mt);
-        space(s);
-        wrd(s, f.ident);
-        end(s);
-      }
-      auto f = print_field;
-      commasep[ast.ty_field](s, fields, f);
-      pclose(s);
-    }
-    case (ast.ty_obj(?methods)) {
-      wrd1(s, "obj");
-      bopen(s);
-      for (ast.ty_method m in methods) {
-        hbox(s);
-        print_ty_fn(s, m.proto, option.some[str](m.ident),
-                    m.inputs, m.output);
-        wrd(s, ";");
-        end(s);
-        line(s);
-      }
-      bclose(s);
-    }
-    case (ast.ty_fn(?proto,?inputs,?output)) {
-      print_ty_fn(s, proto, option.none[str], inputs, output);
-    }
-    case (ast.ty_path(?path,_)) {
-      print_path(s, path);
-    }
-  }
-  end(s);
-}
-
-impure fn print_item(ps s, @ast.item item) {
-  hbox(s);
-  alt (item.node) {
-    case (ast.item_const(?id, ?ty, ?expr, _, _)) {
-      wrd1(s, "const");
-      print_type(s, ty);
-      space(s);
-      wrd1(s, id);
-      wrd1(s, "=");
-      print_expr(s, expr);
-      wrd(s, ";");
-    }
-    case (ast.item_fn(?name,?_fn,?typarams,_,_)) {
-      print_fn(s, _fn.decl, name, typarams);
-      space(s);
-      print_block(s, _fn.body);
-    }
-    case (ast.item_mod(?id,?_mod,_)) {
-      wrd1(s, "mod");
-      wrd1(s, id);
-      bopen(s);
-      for (@ast.item itm in _mod.items) {print_item(s, itm);}
-      bclose(s);
-    }
-    case (ast.item_native_mod(?id,?nmod,_)) {
-      wrd1(s, "native");
-      alt (nmod.abi) {
-        case (ast.native_abi_rust) {wrd1(s, "\"rust\"");}
-        case (ast.native_abi_cdecl) {wrd1(s, "\"cdecl\"");}
-      }
-      wrd1(s, "mod");
-      wrd1(s, id);
-      bopen(s);
-      for (@ast.native_item item in nmod.items) {
-        hbox(s);
-        alt (item.node) {
-          case (ast.native_item_ty(?id,_)) {
-            wrd1(s, "type");
-            wrd(s, id);
-          }
-          case (ast.native_item_fn(?id,?lname,?decl,?typarams,_,_)) {
-            print_fn(s, decl, id, typarams);
-            alt (lname) {
-              case (option.none[str]) {}
-              case (option.some[str](?ss)) {print_string(s,ss);}
-            }
-          }
-        }
-        wrd(s, ";");
-        end(s);
-      }
-      bclose(s);
-    }
-    case (ast.item_ty(?id,?ty,?params,_,_)) {
-      wrd1(s, "type");
-      wrd(s, id);
-      print_type_params(s, params);
-      space(s);
-      wrd1(s, "=");
-      print_type(s, ty);
-      wrd(s, ";");
-    }
-    case (ast.item_tag(?id,?variants,?params,_)) {
-      wrd1(s, "tag");
-      wrd(s, id);
-      print_type_params(s, params);
-      space(s);
-      bopen(s);
-      for (ast.variant v in variants) {
-        wrd(s, v.name);
-        if (_vec.len[ast.variant_arg](v.args) > 0u) {
-          popen(s);
-          impure fn print_variant_arg(ps s, &ast.variant_arg arg) {
-            print_type(s, arg.ty);
-          }
-          auto f = print_variant_arg;
-          commasep[ast.variant_arg](s, v.args, f);
-          pclose(s);
-        }
-        wrd(s, ";");
-        line(s);
-      }
-      bclose(s);
-    }
-    case (ast.item_obj(?id,?_obj,?params,_,_)) {
-      wrd1(s, "obj");
-      wrd(s, id);
-      print_type_params(s, params);
-      popen(s);
-      impure fn print_field(ps s, &ast.obj_field field) {
-        hbox(s);
-        print_type(s, field.ty);
-        space(s);
-        wrd(s, field.ident);
-        end(s);
-      }
-      auto f = print_field;
-      commasep[ast.obj_field](s, _obj.fields, f);
-      pclose(s);
-      space(s);
-      bopen(s);
-      for (@ast.method meth in _obj.methods) {
-        hbox(s);
-        let vec[ast.ty_param] typarams = vec();
-        print_fn(s, meth.node.meth.decl, meth.node.ident, typarams);
-        space(s);
-        print_block(s, meth.node.meth.body);
-        end(s);
-        line(s);
-      }
-      alt (_obj.dtor) {
-        case (option.some[ast.block](?dtor)) {
-          hbox(s);
-          wrd1(s, "close");
-          print_block(s, dtor);
-          end(s);
-          line(s);
-        }
-        case (_) {}
-      }
-      bclose(s);
-    }
-  }
-  end(s);
-  line(s);
-  line(s);
-}
-
-impure fn print_block(ps s, ast.block blk) {
-  bopen(s);
-  for (@ast.stmt st in blk.node.stmts) {
-    alt (st.node) {
-      case (ast.stmt_decl(?decl)) {print_decl(s, decl);}
-      case (ast.stmt_expr(?expr)) {print_expr(s, expr);}
-    }
-    if (front.parser.stmt_ends_with_semi(st)) {wrd(s, ";");}
-    line(s);
-  }
-  alt (blk.node.expr) {
-    case (option.some[@ast.expr](?expr)) {
-      print_expr(s, expr);
-      line(s);
-    }
-    case (_) {}
-  }
-  bclose(s);
-}
-
-impure fn print_literal(ps s, @ast.lit lit) {
-  alt (lit.node) {
-    case (ast.lit_str(?st)) {print_string(s, st);}
-    case (ast.lit_char(?ch)) {
-      wrd(s, "'" + escape_str(_str.from_bytes(vec(ch as u8)), '\'') + "'");
-    }
-    case (ast.lit_int(?val)) {
-      wrd(s, util.common.istr(val));
-    }
-    case (ast.lit_uint(?val)) { // TODO clipping? uistr?
-      wrd(s, util.common.istr(val as int) + "u");
-    }
-    case (ast.lit_float(?fstr)) {
-      wrd(s, fstr);
-    }
-    case (ast.lit_mach_int(?mach,?val)) {
-      wrd(s, util.common.istr(val as int));
-      wrd(s, util.common.ty_mach_to_str(mach));
-    }
-    case (ast.lit_nil) {wrd(s, "()");}
-    case (ast.lit_bool(?val)) {
-      if (val) {wrd(s, "true");} else {wrd(s, "false");}
-    }
-  }
-}
-
-impure fn print_expr(ps s, &@ast.expr expr) {
-  auto pe = print_expr;
-  hbox(s);
-  alt (expr.node) {
-    case (ast.expr_vec(?exprs,?mut,_)) {
-      if (mut == ast.mut) {
-        wrd1(s, "mutable");
-      }
-      wrd(s, "vec");
-      popen(s);
-      commasep[@ast.expr](s, exprs, pe);
-      pclose(s);
-    }
-    case (ast.expr_tup(?exprs,_)) {
-      impure fn printElt(ps s, &ast.elt elt) {
-        hbox(s);
-        if (elt.mut == ast.mut) {wrd1(s, "mutable");}
-        print_expr(s, elt.expr);
-        end(s);
-      }
-      wrd(s, "tup");
-      popen(s);
-      auto f = printElt;
-      commasep[ast.elt](s, exprs, f);
-      pclose(s);
-    }
-    case (ast.expr_rec(?fields,?wth,_)) {
-      impure fn print_field(ps s, &ast.field field) {
-        hbox(s);
-        if (field.mut == ast.mut) {wrd1(s, "mutable");}
-        wrd(s, field.ident);
-        wrd(s, "=");
-        print_expr(s, field.expr);
-        end(s);
-      }
-      wrd(s, "rec");
-      popen(s);
-      auto f = print_field;
-      commasep[ast.field](s, fields, f);
-      alt (wth) {
-        case (option.some[@ast.expr](?expr)) {
-          if (_vec.len[ast.field](fields) > 0u) {space(s);}
-          hbox(s);
-          wrd1(s, "with");
-          print_expr(s, expr);
-          end(s);
-        }
-        case (_) {}
-      }
-      pclose(s);
-    }
-    case (ast.expr_call(?func,?args,_)) {
-      print_expr(s, func);
-      popen(s);
-      commasep[@ast.expr](s, args, pe);
-      pclose(s);
-    }
-    case (ast.expr_bind(?func,?args,_)) {
-      impure fn print_opt(ps s, &option.t[@ast.expr] expr) {
-        alt (expr) {
-          case (option.some[@ast.expr](?expr)) {
-            print_expr(s, expr);
-          }
-          case (_) {wrd(s, "_");}
-        }
-      }
-      wrd1(s, "bind");
-      print_expr(s, func);
-      popen(s);
-      auto f = print_opt;
-      commasep[option.t[@ast.expr]](s, args, f);
-      pclose(s);
-    }
-    case (ast.expr_binary(?op,?lhs,?rhs,_)) {
-      auto prec = operator_prec(op);
-      print_maybe_parens(s, lhs, prec);
-      space(s);
-      wrd1(s, ast.binop_to_str(op));
-      print_maybe_parens(s, rhs, prec + 1);
-    }
-    case (ast.expr_unary(?op,?expr,_)) {
-      wrd(s, ast.unop_to_str(op));
-      print_expr(s, expr);
-    }
-    case (ast.expr_lit(?lit,_)) {
-      print_literal(s, lit);
-    }
-    case (ast.expr_cast(?expr,?ty,_)) {
-      print_maybe_parens(s, expr, as_prec);
-      space(s);
-      wrd1(s, "as");
-      print_type(s, ty);
-    }
-    case (ast.expr_if(?test,?block,?elseopt,_)) {
-      wrd1(s, "if");
-      popen(s);
-      print_expr(s, test);
-      pclose(s);
-      space(s);
-      print_block(s, block);
-      alt (elseopt) {
-        case (option.some[@ast.expr](?_else)) {
-          space(s);
-          wrd1(s, "else");
-          print_expr(s, _else);
-        }
-        case (_) { /* fall through */ }
-      }
-    }
-    case (ast.expr_while(?test,?block,_)) {
-      wrd1(s, "while");
-      popen(s);
-      print_expr(s, test);
-      pclose(s);
-      space(s);
-      print_block(s, block);
-    }
-    case (ast.expr_for(?decl,?expr,?block,_)) {
-      wrd1(s, "for");
-      popen(s);
-      print_decl(s, decl);
-      space(s);
-      wrd1(s, "in");
-      print_expr(s, expr);
-      pclose(s);
-      space(s);
-      print_block(s, block);
-    }
-    case (ast.expr_for_each(?decl,?expr,?block,_)) {
-      wrd1(s, "for each");
-      popen(s);
-      print_decl(s, decl);
-      space(s);
-      wrd1(s, "in");
-      print_expr(s, expr);
-      space(s);
-      print_block(s, block);
-    }
-    case (ast.expr_do_while(?block,?expr,_)) {
-      wrd1(s, "do");
-      space(s);
-      print_block(s, block);
-      space(s);
-      wrd1(s, "while");
-      popen(s);
-      print_expr(s, expr);
-      pclose(s);
-    }
-    case (ast.expr_alt(?expr,?arms,_)) {
-      wrd1(s, "alt");
-      popen(s);
-      print_expr(s, expr);
-      pclose(s);
-      space(s);
-      bopen(s);
-      for (ast.arm arm in arms) {
-        hbox(s);
-        wrd1(s, "case");
-        popen(s);
-        print_pat(s, arm.pat);
-        pclose(s);
-        space(s);
-        print_block(s, arm.block);
-        end(s);
-        line(s);
-      }
-      bclose(s);
-    }
-    case (ast.expr_block(?block,_)) {
-      print_block(s, block);
-    }
-    case (ast.expr_assign(?lhs,?rhs,_)) {
-      print_expr(s, lhs);
-      space(s);
-      wrd1(s, "=");
-      print_expr(s, rhs);
-    }
-    case (ast.expr_assign_op(?op,?lhs,?rhs,_)) {
-      print_expr(s, lhs);
-      space(s);
-      wrd(s, ast.binop_to_str(op));
-      wrd1(s, "=");
-      print_expr(s, rhs);
-    }
-    case (ast.expr_send(?lhs, ?rhs, _)) {
-      print_expr(s, lhs);
-      space(s);
-      wrd1(s, "<|");
-      print_expr(s, rhs);
-    }
-    case (ast.expr_recv(?lhs, ?rhs, _)) {
-      print_expr(s, lhs);
-      space(s);
-      wrd1(s, "<-");
-      print_expr(s, rhs);
-    }
-    case (ast.expr_field(?expr,?id,_)) {
-      print_expr(s, expr);
-      wrd(s, ".");
-      wrd(s, id);
-    }
-    case (ast.expr_index(?expr,?index,_)) {
-      print_expr(s, expr);
-      wrd(s, ".");
-      popen(s);
-      print_expr(s, index);
-      pclose(s);
-    }
-    case (ast.expr_path(?path,_,_)) {
-      print_path(s, path);
-    }
-    case (ast.expr_fail) {
-      wrd(s, "fail");
-    }
-    case (ast.expr_ret(?result)) {
-      wrd(s, "ret");
-      alt (result) {
-        case (option.some[@ast.expr](?expr)) {
-          space(s);
-          print_expr(s, expr);
-        }
-        case (_) {}
-      }
-    }
-    case (ast.expr_put(?result)) {
-      wrd(s, "put");
-      alt (result) {
-        case (option.some[@ast.expr](?expr)) {
-          space(s);
-          print_expr(s, expr);
-        }
-        case (_) {}
-      }
-    }
-    case (ast.expr_be(?result)) {
-      wrd1(s, "be");
-      print_expr(s, result);
-    }
-    case (ast.expr_log(?expr)) {
-      wrd1(s, "log");
-      print_expr(s, expr);
-    }
-    case (ast.expr_check_expr(?expr)) {
-      wrd1(s, "check");
-      print_expr(s, expr);
-    }
-    case (ast.expr_ext(?path, ?args, ?body, _, _)) {
-      wrd(s, "#");
-      print_path(s, path);
-      if (_vec.len[@ast.expr](args) > 0u) {
-        popen(s);
-        commasep[@ast.expr](s, args, pe);
-        pclose(s);
-      }
-      // TODO: extension 'body'
-    }
-    case (ast.expr_port(_)) {
-      wrd(s, "port");
-      popen(s);
-      pclose(s);
-    }
-    case (ast.expr_chan(?expr, _)) {
-      wrd(s, "chan");
-      popen(s);
-      print_expr(s, expr);
-      pclose(s);
-    }
-  }
-  end(s);
-}
-
-impure fn print_decl(ps s, @ast.decl decl) {
-  hbox(s);
-  alt (decl.node) {
-    case (ast.decl_local(?loc)) {
-      alt (loc.ty) {
-        case (option.some[@ast.ty](?ty)) {
-          wrd1(s, "let");
-          print_type(s, ty);
-          space(s);
-        }
-        case (_) {
-          wrd1(s, "auto");
-        }
-      }
-      wrd(s, loc.ident);
-      alt (loc.init) {
-        case (option.some[ast.initializer](?init)) {
-          space(s);
-          alt (init.op) {
-            case (ast.init_assign) {
-              wrd1(s, "=");
-            }
-            case (ast.init_recv) {
-              wrd1(s, "<-");
-            }
-          }
-          print_expr(s, init.expr);
-        }
-        case (_) {}
-      }
-    }
-    case (ast.decl_item(?item)) {
-      print_item(s, item);
-    }
-  }
-  end(s);
-}
-
-impure fn print_path(ps s, ast.path path) {
-  auto first = true;
-  for (str id in path.node.idents) {
-    if (first) {first = false;}
-    else {wrd(s, ".");}
-    wrd(s, id);
-  }
-  if (_vec.len[@ast.ty](path.node.types) > 0u) {
-    wrd(s, "[");
-    auto f = print_type;
-    commasep[@ast.ty](s, path.node.types, f);
-    wrd(s, "]");
-  }
-}
-
-impure fn print_pat(ps s, &@ast.pat pat) {
-  alt (pat.node) {
-    case (ast.pat_wild(_)) {wrd(s, "_");}
-    case (ast.pat_bind(?id,_,_)) {wrd(s, "?" + id);}
-    case (ast.pat_lit(?lit,_)) {print_literal(s, lit);}
-    case (ast.pat_tag(?path,?args,_,_)) {
-      print_path(s, path);
-      if (_vec.len[@ast.pat](args) > 0u) {
-        popen(s);
-        auto f = print_pat;
-        commasep[@ast.pat](s, args, f);
-        pclose(s);
-      }
-    }
-  }
-}
-
-impure fn print_fn(ps s, ast.fn_decl decl, str name,
-                   vec[ast.ty_param] typarams) {
-  alt (decl.effect) {
-    case (ast.eff_impure) {wrd1(s, "impure");}
-    case (ast.eff_unsafe) {wrd1(s, "unsafe");}
-    case (_) {}
-  }
-  wrd1(s, "fn");
-  wrd(s, name);
-  print_type_params(s, typarams);
-  popen(s);
-  impure fn print_arg(ps s, &ast.arg x) {
-    hbox(s);
-    print_type(s, x.ty);
-    space(s);
-    wrd(s, x.ident);
-    end(s);
-  }
-  auto f = print_arg;
-  commasep[ast.arg](s, decl.inputs, f);
-  pclose(s);
-  if (decl.output.node != ast.ty_nil) {
-    space(s);
-    hbox(s);
-    wrd1(s, "->");
-    print_type(s, decl.output);
-    end(s);
-  }
-}
-
-impure fn print_type_params(ps s, vec[ast.ty_param] params) {
-  if (_vec.len[ast.ty_param](params) > 0u) {
-    wrd(s, "[");
-    impure fn printParam(ps s, &ast.ty_param param) {wrd(s, param.ident);}
-    auto f = printParam;
-    commasep[ast.ty_param](s, params, f);
-    wrd(s, "]");
-  }
-}
-
-impure fn print_view_item(ps s, @ast.view_item item) {
-  hbox(s);
-  alt (item.node) {
-    case (ast.view_item_use(?id,?mta,_,_)) {
-      wrd1(s, "use");
-      wrd(s, id);
-      if (_vec.len[@ast.meta_item](mta) > 0u) {
-        popen(s);
-        impure fn print_meta(ps s, &@ast.meta_item item) {
-          hbox(s);
-          wrd1(s, item.node.name);
-          wrd1(s, "=");
-          print_string(s, item.node.value);
-          end(s);
-        }
-        auto f = print_meta;
-        commasep[@ast.meta_item](s, mta, f);
-        pclose(s);
-      }
-    }
-    case (ast.view_item_import(?id,?ids,_,_)) {
-      wrd1(s, "import");
-      if (!_str.eq(id, ids.(_vec.len[str](ids)-1u))) {
-        wrd1(s, id);
-        wrd1(s, "=");
-      }
-      auto first = true;
-      for (str elt in ids) {
-        if (first) {first = false;}
-        else {wrd(s, ".");}
-        wrd(s, elt);
-      }
-    }
-    case (ast.view_item_export(?id)) {
-      wrd1(s, "export");
-      wrd(s, id);
-    }
-  }
-  end(s);
-  wrd(s, ";");
-  line(s);
-}
-
-// FIXME: The fact that this builds up the table anew for every call is
-// not good. Eventually, table should be a const.
-fn operator_prec(ast.binop op) -> int {
-  for (front.parser.op_spec spec in front.parser.prec_table()) {
-    if (spec.op == op) {ret spec.prec;}
-  }
-  fail;
-}
-
-impure fn print_maybe_parens(ps s, @ast.expr expr, int outer_prec) {
-  auto add_them;
-  alt (expr.node) {
-    case (ast.expr_binary(?op,_,_,_)) {
-      add_them = operator_prec(op) < outer_prec;
-    }
-    case (ast.expr_cast(_,_,_)) {
-      add_them = as_prec < outer_prec;
-    }
-    case (_) {
-      add_them = false;
-    }
-  }
-  if (add_them) {popen(s);}
-  print_expr(s, expr);
-  if (add_them) {pclose(s);}
-}
-
-fn escape_str(str st, char to_escape) -> str {
-  let str out = "";
-  auto len = _str.byte_len(st);
-  auto i = 0u;
-  while (i < len) {
-    alt (st.(i) as char) {
-      case ('\n') {out += "\\n";}
-      case ('\t') {out += "\\t";}
-      case ('\r') {out += "\\r";}
-      case ('\\') {out += "\\\\";}
-      case (?cur) {
-        if (cur == to_escape) {out += "\\";}
-        _str.push_byte(out, cur as u8);
-      }
-    }
-    i += 1u;
-  }
-  ret out;
-}
-
 impure fn print_string(ps s, str st) {
-  wrd(s, "\""); wrd(s, escape_str(st, '"')); wrd(s, "\"");
+    wrd(s.s, "\""); wrd(s.s, escape_str(st, '"')); wrd(s.s, "\"");
 }
 
 impure fn print_ty_fn(ps s, ast.proto proto, option.t[str] id,
                       vec[ast.ty_arg] inputs, @ast.ty output) {
-  if (proto == ast.proto_fn) {wrd(s, "fn");}
-  else {wrd(s, "iter");}
-  alt (id) {
-    case (option.some[str](?id)) {space(s); wrd(s, id);}
-    case (_) {}
-  }
-  popen(s);
-  impure fn print_arg(ps s, &ast.ty_arg input) {
-    if (middle.ty.mode_is_alias(input.mode)) {wrd(s, "&");}
-    print_type(s, input.ty);
-  }
-  auto f = print_arg;
-  commasep[ast.ty_arg](s, inputs, f);
-  pclose(s);
-  if (output.node != ast.ty_nil) {
-    space(s);
-    hbox(s);
-    wrd1(s, "->");
-    print_type(s, output);
-    end(s);
-  }
+    if (proto == ast.proto_fn) {wrd(s.s, "fn");}
+    else {wrd(s.s, "iter");}
+    alt (id) {
+        case (option.some[str](?id)) {space(s.s); wrd(s.s, id);}
+        case (_) {}
+    }
+    popen_h(s);
+    impure fn print_arg(ps s, &ast.ty_arg input) {
+        if (middle.ty.mode_is_alias(input.mode)) {wrd(s.s, "&");}
+        print_type(s, input.ty);
+    }
+    auto f = print_arg;
+    commasep[ast.ty_arg](s, inputs, f);
+    pclose(s);
+    maybe_print_comment(s, output.span.lo);
+    if (output.node != ast.ty_nil) {
+        space(s.s);
+        hbox(s);
+        wrd1(s, "->");
+        print_type(s, output);
+        end(s.s);
+    }
+}
+
+fn next_comment(ps s) -> option.t[lexer.cmnt] {
+    alt (s.comments) {
+        case (option.some[vec[lexer.cmnt]](?cmnts)) {
+            if (s.cur_cmnt < _vec.len[lexer.cmnt](cmnts)) {
+                ret option.some[lexer.cmnt](cmnts.(s.cur_cmnt));
+            } else {ret option.none[lexer.cmnt];}
+        }
+        case (_) {ret option.none[lexer.cmnt];}
+    }
+}
+
+impure fn maybe_print_comment(ps s, util.common.pos pos) {
+    while (true) {
+        alt (next_comment(s)) {
+            case (option.some[lexer.cmnt](?cmnt)) {
+                if (cmnt.pos.line < pos.line ||
+                    (cmnt.pos.line == pos.line && cmnt.pos.col < pos.col)) {
+                    print_comment(s, cmnt.val);
+                    if (cmnt.space_after) {line(s.s);}
+                    s.cur_cmnt += 1u;
+                } else { break; }
+            }
+            case (_) {break;}
+        }
+    }
+}
+
+impure fn maybe_print_stmt_comment(ps s, util.common.span span) -> bool {
+    alt (next_comment(s)) {
+        case (option.some[lexer.cmnt](?cmnt)) {
+            if (span.hi.line == cmnt.pos.line) {
+                wrd(s.s, " ");
+                print_comment(s, cmnt.val);
+                s.cur_cmnt += 1u;
+                ret true;
+            }
+        }
+        case (_) {}
+    }
+    ret false;
+}
+
+impure fn print_remaining_comments(ps s) {
+    while (true) {
+        alt (next_comment(s)) {
+            case (option.some[lexer.cmnt](?cmnt)) {
+                print_comment(s, cmnt.val);
+                if (cmnt.space_after) {line(s.s);}
+                s.cur_cmnt += 1u;
+            }
+            case (_) {break;}
+        }
+    }
+}
+
+impure fn print_comment(ps s, lexer.cmnt_ cmnt) {
+    alt (cmnt) {
+        case (lexer.cmnt_line(?val)) {
+            wrd(s.s, "// " + val);
+            pp.hardbreak(s.s);
+        }
+        case (lexer.cmnt_block(?lines)) {
+            pp.abox(s.s);
+            wrd(s.s, "/* ");
+            pp.abox(s.s);
+            auto first = true;
+            for (str ln in lines) {
+                if (first) {first = false;}
+                else {pp.hardbreak(s.s);}
+                wrd(s.s, ln);
+            }
+            end(s.s);
+            wrd(s.s, "*/");
+            end(s.s);
+            line(s.s);
+        }
+    }
 }

--- a/src/comp/pretty/pprust.rs
+++ b/src/comp/pretty/pprust.rs
@@ -553,6 +553,12 @@ impure fn print_expr(ps s, &@ast.expr expr) {
         case (ast.expr_fail) {
             wrd(s.s, "fail");
         }
+        case (ast.expr_break) {
+            wrd(s.s, "break");
+        }
+        case (ast.expr_cont) {
+            wrd(s.s, "cont");
+        }
         case (ast.expr_ret(?result)) {
             wrd(s.s, "ret");
             alt (result) {


### PR DESCRIPTION
Pretty-printed stuff now tends to compile (though there's this issue with @mutable not parsing, so I haven't tried compiling a fully pretty-printed rustc). It also usually looks quite okay, except that line overflows in nested 'horizontal' blocks are handled pretty poorly and tend to result in hideous right-margin-hugging messes. I'll look further into that at some point in the future.
