### PR TITLE
Don't emit invoke instructions inside landing pads.

### DIFF
--- a/src/libcore/rt.rs
+++ b/src/libcore/rt.rs
@@ -37,6 +37,9 @@ fn rt_exchange_malloc(td: *c_char, size: uintptr_t) -> *c_char {
     ret rustrt::rust_upcall_exchange_malloc(td, size);
 }
 
+// NB: Calls to free CANNOT be allowed to fail, as throwing an exception from
+// inside a landing pad may corrupt the state of the exception handler. If a
+// problem occurs, call exit instead.
 #[rt(exchange_free)]
 fn rt_exchange_free(ptr: *c_char) {
     rustrt::rust_upcall_exchange_free(ptr);
@@ -47,6 +50,9 @@ fn rt_malloc(td: *c_char, size: uintptr_t) -> *c_char {
     ret rustrt::rust_upcall_malloc(td, size);
 }
 
+// NB: Calls to free CANNOT be allowed to fail, as throwing an exception from
+// inside a landing pad may corrupt the state of the exception handler. If a
+// problem occurs, call exit instead.
 #[rt(free)]
 fn rt_free(ptr: *c_char) {
     rustrt::rust_upcall_free(ptr);

--- a/src/rustc/middle/trans/closure.rs
+++ b/src/rustc/middle/trans/closure.rs
@@ -319,7 +319,7 @@ fn load_environment(fcx: fn_ctxt,
                     load_ret_handle: bool,
                     ck: ty::closure_kind) {
     let _icx = fcx.insn_ctxt(~"closure::load_environment");
-    let bcx = raw_block(fcx, fcx.llloadenv);
+    let bcx = raw_block(fcx, false, fcx.llloadenv);
 
     // Load a pointer to the closure data, skipping over the box header:
     let llcdata = base::opaque_box_body(bcx, cdata_ty, fcx.llenv);

--- a/src/rustc/middle/trans/common.rs
+++ b/src/rustc/middle/trans/common.rs
@@ -393,17 +393,19 @@ class block_ {
     let parent: option<block>;
     // The 'kind' of basic block this is.
     let kind: block_kind;
+    // Is this block part of a landing pad?
+    let is_lpad: bool;
     // info about the AST node this block originated from, if any
     let node_info: option<node_info>;
     // The function context for the function to which this block is
     // attached.
     let fcx: fn_ctxt;
     new(llbb: BasicBlockRef, parent: option<block>, -kind: block_kind,
-        node_info: option<node_info>, fcx: fn_ctxt) {
+        is_lpad: bool, node_info: option<node_info>, fcx: fn_ctxt) {
         // sigh
         self.llbb = llbb; self.terminated = false; self.unreachable = false;
-        self.parent = parent; self.kind = kind; self.node_info = node_info;
-        self.fcx = fcx;
+        self.parent = parent; self.kind = kind; self.is_lpad = is_lpad;
+        self.node_info = node_info; self.fcx = fcx;
     }
 }
 
@@ -412,8 +414,9 @@ class block_ {
 enum block = @block_;
 
 fn mk_block(llbb: BasicBlockRef, parent: option<block>, -kind: block_kind,
-         node_info: option<node_info>, fcx: fn_ctxt) -> block {
-   block(@block_(llbb, parent, kind, node_info, fcx))
+            is_lpad: bool, node_info: option<node_info>, fcx: fn_ctxt)
+    -> block {
+    block(@block_(llbb, parent, kind, is_lpad, node_info, fcx))
 }
 
 // First two args are retptr, env

--- a/src/rustc/middle/trans/foreign.rs
+++ b/src/rustc/middle/trans/foreign.rs
@@ -537,7 +537,7 @@ fn build_wrap_fn_(ccx: @crate_ctxt,
     tie_up_header_blocks(fcx, lltop);
 
     // Make sure our standard return block (that we didn't use) is terminated
-    let ret_cx = raw_block(fcx, fcx.llreturn);
+    let ret_cx = raw_block(fcx, false, fcx.llreturn);
     Unreachable(ret_cx);
 }
 


### PR DESCRIPTION
We can't throw an exception from inside a landing pad without
corrupting the exception handler, so we have no hope of dealing with
these exceptions anyway. See:

http://llvm.org/docs/ExceptionHandling.html#cleanups

Part of #2861.
