### PR TITLE
Buildsystem patches

### DIFF
--- a/configure
+++ b/configure
@@ -226,7 +226,12 @@ then
     putvar CFG_BAD_VALGRIND
 fi
 
-if [ ! -z "$CFG_LLVM_ROOT" ]
+if [ ! -z "$CFG_LLVM_ROOT" -a -e "$CFG_LLVM_ROOT/bin/llvm-config" ]
+then
+    CFG_LLVM_CONFIG="$CFG_LLVM_ROOT/bin/llvm-config"
+fi
+
+if [ ! -z "$CFG_LLVM_ROOT" -a -z "$CFG_LLVM_CONFIG" ]
 then
     CFG_LLVM_INCDIR="$CFG_LLVM_ROOT/include"
     CFG_LLVM_BINDIR="$CFG_LLVM_ROOT/bin"
@@ -247,14 +252,14 @@ then
                       | cut -d ' ' -f 4-)
 elif [ ! -z "$CFG_LLVM_CONFIG" ]
 then
-    CFG_LLVM_VERSION=$(llvm-config --version)
-    CFG_LLVM_INCDIR=$(llvm-config --includedir)
-    CFG_LLVM_BINDIR=$(llvm-config --bindir)
-    CFG_LLVM_LIBDIR=$(llvm-config --libdir)
-    CFG_LLVM_CXXFLAGS=$(llvm-config --cxxflags)
-    CFG_LLVM_LDFLAGS=$(llvm-config --ldflags)
-    CFG_LLVM_LIBS=$(llvm-config --libs)
-    CFG_LLVM_TRIPLE=$(llvm-config --host-target)
+    CFG_LLVM_VERSION=$($CFG_LLVM_CONFIG --version)
+    CFG_LLVM_INCDIR=$($CFG_LLVM_CONFIG --includedir)
+    CFG_LLVM_BINDIR=$($CFG_LLVM_CONFIG --bindir)
+    CFG_LLVM_LIBDIR=$($CFG_LLVM_CONFIG --libdir)
+    CFG_LLVM_CXXFLAGS=$($CFG_LLVM_CONFIG --cxxflags)
+    CFG_LLVM_LDFLAGS=$($CFG_LLVM_CONFIG --ldflags)
+    CFG_LLVM_LIBS=$($CFG_LLVM_CONFIG --libs)
+    CFG_LLVM_TRIPLE=$($CFG_LLVM_CONFIG --host-target)
 else
     err "either the \"CFG_LLVM_ROOT\" environment variable must be set, or a \
 \"llvm-config\" script must be present"

--- a/configure
+++ b/configure
@@ -274,6 +274,23 @@ case $CFG_LLVM_VERSION in
     ;;
 esac
 
+if [ ! -z "$CFG_CLANG" ]
+then
+    CFG_CLANG_VERSION=$("$CFG_CLANG" \
+                      --version \
+                      | grep version \
+                      | cut -d ' ' -f 3)
+
+    case $CFG_CLANG_VERSION in
+        (3.0svn | 3.0)
+        step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
+        ;;
+        (*)
+        err "bad CLANG version: $CFG_CLANG_VERSION, need >=3.0svn"
+        ;;
+    esac
+fi
+
 putvar CFG_LLVM_ROOT
 putvar CFG_LLVM_INCDIR
 putvar CFG_LLVM_BINDIR

--- a/mk/stage1.mk
+++ b/mk/stage1.mk
@@ -16,7 +16,7 @@ stage1/librustc.o: $(COMPILER_CRATE) $(COMPILER_INPUTS) $(SREQ0)
 stage1/$(CFG_RUSTCLIB): stage1/librustc.o stage1/glue.o
 	@$(call E, link: $@)
 	$(Q)gcc $(CFG_GCCISH_CFLAGS) stage1/glue.o $(CFG_GCCISH_LINK_FLAGS) \
-	-o $@ $< -Lstage1 -Lrt -lrustrt
+	-o $@ $< -Lstage1 -Lrustllvm -Lrt -lrustrt -lrustllvm -lstd
 
 stage1/rustc.o: $(COMPILER_CRATE) $(COMPILER_INPUTS) $(SREQ0)
 	@$(call E, compile: $@)

--- a/mk/stage2.mk
+++ b/mk/stage2.mk
@@ -16,7 +16,7 @@ stage2/librustc.o: $(COMPILER_CRATE) $(COMPILER_INPUTS) $(SREQ1)
 stage2/$(CFG_RUSTCLIB): stage2/librustc.o stage2/glue.o
 	@$(call E, link: $@)
 	$(Q)gcc $(CFG_GCCISH_CFLAGS) stage2/glue.o $(CFG_GCCISH_LINK_FLAGS) \
-	-o $@ $< -Lstage2 -Lrt -lrustrt
+	-o $@ $< -Lstage2 -Lrustllvm -Lrt -lrustrt -lrustllvm -lstd
 
 stage2/rustc.o: $(COMPILER_CRATE) $(COMPILER_INPUTS) $(SREQ1)
 	@$(call E, compile: $@)

--- a/mk/stage3.mk
+++ b/mk/stage3.mk
@@ -16,7 +16,7 @@ stage3/librustc.o: $(COMPILER_CRATE) $(COMPILER_INPUTS) $(SREQ2)
 stage3/$(CFG_RUSTCLIB): stage3/librustc.o stage3/glue.o
 	@$(call E, link: $@)
 	$(Q)gcc $(CFG_GCCISH_CFLAGS) stage3/glue.o $(CFG_GCCISH_LINK_FLAGS) \
-	-o $@ $< -Lstage3 -Lrt -lrustrt
+	-o $@ $< -Lstage3 -Lrustllvm -Lrt -lrustrt -lrustllvm -lstd
 
 stage3/rustc.o: $(COMPILER_CRATE) $(COMPILER_INPUTS) $(SREQ2)
 	@$(call E, compile: $@)


### PR DESCRIPTION
Good morning. These two patches fix some problems I was having with the build system:
- if it finds an llvm-config inside `CFG_LLVM_ROOT`, it will use it to determine the cxxflags and ldflags. This was needed to get macros like `__STDC_LIMIT_MACROS` defined properly. If it doesn't find one, it falls back to the old behavior for windows.
- It errors the configuration if it finds an old clang (<3.0svn). Rust currently depends on an unreleased clang fix for flexible arrays that's used in `src/rt/rust_builtins.cpp`. It's possible that instead of erroring out the build system should just fall back onto gcc. Would that be better?
