### PR TITLE
adding base64 and to_bytes to stdlib

### DIFF
--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -1,0 +1,19 @@
+iface to_bytes {
+    fn to_bytes() -> ~[u8];
+}
+
+impl of to_bytes for ~[u8] {
+    fn to_bytes() -> ~[u8] { copy self }
+}
+
+impl of to_bytes for @~[u8] {
+    fn to_bytes() -> ~[u8] { copy *self }
+}
+
+impl of to_bytes for str {
+    fn to_bytes() -> ~[u8] { str::bytes(self) }
+}
+
+impl of to_bytes for @str {
+    fn to_bytes() -> ~[u8] { str::bytes(*self) }
+}


### PR DESCRIPTION
Good evening,

@graydon mentioned a while ago that base64 encoding/decoding would be a good candidate for the standard library. I also included a `to_bytes` iface as well, which parallels the `to_str` iface. Are these still appropriate? Or do you all think it'd be better to put this in a cargo crate?
