### PR TITLE
Update documentation to use paren-free syntax

### DIFF
--- a/doc/rust.texi
+++ b/doc/rust.texi
@@ -3347,9 +3347,9 @@ expression following the @code{alt} when the case block completes.
 A pattern @code{alt} expression branches on a @emph{pattern}. The exact form of
 matching that occurs depends on the pattern. Patterns consist of some
 combination of literals, tag constructors, variable binding specifications and
-placeholders (@code{_}). A pattern @code{alt} has a parenthesized @emph{head
-expression}, which is the value to compare to the patterns. The type of the
-patterns must equal the type of the head expression.
+placeholders (@code{_}). A pattern @code{alt} has a @emph{head expression},
+which is the value to compare to the patterns. The type of the patterns must
+equal the type of the head expression.
 
 To execute a pattern @code{alt} expression, first the head expression is
 evaluated, then its value is sequentially compared to the patterns in the arms
@@ -3365,7 +3365,7 @@ type list<X> = tag(nil, cons(X, @@list<X>));
 
 let x: list<int> = cons(10, cons(11, nil));
 
-alt (x) @{
+alt x @{
     case (cons(a, cons(b, _))) @{
         process_pair(a,b);
     @}

--- a/doc/rust.texi
+++ b/doc/rust.texi
@@ -956,7 +956,7 @@ x::y::z;
 @end example
 
 In most contexts, the Rust grammar accepts a general @emph{path}, but
-subsequent passes pay restrict paths occurring in various contexts to refer to
+subsequent passes may restrict paths occurring in various contexts to refer to
 slots or items, depending on the semantics of the occurrence. In other words:
 in some contexts a slot is required (for example, on the left hand side of the
 copy operator, @pxref{Ref.Expr.Copy}) and in other contexts an item is

--- a/doc/rust.texi
+++ b/doc/rust.texi
@@ -2008,7 +2008,7 @@ iter range(lo: int, hi: int) -> int @{
 @}
 
 let sum: int = 0;
-for each (x: int in range(0,100)) @{
+for each x: int in range(0,100) @{
     sum += x;
 @}
 @end example
@@ -2464,7 +2464,7 @@ iter range(x: int, y: int) -> int @{
   @}
 @}
 
-for each (i: int in range(5,7)) @{
+for each i: int in range(5,7) @{
   @dots{};
 @}
 @end example
@@ -3172,7 +3172,7 @@ fn read_file_lines(path: str) -> [str] @{
     note path;
     let r: [str];
     let f: file = open_read(path);
-    for each (s: str in lines(f)) @{
+    for each s: str in lines(f) @{
         vec::append(r,s);
     @}
     ret r;
@@ -3271,7 +3271,7 @@ Example a for loop:
 @example
 let v: [foo] = [a, b, c];
 
-for (foo e in v) @{
+for e: foo in v @{
     bar(e);
 @}
 @end example
@@ -3291,7 +3291,7 @@ Example of a foreach loop:
 @example
 let txt: str;
 let lines: [str];
-for each (s: str in str::split(txt, "\n")) @{
+for each s: str in str::split(txt, "\n") @{
     vec::push(lines, s);
 @}
 @end example

--- a/doc/rust.texi
+++ b/doc/rust.texi
@@ -1878,7 +1878,7 @@ were declared without the @code{!} annotation, the following code would not
 typecheck:
 @example
 fn f(i: int) -> int @{
-   if (i == 42) @{
+   if i == 42 @{
      ret 42;
    @}
    else @{
@@ -3056,7 +3056,7 @@ and transfers control to the caller frame.
 An example of a @code{ret} expression:
 @example
 fn max(a: int, b: int) -> int @{
-   if (a > b) @{
+   if a > b @{
       ret a;
    @}
    ret b;
@@ -3081,7 +3081,7 @@ last expression in a block.
 An example of a @code{be} expression:
 @example
 fn print_loop(n: int) @{
-  if (n <= 0) @{
+  if n <= 0 @{
     ret;
   @} else @{
     print_int(n);
@@ -3304,9 +3304,9 @@ for each s: str in str::split(txt, "\n") @{
 @cindex Control-flow
 
 An @code{if} expression is a conditional branch in program control. The form of
-an @code{if} expression is a parenthesized condition expression, followed by a
-consequent block, any number of @code{else if} conditions and blocks, and an
-optional trailing @code{else} block. The condition expressions must have type
+an @code{if} expression is a condition expression, followed by a consequent
+block, any number of @code{else if} conditions and blocks, and an optional
+trailing @code{else} block. The condition expressions must have type
 @code{bool}. If a condition expression evaluates to @code{true}, the
 consequent block is executed and any subsequent @code{else if} or @code{else}
 block is skipped. If a condition expression evaluates to @code{false}, the


### PR DESCRIPTION
This updates the documentation to the new paren-free / paren-optional expression syntax.  There's also a simple typo fix.

The `for` and `for each` examples in the current documentation do not compile.  The `if` and `alt` examples do compile, but are not written in the current style and the documentation is out of date.
