### PR TITLE
Small documentation update for enums

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -2007,7 +2007,7 @@ alt_pat : pat [ "to" pat ] ? [ "if" expr ] ;
 
 An `alt` expression branches on a *pattern*. The exact form of matching that
 occurs depends on the pattern. Patterns consist of some combination of
-literals, destructured tag constructors, records and tuples, variable binding
+literals, destructured enum constructors, records and tuples, variable binding
 specifications and placeholders (`_`). An `alt` expression has a *head
 expression*, which is the value to compare to the patterns. The type of the
 patterns must equal the type of the head expression.
@@ -2022,7 +2022,7 @@ An example of an `alt` expression:
 
 
 ~~~~
-tag list<X> { nil; cons(X, @list<X>); }
+enum list<X> { nil; cons(X, @list<X>); }
 
 let x: list<int> = cons(10, @cons(11, @nil));
 
@@ -3286,7 +3286,7 @@ such as vectors, strings, and the low level communication system (ports,
 channels, tasks).
 
 Support for other built-in types such as simple types, tuples, records, and
-tags is open-coded by the Rust compiler.
+enums is open-coded by the Rust compiler.
 
 
 

--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1058,7 +1058,9 @@ accessed through the components `x` and `y`, and laid out in memory with the
 An _enumeration item_ simultaneously declares a new nominal
 [enumerated type](#enumerated-types) as well as a set of *constructors* that
 can be used to create or pattern-match values of the corresponding enumerated
-type.
+type. Note that `enum` previously was refered to as a `tag`, however this
+definition has been deprecated. While `tag` is no longer used, the two are 
+synonymous.
 
 The constructors of an `enum` type may be recursive: that is, each constructor
 may take an argument that refers, directly or indirectly, to the enumerated

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1346,7 +1346,7 @@ destructors. Resources might go away in the future.
 Rust datatypes are not trivial to copy (the way, for example,
 JavaScript values can be copied by simply taking one or two machine
 words and plunking them somewhere else). Shared boxes require
-reference count updates, big records, tags, or unique pointers require
+reference count updates, big records, enums, or unique pointers require
 an arbitrary amount of data to be copied (plus updating the reference
 counts of shared boxes hanging off them).
 
@@ -1459,7 +1459,7 @@ alt my_rec {
 
 The fact that arguments are conceptually passed by safe reference does
 not mean all arguments are passed by pointer. Composite types like
-records and tags *are* passed by pointer, but single-word values, like
+records and enums *are* passed by pointer, but single-word values, like
 integers and pointers, are simply passed by value. Most of the time,
 the programmer does not have to worry about this, as the compiler will
 simply pick the most efficient passing style. There is one exception,


### PR DESCRIPTION
I came across tags while looking at existing rust code, however couldn't find any definitions in the tutorial or reference. This is a small doc update to fix a few cases where tags are referred to as enums, and add a small note for others who see old tag code and are confused.

Thanks.
