### PR TITLE
Box AST idents

### DIFF
--- a/src/cargo/cargo.rs
+++ b/src/cargo/cargo.rs
@@ -224,10 +224,10 @@ fn load_link(mis: [@ast::meta_item]) -> (option<str>,
     for mis.each {|a|
         alt a.node {
             ast::meta_name_value(v, {node: ast::lit_str(s), span: _}) {
-                alt v {
-                    "name" { name = some(s); }
-                    "vers" { vers = some(s); }
-                    "uuid" { uuid = some(s); }
+                alt *v {
+                    "name" { name = some(*s); }
+                    "vers" { vers = some(*s); }
+                    "uuid" { uuid = some(*s); }
                     _ { }
                 }
             }
@@ -259,15 +259,15 @@ fn load_crate(filename: str) -> option<crate> {
     for c.node.attrs.each {|a|
         alt a.node.value.node {
             ast::meta_name_value(v, {node: ast::lit_str(s), span: _}) {
-                alt v {
-                    "desc" { desc = some(v); }
-                    "sigs" { sigs = some(v); }
-                    "crate_type" { crate_type = some(v); }
+                alt *v {
+                    "desc" { desc = some(*v); }
+                    "sigs" { sigs = some(*v); }
+                    "crate_type" { crate_type = some(*v); }
                     _ { }
                 }
             }
             ast::meta_list(v, mis) {
-                if v == "link" {
+                if *v == "link" {
                     let (n, v, u) = load_link(mis);
                     name = n;
                     vers = v;
@@ -290,7 +290,7 @@ fn load_crate(filename: str) -> option<crate> {
             ast::view_item_use(ident, metas, id) {
                 let name_items = attr::find_meta_items_by_name(metas, "name");
                 let m = if name_items.is_empty() {
-                    metas + [attr::mk_name_value_item_str("name", ident)]
+                    metas + [attr::mk_name_value_item_str(@"name", *ident)]
                 } else {
                     metas
                 };
@@ -303,9 +303,9 @@ fn load_crate(filename: str) -> option<crate> {
                         some(value) {
                             let name = attr::get_meta_item_name(item);
 
-                            alt name {
-                                "vers" { attr_vers = value; }
-                                "from" { attr_from = value; }
+                            alt *name {
+                                "vers" { attr_vers = *value; }
+                                "from" { attr_from = *value; }
                                 _ {}
                             }
                         }
@@ -317,11 +317,11 @@ fn load_crate(filename: str) -> option<crate> {
                     attr_from
                 } else {
                     if !str::is_empty(attr_vers) {
-                        attr_name + "@" + attr_vers
-                    } else { attr_name }
+                        *attr_name + "@" + attr_vers
+                    } else { *attr_name }
                 };
 
-                alt attr_name {
+                alt *attr_name {
                     "std" | "core" { }
                     _ { e.deps += [query]; }
                 }

--- a/src/fuzzer/fuzzer.rs
+++ b/src/fuzzer/fuzzer.rs
@@ -45,7 +45,7 @@ fn common_exprs() -> [ast::expr] {
      dse(ast::expr_cont),
      dse(ast::expr_fail(option::none)),
      dse(ast::expr_fail(option::some(
-         @dse(ast::expr_lit(@dsl(ast::lit_str("boo"))))))),
+         @dse(ast::expr_lit(@dsl(ast::lit_str(@"boo"))))))),
      dse(ast::expr_ret(option::none)),
      dse(ast::expr_lit(@dsl(ast::lit_nil))),
      dse(ast::expr_lit(@dsl(ast::lit_bool(false)))),

--- a/src/libstd/map.rs
+++ b/src/libstd/map.rs
@@ -2,6 +2,7 @@
 
 import chained::hashmap;
 export hashmap, hashfn, eqfn, set, map, chained, hashmap, str_hash;
+export box_str_hash;
 export bytes_hash, int_hash, uint_hash, set_add;
 export hash_from_vec, hash_from_strs, hash_from_bytes;
 export hash_from_ints, hash_from_uints;
@@ -290,6 +291,11 @@ fn hashmap<K: const, V: copy>(hasher: hashfn<K>, eqer: eqfn<K>)
 #[doc = "Construct a hashmap for string keys"]
 fn str_hash<V: copy>() -> hashmap<str, V> {
     ret hashmap(str::hash, str::eq);
+}
+
+#[doc = "Construct a hashmap for boxed string keys"]
+fn box_str_hash<V: copy>() -> hashmap<@str, V> {
+    ret hashmap({|x: @str|str::hash(*x)}, {|x,y|str::eq(*x,*y)});
 }
 
 #[doc = "Construct a hashmap for byte string keys"]

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -30,7 +30,7 @@ fn deserialize_span<D>(_d: D) -> span {
 type spanned<T> = {node: T, span: span};
 
 #[auto_serialize]
-type ident = str;
+type ident = @str;
 
 // Functions may or may not have names.
 #[auto_serialize]
@@ -399,11 +399,11 @@ type lit = spanned<lit_>;
 
 #[auto_serialize]
 enum lit_ {
-    lit_str(str),
+    lit_str(@str),
     lit_int(i64, int_ty),
     lit_uint(u64, uint_ty),
     lit_int_unsuffixed(i64, int_ty),
-    lit_float(str, float_ty),
+    lit_float(@str, float_ty),
     lit_nil,
     lit_bool(bool),
 }

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -23,7 +23,10 @@ pure fn dummy_sp() -> span { ret mk_sp(0u, 0u); }
 
 pure fn path_name(p: @path) -> str { path_name_i(p.idents) }
 
-pure fn path_name_i(idents: [ident]) -> str { str::connect(idents, "::") }
+pure fn path_name_i(idents: [ident]) -> str {
+    // FIXME: Bad copies
+    str::connect(idents.map({|i|*i}), "::")
+}
 
 pure fn path_to_ident(p: @path) -> ident { vec::last(p.idents) }
 
@@ -380,7 +383,7 @@ fn dtor_dec() -> fn_decl {
     let nil_t = @{id: 0, node: ty_nil, span: dummy_sp()};
     // dtor has one argument, of type ()
     {inputs: [{mode: ast::expl(ast::by_ref),
-               ty: nil_t, ident: "_", id: 0}],
+               ty: nil_t, ident: @"_", id: 0}],
      output: nil_t, purity: impure_fn, cf: return_val, constraints: []}
 }
 

--- a/src/libsyntax/ext/auto_serialize.rs
+++ b/src/libsyntax/ext/auto_serialize.rs
@@ -92,7 +92,7 @@ fn expand(cx: ext_ctxt,
           _mitem: ast::meta_item,
           in_items: [@ast::item]) -> [@ast::item] {
     fn not_auto_serialize(a: ast::attribute) -> bool {
-        attr::get_attr_name(a) != "auto_serialize"
+        attr::get_attr_name(a) != @"auto_serialize"
     }
 
     fn filter_attrs(item: @ast::item) -> @ast::item {
@@ -126,18 +126,19 @@ impl helpers for ext_ctxt {
                    helper_name: str) -> @ast::path {
         let head = vec::init(base_path.idents);
         let tail = vec::last(base_path.idents);
-        self.path(base_path.span, head + [helper_name + "_" + tail])
+        self.path(base_path.span, head + [@(helper_name + "_" + *tail)])
     }
 
-    fn path(span: span, strs: [str]) -> @ast::path {
+    fn path(span: span, strs: [ast::ident]) -> @ast::path {
         @{span: span, global: false, idents: strs, rp: none, types: []}
     }
 
-    fn path_tps(span: span, strs: [str], tps: [@ast::ty]) -> @ast::path {
+    fn path_tps(span: span, strs: [ast::ident],
+                tps: [@ast::ty]) -> @ast::path {
         @{span: span, global: false, idents: strs, rp: none, types: tps}
     }
 
-    fn ty_path(span: span, strs: [str], tps: [@ast::ty]) -> @ast::ty {
+    fn ty_path(span: span, strs: [ast::ident], tps: [@ast::ty]) -> @ast::ty {
         @{id: self.next_id(),
           node: ast::ty_path(self.path_tps(span, strs, tps), self.next_id()),
           span: span}
@@ -149,7 +150,7 @@ impl helpers for ext_ctxt {
         let args = vec::map(input_tys) {|ty|
             {mode: ast::expl(ast::by_ref),
              ty: ty,
-             ident: "",
+             ident: @"",
              id: self.next_id()}
         };
 
@@ -170,7 +171,7 @@ impl helpers for ext_ctxt {
         @{id: self.next_id(), node: node, span: span}
     }
 
-    fn var_ref(span: span, name: str) -> @ast::expr {
+    fn var_ref(span: span, name: ast::ident) -> @ast::expr {
         self.expr(span, ast::expr_path(self.path(span, [name])))
     }
 
@@ -192,7 +193,7 @@ impl helpers for ext_ctxt {
          span: expr.span}
     }
 
-    fn binder_pat(span: span, nm: str) -> @ast::pat {
+    fn binder_pat(span: span, nm: ast::ident) -> @ast::pat {
         let path = @{span: span, global: false, idents: [nm],
                      rp: none, types: []};
         @{id: self.next_id(),
@@ -212,7 +213,7 @@ impl helpers for ext_ctxt {
                 ast::expr_alt(v, arms, ast::alt_exhaustive)))
     }
 
-    fn lit_str(span: span, s: str) -> @ast::expr {
+    fn lit_str(span: span, s: @str) -> @ast::expr {
         self.expr(
             span,
             ast::expr_lit(
@@ -310,7 +311,7 @@ fn ser_variant(cx: ext_ctxt,
                bodyfn: fn(-@ast::expr, ast::blk) -> @ast::expr,
                argfn: fn(-@ast::expr, uint, ast::blk) -> @ast::expr)
     -> ast::arm {
-    let vnames = vec::from_fn(vec::len(tys)) {|i| #fmt["__v%u", i]};
+    let vnames = vec::from_fn(vec::len(tys)) {|i| @#fmt["__v%u", i]};
     let pats = vec::from_fn(vec::len(tys)) {|i|
         cx.binder_pat(tys[i].span, vnames[i])
     };
@@ -428,7 +429,7 @@ fn ser_ty(cx: ext_ctxt, tps: ser_tps_map,
             vec::is_empty(path.types) {
             let ident = path.idents[0];
 
-            alt tps.find(ident) {
+            alt tps.find(*ident) {
               some(f) { f(v) }
               none { ser_path(cx, tps, path, s, v) }
             }
@@ -474,7 +475,7 @@ fn ser_ty(cx: ext_ctxt, tps: ser_tps_map,
     }
 }
 
-fn mk_ser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
+fn mk_ser_fn(cx: ext_ctxt, span: span, name: ast::ident, tps: [ast::ty_param],
              f: fn(ext_ctxt, ser_tps_map,
                    -@ast::expr, -@ast::expr) -> [@ast::stmt])
     -> @ast::item {
@@ -489,7 +490,7 @@ fn mk_ser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
              ty: cx.ty_fn(span,
                           [cx.ty_path(span, [tp.ident], [])],
                           cx.ty_nil(span)),
-             ident: "__s" + tp.ident,
+             ident: @("__s" + *tp.ident),
              id: cx.next_id()}});
 
     #debug["tp_inputs = %?", tp_inputs];
@@ -497,12 +498,12 @@ fn mk_ser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
 
     let ser_inputs: [ast::arg] =
         [{mode: ast::expl(ast::by_ref),
-          ty: cx.ty_path(span, ["__S"], []),
-          ident: "__s",
+          ty: cx.ty_path(span, [@"__S"], []),
+          ident: @"__s",
           id: cx.next_id()},
          {mode: ast::expl(ast::by_ref),
           ty: v_ty,
-          ident: "__v",
+          ident: @"__v",
           id: cx.next_id()}]
         + tp_inputs;
 
@@ -510,21 +511,21 @@ fn mk_ser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
     vec::iter2(tps, tp_inputs) {|tp, arg|
         let arg_ident = arg.ident;
         tps_map.insert(
-            tp.ident,
+            *tp.ident,
             fn@(v: @ast::expr) -> [@ast::stmt] {
                 let f = cx.var_ref(span, arg_ident);
-                #debug["serializing type arg %s", arg_ident];
+                #debug["serializing type arg %s", *arg_ident];
                 [#ast(stmt){$(f)($(v));}]
             });
     }
 
     let ser_bnds = @[
         ast::bound_iface(cx.ty_path(span,
-                                    ["std", "serialization", "serializer"],
+                                    [@"std", @"serialization", @"serializer"],
                                     []))];
 
     let ser_tps: [ast::ty_param] =
-        [{ident: "__S",
+        [{ident: @"__S",
           id: cx.next_id(),
           bounds: ser_bnds}] +
         vec::map(tps) {|tp| cx.clone_ty_param(tp) };
@@ -536,7 +537,7 @@ fn mk_ser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
     let ser_blk = cx.blk(span,
                          f(cx, tps_map, #ast{ __s }, #ast{ __v }));
 
-    @{ident: "serialize_" + name,
+    @{ident: @("serialize_" + *name),
       attrs: [],
       id: cx.next_id(),
       node: ast::item_fn({inputs: ser_inputs,
@@ -651,7 +652,7 @@ fn deser_ty(cx: ext_ctxt, tps: deser_tps_map,
             vec::is_empty(path.types) {
             let ident = path.idents[0];
 
-            alt tps.find(ident) {
+            alt tps.find(*ident) {
               some(f) { f() }
               none { deser_path(cx, tps, path, d) }
             }
@@ -683,7 +684,8 @@ fn deser_ty(cx: ext_ctxt, tps: deser_tps_map,
     }
 }
 
-fn mk_deser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
+fn mk_deser_fn(cx: ext_ctxt, span: span,
+               name: ast::ident, tps: [ast::ty_param],
                f: fn(ext_ctxt, deser_tps_map, -@ast::expr) -> @ast::expr)
     -> @ast::item {
     let ext_cx = cx; // required for #ast
@@ -697,15 +699,15 @@ fn mk_deser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
              ty: cx.ty_fn(span,
                           [],
                           cx.ty_path(span, [tp.ident], [])),
-             ident: "__d" + tp.ident,
+             ident: @("__d" + *tp.ident),
              id: cx.next_id()}});
 
     #debug["tp_inputs = %?", tp_inputs];
 
     let deser_inputs: [ast::arg] =
         [{mode: ast::expl(ast::by_ref),
-          ty: cx.ty_path(span, ["__D"], []),
-          ident: "__d",
+          ty: cx.ty_path(span, [@"__D"], []),
+          ident: @"__d",
           id: cx.next_id()}]
         + tp_inputs;
 
@@ -713,7 +715,7 @@ fn mk_deser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
     vec::iter2(tps, tp_inputs) {|tp, arg|
         let arg_ident = arg.ident;
         tps_map.insert(
-            tp.ident,
+            *tp.ident,
             fn@() -> @ast::expr {
                 let f = cx.var_ref(span, arg_ident);
                 #ast{ $(f)() }
@@ -721,12 +723,13 @@ fn mk_deser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
     }
 
     let deser_bnds = @[
-        ast::bound_iface(cx.ty_path(span,
-                                    ["std", "serialization", "deserializer"],
-                                    []))];
+        ast::bound_iface(cx.ty_path(
+            span,
+            [@"std", @"serialization", @"deserializer"],
+            []))];
 
     let deser_tps: [ast::ty_param] =
-        [{ident: "__D",
+        [{ident: @"__D",
           id: cx.next_id(),
           bounds: deser_bnds}] + vec::map(tps) {|tp|
         let cloned = cx.clone_ty_param(tp);
@@ -735,7 +738,7 @@ fn mk_deser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
 
     let deser_blk = cx.expr_blk(f(cx, tps_map, #ast(expr){__d}));
 
-    @{ident: "deserialize_" + name,
+    @{ident: @("deserialize_" + *name),
       attrs: [],
       id: cx.next_id(),
       node: ast::item_fn({inputs: deser_inputs,
@@ -749,7 +752,7 @@ fn mk_deser_fn(cx: ext_ctxt, span: span, name: str, tps: [ast::ty_param],
       span: span}
 }
 
-fn ty_fns(cx: ext_ctxt, name: str, ty: @ast::ty, tps: [ast::ty_param])
+fn ty_fns(cx: ext_ctxt, name: ast::ident, ty: @ast::ty, tps: [ast::ty_param])
     -> [@ast::item] {
 
     let span = ty.span;
@@ -759,7 +762,7 @@ fn ty_fns(cx: ext_ctxt, name: str, ty: @ast::ty, tps: [ast::ty_param])
     ]
 }
 
-fn ser_enum(cx: ext_ctxt, tps: ser_tps_map, e_name: str,
+fn ser_enum(cx: ext_ctxt, tps: ser_tps_map, e_name: ast::ident,
             e_span: span, variants: [ast::variant],
             -s: @ast::expr, -v: @ast::expr) -> [@ast::stmt] {
     let ext_cx = cx;
@@ -808,7 +811,7 @@ fn ser_enum(cx: ext_ctxt, tps: ser_tps_map, e_name: str,
     [#ast(stmt){ $(s).emit_enum($(e_name), $(lam)) }]
 }
 
-fn deser_enum(cx: ext_ctxt, tps: deser_tps_map, e_name: str,
+fn deser_enum(cx: ext_ctxt, tps: deser_tps_map, e_name: ast::ident,
               e_span: span, variants: [ast::variant],
               -d: @ast::expr) -> @ast::expr {
     let ext_cx = cx;
@@ -852,7 +855,7 @@ fn deser_enum(cx: ext_ctxt, tps: deser_tps_map, e_name: str,
     #ast{ $(d).read_enum($(e_name), $(read_lambda)) }
 }
 
-fn enum_fns(cx: ext_ctxt, e_name: str, e_span: span,
+fn enum_fns(cx: ext_ctxt, e_name: ast::ident, e_span: span,
                variants: [ast::variant], tps: [ast::ty_param])
     -> [@ast::item] {
     [

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -9,7 +9,7 @@ type syntax_expander_ =
 type syntax_expander = {
     expander: syntax_expander_,
     span: option<span>};
-type macro_def = {ident: str, ext: syntax_extension};
+type macro_def = {ident: ast::ident, ext: syntax_extension};
 type macro_definer =
     fn@(ext_ctxt, span, ast::mac_arg, ast::mac_body) -> macro_def;
 type item_decorator =
@@ -150,7 +150,7 @@ fn expr_to_str(cx: ext_ctxt, expr: @ast::expr, error: str) -> str {
     alt expr.node {
       ast::expr_lit(l) {
         alt l.node {
-          ast::lit_str(s) { ret s; }
+          ast::lit_str(s) { ret *s; }
           _ { cx.span_fatal(l.span, error); }
         }
       }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -6,7 +6,7 @@ fn mk_lit(cx: ext_ctxt, sp: span, lit: ast::lit_) -> @ast::expr {
     ret @{id: cx.next_id(), node: ast::expr_lit(sp_lit), span: sp};
 }
 fn mk_str(cx: ext_ctxt, sp: span, s: str) -> @ast::expr {
-    let lit = ast::lit_str(s);
+    let lit = ast::lit_str(@s);
     ret mk_lit(cx, sp, lit);
 }
 fn mk_int(cx: ext_ctxt, sp: span, i: int) -> @ast::expr {

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -3,13 +3,13 @@ import base::*;
 fn expand_syntax_ext(cx: ext_ctxt, sp: codemap::span, arg: ast::mac_arg,
                      _body: ast::mac_body) -> @ast::expr {
     let args = get_mac_args_no_max(cx,sp,arg,1u,"concat_idents");
-    let mut res: ast::ident = "";
+    let mut res = "";
     for args.each {|e|
-        res += expr_to_ident(cx, e, "expected an ident");
+        res += *expr_to_ident(cx, e, "expected an ident");
     }
 
     ret @{id: cx.next_id(),
-          node: ast::expr_path(@{span: sp, global: false, idents: [res],
+          node: ast::expr_path(@{span: sp, global: false, idents: [@res],
                                  rp: none, types: []}),
           span: sp};
 }

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -21,8 +21,8 @@ fn expand_syntax_ext(cx: ext_ctxt, sp: codemap::span, arg: ast::mac_arg,
     }
 }
 
-fn make_new_str(cx: ext_ctxt, sp: codemap::span, s: str) -> @ast::expr {
-    ret make_new_lit(cx, sp, ast::lit_str(s));
+fn make_new_str(cx: ext_ctxt, sp: codemap::span, +s: str) -> @ast::expr {
+    ret make_new_lit(cx, sp, ast::lit_str(@s));
 }
 //
 // Local Variables:

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -21,21 +21,21 @@ fn expand_expr(exts: hashmap<str, syntax_extension>, cx: ext_ctxt,
               mac_invoc(pth, args, body) {
                 assert (vec::len(pth.idents) > 0u);
                 let extname = pth.idents[0];
-                alt exts.find(extname) {
+                alt exts.find(*extname) {
                   none {
                     cx.span_fatal(pth.span,
-                                  #fmt["macro undefined: '%s'", extname])
+                                  #fmt["macro undefined: '%s'", *extname])
                   }
                   some(item_decorator(_)) {
                     cx.span_fatal(
                         pth.span,
-                        #fmt["%s can only be used as a decorator", extname]);
+                        #fmt["%s can only be used as a decorator", *extname]);
                   }
                   some(normal({expander: exp, span: exp_sp})) {
                     let expanded = exp(cx, pth.span, args, body);
 
                     cx.bt_push(expanded_from({call_site: s,
-                                callie: {name: extname, span: exp_sp}}));
+                                callie: {name: *extname, span: exp_sp}}));
                     //keep going, outside-in
                     let fully_expanded = fld.fold_expr(expanded).node;
                     cx.bt_pop();
@@ -44,7 +44,7 @@ fn expand_expr(exts: hashmap<str, syntax_extension>, cx: ext_ctxt,
                   }
                   some(macro_defining(ext)) {
                     let named_extension = ext(cx, pth.span, args, body);
-                    exts.insert(named_extension.ident, named_extension.ext);
+                    exts.insert(*named_extension.ident, named_extension.ext);
                     (ast::expr_rec([], none), s)
                   }
                 }
@@ -74,7 +74,7 @@ fn expand_mod_items(exts: hashmap<str, syntax_extension>, cx: ext_ctxt,
               ast::meta_name_value(n, _) { n }
               ast::meta_list(n, _) { n }
             };
-            alt exts.find(mname) {
+            alt exts.find(*mname) {
               none | some(normal(_)) | some(macro_defining(_)) {
                 items
               }

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -36,9 +36,10 @@ fn expand_syntax_ext(cx: ext_ctxt, sp: span, arg: ast::mac_arg,
 fn pieces_to_expr(cx: ext_ctxt, sp: span, pieces: [piece], args: [@ast::expr])
    -> @ast::expr {
     fn make_path_vec(_cx: ext_ctxt, ident: ast::ident) -> [ast::ident] {
-        ret ["extfmt", "rt", ident];
+        ret [@"extfmt", @"rt", ident];
     }
-    fn make_rt_path_expr(cx: ext_ctxt, sp: span, ident: str) -> @ast::expr {
+    fn make_rt_path_expr(cx: ext_ctxt, sp: span,
+                         ident: ast::ident) -> @ast::expr {
         let path = make_path_vec(cx, ident);
         ret mk_path(cx, sp, path);
     }
@@ -57,18 +58,18 @@ fn pieces_to_expr(cx: ext_ctxt, sp: span, pieces: [piece], args: [@ast::expr])
                   flag_sign_always { fstr = "flag_sign_always"; }
                   flag_alternate { fstr = "flag_alternate"; }
                 }
-                flagexprs += [make_rt_path_expr(cx, sp, fstr)];
+                flagexprs += [make_rt_path_expr(cx, sp, @fstr)];
             }
             ret mk_vec_e(cx, sp, flagexprs);
         }
         fn make_count(cx: ext_ctxt, sp: span, cnt: count) -> @ast::expr {
             alt cnt {
               count_implied {
-                ret make_rt_path_expr(cx, sp, "count_implied");
+                ret make_rt_path_expr(cx, sp, @"count_implied");
               }
               count_is(c) {
                 let count_lit = mk_int(cx, sp, c);
-                let count_is_path = make_path_vec(cx, "count_is");
+                let count_is_path = make_path_vec(cx, @"count_is");
                 let count_is_args = [count_lit];
                 ret mk_call(cx, sp, count_is_path, count_is_args);
               }
@@ -88,16 +89,16 @@ fn pieces_to_expr(cx: ext_ctxt, sp: span, pieces: [piece], args: [@ast::expr])
               ty_octal { rt_type = "ty_octal"; }
               _ { rt_type = "ty_default"; }
             }
-            ret make_rt_path_expr(cx, sp, rt_type);
+            ret make_rt_path_expr(cx, sp, @rt_type);
         }
         fn make_conv_rec(cx: ext_ctxt, sp: span, flags_expr: @ast::expr,
                          width_expr: @ast::expr, precision_expr: @ast::expr,
                          ty_expr: @ast::expr) -> @ast::expr {
             ret mk_rec_e(cx, sp,
-                         [{ident: "flags", ex: flags_expr},
-                          {ident: "width", ex: width_expr},
-                          {ident: "precision", ex: precision_expr},
-                          {ident: "ty", ex: ty_expr}]);
+                         [{ident: @"flags", ex: flags_expr},
+                          {ident: @"width", ex: width_expr},
+                          {ident: @"precision", ex: precision_expr},
+                          {ident: @"ty", ex: ty_expr}]);
         }
         let rt_conv_flags = make_flags(cx, sp, cnv.flags);
         let rt_conv_width = make_count(cx, sp, cnv.width);
@@ -109,7 +110,7 @@ fn pieces_to_expr(cx: ext_ctxt, sp: span, pieces: [piece], args: [@ast::expr])
     fn make_conv_call(cx: ext_ctxt, sp: span, conv_type: str, cnv: conv,
                       arg: @ast::expr) -> @ast::expr {
         let fname = "conv_" + conv_type;
-        let path = make_path_vec(cx, fname);
+        let path = make_path_vec(cx, @fname);
         let cnv_expr = make_rt_conv_expr(cx, sp, cnv);
         let args = [cnv_expr, arg];
         ret mk_call(cx, arg.span, path, args);

--- a/src/libsyntax/ext/qquote.rs
+++ b/src/libsyntax/ext/qquote.rs
@@ -35,7 +35,7 @@ impl of qq_helper for @ast::crate {
     fn visit(cx: aq_ctxt, v: vt<aq_ctxt>) {visit_crate(*self, cx, v);}
     fn extract_mac() -> option<ast::mac_> {fail}
     fn mk_parse_fn(cx: ext_ctxt, sp: span) -> @ast::expr {
-        mk_path(cx, sp, ["syntax", "ext", "qquote", "parse_crate"])
+        mk_path(cx, sp, [@"syntax", @"ext", @"qquote", @"parse_crate"])
     }
     fn get_fold_fn() -> str {"fold_crate"}
 }
@@ -49,7 +49,7 @@ impl of qq_helper for @ast::expr {
         }
     }
     fn mk_parse_fn(cx: ext_ctxt, sp: span) -> @ast::expr {
-        mk_path(cx, sp, ["syntax", "ext", "qquote", "parse_expr"])
+        mk_path(cx, sp, [@"syntax", @"ext", @"qquote", @"parse_expr"])
     }
     fn get_fold_fn() -> str {"fold_expr"}
 }
@@ -63,7 +63,7 @@ impl of qq_helper for @ast::ty {
         }
     }
     fn mk_parse_fn(cx: ext_ctxt, sp: span) -> @ast::expr {
-        mk_path(cx, sp, ["syntax", "ext", "qquote", "parse_ty"])
+        mk_path(cx, sp, [@"syntax", @"ext", @"qquote", @"parse_ty"])
     }
     fn get_fold_fn() -> str {"fold_ty"}
 }
@@ -72,7 +72,7 @@ impl of qq_helper for @ast::item {
     fn visit(cx: aq_ctxt, v: vt<aq_ctxt>) {visit_item(self, cx, v);}
     fn extract_mac() -> option<ast::mac_> {fail}
     fn mk_parse_fn(cx: ext_ctxt, sp: span) -> @ast::expr {
-        mk_path(cx, sp, ["syntax", "ext", "qquote", "parse_item"])
+        mk_path(cx, sp, [@"syntax", @"ext", @"qquote", @"parse_item"])
     }
     fn get_fold_fn() -> str {"fold_item"}
 }
@@ -81,7 +81,7 @@ impl of qq_helper for @ast::stmt {
     fn visit(cx: aq_ctxt, v: vt<aq_ctxt>) {visit_stmt(self, cx, v);}
     fn extract_mac() -> option<ast::mac_> {fail}
     fn mk_parse_fn(cx: ext_ctxt, sp: span) -> @ast::expr {
-        mk_path(cx, sp, ["syntax", "ext", "qquote", "parse_stmt"])
+        mk_path(cx, sp, [@"syntax", @"ext", @"qquote", @"parse_stmt"])
     }
     fn get_fold_fn() -> str {"fold_stmt"}
 }
@@ -90,7 +90,7 @@ impl of qq_helper for @ast::pat {
     fn visit(cx: aq_ctxt, v: vt<aq_ctxt>) {visit_pat(self, cx, v);}
     fn extract_mac() -> option<ast::mac_> {fail}
     fn mk_parse_fn(cx: ext_ctxt, sp: span) -> @ast::expr {
-        mk_path(cx, sp, ["syntax", "ext", "qquote", "parse_pat"])
+        mk_path(cx, sp, [@"syntax", @"ext", @"qquote", @"parse_pat"])
     }
     fn get_fold_fn() -> str {"fold_pat"}
 }
@@ -146,7 +146,7 @@ fn expand_ast(ecx: ext_ctxt, _sp: span,
         }
         alt (args[0].node) {
           ast::expr_path(@{idents: id, _}) if vec::len(id) == 1u
-              {what = id[0]}
+              {what = *id[0]}
           _ {ecx.span_fatal(args[0].span, "expected an identifier");}
         }
     }
@@ -230,20 +230,21 @@ fn finish<T: qq_helper>
     let cx = ecx;
 
     let cfg_call = {||
-        mk_call_(cx, sp, mk_access(cx, sp, ["ext_cx"], "cfg"), [])
+        mk_call_(cx, sp, mk_access(cx, sp, [@"ext_cx"], @"cfg"), [])
     };
 
     let parse_sess_call = {||
-        mk_call_(cx, sp, mk_access(cx, sp, ["ext_cx"], "parse_sess"), [])
+        mk_call_(cx, sp, mk_access(cx, sp, [@"ext_cx"], @"parse_sess"), [])
     };
 
     let pcall = mk_call(cx,sp,
-                       ["syntax", "parse", "parser",
-                        "parse_from_source_str"],
+                       [@"syntax", @"parse", @"parser",
+                        @"parse_from_source_str"],
                        [node.mk_parse_fn(cx,sp),
                         mk_str(cx,sp, fname),
                         mk_call(cx,sp,
-                                ["syntax","ext","qquote", "mk_file_substr"],
+                                [@"syntax",@"ext",
+                                 @"qquote", @"mk_file_substr"],
                                 [mk_str(cx,sp, loc.file.name),
                                  mk_uint(cx,sp, loc.line),
                                  mk_uint(cx,sp, loc.col)]),
@@ -255,15 +256,16 @@ fn finish<T: qq_helper>
     let mut rcall = pcall;
     if (g_len > 0u) {
         rcall = mk_call(cx,sp,
-                        ["syntax", "ext", "qquote", "replace"],
+                        [@"syntax", @"ext", @"qquote", @"replace"],
                         [pcall,
                          mk_vec_e(cx,sp, qcx.gather.map_to_vec {|g|
                              mk_call(cx,sp,
-                                     ["syntax", "ext", "qquote", g.constr],
+                                     [@"syntax", @"ext",
+                                      @"qquote", @g.constr],
                                      [g.e])}),
                          mk_path(cx,sp,
-                                 ["syntax", "ext", "qquote",
-                                  node.get_fold_fn()])]);
+                                 [@"syntax", @"ext", @"qquote",
+                                  @node.get_fold_fn()])]);
     }
     ret rcall;
 }

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -36,19 +36,20 @@ fn expand_file(cx: ext_ctxt, sp: span, arg: ast::mac_arg,
     get_mac_args(cx, sp, arg, 0u, option::some(0u), "file");
     let { file: @{ name: filename, _ }, _ } =
         codemap::lookup_char_pos(cx.codemap(), sp.lo);
-    ret make_new_lit(cx, sp, ast::lit_str(filename));
+    ret make_new_lit(cx, sp, ast::lit_str(@filename));
 }
 
 fn expand_stringify(cx: ext_ctxt, sp: span, arg: ast::mac_arg,
                     _body: ast::mac_body) -> @ast::expr {
     let args = get_mac_args(cx, sp, arg, 1u, option::some(1u), "stringify");
-    ret make_new_lit(cx, sp, ast::lit_str(pprust::expr_to_str(args[0])));
+    ret make_new_lit(cx, sp, ast::lit_str(@pprust::expr_to_str(args[0])));
 }
 
 fn expand_mod(cx: ext_ctxt, sp: span, arg: ast::mac_arg, _body: ast::mac_body)
     -> @ast::expr {
     get_mac_args(cx, sp, arg, 0u, option::some(0u), "file");
-    ret make_new_lit(cx, sp, ast::lit_str(str::connect(cx.mod_path(), "::")));
+    ret make_new_lit(cx, sp, ast::lit_str(
+        @str::connect(cx.mod_path().map({|x|*x}), "::")));
 }
 
 fn expand_include(cx: ext_ctxt, sp: span, arg: ast::mac_arg,
@@ -75,7 +76,7 @@ fn expand_include_str(cx: ext_ctxt, sp: codemap::span, arg: ast::mac_arg,
       }
     }
 
-    ret make_new_lit(cx, sp, ast::lit_str(result::unwrap(res)));
+    ret make_new_lit(cx, sp, ast::lit_str(@result::unwrap(res)));
 }
 
 fn expand_include_bin(cx: ext_ctxt, sp: codemap::span, arg: ast::mac_arg,

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -81,7 +81,7 @@ impl parser_common for parser {
     fn token_is_keyword(word: str, ++tok: token::token) -> bool {
         self.require_keyword(word);
         alt tok {
-          token::IDENT(sid, false) { str::eq(word, self.get_str(sid)) }
+          token::IDENT(sid, false) { str::eq(word, *self.get_str(sid)) }
           _ { false }
         }
     }
@@ -97,7 +97,7 @@ impl parser_common for parser {
         // workaround LLVM bug #13042
         alt @self.token {
           @token::IDENT(sid, false) {
-            if str::eq(word, self.get_str(sid)) {
+            if str::eq(word, *self.get_str(sid)) {
                 self.bump();
                 ret true;
             } else { ret false; }
@@ -128,7 +128,7 @@ impl parser_common for parser {
         }
     }
 
-    fn check_restricted_keywords_(w: ast::ident) {
+    fn check_restricted_keywords_(w: str) {
         if self.is_restricted_keyword(w) {
             self.fatal("found `" + w + "` in restricted position");
         }

--- a/src/libsyntax/parse/eval.rs
+++ b/src/libsyntax/parse/eval.rs
@@ -75,7 +75,7 @@ fn parse_companion_mod(cx: ctx, prefix: str, suffix: option<str>)
     }
 }
 
-fn cdir_path_opt(id: str, attrs: [ast::attribute]) -> str {
+fn cdir_path_opt(id: ast::ident, attrs: [ast::attribute]) -> @str {
     alt ::attr::first_attr_value_str_by_name(attrs, "path") {
       some(d) {
         ret d;
@@ -89,11 +89,11 @@ fn eval_crate_directive(cx: ctx, cdir: @ast::crate_directive, prefix: str,
                         &items: [@ast::item]) {
     alt cdir.node {
       ast::cdir_src_mod(id, attrs) {
-        let file_path = cdir_path_opt(id + ".rs", attrs);
+        let file_path = cdir_path_opt(@(*id + ".rs"), attrs);
         let full_path =
-            if path::path_is_absolute(file_path) {
-                file_path
-            } else { prefix + path::path_sep() + file_path };
+            if path::path_is_absolute(*file_path) {
+                *file_path
+            } else { prefix + path::path_sep() + *file_path };
         let p0 =
             new_parser_from_file(cx.sess, cx.cfg, full_path, SOURCE_FILE);
         let inner_attrs = p0.parse_inner_attrs_and_next();
@@ -112,9 +112,9 @@ fn eval_crate_directive(cx: ctx, cdir: @ast::crate_directive, prefix: str,
       ast::cdir_dir_mod(id, cdirs, attrs) {
         let path = cdir_path_opt(id, attrs);
         let full_path =
-            if path::path_is_absolute(path) {
-                path
-            } else { prefix + path::path_sep() + path };
+            if path::path_is_absolute(*path) {
+                *path
+            } else { prefix + path::path_sep() + *path };
         let (m0, a0) = eval_crate_directives_to_mod(
             cx, cdirs, full_path, none);
         let i =

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -151,8 +151,8 @@ class parser {
     fn warn(m: str) {
         self.sess.span_diagnostic.span_warn(copy self.span, m)
     }
-    fn get_str(i: token::str_num) -> str {
-        *interner::get(*self.reader.interner, i)
+    fn get_str(i: token::str_num) -> @str {
+        interner::get(*self.reader.interner, i)
     }
     fn get_id() -> node_id { next_node_id(self.sess) }
 
@@ -178,7 +178,7 @@ class parser {
                 let name = self.parse_value_ident();
                 p.bump();
                 name
-            } else { "" };
+            } else { @"" };
 
             {mode: mode, ty: p.parse_ty(false), ident: name,
              id: p.get_id()}
@@ -229,7 +229,7 @@ class parser {
     fn ident_index(args: [arg], i: ident) -> uint {
         let mut j = 0u;
         for args.each {|a| if a.ident == i { ret j; } j += 1u; }
-        self.fatal("unbound variable `" + i + "` in constraint arg");
+        self.fatal("unbound variable `" + *i + "` in constraint arg");
     }
 
     fn parse_type_constr_arg() -> @ty_constr_arg {
@@ -315,7 +315,7 @@ class parser {
         }
     }
 
-    fn region_from_name(s: option<str>) -> @region {
+    fn region_from_name(s: option<@str>) -> @region {
         let r = alt s {
           some (string) { re_named(string) }
           none { re_anon }
@@ -1858,13 +1858,13 @@ class parser {
 
     fn parse_method_name() -> ident {
         alt copy self.token {
-          token::BINOP(op) { self.bump(); token::binop_to_str(op) }
-          token::NOT { self.bump(); "!" }
-          token::LBRACKET { self.bump(); self.expect(token::RBRACKET); "[]" }
+          token::BINOP(op) { self.bump(); @token::binop_to_str(op) }
+          token::NOT { self.bump(); @"!" }
+          token::LBRACKET { self.bump(); self.expect(token::RBRACKET); @"[]" }
           _ {
             let id = self.parse_value_ident();
-            if id == "unary" && self.eat(token::BINOP(token::MINUS)) {
-                "unary-"
+            if id == @"unary" && self.eat(token::BINOP(token::MINUS)) {
+                @"unary-"
             }
             else { id }
           }
@@ -1969,7 +1969,7 @@ class parser {
         // Hack.  But then, this whole function is in service of a hack.
         let a_r = alt rp {
           rp_none { none }
-          rp_self { some(self.region_from_name(some("self"))) }
+          rp_self { some(self.region_from_name(some(@"self"))) }
         };
 
         @{span: s, global: false, idents: [i],
@@ -2243,7 +2243,7 @@ class parser {
         let mut variants: [variant] = [];
         // Newtype syntax
         if self.token == token::EQ {
-            self.check_restricted_keywords_(id);
+            self.check_restricted_keywords_(*id);
             self.bump();
             let ty = self.parse_ty(false);
             self.expect(token::SEMI);
@@ -2381,7 +2381,7 @@ class parser {
         let lo = self.span.lo;
         let first_ident = self.parse_ident();
         let mut path = [first_ident];
-        #debug("parsed view_path: %s", first_ident);
+        #debug("parsed view_path: %s", *first_ident);
         alt self.token {
           token::EQ {
             // x = foo::bar
@@ -2504,7 +2504,7 @@ class parser {
                       config: self.cfg});
     }
 
-    fn parse_str() -> str {
+    fn parse_str() -> @str {
         alt copy self.token {
           token::LIT_STR(s) { self.bump(); self.get_str(s) }
           _ {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -342,7 +342,7 @@ fn print_region(s: ps, region: @ast::region) {
       ast::re_anon { word_space(s, "&"); }
       ast::re_named(name) {
         word(s.s, "&");
-        word_space(s, name);
+        word_space(s, *name);
       }
     }
 }
@@ -382,7 +382,7 @@ fn print_type_ex(s: ps, &&ty: @ast::ty, print_colons: bool) {
         fn print_field(s: ps, f: ast::ty_field) {
             cbox(s, indent_unit);
             print_mutability(s, f.node.mt.mutbl);
-            word(s.s, f.node.ident);
+            word(s.s, *f.node.ident);
             word_space(s, ":");
             print_type(s, f.node.mt.ty);
             end(s);
@@ -443,7 +443,7 @@ fn print_item(s: ps, &&item: @ast::item) {
     alt item.node {
       ast::item_const(ty, expr) {
         head(s, "const");
-        word_space(s, item.ident + ":");
+        word_space(s, *item.ident + ":");
         print_type(s, ty);
         space(s.s);
         end(s); // end the head-ibox
@@ -461,7 +461,7 @@ fn print_item(s: ps, &&item: @ast::item) {
       }
       ast::item_mod(_mod) {
         head(s, "mod");
-        word_nbsp(s, item.ident);
+        word_nbsp(s, *item.ident);
         bopen(s);
         print_mod(s, _mod, item.attrs);
         bclose(s, item.span);
@@ -469,7 +469,7 @@ fn print_item(s: ps, &&item: @ast::item) {
       ast::item_native_mod(nmod) {
         head(s, "native");
         word_nbsp(s, "mod");
-        word_nbsp(s, item.ident);
+        word_nbsp(s, *item.ident);
         bopen(s);
         print_native_mod(s, nmod, item.attrs);
         bclose(s, item.span);
@@ -478,7 +478,7 @@ fn print_item(s: ps, &&item: @ast::item) {
         ibox(s, indent_unit);
         ibox(s, 0u);
         word_nbsp(s, "type");
-        word(s.s, item.ident);
+        word(s.s, *item.ident);
         print_region_param(s, rp);
         print_type_params(s, params);
         end(s); // end the inner ibox
@@ -492,13 +492,13 @@ fn print_item(s: ps, &&item: @ast::item) {
       ast::item_enum(variants, params, rp) {
         let newtype =
             vec::len(variants) == 1u &&
-                str::eq(item.ident, variants[0].node.name) &&
+                str::eq(*item.ident, *variants[0].node.name) &&
                 vec::len(variants[0].node.args) == 1u;
         if newtype {
             ibox(s, indent_unit);
             word_space(s, "enum");
         } else { head(s, "enum"); }
-        word(s.s, item.ident);
+        word(s.s, *item.ident);
         print_region_param(s, rp);
         print_type_params(s, params);
         space(s.s);
@@ -524,7 +524,7 @@ fn print_item(s: ps, &&item: @ast::item) {
       }
       ast::item_class(tps, ifaces, items, ctor, m_dtor, rp) {
           head(s, "class");
-          word_nbsp(s, item.ident);
+          word_nbsp(s, *item.ident);
           print_region_param(s, rp);
           print_type_params(s, tps);
           word_space(s, "implements");
@@ -570,7 +570,7 @@ fn print_item(s: ps, &&item: @ast::item) {
                       ast::class_mutable { word_nbsp(s, "mut"); }
                       _ {}
                     }
-                    word(s.s, nm);
+                    word(s.s, *nm);
                     word_nbsp(s, ":");
                     print_type(s, t);
                     word(s.s, ";");
@@ -588,7 +588,7 @@ fn print_item(s: ps, &&item: @ast::item) {
        }
       ast::item_impl(tps, rp, ifce, ty, methods) {
         head(s, "impl");
-        word(s.s, item.ident);
+        word(s.s, *item.ident);
         print_region_param(s, rp);
         print_type_params(s, tps);
         space(s.s);
@@ -608,7 +608,7 @@ fn print_item(s: ps, &&item: @ast::item) {
       }
       ast::item_iface(tps, rp, methods) {
         head(s, "iface");
-        word(s.s, item.ident);
+        word(s.s, *item.ident);
         print_region_param(s, rp);
         print_type_params(s, tps);
         word(s.s, " ");
@@ -627,18 +627,18 @@ fn print_item(s: ps, &&item: @ast::item) {
 fn print_res(s: ps, decl: ast::fn_decl, name: ast::ident,
              typarams: [ast::ty_param], rp: ast::region_param) {
     head(s, "resource");
-    word(s.s, name);
+    word(s.s, *name);
     print_region_param(s, rp);
     print_type_params(s, typarams);
     popen(s);
-    word_space(s, decl.inputs[0].ident + ":");
+    word_space(s, *decl.inputs[0].ident + ":");
     print_type(s, decl.inputs[0].ty);
     pclose(s);
     space(s.s);
 }
 
 fn print_variant(s: ps, v: ast::variant) {
-    word(s.s, v.node.name);
+    word(s.s, *v.node.name);
     if vec::len(v.node.args) > 0u {
         popen(s);
         fn print_variant_arg(s: ps, arg: ast::variant_arg) {
@@ -892,7 +892,7 @@ fn print_expr(s: ps, &&expr: @ast::expr) {
         fn print_field(s: ps, field: ast::field) {
             ibox(s, indent_unit);
             if field.node.mutbl == ast::m_mutbl { word_nbsp(s, "mut"); }
-            word(s.s, field.node.ident);
+            word(s.s, *field.node.ident);
             word_space(s, ":");
             print_expr(s, field.node.expr);
             end(s);
@@ -1089,7 +1089,7 @@ fn print_expr(s: ps, &&expr: @ast::expr) {
             print_expr_parens_if_not_bot(s, expr);
         }
         word(s.s, ".");
-        word(s.s, id);
+        word(s.s, *id);
         if vec::len(tys) > 0u {
             word(s.s, "::<");
             commasep(s, inconsistent, tys, print_type);
@@ -1222,7 +1222,7 @@ fn print_decl(s: ps, decl: @ast::decl) {
     }
 }
 
-fn print_ident(s: ps, ident: ast::ident) { word(s.s, ident); }
+fn print_ident(s: ps, ident: ast::ident) { word(s.s, *ident); }
 
 fn print_for_decl(s: ps, loc: @ast::local, coll: @ast::expr) {
     print_local_decl(s, loc);
@@ -1237,7 +1237,7 @@ fn print_path(s: ps, &&path: @ast::path, colons_before_params: bool) {
     let mut first = true;
     for path.idents.each {|id|
         if first { first = false; } else { word(s.s, "::"); }
-        word(s.s, id);
+        word(s.s, *id);
     }
     if path.rp.is_some() || !path.types.is_empty() {
         if colons_before_params { word(s.s, "::"); }
@@ -1290,7 +1290,7 @@ fn print_pat(s: ps, &&pat: @ast::pat) {
         word(s.s, "{");
         fn print_field(s: ps, f: ast::field_pat) {
             cbox(s, indent_unit);
-            word(s.s, f.ident);
+            word(s.s, *f.ident);
             word_space(s, ":");
             print_pat(s, f.pat);
             end(s);
@@ -1327,7 +1327,7 @@ fn print_fn(s: ps, decl: ast::fn_decl, name: ast::ident,
       ast::impure_fn { head(s, "fn") }
       _ { head(s, purity_to_str(decl.purity) + " fn") }
     }
-    word(s.s, name);
+    word(s.s, *name);
     print_type_params(s, typarams);
     print_fn_args_and_ret(s, decl, []);
 }
@@ -1341,7 +1341,7 @@ fn print_fn_args(s: ps, decl: ast::fn_decl,
             if first { first = false; } else { word_space(s, ","); }
             if cap_item.is_move { word_nbsp(s, "move") }
             else { word_nbsp(s, "copy") }
-            word(s.s, cap_item.name);
+            word(s.s, *cap_item.name);
         }
     }
 }
@@ -1418,7 +1418,7 @@ fn print_type_params(s: ps, &&params: [ast::ty_param]) {
     if vec::len(params) > 0u {
         word(s.s, "<");
         fn printParam(s: ps, param: ast::ty_param) {
-            word(s.s, param.ident);
+            word(s.s, *param.ident);
             print_bounds(s, param.bounds);
         }
         commasep(s, inconsistent, params, printParam);
@@ -1429,14 +1429,14 @@ fn print_type_params(s: ps, &&params: [ast::ty_param]) {
 fn print_meta_item(s: ps, &&item: @ast::meta_item) {
     ibox(s, indent_unit);
     alt item.node {
-      ast::meta_word(name) { word(s.s, name); }
+      ast::meta_word(name) { word(s.s, *name); }
       ast::meta_name_value(name, value) {
-        word_space(s, name);
+        word_space(s, *name);
         word_space(s, "=");
         print_literal(s, @value);
       }
       ast::meta_list(name, items) {
-        word(s.s, name);
+        word(s.s, *name);
         popen(s);
         commasep(s, consistent, items, print_meta_item);
         pclose(s);
@@ -1449,7 +1449,7 @@ fn print_view_path(s: ps, &&vp: @ast::view_path) {
     alt vp.node {
       ast::view_path_simple(ident, path, _) {
         if path.idents[vec::len(path.idents)-1u] != ident {
-            word_space(s, ident);
+            word_space(s, *ident);
             word_space(s, "=");
         }
         print_path(s, path, false);
@@ -1464,7 +1464,7 @@ fn print_view_path(s: ps, &&vp: @ast::view_path) {
         print_path(s, path, false);
         word(s.s, "::{");
         commasep(s, inconsistent, idents) {|s, w|
-            word(s.s, w.node.name)
+            word(s.s, *w.node.name)
         }
         word(s.s, "}");
       }
@@ -1481,7 +1481,7 @@ fn print_view_item(s: ps, item: @ast::view_item) {
     alt item.node {
       ast::view_item_use(id, mta, _) {
         head(s, "use");
-        word(s.s, id);
+        word(s.s, *id);
         if vec::len(mta) > 0u {
             popen(s);
             commasep(s, consistent, mta, print_meta_item);
@@ -1529,11 +1529,11 @@ fn print_arg(s: ps, input: ast::arg) {
     print_arg_mode(s, input.mode);
     alt input.ty.node {
       ast::ty_infer {
-        word(s.s, input.ident);
+        word(s.s, *input.ident);
       }
       _ {
-        if str::len(input.ident) > 0u {
-            word_space(s, input.ident + ":");
+        if str::len(*input.ident) > 0u {
+            word_space(s, *input.ident + ":");
         }
         print_type(s, input.ty);
       }
@@ -1546,7 +1546,7 @@ fn print_ty_fn(s: ps, opt_proto: option<ast::proto>,
                tps: option<[ast::ty_param]>) {
     ibox(s, indent_unit);
     word(s.s, opt_proto_to_str(opt_proto));
-    alt id { some(id) { word(s.s, " "); word(s.s, id); } _ { } }
+    alt id { some(id) { word(s.s, " "); word(s.s, *id); } _ { } }
     alt tps { some(tps) { print_type_params(s, tps); } _ { } }
     zerobreak(s.s);
     popen(s);
@@ -1608,7 +1608,7 @@ fn print_literal(s: ps, &&lit: @ast::lit) {
       _ {}
     }
     alt lit.node {
-      ast::lit_str(st) { print_string(s, st); }
+      ast::lit_str(st) { print_string(s, *st); }
       ast::lit_int(ch, ast::ty_char) {
         word(s.s, "'" + char::escape_default(ch as char) + "'");
       }
@@ -1640,7 +1640,7 @@ fn print_literal(s: ps, &&lit: @ast::lit) {
         }
       }
       ast::lit_float(f, t) {
-        word(s.s, f + ast_util::float_ty_to_str(t));
+        word(s.s, *f + ast_util::float_ty_to_str(t));
       }
       ast::lit_nil { word(s.s, "()"); }
       ast::lit_bool(val) {
@@ -1804,7 +1804,7 @@ fn constrs_str<T>(constrs: [T], elt: fn(T) -> str) -> str {
 }
 
 fn fn_arg_idx_to_str(decl: ast::fn_decl, &&idx: uint) -> str {
-    decl.inputs[idx].ident
+    *decl.inputs[idx].ident
 }
 
 fn opt_proto_to_str(opt_p: option<ast::proto>) -> str {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -29,8 +29,8 @@ fn name_of_fn(fk: fn_kind) -> ident {
     alt fk {
       fk_item_fn(name, _) | fk_method(name, _, _) | fk_res(name, _, _)
           | fk_ctor(name, _, _, _) { /* FIXME: bad */ copy name }
-      fk_anon(*) | fk_fn_block(*) { "anon" }
-      fk_dtor(*)                  { "drop" }
+      fk_anon(*) | fk_fn_block(*) { @"anon" }
+      fk_dtor(*)                  { @"drop" }
     }
 }
 

--- a/src/rustc/driver/driver.rs
+++ b/src/rustc/driver/driver.rs
@@ -49,14 +49,14 @@ fn default_configuration(sess: session, argv0: str, input: input) ->
     };
 
     ret [ // Target bindings.
-         attr::mk_word_item(os::family()),
-         mk("target_os", os::sysname()),
-         mk("target_family", os::family()),
-         mk("target_arch", arch),
-         mk("target_libc", libc),
+         attr::mk_word_item(@os::family()),
+         mk(@"target_os", os::sysname()),
+         mk(@"target_family", os::family()),
+         mk(@"target_arch", arch),
+         mk(@"target_libc", libc),
          // Build bindings.
-         mk("build_compiler", argv0),
-         mk("build_input", source_name(input))];
+         mk(@"build_compiler", argv0),
+         mk(@"build_input", source_name(input))];
 }
 
 fn build_configuration(sess: session, argv0: str, input: input) ->
@@ -70,7 +70,7 @@ fn build_configuration(sess: session, argv0: str, input: input) ->
         {
             if sess.opts.test && !attr::contains_name(user_cfg, "test")
                {
-                [attr::mk_word_item("test")]
+                [attr::mk_word_item(@"test")]
             } else { [] }
         };
     ret user_cfg + gen_cfg + default_cfg;
@@ -82,7 +82,7 @@ fn parse_cfgspecs(cfgspecs: [str]) -> ast::crate_cfg {
     // meta_item here. At the moment we just support the meta_word variant.
     // #2399
     let mut words = [];
-    for cfgspecs.each {|s| words += [attr::mk_word_item(s)]; }
+    for cfgspecs.each {|s| words += [attr::mk_word_item(@s)]; }
     ret words;
 }
 

--- a/src/rustc/driver/session.rs
+++ b/src/rustc/driver/session.rs
@@ -199,7 +199,7 @@ fn building_library(req_crate_type: crate_type, crate: @ast::crate,
             alt syntax::attr::first_attr_value_str_by_name(
                 crate.node.attrs,
                 "crate_type") {
-              option::some("lib") { true }
+              option::some(@"lib") { true }
               _ { false }
             }
         }
@@ -227,9 +227,9 @@ mod test {
             style: ast::attr_outer,
             value: ast_util::respan(ast_util::dummy_sp(),
                 ast::meta_name_value(
-                    "crate_type",
+                    @"crate_type",
                     ast_util::respan(ast_util::dummy_sp(),
-                                     ast::lit_str(t))))
+                                     ast::lit_str(@t))))
         })
     }
 

--- a/src/rustc/front/core_inject.rs
+++ b/src/rustc/front/core_inject.rs
@@ -30,11 +30,11 @@ fn inject_libcore_ref(sess: session,
     let n1 = sess.next_node_id();
     let n2 = sess.next_node_id();
 
-    let vi1 = @{node: ast::view_item_use("core", [], n1),
+    let vi1 = @{node: ast::view_item_use(@"core", [], n1),
                 attrs: [],
                 vis: ast::public,
                 span: dummy_sp()};
-    let vp = spanned(ast::view_path_glob(ident_to_path(dummy_sp(), "core"),
+    let vp = spanned(ast::view_path_glob(ident_to_path(dummy_sp(), @"core"),
                                          n2));
     let vi2 = @{node: ast::view_item_import([vp]),
                 attrs: [],

--- a/src/rustc/front/test.rs
+++ b/src/rustc/front/test.rs
@@ -70,7 +70,7 @@ fn fold_mod(_cx: test_ctxt, m: ast::_mod, fld: fold::ast_fold) -> ast::_mod {
     fn nomain(&&item: @ast::item) -> option<@ast::item> {
         alt item.node {
           ast::item_fn(_, _, _) {
-            if item.ident == "main" {
+            if *item.ident == "main" {
                 option::none
             } else { option::some(item) }
           }
@@ -190,9 +190,9 @@ fn mk_test_module(cx: test_ctxt) -> @ast::item {
     let item_ = ast::item_mod(testmod);
     // This attribute tells resolve to let us call unexported functions
     let resolve_unexported_attr =
-        attr::mk_attr(attr::mk_word_item("!resolve_unexported"));
+        attr::mk_attr(attr::mk_word_item(@"!resolve_unexported"));
     let item: ast::item =
-        {ident: "__test",
+        {ident: @"__test",
          attrs: [resolve_unexported_attr],
          id: cx.sess.next_node_id(),
          node: item_,
@@ -231,7 +231,7 @@ fn mk_tests(cx: test_ctxt) -> @ast::item {
 
     let item_ = ast::item_fn(decl, [], body);
     let item: ast::item =
-        {ident: "tests",
+        {ident: @"tests",
          attrs: [],
          id: cx.sess.next_node_id(),
          node: item_,
@@ -246,16 +246,16 @@ fn mk_path(cx: test_ctxt, path: [ast::ident]) -> [ast::ident] {
     let is_std = {
         let items = attr::find_linkage_metas(cx.crate.node.attrs);
         alt attr::last_meta_item_value_str_by_name(items, "name") {
-          some("std") { true }
+          some(@"std") { true }
           _ { false }
         }
     };
-    (if is_std { [] } else { ["std"] }) + path
+    (if is_std { [] } else { [@"std"] }) + path
 }
 
 // The ast::ty of [std::test::test_desc]
 fn mk_test_desc_vec_ty(cx: test_ctxt) -> @ast::ty {
-    let test_desc_ty_path = path_node(mk_path(cx, ["test", "test_desc"]));
+    let test_desc_ty_path = path_node(mk_path(cx, [@"test", @"test_desc"]));
 
     let test_desc_ty: ast::ty =
         {id: cx.sess.next_node_id(),
@@ -288,14 +288,14 @@ fn mk_test_desc_rec(cx: test_ctxt, test: test) -> @ast::expr {
     #debug("encoding %s", ast_util::path_name_i(path));
 
     let name_lit: ast::lit =
-        nospan(ast::lit_str(ast_util::path_name_i(path)));
+        nospan(ast::lit_str(@ast_util::path_name_i(path)));
     let name_expr: ast::expr =
         {id: cx.sess.next_node_id(),
          node: ast::expr_lit(@name_lit),
          span: span};
 
     let name_field: ast::field =
-        nospan({mutbl: ast::m_imm, ident: "name", expr: @name_expr});
+        nospan({mutbl: ast::m_imm, ident: @"name", expr: @name_expr});
 
     let fn_path = path_node(path);
 
@@ -307,7 +307,7 @@ fn mk_test_desc_rec(cx: test_ctxt, test: test) -> @ast::expr {
     let fn_wrapper_expr = mk_test_wrapper(cx, fn_expr, span);
 
     let fn_field: ast::field =
-        nospan({mutbl: ast::m_imm, ident: "fn", expr: fn_wrapper_expr});
+        nospan({mutbl: ast::m_imm, ident: @"fn", expr: fn_wrapper_expr});
 
     let ignore_lit: ast::lit = nospan(ast::lit_bool(test.ignore));
 
@@ -317,7 +317,7 @@ fn mk_test_desc_rec(cx: test_ctxt, test: test) -> @ast::expr {
          span: span};
 
     let ignore_field: ast::field =
-        nospan({mutbl: ast::m_imm, ident: "ignore", expr: @ignore_expr});
+        nospan({mutbl: ast::m_imm, ident: @"ignore", expr: @ignore_expr});
 
     let fail_lit: ast::lit = nospan(ast::lit_bool(test.should_fail));
 
@@ -327,7 +327,7 @@ fn mk_test_desc_rec(cx: test_ctxt, test: test) -> @ast::expr {
          span: span};
 
     let fail_field: ast::field =
-        nospan({mutbl: ast::m_imm, ident: "should_fail", expr: @fail_expr});
+        nospan({mutbl: ast::m_imm, ident: @"should_fail", expr: @fail_expr});
 
     let desc_rec_: ast::expr_ =
         ast::expr_rec([name_field, fn_field, ignore_field, fail_field],
@@ -379,7 +379,7 @@ fn mk_test_wrapper(cx: test_ctxt,
 }
 
 fn mk_main(cx: test_ctxt) -> @ast::item {
-    let str_pt = path_node(["str"]);
+    let str_pt = path_node([@"str"]);
     let str_ty = @{id: cx.sess.next_node_id(),
                    node: ast::ty_path(str_pt, cx.sess.next_node_id()),
                    span: dummy_sp()};
@@ -391,7 +391,7 @@ fn mk_main(cx: test_ctxt) -> @ast::item {
     let args_arg: ast::arg =
         {mode: ast::expl(ast::by_val),
          ty: @args_ty,
-         ident: "args",
+         ident: @"args",
          id: cx.sess.next_node_id()};
 
     let ret_ty = {id: cx.sess.next_node_id(),
@@ -414,7 +414,7 @@ fn mk_main(cx: test_ctxt) -> @ast::item {
 
     let item_ = ast::item_fn(decl, [], body);
     let item: ast::item =
-        {ident: "main",
+        {ident: @"main",
          attrs: [],
          id: cx.sess.next_node_id(),
          node: item_,
@@ -426,7 +426,7 @@ fn mk_main(cx: test_ctxt) -> @ast::item {
 fn mk_test_main_call(cx: test_ctxt) -> @ast::expr {
 
     // Get the args passed to main so we can pass the to test_main
-    let args_path = path_node(["args"]);
+    let args_path = path_node([@"args"]);
 
     let args_path_expr_: ast::expr_ = ast::expr_path(args_path);
 
@@ -434,7 +434,7 @@ fn mk_test_main_call(cx: test_ctxt) -> @ast::expr {
         {id: cx.sess.next_node_id(), node: args_path_expr_, span: dummy_sp()};
 
     // Call __test::test to generate the vector of test_descs
-    let test_path = path_node(["tests"]);
+    let test_path = path_node([@"tests"]);
 
     let test_path_expr_: ast::expr_ = ast::expr_path(test_path);
 
@@ -447,7 +447,7 @@ fn mk_test_main_call(cx: test_ctxt) -> @ast::expr {
         {id: cx.sess.next_node_id(), node: test_call_expr_, span: dummy_sp()};
 
     // Call std::test::test_main
-    let test_main_path = path_node(mk_path(cx, ["test", "test_main"]));
+    let test_main_path = path_node(mk_path(cx, [@"test", @"test_main"]));
 
     let test_main_path_expr_: ast::expr_ = ast::expr_path(test_main_path);
 

--- a/src/rustc/metadata/common.rs
+++ b/src/rustc/metadata/common.rs
@@ -132,5 +132,5 @@ fn hash_path(&&s: str) -> uint {
     ret h;
 }
 
-type link_meta = {name: str, vers: str, extras_hash: str};
+type link_meta = {name: @str, vers: @str, extras_hash: str};
 

--- a/src/rustc/metadata/csearch.rs
+++ b/src/rustc/metadata/csearch.rs
@@ -64,7 +64,7 @@ fn resolve_path(cstore: cstore::cstore, cnum: ast::crate_num,
     [(ast::crate_num, @[u8], ast::def_id)] {
     let cm = cstore::get_crate_data(cstore, cnum);
     #debug("resolve_path %s in crates[%d]:%s",
-           str::connect(path, "::"), cnum, cm.name);
+           ast_util::path_name_i(path), cnum, cm.name);
     let mut result = [];
     for decoder::resolve_path(path, cm.data).each {|def|
         if def.crate == ast::local_crate {
@@ -88,7 +88,7 @@ fn get_item_path(tcx: ty::ctxt, def: ast::def_id) -> ast_map::path {
 
     // FIXME #1920: This path is not always correct if the crate is not linked
     // into the root namespace.
-    [ast_map::path_mod(cdata.name)] + path
+    [ast_map::path_mod(@cdata.name)] + path
 }
 
 enum found_ast {
@@ -170,7 +170,8 @@ fn get_impl_iface(tcx: ty::ctxt, def: ast::def_id) -> option<ty::t> {
     decoder::get_impl_iface(cdata, def.node, tcx)
 }
 
-fn get_impl_method(cstore: cstore::cstore, def: ast::def_id, mname: str)
+fn get_impl_method(cstore: cstore::cstore,
+                   def: ast::def_id, mname: ast::ident)
     -> ast::def_id {
     let cdata = cstore::get_crate_data(cstore, def.crate);
     decoder::get_impl_method(cdata, def.node, mname)
@@ -180,7 +181,8 @@ fn get_impl_method(cstore: cstore::cstore, def: ast::def_id, mname: str)
    for their methods (so that get_iface_methods can be reused to get
    class methods), classes require a slightly different version of
    get_impl_method. Sigh. */
-fn get_class_method(cstore: cstore::cstore, def: ast::def_id, mname: str)
+fn get_class_method(cstore: cstore::cstore,
+                    def: ast::def_id, mname: ast::ident)
     -> ast::def_id {
     let cdata = cstore::get_crate_data(cstore, def.crate);
     decoder::get_class_method(cdata, def.node, mname)

--- a/src/rustc/metadata/loader.rs
+++ b/src/rustc/metadata/loader.rs
@@ -44,7 +44,7 @@ fn load_library_crate(cx: ctxt) -> {ident: str, data: @[u8]} {
       some(t) { ret t; }
       none {
         cx.diag.span_fatal(
-            cx.span, #fmt["can't find crate for '%s'", cx.ident]);
+            cx.span, #fmt["can't find crate for '%s'", *cx.ident]);
       }
     }
 }
@@ -69,7 +69,7 @@ fn find_library_crate_aux(cx: ctxt,
                           filesearch: filesearch::filesearch) ->
    option<{ident: str, data: @[u8]}> {
     let crate_name = crate_name_from_metas(cx.metas);
-    let prefix: str = nn.prefix + crate_name + "-";
+    let prefix: str = nn.prefix + *crate_name + "-";
     let suffix: str = nn.suffix;
 
     let mut matches = [];
@@ -107,7 +107,7 @@ fn find_library_crate_aux(cx: ctxt,
         some(matches[0])
     } else {
         cx.diag.span_err(
-            cx.span, #fmt("multiple matching crates for `%s`", crate_name));
+            cx.span, #fmt("multiple matching crates for `%s`", *crate_name));
         cx.diag.handler().note("candidates:");
         for matches.each {|match|
             cx.diag.handler().note(#fmt("path: %s", match.ident));
@@ -119,7 +119,7 @@ fn find_library_crate_aux(cx: ctxt,
     }
 }
 
-fn crate_name_from_metas(metas: [@ast::meta_item]) -> str {
+fn crate_name_from_metas(metas: [@ast::meta_item]) -> @str {
     let name_items = attr::find_meta_items_by_name(metas, "name");
     alt vec::last_opt(name_items) {
       some(i) {
@@ -146,7 +146,7 @@ fn crate_matches(crate_data: @[u8], metas: [@ast::meta_item], hash: str) ->
     let linkage_metas = attr::find_linkage_metas(attrs);
     if hash.is_not_empty() {
         let chash = decoder::get_crate_hash(crate_data);
-        if chash != hash { ret false; }
+        if *chash != hash { ret false; }
     }
     metadata_matches(linkage_metas, metas)
 }

--- a/src/rustc/metadata/tydecode.rs
+++ b/src/rustc/metadata/tydecode.rs
@@ -46,7 +46,7 @@ fn parse_ident_(st: @pstate, is_last: fn@(char) -> bool) ->
     while !is_last(peek(st)) {
         rslt += str::from_byte(next_byte(st));
     }
-    ret rslt;
+    ret @rslt;
 }
 
 
@@ -210,7 +210,7 @@ fn parse_bound_region(st: @pstate) -> ty::bound_region {
     alt check next(st) {
       's' { ty::br_self }
       'a' { ty::br_anon }
-      '[' { ty::br_named(parse_str(st, ']')) }
+      '[' { ty::br_named(@parse_str(st, ']')) }
     }
 }
 
@@ -322,7 +322,7 @@ fn parse_ty(st: @pstate, conv: conv_did) -> ty::t {
         assert (next(st) == '[');
         let mut fields: [ty::field] = [];
         while peek(st) != ']' {
-            let name = parse_str(st, '=');
+            let name = @parse_str(st, '=');
             fields += [{ident: name, mt: parse_mt(st, conv)}];
         }
         st.pos = st.pos + 1u;

--- a/src/rustc/metadata/tyencode.rs
+++ b/src/rustc/metadata/tyencode.rs
@@ -157,7 +157,7 @@ fn enc_bound_region(w: io::writer, br: ty::bound_region) {
       ty::br_anon { w.write_char('a') }
       ty::br_named(s) {
         w.write_char('[');
-        w.write_str(s);
+        w.write_str(*s);
         w.write_char(']')
       }
     }
@@ -256,7 +256,7 @@ fn enc_sty(w: io::writer, cx: @ctxt, st: ty::sty) {
       ty::ty_rec(fields) {
         w.write_str("R["/&);
         for fields.each {|field|
-            w.write_str(field.ident);
+            w.write_str(*field.ident);
             w.write_char('=');
             enc_mt(w, cx, field.mt);
         }

--- a/src/rustc/middle/astencode.rs
+++ b/src/rustc/middle/astencode.rs
@@ -83,7 +83,7 @@ fn encode_inlined_item(ecx: @e::encode_ctxt,
                        ii: ast::inlined_item,
                        maps: maps) {
     #debug["> Encoding inlined item: %s::%s (%u)",
-           ast_map::path_to_str(path), ii.ident(),
+           ast_map::path_to_str(path), *ii.ident(),
            ebml_w.writer.tell()];
 
     let id_range = compute_id_range(ii);
@@ -94,7 +94,7 @@ fn encode_inlined_item(ecx: @e::encode_ctxt,
     }
 
     #debug["< Encoded inlined fn: %s::%s (%u)",
-           ast_map::path_to_str(path), ii.ident(),
+           ast_map::path_to_str(path), *ii.ident(),
            ebml_w.writer.tell()];
 }
 
@@ -117,10 +117,10 @@ fn decode_inlined_item(cdata: cstore::crate_metadata,
         let ii = renumber_ast(xcx, raw_ii);
         ast_map::map_decoded_item(tcx.sess.diagnostic(),
                                   dcx.tcx.items, path, ii);
-        #debug["Fn named: %s", ii.ident()];
+        #debug["Fn named: %s", *ii.ident()];
         decode_side_tables(xcx, ast_doc);
         #debug["< Decoded inlined fn: %s::%s",
-               ast_map::path_to_str(path), ii.ident()];
+               ast_map::path_to_str(path), *ii.ident()];
         alt ii {
           ast::ii_item(i) {
             #debug(">>> DECODED ITEM >>>\n%s\n<<< DECODED ITEM <<<",

--- a/src/rustc/middle/borrowck.rs
+++ b/src/rustc/middle/borrowck.rs
@@ -241,7 +241,7 @@ enum comp_kind {
     comp_tuple,                  // elt in a tuple
     comp_res,                    // data for a resource
     comp_variant(ast::def_id),   // internals to a variant of given enum
-    comp_field(str,              // name of field
+    comp_field(ast::ident,       // name of field
                ast::mutability), // declared mutability of field
     comp_index(ty::t,            // type of vec/str/etc being deref'd
                ast::mutability)  // mutability of vec content
@@ -409,7 +409,7 @@ impl to_str_methods for borrowck_ctxt {
 
     fn comp_to_repr(comp: comp_kind) -> str {
         alt comp {
-          comp_field(fld, _) { fld }
+          comp_field(fld, _) { *fld }
           comp_index(*) { "[]" }
           comp_tuple { "()" }
           comp_res { "<res>" }

--- a/src/rustc/middle/borrowck/categorization.rs
+++ b/src/rustc/middle/borrowck/categorization.rs
@@ -295,14 +295,15 @@ impl public_methods for borrowck_ctxt {
         ret @{cat:cat_discr(cmt, alt_id) with *cmt};
     }
 
-    fn cat_field<N:ast_node>(node: N, base_cmt: cmt, f_name: str) -> cmt {
+    fn cat_field<N:ast_node>(node: N, base_cmt: cmt,
+                             f_name: ast::ident) -> cmt {
         let f_mutbl = alt field_mutbl(self.tcx, base_cmt.ty, f_name) {
           some(f_mutbl) { f_mutbl }
           none {
             self.tcx.sess.span_bug(
                 node.span(),
                 #fmt["Cannot find field `%s` in type `%s`",
-                     f_name, ty_to_str(self.tcx, base_cmt.ty)]);
+                     *f_name, ty_to_str(self.tcx, base_cmt.ty)]);
           }
         };
         let m = alt f_mutbl {
@@ -427,7 +428,7 @@ impl private_methods for borrowck_ctxt {
 
 fn field_mutbl(tcx: ty::ctxt,
                base_ty: ty::t,
-               f_name: str) -> option<ast::mutability> {
+               f_name: ast::ident) -> option<ast::mutability> {
     // Need to refactor so that records/class fields can be treated uniformly.
     alt ty::get(base_ty).struct {
       ty::ty_rec(fields) {

--- a/src/rustc/middle/capture.rs
+++ b/src/rustc/middle/capture.rs
@@ -44,7 +44,7 @@ fn check_capture_clause(tcx: ty::ctxt,
             tcx.sess.span_warn(
                 cap_item.span,
                 #fmt("captured variable '%s' not used in closure",
-                     cap_item.name));
+                     *cap_item.name));
         }
 
         let cap_def_id = ast_util::def_id_of_def(cap_def).node;
@@ -52,7 +52,7 @@ fn check_capture_clause(tcx: ty::ctxt,
             tcx.sess.span_err(
                 cap_item.span,
                 #fmt("variable '%s' captured more than once",
-                     cap_item.name));
+                     *cap_item.name));
         }
     }
 }
@@ -68,7 +68,7 @@ fn compute_capture_vars(tcx: ty::ctxt,
 
     for (*cap_clause).each { |cap_item|
         #debug("Doing capture var: %s (%?)",
-               cap_item.name, cap_item.id);
+               *cap_item.name, cap_item.id);
 
         let cap_def = tcx.def_map.get(cap_item.id);
         let cap_def_id = ast_util::def_id_of_def(cap_def).node;

--- a/src/rustc/middle/check_alt.rs
+++ b/src/rustc/middle/check_alt.rs
@@ -67,8 +67,8 @@ fn check_exhaustive(tcx: ty::ctxt, sp: span, pats: [@pat]) {
         alt ty::get(ty).struct {
           ty::ty_bool {
             alt check ctor {
-              val(const_int(1i64)) { some("true") }
-              val(const_int(0i64)) { some("false") }
+              val(const_int(1i64)) { some(@"true") }
+              val(const_int(0i64)) { some(@"false") }
             }
           }
           ty::ty_enum(id, _) {
@@ -83,7 +83,7 @@ fn check_exhaustive(tcx: ty::ctxt, sp: span, pats: [@pat]) {
       }
     };
     let msg = "non-exhaustive patterns" + alt ext {
-      some(s) { ": " + s + " not covered" }
+      some(s) { ": " + *s + " not covered" }
       none { "" }
     };
     tcx.sess.span_err(sp, msg);

--- a/src/rustc/middle/const_eval.rs
+++ b/src/rustc/middle/const_eval.rs
@@ -108,11 +108,11 @@ fn eval_const_expr(tcx: middle::ty::ctxt, e: @expr) -> const_val {
 
 fn lit_to_const(lit: @lit) -> const_val {
     alt lit.node {
-      lit_str(s) { const_str(s) }
+      lit_str(s) { const_str(*s) }
       lit_int(n, _) { const_int(n) }
       lit_uint(n, _) { const_uint(n) }
       lit_int_unsuffixed(n, _) { const_int(n) }
-      lit_float(n, _) { const_float(option::get(float::from_str(n)) as f64) }
+      lit_float(n, _) { const_float(option::get(float::from_str(*n)) as f64) }
       lit_nil { const_int(0i64) }
       lit_bool(b) { const_int(b as i64) }
     }

--- a/src/rustc/middle/lint.rs
+++ b/src/rustc/middle/lint.rs
@@ -210,7 +210,7 @@ impl methods for ctxt {
                 for metas.each {|meta|
                     alt meta.node {
                       ast::meta_word(lintname) {
-                        alt lookup_lint(self.dict, lintname) {
+                        alt lookup_lint(self.dict, *lintname) {
                           (name, none) {
                             self.span_lint(
                                 self.get_level(unrecognized_warning),
@@ -444,7 +444,7 @@ fn check_item_old_vecs(cx: ty::ctxt, it: @ast::item) {
 
               ast::ty_path(@{span: _, global: _, idents: ids,
                              rp: none, types: _}, _)
-              if ids == ["str"] && (! uses_vstore.contains_key(t.id)) {
+              if ids == [@"str"] && (! uses_vstore.contains_key(t.id)) {
                 cx.sess.span_lint(
                     old_vecs, it.id, t.id,
                     t.span, "deprecated str type");

--- a/src/rustc/middle/pat_util.rs
+++ b/src/rustc/middle/pat_util.rs
@@ -9,12 +9,12 @@ import std::map::hashmap;
 export pat_binding_ids, pat_bindings, pat_id_map;
 export pat_is_variant;
 
-type pat_id_map = std::map::hashmap<str, node_id>;
+type pat_id_map = std::map::hashmap<ident, node_id>;
 
 // This is used because same-named variables in alternative patterns need to
 // use the node_id of their namesake in the first pattern.
 fn pat_id_map(dm: resolve::def_map, pat: @pat) -> pat_id_map {
-    let map = std::map::str_hash();
+    let map = std::map::box_str_hash();
     pat_bindings(dm, pat) {|p_id, _s, n|
       map.insert(path_to_ident(n), p_id);
     };

--- a/src/rustc/middle/trans/alt.rs
+++ b/src/rustc/middle/trans/alt.rs
@@ -78,9 +78,9 @@ fn variant_opt(tcx: ty::ctxt, pat_id: ast::node_id) -> opt {
 }
 
 type bind_map = [{ident: ast::ident, val: ValueRef}];
-fn assoc(key: str, list: bind_map) -> option<ValueRef> {
+fn assoc(key: ast::ident, list: bind_map) -> option<ValueRef> {
     for vec::each(list) {|elt|
-        if str::eq(elt.ident, key) { ret some(elt.val); }
+        if str::eq(*elt.ident, *key) { ret some(elt.val); }
     }
     ret none;
 }
@@ -194,7 +194,7 @@ fn enter_rec(dm: def_map, m: match, col: uint, fields: [ast::ident],
             for vec::each(fields) {|fname|
                 let mut pat = dummy;
                 for vec::each(fpats) {|fpat|
-                    if str::eq(fpat.ident, fname) { pat = fpat.pat; break; }
+                    if str::eq(*fpat.ident, *fname) { pat = fpat.pat; break; }
                 }
                 pats += [pat];
             }
@@ -287,12 +287,12 @@ fn extract_variant_args(bcx: block, pat_id: ast::node_id,
 }
 
 fn collect_record_fields(m: match, col: uint) -> [ast::ident] {
-    let mut fields = [];
+    let mut fields: [ast::ident] = [];
     for vec::each(m) {|br|
         alt br.pats[col].node {
           ast::pat_rec(fs, _) {
             for vec::each(fs) {|f|
-                if !vec::any(fields, bind str::eq(f.ident, _)) {
+                if !vec::any(fields, {|x| str::eq(*f.ident, *x)}) {
                     fields += [f.ident];
                 }
             }

--- a/src/rustc/middle/trans/closure.rs
+++ b/src/rustc/middle/trans/closure.rs
@@ -390,7 +390,7 @@ fn trans_expr_fn(bcx: block,
     let ccx = bcx.ccx(), bcx = bcx;
     let fty = node_id_type(bcx, id);
     let llfnty = type_of_fn_from_ty(ccx, fty);
-    let sub_path = bcx.fcx.path + [path_name("anon")];
+    let sub_path = bcx.fcx.path + [path_name(@"anon")];
     let s = mangle_internal_name_by_path(ccx, sub_path);
     let llfn = decl_internal_cdecl_fn(ccx.llmod, s, llfnty);
 
@@ -676,7 +676,7 @@ fn trans_bind_thunk(ccx: @crate_ctxt,
     // construct and return that thunk.
 
     // Give the thunk a name, type, and value.
-    let s = mangle_internal_name_by_path_and_seq(ccx, path, "thunk");
+    let s = mangle_internal_name_by_path_and_seq(ccx, path, @"thunk");
     let llthunk_ty = get_pair_fn_ty(type_of(ccx, incoming_fty));
     let llthunk = decl_internal_cdecl_fn(ccx.llmod, s, llthunk_ty);
 

--- a/src/rustc/middle/trans/common.rs
+++ b/src/rustc/middle/trans/common.rs
@@ -933,7 +933,7 @@ fn path_str(p: path) -> str {
         alt e { ast_map::path_name(s) | ast_map::path_mod(s) {
           if first { first = false; }
           else { r += "::"; }
-          r += s;
+          r += *s;
         } }
     }
     r
@@ -966,7 +966,7 @@ fn field_idx_strict(cx: ty::ctxt, sp: span, ident: ast::ident,
     -> uint {
     alt ty::field_idx(ident, fields) {
        none { cx.sess.span_bug(sp, #fmt("base expr doesn't appear to \
-                 have a field named %s", ident)); }
+                 have a field named %s", *ident)); }
        some(i) { i }
     }
 }

--- a/src/rustc/middle/trans/debuginfo.rs
+++ b/src/rustc/middle/trans/debuginfo.rs
@@ -421,7 +421,7 @@ fn create_record(cx: @crate_ctxt, t: ty::t, fields: [ast::ty_field],
         let field_t = ty::get_field(t, field.node.ident).mt.ty;
         let ty_md = create_ty(cx, field_t, field.node.mt.ty);
         let (size, align) = size_and_align_of(cx, field_t);
-        add_member(scx, field.node.ident,
+        add_member(scx, *field.node.ident,
                    line_from_span(cx.sess.codemap, field.span) as int,
                    size as int, align as int, ty_md.node);
     }
@@ -661,7 +661,7 @@ fn create_local_var(bcx: block, local: @ast::local)
         none { create_function(bcx.fcx).node }
         some(_) { create_block(bcx).node }
     };
-    let mdnode = create_var(tg, context, name, filemd.node,
+    let mdnode = create_var(tg, context, *name, filemd.node,
                             loc.line as int, tymd.node);
     let mdval = @{node: mdnode, data: {id: local.node.id}};
     update_cache(cache, AutoVariableTag, local_var_metadata(mdval));
@@ -703,7 +703,7 @@ fn create_arg(bcx: block, arg: ast::arg, sp: span)
     let tymd = create_ty(cx, ty, arg.ty);
     let filemd = create_file(cx, loc.file.name);
     let context = create_function(bcx.fcx);
-    let mdnode = create_var(tg, context.node, arg.ident, filemd.node,
+    let mdnode = create_var(tg, context.node, *arg.ident, filemd.node,
                             loc.line as int, tymd.node);
     let mdval = @{node: mdnode, data: {id: arg.id}};
     update_cache(cache, tg, argument_metadata(mdval));
@@ -769,10 +769,10 @@ fn create_function(fcx: fn_ctxt) -> @metadata<subprogram_md> {
       ast_map::node_expr(expr) {
         alt expr.node {
           ast::expr_fn(_, decl, _, _) {
-            (dbg_cx.names("fn"), decl.output, expr.id)
+            (@dbg_cx.names("fn"), decl.output, expr.id)
           }
           ast::expr_fn_block(decl, _, _) {
-            (dbg_cx.names("fn"), decl.output, expr.id)
+            (@dbg_cx.names("fn"), decl.output, expr.id)
           }
           _ { fcx.ccx.sess.span_bug(expr.span, "create_function: \
                   expected an expr_fn or fn_block here"); }
@@ -810,8 +810,8 @@ fn create_function(fcx: fn_ctxt) -> @metadata<subprogram_md> {
     let fn_metadata = [lltag(SubprogramTag),
                        llunused(),
                        file_node,
-                       llstr(ident),
-                       llstr(ident), //XXX fully-qualified C++ name
+                       llstr(*ident),
+                       llstr(*ident), //XXX fully-qualified C++ name
                        llstr(""), //XXX MIPS name?????
                        file_node,
                        lli32(loc.line as int),

--- a/src/rustc/middle/trans/native.rs
+++ b/src/rustc/middle/trans/native.rs
@@ -421,8 +421,8 @@ fn decl_x86_64_fn(tys: x86_64_tys,
 
 fn link_name(i: @ast::native_item) -> str {
     alt attr::first_attr_value_str_by_name(i.attrs, "link_name") {
-      none { ret i.ident; }
-      option::some(ln) { ret ln; }
+      none { ret *i.ident; }
+      option::some(ln) { ret *ln; }
     }
 }
 
@@ -805,7 +805,7 @@ fn trans_intrinsic(ccx: @crate_ctxt, decl: ValueRef, item: @ast::native_item,
     let fcx = new_fn_ctxt_w_id(ccx, path, decl, item.id,
                                some(substs), some(item.span));
     let mut bcx = top_scope_block(fcx, none), lltop = bcx.llbb;
-    alt check item.ident {
+    alt check *item.ident {
       "size_of" {
         let tp_ty = substs.tys[0];
         let lltp_ty = type_of::type_of(ccx, tp_ty);
@@ -913,7 +913,7 @@ fn trans_crust_fn(ccx: @crate_ctxt, path: ast_map::path, decl: ast::fn_decl,
         let _icx = ccx.insn_ctxt("native::crust::build_rust_fn");
         let t = ty::node_id_to_type(ccx.tcx, id);
         let ps = link::mangle_internal_name_by_path(
-            ccx, path + [ast_map::path_name("__rust_abi")]);
+            ccx, path + [ast_map::path_name(@"__rust_abi")]);
         let llty = type_of_fn_from_ty(ccx, t);
         let llfndecl = decl_internal_cdecl_fn(ccx.llmod, ps, llty);
         trans_fn(ccx, path, decl, body, llfndecl, no_self, none, id);
@@ -950,7 +950,7 @@ fn trans_crust_fn(ccx: @crate_ctxt, path: ast_map::path, decl: ast::fn_decl,
         }
 
         let shim_name = link::mangle_internal_name_by_path(
-            ccx, path + [ast_map::path_name("__rust_stack_shim")]);
+            ccx, path + [ast_map::path_name(@"__rust_stack_shim")]);
         ret build_shim_fn_(ccx, shim_name, llrustfn, tys,
                            lib::llvm::CCallConv,
                            build_args, build_ret);

--- a/src/rustc/middle/trans/reflect.rs
+++ b/src/rustc/middle/trans/reflect.rs
@@ -41,7 +41,7 @@ impl methods for reflector {
 
     fn visit(ty_name: str, args: [ValueRef]) {
         let tcx = self.bcx.tcx();
-        let mth_idx = option::get(ty::method_idx("visit_" + ty_name,
+        let mth_idx = option::get(ty::method_idx(@("visit_" + ty_name),
                                                  *self.visitor_methods));
         let mth_ty = ty::mk_fn(tcx, self.visitor_methods[mth_idx].fty);
         let v = self.visitor_val;
@@ -142,7 +142,7 @@ impl methods for reflector {
             for fields.eachi {|i, field|
                 self.bracketed_mt("rec_field", field.mt,
                                   [self.c_uint(i),
-                                   self.c_slice(field.ident)]);
+                                   self.c_slice(*field.ident)]);
             }
             self.visit("leave_rec", [self.c_uint(vec::len(fields))]);
           }
@@ -209,7 +209,7 @@ impl methods for reflector {
             for fields.eachi {|i, field|
                 self.bracketed_mt("class_field", field.mt,
                                   [self.c_uint(i),
-                                   self.c_slice(field.ident)]);
+                                   self.c_slice(*field.ident)]);
             }
             self.visit("leave_class", [self.c_uint(vec::len(fields))]);
           }
@@ -228,7 +228,7 @@ impl methods for reflector {
                 let extra = [self.c_uint(i),
                              self.c_int(v.disr_val),
                              self.c_uint(vec::len(v.args)),
-                             self.c_slice(v.name)];
+                             self.c_slice(*v.name)];
                 self.visit("enter_enum_variant", extra);
                 for v.args.eachi {|j, a|
                     self.bracketed_t("enum_variant_field", a,

--- a/src/rustc/middle/trans/shape.rs
+++ b/src/rustc/middle/trans/shape.rs
@@ -421,7 +421,7 @@ fn gen_enum_shapes(ccx: @crate_ctxt) -> ValueRef {
             let variant_shape = shape_of_variant(ccx, v);
             add_substr(data, variant_shape);
 
-            let zname = str::bytes(v.name) + [0u8];
+            let zname = str::bytes(*v.name) + [0u8];
             add_substr(data, zname);
         }
         enum_variants += [variants];

--- a/src/rustc/middle/trans/tvec.rs
+++ b/src/rustc/middle/trans/tvec.rs
@@ -236,7 +236,7 @@ fn get_base_and_len(cx: block, v: ValueRef, e_ty: ty::t)
     }
 }
 
-fn trans_estr(bcx: block, s: str, vstore: ast::vstore,
+fn trans_estr(bcx: block, s: @str, vstore: ast::vstore,
               dest: dest) -> block {
     let _icx = bcx.insn_ctxt("tvec::trans_estr");
     let ccx = bcx.ccx();
@@ -245,27 +245,27 @@ fn trans_estr(bcx: block, s: str, vstore: ast::vstore,
       ast::vstore_fixed(_)
       {
         // "hello"/_  =>  "hello"/5  =>  [i8 x 6] in llvm
-        #debug("trans_estr: fixed: %s", s);
-        C_postr(s)
+        #debug("trans_estr: fixed: %s", *s);
+        C_postr(*s)
       }
 
       ast::vstore_slice(_) {
         // "hello"  =>  (*i8, 6u) in llvm
-        #debug("trans_estr: slice '%s'", s);
-        C_estr_slice(ccx, s)
+        #debug("trans_estr: slice '%s'", *s);
+        C_estr_slice(ccx, *s)
       }
 
       ast::vstore_uniq {
-        let cs = PointerCast(bcx, C_cstr(ccx, s), T_ptr(T_i8()));
-        let len = C_uint(ccx, str::len(s));
+        let cs = PointerCast(bcx, C_cstr(ccx, *s), T_ptr(T_i8()));
+        let len = C_uint(ccx, str::len(*s));
         let c = Call(bcx, ccx.upcalls.str_new_uniq, [cs, len]);
         PointerCast(bcx, c,
                     T_unique_ptr(T_unique(ccx, T_vec(ccx, T_i8()))))
       }
 
       ast::vstore_box {
-        let cs = PointerCast(bcx, C_cstr(ccx, s), T_ptr(T_i8()));
-        let len = C_uint(ccx, str::len(s));
+        let cs = PointerCast(bcx, C_cstr(ccx, *s), T_ptr(T_i8()));
+        let len = C_uint(ccx, str::len(*s));
         Call(bcx, ccx.upcalls.str_new_shared, [cs, len])
       }
     };

--- a/src/rustc/middle/trans/type_use.rs
+++ b/src/rustc/middle/trans/type_use.rs
@@ -76,7 +76,7 @@ fn type_uses_for(ccx: @crate_ctxt, fn_id: def_id, n_tps: uint)
       }
       ast_map::node_native_item(i@@{node: native_item_fn(_, _), _}, abi, _) {
         if abi == native_abi_rust_intrinsic {
-            let flags = alt check i.ident {
+            let flags = alt check *i.ident {
               "visit_ty" { 3u }
               "size_of" |  "pref_align_of" | "min_align_of" |
               "init" |  "reinterpret_cast" { use_repr }

--- a/src/rustc/middle/tstate/auxiliary.rs
+++ b/src/rustc/middle/tstate/auxiliary.rs
@@ -41,7 +41,7 @@ fn comma_str(args: [@constr_arg_use]) -> str {
         if comma { rslt += ", "; } else { comma = true; }
         alt a.node {
           carg_base { rslt += "*"; }
-          carg_ident(i) { rslt += i.ident; }
+          carg_ident(i) { rslt += *i.ident; }
           carg_lit(l) { rslt += lit_to_str(l); }
         }
     }
@@ -143,11 +143,11 @@ fn log_states_err(pp: pre_and_post_state) {
     log_cond_err(p2);
 }
 
-fn print_ident(i: ident) { log(debug, " " + i + " "); }
+fn print_ident(i: ident) { log(debug, " " + *i + " "); }
 
 fn print_idents(&idents: [ident]) {
     if vec::len::<ident>(idents) == 0u { ret; }
-    log(debug, "an ident: " + vec::pop::<ident>(idents));
+    log(debug, "an ident: " + *vec::pop::<ident>(idents));
     print_idents(idents);
 }
 
@@ -500,7 +500,7 @@ fn constraints(fcx: fn_ctxt) -> [norm_constraint] {
 fn match_args(fcx: fn_ctxt, occs: @dvec<pred_args>,
               occ: [@constr_arg_use]) -> uint {
     #debug("match_args: looking at %s",
-           constr_args_to_str(fn@(i: inst) -> str { ret i.ident; }, occ));
+           constr_args_to_str(fn@(i: inst) -> str { ret *i.ident; }, occ));
     for (*occs).each {|pd|
         log(debug,
                  "match_args: candidate " + pred_args_to_str(pd));
@@ -581,7 +581,7 @@ fn expr_to_constr(tcx: ty::ctxt, e: @expr) -> sp_constr {
 
 fn pred_args_to_str(p: pred_args) -> str {
     "<" + uint::str(p.node.bit_num) + ", " +
-        constr_args_to_str(fn@(i: inst) -> str { ret i.ident; }, p.node.args)
+        constr_args_to_str(fn@(i: inst) -> str { ret *i.ident; }, p.node.args)
         + ">"
 }
 
@@ -695,7 +695,7 @@ fn insts_to_str(stuff: [constr_arg_general_<inst>]) -> str {
         rslt +=
             " " +
                 alt i {
-                  carg_ident(p) { p.ident }
+                  carg_ident(p) { *p.ident }
                   carg_base { "*" }
                   carg_lit(_) { "[lit]" }
                 } + " ";

--- a/src/rustc/middle/tstate/collect_locals.rs
+++ b/src/rustc/middle/tstate/collect_locals.rs
@@ -138,7 +138,7 @@ fn mk_fn_info(ccx: crate_ctxt,
          used_vars: v,
          ignore: ignore};
     ccx.fm.insert(id, rslt);
-    #debug("%s has %u constraints", name, num_constraints(rslt));
+    #debug("%s has %u constraints", *name, num_constraints(rslt));
 }
 
 

--- a/src/rustc/middle/tstate/states.rs
+++ b/src/rustc/middle/tstate/states.rs
@@ -516,7 +516,7 @@ fn find_pre_post_state_expr(fcx: fn_ctxt, pres: prestate, e: @expr) -> bool {
 fn find_pre_post_state_stmt(fcx: fn_ctxt, pres: prestate, s: @stmt) -> bool {
     let stmt_ann = stmt_to_ann(fcx.ccx, *s);
 
-    #debug["[ %s ]", fcx.name];
+    #debug["[ %s ]", *fcx.name];
     #debug["*At beginning: stmt = %s", stmt_to_str(*s)];
     #debug["*prestate = %s", tritv::to_str(stmt_ann.states.prestate)];
     #debug["*poststate = %s", tritv::to_str(stmt_ann.states.prestate)];

--- a/src/rustc/middle/typeck/check/alt.rs
+++ b/src/rustc/middle/typeck/check/alt.rs
@@ -191,8 +191,8 @@ fn check_pat(pcx: pat_ctxt, pat: @ast::pat, expected: ty::t) {
                       fields",
                                 ex_f_count, f_count]);
         }
-        fn matches(name: str, f: ty::field) -> bool {
-            ret str::eq(name, f.ident);
+        fn matches(name: ast::ident, f: ty::field) -> bool {
+            ret str::eq(*name, *f.ident);
         }
         for fields.each {|f|
             alt vec::find(ex_fields, bind matches(f.ident, _)) {
@@ -203,7 +203,7 @@ fn check_pat(pcx: pat_ctxt, pat: @ast::pat, expected: ty::t) {
                 tcx.sess.span_fatal(pat.span,
                                     #fmt["mismatched types: did not \
                                           expect a record with a field `%s`",
-                                         f.ident]);
+                                         *f.ident]);
               }
             }
         }

--- a/src/rustc/middle/typeck/check/method.rs
+++ b/src/rustc/middle/typeck/check/method.rs
@@ -19,7 +19,7 @@ impl methods for lookup {
     // Entrypoint:
     fn method() -> option<method_origin> {
         #debug["method lookup(m_name=%s, self_ty=%s)",
-               self.m_name, self.fcx.infcx.ty_to_str(self.self_ty)];
+               *self.m_name, self.fcx.infcx.ty_to_str(self.self_ty)];
 
         // First, see whether this is an interface-bounded parameter
         let pass1 = alt ty::get(self.self_ty).struct {

--- a/src/rustc/middle/typeck/check/regionck.rs
+++ b/src/rustc/middle/typeck/check/regionck.rs
@@ -65,7 +65,7 @@ fn visit_pat(p: @ast::pat, &&rcx: rcx, v: rvt) {
     alt p.node {
       ast::pat_ident(path, _)
       if !pat_util::pat_is_variant(fcx.ccx.tcx.def_map, p) {
-        #debug["visit_pat binding=%s", path.idents[0]];
+        #debug["visit_pat binding=%s", *path.idents[0]];
         visit_node(p.id, p.span, rcx);
       }
       _ {}

--- a/src/rustc/middle/typeck/collect.rs
+++ b/src/rustc/middle/typeck/collect.rs
@@ -29,7 +29,7 @@ fn collect_item_types(ccx: @crate_ctxt, crate: @ast::crate) {
     // there ought to be a better approach. Attributes?
 
     for crate.node.module.items.each {|crate_item|
-        if crate_item.ident == "intrinsic" {
+        if *crate_item.ident == "intrinsic" {
             alt crate_item.node {
               ast::item_mod(m) {
                 for m.items.each {|intrinsic_item|
@@ -170,7 +170,7 @@ fn compare_impl_method(tcx: ty::ctxt, sp: span,
                        self_ty: ty::t) {
 
     if impl_m.tps != if_m.tps {
-        tcx.sess.span_err(sp, "method `" + if_m.ident +
+        tcx.sess.span_err(sp, "method `" + *if_m.ident +
                           "` has an incompatible set of type parameters");
         ret;
     }
@@ -178,7 +178,7 @@ fn compare_impl_method(tcx: ty::ctxt, sp: span,
     if vec::len(impl_m.fty.inputs) != vec::len(if_m.fty.inputs) {
         tcx.sess.span_err(sp,#fmt["method `%s` has %u parameters \
                                    but the iface has %u",
-                                  if_m.ident,
+                                  *if_m.ident,
                                   vec::len(impl_m.fty.inputs),
                                   vec::len(if_m.fty.inputs)]);
         ret;
@@ -211,7 +211,7 @@ fn compare_impl_method(tcx: ty::ctxt, sp: span,
     };
     require_same_types(
         tcx, sp, impl_fty, if_fty,
-        {|| "method `" + if_m.ident + "` has an incompatible type"});
+        {|| "method `" + *if_m.ident + "` has an incompatible type"});
     ret;
 
     // Replaces bound references to the self region with `with_r`.
@@ -242,7 +242,7 @@ fn check_methods_against_iface(ccx: @crate_ctxt,
                 ccx.tcx.sess.span_err(
                     span, #fmt["method `%s`'s purity \
                                 not match the iface method's \
-                                purity", m.ident]);
+                                purity", *m.ident]);
             }
             compare_impl_method(
                 ccx.tcx, span, m, vec::len(tps),
@@ -251,7 +251,7 @@ fn check_methods_against_iface(ccx: @crate_ctxt,
           none {
             tcx.sess.span_err(
                 a_ifacety.path.span,
-                #fmt["missing method `%s`", if_m.ident]);
+                #fmt["missing method `%s`", *if_m.ident]);
           }
         } // alt
     } // |if_m|
@@ -511,7 +511,7 @@ fn ty_of_item(ccx: @crate_ctxt, it: @ast::item)
                    rp: ast::rp_none, // functions do not have a self
                    ty: ty::mk_fn(ccx.tcx, tofd)};
         #debug["type of %s (id %d) is %s",
-               it.ident, it.id, ty_to_str(tcx, tpt.ty)];
+               *it.ident, it.id, ty_to_str(tcx, tpt.ty)];
         ccx.tcx.tcache.insert(local_def(it.id), tpt);
         ret tpt;
       }

--- a/src/rustc/middle/typeck/rscope.rs
+++ b/src/rustc/middle/typeck/rscope.rs
@@ -2,7 +2,7 @@ import result::result;
 
 iface region_scope {
     fn anon_region() -> result<ty::region, str>;
-    fn named_region(id: str) -> result<ty::region, str>;
+    fn named_region(id: ast::ident) -> result<ty::region, str>;
 }
 
 enum empty_rscope { empty_rscope }
@@ -10,8 +10,8 @@ impl of region_scope for empty_rscope {
     fn anon_region() -> result<ty::region, str> {
         result::err("region types are not allowed here")
     }
-    fn named_region(id: str) -> result<ty::region, str> {
-        if id == "static" { result::ok(ty::re_static) }
+    fn named_region(id: ast::ident) -> result<ty::region, str> {
+        if *id == "static" { result::ok(ty::re_static) }
         else { result::err("only the static region is allowed here") }
     }
 }
@@ -27,9 +27,9 @@ impl of region_scope for type_rscope {
           }
         }
     }
-    fn named_region(id: str) -> result<ty::region, str> {
+    fn named_region(id: ast::ident) -> result<ty::region, str> {
         empty_rscope.named_region(id).chain_err { |_e|
-            if id == "self" { self.anon_region() }
+            if *id == "self" { self.anon_region() }
             else {
                 result::err("named regions other than `self` are not \
                              allowed as part of a type declaration")
@@ -47,7 +47,7 @@ impl of region_scope for @anon_rscope {
     fn anon_region() -> result<ty::region, str> {
         result::ok(self.anon)
     }
-    fn named_region(id: str) -> result<ty::region, str> {
+    fn named_region(id: ast::ident) -> result<ty::region, str> {
         self.base.named_region(id)
     }
 }
@@ -61,7 +61,7 @@ impl of region_scope for @binding_rscope {
     fn anon_region() -> result<ty::region, str> {
         result::ok(ty::re_bound(ty::br_anon))
     }
-    fn named_region(id: str) -> result<ty::region, str> {
+    fn named_region(id: ast::ident) -> result<ty::region, str> {
         self.base.named_region(id).chain_err {|_e|
             result::ok(ty::re_bound(ty::br_named(id)))
         }

--- a/src/rustc/util/common.rs
+++ b/src/rustc/util/common.rs
@@ -72,7 +72,7 @@ fn local_rhs_span(l: @ast::local, def: span) -> span {
 fn is_main_name(path: syntax::ast_map::path) -> bool {
     // FIXME: path should be a constrained type, so we know
     // the call to last doesn't fail
-    vec::last(path) == syntax::ast_map::path_name("main")
+    vec::last(path) == syntax::ast_map::path_name(@"main")
 }
 
 //

--- a/src/rustc/util/ppaux.rs
+++ b/src/rustc/util/ppaux.rs
@@ -21,7 +21,7 @@ import driver::session::session;
 fn bound_region_to_str(cx: ctxt, br: bound_region) -> str {
     alt br {
       br_anon                        { "&" }
-      br_named(str)                  { #fmt["&%s", str] }
+      br_named(str)                  { #fmt["&%s", *str] }
       br_self if cx.sess.ppregions() { "&<self>" }
       br_self                        { "&self" }
     }
@@ -130,7 +130,7 @@ fn ty_to_str(cx: ctxt, typ: t) -> str {
           _ {purity_to_str(purity) + " "}
         };
         s += proto_to_str(proto);
-        alt ident { some(i) { s += " "; s += i; } _ { } }
+        alt ident { some(i) { s += " "; s += *i; } _ { } }
         s += "(";
         let mut strs = [];
         for inputs.each {|a| strs += [fn_input_to_str(cx, a)]; }
@@ -152,7 +152,7 @@ fn ty_to_str(cx: ctxt, typ: t) -> str {
             m.fty.output, m.fty.ret_style, m.fty.constraints) + ";";
     }
     fn field_to_str(cx: ctxt, f: field) -> str {
-        ret f.ident + ": " + mt_to_str(cx, f.mt);
+        ret *f.ident + ": " + mt_to_str(cx, f.mt);
     }
 
     // if there is an id, print that instead of the structural type:

--- a/src/rustdoc/attr_parser.rs
+++ b/src/rustdoc/attr_parser.rs
@@ -67,7 +67,8 @@ fn parse_crate(attrs: [ast::attribute]) -> crate_attrs {
     let link_metas = attr::find_linkage_metas(attrs);
 
     {
-        name: attr::last_meta_item_value_str_by_name(link_metas, "name")
+        name: attr::last_meta_item_value_str_by_name(
+            link_metas, "name").map({|x|*x})
     }
 }
 
@@ -98,7 +99,7 @@ fn should_not_extract_crate_name_if_no_name_value_in_link_attribute() {
 fn parse_desc(attrs: [ast::attribute]) -> option<str> {
     alt doc_meta(attrs) {
       some(meta) {
-        attr::get_meta_item_value_str(meta)
+        attr::get_meta_item_value_str(meta).map({|x|*x})
       }
       none { none }
     }

--- a/src/rustdoc/attr_pass.rs
+++ b/src/rustdoc/attr_pass.rs
@@ -151,7 +151,7 @@ fn fold_enum(
                   }, _) {
                     let ast_variant = option::get(
                         vec::find(ast_variants) {|v|
-                            v.node.name == variant.name
+                            *v.node.name == variant.name
                         });
 
                     attr_parser::parse_desc(ast_variant.node.attrs)
@@ -207,14 +207,14 @@ fn merge_method_attrs(
             node: ast::item_iface(_, _, methods), _
           }, _) {
             par::seqmap(methods) {|method|
-                (method.ident, attr_parser::parse_desc(method.attrs))
+                (*method.ident, attr_parser::parse_desc(method.attrs))
             }
           }
           ast_map::node_item(@{
             node: ast::item_impl(_, _, _, _, methods), _
           }, _) {
             par::seqmap(methods) {|method|
-                (method.ident, attr_parser::parse_desc(method.attrs))
+                (*method.ident, attr_parser::parse_desc(method.attrs))
             }
           }
           _ { fail "unexpected item" }

--- a/src/rustdoc/extract.rs
+++ b/src/rustdoc/extract.rs
@@ -33,14 +33,14 @@ fn top_moddoc_from_crate(
     crate: @ast::crate,
     default_name: str
 ) -> doc::moddoc {
-    moddoc_from_mod(mk_itemdoc(ast::crate_node_id, default_name),
+    moddoc_from_mod(mk_itemdoc(ast::crate_node_id, @default_name),
                     crate.node.module)
 }
 
 fn mk_itemdoc(id: ast::node_id, name: ast::ident) -> doc::itemdoc {
     {
         id: id,
-        name: name,
+        name: *name,
         path: [],
         brief: none,
         desc: none,
@@ -169,7 +169,7 @@ fn variantdocs_from_variants(
 
 fn variantdoc_from_variant(variant: ast::variant) -> doc::variantdoc {
     {
-        name: variant.node.name,
+        name: *variant.node.name,
         desc: none,
         sig: none
     }
@@ -210,7 +210,7 @@ fn ifacedoc_from_iface(
         item: itemdoc,
         methods: par::seqmap(methods) {|method|
             {
-                name: method.ident,
+                name: *method.ident,
                 brief: none,
                 desc: none,
                 sections: [],
@@ -242,7 +242,7 @@ fn impldoc_from_impl(
         self_ty: none,
         methods: par::seqmap(methods) {|method|
             {
-                name: method.ident,
+                name: *method.ident,
                 brief: none,
                 desc: none,
                 sections: [],

--- a/src/rustdoc/prune_unexported_pass.rs
+++ b/src/rustdoc/prune_unexported_pass.rs
@@ -114,7 +114,7 @@ fn is_exported_from_mod(
           ast_map::node_item(item, _) {
             alt item.node {
               ast::item_mod(m) {
-                ast_util::is_exported(item_name, m)
+                ast_util::is_exported(@item_name, m)
               }
               _ {
                 fail "is_exported_from_mod: not a mod";
@@ -131,7 +131,7 @@ fn is_exported_from_crate(
     item_name: str
 ) -> bool {
     astsrv::exec(srv) {|ctxt|
-        ast_util::is_exported(item_name, ctxt.ast.node.module)
+        ast_util::is_exported(@item_name, ctxt.ast.node.module)
     }
 }
 

--- a/src/rustdoc/reexport_pass.rs
+++ b/src/rustdoc/reexport_pass.rs
@@ -187,7 +187,7 @@ fn build_reexport_path_map(srv: astsrv::srv, -def_map: def_map) -> path_map {
                 if !def.reexp { cont; }
                 alt def_map.find(def.id) {
                   some(itemtag) {
-                    reexportdocs += [(name, itemtag)];
+                    reexportdocs += [(*name, itemtag)];
                   }
                   _ {}
                 }
@@ -231,9 +231,9 @@ fn find_reexport_impl_docs(
           some(ast_map::node_item(item, path)) {
             let path = ast_map::path_to_str(*path);
             if str::is_empty(path) {
-                item.ident
+                *item.ident
             } else {
-                path + "::" + item.ident
+                path + "::" + *item.ident
             }
           }
           _ {
@@ -241,7 +241,7 @@ fn find_reexport_impl_docs(
             ""
           }
         };
-        let ident = i.ident;
+        let ident = *i.ident;
         let doc = alt check def_map.find(i.did) {
           some(doc) { doc }
         };

--- a/src/rustdoc/tystr_pass.rs
+++ b/src/rustdoc/tystr_pass.rs
@@ -116,7 +116,7 @@ fn fold_enum(
                   }, _) {
                     let ast_variant = option::get(
                         vec::find(ast_variants) {|v|
-                            v.node.name == variant.name
+                            *v.node.name == variant.name
                         });
 
                     pprust::variant_to_str(ast_variant)
@@ -151,7 +151,7 @@ fn fold_res(
               ast_map::node_item(@{
                 node: ast::item_res(decl, tys, _, _, _, rp), _
               }, _) {
-                pprust::res_to_str(decl, doc.name(), tys, rp)
+                pprust::res_to_str(decl, @doc.name(), tys, rp)
               }
             }
         })
@@ -200,7 +200,7 @@ fn get_method_sig(
             node: ast::item_iface(_, _, methods), _
           }, _) {
             alt check vec::find(methods) {|method|
-                method.ident == method_name
+                *method.ident == method_name
             } {
                 some(method) {
                     some(pprust::fun_to_str(
@@ -215,7 +215,7 @@ fn get_method_sig(
             node: ast::item_impl(_, _, _, _, methods), _
           }, _) {
             alt check vec::find(methods) {|method|
-                method.ident == method_name
+                *method.ident == method_name
             } {
                 some(method) {
                     some(pprust::fun_to_str(
@@ -307,7 +307,7 @@ fn fold_type(
               }, _) {
                 some(#fmt(
                     "type %s%s = %s",
-                    ident,
+                    *ident,
                     pprust::typarams_to_str(params),
                     pprust::ty_to_str(ty)
                 ))


### PR DESCRIPTION
This commit converts `ast::ident` into a boxed string with the intent of avoiding copies (at the expense of more refcounting, and another level of indirection through the box). The end goal is to convert idents into interned, boxed strings to avoid expensive string comparisons.

This makes the code considerably uglier with lots of boxing and dereferencing. It cuts 2% at most from rustc compile times.
