### PR TITLE
Add support for multiple schedulers

### DIFF
--- a/src/rt/rust.cpp
+++ b/src/rt/rust.cpp
@@ -78,8 +78,9 @@ rust_start(uintptr_t main_fn, int argc, char **argv, void* crate_map) {
     check_claims = env->check_claims;
 
     rust_srv *srv = new rust_srv(env);
-    rust_kernel *kernel = new rust_kernel(srv, env->num_sched_threads);
-    rust_scheduler *sched = kernel->get_default_scheduler();
+    rust_kernel *kernel = new rust_kernel(srv);
+    rust_sched_id sched_id = kernel->create_scheduler(env->num_sched_threads);
+    rust_scheduler *sched = kernel->get_scheduler_by_id(sched_id);
     rust_task_id root_id = sched->create_task(NULL, "main", MAIN_STACK_SIZE);
     rust_task *root_task = kernel->get_task_by_id(root_id);
     I(kernel, root_task != NULL);
@@ -98,7 +99,7 @@ rust_start(uintptr_t main_fn, int argc, char **argv, void* crate_map) {
     root_task->deref();
     root_task = NULL;
 
-    int ret = kernel->start_schedulers();
+    int ret = kernel->wait_for_schedulers();
     delete args;
     delete kernel;
     delete srv;

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -438,7 +438,7 @@ rust_get_sched_id() {
 }
 
 extern "C" CDECL rust_sched_id
-rust_new_sched(size_t threads) {
+rust_new_sched(uintptr_t threads) {
     rust_task *task = rust_task_thread::get_task();
     A(task->thread, threads > 0,
       "Can't create a scheduler with no threads, silly!");

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -626,6 +626,46 @@ rust_log_console_off() {
     log_console_off(task->kernel->env);
 }
 
+extern "C" CDECL lock_and_signal *
+rust_dbg_lock_create() {
+    return new lock_and_signal();
+}
+
+extern "C" CDECL void
+rust_dbg_lock_destroy(lock_and_signal *lock) {
+    rust_task *task = rust_task_thread::get_task();
+    I(task->thread, lock);
+    delete lock;
+}
+
+extern "C" CDECL void
+rust_dbg_lock_lock(lock_and_signal *lock) {
+    rust_task *task = rust_task_thread::get_task();
+    I(task->thread, lock);
+    lock->lock();
+}
+
+extern "C" CDECL void
+rust_dbg_lock_unlock(lock_and_signal *lock) {
+    rust_task *task = rust_task_thread::get_task();
+    I(task->thread, lock);
+    lock->unlock();
+}
+
+extern "C" CDECL void
+rust_dbg_lock_wait(lock_and_signal *lock) {
+    rust_task *task = rust_task_thread::get_task();
+    I(task->thread, lock);
+    lock->wait();
+}
+
+extern "C" CDECL void
+rust_dbg_lock_signal(lock_and_signal *lock) {
+    rust_task *task = rust_task_thread::get_task();
+    I(task->thread, lock);
+    lock->signal();
+}
+
 //
 // Local Variables:
 // mode: C++

--- a/src/rt/rust_internal.h
+++ b/src/rt/rust_internal.h
@@ -61,6 +61,7 @@ struct stk_seg;
 struct type_desc;
 struct frame_glue_fns;
 
+typedef intptr_t rust_sched_id;
 typedef intptr_t rust_task_id;
 typedef intptr_t rust_port_id;
 

--- a/src/rt/rust_internal.h
+++ b/src/rt/rust_internal.h
@@ -104,15 +104,14 @@ static size_t const BUF_BYTES = 2048;
   void ref() { ++ref_count; } \
   void deref() { if (--ref_count == 0) { dtor; } }
 
-#define RUST_ATOMIC_REFCOUNT()                                          \
-    private:                                                            \
-    intptr_t ref_count;                                                 \
-public:                                                                 \
- void ref() {                                                           \
-     intptr_t old = sync::increment(ref_count);                         \
-     assert(old > 0);                                                   \
- }                                                                      \
- void deref() { if(0 == sync::decrement(ref_count)) { delete this; } }
+#define RUST_ATOMIC_REFCOUNT()                                            \
+public:                                                                   \
+   intptr_t ref_count;                                                    \
+   void ref() {                                                           \
+       intptr_t old = sync::increment(ref_count);                         \
+       assert(old > 0);                                                   \
+   }                                                                      \
+   void deref() { if(0 == sync::decrement(ref_count)) { delete_this(); } }
 
 template <typename T> struct task_owned {
     inline void *operator new(size_t size, rust_task *task, const char *tag);

--- a/src/rt/rust_kernel.cpp
+++ b/src/rt/rust_kernel.cpp
@@ -60,6 +60,7 @@ rust_kernel::create_scheduler(size_t num_threads) {
     sched = new (this, "rust_scheduler")
         rust_scheduler(this, srv, num_threads, 0);
     live_schedulers = 1;
+    sched->start_task_threads();
     return 0;
 }
 
@@ -84,15 +85,12 @@ int
 rust_kernel::wait_for_schedulers()
 {
     I(this, !sched_lock.lock_held_by_current_thread());
-    sched->start_task_threads();
-    {
-        scoped_lock with(sched_lock);
-        // Schedulers could possibly have already exited
-        if (live_schedulers != 0) {
-            sched_lock.wait();
-        }
-        return rval;
+    scoped_lock with(sched_lock);
+    // Schedulers could possibly have already exited
+    if (live_schedulers != 0) {
+        sched_lock.wait();
     }
+    return rval;
 }
 
 void

--- a/src/rt/rust_kernel.cpp
+++ b/src/rt/rust_kernel.cpp
@@ -129,11 +129,6 @@ rust_kernel::release_task_id(rust_task_id id) {
         new_live_tasks = --live_tasks;
     }
     KLOG_("Total outstanding tasks: %d", new_live_tasks);
-    if (new_live_tasks == 0) {
-        // There are no more tasks and there never will be.
-        // Tell all the schedulers to exit.
-        sched->exit();
-    }
 }
 
 rust_task *

--- a/src/rt/rust_kernel.cpp
+++ b/src/rt/rust_kernel.cpp
@@ -21,10 +21,6 @@ rust_kernel::rust_kernel(rust_srv *srv, size_t num_threads) :
     live_schedulers = 1;
 }
 
-rust_kernel::~rust_kernel() {
-    delete sched;
-}
-
 void
 rust_kernel::log(uint32_t level, char const *fmt, ...) {
     char buf[BUF_BYTES];
@@ -83,6 +79,7 @@ void
 rust_kernel::release_scheduler() {
     I(this, !sched_lock.lock_held_by_current_thread());
     scoped_lock with(sched_lock);
+    delete sched;
     --live_schedulers;
     if (live_schedulers == 0) {
         // We're all done. Tell the main thread to continue

--- a/src/rt/rust_kernel.cpp
+++ b/src/rt/rust_kernel.cpp
@@ -59,10 +59,11 @@ void rust_kernel::free(void *mem) {
 rust_sched_id
 rust_kernel::create_scheduler(size_t num_threads) {
     I(this, !sched_lock.lock_held_by_current_thread());
+    rust_sched_id id;
     rust_scheduler *sched;
     {
         scoped_lock with(sched_lock);
-        rust_sched_id id = max_sched_id++;
+        id = max_sched_id++;
         K(srv, id != INTPTR_MAX, "Hit the maximum scheduler id");
         sched = new (this, "rust_scheduler")
             rust_scheduler(this, srv, num_threads, id);
@@ -72,7 +73,7 @@ rust_kernel::create_scheduler(size_t num_threads) {
         live_schedulers++;
     }
     sched->start_task_threads();
-    return 0;
+    return id;
 }
 
 rust_scheduler *

--- a/src/rt/rust_kernel.cpp
+++ b/src/rt/rust_kernel.cpp
@@ -17,7 +17,7 @@ rust_kernel::rust_kernel(rust_srv *srv, size_t num_threads) :
     env(srv->env)
 {
     sched = new (this, "rust_scheduler")
-        rust_scheduler(this, srv, num_threads);
+        rust_scheduler(this, srv, num_threads, 0);
     live_schedulers = 1;
 }
 

--- a/src/rt/rust_kernel.h
+++ b/src/rt/rust_kernel.h
@@ -46,7 +46,7 @@ public:
 
     struct rust_env *env;
 
-    rust_kernel(rust_srv *srv, size_t num_threads);
+    rust_kernel(rust_srv *srv);
 
     void log(uint32_t level, char const *fmt, ...);
     void fatal(char const *fmt, ...);
@@ -57,10 +57,11 @@ public:
 
     void fail();
 
-    int start_schedulers();
-    rust_scheduler* get_default_scheduler();
+    rust_sched_id create_scheduler(size_t num_threads);
+    rust_scheduler* get_scheduler_by_id(rust_sched_id id);
     // Called by a scheduler to indicate that it is terminating
-    void release_scheduler();
+    void release_scheduler_id(rust_sched_id id);
+    int wait_for_schedulers();
 
 #ifdef __WIN32__
     void win32_require(LPCTSTR fn, BOOL ok);

--- a/src/rt/rust_kernel.h
+++ b/src/rt/rust_kernel.h
@@ -47,7 +47,6 @@ public:
     struct rust_env *env;
 
     rust_kernel(rust_srv *srv, size_t num_threads);
-    ~rust_kernel();
 
     void log(uint32_t level, char const *fmt, ...);
     void fatal(char const *fmt, ...);

--- a/src/rt/rust_kernel.h
+++ b/src/rt/rust_kernel.h
@@ -35,6 +35,13 @@ private:
     lock_and_signal rval_lock;
     int rval;
 
+    // Protects live_schedulers
+    lock_and_signal sched_lock;
+    // Tracks the number of schedulers currently running.
+    // When this hits 0 we will signal the sched_lock and the
+    // kernel will terminate.
+    uintptr_t live_schedulers;
+
 public:
 
     struct rust_env *env;
@@ -53,6 +60,8 @@ public:
 
     int start_schedulers();
     rust_scheduler* get_default_scheduler();
+    // Called by a scheduler to indicate that it is terminating
+    void release_scheduler();
 
 #ifdef __WIN32__
     void win32_require(LPCTSTR fn, BOOL ok);

--- a/src/rt/rust_kernel.h
+++ b/src/rt/rust_kernel.h
@@ -2,11 +2,14 @@
 #ifndef RUST_KERNEL_H
 #define RUST_KERNEL_H
 
+#include <map>
 #include "memory_region.h"
 #include "rust_log.h"
 
 struct rust_task_thread;
 struct rust_scheduler;
+
+typedef std::map<rust_sched_id, rust_scheduler*> sched_map;
 
 /**
  * A global object shared by all thread domains. Most of the data structures
@@ -20,8 +23,6 @@ class rust_kernel {
 public:
     rust_srv *srv;
 private:
-    rust_scheduler *sched;
-
     // Protects live_tasks, max_task_id and task_table
     lock_and_signal task_lock;
     // Tracks the number of tasks that are being managed by
@@ -35,12 +36,14 @@ private:
     lock_and_signal rval_lock;
     int rval;
 
-    // Protects live_schedulers
+    // Protects live_schedulers, max_sched_id and sched_table
     lock_and_signal sched_lock;
     // Tracks the number of schedulers currently running.
     // When this hits 0 we will signal the sched_lock and the
     // kernel will terminate.
     uintptr_t live_schedulers;
+    rust_sched_id max_sched_id;
+    sched_map sched_table;
 
 public:
 

--- a/src/rt/rust_scheduler.cpp
+++ b/src/rt/rust_scheduler.cpp
@@ -56,6 +56,11 @@ rust_scheduler::destroy_task_threads() {
 void
 rust_scheduler::start_task_threads()
 {
+    // Copy num_threads because it's possible for the last thread
+    // to terminate and have the kernel delete us before we
+    // hit the last check against num_threads, in which case
+    // we would be accessing invalid memory.
+    uintptr_t num_threads = this->num_threads;
     for(size_t i = 0; i < num_threads; ++i) {
         rust_task_thread *thread = threads[i];
         thread->start();

--- a/src/rt/rust_scheduler.cpp
+++ b/src/rt/rust_scheduler.cpp
@@ -3,12 +3,14 @@
 
 rust_scheduler::rust_scheduler(rust_kernel *kernel,
 			       rust_srv *srv,
-			       size_t num_threads) :
+			       size_t num_threads,
+			       rust_sched_id id) :
     kernel(kernel),
     srv(srv),
     env(srv->env),
     live_threads(num_threads),
-    num_threads(num_threads)
+    num_threads(num_threads),
+    id(id)
 {
     isaac_init(kernel, &rctx);
     create_task_threads();

--- a/src/rt/rust_scheduler.cpp
+++ b/src/rt/rust_scheduler.cpp
@@ -115,6 +115,6 @@ rust_scheduler::release_task_thread() {
 	new_live_threads = --live_threads;
     }
     if (new_live_threads == 0) {
-	kernel->release_scheduler();
+	kernel->release_scheduler_id(id);
     }
 }

--- a/src/rt/rust_scheduler.h
+++ b/src/rt/rust_scheduler.h
@@ -49,6 +49,8 @@ public:
     // Called by each thread when it terminates. When all threads
     // terminate the scheduler does as well.
     void release_task_thread();
+
+    rust_sched_id get_id() { return id; }
 };
 
 #endif /* RUST_SCHEDULER_H */

--- a/src/rt/rust_scheduler.h
+++ b/src/rt/rust_scheduler.h
@@ -14,6 +14,8 @@ private:
     lock_and_signal lock;
     // When this hits zero we'll tell the kernel to release us
     uintptr_t live_threads;
+    // When this hits zero we'll tell the threads to exit
+    uintptr_t live_tasks;
     randctx rctx;
 
     array_list<rust_task_thread *> threads;
@@ -27,6 +29,8 @@ private:
     rust_task_thread *create_task_thread(int id);
     void destroy_task_thread(rust_task_thread *thread);
 
+    void exit();
+
 public:
     rust_scheduler(rust_kernel *kernel, rust_srv *srv, size_t num_threads,
 		   rust_sched_id id);
@@ -39,7 +43,8 @@ public:
 			     size_t init_stack_sz);
     rust_task_id create_task(rust_task *spawner, const char *name);
 
-    void exit();
+    void release_task();
+
     size_t number_of_threads();
     // Called by each thread when it terminates. When all threads
     // terminate the scheduler does as well.

--- a/src/rt/rust_scheduler.h
+++ b/src/rt/rust_scheduler.h
@@ -19,6 +19,8 @@ private:
     array_list<rust_task_thread *> threads;
     const size_t num_threads;
 
+    rust_sched_id id;
+
     void create_task_threads();
     void destroy_task_threads();
 
@@ -26,7 +28,8 @@ private:
     void destroy_task_thread(rust_task_thread *thread);
 
 public:
-    rust_scheduler(rust_kernel *kernel, rust_srv *srv, size_t num_threads);
+    rust_scheduler(rust_kernel *kernel, rust_srv *srv, size_t num_threads,
+		   rust_sched_id id);
     ~rust_scheduler();
 
     void start_task_threads();

--- a/src/rt/rust_scheduler.h
+++ b/src/rt/rust_scheduler.h
@@ -10,9 +10,13 @@ public:
     rust_srv *srv;
     rust_env *env;
 private:
+    // Protects the random number context and live_threads
     lock_and_signal lock;
-    array_list<rust_task_thread *> threads;
+    // When this hits zero we'll tell the kernel to release us
+    uintptr_t live_threads;
     randctx rctx;
+
+    array_list<rust_task_thread *> threads;
     const size_t num_threads;
 
     void create_task_threads();
@@ -31,8 +35,12 @@ public:
 			     const char *name,
 			     size_t init_stack_sz);
     rust_task_id create_task(rust_task *spawner, const char *name);
+
     void exit();
     size_t number_of_threads();
+    // Called by each thread when it terminates. When all threads
+    // terminate the scheduler does as well.
+    void release_task_thread();
 };
 
 #endif /* RUST_SCHEDULER_H */

--- a/src/rt/rust_scheduler.h
+++ b/src/rt/rust_scheduler.h
@@ -14,7 +14,6 @@ private:
     array_list<rust_task_thread *> threads;
     randctx rctx;
     const size_t num_threads;
-    int rval;
 
     void create_task_threads();
     void destroy_task_threads();

--- a/src/rt/rust_task.cpp
+++ b/src/rt/rust_task.cpp
@@ -268,7 +268,8 @@ rust_task::rust_task(rust_task_thread *thread, rust_task_list *state,
     }
 }
 
-rust_task::~rust_task()
+void
+rust_task::delete_this()
 {
     I(thread, !thread->lock.lock_held_by_current_thread());
     I(thread, port_table.is_empty());
@@ -291,6 +292,8 @@ rust_task::~rust_task()
     while (stk != NULL) {
         del_stk(this, stk);
     }
+
+    thread->release_task(this);
 }
 
 struct spawn_args {

--- a/src/rt/rust_task.h
+++ b/src/rt/rust_task.h
@@ -122,14 +122,17 @@ rust_task : public kernel_owned<rust_task>, rust_cond
     // The amount of stack we're using, excluding red zones
     size_t total_stack_sz;
 
+private:
+    // Called when the atomic refcount reaches zero
+    void delete_this();
+public:
+
     // Only a pointer to 'name' is kept, so it must live as long as this task.
     rust_task(rust_task_thread *thread,
               rust_task_list *state,
               rust_task *spawner,
               const char *name,
               size_t init_stack_sz);
-
-    ~rust_task();
 
     void start(spawn_fn spawnee_fn,
                rust_opaque_box *env,

--- a/src/rt/rust_task_thread.cpp
+++ b/src/rt/rust_task_thread.cpp
@@ -296,6 +296,7 @@ rust_task_thread::create_task(rust_task *spawner, const char *name,
 
 void rust_task_thread::run() {
     this->start_main_loop();
+    sched->release_task_thread();
 }
 
 #ifndef _WIN32

--- a/src/rt/rust_task_thread.h
+++ b/src/rt/rust_task_thread.h
@@ -122,6 +122,9 @@ struct rust_task_thread : public kernel_owned<rust_task_thread>,
 
     static rust_task *get_task();
 
+    // Called by each task when they are ready to be destroyed
+    void release_task(rust_task *task);
+
     // Tells the scheduler to exit it's scheduling loop and thread
     void exit();
 };

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -100,3 +100,9 @@ rust_uvtmp_read_start
 rust_uvtmp_timer
 rust_uvtmp_delete_buf
 rust_uvtmp_get_req_id
+rust_dbg_lock_create
+rust_dbg_lock_destroy
+rust_dbg_lock_lock
+rust_dbg_lock_unlock
+rust_dbg_lock_wait
+rust_dbg_lock_signal

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -24,6 +24,9 @@ rand_free
 rand_new
 rand_next
 refcount
+rust_get_sched_id
+rust_new_sched
+rust_new_task_in_sched
 rust_path_is_dir
 rust_path_exists
 rust_getcwd

--- a/src/rt/sync/sync.cpp
+++ b/src/rt/sync/sync.cpp
@@ -19,7 +19,7 @@ void sync::sleep(size_t timeout_in_ms) {
 #endif
 }
 
-rust_thread::rust_thread() : _is_running(false), thread(0) {
+rust_thread::rust_thread() : thread(0) {
 }
 
 #if defined(__WIN32__)
@@ -46,7 +46,6 @@ rust_thread::start() {
    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
    pthread_create(&thread, &attr, rust_thread_start, (void *) this);
 #endif
-   _is_running = true;
 }
 
 void
@@ -59,10 +58,4 @@ rust_thread::join() {
      pthread_join(thread, NULL);
 #endif
    thread = 0;
-   _is_running = false;
-}
-
-bool
-rust_thread::is_running() {
-    return _is_running;
 }

--- a/src/rt/sync/sync.h
+++ b/src/rt/sync/sync.h
@@ -37,8 +37,6 @@ public:
  * Thread utility class. Derive and implement your own run() method.
  */
 class rust_thread {
-private:
-    volatile bool _is_running;
 public:
 #if defined(__WIN32__)
     HANDLE thread;
@@ -53,8 +51,6 @@ public:
     }
 
     void join();
-
-    bool is_running();
 
     virtual ~rust_thread() {}   // quiet the compiler
 };

--- a/src/test/run-pass/rt-sched-1.rs
+++ b/src/test/run-pass/rt-sched-1.rs
@@ -1,0 +1,36 @@
+// Tests of the runtime's scheduler interface
+
+type sched_id = int;
+type task_id = int;
+
+type task = *ctypes::void;
+type closure = *ctypes::void;
+
+native mod rustrt {
+    fn rust_new_sched(num_threads: ctypes::size_t) -> sched_id;
+    fn rust_get_sched_id() -> sched_id;
+    fn rust_new_task_in_sched(id: sched_id) -> task_id;
+    fn start_task(id: task_id, f: closure);
+}
+
+fn main() unsafe {
+    let po = comm::port();
+    let ch = comm::chan(po);
+    let parent_sched_id = rustrt::rust_get_sched_id();
+    #error("parent %?", parent_sched_id);
+    let num_threads = 1u;
+    let new_sched_id = rustrt::rust_new_sched(num_threads);
+    #error("new_sched_id %?", new_sched_id);
+    let new_task_id = rustrt::rust_new_task_in_sched(new_sched_id);
+    let f = fn~() {
+        let child_sched_id = rustrt::rust_get_sched_id();
+        #error("child_sched_id %?", child_sched_id);
+        assert child_sched_id != parent_sched_id;
+        assert child_sched_id == new_sched_id;
+        comm::send(ch, ());
+    };
+    let fptr = unsafe::reinterpret_cast(ptr::addr_of(f));
+    rustrt::start_task(new_task_id, fptr);
+    unsafe::leak(f);
+    comm::recv(po);
+}

--- a/src/test/run-pass/rt-sched-1.rs
+++ b/src/test/run-pass/rt-sched-1.rs
@@ -7,7 +7,7 @@ type task = *ctypes::void;
 type closure = *ctypes::void;
 
 native mod rustrt {
-    fn rust_new_sched(num_threads: ctypes::size_t) -> sched_id;
+    fn rust_new_sched(num_threads: uint) -> sched_id;
     fn rust_get_sched_id() -> sched_id;
     fn rust_new_task_in_sched(id: sched_id) -> task_id;
     fn start_task(id: task_id, f: closure);


### PR DESCRIPTION
This series adds support to the kernel for dynamically adding and removing schedulers then adds a single user-visible function, `task::spawn_sched` for spawning a task into a new scheduler. I have not implemented the full design for first-class schedulers, and think I may let this sit as-is for awhile while we review what we want the `core::task` API to look like (it's quite a mess these days).

For the most part this is not that interesting, but commits bde9385dc5f207629381d61db7349f92035c40b9, 0f4ca21e9cd26b6b7d8c6d3bfdf07e949aaa985c, and 36d51818838a45906c8471569b60002d39ea28ff make big changes to the scheduler and task lifecycle and synchronization protocols to eliminate races between scheduler and task destruction and allow schedulers to be destroyed while the kernel is running. It's a little mind-bending, with a lot of events happening on various threads, and I probably can't explain how the kernel/scheduler/task_thread/tasks cooperate to shutdown the kernel without tracing through the code, but I left lots of comments.

This change also breaks `rust_kernel::fail` (the function that kills all tasks) even worse than before. It's very racy, but doesn't break any existing tests.

I'm doing some stress tests now to make sure things are still reliable.
