### PR TITLE
Implemented better error message for missing do statements.

### DIFF
--- a/src/rustc/middle/typeck/check.rs
+++ b/src/rustc/middle/typeck/check.rs
@@ -973,11 +973,25 @@ fn check_expr_with_unifier(fcx: @fn_ctxt,
           _ {}
         }
         check_expr(fcx, rhs, none);
+
         tcx.sess.span_err(
             ex.span, "binary operation " + ast_util::binop_to_str(op) +
             " cannot be applied to type `" +
             fcx.infcx.ty_to_str(lhs_resolved_t) +
             "`");
+
+        // If the or operator is used it might be that the user forgot to
+        // supply the do keyword.  Let's be more helpful in that situation.
+        if op == ast::or {
+          alt ty::get(lhs_resolved_t).struct {
+            ty::ty_fn(f) {
+              tcx.sess.span_note(
+                  ex.span, "did you forget the 'do' keyword for the call?");
+            }
+            _ {}
+          }
+        }
+
         (lhs_resolved_t, false)
     }
     fn check_user_unop(fcx: @fn_ctxt, op_str: str, mname: str,

--- a/src/test/compile-fail/missing-do.rs
+++ b/src/test/compile-fail/missing-do.rs
@@ -1,0 +1,9 @@
+// Regression test for issue #2783
+
+fn foo(f: fn()) { f() }
+
+fn main() {
+    "" || 42; //! ERROR binary operation || cannot be applied to type `str`
+    foo || {}; //! ERROR binary operation || cannot be applied to type `extern fn(fn())`
+    //!^ NOTE did you forget the 'do' keyword for the call?
+}


### PR DESCRIPTION
This fixes #2783 for the case where an empty double pipe
symbol is being used without a do keyword.
