### PR TITLE
Making vec::reserve exact (not nearest power of two), and adding str::reserve

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -97,6 +97,7 @@ export
    as_buf,
    //buf,
    sbuf,
+   reserve,
 
    unsafe;
 
@@ -105,6 +106,7 @@ export
 #[abi = "cdecl"]
 native mod rustrt {
     fn rust_str_push(&s: str, ch: u8);
+    fn str_reserve_shared(&ss: str, nn: ctypes::size_t);
 }
 
 // FIXME: add pure to a lot of functions
@@ -755,6 +757,7 @@ Apply a function to each character
 */
 fn map(ss: str, ff: fn(char) -> char) -> str {
     let result = "";
+    reserve(result, byte_len(ss));
 
     chars_iter(ss, {|cc|
         str::push_char(result, ff(cc));
@@ -1301,6 +1304,13 @@ Type: sbuf
 An unsafe buffer of bytes. Corresponds to a C char pointer.
 */
 type sbuf = *u8;
+
+// Function: reserve
+//
+// Allocate more memory for a string, up to `nn` + 1 bytes
+fn reserve(&ss: str, nn: uint) {
+    rustrt::str_reserve_shared(ss, nn);
+}
 
 // Module: unsafe
 //

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -101,7 +101,7 @@ extern "C" CDECL void
 vec_reserve_shared(type_desc* ty, rust_vec** vp,
                    size_t n_elts) {
     rust_task *task = rust_scheduler::get_task();
-    reserve_vec(task, vp, n_elts * ty->size);
+    reserve_vec_exact(task, vp, n_elts * ty->size);
 }
 
 /**

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -104,6 +104,13 @@ vec_reserve_shared(type_desc* ty, rust_vec** vp,
     reserve_vec_exact(task, vp, n_elts * ty->size);
 }
 
+extern "C" CDECL void
+str_reserve_shared(rust_vec** sp,
+                   size_t n_elts) {
+    rust_task *task = rust_scheduler::get_task();
+    reserve_vec_exact(task, sp, n_elts + 1);
+}
+
 /**
  * Copies elements in an unsafe buffer to the given interior vector. The
  * vector must have size zero.

--- a/src/rt/rust_util.h
+++ b/src/rt/rust_util.h
@@ -179,13 +179,15 @@ inline size_t vec_size(size_t elems) {
     return sizeof(rust_vec) + sizeof(T) * elems;
 }
 
-inline void reserve_vec(rust_task* task, rust_vec** vpp, size_t size) {
+inline void reserve_vec_exact(rust_task* task, rust_vec** vpp, size_t size) {
     if (size > (*vpp)->alloc) {
-        size_t new_alloc = next_power_of_two(size);
-        *vpp = (rust_vec*)task->kernel->realloc(*vpp, new_alloc +
-                                                sizeof(rust_vec));
-        (*vpp)->alloc = new_alloc;
+        *vpp = (rust_vec*)task->kernel->realloc(*vpp, size + sizeof(rust_vec));
+        (*vpp)->alloc = size;
     }
+}
+
+inline void reserve_vec(rust_task* task, rust_vec** vpp, size_t size) {
+    reserve_vec_exact(task, vpp, next_power_of_two(size));
 }
 
 typedef rust_vec rust_str;

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -50,6 +50,7 @@ shape_log_str
 squareroot
 start_task
 vec_reserve_shared
+str_reserve_shared
 vec_from_buf_shared
 unsupervise
 upcall_cmp_type


### PR DESCRIPTION
As discussed briefly on IRC and here: https://github.com/mozilla/rust/issues/1753
