### PR TITLE
Typos on reference manual

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1952,7 +1952,7 @@ for e: foo in v {
 
 ~~~~~~~~{.ebnf .gram}
 if_expr : "if" expr '{' block '}'
-          [ "else" else_tail ] ? ;
+          else_tail ? ;
 
 else_tail : "else" [ if_expr
                    | '{' block '}' ] ;

--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1955,7 +1955,7 @@ if_expr : "if" expr '{' block '}'
           [ "else" else_tail ] ? ;
 
 else_tail : "else" [ if_expr
-                   | '{' block '} ] ;
+                   | '{' block '}' ] ;
 ~~~~~~~~
 
 An `if` expression is a conditional branch in program control. The form of


### PR DESCRIPTION
The [grammar regarding If expressions](http://doc.rust-lang.org/doc/rust.html#if-expressions) on the reference manual (section 6.2.20 as of now) has a few errors:
- The closing bracket for `else_tail` is an unfinished literal
- There are two `else` keywords there
