### PR TITLE
Allow Clang 3.1 in the configure script

### DIFF
--- a/configure
+++ b/configure
@@ -324,7 +324,7 @@ then
                       | cut -d ' ' -f 3)
 
     case $CFG_CLANG_VERSION in
-        (3.0svn | 3.0)
+        (3.0svn | 3.0 | 3.1)
         step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
         CFG_C_COMPILER="clang"
         ;;


### PR DESCRIPTION
Clang 3.1 builds and passes tests.
