### PR TITLE
Swap arg order for option::{may,maybe}

### DIFF
--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -70,7 +70,7 @@ Function: maybe
 
 Applies a function to the contained value or returns a default
 */
-fn maybe<T, U>(def: U, f: block(T) -> U, opt: t<T>) -> U {
+fn maybe<T, U>(def: U, opt: t<T>, f: block(T) -> U) -> U {
     alt opt { none. { def } some(t) { f(t) } }
 }
 
@@ -80,7 +80,7 @@ Function: may
 
 Performs an operation on the contained value or does nothing
 */
-fn may<T>(f: block(T), opt: t<T>) {
+fn may<T>(opt: t<T>, f: block(T)) {
     alt opt { none. {/* nothing */ } some(t) { f(t); } }
 }
 


### PR DESCRIPTION
This lets us write the block syntax sugar:

option::may(x) { |y| … }
