### PR TITLE
Fix formatting of multiline code blocks in asm-comments

### DIFF
--- a/src/rustc/middle/trans/build.rs
+++ b/src/rustc/middle/trans/build.rs
@@ -653,7 +653,7 @@ fn add_comment(bcx: block, text: ~str) {
     let ccx = bcx.ccx();
     if !ccx.sess.no_asm_comments() {
         let sanitized = str::replace(text, ~"$", ~"");
-        let comment_text = ~"# " + sanitized;
+        let comment_text = ~"# " + str::replace(sanitized, ~"\n", ~"\n\t# ");
         let asm = str::as_c_str(comment_text, |c| {
             str::as_c_str(~"", |e| {
                 count_insn(bcx, ~"inlineasm");


### PR DESCRIPTION
When building with -S, the rust source code for each is included as a comment in an InlineAsm block.  However, if the code block contains new-lines, the only the first line ends up being correctly commented and indented.  This patch updates the comment sanitizing code to deal correctly with newlines.
