### PR TITLE
OptLevel changes. Accepts levels 0 to 3 only. '-O' is no longer accepted.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,7 +15,7 @@ ifdef CFG_DISABLE_OPTIMIZE
   $(info cfg: disabling rustc optimization (CFG_DISABLE_OPTIMIZE))
   CFG_RUSTC_FLAGS :=
 else
-  CFG_RUSTC_FLAGS := -O
+  CFG_RUSTC_FLAGS := --OptLevel=2
 endif
 
 ifdef SAVE_TEMPS

--- a/src/comp/driver/session.rs
+++ b/src/comp/driver/session.rs
@@ -26,7 +26,7 @@ type config = rec(os os,
                   ty_mach float_type);
 
 type options = rec(bool shared,
-                   bool optimize,
+                   uint optimize,
                    bool debuginfo,
                    bool verify,
                    bool run_typestate,


### PR DESCRIPTION
OptLevel changes. Accepts levels 0 to 3 only. '-O' is no longer accepted. New snapshot may be required (or modify the stage0/rustc command line to still use -O). I tested linux building rustc with all OptLevels.
