### PR TITLE
std::unicode::icu: add "is*" functions + unit test

### DIFF
--- a/src/libstd/unicode.rs
+++ b/src/libstd/unicode.rs
@@ -152,6 +152,12 @@ mod icu {
     #[abi = "cdecl"]
     native mod libicu {
         pure fn u_hasBinaryProperty(c: UChar32, which: UProperty) -> UBool;
+        pure fn u_isdigit(c: UChar32) -> UBool;
+        pure fn u_islower(c: UChar32) -> UBool;
+        pure fn u_isspace(c: UChar32) -> UBool;
+        pure fn u_isupper(c: UChar32) -> UBool;
+        pure fn u_tolower(c: UChar32) -> UChar32;
+        pure fn u_toupper(c: UChar32) -> UChar32;
     }
 }
 
@@ -164,3 +170,40 @@ pure fn is_XID_continue(c: char) -> bool {
     ret icu::libicu::u_hasBinaryProperty(c, icu::UCHAR_XID_START)
         == icu::TRUE;
 }
+
+/*
+Function: is_digit
+
+Returns true if a character is a digit.
+*/
+pure fn is_digit(c: char) -> bool {
+    ret icu::libicu::u_isdigit(c) == icu::TRUE;
+}
+
+/*
+Function: is_lower
+
+Returns true if a character is a lowercase letter.
+*/
+pure fn is_lower(c: char) -> bool {
+    ret icu::libicu::u_islower(c) == icu::TRUE;
+}
+
+/*
+Function: is_space
+
+Returns true if a character is space.
+*/
+pure fn is_space(c: char) -> bool {
+    ret icu::libicu::u_isspace(c) == icu::TRUE;
+}
+
+/*
+Function: is_upper
+
+Returns true if a character is an uppercase letter.
+*/
+pure fn is_upper(c: char) -> bool {
+    ret icu::libicu::u_isupper(c) == icu::TRUE;
+}
+

--- a/src/test/stdtest/stdtest.rc
+++ b/src/test/stdtest/stdtest.rc
@@ -39,6 +39,10 @@ mod test;
 mod tri;
 mod treemap;
 mod uint;
+
+#[cfg(unicode)]
+mod unicode;
+
 mod unsafe;
 mod uv;
 mod vec;

--- a/src/test/stdtest/unicode.rs
+++ b/src/test/stdtest/unicode.rs
@@ -1,0 +1,30 @@
+import core::*;
+
+use std;
+
+import unicode;
+
+#[test]
+fn test_is_digit() {
+    assert (unicode::icu::is_digit('0'));
+    assert (!unicode::icu::is_digit('m'));
+}
+
+#[test]
+fn test_is_lower() {
+    assert (unicode::icu::is_lower('m'));
+    assert (!unicode::icu::is_lower('M'));
+}
+
+#[test]
+fn test_is_space() {
+    assert (unicode::icu::is_space(' '));
+    assert (!unicode::icu::is_space('m'));
+}
+
+#[test]
+fn test_is_upper() {
+    assert (unicode::icu::is_upper('M'));
+    assert (!unicode::icu::is_upper('m'));
+}
+


### PR DESCRIPTION
Fixes #1370

This is currently guarded by #[cfg(unicode)]
Don't know how to enable this.
