### PR TITLE
Spawn Work

### DIFF
--- a/src/comp/back/upcall.rs
+++ b/src/comp/back/upcall.rs
@@ -113,7 +113,7 @@ fn declare_upcalls(type_names tn, ModuleRef llmod) -> @upcalls {
                         T_ptr(T_tydesc(tn))),
         new_task=d("new_task", [T_ptr(T_str())], T_taskptr(tn)),
         start_task=d("start_task", [T_taskptr(tn), 
-                                    T_int(), T_int(), T_size_t()],
+                                    T_int(), T_int()],
                      T_taskptr(tn)),
         new_thread=d("new_thread", [T_ptr(T_i8())], T_taskptr(tn)),
         start_thread=d("start_thread", [T_taskptr(tn), T_int(), T_int(),

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -5949,7 +5949,6 @@ fn mk_spawn_wrapper(&@block_ctxt cx,
                     &ty::t args_ty) -> result {
     auto llmod = cx.fcx.lcx.ccx.llmod;
     let TypeRef args_ty_tref = type_of(cx.fcx.lcx.ccx, cx.sp, args_ty);
-    //let TypeRef wrapper_fn_type = T_fn([args_ty_tref], T_void());
 
     let TypeRef wrapper_fn_type =
         type_of_fn(cx.fcx.lcx.ccx, cx.sp, ast::proto_fn,
@@ -5963,8 +5962,8 @@ fn mk_spawn_wrapper(&@block_ctxt cx,
                  ty_str(cx.fcx.lcx.ccx.tn, wrapper_fn_type));
 
     // TODO: construct a name based on tname
-    auto llfndecl = decl_cdecl_fn(llmod, "spawn_wrap",
-                                  wrapper_fn_type);
+    auto llfndecl = decl_fastcall_fn(llmod, "spawn_wrap",
+                                     wrapper_fn_type);
 
     log_err #fmt("spawn wrapper decl type: %s", 
                  val_str(cx.fcx.lcx.ccx.tn, llfndecl));
@@ -6028,10 +6027,10 @@ fn mk_spawn_wrapper(&@block_ctxt cx,
         i += 1;
     }
 
-    fbcx.build.Call(llfn,
-                    child_args);
+    fbcx.build.FastCall(llfn,
+                        child_args);
     fbcx.build.RetVoid();
-
+    
     finish_fn(fcx, fbcx.llbb);
 
     // TODO: make sure we clean up everything we need to.

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -5882,9 +5882,7 @@ fn trans_spawn(&@block_ctxt cx,
                                      e));
     }
 
-    // Make the tuple. We have to reverse the types first though.
-    //vec::reverse[ty::t](arg_tys);
-    //vec::reverse[ValueRef](arg_vals);
+    // Make the tuple.
     auto args_ty = ty::mk_imm_tup(cx.fcx.lcx.ccx.tcx, arg_tys);
     
     // Allocate and fill the tuple.

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -5855,11 +5855,6 @@ fn trans_spawn(&@block_ctxt cx,
         }
     };
 
-    // dump a bunch of information
-    log_err "Translating Spawn " +
-        "(The compiled program is not actually running yet, don't worry!";
-    log_err #fmt("task name: %s", tname);
-
     // Generate code
     //
     // This is a several step process. The following things need to happen
@@ -5920,20 +5915,8 @@ fn trans_spawn(&@block_ctxt cx,
 
     // But first, we'll create a task.
     let ValueRef lltname = C_str(bcx.fcx.lcx.ccx, tname);
-    log_err #fmt("ty(new_task) = %s",
-                 val_str(bcx.fcx.lcx.ccx.tn, 
-                         bcx.fcx.lcx.ccx.upcalls.new_task));
-    log_err #fmt("ty(lltaskptr) = %s",
-                 val_str(bcx.fcx.lcx.ccx.tn, 
-                         bcx.fcx.lltaskptr));
-    log_err #fmt("ty(lltname) = %s",
-                 val_str(bcx.fcx.lcx.ccx.tn, 
-                         lltname));
-
-    log_err "Building upcall_new_task";
     auto new_task = bcx.build.Call(bcx.fcx.lcx.ccx.upcalls.new_task,
                               [bcx.fcx.lltaskptr, lltname]);
-    log_err "Done";
 
     // Okay, start the task.
     // First we find the function
@@ -5955,29 +5938,9 @@ fn trans_spawn(&@block_ctxt cx,
 
     auto args_size = size_of(bcx, args_ty).val;
 
-    log_err "Building call to start_task";
-    log_err #fmt("ty(start_task) = %s", 
-                 val_str(bcx.fcx.lcx.ccx.tn,
-                         bcx.fcx.lcx.ccx.upcalls.start_task));
-    log_err #fmt("ty(lltaskptr) = %s", 
-                 val_str(bcx.fcx.lcx.ccx.tn,
-                         bcx.fcx.lltaskptr));
-    log_err #fmt("ty(new_task) = %s", 
-                 val_str(bcx.fcx.lcx.ccx.tn,
-                         new_task));
-    log_err #fmt("ty(llfnptr) = %s", 
-                 val_str(bcx.fcx.lcx.ccx.tn,
-                         llfnptr_i));
-    log_err #fmt("ty(llargs) = %s", 
-                 val_str(bcx.fcx.lcx.ccx.tn,
-                         llargs_i));
-    log_err #fmt("ty(args_size) = %s", 
-                 val_str(bcx.fcx.lcx.ccx.tn,
-                         args_size));
     bcx.build.Call(bcx.fcx.lcx.ccx.upcalls.start_task,
                    [bcx.fcx.lltaskptr, new_task,
                     llfnptr_i, llargs_i, args_size]);
-    log_err "Done";
 
     /*
     alt(dom) {

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -5932,8 +5932,12 @@ fn trans_spawn(&@block_ctxt cx,
     auto llfnptr = bcx.build.GEP(fnptr.val,
                                  [C_int(0), C_int(0)]);
     log_err "Casting llfnptr";
-    auto llfnptr_i = bcx.build.PointerCast(llfnptr,
-                                    T_int());
+    auto llfnptrptr_i = bcx.build.PointerCast(llfnptr,
+                                              T_ptr(T_int()));
+    // We'd better dereference this one more time, since that one points into
+    // the symbol table or something.
+    auto llfnptr_i = bcx.build.Load(llfnptrptr_i);
+
     log_err "Cassting llargs";
     auto llargs_i = bcx.build.PointerCast(llargs.val,
                                    T_int());

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -951,6 +951,7 @@ fn type_is_boxed(&ctxt cx, &t ty) -> bool {
         case (ty_box(_)) { ret true; }
         case (ty_port(_)) { ret true; }
         case (ty_chan(_)) { ret true; }
+        case (ty_task) { ret true; }
         case (_) { ret false; }
     }
     fail;

--- a/src/rt/rust_task.cpp
+++ b/src/rt/rust_task.cpp
@@ -171,12 +171,7 @@ rust_task::start(uintptr_t spawnee_fn,
     src += 1;                  // spawn-call task slot
     src += 1;                  // spawn-call closure-or-obj slot
 
-    spp -= (args_size / sizeof(uintptr_t)) - 1;
-    memmove(spp, src, args_size);
-    spp--;
-
-    //*spp-- = (uintptr_t) *src;       // vec
-    
+    *spp-- = (uintptr_t) *src;       // vec
     *spp-- = (uintptr_t) 0x0;        // closure-or-obj
     *spp-- = (uintptr_t) this;       // task
     *spp-- = (uintptr_t) dummy_ret;  // output address

--- a/src/rt/rust_task.cpp
+++ b/src/rt/rust_task.cpp
@@ -171,14 +171,18 @@ rust_task::start(uintptr_t spawnee_fn,
     src += 1;                  // spawn-call task slot
     src += 1;                  // spawn-call closure-or-obj slot
 
-    *spp-- = (uintptr_t) *src;       // vec
+    spp -= (args_size / sizeof(uintptr_t)) - 1;
+    memmove(spp, src, args_size);
+    spp--;
+
+    //*spp-- = (uintptr_t) *src;       // vec
+    
     *spp-- = (uintptr_t) 0x0;        // closure-or-obj
     *spp-- = (uintptr_t) this;       // task
     *spp-- = (uintptr_t) dummy_ret;  // output address
 
     I(dom, spp == align_down(spp));
     *spp-- = (uintptr_t) (uintptr_t) spawnee_fn;
-
 
     *spp-- = (uintptr_t) 0x0;        // retp
 

--- a/src/rt/rust_upcall.cpp
+++ b/src/rt/rust_upcall.cpp
@@ -466,17 +466,21 @@ extern "C" CDECL rust_task *
 upcall_start_task(rust_task *spawner,
                   rust_task *task,
                   uintptr_t spawnee_fn,
-                  uintptr_t args,
-                  size_t callsz) {
+                  uintptr_t args) {
     LOG_UPCALL_ENTRY(spawner);
 
     rust_dom *dom = spawner->dom;
     DLOG(dom, task,
-             "upcall start_task(task %s @0x%" PRIxPTR
-             ", spawnee 0x%" PRIxPTR
-             ", callsz %" PRIdPTR ")", task->name, task,
-             spawnee_fn, callsz);
-    task->start(spawnee_fn, args, callsz);
+         "upcall start_task(task %s @0x%" PRIxPTR
+         ", spawnee 0x%" PRIxPTR ")", 
+         task->name, task,
+         spawnee_fn);
+
+    // we used to be generating this tuple in rustc, but it's easier to do it
+    // here.
+    uintptr_t start_args[] = {0, 0, 0, args};
+    
+    task->start(spawnee_fn, (uintptr_t)&start_args, sizeof(start_args));
     return task;
 }
 

--- a/src/rt/rust_upcall.cpp
+++ b/src/rt/rust_upcall.cpp
@@ -480,7 +480,7 @@ upcall_start_task(rust_task *spawner,
     // here.
     uintptr_t start_args[] = {0, 0, 0, args};
     
-    task->start(spawnee_fn, (uintptr_t)&start_args, sizeof(start_args));
+    task->start(spawnee_fn, (uintptr_t)start_args, sizeof(start_args));
     return task;
 }
 

--- a/src/test/run-pass/spawn.rs
+++ b/src/test/run-pass/spawn.rs
@@ -1,6 +1,4 @@
 // xfail-stage0
-// xfail-stage1
-// xfail-stage2
 // -*- rust -*-
 
 fn main() {

--- a/src/test/run-pass/spawn.rs
+++ b/src/test/run-pass/spawn.rs
@@ -8,6 +8,6 @@ fn main() {
 }
 
 fn child(int i) {
-   log i;
+   log_err i;
 }
 

--- a/src/test/run-pass/spawn.rs
+++ b/src/test/run-pass/spawn.rs
@@ -4,7 +4,7 @@
 // -*- rust -*-
 
 fn main() {
-  spawn child(10);
+  auto t = spawn child(10);
 }
 
 fn child(int i) {

--- a/src/test/run-pass/spawn.rs
+++ b/src/test/run-pass/spawn.rs
@@ -2,11 +2,11 @@
 // -*- rust -*-
 
 fn main() {
-  auto t = spawn child(10);
+    auto t = spawn child(10);
 }
 
 fn child(int i) {
-   log_err i;
+    log_err i;
 }
 
 // Local Variables:

--- a/src/test/run-pass/spawn.rs
+++ b/src/test/run-pass/spawn.rs
@@ -9,3 +9,11 @@ fn child(int i) {
    log_err i;
 }
 
+// Local Variables:
+// mode: rust;
+// fill-column: 78;
+// indent-tabs-mode: nil
+// c-basic-offset: 4
+// buffer-file-coding-system: utf-8-unix
+// compile-command: "make -k -C .. 2>&1 | sed -e 's/\\/x\\//x:\\//g'";
+// End:

--- a/src/test/run-pass/spawn2.rs
+++ b/src/test/run-pass/spawn2.rs
@@ -2,10 +2,35 @@
 // -*- rust -*-
 
 fn main() {
-  spawn child(10, 20);
+  spawn child(10, 20, 30, 40, 50, 60, 70, 80, 90);
 }
 
-fn child(int i, int j) {
-  log_err i;
-  log_err j;
+fn child(int i1,
+         int i2,
+         int i3,
+         int i4,
+         int i5,
+         int i6,
+         int i7,
+         int i8,
+         int i9) 
+{
+  log_err i1;
+  log_err i2;
+  log_err i3;
+  log_err i4;
+  log_err i5;
+  log_err i6;
+  log_err i7;
+  log_err i8;
+  log_err i9;
 }
+
+// Local Variables:
+// mode: rust;
+// fill-column: 78;
+// indent-tabs-mode: nil
+// c-basic-offset: 4
+// buffer-file-coding-system: utf-8-unix
+// compile-command: "make -k -C .. 2>&1 | sed -e 's/\\/x\\//x:\\//g'";
+// End:

--- a/src/test/run-pass/spawn2.rs
+++ b/src/test/run-pass/spawn2.rs
@@ -1,0 +1,15 @@
+// xfail-stage0
+// xfail-stage1
+// xfail-stage2
+// -*- rust -*-
+
+use std;
+
+fn main() {
+  spawn child(10, 20);
+}
+
+fn child(int i, int j) {
+  log_err i;
+  log_err j;
+}

--- a/src/test/run-pass/spawn2.rs
+++ b/src/test/run-pass/spawn2.rs
@@ -1,9 +1,5 @@
 // xfail-stage0
-// xfail-stage1
-// xfail-stage2
 // -*- rust -*-
-
-use std;
 
 fn main() {
   spawn child(10, 20);


### PR DESCRIPTION
Arguments find their way to the child task, even using multiple arguments!

Refcounting for spawned tasks seems to work slightly better now, so programs using tasks will terminate.
