### PR TITLE
"new" vectors

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -205,7 +205,7 @@ COMPILER_INPUTS := $(filter-out $(S)src/rustc/driver/rustc.rs,     \
 
 LIBRUSTSYNTAX_CRATE := $(S)src/librustsyntax/rustsyntax.rc
 LIBRUSTSYNTAX_INPUTS := $(wildcard $(addprefix $(S)src/librustsyntax/, \
-                            rustsyntax.rc *.rs))
+                            rustsyntax.rc *.rs */*.rs */*/*.rs))
 
 RUSTC_INPUTS := $(S)src/rustc/driver/rustc.rs
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -127,6 +127,8 @@ tidy:
               $(wildcard $(S)src/etc/*.py)  \
               $(COMPILER_CRATE) \
               $(COMPILER_INPUTS) \
+              $(LIBRUSTSYNTAX_CRATE) \
+              $(LIBRUSTSYNTAX_INPUTS) \
               $(CORELIB_CRATE) \
               $(CORELIB_INPUTS) \
               $(STDLIB_CRATE) \

--- a/src/librustsyntax/ast.rs
+++ b/src/librustsyntax/ast.rs
@@ -169,6 +169,14 @@ enum proto {
     proto_block,   // fn&
 }
 
+#[auto_serialize]
+enum vstore {
+    vstore_fixed(option<uint>),   // [1,2,3,4]/_ or 4   FIXME: uint -> @expr
+    vstore_uniq,                  // [1,2,3,4]/~
+    vstore_box,                   // [1,2,3,4]/@
+    vstore_slice(region)          // [1,2,3,4]/&(foo)?
+}
+
 pure fn is_blockish(p: ast::proto) -> bool {
     alt p {
       proto_any | proto_block { true }
@@ -278,6 +286,7 @@ enum alt_mode { alt_check, alt_exhaustive, }
 
 #[auto_serialize]
 enum expr_ {
+    expr_vstore(@expr, vstore),
     expr_vec([@expr], mutability),
     expr_rec([field], option<@expr>),
     expr_call(@expr, [@expr], bool),
@@ -459,6 +468,7 @@ enum ty_ {
     ty_tup([@ty]),
     ty_path(@path, node_id),
     ty_constr(@ty, [@ty_constr]),
+    ty_vstore(@ty, vstore),
     ty_mac(mac),
     // ty_infer means the type should be inferred instead of it having been
     // specified. This should only appear at the "top level" of a type and not

--- a/src/librustsyntax/ext/auto_serialize.rs
+++ b/src/librustsyntax/ext/auto_serialize.rs
@@ -367,8 +367,7 @@ fn ser_ty(cx: ext_ctxt, tps: ser_tps_map,
       }
 
       ast::ty_ptr(_) | ast::ty_rptr(_, _) {
-        cx.span_err(
-            ty.span, #fmt["Cannot serialize pointer types"]);
+        cx.span_err(ty.span, "cannot serialize pointer types");
         []
       }
 
@@ -390,8 +389,7 @@ fn ser_ty(cx: ext_ctxt, tps: ser_tps_map,
       }
 
       ast::ty_fn(_, _) {
-        cx.span_err(
-            ty.span, #fmt["Cannot serialize function types"]);
+        cx.span_err(ty.span, "cannot serialize function types");
         []
       }
 
@@ -448,15 +446,17 @@ fn ser_ty(cx: ext_ctxt, tps: ser_tps_map,
       }
 
       ast::ty_mac(_) {
-        cx.span_err(
-            ty.span, #fmt["Cannot serialize macro types"]);
+        cx.span_err(ty.span, "cannot serialize macro types");
         []
       }
 
       ast::ty_infer {
-        cx.span_err(
-            ty.span, #fmt["Cannot serialize inferred types"]);
+        cx.span_err(ty.span, "cannot serialize inferred types");
         []
+      }
+
+      ast::ty_vstore(_, _) {
+        cx.span_unimpl(ty.span, "serialization for vstore types");
       }
 
       ast::ty_vec(mt) {
@@ -673,6 +673,10 @@ fn deser_ty(cx: ext_ctxt, tps: deser_tps_map,
 
       ast::ty_infer {
         #ast{ fail }
+      }
+
+      ast::ty_vstore(_, _) {
+        cx.span_unimpl(ty.span, "deserialization for vstore types");
       }
 
       ast::ty_vec(mt) {

--- a/src/librustsyntax/fold.rs
+++ b/src/librustsyntax/fold.rs
@@ -389,6 +389,9 @@ fn noop_fold_expr(e: expr_, fld: ast_fold) -> expr_ {
                      fld.new_id(i),
                      fld.fold_expr(v))
           }
+          expr_vstore(e, v) {
+            expr_vstore(fld.fold_expr(e), v)
+          }
           expr_vec(exprs, mutt) {
             expr_vec(fld.map_exprs(fld.fold_expr, exprs), mutt)
           }
@@ -497,6 +500,7 @@ fn noop_fold_ty(t: ty_, fld: ast_fold) -> ty_ {
       ty_path(path, id) {ty_path(fld.fold_path(path), fld.new_id(id))}
       // FIXME: constrs likely needs to be folded...
       ty_constr(ty, constrs) {ty_constr(fld.fold_ty(ty), constrs)}
+      ty_vstore(t, vs) {ty_vstore(fld.fold_ty(t), vs)}
       ty_mac(mac) {ty_mac(fold_mac(mac))}
       ty_infer {t}
     }

--- a/src/librustsyntax/parse/parser.rs
+++ b/src/librustsyntax/parse/parser.rs
@@ -392,7 +392,7 @@ fn parse_ty_postfix(orig_t: ast::ty_, p: parser, colons_before_params: bool,
 
     if p.token == token::BINOP(token::SLASH) {
         let orig_hi = p.last_span.hi;
-        alt parse_maybe_vstore(p) {
+        alt maybe_parse_vstore(p) {
           none { }
           some(v) {
             let t = ast::ty_vstore(mk_ty(p, orig_t, lo, orig_hi), v);
@@ -693,7 +693,7 @@ fn have_dollar(p: parser) -> option<ast::mac_> {
     }
 }
 
-fn parse_maybe_vstore(p: parser) -> option<ast::vstore> {
+fn maybe_parse_vstore(p: parser) -> option<ast::vstore> {
     if p.token == token::BINOP(token::SLASH) {
         p.bump();
         alt p.token {
@@ -1060,7 +1060,7 @@ fn parse_bottom_expr(p: parser) -> pexpr {
     alt ex {
       ast::expr_lit(@{node: ast::lit_str(_), span: _}) |
       ast::expr_vec(_, _)  {
-        alt parse_maybe_vstore(p) {
+        alt maybe_parse_vstore(p) {
           none { }
           some(v) {
             hi = p.span.hi;

--- a/src/librustsyntax/visit.rs
+++ b/src/librustsyntax/visit.rs
@@ -170,11 +170,10 @@ fn skip_ty<E>(_t: @ty, _e: E, _v: vt<E>) {}
 
 fn visit_ty<E>(t: @ty, e: E, v: vt<E>) {
     alt t.node {
-      ty_box(mt) { v.visit_ty(mt.ty, e, v); }
-      ty_uniq(mt) { v.visit_ty(mt.ty, e, v); }
-      ty_vec(mt) { v.visit_ty(mt.ty, e, v); }
-      ty_ptr(mt) { v.visit_ty(mt.ty, e, v); }
-      ty_rptr(_, mt) { v.visit_ty(mt.ty, e, v); }
+      ty_box(mt) | ty_uniq(mt) |
+      ty_vec(mt) | ty_ptr(mt) | ty_rptr(_, mt) {
+        v.visit_ty(mt.ty, e, v);
+      }
       ty_rec(flds) {
         for flds.each {|f| v.visit_ty(f.node.mt.ty, e, v); }
       }
@@ -187,6 +186,9 @@ fn visit_ty<E>(t: @ty, e: E, v: vt<E>) {
         v.visit_ty(decl.output, e, v);
       }
       ty_path(p, _) { visit_path(p, e, v); }
+      ty_vstore(t, _) {
+        v.visit_ty(t, e, v);
+      }
       ty_constr(t, cs) {
         v.visit_ty(t, e, v);
         for cs.each {|tc|
@@ -335,6 +337,7 @@ fn visit_expr<E>(ex: @expr, e: E, v: vt<E>) {
         v.visit_expr(pool, e, v);
         v.visit_expr(val, e, v);
       }
+      expr_vstore(x, _) { v.visit_expr(x, e, v); }
       expr_vec(es, _) { visit_exprs(es, e, v); }
       expr_rec(flds, base) {
         for flds.each {|f| v.visit_expr(f.node.expr, e, v); }

--- a/src/rustc/metadata/tydecode.rs
+++ b/src/rustc/metadata/tydecode.rs
@@ -6,6 +6,8 @@ import syntax::ast_util;
 import syntax::ast_util::respan;
 import middle::ty;
 import std::map::hashmap;
+import driver::session;
+import session::session;
 
 export parse_ty_data, parse_def_id, parse_ident;
 export parse_bounds_data;
@@ -176,6 +178,10 @@ fn parse_proto(c: char) -> ast::proto {
     }
 }
 
+fn parse_vstore(st: @pstate) -> ty::vstore {
+    st.tcx.sess.unimpl("tydecode::parse_vstore");
+}
+
 fn parse_ty(st: @pstate, conv: conv_did) -> ty::t {
     alt check next(st) {
       'n' { ret ty::mk_nil(st.tcx); }
@@ -231,6 +237,15 @@ fn parse_ty(st: @pstate, conv: conv_did) -> ty::t {
       '~' { ret ty::mk_uniq(st.tcx, parse_mt(st, conv)); }
       '*' { ret ty::mk_ptr(st.tcx, parse_mt(st, conv)); }
       'I' { ret ty::mk_vec(st.tcx, parse_mt(st, conv)); }
+      'V' {
+        let mt = parse_mt(st, conv);
+        let v = parse_vstore(st);
+        ret ty::mk_evec(st.tcx, mt, v);
+      }
+      'v' {
+        let v = parse_vstore(st);
+        ret ty::mk_estr(st.tcx, v);
+      }
       'R' {
         assert (next(st) == '[');
         let mut fields: [ty::field] = [];

--- a/src/rustc/metadata/tyencode.rs
+++ b/src/rustc/metadata/tyencode.rs
@@ -176,6 +176,7 @@ fn enc_sty(w: io::writer, cx: @ctxt, st: ty::sty) {
           ty_f64 { w.write_str("MF"); }
         }
       }
+      ty::ty_estr(_) { cx.tcx.sess.unimpl("tyencode::enc_sty on estr"); }
       ty::ty_str { w.write_char('S'); }
       ty::ty_enum(def, tys) {
         w.write_str("t[");
@@ -204,6 +205,7 @@ fn enc_sty(w: io::writer, cx: @ctxt, st: ty::sty) {
         enc_region(w, r);
         enc_mt(w, cx, mt);
       }
+      ty::ty_evec(_, _) { cx.tcx.sess.unimpl("tyencode::enc_sty on evec"); }
       ty::ty_vec(mt) { w.write_char('I'); enc_mt(w, cx, mt); }
       ty::ty_rec(fields) {
         w.write_str("R[");

--- a/src/rustc/middle/infer.rs
+++ b/src/rustc/middle/infer.rs
@@ -908,6 +908,15 @@ fn super_tys<C:combine>(
         }
       }
 
+      (ty::ty_evec(a_mt, ty::vstore_slice(a_r)),
+       ty::ty_evec(b_mt, ty::vstore_slice(b_r))) {
+        self.contraregions(a_r, b_r).chain {|r|
+            self.mts(a_mt, b_mt).chain {|mt|
+                ok(ty::mk_evec(tcx, mt, ty::vstore_slice(r)))
+            }
+        }
+      }
+
       (ty::ty_res(a_id, a_t, a_tps), ty::ty_res(b_id, b_t, b_tps))
       if a_id == b_id {
         self.tys(a_t, b_t).chain {|t|

--- a/src/rustc/middle/mutbl.rs
+++ b/src/rustc/middle/mutbl.rs
@@ -92,12 +92,14 @@ fn expr_root_(tcx: ty::ctxt, ctor_self: option<node_id>,
           expr_index(base, _) {
             let auto_unbox = maybe_auto_unbox(tcx, ty::expr_ty(tcx, base));
             alt ty::get(auto_unbox.t).struct {
+              ty::ty_evec(mt, _) |
               ty::ty_vec(mt) {
                 ds +=
                     [@{mutbl: mt.mutbl == m_mutbl,
                        kind: index,
                        outer_t: auto_unbox.t}];
               }
+              ty::ty_estr(_) |
               ty::ty_str {
                 ds += [@{mutbl: false, kind: index, outer_t: auto_unbox.t}];
               }

--- a/src/rustc/middle/region.rs
+++ b/src/rustc/middle/region.rs
@@ -414,6 +414,7 @@ fn resolve_ty(ty: @ast::ty, cx: ctxt, visitor: visit::vt<ctxt>) {
     cx.region_map.ast_type_to_inferred_region.insert(ty.id, inferred_region);
 
     alt ty.node {
+      ast::ty_vstore(_, ast::vstore_slice(r)) |
       ast::ty_rptr(r, _) {
         resolve_region_binding(cx, ty.span, r);
       }

--- a/src/rustc/middle/region.rs
+++ b/src/rustc/middle/region.rs
@@ -168,9 +168,10 @@ type region_map = {
     ast_type_to_inferred_region: hashmap<ast::node_id,ty::region>,
     /*
      * Mapping from an address-of operator or alt expression to its containing
-     * block. This is used as the region if the operand is an rvalue.
+     * region (usually ty::region_scope(block). This is used as the region if
+     * the operand is an rvalue.
      */
-    rvalue_to_block: hashmap<ast::node_id,ast::node_id>
+    rvalue_to_region: hashmap<ast::node_id,ty::region>
 };
 
 type region_scope = @{
@@ -366,41 +367,26 @@ fn get_inferred_region(cx: ctxt, sp: syntax::codemap::span) -> ty::region {
     }
 }
 
-fn resolve_region_binding(cx: ctxt, span: span, region: ast::region) {
-
-    let id = region.id;
-    let rm = cx.region_map;
+fn resolve_region_binding(cx: ctxt, span: span,
+                          region: ast::region) -> ty::region {
     alt region.node {
-      ast::re_inferred {
-        // option::may(cx.scope.resolve_anon()) {|r|
-        //     rm.ast_type_to_region.insert(id, r);
-        // }
-      }
-
-      ast::re_static { /* fallthrough */ }
-
+      ast::re_inferred { ty::re_default }
+      ast::re_static { ty::re_static }
       ast::re_named(ident) {
         alt cx.scope.resolve_ident(ident) {
-          some(r) {
-            rm.ast_type_to_region.insert(id, r);
-          }
-
+          some(r) { r }
           none {
-            cx.sess.span_err(
+            cx.sess.span_fatal(
                 span,
                 #fmt["the region `%s` is not declared", ident]);
           }
         }
       }
-
       ast::re_self {
         alt cx.scope.resolve_self() {
-          some(r) {
-            rm.ast_type_to_region.insert(id, r);
-          }
-
+          some(r) { r }
           none {
-            cx.sess.span_err(
+            cx.sess.span_fatal(
                 span,
                 "the `self` region is not allowed here");
           }
@@ -416,7 +402,8 @@ fn resolve_ty(ty: @ast::ty, cx: ctxt, visitor: visit::vt<ctxt>) {
     alt ty.node {
       ast::ty_vstore(_, ast::vstore_slice(r)) |
       ast::ty_rptr(r, _) {
-        resolve_region_binding(cx, ty.span, r);
+        let region = resolve_region_binding(cx, ty.span, r);
+        cx.region_map.ast_type_to_region.insert(ty.id, region);
       }
       _ { /* nothing to do */ }
     }
@@ -504,12 +491,17 @@ fn resolve_expr(expr: @ast::expr, cx: ctxt, visitor: visit::vt<ctxt>) {
                           in_alt: false with cx};
             visit::visit_expr(expr, new_cx, visitor);
         }
+        ast::expr_vstore(e, ast::vstore_slice(r)) {
+          let region = resolve_region_binding(cx, e.span, r);
+          cx.region_map.rvalue_to_region.insert(expr.id, region);
+        }
         ast::expr_addr_of(_, subexpr) | ast::expr_alt(subexpr, _, _) {
             // Record the block that this expression appears in, in case the
             // operand is an rvalue.
             alt cx.parent {
                 pa_block(blk_id) {
-                    cx.region_map.rvalue_to_block.insert(subexpr.id, blk_id);
+                  let region = ty::re_scope(blk_id);
+                  cx.region_map.rvalue_to_region.insert(subexpr.id, region);
                 }
                 _ { cx.sess.span_bug(expr.span, "expr outside of block?!"); }
             }
@@ -522,7 +514,8 @@ fn resolve_expr(expr: @ast::expr, cx: ctxt, visitor: visit::vt<ctxt>) {
 fn resolve_local(local: @ast::local, cx: ctxt, visitor: visit::vt<ctxt>) {
     alt cx.parent {
         pa_block(blk_id) {
-            cx.region_map.rvalue_to_block.insert(local.node.id, blk_id);
+          let region = ty::re_scope(blk_id);
+          cx.region_map.rvalue_to_region.insert(local.node.id, region);
         }
         _ { cx.sess.span_bug(local.span, "local outside of block?!"); }
     }
@@ -566,7 +559,7 @@ fn resolve_crate(sess: session, def_map: resolve::def_map, crate: @ast::crate)
                                   local_blocks: map::int_hash(),
                                   ast_type_to_inferred_region:
                                     map::int_hash(),
-                                  rvalue_to_block: map::int_hash()},
+                                  rvalue_to_region: map::int_hash()},
                     scope: root_scope(0),
                     mut queued_locals: [],
                     parent: pa_crate,

--- a/src/rustc/middle/trans/base.rs
+++ b/src/rustc/middle/trans/base.rs
@@ -1236,7 +1236,7 @@ fn copy_val_no_check(bcx: block, action: copy_action, dst: ValueRef,
     let _icx = bcx.insn_ctxt("copy_val_no_check");
     let ccx = bcx.ccx();
     let mut bcx = bcx;
-    if ty::type_is_scalar(t) {
+    if ty::type_is_scalar(t) || ty::type_is_slice(t) {
         Store(bcx, src, dst);
         ret bcx;
     }
@@ -1268,7 +1268,7 @@ fn move_val(cx: block, action: copy_action, dst: ValueRef,
     let mut src_val = src.val;
     let tcx = cx.tcx();
     let mut cx = cx;
-    if ty::type_is_scalar(t) {
+    if ty::type_is_scalar(t) || ty::type_is_slice(t) {
         if src.kind == owned { src_val = Load(cx, src_val); }
         Store(cx, src_val, dst);
         ret cx;
@@ -2294,6 +2294,13 @@ fn trans_index(cx: block, ex: @ast::expr, base: @ast::expr,
         let body = GEPi(bcx, v, [0, 0]);
         (lim, body)
       }
+      ty::ty_estr(ty::vstore_slice(_)) |
+      ty::ty_evec(_, ty::vstore_slice(_)) {
+        let body = Load(bcx, GEPi(bcx, v, [0, 0]));
+        let lim = Load(bcx, GEPi(bcx, v, [0, 1]));
+        (lim, body)
+      }
+
       ty::ty_estr(_) | ty::ty_evec(_, _) {
         bcx.sess().unimpl(#fmt("unsupported evec/estr type trans_index"));
       }

--- a/src/rustc/middle/trans/type_of.rs
+++ b/src/rustc/middle/trans/type_of.rs
@@ -48,14 +48,37 @@ fn type_of(cx: @crate_ctxt, t: ty::t) -> TypeRef {
       ty::ty_int(t) { T_int_ty(cx, t) }
       ty::ty_uint(t) { T_uint_ty(cx, t) }
       ty::ty_float(t) { T_float_ty(cx, t) }
+      ty::ty_estr(ty::vstore_uniq) |
       ty::ty_str { T_ptr(T_vec(cx, T_i8())) }
       ty::ty_enum(did, _) { type_of_enum(cx, did, t) }
+      ty::ty_estr(ty::vstore_box) { T_ptr(T_box(cx, T_i8())) }
+      ty::ty_evec(mt, ty::vstore_box) |
       ty::ty_box(mt) { T_ptr(T_box(cx, type_of(cx, mt.ty))) }
       ty::ty_opaque_box { T_ptr(T_box(cx, T_i8())) }
       ty::ty_uniq(mt) { T_ptr(type_of(cx, mt.ty)) }
+      ty::ty_evec(mt, ty::vstore_uniq) |
       ty::ty_vec(mt) { T_ptr(T_vec(cx, type_of(cx, mt.ty))) }
       ty::ty_ptr(mt) { T_ptr(type_of(cx, mt.ty)) }
       ty::ty_rptr(_, mt) { T_ptr(type_of(cx, mt.ty)) }
+
+      ty::ty_evec(mt, ty::vstore_slice(_)) {
+        T_struct([T_ptr(type_of(cx, mt.ty)),
+                  T_uint_ty(cx, ast::ty_u)])
+      }
+
+      ty::ty_estr(ty::vstore_slice(_)) {
+        T_struct([T_ptr(T_i8()),
+                  T_uint_ty(cx, ast::ty_u)])
+      }
+
+      ty::ty_estr(ty::vstore_fixed(n)) {
+        T_array(T_i8(), n)
+      }
+
+      ty::ty_evec(mt, ty::vstore_fixed(n)) {
+        T_array(type_of(cx, mt.ty), n)
+      }
+
       ty::ty_rec(fields) {
         let mut tys: [TypeRef] = [];
         for vec::each(fields) {|f|

--- a/src/rustc/middle/trans/type_of.rs
+++ b/src/rustc/middle/trans/type_of.rs
@@ -72,7 +72,7 @@ fn type_of(cx: @crate_ctxt, t: ty::t) -> TypeRef {
       }
 
       ty::ty_estr(ty::vstore_fixed(n)) {
-        T_array(T_i8(), n)
+        T_array(T_i8(), n + 1u /* +1 for trailing null */)
       }
 
       ty::ty_evec(mt, ty::vstore_fixed(n)) {

--- a/src/rustc/middle/trans/type_use.rs
+++ b/src/rustc/middle/trans/type_use.rs
@@ -136,7 +136,9 @@ fn node_type_needs(cx: ctx, use: uint, id: node_id) {
 
 fn mark_for_expr(cx: ctx, e: @expr) {
     alt e.node {
-      expr_vec(_, _) | expr_rec(_, _) | expr_tup(_) |
+      expr_vstore(_, _) |
+      expr_vec(_, _) |
+      expr_rec(_, _) | expr_tup(_) |
       expr_unary(box(_), _) | expr_unary(uniq(_), _) |
       expr_cast(_, _) | expr_binary(add, _, _) |
       expr_copy(_) | expr_move(_, _) {

--- a/src/rustc/middle/tstate/pre_post_conditions.rs
+++ b/src/rustc/middle/tstate/pre_post_conditions.rs
@@ -321,7 +321,14 @@ fn find_pre_post_expr(fcx: fn_ctxt, e: @expr) {
           _ { }
         }
       }
-      expr_vec(args, _) { find_pre_post_exprs(fcx, args, e.id); }
+      expr_vstore(ee, _) {
+        find_pre_post_expr(fcx, ee);
+        let p = expr_pp(fcx.ccx, ee);
+        set_pre_and_post(fcx.ccx, e.id, p.precondition, p.postcondition);
+      }
+      expr_vec(args, _) {
+        find_pre_post_exprs(fcx, args, e.id);
+      }
       expr_path(p) {
         let rslt = expr_pp(fcx.ccx, e);
         clear_pp(rslt);

--- a/src/rustc/middle/tstate/states.rs
+++ b/src/rustc/middle/tstate/states.rs
@@ -358,6 +358,12 @@ fn find_pre_post_state_expr(fcx: fn_ctxt, pres: prestate, e: @expr) -> bool {
       expr_new(p, _, v) {
         ret find_pre_post_state_two(fcx, pres, p, v, e.id, oper_pure);
       }
+      expr_vstore(ee, _) {
+        let mut changed = find_pre_post_state_expr(fcx, pres, ee);
+        set_prestate_ann(fcx.ccx, e.id, expr_prestate(fcx.ccx, ee));
+        set_poststate_ann(fcx.ccx, e.id, expr_poststate(fcx.ccx, ee));
+        ret changed;
+      }
       expr_vec(elts, _) {
         ret find_pre_post_state_exprs(fcx, pres, e.id,
                                       vec::from_elem(vec::len(elts),

--- a/src/rustc/middle/ty.rs
+++ b/src/rustc/middle/ty.rs
@@ -118,7 +118,7 @@ export type_is_sequence;
 export type_is_signed;
 export type_is_structural;
 export type_is_copyable;
-export type_is_tup_like;
+export type_is_slice;
 export type_is_unique;
 export type_is_c_like_enum;
 export type_structurally_contains;
@@ -858,13 +858,6 @@ fn sequence_element_type(cx: ctxt, ty: t) -> t {
     }
 }
 
-pure fn type_is_tup_like(ty: t) -> bool {
-    alt get(ty).struct {
-      ty_rec(_) | ty_tup(_) { true }
-      _ { false }
-    }
-}
-
 fn get_element_type(ty: t, i: uint) -> t {
     alt get(ty).struct {
       ty_rec(flds) { ret flds[i].mt.ty; }
@@ -884,6 +877,13 @@ pure fn type_is_boxed(ty: t) -> bool {
     alt get(ty).struct {
       ty_box(_) | ty_opaque_box { true }
       _ { false }
+    }
+}
+
+pure fn type_is_slice(ty: t) -> bool {
+    alt get(ty).struct {
+      ty_evec(_, vstore_slice(_)) | ty_estr(vstore_slice(_)) { true }
+      _ { ret false; }
     }
 }
 

--- a/src/rustc/middle/typeck.rs
+++ b/src/rustc/middle/typeck.rs
@@ -276,49 +276,39 @@ fn type_is_c_like_enum(fcx: @fn_ctxt, sp: span, typ: ty::t) -> bool {
 
 enum mode { m_collect, m_check, m_check_tyvar(@fn_ctxt), }
 
-fn ast_region_to_region(tcx: ty::ctxt,
-                        region: ast::region) -> ty::region {
-    alt region.node {
-      ast::re_inferred {
-        // this must be replaced later by a fixup_regions() pass
-        ty::re_default
+fn ast_ty_vstore_to_vstore(tcx: ty::ctxt, ty: @ast::ty,
+                           v: ast::vstore) -> ty::vstore {
+    alt v {
+      ast::vstore_fixed(none) {
+        tcx.sess.span_bug(ty.span,
+                          "implied fixed length in ast_ty_vstore_to_vstore");
       }
-      ast::re_self | ast::re_named(_) {
-        tcx.region_map.ast_type_to_region.get(region.id)
+      ast::vstore_fixed(some(u)) {
+        ty::vstore_fixed(u)
       }
-      ast::re_static {
-        ty::re_static
+      ast::vstore_uniq { ty::vstore_uniq }
+      ast::vstore_box { ty::vstore_box }
+      ast::vstore_slice(r) {
+        ty::vstore_slice(tcx.region_map.ast_type_to_region.get(ty.id))
       }
     }
 }
 
-fn ast_vstore_to_vstore(tcx: ty::ctxt, span: span, n: option<uint>,
-                        v: ast::vstore) -> ty::vstore {
+fn ast_expr_vstore_to_vstore(fcx: @fn_ctxt, e: @ast::expr, n: uint,
+                             v: ast::vstore) -> ty::vstore {
     alt v {
-      ast::vstore_fixed(none) {
-        alt n {
-          some(n) { ty::vstore_fixed(n) }
-          none {
-            tcx.sess.bug("implied fixed length in ast_vstore_to_vstore with \
-                          no default length")
-          }
-        }
-      }
+      ast::vstore_fixed(none) { ty::vstore_fixed(n) }
       ast::vstore_fixed(some(u)) {
-        alt n {
-          some(n) if n != u {
-            tcx.sess.span_err(span,
-                              #fmt("fixed-size sequence mismatch: %u vs. %u",
-                                   u, n));
-          }
-          _ { }
+        if n != u {
+            let s = #fmt("fixed-size sequence mismatch: %u vs. %u",u, n);
+            fcx.ccx.tcx.sess.span_err(e.span,s);
         }
         ty::vstore_fixed(u)
       }
       ast::vstore_uniq { ty::vstore_uniq }
       ast::vstore_box { ty::vstore_box }
-      ast::vstore_slice(region) {
-        ty::vstore_slice(ast_region_to_region(tcx, region))
+      ast::vstore_slice(r) {
+        ty::vstore_slice(region_of(fcx, e))
       }
     }
 }
@@ -408,7 +398,7 @@ fn ast_ty_to_ty(tcx: ty::ctxt, mode: mode, &&ast_ty: @ast::ty) -> ty::t {
             ty::mk_ptr(tcx, ast_mt_to_mt(tcx, mode, mt))
           }
           ast::ty_rptr(region, mt) {
-            let region = ast_region_to_region(tcx, region);
+            let region = tcx.region_map.ast_type_to_region.get(region.id);
             ty::mk_rptr(tcx, region, ast_mt_to_mt(tcx, mode, mt))
           }
           ast::ty_tup(fields) {
@@ -473,8 +463,8 @@ fn ast_ty_to_ty(tcx: ty::ctxt, mode: mode, &&ast_ty: @ast::ty) -> ty::t {
             }
           }
           ast::ty_vstore(t, vst) {
-            let vst = ast_vstore_to_vstore(tcx, ast_ty.span, none, vst);
-            alt ty::get(do_ast_ty_to_ty(tcx, mode, t)).struct {
+            let vst = ast_ty_vstore_to_vstore(tcx, ast_ty, vst);
+            let ty = alt ty::get(do_ast_ty_to_ty(tcx, mode, t)).struct {
               ty::ty_vec(mt) { ty::mk_evec(tcx, mt, vst) }
               ty::ty_str { ty::mk_estr(tcx, vst) }
               _ {
@@ -482,7 +472,8 @@ fn ast_ty_to_ty(tcx: ty::ctxt, mode: mode, &&ast_ty: @ast::ty) -> ty::t {
                                     "found sequence storage modifier \
                                      on non-sequence type");
               }
-            }
+            };
+            fixup_regions_to_block(tcx, ty, ast_ty)
           }
           ast::ty_constr(t, cs) {
             let mut out_cs = [];
@@ -2512,8 +2503,7 @@ fn region_of(fcx: @fn_ctxt, expr: @ast::expr) -> ty::region {
             }
         }
         _ {
-            let blk_id = fcx.ccx.tcx.region_map.rvalue_to_block.get(expr.id);
-            ret ty::re_scope(blk_id);
+            ret fcx.ccx.tcx.region_map.rvalue_to_region.get(expr.id);
         }
     }
 }
@@ -2849,27 +2839,27 @@ fn check_expr_with_unifier(fcx: @fn_ctxt, expr: @ast::expr, unify: unifier,
     alt expr.node {
 
       ast::expr_vstore(ev, vst) {
-        alt ev.node {
+        let typ = alt ev.node {
           ast::expr_lit(@{node: ast::lit_str(s), span:_}) {
-            let tt = ast_vstore_to_vstore(tcx, expr.span,
-                                          some(str::len(s)), vst);
-            let typ = ty::mk_estr(tcx, tt);
-            fcx.write_ty(ev.id, typ);
-            fcx.write_ty(id, typ);
+            let tt = ast_expr_vstore_to_vstore(fcx, expr,
+                                               str::len(s), vst);
+            ty::mk_estr(tcx, tt)
           }
           ast::expr_vec(args, mutbl) {
-            let tt = ast_vstore_to_vstore(tcx, expr.span,
-                                          some(vec::len(args)), vst);
+            let tt = ast_expr_vstore_to_vstore(fcx, expr,
+                                               vec::len(args), vst);
             let t: ty::t = next_ty_var(fcx);
             for args.each {|e| bot |= check_expr_with(fcx, e, t); }
-            let typ = ty::mk_evec(tcx, {ty: t, mutbl: mutbl}, tt);
-            fcx.write_ty(ev.id, typ);
-            fcx.write_ty(id, typ);
+            ty::mk_evec(tcx, {ty: t, mutbl: mutbl}, tt)
           }
           _ {
-            tcx.sess.span_err(expr.span, "vstore modifier on non-sequence");
+            tcx.sess.span_bug(expr.span, "vstore modifier on non-sequence")
           }
-        }
+        };
+        let region = fcx.ccx.tcx.region_map.rvalue_to_region.get(expr.id);
+        let typ = replace_default_region(tcx, region, typ);
+        fcx.write_ty(ev.id, typ);
+        fcx.write_ty(id, typ);
       }
 
       ast::expr_lit(lit) {
@@ -3075,7 +3065,7 @@ fn check_expr_with_unifier(fcx: @fn_ctxt, expr: @ast::expr, unify: unifier,
         let pattern_ty = next_ty_var(fcx);
         bot = check_expr_with(fcx, discrim, pattern_ty);
 
-        let parent_block = tcx.region_map.rvalue_to_block.get(discrim.id);
+        let parent_region = tcx.region_map.rvalue_to_region.get(discrim.id);
 
         // Typecheck the patterns first, so that we get types for all the
         // bindings.
@@ -3084,9 +3074,9 @@ fn check_expr_with_unifier(fcx: @fn_ctxt, expr: @ast::expr, unify: unifier,
             let pcx = {
                 fcx: fcx,
                 map: pat_util::pat_id_map(tcx.def_map, arm.pats[0]),
-                alt_region: ty::re_scope(parent_block),
+                alt_region: parent_region,
                 block_region: ty::re_scope(arm.body.node.id),
-                pat_region: ty::re_scope(parent_block)
+                pat_region: parent_region
             };
 
             for arm.pats.each {|p| check_pat(pcx, p, pattern_ty);}
@@ -3529,8 +3519,7 @@ fn check_decl_local(fcx: @fn_ctxt, local: @ast::local) -> bool {
       _ {/* fall through */ }
     }
 
-    let block_id = fcx.ccx.tcx.region_map.rvalue_to_block.get(local.node.id);
-    let region = ty::re_scope(block_id);
+    let region = fcx.ccx.tcx.region_map.rvalue_to_region.get(local.node.id);
     let pcx = {
         fcx: fcx,
         map: pat_util::pat_id_map(fcx.ccx.tcx.def_map, local.node.pat),

--- a/src/test/run-pass/estr-internal.rs
+++ b/src/test/run-pass/estr-internal.rs
@@ -1,0 +1,9 @@
+// xfail-test
+fn main() {
+    let x : str/5 = "hello"/5;
+    let y : str/5 = "there"/_;
+    let mut z = "thing"/_;
+    z = x;
+    assert z[1] == 'h' as u8;
+    assert z[4] == 'g' as u8;
+}

--- a/src/test/run-pass/estr-internal.rs
+++ b/src/test/run-pass/estr-internal.rs
@@ -1,9 +1,8 @@
-// xfail-test
 fn main() {
     let x : str/5 = "hello"/5;
-    let y : str/5 = "there"/_;
+    let _y : str/5 = "there"/_;
     let mut z = "thing"/_;
     z = x;
-    assert z[1] == 'h' as u8;
-    assert z[4] == 'g' as u8;
+    assert z[0] == ('h' as u8);
+    assert z[4] == ('o' as u8);
 }

--- a/src/test/run-pass/estr-shared.rs
+++ b/src/test/run-pass/estr-shared.rs
@@ -1,0 +1,4 @@
+// xfail-test
+fn main() {
+    let x : str/@ = "hello"/@;
+}

--- a/src/test/run-pass/estr-slice.rs
+++ b/src/test/run-pass/estr-slice.rs
@@ -1,8 +1,7 @@
-// xfail-test
 fn main() {
-    let x : str/& = "hello";
-    let mut y = "there";
+    let x = "hello"/&;
+    let mut y = "there"/&;
     y = x;
-    assert y[1] == 'h' as u8;
-    assert y[4] == 'e' as u8;
+    assert y[0] == 'h' as u8;
+    assert y[4] == 'o' as u8;
 }

--- a/src/test/run-pass/estr-slice.rs
+++ b/src/test/run-pass/estr-slice.rs
@@ -1,0 +1,8 @@
+// xfail-test
+fn main() {
+    let x : str/& = "hello";
+    let mut y = "there";
+    y = x;
+    assert y[1] == 'h' as u8;
+    assert y[4] == 'e' as u8;
+}

--- a/src/test/run-pass/estr-uniq.rs
+++ b/src/test/run-pass/estr-uniq.rs
@@ -1,0 +1,4 @@
+// xfail-test
+fn main() {
+    let x : str/~ = "hello"/~;
+}


### PR DESCRIPTION
This is a first cut of #2112 which means we should have consensus in there that we want the feature before landing. At the same time, I'd like some feedback on the direction I'm taking for implementation, and at some point I'd like to stop playing rebase-around-the-typechecker.

The current code is able to translate a fixed-size string allocation down to a single instruction (sp adjustment) and an init / copy to a simple block data-movement. So it's headed in, I think, the right direction. Working on slices next. It does not do the whole slew of things described in #2112 yet. It parses all of those types but only knows how to translate fixed-size strings (and doesn't yet put them in constant-space).

Anyway, take a look and let me know if you see any glaring mistakes. I'm happy to update this as I get feedback.
