### PR TITLE
expose --link-args to rustc

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -126,6 +126,9 @@ Build a test harness.
 .TP
 \fB--warn-unused-imports\fR:
 Warn about unnecessary imports.
+.TP
+\fB--link-args\fR \fIargs\fR:
+Pass arguments to the linker.
 .SH "BUGS"
 See \fBhttps://github.com/graydon/rust/issues\fR for a list of known bugs.
 .SH "AUTHOR"

--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -321,7 +321,7 @@ mod write {
  *
  * There are a few issues to handle:
  *
- *  - Linnkers operate on a flat namespace, so we have to flatten names.
+ *  - Linkers operate on a flat namespace, so we have to flatten names.
  *    We do this using the C++ namespace-mangling technique. Foo::bar
  *    symbols and such.
  *

--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -655,6 +655,10 @@ fn link_binary(sess: session::session,
 
     gcc_args += rpath::get_rpath_flags(sess, output);
 
+    if !vec::is_empty(sess.get_opts().link_args) {
+        gcc_args += sess.get_opts().link_args;
+    }
+
     log #fmt("gcc link args: %s", str::connect(gcc_args, " "));
     // We run 'gcc' here
     let prog = run::program_output(prog, gcc_args);

--- a/src/comp/driver/rustc.rs
+++ b/src/comp/driver/rustc.rs
@@ -329,6 +329,7 @@ options:
     --stack-growth     perform stack checks (experimental)
     --warn-unused-imports
                        warn about unnecessary imports
+    --link-args <args> pass arguments to the linker
 
 ");
 }
@@ -455,6 +456,10 @@ fn build_session_options(match: getopts::match)
         };
 
     let addl_lib_search_paths = getopts::opt_strs(match, "L");
+    let link_args = vec::concat(
+        vec::map(
+            { |args| str::split(args, ' ' as u8) },
+            getopts::opt_strs(match, "link-args")));
     let cfg = parse_cfgspecs(getopts::opt_strs(match, "cfg"));
     let test = opt_present(match, "test");
     let do_gc = opt_present(match, "gc");
@@ -473,6 +478,7 @@ fn build_session_options(match: getopts::match)
           time_llvm_passes: time_llvm_passes,
           output_type: output_type,
           addl_lib_search_paths: addl_lib_search_paths,
+          link_args: link_args,
           maybe_sysroot: sysroot_opt,
           target_triple: target,
           cfg: cfg,
@@ -524,7 +530,8 @@ fn opts() -> [getopts::opt] {
          optflag("lib"), optflag("bin"), optflag("static"), optflag("gc"),
          optflag("stack-growth"),
          optflag("no-asm-comments"),
-         optflag("warn-unused-imports")];
+         optflag("warn-unused-imports"),
+         optmulti("link-args")];
 }
 
 fn build_output_filenames(ifile: str, ofile: option::t<str>,

--- a/src/comp/driver/session.rs
+++ b/src/comp/driver/session.rs
@@ -38,6 +38,7 @@ type options =
      time_llvm_passes: bool,
      output_type: back::link::output_type,
      addl_lib_search_paths: [str],
+     link_args: [str],
      maybe_sysroot: option::t<str>,
      target_triple: str,
      cfg: ast::crate_cfg,

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -150,10 +150,7 @@ fn name_str(nm: name) -> str {
 }
 
 fn find_opt(opts: [opt], nm: name) -> option::t<uint> {
-    let i = 0u;
-    let l = vec::len::<opt>(opts);
-    while i < l { if opts[i].name == nm { ret some::<uint>(i); } i += 1u; }
-    ret none::<uint>;
+    vec::position_pred({ |opt| opt.name == nm }, opts)
 }
 
 /*

--- a/src/test/stdtest/getopts.rs
+++ b/src/test/stdtest/getopts.rs
@@ -443,10 +443,11 @@ fn test_unrecognized_option_short() {
 fn test_combined() {
     let args =
         ["prog", "free1", "-s", "20", "free2", "--flag", "--long=30", "-f",
-         "-m", "40", "-m", "50"];
+         "-m", "40", "-m", "50", "-n", "-A B", "-n", "-60 70"];
     let opts =
         [opt::optopt("s"), opt::optflag("flag"), opt::reqopt("long"),
-         opt::optflag("f"), opt::optmulti("m"), opt::optopt("notpresent")];
+         opt::optflag("f"), opt::optmulti("m"), opt::optmulti("n"),
+         opt::optopt("notpresent")];
     let rs = opt::getopts(args, opts);
     alt rs {
       opt::success(m) {
@@ -459,6 +460,8 @@ fn test_combined() {
         assert (opt::opt_present(m, "f"));
         assert (opt::opt_strs(m, "m")[0] == "40");
         assert (opt::opt_strs(m, "m")[1] == "50");
+        assert (opt::opt_strs(m, "n")[0] == "-A B");
+        assert (opt::opt_strs(m, "n")[1] == "-60 70");
         assert (!opt::opt_present(m, "notpresent"));
       }
       _ { fail; }


### PR DESCRIPTION
This is useful for writing configure scripts for extension libraries. It also includes a typo fix, some code cleanup, and a test for getopts.
