### PR TITLE
Added to bad_expr_word_table reserved words

### DIFF
--- a/src/comp/syntax/parse/parser.rs
+++ b/src/comp/syntax/parse/parser.rs
@@ -1,4 +1,3 @@
-
 import core::{vec, str, option, either, result};
 import std::{io, fs};
 import option::{some, none};
@@ -150,7 +149,9 @@ fn bad_expr_word_table() -> hashmap<str, ()> {
                  "cont", "ret", "be", "fail", "type", "resource", "check",
                  "assert", "claim", "native", "fn", "pure",
                  "unsafe", "import", "export", "let", "const",
-                 "log", "copy", "sendfn", "impl", "iface", "enum"] {
+                 "log", "copy", "sendfn", "impl", "iface", "enum",
+                 "m32", "m64", "m128", "f80", "f16", f128",
+                 "class", "trait"] {
         words.insert(word, ());
     }
     words


### PR DESCRIPTION
Issue #1587: Added to bad_expr_word_table the reserved words found at 3.5.2 in the docs.

https://github.com/mozilla/rust/issues/1587
http://doc.rust-lang.org/doc/rust.html#reserved-words
