### PR TITLE
rustc: Fix position of diagnostic highlight lines

### DIFF
--- a/src/comp/syntax/codemap.rs
+++ b/src/comp/syntax/codemap.rs
@@ -193,7 +193,7 @@ fn maybe_highlight_lines(sp: option::t<span>, cm: codemap,
         if vec::len(lines.lines) == 1u {
             let lo = lookup_char_pos(cm, option::get(sp).lo);
             let digits = 0u;
-            let num = lines.lines[0] / 10u;
+            let num = (lines.lines[0] + 1u) / 10u;
 
             // how many digits must be indent past?
             while num > 0u { num /= 10u; digits += 1u; }


### PR DESCRIPTION
Diagnostic highlight lines are incorrect placed when the related line
number is 10, 100, etc.

For example, diagnostic highlight is misplaced when compiling the following code.

``` javascript
use std;                      // 1
                              // 2
fn main() {                   // 3
    import std::vec;          // 4
                              // 5
                              // 6
                              // 7
    {                         // 8
                              // 9
        import std::sha;      // 10
    }                         // 11
}
```

``` javascript
import-in-block.rs:10:8: 10:23 error: unresolved import: sha
import-in-block.rs:10         import std::sha;      // 10
                             ^~~~~~~~~~~~~~~
```

The root cause is line number is treated as 0 based (should be 1 based)
when calculating offset of line number digits.
