### PR TITLE
Fleshing out vec functions

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -929,8 +929,8 @@ for the parameter list, as in `{|| ...}`.
 Partial application is done using the `bind` keyword in Rust.
 
 ~~~~
-let daynum = bind vec::position(_, ["mo", "tu", "we", "do",
-                                    "fr", "sa", "su"]);
+let daynum = bind vec::position_elt(["mo", "tu", "we", "do",
+                                     "fr", "sa", "su"], _);
 ~~~~
 
 Binding a function produces a boxed closure (`fn@` type) in which some

--- a/src/comp/middle/alias.rs
+++ b/src/comp/middle/alias.rs
@@ -679,7 +679,7 @@ fn filter_invalid(src: list<@invalid>, bs: [binding]) -> list<@invalid> {
     while cur != list::nil {
         alt cur {
           list::cons(head, tail) {
-            let p = vec::position_pred(bs, {|b| b.node_id == head.node_id});
+            let p = vec::position(bs, {|b| b.node_id == head.node_id});
             if !is_none(p) { out = list::cons(head, @out); }
             cur = *tail;
           }

--- a/src/comp/middle/shape.rs
+++ b/src/comp/middle/shape.rs
@@ -430,7 +430,7 @@ fn shape_of(ccx: @crate_ctxt, t: ty::t, ty_param_map: [uint]) -> [u8] {
       }
       ty::ty_param(n, _) {
         // Find the type parameter in the parameter list.
-        alt vec::position(n, ty_param_map) {
+        alt vec::position_elt(ty_param_map, n) {
           some(i) { s += [shape_var, i as u8]; }
           none { fail "ty param not found in ty_param_map"; }
         }

--- a/src/comp/middle/trans/base.rs
+++ b/src/comp/middle/trans/base.rs
@@ -3375,7 +3375,7 @@ fn trans_rec(bcx: @block_ctxt, fields: [ast::field],
     let ty_fields = alt ty::struct(bcx_tcx(bcx), t) { ty::ty_rec(f) { f } };
     let temp_cleanups = [];
     for fld in fields {
-        let ix = option::get(vec::position_pred(ty_fields, {|ft|
+        let ix = option::get(vec::position(ty_fields, {|ft|
             str::eq(fld.node.ident, ft.ident)
         }));
         let dst = GEP_tup_like_1(bcx, t, addr, [0, ix as int]);

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -1513,7 +1513,7 @@ fn lookup_method(fcx: @fn_ctxt, isc: resolve::iscopes,
                     ty::ty_iface(i, tps) { (i, tps) }
                 };
                 let ifce_methods = ty::iface_methods(tcx, iid);
-                alt vec::position_pred(*ifce_methods, {|m| m.ident == name}) {
+                alt vec::position(*ifce_methods, {|m| m.ident == name}) {
                   some(pos) {
                     let m = ifce_methods[pos];
                     ret some({method_ty: ty::mk_fn(tcx, m.fty),

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -614,7 +614,7 @@ fn find<T: copy>(v: [T], f: fn(T) -> bool) -> option::t<T> {
 }
 
 /*
-Function: position
+Function: position_elt
 
 Find the first index containing a matching value
 
@@ -623,18 +623,16 @@ Returns:
 option::some(uint) - The first index containing a matching value
 option::none - No elements matched
 */
-fn position<T>(x: T, v: [T]) -> option::t<uint> {
-    let i: uint = 0u;
-    while i < len(v) { if x == v[i] { ret some::<uint>(i); } i += 1u; }
-    ret none;
+fn position_elt<T>(v: [T], x: T) -> option::t<uint> {
+    position(v) { |y| x == y }
 }
 
 /*
-Function: position_pred
+Function: position
 
 Find the first index for which the value matches some predicate
 */
-fn position_pred<T>(v: [T], f: fn(T) -> bool) -> option::t<uint> {
+fn position<T>(v: [T], f: fn(T) -> bool) -> option::t<uint> {
     let i: uint = 0u;
     while i < len(v) { if f(v[i]) { ret some::<uint>(i); } i += 1u; }
     ret none;
@@ -1453,21 +1451,26 @@ mod tests {
     }
 
     #[test]
-    fn test_position() {
-        let v1: [int] = [1, 2, 3, 3, 2, 5];
-        assert (position(1, v1) == option::some::<uint>(0u));
-        assert (position(2, v1) == option::some::<uint>(1u));
-        assert (position(5, v1) == option::some::<uint>(5u));
-        assert (position(4, v1) == option::none::<uint>);
+    fn test_position_elt() {
+        assert position_elt([], 1) == none;
+
+        let v1 = [1, 2, 3, 3, 2, 5];
+        assert position_elt(v1, 1) == some(0u);
+        assert position_elt(v1, 2) == some(1u);
+        assert position_elt(v1, 5) == some(5u);
+        assert position_elt(v1, 4) == none;
     }
 
     #[test]
-    fn test_position_pred() {
+    fn test_position() {
         fn less_than_three(&&i: int) -> bool { ret i < 3; }
         fn is_eighteen(&&i: int) -> bool { ret i == 18; }
-        let v1: [int] = [5, 4, 3, 2, 1];
-        assert position_pred(v1, less_than_three) == option::some::<uint>(3u);
-        assert position_pred(v1, is_eighteen) == option::none::<uint>;
+
+        assert position([], less_than_three) == none;
+
+        let v1 = [5, 4, 3, 2, 1];
+        assert position(v1, less_than_three) == some(3u);
+        assert position(v1, is_eighteen) == none;
     }
 
     #[test]

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -600,6 +600,21 @@ fn concat<T: copy>(v: [const [const T]]) -> [T] {
 }
 
 /*
+Function: connect
+
+Concatenate a vector of vectors, placing a given separator between each
+*/
+fn connect<T: copy>(v: [const [const T]], sep: T) -> [T] {
+    let new: [T] = [];
+    let first = true;
+    for inner: [T] in v {
+        if first { first = false; } else { push(new, sep); }
+        new += inner;
+    }
+    ret new;
+}
+
+/*
 Function: foldl
 
 Reduce a vector from left to right
@@ -1925,6 +1940,13 @@ mod tests {
     #[test]
     fn test_concat() {
         assert concat([[1], [2,3]]) == [1, 2, 3];
+    }
+
+    #[test]
+    fn test_connect() {
+        assert connect([], 0) == [];
+        assert connect([[1], [2, 3]], 0) == [1, 0, 2, 3];
+        assert connect([[1], [2], [3]], 0) == [1, 0, 2, 0, 3];
     }
 
     #[test]

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -149,7 +149,7 @@ fn name_str(nm: name) -> str {
 }
 
 fn find_opt(opts: [opt], nm: name) -> option::t<uint> {
-    vec::position_pred(opts, { |opt| opt.name == nm })
+    vec::position(opts, { |opt| opt.name == nm })
 }
 
 /*

--- a/src/libstd/map.rs
+++ b/src/libstd/map.rs
@@ -95,6 +95,7 @@ iface map<K: copy, V: copy> {
     Iterate over all the keys in the map
     */
     fn keys(fn(K));
+
     /*
     Iterate over all the values in the map
     */


### PR DESCRIPTION
Added:

```
vec::position_from(v: [T], start: uint, end: uint, f: fn(T) -> bool) -> uint

vec::rposition(v: [T], f: fn(T) -> bool) -> uint
vec::rposition_from(v: [T], start: uint, end: uint, f: fn(T) -> bool) -> uint

vec::find(v: [T], f: fn(T) -> bool) -> T
vec::find_from(v: [T], start: uint, end: uint, f: fn(T) -> bool) -> T

vec::rfind(v: [T], f: fn(T) -> bool) -> T
vec::rfind_from(v: [T], start: uint, end: uint, f: fn(T) -> bool) -> T

vec::split(v: [T], f: fn(T) -> bool) -> [[T]]
vec::splitn(v: [T], n: uint, f: fn(T) -> bool) -> [[T]]

vec::rsplit(v: [T], f: fn(T) -> bool) -> [[T]]
vec::rsplitn(v: [T], n: uint, f: fn(T) -> bool) -> [[T]]
```

Renamed:

```
vec::position(v: [T], x: T) -> uint   =>  vec::position_elt(v: [T], x: T) -> uint
vec::position_pred(v: [T], f: fn(T) -> bool) -> uint  =>   vec::position(v: [T], f: fn(T) -> bool) -> uint
```

I'm not sure I'm crazy about keeping around `position_elt` though, since almost every other vec function just takes a block. What do you all think?
