### PR TITLE
Fixed a missing double quote in an example in the tutorial

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -898,7 +898,7 @@ that callers have the flexibility to pass whatever they want.
 ~~~~
 ## xfail-test
 fn call_twice(f: fn()) { f(); f(); }
-call_twice({|| "I am a stack closure; });
+call_twice({|| "I am a stack closure"; });
 call_twice(fn@() { "I am a boxed closure"; });
 fn bare_function() { "I am a plain function"; }
 call_twice(bare_function);


### PR DESCRIPTION
There was a missing double quote in the example for section 5.1.2 (Closure compatibility) of the tutorial
