### PR TITLE
temporary hack to make testing std::time reliable

### DIFF
--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -824,6 +824,18 @@ mod tests {
     import task;
 
     #[test]
+    fn test_all() {
+        test_get_time();
+        test_precise_time();
+        test_at_utc();
+        test_at();
+        test_to_timespec();
+        test_conversions();
+        test_strptime();
+        test_ctime();
+        test_strftime();
+    }
+
     fn test_get_time() {
         const some_recent_date: i64 = 1325376000i64; // 2012-01-01T00:00:00Z
         const some_future_date: i64 = 1577836800i64; // 2020-01-01T00:00:00Z
@@ -847,7 +859,6 @@ mod tests {
         }
     }
 
-    #[test]
     fn test_precise_time() {
         let s0 = precise_time_s();
         let ns1 = precise_time_ns();
@@ -865,7 +876,6 @@ mod tests {
         assert ns2 >= ns1;
     }
 
-    #[test]
     fn test_at_utc() {
         os::setenv("TZ", "America/Los_Angeles");
 
@@ -886,7 +896,6 @@ mod tests {
         assert utc.tm_nsec == 54321_i32;
     }
 
-    #[test]
     fn test_at() {
         os::setenv("TZ", "America/Los_Angeles");
 
@@ -912,7 +921,6 @@ mod tests {
         assert local.tm_nsec == 54321_i32;
     }
 
-    #[test]
     fn test_to_timespec() {
         os::setenv("TZ", "America/Los_Angeles");
 
@@ -923,7 +931,6 @@ mod tests {
         assert utc.to_local().to_timespec() == time;
     }
 
-    #[test]
     fn test_conversions() {
         os::setenv("TZ", "America/Los_Angeles");
 
@@ -939,7 +946,6 @@ mod tests {
         assert utc.to_local().to_utc() == utc;
     }
 
-    #[test]
     fn test_strptime() {
         os::setenv("TZ", "America/Los_Angeles");
 
@@ -1084,7 +1090,6 @@ mod tests {
         assert test("%", "%%");
     }
 
-    #[test]
     fn test_ctime() {
         os::setenv("TZ", "America/Los_Angeles");
 
@@ -1096,7 +1101,6 @@ mod tests {
         assert local.ctime() == "Fri Feb 13 15:31:30 2009";
     }
 
-    #[test]
     fn test_strftime() {
         os::setenv("TZ", "America/Los_Angeles");
 


### PR DESCRIPTION
This is a quick hack to address #2160 until we get some kind of global, static, singleton or whatever to fix the setenv threading problem.
