### PR TITLE
Fix compilation error and segmentation fault on FreeBSD

### DIFF
--- a/src/libcore/cmath.rs
+++ b/src/libcore/cmath.rs
@@ -49,6 +49,7 @@ native mod c_double {
     pure fn ldexp(x: c_double, n: c_int) -> c_double;
     #[cfg(target_os = "linux")]
     #[cfg(target_os = "macos")]
+    #[cfg(target_os = "freebsd")]
     #[link_name="lgamma_r"] pure fn lgamma(n: c_double,
                                            &sign: c_int) -> c_double;
     #[cfg(target_os = "win32")]
@@ -130,6 +131,7 @@ native mod c_float {
 
     #[cfg(target_os="linux")]
     #[cfg(target_os="macos")]
+    #[cfg(target_os="freebsd")]
     #[link_name="lgammaf_r"] pure fn lgamma(n: c_float,
                                             &sign: c_int) -> c_float;
 

--- a/src/rt/rust_log.cpp
+++ b/src/rt/rust_log.cpp
@@ -143,7 +143,7 @@ rust_log::trace_ln(rust_task *task, uint32_t level, char *message) {
 
 struct mod_entry {
     const char* name;
-    size_t* state;
+    uint32_t* state;
 };
 
 struct cratemap {
@@ -232,19 +232,19 @@ void print_crate_log_map(const cratemap* map) {
 
 // These are pseudo-modules used to control logging in the runtime.
 
-size_t log_rt_mem;
-size_t log_rt_comm;
-size_t log_rt_task;
-size_t log_rt_dom;
-size_t log_rt_trace;
-size_t log_rt_cache;
-size_t log_rt_upcall;
-size_t log_rt_timer;
-size_t log_rt_gc;
-size_t log_rt_stdlib;
-size_t log_rt_kern;
-size_t log_rt_backtrace;
-size_t log_rt_callback;
+uint32_t log_rt_mem;
+uint32_t log_rt_comm;
+uint32_t log_rt_task;
+uint32_t log_rt_dom;
+uint32_t log_rt_trace;
+uint32_t log_rt_cache;
+uint32_t log_rt_upcall;
+uint32_t log_rt_timer;
+uint32_t log_rt_gc;
+uint32_t log_rt_stdlib;
+uint32_t log_rt_kern;
+uint32_t log_rt_backtrace;
+uint32_t log_rt_callback;
 
 static const mod_entry _rt_module_map[] =
     {{"::rt::mem", &log_rt_mem},

--- a/src/rt/rust_log.h
+++ b/src/rt/rust_log.h
@@ -56,18 +56,18 @@ private:
 
 void update_log_settings(void* crate_map, char* settings);
 
-extern size_t log_rt_mem;
-extern size_t log_rt_comm;
-extern size_t log_rt_task;
-extern size_t log_rt_dom;
-extern size_t log_rt_trace;
-extern size_t log_rt_cache;
-extern size_t log_rt_upcall;
-extern size_t log_rt_timer;
-extern size_t log_rt_gc;
-extern size_t log_rt_stdlib;
-extern size_t log_rt_kern;
-extern size_t log_rt_backtrace;
-extern size_t log_rt_callback;
+extern uint32_t log_rt_mem;
+extern uint32_t log_rt_comm;
+extern uint32_t log_rt_task;
+extern uint32_t log_rt_dom;
+extern uint32_t log_rt_trace;
+extern uint32_t log_rt_cache;
+extern uint32_t log_rt_upcall;
+extern uint32_t log_rt_timer;
+extern uint32_t log_rt_gc;
+extern uint32_t log_rt_stdlib;
+extern uint32_t log_rt_kern;
+extern uint32_t log_rt_backtrace;
+extern uint32_t log_rt_callback;
 
 #endif /* RUST_LOG_H */


### PR DESCRIPTION
- add lgamma functions
- match mod_entry type
  - the type of state field in runtime is size_t, but the type in LLVM code is i32.
    It causes some problems because size_t is 64-bit on 64-bit platform.
