### PR TITLE
str::split renaming (updated++)

### DIFF
--- a/src/cargo/pgp.rs
+++ b/src/cargo/pgp.rs
@@ -94,7 +94,7 @@ fn verify(root: str, data: str, sig: str, keyfp: str) -> bool {
     let p = gpg(["--homedir", path, "--with-fingerprint", "--verify", sig,
                  data]);
     let res = "Primary key fingerprint: " + keyfp;
-    for line in str::split(p.err, '\n' as u8) {
+    for line in str::split_byte(p.err, '\n' as u8) {
         if line == res {
             ret true;
         }

--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -113,12 +113,13 @@ mod write {
 
     // Decides what to call an intermediate file, given the name of the output
     // and the extension to use.
-    fn mk_intermediate_name(output_path: str, extension: str) -> str {
+    fn mk_intermediate_name(output_path: str, extension: str) -> str unsafe {
         let dot_pos = str::index(output_path, '.' as u8);
         let stem;
         if dot_pos < 0 {
             stem = output_path;
-        } else { stem = str::substr(output_path, 0u, dot_pos as uint); }
+        } else { stem = str::unsafe::slice_bytes(output_path, 0u,
+                                                 dot_pos as uint); }
         ret stem + "." + extension;
     }
     fn run_passes(sess: session, llmod: ModuleRef, output: str) {
@@ -480,8 +481,8 @@ fn build_link_meta(sess: session, c: ast::crate, output: str,
     ret {name: name, vers: vers, extras_hash: extras_hash};
 }
 
-fn truncated_sha1_result(sha: sha1) -> str {
-    ret str::substr(sha.result_str(), 0u, 16u);
+fn truncated_sha1_result(sha: sha1) -> str unsafe {
+    ret str::unsafe::slice_bytes(sha.result_str(), 0u, 16u);
 }
 
 

--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -443,7 +443,8 @@ fn build_link_meta(sess: session, c: ast::crate, output: str,
               none {
                 let name =
                     {
-                        let os = str::split(fs::basename(output), '.' as u8);
+                        let os = str::split_byte(
+                                   fs::basename(output), '.' as u8);
                         if (vec::len(os) < 2u) {
                             sess.fatal(#fmt("Output file name %s doesn't\
                               appear to have an extension", output));
@@ -578,7 +579,7 @@ fn link_binary(sess: session,
             } else { ret filename; }
         };
         fn rmext(filename: str) -> str {
-            let parts = str::split(filename, '.' as u8);
+            let parts = str::split_byte(filename, '.' as u8);
             vec::pop(parts);
             ret str::connect(parts, ".");
         }

--- a/src/comp/back/rpath.rs
+++ b/src/comp/back/rpath.rs
@@ -128,8 +128,8 @@ fn get_relative_to(abs1: fs::path, abs2: fs::path) -> fs::path {
            abs1, abs2);
     let normal1 = fs::normalize(abs1);
     let normal2 = fs::normalize(abs2);
-    let split1 = str::split(normal1, os_fs::path_sep as u8);
-    let split2 = str::split(normal2, os_fs::path_sep as u8);
+    let split1 = str::split_byte(normal1, os_fs::path_sep as u8);
+    let split2 = str::split_byte(normal2, os_fs::path_sep as u8);
     let len1 = vec::len(split1);
     let len2 = vec::len(split2);
     assert len1 > 0u;

--- a/src/comp/metadata/cstore.rs
+++ b/src/comp/metadata/cstore.rs
@@ -120,7 +120,7 @@ fn get_used_libraries(cstore: cstore) -> [str] {
 }
 
 fn add_used_link_args(cstore: cstore, args: str) {
-    p(cstore).used_link_args += str::split(args, ' ' as u8);
+    p(cstore).used_link_args += str::split_byte(args, ' ' as u8);
 }
 
 fn get_used_link_args(cstore: cstore) -> [str] {

--- a/src/comp/util/ppaux.rs
+++ b/src/comp/util/ppaux.rs
@@ -116,9 +116,9 @@ fn ty_to_str(cx: ctxt, typ: t) -> str {
     }
 }
 
-fn ty_to_short_str(cx: ctxt, typ: t) -> str {
+fn ty_to_short_str(cx: ctxt, typ: t) -> str unsafe {
     let s = encoder::encoded_ty(cx, typ);
-    if str::byte_len(s) >= 32u { s = str::substr(s, 0u, 32u); }
+    if str::byte_len(s) >= 32u { s = str::unsafe::slice_bytes(s, 0u, 32u); }
     ret s;
 }
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -199,7 +199,7 @@ fn check_error_patterns(props: test_props,
 
     let next_err_idx = 0u;
     let next_err_pat = props.error_patterns[next_err_idx];
-    for line: str in str::split(procres.stdout, '\n' as u8) {
+    for line: str in str::split_byte(procres.stdout, '\n' as u8) {
         if str::find(line, next_err_pat) > 0 {
             #debug("found error pattern %s", next_err_pat);
             next_err_idx += 1u;
@@ -246,7 +246,7 @@ fn check_expected_errors(expected_errors: [errors::expected_error],
     //    filename:line1:col1: line2:col2: *warning:* msg
     // where line1:col1: is the starting point, line2:col2:
     // is the ending point, and * represents ANSI color codes.
-    for line: str in str::split(procres.stdout, '\n' as u8) {
+    for line: str in str::split_byte(procres.stdout, '\n' as u8) {
         let was_expected = false;
         vec::iteri(expected_errors) {|i, ee|
             if !found_flags[i] {
@@ -349,7 +349,7 @@ fn split_maybe_args(argstr: option<str>) -> [str] {
     }
 
     alt argstr {
-      option::some(s) { rm_whitespace(str::split(s, ' ' as u8)) }
+      option::some(s) { rm_whitespace(str::split_byte(s, ' ' as u8)) }
       option::none { [] }
     }
 }
@@ -411,7 +411,7 @@ fn output_base_name(config: config, testfile: str) -> str {
     let base = config.build_base;
     let filename =
         {
-            let parts = str::split(fs::basename(testfile), '.' as u8);
+            let parts = str::split_byte(fs::basename(testfile), '.' as u8);
             parts = vec::slice(parts, 0u, vec::len(parts) - 1u);
             str::connect(parts, ".")
         };

--- a/src/libcore/u8.rs
+++ b/src/libcore/u8.rs
@@ -49,6 +49,9 @@ pure fn ge(x: u8, y: u8) -> bool { ret x >= y; }
 /* Predicate: gt */
 pure fn gt(x: u8, y: u8) -> bool { ret x > y; }
 
+/* Predicate: is_ascii */
+pure fn is_ascii(x: u8) -> bool { ret 0u8 == x & 128u8; }
+
 /*
 Function: range
 

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -252,12 +252,16 @@ the first element of the returned vector will be the drive letter
 followed by a colon.
 */
 fn split(p: path) -> [path] {
-    let split1 = str::split(p, os_fs::path_sep as u8);
+    // FIXME: use UTF-8 safe str, and/or various other string formats
+    let split1 = str::split_byte(p, os_fs::path_sep as u8);
     let split2 = [];
     for s in split1 {
-        split2 += str::split(s, os_fs::alt_path_sep as u8);
+        split2 += str::split_byte(s, os_fs::alt_path_sep as u8);
     }
-    ret split2;
+
+    // filter out ""
+    let split3 = vec::filter(split2, {|seg| "" != seg});
+    ret split3;
 }
 
 /*
@@ -270,9 +274,10 @@ path includes directory components then they are included in the filename part
 of the result pair.
 */
 fn splitext(p: path) -> (str, str) {
+    // FIXME: use UTF-8 safe str, and/or various other string formats
     if str::is_empty(p) { ("", "") }
     else {
-        let parts = str::split(p, '.' as u8);
+        let parts = str::split_byte(p, '.' as u8);
         if vec::len(parts) > 1u {
             let base = str::connect(vec::init(parts), ".");
             let ext = "." + option::get(vec::last(parts));

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -43,13 +43,13 @@ The dirname of "/usr/share" will be "/usr", but the dirname of
 
 If the path is not prefixed with a directory, then "." is returned.
 */
-fn dirname(p: path) -> path {
+fn dirname(p: path) -> path unsafe {
     let i: int = str::rindex(p, os_fs::path_sep as u8);
     if i == -1 {
         i = str::rindex(p, os_fs::alt_path_sep as u8);
         if i == -1 { ret "."; }
     }
-    ret str::substr(p, 0u, i as uint);
+    ret str::unsafe::slice_bytes(p, 0u, i as uint);
 }
 
 /*

--- a/src/libstd/net.rs
+++ b/src/libstd/net.rs
@@ -49,7 +49,8 @@ Failure:
 String must be a valid IPv4 address
 */
 fn parse_addr(ip: str) -> ip_addr {
-    let parts = vec::map(str::split(ip, "."[0]), {|s| uint::from_str(s) });
+    let parts = vec::map(str::split_byte(ip, "."[0]),
+                         {|s| uint::from_str(s) });
     if vec::len(parts) != 4u { fail "Too many dots in IP address"; }
     for i in parts { if i > 255u { fail "Invalid IP Address part."; } }
     ipv4(parts[0] as u8, parts[1] as u8, parts[2] as u8, parts[3] as u8)

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -1341,11 +1341,12 @@ mod tests {
           node::empty { ret "" }
           node::content(x) {
             let str = @mutable "";
-            fn aux(str: @mutable str, node: @node::node) {
+            fn aux(str: @mutable str, node: @node::node) unsafe {
                 alt(*node) {
                   node::leaf(x) {
-                    *str += str::substr(
-                        *x.content, x.byte_offset, x.byte_len);
+                    *str += str::unsafe::slice_bytes(
+                        *x.content, x.byte_offset,
+                        x.byte_offset + x.byte_len);
                   }
                   node::concat(x) {
                     aux(str, x.left);

--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -291,7 +291,7 @@ fn mk_sha1() -> sha1 {
 mod tests {
 
     #[test]
-    fn test() {
+    fn test() unsafe {
         type test = {input: str, output: [u8]};
 
         fn a_million_letter_a() -> str {
@@ -372,7 +372,8 @@ mod tests {
             let left = len;
             while left > 0u {
                 let take = (left + 1u) / 2u;
-                sh.input_str(str::substr(t.input, len - left, take));
+                sh.input_str(str::unsafe::slice_bytes(t.input, len - left,
+                             take + len - left));
                 left = left - take;
             }
             let out = sh.result();

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -33,8 +33,7 @@ fn read_grid(f: io::reader) -> grid_t {
 
     let g = vec::init_fn(10u, {|_i| vec::init_elt_mut(10u, 0 as u8) });
     while !f.eof() {
-        // FIXME: replace with unicode compliant call
-        let comps = str::split(str::trim(f.read_line()), ',' as u8);
+        let comps = str::split_byte(str::trim(f.read_line()), ',' as u8);
         if vec::len(comps) >= 3u {
             let row     = uint::from_str(comps[0]) as u8;
             let col     = uint::from_str(comps[1]) as u8;


### PR DESCRIPTION
Another batch of renaming:
- Renamed str::split  -> str::split_byte
- Renamed str::splitn -> str::splitn_byte
- Renamed str::split_func -> str::split
- Renamed str::split_char -> str::split_char
- Renamed str::split_chars_iter -> str::split_char_iter

Also:
- Fixed the behavior of str::split_str, so that it matches split_chars and split (i.e. `["", "XXX", "YYY", ""] == split_str(".XXX.YYY.", ".")`)
- Added u8::is_ascii
- Fixed str::split_byte and str::splitn_byte so that they handle splitting UTF-8 strings on a given UTF-8/ASCII byte and also handle "" as the others do
