### PR TITLE
exposing --link-args to rustc

### DIFF
--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -321,7 +321,7 @@ mod write {
  *
  * There are a few issues to handle:
  *
- *  - Linnkers operate on a flat namespace, so we have to flatten names.
+ *  - Linkers operate on a flat namespace, so we have to flatten names.
  *    We do this using the C++ namespace-mangling technique. Foo::bar
  *    symbols and such.
  *

--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -657,6 +657,10 @@ fn link_binary(sess: session::session,
 
     gcc_args += rpath::get_rpath_flags(sess, output);
 
+    if !vec::is_empty(sess.get_opts().link_args) {
+        gcc_args += sess.get_opts().link_args;
+    }
+
     log #fmt("gcc link args: %s", str::connect(gcc_args, " "));
     // We run 'gcc' here
     let prog = run::program_output(prog, gcc_args);

--- a/src/comp/driver/rustc.rs
+++ b/src/comp/driver/rustc.rs
@@ -328,6 +328,7 @@ options:
     --stack-growth     perform stack checks (experimental)
     --warn-unused-imports
                        warn about unnecessary imports
+    --link-args <args> pass arguments to the linker
 
 ");
 }
@@ -454,6 +455,11 @@ fn build_session_options(match: getopts::match)
         };
 
     let addl_lib_search_paths = getopts::opt_strs(match, "L");
+    let link_args =
+        alt getopts::opt_maybe_str(match, "link-args") {
+            none. { [] }
+            some(args) { str::split(args, ' ' as u8) }
+        };
     let cfg = parse_cfgspecs(getopts::opt_strs(match, "cfg"));
     let test = opt_present(match, "test");
     let do_gc = opt_present(match, "gc");
@@ -472,6 +478,7 @@ fn build_session_options(match: getopts::match)
           time_llvm_passes: time_llvm_passes,
           output_type: output_type,
           addl_lib_search_paths: addl_lib_search_paths,
+          link_args: link_args,
           maybe_sysroot: sysroot_opt,
           target_triple: target,
           cfg: cfg,
@@ -523,7 +530,8 @@ fn opts() -> [getopts::opt] {
          optflag("lib"), optflag("bin"), optflag("static"), optflag("gc"),
          optflag("stack-growth"),
          optflag("no-asm-comments"),
-         optflag("warn-unused-imports")];
+         optflag("warn-unused-imports"),
+         optopt("link-args")];
 }
 
 fn build_output_filenames(ifile: str, ofile: option::t<str>,

--- a/src/comp/driver/session.rs
+++ b/src/comp/driver/session.rs
@@ -38,6 +38,7 @@ type options =
      time_llvm_passes: bool,
      output_type: back::link::output_type,
      addl_lib_search_paths: [str],
+     link_args: [str],
      maybe_sysroot: option::t<str>,
      target_triple: str,
      cfg: ast::crate_cfg,


### PR DESCRIPTION
This lets a configure-type script specify things like c library locations and other misc linker related things for extension libraries.
