### PR TITLE
Removed comma from rust-mode.el

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -53,8 +53,8 @@
 (defvar rust-value-keywords
   (let ((table (make-hash-table :test 'equal)))
     (dolist (word '("mod" "const" "class" "type"
-					"trait" "struct", "fn" "enum"
-					"impl"))
+                    "trait" "struct" "fn" "enum"
+                    "impl"))
       (puthash word 'def table))
     (dolist (word '("again" "assert"
                     "break"


### PR DESCRIPTION
The "fn" keyword wasn’t highlighted so I checked the rust-mode.el and it had a comma placed directly before it.

``` lisp
(dolist (word '("mod" "const" "class" "type"
                      "trait" "struct", "fn" "enum"
                       "impl"))
```

I assume this was accidentally placed there. If not ignore this pull request.
