### PR TITLE
llvm::mk_object_file to option type (fixes OS X crash)

### DIFF
--- a/src/comp/lib/llvm.rs
+++ b/src/comp/lib/llvm.rs
@@ -1,4 +1,4 @@
-import std::{vec, str};
+import std::{vec, str, option};
 import std::str::sbuf;
 
 import llvm::{ModuleRef, ContextRef, TypeRef, TypeHandleRef, ValueRef,
@@ -1057,9 +1057,10 @@ resource object_file_res(ObjectFile: ObjectFileRef) {
 
 type object_file = {llof: ObjectFileRef, dtor: @object_file_res};
 
-fn mk_object_file(llmb: MemoryBufferRef) -> object_file {
+fn mk_object_file(llmb: MemoryBufferRef) -> option::t<object_file> {
     let llof = llvm::LLVMCreateObjectFile(llmb);
-    ret {llof: llof, dtor: @object_file_res(llof)};
+    if llof as int == 0 { ret option::none::<object_file>; }
+    ret option::some::<object_file>({llof: llof, dtor: @object_file_res(llof)});
 }
 
 /* Memory-managed interface to section iterators. */

--- a/src/comp/metadata/creader.rs
+++ b/src/comp/metadata/creader.rs
@@ -175,7 +175,10 @@ fn get_metadata_section(sess: session::session,
         llvm::LLVMRustCreateMemoryBufferWithContentsOfFile(buf)
                                    });
     if mb as int == 0 { ret option::none::<@[u8]>; }
-    let of = mk_object_file(mb);
+    let of = alt mk_object_file(mb) {
+        option::some(of) { of }
+        _ { ret option::none::<@[u8]>; }
+    };
     let si = mk_section_iter(of.llof);
     while llvm::LLVMIsSectionIteratorAtEnd(of.llof, si.llsi) == False {
         let name_buf = llvm::LLVMGetSectionName(si.llsi);


### PR DESCRIPTION
llvm::mk_object_file should really return an option, since the underlying LLVM function can fail.  Fixes a crash on OS X when rust has bad dylibs within eyeshot.

Probably other functions throughout the llvm bindings should also have option types returned when they could potentially return null from LLVM -- but this is at least enough to fix a crash in which a "bad" dylib (i.e., one that LLVM can't parse) causes rustc to crash.
