### PR TITLE
core: rename str::lteq to str::le

### DIFF
--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -1588,7 +1588,7 @@ fn method_idx(id: ast::ident, meths: [method]) -> option<uint> {
 
 fn sort_methods(meths: [method]) -> [method] {
     fn method_lteq(a: method, b: method) -> bool {
-        ret str::lteq(a.ident, b.ident);
+        ret str::le(a.ident, b.ident);
     }
     ret std::sort::merge_sort(bind method_lteq(_, _), meths);
 }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -54,7 +54,7 @@ export
 
    // Comparing strings
    eq,
-   lteq,
+   le,
    hash,
 
    // Iterating through strings
@@ -704,11 +704,11 @@ Bytewise string equality
 pure fn eq(&&a: str, &&b: str) -> bool { a == b }
 
 /*
-Function: lteq
+Function: le
 
 Bytewise less than or equal
 */
-pure fn lteq(&&a: str, &&b: str) -> bool { a <= b }
+pure fn le(&&a: str, &&b: str) -> bool { a <= b }
 
 /*
 Function: hash
@@ -1381,10 +1381,10 @@ mod tests {
     }
 
     #[test]
-    fn test_lteq() {
-        assert (lteq("", ""));
-        assert (lteq("", "foo"));
-        assert (lteq("foo", "foo"));
+    fn test_le() {
+        assert (le("", ""));
+        assert (le("", "foo"));
+        assert (le("foo", "foo"));
         assert (!eq("foo", "bar"));
     }
 

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -279,7 +279,7 @@ fn filter_tests(opts: test_opts,
     filtered =
         {
             fn lteq(t1: test_desc, t2: test_desc) -> bool {
-                str::lteq(t1.name, t2.name)
+                str::le(t1.name, t2.name)
             }
             sort::merge_sort(bind lteq(_, _), filtered)
         };

--- a/src/rustdoc/sort_pass.rs
+++ b/src/rustdoc/sort_pass.rs
@@ -38,7 +38,7 @@ fn fold_mod(
 #[test]
 fn test() {
     fn name_lteq(item1: doc::itemtag, item2: doc::itemtag) -> bool {
-        str::lteq(item1.name(), item2.name())
+        str::le(item1.name(), item2.name())
     }
 
     let source = "mod z { mod y { } fn x() { } } mod w { }";


### PR DESCRIPTION
As per the discussion on #1710 (naming consistency: lteq vs le -> standardizing on le)
