### PR TITLE
let clang build llvm & change the order of llvm include path

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -212,7 +212,9 @@ LLVM_INCDIR_$(1)=$$(shell "$$(LLVM_CONFIG_$(1))" --includedir)
 LLVM_LIBDIR_$(1)=$$(shell "$$(LLVM_CONFIG_$(1))" --libdir)
 LLVM_LIBS_$(1)=$$(shell "$$(LLVM_CONFIG_$(1))" --libs $$(LLVM_COMPONENTS))
 LLVM_LDFLAGS_$(1)=$$(shell "$$(LLVM_CONFIG_$(1))" --ldflags)
-LLVM_CXXFLAGS_$(1)=$$(shell "$$(LLVM_CONFIG_$(1))" --cxxflags)
+# On FreeBSD, it may search wrong headers (that are for pre-installed LLVM),
+# so we replace -I with -iquote to ensure that it searches bundled LLVM first.
+LLVM_CXXFLAGS_$(1)=$$(subst -I, -iquote , $$(shell "$$(LLVM_CONFIG_$(1))" --cxxflags))
 LLVM_HOST_TRIPLE_$(1)=$$(shell "$$(LLVM_CONFIG_$(1))" --host-target)
 
 LLVM_AS_$(1)=$$(CFG_LLVM_INST_DIR_$(1))/bin/llvm-as$$(X)

--- a/configure
+++ b/configure
@@ -536,14 +536,25 @@ do
 	# Disable unused LLVM features
 	LLVM_OPTS="$LLVM_DBG_OPTS --disable-docs --disable-jit --enable-bindings=none --disable-threads --disable-pthreads"
 
-	LLVM_CXX_32="g++ -m32"
-	LLVM_CC_32="gcc -m32"
+	if [ "$CFG_C_COMPILER" = "clang" ]
+	then
+	    LLVM_CXX_32="clang++ -m32"
+	    LLVM_CC_32="clang -m32"
+
+	    LLVM_CXX_64="clang++"
+	    LLVM_CC_64="clang"
+	else
+	    LLVM_CXX_32="g++ -m32"
+	    LLVM_CC_32="gcc -m32"
+
+	    LLVM_CXX_64="g++"
+	    LLVM_CC_64="gcc"
+	fi
+
 	LLVM_CFLAGS_32="-m32"
 	LLVM_CXXFLAGS_32="-m32"
 	LLVM_LDFLAGS_32="-m32"
 
-	LLVM_CXX_64="g++"
-	LLVM_CC_64="gcc"
 	LLVM_CFLAGS_64=""
 	LLVM_CXXFLAGS_64=""
 	LLVM_LDFLAGS_64=""

--- a/configure
+++ b/configure
@@ -536,20 +536,20 @@ do
 	# Disable unused LLVM features
 	LLVM_OPTS="$LLVM_DBG_OPTS --disable-docs --disable-jit --enable-bindings=none --disable-threads --disable-pthreads"
 
-	if [ "$CFG_C_COMPILER" = "clang" ]
-	then
+        if [ "$CFG_C_COMPILER" = "clang" ]
+        then
 	    LLVM_CXX_32="clang++ -m32"
 	    LLVM_CC_32="clang -m32"
 
 	    LLVM_CXX_64="clang++"
 	    LLVM_CC_64="clang"
-	else
+        else
 	    LLVM_CXX_32="g++ -m32"
 	    LLVM_CC_32="gcc -m32"
 
 	    LLVM_CXX_64="g++"
 	    LLVM_CC_64="gcc"
-	fi
+        fi
 
 	LLVM_CFLAGS_32="-m32"
 	LLVM_CXXFLAGS_32="-m32"

--- a/configure
+++ b/configure
@@ -536,14 +536,25 @@ do
 	# Disable unused LLVM features
 	LLVM_OPTS="$LLVM_DBG_OPTS --disable-docs --disable-jit --enable-bindings=none --disable-threads --disable-pthreads"
 
-	LLVM_CXX_32="g++ -m32"
-	LLVM_CC_32="gcc -m32"
+        if [ "$CFG_C_COMPILER" = "clang" ]
+        then
+	    LLVM_CXX_32="clang++ -m32"
+	    LLVM_CC_32="clang -m32"
+
+	    LLVM_CXX_64="clang++"
+	    LLVM_CC_64="clang"
+        else
+	    LLVM_CXX_32="g++ -m32"
+	    LLVM_CC_32="gcc -m32"
+
+	    LLVM_CXX_64="g++"
+	    LLVM_CC_64="gcc"
+        fi
+
 	LLVM_CFLAGS_32="-m32"
 	LLVM_CXXFLAGS_32="-m32"
 	LLVM_LDFLAGS_32="-m32"
 
-	LLVM_CXX_64="g++"
-	LLVM_CC_64="gcc"
 	LLVM_CFLAGS_64=""
 	LLVM_CXXFLAGS_64=""
 	LLVM_LDFLAGS_64=""

--- a/configure
+++ b/configure
@@ -536,25 +536,14 @@ do
 	# Disable unused LLVM features
 	LLVM_OPTS="$LLVM_DBG_OPTS --disable-docs --disable-jit --enable-bindings=none --disable-threads --disable-pthreads"
 
-        if [ "$CFG_C_COMPILER" = "clang" ]
-        then
-	    LLVM_CXX_32="clang++ -m32"
-	    LLVM_CC_32="clang -m32"
-
-	    LLVM_CXX_64="clang++"
-	    LLVM_CC_64="clang"
-        else
-	    LLVM_CXX_32="g++ -m32"
-	    LLVM_CC_32="gcc -m32"
-
-	    LLVM_CXX_64="g++"
-	    LLVM_CC_64="gcc"
-        fi
-
+	LLVM_CXX_32="g++ -m32"
+	LLVM_CC_32="gcc -m32"
 	LLVM_CFLAGS_32="-m32"
 	LLVM_CXXFLAGS_32="-m32"
 	LLVM_LDFLAGS_32="-m32"
 
+	LLVM_CXX_64="g++"
+	LLVM_CC_64="gcc"
 	LLVM_CFLAGS_64=""
 	LLVM_CXXFLAGS_64=""
 	LLVM_LDFLAGS_64=""

--- a/configure
+++ b/configure
@@ -536,20 +536,20 @@ do
 	# Disable unused LLVM features
 	LLVM_OPTS="$LLVM_DBG_OPTS --disable-docs --disable-jit --enable-bindings=none --disable-threads --disable-pthreads"
 
-        if [ "$CFG_C_COMPILER" = "clang" ]
-        then
+	if [ "$CFG_C_COMPILER" = "clang" ]
+	then
 	    LLVM_CXX_32="clang++ -m32"
 	    LLVM_CC_32="clang -m32"
 
 	    LLVM_CXX_64="clang++"
 	    LLVM_CC_64="clang"
-        else
+	else
 	    LLVM_CXX_32="g++ -m32"
 	    LLVM_CC_32="gcc -m32"
 
 	    LLVM_CXX_64="g++"
 	    LLVM_CC_64="gcc"
-        fi
+	fi
 
 	LLVM_CFLAGS_32="-m32"
 	LLVM_CXXFLAGS_32="-m32"

--- a/mk/rustllvm.mk
+++ b/mk/rustllvm.mk
@@ -37,7 +37,7 @@ rustllvm/$(1)/$(CFG_RUSTLLVM): $$(RUSTLLVM_OBJS_OBJS_$(1)) \
 
 rustllvm/$(1)/%.o: rustllvm/%.cpp $$(MKFILE_DEPS) $$(LLVM_CONFIG_$(1))
 	@$$(call E, compile: $$@)
-	$$(Q)$$(call CFG_COMPILE_C_$(1), $$@, $$(subst -I, -iquote , $$(LLVM_CXXFLAGS_$(1))) $$(RUSTLLVM_INCS_$(1))) $$<
+	$$(Q)$$(call CFG_COMPILE_C_$(1), $$@, $$(LLVM_CXXFLAGS_$(1)) $$(RUSTLLVM_INCS_$(1))) $$<
 endef
 
 # Instantiate template for all stages

--- a/mk/rustllvm.mk
+++ b/mk/rustllvm.mk
@@ -37,7 +37,7 @@ rustllvm/$(1)/$(CFG_RUSTLLVM): $$(RUSTLLVM_OBJS_OBJS_$(1)) \
 
 rustllvm/$(1)/%.o: rustllvm/%.cpp $$(MKFILE_DEPS) $$(LLVM_CONFIG_$(1))
 	@$$(call E, compile: $$@)
-	$$(Q)$$(call CFG_COMPILE_C_$(1), $$@, $$(LLVM_CXXFLAGS_$(1)) $$(RUSTLLVM_INCS_$(1))) $$<
+	$$(Q)$$(call CFG_COMPILE_C_$(1), $$@, $$(subst -I, -iquote , $$(LLVM_CXXFLAGS_$(1))) $$(RUSTLLVM_INCS_$(1))) $$<
 endef
 
 # Instantiate template for all stages


### PR DESCRIPTION
- When specifying enable-llvm, it still uses gcc to build llvm.
  Adding a condition, let clang do that work.
- If system has installed llvm and specifies include paths in the CFLAGS, it may fail to link rustllvm.
  In freebsd's case, 3rd-party libs are installed in /usr/local, so we have to add extra paths to find them.
  When compiling rustllvm, it looks up /usr/local/include/llvm/Config/Targets.def not bundled llvm.
  That causes RustWrapper.o contains nonexistent symbols, so I replace -I with -iquote to ensure that include paths of LLVM_CXXFLAGS comes before CFLAGS.
