### PR TITLE
rustc: add --read-attr <name>

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -50,6 +50,10 @@ Pretty-print the input. Valid \fItype\fRs are:
 \fB--ls\fR:
 Lists symbols defined by the specified \fBcompiled\fR library.
 .TP
+\fB--read-attr\fR \fIname\fR:
+Print the named attribute of the specified \fBcompiled\fR library, or nothing
+if no such attribute exists.
+.TP
 \fB-L\fR \fIpath\fR:
 Adds \fIpath\fR to the library search path.
 .TP

--- a/src/comp/driver/rustc.rs
+++ b/src/comp/driver/rustc.rs
@@ -251,6 +251,7 @@ options:
     --static           use or produce static libraries
     --pretty [type]    pretty-print the input instead of compiling
     --ls               list the symbols defined by a crate file
+    --read-attr <name> read a specific crate attribute
     -L <path>          add a directory to the library search path
     --noverify         suppress LLVM verification step (slight speedup)
     --parse-only       parse only; do not compile, assemble, or link
@@ -448,7 +449,8 @@ fn opts() -> [getopts::opt] {
          optflag("no-typestate"), optflag("noverify"),
          optmulti("cfg"), optflag("test"),
          optflag("lib"), optflag("static"), optflag("gc"),
-         optflag("stack-growth"), optflag("check-unsafe")];
+         optflag("stack-growth"), optflag("check-unsafe"),
+         optflagopt("read-attr")];
 }
 
 fn build_output_filenames(ifile: str, ofile: option::t<str>,
@@ -543,6 +545,12 @@ fn main(args: [str]) {
     let ls = opt_present(match, "ls");
     if ls {
         metadata::creader::list_file_metadata(sess, ifile, io::stdout());
+        ret;
+    }
+
+    if opt_present(match, "read-attr") {
+        let arg = getopts::opt_str(match, "read-attr");
+        metadata::creader::read_attr(sess, ifile, io::stdout(), arg);
         ret;
     }
 

--- a/src/comp/metadata/creader.rs
+++ b/src/comp/metadata/creader.rs
@@ -17,6 +17,7 @@ import common::*;
 
 export read_crates;
 export list_file_metadata;
+export read_attr;
 
 // Traverses an AST, reading all the information about use'd crates and native
 // libraries necessary for later resolving, typechecking, linking, etc.
@@ -78,6 +79,15 @@ fn list_file_metadata(sess: session::session, path: str, out: io::writer) {
       option::none. {
         out.write_str("Could not find metadata in " + path + ".\n");
       }
+    }
+}
+
+fn read_attr(sess: session::session, path: str, out: io::writer, name: str) {
+    alt get_metadata_section(sess, path) {
+        option::none. { }
+        option::some(bytes) {
+            decoder::print_crate_attr(bytes, out, name);
+        }
     }
 }
 

--- a/src/comp/metadata/decoder.rs
+++ b/src/comp/metadata/decoder.rs
@@ -22,6 +22,7 @@ export list_crate_metadata;
 export crate_dep;
 export get_crate_deps;
 export external_resolver;
+export print_crate_attr;
 
 // A function that takes a def_id relative to the crate being searched and
 // returns a def_id relative to the compilation environment, i.e. if we hit a
@@ -413,6 +414,18 @@ fn list_crate_metadata(bytes: @[u8], out: io::writer) {
     list_crate_attributes(md, out);
     list_crate_deps(bytes, out);
     list_crate_items(bytes, md, out);
+}
+
+fn print_crate_attr(bytes: @[u8], out: io::writer, name: str) {
+    let md = ebml::new_doc(bytes);
+    for attr: ast::attribute in get_attributes(md) {
+        alt attr.node.value.node {
+            ast::meta_name_value(mname, value) when mname == name {
+                out.write_str(#fmt["%s\n", pprust::attribute_to_str(attr)]);
+            }
+            _ { }
+        }
+    }
 }
 
 // Local Variables:


### PR DESCRIPTION
Prints a particular named attribute of the specified compiled crate.
