### PR TITLE
Basic debugging information support

### DIFF
--- a/src/comp/driver/rustc.rs
+++ b/src/comp/driver/rustc.rs
@@ -421,7 +421,8 @@ fn build_session_options(match: getopts::match)
     let libcore = !opt_present(match, "no-core");
     let verify = !opt_present(match, "no-verify");
     let save_temps = opt_present(match, "save-temps");
-    let debuginfo = opt_present(match, "g");
+    let extra_debuginfo = opt_present(match, "xg");
+    let debuginfo = opt_present(match, "g") || extra_debuginfo;
     let stats = opt_present(match, "stats");
     let time_passes = opt_present(match, "time-passes");
     let time_llvm_passes = opt_present(match, "time-llvm-passes");
@@ -468,6 +469,7 @@ fn build_session_options(match: getopts::match)
           libcore: libcore,
           optimize: opt_level,
           debuginfo: debuginfo,
+          extra_debuginfo: extra_debuginfo,
           verify: verify,
           save_temps: save_temps,
           stats: stats,
@@ -516,7 +518,7 @@ fn opts() -> [getopts::opt] {
          optflag("emit-llvm"), optflagopt("pretty"),
          optflag("ls"), optflag("parse-only"), optflag("no-trans"),
          optflag("O"), optopt("opt-level"), optmulti("L"), optflag("S"),
-         optopt("o"), optopt("out-dir"),
+         optopt("o"), optopt("out-dir"), optflag("xg"),
          optflag("c"), optflag("g"), optflag("save-temps"),
          optopt("sysroot"), optopt("target"), optflag("stats"),
          optflag("time-passes"), optflag("time-llvm-passes"),

--- a/src/comp/driver/rustc.rs
+++ b/src/comp/driver/rustc.rs
@@ -489,7 +489,7 @@ fn build_session_options(match: getopts::match)
     ret sopts;
 }
 
-fn build_session(sopts: @session::options) -> session::session {
+fn build_session(sopts: @session::options, input: str) -> session::session {
     let target_cfg = build_target_config(sopts);
     let cstore = cstore::mk_cstore();
     let filesearch = filesearch::mk_filesearch(
@@ -498,7 +498,7 @@ fn build_session(sopts: @session::options) -> session::session {
         sopts.addl_lib_search_paths);
     ret session::session(target_cfg, sopts, cstore,
                          @{cm: codemap::new_codemap(), mutable next_id: 1},
-                         none, 0u, filesearch, false);
+                         none, 0u, filesearch, false, fs::dirname(input));
 }
 
 fn parse_pretty(sess: session::session, &&name: str) -> pp_mode {
@@ -644,7 +644,7 @@ fn main(args: [str]) {
     };
 
     let sopts = build_session_options(match);
-    let sess = build_session(sopts);
+    let sess = build_session(sopts, ifile);
     let odir = getopts::opt_maybe_str(match, "out-dir");
     let ofile = getopts::opt_maybe_str(match, "o");
     let cfg = build_configuration(sess, binary, ifile);
@@ -676,7 +676,7 @@ mod test {
               ok(m) { m }
             };
         let sessopts = build_session_options(match);
-        let sess = build_session(sessopts);
+        let sess = build_session(sessopts, "");
         let cfg = build_configuration(sess, "whatever", "whatever");
         assert (attr::contains_name(cfg, "test"));
     }
@@ -690,7 +690,7 @@ mod test {
               ok(m) { m }
             };
         let sessopts = build_session_options(match);
-        let sess = build_session(sessopts);
+        let sess = build_session(sessopts, "");
         let cfg = build_configuration(sess, "whatever", "whatever");
         let test_items = attr::find_meta_items_by_name(cfg, "test");
         assert (vec::len(test_items) == 1u);

--- a/src/comp/driver/session.rs
+++ b/src/comp/driver/session.rs
@@ -31,6 +31,7 @@ type options =
      libcore: bool,
      optimize: uint,
      debuginfo: bool,
+     extra_debuginfo: bool,
      verify: bool,
      save_temps: bool,
      stats: bool,

--- a/src/comp/driver/session.rs
+++ b/src/comp/driver/session.rs
@@ -60,7 +60,8 @@ obj session(targ_cfg: @config,
             mutable main_fn: option::t<node_id>,
             mutable err_count: uint,
             filesearch: filesearch::filesearch,
-            mutable building_library: bool) {
+            mutable building_library: bool,
+            working_dir: str) {
     fn get_targ_cfg() -> @config { ret targ_cfg; }
     fn get_opts() -> @options { ret opts; }
     fn get_cstore() -> metadata::cstore::cstore { cstore }
@@ -122,6 +123,9 @@ obj session(targ_cfg: @config,
     fn building_library() -> bool { building_library }
     fn set_building_library(crate: @ast::crate) {
         building_library = session::building_library(opts.crate_type, crate);
+    }
+    fn get_working_dir() -> str {
+        ret working_dir;
     }
 }
 

--- a/src/comp/lib/llvm.rs
+++ b/src/comp/lib/llvm.rs
@@ -256,6 +256,7 @@ native mod llvm {
 
     /* Operations on Users */
     fn LLVMGetOperand(Val: ValueRef, Index: uint) -> ValueRef;
+    fn LLVMSetOperand(Val: ValueRef, Index: uint, Op: ValueRef);
 
     /* Operations on constants of any type */
     fn LLVMConstNull(Ty: TypeRef) -> ValueRef;
@@ -275,6 +276,8 @@ native mod llvm {
     fn LLVMMDNodeInContext(C: ContextRef, Vals: *ValueRef, Count: uint) ->
        ValueRef;
     fn LLVMMDNode(Vals: *ValueRef, Count: uint) -> ValueRef;
+    fn LLVMAddNamedMetadataOperand(M: ModuleRef, Str: sbuf, SLen: uint,
+                                   Val: ValueRef);
 
     /* Operations on scalar constants */
     fn LLVMConstInt(IntTy: TypeRef, N: ULongLong, SignExtend: Bool) ->

--- a/src/comp/lib/llvm.rs
+++ b/src/comp/lib/llvm.rs
@@ -234,9 +234,11 @@ native mod llvm {
     /* Operations on other types */
     fn LLVMVoidTypeInContext(C: ContextRef) -> TypeRef;
     fn LLVMLabelTypeInContext(C: ContextRef) -> TypeRef;
+    fn LLVMMetadataTypeInContext(C: ContextRef) -> TypeRef;
 
     fn LLVMVoidType() -> TypeRef;
     fn LLVMLabelType() -> TypeRef;
+    fn LLVMMetadataType() -> TypeRef;
 
     /* Operations on all values */
     fn LLVMTypeOf(Val: ValueRef) -> TypeRef;

--- a/src/comp/middle/ast_map.rs
+++ b/src/comp/middle/ast_map.rs
@@ -73,6 +73,7 @@ fn map_item(cx: ctx, i: @item) {
       }
       item_impl(_, _, ms) {
         for m in ms { cx.map.insert(m.node.id, node_method(m)); }
+      }
       item_res(_, dtor_id, _, ctor_id) {
         cx.map.insert(ctor_id, node_res_ctor(i));
         cx.map.insert(dtor_id, node_item(i));

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -239,22 +239,26 @@ fn get_basic_type_metadata(cx: @crate_ctxt, t: ty::t, ty: @ast::ty)
     }
     let (name, (size, align), encoding) = alt ty.node {
       ast::ty_bool. {("bool", size_and_align_of::<bool>(), DW_ATE_boolean)}
-      ast::ty_int. {("int", size_and_align_of::<int>(), DW_ATE_signed)}
-      ast::ty_uint. {("uint", size_and_align_of::<uint>(), DW_ATE_unsigned)}
-      ast::ty_float. {("float", size_and_align_of::<float>(), DW_ATE_float)}
-      ast::ty_machine(m) { alt m {
+      ast::ty_int(m) { alt m {
+        ast::ty_char. {("char", size_and_align_of::<char>(), DW_ATE_unsigned)}
+        ast::ty_i. {("int", size_and_align_of::<int>(), DW_ATE_signed)}
         ast::ty_i8. {("i8", size_and_align_of::<i8>(), DW_ATE_signed_char)}
         ast::ty_i16. {("i16", size_and_align_of::<i16>(), DW_ATE_signed)}
         ast::ty_i32. {("i32", size_and_align_of::<i32>(), DW_ATE_signed)}
         ast::ty_i64. {("i64", size_and_align_of::<i64>(), DW_ATE_signed)}
+      }}
+      ast::ty_uint(m) { alt m {
+        ast::ty_u. {("uint", size_and_align_of::<uint>(), DW_ATE_unsigned)}
         ast::ty_u8. {("u8", size_and_align_of::<u8>(), DW_ATE_unsigned_char)}
         ast::ty_u16. {("u16", size_and_align_of::<u16>(), DW_ATE_unsigned)}
         ast::ty_u32. {("u32", size_and_align_of::<u32>(), DW_ATE_unsigned)}
         ast::ty_u64. {("u64", size_and_align_of::<u64>(), DW_ATE_unsigned)}
+      }}
+      ast::ty_float(m) { alt m {
+        ast::ty_f. {("float", size_and_align_of::<float>(), DW_ATE_float)}
         ast::ty_f32. {("f32", size_and_align_of::<f32>(), DW_ATE_float)}
         ast::ty_f64. {("f64", size_and_align_of::<f64>(), DW_ATE_float)}
-      } }
-      ast::ty_char. {("char", size_and_align_of::<char>(), DW_ATE_unsigned)}
+      }}
     };
     let fname = filename_from_span(cx, ty.span);
     let file_node = get_file_metadata(cx, fname);
@@ -327,7 +331,7 @@ fn get_boxed_type_metadata(cx: @crate_ctxt, outer: ty::t, inner: ty::t,
     //let cu_node = get_compile_unit_metadata(cx, fname);
     let tcx = ccx_tcx(cx);
     let uint_t = ty::mk_uint(tcx);
-    let uint_ty = @{node: ast::ty_uint, span: span};
+    let uint_ty = @{node: ast::ty_uint(ast::ty_u), span: span};
     let refcount_type = get_basic_type_metadata(cx, uint_t, uint_ty);
     /*let refcount_ptr_type = get_pointer_type_metadata(cx,
                                                       ty::mk_imm_uniq(tcx, uint_t),
@@ -389,11 +393,9 @@ fn get_ty_metadata(cx: @crate_ctxt, t: ty::t, ty: @ast::ty) -> @metadata<tydesc_
           ty::ty_nil. { ast::ty_nil }
           ty::ty_bot. { ast::ty_bot }
           ty::ty_bool. { ast::ty_bool }
-          ty::ty_int. { ast::ty_int }
-          ty::ty_float. { ast::ty_float }
-          ty::ty_uint. { ast::ty_uint }
-          ty::ty_machine(mt) { ast::ty_machine(mt) }
-          ty::ty_char. { ast::ty_char }
+          ty::ty_int(t) { ast::ty_int(t) }
+          ty::ty_float(t) { ast::ty_float(t) }
+          ty::ty_uint(t) { ast::ty_uint(t) }
           ty::ty_box(mt) { ast::ty_box({ty: t_to_ty(cx, mt.ty, span),
                                         mut: mt.mut}) }
           ty::ty_uniq(mt) { ast::ty_uniq({ty: t_to_ty(cx, mt.ty, span),

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -253,6 +253,9 @@ fn get_ty_metadata(cx: @crate_ctxt, t: ty::t, ty: @ast::ty) -> @metadata<tydesc_
     let llnode = llmdnode(lldata);
     let mdval = @{node: llnode, data: {hash: ty::hash_ty(t)}};
     update_cache(cache, BasicTypeDescriptorTag, tydesc_metadata(mdval));
+    llvm::LLVMAddNamedMetadataOperand(cx.llmod, as_buf("llvm.dbg.ty"),
+                                      str::byte_len("llvm.dbg.ty"),
+                                      llnode);
     ret mdval;
 }
 
@@ -295,21 +298,21 @@ fn get_local_var_metadata(bcx: @block_ctxt, local: @ast::local)
       }
     };
     let declargs = [llmdnode([llptr]), mdnode];
-    let instr = trans_build::Call(bcx, cx.intrinsics.get("llvm.dbg.declare"),
-                                  declargs);
+    trans_build::Call(bcx, cx.intrinsics.get("llvm.dbg.declare"),
+                      declargs);
     llvm::LLVMAddNamedMetadataOperand(cx.llmod, as_buf("llvm.dbg.vars"),
                                       str::byte_len("llvm.dbg.vars"),
                                       mdnode);
     ret mdval;
 }
 
-fn update_source_pos<T>(cx: @block_ctxt, s: T) {
+fn update_source_pos(cx: @block_ctxt, s: codemap::span) {
     if !bcx_ccx(cx).sess.get_opts().debuginfo {
         ret;
     }
     cx.source_pos = option::some(
         codemap::lookup_char_pos(bcx_ccx(cx).sess.get_codemap(),
-                                 s.span.lo)); //XXX maybe hi
+                                 s.lo)); //XXX maybe hi
 
 }
 

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -1,0 +1,192 @@
+import std::{vec, str, map, option, unsafe};
+import std::vec::to_ptr;
+import std::map::hashmap;
+import lib::llvm::llvm;
+import lib::llvm::llvm::{ModuleRef, ValueRef};
+import middle::trans_common::*;
+import syntax::{ast, codemap};
+
+const LLVMDebugVersion: int = 0x80000;
+
+const DW_LANG_RUST: int = 0x9000;
+const DW_VIRTUALITY_none: int = 0;
+
+const CompileUnitTag: int = 17;
+const FileDescriptorTag: int = 41;
+const SubprogramTag: int = 46;
+
+fn as_buf(s: str) -> str::sbuf {
+    str::as_buf(s, {|sbuf| sbuf})
+}
+fn llstr(s: str) -> ValueRef {
+    llvm::LLVMMDString(as_buf(s), str::byte_len(s))
+}
+
+fn lltag(lltag: int) -> ValueRef {
+    lli32(0x80000 + lltag)
+}
+fn lli32(val: int) -> ValueRef {
+    C_i32(val as i32)
+}
+fn lli1(bval: bool) -> ValueRef {
+    C_bool(bval)
+}
+fn llmdnode(elems: [ValueRef]) -> ValueRef unsafe {
+    llvm::LLVMMDNode(vec::unsafe::to_ptr(elems),
+                     vec::len(elems))
+}
+fn llunused() -> ValueRef {
+    lli32(0x0)
+}
+
+fn update_cache(cache: metadata_cache, mdtag: int, val: debug_metadata) {
+    let existing = if cache.contains_key(mdtag) {
+        cache.get(mdtag)
+    } else {
+        []
+    };
+    cache.insert(mdtag, existing + [val]);
+}
+
+////////////////
+
+type metadata<T> = {node: ValueRef, data: T};
+
+type file_md = {path: str};
+type compile_unit_md = {path: str};
+type subprogram_md = {name: str, file: str};
+
+type metadata_cache = hashmap<int, [debug_metadata]>;
+
+tag debug_metadata {
+    file_metadata(@metadata<file_md>);
+    compile_unit_metadata(@metadata<compile_unit_md>);
+    subprogram_metadata(@metadata<subprogram_md>);
+}
+
+fn md_from_metadata<T>(val: debug_metadata) -> T unsafe {
+    alt val {
+      file_metadata(md) { unsafe::reinterpret_cast(md) }
+      compile_unit_metadata(md) { unsafe::reinterpret_cast(md) }
+      subprogram_metadata(md) { unsafe::reinterpret_cast(md) }
+    }
+}
+
+fn cached_metadata<T>(cache: metadata_cache, mdtag: int,
+                      eq: block(md: T) -> bool) -> option::t<T> {
+    if cache.contains_key(mdtag) {
+        let items = cache.get(mdtag);
+        for item in items {
+            let md: T = md_from_metadata::<T>(item);
+            if eq(md) {
+                ret option::some(md);
+            }
+        }
+    }
+    ret option::none;
+}
+
+fn get_compile_unit_metadata(cx: @crate_ctxt, full_path: str)
+    -> @metadata<compile_unit_md> {
+    let cache = cx.llmetadata;
+    alt cached_metadata::<@metadata<compile_unit_md>>(cache, CompileUnitTag,
+                        {|md| md.data.path == full_path}) {
+      option::some(md) { ret md; }
+      option::none. {}
+    }
+    let sep = str::rindex(full_path, '/' as u8) as uint;
+    let fname = str::slice(full_path, sep + 1u,
+                           str::byte_len(full_path));
+    let path = str::slice(full_path, 0u, sep + 1u);
+    let unit_metadata = [lltag(CompileUnitTag),
+                         llunused(),
+                         lli32(DW_LANG_RUST),
+                         llstr(fname),
+                         llstr(path),
+                         llstr(#env["CFG_VERSION"]),
+                         lli1(false), // main compile unit
+                         lli1(cx.sess.get_opts().optimize != 0u),
+                         llstr(""), // flags (???)
+                         lli32(0) // runtime version (???)
+                         // list of enum types
+                         // list of retained values
+                         // list of subprograms
+                         // list of global variables
+                        ];
+    let unit_node = llmdnode(unit_metadata);
+    llvm::LLVMAddNamedMetadataOperand(cx.llmod, as_buf("llvm.dbg.cu"),
+                                  str::byte_len("llvm.dbg.cu"),
+                                  unit_node);
+    let mdval = @{node: unit_node, data: {path: full_path}};
+    update_cache(cache, CompileUnitTag, compile_unit_metadata(mdval));
+    ret mdval;
+}
+
+//        let kind_id = llvm::LLVMGetMDKindID(as_buf("dbg"),
+//                                            str::byte_len("dbg"));
+
+
+fn get_file_metadata(cx: @crate_ctxt, full_path: str) -> @metadata<file_md> {
+    let cache = cx.llmetadata;
+    alt cached_metadata::<@metadata<file_md>>(
+        cache, FileDescriptorTag, {|md| md.data.path == full_path}) {
+      option::some(md) { ret md; }
+      option::none. {}
+    }
+    let sep = str::rindex(full_path, '/' as u8) as uint;
+    let fname = str::slice(full_path, sep + 1u,
+                           str::byte_len(full_path));
+    let path = str::slice(full_path, 0u, sep + 1u);
+    let unit_node = get_compile_unit_metadata(cx, path).node;
+    let file_md = [lltag(FileDescriptorTag),
+                   llstr(fname),
+                   llstr(path),
+                   unit_node];
+    let val = llmdnode(file_md);
+    let mdval = @{node: val, data: {path: full_path}};
+    update_cache(cache, FileDescriptorTag, file_metadata(mdval));
+    ret mdval;
+}
+
+fn get_function_metadata(cx: @crate_ctxt, item: @ast::item,
+                         llfndecl: ValueRef) -> @metadata<subprogram_md> {
+    let cache = cx.llmetadata;
+    alt cached_metadata::<@metadata<subprogram_md>>(
+        cache, SubprogramTag, {|md| md.data.name == item.ident &&
+                                    /*sub.path == ??*/ true}) {
+      option::some(md) { ret md; }
+      option::none. {}
+    }
+    let loc = codemap::lookup_char_pos(cx.sess.get_codemap(),
+                                           item.span.lo);
+        let file_node = get_file_metadata(cx, loc.filename).node;
+        let fn_metadata = [lltag(SubprogramTag),
+                           llunused(),
+                           file_node,
+                           llstr(item.ident),
+                           llstr(item.ident), //XXX fully-qualified C++ name
+                           llstr(item.ident), //XXX MIPS name?????
+                           file_node,
+                           lli32(loc.line as int),
+                           C_null(T_ptr(T_nil())), // XXX reference to tydesc
+                           lli1(false), //XXX static
+                           lli1(true), // not extern
+                           lli32(DW_VIRTUALITY_none), // virtual-ness
+                           lli32(0i), //index into virt func
+                           C_null(T_ptr(T_nil())), // base type with vtbl
+                           lli1(false), // artificial
+                           lli1(cx.sess.get_opts().optimize != 0u),
+                           llfndecl
+                           //list of template params
+                           //func decl descriptor
+                           //list of func vars
+                          ];
+        let val = llmdnode(fn_metadata);
+        llvm::LLVMAddNamedMetadataOperand(cx.llmod, as_buf("llvm.dbg.sp"),
+                                          str::byte_len("llvm.dbg.sp"),
+                                          val);
+        let mdval = @{node: val, data: {name: item.ident,
+                                        file: loc.filename}};
+        update_cache(cache, SubprogramTag, subprogram_metadata(mdval));
+        ret mdval;
+}

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -1,8 +1,10 @@
-import std::{vec, str, option, unsafe, fs, sys, ctypes};
+import core::{vec, str, option, sys, ctypes, unsafe};
+import std::fs;
 import std::map::hashmap;
 import lib::llvm::llvm;
 import lib::llvm::llvm::ValueRef;
 import middle::trans_common::*;
+import middle::trans_build::B;
 import middle::ty;
 import syntax::{ast, codemap};
 import ast::ty;
@@ -66,7 +68,7 @@ fn llunused() -> ValueRef {
     lli32(0x0)
 }
 fn llnull() -> ValueRef unsafe {
-    unsafe::reinterpret_cast(std::ptr::null::<ValueRef>())
+    unsafe::reinterpret_cast(ptr::null::<ValueRef>())
 }
 
 fn add_named_metadata(cx: @crate_ctxt, name: str, val: ValueRef) {
@@ -621,7 +623,7 @@ fn create_local_var(bcx: @block_ctxt, local: @ast::local)
     }
 
     let name = alt local.node.pat.node {
-      ast::pat_bind(ident) { ident }
+      ast::pat_bind(ident, _) { ident /*XXX deal with optional node binding */ }
     };
     let loc = codemap::lookup_char_pos(cx.sess.get_codemap(),
                                        local.span.lo);
@@ -727,7 +729,7 @@ fn create_function(fcx: @fn_ctxt) -> @metadata<subprogram_md> {
       }
       ast_map::node_expr(expr) {
         alt expr.node {
-          ast::expr_fn(f) {
+          ast::expr_fn(f, _) {
             (dbg_cx.names.next("fn"), f.decl.output, expr.id)
           }
         }

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -162,13 +162,18 @@ fn create_compile_unit(cx: @crate_ctxt, full_path: str)
       option::none. {}
     }
 
-    let fname = fs::basename(full_path);
-    let path = fs::dirname(full_path);
+    let work_dir = cx.sess.get_working_dir();
+    let file_path = if str::starts_with(full_path, work_dir) {
+        str::slice(full_path, str::byte_len(work_dir),
+                   str::byte_len(full_path))
+    } else {
+        full_path
+    };
     let unit_metadata = [lltag(tg),
                          llunused(),
                          lli32(DW_LANG_RUST),
-                         llstr(fname),
-                         llstr(path),
+                         llstr(file_path),
+                         llstr(work_dir),
                          llstr(#env["CFG_VERSION"]),
                          lli1(false), // main compile unit
                          lli1(cx.sess.get_opts().optimize != 0u),

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -1,12 +1,13 @@
-import std::{vec, str, map, option, unsafe};
-import std::vec::to_ptr;
+import std::{vec, str, option, unsafe, fs};
 import std::map::hashmap;
 import lib::llvm::llvm;
-import lib::llvm::llvm::{ModuleRef, ValueRef};
+import lib::llvm::llvm::ValueRef;
 import middle::trans_common::*;
+import middle::ty;
+import ast::ty;
 import syntax::{ast, codemap};
 
-const LLVMDebugVersion: int = 0x80000;
+const LLVMDebugVersion: int = (9 << 16); //& 0xffff0000; // 0x80000 ?
 
 const DW_LANG_RUST: int = 0x9000;
 const DW_VIRTUALITY_none: int = 0;
@@ -14,6 +15,18 @@ const DW_VIRTUALITY_none: int = 0;
 const CompileUnitTag: int = 17;
 const FileDescriptorTag: int = 41;
 const SubprogramTag: int = 46;
+const BasicTypeDescriptorTag: int = 36;
+const AutoVariableTag: int = 256;
+const ArgVariableTag: int = 257;
+const ReturnVariableTag: int = 258;
+const LexicalBlockTag: int = 11;
+
+const DW_ATE_boolean: int = 0x02;
+const DW_ATE_float: int = 0x04;
+const DW_ATE_signed: int = 0x05;
+const DW_ATE_signed_char: int = 0x06;
+const DW_ATE_unsigned: int = 0x07;
+const DW_ATE_unsigned_char: int = 0x08;
 
 fn as_buf(s: str) -> str::sbuf {
     str::as_buf(s, {|sbuf| sbuf})
@@ -23,10 +36,13 @@ fn llstr(s: str) -> ValueRef {
 }
 
 fn lltag(lltag: int) -> ValueRef {
-    lli32(0x80000 + lltag)
+    lli32(LLVMDebugVersion | lltag)
 }
 fn lli32(val: int) -> ValueRef {
     C_i32(val as i32)
+}
+fn lli64(val: int) -> ValueRef {
+    C_i64(val as i64)
 }
 fn lli1(bval: bool) -> ValueRef {
     C_bool(bval)
@@ -37,6 +53,9 @@ fn llmdnode(elems: [ValueRef]) -> ValueRef unsafe {
 }
 fn llunused() -> ValueRef {
     lli32(0x0)
+}
+fn llnull() -> ValueRef {
+    C_null(T_ptr(T_nil()))
 }
 
 fn update_cache(cache: metadata_cache, mdtag: int, val: debug_metadata) {
@@ -55,6 +74,9 @@ type metadata<T> = {node: ValueRef, data: T};
 type file_md = {path: str};
 type compile_unit_md = {path: str};
 type subprogram_md = {name: str, file: str};
+type local_var_md = {id: ast::node_id};
+type tydesc_md = {hash: uint};
+type block_md = {start: codemap::loc, end: codemap::loc};
 
 type metadata_cache = hashmap<int, [debug_metadata]>;
 
@@ -62,18 +84,31 @@ tag debug_metadata {
     file_metadata(@metadata<file_md>);
     compile_unit_metadata(@metadata<compile_unit_md>);
     subprogram_metadata(@metadata<subprogram_md>);
+    local_var_metadata(@metadata<local_var_md>);
+    tydesc_metadata(@metadata<tydesc_md>);
+    block_metadata(@metadata<block_md>);
+}
+
+fn cast_safely<T, U>(val: T) -> U unsafe {
+    let val2 = val;
+    let val3 = unsafe::reinterpret_cast(val2);
+    unsafe::leak(val2);
+    ret val3;
 }
 
 fn md_from_metadata<T>(val: debug_metadata) -> T unsafe {
     alt val {
-      file_metadata(md) { unsafe::reinterpret_cast(md) }
-      compile_unit_metadata(md) { unsafe::reinterpret_cast(md) }
-      subprogram_metadata(md) { unsafe::reinterpret_cast(md) }
+      file_metadata(md) { cast_safely(md) }
+      compile_unit_metadata(md) { cast_safely(md) }
+      subprogram_metadata(md) { cast_safely(md) }
+      local_var_metadata(md) { cast_safely(md) }
+      tydesc_metadata(md) { cast_safely(md) }
+      block_metadata(md) { cast_safely(md) }
     }
 }
 
 fn cached_metadata<T>(cache: metadata_cache, mdtag: int,
-                      eq: block(md: T) -> bool) -> option::t<T> {
+                      eq: block(md: T) -> bool) -> option::t<T> unsafe {
     if cache.contains_key(mdtag) {
         let items = cache.get(mdtag);
         for item in items {
@@ -94,10 +129,8 @@ fn get_compile_unit_metadata(cx: @crate_ctxt, full_path: str)
       option::some(md) { ret md; }
       option::none. {}
     }
-    let sep = str::rindex(full_path, '/' as u8) as uint;
-    let fname = str::slice(full_path, sep + 1u,
-                           str::byte_len(full_path));
-    let path = str::slice(full_path, 0u, sep + 1u);
+    let fname = fs::basename(full_path);
+    let path = fs::dirname(full_path);
     let unit_metadata = [lltag(CompileUnitTag),
                          llunused(),
                          lli32(DW_LANG_RUST),
@@ -122,22 +155,18 @@ fn get_compile_unit_metadata(cx: @crate_ctxt, full_path: str)
     ret mdval;
 }
 
-//        let kind_id = llvm::LLVMGetMDKindID(as_buf("dbg"),
-//                                            str::byte_len("dbg"));
-
-
 fn get_file_metadata(cx: @crate_ctxt, full_path: str) -> @metadata<file_md> {
     let cache = cx.llmetadata;
     alt cached_metadata::<@metadata<file_md>>(
-        cache, FileDescriptorTag, {|md| md.data.path == full_path}) {
+        cache, FileDescriptorTag,
+        {|md|
+         md.data.path == full_path}) {
       option::some(md) { ret md; }
       option::none. {}
     }
-    let sep = str::rindex(full_path, '/' as u8) as uint;
-    let fname = str::slice(full_path, sep + 1u,
-                           str::byte_len(full_path));
-    let path = str::slice(full_path, 0u, sep + 1u);
-    let unit_node = get_compile_unit_metadata(cx, path).node;
+    let fname = fs::basename(full_path);
+    let path = fs::dirname(full_path);
+    let unit_node = get_compile_unit_metadata(cx, full_path).node;
     let file_md = [lltag(FileDescriptorTag),
                    llstr(fname),
                    llstr(path),
@@ -146,6 +175,162 @@ fn get_file_metadata(cx: @crate_ctxt, full_path: str) -> @metadata<file_md> {
     let mdval = @{node: val, data: {path: full_path}};
     update_cache(cache, FileDescriptorTag, file_metadata(mdval));
     ret mdval;
+}
+
+fn get_block_metadata(cx: @block_ctxt) -> @metadata<block_md> {
+    let cache = bcx_ccx(cx).llmetadata;
+    let start = codemap::lookup_char_pos(bcx_ccx(cx).sess.get_codemap(),
+                                         cx.sp.lo);
+    let fname = start.filename;
+    let end = codemap::lookup_char_pos(bcx_ccx(cx).sess.get_codemap(),
+                                       cx.sp.hi);
+    alt cached_metadata::<@metadata<block_md>>(
+        cache, LexicalBlockTag,
+        {|md| start == md.data.start && end == md.data.end}) {
+      option::some(md) { ret md; }
+      option::none. {}
+    }
+    let parent = alt cx.parent {
+      trans_common::parent_none. { llnull() }
+      trans_common::parent_some(bcx) {
+        get_block_metadata(bcx).node
+      }
+    };
+    let file_node = get_file_metadata(bcx_ccx(cx), fname);
+    let unique_id = alt cache.find(LexicalBlockTag) {
+      option::some(v) { vec::len(v) as int }
+      option::none. { 0 }
+    };
+    let lldata = [lltag(LexicalBlockTag),
+                  parent,
+                  lli32(start.line as int),
+                  lli32(start.col as int),
+                  file_node.node,
+                  lli32(unique_id)
+                 ];
+      let val = llmdnode(lldata);
+      let mdval = @{node: val, data: {start: start, end: end}};
+      update_cache(cache, LexicalBlockTag, block_metadata(mdval));
+      ret mdval;
+}
+
+fn get_ty_metadata(cx: @crate_ctxt, t: ty::t, ty: @ast::ty) -> @metadata<tydesc_md> {
+    let cache = cx.llmetadata;
+    alt cached_metadata::<@metadata<tydesc_md>>(
+        cache, BasicTypeDescriptorTag,
+        {|md| ty::hash_ty(t) == ty::hash_ty(md.data.hash)}) {
+      option::some(md) { ret md; }
+      option::none. {}
+    }
+    let (name, size, flags) = alt ty.node {
+      ast::ty_bool. { ("bool", 1, DW_ATE_boolean) }
+      ast::ty_int. { ("int", 32, DW_ATE_signed) } //XXX machine-dependent?
+      ast::ty_uint. { ("uint", 32, DW_ATE_unsigned) } //XXX machine-dependent?
+      ast::ty_float. { ("float", 32, DW_ATE_float) } //XXX machine-dependent?
+      ast::ty_machine(m) { alt m {
+        ast::ty_i8. { ("i8", 1, DW_ATE_signed_char) }
+        ast::ty_i16. { ("i16", 16, DW_ATE_signed) }
+        ast::ty_i32. { ("i32", 32, DW_ATE_signed) }
+        ast::ty_i64. { ("i64", 64, DW_ATE_signed) }
+        ast::ty_u8. { ("u8", 8, DW_ATE_unsigned_char) }
+        ast::ty_u16. { ("u16", 16, DW_ATE_unsigned) }
+        ast::ty_u32. { ("u32", 32, DW_ATE_unsigned) }
+        ast::ty_u64. { ("u64", 64, DW_ATE_unsigned) }
+        ast::ty_f32. { ("f32", 32, DW_ATE_float) }
+        ast::ty_f64. { ("f64", 64, DW_ATE_float) }
+      } }
+      ast::ty_char. { ("char", 32, DW_ATE_unsigned) }
+    };
+    let lldata = [lltag(BasicTypeDescriptorTag),
+                  llunused(), //XXX scope context
+                  llstr(name),
+                  llnull(), //XXX basic types only
+                  lli32(0), //XXX basic types only
+                  lli64(size),
+                  lli64(32), //XXX alignment?
+                  lli64(0), //XXX offset?
+                  lli32(flags)];
+    let llnode = llmdnode(lldata);
+    let mdval = @{node: llnode, data: {hash: ty::hash_ty(t)}};
+    update_cache(cache, BasicTypeDescriptorTag, tydesc_metadata(mdval));
+    ret mdval;
+}
+
+fn get_local_var_metadata(bcx: @block_ctxt, local: @ast::local)
+    -> @metadata<local_var_md> unsafe {
+    let cx = bcx_ccx(bcx);
+    let cache = cx.llmetadata;
+    alt cached_metadata::<@metadata<local_var_md>>(
+        cache, AutoVariableTag, {|md| md.data.id == local.node.id}) {
+      option::some(md) { ret md; }
+      option::none. {}
+    }
+    let name = alt local.node.pat.node {
+      ast::pat_bind(ident) { ident }
+    };
+    let loc = codemap::lookup_char_pos(cx.sess.get_codemap(),
+                                       local.span.lo);
+    let ty = trans::node_id_type(cx, local.node.id);
+    let tymd = get_ty_metadata(cx, ty, local.node.ty);
+    let filemd = get_file_metadata(cx, loc.filename);
+    let blockmd = get_block_metadata(bcx);
+    let lldata = [lltag(AutoVariableTag),
+                  blockmd.node, //XXX block context (maybe subprogram if possible?)
+                  llstr(name), // name
+                  filemd.node,
+                  lli32(loc.line as int), // line
+                  tymd.node,
+                  lli32(0), //XXX flags
+                  llnull() // inline loc reference
+                 ];
+    let mdnode = llmdnode(lldata);
+    let mdval = @{node: mdnode, data: {id: local.node.id}};
+    update_cache(cache, AutoVariableTag, local_var_metadata(mdval));
+    let llptr = alt bcx.fcx.lllocals.find(local.node.id) {
+      option::some(local_mem(v)) { v }
+      option::none. {
+        alt bcx.fcx.lllocals.get(local.node.pat.id) {
+          local_imm(v) { v }
+        }
+      }
+    };
+    let declargs = [llmdnode([llptr]), mdnode];
+    let instr = trans_build::Call(bcx, cx.intrinsics.get("llvm.dbg.declare"),
+                                  declargs);
+    llvm::LLVMAddNamedMetadataOperand(cx.llmod, as_buf("llvm.dbg.vars"),
+                                      str::byte_len("llvm.dbg.vars"),
+                                      mdnode);
+    ret mdval;
+}
+
+fn update_source_pos<T>(cx: @block_ctxt, s: T) {
+    if !bcx_ccx(cx).sess.get_opts().debuginfo {
+        ret;
+    }
+    cx.source_pos = option::some(
+        codemap::lookup_char_pos(bcx_ccx(cx).sess.get_codemap(),
+                                 s.span.lo)); //XXX maybe hi
+
+}
+
+fn reset_source_pos(cx: @block_ctxt) {
+    cx.source_pos = option::none;
+}
+
+fn add_line_info(cx: @block_ctxt, llinstr: ValueRef) {
+    if !bcx_ccx(cx).sess.get_opts().debuginfo ||
+        option::is_none(cx.source_pos) {
+        ret;
+    }
+    let loc = option::get(cx.source_pos);
+    let blockmd = get_block_metadata(cx);
+    let kind_id = llvm::LLVMGetMDKindID(as_buf("dbg"), str::byte_len("dbg"));
+    let scopedata = [lli32(loc.line as int),
+                     lli32(loc.col as int),
+                     blockmd.node,
+                     llnull()];
+    let dbgscope = llmdnode(scopedata);
+    llvm::LLVMSetMetadata(llinstr, kind_id, dbgscope);    
 }
 
 fn get_function_metadata(cx: @crate_ctxt, item: @ast::item,
@@ -159,34 +344,43 @@ fn get_function_metadata(cx: @crate_ctxt, item: @ast::item,
     }
     let loc = codemap::lookup_char_pos(cx.sess.get_codemap(),
                                            item.span.lo);
-        let file_node = get_file_metadata(cx, loc.filename).node;
-        let fn_metadata = [lltag(SubprogramTag),
-                           llunused(),
-                           file_node,
-                           llstr(item.ident),
-                           llstr(item.ident), //XXX fully-qualified C++ name
-                           llstr(item.ident), //XXX MIPS name?????
-                           file_node,
-                           lli32(loc.line as int),
-                           C_null(T_ptr(T_nil())), // XXX reference to tydesc
-                           lli1(false), //XXX static
-                           lli1(true), // not extern
-                           lli32(DW_VIRTUALITY_none), // virtual-ness
-                           lli32(0i), //index into virt func
-                           C_null(T_ptr(T_nil())), // base type with vtbl
-                           lli1(false), // artificial
-                           lli1(cx.sess.get_opts().optimize != 0u),
-                           llfndecl
-                           //list of template params
-                           //func decl descriptor
-                           //list of func vars
-                          ];
-        let val = llmdnode(fn_metadata);
-        llvm::LLVMAddNamedMetadataOperand(cx.llmod, as_buf("llvm.dbg.sp"),
-                                          str::byte_len("llvm.dbg.sp"),
-                                          val);
-        let mdval = @{node: val, data: {name: item.ident,
-                                        file: loc.filename}};
-        update_cache(cache, SubprogramTag, subprogram_metadata(mdval));
-        ret mdval;
+    let file_node = get_file_metadata(cx, loc.filename).node;
+    let mangled = cx.item_symbols.get(item.id);
+    let ret_ty = alt item.node {
+      ast::item_fn(f, _) { f.decl.output }
+    };
+    let ty_node = alt ret_ty.node {
+      ast::ty_nil. { llnull() }
+      _ { get_ty_metadata(cx, ty::node_id_to_type(ccx_tcx(cx), item.id),
+                          ret_ty).node }
+    };
+    let fn_metadata = [lltag(SubprogramTag),
+                       llunused(),
+                       file_node,
+                       llstr(item.ident),
+                       llstr(item.ident), //XXX fully-qualified C++ name
+                       llstr(mangled), //XXX MIPS name?????
+                       file_node,
+                       lli32(loc.line as int),
+                       ty_node,
+                       lli1(false), //XXX static (check export)
+                       lli1(true), // not extern
+                       lli32(DW_VIRTUALITY_none), // virtual-ness
+                       lli32(0i), //index into virt func
+                       llnull(), // base type with vtbl
+                       lli1(false), // artificial
+                       lli1(cx.sess.get_opts().optimize != 0u),
+                       llfndecl
+                       //list of template params
+                       //func decl descriptor
+                       //list of func vars
+                      ];
+    let val = llmdnode(fn_metadata);
+    llvm::LLVMAddNamedMetadataOperand(cx.llmod, as_buf("llvm.dbg.sp"),
+                                      str::byte_len("llvm.dbg.sp"),
+                                      val);
+    let mdval = @{node: val, data: {name: item.ident,
+                                    file: loc.filename}};
+    update_cache(cache, SubprogramTag, subprogram_metadata(mdval));
+    ret mdval;
 }

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -230,7 +230,20 @@ fn get_ty_metadata(cx: @crate_ctxt, t: ty::t, ty: @ast::ty) -> @metadata<tydesc_
     fn size_and_align_of<T>() -> (int, int) {
         (sys::size_of::<T>() as int, sys::align_of::<T>() as int)
     }
-    let (name, (size, align), encoding) = alt ty.node {
+    let ast_ty = alt ty.node {
+      ast::ty_infer. {
+        alt ty::struct(ccx_tcx(cx), t) {
+          ty::ty_bool. { ast::ty_bool }
+          ty::ty_int. { ast::ty_int }
+          ty::ty_uint. { ast::ty_uint }
+          ty::ty_float. { ast::ty_float }
+          ty::ty_machine(m) { ast::ty_machine(m) }
+          ty::ty_char. { ast::ty_char }
+        }
+      }
+      _ { ty.node }
+    };
+    let (name, (size, align), encoding) = alt ast_ty {
       ast::ty_bool. {("bool", size_and_align_of::<bool>(), DW_ATE_boolean)}
       ast::ty_int. {("int", size_and_align_of::<int>(), DW_ATE_signed)}
       ast::ty_uint. {("uint", size_and_align_of::<uint>(), DW_ATE_unsigned)}

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -782,9 +782,14 @@ fn create_function(fcx: @fn_ctxt, item: @ast::item, llfndecl: ValueRef)
     let ret_ty = alt item.node {
       ast::item_fn(f, _) { f.decl.output }
     };
-    let ty_node = alt ret_ty.node {
-      ast::ty_nil. { llnull() }
-      _ { create_ty(cx, ty::node_id_to_type(ccx_tcx(cx), item.id), ret_ty).node }
+    let ty_node = if cx.sess.get_opts().extra_debuginfo {
+        alt ret_ty.node {
+          ast::ty_nil. { llnull() }
+          _ { create_ty(cx, ty::node_id_to_type(ccx_tcx(cx), item.id),
+                        ret_ty).node }
+        }
+    } else {
+        llnull()
     };
     let sub_node = create_composite_type(SubroutineTag, "", file_node, 0, 0,
                                          0, 0, option::none,

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -73,7 +73,8 @@ fn llnull() -> ValueRef unsafe {
 
 fn add_named_metadata(cx: @crate_ctxt, name: str, val: ValueRef) {
     str::as_buf(name, {|sbuf|
-        llvm::LLVMAddNamedMetadataOperand(cx.llmod, sbuf, str::byte_len(name), val)
+        llvm::LLVMAddNamedMetadataOperand(cx.llmod, sbuf, str::byte_len(name),
+                                          val)
     })
 }
 
@@ -356,7 +357,7 @@ fn create_structure(file: @metadata<file_md>, name: str, line: int)
                mutable members: [],
                mutable total_size: 0,
                align: 64 //XXX different alignment per arch?
-              }; 
+              };
     ret cx;
 }
 
@@ -378,8 +379,9 @@ fn create_derived_type(type_tag: int, file: ValueRef, name: str, line: int,
 
 fn add_member(cx: @struct_ctxt, name: str, line: int, size: int, align: int,
               ty: ValueRef) {
-    cx.members += [create_derived_type(MemberTag, cx.file, name, line, size * 8,
-                                       align * 8, cx.total_size, ty)];
+    cx.members += [create_derived_type(MemberTag, cx.file, name, line,
+                                       size * 8, align * 8, cx.total_size,
+                                       ty)];
     cx.total_size += size * 8;
 }
 
@@ -421,10 +423,10 @@ fn create_boxed_type(cx: @crate_ctxt, outer: ty::t, _inner: ty::t,
     let uint_ty = @{node: ast::ty_uint(ast::ty_u), span: span};
     let refcount_type = create_basic_type(cx, uint_t, uint_ty);
     let scx = create_structure(file_node, ty_to_str(ccx_tcx(cx), outer), 0);
-    add_member(scx, "refcnt", 0, sys::size_of::<uint>() as int, 
+    add_member(scx, "refcnt", 0, sys::size_of::<uint>() as int,
                sys::align_of::<uint>() as int, refcount_type.node);
     add_member(scx, "boxed", 0, 8, //XXX member_size_and_align(??)
-               8, //XXX just a guess 
+               8, //XXX just a guess
                boxed.node);
     let llnode = finish_structure(scx);
     let mdval = @{node: llnode, data: {hash: outer}};
@@ -477,7 +479,7 @@ fn create_vec(cx: @crate_ctxt, vec_t: ty::t, elem_t: ty::t, vec_ty: @ast::ty)
                                          arr_size, arr_align, 0,
                                          option::some(elem_ty_md.node),
                                          option::some([subrange]));
-    add_member(scx, "data", 0, 0, // according to an equivalent clang dump, the size should be 0
+    add_member(scx, "data", 0, 0, // clang says the size should be 0
                sys::align_of::<u8>() as int, data_ptr);
     let llnode = finish_structure(scx);
     ret @{node: llnode, data: {hash: vec_t}};
@@ -521,7 +523,8 @@ fn member_size_and_align(ty: @ast::ty) -> (int, int) {
     }
 }
 
-fn create_ty(cx: @crate_ctxt, t: ty::t, ty: @ast::ty) -> @metadata<tydesc_md> {
+fn create_ty(cx: @crate_ctxt, t: ty::t, ty: @ast::ty)
+    -> @metadata<tydesc_md> {
     /*let cache = get_cache(cx);
     alt cached_metadata::<@metadata<tydesc_md>>(
         cache, tg, {|md| t == md.data.hash}) {
@@ -623,7 +626,7 @@ fn create_local_var(bcx: @block_ctxt, local: @ast::local)
     }
 
     let name = alt local.node.pat.node {
-      ast::pat_bind(ident, _) { ident /*XXX deal with optional node binding */ }
+      ast::pat_bind(ident, _) { ident /*XXX deal w/ optional node binding*/ }
     };
     let loc = codemap::lookup_char_pos(cx.sess.get_codemap(),
                                        local.span.lo);

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -4015,7 +4015,7 @@ fn trans_stmt(cx: @block_ctxt, s: ast::stmt) -> @block_ctxt {
 
     let bcx = cx;
     debuginfo::update_source_pos(cx, s.span);
-    
+
     alt s.node {
       ast::stmt_expr(e, _) { bcx = trans_expr(cx, e, ignore); }
       ast::stmt_decl(d, _) {
@@ -4562,7 +4562,8 @@ fn trans_fn(cx: @local_ctxt, sp: span, f: ast::_fn, llfndecl: ValueRef,
     let do_time = cx.ccx.sess.get_opts().stats;
     let start = do_time ? time::get_time() : {sec: 0u32, usec: 0u32};
     let fcx = option::none;
-    trans_closure(cx, sp, f, llfndecl, ty_self, ty_params, id, {|new_fcx| fcx = option::some(new_fcx);});
+    trans_closure(cx, sp, f, llfndecl, ty_self, ty_params, id,
+                  {|new_fcx| fcx = option::some(new_fcx);});
     if cx.ccx.sess.get_opts().extra_debuginfo {
         debuginfo::create_function(option::get(fcx));
     }

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -4027,7 +4027,7 @@ fn trans_stmt(cx: @block_ctxt, s: ast::stmt) -> @block_ctxt {
                 } else {
                     bcx = init_ref_local(bcx, local);
                 }
-                if bcx_ccx(cx).sess.get_opts().debuginfo {
+                if bcx_ccx(cx).sess.get_opts().extra_debuginfo {
                     debuginfo::create_local_var(bcx, local);
                 }
             }
@@ -4422,7 +4422,7 @@ fn create_llargs_for_fn_args(cx: @fn_ctxt, ty_self: self_arg,
 
 fn copy_args_to_allocas(fcx: @fn_ctxt, bcx: @block_ctxt, args: [ast::arg],
                         arg_tys: [ty::arg]) -> @block_ctxt {
-    if fcx_ccx(fcx).sess.get_opts().debuginfo {
+    if fcx_ccx(fcx).sess.get_opts().extra_debuginfo {
         llvm::LLVMAddAttribute(llvm::LLVMGetFirstParam(fcx.llfn),
                                lib::llvm::LLVMStructRetAttribute as
                                    lib::llvm::llvm::Attribute);
@@ -4446,7 +4446,7 @@ fn copy_args_to_allocas(fcx: @fn_ctxt, bcx: @block_ctxt, args: [ast::arg],
           }
           ast::by_ref. {}
         }
-        if fcx_ccx(fcx).sess.get_opts().debuginfo {
+        if fcx_ccx(fcx).sess.get_opts().extra_debuginfo {
             debuginfo::create_arg(bcx, args[arg_n]);
         }
         arg_n += 1u;
@@ -4584,7 +4584,7 @@ fn trans_fn(cx: @local_ctxt, sp: span, f: ast::_fn, llfndecl: ValueRef,
     let start = do_time ? time::get_time() : {sec: 0u32, usec: 0u32};
     let fcx = option::none;
     trans_closure(cx, sp, f, llfndecl, ty_self, ty_params, id, {|new_fcx| fcx = option::some(new_fcx);});
-    if cx.ccx.sess.get_opts().debuginfo {
+    if cx.ccx.sess.get_opts().extra_debuginfo {
         let item = alt option::get(cx.ccx.ast_map.find(id)) {
             ast_map::node_item(item) { item }
         };
@@ -5654,7 +5654,7 @@ fn trans_crate(sess: session::session, crate: @ast::crate, tcx: ty::ctxt,
     let td = mk_target_data(sess.get_targ_cfg().target_strs.data_layout);
     let tn = mk_type_names();
     let intrinsics = declare_intrinsics(llmod);
-    if sess.get_opts().debuginfo {
+    if sess.get_opts().extra_debuginfo {
         declare_dbg_intrinsics(llmod, intrinsics);
     }
     let int_type = T_int(targ_cfg);

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -5673,6 +5673,12 @@ fn trans_crate(sess: session::session, crate: @ast::crate, tcx: ty::ctxt,
     let sha1s = map::mk_hashmap::<ty::t, str>(hasher, eqer);
     let short_names = map::mk_hashmap::<ty::t, str>(hasher, eqer);
     let crate_map = decl_crate_map(sess, link_meta.name, llmod);
+    let dbg_cx = if sess.get_opts().debuginfo {
+        option::some(@{llmetadata: map::new_int_hash(),
+                       names: namegen(0)})
+    } else {
+        option::none
+    };
     let ccx =
         @{sess: sess,
           llmod: llmod,
@@ -5723,7 +5729,7 @@ fn trans_crate(sess: session::session, crate: @ast::crate, tcx: ty::ctxt,
           shape_cx: shape::mk_ctxt(llmod),
           gc_cx: gc::mk_ctxt(),
           crate_map: crate_map,
-          llmetadata: map::new_int_hash()};
+          dbg_cx: dbg_cx};
     let cx = new_local_ctxt(ccx);
     collect_items(ccx, crate);
     collect_tag_ctors(ccx, crate);

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -4028,7 +4028,7 @@ fn trans_stmt(cx: @block_ctxt, s: ast::stmt) -> @block_ctxt {
                     bcx = init_ref_local(bcx, local);
                 }
                 if bcx_ccx(cx).sess.get_opts().debuginfo {
-                    debuginfo::get_local_var_metadata(bcx, local);
+                    debuginfo::create_local_var(bcx, local);
                 }
             }
           }
@@ -4426,7 +4426,6 @@ fn copy_args_to_allocas(fcx: @fn_ctxt, bcx: @block_ctxt, args: [ast::arg],
         llvm::LLVMAddAttribute(llvm::LLVMGetFirstParam(fcx.llfn),
                                lib::llvm::LLVMStructRetAttribute as
                                    lib::llvm::llvm::Attribute);
-        //let _ = debuginfo::get_retval_metadata(bcx);
     }
     let arg_n: uint = 0u, bcx = bcx;
     for arg in arg_tys {
@@ -4448,7 +4447,7 @@ fn copy_args_to_allocas(fcx: @fn_ctxt, bcx: @block_ctxt, args: [ast::arg],
           ast::by_ref. {}
         }
         if fcx_ccx(fcx).sess.get_opts().debuginfo {
-            let _ = debuginfo::get_arg_metadata(bcx, args[arg_n]);
+            debuginfo::create_arg(bcx, args[arg_n]);
         }
         arg_n += 1u;
     }
@@ -4589,7 +4588,7 @@ fn trans_fn(cx: @local_ctxt, sp: span, f: ast::_fn, llfndecl: ValueRef,
         let item = alt option::get(cx.ccx.ast_map.find(id)) {
             ast_map::node_item(item) { item }
         };
-        debuginfo::get_function_metadata(option::get(fcx), item, llfndecl);
+        debuginfo::create_function(option::get(fcx), item, llfndecl);
     }
     if do_time {
         let end = time::get_time();

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -3519,7 +3519,7 @@ fn trans_temp_expr(bcx: @block_ctxt, e: @ast::expr) -> result {
 // - exprs with non-immediate type never get dest=by_val
 fn trans_expr(bcx: @block_ctxt, e: @ast::expr, dest: dest) -> @block_ctxt {
     let tcx = bcx_tcx(bcx);
-    debuginfo::update_source_pos(bcx, e);
+    debuginfo::update_source_pos(bcx, e.span);
 
     if expr_is_lval(bcx, e) {
         ret lval_to_dps(bcx, e, dest);
@@ -4014,7 +4014,7 @@ fn trans_stmt(cx: @block_ctxt, s: ast::stmt) -> @block_ctxt {
     }
 
     let bcx = cx;
-    debuginfo::update_source_pos(cx, s);
+    debuginfo::update_source_pos(cx, s.span);
     
     alt s.node {
       ast::stmt_expr(e, _) { bcx = trans_expr(cx, e, ignore); }
@@ -4263,7 +4263,7 @@ fn trans_block(bcx: @block_ctxt, b: ast::blk) -> @block_ctxt {
 fn trans_block_dps(bcx: @block_ctxt, b: ast::blk, dest: dest)
     -> @block_ctxt {
     let bcx = bcx;
-    debuginfo::update_source_pos(bcx, b);
+    debuginfo::update_source_pos(bcx, b.span);
     block_locals(b) {|local| bcx = alloc_local(bcx, local); };
     for s: @ast::stmt in b.node.stmts {
         bcx = trans_stmt(bcx, *s);

--- a/src/comp/middle/trans_build.rs
+++ b/src/comp/middle/trans_build.rs
@@ -408,7 +408,7 @@ fn GEP(cx: @block_ctxt, Pointer: ValueRef, Indices: [ValueRef]) -> ValueRef {
     unsafe {
         let instr = llvm::LLVMBuildGEP(B(cx), Pointer, vec::to_ptr(Indices),
                                        vec::len(Indices), noname());
-        debuginfo::add_line_info(cx, instr);
+        //debuginfo::add_line_info(cx, instr);
         ret instr;
     }
 }
@@ -425,18 +425,18 @@ fn InBoundsGEP(cx: @block_ctxt, Pointer: ValueRef, Indices: [ValueRef]) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_nil())); }
     unsafe {
-        let v = llvm::LLVMBuildInBoundsGEP(B(cx), Pointer,
-                                           vec::to_ptr(Indices),
-                                           vec::len(Indices), noname());
-        debuginfo::add_line_info(cx, v);
-        ret v;
+        let instr = llvm::LLVMBuildInBoundsGEP(B(cx), Pointer,
+                                               vec::to_ptr(Indices),
+                                               vec::len(Indices), noname());
+        //debuginfo::add_line_info(cx, instr);
+        ret instr;
     }
 }
 
 fn StructGEP(cx: @block_ctxt, Pointer: ValueRef, Idx: uint) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_nil())); }
     let instr = llvm::LLVMBuildStructGEP(B(cx), Pointer, Idx, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
@@ -458,84 +458,84 @@ fn GlobalStringPtr(cx: @block_ctxt, _Str: sbuf) -> ValueRef {
 fn Trunc(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildTrunc(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn ZExt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildZExt(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn SExt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildSExt(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn FPToUI(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildFPToUI(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn FPToSI(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildFPToSI(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn UIToFP(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildUIToFP(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn SIToFP(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildSIToFP(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn FPTrunc(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildFPTrunc(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn FPExt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildFPExt(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn PtrToInt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildPtrToInt(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn IntToPtr(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildIntToPtr(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn BitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildBitCast(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
@@ -543,7 +543,7 @@ fn ZExtOrBitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildZExtOrBitCast(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
@@ -551,7 +551,7 @@ fn SExtOrBitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildSExtOrBitCast(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
@@ -559,7 +559,7 @@ fn TruncOrBitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildTruncOrBitCast(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
@@ -567,28 +567,28 @@ fn Cast(cx: @block_ctxt, Op: Opcode, Val: ValueRef, DestTy: TypeRef,
         _Name: sbuf) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildCast(B(cx), Op, Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn PointerCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildPointerCast(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn IntCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildIntCast(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
 fn FPCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
     let instr = llvm::LLVMBuildFPCast(B(cx), Val, DestTy, noname());
-    debuginfo::add_line_info(cx, instr);
+    //debuginfo::add_line_info(cx, instr);
     ret instr;
 }
 
@@ -670,7 +670,7 @@ fn Call(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef]) -> ValueRef {
     unsafe {
         let instr = llvm::LLVMBuildCall(B(cx), Fn, vec::to_ptr(Args),
                                         vec::len(Args), noname());
-        debuginfo::add_line_info(cx, instr);
+        //debuginfo::add_line_info(cx, instr);
         ret instr;
     }
 }

--- a/src/comp/middle/trans_build.rs
+++ b/src/comp/middle/trans_build.rs
@@ -104,6 +104,14 @@ fn Invoke(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef],
         let instr = llvm::LLVMBuildInvoke(B(cx), Fn, vec::to_ptr(Args),
                                           vec::len(Args), Then, Catch,
                                           noname());
+        if bcx_ccx(cx).sess.get_opts().debuginfo {
+            /*llvm::LLVMAddAttribute(option::get(vec::last(llargs)),
+            lib::llvm::LLVMStructRetAttribute as
+            lib::llvm::llvm::Attribute);*/
+            llvm::LLVMAddInstrAttribute(instr, 1u,
+                                        lib::llvm::LLVMStructRetAttribute as
+                                            lib::llvm::llvm::Attribute);
+        }
         debuginfo::add_line_info(cx, instr);
     }
 }

--- a/src/comp/middle/trans_build.rs
+++ b/src/comp/middle/trans_build.rs
@@ -670,7 +670,7 @@ fn Call(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef]) -> ValueRef {
     unsafe {
         let instr = llvm::LLVMBuildCall(B(cx), Fn, vec::to_ptr(Args),
                                         vec::len(Args), noname());
-        //debuginfo::add_line_info(cx, instr);
+        debuginfo::add_line_info(cx, instr);
         ret instr;
     }
 }

--- a/src/comp/middle/trans_build.rs
+++ b/src/comp/middle/trans_build.rs
@@ -631,7 +631,8 @@ fn Trap(cx: @block_ctxt) {
     assert (T as int != 0);
     let Args: [ValueRef] = [];
     unsafe {
-        llvm::LLVMBuildCall(b, T, vec::to_ptr(Args), vec::len(Args), noname());
+        llvm::LLVMBuildCall(b, T, vec::to_ptr(Args), vec::len(Args),
+                            noname());
     }
 }
 

--- a/src/comp/middle/trans_build.rs
+++ b/src/comp/middle/trans_build.rs
@@ -25,14 +25,16 @@ fn RetVoid(cx: @block_ctxt) {
     if cx.unreachable { ret; }
     assert (!cx.terminated);
     cx.terminated = true;
-    llvm::LLVMBuildRetVoid(B(cx));
+    let instr = llvm::LLVMBuildRetVoid(B(cx));
+    debuginfo::add_line_info(cx, instr);
 }
 
 fn Ret(cx: @block_ctxt, V: ValueRef) {
     if cx.unreachable { ret; }
     assert (!cx.terminated);
     cx.terminated = true;
-    llvm::LLVMBuildRet(B(cx), V);
+    let instr = llvm::LLVMBuildRet(B(cx), V);
+    debuginfo::add_line_info(cx, instr);
 }
 
 fn AggregateRet(cx: @block_ctxt, RetVals: [ValueRef]) {
@@ -40,8 +42,9 @@ fn AggregateRet(cx: @block_ctxt, RetVals: [ValueRef]) {
     assert (!cx.terminated);
     cx.terminated = true;
     unsafe {
-        llvm::LLVMBuildAggregateRet(B(cx), vec::to_ptr(RetVals),
-                                    vec::len(RetVals));
+        let instr = llvm::LLVMBuildAggregateRet(B(cx), vec::to_ptr(RetVals),
+                                                vec::len(RetVals));
+        debuginfo::add_line_info(cx, instr);
     }
 }
 
@@ -49,7 +52,8 @@ fn Br(cx: @block_ctxt, Dest: BasicBlockRef) {
     if cx.unreachable { ret; }
     assert (!cx.terminated);
     cx.terminated = true;
-    llvm::LLVMBuildBr(B(cx), Dest);
+    let instr = llvm::LLVMBuildBr(B(cx), Dest);
+    debuginfo::add_line_info(cx, instr);
 }
 
 fn CondBr(cx: @block_ctxt, If: ValueRef, Then: BasicBlockRef,
@@ -57,7 +61,8 @@ fn CondBr(cx: @block_ctxt, If: ValueRef, Then: BasicBlockRef,
     if cx.unreachable { ret; }
     assert (!cx.terminated);
     cx.terminated = true;
-    llvm::LLVMBuildCondBr(B(cx), If, Then, Else);
+    let instr = llvm::LLVMBuildCondBr(B(cx), If, Then, Else);
+    debuginfo::add_line_info(cx, instr);
 }
 
 fn Switch(cx: @block_ctxt, V: ValueRef, Else: BasicBlockRef, NumCases: uint)
@@ -65,7 +70,9 @@ fn Switch(cx: @block_ctxt, V: ValueRef, Else: BasicBlockRef, NumCases: uint)
     if cx.unreachable { ret _Undef(V); }
     assert !cx.terminated;
     cx.terminated = true;
-    ret llvm::LLVMBuildSwitch(B(cx), V, Else, NumCases);
+    let instr = llvm::LLVMBuildSwitch(B(cx), V, Else, NumCases);
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn AddCase(S: ValueRef, OnVal: ValueRef, Dest: BasicBlockRef) {
@@ -77,7 +84,8 @@ fn IndirectBr(cx: @block_ctxt, Addr: ValueRef, NumDests: uint) {
     if cx.unreachable { ret; }
     assert (!cx.terminated);
     cx.terminated = true;
-    llvm::LLVMBuildIndirectBr(B(cx), Addr, NumDests);
+    let instr = llvm::LLVMBuildIndirectBr(B(cx), Addr, NumDests);
+    debuginfo::add_line_info(cx, instr);
 }
 
 // This is a really awful way to get a zero-length c-string, but better (and a
@@ -93,8 +101,10 @@ fn Invoke(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef],
     assert (!cx.terminated);
     cx.terminated = true;
     unsafe {
-        llvm::LLVMBuildInvoke(B(cx), Fn, vec::to_ptr(Args),
-                              vec::len(Args), Then, Catch, noname());
+        let instr = llvm::LLVMBuildInvoke(B(cx), Fn, vec::to_ptr(Args),
+                                          vec::len(Args), Then, Catch,
+                                          noname());
+        debuginfo::add_line_info(cx, instr);
     }
 }
 
@@ -107,6 +117,7 @@ fn FastInvoke(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef],
         let v = llvm::LLVMBuildInvoke(B(cx), Fn, vec::to_ptr(Args),
                                       vec::len(Args), Then, Catch, noname());
         llvm::LLVMSetInstructionCallConv(v, lib::llvm::LLVMFastCallConv);
+        debuginfo::add_line_info(cx, v);
     }
 }
 
@@ -123,183 +134,254 @@ fn _Undef(val: ValueRef) -> ValueRef {
 /* Arithmetic */
 fn Add(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildAdd(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildAdd(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn NSWAdd(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildNSWAdd(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildNSWAdd(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn NUWAdd(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildNUWAdd(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildNUWAdd(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FAdd(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildFAdd(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildFAdd(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Sub(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildSub(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildSub(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn NSWSub(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildNSWSub(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildNSWSub(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn NUWSub(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildNUWSub(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildNUWSub(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FSub(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildFSub(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildFSub(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Mul(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildMul(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildMul(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn NSWMul(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildNSWMul(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildNSWMul(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn NUWMul(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildNUWMul(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildNUWMul(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FMul(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildFMul(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildFMul(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn UDiv(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildUDiv(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildUDiv(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn SDiv(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildSDiv(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildSDiv(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn ExactSDiv(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildExactSDiv(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildExactSDiv(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FDiv(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildFDiv(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildFDiv(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn URem(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildURem(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildURem(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn SRem(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildSRem(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildSRem(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FRem(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildFRem(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildFRem(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Shl(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildShl(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildShl(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn LShr(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildLShr(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildLShr(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn AShr(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildAShr(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildAShr(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn And(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildAnd(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildAnd(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Or(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildOr(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildOr(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Xor(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildXor(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildXor(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn BinOp(cx: @block_ctxt, Op: Opcode, LHS: ValueRef, RHS: ValueRef) ->
    ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    ret llvm::LLVMBuildBinOp(B(cx), Op, LHS, RHS, noname());
+    let instr = llvm::LLVMBuildBinOp(B(cx), Op, LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Neg(cx: @block_ctxt, V: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(V); }
-    ret llvm::LLVMBuildNeg(B(cx), V, noname());
+    let instr = llvm::LLVMBuildNeg(B(cx), V, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn NSWNeg(cx: @block_ctxt, V: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(V); }
-    ret llvm::LLVMBuildNSWNeg(B(cx), V, noname());
+    let instr = llvm::LLVMBuildNSWNeg(B(cx), V, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn NUWNeg(cx: @block_ctxt, V: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(V); }
-    ret llvm::LLVMBuildNUWNeg(B(cx), V, noname());
+    let instr = llvm::LLVMBuildNUWNeg(B(cx), V, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 fn FNeg(cx: @block_ctxt, V: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(V); }
-    ret llvm::LLVMBuildFNeg(B(cx), V, noname());
+    let instr = llvm::LLVMBuildFNeg(B(cx), V, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Not(cx: @block_ctxt, V: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(V); }
-    ret llvm::LLVMBuildNot(B(cx), V, noname());
+    let instr = llvm::LLVMBuildNot(B(cx), V, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 /* Memory */
 fn Malloc(cx: @block_ctxt, Ty: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_i8())); }
-    ret llvm::LLVMBuildMalloc(B(cx), Ty, noname());
+    let instr = llvm::LLVMBuildMalloc(B(cx), Ty, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn ArrayMalloc(cx: @block_ctxt, Ty: TypeRef, Val: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_i8())); }
-    ret llvm::LLVMBuildArrayMalloc(B(cx), Ty, Val, noname());
+    let instr = llvm::LLVMBuildArrayMalloc(B(cx), Ty, Val, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Alloca(cx: @block_ctxt, Ty: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(Ty)); }
-    ret llvm::LLVMBuildAlloca(B(cx), Ty, noname());
+    let instr = llvm::LLVMBuildAlloca(B(cx), Ty, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn ArrayAlloca(cx: @block_ctxt, Ty: TypeRef, Val: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(Ty)); }
-    ret llvm::LLVMBuildArrayAlloca(B(cx), Ty, Val, noname());
+    let instr = llvm::LLVMBuildArrayAlloca(B(cx), Ty, Val, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Free(cx: @block_ctxt, PointerVal: ValueRef) {
     if cx.unreachable { ret; }
-    llvm::LLVMBuildFree(B(cx), PointerVal);
+    let instr = llvm::LLVMBuildFree(B(cx), PointerVal);
+    debuginfo::add_line_info(cx, instr);
 }
 
 fn Load(cx: @block_ctxt, PointerVal: ValueRef) -> ValueRef {
@@ -310,19 +392,24 @@ fn Load(cx: @block_ctxt, PointerVal: ValueRef) -> ValueRef {
             llvm::LLVMGetElementType(ty) } else { ccx.int_type };
         ret llvm::LLVMGetUndef(eltty);
     }
-    ret llvm::LLVMBuildLoad(B(cx), PointerVal, noname());
+    let instr = llvm::LLVMBuildLoad(B(cx), PointerVal, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Store(cx: @block_ctxt, Val: ValueRef, Ptr: ValueRef) {
     if cx.unreachable { ret; }
-    llvm::LLVMBuildStore(B(cx), Val, Ptr);
+    let instr = llvm::LLVMBuildStore(B(cx), Val, Ptr);
+    debuginfo::add_line_info(cx, instr);
 }
 
 fn GEP(cx: @block_ctxt, Pointer: ValueRef, Indices: [ValueRef]) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_nil())); }
     unsafe {
-        ret llvm::LLVMBuildGEP(B(cx), Pointer, vec::to_ptr(Indices),
-                               vec::len(Indices), noname());
+        let instr = llvm::LLVMBuildGEP(B(cx), Pointer, vec::to_ptr(Indices),
+                                       vec::len(Indices), noname());
+        debuginfo::add_line_info(cx, instr);
+        ret instr;
     }
 }
 
@@ -338,142 +425,195 @@ fn InBoundsGEP(cx: @block_ctxt, Pointer: ValueRef, Indices: [ValueRef]) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_nil())); }
     unsafe {
-        ret llvm::LLVMBuildInBoundsGEP(B(cx), Pointer, vec::to_ptr(Indices),
-                                       vec::len(Indices), noname());
+        let v = llvm::LLVMBuildInBoundsGEP(B(cx), Pointer,
+                                           vec::to_ptr(Indices),
+                                           vec::len(Indices), noname());
+        debuginfo::add_line_info(cx, v);
+        ret v;
     }
 }
 
 fn StructGEP(cx: @block_ctxt, Pointer: ValueRef, Idx: uint) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_nil())); }
-    ret llvm::LLVMBuildStructGEP(B(cx), Pointer, Idx, noname());
+    let instr = llvm::LLVMBuildStructGEP(B(cx), Pointer, Idx, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn GlobalString(cx: @block_ctxt, _Str: sbuf) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_i8())); }
-    ret llvm::LLVMBuildGlobalString(B(cx), _Str, noname());
+    let instr = llvm::LLVMBuildGlobalString(B(cx), _Str, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn GlobalStringPtr(cx: @block_ctxt, _Str: sbuf) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_i8())); }
-    ret llvm::LLVMBuildGlobalStringPtr(B(cx), _Str, noname());
+    let instr = llvm::LLVMBuildGlobalStringPtr(B(cx), _Str, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 /* Casts */
 fn Trunc(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildTrunc(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildTrunc(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn ZExt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildZExt(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildZExt(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn SExt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildSExt(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildSExt(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FPToUI(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildFPToUI(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildFPToUI(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FPToSI(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildFPToSI(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildFPToSI(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn UIToFP(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildUIToFP(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildUIToFP(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn SIToFP(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildSIToFP(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildSIToFP(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FPTrunc(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildFPTrunc(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildFPTrunc(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FPExt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildFPExt(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildFPExt(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn PtrToInt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildPtrToInt(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildPtrToInt(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn IntToPtr(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildIntToPtr(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildIntToPtr(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn BitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildBitCast(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildBitCast(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn ZExtOrBitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildZExtOrBitCast(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildZExtOrBitCast(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn SExtOrBitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildSExtOrBitCast(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildSExtOrBitCast(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn TruncOrBitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildTruncOrBitCast(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildTruncOrBitCast(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Cast(cx: @block_ctxt, Op: Opcode, Val: ValueRef, DestTy: TypeRef,
         _Name: sbuf) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildCast(B(cx), Op, Val, DestTy, noname());
+    let instr = llvm::LLVMBuildCast(B(cx), Op, Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn PointerCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildPointerCast(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildPointerCast(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn IntCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildIntCast(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildIntCast(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FPCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    ret llvm::LLVMBuildFPCast(B(cx), Val, DestTy, noname());
+    let instr = llvm::LLVMBuildFPCast(B(cx), Val, DestTy, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 
 /* Comparisons */
 fn ICmp(cx: @block_ctxt, Op: uint, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_i1()); }
-    ret llvm::LLVMBuildICmp(B(cx), Op, LHS, RHS, noname());
+    let instr = llvm::LLVMBuildICmp(B(cx), Op, LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn FCmp(cx: @block_ctxt, Op: uint, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_i1()); }
-    ret llvm::LLVMBuildFCmp(B(cx), Op, LHS, RHS, noname());
+    let instr = llvm::LLVMBuildFCmp(B(cx), Op, LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 /* Miscellaneous instructions */
 fn EmptyPhi(cx: @block_ctxt, Ty: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(Ty); }
-    ret llvm::LLVMBuildPhi(B(cx), Ty, noname());
+    let instr = llvm::LLVMBuildPhi(B(cx), Ty, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Phi(cx: @block_ctxt, Ty: TypeRef, vals: [ValueRef], bbs: [BasicBlockRef])
@@ -528,8 +668,10 @@ fn add_comment(bcx: @block_ctxt, text: str) {
 fn Call(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef]) -> ValueRef {
     if cx.unreachable { ret _UndefReturn(cx, Fn); }
     unsafe {
-        ret llvm::LLVMBuildCall(B(cx), Fn, vec::to_ptr(Args),
-                                vec::len(Args), noname());
+        let instr = llvm::LLVMBuildCall(B(cx), Fn, vec::to_ptr(Args),
+                                        vec::len(Args), noname());
+        debuginfo::add_line_info(cx, instr);
+        ret instr;
     }
 }
 
@@ -539,6 +681,7 @@ fn FastCall(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef]) -> ValueRef {
         let v = llvm::LLVMBuildCall(B(cx), Fn, vec::to_ptr(Args),
                                     vec::len(Args), noname());
         llvm::LLVMSetInstructionCallConv(v, lib::llvm::LLVMFastCallConv);
+        debuginfo::add_line_info(cx, v);
         ret v;
     }
 }
@@ -550,6 +693,7 @@ fn CallWithConv(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef], Conv: uint)
         let v = llvm::LLVMBuildCall(B(cx), Fn, vec::to_ptr(Args),
                                     vec::len(Args), noname());
         llvm::LLVMSetInstructionCallConv(v, Conv);
+        debuginfo::add_line_info(cx, v);
         ret v;
     }
 }
@@ -557,57 +701,76 @@ fn CallWithConv(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef], Conv: uint)
 fn Select(cx: @block_ctxt, If: ValueRef, Then: ValueRef, Else: ValueRef) ->
    ValueRef {
     if cx.unreachable { ret _Undef(Then); }
-    ret llvm::LLVMBuildSelect(B(cx), If, Then, Else, noname());
+    let instr = llvm::LLVMBuildSelect(B(cx), If, Then, Else, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn VAArg(cx: @block_ctxt, list: ValueRef, Ty: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(Ty); }
-    ret llvm::LLVMBuildVAArg(B(cx), list, Ty, noname());
+    let instr = llvm::LLVMBuildVAArg(B(cx), list, Ty, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn ExtractElement(cx: @block_ctxt, VecVal: ValueRef, Index: ValueRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_nil()); }
-    ret llvm::LLVMBuildExtractElement(B(cx), VecVal, Index, noname());
+    let instr = llvm::LLVMBuildExtractElement(B(cx), VecVal, Index, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn InsertElement(cx: @block_ctxt, VecVal: ValueRef, EltVal: ValueRef,
                  Index: ValueRef) {
     if cx.unreachable { ret; }
-    llvm::LLVMBuildInsertElement(B(cx), VecVal, EltVal, Index, noname());
+    let instr = llvm::LLVMBuildInsertElement(B(cx), VecVal, EltVal, Index,
+                                             noname());
+    debuginfo::add_line_info(cx, instr);
 }
 
 fn ShuffleVector(cx: @block_ctxt, V1: ValueRef, V2: ValueRef,
                  Mask: ValueRef) {
     if cx.unreachable { ret; }
-    llvm::LLVMBuildShuffleVector(B(cx), V1, V2, Mask, noname());
+    let instr = llvm::LLVMBuildShuffleVector(B(cx), V1, V2, Mask, noname());
+    debuginfo::add_line_info(cx, instr);
 }
 
 fn ExtractValue(cx: @block_ctxt, AggVal: ValueRef, Index: uint) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_nil()); }
-    ret llvm::LLVMBuildExtractValue(B(cx), AggVal, Index, noname());
+    let instr = llvm::LLVMBuildExtractValue(B(cx), AggVal, Index, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn InsertValue(cx: @block_ctxt, AggVal: ValueRef, EltVal: ValueRef,
                Index: uint) {
     if cx.unreachable { ret; }
-    llvm::LLVMBuildInsertValue(B(cx), AggVal, EltVal, Index, noname());
+    let instr = llvm::LLVMBuildInsertValue(B(cx), AggVal, EltVal, Index,
+                                           noname());
+    debuginfo::add_line_info(cx, instr);
 }
 
 fn IsNull(cx: @block_ctxt, Val: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_i1()); }
-    ret llvm::LLVMBuildIsNull(B(cx), Val, noname());
+    let instr = llvm::LLVMBuildIsNull(B(cx), Val, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn IsNotNull(cx: @block_ctxt, Val: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_i1()); }
-    ret llvm::LLVMBuildIsNotNull(B(cx), Val, noname());
+    let instr = llvm::LLVMBuildIsNotNull(B(cx), Val, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn PtrDiff(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     let ccx = cx.fcx.lcx.ccx;
     if cx.unreachable { ret llvm::LLVMGetUndef(ccx.int_type); }
-    ret llvm::LLVMBuildPtrDiff(B(cx), LHS, RHS, noname());
+    let instr = llvm::LLVMBuildPtrDiff(B(cx), LHS, RHS, noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn Trap(cx: @block_ctxt) {
@@ -622,15 +785,19 @@ fn Trap(cx: @block_ctxt) {
     assert (T as int != 0);
     let Args: [ValueRef] = [];
     unsafe {
-        llvm::LLVMBuildCall(b, T, vec::to_ptr(Args),
-                            vec::len(Args), noname());
+        let instr = llvm::LLVMBuildCall(b, T, vec::to_ptr(Args),
+                                        vec::len(Args), noname());
+        debuginfo::add_line_info(cx, instr);
     }
 }
 
 fn LandingPad(cx: @block_ctxt, Ty: TypeRef, PersFn: ValueRef,
               NumClauses: uint) -> ValueRef {
     assert !cx.terminated && !cx.unreachable;
-    ret llvm::LLVMBuildLandingPad(B(cx), Ty, PersFn, NumClauses, noname());
+    let instr = llvm::LLVMBuildLandingPad(B(cx), Ty, PersFn, NumClauses,
+                                          noname());
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 fn SetCleanup(_cx: @block_ctxt, LandingPad: ValueRef) {
@@ -640,7 +807,9 @@ fn SetCleanup(_cx: @block_ctxt, LandingPad: ValueRef) {
 fn Resume(cx: @block_ctxt, Exn: ValueRef) -> ValueRef {
     assert (!cx.terminated);
     cx.terminated = true;
-    ret llvm::LLVMBuildResume(B(cx), Exn);
+    let instr = llvm::LLVMBuildResume(B(cx), Exn);
+    debuginfo::add_line_info(cx, instr);
+    ret instr;
 }
 
 //

--- a/src/comp/middle/trans_build.rs
+++ b/src/comp/middle/trans_build.rs
@@ -25,16 +25,14 @@ fn RetVoid(cx: @block_ctxt) {
     if cx.unreachable { ret; }
     assert (!cx.terminated);
     cx.terminated = true;
-    let instr = llvm::LLVMBuildRetVoid(B(cx));
-    debuginfo::add_line_info(cx, instr);
+    llvm::LLVMBuildRetVoid(B(cx));
 }
 
 fn Ret(cx: @block_ctxt, V: ValueRef) {
     if cx.unreachable { ret; }
     assert (!cx.terminated);
     cx.terminated = true;
-    let instr = llvm::LLVMBuildRet(B(cx), V);
-    debuginfo::add_line_info(cx, instr);
+    llvm::LLVMBuildRet(B(cx), V);
 }
 
 fn AggregateRet(cx: @block_ctxt, RetVals: [ValueRef]) {
@@ -42,9 +40,8 @@ fn AggregateRet(cx: @block_ctxt, RetVals: [ValueRef]) {
     assert (!cx.terminated);
     cx.terminated = true;
     unsafe {
-        let instr = llvm::LLVMBuildAggregateRet(B(cx), vec::to_ptr(RetVals),
-                                                vec::len(RetVals));
-        debuginfo::add_line_info(cx, instr);
+        llvm::LLVMBuildAggregateRet(B(cx), vec::to_ptr(RetVals),
+                                    vec::len(RetVals));
     }
 }
 
@@ -52,8 +49,7 @@ fn Br(cx: @block_ctxt, Dest: BasicBlockRef) {
     if cx.unreachable { ret; }
     assert (!cx.terminated);
     cx.terminated = true;
-    let instr = llvm::LLVMBuildBr(B(cx), Dest);
-    debuginfo::add_line_info(cx, instr);
+    llvm::LLVMBuildBr(B(cx), Dest);
 }
 
 fn CondBr(cx: @block_ctxt, If: ValueRef, Then: BasicBlockRef,
@@ -61,8 +57,7 @@ fn CondBr(cx: @block_ctxt, If: ValueRef, Then: BasicBlockRef,
     if cx.unreachable { ret; }
     assert (!cx.terminated);
     cx.terminated = true;
-    let instr = llvm::LLVMBuildCondBr(B(cx), If, Then, Else);
-    debuginfo::add_line_info(cx, instr);
+    llvm::LLVMBuildCondBr(B(cx), If, Then, Else);
 }
 
 fn Switch(cx: @block_ctxt, V: ValueRef, Else: BasicBlockRef, NumCases: uint)
@@ -70,9 +65,7 @@ fn Switch(cx: @block_ctxt, V: ValueRef, Else: BasicBlockRef, NumCases: uint)
     if cx.unreachable { ret _Undef(V); }
     assert !cx.terminated;
     cx.terminated = true;
-    let instr = llvm::LLVMBuildSwitch(B(cx), V, Else, NumCases);
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildSwitch(B(cx), V, Else, NumCases);
 }
 
 fn AddCase(S: ValueRef, OnVal: ValueRef, Dest: BasicBlockRef) {
@@ -84,8 +77,7 @@ fn IndirectBr(cx: @block_ctxt, Addr: ValueRef, NumDests: uint) {
     if cx.unreachable { ret; }
     assert (!cx.terminated);
     cx.terminated = true;
-    let instr = llvm::LLVMBuildIndirectBr(B(cx), Addr, NumDests);
-    debuginfo::add_line_info(cx, instr);
+    llvm::LLVMBuildIndirectBr(B(cx), Addr, NumDests);
 }
 
 // This is a really awful way to get a zero-length c-string, but better (and a
@@ -105,14 +97,10 @@ fn Invoke(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef],
                                           vec::len(Args), Then, Catch,
                                           noname());
         if bcx_ccx(cx).sess.get_opts().debuginfo {
-            /*llvm::LLVMAddAttribute(option::get(vec::last(llargs)),
-            lib::llvm::LLVMStructRetAttribute as
-            lib::llvm::llvm::Attribute);*/
             llvm::LLVMAddInstrAttribute(instr, 1u,
                                         lib::llvm::LLVMStructRetAttribute as
                                             lib::llvm::llvm::Attribute);
         }
-        debuginfo::add_line_info(cx, instr);
     }
 }
 
@@ -125,7 +113,6 @@ fn FastInvoke(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef],
         let v = llvm::LLVMBuildInvoke(B(cx), Fn, vec::to_ptr(Args),
                                       vec::len(Args), Then, Catch, noname());
         llvm::LLVMSetInstructionCallConv(v, lib::llvm::LLVMFastCallConv);
-        debuginfo::add_line_info(cx, v);
     }
 }
 
@@ -142,254 +129,183 @@ fn _Undef(val: ValueRef) -> ValueRef {
 /* Arithmetic */
 fn Add(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildAdd(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildAdd(B(cx), LHS, RHS, noname());
 }
 
 fn NSWAdd(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildNSWAdd(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildNSWAdd(B(cx), LHS, RHS, noname());
 }
 
 fn NUWAdd(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildNUWAdd(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildNUWAdd(B(cx), LHS, RHS, noname());
 }
 
 fn FAdd(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildFAdd(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFAdd(B(cx), LHS, RHS, noname());
 }
 
 fn Sub(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildSub(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildSub(B(cx), LHS, RHS, noname());
 }
 
 fn NSWSub(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildNSWSub(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildNSWSub(B(cx), LHS, RHS, noname());
 }
 
 fn NUWSub(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildNUWSub(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildNUWSub(B(cx), LHS, RHS, noname());
 }
 
 fn FSub(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildFSub(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFSub(B(cx), LHS, RHS, noname());
 }
 
 fn Mul(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildMul(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildMul(B(cx), LHS, RHS, noname());
 }
 
 fn NSWMul(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildNSWMul(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildNSWMul(B(cx), LHS, RHS, noname());
 }
 
 fn NUWMul(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildNUWMul(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildNUWMul(B(cx), LHS, RHS, noname());
 }
 
 fn FMul(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildFMul(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFMul(B(cx), LHS, RHS, noname());
 }
 
 fn UDiv(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildUDiv(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildUDiv(B(cx), LHS, RHS, noname());
 }
 
 fn SDiv(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildSDiv(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildSDiv(B(cx), LHS, RHS, noname());
 }
 
 fn ExactSDiv(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildExactSDiv(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildExactSDiv(B(cx), LHS, RHS, noname());
 }
 
 fn FDiv(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildFDiv(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFDiv(B(cx), LHS, RHS, noname());
 }
 
 fn URem(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildURem(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildURem(B(cx), LHS, RHS, noname());
 }
 
 fn SRem(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildSRem(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildSRem(B(cx), LHS, RHS, noname());
 }
 
 fn FRem(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildFRem(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFRem(B(cx), LHS, RHS, noname());
 }
 
 fn Shl(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildShl(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildShl(B(cx), LHS, RHS, noname());
 }
 
 fn LShr(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildLShr(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildLShr(B(cx), LHS, RHS, noname());
 }
 
 fn AShr(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildAShr(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildAShr(B(cx), LHS, RHS, noname());
 }
 
 fn And(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildAnd(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildAnd(B(cx), LHS, RHS, noname());
 }
 
 fn Or(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildOr(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildOr(B(cx), LHS, RHS, noname());
 }
 
 fn Xor(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildXor(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildXor(B(cx), LHS, RHS, noname());
 }
 
 fn BinOp(cx: @block_ctxt, Op: Opcode, LHS: ValueRef, RHS: ValueRef) ->
    ValueRef {
     if cx.unreachable { ret _Undef(LHS); }
-    let instr = llvm::LLVMBuildBinOp(B(cx), Op, LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildBinOp(B(cx), Op, LHS, RHS, noname());
 }
 
 fn Neg(cx: @block_ctxt, V: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(V); }
-    let instr = llvm::LLVMBuildNeg(B(cx), V, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildNeg(B(cx), V, noname());
 }
 
 fn NSWNeg(cx: @block_ctxt, V: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(V); }
-    let instr = llvm::LLVMBuildNSWNeg(B(cx), V, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildNSWNeg(B(cx), V, noname());
 }
 
 fn NUWNeg(cx: @block_ctxt, V: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(V); }
-    let instr = llvm::LLVMBuildNUWNeg(B(cx), V, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildNUWNeg(B(cx), V, noname());
 }
 fn FNeg(cx: @block_ctxt, V: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(V); }
-    let instr = llvm::LLVMBuildFNeg(B(cx), V, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFNeg(B(cx), V, noname());
 }
 
 fn Not(cx: @block_ctxt, V: ValueRef) -> ValueRef {
     if cx.unreachable { ret _Undef(V); }
-    let instr = llvm::LLVMBuildNot(B(cx), V, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildNot(B(cx), V, noname());
 }
 
 /* Memory */
 fn Malloc(cx: @block_ctxt, Ty: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_i8())); }
-    let instr = llvm::LLVMBuildMalloc(B(cx), Ty, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildMalloc(B(cx), Ty, noname());
 }
 
 fn ArrayMalloc(cx: @block_ctxt, Ty: TypeRef, Val: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_i8())); }
-    let instr = llvm::LLVMBuildArrayMalloc(B(cx), Ty, Val, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildArrayMalloc(B(cx), Ty, Val, noname());
 }
 
 fn Alloca(cx: @block_ctxt, Ty: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(Ty)); }
-    let instr = llvm::LLVMBuildAlloca(B(cx), Ty, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildAlloca(B(cx), Ty, noname());
 }
 
 fn ArrayAlloca(cx: @block_ctxt, Ty: TypeRef, Val: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(Ty)); }
-    let instr = llvm::LLVMBuildArrayAlloca(B(cx), Ty, Val, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildArrayAlloca(B(cx), Ty, Val, noname());
 }
 
 fn Free(cx: @block_ctxt, PointerVal: ValueRef) {
     if cx.unreachable { ret; }
-    let instr = llvm::LLVMBuildFree(B(cx), PointerVal);
-    debuginfo::add_line_info(cx, instr);
+    llvm::LLVMBuildFree(B(cx), PointerVal);
 }
 
 fn Load(cx: @block_ctxt, PointerVal: ValueRef) -> ValueRef {
@@ -400,24 +316,19 @@ fn Load(cx: @block_ctxt, PointerVal: ValueRef) -> ValueRef {
             llvm::LLVMGetElementType(ty) } else { ccx.int_type };
         ret llvm::LLVMGetUndef(eltty);
     }
-    let instr = llvm::LLVMBuildLoad(B(cx), PointerVal, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildLoad(B(cx), PointerVal, noname());
 }
 
 fn Store(cx: @block_ctxt, Val: ValueRef, Ptr: ValueRef) {
     if cx.unreachable { ret; }
-    let instr = llvm::LLVMBuildStore(B(cx), Val, Ptr);
-    debuginfo::add_line_info(cx, instr);
+    llvm::LLVMBuildStore(B(cx), Val, Ptr);
 }
 
 fn GEP(cx: @block_ctxt, Pointer: ValueRef, Indices: [ValueRef]) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_nil())); }
     unsafe {
-        let instr = llvm::LLVMBuildGEP(B(cx), Pointer, vec::to_ptr(Indices),
-                                       vec::len(Indices), noname());
-        //debuginfo::add_line_info(cx, instr);
-        ret instr;
+        ret llvm::LLVMBuildGEP(B(cx), Pointer, vec::to_ptr(Indices),
+                               vec::len(Indices), noname());
     }
 }
 
@@ -433,195 +344,143 @@ fn InBoundsGEP(cx: @block_ctxt, Pointer: ValueRef, Indices: [ValueRef]) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_nil())); }
     unsafe {
-        let instr = llvm::LLVMBuildInBoundsGEP(B(cx), Pointer,
-                                               vec::to_ptr(Indices),
-                                               vec::len(Indices), noname());
-        //debuginfo::add_line_info(cx, instr);
-        ret instr;
+        ret llvm::LLVMBuildInBoundsGEP(B(cx), Pointer,
+                                       vec::to_ptr(Indices),
+                                       vec::len(Indices), noname());
     }
 }
 
 fn StructGEP(cx: @block_ctxt, Pointer: ValueRef, Idx: uint) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_nil())); }
-    let instr = llvm::LLVMBuildStructGEP(B(cx), Pointer, Idx, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildStructGEP(B(cx), Pointer, Idx, noname());
 }
 
 fn GlobalString(cx: @block_ctxt, _Str: sbuf) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_i8())); }
-    let instr = llvm::LLVMBuildGlobalString(B(cx), _Str, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildGlobalString(B(cx), _Str, noname());
 }
 
 fn GlobalStringPtr(cx: @block_ctxt, _Str: sbuf) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_ptr(T_i8())); }
-    let instr = llvm::LLVMBuildGlobalStringPtr(B(cx), _Str, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildGlobalStringPtr(B(cx), _Str, noname());
 }
 
 /* Casts */
 fn Trunc(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildTrunc(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildTrunc(B(cx), Val, DestTy, noname());
 }
 
 fn ZExt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildZExt(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildZExt(B(cx), Val, DestTy, noname());
 }
 
 fn SExt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildSExt(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildSExt(B(cx), Val, DestTy, noname());
 }
 
 fn FPToUI(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildFPToUI(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFPToUI(B(cx), Val, DestTy, noname());
 }
 
 fn FPToSI(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildFPToSI(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFPToSI(B(cx), Val, DestTy, noname());
 }
 
 fn UIToFP(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildUIToFP(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildUIToFP(B(cx), Val, DestTy, noname());
 }
 
 fn SIToFP(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildSIToFP(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildSIToFP(B(cx), Val, DestTy, noname());
 }
 
 fn FPTrunc(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildFPTrunc(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFPTrunc(B(cx), Val, DestTy, noname());
 }
 
 fn FPExt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildFPExt(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFPExt(B(cx), Val, DestTy, noname());
 }
 
 fn PtrToInt(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildPtrToInt(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildPtrToInt(B(cx), Val, DestTy, noname());
 }
 
 fn IntToPtr(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildIntToPtr(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildIntToPtr(B(cx), Val, DestTy, noname());
 }
 
 fn BitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildBitCast(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildBitCast(B(cx), Val, DestTy, noname());
 }
 
 fn ZExtOrBitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildZExtOrBitCast(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildZExtOrBitCast(B(cx), Val, DestTy, noname());
 }
 
 fn SExtOrBitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildSExtOrBitCast(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildSExtOrBitCast(B(cx), Val, DestTy, noname());
 }
 
 fn TruncOrBitCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildTruncOrBitCast(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildTruncOrBitCast(B(cx), Val, DestTy, noname());
 }
 
 fn Cast(cx: @block_ctxt, Op: Opcode, Val: ValueRef, DestTy: TypeRef,
         _Name: sbuf) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildCast(B(cx), Op, Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildCast(B(cx), Op, Val, DestTy, noname());
 }
 
 fn PointerCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildPointerCast(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildPointerCast(B(cx), Val, DestTy, noname());
 }
 
 fn IntCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildIntCast(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildIntCast(B(cx), Val, DestTy, noname());
 }
 
 fn FPCast(cx: @block_ctxt, Val: ValueRef, DestTy: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(DestTy); }
-    let instr = llvm::LLVMBuildFPCast(B(cx), Val, DestTy, noname());
-    //debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFPCast(B(cx), Val, DestTy, noname());
 }
 
 
 /* Comparisons */
 fn ICmp(cx: @block_ctxt, Op: uint, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_i1()); }
-    let instr = llvm::LLVMBuildICmp(B(cx), Op, LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildICmp(B(cx), Op, LHS, RHS, noname());
 }
 
 fn FCmp(cx: @block_ctxt, Op: uint, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_i1()); }
-    let instr = llvm::LLVMBuildFCmp(B(cx), Op, LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildFCmp(B(cx), Op, LHS, RHS, noname());
 }
 
 /* Miscellaneous instructions */
 fn EmptyPhi(cx: @block_ctxt, Ty: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(Ty); }
-    let instr = llvm::LLVMBuildPhi(B(cx), Ty, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildPhi(B(cx), Ty, noname());
 }
 
 fn Phi(cx: @block_ctxt, Ty: TypeRef, vals: [ValueRef], bbs: [BasicBlockRef])
@@ -656,7 +515,9 @@ fn _UndefReturn(cx: @block_ctxt, Fn: ValueRef) -> ValueRef {
 fn add_span_comment(bcx: @block_ctxt, sp: span, text: str) {
     let ccx = bcx_ccx(bcx);
     if (!ccx.sess.get_opts().no_asm_comments) {
-        add_comment(bcx, text + " (" + ccx.sess.span_str(sp) + ")");
+        let s = text + " (" + ccx.sess.span_str(sp) + ")";
+        log s;
+        add_comment(bcx, s);
     }
 }
 
@@ -676,10 +537,8 @@ fn add_comment(bcx: @block_ctxt, text: str) {
 fn Call(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef]) -> ValueRef {
     if cx.unreachable { ret _UndefReturn(cx, Fn); }
     unsafe {
-        let instr = llvm::LLVMBuildCall(B(cx), Fn, vec::to_ptr(Args),
-                                        vec::len(Args), noname());
-        debuginfo::add_line_info(cx, instr);
-        ret instr;
+        ret llvm::LLVMBuildCall(B(cx), Fn, vec::to_ptr(Args),
+                                vec::len(Args), noname());
     }
 }
 
@@ -689,7 +548,6 @@ fn FastCall(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef]) -> ValueRef {
         let v = llvm::LLVMBuildCall(B(cx), Fn, vec::to_ptr(Args),
                                     vec::len(Args), noname());
         llvm::LLVMSetInstructionCallConv(v, lib::llvm::LLVMFastCallConv);
-        debuginfo::add_line_info(cx, v);
         ret v;
     }
 }
@@ -701,7 +559,6 @@ fn CallWithConv(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef], Conv: uint)
         let v = llvm::LLVMBuildCall(B(cx), Fn, vec::to_ptr(Args),
                                     vec::len(Args), noname());
         llvm::LLVMSetInstructionCallConv(v, Conv);
-        debuginfo::add_line_info(cx, v);
         ret v;
     }
 }
@@ -709,76 +566,57 @@ fn CallWithConv(cx: @block_ctxt, Fn: ValueRef, Args: [ValueRef], Conv: uint)
 fn Select(cx: @block_ctxt, If: ValueRef, Then: ValueRef, Else: ValueRef) ->
    ValueRef {
     if cx.unreachable { ret _Undef(Then); }
-    let instr = llvm::LLVMBuildSelect(B(cx), If, Then, Else, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildSelect(B(cx), If, Then, Else, noname());
 }
 
 fn VAArg(cx: @block_ctxt, list: ValueRef, Ty: TypeRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(Ty); }
-    let instr = llvm::LLVMBuildVAArg(B(cx), list, Ty, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildVAArg(B(cx), list, Ty, noname());
 }
 
 fn ExtractElement(cx: @block_ctxt, VecVal: ValueRef, Index: ValueRef) ->
    ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_nil()); }
-    let instr = llvm::LLVMBuildExtractElement(B(cx), VecVal, Index, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildExtractElement(B(cx), VecVal, Index, noname());
 }
 
 fn InsertElement(cx: @block_ctxt, VecVal: ValueRef, EltVal: ValueRef,
                  Index: ValueRef) {
     if cx.unreachable { ret; }
-    let instr = llvm::LLVMBuildInsertElement(B(cx), VecVal, EltVal, Index,
-                                             noname());
-    debuginfo::add_line_info(cx, instr);
+    llvm::LLVMBuildInsertElement(B(cx), VecVal, EltVal, Index, noname());
 }
 
 fn ShuffleVector(cx: @block_ctxt, V1: ValueRef, V2: ValueRef,
                  Mask: ValueRef) {
     if cx.unreachable { ret; }
-    let instr = llvm::LLVMBuildShuffleVector(B(cx), V1, V2, Mask, noname());
-    debuginfo::add_line_info(cx, instr);
+    llvm::LLVMBuildShuffleVector(B(cx), V1, V2, Mask, noname());
 }
 
 fn ExtractValue(cx: @block_ctxt, AggVal: ValueRef, Index: uint) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_nil()); }
-    let instr = llvm::LLVMBuildExtractValue(B(cx), AggVal, Index, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildExtractValue(B(cx), AggVal, Index, noname());
 }
 
 fn InsertValue(cx: @block_ctxt, AggVal: ValueRef, EltVal: ValueRef,
                Index: uint) {
     if cx.unreachable { ret; }
-    let instr = llvm::LLVMBuildInsertValue(B(cx), AggVal, EltVal, Index,
-                                           noname());
-    debuginfo::add_line_info(cx, instr);
+    llvm::LLVMBuildInsertValue(B(cx), AggVal, EltVal, Index, noname());
 }
 
 fn IsNull(cx: @block_ctxt, Val: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_i1()); }
-    let instr = llvm::LLVMBuildIsNull(B(cx), Val, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildIsNull(B(cx), Val, noname());
 }
 
 fn IsNotNull(cx: @block_ctxt, Val: ValueRef) -> ValueRef {
     if cx.unreachable { ret llvm::LLVMGetUndef(T_i1()); }
-    let instr = llvm::LLVMBuildIsNotNull(B(cx), Val, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildIsNotNull(B(cx), Val, noname());
 }
 
 fn PtrDiff(cx: @block_ctxt, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     let ccx = cx.fcx.lcx.ccx;
     if cx.unreachable { ret llvm::LLVMGetUndef(ccx.int_type); }
-    let instr = llvm::LLVMBuildPtrDiff(B(cx), LHS, RHS, noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildPtrDiff(B(cx), LHS, RHS, noname());
 }
 
 fn Trap(cx: @block_ctxt) {
@@ -793,19 +631,14 @@ fn Trap(cx: @block_ctxt) {
     assert (T as int != 0);
     let Args: [ValueRef] = [];
     unsafe {
-        let instr = llvm::LLVMBuildCall(b, T, vec::to_ptr(Args),
-                                        vec::len(Args), noname());
-        debuginfo::add_line_info(cx, instr);
+        llvm::LLVMBuildCall(b, T, vec::to_ptr(Args), vec::len(Args), noname());
     }
 }
 
 fn LandingPad(cx: @block_ctxt, Ty: TypeRef, PersFn: ValueRef,
               NumClauses: uint) -> ValueRef {
     assert !cx.terminated && !cx.unreachable;
-    let instr = llvm::LLVMBuildLandingPad(B(cx), Ty, PersFn, NumClauses,
-                                          noname());
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildLandingPad(B(cx), Ty, PersFn, NumClauses, noname());
 }
 
 fn SetCleanup(_cx: @block_ctxt, LandingPad: ValueRef) {
@@ -815,9 +648,7 @@ fn SetCleanup(_cx: @block_ctxt, LandingPad: ValueRef) {
 fn Resume(cx: @block_ctxt, Exn: ValueRef) -> ValueRef {
     assert (!cx.terminated);
     cx.terminated = true;
-    let instr = llvm::LLVMBuildResume(B(cx), Exn);
-    debuginfo::add_line_info(cx, instr);
-    ret instr;
+    ret llvm::LLVMBuildResume(B(cx), Exn);
 }
 
 //

--- a/src/comp/middle/trans_closure.rs
+++ b/src/comp/middle/trans_closure.rs
@@ -336,6 +336,7 @@ fn trans_expr_fn(bcx: @block_ctxt, f: ast::_fn, sp: span,
     let sub_cx = extend_path(bcx.fcx.lcx, ccx.names.next("anon"));
     let s = mangle_internal_name_by_path(ccx, sub_cx.path);
     let llfn = decl_internal_cdecl_fn(ccx.llmod, s, llfnty);
+    register_fn(ccx, sp, sub_cx.path, "anon fn", [], id);
 
     let trans_closure_env = lambda(ck: ty::closure_kind) -> ValueRef {
         let upvars = get_freevars(ccx.tcx, id);

--- a/src/comp/middle/trans_common.rs
+++ b/src/comp/middle/trans_common.rs
@@ -386,7 +386,8 @@ type block_ctxt =
      mutable lpad: option::t<BasicBlockRef>,
      sp: span,
      fcx: @fn_ctxt,
-     mutable source_pos: option::t<syntax::codemap::loc>};
+     source_pos: {mutable usable: bool,
+                  mutable pos: [syntax::codemap::loc]}};
 
 // FIXME: we should be able to use option::t<@block_parent> here but
 // the infinite-tag check in rustboot gets upset.

--- a/src/comp/middle/trans_common.rs
+++ b/src/comp/middle/trans_common.rs
@@ -117,7 +117,7 @@ type crate_ctxt =
      shape_cx: shape::ctxt,
      gc_cx: gc::ctxt,
      crate_map: ValueRef,
-     llmetadata: debuginfo::metadata_cache};
+     dbg_cx: option::t<@debuginfo::debug_ctxt>};
 
 type local_ctxt =
     {path: [str],

--- a/src/comp/middle/trans_common.rs
+++ b/src/comp/middle/trans_common.rs
@@ -806,7 +806,7 @@ fn C_i32(i: i32) -> ValueRef {
 }
 
 fn C_i64(i: i64) -> ValueRef {
-    ret C_integral(T_i64(), i as uint, True);
+    ret C_integral(T_i64(), i as u64, True);
 }
 
 fn C_int(cx: @crate_ctxt, i: int) -> ValueRef {

--- a/src/comp/middle/trans_common.rs
+++ b/src/comp/middle/trans_common.rs
@@ -385,7 +385,8 @@ type block_ctxt =
      mutable lpad_dirty: bool,
      mutable lpad: option::t<BasicBlockRef>,
      sp: span,
-     fcx: @fn_ctxt};
+     fcx: @fn_ctxt,
+     mutable source_pos: option::t<syntax::codemap::loc>};
 
 // FIXME: we should be able to use option::t<@block_parent> here but
 // the infinite-tag check in rustboot gets upset.
@@ -463,6 +464,8 @@ fn T_nil() -> TypeRef {
 
     ret llvm::LLVMInt1Type();
 }
+
+fn T_metadata() -> TypeRef { ret llvm::LLVMMetadataType(); }
 
 fn T_i1() -> TypeRef { ret llvm::LLVMInt1Type(); }
 
@@ -799,6 +802,10 @@ fn C_bool(b: bool) -> ValueRef {
 
 fn C_i32(i: i32) -> ValueRef {
     ret C_integral(T_i32(), i as u64, True);
+}
+
+fn C_i64(i: i64) -> ValueRef {
+    ret C_integral(T_i64(), i as uint, True);
 }
 
 fn C_int(cx: @crate_ctxt, i: int) -> ValueRef {

--- a/src/comp/middle/trans_common.rs
+++ b/src/comp/middle/trans_common.rs
@@ -385,9 +385,7 @@ type block_ctxt =
      mutable lpad_dirty: bool,
      mutable lpad: option::t<BasicBlockRef>,
      sp: span,
-     fcx: @fn_ctxt,
-     source_pos: {mutable usable: bool,
-                  mutable pos: [syntax::codemap::loc]}};
+     fcx: @fn_ctxt};
 
 // FIXME: we should be able to use option::t<@block_parent> here but
 // the infinite-tag check in rustboot gets upset.

--- a/src/comp/middle/trans_common.rs
+++ b/src/comp/middle/trans_common.rs
@@ -116,7 +116,8 @@ type crate_ctxt =
      builder: BuilderRef_res,
      shape_cx: shape::ctxt,
      gc_cx: gc::ctxt,
-     crate_map: ValueRef};
+     crate_map: ValueRef,
+     llmetadata: debuginfo::metadata_cache};
 
 type local_ctxt =
     {path: [str],

--- a/src/comp/middle/trans_vec.rs
+++ b/src/comp/middle/trans_vec.rs
@@ -27,6 +27,7 @@ fn pointer_add(bcx: @block_ctxt, ptr: ValueRef, bytes: ValueRef) -> ValueRef {
 }
 
 fn alloc_raw(bcx: @block_ctxt, fill: ValueRef, alloc: ValueRef) -> result {
+    let _s = debuginfo::invalidate_source_pos(bcx);
     let ccx = bcx_ccx(bcx);
     let llvecty = ccx.opaque_vec_type;
     let vecsize = Add(bcx, alloc, llsize_of(ccx, llvecty));
@@ -45,6 +46,7 @@ type alloc_result =
      llunitty: TypeRef};
 
 fn alloc(bcx: @block_ctxt, vec_ty: ty::t, elts: uint) -> alloc_result {
+    let _s = debuginfo::invalidate_source_pos(bcx);
     let ccx = bcx_ccx(bcx);
     let unit_ty = ty::sequence_element_type(bcx_tcx(bcx), vec_ty);
     let llunitty = type_of_or_i8(bcx, unit_ty);

--- a/src/comp/middle/trans_vec.rs
+++ b/src/comp/middle/trans_vec.rs
@@ -27,7 +27,6 @@ fn pointer_add(bcx: @block_ctxt, ptr: ValueRef, bytes: ValueRef) -> ValueRef {
 }
 
 fn alloc_raw(bcx: @block_ctxt, fill: ValueRef, alloc: ValueRef) -> result {
-    let _s = debuginfo::invalidate_source_pos(bcx);
     let ccx = bcx_ccx(bcx);
     let llvecty = ccx.opaque_vec_type;
     let vecsize = Add(bcx, alloc, llsize_of(ccx, llvecty));
@@ -46,7 +45,6 @@ type alloc_result =
      llunitty: TypeRef};
 
 fn alloc(bcx: @block_ctxt, vec_ty: ty::t, elts: uint) -> alloc_result {
-    let _s = debuginfo::invalidate_source_pos(bcx);
     let ccx = bcx_ccx(bcx);
     let unit_ty = ty::sequence_element_type(bcx_tcx(bcx), vec_ty);
     let llunitty = type_of_or_i8(bcx, unit_ty);

--- a/src/comp/rustc.rc
+++ b/src/comp/rustc.rc
@@ -37,6 +37,7 @@ mod middle {
     mod freevars;
     mod shape;
     mod gc;
+    mod debuginfo;
 
     mod tstate {
         mod ck;

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -165,3 +165,17 @@ extern "C" LLVMValueRef LLVMGetOrInsertFunction(LLVMModuleRef M,
   return wrap(unwrap(M)->getOrInsertFunction(Name,
                                              unwrap<FunctionType>(FunctionTy)));
 }
+
+extern "C" LLVMTypeRef LLVMMetadataTypeInContext(LLVMContextRef C) {
+  return wrap(Type::getMetadataTy(*unwrap(C)));
+}
+extern "C" LLVMTypeRef LLVMMetadataType(void) {
+  return LLVMMetadataTypeInContext(LLVMGetGlobalContext());
+}
+
+extern "C" void LLVMAddNamedMetadataOperand(LLVMModuleRef M, const char *Str,
+                                            unsigned SLen, LLVMValueRef Val)
+{
+  NamedMDNode *N = unwrap(M)->getOrInsertNamedMetadata(StringRef(Str, SLen));
+  N->addOperand(unwrap<MDNode>(Val));
+}

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -487,6 +487,7 @@ LLVMMDNode
 LLVMMDNodeInContext
 LLVMMDString
 LLVMMDStringInContext
+LLVMAddNamedMetadataOperand
 LLVMModuleCreateWithName
 LLVMModuleCreateWithNameInContext
 LLVMMoveBasicBlockAfter

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -484,9 +484,6 @@ LLVMIsThreadLocal
 LLVMIsUndef
 LLVMLabelType
 LLVMLabelTypeInContext
-LLVMLinkInInterpreter
-LLVMLinkInJIT
-LLVMLinkInMCJIT
 LLVMMDNode
 LLVMMDNodeInContext
 LLVMMDString

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -60,6 +60,7 @@ LLVMAddLoopRotatePass
 LLVMAddLoopUnrollPass
 LLVMAddLoopUnswitchPass
 LLVMAddMemCpyOptPass
+LLVMAddNamedMetadataOperand
 LLVMAddPromoteMemoryToRegisterPass
 LLVMAddPruneEHPass
 LLVMAddReassociatePass
@@ -483,11 +484,15 @@ LLVMIsThreadLocal
 LLVMIsUndef
 LLVMLabelType
 LLVMLabelTypeInContext
+LLVMLinkInInterpreter
+LLVMLinkInJIT
+LLVMLinkInMCJIT
 LLVMMDNode
 LLVMMDNodeInContext
 LLVMMDString
 LLVMMDStringInContext
-LLVMAddNamedMetadataOperand
+LLVMMetadataType
+LLVMMetadataTypeInContext
 LLVMModuleCreateWithName
 LLVMModuleCreateWithNameInContext
 LLVMMoveBasicBlockAfter


### PR DESCRIPTION
nmatsakis expressed interest in integrating even basic debugging support, and that's what this provides. The -g flag will produce source line correspondence output, allowing for stepping and breakpoints inside gdb. There's also an --xg (extra debugging) flag behind which the rest of the debugging support lies unfinished (ie. can't build rustc completely yet, but works on toy programs).

Some stats:

```
godot:build jdm$ time x86_64-apple-darwin/stage2/bin/rustc --target=x86_64-apple-darwin  -o x86_64-apple-darwin/stage2/lib/rustc/x86_64-apple-darwin/bin/rustc ../src/comp/rustc.rc
warning: no debug symbols in executable (-arch x86_64)

real    0m40.174s
user    0m39.633s
sys 0m0.708s

godot:build jdm$ time x86_64-apple-darwin/stage2/bin/rustc -g --target=x86_64-apple-darwin  -o x86_64-apple-darwin/stage2/lib/rustc/x86_64-apple-darwin/bin/rustc ../src/comp/rustc.rc

real    1m50.058s
user    1m49.456s
sys 0m1.125s
```

Requires the llvm patch that's sitting in brson's repository to allow rustc to finish building.
