### PR TITLE
make ctags targets phony

### DIFF
--- a/mk/ctags.mk
+++ b/mk/ctags.mk
@@ -3,6 +3,8 @@
 # Requires Exuberant Ctags: http://ctags.sourceforge.net/index.html
 ######################################################################
 
+.PHONY: TAGS.emacs TAGS.vi
+
 CTAGS_OPTS=--options=${CFG_SRC_DIR}/src/etc/ctags.rust -R ${CFG_SRC_DIR}/src
 
 TAGS.emacs:


### PR DESCRIPTION
These targets ought to be phony, even though they are real files, since they don't have proper dependencies and sometimes make decides not to rebuild them.
