### PR TITLE
Add a task::set_sched_mode function

### DIFF
--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -163,15 +163,11 @@ mod global_env {
         let builder_fn = || {
             let builder = task::builder();
             task::unsupervise(builder);
-            task::set_opts(builder, {
-                sched:  some({
-                    mode: task::single_threaded,
-                    // FIXME (#2621): This would be a good place to use a
-                    // very small foreign stack
-                    foreign_stack_size: none
-                })
-                with task::get_opts(builder)
-            });
+
+            // FIXME (#2621): This would be a good place to use a very small
+            // foreign stack
+            task::set_sched_mode(builder, task::single_threaded);
+
             builder
         };
         unsafe {

--- a/src/libcore/task.rs
+++ b/src/libcore/task.rs
@@ -38,6 +38,7 @@ export builder;
 export default_task_opts;
 export get_opts;
 export set_opts;
+export set_sched_mode;
 export add_wrapper;
 export run;
 
@@ -235,6 +236,16 @@ fn set_opts(builder: builder, opts: task_opts) {
      */
 
     builder.opts = opts;
+}
+
+fn set_sched_mode(builder: builder, mode: sched_mode) {
+    set_opts(builder, { 
+        sched: some({
+            mode: mode,
+            foreign_stack_size: none
+        })
+        with get_opts(builder)
+    });
 }
 
 fn add_wrapper(builder: builder, gen_body: fn@(+fn~()) -> fn~()) {
@@ -467,13 +478,7 @@ fn spawn_sched(mode: sched_mode, +f: fn~()) {
      */
 
     let mut builder = builder();
-    set_opts(builder, {
-        sched: some({
-            mode: mode,
-            foreign_stack_size: none
-        })
-        with get_opts(builder)
-    });
+    set_sched_mode(builder, mode);
     run(builder, f);
 }
 
@@ -1207,14 +1212,7 @@ fn test_avoid_copying_the_body_unsupervise() {
 #[test]
 fn test_osmain() {
     let buildr = builder();
-    let opts = {
-        sched: some({
-            mode: osmain,
-            foreign_stack_size: none
-        })
-        with get_opts(buildr)
-    };
-    set_opts(buildr, opts);
+    set_sched_mode(buildr, mode);
 
     let po = comm::port();
     let ch = comm::chan(po);

--- a/src/libstd/uv_global_loop.rs
+++ b/src/libstd/uv_global_loop.rs
@@ -40,14 +40,7 @@ fn get_monitor_task_gl() -> iotask unsafe {
 
     let builder_fn = || {
         let builder = task::builder();
-        task::set_opts(builder, {
-            supervise: false,
-            sched: some({
-                mode: task::single_threaded,
-                foreign_stack_size: none
-            })
-            with task::get_opts(builder)
-        });
+        task::set_sched_mode(builder, task::single_threaded);
         builder
     };
 

--- a/src/libstd/uv_iotask.rs
+++ b/src/libstd/uv_iotask.rs
@@ -25,19 +25,11 @@ enum iotask {
 
 fn spawn_iotask(-builder: task::builder) -> iotask {
 
-    import task::{set_opts, get_opts, single_threaded, run};
-
-    set_opts(builder, {
-        sched: some({
-            mode: single_threaded,
-            foreign_stack_size: none
-        })
-        with get_opts(builder)
-    });
+    task::set_sched_mode(builder, task::single_threaded);
 
     do listen |iotask_ch| {
 
-        do run(copy(builder)) {
+        do task::run(copy(builder)) {
             #debug("entering libuv task");
             run_loop(iotask_ch);
             #debug("libuv task exiting");


### PR DESCRIPTION
This gets rid of some of the boilerplate needed to spin up a thread in a custom scheduler.
