### PR TITLE
WIP: distinguish inferable types from non-inferable types

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -98,7 +98,13 @@ fn chain<T, U: copy, V: copy>(res: result<T, V>, op: fn(T) -> result<U, V>)
 // deforested) style because I have found that, in practice, this is
 // the most concise way to do things.  That means that they do not not
 // terminate with a call to `ok(v)` but rather `nxt(v)`.  If you would
-// like to just get the result, just pass in `ok` as `nxt`.
+// like to just get the result, just pass in `ok1` as `nxt`.
+
+#[doc = "An annoying helper function for bridging argument modes when
+using deforested functions."]
+fn ok1<T:copy,U>(x: T) -> result<T,U> {
+    ok(x)
+}
 
 #[doc = "
 Maps each element in the vector `ts` using the operation `op`.  Should an
@@ -118,7 +124,7 @@ checking for overflow:
     }
 
 Note: if you have to combine a deforested style transform with map,
-you should use `ok` for the `nxt` operation, as shown here (this is an
+you should use `ok1` for the `nxt` operation, as shown here (this is an
 alternate version of the previous example where the
 `inc_conditionally()` routine is deforested):
 
@@ -127,7 +133,7 @@ alternate version of the previous example where the
         if x == uint::max_value { ret err(\"overflow\"); }
         else { ret nxt(x+1u); }
     }
-    map([1u, 2u, 3u], inc_conditionally(_, ok)) {|incd|
+    map([1u, 2u, 3u], inc_conditionally(_, ok1)) {|incd|
         assert incd == [2u, 3u, 4u];
     }
 "]

--- a/src/rustc/metadata/decoder.rs
+++ b/src/rustc/metadata/decoder.rs
@@ -14,6 +14,7 @@ import tydecode::{parse_ty_data, parse_def_id, parse_bounds_data,
 import syntax::print::pprust;
 import cmd=cstore::crate_metadata;
 import middle::trans::common::maps;
+import ty::ty_ops;
 
 export get_class_items;
 export get_symbol;

--- a/src/rustc/metadata/encoder.rs
+++ b/src/rustc/metadata/encoder.rs
@@ -11,7 +11,7 @@ import syntax::ast_util::local_def;
 import common::*;
 import middle::trans::common::crate_ctxt;
 import middle::ty;
-import middle::ty::node_id_to_type;
+import middle::ty::{node_id_to_type, ty_ops};
 import middle::ast_map;
 import front::attr;
 import driver::session::session;

--- a/src/rustc/metadata/tydecode.rs
+++ b/src/rustc/metadata/tydecode.rs
@@ -5,6 +5,7 @@ import syntax::ast::*;
 import syntax::ast_util;
 import syntax::ast_util::respan;
 import middle::ty;
+import middle::ty::ty_ops;
 import std::map::hashmap;
 
 export parse_ty_data, parse_def_id, parse_ident;
@@ -265,7 +266,6 @@ fn parse_ty(st: @pstate, conv: conv_did) -> ty::t {
         st.pos = st.pos + 1u;
         ret ty::mk_res(st.tcx, def, inner, params);
       }
-      'X' { ret ty::mk_var(st.tcx, parse_int(st)); }
       'Y' { ret ty::mk_type(st.tcx); }
       'C' {
         let ck = alt check next(st) {

--- a/src/rustc/metadata/tyencode.rs
+++ b/src/rustc/metadata/tyencode.rs
@@ -190,7 +190,6 @@ fn enc_sty(w: io::writer, cx: @ctxt, st: ty::sty) {
         for t: ty::t in tps { enc_ty(w, cx, t); }
         w.write_char(']');
       }
-      ty::ty_var(id) { w.write_char('X'); w.write_str(int::str(id)); }
       ty::ty_param(id, did) {
         w.write_char('p');
         w.write_str(cx.ds(did));

--- a/src/rustc/middle/fn_usage.rs
+++ b/src/rustc/middle/fn_usage.rs
@@ -21,7 +21,7 @@ fn fn_usage_expr(expr: @ast::expr,
             alt ctx.tcx.def_map.find(expr.id) {
               some(ast::def_fn(_, ast::unsafe_fn)) {
                 log(error, ("expr=", expr_to_str(expr)));
-                ctx.tcx.sess.span_fatal(
+                ctx.tcx.sess.span_err(
                     expr.span,
                     "unsafe functions can only be called");
               }
@@ -33,7 +33,7 @@ fn fn_usage_expr(expr: @ast::expr,
             && ty::expr_has_ty_params(ctx.tcx, expr) {
             alt ty::get(ty::expr_ty(ctx.tcx, expr)).struct {
               ty::ty_fn({proto: ast::proto_bare, _}) {
-                ctx.tcx.sess.span_fatal(
+                ctx.tcx.sess.span_err(
                     expr.span,
                     "generic bare functions can only be called or bound");
               }

--- a/src/rustc/middle/trans/alt.rs
+++ b/src/rustc/middle/trans/alt.rs
@@ -13,6 +13,7 @@ import syntax::print::pprust::pat_to_str;
 import back::abi;
 import resolve::def_map;
 import std::map::hashmap;
+import ty::ty_ops;
 
 import common::*;
 

--- a/src/rustc/middle/trans/base.rs
+++ b/src/rustc/middle/trans/base.rs
@@ -40,6 +40,7 @@ import link::{mangle_internal_name_by_type_only,
               mangle_exported_name};
 import metadata::{csearch, cstore};
 import util::ppaux::{ty_to_str, ty_to_short_str};
+import ty::ty_ops;
 
 import common::*;
 import build::*;

--- a/src/rustc/middle/trans/closure.rs
+++ b/src/rustc/middle/trans/closure.rs
@@ -18,6 +18,7 @@ import util::ppaux::ty_to_str;
 import ast_map::{path, path_mod, path_name};
 import driver::session::session;
 import std::map::hashmap;
+import ty::ty_ops;
 
 // ___Good to know (tm)__________________________________________________
 //

--- a/src/rustc/middle/trans/common.rs
+++ b/src/rustc/middle/trans/common.rs
@@ -19,6 +19,7 @@ import lib::llvm::{ModuleRef, ValueRef, TypeRef, BasicBlockRef, BuilderRef};
 import lib::llvm::{True, False, Bool};
 import metadata::csearch;
 import ast_map::path;
+import ty::ty_ops;
 
 type namegen = fn@(str) -> str;
 fn new_namegen() -> namegen {

--- a/src/rustc/middle/trans/debuginfo.rs
+++ b/src/rustc/middle/trans/debuginfo.rs
@@ -11,6 +11,7 @@ import ast::ty;
 import pat_util::*;
 import util::ppaux::ty_to_str;
 import driver::session::session;
+import ty::ty_ops;
 
 export create_local_var;
 export create_function;

--- a/src/rustc/middle/trans/impl.rs
+++ b/src/rustc/middle/trans/impl.rs
@@ -13,6 +13,7 @@ import lib::llvm::{ValueRef, TypeRef};
 import lib::llvm::llvm::LLVMGetParam;
 import ast_map::{path, path_mod, path_name};
 import std::map::hashmap;
+import ty::ty_ops;
 
 fn trans_impl(ccx: @crate_ctxt, path: path, name: ast::ident,
               methods: [@ast::method], tps: [ast::ty_param]) {
@@ -238,7 +239,7 @@ fn make_impl_vtable(ccx: @crate_ctxt, impl_id: ast::def_id, substs: [ty::t],
     make_vtable(ccx, vec::map(*ty::iface_methods(tcx, ifce_id), {|im|
         let fty = ty::substitute_type_params(tcx, substs,
                                              ty::mk_fn(tcx, im.fty));
-        if (*im.tps).len() > 0u || ty::type_has_vars(fty) {
+        if (*im.tps).len() > 0u || ty::type_has_self(fty) {
             C_null(T_ptr(T_nil()))
         } else {
             let m_id = method_with_name(ccx, impl_id, im.ident);

--- a/src/rustc/middle/trans/shape.rs
+++ b/src/rustc/middle/trans/shape.rs
@@ -10,13 +10,13 @@ import middle::trans::common::*;
 import back::abi;
 import middle::ty;
 import middle::ty::field;
+import middle::ty::ty_ops;
 import syntax::ast;
 import syntax::ast_util::dummy_sp;
 import syntax::util::interner;
 import util::common;
 import trans::build::{Load, Store, Add, GEPi};
 import syntax::codemap::span;
-
 import std::map::hashmap;
 
 import ty_ctxt = middle::ty::ctxt;
@@ -405,7 +405,7 @@ fn shape_of(ccx: @crate_ctxt, t: ty::t, ty_param_map: [uint]) -> [u8] {
       ty::ty_fn({proto: ast::proto_bare, _}) { [shape_bare_fn] }
       ty::ty_opaque_closure_ptr(_) { [shape_opaque_closure_ptr] }
       ty::ty_constr(inner_t, _) { shape_of(ccx, inner_t, ty_param_map) }
-      ty::ty_var(_) | ty::ty_self(_) {
+      ty::ty_self(_) {
         ccx.sess.bug("shape_of: unexpected type struct found");
       }
     }
@@ -635,7 +635,7 @@ fn simplify_type(tcx: ty::ctxt, typ: ty::t) -> ty::t {
           _ { typ }
         }
     }
-    ty::fold_ty(tcx, ty::fm_general(bind simplifier(tcx, _)), typ)
+    ty::fold(tcx, typ) {|t| simplifier(tcx, t) }
 }
 
 // Given a tag type `ty`, returns the offset of the payload.

--- a/src/rustc/middle/trans/tvec.rs
+++ b/src/rustc/middle/trans/tvec.rs
@@ -9,6 +9,7 @@ import base::{call_memmove, trans_shared_malloc,
 import shape::llsize_of;
 import build::*;
 import common::*;
+import ty::ty_ops;
 
 fn get_fill(bcx: block, vptr: ValueRef) -> ValueRef {
     Load(bcx, GEPi(bcx, vptr, [0, abi::vec_elt_fill]))

--- a/src/rustc/middle/trans/type_of.rs
+++ b/src/rustc/middle/trans/type_of.rs
@@ -38,9 +38,6 @@ fn type_of_fn_from_ty(cx: @crate_ctxt, fty: ty::t) -> TypeRef {
 }
 
 fn type_of(cx: @crate_ctxt, t: ty::t) -> TypeRef {
-    assert !ty::type_has_vars(t);
-    // Check the cache.
-
     if cx.lltypes.contains_key(t) { ret cx.lltypes.get(t); }
     let llty = alt ty::get(t).struct {
       ty::ty_nil | ty::ty_bot { T_nil() }
@@ -87,18 +84,17 @@ fn type_of(cx: @crate_ctxt, t: ty::t) -> TypeRef {
         for ci in cls_items {
             // only instance vars are record fields at runtime
             alt ci.contents {
-                var_ty(t) {
-                  let fty = type_of(cx, t);
-                  tys += [fty];
-                }
-                _ {}
+              var_ty(t) {
+                let fty = type_of(cx, t);
+                tys += [fty];
+              }
+              _ {}
             }
         }
         T_struct(tys)
       }
       ty::ty_self(_) { cx.tcx.sess.unimpl("type_of: ty_self \
                          not implemented"); }
-      ty::ty_var(_) { cx.tcx.sess.bug("type_of shouldn't see a ty_var"); }
     };
     cx.lltypes.insert(t, llty);
     ret llty;

--- a/src/rustc/syntax/visit.rs
+++ b/src/rustc/syntax/visit.rs
@@ -127,7 +127,7 @@ fn visit_item<E>(i: @item, e: E, v: vt<E>) {
       }
       item_impl(tps, ifce, ty, methods) {
         v.visit_ty_params(tps, e, v);
-        alt ifce { some(ty) { v.visit_ty(ty, e, v); } _ {} }
+        alt ifce { some(ty) { v.visit_ty(ty, e, v); } none {} }
         v.visit_ty(ty, e, v);
         for m in methods {
             visit_method_helper(m, e, v)
@@ -190,7 +190,8 @@ fn visit_ty<E>(t: @ty, e: E, v: vt<E>) {
             v.visit_constr(tc.node.path, tc.span, tc.node.id, e, v);
         }
       }
-      _ {}
+      ty_mac(m) { visit_mac(m, e, v); }
+      ty_nil | ty_bot | ty_infer { /* fallthrough */ }
     }
 }
 
@@ -240,7 +241,7 @@ fn visit_ty_params<E>(tps: [ty_param], e: E, v: vt<E>) {
         for bound in *tp.bounds {
             alt bound {
               bound_iface(t) { v.visit_ty(t, e, v); }
-              _ {}
+              bound_copy | bound_send { /* fallthrough */ }
             }
         }
     }


### PR DESCRIPTION
This is a "work in progress" refactoring I wanted some feedback on.  The idea is to separate out the representation of types into "types used during inference" (`ty::t_i`) and "types during the rest of compilation" (`ty::t`).  One immediate effect of this is that `ty_var` is no longer a member of `ty::t`, so we no longer need to check for it and "fail" all over the place, as we used to do.  The eventual goal is to make more things inferable in a more powerful way: e.g., fn protos, integer literal suffixes, regions, etc, all without affecting the `ty::t` type as a whole.

Both `ty::t` and `ty::t_i` are defined based on a common base set of types called things like `ty::sty_base`, `ty::fn_ty_base` and so on.  These types are parameterized by a generic type `T` which represents the "type of a type".  This is the famous "Curiously Recurring Template Pattern", or CRTP as pcwalton likes to call it.  For the most part there is very little duplication of code, though some of the type declarations can be a bit mind-bending.  Generic functions that operate over both `ty::t` and `ty::t_i` (such as `fold_ty`, `walk_ty`, and even unification) are currently coded using ifaces and impls.  This can probably be improved further and ultimately made much nicer using traits.

Currently the code type checks but I cannot run it because the stage0 compiler fails with an obscure error during trans.  As far as I can tell the patch is exposing a bug in monomorphization.  I have tried to narrow down the problem but so far haven't produced anything useful. @marijnh if you are interested in taking a look lemme' know. :)
