### PR TITLE
Fix Issue 476: emit LLVM assembly

### DIFF
--- a/src/comp/driver/rustc.rs
+++ b/src/comp/driver/rustc.rs
@@ -344,6 +344,8 @@ fn build_session_options(match: getopts::match)
     let output_type =
         if parse_only || no_trans {
             link::output_type_none
+        } else if opt_present(match, "S") && opt_present(match, "emit-llvm") {
+            link::output_type_llvm_assembly
         } else if opt_present(match, "S") {
             link::output_type_assembly
         } else if opt_present(match, "c") {
@@ -475,6 +477,7 @@ fn build_output_filenames(ifile: str, ofile: option::t<str>,
               link::output_type_none. { "none" }
               link::output_type_bitcode. { "bc" }
               link::output_type_assembly. { "s" }
+              link::output_type_llvm_assembly. { "s" }
               // Object and exe output both use the '.o' extension here
               link::output_type_object. | link::output_type_exe. {
                 "o"

--- a/src/comp/lib/llvm.rs
+++ b/src/comp/lib/llvm.rs
@@ -866,6 +866,9 @@ native "c-stack-cdecl" mod llvm = "rustllvm" {
     fn LLVMRustConstSmallInt(IntTy: TypeRef, N: uint, SignExtend: Bool) ->
        ValueRef;
 
+    fn LLVMRustAddPrintModulePass(PM: PassManagerRef, M: ModuleRef,
+                                  Output: sbuf);
+
     /** Turn on LLVM pass-timing. */
     fn LLVMRustEnableTimePasses();
     /** Turn on LLVM segmented stacks. */

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -6051,7 +6051,9 @@ fn write_abi_version(ccx: @crate_ctxt) {
 fn trans_crate(sess: session::session, crate: @ast::crate, tcx: ty::ctxt,
                output: str, amap: ast_map::map, mut_map: mut::mut_map,
                copy_map: alias::copy_map) -> ModuleRef {
-    let llmod = str::as_buf("rust_out", {|buf|
+    let sha = std::sha1::mk_sha1();
+    let link_meta = link::build_link_meta(sess, *crate, output, sha);
+    let llmod = str::as_buf(link_meta.name, {|buf|
         llvm::LLVMModuleCreateWithNameInContext
             (buf, llvm::LLVMGetGlobalContext())
     });
@@ -6081,8 +6083,6 @@ fn trans_crate(sess: session::session, crate: @ast::crate, tcx: ty::ctxt,
     let lltypes = map::mk_hashmap::<ty::t, TypeRef>(hasher, eqer);
     let sha1s = map::mk_hashmap::<ty::t, str>(hasher, eqer);
     let short_names = map::mk_hashmap::<ty::t, str>(hasher, eqer);
-    let sha = std::sha1::mk_sha1();
-    let link_meta = link::build_link_meta(sess, *crate, output, sha);
     let crate_map = decl_crate_map(sess, link_meta.name, llmod);
     let ccx =
         @{sess: sess,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -15,6 +15,7 @@
 #include "llvm/Linker.h"
 #include "llvm/PassManager.h"
 #include "llvm/ADT/Triple.h"
+#include "llvm/Assembly/PrintModulePass.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
@@ -45,6 +46,17 @@ extern "C" const char *LLVMRustGetLastError(void) {
 }
 
 extern "C" void LLVMAddBasicAliasAnalysisPass(LLVMPassManagerRef PM);
+
+extern "C" void LLVMRustAddPrintModulePass(LLVMPassManagerRef PMR,
+                                           LLVMModuleRef M,
+                                           const char* path) {
+  PassManager *PM = unwrap<PassManager>(PMR);
+  std::string ErrorInfo;
+  raw_fd_ostream OS(path, ErrorInfo, raw_fd_ostream::F_Binary);
+  formatted_raw_ostream FOS(OS);
+  PM->add(createPrintModulePass(&FOS));
+  PM->run(*unwrap(M));
+}
 
 extern "C" bool LLVMLinkModules(LLVMModuleRef Dest, LLVMModuleRef Src) {
   static std::string err;

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -24,6 +24,7 @@ LLVMAddAlias
 LLVMAddArgumentPromotionPass
 LLVMAddAttribute
 LLVMAddBasicAliasAnalysisPass
+LLVMRustAddPrintModulePass
 LLVMAddCFGSimplificationPass
 LLVMAddCase
 LLVMAddClause


### PR DESCRIPTION
Hi,

I split the implementation to 2 commits.

852e789 rustc: Set LLVM module identifier as crate name
b12de98 rustc: Add support of generating LLVM assembly

Suffix ".s" is used for compatible with Clang, although utilities like "llvm-dis" and "opt" rename file.bc to file.ll by default.

Personally, I think ".ll" is better for debugging purpose. Opinions?

Haitao
