### PR TITLE
build: added CFG_INSTALL_SNAP for automatically activating test snapshots

### DIFF
--- a/mk/snap.mk
+++ b/mk/snap.mk
@@ -2,8 +2,13 @@ define DEF_SNAP_FOR_STAGE_H
 # $(1) stage
 # $(2) triple
 
+ifdef CFG_INSTALL_SNAP
+snap-stage$(1)-H-$(2): $$(HSREQ$(1)_H_$(2))
+	$(S)src/etc/make-snapshot.py stage$(1) $(2) install
+else
 snap-stage$(1)-H-$(2): $$(HSREQ$(1)_H_$(2))
 	$(S)src/etc/make-snapshot.py stage$(1) $(2)
+endif
 
 endef
 

--- a/src/etc/make-snapshot.py
+++ b/src/etc/make-snapshot.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
 
 import snapshot, sys
-print(snapshot.make_snapshot(sys.argv[1], sys.argv[2]))
+
+if len(sys.argv) == 2:
+    print(snapshot.make_snapshot(sys.argv[1], sys.argv[2], ""))
+else:
+    print(snapshot.make_snapshot(sys.argv[1], sys.argv[2], sys.argv[3]))

--- a/src/etc/snapshot.py
+++ b/src/etc/snapshot.py
@@ -111,7 +111,7 @@ def hash_file(x):
     return scrub(h.hexdigest())
 
 
-def make_snapshot(stage, triple):
+def make_snapshot(stage, triple, flag):
     kernel = get_kernel(triple)
     platform = get_platform(triple)
     rev = local_rev_short_sha()
@@ -132,4 +132,34 @@ def make_snapshot(stage, triple):
     file1 = full_snapshot_name(date, rev, platform, h)
 
     shutil.move(file0, file1)
+
+    if flag == "install":
+      # FIXME this is an ugly quick hack; pls make it better
+      path  = file1
+      comps = path.split("-")
+      parts = { 'year': comps[2], \
+                'month': comps[3], \
+                'date': comps[4], \
+                'check': comps[5], \
+                'plat': comps[6], \
+                'arch': comps[7], \
+                'sha': comps[8].split(".")[0] }
+
+      shutil.move(path, "dl/" + path)
+      shutil.move('src/snapshots.txt', 'src/snapshots-old.txt')
+
+      newf = open('src/snapshots.txt', 'w')
+      newf.write("T %(year)s-%(month)s-%(date)s %(check)s\n" % parts)
+      newf.write("  %(plat)s-%(arch)s %(sha)s\n\n" % parts)
+
+      oldf = open('src/snapshots-old.txt', 'r')
+      for line in oldf:
+        newf.write(line)
+      oldf.close()
+
+      newf.close()
+
+      os.remove('src/snapshots-old.txt')
+
+
     return file1


### PR DESCRIPTION
This is only guaranteed to work when building in the top-level dir

-- This really just is a quick hack. I found it to be useful and it shouldn't hurt anyone. 
