### PR TITLE
Fix parse error in constrained-type-missing-check.rs

### DIFF
--- a/src/test/compile-fail/constrained-type-missing-check.rs
+++ b/src/test/compile-fail/constrained-type-missing-check.rs
@@ -4,7 +4,7 @@
 
 pure fn less_than(x: int, y: int) -> bool { ret x < y; }
 
-type ordered_range = {low: int, high: int} : less_than(low, high);
+type ordered_range = {low: int, high: int} : less_than(*.low, *.high);
 
 fn main() {
     // Should fail to compile, b/c we're not doing the check


### PR DESCRIPTION
I noticed that this test was expected to succeed, but was actually failing to compile with "expecting *, found low".

There's a deeper issue here, which is that "make test" did not catch this problem.  I'm guessing this because "// xfail-test" is not processed when parsing fails.
