### PR TITLE
(core::str) mark push/pop/shift byte functions unsafe, rename len functions, and fix replace

### DIFF
--- a/src/cargo/cargo.rs
+++ b/src/cargo/cargo.rs
@@ -174,10 +174,10 @@ fn print(s: str) {
 }
 
 fn rest(s: str, start: uint) -> str {
-    if (start >= str::char_len(s)) {
+    if (start >= str::len(s)) {
         ""
     } else {
-        str::slice(s, start, str::char_len(s))
+        str::slice(s, start, str::len(s))
     }
 }
 
@@ -654,7 +654,7 @@ fn cmd_install(c: cargo) unsafe {
         alt str::index(uuid, '/') {
             option::some(idx) {
                let source = str::slice(uuid, 0u, idx);
-               uuid = str::slice(uuid, idx + 1u, str::char_len(uuid));
+               uuid = str::slice(uuid, idx + 1u, str::len(uuid));
                install_uuid_specific(c, wd, source, uuid);
             }
             option::none {
@@ -666,7 +666,7 @@ fn cmd_install(c: cargo) unsafe {
         alt str::index(name, '/') {
             option::some(idx) {
                let source = str::slice(name, 0u, idx);
-               name = str::slice(name, idx + 1u, str::char_len(name));
+               name = str::slice(name, idx + 1u, str::len(name));
                install_named_specific(c, wd, source, name);
             }
             option::none {

--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -396,7 +396,7 @@ fn build_link_meta(sess: session, c: ast::crate, output: str,
                               metas: provided_metas,
                               dep_hashes: [str]) -> str {
         fn len_and_str(s: str) -> str {
-            ret #fmt["%u_%s", str::byte_len(s), s];
+            ret #fmt["%u_%s", str::len_bytes(s), s];
         }
 
         fn len_and_str_lit(l: ast::lit) -> str {
@@ -521,7 +521,7 @@ fn mangle(ss: path) -> str {
 
     for s in ss {
         alt s { path_name(s) | path_mod(s) {
-          n += #fmt["%u%s", str::byte_len(s), s];
+          n += #fmt["%u%s", str::len_bytes(s), s];
         } }
     }
     n += "E"; // End name-sequence.
@@ -573,7 +573,7 @@ fn link_binary(sess: session,
                  config.os == session::os_freebsd) &&
                 str::find(filename, "lib") == 0 {
                 ret str::unsafe::slice_bytes(filename, 3u,
-                               str::byte_len(filename));
+                               str::len_bytes(filename));
             } else { ret filename; }
         };
         fn rmext(filename: str) -> str {

--- a/src/comp/driver/diagnostic.rs
+++ b/src/comp/driver/diagnostic.rs
@@ -210,7 +210,7 @@ fn highlight_lines(cm: codemap::codemap, sp: span,
     if elided {
         let last_line = display_lines[vec::len(display_lines) - 1u];
         let s = #fmt["%s:%u ", fm.name, last_line + 1u];
-        let indent = str::char_len(s);
+        let indent = str::len(s);
         let out = "";
         while indent > 0u { out += " "; indent -= 1u; }
         out += "...\n";
@@ -228,7 +228,7 @@ fn highlight_lines(cm: codemap::codemap, sp: span,
         while num > 0u { num /= 10u; digits += 1u; }
 
         // indent past |name:## | and the 0-offset column location
-        let left = str::char_len(fm.name) + digits + lo.col + 3u;
+        let left = str::len(fm.name) + digits + lo.col + 3u;
         let s = "";
         while left > 0u { str::push_char(s, ' '); left -= 1u; }
 

--- a/src/comp/driver/rustc.rs
+++ b/src/comp/driver/rustc.rs
@@ -13,7 +13,7 @@ import rustc::driver::diagnostic;
 fn version(argv0: str) {
     let vers = "unknown version";
     let env_vers = #env["CFG_VERSION"];
-    if str::byte_len(env_vers) != 0u { vers = env_vers; }
+    if str::len_bytes(env_vers) != 0u { vers = env_vers; }
     io::stdout().write_str(#fmt["%s %s\n", argv0, vers]);
     io::stdout().write_str(#fmt["host: %s\n", host_triple()]);
 }

--- a/src/comp/middle/debuginfo.rs
+++ b/src/comp/middle/debuginfo.rs
@@ -48,7 +48,7 @@ const DW_ATE_unsigned_char: int = 0x08;
 
 fn llstr(s: str) -> ValueRef {
     str::as_buf(s, {|sbuf|
-        llvm::LLVMMDString(sbuf, str::byte_len(s) as ctypes::c_uint)
+        llvm::LLVMMDString(sbuf, str::len_bytes(s) as ctypes::c_uint)
     })
 }
 fn lltag(lltag: int) -> ValueRef {
@@ -167,8 +167,8 @@ fn create_compile_unit(cx: @crate_ctxt, full_path: str)
 
     let work_dir = cx.sess.working_dir;
     let file_path = if str::starts_with(full_path, work_dir) {
-        str::unsafe::slice_bytes(full_path, str::byte_len(work_dir),
-                   str::byte_len(full_path))
+        str::unsafe::slice_bytes(full_path, str::len_bytes(work_dir),
+                   str::len_bytes(full_path))
     } else {
         full_path
     };

--- a/src/comp/middle/trans/common.rs
+++ b/src/comp/middle/trans/common.rs
@@ -767,7 +767,7 @@ fn C_u8(i: uint) -> ValueRef { ret C_integral(T_i8(), i as u64, False); }
 // our boxed-and-length-annotated strings.
 fn C_cstr(cx: @crate_ctxt, s: str) -> ValueRef {
     let sc = str::as_buf(s) {|buf|
-        llvm::LLVMConstString(buf, str::byte_len(s) as unsigned, False)
+        llvm::LLVMConstString(buf, str::len_bytes(s) as unsigned, False)
     };
     let g =
         str::as_buf(cx.names("str"),
@@ -781,7 +781,7 @@ fn C_cstr(cx: @crate_ctxt, s: str) -> ValueRef {
 // Returns a Plain Old LLVM String:
 fn C_postr(s: str) -> ValueRef {
     ret str::as_buf(s) {|buf|
-        llvm::LLVMConstString(buf, str::byte_len(s) as unsigned, False)
+        llvm::LLVMConstString(buf, str::len_bytes(s) as unsigned, False)
     };
 }
 

--- a/src/comp/middle/trans/tvec.rs
+++ b/src/comp/middle/trans/tvec.rs
@@ -130,7 +130,7 @@ fn trans_vec(bcx: @block_ctxt, args: [@ast::expr], id: ast::node_id,
 }
 
 fn trans_str(bcx: @block_ctxt, s: str, dest: dest) -> @block_ctxt {
-    let veclen = str::byte_len(s) + 1u; // +1 for \0
+    let veclen = str::len_bytes(s) + 1u; // +1 for \0
     let {bcx: bcx, val: sptr, _} =
         alloc(bcx, ty::mk_str(bcx_tcx(bcx)), veclen);
 

--- a/src/comp/syntax/codemap.rs
+++ b/src/comp/syntax/codemap.rs
@@ -135,7 +135,7 @@ fn lookup_byte_offset(cm: codemap::codemap, chpos: uint)
     let {fm,line} = lookup_line(cm,chpos,lookup);
     let line_offset = fm.lines[line].byte - fm.start_pos.byte;
     let col = chpos - fm.lines[line].ch;
-    let col_offset = str::byte_len_range(*fm.src, line_offset, col);
+    let col_offset = str::substr_len_bytes(*fm.src, line_offset, col);
     ret {fm: fm, pos: line_offset + col_offset};
 }
 

--- a/src/comp/syntax/ext/qquote.rs
+++ b/src/comp/syntax/ext/qquote.rs
@@ -202,7 +202,7 @@ fn expand_qquote<N: qq_helper>
         if (j < g_len && i == cx.gather[j].lo) {
             assert ch == '$';
             let repl = #fmt("$%u ", j);
-            state = skip(str::char_len(repl));
+            state = skip(str::len(repl));
             str2 += repl;
         }
         alt state {

--- a/src/comp/syntax/parse/lexer.rs
+++ b/src/comp/syntax/parse/lexer.rs
@@ -149,11 +149,11 @@ fn scan_exponent(rdr: reader) -> option<str> {
     let c = rdr.curr;
     let rslt = "";
     if c == 'e' || c == 'E' {
-        str::push_byte(rslt, c as u8);
+        str::push_char(rslt, c);
         rdr.bump();
         c = rdr.curr;
         if c == '-' || c == '+' {
-            str::push_byte(rslt, c as u8);
+            str::push_char(rslt, c);
             rdr.bump();
         }
         let exponent = scan_digits(rdr, 10u);
@@ -170,7 +170,7 @@ fn scan_digits(rdr: reader, radix: uint) -> str {
         if c == '_' { rdr.bump(); cont; }
         alt char::maybe_digit(c) {
           some(d) if (d as uint) < radix {
-            str::push_byte(rslt, c as u8);
+            str::push_char(rslt, c);
             rdr.bump();
           }
           _ { break; }
@@ -472,11 +472,11 @@ fn next_token_inner(rdr: reader) -> token::token {
                 let escaped = rdr.curr;
                 rdr.bump();
                 alt escaped {
-                  'n' { str::push_byte(accum_str, '\n' as u8); }
-                  'r' { str::push_byte(accum_str, '\r' as u8); }
-                  't' { str::push_byte(accum_str, '\t' as u8); }
-                  '\\' { str::push_byte(accum_str, '\\' as u8); }
-                  '"' { str::push_byte(accum_str, '"' as u8); }
+                  'n' { str::push_char(accum_str, '\n'); }
+                  'r' { str::push_char(accum_str, '\r'); }
+                  't' { str::push_char(accum_str, '\t'); }
+                  '\\' { str::push_char(accum_str, '\\'); }
+                  '"' { str::push_char(accum_str, '"'); }
                   '\n' { consume_whitespace(rdr); }
                   'x' {
                     str::push_char(accum_str, scan_numeric_escape(rdr, 2u));

--- a/src/comp/syntax/parse/lexer.rs
+++ b/src/comp/syntax/parse/lexer.rs
@@ -58,7 +58,7 @@ fn new_reader(cm: codemap::codemap,
               itr: @interner::interner<str>) -> reader {
     let r = @{cm: cm,
               span_diagnostic: span_diagnostic,
-              src: filemap.src, len: str::byte_len(*filemap.src),
+              src: filemap.src, len: str::len_bytes(*filemap.src),
               mutable col: 0u, mutable pos: 0u, mutable curr: -1 as char,
               mutable chpos: filemap.start_pos.ch, mutable strs: [],
               filemap: filemap, interner: itr};
@@ -157,7 +157,7 @@ fn scan_exponent(rdr: reader) -> option<str> {
             rdr.bump();
         }
         let exponent = scan_digits(rdr, 10u);
-        if str::byte_len(exponent) > 0u {
+        if str::len_bytes(exponent) > 0u {
             ret some(rslt + exponent);
         } else { rdr.fatal("scan_exponent: bad fp literal"); }
     } else { ret none::<str>; }
@@ -220,7 +220,7 @@ fn scan_number(c: char, rdr: reader) -> token::token {
             tp = if signed { either::left(ast::ty_i64) }
                       else { either::right(ast::ty_u64) };
         }
-        if str::byte_len(num_str) == 0u {
+        if str::len_bytes(num_str) == 0u {
             rdr.fatal("no valid digits found for number");
         }
         let parsed = u64::from_str(num_str, base as u64);
@@ -267,7 +267,7 @@ fn scan_number(c: char, rdr: reader) -> token::token {
         ret token::LIT_FLOAT(interner::intern(*rdr.interner, num_str),
                              ast::ty_f);
     } else {
-        if str::byte_len(num_str) == 0u {
+        if str::len_bytes(num_str) == 0u {
             rdr.fatal("no valid digits found for number");
         }
         let parsed = u64::from_str(num_str, base as u64);
@@ -604,8 +604,8 @@ fn trim_whitespace_prefix_and_push_line(&lines: [str],
                                         s: str, col: uint) unsafe {
     let s1;
     if all_whitespace(s, 0u, col) {
-        if col < str::byte_len(s) {
-            s1 = str::unsafe::slice_bytes(s, col, str::byte_len(s));
+        if col < str::len_bytes(s) {
+            s1 = str::unsafe::slice_bytes(s, col, str::len_bytes(s));
         } else { s1 = ""; }
     } else { s1 = s; }
     log(debug, "pushing line: " + s1);
@@ -645,7 +645,7 @@ fn read_block_comment(rdr: reader, code_to_the_left: bool) -> cmnt {
             }
         }
     }
-    if str::byte_len(curr_line) != 0u {
+    if str::len_bytes(curr_line) != 0u {
         trim_whitespace_prefix_and_push_line(lines, curr_line, col);
     }
     let style = if code_to_the_left { trailing } else { isolated };

--- a/src/comp/syntax/parse/token.rs
+++ b/src/comp/syntax/parse/token.rs
@@ -139,7 +139,7 @@ fn to_str(r: reader, t: token) -> str {
         // FIXME: escape.
         let tmp = "'";
         str::push_char(tmp, c as char);
-        str::push_byte(tmp, '\'' as u8);
+        str::push_char(tmp, '\'');
         ret tmp;
       }
       LIT_INT(i, t) {

--- a/src/comp/syntax/print/pp.rs
+++ b/src/comp/syntax/print/pp.rs
@@ -491,7 +491,7 @@ fn end(p: printer) { p.pretty_print(END); }
 fn eof(p: printer) { p.pretty_print(EOF); }
 
 fn word(p: printer, wrd: str) {
-    p.pretty_print(STRING(wrd, str::char_len(wrd) as int));
+    p.pretty_print(STRING(wrd, str::len(wrd) as int));
 }
 
 fn huge_word(p: printer, wrd: str) {

--- a/src/comp/syntax/print/pprust.rs
+++ b/src/comp/syntax/print/pprust.rs
@@ -201,7 +201,7 @@ fn head(s: ps, w: str) {
     // outer-box is consistent
     cbox(s, indent_unit);
     // head-box is inconsistent
-    ibox(s, str::char_len(w) + 1u);
+    ibox(s, str::len(w) + 1u);
     // keyword that starts the head
     word_nbsp(s, w);
 }
@@ -1458,7 +1458,7 @@ fn print_ty_fn(s: ps, opt_proto: option<ast::proto>,
     popen(s);
     fn print_arg(s: ps, input: ast::arg) {
         print_arg_mode(s, input.mode);
-        if str::byte_len(input.ident) > 0u {
+        if str::len_bytes(input.ident) > 0u {
             word_space(s, input.ident + ":");
         }
         print_type(s, input.ty);
@@ -1640,7 +1640,7 @@ fn print_string(s: ps, st: str) {
 
 fn escape_str(st: str, to_escape: char) -> str {
     let out: str = "";
-    let len = str::byte_len(st);
+    let len = str::len_bytes(st);
     let i = 0u;
     while i < len {
         alt st[i] as char {

--- a/src/comp/util/ppaux.rs
+++ b/src/comp/util/ppaux.rs
@@ -132,7 +132,7 @@ fn ty_to_str(cx: ctxt, typ: t) -> str {
 
 fn ty_to_short_str(cx: ctxt, typ: t) -> str unsafe {
     let s = encoder::encoded_ty(cx, typ);
-    if str::byte_len(s) >= 32u { s = str::unsafe::slice_bytes(s, 0u, 32u); }
+    if str::len_bytes(s) >= 32u { s = str::unsafe::slice_bytes(s, 0u, 32u); }
     ret s;
 }
 

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -26,12 +26,12 @@ fn parse_expected(line_num: uint, line: str) -> [expected_error] unsafe {
     let error_tag = "//!";
     let idx0 = str::find(line, error_tag);
     if idx0 < 0 { ret []; }
-    let idx = (idx0 as uint) + str::byte_len(error_tag);
+    let idx = (idx0 as uint) + str::len_bytes(error_tag);
 
     // "//!^^^ kind msg" denotes a message expected
     // three lines above current line:
     let adjust_line = 0u;
-    let len = str::byte_len(line);
+    let len = str::len_bytes(line);
     while idx < len && line[idx] == ('^' as u8) {
         adjust_line += 1u;
         idx += 1u;

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -109,8 +109,8 @@ fn parse_name_value_directive(line: str,
     if str::find(line, keycolon) >= 0 {
         let colon = str::find(line, keycolon) as uint;
         let value =
-            str::unsafe::slice_bytes(line, colon + str::byte_len(keycolon),
-                       str::byte_len(line));
+            str::unsafe::slice_bytes(line, colon + str::len_bytes(keycolon),
+                       str::len_bytes(line));
         #debug("%s: %s", directive,  value);
         option::some(value)
     } else { option::none }

--- a/src/fuzzer/fuzzer.rs
+++ b/src/fuzzer/fuzzer.rs
@@ -285,7 +285,7 @@ fn check_variants_T<T: copy>(
 
 fn last_part(filename: str) -> str {
   let ix = option::get(str::rindex(filename, '/'));
-  str::slice(filename, ix + 1u, str::char_len(filename) - 3u)
+  str::slice(filename, ix + 1u, str::len(filename) - 3u)
 }
 
 enum happiness { passed, cleanly_rejected(str), known_bug(str), failed(str), }
@@ -333,7 +333,7 @@ fn removeDirIfExists(filename: str) {
 fn check_running(exe_filename: str) -> happiness {
     let p = std::run::program_output("/Users/jruderman/scripts/timed_run_rust_program.py", [exe_filename]);
     let comb = p.out + "\n" + p.err;
-    if str::byte_len(comb) > 1u {
+    if str::len_bytes(comb) > 1u {
         log(error, "comb comb comb: " + comb);
     }
 

--- a/src/libcore/extfmt.rs
+++ b/src/libcore/extfmt.rs
@@ -82,10 +82,10 @@ mod ct {
 
     fn parse_fmt_string(s: str, error: error_fn) -> [piece] unsafe {
         let pieces: [piece] = [];
-        let lim = str::byte_len(s);
+        let lim = str::len_bytes(s);
         let buf = "";
         fn flush_buf(buf: str, &pieces: [piece]) -> str {
-            if str::byte_len(buf) > 0u {
+            if str::len_bytes(buf) > 0u {
                 let piece = piece_string(buf);
                 pieces += [piece];
             }
@@ -325,7 +325,7 @@ mod rt {
             alt cv.precision {
               count_implied { s }
               count_is(max) {
-                if max as uint < str::char_len(s) {
+                if max as uint < str::len(s) {
                     str::substr(s, 0u, max as uint)
                 } else { s }
               }
@@ -368,7 +368,7 @@ mod rt {
                 ""
             } else {
                 let s = uint::to_str(num, radix);
-                let len = str::char_len(s);
+                let len = str::len(s);
                 if len < prec {
                     let diff = prec - len;
                     let pad = str_init_elt(diff, '0');
@@ -400,7 +400,7 @@ mod rt {
             uwidth = width as uint;
           }
         }
-        let strlen = str::char_len(s);
+        let strlen = str::len(s);
         if uwidth <= strlen { ret s; }
         let padchar = ' ';
         let diff = uwidth - strlen;
@@ -433,12 +433,12 @@ mod rt {
         // zeros. It may make sense to convert zero padding to a precision
         // instead.
 
-        if signed && zero_padding && str::byte_len(s) > 0u {
+        if signed && zero_padding && str::len_bytes(s) > 0u {
             let head = s[0];
             if head == '+' as u8 || head == '-' as u8 || head == ' ' as u8 {
                 let headstr = str::from_bytes([head]);
                 // FIXME: not UTF-8 safe
-                let bytelen = str::byte_len(s);
+                let bytelen = str::len_bytes(s);
                 let numpart = str::unsafe::slice_bytes(s, 1u, bytelen);
                 ret headstr + padstr + numpart;
             }

--- a/src/libcore/float.rs
+++ b/src/libcore/float.rs
@@ -128,7 +128,7 @@ fn from_str(num: str) -> float {
 
    let pos = 0u;                  //Current byte position in the string.
                                   //Used to walk the string in O(n).
-   let len = str::byte_len(num);  //Length of the string, in bytes.
+   let len = str::len_bytes(num);  //Length of the string, in bytes.
 
    if len == 0u { ret 0.; }
    let total = 0f;                //Accumulated result

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -889,7 +889,7 @@ Returns:
 
 The index of the first occurance of `needle`, or -1 if not found.
 
-FIXME: UTF-8
+FIXME: return an option<char position uint> instead
 */
 fn find(haystack: str, needle: str) -> int {
     let haystack_len: int = len_bytes(haystack) as int;
@@ -1003,7 +1003,6 @@ fn is_whitespace(s: str) -> bool {
 // Function: len_bytes
 //
 // Returns the string length in bytes
-// (Synonym: byte_len)
 pure fn len_bytes(s: str) -> uint unsafe {
     as_bytes(s) { |v|
         let vlen = vec::len(v);
@@ -1013,21 +1012,15 @@ pure fn len_bytes(s: str) -> uint unsafe {
     }
 }
 
-// FIXME: remove
-pure fn byte_len(s: str) -> uint unsafe { len_bytes(s) }
-
 // Function: len
 //
 // String length or size in characters.
-// (Synonyms: len_chars, char_len)
+// (Synonym: len_chars)
 fn len(s: str) -> uint {
     substr_len_chars(s, 0u, len_bytes(s))
 }
 
 fn len_chars(s: str) -> uint { len(s) }
-
-// FIXME: remove
-fn char_len(s: str) -> uint { len(s) }
 
 /*
 Section: Misc

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -79,8 +79,8 @@ export
    is_empty,
    is_not_empty,
    is_whitespace,
-   byte_len,
-   char_len,
+   len_bytes,
+   len_chars, len,
 
    // Misc
    // FIXME: perhaps some more of this section shouldn't be exported?
@@ -473,7 +473,7 @@ fn split_str(ss: str, sep: str) -> [str] unsafe {
     // unsafe is justified: we are splitting
     // UTF-8 with UTF-8, so the results will be OK
 
-    let sep_len = str::byte_len(sep);
+    let sep_len = len_bytes(sep);
     assert sep_len > 0u;
     let vv = [];
     let start = 0u, start_match = 0u, current = 0u, matching = 0u;
@@ -525,7 +525,7 @@ fn split(ss: str, sepfn: fn(cc: char)->bool) -> [str] {
         }
     });
 
-    if char_len(accum) >= 0u || ends_with_sep {
+    if len(accum) >= 0u || ends_with_sep {
         vv += [accum];
     }
 
@@ -597,7 +597,7 @@ separated by whitespace
 */
 fn words(ss: str) -> [str] {
     ret vec::filter( split(ss, {|cc| char::is_whitespace(cc)}),
-                     {|w| 0u < str::char_len(w)});
+                     {|w| 0u < str::len(w)});
 }
 
 /*
@@ -607,7 +607,7 @@ Create a vector of substrings of size `nn`
 */
 fn windowed(nn: uint, ss: str) -> [str] {
     let ww = [];
-    let len = str::char_len(ss);
+    let len = str::len(ss);
 
     assert 1u <= nn;
 
@@ -667,7 +667,7 @@ fn replace(s: str, from: str, to: str) : is_not_empty(from) -> str unsafe {
             ret s;
         }
         ret slice(s, 0u, idx as uint) + to +
-            replace(slice(s, idx as uint + char_len(from), char_len(s)),
+            replace(slice(s, idx as uint + len(from), len(s)),
                     from, to);
     }
 }
@@ -856,7 +856,7 @@ fn index(ss: str, cc: char) -> option<uint> {
 // (as option some/none)
 fn rindex(ss: str, cc: char) -> option<uint> {
     let bii = byte_len(ss);
-    let cii = char_len(ss);
+    let cii = len(ss);
     while bii > 0u {
         let {ch, prev} = char_range_at_reverse(ss, bii);
         cii -= 1u;
@@ -947,8 +947,8 @@ haystack - The string to look in
 needle - The string to look for
 */
 fn ends_with(haystack: str, needle: str) -> bool {
-    let haystack_len: uint = char_len(haystack);
-    let needle_len: uint = char_len(needle);
+    let haystack_len: uint = len(haystack);
+    let needle_len: uint = len(needle);
     ret if needle_len == 0u {
             true
         } else if needle_len > haystack_len {
@@ -997,14 +997,12 @@ fn is_whitespace(s: str) -> bool {
     ret all(s, char::is_whitespace);
 }
 
-/*
-Function: byte_len
 
-Returns the length in bytes of a string
-
-FIXME: rename to 'len_bytes'
-*/
-pure fn byte_len(s: str) -> uint unsafe {
+// Function: len_bytes
+//
+// Returns the string length in bytes
+// (Synonym: byte_len)
+pure fn len_bytes(s: str) -> uint unsafe {
     as_bytes(s) { |v|
         let vlen = vec::len(v);
         // There should always be a null terminator
@@ -1013,16 +1011,21 @@ pure fn byte_len(s: str) -> uint unsafe {
     }
 }
 
-/*
-Function: char_len
+// FIXME: remove
+pure fn byte_len(s: str) -> uint unsafe { len_bytes(s) }
 
-Count the number of unicode characters in a string
-
-FIXME: rename to 'len_chars'
-*/
-fn char_len(s: str) -> uint {
-    ret char_len_range(s, 0u, byte_len(s));
+// Function: len
+//
+// String length or size in characters.
+// (Synonyms: len_chars, char_len)
+fn len(s: str) -> uint {
+    char_len_range(s, 0u, byte_len(s))
 }
+
+fn len_chars(s: str) -> uint { len(s) }
+
+// FIXME: remove
+fn char_len(s: str) -> uint { len(s) }
 
 /*
 Section: Misc

--- a/src/libcore/u64.rs
+++ b/src/libcore/u64.rs
@@ -118,11 +118,11 @@ Function: from_str
 Parse a string as an unsigned integer.
 */
 fn from_str(buf: str, radix: u64) -> u64 {
-    if str::byte_len(buf) == 0u {
+    if str::len_bytes(buf) == 0u {
         #error("parse_buf(): buf is empty");
         fail;
     }
-    let i = str::byte_len(buf) - 1u;
+    let i = str::len_bytes(buf) - 1u;
     let power = 1u64, n = 0u64;
     while true {
         let digit = char::to_digit(buf[i] as char) as u64;

--- a/src/libcore/uint.rs
+++ b/src/libcore/uint.rs
@@ -256,7 +256,7 @@ fn to_str(num: uint, radix: uint) -> str {
         n /= radix;
     }
     let s1: str = "";
-    let len: uint = str::byte_len(s);
+    let len: uint = str::len_bytes(s);
     while len != 0u { len -= 1u; s1 += str::from_byte(s[len]); }
     ret s1;
 }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -89,14 +89,14 @@ any leading path separator on `post`, and returns the concatenation of the two
 with a single path separator between them.
 */
 
-fn connect(pre: path, post: path) -> path {
+fn connect(pre: path, post: path) -> path unsafe {
     let pre_ = pre;
     let post_ = post;
     let sep = os_fs::path_sep as u8;
     let pre_len = str::byte_len(pre);
     let post_len = str::byte_len(post);
-    if pre_len > 1u && pre[pre_len-1u] == sep { str::pop_byte(pre_); }
-    if post_len > 1u && post[0] == sep { str::shift_byte(post_); }
+    if pre_len > 1u && pre[pre_len-1u] == sep { str::unsafe::pop_byte(pre_); }
+    if post_len > 1u && post[0] == sep { str::unsafe::shift_byte(post_); }
     ret pre_ + path_sep() + post_;
 }
 

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -45,7 +45,7 @@ fn splitDirnameBasename (pp: path) -> {dirname: str, basename: str} {
     }
 
     ret {dirname: str::slice(pp, 0u, ii),
-         basename: str::slice(pp, ii + 1u, str::char_len(pp))};
+         basename: str::slice(pp, ii + 1u, str::len(pp))};
 }
 
 /*
@@ -93,8 +93,8 @@ fn connect(pre: path, post: path) -> path unsafe {
     let pre_ = pre;
     let post_ = post;
     let sep = os_fs::path_sep as u8;
-    let pre_len = str::byte_len(pre);
-    let post_len = str::byte_len(post);
+    let pre_len = str::len_bytes(pre);
+    let post_len = str::len_bytes(post);
     if pre_len > 1u && pre[pre_len-1u] == sep { str::unsafe::pop_byte(pre_); }
     if post_len > 1u && post[0] == sep { str::unsafe::shift_byte(post_); }
     ret pre_ + path_sep() + post_;
@@ -171,7 +171,7 @@ Lists the contents of a directory.
 */
 fn list_dir(p: path) -> [str] {
     let p = p;
-    let pl = str::byte_len(p);
+    let pl = str::len_bytes(p);
     if pl == 0u || p[pl - 1u] as char != os_fs::path_sep { p += path_sep(); }
     let full_paths: [str] = [];
     for filename: str in os_fs::list_dir(p) {
@@ -337,7 +337,7 @@ fn normalize(p: path) -> path {
     let s = reabsolute(p, s);
     let s = reterminate(p, s);
 
-    let s = if str::byte_len(s) == 0u {
+    let s = if str::len_bytes(s) == 0u {
         "."
     } else {
         s
@@ -404,7 +404,7 @@ fn normalize(p: path) -> path {
     }
 
     fn reterminate(orig: path, new: path) -> path {
-        let last = orig[str::byte_len(orig) - 1u];
+        let last = orig[str::len_bytes(orig) - 1u];
         if last == os_fs::path_sep as u8
             || last == os_fs::path_sep as u8 {
             ret new + path_sep();

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -79,7 +79,7 @@ A description of a possible option
 type opt = {name: name, hasarg: hasarg, occur: occur};
 
 fn mkname(nm: str) -> name {
-    ret if str::char_len(nm) == 1u {
+    ret if str::len(nm) == 1u {
             short(str::char_at(nm, 0u))
         } else { long(nm) };
 }
@@ -141,7 +141,7 @@ of matches and a vector of free strings.
 type match = {opts: [opt], vals: [mutable [optval]], free: [str]};
 
 fn is_arg(arg: str) -> bool {
-    ret str::byte_len(arg) > 1u && arg[0] == '-' as u8;
+    ret str::len_bytes(arg) > 1u && arg[0] == '-' as u8;
 }
 
 fn name_str(nm: name) -> str {
@@ -218,7 +218,7 @@ fn getopts(args: [str], opts: [opt]) -> result unsafe {
     let i = 0u;
     while i < l {
         let cur = args[i];
-        let curlen = str::byte_len(cur);
+        let curlen = str::len_bytes(cur);
         if !is_arg(cur) {
             free += [cur];
         } else if str::eq(cur, "--") {

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -70,13 +70,13 @@ fn to_str(j: json) -> str {
 }
 
 fn rest(s: str) -> str {
-    assert(str::char_len(s) >= 1u);
-    str::slice(s, 1u, str::char_len(s))
+    assert(str::len(s) >= 1u);
+    str::slice(s, 1u, str::len(s))
 }
 
 fn from_str_str(s: str) -> (option<json>, str) {
     let pos = 0u;
-    let len = str::byte_len(s);
+    let len = str::len_bytes(s);
     let escape = false;
     let res = "";
 
@@ -99,7 +99,7 @@ fn from_str_str(s: str) -> (option<json>, str) {
             cont;
         } else if (c == '"') {
             ret (some(string(res)),
-                 str::slice(s, pos, str::char_len(s)));
+                 str::slice(s, pos, str::len(s)));
         }
         res = res + str::from_char(c);
     }
@@ -172,7 +172,7 @@ fn from_str_dict(s: str) -> (option<json>, str) {
 
 fn from_str_float(s: str) -> (option<json>, str) {
     let pos = 0u;
-    let len = str::byte_len(s);
+    let len = str::len_bytes(s);
     let res = 0f;
     let neg = 1f;
 
@@ -200,12 +200,12 @@ fn from_str_float(s: str) -> (option<json>, str) {
             }
             '.' { break; }
             _ { ret (some(num(neg * res)),
-                     str::slice(s, opos, str::char_len(s))); }
+                     str::slice(s, opos, str::len(s))); }
         }
     }
 
     if pos == len {
-        ret (some(num(neg * res)), str::slice(s, pos, str::char_len(s)));
+        ret (some(num(neg * res)), str::slice(s, pos, str::len(s)));
     }
 
     let dec = 1f;
@@ -220,17 +220,17 @@ fn from_str_float(s: str) -> (option<json>, str) {
                 res += (((c as int) - ('0' as int)) as float) * dec;
             }
             _ { ret (some(num(neg * res)),
-                     str::slice(s, opos, str::char_len(s))); }
+                     str::slice(s, opos, str::len(s))); }
         }
     }
-    ret (some(num(neg * res)), str::slice(s, pos, str::char_len(s)));
+    ret (some(num(neg * res)), str::slice(s, pos, str::len(s)));
 }
 
 fn from_str_bool(s: str) -> (option<json>, str) {
     if (str::starts_with(s, "true")) {
-        (some(boolean(true)), str::slice(s, 4u, str::char_len(s)))
+        (some(boolean(true)), str::slice(s, 4u, str::len(s)))
     } else if (str::starts_with(s, "false")) {
-        (some(boolean(false)), str::slice(s, 5u, str::char_len(s)))
+        (some(boolean(false)), str::slice(s, 5u, str::len(s)))
     } else {
         (none, s)
     }
@@ -238,7 +238,7 @@ fn from_str_bool(s: str) -> (option<json>, str) {
 
 fn from_str_null(s: str) -> (option<json>, str) {
     if (str::starts_with(s, "null")) {
-        (some(null), str::slice(s, 4u, str::char_len(s)))
+        (some(null), str::slice(s, 4u, str::len(s)))
     } else {
         (none, s)
     }

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -77,7 +77,7 @@ fn mk_rng() -> rng {
             let i = 0u;
             while (i < len) {
                 let n = rustrt::rand_next(**self) as uint %
-                    str::char_len(charset);
+                    str::len(charset);
                 s = s + str::from_char(str::char_at(charset, n));
                 i += 1u;
             }
@@ -130,8 +130,8 @@ mod tests {
         log(debug, r.gen_str(10u));
         log(debug, r.gen_str(10u));
         log(debug, r.gen_str(10u));
-        assert(str::char_len(r.gen_str(10u)) == 10u);
-        assert(str::char_len(r.gen_str(16u)) == 16u);
+        assert(str::len(r.gen_str(10u)) == 10u);
+        assert(str::len(r.gen_str(16u)) == 16u);
     }
 }
 

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -65,7 +65,7 @@ Performance notes:
 - the function runs in linear time.
  */
 fn of_str(str: @str) -> rope {
-    ret of_substr(str, 0u, str::byte_len(*str));
+    ret of_substr(str, 0u, str::len_bytes(*str));
 }
 
 /*
@@ -93,7 +93,7 @@ Safety notes:
  */
 fn of_substr(str: @str, byte_offset: uint, byte_len: uint) -> rope {
     if byte_len == 0u { ret node::empty; }
-    if byte_offset + byte_len  > str::byte_len(*str) { fail; }
+    if byte_offset + byte_len  > str::len_bytes(*str) { fail; }
     ret node::content(node::of_substr(str, byte_offset, byte_len));
 }
 
@@ -540,6 +540,7 @@ pure fn char_len(rope: rope) -> uint {
  Returns: The number of bytes in the rope
 
  Performance note: Constant time.
+ FIXME: char or byte?
  */
 pure fn byte_len(rope: rope) -> uint {
    alt(rope) {
@@ -720,7 +721,7 @@ mod node {
     the length of `str`.
      */
     fn of_str(str: @str) -> @node {
-        ret of_substr(str, 0u, str::byte_len(*str));
+        ret of_substr(str, 0u, str::len_bytes(*str));
     }
 
     /*
@@ -767,7 +768,7 @@ mod node {
     */
     fn of_substr_unsafer(str: @str, byte_start: uint, byte_len: uint,
                           char_len: uint) -> @node {
-        assert(byte_start + byte_len <= str::byte_len(*str));
+        assert(byte_start + byte_len <= str::len_bytes(*str));
         let candidate = @leaf({
                 byte_offset: byte_start,
                 byte_len:    byte_len,
@@ -1372,7 +1373,7 @@ mod tests {
         let sample = @"0123456789ABCDE";
         let r      = of_str(sample);
 
-        assert char_len(r) == str::char_len(*sample);
+        assert char_len(r) == str::len(*sample);
         assert rope_to_string(r) == *sample;
     }
 
@@ -1383,11 +1384,11 @@ mod tests {
         while i < 10 { *buf = *buf + *buf; i+=1;}
         let sample = @*buf;
         let r      = of_str(sample);
-        assert char_len(r) == str::char_len(*sample);
+        assert char_len(r) == str::len(*sample);
         assert rope_to_string(r) == *sample;
 
         let string_iter = 0u;
-        let string_len  = str::byte_len(*sample);
+        let string_len  = str::len_bytes(*sample);
         let rope_iter   = iterator::char::start(r);
         let equal       = true;
         let pos         = 0u;
@@ -1426,7 +1427,7 @@ mod tests {
             }
         }
 
-        assert len == str::char_len(*sample);
+        assert len == str::len(*sample);
     }
 
     #[test]

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -743,7 +743,7 @@ mod node {
      */
     fn of_substr(str: @str, byte_start: uint, byte_len: uint) -> @node {
         ret of_substr_unsafer(str, byte_start, byte_len,
-                  str::char_len_range(*str, byte_start, byte_len));
+                  str::substr_len_chars(*str, byte_start, byte_len));
     }
 
     /*
@@ -795,7 +795,7 @@ mod node {
                     if i == 0u  { first_leaf_char_len }
                     else { hint_max_leaf_char_len };
                 let chunk_byte_len =
-                    str::byte_len_range(*str, offset, chunk_char_len);
+                    str::substr_len_bytes(*str, offset, chunk_char_len);
                 nodes[i] = @leaf({
                     byte_offset: offset,
                     byte_len:    chunk_byte_len,
@@ -998,7 +998,7 @@ mod node {
             alt(*node) {
               node::leaf(x) {
                 let char_len =
-                    str::char_len_range(*x.content, byte_offset, byte_len);
+                    str::substr_len_chars(*x.content, byte_offset, byte_len);
                 ret @leaf({byte_offset: byte_offset,
                                 byte_len:    byte_len,
                                 char_len:    char_len,
@@ -1059,9 +1059,9 @@ mod node {
                     ret node;
                 }
                 let byte_offset =
-                    str::byte_len_range(*x.content, 0u, char_offset);
+                    str::substr_len_bytes(*x.content, 0u, char_offset);
                 let byte_len    =
-                    str::byte_len_range(*x.content, byte_offset, char_len);
+                    str::substr_len_bytes(*x.content, byte_offset, char_len);
                 ret @leaf({byte_offset: byte_offset,
                            byte_len:    byte_len,
                            char_len:    char_len,

--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -368,7 +368,7 @@ mod tests {
 
         // Test that it works when accepting the message in pieces
         for t: test in tests {
-            let len = str::byte_len(t.input);
+            let len = str::len_bytes(t.input);
             let left = len;
             while left > 0u {
                 let take = (left + 1u) / 2u;

--- a/src/rustdoc/desc_to_brief_pass.rs
+++ b/src/rustdoc/desc_to_brief_pass.rs
@@ -240,7 +240,7 @@ fn parse_desc(desc: str) -> (option<str>, option<str>) {
 
     if check vec::is_not_empty(paras) {
         let maybe_brief = vec::head(paras);
-        if str::char_len(maybe_brief) <= max_brief_len {
+        if str::len(maybe_brief) <= max_brief_len {
             let desc_paras = vec::tail(paras);
             let desc = if vec::is_not_empty(desc_paras) {
                 some(str::connect(desc_paras, "\n\n"))

--- a/src/rustdoc/unindent_pass.rs
+++ b/src/rustdoc/unindent_pass.rs
@@ -67,8 +67,8 @@ fn unindent(s: str) -> str {
             if str::is_whitespace(line) {
                 line
             } else {
-                assert str::byte_len(line) >= min_indent;
-                str::slice(line, min_indent, str::char_len(line))
+                assert str::len_bytes(line) >= min_indent;
+                str::slice(line, min_indent, str::len(line))
             }
         };
         str::connect(unindented, "\n")

--- a/src/test/bench/99bob-iter.rs
+++ b/src/test/bench/99bob-iter.rs
@@ -22,7 +22,7 @@ fn b8() -> str {
     ret "Go to the store and buy some more, # of beer on the wall.";
 }
 
-fn sub(t: str, n: int) -> str {
+fn sub(t: str, n: int) -> str unsafe {
     let b: str = "";
     let i: uint = 0u;
     let ns: str;
@@ -32,7 +32,8 @@ fn sub(t: str, n: int) -> str {
       _ { ns = int::to_str(n, 10u) + " bottles"; }
     }
     while i < str::byte_len(t) {
-        if t[i] == '#' as u8 { b += ns; } else { str::push_byte(b, t[i]); }
+        if t[i] == '#' as u8 { b += ns; }
+        else { str::unsafe::push_byte(b, t[i]); }
         i += 1u;
     }
     ret b;

--- a/src/test/bench/99bob-iter.rs
+++ b/src/test/bench/99bob-iter.rs
@@ -31,7 +31,7 @@ fn sub(t: str, n: int) -> str unsafe {
       1 { ns = "1 bottle"; }
       _ { ns = int::to_str(n, 10u) + " bottles"; }
     }
-    while i < str::byte_len(t) {
+    while i < str::len_bytes(t) {
         if t[i] == '#' as u8 { b += ns; }
         else { str::unsafe::push_byte(b, t[i]); }
         i += 1u;

--- a/src/test/bench/99bob-simple.rs
+++ b/src/test/bench/99bob-simple.rs
@@ -22,7 +22,7 @@ fn b8() -> str {
     ret "Go to the store and buy some more, # of beer on the wall.";
 }
 
-fn sub(t: str, n: int) -> str {
+fn sub(t: str, n: int) -> str unsafe {
     let b: str = "";
     let i: uint = 0u;
     let ns: str;
@@ -32,7 +32,8 @@ fn sub(t: str, n: int) -> str {
       _ { ns = int::to_str(n, 10u) + " bottles"; }
     }
     while i < str::byte_len(t) {
-        if t[i] == '#' as u8 { b += ns; } else { str::push_byte(b, t[i]); }
+        if t[i] == '#' as u8 { b += ns; }
+        else { str::unsafe::push_byte(b, t[i]); }
         i += 1u;
     }
     ret b;

--- a/src/test/bench/99bob-simple.rs
+++ b/src/test/bench/99bob-simple.rs
@@ -31,7 +31,7 @@ fn sub(t: str, n: int) -> str unsafe {
       1 { ns = "1 bottle"; }
       _ { ns = int::to_str(n, 10u) + " bottles"; }
     }
-    while i < str::byte_len(t) {
+    while i < str::len_bytes(t) {
         if t[i] == '#' as u8 { b += ns; }
         else { str::unsafe::push_byte(b, t[i]); }
         i += 1u;

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -47,8 +47,8 @@ fn make_random_fasta(id: str, desc: str, genelist: [aminoacids], n: int) {
     let rng = @{mutable last: std::rand::mk_rng().next()};
     let op: str = "";
     uint::range(0u, n as uint) {|_i|
-        str::push_byte(op, select_random(myrandom_next(rng, 100u32),
-                                         genelist) as u8);
+        str::push_char(op, select_random(myrandom_next(rng, 100u32),
+                                         genelist));
         if str::byte_len(op) >= LINE_LENGTH() {
             log(debug, op);
             op = "";
@@ -57,12 +57,12 @@ fn make_random_fasta(id: str, desc: str, genelist: [aminoacids], n: int) {
     if str::byte_len(op) > 0u { log(debug, op); }
 }
 
-fn make_repeat_fasta(id: str, desc: str, s: str, n: int) {
+fn make_repeat_fasta(id: str, desc: str, s: str, n: int) unsafe {
     log(debug, ">" + id + " " + desc);
     let op: str = "";
     let sl: uint = str::byte_len(s);
     uint::range(0u, n as uint) {|i|
-        str::push_byte(op, s[i % sl]);
+        str::unsafe::push_byte(op, s[i % sl]);
         if str::byte_len(op) >= LINE_LENGTH() {
             log(debug, op);
             op = "";

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -49,26 +49,26 @@ fn make_random_fasta(id: str, desc: str, genelist: [aminoacids], n: int) {
     uint::range(0u, n as uint) {|_i|
         str::push_char(op, select_random(myrandom_next(rng, 100u32),
                                          genelist));
-        if str::byte_len(op) >= LINE_LENGTH() {
+        if str::len_bytes(op) >= LINE_LENGTH() {
             log(debug, op);
             op = "";
         }
     }
-    if str::byte_len(op) > 0u { log(debug, op); }
+    if str::len_bytes(op) > 0u { log(debug, op); }
 }
 
 fn make_repeat_fasta(id: str, desc: str, s: str, n: int) unsafe {
     log(debug, ">" + id + " " + desc);
     let op: str = "";
-    let sl: uint = str::byte_len(s);
+    let sl: uint = str::len_bytes(s);
     uint::range(0u, n as uint) {|i|
         str::unsafe::push_byte(op, s[i % sl]);
-        if str::byte_len(op) >= LINE_LENGTH() {
+        if str::len_bytes(op) >= LINE_LENGTH() {
             log(debug, op);
             op = "";
         }
     }
-    if str::byte_len(op) > 0u { log(debug, op); }
+    if str::len_bytes(op) > 0u { log(debug, op); }
 }
 
 fn acid(ch: char, prob: u32) -> aminoacids { ret {ch: ch, prob: prob}; }

--- a/src/test/run-pass/bind-native-fn.rs
+++ b/src/test/run-pass/bind-native-fn.rs
@@ -13,7 +13,7 @@ native mod libc {
 fn main() {
     let s = "hello world\n";
     let b = str::bytes(s);
-    let l = str::byte_len(s);
+    let l = str::len_bytes(s);
     let b8 = unsafe { vec::unsafe::to_ptr(b) };
     libc::write(0i32, b8, l);
     let a = bind libc::write(0i32, _, _);

--- a/src/test/run-pass/string-self-append.rs
+++ b/src/test/run-pass/string-self-append.rs
@@ -7,8 +7,8 @@ fn main() {
     let i = 20;
     let expected_len = 1u;
     while i > 0 {
-        log(error, str::byte_len(a));
-        assert (str::byte_len(a) == expected_len);
+        log(error, str::len_bytes(a));
+        assert (str::len_bytes(a) == expected_len);
         a += a;
         i -= 1;
         expected_len *= 2u;

--- a/src/test/run-pass/utf8_chars.rs
+++ b/src/test/run-pass/utf8_chars.rs
@@ -7,8 +7,8 @@ fn main() {
     let chs: [char] = ['e', 'é', '€', 0x10000 as char];
     let s: str = str::from_chars(chs);
 
-    assert (str::byte_len(s) == 10u);
-    assert (str::char_len(s) == 4u);
+    assert (str::len_bytes(s) == 10u);
+    assert (str::len(s) == 4u);
     assert (vec::len::<char>(str::chars(s)) == 4u);
     assert (str::eq(str::from_chars(str::chars(s)), s));
     assert (str::char_at(s, 0u) == 'e');


### PR DESCRIPTION
Various updates to core::str, including:
- move push_byte, push_bytes, pop_byte, and shift_byte into str::unsafe and mark them unsafe
- rename byte_len -> len_bytes
- rename char_len -> len / len_chars
- rename byte_len_range -> substr_len_bytes and
- rename char_len_range -> substr_len_chars
- fix replace and starts_with (for UTF-8) and add more unicode find/contains/replace test cases

(Third try re: #1819 and #1820.)
