### PR TITLE
cargo: Add local mode and use it by default

### DIFF
--- a/src/comp/util/filesearch.rs
+++ b/src/comp/util/filesearch.rs
@@ -16,6 +16,7 @@ export pick_file;
 export search;
 export relative_target_lib_path;
 export get_cargo_root;
+export get_cargo_root_nearest;
 export libdir;
 
 type pick<T> = fn(path: fs::path) -> option<T>;
@@ -43,6 +44,10 @@ fn mk_filesearch(maybe_sysroot: option<fs::path>,
         fn lib_search_paths() -> [fs::path] {
             self.addl_lib_search_paths
                 + [make_target_lib_path(self.sysroot, self.target_triple)]
+                + alt get_cargo_lib_path_nearest() {
+                  result::ok(p) { [p] }
+                  result::err(p) { [] }
+                }
                 + alt get_cargo_lib_path() {
                   result::ok(p) { [p] }
                   result::err(p) { [] }
@@ -121,8 +126,40 @@ fn get_cargo_root() -> result::t<fs::path, str> {
     }
 }
 
+fn get_cargo_root_nearest() -> result::t<fs::path, str> {
+    result::chain(get_cargo_root()) { |p|
+        let cwd = os::getcwd();
+        let dirname = fs::dirname(cwd);
+        let dirpath = fs::split(dirname);
+        let cwd_cargo = fs::connect(cwd, ".cargo");
+        let par_cargo = fs::connect(dirname, ".cargo");
+
+        // FIXME: this duplicates lib path
+        if cwd_cargo == p {
+            ret result::ok(p);
+        }
+
+        while vec::is_not_empty(dirpath) && par_cargo != p {
+            if fs::path_is_dir(par_cargo) {
+                ret result::ok(par_cargo);
+            }
+            vec::pop(dirpath);
+            dirname = fs::dirname(dirname);
+            par_cargo = fs::connect(dirname, ".cargo");
+        }
+
+        result::ok(cwd_cargo)
+    }
+}
+
 fn get_cargo_lib_path() -> result::t<fs::path, str> {
     result::chain(get_cargo_root()) { |p|
+        result::ok(fs::connect(p, libdir()))
+    }
+}
+
+fn get_cargo_lib_path_nearest() -> result::t<fs::path, str> {
+    result::chain(get_cargo_root_nearest()) { |p|
         result::ok(fs::connect(p, libdir()))
     }
 }

--- a/src/comp/util/filesearch.rs
+++ b/src/comp/util/filesearch.rs
@@ -15,6 +15,7 @@ export pick;
 export pick_file;
 export search;
 export relative_target_lib_path;
+export get_cargo_sysroot;
 export get_cargo_root;
 export get_cargo_root_nearest;
 export libdir;
@@ -52,6 +53,8 @@ fn mk_filesearch(maybe_sysroot: option<fs::path>,
                   result::ok(p) { [p] }
                   result::err(p) { [] }
                 }
+                + [fs::connect(fs::connect(self.sysroot, ".cargo"),
+                               libdir())]
         }
         fn get_target_lib_path() -> fs::path {
             make_target_lib_path(self.sysroot, self.target_triple)
@@ -114,6 +117,10 @@ fn get_sysroot(maybe_sysroot: option<fs::path>) -> fs::path {
     }
 }
 
+fn get_cargo_sysroot() -> result::t<fs::path, str> {
+    result::ok(fs::connect(get_default_sysroot(),  ".cargo"))
+}
+
 fn get_cargo_root() -> result::t<fs::path, str> {
     alt generic_os::getenv("CARGO_ROOT") {
         some(_p) { result::ok(_p) }
@@ -134,9 +141,8 @@ fn get_cargo_root_nearest() -> result::t<fs::path, str> {
         let cwd_cargo = fs::connect(cwd, ".cargo");
         let par_cargo = fs::connect(dirname, ".cargo");
 
-        // FIXME: this duplicates lib path
-        if cwd_cargo == p {
-            ret result::ok(p);
+        if fs::path_is_dir(cwd_cargo) || cwd_cargo == p {
+            ret result::ok(cwd_cargo);
         }
 
         while vec::is_not_empty(dirpath) && par_cargo != p {


### PR DESCRIPTION
Issue #1756

The changes are the following:
- Add local mode which does operate with project's ".cargo" rather than "~/.cargo".
- Use local mode by default. you can change it with "-g" or "--global", for global mode operation.
- Add functions that required to add lib directory in project's ".cargo" to linker search path.
- Use `std::getopts` in cargo.rs to avoid arguments ordering problems.
