### PR TITLE
Issue #448 - Multiline strings

### DIFF
--- a/src/comp/front/lexer.rs
+++ b/src/comp/front/lexer.rs
@@ -632,6 +632,9 @@ fn next_token(&reader rdr) -> token::token {
                             case ('"') {
                                 str::push_byte(accum_str, '"' as u8);
                             }
+                            case ('\n') {
+                                consume_whitespace(rdr);
+                            }
 
                             case ('x') {
                                 str::push_char(accum_str,

--- a/src/test/run-pass/str-multiline.rs
+++ b/src/test/run-pass/str-multiline.rs
@@ -1,0 +1,15 @@
+// -*- rust -*-
+
+use std;
+import std::str;
+
+fn main() {
+  let str a = "this \
+is a test";
+  let str b = "this \
+               is \
+               another \
+               test";
+  assert (str::eq(a, "this is a test"));
+  assert (str::eq(b, "this is another test"));
+}


### PR DESCRIPTION
This seemed like an easy way to get involved. This patch adds the ability to write strings like "a \
     b \
c" and have them turn into "a b c".
