### PR TITLE
Push scheduler lock acquisition into rust_chan::send from its upcall

### DIFF
--- a/src/rt/rust_chan.cpp
+++ b/src/rt/rust_chan.cpp
@@ -70,6 +70,7 @@ void rust_chan::disassociate() {
  * Attempt to send data to the associated port.
  */
 void rust_chan::send(void *sptr) {
+    scoped_lock with(task->kernel->scheduler_lock);
     buffer.enqueue(sptr);
 
     rust_scheduler *sched = task->sched;


### PR DESCRIPTION
This is useful for native code which wants to send things on channels.
