### PR TITLE
Autoderef calls

### DIFF
--- a/src/comp/middle/alias.rs
+++ b/src/comp/middle/alias.rs
@@ -663,7 +663,7 @@ fn def_is_local(&ast::def d, bool objfields_count) -> bool {
 }
 
 fn fty_args(&ctx cx, ty::t fty) -> ty::arg[] {
-    ret alt (ty::struct(*cx.tcx, fty)) {
+    ret alt (ty::struct(*cx.tcx, ty::type_autoderef(*cx.tcx, fty))) {
             case (ty::ty_fn(_, ?args, _, _, _)) { args }
             case (ty::ty_native_fn(_, ?args, _)) { args }
         };

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -3367,7 +3367,7 @@ fn trans_compare(&@block_ctxt cx0, ast::binop op, &ty::t t0, ValueRef lhs0,
     auto rhs_r = autoderef(cx, rhs0, t0);
     auto rhs = rhs_r.val;
     cx = rhs_r.bcx;
-    auto t = autoderefed_ty(cx.fcx.lcx.ccx, t0);
+    auto t = ty::type_autoderef(cx.fcx.lcx.ccx.tcx, t0);
     // Determine the operation we need.
     // FIXME: Use or-patterns when we have them.
 
@@ -4126,17 +4126,6 @@ fn autoderef(&@block_ctxt cx, ValueRef v, &ty::t t) -> result {
     ret rslt(cx, v1);
 }
 
-fn autoderefed_ty(&@crate_ctxt ccx, &ty::t t) -> ty::t {
-    let ty::t t1 = t;
-    while (true) {
-        alt (ty::struct(ccx.tcx, t1)) {
-            case (ty::ty_box(?mt)) { t1 = mt.ty; }
-            case (_) { break; }
-        }
-    }
-    ret t1;
-}
-
 fn trans_binary(&@block_ctxt cx, ast::binop op, &@ast::expr a, &@ast::expr b)
    -> result {
 
@@ -4199,7 +4188,7 @@ fn trans_binary(&@block_ctxt cx, ast::binop op, &@ast::expr a, &@ast::expr b)
             auto rhty = ty::expr_ty(cx.fcx.lcx.ccx.tcx, b);
             rhs = autoderef(rhs.bcx, rhs.val, rhty);
             ret trans_eager_binop(rhs.bcx, op,
-                                  autoderefed_ty(cx.fcx.lcx.ccx, lhty),
+                                  ty::type_autoderef(cx.fcx.lcx.ccx.tcx,lhty),
                                   lhs.val, rhs.val);
         }
     }
@@ -4910,7 +4899,7 @@ fn trans_path(&@block_ctxt cx, &ast::path p, ast::node_id id) -> lval_result {
 fn trans_field(&@block_ctxt cx, &span sp, ValueRef v, &ty::t t0,
                &ast::ident field, ast::node_id id) -> lval_result {
     auto r = autoderef(cx, v, t0);
-    auto t = autoderefed_ty(cx.fcx.lcx.ccx, t0);
+    auto t = ty::type_autoderef(cx.fcx.lcx.ccx.tcx, t0);
     alt (ty::struct(cx.fcx.lcx.ccx.tcx, t)) {
         case (ty::ty_tup(_)) {
             let uint ix = ty::field_num(cx.fcx.lcx.ccx.sess, sp, field);

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -176,6 +176,7 @@ export type_is_copyable;
 export type_is_tup_like;
 export type_is_str;
 export type_owns_heap_mem;
+export type_autoderef;
 export type_param;
 export def_to_str;
 export unify;
@@ -1279,6 +1280,17 @@ fn type_param(&ctxt cx, &t ty) -> option::t[uint] {
         case (_) {/* fall through */ }
     }
     ret none[uint];
+}
+
+fn type_autoderef(&ctxt cx, &ty::t t) -> ty::t {
+    let ty::t t1 = t;
+    while (true) {
+        alt (struct(cx, t1)) {
+            case (ty::ty_box(?mt)) { t1 = mt.ty; }
+            case (_) { break; }
+        }
+    }
+    ret t1;
 }
 
 fn def_to_str(&ast::def_id did) -> str { ret #fmt("%d:%d", did._0, did._1); }

--- a/src/test/compile-fail/auto-deref-bind.rs
+++ b/src/test/compile-fail/auto-deref-bind.rs
@@ -1,0 +1,7 @@
+// error-pattern: mismatched types
+
+fn add1(int i) -> int { ret i+1; }
+fn main() {
+    auto f = @add1;
+    auto g = bind f(5);
+}

--- a/src/test/run-pass/auto-deref-fn.rs
+++ b/src/test/run-pass/auto-deref-fn.rs
@@ -1,0 +1,11 @@
+// xfail-stage0
+
+fn add1(int i) -> int { ret i+1; }
+fn main() {
+    auto f = @add1;
+    auto g = @f;
+    auto h = @@@add1;
+    assert(f(5) == 6);
+    assert(g(8) == 9);
+    assert(h(0x1badd00d) == 0x1badd00e);
+}


### PR DESCRIPTION
Implement autoderef for function calls.

This is important since we are going to be making functions noncopyable
soon, which means we'll be seeing a lot of boxed functions.
(*f)(...) is really just too heavyweight.
