### PR TITLE
Add should_fail annotation for unit tests

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -170,7 +170,8 @@ fn make_test(cx: cx, testfile: str, configport: port<[u8]>) ->
    test::test_desc<fn@()> {
     {name: make_test_name(cx.config, testfile),
      fn: make_test_closure(testfile, chan(configport)),
-     ignore: header::is_test_ignored(cx.config, testfile)}
+     ignore: header::is_test_ignored(cx.config, testfile),
+     should_fail: false}
 }
 
 fn make_test_name(config: config, testfile: str) -> str {

--- a/src/test/stdtest/char.rs
+++ b/src/test/stdtest/char.rs
@@ -26,3 +26,15 @@ fn test_to_digit() {
     assert (char::to_digit('z') == 35u8);
     assert (char::to_digit('Z') == 35u8);
 }
+
+#[test]
+#[should_fail]
+fn test_to_digit_fail_1() {
+    char::to_digit(' ');
+}
+
+#[test]
+#[should_fail]
+fn test_to_digit_fail_2() {
+    char::to_digit('$');
+}

--- a/src/test/stdtest/int.rs
+++ b/src/test/stdtest/int.rs
@@ -20,6 +20,18 @@ fn test_from_str() {
 }
 
 #[test]
+#[should_fail]
+fn test_from_str_fail_1() {
+    int::from_str(" ");
+}
+
+#[test]
+#[should_fail]
+fn test_from_str_fail_2() {
+    int::from_str("x");
+}
+
+#[test]
 fn test_parse_buf() {
     assert (int::parse_buf(bytes("123"), 10u) == 123);
     assert (int::parse_buf(bytes("1001"), 2u) == 9);
@@ -38,6 +50,18 @@ fn test_parse_buf() {
     assert (int::parse_buf(bytes("-FFFF"), 16u) == -65535);
     assert (int::parse_buf(bytes("-z"), 36u) == -35);
     assert (int::parse_buf(bytes("-Z"), 36u) == -35);
+}
+
+#[test]
+#[should_fail]
+fn test_parse_buf_fail_1() {
+    int::parse_buf(bytes("Z"), 35u);
+}
+
+#[test]
+#[should_fail]
+fn test_parse_buf_fail_2() {
+    int::parse_buf(bytes("-9"), 2u);
 }
 
 #[test]

--- a/src/test/stdtest/test.rs
+++ b/src/test/stdtest/test.rs
@@ -7,7 +7,7 @@ import std::vec;
 #[test]
 fn do_not_run_ignored_tests() {
     fn f() { fail; }
-    let desc = {name: "whatever", fn: f, ignore: true};
+    let desc = {name: "whatever", fn: f, ignore: true, should_fail: false};
     let future = test::run_test(desc, test::default_test_to_task);
     let result = future.wait();
     assert result != test::tr_ok;
@@ -16,9 +16,25 @@ fn do_not_run_ignored_tests() {
 #[test]
 fn ignored_tests_result_in_ignored() {
     fn f() { }
-    let desc = {name: "whatever", fn: f, ignore: true};
+    let desc = {name: "whatever", fn: f, ignore: true, should_fail: false};
     let res = test::run_test(desc, test::default_test_to_task).wait();
     assert (res == test::tr_ignored);
+}
+
+#[test]
+fn test_should_fail() {
+    fn f() { fail; }
+    let desc = {name: "whatever", fn: f, ignore: false, should_fail: true};
+    let res = test::run_test(desc, test::default_test_to_task).wait();
+    assert res == test::tr_ok;
+}
+
+#[test]
+fn test_should_fail_but_succeeds() {
+    fn f() { }
+    let desc = {name: "whatever", fn: f, ignore: false, should_fail: true};
+    let res = test::run_test(desc, test::default_test_to_task).wait();
+    assert res == test::tr_failed;
 }
 
 #[test]
@@ -44,8 +60,8 @@ fn filter_for_ignored_option() {
 
     let opts = {filter: option::none, run_ignored: true};
     let tests =
-        [{name: "1", fn: fn () { }, ignore: true},
-         {name: "2", fn: fn () { }, ignore: false}];
+        [{name: "1", fn: fn () { }, ignore: true, should_fail: false},
+         {name: "2", fn: fn () { }, ignore: false, should_fail: false}];
     let filtered = test::filter_tests(opts, tests);
 
     assert (vec::len(filtered) == 1u);
@@ -69,7 +85,8 @@ fn sort_tests() {
             let testfn = fn () { };
             let tests = [];
             for name: str in names {
-                let test = {name: name, fn: testfn, ignore: false};
+                let test = {name: name, fn: testfn, ignore: false,
+                  should_fail: false};
                 tests += [test];
             }
             tests

--- a/src/test/stdtest/uint.rs
+++ b/src/test/stdtest/uint.rs
@@ -15,6 +15,18 @@ fn test_from_str() {
 }
 
 #[test]
+#[should_fail]
+fn test_from_str_fail_1() {
+    uint::from_str(" ");
+}
+
+#[test]
+#[should_fail]
+fn test_from_str_fail_2() {
+    uint::from_str("x");
+}
+
+#[test]
 fn test_parse_buf() {
     assert (uint::parse_buf(bytes("123"), 10u) == 123u);
     assert (uint::parse_buf(bytes("1001"), 2u) == 9u);
@@ -22,6 +34,18 @@ fn test_parse_buf() {
     assert (uint::parse_buf(bytes("123"), 16u) == 291u);
     assert (uint::parse_buf(bytes("ffff"), 16u) == 65535u);
     assert (uint::parse_buf(bytes("z"), 36u) == 35u);
+}
+
+#[test]
+#[should_fail]
+fn test_parse_buf_fail_1() {
+    uint::parse_buf(bytes("Z"), 10u);
+}
+
+#[test]
+#[should_fail]
+fn test_parse_buf_fail_2() {
+    uint::parse_buf(bytes("_"), 2u);
 }
 
 #[test]


### PR DESCRIPTION
This allows test cases to assert that a function is expected to fail. Tests annotated with "should_fail" will succeed only if the function fails.
