### PR TITLE
Add extra buffalo.

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1948,11 +1948,11 @@ and one for values. This means that this code is valid:
 ~~~~
 mod buffalo {
     type buffalo = int;
-    fn buffalo(buffalo: buffalo) -> buffalo { buffalo }
+    fn buffalo<buffalo: copy>(buffalo: buffalo) -> buffalo { buffalo }
 }
 fn main() {
     let buffalo: buffalo::buffalo = 1;
-    buffalo::buffalo(buffalo::buffalo(buffalo));
+    buffalo::buffalo::<buffalo::buffalo>(buffalo::buffalo(buffalo));
 }
 ~~~~
 


### PR DESCRIPTION
The tutorial did not maximally buffalo.  Now it does.  (In particular, modules, values, and types were never on the same line.)
