### PR TITLE
New compiler flags: -W all -W no-all -W err-all

### DIFF
--- a/src/rustc/driver/rustc.rs
+++ b/src/rustc/driver/rustc.rs
@@ -67,6 +67,9 @@ Options:
     -W <foo>           enable warning <foo>
     -W no-<foo>        disable warning <foo>
     -W err-<foo>       enable warning <foo> as an error
+    -W all             enable all warnings
+    -W no-all          disable all warnings
+    -W err-all         enable all warnings as errors
     -W help            Print available warnings and default settings
 
     -Z help            list internal options for debugging rustc


### PR DESCRIPTION
Use `RUST_LOG=rustc::driver=2` to see the effect of the new options.

When `rustc` is invoked with `-W all`, it sets the lint flags equal to the keys of the master lint flags hashtable. As per the convention of the individual lint flags, using `-W no-all` will do the same, but prepends each lint flag with `no-`, thereby disabling it. Using `-W err-all` prepends all lint flags with `err-` to abort compilation upon a lint warning.

Here's the test file I used:

```
use std;
import std::bitv;  // unused-import warning

fn main() {
    while true {  // while-true warning
        io::println("hello");
        log(error, "world");  // old-vecs warning
        #error("%?", "again!");  // lots of old-vecs warnings
        break;
    }
}
```
