### PR TITLE
package.el friendly rust mode

### DIFF
--- a/src/etc/emacs/cm-mode.el
+++ b/src/etc/emacs/cm-mode.el
@@ -190,4 +190,4 @@
 
 (provide 'cm-mode)
 
-;;; <name>.el ends here
+;;; cm-mode.el ends here

--- a/src/etc/emacs/cm-mode.el
+++ b/src/etc/emacs/cm-mode.el
@@ -1,8 +1,12 @@
-;; Wrapper for CodeMirror-style emacs modes. Highlighting is done by
-;; running a stateful parser (with first-class state object) over the
-;; buffer, line by line, using the output to add 'face properties, and
-;; storing the parser state at the end of each line. Indentation is
-;; done based on the parser state at the start of the line.
+;;; cm-mode.el --- Wrapper for CodeMirror-style emacs modes
+
+;; Version: 0.1.0
+
+;; Highlighting is done by running a stateful parser (with first-class
+;; state object) over the buffer, line by line, using the output to
+;; add 'face properties, and storing the parser state at the end of
+;; each line. Indentation is done based on the parser state at the
+;; start of the line.
 
 (eval-when-compile (require 'cl))
 
@@ -163,7 +167,7 @@
         (cm-schedule-work 0.05)))))
 
 (defun cm-do-some-work ()
-  (save-excursion 
+  (save-excursion
     (condition-case cnd (cm-do-some-work-inner)
       (error (print cnd) (error cnd)))))
 
@@ -174,6 +178,7 @@
 
 ;; Entry function
 
+;;;###autoload
 (defun cm-mode (mode)
   (set (make-local-variable 'cm-cur-mode) mode)
   (set (make-local-variable 'cm-worklist) (list (copy-marker 1)))
@@ -184,3 +189,5 @@
   (cm-schedule-work 0.05))
 
 (provide 'cm-mode)
+
+;;; <name>.el ends here

--- a/src/etc/emacs/cm-mode.el
+++ b/src/etc/emacs/cm-mode.el
@@ -1,6 +1,7 @@
-;;; cm-mode.el --- Wrapper for CodeMirror-style emacs modes
+;;; cm-mode.el --- Wrapper for CodeMirror-style Emacs modes
 
 ;; Version: 0.1.0
+;; Url: https://github.com/mozilla/rust
 
 ;; Highlighting is done by running a stateful parser (with first-class
 ;; state object) over the buffer, line by line, using the output to

--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -2,6 +2,7 @@
 
 ;; Version: 0.1.0
 ;; Package-Requires: ((cm-mode "0.1.0"))
+;; Url: https://github.com/mozilla/rust
 
 (require 'cm-mode)
 (require 'cc-mode)

--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -1,3 +1,8 @@
+;;; rust-mode.el --- A major emacs mode for editing Rust source code
+
+;; Version: 0.1.0
+;; Package-Requires: ((cm-mode "0.1.0"))
+
 (require 'cm-mode)
 (require 'cc-mode)
 
@@ -277,6 +282,7 @@
             ((eq (rust-context-align cx) t) (+ (rust-context-column cx) (if closing -1 0)))
             (t (+ base (if closing 0 unit)))))))
 
+;;;###autoload
 (define-derived-mode rust-mode fundamental-mode "Rust"
   "Major mode for editing Rust source files."
   (set-syntax-table rust-syntax-table)
@@ -293,3 +299,5 @@
 (define-key rust-mode-map "{" 'rust-electric-brace)
 
 (provide 'rust-mode)
+
+;;; rust-mode.el ends here


### PR DESCRIPTION
as described in #3187

I made it so that cm-mode and rust-mode are separate, rust-mode flags cm-mode as a dependency instead of packaging it as a multi-file package (in case cm-mode is used by another rust related mode later on). 

I will test it with a local melpa repository later today (short on time, not sure I'll make it today) and confirm it works. 
