### PR TITLE
Request for review: Make ty::t type self-sufficient

### DIFF
--- a/src/comp/metadata/decoder.rs
+++ b/src/comp/metadata/decoder.rs
@@ -113,7 +113,7 @@ fn doc_type(doc: ebml::doc, tcx: ty::ctxt, cdata: cmd) -> ty::t {
 fn item_type(item: ebml::doc, tcx: ty::ctxt, cdata: cmd) -> ty::t {
     let t = doc_type(item, tcx, cdata);
     if family_names_type(item_family(item)) {
-        ty::mk_named(tcx, t, @item_name(item))
+        ty::mk_named(tcx, t, item_name(item))
     } else { t }
 }
 
@@ -247,7 +247,7 @@ fn get_enum_variants(cdata: cmd, id: ast::node_id, tcx: ty::ctxt)
         let ctor_ty = item_type(item, tcx, cdata);
         let name = item_name(item);
         let arg_tys: [ty::t] = [];
-        alt ty::struct(tcx, ctor_ty) {
+        alt ty::get(ctor_ty).struct {
           ty::ty_fn(f) {
             for a: ty::arg in f.inputs { arg_tys += [a.ty]; }
           }
@@ -302,7 +302,7 @@ fn get_iface_methods(cdata: cmd, id: ast::node_id, tcx: ty::ctxt)
         let bounds = item_ty_param_bounds(mth, tcx, cdata);
         let name = item_name(mth);
         let ty = doc_type(mth, tcx, cdata);
-        let fty = alt ty::struct(tcx, ty) { ty::ty_fn(f) { f }
+        let fty = alt ty::get(ty).struct { ty::ty_fn(f) { f }
           _ { tcx.sess.bug("get_iface_methods: id has non-function type");
         } };
         result += [{ident: name, tps: bounds, fty: fty}];

--- a/src/comp/metadata/encoder.rs
+++ b/src/comp/metadata/encoder.rs
@@ -353,7 +353,7 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: ebml::writer, item: @item,
         encode_def_id(ebml_w, local_def(ctor_id));
         encode_family(ebml_w, 'y' as u8);
         encode_type_param_bounds(ebml_w, ecx, tps);
-        encode_type(ecx, ebml_w, ty::ty_fn_ret(tcx, fn_ty));
+        encode_type(ecx, ebml_w, ty::ty_fn_ret(fn_ty));
         encode_name(ebml_w, item.ident);
         encode_symbol(ecx, ebml_w, item.id);
         ebml::end_tag(ebml_w);

--- a/src/comp/metadata/tydecode.rs
+++ b/src/comp/metadata/tydecode.rs
@@ -292,7 +292,7 @@ fn parse_ty(st: @pstate, conv: conv_did) -> ty::t {
         while peek(st) as char != '"' { str::push_byte(name, next(st)); }
         st.pos = st.pos + 1u;
         let inner = parse_ty(st, conv);
-        ty::mk_named(st.tcx, inner, @name)
+        ty::mk_named(st.tcx, inner, name)
       }
       c { #error("unexpected char in type string: %c", c); fail;}
     }

--- a/src/comp/metadata/tyencode.rs
+++ b/src/comp/metadata/tyencode.rs
@@ -42,8 +42,7 @@ fn enc_ty(w: io::writer, cx: @ctxt, t: ty::t) {
           some(s) { *s }
           none {
             let buf = io::mk_mem_buffer();
-            enc_sty(io::mem_buffer_writer(buf), cx,
-                    ty::struct_raw(cx.tcx, t));
+            enc_sty(io::mem_buffer_writer(buf), cx, ty::get(t).struct);
             cx.tcx.short_names_cache.insert(t, @io::mem_buffer_str(buf));
             io::mem_buffer_str(buf)
           }
@@ -55,7 +54,15 @@ fn enc_ty(w: io::writer, cx: @ctxt, t: ty::t) {
           some(a) { w.write_str(*a.s); ret; }
           none {
             let pos = w.tell();
-            enc_sty(w, cx, ty::struct_raw(cx.tcx, t));
+            alt ty::type_name(t) {
+              some(n) {
+                w.write_char('"');
+                w.write_str(n);
+                w.write_char('"');
+              }
+              _ {}
+            }
+            enc_sty(w, cx, ty::get(t).struct);
             let end = w.tell();
             let len = end - pos;
             fn estimate_sz(u: uint) -> uint {
@@ -179,14 +186,6 @@ fn enc_sty(w: io::writer, cx: @ctxt, st: ty::sty) {
         enc_ty(w, cx, ty);
         for tc: @ty::type_constr in cs { enc_ty_constr(w, cx, tc); }
         w.write_char(']');
-      }
-      ty::ty_named(t, name) {
-        if cx.abbrevs != ac_no_abbrevs {
-            w.write_char('"');
-            w.write_str(*name);
-            w.write_char('"');
-        }
-        enc_ty(w, cx, t);
       }
     }
 }

--- a/src/comp/middle/alias.rs
+++ b/src/comp/middle/alias.rs
@@ -80,7 +80,7 @@ fn visit_fn(cx: @ctx, _fk: visit::fn_kind, decl: ast::fn_decl,
             id: ast::node_id, sc: scope, v: vt<scope>) {
     visit::visit_fn_decl(decl, sc, v);
     let fty = ty::node_id_to_type(cx.tcx, id);
-    let args = ty::ty_fn_args(cx.tcx, fty);
+    let args = ty::ty_fn_args(fty);
     for arg in args {
         if arg.mode == ast::by_val &&
            ty::type_has_dynamic_size(cx.tcx, arg.ty) {
@@ -90,7 +90,7 @@ fn visit_fn(cx: @ctx, _fk: visit::fn_kind, decl: ast::fn_decl,
 
     // Blocks need to obey any restrictions from the enclosing scope, and may
     // be called multiple times.
-    let proto = ty::ty_fn_proto(cx.tcx, fty);
+    let proto = ty::ty_fn_proto(fty);
     alt proto {
       ast::proto_block | ast::proto_any {
         check_loop(*cx, sc) {|| v.visit_block(body, sc, v);}
@@ -219,7 +219,7 @@ fn cant_copy(cx: ctx, b: binding) -> bool {
 fn check_call(cx: ctx, sc: scope, f: @ast::expr, args: [@ast::expr])
     -> [binding] {
     let fty = ty::expr_ty(cx.tcx, f);
-    let arg_ts = ty::ty_fn_args(cx.tcx, fty);
+    let arg_ts = ty::ty_fn_args(fty);
     let mut_roots: [{arg: uint, node: node_id}] = [];
     let bindings = [];
     let i = 0u;
@@ -364,7 +364,7 @@ fn check_for(cx: ctx, local: @ast::local, seq: @ast::expr, blk: ast::blk,
     // If this is a mutable vector, don't allow it to be touched.
     let seq_t = ty::expr_ty(cx.tcx, seq);
     let cur_mut = root.mut;
-    alt ty::struct(cx.tcx, seq_t) {
+    alt ty::get(seq_t).struct {
       ty::ty_vec(mt) {
         if mt.mut != ast::imm {
             cur_mut = some(contains(seq_t));
@@ -503,7 +503,7 @@ fn ty_can_unsafely_include(cx: ctx, needle: unsafe_ty, haystack: ty::t,
           contains(ty) { ty == haystack }
           mut_contains(ty) { mut && ty == haystack }
         } { ret true; }
-        alt ty::struct(tcx, haystack) {
+        alt ty::get(haystack).struct {
           ty::ty_enum(_, ts) {
             for t: ty::t in ts {
                 if helper(tcx, needle, t, mut) { ret true; }
@@ -558,7 +558,7 @@ fn local_id_of_node(cx: ctx, id: node_id) -> uint {
 // implicit copy.
 fn copy_is_expensive(tcx: ty::ctxt, ty: ty::t) -> bool {
     fn score_ty(tcx: ty::ctxt, ty: ty::t) -> uint {
-        ret alt ty::struct(tcx, ty) {
+        ret alt ty::get(ty).struct {
           ty::ty_nil | ty::ty_bot | ty::ty_bool | ty::ty_int(_) |
           ty::ty_uint(_) | ty::ty_float(_) | ty::ty_type |
           ty::ty_ptr(_) { 1u }
@@ -616,7 +616,7 @@ fn pattern_roots(tcx: ty::ctxt, mut: option<unsafe_ty>, pat: @ast::pat)
           }
           ast::pat_box(p) {
             let ty = ty::node_id_to_type(tcx, pat.id);
-            let m = alt ty::struct(tcx, ty) {
+            let m = alt ty::get(ty).struct {
               ty::ty_box(mt) { mt.mut != ast::imm }
               _ { tcx.sess.span_bug(pat.span, "box pat has non-box type"); }
             },
@@ -625,7 +625,7 @@ fn pattern_roots(tcx: ty::ctxt, mut: option<unsafe_ty>, pat: @ast::pat)
           }
           ast::pat_uniq(p) {
             let ty = ty::node_id_to_type(tcx, pat.id);
-            let m = alt ty::struct(tcx, ty) {
+            let m = alt ty::get(ty).struct {
               ty::ty_uniq(mt) { mt.mut != ast::imm }
               _ { tcx.sess.span_bug(pat.span, "uniq pat has non-uniq type"); }
             },

--- a/src/comp/middle/block_use.rs
+++ b/src/comp/middle/block_use.rs
@@ -13,7 +13,7 @@ fn check_crate(tcx: ty::ctxt, crate: @crate) {
 
 fn visit_expr(ex: @expr, cx: ctx, v: visit::vt<ctx>) {
     if !cx.allow_block {
-        alt ty::struct(cx.tcx, ty::expr_ty(cx.tcx, ex)) {
+        alt ty::get(ty::expr_ty(cx.tcx, ex)).struct {
           ty::ty_fn({proto: p, _}) if is_blockish(p) {
             cx.tcx.sess.span_err(ex.span, "expressions with block type \
                 can only appear in callee or (by-ref) argument position");
@@ -27,7 +27,7 @@ fn visit_expr(ex: @expr, cx: ctx, v: visit::vt<ctx>) {
         cx.allow_block = true;
         v.visit_expr(f, cx, v);
         let i = 0u;
-        for arg_t in ty::ty_fn_args(cx.tcx, ty::expr_ty(cx.tcx, f)) {
+        for arg_t in ty::ty_fn_args(ty::expr_ty(cx.tcx, f)) {
             cx.allow_block = arg_t.mode == by_ref;
             v.visit_expr(args[i], cx, v);
             i += 1u;

--- a/src/comp/middle/check_alt.rs
+++ b/src/comp/middle/check_alt.rs
@@ -73,7 +73,7 @@ fn check_exhaustive(tcx: ty::ctxt, sp:span, scrut_ty:ty::t, pats:[@pat]) {
     /* Otherwise, get the list of variants and make sure each one is
      represented. Then recurse on the columns. */
 
-    let ty_def_id = alt ty::struct(tcx, scrut_ty) {
+    let ty_def_id = alt ty::get(scrut_ty).struct {
             ty_enum(id, _) { id }
             _ { ret; } };
 

--- a/src/comp/middle/fn_usage.rs
+++ b/src/comp/middle/fn_usage.rs
@@ -31,7 +31,7 @@ fn fn_usage_expr(expr: @ast::expr,
         }
         if !ctx.generic_bare_fn_legal
             && ty::expr_has_ty_params(ctx.tcx, expr) {
-            alt ty::struct(ctx.tcx, ty::expr_ty(ctx.tcx, expr)) {
+            alt ty::get(ty::expr_ty(ctx.tcx, expr)).struct {
               ty::ty_fn({proto: ast::proto_bare, _}) {
                 ctx.tcx.sess.span_fatal(
                     expr.span,

--- a/src/comp/middle/kind.rs
+++ b/src/comp/middle/kind.rs
@@ -60,7 +60,7 @@ fn check_crate(tcx: ty::ctxt, method_map: typeck::method_map,
 fn with_appropriate_checker(cx: ctx, id: node_id,
                             b: fn(fn@(ctx, ty::t, sp: span))) {
     let fty = ty::node_id_to_type(cx.tcx, id);
-    alt ty::ty_fn_proto(cx.tcx, fty) {
+    alt ty::ty_fn_proto(fty) {
       proto_uniq { b(check_send); }
       proto_box { b(check_copy); }
       proto_bare { b(check_none); }
@@ -142,9 +142,10 @@ fn check_expr(e: @expr, cx: ctx, v: visit::vt<ctx>) {
           some(ex) {
             // All noncopyable fields must be overridden
             let t = ty::expr_ty(cx.tcx, ex);
-            let ty_fields = alt ty::struct(cx.tcx, t) { ty::ty_rec(f) { f }
-              _ { cx.tcx.sess.span_bug(ex.span,
-                     "Bad expr type in record"); } };
+            let ty_fields = alt ty::get(t).struct {
+              ty::ty_rec(f) { f }
+              _ { cx.tcx.sess.span_bug(ex.span, "Bad expr type in record"); }
+            };
             for tf in ty_fields {
                 if !vec::any(fields, {|f| f.node.ident == tf.ident}) &&
                     !ty::kind_can_be_copied(ty::type_kind(cx.tcx, tf.mt.ty)) {
@@ -164,7 +165,7 @@ fn check_expr(e: @expr, cx: ctx, v: visit::vt<ctx>) {
       }
       expr_call(f, args, _) {
         let i = 0u;
-        for arg_t in ty::ty_fn_args(cx.tcx, ty::expr_ty(cx.tcx, f)) {
+        for arg_t in ty::ty_fn_args(ty::expr_ty(cx.tcx, f)) {
             alt arg_t.mode { by_copy { maybe_copy(cx, args[i]); } _ {} }
             i += 1u;
         }
@@ -239,7 +240,7 @@ fn check_copy_ex(cx: ctx, ex: @expr, _warn: bool) {
         check_copy(cx, ty, ex.span);
         // FIXME turn this on again once vector types are no longer unique.
         // Right now, it is too annoying to be useful.
-        /* if warn && ty::type_is_unique(cx.tcx, ty) {
+        /* if warn && ty::type_is_unique(ty) {
             cx.tcx.sess.span_warn(ex.span, "copying a unique value");
         }*/
     }

--- a/src/comp/middle/last_use.rs
+++ b/src/comp/middle/last_use.rs
@@ -65,7 +65,7 @@ fn find_last_uses(c: @crate, def_map: resolve::def_map,
 }
 
 fn ex_is_blockish(cx: ctx, id: node_id) -> bool {
-    alt ty::struct(cx.tcx, ty::node_id_to_type(cx.tcx, id)) {
+    alt ty::get(ty::node_id_to_type(cx.tcx, id)).struct {
       ty::ty_fn({proto: p, _}) if is_blockish(p) { true }
       _ { false }
     }
@@ -147,7 +147,7 @@ fn visit_expr(ex: @expr, cx: ctx, v: visit::vt<ctx>) {
       expr_call(f, args, _) {
         v.visit_expr(f, cx, v);
         let i = 0u, fns = [];
-        let arg_ts = ty::ty_fn_args(cx.tcx, ty::expr_ty(cx.tcx, f));
+        let arg_ts = ty::ty_fn_args(ty::expr_ty(cx.tcx, f));
         for arg in args {
             alt arg.node {
               expr_fn(p, _, _, _) if is_blockish(p) {
@@ -175,7 +175,7 @@ fn visit_fn(fk: visit::fn_kind, decl: fn_decl, body: blk,
             sp: span, id: node_id,
             cx: ctx, v: visit::vt<ctx>) {
     let fty = ty::node_id_to_type(cx.tcx, id);
-    let proto = ty::ty_fn_proto(cx.tcx, fty);
+    let proto = ty::ty_fn_proto(fty);
     alt proto {
       proto_any | proto_block {
         visit_block(func, cx, {||

--- a/src/comp/middle/mut.rs
+++ b/src/comp/middle/mut.rs
@@ -18,7 +18,7 @@ fn expr_root(tcx: ty::ctxt, ex: @expr, autoderef: bool) ->
     fn maybe_auto_unbox(tcx: ty::ctxt, t: ty::t) -> {t: ty::t, ds: [deref]} {
         let ds = [], t = t;
         while true {
-            alt ty::struct(tcx, t) {
+            alt ty::get(t).struct {
               ty::ty_box(mt) {
                 ds += [@{mut: mt.mut == mut, kind: unbox(false), outer_t: t}];
                 t = mt.ty;
@@ -51,7 +51,7 @@ fn expr_root(tcx: ty::ctxt, ex: @expr, autoderef: bool) ->
           expr_field(base, ident, _) {
             let auto_unbox = maybe_auto_unbox(tcx, ty::expr_ty(tcx, base));
             let is_mut = false;
-            alt ty::struct(tcx, auto_unbox.t) {
+            alt ty::get(auto_unbox.t).struct {
               ty::ty_rec(fields) {
                 for fld: ty::field in fields {
                     if str::eq(ident, fld.ident) {
@@ -68,7 +68,7 @@ fn expr_root(tcx: ty::ctxt, ex: @expr, autoderef: bool) ->
           }
           expr_index(base, _) {
             let auto_unbox = maybe_auto_unbox(tcx, ty::expr_ty(tcx, base));
-            alt ty::struct(tcx, auto_unbox.t) {
+            alt ty::get(auto_unbox.t).struct {
               ty::ty_vec(mt) {
                 ds +=
                     [@{mut: mt.mut == mut,
@@ -87,7 +87,7 @@ fn expr_root(tcx: ty::ctxt, ex: @expr, autoderef: bool) ->
             if op == deref {
                 let base_t = ty::expr_ty(tcx, base);
                 let is_mut = false, ptr = false;
-                alt ty::struct(tcx, base_t) {
+                alt ty::get(base_t).struct {
                   ty::ty_box(mt) { is_mut = mt.mut == mut; }
                   ty::ty_uniq(mt) { is_mut = mt.mut == mut; }
                   ty::ty_res(_, _, _) { }
@@ -225,7 +225,7 @@ fn check_move_rhs(cx: @ctx, src: @expr) {
 }
 
 fn check_call(cx: @ctx, f: @expr, args: [@expr]) {
-    let arg_ts = ty::ty_fn_args(cx.tcx, ty::expr_ty(cx.tcx, f));
+    let arg_ts = ty::ty_fn_args(ty::expr_ty(cx.tcx, f));
     let i = 0u;
     for arg_t: ty::arg in arg_ts {
         alt arg_t.mode {
@@ -238,7 +238,7 @@ fn check_call(cx: @ctx, f: @expr, args: [@expr]) {
 }
 
 fn check_bind(cx: @ctx, f: @expr, args: [option<@expr>]) {
-    let arg_ts = ty::ty_fn_args(cx.tcx, ty::expr_ty(cx.tcx, f));
+    let arg_ts = ty::ty_fn_args(ty::expr_ty(cx.tcx, f));
     let i = 0u;
     for arg in args {
         alt arg {
@@ -272,7 +272,7 @@ fn is_immutable_def(cx: @ctx, def: def) -> option<str> {
       def_self(_) { some("self argument") }
       def_upvar(_, inner, node_id) {
         let ty = ty::node_id_to_type(cx.tcx, node_id);
-        let proto = ty::ty_fn_proto(cx.tcx, ty);
+        let proto = ty::ty_fn_proto(ty);
         ret alt proto {
           proto_any | proto_block { is_immutable_def(cx, *inner) }
           _ { some("upvar") }

--- a/src/comp/middle/shape.rs
+++ b/src/comp/middle/shape.rs
@@ -76,7 +76,7 @@ fn hash_res_info(ri: res_info) -> uint {
     h *= 33u;
     h += ri.did.node as uint;
     h *= 33u;
-    h += ri.t as uint;
+    h += ty::type_id(ri.t);
     ret h;
 }
 
@@ -121,7 +121,7 @@ fn largest_variants(ccx: @crate_ctxt, tag_id: ast::def_id) -> [uint] {
         let bounded = true;
         let {a: min_size, b: min_align} = {a: 0u, b: 0u};
         for elem_t: ty::t in variant.args {
-            if ty::type_contains_params(ccx.tcx, elem_t) {
+            if ty::type_has_params(elem_t) {
                 // TODO: We could do better here; this causes us to
                 // conservatively assume that (int, T) has minimum size 0,
                 // when in fact it has minimum size sizeof(int).
@@ -319,7 +319,7 @@ fn add_substr(&dest: [u8], src: [u8]) {
 fn shape_of(ccx: @crate_ctxt, t: ty::t, ty_param_map: [uint]) -> [u8] {
     let s = [];
 
-    alt ty::struct(ccx.tcx, t) {
+    alt ty::get(t).struct {
       ty::ty_nil | ty::ty_bool | ty::ty_uint(ast::ty_u8) |
       ty::ty_bot { s += [shape_u8]; }
       ty::ty_int(ast::ty_i) { s += [s_int(ccx.tcx)]; }
@@ -449,9 +449,6 @@ fn shape_of(ccx: @crate_ctxt, t: ty::t, ty_param_map: [uint]) -> [u8] {
       }
       ty::ty_constr(inner_t, _) {
         s += shape_of(ccx, inner_t, ty_param_map);
-      }
-      ty::ty_named(_, _) {
-        ccx.tcx.sess.bug("shape_of: shouldn't see a ty_named");
       }
     }
 
@@ -667,7 +664,7 @@ fn llalign_of(cx: @crate_ctxt, t: TypeRef) -> ValueRef {
 fn static_size_of_enum(cx: @crate_ctxt, t: ty::t)
     : type_has_static_size(cx, t) -> uint {
     if cx.enum_sizes.contains_key(t) { ret cx.enum_sizes.get(t); }
-    alt ty::struct(cx.tcx, t) {
+    alt ty::get(t).struct {
       ty::ty_enum(tid, subtys) {
         // Compute max(variant sizes).
 
@@ -722,7 +719,7 @@ fn dynamic_metrics(cx: @block_ctxt, t: ty::t) -> metrics {
         ret { bcx: bcx, sz: off, align: max_align };
     }
 
-    alt ty::struct(bcx_tcx(cx), t) {
+    alt ty::get(t).struct {
       ty::ty_param(p, _) {
         let ti = none::<@tydesc_info>;
         let {bcx, val: tydesc} = base::get_tydesc(cx, t, false, ti).result;
@@ -786,7 +783,7 @@ fn dynamic_metrics(cx: @block_ctxt, t: ty::t) -> metrics {
 // types.
 fn simplify_type(ccx: @crate_ctxt, typ: ty::t) -> ty::t {
     fn simplifier(ccx: @crate_ctxt, typ: ty::t) -> ty::t {
-        alt ty::struct(ccx.tcx, typ) {
+        alt ty::get(typ).struct {
           ty::ty_box(_) | ty::ty_iface(_, _) {
             ret ty::mk_imm_box(ccx.tcx, ty::mk_nil(ccx.tcx));
           }

--- a/src/comp/middle/trans/base.rs
+++ b/src/comp/middle/trans/base.rs
@@ -55,9 +55,6 @@ fn type_of_1(bcx: @block_ctxt, t: ty::t) -> TypeRef {
 
 fn type_of(cx: @crate_ctxt, t: ty::t) : type_has_static_size(cx, t)
    -> TypeRef {
-    // Should follow from type_has_static_size -- argh.
-    // FIXME (requires Issue #586)
-    check non_ty_var(cx, t);
     type_of_inner(cx, t)
 }
 
@@ -66,9 +63,6 @@ fn type_of_explicit_args(cx: @crate_ctxt, inputs: [ty::arg]) ->
     let atys = [];
     for arg in inputs {
         let arg_ty = arg.ty;
-        // FIXME: would be nice to have a constraint on arg
-        // that would obviate the need for this check
-        check non_ty_var(cx, arg_ty);
         let llty = type_of_inner(cx, arg_ty);
         atys += [if arg.mode == ast::by_val { llty } else { T_ptr(llty) }];
     }
@@ -87,7 +81,6 @@ fn type_of_fn(cx: @crate_ctxt, inputs: [ty::arg],
     let atys: [TypeRef] = [];
 
     // Arg 0: Output pointer.
-    check non_ty_var(cx, output);
     let out_ty = T_ptr(type_of_inner(cx, output));
     atys += [out_ty];
 
@@ -112,17 +105,15 @@ fn type_of_fn(cx: @crate_ctxt, inputs: [ty::arg],
 // Given a function type and a count of ty params, construct an llvm type
 fn type_of_fn_from_ty(cx: @crate_ctxt, fty: ty::t,
                       param_bounds: [ty::param_bounds]) -> TypeRef {
-    let ret_ty = ty::ty_fn_ret(cx.tcx, fty);
-    ret type_of_fn(cx, ty::ty_fn_args(cx.tcx, fty),
-                   ret_ty, param_bounds);
+    type_of_fn(cx, ty::ty_fn_args(fty), ty::ty_fn_ret(fty), param_bounds)
 }
 
-fn type_of_inner(cx: @crate_ctxt, t: ty::t)
-    : non_ty_var(cx, t) -> TypeRef {
+fn type_of_inner(cx: @crate_ctxt, t: ty::t) -> TypeRef {
+    assert !ty::type_has_vars(t);
     // Check the cache.
 
     if cx.lltypes.contains_key(t) { ret cx.lltypes.get(t); }
-    let llty = alt ty::struct(cx.tcx, t) {
+    let llty = alt ty::get(t).struct {
       ty::ty_nil { T_nil() }
       ty::ty_bot {
         T_nil() /* ...I guess? */
@@ -135,30 +126,24 @@ fn type_of_inner(cx: @crate_ctxt, t: ty::t)
       ty::ty_enum(did, _) { type_of_enum(cx, did, t) }
       ty::ty_box(mt) {
         let mt_ty = mt.ty;
-        check non_ty_var(cx, mt_ty);
         T_ptr(T_box(cx, type_of_inner(cx, mt_ty))) }
       ty::ty_uniq(mt) {
         let mt_ty = mt.ty;
-        check non_ty_var(cx, mt_ty);
         T_ptr(type_of_inner(cx, mt_ty)) }
       ty::ty_vec(mt) {
         let mt_ty = mt.ty;
         if ty::type_has_dynamic_size(cx.tcx, mt_ty) {
             T_ptr(cx.opaque_vec_type)
         } else {
-            // should be unnecessary
-            check non_ty_var(cx, mt_ty);
             T_ptr(T_vec(cx, type_of_inner(cx, mt_ty))) }
       }
       ty::ty_ptr(mt) {
         let mt_ty = mt.ty;
-        check non_ty_var(cx, mt_ty);
         T_ptr(type_of_inner(cx, mt_ty)) }
       ty::ty_rec(fields) {
         let tys: [TypeRef] = [];
         for f: ty::field in fields {
             let mt_ty = f.mt.ty;
-            check non_ty_var(cx, mt_ty);
             tys += [type_of_inner(cx, mt_ty)];
         }
         T_struct(tys)
@@ -169,7 +154,6 @@ fn type_of_inner(cx: @crate_ctxt, t: ty::t)
       ty::ty_iface(_, _) { T_opaque_iface_ptr(cx) }
       ty::ty_res(_, sub, tps) {
         let sub1 = ty::substitute_type_params(cx.tcx, tps, sub);
-        check non_ty_var(cx, sub1);
         // FIXME #1184: Resource flag is larger than necessary
         ret T_struct([cx.int_type, type_of_inner(cx, sub1)]);
       }
@@ -185,7 +169,6 @@ fn type_of_inner(cx: @crate_ctxt, t: ty::t)
       ty::ty_tup(elts) {
         let tys = [];
         for elt in elts {
-            check non_ty_var(cx, elt);
             tys += [type_of_inner(cx, elt)];
         }
         T_struct(tys)
@@ -194,8 +177,6 @@ fn type_of_inner(cx: @crate_ctxt, t: ty::t)
         T_opaque_box_ptr(cx)
       }
       ty::ty_constr(subt,_) {
-        // FIXME: could be a constraint on ty_fn
-          check non_ty_var(cx, subt);
           type_of_inner(cx, subt)
       }
       _ {
@@ -224,7 +205,7 @@ fn type_of_enum(cx: @crate_ctxt, did: ast::def_id, t: ty::t)
 fn type_of_ty_param_bounds_and_ty
     (ccx: @crate_ctxt, tpt: ty::ty_param_bounds_and_ty) -> TypeRef {
     let t = tpt.ty;
-    alt ty::struct(ccx.tcx, t) {
+    alt ty::get(t).struct {
       ty::ty_fn(_) {
         ret type_of_fn_from_ty(ccx, t, *tpt.bounds);
       }
@@ -449,7 +430,7 @@ fn mk_obstack_token(ccx: @crate_ctxt, fcx: @fn_ctxt) ->
 // types.
 fn simplify_type(ccx: @crate_ctxt, typ: ty::t) -> ty::t {
     fn simplifier(ccx: @crate_ctxt, typ: ty::t) -> ty::t {
-        alt ty::struct(ccx.tcx, typ) {
+        alt ty::get(typ).struct {
           ty::ty_box(_) | ty::ty_iface(_, _) {
             ret ty::mk_imm_box(ccx.tcx, ty::mk_nil(ccx.tcx));
           }
@@ -507,7 +488,7 @@ fn dynamic_size_of(cx: @block_ctxt, t: ty::t) -> result {
         //};
         ret rslt(bcx, off);
     }
-    alt ty::struct(bcx_tcx(cx), t) {
+    alt ty::get(t).struct {
       ty::ty_param(p, _) {
         let szptr = field_of_tydesc(cx, t, false, abi::tydesc_field_size);
         ret rslt(szptr.bcx, Load(szptr.bcx, szptr.val));
@@ -561,7 +542,7 @@ fn dynamic_size_of(cx: @block_ctxt, t: ty::t) -> result {
 fn dynamic_align_of(cx: @block_ctxt, t: ty::t) -> result {
 // FIXME: Typestate constraint that shows this alt is
 // exhaustive
-    alt ty::struct(bcx_tcx(cx), t) {
+    alt ty::get(t).struct {
       ty::ty_param(p, _) {
         let aptr = field_of_tydesc(cx, t, false, abi::tydesc_field_align);
         ret rslt(aptr.bcx, Load(aptr.bcx, aptr.val));
@@ -614,22 +595,13 @@ fn bump_ptr(bcx: @block_ctxt, t: ty::t, base: ValueRef, sz: ValueRef) ->
     } else { bumped }
 }
 
-// GEP_tup_like is a pain to use if you always have to precede it with a
-// check.
-fn GEP_tup_like_1(cx: @block_ctxt, t: ty::t, base: ValueRef, ixs: [int])
-    -> result {
-    check type_is_tup_like(cx, t);
-    ret GEP_tup_like(cx, t, base, ixs);
-}
-
 // Replacement for the LLVM 'GEP' instruction when field-indexing into a
 // tuple-like structure (tup, rec) with a static index. This one is driven off
 // ty::struct and knows what to do when it runs into a ty_param stuck in the
 // middle of the thing it's GEP'ing into. Much like size_of and align_of,
 // above.
 fn GEP_tup_like(bcx: @block_ctxt, t: ty::t, base: ValueRef, ixs: [int])
-    : type_is_tup_like(bcx, t) -> result {
-
+    -> result {
     fn compute_off(bcx: @block_ctxt,
                    off: ValueRef,
                    t: ty::t,
@@ -639,11 +611,10 @@ fn GEP_tup_like(bcx: @block_ctxt, t: ty::t, base: ValueRef, ixs: [int])
             ret (bcx, off, t);
         }
 
-        let tcx = bcx_tcx(bcx);
         let ix = ixs[n];
         let bcx = bcx, off = off;
         int::range(0, ix) {|i|
-            let comp_t = ty::get_element_type(tcx, t, i as uint);
+            let comp_t = ty::get_element_type(t, i as uint);
             let align = align_of(bcx, comp_t);
             bcx = align.bcx;
             off = align_to(bcx, off, align.val);
@@ -652,7 +623,7 @@ fn GEP_tup_like(bcx: @block_ctxt, t: ty::t, base: ValueRef, ixs: [int])
             off = Add(bcx, off, sz.val);
         }
 
-        let comp_t = ty::get_element_type(tcx, t, ix as uint);
+        let comp_t = ty::get_element_type(t, ix as uint);
         let align = align_of(bcx, comp_t);
         bcx = align.bcx;
         off = align_to(bcx, off, align.val);
@@ -721,8 +692,6 @@ fn GEP_enum(cx: @block_ctxt, llblobptr: ValueRef, enum_id: ast::def_id,
     } else { llunionptr = llblobptr; }
 
     // Do the GEP_tup_like().
-    // Silly check -- postcondition on mk_tup?
-    check type_is_tup_like(cx, tup_ty);
     let rs = GEP_tup_like(cx, tup_ty, llunionptr, [0, ix as int]);
     // Cast the result to the appropriate type, if necessary.
 
@@ -820,7 +789,7 @@ fn linearize_ty_params(cx: @block_ctxt, t: ty::t) ->
    {params: [uint], descs: [ValueRef]} {
     let param_vals = [], param_defs = [];
     ty::walk_ty(bcx_tcx(cx), t) {|t|
-        alt ty::struct(bcx_tcx(cx), t) {
+        alt ty::get(t).struct {
           ty::ty_param(pid, _) {
             if !vec::any(param_defs, {|d| d == pid}) {
                 param_vals += [cx.fcx.lltyparams[pid].desc];
@@ -935,7 +904,7 @@ fn get_tydesc(cx: @block_ctxt, t: ty::t, escapes: bool,
    -> get_tydesc_result {
 
     // Is the supplied type a type param? If so, return the passed-in tydesc.
-    alt ty::type_param(bcx_tcx(cx), t) {
+    alt ty::type_param(t) {
       some(id) {
         if id < vec::len(cx.fcx.lltyparams) {
             ret {kind: tk_param,
@@ -950,7 +919,7 @@ fn get_tydesc(cx: @block_ctxt, t: ty::t, escapes: bool,
     }
 
     // Does it contain a type param? If so, generate a derived tydesc.
-    if ty::type_contains_params(bcx_tcx(cx), t) {
+    if ty::type_has_params(t) {
         ret {kind: tk_derived,
              result: get_derived_tydesc(cx, t, escapes, static_ti)};
     }
@@ -995,8 +964,8 @@ fn set_custom_stack_growth_fn(f: ValueRef) {
     llvm::LLVMAddFunctionAttr(f, 0u as c_uint, 1u as c_uint);
 }
 
-fn set_glue_inlining(ccx: @crate_ctxt, f: ValueRef, t: ty::t) {
-    if ty::type_is_structural(ccx.tcx, t) {
+fn set_glue_inlining(f: ValueRef, t: ty::t) {
+    if ty::type_is_structural(t) {
         set_no_inline(f);
     } else { set_always_inline(f); }
 }
@@ -1052,7 +1021,7 @@ fn declare_generic_glue(ccx: @crate_ctxt, t: ty::t, llfnty: TypeRef,
         fn_nm = sanitize(fn_nm);
     } else { fn_nm = mangle_internal_name_by_seq(ccx, "glue_" + name); }
     let llfn = decl_cdecl_fn(ccx.llmod, fn_nm, llfnty);
-    set_glue_inlining(ccx, llfn, t);
+    set_glue_inlining(llfn, t);
     ret llfn;
 }
 
@@ -1169,14 +1138,12 @@ fn emit_tydescs(ccx: @crate_ctxt) {
 fn make_take_glue(cx: @block_ctxt, v: ValueRef, t: ty::t) {
 
     let bcx = cx;
-    let tcx = bcx_tcx(cx);
     // NB: v is an *alias* of type t here, not a direct value.
-    bcx = alt ty::struct(tcx, t) {
+    bcx = alt ty::get(t).struct {
       ty::ty_box(_) | ty::ty_iface(_, _) {
         incr_refcnt_of_boxed(bcx, Load(bcx, v))
       }
       ty::ty_uniq(_) {
-        check uniq::type_is_unique_box(bcx, t);
         let r = uniq::duplicate(bcx, Load(bcx, v), t);
         Store(r.bcx, r.val, v);
         r.bcx
@@ -1200,7 +1167,7 @@ fn make_take_glue(cx: @block_ctxt, v: ValueRef, t: ty::t) {
       ty::ty_opaque_closure_ptr(ck) {
         closure::make_opaque_cbox_take_glue(bcx, ck, v)
       }
-      _ if ty::type_is_structural(bcx_tcx(bcx), t) {
+      _ if ty::type_is_structural(t) {
         iter_structural_ty(bcx, v, t, take_ty)
       }
       _ { bcx }
@@ -1220,7 +1187,7 @@ fn incr_refcnt_of_boxed(cx: @block_ctxt, box_ptr: ValueRef) -> @block_ctxt {
 }
 
 fn free_box(bcx: @block_ctxt, v: ValueRef, t: ty::t) -> @block_ctxt {
-    ret alt ty::struct(bcx_tcx(bcx), t) {
+    ret alt ty::get(t).struct {
       ty::ty_box(body_mt) {
         let v = PointerCast(bcx, v, type_of_1(bcx, t));
         let body = GEPi(bcx, v, [0, abi::box_field_body]);
@@ -1236,12 +1203,11 @@ fn make_free_glue(bcx: @block_ctxt, v: ValueRef, t: ty::t) {
     // v is a pointer to the actual box component of the type here. The
     // ValueRef will have the wrong type here (make_generic_glue is casting
     // everything to a pointer to the type that the glue acts on).
-    let bcx = alt ty::struct(bcx_tcx(bcx), t) {
+    let bcx = alt ty::get(t).struct {
       ty::ty_box(body_mt) {
         free_box(bcx, v, t)
       }
       ty::ty_uniq(content_mt) {
-        check uniq::type_is_unique_box(bcx, t);
         let v = PointerCast(bcx, v, type_of_1(bcx, t));
         uniq::make_free_glue(bcx, v, t)
       }
@@ -1284,30 +1250,29 @@ fn make_free_glue(bcx: @block_ctxt, v: ValueRef, t: ty::t) {
 fn make_drop_glue(bcx: @block_ctxt, v0: ValueRef, t: ty::t) {
     // NB: v0 is an *alias* of type t here, not a direct value.
     let ccx = bcx_ccx(bcx);
-    let bcx =
-        alt ty::struct(ccx.tcx, t) {
-          ty::ty_box(_) | ty::ty_iface(_, _) {
-              decr_refcnt_maybe_free(bcx, Load(bcx, v0), t)
-          }
-          ty::ty_uniq(_) | ty::ty_vec(_) | ty::ty_str | ty::ty_send_type {
-            free_ty(bcx, Load(bcx, v0), t)
-          }
-          ty::ty_res(did, inner, tps) {
-            trans_res_drop(bcx, v0, did, inner, tps)
-          }
-          ty::ty_fn(_) {
-            closure::make_fn_glue(bcx, v0, t, drop_ty)
-          }
-          ty::ty_opaque_closure_ptr(ck) {
-            closure::make_opaque_cbox_drop_glue(bcx, ck, v0)
-          }
-          _ {
-            if ty::type_needs_drop(ccx.tcx, t) &&
-               ty::type_is_structural(ccx.tcx, t) {
-                iter_structural_ty(bcx, v0, t, drop_ty)
-            } else { bcx }
-          }
-        };
+    let bcx = alt ty::get(t).struct {
+      ty::ty_box(_) | ty::ty_iface(_, _) {
+        decr_refcnt_maybe_free(bcx, Load(bcx, v0), t)
+      }
+      ty::ty_uniq(_) | ty::ty_vec(_) | ty::ty_str | ty::ty_send_type {
+        free_ty(bcx, Load(bcx, v0), t)
+      }
+      ty::ty_res(did, inner, tps) {
+        trans_res_drop(bcx, v0, did, inner, tps)
+      }
+      ty::ty_fn(_) {
+        closure::make_fn_glue(bcx, v0, t, drop_ty)
+      }
+      ty::ty_opaque_closure_ptr(ck) {
+        closure::make_opaque_cbox_drop_glue(bcx, ck, v0)
+      }
+      _ {
+        if ty::type_needs_drop(ccx.tcx, t) &&
+            ty::type_is_structural(t) {
+            iter_structural_ty(bcx, v0, t, drop_ty)
+        } else { bcx }
+      }
+    };
     build_return(bcx);
 }
 
@@ -1319,15 +1284,12 @@ fn trans_res_drop(cx: @block_ctxt, rs: ValueRef, did: ast::def_id,
     let drop_cx = new_sub_block_ctxt(cx, "drop res");
     let next_cx = new_sub_block_ctxt(cx, "next");
 
-    // Silly check
-    check type_is_tup_like(cx, tup_ty);
     let drop_flag = GEP_tup_like(cx, tup_ty, rs, [0, 0]);
     let cx = drop_flag.bcx;
     let null_test = IsNull(cx, Load(cx, drop_flag.val));
     CondBr(cx, null_test, next_cx.llbb, drop_cx.llbb);
     cx = drop_cx;
 
-    check type_is_tup_like(cx, tup_ty);
     let val = GEP_tup_like(cx, tup_ty, rs, [0, 1]);
     cx = val.bcx;
     // Find and call the actual destructor.
@@ -1406,7 +1368,7 @@ fn compare_scalar_types(cx: @block_ctxt, lhs: ValueRef, rhs: ValueRef,
                         t: ty::t, op: ast::binop) -> result {
     let f = bind compare_scalar_values(cx, lhs, rhs, _, op);
 
-    alt ty::struct(bcx_tcx(cx), t) {
+    alt ty::get(t).struct {
       ty::ty_nil { ret rslt(cx, f(nil_type)); }
       ty::ty_bool | ty::ty_ptr(_) { ret rslt(cx, f(unsigned_int)); }
       ty::ty_int(_) { ret rslt(cx, f(signed_int)); }
@@ -1520,7 +1482,7 @@ fn iter_structural_ty(cx: @block_ctxt, av: ValueRef, t: ty::t,
         let fn_ty = variant.ctor_ty;
         let ccx = bcx_ccx(cx);
         let cx = cx;
-        alt ty::struct(ccx.tcx, fn_ty) {
+        alt ty::get(fn_ty).struct {
           ty::ty_fn({inputs: args, _}) {
             let j = 0u;
             let v_id = variant.id;
@@ -1544,12 +1506,10 @@ fn iter_structural_ty(cx: @block_ctxt, av: ValueRef, t: ty::t,
     Typestate constraint that shows the unimpl case doesn't happen?
     */
     let cx = cx;
-    alt ty::struct(bcx_tcx(cx), t) {
+    alt ty::get(t).struct {
       ty::ty_rec(fields) {
         let i: int = 0;
         for fld: ty::field in fields {
-            // Silly check
-            check type_is_tup_like(cx, t);
             let {bcx: bcx, val: llfld_a} = GEP_tup_like(cx, t, av, [0, i]);
             cx = f(bcx, llfld_a, fld.mt.ty);
             i += 1;
@@ -1558,8 +1518,6 @@ fn iter_structural_ty(cx: @block_ctxt, av: ValueRef, t: ty::t,
       ty::ty_tup(args) {
         let i = 0;
         for arg in args {
-            // Silly check
-            check type_is_tup_like(cx, t);
             let {bcx: bcx, val: llfld_a} = GEP_tup_like(cx, t, av, [0, i]);
             cx = f(bcx, llfld_a, arg);
             i += 1;
@@ -1570,8 +1528,6 @@ fn iter_structural_ty(cx: @block_ctxt, av: ValueRef, t: ty::t,
         let inner1 = ty::substitute_type_params(tcx, tps, inner);
         let inner_t_s = ty::substitute_type_params(tcx, tps, inner);
         let tup_t = ty::mk_tup(tcx, [ty::mk_int(tcx), inner_t_s]);
-        // Silly check
-        check type_is_tup_like(cx, tup_t);
         let {bcx: bcx, val: llfld_a} = GEP_tup_like(cx, tup_t, av, [0, 1]);
         ret f(bcx, llfld_a, inner1);
       }
@@ -1800,7 +1756,7 @@ fn drop_ty(cx: @block_ctxt, v: ValueRef, t: ty::t) -> @block_ctxt {
 }
 
 fn drop_ty_immediate(bcx: @block_ctxt, v: ValueRef, t: ty::t) -> @block_ctxt {
-    alt ty::struct(bcx_tcx(bcx), t) {
+    alt ty::get(t).struct {
       ty::ty_uniq(_) | ty::ty_vec(_) | ty::ty_str { free_ty(bcx, v, t) }
       ty::ty_box(_) | ty::ty_iface(_, _) { decr_refcnt_maybe_free(bcx, v, t) }
       // Precondition?
@@ -1809,12 +1765,11 @@ fn drop_ty_immediate(bcx: @block_ctxt, v: ValueRef, t: ty::t) -> @block_ctxt {
 }
 
 fn take_ty_immediate(bcx: @block_ctxt, v: ValueRef, t: ty::t) -> result {
-    alt ty::struct(bcx_tcx(bcx), t) {
+    alt ty::get(t).struct {
       ty::ty_box(_) | ty::ty_iface(_, _) {
         rslt(incr_refcnt_of_boxed(bcx, v), v)
       }
       ty::ty_uniq(_) {
-        check uniq::type_is_unique_box(bcx, t);
         uniq::duplicate(bcx, v, t)
       }
       ty::ty_str | ty::ty_vec(_) { tvec::duplicate(bcx, v, t) }
@@ -1858,7 +1813,7 @@ fn memmove_ty(bcx: @block_ctxt, dst: ValueRef, src: ValueRef, t: ty::t) ->
     @block_ctxt {
     let ccx = bcx_ccx(bcx);
     if check type_has_static_size(ccx, t) {
-        if ty::type_is_structural(bcx_tcx(bcx), t) {
+        if ty::type_is_structural(t) {
             let llsz = llsize_of(ccx, type_of(ccx, t));
             ret call_memmove(bcx, dst, src, llsz).bcx;
         }
@@ -1873,9 +1828,9 @@ fn memmove_ty(bcx: @block_ctxt, dst: ValueRef, src: ValueRef, t: ty::t) ->
 enum copy_action { INIT, DROP_EXISTING, }
 
 // These are the types that are passed by pointer.
-fn type_is_structural_or_param(tcx: ty::ctxt, t: ty::t) -> bool {
-    if ty::type_is_structural(tcx, t) { ret true; }
-    alt ty::struct(tcx, t) {
+fn type_is_structural_or_param(t: ty::t) -> bool {
+    if ty::type_is_structural(t) { ret true; }
+    alt ty::get(t).struct {
       ty::ty_param(_, _) { ret true; }
       _ { ret false; }
     }
@@ -1884,8 +1839,8 @@ fn type_is_structural_or_param(tcx: ty::ctxt, t: ty::t) -> bool {
 fn copy_val(cx: @block_ctxt, action: copy_action, dst: ValueRef,
             src: ValueRef, t: ty::t) -> @block_ctxt {
     if action == DROP_EXISTING &&
-        (type_is_structural_or_param(bcx_tcx(cx), t) ||
-         ty::type_is_unique(bcx_tcx(cx), t)) {
+        (type_is_structural_or_param(t) ||
+         ty::type_is_unique(t)) {
         let do_copy_cx = new_sub_block_ctxt(cx, "do_copy");
         let next_cx = new_sub_block_ctxt(cx, "next");
         let dstcmp = load_if_immediate(cx, dst, t);
@@ -1903,18 +1858,18 @@ fn copy_val(cx: @block_ctxt, action: copy_action, dst: ValueRef,
 fn copy_val_no_check(bcx: @block_ctxt, action: copy_action, dst: ValueRef,
                      src: ValueRef, t: ty::t) -> @block_ctxt {
     let ccx = bcx_ccx(bcx), bcx = bcx;
-    if ty::type_is_scalar(ccx.tcx, t) {
+    if ty::type_is_scalar(t) {
         Store(bcx, src, dst);
         ret bcx;
     }
-    if ty::type_is_nil(ccx.tcx, t) || ty::type_is_bot(ccx.tcx, t) { ret bcx; }
-    if ty::type_is_boxed(ccx.tcx, t) || ty::type_is_vec(ccx.tcx, t) ||
-       ty::type_is_unique_box(ccx.tcx, t) {
+    if ty::type_is_nil(t) || ty::type_is_bot(t) { ret bcx; }
+    if ty::type_is_boxed(t) || ty::type_is_vec(t) ||
+       ty::type_is_unique_box(t) {
         if action == DROP_EXISTING { bcx = drop_ty(bcx, dst, t); }
         Store(bcx, src, dst);
         ret take_ty(bcx, dst, t);
     }
-    if type_is_structural_or_param(ccx.tcx, t) {
+    if type_is_structural_or_param(t) {
         if action == DROP_EXISTING { bcx = drop_ty(bcx, dst, t); }
         bcx = memmove_ty(bcx, dst, src, t);
         ret take_ty(bcx, dst, t);
@@ -1933,13 +1888,13 @@ fn move_val(cx: @block_ctxt, action: copy_action, dst: ValueRef,
             src: lval_result, t: ty::t) -> @block_ctxt {
     let src_val = src.val;
     let tcx = bcx_tcx(cx), cx = cx;
-    if ty::type_is_scalar(tcx, t) {
+    if ty::type_is_scalar(t) {
         if src.kind == owned { src_val = Load(cx, src_val); }
         Store(cx, src_val, dst);
         ret cx;
-    } else if ty::type_is_nil(tcx, t) || ty::type_is_bot(tcx, t) {
+    } else if ty::type_is_nil(t) || ty::type_is_bot(t) {
         ret cx;
-    } else if ty::type_is_boxed(tcx, t) || ty::type_is_unique(tcx, t) {
+    } else if ty::type_is_boxed(t) || ty::type_is_unique(t) {
         if src.kind == owned { src_val = Load(cx, src_val); }
         if action == DROP_EXISTING { cx = drop_ty(cx, dst, t); }
         Store(cx, src_val, dst);
@@ -1947,7 +1902,7 @@ fn move_val(cx: @block_ctxt, action: copy_action, dst: ValueRef,
         // If we're here, it must be a temporary.
         revoke_clean(cx, src_val);
         ret cx;
-    } else if type_is_structural_or_param(tcx, t) {
+    } else if type_is_structural_or_param(t) {
         if action == DROP_EXISTING { cx = drop_ty(cx, dst, t); }
         cx = memmove_ty(cx, dst, src_val, t);
         if src.kind == owned { ret zero_alloca(cx, src_val, t); }
@@ -2021,7 +1976,7 @@ fn trans_unary(bcx: @block_ctxt, op: ast::unop, e: @ast::expr,
       }
       ast::neg {
         let {bcx, val} = trans_temp_expr(bcx, e);
-        let neg = if ty::type_is_fp(bcx_tcx(bcx), e_ty) {
+        let neg = if ty::type_is_fp(e_ty) {
             FNeg(bcx, val)
         } else { Neg(bcx, val) };
         ret store_in_dest(bcx, neg, dest);
@@ -2054,7 +2009,7 @@ fn trans_unary(bcx: @block_ctxt, op: ast::unop, e: @ast::expr,
 
 fn trans_compare(cx: @block_ctxt, op: ast::binop, lhs: ValueRef,
                  _lhs_t: ty::t, rhs: ValueRef, rhs_t: ty::t) -> result {
-    if ty::type_is_scalar(bcx_tcx(cx), rhs_t) {
+    if ty::type_is_scalar(rhs_t) {
       let rs = compare_scalar_types(cx, lhs, rhs, rhs_t, op);
       ret rslt(rs.bcx, rs.val);
     }
@@ -2090,10 +2045,10 @@ fn trans_eager_binop(cx: @block_ctxt, op: ast::binop, lhs: ValueRef,
     -> @block_ctxt {
     if dest == ignore { ret cx; }
     let intype = lhs_t;
-    if ty::type_is_bot(bcx_tcx(cx), intype) { intype = rhs_t; }
-    let is_float = ty::type_is_fp(bcx_tcx(cx), intype);
+    if ty::type_is_bot(intype) { intype = rhs_t; }
+    let is_float = ty::type_is_fp(intype);
 
-    if op == ast::add && ty::type_is_sequence(bcx_tcx(cx), intype) {
+    if op == ast::add && ty::type_is_sequence(intype) {
         ret tvec::trans_add(cx, intype, lhs, rhs, dest);
     }
     let cx = cx, val = alt op {
@@ -2111,13 +2066,13 @@ fn trans_eager_binop(cx: @block_ctxt, op: ast::binop, lhs: ValueRef,
       }
       ast::div {
         if is_float { FDiv(cx, lhs, rhs) }
-        else if ty::type_is_signed(bcx_tcx(cx), intype) {
+        else if ty::type_is_signed(intype) {
             SDiv(cx, lhs, rhs)
         } else { UDiv(cx, lhs, rhs) }
       }
       ast::rem {
         if is_float { FRem(cx, lhs, rhs) }
-        else if ty::type_is_signed(bcx_tcx(cx), intype) {
+        else if ty::type_is_signed(intype) {
             SRem(cx, lhs, rhs)
         } else { URem(cx, lhs, rhs) }
       }
@@ -2157,7 +2112,7 @@ fn trans_assign_op(bcx: @block_ctxt, ex: @ast::expr, op: ast::binop,
     }
 
     // Special case for `+= [x]`
-    alt ty::struct(tcx, t) {
+    alt ty::get(t).struct {
       ty::ty_vec(_) {
         alt src.node {
           ast::expr_vec(args, _) {
@@ -2170,7 +2125,7 @@ fn trans_assign_op(bcx: @block_ctxt, ex: @ast::expr, op: ast::binop,
       _ { }
     }
     let {bcx, val: rhs_val} = trans_temp_expr(lhs_res.bcx, src);
-    if ty::type_is_sequence(tcx, t) {
+    if ty::type_is_sequence(t) {
         alt op {
           ast::add {
             ret tvec::trans_append(bcx, t, lhs_res.val, rhs_val);
@@ -2187,7 +2142,7 @@ fn autoderef(cx: @block_ctxt, v: ValueRef, t: ty::t) -> result_t {
     let t1: ty::t = t;
     let ccx = bcx_ccx(cx);
     while true {
-        alt ty::struct(ccx.tcx, t1) {
+        alt ty::get(t1).struct {
           ty::ty_box(mt) {
             let body = GEPi(cx, v1, [0, abi::box_field_body]);
             t1 = mt.ty;
@@ -2202,8 +2157,7 @@ fn autoderef(cx: @block_ctxt, v: ValueRef, t: ty::t) -> result_t {
             } else { v1 = body; }
           }
           ty::ty_uniq(_) {
-            check uniq::type_is_unique_box(cx, t1);
-            let derefed = uniq::autoderef(cx, v1, t1);
+            let derefed = uniq::autoderef(v1, t1);
             t1 = derefed.t;
             v1 = derefed.v;
           }
@@ -2426,7 +2380,7 @@ fn trans_for(cx: @block_ctxt, local: @ast::local, seq: @ast::expr,
     let {bcx: bcx, val: seq} = trans_temp_expr(cx, seq);
     let seq = PointerCast(bcx, seq, T_ptr(ccx.opaque_vec_type));
     let fill = tvec::get_fill(bcx, seq);
-    if ty::type_is_str(bcx_tcx(bcx), seq_ty) {
+    if ty::type_is_str(seq_ty) {
         fill = Sub(bcx, fill, C_int(ccx, 1));
     }
     let bcx = tvec::iter_vec_raw(bcx, seq, seq_ty, fill,
@@ -2560,7 +2514,7 @@ fn lval_static_fn(bcx: @block_ctxt, fn_id: ast::def_id, id: ast::node_id)
     let tpt = ty::lookup_item_type(ccx.tcx, fn_id);
     if ccx.sess.opts.monomorphize && vec::len(tys) > 0u &&
        fn_id.crate == ast::local_crate &&
-       !vec::any(tys, {|t| ty::type_contains_params(ccx.tcx, t)}) &&
+       !vec::any(tys, {|t| ty::type_has_params(t)}) &&
        vec::all(*tpt.bounds, {|bs| vec::all(*bs, {|b|
            alt b { ty::bound_iface(_) { false } _ { true } }
        })}) {
@@ -2699,15 +2653,13 @@ fn trans_rec_field(bcx: @block_ctxt, base: @ast::expr,
                    field: ast::ident) -> lval_result {
     let {bcx, val} = trans_temp_expr(bcx, base);
     let {bcx, val, ty} = autoderef(bcx, val, expr_ty(bcx, base));
-    let fields = alt ty::struct(bcx_tcx(bcx), ty) {
+    let fields = alt ty::get(ty).struct {
             ty::ty_rec(fs) { fs }
             // Constraint?
             _ { bcx_tcx(bcx).sess.span_bug(base.span, "trans_rec_field:\
                  base expr has non-record type"); }
         };
     let ix = option::get(ty::field_idx(field, fields));
-    // Silly check
-    check type_is_tup_like(bcx, ty);
     let {bcx, val} = GEP_tup_like(bcx, ty, val, [0, ix as int]);
     ret {bcx: bcx, val: val, kind: owned};
 }
@@ -2808,29 +2760,28 @@ fn trans_lval(cx: @block_ctxt, e: @ast::expr) -> lval_result {
         let ccx = bcx_ccx(cx);
         let sub = trans_temp_expr(cx, base);
         let t = expr_ty(cx, base);
-        let val =
-            alt ty::struct(ccx.tcx, t) {
-              ty::ty_box(_) {
-                GEPi(sub.bcx, sub.val, [0, abi::box_field_body])
-              }
-              ty::ty_res(_, _, _) {
-                GEPi(sub.bcx, sub.val, [0, 1])
-              }
-              ty::ty_enum(_, _) {
-                let ety = expr_ty(cx, e);
-                let ellty =
-                    if check type_has_static_size(ccx, ety) {
-                        T_ptr(type_of(ccx, ety))
-                    } else { T_typaram_ptr(ccx.tn) };
-                PointerCast(sub.bcx, sub.val, ellty)
-              }
-              ty::ty_ptr(_) | ty::ty_uniq(_) { sub.val }
-              // Precondition?
-              _ {
-                  bcx_tcx(cx).sess.span_bug(e.span, "trans_lval:\
-                    Weird argument in deref");
-              }
-            };
+        let val = alt ty::get(t).struct {
+          ty::ty_box(_) {
+            GEPi(sub.bcx, sub.val, [0, abi::box_field_body])
+          }
+          ty::ty_res(_, _, _) {
+            GEPi(sub.bcx, sub.val, [0, 1])
+          }
+          ty::ty_enum(_, _) {
+            let ety = expr_ty(cx, e);
+            let ellty =
+                if check type_has_static_size(ccx, ety) {
+                T_ptr(type_of(ccx, ety))
+            } else { T_typaram_ptr(ccx.tn) };
+            PointerCast(sub.bcx, sub.val, ellty)
+          }
+          ty::ty_ptr(_) | ty::ty_uniq(_) { sub.val }
+          // Precondition?
+          _ {
+            bcx_tcx(cx).sess.span_bug(e.span, "trans_lval:\
+                                               Weird argument in deref");
+          }
+        };
         ret lval_owned(sub.bcx, val);
       }
       _ { bcx_ccx(cx).sess.span_bug(e.span, "non-lval in trans_lval"); }
@@ -2855,7 +2806,7 @@ fn maybe_add_env(bcx: @block_ctxt, c: lval_maybe_callee)
 fn lval_maybe_callee_to_lval(c: lval_maybe_callee, ty: ty::t) -> lval_result {
     alt c.generic {
       some(gi) {
-        let n_args = vec::len(ty::ty_fn_args(bcx_tcx(c.bcx), ty));
+        let n_args = vec::len(ty::ty_fn_args(ty));
         let args = vec::init_elt(n_args, none::<@ast::expr>);
         let space = alloc_ty(c.bcx, ty);
         let bcx = closure::trans_bind_1(space.bcx, ty, c, args, ty,
@@ -2898,7 +2849,7 @@ fn trans_cast(cx: @block_ctxt, e: @ast::expr, id: ast::node_id,
               dest: dest) -> @block_ctxt {
     let ccx = bcx_ccx(cx);
     let t_out = node_id_type(cx, id);
-    alt ty::struct(bcx_tcx(cx), t_out) {
+    alt ty::get(t_out).struct {
       ty::ty_iface(_, _) { ret impl::trans_cast(cx, e, id, dest); }
       _ {}
     }
@@ -2911,20 +2862,16 @@ fn trans_cast(cx: @block_ctxt, e: @ast::expr, id: ast::node_id,
     let ll_t_out = type_of(ccx, t_out);
 
     enum kind { pointer, integral, float, enum_, other, }
-    fn t_kind(tcx: ty::ctxt, t: ty::t) -> kind {
-        ret if ty::type_is_fp(tcx, t) {
-                float
-            } else if ty::type_is_unsafe_ptr(tcx, t) {
-                pointer
-            } else if ty::type_is_integral(tcx, t) {
-                integral
-            } else if ty::type_is_enum(tcx, t) {
-                enum_
-            } else { other };
+    fn t_kind(t: ty::t) -> kind {
+        ret if ty::type_is_fp(t) { float }
+        else if ty::type_is_unsafe_ptr(t) { pointer }
+        else if ty::type_is_integral(t) { integral }
+        else if ty::type_is_enum(t) { enum_ }
+        else { other };
     }
-    let k_in = t_kind(ccx.tcx, t_in);
-    let k_out = t_kind(ccx.tcx, t_out);
-    let s_in = k_in == integral && ty::type_is_signed(ccx.tcx, t_in);
+    let k_in = t_kind(t_in);
+    let k_out = t_kind(t_out);
+    let s_in = k_in == integral && ty::type_is_signed(t_in);
 
     let newval =
         alt {in: k_in, out: k_out} {
@@ -2940,7 +2887,7 @@ fn trans_cast(cx: @block_ctxt, e: @ast::expr, id: ast::node_id,
             } else { UIToFP(e_res.bcx, e_res.val, ll_t_out) }
           }
           {in: float, out: integral} {
-            if ty::type_is_signed(ccx.tcx, t_out) {
+            if ty::type_is_signed(t_out) {
                 FPToSI(e_res.bcx, e_res.val, ll_t_out)
             } else { FPToUI(e_res.bcx, e_res.val, ll_t_out) }
           }
@@ -2977,7 +2924,7 @@ fn trans_arg_expr(cx: @block_ctxt, arg: ty::arg, lldestty: TypeRef,
    result {
     let ccx = bcx_ccx(cx);
     let e_ty = expr_ty(cx, e);
-    let is_bot = ty::type_is_bot(ccx.tcx, e_ty);
+    let is_bot = ty::type_is_bot(e_ty);
     let lv = trans_temp_lval(cx, e);
     let bcx = lv.bcx;
     let val = lv.val;
@@ -2988,7 +2935,7 @@ fn trans_arg_expr(cx: @block_ctxt, arg: ty::arg, lldestty: TypeRef,
         // to have type lldestty (the callee's expected type).
         val = llvm::LLVMGetUndef(lldestty);
     } else if arg.mode == ast::by_ref || arg.mode == ast::by_val {
-        let copied = false, imm = ty::type_is_immediate(ccx.tcx, e_ty);
+        let copied = false, imm = ty::type_is_immediate(e_ty);
         if arg.mode == ast::by_ref && lv.kind != owned && imm {
             val = do_spill_noroot(bcx, val);
             copied = true;
@@ -3010,7 +2957,7 @@ fn trans_arg_expr(cx: @block_ctxt, arg: ty::arg, lldestty: TypeRef,
         let last_use = ccx.last_uses.contains_key(e.id);
         bcx = cx;
         if lv.kind == temporary { revoke_clean(bcx, val); }
-        if lv.kind == owned || !ty::type_is_immediate(ccx.tcx, e_ty) {
+        if lv.kind == owned || !ty::type_is_immediate(e_ty) {
             bcx = memmove_ty(bcx, alloc, val, e_ty);
             if last_use && ty::type_needs_drop(ccx.tcx, e_ty) {
                 bcx = zero_alloca(bcx, val, e_ty);
@@ -3020,13 +2967,13 @@ fn trans_arg_expr(cx: @block_ctxt, arg: ty::arg, lldestty: TypeRef,
         if lv.kind != temporary && !last_use {
             bcx = take_ty(bcx, val, e_ty);
         }
-    } else if ty::type_is_immediate(ccx.tcx, e_ty) && lv.kind != owned {
+    } else if ty::type_is_immediate(e_ty) && lv.kind != owned {
         let r = do_spill(bcx, val, e_ty);
         val = r.val;
         bcx = r.bcx;
     }
 
-    if !is_bot && ty::type_contains_params(ccx.tcx, arg.ty) {
+    if !is_bot && ty::type_has_params(arg.ty) {
         val = PointerCast(bcx, val, lldestty);
     }
 
@@ -3057,17 +3004,16 @@ fn trans_args(cx: @block_ctxt, llenv: ValueRef,
        to_zero: [{v: ValueRef, t: ty::t}],
        to_revoke: [{v: ValueRef, t: ty::t}]} {
 
-    let args: [ty::arg] = ty::ty_fn_args(bcx_tcx(cx), fn_ty);
+    let args = ty::ty_fn_args(fn_ty);
     let llargs: [ValueRef] = [];
     let lltydescs: [ValueRef] = [];
     let to_zero = [];
     let to_revoke = [];
 
     let ccx = bcx_ccx(cx);
-    let tcx = ccx.tcx;
     let bcx = cx;
 
-    let retty = ty::ty_fn_ret(tcx, fn_ty), full_retty = retty;
+    let retty = ty::ty_fn_ret(fn_ty), full_retty = retty;
     alt gen {
       some(g) {
         lazily_emit_all_generic_info_tydesc_glues(cx, g);
@@ -3088,15 +3034,15 @@ fn trans_args(cx: @block_ctxt, llenv: ValueRef,
             }
             i += 1u;
         }
-        args = ty::ty_fn_args(tcx, g.item_type);
-        retty = ty::ty_fn_ret(tcx, g.item_type);
+        args = ty::ty_fn_args(g.item_type);
+        retty = ty::ty_fn_ret(g.item_type);
       }
       _ { }
     }
     // Arg 0: Output pointer.
     let llretslot = alt dest {
       ignore {
-        if ty::type_is_nil(tcx, retty) {
+        if ty::type_is_nil(retty) {
             llvm::LLVMGetUndef(T_ptr(T_nil()))
         } else {
             let {bcx: cx, val} = alloc_ty(bcx, full_retty);
@@ -3112,13 +3058,12 @@ fn trans_args(cx: @block_ctxt, llenv: ValueRef,
       }
     };
 
-    if ty::type_contains_params(tcx, retty) {
+    if ty::type_has_params(retty) {
         // It's possible that the callee has some generic-ness somewhere in
         // its return value -- say a method signature within an obj or a fn
         // type deep in a structure -- which the caller has a concrete view
         // of. If so, cast the caller's view of the restlot to the callee's
         // view, for the sake of making a type-compatible call.
-        check non_ty_var(ccx, retty);
         let llretty = T_ptr(type_of_inner(ccx, retty));
         llargs += [PointerCast(cx, llretslot, llretty)];
     } else { llargs += [llretslot]; }
@@ -3222,7 +3167,7 @@ fn trans_call_inner(in_cx: @block_ctxt, fn_expr_ty: ty::t,
 
     bcx = trans_block_cleanups(bcx, cx);
     let next_cx = new_sub_block_ctxt(in_cx, "next");
-    if bcx.unreachable || ty::type_is_bot(tcx, ret_ty) {
+    if bcx.unreachable || ty::type_is_bot(ret_ty) {
         Unreachable(next_cx);
     }
     Br(bcx, next_cx.llbb);
@@ -3360,7 +3305,7 @@ fn trans_tup(bcx: @block_ctxt, elts: [@ast::expr], id: ast::node_id,
     };
     let temp_cleanups = [], i = 0;
     for e in elts {
-        let dst = GEP_tup_like_1(bcx, t, addr, [0, i]);
+        let dst = GEP_tup_like(bcx, t, addr, [0, i]);
         let e_ty = expr_ty(bcx, e);
         bcx = trans_expr_save_in(dst.bcx, e, dst.val);
         add_clean_temp_mem(bcx, dst.val, e_ty);
@@ -3387,7 +3332,8 @@ fn trans_rec(bcx: @block_ctxt, fields: [ast::field],
       _ { bcx_tcx(bcx).sess.bug("trans_rec: weird dest"); }
     };
 
-    let ty_fields = alt ty::struct(bcx_tcx(bcx), t) { ty::ty_rec(f) { f }
+    let ty_fields = alt ty::get(t).struct {
+      ty::ty_rec(f) { f }
       _ { bcx_tcx(bcx).sess.bug("trans_rec: id doesn't\
            have a record type") } };
     let temp_cleanups = [];
@@ -3395,7 +3341,7 @@ fn trans_rec(bcx: @block_ctxt, fields: [ast::field],
         let ix = option::get(vec::position_pred(ty_fields, {|ft|
             str::eq(fld.node.ident, ft.ident)
         }));
-        let dst = GEP_tup_like_1(bcx, t, addr, [0, ix as int]);
+        let dst = GEP_tup_like(bcx, t, addr, [0, ix as int]);
         bcx = trans_expr_save_in(dst.bcx, fld.node.expr, dst.val);
         add_clean_temp_mem(bcx, dst.val, ty_fields[ix].mt.ty);
         temp_cleanups += [dst.val];
@@ -3407,8 +3353,8 @@ fn trans_rec(bcx: @block_ctxt, fields: [ast::field],
         // Copy over inherited fields
         for tf in ty_fields {
             if !vec::any(fields, {|f| str::eq(f.node.ident, tf.ident)}) {
-                let dst = GEP_tup_like_1(bcx, t, addr, [0, i]);
-                let base = GEP_tup_like_1(bcx, t, base_val, [0, i]);
+                let dst = GEP_tup_like(bcx, t, addr, [0, i]);
+                let base = GEP_tup_like(bcx, t, base_val, [0, i]);
                 let val = load_if_immediate(base.bcx, base.val, tf.mt.ty);
                 bcx = copy_val(base.bcx, INIT, dst.val, val, tf.mt.ty);
             }
@@ -3428,8 +3374,8 @@ fn trans_rec(bcx: @block_ctxt, fields: [ast::field],
 // that nil or bot expressions get ignore rather than save_in as destination.
 fn trans_expr_save_in(bcx: @block_ctxt, e: @ast::expr, dest: ValueRef)
     -> @block_ctxt {
-    let tcx = bcx_tcx(bcx), t = expr_ty(bcx, e);
-    let do_ignore = ty::type_is_bot(tcx, t) || ty::type_is_nil(tcx, t);
+    let t = expr_ty(bcx, e);
+    let do_ignore = ty::type_is_bot(t) || ty::type_is_nil(t);
     ret trans_expr(bcx, e, if do_ignore { ignore } else { save_in(dest) });
 }
 
@@ -3443,12 +3389,11 @@ fn trans_temp_lval(bcx: @block_ctxt, e: @ast::expr) -> lval_result {
     if expr_is_lval(bcx, e) {
         ret trans_lval(bcx, e);
     } else {
-        let tcx = bcx_tcx(bcx);
         let ty = expr_ty(bcx, e);
-        if ty::type_is_nil(tcx, ty) || ty::type_is_bot(tcx, ty) {
+        if ty::type_is_nil(ty) || ty::type_is_bot(ty) {
             bcx = trans_expr(bcx, e, ignore);
             ret {bcx: bcx, val: C_nil(), kind: temporary};
-        } else if ty::type_is_immediate(bcx_tcx(bcx), ty) {
+        } else if ty::type_is_immediate(ty) {
             let cell = empty_dest_cell();
             bcx = trans_expr(bcx, e, by_val(cell));
             add_clean_temp(bcx, *cell, ty);
@@ -3522,7 +3467,7 @@ fn trans_expr(bcx: @block_ctxt, e: @ast::expr, dest: dest) -> @block_ctxt {
             bcx, proto, decl, body, e.span, e.id, *cap_clause, dest);
       }
       ast::expr_fn_block(decl, body) {
-        alt ty::struct(tcx, expr_ty(bcx, e)) {
+        alt ty::get(expr_ty(bcx, e)).struct {
           ty::ty_fn({proto, _}) {
             #debug("translating fn_block %s with type %s",
                    expr_to_str(e), ty_to_str(tcx, expr_ty(bcx, e)));
@@ -3705,7 +3650,7 @@ fn do_spill(cx: @block_ctxt, v: ValueRef, t: ty::t) -> result {
     // We have a value but we have to spill it, and root it, to pass by alias.
     let bcx = cx;
 
-    if ty::type_is_bot(bcx_tcx(bcx), t) {
+    if ty::type_is_bot(t) {
         ret rslt(bcx, C_null(T_ptr(T_i8())));
     }
 
@@ -3727,18 +3672,18 @@ fn do_spill_noroot(cx: @block_ctxt, v: ValueRef) -> ValueRef {
 }
 
 fn spill_if_immediate(cx: @block_ctxt, v: ValueRef, t: ty::t) -> result {
-    if ty::type_is_immediate(bcx_tcx(cx), t) { ret do_spill(cx, v, t); }
+    if ty::type_is_immediate(t) { ret do_spill(cx, v, t); }
     ret rslt(cx, v);
 }
 
 fn load_if_immediate(cx: @block_ctxt, v: ValueRef, t: ty::t) -> ValueRef {
-    if ty::type_is_immediate(bcx_tcx(cx), t) { ret Load(cx, v); }
+    if ty::type_is_immediate(t) { ret Load(cx, v); }
     ret v;
 }
 
 fn trans_log(lvl: @ast::expr, cx: @block_ctxt, e: @ast::expr) -> @block_ctxt {
-    let ccx = bcx_ccx(cx), tcx = ccx.tcx;
-    if ty::type_is_bot(tcx, expr_ty(cx, lvl)) {
+    let ccx = bcx_ccx(cx);
+    if ty::type_is_bot(expr_ty(cx, lvl)) {
        ret trans_expr(cx, lvl, ignore);
     }
 
@@ -3816,12 +3761,12 @@ fn trans_fail_expr(bcx: @block_ctxt, sp_opt: option<span>,
         let e_ty = expr_ty(bcx, expr);
         bcx = expr_res.bcx;
 
-        if ty::type_is_str(tcx, e_ty) {
+        if ty::type_is_str(e_ty) {
             let data = tvec::get_dataptr(
                 bcx, expr_res.val, type_of_or_i8(
                     bcx, ty::mk_mach_uint(tcx, ast::ty_u8)));
             ret trans_fail_value(bcx, sp_opt, data);
-        } else if bcx.unreachable || ty::type_is_bot(tcx, e_ty) {
+        } else if bcx.unreachable || ty::type_is_bot(e_ty) {
             ret bcx;
         } else {
             bcx_ccx(bcx).sess.span_bug(
@@ -4243,7 +4188,7 @@ fn alloc_local(cx: @block_ctxt, local: @ast::local) -> @block_ctxt {
     let ccx = bcx_ccx(cx);
     if is_simple && !ccx.mut_map.contains_key(local.node.pat.id) &&
        !ccx.last_uses.contains_key(local.node.pat.id) &&
-       ty::type_is_immediate(ccx.tcx, t) {
+       ty::type_is_immediate(t) {
         alt local.node.init {
           some({op: ast::init_assign, _}) { ret cx; }
           _ {}
@@ -4278,7 +4223,7 @@ fn trans_block_dps(bcx: @block_ctxt, b: ast::blk, dest: dest)
     }
     alt b.node.expr {
       some(e) {
-        let bt = ty::type_is_bot(bcx_tcx(bcx), expr_ty(bcx, e));
+        let bt = ty::type_is_bot(expr_ty(bcx, e));
         debuginfo::update_source_pos(bcx, e.span);
         bcx = trans_expr(bcx, e, if bt { ignore } else { dest });
       }
@@ -4428,7 +4373,7 @@ fn copy_args_to_allocas(fcx: @fn_ctxt, bcx: @block_ctxt, args: [ast::arg],
           ast::by_mut_ref { }
           ast::by_move | ast::by_copy { add_clean(bcx, argval, arg.ty); }
           ast::by_val {
-            if !ty::type_is_immediate(bcx_tcx(bcx), arg.ty) {
+            if !ty::type_is_immediate(arg.ty) {
                 let {bcx: cx, val: alloc} = alloc_ty(bcx, arg.ty);
                 bcx = cx;
                 Store(bcx, argval, alloc);
@@ -4451,7 +4396,7 @@ fn copy_args_to_allocas(fcx: @fn_ctxt, bcx: @block_ctxt, args: [ast::arg],
 // cries out for a precondition
 fn arg_tys_of_fn(ccx: @crate_ctxt, id: ast::node_id) -> [ty::arg] {
     let tt = ty::node_id_to_type(ccx.tcx, id);
-    alt ty::struct(ccx.tcx, tt) {
+    alt ty::get(tt).struct {
       ty::ty_fn({inputs, _}) { inputs }
       _ { ccx.sess.bug(#fmt("arg_tys_of_fn called on non-function\
             type %s", ty_to_str(ccx.tcx, tt)));}
@@ -4504,8 +4449,8 @@ fn trans_closure(ccx: @crate_ctxt, path: path, decl: ast::fn_decl,
     // trans_mod, trans_item, et cetera) and those that do
     // (trans_block, trans_expr, et cetera).
     if option::is_none(body.node.expr) ||
-       ty::type_is_bot(ccx.tcx, block_ty) ||
-       ty::type_is_nil(ccx.tcx, block_ty) {
+       ty::type_is_bot(block_ty) ||
+       ty::type_is_nil(block_ty) {
         bcx = trans_block(bcx, body);
     } else {
         bcx = trans_block_dps(bcx, body, save_in(fcx.llretptr));
@@ -4559,11 +4504,8 @@ fn trans_res_ctor(ccx: @crate_ctxt, path: path, dtor: ast::fn_decl,
         llretptr = BitCast(bcx, llretptr, llret_t);
     }
 
-    // FIXME: silly checks
-    check type_is_tup_like(bcx, tup_t);
     let {bcx, val: dst} = GEP_tup_like(bcx, tup_t, llretptr, [0, 1]);
     bcx = memmove_ty(bcx, dst, arg, arg_t);
-    check type_is_tup_like(bcx, tup_t);
     let flag = GEP_tup_like(bcx, tup_t, llretptr, [0, 0]);
     bcx = flag.bcx;
     // FIXME #1184: Resource flag is larger than necessary
@@ -4638,7 +4580,7 @@ fn trans_enum_variant(ccx: @crate_ctxt,
           _ { bcx_tcx(bcx).sess.span_fatal(variant.span, "Someone forgot\
                 to document an invariant in trans_tag_variant"); } };
         let arg_ty = arg_tys[i].ty;
-        if ty::type_contains_params(bcx_tcx(bcx), arg_ty) {
+        if ty::type_has_params(arg_ty) {
             lldestptr = PointerCast(bcx, lldestptr, val_ty(llarg));
         }
         bcx = memmove_ty(bcx, lldestptr, llarg, arg_ty);
@@ -4661,8 +4603,8 @@ fn trans_const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
         /* Neither type is bottom, and we expect them to be unified already,
          * so the following is safe. */
         let ty = ty::expr_ty(cx.tcx, e1);
-        let is_float = ty::type_is_fp(ccx_tcx(cx), ty);
-        let signed = ty::type_is_signed(ccx_tcx(cx), ty);
+        let is_float = ty::type_is_fp(ty);
+        let signed = ty::type_is_signed(ty);
         ret alt b {
           ast::add    {
             if is_float { llvm::LLVMConstFAdd(te1, te2) }
@@ -4705,7 +4647,7 @@ fn trans_const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
       ast::expr_unary(u, e) {
         let te = trans_const_expr(cx, e);
         let ty = ty::expr_ty(cx.tcx, e);
-        let is_float = ty::type_is_fp(ccx_tcx(cx), ty);
+        let is_float = ty::type_is_fp(ty);
         ret alt u {
           ast::box(_)  |
           ast::uniq(_) |
@@ -4749,18 +4691,15 @@ type c_stack_tys = {
 
 fn c_stack_tys(ccx: @crate_ctxt,
                id: ast::node_id) -> @c_stack_tys {
-    alt ty::struct(ccx.tcx, ty::node_id_to_type(ccx.tcx, id)) {
+    alt ty::get(ty::node_id_to_type(ccx.tcx, id)).struct {
       ty::ty_fn({inputs: arg_tys, output: ret_ty, _}) {
-        let tcx = ccx.tcx;
         let llargtys = type_of_explicit_args(ccx, arg_tys);
-        check non_ty_var(ccx, ret_ty); // NDM does this truly hold?
         let llretty = type_of_inner(ccx, ret_ty);
         let bundle_ty = T_struct(llargtys + [T_ptr(llretty)]);
         ret @{
             arg_tys: llargtys,
             ret_ty: llretty,
-            ret_def: !ty::type_is_bot(tcx, ret_ty) &&
-                !ty::type_is_nil(tcx, ret_ty),
+            ret_def: !ty::type_is_bot(ret_ty) && !ty::type_is_nil(ret_ty),
             base_fn_ty: T_fn(llargtys, llretty),
             bundle_ty: bundle_ty,
             shim_fn_ty: T_fn([T_ptr(bundle_ty)], T_void())
@@ -5026,7 +4965,7 @@ fn create_main_wrapper(ccx: @crate_ctxt, sp: span, main_llfn: ValueRef,
 
     let main_takes_argv =
         // invariant!
-        alt ty::struct(ccx.tcx, main_node_type) {
+        alt ty::get(main_node_type).struct {
           ty::ty_fn({inputs, _}) { vec::len(inputs) != 0u }
           _ { ccx.sess.span_fatal(sp, "main has a non-function type"); }
         };
@@ -5138,7 +5077,7 @@ fn native_fn_ty_param_count(cx: @crate_ctxt, id: ast::node_id) -> uint {
 fn native_fn_wrapper_type(cx: @crate_ctxt, sp: span,
                           param_bounds: [ty::param_bounds],
                           x: ty::t) -> TypeRef {
-    alt ty::struct(cx.tcx, x) {
+    alt ty::get(x).struct {
       ty::ty_fn({inputs: args, output: out, _}) {
         ret type_of_fn(cx, args, out, param_bounds);
       }

--- a/src/comp/middle/trans/closure.rs
+++ b/src/comp/middle/trans/closure.rs
@@ -202,7 +202,6 @@ fn allocate_cbox(bcx: @block_ctxt,
       }
       ty::ck_uniq {
         let uniq_cbox_ty = mk_tuplified_uniq_cbox_ty(tcx, cdata_ty);
-        check uniq::type_is_unique_box(bcx, uniq_cbox_ty);
         let {bcx, val: box} = uniq::alloc_uniq(bcx, uniq_cbox_ty);
         nuke_ref_count(bcx, box);
         let bcx = store_uniq_tydesc(bcx, cdata_ty, box, ti);
@@ -279,7 +278,6 @@ fn store_environment(
     let cbox_ty = tuplify_box_ty(tcx, cdata_ty);
     let cboxptr_ty = ty::mk_ptr(tcx, {ty:cbox_ty, mut:ast::imm});
     let llbox = cast_if_we_can(bcx, llbox, cboxptr_ty);
-    check type_is_tup_like(bcx, cbox_ty);
 
     // If necessary, copy tydescs describing type parameters into the
     // appropriate slot in the closure.
@@ -308,11 +306,9 @@ fn store_environment(
                                   ev_to_str(ccx, bv)));
         }
 
-        let bound_data = GEP_tup_like_1(bcx, cbox_ty, llbox,
-                                        [0,
-                                         abi::box_field_body,
-                                         abi::closure_body_bindings,
-                                         i as int]);
+        let bound_data = GEP_tup_like(bcx, cbox_ty, llbox,
+                                      [0, abi::box_field_body,
+                                       abi::closure_body_bindings, i as int]);
         bcx = bound_data.bcx;
         let bound_data = bound_data.val;
         alt bv {
@@ -404,7 +400,6 @@ fn load_environment(enclosing_cx: @block_ctxt,
     // Populate the type parameters from the environment. We need to
     // do this first because the tydescs are needed to index into
     // the bindings if they are dynamically sized.
-    check type_is_tup_like(bcx, cdata_ty);
     let {bcx, val: lltydescs} = GEP_tup_like(bcx, cdata_ty, llcdata,
                                             [0, abi::closure_body_ty_params]);
     let off = 0;
@@ -429,7 +424,6 @@ fn load_environment(enclosing_cx: @block_ctxt,
         alt cap_var.mode {
           capture::cap_drop { /* ignore */ }
           _ {
-            check type_is_tup_like(bcx, cdata_ty);
             let upvarptr =
                 GEP_tup_like(bcx, cdata_ty, llcdata,
                              [0, abi::closure_body_bindings, i as int]);
@@ -612,7 +606,7 @@ fn make_fn_glue(
         }
     };
 
-    ret alt ty::struct(tcx, t) {
+    ret alt ty::get(t).struct {
       ty::ty_fn({proto: ast::proto_bare, _}) |
       ty::ty_fn({proto: ast::proto_block, _}) |
       ty::ty_fn({proto: ast::proto_any, _}) { bcx }
@@ -742,7 +736,7 @@ fn trans_bind_thunk(ccx: @crate_ctxt,
     // If we supported constraints on record fields, we could make the
     // constraints for this function:
     /*
-    : returns_non_ty_var(ccx, outgoing_fty),
+    : returns_non_ty_var(outgoing_fty),
       type_has_static_size(ccx, incoming_fty) ->
     */
     // but since we don't, we have to do the checks at the beginning.
@@ -811,8 +805,6 @@ fn trans_bind_thunk(ccx: @crate_ctxt,
         (fptr, llvm::LLVMGetUndef(T_opaque_cbox_ptr(ccx)), 0)
       }
       none {
-        // Silly check
-        check type_is_tup_like(bcx, cdata_ty);
         let {bcx: cx, val: pair} =
             GEP_tup_like(bcx, cdata_ty, llcdata,
                          [0, abi::closure_body_bindings, 0]);
@@ -830,16 +822,15 @@ fn trans_bind_thunk(ccx: @crate_ctxt,
 
     // Get f's return type, which will also be the return type of the entire
     // bind expression.
-    let outgoing_ret_ty = ty::ty_fn_ret(ccx.tcx, outgoing_fty);
+    let outgoing_ret_ty = ty::ty_fn_ret(outgoing_fty);
 
     // Get the types of the arguments to f.
-    let outgoing_args = ty::ty_fn_args(ccx.tcx, outgoing_fty);
+    let outgoing_args = ty::ty_fn_args(outgoing_fty);
 
     // The 'llretptr' that will arrive in the thunk we're creating also needs
     // to be the correct type.  Cast it to f's return type, if necessary.
     let llretptr = fcx.llretptr;
-    if ty::type_contains_params(ccx.tcx, outgoing_ret_ty) {
-        check non_ty_var(ccx, outgoing_ret_ty);
+    if ty::type_has_params(outgoing_ret_ty) {
         let llretty = type_of_inner(ccx, outgoing_ret_ty);
         llretptr = PointerCast(bcx, llretptr, T_ptr(llretty));
     }
@@ -848,7 +839,6 @@ fn trans_bind_thunk(ccx: @crate_ctxt,
     let llargs: [ValueRef] = [llretptr, lltargetenv];
 
     // Copy in the type parameters.
-    check type_is_tup_like(l_bcx, cdata_ty);
     let {bcx: l_bcx, val: param_record} =
         GEP_tup_like(l_bcx, cdata_ty, llcdata,
                      [0, abi::closure_body_ty_params]);
@@ -888,8 +878,6 @@ fn trans_bind_thunk(ccx: @crate_ctxt,
           // Arg provided at binding time; thunk copies it from
           // closure.
           some(e) {
-            // Silly check
-            check type_is_tup_like(bcx, cdata_ty);
             let bound_arg =
                 GEP_tup_like(bcx, cdata_ty, llcdata,
                              [0, abi::closure_body_bindings, b]);
@@ -904,7 +892,7 @@ fn trans_bind_thunk(ccx: @crate_ctxt,
             }
             // If the type is parameterized, then we need to cast the
             // type we actually have to the parameterized out type.
-            if ty::type_contains_params(ccx.tcx, out_arg.ty) {
+            if ty::type_has_params(out_arg.ty) {
                 val = PointerCast(bcx, val, llout_arg_ty);
             }
             llargs += [val];
@@ -914,7 +902,7 @@ fn trans_bind_thunk(ccx: @crate_ctxt,
           // Arg will be provided when the thunk is invoked.
           none {
             let arg: ValueRef = llvm::LLVMGetParam(llthunk, a as c_uint);
-            if ty::type_contains_params(ccx.tcx, out_arg.ty) {
+            if ty::type_has_params(out_arg.ty) {
                 arg = PointerCast(bcx, arg, llout_arg_ty);
             }
             llargs += [arg];

--- a/src/comp/middle/trans/common.rs
+++ b/src/comp/middle/trans/common.rs
@@ -234,7 +234,7 @@ fn add_clean_temp(cx: @block_ctxt, val: ValueRef, ty: ty::t) {
     if !ty::type_needs_drop(bcx_tcx(cx), ty) { ret; }
     fn do_drop(bcx: @block_ctxt, val: ValueRef, ty: ty::t) ->
        @block_ctxt {
-        if ty::type_is_immediate(bcx_tcx(bcx), ty) {
+        if ty::type_is_immediate(ty) {
             ret base::drop_ty_immediate(bcx, val, ty);
         } else {
             ret drop_ty(bcx, val, ty);
@@ -298,8 +298,6 @@ fn get_res_dtor(ccx: @crate_ctxt, did: ast::def_id, inner_t: ty::t)
 
     let param_bounds = ty::lookup_item_type(ccx.tcx, did).bounds;
     let nil_res = ty::mk_nil(ccx.tcx);
-    // FIXME: Silly check -- mk_nil should have a postcondition
-    check non_ty_var(ccx, nil_res);
     let f_t = type_of_fn(ccx, [{mode: ast::by_ref, ty: inner_t}],
                          nil_res, *param_bounds);
     ret base::get_extern_const(ccx.externs, ccx.llmod,
@@ -855,23 +853,6 @@ pure fn type_has_static_size(cx: @crate_ctxt, t: ty::t) -> bool {
     !ty::type_has_dynamic_size(cx.tcx, t)
 }
 
-pure fn non_ty_var(cx: @crate_ctxt, t: ty::t) -> bool {
-    let st = ty::struct(cx.tcx, t);
-    alt st {
-      ty::ty_var(_) { false }
-      _          { true }
-    }
-}
-
-pure fn returns_non_ty_var(cx: @crate_ctxt, t: ty::t) -> bool {
-    non_ty_var(cx, ty::ty_fn_ret(cx.tcx, t))
-}
-
-pure fn type_is_tup_like(cx: @block_ctxt, t: ty::t) -> bool {
-    let tcx = bcx_tcx(cx);
-    ty::type_is_tup_like(tcx, t)
-}
-
 // Used to identify cached dictionaries
 enum dict_param {
     dict_param_dict(dict_id),
@@ -884,7 +865,7 @@ fn hash_dict_id(&&dp: dict_id) -> uint {
         h = h << 2u;
         alt param {
           dict_param_dict(d) { h += hash_dict_id(d); }
-          dict_param_ty(t) { h += t; }
+          dict_param_ty(t) { h += ty::type_id(t); }
         }
     }
     h
@@ -895,7 +876,7 @@ fn hash_dict_id(&&dp: dict_id) -> uint {
 type mono_id = @{def: ast::def_id, substs: [ty::t], dicts: [dict_id]};
 fn hash_mono_id(&&mi: mono_id) -> uint {
     let h = syntax::ast_util::hash_def_id(mi.def);
-    for ty in mi.substs { h = (h << 2u) + ty; }
+    for ty in mi.substs { h = (h << 2u) + ty::type_id(ty); }
     for dict in mi.dicts { h = (h << 2u) + hash_dict_id(dict); }
     h
 }

--- a/src/comp/middle/trans/impl.rs
+++ b/src/comp/middle/trans/impl.rs
@@ -111,7 +111,7 @@ fn trans_vtable_callee(bcx: @block_ctxt, self: ValueRef, dict: ValueRef,
                              T_ptr(T_array(T_ptr(llfty), n_method + 1u)));
     let mptr = Load(bcx, GEPi(bcx, vtable, [0, n_method as int]));
     let generic = none;
-    if vec::len(*method.tps) > 0u || ty::type_contains_params(tcx, fty) {
+    if vec::len(*method.tps) > 0u || ty::type_has_params(fty) {
         let tydescs = [], tis = [];
         let tptys = ty::node_id_to_type_params(tcx, callee_id);
         for t in vec::tail_n(tptys, vec::len(tptys) - vec::len(*method.tps)) {
@@ -145,7 +145,6 @@ fn trans_param_callee(bcx: @block_ctxt, callee_id: ast::node_id,
 fn trans_iface_callee(bcx: @block_ctxt, callee_id: ast::node_id,
                       base: @ast::expr, n_method: uint)
     -> lval_maybe_callee {
-    let tcx = bcx_tcx(bcx);
     let {bcx, val} = trans_temp_expr(bcx, base);
     let box_body = GEPi(bcx, val, [0, abi::box_field_body]);
     let dict = Load(bcx, PointerCast(bcx, GEPi(bcx, box_body, [0, 1]),
@@ -153,7 +152,7 @@ fn trans_iface_callee(bcx: @block_ctxt, callee_id: ast::node_id,
     // FIXME[impl] I doubt this is alignment-safe
     let self = PointerCast(bcx, GEPi(bcx, box_body, [0, 2]),
                            T_opaque_cbox_ptr(bcx_ccx(bcx)));
-    let iface_id = alt ty::struct(tcx, expr_ty(bcx, base)) {
+    let iface_id = alt ty::get(expr_ty(bcx, base)).struct {
         ty::ty_iface(did, _) { did }
         // precondition
         _ { bcx_tcx(bcx).sess.span_bug(base.span, "base has non-iface type \
@@ -307,7 +306,7 @@ fn trans_iface_vtable(ccx: @crate_ctxt, pt: path, it: @ast::item) {
 fn dict_is_static(tcx: ty::ctxt, origin: typeck::dict_origin) -> bool {
     alt origin {
       typeck::dict_static(_, ts, origs) {
-        vec::all(ts, {|t| !ty::type_contains_params(tcx, t)}) &&
+        vec::all(ts, {|t| !ty::type_has_params(t)}) &&
         vec::all(*origs, {|o| dict_is_static(tcx, o)})
       }
       typeck::dict_iface(_) { true }

--- a/src/comp/middle/trans/tvec.rs
+++ b/src/comp/middle/trans/tvec.rs
@@ -157,7 +157,7 @@ fn trans_append(cx: @block_ctxt, vec_ty: ty::t, lhsptr: ValueRef,
             (PointerCast(cx, lhsptr, T_ptr(T_ptr(ccx.opaque_vec_type))),
              PointerCast(cx, rhs, T_ptr(ccx.opaque_vec_type)))
         };
-    let strings = alt ty::struct(bcx_tcx(cx), vec_ty) {
+    let strings = alt ty::get(vec_ty).struct {
       ty::ty_str { true }
       ty::ty_vec(_) { false }
       _ {
@@ -233,7 +233,7 @@ fn trans_append_literal(bcx: @block_ctxt, vptrptr: ValueRef, vec_ty: ty::t,
 fn trans_add(bcx: @block_ctxt, vec_ty: ty::t, lhs: ValueRef,
              rhs: ValueRef, dest: dest) -> @block_ctxt {
     let ccx = bcx_ccx(bcx);
-    let strings = alt ty::struct(bcx_tcx(bcx), vec_ty) {
+    let strings = alt ty::get(vec_ty).struct {
       ty::ty_str { true }
       _ { false }
     };

--- a/src/comp/middle/trans/uniq.rs
+++ b/src/comp/middle/trans/uniq.rs
@@ -14,17 +14,11 @@ import base::{
 };
 import shape::{size_of};
 
-export trans_uniq, make_free_glue, type_is_unique_box, autoderef, duplicate,
-       alloc_uniq;
-
-pure fn type_is_unique_box(bcx: @block_ctxt, ty: ty::t) -> bool {
-    ty::type_is_unique_box(bcx_tcx(bcx), ty)
-}
+export trans_uniq, make_free_glue, autoderef, duplicate, alloc_uniq;
 
 fn trans_uniq(bcx: @block_ctxt, contents: @ast::expr,
               node_id: ast::node_id, dest: dest) -> @block_ctxt {
     let uniq_ty = node_id_type(bcx, node_id);
-    check type_is_unique_box(bcx, uniq_ty);
     let {bcx, val: llptr} = alloc_uniq(bcx, uniq_ty);
     add_clean_free(bcx, llptr, true);
     bcx = base::trans_expr_save_in(bcx, contents, llptr);
@@ -32,18 +26,14 @@ fn trans_uniq(bcx: @block_ctxt, contents: @ast::expr,
     ret base::store_in_dest(bcx, llptr, dest);
 }
 
-fn alloc_uniq(cx: @block_ctxt, uniq_ty: ty::t)
-    : type_is_unique_box(cx, uniq_ty) -> result {
-
+fn alloc_uniq(cx: @block_ctxt, uniq_ty: ty::t) -> result {
     let bcx = cx;
-    let contents_ty = content_ty(bcx, uniq_ty);
+    let contents_ty = content_ty(uniq_ty);
     let r = size_of(bcx, contents_ty);
     bcx = r.bcx;
     let llsz = r.val;
 
-    let ccx = bcx_ccx(bcx);
-    check non_ty_var(ccx, contents_ty);
-    let llptrty = T_ptr(type_of_inner(ccx, contents_ty));
+    let llptrty = T_ptr(type_of_inner(bcx_ccx(bcx), contents_ty));
 
     r = trans_shared_malloc(bcx, llptrty, llsz);
     bcx = r.bcx;
@@ -53,8 +43,7 @@ fn alloc_uniq(cx: @block_ctxt, uniq_ty: ty::t)
 }
 
 fn make_free_glue(cx: @block_ctxt, vptr: ValueRef, t: ty::t)
-    : type_is_unique_box(cx, t) -> @block_ctxt {
-
+    -> @block_ctxt {
     let bcx = cx;
     let free_cx = new_sub_block_ctxt(bcx, "uniq_free");
     let next_cx = new_sub_block_ctxt(bcx, "uniq_free_next");
@@ -62,32 +51,26 @@ fn make_free_glue(cx: @block_ctxt, vptr: ValueRef, t: ty::t)
     CondBr(bcx, null_test, next_cx.llbb, free_cx.llbb);
 
     let bcx = free_cx;
-    let bcx = drop_ty(bcx, vptr, content_ty(cx, t));
+    let bcx = drop_ty(bcx, vptr, content_ty(t));
     let bcx = trans_shared_free(bcx, vptr);
     Br(bcx, next_cx.llbb);
     next_cx
 }
 
-fn content_ty(bcx: @block_ctxt, t: ty::t)
-    : type_is_unique_box(bcx, t) -> ty::t {
-
-    alt ty::struct(bcx_tcx(bcx), t) {
+fn content_ty(t: ty::t) -> ty::t {
+    alt ty::get(t).struct {
       ty::ty_uniq({ty: ct, _}) { ct }
       _ { std::util::unreachable(); }
     }
 }
 
-fn autoderef(bcx: @block_ctxt, v: ValueRef, t: ty::t)
-    : type_is_unique_box(bcx, t) -> {v: ValueRef, t: ty::t} {
-
-    let content_ty = content_ty(bcx, t);
+fn autoderef(v: ValueRef, t: ty::t) -> {v: ValueRef, t: ty::t} {
+    let content_ty = content_ty(t);
     ret {v: v, t: content_ty};
 }
 
-fn duplicate(bcx: @block_ctxt, v: ValueRef, t: ty::t)
-    : type_is_unique_box(bcx, t) -> result {
-
-    let content_ty = content_ty(bcx, t);
+fn duplicate(bcx: @block_ctxt, v: ValueRef, t: ty::t) -> result {
+    let content_ty = content_ty(t);
     let {bcx, val: llptr} = alloc_uniq(bcx, t);
 
     let src = load_if_immediate(bcx, v, content_ty);

--- a/src/comp/middle/tstate/auxiliary.rs
+++ b/src/comp/middle/tstate/auxiliary.rs
@@ -492,14 +492,14 @@ fn new_crate_ctxt(cx: ty::ctxt) -> crate_ctxt {
  If it has a function type with a ! annotation,
 the answer is noreturn. */
 fn controlflow_expr(ccx: crate_ctxt, e: @expr) -> ret_style {
-    alt ty::struct(ccx.tcx, ty::node_id_to_type(ccx.tcx, e.id)) {
+    alt ty::get(ty::node_id_to_type(ccx.tcx, e.id)).struct {
       ty::ty_fn(f) { ret f.ret_style; }
       _ { ret return_val; }
     }
 }
 
 fn constraints_expr(cx: ty::ctxt, e: @expr) -> [@ty::constr] {
-    alt ty::struct(cx, ty::node_id_to_type(cx, e.id)) {
+    alt ty::get(ty::node_id_to_type(cx, e.id)).struct {
       ty::ty_fn(f) { ret f.constraints; }
       _ { ret []; }
     }
@@ -1071,10 +1071,9 @@ fn locals_to_bindings(tcx: ty::ctxt,
 }
 
 fn callee_modes(fcx: fn_ctxt, callee: node_id) -> [mode] {
-    let ty =
-        ty::type_autoderef(fcx.ccx.tcx,
-                           ty::node_id_to_type(fcx.ccx.tcx, callee));
-    alt ty::struct(fcx.ccx.tcx, ty) {
+    let ty = ty::type_autoderef(fcx.ccx.tcx,
+                                ty::node_id_to_type(fcx.ccx.tcx, callee));
+    alt ty::get(ty).struct {
       ty::ty_fn({inputs: args, _}) {
         let modes = [];
         for arg: ty::arg in args { modes += [arg.mode]; }

--- a/src/comp/middle/tstate/ck.rs
+++ b/src/comp/middle/tstate/ck.rs
@@ -113,7 +113,7 @@ fn check_states_against_conditions(fcx: fn_ctxt,
     /* Check that the return value is initialized */
     let post = aux::block_poststate(fcx.ccx, f_body);
     if !promises(fcx, post, fcx.enclosing.i_return) &&
-       !type_is_nil(fcx.ccx.tcx, ret_ty_of_fn(fcx.ccx.tcx, id)) &&
+       !type_is_nil(ret_ty_of_fn(fcx.ccx.tcx, id)) &&
        f_decl.cf == return_val {
         fcx.ccx.tcx.sess.span_err(f_body.span,
                                   "In function " + fcx.name +

--- a/src/comp/middle/tstate/states.rs
+++ b/src/comp/middle/tstate/states.rs
@@ -758,7 +758,7 @@ fn find_pre_post_state_fn(fcx: fn_ctxt,
         // We don't want to clear the diverges bit for bottom typed things,
         // which really do diverge. I feel like there is a cleaner way
         // to do this than checking the type.
-        if !type_is_bot(fcx.ccx.tcx, expr_ty(fcx.ccx.tcx, tailexpr)) {
+        if !type_is_bot(expr_ty(fcx.ccx.tcx, tailexpr)) {
             let post = false_postcond(num_constrs);
             // except for the "diverges" bit...
             kill_poststate_(fcx, fcx.enclosing.i_diverge, post);

--- a/src/comp/middle/ty.rs
+++ b/src/comp/middle/ty.rs
@@ -16,7 +16,6 @@ import syntax::ast_util;
 import syntax::codemap::span;
 import metadata::csearch;
 import util::common::*;
-import syntax::util::interner;
 import util::ppaux::ty_to_str;
 import util::ppaux::ty_constr_to_str;
 import util::ppaux::mode_str;
@@ -45,7 +44,6 @@ export get_field;
 export get_fields;
 export fm_general;
 export get_element_type;
-export idx_nil;
 export is_binopable;
 export is_pred_ty;
 export lookup_item_type;
@@ -83,14 +81,11 @@ export mk_uniq;
 export mk_var;
 export mk_opaque_closure_ptr;
 export mk_named;
-export gen_ty;
 export mt;
 export node_type_table;
 export pat_ty;
 export ret_ty_of_fn;
 export sequence_element_type;
-export struct, struct_raw;
-export ty_name;
 export sort_methods;
 export stmt_node_id;
 export sty;
@@ -127,13 +122,11 @@ export ty_send_type;
 export ty_uint;
 export ty_uniq;
 export ty_var;
-export ty_named;
+export get, type_has_params, type_has_vars, type_name, type_id;
 export same_type;
 export ty_var_id;
 export ty_fn_args;
 export type_constr;
-export type_contains_params;
-export type_contains_vars;
 export kind, kind_sendable, kind_copyable, kind_noncopyable;
 export kind_can_be_copied, kind_can_be_sent, proto_kind, kind_lteq, type_kind;
 export type_err;
@@ -199,10 +192,11 @@ type mt = {ty: t, mut: ast::mutability};
 
 // Contains information needed to resolve types and (in the future) look up
 // the types of AST nodes.
-type creader_cache = hashmap<{cnum: int, pos: uint, len: uint}, ty::t>;
+type creader_cache = hashmap<{cnum: int, pos: uint, len: uint}, t>;
 
 type ctxt =
-    @{ts: @type_store,
+    @{interner: hashmap<{struct: sty, name: option<str>}, t_box>,
+      mutable next_id: uint,
       sess: session::session,
       def_map: resolve::def_map,
       node_types: node_type_table,
@@ -219,15 +213,25 @@ type ctxt =
       iface_method_cache: hashmap<def_id, @[method]>,
       ty_param_bounds: hashmap<ast::node_id, param_bounds>};
 
-type ty_ctxt = ctxt;
+type t_box = @{struct: sty,
+               id: uint,
+               has_params: bool,
+               has_vars: bool,
+               name: option<str>};
+enum t_opaque {}
+type t = *t_opaque;
 
-// Never construct these manually. These are interned.
-type raw_t = {struct: sty,
-              hash: uint,
-              has_params: bool,
-              has_vars: bool};
+pure fn get(t: t) -> t_box unsafe {
+    let t2 = unsafe::reinterpret_cast::<t, t_box>(t);
+    let t3 = t2;
+    unsafe::leak(t2);
+    t3
+}
 
-type t = uint;
+fn type_has_params(t: t) -> bool { get(t).has_params }
+fn type_has_vars(t: t) -> bool { get(t).has_vars }
+fn type_name(t: t) -> option<str> { get(t).name }
+fn type_id(t: t) -> uint { get(t).id }
 
 enum closure_kind {
     ck_block,
@@ -269,7 +273,6 @@ enum sty {
     ty_send_type, // type_desc* that has been cloned into exchange heap
     ty_constr(t, [@type_constr]),
     ty_opaque_closure_ptr(closure_kind), // ptr to env for fn, fn@, fn~
-    ty_named(t, @str),
 }
 
 // In the middle end, constraints have a def_id attached, referring
@@ -318,75 +321,7 @@ type ty_param_bounds_and_ty = {bounds: @[param_bounds], ty: t};
 
 type type_cache = hashmap<ast::def_id, ty_param_bounds_and_ty>;
 
-const idx_nil: uint = 0u;
-
-const idx_bool: uint = 1u;
-
-const idx_int: uint = 2u;
-
-const idx_float: uint = 3u;
-
-const idx_uint: uint = 4u;
-
-const idx_i8: uint = 5u;
-
-const idx_i16: uint = 6u;
-
-const idx_i32: uint = 7u;
-
-const idx_i64: uint = 8u;
-
-const idx_u8: uint = 9u;
-
-const idx_u16: uint = 10u;
-
-const idx_u32: uint = 11u;
-
-const idx_u64: uint = 12u;
-
-const idx_f32: uint = 13u;
-
-const idx_f64: uint = 14u;
-
-const idx_char: uint = 15u;
-
-const idx_str: uint = 16u;
-
-const idx_type: uint = 17u;
-
-const idx_send_type: uint = 18u;
-
-const idx_bot: uint = 19u;
-
-const idx_first_others: uint = 20u;
-
-type type_store = interner::interner<@raw_t>;
-
 type node_type_table = @smallintmap::smallintmap<t>;
-
-fn populate_type_store(cx: ctxt) {
-    intern(cx, ty_nil);
-    intern(cx, ty_bool);
-    intern(cx, ty_int(ast::ty_i));
-    intern(cx, ty_float(ast::ty_f));
-    intern(cx, ty_uint(ast::ty_u));
-    intern(cx, ty_int(ast::ty_i8));
-    intern(cx, ty_int(ast::ty_i16));
-    intern(cx, ty_int(ast::ty_i32));
-    intern(cx, ty_int(ast::ty_i64));
-    intern(cx, ty_uint(ast::ty_u8));
-    intern(cx, ty_uint(ast::ty_u16));
-    intern(cx, ty_uint(ast::ty_u32));
-    intern(cx, ty_uint(ast::ty_u64));
-    intern(cx, ty_float(ast::ty_f32));
-    intern(cx, ty_float(ast::ty_f64));
-    intern(cx, ty_int(ast::ty_char));
-    intern(cx, ty_str);
-    intern(cx, ty_type);
-    intern(cx, ty_send_type);
-    intern(cx, ty_bot);
-    assert (vec::len(cx.ts.vect) == idx_first_others);
-}
 
 fn mk_rcache() -> creader_cache {
     type val = {cnum: int, pos: uint, len: uint};
@@ -399,58 +334,52 @@ fn mk_rcache() -> creader_cache {
     ret map::mk_hashmap(hash_cache_entry, eq_cache_entries);
 }
 
-fn new_ty_hash<V: copy>() -> map::hashmap<t, V> { map::new_uint_hash() }
+fn new_ty_hash<V: copy>() -> map::hashmap<t, V> {
+    map::mk_hashmap({|&&t: t| type_id(t)},
+                    {|&&a: t, &&b: t| type_id(a) == type_id(b)})
+}
 
 fn mk_ctxt(s: session::session, dm: resolve::def_map, amap: ast_map::map,
            freevars: freevars::freevar_map) -> ctxt {
-    fn eq_raw_ty(&&a: @raw_t, &&b: @raw_t) -> bool {
-        ret a.hash == b.hash && a.struct == b.struct;
-    }
-    let ts = @interner::mk::<@raw_t>(hash_raw_ty, eq_raw_ty);
-    let cx =
-        @{ts: ts,
-          sess: s,
-          def_map: dm,
-          node_types: @smallintmap::mk(),
-          node_type_substs: map::new_int_hash(),
-          items: amap,
-          freevars: freevars,
-          tcache: new_def_hash(),
-          rcache: mk_rcache(),
-          short_names_cache: new_ty_hash(),
-          needs_drop_cache: new_ty_hash(),
-          kind_cache: new_ty_hash(),
-          ast_ty_to_ty_cache:
-              map::mk_hashmap(ast_util::hash_ty, ast_util::eq_ty),
-          enum_var_cache: new_def_hash(),
-          iface_method_cache: new_def_hash(),
-          ty_param_bounds: map::new_int_hash()};
-    populate_type_store(cx);
-    ret cx;
+    let interner = map::mk_hashmap({|&&k: {struct: sty, name: option<str>}|
+        hash_type_structure(k.struct) + alt k.name {
+          some(s) { str::hash(s) } _ { 0u }
+        }
+    }, {|&&a, &&b| a == b});
+    @{interner: interner,
+      mutable next_id: 0u,
+      sess: s,
+      def_map: dm,
+      node_types: @smallintmap::mk(),
+      node_type_substs: map::new_int_hash(),
+      items: amap,
+      freevars: freevars,
+      tcache: new_def_hash(),
+      rcache: mk_rcache(),
+      short_names_cache: new_ty_hash(),
+      needs_drop_cache: new_ty_hash(),
+      kind_cache: new_ty_hash(),
+      ast_ty_to_ty_cache: map::mk_hashmap(ast_util::hash_ty, ast_util::eq_ty),
+      enum_var_cache: new_def_hash(),
+      iface_method_cache: new_def_hash(),
+      ty_param_bounds: map::new_int_hash()}
 }
 
 
 // Type constructors
-fn mk_raw_ty(cx: ctxt, st: sty) -> @raw_t {
-    let h = hash_type_structure(st);
-    let has_params: bool = false;
-    let has_vars: bool = false;
-    fn derive_flags_t(cx: ctxt, &has_params: bool, &has_vars: bool, tt: t) {
-        let rt = interner::get::<@raw_t>(*cx.ts, tt);
-        has_params = has_params || rt.has_params;
-        has_vars = has_vars || rt.has_vars;
+fn mk_t(cx: ctxt, st: sty) -> t { mk_t_named(cx, st, none) }
+
+fn mk_t_named(cx: ctxt, st: sty, name: option<str>) -> t {
+    let key = {struct: st, name: name};
+    alt cx.interner.find(key) {
+      some(t) { unsafe { ret unsafe::reinterpret_cast(t); } }
+      _ {}
     }
-    fn derive_flags_mt(cx: ctxt, &has_params: bool, &has_vars: bool, m: mt) {
-        derive_flags_t(cx, has_params, has_vars, m.ty);
-    }
-    fn derive_flags_arg(cx: ctxt, &has_params: bool, &has_vars: bool,
-                        a: arg) {
-        derive_flags_t(cx, has_params, has_vars, a.ty);
-    }
-    fn derive_flags_sig(cx: ctxt, &has_params: bool, &has_vars: bool,
-                        args: [arg], tt: t) {
-        for a: arg in args { derive_flags_arg(cx, has_params, has_vars, a); }
-        derive_flags_t(cx, has_params, has_vars, tt);
+    let has_params = false, has_vars = false;
+    fn derive_flags(&has_params: bool, &has_vars: bool, tt: t) {
+        let t = get(tt);
+        has_params |= t.has_params;
+        has_vars |= t.has_vars;
     }
     alt st {
       ty_nil | ty_bot | ty_bool | ty_int(_) | ty_float(_) | ty_uint(_) |
@@ -458,180 +387,116 @@ fn mk_raw_ty(cx: ctxt, st: sty) -> @raw_t {
       ty_param(_, _) { has_params = true; }
       ty_var(_) { has_vars = true; }
       ty_enum(_, tys) | ty_iface(_, tys) {
-        for tt: t in tys { derive_flags_t(cx, has_params, has_vars, tt); }
+        for tt in tys { derive_flags(has_params, has_vars, tt); }
       }
-      ty_box(m) { derive_flags_mt(cx, has_params, has_vars, m); }
-      ty_uniq(m) { derive_flags_mt(cx, has_params, has_vars, m); }
-      ty_vec(m) { derive_flags_mt(cx, has_params, has_vars, m); }
-      ty_ptr(m) { derive_flags_mt(cx, has_params, has_vars, m); }
+      ty_box(m) | ty_uniq(m) | ty_vec(m) | ty_ptr(m) {
+        derive_flags(has_params, has_vars, m.ty);
+      }
       ty_rec(flds) {
-        for f: field in flds {
-            derive_flags_mt(cx, has_params, has_vars, f.mt);
-        }
+        for f in flds { derive_flags(has_params, has_vars, f.mt.ty); }
       }
       ty_tup(ts) {
-        for tt in ts { derive_flags_t(cx, has_params, has_vars, tt); }
+        for tt in ts { derive_flags(has_params, has_vars, tt); }
       }
       ty_fn(f) {
-        derive_flags_sig(cx, has_params, has_vars, f.inputs, f.output);
+        for a in f.inputs { derive_flags(has_params, has_vars, a.ty); }
+        derive_flags(has_params, has_vars, f.output);
       }
       ty_res(_, tt, tps) {
-        derive_flags_t(cx, has_params, has_vars, tt);
-        for tt: t in tps { derive_flags_t(cx, has_params, has_vars, tt); }
+        derive_flags(has_params, has_vars, tt);
+        for tt in tps { derive_flags(has_params, has_vars, tt); }
       }
-      ty_constr(tt, _) | ty_named(tt, _) {
-        derive_flags_t(cx, has_params, has_vars, tt);
+      ty_constr(tt, _) {
+        derive_flags(has_params, has_vars, tt);
       }
     }
-    ret @{struct: st,
-          hash: h,
-          has_params: has_params,
-          has_vars: has_vars};
+    let t = @{struct: st,
+              id: cx.next_id,
+              has_params: has_params,
+              has_vars: has_vars,
+              name: name};
+    cx.interner.insert(key, t);
+    cx.next_id += 1u;
+    unsafe { unsafe::reinterpret_cast(t) }
 }
 
-fn intern(cx: ctxt, st: sty) {
-    interner::intern(*cx.ts, mk_raw_ty(cx, st));
-}
+fn mk_nil(cx: ctxt) -> t { mk_t(cx, ty_nil) }
 
-// These are private constructors to this module. External users should always
-// use the mk_foo() functions below.
-fn gen_ty(cx: ctxt, st: sty) -> t {
-    let raw_type = mk_raw_ty(cx, st);
-    ret interner::intern(*cx.ts, raw_type);
-}
+fn mk_bot(cx: ctxt) -> t { mk_t(cx, ty_bot) }
 
-fn mk_nil(_cx: ctxt) -> t { ret idx_nil; }
+fn mk_bool(cx: ctxt) -> t { mk_t(cx, ty_bool) }
 
-fn mk_bot(_cx: ctxt) -> t { ret idx_bot; }
+fn mk_int(cx: ctxt) -> t { mk_t(cx, ty_int(ast::ty_i)) }
 
-fn mk_bool(_cx: ctxt) -> t { ret idx_bool; }
+fn mk_float(cx: ctxt) -> t { mk_t(cx, ty_float(ast::ty_f)) }
 
-fn mk_int(_cx: ctxt) -> t { ret idx_int; }
+fn mk_uint(cx: ctxt) -> t { mk_t(cx, ty_uint(ast::ty_u)) }
 
-fn mk_float(_cx: ctxt) -> t { ret idx_float; }
+fn mk_mach_int(cx: ctxt, tm: ast::int_ty) -> t { mk_t(cx, ty_int(tm)) }
 
-fn mk_uint(_cx: ctxt) -> t { ret idx_uint; }
+fn mk_mach_uint(cx: ctxt, tm: ast::uint_ty) -> t { mk_t(cx, ty_uint(tm)) }
 
-fn mk_mach_int(_cx: ctxt, tm: ast::int_ty) -> t {
-    alt tm {
-      ast::ty_i { ret idx_int; }
-      ast::ty_char { ret idx_char; }
-      ast::ty_i8 { ret idx_i8; }
-      ast::ty_i16 { ret idx_i16; }
-      ast::ty_i32 { ret idx_i32; }
-      ast::ty_i64 { ret idx_i64; }
-    }
-}
+fn mk_mach_float(cx: ctxt, tm: ast::float_ty) -> t { mk_t(cx, ty_float(tm)) }
 
-fn mk_mach_uint(_cx: ctxt, tm: ast::uint_ty) -> t {
-    alt tm {
-      ast::ty_u { ret idx_uint; }
-      ast::ty_u8 { ret idx_u8; }
-      ast::ty_u16 { ret idx_u16; }
-      ast::ty_u32 { ret idx_u32; }
-      ast::ty_u64 { ret idx_u64; }
-    }
-}
+fn mk_char(cx: ctxt) -> t { mk_t(cx, ty_int(ast::ty_char)) }
 
-fn mk_mach_float(_cx: ctxt, tm: ast::float_ty) -> t {
-    alt tm {
-      ast::ty_f { ret idx_float; }
-      ast::ty_f32 { ret idx_f32; }
-      ast::ty_f64 { ret idx_f64; }
-    }
-}
-
-
-fn mk_char(_cx: ctxt) -> t { ret idx_char; }
-
-fn mk_str(_cx: ctxt) -> t { ret idx_str; }
+fn mk_str(cx: ctxt) -> t { mk_t(cx, ty_str) }
 
 fn mk_enum(cx: ctxt, did: ast::def_id, tys: [t]) -> t {
-    ret gen_ty(cx, ty_enum(did, tys));
+    mk_t(cx, ty_enum(did, tys))
 }
 
-fn mk_box(cx: ctxt, tm: mt) -> t { ret gen_ty(cx, ty_box(tm)); }
+fn mk_box(cx: ctxt, tm: mt) -> t { mk_t(cx, ty_box(tm)) }
 
-fn mk_uniq(cx: ctxt, tm: mt) -> t { ret gen_ty(cx, ty_uniq(tm)); }
+fn mk_imm_box(cx: ctxt, ty: t) -> t { mk_box(cx, {ty: ty, mut: ast::imm}) }
 
-fn mk_imm_uniq(cx: ctxt, ty: t) -> t {
-    ret mk_uniq(cx, {ty: ty, mut: ast::imm});
-}
+fn mk_uniq(cx: ctxt, tm: mt) -> t { mk_t(cx, ty_uniq(tm)) }
 
-fn mk_ptr(cx: ctxt, tm: mt) -> t { ret gen_ty(cx, ty_ptr(tm)); }
+fn mk_imm_uniq(cx: ctxt, ty: t) -> t { mk_uniq(cx, {ty: ty, mut: ast::imm}) }
 
-fn mk_imm_box(cx: ctxt, ty: t) -> t {
-    ret mk_box(cx, {ty: ty, mut: ast::imm});
-}
+fn mk_ptr(cx: ctxt, tm: mt) -> t { mk_t(cx, ty_ptr(tm)) }
 
-fn mk_mut_ptr(cx: ctxt, ty: t) -> t {
-    ret mk_ptr(cx, {ty: ty, mut: ast::mut});
-}
+fn mk_mut_ptr(cx: ctxt, ty: t) -> t { mk_ptr(cx, {ty: ty, mut: ast::mut}) }
 
-fn mk_vec(cx: ctxt, tm: mt) -> t { ret gen_ty(cx, ty_vec(tm)); }
+fn mk_vec(cx: ctxt, tm: mt) -> t { mk_t(cx, ty_vec(tm)) }
 
-fn mk_rec(cx: ctxt, fs: [field]) -> t { ret gen_ty(cx, ty_rec(fs)); }
+fn mk_rec(cx: ctxt, fs: [field]) -> t { mk_t(cx, ty_rec(fs)) }
 
 fn mk_constr(cx: ctxt, t: t, cs: [@type_constr]) -> t {
-    ret gen_ty(cx, ty_constr(t, cs));
+    mk_t(cx, ty_constr(t, cs))
 }
 
-fn mk_tup(cx: ctxt, ts: [t]) -> t { ret gen_ty(cx, ty_tup(ts)); }
+fn mk_tup(cx: ctxt, ts: [t]) -> t { mk_t(cx, ty_tup(ts)) }
 
-fn mk_fn(cx: ctxt, fty: fn_ty) -> t {
-    ret gen_ty(cx, ty_fn(fty));
-}
+fn mk_fn(cx: ctxt, fty: fn_ty) -> t { mk_t(cx, ty_fn(fty)) }
 
 fn mk_iface(cx: ctxt, did: ast::def_id, tys: [t]) -> t {
-    ret gen_ty(cx, ty_iface(did, tys));
+    mk_t(cx, ty_iface(did, tys))
 }
 
 fn mk_res(cx: ctxt, did: ast::def_id, inner: t, tps: [t]) -> t {
-    ret gen_ty(cx, ty_res(did, inner, tps));
+    mk_t(cx, ty_res(did, inner, tps))
 }
 
-fn mk_var(cx: ctxt, v: int) -> t { ret gen_ty(cx, ty_var(v)); }
+fn mk_var(cx: ctxt, v: int) -> t { mk_t(cx, ty_var(v)) }
 
-fn mk_param(cx: ctxt, n: uint, k: def_id) -> t {
-    ret gen_ty(cx, ty_param(n, k));
-}
+fn mk_param(cx: ctxt, n: uint, k: def_id) -> t { mk_t(cx, ty_param(n, k)) }
 
-fn mk_type(_cx: ctxt) -> t { ret idx_type; }
+fn mk_type(cx: ctxt) -> t { mk_t(cx, ty_type) }
 
-fn mk_send_type(_cx: ctxt) -> t { ret idx_send_type; }
+fn mk_send_type(cx: ctxt) -> t { mk_t(cx, ty_send_type) }
 
 fn mk_opaque_closure_ptr(cx: ctxt, ck: closure_kind) -> t {
-    ret gen_ty(cx, ty_opaque_closure_ptr(ck));
+    mk_t(cx, ty_opaque_closure_ptr(ck))
 }
 
-fn mk_named(cx: ctxt, base: t, name: @str) -> t {
-    gen_ty(cx, ty_named(base, name))
-}
-
-// Returns the one-level-deep type structure of the given type.
-pure fn struct(cx: ctxt, typ: t) -> sty {
-    alt interner::get(*cx.ts, typ).struct {
-      ty_named(t, _) { struct(cx, t) }
-      s { s }
-    }
-}
-
-pure fn struct_raw(cx: ctxt, typ: t) -> sty {
-    interner::get(*cx.ts, typ).struct
-}
-
-// Returns struct(cx, typ) but replaces all occurences of platform
-// dependent primitive types with their machine type equivalent
-pure fn mach_struct(cx: ctxt, cfg: @session::config, typ: t) -> sty {
-    alt interner::get(*cx.ts, typ).struct {
-      ty_named(t, _) { mach_struct(cx, cfg, t) }
-      s { mach_sty(cfg, s) }
-    }
+fn mk_named(cx: ctxt, base: t, name: str) -> t {
+    mk_t_named(cx, get(base).struct, some(name))
 }
 
 // Converts s to its machine type equivalent
-pure fn mach_sty(cfg: @session::config, s: sty) -> sty {
-    alt s {
+pure fn mach_sty(cfg: @session::config, t: t) -> sty {
+    alt get(t).struct {
       ty_int(ast::ty_i) { ty_int(cfg.int_type) }
       ty_uint(ast::ty_u) { ty_uint(cfg.uint_type) }
       ty_float(ast::ty_f) { ty_float(cfg.float_type) }
@@ -639,15 +504,8 @@ pure fn mach_sty(cfg: @session::config, s: sty) -> sty {
     }
 }
 
-pure fn ty_name(cx: ctxt, typ: t) -> option<@str> {
-    alt interner::get(*cx.ts, typ).struct {
-      ty_named(_, n) { some(n) }
-      _ { none }
-    }
-}
-
 fn walk_ty(cx: ctxt, ty: t, f: fn(t)) {
-    alt struct(cx, ty) {
+    alt get(ty).struct {
       ty_nil | ty_bot | ty_bool | ty_int(_) | ty_uint(_) | ty_float(_) |
       ty_str | ty_send_type | ty_type |
       ty_opaque_closure_ptr(_) | ty_var(_) | ty_param(_, _) {}
@@ -669,9 +527,6 @@ fn walk_ty(cx: ctxt, ty: t, f: fn(t)) {
       }
       ty_constr(sub, _) { walk_ty(cx, sub, f); }
       ty_uniq(tm) { walk_ty(cx, tm.ty, f); }
-      // precondition?
-      ty_named(_,_) { cx.sess.bug("walk_ty: should not see a ty_named \
-                        here"); }
     }
     f(ty);
 }
@@ -686,12 +541,13 @@ fn fold_ty(cx: ctxt, fld: fold_mode, ty_0: t) -> t {
     let ty = ty_0;
     // Fast paths.
 
+    let tb = get(ty);
     alt fld {
-      fm_var(_) { if !type_contains_vars(cx, ty) { ret ty; } }
-      fm_param(_) { if !type_contains_params(cx, ty) { ret ty; } }
+      fm_var(_) { if !tb.has_vars { ret ty; } }
+      fm_param(_) { if !tb.has_params { ret ty; } }
       fm_general(_) {/* no fast path */ }
     }
-    alt interner::get(*cx.ts, ty).struct {
+    alt tb.struct {
       ty_nil | ty_bot | ty_bool | ty_int(_) | ty_uint(_) | ty_float(_) |
       ty_str | ty_type | ty_send_type | ty_opaque_closure_ptr(_) {}
       ty_box(tm) {
@@ -699,9 +555,6 @@ fn fold_ty(cx: ctxt, fld: fold_mode, ty_0: t) -> t {
       }
       ty_uniq(tm) {
         ty = mk_uniq(cx, {ty: fold_ty(cx, fld, tm.ty), mut: tm.mut});
-      }
-      ty_named(t, nm) {
-        ty = mk_named(cx, fold_ty(cx, fld, t), nm);
       }
       ty_ptr(tm) {
         ty = mk_ptr(cx, {ty: fold_ty(cx, fld, tm.ty), mut: tm.mut});
@@ -765,20 +618,14 @@ fn fold_ty(cx: ctxt, fld: fold_mode, ty_0: t) -> t {
 
 // Type utilities
 
-fn type_is_nil(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) { ty_nil { ret true; } _ { ret false; } }
-}
+fn type_is_nil(ty: t) -> bool { get(ty).struct == ty_nil }
 
-fn type_is_bot(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) { ty_bot { ret true; } _ { ret false; } }
-}
+fn type_is_bot(ty: t) -> bool { get(ty).struct == ty_bot }
 
-fn type_is_bool(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) { ty_bool { ret true; } _ { ret false; } }
-}
+fn type_is_bool(ty: t) -> bool { get(ty).struct == ty_bool }
 
-fn type_is_structural(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+fn type_is_structural(ty: t) -> bool {
+    alt get(ty).struct {
       ty_rec(_) | ty_tup(_) | ty_enum(_, _) | ty_fn(_) |
       ty_res(_, _, _) { true }
       _ { false }
@@ -789,84 +636,77 @@ fn type_is_copyable(cx: ctxt, ty: t) -> bool {
     ret kind_can_be_copied(type_kind(cx, ty));
 }
 
-fn type_is_sequence(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+fn type_is_sequence(ty: t) -> bool {
+    alt get(ty).struct {
       ty_str { ret true; }
       ty_vec(_) { ret true; }
       _ { ret false; }
     }
 }
 
-fn type_is_str(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) { ty_str { ret true; } _ { ret false; } }
-}
+fn type_is_str(ty: t) -> bool { get(ty).struct == ty_str }
 
 fn sequence_element_type(cx: ctxt, ty: t) -> t {
-    alt struct(cx, ty) {
+    alt get(ty).struct {
       ty_str { ret mk_mach_uint(cx, ast::ty_u8); }
       ty_vec(mt) { ret mt.ty; }
       _ { cx.sess.bug("sequence_element_type called on non-sequence value"); }
     }
 }
 
-pure fn type_is_tup_like(cx: ctxt, ty: t) -> bool {
-    let sty = struct(cx, ty);
-    alt sty {
+pure fn type_is_tup_like(ty: t) -> bool {
+    alt get(ty).struct {
       ty_rec(_) | ty_tup(_) { true }
       _ { false }
     }
 }
 
-fn get_element_type(cx: ctxt, ty: t, i: uint) -> t {
-    alt struct(cx, ty) {
+fn get_element_type(ty: t, i: uint) -> t {
+    alt get(ty).struct {
       ty_rec(flds) { ret flds[i].mt.ty; }
       ty_tup(ts) { ret ts[i]; }
-      _ {
-        cx.sess.bug(
-            #fmt["get_element_type called on invalid type %s with index %u",
-                 ty_to_str(cx, ty), i]);
-      }
+      _ { fail "get_element_type called on invalid type"; }
     }
 }
 
-pure fn type_is_box(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+pure fn type_is_box(ty: t) -> bool {
+    alt get(ty).struct {
       ty_box(_) { ret true; }
       _ { ret false; }
     }
 }
 
-pure fn type_is_boxed(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+pure fn type_is_boxed(ty: t) -> bool {
+    alt get(ty).struct {
       ty_box(_) | ty_iface(_, _) { ret true; }
       _ { ret false; }
     }
 }
 
-pure fn type_is_unique_box(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+pure fn type_is_unique_box(ty: t) -> bool {
+    alt get(ty).struct {
       ty_uniq(_) { ret true; }
       _ { ret false; }
     }
 }
 
-pure fn type_is_unsafe_ptr(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+pure fn type_is_unsafe_ptr(ty: t) -> bool {
+    alt get(ty).struct {
       ty_ptr(_) { ret true; }
       _ { ret false; }
     }
 }
 
-pure fn type_is_vec(cx: ctxt, ty: t) -> bool {
-    ret alt struct(cx, ty) {
+pure fn type_is_vec(ty: t) -> bool {
+    ret alt get(ty).struct {
           ty_vec(_) { true }
           ty_str { true }
           _ { false }
         };
 }
 
-pure fn type_is_unique(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+pure fn type_is_unique(ty: t) -> bool {
+    alt get(ty).struct {
       ty_uniq(_) { ret true; }
       ty_vec(_) { true }
       ty_str { true }
@@ -874,8 +714,8 @@ pure fn type_is_unique(cx: ctxt, ty: t) -> bool {
     }
 }
 
-pure fn type_is_scalar(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+pure fn type_is_scalar(ty: t) -> bool {
+    alt get(ty).struct {
       ty_nil | ty_bool | ty_int(_) | ty_float(_) | ty_uint(_) |
       ty_send_type | ty_type | ty_ptr(_) { true }
       _ { false }
@@ -883,9 +723,9 @@ pure fn type_is_scalar(cx: ctxt, ty: t) -> bool {
 }
 
 // FIXME maybe inline this for speed?
-fn type_is_immediate(cx: ctxt, ty: t) -> bool {
-    ret type_is_scalar(cx, ty) || type_is_boxed(cx, ty) ||
-        type_is_unique(cx, ty);
+fn type_is_immediate(ty: t) -> bool {
+    ret type_is_scalar(ty) || type_is_boxed(ty) ||
+        type_is_unique(ty);
 }
 
 fn type_needs_drop(cx: ctxt, ty: t) -> bool {
@@ -895,7 +735,7 @@ fn type_needs_drop(cx: ctxt, ty: t) -> bool {
     }
 
     let accum = false;
-    let result = alt struct(cx, ty) {
+    let result = alt get(ty).struct {
       // scalar types
       ty_nil | ty_bot | ty_bool | ty_int(_) | ty_float(_) | ty_uint(_) |
       ty_type | ty_ptr(_) { false }
@@ -966,7 +806,7 @@ fn kind_lteq(a: kind, b: kind) -> bool {
 }
 
 fn lower_kind(a: kind, b: kind) -> kind {
-    if ty::kind_lteq(a, b) { a } else { b }
+    if kind_lteq(a, b) { a } else { b }
 }
 
 fn type_kind(cx: ctxt, ty: t) -> kind {
@@ -978,7 +818,7 @@ fn type_kind(cx: ctxt, ty: t) -> kind {
     // Insert a default in case we loop back on self recursively.
     cx.kind_cache.insert(ty, kind_sendable);
 
-    let result = alt struct(cx, ty) {
+    let result = alt get(ty).struct {
       // Scalar and unique types are sendable
       ty_nil | ty_bot | ty_bool | ty_int(_) | ty_uint(_) | ty_float(_) |
       ty_ptr(_) | ty_send_type | ty_str { kind_sendable }
@@ -1032,7 +872,7 @@ fn type_kind(cx: ctxt, ty: t) -> kind {
 
 fn type_structurally_contains(cx: ctxt, ty: t, test: fn(sty) -> bool) ->
    bool {
-    let sty = struct(cx, ty);
+    let sty = get(ty).struct;
     if test(sty) { ret true; }
     alt sty {
       ty_enum(did, tps) {
@@ -1074,7 +914,7 @@ pure fn type_has_dynamic_size(cx: ctxt, ty: t) -> bool unchecked {
     actually checkable. It seems to me like a lot of properties
     that the type context tracks about types should be immutable.)
     */
-    type_structurally_contains(cx, ty) {|sty|
+    type_has_params(ty) && type_structurally_contains(cx, ty) {|sty|
         alt sty {
           ty_param(_, _) { true }
           _ { false }
@@ -1117,26 +957,26 @@ fn type_structurally_contains_uniques(cx: ctxt, ty: t) -> bool {
     });
 }
 
-fn type_is_integral(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+fn type_is_integral(ty: t) -> bool {
+    alt get(ty).struct {
       ty_int(_) | ty_uint(_) | ty_bool { true }
       _ { false }
     }
 }
 
-fn type_is_fp(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+fn type_is_fp(ty: t) -> bool {
+    alt get(ty).struct {
       ty_float(_) { true }
       _ { false }
     }
 }
 
-fn type_is_numeric(cx: ctxt, ty: t) -> bool {
-    ret type_is_integral(cx, ty) || type_is_fp(cx, ty);
+fn type_is_numeric(ty: t) -> bool {
+    ret type_is_integral(ty) || type_is_fp(ty);
 }
 
-fn type_is_signed(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+fn type_is_signed(ty: t) -> bool {
+    alt get(ty).struct {
       ty_int(_) { true }
       _ { false }
     }
@@ -1146,7 +986,7 @@ fn type_is_signed(cx: ctxt, ty: t) -> bool {
 // that the cycle collector might care about.
 fn type_is_pod(cx: ctxt, ty: t) -> bool {
     let result = true;
-    alt struct(cx, ty) {
+    alt get(ty).struct {
       // Scalar types
       ty_nil | ty_bot | ty_bool | ty_int(_) | ty_float(_) | ty_uint(_) |
       ty_send_type | ty_type | ty_ptr(_) { result = true; }
@@ -1181,17 +1021,13 @@ fn type_is_pod(cx: ctxt, ty: t) -> bool {
       }
       ty_param(_, _) { result = false; }
       ty_opaque_closure_ptr(_) { result = true; }
-      ty_named(_,_) {
-          cx.sess.bug("ty_named in type_is_pod");
-      }
-
     }
 
     ret result;
 }
 
-fn type_is_enum(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+fn type_is_enum(ty: t) -> bool {
+    alt get(ty).struct {
       ty_enum(_, _) { ret true; }
       _ { ret false;}
     }
@@ -1200,7 +1036,7 @@ fn type_is_enum(cx: ctxt, ty: t) -> bool {
 // Whether a type is enum like, that is a enum type with only nullary
 // constructors
 fn type_is_c_like_enum(cx: ctxt, ty: t) -> bool {
-    alt struct(cx, ty) {
+    alt get(ty).struct {
       ty_enum(did, tps) {
         let variants = enum_variants(cx, did);
         let some_n_ary = vec::any(*variants, {|v| vec::len(v.args) > 0u});
@@ -1210,8 +1046,8 @@ fn type_is_c_like_enum(cx: ctxt, ty: t) -> bool {
     }
 }
 
-fn type_param(cx: ctxt, ty: t) -> option<uint> {
-    alt struct(cx, ty) {
+fn type_param(ty: t) -> option<uint> {
+    alt get(ty).struct {
       ty_param(id, _) { ret some(id); }
       _ {/* fall through */ }
     }
@@ -1223,15 +1059,15 @@ fn type_param(cx: ctxt, ty: t) -> option<uint> {
 fn vars_in_type(cx: ctxt, ty: t) -> [int] {
     let rslt = [];
     walk_ty(cx, ty) {|ty|
-        alt struct(cx, ty) { ty_var(v) { rslt += [v]; } _ { } }
+        alt get(ty).struct { ty_var(v) { rslt += [v]; } _ { } }
     }
     rslt
 }
 
-fn type_autoderef(cx: ctxt, t: ty::t) -> ty::t {
+fn type_autoderef(cx: ctxt, t: t) -> t {
     let t1 = t;
     while true {
-        alt struct(cx, t1) {
+        alt get(t1).struct {
           ty_box(mt) | ty_uniq(mt) { t1 = mt.ty; }
           ty_res(_, inner, tps) {
             t1 = substitute_type_params(cx, tps, inner);
@@ -1251,57 +1087,29 @@ fn type_autoderef(cx: ctxt, t: ty::t) -> ty::t {
 
 // Type hashing.
 fn hash_type_structure(st: sty) -> uint {
-    fn hash_uint(id: uint, n: uint) -> uint {
-        let h = id;
-        h += (h << 5u) + n;
-        ret h;
-    }
+    fn hash_uint(id: uint, n: uint) -> uint { (id << 2u) + n }
     fn hash_def(id: uint, did: ast::def_id) -> uint {
-        let h = id;
-        h += (h << 5u) + (did.crate as uint);
-        h += (h << 5u) + (did.node as uint);
-        ret h;
+        let h = (id << 2u) + (did.crate as uint);
+        (h << 2u) + (did.node as uint)
     }
-    fn hash_subty(id: uint, subty: t) -> uint {
-        let h = id;
-        h += (h << 5u) + subty;
-        ret h;
-    }
+    fn hash_subty(id: uint, subty: t) -> uint { (id << 2u) + type_id(subty) }
     fn hash_subtys(id: uint, subtys: [t]) -> uint {
         let h = id;
-        vec::iter(subtys) { |subty|
-            h = hash_subty(h, subty);
-        }
-        ret h;
+        for s in subtys { h = (h << 2u) + type_id(s) }
+        h
     }
     fn hash_type_constr(id: uint, c: @type_constr) -> uint {
         let h = id;
-        h += (h << 5u) + hash_def(h, c.node.id);
-        ret hash_type_constr_args(h, c.node.args);
-    }
-    fn hash_type_constr_args(id: uint, args: [@ty_constr_arg]) -> uint {
-        let h = id;
-        for a: @ty_constr_arg in args {
+        h = (h << 2u) + hash_def(h, c.node.id);
+        // FIXME this makes little sense
+        for a in c.node.args {
             alt a.node {
-              carg_base { h += h << 5u; }
-              carg_lit(_) {
-                // FIXME
-                fail "lit args not implemented yet";
-              }
-              carg_ident(p) {
-                // FIXME: Not sure what to do here.
-                h += h << 5u;
-              }
+              carg_base { h += h << 2u; }
+              carg_lit(_) { fail "lit args not implemented yet"; }
+              carg_ident(p) { h += h << 2u; }
             }
         }
-        ret h;
-    }
-
-    fn hash_fn(id: uint, args: [arg], rty: t) -> uint {
-        let h = id;
-        for a: arg in args { h += (h << 5u) + a.ty; }
-        h += (h << 5u) + rty;
-        ret h;
+        h
     }
     alt st {
       ty_nil { 0u } ty_bool { 1u }
@@ -1320,52 +1128,51 @@ fn hash_type_structure(st: sty) -> uint {
       ty_float(t) {
         alt t { ast::ty_f { 13u } ast::ty_f32 { 14u } ast::ty_f64 { 15u } }
       }
-      ty_str { ret 17u; }
+      ty_str { 17u }
       ty_enum(did, tys) {
         let h = hash_def(18u, did);
-        for typ: t in tys { h += (h << 5u) + typ; }
-        ret h;
+        for typ: t in tys { h = hash_subty(h, typ); }
+        h
       }
-      ty_box(mt) { ret hash_subty(19u, mt.ty); }
-      ty_vec(mt) { ret hash_subty(21u, mt.ty); }
+      ty_box(mt) { hash_subty(19u, mt.ty) }
+      ty_vec(mt) { hash_subty(21u, mt.ty) }
       ty_rec(fields) {
         let h = 26u;
-        for f: field in fields { h += (h << 5u) + f.mt.ty; }
-        ret h;
+        for f in fields { h = hash_subty(h, f.mt.ty); }
+        h
       }
-      ty_tup(ts) { ret hash_subtys(25u, ts); }
-
-      // ???
-      ty_fn(f) { ret hash_fn(27u, f.inputs, f.output); }
-      ty_var(v) { ret hash_uint(30u, v as uint); }
-      ty_param(pid, _) { ret hash_uint(31u, pid); }
-      ty_type { ret 32u; }
-      ty_bot { ret 34u; }
-      ty_ptr(mt) { ret hash_subty(35u, mt.ty); }
+      ty_tup(ts) { hash_subtys(25u, ts) }
+      ty_fn(f) {
+        let h = 27u;
+        for a in f.inputs { h = hash_subty(h, a.ty); }
+        hash_subty(h, f.output)
+      }
+      ty_var(v) { hash_uint(30u, v as uint) }
+      ty_param(pid, did) { hash_def(hash_uint(31u, pid), did) }
+      ty_type { 32u }
+      ty_bot { 34u }
+      ty_ptr(mt) { hash_subty(35u, mt.ty) }
       ty_res(did, sub, tps) {
         let h = hash_subty(hash_def(18u, did), sub);
-        ret hash_subtys(h, tps);
+        hash_subtys(h, tps)
       }
       ty_constr(t, cs) {
         let h = hash_subty(36u, t);
-        for c: @type_constr in cs { h += (h << 5u) + hash_type_constr(h, c); }
-        ret h;
+        for c in cs { h = (h << 2u) + hash_type_constr(h, c); }
+        h
       }
-      ty_uniq(mt) { ret hash_subty(37u, mt.ty); }
-      ty_send_type { ret 38u; }
-      ty_named(t, name) { (str::hash(*name) << 5u) + hash_subty(39u, t) }
+      ty_uniq(mt) { hash_subty(37u, mt.ty) }
+      ty_send_type { 38u }
       ty_iface(did, tys) {
         let h = hash_def(40u, did);
         for typ: t in tys { h = hash_subty(h, typ); }
-        ret h;
+        h
       }
-      ty_opaque_closure_ptr(ck_block) { ret 41u; }
-      ty_opaque_closure_ptr(ck_box) { ret 42u; }
-      ty_opaque_closure_ptr(ck_uniq) { ret 43u; }
+      ty_opaque_closure_ptr(ck_block) { 41u }
+      ty_opaque_closure_ptr(ck_box) { 42u }
+      ty_opaque_closure_ptr(ck_uniq) { 43u }
     }
 }
-
-fn hash_raw_ty(&&rt: @raw_t) -> uint { ret rt.hash; }
 
 fn arg_eq<T>(eq: fn(T, T) -> bool,
              a: @sp_constr_arg<T>,
@@ -1430,7 +1237,7 @@ fn node_id_has_type_params(cx: ctxt, id: ast::node_id) -> bool {
 fn count_ty_params(cx: ctxt, ty: t) -> uint {
     let param_indices = [];
     walk_ty(cx, ty) {|t|
-        alt struct(cx, t) {
+        alt get(t).struct {
           ty_param(param_idx, _) {
             if !vec::any(param_indices, {|i| i == param_idx}) {
                 param_indices += [param_idx];
@@ -1442,68 +1249,51 @@ fn count_ty_params(cx: ctxt, ty: t) -> uint {
     vec::len(param_indices)
 }
 
-fn type_contains_vars(cx: ctxt, typ: t) -> bool {
-    ret interner::get(*cx.ts, typ).has_vars;
-}
-
-fn type_contains_params(cx: ctxt, typ: t) -> bool {
-    ret interner::get(*cx.ts, typ).has_params;
-}
-
-
 // Type accessors for substructures of types
-fn ty_fn_args(cx: ctxt, fty: t) -> [arg] {
-    alt struct(cx, fty) {
-      ty::ty_fn(f) { ret f.inputs; }
-      _ { cx.sess.bug("ty_fn_args() called on non-fn type"); }
+fn ty_fn_args(fty: t) -> [arg] {
+    alt get(fty).struct {
+      ty_fn(f) { f.inputs }
+      _ { fail "ty_fn_args() called on non-fn type"; }
     }
 }
 
-fn ty_fn_proto(cx: ctxt, fty: t) -> ast::proto {
-    alt struct(cx, fty) {
-      ty::ty_fn(f) { ret f.proto; }
-      _ { cx.sess.bug("ty_fn_proto() called on non-fn type"); }
+fn ty_fn_proto(fty: t) -> ast::proto {
+    alt get(fty).struct {
+      ty_fn(f) { f.proto }
+      _ { fail "ty_fn_proto() called on non-fn type"; }
     }
 }
 
-pure fn ty_fn_ret(cx: ctxt, fty: t) -> t {
-    let sty = struct(cx, fty);
-    alt sty {
-      ty::ty_fn(f) { ret f.output; }
-      _ {
-        // Unchecked is ok since we diverge here
-        // (might want to change the typechecker to allow
-        // it without an unchecked)
-        // Or, it wouldn't be necessary if we had the right
-        // typestate constraint on cx and t (then we could
-        // call unreachable() instead)
-        unchecked { cx.sess.bug("ty_fn_ret() called on non-fn type"); }}
+pure fn ty_fn_ret(fty: t) -> t {
+    alt get(fty).struct {
+      ty_fn(f) { f.output }
+      _ { fail "ty_fn_ret() called on non-fn type"; }
     }
 }
 
-fn ty_fn_ret_style(cx: ctxt, fty: t) -> ast::ret_style {
-    alt struct(cx, fty) {
-      ty::ty_fn(f) { f.ret_style }
-      _ { cx.sess.bug("ty_fn_ret_style() called on non-fn type"); }
+fn ty_fn_ret_style(fty: t) -> ast::ret_style {
+    alt get(fty).struct {
+      ty_fn(f) { f.ret_style }
+      _ { fail "ty_fn_ret_style() called on non-fn type"; }
     }
 }
 
-fn is_fn_ty(cx: ctxt, fty: t) -> bool {
-    alt struct(cx, fty) {
-      ty::ty_fn(_) { ret true; }
+fn is_fn_ty(fty: t) -> bool {
+    alt get(fty).struct {
+      ty_fn(_) { ret true; }
       _ { ret false; }
     }
 }
 
 // Just checks whether it's a fn that returns bool,
 // not its purity.
-fn is_pred_ty(cx: ctxt, fty: t) -> bool {
-    is_fn_ty(cx, fty) && type_is_bool(cx, ty_fn_ret(cx, fty))
+fn is_pred_ty(fty: t) -> bool {
+    is_fn_ty(fty) && type_is_bool(ty_fn_ret(fty))
 }
 
-fn ty_var_id(cx: ctxt, typ: t) -> int {
-    alt struct(cx, typ) {
-      ty::ty_var(vid) { ret vid; }
+fn ty_var_id(typ: t) -> int {
+    alt get(typ).struct {
+      ty_var(vid) { ret vid; }
       _ { #error("ty_var_id called on non-var ty"); fail; }
     }
 }
@@ -1574,8 +1364,8 @@ fn get_field(tcx: ctxt, rec_ty: t, id: ast::ident) -> field {
 
 // TODO: could have a precondition instead of failing
 fn get_fields(tcx:ctxt, rec_ty:t) -> [field] {
-    alt struct(tcx, rec_ty) {
-       ty::ty_rec(fields) { fields }
+    alt get(rec_ty).struct {
+       ty_rec(fields) { fields }
        _ { tcx.sess.bug("get_fields called on non-record type"); }
     }
 }
@@ -1595,10 +1385,8 @@ fn sort_methods(meths: [method]) -> [method] {
 
 fn occurs_check_fails(tcx: ctxt, sp: option<span>, vid: int, rt: t) ->
    bool {
-    if !type_contains_vars(tcx, rt) {
-        // Fast path
-        ret false;
-    }
+    // Fast path
+    if !type_has_vars(rt) { ret false; }
 
     // Occurs check!
     if vec::member(vid, vars_in_type(tcx, rt)) {
@@ -1610,7 +1398,7 @@ fn occurs_check_fails(tcx: ctxt, sp: option<span>, vid: int, rt: t) ->
             tcx.sess.span_fatal
                 (s, "Type inference failed because I \
                      could not find a type\n that's both of the form "
-                 + ty_to_str(tcx, ty::mk_var(tcx, vid)) +
+                 + ty_to_str(tcx, mk_var(tcx, vid)) +
                  " and of the form " + ty_to_str(tcx, rt) +
                  ". Such a type would have to be infinitely large.");
           }
@@ -1624,7 +1412,6 @@ fn occurs_check_fails(tcx: ctxt, sp: option<span>, vid: int, rt: t) ->
 //
 //     http://www.cs.man.ac.uk/~hoderk/ubench/unification_full.pdf
 mod unify {
-
     export fixup_result;
     export fixup_vars;
     export fix_ok;
@@ -1652,14 +1439,14 @@ mod unify {
         precise,
         in_bindings(@var_bindings),
     }
-    type ctxt = {st: unify_style, tcx: ty_ctxt};
+    type uctxt = {st: unify_style, tcx: ctxt};
 
     fn mk_var_bindings() -> @var_bindings {
         ret @{sets: ufind::make(), types: smallintmap::mk::<t>()};
     }
 
     // Unifies two sets.
-    fn union(cx: @ctxt, set_a: uint, set_b: uint,
+    fn union(cx: @uctxt, set_a: uint, set_b: uint,
              variance: variance) -> union_result {
         let vb = alt cx.st {
             in_bindings(vb) { vb }
@@ -1700,20 +1487,20 @@ mod unify {
     }
 
     fn record_var_binding_for_expected(
-        cx: @ctxt, key: int, typ: t, variance: variance) -> result {
+        cx: @uctxt, key: int, typ: t, variance: variance) -> result {
         record_var_binding(
             cx, key, typ, variance_transform(variance, covariant))
     }
 
     fn record_var_binding_for_actual(
-        cx: @ctxt, key: int, typ: t, variance: variance) -> result {
+        cx: @uctxt, key: int, typ: t, variance: variance) -> result {
         // Unifying in 'the other direction' so flip the variance
         record_var_binding(
             cx, key, typ, variance_transform(variance, contravariant))
     }
 
     fn record_var_binding(
-        cx: @ctxt, key: int, typ: t, variance: variance) -> result {
+        cx: @uctxt, key: int, typ: t, variance: variance) -> result {
 
         let vb = alt cx.st { in_bindings(vb) { vb }
             _ { cx.tcx.sess.bug("Someone forgot to document an invariant \
@@ -1736,10 +1523,10 @@ mod unify {
     }
 
     // Simple structural type comparison.
-    fn struct_cmp(cx: @ctxt, expected: t, actual: t) -> result {
+    fn struct_cmp(cx: @uctxt, expected: t, actual: t) -> result {
         let tcx = cx.tcx;
         let cfg = tcx.sess.targ_cfg;
-        if mach_struct(tcx, cfg, expected) == mach_struct(tcx, cfg, actual) {
+        if mach_sty(cfg, expected) == mach_sty(cfg, actual) {
             ret ures_ok(expected);
         }
         ret ures_err(terr_mismatch);
@@ -1855,8 +1642,8 @@ mod unify {
           _ { some(ures_err(terr_mismatch)) }
         };
     }
-    fn unify_args(cx: @ctxt, e_args: [arg], a_args: [arg], variance: variance)
-        -> either::t<result, [arg]> {
+    fn unify_args(cx: @uctxt, e_args: [arg], a_args: [arg],
+                  variance: variance) -> either::t<result, [arg]> {
         if !vec::same_length(e_args, a_args) {
             ret either::left(ures_err(terr_arg_count));
         }
@@ -1887,7 +1674,7 @@ mod unify {
         }
         either::right(result)
     }
-    fn unify_fn(cx: @ctxt, e_f: fn_ty, a_f: fn_ty, variance: variance)
+    fn unify_fn(cx: @uctxt, e_f: fn_ty, a_f: fn_ty, variance: variance)
         -> result {
         alt unify_fn_proto(e_f.proto, a_f.proto, variance) {
           some(err) { ret err; }
@@ -1922,9 +1709,9 @@ mod unify {
     }
 
     // If the given type is a variable, returns the structure of that type.
-    fn resolve_type_structure(tcx: ty_ctxt, vb: @var_bindings, typ: t) ->
+    fn resolve_type_structure(vb: @var_bindings, typ: t) ->
        fixup_result {
-        alt struct(tcx, typ) {
+        alt get(typ).struct {
           ty_var(vid) {
             if vid as uint >= ufind::set_count(vb.sets) { ret fix_err(vid); }
             let root_id = ufind::find(vb.sets, vid as uint);
@@ -1979,7 +1766,7 @@ mod unify {
         }
     }
 
-    fn unify_tps(cx: @ctxt, expected_tps: [t], actual_tps: [t],
+    fn unify_tps(cx: @uctxt, expected_tps: [t], actual_tps: [t],
                  variance: variance, finish: fn([t]) -> result) -> result {
         let result_tps = [], i = 0u;
         for exp in expected_tps {
@@ -1993,7 +1780,7 @@ mod unify {
         }
         finish(result_tps)
     }
-    fn unify_step(cx: @ctxt, expected: t, actual: t,
+    fn unify_step(cx: @uctxt, expected: t, actual: t,
                   variance: variance) -> result {
         // FIXME: rewrite this using tuple pattern matching when available, to
         // avoid all this rightward drift and spikiness.
@@ -2007,13 +1794,13 @@ mod unify {
         // Stage 1: Handle the cases in which one side or another is a type
         // variable
 
-        alt struct(cx.tcx, actual) {
+        alt get(actual).struct {
           // If the RHS is a variable type, then just do the
           // appropriate binding.
-          ty::ty_var(actual_id) {
+          ty_var(actual_id) {
             let actual_n = actual_id as uint;
-            alt struct(cx.tcx, expected) {
-              ty::ty_var(expected_id) {
+            alt get(expected).struct {
+              ty_var(expected_id) {
                 let expected_n = expected_id as uint;
                 alt union(cx, expected_n, actual_n, variance) {
                   unres_ok {/* fall through */ }
@@ -2033,8 +1820,8 @@ mod unify {
           }
           _ {/* empty */ }
         }
-        alt struct(cx.tcx, expected) {
-          ty::ty_var(expected_id) {
+        alt get(expected).struct {
+          ty_var(expected_id) {
             // Add a binding. (`actual` can't actually be a var here.)
             alt record_var_binding_for_expected(
                 cx, expected_id, actual,
@@ -2048,31 +1835,31 @@ mod unify {
         }
         // Stage 2: Handle all other cases.
 
-        alt struct(cx.tcx, actual) {
-          ty::ty_bot { ret ures_ok(expected); }
+        alt get(actual).struct {
+          ty_bot { ret ures_ok(expected); }
           _ {/* fall through */ }
         }
-        alt struct(cx.tcx, expected) {
-          ty::ty_nil { ret struct_cmp(cx, expected, actual); }
+        alt get(expected).struct {
+          ty_nil { ret struct_cmp(cx, expected, actual); }
           // _|_ unifies with anything
-          ty::ty_bot {
+          ty_bot {
             ret ures_ok(actual);
           }
-          ty::ty_bool | ty::ty_int(_) | ty_uint(_) | ty_float(_) |
-          ty::ty_str | ty::ty_send_type {
+          ty_bool | ty_int(_) | ty_uint(_) | ty_float(_) |
+          ty_str | ty_send_type {
             ret struct_cmp(cx, expected, actual);
           }
-          ty::ty_param(expected_n, _) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_param(actual_n, _) if expected_n == actual_n {
+          ty_param(expected_n, _) {
+            alt get(actual).struct {
+              ty_param(actual_n, _) if expected_n == actual_n {
                 ret ures_ok(expected);
               }
               _ { ret ures_err(terr_mismatch); }
             }
           }
-          ty::ty_enum(expected_id, expected_tps) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_enum(actual_id, actual_tps) {
+          ty_enum(expected_id, expected_tps) {
+            alt get(actual).struct {
+              ty_enum(actual_id, actual_tps) {
                 if expected_id != actual_id {
                     ret ures_err(terr_mismatch);
                 }
@@ -2085,8 +1872,8 @@ mod unify {
             ret ures_err(terr_mismatch);
           }
           ty_iface(expected_id, expected_tps) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_iface(actual_id, actual_tps) {
+            alt get(actual).struct {
+              ty_iface(actual_id, actual_tps) {
                 if expected_id != actual_id {
                     ret ures_err(terr_mismatch);
                 }
@@ -2098,9 +1885,9 @@ mod unify {
             }
             ret ures_err(terr_mismatch);
           }
-          ty::ty_box(expected_mt) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_box(actual_mt) {
+          ty_box(expected_mt) {
+            alt get(actual).struct {
+              ty_box(actual_mt) {
                 let (mutt, var) = alt unify_mut(
                     expected_mt.mut, actual_mt.mut, variance) {
                   none { ret ures_err(terr_box_mutability); }
@@ -2119,9 +1906,9 @@ mod unify {
               _ { ret ures_err(terr_mismatch); }
             }
           }
-          ty::ty_uniq(expected_mt) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_uniq(actual_mt) {
+          ty_uniq(expected_mt) {
+            alt get(actual).struct {
+              ty_uniq(actual_mt) {
                 let (mutt, var) = alt unify_mut(
                     expected_mt.mut, actual_mt.mut, variance) {
                   none { ret ures_err(terr_box_mutability); }
@@ -2140,9 +1927,9 @@ mod unify {
               _ { ret ures_err(terr_mismatch); }
             }
           }
-          ty::ty_vec(expected_mt) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_vec(actual_mt) {
+          ty_vec(expected_mt) {
+            alt get(actual).struct {
+              ty_vec(actual_mt) {
                 let (mutt, var) = alt unify_mut(
                     expected_mt.mut, actual_mt.mut, variance) {
                   none { ret ures_err(terr_vec_mutability); }
@@ -2161,9 +1948,9 @@ mod unify {
               _ { ret ures_err(terr_mismatch); }
             }
           }
-          ty::ty_ptr(expected_mt) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_ptr(actual_mt) {
+          ty_ptr(expected_mt) {
+            alt get(actual).struct {
+              ty_ptr(actual_mt) {
                 let (mutt, var) = alt unify_mut(
                     expected_mt.mut, actual_mt.mut, variance) {
                   none { ret ures_err(terr_vec_mutability); }
@@ -2182,9 +1969,9 @@ mod unify {
               _ { ret ures_err(terr_mismatch); }
             }
           }
-          ty::ty_res(ex_id, ex_inner, ex_tps) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_res(act_id, act_inner, act_tps) {
+          ty_res(ex_id, ex_inner, ex_tps) {
+            alt get(actual).struct {
+              ty_res(act_id, act_inner, act_tps) {
                 if ex_id.crate != act_id.crate || ex_id.node != act_id.node {
                     ret ures_err(terr_mismatch);
                 }
@@ -2211,9 +1998,9 @@ mod unify {
               _ { ret ures_err(terr_mismatch); }
             }
           }
-          ty::ty_rec(expected_fields) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_rec(actual_fields) {
+          ty_rec(expected_fields) {
+            alt get(actual).struct {
+              ty_rec(actual_fields) {
                 let expected_len = vec::len::<field>(expected_fields);
                 let actual_len = vec::len::<field>(actual_fields);
                 if expected_len != actual_len {
@@ -2257,9 +2044,9 @@ mod unify {
               _ { ret ures_err(terr_mismatch); }
             }
           }
-          ty::ty_tup(expected_elems) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_tup(actual_elems) {
+          ty_tup(expected_elems) {
+            alt get(actual).struct {
+              ty_tup(actual_elems) {
                 let expected_len = vec::len(expected_elems);
                 let actual_len = vec::len(actual_elems);
                 if expected_len != actual_len {
@@ -2287,19 +2074,19 @@ mod unify {
               _ { ret ures_err(terr_mismatch); }
             }
           }
-          ty::ty_fn(expected_f) {
-            alt struct(cx.tcx, actual) {
-              ty::ty_fn(actual_f) {
+          ty_fn(expected_f) {
+            alt get(actual).struct {
+              ty_fn(actual_f) {
                 ret unify_fn(cx, expected_f, actual_f, variance);
               }
               _ { ret ures_err(terr_mismatch); }
             }
           }
-          ty::ty_constr(expected_t, expected_constrs) {
+          ty_constr(expected_t, expected_constrs) {
 
             // unify the base types...
-            alt struct(cx.tcx, actual) {
-              ty::ty_constr(actual_t, actual_constrs) {
+            alt get(actual).struct {
+              ty_constr(actual_t, actual_constrs) {
                 let rslt = unify_step(
                     cx, expected_t, actual_t, variance);
                 alt rslt {
@@ -2326,11 +2113,11 @@ mod unify {
         }
     }
     fn unify(expected: t, actual: t, st: unify_style,
-             tcx: ty_ctxt) -> result {
+             tcx: ctxt) -> result {
         let cx = @{st: st, tcx: tcx};
         ret unify_step(cx, expected, actual, covariant);
     }
-    fn dump_var_bindings(tcx: ty_ctxt, vb: @var_bindings) {
+    fn dump_var_bindings(tcx: ctxt, vb: @var_bindings) {
         let i = 0u;
         while i < vec::len::<ufind::node>(vb.sets.nodes) {
             let sets = "";
@@ -2353,20 +2140,20 @@ mod unify {
     //    Takes an optional span - complain about occurs check violations
     //    iff the span is present (so that if we already know we're going
     //    to error anyway, we don't complain)
-    fn fixup_vars(tcx: ty_ctxt, sp: option<span>, vb: @var_bindings,
+    fn fixup_vars(tcx: ctxt, sp: option<span>, vb: @var_bindings,
                   typ: t) -> fixup_result {
-        fn subst_vars(tcx: ty_ctxt, sp: option<span>, vb: @var_bindings,
+        fn subst_vars(tcx: ctxt, sp: option<span>, vb: @var_bindings,
                       unresolved: @mutable option<int>,
                       vars_seen: std::list::list<int>, vid: int) -> t {
             // Should really return a fixup_result instead of a t, but fold_ty
             // doesn't allow returning anything but a t.
             if vid as uint >= ufind::set_count(vb.sets) {
                 *unresolved = some(vid);
-                ret ty::mk_var(tcx, vid);
+                ret mk_var(tcx, vid);
             }
             let root_id = ufind::find(vb.sets, vid as uint);
             alt smallintmap::find::<t>(vb.types, root_id) {
-              none { *unresolved = some(vid); ret ty::mk_var(tcx, vid); }
+              none { *unresolved = some(vid); ret mk_var(tcx, vid); }
               some(rt) {
                 let give_up = false;
                 std::list::iter(vars_seen) {|v|
@@ -2396,7 +2183,7 @@ mod unify {
           some(var_id) { ret fix_err(var_id); }
         }
     }
-    fn resolve_type_var(tcx: ty_ctxt, sp: option<span>, vb: @var_bindings,
+    fn resolve_type_var(tcx: ctxt, sp: option<span>, vb: @var_bindings,
                         vid: int) -> fixup_result {
         if vid as uint >= ufind::set_count(vb.sets) { ret fix_err(vid); }
         let root_id = ufind::find(vb.sets, vid as uint);
@@ -2414,7 +2201,7 @@ fn same_type(cx: ctxt, a: t, b: t) -> bool {
     }
 }
 
-fn type_err_to_str(err: ty::type_err) -> str {
+fn type_err_to_str(err: type_err) -> str {
     alt err {
       terr_mismatch { ret "types differ"; }
       terr_ret_style_mismatch(expect, actual) {
@@ -2464,10 +2251,10 @@ fn type_err_to_str(err: ty::type_err) -> str {
 
 // Replaces type parameters in the given type using the given list of
 // substitions.
-fn substitute_type_params(cx: ctxt, substs: [ty::t], typ: t) -> t {
-   if !type_contains_params(cx, typ) { ret typ; }
+fn substitute_type_params(cx: ctxt, substs: [t], typ: t) -> t {
+    if !type_has_params(typ) { ret typ; }
     // Precondition? idx < vec::len(substs)
-    fn substituter(_cx: ctxt, substs: @[ty::t], idx: uint, _did: def_id)
+    fn substituter(_cx: ctxt, substs: @[t], idx: uint, _did: def_id)
         -> t {
         if idx < vec::len(*substs) {
             ret substs[idx];
@@ -2516,7 +2303,7 @@ fn impl_iface(cx: ctxt, id: ast::def_id) -> option<t> {
 }
 
 // Enum information
-type variant_info = @{args: [ty::t], ctor_ty: ty::t, name: str,
+type variant_info = @{args: [t], ctor_ty: t, name: str,
                       id: ast::def_id, disr_val: int};
 
 fn enum_variants(cx: ctxt, id: ast::def_id) -> @[variant_info] {
@@ -2536,7 +2323,7 @@ fn enum_variants(cx: ctxt, id: ast::def_id) -> @[variant_info] {
             @vec::map(variants, {|variant|
                 let ctor_ty = node_id_to_type(cx, variant.node.id);
                 let arg_tys = if vec::len(variant.node.args) > 0u {
-                    vec::map(ty_fn_args(cx, ctor_ty), {|a| a.ty})
+                    vec::map(ty_fn_args(ctor_ty), {|a| a.ty})
                 } else { [] };
                 alt variant.node.disr_expr {
                   some (ex) {
@@ -2595,11 +2382,10 @@ fn lookup_item_type(cx: ctxt, did: ast::def_id) -> ty_param_bounds_and_ty {
 }
 
 fn ret_ty_of_fn(cx: ctxt, id: ast::node_id) -> t {
-    ty_fn_ret(cx, node_id_to_type(cx, id))
+    ty_fn_ret(node_id_to_type(cx, id))
 }
 
-fn is_binopable(cx: ctxt, ty: t, op: ast::binop) -> bool {
-
+fn is_binopable(_cx: ctxt, ty: t, op: ast::binop) -> bool {
     const tycat_other: int = 0;
     const tycat_bool: int = 1;
     const tycat_int: int = 2;
@@ -2642,8 +2428,8 @@ fn is_binopable(cx: ctxt, ty: t, op: ast::binop) -> bool {
         }
     }
 
-    fn tycat(cx: ctxt, ty: t) -> int {
-        alt struct(cx, ty) {
+    fn tycat(ty: t) -> int {
+        alt get(ty).struct {
           ty_bool { tycat_bool }
           ty_int(_) { tycat_int }
           ty_uint(_) { tycat_int }
@@ -2677,11 +2463,11 @@ fn is_binopable(cx: ctxt, ty: t, op: ast::binop) -> bool {
          [t, f, f, f, t, t, f, f], [t, f, f, f, t, t, f, f],
          [f, f, f, f, t, t, f, f], [t, t, t, t, t, t, t, t]]; /*struct*/
 
-    ret tbl[tycat(cx, ty)][opcat(op)];
+    ret tbl[tycat(ty)][opcat(op)];
 }
 
-fn ast_constr_to_constr<T>(tcx: ty::ctxt, c: @ast::constr_general<T>) ->
-   @ty::constr_general<T> {
+fn ast_constr_to_constr<T>(tcx: ctxt, c: @ast::constr_general<T>) ->
+   @constr_general<T> {
     alt tcx.def_map.find(c.node.id) {
       some(ast::def_fn(pred_id, ast::pure_fn)) {
         ret @ast_util::respan(c.span,

--- a/src/comp/util/ppaux.rs
+++ b/src/comp/util/ppaux.rs
@@ -24,10 +24,10 @@ fn ty_to_str(cx: ctxt, typ: t) -> str {
        str {
         let modestr = alt input.mode {
           ast::by_ref {
-            if ty::type_is_immediate(cx, input.ty) { "&&" } else { "" }
+            if ty::type_is_immediate(input.ty) { "&&" } else { "" }
           }
           ast::by_val {
-            if ty::type_is_immediate(cx, input.ty) { "" } else { "++" }
+            if ty::type_is_immediate(input.ty) { "" } else { "++" }
           }
           _ { mode_str(input.mode) }
         };
@@ -43,7 +43,7 @@ fn ty_to_str(cx: ctxt, typ: t) -> str {
         for a: arg in inputs { strs += [fn_input_to_str(cx, a)]; }
         s += str::connect(strs, ", ");
         s += ")";
-        if struct(cx, output) != ty_nil {
+        if ty::get(output).struct != ty_nil {
             s += " -> ";
             alt cf {
               ast::noreturn { s += "!"; }
@@ -69,22 +69,22 @@ fn ty_to_str(cx: ctxt, typ: t) -> str {
         }
         ret mstr + ty_to_str(cx, m.ty);
     }
-    alt ty_name(cx, typ) {
+    alt ty::type_name(typ) {
       some(cs) {
-        alt struct(cx, typ) {
+        alt ty::get(typ).struct {
           ty_enum(_, tps) | ty_res(_, _, tps) {
             if vec::len(tps) > 0u {
                 let strs = vec::map(tps, {|t| ty_to_str(cx, t)});
-                ret *cs + "<" + str::connect(strs, ",") + ">";
+                ret cs + "<" + str::connect(strs, ",") + ">";
             }
           }
           _ {}
         }
-        ret *cs;
+        ret cs;
       }
       _ { }
     }
-    ret alt struct(cx, typ) {
+    ret alt ty::get(typ).struct {
       ty_nil { "()" }
       ty_bot { "_|_" }
       ty_bool { "bool" }


### PR DESCRIPTION
This is a rather nice cleanup, but, as described in the commit message, introduces a bit of unsafe code. I may be so blinded by my unwillingness to abandon my pleasant patch that my judgement is clouded. I'd like to have one or two team member sign off on this before I merge it. No need to read the whole patch -- the commit message and `mk_t` in `ty.rs` should give you a good idea of what it does.

(The slowdown seen by the non-unsafe version of this patch has turned into a small speedup in the unsafe version.)
