### PR TITLE
Add test attributes to test functions missing test attributes.

### DIFF
--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -97,6 +97,7 @@ mod tests {
         assert ((), ((), 100)).to_str() == "((), ((), 100))";
     }
 
+    #[test]
     fn test_vectors() {
         let x: ~[int] = ~[];
         assert x.to_str() == "~[]";
@@ -106,6 +107,7 @@ mod tests {
                "~[~[], ~[1], ~[1, 1]]";
     }
 
+    #[test]
     fn test_pointer_types() {
         assert (@1).to_str() == "@1";
         assert (~(true, false)).to_str() == "~(true, false)";


### PR DESCRIPTION
It seems somebody forgot to add the proper attributes for the test suite to notice this.
