### PR TITLE
Use singlequotes in the typechecker error messages too, to distinguish code and English

### DIFF
--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -367,7 +367,7 @@ fn ast_ty_to_ty(tcx: ty::ctxt, mode: mode, &&ast_ty: @ast::ty) -> ty::t {
         alt mode {
           m_check_tyvar(fcx) { ret next_ty_var(fcx); }
           _ { tcx.sess.span_bug(ast_ty.span,
-                                "found ty_infer in unexpected place"); }
+                                "found 'ty_infer' in unexpected place"); }
         }
       }
     }
@@ -866,11 +866,12 @@ mod demand {
             let e_err = resolve_type_vars_if_possible(fcx, expected);
             let a_err = resolve_type_vars_if_possible(fcx, actual);
             fcx.ccx.tcx.sess.span_err(sp,
-                                      "mismatched types: expected " +
+                                      "mismatched types: expected '" +
                                           ty_to_str(fcx.ccx.tcx, e_err) +
-                                          " but found " +
-                                          ty_to_str(fcx.ccx.tcx, a_err) + " ("
-                                          + ty::type_err_to_str(err) + ")");
+                                          "' but found '" +
+                                          ty_to_str(fcx.ccx.tcx, a_err) +
+                                          "' (" + ty::type_err_to_str(err) +
+                                          ")");
             ret mk_result(fcx, expected, ty_param_subst_var_ids);
           }
         }
@@ -1273,7 +1274,7 @@ fn check_pat(fcx: @fn_ctxt, map: ast_util::pat_id_map, pat: @ast::pat,
             // can never tell.
             fcx.ccx.tcx.sess.span_fatal
                 (pat.span,
-                 #fmt["mismatched types: expected %s, found tag",
+                 #fmt["mismatched types: expected '%s' but found tag",
                       ty_to_str(fcx.ccx.tcx, expected)]);
           }
         }
@@ -1285,7 +1286,8 @@ fn check_pat(fcx: @fn_ctxt, map: ast_util::pat_id_map, pat: @ast::pat,
           ty::ty_rec(fields) { ex_fields = fields; }
           _ {
             fcx.ccx.tcx.sess.span_fatal
-                (pat.span, #fmt["mismatched types: expected %s, found record",
+                (pat.span,
+                #fmt["mismatched types: expected '%s' but found record",
                                 ty_to_str(fcx.ccx.tcx, expected)]);
           }
         }
@@ -1307,7 +1309,7 @@ fn check_pat(fcx: @fn_ctxt, map: ast_util::pat_id_map, pat: @ast::pat,
               none. {
                 fcx.ccx.tcx.sess.span_fatal(pat.span,
                                             #fmt["mismatched types: did not \
-                                             expect a record with a field %s",
+                                           expect a record with a field '%s'",
                                                  f.ident]);
               }
             }
@@ -1320,8 +1322,9 @@ fn check_pat(fcx: @fn_ctxt, map: ast_util::pat_id_map, pat: @ast::pat,
           ty::ty_tup(elts) { ex_elts = elts; }
           _ {
             fcx.ccx.tcx.sess.span_fatal
-                (pat.span, #fmt["mismatched types: expected %s, found tuple",
-                                ty_to_str(fcx.ccx.tcx, expected)]);
+                (pat.span,
+                 #fmt["mismatched types: expected '%s', found tuple",
+                        ty_to_str(fcx.ccx.tcx, expected)]);
           }
         }
         let e_count = vec::len(elts);
@@ -1343,9 +1346,9 @@ fn check_pat(fcx: @fn_ctxt, map: ast_util::pat_id_map, pat: @ast::pat,
           }
           _ {
             fcx.ccx.tcx.sess.span_fatal(pat.span,
-                                        "mismatched types: expected " +
+                                        "mismatched types: expected '" +
                                             ty_to_str(fcx.ccx.tcx, expected) +
-                                            " found box");
+                                            "' found box");
           }
         }
       }
@@ -1357,9 +1360,9 @@ fn check_pat(fcx: @fn_ctxt, map: ast_util::pat_id_map, pat: @ast::pat,
           }
           _ {
             fcx.ccx.tcx.sess.span_fatal(pat.span,
-                                        "mismatched types: expected " +
+                                        "mismatched types: expected '" +
                                             ty_to_str(fcx.ccx.tcx, expected) +
-                                            " found uniq");
+                                            "' found uniq");
           }
         }
       }
@@ -1761,8 +1764,8 @@ fn check_expr_with_unifier(fcx: @fn_ctxt, expr: @ast::expr, unify: unifier,
             if !type_is_integral(fcx, oper.span, oper_t) &&
                    structure_of(fcx, oper.span, oper_t) != ty::ty_bool {
                 tcx.sess.span_err(expr.span,
-                                  #fmt["mismatched types: expected bool \
-                          or integer but found %s",
+                                  #fmt["mismatched types: expected 'bool' \
+                          or 'integer' but found '%s'",
                                        ty_to_str(tcx, oper_t)]);
             }
           }
@@ -1772,8 +1775,8 @@ fn check_expr_with_unifier(fcx: @fn_ctxt, expr: @ast::expr, unify: unifier,
                      ty::type_is_fp(tcx, oper_t)) {
                 tcx.sess.span_err(expr.span,
                                   "applying unary minus to \
-                   non-numeric type "
-                                      + ty_to_str(tcx, oper_t));
+                   non-numeric type '"
+                                      + ty_to_str(tcx, oper_t) + "'");
             }
           }
         }
@@ -1889,7 +1892,7 @@ fn check_expr_with_unifier(fcx: @fn_ctxt, expr: @ast::expr, unify: unifier,
           _ {
             tcx.sess.span_fatal(expr.span,
                                 "mismatched types: expected vector or string "
-                                + "but found " + ty_to_str(tcx, ety));
+                                + "but found '" + ty_to_str(tcx, ety) + "'");
           }
         }
         bot |= check_for(fcx, decl, elt_ty, body, id);
@@ -2220,8 +2223,8 @@ fn check_expr_with_unifier(fcx: @fn_ctxt, expr: @ast::expr, unify: unifier,
         if !type_is_integral(fcx, idx.span, idx_t) {
             tcx.sess.span_err(idx.span,
                               "mismatched types: expected \
-                               integer but found "
-                                  + ty_to_str(tcx, idx_t));
+                               'integer' but found '"
+                                  + ty_to_str(tcx, idx_t) + "'");
         }
         alt structure_of(fcx, expr.span, base_t) {
           ty::ty_vec(mt) { write::ty_only_fixup(fcx, id, mt.ty); }
@@ -2658,13 +2661,13 @@ fn check_item(ccx: @crate_ctxt, it: @ast::item) {
                       some(m) {
                         if !ty::same_method(ccx.tcx, m, if_m) {
                             ccx.tcx.sess.span_err(
-                                ty.span, "method " + if_m.ident +
-                                " has the wrong type");
+                                ty.span, "method '" + if_m.ident +
+                                "' has the wrong type");
                         }
                       }
                       none. {
-                        ccx.tcx.sess.span_err(ty.span, "missing method " +
-                                              if_m.ident);
+                        ccx.tcx.sess.span_err(ty.span, "missing method '" +
+                                              if_m.ident + "'");
                       }
                     }
                 }
@@ -2708,15 +2711,15 @@ fn check_main_fn_ty(tcx: ty::ctxt, main_id: ast::node_id) {
         if !ok {
             let span = ast_map::node_span(tcx.items.get(main_id));
             tcx.sess.span_err(span,
-                              "wrong type in main function: found " +
-                                  ty_to_str(tcx, main_t));
+                              "wrong type in main function: found '" +
+                                  ty_to_str(tcx, main_t) + "'");
         }
       }
       _ {
         let span = ast_map::node_span(tcx.items.get(main_id));
         tcx.sess.span_bug(span,
-                          "main has a non-function type: found" +
-                              ty_to_str(tcx, main_t));
+                          "main has a non-function type: found '" +
+                              ty_to_str(tcx, main_t) + "'");
       }
     }
 }

--- a/src/test/compile-fail/bad-const-type.rs
+++ b/src/test/compile-fail/bad-const-type.rs
@@ -1,4 +1,4 @@
-// error-pattern:expected str but found int
+// error-pattern:expected 'str' but found 'int'
 
 const i: str = 10;
 fn main() { log(debug, i); }

--- a/src/test/compile-fail/bad-record-pat-2.rs
+++ b/src/test/compile-fail/bad-record-pat-2.rs
@@ -1,3 +1,3 @@
-// error-pattern:did not expect a record with a field q
+// error-pattern:did not expect a record with a field 'q'
 
 fn main() { alt {x: 1, y: 2} { {x: x, q: q} { } } }

--- a/src/test/compile-fail/fail-type-err.rs
+++ b/src/test/compile-fail/fail-type-err.rs
@@ -1,2 +1,2 @@
-// error-pattern:expected str but found [int]
+// error-pattern:expected 'str' but found '[int]'
 fn main() { fail [0]; }

--- a/src/test/compile-fail/fn-bare-bind.rs
+++ b/src/test/compile-fail/fn-bare-bind.rs
@@ -1,4 +1,4 @@
-// error-pattern:mismatched types: expected fn() but found fn@()
+// error-pattern:mismatched types: expected 'fn()' but found 'fn@()'
 
 fn f() {
 }

--- a/src/test/compile-fail/fn-compare-mismatch.rs
+++ b/src/test/compile-fail/fn-compare-mismatch.rs
@@ -1,4 +1,4 @@
-// error-pattern:expected fn() but found fn(++int)
+// error-pattern:expected 'fn()' but found 'fn(++int)'
 
 fn main() {
     fn f() { }

--- a/src/test/compile-fail/main-wrong-type-2.rs
+++ b/src/test/compile-fail/main-wrong-type-2.rs
@@ -1,2 +1,2 @@
-// error-pattern:wrong type in main function: found fn() -> char
+// error-pattern:wrong type in main function: found 'fn() -> char'
 fn main() -> char { }

--- a/src/test/compile-fail/main-wrong-type.rs
+++ b/src/test/compile-fail/main-wrong-type.rs
@@ -1,2 +1,2 @@
-// error-pattern:wrong type in main function: found fn(
+// error-pattern:wrong type in main function: found 'fn(&&{x: int,y: int})'
 fn main(foo: {x: int, y: int}) { }

--- a/src/test/compile-fail/minus-string.rs
+++ b/src/test/compile-fail/minus-string.rs
@@ -1,3 +1,3 @@
-// error-pattern:applying unary minus to non-numeric type str
+// error-pattern:applying unary minus to non-numeric type 'str'
 
 fn main() { -"foo"; }

--- a/src/test/compile-fail/native-type-mismatch.rs
+++ b/src/test/compile-fail/native-type-mismatch.rs
@@ -1,4 +1,4 @@
-// error-pattern:expected *Mb but found native
+// error-pattern:expected '*Mb' but found 'native'
 use std;
 
 fn main() unsafe {

--- a/src/test/compile-fail/nonsense-constraints.rs
+++ b/src/test/compile-fail/nonsense-constraints.rs
@@ -1,5 +1,5 @@
 // Tests that the typechecker checks constraints
-// error-pattern:mismatched types: expected uint but found u8
+// error-pattern:mismatched types: expected 'uint' but found 'u8'
 use std;
 import uint;
 

--- a/src/test/compile-fail/rec-extend.rs
+++ b/src/test/compile-fail/rec-extend.rs
@@ -1,4 +1,4 @@
-// error-pattern:expected int but found bool
+// error-pattern:expected 'int' but found 'bool'
 
 fn main() {
 

--- a/src/test/compile-fail/sendfn-is-not-a-lambda.rs
+++ b/src/test/compile-fail/sendfn-is-not-a-lambda.rs
@@ -1,4 +1,4 @@
-// error-pattern: mismatched types: expected lambda(++uint) -> uint
+// error-pattern: mismatched types: expected 'lambda(++uint) -> uint'
 
 fn test(f: lambda(uint) -> uint) -> uint {
     ret f(22u);

--- a/src/test/compile-fail/type-mismatch-multiple.rs
+++ b/src/test/compile-fail/type-mismatch-multiple.rs
@@ -1,5 +1,5 @@
 // Checking that the compiler reports multiple type errors at once
-// error-pattern:mismatched types: expected bool
-// error-pattern:mismatched types: expected int
+// error-pattern:mismatched types: expected 'bool'
+// error-pattern:mismatched types: expected 'int'
 
 fn main() { let a: bool = 1; let b: int = true; }

--- a/src/test/compile-fail/type-mismatch.rs
+++ b/src/test/compile-fail/type-mismatch.rs
@@ -1,4 +1,4 @@
-// error-pattern:expected bool but found int
+// error-pattern:expected 'bool' but found 'int'
 // issue #516
 
 fn main() { let x = true; let y = 1; let z = x + y; }


### PR DESCRIPTION
Please correct if i quoted too much.
