### PR TITLE
Update RustWrapper.cpp so that LLVM revision 134231 from June 30, 2011 at

### DIFF
--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -85,7 +85,9 @@ extern "C" void LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
   std::string Err;
   const Target *TheTarget = TargetRegistry::lookupTarget(triple, Err);
   std::string FeaturesStr;
-  TargetMachine *Target = TheTarget->createTargetMachine(triple, FeaturesStr);
+  std::string Trip(triple);
+  std::string CPUStr = llvm::sys::getHostCPUName();
+  TargetMachine *Target = TheTarget->createTargetMachine(Trip, CPUStr, FeaturesStr);
   bool NoVerify = false;
   PassManager *PM = unwrap<PassManager>(PMR);
   std::string ErrorInfo;


### PR DESCRIPTION
Update RustWrapper.cpp so that LLVM revision 134231 from June 30, 2011 at 22:15 GMT, works.
