### PR TITLE
Only print colored error messages if the output is going to the screen

### DIFF
--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -840,6 +840,9 @@ impl tcp_socket_buf of io::writer for @tcp_socket_buf {
     fn flush() -> int {
         0
     }
+    fn get_type() -> io::writer_type {
+        io::file
+    }
 }
 
 // INTERNAL API

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -163,14 +163,16 @@ fn diagnosticcolor(lvl: level) -> u8 {
 }
 
 fn print_diagnostic(topic: ~str, lvl: level, msg: ~str) {
+    let use_color = term::color_supported() &&
+        io::stderr().get_type() == io::screen;
     if str::is_not_empty(topic) {
         io::stderr().write_str(#fmt["%s ", topic]);
     }
-    if term::color_supported() {
+    if use_color {
         term::fg(io::stderr(), diagnosticcolor(lvl));
     }
     io::stderr().write_str(#fmt["%s:", diagnosticstr(lvl)]);
-    if term::color_supported() {
+    if use_color {
         term::reset(io::stderr());
     }
     io::stderr().write_str(#fmt[" %s\n", msg]);

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -88,6 +88,7 @@ impl of io::writer for devnull {
     fn seek(_i: int, _s: io::seek_style) {}
     fn tell() -> uint {0_u}
     fn flush() -> int {0}
+    fn get_type() -> io::writer_type { io::file }
 }
 
 fn writer(path: ~str, writech: comm::chan<comm::chan<line>>, size: uint)


### PR DESCRIPTION
Most tools print color if isatty() returns true.  This patch adds an io::writer.get_type() method that gives hints as to the underlying writer type.  The diagnostics code then uses this to determine if it should print in colour or not.
