### PR TITLE
write out "inf"/"-inf" in float::to_str_common

### DIFF
--- a/src/libcore/float.rs
+++ b/src/libcore/float.rs
@@ -42,6 +42,8 @@ Converts a float to a string
 "]
 fn to_str_common(num: float, digits: uint, exact: bool) -> str {
     if is_NaN(num) { ret "NaN"; }
+    if num == infinity { ret "inf"; }
+    if num == neg_infinity { ret "-inf"; }
     let mut (num, accum) = if num < 0.0 { (-num, "-") } else { (num, "") };
     let trunc = num as uint;
     let mut frac = num - (trunc as float);


### PR DESCRIPTION
We were writing out zero when we encountered infinite floating point numbers in float::to_str_common. This fixes that. I chose "inf"/"-inf" as it's what printf(3) does.
