### PR TITLE
Allow io::reader to use preallocated buffers, plus other misc changes

### DIFF
--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -1,6 +1,7 @@
 //! Process spawning
 import option::{some, none};
 import libc::{pid_t, c_void, c_int};
+import io::reader_util;
 
 export program;
 export run_program;

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -27,7 +27,7 @@ export init;
 export last;
 export last_opt;
 export slice;
-export view;
+export view, mut_view, const_view;
 export split;
 export splitn;
 export rsplit;
@@ -315,6 +315,30 @@ pure fn slice<T: copy>(v: &[const T], start: uint, end: uint) -> ~[T] {
 
 /// Return a slice that points into another slice.
 pure fn view<T>(v: &[T], start: uint, end: uint) -> &[T] {
+    assert (start <= end);
+    assert (end <= len(v));
+    do unpack_slice(v) |p, _len| {
+        unsafe {
+            ::unsafe::reinterpret_cast(
+                (ptr::offset(p, start), (end - start) * sys::size_of::<T>()))
+        }
+    }
+}
+
+/// Return a slice that points into another slice.
+pure fn mut_view<T>(v: &[mut T], start: uint, end: uint) -> &[mut T] {
+    assert (start <= end);
+    assert (end <= len(v));
+    do unpack_slice(v) |p, _len| {
+        unsafe {
+            ::unsafe::reinterpret_cast(
+                (ptr::offset(p, start), (end - start) * sys::size_of::<T>()))
+        }
+    }
+}
+
+/// Return a slice that points into another slice.
+pure fn const_view<T>(v: &[const T], start: uint, end: uint) -> &[const T] {
     assert (start <= end);
     assert (end <= len(v));
     do unpack_slice(v) |p, _len| {

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -1598,6 +1598,34 @@ mod unsafe {
             ::unsafe::reinterpret_cast(ptr::addr_of(pair));
         f(*v)
     }
+
+    /**
+      * Copies data from one vector to another.
+      *
+      * Copies `count` bytes from `src` to `dst`. The source and destination
+      * may overlap.
+      */
+    unsafe fn memcpy<T>(dst: &[mut T], src: &[const T], count: uint) {
+        do unpack_slice(dst) |p_dst, _len_dst| {
+            do unpack_slice(src) |p_src, _len_src| {
+                ptr::memcpy(p_dst, p_src, count)
+            }
+        }
+    }
+
+    /**
+      * Copies data from one vector to another.
+      *
+      * Copies `count` bytes from `src` to `dst`. The source and destination
+      * may overlap.
+      */
+    unsafe fn memmove<T>(dst: &[mut T], src: &[const T], count: uint) {
+        do unpack_slice(dst) |p_dst, _len_dst| {
+            do unpack_slice(src) |p_src, _len_src| {
+                ptr::memmove(p_dst, p_src, count)
+            }
+        }
+    }
 }
 
 /// Operations on `[u8]`
@@ -1605,6 +1633,7 @@ mod u8 {
     export cmp;
     export lt, le, eq, ne, ge, gt;
     export hash;
+    export memcpy, memmove;
 
     /// Bytewise string comparison
     pure fn cmp(&&a: ~[u8], &&b: ~[u8]) -> int {
@@ -1654,6 +1683,32 @@ mod u8 {
         let mut u: uint = 5381u;
         vec::iter(s, |c| {u *= 33u; u += c as uint;});
         ret u;
+    }
+
+    /**
+      * Copies data from one vector to another.
+      *
+      * Copies `count` bytes from `src` to `dst`. The source and destination
+      * may not overlap.
+      */
+    fn memcpy(dst: &[mut u8], src: &[const u8], count: uint) {
+        assert dst.len() >= count;
+        assert src.len() >= count;
+
+        unsafe { vec::unsafe::memcpy(dst, src, count) }
+    }
+
+    /**
+      * Copies data from one vector to another.
+      *
+      * Copies `count` bytes from `src` to `dst`. The source and destination
+      * may overlap.
+      */
+    fn memmove(dst: &[mut u8], src: &[const u8], count: uint) {
+        assert dst.len() >= count;
+        assert src.len() >= count;
+
+        unsafe { vec::unsafe::memmove(dst, src, count) }
     }
 }
 

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -313,7 +313,7 @@ pure fn slice<T: copy>(v: &[const T], start: uint, end: uint) -> ~[T] {
     ret result;
 }
 
-#[doc = "Return a slice that points into another slice."]
+/// Return a slice that points into another slice.
 pure fn view<T>(v: &[T], start: uint, end: uint) -> &[T] {
     assert (start <= end);
     assert (end <= len(v));

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -651,7 +651,6 @@ fn grow_set<T: copy>(&v: ~[mut T], index: uint, initval: T, val: T) {
     v[index] = val;
 }
 
-
 // Functional utilities
 
 /// Apply a function to each element of a vector and return the results

--- a/src/test/auxiliary/issue-2526.rs
+++ b/src/test/auxiliary/issue-2526.rs
@@ -1,4 +1,4 @@
-#[link(name = "zmq",
+#[link(name = "issue_2526",
        vers = "0.2",
        uuid = "54cc1bc9-02b8-447c-a227-75ebc923bc29")];
 #[crate_type = "lib"];

--- a/src/test/run-pass/issue-2526-a.rs
+++ b/src/test/run-pass/issue-2526-a.rs
@@ -1,8 +1,8 @@
 // xfail-fast
 // aux-build:issue-2526.rs
 
-use zmq;
-import zmq::*;
+use issue_2526;
+import issue_2526::*;
 
 fn main() {}
 


### PR DESCRIPTION
This theoretically should speed up `io::reader` hotpaths by eliminating the need for a malloc per loop. Plus it comes with a memcpy/memmove that works over slices.
