### PR TITLE
fix compiletest deadlock on freebsd

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -33,12 +33,6 @@ ifneq ($(findstring freebsd,$(CFG_OSTYPE)),)
   CFG_DEF_SUFFIX := .bsd.def
   CFG_INSTALL_NAME =
   CFG_PERF_TOOL := /usr/bin/time
-
-  # FIXME (1825): We're deadlocking on FreeBSD
-  ifndef RUST_THREADS
-    RUST_THREADS=1
-    export RUST_THREADS
-  endif
 endif
 
 ifneq ($(findstring linux,$(CFG_OSTYPE)),)

--- a/src/rustc/back/link.rs
+++ b/src/rustc/back/link.rs
@@ -645,12 +645,13 @@ fn link_binary(sess: session,
     }
 
     if sess.targ_cfg.os == session::os_freebsd {
-        cc_args += ["-lrt", "-L/usr/local/lib", "-lexecinfo",
-                     "-L/usr/local/lib/gcc46",
-                     "-L/usr/local/lib/gcc44", "-lstdc++",
-                     "-Wl,-z,origin",
-                     "-Wl,-rpath,/usr/local/lib/gcc46",
-                     "-Wl,-rpath,/usr/local/lib/gcc44"];
+        cc_args += ["-pthread", "-lrt",
+                    "-L/usr/local/lib", "-lexecinfo",
+                    "-L/usr/local/lib/gcc46",
+                    "-L/usr/local/lib/gcc44", "-lstdc++",
+                    "-Wl,-z,origin",
+                    "-Wl,-rpath,/usr/local/lib/gcc46",
+                    "-Wl,-rpath,/usr/local/lib/gcc44"];
     }
 
     // OS X 10.6 introduced 'compact unwind info', which is produced by the


### PR DESCRIPTION
Adding "-pthread" link flag seems to fix the problem.
make check runs successfully and does not encounter #2325 and #2520 .
By the way, I also remove bind-native-fn from tests because of #2522.
