### PR TITLE
Add rustrt wrapper functions to export list.

### DIFF
--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -86,6 +86,11 @@ upcall_del_stack
 upcall_reset_stack_limit
 upcall_exchange_malloc
 upcall_exchange_free
+rust_upcall_exchange_free
+rust_upcall_exchange_malloc
+rust_upcall_fail
+rust_upcall_free
+rust_upcall_malloc
 rust_uv_loop_new
 rust_uv_loop_delete
 rust_uv_loop_refcount


### PR DESCRIPTION
Fixes the build for 874b2f1ed5f29b634292772ec1b05497838526aa
