### PR TITLE
switch "make all" to build stage2 versions of fuzzer, cargo, and rustdoc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -421,9 +421,9 @@ else
 TSREQS :=											\
 	$(foreach target,$(CFG_TARGET_TRIPLES),			\
 		$(SREQ3_T_$(target)_H_$(CFG_HOST_TRIPLE)))
-FUZZ := $(HBIN3_H_$(CFG_HOST_TRIPLE))/fuzzer$(X)
-CARGO := $(HBIN3_H_$(CFG_HOST_TRIPLE))/cargo$(X)
-RUSTDOC := $(HBIN3_H_$(CFG_HOST_TRIPLE))/rustdoc$(X)
+FUZZ := $(HBIN2_H_$(CFG_HOST_TRIPLE))/fuzzer$(X)
+CARGO := $(HBIN2_H_$(CFG_HOST_TRIPLE))/cargo$(X)
+RUSTDOC := $(HBIN2_H_$(CFG_HOST_TRIPLE))/rustdoc$(X)
 
 all: rustc $(GENERATED) docs $(FUZZ) $(CARGO) $(RUSTDOC)
 


### PR DESCRIPTION
This should trim some time off "make all" because it doesn't force the stage3 rustc to be built. Even better, we can directly use the cargo out of the build directory because we automatically build the stage2 libcore and libstd.

The downside is that the stage3 build directory now will be empty by default. Not sure how much of a downside that is though.
