### PR TITLE
Kill rust abi 2

### DIFF
--- a/src/comp/back/upcall.rs
+++ b/src/comp/back/upcall.rs
@@ -5,7 +5,7 @@ import trans::decl_cdecl_fn;
 import middle::trans_common::{T_f32, T_f64, T_fn, T_bool, T_i1, T_i8, T_i32,
                               T_int, T_vec, T_nil, T_opaque_chan_ptr,
                               T_opaque_vec, T_opaque_port_ptr, T_ptr,
-                              T_size_t, T_void};
+                              T_size_t, T_void, T_float};
 import lib::llvm::type_names;
 import lib::llvm::llvm::ModuleRef;
 import lib::llvm::llvm::ValueRef;
@@ -28,6 +28,7 @@ type upcalls =
      dynastack_free: ValueRef,
      alloc_c_stack: ValueRef,
      call_c_stack: ValueRef,
+     call_c_stack_float: ValueRef,
      rust_personality: ValueRef};
 
 fn declare_upcalls(_tn: type_names, tydesc_type: TypeRef,
@@ -77,6 +78,9 @@ fn declare_upcalls(_tn: type_names, tydesc_type: TypeRef,
           call_c_stack: d("call_c_stack",
                           [T_ptr(T_fn([], T_int())), T_ptr(T_i8())],
                           T_int()),
+          call_c_stack_float: d("call_c_stack_float",
+                                [T_ptr(T_fn([], T_int())), T_ptr(T_i8())],
+                                T_float()),
           rust_personality: d("rust_personality", [], T_i32())
          };
 }

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -3889,8 +3889,6 @@ fn trans_c_stack_native_call(bcx: @block_ctxt, f: @ast::expr,
     if lib::llvm::llvm::LLVMGetTypeKind(llretty) as int == 11 { // pointer
         llretval = IntToPtr(bcx, llrawretval, llretty);
     } else {
-        log_err("TruncOrBitCast(", val_str(ccx.tn, llrawretval), ", ",
-                ty_str(ccx.tn, llretty), ")");
         llretval = TruncOrBitCast(bcx, llrawretval, llretty);
     }
 

--- a/src/lib/comm.rs
+++ b/src/lib/comm.rs
@@ -12,14 +12,14 @@ native "c-stack-cdecl" mod rustrt {
     type void;
     type rust_port;
 
-    fn chan_id_send<~T>(unused_task: *void, t: *sys::type_desc,
+    fn chan_id_send<~T>(t: *sys::type_desc,
                         target_task: task::task, target_port: port_id,
                         -data: T);
 
-    fn new_port(unused_task: *void, unit_sz: uint) -> *rust_port;
-    fn del_port(unused_task: *void, po: *rust_port);
-    fn drop_port(unused_task: *void, po: *rust_port);
-    fn get_port_id(unused_task: *void, po: *rust_port) -> port_id;
+    fn new_port(unit_sz: uint) -> *rust_port;
+    fn del_port(po: *rust_port);
+    fn drop_port(po: *rust_port);
+    fn get_port_id(po: *rust_port) -> port_id;
 }
 
 native "rust-intrinsic" mod rusti {
@@ -33,20 +33,20 @@ type port_id = int;
 tag chan<~T> { chan_t(task::task, port_id); }
 
 resource port_ptr(po: *rustrt::rust_port) {
-    rustrt::drop_port(ptr::null(), po);
-    rustrt::del_port(ptr::null(), po);
+    rustrt::drop_port(po);
+    rustrt::del_port(po);
 }
 
 tag port<~T> { port_t(@port_ptr); }
 
 fn send<~T>(ch: chan<T>, -data: T) {
     let chan_t(t, p) = ch;
-    rustrt::chan_id_send(ptr::null(), sys::get_type_desc::<T>(), t, p, data);
+    rustrt::chan_id_send(sys::get_type_desc::<T>(), t, p, data);
     task::yield();
 }
 
 fn port<~T>() -> port<T> {
-    let p = rustrt::new_port(ptr::null(), sys::size_of::<T>());
+    let p = rustrt::new_port(sys::size_of::<T>());
     ret port_t(@port_ptr(p));
 }
 
@@ -55,6 +55,6 @@ fn recv<~T>(p: port<T>) -> T {
 }
 
 fn chan<~T>(p: port<T>) -> chan<T> {
-    let id = rustrt::get_port_id(ptr::null(), ***p);
+    let id = rustrt::get_port_id(***p);
     ret chan_t(task::get_task_id(), id);
 }

--- a/src/lib/comm.rs
+++ b/src/lib/comm.rs
@@ -8,17 +8,18 @@ export recv;
 export chan;
 export port;
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     type void;
     type rust_port;
 
-    fn chan_id_send<~T>(target_task: task::task, target_port: port_id,
+    fn chan_id_send<~T>(unused_task: *void, t: *sys::type_desc,
+                        target_task: task::task, target_port: port_id,
                         -data: T);
 
-    fn new_port(unit_sz: uint) -> *rust_port;
-    fn del_port(po: *rust_port);
-    fn drop_port(po: *rust_port);
-    fn get_port_id(po: *rust_port) -> port_id;
+    fn new_port(unused_task: *void, unit_sz: uint) -> *rust_port;
+    fn del_port(unused_task: *void, po: *rust_port);
+    fn drop_port(unused_task: *void, po: *rust_port);
+    fn get_port_id(unused_task: *void, po: *rust_port) -> port_id;
 }
 
 native "rust-intrinsic" mod rusti {
@@ -32,23 +33,28 @@ type port_id = int;
 tag chan<~T> { chan_t(task::task, port_id); }
 
 resource port_ptr(po: *rustrt::rust_port) {
-    rustrt::drop_port(po);
-    rustrt::del_port(po);
+    rustrt::drop_port(ptr::null(), po);
+    rustrt::del_port(ptr::null(), po);
 }
 
 tag port<~T> { port_t(@port_ptr); }
 
 fn send<~T>(ch: chan<T>, -data: T) {
     let chan_t(t, p) = ch;
-    rustrt::chan_id_send(t, p, data);
+    rustrt::chan_id_send(ptr::null(), sys::get_type_desc::<T>(), t, p, data);
+    task::yield();
 }
 
 fn port<~T>() -> port<T> {
-    port_t(@port_ptr(rustrt::new_port(sys::size_of::<T>())))
+    let p = rustrt::new_port(ptr::null(), sys::size_of::<T>());
+    ret port_t(@port_ptr(p));
 }
 
-fn recv<~T>(p: port<T>) -> T { ret rusti::recv(***p) }
+fn recv<~T>(p: port<T>) -> T {
+    ret rusti::recv(***p);
+}
 
 fn chan<~T>(p: port<T>) -> chan<T> {
-    chan_t(task::get_task_id(), rustrt::get_port_id(***p))
+    let id = rustrt::get_port_id(ptr::null(), ***p);
+    ret chan_t(task::get_task_id(), id);
 }

--- a/src/lib/dbg.rs
+++ b/src/lib/dbg.rs
@@ -8,23 +8,31 @@
  * logging.
  */
 
-native "rust" mod rustrt {
-    fn debug_tydesc<T>();
-    fn debug_opaque<T>(x: T);
-    fn debug_box<T>(x: @T);
-    fn debug_tag<T>(x: T);
-    fn debug_obj<T>(x: T, nmethods: uint, nbytes: uint);
-    fn debug_fn<T>(x: T);
-    fn debug_ptrcast<T, U>(x: @T) -> @U;
+native "c-stack-cdecl" mod rustrt {
+    fn debug_tydesc(td: *sys::type_desc);
+    fn debug_opaque<T>(td: *sys::type_desc, x: T);
+    fn debug_box<T>(td: *sys::type_desc, x: @T);
+    fn debug_tag<T>(td: *sys::type_desc, x: T);
+    fn debug_obj<T>(td: *sys::type_desc, x: T, nmethods: uint, nbytes: uint);
+    fn debug_fn<T>(td: *sys::type_desc, x: T);
+    fn debug_ptrcast<T, U>(td: *sys::type_desc, x: @T) -> @U;
 }
 
-fn debug_tydesc<T>() { rustrt::debug_tydesc::<T>(); }
+fn debug_tydesc<T>() {
+    rustrt::debug_tydesc(sys::get_type_desc::<T>());
+}
 
-fn debug_opaque<T>(x: T) { rustrt::debug_opaque::<T>(x); }
+fn debug_opaque<T>(x: T) {
+    rustrt::debug_opaque::<T>(sys::get_type_desc::<T>(), x);
+}
 
-fn debug_box<T>(x: @T) { rustrt::debug_box::<T>(x); }
+fn debug_box<T>(x: @T) {
+    rustrt::debug_box::<T>(sys::get_type_desc::<T>(), x);
+}
 
-fn debug_tag<T>(x: T) { rustrt::debug_tag::<T>(x); }
+fn debug_tag<T>(x: T) {
+    rustrt::debug_tag::<T>(sys::get_type_desc::<T>(), x);
+}
 
 
 /**
@@ -37,13 +45,15 @@ fn debug_tag<T>(x: T) { rustrt::debug_tag::<T>(x); }
  * the front of any obj's data tuple.x
  */
 fn debug_obj<T>(x: T, nmethods: uint, nbytes: uint) {
-    rustrt::debug_obj::<T>(x, nmethods, nbytes);
+    rustrt::debug_obj::<T>(sys::get_type_desc::<T>(), x, nmethods, nbytes);
 }
 
-fn debug_fn<T>(x: T) { rustrt::debug_fn::<T>(x); }
+fn debug_fn<T>(x: T) {
+    rustrt::debug_fn::<T>(sys::get_type_desc::<T>(), x);
+}
 
 unsafe fn ptr_cast<T, U>(x: @T) -> @U {
-    ret rustrt::debug_ptrcast::<T, U>(x);
+    ret rustrt::debug_ptrcast::<T, U>(sys::get_type_desc::<T>(), x);
 }
 
 fn refcount<T>(a: @T) -> uint unsafe {

--- a/src/lib/fs.rs
+++ b/src/lib/fs.rs
@@ -2,7 +2,7 @@
 import os::getcwd;
 import os_fs;
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn rust_file_is_dir(path: str::sbuf) -> int;
 }
 

--- a/src/lib/io.rs
+++ b/src/lib/io.rs
@@ -1,7 +1,7 @@
 
 import os::libc;
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn rust_get_stdin() -> os::libc::FILE;
     fn rust_get_stdout() -> os::libc::FILE;
     fn rust_get_stderr() -> os::libc::FILE;

--- a/src/lib/linux_os.rs
+++ b/src/lib/linux_os.rs
@@ -72,7 +72,7 @@ fn waitpid(pid: int) -> int {
     ret status;
 }
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn rust_getcwd() -> str;
 }
 

--- a/src/lib/macos_os.rs
+++ b/src/lib/macos_os.rs
@@ -71,7 +71,7 @@ fn waitpid(pid: int) -> int {
     ret status;
 }
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn rust_getcwd() -> str;
 }
 

--- a/src/lib/posix_fs.rs
+++ b/src/lib/posix_fs.rs
@@ -1,6 +1,6 @@
 
 native "c-stack-cdecl" mod rustrt {
-    fn rust_list_files(&&path: str) -> [str];
+    fn rust_list_files(path: str) -> [str];
 }
 
 fn list_dir(path: str) -> [str] {

--- a/src/lib/posix_fs.rs
+++ b/src/lib/posix_fs.rs
@@ -1,5 +1,5 @@
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn rust_list_files(&&path: str) -> [str];
 }
 

--- a/src/lib/rand.rs
+++ b/src/lib/rand.rs
@@ -4,7 +4,7 @@
 /**
  * Bindings the runtime's random number generator (ISAAC).
  */
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     type rctx;
     fn rand_new() -> rctx;
     fn rand_next(c: rctx) -> u32;

--- a/src/lib/run_program.rs
+++ b/src/lib/run_program.rs
@@ -8,7 +8,7 @@ export program_output;
 export spawn_process;
 export waitpid;
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn rust_run_program(argv: *sbuf, in_fd: int, out_fd: int, err_fd: int) ->
        int;
 }

--- a/src/lib/str.rs
+++ b/src/lib/str.rs
@@ -7,7 +7,7 @@ export eq, lteq, hash, is_empty, is_not_empty, is_whitespace, byte_len, index,
        str_from_cstr, sbuf, as_buf, push_byte, utf8_char_width, safe_slice,
        contains;
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn rust_str_push(&s: str, ch: u8);
 }
 

--- a/src/lib/sys.rs
+++ b/src/lib/sys.rs
@@ -2,6 +2,10 @@
 //export rustrt;
 //export size_of;
 
+tag type_desc {
+    type_desc(@type_desc);
+}
+
 native "rust" mod rustrt {
     // Explicitly re-export native stuff we want to be made
     // available outside this crate. Otherwise it's
@@ -12,6 +16,11 @@ native "rust" mod rustrt {
     fn refcount<T>(t: @T) -> uint;
     fn do_gc();
     fn unsupervise();
+    fn get_type_desc<T>() -> *type_desc;
+}
+
+fn get_type_desc<T>() -> *type_desc {
+    ret rustrt::get_type_desc::<T>();
 }
 
 fn last_os_error() -> str {

--- a/src/lib/sys.rs
+++ b/src/lib/sys.rs
@@ -6,21 +6,24 @@ tag type_desc {
     type_desc(@type_desc);
 }
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     // Explicitly re-export native stuff we want to be made
     // available outside this crate. Otherwise it's
     // visible-in-crate, but not re-exported.
     fn last_os_error() -> str;
-    fn size_of<T>() -> uint;
-    fn align_of<T>() -> uint;
+    fn size_of(td: *type_desc) -> uint;
+    fn align_of(td: *type_desc) -> uint;
     fn refcount<T>(t: @T) -> uint;
     fn do_gc();
     fn unsupervise();
+}
+
+native "rust-intrinsic" mod rusti {
     fn get_type_desc<T>() -> *type_desc;
 }
 
 fn get_type_desc<T>() -> *type_desc {
-    ret rustrt::get_type_desc::<T>();
+    ret rusti::get_type_desc::<T>();
 }
 
 fn last_os_error() -> str {
@@ -28,11 +31,11 @@ fn last_os_error() -> str {
 }
 
 fn size_of<T>() -> uint {
-    ret rustrt::size_of::<T>();
+    ret rustrt::size_of(get_type_desc::<T>());
 }
 
 fn align_of<T>() -> uint {
-    ret rustrt::align_of::<T>();
+    ret rustrt::align_of(get_type_desc::<T>());
 }
 
 fn refcount<T>(t: @T) -> uint {

--- a/src/lib/task.rs
+++ b/src/lib/task.rs
@@ -26,7 +26,6 @@ native "rust" mod rustrt {
     fn task_sleep(time_in_us: uint);
     fn task_yield();
     fn task_join(t: task_id) -> int;
-    fn unsupervise();
     fn pin_task();
     fn unpin_task();
     fn get_task_id() -> task_id;
@@ -85,7 +84,7 @@ fn join_id(t: task_id) -> task_result {
     alt rustrt::task_join(t) { 0 { tr_success } _ { tr_failure } }
 }
 
-fn unsupervise() { ret rustrt::unsupervise(); }
+fn unsupervise() { ret sys::unsupervise(); }
 
 fn pin() { rustrt::pin_task(); }
 

--- a/src/lib/task.rs
+++ b/src/lib/task.rs
@@ -22,25 +22,27 @@ export spawn;
 export spawn_notify;
 export spawn_joinable;
 
-native "rust" mod rustrt {                           // C Stack?
-    fn task_sleep(time_in_us: uint);                 // No
-    fn task_yield();                                 // No
-    fn start_task(id: task_id, closure: *u8);        // No
-    fn task_join(t: task_id) -> int;                 // Refactor
+native "cdecl" mod rustrt {
+    // these must run on the Rust stack so that they can swap stacks etc:
+    fn task_sleep(time_in_us: uint);
+    fn task_yield();
+    fn start_task(id: task_id, closure: *u8);
+    fn task_join(t: task_id) -> int;
 }
 
 native "c-stack-cdecl" mod rustrt2 = "rustrt" {
-    fn pin_task();                                   // Yes
-    fn unpin_task();                                 // Yes
-    fn get_task_id() -> task_id;                     // Yes
+    // these can run on the C stack:
+    fn pin_task();
+    fn unpin_task();
+    fn get_task_id() -> task_id;
 
-    fn set_min_stack(stack_size: uint);              // Yes
+    fn set_min_stack(stack_size: uint);
 
     fn new_task() -> task_id;
     fn drop_task(task: *rust_task);
     fn get_task_pointer(id: task_id) -> *rust_task;
 
-    fn migrate_alloc(alloc: *u8, target: task_id);   // Yes
+    fn migrate_alloc(alloc: *u8, target: task_id);
 }
 
 type rust_task =

--- a/src/lib/test.rs
+++ b/src/lib/test.rs
@@ -26,7 +26,7 @@ export default_test_to_task;
 export configure_test_task;
 export joinable;
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn sched_threads() -> uint;
 }
 

--- a/src/lib/time.rs
+++ b/src/lib/time.rs
@@ -1,6 +1,6 @@
 
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn get_time(&sec: u32, &usec: u32);
     fn nano_time(&ns: u64);
 }

--- a/src/lib/unsafe.rs
+++ b/src/lib/unsafe.rs
@@ -4,7 +4,7 @@ native "rust-intrinsic" mod rusti {
     fn cast<T, U>(src: T) -> U;
 }
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn leak<@T>(-thing: T);
 }
 

--- a/src/lib/vec.rs
+++ b/src/lib/vec.rs
@@ -21,7 +21,6 @@ native "c-stack-cdecl" mod rustrt {
 
 /// Reserves space for `n` elements in the given vector.
 fn reserve<@T>(&v: [mutable? T], n: uint) {
-    log_err("reserve: v=", ptr::addr_of(v), " n=", n);
     rustrt::vec_reserve_shared(null(), sys::get_type_desc::<T>(), v, n);
 }
 

--- a/src/lib/vec.rs
+++ b/src/lib/vec.rs
@@ -2,26 +2,24 @@
 
 import option::{some, none};
 import uint::next_power_of_two;
-import ptr::{addr_of, null};
+import ptr::addr_of;
 
 native "rust-intrinsic" mod rusti {
     fn vec_len<T>(&&v: [mutable? T]) -> uint;
 }
 
 native "c-stack-cdecl" mod rustrt {
-    fn vec_reserve_shared<T>(dummy: *util::void,
-                             t: *sys::type_desc,
+    fn vec_reserve_shared<T>(t: *sys::type_desc,
                              &v: [mutable? T],
                              n: uint);
-    fn vec_from_buf_shared<T>(dummy: *util::void,
-                              t: *sys::type_desc,
+    fn vec_from_buf_shared<T>(t: *sys::type_desc,
                               ptr: *T,
                               count: uint) -> [T];
 }
 
 /// Reserves space for `n` elements in the given vector.
 fn reserve<@T>(&v: [mutable? T], n: uint) {
-    rustrt::vec_reserve_shared(null(), sys::get_type_desc::<T>(), v, n);
+    rustrt::vec_reserve_shared(sys::get_type_desc::<T>(), v, n);
 }
 
 pure fn len<T>(v: [mutable? T]) -> uint { unchecked { rusti::vec_len(v) } }
@@ -358,7 +356,7 @@ mod unsafe {
     type vec_repr = {mutable fill: uint, mutable alloc: uint, data: u8};
 
     unsafe fn from_buf<@T>(ptr: *T, elts: uint) -> [T] {
-        ret rustrt::vec_from_buf_shared(null(), sys::get_type_desc::<T>(),
+        ret rustrt::vec_from_buf_shared(sys::get_type_desc::<T>(),
                                         ptr, elts);
     }
 

--- a/src/lib/win32_fs.rs
+++ b/src/lib/win32_fs.rs
@@ -2,7 +2,6 @@
 
 native "c-stack-cdecl" mod rustrt {
     fn rust_list_files(path: str) -> [str];
-    fn rust_file_is_dir(path: str) -> int;
 }
 
 fn list_dir(path: str) -> [str] {

--- a/src/lib/win32_fs.rs
+++ b/src/lib/win32_fs.rs
@@ -1,8 +1,8 @@
 
 
 native "c-stack-cdecl" mod rustrt {
-    fn rust_list_files(&&path: str) -> [str];
-    fn rust_file_is_dir(&&path: str) -> int;
+    fn rust_list_files(path: str) -> [str];
+    fn rust_file_is_dir(path: str) -> int;
 }
 
 fn list_dir(path: str) -> [str] {

--- a/src/lib/win32_fs.rs
+++ b/src/lib/win32_fs.rs
@@ -1,6 +1,6 @@
 
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn rust_list_files(&&path: str) -> [str];
     fn rust_file_is_dir(&&path: str) -> int;
 }

--- a/src/lib/win32_os.rs
+++ b/src/lib/win32_os.rs
@@ -79,7 +79,7 @@ fn fd_FILE(fd: int) -> libc::FILE {
     ret str::as_buf("r", {|modebuf| libc::_fdopen(fd, modebuf) });
 }
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn rust_process_wait(handle: int) -> int;
     fn rust_getcwd() -> str;
 }

--- a/src/rt/arch/i386/ccall.S
+++ b/src/rt/arch/i386/ccall.S
@@ -6,10 +6,14 @@
 // slower.
 #if defined(__APPLE__) || defined(_WIN32)
 .globl _upcall_call_c_stack
+.globl _upcall_call_c_stack_float
 _upcall_call_c_stack:
+_upcall_call_c_stack_float:
 #else
 .globl upcall_call_c_stack
+.globl upcall_call_c_stack_float
 upcall_call_c_stack:
+upcall_call_c_stack_float:
 #endif
     pushl %ebp
     movl %esp,%ebp          // save esp

--- a/src/rt/intrinsics/intrinsics.cpp
+++ b/src/rt/intrinsics/intrinsics.cpp
@@ -48,3 +48,9 @@ rust_intrinsic_recv(rust_task *task, void **retptr, type_desc *ty,
     port_recv((uintptr_t*)retptr, port);
 }
 
+extern "C" void
+rust_intrinsic_get_type_desc(rust_task *task, void **retptr,
+                             type_desc* ty) {
+    *(type_desc**)retptr = ty;
+}
+

--- a/src/rt/intrinsics/intrinsics.cpp
+++ b/src/rt/intrinsics/intrinsics.cpp
@@ -7,7 +7,7 @@
 #include <cstring>
 
 extern "C" CDECL void
-upcall_fail(rust_task *task, char const *expr, char const *file, size_t line);
+upcall_fail(char const *expr, char const *file, size_t line);
 
 extern "C" void
 rust_intrinsic_vec_len(rust_task *task, size_t *retptr, type_desc *ty,

--- a/src/rt/intrinsics/intrinsics.ll.in
+++ b/src/rt/intrinsics/intrinsics.ll.in
@@ -52,7 +52,7 @@ target triple = "@CFG_LLVM_TRIPLE@"
 %struct.rust_vec = type { i32, i32, [0 x i8] }
 %"struct.std::_Rb_tree<void *, std::pair<void *const, const type_desc *>, std::_Select1st<std::pair<void *const, const type_desc *> >, std::less<void *>, std::allocator<std::pair<void *const, const type_desc *> > >::_Rb_tree_impl" = type { %struct.rust_cond, %"struct.std::_Rb_tree_node_base", i32 }
 %"struct.std::_Rb_tree_node_base" = type { i32, %"struct.std::_Rb_tree_node_base"*, %"struct.std::_Rb_tree_node_base"*, %"struct.std::_Rb_tree_node_base"* }
-%struct.type_desc = type { %struct.type_desc**, i32, i32, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*)*, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*)*, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*)*, i8*, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*)*, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*)*, i32, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*, i8*, i8)*, i8*, %struct.rust_shape_tables*, i32, i32, %struct.UT_hash_handle, i32, [0 x %struct.type_desc*] }
+%struct.type_desc = type { %struct.type_desc**, i32, i32, void (i8*, i8*, %struct.type_desc**, i8*)*, void (i8*, i8*, %struct.type_desc**, i8*)*, void (i8*, i8*, %struct.type_desc**, i8*)*, i8*, void (i8*, i8*, %struct.type_desc**, i8*)*, void (i8*, i8*, %struct.type_desc**, i8*)*, i32, void (i8*, i8*, %struct.type_desc**, i8*, i8*, i8)*, i8*, %struct.rust_shape_tables*, i32, i32, %struct.UT_hash_handle, i32, [0 x %struct.type_desc*] }
 
 @.str = private unnamed_addr constant [42 x i8] c"attempt to cast values of differing sizes\00"
 @.str1 = private unnamed_addr constant [15 x i8] c"intrinsics.cpp\00"
@@ -77,7 +77,7 @@ define void @rust_intrinsic_ptr_offset(%struct.rust_task* nocapture %task, i8** 
   ret void
 }
 
-define void @rust_intrinsic_cast(%struct.rust_task* %task, i8* nocapture %retptr, %struct.type_desc* nocapture %t1, %struct.type_desc* nocapture %t2, i8* nocapture %src) {
+define void @rust_intrinsic_cast(%struct.rust_task* nocapture %task, i8* nocapture %retptr, %struct.type_desc* nocapture %t1, %struct.type_desc* nocapture %t2, i8* nocapture %src) {
   %1 = getelementptr inbounds %struct.type_desc* %t1, i32 0, i32 1
   %2 = load i32* %1, align 4
   %3 = getelementptr inbounds %struct.type_desc* %t2, i32 0, i32 1
@@ -85,9 +85,9 @@ define void @rust_intrinsic_cast(%struct.rust_task* %task, i8* nocapture %retptr
   %5 = icmp eq i32 %2, %4
   br i1 %5, label %7, label %6
 
-if.then:                                          ; preds = %entry
-  tail call void @upcall_fail(i8* getelementptr inbounds ([42 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([15 x i8]* @.str1, i32 0, i32 0), i32 45)
-  br label %return
+; <label>:6                                       ; preds = %0
+  tail call void @upcall_fail(i8* getelementptr inbounds ([42 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([15 x i8]* @.str1, i32 0, i32 0), i32 32)
+  br label %8
 
 ; <label>:7                                       ; preds = %0
   tail call void @llvm.memmove.p0i8.p0i8.i32(i8* %retptr, i8* %src, i32 %2, i32 1, i1 false)
@@ -106,10 +106,9 @@ define void @rust_intrinsic_addr_of(%struct.rust_task* nocapture %task, i8** noc
   ret void
 }
 
-define linkonce_odr void @rust_intrinsic_recv(%struct.rust_task* %task, i8** %retptr, %struct.type_desc* nocapture %ty, %class.rust_port* %port) {
-entry:
-  %0 = bitcast i8** %retptr to i32*
-  tail call void @port_recv(i32* %0, %class.rust_port* %port)
+define void @rust_intrinsic_recv(%struct.rust_task* nocapture %task, i8** %retptr, %struct.type_desc* nocapture %ty, %class.rust_port* %port) {
+  %1 = bitcast i8** %retptr to i32*
+  tail call void @port_recv(i32* %1, %class.rust_port* %port)
   ret void
 }
 

--- a/src/rt/intrinsics/intrinsics.ll.in
+++ b/src/rt/intrinsics/intrinsics.ll.in
@@ -1,96 +1,99 @@
 ; ModuleID = 'intrinsics.cpp'
 target triple = "@CFG_LLVM_TRIPLE@"
 
-%struct.rust_task = type { i32, %struct.stk_seg*, i32, i32, %struct.gc_alloc*, %struct.rust_scheduler*, %class.rust_crate_cache*, %class.rust_kernel*, i8*, %class.rust_task_list*, %struct.rust_cond*, i8*, %struct.rust_task*, i32, i32, i32, %class.timer, i32*, %class.array_list, %class.context, i32, i32, %class.memory_region, %"class.rust_task::wakeup_callback"*, i8, i8, %class.lock_and_signal }
-%struct.stk_seg = type { i32, i32, [0 x i8] }
-%struct.gc_alloc = type { %struct.gc_alloc*, %struct.gc_alloc*, i32, [0 x i8] }
-%struct.rust_scheduler = type { %class.rust_thread, %struct.rc_base, i32, %class.rust_log, i32, %class.rust_srv*, i8*, %class.rust_task_list, %class.rust_task_list, %class.rust_task_list, %class.rust_task_list, %class.rust_crate_cache, %struct.randctx, %class.rust_kernel*, i32, %class.hash_map, %class.hash_map.3, i32, %class.lock_and_signal, i32, %struct._opaque_pthread_attr_t, %struct.rust_env* }
-%class.rust_thread = type { i32 (...)**, i8, %struct._opaque_pthread_t* }
-%struct._opaque_pthread_t = type { i32, %struct.__darwin_pthread_handler_rec*, [596 x i8] }
-%struct.__darwin_pthread_handler_rec = type { {}*, i8*, %struct.__darwin_pthread_handler_rec* }
-%struct.rc_base = type { i32 }
-%class.rust_log = type { i32 (...)**, %class.rust_srv*, %struct.rust_scheduler*, i8 }
-%class.rust_srv = type { i32 (...)**, %struct.rust_env*, %class.memory_region }
-%struct.rust_env = type { i32, i32, i8*, i8, i8, i8* }
-%class.memory_region = type { i32 (...)**, %class.rust_srv*, %class.memory_region*, i32, %class.array_list.0, i8, i8, %class.lock_and_signal, i8 }
-%class.array_list.0 = type { i32, %"struct.memory_region::alloc_header"**, i32 }
-%"struct.memory_region::alloc_header" = type { i32, i32, i8*, [0 x i8] }
-%class.lock_and_signal = type { i32 (...)**, %struct._opaque_pthread_cond_t, %struct._opaque_pthread_mutex_t, %struct._opaque_pthread_t*, i8, i8 }
-%struct._opaque_pthread_cond_t = type { i32, [24 x i8] }
-%struct._opaque_pthread_mutex_t = type { i32, [40 x i8] }
-%class.rust_task_list = type { %class.indexed_list, %struct.rust_scheduler*, i8* }
-%class.indexed_list = type { i32 (...)**, %class.array_list }
+%0 = type { i32, %"struct.memory_region::alloc_header"**, i32 }
+%1 = type { i32, %struct.rust_scheduler**, i32 }
+%2 = type { %"struct.hash_map<long, rust_task *>::map_entry"* }
+%3 = type { %struct.rust_task*, i32, i32, %class.rust_chan** }
 %class.array_list = type { i32, %struct.rust_task**, i32 }
+%class.circular_buffer = type { %class.rust_kernel*, i32, i32, i32, i32, i8* }
+%class.context = type { %struct.registers_t, %class.context* }
+%"class.debug::task_debug_info" = type { %"class.std::map" }
+%class.hash_map = type { %"struct.hash_map<long, rust_port *>::map_entry"* }
+%class.indexed_list = type { i32 (...)**, %class.array_list }
+%class.lock_and_signal = type { i32 (...)**, %struct._opaque_pthread_cond_t, %struct._opaque_pthread_mutex_t, %struct._opaque_pthread_t*, i8, i8 }
+%class.memory_region = type { i32 (...)**, %class.rust_srv*, %class.memory_region*, i32, %0, i8, i8, %class.lock_and_signal }
+%class.ptr_vec = type { %struct.rust_task*, i32, i32, %struct.rust_token** }
+%class.rust_chan = type { i32, %class.rust_kernel*, %struct.rust_task*, %class.rust_port*, i32, %class.circular_buffer }
 %class.rust_crate_cache = type { %struct.type_desc*, %struct.rust_scheduler*, i32 }
-%struct.type_desc = type { %struct.type_desc**, i32, i32, {}*, {}*, {}*, {}*, {}*, {}*, i32, {}*, %struct.UT_hash_handle, i32, [0 x %struct.type_desc*] }
+%class.rust_kernel = type { i32 (...)**, %class.memory_region, %class.rust_log, %class.rust_srv*, %class.lock_and_signal, %1, %struct.randctx, i32, %2, i32, i32, i32, %struct.rust_env* }
+%class.rust_log = type { i32 (...)**, %class.rust_srv*, %struct.rust_scheduler*, i8 }
+%class.rust_obstack = type { %struct.rust_obstack_chunk*, %struct.rust_task* }
+%class.rust_port = type { i32, i32, %class.rust_kernel*, %struct.rust_task*, %class.rust_chan*, i32, %class.ptr_vec, %3, %class.lock_and_signal }
+%class.rust_srv = type { i32 (...)**, %struct.rust_env*, %class.memory_region }
+%"class.rust_task::wakeup_callback" = type { i32 (...)** }
+%class.rust_task_list = type { %class.indexed_list, %struct.rust_scheduler*, i8* }
+%class.rust_thread = type { i32 (...)**, i8, %struct._opaque_pthread_t* }
+%"class.std::_Rb_tree" = type { %"struct.std::_Rb_tree<void *, std::pair<void *const, const type_desc *>, std::_Select1st<std::pair<void *const, const type_desc *> >, std::less<void *>, std::allocator<std::pair<void *const, const type_desc *> > >::_Rb_tree_impl" }
+%"class.std::map" = type { %"class.std::_Rb_tree" }
+%class.timer = type { i32 (...)**, i64, i64 }
+%struct.UT_hash_bucket = type { %struct.UT_hash_handle*, i32, i32 }
 %struct.UT_hash_handle = type { %struct.UT_hash_table*, i8*, i8*, %struct.UT_hash_handle*, %struct.UT_hash_handle*, i8*, i32, i32 }
 %struct.UT_hash_table = type { %struct.UT_hash_bucket*, i32, i32, i32, %struct.UT_hash_handle*, i32, i32, i32, i32, i32 }
-%struct.UT_hash_bucket = type { %struct.UT_hash_handle*, i32, i32 }
-%struct.randctx = type { i32, [256 x i32], [256 x i32], i32, i32, i32 }
-%class.rust_kernel = type { i32 (...)**, %class.memory_region, %class.rust_log, %class.rust_srv*, %class.lock_and_signal, %class.array_list.4, %struct.randctx, i32, i32, i32, %struct.rust_env* }
-%class.array_list.4 = type { i32, %struct.rust_scheduler**, i32 }
-%class.hash_map = type { %"struct.hash_map<rust_task *, rust_task *>::map_entry"* }
-%"struct.hash_map<rust_task *, rust_task *>::map_entry" = type opaque
-%class.hash_map.3 = type { %"struct.hash_map<rust_port *, rust_port *>::map_entry"* }
-%"struct.hash_map<rust_port *, rust_port *>::map_entry" = type opaque
+%struct.__darwin_pthread_handler_rec = type { void (i8*)*, i8*, %struct.__darwin_pthread_handler_rec* }
 %struct._opaque_pthread_attr_t = type { i32, [36 x i8] }
-%struct.rust_cond = type { i8 }
-%class.timer = type { i32 (...)**, i64, i64 }
-%class.context = type { %struct.registers_t, %class.context* }
+%struct._opaque_pthread_cond_t = type { i32, [24 x i8] }
+%struct._opaque_pthread_mutex_t = type { i32, [40 x i8] }
+%struct._opaque_pthread_t = type { i32, %struct.__darwin_pthread_handler_rec*, [596 x i8] }
+%struct.chan_handle = type { i32, i32 }
+%"struct.hash_map<long, rust_port *>::map_entry" = type opaque
+%"struct.hash_map<long, rust_task *>::map_entry" = type opaque
+%"struct.memory_region::alloc_header" = type { i32, i32, i8*, i32, [0 x i8] }
+%struct.randctx = type { i32, [256 x i32], [256 x i32], i32, i32, i32 }
 %struct.registers_t = type { i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i16, i16, i32, i32 }
-%"class.rust_task::wakeup_callback" = type { i32 (...)** }
-%struct.rc_base.5 = type { i32 }
-%struct.rust_vec = type { i32, i32, [ 0 x i8 ] }
-%class.rust_port = type { i32, %class.rust_kernel*, %struct.rust_task*, i32, %class.ptr_vec, %class.ptr_vec.7, %class.rust_chan*, %class.lock_and_signal }
-%class.ptr_vec = type { %struct.rust_task*, i32, i32, %struct.rust_token** }
+%struct.rust_cond = type { i8 }
+%struct.rust_env = type { i32, i32, i8*, i8, i8, i8* }
+%struct.rust_obstack_chunk = type { %struct.rust_obstack_chunk*, i32, i32, i32, [0 x i8] }
+%struct.rust_scheduler = type { %class.rust_thread, i32, i32, %class.rust_log, i32, %class.rust_srv*, i8*, %class.rust_task_list, %class.rust_task_list, %class.rust_task_list, %class.rust_task_list, %class.rust_crate_cache, %struct.randctx, %class.rust_kernel*, i32, i32, %class.lock_and_signal, i32, %struct._opaque_pthread_attr_t, %struct.rust_env*, %class.context }
+%struct.rust_shape_tables = type { i8*, i8* }
+%struct.rust_task = type { %struct.rust_task_user, i32, %class.context, %struct.rust_vec*, i32, %struct.rust_scheduler*, %class.rust_crate_cache*, %class.rust_kernel*, i8*, %class.rust_task_list*, %struct.rust_cond*, i8*, %struct.rust_task*, i32, i32, %class.timer, i32*, %class.array_list, i32, i32, %class.memory_region, %"class.rust_task::wakeup_callback"*, i8, i8, i8, %class.lock_and_signal, %class.hash_map, %class.rust_obstack, %"class.std::map", i32, %"class.debug::task_debug_info" }
+%struct.rust_task_user = type { i32, i32, %struct.chan_handle, i32 }
 %struct.rust_token = type opaque
-%class.ptr_vec.7 = type { %struct.rust_task*, i32, i32, %class.rust_chan** }
-%class.rust_chan = type { i32, %class.rust_kernel*, %struct.rust_task*, %class.rust_port*, i32, %class.circular_buffer }
-%class.circular_buffer = type { %class.rust_kernel*, i32, i32, i32, i32, i8* }
+%struct.rust_vec = type { i32, i32, [0 x i8] }
+%"struct.std::_Rb_tree<void *, std::pair<void *const, const type_desc *>, std::_Select1st<std::pair<void *const, const type_desc *> >, std::less<void *>, std::allocator<std::pair<void *const, const type_desc *> > >::_Rb_tree_impl" = type { %struct.rust_cond, %"struct.std::_Rb_tree_node_base", i32 }
+%"struct.std::_Rb_tree_node_base" = type { i32, %"struct.std::_Rb_tree_node_base"*, %"struct.std::_Rb_tree_node_base"*, %"struct.std::_Rb_tree_node_base"* }
+%struct.type_desc = type { %struct.type_desc**, i32, i32, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*)*, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*)*, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*)*, i8*, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*)*, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*)*, i32, void (i8*, %struct.rust_task*, i8*, %struct.type_desc**, i8*, i8*, i8)*, i8*, %struct.rust_shape_tables*, i32, i32, %struct.UT_hash_handle, i32, [0 x %struct.type_desc*] }
 
-@.str = private unnamed_addr constant [42 x i8] c"attempt to cast values of differing sizes\00", align 1
-@.str1 = private unnamed_addr constant [15 x i8] c"intrinsics.cpp\00", align 1
+@.str = private unnamed_addr constant [42 x i8] c"attempt to cast values of differing sizes\00"
+@.str1 = private unnamed_addr constant [15 x i8] c"intrinsics.cpp\00"
 
-define linkonce_odr void @rust_intrinsic_vec_len(%struct.rust_task* nocapture %task, i32* nocapture %retptr, %struct.type_desc* nocapture %ty, %struct.rust_vec** nocapture %v) nounwind {
-entry:
-  %ptr1 = load %struct.rust_vec** %v, align 4, !tbaa !0
-  %fill1 = getelementptr inbounds %struct.rust_vec* %ptr1, i32 0, i32 0
-  %tmp2 = load i32* %fill1, align 4, !tbaa !0
-  %size = getelementptr inbounds %struct.type_desc* %ty, i32 0, i32 1
-  %tmp20 = load i32* %size, align 4, !tbaa !0
-  %div = udiv i32 %tmp2, %tmp20
-  store i32 %div, i32* %retptr, align 4, !tbaa !0
+define void @rust_intrinsic_vec_len(%struct.rust_task* nocapture %task, i32* nocapture %retptr, %struct.type_desc* nocapture %ty, %struct.rust_vec** nocapture %vp) nounwind {
+  %1 = load %struct.rust_vec** %vp, align 4
+  %2 = getelementptr inbounds %struct.rust_vec* %1, i32 0, i32 0
+  %3 = load i32* %2, align 4
+  %4 = getelementptr inbounds %struct.type_desc* %ty, i32 0, i32 1
+  %5 = load i32* %4, align 4
+  %6 = udiv i32 %3, %5
+  store i32 %6, i32* %retptr, align 4
   ret void
 }
 
-define linkonce_odr void @rust_intrinsic_ptr_offset(%struct.rust_task* nocapture %task, i8** nocapture %retptr, %struct.type_desc* nocapture %ty, i8* %ptr, i32 %count) nounwind {
-entry:
-  %size = getelementptr inbounds %struct.type_desc* %ty, i32 0, i32 1
-  %tmp1 = load i32* %size, align 4, !tbaa !0
-  %mul = mul i32 %tmp1, %count
-  %arrayidx = getelementptr inbounds i8* %ptr, i32 %mul
-  store i8* %arrayidx, i8** %retptr, align 4, !tbaa !3
+define void @rust_intrinsic_ptr_offset(%struct.rust_task* nocapture %task, i8** nocapture %retptr, %struct.type_desc* nocapture %ty, i8* %ptr, i32 %count) nounwind {
+  %1 = getelementptr inbounds %struct.type_desc* %ty, i32 0, i32 1
+  %2 = load i32* %1, align 4
+  %3 = mul i32 %2, %count
+  %4 = getelementptr inbounds i8* %ptr, i32 %3
+  store i8* %4, i8** %retptr, align 4
   ret void
 }
 
-define linkonce_odr void @rust_intrinsic_cast(%struct.rust_task* %task, i8* nocapture %retptr, %struct.type_desc* nocapture %t1, %struct.type_desc* nocapture %t2, i8* nocapture %src) {
-entry:
-  %size = getelementptr inbounds %struct.type_desc* %t1, i32 0, i32 1
-  %tmp1 = load i32* %size, align 4, !tbaa !0
-  %size3 = getelementptr inbounds %struct.type_desc* %t2, i32 0, i32 1
-  %tmp4 = load i32* %size3, align 4, !tbaa !0
-  %cmp = icmp eq i32 %tmp1, %tmp4
-  br i1 %cmp, label %if.end, label %if.then
+define void @rust_intrinsic_cast(%struct.rust_task* %task, i8* nocapture %retptr, %struct.type_desc* nocapture %t1, %struct.type_desc* nocapture %t2, i8* nocapture %src) {
+  %1 = getelementptr inbounds %struct.type_desc* %t1, i32 0, i32 1
+  %2 = load i32* %1, align 4
+  %3 = getelementptr inbounds %struct.type_desc* %t2, i32 0, i32 1
+  %4 = load i32* %3, align 4
+  %5 = icmp eq i32 %2, %4
+  br i1 %5, label %7, label %6
 
 if.then:                                          ; preds = %entry
   tail call void @upcall_fail(i8* getelementptr inbounds ([42 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([15 x i8]* @.str1, i32 0, i32 0), i32 45)
   br label %return
 
-if.end:                                           ; preds = %entry
-  tail call void @llvm.memmove.p0i8.p0i8.i32(i8* %retptr, i8* %src, i32 %tmp1, i32 1, i1 false)
-  br label %return
+; <label>:7                                       ; preds = %0
+  tail call void @llvm.memmove.p0i8.p0i8.i32(i8* %retptr, i8* %src, i32 %2, i32 1, i1 false)
+  br label %8
 
-return:                                           ; preds = %if.end, %if.then
+; <label>:8                                       ; preds = %7, %6
   ret void
 }
 
@@ -98,9 +101,8 @@ declare void @upcall_fail(i8*, i8*, i32)
 
 declare void @llvm.memmove.p0i8.p0i8.i32(i8* nocapture, i8* nocapture, i32, i32, i1) nounwind
 
-define linkonce_odr void @rust_intrinsic_addr_of(%struct.rust_task* nocapture %task, i8** nocapture %retptr, %struct.type_desc* nocapture %ty, i8* %valptr) nounwind {
-entry:
-  store i8* %valptr, i8** %retptr, align 4, !tbaa !3
+define void @rust_intrinsic_addr_of(%struct.rust_task* nocapture %task, i8** nocapture %retptr, %struct.type_desc* nocapture %ty, i8* %valptr) nounwind {
+  store i8* %valptr, i8** %retptr, align 4
   ret void
 }
 
@@ -113,7 +115,8 @@ entry:
 
 declare void @port_recv(i32*, %class.rust_port*)
 
-!0 = metadata !{metadata !"long", metadata !1}
-!1 = metadata !{metadata !"omnipotent char", metadata !2}
-!2 = metadata !{metadata !"Simple C/C++ TBAA", null}
-!3 = metadata !{metadata !"any pointer", metadata !1}
+define void @rust_intrinsic_get_type_desc(%struct.rust_task* nocapture %task, i8** nocapture %retptr, %struct.type_desc* %ty) nounwind {
+  %ty.c = bitcast %struct.type_desc* %ty to i8*
+  store i8* %ty.c, i8** %retptr, align 4
+  ret void
+}

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -92,7 +92,7 @@ leak(void *thing) {
 }
 
 extern "C" CDECL intptr_t
-refcount(type_desc *t, intptr_t *v) {
+refcount(intptr_t *v) {
     // Passed-in value has refcount 1 too high
     // because it was ref'ed while making the call.
     return (*v) - 1;
@@ -107,11 +107,6 @@ extern "C" CDECL void
 unsupervise() {
     rust_task *task = rust_scheduler::get_task();
     task->unsupervise();
-}
-
-extern "C" CDECL type_desc*
-get_type_desc(void *unused_task, type_desc* t) {
-    return t;
 }
 
 extern "C" CDECL void

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -325,12 +325,12 @@ debug_ptrcast(type_desc *from_ty,
 }
 
 extern "C" CDECL rust_vec*
-rust_list_files(rust_vec **path) {
+rust_list_files(rust_str *path) {
     rust_task *task = rust_scheduler::get_task();
     array_list<rust_str*> strings;
 #if defined(__WIN32__)
     WIN32_FIND_DATA FindFileData;
-    HANDLE hFind = FindFirstFile((char*)(*path)->data, &FindFileData);
+    HANDLE hFind = FindFirstFile((char*)path->data, &FindFileData);
     if (hFind != INVALID_HANDLE_VALUE) {
         do {
             rust_str *str = make_str(task->kernel, FindFileData.cFileName,
@@ -341,7 +341,7 @@ rust_list_files(rust_vec **path) {
         FindClose(hFind);
     }
 #else
-    DIR *dirp = opendir((char*)(*path)->data);
+    DIR *dirp = opendir((char*)path->data);
   if (dirp) {
       struct dirent *dp;
       while ((dp = readdir(dirp))) {

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -160,22 +160,12 @@ rand_new() {
 }
 
 extern "C" CDECL size_t
-<<<<<<< HEAD
 rand_next(randctx *rctx) {
-=======
-rand_next(randctx *rctx)
-{
->>>>>>> move rand functions into c-stack-cdecl mode
     return isaac_rand(rctx);
 }
 
 extern "C" CDECL void
-<<<<<<< HEAD
 rand_free(randctx *rctx) {
-=======
-rand_free(randctx *rctx)
-{
->>>>>>> move rand functions into c-stack-cdecl mode
     rust_task *task = rust_scheduler::get_task();
     task->free(rctx);
 }
@@ -221,7 +211,9 @@ task_join(rust_task_id tid) {
 /* Debug builtins for std::dbg. */
 
 static void
-debug_tydesc_helper(rust_task* task, type_desc *t) {
+debug_tydesc_helper(type_desc *t)
+{
+    rust_task *task = rust_scheduler::get_task();
     LOG(task, stdlib, "  size %" PRIdPTR ", align %" PRIdPTR
         ", first_param 0x%" PRIxPTR,
         t->size, t->align, t->first_param);
@@ -231,14 +223,14 @@ extern "C" CDECL void
 debug_tydesc(type_desc *t) {
     rust_task *task = rust_scheduler::get_task();
     LOG(task, stdlib, "debug_tydesc");
-    debug_tydesc_helper(task, t);
+    debug_tydesc_helper(t);
 }
 
 extern "C" CDECL void
 debug_opaque(type_desc *t, uint8_t *front) {
     rust_task *task = rust_scheduler::get_task();
     LOG(task, stdlib, "debug_opaque");
-    debug_tydesc_helper(task, t);
+    debug_tydesc_helper(t);
     // FIXME may want to actually account for alignment.  `front` may not
     // indeed be the front byte of the passed-in argument.
     for (uintptr_t i = 0; i < t->size; ++front, ++i) {
@@ -257,7 +249,7 @@ extern "C" CDECL void
 debug_box(type_desc *t, rust_box *box) {
     rust_task *task = rust_scheduler::get_task();
     LOG(task, stdlib, "debug_box(0x%" PRIxPTR ")", box);
-    debug_tydesc_helper(task, t);
+    debug_tydesc_helper(t);
     LOG(task, stdlib, "  refcount %" PRIdPTR,
         box->ref_count - 1);  // -1 because we ref'ed for this call
     for (uintptr_t i = 0; i < t->size; ++i) {
@@ -275,7 +267,7 @@ debug_tag(type_desc *t, rust_tag *tag) {
     rust_task *task = rust_scheduler::get_task();
 
     LOG(task, stdlib, "debug_tag");
-    debug_tydesc_helper(task, t);
+    debug_tydesc_helper(t);
     LOG(task, stdlib, "  discriminant %" PRIdPTR, tag->discriminant);
 
     for (uintptr_t i = 0; i < t->size - sizeof(tag->discriminant); ++i)
@@ -293,7 +285,7 @@ debug_obj(type_desc *t, rust_obj *obj, size_t nmethods, size_t nbytes) {
     rust_task *task = rust_scheduler::get_task();
 
     LOG(task, stdlib, "debug_obj with %" PRIdPTR " methods", nmethods);
-    debug_tydesc_helper(task, t);
+    debug_tydesc_helper(t);
     LOG(task, stdlib, "  vtbl at 0x%" PRIxPTR, obj->vtbl);
     LOG(task, stdlib, "  body at 0x%" PRIxPTR, obj->body);
 
@@ -314,7 +306,7 @@ extern "C" CDECL void
 debug_fn(type_desc *t, rust_fn *fn) {
     rust_task *task = rust_scheduler::get_task();
     LOG(task, stdlib, "debug_fn");
-    debug_tydesc_helper(task, t);
+    debug_tydesc_helper(t);
     LOG(task, stdlib, "  thunk at 0x%" PRIxPTR, fn->thunk);
     LOG(task, stdlib, "  closure at 0x%" PRIxPTR, fn->closure);
     if (fn->closure) {
@@ -328,9 +320,9 @@ debug_ptrcast(type_desc *from_ty,
               void *ptr) {
     rust_task *task = rust_scheduler::get_task();
     LOG(task, stdlib, "debug_ptrcast from");
-    debug_tydesc_helper(task, from_ty);
+    debug_tydesc_helper(from_ty);
     LOG(task, stdlib, "to");
-    debug_tydesc_helper(task, to_ty);
+    debug_tydesc_helper(to_ty);
     return ptr;
 }
 

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -86,7 +86,7 @@ align_of(type_desc *t) {
 }
 
 extern "C" CDECL void
-leak(type_desc *t, void *thing) {
+leak(void *thing) {
     // Do nothing. Call this with move-mode in order to say "Don't worry rust,
     // I'll take care of this."
 }

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -160,12 +160,22 @@ rand_new() {
 }
 
 extern "C" CDECL size_t
+<<<<<<< HEAD
 rand_next(randctx *rctx) {
+=======
+rand_next(randctx *rctx)
+{
+>>>>>>> move rand functions into c-stack-cdecl mode
     return isaac_rand(rctx);
 }
 
 extern "C" CDECL void
+<<<<<<< HEAD
 rand_free(randctx *rctx) {
+=======
+rand_free(randctx *rctx)
+{
+>>>>>>> move rand functions into c-stack-cdecl mode
     rust_task *task = rust_scheduler::get_task();
     task->free(rctx);
 }

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -576,7 +576,6 @@ chan_id_send(type_desc *t, rust_task_id target_task_id,
             port->remote_chan->send(sptr);
         }
         target_task->deref();
-        task->yield();
     }
 }
 

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -559,8 +559,8 @@ void drop_port(rust_port *port) {
     port->ref_count--;
 }
 
-extern "C" CDECL void
-chan_send(rust_chan *chan, void *sptr) {
+extern "C" CDECL
+void chan_send(rust_chan *chan, void *sptr) {
     chan->send(sptr);
 }
 

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -65,6 +65,7 @@ task_join
 unsupervise
 upcall_alloc_c_stack
 upcall_call_c_stack
+upcall_call_c_stack_float
 upcall_cmp_type
 upcall_dynastack_alloc
 upcall_dynastack_alloc_2

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -62,7 +62,6 @@ vec_from_buf_shared
 task_sleep
 task_yield
 task_join
-get_type_desc
 unsupervise
 upcall_alloc_c_stack
 upcall_call_c_stack

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -1,8 +1,8 @@
 // based on:
 // http://shootout.alioth.debian.org/u32/benchmark.php?test=nbody&lang=java
 
-native "llvm" mod llvm {
-    fn sqrt(n: float) -> float = "sqrt.f64";
+native "c-stack-cdecl" mod llvm = "" {
+    fn sqrt(n: float) -> float;
 }
 
 fn main() {

--- a/src/test/run-pass/bind-native.rs
+++ b/src/test/run-pass/bind-native.rs
@@ -2,7 +2,7 @@
 Can we bind native things?
 */
 
-native "rust" mod rustrt {
+native "cdecl" mod rustrt {
     fn task_yield();
 }
 

--- a/src/test/run-pass/binops.rs
+++ b/src/test/run-pass/binops.rs
@@ -117,7 +117,7 @@ fn test_fn() {
     assert (h1 >= h2);
 }
 
-native "rust" mod native_mod = "" {
+native "cdecl" mod native_mod = "" {
     fn do_gc();
     fn unsupervise();
 }

--- a/src/test/run-pass/c-stack-as-value.rs
+++ b/src/test/run-pass/c-stack-as-value.rs
@@ -1,0 +1,9 @@
+// xfail-test
+
+native "c-stack-cdecl" mod rustrt {
+    fn unsupervise();
+}
+
+fn main() {
+    let _foo = rustrt::unsupervise;
+}

--- a/src/test/run-pass/conditional-compile.rs
+++ b/src/test/run-pass/conditional-compile.rs
@@ -4,13 +4,13 @@ const b: bool = false;
 const b: bool = true;
 
 #[cfg(bogus)]
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     // This symbol doesn't exist and would be a link error if this
     // module was translated
     fn bogus();
 }
 
-native "rust" mod rustrt { }
+native "c-stack-cdecl" mod rustrt { }
 
 #[cfg(bogus)]
 type t = int;
@@ -79,7 +79,7 @@ fn test_in_fn_ctxt() {
 }
 
 mod test_native_items {
-    native "rust" mod rustrt {
+    native "c-stack-cdecl" mod rustrt {
         #[cfg(bogus)]
         fn vec_from_buf_shared<T>(ptr: *T, count: uint) -> [T];
         fn vec_from_buf_shared<T>(ptr: *T, count: uint) -> [T];

--- a/src/test/run-pass/import-from-native.rs
+++ b/src/test/run-pass/import-from-native.rs
@@ -3,7 +3,7 @@ mod spam {
     fn eggs() { }
 }
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     import spam::{ham, eggs};
     export ham;
     export eggs;

--- a/src/test/run-pass/invoke-external-native.rs
+++ b/src/test/run-pass/invoke-external-native.rs
@@ -1,0 +1,11 @@
+// xfail-test
+
+import std::sys;
+
+// The purpose of this test is to check that we can
+// successfully (and safely) invoke external, c-stack-cdecl
+// functions from outside the crate.
+
+fn main() {
+    let foo = sys::rustrt::last_os_error();
+}

--- a/src/test/run-pass/issue-506.rs
+++ b/src/test/run-pass/issue-506.rs
@@ -9,6 +9,6 @@ native "cdecl" mod rustrt {
     fn task_yield();
 }
 
-fn yield_wrap() { rustrt::task_yield(); }
+fn yield_wrap(&&_arg: ()) { rustrt::task_yield(); }
 
 fn main() { task::spawn((), yield_wrap); }

--- a/src/test/run-pass/issue-506.rs
+++ b/src/test/run-pass/issue-506.rs
@@ -5,10 +5,10 @@
 use std;
 import std::task;
 
-native "rust" mod rustrt {
+native "cdecl" mod rustrt {
     fn task_yield();
 }
 
-fn yield_wrap(&&_i: ()) unsafe { rustrt::task_yield(); }
+fn yield_wrap() { rustrt::task_yield(); }
 
 fn main() { task::spawn((), yield_wrap); }

--- a/src/test/run-pass/item-attributes.rs
+++ b/src/test/run-pass/item-attributes.rs
@@ -29,7 +29,7 @@ mod test_single_attr_outer {
     mod mod1 { }
 
     #[attr = "val"]
-    native "rust" mod rustrt { }
+    native "c-stack-cdecl" mod rustrt { }
 
     #[attr = "val"]
     type t = obj { };
@@ -55,7 +55,7 @@ mod test_multi_attr_outer {
 
     #[attr1 = "val"]
     #[attr2 = "val"]
-    native "rust" mod rustrt { }
+    native "c-stack-cdecl" mod rustrt { }
 
     #[attr1 = "val"]
     #[attr2 = "val"]
@@ -83,7 +83,7 @@ mod test_stmt_single_attr_outer {
         }
 
         #[attr = "val"]
-        native "rust" mod rustrt {
+        native "c-stack-cdecl" mod rustrt {
         }
         */
 
@@ -116,7 +116,7 @@ mod test_stmt_multi_attr_outer {
 
         #[attr1 = "val"]
         #[attr2 = "val"]
-        native "rust" mod rustrt {
+        native "c-stack-cdecl" mod rustrt {
         }
         */
 
@@ -182,7 +182,7 @@ mod test_other_forms {
 }
 
 mod test_native_items {
-    native "rust" mod rustrt {
+    native "c-stack-cdecl" mod rustrt {
         #[attr];
 
         #[attr]

--- a/src/test/run-pass/native-mod.rc
+++ b/src/test/run-pass/native-mod.rc
@@ -10,7 +10,7 @@ native mod libc = target_libc {
   fn free(int p) -> ();
 }
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
   fn str_buf(str s) -> int;
 }
 

--- a/src/test/run-pass/native.rc
+++ b/src/test/run-pass/native.rc
@@ -1,7 +1,7 @@
 // xfail-test
 // -*- rust -*-
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
   fn str_buf(str s) -> int;
 }
 

--- a/src/test/run-pass/native2.rs
+++ b/src/test/run-pass/native2.rs
@@ -1,10 +1,10 @@
 
 
-native "rust" mod rustrt {
+native "c-stack-cdecl" mod rustrt {
     fn unsupervise();
 }
 
-native "rust" mod bar = "" { }
+native "c-stack-cdecl" mod bar = "" { }
 
 native "cdecl" mod zed = "" { }
 

--- a/src/test/run-pass/unique-copy-box.rs
+++ b/src/test/run-pass/unique-copy-box.rs
@@ -1,5 +1,5 @@
 use std;
-import std::sys::rustrt::refcount;
+import std::sys::refcount;
 
 fn main() unsafe {
     let i = ~@1;

--- a/src/test/stdtest/comm.rs
+++ b/src/test/stdtest/comm.rs
@@ -5,6 +5,13 @@ import std::comm;
 fn create_port_and_chan() { let p = comm::port::<int>(); comm::chan(p); }
 
 #[test]
+fn send_int() {
+    let p = comm::port::<int>();
+    let c = comm::chan(p);
+    comm::send(c, 22);
+}
+
+#[test]
 fn send_recv_fn() {
     let p = comm::port::<int>();
     let c = comm::chan::<int>(p);
@@ -21,8 +28,16 @@ fn send_recv_fn_infer() {
 }
 
 #[test]
-fn chan_chan() {
+fn chan_chan_infer() {
     let p = comm::port(), p2 = comm::port::<int>();
+    let c = comm::chan(p);
+    comm::send(c, comm::chan(p2));
+    comm::recv(p);
+}
+
+#[test]
+fn chan_chan() {
+    let p = comm::port::<comm::chan<int>>(), p2 = comm::port::<int>();
     let c = comm::chan(p);
     comm::send(c, comm::chan(p2));
     comm::recv(p);

--- a/src/test/stdtest/sys.rs
+++ b/src/test/stdtest/sys.rs
@@ -1,4 +1,6 @@
 import std::sys;
 
 #[test]
-fn last_os_error() unsafe { log sys::rustrt::last_os_error(); }
+fn last_os_error() {
+    log sys::last_os_error();
+}


### PR DESCRIPTION
second half of the patch to remove uses of the "rust" ABI.  This half mostly adjusts function declarations.  It also fixes a bug in c-stack-cdecl concerning float return values.  This fix will need to propagate before uses of "llvm" ABI can be fully replaced w/ c-stack-cdecl.
