### PR TITLE
core: Export f32::ge(), f64::ge(), and float::ge()

### DIFF
--- a/src/libcore/f32.rs
+++ b/src/libcore/f32.rs
@@ -5,7 +5,7 @@
 import cmath::c_float::*;
 import cmath::c_float_targ_consts::*;
 
-export add, sub, mul, div, rem, lt, le, gt, eq, ne;
+export add, sub, mul, div, rem, lt, le, eq, ne, ge, gt;
 export is_positive, is_negative, is_nonpositive, is_nonnegative;
 export is_zero, is_infinite, is_finite;
 export NaN, is_NaN, infinity, neg_infinity;

--- a/src/libcore/f64.rs
+++ b/src/libcore/f64.rs
@@ -8,7 +8,7 @@ import cmath::c_double_targ_consts::*;
 // Even though this module exports everything defined in it,
 // because it contains re-exports, we also have to explicitly
 // export locally defined things. That's a bit annoying.
-export add, sub, mul, div, rem, lt, le, gt, eq, ne;
+export add, sub, mul, div, rem, lt, le, eq, ne, ge, gt;
 export is_positive, is_negative, is_nonpositive, is_nonnegative;
 export is_zero, is_infinite, is_finite;
 export NaN, is_NaN, infinity, neg_infinity;

--- a/src/libcore/float.rs
+++ b/src/libcore/float.rs
@@ -4,7 +4,7 @@
 // because it contains re-exports, we also have to explicitly
 // export locally defined things. That's a bit annoying.
 export to_str_common, to_str_exact, to_str, from_str;
-export add, sub, mul, div, rem, lt, le, gt, eq, ne;
+export add, sub, mul, div, rem, lt, le, eq, ne, ge, gt;
 export is_positive, is_negative, is_nonpositive, is_nonnegative;
 export is_zero, is_infinite, is_finite;
 export NaN, is_NaN, infinity, neg_infinity;
@@ -28,7 +28,7 @@ export j0, j1, jn, y0, y1, yn;
 
 import m_float = f64;
 
-import f64::{add, sub, mul, div, rem, lt, le, gt, eq, ne};
+import f64::{add, sub, mul, div, rem, lt, le, eq, ne, ge, gt};
 import f64::logarithm;
 import f64::{acos, asin, atan2, cbrt, ceil, copysign, cosh, floor};
 import f64::{erf, erfc, exp, expm1, exp2, abs_sub};


### PR DESCRIPTION
Without this fix, the following program fails to compile because the ge() function is not exported from the f32, f64, or float modules:

fn main() {
    f32::lt(0f32, 0f32);
    f32::le(0f32, 0f32);
    f32::eq(0f32, 0f32);
    f32::ne(0f32, 0f32);
    f32::ge(0f32, 0f32);
    f32::gt(0f32, 0f32);

```
f64::lt(0f64, 0f64);
f64::le(0f64, 0f64);
f64::eq(0f64, 0f64);
f64::ne(0f64, 0f64);
f64::ge(0f64, 0f64);
f64::gt(0f64, 0f64);

float::lt(0f64, 0f64);
float::le(0f64, 0f64);
float::eq(0f64, 0f64);
float::ne(0f64, 0f64);
float::ge(0f64, 0f64);
float::gt(0f64, 0f64);
```

}

test.rs:6:4: 6:11 error: unresolved name: f32::ge
test.rs:6     f32::ge(0f32, 0f32);
              ^~~~~~~
test.rs:6:4: 6:11 error: unresolved name: f32::ge
test.rs:6     f32::ge(0f32, 0f32);
              ^~~~~~~
test.rs:13:4: 13:11 error: unresolved name: f64::ge
test.rs:13     f64::ge(0f64, 0f64);
               ^~~~~~~
test.rs:13:4: 13:11 error: unresolved name: f64::ge
test.rs:13     f64::ge(0f64, 0f64);
               ^~~~~~~
test.rs:20:4: 20:13 error: unresolved name: float::ge
test.rs:20     float::ge(0f64, 0f64);
               ^~~~~~~~~
test.rs:20:4: 20:13 error: unresolved name: float::ge
test.rs:20     float::ge(0f64, 0f64);
               ^~~~~~~~~
error: aborting due to 6 previous errors
