### PR TITLE
More cleanups to commits for issue #1393

### DIFF
--- a/doc/tutorial/data.md
+++ b/doc/tutorial/data.md
@@ -103,6 +103,24 @@ equivalent to a C enum:
 This will define `north`, `east`, `south`, and `west` as constants,
 all of which have type `direction`.
 
+When the enum is C like, that is none of the variants have parameters,
+it is possible to explicit set the discriminator values to an integer
+value:
+
+    enum color {
+      red = 0xff0000;
+      green = 0x00ff00;
+      blue = 0x0000ff;
+    }
+
+If an explicit discriminator is not specified for a variant, the value
+defaults to the value of the previous variant plus one.  If the first
+variant does not have a discriminator, it defaults to 0.  For example,
+the value of `north` is 0, `east` is 1, etc.
+
+When an enum is C-like the `as` cast operator can be used to get the
+discriminator's value.
+
 <a name="single_variant_enum"></a>
 
 There is a special case for enums with a single variant. These are

--- a/src/comp/metadata/encoder.rs
+++ b/src/comp/metadata/encoder.rs
@@ -232,6 +232,8 @@ fn encode_tag_variant_info(ecx: @encode_ctxt, ebml_w: ebml::writer,
                            id: node_id, variants: [variant],
                            &index: [entry<int>], ty_params: [ty_param]) {
     let disr_val = 0;
+    let i = 0;
+    let vi = ty::tag_variants(ecx.ccx.tcx, {crate: local_crate, node: id});
     for variant: variant in variants {
         index += [{val: variant.node.id, pos: ebml_w.writer.tell()}];
         ebml::start_tag(ebml_w, tag_items_data_item);
@@ -244,13 +246,14 @@ fn encode_tag_variant_info(ecx: @encode_ctxt, ebml_w: ebml::writer,
             encode_symbol(ecx, ebml_w, variant.node.id);
         }
         encode_discriminant(ecx, ebml_w, variant.node.id);
-        if variant.node.disr_val != disr_val {
-            encode_disr_val(ecx, ebml_w, variant.node.disr_val);
-            disr_val = variant.node.disr_val;
+        if vi[i].disr_val != disr_val {
+            encode_disr_val(ecx, ebml_w, vi[i].disr_val);
+            disr_val = vi[i].disr_val;
         }
         encode_type_param_bounds(ebml_w, ecx, ty_params);
         ebml::end_tag(ebml_w);
         disr_val += 1;
+        i += 1;
     }
 }
 

--- a/src/comp/middle/check_const.rs
+++ b/src/comp/middle/check_const.rs
@@ -15,6 +15,13 @@ fn check_crate(sess: session, crate: @crate) {
 fn check_item(it: @item, &&_is_const: bool, v: visit::vt<bool>) {
     alt it.node {
       item_const(_, ex) { v.visit_expr(ex, true, v); }
+      item_tag(vs, _) {
+        for var in vs {
+            option::may(var.node.disr_expr) {|ex|
+                v.visit_expr(ex, true, v);
+            }
+        }
+      }
       _ { visit::visit_item(it, false, v); }
     }
 }

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -2631,17 +2631,30 @@ fn tag_variants(cx: ctxt, id: ast::def_id) -> @[variant_info] {
     let result = if ast::local_crate != id.crate {
         @csearch::get_tag_variants(cx, id)
     } else {
+        // FIXME: Now that the variants are run through the type checker (to
+        // check the disr_expr if it exists), this code should likely be
+        // moved there to avoid having to call eval_const_expr twice
         alt cx.items.get(id.node) {
           ast_map::node_item(@{node: ast::item_tag(variants, _), _}) {
+            let disr_val = -1;
             @vec::map(variants, {|variant|
                 let ctor_ty = node_id_to_monotype(cx, variant.node.id);
                 let arg_tys = if vec::len(variant.node.args) > 0u {
                     vec::map(ty_fn_args(cx, ctor_ty), {|a| a.ty})
                 } else { [] };
+                alt variant.node.disr_expr {
+                  some (ex) {
+                    // FIXME: issue #1417
+                    disr_val = alt syntax::ast_util::eval_const_expr(ex) {
+                      ast_util::const_int(val) {val as int}
+                    }
+                  }
+                  _ {disr_val += 1;}
+                }
                 @{args: arg_tys,
                   ctor_ty: ctor_ty,
                   id: ast_util::local_def(variant.node.id),
-                  disr_val: variant.node.disr_val
+                  disr_val: disr_val
                  }
             })
           }

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -2461,6 +2461,55 @@ fn check_const(ccx: @crate_ctxt, _sp: span, e: @ast::expr, id: ast::node_id) {
     demand::simple(fcx, e.span, declty, cty);
 }
 
+fn check_tag_variants(ccx: @crate_ctxt, _sp: span, vs: [ast::variant],
+                      id: ast::node_id) {
+    // FIXME: this is kinda a kludge; we manufacture a fake function context
+    // and statement context for checking the initializer expression.
+    let rty = node_id_to_type(ccx.tcx, id);
+    let fixups: [ast::node_id] = [];
+    let fcx: @fn_ctxt =
+        @{ret_ty: rty,
+          purity: ast::pure_fn,
+          proto: ast::proto_box,
+          var_bindings: ty::unify::mk_var_bindings(),
+          locals: new_int_hash::<int>(),
+          next_var_id: @mutable 0,
+          mutable fixups: fixups,
+          ccx: ccx};
+    let disr_vals: [int] = [];
+    let disr_val = 0;
+    for v in vs {
+        alt v.node.disr_expr {
+          some(e) {
+            check_expr(fcx, e);
+            let cty = expr_ty(fcx.ccx.tcx, e);
+            let declty =ty::mk_int(fcx.ccx.tcx);
+            demand::simple(fcx, e.span, declty, cty);
+            // FIXME: issue #1417
+            // Also, check_expr (from check_const pass) doesn't guarantee that
+            // the expression in an form that eval_const_expr can handle, so
+            // we may still get an internal compiler error
+            alt syntax::ast_util::eval_const_expr(e) {
+              syntax::ast_util::const_int(val) {
+                disr_val = val as int;
+              }
+              _ {
+                ccx.tcx.sess.span_err(e.span,
+                                      "expected signed integer constant");
+              }
+            }
+          }
+          _ {}
+        }
+        if vec::member(disr_val, disr_vals) {
+            ccx.tcx.sess.span_err(v.span,
+                                  "discriminator value already exists.");
+        }
+        disr_vals += [disr_val];
+        disr_val += 1;
+    }
+}
+
 // A generic function for checking the pred in a check
 // or if-check
 fn check_pred_expr(fcx: @fn_ctxt, e: @ast::expr) -> bool {
@@ -2632,6 +2681,7 @@ fn check_method(ccx: @crate_ctxt, method: @ast::method) {
 fn check_item(ccx: @crate_ctxt, it: @ast::item) {
     alt it.node {
       ast::item_const(_, e) { check_const(ccx, it.span, e, it.id); }
+      ast::item_tag(vs, _) { check_tag_variants(ccx, it.span, vs, it.id); }
       ast::item_fn(decl, tps, body) {
         check_fn(ccx, ast::proto_bare, decl, body, it.id, none);
       }

--- a/src/comp/syntax/ast.rs
+++ b/src/comp/syntax/ast.rs
@@ -409,7 +409,7 @@ type native_mod =
 type variant_arg = {ty: @ty, id: node_id};
 
 type variant_ = {name: ident, args: [variant_arg], id: node_id,
-                disr_val: int, disr_expr: option::t<@expr>};
+                 disr_expr: option::t<@expr>};
 
 type variant = spanned<variant_>;
 

--- a/src/comp/syntax/ast_util.rs
+++ b/src/comp/syntax/ast_util.rs
@@ -241,8 +241,7 @@ tag const_val {
     const_str(str);
 }
 
-// FIXME (#1417): any function that uses this function should likely be moved
-// into the middle end
+// FIXME: issue #1417
 fn eval_const_expr(e: @expr) -> const_val {
     fn fromb(b: bool) -> const_val { const_int(b as i64) }
     alt e.node {

--- a/src/comp/syntax/fold.rs
+++ b/src/comp/syntax/fold.rs
@@ -432,21 +432,12 @@ fn noop_fold_variant(v: variant_, fld: ast_fold) -> variant_ {
     }
     let fold_variant_arg = bind fold_variant_arg_(_, fld);
     let args = vec::map(v.args, fold_variant_arg);
-    let (de, dv) = alt v.disr_expr {
-      some(e) {
-        let de = fld.fold_expr(e);
-        // FIXME (#1417): see parser.rs
-        let dv = alt syntax::ast_util::eval_const_expr(e) {
-          ast_util::const_int(val) {
-            val as int
-          }
-        };
-        (some(de), dv)
-      }
-      none. { (none, v.disr_val) }
+    let de = alt v.disr_expr {
+      some(e) {some(fld.fold_expr(e))}
+      none. {none}
     };
     ret {name: v.name, args: args, id: v.id,
-         disr_val: dv,  disr_expr: de};
+         disr_expr: de};
 }
 
 fn noop_fold_ident(&&i: ident, _fld: ast_fold) -> ident { ret i; }

--- a/src/comp/syntax/print/pprust.rs
+++ b/src/comp/syntax/print/pprust.rs
@@ -428,6 +428,14 @@ fn print_item(s: ps, &&item: @ast::item) {
                     commasep(s, consistent, v.node.args, print_variant_arg);
                     pclose(s);
                 }
+                alt v.node.disr_expr {
+                  some(expr) {
+                    nbsp(s);
+                    word_nbsp(s, "=");
+                    print_expr(s, expr);
+                  }
+                  _ {}
+                }
                 word(s.s, ";");
                 maybe_print_trailing_comment(s, v.span, none::<uint>);
             }

--- a/src/test/compile-fail/tag-variant-disr-type-mismatch.rs
+++ b/src/test/compile-fail/tag-variant-disr-type-mismatch.rs
@@ -1,0 +1,8 @@
+//error-pattern: mismatched types
+
+tag color {
+    red = 1u;
+    blue = 2;
+}
+
+fn main() {}

--- a/src/test/run-pass/enum-disr-val-pretty.rs
+++ b/src/test/run-pass/enum-disr-val-pretty.rs
@@ -1,0 +1,16 @@
+// pp-exact
+
+enum color { red = 1; green; blue; imaginary = -1; }
+
+fn main() {
+    test_color(red, 1, "red");
+    test_color(green, 2, "green");
+    test_color(blue, 3, "blue");
+    test_color(imaginary, -1, "imaginary");
+}
+
+fn test_color(color: color, val: int, name: str) {
+    assert (color as int == val);
+    assert (color as float == val as float);
+}
+


### PR DESCRIPTION
The commits:
1. Update the tutorial to document the new feature.
2. Fix #1510.
3. Avoid evaluating discriminator value constants when parsing
4. Correctly type checks the discriminator value as an integer
