### PR TITLE
Last pieces of self-call support.

### DIFF
--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -899,7 +899,7 @@ impure fn parse_bottom_expr(parser p) -> @ast.expr {
                                            some(token.COMMA),
                                            pf, p);
             hi = es.span;
-            auto ex = ast.expr_call_self(e, es.node, ast.ann_none);
+            ex = ast.expr_call_self(e, es.node, ast.ann_none);
         }
 
         case (_) {

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -26,6 +26,12 @@ type method = rec(ast.proto proto,
 
 type mt = rec(@t ty, ast.mutability mut);
 
+// Convert from method type to function type.  Pretty easy; we just drop
+// 'ident'.
+fn method_ty_to_fn_ty(method m) -> @ty.t {
+    ret plain_ty(ty_fn(m.proto, m.inputs, m.output));
+}
+
 // NB: If you change this, you'll probably want to change the corresponding
 // AST structure in front/ast.rs as well.
 type t = rec(sty struct, option.t[str] cname);


### PR DESCRIPTION
The last few pieces of the hack that lets us use trans.trans_call() to
translate self-calls, plus a fix for the parser bug that was
preventing self-call expressions from getting past parsing.
test/run-pass/obj-self.rs works now (as in it actually prints "hi!"
twice!).
