### PR TITLE
std: Fix env() assert when an environment variable's value contains a '=' char

### DIFF
--- a/src/libstd/generic_os.rs
+++ b/src/libstd/generic_os.rs
@@ -21,7 +21,7 @@ fn setenv(n: str, v: str) { }
 fn env() -> [(str,str)] {
     let pairs = [];
     for p in os::rustrt::rust_env_pairs() {
-        let vs = str::split_char(p, '=');
+        let vs = str::splitn_char(p, '=', 1u);
         assert vec::len(vs) == 2u;
         pairs += [(vs[0], vs[1])];
     }


### PR DESCRIPTION
This patch fixes a rust build error from env() assertion failures.

MingW on Windows seems to set some funky environment variables like "=C:=C:\MinGW\msys\1.0\bin" and "!::=::\" that cause some assertion failures when trying to build rust. Some of the environment variables may contain '=' chars in their value _or even their name_!

This small patch avoids the assertion failure. I chose not to hide or sanitize these funky environment variables because they do exist in the system environment. I am also lazy.
