### PR TITLE
Implemented computing prestates and poststates for a few expression forms

### DIFF
--- a/src/comp/middle/typestate_check.rs
+++ b/src/comp/middle/typestate_check.rs
@@ -890,9 +890,9 @@ fn seq_states(&_fn_info_map fm, &fn_info enclosing,
 }
 
 fn find_pre_post_state_exprs(&_fn_info_map fm,
-			     &fn_info enclosing,
-			     &prestate pres,
-			     &ann a, &vec[@expr] es) -> bool {
+                             &fn_info enclosing,
+                             &prestate pres,
+                             &ann a, &vec[@expr] es) -> bool {
   auto res = seq_states(fm, enclosing, pres, es);
   set_prestate_ann(a, pres);
   set_poststate_ann(a, res._1);
@@ -918,21 +918,21 @@ fn find_pre_post_state_expr(&_fn_info_map fm, &fn_info enclosing,
     case (expr_call(?operator, ?operands, ?a)) {
       /* do the prestate for the rator */
       changed = find_pre_post_state_expr(fm, enclosing, pres, operator)
-	|| changed;
+        || changed;
       /* rands go left-to-right */
       ret(find_pre_post_state_exprs(fm, enclosing,
-				    expr_poststate(*operator), a, operands)
-	  || changed);
+                                    expr_poststate(*operator), a, operands)
+          || changed);
     }
     case (expr_path(_,_,?a)) {
       pure_exp(a, pres);
       ret false;
     }
     case (expr_log(?e,?a)) {
-	changed = find_pre_post_state_expr(fm, enclosing, pres, e);
-	set_prestate_ann(a, pres);
-	set_poststate_ann(a, expr_poststate(*e));
-	ret changed;
+        changed = find_pre_post_state_expr(fm, enclosing, pres, e);
+        set_prestate_ann(a, pres);
+        set_poststate_ann(a, expr_poststate(*e));
+        ret changed;
     }
     case (_) {
       log("find_pre_post_state_expr: implement this case!");
@@ -954,23 +954,23 @@ fn find_pre_post_state_stmt(&_fn_info_map fm, &fn_info enclosing,
         case (ast.decl_local(?alocal)) {
           alt (alocal.init) {
             case (some[ast.initializer](?an_init)) {
-	      changed = find_pre_post_state_expr
-		(fm, enclosing,	pres, an_init.expr) || changed;
-	      set_prestate(stmt_ann, expr_prestate(*an_init.expr));
-	      set_poststate(stmt_ann, expr_poststate(*an_init.expr));
-	      gen(enclosing, stmt_ann, alocal.id);
-	      ret changed;
-	    }
-	    case (none[ast.initializer]) {
-	      set_prestate(stmt_ann, pres);
-	      set_poststate(stmt_ann, pres);
-	      ret false;
-	    }
+              changed = find_pre_post_state_expr
+                (fm, enclosing, pres, an_init.expr) || changed;
+              set_prestate(stmt_ann, expr_prestate(*an_init.expr));
+              set_poststate(stmt_ann, expr_poststate(*an_init.expr));
+              gen(enclosing, stmt_ann, alocal.id);
+              ret changed;
+            }
+            case (none[ast.initializer]) {
+              set_prestate(stmt_ann, pres);
+              set_poststate(stmt_ann, pres);
+              ret false;
+            }
           }
         }
-	case (ast.decl_item(?an_item)) {
-	  be find_pre_post_state_item(fm, an_item);
-	}
+        case (ast.decl_item(?an_item)) {
+          be find_pre_post_state_item(fm, an_item);
+        }
       }
     }
     case (stmt_expr(?e, ?a)) {
@@ -989,7 +989,6 @@ fn find_pre_post_state_stmt(&_fn_info_map fm, &fn_info enclosing,
    returns a boolean flag saying whether any pre- or poststates changed */
 fn find_pre_post_state_block(&_fn_info_map fm, &fn_info enclosing, block b)
   -> bool {
-  log("pre_post_state_block: " + uistr(fm.size()) + " " + uistr(enclosing.size()));
 
   auto changed = false;
   auto num_local_vars = num_locals(enclosing);
@@ -1023,11 +1022,8 @@ fn find_pre_post_state_fn(&_fn_info_map f_info, &fn_info fi, &ast._fn f)
 }
 
 fn fixed_point_states(_fn_info_map fm, fn_info f_info,
-		      // with no ampersands for the first two args, and likewise for find_pre_post_state_fn,
-		      // I got a segfault
                       fn (&_fn_info_map, &fn_info, &ast._fn) -> bool f,
                       &ast._fn start) -> () {
-  log("fixed_point_states: " + uistr(fm.size()) + " " + uistr(f_info.size()));
 
   auto changed = f(fm, f_info, start);
 
@@ -1061,11 +1057,11 @@ fn check_states_stmt(fn_info enclosing, &stmt s) -> () {
 
       if (!implies(pres, prec)) {
         log("check_states_stmt: unsatisfied precondition for ");
-	log_stmt(s);
-	log("Precondition: ");
-	log_bitv(enclosing, prec);
-	log("Prestate: ");
-	log_bitv(enclosing, pres);
+        log_stmt(s);
+        log("Precondition: ");
+        log_bitv(enclosing, prec);
+        log("Prestate: ");
+        log_bitv(enclosing, pres);
         fail;
       }
     }
@@ -1094,8 +1090,6 @@ fn check_item_fn_state(&_fn_info_map f_info_map, &span sp, ident i,
   /* Look up the var-to-bit-num map for this function */
   check(f_info_map.contains_key(id));
   auto f_info = f_info_map.get(id);
-
-  log("check_item_fn_state: id = " + i + " " + uistr(f_info_map.size()) + " " + uistr(f_info.size()));
 
   /* Compute the pre- and post-states for this function */
   auto g = find_pre_post_state_fn;

--- a/src/comp/rustc.rc
+++ b/src/comp/rustc.rc
@@ -65,10 +65,14 @@ auth lib.llvm = unsafe;
 auth pretty.pprust = impure;
 auth middle.typestate_check.find_pre_post_block = impure;
 auth middle.typestate_check.find_pre_post_state_block = impure;
+auth middle.typestate_check.find_pre_post_state_stmt = impure;
+auth middle.typestate_check.find_pre_post_state_expr = impure;
+auth middle.typestate_check.find_pre_post_state_exprs = impure;
 auth middle.typestate_check.find_pre_post_expr  = impure;
 auth middle.typestate_check.find_pre_post_stmt  = impure;
 auth middle.typestate_check.check_states_against_conditions = impure;
 auth middle.typestate_check.check_states_stmt   = impure;
+auth middle.typestate_check.log_stmt            = impure;
 auth util.typestate_ann.implies = impure;
 
 mod lib {

--- a/src/comp/util/common.rs
+++ b/src/comp/util/common.rs
@@ -1,5 +1,6 @@
 import std._uint;
 import std._int;
+import std._vec;
 import front.ast;
 
 
@@ -73,6 +74,17 @@ fn new_int_hash[V]() -> std.map.hashmap[int,V] {
 
 fn istr(int i) -> str {
     ret _int.to_str(i, 10u);
+}
+
+fn uistr(uint i) -> str {
+    ret _uint.to_str(i, 10u);
+}
+
+fn elt_expr(&ast.elt e) -> @ast.expr { ret e.expr; }
+
+fn elt_exprs(vec[ast.elt] elts) -> vec[@ast.expr] {
+    auto f = elt_expr;
+    be _vec.map[ast.elt, @ast.expr](f, elts);
 }
 
 //

--- a/src/comp/util/typestate_ann.rs
+++ b/src/comp/util/typestate_ann.rs
@@ -104,6 +104,18 @@ impure fn set_postcondition(&ts_ann a, &postcond p) -> () {
   bitv.copy(p, a.conditions.postcondition);
 }
 
+// Sets all the bits in a's prestate to equal the
+// corresponding bit in p's prestate.
+impure fn set_prestate(&ts_ann a, &prestate p) -> () {
+  bitv.copy(p, a.states.prestate);
+}
+
+// Sets all the bits in a's postcondition to equal the
+// corresponding bit in p's postcondition.
+impure fn set_poststate(&ts_ann a, &poststate p) -> () {
+  bitv.copy(p, a.states.poststate);
+}
+
 // Set all the bits in p that are set in new
 impure fn extend_prestate(&prestate p, &poststate new) -> () {
   bitv.union(p, new);
@@ -119,5 +131,5 @@ fn ann_prestate(&ts_ann a) -> prestate {
 
 impure fn implies(bitv.t a, bitv.t b) -> bool {
   bitv.difference(b, a);
-  be bitv.is_false(b);
+  ret bitv.is_false(b);
 }

--- a/src/lib/bitv.rs
+++ b/src/lib/bitv.rs
@@ -170,6 +170,21 @@ fn to_vec(&t v) -> vec[uint] {
     ret _vec.init_fn[uint](sub, v.nbits);
 }
 
+fn to_str(&t v) -> str {
+    auto res = "";
+
+    for(uint i in v.storage) {
+        if (i == 1u) {
+            res += "1";
+        }
+        else {
+            res += "0";
+        }
+    }
+
+    ret res;
+}
+
 // FIXME: can we just use structural equality on to_vec?
 fn eq_vec(&t v0, &vec[uint] v1) -> bool {
     check (v0.nbits == _vec.len[uint](v1));


### PR DESCRIPTION
Implemented computing prestates and poststates for a few expression forms.

The typestate checker (if it's uncommented) now correctly rejects a
trivial example program that has an uninitialized variable.
