### PR TITLE
Macro fixups

### DIFF
--- a/src/comp/driver/diagnostic.rs
+++ b/src/comp/driver/diagnostic.rs
@@ -179,6 +179,7 @@ fn emit(cmsp: option<(codemap::codemap, span)>,
         let lines = codemap::span_to_lines(sp, cm);
         print_diagnostic(ss, lvl, msg);
         highlight_lines(cm, sp, lines);
+        print_macro_backtrace(cm, sp);
       }
       none {
         print_diagnostic("", lvl, msg);
@@ -239,5 +240,17 @@ fn highlight_lines(cm: codemap::codemap, sp: span,
             while width > 0u { str::push_char(s, '~'); width -= 1u; }
         }
         io::stderr().write_str(s + "\n");
+    }
+}
+
+fn print_macro_backtrace(cm: codemap::codemap, sp: span) {
+    option::may (sp.expn_info) {|ei|
+        let ss = option::maybe("", ei.callie.span,
+                               bind codemap::span_to_str(_, cm));
+        print_diagnostic(ss, note,
+                         #fmt("in expansion of #%s", ei.callie.name));
+        let ss = codemap::span_to_str(ei.call_site, cm);
+        print_diagnostic(ss, note, "expansion site");
+        print_macro_backtrace(cm, ei.call_site);
     }
 }

--- a/src/comp/front/core_inject.rs
+++ b/src/comp/front/core_inject.rs
@@ -24,7 +24,7 @@ fn inject_libcore_ref(sess: session,
     fn spanned<T: copy>(x: T) -> @ast::spanned<T> {
         ret @{node: x,
               span: {lo: 0u, hi: 0u,
-                     expanded_from: codemap::os_none}};
+                     expn_info: option::none}};
     }
 
     let n1 = sess.next_node_id();

--- a/src/comp/syntax/ast.rs
+++ b/src/comp/syntax/ast.rs
@@ -283,7 +283,6 @@ enum mac_ {
     mac_embed_block(blk),
     mac_ellipsis,
     // the span is used by the quoter/anti-quoter ...
-    mac_qq(span /* span of expr */, @expr), // quasi-quote
     mac_aq(span /* span of quote */, @expr), // anti-quote
     mac_var(uint)
 }

--- a/src/comp/syntax/ast_util.rs
+++ b/src/comp/syntax/ast_util.rs
@@ -7,7 +7,7 @@ fn respan<T: copy>(sp: span, t: T) -> spanned<T> {
 
 /* assuming that we're not in macro expansion */
 fn mk_sp(lo: uint, hi: uint) -> span {
-    ret {lo: lo, hi: hi, expanded_from: codemap::os_none};
+    ret {lo: lo, hi: hi, expn_info: none};
 }
 
 // make this a const, once the compiler supports it

--- a/src/comp/syntax/codemap.rs
+++ b/src/comp/syntax/codemap.rs
@@ -92,38 +92,18 @@ fn lookup_byte_pos(map: codemap, pos: uint) -> loc {
     ret lookup_pos(map, pos, lookup);
 }
 
-enum opt_span {
-
-    //hack (as opposed to option), to make `span` compile
-    os_none,
-    os_some(@span),
+enum expn_info_ {
+    expanded_from({call_site: span,
+                   callie: {name: str, span: option<span>}})
 }
-type span = {lo: uint, hi: uint, expanded_from: opt_span};
+type expn_info = option<@expn_info_>;
+type span = {lo: uint, hi: uint, expn_info: expn_info};
 
 fn span_to_str(sp: span, cm: codemap) -> str {
-    let cur = sp;
-    let res = "";
-    // FIXME: Should probably be doing pointer comparison on filemap
-    let prev_file = none;
-    while true {
-        let lo = lookup_char_pos(cm, cur.lo);
-        let hi = lookup_char_pos(cm, cur.hi);
-        res +=
-            #fmt["%s:%u:%u: %u:%u",
-                 if some(lo.file.name) == prev_file {
-                     "-"
-                 } else { lo.file.name }, lo.line, lo.col, hi.line, hi.col];
-        alt cur.expanded_from {
-          os_none { break; }
-          os_some(new_sp) {
-            cur = *new_sp;
-            prev_file = some(lo.file.name);
-            res += "<<";
-          }
-        }
-    }
-
-    ret res;
+    let lo = lookup_char_pos(cm, sp.lo);
+    let hi = lookup_char_pos(cm, sp.hi);
+    ret #fmt("%s:%u:%u: %u:%u", lo.file.name,
+             lo.line, lo.col, hi.line, hi.col)
 }
 
 type file_lines = {file: filemap, lines: [uint]};

--- a/src/comp/syntax/ext/expand.rs
+++ b/src/comp/syntax/ext/expand.rs
@@ -11,7 +11,7 @@ import syntax::ext::base::*;
 import syntax::ext::qquote::{expand_qquote,qq_helper};
 import syntax::parse::parser::parse_expr_from_source_str;
 
-import codemap::span;
+import codemap::{span, expanded_from};
 
 fn expand_expr(exts: hashmap<str, syntax_extension>, cx: ext_ctxt,
                e: expr_, s: span, fld: ast_fold,
@@ -29,10 +29,12 @@ fn expand_expr(exts: hashmap<str, syntax_extension>, cx: ext_ctxt,
                     cx.span_fatal(pth.span,
                                   #fmt["macro undefined: '%s'", extname])
                   }
-                  some(normal(ext)) {
-                    let expanded = ext(cx, pth.span, args, body);
+                  some(normal({expander: exp, span: exp_sp})) {
+                    let expanded = exp(cx, pth.span, args, body);
 
-                    cx.bt_push(mac.span);
+                    let info = {call_site: s,
+                                callie: {name: extname, span: exp_sp}};
+                    cx.bt_push(expanded_from(info));
                     //keep going, outside-in
                     let fully_expanded = fld.fold_expr(expanded).node;
                     cx.bt_pop();
@@ -51,6 +53,11 @@ fn expand_expr(exts: hashmap<str, syntax_extension>, cx: ext_ctxt,
           }
           _ { orig(e, s, fld) }
         };
+}
+
+fn new_span(cx: ext_ctxt, sp: span) -> span {
+    /* this discards information in the case of macro-defining macros */
+    ret {lo: sp.lo, hi: sp.hi, expn_info: cx.backtrace()};
 }
 
 // FIXME: this is a terrible kludge to inject some macros into the default
@@ -73,7 +80,8 @@ fn expand_crate(sess: session::session, c: @crate) -> @crate {
     let afp = default_ast_fold();
     let cx: ext_ctxt = mk_ctxt(sess);
     let f_pre =
-        {fold_expr: bind expand_expr(exts, cx, _, _, _, afp.fold_expr)
+        {fold_expr: bind expand_expr(exts, cx, _, _, _, afp.fold_expr),
+         new_span: bind new_span(cx, _)
             with *afp};
     let f = make_fold(f_pre);
     let cm = parse_expr_from_source_str("<core-macros>",

--- a/src/comp/syntax/ext/expand.rs
+++ b/src/comp/syntax/ext/expand.rs
@@ -5,7 +5,7 @@ import option::{none, some};
 import std::map::hashmap;
 import vec;
 
-import syntax::ast::{crate, expr_, expr_mac, mac_invoc, mac_qq};
+import syntax::ast::{crate, expr_, expr_mac, mac_invoc};
 import syntax::fold::*;
 import syntax::ext::base::*;
 import syntax::ext::qquote::{expand_qquote,qq_helper};
@@ -45,13 +45,6 @@ fn expand_expr(exts: hashmap<str, syntax_extension>, cx: ext_ctxt,
                     (ast::expr_rec([], none), s)
                   }
                 }
-              }
-              mac_qq(sp, exp) {
-                let r = expand_qquote(cx, sp, none, exp);
-                // need to keep going, resuls may contain embedded qquote or
-                // macro that need expanding
-                let r2 = fld.fold_expr(r);
-                (r2.node, s)
               }
               _ { cx.span_bug(mac.span, "naked syntactic bit") }
             }

--- a/src/comp/syntax/ext/qquote.rs
+++ b/src/comp/syntax/ext/qquote.rs
@@ -3,7 +3,7 @@ import driver::session;
 import option::{none, some};
 
 import syntax::ast::{crate, expr_, mac_invoc,
-                     mac_qq, mac_aq, mac_var};
+                     mac_aq, mac_var};
 import syntax::fold::*;
 import syntax::visit::*;
 import syntax::ext::base::*;
@@ -156,7 +156,7 @@ fn expand_ast(ecx: ext_ctxt, _sp: span,
         let node = parse_from_source_str
             (f, fname, some(ss), str,
              ecx.session().opts.cfg, ecx.session().parse_sess);
-        ret expand_qquote(ecx, node.span(), some(*str), node);
+        ret expand_qquote(ecx, node.span(), *str, node);
     }
 
     ret alt what {
@@ -185,13 +185,9 @@ fn parse_item(p: parser) -> @ast::item {
 }
 
 fn expand_qquote<N: qq_helper>
-    (ecx: ext_ctxt, sp: span, maybe_str: option::t<str>, node: N)
+    (ecx: ext_ctxt, sp: span, str: str, node: N)
     -> @ast::expr
 {
-    let str = alt(maybe_str) {
-      some(s) {s}
-      none {codemap::span_to_snippet(sp, ecx.session().parse_sess.cm)}
-    };
     let qcx = gather_anti_quotes(sp.lo, node);
     let cx = qcx;
     let prev = 0u;

--- a/src/comp/syntax/ext/simplext.rs
+++ b/src/comp/syntax/ext/simplext.rs
@@ -587,7 +587,6 @@ fn p_t_s_r_mac(cx: ext_ctxt, mac: ast::mac, s: selector, b: binders) {
           none { no_des(cx, blk.span, "under `#{}`"); }
         }
       }
-      ast::mac_qq(_,_) { no_des(cx, mac.span, "quasiquotes"); }
       ast::mac_aq(_,_) { no_des(cx, mac.span, "antiquotes"); }
       ast::mac_var(_) { no_des(cx, mac.span, "antiquote variables"); }
     }

--- a/src/comp/syntax/ext/simplext.rs
+++ b/src/comp/syntax/ext/simplext.rs
@@ -190,7 +190,7 @@ fn transcribe(cx: ext_ctxt, b: bindings, body: @expr) -> @expr {
     fn new_id(_old: node_id, cx: ext_ctxt) -> node_id { ret cx.next_id(); }
     fn new_span(cx: ext_ctxt, sp: span) -> span {
         /* this discards information in the case of macro-defining macros */
-        ret {lo: sp.lo, hi: sp.hi, expanded_from: cx.backtrace()};
+        ret {lo: sp.lo, hi: sp.hi, expn_info: cx.backtrace()};
     }
     let afp = default_ast_fold();
     let f_pre =
@@ -202,8 +202,8 @@ fn transcribe(cx: ext_ctxt, b: bindings, body: @expr) -> @expr {
          fold_block:
              bind transcribe_block(cx, b, idx_path, _, _, _, afp.fold_block),
          map_exprs: bind transcribe_exprs(cx, b, idx_path, _, _),
-         new_id: bind new_id(_, cx),
-         new_span: bind new_span(cx, _) with *afp};
+         new_id: bind new_id(_, cx)
+         with *afp};
     let f = make_fold(f_pre);
     let result = f.fold_expr(body);
     ret result;
@@ -753,7 +753,7 @@ fn add_new_extension(cx: ext_ctxt, sp: span, arg: ast::mac_arg,
                                    "at least one clause")
                }
              },
-         ext: normal(ext)};
+         ext: normal({expander: ext, span: some(arg.span)})};
 
     fn generic_extension(cx: ext_ctxt, sp: span, arg: ast::mac_arg,
                          _body: ast::mac_body, clauses: [@clause]) -> @expr {

--- a/src/comp/syntax/fold.rs
+++ b/src/comp/syntax/fold.rs
@@ -144,7 +144,6 @@ fn fold_mac_(m: mac, fld: ast_fold) -> mac {
                mac_embed_type(ty) { mac_embed_type(fld.fold_ty(ty)) }
                mac_embed_block(blk) { mac_embed_block(fld.fold_block(blk)) }
                mac_ellipsis { mac_ellipsis }
-               mac_qq(_,_) { /* fixme */ m.node }
                mac_aq(_,_) { /* fixme */ m.node }
                mac_var(_) { /* fixme */ m.node }
              },

--- a/src/comp/syntax/parse/lexer.rs
+++ b/src/comp/syntax/parse/lexer.rs
@@ -349,7 +349,6 @@ fn next_token_inner(rdr: reader) -> token::token {
       '#' {
         rdr.bump();
         if rdr.curr == '<' { rdr.bump(); ret token::POUND_LT; }
-        if rdr.curr == '(' { rdr.bump(); ret token::POUND_LPAREN; }
         if rdr.curr == '{' { rdr.bump(); ret token::POUND_LBRACE; }
         ret token::POUND;
       }

--- a/src/comp/syntax/parse/parser.rs
+++ b/src/comp/syntax/parse/parser.rs
@@ -875,12 +875,6 @@ fn parse_bottom_expr(p: parser) -> pexpr {
     } else if p.token == token::ELLIPSIS {
         p.bump();
         ret pexpr(mk_mac_expr(p, lo, p.span.hi, ast::mac_ellipsis));
-    } else if p.token == token::POUND_LPAREN {
-        p.bump();
-        let e = parse_expr(p);
-        expect(p, token::RPAREN);
-        ret pexpr(mk_mac_expr(p, lo, p.span.hi,
-                              ast::mac_qq(e.span, e)));
     } else if eat_word(p, "bind") {
         let e = parse_expr_res(p, RESTRICT_NO_CALL_EXPRS);
         fn parse_expr_opt(p: parser) -> option<@ast::expr> {

--- a/src/comp/syntax/parse/token.rs
+++ b/src/comp/syntax/parse/token.rs
@@ -53,7 +53,6 @@ enum token {
     LBRACE,
     RBRACE,
     POUND,
-    POUND_LPAREN,
     POUND_LBRACE,
     POUND_LT,
 
@@ -128,7 +127,6 @@ fn to_str(r: reader, t: token) -> str {
       LBRACE { ret "{"; }
       RBRACE { ret "}"; }
       POUND { ret "#"; }
-      POUND_LPAREN { ret "#("; }
       POUND_LBRACE { ret "#{"; }
       POUND_LT { ret "#<"; }
 

--- a/src/comp/syntax/visit.rs
+++ b/src/comp/syntax/visit.rs
@@ -300,7 +300,6 @@ fn visit_mac<E>(m: mac, e: E, v: vt<E>) {
       ast::mac_embed_type(ty) { v.visit_ty(ty, e, v); }
       ast::mac_embed_block(blk) { v.visit_block(blk, e, v); }
       ast::mac_ellipsis { }
-      ast::mac_qq(_, e) { /* FIXME: maybe visit */ }
       ast::mac_aq(_, e) { /* FIXME: maybe visit */ }
       ast::mac_var(_) { }
     }

--- a/src/test/run-pass/qquote.rs
+++ b/src/test/run-pass/qquote.rs
@@ -53,7 +53,7 @@ fn main() {
     let expr3 = #ast{2 - $(abc) + 7};
     check_pp(expr3,  pprust::print_expr, "2 - 23 + 7");
 
-    let expr4 = #ast{2 - $(#(3)) + 9};
+    let expr4 = #ast{2 - $(#ast{3}) + 9};
     check_pp(expr4,  pprust::print_expr, "2 - 3 + 9");
 
     let ty = #ast(ty){int};


### PR DESCRIPTION
The first commit removes support the `$(...)` quasi-quote form, as the `#ast{...}` form is now preferred.

The second one fixes macro backtraces.  See the commit message for detail.

I can split into two separate full requests if required.
