### PR TITLE
Update LinkModules invocation to use new prototype

### DIFF
--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -53,7 +53,7 @@ extern "C" bool LLVMLinkModules(LLVMModuleRef Dest, LLVMModuleRef Src) {
   // function" error.
   Module *DM = reinterpret_cast<Module *>(Dest);
   Module *SM = reinterpret_cast<Module *>(Src);
-  if (Linker::LinkModules(DM, SM, &err)) {
+  if (Linker::LinkModules(DM, SM, Linker::DestroySource, &err)) {
     LLVMRustError = err.c_str();
     return false;
   }


### PR DESCRIPTION
LLVM revision 141606 changes the prototype of llvm::Linker::LinkModules.

Signed-off-by: Elly Jones elly@leptoquark.net
