### PR TITLE
preparing for removing math from std

### DIFF
--- a/src/libstd/comm.rs
+++ b/src/libstd/comm.rs
@@ -29,6 +29,8 @@ Example:
 import sys;
 import task;
 
+import core::ctypes;
+
 export send;
 export recv;
 export chan;

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -4,6 +4,7 @@ Module: fs
 File system manipulation
 */
 
+import core::ctypes;
 import core::vec;
 import core::option;
 import os;

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -6,8 +6,8 @@ Basic input/output
 
 import core::option;
 import core::result;
-import ctypes::fd_t;
-import ctypes::c_int;
+import core::ctypes::fd_t;
+import core::ctypes::c_int;
 
 #[abi = "cdecl"]
 native mod rustrt {

--- a/src/libstd/linux_os.rs
+++ b/src/libstd/linux_os.rs
@@ -5,7 +5,7 @@ TODO: Restructure and document
 */
 
 import core::option;
-import ctypes::*;
+import core::ctypes::*;
 
 export libc;
 export libc_constants;

--- a/src/libstd/macos_os.rs
+++ b/src/libstd/macos_os.rs
@@ -1,5 +1,5 @@
 import core::option;
-import ctypes::*;
+import core::ctypes::*;
 
 export libc;
 export libc_constants;

--- a/src/libstd/math.rs
+++ b/src/libstd/math.rs
@@ -23,9 +23,9 @@ import f32 = math_f32;
 
 // These two must match in width according to architecture
 
-import ctypes::m_float;
-import ctypes::c_int;
-import ptr;
+import core::mtypes::m_float;
+import core::ctypes::c_int;
+import core::ptr;
 import m_float = math_f64;
 
 /*

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -1103,7 +1103,7 @@ mod node {
                      right   : right,
              char_len: char_len(left) + char_len(right),
                      byte_len: byte_len(left) + byte_len(right),
-             height: math::max(height(left), height(right)) + 1u
+             height: float::max(height(left), height(right)) + 1u
                     })
     }
 

--- a/src/libstd/uv.rs
+++ b/src/libstd/uv.rs
@@ -12,6 +12,8 @@ export loop_new, loop_delete, default_loop, run, unref;
 export idle_init, idle_start;
 export idle_new;
 
+import core::ctypes;
+
 #[link_name = "rustrt"]
 native mod uv {
     fn rust_uv_loop_new() -> *loop_t;

--- a/src/libstd/win32_os.rs
+++ b/src/libstd/win32_os.rs
@@ -1,5 +1,5 @@
 import core::option;
-import ctypes::*;
+import core::ctypes::*;
 
 #[abi = "cdecl"]
 #[link_name = ""]               // FIXME remove after #[nolink] is snapshotted


### PR DESCRIPTION
please snap.

this makes all math leftovers explicitly depend on the new core::\* equivalents to the degree possible now.

hopefully after this is snapped, some leftover mods can be removed from std.  there is a dependency from math to math_f32 and math_f64 which i could not untangle in this round, hope that gets possible after this patch.
