### PR TITLE
Kill rust abi

### DIFF
--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -3848,8 +3848,7 @@ fn trans_c_stack_native_call(bcx: @block_ctxt, f: @ast::expr,
 
         let r = trans_arg_expr(bcx, ty_arg, llargty, to_zero, to_revoke, arg);
         let llargval = r.val; bcx = r.bcx;
-        { llval: llargval, llty: llargty, static: static,
-          by_val: ty_arg.mode == ast::by_val }
+        { llval: llargval, llty: llargty, static: static, mode: ty_arg.mode }
     }, fn_arg_tys, args);
 
     // Allocate the argument bundle.
@@ -3865,7 +3864,10 @@ fn trans_c_stack_native_call(bcx: @block_ctxt, f: @ast::expr,
         if llarg.static {
             // FIXME: This load is unfortunate. It won't be necessary once we
             // have reference types again.
-            llargval = llarg.by_val ? llarg.llval : Load(bcx, llarg.llval);
+            llargval = alt llarg.mode {
+              ast::by_val. | ast::by_mut_ref. { llarg.llval }
+              ast::by_ref. | ast::mode_infer. { Load(bcx, llarg.llval) }
+            };
         } else {
             llargval = llarg.llval;
         }

--- a/src/comp/middle/trans_build.rs
+++ b/src/comp/middle/trans_build.rs
@@ -3,7 +3,8 @@ import std::str::sbuf;
 import lib::llvm::llvm;
 import llvm::{ValueRef, TypeRef, BasicBlockRef, BuilderRef, Opcode,
               ModuleRef};
-import trans_common::{block_ctxt, T_ptr, T_nil, T_int, T_i8, T_i1, val_ty};
+import trans_common::{block_ctxt, T_ptr, T_nil, T_int, T_i8, T_i1,
+                      val_ty, val_str, bcx_ccx};
 
 fn B(cx: @block_ctxt) -> BuilderRef {
     let b = *cx.fcx.lcx.ccx.builder;

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -109,6 +109,11 @@ unsupervise() {
     task->unsupervise();
 }
 
+extern "C" CDECL type_desc*
+get_type_desc(void *unused_task, type_desc* t) {
+    return t;
+}
+
 extern "C" CDECL void
 vec_reserve_shared(type_desc* ty, rust_vec** vp,
                    size_t n_elts) {

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -62,6 +62,7 @@ vec_from_buf_shared
 task_sleep
 task_yield
 task_join
+get_type_desc
 unsupervise
 upcall_alloc_c_stack
 upcall_call_c_stack


### PR DESCRIPTION
This patch (delivered in two parts) removes all uses of the "rust" ABI (although not the constant itself) and replaces them with c-stack-cdecl (except for a select few routines).  This first part just fixes some bugs in c-stack-cdecl compilation.  The second patch (coming post snapshot) actually converts most of the natives to use it.
