### PR TITLE
Continued sketching out code for checking states against preconditions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ config.mk
 /test/
 /build/
 src/.DS_Store
+/stage0/

--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -215,8 +215,8 @@ tag mode {
 
 type stmt = spanned[stmt_];
 tag stmt_ {
-    stmt_decl(@decl);
-    stmt_expr(@expr);
+    stmt_decl(@decl, option.t[@ts_ann]);
+    stmt_expr(@expr, option.t[@ts_ann]);
     // These only exist in crate-level blocks.
     stmt_crate_directive(@crate_directive);
 }
@@ -495,7 +495,7 @@ fn index_native_view_item(native_mod_index index, @view_item it) {
 
 fn index_stmt(block_index index, @stmt s) {
     alt (s.node) {
-        case (ast.stmt_decl(?d)) {
+        case (ast.stmt_decl(?d,_)) {
             alt (d.node) {
                 case (ast.decl_local(?loc)) {
                     index.insert(loc.ident, ast.bie_local(loc));

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -11,6 +11,7 @@ import util.common;
 import util.common.filename;
 import util.common.span;
 import util.common.new_str_hash;
+import util.typestate_ann.ts_ann;
 
 tag restriction {
     UNRESTRICTED;
@@ -1555,13 +1556,13 @@ impure fn parse_source_stmt(parser p) -> @ast.stmt {
         case (token.LET) {
             auto decl = parse_let(p);
             auto hi = p.get_span();
-            ret @spanned(lo, hi, ast.stmt_decl(decl));
+            ret @spanned(lo, hi, ast.stmt_decl(decl, none[@ts_ann]));
         }
 
         case (token.AUTO) {
             auto decl = parse_auto(p);
             auto hi = p.get_span();
-            ret @spanned(lo, hi, ast.stmt_decl(decl));
+            ret @spanned(lo, hi, ast.stmt_decl(decl, none[@ts_ann]));
         }
 
         case (_) {
@@ -1570,13 +1571,13 @@ impure fn parse_source_stmt(parser p) -> @ast.stmt {
                 auto i = parse_item(p);
                 auto hi = i.span;
                 auto decl = @spanned(lo, hi, ast.decl_item(i));
-                ret @spanned(lo, hi, ast.stmt_decl(decl));
+                ret @spanned(lo, hi, ast.stmt_decl(decl, none[@ts_ann]));
 
             } else {
                 // Remainder are line-expr stmts.
                 auto e = parse_expr(p);
                 auto hi = p.get_span();
-                ret @spanned(lo, hi, ast.stmt_expr(e));
+                ret @spanned(lo, hi, ast.stmt_expr(e, none[@ts_ann]));
             }
         }
     }
@@ -1613,7 +1614,7 @@ fn index_arm(@ast.pat pat) -> hashmap[ast.ident,ast.def_id] {
 
 fn stmt_to_expr(@ast.stmt stmt) -> option.t[@ast.expr] {
     alt (stmt.node) {
-        case (ast.stmt_expr(?e)) { ret some[@ast.expr](e); }
+        case (ast.stmt_expr(?e,_)) { ret some[@ast.expr](e); }
         case (_) { /* fall through */ }
     }
     ret none[@ast.expr];
@@ -1621,13 +1622,13 @@ fn stmt_to_expr(@ast.stmt stmt) -> option.t[@ast.expr] {
 
 fn stmt_ends_with_semi(@ast.stmt stmt) -> bool {
     alt (stmt.node) {
-        case (ast.stmt_decl(?d)) {
+        case (ast.stmt_decl(?d,_)) {
             alt (d.node) {
                 case (ast.decl_local(_)) { ret true; }
                 case (ast.decl_item(_)) { ret false; }
             }
         }
-        case (ast.stmt_expr(?e)) {
+        case (ast.stmt_expr(?e,_)) {
             alt (e.node) {
                 case (ast.expr_vec(_,_,_))      { ret true; }
                 case (ast.expr_tup(_,_))        { ret true; }

--- a/src/comp/middle/resolve.rs
+++ b/src/comp/middle/resolve.rs
@@ -6,6 +6,7 @@ import front.creader;
 import driver.session;
 import util.common.new_def_hash;
 import util.common.span;
+import util.typestate_ann.ts_ann;
 import std.map.hashmap;
 import std.list.list;
 import std.list.nil;
@@ -348,7 +349,7 @@ fn lookup_name_wrapped(&env e, ast.ident i, namespace ns)
 
     fn found_decl_stmt(@ast.stmt s, namespace ns) -> def_wrap {
         alt (s.node) {
-            case (ast.stmt_decl(?d)) {
+            case (ast.stmt_decl(?d,_)) {
                 alt (d.node) {
                     case (ast.decl_local(?loc)) {
                         auto t = ast.def_local(loc.id);

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -5208,11 +5208,11 @@ fn init_local(@block_ctxt cx, @ast.local local) -> result {
 fn trans_stmt(@block_ctxt cx, &ast.stmt s) -> result {
     auto bcx = cx;
     alt (s.node) {
-        case (ast.stmt_expr(?e)) {
+        case (ast.stmt_expr(?e,_)) {
             bcx = trans_expr(cx, e).bcx;
         }
 
-        case (ast.stmt_decl(?d)) {
+        case (ast.stmt_decl(?d,_)) {
             alt (d.node) {
                 case (ast.decl_local(?local)) {
                     bcx = init_local(bcx, local).bcx;
@@ -5302,7 +5302,7 @@ iter block_locals(&ast.block b) -> @ast.local {
     // use the index here.
     for (@ast.stmt s in b.node.stmts) {
         alt (s.node) {
-            case (ast.stmt_decl(?d)) {
+            case (ast.stmt_decl(?d,_)) {
                 alt (d.node) {
                     case (ast.decl_local(?local)) {
                         put local;

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -731,7 +731,7 @@ fn item_ty(@ast.item it) -> ty_params_and_ty {
 
 fn stmt_ty(@ast.stmt s) -> @t {
     alt (s.node) {
-        case (ast.stmt_expr(?e)) {
+        case (ast.stmt_expr(?e,_)) {
             ret expr_ty(e);
         }
         case (_) {

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -2479,12 +2479,12 @@ fn check_decl_local(&@fn_ctxt fcx, &@ast.decl decl) -> @ast.decl {
 
 fn check_stmt(&@fn_ctxt fcx, &@ast.stmt stmt) -> @ast.stmt {
     alt (stmt.node) {
-        case (ast.stmt_decl(?decl)) {
+        case (ast.stmt_decl(?decl,?a)) {
             alt (decl.node) {
                 case (ast.decl_local(_)) {
                     auto decl_1 = check_decl_local(fcx, decl);
                     ret @fold.respan[ast.stmt_](stmt.span,
-                                                ast.stmt_decl(decl_1));
+                                                ast.stmt_decl(decl_1, a));
                 }
 
                 case (ast.decl_item(_)) {
@@ -2495,9 +2495,9 @@ fn check_stmt(&@fn_ctxt fcx, &@ast.stmt stmt) -> @ast.stmt {
             ret stmt;
         }
 
-        case (ast.stmt_expr(?expr)) {
+        case (ast.stmt_expr(?expr,?a)) {
             auto expr_t = check_expr(fcx, expr);
-            ret @fold.respan[ast.stmt_](stmt.span, ast.stmt_expr(expr_t));
+            ret @fold.respan[ast.stmt_](stmt.span, ast.stmt_expr(expr_t, a));
         }
     }
 

--- a/src/comp/pretty/pprust.rs
+++ b/src/comp/pretty/pprust.rs
@@ -339,8 +339,8 @@ impure fn print_block(ps s, ast.block blk) {
         cur_line = st.span.hi.line;
         maybe_print_comment(s, st.span.lo);
         alt (st.node) {
-            case (ast.stmt_decl(?decl)) {print_decl(s, decl);}
-            case (ast.stmt_expr(?expr)) {print_expr(s, expr);}
+          case (ast.stmt_decl(?decl,_)) {print_decl(s, decl);}
+          case (ast.stmt_expr(?expr,_)) {print_expr(s, expr);}
         }
         if (front.parser.stmt_ends_with_semi(st)) {wrd(s.s, ";");}
         if (!maybe_print_line_comment(s, st.span)) {line(s.s);}

--- a/src/comp/rustc.rc
+++ b/src/comp/rustc.rc
@@ -62,7 +62,11 @@ auth middle.typestate_check.log_expr = impure;
 auth lib.llvm = unsafe;
 auth pretty.pprust = impure;
 auth middle.typestate_check.find_pre_post_block = impure;
-auth middle.typestate_check.find_pre_post_expr = impure;
+auth middle.typestate_check.find_pre_post_state_block = impure;
+auth middle.typestate_check.find_pre_post_expr  = impure;
+auth middle.typestate_check.find_pre_post_stmt  = impure;
+auth middle.typestate_check.check_states_against_conditions = impure;
+auth middle.typestate_check.check_states_stmt   = impure;
 auth util.typestate_ann.implies = impure;
 
 mod lib {

--- a/src/comp/util/typestate_ann.rs
+++ b/src/comp/util/typestate_ann.rs
@@ -36,14 +36,27 @@ fn true_postcond(uint num_vars) -> postcond {
   be true_precond(num_vars);
 }
 
+fn empty_prestate(uint num_vars) -> prestate {
+  be true_precond(num_vars);
+}
+
+fn empty_poststate(uint num_vars) -> poststate {
+  be true_precond(num_vars);
+}
+
 fn empty_pre_post(uint num_vars) -> pre_and_post {
-  ret(rec(precondition=true_precond(num_vars),
-           postcondition=true_postcond(num_vars)));
+  ret(rec(precondition=empty_prestate(num_vars),
+          postcondition=empty_poststate(num_vars)));
 }
 
 fn empty_states(uint num_vars) -> pre_and_post_state {
   ret(rec(prestate=true_precond(num_vars),
            poststate=true_postcond(num_vars)));
+}
+
+fn empty_ann(uint num_vars) -> ts_ann {
+  ret(rec(conditions=empty_pre_post(num_vars),
+          states=empty_states(num_vars)));
 }
 
 fn get_pre(&pre_and_post p) -> precond {
@@ -74,7 +87,37 @@ impure fn require_and_preserve(uint i, &pre_and_post p) -> () {
   bitv.set(p.postcondition, i, true);
 }
 
-fn implies(bitv.t a, bitv.t b) -> bool {
+impure fn set_in_postcond(uint i, &pre_and_post p) -> () {
+  // sets the ith bit in p's post
+  bitv.set(p.postcondition, i, true);
+}
+
+// Sets all the bits in a's precondition to equal the
+// corresponding bit in p's precondition.
+impure fn set_precondition(&ts_ann a, &precond p) -> () {
+  bitv.copy(p, a.conditions.precondition);
+}
+
+// Sets all the bits in a's postcondition to equal the
+// corresponding bit in p's postcondition.
+impure fn set_postcondition(&ts_ann a, &postcond p) -> () {
+  bitv.copy(p, a.conditions.postcondition);
+}
+
+// Set all the bits in p that are set in new
+impure fn extend_prestate(&prestate p, &poststate new) -> () {
+  bitv.union(p, new);
+}
+
+fn ann_precond(&ts_ann a) -> precond {
+  ret a.conditions.precondition;
+}
+
+fn ann_prestate(&ts_ann a) -> prestate {
+  ret a.states.prestate;
+}
+
+impure fn implies(bitv.t a, bitv.t b) -> bool {
   bitv.difference(b, a);
-  ret (bitv.equal(b, bitv.create(b.nbits, false)));
+  be bitv.is_false(b);
 }

--- a/src/lib/_vec.rs
+++ b/src/lib/_vec.rs
@@ -1,5 +1,6 @@
 import option.none;
 import option.some;
+import util.orb;
 
 type vbuf = rustrt.vbuf;
 
@@ -228,6 +229,26 @@ fn foldl[T, U](fn (&U, &T) -> U p, &U z, &vec[T] v) -> U {
 
         ret (p(foldl[T,U](p, z, rest), v.(0)));
     }
+}
+
+fn unzip[T, U](&vec[tup(T, U)] v) -> tup(vec[T], vec[U]) {
+    auto sz = len[tup(T, U)](v);
+
+    if (sz == 0u) {
+        ret tup(alloc[T](0u), alloc[U](0u));
+    }
+    else {
+        auto rest = slice[tup(T, U)](v, 1u, sz);
+        auto tl   = unzip[T, U](rest);
+        auto a    = vec(v.(0)._0);
+        auto b    = vec(v.(0)._1);
+        ret tup(a + tl._0, b + tl._1);
+    }
+}
+
+fn or(&vec[bool] v) -> bool {
+    auto f = orb;
+    be _vec.foldl[bool, bool](f, false, v);
 }
 
 // Local Variables:

--- a/src/lib/bitv.rs
+++ b/src/lib/bitv.rs
@@ -135,6 +135,28 @@ impure fn set(&t v, uint i, bool x) {
     }
 }
 
+/* true if all bits are 1 */
+fn is_true(&t v) -> bool {
+    for(uint i in v.storage) {
+        if (i != 1u) {
+            ret false;
+        }
+    }
+
+    ret true;
+}
+
+/* true if all bits are non-1 */
+fn is_false(&t v) -> bool {
+    for(uint i in v.storage) {
+        if (i == 1u) {
+            ret false;
+        }
+    }
+
+    ret true;
+}
+
 fn init_to_vec(t v, uint i) -> uint {
     if (get(v, i)) {
         ret 1u;

--- a/src/lib/option.rs
+++ b/src/lib/option.rs
@@ -38,6 +38,13 @@ fn is_none[T](&t[T] opt) -> bool {
     }
 }
 
+fn from_maybe[T](&T def, &t[T] opt) -> T {
+    alt(opt) {
+        case (none[T])     { ret def; }
+        case (some[T](?t)) { ret t; }
+    }
+}
+
 // Local Variables:
 // mode: rust;
 // fill-column: 78;

--- a/src/lib/util.rs
+++ b/src/lib/util.rs
@@ -11,6 +11,18 @@ fn rational_leq(&rational x, &rational y) -> bool {
     ret x.num * y.den <= y.num * x.den;
 }
 
+fn fst[T, U](&tup(T, U) x) -> T {
+    ret x._0;
+}
+
+fn snd[T, U](&tup(T, U) x) -> U {
+    ret x._1;
+}
+
+fn orb(&bool a, &bool b) -> bool {
+    ret a || b;
+}
+
 // Local Variables:
 // mode: rust;
 // fill-column: 78;


### PR DESCRIPTION
It's still sketchy. I added a typestate annotation field to statements
tagged stmt_decl or stmt_expr, because a stmt_decl statement has a typestate
that's different from that of its child node. This necessitated trivial
changes to a bunch of other files all over to the compiler. I also added a
few small standard library functions, some of which I didn't actually end
up using but which I thought might be useful anyway.
