### PR TITLE
high-level tcp bindings for std

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -218,13 +218,11 @@ fn iter2<S,T,U:copy>(ss: [S], ts: [T],
 
 #[doc="
 Unwraps a result, assuming it is an `ok(T)`
-
-This operation is unsafe.
 "]
 fn unwrap<T, U>(-res: result<T, U>) -> T unsafe {
     let addr = alt res {
       ok(x) { ptr::addr_of(x) }
-      err(_) { fail "option none" }
+      err(_) { fail "error result" }
     };
     let liberated_value = unsafe::reinterpret_cast(*addr);
     unsafe::forget(res);

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -216,6 +216,21 @@ fn iter2<S,T,U:copy>(ss: [S], ts: [T],
     ret ok(());
 }
 
+#[doc="
+Unwraps a result, assuming it is an `ok(T)`
+
+This operation is unsafe.
+"]
+fn unwrap<T, U>(-res: result<T, U>) -> T unsafe {
+    let addr = alt res {
+      ok(x) { ptr::addr_of(x) }
+      err(_) { fail "option none" }
+    };
+    let liberated_value = unsafe::reinterpret_cast(*addr);
+    unsafe::forget(res);
+    ret liberated_value;
+}
+
 #[cfg(test)]
 mod tests {
     fn op1() -> result::result<int, str> { result::ok(666) }

--- a/src/libstd/net.rs
+++ b/src/libstd/net.rs
@@ -1,49 +1,7 @@
-import vec;
-import uint;
+#[doc="
+Top-level module for network-related functionality
+"];
 
-#[doc = "An IP address"]
-enum ip_addr {
-    /*
-    Variant: ipv4
 
-    An IPv4 address
-    */
-    ipv4(u8, u8, u8, u8),
-}
-
-#[doc = "Convert an `ip_addr` to a str"]
-fn format_addr(ip: ip_addr) -> str {
-    alt ip {
-      ipv4(a, b, c, d) {
-        #fmt["%u.%u.%u.%u", a as uint, b as uint, c as uint, d as uint]
-      }
-    }
-}
-
-#[doc = "
-Convert a str to `ip_addr`
-
-Converts a string of the format `x.x.x.x` into an ip_addr enum.
-
-Fails if the string is not a valid IPv4 address
-"]
-fn parse_addr(ip: str) -> ip_addr {
-    let parts = vec::map(str::split_char(ip, '.'), {|s|
-        alt uint::from_str(s) {
-          some(n) if n <= 255u { n }
-          _ { fail "Invalid IP Address part." }
-        }
-    });
-    if vec::len(parts) != 4u { fail "Too many dots in IP address"; }
-    ipv4(parts[0] as u8, parts[1] as u8, parts[2] as u8, parts[3] as u8)
-}
-
-#[test]
-fn test_format_ip() {
-    assert (net::format_addr(net::ipv4(127u8, 0u8, 0u8, 1u8)) == "127.0.0.1")
-}
-
-#[test]
-fn test_parse_ip() {
-    assert (net::parse_addr("127.0.0.1") == net::ipv4(127u8, 0u8, 0u8, 1u8));
-}
+import ip = net_ip;
+export ip; 

--- a/src/libstd/net.rs
+++ b/src/libstd/net.rs
@@ -2,6 +2,8 @@
 Top-level module for network-related functionality
 "];
 
+import tcp = net_tcp;
+export tcp;
 
 import ip = net_ip;
 export ip; 

--- a/src/libstd/net.rs
+++ b/src/libstd/net.rs
@@ -6,4 +6,4 @@ import tcp = net_tcp;
 export tcp;
 
 import ip = net_ip;
-export ip; 
+export ip;

--- a/src/libstd/net_ip.rs
+++ b/src/libstd/net_ip.rs
@@ -1,0 +1,74 @@
+#[doc="
+Types/fns concerning Internet Protocol (IP), versions 4 & 6
+"];
+
+import vec;
+import uint;
+
+export ip_addr;
+export v4;
+//format_addr, parse_addr;
+
+#[doc = "An IP address"]
+enum ip_addr {
+    #[doc="An IPv4 address"]
+    ipv4(u8, u8, u8, u8),
+}
+
+#[doc="
+Convert a `ip_addr` to a str
+
+# Arguments
+
+* ip - a `std::net::ip::ip_addr`
+"]
+fn format_addr(ip: ip_addr) -> str {
+    alt ip {
+      ipv4(a, b, c, d) {
+        #fmt["%u.%u.%u.%u", a as uint, b as uint, c as uint, d as uint]
+      }
+    }
+}
+
+mod v4 {
+    #[doc = "
+    Convert a str to `ip_addr`
+
+    # Failure
+
+j    Fails if the string is not a valid IPv4 address
+
+    # Arguments
+
+    * ip - a string of the format `x.x.x.x`
+
+    # Returns
+
+    * an `ip_addr` of the `ipv4` variant
+    "]
+    fn parse_addr(ip: str) -> ip_addr {
+        let parts = vec::map(str::split_char(ip, '.'), {|s|
+            alt uint::from_str(s) {
+              some(n) if n <= 255u { n }
+              _ { fail "Invalid IP Address part." }
+            }
+        });
+        if vec::len(parts) != 4u { fail "Too many dots in IP address"; }
+        ipv4(parts[0] as u8, parts[1] as u8, parts[2] as u8, parts[3] as u8)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_format_ip() {
+        assert (format_addr(ipv4(127u8, 0u8, 0u8, 1u8))
+                == "127.0.0.1")
+    }
+
+    #[test]
+    fn test_parse_ip() {
+        assert (v4::parse_addr("127.0.0.1") ==
+                ipv4(127u8, 0u8, 0u8, 1u8));
+    }
+}

--- a/src/libstd/net_ip.rs
+++ b/src/libstd/net_ip.rs
@@ -6,6 +6,7 @@ import vec;
 import uint;
 
 export ip_addr;
+export format_addr;
 export v4;
 //format_addr, parse_addr;
 

--- a/src/libstd/net_ip.rs
+++ b/src/libstd/net_ip.rs
@@ -14,6 +14,7 @@ export v4;
 enum ip_addr {
     #[doc="An IPv4 address"]
     ipv4(u8, u8, u8, u8),
+    ipv6(u16,u16,u16,u16,u16,u16,u16,u16)
 }
 
 #[doc="
@@ -27,6 +28,9 @@ fn format_addr(ip: ip_addr) -> str {
     alt ip {
       ipv4(a, b, c, d) {
         #fmt["%u.%u.%u.%u", a as uint, b as uint, c as uint, d as uint]
+      }
+      ipv6(a,b,c,d,e,f,g,h) {
+        fail "FIXME impl parsing of ipv6 addr";
       }
     }
 }

--- a/src/libstd/net_ip.rs
+++ b/src/libstd/net_ip.rs
@@ -5,10 +5,9 @@ Types/fns concerning Internet Protocol (IP), versions 4 & 6
 import vec;
 import uint;
 
-export ip_addr;
+export ip_addr, parse_addr_err;
 export format_addr;
 export v4;
-//format_addr, parse_addr;
 
 #[doc = "An IP address"]
 enum ip_addr {
@@ -16,6 +15,13 @@ enum ip_addr {
     ipv4(u8, u8, u8, u8),
     ipv6(u16,u16,u16,u16,u16,u16,u16,u16)
 }
+
+#[doc="
+Human-friendly feedback on why a parse_addr attempt failed
+"]
+type parse_addr_err = {
+    err_msg: str
+};
 
 #[doc="
 Convert a `ip_addr` to a str
@@ -29,7 +35,7 @@ fn format_addr(ip: ip_addr) -> str {
       ipv4(a, b, c, d) {
         #fmt["%u.%u.%u.%u", a as uint, b as uint, c as uint, d as uint]
       }
-      ipv6(a,b,c,d,e,f,g,h) {
+      ipv6(_, _, _, _, _, _, _, _) {
         fail "FIXME impl parsing of ipv6 addr";
       }
     }
@@ -52,14 +58,32 @@ j    Fails if the string is not a valid IPv4 address
     * an `ip_addr` of the `ipv4` variant
     "]
     fn parse_addr(ip: str) -> ip_addr {
+        alt try_parse_addr(ip) {
+          result::ok(addr) { addr }
+          result::err(err_data) {
+            fail err_data.err_msg
+          }
+        }
+    }
+    fn try_parse_addr(ip: str) -> result::result<ip_addr,parse_addr_err> {
         let parts = vec::map(str::split_char(ip, '.'), {|s|
             alt uint::from_str(s) {
               some(n) if n <= 255u { n }
-              _ { fail "Invalid IP Address part." }
+              _ { 256u }
             }
         });
-        if vec::len(parts) != 4u { fail "Too many dots in IP address"; }
-        ipv4(parts[0] as u8, parts[1] as u8, parts[2] as u8, parts[3] as u8)
+        if vec::len(parts) != 4u {
+            result::err({err_msg: #fmt("'%s' doesn't have 4 parts",
+                        ip)})
+        }
+        else if vec::contains(parts, 256u) {
+            result::err({err_msg: #fmt("invalid octal in provided addr '%s'",
+                        ip)})
+        }
+        else {
+            result::ok(ipv4(parts[0] as u8, parts[1] as u8,
+                 parts[2] as u8, parts[3] as u8))
+        }
     }
 }
 

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -1,0 +1,59 @@
+#[doc="
+High-level interface to libuv's TCP functionality
+"];
+
+#[cfg(ignore)]
+mod test {
+    #[test]
+    fn test_gl_tcp_ipv4_request() {
+        let ip = "127.0.0.1";
+        let port = 80u;
+        let expected_read_msg = "foo";
+        let actual_write_msg = "bar";
+        let addr = ipv4::address(ip, port);
+
+        let data_po = comm::port::<[u8]>();
+        let data_ch = comm::chan(data_po);
+        
+        alt connect(addr) {
+          tcp_connected(tcp_stream) {
+            let write_data = str::as_buf(actual_write_msg);
+            alt write(tcp_stream, [write_data]) {
+              tcp_write_success {
+                let mut total_read_data: [u8] = []
+                let reader_po = read_start(tcp_stream);
+                loop {
+                    alt comm::recv(reader_po) {
+                      new_read_data(data) {
+                        total_read_data += data;
+                        // theoretically, we could keep iterating, here, if
+                        // we expect the server on the other end to keep
+                        // streaming/chunking data to us, but..
+                        read_stop(tcp_stream);
+                        break;
+                      }
+                      done_reading {
+                        break;
+                      }
+                      error {
+                        fail "erroring occured during read attempt.. FIXME need info";
+                      }
+                    }
+                }
+                comm::send(data_ch, total_read_data);
+              }
+              tcp_write_error {
+                fail "error during write attempt.. FIXME need err info";
+              }
+            }
+          }
+          tcp_connect_error {
+            fail "error during connection attempt.. FIXME need err info..";
+          }
+        }
+
+        let actual_data = comm::recv(data_po);
+        let resp = str::from_bytes(actual_data);
+        log(debug, "DATA RECEIVED: "+resp);
+    }
+}

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -2,26 +2,212 @@
 High-level interface to libuv's TCP functionality
 "];
 
-#[cfg(ignore)]
+import ip = net_ip;
+
+export tcp_connect_result;
+export connect;
+
+enum tcp_socket {
+    valid_tcp_socket(@tcp_socket_data)
+}
+
+enum tcp_connect_result {
+    tcp_connected(tcp_socket),
+    tcp_connect_error(uv::ll::uv_err_data)
+}
+
+#[doc="
+Initiate a client connection over TCP/IP
+
+# Arguments
+
+* ip - The IP address (versions 4 or 6) of the remote host
+* port - the unsigned integer of the desired remote host port
+
+# Returns
+
+A `tcp_connect_result` that can be used to determine the connection and,
+if successful, send and receive data to/from the remote host
+"]
+fn connect(input_ip: ip::ip_addr, port: uint) -> tcp_connect_result unsafe {
+    let result_po = comm::port::<conn_attempt>();
+    let closed_signal_po = comm::port::<()>();
+    let conn_data = {
+        result_ch: comm::chan(result_po),
+        closed_signal_ch: comm::chan(closed_signal_po)
+    };
+    let conn_data_ptr = ptr::addr_of(conn_data);
+    let socket_data = @{
+        reader_port: comm::port::<[u8]>(),
+        stream_handle : uv::ll::tcp_t(),
+        connect_req : uv::ll::connect_t(),
+        write_req : uv::ll::write_t()
+    };
+    log(debug, #fmt("tcp_connect result_ch %?", conn_data.result_ch));
+    // get an unsafe representation of our stream_handle_ptr that
+    // we can send into the interact cb to be handled in libuv..
+    let socket_data_ptr: *tcp_socket_data =
+        ptr::addr_of(*socket_data);
+    // in we go!
+    let hl_loop = uv::global_loop::get();
+    log(debug, #fmt("stream_handl_ptr outside interact %?",
+        ptr::addr_of((*socket_data_ptr).stream_handle)));
+    uv::hl::interact(hl_loop) {|loop_ptr|
+        log(debug, "in interact cb for tcp client connect..");
+        let stream_handle_ptr =
+            ptr::addr_of((*socket_data_ptr).stream_handle);
+        log(debug, #fmt("stream_handl_ptr in interact %?",
+            stream_handle_ptr));
+        alt uv::ll::tcp_init( loop_ptr, stream_handle_ptr) {
+          0i32 {
+            log(debug, "tcp_init successful");
+            alt input_ip {
+              ipv4 {
+                log(debug, "dealing w/ ipv4 connection..");
+                let tcp_addr = ipv4_ip_addr_to_sockaddr_in(input_ip,
+                                                           port);
+                let tcp_addr_ptr = ptr::addr_of(tcp_addr);
+                let connect_req_ptr =
+                    ptr::addr_of((*socket_data_ptr).connect_req);
+                alt uv::ll::tcp_connect(
+                    connect_req_ptr,
+                    stream_handle_ptr,
+                    tcp_addr_ptr,
+                    tcp_connect_on_connect_cb) {
+                  0i32 {
+                    log(debug, "tcp_connect successful");
+                    // reusable data that we'll have for the
+                    // duration..
+                    uv::ll::set_data_for_uv_handle(stream_handle_ptr,
+                                               socket_data_ptr);
+                    // just so the connect_cb can send the
+                    // outcome..
+                    uv::ll::set_data_for_req(connect_req_ptr,
+                                             conn_data_ptr);
+                    log(debug, "leaving tcp_connect interact cb...");
+                    // let tcp_connect_on_connect_cb send on
+                    // the result_ch, now..
+                  }
+                  _ {
+                    // immediate connect failure.. probably a garbage
+                    // ip or somesuch
+                    let err_data = uv::ll::get_last_err_data(loop_ptr);
+                    comm::send((*conn_data_ptr).result_ch,
+                               conn_failure(err_data));
+                    uv::ll::set_data_for_uv_handle(stream_handle_ptr,
+                                                   conn_data_ptr);
+                    uv::ll::close(stream_handle_ptr, stream_error_close_cb);
+                  }
+                }
+              }
+            }
+        }
+          _ {
+            // failure to create a tcp handle
+            let err_data = uv::ll::get_last_err_data(loop_ptr);
+            comm::send((*conn_data_ptr).result_ch,
+                       conn_failure(err_data));
+          }
+        }
+    };
+    alt comm::recv(result_po) {
+      conn_success {
+        log(debug, "tcp::connect - received success on result_po");
+        tcp_connected(valid_tcp_socket(socket_data))
+      }
+      conn_failure(err_data) {
+        comm::recv(closed_signal_po);
+        log(debug, "tcp::connect - received failure on result_po");
+        tcp_connect_error(err_data)
+      }
+    }
+}
+// INTERNAL API
+type connect_req_data = {
+    result_ch: comm::chan<conn_attempt>,
+    closed_signal_ch: comm::chan<()>
+};
+
+crust fn stream_error_close_cb(handle: *uv::ll::uv_tcp_t) unsafe {
+    let data = uv::ll::get_data_for_uv_handle(handle) as
+        *connect_req_data;
+    comm::send((*data).closed_signal_ch, ());
+    log(debug, #fmt("exiting steam_error_close_cb for %?", handle));
+}
+
+crust fn tcp_connect_close_cb(handle: *uv::ll::uv_tcp_t) unsafe {
+    log(debug, #fmt("closed client tcp handle %?", handle));
+}
+
+crust fn tcp_connect_on_connect_cb(connect_req_ptr: *uv::ll::uv_connect_t,
+                                   status: libc::c_int) unsafe {
+    let conn_data_ptr = (uv::ll::get_data_for_req(connect_req_ptr)
+                      as *connect_req_data);
+    let result_ch = (*conn_data_ptr).result_ch;
+    log(debug, #fmt("tcp_connect result_ch %?", result_ch));
+    let tcp_stream_ptr =
+        uv::ll::get_stream_handle_from_connect_req(connect_req_ptr);
+    alt status {
+      0i32 {
+        log(debug, "successful tcp connection!");
+        comm::send(result_ch, conn_success);
+      }
+      _ {
+        log(debug, "error in tcp_connect_on_connect_cb");
+        let loop_ptr = uv::ll::get_loop_for_uv_handle(tcp_stream_ptr);
+        let err_data = uv::ll::get_last_err_data(loop_ptr);
+        log(debug, #fmt("err_data %? %?", err_data.err_name,
+                        err_data.err_msg));
+        comm::send(result_ch, conn_failure(err_data));
+        uv::ll::set_data_for_uv_handle(tcp_stream_ptr,
+                                       conn_data_ptr);
+        uv::ll::close(tcp_stream_ptr, stream_error_close_cb);
+      }
+    }
+    log(debug, "leaving tcp_connect_on_connect_cb");
+}
+
+enum conn_attempt {
+    conn_success,
+    conn_failure(uv::ll::uv_err_data)
+}
+
+
+type tcp_socket_data = {
+    reader_port: comm::port<[u8]>,
+    stream_handle: uv::ll::uv_tcp_t,
+    connect_req: uv::ll::uv_connect_t,
+    write_req: uv::ll::uv_write_t
+};
+
+// convert rust ip_addr to libuv's native representation
+fn ipv4_ip_addr_to_sockaddr_in(input: ip::ip_addr,
+                               port: uint) -> uv::ll::sockaddr_in unsafe {
+    uv::ll::ip4_addr(ip::format_addr(input), port as int)
+}
+
+#[cfg(test)]
 mod test {
     #[test]
     fn test_gl_tcp_ipv4_request() {
-        let ip = "127.0.0.1";
+        let ip_str = "127.0.0.1";
         let port = 80u;
         let expected_read_msg = "foo";
         let actual_write_msg = "bar";
-        let addr = ipv4::address(ip, port);
+        let host_ip = ip::v4::parse_addr(ip_str);
 
         let data_po = comm::port::<[u8]>();
         let data_ch = comm::chan(data_po);
         
-        alt connect(addr) {
-          tcp_connected(tcp_stream) {
+        alt connect(host_ip, port) {
+          tcp_connected(sock) {
+            log(debug, "successful tcp connect");
+            /*
             let write_data = str::as_buf(actual_write_msg);
-            alt write(tcp_stream, [write_data]) {
+            alt write(sock, [write_data]) {
               tcp_write_success {
-                let mut total_read_data: [u8] = []
-                let reader_po = read_start(tcp_stream);
+                let mut total_read_data: [u8] = [];
+                let reader_po = read_start(sock);nyw
                 loop {
                     alt comm::recv(reader_po) {
                       new_read_data(data) {
@@ -36,7 +222,8 @@ mod test {
                         break;
                       }
                       error {
-                        fail "erroring occured during read attempt.. FIXME need info";
+                        fail "erroring occured during read attempt.."
+                            + "FIXME need info";
                       }
                     }
                 }
@@ -46,9 +233,13 @@ mod test {
                 fail "error during write attempt.. FIXME need err info";
               }
             }
+            */
           }
-          tcp_connect_error {
-            fail "error during connection attempt.. FIXME need err info..";
+          tcp_connect_error(err_data) {
+            log(debug, "tcp_connect_error received..");
+            log(debug, #fmt("tcp connect error: %? %?", err_data.err_name,
+                           err_data.err_msg));
+            assert false;
           }
         }
 

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -1424,7 +1424,7 @@ mod test {
                             let sock = result::unwrap(accept_result);
                             log(debug, "SERVER: successfully accepted"+
                                 "connection!");
-                            let received_req_bytes = sock.read(2000u);
+                            let received_req_bytes = sock.read(0u);
                             alt received_req_bytes {
                               result::ok(data) {
                                 server_ch.send(
@@ -1492,7 +1492,7 @@ mod test {
             log(debug, "SERVER: successfully accepted"+
                 "connection!");
             let received_req_bytes =
-                sock.read(2000u);
+                sock.read(0u);
             alt received_req_bytes {
               result::ok(data) {
                 server_ch.send(
@@ -1529,7 +1529,7 @@ mod test {
             let sock = result::unwrap(connect_result);
             let resp_bytes = str::bytes(resp);
             tcp_write_single(sock, resp_bytes);
-            let read_result = sock.read(2000u);
+            let read_result = sock.read(0u);
             if read_result.is_failure() {
                 log(debug, "CLIENT: failure to read");
                 ""

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -23,6 +23,7 @@ export test, tempfile, serialization;
 // General io and system-services modules
 
 mod net;
+mod net_ip;
 mod net_tcp;
 
 // libuv modules

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -23,6 +23,7 @@ export test, tempfile, serialization;
 // General io and system-services modules
 
 mod net;
+mod net_tcp;
 
 // libuv modules
 mod uv;

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -13,7 +13,8 @@
 use core(vers = "0.2");
 import core::*;
 
-export net, uv;
+export net, net_tcp;
+export uv, uv_ll, uv_hl, uv_global_loop;
 export c_vec, util, timer;
 export bitv, deque, fun_treemap, list, map, smallintmap, sort, treemap;
 export rope, arena;

--- a/src/libstd/timer.rs
+++ b/src/libstd/timer.rs
@@ -190,6 +190,7 @@ mod test {
     // the majority of tries.
 
     #[test]
+    #[cfg(ignore)]
     fn test_gl_timer_recv_timeout_before_time_passes() {
         let times = 100;
         let mut successes = 0;

--- a/src/libstd/timer.rs
+++ b/src/libstd/timer.rs
@@ -238,10 +238,10 @@ mod test {
                 delayed_send(hl_loop, 1000u, test_ch, expected);
             };
 
-            let actual = alt recv_timeout(hl_loop, 1u, test_po) {
+            alt recv_timeout(hl_loop, 1u, test_po) {
               none { successes += 1; }
               _ { failures += 1; }
-            };
+            }
         }
 
         assert successes > times / 2;

--- a/src/libstd/uv_global_loop.rs
+++ b/src/libstd/uv_global_loop.rs
@@ -151,11 +151,11 @@ mod test {
     }
     crust fn simple_timer_cb(timer_ptr: *ll::uv_timer_t,
                              status: libc::c_int) unsafe {
-        log(debug, "in simple timer cb");
+        log(debug, #fmt("in simple timer cb status %?", status));
         ll::timer_stop(timer_ptr);
         let hl_loop = get_gl();
         hl::interact(hl_loop) {|loop_ptr|
-            log(debug, "closing timer");
+            log(debug, #fmt("closing timer loop %?", loop_ptr));
             ll::close(timer_ptr, simple_timer_close_cb);
             log(debug, "about to deref exit_ch_ptr");
             log(debug, "after msg sent on deref'd exit_ch");

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -1318,7 +1318,7 @@ mod test {
         assert str::contains(msg_from_server, server_resp_msg);
     }
 
-    // don't run this test on fbsd or 32bit linux
+    // FIXME don't run on fbsd or linux 32 bit(#2064)
     #[cfg(target_os="win32")]
     #[cfg(target_os="darwin")]
     #[cfg(target_os="linux")]

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -642,7 +642,7 @@ unsafe fn listen<T>(stream: *T, backlog: libc::c_int,
     ret rustrt::rust_uv_listen(stream as *libc::c_void, backlog, cb);
 }
 
-unsafe fn accept<T, U>(server: *T, client: *T)
+unsafe fn accept(server: *libc::c_void, client: *libc::c_void)
     -> libc::c_int {
     ret rustrt::rust_uv_accept(server as *libc::c_void,
                                client as *libc::c_void);

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -1280,7 +1280,7 @@ mod test {
     fn impl_uv_tcp_server_and_request() unsafe {
         let bind_ip = "0.0.0.0";
         let request_ip = "127.0.0.1";
-        let port = 8888;
+        let port = 8887;
         let kill_server_msg = "does a dog have buddha nature?";
         let server_resp_msg = "mu!";
         let client_port = comm::port::<str>();

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -637,14 +637,15 @@ unsafe fn tcp_bind(tcp_server_ptr: *uv_tcp_t,
                                  addr_ptr);
 }
 
-unsafe fn listen(stream: *libc::c_void, backlog: libc::c_int,
+unsafe fn listen<T>(stream: *T, backlog: libc::c_int,
                  cb: *u8) -> libc::c_int {
-    ret rustrt::rust_uv_listen(stream, backlog, cb);
+    ret rustrt::rust_uv_listen(stream as *libc::c_void, backlog, cb);
 }
 
-unsafe fn accept(server: *libc::c_void, client: *libc::c_void)
+unsafe fn accept<T, U>(server: *T, client: *T)
     -> libc::c_int {
-    ret rustrt::rust_uv_accept(server, client);
+    ret rustrt::rust_uv_accept(server as *libc::c_void,
+                               client as *libc::c_void);
 }
 
 unsafe fn write<T>(req: *uv_write_t, stream: *T,

--- a/src/rt/rust_uv.cpp
+++ b/src/rt/rust_uv.cpp
@@ -456,7 +456,7 @@ rust_uv_current_kernel_malloc(size_t size) {
 	return current_kernel_malloc(size, "rust_uv_current_kernel_malloc");
 }
 
-extern "C" void*
+extern "C" void
 rust_uv_current_kernel_free(void* mem) {
-	return current_kernel_free(mem);
+	current_kernel_free(mem);
 }

--- a/src/rt/rust_uv.cpp
+++ b/src/rt/rust_uv.cpp
@@ -450,3 +450,13 @@ rust_uv_get_kernel_global_chan_ptr() {
     LOG(task, stdlib,"global loop val: %lu", (unsigned long int)*result);
     return result;
 }
+
+extern "C" void*
+rust_uv_current_kernel_malloc(size_t size) {
+	return current_kernel_malloc(size, "rust_uv_current_kernel_malloc");
+}
+
+extern "C" void*
+rust_uv_current_kernel_free(void* mem) {
+	return current_kernel_free(mem);
+}

--- a/src/rt/rust_uv.cpp
+++ b/src/rt/rust_uv.cpp
@@ -453,10 +453,10 @@ rust_uv_get_kernel_global_chan_ptr() {
 
 extern "C" void*
 rust_uv_current_kernel_malloc(size_t size) {
-	return current_kernel_malloc(size, "rust_uv_current_kernel_malloc");
+    return current_kernel_malloc(size, "rust_uv_current_kernel_malloc");
 }
 
 extern "C" void
 rust_uv_current_kernel_free(void* mem) {
-	current_kernel_free(mem);
+    current_kernel_free(mem);
 }

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -143,6 +143,8 @@ rust_uv_set_data_for_req
 rust_uv_get_base_from_buf
 rust_uv_get_len_from_buf
 rust_uv_get_kernel_global_chan_ptr
+rust_uv_current_kernel_malloc
+rust_uv_current_kernel_free
 rust_dbg_lock_create
 rust_dbg_lock_destroy
 rust_dbg_lock_lock


### PR DESCRIPTION
### quick summary

This pull req includes high-level TCP/IP bindings for the rust stdlib (both server and client API), under the `std::net::tcp` module. I also did some reshuffling of the IP stuff and pushed it into the `net::ip` module.

also: adding `result::unwrap` (from a patch from @nmatsakis) and ignore'd a test on std::timer that is starting to fail more and more, as perf chokes due to valgrind and threading behavior (the test is time-sensitive, so probably poorly conceived to begin with)
### only slightly more in-depth

An example demonstrating the TCP client/request API can be found [here](https://github.com/olsonjeffery/rust/blob/hl_tcp/src/libstd/net_tcp.rs#L1352).

Interestingly, because of API-style friction between libuv and rust, I found it neccesary to expose two separate UIs to the TCP server API. Quickly, with examples, they are:
- the `net::tcp::listen_for_conn` entry point, an example of which is [here](https://github.com/olsonjeffery/rust/blob/hl_tcp/src/libstd/net_tcp.rs#L1225). This call is blocking for the lifetime of the TCP server connection and uses a callback running on the libuv loop (!).
- and the `net::tcp::new_listener` entry point, an example of which can be found [here](https://github.com/olsonjeffery/rust/blob/hl_tcp/src/libstd/net_tcp.rs#L1300). This bit of API, on successful setup, returns a (vaguely) `comm::port`-like object that uses can peek/recv on (using custom API), as needed, to get new connections.

The `new_listener` API varies, subtly, from the `listen_for_conn` entry point because it _accepts new connections immediately_ (with the overhead that this entails), while `listen_for_conn` gives a user the chance to manually `accept` a connection, or just drop it, in line with the default behavior of libuv.

To more fully articulate this, I'm just going to paste my commit msg from `95f0b90`:
- we now have two interfaces for the TCP/IP server/listener workflow,
  based on different user approaches surrounding how to deal with the
  flow of accept a new tcp connection:
1. the "original" API closely mimics the low-level libuv API, in that we
   have an on_connect_cb that the user provides _that is ran on the libuv
   thread_. In this callback, the user can accept() a connection, turning it
   into a tcp_socket.. of course, before accepting, they have the option
   of passing it to a new task, provided they _make the cb block until
   the accept is done_ .. this is because, in libuv, you have to do the
   uv_accept call in the span of that on_connect_cb callback that gets fired
   when a new connection comes in. thems the breaks..

I wanted to just get rid of this API, because the general proposition of
users always running code on the libuv thread sounds like an invitation
for many future headaches. the API restriction to have to choose to
immediately accept a connection (and allow the user to block libuv as
needed) isn't too bad for power users who could conceive of circumstances
where they would drop an incoming TCP connection and know what they're
doing, in general.

but as a general API, I thought this was a bit cumbersome, so I ended up
devising..
1. an API that is initiated with a call to `net::tcp::new_listener()` ..
   has a similar signature to `net::tcp::listen()`, except that is just
   returns an object that sort of behaves like a `comm::port`. Users can
   block on the `tcp_conn_port` to receive new connections, either in the
   current task or in a new task, depending on which API route they take
   (`net::tcp::conn_recv` or `net::tcp::conn_recv_spawn` respectively).. there
   is also a `net::tcp::conn_peek` function that will do a peek on the
   underlying port to see if there are pending connections.

The main difference, with this API, is that the low-level libuv glue is
going to _accept every connection attempt_, along with the overhead that
that brings. But, this is a much more hassle-free API for 95% of use
cases and will probably be the one that most users will want to reach for.
### what's needed to fill this out
1. IPv6! I stubbed out the data structure, but parsing IPv6 addr strings is non-trivial, so I'm not sure how to tackle this from rust, just yet. If anyone wants to pitch in, that'd be swell.
2. The other bits of the tcp API. I only added connection-establishment for clients/server and read/write over TCP streams.. so stuff like setting keep-alive, etc needs to be added.
