### PR TITLE
Fix a typo in lock_and_signal.cpp

### DIFF
--- a/src/rt/sync/lock_and_signal.cpp
+++ b/src/rt/sync/lock_and_signal.cpp
@@ -78,7 +78,7 @@ bool lock_and_signal::timed_wait(size_t timeout_in_ms) {
     EnterCriticalSection(&_cs);
     _holding_thread = GetCurrentThreadId();
 #else
-    if (timeout_in_ns == 0) {
+    if (timeout_in_ms == 0) {
         CHECKED(pthread_cond_wait(&_cond, &_mutex));
     } else {
         timeval time_val;


### PR DESCRIPTION
Just noticed that there's a typo in lock_and_signal.cpp has a typo that breaks the build. This patch should fix the problem though.
