### PR TITLE
Fix an error compiling on centos 5

### DIFF
--- a/src/rt/rust_signal.h
+++ b/src/rt/rust_signal.h
@@ -5,6 +5,7 @@
 class rust_signal {
 public:
     virtual void signal() = 0;
+    virtual ~rust_signal() {}
 };
 
 #endif /* RUST_SIGNAL_H */


### PR DESCRIPTION
Unfortunately this doesn't get rust to compile on Centos 5. Centos 5 uses glibc 2.5, but the snapshot-0 needs glibc 2.6+. Here's the error from that:

```
x86_64-unknown-linux-gnu/stage0/bin/rustc: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.11' not found (required by /home/erickt/rust-0.3/x86_64-unknown-linux-gnu/stage0/bin/../lib/librustrt.so)
x86_64-unknown-linux-gnu/stage0/bin/rustc: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.9' not found (required by /home/erickt/rust-0.3/x86_64-unknown-linux-gnu/stage0/bin/../lib/librustrt.so)
x86_64-unknown-linux-gnu/stage0/bin/rustc: /lib64/libc.so.6: version `GLIBC_2.6' not found (required by /home/erickt/rust-0.3/x86_64-unknown-linux-gnu/stage0/bin/../lib/librustrt.so)
x86_64-unknown-linux-gnu/stage0/bin/rustc: /lib64/libc.so.6: version `GLIBC_2.9' not found (required by /home/erickt/rust-0.3/x86_64-unknown-linux-gnu/stage0/bin/../lib/librustrt.so)
x86_64-unknown-linux-gnu/stage0/bin/rustc: /lib64/libc.so.6: version `GLIBC_2.7' not found (required by /home/erickt/rust-0.3/x86_64-unknown-linux-gnu/stage0/bin/../lib/librustrt.so)
x86_64-unknown-linux-gnu/stage0/bin/rustc: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.9' not found (required by /home/erickt/rust-0.3/x86_64-unknown-linux-gnu/stage0/bin/../lib/./librustllvm.so)
make: *** [x86_64-unknown-linux-gnu/stage0/lib/rustc/x86_64-unknown-linux-gnu/lib/libcore.so] Error 1

```
