### PR TITLE
Pseudomethods

### DIFF
--- a/src/comp/front/lexer.rs
+++ b/src/comp/front/lexer.rs
@@ -611,7 +611,6 @@ fn next_token(reader rdr) -> token.token {
 
     alt (c) {
         // One-byte tokens.
-        case (':') { rdr.bump(); ret token.COLON; }
         case ('?') { rdr.bump(); ret token.QUES; }
         case (';') { rdr.bump(); ret token.SEMI; }
         case (',') { rdr.bump(); ret token.COMMA; }
@@ -628,6 +627,16 @@ fn next_token(reader rdr) -> token.token {
 
 
         // Multi-byte tokens.
+        case (':') {
+            rdr.bump();
+            if (rdr.curr() == ':') {
+                rdr.bump();
+                ret token.COLONCOLON;
+            } else {
+                ret token.COLON;
+            }
+        }
+
         case ('=') {
             rdr.bump();
             if (rdr.curr() == '=') {

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -1007,6 +1007,35 @@ fn parse_dot_or_call_expr(parser p) -> @ast.expr {
                 }
             }
 
+            case (token.COLONCOLON) {
+                // Pseudomethod calls: e::pm() is sugar for pm(e).
+                p.bump();
+                
+                auto pm = parse_bottom_expr(p);
+
+                // Throw out the parens.
+                expect(p, token.LPAREN);
+                expect(p, token.RPAREN);
+
+
+                // // The rest of the arguments.
+                // auto pf = parse_expr;
+                // auto lo = p.get_lo_pos();
+                // auto hi = p.get_hi_pos();
+                // expect(p, token.LPAREN);
+                // auto result = parse_seq_to_end[@ast.expr](token.RPAREN, 
+                //                                           some(token.COMMA), 
+                //                                           pf, hi, p);
+                // // Get all the arguments together.
+                // vec[@ast.expr] args = vec(e) + result;
+                // spanned(lo, hi, args);
+
+                auto e_ = ast.expr_call(pm, vec(@spanned(lo, hi, e.node)), 
+                                        ast.ann_none);
+
+                e = @spanned(lo, hi, e_);
+            }
+
             case (token.DOT) {
                 p.bump();
                 alt (p.peek()) {

--- a/src/comp/front/parser.rs
+++ b/src/comp/front/parser.rs
@@ -1013,26 +1013,20 @@ fn parse_dot_or_call_expr(parser p) -> @ast.expr {
                 
                 auto pm = parse_bottom_expr(p);
 
-                // Throw out the parens.
+                // Parse the rest of the arguments.
+                auto pf = parse_expr;
+                auto lo = p.get_lo_pos();
+                auto hi = p.get_hi_pos();
                 expect(p, token.LPAREN);
-                expect(p, token.RPAREN);
+                auto result = parse_seq_to_end[@ast.expr](token.RPAREN, 
+                                                          some(token.COMMA), 
+                                                          pf, hi, p);
 
+                // Get all the arguments together.
+                let vec[@ast.expr] args = vec(e) + result;
+                auto es = @spanned(lo, hi, args);
 
-                // // The rest of the arguments.
-                // auto pf = parse_expr;
-                // auto lo = p.get_lo_pos();
-                // auto hi = p.get_hi_pos();
-                // expect(p, token.LPAREN);
-                // auto result = parse_seq_to_end[@ast.expr](token.RPAREN, 
-                //                                           some(token.COMMA), 
-                //                                           pf, hi, p);
-                // // Get all the arguments together.
-                // vec[@ast.expr] args = vec(e) + result;
-                // spanned(lo, hi, args);
-
-                auto e_ = ast.expr_call(pm, vec(@spanned(lo, hi, e.node)), 
-                                        ast.ann_none);
-
+                auto e_ = ast.expr_call(pm, es.node, ast.ann_none);
                 e = @spanned(lo, hi, e_);
             }
 

--- a/src/comp/front/token.rs
+++ b/src/comp/front/token.rs
@@ -45,6 +45,7 @@ tag token {
     COMMA;
     SEMI;
     COLON;
+    COLONCOLON;
     QUES;
     RARROW;
     SEND;
@@ -214,6 +215,7 @@ fn to_str(token t) -> str {
         case (COMMA) { ret ","; }
         case (SEMI) { ret ";"; }
         case (COLON) { ret ":"; }
+        case (COLONCOLON) { ret ":"; }
         case (QUES) { ret "?"; }
         case (RARROW) { ret "->"; }
         case (SEND) { ret "<|"; }

--- a/src/comp/front/token.rs
+++ b/src/comp/front/token.rs
@@ -215,7 +215,7 @@ fn to_str(token t) -> str {
         case (COMMA) { ret ","; }
         case (SEMI) { ret ";"; }
         case (COLON) { ret ":"; }
-        case (COLONCOLON) { ret ":"; }
+        case (COLONCOLON) { ret "::"; }
         case (QUES) { ret "?"; }
         case (RARROW) { ret "->"; }
         case (SEND) { ret "<|"; }

--- a/src/test/run-pass/pseudomethod.rs
+++ b/src/test/run-pass/pseudomethod.rs
@@ -3,26 +3,53 @@ use std;
 import std._vec.len;
 fn main() {
 
-    // Sanity check
+    // Pseudomethod using a library function
     let uint a = len[int](vec(1, 2, 3, 4));
     log a;
-    let vec[int] v = vec(1, 2, 3, 4);
-    let uint b = len[int](v);
+    let uint b = vec(1, 2, 3, 4)::len[int]();
     log b;
     check (a == b);
 
-    // Pseudomethod
-    let uint c = vec(1, 2, 3, 4)::len[int]();
+    let vec[int] v = vec(1, 2, 3, 4);
+    let uint c = len[int](v);
     log c;
     let uint d = v::len[int]();
     log d;
     check (c == d);
 
-    // User-defined pseudomethod
+    // User-defined pseudomethods
     fn exclaim(str s) -> str { ret s + "!"; }
     let str e = exclaim("hello");
     log e;
     let str f = "hello"::exclaim();
     log f;
     check (e == f);
+
+    fn plus(int a, int b) -> int { ret a + b; }
+    let int m = 2 * 3::plus(4) + 5;
+    let int n = 2 * (3 + 4) + 5;
+    log m;
+    log n;
+    check (m == n);
+
+    // Multi-argument pseudomethod
+    fn bang_huh(str s1, str s2) -> str { 
+        ret s1 + "!" + s2 + "?";
+    }
+    let str g = bang_huh("hello", "world");
+    log g;
+    let str h = "hello"::bang_huh("world");
+    log h;
+    check (g == h);
+
+    // Stacking pseudomethods
+    let str i = "hello"::exclaim()::bang_huh("world");
+    log i;
+    let str j = bang_huh(exclaim("hello"), "world");
+    log j;
+    check (i == j);
+
+    let int k = (vec("foo", "bar", "baz")::len[str]() as int)::plus(50);
+    log k;
+    check (k == 53);
 }

--- a/src/test/run-pass/pseudomethod.rs
+++ b/src/test/run-pass/pseudomethod.rs
@@ -1,0 +1,28 @@
+// xfail-boot
+use std;
+import std._vec.len;
+fn main() {
+
+    // Sanity check
+    let uint a = len[int](vec(1, 2, 3, 4));
+    log a;
+    let vec[int] v = vec(1, 2, 3, 4);
+    let uint b = len[int](v);
+    log b;
+    check (a == b);
+
+    // Pseudomethod
+    let uint c = vec(1, 2, 3, 4)::len[int]();
+    log c;
+    let uint d = v::len[int]();
+    log d;
+    check (c == d);
+
+    // User-defined pseudomethod
+    fn exclaim(str s) -> str { ret s + "!"; }
+    let str e = exclaim("hello");
+    log e;
+    let str f = "hello"::exclaim();
+    log f;
+    check (e == f);
+}


### PR DESCRIPTION
Here's some very simple support for pseudomethods.  It does all its desugaring in the parser, and everything looks like an ordinary expr_call node from there on out.  The '::' syntax was suggested by pcwalton.
