### PR TITLE
Add an INSTALL.txt

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,0 +1,68 @@
+### Installing Rust
+
+Windows installer
+=========================
+
+FIXME: the installer is broken and borks %PATH%
+
+
+Source build
+=========================
+
+The Rust compiler is slightly unusual in that it is written in Rust and
+therefore must be built by a precompiled "snapshot" version of itself (made in
+an earlier state of development). As such, source builds require that:
+
+    * You are connected to the internet, to fetch snapshots.
+
+    * You can at least execute snapshot binaries of one of the forms we offer
+      them in. Currently we build and test snapshots on:
+        * Windows (7, server 2008 r2) x86 only
+        * Linux 2.6.x (various distributions) x86 and x86-64
+        * OSX 10.6 ("Snow leopard") or 10.7 ("Lion") x86 and x86-64
+
+You may find other platforms work, but these are our "tier 1" supported build
+environments that are most likely to work. Further platforms will be added to
+the list in the future via cross-compilation.
+
+To build from source you will also need the following prerequisite packages:
+
+    * g++ 4.4 or clang++ 3.x
+    * python 2.6 or later
+    * perl 5.0 or later
+    * gnu make 3.81 or later
+    * curl
+
+
+Building and installing
+=========================
+
+Assuming you're on a relatively modern Linux/OSX system and have met the
+prerequisites, something along these lines should work:
+
+    $ tar -xzf rust-0.1.tar.gz
+    $ cd rust-0.1
+    $ ./configure
+    $ make && make install
+
+When complete, make install will place the following programs into
+/usr/local/bin:
+
+    * rustc, the Rust compiler
+    * rustdoc, the API-documentation tool
+    * cargo, the Rust package manager
+
+In addition to a manual page under /usr/local/share/man and a set of host and
+target libraries under /usr/local/lib/rustc.
+
+The install locations can be adjusted by passing a --prefix argument to
+configure. Various other options are also supported, pass --help for more
+information on them.
+
+
+More help
+=========================
+
+Be sure to check out the 'Getting started' page on the Rust wiki:
+
+    https://github.com/mozilla/rust/wiki/Doc-getting-started

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -15,6 +15,7 @@ PKG_GITMODULES := $(S)src/libuv $(S)src/llvm
 
 PKG_FILES := \
     $(S)LICENSE.txt $(S)README.txt             \
+    $(S)INSTALL.txt                            \
     $(S)configure $(S)Makefile.in              \
     $(S)man                                    \
     $(S)doc                                    \


### PR DESCRIPTION
The installation procedure requires internet _anyway_, but some Unix denizens may be a little muffed at the idea a source package doesn't contain installation instructions! This is basically a slightly modified copy of the installation instructions in the tutorial.

Note, the windows bit is currently commented out as a FIXME, since the installer is broken. The link to the installer should be taken out of the tutorial as well - I'll submit a request for that shortly.

When Rust 0.2 or 1.0 or whatever comes out, this should be part of the distributed tarball. So it'll need to be added to the distribution. I can also do this.
