### PR TITLE
Choose task thread in rust_scheduler by round robin

### DIFF
--- a/src/rt/rust_scheduler.cpp
+++ b/src/rt/rust_scheduler.cpp
@@ -11,6 +11,7 @@ rust_scheduler::rust_scheduler(rust_kernel *kernel,
     live_threads(num_threads),
     live_tasks(0),
     num_threads(num_threads),
+    cur_thread(0),
     id(id)
 {
     create_task_threads();
@@ -87,9 +88,9 @@ rust_scheduler::create_task(rust_task *spawner, const char *name) {
     {
         scoped_lock with(lock);
         live_tasks++;
-        if (++cur_thread >= num_threads)
+        thread_no = cur_thread++;
+        if (cur_thread >= num_threads)
             cur_thread = 0;
-        thread_no = cur_thread;
     }
     rust_task_thread *thread = threads[thread_no];
     return thread->create_task(spawner, name);

--- a/src/rt/rust_scheduler.h
+++ b/src/rt/rust_scheduler.h
@@ -10,16 +10,16 @@ public:
     rust_srv *srv;
     rust_env *env;
 private:
-    // Protects the random number context and live_threads
+    // Protects live_threads and cur_thread increments
     lock_and_signal lock;
     // When this hits zero we'll tell the kernel to release us
     uintptr_t live_threads;
     // When this hits zero we'll tell the threads to exit
     uintptr_t live_tasks;
-    randctx rctx;
 
     array_list<rust_task_thread *> threads;
     const size_t num_threads;
+    size_t cur_thread;
 
     rust_sched_id id;
 


### PR DESCRIPTION
Remove the random context from rust_scheduler and use a simple round robin system to choose which thread a new task gets put on. Also, some incorrect tab indents around scoped blocks were fixed.
