### PR TITLE
Allow configuring to use llvm-root with 3.0, 3.0svn, 3.1, 3.1svn

### DIFF
--- a/configure
+++ b/configure
@@ -378,7 +378,7 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-	(3.1svn)
+	(3.1svn|3.1|3.0svn|3.0)
 	    msg "found ok version of LLVM: $LLVM_VERSION"
 	    ;;
 	(*)

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -76,9 +76,9 @@ extern "C" bool LLVMLinkModules(LLVMModuleRef Dest, LLVMModuleRef Src) {
 }
 
 void LLVMInitializeX86TargetInfo();
-void LLVMInitializeX86TargetMCs();
-void LLVMInitializeX86AsmPrinters();
-void LLVMInitializeX86AsmParsers();
+void LLVMInitializeX86TargetMC();
+void LLVMInitializeX86AsmPrinter();
+void LLVMInitializeX86AsmParser();
 
 extern "C" bool
 LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
@@ -95,9 +95,9 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
   // into the registry that Rust can not generate machine code for.
 
   LLVMInitializeX86TargetInfo();
-  LLVMInitializeX86TargetMCs();
-  LLVMInitializeX86AsmPrinters();
-  LLVMInitializeX86AsmParsers();
+  LLVMInitializeX86TargetMC();
+  LLVMInitializeX86AsmPrinter();
+  LLVMInitializeX86AsmParser();
 
   TargetOptions Options;
   Options.NoFramePointerElim = true;

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -84,10 +84,15 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
                         CodeGenOpt::Level OptLevel,
 			bool EnableSegmentedStacks) {
 
-  InitializeAllTargets();
-  InitializeAllTargetMCs();
-  InitializeAllAsmPrinters();
-  InitializeAllAsmParsers();
+  // Only initialize the platforms supported by Rust here,
+  // because using --llvm-root will have multiple platforms
+  // that rustllvm doesn't actually link to and it's pointless to put target info
+  // into the registry that Rust can not generate machine code for.
+
+  LLVMInitializeX86TargetInfo();
+  LLVMInitializeX86TargetMCs();
+  LLVMInitializeX86AsmPrinters();
+  LLVMInitializeX86AsmParsers();
 
   TargetOptions Options;
   Options.NoFramePointerElim = true;

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -75,6 +75,11 @@ extern "C" bool LLVMLinkModules(LLVMModuleRef Dest, LLVMModuleRef Src) {
   return true;
 }
 
+void LLVMInitializeX86TargetInfo();
+void LLVMInitializeX86TargetMCs();
+void LLVMInitializeX86AsmPrinters();
+void LLVMInitializeX86AsmParsers();
+
 extern "C" bool
 LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
                         LLVMModuleRef M,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -76,6 +76,7 @@ extern "C" bool LLVMLinkModules(LLVMModuleRef Dest, LLVMModuleRef Src) {
 }
 
 void LLVMInitializeX86TargetInfo();
+void LLVMInitializeX86Target();
 void LLVMInitializeX86TargetMC();
 void LLVMInitializeX86AsmPrinter();
 void LLVMInitializeX86AsmParser();
@@ -95,6 +96,7 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
   // into the registry that Rust can not generate machine code for.
 
   LLVMInitializeX86TargetInfo();
+  LLVMInitializeX86Target();
   LLVMInitializeX86TargetMC();
   LLVMInitializeX86AsmPrinter();
   LLVMInitializeX86AsmParser();

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -390,6 +390,8 @@ LLVMInitializeX86Disassembler
 LLVMInitializeX86Disassembler
 LLVMInitializeX86Target
 LLVMInitializeX86Target
+LLVMInitializeX86TargetMC
+LLVMInitializeX86TargetMC
 LLVMInitializeX86TargetInfo
 LLVMInitializeX86TargetInfo
 LLVMInsertBasicBlock


### PR DESCRIPTION
This is a few patches that allows using `llvm-root` with SVN and stable releases. This allows people to use a globally installed LLVM, which didn't work before because of the following reasons:
- `llvm-root` didn't accept the straight 3.1 and 3.0 releases. I've changed the configure script to allow 3.0, 3.0svn, 3.1 and 3.1svn. I'm not sure if 3.0 actually even works, but I just assumed it did because of the error message that was already there.
- `RustWrapper.cc` was initializing all targets whereas `rustllvm.def.in` was only linking to X86 (including X86_64) because that's all Rust supports generating machine code for. I've changed `RustWrapper.cc` to only initialize the targets that Rust currently actually supports.

I am not entirely sure of the status of ARM in Rust (I see a few mentions of it in the source code), so I'm not sure whether that should be initialized / linked in as well (it is currently not linked into in `rustllvm.def.in`). Another thing is `rustllvm.def.in` has repeated mentions of the X86 initialization functions, I'm not sure whether that is intentional or not.
