### PR TITLE
Moved log method into logger class better than scheduler

### DIFF
--- a/src/rt/rust_log.cpp
+++ b/src/rt/rust_log.cpp
@@ -90,6 +90,22 @@ append_string(char *buffer, const char *format, ...) {
 }
 
 void
+rust_log::log(rust_task* task, uint32_t level, char const *fmt, ...) {
+    char buf[BUF_BYTES];
+    va_list args;
+    va_start(args, fmt);
+    int formattedbytes = vsnprintf(buf, sizeof(buf), fmt, args);
+    if( formattedbytes and (unsigned)formattedbytes > BUF_BYTES ){
+        const char truncatedstr[] = "[...]";
+        memcpy( &buf[BUF_BYTES-sizeof(truncatedstr)],
+                truncatedstr,
+                sizeof(truncatedstr));
+    }
+    trace_ln(task, level, buf);
+    va_end(args);
+}
+
+void
 rust_log::trace_ln(char *prefix, char *message) {
     char buffer[BUF_BYTES] = "";
     _log_lock.lock();
@@ -301,6 +317,7 @@ void update_log_settings(void* crate_map, char* settings) {
 
     free(buffer);
 }
+
 
 //
 // Local Variables:

--- a/src/rt/rust_log.h
+++ b/src/rt/rust_log.h
@@ -23,7 +23,7 @@ const uint32_t log_debug = 3;
     do {                                                        \
         rust_sched_loop* _d_ = sched_loop;                      \
         if (log_rt_##field >= lvl && _d_->log_lvl >= lvl) {     \
-            _d_->log(task, lvl, __VA_ARGS__);                   \
+            _d_->get_log().log(task, lvl, __VA_ARGS__);         \
         }                                                       \
     } while (0)
 
@@ -45,6 +45,7 @@ public:
     rust_log(rust_sched_loop *sched_loop);
     virtual ~rust_log();
 
+    void log(rust_task* task, uint32_t level, char const *fmt, ...);
     void trace_ln(rust_task *task, uint32_t level, char *message);
     void trace_ln(char *prefix, char *message);
     bool is_tracing(uint32_t type_bits);

--- a/src/rt/rust_sched_loop.cpp
+++ b/src/rt/rust_sched_loop.cpp
@@ -49,26 +49,10 @@ rust_sched_loop::activate(rust_task *task) {
     DLOG(this, task, "task has returned");
 }
 
-// FIXME #2495: This logging code doesn't belong in the scheduler
-void
-rust_sched_loop::log(rust_task* task, uint32_t level, char const *fmt, ...) {
-    char buf[BUF_BYTES];
-    va_list args;
-    va_start(args, fmt);
-    int formattedbytes = vsnprintf(buf, sizeof(buf), fmt, args);
-    if( formattedbytes and (unsigned)formattedbytes > BUF_BYTES ){
-        const char truncatedstr[] = "[...]";
-        memcpy( &buf[BUF_BYTES-sizeof(truncatedstr)],
-                truncatedstr,
-                sizeof(truncatedstr));
-    }
-    _log.trace_ln(task, level, buf);
-    va_end(args);
-}
 
 void
 rust_sched_loop::fail() {
-    log(NULL, log_err, "domain %s @0x%" PRIxPTR " root task failed",
+    _log.log(NULL, log_err, "domain %s @0x%" PRIxPTR " root task failed",
         name, this);
     kernel->fail();
 }
@@ -168,18 +152,18 @@ rust_sched_loop::log_state() {
     if (log_rt_task < log_debug) return;
 
     if (!running_tasks.is_empty()) {
-        log(NULL, log_debug, "running tasks:");
+        _log.log(NULL, log_debug, "running tasks:");
         for (size_t i = 0; i < running_tasks.length(); i++) {
-            log(NULL, log_debug, "\t task: %s @0x%" PRIxPTR,
+            _log.log(NULL, log_debug, "\t task: %s @0x%" PRIxPTR,
                 running_tasks[i]->name,
                 running_tasks[i]);
         }
     }
 
     if (!blocked_tasks.is_empty()) {
-        log(NULL, log_debug, "blocked tasks:");
+        _log.log(NULL, log_debug, "blocked tasks:");
         for (size_t i = 0; i < blocked_tasks.length(); i++) {
-            log(NULL, log_debug, "\t task: %s @0x%" PRIxPTR
+            _log.log(NULL, log_debug, "\t task: %s @0x%" PRIxPTR
                 ", blocked on: 0x%" PRIxPTR " '%s'",
                 blocked_tasks[i]->name, blocked_tasks[i],
                 blocked_tasks[i]->get_cond(),

--- a/src/rt/rust_sched_loop.h
+++ b/src/rt/rust_sched_loop.h
@@ -96,7 +96,6 @@ public:
     // domain.
     rust_sched_loop(rust_scheduler *sched, int id);
     void activate(rust_task *task);
-    void log(rust_task *task, uint32_t level, char const *fmt, ...);
     rust_log & get_log();
     void fail();
 

--- a/src/rt/rust_shape.cpp
+++ b/src/rt/rust_shape.cpp
@@ -624,6 +624,6 @@ shape_log_type(const type_desc *tydesc, uint8_t *data, uint32_t level) {
 
     log.walk();
 
-    task->sched_loop->log(task, level, "%s", ss.str().c_str());
+    task->sched_loop->get_log().log(task, level, "%s", ss.str().c_str());
 }
 


### PR DESCRIPTION
Moved the log formatter method "log" from rust_sched_loop to rust_log, updated all the references to pass through sched.get_log() to invoke through the logger object.

Tests ran fine.
Fixes #2495
