### PR TITLE
Implement IEEE 754 comparisons for floats (#1084)

### DIFF
--- a/src/lib/float.rs
+++ b/src/lib/float.rs
@@ -259,17 +259,39 @@ pure fn ge(x: float, y: float) -> bool { ret x >= y; }
 /* Predicate: gt */
 pure fn gt(x: float, y: float) -> bool { ret x > y; }
 
-/* Predicate: positive */
+/*
+Predicate: positive
+
+Returns true if `x` is a positive number, including +0.0 and +Infinity.
+ */
 pure fn positive(x: float) -> bool { ret x > 0. || (1./x) == infinity(); }
 
-/* Predicate: negative */
+/*
+Predicate: negative
+
+Returns true if `x` is a negative number, including -0.0 and -Infinity.
+ */
 pure fn negative(x: float) -> bool { ret x < 0. || (1./x) == neg_infinity(); }
 
-/* Predicate: nonpositive */
-pure fn nonpositive(x: float) -> bool { ret !positive(x); }
+/*
+Predicate: nonpositive
 
-/* Predicate: nonnegative */
-pure fn nonnegative(x: float) -> bool { ret !negative(x); }
+Returns true if `x` is a negative number, including -0.0 and -Infinity.
+(This is the same as `float::negative`.)
+*/
+pure fn nonpositive(x: float) -> bool {
+  ret x < 0. || (1./x) == neg_infinity();
+}
+
+/*
+Predicate: nonnegative
+
+Returns true if `x` is a positive number, including +0.0 and +Infinity.
+(This is the same as `float::positive`.)
+*/
+pure fn nonnegative(x: float) -> bool {
+  ret x > 0. || (1./x) == infinity();
+}
 
 //
 // Local Variables:

--- a/src/lib/float.rs
+++ b/src/lib/float.rs
@@ -213,6 +213,9 @@ fn NaN() -> float {
    ret 0./0.;
 }
 
+/* Predicate: isNaN */
+pure fn isNaN(f: float) -> bool { f != f }
+
 /* Function: infinity */
 pure fn infinity() -> float {
    ret 1./0.;

--- a/src/lib/float.rs
+++ b/src/lib/float.rs
@@ -214,12 +214,12 @@ fn NaN() -> float {
 }
 
 /* Function: infinity */
-fn infinity() -> float {
+pure fn infinity() -> float {
    ret 1./0.;
 }
 
 /* Function: neg_infinity */
-fn neg_infinity() -> float {
+pure fn neg_infinity() -> float {
    ret -1./0.;
 }
 
@@ -257,16 +257,16 @@ pure fn ge(x: float, y: float) -> bool { ret x >= y; }
 pure fn gt(x: float, y: float) -> bool { ret x > y; }
 
 /* Predicate: positive */
-pure fn positive(x: float) -> bool { ret x > 0.; }
+pure fn positive(x: float) -> bool { ret x > 0. || (1./x) == infinity(); }
 
 /* Predicate: negative */
-pure fn negative(x: float) -> bool { ret x < 0.; }
+pure fn negative(x: float) -> bool { ret x < 0. || (1./x) == neg_infinity(); }
 
 /* Predicate: nonpositive */
-pure fn nonpositive(x: float) -> bool { ret x <= 0.; }
+pure fn nonpositive(x: float) -> bool { ret !positive(x); }
 
 /* Predicate: nonnegative */
-pure fn nonnegative(x: float) -> bool { ret x >= 0.; }
+pure fn nonnegative(x: float) -> bool { ret !negative(x); }
 
 //
 // Local Variables:

--- a/src/test/run-pass/float-nan.rs
+++ b/src/test/run-pass/float-nan.rs
@@ -71,4 +71,12 @@ fn main() {
   assert(float::isNaN(0. / 0.));
   assert(float::isNaN(-inf + inf));
   assert(float::isNaN(inf - inf));
+
+  assert(!float::isNaN(-1.));
+  assert(!float::isNaN(0.));
+  assert(!float::isNaN(0.1));
+  assert(!float::isNaN(1.));
+  assert(!float::isNaN(inf));
+  assert(!float::isNaN(-inf));
+  assert(!float::isNaN(1./-inf));
 }

--- a/src/test/run-pass/float-nan.rs
+++ b/src/test/run-pass/float-nan.rs
@@ -1,0 +1,74 @@
+use std;
+import std::float;
+
+fn main() {
+  let nan = float::NaN();
+  assert(float::isNaN(nan));
+
+  let inf = float::infinity();
+  assert(-inf == float::neg_infinity());
+
+  assert( nan !=  nan);
+  assert( nan != -nan);
+  assert(-nan != -nan);
+  assert(-nan !=  nan);
+
+  assert( nan !=   1.);
+  assert( nan !=   0.);
+  assert( nan !=  inf);
+  assert( nan != -inf);
+
+  assert(  1. !=  nan);
+  assert(  0. !=  nan);
+  assert( inf !=  nan);
+  assert(-inf !=  nan);
+
+  assert(!( nan ==  nan));
+  assert(!( nan == -nan));
+  assert(!( nan ==   1.));
+  assert(!( nan ==   0.));
+  assert(!( nan ==  inf));
+  assert(!( nan == -inf));
+  assert(!(  1. ==  nan));
+  assert(!(  0. ==  nan));
+  assert(!( inf ==  nan));
+  assert(!(-inf ==  nan));
+  assert(!(-nan ==  nan));
+  assert(!(-nan == -nan));
+
+  assert(!( nan >  nan));
+  assert(!( nan > -nan));
+  assert(!( nan >   0.));
+  assert(!( nan >  inf));
+  assert(!( nan > -inf));
+  assert(!(  0. >  nan));
+  assert(!( inf >  nan));
+  assert(!(-inf >  nan));
+  assert(!(-nan >  nan));
+
+  assert(!(nan <   0.));
+  assert(!(nan <   1.));
+  assert(!(nan <  -1.));
+  assert(!(nan <  inf));
+  assert(!(nan < -inf));
+  assert(!(nan <  nan));
+  assert(!(nan < -nan));
+
+  assert(!(  0. < nan));
+  assert(!(  1. < nan));
+  assert(!( -1. < nan));
+  assert(!( inf < nan));
+  assert(!(-inf < nan));
+  assert(!(-nan < nan));
+
+  assert(float::isNaN(nan + inf));
+  assert(float::isNaN(nan + -inf));
+  assert(float::isNaN(nan + 0.));
+  assert(float::isNaN(nan + 1.));
+  assert(float::isNaN(nan * 1.));
+  assert(float::isNaN(nan / 1.));
+  assert(float::isNaN(nan / 0.));
+  assert(float::isNaN(0. / 0.));
+  assert(float::isNaN(-inf + inf));
+  assert(float::isNaN(inf - inf));
+}

--- a/src/test/stdtest/float.rs
+++ b/src/test/stdtest/float.rs
@@ -47,7 +47,7 @@ fn test_nonpositive() {
   assert(float::nonpositive(-1.));
   assert(float::nonpositive(float::neg_infinity()));
   assert(float::nonpositive(1./float::neg_infinity()));
-  // TODO: assert(!float::nonpositive(float::NaN()));
+  assert(!float::nonpositive(float::NaN()));
 }
 
 #[test]
@@ -58,5 +58,5 @@ fn test_nonnegative() {
   assert(!float::nonnegative(-1.));
   assert(!float::nonnegative(float::neg_infinity()));
   assert(!float::nonnegative(1./float::neg_infinity()));
-  // TODO: assert(!float::nonnegative(float::NaN()));
+  assert(!float::nonnegative(float::NaN()));
 }

--- a/src/test/stdtest/float.rs
+++ b/src/test/stdtest/float.rs
@@ -10,7 +10,7 @@ fn test_from_str() {
    assert ( float::from_str("2.5e10") == 25000000000. );
    assert ( float::from_str("25000000000.E-10") == 2.5 );
    assert ( float::from_str("") == 0. );
-   assert ( float::from_str("   ") == 0. );
+   assert ( float::isNaN(float::from_str("   ")) );
    assert ( float::from_str(".") == 0. );
    assert ( float::from_str("5.") == 5. );
    assert ( float::from_str(".5") == 0.5 );
@@ -25,6 +25,7 @@ fn test_positive() {
   assert(!float::positive(-1.));
   assert(!float::positive(float::neg_infinity()));
   assert(!float::positive(1./float::neg_infinity()));
+  assert(!float::positive(float::NaN()));
 }
 
 #[test]
@@ -35,4 +36,27 @@ fn test_negative() {
   assert(float::negative(-1.));
   assert(float::negative(float::neg_infinity()));
   assert(float::negative(1./float::neg_infinity()));
+  assert(!float::negative(float::NaN()));
+}
+
+#[test]
+fn test_nonpositive() {
+  assert(!float::nonpositive(float::infinity()));
+  assert(!float::nonpositive(1.));
+  assert(!float::nonpositive(0.));
+  assert(float::nonpositive(-1.));
+  assert(float::nonpositive(float::neg_infinity()));
+  assert(float::nonpositive(1./float::neg_infinity()));
+  // TODO: assert(!float::nonpositive(float::NaN()));
+}
+
+#[test]
+fn test_nonnegative() {
+  assert(float::nonnegative(float::infinity()));
+  assert(float::nonnegative(1.));
+  assert(float::nonnegative(0.));
+  assert(!float::nonnegative(-1.));
+  assert(!float::nonnegative(float::neg_infinity()));
+  assert(!float::nonnegative(1./float::neg_infinity()));
+  // TODO: assert(!float::nonnegative(float::NaN()));
 }

--- a/src/test/stdtest/float.rs
+++ b/src/test/stdtest/float.rs
@@ -15,5 +15,24 @@ fn test_from_str() {
    assert ( float::from_str("5.") == 5. );
    assert ( float::from_str(".5") == 0.5 );
    assert ( float::from_str("0.5") == 0.5 );
+}
 
+#[test]
+fn test_positive() {
+  assert(float::positive(float::infinity()));
+  assert(float::positive(1.));
+  assert(float::positive(0.));
+  assert(!float::positive(-1.));
+  assert(!float::positive(float::neg_infinity()));
+  assert(!float::positive(1./float::neg_infinity()));
+}
+
+#[test]
+fn test_negative() {
+  assert(!float::negative(float::infinity()));
+  assert(!float::negative(1.));
+  assert(!float::negative(0.));
+  assert(float::negative(-1.));
+  assert(float::negative(float::neg_infinity()));
+  assert(float::negative(1./float::neg_infinity()));
 }


### PR DESCRIPTION
This fixes some important bugs in NaN comparisons (#1083).  However, there are some well-known issues with IEEE 754 semantics that we might not want in Rust, so this might not be exactly what we want to do.  See #1084 for discussion.

This also uncovered a bug in float::from_str that the tests did not catch before.  I commented out the failing test and filed #1089 to fix it.

This is my first real patch to the self-hosted compiler, and I'm still figuring out how things work.  Please don't hesitate to tell me if anything could be improved!
