### PR TITLE
Move to macro-based logging checks in the C++ code

### DIFF
--- a/src/rt/circular_buffer.cpp
+++ b/src/rt/circular_buffer.cpp
@@ -14,7 +14,7 @@ circular_buffer::circular_buffer(rust_dom *dom, size_t unit_sz) :
 
     A(dom, unit_sz, "Unit size must be larger than zero.");
 
-    dom->log(rust_log::MEM | rust_log::COMM,
+    DLOG(dom, rust_log::MEM | rust_log::COMM,
              "new circular_buffer(buffer_sz=%d, unread=%d)"
              "-> circular_buffer=0x%" PRIxPTR,
              _buffer_sz, _unread, this);
@@ -23,7 +23,7 @@ circular_buffer::circular_buffer(rust_dom *dom, size_t unit_sz) :
 }
 
 circular_buffer::~circular_buffer() {
-    dom->log(rust_log::MEM, "~circular_buffer 0x%" PRIxPTR, this);
+    DLOG(dom, rust_log::MEM, "~circular_buffer 0x%" PRIxPTR, this);
     I(dom, _buffer);
     W(dom, _unread == 0,
       "freeing circular_buffer with %d unread bytes", _unread);
@@ -79,7 +79,7 @@ circular_buffer::enqueue(void *src) {
         grow();
     }
 
-    dom->log(rust_log::MEM | rust_log::COMM,
+    DLOG(dom, rust_log::MEM | rust_log::COMM,
              "circular_buffer enqueue "
              "unread: %d, next: %d, buffer_sz: %d, unit_sz: %d",
              _unread, _next, _buffer_sz, unit_sz);
@@ -101,7 +101,7 @@ circular_buffer::enqueue(void *src) {
     memcpy(&_buffer[dst_idx], src, unit_sz);
     _unread += unit_sz;
 
-    dom->log(rust_log::MEM | rust_log::COMM,
+    DLOG(dom, rust_log::MEM | rust_log::COMM,
              "circular_buffer pushed data at index: %d", dst_idx);
 }
 
@@ -117,7 +117,7 @@ circular_buffer::dequeue(void *dst) {
     I(dom, _unread <= _buffer_sz);
     I(dom, _buffer);
 
-    dom->log(rust_log::MEM | rust_log::COMM,
+    DLOG(dom, rust_log::MEM | rust_log::COMM,
              "circular_buffer dequeue "
              "unread: %d, next: %d, buffer_sz: %d, unit_sz: %d",
              _unread, _next, _buffer_sz, unit_sz);
@@ -126,7 +126,7 @@ circular_buffer::dequeue(void *dst) {
     if (dst != NULL) {
         memcpy(dst, &_buffer[_next], unit_sz);
     }
-    dom->log(rust_log::MEM | rust_log::COMM,
+    DLOG(dom, rust_log::MEM | rust_log::COMM,
              "shifted data from index %d", _next);
     _unread -= unit_sz;
     _next += unit_sz;
@@ -144,7 +144,7 @@ void
 circular_buffer::grow() {
     size_t new_buffer_sz = _buffer_sz * 2;
     I(dom, new_buffer_sz <= MAX_CIRCULAR_BUFFER_SIZE);
-    dom->log(rust_log::MEM | rust_log::COMM,
+    DLOG(dom, rust_log::MEM | rust_log::COMM,
              "circular_buffer is growing to %d bytes", new_buffer_sz);
     void *new_buffer = dom->malloc(new_buffer_sz);
     transfer(new_buffer);
@@ -158,7 +158,7 @@ void
 circular_buffer::shrink() {
     size_t new_buffer_sz = _buffer_sz / 2;
     I(dom, initial_size() <= new_buffer_sz);
-    dom->log(rust_log::MEM | rust_log::COMM,
+    DLOG(dom, rust_log::MEM | rust_log::COMM,
              "circular_buffer is shrinking to %d bytes", new_buffer_sz);
     void *new_buffer = dom->malloc(new_buffer_sz);
     transfer(new_buffer);

--- a/src/rt/rust.cpp
+++ b/src/rt/rust.cpp
@@ -87,10 +87,10 @@ rust_start(uintptr_t main_fn, rust_crate const *crate, int argc,
     rust_dom *dom = handle->referent();
     command_line_args *args = new (dom) command_line_args(dom, argc, argv);
 
-    dom->log(rust_log::DOM, "startup: %d args in 0x%" PRIxPTR,
+    DLOG(dom, rust_log::DOM, "startup: %d args in 0x%" PRIxPTR,
              args->argc, (uintptr_t)args->args);
     for (int i = 0; i < args->argc; i++) {
-        dom->log(rust_log::DOM,
+        DLOG(dom, rust_log::DOM,
             "startup: arg[%d] = '%s'", i, args->argv[i]);
     }
 

--- a/src/rt/rust_chan.cpp
+++ b/src/rt/rust_chan.cpp
@@ -13,14 +13,14 @@ rust_chan::rust_chan(rust_task *task,
     if (port) {
         associate(port);
     }
-    task->log(rust_log::MEM | rust_log::COMM,
+    LOG(task, rust_log::MEM | rust_log::COMM,
               "new rust_chan(task=0x%" PRIxPTR
               ", port=0x%" PRIxPTR ") -> chan=0x%" PRIxPTR,
               (uintptr_t) task, (uintptr_t) port, (uintptr_t) this);
 }
 
 rust_chan::~rust_chan() {
-    task->log(rust_log::MEM | rust_log::COMM,
+    LOG(task, rust_log::MEM | rust_log::COMM,
               "del rust_chan(task=0x%" PRIxPTR ")", (uintptr_t) this);
 
     A(task->dom, is_associated() == false,
@@ -33,7 +33,7 @@ rust_chan::~rust_chan() {
 void rust_chan::associate(maybe_proxy<rust_port> *port) {
     this->port = port;
     if (port->is_proxy() == false) {
-        task->log(rust_log::TASK,
+        LOG(task, rust_log::TASK,
             "associating chan: 0x%" PRIxPTR " with port: 0x%" PRIxPTR,
             this, port);
         this->port->referent()->chans.push(this);
@@ -51,7 +51,7 @@ void rust_chan::disassociate() {
     A(task->dom, is_associated(), "Channel must be associated with a port.");
 
     if (port->is_proxy() == false) {
-        task->log(rust_log::TASK,
+        LOG(task, rust_log::TASK,
             "disassociating chan: 0x%" PRIxPTR " from port: 0x%" PRIxPTR,
             this, port->referent());
         port->referent()->chans.swap_delete(this);
@@ -84,7 +84,7 @@ void rust_chan::send(void *sptr) {
     } else {
         rust_port *target_port = port->referent();
         if (target_port->task->blocked_on(target_port)) {
-            dom->log(rust_log::COMM, "dequeued in rendezvous_ptr");
+            DLOG(dom, rust_log::COMM, "dequeued in rendezvous_ptr");
             buffer.dequeue(target_port->task->rendezvous_ptr);
             target_port->task->rendezvous_ptr = 0;
             target_port->task->wakeup(target_port);

--- a/src/rt/rust_crate.cpp
+++ b/src/rt/rust_crate.cpp
@@ -41,7 +41,7 @@ rust_crate::mem_area::mem_area(rust_dom *dom, uintptr_t pos, size_t sz)
     base(pos),
     lim(pos + sz)
 {
-  dom->log(rust_log::MEM, "new mem_area [0x%" PRIxPTR ",0x%" PRIxPTR "]",
+  DLOG(dom, rust_log::MEM, "new mem_area [0x%" PRIxPTR ",0x%" PRIxPTR "]",
            base, lim);
 }
 

--- a/src/rt/rust_crate_reader.cpp
+++ b/src/rt/rust_crate_reader.cpp
@@ -92,7 +92,7 @@ rust_crate_reader::mem_reader::adv(size_t amt)
     ok = false;
   if (!ok)
     return;
-  // mem.dom->log(rust_log::MEM, "adv %d bytes", amt);
+  // mem.DLOG(dom, rust_log::MEM, "adv %d bytes", amt);
   pos += amt;
   ok &= !at_end();
   I(mem.dom, at_end() || (mem.base <= pos && pos < mem.lim));
@@ -120,7 +120,7 @@ rust_crate_reader::abbrev_reader::abbrev_reader
   rust_dom *dom = mem.dom;
   while (is_ok() && !at_end()) {
 
-    // dom->log(rust_log::DWARF, "reading new abbrev at 0x%" PRIxPTR,
+    // DLOG(dom, rust_log::DWARF, "reading new abbrev at 0x%" PRIxPTR,
     //          tell_off());
 
     uintptr_t idx, tag;
@@ -133,13 +133,13 @@ rust_crate_reader::abbrev_reader::abbrev_reader
     size_t body_off = tell_off();
     while (is_ok() && step_attr_form_pair(attr, form));
 
-    // dom->log(rust_log::DWARF,
+    // DLOG(dom, rust_log::DWARF,
     //         "finished scanning attr/form pairs, pos=0x%"
     //         PRIxPTR ", lim=0x%" PRIxPTR ", is_ok=%d, at_end=%d",
     //        pos, mem.lim, is_ok(), at_end());
 
     if (is_ok() || at_end()) {
-      dom->log(rust_log::DWARF, "read abbrev: %" PRIdPTR, idx);
+      DLOG(dom, rust_log::DWARF, "read abbrev: %" PRIdPTR, idx);
       I(dom, idx = abbrevs.length() + 1);
       abbrevs.push(new (dom) abbrev(dom, body_off,
                                     tell_off() - body_off,
@@ -162,11 +162,11 @@ rust_crate_reader::abbrev_reader::step_attr_form_pair(uintptr_t &attr,
 {
   attr = 0;
   form = 0;
-  // mem.dom->log(rust_log::DWARF, "reading attr/form pair at 0x%" PRIxPTR,
+  // mem.DLOG(dom, rust_log::DWARF, "reading attr/form pair at 0x%" PRIxPTR,
   //              tell_off());
   get_uleb(attr);
   get_uleb(form);
-  // mem.dom->log(rust_log::DWARF, "attr 0x%" PRIxPTR ", form 0x%" PRIxPTR,
+  // mem.DLOG(dom, rust_log::DWARF, "attr 0x%" PRIxPTR ", form 0x%" PRIxPTR,
   //              attr, form);
   return ! (attr == 0 && form == 0);
 }
@@ -254,18 +254,19 @@ rust_crate_reader::die::die(die_reader *rdr, uintptr_t off)
   rdr->get_uleb(ab_idx);
   if (!ab_idx) {
     ab = NULL;
-    dom->log(rust_log::DWARF, "DIE <0x%" PRIxPTR "> (null)", off);
-    dom->get_log().outdent();
+    DLOG(dom, rust_log::DWARF, "DIE <0x%" PRIxPTR "> (null)", off);
+    if (dom->get_log().is_tracing(rust_log::DWARF))
+        dom->get_log().outdent();
   } else {
     ab = rdr->abbrevs.get_abbrev(ab_idx);
     if (!ab) {
-        dom->log(rust_log::DWARF, "  bad abbrev number: 0x%"
+        DLOG(dom, rust_log::DWARF, "  bad abbrev number: 0x%"
                  PRIxPTR, ab_idx);
         rdr->fail();
     } else {
-        dom->log(rust_log::DWARF, "DIE <0x%" PRIxPTR "> abbrev 0x%"
+        DLOG(dom, rust_log::DWARF, "DIE <0x%" PRIxPTR "> abbrev 0x%"
                  PRIxPTR, off, ab_idx);
-        dom->log(rust_log::DWARF, "  tag 0x%x, has children: %d",
+        DLOG(dom, rust_log::DWARF, "  tag 0x%x, has children: %d",
                  ab->tag, ab->has_children);
     }
   }
@@ -353,7 +354,7 @@ rust_crate_reader::die::step_attr(attr &a) const
       break;
 
     default:
-      rdr->mem.dom->log(rust_log::DWARF, "  unknown dwarf form: 0x%"
+      DLOG(rdr->mem.dom, rust_log::DWARF, "  unknown dwarf form: 0x%"
                         PRIxPTR, a.form);
       rdr->fail();
       break;
@@ -473,16 +474,16 @@ rust_crate_reader::die::next() const
         while (step_attr(a)) {
             I(dom, !(a.is_numeric() && a.is_string()));
             if (a.is_numeric())
-                dom->log(rust_log::DWARF, "  attr num: 0x%"
+                DLOG(dom, rust_log::DWARF, "  attr num: 0x%"
                          PRIxPTR, a.get_num(dom));
             else if (a.is_string())
-                dom->log(rust_log::DWARF, "  attr str: %s",
+                DLOG(dom, rust_log::DWARF, "  attr str: %s",
                          a.get_str(dom));
             else
-                dom->log(rust_log::DWARF, "  attr ??:");
+                DLOG(dom, rust_log::DWARF, "  attr ??:");
         }
     }
-    if (has_children())
+    if (has_children() && dom->get_log().is_tracing(rust_log::DWARF))
         dom->get_log().indent();
   }
   return die(rdr, rdr->tell_off());
@@ -493,12 +494,12 @@ rust_crate_reader::die::next_sibling() const
 {
   // FIXME: use DW_AT_sibling, when present.
   if (has_children()) {
-    // rdr->mem.dom->log(rust_log::DWARF, "+++ children of die 0x%"
+    // DLOG(rdr->mem.dom, rust_log::DWARF, "+++ children of die 0x%"
     //                   PRIxPTR, off);
     die child = next();
     while (!child.is_null())
       child = child.next_sibling();
-    // rdr->mem.dom->log(rust_log::DWARF, "--- children of die 0x%"
+    // DLOG(rdr->mem.dom, rust_log::DWARF, "--- children of die 0x%"
     //                   PRIxPTR, off);
     return child.next();
   } else {
@@ -553,16 +554,16 @@ rust_crate_reader::die_reader::die_reader(rust_crate::mem_area &die_mem,
   get(sizeof_addr);
 
   if (is_ok()) {
-    dom->log(rust_log::DWARF, "new root CU at 0x%" PRIxPTR, die_mem.base);
-    dom->log(rust_log::DWARF, "CU unit length: %" PRId32, cu_unit_length);
-    dom->log(rust_log::DWARF, "dwarf version: %" PRId16, dwarf_vers);
-    dom->log(rust_log::DWARF, "CU abbrev off: %" PRId32, cu_abbrev_off);
-    dom->log(rust_log::DWARF, "size of address: %" PRId8, sizeof_addr);
+    DLOG(dom, rust_log::DWARF, "new root CU at 0x%" PRIxPTR, die_mem.base);
+    DLOG(dom, rust_log::DWARF, "CU unit length: %" PRId32, cu_unit_length);
+    DLOG(dom, rust_log::DWARF, "dwarf version: %" PRId16, dwarf_vers);
+    DLOG(dom, rust_log::DWARF, "CU abbrev off: %" PRId32, cu_abbrev_off);
+    DLOG(dom, rust_log::DWARF, "size of address: %" PRId8, sizeof_addr);
     I(dom, sizeof_addr == sizeof(uintptr_t));
     I(dom, dwarf_vers >= 2);
     I(dom, cu_base + cu_unit_length == die_mem.lim - die_mem.base);
   } else {
-    dom->log(rust_log::DWARF, "failed to read root CU header");
+    DLOG(dom, rust_log::DWARF, "failed to read root CU header");
   }
 }
 
@@ -579,9 +580,9 @@ rust_crate_reader::rust_crate_reader(rust_dom *dom,
     die_mem(crate->get_debug_info(dom)),
     dies(die_mem, abbrevs)
 {
-  dom->log(rust_log::MEM, "crate_reader on crate: 0x%" PRIxPTR, this);
-  dom->log(rust_log::MEM, "debug_abbrev: 0x%" PRIxPTR, abbrev_mem.base);
-  dom->log(rust_log::MEM, "debug_info: 0x%" PRIxPTR, die_mem.base);
+  DLOG(dom, rust_log::MEM, "crate_reader on crate: 0x%" PRIxPTR, this);
+  DLOG(dom, rust_log::MEM, "debug_abbrev: 0x%" PRIxPTR, abbrev_mem.base);
+  DLOG(dom, rust_log::MEM, "debug_info: 0x%" PRIxPTR, die_mem.base);
   // For now, perform diagnostics only.
   dies.dump();
 }

--- a/src/rt/rust_dom.h
+++ b/src/rt/rust_dom.h
@@ -88,6 +88,11 @@ struct rust_dom : public kernel_owned<rust_dom>, rc_base<rust_dom>
     rust_task *create_task(rust_task *spawner, const char *name);
 };
 
+inline rust_log &
+rust_dom::get_log() {
+    return _log;
+}
+
 //
 // Local Variables:
 // mode: C++

--- a/src/rt/rust_log.cpp
+++ b/src/rt/rust_log.cpp
@@ -204,11 +204,6 @@ rust_log::trace_ln(rust_task *task, ansi_color color,
     }
 }
 
-bool
-rust_log::is_tracing(uint32_t type_bits) {
-    return type_bits & _type_bit_mask;
-}
-
 void
 rust_log::indent() {
     _indent++;

--- a/src/rt/rust_log.h
+++ b/src/rt/rust_log.h
@@ -1,6 +1,21 @@
 #ifndef RUST_LOG_H
 #define RUST_LOG_H
 
+#define DLOG(dom, mask, ...)                      \
+  if ((dom)->get_log().is_tracing(mask)) {        \
+      (dom)->log(mask, __VA_ARGS__);              \
+  } else
+#define LOG(task, mask, ...)                      \
+  DLOG((task)->dom, mask, __VA_ARGS__)
+#define LOG_I(task, mask, ...)                    \
+  if ((task)->dom->get_log().is_tracing(mask)) {  \
+      (task)->dom->get_log().reset_indent(0);     \
+      (task)->dom->log(mask, __VA_ARGS__);        \
+      (task)->dom->get_log().indent();            \
+  } else
+#define LOGPTR(dom, msg, ptrval)                  \
+  DLOG(dom, rust_log::MEM, "%s 0x%" PRIxPTR, msg, ptrval)
+
 class rust_dom;
 class rust_task;
 
@@ -64,5 +79,10 @@ private:
     uint32_t _indent;
     void trace_ln(rust_task *task, char *message);
 };
+
+inline bool
+rust_log::is_tracing(uint32_t type_bits) {
+    return type_bits & _type_bit_mask;
+}
 
 #endif /* RUST_LOG_H */

--- a/src/rt/rust_port.cpp
+++ b/src/rt/rust_port.cpp
@@ -5,7 +5,7 @@ rust_port::rust_port(rust_task *task, size_t unit_sz) :
                      maybe_proxy<rust_port>(this), task(task),
                      unit_sz(unit_sz), writers(task->dom), chans(task->dom) {
 
-    task->log(rust_log::MEM | rust_log::COMM,
+    LOG(task, rust_log::MEM | rust_log::COMM,
               "new rust_port(task=0x%" PRIxPTR ", unit_sz=%d) -> port=0x%"
               PRIxPTR, (uintptr_t)task, unit_sz, (uintptr_t)this);
 
@@ -14,10 +14,10 @@ rust_port::rust_port(rust_task *task, size_t unit_sz) :
 }
 
 rust_port::~rust_port() {
-    task->log(rust_log::COMM | rust_log::MEM,
+    LOG(task, rust_log::COMM | rust_log::MEM,
               "~rust_port 0x%" PRIxPTR, (uintptr_t) this);
 
-    log_state();
+    //    log_state();
 
     // Disassociate channels from this port.
     while (chans.is_empty() == false) {
@@ -25,7 +25,7 @@ rust_port::~rust_port() {
         chan->disassociate();
 
         if (chan->ref_count == 0) {
-            task->log(rust_log::COMM,
+            LOG(task, rust_log::COMM,
                 "chan: 0x%" PRIxPTR " is dormant, freeing", chan);
             delete chan;
         }
@@ -39,7 +39,7 @@ bool rust_port::receive(void *dptr) {
         rust_chan *chan = chans[i];
         if (chan->buffer.is_empty() == false) {
             chan->buffer.dequeue(dptr);
-            task->log(rust_log::COMM, "<=== read data ===");
+            LOG(task, rust_log::COMM, "<=== read data ===");
             return true;
         }
     }
@@ -47,12 +47,12 @@ bool rust_port::receive(void *dptr) {
 }
 
 void rust_port::log_state() {
-    task->log(rust_log::COMM,
+    LOG(task, rust_log::COMM,
               "rust_port: 0x%" PRIxPTR ", associated channel(s): %d",
               this, chans.length());
     for (uint32_t i = 0; i < chans.length(); i++) {
         rust_chan *chan = chans[i];
-        task->log(rust_log::COMM,
+        LOG(task, rust_log::COMM,
             "\tchan: 0x%" PRIxPTR ", size: %d, remote: %s",
             chan,
             chan->buffer.size(),

--- a/src/rt/rust_task_list.cpp
+++ b/src/rt/rust_task_list.cpp
@@ -7,10 +7,10 @@ rust_task_list::rust_task_list (rust_dom *dom, const char* name) :
 
 void
 rust_task_list::delete_all() {
-    dom->log(rust_log::TASK, "deleting all %s tasks", name);
+    DLOG(dom, rust_log::TASK, "deleting all %s tasks", name);
     while (is_empty() == false) {
         rust_task *task = pop_value();
-        dom->log(rust_log::TASK, "deleting task " PTR, task);
+        DLOG(dom, rust_log::TASK, "deleting task " PTR, task);
         delete task;
     }
 }

--- a/src/rt/rust_timer.cpp
+++ b/src/rt/rust_timer.cpp
@@ -30,7 +30,7 @@ timer_loop(void *ptr) {
     // We were handed the rust_timer that owns us.
     rust_timer *timer = (rust_timer *)ptr;
     rust_dom *dom = timer->dom;
-    dom->log(rust_log::TIMER, "in timer 0x%" PRIxPTR, (uintptr_t)timer);
+    DLOG(dom, rust_log::TIMER, "in timer 0x%" PRIxPTR, (uintptr_t)timer);
     size_t ms = TIME_SLICE_IN_MS;
 
     while (!timer->exit_flag) {
@@ -39,7 +39,7 @@ timer_loop(void *ptr) {
 #else
         usleep(ms * 1000);
 #endif
-        dom->log(rust_log::TIMER, "timer 0x%" PRIxPTR
+        DLOG(dom, rust_log::TIMER, "timer 0x%" PRIxPTR
         " interrupting domain 0x%" PRIxPTR, (uintptr_t) timer,
                  (uintptr_t) dom);
         dom->interrupt_flag = 1;
@@ -54,7 +54,7 @@ timer_loop(void *ptr) {
 
 rust_timer::rust_timer(rust_dom *dom) :
     dom(dom), exit_flag(0) {
-    dom->log(rust_log::TIMER, "creating timer for domain 0x%" PRIxPTR, dom);
+    DLOG(dom, rust_log::TIMER, "creating timer for domain 0x%" PRIxPTR, dom);
 #if defined(__WIN32__)
     thread = CreateThread(NULL, 0, timer_loop, this, 0, NULL);
     dom->win32_require("CreateThread", thread != NULL);

--- a/src/rt/rust_util.h
+++ b/src/rt/rust_util.h
@@ -24,7 +24,7 @@ ptr_vec<T>::ptr_vec(rust_dom *dom) :
     data(new (dom) T*[alloc])
 {
     I(dom, data);
-    dom->log(rust_log::MEM,
+    DLOG(dom, rust_log::MEM,
              "new ptr_vec(data=0x%" PRIxPTR ") -> 0x%" PRIxPTR,
              (uintptr_t)data, (uintptr_t)this);
 }
@@ -33,7 +33,7 @@ template <typename T>
 ptr_vec<T>::~ptr_vec()
 {
     I(dom, data);
-    dom->log(rust_log::MEM,
+    DLOG(dom, rust_log::MEM,
              "~ptr_vec 0x%" PRIxPTR ", data=0x%" PRIxPTR,
              (uintptr_t)this, (uintptr_t)data);
     I(dom, fill == 0);


### PR DESCRIPTION
No functions should be called for log statements that turn out to be
inactive.
