### PR TITLE
Further work on typestate. Handles expr_rec and expr_assign now.

### DIFF
--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -215,8 +215,10 @@ tag mode {
 
 type stmt = spanned[stmt_];
 tag stmt_ {
-    stmt_decl(@decl, option.t[@ts_ann]);
-    stmt_expr(@expr, option.t[@ts_ann]);
+/* Only the ts_ann field is meaningful for statements,
+   but we make it an ann to make traversals simpler */
+    stmt_decl(@decl, ann); 
+    stmt_expr(@expr, ann);
     // These only exist in crate-level blocks.
     stmt_crate_directive(@crate_directive);
 }

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -11,7 +11,7 @@ import util.common;
 import util.common.filename;
 import util.common.span;
 import util.common.new_str_hash;
-import util.typestate_ann.ts_ann;
+import util.common.plain_ann;
 
 tag restriction {
     UNRESTRICTED;
@@ -1562,14 +1562,15 @@ impure fn parse_source_stmt(parser p) -> @ast.stmt {
 
         case (token.LET) {
             auto decl = parse_let(p);
-            ret @spanned(lo, decl.span.hi,
-                         ast.stmt_decl(decl, none[@ts_ann]));
+            auto hi = p.get_span();
+            ret @spanned
+                (lo, decl.span.hi, ast.stmt_decl(decl, plain_ann()));
         }
 
         case (token.AUTO) {
             auto decl = parse_auto(p);
-            ret @spanned(lo, decl.span.hi,
-                         ast.stmt_decl(decl, none[@ts_ann]));
+            auto hi = p.get_span();
+            ret @spanned(lo, decl.span.hi, ast.stmt_decl(decl, plain_ann()));
         }
 
         case (_) {
@@ -1578,12 +1579,13 @@ impure fn parse_source_stmt(parser p) -> @ast.stmt {
                 auto i = parse_item(p);
                 auto hi = i.span.hi;
                 auto decl = @spanned(lo, hi, ast.decl_item(i));
-                ret @spanned(lo, hi, ast.stmt_decl(decl, none[@ts_ann]));
+                ret @spanned(lo, hi, ast.stmt_decl(decl, plain_ann()));
 
             } else {
                 // Remainder are line-expr stmts.
                 auto e = parse_expr(p);
-                ret @spanned(lo, e.span.hi, ast.stmt_expr(e, none[@ts_ann]));
+                auto hi = p.get_span();
+                ret @spanned(lo, e.span.hi, ast.stmt_expr(e, plain_ann()));
             }
         }
     }

--- a/src/comp/middle/fold.rs
+++ b/src/comp/middle/fold.rs
@@ -232,11 +232,11 @@ type ast_fold[ENV] =
 
      // Stmt folds.
      (fn(&ENV e, &span sp,
-         @decl decl, option.t[@ts_ann] a)
+         @decl decl, ann a)
       -> @stmt)                                   fold_stmt_decl,
 
      (fn(&ENV e, &span sp,
-         @expr e, option.t[@ts_ann] a)
+         @expr e, ann a)
       -> @stmt)                                   fold_stmt_expr,
 
      // Item folds.
@@ -470,7 +470,9 @@ fn fold_decl[ENV](&ENV env, ast_fold[ENV] fld, @decl d) -> @decl {
                 }
                 case (_) { /* fall through */  }
             }
-            let @ast.local local_ = @rec(ty=ty_, init=init_ with *local);
+            auto ann_ = fld.fold_ann(env_, local.ann);
+            let @ast.local local_ =
+                @rec(ty=ty_, init=init_, ann=ann_ with *local);
             ret fld.fold_decl_local(env_, d.span, local_);
         }
 
@@ -830,12 +832,14 @@ fn fold_stmt[ENV](&ENV env, ast_fold[ENV] fld, &@stmt s) -> @stmt {
     alt (s.node) {
         case (ast.stmt_decl(?d, ?a)) {
             auto dd = fold_decl(env_, fld, d);
-            ret fld.fold_stmt_decl(env_, s.span, dd, a);
+            auto aa = fld.fold_ann(env_, a);
+            ret fld.fold_stmt_decl(env_, s.span, dd, aa);
         }
 
         case (ast.stmt_expr(?e, ?a)) {
             auto ee = fold_expr(env_, fld, e);
-            ret fld.fold_stmt_expr(env_, s.span, ee, a);
+            auto aa = fld.fold_ann(env_, a);
+            ret fld.fold_stmt_expr(env_, s.span, ee, aa);
         }
     }
     fail;
@@ -1426,13 +1430,11 @@ fn identity_fold_pat_tag[ENV](&ENV e, &span sp, path p, vec[@pat] args,
 
 // Stmt identities.
 
-fn identity_fold_stmt_decl[ENV](&ENV env, &span sp, @decl d,
-                                option.t[@ts_ann] a) -> @stmt {
+fn identity_fold_stmt_decl[ENV](&ENV env, &span sp, @decl d, ann a) -> @stmt {
     ret @respan(sp, ast.stmt_decl(d, a));
 }
 
-fn identity_fold_stmt_expr[ENV](&ENV e, &span sp, @expr x,
-                                option.t[@ts_ann] a) -> @stmt {
+fn identity_fold_stmt_expr[ENV](&ENV e, &span sp, @expr x, ann a) -> @stmt {
     ret @respan(sp, ast.stmt_expr(x, a));
 }
 
@@ -1705,7 +1707,7 @@ fn new_identity_fold[ENV]() -> ast_fold[ENV] {
              bind identity_fold_native_item_ty[ENV](_,_,_,_),
          fold_item_tag  = bind identity_fold_item_tag[ENV](_,_,_,_,_,_,_),
          fold_item_obj  = bind identity_fold_item_obj[ENV](_,_,_,_,_,_,_),
-
+       
          fold_view_item_use =
              bind identity_fold_view_item_use[ENV](_,_,_,_,_,_),
          fold_view_item_import =

--- a/src/comp/util/common.rs
+++ b/src/comp/util/common.rs
@@ -1,8 +1,17 @@
 import std._uint;
 import std._int;
 import std._vec;
+import std.option.none;
 import front.ast;
+import util.typestate_ann.ts_ann;
 
+import std.io.stdout;
+import std.io.str_writer;
+import std.io.string_writer;
+import pretty.pprust.print_block;
+import pretty.pprust.print_expr;
+import pretty.pprust.print_decl;
+import pretty.pp.mkstate;
 
 type filename = str;
 type span = rec(uint lo, uint hi);
@@ -84,6 +93,40 @@ fn elt_expr(&ast.elt e) -> @ast.expr { ret e.expr; }
 fn elt_exprs(vec[ast.elt] elts) -> vec[@ast.expr] {
     auto f = elt_expr;
     be _vec.map[ast.elt, @ast.expr](f, elts);
+}
+
+fn field_expr(&ast.field f) -> @ast.expr { ret f.expr; }
+
+fn field_exprs(vec[ast.field] fields) -> vec [@ast.expr] {
+    auto f = field_expr;
+    ret _vec.map[ast.field, @ast.expr](f, fields);
+}
+
+fn plain_ann() -> ast.ann {
+  ret ast.ann_type(middle.ty.plain_ty(middle.ty.ty_nil),
+                   none[vec[@middle.ty.t]], none[@ts_ann]);
+}
+
+fn log_expr(@ast.expr e) -> () {
+  let str_writer s = string_writer();
+  auto out_ = mkstate(s.get_writer(), 80u);
+  auto out = @rec(s=out_,
+                  comments=none[vec[front.lexer.cmnt]],
+                  mutable cur_cmnt=0u);
+
+  print_expr(out, e);
+  log(s.get_str());
+}
+
+fn log_block(&ast.block b) -> () {
+  let str_writer s = string_writer();
+  auto out_ = mkstate(s.get_writer(), 80u);
+  auto out = @rec(s=out_,
+                  comments=none[vec[front.lexer.cmnt]],
+                  mutable cur_cmnt=0u);
+
+  print_block(out, b);
+  log(s.get_str());
 }
 
 //

--- a/src/lib/bitv.rs
+++ b/src/lib/bitv.rs
@@ -74,6 +74,15 @@ impure fn copy(&t v0, t v1) -> bool {
     ret process(sub, v0, v1);
 }
 
+fn clone(t v) -> t {
+    auto storage = _vec.init_elt_mut[uint](0u, v.nbits / uint_bits() + 1u);
+    auto len = _vec.len[mutable uint](v.storage);
+    for each (uint i in _uint.range(0u, len)) {
+        storage.(i) = v.storage.(i);
+    }
+    ret rec(storage = storage, nbits = v.nbits);
+}
+
 fn get(&t v, uint i) -> bool {
     check (i < v.nbits);
 
@@ -137,7 +146,7 @@ impure fn set(&t v, uint i, bool x) {
 
 /* true if all bits are 1 */
 fn is_true(&t v) -> bool {
-    for(uint i in v.storage) {
+    for (uint i in to_vec(v)) {
         if (i != 1u) {
             ret false;
         }
@@ -148,7 +157,7 @@ fn is_true(&t v) -> bool {
 
 /* true if all bits are non-1 */
 fn is_false(&t v) -> bool {
-    for(uint i in v.storage) {
+    for (uint i in to_vec(v)) {
         if (i == 1u) {
             ret false;
         }
@@ -173,7 +182,7 @@ fn to_vec(&t v) -> vec[uint] {
 fn to_str(&t v) -> str {
     auto res = "";
 
-    for(uint i in v.storage) {
+    for (uint i in bitv.to_vec(v)) {
         if (i == 1u) {
             res += "1";
         }


### PR DESCRIPTION
Also changed the ts_ann field on statements to be an ann instead,
which explains most of the changes.

As well, got rid of the "warning: no type for expression" error
by filling in annotations for local decls in typeck (not sure whether
this was my fault or not).

Finally, in bitv, added a clone() function to copy a bit vector,
and fixed is_true, is_false, and to_str to not be nonsense.
