### PR TITLE
Better error when rustc fails to write output.

### DIFF
--- a/src/rustc/back/link.rs
+++ b/src/rustc/back/link.rs
@@ -1,4 +1,4 @@
-import libc::{c_int, c_uint};
+import libc::{c_int, c_uint, c_char};
 import driver::session;
 import session::session;
 import lib::llvm::llvm;
@@ -30,6 +30,21 @@ fn llvm_err(sess: session, msg: str) -> ! unsafe {
     if cstr == ptr::null() {
         sess.fatal(msg);
     } else { sess.fatal(msg + ": " + str::unsafe::from_c_str(cstr)); }
+}
+
+fn WriteOutputFile(sess:session,
+        PM: lib::llvm::PassManagerRef, M: ModuleRef,
+        Triple: *c_char,
+        // FIXME: When #2334 is fixed, change
+        // c_uint to FileType
+        Output: *c_char, FileType: c_uint,
+        OptLevel: c_int,
+        EnableSegmentedStacks: bool) {
+    let result = llvm::LLVMRustWriteOutputFile(
+            PM, M, Triple, Output, FileType, OptLevel, EnableSegmentedStacks);
+    if (!result) {
+        llvm_err(sess, "Could not write output");
+    }
 }
 
 mod write {
@@ -160,7 +175,8 @@ mod write {
                         sess.targ_cfg.target_strs.target_triple,
                         |buf_t| {
                             str::as_c_str(output, |buf_o| {
-                                llvm::LLVMRustWriteOutputFile(
+                                WriteOutputFile(
+                                    sess,
                                     pm.llpm,
                                     llmod,
                                     buf_t,
@@ -181,7 +197,8 @@ mod write {
                         sess.targ_cfg.target_strs.target_triple,
                         |buf_t| {
                             str::as_c_str(output, |buf_o| {
-                                llvm::LLVMRustWriteOutputFile(
+                                WriteOutputFile(
+                                    sess,
                                     pm.llpm,
                                     llmod,
                                     buf_t,
@@ -200,7 +217,8 @@ mod write {
                     sess.targ_cfg.target_strs.target_triple,
                     |buf_t| {
                         str::as_c_str(output, |buf_o| {
-                            llvm::LLVMRustWriteOutputFile(
+                            WriteOutputFile(
+                                sess,
                                 pm.llpm,
                                 llmod,
                                 buf_t,

--- a/src/rustc/lib/llvm.rs
+++ b/src/rustc/lib/llvm.rs
@@ -941,7 +941,7 @@ extern mod llvm {
                                // c_uint to FileType
                                Output: *c_char, FileType: c_uint,
                                OptLevel: c_int,
-                               EnableSegmentedStacks: bool);
+                               EnableSegmentedStacks: bool) -> bool;
 
     /** Returns a string describing the last error caused by an LLVMRust*
         call. */

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -75,7 +75,7 @@ extern "C" bool LLVMLinkModules(LLVMModuleRef Dest, LLVMModuleRef Src) {
   return true;
 }
 
-extern "C" void
+extern "C" bool
 LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
                         LLVMModuleRef M,
                         const char *triple,
@@ -107,6 +107,10 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
   std::string ErrorInfo;
   raw_fd_ostream OS(path, ErrorInfo,
                     raw_fd_ostream::F_Binary);
+  if (ErrorInfo != "") {
+    LLVMRustError = ErrorInfo.c_str();
+    return false;
+  }
   formatted_raw_ostream FOS(OS);
 
   bool foo = Target->addPassesToEmitFile(*PM, FOS, FileType, NoVerify);
@@ -114,6 +118,7 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
   (void)foo;
   PM->run(*unwrap(M));
   delete Target;
+  return true;
 }
 
 extern "C" LLVMModuleRef LLVMRustParseAssemblyFile(const char *Filename) {


### PR DESCRIPTION
For bug #2360. When we construct our raw_fd_ostream for the output file in our LLVM wrapper, stop ignoring the error output.
