### PR TITLE
(core::str) Fixing index and rindex

### DIFF
--- a/src/cargo/cargo.rs
+++ b/src/cargo/cargo.rs
@@ -651,7 +651,7 @@ fn cmd_install(c: cargo) unsafe {
 
     if str::starts_with(target, "uuid:") {
         let uuid = rest(target, 5u);
-        let idx = str::index(uuid, '/' as u8);
+        let idx = str::index_byte(uuid, '/' as u8);
         if idx != -1 {
             let source = str::unsafe::slice_bytes(uuid, 0u, idx as uint);
             uuid = str::unsafe::slice_bytes(uuid, idx as uint + 1u,
@@ -662,7 +662,7 @@ fn cmd_install(c: cargo) unsafe {
         }
     } else {
         let name = target;
-        let idx = str::index(name, '/' as u8);
+        let idx = str::index_byte(name, '/' as u8);
         if idx != -1 {
             let source = str::unsafe::slice_bytes(name, 0u, idx as uint);
             name = str::unsafe::slice_bytes(name, idx as uint + 1u,

--- a/src/cargo/cargo.rs
+++ b/src/cargo/cargo.rs
@@ -651,25 +651,27 @@ fn cmd_install(c: cargo) unsafe {
 
     if str::starts_with(target, "uuid:") {
         let uuid = rest(target, 5u);
-        let idx = str::index_byte(uuid, '/' as u8);
-        if idx != -1 {
-            let source = str::unsafe::slice_bytes(uuid, 0u, idx as uint);
-            uuid = str::unsafe::slice_bytes(uuid, idx as uint + 1u,
-                                      str::byte_len(uuid));
-            install_uuid_specific(c, wd, source, uuid);
-        } else {
-            install_uuid(c, wd, uuid);
+        alt str::index(uuid, '/') {
+            option::some(idx) {
+               let source = str::slice(uuid, 0u, idx);
+               uuid = str::slice(uuid, idx + 1u, str::char_len(uuid));
+               install_uuid_specific(c, wd, source, uuid);
+            }
+            option::none {
+               install_uuid(c, wd, uuid);
+            }
         }
     } else {
         let name = target;
-        let idx = str::index_byte(name, '/' as u8);
-        if idx != -1 {
-            let source = str::unsafe::slice_bytes(name, 0u, idx as uint);
-            name = str::unsafe::slice_bytes(name, idx as uint + 1u,
-                                      str::byte_len(name));
-            install_named_specific(c, wd, source, name);
-        } else {
-            install_named(c, wd, name);
+        alt str::index(name, '/') {
+            option::some(idx) {
+               let source = str::slice(name, 0u, idx);
+               name = str::slice(name, idx + 1u, str::char_len(name));
+               install_named_specific(c, wd, source, name);
+            }
+            option::none {
+               install_named(c, wd, name);
+            }
         }
     }
 }

--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -109,14 +109,16 @@ mod write {
     // Decides what to call an intermediate file, given the name of the output
     // and the extension to use.
     fn mk_intermediate_name(output_path: str, extension: str) -> str unsafe {
-        let dot_pos = str::index_byte(output_path, '.' as u8);
-        let stem;
-        if dot_pos < 0 {
-            stem = output_path;
-        } else { stem = str::unsafe::slice_bytes(output_path, 0u,
-                                                 dot_pos as uint); }
+        let stem = alt str::index(output_path, '.') {
+                       option::some(dot_pos) {
+                           str::slice(output_path, 0u, dot_pos)
+                       }
+                       option::none { output_path }
+                   };
+
         ret stem + "." + extension;
     }
+
     fn run_passes(sess: session, llmod: ModuleRef, output: str) {
         let opts = sess.opts;
         if opts.time_llvm_passes { llvm::LLVMRustEnableTimePasses(); }

--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -109,7 +109,7 @@ mod write {
     // Decides what to call an intermediate file, given the name of the output
     // and the extension to use.
     fn mk_intermediate_name(output_path: str, extension: str) -> str unsafe {
-        let dot_pos = str::index(output_path, '.' as u8);
+        let dot_pos = str::index_byte(output_path, '.' as u8);
         let stem;
         if dot_pos < 0 {
             stem = output_path;

--- a/src/comp/syntax/codemap.rs
+++ b/src/comp/syntax/codemap.rs
@@ -125,7 +125,7 @@ fn get_line(fm: filemap, line: int) -> str unsafe {
         // the remainder of the file, which is undesirable.
         end = str::byte_len(*fm.src);
         let rest = str::unsafe::slice_bytes(*fm.src, begin, end);
-        let newline = str::index(rest, '\n' as u8);
+        let newline = str::index_byte(rest, '\n' as u8);
         if newline != -1 { end = begin + (newline as uint); }
     }
     ret str::unsafe::slice_bytes(*fm.src, begin, end);

--- a/src/comp/syntax/codemap.rs
+++ b/src/comp/syntax/codemap.rs
@@ -119,16 +119,13 @@ fn get_line(fm: filemap, line: int) -> str unsafe {
     let end: uint;
     if line as uint < vec::len(fm.lines) - 1u {
         end = fm.lines[line + 1].byte - fm.start_pos.byte;
+        ret str::unsafe::slice_bytes(*fm.src, begin, end);
     } else {
         // If we're not done parsing the file, we're at the limit of what's
         // parsed. If we just slice the rest of the string, we'll print out
         // the remainder of the file, which is undesirable.
-        end = str::byte_len(*fm.src);
-        let rest = str::unsafe::slice_bytes(*fm.src, begin, end);
-        let newline = str::index_byte(rest, '\n' as u8);
-        if newline != -1 { end = begin + (newline as uint); }
+        ret str::splitn_char(*fm.src, '\n', 1u)[0];
     }
-    ret str::unsafe::slice_bytes(*fm.src, begin, end);
 }
 
 fn lookup_byte_offset(cm: codemap::codemap, chpos: uint)

--- a/src/fuzzer/fuzzer.rs
+++ b/src/fuzzer/fuzzer.rs
@@ -283,10 +283,9 @@ fn check_variants_T<T: copy>(
     }
 }
 
-fn last_part(filename: str) -> str unsafe {
-  let ix = str::rindex_byte(filename, 47u8 /* '/' */);
-  assert ix >= 0;
-  str::unsafe::slice_bytes(filename, ix as uint + 1u, str::byte_len(filename) - 3u)
+fn last_part(filename: str) -> str {
+  let ix = option::get(str::rindex(filename, '/'));
+  str::slice(filename, ix + 1u, str::char_len(filename) - 3u)
 }
 
 enum happiness { passed, cleanly_rejected(str), known_bug(str), failed(str), }

--- a/src/fuzzer/fuzzer.rs
+++ b/src/fuzzer/fuzzer.rs
@@ -284,7 +284,7 @@ fn check_variants_T<T: copy>(
 }
 
 fn last_part(filename: str) -> str unsafe {
-  let ix = str::rindex(filename, 47u8 /* '/' */);
+  let ix = str::rindex_byte(filename, 47u8 /* '/' */);
   assert ix >= 0;
   str::unsafe::slice_bytes(filename, ix as uint + 1u, str::byte_len(filename) - 3u)
 }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -870,6 +870,30 @@ fn lines_iter(ss: str, ff: fn(&&str)) {
 Section: Searching
 */
 
+// Function: index
+//
+// Returns the index of the first matching char
+// (as option some/none)
+fn index(ss: str, cc: char) -> option<uint> {
+    let bii = 0u;
+    let cii = 0u;
+    let len = byte_len(ss);
+    while bii < len {
+        let {ch, next} = char_range_at(ss, bii);
+
+        // found here?
+        if ch == cc {
+            ret option::some(cii);
+        }
+
+        cii += 1u;
+        bii = next;
+    }
+
+    // wasn't found
+    ret option::none;
+}
+
 /*
 Function: index
 
@@ -1448,6 +1472,9 @@ mod tests {
         assert (index_byte("hello", 'e' as u8) == 1);
         assert (index_byte("hello", 'o' as u8) == 4);
         assert (index_byte("hello", 'z' as u8) == -1);
+        assert (index("hello", 'e') == option::some(1u));
+        assert (index("hello", 'o') == option::some(4u));
+        assert (index("hello", 'z') == option::none);
         assert (rindex_byte("hello", 'l' as u8) == 3);
         assert (rindex_byte("hello", 'h' as u8) == 0);
         assert (rindex_byte("hello", 'z' as u8) == -1);

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -70,8 +70,10 @@ export
    lines_iter,
 
    // Searching
-   index,
-   rindex,
+   //index,
+   //rindex,
+   index_byte,
+   rindex_byte,
    find,
    contains,
    starts_with,
@@ -876,7 +878,7 @@ no match is found.
 
 FIXME: UTF-8
 */
-fn index(s: str, c: u8) -> int {
+fn index_byte(s: str, c: u8) -> int {
     let i: int = 0;
     for k: u8 in s { if k == c { ret i; } i += 1; }
     ret -1;
@@ -890,7 +892,7 @@ if no match is found.
 
 FIXME: UTF-8
 */
-fn rindex(s: str, c: u8) -> int {
+fn rindex_byte(s: str, c: u8) -> int {
     let n: int = byte_len(s) as int;
     while n >= 0 { if s[n] == c { ret n; } n -= 1; }
     ret n;
@@ -1443,12 +1445,12 @@ mod tests {
 
     #[test]
     fn test_index_and_rindex() {
-        assert (index("hello", 'e' as u8) == 1);
-        assert (index("hello", 'o' as u8) == 4);
-        assert (index("hello", 'z' as u8) == -1);
-        assert (rindex("hello", 'l' as u8) == 3);
-        assert (rindex("hello", 'h' as u8) == 0);
-        assert (rindex("hello", 'z' as u8) == -1);
+        assert (index_byte("hello", 'e' as u8) == 1);
+        assert (index_byte("hello", 'o' as u8) == 4);
+        assert (index_byte("hello", 'z' as u8) == -1);
+        assert (rindex_byte("hello", 'l' as u8) == 3);
+        assert (rindex_byte("hello", 'h' as u8) == 0);
+        assert (rindex_byte("hello", 'z' as u8) == -1);
     }
 
     #[test]

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -72,8 +72,6 @@ export
    // Searching
    index,
    rindex,
-   index_byte,
-   rindex_byte,
    find,
    contains,
    starts_with,
@@ -914,34 +912,6 @@ fn rindex(ss: str, cc: char) -> option<uint> {
 }
 
 /*
-Function: index
-
-Returns the index of the first matching byte. Returns -1 if
-no match is found.
-
-FIXME: UTF-8
-*/
-fn index_byte(s: str, c: u8) -> int {
-    let i: int = 0;
-    for k: u8 in s { if k == c { ret i; } i += 1; }
-    ret -1;
-}
-
-/*
-Function: rindex
-
-Returns the index of the last matching byte. Returns -1
-if no match is found.
-
-FIXME: UTF-8
-*/
-fn rindex_byte(s: str, c: u8) -> int {
-    let n: int = byte_len(s) as int;
-    while n >= 0 { if s[n] == c { ret n; } n -= 1; }
-    ret n;
-}
-
-/*
 Function: find
 
 Finds the index of the first matching substring.
@@ -1519,20 +1489,6 @@ mod tests {
         assert (rindex("hello", 'o') == option::some(4u));
         assert (rindex("hello", 'h') == option::some(0u));
         assert (rindex("hello", 'z') == option::none);
-    }
-
-    #[test]
-    fn test_index_byte() {
-        assert ( index_byte("hello", 'e' as u8) == 1);
-        assert ( index_byte("hello", 'o' as u8) == 4);
-        assert ( index_byte("hello", 'z' as u8) == -1);
-    }
-
-    #[test]
-    fn test_rindex_byte() {
-        assert (rindex_byte("hello", 'l' as u8) == 3);
-        assert (rindex_byte("hello", 'h' as u8) == 0);
-        assert (rindex_byte("hello", 'z' as u8) == -1);
     }
 
     #[test]

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -70,7 +70,7 @@ export
    lines_iter,
 
    // Searching
-   //index,
+   index,
    //rindex,
    index_byte,
    rindex_byte,

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -44,9 +44,9 @@ The dirname of "/usr/share" will be "/usr", but the dirname of
 If the path is not prefixed with a directory, then "." is returned.
 */
 fn dirname(p: path) -> path unsafe {
-    let i: int = str::rindex(p, os_fs::path_sep as u8);
+    let i: int = str::rindex_byte(p, os_fs::path_sep as u8);
     if i == -1 {
-        i = str::rindex(p, os_fs::alt_path_sep as u8);
+        i = str::rindex_byte(p, os_fs::alt_path_sep as u8);
         if i == -1 { ret "."; }
     }
     ret str::unsafe::slice_bytes(p, 0u, i as uint);
@@ -64,9 +64,9 @@ the provided path. If an empty path is provided or the path ends
 with a path separator then an empty path is returned.
 */
 fn basename(p: path) -> path unsafe {
-    let i: int = str::rindex(p, os_fs::path_sep as u8);
+    let i: int = str::rindex_byte(p, os_fs::path_sep as u8);
     if i == -1 {
-        i = str::rindex(p, os_fs::alt_path_sep as u8);
+        i = str::rindex_byte(p, os_fs::alt_path_sep as u8);
         if i == -1 { ret p; }
     }
     let len = str::byte_len(p);

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -32,6 +32,22 @@ A path or fragment of a filesystem path
 */
 type path = str;
 
+fn splitDirnameBasename (pp: path) -> {dirname: str, basename: str} {
+    let ii;
+    alt str::rindex(pp, os_fs::path_sep) {
+        option::some(xx) { ii = xx; }
+        option::none {
+            alt str::rindex(pp, os_fs::alt_path_sep) {
+                option::some(xx) { ii = xx; }
+                option::none { ret {dirname: ".", basename: pp}; }
+            }
+        }
+    }
+
+    ret {dirname: str::slice(pp, 0u, ii),
+         basename: str::slice(pp, ii + 1u, str::char_len(pp))};
+}
+
 /*
 Function: dirname
 
@@ -43,13 +59,8 @@ The dirname of "/usr/share" will be "/usr", but the dirname of
 
 If the path is not prefixed with a directory, then "." is returned.
 */
-fn dirname(p: path) -> path unsafe {
-    let i: int = str::rindex_byte(p, os_fs::path_sep as u8);
-    if i == -1 {
-        i = str::rindex_byte(p, os_fs::alt_path_sep as u8);
-        if i == -1 { ret "."; }
-    }
-    ret str::unsafe::slice_bytes(p, 0u, i as uint);
+fn dirname(pp: path) -> path {
+    ret splitDirnameBasename(pp).dirname;
 }
 
 /*
@@ -63,17 +74,9 @@ path separators in the path then the returned path is identical to
 the provided path. If an empty path is provided or the path ends
 with a path separator then an empty path is returned.
 */
-fn basename(p: path) -> path unsafe {
-    let i: int = str::rindex_byte(p, os_fs::path_sep as u8);
-    if i == -1 {
-        i = str::rindex_byte(p, os_fs::alt_path_sep as u8);
-        if i == -1 { ret p; }
-    }
-    let len = str::byte_len(p);
-    if (i + 1) as uint >= len { ret p; }
-    ret str::unsafe::slice_bytes(p, (i + 1) as uint, len);
+fn basename(pp: path) -> path {
+    ret splitDirnameBasename(pp).basename;
 }
-
 
 // FIXME: Need some typestate to avoid bounds check when len(pre) == 0
 /*

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -230,16 +230,14 @@ fn getopts(args: [str], opts: [opt]) -> result unsafe {
             let i_arg = option::none::<str>;
             if cur[1] == '-' as u8 {
                 let tail = str::unsafe::slice_bytes(cur, 2u, curlen);
-                let eq = str::index_byte(tail, '=' as u8);
-                if eq == -1 {
+                let tail_eq = str::splitn_char(tail, '=', 1u);
+                if vec::len(tail_eq) <= 1u {
                     names = [long(tail)];
                 } else {
                     names =
-                        [long(str::unsafe::slice_bytes(tail,0u,eq as uint))];
+                        [long(tail_eq[0])];
                     i_arg =
-                        option::some::<str>(str::unsafe::slice_bytes(tail,
-                                                       (eq as uint) + 1u,
-                                                       curlen - 2u));
+                        option::some::<str>(tail_eq[1]);
                 }
             } else {
                 let j = 1u;

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -230,7 +230,7 @@ fn getopts(args: [str], opts: [opt]) -> result unsafe {
             let i_arg = option::none::<str>;
             if cur[1] == '-' as u8 {
                 let tail = str::unsafe::slice_bytes(cur, 2u, curlen);
-                let eq = str::index(tail, '=' as u8);
+                let eq = str::index_byte(tail, '=' as u8);
                 if eq == -1 {
                     names = [long(tail)];
                 } else {


### PR DESCRIPTION
These commits make index and rindex return character positions of a matched char (rather than byte positions), and use `option::none` rather than `-1` to indicate a character not found.
