### PR TITLE
rustdoc: delete bogus license text

### DIFF
--- a/src/rustdoc/rustdoc.rs
+++ b/src/rustdoc/rustdoc.rs
@@ -1,18 +1,5 @@
-/* rustdoc - rust->markdown translator
- *
+/* rustdoc: rust -> markdown translator
  * Copyright 2011 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 use std;

--- a/src/rustdoc/rustdoc.rs
+++ b/src/rustdoc/rustdoc.rs
@@ -1,5 +1,5 @@
 /* rustdoc: rust -> markdown translator
- * Copyright 2011 Google Inc. All Rights Reserved.
+ * Copyright 2011 Google Inc.
  */
 
 use std;


### PR DESCRIPTION
Rustdoc is under the same license as the rest of Rust, not under apache-2.0.

Signed-off-by: Elly Jones elly@leptoquark.net
