### PR TITLE
Automatically export methods on core numeric types

### DIFF
--- a/src/libcore/core.rs
+++ b/src/libcore/core.rs
@@ -11,9 +11,24 @@ import option::extensions;
 import option_iter::extensions;
 import ptr::extensions;
 import rand::extensions;
+import int::extensions::*;
+import i8::extensions::*;
+import i16::extensions::*;
+import i32::extensions::*;
+import i64::extensions::*;
+import uint::extensions::*;
+import u8::extensions::*;
+import u16::extensions::*;
+import u32::extensions::*;
+import u64::extensions::*;
+import float::extensions::*;
+import f32::extensions::*;
+import f64::extensions::*;
 
 export path, option, some, none, unreachable;
 export extensions;
+// The following exports are the extension impls for numeric types
+export num;
 
 // Export the log levels as global constants. Higher levels mean
 // more-verbosity. Error is the bottom level, default logging level is

--- a/src/libcore/f32.rs
+++ b/src/libcore/f32.rs
@@ -18,7 +18,7 @@ export mul_add, fmax, fmin, nextafter, frexp, hypot, ldexp;
 export lgamma, ln, log_radix, ln1p, log10, log2, ilog_radix;
 export modf, pow, round, sin, sinh, sqrt, tan, tanh, tgamma, trunc;
 export signbit;
-export num;
+export extensions;
 
 // These are not defined inside consts:: for consistency with
 // the integer types
@@ -173,16 +173,18 @@ pure fn log2(n: f32) -> f32 {
     ret ln(n) / consts::ln_2;
 }
 
-impl num of num for f32 {
-    fn add(&&other: f32)    -> f32 { ret self + other; }
-    fn sub(&&other: f32)    -> f32 { ret self - other; }
-    fn mul(&&other: f32)    -> f32 { ret self * other; }
-    fn div(&&other: f32)    -> f32 { ret self / other; }
-    fn modulo(&&other: f32) -> f32 { ret self % other; }
-    fn neg()                -> f32 { ret -self;        }
+mod extensions {
+    impl num of num for f32 {
+        fn add(&&other: f32)    -> f32 { ret self + other; }
+        fn sub(&&other: f32)    -> f32 { ret self - other; }
+        fn mul(&&other: f32)    -> f32 { ret self * other; }
+        fn div(&&other: f32)    -> f32 { ret self / other; }
+        fn modulo(&&other: f32) -> f32 { ret self % other; }
+        fn neg()                -> f32 { ret -self;        }
 
-    fn to_int()         -> int { ret self as int; }
-    fn from_int(n: int) -> f32 { ret n as f32;    }
+        fn to_int()         -> int { ret self as int; }
+        fn from_int(n: int) -> f32 { ret n as f32;    }
+    }
 }
 
 //

--- a/src/libcore/f64.rs
+++ b/src/libcore/f64.rs
@@ -22,7 +22,7 @@ export lgamma, ln, log_radix, ln1p, log10, log2, ilog_radix;
 export modf, pow, round, sin, sinh, sqrt, tan, tanh, tgamma, trunc;
 export signbit;
 export epsilon;
-export num;
+export extensions;
 
 // These are not defined inside consts:: for consistency with
 // the integer types
@@ -196,16 +196,18 @@ pure fn log2(n: f64) -> f64 {
     ret ln(n) / consts::ln_2;
 }
 
-impl num of num for f64 {
-    fn add(&&other: f64)    -> f64 { ret self + other; }
-    fn sub(&&other: f64)    -> f64 { ret self - other; }
-    fn mul(&&other: f64)    -> f64 { ret self * other; }
-    fn div(&&other: f64)    -> f64 { ret self / other; }
-    fn modulo(&&other: f64) -> f64 { ret self % other; }
-    fn neg()                -> f64 { ret -self;        }
+mod extensions {
+    impl num of num for f64 {
+        fn add(&&other: f64)    -> f64 { ret self + other; }
+        fn sub(&&other: f64)    -> f64 { ret self - other; }
+        fn mul(&&other: f64)    -> f64 { ret self * other; }
+        fn div(&&other: f64)    -> f64 { ret self / other; }
+        fn modulo(&&other: f64) -> f64 { ret self % other; }
+        fn neg()                -> f64 { ret -self;        }
 
-    fn to_int()         -> int { ret self as int; }
-    fn from_int(n: int) -> f64 { ret n as f64;    }
+        fn to_int()         -> int { ret self as int; }
+        fn from_int(n: int) -> f64 { ret n as f64;    }
+    }
 }
 
 //

--- a/src/libcore/float.rs
+++ b/src/libcore/float.rs
@@ -17,7 +17,7 @@ export lgamma, ln, log_radix, ln1p, log10, log2, ilog_radix;
 export modf, pow, round, sin, sinh, sqrt, tan, tanh, tgamma, trunc;
 export signbit;
 export pow_with_uint;
-export num;
+export extensions;
 
 // export when m_float == c_double
 
@@ -410,16 +410,18 @@ fn sin(x: float) -> float { f64::sin(x as f64) as float }
 fn cos(x: float) -> float { f64::cos(x as f64) as float }
 fn tan(x: float) -> float { f64::tan(x as f64) as float }
 
-impl num of num for float {
-    fn add(&&other: float)    -> float { ret self + other; }
-    fn sub(&&other: float)    -> float { ret self - other; }
-    fn mul(&&other: float)    -> float { ret self * other; }
-    fn div(&&other: float)    -> float { ret self / other; }
-    fn modulo(&&other: float) -> float { ret self % other; }
-    fn neg()                  -> float { ret -self;        }
+mod extensions {
+    impl num of num for float {
+        fn add(&&other: float)    -> float { ret self + other; }
+        fn sub(&&other: float)    -> float { ret self - other; }
+        fn mul(&&other: float)    -> float { ret self * other; }
+        fn div(&&other: float)    -> float { ret self / other; }
+        fn modulo(&&other: float) -> float { ret self % other; }
+        fn neg()                  -> float { ret -self;        }
 
-    fn to_int()         -> int   { ret self as int; }
-    fn from_int(n: int) -> float { ret n as float;  }
+        fn to_int()         -> int   { ret self as int; }
+        fn from_int(n: int) -> float { ret n as float;  }
+    }
 }
 
 #[test]

--- a/src/libcore/int-template.rs
+++ b/src/libcore/int-template.rs
@@ -12,7 +12,7 @@ export range;
 export compl;
 export abs;
 export parse_buf, from_str, to_str, to_str_bytes, str;
-export ord, eq, num;
+export ord, eq, extensions;
 
 const min_value: T = -1 as T << (inst::bits - 1 as T);
 const max_value: T = min_value - 1 as T;
@@ -124,16 +124,18 @@ impl eq of eq for T {
     }
 }
 
-impl num of num::num for T {
-    fn add(&&other: T)    -> T { ret self + other; }
-    fn sub(&&other: T)    -> T { ret self - other; }
-    fn mul(&&other: T)    -> T { ret self * other; }
-    fn div(&&other: T)    -> T { ret self / other; }
-    fn modulo(&&other: T) -> T { ret self % other; }
-    fn neg()              -> T { ret -self;        }
+mod extensions {
+    impl num of num::num for T {
+        fn add(&&other: T)    -> T { ret self + other; }
+        fn sub(&&other: T)    -> T { ret self - other; }
+        fn mul(&&other: T)    -> T { ret self * other; }
+        fn div(&&other: T)    -> T { ret self / other; }
+        fn modulo(&&other: T) -> T { ret self % other; }
+        fn neg()              -> T { ret -self;        }
 
-    fn to_int()         -> int { ret self as int; }
-    fn from_int(n: int) -> T   { ret n as T;      }
+        fn to_int()         -> int { ret self as int; }
+        fn from_int(n: int) -> T   { ret n as T;      }
+    }
 }
 
 

--- a/src/libcore/uint-template.rs
+++ b/src/libcore/uint-template.rs
@@ -12,7 +12,7 @@ export range;
 export compl;
 export to_str, to_str_bytes;
 export from_str, from_str_radix, str, parse_buf;
-export ord, eq, num;
+export ord, eq, extensions;
 
 const min_value: T = 0 as T;
 const max_value: T = 0 as T - 1 as T;
@@ -65,16 +65,18 @@ impl eq of eq for T {
     }
 }
 
-impl num of num::num for T {
-    fn add(&&other: T)    -> T { ret self + other; }
-    fn sub(&&other: T)    -> T { ret self - other; }
-    fn mul(&&other: T)    -> T { ret self * other; }
-    fn div(&&other: T)    -> T { ret self / other; }
-    fn modulo(&&other: T) -> T { ret self % other; }
-    fn neg()              -> T { ret -self;        }
+mod extensions {
+    impl num of num::num for T {
+        fn add(&&other: T)    -> T { ret self + other; }
+        fn sub(&&other: T)    -> T { ret self - other; }
+        fn mul(&&other: T)    -> T { ret self * other; }
+        fn div(&&other: T)    -> T { ret self / other; }
+        fn modulo(&&other: T) -> T { ret self % other; }
+        fn neg()              -> T { ret -self;        }
 
-    fn to_int()         -> int { ret self as int; }
-    fn from_int(n: int) -> T   { ret n as T;      }
+        fn to_int()         -> int { ret self as int; }
+        fn from_int(n: int) -> T   { ret n as T;      }
+    }
 }
 
 #[doc = "

--- a/src/test/run-pass/numeric-method-autoexport.rs
+++ b/src/test/run-pass/numeric-method-autoexport.rs
@@ -1,0 +1,24 @@
+// This file is intended to test only that methods are automatically
+// reachable for each numeric type, for each exported impl, with no imports
+// necessary. Testing the methods of the impls is done within the source
+// file for each numeric type.
+fn main() {
+    // extensions::num
+    assert 15.add(6) == 21;
+    assert 15i8.add(6i8) == 21i8;
+    assert 15i16.add(6i16) == 21i16;
+    assert 15i32.add(6i32) == 21i32;
+    assert 15i64.add(6i64) == 21i64;
+
+    // extensions::num
+    assert 15u.add(6u) == 21u;
+    assert 15u8.add(6u8) == 21u8;
+    assert 15u16.add(6u16) == 21u16;
+    assert 15u32.add(6u32) == 21u32;
+    assert 15u64.add(6u64) == 21u64;
+
+    // extensions::num
+    assert 10f.to_int() == 10;
+    assert 10f32.to_int() == 10;
+    assert 10f64.to_int() == 10;
+}


### PR DESCRIPTION
Each numeric type now contains an extensions module that is automatically exported. At the moment each extensions module contains only the impl for the `num::num` iface. Other impls soon to follow (hopefully), partly contingent on #2716 being fixed.
