### PR TITLE
rustc: -L also indicates the location of native libraries

### DIFF
--- a/src/test/run-pass/native-lib-path.rs
+++ b/src/test/run-pass/native-lib-path.rs
@@ -1,0 +1,14 @@
+// xfail-test FIXME I don't know how to test this
+// compile-flags:-L.
+// The -L flag is also used for linking native libraries
+
+// FIXME: I want to name a mod that would not link successfully
+// wouthout providing a -L argument to the compiler, and that
+// will also be found successfully at runtime.
+native mod WHATGOESHERE {
+    fn IDONTKNOW() -> u32;
+}
+
+fn main() {
+    assert IDONTKNOW() == 0x_BAD_DOOD_u32;
+}


### PR DESCRIPTION
-L currently specifies paths to search for Rust crates

Building crates that use native libraries is difficult. When the
library is located somewhere unexpected there is no way
to tell rustc additional paths to look in.

If libclang is located at `.` then rustc is not going to
know that and linking will fail.

To get around that I often end up inserting

```
#[link_args = "-L."] native mod m { }
```

into other crates to get them to build.

Now you just `rustc -L .` and it builds.

This doesn't do any rpathing so it's still up to somebody else
to put the library somewhere it will be found or use LD_LIBRARY_PATH

This feature comes with a single, XFAILed test, because I could
not think of a way to test it. Odd.
