### PR TITLE
Add logo to HTML docs

### DIFF
--- a/doc/rust.css
+++ b/doc/rust.css
@@ -51,3 +51,11 @@ h3 a:link, h3 a:visited { color: black; }
 .cm-s-default span.cm-bracket {color: #cc7;}
 .cm-s-default span.cm-tag {color: #170;}
 .cm-s-default span.cm-attribute {color: #00c;}
+
+h1.title {
+  padding-top: 140px;
+  background-image: url('http://www.rust-lang.org/logos/rust-logo-128x128-blk.png');
+  background-repeat: no-repeat;
+  backround-position: right;
+  backround-attachment: fixed;
+}

--- a/doc/rust.css
+++ b/doc/rust.css
@@ -53,9 +53,7 @@ h3 a:link, h3 a:visited { color: black; }
 .cm-s-default span.cm-attribute {color: #00c;}
 
 h1.title {
-  padding-top: 140px;
-  background-image: url('http://www.rust-lang.org/logos/rust-logo-128x128-blk.png');
+  background-image: url('http://www.rust-lang.org/logos/rust-logo-32x32-blk.png');
   background-repeat: no-repeat;
-  backround-position: right;
-  backround-attachment: fixed;
+  background-position: right;
 }


### PR DESCRIPTION
This adds the logo to the HTML versions of the docs, via CSS.
![rust logo 128x128](http://www.rust-lang.org/logos/rust-logo-128x128-blk.png)
