### PR TITLE
tutorial: Fix type mismatch in example FFI code

### DIFF
--- a/doc/tutorial/ffi.md
+++ b/doc/tutorial/ffi.md
@@ -183,7 +183,7 @@ microsecond-resolution timer.
         fn gettimeofday(tv: *timeval, tz: *()) -> i32;
     }
     fn unix_time_in_microseconds() -> u64 unsafe {
-        let x = {tv_sec: 0u32, tv_usec: 0u32};
+        let x = {mutable tv_sec: 0u32, mutable tv_usec: 0u32};
         libc::gettimeofday(std::ptr::addr_of(x), std::ptr::null());
         ret (x.tv_sec as u64) * 1000_000_u64 + (x.tv_usec as u64);
     }


### PR DESCRIPTION
Compile error:
time.rs:13:23: 13:43 error: mismatched types: expected
*R[tv_sec=mMltv_usec=mMl] but found *R[tv_sec=Mltv_usec=Ml](record
elements differ in mutability)
time.rs:13     libc::gettimeofday(std::ptr::addr_of(x), std::ptr::null());
                                  ^~~~~~~~~~~~~~~~~~~~
error: aborting due to previous errors
rust: upcall fail 'explicit failure', ../src/comp/driver/session.rs:70
rust: domain main @0x9dfd178 root task failed
