### PR TITLE
Pretty printing for closures - much better.

### DIFF
--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -254,7 +254,8 @@ impl printer {
                 self.left = 0u;
                 self.right = 0u;
             } else { self.advance_right(); }
-            debug!{"pp BEGIN/buffer ~[%u,%u]", self.left, self.right};
+            debug!{"pp BEGIN(%d)/buffer ~[%u,%u]",
+                   b.offset, self.left, self.right};
             self.token[self.right] = t;
             self.size[self.right] = -self.right_total;
             self.scan_push(self.right);
@@ -278,7 +279,8 @@ impl printer {
                 self.left = 0u;
                 self.right = 0u;
             } else { self.advance_right(); }
-            debug!{"pp BREAK/buffer ~[%u,%u]", self.left, self.right};
+            debug!{"pp BREAK(%d)/buffer ~[%u,%u]",
+                   b.offset, self.left, self.right};
             self.check_stack(0);
             self.scan_push(self.right);
             self.token[self.right] = t;
@@ -287,10 +289,12 @@ impl printer {
           }
           STRING(s, len) => {
             if self.scan_stack_empty {
-                debug!{"pp STRING/print ~[%u,%u]", self.left, self.right};
+                debug!{"pp STRING('%s')/print ~[%u,%u]",
+                       *s, self.left, self.right};
                 self.print(t, len);
             } else {
-                debug!{"pp STRING/buffer ~[%u,%u]", self.left, self.right};
+                debug!{"pp STRING('%s')/buffer ~[%u,%u]",
+                       *s, self.left, self.right};
                 self.advance_right();
                 self.token[self.right] = t;
                 self.size[self.right] = len;
@@ -444,22 +448,25 @@ impl printer {
             let top = self.get_top();
             match top.pbreak {
               fits => {
-                debug!{"print BREAK in fitting block"};
+                debug!{"print BREAK(%d) in fitting block", b.blank_space};
                 self.space -= b.blank_space;
                 self.indent(b.blank_space);
               }
               broken(consistent) => {
-                debug!{"print BREAK in consistent block"};
+                debug!{"print BREAK(%d+%d) in consistent block",
+                       top.offset, b.offset};
                 self.print_newline(top.offset + b.offset);
                 self.space = self.margin - (top.offset + b.offset);
               }
               broken(inconsistent) => {
                 if L > self.space {
-                    debug!{"print BREAK w/ newline in inconsistent"};
+                    debug!{"print BREAK(%d+%d) w/ newline in inconsistent",
+                           top.offset, b.offset};
                     self.print_newline(top.offset + b.offset);
                     self.space = self.margin - (top.offset + b.offset);
                 } else {
-                    debug!{"print BREAK w/o newline in inconsistent"};
+                    debug!{"print BREAK(%d) w/o newline in inconsistent",
+                           b.blank_space};
                     self.indent(b.blank_space);
                     self.space -= b.blank_space;
                 }
@@ -467,7 +474,7 @@ impl printer {
             }
           }
           STRING(s, len) => {
-            debug!{"print STRING"};
+            debug!{"print STRING(%s)", *s};
             assert (L == len);
             // assert L <= space;
             self.space -= len;


### PR DESCRIPTION
The way the pretty printer currently handles closures is distinctly unsatisfying (the elipsis are to indicate that there is enough content so that the entire expression cannot fit on a single line; if it could, things would look fine):

```
fn main() {
    do foo(bar) |a|
                    {
                        baa...z;
                    }
    for foo(bar) |a|
                    {
                        baz;
                        ...
                        baz;
                    }
    let f =
        |a|
            {
                foo;
                ...
                foo;
            };
}
```

What is happening is that the entire closure is wrapped in a pretty printing box; since it can't fit on the line with the do / for, it starts printing it and then has to break the line, and it indents relative to that, so the block is 4 spaces in from the beginning of the closure. A lot better, in my opinion (and how I think a person would write it), is:

```
fn main() {
    do foo(bar) |a| {
        baa...z;
    }
    for foo(bar) |a| {
        baz;
        ...
        baz;
    }
    let f = |a| {
        foo;
        ...
        foo;
    };
}
```

That is, the indentation is keyed on the beginning of the expression. Ideally, the way the boxes would be arranged is that the closure argument would be absorbed into the "head" box that has the do/for/let, but writing the code that way seemed to involve more code complexity, as we need to be looking for closures before we actually see the AST expression for them.

What I did, and this pull request implements, fixes the formatting for do and for expressions (they look exactly like the "desired" output). It does this by eliminating the surrounding block (which involved a little bit of refactoring to allow you to close brackets without having a surrounding box to close). It does not fix the let expression - the arguments for the closure start on the following line. I'm actually not sure why this is happening; it might be something with an easy fix. The output of the code that this pull request adds is the following:

```
fn main() {
    do foo(bar) |a| {
        baa...z;
    }
    for foo(bar) |a| {
        baz;
        ...
        baz;
    }
    let f = 
        |a| {
        foo;
        ...
        foo;
    };
}
```

I'm not sure if this is the best approach - this is the first that I've dealt with the AST or the pretty printer, so I could be doing something non-optimally. Hopefully people can given feedback on the code / how it works. 

The diff includes some changes to libsyntax/print/pp.rs to make the debug output more verbose - this was helpful to me as someone unfamiliar with the code, and so seem to make sense. The rest is changes to libsyntax/print/pprust.rs, based on the changes described.
