### PR TITLE
Prioritize GCC over Clang if CFG_ONLY_GCC is set.

### DIFF
--- a/configure
+++ b/configure
@@ -324,7 +324,7 @@ case $CFG_LLVM_VERSION in
     ;;
 esac
 
-if [ ! -z "$CFG_CLANG" ]
+if [ ! -z "$CFG_CLANG" -a -z "$CFG_ONLY_GCC" ]
 then
     CFG_CLANG_VERSION=$("$CFG_CLANG" \
                       --version \


### PR DESCRIPTION
On OS X I'd rather just be able to use GCC instead of the clang builds I use/play with.
