### PR TITLE
rt: lock_and_signal fixes

### DIFF
--- a/src/rt/sync/lock_and_signal.cpp
+++ b/src/rt/sync/lock_and_signal.cpp
@@ -34,6 +34,7 @@ lock_and_signal::lock_and_signal()
 lock_and_signal::~lock_and_signal() {
 #if defined(__WIN32__)
     CloseHandle(_event);
+    DeleteCriticalSection(&_cs);
 #else
     CHECKED(pthread_cond_destroy(&_cond));
     CHECKED(pthread_mutex_destroy(&_mutex));


### PR DESCRIPTION
1. Fix a Windows CRITICAL_SECTION leak in lock_and_signal.
2. Initialize Windows CRITICAL_SECTION with non-zero spin count, otherwise it will default to 0, even on multi-processor systems. MSDN suggests using 4000. On single-processor systems, the spin count parameter is ignored and the critical section's spin count defaults to 0. For Windows >= Vista, extra debug info is allocated for CRITICAL_SECTIONs but not released in a timely manner. Consider using InitializeCriticalSectionEx(CRITICAL_SECTION_NO_DEBUG_INFO).
3. Assert that locks are not reentered on the same thread, unlocked by a different thread, or deleted while locked.
