### PR TITLE
(core::str) changes to find / find_bytes

### DIFF
--- a/src/comp/back/link.rs
+++ b/src/comp/back/link.rs
@@ -568,10 +568,11 @@ fn link_binary(sess: session,
     // Converts a library file name into a cc -l argument
     fn unlib(config: @session::config, filename: str) -> str unsafe {
         let rmlib = fn@(filename: str) -> str {
+            let found = str::find_bytes(filename, "lib");
             if config.os == session::os_macos ||
                 (config.os == session::os_linux ||
                  config.os == session::os_freebsd) &&
-                str::find(filename, "lib") == 0 {
+                option::is_some(found) && option::get(found) == 0u {
                 ret str::unsafe::slice_bytes(filename, 3u,
                                str::len_bytes(filename));
             } else { ret filename; }

--- a/src/comp/driver/driver.rs
+++ b/src/comp/driver/driver.rs
@@ -269,28 +269,28 @@ fn pretty_print_input(sess: session, cfg: ast::crate_cfg, input: str,
 }
 
 fn get_os(triple: str) -> option<session::os> {
-    ret if str::find(triple, "win32") >= 0 ||
-               str::find(triple, "mingw32") >= 0 {
+    ret if str::contains(triple, "win32") ||
+               str::contains(triple, "mingw32") {
             some(session::os_win32)
-        } else if str::find(triple, "darwin") >= 0 {
+        } else if str::contains(triple, "darwin") {
             some(session::os_macos)
-        } else if str::find(triple, "linux") >= 0 {
+        } else if str::contains(triple, "linux") {
             some(session::os_linux)
-        } else if str::find(triple, "freebsd") >= 0 {
+        } else if str::contains(triple, "freebsd") {
             some(session::os_freebsd)
         } else { none };
 }
 
 fn get_arch(triple: str) -> option<session::arch> {
-    ret if str::find(triple, "i386") >= 0 || str::find(triple, "i486") >= 0 ||
-               str::find(triple, "i586") >= 0 ||
-               str::find(triple, "i686") >= 0 ||
-               str::find(triple, "i786") >= 0 {
+    ret if str::contains(triple, "i386") || str::contains(triple, "i486") ||
+               str::contains(triple, "i586") ||
+               str::contains(triple, "i686") ||
+               str::contains(triple, "i786") {
             some(session::arch_x86)
-        } else if str::find(triple, "x86_64") >= 0 {
+        } else if str::contains(triple, "x86_64") {
             some(session::arch_x86_64)
-        } else if str::find(triple, "arm") >= 0 ||
-                      str::find(triple, "xscale") >= 0 {
+        } else if str::contains(triple, "arm") ||
+                      str::contains(triple, "xscale") {
             some(session::arch_arm)
         } else { none };
 }

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -24,9 +24,11 @@ fn load_errors(testfile: str) -> [expected_error] {
 
 fn parse_expected(line_num: uint, line: str) -> [expected_error] unsafe {
     let error_tag = "//!";
-    let idx0 = str::find(line, error_tag);
-    if idx0 < 0 { ret []; }
-    let idx = (idx0 as uint) + str::len_bytes(error_tag);
+    let idx;
+    alt str::find_bytes(line, error_tag) {
+         option::none { ret []; }
+         option::some(nn) { idx = (nn as uint) + str::len_bytes(error_tag); }
+    }
 
     // "//!^^^ kind msg" denotes a message expected
     // three lines above current line:

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -100,18 +100,21 @@ fn parse_pp_exact(line: str, testfile: str) -> option<str> {
 }
 
 fn parse_name_directive(line: str, directive: str) -> bool {
-    str::find(line, directive) >= 0
+    str::contains(line, directive)
 }
 
 fn parse_name_value_directive(line: str,
                               directive: str) -> option<str> unsafe {
     let keycolon = directive + ":";
-    if str::find(line, keycolon) >= 0 {
-        let colon = str::find(line, keycolon) as uint;
-        let value =
-            str::unsafe::slice_bytes(line, colon + str::len_bytes(keycolon),
-                       str::len_bytes(line));
-        #debug("%s: %s", directive,  value);
-        option::some(value)
-    } else { option::none }
+    alt str::find_bytes(line, keycolon) {
+        option::some(colon) {
+            let value =
+                str::unsafe::slice_bytes(line,
+                                         colon + str::len_bytes(keycolon),
+                                         str::len_bytes(line));
+            #debug("%s: %s", directive,  value);
+            option::some(value)
+        }
+        option::none { option::none }
+    }
 }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -199,7 +199,7 @@ fn check_error_patterns(props: test_props,
     let next_err_idx = 0u;
     let next_err_pat = props.error_patterns[next_err_idx];
     for line: str in str::split_byte(procres.stderr, '\n' as u8) {
-        if str::find(line, next_err_pat) > 0 {
+        if str::contains(line, next_err_pat) {
             #debug("found error pattern %s", next_err_pat);
             next_err_idx += 1u;
             if next_err_idx == vec::len(props.error_patterns) {

--- a/src/fuzzer/fuzzer.rs
+++ b/src/fuzzer/fuzzer.rs
@@ -16,7 +16,7 @@ fn write_file(filename: str, content: str) {
 }
 
 fn contains(haystack: str, needle: str) -> bool {
-    str::find(haystack, needle) != -1
+    str::contains(haystack, needle)
 }
 
 fn find_rust_files(&files: [str], path: str) {

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -908,6 +908,39 @@ fn find(haystack: str, needle: str) -> int {
     ret -1;
 }
 
+// Function: find_chars
+//
+// Find the character position of the first instance of the substring,
+// or return option::none
+//
+// FIXME: rename find_chars -> find,
+//               find -> find_bytes
+fn find_chars(hay: str, pin: str) -> option<uint> {
+   alt find(hay, pin) {
+      -1 { ret option::none; }
+       n { ret option::some(b2c_pos(hay, n as uint)); }
+   }
+}
+
+// Function: b2c_pos
+//
+// Convert a byte position into a char position
+// within a given string
+fn b2c_pos(ss: str, bpos: uint) -> uint {
+   assert bpos < len_bytes(ss);
+
+   let ii = 0u;
+   let cpos = 0u;
+
+   while ii < bpos {
+      let sz = utf8_char_width(ss[ii]);
+      ii += sz;
+      cpos += 1u;
+   }
+
+   ret cpos;
+}
+
 /*
 Function: contains
 
@@ -1716,6 +1749,23 @@ mod tests {
         assert (find(data, "ะเ")   ==  6); // byte position
         assert (find(data, "中华") ==  27); // byte position
         assert (find(data, "ไท华") == -1);
+    }
+
+    #[test]
+    fn test_find_chars() {
+        let data = "ประเทศไทย中华Việt Nam";
+        assert (find_chars(data, "ประเ") == option::some(0u));
+        assert (find_chars(data, "ะเ")   == option::some(2u));
+        assert (find_chars(data, "中华") == option::some(9u));
+        assert (find_chars(data, "ไท华") == option::none);
+    }
+
+    #[test]
+    fn test_b2c_pos() {
+        let data = "ประเทศไทย中华Việt Nam";
+        assert 0u == b2c_pos(data, 0u);
+        assert 2u == b2c_pos(data, 6u);
+        assert 9u == b2c_pos(data, 27u);
     }
 
     #[test]

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -932,12 +932,12 @@ Parameters:
 haystack - The string to look in
 needle - The string to look for
 */
-fn starts_with(haystack: str, needle: str) -> bool {
-    let haystack_len: uint = len(haystack);
-    let needle_len: uint = len(needle);
+fn starts_with(haystack: str, needle: str) -> bool unsafe {
+    let haystack_len: uint = len_bytes(haystack);
+    let needle_len: uint = len_bytes(needle);
     if needle_len == 0u { ret true; }
     if needle_len > haystack_len { ret false; }
-    ret eq(substr(haystack, 0u, needle_len), needle);
+    ret eq(unsafe::slice_bytes(haystack, 0u, needle_len), needle);
 }
 
 /*

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -920,7 +920,7 @@ fn find(haystack: str, needle: str) -> option<uint> {
 // Convert a byte position into a char position
 // within a given string
 fn b2c_pos(ss: str, bpos: uint) -> uint {
-   assert bpos < len_bytes(ss);
+   assert bpos == 0u || bpos < len_bytes(ss);
 
    let ii = 0u;
    let cpos = 0u;
@@ -1725,6 +1725,9 @@ mod tests {
     #[test]
     fn test_find_bytes() {
         // byte positions
+        assert (find_bytes("banana", "apple pie") == option::none);
+        assert (find_bytes("", "") == option::some(0u));
+
         let data = "ประเทศไทย中华Việt Nam";
         assert (find_bytes(data, "")     == option::some(0u));
         assert (find_bytes(data, "ประเ") == option::some( 0u));
@@ -1736,6 +1739,9 @@ mod tests {
     #[test]
     fn test_find() {
         // char positions
+        assert (find("banana", "apple pie") == option::none);
+        assert (find("", "") == option::some(0u));
+
         let data = "ประเทศไทย中华Việt Nam";
         assert (find(data, "")     == option::some(0u));
         assert (find(data, "ประเ") == option::some(0u));

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -880,6 +880,8 @@ fn rindex(ss: str, cc: char) -> option<uint> {
 //
 // Find the char position of the first instance of one string
 // within another, or return option::none
+//
+// FIXME: Boyer-Moore should be significantly faster
 fn find_bytes(haystack: str, needle: str) -> option<uint> {
     let haystack_len = len_bytes(haystack);
     let needle_len   = len_bytes(needle);

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -258,7 +258,7 @@ fn filter_tests(opts: test_opts,
 
         fn filter_fn(test: test_desc, filter_str: str) ->
             option<test_desc> {
-            if str::find(test.name, filter_str) >= 0 {
+            if str::contains(test.name, filter_str) {
                 ret option::some(test);
             } else { ret option::none; }
         }

--- a/src/rustdoc/markdown_pass.rs
+++ b/src/rustdoc/markdown_pass.rs
@@ -56,10 +56,10 @@ fn should_write_modules_last() {
          fn d() { }"
     );
 
-    let idx_a = str::find(markdown, "# Module `a`");
-    let idx_b = str::find(markdown, "## Function `b`");
-    let idx_c = str::find(markdown, "# Module `c`");
-    let idx_d = str::find(markdown, "## Function `d`");
+    let idx_a = option::get(str::find_bytes(markdown, "# Module `a`"));
+    let idx_b = option::get(str::find_bytes(markdown, "## Function `b`"));
+    let idx_c = option::get(str::find_bytes(markdown, "# Module `c`"));
+    let idx_d = option::get(str::find_bytes(markdown, "## Function `d`"));
 
     assert idx_b < idx_d;
     assert idx_d < idx_a;


### PR DESCRIPTION
As a result of these commits:
- starts_with will use slice_bytes to be a little bit faster
- the b2c_pos (to convert byte positions to character positions) will be added
- find and find_bytes return option types with char and byte positions, respectively
