### PR TITLE
Crust functions

### DIFF
--- a/src/comp/back/upcall.rs
+++ b/src/comp/back/upcall.rs
@@ -28,6 +28,7 @@ type upcalls =
      dynastack_free: ValueRef,
      alloc_c_stack: ValueRef,
      call_shim_on_c_stack: ValueRef,
+     call_shim_on_rust_stack: ValueRef,
      rust_personality: ValueRef,
      reset_stack_limit: ValueRef};
 
@@ -106,6 +107,9 @@ fn declare_upcalls(targ_cfg: @session::config,
                 // arguments: void *args, void *fn_ptr
                 [T_ptr(T_i8()), T_ptr(T_i8())],
                 int_t),
+          call_shim_on_rust_stack:
+              d("call_shim_on_rust_stack",
+                [T_ptr(T_i8()), T_ptr(T_i8())], int_t),
           rust_personality:
               d("rust_personality", [], T_i32()),
           reset_stack_limit:

--- a/src/comp/metadata/encoder.rs
+++ b/src/comp/metadata/encoder.rs
@@ -312,7 +312,12 @@ fn encode_info_for_mod(ecx: @encode_ctxt, ebml_w: ebml::writer, md: _mod,
 }
 
 fn purity_fn_family(p: purity) -> char {
-    alt p { unsafe_fn { 'u' } pure_fn { 'p' } impure_fn { 'f' } }
+    alt p {
+      unsafe_fn { 'u' }
+      pure_fn { 'p' }
+      impure_fn { 'f' }
+      crust_fn { 'c' }
+    }
 }
 
 fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: ebml::writer, item: @item,

--- a/src/comp/middle/trans/base.rs
+++ b/src/comp/middle/trans/base.rs
@@ -4460,180 +4460,6 @@ fn trans_const(cx: @crate_ctxt, e: @ast::expr, id: ast::node_id) {
     }
 }
 
-type c_stack_tys = {
-    arg_tys: [TypeRef],
-    ret_ty: TypeRef,
-    ret_def: bool,
-    base_fn_ty: TypeRef,
-    bundle_ty: TypeRef,
-    shim_fn_ty: TypeRef
-};
-
-fn c_stack_tys(ccx: @crate_ctxt,
-               id: ast::node_id) -> @c_stack_tys {
-    alt ty::get(ty::node_id_to_type(ccx.tcx, id)).struct {
-      ty::ty_fn({inputs: arg_tys, output: ret_ty, _}) {
-        let llargtys = type_of_explicit_args(ccx, arg_tys);
-        let llretty = type_of(ccx, ret_ty);
-        let bundle_ty = T_struct(llargtys + [T_ptr(llretty)]);
-        ret @{
-            arg_tys: llargtys,
-            ret_ty: llretty,
-            ret_def: !ty::type_is_bot(ret_ty) && !ty::type_is_nil(ret_ty),
-            base_fn_ty: T_fn(llargtys, llretty),
-            bundle_ty: bundle_ty,
-            shim_fn_ty: T_fn([T_ptr(bundle_ty)], T_void())
-        };
-      }
-      _ {
-          // Precondition?
-          ccx.tcx.sess.bug("c_stack_tys called on non-function type");
-      }
-    }
-}
-
-// For each native function F, we generate a wrapper function W and a shim
-// function S that all work together.  The wrapper function W is the function
-// that other rust code actually invokes.  Its job is to marshall the
-// arguments into a struct.  It then uses a small bit of assembly to switch
-// over to the C stack and invoke the shim function.  The shim function S then
-// unpacks the arguments from the struct and invokes the actual function F
-// according to its specified calling convention.
-//
-// Example: Given a native c-stack function F(x: X, y: Y) -> Z,
-// we generate a wrapper function W that looks like:
-//
-//    void W(Z* dest, void *env, X x, Y y) {
-//        struct { X x; Y y; Z *z; } args = { x, y, z };
-//        call_on_c_stack_shim(S, &args);
-//    }
-//
-// The shim function S then looks something like:
-//
-//     void S(struct { X x; Y y; Z *z; } *args) {
-//         *args->z = F(args->x, args->y);
-//     }
-//
-// However, if the return type of F is dynamically sized or of aggregate type,
-// the shim function looks like:
-//
-//     void S(struct { X x; Y y; Z *z; } *args) {
-//         F(args->z, args->x, args->y);
-//     }
-//
-// Note: on i386, the layout of the args struct is generally the same as the
-// desired layout of the arguments on the C stack.  Therefore, we could use
-// upcall_alloc_c_stack() to allocate the `args` structure and switch the
-// stack pointer appropriately to avoid a round of copies.  (In fact, the shim
-// function itself is unnecessary). We used to do this, in fact, and will
-// perhaps do so in the future.
-fn trans_native_mod(ccx: @crate_ctxt,
-                    native_mod: ast::native_mod, abi: ast::native_abi) {
-    fn build_shim_fn(ccx: @crate_ctxt,
-                     native_item: @ast::native_item,
-                     tys: @c_stack_tys,
-                     cc: lib::llvm::CallConv) -> ValueRef {
-        let lname = link_name(native_item);
-
-        // Declare the "prototype" for the base function F:
-        let llbasefn = decl_fn(ccx.llmod, lname, cc, tys.base_fn_ty);
-
-        // Create the shim function:
-        let shim_name = lname + "__c_stack_shim";
-        let llshimfn = decl_internal_cdecl_fn(
-            ccx.llmod, shim_name, tys.shim_fn_ty);
-
-        // Declare the body of the shim function:
-        let fcx = new_fn_ctxt(ccx, [], llshimfn, none);
-        let bcx = new_top_block_ctxt(fcx, none);
-        let lltop = bcx.llbb;
-        let llargbundle = llvm::LLVMGetParam(llshimfn, 0 as c_uint);
-        let i = 0u, n = vec::len(tys.arg_tys);
-        let llargvals = [];
-        while i < n {
-            let llargval = load_inbounds(bcx, llargbundle, [0, i as int]);
-            llargvals += [llargval];
-            i += 1u;
-        }
-
-        // Create the call itself and store the return value:
-        let llretval = CallWithConv(bcx, llbasefn,
-                                    llargvals, cc); // r
-        if tys.ret_def {
-            // R** llretptr = &args->r;
-            let llretptr = GEPi(bcx, llargbundle, [0, n as int]);
-            // R* llretloc = *llretptr; /* (args->r) */
-            let llretloc = Load(bcx, llretptr);
-            // *args->r = r;
-            Store(bcx, llretval, llretloc);
-        }
-
-        // Finish up:
-        build_return(bcx);
-        finish_fn(fcx, lltop);
-
-        ret llshimfn;
-    }
-
-    fn build_wrap_fn(ccx: @crate_ctxt,
-                     tys: @c_stack_tys,
-                     num_tps: uint,
-                     llshimfn: ValueRef,
-                     llwrapfn: ValueRef) {
-        let fcx = new_fn_ctxt(ccx, [], llwrapfn, none);
-        let bcx = new_top_block_ctxt(fcx, none);
-        let lltop = bcx.llbb;
-
-        // Allocate the struct and write the arguments into it.
-        let llargbundle = alloca(bcx, tys.bundle_ty);
-        let i = 0u, n = vec::len(tys.arg_tys);
-        let implicit_args = 2u + num_tps; // ret + env
-        while i < n {
-            let llargval = llvm::LLVMGetParam(llwrapfn,
-                                              (i + implicit_args) as c_uint);
-            store_inbounds(bcx, llargval, llargbundle, [0, i as int]);
-            i += 1u;
-        }
-        let llretptr = llvm::LLVMGetParam(llwrapfn, 0 as c_uint);
-        store_inbounds(bcx, llretptr, llargbundle, [0, n as int]);
-
-        // Create call itself.
-        let call_shim_on_c_stack = ccx.upcalls.call_shim_on_c_stack;
-        let llshimfnptr = PointerCast(bcx, llshimfn, T_ptr(T_i8()));
-        let llrawargbundle = PointerCast(bcx, llargbundle, T_ptr(T_i8()));
-        Call(bcx, call_shim_on_c_stack, [llrawargbundle, llshimfnptr]);
-        build_return(bcx);
-        finish_fn(fcx, lltop);
-    }
-
-    let cc = lib::llvm::CCallConv;
-    alt abi {
-      ast::native_abi_rust_intrinsic { ret; }
-      ast::native_abi_cdecl { cc = lib::llvm::CCallConv; }
-      ast::native_abi_stdcall { cc = lib::llvm::X86StdcallCallConv; }
-    }
-
-    for native_item in native_mod.items {
-      alt native_item.node {
-        ast::native_item_fn(fn_decl, tps) {
-          let id = native_item.id;
-          let tys = c_stack_tys(ccx, id);
-          alt ccx.item_ids.find(id) {
-            some(llwrapfn) {
-              let llshimfn = build_shim_fn(ccx, native_item, tys, cc);
-              build_wrap_fn(ccx, tys, vec::len(tps), llshimfn, llwrapfn);
-            }
-            none {
-              ccx.sess.span_fatal(
-                  native_item.span,
-                  "unbound function item in trans_native_mod");
-            }
-          }
-        }
-      }
-    }
-}
-
 fn trans_item(ccx: @crate_ctxt, item: ast::item) {
     let path = alt ccx.tcx.items.get(item.id) {
       ast_map::node_item(_, p) { p }
@@ -4692,7 +4518,7 @@ fn trans_item(ccx: @crate_ctxt, item: ast::item) {
           either::right(abi_) { abi_ }
           either::left(msg) { ccx.sess.span_fatal(item.span, msg) }
         };
-        trans_native_mod(ccx, native_mod, abi);
+        native::trans_native_mod(ccx, native_mod, abi);
       }
       _ {/* fall through */ }
     }
@@ -4839,13 +4665,6 @@ fn fill_fn_pair(bcx: @block_ctxt, pair: ValueRef, llfn: ValueRef,
     Store(bcx, llenvblobptr, env_cell);
 }
 
-fn link_name(i: @ast::native_item) -> str {
-    alt attr::get_meta_item_value_str_by_name(i.attrs, "link_name") {
-      none { ret i.ident; }
-      option::some(ln) { ret ln; }
-    }
-}
-
 fn collect_native_item(ccx: @crate_ctxt,
                        abi: @mutable option<ast::native_abi>,
                        i: @ast::native_item) {
@@ -4874,7 +4693,7 @@ fn collect_native_item(ccx: @crate_ctxt,
             let fn_type = type_of_fn_from_ty(
                 ccx, node_type,
                 vec::map(tps, {|p| param_bounds(ccx, p)}));
-            let ri_name = "rust_intrinsic_" + link_name(i);
+            let ri_name = "rust_intrinsic_" + native::link_name(i);
             let llnativefn = get_extern_fn(
                 ccx.externs, ccx.llmod, ri_name,
                 lib::llvm::CCallConv, fn_type);

--- a/src/comp/middle/trans/base.rs
+++ b/src/comp/middle/trans/base.rs
@@ -4195,14 +4195,17 @@ fn copy_args_to_allocas(fcx: @fn_ctxt, bcx: @block_ctxt, args: [ast::arg],
 // Ties up the llstaticallocas -> llloadenv -> llderivedtydescs ->
 // lldynamicallocas -> lltop edges, and builds the return block.
 fn finish_fn(fcx: @fn_ctxt, lltop: BasicBlockRef) {
+    tie_up_header_blocks(fcx, lltop);
+    let ret_cx = new_raw_block_ctxt(fcx, fcx.llreturn);
+    trans_fn_cleanups(fcx, ret_cx);
+    RetVoid(ret_cx);
+}
+
+fn tie_up_header_blocks(fcx: @fn_ctxt, lltop: BasicBlockRef) {
     Br(new_raw_block_ctxt(fcx, fcx.llstaticallocas), fcx.llloadenv);
     Br(new_raw_block_ctxt(fcx, fcx.llloadenv), fcx.llderivedtydescs_first);
     Br(new_raw_block_ctxt(fcx, fcx.llderivedtydescs), fcx.lldynamicallocas);
     Br(new_raw_block_ctxt(fcx, fcx.lldynamicallocas), lltop);
-
-    let ret_cx = new_raw_block_ctxt(fcx, fcx.llreturn);
-    trans_fn_cleanups(fcx, ret_cx);
-    RetVoid(ret_cx);
 }
 
 enum self_arg { impl_self(ty::t), no_self, }
@@ -4554,13 +4557,20 @@ fn param_bounds(ccx: @crate_ctxt, tp: ast::ty_param) -> ty::param_bounds {
     ccx.tcx.ty_param_bounds.get(tp.id)
 }
 
-fn register_fn_full(ccx: @crate_ctxt, sp: span, path: path, _flav: str,
+fn register_fn_full(ccx: @crate_ctxt, sp: span, path: path, flav: str,
                     tps: [ast::ty_param], node_id: ast::node_id,
                     node_type: ty::t) {
     let llfty = type_of_fn_from_ty(ccx, node_type,
                                    vec::map(tps, {|p| param_bounds(ccx, p)}));
+    register_fn_fuller(ccx, sp, path, flav, node_id, node_type,
+                       lib::llvm::CCallConv, llfty);
+}
+
+fn register_fn_fuller(ccx: @crate_ctxt, sp: span, path: path, _flav: str,
+                      node_id: ast::node_id, node_type: ty::t,
+                      cc: lib::llvm::CallConv, llfty: TypeRef) {
     let ps: str = mangle_exported_name(ccx, path, node_type);
-    let llfn: ValueRef = decl_cdecl_fn(ccx.llmod, ps, llfty);
+    let llfn: ValueRef = decl_fn(ccx.llmod, ps, cc, llfty);
     ccx.item_ids.insert(node_id, llfn);
     ccx.item_symbols.insert(node_id, ps);
 
@@ -4749,9 +4759,13 @@ fn collect_item(ccx: @crate_ctxt, abi: @mutable option<ast::native_abi>,
           either::right(abi_) { *abi = option::some(abi_); }
         }
       }
-      ast::item_fn(_, tps, _) {
-        register_fn(ccx, i.span, my_path, "fn", tps,
-                    i.id);
+      ast::item_fn(decl, tps, _) {
+        if decl.purity != ast::crust_fn {
+            register_fn(ccx, i.span, my_path, "fn", tps,
+                        i.id);
+        } else {
+            native::register_crust_fn(ccx, i.span, my_path, i.id);
+        }
       }
       ast::item_impl(tps, _, _, methods) {
         let path = my_path + [path_name(int::str(i.id))];

--- a/src/comp/middle/trans/base.rs
+++ b/src/comp/middle/trans/base.rs
@@ -2339,6 +2339,19 @@ fn lval_static_fn(bcx: @block_ctxt, fn_id: ast::def_id, id: ast::node_id,
         // External reference.
         trans_external_path(bcx, fn_id, tpt)
     };
+
+    // FIXME: Need to support external crust functions
+    if fn_id.crate == ast::local_crate {
+        alt bcx_tcx(bcx).def_map.find(id) {
+          some(ast::def_fn(_, ast::crust_fn)) {
+            // Crust functions are just opaque pointers
+            let val = PointerCast(bcx, val, T_ptr(T_i8()));
+            ret lval_no_env(bcx, val, owned_imm);
+          }
+          _ { }
+        }
+    }
+
     let gen = generic_none, bcx = bcx;
     if vec::len(tys) > 0u {
         let tydescs = [], tis = [];

--- a/src/comp/middle/trans/base.rs
+++ b/src/comp/middle/trans/base.rs
@@ -4467,15 +4467,19 @@ fn trans_item(ccx: @crate_ctxt, item: ast::item) {
     };
     alt item.node {
       ast::item_fn(decl, tps, body) {
-        alt ccx.item_ids.find(item.id) {
-          some(llfndecl) {
-            trans_fn(ccx, *path + [path_name(item.ident)], decl, body,
-                     llfndecl, no_self, tps, none, item.id);
-          }
+        let llfndecl = alt ccx.item_ids.find(item.id) {
+          some(llfndecl) { llfndecl }
           _ {
             ccx.sess.span_fatal(item.span,
                                 "unbound function item in trans_item");
           }
+        };
+        if decl.purity != ast::crust_fn  {
+            trans_fn(ccx, *path + [path_name(item.ident)], decl, body,
+                     llfndecl, no_self, tps, none, item.id);
+        } else {
+            native::trans_crust_fn(ccx, *path + [path_name(item.ident)],
+                                   decl, body, llfndecl, item.id);
         }
       }
       ast::item_impl(tps, _, _, ms) {

--- a/src/comp/middle/trans/native.rs
+++ b/src/comp/middle/trans/native.rs
@@ -1,0 +1,191 @@
+import driver::session::session;
+import ctypes::c_uint;
+import front::attr;
+import lib::llvm::{ llvm, TypeRef, ValueRef };
+import syntax::ast;
+import common::*;
+import build::*;
+import base::*;
+
+export link_name, trans_native_mod;
+
+fn link_name(i: @ast::native_item) -> str {
+    alt attr::get_meta_item_value_str_by_name(i.attrs, "link_name") {
+      none { ret i.ident; }
+      option::some(ln) { ret ln; }
+    }
+}
+
+type c_stack_tys = {
+    arg_tys: [TypeRef],
+    ret_ty: TypeRef,
+    ret_def: bool,
+    base_fn_ty: TypeRef,
+    bundle_ty: TypeRef,
+    shim_fn_ty: TypeRef
+};
+
+fn c_stack_tys(ccx: @crate_ctxt,
+               id: ast::node_id) -> @c_stack_tys {
+    alt ty::get(ty::node_id_to_type(ccx.tcx, id)).struct {
+      ty::ty_fn({inputs: arg_tys, output: ret_ty, _}) {
+        let llargtys = type_of_explicit_args(ccx, arg_tys);
+        let llretty = type_of(ccx, ret_ty);
+        let bundle_ty = T_struct(llargtys + [T_ptr(llretty)]);
+        ret @{
+            arg_tys: llargtys,
+            ret_ty: llretty,
+            ret_def: !ty::type_is_bot(ret_ty) && !ty::type_is_nil(ret_ty),
+            base_fn_ty: T_fn(llargtys, llretty),
+            bundle_ty: bundle_ty,
+            shim_fn_ty: T_fn([T_ptr(bundle_ty)], T_void())
+        };
+      }
+      _ {
+          // Precondition?
+          ccx.tcx.sess.bug("c_stack_tys called on non-function type");
+      }
+    }
+}
+
+// For each native function F, we generate a wrapper function W and a shim
+// function S that all work together.  The wrapper function W is the function
+// that other rust code actually invokes.  Its job is to marshall the
+// arguments into a struct.  It then uses a small bit of assembly to switch
+// over to the C stack and invoke the shim function.  The shim function S then
+// unpacks the arguments from the struct and invokes the actual function F
+// according to its specified calling convention.
+//
+// Example: Given a native c-stack function F(x: X, y: Y) -> Z,
+// we generate a wrapper function W that looks like:
+//
+//    void W(Z* dest, void *env, X x, Y y) {
+//        struct { X x; Y y; Z *z; } args = { x, y, z };
+//        call_on_c_stack_shim(S, &args);
+//    }
+//
+// The shim function S then looks something like:
+//
+//     void S(struct { X x; Y y; Z *z; } *args) {
+//         *args->z = F(args->x, args->y);
+//     }
+//
+// However, if the return type of F is dynamically sized or of aggregate type,
+// the shim function looks like:
+//
+//     void S(struct { X x; Y y; Z *z; } *args) {
+//         F(args->z, args->x, args->y);
+//     }
+//
+// Note: on i386, the layout of the args struct is generally the same as the
+// desired layout of the arguments on the C stack.  Therefore, we could use
+// upcall_alloc_c_stack() to allocate the `args` structure and switch the
+// stack pointer appropriately to avoid a round of copies.  (In fact, the shim
+// function itself is unnecessary). We used to do this, in fact, and will
+// perhaps do so in the future.
+fn trans_native_mod(ccx: @crate_ctxt,
+                    native_mod: ast::native_mod, abi: ast::native_abi) {
+    fn build_shim_fn(ccx: @crate_ctxt,
+                     native_item: @ast::native_item,
+                     tys: @c_stack_tys,
+                     cc: lib::llvm::CallConv) -> ValueRef {
+        let lname = link_name(native_item);
+
+        // Declare the "prototype" for the base function F:
+        let llbasefn = decl_fn(ccx.llmod, lname, cc, tys.base_fn_ty);
+
+        // Create the shim function:
+        let shim_name = lname + "__c_stack_shim";
+        let llshimfn = decl_internal_cdecl_fn(
+            ccx.llmod, shim_name, tys.shim_fn_ty);
+
+        // Declare the body of the shim function:
+        let fcx = new_fn_ctxt(ccx, [], llshimfn, none);
+        let bcx = new_top_block_ctxt(fcx, none);
+        let lltop = bcx.llbb;
+        let llargbundle = llvm::LLVMGetParam(llshimfn, 0 as c_uint);
+        let i = 0u, n = vec::len(tys.arg_tys);
+        let llargvals = [];
+        while i < n {
+            let llargval = load_inbounds(bcx, llargbundle, [0, i as int]);
+            llargvals += [llargval];
+            i += 1u;
+        }
+
+        // Create the call itself and store the return value:
+        let llretval = CallWithConv(bcx, llbasefn,
+                                    llargvals, cc); // r
+        if tys.ret_def {
+            // R** llretptr = &args->r;
+            let llretptr = GEPi(bcx, llargbundle, [0, n as int]);
+            // R* llretloc = *llretptr; /* (args->r) */
+            let llretloc = Load(bcx, llretptr);
+            // *args->r = r;
+            Store(bcx, llretval, llretloc);
+        }
+
+        // Finish up:
+        build_return(bcx);
+        finish_fn(fcx, lltop);
+
+        ret llshimfn;
+    }
+
+    fn build_wrap_fn(ccx: @crate_ctxt,
+                     tys: @c_stack_tys,
+                     num_tps: uint,
+                     llshimfn: ValueRef,
+                     llwrapfn: ValueRef) {
+        let fcx = new_fn_ctxt(ccx, [], llwrapfn, none);
+        let bcx = new_top_block_ctxt(fcx, none);
+        let lltop = bcx.llbb;
+
+        // Allocate the struct and write the arguments into it.
+        let llargbundle = alloca(bcx, tys.bundle_ty);
+        let i = 0u, n = vec::len(tys.arg_tys);
+        let implicit_args = 2u + num_tps; // ret + env
+        while i < n {
+            let llargval = llvm::LLVMGetParam(llwrapfn,
+                                              (i + implicit_args) as c_uint);
+            store_inbounds(bcx, llargval, llargbundle, [0, i as int]);
+            i += 1u;
+        }
+        let llretptr = llvm::LLVMGetParam(llwrapfn, 0 as c_uint);
+        store_inbounds(bcx, llretptr, llargbundle, [0, n as int]);
+
+        // Create call itself.
+        let call_shim_on_c_stack = ccx.upcalls.call_shim_on_c_stack;
+        let llshimfnptr = PointerCast(bcx, llshimfn, T_ptr(T_i8()));
+        let llrawargbundle = PointerCast(bcx, llargbundle, T_ptr(T_i8()));
+        Call(bcx, call_shim_on_c_stack, [llrawargbundle, llshimfnptr]);
+        build_return(bcx);
+        finish_fn(fcx, lltop);
+    }
+
+    let cc = lib::llvm::CCallConv;
+    alt abi {
+      ast::native_abi_rust_intrinsic { ret; }
+      ast::native_abi_cdecl { cc = lib::llvm::CCallConv; }
+      ast::native_abi_stdcall { cc = lib::llvm::X86StdcallCallConv; }
+    }
+
+    for native_item in native_mod.items {
+      alt native_item.node {
+        ast::native_item_fn(fn_decl, tps) {
+          let id = native_item.id;
+          let tys = c_stack_tys(ccx, id);
+          alt ccx.item_ids.find(id) {
+            some(llwrapfn) {
+              let llshimfn = build_shim_fn(ccx, native_item, tys, cc);
+              build_wrap_fn(ccx, tys, vec::len(tps), llshimfn, llwrapfn);
+            }
+            none {
+              ccx.sess.span_fatal(
+                  native_item.span,
+                  "unbound function item in trans_native_mod");
+            }
+          }
+        }
+      }
+    }
+}

--- a/src/comp/middle/trans/native.rs
+++ b/src/comp/middle/trans/native.rs
@@ -7,7 +7,7 @@ import common::*;
 import build::*;
 import base::*;
 
-export link_name, trans_native_mod;
+export link_name, trans_native_mod, trans_crust_fn;
 
 fn link_name(i: @ast::native_item) -> str {
     alt attr::get_meta_item_value_str_by_name(i.attrs, "link_name") {
@@ -188,4 +188,9 @@ fn trans_native_mod(ccx: @crate_ctxt,
         }
       }
     }
+}
+
+fn trans_crust_fn(ccx: @crate_ctxt, path: ast_map::path, decl: ast::fn_decl,
+                  body: ast::blk, llfndecl: ValueRef, id: ast::node_id) {
+    trans_fn(ccx, path, decl, body, llfndecl, no_self, [], none, id)
 }

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -107,6 +107,18 @@ fn ty_param_bounds_and_ty_for_def(fcx: @fn_ctxt, sp: span, defn: ast::def) ->
           }
         }
       }
+      ast::def_fn(id, ast::crust_fn) {
+        // Crust functions are just u8 pointers
+        ret {
+            bounds: @[],
+            ty: ty::mk_ptr(
+                fcx.ccx.tcx,
+                {
+                    ty: ty::mk_mach_uint(fcx.ccx.tcx, ast::ty_u8),
+                    mut: ast::imm
+                })
+        };
+      }
       ast::def_fn(id, _) | ast::def_const(id) |
       ast::def_variant(_, id) | ast::def_class(id)
           | ast::def_class_method(_, id) | ast::def_class_field(_, id)

--- a/src/comp/middle/typeck.rs
+++ b/src/comp/middle/typeck.rs
@@ -1535,7 +1535,7 @@ fn require_unsafe(sess: session, f_purity: ast::purity, sp: span) {
 fn require_impure(sess: session, f_purity: ast::purity, sp: span) {
     alt f_purity {
       ast::unsafe_fn { ret; }
-      ast::impure_fn { ret; }
+      ast::impure_fn | ast::crust_fn { ret; }
       ast::pure_fn {
         sess.span_err(sp, "Found impure expression in pure function decl");
       }
@@ -1568,7 +1568,7 @@ fn require_pure_call(ccx: @crate_ctxt, caller_purity: ast::purity,
       }
     };
     alt (caller_purity, callee_purity) {
-      (ast::impure_fn, ast::unsafe_fn) {
+      (ast::impure_fn, ast::unsafe_fn) | (ast::crust_fn, ast::unsafe_fn) {
         ccx.tcx.sess.span_err(sp, "safe function calls function marked \
                                    unsafe");
       }

--- a/src/comp/rustc.rc
+++ b/src/comp/rustc.rc
@@ -23,6 +23,7 @@ mod middle {
         mod closure;
         mod tvec;
         mod impl;
+        mod native;
     }
     mod ty;
     mod ast_map;

--- a/src/comp/syntax/ast.rs
+++ b/src/comp/syntax/ast.rs
@@ -407,6 +407,7 @@ enum purity {
     pure_fn, // declared with "pure fn"
     unsafe_fn, // declared with "unsafe fn"
     impure_fn, // declared with "fn"
+    crust_fn, // declared with "crust fn"
 }
 
 enum ret_style {

--- a/src/comp/syntax/parse/parser.rs
+++ b/src/comp/syntax/parse/parser.rs
@@ -150,7 +150,7 @@ fn bad_expr_word_table() -> hashmap<str, ()> {
                  "export", "fail", "fn", "for", "if",  "iface", "impl",
                  "import", "let", "log", "mod", "mutable", "native", "pure",
                  "resource", "ret", "trait", "type", "unchecked", "unsafe",
-                 "while"] {
+                 "while, crust"] {
         words.insert(word, ());
     }
     words
@@ -2276,6 +2276,9 @@ fn parse_item(p: parser, attrs: [ast::attribute]) -> option<@ast::item> {
         p.bump();
         expect_word(p, "fn");
         ret some(parse_item_fn(p, ast::unsafe_fn, attrs));
+    } else if eat_word(p, "crust") {
+        expect_word(p, "fn");
+        ret some(parse_item_fn(p, ast::crust_fn, attrs));
     } else if eat_word(p, "mod") {
         ret some(parse_item_mod(p, attrs));
     } else if eat_word(p, "native") {

--- a/src/comp/syntax/print/pprust.rs
+++ b/src/comp/syntax/print/pprust.rs
@@ -1199,6 +1199,7 @@ fn print_fn(s: ps, decl: ast::fn_decl, name: ast::ident,
       ast::impure_fn { head(s, "fn"); }
       ast::unsafe_fn { head(s, "unsafe fn"); }
       ast::pure_fn { head(s, "pure fn"); }
+      ast::crust_fn { head(s, "crust fn"); }
     }
     word(s.s, name);
     print_type_params(s, typarams);

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -576,7 +576,7 @@ port_recv(uintptr_t *dptr, rust_port *port,
 
         // If this task has been killed then we're not going to bother
         // blocking, we have to unwind.
-        if (task->killed) {
+        if (task->must_fail_from_being_killed()) {
             *killed = true;
             return;
         }

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -657,8 +657,8 @@ rust_dbg_lock_signal(lock_and_signal *lock) {
 typedef void *(*dbg_callback)(void*);
 
 extern "C" CDECL void *
-rust_dbg_call(dbg_callback *cb, void *data) {
-    return (*cb)(data);
+rust_dbg_call(dbg_callback cb, void *data) {
+    return cb(data);
 }
 
 //

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -654,6 +654,13 @@ rust_dbg_lock_signal(lock_and_signal *lock) {
     lock->signal();
 }
 
+typedef void *(*dbg_callback)(void*);
+
+extern "C" CDECL void *
+rust_dbg_call(dbg_callback *cb, void *data) {
+    return (*cb)(data);
+}
+
 //
 // Local Variables:
 // mode: C++

--- a/src/rt/rust_task.h
+++ b/src/rt/rust_task.h
@@ -231,6 +231,7 @@ rust_task::call_on_c_stack(void *args, void *fn_ptr) {
     // Too expensive to check
     // I(thread, on_rust_stack());
 
+    uintptr_t prev_rust_sp = next_rust_sp;
     next_rust_sp = get_sp();
 
     bool borrowed_a_c_stack = false;
@@ -251,6 +252,8 @@ rust_task::call_on_c_stack(void *args, void *fn_ptr) {
     if (borrowed_a_c_stack) {
         return_c_stack();
     }
+
+    next_rust_sp = prev_rust_sp;
 }
 
 inline void
@@ -259,11 +262,14 @@ rust_task::call_on_rust_stack(void *args, void *fn_ptr) {
     // I(thread, !on_rust_stack());
     I(thread, next_rust_sp);
 
+    uintptr_t prev_c_sp = next_c_sp;
     next_c_sp = get_sp();
 
     uintptr_t sp = sanitize_next_sp(next_rust_sp);
 
     __morestack(args, fn_ptr, sp);
+
+    next_c_sp = prev_c_sp;
 }
 
 inline void

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -104,3 +104,4 @@ rust_dbg_lock_lock
 rust_dbg_lock_unlock
 rust_dbg_lock_wait
 rust_dbg_lock_signal
+rust_dbg_call

--- a/src/test/compile-fail/crust-no-bind.rs
+++ b/src/test/compile-fail/crust-no-bind.rs
@@ -1,0 +1,7 @@
+// error-pattern:expected function or native function but found *u8
+crust fn f() {
+}
+
+fn main() {
+    let x = bind f();
+}

--- a/src/test/compile-fail/crust-no-call.rs
+++ b/src/test/compile-fail/crust-no-call.rs
@@ -1,0 +1,7 @@
+// error-pattern:expected function or native function but found *u8
+crust fn f() {
+}
+
+fn main() {
+    f();
+}

--- a/src/test/compile-fail/crust-wrong-value-type.rs
+++ b/src/test/compile-fail/crust-wrong-value-type.rs
@@ -1,0 +1,8 @@
+// error-pattern:expected `fn()` but found `*u8`
+crust fn f() {
+}
+
+fn main() {
+    // Crust functions are *u8 types
+    let _x: fn() = f;
+}

--- a/src/test/run-fail/crust-fail.rs
+++ b/src/test/run-fail/crust-fail.rs
@@ -1,0 +1,31 @@
+// error-pattern:explicit failure
+// Testing that runtime failure doesn't cause callbacks to abort abnormally.
+// Instead the failure will be delivered after the callbacks return.
+
+native mod rustrt {
+    fn rust_dbg_call(cb: *u8,
+                     data: ctypes::uintptr_t) -> ctypes::uintptr_t;
+}
+
+crust fn cb(data: ctypes::uintptr_t) -> ctypes::uintptr_t {
+    if data == 1u {
+        data
+    } else {
+        count(data - 1u) + count(data - 1u)
+    }
+}
+
+fn count(n: uint) -> uint {
+    task::yield();
+    rustrt::rust_dbg_call(cb, n)
+}
+
+fn main() {
+    iter::repeat(10u) {||
+        task::spawn {||
+            let result = count(5u);
+            #debug("result = %?", result);
+            fail;
+        };
+    }
+}

--- a/src/test/run-pass/crust-1.rs
+++ b/src/test/run-pass/crust-1.rs
@@ -1,0 +1,5 @@
+crust fn f() {
+}
+
+fn main() {
+}

--- a/src/test/run-pass/crust-call-deep.rs
+++ b/src/test/run-pass/crust-call-deep.rs
@@ -1,0 +1,23 @@
+native mod rustrt {
+    fn rust_dbg_call(cb: *u8,
+                     data: ctypes::uintptr_t) -> ctypes::uintptr_t;
+}
+
+crust fn cb(data: ctypes::uintptr_t) -> ctypes::uintptr_t {
+    if data == 1u {
+        data
+    } else {
+        count(data - 1u) + 1u
+    }
+}
+
+fn count(n: uint) -> uint {
+    #debug("n = %?", n);
+    rustrt::rust_dbg_call(cb, n)
+}
+
+fn main() {
+    let result = count(1000u);
+    #debug("result = %?", result);
+    assert result == 1000u;
+}

--- a/src/test/run-pass/crust-call-deep2.rs
+++ b/src/test/run-pass/crust-call-deep2.rs
@@ -1,0 +1,27 @@
+native mod rustrt {
+    fn rust_dbg_call(cb: *u8,
+                     data: ctypes::uintptr_t) -> ctypes::uintptr_t;
+}
+
+crust fn cb(data: ctypes::uintptr_t) -> ctypes::uintptr_t {
+    if data == 1u {
+        data
+    } else {
+        count(data - 1u) + 1u
+    }
+}
+
+fn count(n: uint) -> uint {
+    #debug("n = %?", n);
+    rustrt::rust_dbg_call(cb, n)
+}
+
+fn main() {
+    // Make sure we're on a task with small Rust stacks (main currently
+    // has a large stack)
+    task::spawn {||
+        let result = count(1000u);
+        #debug("result = %?", result);
+        assert result == 1000u;
+    };
+}

--- a/src/test/run-pass/crust-call-scrub.rs
+++ b/src/test/run-pass/crust-call-scrub.rs
@@ -1,0 +1,31 @@
+// This time we're testing repeatedly going up and down both stacks to
+// make sure the stack pointers are maintained properly in both
+// directions
+
+native mod rustrt {
+    fn rust_dbg_call(cb: *u8,
+                     data: ctypes::uintptr_t) -> ctypes::uintptr_t;
+}
+
+crust fn cb(data: ctypes::uintptr_t) -> ctypes::uintptr_t {
+    if data == 1u {
+        data
+    } else {
+        count(data - 1u) + count(data - 1u)
+    }
+}
+
+fn count(n: uint) -> uint {
+    #debug("n = %?", n);
+    rustrt::rust_dbg_call(cb, n)
+}
+
+fn main() {
+    // Make sure we're on a task with small Rust stacks (main currently
+    // has a large stack)
+    task::spawn {||
+        let result = count(12u);
+        #debug("result = %?", result);
+        assert result == 2048u;
+    };
+}

--- a/src/test/run-pass/crust-call.rs
+++ b/src/test/run-pass/crust-call.rs
@@ -1,0 +1,23 @@
+native mod rustrt {
+    fn rust_dbg_call(cb: *u8,
+                     data: ctypes::uintptr_t) -> ctypes::uintptr_t;
+}
+
+crust fn cb(data: ctypes::uintptr_t) -> ctypes::uintptr_t {
+    if data == 1u {
+        data
+    } else {
+        fact(data - 1u) * data
+    }
+}
+
+fn fact(n: uint) -> uint {
+    #debug("n = %?", n);
+    rustrt::rust_dbg_call(cb, n)
+}
+
+fn main() {
+    let result = fact(10u);
+    #debug("result = %?", result);
+    assert result == 3628800u;
+}

--- a/src/test/run-pass/crust-take-value.rs
+++ b/src/test/run-pass/crust-take-value.rs
@@ -1,0 +1,7 @@
+crust fn f() {
+}
+
+fn main() {
+    // Crust functions are *u8 types
+    let _x: *u8 = f;
+}

--- a/src/test/run-pass/crust-take-value.rs
+++ b/src/test/run-pass/crust-take-value.rs
@@ -1,7 +1,15 @@
 crust fn f() {
 }
 
+crust fn g() {
+}
+
 fn main() {
     // Crust functions are *u8 types
-    let _x: *u8 = f;
+    let a: *u8 = f;
+    let b: *u8 = f;
+    let c: *u8 = g;
+
+    assert a == b;
+    assert a != c;
 }

--- a/src/test/run-pass/crust-yield.rs
+++ b/src/test/run-pass/crust-yield.rs
@@ -1,0 +1,27 @@
+native mod rustrt {
+    fn rust_dbg_call(cb: *u8,
+                     data: ctypes::uintptr_t) -> ctypes::uintptr_t;
+}
+
+crust fn cb(data: ctypes::uintptr_t) -> ctypes::uintptr_t {
+    if data == 1u {
+        data
+    } else {
+        count(data - 1u) + count(data - 1u)
+    }
+}
+
+fn count(n: uint) -> uint {
+    task::yield();
+    rustrt::rust_dbg_call(cb, n)
+}
+
+fn main() {
+    iter::repeat(10u) {||
+        task::spawn {||
+            let result = count(5u);
+            #debug("result = %?", result);
+            assert result == 16u;
+        };
+    }
+}


### PR DESCRIPTION
This implements the compiler changes necessary to generate Rust functions that can be called from C.

Here's an example of how it works:

https://github.com/brson/rust/blob/crust/src/test/run-pass/crust-call-scrub.rs

The syntax and typing (they're all *u8) of these functions is not that satisfactory, but I guess we can improve it later.

I made 'crust' a function purity in the AST, which is not all that true. Cross-crate crust functions also don't work yet. So there's some more work to be done, but this includes all the important mechanics.
