### PR TITLE
rt: cleanup passing around of rust_env

### DIFF
--- a/src/rt/rust_kernel.cpp
+++ b/src/rt/rust_kernel.cpp
@@ -11,7 +11,7 @@
 
 rust_kernel::rust_kernel(rust_env *env) :
     _region(env, true),
-    _log(env, NULL),
+    _log(NULL),
     max_task_id(0),
     max_port_id(0),
     rval(0),

--- a/src/rt/rust_log.cpp
+++ b/src/rt/rust_log.cpp
@@ -40,8 +40,7 @@ log_console_off(rust_env *env) {
     }
 }
 
-rust_log::rust_log(rust_env *env, rust_sched_loop *sched_loop) :
-    _env(env),
+rust_log::rust_log(rust_sched_loop *sched_loop) :
     _sched_loop(sched_loop) {
 }
 

--- a/src/rt/rust_log.h
+++ b/src/rt/rust_log.h
@@ -40,7 +40,7 @@ struct rust_task;
 class rust_log {
 
 public:
-    rust_log(rust_env *env, rust_sched_loop *sched_loop);
+    rust_log(rust_sched_loop *sched_loop);
     virtual ~rust_log();
 
     void trace_ln(rust_task *task, uint32_t level, char *message);
@@ -48,7 +48,6 @@ public:
     bool is_tracing(uint32_t type_bits);
 
 private:
-    rust_env *_env;
     rust_sched_loop *_sched_loop;
     bool _use_labels;
     void trace_ln(rust_task *task, char *message);

--- a/src/rt/rust_sched_loop.cpp
+++ b/src/rt/rust_sched_loop.cpp
@@ -18,7 +18,7 @@ const size_t C_STACK_SIZE = 1024*1024;
 bool rust_sched_loop::tls_initialized = false;
 
 rust_sched_loop::rust_sched_loop(rust_scheduler *sched,int id) :
-    _log(env, this),
+    _log(this),
     id(id),
     should_exit(false),
     cached_c_stack(NULL),
@@ -28,8 +28,7 @@ rust_sched_loop::rust_sched_loop(rust_scheduler *sched,int id) :
     sched(sched),
     log_lvl(log_debug),
     min_stack_size(kernel->env->min_stack_size),
-    env(kernel->env),
-    local_region(env, false),
+    local_region(kernel->env, false),
     // TODO: calculate a per scheduler name.
     name("main")
 {
@@ -277,7 +276,7 @@ rust_sched_loop::create_task(rust_task *spawner, const char *name) {
     rust_task *task =
         new (this->kernel, "rust_task")
         rust_task (this, task_state_newborn,
-                   spawner, name, env->min_stack_size);
+                   spawner, name, kernel->env->min_stack_size);
     DLOG(this, task, "created task: " PTR ", spawner: %s, name: %s",
                         task, spawner ? spawner->name : "null", name);
 

--- a/src/rt/rust_sched_loop.h
+++ b/src/rt/rust_sched_loop.h
@@ -79,7 +79,6 @@ public:
     uint32_t log_lvl;
 
     size_t min_stack_size;
-    rust_env *env;
     memory_region local_region;
 
     randctx rctx;

--- a/src/rt/rust_task.cpp
+++ b/src/rt/rust_task.cpp
@@ -513,7 +513,7 @@ rust_task::new_stack(size_t requested_sz) {
     size_t rust_stk_sz = get_next_stack_size(min_sz,
                                              current_sz, requested_sz);
 
-    if (total_stack_sz + rust_stk_sz > sched_loop->env->max_stack_size) {
+    if (total_stack_sz + rust_stk_sz > kernel->env->max_stack_size) {
         LOG_ERR(this, task, "task %" PRIxPTR " ran out of stack", this);
         fail();
     }


### PR DESCRIPTION
A bunch of structures in rt needlessly keep around references to rust_env. Cleanup those areas so rust_env is only kept where it is needed.
