### PR TITLE
Change cont out of loop error to again out of loop

### DIFF
--- a/src/rustc/middle/check_loop.rs
+++ b/src/rustc/middle/check_loop.rs
@@ -35,7 +35,7 @@ fn check_crate(tcx: ty::ctxt, crate: @crate) {
               }
               expr_again {
                 if !cx.in_loop {
-                    tcx.sess.span_err(e.span, "`cont` outside of loop");
+                    tcx.sess.span_err(e.span, "`again` outside of loop");
                 }
               }
               expr_ret(oe) {


### PR DESCRIPTION
```
a.rs:2:1: 2:7 error: `cont` outside of loop
a.rs:2  again;
```

is now:

```
a.rs:2:1: 2:7 error: `again` outside of loop
a.rs:2  again;
```
