### PR TITLE
core: removing repeated code in os.rs homedir() test

### DIFF
--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -963,9 +963,6 @@ mod tests {
         setenv(~"USERPROFILE", ~"/home/MountainView");
         assert os::homedir() == some(~"/home/MountainView");
 
-        setenv(~"USERPROFILE", ~"/home/MountainView");
-        assert os::homedir() == some(~"/home/MountainView");
-
         setenv(~"HOME", ~"/home/MountainView");
         setenv(~"USERPROFILE", ~"/home/PaloAlto");
         assert os::homedir() == some(~"/home/MountainView");


### PR DESCRIPTION
I noticed this - unless there is a reason to test the exact same operation twice, this code seems redundant. (ie, it is the same as the previous two lines). 
