### PR TITLE
fixes an error that happens during make check

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -104,7 +104,7 @@ endif
 # Extracting tests for docs
 ######################################################################
 
-EXTRACT_TESTS := $(CFG_PYTHON) $(S)src/etc/extract-tests.py
+EXTRACT_TESTS := "$(CFG_PYTHON)" $(S)src/etc/extract-tests.py
 
 define DEF_DOC_TEST_HOST
 


### PR DESCRIPTION
extract: tutorial tests
make: /c/Program: Command not found
make: **\* [doc-tutorial-extracti686-pc-mingw32] Error 127
