### PR TITLE
Fix syntax errors in "alt" documentation

### DIFF
--- a/doc/rust.texi
+++ b/doc/rust.texi
@@ -3353,10 +3353,9 @@ equal the type of the head expression.
 
 To execute a pattern @code{alt} expression, first the head expression is
 evaluated, then its value is sequentially compared to the patterns in the arms
-until a match is found. The first arm with a matching @code{case} pattern is
-chosen as the branch target of the @code{alt}, any variables bound by the
-pattern are assigned to local slots in the arm's block, and control enters the
-block.
+until a match is found. The first arm with a matching pattern is chosen as the
+branch target of the @code{alt}, any variables bound by the pattern are
+assigned to local slots in the arm's block, and control enters the block.
 
 An example of a pattern @code{alt} expression:
 
@@ -3366,13 +3365,13 @@ type list<X> = tag(nil, cons(X, @@list<X>));
 let x: list<int> = cons(10, cons(11, nil));
 
 alt x @{
-    case (cons(a, cons(b, _))) @{
+    cons(a, cons(b, _)) @{
         process_pair(a,b);
     @}
-    case (cons(v=10, _)) @{
+    cons(v=10, _) @{
         process_ten(v);
     @}
-    case (_) @{
+    _ @{
         fail;
     @}
 @}

--- a/doc/rust.texi
+++ b/doc/rust.texi
@@ -2133,7 +2133,7 @@ tag list<T> @{
   cons(T, @@list<T>);
 @}
 
-let a: list<int> = cons(7, cons(13, nil));
+let a: list<int> = cons(7, @@cons(13, @@nil));
 @end example
 
 
@@ -3360,16 +3360,16 @@ assigned to local slots in the arm's block, and control enters the block.
 An example of a pattern @code{alt} expression:
 
 @example
-type list<X> = tag(nil, cons(X, @@list<X>));
+tag list<X> @{ nil; cons(X, @@list<X>); @}
 
-let x: list<int> = cons(10, cons(11, nil));
+let x: list<int> = cons(10, @@cons(11, @@nil));
 
 alt x @{
-    cons(a, cons(b, _)) @{
+    cons(a, @@cons(b, _)) @{
         process_pair(a,b);
     @}
-    cons(v=10, _) @{
-        process_ten(v);
+    cons(10, _) @{
+        process_ten();
     @}
     _ @{
         fail;


### PR DESCRIPTION
This updates more example code to use current syntax.
