### PR TITLE
Auto link

### DIFF
--- a/src/comp/README
+++ b/src/comp/README
@@ -73,5 +73,5 @@ Control and information flow within the compiler:
 
 - Finally middle/trans.rs is applied to the AST, which performs a
   type-directed translation to LLVM-ese. When it's finished synthesizing LLVM
-  values, rustc asks LLVM to write them out as a bitcode file, on which you
-  can run the normal LLVM pipeline (opt, llc, as) to get an executable.
+  values, rustc asks LLVM to write them out as an executable, on which the
+  normal LLVM pipeline (opt, llc, as) was run.

--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -171,8 +171,8 @@ mod write {
                                _str::buf(output), LLVMAssemblyFile);
                 }
 
-                // Save the object file for -c or only --save-temps
-                // is used and an exe is built
+                // Save the object file for -c or --save-temps alone
+                // This .o is needed when an exe is built
                 if ((opts.output_type == output_type_object) ||
                     (opts.output_type == output_type_exe)) {
                         llvm::LLVMRustWriteOutputFile(pm.llpm, llmod,
@@ -197,7 +197,7 @@ mod write {
             ret;
         }
 
-        // If only a bitcode file is asked for by using the '--bitcode'
+        // If only a bitcode file is asked for by using the '--emit-llvm'
         // flag, then output it here
         llvm::LLVMRunPassManager(pm.llpm, llmod);
 

--- a/src/comp/driver/rustc.rs
+++ b/src/comp/driver/rustc.rs
@@ -155,7 +155,7 @@ options:
     -O                 optimize
     -S                 compile only; do not assemble or link
     -c                 compile and assemble, but do not link
-    --bitcode          produce an LLVM bitcode file
+    --emit-llvm        produce an LLVM bitcode file
     --save-temps       write intermediate files in addition to normal output
     --stats            gather and report various compilation statistics
     --time-passes      time the individual phases of the compiler
@@ -207,7 +207,7 @@ fn main(vec[str] args) {
 
     auto opts = vec(optflag("h"), optflag("help"),
                     optflag("v"), optflag("version"),
-                    optflag("glue"), optflag("bitcode"),
+                    optflag("glue"), optflag("emit-llvm"),
                     optflag("pretty"), optflag("ls"), optflag("parse-only"),
                     optflag("O"), optflag("shared"), optmulti("L"),
                     optflag("S"), optflag("c"), optopt("o"), optflag("g"),
@@ -250,7 +250,7 @@ fn main(vec[str] args) {
         output_type = link::output_type_assembly;
     } else if (opt_present(match, "c")) {
         output_type = link::output_type_object;
-    } else if (opt_present(match, "bitcode")) {
+    } else if (opt_present(match, "emit-llvm")) {
         output_type = link::output_type_bitcode;
     }
 


### PR DESCRIPTION
Automatically link rustc output into an executable. Adds --emit-lvm flag for emitting bitcode files. Not tested on Mac or Win by me as I don't have those environments set up here.
