### PR TITLE
add a copyless with_str_reader, and remove_file

### DIFF
--- a/src/comp/driver/driver.rs
+++ b/src/comp/driver/driver.rs
@@ -272,8 +272,10 @@ fn pretty_print_input(sess: session, cfg: ast::crate_cfg, input: str,
       ppm_expanded | ppm_normal {}
     }
     let src = codemap::get_filemap(sess.codemap, input).src;
-    pprust::print_crate(sess.codemap, sess.span_diagnostic, crate, input,
-                        io::str_reader(*src), io::stdout(), ann);
+    io::with_str_reader(*src) { |rdr|
+        pprust::print_crate(sess.codemap, sess.span_diagnostic, crate, input,
+                            rdr, io::stdout(), ann);
+    }
 }
 
 fn get_os(triple: str) -> option<session::os> {

--- a/src/comp/driver/driver.rs
+++ b/src/comp/driver/driver.rs
@@ -273,7 +273,7 @@ fn pretty_print_input(sess: session, cfg: ast::crate_cfg, input: str,
     }
     let src = codemap::get_filemap(sess.codemap, input).src;
     pprust::print_crate(sess.codemap, sess.span_diagnostic, crate, input,
-                        io::string_reader(*src), io::stdout(), ann);
+                        io::str_reader(*src), io::stdout(), ann);
 }
 
 fn get_os(triple: str) -> option<session::os> {

--- a/src/fuzzer/fuzzer.rs
+++ b/src/fuzzer/fuzzer.rs
@@ -412,12 +412,14 @@ fn parse_and_print(code: @str) -> str {
     write_file(filename, *code);
     let crate = parser::parse_crate_from_source_str(
         filename, code, [], sess);
-    ret as_str(bind pprust::print_crate(sess.cm,
+    io::with_str_reader(*code) { |rdr|
+        as_str(bind pprust::print_crate(sess.cm,
                                         sess.span_diagnostic,
                                         crate,
                                         filename,
-                                        io::str_reader(*code), _,
-                                        pprust::no_ann()));
+                                        rdr, _,
+                                        pprust::no_ann()))
+    }
 }
 
 fn has_raw_pointers(c: ast::crate) -> bool {
@@ -557,13 +559,15 @@ fn check_variants(files: [str], cx: context) {
             parser::parse_crate_from_source_str(
                 file,
                 s, [], sess);
-        #error("%s",
-               as_str(bind pprust::print_crate(sess.cm,
-                                               sess.span_diagnostic,
-                                               crate,
-                                               file,
-                                               io::str_reader(*s), _,
-                                               pprust::no_ann())));
+        io::with_str_reader(*s) { |rdr|
+            #error("%s",
+                   as_str(bind pprust::print_crate(sess.cm,
+                                                   sess.span_diagnostic,
+                                                   crate,
+                                                   file,
+                                                   rdr, _,
+                                                   pprust::no_ann())));
+        }
         check_variants_of_ast(*crate, sess.cm, file, cx);
     }
 }

--- a/src/fuzzer/fuzzer.rs
+++ b/src/fuzzer/fuzzer.rs
@@ -268,7 +268,7 @@ fn check_variants_T<T: copy>(
                         diagnostic::mk_span_handler(handler, codemap),
                         crate2,
                         filename,
-                        io::string_reader(""), _,
+                        io::str_reader(""), _,
                         pprust::no_ann()));
                 alt cx.mode {
                   tm_converge {
@@ -416,7 +416,7 @@ fn parse_and_print(code: @str) -> str {
                                         sess.span_diagnostic,
                                         crate,
                                         filename,
-                                        io::string_reader(*code), _,
+                                        io::str_reader(*code), _,
                                         pprust::no_ann()));
 }
 
@@ -562,7 +562,7 @@ fn check_variants(files: [str], cx: context) {
                                                sess.span_diagnostic,
                                                crate,
                                                file,
-                                               io::string_reader(*s), _,
+                                               io::str_reader(*s), _,
                                                pprust::no_ann())));
         check_variants_of_ast(*crate, sess.cm, file, cx);
     }

--- a/src/libstd/freebsd_os.rs
+++ b/src/libstd/freebsd_os.rs
@@ -62,6 +62,7 @@ native mod libc {
     fn mkdir(path: str::sbuf, mode: c_int) -> c_int;
     fn rmdir(path: str::sbuf) -> c_int;
     fn chdir(path: str::sbuf) -> c_int;
+    fn unlink(path: str::sbuf) -> c_int;
 
     fn sysctl(name: *c_int, namelen: c_uint,
               oldp: *u8, &oldlenp: size_t,

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -449,6 +449,27 @@ fn homedir() -> option<path> {
     }
 }
 
+/*
+Function: remove_file
+
+Deletes an existing file.
+*/
+fn remove_file(p: path) -> bool {
+    ret unlink(p);
+
+    #[cfg(target_os = "win32")]
+    fn unlink(p: path) -> bool {
+        ret str::as_buf(p, {|buf| os::kernel32::DeleteFile(buf)});
+    }
+
+    #[cfg(target_os = "linux")]
+    #[cfg(target_os = "macos")]
+    #[cfg(target_os = "freebsd")]
+    fn unlink(_p: path) -> bool {
+        ret str::as_buf(_p, {|buf| os::libc::unlink(buf) == 0i32 });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -270,7 +270,7 @@ fn with_bytes_reader_between<t>(bytes: [u8], start: uint, end: uint,
     f(bytes_reader_between(bytes, start, end))
 }
 
-fn string_reader(s: str) -> reader {
+fn str_reader(s: str) -> reader {
     bytes_reader(str::bytes(s))
 }
 
@@ -662,7 +662,7 @@ mod tests {
 
     #[test]
     fn test_readchars_empty() {
-        let inp : io::reader = io::string_reader("");
+        let inp : io::reader = io::str_reader("");
         let res : [char] = inp.read_chars(128u);
         assert(vec::len(res) == 0u);
     }
@@ -677,7 +677,7 @@ mod tests {
             29983, 38152, 30340, 27748,
             21273, 20999, 32905, 27748];
         fn check_read_ln(len : uint, s: str, ivals: [int]) {
-            let inp : io::reader = io::string_reader(s);
+            let inp : io::reader = io::str_reader(s);
             let res : [char] = inp.read_chars(len);
             if (len <= vec::len(ivals)) {
                 assert(vec::len(res) == len);
@@ -696,14 +696,14 @@ mod tests {
 
     #[test]
     fn test_readchar() {
-        let inp : io::reader = io::string_reader("生");
+        let inp : io::reader = io::str_reader("生");
         let res : char = inp.read_char();
         assert(res as int == 29983);
     }
 
     #[test]
     fn test_readchar_empty() {
-        let inp : io::reader = io::string_reader("");
+        let inp : io::reader = io::str_reader("");
         let res : char = inp.read_char();
         assert(res as int == -1);
     }

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -490,7 +490,7 @@ Function: from_str
 Deserializes a json value from a string.
 */
 fn from_str(s: str) -> result::t<json, error> {
-    from_reader(io::string_reader(s))
+    io::with_str_reader(s, from_reader)
 }
 
 /*

--- a/src/libstd/linux_os.rs
+++ b/src/libstd/linux_os.rs
@@ -63,6 +63,7 @@ native mod libc {
     fn mkdir(path: str::sbuf, mode: c_int) -> c_int;
     fn rmdir(path: str::sbuf) -> c_int;
     fn chdir(path: str::sbuf) -> c_int;
+    fn unlink(path: str::sbuf) -> c_int;
 }
 
 mod libc_constants {

--- a/src/libstd/macos_os.rs
+++ b/src/libstd/macos_os.rs
@@ -55,6 +55,7 @@ native mod libc {
     fn mkdir(s: str::sbuf, mode: c_int) -> c_int;
     fn rmdir(s: str::sbuf) -> c_int;
     fn chdir(s: str::sbuf) -> c_int;
+    fn unlink(path: str::sbuf) -> c_int;
 
     // FIXME: Needs varags
     fn fcntl(fd: fd_t, cmd: c_int) -> c_int;

--- a/src/libstd/win32_os.rs
+++ b/src/libstd/win32_os.rs
@@ -62,6 +62,7 @@ native mod kernel32 {
                         lpSecurityAttributes: LPSECURITY_ATTRIBUTES) -> bool;
     fn RemoveDirectoryA(lpPathName: LPCTSTR) -> bool;
     fn SetCurrentDirectoryA(lpPathName: LPCTSTR) -> bool;
+    fn DeleteFile(lpFileName: LPCTSTR) -> bool;
 }
 
 // FIXME turn into constants

--- a/src/test/bench/task-perf-word-count.rs
+++ b/src/test/bench/task-perf-word-count.rs
@@ -21,7 +21,7 @@ import comm::recv;
 import comm::send;
 
 fn map(input: str, emit: map_reduce::putter) {
-    let f = io::string_reader(input);
+    let f = io::str_reader(input);
 
 
     while true {


### PR DESCRIPTION
io::with_str_reader is a copyless way to make a reader from a string. I also renamed string_reader to str_reader, and added a remove_file function. It sounds like Graydon is in the middle of work there, so I'm okay punting on that commit for now.
