### PR TITLE
Properly highlight nested comments in vim

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -3,15 +3,10 @@
 " Maintainer:   Patrick Walton <pcwalton@mozilla.com>
 " Last Change:  2010 Oct 13
 
-" Quit when a syntax file was already loaded
-if !exists("main_syntax")
-  if version < 600
-    syntax clear
-  elseif exists("b:current_syntax")
-    finish
-  endif
-  " we define it here so that included files can test for it
-  let main_syntax='rust'
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
 endif
 
 syn keyword   rustKeyword     alt as assert break


### PR DESCRIPTION
Prior to this commit, every block comment /\* */ required two closing tags for
every opening tag in order to terminate the highlighting. Setting and testing
for a variable was the culprit, though I'm not certain why, but they appear to
just be boilerplate lines from whatever pcwalton based this file upon. I've
looked at other officially-distributed vim highlighting files and none seem to
do the test that this commit removes, so I'm fairly certain it didn't provide
anything vital. And now comment highlighting works!
