### PR TITLE
made leak an intrinsic to avoid a c-call. added memmove and memcpy intrinsics

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -57,15 +57,17 @@ fn null<T>() -> *T unsafe { ret unsafe::reinterpret_cast(0u); }
 Function: memcpy
 
 Copies data from one src to dst that is not overlapping each other.
+Count is the number of elements to copy and not the number of bytes.
 */
-fn memcpy<T>(dst: *T, src: *T, count: uint) unsafe { rusti::memcpy(dst, src, count); }
+unsafe fn memcpy<T>(dst: *T, src: *T, count: uint) { rusti::memcpy(dst, src, count); }
 
 /*
 Function: memmove
 
 Copies data from one src to dst, overlap between the two pointers may occur.
+Count is the number of elements to copy and not the number of bytes.
 */
-fn memmove<T>(dst: *T, src: *T, count: uint) unsafe { rusti::memcpy(dst, src, count); }
+unsafe fn memmove<T>(dst: *T, src: *T, count: uint)  { rusti::memcpy(dst, src, count); }
 
 #[test]
 fn test() unsafe {

--- a/src/libcore/unsafe.rs
+++ b/src/libcore/unsafe.rs
@@ -9,10 +9,6 @@ export reinterpret_cast, leak;
 #[abi = "rust-intrinsic"]
 native mod rusti {
     fn cast<T, U>(src: T) -> U;
-}
-
-#[abi = "cdecl"]
-native mod rustrt {
     fn leak<T>(-thing: T);
 }
 
@@ -40,7 +36,7 @@ to run any required cleanup or memory-management operations on it. This
 can be used for various acts of magick, particularly when using
 reinterpret_cast on managed pointer types.
 */
-unsafe fn leak<T>(-thing: T) { rustrt::leak(thing); }
+unsafe fn leak<T>(-thing: T) { rusti::leak(thing); }
 
 #[cfg(test)]
 mod tests {

--- a/src/rt/intrinsics/intrinsics.cpp
+++ b/src/rt/intrinsics/intrinsics.cpp
@@ -83,3 +83,32 @@ rust_intrinsic_task_yield(void **retptr,
     rust_task_yield(task, killed);
 }
 
+extern "C" void
+rust_intrinsic_memmove(void *retptr,
+                    void *env,
+                    type_desc *ty,
+                    void *dst,
+                    void *src,
+                    uintptr_t count)
+{
+    memmove(dst, src, ty->size * count);
+}
+
+extern "C" void
+rust_intrinsic_memcpy(void *retptr,
+                    void *env,
+                    type_desc *ty,
+                    void *dst,
+                    void *src,
+                    uintptr_t count)
+{
+    memcpy(dst, src, ty->size * count);
+}
+
+extern "C" void
+rust_intrinsic_leak(void *retptr,
+                    void *env,
+                    type_desc *ty,
+                    void *thing)
+{
+}

--- a/src/rt/intrinsics/intrinsics.i386.ll.in
+++ b/src/rt/intrinsics/intrinsics.i386.ll.in
@@ -120,6 +120,28 @@ entry:
 
 declare void @rust_task_yield(%struct.rust_task*, i8*)
 
+define void @rust_intrinsic_memmove(i8* nocapture %retptr, i8* nocapture %env, %struct.type_desc* nocapture %ty, i8* nocapture %dst, i8* nocapture %src, i32 %count) nounwind {
+  %1 = getelementptr inbounds %struct.type_desc* %ty, i32 0, i32 1
+  %2 = load i32* %1, align 4, !tbaa !3
+  %3 = mul i32 %2, %count
+  tail call void @llvm.memmove.p0i8.p0i8.i32(i8* %dst, i8* %src, i32 %3, i32 1, i1 false)
+  ret void
+}
+
+define void @rust_intrinsic_memcpy(i8* nocapture %retptr, i8* nocapture %env, %struct.type_desc* nocapture %ty, i8* nocapture %dst, i8* nocapture %src, i32 %count) nounwind {
+  %1 = getelementptr inbounds %struct.type_desc* %ty, i32 0, i32 1
+  %2 = load i32* %1, align 4, !tbaa !3
+  %3 = mul i32 %2, %count
+  tail call void @llvm.memcpy.p0i8.p0i8.i32(i8* %dst, i8* %src, i32 %3, i32 1, i1 false)
+  ret void
+}
+
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8* nocapture, i8* nocapture, i32, i32, i1) nounwind
+
+define void @rust_intrinsic_leak(i8* nocapture %retptr, i8* nocapture %env, %struct.type_desc* nocapture %ty, i8* nocapture %thing) nounwind readnone {
+  ret void
+}
+
 !0 = metadata !{metadata !"any pointer", metadata !1}
 !1 = metadata !{metadata !"omnipotent char", metadata !2}
 !2 = metadata !{metadata !"Simple C/C++ TBAA", null}

--- a/src/rt/intrinsics/intrinsics.x86_64.ll.in
+++ b/src/rt/intrinsics/intrinsics.x86_64.ll.in
@@ -120,6 +120,28 @@ entry:
 
 declare void @rust_task_yield(%struct.rust_task*, i8*)
 
+define void @rust_intrinsic_memmove(i8* nocapture %retptr, i8* nocapture %env, %struct.type_desc* nocapture %ty, i8* nocapture %dst, i8* nocapture %src, i64 %count) nounwind uwtable {
+  %1 = getelementptr inbounds %struct.type_desc* %ty, i64 0, i32 1
+  %2 = load i64* %1, align 8, !tbaa !3
+  %3 = mul i64 %2, %count
+  tail call void @llvm.memmove.p0i8.p0i8.i64(i8* %dst, i8* %src, i64 %3, i32 1, i1 false)
+  ret void
+}
+
+define void @rust_intrinsic_memcpy(i8* nocapture %retptr, i8* nocapture %env, %struct.type_desc* nocapture %ty, i8* nocapture %dst, i8* nocapture %src, i64 %count) nounwind uwtable {
+  %1 = getelementptr inbounds %struct.type_desc* %ty, i64 0, i32 1
+  %2 = load i64* %1, align 8, !tbaa !3
+  %3 = mul i64 %2, %count
+  tail call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dst, i8* %src, i64 %3, i32 1, i1 false)
+  ret void
+}
+
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture, i8* nocapture, i64, i32, i1) nounwind
+
+define void @rust_intrinsic_leak(i8* nocapture %retptr, i8* nocapture %env, %struct.type_desc* nocapture %ty, i8* nocapture %thing) nounwind uwtable readnone {
+  ret void
+}
+
 !0 = metadata !{metadata !"any pointer", metadata !1}
 !1 = metadata !{metadata !"omnipotent char", metadata !2}
 !2 = metadata !{metadata !"Simple C/C++ TBAA", null}


### PR DESCRIPTION
Fixes #1667 and prepares for future str library optimization.
