### PR TITLE
[cargo] detect libs properly

### DIFF
--- a/src/cargo/cargo.rs
+++ b/src/cargo/cargo.rs
@@ -367,12 +367,8 @@ fn test_one_crate(_c: cargo, _path: str, cf: str, _p: pkg) {
         ret;
     }
     let new = fs::list_dir(buildpath);
-    let exec_suffix = os::exec_suffix();
     for ct: str in new {
-        if (exec_suffix != "" && str::ends_with(ct, exec_suffix)) ||
-            (exec_suffix == "" && !str::starts_with(ct, "./lib")) {
-            run::run_program(ct, []);
-        }
+        run::run_program(ct, []);
     }
 }
 
@@ -389,7 +385,8 @@ fn install_one_crate(c: cargo, _path: str, cf: str, _p: pkg) {
     let exec_suffix = os::exec_suffix();
     for ct: str in new {
         if (exec_suffix != "" && str::ends_with(ct, exec_suffix)) ||
-            (exec_suffix == "" && !str::starts_with(ct, "./lib")) {
+            (exec_suffix == "" && !str::starts_with(fs::basename(ct),
+                                                    "lib")) {
             #debug("  bin: %s", ct);
             // FIXME: need libstd fs::copy or something
             run::run_program("cp", [ct, c.bindir]);


### PR DESCRIPTION
The change to do build and test in different directories broke library
detection.
