### PR TITLE
Patch to error and fail instead of using all available memory

### DIFF
--- a/src/comp/syntax/parse/lexer.rs
+++ b/src/comp/syntax/parse/lexer.rs
@@ -490,8 +490,14 @@ fn next_token_inner(rdr: reader) -> token::token {
         ret token::LIT_CHAR(c2);
       }
       '"' {
+	let n = rdr.get_chpos(); 
         rdr.bump();
         while rdr.curr() != '"' {
+            if rdr.is_eof() {
+                rdr.err(#fmt["unterminated double quote string: %s", rdr.get_str_from(n)]);
+                fail;
+            }
+
             let ch = rdr.curr();
             rdr.bump();
             alt ch {

--- a/src/test/compile-fail/unbalanced-doublequote.rs
+++ b/src/test/compile-fail/unbalanced-doublequote.rs
@@ -1,0 +1,8 @@
+// -*- rust -*-
+
+// error-pattern: unterminated double quote string 
+
+
+fn main() {
+	" 
+}


### PR DESCRIPTION
then crashing to detect the error condition of an unmatched
double quote before the end of a file.

I couldn't get it to show nice error messages, so this may not be
the ideal fix.

A test case for this situation has also been added.

I have made a pull request, but unsure if its the correct way of showing errors, feel free to change it.
