### PR TITLE
Removed comma from rust-mode.el 

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -53,8 +53,8 @@
 (defvar rust-value-keywords
   (let ((table (make-hash-table :test 'equal)))
     (dolist (word '("mod" "const" "class" "type"
-					"trait" "struct", "fn" "enum"
-					"impl"))
+                    "trait" "struct" "fn" "enum"
+                    "impl"))
       (puthash word 'def table))
     (dolist (word '("again" "assert"
                     "break"


### PR DESCRIPTION
Removed a comma from the keywords in rust-mode.el
I assume this was accidentally put there. 
Otherwise ignore this pull request

``` lisp
 (dolist (word '("mod" "const" "class" "type"
                        "trait" "struct", "fn" "enum"
                        "impl"))
```

This fixes the fn keyword not being syntax highlighted
