### PR TITLE
rustc: Strict enforcement of glue function types.

### DIFF
--- a/src/rustc/middle/trans/closure.rs
+++ b/src/rustc/middle/trans/closure.rs
@@ -492,7 +492,7 @@ fn make_opaque_cbox_drop_glue(
                                ty::mk_opaque_closure_ptr(bcx.tcx(), ck))
       }
       ty::ck_uniq => {
-        free_ty(bcx, Load(bcx, cboxptr),
+        free_ty(bcx, cboxptr,
                 ty::mk_opaque_closure_ptr(bcx.tcx(), ck))
       }
     }
@@ -501,7 +501,7 @@ fn make_opaque_cbox_drop_glue(
 fn make_opaque_cbox_free_glue(
     bcx: block,
     ck: ty::closure_kind,
-    cbox: ValueRef)     // ptr to the opaque closure
+    cbox: ValueRef)     // ptr to ptr to the opaque closure
     -> block {
     let _icx = bcx.insn_ctxt(~"closure::make_opaque_cbox_free_glue");
     match ck {
@@ -513,7 +513,7 @@ fn make_opaque_cbox_free_glue(
     do with_cond(bcx, IsNotNull(bcx, cbox)) |bcx| {
         // Load the type descr found in the cbox
         let lltydescty = T_ptr(ccx.tydesc_type);
-        let cbox = PointerCast(bcx, cbox, T_opaque_cbox_ptr(ccx));
+        let cbox = Load(bcx, cbox);
         let tydescptr = GEPi(bcx, cbox, ~[0u, abi::box_field_tydesc]);
         let tydesc = Load(bcx, tydescptr);
         let tydesc = PointerCast(bcx, tydesc, lltydescty);

--- a/src/rustc/middle/trans/common.rs
+++ b/src/rustc/middle/trans/common.rs
@@ -655,7 +655,7 @@ fn T_tydesc_field(cx: @crate_ctxt, field: uint) -> TypeRef unsafe {
     return t;
 }
 
-fn T_glue_fn(cx: @crate_ctxt) -> TypeRef {
+fn T_generic_glue_fn(cx: @crate_ctxt) -> TypeRef {
     let s = ~"glue_fn";
     match name_has_type(cx.tn, s) {
       some(t) => return t,

--- a/src/rustc/middle/trans/tvec.rs
+++ b/src/rustc/middle/trans/tvec.rs
@@ -175,10 +175,13 @@ fn trans_evec(bcx: block, elements: evec_elements,
             let ty = ty::mk_evec(bcx.tcx(),
                                  {ty: unit_ty, mutbl: ast::m_mutbl},
                                  ty::vstore_fixed(count));
+            let llty = T_ptr(type_of::type_of(bcx.ccx(), ty));
 
             let n = C_uint(ccx, count);
             let vp = base::arrayalloca(bcx, llunitty, n);
-            add_clean(bcx, vp, ty);
+            // Cast to the fake type we told cleanup to expect.
+            let vp0 = BitCast(bcx, vp, llty);
+            add_clean(bcx, vp0, ty);
 
             let len = Mul(bcx, n, unit_sz);
 

--- a/src/rustc/middle/trans/type_of.rs
+++ b/src/rustc/middle/trans/type_of.rs
@@ -10,6 +10,7 @@ export type_of_dtor;
 export type_of_explicit_args;
 export type_of_fn_from_ty;
 export type_of_fn;
+export type_of_glue_fn;
 export type_of_non_gc_box;
 
 fn type_of_explicit_args(cx: @crate_ctxt,
@@ -244,3 +245,9 @@ fn type_of_dtor(ccx: @crate_ctxt, self_ty: ty::t) -> TypeRef {
          llvm::LLVMVoidType())
 }
 
+fn type_of_glue_fn(ccx: @crate_ctxt, t: ty::t) -> TypeRef {
+    let tydescpp = T_ptr(T_ptr(ccx.tydesc_type));
+    let llty = T_ptr(type_of(ccx, t));
+    return T_fn(~[T_ptr(T_nil()), T_ptr(T_nil()), tydescpp, llty],
+                T_void());
+}

--- a/src/rustc/middle/trans/uniq.rs
+++ b/src/rustc/middle/trans/uniq.rs
@@ -7,9 +7,10 @@ import shape::llsize_of;
 
 export make_free_glue, autoderef, duplicate;
 
-fn make_free_glue(bcx: block, vptr: ValueRef, t: ty::t)
+fn make_free_glue(bcx: block, vptrptr: ValueRef, t: ty::t)
     -> block {
     let _icx = bcx.insn_ctxt(~"uniq::make_free_glue");
+    let vptr = Load(bcx, vptrptr);
     do with_cond(bcx, IsNotNull(bcx, vptr)) |bcx| {
         let content_ty = content_ty(t);
         let body_ptr = opaque_box_body(bcx, content_ty, vptr);


### PR DESCRIPTION
Make all glue functions take values by alias to remove the need for
bitcasts at the top of every glue function. Use static type
information to produce the correct type for glue functions so that
LLVM can enforce the type system at call sites.
