### PR TITLE
Support for self-calls that take arguments.

### DIFF
--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -258,7 +258,7 @@ tag expr_ {
     expr_tup(vec[elt], ann);
     expr_rec(vec[field], option.t[@expr], ann);
     expr_call(@expr, vec[@expr], ann);
-    expr_call_self(ident, vec[@expr], ann);
+    expr_self_method(ident, ann);
     expr_bind(@expr, vec[option.t[@expr]], ann);
     expr_spawn(spawn_dom, option.t[str], @expr, vec[@expr], ann);
     expr_binary(binop, @expr, @expr, ann);

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -893,14 +893,14 @@ impure fn parse_bottom_expr(parser p) -> @ast.expr {
             p.bump();
             expect(p, token.DOT);
             // The rest is a call expression.
-            auto e = parse_ident(p);
+            let @ast.expr f = parse_self_method(p);
             auto pf = parse_expr;
             auto es = parse_seq[@ast.expr](token.LPAREN,
                                            token.RPAREN,
                                            some(token.COMMA),
                                            pf, p);
             hi = es.span;
-            ex = ast.expr_call_self(e, es.node, ast.ann_none);
+            ex = ast.expr_call(f, es.node, ast.ann_none);
         }
 
         case (_) {
@@ -964,6 +964,13 @@ impure fn extend_expr_by_ident(parser p, span lo, span hi,
         }
     }
     ret @spanned(lo, hi, e_);
+}
+
+impure fn parse_self_method(parser p) -> @ast.expr {
+    auto lo = p.get_span();
+    let ast.ident f_name = parse_ident(p);
+    auto hi = p.get_span();
+    ret @spanned(lo, hi, ast.expr_self_method(f_name, ast.ann_none));
 }
 
 impure fn parse_dot_or_call_expr(parser p) -> @ast.expr {
@@ -1634,7 +1641,7 @@ fn stmt_ends_with_semi(@ast.stmt stmt) -> bool {
                 case (ast.expr_tup(_,_))        { ret true; }
                 case (ast.expr_rec(_,_,_))      { ret true; }
                 case (ast.expr_call(_,_,_))     { ret true; }
-                case (ast.expr_call_self(_,_,_)){ ret true; }
+                case (ast.expr_self_method(_,_)){ ret false; }
                 case (ast.expr_binary(_,_,_,_)) { ret true; }
                 case (ast.expr_unary(_,_,_))    { ret true; }
                 case (ast.expr_lit(_,_))        { ret true; }

--- a/src/comp/middle/fold.rs
+++ b/src/comp/middle/fold.rs
@@ -89,8 +89,7 @@ type ast_fold[ENV] =
          ann a) -> @expr)                         fold_expr_call,
 
      (fn(&ENV e, &span sp,
-         ident id, vec[@expr] args,
-         ann a) -> @expr)                         fold_expr_call_self,
+         ident id, ann a) -> @expr)               fold_expr_self_method,
 
      (fn(&ENV e, &span sp,
          @expr f, vec[option.t[@expr]] args,
@@ -569,9 +568,8 @@ fn fold_expr[ENV](&ENV env, ast_fold[ENV] fld, &@expr e) -> @expr {
             ret fld.fold_expr_call(env_, e.span, ff, aargs, t);
         }
 
-        case (ast.expr_call_self(?ident, ?args, ?t)) {
-            auto aargs = fold_exprs(env_, fld, args);
-            ret fld.fold_expr_call_self(env_, e.span, ident, aargs, t);
+        case (ast.expr_self_method(?ident, ?t)) {
+            ret fld.fold_expr_self_method(env_, e.span, ident, t);
         }
 
         case (ast.expr_bind(?f, ?args_opt, ?t)) {
@@ -1187,9 +1185,9 @@ fn identity_fold_expr_call[ENV](&ENV env, &span sp, @expr f,
     ret @respan(sp, ast.expr_call(f, args, a));
 }
 
-fn identity_fold_expr_call_self[ENV](&ENV env, &span sp, ident id,
-                                vec[@expr] args, ann a) -> @expr {
-    ret @respan(sp, ast.expr_call_self(id, args, a));
+fn identity_fold_expr_self_method[ENV](&ENV env, &span sp, ident id,
+                                       ann a) -> @expr {
+    ret @respan(sp, ast.expr_self_method(id, a));
 }
 
 fn identity_fold_expr_bind[ENV](&ENV env, &span sp, @expr f,
@@ -1601,8 +1599,8 @@ fn new_identity_fold[ENV]() -> ast_fold[ENV] {
          fold_expr_tup    = bind identity_fold_expr_tup[ENV](_,_,_,_),
          fold_expr_rec    = bind identity_fold_expr_rec[ENV](_,_,_,_,_),
          fold_expr_call   = bind identity_fold_expr_call[ENV](_,_,_,_,_),
-         fold_expr_call_self
-                          = bind identity_fold_expr_call_self[ENV](_,_,_,_,_),
+         fold_expr_self_method
+                          = bind identity_fold_expr_self_method[ENV](_,_,_,_),
          fold_expr_bind   = bind identity_fold_expr_bind[ENV](_,_,_,_,_),
          fold_expr_spawn  = bind identity_fold_expr_spawn[ENV](_,_,_,_,_,_,_),
          fold_expr_binary = bind identity_fold_expr_binary[ENV](_,_,_,_,_,_),

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -3911,10 +3911,7 @@ fn trans_lval(@block_ctxt cx, @ast.expr e) -> lval_result {
                                              C_int(abi.box_rc_field_body)));
             ret lval_mem(sub.bcx, val);
         }
-
-        // Kind of bizarre to pass an *entire* self-call here...but let's try
-        // it
-        case (ast.expr_call_self(?ident, _, ?ann)) {
+        case (ast.expr_self_method(?ident, ?ann)) {
             alt (cx.fcx.llself) {
                 case (some[self_vt](?s_vt)) {
                     auto r =  s_vt.v;
@@ -4764,11 +4761,6 @@ fn trans_expr(@block_ctxt cx, @ast.expr e) -> result {
 
         case (ast.expr_call(?f, ?args, ?ann)) {
             ret trans_call(cx, f, none[ValueRef], args, ann);
-        }
-
-        case (ast.expr_call_self(?ident, ?args, ?ann)) {
-            // A weird hack to make self-calls work.
-            ret trans_call(cx, e, none[ValueRef], args, ann);
         }
 
         case (ast.expr_cast(?e, _, ?ann)) {

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -764,7 +764,7 @@ fn expr_ty(@ast.expr expr) -> @t {
         case (ast.expr_rec(_, _, ?ann))       { ret ann_to_type(ann); }
         case (ast.expr_bind(_, _, ?ann))      { ret ann_to_type(ann); }
         case (ast.expr_call(_, _, ?ann))      { ret ann_to_type(ann); }
-        case (ast.expr_call_self(_, _, ?ann)) { ret ann_to_type(ann); }
+        case (ast.expr_self_method(_, ?ann))  { ret ann_to_type(ann); }
         case (ast.expr_spawn(_, _, _, _, ?ann))
                                               { ret ann_to_type(ann); }
         case (ast.expr_binary(_, _, _, ?ann)) { ret ann_to_type(ann); }

--- a/src/comp/pretty/pprust.rs
+++ b/src/comp/pretty/pprust.rs
@@ -454,12 +454,9 @@ impure fn print_expr(ps s, &@ast.expr expr) {
             commasep_exprs(s, args);
             pclose(s);
         }
-        case (ast.expr_call_self(?ident,?args,_)) {
+        case (ast.expr_self_method(?ident,_)) {
             wrd(s.s, "self.");
             print_ident(s, ident);
-            popen(s);
-            commasep_exprs(s, args);
-            pclose(s);
         }
         case (ast.expr_bind(?func,?args,_)) {
             impure fn print_opt(ps s, &option.t[@ast.expr] expr) {

--- a/src/test/run-pass/obj-self-2.rs
+++ b/src/test/run-pass/obj-self-2.rs
@@ -1,0 +1,19 @@
+// xfail-boot
+fn main() {
+
+  obj foo() {
+      impure fn m1(mutable int i) {
+          i += 1;
+          log "hi!";
+      }
+      impure fn m2(mutable int i) {
+          i += 1;
+          self.m1(i);
+      }
+  }
+  
+  auto a = foo();
+  let int i = 0;
+  a.m1(i);
+  a.m2(i);
+}

--- a/src/test/run-pass/obj-self-3.rs
+++ b/src/test/run-pass/obj-self-3.rs
@@ -1,0 +1,31 @@
+// xfail-boot
+fn main() {
+
+  obj foo() {
+      impure fn m1(mutable int i) -> int {
+          i += 1;
+          ret i;
+      }
+      impure fn m2(mutable int i) -> int {
+          ret self.m1(i);
+      }
+      impure fn m3(mutable int i) -> int {
+          i += 1;
+          ret self.m1(i);
+      }
+  }
+  
+  auto a = foo();
+  let int i = 0;
+
+  // output should be: 0, 1, 2, 4
+  log i;
+  i = a.m1(i);
+  log i;
+  i = a.m2(i);
+  log i;
+  i = a.m3(i);
+  log i;
+}
+
+


### PR DESCRIPTION
Nicer parsing of self-calls (expr_self_method nodes inside expr_call
nodes, rather than a separate expr_call_self) makes typechecking
tractable.  We can now write self-calls that take arguments and return
values (see: test/run-pass/obj-self-*.rs).
