### PR TITLE
Pretty printing brackets on match arms

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -838,6 +838,11 @@ fn print_block_unclosed(s: ps, blk: ast::blk) {
                                  false);
 }
 
+fn print_block_unclosed_indent(s: ps, blk: ast::blk, indented: uint) {
+    print_possibly_embedded_block_(s, blk, block_normal, indented, ~[],
+                                   false);
+}
+
 fn print_block_with_attrs(s: ps, blk: ast::blk, attrs: ~[ast::attribute]) {
     print_possibly_embedded_block_(s, blk, block_normal, indent_unit, attrs,
                                   true);
@@ -1178,8 +1183,16 @@ fn print_expr(s: ps, &&expr: @ast::expr) {
             assert arm.body.node.rules == ast::default_blk;
             match arm.body.node.expr {
               some(expr) => {
-                end(s); // close the ibox for the pattern
-                print_expr(s, expr);
+                match expr.node {
+                  ast::expr_block(blk) => {
+                    // the block will close the pattern's ibox
+                    print_block_unclosed_indent(s, blk, alt_indent_unit);
+                  }
+                  _ => {
+                    end(s); // close the ibox for the pattern
+                    print_expr(s, expr);
+                  }
+                }
                 if !expr_is_simple_block(expr)
                     && i < len - 1 {
                     word(s.s, ~",");


### PR DESCRIPTION
Currently, the pretty printer prints the brackets for match arms (if they are blocks) on a new line. This means you get something like (omitting a bunch of repetitions to make it not all fit inline):

```
fn main() {
    match h {
      something =>
      {
          hello;
          ...
          hello;
      }
    }
}
```

This is because the block is printed with print_expr, which means the whole thing is wrapped inside of a box. What should happen is that the opening bracket should be in the head box with "something =>" (that's how it works elsewhere). With the code in this pull request, the same code is formatted as:

```
fn main() {
    match h {
      something => {
        hello;
        ...
        hello;
      }
    }
}
```

Which seems better.

Edit: Now that incoming is not burning, I can confirm that the code here does not cause any test failures. 
