### PR TITLE
Fix an insane rt build error running 'make check -j3' on Fedora

### DIFF
--- a/src/rt/arch/i386/context.h
+++ b/src/rt/arch/i386/context.h
@@ -7,9 +7,7 @@
 #include <inttypes.h>
 #include <stdint.h>
 
-#ifdef HAVE_VALGRIND
-#include <valgrind/memcheck.h>
-#endif
+#include "../../memcheck.h"
 
 template<typename T>
 T align_down(T sp)


### PR DESCRIPTION
I have no idea how this worked before at all, or why this was occuring on my Fedora machine the way it was. Running `make check` did not turn up this error, only running `make check -j3` did - which revealed `context.h` trying to include `valgrind/memcheck.h`, while the source has its own copy.

This was hidden behind a `HAS_VALGRIND`, which was definitely triggered _somehow_ - because I had `valgrind-devel` installed on my machine, and GCC 4.6, `context.h` was pulling it in and the build was failing due to the old issue #350. If I removed `valgrind-devel` and ran the build with `make check -j3`, GCC would complain it couldn't find `valgrind/memcheck.h`. But `make check` always works?!?!?!

Either way, it's dead now.
