### PR TITLE
'again' keyword

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -12,8 +12,8 @@ endif
 
 syn keyword   rustAssert      assert
 syn match     rustAssert      "assert\(\w\)*"
-syn keyword   rustKeyword     alt as break
-syn keyword   rustKeyword     check claim cont const copy do drop else export extern fail
+syn keyword   rustKeyword     again alt as break
+syn keyword   rustKeyword     check claim const copy do drop else export extern fail
 syn keyword   rustKeyword     for if impl import in let log
 syn keyword   rustKeyword     loop mod mut new of pure
 syn keyword   rustKeyword     ret self to unchecked

--- a/src/rustc/middle/check_loop.rs
+++ b/src/rustc/middle/check_loop.rs
@@ -35,7 +35,7 @@ fn check_crate(tcx: ty::ctxt, crate: @crate) {
               }
               expr_again {
                 if !cx.in_loop {
-                    tcx.sess.span_err(e.span, "`cont` outside of loop");
+                    tcx.sess.span_err(e.span, "`again` outside of loop");
                 }
               }
               expr_ret(oe) {


### PR DESCRIPTION
- Fixed Vim syntax file to highlight 'again'; removed 'cont'.
- Fixed compiler error string (used to show 'again' instead of 'cont').
