### PR TITLE
core: Remove *_mut functions from vec

### DIFF
--- a/src/comp/middle/check_alt.rs
+++ b/src/comp/middle/check_alt.rs
@@ -88,7 +88,7 @@ fn check_exhaustive(tcx: ty::ctxt, sp: span, pats: [@pat]) {
         }));
       }
       ty::ty_tup(ts) {
-        let cols = vec::init_elt_mut(ts.len(), []);
+        let cols = vec::to_mut(vec::init_elt(ts.len(), []));
         for p in pats {
             alt raw_pat(p).node {
               pat_tup(sub) {
@@ -156,7 +156,7 @@ fn check_exhaustive_enum(tcx: ty::ctxt, enum_id: def_id, sp: span,
     let variants = enum_variants(tcx, enum_id);
     let columns_by_variant = vec::map(*variants, {|v|
         {mutable seen: false,
-         cols: vec::init_elt_mut(v.args.len(), [])}
+         cols: vec::to_mut(vec::init_elt(v.args.len(), []))}
     });
 
     for pat in pats {

--- a/src/comp/middle/trans/alt.rs
+++ b/src/comp/middle/trans/alt.rs
@@ -337,7 +337,7 @@ fn pick_col(m: match) -> uint {
           _ { 0u }
         }
     }
-    let scores = vec::init_elt_mut(m[0].pats.len(), 0u);
+    let scores = vec::to_mut(vec::init_elt(m[0].pats.len(), 0u));
     for br: match_branch in m {
         let i = 0u;
         for p: @ast::pat in br.pats { scores[i] += score(p); i += 1u; }

--- a/src/comp/middle/trans/base.rs
+++ b/src/comp/middle/trans/base.rs
@@ -740,7 +740,9 @@ fn make_generic_glue_inner(ccx: crate_ctxt, t: ty::t,
         p += 1u;
     }
 
-    fcx.lltyparams = vec::map_mut(lltydescs, {|d| {desc: d, dicts: none}});
+    fcx.lltyparams = vec::map(vec::from_mut(lltydescs), {|d|
+        {desc: d, dicts: none}
+    });
 
     let bcx = top_scope_block(fcx, none);
     let lltop = bcx.llbb;

--- a/src/comp/middle/tstate/auxiliary.rs
+++ b/src/comp/middle/tstate/auxiliary.rs
@@ -294,7 +294,7 @@ fn get_fn_info(ccx: crate_ctxt, id: node_id) -> fn_info {
 fn add_node(ccx: crate_ctxt, i: node_id, a: ts_ann) {
     let sz = vec::len(*ccx.node_anns);
     if sz <= i as uint {
-        vec::grow_mut(*ccx.node_anns, (i as uint) - sz + 1u, empty_ann(0u));
+        vec::grow(*ccx.node_anns, (i as uint) - sz + 1u, empty_ann(0u));
     }
     ccx.node_anns[i] = a;
 }

--- a/src/comp/syntax/print/pp.rs
+++ b/src/comp/syntax/print/pp.rs
@@ -101,9 +101,9 @@ fn mk_printer(out: io::writer, linewidth: uint) -> printer {
     // fall behind.
     let n: uint = 3u * linewidth;
     #debug("mk_printer %u", linewidth);
-    let token: [mutable token] = vec::init_elt_mut(n, EOF);
-    let size: [mutable int] = vec::init_elt_mut(n, 0);
-    let scan_stack: [mutable uint] = vec::init_elt_mut(n, 0u);
+    let token: [mutable token] = vec::to_mut(vec::init_elt(n, EOF));
+    let size: [mutable int] = vec::to_mut(vec::init_elt(n, 0));
+    let scan_stack: [mutable uint] = vec::to_mut(vec::init_elt(n, 0u));
     let print_stack: [print_stack_elt] = [];
     @{out: out,
       buf_len: n,

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -229,7 +229,8 @@ fn check_expected_errors(expected_errors: [errors::expected_error],
                          procres: procres) {
 
     // true if we found the error in question
-    let found_flags = vec::init_elt_mut(vec::len(expected_errors), false);
+    let found_flags = vec::to_mut(vec::init_elt(
+        vec::len(expected_errors), false));
 
     if procres.status == 0 {
         fatal("process did not return an error status");

--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -49,7 +49,7 @@ init - If true then the bits are initialized to 1, otherwise 0
 */
 fn create(nbits: uint, init: bool) -> t {
     let elt = if init { !0u } else { 0u };
-    let storage = vec::init_elt_mut::<uint>(nbits / uint_bits + 1u, elt);
+    let storage = vec::to_mut(vec::init_elt(nbits / uint_bits + 1u, elt));
     ret @{storage: storage, nbits: nbits};
 }
 
@@ -117,7 +117,7 @@ Function: clone
 Makes a copy of a bitvector
 */
 fn clone(v: t) -> t {
-    let storage = vec::init_elt_mut::<uint>(v.nbits / uint_bits + 1u, 0u);
+    let storage = vec::to_mut(vec::init_elt(v.nbits / uint_bits + 1u, 0u));
     let len = vec::len(v.storage);
     uint::range(0u, len) {|i| storage[i] = v.storage[i]; };
     ret @{storage: storage, nbits: v.nbits};

--- a/src/libstd/deque.rs
+++ b/src/libstd/deque.rs
@@ -127,7 +127,7 @@ fn create<T: copy>() -> t<T> {
         mutable nelts: 0u,
         mutable lo: 0u,
         mutable hi: 0u,
-        mutable elts: vec::init_elt_mut(initial_capacity, none)
+        mutable elts: vec::to_mut(vec::init_elt(initial_capacity, none))
     };
     repr as t::<T>
 }

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -212,7 +212,7 @@ err(fail_) - On failure. Use <fail_str> to get an error message.
 fn getopts(args: [str], opts: [opt]) -> result unsafe {
     let n_opts = vec::len::<opt>(opts);
     fn f(_x: uint) -> [optval] { ret []; }
-    let vals = vec::init_fn_mut::<[optval]>(n_opts, f);
+    let vals = vec::to_mut(vec::init_fn(n_opts, f));
     let free: [str] = [];
     let l = vec::len(args);
     let i = 0u;

--- a/src/libstd/map.rs
+++ b/src/libstd/map.rs
@@ -243,7 +243,7 @@ mod chained {
     }
 
     fn chains<K: copy, V: copy>(nchains: uint) -> [mutable chain<K,V>] {
-        ret vec::init_elt_mut(nchains, absent);
+        ret vec::to_mut(vec::init_elt(nchains, absent));
     }
 
     fn foreach_entry<K: copy, V: copy>(chain0: chain<K,V>,

--- a/src/libstd/md4.rs
+++ b/src/libstd/md4.rs
@@ -30,7 +30,7 @@ fn md4(msg: [u8]) -> {a: u32, b: u32, c: u32, d: u32} {
     }
 
     let i = 0u, e = vec::len(msg);
-    let x = vec::init_elt_mut(16u, 0u32);
+    let x = vec::to_mut(vec::init_elt(16u, 0u32));
     while i < e {
         let aa = a, bb = b, cc = c, dd = d;
 

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -181,7 +181,7 @@ fn concat(v: [rope]) -> rope {
     //Copy `v` into a mutable vector
     let len   = vec::len(v);
     if len == 0u { ret node::empty; }
-    let ropes = vec::init_elt_mut(len, v[0]);
+    let ropes = vec::to_mut(vec::init_elt(len, v[0]));
     uint::range(1u, len) {|i|
        ropes[i] = v[i];
     }
@@ -780,7 +780,7 @@ mod node {
             //Firstly, split `str` in slices of hint_max_leaf_char_len
             let leaves = uint::div_ceil(char_len, hint_max_leaf_char_len);
             //Number of leaves
-            let nodes  = vec::init_elt_mut(leaves, candidate);
+            let nodes  = vec::to_mut(vec::init_elt(leaves, candidate));
 
             let i = 0u;
             let offset = byte_start;
@@ -893,7 +893,7 @@ mod node {
     }
 
     fn serialize_node(node: @node) -> str unsafe {
-        let buf = vec::init_elt_mut(byte_len(node), 0u8);
+        let buf = vec::to_mut(vec::init_elt(byte_len(node), 0u8));
         let offset = 0u;//Current position in the buffer
         let it = leaf_iterator::start(node);
         while true {
@@ -1224,7 +1224,7 @@ mod node {
         }
 
         fn start(node: @node) -> t {
-            let stack = vec::init_elt_mut(height(node)+1u, node);
+            let stack = vec::to_mut(vec::init_elt(height(node)+1u, node));
             ret {
                 stack:             stack,
                 mutable stackpos:  0

--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -274,13 +274,13 @@ fn mk_sha1() -> sha1 {
         }
     }
     let st = {
-        h: vec::init_elt_mut(digest_buf_len, 0u32),
+        h: vec::to_mut(vec::init_elt(digest_buf_len, 0u32)),
         mutable len_low: 0u32,
         mutable len_high: 0u32,
-        msg_block: vec::init_elt_mut(msg_block_len, 0u8),
+        msg_block: vec::to_mut(vec::init_elt(msg_block_len, 0u8)),
         mutable msg_block_idx: 0u,
         mutable computed: false,
-        work_buf: vec::init_elt_mut(work_buf_len, 0u32)
+        work_buf: vec::to_mut(vec::init_elt(work_buf_len, 0u32))
     };
     let sh = st as sha1;
     sh.reset();

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -73,7 +73,7 @@ fn contains_key<T: copy>(m: smallintmap<T>, key: uint) -> bool {
 // FIXME: Are these really useful?
 
 fn truncate<T: copy>(m: smallintmap<T>, len: uint) {
-    m.v = vec::slice_mut::<option<T>>(m.v, 0u, len);
+    m.v = vec::to_mut(vec::slice::<option<T>>(m.v, 0u, len));
 }
 
 fn max_key<T>(m: smallintmap<T>) -> uint {

--- a/src/test/bench/shootout-fannkuchredux.rs
+++ b/src/test/bench/shootout-fannkuchredux.rs
@@ -6,9 +6,9 @@ import vec;
 fn fannkuch(n: int) -> int {
     fn perm1init(i: uint) -> int { ret i as int; }
 
-    let perm = vec::init_elt_mut(n as uint, 0);
-    let perm1 = vec::init_fn_mut(n as uint, perm1init);
-    let count = vec::init_elt_mut(n as uint, 0);
+    let perm = vec::to_mut(vec::init_elt(n as uint, 0));
+    let perm1 = vec::to_mut(vec::init_fn(n as uint, perm1init));
+    let count = vec::to_mut(vec::init_elt(n as uint, 0));
     let f = 0;
     let i = 0;
     let k = 0;

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -35,7 +35,7 @@ fn eval_At_times_u(u: [const float], Au: [mutable float]) {
 }
 
 fn eval_AtA_times_u(u: [const float], AtAu: [mutable float]) {
-    let v = vec::init_elt_mut(vec::len(u), 0.0);
+    let v = vec::to_mut(vec::init_elt(vec::len(u), 0.0));
     eval_A_times_u(u, v);
     eval_At_times_u(v, AtAu);
 }
@@ -48,8 +48,8 @@ fn main(args: [str]) {
         1000u
     };
 
-    let u = vec::init_elt_mut(N, 1.0);
-    let v = vec::init_elt_mut(N, 0.0);
+    let u = vec::to_mut(vec::init_elt(N, 1.0));
+    let v = vec::to_mut(vec::init_elt(N, 0.0));
     let i = 0u;
     while i < 10u {
         eval_AtA_times_u(u, v);

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -31,7 +31,9 @@ enum grid_t { grid_ctor(grid), }
 fn read_grid(f: io::reader) -> grid_t {
     assert f.read_line() == "9,9"; /* assert first line is exactly "9,9" */
 
-    let g = vec::init_fn(10u, {|_i| vec::init_elt_mut(10u, 0 as u8) });
+    let g = vec::init_fn(10u, {|_i|
+        vec::to_mut(vec::init_elt(10u, 0 as u8))
+    });
     while !f.eof() {
         let comps = str::split_char(str::trim(f.read_line()), ',');
         if vec::len(comps) >= 3u {
@@ -129,7 +131,9 @@ fn write_grid(f: io::writer, g: grid_t) {
 fn main(args: [str]) {
     let grid = if vec::len(args) == 1u {
         // FIXME create sudoku inline since nested vec consts dont work yet
-        let g = vec::init_fn(10u, {|_i| vec::init_elt_mut(10u, 0 as u8) });
+        let g = vec::init_fn(10u, {|_i|
+            vec::to_mut(vec::init_elt(10u, 0 as u8))
+        });
         g[0][1] = 4u8;
         g[0][3] = 6u8;
         g[0][7] = 3u8;


### PR DESCRIPTION
Instead of duplicating functions whenever we need one that works with mutable vectors, use `vec::to_mut` and `vec::from_mut` to convert back and forth in place.

I think I prefer this approach, but for some reason it causes a 1 second regression in compiling rustc, with some corresponding increase in code size.
