### PR TITLE
core: add os::copy_file function

### DIFF
--- a/src/libcore/libc.rs
+++ b/src/libcore/libc.rs
@@ -1155,6 +1155,9 @@ mod funcs {
             fn CreateDirectoryW(lpPathName: LPCWSTR,
                                 lpSecurityAttributes:
                                 LPSECURITY_ATTRIBUTES) -> BOOL;
+            fn CopyFileW(lpExistingFileName: LPCWSTR,
+                         lpNewFileName: LPCWSTR,
+                         bFailIfExists: BOOL) -> BOOL;
             fn DeleteFileW(lpPathName: LPCWSTR) -> BOOL;
             fn RemoveDirectoryW(lpPathName: LPCWSTR) -> BOOL;
             fn SetCurrentDirectoryW(lpPathName: LPCWSTR) -> BOOL;


### PR DESCRIPTION
This adds os::copy_file to libcore as requested in #1983.

I'll submit relevant changes to cargo as a separate pull request.
