### PR TITLE
package.el rust-mode (update)

### DIFF
--- a/src/etc/emacs/README.md
+++ b/src/etc/emacs/README.md
@@ -4,7 +4,10 @@ rust-mode: A major emacs mode for editing Rust source code
 `rust-mode` makes editing [Rust](http://rust-lang.org) code with emacs
 enjoyable.
 
-To install, check out this repository and add this to your .emacs
+
+### Manual Installation
+
+To install manually, check out this repository and add this to your .emacs
 file:
 
     (add-to-list 'load-path "/path/to/rust-mode/")
@@ -25,3 +28,49 @@ it, and pressing `C-j`:
 
 Rust mode will automatically be associated with .rs and .rc files. To
 enable it explicitly, do `M-x rust-mode`.
+
+### package.el installation via Marmalade or Melpa
+
+It can be more convenient to use Emacs's package manager to handle
+installation for you if you use many elisp libraries.
+
+```lisp
+(require 'package)
+(add-to-list 'package-archives
+             '("marmalade" . "http://marmalade-repo.org/packages/"))
+(package-initialize)
+```
+
+```lisp
+(require 'package)
+(add-to-list 'package-archives
+             '("melpa" . "http://melpa.milkbox.net/packages/") t)
+(package-initialize)
+```
+
+If you use a version of Emacs prior to 24 that doesn't include
+package.el, you can get it from http://bit.ly/pkg-el23.
+
+If you have an older ELPA package.el installed from tromey.com, you
+should upgrade in order to support installation from multiple sources.
+The ELPA archive is deprecated and no longer accepting new packages,
+so the version there (1.7.1) is very outdated.
+
+
+#### Important
+
+In order to have cm-mode properly initialized after compilation prior
+to rust-mode.el compilation you will need to add these `advices` to
+your init file or if you are a melpa user install the `melpa` package.
+
+```lisp
+(defadvice package-download-tar
+  (after package-download-tar-initialize activate compile)
+  "initialize the package after compilation"
+  (package-initialize))
+
+(defadvice package-download-single
+  (after package-download-single-initialize activate compile)
+  "initialize the package after compilation"
+  (package-initialize))
+```

--- a/src/etc/emacs/README.md
+++ b/src/etc/emacs/README.md
@@ -29,10 +29,12 @@ it, and pressing `C-j`:
 Rust mode will automatically be associated with .rs and .rc files. To
 enable it explicitly, do `M-x rust-mode`.
 
-### package.el installation via Marmalade or Melpa
+### package.el installation via Marmalade
 
 It can be more convenient to use Emacs's package manager to handle
-installation for you if you use many elisp libraries.
+installation for you if you use many elisp libraries. If you have
+package.el but haven't added Marmalade, the community package source,
+yet, add this to ~/.emacs.d/init.el:
 
 ```lisp
 (require 'package)
@@ -41,12 +43,10 @@ installation for you if you use many elisp libraries.
 (package-initialize)
 ```
 
-```lisp
-(require 'package)
-(add-to-list 'package-archives
-             '("melpa" . "http://melpa.milkbox.net/packages/") t)
-(package-initialize)
-```
+Then do this to load the package listing:
+
+* <kbd>M-x eval-buffer</kbd>
+* <kbd>M-x package-refresh-contents</kbd>
 
 If you use a version of Emacs prior to 24 that doesn't include
 package.el, you can get it from http://bit.ly/pkg-el23.
@@ -56,6 +56,17 @@ should upgrade in order to support installation from multiple sources.
 The ELPA archive is deprecated and no longer accepting new packages,
 so the version there (1.7.1) is very outdated.
 
+From there you can install rust-mode or any other modes by choosing
+them from a list:
+
+* <kbd>M-x package-list-packages</kbd>
+
+Now, to install packages, move your cursor to them and press i. This
+will mark the packages for installation. When you're done with
+marking, press x, and ELPA will install the packages for you (under
+~/.emacs.d/elpa/).
+
+* or using <kbd>M-x package-install rust-mode
 
 #### Important
 

--- a/src/etc/emacs/cm-mode.el
+++ b/src/etc/emacs/cm-mode.el
@@ -190,4 +190,4 @@
 
 (provide 'cm-mode)
 
-;;; <name>.el ends here
+;;; cm-mode.el ends here

--- a/src/etc/emacs/cm-mode.el
+++ b/src/etc/emacs/cm-mode.el
@@ -1,8 +1,8 @@
 ;;; cm-mode.el --- Wrapper for CodeMirror-style Emacs modes
 
 ;; Version: 0.1.0
+;; Author: Mozilla
 ;; Url: https://github.com/mozilla/rust
-
 ;; Highlighting is done by running a stateful parser (with first-class
 ;; state object) over the buffer, line by line, using the output to
 ;; add 'face properties, and storing the parser state at the end of

--- a/src/etc/emacs/cm-mode.el
+++ b/src/etc/emacs/cm-mode.el
@@ -1,8 +1,12 @@
-;; Wrapper for CodeMirror-style emacs modes. Highlighting is done by
-;; running a stateful parser (with first-class state object) over the
-;; buffer, line by line, using the output to add 'face properties, and
-;; storing the parser state at the end of each line. Indentation is
-;; done based on the parser state at the start of the line.
+;;; cm-mode.el --- Wrapper for CodeMirror-style emacs modes
+
+;; Version: 0.1.0
+
+;; Highlighting is done by running a stateful parser (with first-class
+;; state object) over the buffer, line by line, using the output to
+;; add 'face properties, and storing the parser state at the end of
+;; each line. Indentation is done based on the parser state at the
+;; start of the line.
 
 (eval-when-compile (require 'cl))
 
@@ -163,7 +167,7 @@
         (cm-schedule-work 0.05)))))
 
 (defun cm-do-some-work ()
-  (save-excursion 
+  (save-excursion
     (condition-case cnd (cm-do-some-work-inner)
       (error (print cnd) (error cnd)))))
 
@@ -174,6 +178,7 @@
 
 ;; Entry function
 
+;;;###autoload
 (defun cm-mode (mode)
   (set (make-local-variable 'cm-cur-mode) mode)
   (set (make-local-variable 'cm-worklist) (list (copy-marker 1)))
@@ -184,3 +189,5 @@
   (cm-schedule-work 0.05))
 
 (provide 'cm-mode)
+
+;;; <name>.el ends here

--- a/src/etc/emacs/cm-mode.el
+++ b/src/etc/emacs/cm-mode.el
@@ -1,6 +1,7 @@
-;;; cm-mode.el --- Wrapper for CodeMirror-style emacs modes
+;;; cm-mode.el --- Wrapper for CodeMirror-style Emacs modes
 
 ;; Version: 0.1.0
+;; Url: https://github.com/mozilla/rust
 
 ;; Highlighting is done by running a stateful parser (with first-class
 ;; state object) over the buffer, line by line, using the output to

--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -2,6 +2,7 @@
 
 ;; Version: 0.1.0
 ;; Package-Requires: ((cm-mode "0.1.0"))
+;; Url: https://github.com/mozilla/rust
 
 (require 'cm-mode)
 (require 'cc-mode)

--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -1,3 +1,8 @@
+;;; rust-mode.el --- A major emacs mode for editing Rust source code
+
+;; Version: 0.1.0
+;; Package-Requires: ((cm-mode "0.1.0"))
+
 (require 'cm-mode)
 (require 'cc-mode)
 
@@ -277,6 +282,7 @@
             ((eq (rust-context-align cx) t) (+ (rust-context-column cx) (if closing -1 0)))
             (t (+ base (if closing 0 unit)))))))
 
+;;;###autoload
 (define-derived-mode rust-mode fundamental-mode "Rust"
   "Major mode for editing Rust source files."
   (set-syntax-table rust-syntax-table)
@@ -293,3 +299,5 @@
 (define-key rust-mode-map "{" 'rust-electric-brace)
 
 (provide 'rust-mode)
+
+;;; rust-mode.el ends here

--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -1,6 +1,7 @@
 ;;; rust-mode.el --- A major emacs mode for editing Rust source code
 
 ;; Version: 0.1.0
+;; Author: Mozilla
 ;; Package-Requires: ((cm-mode "0.1.0"))
 ;; Url: https://github.com/mozilla/rust
 


### PR DESCRIPTION
follow-up from #3187

It is now tested with Marmalade and I will also submit the recipes to melpa once its pushed here since I need to reference a repo/path from it.

I also took the liberty to update the readme with some instructions since the cm-mode dependency requires some trickery with `advices` so that rust-mode.el knows where to find cm-mode when compiling.

I pushed both packages on Marmalade, you can see them here http://marmalade-repo.org/packages/rust-mode http://marmalade-repo.org/packages/cm-mode, I will need to transfer ownership or at least add another more official owner at some point I guess.

I also added Mozilla in the Authors meta data, let me know if that needs to be changed.

Note: This push request includes the commits you rebased already.
