### PR TITLE
Various additions to core::iter

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -85,6 +85,29 @@ fn repeat(times: uint, blk: fn()) {
     }
 }
 
+fn min<A:copy,IA:iterable<A>>(self: IA) -> A {
+    alt foldl(self, none) {|a, b|
+        alt a {
+          some(a) { some(math::min(a, b)) }
+          none { some(b) }
+        }
+    } {
+        some(val) { val }
+        none { fail "min called on empty iterator" }
+    }
+}
+
+fn max<A:copy,IA:iterable<A>>(self: IA) -> A {
+    alt foldl(self, none) {|a, b|
+        alt a {
+          some(a) { some(math::max(a, b)) }
+          none { some(b) }
+        }
+    } {
+        some(val) { val }
+        none { fail "max called on empty iterator" }
+    }
+}
 
 #[test]
 fn test_enumerate() {
@@ -168,4 +191,26 @@ fn test_repeat() {
     assert c == [0u, 1u, 4u, 9u, 16u];
 }
 
+#[test]
+fn test_min() {
+    assert min([5, 4, 1, 2, 3]) == 1;
+}
 
+#[test]
+#[should_fail]
+#[ignore(cfg(target_os = "win32"))]
+fn test_min_empty() {
+    min::<int, [int]>([]);
+}
+
+#[test]
+fn test_max() {
+    assert max([1, 2, 4, 2, 3]) == 4;
+}
+
+#[test]
+#[should_fail]
+#[ignore(cfg(target_os = "win32"))]
+fn test_max_empty() {
+    max::<int, [int]>([]);
+}

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -82,6 +82,16 @@ fn reverse<A:copy,IA:iterable<A>>(self: IA, blk: fn(A)) {
     vec::riter(to_list(self), blk)
 }
 
+fn count<A,IA:iterable<A>>(self: IA, x: A) -> uint {
+    foldl(self, 0u) {|count, value|
+        if value == x {
+            count + 1u
+        } else {
+            count
+        }
+    }
+}
+
 fn repeat(times: uint, blk: fn()) {
     let i = 0u;
     while i < times {
@@ -223,4 +233,9 @@ fn test_max_empty() {
 #[test]
 fn test_reverse() {
     assert to_list(bind reverse([1, 2, 3], _)) == [3, 2, 1];
+}
+
+#[test]
+fn test_count() {
+    assert count([1, 2, 1, 2, 1], 1) == 3u;
 }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -77,6 +77,11 @@ fn to_list<A:copy,IA:iterable<A>>(self: IA) -> [A] {
     foldl::<A,[A],IA>(self, [], {|r, a| r + [a]})
 }
 
+// FIXME: This could be made more efficient with an riterable interface
+fn reverse<A:copy,IA:iterable<A>>(self: IA, blk: fn(A)) {
+    vec::riter(to_list(self), blk)
+}
+
 fn repeat(times: uint, blk: fn()) {
     let i = 0u;
     while i < times {
@@ -213,4 +218,9 @@ fn test_max() {
 #[ignore(cfg(target_os = "win32"))]
 fn test_max_empty() {
     max::<int, [int]>([]);
+}
+
+#[test]
+fn test_reverse() {
+    assert to_list(bind reverse([1, 2, 3], _)) == [3, 2, 1];
 }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -73,6 +73,16 @@ fn foldl<A,B:copy,IA:iterable<A>>(self: IA, b0: B, blk: fn(B, A) -> B) -> B {
     ret b;
 }
 
+fn foldr<A:copy,B:copy,IA:iterable<A>>(
+    self: IA, b0: B, blk: fn(A, B) -> B) -> B {
+
+    let b = b0;
+    reverse(self) {|a|
+        b = blk(a, b);
+    }
+    ret b;
+}
+
 fn to_list<A:copy,IA:iterable<A>>(self: IA) -> [A] {
     foldl::<A,[A],IA>(self, [], {|r, a| r + [a]})
 }
@@ -238,4 +248,13 @@ fn test_reverse() {
 #[test]
 fn test_count() {
     assert count([1, 2, 1, 2, 1], 1) == 3u;
+}
+
+#[test]
+fn test_foldr() {
+    fn sub(&&a: int, &&b: int) -> int {
+        a - b
+    }
+    let sum = foldr([1, 2, 3, 4], 0, sub);
+    assert sum == -2;
 }


### PR DESCRIPTION
This adds min, max, reverse, count, and foldr functions to core::iter. foldr is implemented the slow way. I did some experimenting with a riterable interface but ran into some type checking problems.

The only thing interesting here is that I changed the signatures of foldl and foldr to move the accumulator value instead of copying.

@nikomatsakis have a look.
