### PR TITLE
Implemented package descriptions for cargo

### DIFF
--- a/src/cargo/cargo.rs
+++ b/src/cargo/cargo.rs
@@ -693,7 +693,7 @@ fn print_pkg(s: source, p: package) {
     }
     info(m);
     if p.description != "" {
-        print("   >> " + p.description)
+        print("   >> " + p.description + "\n")
     }
 }
 fn cmd_list(c: cargo, argv: [str]) {

--- a/src/cargo/cargo.rs
+++ b/src/cargo/cargo.rs
@@ -270,8 +270,15 @@ fn load_one_source_package(&src: source, p: map::hashmap<str, json::json>) {
         }
         _ { }
     }
-    // TODO: make this *actually* get the description from the .rc file.
-    let description = "This package's description.";
+
+    let description = alt p.find("description") {
+        some(json::string(_n)) { _n }
+        _ {
+            warn("Malformed source json: " + src.name + " (missing description)");
+            ret;
+        }
+    };
+
     vec::grow(src.packages, 1u, {
         // source: _source(src),
         name: name,

--- a/src/cargo/cargo.rs
+++ b/src/cargo/cargo.rs
@@ -34,6 +34,7 @@ type package = {
     uuid: str,
     url: str,
     method: str,
+    description: str,
     ref: option::t<str>,
     tags: [str]
 };
@@ -269,12 +270,15 @@ fn load_one_source_package(&src: source, p: map::hashmap<str, json::json>) {
         }
         _ { }
     }
+    // TODO: make this *actually* get the description from the .rc file.
+    let description = "This package's description.";
     vec::grow(src.packages, 1u, {
         // source: _source(src),
         name: name,
         uuid: uuid,
         url: url,
         method: method,
+        description: description,
         ref: ref,
         tags: tags
     });
@@ -681,6 +685,9 @@ fn print_pkg(s: source, p: package) {
         m = m + " [" + str::connect(p.tags, ", ") + "]";
     }
     info(m);
+    if p.description != "" {
+        print("   >> " + p.description)
+    }
 }
 fn cmd_list(c: cargo, argv: [str]) {
     for_each_package(c, { |s, p|


### PR DESCRIPTION
This solves issue [1601](https://github.com/mozilla/rust/issues/1601).

Descriptions are taken from a `description` field for each package in the `packages.json` file of a cargo repository. I also submitted a [pull request to cargo-central](https://github.com/mozilla/cargo-central/pull/5) with these fields; for now, though, you can point your `sources.json` to `https://raw.github.com/startling/cargo-central/descriptions/packages.json` and see how it works.

Example output:

```
$ cargo list
info: central/rustray (c89c5834-63db-4a6e-8e0a-d75985b1730e) [example]
   >> A raytracing proof-of-concept in Rust.

info: central/rust-hello (83941200-18b3-41b1-8316-b98a2950b33a) [example]
   >> Hello World in rust.

info: central/crypto (38297409-b4c2-4499-8131-a99a7e44dad3) [crypto]
   >> OpenSSL libcrypto bindings for the Rust language.

info: central/zlib (6c34ea67-f290-4438-9d82-db480114d7da) [compression]
   >> zlib bindings for rust.

info: central/pcre (54aba0f8-a7b1-4beb-92f1-4cf625264841) [regex]
   >> PCRE bindings for Rust.

info: central/tnetstring (ce93b70c-c22a-45fa-97a7-66ab97009005) [serialization]
   >> tnetstring serialization library for rust.

info: central/zmq (54cc1bc9-02b8-447c-a227-75ebc923bc29)
   >> Rust zeromq bindings.

info: central/sqlite (5dd017c1-a8fb-458f-b430-cecf793ffbd5) [database]
   >> SQLite3 Bindings for Rust.

info: central/rustx (ec9ace30-b7dc-4d66-9cce-a21cc1c06c93) [utility, script, shortcut]
   >> Scripts to compile and run Rust programs in one command.

info: central/csv (c88f4e89-fc12-4cb3-a978-35d135aefcfd) [spreadsheet]
   >> CSV implementation for Rust.

info: central/iter (1ADE62EE-BE76-46C1-B065-3438B7199A37)
   >> An iteration library for Rust.

```
