### PR TITLE
Issue 1403: Warn if int or uint is used in native fn declarations

### DIFF
--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -170,27 +170,27 @@ mod write {
             llvm::LLVMAddTargetData(td.lltd, fpm.llpm);
 
             let FPMB = llvm::LLVMPassManagerBuilderCreate();
-            llvm::LLVMPassManagerBuilderSetOptLevel(FPMB, 2u32);
+            llvm::LLVMPassManagerBuilderSetOptLevel(FPMB, 2u as c_uint);
             llvm::LLVMPassManagerBuilderPopulateFunctionPassManager(FPMB,
                                                                     fpm.llpm);
             llvm::LLVMPassManagerBuilderDispose(FPMB);
 
             llvm::LLVMRunPassManager(fpm.llpm, llmod);
-            let threshold = 225u as c_uint;
-            if opts.optimize == 3u { threshold = 275u as c_uint; }
+            let threshold = 225u;
+            if opts.optimize == 3u { threshold = 275u; }
 
             let MPMB = llvm::LLVMPassManagerBuilderCreate();
             llvm::LLVMPassManagerBuilderSetOptLevel(MPMB,
-                                                    opts.optimize as u32);
+                                                    opts.optimize as c_uint);
             llvm::LLVMPassManagerBuilderSetSizeLevel(MPMB, 0);
             llvm::LLVMPassManagerBuilderSetDisableUnitAtATime(MPMB, False);
             llvm::LLVMPassManagerBuilderSetDisableUnrollLoops(MPMB, False);
             llvm::LLVMPassManagerBuilderSetDisableSimplifyLibCalls(MPMB,
                                                                    False);
 
-            if threshold != 0u32 {
+            if threshold != 0u {
                 llvm::LLVMPassManagerBuilderUseInlinerWithThreshold
-                    (MPMB, threshold);
+                    (MPMB, threshold as c_uint);
             }
             llvm::LLVMPassManagerBuilderPopulateModulePassManager(MPMB,
                                                                   pm.llpm);

--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -1,4 +1,4 @@
-
+import core::ctypes::{c_int, c_uint};
 import driver::session;
 import session::session;
 import lib::llvm::llvm;
@@ -170,24 +170,25 @@ mod write {
             llvm::LLVMAddTargetData(td.lltd, fpm.llpm);
 
             let FPMB = llvm::LLVMPassManagerBuilderCreate();
-            llvm::LLVMPassManagerBuilderSetOptLevel(FPMB, 2u);
+            llvm::LLVMPassManagerBuilderSetOptLevel(FPMB, 2u32);
             llvm::LLVMPassManagerBuilderPopulateFunctionPassManager(FPMB,
                                                                     fpm.llpm);
             llvm::LLVMPassManagerBuilderDispose(FPMB);
 
             llvm::LLVMRunPassManager(fpm.llpm, llmod);
-            let threshold: uint = 225u;
-            if opts.optimize == 3u { threshold = 275u; }
+            let threshold = 225u as c_uint;
+            if opts.optimize == 3u { threshold = 275u as c_uint; }
 
             let MPMB = llvm::LLVMPassManagerBuilderCreate();
-            llvm::LLVMPassManagerBuilderSetOptLevel(MPMB, opts.optimize);
+            llvm::LLVMPassManagerBuilderSetOptLevel(MPMB,
+                                                    opts.optimize as u32);
             llvm::LLVMPassManagerBuilderSetSizeLevel(MPMB, 0);
             llvm::LLVMPassManagerBuilderSetDisableUnitAtATime(MPMB, False);
             llvm::LLVMPassManagerBuilderSetDisableUnrollLoops(MPMB, False);
             llvm::LLVMPassManagerBuilderSetDisableSimplifyLibCalls(MPMB,
                                                                    False);
 
-            if threshold != 0u {
+            if threshold != 0u32 {
                 llvm::LLVMPassManagerBuilderUseInlinerWithThreshold
                     (MPMB, threshold);
             }
@@ -198,12 +199,12 @@ mod write {
         }
         if opts.verify { llvm::LLVMAddVerifierPass(pm.llpm); }
         if is_object_or_assembly_or_exe(opts.output_type) {
-            let LLVMAssemblyFile: int = 0;
-            let LLVMObjectFile: int = 1;
-            let LLVMOptNone: int = 0; // -O0
-            let LLVMOptLess: int = 1; // -O1
-            let LLVMOptDefault: int = 2; // -O2, -Os
-            let LLVMOptAggressive: int = 3; // -O3
+            let LLVMAssemblyFile  = 0 as c_int;
+            let LLVMObjectFile    = 1 as c_int;
+            let LLVMOptNone       = 0 as c_int; // -O0
+            let LLVMOptLess       = 1 as c_int; // -O1
+            let LLVMOptDefault    = 2 as c_int; // -O2, -Os
+            let LLVMOptAggressive = 3 as c_int; // -O3
 
             let CodeGenOptLevel;
             alt opts.optimize {

--- a/src/comp/lib/llvm.rs
+++ b/src/comp/lib/llvm.rs
@@ -4,9 +4,8 @@ import str::sbuf;
 import llvm::{TypeRef, MemoryBufferRef,
               PassManagerRef, TargetDataRef,
               ObjectFileRef, SectionIteratorRef};
+import ctypes::{c_int, c_uint, unsigned, longlong, ulonglong};
 
-type ULongLong = u64;
-type LongLong = i64;
 type Long = i32;
 type Bool = int;
 
@@ -141,9 +140,9 @@ native mod llvm {
     fn LLVMContextCreate() -> ContextRef;
     fn LLVMGetGlobalContext() -> ContextRef;
     fn LLVMContextDispose(C: ContextRef);
-    fn LLVMGetMDKindIDInContext(C: ContextRef, Name: sbuf, SLen: uint) ->
-       uint;
-    fn LLVMGetMDKindID(Name: sbuf, SLen: uint) -> uint;
+    fn LLVMGetMDKindIDInContext(C: ContextRef, Name: sbuf, SLen: unsigned) ->
+       unsigned;
+    fn LLVMGetMDKindID(Name: sbuf, SLen: unsigned) -> unsigned;
 
     /* Create and destroy modules. */
     fn LLVMModuleCreateWithNameInContext(ModuleID: sbuf, C: ContextRef) ->
@@ -170,7 +169,7 @@ native mod llvm {
     // we directly inspect the values, and casting from
     // a native doesn't work yet (only *to* a native).
 
-    fn LLVMGetTypeKind(Ty: TypeRef) -> int;
+    fn LLVMGetTypeKind(Ty: TypeRef) -> c_int;
 
     /** See llvm::LLVMType::getContext. */
     fn LLVMGetTypeContext(Ty: TypeRef) -> ContextRef;
@@ -181,15 +180,15 @@ native mod llvm {
     fn LLVMInt16TypeInContext(C: ContextRef) -> TypeRef;
     fn LLVMInt32TypeInContext(C: ContextRef) -> TypeRef;
     fn LLVMInt64TypeInContext(C: ContextRef) -> TypeRef;
-    fn LLVMIntTypeInContext(C: ContextRef, NumBits: uint) -> TypeRef;
+    fn LLVMIntTypeInContext(C: ContextRef, NumBits: unsigned) -> TypeRef;
 
     fn LLVMInt1Type() -> TypeRef;
     fn LLVMInt8Type() -> TypeRef;
     fn LLVMInt16Type() -> TypeRef;
     fn LLVMInt32Type() -> TypeRef;
     fn LLVMInt64Type() -> TypeRef;
-    fn LLVMIntType(NumBits: uint) -> TypeRef;
-    fn LLVMGetIntTypeWidth(IntegerTy: TypeRef) -> uint;
+    fn LLVMIntType(NumBits: unsigned) -> TypeRef;
+    fn LLVMGetIntTypeWidth(IntegerTy: TypeRef) -> unsigned;
 
     /* Operations on real types */
     fn LLVMFloatTypeInContext(C: ContextRef) -> TypeRef;
@@ -206,30 +205,34 @@ native mod llvm {
 
     /* Operations on function types */
     fn LLVMFunctionType(ReturnType: TypeRef, ParamTypes: *TypeRef,
-                        ParamCount: uint, IsVarArg: Bool) -> TypeRef;
+                        ParamCount: unsigned, IsVarArg: Bool) -> TypeRef;
     fn LLVMIsFunctionVarArg(FunctionTy: TypeRef) -> Bool;
     fn LLVMGetReturnType(FunctionTy: TypeRef) -> TypeRef;
-    fn LLVMCountParamTypes(FunctionTy: TypeRef) -> uint;
+    fn LLVMCountParamTypes(FunctionTy: TypeRef) -> unsigned;
     fn LLVMGetParamTypes(FunctionTy: TypeRef, Dest: *TypeRef);
 
     /* Operations on struct types */
     fn LLVMStructTypeInContext(C: ContextRef, ElementTypes: *TypeRef,
-                               ElementCount: uint, Packed: Bool) -> TypeRef;
-    fn LLVMStructType(ElementTypes: *TypeRef, ElementCount: uint,
+                               ElementCount: unsigned,
+                               Packed: Bool) -> TypeRef;
+    fn LLVMStructType(ElementTypes: *TypeRef, ElementCount: unsigned,
                       Packed: Bool) -> TypeRef;
-    fn LLVMCountStructElementTypes(StructTy: TypeRef) -> uint;
+    fn LLVMCountStructElementTypes(StructTy: TypeRef) -> unsigned;
     fn LLVMGetStructElementTypes(StructTy: TypeRef, Dest: *TypeRef);
     fn LLVMIsPackedStruct(StructTy: TypeRef) -> Bool;
 
     /* Operations on array, pointer, and vector types (sequence types) */
-    fn LLVMArrayType(ElementType: TypeRef, ElementCount: uint) -> TypeRef;
-    fn LLVMPointerType(ElementType: TypeRef, AddressSpace: uint) -> TypeRef;
-    fn LLVMVectorType(ElementType: TypeRef, ElementCount: uint) -> TypeRef;
+    fn LLVMArrayType(ElementType: TypeRef,
+                     ElementCount: unsigned) -> TypeRef;
+    fn LLVMPointerType(ElementType: TypeRef,
+                       AddressSpace: unsigned) -> TypeRef;
+    fn LLVMVectorType(ElementType: TypeRef,
+                      ElementCount: unsigned) -> TypeRef;
 
     fn LLVMGetElementType(Ty: TypeRef) -> TypeRef;
-    fn LLVMGetArrayLength(ArrayTy: TypeRef) -> uint;
-    fn LLVMGetPointerAddressSpace(PointerTy: TypeRef) -> uint;
-    fn LLVMGetVectorSize(VectorTy: TypeRef) -> uint;
+    fn LLVMGetArrayLength(ArrayTy: TypeRef) -> unsigned;
+    fn LLVMGetPointerAddressSpace(PointerTy: TypeRef) -> unsigned;
+    fn LLVMGetVectorSize(VectorTy: TypeRef) -> unsigned;
 
     /* Operations on other types */
     fn LLVMVoidTypeInContext(C: ContextRef) -> TypeRef;
@@ -246,9 +249,9 @@ native mod llvm {
     fn LLVMSetValueName(Val: ValueRef, Name: sbuf);
     fn LLVMDumpValue(Val: ValueRef);
     fn LLVMReplaceAllUsesWith(OldVal: ValueRef, NewVal: ValueRef);
-    fn LLVMHasMetadata(Val: ValueRef) -> int;
-    fn LLVMGetMetadata(Val: ValueRef, KindID: uint) -> ValueRef;
-    fn LLVMSetMetadata(Val: ValueRef, KindID: uint, Node: ValueRef);
+    fn LLVMHasMetadata(Val: ValueRef) -> c_int;
+    fn LLVMGetMetadata(Val: ValueRef, KindID: unsigned) -> ValueRef;
+    fn LLVMSetMetadata(Val: ValueRef, KindID: unsigned, Node: ValueRef);
 
     /* Operations on Uses */
     fn LLVMGetFirstUse(Val: ValueRef) -> UseRef;
@@ -257,8 +260,8 @@ native mod llvm {
     fn LLVMGetUsedValue(U: UseRef) -> ValueRef;
 
     /* Operations on Users */
-    fn LLVMGetOperand(Val: ValueRef, Index: uint) -> ValueRef;
-    fn LLVMSetOperand(Val: ValueRef, Index: uint, Op: ValueRef);
+    fn LLVMGetOperand(Val: ValueRef, Index: unsigned) -> ValueRef;
+    fn LLVMSetOperand(Val: ValueRef, Index: unsigned, Op: ValueRef);
 
     /* Operations on constants of any type */
     fn LLVMConstNull(Ty: TypeRef) -> ValueRef;
@@ -272,45 +275,46 @@ native mod llvm {
     fn LLVMConstPointerNull(Ty: TypeRef) -> ValueRef;
 
     /* Operations on metadata */
-    fn LLVMMDStringInContext(C: ContextRef, Str: sbuf, SLen: uint) ->
+    fn LLVMMDStringInContext(C: ContextRef, Str: sbuf, SLen: unsigned) ->
        ValueRef;
-    fn LLVMMDString(Str: sbuf, SLen: uint) -> ValueRef;
-    fn LLVMMDNodeInContext(C: ContextRef, Vals: *ValueRef, Count: uint) ->
+    fn LLVMMDString(Str: sbuf, SLen: unsigned) -> ValueRef;
+    fn LLVMMDNodeInContext(C: ContextRef, Vals: *ValueRef, Count: unsigned) ->
        ValueRef;
-    fn LLVMMDNode(Vals: *ValueRef, Count: uint) -> ValueRef;
+    fn LLVMMDNode(Vals: *ValueRef, Count: unsigned) -> ValueRef;
     fn LLVMAddNamedMetadataOperand(M: ModuleRef, Str: sbuf,
                                    Val: ValueRef);
 
     /* Operations on scalar constants */
-    fn LLVMConstInt(IntTy: TypeRef, N: ULongLong, SignExtend: Bool) ->
+    fn LLVMConstInt(IntTy: TypeRef, N: ulonglong, SignExtend: Bool) ->
        ValueRef;
     // FIXME: radix is actually u8, but our native layer can't handle this
     // yet.  lucky for us we're little-endian. Small miracles.
-    fn LLVMConstIntOfString(IntTy: TypeRef, Text: sbuf, Radix: int) ->
+    fn LLVMConstIntOfString(IntTy: TypeRef, Text: sbuf, Radix: c_int) ->
        ValueRef;
-    fn LLVMConstIntOfStringAndSize(IntTy: TypeRef, Text: sbuf, SLen: uint,
+    fn LLVMConstIntOfStringAndSize(IntTy: TypeRef, Text: sbuf, SLen: unsigned,
                                    Radix: u8) -> ValueRef;
     fn LLVMConstReal(RealTy: TypeRef, N: f64) -> ValueRef;
     fn LLVMConstRealOfString(RealTy: TypeRef, Text: sbuf) -> ValueRef;
-    fn LLVMConstRealOfStringAndSize(RealTy: TypeRef, Text: sbuf, SLen: uint)
-       -> ValueRef;
-    fn LLVMConstIntGetZExtValue(ConstantVal: ValueRef) -> ULongLong;
-    fn LLVMConstIntGetSExtValue(ConstantVal: ValueRef) -> LongLong;
+    fn LLVMConstRealOfStringAndSize(RealTy: TypeRef, Text: sbuf,
+                                    SLen: unsigned) -> ValueRef;
+    fn LLVMConstIntGetZExtValue(ConstantVal: ValueRef) -> ulonglong;
+    fn LLVMConstIntGetSExtValue(ConstantVal: ValueRef) -> longlong;
 
 
     /* Operations on composite constants */
-    fn LLVMConstStringInContext(C: ContextRef, Str: sbuf, Length: uint,
+    fn LLVMConstStringInContext(C: ContextRef, Str: sbuf, Length: unsigned,
                                 DontNullTerminate: Bool) -> ValueRef;
     fn LLVMConstStructInContext(C: ContextRef, ConstantVals: *ValueRef,
-                                Count: uint, Packed: Bool) -> ValueRef;
+                                Count: unsigned, Packed: Bool) -> ValueRef;
 
-    fn LLVMConstString(Str: sbuf, Length: uint, DontNullTerminate: Bool) ->
-       ValueRef;
+    fn LLVMConstString(Str: sbuf, Length: unsigned,
+                       DontNullTerminate: Bool) -> ValueRef;
     fn LLVMConstArray(ElementTy: TypeRef, ConstantVals: *ValueRef,
-                      Length: uint) -> ValueRef;
-    fn LLVMConstStruct(ConstantVals: *ValueRef, Count: uint, Packed: Bool) ->
-       ValueRef;
-    fn LLVMConstVector(ScalarConstantVals: *ValueRef, Size: uint) -> ValueRef;
+                      Length: unsigned) -> ValueRef;
+    fn LLVMConstStruct(ConstantVals: *ValueRef,
+                       Count: unsigned, Packed: Bool) -> ValueRef;
+    fn LLVMConstVector(ScalarConstantVals: *ValueRef,
+                       Size: unsigned) -> ValueRef;
 
     /* Constant expressions */
     fn LLVMAlignOf(Ty: TypeRef) -> ValueRef;
@@ -364,9 +368,9 @@ native mod llvm {
     fn LLVMConstAShr(LHSConstant: ValueRef, RHSConstant: ValueRef) ->
        ValueRef;
     fn LLVMConstGEP(ConstantVal: ValueRef, ConstantIndices: *uint,
-                    NumIndices: uint) -> ValueRef;
+                    NumIndices: unsigned) -> ValueRef;
     fn LLVMConstInBoundsGEP(ConstantVal: ValueRef, ConstantIndices: *uint,
-                            NumIndices: uint) -> ValueRef;
+                            NumIndices: unsigned) -> ValueRef;
     fn LLVMConstTrunc(ConstantVal: ValueRef, ToType: TypeRef) -> ValueRef;
     fn LLVMConstSExt(ConstantVal: ValueRef, ToType: TypeRef) -> ValueRef;
     fn LLVMConstZExt(ConstantVal: ValueRef, ToType: TypeRef) -> ValueRef;
@@ -401,10 +405,10 @@ native mod llvm {
                               VectorBConstant: ValueRef,
                               MaskConstant: ValueRef) -> ValueRef;
     fn LLVMConstExtractValue(AggConstant: ValueRef, IdxList: *uint,
-                             NumIdx: uint) -> ValueRef;
+                             NumIdx: unsigned) -> ValueRef;
     fn LLVMConstInsertValue(AggConstant: ValueRef,
                             ElementValueConstant: ValueRef, IdxList: *uint,
-                            NumIdx: uint) -> ValueRef;
+                            NumIdx: unsigned) -> ValueRef;
     fn LLVMConstInlineAsm(Ty: TypeRef, AsmString: sbuf, Constraints: sbuf,
                           HasSideEffects: Bool, IsAlignStack: Bool) ->
        ValueRef;
@@ -421,14 +425,14 @@ native mod llvm {
     fn LLVMSetSection(Global: ValueRef, Section: sbuf);
     fn LLVMGetVisibility(Global: ValueRef) -> Visibility;
     fn LLVMSetVisibility(Global: ValueRef, Viz: Visibility);
-    fn LLVMGetAlignment(Global: ValueRef) -> uint;
-    fn LLVMSetAlignment(Global: ValueRef, Bytes: uint);
+    fn LLVMGetAlignment(Global: ValueRef) -> unsigned;
+    fn LLVMSetAlignment(Global: ValueRef, Bytes: unsigned);
 
 
     /* Operations on global variables */
     fn LLVMAddGlobal(M: ModuleRef, Ty: TypeRef, Name: sbuf) -> ValueRef;
     fn LLVMAddGlobalInAddressSpace(M: ModuleRef, Ty: TypeRef, Name: sbuf,
-                                   AddressSpace: uint) -> ValueRef;
+                                   AddressSpace: unsigned) -> ValueRef;
     fn LLVMGetNamedGlobal(M: ModuleRef, Name: sbuf) -> ValueRef;
     fn LLVMGetFirstGlobal(M: ModuleRef) -> ValueRef;
     fn LLVMGetLastGlobal(M: ModuleRef) -> ValueRef;
@@ -457,19 +461,19 @@ native mod llvm {
     fn LLVMDeleteFunction(Fn: ValueRef);
     fn LLVMGetOrInsertFunction(M: ModuleRef, Name: sbuf, FunctionTy: TypeRef)
        -> ValueRef;
-    fn LLVMGetIntrinsicID(Fn: ValueRef) -> uint;
-    fn LLVMGetFunctionCallConv(Fn: ValueRef) -> uint;
-    fn LLVMSetFunctionCallConv(Fn: ValueRef, CC: uint);
+    fn LLVMGetIntrinsicID(Fn: ValueRef) -> unsigned;
+    fn LLVMGetFunctionCallConv(Fn: ValueRef) -> unsigned;
+    fn LLVMSetFunctionCallConv(Fn: ValueRef, CC: unsigned);
     fn LLVMGetGC(Fn: ValueRef) -> sbuf;
     fn LLVMSetGC(Fn: ValueRef, Name: sbuf);
-    fn LLVMAddFunctionAttr(Fn: ValueRef, PA: Attribute, HighPA: uint);
+    fn LLVMAddFunctionAttr(Fn: ValueRef, PA: Attribute, HighPA: unsigned);
     fn LLVMGetFunctionAttr(Fn: ValueRef) -> Attribute;
-    fn LLVMRemoveFunctionAttr(Fn: ValueRef, PA: Attribute, HighPA: uint);
+    fn LLVMRemoveFunctionAttr(Fn: ValueRef, PA: Attribute, HighPA: unsigned);
 
     /* Operations on parameters */
-    fn LLVMCountParams(Fn: ValueRef) -> uint;
+    fn LLVMCountParams(Fn: ValueRef) -> unsigned;
     fn LLVMGetParams(Fn: ValueRef, Params: *ValueRef);
-    fn LLVMGetParam(Fn: ValueRef, Index: uint) -> ValueRef;
+    fn LLVMGetParam(Fn: ValueRef, Index: unsigned) -> ValueRef;
     fn LLVMGetParamParent(Inst: ValueRef) -> ValueRef;
     fn LLVMGetFirstParam(Fn: ValueRef) -> ValueRef;
     fn LLVMGetLastParam(Fn: ValueRef) -> ValueRef;
@@ -478,14 +482,14 @@ native mod llvm {
     fn LLVMAddAttribute(Arg: ValueRef, PA: Attribute);
     fn LLVMRemoveAttribute(Arg: ValueRef, PA: Attribute);
     fn LLVMGetAttribute(Arg: ValueRef) -> Attribute;
-    fn LLVMSetParamAlignment(Arg: ValueRef, align: uint);
+    fn LLVMSetParamAlignment(Arg: ValueRef, align: unsigned);
 
     /* Operations on basic blocks */
     fn LLVMBasicBlockAsValue(BB: BasicBlockRef) -> ValueRef;
     fn LLVMValueIsBasicBlock(Val: ValueRef) -> Bool;
     fn LLVMValueAsBasicBlock(Val: ValueRef) -> BasicBlockRef;
     fn LLVMGetBasicBlockParent(BB: BasicBlockRef) -> ValueRef;
-    fn LLVMCountBasicBlocks(Fn: ValueRef) -> uint;
+    fn LLVMCountBasicBlocks(Fn: ValueRef) -> unsigned;
     fn LLVMGetBasicBlocks(Fn: ValueRef, BasicBlocks: *ValueRef);
     fn LLVMGetFirstBasicBlock(Fn: ValueRef) -> BasicBlockRef;
     fn LLVMGetLastBasicBlock(Fn: ValueRef) -> BasicBlockRef;
@@ -511,11 +515,13 @@ native mod llvm {
     fn LLVMGetPreviousInstruction(Inst: ValueRef) -> ValueRef;
 
     /* Operations on call sites */
-    fn LLVMSetInstructionCallConv(Instr: ValueRef, CC: uint);
-    fn LLVMGetInstructionCallConv(Instr: ValueRef) -> uint;
-    fn LLVMAddInstrAttribute(Instr: ValueRef, index: uint, IA: Attribute);
-    fn LLVMRemoveInstrAttribute(Instr: ValueRef, index: uint, IA: Attribute);
-    fn LLVMSetInstrParamAlignment(Instr: ValueRef, index: uint, align: uint);
+    fn LLVMSetInstructionCallConv(Instr: ValueRef, CC: unsigned);
+    fn LLVMGetInstructionCallConv(Instr: ValueRef) -> unsigned;
+    fn LLVMAddInstrAttribute(Instr: ValueRef, index: unsigned, IA: Attribute);
+    fn LLVMRemoveInstrAttribute(Instr: ValueRef, index: unsigned,
+                                IA: Attribute);
+    fn LLVMSetInstrParamAlignment(Instr: ValueRef, index: unsigned,
+                                  align: unsigned);
 
     /* Operations on call instructions (only) */
     fn LLVMIsTailCall(CallInst: ValueRef) -> Bool;
@@ -523,10 +529,11 @@ native mod llvm {
 
     /* Operations on phi nodes */
     fn LLVMAddIncoming(PhiNode: ValueRef, IncomingValues: *ValueRef,
-                       IncomingBlocks: *BasicBlockRef, Count: uint);
-    fn LLVMCountIncoming(PhiNode: ValueRef) -> uint;
-    fn LLVMGetIncomingValue(PhiNode: ValueRef, Index: uint) -> ValueRef;
-    fn LLVMGetIncomingBlock(PhiNode: ValueRef, Index: uint) -> BasicBlockRef;
+                       IncomingBlocks: *BasicBlockRef, Count: unsigned);
+    fn LLVMCountIncoming(PhiNode: ValueRef) -> unsigned;
+    fn LLVMGetIncomingValue(PhiNode: ValueRef, Index: unsigned) -> ValueRef;
+    fn LLVMGetIncomingBlock(PhiNode: ValueRef,
+                            Index: unsigned) -> BasicBlockRef;
 
     /* Instruction builders */
     fn LLVMCreateBuilderInContext(C: ContextRef) -> BuilderRef;
@@ -550,20 +557,20 @@ native mod llvm {
     /* Terminators */
     fn LLVMBuildRetVoid(B: BuilderRef) -> ValueRef;
     fn LLVMBuildRet(B: BuilderRef, V: ValueRef) -> ValueRef;
-    fn LLVMBuildAggregateRet(B: BuilderRef, RetVals: *ValueRef, N: uint) ->
-       ValueRef;
+    fn LLVMBuildAggregateRet(B: BuilderRef, RetVals: *ValueRef,
+                             N: unsigned) -> ValueRef;
     fn LLVMBuildBr(B: BuilderRef, Dest: BasicBlockRef) -> ValueRef;
     fn LLVMBuildCondBr(B: BuilderRef, If: ValueRef, Then: BasicBlockRef,
                        Else: BasicBlockRef) -> ValueRef;
     fn LLVMBuildSwitch(B: BuilderRef, V: ValueRef, Else: BasicBlockRef,
-                       NumCases: uint) -> ValueRef;
-    fn LLVMBuildIndirectBr(B: BuilderRef, Addr: ValueRef, NumDests: uint) ->
-       ValueRef;
+                       NumCases: unsigned) -> ValueRef;
+    fn LLVMBuildIndirectBr(B: BuilderRef, Addr: ValueRef,
+                           NumDests: unsigned) -> ValueRef;
     fn LLVMBuildInvoke(B: BuilderRef, Fn: ValueRef, Args: *ValueRef,
-                       NumArgs: uint, Then: BasicBlockRef,
+                       NumArgs: unsigned, Then: BasicBlockRef,
                        Catch: BasicBlockRef, Name: sbuf) -> ValueRef;
     fn LLVMBuildLandingPad(B: BuilderRef, Ty: TypeRef, PersFn: ValueRef,
-                           NumClauses: uint, Name: sbuf) -> ValueRef;
+                           NumClauses: unsigned, Name: sbuf) -> ValueRef;
     fn LLVMBuildResume(B: BuilderRef, Exn: ValueRef) -> ValueRef;
     fn LLVMBuildUnreachable(B: BuilderRef) -> ValueRef;
 
@@ -651,11 +658,12 @@ native mod llvm {
     fn LLVMBuildStore(B: BuilderRef, Val: ValueRef, Ptr: ValueRef) ->
        ValueRef;
     fn LLVMBuildGEP(B: BuilderRef, Pointer: ValueRef, Indices: *ValueRef,
-                    NumIndices: uint, Name: sbuf) -> ValueRef;
+                    NumIndices: unsigned, Name: sbuf) -> ValueRef;
     fn LLVMBuildInBoundsGEP(B: BuilderRef, Pointer: ValueRef,
-                            Indices: *ValueRef, NumIndices: uint, Name: sbuf)
+                            Indices: *ValueRef, NumIndices: unsigned,
+                            Name: sbuf)
        -> ValueRef;
-    fn LLVMBuildStructGEP(B: BuilderRef, Pointer: ValueRef, Idx: uint,
+    fn LLVMBuildStructGEP(B: BuilderRef, Pointer: ValueRef, Idx: unsigned,
                           Name: sbuf) -> ValueRef;
     fn LLVMBuildGlobalString(B: BuilderRef, Str: sbuf, Name: sbuf) ->
        ValueRef;
@@ -703,15 +711,15 @@ native mod llvm {
                        Name: sbuf) -> ValueRef;
 
     /* Comparisons */
-    fn LLVMBuildICmp(B: BuilderRef, Op: uint, LHS: ValueRef, RHS: ValueRef,
-                     Name: sbuf) -> ValueRef;
-    fn LLVMBuildFCmp(B: BuilderRef, Op: uint, LHS: ValueRef, RHS: ValueRef,
-                     Name: sbuf) -> ValueRef;
+    fn LLVMBuildICmp(B: BuilderRef, Op: unsigned, LHS: ValueRef,
+                     RHS: ValueRef, Name: sbuf) -> ValueRef;
+    fn LLVMBuildFCmp(B: BuilderRef, Op: unsigned, LHS: ValueRef,
+                     RHS: ValueRef, Name: sbuf) -> ValueRef;
 
     /* Miscellaneous instructions */
     fn LLVMBuildPhi(B: BuilderRef, Ty: TypeRef, Name: sbuf) -> ValueRef;
     fn LLVMBuildCall(B: BuilderRef, Fn: ValueRef, Args: *ValueRef,
-                     NumArgs: uint, Name: sbuf) -> ValueRef;
+                     NumArgs: unsigned, Name: sbuf) -> ValueRef;
     fn LLVMBuildSelect(B: BuilderRef, If: ValueRef, Then: ValueRef,
                        Else: ValueRef, Name: sbuf) -> ValueRef;
     fn LLVMBuildVAArg(B: BuilderRef, list: ValueRef, Ty: TypeRef, Name: sbuf)
@@ -723,10 +731,10 @@ native mod llvm {
        -> ValueRef;
     fn LLVMBuildShuffleVector(B: BuilderRef, V1: ValueRef, V2: ValueRef,
                               Mask: ValueRef, Name: sbuf) -> ValueRef;
-    fn LLVMBuildExtractValue(B: BuilderRef, AggVal: ValueRef, Index: uint,
+    fn LLVMBuildExtractValue(B: BuilderRef, AggVal: ValueRef, Index: unsigned,
                              Name: sbuf) -> ValueRef;
     fn LLVMBuildInsertValue(B: BuilderRef, AggVal: ValueRef, EltVal: ValueRef,
-                            Index: uint, Name: sbuf) -> ValueRef;
+                            Index: unsigned, Name: sbuf) -> ValueRef;
 
     fn LLVMBuildIsNull(B: BuilderRef, Val: ValueRef, Name: sbuf) -> ValueRef;
     fn LLVMBuildIsNotNull(B: BuilderRef, Val: ValueRef, Name: sbuf) ->
@@ -738,7 +746,7 @@ native mod llvm {
     fn LLVMIsATerminatorInst(Inst: ValueRef) -> ValueRef;
 
     /** Writes a module to the specified path. Returns 0 on success. */
-    fn LLVMWriteBitcodeToFile(M: ModuleRef, Path: sbuf) -> int;
+    fn LLVMWriteBitcodeToFile(M: ModuleRef, Path: sbuf) -> c_int;
 
     /** Creates target data from a target layout string. */
     fn LLVMCreateTargetData(StringRep: sbuf) -> TargetDataRef;
@@ -746,9 +754,10 @@ native mod llvm {
         references the target data only weakly. */
     fn LLVMAddTargetData(TD: TargetDataRef, PM: PassManagerRef);
     /** Returns the size of a type. FIXME: rv is actually a ULongLong! */
-    fn LLVMStoreSizeOfType(TD: TargetDataRef, Ty: TypeRef) -> uint;
+    fn LLVMStoreSizeOfType(TD: TargetDataRef, Ty: TypeRef) -> unsigned;
     /** Returns the alignment of a type. */
-    fn LLVMPreferredAlignmentOfType(TD: TargetDataRef, Ty: TypeRef) -> uint;
+    fn LLVMPreferredAlignmentOfType(TD: TargetDataRef,
+                                    Ty: TypeRef) -> unsigned;
     /** Disposes target data. */
     fn LLVMDisposeTargetData(TD: TargetDataRef);
 
@@ -801,7 +810,7 @@ native mod llvm {
     fn LLVMPassManagerBuilderCreate() -> PassManagerBuilderRef;
     fn LLVMPassManagerBuilderDispose(PMB: PassManagerBuilderRef);
     fn LLVMPassManagerBuilderSetOptLevel(PMB: PassManagerBuilderRef,
-                                         OptimizationLevel: uint);
+                                         OptimizationLevel: unsigned);
     fn LLVMPassManagerBuilderSetSizeLevel(PMB: PassManagerBuilderRef,
                                           Value: Bool);
     fn LLVMPassManagerBuilderSetDisableUnitAtATime(PMB: PassManagerBuilderRef,
@@ -811,7 +820,7 @@ native mod llvm {
     fn LLVMPassManagerBuilderSetDisableSimplifyLibCalls
         (PMB: PassManagerBuilderRef, Value: Bool);
     fn LLVMPassManagerBuilderUseInlinerWithThreshold
-        (PMB: PassManagerBuilderRef, threshold: uint);
+        (PMB: PassManagerBuilderRef, threshold: unsigned);
     fn LLVMPassManagerBuilderPopulateModulePassManager
         (PMB: PassManagerBuilderRef, PM: PassManagerRef);
 
@@ -844,9 +853,8 @@ native mod llvm {
     fn LLVMMoveToNextSection(SI: SectionIteratorRef);
     /** Returns the current section name. */
     fn LLVMGetSectionName(SI: SectionIteratorRef) -> sbuf;
-    /** Returns the current section size.
-        FIXME: The return value is actually a uint64_t! */
-    fn LLVMGetSectionSize(SI: SectionIteratorRef) -> uint;
+    /** Returns the current section size. */
+    fn LLVMGetSectionSize(SI: SectionIteratorRef) -> ulonglong;
     /** Returns the current section contents as a string buffer. */
     fn LLVMGetSectionContents(SI: SectionIteratorRef) -> sbuf;
 
@@ -857,7 +865,7 @@ native mod llvm {
 
     /* FIXME: The FileType is an enum.*/
     fn LLVMRustWriteOutputFile(PM: PassManagerRef, M: ModuleRef, Triple: sbuf,
-                               Output: sbuf, FileType: int, OptLevel: int,
+                               Output: sbuf, FileType: c_int, OptLevel: c_int,
                                EnableSegmentedStacks: bool);
 
     /** Returns a string describing the last error caused by an LLVMRust*
@@ -871,7 +879,7 @@ native mod llvm {
     fn LLVMRustParseAssemblyFile(Filename: sbuf) -> ModuleRef;
 
     /** FiXME: Hacky adaptor for lack of ULongLong in FFI: */
-    fn LLVMRustConstInt(IntTy: TypeRef, N_hi: uint, N_lo: uint,
+    fn LLVMRustConstInt(IntTy: TypeRef, N_hi: unsigned, N_lo: unsigned,
                         SignExtend: Bool) -> ValueRef;
 
     fn LLVMRustAddPrintModulePass(PM: PassManagerRef, M: ModuleRef,
@@ -886,10 +894,10 @@ native mod llvm {
     fn LLVMStructCreateNamed(C: ContextRef, Name: sbuf) -> TypeRef;
 
     fn LLVMStructSetBody(StructTy: TypeRef, ElementTypes: *TypeRef,
-                         ElementCount: uint, Packed: Bool);
+                         ElementCount: unsigned, Packed: Bool);
 
-    fn LLVMConstNamedStruct(S: TypeRef, ConstantVals: *ValueRef, Count: uint)
-       -> ValueRef;
+    fn LLVMConstNamedStruct(S: TypeRef, ConstantVals: *ValueRef,
+                            Count: unsigned) -> ValueRef;
 
     /** Links LLVM modules together. `Src` is destroyed by this call and
         must never be referenced again. */
@@ -934,7 +942,7 @@ fn type_to_str_inner(names: type_names, outer0: [TypeRef], ty: TypeRef) ->
 
     let outer = outer0 + [ty];
 
-    let kind: int = llvm::LLVMGetTypeKind(ty);
+    let kind: int = llvm::LLVMGetTypeKind(ty) as int;
 
     fn tys_str(names: type_names, outer: [TypeRef], tys: [TypeRef]) -> str {
         let s: str = "";
@@ -963,7 +971,7 @@ fn type_to_str_inner(names: type_names, outer0: [TypeRef], ty: TypeRef) ->
       9 {
         let s = "fn(";
         let out_ty: TypeRef = llvm::LLVMGetReturnType(ty);
-        let n_args: uint = llvm::LLVMCountParamTypes(ty);
+        let n_args = llvm::LLVMCountParamTypes(ty) as uint;
         let args: [TypeRef] = vec::init_elt::<TypeRef>(0 as TypeRef, n_args);
         unsafe {
             llvm::LLVMGetParamTypes(ty, vec::to_ptr(args));
@@ -975,7 +983,7 @@ fn type_to_str_inner(names: type_names, outer0: [TypeRef], ty: TypeRef) ->
       }
       10 {
         let s: str = "{";
-        let n_elts: uint = llvm::LLVMCountStructElementTypes(ty);
+        let n_elts = llvm::LLVMCountStructElementTypes(ty) as uint;
         let elts: [TypeRef] = vec::init_elt::<TypeRef>(0 as TypeRef, n_elts);
         unsafe {
             llvm::LLVMGetStructElementTypes(ty, vec::to_ptr(elts));
@@ -987,7 +995,7 @@ fn type_to_str_inner(names: type_names, outer0: [TypeRef], ty: TypeRef) ->
       11 {
         let el_ty = llvm::LLVMGetElementType(ty);
         ret "[" + type_to_str_inner(names, outer, el_ty) + " x " +
-            uint::str(llvm::LLVMGetArrayLength(ty)) + "]";
+            uint::str(llvm::LLVMGetArrayLength(ty) as uint) + "]";
       }
       12 {
         let i: uint = 0u;
@@ -1009,7 +1017,7 @@ fn type_to_str_inner(names: type_names, outer0: [TypeRef], ty: TypeRef) ->
 }
 
 fn float_width(llt: TypeRef) -> uint {
-    ret alt llvm::LLVMGetTypeKind(llt) {
+    ret alt llvm::LLVMGetTypeKind(llt) as int {
           1 { 32u }
           2 { 64u }
           3 { 80u }
@@ -1019,7 +1027,8 @@ fn float_width(llt: TypeRef) -> uint {
 }
 
 fn fn_ty_param_tys(fn_ty: TypeRef) -> [TypeRef] unsafe {
-    let args = vec::init_elt(0 as TypeRef, llvm::LLVMCountParamTypes(fn_ty));
+    let args = vec::init_elt(0 as TypeRef,
+                             llvm::LLVMCountParamTypes(fn_ty) as uint);
     llvm::LLVMGetParamTypes(fn_ty, vec::to_ptr(args));
     ret args;
 }

--- a/src/comp/metadata/creader.rs
+++ b/src/comp/metadata/creader.rs
@@ -221,7 +221,7 @@ fn get_metadata_section(sess: session::session,
         let name = unsafe { str::from_cstr(name_buf) };
         if str::eq(name, sess.targ_cfg.target_strs.meta_sect_name) {
             let cbuf = llvm::LLVMGetSectionContents(si.llsi);
-            let csz = llvm::LLVMGetSectionSize(si.llsi);
+            let csz = llvm::LLVMGetSectionSize(si.llsi) as uint;
             unsafe {
                 let cvbuf: *u8 = unsafe::reinterpret_cast(cbuf);
                 ret option::some::<@[u8]>(@vec::unsafe::from_buf(cvbuf, csz));

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -45,7 +45,7 @@ const DW_ATE_unsigned_char: int = 0x08;
 
 fn llstr(s: str) -> ValueRef {
     str::as_buf(s, {|sbuf|
-        llvm::LLVMMDString(sbuf, str::byte_len(s) as u32)
+        llvm::LLVMMDString(sbuf, str::byte_len(s) as ctypes::c_uint)
     })
 }
 fn lltag(lltag: int) -> ValueRef {
@@ -62,7 +62,7 @@ fn lli1(bval: bool) -> ValueRef {
 }
 fn llmdnode(elems: [ValueRef]) -> ValueRef unsafe {
     llvm::LLVMMDNode(vec::unsafe::to_ptr(elems),
-                     vec::len(elems) as u32)
+                     vec::len(elems) as ctypes::c_uint)
 }
 fn llunused() -> ValueRef {
     lli32(0x0)

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -45,7 +45,7 @@ const DW_ATE_unsigned_char: int = 0x08;
 
 fn llstr(s: str) -> ValueRef {
     str::as_buf(s, {|sbuf|
-        llvm::LLVMMDString(sbuf, str::byte_len(s))
+        llvm::LLVMMDString(sbuf, str::byte_len(s) as u32)
     })
 }
 fn lltag(lltag: int) -> ValueRef {
@@ -62,7 +62,7 @@ fn lli1(bval: bool) -> ValueRef {
 }
 fn llmdnode(elems: [ValueRef]) -> ValueRef unsafe {
     llvm::LLVMMDNode(vec::unsafe::to_ptr(elems),
-                     vec::len(elems))
+                     vec::len(elems) as u32)
 }
 fn llunused() -> ValueRef {
     lli32(0x0)

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -1070,7 +1070,7 @@ fn set_no_inline(f: ValueRef) {
     llvm::LLVMAddFunctionAttr(f,
                               lib::llvm::LLVMNoInlineAttribute as
                                   lib::llvm::llvm::Attribute,
-                              0u32);
+                              0u as c_uint);
 }
 
 // Tell LLVM to emit the information necessary to unwind the stack for the
@@ -1079,19 +1079,20 @@ fn set_uwtable(f: ValueRef) {
     llvm::LLVMAddFunctionAttr(f,
                               lib::llvm::LLVMUWTableAttribute as
                                   lib::llvm::llvm::Attribute,
-                              0u32);
+                              0u as c_uint);
 }
 
 fn set_always_inline(f: ValueRef) {
     llvm::LLVMAddFunctionAttr(f,
                               lib::llvm::LLVMAlwaysInlineAttribute as
                                   lib::llvm::llvm::Attribute,
-                              0u32);
+                              0u as c_uint);
 }
 
 fn set_custom_stack_growth_fn(f: ValueRef) {
     // TODO: Remove this hack to work around the lack of u64 in the FFI.
-    llvm::LLVMAddFunctionAttr(f, 0 as lib::llvm::llvm::Attribute, 1u32);
+    llvm::LLVMAddFunctionAttr(f, 0 as lib::llvm::llvm::Attribute,
+                              1u as c_uint);
 }
 
 fn set_glue_inlining(cx: @local_ctxt, f: ValueRef, t: ty::t) {
@@ -1178,7 +1179,7 @@ fn make_generic_glue_inner(cx: @local_ctxt, sp: span, t: ty::t,
         } else { T_ptr(T_i8()) };
 
     let ty_param_count = vec::len::<uint>(ty_params);
-    let lltyparams = llvm::LLVMGetParam(llfn, 2u32);
+    let lltyparams = llvm::LLVMGetParam(llfn, 2u as c_uint);
     let load_env_bcx = new_raw_block_ctxt(fcx, fcx.llloadenv);
     let lltydescs = [mutable];
     let p = 0u;
@@ -1193,7 +1194,7 @@ fn make_generic_glue_inner(cx: @local_ctxt, sp: span, t: ty::t,
 
     let bcx = new_top_block_ctxt(fcx);
     let lltop = bcx.llbb;
-    let llrawptr0 = llvm::LLVMGetParam(llfn, 3u32);
+    let llrawptr0 = llvm::LLVMGetParam(llfn, 3u as c_uint);
     let llval0 = BitCast(bcx, llrawptr0, llty);
     helper(bcx, llval0, t);
     finish_fn(fcx, lltop);
@@ -4305,8 +4306,8 @@ fn new_fn_ctxt_w_id(cx: @local_ctxt, sp: span, llfndecl: ValueRef,
     -> @fn_ctxt {
     let llbbs = mk_standard_basic_blocks(llfndecl);
     ret @{llfn: llfndecl,
-          llenv: llvm::LLVMGetParam(llfndecl, 1u32),
-          llretptr: llvm::LLVMGetParam(llfndecl, 0u32),
+          llenv: llvm::LLVMGetParam(llfndecl, 1u as c_uint),
+          llretptr: llvm::LLVMGetParam(llfndecl, 0u as c_uint),
           mutable llstaticallocas: llbbs.sa,
           mutable llloadenv: llbbs.ca,
           mutable llderivedtydescs_first: llbbs.dt,
@@ -4349,7 +4350,7 @@ fn create_llargs_for_fn_args(cx: @fn_ctxt, ty_self: self_arg,
     // Skip the implicit arguments 0, and 1.  TODO: Pull out 2u and define
     // it as a constant, since we're using it in several places in trans this
     // way.
-    let arg_n = 2u32;
+    let arg_n = 2u;
     alt ty_self {
       impl_self(tt) {
         cx.llself = some({v: cx.llenv, t: tt});
@@ -4357,13 +4358,14 @@ fn create_llargs_for_fn_args(cx: @fn_ctxt, ty_self: self_arg,
       no_self. {}
     }
     for tp in ty_params {
-        let lltydesc = llvm::LLVMGetParam(cx.llfn, arg_n), dicts = none;
-        arg_n += 1u32;
+        let lltydesc = llvm::LLVMGetParam(cx.llfn, arg_n as c_uint);
+        let dicts = none;
+        arg_n += 1u;
         for bound in *fcx_tcx(cx).ty_param_bounds.get(tp.id) {
             alt bound {
               ty::bound_iface(_) {
-                let dict = llvm::LLVMGetParam(cx.llfn, arg_n);
-                arg_n += 1u32;
+                let dict = llvm::LLVMGetParam(cx.llfn, arg_n as c_uint);
+                arg_n += 1u;
                 dicts = some(alt dicts {
                     none. { [dict] }
                     some(ds) { ds + [dict] }
@@ -4378,13 +4380,13 @@ fn create_llargs_for_fn_args(cx: @fn_ctxt, ty_self: self_arg,
     // Populate the llargs field of the function context with the ValueRefs
     // that we get from llvm::LLVMGetParam for each argument.
     for arg: ast::arg in args {
-        let llarg = llvm::LLVMGetParam(cx.llfn, arg_n);
+        let llarg = llvm::LLVMGetParam(cx.llfn, arg_n as c_uint);
         assert (llarg as int != 0);
         // Note that this uses local_mem even for things passed by value.
         // copy_args_to_allocas will overwrite the table entry with local_imm
         // before it's actually used.
         cx.llargs.insert(arg.id, local_mem(llarg));
-        arg_n += 1u32;
+        arg_n += 1u;
     }
 }
 
@@ -4807,7 +4809,7 @@ fn trans_native_mod(lcx: @local_ctxt, native_mod: ast::native_mod,
         let fcx = new_fn_ctxt(lcx, span, llshimfn);
         let bcx = new_top_block_ctxt(fcx);
         let lltop = bcx.llbb;
-        let llargbundle = llvm::LLVMGetParam(llshimfn, 0u32);
+        let llargbundle = llvm::LLVMGetParam(llshimfn, 0 as c_uint);
         let i = 0u, n = vec::len(tys.arg_tys);
         let llargvals = [];
         while i < n {
@@ -4857,7 +4859,7 @@ fn trans_native_mod(lcx: @local_ctxt, native_mod: ast::native_mod,
             store_inbounds(bcx, llargval, llargbundle, [0, i as int]);
             i += 1u;
         }
-        let llretptr = llvm::LLVMGetParam(llwrapfn, 0u32);
+        let llretptr = llvm::LLVMGetParam(llwrapfn, 0 as c_uint);
         store_inbounds(bcx, llretptr, llargbundle, [0, n as int]);
 
         // Create call itself.
@@ -5042,10 +5044,10 @@ fn create_main_wrapper(ccx: @crate_ctxt, sp: span, main_llfn: ValueRef,
         let bcx = new_top_block_ctxt(fcx);
         let lltop = bcx.llbb;
 
-        let lloutputarg = llvm::LLVMGetParam(llfdecl, 0u32);
-        let llenvarg = llvm::LLVMGetParam(llfdecl, 1u32);
+        let lloutputarg = llvm::LLVMGetParam(llfdecl, 0 as c_uint);
+        let llenvarg = llvm::LLVMGetParam(llfdecl, 1 as c_uint);
         let args = [lloutputarg, llenvarg];
-        if takes_argv { args += [llvm::LLVMGetParam(llfdecl, 2u32)]; }
+        if takes_argv { args += [llvm::LLVMGetParam(llfdecl, 2 as c_uint)]; }
         Call(bcx, main_llfn, args);
         build_return(bcx);
 
@@ -5076,8 +5078,8 @@ fn create_main_wrapper(ccx: @crate_ctxt, sp: span, main_llfn: ValueRef,
         let start = str::as_buf("rust_start", {|buf|
             llvm::LLVMAddGlobal(ccx.llmod, start_ty, buf)
         });
-        let args = [rust_main, llvm::LLVMGetParam(llfn, 0u32),
-                    llvm::LLVMGetParam(llfn, 1u32), crate_map];
+        let args = [rust_main, llvm::LLVMGetParam(llfn, 0 as c_uint),
+                    llvm::LLVMGetParam(llfn, 1 as c_uint), crate_map];
         let result = unsafe {
             llvm::LLVMBuildCall(bld, start, vec::to_ptr(args),
                                 vec::len(args) as c_uint, noname())

--- a/src/comp/middle/trans.rs
+++ b/src/comp/middle/trans.rs
@@ -13,6 +13,7 @@
 //     but many TypeRefs correspond to one ty::t; for instance, tup(int, int,
 //     int) and rec(x=int, y=int, z=int) will have the same TypeRef.
 
+import core::ctypes::c_uint;
 import std::{map, time};
 import std::map::hashmap;
 import std::map::{new_int_hash, new_str_hash};
@@ -291,11 +292,12 @@ fn log_fn_time(ccx: @crate_ctxt, name: str, start: time::timeval,
 }
 
 
-fn decl_fn(llmod: ModuleRef, name: str, cc: uint, llty: TypeRef) -> ValueRef {
+fn decl_fn(llmod: ModuleRef, name: str, cc: uint, llty: TypeRef) ->
+    ValueRef {
     let llfn: ValueRef =
         str::as_buf(name, {|buf|
             llvm::LLVMGetOrInsertFunction(llmod, buf, llty) });
-    llvm::LLVMSetFunctionCallConv(llfn, cc);
+    llvm::LLVMSetFunctionCallConv(llfn, cc as c_uint);
     ret llfn;
 }
 
@@ -338,7 +340,8 @@ fn get_simple_extern_fn(cx: @block_ctxt,
     let inputs = vec::init_elt::<TypeRef>(ccx.int_type, n_args as uint);
     let output = ccx.int_type;
     let t = T_fn(inputs, output);
-    ret get_extern_fn(externs, llmod, name, lib::llvm::LLVMCCallConv, t);
+    ret get_extern_fn(externs, llmod, name,
+                      lib::llvm::LLVMCCallConv, t);
 }
 
 fn trans_native_call(cx: @block_ctxt, externs: hashmap<str, ValueRef>,
@@ -389,12 +392,12 @@ fn align_to(cx: @block_ctxt, off: ValueRef, align: ValueRef) -> ValueRef {
 
 // Returns the real size of the given type for the current target.
 fn llsize_of_real(cx: @crate_ctxt, t: TypeRef) -> uint {
-    ret llvm::LLVMStoreSizeOfType(cx.td.lltd, t);
+    ret llvm::LLVMStoreSizeOfType(cx.td.lltd, t) as uint;
 }
 
 // Returns the real alignment of the given type for the current target.
 fn llalign_of_real(cx: @crate_ctxt, t: TypeRef) -> uint {
-    ret llvm::LLVMPreferredAlignmentOfType(cx.td.lltd, t);
+    ret llvm::LLVMPreferredAlignmentOfType(cx.td.lltd, t) as uint;
 }
 
 fn llsize_of(cx: @crate_ctxt, t: TypeRef) -> ValueRef {
@@ -1067,7 +1070,7 @@ fn set_no_inline(f: ValueRef) {
     llvm::LLVMAddFunctionAttr(f,
                               lib::llvm::LLVMNoInlineAttribute as
                                   lib::llvm::llvm::Attribute,
-                              0u);
+                              0u32);
 }
 
 // Tell LLVM to emit the information necessary to unwind the stack for the
@@ -1076,19 +1079,19 @@ fn set_uwtable(f: ValueRef) {
     llvm::LLVMAddFunctionAttr(f,
                               lib::llvm::LLVMUWTableAttribute as
                                   lib::llvm::llvm::Attribute,
-                              0u);
+                              0u32);
 }
 
 fn set_always_inline(f: ValueRef) {
     llvm::LLVMAddFunctionAttr(f,
                               lib::llvm::LLVMAlwaysInlineAttribute as
                                   lib::llvm::llvm::Attribute,
-                              0u);
+                              0u32);
 }
 
 fn set_custom_stack_growth_fn(f: ValueRef) {
     // TODO: Remove this hack to work around the lack of u64 in the FFI.
-    llvm::LLVMAddFunctionAttr(f, 0 as lib::llvm::llvm::Attribute, 1u);
+    llvm::LLVMAddFunctionAttr(f, 0 as lib::llvm::llvm::Attribute, 1u32);
 }
 
 fn set_glue_inlining(cx: @local_ctxt, f: ValueRef, t: ty::t) {
@@ -1175,7 +1178,7 @@ fn make_generic_glue_inner(cx: @local_ctxt, sp: span, t: ty::t,
         } else { T_ptr(T_i8()) };
 
     let ty_param_count = vec::len::<uint>(ty_params);
-    let lltyparams = llvm::LLVMGetParam(llfn, 2u);
+    let lltyparams = llvm::LLVMGetParam(llfn, 2u32);
     let load_env_bcx = new_raw_block_ctxt(fcx, fcx.llloadenv);
     let lltydescs = [mutable];
     let p = 0u;
@@ -1190,7 +1193,7 @@ fn make_generic_glue_inner(cx: @local_ctxt, sp: span, t: ty::t,
 
     let bcx = new_top_block_ctxt(fcx);
     let lltop = bcx.llbb;
-    let llrawptr0 = llvm::LLVMGetParam(llfn, 3u);
+    let llrawptr0 = llvm::LLVMGetParam(llfn, 3u32);
     let llval0 = BitCast(bcx, llrawptr0, llty);
     helper(bcx, llval0, t);
     finish_fn(fcx, lltop);
@@ -4302,8 +4305,8 @@ fn new_fn_ctxt_w_id(cx: @local_ctxt, sp: span, llfndecl: ValueRef,
     -> @fn_ctxt {
     let llbbs = mk_standard_basic_blocks(llfndecl);
     ret @{llfn: llfndecl,
-          llenv: llvm::LLVMGetParam(llfndecl, 1u),
-          llretptr: llvm::LLVMGetParam(llfndecl, 0u),
+          llenv: llvm::LLVMGetParam(llfndecl, 1u32),
+          llretptr: llvm::LLVMGetParam(llfndecl, 0u32),
           mutable llstaticallocas: llbbs.sa,
           mutable llloadenv: llbbs.ca,
           mutable llderivedtydescs_first: llbbs.dt,
@@ -4346,7 +4349,7 @@ fn create_llargs_for_fn_args(cx: @fn_ctxt, ty_self: self_arg,
     // Skip the implicit arguments 0, and 1.  TODO: Pull out 2u and define
     // it as a constant, since we're using it in several places in trans this
     // way.
-    let arg_n = 2u;
+    let arg_n = 2u32;
     alt ty_self {
       impl_self(tt) {
         cx.llself = some({v: cx.llenv, t: tt});
@@ -4355,12 +4358,12 @@ fn create_llargs_for_fn_args(cx: @fn_ctxt, ty_self: self_arg,
     }
     for tp in ty_params {
         let lltydesc = llvm::LLVMGetParam(cx.llfn, arg_n), dicts = none;
-        arg_n += 1u;
+        arg_n += 1u32;
         for bound in *fcx_tcx(cx).ty_param_bounds.get(tp.id) {
             alt bound {
               ty::bound_iface(_) {
                 let dict = llvm::LLVMGetParam(cx.llfn, arg_n);
-                arg_n += 1u;
+                arg_n += 1u32;
                 dicts = some(alt dicts {
                     none. { [dict] }
                     some(ds) { ds + [dict] }
@@ -4381,7 +4384,7 @@ fn create_llargs_for_fn_args(cx: @fn_ctxt, ty_self: self_arg,
         // copy_args_to_allocas will overwrite the table entry with local_imm
         // before it's actually used.
         cx.llargs.insert(arg.id, local_mem(llarg));
-        arg_n += 1u;
+        arg_n += 1u32;
     }
 }
 
@@ -4804,7 +4807,7 @@ fn trans_native_mod(lcx: @local_ctxt, native_mod: ast::native_mod,
         let fcx = new_fn_ctxt(lcx, span, llshimfn);
         let bcx = new_top_block_ctxt(fcx);
         let lltop = bcx.llbb;
-        let llargbundle = llvm::LLVMGetParam(llshimfn, 0u);
+        let llargbundle = llvm::LLVMGetParam(llshimfn, 0u32);
         let i = 0u, n = vec::len(tys.arg_tys);
         let llargvals = [];
         while i < n {
@@ -4814,7 +4817,8 @@ fn trans_native_mod(lcx: @local_ctxt, native_mod: ast::native_mod,
         }
 
         // Create the call itself and store the return value:
-        let llretval = CallWithConv(bcx, llbasefn, llargvals, cc); // r
+        let llretval = CallWithConv(bcx, llbasefn,
+                                    llargvals, cc as c_uint); // r
         if tys.ret_def {
             // R** llretptr = &args->r;
             let llretptr = GEPi(bcx, llargbundle, [0, n as int]);
@@ -4848,11 +4852,12 @@ fn trans_native_mod(lcx: @local_ctxt, native_mod: ast::native_mod,
         let i = 0u, n = vec::len(tys.arg_tys);
         let implicit_args = 2u + num_tps; // ret + env
         while i < n {
-            let llargval = llvm::LLVMGetParam(llwrapfn, i + implicit_args);
+            let llargval = llvm::LLVMGetParam(llwrapfn,
+                                              (i + implicit_args) as c_uint);
             store_inbounds(bcx, llargval, llargbundle, [0, i as int]);
             i += 1u;
         }
-        let llretptr = llvm::LLVMGetParam(llwrapfn, 0u);
+        let llretptr = llvm::LLVMGetParam(llwrapfn, 0u32);
         store_inbounds(bcx, llretptr, llargbundle, [0, n as int]);
 
         // Create call itself.
@@ -4865,7 +4870,7 @@ fn trans_native_mod(lcx: @local_ctxt, native_mod: ast::native_mod,
     }
 
     let ccx = lcx_ccx(lcx);
-    let cc: uint = lib::llvm::LLVMCCallConv;
+    let cc = lib::llvm::LLVMCCallConv;
     alt abi {
       ast::native_abi_rust_intrinsic. { ret; }
       ast::native_abi_cdecl. { cc = lib::llvm::LLVMCCallConv; }
@@ -5037,10 +5042,10 @@ fn create_main_wrapper(ccx: @crate_ctxt, sp: span, main_llfn: ValueRef,
         let bcx = new_top_block_ctxt(fcx);
         let lltop = bcx.llbb;
 
-        let lloutputarg = llvm::LLVMGetParam(llfdecl, 0u);
-        let llenvarg = llvm::LLVMGetParam(llfdecl, 1u);
+        let lloutputarg = llvm::LLVMGetParam(llfdecl, 0u32);
+        let llenvarg = llvm::LLVMGetParam(llfdecl, 1u32);
         let args = [lloutputarg, llenvarg];
-        if takes_argv { args += [llvm::LLVMGetParam(llfdecl, 2u)]; }
+        if takes_argv { args += [llvm::LLVMGetParam(llfdecl, 2u32)]; }
         Call(bcx, main_llfn, args);
         build_return(bcx);
 
@@ -5071,11 +5076,11 @@ fn create_main_wrapper(ccx: @crate_ctxt, sp: span, main_llfn: ValueRef,
         let start = str::as_buf("rust_start", {|buf|
             llvm::LLVMAddGlobal(ccx.llmod, start_ty, buf)
         });
-        let args = [rust_main, llvm::LLVMGetParam(llfn, 0u),
-                    llvm::LLVMGetParam(llfn, 1u), crate_map];
+        let args = [rust_main, llvm::LLVMGetParam(llfn, 0u32),
+                    llvm::LLVMGetParam(llfn, 1u32), crate_map];
         let result = unsafe {
             llvm::LLVMBuildCall(bld, start, vec::to_ptr(args),
-                                vec::len(args), noname())
+                                vec::len(args) as c_uint, noname())
         };
         llvm::LLVMBuildRet(bld, result);
     }

--- a/src/comp/middle/trans_build.rs
+++ b/src/comp/middle/trans_build.rs
@@ -1,5 +1,5 @@
 import core::{vec, str};
-import core::ctypes::c_uint;
+import core::ctypes::{c_uint, c_int};
 import str::sbuf;
 import lib::llvm::llvm;
 import syntax::codemap;
@@ -311,7 +311,7 @@ fn Load(cx: @block_ctxt, PointerVal: ValueRef) -> ValueRef {
     let ccx = cx.fcx.lcx.ccx;
     if cx.unreachable {
         let ty = val_ty(PointerVal);
-        let eltty = if llvm::LLVMGetTypeKind(ty) == 11i32 {
+        let eltty = if llvm::LLVMGetTypeKind(ty) == 11 as c_int {
             llvm::LLVMGetElementType(ty) } else { ccx.int_type };
         ret llvm::LLVMGetUndef(eltty);
     }
@@ -500,14 +500,14 @@ fn AddIncomingToPhi(phi: ValueRef, val: ValueRef, bb: BasicBlockRef) {
     unsafe {
         let valptr = unsafe::reinterpret_cast(ptr::addr_of(val));
         let bbptr = unsafe::reinterpret_cast(ptr::addr_of(bb));
-        llvm::LLVMAddIncoming(phi, valptr, bbptr, 1u32);
+        llvm::LLVMAddIncoming(phi, valptr, bbptr, 1 as c_uint);
     }
 }
 
 fn _UndefReturn(cx: @block_ctxt, Fn: ValueRef) -> ValueRef {
     let ccx = cx.fcx.lcx.ccx;
     let ty = val_ty(Fn);
-    let retty = if llvm::LLVMGetTypeKind(ty) == 8i32 {
+    let retty = if llvm::LLVMGetTypeKind(ty) == 8 as c_int {
         llvm::LLVMGetReturnType(ty) } else { ccx.int_type };
     ret llvm::LLVMGetUndef(retty);
 }

--- a/src/comp/middle/trans_closure.rs
+++ b/src/comp/middle/trans_closure.rs
@@ -918,7 +918,7 @@ fn trans_bind_thunk(cx: @local_ctxt,
         fcx.lltyparams += [{desc: dsc, dicts: dicts}];
     }
 
-    let a: uint = 2u; // retptr, env come first
+    let a: u32 = 2u32; // retptr, env come first
     let b: int = starting_idx;
     let outgoing_arg_index: uint = 0u;
     let llout_arg_tys: [TypeRef] =
@@ -960,7 +960,7 @@ fn trans_bind_thunk(cx: @local_ctxt,
                 arg = PointerCast(bcx, arg, llout_arg_ty);
             }
             llargs += [arg];
-            a += 1u;
+            a += 1u32;
           }
         }
         outgoing_arg_index += 1u;

--- a/src/comp/middle/trans_closure.rs
+++ b/src/comp/middle/trans_closure.rs
@@ -1,3 +1,4 @@
+import core::ctypes::c_uint;
 import syntax::ast;
 import syntax::ast_util;
 import lib::llvm::llvm;
@@ -918,7 +919,7 @@ fn trans_bind_thunk(cx: @local_ctxt,
         fcx.lltyparams += [{desc: dsc, dicts: dicts}];
     }
 
-    let a: u32 = 2u32; // retptr, env come first
+    let a: uint = 2u; // retptr, env come first
     let b: int = starting_idx;
     let outgoing_arg_index: uint = 0u;
     let llout_arg_tys: [TypeRef] =
@@ -955,12 +956,12 @@ fn trans_bind_thunk(cx: @local_ctxt,
 
           // Arg will be provided when the thunk is invoked.
           none. {
-            let arg: ValueRef = llvm::LLVMGetParam(llthunk, a);
+            let arg: ValueRef = llvm::LLVMGetParam(llthunk, a as c_uint);
             if ty::type_contains_params(cx.ccx.tcx, out_arg.ty) {
                 arg = PointerCast(bcx, arg, llout_arg_ty);
             }
             llargs += [arg];
-            a += 1u32;
+            a += 1u;
           }
         }
         outgoing_arg_index += 1u;

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -2678,6 +2678,25 @@ fn check_method(ccx: @crate_ctxt, method: @ast::method) {
     check_fn(ccx, ast::proto_bare, method.decl, method.body, method.id, none);
 }
 
+fn check_native_fn(ccx: @crate_ctxt, decl: ast::fn_decl) {
+    let tys = vec::map(decl.inputs) {|a| a.ty };
+    for ty in (tys + [decl.output]) {
+        alt ty.node {
+          ast::ty_int(ast::ty_i.) {
+            ccx.tcx.sess.span_warn(
+                ty.span, "found rust type `int` in native module, while " +
+                         "ctypes::c_int or ctypes::long should be used");
+          }
+          ast::ty_uint(ast::ty_u.) {
+            ccx.tcx.sess.span_warn(
+                ty.span, "found rust type `uint` in native module, while " +
+                         "ctypes::c_uint or ctypes::ulong should be used");
+          }
+          _ { }
+        }
+    }
+}
+
 fn check_item(ccx: @crate_ctxt, it: @ast::item) {
     alt it.node {
       ast::item_const(_, e) { check_const(ccx, it.span, e, it.id); }
@@ -2687,6 +2706,16 @@ fn check_item(ccx: @crate_ctxt, it: @ast::item) {
       }
       ast::item_res(decl, tps, body, dtor_id, _) {
         check_fn(ccx, ast::proto_bare, decl, body, dtor_id, none);
+      }
+      ast::item_native_mod(nmod) {
+        for ni in nmod.items {
+            alt ni.node {
+              ast::native_item_fn(decl, tps) {
+                check_native_fn(ccx, decl);
+              }
+              _ { }
+            }
+        }
       }
       ast::item_impl(tps, _, ty, ms) {
         ccx.self_infos += [self_impl(ast_ty_to_ty(ccx.tcx, m_check, ty))];

--- a/src/libcore/comm.rs
+++ b/src/libcore/comm.rs
@@ -40,7 +40,7 @@ native mod rustrt {
                             target_task: task::task, target_port: port_id,
                             data: T) -> ctypes::uintptr_t;
 
-    fn new_port(unit_sz: uint) -> *rust_port;
+    fn new_port(unit_sz: ctypes::size_t) -> *rust_port;
     fn del_port(po: *rust_port);
     fn rust_port_detach(po: *rust_port);
     fn get_port_id(po: *rust_port) -> port_id;

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -6,7 +6,7 @@ Unsafe pointer utility functions
 #[abi = "rust-intrinsic"]
 native mod rusti {
     fn addr_of<T>(val: T) -> *T;
-    fn ptr_offset<T>(ptr: *T, count: uint) -> *T;
+    fn ptr_offset<T>(ptr: *T, count: ctypes::uintptr_t) -> *T;
 }
 
 /*

--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -16,12 +16,12 @@ native mod rustrt {
     // available outside this crate. Otherwise it's
     // visible-in-crate, but not re-exported.
     fn last_os_error() -> str;
-    fn refcount<T>(t: @T) -> uint;
+    fn refcount<T>(t: @T) -> ctypes::intptr_t;
     fn do_gc();
     fn unsupervise();
     fn shape_log_str<T>(t: *sys::type_desc, data: T) -> str;
-    fn rust_set_exit_status(code: int);
-    fn set_min_stack(size: uint);
+    fn rust_set_exit_status(code: ctypes::intptr_t);
+    fn set_min_stack(size: ctypes::uintptr_t);
 }
 
 #[abi = "rust-intrinsic"]
@@ -103,7 +103,7 @@ fn log_str<T>(t: T) -> str {
             with the default failure status."
 )]
 fn set_exit_status(code: int) {
-    rustrt::rust_set_exit_status(code);
+    rustrt::rust_set_exit_status(code as ctypes::intptr_t);
 }
 
 // FIXME: #1495 - This shouldn't exist

--- a/src/libcore/task.rs
+++ b/src/libcore/task.rs
@@ -55,7 +55,7 @@ export try;
 #[abi = "rust-intrinsic"]
 native mod rusti {
     // these must run on the Rust stack so that they can swap stacks etc:
-    fn task_sleep(task: *rust_task, time_in_us: uint, &killed: bool);
+    fn task_sleep(task: *rust_task, time_in_us: c::size_t, &killed: bool);
 }
 
 type rust_closure = {

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -8,17 +8,17 @@ import ptr::addr_of;
 
 #[abi = "rust-intrinsic"]
 native mod rusti {
-    fn vec_len<T>(&&v: [const T]) -> uint;
+    fn vec_len<T>(&&v: [const T]) -> ctypes::size_t;
 }
 
 #[abi = "cdecl"]
 native mod rustrt {
     fn vec_reserve_shared<T>(t: *sys::type_desc,
                              &v: [const T],
-                             n: uint);
+                             n: ctypes::size_t);
     fn vec_from_buf_shared<T>(t: *sys::type_desc,
                               ptr: *T,
-                              count: uint) -> [T];
+                              count: ctypes::size_t) -> [T];
 }
 
 /*

--- a/src/libstd/dbg.rs
+++ b/src/libstd/dbg.rs
@@ -14,7 +14,8 @@ native mod rustrt {
     fn debug_opaque<T>(td: *sys::type_desc, x: T);
     fn debug_box<T>(td: *sys::type_desc, x: @T);
     fn debug_tag<T>(td: *sys::type_desc, x: T);
-    fn debug_obj<T>(td: *sys::type_desc, x: T, nmethods: uint, nbytes: uint);
+    fn debug_obj<T>(td: *sys::type_desc, x: T,
+                    nmethods: ctypes::size_t, nbytes: ctypes::size_t);
     fn debug_fn<T>(td: *sys::type_desc, x: T);
     fn debug_ptrcast<T, U>(td: *sys::type_desc, x: @T) -> @U;
 }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -120,7 +120,9 @@ Function: path_is_dir
 Indicates whether a path represents a directory.
 */
 fn path_is_dir(p: path) -> bool {
-    ret str::as_buf(p, {|buf| rustrt::rust_path_is_dir(buf) != 0i32 });
+    ret str::as_buf(p, {|buf|
+        rustrt::rust_path_is_dir(buf) != 0 as ctypes::c_int
+    });
 }
 
 /*
@@ -129,7 +131,9 @@ Function: path_exists
 Indicates whether a path exists.
 */
 fn path_exists(p: path) -> bool {
-    ret str::as_buf(p, {|buf| rustrt::rust_path_exists(buf) != 0i32 });
+    ret str::as_buf(p, {|buf|
+        rustrt::rust_path_exists(buf) != 0 as ctypes::c_int
+    });
 }
 
 /*

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -13,8 +13,8 @@ import os_fs;
 
 #[abi = "cdecl"]
 native mod rustrt {
-    fn rust_path_is_dir(path: str::sbuf) -> int;
-    fn rust_path_exists(path: str::sbuf) -> int;
+    fn rust_path_is_dir(path: str::sbuf) -> ctypes::c_int;
+    fn rust_path_exists(path: str::sbuf) -> ctypes::c_int;
 }
 
 /*
@@ -120,7 +120,7 @@ Function: path_is_dir
 Indicates whether a path represents a directory.
 */
 fn path_is_dir(p: path) -> bool {
-    ret str::as_buf(p, {|buf| rustrt::rust_path_is_dir(buf) != 0 });
+    ret str::as_buf(p, {|buf| rustrt::rust_path_is_dir(buf) != 0i32 });
 }
 
 /*
@@ -129,7 +129,7 @@ Function: path_exists
 Indicates whether a path exists.
 */
 fn path_exists(p: path) -> bool {
-    ret str::as_buf(p, {|buf| rustrt::rust_path_exists(buf) != 0 });
+    ret str::as_buf(p, {|buf| rustrt::rust_path_exists(buf) != 0i32 });
 }
 
 /*

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -5,6 +5,7 @@
 
 import result::{ok, err};
 import io::writer_util;
+import core::ctypes;
 
 export test_name;
 export test_fn;
@@ -28,7 +29,7 @@ export joinable;
 
 #[abi = "cdecl"]
 native mod rustrt {
-    fn sched_threads() -> uint;
+    fn sched_threads() -> ctypes::size_t;
 }
 
 // The name of a test. By convention this follows the rules for rust

--- a/src/test/compile-fail/warn-native-int-types.rs
+++ b/src/test/compile-fail/warn-native-int-types.rs
@@ -1,0 +1,9 @@
+//error-pattern:ctypes::c_int or ctypes::long should be used
+native mod xx {
+  fn strlen(str: *u8) -> uint;
+  fn foo(x: int, y: uint);
+}
+
+fn main() {
+  "let compile fail to verify warning message" = 999;
+}


### PR DESCRIPTION
Please refer discussion of #1403.

Commit 37a2985 implements the check;
Commit 8926d5e fixes all occurrences in the current code base.

Is warn enough, or should we report errors?

I may not have used proper English for the warning message. Please help me correct that, if so. :)
