### PR TITLE
Re-enable corrected error line printing and highlighting

### DIFF
--- a/src/comp/syntax/codemap.rs
+++ b/src/comp/syntax/codemap.rs
@@ -64,8 +64,7 @@ fn emit_diagnostic(&option::t[span] sp, &str msg, &str kind, u8 color,
         case (some(?ssp)) {
             ss = span_to_str(ssp, cm);
 
-            // FIXME: we're not able to look up lines read from .rc files yet.
-            // maybe_lines = some(span_to_lines(ssp, cm));
+            maybe_lines = some(span_to_lines(ssp, cm));
 
         }
         case (none) { }

--- a/src/comp/syntax/codemap.rs
+++ b/src/comp/syntax/codemap.rs
@@ -63,9 +63,7 @@ fn emit_diagnostic(&option::t[span] sp, &str msg, &str kind, u8 color,
     alt (sp) {
         case (some(?ssp)) {
             ss = span_to_str(ssp, cm);
-
             maybe_lines = some(span_to_lines(ssp, cm));
-
         }
         case (none) { }
     }
@@ -167,12 +165,12 @@ fn span_to_lines(span sp, codemap::codemap cm) -> @file_lines {
 }
 
 fn get_line(filemap fm, int line, &str file) -> str {
-    let uint begin = fm.lines.(line) - fm.lines.(0);
+    let uint begin = fm.lines.(line) - fm.start_pos;
     let uint end;
     if ((line as uint) + 1u >= vec::len(fm.lines)) {
         end = str::byte_len(file);
     } else {
-        end = fm.lines.(line + 1) - fm.lines.(0);
+        end = fm.lines.(line + 1) - fm.start_pos;
     }
     ret str::slice(file, begin, end);
 }

--- a/src/comp/syntax/codemap.rs
+++ b/src/comp/syntax/codemap.rs
@@ -85,7 +85,7 @@ fn emit_diagnostic(&option::t[span] sp, &str msg, &str kind, u8 color,
             //        get access to the necessary lines.
             auto rdr = io::file_reader(lines.name);
             auto file = str::unsafe_from_bytes(rdr.read_whole_stream());
-            auto fm = codemap::get_filemap(cm, lines.name);
+            auto fm = get_filemap(cm, lines.name);
 
             // arbitrarily only print up to six lines of the error
             auto max_lines = 6u;
@@ -98,7 +98,7 @@ fn emit_diagnostic(&option::t[span] sp, &str msg, &str kind, u8 color,
             // Print the offending lines
             for (uint line in display_lines) {
                 io::stdout().write_str(#fmt("%s:%u ", fm.name, line + 1u));
-                auto s = codemap::get_line(fm, line as int, file);
+                auto s = get_line(fm, line as int, file);
                 if (!str::ends_with(s, "\n")) {
                     s += "\n";
                 }
@@ -116,7 +116,7 @@ fn emit_diagnostic(&option::t[span] sp, &str msg, &str kind, u8 color,
 
             // If there's one line at fault we can easily point to the problem
             if (vec::len(lines.lines) == 1u) {
-                auto lo = codemap::lookup_pos(cm, option::get(sp).lo);
+                auto lo = lookup_pos(cm, option::get(sp).lo);
                 auto digits = 0u;
                 auto num = lines.lines.(0) / 10u;
 
@@ -129,7 +129,7 @@ fn emit_diagnostic(&option::t[span] sp, &str msg, &str kind, u8 color,
                 while (left > 0u) { str::push_char(s, ' '); left -= 1u; }
 
                 s += "^";
-                auto hi = codemap::lookup_pos(cm, option::get(sp).hi);
+                auto hi = lookup_pos(cm, option::get(sp).hi);
                 if (hi.col != lo.col) {
                     // the ^ already takes up one space
                     auto width = hi.col - lo.col - 1u;
@@ -168,13 +168,14 @@ fn span_to_lines(span sp, codemap::codemap cm) -> @file_lines {
 }
 
 fn get_line(filemap fm, int line, &str file) -> str {
+    let uint begin = fm.lines.(line) - fm.lines.(0);
     let uint end;
     if ((line as uint) + 1u >= vec::len(fm.lines)) {
         end = str::byte_len(file);
     } else {
-        end = fm.lines.(line + 1);
+        end = fm.lines.(line + 1) - fm.lines.(0);
     }
-    ret str::slice(file, fm.lines.(line), end);
+    ret str::slice(file, begin, end);
 }
 
 fn get_filemap(codemap cm, str filename) -> filemap {


### PR DESCRIPTION
make fast-check now works correctly, as does regular check.
