### PR TITLE
fleshing out time.rs

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -109,6 +109,14 @@ fn chain_err<T: copy, U: copy, V: copy>(
 }
 
 impl extensions<T:copy, E:copy> for result<T,E> {
+    fn get() -> T { get(self) }
+
+    fn get_err() -> E { get_err(self) }
+
+    fn success() -> bool { success(self) }
+
+    fn failure() -> bool { failure(self) }
+
     fn chain<U:copy>(op: fn(T) -> result<U,E>) -> result<U,E> {
         chain(self, op)
     }

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -108,7 +108,7 @@ fn chain_err<T: copy, U: copy, V: copy>(
     }
 }
 
-impl methods<T:copy,E:copy> for result<T,E> {
+impl extensions<T:copy, E:copy> for result<T,E> {
     fn chain<U:copy>(op: fn(T) -> result<U,E>) -> result<U,E> {
         chain(self, op)
     }

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -1,21 +1,21 @@
 #[abi = "cdecl"]
 native mod rustrt {
-    fn get_time(&sec: i64, &usec: i32);
+    fn get_time(&sec: i64, &nsec: i32);
     fn precise_time_ns(&ns: u64);
 }
 
 #[doc = "A record specifying a time value in seconds and microseconds."]
-type timeval = {sec: i64, usec: i32};
+type timespec = {sec: i64, nsec: i32};
 
 #[doc = "
-Returns the current time as a `timeval` containing the seconds and
+Returns the current time as a `timespec` containing the seconds and
 microseconds since 1970-01-01T00:00:00Z.
 "]
-fn get_time() -> timeval {
+fn get_time() -> timespec {
     let mut sec = 0i64;
-    let mut usec = 0i32;
-    rustrt::get_time(sec, usec);
-    ret {sec: sec, usec: usec};
+    let mut nsec = 0i32;
+    rustrt::get_time(sec, nsec);
+    ret {sec: sec, nsec: nsec};
 }
 
 #[doc = "
@@ -47,20 +47,20 @@ mod tests {
 
         let tv1 = get_time();
         log(debug, "tv1=" + uint::str(tv1.sec as uint) + " sec + "
-                   + uint::str(tv1.usec as uint) + " usec");
+                   + uint::str(tv1.nsec as uint) + " nsec");
 
         assert tv1.sec > some_recent_date;
-        assert tv1.usec < 1000000i32;
+        assert tv1.nsec < 1000000000i32;
 
         let tv2 = get_time();
         log(debug, "tv2=" + uint::str(tv2.sec as uint) + " sec + "
-                   + uint::str(tv2.usec as uint) + " usec");
+                   + uint::str(tv2.nsec as uint) + " nsec");
 
         assert tv2.sec >= tv1.sec;
         assert tv2.sec < some_future_date;
-        assert tv2.usec < 1000000i32;
+        assert tv2.nsec < 1000000000i32;
         if tv2.sec == tv1.sec {
-            assert tv2.usec >= tv1.usec;
+            assert tv2.nsec >= tv1.nsec;
         }
     }
 

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -1,7 +1,29 @@
+import libc::{c_char, c_int, c_long, size_t, time_t};
+import io::{reader, reader_util};
+import result::{result, ok, err, extensions};
+
+export
+    timespec,
+    get_time,
+    precise_time_ns,
+    precise_time_s,
+    tm,
+    empty_tm,
+    now,
+    at,
+    now_utc,
+    at_utc;
+
 #[abi = "cdecl"]
 native mod rustrt {
     fn get_time(&sec: i64, &nsec: i32);
     fn precise_time_ns(&ns: u64);
+
+    // FIXME: The i64 values can be passed by-val when #2064 is fixed.
+    fn rust_gmtime(&&sec: i64, &&nsec: i32, &&result: tm);
+    fn rust_localtime(&&sec: i64, &&nsec: i32, &result: tm);
+    fn rust_timegm(&&tm: tm, &sec: i64);
+    fn rust_mktime(&&tm: tm, &sec: i64);
 }
 
 #[doc = "A record specifying a time value in seconds and microseconds."]
@@ -34,6 +56,87 @@ in seconds since an unspecified epoch.
 "]
 fn precise_time_s() -> float {
     ret (precise_time_ns() as float) / 1000000000.;
+}
+
+type tm = {
+    tm_sec: i32, // seconds after the minute [0-60]
+    tm_min: i32, // minutes after the hour [0-59]
+    tm_hour: i32, // hours after midnight [0-23]
+    tm_mday: i32, // days of the month [1-31]
+    tm_mon: i32, // months since January [0-11]
+    tm_year: i32, // years since 1900
+    tm_wday: i32, // days since Sunday [0-6]
+    tm_yday: i32, // days since January 1 [0-365]
+    tm_isdst: i32, // Daylight Savings Time flag
+    tm_gmtoff: i32, // offset from UTC in seconds
+    tm_zone: str, // timezone abbreviation
+    tm_nsec: i32, // nanoseconds
+};
+
+fn empty_tm() -> tm {
+    {
+        tm_sec: 0_i32,
+        tm_min: 0_i32,
+        tm_hour: 0_i32,
+        tm_mday: 0_i32,
+        tm_mon: 0_i32,
+        tm_year: 0_i32,
+        tm_wday: 0_i32,
+        tm_yday: 0_i32,
+        tm_isdst: 0_i32,
+        tm_gmtoff: 0_i32,
+        tm_zone: "",
+        tm_nsec: 0_i32,
+    }
+}
+
+#[doc = "Returns the specified time in UTC"]
+fn at_utc(clock: timespec) -> tm {
+    let mut {sec, nsec} = clock;
+    let mut tm = empty_tm();
+    rustrt::rust_gmtime(sec, nsec, tm);
+    tm
+}
+
+#[doc = "Returns the current time in UTC"]
+fn now_utc() -> tm {
+    at_utc(get_time())
+}
+
+#[doc = "Returns the specified time in the local timezone"]
+fn at(clock: timespec) -> tm {
+    let mut {sec, nsec} = clock;
+    let mut tm = empty_tm();
+    rustrt::rust_localtime(sec, nsec, tm);
+    tm
+}
+
+#[doc = "Returns the current time in the local timezone"]
+fn now() -> tm {
+    at(get_time())
+}
+
+impl tm for tm {
+    #[doc = "Convert time to the seconds from January 1, 1970"]
+    fn to_timespec() -> timespec {
+        let mut sec = 0i64;
+        if self.tm_gmtoff == 0_i32 {
+            rustrt::rust_timegm(self, sec);
+        } else {
+            rustrt::rust_mktime(self, sec);
+        }
+        { sec: sec, nsec: self.tm_nsec }
+    }
+
+    #[doc = "Convert time to the local timezone"]
+    fn to_local() -> tm {
+        at(self.to_timespec())
+    }
+
+    #[doc = "Convert time to the UTC"]
+    fn to_utc() -> tm {
+        at_utc(self.to_timespec())
+    }
 }
 
 #[cfg(test)]
@@ -80,5 +183,79 @@ mod tests {
         let ns2 = precise_time_ns();
         log(debug, "ns2=" + u64::str(ns2) + " ns");
         assert ns2 >= ns1;
+    }
+
+    #[test]
+    fn test_at_utc() {
+        os::setenv("TZ", "America/Los_Angeles");
+
+        let time = { sec: 1234567890_i64, nsec: 54321_i32 };
+        let utc = at_utc(time);
+
+        assert utc.tm_sec == 30_i32;
+        assert utc.tm_min == 31_i32;
+        assert utc.tm_hour == 23_i32;
+        assert utc.tm_mday == 13_i32;
+        assert utc.tm_mon == 1_i32;
+        assert utc.tm_year == 109_i32;
+        assert utc.tm_wday == 5_i32;
+        assert utc.tm_yday == 43_i32;
+        assert utc.tm_isdst == 0_i32;
+        assert utc.tm_gmtoff == 0_i32;
+        assert utc.tm_zone == "UTC";
+        assert utc.tm_nsec == 54321_i32;
+    }
+
+    #[test]
+    fn test_at() {
+        os::setenv("TZ", "America/Los_Angeles");
+
+        let time = { sec: 1234567890_i64, nsec: 54321_i32 };
+        let local = at(time);
+
+        assert local.tm_sec == 30_i32;
+        assert local.tm_min == 31_i32;
+        assert local.tm_hour == 15_i32;
+        assert local.tm_mday == 13_i32;
+        assert local.tm_mon == 1_i32;
+        assert local.tm_year == 109_i32;
+        assert local.tm_wday == 5_i32;
+        assert local.tm_yday == 43_i32;
+        assert local.tm_isdst == 0_i32;
+        assert local.tm_gmtoff == -28800_i32;
+
+        // FIXME: We should probably standardize on the timezone
+        // abbreviation.
+        let zone = local.tm_zone;
+        assert zone == "PST" || zone == "Pacific Standard Time";
+
+        assert local.tm_nsec == 54321_i32;
+    }
+
+    #[test]
+    fn test_to_timespec() {
+        os::setenv("TZ", "America/Los_Angeles");
+
+        let time = { sec: 1234567890_i64, nsec: 54321_i32 };
+        let utc = at_utc(time);
+
+        assert utc.to_timespec() == time;
+        assert utc.to_local().to_timespec() == time;
+    }
+
+    #[test]
+    fn test_conversions() {
+        os::setenv("TZ", "America/Los_Angeles");
+
+        let time = { sec: 1234567890_i64, nsec: 54321_i32 };
+        let utc = at_utc(time);
+        let local = at(time);
+
+        assert local.to_local() == local;
+        assert local.to_utc() == utc;
+        assert local.to_utc().to_local() == local;
+        assert utc.to_utc() == utc;
+        assert utc.to_local() == local;
+        assert utc.to_local().to_utc() == utc;
     }
 }

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -1,19 +1,19 @@
 #[abi = "cdecl"]
 native mod rustrt {
-    fn get_time(&sec: u32, &usec: u32);
+    fn get_time(&sec: i64, &usec: i32);
     fn precise_time_ns(&ns: u64);
 }
 
 #[doc = "A record specifying a time value in seconds and microseconds."]
-type timeval = {sec: u32, usec: u32};
+type timeval = {sec: i64, usec: i32};
 
 #[doc = "
 Returns the current time as a `timeval` containing the seconds and
 microseconds since 1970-01-01T00:00:00Z.
 "]
 fn get_time() -> timeval {
-    let mut sec = 0u32;
-    let mut usec = 0u32;
+    let mut sec = 0i64;
+    let mut usec = 0i32;
     rustrt::get_time(sec, usec);
     ret {sec: sec, usec: usec};
 }
@@ -42,15 +42,15 @@ mod tests {
 
     #[test]
     fn test_get_time() {
-        const some_recent_date: u32 = 1325376000u32; // 2012-01-01T00:00:00Z
-        const some_future_date: u32 = 1577836800u32; // 2020-01-01T00:00:00Z
+        const some_recent_date: i64 = 1325376000i64; // 2012-01-01T00:00:00Z
+        const some_future_date: i64 = 1577836800i64; // 2020-01-01T00:00:00Z
 
         let tv1 = get_time();
         log(debug, "tv1=" + uint::str(tv1.sec as uint) + " sec + "
                    + uint::str(tv1.usec as uint) + " usec");
 
         assert tv1.sec > some_recent_date;
-        assert tv1.usec < 1000000u32;
+        assert tv1.usec < 1000000i32;
 
         let tv2 = get_time();
         log(debug, "tv2=" + uint::str(tv2.sec as uint) + " sec + "
@@ -58,7 +58,7 @@ mod tests {
 
         assert tv2.sec >= tv1.sec;
         assert tv2.sec < some_future_date;
-        assert tv2.usec < 1000000u32;
+        assert tv2.usec < 1000000i32;
         if tv2.sec == tv1.sec {
             assert tv2.usec >= tv1.usec;
         }

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -8,6 +8,8 @@
 #include "rust_abi.h"
 #include "rust_port.h"
 
+#include <time.h>
+
 #ifdef __APPLE__
 #include <crt_externs.h>
 #endif
@@ -446,6 +448,127 @@ extern "C" CDECL void
 precise_time_ns(uint64_t *ns) {
     timer t;
     *ns = t.time_ns();
+}
+
+struct rust_tm {
+    int32_t tm_sec;
+    int32_t tm_min;
+    int32_t tm_hour;
+    int32_t tm_mday;
+    int32_t tm_mon;
+    int32_t tm_year;
+    int32_t tm_wday;
+    int32_t tm_yday;
+    int32_t tm_isdst;
+    int32_t tm_gmtoff;
+    rust_str *tm_zone;
+    int32_t tm_nsec;
+};
+
+void rust_tm_to_tm(rust_tm* in_tm, tm* out_tm) {
+    memset(out_tm, 0, sizeof(tm));
+    out_tm->tm_sec = in_tm->tm_sec;
+    out_tm->tm_min = in_tm->tm_min;
+    out_tm->tm_hour = in_tm->tm_hour;
+    out_tm->tm_mday = in_tm->tm_mday;
+    out_tm->tm_mon = in_tm->tm_mon;
+    out_tm->tm_year = in_tm->tm_year;
+    out_tm->tm_wday = in_tm->tm_wday;
+    out_tm->tm_yday = in_tm->tm_yday;
+    out_tm->tm_isdst = in_tm->tm_isdst;
+}
+
+void tm_to_rust_tm(tm* in_tm, rust_tm* out_tm, int32_t gmtoff,
+                   const char *zone, int32_t nsec) {
+    out_tm->tm_sec = in_tm->tm_sec;
+    out_tm->tm_min = in_tm->tm_min;
+    out_tm->tm_hour = in_tm->tm_hour;
+    out_tm->tm_mday = in_tm->tm_mday;
+    out_tm->tm_mon = in_tm->tm_mon;
+    out_tm->tm_year = in_tm->tm_year;
+    out_tm->tm_wday = in_tm->tm_wday;
+    out_tm->tm_yday = in_tm->tm_yday;
+    out_tm->tm_isdst = in_tm->tm_isdst;
+    out_tm->tm_gmtoff = gmtoff;
+    out_tm->tm_nsec = nsec;
+
+    if (zone != NULL) {
+        size_t size = strlen(zone);
+        str_reserve_shared(&out_tm->tm_zone, size);
+        memcpy(out_tm->tm_zone->data, zone, size);
+        out_tm->tm_zone->fill = size + 1;
+        out_tm->tm_zone->data[size] = '\0';
+    }
+}
+
+#if defined(__WIN32__)
+#define TZSET() _tzset()
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)
+#define GMTIME(clock, result) gmtime_s((result), (clock))
+#define LOCALTIME(clock, result) localtime_s((result), (clock))
+#define TIMEGM(result) _mkgmtime64(result)
+#else
+struct tm* GMTIME(const time_t *clock, tm *result) {
+    struct tm* t = gmtime(clock);
+    if (t == NULL || result == NULL) { return NULL; }
+    *result = *t;
+    return result;
+}
+struct tm* LOCALTIME(const time_t *clock, tm *result) {
+    struct tm* t = localtime(clock);
+    if (t == NULL || result == NULL) { return NULL; }
+    *result = *t;
+    return result;
+}
+#define TIMEGM(result) mktime((result)) - _timezone
+#endif
+#else
+#define TZSET() tzset()
+#define GMTIME(clock, result) gmtime_r((clock), (result))
+#define LOCALTIME(clock, result) localtime_r((clock), (result))
+#define TIMEGM(result) timegm(result)
+#endif
+
+extern "C" CDECL void
+rust_gmtime(int64_t *sec, int32_t *nsec, rust_tm *timeptr) {
+    tm tm;
+    time_t s = *sec;
+    GMTIME(&s, &tm);
+
+    tm_to_rust_tm(&tm, timeptr, 0, "UTC", *nsec);
+}
+
+extern "C" CDECL void
+rust_localtime(int64_t *sec, int32_t *nsec, rust_tm *timeptr) {
+    tm tm;
+    TZSET();
+    time_t s = *sec;
+    LOCALTIME(&s, &tm);
+
+#if defined(__WIN32__)
+    int32_t gmtoff = -timezone;
+    char zone[64];
+    strftime(zone, sizeof(zone), "%Z", &tm);
+#else
+    int32_t gmtoff = tm.tm_gmtoff;
+    const char *zone = tm.tm_zone;
+#endif
+
+    tm_to_rust_tm(&tm, timeptr, gmtoff, zone, *nsec);
+}
+
+extern "C" CDECL void
+rust_timegm(rust_tm* timeptr, int64_t *out) {
+    tm t;
+    rust_tm_to_tm(timeptr, &t);
+    *out = TIMEGM(&t);
+}
+
+extern "C" CDECL void
+rust_mktime(rust_tm* timeptr, int64_t *out) {
+    tm t;
+    rust_tm_to_tm(timeptr, &t);
+    *out = mktime(&t);
 }
 
 extern "C" CDECL rust_sched_id

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -408,7 +408,7 @@ rust_ptr_eq(type_desc *t, rust_box *a, rust_box *b) {
 
 #if defined(__WIN32__)
 extern "C" CDECL void
-get_time(uint32_t *sec, uint32_t *usec) {
+get_time(int64_t *sec, int32_t *usec) {
     FILETIME fileTime;
     GetSystemTimeAsFileTime(&fileTime);
 
@@ -427,7 +427,7 @@ get_time(uint32_t *sec, uint32_t *usec) {
 }
 #else
 extern "C" CDECL void
-get_time(uint32_t *sec, uint32_t *usec) {
+get_time(int64_t *sec, int32_t *usec) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     *sec = tv.tv_sec;

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -79,7 +79,7 @@ rust_getcwd() {
         return NULL;
     }
 
-    return make_str(task->kernel, cbuf, strlen(cbuf), "rust_str(getcwd");
+    return make_str(task->kernel, cbuf, strlen(cbuf), "rust_str(getcwd)");
 }
 
 #if defined(__WIN32__)

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -12,6 +12,10 @@ debug_abi_2
 get_port_id
 get_task_id
 get_time
+rust_gmtime
+rust_localtime
+rust_timegm
+rust_mktime
 last_os_error
 new_port
 new_task

--- a/src/rustc/middle/infer.rs
+++ b/src/rustc/middle/infer.rs
@@ -5,7 +5,7 @@ import middle::ty;
 import syntax::ast;
 import syntax::ast::{ret_style};
 import util::ppaux::{ty_to_str, mt_to_str};
-import result::{result, methods, chain, chain_err, ok, err, map, map2, iter2};
+import result::{result, extensions, ok, err, map, map2, iter2};
 import ty::type_is_bot;
 
 export infer_ctxt;
@@ -85,7 +85,7 @@ fn fixup_vars(cx: infer_ctxt, a: ty::t) -> fres<ty::t> {
 impl methods for ures {
     fn then<T:copy>(f: fn() -> result<T,ty::type_err>)
         -> result<T,ty::type_err> {
-        chain(self) {|_i| f() }
+        self.chain() {|_i| f() }
     }
 }
 

--- a/src/rustc/middle/trans/base.rs
+++ b/src/rustc/middle/trans/base.rs
@@ -4056,7 +4056,7 @@ fn trans_fn(ccx: @crate_ctxt,
             id: ast::node_id) {
     let do_time = ccx.sess.opts.stats;
     let start = if do_time { time::get_time() }
-                else { {sec: 0u32, usec: 0u32} };
+                else { {sec: 0i64, usec: 0i32} };
     let _icx = ccx.insn_ctxt("trans_fn");
     trans_closure(ccx, path, decl, body, llfndecl, ty_self,
                   param_substs, id, {|fcx|

--- a/src/rustc/middle/trans/base.rs
+++ b/src/rustc/middle/trans/base.rs
@@ -155,10 +155,10 @@ fn get_dest_addr(dest: dest) -> ValueRef {
     }
 }
 
-fn log_fn_time(ccx: @crate_ctxt, name: str, start: time::timeval,
-               end: time::timeval) {
+fn log_fn_time(ccx: @crate_ctxt, name: str, start: time::timespec,
+               end: time::timespec) {
     let elapsed = 1000 * ((end.sec - start.sec) as int) +
-        ((end.usec as int) - (start.usec as int)) / 1000;
+        ((end.nsec as int) - (start.nsec as int)) / 1000000;
     *ccx.stats.fn_times += [{ident: name, time: elapsed}];
 }
 
@@ -4056,7 +4056,7 @@ fn trans_fn(ccx: @crate_ctxt,
             id: ast::node_id) {
     let do_time = ccx.sess.opts.stats;
     let start = if do_time { time::get_time() }
-                else { {sec: 0i64, usec: 0i32} };
+                else { {sec: 0i64, nsec: 0i32} };
     let _icx = ccx.insn_ctxt("trans_fn");
     trans_closure(ccx, path, decl, body, llfndecl, ty_self,
                   param_substs, id, {|fcx|


### PR DESCRIPTION
Good morning all,

I finally got my time code to a point where it works on all the platforms. This patch series does a couple things. First, it converts get_time to return {sec: i64, nsec: i32}. I made this change because many systems return negative values for times before 1/1/1970, 64 bit machines can return 64 bit second times, and linux can return subtimes with nanosecond resolution.

Second, I added pure-rust versions of strftime and strptime. The functionality is not complete to the c standard, but it's pretty thorough. I also added some helper functions that generate time strings for generating ctime, rfc822, and rfc 3339 formatted strings.

Please let me know if you have comments or want changes. I'm not completely sold on using strftime formats. It's standard, but you need to look at documentation to decipher what's going on. Perhaps instead we should copy how [icu](http://userguide.icu-project.org/formatparse/datetime), [C#](http://msdn.microsoft.com/en-us/library/8kb3ddd4.aspx), [java](http://docs.oracle.com/javase/1.4.2/docs/api/java/text/SimpleDateFormat.html) or [go](http://golang.org/pkg/time/#constants) does time string formatting.
