### PR TITLE
tutorial: added a missing closing backtick to fix formatting in the for-loops text

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1187,7 +1187,7 @@ Empty argument lists can be omitted from `do` expressions.
 
 Most iteration in Rust is done with `for` loops. Like `do`,
 `for` is a nice syntax for doing control flow with closures.
-Additionally, within a `for` loop, `break, `cont`, and `ret`
+Additionally, within a `for` loop, `break`, `cont`, and `ret`
 work just as they do with `while` and `loop`.
 
 Consider again our `each` function, this time improved to


### PR DESCRIPTION
the most trivial of changes
