### PR TITLE
Add map::clear

### DIFF
--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -73,6 +73,9 @@ impl <V: copy> of map::map<uint, V> for smallintmap<V> {
         self.v.set_elt(key, none);
         old
     }
+    fn clear() {
+        self.v.set(~[mut]);
+    }
     fn contains_key(&&key: uint) -> bool {
         contains_key(self, key)
     }


### PR DESCRIPTION
Add clear to the map interface, and implement it in hashmap and smallintmap. This fixes #2775.

I didn't add anything to treemap, which notably doesn't implement map.

I tied my pull request to a specific commit this time instead of a branch; I'm not sure whether that's better, or whether I'll be able to change what commit, if I need to revise it. We'll see!
