### PR TITLE
Add spawn_conversation

### DIFF
--- a/src/libcore/priv.rs
+++ b/src/libcore/priv.rs
@@ -40,9 +40,8 @@ unsafe fn chan_from_global_ptr<T: send>(
         log(debug,~"is probably zero...");
         // There's no global channel. We must make it
 
-        let setup_po = comm::port();
-        let setup_ch = comm::chan(setup_po);
-        let setup_ch = do task_fn().spawn_listener |setup_po| {
+        let (setup_po, setup_ch) = do task_fn().spawn_conversation
+            |setup_po, setup_ch| {
             let po = comm::port::<T>();
             let ch = comm::chan(po);
             comm::send(setup_ch, ch);

--- a/src/rustdoc/page_pass.rs
+++ b/src/rustdoc/page_pass.rs
@@ -29,9 +29,8 @@ fn run(
         return doc;
     }
 
-    let result_port = comm::port();
-    let result_chan = comm::chan(result_port);
-    let page_chan = do task::spawn_listener |page_port| {
+    let (result_port, page_chan) = do task::spawn_conversation
+        |page_port, result_chan| {
         comm::send(result_chan, make_doc_from_pages(page_port));
     };
 

--- a/src/test/bench/msgsend.rs
+++ b/src/test/bench/msgsend.rs
@@ -28,15 +28,12 @@ fn server(requests: comm::port<request>, responses: comm::chan<uint>) {
 }
 
 fn run(args: ~[~str]) {
-    let from_child = comm::port();
-    let to_parent = comm::chan(from_child);
-    let to_child = do task::spawn_listener |po| {
-        server(po, to_parent);
+    let (from_child, to_child) = do task::spawn_conversation |po, ch| {
+        server(po, ch);
     };
     let size = option::get(uint::from_str(args[1]));
     let workers = option::get(uint::from_str(args[2]));
     let start = std::time::precise_time_s();
-    let to_child = to_child;
     let mut worker_results = ~[];
     for uint::range(0u, workers) |_i| {
         do task::task().future_result(|+r| {
@@ -65,7 +62,7 @@ fn main(args: ~[~str]) {
         ~[~"", ~"10000", ~"4"]
     } else {
         args
-    };        
+    };
 
     debug!{"%?", args};
     run(args);


### PR DESCRIPTION
Adds a convenience function for bidirectional communication. This lets programmers avoid boilerplate that's prone to mistakes and/or variable shadowing.
