### PR TITLE
(float) fix some rounding errors when showing as str

### DIFF
--- a/src/test/run-pass/syntax-extension-fmt.rs
+++ b/src/test/run-pass/syntax-extension-fmt.rs
@@ -94,7 +94,7 @@ fn part3() {
     test(#fmt["%.o", 10u], "12");
     test(#fmt["%.t", 3u], "11");
     test(#fmt["%.c", 'A'], "A");
-    test(#fmt["%.f", 5.82], "5");
+    test(#fmt["%.f", 5.82], "6");
     test(#fmt["%.0d", 0], "");
     test(#fmt["%.0u", 0u], "");
     test(#fmt["%.0x", 0u], "");
@@ -107,7 +107,7 @@ fn part3() {
     test(#fmt["%.0o", 10u], "12");
     test(#fmt["%.0t", 3u], "11");
     test(#fmt["%.0c", 'A'], "A");
-    test(#fmt["%.0f", 5.892], "5");
+    test(#fmt["%.0f", 5.892], "6");
     test(#fmt["%.1d", 0], "0");
     test(#fmt["%.1u", 0u], "0");
     test(#fmt["%.1x", 0u], "0");


### PR DESCRIPTION
This seems to fix issue #1876, and some of the superficial parts of
issue #1375.  The #fmt macro and the to_str functions will round,
rather than truncate, floats as strings.

Other issues remain, and I wrote more code here than intended, but the
following should pass now.

```
fn x() {
   assert "3.1416"      == #fmt["%.4f", 3.14159];
   assert "3"           == #fmt["%.0f", 3.14159];
   assert "99"          == #fmt["%.0f", 98.5];
   assert "7.0000"      == #fmt["%.4f", 6.999999999];
   assert "3.141590000" == #fmt["%.9f", 3.14159];
}
```
