### PR TITLE
add the configure option --enable-local-rust to pull rust from your environment

### DIFF
--- a/configure
+++ b/configure
@@ -294,7 +294,9 @@ opt fast-make 0 "use .gitmodules as timestamp for submodule deps"
 opt manage-submodules 1 "let the build manage the git submodules"
 opt mingw-cross 0 "cross-compile for win32 using mingw"
 opt clang 0 "prefer clang to gcc for building the runtime"
+opt local-rust 0 "use an installed rustc rather than downloading a snapshot"
 valopt prefix "/usr/local" "set installation prefix"
+valopt local-rust-root "/usr/local" "set prefix for local rust binary"
 valopt llvm-root "" "set LLVM root"
 valopt host-triple "${DEFAULT_HOST_TRIPLE}" "LLVM host triple"
 valopt target-triples "${CFG_HOST_TRIPLE}" "LLVM target triples"
@@ -337,7 +339,6 @@ probe CFG_XETEX            xetex
 probe CFG_LUATEX           luatex
 probe CFG_NODE             nodejs node
 
-
 if [ ! -z "$CFG_PANDOC" ]
 then
     PV=$(pandoc --version | awk '/^pandoc/ {print $2}')
@@ -346,6 +347,14 @@ then
 	step_msg "pandoc $PV is too old. disabling"
 	BAD_PANDOC=1
     fi
+fi
+
+if [ ! -z "$CFG_ENABLE_LOCAL_RUST" -a ! -f ${CFG_LOCAL_RUST_ROOT}/bin/rustc ]
+then
+    err "no local rust to use"
+else
+    LRV=`${CFG_LOCAL_RUST_ROOT}/bin/rustc --version`
+    step_msg "using rustc at: ${CFG_LOCAL_RUST_ROOT} with version: " $LRV
 fi
 
 if [ -z "$CFG_ENABLE_CLANG" -a -z "$CFG_GCC" ]
@@ -715,7 +724,6 @@ do
     putvar $CFG_LLVM_BUILD_DIR
     putvar $CFG_LLVM_INST_DIR
 done
-
 
 # Munge any paths that appear in config.mk back to posix-y
 perl -i.bak -p -e 's@ ([a-zA-Z]):[/\\]@ /\1/@go;' \

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -1,12 +1,18 @@
 # Extract the snapshot host compiler
 
+
+
 $(HBIN0_H_$(CFG_HOST_TRIPLE))/rustc$(X):		\
 		$(S)src/snapshots.txt					\
 		$(S)src/etc/get-snapshot.py $(MKFILE_DEPS)
 	@$(call E, fetch: $@)
 #   Note: the variable "SNAPSHOT_FILE" is generally not set, and so
 #   we generally only pass one argument to this script.  
+ifdef CFG_ENABLE_LOCAL_RUST
+	$(Q)$(S)src/etc/local_stage0.sh $(CFG_HOST_TRIPLE) $(CFG_LOCAL_RUST_ROOT)
+else 
 	$(Q)$(S)src/etc/get-snapshot.py $(CFG_HOST_TRIPLE) $(SNAPSHOT_FILE)
+endif 
 	$(Q)touch $@
 
 # Host libs will be extracted by the above rule

--- a/src/etc/local_stage0.sh
+++ b/src/etc/local_stage0.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+TARG_DIR=$1 
+PREFIX=$2
+
+BINDIR=bin
+LIBDIR=lib
+
+OS=`uname -s`
+case $OS in 
+    ("Linux"|"FreeBSD")
+	BIN_SUF=
+	LIB_SUF=.so
+	break
+	;;
+    ("Darwin")
+	BIN_SUF=
+	LIB_SUF=.dylib
+	break
+	;;
+    (*)
+	BIN_SUF=.exe
+	LIB_SUF=.dll
+	LIBDIR=bin
+	break
+	;;
+esac
+
+if [ -z $PREFIX ]; then
+    echo "No local rust specified."
+    exit 1
+fi
+
+if [ ! -e ${PREFIX}/bin/rustc ]; then
+    echo "No local rust installed at ${PREFIX}"
+    exit 1
+fi
+
+if [ -z $TARG_DIR ]; then
+    echo "No target directory specified."
+    exit 1
+fi
+
+cp ${PREFIX}/bin/rustc ${TARG_DIR}/stage0/bin/
+cp ${PREFIX}/lib/rustc/${TARG_DIR}/${LIBDIR}/* ${TARG_DIR}/stage0/${LIBDIR}/
+cp ${PREFIX}/lib/librust*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/
+cp ${PREFIX}/lib/libcore*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/
+cp ${PREFIX}/lib/libstd*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/


### PR DESCRIPTION
Useful if you're offline, or if you're trying to work around a bug in the snapshot compiler, as I was.

usage: --enable-local-rust to enable
--local-rust-root="/path/to/rustc/" to change the path, which defaults to
"/usr/local/"

Tested on OS X and Linux, likely broken on windows.
