### PR TITLE
Fix #1015

### DIFF
--- a/src/comp/driver/rustc.rs
+++ b/src/comp/driver/rustc.rs
@@ -94,7 +94,7 @@ fn time<@T>(do_it: bool, what: str, thunk: fn() -> T) -> T {
     let rv = thunk();
     let end = std::time::precise_time_s();
     log_err #fmt["time: %s took %s s", what,
-                 std::float::float_to_str(end - start, 3u)];
+                 std::float::to_str(end - start, 3u)];
     ret rv;
 }
 

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -1303,8 +1303,8 @@ fn valid_range_bounds(l1: @ast::lit, l2: @ast::lit) -> bool {
     alt l1.node {
       ast::lit_float(s1) | ast::lit_mach_float(_, s1) {
         let s2 = lit_as_float(l2);
-        let f1 = std::float::str_to_float(s1);
-        let f2 = std::float::str_to_float(s2);
+        let f1 = std::float::from_str(s1);
+        let f2 = std::float::from_str(s2);
         ret *util::common::min(f1, f2) == f1
       }
       ast::lit_uint(_) | ast::lit_char(_) {

--- a/src/comp/util/common.rs
+++ b/src/comp/util/common.rs
@@ -156,8 +156,8 @@ fn lit_in_range(l: @ast::lit, m1: @ast::lit, m2: @ast::lit) -> bool {
       frange(f1, f2) {
         alt l.node {
           ast::lit_float(f3) | ast::lit_mach_float(_, f3) {
-            std::float::str_to_float(f3) >= *min(f1, f2) &&
-            std::float::str_to_float(f3) <= *max(f1, f2)
+            std::float::from_str(f3) >= *min(f1, f2) &&
+            std::float::from_str(f3) <= *max(f1, f2)
           }
           _ { fail }
         }
@@ -232,7 +232,7 @@ fn lits_to_range(l: @ast::lit, r: @ast::lit) -> range {
       }
       ast::lit_float(f1) | ast::lit_mach_float(_, f1) {
         alt r.node { ast::lit_float(f2) | ast::lit_mach_float(_, f2) {
-          frange(std::float::str_to_float(f1), std::float::str_to_float(f2))
+          frange(std::float::from_str(f1), std::float::from_str(f2))
         }
         _ { fail } }
       }

--- a/src/lib/float.rs
+++ b/src/lib/float.rs
@@ -2,7 +2,7 @@
  * String conversions
  */
 
-fn float_to_str(num: float, digits: uint) -> str {
+fn to_str(num: float, digits: uint) -> str {
     let accum = if num < 0.0 { num = -num; "-" } else { "" };
     let trunc = num as uint;
     let frac = num - (trunc as float);
@@ -36,7 +36,7 @@ fn float_to_str(num: float, digits: uint) -> str {
  * @return [NaN] if the string did not represent a valid number.
  * @return Otherwise, the floating-point number represented [num].
  */
-fn str_to_float(num: str) -> float {
+fn from_str(num: str) -> float {
    let pos = 0u;                  //Current byte position in the string.
                                   //Used to walk the string in O(n).
    let len = str::byte_len(num);  //Length of the string, in bytes.

--- a/src/lib/int.rs
+++ b/src/lib/int.rs
@@ -73,16 +73,19 @@ fn to_str(n: int, radix: uint) -> str {
 fn str(i: int) -> str { ret to_str(i, 10u); }
 
 fn pow(base: int, exponent: uint) -> int {
-    ret if exponent == 0u {
-            1
-        } else if base == 0 {
-            0
-        } else {
-            let accum = base;
-            let count = exponent;
-            while count > 1u { accum *= base; count -= 1u; }
-            accum
-        };
+    if exponent == 0u { ret 1; } //Not mathemtically true if [base == 0]
+    if base     == 0  { ret 0; }
+    let my_pow  = exponent;
+    let acc     = 1;
+    let multiplier = base;
+    while(my_pow > 0u) {
+      if my_pow % 2u == 1u {
+         acc *= multiplier;
+      }
+      my_pow     /= 2u;
+      multiplier *= multiplier;
+    }
+    ret acc;
 }
 // Local Variables:
 // mode: rust;

--- a/src/test/stdtest/float.rs
+++ b/src/test/stdtest/float.rs
@@ -1,0 +1,19 @@
+use std;
+import std::float;
+
+#[test]
+fn test_from_str() {
+   assert ( float::from_str("3.14") == 3.14 );
+   assert ( float::from_str("+3.14") == 3.14 );
+   assert ( float::from_str("-3.14") == -3.14 );
+   assert ( float::from_str("2.5E10") == 25000000000. );
+   assert ( float::from_str("2.5e10") == 25000000000. );
+   assert ( float::from_str("25000000000.E-10") == 2.5 );
+   assert ( float::from_str("") == 0. );
+   assert ( float::from_str("   ") == 0. );
+   assert ( float::from_str(".") == 0. );
+   assert ( float::from_str("5.") == 5. );
+   assert ( float::from_str(".5") == 0.5 );
+   assert ( float::from_str("0.5") == 0.5 );
+
+}

--- a/src/test/stdtest/stdtest.rc
+++ b/src/test/stdtest/stdtest.rc
@@ -29,6 +29,7 @@ mod sys;
 mod task;
 mod test;
 mod uint;
+mod float;
 
 // Local Variables:
 // mode: rust


### PR DESCRIPTION
This should fix issue #1015. I have reimplemented `str_to_float` to extend the grammar that it can parse. Including, say, strings with a decimal part :)

I take the opportunity to replace the implementation of `int::pow` to use fast exponentiation, to add a few functions to the new `float` module, as well as a few tests. I also renamed `str_to_float` and `float_to_str` into `float::from_str` and `float::to_str`, to harmonize with the `int` module.
