### PR TITLE
Fix link error on Arch Linux

### DIFF
--- a/src/rustc/back/link.rs
+++ b/src/rustc/back/link.rs
@@ -636,7 +636,7 @@ fn link_binary(sess: session,
     // On linux librt and libdl are an indirect dependencies via rustrt,
     // and binutils 2.22+ won't add them automatically
     if sess.targ_cfg.os == session::os_linux {
-        cc_args += ["-lrt", "-ldl"];
+        cc_args += ["-lrt", "-ldl", "-lm"];
     }
 
     if sess.targ_cfg.os == session::os_freebsd {


### PR DESCRIPTION
There is a link error during make check.
I add the "-lm" flag to fix the problem.

```
cfg: shell host triple x86_64-unknown-linux-gnu
cfg: host for x86_64-unknown-linux-gnu is x86_64
cfg: unix-y environment
cfg: using gcc
cfg: no pandoc found, omitting doc/rust.pdf
cfg: no llnextgen found, omitting grammar-verification
cfg: no pandoc found, omitting library doc build
cfg: including dist rules
cfg: including test rules
check: formatting
compile_and_link: x86_64-unknown-linux-gnu/test/rustctest.stage2-x86_64-unknown-linux-gnu
error: linking with cc failed with code 1
note: cc arguments: -L/home/jyyou/src/rust-git/b/x86_64-unknown-linux-gnu/stage2/lib/rustc/x86_64-unknown-linux-gnu/lib -m64 -o x86_64-unknown-linux-gnu/test/rustctest.stage2-x86_64-unknown-linux-gnu x86_64-unknown-linux-gnu/test/rustctest.o -L/home/jyyou/src/rust-git/b/x86_64-unknown-linux-gnu/stage2/lib/rustc/x86_64-unknown-linux-gnu/lib -lcore-d27e4777a53c3e50-0.2 -L/home/jyyou/src/rust-git/b/x86_64-unknown-linux-gnu/stage2/lib/rustc/x86_64-unknown-linux-gnu/lib -lstd-d399da1ab6f5bec0-0.2 -L/home/jyyou/src/rust-git/b/x86_64-unknown-linux-gnu/stage2/lib/rustc/x86_64-unknown-linux-gnu/lib -lsyntax-b45cc7d0b085bc34-0.2 -Lrustllvm -lrustllvm -lrustrt -lrt -ldl -lmorestack -Wl,-rpath,$ORIGIN/../stage2/lib/rustc/x86_64-unknown-linux-gnu/lib -Wl,-rpath,/home/jyyou/src/rust-git/b/x86_64-unknown-linux-gnu/stage2/lib/rustc/x86_64-unknown-linux-gnu/lib -Wl,-rpath,/usr/local/lib/rustc/x86_64-unknown-linux-gnu/lib
note: /usr/bin/ld: x86_64-unknown-linux-gnu/test/rustctest.o: undefined reference to symbol 'fmod@@GLIBC_2.2.5'
/usr/bin/ld: note: 'fmod@@GLIBC_2.2.5' is defined in DSO /lib/libm.so.6 so try adding it to the linker command line
/lib/libm.so.6: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status

error: aborting due to 1 previous errors
make: *** [x86_64-unknown-linux-gnu/test/rustctest.stage2-x86_64-unknown-linux-gnu] Error 101
```
