### PR TITLE
freebsd clang support

### DIFF
--- a/configure
+++ b/configure
@@ -340,7 +340,8 @@ then
     CFG_CLANG_VERSION=$("$CFG_CLANG" \
                       --version \
                       | grep version \
-                      | cut -d ' ' -f 3)
+                      | sed 's/.*\(version .*\)/\1/' \
+                      | cut -d ' ' -f 2)
 
     case $CFG_CLANG_VERSION in
         (3.0svn | 3.0 | 3.1)

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -188,7 +188,7 @@ ifeq ($(CFG_C_COMPILER),clang)
   CC=clang
   CXX=clang++
   CPP=cpp
-  CFG_GCCISH_CFLAGS += -Wall -Werror -fno-rtti -g
+  CFG_GCCISH_CFLAGS += -Wall -Werror -Wno-c++11-compat -fno-rtti -g
   CFG_GCCISH_LINK_FLAGS += -g
   CFG_DEPEND_C = $(CFG_GCCISH_CROSS)$(CXX) $(CFG_GCCISH_CFLAGS) -MT "$(1)" \
     -MM $(2)

--- a/src/rt/rust_unwind.h
+++ b/src/rt/rust_unwind.h
@@ -17,8 +17,12 @@ typedef int _Unwind_Reason_Code;
 
 #if (defined __APPLE__) || (defined __clang__)
 
+#ifndef __FreeBSD__
+
 typedef int _Unwind_Action;
 typedef void _Unwind_Exception;
+
+#endif
 
 #endif
 


### PR DESCRIPTION
- On FreeBSD 9.0, the builtin clang is a modified version.
  The output of --version is "FreeBSD clang version 3.0 (branches/release_30 142614) 20111021" that is not the same as ordinary clang.
  I remove the text before "version 3.0" to get the correct number.
- When using clang to compile rust_shape.cpp, it shows a error message that indicates "alignof" is a keyword in C++11. I add "-Wno-c++11-compat" to suppress the error.
- Clang needs libunwind to get unwind support. Some types have been defined in the library so I add a condition to skip them
