### PR TITLE
Tutorial: Added note about type parameters in ifaces.

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2508,6 +2508,18 @@ Note that functions do not explicitly have the type parameters that
 are provided by the iface. It will cause a compile-time error if you
 include them in the iface or impl.
 
+## Use of the type `self` in interfaces
+
+Interfaces may use `self` as a type where the implementation uses its
+own type. This defines an interface for testing equality of a type with
+itself:
+
+~~~~
+iface eq {
+  fn equals(other: self) -> bool;
+}
+~~~~
+
 ## Casting to an interface type
 
 The above allows us to define functions that polymorphically act on

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2504,6 +2504,10 @@ needed because it could also, for example, specify an implementation
 of `seq<int>`—the `of` clause *refers* to a type, rather than defining
 one.
 
+Note that functions do not explicitly have the type parameters that 
+are provided by the iface. It will cause a compile-time error if you
+include them in the iface or impl.
+
 ## Casting to an interface type
 
 The above allows us to define functions that polymorphically act on


### PR DESCRIPTION
Specficially, the type parameters should be left off of the function
signatures in both the iface and the impl if they are already in the
iface declaration.
