### PR TITLE
Update the keyword lists in rust.md and syntax.vim

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -218,16 +218,17 @@ alt any as assert
 be bind block bool break
 char check claim const cont
 do
-else export
+else enum export
 f32 f64 fail false float fn for
 i16 i32 i64 i8 if iface impl import in int
 let log
 mod mutable
 native note
+of
 prove pure
 resource ret
 self str syntax
-tag true type
+true type
 u16 u32 u64 u8 uint unchecked unsafe use
 vec
 while

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -14,15 +14,18 @@ if !exists("main_syntax")
   let main_syntax='rust'
 endif
 
-syn keyword   rustKeyword     alt as assert auth be bind block break chan
+syn keyword   rustKeyword     alt as assert be bind block break
 syn keyword   rustKeyword     check claim cont const copy do else enum export fail
 syn keyword   rustKeyword     fn for if iface impl import in inline lambda let log
-syn keyword   rustKeyword     log_err mod mutable native note of prove pure
-syn keyword   rustKeyword     resource ret self tag type unsafe use while
-syn keyword   rustKeyword     with
+syn keyword   rustKeyword     mod mutable native note of prove pure
+syn keyword   rustKeyword     resource ret self syntax type unchecked
+syn keyword   rustKeyword     unsafe use while with
+
+" Reserved words
+syn keyword   rustKeyword     m32 m64 m128 f80 f16 f128 class trait
 
 syn keyword   rustType        any int uint float char bool u8 u16 u32 u64 f32
-syn keyword   rustType        f64 i8 i16 i32 i64 str task
+syn keyword   rustType        f64 i8 i16 i32 i64 str
 
 syn keyword   rustBoolean     true false
 


### PR DESCRIPTION
Add new keywords "enum" and "of", and remove old keywords "auth", "chan",
"log_err", "tag", and "task".

Also add reserved words to the syntax file, to help Vim users avoid using them
as identifiers.
