### PR TITLE
doc: Fix minor typo in tutorial

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -898,7 +898,7 @@ that callers have the flexibility to pass whatever they want.
 ~~~~
 ## xfail-test
 fn call_twice(f: fn()) { f(); f(); }
-call_twice({|| "I am a stack closure; });
+call_twice({|| "I am a stack closure"; });
 call_twice(fn@() { "I am a boxed closure"; });
 fn bare_function() { "I am a plain function"; }
 call_twice(bare_function);


### PR DESCRIPTION
Commit 1304e introduced a mismatched quote. This adds a matching quote, making tutorial code properly highlighted.
