### PR TITLE
char/string cleanup

### DIFF
--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -34,7 +34,7 @@ fn llvm_err(sess: session::session, msg: str) unsafe {
     let buf = llvm::LLVMRustGetLastError();
     if buf == ptr::null() {
         sess.fatal(msg);
-    } else { sess.fatal(msg + ": " + str::str_from_cstr(buf)); }
+    } else { sess.fatal(msg + ": " + str::from_cstr(buf)); }
 }
 
 fn load_intrinsics_bc(sess: session::session) -> option::t<ModuleRef> {

--- a/src/comp/metadata/creader.rs
+++ b/src/comp/metadata/creader.rs
@@ -216,7 +216,7 @@ fn get_metadata_section(sess: session::session,
     let si = mk_section_iter(of.llof);
     while llvm::LLVMIsSectionIteratorAtEnd(of.llof, si.llsi) == False {
         let name_buf = llvm::LLVMGetSectionName(si.llsi);
-        let name = unsafe { str::str_from_cstr(name_buf) };
+        let name = unsafe { str::from_cstr(name_buf) };
         if str::eq(name, sess.get_targ_cfg().target_strs.meta_sect_name) {
             let cbuf = llvm::LLVMGetSectionContents(si.llsi);
             let csz = llvm::LLVMGetSectionSize(si.llsi);

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -41,7 +41,7 @@ export is_alphabetic,
        is_XID_start, is_XID_continue,
        is_lowercase, is_uppercase,
        is_whitespace, is_alphanumeric,
-       to_digit, to_lowercase, to_uppercase, maybe_digit, cmp;
+       to_digit, to_lower, to_upper, maybe_digit, cmp;
 
 import is_alphabetic = unicode::derived_property::Alphabetic;
 import is_XID_start = unicode::derived_property::XID_Start;
@@ -137,13 +137,13 @@ pure fn maybe_digit(c: char) -> option::t<u8> {
 }
 
 /*
- Function: to_lowercase
+ Function: to_lower
 
  Convert a char to the corresponding lower case.
 
  FIXME: works only on ASCII
 */
-pure fn to_lowercase(c: char) -> char {
+pure fn to_lower(c: char) -> char {
     alt c {
       'A' to 'Z' { ((c as u8) + 32u8) as char }
       _ { c }
@@ -151,13 +151,13 @@ pure fn to_lowercase(c: char) -> char {
 }
 
 /*
- Function: to_uppercase
+ Function: to_upper
 
  Convert a char to the corresponding upper case.
 
  FIXME: works only on ASCII
 */
-pure fn to_uppercase(c: char) -> char {
+pure fn to_upper(c: char) -> char {
     alt c {
       'a' to 'z' { ((c as u8) - 32u8) as char }
       _ { c }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -116,14 +116,7 @@ Function: is_whitespace
 Returns true if the string contains only whitespace
 */
 fn is_whitespace(s: str) -> bool {
-    let i = 0u;
-    let len = char_len(s);
-    while i < len {
-        // FIXME: This is not how char_at works
-        if !char::is_whitespace(char_at(s, i)) { ret false; }
-        i += 1u;
-    }
-    ret true;
+    ret loop_chars(s, char::is_whitespace);
 }
 
 /*

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -833,7 +833,7 @@ Convert a string to lowercase
 fn to_lower(s: str) -> str {
     let outstr = "";
     iter_chars(s) { |c|
-        push_char(outstr, char::to_lowercase(c));
+        push_char(outstr, char::to_lower(c));
     }
     ret outstr;
 }
@@ -845,7 +845,7 @@ Convert a string to uppercase
 fn to_upper(s: str) -> str {
     let outstr = "";
     iter_chars(s) { |c|
-        push_char(outstr, char::to_uppercase(c));
+        push_char(outstr, char::to_upper(c));
     }
     ret outstr;
 }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -12,7 +12,7 @@ export eq, lteq, hash, is_empty, is_not_empty, is_whitespace, byte_len,
        push_char, is_utf8, from_chars, to_chars, char_len, char_len_range,
        char_at, bytes, is_ascii, shift_byte, pop_byte,
        unsafe_from_byte, unsafe_from_bytes, from_char, char_range_at,
-       str_from_cstr, sbuf, as_buf, push_byte, utf8_char_width, safe_slice,
+       from_cstr, sbuf, as_buf, push_byte, utf8_char_width, safe_slice,
        contains, iter_chars, loop_chars, loop_chars_sub,
        escape;
 
@@ -973,11 +973,11 @@ fn as_buf<T>(s: str, f: block(sbuf) -> T) -> T unsafe {
 }
 
 /*
-Function: str_from_cstr
+Function: from_cstr
 
 Create a Rust string from a null-terminated C string
 */
-unsafe fn str_from_cstr(cstr: sbuf) -> str {
+unsafe fn from_cstr(cstr: sbuf) -> str {
     let res = "";
     let start = cstr;
     let curr = start;

--- a/src/libstd/generic_os.rs
+++ b/src/libstd/generic_os.rs
@@ -35,7 +35,7 @@ fn getenv(n: str) -> option::t<str> unsafe {
             option::none::<str>
         } else {
             let s = unsafe::reinterpret_cast(s);
-            option::some::<str>(str::str_from_cstr(s))
+            option::some::<str>(str::from_cstr(s))
         };
 }
 

--- a/src/test/stdtest/char.rs
+++ b/src/test/stdtest/char.rs
@@ -62,17 +62,17 @@ fn test_to_digit_fail_2() {
 }
 
 #[test]
-fn test_to_lowercase() {
-    assert (char::to_lowercase('H') == 'h');
-    assert (char::to_lowercase('e') == 'e');
-    //assert (char::to_lowercase('Ö') == 'ö');
-    assert (char::to_lowercase('ß') == 'ß');
+fn test_to_lower() {
+    assert (char::to_lower('H') == 'h');
+    assert (char::to_lower('e') == 'e');
+    //assert (char::to_lower('Ö') == 'ö');
+    assert (char::to_lower('ß') == 'ß');
 }
 
 #[test]
-fn test_to_uppercase() {
-    assert (char::to_uppercase('l') == 'L');
-    assert (char::to_uppercase('Q') == 'Q');
-    //assert (char::to_uppercase('ü') == 'Ü');
-    assert (char::to_uppercase('ß') == 'ß');
+fn test_to_upper() {
+    assert (char::to_upper('l') == 'L');
+    assert (char::to_upper('Q') == 'Q');
+    //assert (char::to_upper('ü') == 'Ü');
+    assert (char::to_upper('ß') == 'ß');
 }

--- a/src/test/stdtest/str.rs
+++ b/src/test/stdtest/str.rs
@@ -287,10 +287,10 @@ fn unsafe_from_bytes() {
 }
 
 #[test]
-fn str_from_cstr() unsafe {
+fn from_cstr() unsafe {
     let a = [65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 0u8];
     let b = vec::to_ptr(a);
-    let c = str::str_from_cstr(b);
+    let c = str::from_cstr(b);
     assert (c == "AAAAAAA");
 }
 
@@ -312,7 +312,7 @@ fn as_buf_small() unsafe {
 fn as_buf2() unsafe {
     let s = "hello";
     let sb = str::as_buf(s, {|b| b });
-    let s_cstr = str::str_from_cstr(sb);
+    let s_cstr = str::from_cstr(sb);
     assert (str::eq(s_cstr, s));
 }
 


### PR DESCRIPTION
- make str::is_whitespace() simpler (get rid of a "FIXME" en passant)
- rename char::to_lower/uppercase() to char::to_lower/upper(), analogous to str::to_lower/upper()
- rename str::str_from_cstr() to str::from_cstr() analogous to all the other str::from*() functions
