### PR TITLE
Add to_str for hashmap.

### DIFF
--- a/src/libstd/map.rs
+++ b/src/libstd/map.rs
@@ -1,6 +1,8 @@
 //! A map type
 
 import chained::hashmap;
+import io::writer_util;
+import to_str::to_str;
 export hashmap, hashfn, eqfn, set, map, chained, hashmap, str_hash;
 export box_str_hash;
 export bytes_hash, int_hash, uint_hash, set_add;
@@ -92,12 +94,13 @@ mod chained {
         absent
     }
 
-    type t<K, V> = @{
+    type inner<K, V> = {
         mut count: uint,
         mut chains: ~[mut chain<K,V>],
         hasher: hashfn<K>,
         eqer: eqfn<K>
     };
+    type t<K, V> = @inner<K, V>;
 
     enum search_result<K, V> {
         not_found,
@@ -105,7 +108,7 @@ mod chained {
         found_after(@entry<K,V>, @entry<K,V>)
     }
 
-    impl private_methods<K, V: copy> for t<K, V> {
+    impl private_methods<K, V: copy> for inner<K, V> {
         fn search_rem(k: K, h: uint, idx: uint,
                       e_root: @entry<K,V>) -> search_result<K,V> {
             let mut e0 = e_root;
@@ -275,6 +278,33 @@ mod chained {
 
         fn each_value(blk: fn(V) -> bool) { self.each(|_k, v| blk(v)) }
     }
+
+    impl hashmap<K: to_str, V: to_str copy> of to_str for inner<K, V> {
+        fn to_writer(wr: io::writer) {
+            if self.count == 0u {
+                wr.write_str("{}");
+                ret;
+            }
+
+            wr.write_str("{ ");
+            let mut first = true;
+            for self.each_entry |entry| {
+                if !first {
+                    wr.write_str(", ");
+                }
+                first = false;
+                wr.write_str(entry.key.to_str());
+                wr.write_str(": ");
+                wr.write_str((copy entry.value).to_str());
+            };
+            wr.write_str(" }");
+        }
+
+        fn to_str() -> str {
+            do io::with_str_writer |wr| { self.to_writer(wr) }
+        }
+    }
+
 
     fn chains<K,V>(nchains: uint) -> ~[mut chain<K,V>] {
         ret vec::to_mut(vec::from_elem(nchains, absent));


### PR DESCRIPTION
Fixes #2566.

I had to do a bit of refactoring to make this work, because there is already a to_str instance for \forall T.@T, and hashmap has type @{...}, so I couldn't make a to_str instance for hashmap. Instead, I factored out the raw record type as "inner", and put the to_str instance on that. This required moving the private helper methods onto inner as well, which I guess works fine because of magical auto-dereferencing when calling them.

The thing I most worry about is that I have somehow changed the memory layout / behavior of hashmaps by doing this, but I don't _think_ so.

There seems to be an aesthetic choice here between calling to_str on the keys and values, versus printing them with "%?". I chose the former as more consistent, but the latter produces slightly more useful output (printing strings quoted, e.g.) It seems like there should be a more unified notion of how to print things, somehow. Shouldn't "%?" be using the to_str iface, where present? Is there some iface it does use?

[Oh, and the actual printing code, which was the least trouble in this whole exercise, is stolen from the json module, which is why it uses a writer. I could do something else if it would be more idiomatic.]
