### PR TITLE
Add comma after "For example" in tutorial

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1560,7 +1560,7 @@ if favorite_crayon_name.len() > 5 {
 
 Named functions, like those we've seen so far, may not refer to local
 variables declared outside the function - they do not "close over
-their environment". For example you couldn't write the following:
+their environment". For example, you couldn't write the following:
 
 ~~~~ {.ignore}
 let foo = 10;


### PR DESCRIPTION
In the tutorial, my eye really expects to see a comma after "For example" in the first paragraph of # Closures. A web search seems to confirm that this is the common practice.

(It is so awesome to be reading a programming language tutorial where the examples are about playing Rock, Paper, Scissors and eating crayons.)
