### PR TITLE
Build stage0/lib/libstd.so using the stage0 compiler.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -226,8 +226,8 @@ config.mk: $(S)configure $(S)Makefile.in $(S)src/snapshots.txt
 ######################################################################
 
 include $(CFG_SRC_DIR)/mk/intrinsics.mk
-include $(CFG_SRC_DIR)/mk/stage0.mk
 include $(CFG_SRC_DIR)/mk/stageN.mk
+include $(CFG_SRC_DIR)/mk/stage0.mk
 include $(CFG_SRC_DIR)/mk/rt.mk
 include $(CFG_SRC_DIR)/mk/rustllvm.mk
 include $(CFG_SRC_DIR)/mk/autodep.mk

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -35,6 +35,8 @@ stage0/lib/main.o: rt/main.o
 stage0/lib/$(CFG_RUNTIME): stage0/rustc$(X)
 	$(Q)touch $@
 
-# stage0/lib/$(CFG_STDLIB) and stage0/lib/libstd.rlib rules are generated
-# in stageN.mk
+# Instantiate template (in stageN.mk) for building
+# stage0/lib/$(CFG_STDLIB) and stage0/lib/libstd.rlib.
+SREQpre = stage0/lib/main.o $(MKFILES)
+$(eval $(call STDLIBGEN,pre,0))
 

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -1,18 +1,21 @@
+# FIXME: temporary hack: stdlib comes in the lib/ directory, but we want it in
+# the base directory, so we move it out.
 stage0/rustc$(X): $(S)src/snapshots.txt $(S)src/etc/get-snapshot.py $(MKFILES)
 	@$(call E, fetch: $@)
 	$(Q)$(S)src/etc/get-snapshot.py
+	$(Q)mv stage0/lib/$(CFG_STDLIB) stage0/$(CFG_STDLIB)
 	$(Q)touch $@
 
 # Host libs will be made in the process of making rustc above.
 
-# FIXME: temporary hack: the first two are currently carried in
-# lib/ directory only, so we copy them out.
+# FIXME: temporary hack: the runtime is currently carried in
+# lib/ directory only, so we copy it out.
 
 stage0/$(CFG_RUNTIME): stage0/lib/$(CFG_RUNTIME)
 	$(Q)cp $< $@
 
-stage0/$(CFG_STDLIB): stage0/lib/$(CFG_STDLIB)
-	$(Q)cp $< $@
+stage0/$(CFG_STDLIB): stage0/rustc$(X)
+	$(Q)touch $@
 
 stage0/$(CFG_RUSTLLVM): stage0/rustc$(X)
 	$(Q)touch $@
@@ -28,11 +31,10 @@ stage0/lib/glue.o: stage0/rustc$(X)
 stage0/lib/main.o: rt/main.o
 	$(Q)cp $< $@
 
+
 stage0/lib/$(CFG_RUNTIME): stage0/rustc$(X)
 	$(Q)touch $@
 
-stage0/lib/$(CFG_STDLIB): stage0/rustc$(X)
-	$(Q)touch $@
+# stage0/lib/$(CFG_STDLIB) and stage0/lib/libstd.rlib rules are generated
+# in stageN.mk
 
-stage0/lib/libstd.rlib: stage0/rustc$(X)
-	$(Q)touch $@

--- a/mk/stageN.mk
+++ b/mk/stageN.mk
@@ -96,10 +96,6 @@ stage$(2)/lib/$$(CFG_LIBRUSTC): $$(COMPILER_CRATE) $$(COMPILER_INPUTS) \
 
 endef
 
-# Instantiate template for building initial stdlib
-SREQpre = stage0/lib/main.o $(MKFILES)
-$(eval $(call STDLIBGEN,pre,0))
-
 # Instantiate template for 0->1, 1->2, 2->3 build dirs
 
 $(eval $(call STAGEN,0,1))

--- a/mk/stageN.mk
+++ b/mk/stageN.mk
@@ -2,6 +2,29 @@
 #
 # The easiest way to read this template is to assume we're building stage2
 # using stage1, and mentally gloss $(1) as 1, $(2) as 2.
+#
+# STDLIBGEN is pulled out seperately because we need to specially invoke
+# it to build stage0/lib/libstd using stage0/rustc.
+
+define STDLIBGEN
+stage$(2)/lib/$$(CFG_STDLIB): $$(STDLIB_CRATE) $$(STDLIB_INPUTS) \
+                              stage$(2)/rustc$$(X)               \
+                              stage$(2)/$$(CFG_RUNTIME)          \
+                              stage$(2)/$$(CFG_RUSTLLVM)         \
+                              stage$(2)/lib/glue.o               \
+                              $$(SREQ$(1))
+	@$$(call E, compile_and_link: $$@)
+	$$(STAGE$(2))  --lib -o $$@ $$<
+
+stage$(2)/lib/libstd.rlib: $$(STDLIB_CRATE) $$(STDLIB_INPUTS) \
+                           stage$(2)/rustc$$(X)               \
+                           stage$(2)/$$(CFG_RUNTIME)          \
+                           stage$(2)/$$(CFG_RUSTLLVM)         \
+                           stage$(2)/lib/glue.o               \
+                           $$(SREQ$(1))
+	@$$(call E, compile_and_link: $$@)
+	$$(STAGE$(2)) --lib --static -o $$@ $$<
+endef
 
 define STAGEN
 
@@ -56,24 +79,7 @@ stage$(2)/lib/glue.o: stage$(2)/rustc$$(X)        \
 	@$$(call E, generate: $$@)
 	$$(STAGE$(2)) -c -o $$@ --glue
 
-stage$(2)/lib/$$(CFG_STDLIB): $$(STDLIB_CRATE) $$(STDLIB_INPUTS) \
-                              stage$(2)/rustc$$(X)               \
-                              stage$(2)/$$(CFG_RUNTIME)          \
-                              stage$(2)/$$(CFG_RUSTLLVM)         \
-                              stage$(2)/lib/glue.o               \
-                              $$(SREQ$(1))
-	@$$(call E, compile_and_link: $$@)
-	$$(STAGE$(2))  --lib -o $$@ $$<
-
-stage$(2)/lib/libstd.rlib: $$(STDLIB_CRATE) $$(STDLIB_INPUTS) \
-                           stage$(2)/rustc$$(X)               \
-                           stage$(2)/$$(CFG_RUNTIME)          \
-                           stage$(2)/$$(CFG_RUSTLLVM)         \
-                           stage$(2)/lib/glue.o               \
-                           $$(SREQ$(1))
-	@$$(call E, compile_and_link: $$@)
-	$$(STAGE$(2)) --lib --static -o $$@ $$<
-
+$(eval $(call STDLIBGEN,$(1),$(2)))
 
 stage$(2)/lib/main.o: rt/main.o
 	@$$(call E, cp: $$@)
@@ -89,6 +95,10 @@ stage$(2)/lib/$$(CFG_LIBRUSTC): $$(COMPILER_CRATE) $$(COMPILER_INPUTS) \
 	$$(STAGE$(2)) --lib -o $$@ $$<
 
 endef
+
+# Instantiate template for building initial stdlib
+SREQpre = stage0/lib/main.o $(MKFILES)
+$(eval $(call STDLIBGEN,pre,0))
 
 # Instantiate template for 0->1, 1->2, 2->3 build dirs
 

--- a/src/etc/snapshot.py
+++ b/src/etc/snapshot.py
@@ -16,11 +16,11 @@ download_dir_base = "dl"
 download_unpack_base = os.path.join(download_dir_base, "unpack")
 
 snapshot_files = {
-    "linux": ["rustc", "lib/glue.o", "lib/libstd.so", "lib/libstd.rlib",
+    "linux": ["rustc", "lib/glue.o", "lib/libstd.so",
               "lib/librustrt.so", "librustllvm.so", "lib/intrinsics.bc"],
-    "macos": ["rustc", "lib/glue.o", "lib/libstd.dylib", "lib/libstd.rlib",
+    "macos": ["rustc", "lib/glue.o", "lib/libstd.dylib",
               "lib/librustrt.dylib", "librustllvm.dylib", "lib/intrinsics.bc"],
-    "winnt": ["rustc.exe", "lib/glue.o", "lib/std.dll", "lib/libstd.rlib",
+    "winnt": ["rustc.exe", "lib/glue.o", "lib/std.dll",
               "lib/rustrt.dll", "rustllvm.dll", "lib/intrinsics.bc"]
     }
 


### PR DESCRIPTION
This essentially starts the bootstrapping one step earlier by building
the stdlib from source using the stage0 compiler and then using that
stdlib to build the stage1 compiler. (Instead of starting by building
the stage1 compiler and then building a stdlib with it).

This means we should now be able to add features to the stdlib and use
them in the compiler without having to do a snapshot. (On the flip
side, this means that we now need to do a snapshot if we want to use a
new language feature in the stdlib, but that doesn't really seem too
burdensome (we already need to snapshot if we want to use a new
language feature in the compiler)).
