### PR TITLE
Fail to configure without an LLVM-friendly Python

### DIFF
--- a/configure
+++ b/configure
@@ -311,8 +311,13 @@ fi
 step_msg "looking for build programs"
 
 probe_need CFG_PERL        perl
-probe_need CFG_PYTHON      python python2.6 python2 python3
 probe_need CFG_CURL        curl
+probe_need CFG_PYTHON      python2.7 python2.6 python2 python
+
+python_version=$($CFG_PYTHON -V 2>&1)
+if [ $(echo $python_version | grep -c '^Python 2\.[4567]') -ne 1 ]; then
+    err "Found $python_version, but LLVM requires Python 2.4-2.7"
+fi
 
 # If we have no git directory then we are probably a tarball distribution
 # and shouldn't attempt to load submodules


### PR DESCRIPTION
This addresses issue #2720. According to LLVM's documentation, it requires a
version of Python between 2.4 and 2.7. Without the proper version, LLVM fails
to build with cryptic errors. Prior to this commit, the configure script
checked for the `python` command in the environment, but didn't actually check
the version, which can cause problems e.g. on Linux distros where the default
is Python 3. Now the configure script always prefers to select a more specific
version of Python when available, in the order `python2.7` > `python2.6` >
`python2` > `python`, and will always check to ensure that the interpreter's
version is in the correct range.
