### PR TITLE
Logstderr

### DIFF
--- a/src/comp/driver/diagnostic.rs
+++ b/src/comp/driver/diagnostic.rs
@@ -159,16 +159,16 @@ fn diagnosticcolor(lvl: level) -> u8 {
 
 fn print_diagnostic(topic: str, lvl: level, msg: str) {
     if str::is_not_empty(topic) {
-        io::stdout().write_str(#fmt["%s ", topic]);
+        io::stderr().write_str(#fmt["%s ", topic]);
     }
     if term::color_supported() {
-        term::fg(io::stdout(), diagnosticcolor(lvl));
+        term::fg(io::stderr(), diagnosticcolor(lvl));
     }
-    io::stdout().write_str(#fmt["%s:", diagnosticstr(lvl)]);
+    io::stderr().write_str(#fmt["%s:", diagnosticstr(lvl)]);
     if term::color_supported() {
-        term::reset(io::stdout());
+        term::reset(io::stderr());
     }
-    io::stdout().write_str(#fmt[" %s\n", msg]);
+    io::stderr().write_str(#fmt[" %s\n", msg]);
 }
 
 fn emit(cmsp: option<(codemap::codemap, span)>,
@@ -202,10 +202,10 @@ fn highlight_lines(cm: codemap::codemap, sp: span,
     }
     // Print the offending lines
     for line: uint in display_lines {
-        io::stdout().write_str(#fmt["%s:%u ", fm.name, line + 1u]);
+        io::stderr().write_str(#fmt["%s:%u ", fm.name, line + 1u]);
         let s = codemap::get_line(fm, line as int);
         if !str::ends_with(s, "\n") { s += "\n"; }
-        io::stdout().write_str(s);
+        io::stderr().write_str(s);
     }
     if elided {
         let last_line = display_lines[vec::len(display_lines) - 1u];
@@ -214,7 +214,7 @@ fn highlight_lines(cm: codemap::codemap, sp: span,
         let out = "";
         while indent > 0u { out += " "; indent -= 1u; }
         out += "...\n";
-        io::stdout().write_str(out);
+        io::stderr().write_str(out);
     }
 
 
@@ -239,7 +239,7 @@ fn highlight_lines(cm: codemap::codemap, sp: span,
             let width = hi.col - lo.col - 1u;
             while width > 0u { str::push_char(s, '~'); width -= 1u; }
         }
-        io::stdout().write_str(s + "\n");
+        io::stderr().write_str(s + "\n");
     }
 }
 

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -52,8 +52,8 @@ fn run(lib_path: str, prog: str, args: [str],
 
 
     writeclose(pipe_in.out, input);
-    let output = readclose(pipe_out.in);
     let errput = readclose(pipe_err.in);
+    let output = readclose(pipe_out.in);
     let status = run::waitpid(pid);
     ret {status: status, out: output, err: errput};
 }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -198,7 +198,7 @@ fn check_error_patterns(props: test_props,
 
     let next_err_idx = 0u;
     let next_err_pat = props.error_patterns[next_err_idx];
-    for line: str in str::split_byte(procres.stdout, '\n' as u8) {
+    for line: str in str::split_byte(procres.stderr, '\n' as u8) {
         if str::find(line, next_err_pat) > 0 {
             #debug("found error pattern %s", next_err_pat);
             next_err_idx += 1u;
@@ -245,7 +245,7 @@ fn check_expected_errors(expected_errors: [errors::expected_error],
     //    filename:line1:col1: line2:col2: *warning:* msg
     // where line1:col1: is the starting point, line2:col2:
     // is the ending point, and * represents ANSI color codes.
-    for line: str in str::split_byte(procres.stdout, '\n' as u8) {
+    for line: str in str::split_byte(procres.stderr, '\n' as u8) {
         let was_expected = false;
         vec::iteri(expected_errors) {|i, ee|
             if !found_flags[i] {

--- a/src/rt/rust_srv.cpp
+++ b/src/rt/rust_srv.cpp
@@ -25,11 +25,7 @@ rust_srv::realloc(void *p, size_t bytes) {
 
 void
 rust_srv::log(char const *msg) {
-    printf("rust: %s\n", msg);
-    // FIXME: flushing each time is expensive, but at the moment
-    // necessary to get output through before a rust_task::fail
-    // call. This should be changed.
-    fflush(stdout);
+    fprintf(stderr, "rust: %s\n", msg);
 }
 
 void

--- a/src/rt/rust_srv.cpp
+++ b/src/rt/rust_srv.cpp
@@ -26,6 +26,10 @@ rust_srv::realloc(void *p, size_t bytes) {
 void
 rust_srv::log(char const *msg) {
     fprintf(stderr, "rust: %s\n", msg);
+    // FIXME: flushing each time is expensive, but at the moment
+    // necessary to get output through before a rust_task::fail
+    // call. This should be changed.
+    fflush(stderr);
 }
 
 void


### PR DESCRIPTION
Log to stderr instead of stdout.

This time with a possible workaround for the hang on windows when running tests.

Pushed once before in #1750, but caused #1769, so reverted.
