### PR TITLE
Minor fixes

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1308,7 +1308,7 @@ iterate over all characters, which `str::chars` helps with), and
 for those that do, many don't need actual characters, and can operate
 on bytes. For algorithms that do really need to index by character,
 there's the option to convert your string to a character vector (using
-`str::to_chars`).
+`str::chars`).
 
 Like vectors, strings are always unique. You can wrap them in a shared
 box to share them. Unlike vectors, there is no mutable variant of

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -46,9 +46,10 @@ syn match	rustFloat		display contained "\.\d\+\(e[-+]\=\d\+\)\=[fl]\=\>"
 "floating point number, without dot, with exponent
 syn match	rustFloat		display contained "\d\+e[-+]\=\d\+[fl]\=\>"
 
-syn match   rustCharacter   "'[^']*'"
-
 syn case match
+
+syn match   rustCharacter   "'\([^'\\]\|\\\(['nrt\\\"]\|x\x\{2}\|u\x\{4}\|U\x\{8}\)\)'"
+
 syn region    rustComment     start="/\*" end="\*/" contains=rustComment
 syn region    rustComment     start="//" skip="\\$" end="$" keepend
 


### PR DESCRIPTION
- Small error in the tutorial as of #1714
- '\'' would cause problems with Vim's syntax highlighting, so I expanded that rule.
