### PR TITLE
core: adding os::tmpdir() that returns a system temporary directory if it can find one

### DIFF
--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -465,16 +465,16 @@ fn homedir() -> option<Path> {
 }
 
 /**
- * Returns the path to a temporary directory, if known.
+ * Returns the path to a temporary directory.
  *
  * On Unix, returns the value of the 'TMPDIR' environment variable if it is
  * set and non-empty and '/tmp' otherwise.
  *
  * On Windows, returns the value of, in order, the 'TMP', 'TEMP',
- * 'USERPROFILE' environment variable if any are set and not the empty
- * string. Otherwise, tmpdir returns option::none.
+ * 'USERPROFILE' environment variable  if any are set and not the empty
+ * string. Otherwise, tmpdir returns the path to the Windows directory.
  */
-fn tmpdir() -> option<Path> {
+fn tmpdir() -> Path {
     return lookup();
 
     fn getenv_nonempty(v: Path) -> option<Path> {
@@ -490,15 +490,18 @@ fn tmpdir() -> option<Path> {
     }
 
     #[cfg(unix)]
-    fn lookup() -> option<Path> {
-        option::or(getenv_nonempty(~"TMPDIR"), some(~"/tmp"))
+    fn lookup() -> Path {
+        option::get_default(getenv_nonempty(~"TMPDIR"), ~"/tmp")
     }
 
     #[cfg(windows)]
-    fn lookup() -> option<Path> {
-        option::or(getenv_nonempty(~"TMP"),
-        option::or(getenv_nonempty(~"TEMP"),
-                   getenv_nonempty(~"USERPROFILE")))
+    fn lookup() -> Path {
+        option::get_default(
+                    option::or(getenv_nonempty(~"TMP"),
+                    option::or(getenv_nonempty(~"TEMP"),
+                    option::or(getenv_nonempty(~"USERPROFILE"),
+                               getenv_nonempty(~"WINDIR")))),
+                    ~"C:\\Windows")
     }
 }
 /// Recursively walk a directory structure
@@ -970,7 +973,7 @@ mod tests {
 
     #[test]
     fn tmpdir() {
-        option::iter(os::tmpdir(), |s| assert !str::is_empty(s));
+        assert !str::is_empty(os::tmpdir());
     }
 
     // Issue #712

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -968,6 +968,11 @@ mod tests {
                                |s| setenv(~"USERPROFILE", s));
     }
 
+    #[test]
+    fn tmpdir() {
+        option::iter(os::tmpdir(), |s| assert !str::is_empty(s));
+    }
+
     // Issue #712
     #[test]
     fn test_list_dir_no_invalid_memory_access() { os::list_dir(~"."); }


### PR DESCRIPTION
This should be cross platform, but I have no access to a windows machine to test! So, I can confirm that it works on *nix, and it should work on windows (it doesn't do anything fancy).

The only part that isn't great is that it is guaranteed to return on *nix and not on windows. I was basing this off of haskell's System.Directory.getTemporaryDirectory, and what they do for the windows version is return the Windows directory if none of the env. variables are set, and doing this they can always return a directory. 

If we copied that behavior, the signature could change to reflect that it always gives back a Path, which might be desirable. I don't know how to get the Windows directory, and have no way to test, so I don't think I'm the person to add that, but I would support it happening.
