### PR TITLE
a couple misc changes

### DIFF
--- a/src/cargo/cargo.rs
+++ b/src/cargo/cargo.rs
@@ -18,13 +18,7 @@ import vec;
 import std::getopts;
 import getopts::{optflag, optopt, opt_present};
 
-enum _src {
-    /* Break cycles in package <-> source */
-    _source(source),
-}
-
 type package = {
-//    source: _src,
     name: str,
     uuid: str,
     url: str,
@@ -293,7 +287,6 @@ fn load_one_source_package(&src: source, p: map::hashmap<str, json::json>) {
     };
 
     vec::grow(src.packages, 1u, {
-        // source: _source(src),
         name: name,
         uuid: uuid,
         url: url,

--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -161,6 +161,24 @@ impl reader_util for reader {
         while !self.eof() { buf += self.read_bytes(2048u); }
         buf
     }
+
+    fn each_byte(it: fn(int) -> bool) {
+        while !self.eof() {
+            if !it(self.read_byte()) { break; }
+        }
+    }
+
+    fn each_char(it: fn(char) -> bool) {
+        while !self.eof() {
+            if !it(self.read_char()) { break; }
+        }
+    }
+
+    fn each_line(it: fn(str) -> bool) {
+        while !self.eof() {
+            if !it(self.read_line()) { break; }
+        }
+    }
 }
 
 // Reader implementations

--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -1,7 +1,7 @@
 #[doc ="
 An implementation of the SHA-1 cryptographic hash.
 
-First create a `sha1` object using the `mk_sha1` constructor, then
+First create a `sha1` object using the `sha1` constructor, then
 feed it input using the `input` or `input_str` methods, which may be
 called any number of times.
 

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -530,6 +530,11 @@ struct tm* LOCALTIME(const time_t *clock, tm *result) {
 #endif
 
 extern "C" CDECL void
+rust_tzset() {
+    TZSET();
+}
+
+extern "C" CDECL void
 rust_gmtime(int64_t *sec, int32_t *nsec, rust_tm *timeptr) {
     tm tm;
     time_t s = *sec;
@@ -541,7 +546,6 @@ rust_gmtime(int64_t *sec, int32_t *nsec, rust_tm *timeptr) {
 extern "C" CDECL void
 rust_localtime(int64_t *sec, int32_t *nsec, rust_tm *timeptr) {
     tm tm;
-    TZSET();
     time_t s = *sec;
     LOCALTIME(&s, &tm);
 

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -12,6 +12,7 @@ debug_abi_2
 get_port_id
 get_task_id
 get_time
+rust_tzset
 rust_gmtime
 rust_localtime
 rust_timegm


### PR DESCRIPTION
I've been sitting on some commits for a couple weeks now. Mainly just some cleanup, but also exposes tzset() and adds support for io iterable functions like `for io::stdin().each_byte() { |byte| ... }`.
