### PR TITLE
Added `src/etc/vim/ftdetect/rust.vim` for vim filetype detection.

### DIFF
--- a/src/etc/vim/ftdetect/rust.vim
+++ b/src/etc/vim/ftdetect/rust.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.rs    set filetype=rust


### PR DESCRIPTION
Previously, in order to get vim's syntax highlighting,  you needed to manually `:setf rust` on every file. Now vim will recognize `*.rs` files as rust. This is a little nicer.
