### PR TITLE
(core::str) Boyer-Moore string searching

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1202,7 +1202,7 @@ Returns true if one string contains another
 * needle - The string to look for
 "]
 fn contains(haystack: str, needle: str) -> bool {
-    option::is_some(find_str_between(haystack, needle, 0u, len(haystack)))
+    option::is_some(find_str(haystack, needle))
 }
 
 #[doc = "
@@ -2039,7 +2039,6 @@ mod tests {
 
     #[test]
     fn test_find_str() {
-        // byte positions
         assert find_str("banana", "apple pie") == none;
         assert find_str("", "") == some(0u);
 
@@ -2052,16 +2051,12 @@ mod tests {
     }
 
     #[test]
-    fn test_find_str_between() {
+    fn test_find_str_between_ascii() {
         assert find_str_between("", "", 0u, 0u) == some(0u);
         assert find_str_between("", "pow", 0u, 0u) == none;
         assert find_str_between("donatello", "don", 0u, 9u) == some(0u);
-      //assert find_str_between("don", "donatello", 0u, 10u) == none; //was OK
-        assert find_str_between("don", "donatello", 0u, 3u) == none; //OK
-    }
+        assert find_str_between("don", "donatello", 0u, 3u) == none;
 
-    #[test]
-    fn test_find_str_between_ascii() {
         let data0 = "abcabc";
         assert find_str_between(data0, "ab", 0u, 6u) == some(0u);
         assert find_str_between(data0, "ab", 2u, 6u) == some(3u);

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -57,6 +57,7 @@ export
    map,
    bytes_iter,
    chars_iter,
+   chars_iteri,
    split_char_iter,
    splitn_char_iter,
    words_iter,
@@ -582,13 +583,19 @@ fn bytes_iter(ss: str, it: fn(u8)) {
 }
 
 #[doc = "Iterate over the characters in a string"]
-fn chars_iter(s: str, it: fn(char)) {
+fn chars_iter(ss: str, it: fn(char)) {
+    chars_iteri(ss, {|_ii, ch| it(ch)})
+}
+
+#[doc = "Iterate over the characters in a string"]
+fn chars_iteri(ss: str, it: fn(uint,char)) {
     let mut pos = 0u;
     let len = len(s);
+
     while (pos < len) {
-        let {ch, next} = char_range_at(s, pos);
+        let {ch, next} = char_range_at(ss, pos);
+        it(pos, ch);
         pos = next;
-        it(ch);
     }
 }
 

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1102,24 +1102,25 @@ fn boyer_moore_search (haystack: str, needle: str,
 
     // generate the tables
     let ct = boyer_moore_unmatched_chars(needle);
-    let pt = boyer_moore_matching_suffixes(needle);
+    //let pt = boyer_moore_matching_suffixes(needle);
 
     // query both tables based on position
     // within the needle and character in haystack
     let getShift = fn@(pos: uint, ch: u8) -> uint {
         let matchedSoFar = nlen - 1u - pos;
         let rawCharShift = ct[ch as uint];
-        let prefShift    = pt[matchedSoFar];
+//        let prefShift    = pt[matchedSoFar];
 
         if rawCharShift >= matchedSoFar {
            let adjCharShift = rawCharShift - matchedSoFar;
 
-           if adjCharShift > prefShift {
+//           if adjCharShift > prefShift {
                ret adjCharShift;
-           }
+//           }
         }
 
-        ret prefShift;
+//        ret prefShift;
+        ret 1u;
     };
 
     // step up through the haystack

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1019,10 +1019,15 @@ fn findn_str_between (haystack: str, needle: str,
                       nn: uint,
                       start: uint, end: uint) -> [uint] {
 
-    let BM = boyer_moore_search(haystack, needle, nn, start, end);
-    let SS = simple_search(haystack, needle, nn, start, end);
-    assert SS == BM;
-    ret SS;
+    let hl = str::len(haystack);
+    let nl = str::len(needle);
+
+    // numbers subject to change...
+    if hl > 10*nl + 1500 && nl > 10 {
+        ret boyer_moore_search(haystack, needle, nn, start, end);
+    } else {
+        ret simple_search(haystack, needle, nn, start, end);
+    }
 }
 
 #[doc = "

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1023,7 +1023,9 @@ fn findn_str_between (haystack: str, needle: str,
     let nl = str::len(needle);
 
     // numbers subject to change...
-    if hl > 10*nl + 1500 && nl > 10 {
+    if hl > 10u * nl + 1500u
+       && nl > 10u
+    {
         ret boyer_moore_search(haystack, needle, nn, start, end);
     } else {
         ret simple_search(haystack, needle, nn, start, end);

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1165,10 +1165,8 @@ fn boyer_moore_unmatched_chars(needle: str) -> [uint] {
     let len = str::len(needle);
     let mm  = vec::to_mut(vec::init_elt(255u, len));
 
+    assert 0u < len;
     let mut jj = len - 1u; // drop the last byte
-
-    //assert 0u <= jj;
-    //assert       jj < str::len(needle);
 
     // from last-1 to first
     while jj > 0u {
@@ -1193,7 +1191,6 @@ fn boyer_moore_matching_suffixes(needle_str: str) -> [uint] {
     let needle = str::bytes(needle_str);
 
     let len   = vec::len(needle);
-    //assert 0u < len;
 
     // initialize len chars to len
     let mm  = vec::to_mut(vec::init_elt(len, len));

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -69,7 +69,7 @@ export
    find_char, find_char_from, find_char_between,
    rfind_char, rfind_char_from, rfind_char_between,
    find_str, find_str_from, find_str_between,
-   findn_str,
+   findn_str, findn_str_between,
    contains,
    starts_with,
    ends_with,
@@ -2057,10 +2057,10 @@ mod tests {
         assert find_str_between("donatello", "don", 0u, 9u) == some(0u);
         assert find_str_between("don", "donatello", 0u, 3u) == none;
 
-        let data0 = "abcabc";
-        assert find_str_between(data0, "ab", 0u, 6u) == some(0u);
-        assert find_str_between(data0, "ab", 2u, 6u) == some(3u);
-        assert find_str_between(data0, "ab", 2u, 4u) == none;
+        let data = "abcabc";
+        assert find_str_between(data, "ab", 0u, 6u) == some(0u);
+        assert find_str_between(data, "ab", 2u, 6u) == some(3u);
+        assert find_str_between(data, "ab", 2u, 4u) == none;
     }
 
     #[test]
@@ -2081,6 +2081,14 @@ mod tests {
         assert find_str_between(data, "ย中", 43u, 86u) == some(67u);
         assert find_str_between(data, "iệt", 43u, 86u) == some(77u);
         assert find_str_between(data, "Nam", 43u, 86u) == some(83u);
+    }
+
+    #[test]
+    fn test_findn_str_between() {
+        let data = "abcabc";
+        assert findn_str_between(data, "ab", 2u, 0u, 6u) == [0u, 3u];
+        assert findn_str_between(data, "ab", 1u, 0u, 6u) == [0u];
+        assert findn_str_between(data, "ax", 1u, 0u, 6u) == [];
     }
 
     #[test]

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -900,7 +900,7 @@ fn ends_with <TT> (vvv: [TT], vv: [TT]) -> bool {
     if lll < ll { ret false; }
 
     let delta = lll - ll;
-    let res = true;
+    let mut res = true;
 
     vec::riteri(vv) {|ii, elem|
         if elem != vvv[delta + ii] { res = false; }

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -869,6 +869,9 @@ fn permute<T: copy>(v: [T], put: fn([T])) {
   }
 }
 
+// Function: windowed
+//
+// Return all sub-vectors of size `nn`
 fn windowed <TT: copy> (nn: uint, xx: [const TT]) -> [[TT]] {
    let mut ww = [];
 
@@ -884,6 +887,26 @@ fn windowed <TT: copy> (nn: uint, xx: [const TT]) -> [[TT]] {
    });
 
    ret ww;
+}
+
+#[doc = "
+Return true if the first vector ends with the second
+(including if the second is [])
+"]
+fn ends_with <TT> (vvv: [TT], vv: [TT]) -> bool {
+    let lll = vec::len(vvv);
+    let ll  = vec::len(vv);
+
+    if lll < ll { ret false; }
+
+    let delta = lll - ll;
+    let res = true;
+
+    vec::riteri(vv) {|ii, elem|
+        if elem != vvv[delta + ii] { res = false; }
+    }
+
+    ret res;
 }
 
 #[doc = "
@@ -1759,6 +1782,18 @@ mod tests {
         let mut x = [1, 2, 3];
         unshift(x, 0);
         assert x == [0, 1, 2, 3];
+    }
+
+    #[test]
+    fn test_ends_with() {
+        assert true  == ends_with([7,7,7,0,1,2], [0,1,2]);
+        assert false == ends_with([7,7,7,0,1,2,7], [0,1,2]);
+        assert true  == ends_with([0,1,2], [0,1,2]);
+        assert false == ends_with([0,1,2], [0,1,2,3]);
+        assert true  == ends_with([0,1,2], []);
+        let empty : [uint] = []; // just feed a type into this thing
+        assert true  == ends_with(empty, empty);
+        assert false == ends_with([],[0,1,2,3]);
     }
 }
 

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -869,9 +869,7 @@ fn permute<T: copy>(v: [T], put: fn([T])) {
   }
 }
 
-// Function: windowed
-//
-// Return all sub-vectors of size `nn`
+#[doc = "Return all sub-vectors of size `nn`"]
 fn windowed <TT: copy> (nn: uint, xx: [const TT]) -> [[TT]] {
    let mut ww = [];
 

--- a/src/rustdoc/markdown_pass.rs
+++ b/src/rustdoc/markdown_pass.rs
@@ -57,6 +57,7 @@ fn should_write_modules_last() {
     types of items, or else the header nesting will end up wrong, with
     modules appearing to contain items that they do not.
     */
+
     let markdown = test::render(
         "mod a { }\
          fn b() { }\

--- a/src/rustdoc/markdown_pass.rs
+++ b/src/rustdoc/markdown_pass.rs
@@ -57,7 +57,6 @@ fn should_write_modules_last() {
     types of items, or else the header nesting will end up wrong, with
     modules appearing to contain items that they do not.
     */
-
     let markdown = test::render(
         "mod a { }\
          fn b() { }\


### PR DESCRIPTION
Here, I've added a Boyer-Moore string search.  It computes a pair of tables based on the "needle" being searched for, and then uses them to go faster through the "haystack"...

I've used it within str::find_str_between and str::iter_matches, and also added these functions:
- str::findn_str_between
- str::findn_str
- vec::ends_with
- str::chars_iteri
