### PR TITLE
Print error lines and highlight error span

### DIFF
--- a/src/comp/driver/session.rs
+++ b/src/comp/driver/session.rs
@@ -11,6 +11,7 @@ import std::option;
 import std::option::some;
 import std::option::none;
 import std::str;
+import std::vec;
 
 tag os { os_win32; os_macos; os_linux; }
 
@@ -70,16 +71,62 @@ fn emit_diagnostic(option::t[span] sp, str msg, str kind, u8 color,
     io::stdout().write_str(#fmt(" %s\n", msg));
     alt (maybe_lines) {
         case (some(?lines)) {
+            // Print the offending lines
             auto rdr = io::file_reader(lines.name);
             auto file = str::unsafe_from_bytes(rdr.read_whole_stream());
             auto fm = codemap::get_filemap(cm, lines.name);
-            for (uint line in lines.lines) {
+
+            // arbitrarily only print up to six lines of the error
+            auto max_lines = 6u;
+            auto elided = false;
+            auto display_lines = lines.lines;
+            if (vec::len(display_lines) > max_lines) {
+                display_lines = vec::slice(display_lines, 0u, max_lines);
+                elided = true;
+            }
+            for (uint line in display_lines) {
                 io::stdout().write_str(#fmt("%s:%u ", fm.name, line + 1u));
                 auto s = codemap::get_line(fm, line as int, file);
                 if (!str::ends_with(s, "\n")) {
                     s += "\n";
                 }
                 io::stdout().write_str(s);
+            }
+            if (elided) {
+                auto last_line = display_lines.(vec::len(display_lines) - 1u);
+                auto s = #fmt("%s:%u ", fm.name, last_line + 1u);
+                auto indent = str::char_len(s);
+                auto out = "";
+                while (indent > 0u) { out += " "; indent -= 1u; }
+                out += "...\n";
+                io::stdout().write_str(out);
+            }
+
+            // If there's one line at fault we can easily point to the problem
+            if (vec::len(lines.lines) == 1u) {
+                auto lo = codemap::lookup_pos(cm, option::get(sp).lo);
+                auto digits = 0u;
+                auto num = lines.lines.(0) / 10u;
+
+                // how many digits must be indent past?
+                while (num > 0u) { num /= 10u; digits += 1u; }
+
+                // indent past |name:## | and the 0-offset column location
+                auto left = str::char_len(fm.name) + digits + lo.col + 3u;
+                auto s = "";
+                while (left > 0u) { str::push_char(s, ' '); left -= 1u; }
+
+                s += "^";
+                auto hi = codemap::lookup_pos(cm, option::get(sp).hi);
+                if (hi.col != lo.col) {
+                    // the ^ already takes up one space
+                    auto width = hi.col - lo.col - 1u;
+                    while (width > 0u) {
+                        str::push_char(s, '~');
+                        width -= 1u;
+                    }
+                }
+                io::stdout().write_str(s + "\n");
             }
         }
         case (_) {}

--- a/src/comp/driver/session.rs
+++ b/src/comp/driver/session.rs
@@ -71,7 +71,8 @@ fn emit_diagnostic(option::t[span] sp, str msg, str kind, u8 color,
     io::stdout().write_str(#fmt(" %s\n", msg));
     alt (maybe_lines) {
         case (some(?lines)) {
-            // Print the offending lines
+            // FIXME: reading in the entire file is the worst possible way to
+            //        get access to the necessary lines.
             auto rdr = io::file_reader(lines.name);
             auto file = str::unsafe_from_bytes(rdr.read_whole_stream());
             auto fm = codemap::get_filemap(cm, lines.name);
@@ -84,6 +85,7 @@ fn emit_diagnostic(option::t[span] sp, str msg, str kind, u8 color,
                 display_lines = vec::slice(display_lines, 0u, max_lines);
                 elided = true;
             }
+            // Print the offending lines
             for (uint line in display_lines) {
                 io::stdout().write_str(#fmt("%s:%u ", fm.name, line + 1u));
                 auto s = codemap::get_line(fm, line as int, file);

--- a/src/comp/front/codemap.rs
+++ b/src/comp/front/codemap.rs
@@ -49,7 +49,9 @@ fn get_line(filemap fm, int line, &str file) -> str {
     } else {
         end = fm.lines.(line + 1);
     }
-    ret str::slice(file, fm.lines.(line), end);
+    auto begin = fm.lines.(line) - fm.start_pos;
+    end -= fm.start_pos;
+    ret str::slice(file, begin, end);
 }
 
 fn get_filemap(codemap cm, str filename) -> filemap {

--- a/src/comp/front/codemap.rs
+++ b/src/comp/front/codemap.rs
@@ -1,5 +1,6 @@
 
 import std::vec;
+import std::str;
 
 
 /* A codemap is a thing that maps uints to file/line/column positions
@@ -39,6 +40,27 @@ fn lookup_pos(codemap map, uint pos) -> loc {
         if (f.lines.(m) > pos) { b = m; } else { a = m; }
     }
     ret rec(filename=f.name, line=a + 1u, col=pos - f.lines.(a));
+}
+
+fn get_line(filemap fm, int line, &str file) -> str {
+    let uint end;
+    if ((line as uint) + 1u >= vec::len(fm.lines)) {
+        end = str::byte_len(file);
+    } else {
+        end = fm.lines.(line + 1);
+    }
+    ret str::slice(file, fm.lines.(line), end);
+}
+
+fn get_filemap(codemap cm, str filename) -> filemap {
+    for (filemap fm in cm.files) {
+        if (fm.name == filename) {
+            ret fm;
+        }
+    }
+    //XXjdm the following triggers a mismatched type bug
+    //      (or expected function, found _|_)
+    fail;// ("asking for " + filename + " which we don't know about");
 }
 //
 // Local Variables:


### PR DESCRIPTION
This isn't necessarily a request to pull, but more a request for feedback.  This branch gives output like:

`../src/test/compile-fail/forgot-ret.rs:8:19:12:1: note: In function f, not all control paths return a value
../src/test/compile-fail/forgot-ret.rs:8 fn f(int a) -> int {
../src/test/compile-fail/forgot-ret.rs:9   if (god_exists(a)) {
../src/test/compile-fail/forgot-ret.rs:10     ret 5;
                                          ...`

`../src/test/compile-fail/for-loop-decl.rs:13:40:13:44: error: mismatched types: expected @tup(uint,tup(uint,uint)) but found @tup(uint,var_info) (types differ)
../src/test/compile-fail/for-loop-decl.rs:13   for each (@tup(uint, tup(uint, uint)) p in enclosing.vars.items()) {
                                                                                     ^~~~`

The ^~~~ extends for the full width of the error span, so it's easier to see when spans are larger than they should be as well.

The downside here is that I took the easy route for obtaining the file contents and just read in the entire file on demand whenever we print an error. I fully acknowledge that that's an awful thing to do, but I was having trouble figuring out a better way to acquire the file contents from the lexer from all the different possible places we could be throwing errors.
