### PR TITLE
remove call to pthread_exit()

### DIFF
--- a/src/rt/rust.cpp
+++ b/src/rt/rust.cpp
@@ -109,12 +109,6 @@ rust_start(uintptr_t main_fn, int argc, char **argv,
 
     free_env(env);
 
-#if !defined(__WIN32__)
-    // Don't take down the process if the main thread exits without an
-    // error.
-    if (!ret)
-        pthread_exit(NULL);
-#endif
     return ret;
 }
 


### PR DESCRIPTION
It causes OS X Lion to hang.  This pull request alone does not allow one to build on OS X Lion, as the recent snapshots are broken.
