### PR TITLE
build: Stop building stage3 on normal test cycles

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -397,7 +397,7 @@ rustc-stage3: rustc-stage3-H-$(CFG_HOST_TRIPLE)
 define DEF_RUSTC_TARGET
 # $(1) == architecture
 
-rustc-H-$(1): rustc-stage3-H-$(1)
+rustc-H-$(1): rustc-stage2-H-$(1)
 endef
 
 $(foreach host,$(CFG_TARGET_TRIPLES),			\

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -14,7 +14,7 @@ else
 endif
 
 # The stage we install from
-ISTAGE = 3
+ISTAGE = 2
 
 PREFIX_ROOT = $(CFG_PREFIX)
 PREFIX_BIN = $(PREFIX_ROOT)/bin
@@ -56,6 +56,7 @@ install: all install-host install-targets
 
 # Shorthand for build/stageN/bin
 HB = $(HBIN$(ISTAGE)_H_$(CFG_HOST_TRIPLE))
+HB3 = $(HBIN3_H_$(CFG_HOST_TRIPLE))
 # Shorthand for build/stageN/lib
 HL = $(HLIB$(ISTAGE)_H_$(CFG_HOST_TRIPLE))
 # Shorthand for the prefix bin directory
@@ -67,9 +68,9 @@ install-host: $(SREQ$(ISTAGE)_T_$(CFG_HOST_TRIPLE)_H_$(CFG_HOST_TRIPLE))
 	$(Q)mkdir -p $(PREFIX_BIN)
 	$(Q)mkdir -p $(PREFIX_LIB)
 	$(Q)mkdir -p $(PREFIX_ROOT)/share/man/man1
-	$(Q)$(call INSTALL,$(HB),$(PHB),rustc$(X))
-	$(Q)$(call INSTALL,$(HB),$(PHB),cargo$(X))
-	$(Q)$(call INSTALL,$(HB),$(PHB),rustdoc$(X))
+	$(Q)$(call INSTALL,$(HB3),$(PHB),rustc$(X))
+	$(Q)$(call INSTALL,$(HB3),$(PHB),cargo$(X))
+	$(Q)$(call INSTALL,$(HB3),$(PHB),rustdoc$(X))
 	$(Q)$(call INSTALL,$(HL),$(PHL),$(CFG_RUNTIME))
 	$(Q)$(call INSTALL_LIB,$(HL),$(PHL),$(CORELIB_GLOB))
 	$(Q)$(call INSTALL_LIB,$(HL),$(PHL),$(STDLIB_GLOB))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -70,7 +70,7 @@ endif
 # Main test targets
 ######################################################################
 
-check: all tidy check-stage3 \
+check: all tidy check-stage2 \
 
 check-full: all tidy check-stage1 check-stage2 check-stage3 \
 


### PR DESCRIPTION
Issue #1419

I added a var `HB3`, shorthand to `build/stage3/bin` to install compiled tools. This's ugly, but simpler than locating to the right target of stage2/bin.

Passed all bots.
