### PR TITLE
Overhaul constructor naming in libs

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -229,7 +229,7 @@ fn check_expected_errors(expected_errors: [errors::expected_error],
                          procres: procres) {
 
     // true if we found the error in question
-    let found_flags = vec::to_mut(vec::init_elt(
+    let found_flags = vec::to_mut(vec::from_elem(
         vec::len(expected_errors), false));
 
     if procres.status == 0 {

--- a/src/libcore/extfmt.rs
+++ b/src/libcore/extfmt.rs
@@ -385,7 +385,7 @@ mod rt {
 
     // FIXME: This might be useful in str: but needs to be utf8 safe first
     fn str_init_elt(n_elts: uint, c: char) -> str {
-        let svec = vec::init_elt::<u8>(n_elts, c as u8);
+        let svec = vec::from_elem::<u8>(n_elts, c as u8);
 
         ret str::from_bytes(svec);
     }

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -60,7 +60,7 @@ fn as_c_charp<T>(s: str, f: fn(*c_char) -> T) -> T {
 
 fn fill_charp_buf(f: fn(*mutable c_char, size_t) -> bool)
     -> option<str> {
-    let buf = vec::to_mut(vec::init_elt(tmpbuf_sz, 0u8 as c_char));
+    let buf = vec::to_mut(vec::from_elem(tmpbuf_sz, 0u8 as c_char));
     vec::as_mut_buf(buf) { |b|
         if f(b, tmpbuf_sz as size_t) {
             some(str::from_cstr(b as str::sbuf))
@@ -76,7 +76,7 @@ mod win32 {
 
     fn fill_utf16_buf_and_decode(f: fn(*mutable u16, dword) -> dword)
         -> option<str> {
-        let buf = vec::to_mut(vec::init_elt(tmpbuf_sz, 0u16));
+        let buf = vec::to_mut(vec::from_elt(tmpbuf_sz, 0u16));
         vec::as_mut_buf(buf) {|b|
             let k : dword = f(b, tmpbuf_sz as dword);
             if k == (0 as dword) {

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -8,8 +8,8 @@ export is_not_empty;
 export same_length;
 export reserve;
 export len;
-export init_fn;
-export init_elt;
+export from_fn;
+export from_elem;
 export to_mut;
 export from_mut;
 export head;
@@ -129,7 +129,7 @@ Creates and initializes an immutable vector.
 Creates an immutable vector of size `n_elts` and initializes the elements
 to the value returned by the function `op`.
 "]
-fn init_fn<T>(n_elts: uint, op: init_op<T>) -> [T] {
+fn from_fn<T>(n_elts: uint, op: init_op<T>) -> [T] {
     let mut v = [];
     reserve(v, n_elts);
     let mut i: uint = 0u;
@@ -143,7 +143,7 @@ Creates and initializes an immutable vector.
 Creates an immutable vector of size `n_elts` and initializes the elements
 to the value `t`.
 "]
-fn init_elt<T: copy>(n_elts: uint, t: T) -> [T] {
+fn from_elem<T: copy>(n_elts: uint, t: T) -> [T] {
     let mut v = [];
     reserve(v, n_elts);
     let mut i: uint = 0u;
@@ -182,7 +182,7 @@ fn tailn<T: copy>(v: [const T], n: uint) -> [T] {
     slice(v, n, len(v))
 }
 
-// FIXME: This name is sort of confusing next to init_fn, etc
+// FIXME: This name is sort of confusing next to from_fn, etc
 // but this is the name haskell uses for this function,
 // along with head/tail/last.
 #[doc = "Returns all but the last elemnt of a vector"]
@@ -999,16 +999,16 @@ mod tests {
     }
 
     #[test]
-    fn test_init_fn() {
-        // Test on-stack init_fn.
-        let v = init_fn(3u, square);
+    fn test_from_fn() {
+        // Test on-stack from_fn.
+        let v = from_fn(3u, square);
         assert (len(v) == 3u);
         assert (v[0] == 0u);
         assert (v[1] == 1u);
         assert (v[2] == 4u);
 
-        // Test on-heap init_fn.
-        v = init_fn(5u, square);
+        // Test on-heap from_fn.
+        v = from_fn(5u, square);
         assert (len(v) == 5u);
         assert (v[0] == 0u);
         assert (v[1] == 1u);
@@ -1018,15 +1018,15 @@ mod tests {
     }
 
     #[test]
-    fn test_init_elt() {
-        // Test on-stack init_elt.
-        let v = init_elt(2u, 10u);
+    fn test_from_elem() {
+        // Test on-stack from_elem.
+        let v = from_elem(2u, 10u);
         assert (len(v) == 2u);
         assert (v[0] == 10u);
         assert (v[1] == 10u);
 
-        // Test on-heap init_elt.
-        v = init_elt(6u, 20u);
+        // Test on-heap from_elem.
+        v = from_elem(6u, 20u);
         assert (v[0] == 20u);
         assert (v[1] == 20u);
         assert (v[2] == 20u);

--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -37,7 +37,7 @@ Constructs a bitvector
 "]
 fn create(nbits: uint, init: bool) -> t {
     let elt = if init { !0u } else { 0u };
-    let storage = vec::to_mut(vec::init_elt(nbits / uint_bits + 1u, elt));
+    let storage = vec::to_mut(vec::from_elem(nbits / uint_bits + 1u, elt));
     ret @{storage: storage, nbits: nbits};
 }
 
@@ -84,7 +84,7 @@ fn assign(v0: t, v1: t) -> bool { let sub = right; ret process(v0, v1, sub); }
 
 #[doc = "Makes a copy of a bitvector"]
 fn clone(v: t) -> t {
-    let storage = vec::to_mut(vec::init_elt(v.nbits / uint_bits + 1u, 0u));
+    let storage = vec::to_mut(vec::from_elem(v.nbits / uint_bits + 1u, 0u));
     let len = vec::len(v.storage);
     uint::range(0u, len) {|i| storage[i] = v.storage[i]; };
     ret @{storage: storage, nbits: v.nbits};
@@ -190,7 +190,7 @@ Each uint in the resulting vector has either value 0u or 1u.
 "]
 fn to_vec(v: t) -> [uint] {
     let sub = bind init_to_vec(v, _);
-    ret vec::init_fn::<uint>(v.nbits, sub);
+    ret vec::from_fn::<uint>(v.nbits, sub);
 }
 
 
@@ -232,7 +232,7 @@ mod tests {
         let act;
         let exp;
         act = create(0u, false);
-        exp = vec::init_elt::<uint>(0u, 0u);
+        exp = vec::from_elem::<uint>(0u, 0u);
         assert (eq_vec(act, exp));
     }
 

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -26,7 +26,7 @@ taken to ensure that a reference to the c_vec::t is still held if needed.
 "];
 
 export t;
-export create, create_with_dtor;
+export c_vec, c_vec_with_dtor;
 export get, set;
 export len;
 export ptr;
@@ -60,7 +60,7 @@ Create a c_vec::t from a native buffer with a given length.
 * base - A native pointer to a buffer
 * len - The number of elements in the buffer
 "]
-unsafe fn create<T>(base: *mutable T, len: uint) -> t<T> {
+unsafe fn c_vec<T>(base: *mutable T, len: uint) -> t<T> {
     ret t({base: base,
            len: len,
            rsrc: @dtor_res(option::none)
@@ -78,7 +78,7 @@ and a function to run upon destruction.
 * dtor - A function to run when the value is destructed, useful
          for freeing the buffer, etc.
 "]
-unsafe fn create_with_dtor<T>(base: *mutable T, len: uint, dtor: fn@())
+unsafe fn c_vec_with_dtor<T>(base: *mutable T, len: uint, dtor: fn@())
   -> t<T> {
     ret t({base: base,
            len: len,
@@ -140,7 +140,7 @@ mod tests {
 
         assert mem as int != 0;
 
-        ret unsafe { create_with_dtor(mem, n, bind libc::free(mem)) };
+        ret unsafe { c_vec_with_dtor(mem, n, bind libc::free(mem)) };
     }
 
     #[test]

--- a/src/libstd/deque.rs
+++ b/src/libstd/deque.rs
@@ -105,7 +105,7 @@ fn create<T: copy>() -> t<T> {
         mutable nelts: 0u,
         mutable lo: 0u,
         mutable hi: 0u,
-        mutable elts: vec::to_mut(vec::init_elt(initial_capacity, none))
+        mutable elts: vec::to_mut(vec::from_elem(initial_capacity, none))
     };
     repr as t::<T>
 }

--- a/src/libstd/ebml.rs
+++ b/src/libstd/ebml.rs
@@ -25,7 +25,6 @@ export doc_as_i16;
 export doc_as_i32;
 export doc_as_i64;
 export writer;
-export mk_writer;
 
 type ebml_tag = {id: uint, size: uint};
 
@@ -177,7 +176,7 @@ fn write_vuint(w: io::writer, n: uint) {
     fail #fmt("vint to write too big: %?", n);
 }
 
-fn mk_writer(w: io::writer) -> writer {
+fn writer(w: io::writer) -> writer {
     let size_positions: [uint] = [];
     ret {writer: w, mutable size_positions: size_positions};
 }

--- a/src/libstd/freebsd_os.rs
+++ b/src/libstd/freebsd_os.rs
@@ -135,7 +135,7 @@ fn dylib_filename(base: str) -> str { ret "lib" + base + ".so"; }
 fn get_exe_path() -> option<fs::path> unsafe {
     let bufsize = 1023u;
     // FIXME: path "strings" will likely need fixing...
-    let path = str::from_bytes(vec::init_elt(bufsize, 0u8));
+    let path = str::from_bytes(vec::from_elem(bufsize, 0u8));
     let mib = [libc_constants::CTL_KERN,
                libc_constants::KERN_PROC,
                libc_constants::KERN_PROC_PATHNAME, -1i32];

--- a/src/libstd/generic_os.rs
+++ b/src/libstd/generic_os.rs
@@ -100,7 +100,7 @@ mod tests {
 
     fn make_rand_name() -> str {
         import rand;
-        let rng: rand::rng = rand::mk_rng();
+        let rng: rand::rng = rand::rng();
         let n = "TEST" + rng.gen_str(10u);
         assert option::is_none(getenv(n));
         n

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -171,7 +171,7 @@ to get an error message.
 fn getopts(args: [str], opts: [opt]) -> result unsafe {
     let n_opts = vec::len::<opt>(opts);
     fn f(_x: uint) -> [optval] { ret []; }
-    let vals = vec::to_mut(vec::init_fn(n_opts, f));
+    let vals = vec::to_mut(vec::from_fn(n_opts, f));
     let free: [str] = [];
     let l = vec::len(args);
     let i = 0u;

--- a/src/libstd/linux_os.rs
+++ b/src/libstd/linux_os.rs
@@ -131,7 +131,7 @@ fn dylib_filename(base: str) -> str { ret "lib" + base + ".so"; }
 fn get_exe_path() -> option<fs::path> {
     let bufsize = 1023u;
     // FIXME: path "strings" will likely need fixing...
-    let path = str::from_bytes(vec::init_elt(bufsize, 0u8));
+    let path = str::from_bytes(vec::from_elem(bufsize, 0u8));
     ret str::as_buf("/proc/self/exe", { |proc_self_buf|
         str::as_buf(path, { |path_buf|
             if libc::readlink(proc_self_buf, path_buf, bufsize) != -1 {

--- a/src/libstd/macos_os.rs
+++ b/src/libstd/macos_os.rs
@@ -140,7 +140,7 @@ fn get_exe_path() -> option<fs::path> {
     // FIXME: This doesn't handle the case where the buffer is too small
     // FIXME: path "strings" will likely need fixing...
     let bufsize = 1023u32;
-    let path = str::from_bytes(vec::init_elt(bufsize as uint, 0u8));
+    let path = str::from_bytes(vec::from_elem(bufsize as uint, 0u8));
     ret str::as_buf(path, { |path_buf|
         if mac_libc::_NSGetExecutablePath(path_buf,
                                           ptr::mut_addr_of(bufsize)) == 0i32 {

--- a/src/libstd/map.rs
+++ b/src/libstd/map.rs
@@ -1,7 +1,7 @@
 #[doc = "A map type"];
 
 import chained::hashmap;
-export hashmap, hashfn, eqfn, set, map, chained, mk_hashmap, new_str_hash;
+export hashmap, hashfn, eqfn, set, map, chained, new_hashmap, new_str_hash;
 export new_bytes_hash, new_int_hash, new_uint_hash, set_add;
 
 #[doc = "
@@ -202,7 +202,7 @@ mod chained {
     }
 
     fn chains<K: copy, V: copy>(nchains: uint) -> [mutable chain<K,V>] {
-        ret vec::to_mut(vec::init_elt(nchains, absent));
+        ret vec::to_mut(vec::from_elem(nchains, absent));
     }
 
     fn foreach_entry<K: copy, V: copy>(chain0: chain<K,V>,
@@ -288,7 +288,7 @@ mod chained {
 }
 
 /*
-Function: mk_hashmap
+Function: new_hashmap
 
 Construct a hashmap.
 
@@ -297,33 +297,33 @@ Parameters:
 hasher - The hash function for key type K
 eqer - The equality function for key type K
 */
-fn mk_hashmap<K: copy, V: copy>(hasher: hashfn<K>, eqer: eqfn<K>)
+fn new_hashmap<K: copy, V: copy>(hasher: hashfn<K>, eqer: eqfn<K>)
         -> hashmap<K, V> {
     chained::mk(hasher, eqer)
 }
 
 #[doc = "Construct a hashmap for string keys"]
 fn new_str_hash<V: copy>() -> hashmap<str, V> {
-    ret mk_hashmap(str::hash, str::eq);
+    ret new_hashmap(str::hash, str::eq);
 }
 
 #[doc = "Construct a hashmap for byte string keys"]
 fn new_bytes_hash<V: copy>() -> hashmap<[u8], V> {
-    ret mk_hashmap(vec::u8::hash, vec::u8::eq);
+    ret new_hashmap(vec::u8::hash, vec::u8::eq);
 }
 
 #[doc = "Construct a hashmap for int keys"]
 fn new_int_hash<V: copy>() -> hashmap<int, V> {
     fn hash_int(&&x: int) -> uint { int::hash(x) }
     fn eq_int(&&a: int, &&b: int) -> bool { ret a == b; }
-    ret mk_hashmap(hash_int, eq_int);
+    ret new_hashmap(hash_int, eq_int);
 }
 
 #[doc = "Construct a hashmap for uint keys"]
 fn new_uint_hash<V: copy>() -> hashmap<uint, V> {
     fn hash_uint(&&x: uint) -> uint { uint::hash(x) }
     fn eq_uint(&&a: uint, &&b: uint) -> bool { ret a == b; }
-    ret mk_hashmap(hash_uint, eq_uint);
+    ret new_hashmap(hash_uint, eq_uint);
 }
 
 #[doc = "
@@ -345,7 +345,7 @@ mod tests {
         let eqer_str: map::eqfn<str> = str::eq;
         #debug("uint -> uint");
         let hm_uu: map::hashmap<uint, uint> =
-            map::mk_hashmap::<uint, uint>(hasher_uint, eqer_uint);
+            map::new_hashmap::<uint, uint>(hasher_uint, eqer_uint);
         assert (hm_uu.insert(10u, 12u));
         assert (hm_uu.insert(11u, 13u));
         assert (hm_uu.insert(12u, 14u));
@@ -361,7 +361,7 @@ mod tests {
         let twelve: str = "twelve";
         #debug("str -> uint");
         let hm_su: map::hashmap<str, uint> =
-            map::mk_hashmap::<str, uint>(hasher_str, eqer_str);
+            map::new_hashmap::<str, uint>(hasher_str, eqer_str);
         assert (hm_su.insert("ten", 12u));
         assert (hm_su.insert(eleven, 13u));
         assert (hm_su.insert("twelve", 14u));
@@ -375,7 +375,7 @@ mod tests {
         assert (hm_su.get("twelve") == 12u);
         #debug("uint -> str");
         let hm_us: map::hashmap<uint, str> =
-            map::mk_hashmap::<uint, str>(hasher_uint, eqer_uint);
+            map::new_hashmap::<uint, str>(hasher_uint, eqer_uint);
         assert (hm_us.insert(10u, "twelve"));
         assert (hm_us.insert(11u, "thirteen"));
         assert (hm_us.insert(12u, "fourteen"));
@@ -388,7 +388,7 @@ mod tests {
         assert (str::eq(hm_us.get(12u), "twelve"));
         #debug("str -> str");
         let hm_ss: map::hashmap<str, str> =
-            map::mk_hashmap::<str, str>(hasher_str, eqer_str);
+            map::new_hashmap::<str, str>(hasher_str, eqer_str);
         assert (hm_ss.insert(ten, "twelve"));
         assert (hm_ss.insert(eleven, "thirteen"));
         assert (hm_ss.insert(twelve, "fourteen"));
@@ -416,7 +416,7 @@ mod tests {
         let hasher_uint: map::hashfn<uint> = uint_id;
         let eqer_uint: map::eqfn<uint> = eq_uint;
         let hm_uu: map::hashmap<uint, uint> =
-            map::mk_hashmap::<uint, uint>(hasher_uint, eqer_uint);
+            map::new_hashmap::<uint, uint>(hasher_uint, eqer_uint);
         let i: uint = 0u;
         while i < num_to_insert {
             assert (hm_uu.insert(i, i * i));
@@ -443,7 +443,7 @@ mod tests {
         let hasher_str: map::hashfn<str> = str::hash;
         let eqer_str: map::eqfn<str> = str::eq;
         let hm_ss: map::hashmap<str, str> =
-            map::mk_hashmap::<str, str>(hasher_str, eqer_str);
+            map::new_hashmap::<str, str>(hasher_str, eqer_str);
         i = 0u;
         while i < num_to_insert {
             assert hm_ss.insert(uint::to_str(i, 2u), uint::to_str(i * i, 2u));
@@ -496,7 +496,7 @@ mod tests {
         let hasher: map::hashfn<uint> = hash;
         let eqer: map::eqfn<uint> = eq;
         let hm: map::hashmap<uint, uint> =
-            map::mk_hashmap::<uint, uint>(hasher, eqer);
+            map::new_hashmap::<uint, uint>(hasher, eqer);
         let i: uint = 0u;
         while i < num_to_insert {
             assert (hm.insert(i, i * i));
@@ -559,7 +559,7 @@ mod tests {
     #[test]
     fn test_contains_key() {
         let key = "k";
-        let map = map::mk_hashmap::<str, str>(str::hash, str::eq);
+        let map = map::new_hashmap::<str, str>(str::hash, str::eq);
         assert (!map.contains_key(key));
         map.insert(key, "val");
         assert (map.contains_key(key));
@@ -568,7 +568,7 @@ mod tests {
     #[test]
     fn test_find() {
         let key = "k";
-        let map = map::mk_hashmap::<str, str>(str::hash, str::eq);
+        let map = map::new_hashmap::<str, str>(str::hash, str::eq);
         assert (option::is_none(map.find(key)));
         map.insert(key, "val");
         assert (option::get(map.find(key)) == "val");

--- a/src/libstd/md4.rs
+++ b/src/libstd/md4.rs
@@ -30,7 +30,7 @@ fn md4(msg: [u8]) -> {a: u32, b: u32, c: u32, d: u32} {
     }
 
     let i = 0u, e = vec::len(msg);
-    let x = vec::to_mut(vec::init_elt(16u, 0u32));
+    let x = vec::to_mut(vec::from_elem(16u, 0u32));
     while i < e {
         let aa = a, bb = b, cc = c, dd = d;
 

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -27,7 +27,7 @@ iface rng {
 resource rand_res(c: *rctx) { rustrt::rand_free(c); }
 
 #[doc = "Create a random number generator"]
-fn mk_rng() -> rng {
+fn rng() -> rng {
     impl of rng for @rand_res {
         fn next() -> u32 { ret rustrt::rand_next(**self); }
         fn next_float() -> float {
@@ -70,11 +70,11 @@ mod tests {
 
     #[test]
     fn test() {
-        let r1: rand::rng = rand::mk_rng();
+        let r1: rand::rng = rand::rng();
         log(debug, r1.next());
         log(debug, r1.next());
         {
-            let r2 = rand::mk_rng();
+            let r2 = rand::rng();
             log(debug, r1.next());
             log(debug, r2.next());
             log(debug, r1.next());
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn genstr() {
-        let r: rand::rng = rand::mk_rng();
+        let r: rand::rng = rand::rng();
         log(debug, r.gen_str(10u));
         log(debug, r.gen_str(10u));
         log(debug, r.gen_str(10u));

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -157,7 +157,7 @@ fn concat(v: [rope]) -> rope {
     //Copy `v` into a mutable vector
     let len   = vec::len(v);
     if len == 0u { ret node::empty; }
-    let ropes = vec::to_mut(vec::init_elt(len, v[0]));
+    let ropes = vec::to_mut(vec::from_elem(len, v[0]));
     uint::range(1u, len) {|i|
        ropes[i] = v[i];
     }
@@ -686,7 +686,7 @@ mod node {
             //Firstly, split `str` in slices of hint_max_leaf_char_len
             let leaves = uint::div_ceil(char_len, hint_max_leaf_char_len);
             //Number of leaves
-            let nodes  = vec::to_mut(vec::init_elt(leaves, candidate));
+            let nodes  = vec::to_mut(vec::from_elem(leaves, candidate));
 
             let i = 0u;
             let offset = byte_start;
@@ -797,7 +797,7 @@ mod node {
     }
 
     fn serialize_node(node: @node) -> str unsafe {
-        let buf = vec::to_mut(vec::init_elt(byte_len(node), 0u8));
+        let buf = vec::to_mut(vec::from_elem(byte_len(node), 0u8));
         let offset = 0u;//Current position in the buffer
         let it = leaf_iterator::start(node);
         loop {
@@ -1126,7 +1126,7 @@ mod node {
         }
 
         fn start(node: @node) -> t {
-            let stack = vec::to_mut(vec::init_elt(height(node)+1u, node));
+            let stack = vec::to_mut(vec::from_elem(height(node)+1u, node));
             ret {
                 stack:             stack,
                 mutable stackpos:  0
@@ -1392,7 +1392,7 @@ mod tests {
         }
 
         //Same rope, obtained with rope::concat
-        let r2 = concat(vec::init_elt(10u, chunk));
+        let r2 = concat(vec::from_elem(10u, chunk));
 
         assert eq(r, r2);
     }

--- a/src/libstd/serialization.rs
+++ b/src/libstd/serialization.rs
@@ -165,7 +165,7 @@ impl of serializer for ebml::writer {
 type ebml_deserializer = {mutable parent: ebml::doc,
                           mutable pos: uint};
 
-fn mk_ebml_deserializer(d: ebml::doc) -> ebml_deserializer {
+fn ebml_deserializer(d: ebml::doc) -> ebml_deserializer {
     {mutable parent: d, mutable pos: d.start}
 }
 
@@ -401,10 +401,10 @@ fn test_option_int() {
     fn test_v(v: option<int>) {
         #debug["v == %?", v];
         let mbuf = io::mk_mem_buffer();
-        let ebml_w = ebml::mk_writer(io::mem_buffer_writer(mbuf));
+        let ebml_w = ebml::writer(io::mem_buffer_writer(mbuf));
         serialize_0(ebml_w, v);
         let ebml_doc = ebml::new_doc(@io::mem_buffer_buf(mbuf));
-        let deser = mk_ebml_deserializer(ebml_doc);
+        let deser = ebml_deserializer(ebml_doc);
         let v1 = deserialize_0(deser);
         #debug["v1 == %?", v1];
         assert v == v1;

--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -18,7 +18,6 @@ the `reset` method.
  * point this will want to be rewritten.
  */
 export sha1;
-export mk_sha1;
 
 #[doc = "The SHA-1 interface"]
 iface sha1 {
@@ -51,7 +50,7 @@ const k3: u32 = 0xCA62C1D6u32;
 
 
 #[doc = "Construct a `sha` object"]
-fn mk_sha1() -> sha1 {
+fn sha1() -> sha1 {
     type sha1state =
         {h: [mutable u32],
          mutable len_low: u32,
@@ -244,13 +243,13 @@ fn mk_sha1() -> sha1 {
         }
     }
     let st = {
-        h: vec::to_mut(vec::init_elt(digest_buf_len, 0u32)),
+        h: vec::to_mut(vec::from_elem(digest_buf_len, 0u32)),
         mutable len_low: 0u32,
         mutable len_high: 0u32,
-        msg_block: vec::to_mut(vec::init_elt(msg_block_len, 0u8)),
+        msg_block: vec::to_mut(vec::from_elem(msg_block_len, 0u8)),
         mutable msg_block_idx: 0u,
         mutable computed: false,
-        work_buf: vec::to_mut(vec::init_elt(work_buf_len, 0u32))
+        work_buf: vec::to_mut(vec::from_elem(work_buf_len, 0u32))
     };
     let sh = st as sha1;
     sh.reset();
@@ -327,7 +326,7 @@ mod tests {
         }
         // Test that it works when accepting the message all at once
 
-        let sh = sha1::mk_sha1();
+        let sh = sha1::sha1();
         for t: test in tests {
             sh.input_str(t.input);
             let out = sh.result();

--- a/src/libstd/tempfile.rs
+++ b/src/libstd/tempfile.rs
@@ -6,7 +6,7 @@ import option::{none, some};
 import rand;
 
 fn mkdtemp(prefix: str, suffix: str) -> option<str> {
-    let r = rand::mk_rng();
+    let r = rand::rng();
     let i = 0u;
     while (i < 1000u) {
         let s = prefix + r.gen_str(16u) + suffix;

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -316,7 +316,7 @@ fn run_test(+test: test_desc, monitor_ch: comm::chan<monitor_msg>) {
     task::spawn {||
 
         let testfn = test.fn;
-        let builder = task::mk_task_builder();
+        let builder = task::task_builder();
         let result_future = task::future_result(builder);
         task::unsupervise(builder);
         task::run(builder, testfn);

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -10,7 +10,7 @@ import core::option::{some, none};
 import option = core::option;
 
 export treemap;
-export init;
+export treemap;
 export insert;
 export find;
 export traverse;
@@ -20,7 +20,7 @@ type treemap<K, V> = @mutable tree_node<K, V>;
 enum tree_node<K, V> { empty, node(@K, @V, treemap<K, V>, treemap<K, V>) }
 
 #[doc = "Create a treemap"]
-fn init<K, V>() -> treemap<K, V> { @mutable empty }
+fn treemap<K, V>() -> treemap<K, V> { @mutable empty }
 
 #[doc = "Insert a value into the map"]
 fn insert<K: copy, V: copy>(m: treemap<K, V>, k: K, v: V) {
@@ -78,36 +78,36 @@ fn traverse<K, V>(m: treemap<K, V>, f: fn(K, V)) {
 mod tests {
 
     #[test]
-    fn init_treemap() { let _m = init::<int, int>(); }
+    fn init_treemap() { let _m = treemap::<int, int>(); }
 
     #[test]
-    fn insert_one() { let m = init(); insert(m, 1, 2); }
+    fn insert_one() { let m = treemap(); insert(m, 1, 2); }
 
     #[test]
-    fn insert_two() { let m = init(); insert(m, 1, 2); insert(m, 3, 4); }
+    fn insert_two() { let m = treemap(); insert(m, 1, 2); insert(m, 3, 4); }
 
     #[test]
     fn insert_find() {
-        let m = init();
+        let m = treemap();
         insert(m, 1, 2);
         assert (find(m, 1) == some(2));
     }
 
     #[test]
     fn find_empty() {
-        let m = init::<int, int>(); assert (find(m, 1) == none);
+        let m = treemap::<int, int>(); assert (find(m, 1) == none);
     }
 
     #[test]
     fn find_not_found() {
-        let m = init();
+        let m = treemap();
         insert(m, 1, 2);
         assert (find(m, 2) == none);
     }
 
     #[test]
     fn traverse_in_order() {
-        let m = init();
+        let m = treemap();
         insert(m, 3, ());
         insert(m, 0, ());
         insert(m, 4, ());
@@ -123,7 +123,7 @@ mod tests {
 
     #[test]
     fn u8_map() {
-        let m = init();
+        let m = treemap();
 
         let k1 = str::bytes("foo");
         let k2 = str::bytes("bar");

--- a/src/libstd/uv.rs
+++ b/src/libstd/uv.rs
@@ -409,7 +409,7 @@ fn do_send(h: *ctypes::void) {
     rustrt::rust_uv_async_send(h);
 }
 fn gen_handle_id() -> [u8] {
-    ret rand::mk_rng().gen_bytes(16u);
+    ret rand::rng().gen_bytes(16u);
 }
 fn get_handle_id_from(buf: *u8) -> [u8] unsafe {
     ret vec::unsafe::from_buf(buf, 16u);

--- a/src/libstd/win32_os.rs
+++ b/src/libstd/win32_os.rs
@@ -120,7 +120,7 @@ fn get_exe_path() -> option<fs::path> {
     // FIXME: This doesn't handle the case where the buffer is too small
     // FIXME: path "strings" will likely need fixing...
     let bufsize = 1023u;
-    let path = str::from_bytes(vec::init_elt(bufsize, 0u8));
+    let path = str::from_bytes(vec::from_elem(bufsize, 0u8));
     ret str::as_buf(path, { |path_buf|
         if kernel32::GetModuleFileNameA(0u, path_buf,
                                         bufsize as u32) != 0u32 {

--- a/src/rustc/lib/llvm.rs
+++ b/src/rustc/lib/llvm.rs
@@ -940,7 +940,7 @@ fn name_has_type(tn: type_names, s: str) -> option<TypeRef> {
 fn mk_type_names() -> type_names {
     fn hash(&&t: TypeRef) -> uint { ret t as uint; }
     fn eq(&&a: TypeRef, &&b: TypeRef) -> bool { ret a as uint == b as uint; }
-    @{type_names: std::map::mk_hashmap(hash, eq),
+    @{type_names: std::map::new_hashmap(hash, eq),
       named_types: std::map::new_str_hash()}
 }
 
@@ -987,7 +987,7 @@ fn type_to_str_inner(names: type_names, outer0: [TypeRef], ty: TypeRef) ->
         let s = "fn(";
         let out_ty: TypeRef = llvm::LLVMGetReturnType(ty);
         let n_args = llvm::LLVMCountParamTypes(ty) as uint;
-        let args: [TypeRef] = vec::init_elt::<TypeRef>(n_args, 0 as TypeRef);
+        let args: [TypeRef] = vec::from_elem::<TypeRef>(n_args, 0 as TypeRef);
         unsafe {
             llvm::LLVMGetParamTypes(ty, vec::unsafe::to_ptr(args));
         }
@@ -999,7 +999,7 @@ fn type_to_str_inner(names: type_names, outer0: [TypeRef], ty: TypeRef) ->
       10 {
         let s: str = "{";
         let n_elts = llvm::LLVMCountStructElementTypes(ty) as uint;
-        let elts: [TypeRef] = vec::init_elt::<TypeRef>(n_elts, 0 as TypeRef);
+        let elts: [TypeRef] = vec::from_elem::<TypeRef>(n_elts, 0 as TypeRef);
         unsafe {
             llvm::LLVMGetStructElementTypes(ty, vec::unsafe::to_ptr(elts));
         }
@@ -1042,7 +1042,7 @@ fn float_width(llt: TypeRef) -> uint {
 }
 
 fn fn_ty_param_tys(fn_ty: TypeRef) -> [TypeRef] unsafe {
-    let args = vec::init_elt(llvm::LLVMCountParamTypes(fn_ty) as uint,
+    let args = vec::from_elem(llvm::LLVMCountParamTypes(fn_ty) as uint,
                              0 as TypeRef);
     llvm::LLVMGetParamTypes(fn_ty, vec::unsafe::to_ptr(args));
     ret args;

--- a/src/rustc/metadata/astencode.rs
+++ b/src/rustc/metadata/astencode.rs
@@ -244,7 +244,7 @@ fn encode_id_range(ebml_w: ebml::writer, id_range: id_range) {
 
 fn decode_id_range(par_doc: ebml::doc) -> id_range {
     let range_doc = par_doc[c::tag_id_range];
-    let dsr = serialization::mk_ebml_deserializer(range_doc);
+    let dsr = serialization::ebml_deserializer(range_doc);
     dsr.read_tup(2u) {||
         {min: dsr.read_tup_elt(0u) {|| dsr.read_int() },
          max: dsr.read_tup_elt(1u) {|| dsr.read_int() }}
@@ -369,7 +369,7 @@ fn simplify_ast(ii: ast::inlined_item) -> ast::inlined_item {
 
 fn decode_ast(par_doc: ebml::doc) -> ast::inlined_item {
     let chi_doc = par_doc[c::tag_tree];
-    let d = serialization::mk_ebml_deserializer(chi_doc);
+    let d = serialization::ebml_deserializer(chi_doc);
     astencode_gen::deserialize_syntax_ast_inlined_item(d)
 }
 
@@ -399,7 +399,7 @@ fn encode_def(ebml_w: ebml::writer, def: ast::def) {
 }
 
 fn decode_def(xcx: extended_decode_ctxt, doc: ebml::doc) -> ast::def {
-    let dsr = serialization::mk_ebml_deserializer(doc);
+    let dsr = serialization::ebml_deserializer(doc);
     let def = astencode_gen::deserialize_syntax_ast_def(dsr);
     def.tr(xcx)
 }
@@ -851,7 +851,7 @@ fn decode_side_tables(xcx: extended_decode_ctxt,
             dcx.maps.copy_map.insert(id, ());
         } else {
             let val_doc = entry_doc[c::tag_table_val];
-            let val_dsr = serialization::mk_ebml_deserializer(val_doc);
+            let val_dsr = serialization::ebml_deserializer(val_doc);
             if tag == (c::tag_table_def as uint) {
                 let def = decode_def(xcx, val_doc);
                 dcx.tcx.def_map.insert(id, def);
@@ -904,7 +904,7 @@ fn encode_item_ast(ebml_w: ebml::writer, item: @ast::item) {
 #[cfg(test)]
 fn decode_item_ast(par_doc: ebml::doc) -> @ast::item {
     let chi_doc = par_doc[c::tag_tree];
-    let d = serialization::mk_ebml_deserializer(chi_doc);
+    let d = serialization::ebml_deserializer(chi_doc);
     @astencode_gen::deserialize_syntax_ast_item(d)
 }
 
@@ -949,7 +949,7 @@ fn mk_ctxt() -> fake_ext_ctxt {
 fn roundtrip(in_item: @ast::item) {
     #debug["in_item = %s", pprust::item_to_str(in_item)];
     let mbuf = io::mk_mem_buffer();
-    let ebml_w = ebml::mk_writer(io::mem_buffer_writer(mbuf));
+    let ebml_w = ebml::writer(io::mem_buffer_writer(mbuf));
     encode_item_ast(ebml_w, in_item);
     let ebml_doc = ebml::new_doc(@io::mem_buffer_buf(mbuf));
     let out_item = decode_item_ast(ebml_doc);

--- a/src/rustc/metadata/astencode_gen.rs
+++ b/src/rustc/metadata/astencode_gen.rs
@@ -4303,7 +4303,7 @@ fn deserialize_8<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::meta_item*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_9(s) })
                                 })
@@ -4728,7 +4728,7 @@ fn deserialize_2<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::attribute*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_3(s) })
                                 })
@@ -4864,7 +4864,7 @@ fn deserialize_36<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::ty_field*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_37(s) })
                                 })
@@ -4977,7 +4977,7 @@ fn deserialize_41<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::arg*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_42(s) })
                                 })
@@ -5028,7 +5028,7 @@ fn deserialize_54<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::ident*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_1(s) })
                                 })
@@ -5041,7 +5041,7 @@ fn deserialize_55<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::ty*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_29(s) })
                                 })
@@ -5177,7 +5177,7 @@ fn deserialize_56<S: std::serialization::deserializer>(s: S) ->
                /*@{node: syntax::ast::constr_arg_general_<uint>,span: syntax::codemap::span}*/
 
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_57(s) })
                                 })
@@ -5246,7 +5246,7 @@ fn deserialize_47<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::constr*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_48(s) })
                                 })
@@ -5356,7 +5356,7 @@ fn deserialize_65<S: std::serialization::deserializer>(s: S) ->
                /*@{node: syntax::ast::constr_arg_general_<@syntax::ast::path>,span: syntax::codemap::span}*/
 
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_66(s) })
                                 })
@@ -5419,7 +5419,7 @@ fn deserialize_61<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::ty_constr*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_62(s) })
                                 })
@@ -5432,7 +5432,7 @@ fn deserialize_75<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::expr*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_72(s) })
                                 })
@@ -5490,7 +5490,7 @@ fn deserialize_76<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::field*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_77(s) })
                                 })
@@ -5524,7 +5524,7 @@ fn deserialize_80<S: std::serialization::deserializer>(s: S) ->
 
                /*core::option::t<@syntax::ast::expr>*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_79(s) })
                                 })
@@ -5639,7 +5639,7 @@ fn deserialize_94<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::ident*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_1(s) })
                                 })
@@ -5696,7 +5696,7 @@ fn deserialize_95<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::path_list_ident*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_96(s) })
                                 })
@@ -5792,7 +5792,7 @@ fn deserialize_89<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::view_path*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_90(s) })
                                 })
@@ -5875,7 +5875,7 @@ fn deserialize_85<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::view_item*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_86(s) })
                                 })
@@ -5909,7 +5909,7 @@ fn deserialize_113<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::pat*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_109(s) })
@@ -5943,7 +5943,7 @@ fn deserialize_114<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::field_pat*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_115(s) })
@@ -6195,7 +6195,7 @@ fn deserialize_105<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::local*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_106(s) })
@@ -6344,7 +6344,7 @@ fn deserialize_98<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::stmt*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_99(s) })
                                 })
@@ -6457,7 +6457,7 @@ fn deserialize_121<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::arm*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_122(s) })
@@ -6523,7 +6523,7 @@ fn deserialize_126<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::capture_item*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_127(s) })
@@ -7376,7 +7376,7 @@ fn deserialize_136<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::ty_param_bound*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_137(s) })
@@ -7420,7 +7420,7 @@ fn deserialize_133<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::ty_param*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_134(s) })
@@ -7434,7 +7434,7 @@ fn deserialize_139<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::item*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_119(s) })
@@ -7530,7 +7530,7 @@ fn deserialize_141<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::native_item*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_142(s) })
@@ -7581,7 +7581,7 @@ fn deserialize_148<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::variant_arg*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_149(s) })
@@ -7648,7 +7648,7 @@ fn deserialize_145<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::variant*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_146(s) })
@@ -7786,7 +7786,7 @@ fn deserialize_150<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::class_item*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_151(s) })
@@ -7875,7 +7875,7 @@ fn deserialize_159<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::ty_method*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_160(s) })
@@ -7960,7 +7960,7 @@ fn deserialize_162<S: std::serialization::deserializer>(s: S) ->
 
                /*@syntax::ast::method*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i,
                                                    {|| deserialize_163(s) })
@@ -9142,7 +9142,7 @@ fn deserialize_174<S: std::serialization::deserializer>(s: S) ->
 
                /*syntax::ast::node_id*/
                {|len|
-                   vec::init_fn(len,
+                   vec::from_fn(len,
                                 {|i|
                                     s.read_vec_elt(i, {|| deserialize_27(s) })
                                 })

--- a/src/rustc/metadata/encoder.rs
+++ b/src/rustc/metadata/encoder.rs
@@ -747,7 +747,7 @@ fn encode_metadata(cx: crate_ctxt, crate: @crate) -> [u8] {
 
     let buf = io::mk_mem_buffer();
     let buf_w = io::mem_buffer_writer(buf);
-    let ebml_w = ebml::mk_writer(buf_w);
+    let ebml_w = ebml::writer(buf_w);
 
     encode_hash(ebml_w, cx.link_meta.extras_hash);
 

--- a/src/rustc/middle/check_alt.rs
+++ b/src/rustc/middle/check_alt.rs
@@ -89,7 +89,7 @@ fn check_exhaustive(tcx: ty::ctxt, sp: span, pats: [@pat]) {
         }));
       }
       ty::ty_tup(ts) {
-        let cols = vec::to_mut(vec::init_elt(ts.len(), []));
+        let cols = vec::to_mut(vec::from_elem(ts.len(), []));
         for p in pats {
             alt raw_pat(p).node {
               pat_tup(sub) {
@@ -101,7 +101,7 @@ fn check_exhaustive(tcx: ty::ctxt, sp: span, pats: [@pat]) {
         vec::iter(cols) {|col| check_exhaustive(tcx, sp, col); }
       }
       ty::ty_rec(fs) {
-        let cols = vec::init_elt(fs.len(), {mutable wild: false,
+        let cols = vec::from_elem(fs.len(), {mutable wild: false,
                                             mutable pats: []});
         for p in pats {
             alt raw_pat(p).node {
@@ -157,7 +157,7 @@ fn check_exhaustive_enum(tcx: ty::ctxt, enum_id: def_id, sp: span,
     let variants = enum_variants(tcx, enum_id);
     let columns_by_variant = vec::map(*variants, {|v|
         {mutable seen: false,
-         cols: vec::to_mut(vec::init_elt(v.args.len(), []))}
+         cols: vec::to_mut(vec::from_elem(v.args.len(), []))}
     });
 
     for pat in pats {

--- a/src/rustc/middle/last_use.rs
+++ b/src/rustc/middle/last_use.rs
@@ -58,7 +58,7 @@ fn find_last_uses(c: @crate, def_map: resolve::def_map,
                            visit_stmt: visit_stmt,
                            visit_fn: visit_fn
                            with *visit::default_visitor()});
-    let cx = {last_uses: std::map::mk_hashmap(hash_use_id, {|a, b| a == b}),
+    let cx = {last_uses: std::map::new_hashmap(hash_use_id, {|a, b| a == b}),
               def_map: def_map,
               ref_map: ref_map,
               tcx: tcx,

--- a/src/rustc/middle/resolve.rs
+++ b/src/rustc/middle/resolve.rs
@@ -8,7 +8,7 @@ import front::attr;
 import metadata::{csearch, cstore};
 import driver::session::session;
 import util::common::*;
-import std::map::{new_int_hash, new_str_hash, mk_hashmap};
+import std::map::{new_int_hash, new_str_hash, new_hashmap};
 import syntax::codemap::span;
 import syntax::visit;
 import visit::vt;
@@ -82,7 +82,7 @@ fn new_ext_hash() -> ext_hash {
         ret util::common::def_eq(v1.did, v2.did) &&
                 str::eq(v1.ident, v2.ident) && v1.ns == v2.ns;
     }
-    ret std::map::mk_hashmap::<key, def>(hash, eq);
+    ret std::map::new_hashmap::<key, def>(hash, eq);
 }
 
 enum mod_index_entry {

--- a/src/rustc/middle/trans/alt.rs
+++ b/src/rustc/middle/trans/alt.rs
@@ -174,7 +174,7 @@ fn enter_opt(tcx: ty::ctxt, m: match, opt: opt, col: uint,
           ast::pat_range(l1, l2) {
             if opt_eq(range(l1, l2), opt) { some([]) } else { none }
           }
-          _ { some(vec::init_elt(variant_size, dummy)) }
+          _ { some(vec::from_elem(variant_size, dummy)) }
         }
     }
 }
@@ -195,7 +195,7 @@ fn enter_rec(dm: def_map, m: match, col: uint, fields: [ast::ident],
             }
             some(pats)
           }
-          _ { some(vec::init_elt(fields.len(), dummy)) }
+          _ { some(vec::from_elem(fields.len(), dummy)) }
         }
     }
 }
@@ -206,7 +206,7 @@ fn enter_tup(dm: def_map, m: match, col: uint, val: ValueRef,
     enter_match(dm, m, col, val) {|p|
         alt p.node {
           ast::pat_tup(elts) { some(elts) }
-          _ { some(vec::init_elt(n_elts, dummy)) }
+          _ { some(vec::from_elem(n_elts, dummy)) }
         }
     }
 }
@@ -334,7 +334,7 @@ fn pick_col(m: match) -> uint {
           _ { 0u }
         }
     }
-    let scores = vec::to_mut(vec::init_elt(m[0].pats.len(), 0u));
+    let scores = vec::to_mut(vec::from_elem(m[0].pats.len(), 0u));
     for br: match_branch in m {
         let i = 0u;
         for p: @ast::pat in br.pats { scores[i] += score(p); i += 1u; }

--- a/src/rustc/middle/trans/base.rs
+++ b/src/rustc/middle/trans/base.rs
@@ -208,7 +208,7 @@ fn get_simple_extern_fn(cx: block,
                         llmod: ModuleRef,
                         name: str, n_args: int) -> ValueRef {
     let ccx = cx.fcx.ccx;
-    let inputs = vec::init_elt(n_args as uint, ccx.int_type);
+    let inputs = vec::from_elem(n_args as uint, ccx.int_type);
     let output = ccx.int_type;
     let t = T_fn(inputs, output);
     ret get_extern_fn(externs, llmod, name, lib::llvm::CCallConv, t);
@@ -2547,7 +2547,7 @@ fn lval_maybe_callee_to_lval(c: lval_maybe_callee, ty: ty::t) -> lval_result {
         alt c.env { self_env(_, _) | dict_env(_, _) { true } _ { false } };
     if must_bind {
         let n_args = ty::ty_fn_args(ty).len();
-        let args = vec::init_elt(n_args, none);
+        let args = vec::from_elem(n_args, none);
         let space = alloc_ty(c.bcx, ty);
         let bcx = closure::trans_bind_1(space.bcx, ty, c, args, ty,
                                               save_in(space.val));
@@ -4928,7 +4928,7 @@ fn write_abi_version(ccx: crate_ctxt) {
 fn trans_crate(sess: session::session, crate: @ast::crate, tcx: ty::ctxt,
                output: str, emap: resolve::exp_map, maps: maps)
     -> (ModuleRef, link::link_meta) {
-    let sha = std::sha1::mk_sha1();
+    let sha = std::sha1::sha1();
     let link_meta = link::build_link_meta(sess, *crate, output, sha);
 
     // Append ".rc" to crate name as LLVM module identifier.
@@ -4991,9 +4991,9 @@ fn trans_crate(sess: session::session, crate: @ast::crate, tcx: ty::ctxt,
           discrims: ast_util::new_def_id_hash::<ValueRef>(),
           discrim_symbols: new_int_hash::<str>(),
           tydescs: ty::new_ty_hash(),
-          dicts: map::mk_hashmap(hash_dict_id, {|a, b| a == b}),
+          dicts: map::new_hashmap(hash_dict_id, {|a, b| a == b}),
           external: util::common::new_def_hash(),
-          monomorphized: map::mk_hashmap(hash_mono_id, {|a, b| a == b}),
+          monomorphized: map::new_hashmap(hash_mono_id, {|a, b| a == b}),
           module_data: new_str_hash::<ValueRef>(),
           lltypes: ty::new_ty_hash(),
           names: new_namegen(),

--- a/src/rustc/middle/trans/common.rs
+++ b/src/rustc/middle/trans/common.rs
@@ -391,7 +391,7 @@ fn val_str(tn: type_names, v: ValueRef) -> str { ret ty_str(tn, val_ty(v)); }
 fn struct_elt(llstructty: TypeRef, n: uint) -> TypeRef unsafe {
     let elt_count = llvm::LLVMCountStructElementTypes(llstructty) as uint;
     assert (n < elt_count);
-    let elt_tys = vec::init_elt(elt_count, T_nil());
+    let elt_tys = vec::from_elem(elt_count, T_nil());
     llvm::LLVMGetStructElementTypes(llstructty, to_ptr(elt_tys));
     ret llvm::LLVMGetElementType(elt_tys[n]);
 }
@@ -572,7 +572,7 @@ fn T_tydesc_field(cx: crate_ctxt, field: int) -> TypeRef unsafe {
     // Bit of a kludge: pick the fn typeref out of the tydesc..
 
     let tydesc_elts: [TypeRef] =
-        vec::init_elt::<TypeRef>(abi::n_tydesc_fields as uint,
+        vec::from_elem::<TypeRef>(abi::n_tydesc_fields as uint,
                                  T_nil());
     llvm::LLVMGetStructElementTypes(cx.tydesc_type,
                                     to_ptr::<TypeRef>(tydesc_elts));
@@ -724,7 +724,7 @@ fn T_opaque_enum_ptr(cx: crate_ctxt) -> TypeRef {
 }
 
 fn T_captured_tydescs(cx: crate_ctxt, n: uint) -> TypeRef {
-    ret T_struct(vec::init_elt::<TypeRef>(n, T_ptr(cx.tydesc_type)));
+    ret T_struct(vec::from_elem::<TypeRef>(n, T_ptr(cx.tydesc_type)));
 }
 
 fn T_opaque_iface(cx: crate_ctxt) -> TypeRef {

--- a/src/rustc/middle/trans/impl.rs
+++ b/src/rustc/middle/trans/impl.rs
@@ -202,7 +202,7 @@ fn trans_iface_callee(bcx: block, callee_id: ast::node_id,
 fn llfn_arg_tys(ft: TypeRef) -> {inputs: [TypeRef], output: TypeRef} {
     let out_ty = llvm::LLVMGetReturnType(ft);
     let n_args = llvm::LLVMCountParamTypes(ft);
-    let args = vec::init_elt(n_args as uint, 0 as TypeRef);
+    let args = vec::from_elem(n_args as uint, 0 as TypeRef);
     unsafe { llvm::LLVMGetParamTypes(ft, vec::unsafe::to_ptr(args)); }
     {inputs: args, output: out_ty}
 }

--- a/src/rustc/middle/tstate/states.rs
+++ b/src/rustc/middle/tstate/states.rs
@@ -357,7 +357,7 @@ fn find_pre_post_state_expr(fcx: fn_ctxt, pres: prestate, e: @expr) -> bool {
     alt e.node {
       expr_vec(elts, _) {
         ret find_pre_post_state_exprs(fcx, pres, e.id,
-                                      vec::init_elt(vec::len(elts),
+                                      vec::from_elem(vec::len(elts),
                                                     init_assign), elts,
                                       return_val);
       }
@@ -401,7 +401,7 @@ fn find_pre_post_state_expr(fcx: fn_ctxt, pres: prestate, e: @expr) -> bool {
         let exs = field_exprs(fields);
         let changed =
             find_pre_post_state_exprs(fcx, pres, e.id,
-                                      vec::init_elt(vec::len(fields),
+                                      vec::from_elem(vec::len(fields),
                                                     init_assign),
                                       exs, return_val);
 
@@ -415,7 +415,7 @@ fn find_pre_post_state_expr(fcx: fn_ctxt, pres: prestate, e: @expr) -> bool {
       }
       expr_tup(elts) {
         ret find_pre_post_state_exprs(fcx, pres, e.id,
-                                      vec::init_elt(vec::len(elts),
+                                      vec::from_elem(vec::len(elts),
                                                     init_assign), elts,
                                       return_val);
       }

--- a/src/rustc/middle/ty.rs
+++ b/src/rustc/middle/ty.rs
@@ -322,18 +322,18 @@ fn mk_rcache() -> creader_cache {
     fn eq_cache_entries(a: val, b: val) -> bool {
         ret a.cnum == b.cnum && a.pos == b.pos && a.len == b.len;
     }
-    ret map::mk_hashmap(hash_cache_entry, eq_cache_entries);
+    ret map::new_hashmap(hash_cache_entry, eq_cache_entries);
 }
 
 fn new_ty_hash<V: copy>() -> map::hashmap<t, V> {
-    map::mk_hashmap({|&&t: t| type_id(t)},
+    map::new_hashmap({|&&t: t| type_id(t)},
                     {|&&a: t, &&b: t| type_id(a) == type_id(b)})
 }
 
 fn mk_ctxt(s: session::session, dm: resolve::def_map, amap: ast_map::map,
            freevars: freevars::freevar_map,
            region_map: @middle::region::region_map) -> ctxt {
-    let interner = map::mk_hashmap({|&&k: intern_key|
+    let interner = map::new_hashmap({|&&k: intern_key|
         hash_type_structure(k.struct) +
             option::maybe(0u, k.o_def_id, ast_util::hash_def_id)
     }, {|&&a, &&b| a == b});
@@ -351,7 +351,8 @@ fn mk_ctxt(s: session::session, dm: resolve::def_map, amap: ast_map::map,
       short_names_cache: new_ty_hash(),
       needs_drop_cache: new_ty_hash(),
       kind_cache: new_ty_hash(),
-      ast_ty_to_ty_cache: map::mk_hashmap(ast_util::hash_ty, ast_util::eq_ty),
+      ast_ty_to_ty_cache: map::new_hashmap(
+          ast_util::hash_ty, ast_util::eq_ty),
       enum_var_cache: new_def_hash(),
       iface_method_cache: new_def_hash(),
       ty_param_bounds: map::new_int_hash(),

--- a/src/rustc/middle/typeck.rs
+++ b/src/rustc/middle/typeck.rs
@@ -190,7 +190,7 @@ fn instantiate_path(fcx: @fn_ctxt, pth: @ast::path,
         });
         write_ty_substs(fcx.ccx.tcx, id, tpt.ty, substs);
     } else if ty_param_count > 0u {
-        let vars = vec::init_fn(ty_param_count, {|_i| next_ty_var(fcx)});
+        let vars = vec::from_fn(ty_param_count, {|_i| next_ty_var(fcx)});
         write_ty_substs(fcx.ccx.tcx, id, tpt.ty, vars);
     } else {
         write_ty(fcx.ccx.tcx, id, tpt.ty);
@@ -697,7 +697,7 @@ fn compare_impl_method(tcx: ty::ctxt, sp: span, impl_m: ty::method,
         });
         let impl_fty = ty::mk_fn(tcx, {inputs: auto_modes with impl_m.fty});
         // Add dummy substs for the parameters of the impl method
-        let substs = substs + vec::init_fn(vec::len(*if_m.tps), {|i|
+        let substs = substs + vec::from_fn(vec::len(*if_m.tps), {|i|
             ty::mk_param(tcx, i + impl_tps, {crate: 0, node: 0})
         });
         let if_fty = ty::mk_fn(tcx, if_m.fty);
@@ -1685,7 +1685,7 @@ fn lookup_method(fcx: @fn_ctxt, expr: @ast::expr, node_id: ast::node_id,
                                      parameters given for this method");
 
                 }
-                substs += vec::init_fn(method_n_tps, {|_i|
+                substs += vec::from_fn(method_n_tps, {|_i|
                     ty::mk_var(tcx, next_ty_var_id(fcx))
                 });
             } else {
@@ -1957,7 +1957,7 @@ fn check_expr_with_unifier(fcx: @fn_ctxt, expr: @ast::expr, unify: unifier,
             // check against
             let dummy = {mode: ast::expl(ast::by_ref),
                          ty: ty::mk_bot(fcx.ccx.tcx)};
-            arg_tys = vec::init_elt(supplied_arg_count, dummy);
+            arg_tys = vec::from_elem(supplied_arg_count, dummy);
         }
 
         // Check the arguments.
@@ -2682,7 +2682,7 @@ fn next_ty_var(fcx: @fn_ctxt) -> ty::t {
 
 fn bind_params(fcx: @fn_ctxt, tp: ty::t, count: uint)
     -> {vars: [ty::t], ty: ty::t} {
-    let vars = vec::init_fn(count, {|_i| next_ty_var(fcx)});
+    let vars = vec::from_fn(count, {|_i| next_ty_var(fcx)});
     {vars: vars, ty: ty::substitute_type_params(fcx.ccx.tcx, vars, tp)}
 }
 

--- a/src/rustc/syntax/ast_util.rs
+++ b/src/rustc/syntax/ast_util.rs
@@ -227,7 +227,7 @@ fn eq_def_id(&&a: def_id, &&b: def_id) -> bool {
 }
 
 fn new_def_id_hash<T: copy>() -> std::map::hashmap<def_id, T> {
-    std::map::mk_hashmap(hash_def_id, eq_def_id)
+    std::map::new_hashmap(hash_def_id, eq_def_id)
 }
 
 fn block_from_expr(e: @expr) -> blk {

--- a/src/rustc/syntax/print/pp.rs
+++ b/src/rustc/syntax/print/pp.rs
@@ -101,9 +101,9 @@ fn mk_printer(out: io::writer, linewidth: uint) -> printer {
     // fall behind.
     let n: uint = 3u * linewidth;
     #debug("mk_printer %u", linewidth);
-    let token: [mutable token] = vec::to_mut(vec::init_elt(n, EOF));
-    let size: [mutable int] = vec::to_mut(vec::init_elt(n, 0));
-    let scan_stack: [mutable uint] = vec::to_mut(vec::init_elt(n, 0u));
+    let token: [mutable token] = vec::to_mut(vec::from_elem(n, EOF));
+    let size: [mutable int] = vec::to_mut(vec::from_elem(n, 0));
+    let scan_stack: [mutable uint] = vec::to_mut(vec::from_elem(n, 0u));
     let print_stack: [print_stack_elt] = [];
     @{out: out,
       buf_len: n,

--- a/src/rustc/syntax/util/interner.rs
+++ b/src/rustc/syntax/util/interner.rs
@@ -11,7 +11,7 @@ type interner<T> =
      eqer: eqfn<T>};
 
 fn mk<T: copy>(hasher: hashfn<T>, eqer: eqfn<T>) -> interner<T> {
-    let m = map::mk_hashmap::<T, uint>(hasher, eqer);
+    let m = map::new_hashmap::<T, uint>(hasher, eqer);
     ret {map: m, mutable vect: [], hasher: hasher, eqer: eqer};
 }
 

--- a/src/rustc/util/common.rs
+++ b/src/rustc/util/common.rs
@@ -21,7 +21,7 @@ fn hash_def(d: ast::def_id) -> uint {
 fn new_def_hash<V: copy>() -> std::map::hashmap<ast::def_id, V> {
     let hasher: std::map::hashfn<ast::def_id> = hash_def;
     let eqer: std::map::eqfn<ast::def_id> = def_eq;
-    ret std::map::mk_hashmap::<ast::def_id, V>(hasher, eqer);
+    ret std::map::new_hashmap::<ast::def_id, V>(hasher, eqer);
 }
 
 fn field_expr(f: ast::field) -> @ast::expr { ret f.node.expr; }

--- a/src/rustdoc/markdown_pass.rs
+++ b/src/rustdoc/markdown_pass.rs
@@ -172,7 +172,7 @@ fn write_header(ctxt: ctxt, lvl: hlvl, doc: doc::itemtag) {
 }
 
 fn write_header_(ctxt: ctxt, lvl: hlvl, title: str) {
-    let hashes = str::from_chars(vec::init_elt(lvl as uint, '#'));
+    let hashes = str::from_chars(vec::from_elem(lvl as uint, '#'));
     ctxt.w.write_line(#fmt("%s %s", hashes, title));
     ctxt.w.write_line("");
 }

--- a/src/serializer/serializer.rs
+++ b/src/serializer/serializer.rs
@@ -238,7 +238,7 @@ impl serialize_methods for serialize_ctx {
             fail "TODO--implement class";
           }
           ty::ty_rec(fields) {
-            let stmts = vec::init_fn(vec::len(fields)) {|i|
+            let stmts = vec::from_fn(vec::len(fields)) {|i|
                 let field = fields[i];
                 let f_name = field.ident;
                 let f_ty = field.mt.ty;
@@ -318,10 +318,10 @@ impl serialize_methods for serialize_ctx {
     fn serialize_arm(v_path: str, emit_fn: str, args: [ty::t])
         -> (ast_pat, [ast_stmt]) {
         let n_args = vec::len(args);
-        let arg_nms = vec::init_fn(n_args) {|i| #fmt["v%u", i] };
+        let arg_nms = vec::from_fn(n_args) {|i| #fmt["v%u", i] };
         let v_pat =
             #fmt["\n%s(%s)\n", v_path, str::connect(arg_nms, ",")];
-        let stmts = vec::init_fn(n_args) {|i|
+        let stmts = vec::from_fn(n_args) {|i|
             let arg_ty = args[i];
             let serialize_expr =
                 self.serialize_ty(arg_ty, arg_nms[i]);
@@ -403,7 +403,7 @@ impl deserialize_methods for serialize_ctx {
           ty::ty_vec(mt) {
             let selem = self.deserialize_ty(mt.ty);
             #fmt["s.read_vec({|len|\n\
-                    vec::init_fn(len, {|i|\n\
+                    vec::from_fn(len, {|i|\n\
                       s.read_vec_elt(i, {||\n\
                         %s\n\
                   })})})", selem]
@@ -456,7 +456,7 @@ impl deserialize_methods for serialize_ctx {
                         tps: [ty::t]) -> ast_expr {
         let variants = ty::substd_enum_variants(self.tcx, id, tps);
 
-        let arms = vec::init_fn(vec::len(variants)) {|v_id|
+        let arms = vec::from_fn(vec::len(variants)) {|v_id|
             let variant = variants[v_id];
             let item_path = ty::item_path(self.tcx, variant.id);
             let v_path = ast_map::path_to_str(item_path);
@@ -484,7 +484,7 @@ impl deserialize_methods for serialize_ctx {
 
     fn deserialize_arm(v_path: str, read_fn: str, args: [ty::t])
         -> ast_expr {
-        let exprs = vec::init_fn(vec::len(args)) {|i|
+        let exprs = vec::from_fn(vec::len(args)) {|i|
             let rexpr = self.deserialize_ty(args[i]);
             #fmt["\ns.%s(%uu, {||%s})\n", read_fn, i, rexpr]
         };

--- a/src/test/bench/msgsend.rs
+++ b/src/test/bench/msgsend.rs
@@ -39,7 +39,7 @@ fn run(args: [str]) {
     let to_child = to_child;
     let worker_results = [];
     uint::range(0u, workers) {|_i|
-        let builder = task::mk_task_builder();
+        let builder = task::task_builder();
         worker_results += [task::future_result(builder)];
         task::run(builder) {||
             uint::range(0u, size / workers) {|_i|

--- a/src/test/bench/shootout-fannkuchredux.rs
+++ b/src/test/bench/shootout-fannkuchredux.rs
@@ -6,9 +6,9 @@ import vec;
 fn fannkuch(n: int) -> int {
     fn perm1init(i: uint) -> int { ret i as int; }
 
-    let perm = vec::to_mut(vec::init_elt(n as uint, 0));
-    let perm1 = vec::to_mut(vec::init_fn(n as uint, perm1init));
-    let count = vec::to_mut(vec::init_elt(n as uint, 0));
+    let perm = vec::to_mut(vec::from_elem(n as uint, 0));
+    let perm1 = vec::to_mut(vec::from_fn(n as uint, perm1init));
+    let count = vec::to_mut(vec::from_elem(n as uint, 0));
     let f = 0;
     let i = 0;
     let k = 0;

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -44,7 +44,7 @@ fn select_random(r: u32, genelist: [aminoacids]) -> char {
 
 fn make_random_fasta(id: str, desc: str, genelist: [aminoacids], n: int) {
     log(debug, ">" + id + " " + desc);
-    let rng = @{mutable last: std::rand::mk_rng().next()};
+    let rng = @{mutable last: std::rand::rng().next()};
     let op: str = "";
     uint::range(0u, n as uint) {|_i|
         str::push_char(op, select_random(myrandom_next(rng, 100u32),

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -71,7 +71,7 @@ fn stress_task(&&id: int) {
 fn stress(num_tasks: int) {
     let results = [];
     range(0, num_tasks) {|i|
-        let builder = task::mk_task_builder();
+        let builder = task::task_builder();
         results += [task::future_result(builder)];
         task::run(builder) {|| stress_task(i); }
     }

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -35,7 +35,7 @@ fn eval_At_times_u(u: [const float], Au: [mutable float]) {
 }
 
 fn eval_AtA_times_u(u: [const float], AtAu: [mutable float]) {
-    let v = vec::to_mut(vec::init_elt(vec::len(u), 0.0));
+    let v = vec::to_mut(vec::from_elem(vec::len(u), 0.0));
     eval_A_times_u(u, v);
     eval_At_times_u(v, AtAu);
 }
@@ -48,8 +48,8 @@ fn main(args: [str]) {
         1000u
     };
 
-    let u = vec::to_mut(vec::init_elt(N, 1.0));
-    let v = vec::to_mut(vec::init_elt(N, 0.0));
+    let u = vec::to_mut(vec::from_elem(N, 1.0));
+    let v = vec::to_mut(vec::from_elem(N, 0.0));
     let i = 0u;
     while i < 10u {
         eval_AtA_times_u(u, v);

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -31,8 +31,8 @@ enum grid_t { grid_ctor(grid), }
 fn read_grid(f: io::reader) -> grid_t {
     assert f.read_line() == "9,9"; /* assert first line is exactly "9,9" */
 
-    let g = vec::init_fn(10u, {|_i|
-        vec::to_mut(vec::init_elt(10u, 0 as u8))
+    let g = vec::from_fn(10u, {|_i|
+        vec::to_mut(vec::from_elem(10u, 0 as u8))
     });
     while !f.eof() {
         let comps = str::split_char(str::trim(f.read_line()), ',');
@@ -131,8 +131,8 @@ fn write_grid(f: io::writer, g: grid_t) {
 fn main(args: [str]) {
     let grid = if vec::len(args) == 1u {
         // FIXME create sudoku inline since nested vec consts dont work yet
-        let g = vec::init_fn(10u, {|_i|
-            vec::to_mut(vec::init_elt(10u, 0 as u8))
+        let g = vec::from_fn(10u, {|_i|
+            vec::to_mut(vec::from_elem(10u, 0 as u8))
         });
         g[0][1] = 4u8;
         g[0][3] = 6u8;

--- a/src/test/bench/task-perf-word-count.rs
+++ b/src/test/bench/task-perf-word-count.rs
@@ -62,7 +62,7 @@ mod map_reduce {
        [future::future<task::task_result>] {
         let results = [];
         for i: str in inputs {
-            let builder = task::mk_task_builder();
+            let builder = task::task_builder();
             results += [task::future_result(builder)];
             task::run(builder) {|| map_task(ctrl, i)}
         }
@@ -160,7 +160,7 @@ mod map_reduce {
                     // log(error, "creating new reducer for " + k);
                     let p = port();
                     let ch = chan(p);
-                    let builder = task::mk_task_builder();
+                    let builder = task::task_builder();
                     results += [task::future_result(builder)];
                     task::run(builder) {||reduce_task(k, ch)}
                     c = recv(p);

--- a/src/test/run-fail/unwind-misc-1.rs
+++ b/src/test/run-fail/unwind-misc-1.rs
@@ -15,7 +15,7 @@ fn main() {
         ret s == t;
     }
 
-    let map = map::mk_hashmap(hash, eq);
+    let map = map::new_hashmap(hash, eq);
     let arr = [];
     uint::range(0u, 10u) {|i|
         arr += [@"key stuff"];

--- a/src/test/run-pass/import-glob-crate.rs
+++ b/src/test/run-pass/import-glob-crate.rs
@@ -3,7 +3,7 @@ use std;
 import vec::*;
 
 fn main() {
-    let v = init_elt(0u, 0);
+    let v = from_elem(0u, 0);
     v += [4, 2];
     assert (reversed(v) == [2, 4]);
 }

--- a/src/test/run-pass/lots-a-fail.rs
+++ b/src/test/run-pass/lots-a-fail.rs
@@ -14,7 +14,7 @@ fn iloop() {
 
 fn main() {
     uint::range(0u, 100u) {|_i|
-        let builder = task::mk_task_builder();
+        let builder = task::task_builder();
         task::unsupervise(builder);
         task::run(builder) {|| iloop(); };
     }

--- a/src/test/run-pass/mod-view-items.rs
+++ b/src/test/run-pass/mod-view-items.rs
@@ -7,7 +7,7 @@
 mod m {
     use std;
     import vec;
-    fn f() -> [int] { vec::init_elt(1u, 0) }
+    fn f() -> [int] { vec::from_elem(1u, 0) }
 }
 
 fn main() { let x = m::f(); }

--- a/src/test/run-pass/morestack6.rs
+++ b/src/test/run-pass/morestack6.rs
@@ -57,7 +57,7 @@ fn main() {
         calllink09,
         calllink10
     ];
-    let rng = rand::mk_rng();
+    let rng = rand::rng();
     for f in fns {
         let sz = rng.next() % 256u32 + 256u32;
         let frame_backoff = rng.next() % 10u32 + 1u32;

--- a/src/test/run-pass/send-iloop.rs
+++ b/src/test/run-pass/send-iloop.rs
@@ -22,7 +22,7 @@ fn iloop() {
 
 fn main() {
     uint::range(0u, 16u) {|_i|
-        let builder = task::mk_task_builder();
+        let builder = task::task_builder();
         task::unsupervise(builder);
         task::run(builder) {|| iloop(); }
     }

--- a/src/test/run-pass/task-comm-12.rs
+++ b/src/test/run-pass/task-comm-12.rs
@@ -7,7 +7,7 @@ fn start(&&task_number: int) { #debug("Started / Finished task."); }
 
 fn test00() {
     let i: int = 0;
-    let builder = task::mk_task_builder();
+    let builder = task::task_builder();
     let r = task::future_result(builder);
     task::run(builder) {|| start(i); };
 

--- a/src/test/run-pass/task-comm-3.rs
+++ b/src/test/run-pass/task-comm-3.rs
@@ -32,7 +32,7 @@ fn test00() {
     // Create and spawn tasks...
     let results = [];
     while i < number_of_tasks {
-        let builder = task::mk_task_builder();
+        let builder = task::task_builder();
         results += [task::future_result(builder)];
         task::run(builder) {||
             test00_start(ch, i, number_of_messages)

--- a/src/test/run-pass/task-comm-9.rs
+++ b/src/test/run-pass/task-comm-9.rs
@@ -16,7 +16,7 @@ fn test00() {
     let number_of_messages: int = 10;
     let ch = comm::chan(p);
 
-    let builder = task::mk_task_builder();
+    let builder = task::task_builder();
     let r = task::future_result(builder);
     task::run(builder) {||
         test00_start(ch, number_of_messages);

--- a/src/test/run-pass/task-comm.rs
+++ b/src/test/run-pass/task-comm.rs
@@ -41,7 +41,7 @@ fn test00() {
     let results = [];
     while i < number_of_tasks {
         i = i + 1;
-        let builder = task::mk_task_builder();
+        let builder = task::task_builder();
         results += [task::future_result(builder)];
         task::run(builder) {|| test00_start(ch, i, number_of_messages);}
     }
@@ -126,7 +126,7 @@ fn test06() {
     let results = [];
     while i < number_of_tasks {
         i = i + 1;
-        let builder = task::mk_task_builder();
+        let builder = task::task_builder();
         results += [task::future_result(builder)];
         task::run(builder) {|| test06_start(i);};
     }

--- a/src/test/run-pass/task-killjoin.rs
+++ b/src/test/run-pass/task-killjoin.rs
@@ -24,7 +24,7 @@ fn supervisor() {
 }
 
 fn main() {
-    let builder = task::mk_task_builder();
+    let builder = task::task_builder();
     task::unsupervise(builder);
     task::run(builder) {|| supervisor(); }
 }

--- a/src/test/run-pass/too-much-recursion.rs
+++ b/src/test/run-pass/too-much-recursion.rs
@@ -5,7 +5,7 @@
 // that it doesn't bring down the whole proc
 
 fn main() {
-    let builder = task::mk_task_builder();
+    let builder = task::task_builder();
     task::unsupervise(builder);
     task::run(builder) {||
         fn f() { f() };

--- a/src/test/run-pass/unwind-box.rs
+++ b/src/test/run-pass/unwind-box.rs
@@ -8,7 +8,7 @@ fn f() {
 }
 
 fn main() {
-    let builder = task::mk_task_builder();
+    let builder = task::task_builder();
     task::unsupervise(builder);
     task::run(builder) {|| f(); }
 }

--- a/src/test/run-pass/unwind-resource.rs
+++ b/src/test/run-pass/unwind-resource.rs
@@ -15,7 +15,7 @@ fn f(c: comm::chan<bool>) {
 fn main() {
     let p = comm::port();
     let c = comm::chan(p);
-    let builder = task::mk_task_builder();
+    let builder = task::task_builder();
     task::unsupervise(builder);
     task::run(builder) {|| f(c); }
     assert comm::recv(p);

--- a/src/test/run-pass/unwind-resource2.rs
+++ b/src/test/run-pass/unwind-resource2.rs
@@ -12,7 +12,7 @@ fn f() {
 }
 
 fn main() {
-    let builder = task::mk_task_builder();
+    let builder = task::task_builder();
     task::unsupervise(builder);
     task::run(builder) {|| f(); }
 }

--- a/src/test/run-pass/unwind-unique.rs
+++ b/src/test/run-pass/unwind-unique.rs
@@ -8,7 +8,7 @@ fn f() {
 }
 
 fn main() {
-    let builder = task::mk_task_builder();
+    let builder = task::task_builder();
     task::unsupervise(builder);
     task::run(builder) {|| f(); }
 }

--- a/src/test/run-pass/yield.rs
+++ b/src/test/run-pass/yield.rs
@@ -4,7 +4,7 @@ import task;
 import task::*;
 
 fn main() {
-    let builder = task::mk_task_builder();
+    let builder = task::task_builder();
     let result = task::future_result(builder);
     task::run(builder) {|| child(); }
     #error("1");

--- a/src/test/run-pass/yield1.rs
+++ b/src/test/run-pass/yield1.rs
@@ -4,7 +4,7 @@ import task;
 import task::*;
 
 fn main() {
-    let builder = task::mk_task_builder();
+    let builder = task::task_builder();
     let result = task::future_result(builder);
     task::run(builder) {|| child(); }
     #error("1");


### PR DESCRIPTION
This attempts to bring our constructor naming in line with the conventions discussed on IRC and codified in the [style guide](https://github.com/mozilla/rust/wiki/Note-style-guide).

Most constructors are now just named after the type they construct. In some cases this involved tweaking the types a bit. For example the opaque task_builder type went from

```
enum task_builder = {
    ...
};
```

to

```
enum task_builder {
    task_builder_({
        ....
    }
}
```

Other functions were changed to use the `new_` prefix. No functions in core ended up named this way.

The `vec::init_*` functions are now `vec::from_*`.

In `std::map`, even though the hashmap constructor could have been named `hashmap`, I named it `new_hashmap` to be consistent with all the other convenience constructors in `map`.

It doesn't mess with the `io` module so as to not create too many conflicts for graydon's work.
