### PR TITLE
Fix link error by explicitly link needed DSOs

### DIFF
--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -582,7 +582,7 @@ fn link_binary(sess: session::session,
         gcc_args += ["-lm", main];
     }
 
-    gcc_args += ["-lrustrt"];
+    gcc_args += ["-lrustrt", "-lrt"];
 
     gcc_args += rpath::get_rpath_flags(sess, saved_out_filename);
 


### PR DESCRIPTION
Building Rust(version 280bc56) on Ubuntu 11.10 failed with link error,
like:

compile_and_link: stage0/lib/rustc/i686-unknown-linux-gnu/lib/libstd.so
compile_and_link: stage0/lib/rustc/i686-unknown-linux-gnu/bin/rustc
/local/src/rust/build/stage0/lib/rustc/i686-unknown-linux-gnu/lib/librustrt.so:
undefined reference to `clock_gettime'
collect2: ld returned 1 exit status
error: linking with gcc failed with code 1

GCC toolchain released by Ubuntu 11.10 introduced a few compiler flags
that are different with upstream GCC[1]. Flags "-Wl,--as-needed' and
'-Wl,--no-copy-dt-needed-entries' are passed by default.

Function clock_gettime from librt is used by librustrt, indirectly by
rustc. It is necessary to explicitly pass the "-lrt" flags when building
rustc.

Please note since the toolchain changes will be the default in the next
release(2.22) of binutils, this is not actually a Debian/Ubuntu specific
issue.
1. https://wiki.ubuntu.com/OneiricOcelot/ReleaseNotes#GCC_4.6_Toolchain

Signed-off-by: Haitao Li lihaitao@gmail.com
