### PR TITLE
Relax the need for "u" suffixes on uints under certain conditions.

### DIFF
--- a/src/test/compile-fail/inferred-integer-literal-type.rs
+++ b/src/test/compile-fail/inferred-integer-literal-type.rs
@@ -1,0 +1,20 @@
+// Issue #1425.
+
+// Relax the need for the "u" suffix on unsigned integer literals
+// under certain very limited conditions.
+
+// But, when inferring uint types for would-be ints, make sure we
+// don't allow chars to be treated as uints.
+
+fn main() {
+    let x1: uint = 'c'; //! ERROR mismatched types
+    let x2 = 1u + 'c'; //! ERROR mismatched types
+    let x3: uint = 1u + 'c'; //! ERROR mismatched types
+    let x4 = vec::slice(["hello", "world"], 'c', 'd');
+    //!^ ERROR mismatched types
+    //!^^ ERROR mismatched types
+    let x5 = vec::slice(["hello", "world"], 0u, 'c');
+    //!^ ERROR mismatched types
+    let x6 = vec::slice(["hello", "world"], 'c', 1u);
+    //!^ ERROR mismatched types
+}

--- a/src/test/compile-fail/issue-1362.rs
+++ b/src/test/compile-fail/issue-1362.rs
@@ -1,7 +1,7 @@
 // Regression test for issue #1362 - without that fix the span will be bogus
 // no-reformat
 fn main() {
-  let x: uint = 20; //! ERROR mismatched types
+  let x: uint = "hello"; //! ERROR mismatched types
 }
 // NOTE: Do not add any extra lines as the line number the error is
 // on is significant; an error later in the source file might not

--- a/src/test/compile-fail/issue-1448-2.rs
+++ b/src/test/compile-fail/issue-1448-2.rs
@@ -1,5 +1,5 @@
 // Regresion test for issue #1448 and #1386
 
 fn main() {
-    #debug["%u", 10]; //! ERROR mismatched types
+    #debug["%u", "hello"]; //! ERROR mismatched types
 }

--- a/src/test/run-pass/inferred-integer-literal-type.rs
+++ b/src/test/run-pass/inferred-integer-literal-type.rs
@@ -1,0 +1,22 @@
+// Issue #1425.
+
+// Relax the need for the "u" suffix on unsigned integer literals
+// under certain very limited conditions.
+
+fn main() {
+    let x1: uint = 4;
+    let x2 = 1u + 5;
+    let x3: uint = 1u + 6;
+    let x4 = vec::slice(["hello", "world"], 0, 1);
+    let x5 = vec::slice(["hello", "world"], 0u, 1);
+    let x6 = vec::slice(["hello", "world"], 0, 1u);
+
+    // Something we can't do yet.
+    // let x = 5;
+    // fn foo(a : uint) { } 
+    // foo(x);
+
+    // These fail, too, as predicted.
+    // let x7 = 1 + 5u;
+    // let x8: uint = 1 + 6u;
+}


### PR DESCRIPTION
An attempt at Issue #1425.  A more principled approach would have to
involve creating a new kind of type variable and doing unification on
those, separately from the existing type vars; this is more of a quick
hack.

Explaining the two tests I changed: It looks as though the
issue-1448-2.rs and issue-1362.rs tests were using unsuffixed integer
literals in a context that expected a uint, merely to trigger a
"mismatched types" error in the fastest way possible.  So, we can just
replace the unsuffixed integer literal with a string.
