### PR TITLE
Inline `range` for all integral types

### DIFF
--- a/src/libcore/int-template.rs
+++ b/src/libcore/int-template.rs
@@ -38,6 +38,7 @@ pure fn is_negative(x: T) -> bool { x < 0 as T }
 pure fn is_nonpositive(x: T) -> bool { x <= 0 as T }
 pure fn is_nonnegative(x: T) -> bool { x >= 0 as T }
 
+#[inline(always)]
 #[doc = "Iterate over the range [`lo`..`hi`)"]
 fn range(lo: T, hi: T, it: fn(T) -> bool) {
     let mut i = lo;


### PR DESCRIPTION
Here are the test files (blogbench-while.rs and blogbench-for.rs):

```
import io::writer_util;

fn main(args: [str]) {
    let count = option::get(int::from_str(args[1]));
    let rng = rand::seeded_rng(rand::seed());

    let fw = result::get(io::buffered_file_writer("vec_gen.out"));
    let mut i = 0;
    while i < count {
        let r = (rng.next() & 0x7fffffffu32) as uint;
        fw.write_uint(r);
        fw.write_char('\n');
        i += 1;
    }
}
```

```
import io::writer_util;

fn main(args: [str]) {
    let count = option::get(int::from_str(args[1]));
    let rng = rand::seeded_rng(rand::seed());

    let fw = result::get(io::buffered_file_writer("vec_gen.out"));
    for int::range(0, count) {|_i|
        let r = (rng.next() & 0x7fffffffu32) as uint;
        fw.write_uint(r);
        fw.write_char('\n');
    }
}
```

I compiled blogbench-for.rs twice, once with HEAD and once with my commit that forces the `range` function to inline. All files were compiled with `--opt-level 3`. Here are my unscientific results:

```
kibble@Dreamland:/media/warehouse/scrap
⌁ time ./blogbench-while 100000000 && time ./blogbench-for-old 100000000 && time ./blogbench-for-new 100000000

real    0m19.102s
user    0m13.873s
sys     0m0.288s

real    0m29.946s
user    0m21.481s
sys     0m0.644s

real    0m18.607s
user    0m12.957s
sys     0m0.368s

kibble@Dreamland:/media/warehouse/scrap
⌁ time ./blogbench-while 100000000 && time ./blogbench-for-old 100000000 && time ./blogbench-for-new 100000000

real    0m17.834s
user    0m12.973s
sys     0m0.308s

real    0m26.919s
user    0m19.281s
sys     0m0.460s

real    0m20.518s
user    0m14.393s
sys     0m0.364s

kibble@Dreamland:/media/warehouse/scrap
⌁ time ./blogbench-while 100000000 && time ./blogbench-for-old 100000000 && time ./blogbench-for-new 100000000

real    0m20.678s
user    0m14.997s
sys     0m0.408s

real    0m22.702s
user    0m16.633s
sys     0m0.372s

real    0m18.628s
user    0m13.073s
sys     0m0.312s
```

Across three trials, this commit decreases the execution time of `int::range` by an average of about 25%.
