### PR TITLE
issue 1296: implement #[nolink]; deprecate #[link_name = ""]

### DIFF
--- a/doc/tutorial/ffi.md
+++ b/doc/tutorial/ffi.md
@@ -189,7 +189,7 @@ microsecond-resolution timer.
     use std;
     type timeval = {mutable tv_sec: u32,
                     mutable tv_usec: u32};
-    #[link_name = ""]
+    #[nolink]
     native mod libc {
         fn gettimeofday(tv: *timeval, tz: *()) -> i32;
     }
@@ -199,7 +199,7 @@ microsecond-resolution timer.
         ret (x.tv_sec as u64) * 1000_000_u64 + (x.tv_usec as u64);
     }
 
-The `#[link_name = ""]` sets the name of the native module to the
+The `#[nolink]` sets the name of the native module to the
 empty string to prevent the rust compiler from trying to link it.
 The standard C library is already linked with Rust programs.
 

--- a/src/comp/metadata/creader.rs
+++ b/src/comp/metadata/creader.rs
@@ -57,11 +57,19 @@ fn visit_item(e: env, i: @ast::item) {
           }
           either::left(msg) { e.sess.span_fatal(i.span, msg); }
         }
+
         let cstore = e.sess.get_cstore();
         let native_name = i.ident;
+        if vec::len(attr::find_attrs_by_name(i.attrs, "nolink")) > 0u {
+            ret;
+        }
         alt attr::get_meta_item_value_str_by_name(i.attrs, "link_name") {
           some(nn) { native_name = nn; }
           none. { }
+        }
+        if native_name == "" {
+            e.sess.span_fatal(i.span,
+                "empty #[link_name] not allowed; use #[nolink].");
         }
         if !cstore::add_used_library(cstore, native_name) { ret; }
         for a: ast::attribute in

--- a/src/comp/metadata/cstore.rs
+++ b/src/comp/metadata/cstore.rs
@@ -90,7 +90,7 @@ fn get_used_crate_files(cstore: cstore) -> [str] {
 }
 
 fn add_used_library(cstore: cstore, lib: str) -> bool {
-    if lib == "" { ret false; }
+    assert lib != "";
 
     if vec::member(lib, p(cstore).used_libraries) { ret false; }
     p(cstore).used_libraries += [lib];

--- a/src/comp/metadata/cstore.rs
+++ b/src/comp/metadata/cstore.rs
@@ -93,7 +93,6 @@ fn add_used_library(cstore: cstore, lib: str) -> bool {
     if lib == "" { ret false; }
 
     if vec::member(lib, p(cstore).used_libraries) { ret false; }
-
     p(cstore).used_libraries += [lib];
     ret true;
 }

--- a/src/libstd/linux_os.rs
+++ b/src/libstd/linux_os.rs
@@ -24,7 +24,8 @@ export fsync_fd;
 // FIXME Somehow merge stuff duplicated here and macosx_os.rs. Made difficult
 // by https://github.com/graydon/rust/issues#issue/268
 
-#[link_name = ""]
+#[link_name = ""]               // FIXME remove after #[nolink] is snapshotted
+#[nolink]
 #[abi = "cdecl"]
 native mod libc {
     fn read(fd: fd_t, buf: *u8, count: size_t) -> ssize_t;

--- a/src/libstd/macos_os.rs
+++ b/src/libstd/macos_os.rs
@@ -18,7 +18,7 @@ export fsync_fd;
 // FIXME Refactor into unix_os module or some such. Doesn't
 // seem to work right now.
 
-#[link_name = ""]
+#[nolink]
 #[abi = "cdecl"]
 native mod libc {
     fn read(fd: fd_t, buf: *u8, count: size_t) -> ssize_t;
@@ -118,7 +118,8 @@ native mod rustrt {
 
 fn getcwd() -> str { ret rustrt::rust_getcwd(); }
 
-#[link_name = ""]
+#[link_name = ""]               // FIXME remove after #[nolink] is snapshotted
+#[nolink]
 #[abi = "cdecl"]
 native mod mac_libc {
     fn _NSGetExecutablePath(buf: str::sbuf,

--- a/src/libstd/win32_os.rs
+++ b/src/libstd/win32_os.rs
@@ -2,7 +2,8 @@ import core::option;
 import ctypes::*;
 
 #[abi = "cdecl"]
-#[link_name = ""]
+#[link_name = ""]               // FIXME remove after #[nolink] is snapshotted
+#[nolink]
 native mod libc {
     fn read(fd: fd_t, buf: *u8, count: size_t) -> ssize_t;
     fn write(fd: fd_t, buf: *u8, count: size_t) -> ssize_t;

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -2,7 +2,7 @@
 // http://shootout.alioth.debian.org/u32/benchmark.php?test=nbody&lang=java
 
 #[abi = "cdecl"]
-#[link_name = ""]
+#[nolink]
 native mod llvm {
     fn sqrt(n: float) -> float;
 }

--- a/src/test/compile-fail/empty-linkname.rs
+++ b/src/test/compile-fail/empty-linkname.rs
@@ -1,0 +1,5 @@
+// error-pattern:empty #[link_name] not allowed; use #[nolink].
+
+#[link_name = ""]
+native mod foo {
+}

--- a/src/test/compile-fail/nolink-with-link-args.rs
+++ b/src/test/compile-fail/nolink-with-link-args.rs
@@ -1,0 +1,11 @@
+// error-pattern:aFdEfSeVEE
+
+/* We're testing that link_args are indeed passed when nolink is specified.
+So we try to compile with junk link_args and make sure they are visible in
+the compiler output. */
+
+#[link_args = "aFdEfSeVEEE"]
+#[nolink]
+native mod m1 { }
+
+fn main() { }

--- a/src/test/compile-fail/redundant-link-args.rs
+++ b/src/test/compile-fail/redundant-link-args.rs
@@ -1,0 +1,17 @@
+// error-pattern:library 'm' already added: can't specify link_args.
+
+/* I think it should undefined to have multiple modules that link in the same
+  library, but provide different link arguments. Unfortunately we don't track
+  link_args by module -- they are just appended as discovered into the crate
+  store -- but for now, it should be an error to provide link_args on a module
+  that's already been included (with or without link_args). */
+
+#[link_name= "m"]
+#[link_args="-foo"]             // this could have been elided.
+native mod m1 {
+}
+
+#[link_name= "m"]
+#[link_args="-bar"]             // this is the actual error trigger.
+native mod m2 {
+}

--- a/src/test/run-pass/bind-native-fn.rs
+++ b/src/test/run-pass/bind-native-fn.rs
@@ -5,7 +5,7 @@ use std;
 import str;
 import ctypes::*;
 
-#[link_name = ""]
+#[nolink]
 native mod libc {
     fn write(fd: c_int, buf: *u8, nbyte: size_t);
 }

--- a/src/test/run-pass/binops.rs
+++ b/src/test/run-pass/binops.rs
@@ -118,7 +118,7 @@ fn test_fn() {
 }
 
 #[abi = "cdecl"]
-#[link_name = ""]
+#[nolink]
 native mod test {
     fn do_gc();
     fn unsupervise();

--- a/src/test/run-pass/c-stack-returning-int64.rs
+++ b/src/test/run-pass/c-stack-returning-int64.rs
@@ -2,7 +2,7 @@ use std;
 import str;
 
 #[abi = "cdecl"]
-#[link_name = ""]
+#[nolink]
 native mod libc {
     fn atol(x: str::sbuf) -> int;
     fn atoll(x: str::sbuf) -> i64;

--- a/src/test/run-pass/import-glob-1.rs
+++ b/src/test/run-pass/import-glob-1.rs
@@ -21,7 +21,7 @@ mod a1 {
 mod a2 {
     //   |   |   |
     #[abi = "cdecl"]
-    #[link_name = ""]
+    #[nolink]
     native mod b1 {
         //   |   |   |
         import a1::b2::*;

--- a/src/test/run-pass/native-fn-linkname.rs
+++ b/src/test/run-pass/native-fn-linkname.rs
@@ -3,7 +3,7 @@ use std;
 import vec;
 import str;
 
-#[link_name = ""]
+#[nolink]
 #[abi = "cdecl"]
 native mod libc {
     #[link_name = "strlen"]

--- a/src/test/run-pass/native-opaque-type.rs
+++ b/src/test/run-pass/native-opaque-type.rs
@@ -1,7 +1,7 @@
 
 
 #[abi = "cdecl"]
-#[link_name = ""]
+#[nolink]
 native mod libc {
     type file_handle;
 }

--- a/src/test/run-pass/native2.rs
+++ b/src/test/run-pass/native2.rs
@@ -6,21 +6,21 @@ native mod rustrt {
 }
 
 #[abi = "cdecl"]
-#[link_name = ""]
+#[nolink]
 native mod bar { }
 
 #[abi = "cdecl"]
-#[link_name = ""]
+#[nolink]
 native mod zed { }
 
 #[abi = "cdecl"]
-#[link_name = ""]
+#[nolink]
 native mod libc {
     fn write(fd: int, buf: *u8, count: uint) -> int;
 }
 
 #[abi = "cdecl"]
-#[link_name = ""]
+#[nolink]
 native mod baz { }
 
 fn main(args: [str]) { }

--- a/src/test/stdtest/c_vec.rs
+++ b/src/test/stdtest/c_vec.rs
@@ -5,7 +5,7 @@ use std;
 import std::c_vec::*;
 import ctypes::*;
 
-#[link_name = ""]
+#[nolink]
 #[abi = "cdecl"]
 native mod libc {
     fn malloc(n: size_t) -> *mutable u8;


### PR DESCRIPTION
The #[link_name = ""] attributes in the standard library will need to be removed later, after new compiler snapshots are generated; I've left fixme notes to take care of that later.
