### PR TITLE
Additions re: Ubuntu PPA for Rust

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -493,6 +493,12 @@ ifneq ($(findstring clean,$(MAKECMDGOALS)),)
 endif
 
 ifneq ($(findstring install,$(MAKECMDGOALS)),)
+  ifdef DESTDIR
+    CFG_INFO := $(info cfg: setting CFG_PREFIX via DESTDIR, $(DESTDIR))
+    CFG_PREFIX:=$(DESTDIR)
+    export CFG_PREFIX
+  endif
+
   CFG_INFO := $(info cfg: including install rules)
   include $(CFG_SRC_DIR)/mk/install.mk
 endif

--- a/src/etc/latest-unix-snaps.py
+++ b/src/etc/latest-unix-snaps.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import os, tarfile, hashlib, re, shutil, sys
+from snapshot import *
+
+f = open(snapshotfile)
+date = None
+rev = None
+platform = None
+snap = None
+i = 0
+
+newestSet = {}
+
+
+for line in f.readlines():
+    i += 1
+    parsed = parse_line(i, line)
+    if (not parsed): continue
+
+    if parsed["type"] == "snapshot":
+        if (len(newestSet) == 0 or parsed["date"] > newestSet["date"]):
+            newestSet["date"] = parsed["date"] 
+            newestSet["rev"] = parsed["rev"] 
+            newestSet["files"] = []
+            addingMode = True
+        else:
+            addingMode = False
+
+    elif addingMode == True and parsed["type"] == "file":
+        tux = re.compile("linux", re.IGNORECASE)
+        if (tux.match(parsed["platform"]) != None):
+           ff = {}
+           ff["platform"] = parsed["platform"]
+           ff["hash"] = parsed["hash"]
+           newestSet["files"] += [ff]
+
+
+def download_new_file (date, rev, platform, hsh):
+        snap = full_snapshot_name(date, rev, platform, hsh)
+        dl = os.path.join(download_dir_base, snap)
+        url = download_url_base + "/" + snap
+        if (not os.path.exists(dl)):
+            print("downloading " + url)
+            get_url_to_file(url, dl)
+        if (snap_filename_hash_part(snap) == hash_file(dl)):
+            print("got download with ok hash")
+        else:
+            raise Exception("bad hash on download")
+
+for ff in newestSet["files"]:
+   download_new_file (newestSet["date"], newestSet["rev"], ff["platform"], ff["hash"])
+
+


### PR DESCRIPTION
The first change lets DESTDIR be used with `make install` to set the installation destination independently, as is required in Launchpad's build process.  See http://www.gnu.org/prep/standards/html_node/DESTDIR.html and http://www.debian.org/doc/manuals/maint-guide/modify.en.html#id459110.

(Note that there is a possibility of some conflict happening regarding src/comp/back/rpath.rs, which relies on the prefix as a fallback path.)

The second adds a Python script to src/etc which can be used to grab the latest snapshots.
$ mkdir dl
$ CFG_SRC_DIR=. python src/etc/latest-unix-snaps.py

Cheers,
Kevin
