### PR TITLE
typestate_check can now handle expr_block, expr_if, and expr_binary

### DIFF
--- a/src/comp/front/ast.rs
+++ b/src/comp/front/ast.rs
@@ -100,7 +100,8 @@ tag block_index_entry {
 }
 type block_ = rec(vec[@stmt] stmts,
                   option.t[@expr] expr,
-                  hashmap[ident,block_index_entry] index);
+                  hashmap[ident,block_index_entry] index,
+                  ann a); /* ann is only meaningful for the ts_ann field */
 
 type variant_def = tup(def_id /* tag */, def_id /* variant */);
 

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -1598,7 +1598,7 @@ fn index_block(vec[@ast.stmt] stmts, option.t[@ast.expr] expr) -> ast.block_ {
     for (@ast.stmt s in stmts) {
         ast.index_stmt(index, s);
     }
-    ret rec(stmts=stmts, expr=expr, index=index);
+    ret rec(stmts=stmts, expr=expr, index=index, a=ast.ann_none);
 }
 
 fn index_arm(@ast.pat pat) -> hashmap[ast.ident,ast.def_id] {

--- a/src/comp/middle/fold.rs
+++ b/src/comp/middle/fold.rs
@@ -871,7 +871,8 @@ fn fold_block[ENV](&ENV env, ast_fold[ENV] fld, &block blk) -> block {
         }
     }
 
-    ret respan(blk.span, rec(stmts=stmts, expr=expr, index=index));
+    auto aa = fld.fold_ann(env, blk.node.a); 
+    ret respan(blk.span, rec(stmts=stmts, expr=expr, index=index, a=aa));
 }
 
 fn fold_arm[ENV](&ENV env, ast_fold[ENV] fld, &arm a) -> arm {

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -1399,7 +1399,8 @@ mod Pushdown {
                 auto e_1 = pushdown_expr(fcx, expected, e_0);
                 auto block_ = rec(stmts=bloc.node.stmts,
                                   expr=some[@ast.expr](e_1),
-                                  index=bloc.node.index);
+                                  index=bloc.node.index,
+                                  a=boring_ann());
                 ret fold.respan[ast.block_](bloc.span, block_);
             }
             case (none[@ast.expr]) {
@@ -2569,7 +2570,8 @@ fn check_block(&@fn_ctxt fcx, &ast.block block) -> ast.block {
 
     ret fold.respan[ast.block_](block.span,
                                 rec(stmts=stmts, expr=expr,
-                                    index=block.node.index));
+                                    index=block.node.index,
+                                    a=boring_ann()));
 }
 
 fn check_const(&@crate_ctxt ccx, &span sp, ast.ident ident, @ast.ty t,

--- a/src/comp/util/typestate_ann.rs
+++ b/src/comp/util/typestate_ann.rs
@@ -75,6 +75,10 @@ fn union(&precond p1, &precond p2) -> bool {
   be bitv.union(p1, p2);
 }
 
+fn intersect(&precond p1, &precond p2) -> bool {
+  be bitv.intersect(p1, p2);
+}
+
 fn pps_len(&pre_and_post p) -> uint {
   // gratuitous check
   check (p.precondition.nbits == p.postcondition.nbits);


### PR DESCRIPTION
(caveat for the latter: it assumes that binary operations are strict;
a TODO is to detect or and and and correctly reflect that they're lazy
in the second argument). I had to add an ann field to ast.block,
resulting in the usual boilerplate changes.

Test cases that currently work (if you uncomment the typestate pass
in the driver) (all these are under test/compile-fail):

fru-typestate
ret-uninit
use-uninit
use-uninit-2
use-uninit-3
