### PR TITLE
Consolidating expr_to_str functions.

### DIFF
--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -12,14 +12,11 @@ import std.option.none;
 
 import front.ast;
 import front.creader;
-import pretty.pprust;
 import driver.session;
 import middle.ty;
 import back.Link;
 import back.x86;
 import back.abi;
-
-import pretty.pprust;
 
 import middle.ty.pat_ty;
 
@@ -5397,7 +5394,7 @@ fn trans_log(int lvl, @block_ctxt cx, @ast.expr e) -> result {
 fn trans_check_expr(@block_ctxt cx, @ast.expr e) -> result {
     auto cond_res = trans_expr(cx, e);
 
-    auto expr_str = pretty.pprust.expr_to_str(e);
+    auto expr_str = util.common.expr_to_str(e);
     auto fail_cx = new_sub_block_ctxt(cx, "fail");
     auto fail_res = trans_fail(fail_cx, some[common.span](e.span), expr_str);
 

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -1963,7 +1963,7 @@ fn replace_expr_type(@ast.expr expr, tup(vec[t], t) new_tyt) -> @ast.expr {
         }
         case (_) {
             log_err "unhandled expr type in replace_expr_type(): " +
-                pretty.pprust.expr_to_str(expr);
+                util.common.expr_to_str(expr);
             fail;
         }
     }

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -42,8 +42,6 @@ import std.option.none;
 import std.option.some;
 import std.option.from_maybe;
 
-import pretty.pprust;
-
 import util.typestate_ann.ts_ann;
 
 type ty_table = hashmap[ast.def_id, ty.t];
@@ -1476,7 +1474,7 @@ mod Pushdown {
             case (_) {
                 fcx.ccx.sess.span_unimpl(e.span,
                     #fmt("type unification for expression variant: %s",
-                         pretty.pprust.expr_to_str(e)));
+                         util.common.expr_to_str(e)));
                 fail;
             }
         }
@@ -1735,7 +1733,7 @@ fn require_pure_function(@crate_ctxt ccx, &ast.def_id d_id, &span sp) -> () {
 
 fn check_expr(&@fn_ctxt fcx, @ast.expr expr) -> @ast.expr {
     //fcx.ccx.sess.span_warn(expr.span, "typechecking expr " +
-    //                       pretty.pprust.expr_to_str(expr));
+    //                       util.common.expr_to_str(expr));
 
     // A generic function to factor out common logic from call and bind
     // expressions.

--- a/src/comp/pretty/pprust.rs
+++ b/src/comp/pretty/pprust.rs
@@ -41,15 +41,6 @@ fn block_to_str(&ast.block blk) -> str {
     ret writer.get_str();
 }
 
-fn expr_to_str(&@ast.expr e) -> str {
-    auto writer = io.string_writer();
-    auto s = @rec(s=pp.mkstate(writer.get_writer(), 78u),
-                  comments=option.none[vec[lexer.cmnt]],
-                  mutable cur_cmnt=0u);
-    print_expr(s, e);
-    ret writer.get_str();
-}
-
 fn pat_to_str(&@ast.pat p) -> str {
     auto writer = io.string_writer();
     auto s = @rec(s=pp.mkstate(writer.get_writer(), 78u),

--- a/src/comp/util/common.rs
+++ b/src/comp/util/common.rs
@@ -122,22 +122,22 @@ fn plain_ann(middle.ty.ctxt tcx) -> ast.ann {
                    none[vec[middle.ty.t]], none[@ts_ann]);
 }
 
-fn expr_to_str(&ast.expr e) -> str {
+fn expr_to_str(&@ast.expr e) -> str {
   let str_writer s = string_writer();
   auto out_ = mkstate(s.get_writer(), 80u);
   auto out = @rec(s=out_,
                   comments=none[vec[front.lexer.cmnt]],
                   mutable cur_cmnt=0u);
-  print_expr(out, @e);
+  print_expr(out, e);
   ret s.get_str();
 }
 
 fn log_expr(&ast.expr e) -> () {
-    log(expr_to_str(e));
+    log(expr_to_str(@e));
 }
 
 fn log_expr_err(&ast.expr e) -> () {
-    log_err(expr_to_str(e));
+    log_err(expr_to_str(@e));
 }
 
 fn block_to_str(&ast.block b) -> str {


### PR DESCRIPTION
Got rid of the redundant expr_to_str in pretty.pprust, and tweaked the signature of the one in util.common to match the one we're replacing.
