### PR TITLE
Exposing STDERR to rust

### DIFF
--- a/src/lib/io.rs
+++ b/src/lib/io.rs
@@ -4,6 +4,7 @@ import os::libc;
 native "rust" mod rustrt {
     fn rust_get_stdin() -> os::libc::FILE;
     fn rust_get_stdout() -> os::libc::FILE;
+    fn rust_get_stderr() -> os::libc::FILE;
 }
 
 
@@ -374,6 +375,7 @@ fn buffered_file_buf_writer(path: &istr) -> buf_writer {
 
 // FIXME it would be great if this could be a const
 fn stdout() -> writer { ret new_writer(fd_buf_writer(1, option::none)); }
+fn stderr() -> writer { ret new_writer(fd_buf_writer(2, option::none)); }
 
 type str_writer =
     obj {

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -534,6 +534,7 @@ rust_file_is_dir(rust_task *task, rust_str *path) {
 
 extern "C" CDECL FILE* rust_get_stdin() {return stdin;}
 extern "C" CDECL FILE* rust_get_stdout() {return stdout;}
+extern "C" CDECL FILE* rust_get_stderr() {return stderr;}
 
 extern "C" CDECL int
 rust_ptr_eq(rust_task *task, type_desc *t, rust_box *a, rust_box *b) {

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -48,6 +48,7 @@ rust_dirent_filename
 rust_file_is_dir
 rust_get_stdin
 rust_get_stdout
+rust_get_stderr
 rust_istr_push
 rust_list_files
 rust_process_wait


### PR DESCRIPTION
Noticed that only STDIN and STDOUT are exposed to rust. This patch also adds STDERR to the list.
