### PR TITLE
fix the hello world example in tutorial

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -209,8 +209,8 @@ Rust program files are, by convention, given the extension `.rs`. Say
 we have a file `hello.rs` containing this program:
 
 ~~~~
-fn main(args: ~[~str]) {
-    io::println(~"hello world from '" + args[0] + ~"'!");
+fn main(args: ~[str]) {
+    io::println(~"hello world from '" + args[0] + "'!");
 }
 ~~~~
 


### PR DESCRIPTION
the hello world example in the tutorial is wrong and does not compile.

this patch makes it compile and run.
