### PR TITLE
Mark valgrind's _qzz_res as unused to silence warnings on gcc 4.6.

### DIFF
--- a/src/rt/memcheck.h
+++ b/src/rt/memcheck.h
@@ -184,7 +184,7 @@ typedef
 
 /* Do a full memory leak check (like --leak-check=full) mid-execution. */
 #define VALGRIND_DO_LEAK_CHECK                                   \
-   {unsigned long _qzz_res;                                      \
+   {unsigned long _qzz_res __attribute((unused));                \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                      \
                             VG_USERREQ__DO_LEAK_CHECK,           \
                             0, 0, 0, 0, 0);                      \
@@ -192,7 +192,7 @@ typedef
 
 /* Do a summary memory leak check (like --leak-check=summary) mid-execution. */
 #define VALGRIND_DO_QUICK_LEAK_CHECK				 \
-   {unsigned long _qzz_res;                                      \
+   {unsigned long _qzz_res __attribute((unused));                \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                      \
                             VG_USERREQ__DO_LEAK_CHECK,           \
                             1, 0, 0, 0, 0);                      \
@@ -207,7 +207,7 @@ typedef
       are.  We also initialise '_qzz_leaked', etc because
       VG_USERREQ__COUNT_LEAKS doesn't mark the values returned as
       defined. */                                                        \
-   {unsigned long _qzz_res;                                              \
+   {unsigned long _qzz_res __attribute((unused));                        \
     unsigned long _qzz_leaked    = 0, _qzz_dubious    = 0;               \
     unsigned long _qzz_reachable = 0, _qzz_suppressed = 0;               \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                              \
@@ -229,7 +229,7 @@ typedef
       are.  We also initialise '_qzz_leaked', etc because
       VG_USERREQ__COUNT_LEAKS doesn't mark the values returned as
       defined. */                                                        \
-   {unsigned long _qzz_res;                                              \
+   {unsigned long _qzz_res __attribute((unused));                        \
     unsigned long _qzz_leaked    = 0, _qzz_dubious    = 0;               \
     unsigned long _qzz_reachable = 0, _qzz_suppressed = 0;               \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                              \

--- a/src/rt/valgrind.h
+++ b/src/rt/valgrind.h
@@ -4403,7 +4403,7 @@ vg_VALGRIND_DO_CLIENT_REQUEST_EXPR(uintptr_t _zzq_default,
    since it provides a way to make sure valgrind will retranslate the
    invalidated area.  Returns no value. */
 #define VALGRIND_DISCARD_TRANSLATIONS(_qzz_addr,_qzz_len)         \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__DISCARD_TRANSLATIONS,  \
                                _qzz_addr, _qzz_len, 0, 0, 0);     \
@@ -4652,7 +4652,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    Ignored if addr == 0.
 */
 #define VALGRIND_MALLOCLIKE_BLOCK(addr, sizeB, rzB, is_zeroed)    \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__MALLOCLIKE_BLOCK,      \
                                addr, sizeB, rzB, is_zeroed, 0);   \
@@ -4662,7 +4662,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    Ignored if addr == 0.
 */
 #define VALGRIND_FREELIKE_BLOCK(addr, rzB)                        \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__FREELIKE_BLOCK,        \
                                addr, rzB, 0, 0, 0);               \
@@ -4670,7 +4670,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Create a memory pool. */
 #define VALGRIND_CREATE_MEMPOOL(pool, rzB, is_zeroed)             \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__CREATE_MEMPOOL,        \
                                pool, rzB, is_zeroed, 0, 0);       \
@@ -4678,7 +4678,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Destroy a memory pool. */
 #define VALGRIND_DESTROY_MEMPOOL(pool)                            \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__DESTROY_MEMPOOL,       \
                                pool, 0, 0, 0, 0);                 \
@@ -4686,7 +4686,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Associate a piece of memory with a memory pool. */
 #define VALGRIND_MEMPOOL_ALLOC(pool, addr, size)                  \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__MEMPOOL_ALLOC,         \
                                pool, addr, size, 0, 0);           \
@@ -4694,7 +4694,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Disassociate a piece of memory from a memory pool. */
 #define VALGRIND_MEMPOOL_FREE(pool, addr)                         \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__MEMPOOL_FREE,          \
                                pool, addr, 0, 0, 0);              \
@@ -4702,7 +4702,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Disassociate any pieces outside a particular range. */
 #define VALGRIND_MEMPOOL_TRIM(pool, addr, size)                   \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__MEMPOOL_TRIM,          \
                                pool, addr, size, 0, 0);           \
@@ -4710,7 +4710,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Resize and/or move a piece associated with a memory pool. */
 #define VALGRIND_MOVE_MEMPOOL(poolA, poolB)                       \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__MOVE_MEMPOOL,          \
                                poolA, poolB, 0, 0, 0);            \
@@ -4718,7 +4718,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Resize and/or move a piece associated with a memory pool. */
 #define VALGRIND_MEMPOOL_CHANGE(pool, addrA, addrB, size)         \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__MEMPOOL_CHANGE,        \
                                pool, addrA, addrB, size, 0);      \
@@ -4747,7 +4747,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 /* Unmark the piece of memory associated with a stack id as being a
    stack. */
 #define VALGRIND_STACK_DEREGISTER(id)                             \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__STACK_DEREGISTER,      \
                                id, 0, 0, 0, 0);                   \
@@ -4755,7 +4755,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Change the start and end address of the stack id. */
 #define VALGRIND_STACK_CHANGE(id, start, end)                     \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__STACK_CHANGE,          \
                                id, start, end, 0, 0);             \
@@ -4763,7 +4763,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Load PDB debug info for Wine PE image_map. */
 #define VALGRIND_LOAD_PDB_DEBUGINFO(fd, ptr, total_size, delta)   \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__LOAD_PDB_DEBUGINFO,    \
                                fd, ptr, total_size, delta, 0);    \
@@ -4774,7 +4774,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    result will be dumped in there and is guaranteed to be zero
    terminated.  If no info is found, the first byte is set to zero. */
 #define VALGRIND_MAP_IP_TO_SRCLOC(addr, buf64)                    \
-   {unsigned int _qzz_res;                                        \
+   {unsigned int _qzz_res __attribute((unused));                  \
     VALGRIND_DO_CLIENT_REQUEST(_qzz_res, 0,                       \
                                VG_USERREQ__MAP_IP_TO_SRCLOC,      \
                                addr, buf64, 0, 0, 0);             \


### PR DESCRIPTION
This applies c11675 by Julian Seward from valgrind trunk
(svn://svn.valgrind.org/valgrind/trunk) to rustrt's included
copies of memcheck.h and valgrind.h, effectively backporting
the fix from the unreleased 3.6.2. The commit simply applies
the gcc 'unused' attribute to the relevant declarations.

This change allows compilation of the runtime code under
gcc 4.6 with -Werror, as the makefile currently requests.
