### PR TITLE
Add function aliases for float operators, and clean up other numeric functions

### DIFF
--- a/src/comp/back/rpath.rs
+++ b/src/comp/back/rpath.rs
@@ -3,6 +3,7 @@ import std::fs;
 import std::os_fs;
 import std::vec;
 import std::map;
+import std::math;
 import std::str;
 import std::uint;
 import metadata::cstore;
@@ -128,7 +129,7 @@ fn get_relative_to(abs1: fs::path, abs2: fs::path) -> fs::path {
     assert len1 > 0u;
     assert len2 > 0u;
 
-    let max_common_path = uint::min(len1, len2) - 1u;
+    let max_common_path = math::min(len1, len2) - 1u;
     let start_idx = 0u;
     while start_idx < max_common_path
         && split1[start_idx] == split2[start_idx] {

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -6,6 +6,7 @@ import std::box;
 import std::ufind;
 import std::map;
 import std::map::hashmap;
+import std::math;
 import std::option;
 import std::option::none;
 import std::option::some;
@@ -1812,7 +1813,7 @@ mod unify {
     // Unifies two sets.
     fn union(cx: @ctxt, set_a: uint, set_b: uint,
              variance: variance) -> union_result {
-        ufind::grow(cx.vb.sets, uint::max(set_a, set_b) + 1u);
+        ufind::grow(cx.vb.sets, math::max(set_a, set_b) + 1u);
         let root_a = ufind::find(cx.vb.sets, set_a);
         let root_b = ufind::find(cx.vb.sets, set_b);
 

--- a/src/fuzzer/fuzzer.rs
+++ b/src/fuzzer/fuzzer.rs
@@ -1,7 +1,7 @@
 use std;
 use rustc;
 
-import std::{fs, io, getopts, vec, str, int, uint, option};
+import std::{fs, io, getopts, math, vec, str, int, uint, option};
 import std::getopts::{optopt, opt_present, opt_str};
 import std::io::stdout;
 
@@ -242,9 +242,9 @@ fn check_variants_T<T>(
     let L = vec::len(things);
 
     if L < 100u {
-        under(uint::min(L, 20u)) {|i|
+        under(math::min(L, 20u)) {|i|
             log_err "Replacing... #" + uint::str(i);
-            under(uint::min(L, 30u)) {|j|
+            under(math::min(L, 30u)) {|j|
                 log_err "With... " + stringifier(@things[j]);
                 let crate2 = @replacer(crate, i, things[j], cx.mode);
                 // It would be best to test the *crate* for stability, but testing the

--- a/src/lib/float.rs
+++ b/src/lib/float.rs
@@ -223,6 +223,36 @@ fn neg_infinity() -> float {
    ret -1./0.;
 }
 
+pure fn add(x: float, y: float) -> float { ret x + y; }
+
+pure fn sub(x: float, y: float) -> float { ret x - y; }
+
+pure fn mul(x: float, y: float) -> float { ret x * y; }
+
+pure fn div(x: float, y: float) -> float { ret x / y; }
+
+pure fn rem(x: float, y: float) -> float { ret x % y; }
+
+pure fn lt(x: float, y: float) -> bool { ret x < y; }
+
+pure fn le(x: float, y: float) -> bool { ret x <= y; }
+
+pure fn eq(x: float, y: float) -> bool { ret x == y; }
+
+pure fn ne(x: float, y: float) -> bool { ret x != y; }
+
+pure fn ge(x: float, y: float) -> bool { ret x >= y; }
+
+pure fn gt(x: float, y: float) -> bool { ret x > y; }
+
+pure fn positive(x: float) -> bool { ret x > 0.; }
+
+pure fn negative(x: float) -> bool { ret x < 0.; }
+
+pure fn nonpositive(x: float) -> bool { ret x <= 0.; }
+
+pure fn nonnegative(x: float) -> bool { ret x >= 0.; }
+
 //
 // Local Variables:
 // mode: rust

--- a/src/lib/float.rs
+++ b/src/lib/float.rs
@@ -223,34 +223,49 @@ fn neg_infinity() -> float {
    ret -1./0.;
 }
 
+/* Function: add */
 pure fn add(x: float, y: float) -> float { ret x + y; }
 
+/* Function: sub */
 pure fn sub(x: float, y: float) -> float { ret x - y; }
 
+/* Function: mul */
 pure fn mul(x: float, y: float) -> float { ret x * y; }
 
+/* Function: div */
 pure fn div(x: float, y: float) -> float { ret x / y; }
 
+/* Function: rem */
 pure fn rem(x: float, y: float) -> float { ret x % y; }
 
+/* Predicate: lt */
 pure fn lt(x: float, y: float) -> bool { ret x < y; }
 
+/* Predicate: le */
 pure fn le(x: float, y: float) -> bool { ret x <= y; }
 
+/* Predicate: eq */
 pure fn eq(x: float, y: float) -> bool { ret x == y; }
 
+/* Predicate: ne */
 pure fn ne(x: float, y: float) -> bool { ret x != y; }
 
+/* Predicate: ge */
 pure fn ge(x: float, y: float) -> bool { ret x >= y; }
 
+/* Predicate: gt */
 pure fn gt(x: float, y: float) -> bool { ret x > y; }
 
+/* Predicate: positive */
 pure fn positive(x: float) -> bool { ret x > 0.; }
 
+/* Predicate: negative */
 pure fn negative(x: float) -> bool { ret x < 0.; }
 
+/* Predicate: nonpositive */
 pure fn nonpositive(x: float) -> bool { ret x <= 0.; }
 
+/* Predicate: nonnegative */
 pure fn nonnegative(x: float) -> bool { ret x >= 0.; }
 
 //

--- a/src/lib/u8.rs
+++ b/src/lib/u8.rs
@@ -1,26 +1,52 @@
+/*
+Module: u8
+*/
+
+/*
+Function: max_value
+
+The maximum value of a u8.
+*/
 pure fn max_value() -> u8 { ret 255u8; }
+
+/*
+Function: min_value
+
+The minumum value of a u8.
+*/
 pure fn min_value() -> u8 { ret 0u8; }
 
+/* Function: add */
 pure fn add(x: u8, y: u8) -> u8 { ret x + y; }
 
+/* Function: sub */
 pure fn sub(x: u8, y: u8) -> u8 { ret x - y; }
 
+/* Function: mul */
 pure fn mul(x: u8, y: u8) -> u8 { ret x * y; }
 
+/* Function: div */
 pure fn div(x: u8, y: u8) -> u8 { ret x / y; }
 
+/* Function: rem */
 pure fn rem(x: u8, y: u8) -> u8 { ret x % y; }
 
+/* Predicate: lt */
 pure fn lt(x: u8, y: u8) -> bool { ret x < y; }
 
+/* Predicate: le */
 pure fn le(x: u8, y: u8) -> bool { ret x <= y; }
 
+/* Predicate: eq */
 pure fn eq(x: u8, y: u8) -> bool { ret x == y; }
 
+/* Predicate: ne */
 pure fn ne(x: u8, y: u8) -> bool { ret x != y; }
 
+/* Predicate: ge */
 pure fn ge(x: u8, y: u8) -> bool { ret x >= y; }
 
+/* Predicate: gt */
 pure fn gt(x: u8, y: u8) -> bool { ret x > y; }
 
 fn range(lo: u8, hi: u8, it: block(u8)) {

--- a/src/lib/uint.rs
+++ b/src/lib/uint.rs
@@ -14,15 +14,15 @@ pure fn max_value() -> uint {
      ret 0u - 1u;
 }
 
-fn add(x: uint, y: uint) -> uint { ret x + y; }
+pure fn add(x: uint, y: uint) -> uint { ret x + y; }
 
-fn sub(x: uint, y: uint) -> uint { ret x - y; }
+pure fn sub(x: uint, y: uint) -> uint { ret x - y; }
 
-fn mul(x: uint, y: uint) -> uint { ret x * y; }
+pure fn mul(x: uint, y: uint) -> uint { ret x * y; }
 
-fn div(x: uint, y: uint) -> uint { ret x / y; }
+pure fn div(x: uint, y: uint) -> uint { ret x / y; }
 
-fn rem(x: uint, y: uint) -> uint { ret x % y; }
+pure fn rem(x: uint, y: uint) -> uint { ret x % y; }
 
 pure fn lt(x: uint, y: uint) -> bool { ret x < y; }
 

--- a/src/lib/uint.rs
+++ b/src/lib/uint.rs
@@ -55,10 +55,6 @@ pure fn ge(x: uint, y: uint) -> bool { ret x >= y; }
 /* Predicate: gt */
 pure fn gt(x: uint, y: uint) -> bool { ret x > y; }
 
-fn max(x: uint, y: uint) -> uint { if x > y { ret x; } ret y; }
-
-fn min(x: uint, y: uint) -> uint { if x > y { ret y; } ret x; }
-
 /*
 Function: range
 

--- a/src/lib/uint.rs
+++ b/src/lib/uint.rs
@@ -1,49 +1,78 @@
-/**
- * Return the minimal value for an uint.
- *
- * This is always 0
- */
+/*
+Module: uint
+*/
+
+/*
+Function: min_value
+
+Return the minimal value for an uint.
+
+This is always 0
+*/
 pure fn min_value() -> uint { ret 0u; }
 
-/**
- * Return the maximal value for an uint.
- *
- * This is 2^wordsize - 1
- */
+/*
+Function: max_value
+
+Return the maximal value for an uint.
+
+This is 2^wordsize - 1
+*/
 pure fn max_value() -> uint {
      ret 0u - 1u;
 }
 
+/* Function: add */
 pure fn add(x: uint, y: uint) -> uint { ret x + y; }
 
+/* Function: sub */
 pure fn sub(x: uint, y: uint) -> uint { ret x - y; }
 
+/* Function: mul */
 pure fn mul(x: uint, y: uint) -> uint { ret x * y; }
 
+/* Function: div */
 pure fn div(x: uint, y: uint) -> uint { ret x / y; }
 
+/* Function: rem */
 pure fn rem(x: uint, y: uint) -> uint { ret x % y; }
 
+/* Predicate: lt */
 pure fn lt(x: uint, y: uint) -> bool { ret x < y; }
 
+/* Predicate: le */
 pure fn le(x: uint, y: uint) -> bool { ret x <= y; }
 
+/* Predicate: eq */
 pure fn eq(x: uint, y: uint) -> bool { ret x == y; }
 
+/* Predicate: ne */
 pure fn ne(x: uint, y: uint) -> bool { ret x != y; }
 
+/* Predicate: ge */
 pure fn ge(x: uint, y: uint) -> bool { ret x >= y; }
 
+/* Predicate: gt */
 pure fn gt(x: uint, y: uint) -> bool { ret x > y; }
 
 fn max(x: uint, y: uint) -> uint { if x > y { ret x; } ret y; }
 
 fn min(x: uint, y: uint) -> uint { if x > y { ret y; } ret x; }
 
+/*
+Function: range
+
+Iterate over the range [`lo`..`hi`)
+*/
 fn range(lo: uint, hi: uint, it: block(uint)) {
     while lo < hi { it(lo); lo += 1u; }
 }
 
+/*
+Function: next_power_of_two
+
+Returns the smallest power of 2 greater than or equal to `n`
+*/
 fn next_power_of_two(n: uint) -> uint {
     let halfbits: uint = sys::size_of::<uint>() * 4u;
     let tmp: uint = n - 1u;
@@ -52,6 +81,20 @@ fn next_power_of_two(n: uint) -> uint {
     ret tmp + 1u;
 }
 
+/*
+Function: parse_buf
+
+Parse a buffer of bytes
+
+Parameters:
+
+buf - A byte buffer
+radix - The base of the number
+
+Failure:
+
+buf must not be empty
+*/
 fn parse_buf(buf: [u8], radix: uint) -> uint {
     if vec::len::<u8>(buf) == 0u {
         log_err "parse_buf(): buf is empty";
@@ -69,8 +112,22 @@ fn parse_buf(buf: [u8], radix: uint) -> uint {
     fail;
 }
 
+/*
+Function: from_str
+
+Parse a string to an int
+
+Failure:
+
+s must not be empty
+*/
 fn from_str(s: str) -> uint { parse_buf(str::bytes(s), 10u) }
 
+/*
+Function: to_str
+
+Convert to a string in a given base
+*/
 fn to_str(num: uint, radix: uint) -> str {
     let n = num;
     assert (0u < radix && radix <= 16u);
@@ -106,6 +163,12 @@ fn to_str(num: uint, radix: uint) -> str {
     while len != 0u { len -= 1u; s1 += str::unsafe_from_byte(s[len]); }
     ret s1;
 }
+
+/*
+Function: str
+
+Convert to a string
+*/
 fn str(i: uint) -> str { ret to_str(i, 10u); }
 
 // Local Variables:


### PR DESCRIPTION
Here's a patch to add functions to `std::float` that match the ones in `std::int` and `std::uint`.

Also included are some patches to clean up signatures and documentation for related functions, and remove a couple of redundant functions.
