### PR TITLE
Add debug flag to turn off landing pads.

### DIFF
--- a/src/rustc/driver/session.rs
+++ b/src/rustc/driver/session.rs
@@ -39,6 +39,7 @@ const coherence: uint = 512u;
 const borrowck_stats: uint = 1024u;
 const borrowck_note_pure: uint = 2048;
 const borrowck_note_loan: uint = 4096;
+const no_landing_pads: uint = 8192;
 
 fn debugging_opts_map() -> ~[(~str, ~str, uint)] {
     ~[(~"ppregions", ~"prettyprint regions with \
@@ -58,7 +59,9 @@ fn debugging_opts_map() -> ~[(~str, ~str, uint)] {
      (~"borrowck-note-pure", ~"note where purity is req'd",
       borrowck_note_pure),
      (~"borrowck-note-loan", ~"note where loans are req'd",
-      borrowck_note_loan)
+      borrowck_note_loan),
+     (~"no-landing-pads", ~"omit landing pads for unwinding",
+      no_landing_pads)
     ]
 }
 

--- a/src/rustc/middle/trans/base.rs
+++ b/src/rustc/middle/trans/base.rs
@@ -3224,6 +3224,10 @@ fn invoke(bcx: block, llfn: ValueRef, llargs: ~[ValueRef]) -> block {
 }
 
 fn need_invoke(bcx: block) -> bool {
+    if (bcx.ccx().sess.opts.debugging_opts & session::no_landing_pads != 0) {
+        ret false;
+    }
+
     if have_cached_lpad(bcx) {
         ret true;
     }


### PR DESCRIPTION
This would be really useful for #2997, where I can't make a clean build without having this feature in a snapshot.
