### PR TITLE
Fix tests most unused pattern variable warnings

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1859,83 +1859,83 @@ mod unsafe {
     /// Converts a byte to a string.
     unsafe fn from_byte(u: u8) -> ~str { unsafe::from_bytes([u]) }
 
-   /**
-    * Takes a bytewise (not UTF-8) slice from a string.
-    *
-    * Returns the substring from [`begin`..`end`).
-    *
-    * # Failure
-    *
-    * If begin is greater than end.
-    * If end is greater than the length of the string.
-    */
-   unsafe fn slice_bytes(s: &str, begin: uint, end: uint) -> ~str {
-       do as_buf(s) |sbuf, n| {
-           assert (begin <= end);
-           assert (end <= n);
-
-           let mut v = ~[];
-           vec::reserve(v, end - begin + 1u);
-           unsafe {
-               do vec::as_buf(v) |vbuf, _vlen| {
-                   let src = ptr::offset(sbuf, begin);
-                   ptr::memcpy(vbuf, src, end - begin);
-               }
-               vec::unsafe::set_len(v, end - begin);
-               vec::push(v, 0u8);
-               ::unsafe::transmute(v)
-           }
-       }
-   }
-
-   /**
-    * Takes a bytewise (not UTF-8) view from a string.
-    *
-    * Returns the substring from [`begin`..`end`).
-    *
-    * # Failure
-    *
-    * If begin is greater than end.
-    * If end is greater than the length of the string.
-    */
-   #[inline]
-   unsafe fn view_bytes(s: &str, begin: uint, end: uint) -> &str {
-       do as_buf(s) |sbuf, n| {
+    /**
+     * Takes a bytewise (not UTF-8) slice from a string.
+     *
+     * Returns the substring from [`begin`..`end`).
+     *
+     * # Failure
+     *
+     * If begin is greater than end.
+     * If end is greater than the length of the string.
+     */
+    unsafe fn slice_bytes(s: &str, begin: uint, end: uint) -> ~str {
+        do as_buf(s) |sbuf, n| {
             assert (begin <= end);
             assert (end <= n);
 
-            let tuple = (ptr::offset(sbuf, begin), end - begin + 1);
-            ::unsafe::reinterpret_cast(tuple)
-       }
-   }
+            let mut v = ~[];
+            vec::reserve(v, end - begin + 1u);
+            unsafe {
+                do vec::as_buf(v) |vbuf, _vlen| {
+                    let src = ptr::offset(sbuf, begin);
+                    ptr::memcpy(vbuf, src, end - begin);
+                }
+                vec::unsafe::set_len(v, end - begin);
+                vec::push(v, 0u8);
+                ::unsafe::transmute(v)
+            }
+        }
+    }
 
-   /// Appends a byte to a string. (Not UTF-8 safe).
-   unsafe fn push_byte(&s: ~str, b: u8) {
-       rustrt::rust_str_push(s, b);
-   }
+    /**
+     * Takes a bytewise (not UTF-8) view from a string.
+     *
+     * Returns the substring from [`begin`..`end`).
+     *
+     * # Failure
+     *
+     * If begin is greater than end.
+     * If end is greater than the length of the string.
+     */
+    #[inline]
+    unsafe fn view_bytes(s: &str, begin: uint, end: uint) -> &str {
+        do as_buf(s) |sbuf, n| {
+             assert (begin <= end);
+             assert (end <= n);
 
-   /// Appends a vector of bytes to a string. (Not UTF-8 safe).
-   unsafe fn push_bytes(&s: ~str, bytes: ~[u8]) {
-       for vec::each(bytes) |byte| { rustrt::rust_str_push(s, byte); }
-   }
+             let tuple = (ptr::offset(sbuf, begin), end - begin + 1);
+             ::unsafe::reinterpret_cast(tuple)
+        }
+    }
 
-   /// Removes the last byte from a string and returns it. (Not UTF-8 safe).
-   unsafe fn pop_byte(&s: ~str) -> u8 {
-       let len = len(s);
-       assert (len > 0u);
-       let b = s[len - 1u];
-       unsafe { set_len(s, len - 1u) };
-       return b;
-   }
+    /// Appends a byte to a string. (Not UTF-8 safe).
+    unsafe fn push_byte(&s: ~str, b: u8) {
+        rustrt::rust_str_push(s, b);
+    }
 
-   /// Removes the first byte from a string and returns it. (Not UTF-8 safe).
-   unsafe fn shift_byte(&s: ~str) -> u8 {
-       let len = len(s);
-       assert (len > 0u);
-       let b = s[0];
-       s = unsafe { unsafe::slice_bytes(s, 1u, len) };
-       return b;
-   }
+    /// Appends a vector of bytes to a string. (Not UTF-8 safe).
+    unsafe fn push_bytes(&s: ~str, bytes: ~[u8]) {
+        for vec::each(bytes) |byte| { rustrt::rust_str_push(s, byte); }
+    }
+
+    /// Removes the last byte from a string and returns it. (Not UTF-8 safe).
+    unsafe fn pop_byte(&s: ~str) -> u8 {
+        let len = len(s);
+        assert (len > 0u);
+        let b = s[len - 1u];
+        unsafe { set_len(s, len - 1u) };
+        return b;
+    }
+
+    /// Removes the first byte from a string and returns it. (Not UTF-8 safe).
+    unsafe fn shift_byte(&s: ~str) -> u8 {
+        let len = len(s);
+        assert (len > 0u);
+        let b = s[0];
+        s = unsafe { unsafe::slice_bytes(s, 1u, len) };
+        return b;
+    }
 
     /// Sets the length of the string and adds the null terminator
     unsafe fn set_len(&v: ~str, new_len: uint) {

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -223,7 +223,7 @@ fn map_item(i: @item, cx: ctx, v: vt) {
         map_struct_def(struct_def, node_item(i, item_path), i.ident, i.id, cx,
                        v);
       }
-      item_trait(tps, traits, methods) => {
+      item_trait(_, traits, methods) => {
         // Map trait refs to their parent classes. This is
         // so we can find the self_ty
         for traits.each |p| {
@@ -318,16 +318,16 @@ fn node_id_to_str(map: map, id: node_id, itr: ident_interner) -> ~str {
         fmt!("foreign item %s with abi %? (id=%?)",
              path_ident_to_str(*path, item.ident, itr), abi, id)
       }
-      Some(node_method(m, impl_did, path)) => {
+      Some(node_method(m, _, path)) => {
         fmt!("method %s in %s (id=%?)",
              *itr.get(m.ident), path_to_str(*path, itr), id)
       }
-      Some(node_trait_method(tm, impl_did, path)) => {
+      Some(node_trait_method(tm, _, path)) => {
         let m = ast_util::trait_method_to_ty_method(*tm);
         fmt!("method %s in %s (id=%?)",
              *itr.get(m.ident), path_to_str(*path, itr), id)
       }
-      Some(node_variant(variant, def_id, path)) => {
+      Some(node_variant(variant, _, path)) => {
         fmt!("variant %s in %s (id=%?)",
              *itr.get(variant.node.name), path_to_str(*path, itr), id)
       }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -197,7 +197,7 @@ fn expand_item_mac(exts: hashmap<~str, syntax_extension>,
                    cx: ext_ctxt, &&it: @ast::item,
                    fld: ast_fold) -> Option<@ast::item> {
     match it.node {
-      item_mac({node: mac_invoc_tt(pth, tts), span}) => {
+      item_mac({node: mac_invoc_tt(pth, tts), _}) => {
         let extname = cx.parse_sess().interner.get(pth.idents[0]);
         match exts.find(*extname) {
           None => {

--- a/src/libsyntax/ext/simplext.rs
+++ b/src/libsyntax/ext/simplext.rs
@@ -504,7 +504,7 @@ fn p_t_s_r_path(cx: ext_ctxt, p: @path, s: selector, b: binders) {
       Some(p_id) => {
         fn select(cx: ext_ctxt, m: matchable) -> match_result {
             return match m {
-                  match_expr(e) => Some(leaf(specialize_match(m))),
+                  match_expr(*) => Some(leaf(specialize_match(m))),
                   _ => cx.bug(~"broken traversal in p_t_s_r")
                 }
         }
@@ -646,7 +646,7 @@ fn add_new_extension(cx: ext_ctxt, sp: span, arg: ast::mac_arg,
             match elts[0u].node {
               expr_mac(mac) => {
                 match mac.node {
-                  mac_invoc(pth, invoc_arg, body) => {
+                  mac_invoc(pth, invoc_arg, _) => {
                     match path_to_ident(pth) {
                       Some(id) => {
                         let id_str = cx.str_of(id);

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -378,7 +378,7 @@ impl printer {
         if !self.scan_stack_empty {
             let x = self.scan_top();
             match copy self.token[x] {
-              BEGIN(b) => {
+              BEGIN(_) => {
                 if k > 0 {
                     self.size[self.scan_pop()] = self.size[x] +
                         self.right_total;

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -250,7 +250,7 @@ fn visit_pat<E>(p: @pat, e: E, v: vt<E>) {
 
 fn visit_foreign_item<E>(ni: @foreign_item, e: E, v: vt<E>) {
     match ni.node {
-      foreign_item_fn(fd, purity, tps) => {
+      foreign_item_fn(fd, _, tps) => {
         v.visit_ty_params(tps, e, v);
         visit_fn_decl(fd, e, v);
       }

--- a/src/rustc/metadata/creader.rs
+++ b/src/rustc/metadata/creader.rs
@@ -109,7 +109,7 @@ fn visit_view_item(e: env, i: @ast::view_item) {
 
 fn visit_item(e: env, i: @ast::item) {
     match i.node {
-      ast::item_foreign_mod(m) => {
+      ast::item_foreign_mod(_) => {
         match attr::foreign_abi(i.attrs) {
           either::Right(abi) => {
             if abi != ast::foreign_abi_cdecl &&

--- a/src/rustc/metadata/encoder.rs
+++ b/src/rustc/metadata/encoder.rs
@@ -519,7 +519,7 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: ebml::writer, item: @item,
         encode_path(ecx, ebml_w, path, ast_map::path_name(item.ident));
         ebml_w.end_tag();
       }
-      item_fn(decl, purity, tps, _) => {
+      item_fn(_, purity, tps, _) => {
         add_to_index();
         ebml_w.start_tag(tag_items_data_item);
         encode_def_id(ebml_w, local_def(item.id));
@@ -630,7 +630,7 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: ebml::writer, item: @item,
         needs to know*/
         for struct_def.fields.each |f| {
             match f.node.kind {
-                named_field(ident, mutability, vis) => {
+                named_field(ident, _, vis) => {
                    ebml_w.start_tag(tag_item_field);
                    encode_visibility(ebml_w, vis);
                    encode_name(ecx, ebml_w, ident);
@@ -790,7 +790,7 @@ fn encode_info_for_foreign_item(ecx: @encode_ctxt, ebml_w: ebml::writer,
 
     ebml_w.start_tag(tag_items_data_item);
     match nitem.node {
-      foreign_item_fn(fn_decl, purity, tps) => {
+      foreign_item_fn(_, purity, tps) => {
         encode_def_id(ebml_w, local_def(nitem.id));
         encode_family(ebml_w, purity_fn_family(purity));
         encode_type_param_bounds(ebml_w, ecx, tps);
@@ -803,7 +803,7 @@ fn encode_info_for_foreign_item(ecx: @encode_ctxt, ebml_w: ebml::writer,
         }
         encode_path(ecx, ebml_w, path, ast_map::path_name(nitem.ident));
       }
-      foreign_item_const(t) => {
+      foreign_item_const(*) => {
         encode_def_id(ebml_w, local_def(nitem.id));
         encode_family(ebml_w, 'c');
         encode_type(ecx, ebml_w, node_id_to_type(ecx.tcx, nitem.id));

--- a/src/rustc/metadata/filesearch.rs
+++ b/src/rustc/metadata/filesearch.rs
@@ -44,11 +44,11 @@ fn mk_filesearch(maybe_sysroot: Option<Path>,
                                            self.target_triple));
             match get_cargo_lib_path_nearest() {
               result::ok(p) => vec::push(paths, p),
-              result::err(p) => ()
+              result::err(_) => ()
             }
             match get_cargo_lib_path() {
               result::ok(p) => vec::push(paths, p),
-              result::err(p) => ()
+              result::err(_) => ()
             }
             paths
         }

--- a/src/rustc/middle/borrowck/gather_loans.rs
+++ b/src/rustc/middle/borrowck/gather_loans.rs
@@ -410,7 +410,7 @@ impl gather_loan_ctxt {
                   arm_id: ast::node_id, alt_id: ast::node_id) {
         do self.bccx.cat_pattern(discr_cmt, root_pat) |cmt, pat| {
             match pat.node {
-              ast::pat_ident(bm, id, o_pat) if !self.pat_is_variant(pat) => {
+              ast::pat_ident(bm, _, _) if !self.pat_is_variant(pat) => {
                 match bm {
                   ast::bind_by_value | ast::bind_by_move => {
                     // copying does not borrow anything, so no check

--- a/src/rustc/middle/borrowck/loan.rs
+++ b/src/rustc/middle/borrowck/loan.rs
@@ -113,9 +113,9 @@ impl loan_ctxt {
             // then the memory is freed.
             self.loan_unstable_deref(cmt, cmt_base, req_mutbl)
           }
-          cat_deref(cmt1, _, unsafe_ptr) |
-          cat_deref(cmt1, _, gc_ptr) |
-          cat_deref(cmt1, _, region_ptr(_)) => {
+          cat_deref(_, _, unsafe_ptr) |
+          cat_deref(_, _, gc_ptr) |
+          cat_deref(_, _, region_ptr(_)) => {
             // Aliased data is simply not lendable.
             self.bccx.tcx.sess.span_bug(
                 cmt.span,

--- a/src/rustc/middle/borrowck/preserve.rs
+++ b/src/rustc/middle/borrowck/preserve.rs
@@ -16,7 +16,7 @@ impl preserve_condition {
     fn combine(pc: preserve_condition) -> preserve_condition {
         match self {
           pc_ok => {pc}
-          pc_if_pure(e) => {self}
+          pc_if_pure(_) => {self}
         }
     }
 }

--- a/src/rustc/middle/check_alt.rs
+++ b/src/rustc/middle/check_alt.rs
@@ -351,7 +351,7 @@ fn specialize(tcx: ty::ctxt, r: ~[@pat], ctor_id: ctor, arity: uint,
         // Grab the class data that we care about.
         let class_fields, class_id;
         match ty::get(left_ty).struct {
-            ty::ty_class(cid, substs) => {
+            ty::ty_class(cid, _) => {
                 class_id = cid;
                 class_fields = ty::lookup_class_fields(tcx, class_id);
             }
@@ -414,7 +414,7 @@ fn check_local(tcx: ty::ctxt, loc: @local, &&s: (), v: visit::vt<()>) {
 
 fn is_refutable(tcx: ty::ctxt, pat: @pat) -> bool {
     match tcx.def_map.find(pat.id) {
-      Some(def_variant(enum_id, var_id)) => {
+      Some(def_variant(enum_id, _)) => {
         if vec::len(*ty::enum_variants(tcx, enum_id)) != 1u {
             return true;
         }

--- a/src/rustc/middle/check_const.rs
+++ b/src/rustc/middle/check_const.rs
@@ -179,7 +179,7 @@ fn check_item_recursion(sess: session, ast_map: ast_map::map,
 
     fn visit_expr(e: @expr, &&env: env, v: visit::vt<env>) {
         match e.node {
-          expr_path(path) => {
+          expr_path(*) => {
             match env.def_map.find(e.id) {
               Some(def_const(def_id)) => {
                 match env.ast_map.get(def_id.node) {

--- a/src/rustc/middle/freevars.rs
+++ b/src/rustc/middle/freevars.rs
@@ -39,7 +39,7 @@ fn collect_freevars(def_map: resolve3::DefMap, blk: ast::blk)
 
     let walk_expr = fn@(expr: @ast::expr, &&depth: int, v: visit::vt<int>) {
             match expr.node {
-              ast::expr_fn(proto, decl, _, _) => {
+              ast::expr_fn(proto, _, _, _) => {
                 if proto != ast::proto_bare {
                     visit::visit_expr(expr, depth + 1, v);
                 }
@@ -47,7 +47,7 @@ fn collect_freevars(def_map: resolve3::DefMap, blk: ast::blk)
               ast::expr_fn_block(*) => {
                 visit::visit_expr(expr, depth + 1, v);
               }
-              ast::expr_path(path) => {
+              ast::expr_path(*) => {
                   let mut i = 0;
                   match def_map.find(expr.id) {
                     None => fail ~"path not found",

--- a/src/rustc/middle/lint.rs
+++ b/src/rustc/middle/lint.rs
@@ -417,7 +417,7 @@ fn check_item_ctypes(cx: ty::ctxt, it: @ast::item) {
       either::Right(ast::foreign_abi_rust_intrinsic) => {
         for nmod.items.each |ni| {
             match ni.node {
-              ast::foreign_item_fn(decl, _, tps) => {
+              ast::foreign_item_fn(decl, _, _) => {
                 check_foreign_fn(cx, it.id, decl);
               }
               ast::foreign_item_const(*) => {}  // XXX: Not implemented.
@@ -434,7 +434,7 @@ fn check_item_path_statement(cx: ty::ctxt, it: @ast::item) {
             match s.node {
               ast::stmt_semi(@{id: id,
                                callee_id: _,
-                               node: ast::expr_path(@path),
+                               node: ast::expr_path(_),
                                span: _}, _) => {
                 cx.sess.span_lint(
                     path_statement, id, it.id,

--- a/src/rustc/middle/liveness.rs
+++ b/src/rustc/middle/liveness.rs
@@ -338,18 +338,13 @@ impl IrMaps {
         let vk = self.var_kinds[*var];
         debug!("Node %d is a last use of variable %?", expr_id, vk);
         match vk {
-          Arg(id, name, by_move) |
-          Arg(id, name, by_copy) |
-          Local(LocalInfo {id:id, ident:name,
-                           kind: FromLetNoInitializer, _}) |
-          Local(LocalInfo {id:id, ident:name,
-                           kind: FromLetWithInitializer, _}) |
-          Local(LocalInfo {id:id, ident:name,
-                           kind: FromMatch(bind_by_value), _}) |
-          Local(LocalInfo {id:id, ident:name,
-                           kind: FromMatch(bind_by_ref(_)), _}) |
-          Local(LocalInfo {id:id, ident:name,
-                           kind: FromMatch(bind_by_move), _}) => {
+          Arg(id, _, by_move) |
+          Arg(id, _, by_copy) |
+          Local(LocalInfo {id: id, kind: FromLetNoInitializer, _}) |
+          Local(LocalInfo {id: id, kind: FromLetWithInitializer, _}) |
+          Local(LocalInfo {id: id, kind: FromMatch(bind_by_value), _}) |
+          Local(LocalInfo {id: id, kind: FromMatch(bind_by_ref(_)), _}) |
+          Local(LocalInfo {id: id, kind: FromMatch(bind_by_move), _}) => {
             let v = match self.last_use_map.find(expr_id) {
               Some(v) => v,
               None => {
@@ -1493,7 +1488,7 @@ fn check_expr(expr: @expr, &&self: @Liveness, vt: vt<@Liveness>) {
         visit::visit_expr(expr, self, vt);
       }
 
-      expr_fn(_, _, _, cap_clause) | expr_fn_block(_, _, cap_clause) => {
+      expr_fn(*) | expr_fn_block(*) => {
         let caps = (*self.ir).captures(expr);
         for (*caps).each |cap| {
             let var = self.variable_from_rdef(cap.rv, expr.span);

--- a/src/rustc/middle/mem_categorization.rs
+++ b/src/rustc/middle/mem_categorization.rs
@@ -378,7 +378,7 @@ impl &mem_categorization_ctxt {
               mutbl:m_imm, ty:expr_ty}
           }
 
-          ast::def_upvar(upvid, inner, fn_node_id, _) => {
+          ast::def_upvar(_, inner, fn_node_id, _) => {
             let ty = ty::node_id_to_type(self.tcx, fn_node_id);
             let proto = ty::ty_fn_proto(ty);
             match proto {
@@ -856,7 +856,7 @@ fn field_mutbl(tcx: ty::ctxt,
             }
         }
       }
-      ty::ty_class(did, substs) => {
+      ty::ty_class(did, _) => {
         for ty::lookup_class_fields(tcx, did).each |fld| {
             if fld.ident == f_name {
                 let m = match fld.mutability {

--- a/src/rustc/middle/region.rs
+++ b/src/rustc/middle/region.rs
@@ -216,7 +216,7 @@ fn resolve_arm(arm: ast::arm, cx: ctxt, visitor: visit::vt<ctxt>) {
 
 fn resolve_pat(pat: @ast::pat, cx: ctxt, visitor: visit::vt<ctxt>) {
     match pat.node {
-      ast::pat_ident(_, path, _) => {
+      ast::pat_ident(*) => {
         let defn_opt = cx.def_map.find(pat.id);
         match defn_opt {
           Some(ast::def_variant(_,_)) => {
@@ -239,8 +239,8 @@ fn resolve_stmt(stmt: @ast::stmt, cx: ctxt, visitor: visit::vt<ctxt>) {
       ast::stmt_decl(*) => {
         visit::visit_stmt(stmt, cx, visitor);
       }
-      ast::stmt_expr(expr, stmt_id) |
-      ast::stmt_semi(expr, stmt_id) => {
+      ast::stmt_expr(_, stmt_id) |
+      ast::stmt_semi(_, stmt_id) => {
         record_parent(cx, stmt_id);
         let mut expr_cx = cx;
         expr_cx.parent = Some(stmt_id);
@@ -259,7 +259,7 @@ fn resolve_expr(expr: @ast::expr, cx: ctxt, visitor: visit::vt<ctxt>) {
                                                            cx.sess.intr()));
         new_cx.parent = Some(expr.id);
       }
-      ast::expr_match(subexpr, _) => {
+      ast::expr_match(*) => {
         debug!("node %d: %s", expr.id, pprust::expr_to_str(expr,
                                                            cx.sess.intr()));
         new_cx.parent = Some(expr.id);

--- a/src/rustc/middle/resolve3.rs
+++ b/src/rustc/middle/resolve3.rs
@@ -33,7 +33,7 @@ import syntax::ast::{local, local_crate, lt, method, mul, ne, neg, node_id};
 import syntax::ast::{pat, pat_enum, pat_ident, path, prim_ty, pat_box};
 import syntax::ast::{pat_lit, pat_range, pat_rec, pat_struct, pat_tup};
 import syntax::ast::{pat_uniq, pat_wild, private, provided, public, required};
-import syntax::ast::{rem, self_ty_, shl, stmt_decl, struct_field};
+import syntax::ast::{rem, self_ty_, shl, shr, stmt_decl, struct_field};
 import syntax::ast::{struct_variant_kind, sty_static, subtract, trait_ref};
 import syntax::ast::{tuple_variant_kind, ty, ty_bool, ty_char, ty_f, ty_f32};
 import syntax::ast::{ty_f64, ty_float, ty_i, ty_i16, ty_i32, ty_i64, ty_i8};

--- a/src/rustc/middle/resolve3.rs
+++ b/src/rustc/middle/resolve3.rs
@@ -529,7 +529,7 @@ struct NameBindings {
 
     fn span_for_namespace(namespace: Namespace) -> Option<span> {
         match self.def_for_namespace(namespace) {
-          Some(d) => {
+          Some(_) => {
             match namespace {
               TypeNS   => self.type_span,
               ValueNS  => self.value_span,
@@ -866,7 +866,7 @@ struct Resolver {
 
                 visit_mod(module_, sp, item.id, new_parent, visitor);
             }
-            item_foreign_mod(foreign_module) => {
+            item_foreign_mod(*) => {
               let (name_bindings, new_parent) = self.add_child(atom, parent,
                                                            ~[ModuleNS], sp);
 
@@ -891,7 +891,7 @@ struct Resolver {
                      def_const(local_def(item.id)),
                      sp);
             }
-            item_fn(decl, purity, _, _) => {
+            item_fn(_, purity, _, _) => {
               let (name_bindings, new_parent) = self.add_child(atom, parent,
                                                         ~[ValueNS], sp);
 
@@ -1217,7 +1217,7 @@ struct Resolver {
             self.add_child(name, parent, ~[ValueNS], foreign_item.span);
 
         match foreign_item.node {
-            foreign_item_fn(fn_decl, purity, type_parameters) => {
+            foreign_item_fn(_, purity, type_parameters) => {
                 let def = def_fn(local_def(foreign_item.id), purity);
                 (*name_bindings).define_value(Public, def, foreign_item.span);
 
@@ -1227,7 +1227,7 @@ struct Resolver {
                     visit_foreign_item(foreign_item, new_parent, visitor);
                 }
             }
-            foreign_item_const(item_type) => {
+            foreign_item_const(*) => {
                 let def = def_const(local_def(foreign_item.id));
                 (*name_bindings).define_value(Public, def, foreign_item.span);
 
@@ -1319,8 +1319,8 @@ struct Resolver {
               }
             }
           }
-          def_fn(def_id, _) | def_static_method(def_id, _) |
-          def_const(def_id) | def_variant(_, def_id) => {
+          def_fn(*) | def_static_method(*) | def_const(*) |
+          def_variant(*) => {
             debug!("(building reduced graph for external \
                     crate) building value %s", final_ident);
             (*child_name_bindings).define_value(Public, def, dummy_sp());
@@ -2710,7 +2710,7 @@ struct Resolver {
                                         body_id);
                     }
                 }
-                MethodRibKind(item_id, method_id) => {
+                MethodRibKind(item_id, _) => {
                   // If the def is a ty param, and came from the parent
                   // item, it's ok
                   match def {
@@ -2954,7 +2954,7 @@ struct Resolver {
                                                        visitor);
                                 }
                             }
-                            foreign_item_const(item_type) => {
+                            foreign_item_const(_) => {
                                 visit_foreign_item(foreign_item, (),
                                                    visitor);
                             }
@@ -3033,7 +3033,7 @@ struct Resolver {
         f();
 
         match type_parameters {
-            HasTypeParameters(type_parameters, _, _, _) => {
+            HasTypeParameters(*) => {
                 (*self.type_ribs).pop();
             }
 
@@ -4228,7 +4228,7 @@ struct Resolver {
                                               fmt!("use of undeclared label \
                                                    `%s`", self.session.str_of(
                                                   label))),
-                    Some(dl_def(def @ def_label(id))) =>
+                    Some(dl_def(def @ def_label(_))) =>
                         self.record_def(expr.id, def),
                     Some(_) =>
                         self.session.span_bug(expr.span,
@@ -4514,7 +4514,7 @@ struct Resolver {
                     atoms.push(name);
                     current_module = module_;
                 }
-                BlockParentLink(module_, node_id) => {
+                BlockParentLink(module_, _) => {
                     atoms.push(syntax::parse::token::special_idents::opaque);
                     current_module = module_;
                 }
@@ -4555,7 +4555,7 @@ struct Resolver {
             let mut module_repr;
             match (*import_resolution).target_for_namespace(ModuleNS) {
                 None => { module_repr = ~""; }
-                Some(target) => {
+                Some(_) => {
                     module_repr = ~" module:?";
                     // XXX
                 }
@@ -4564,7 +4564,7 @@ struct Resolver {
             let mut value_repr;
             match (*import_resolution).target_for_namespace(ValueNS) {
                 None => { value_repr = ~""; }
-                Some(target) => {
+                Some(_) => {
                     value_repr = ~" value:?";
                     // XXX
                 }
@@ -4573,7 +4573,7 @@ struct Resolver {
             let mut type_repr;
             match (*import_resolution).target_for_namespace(TypeNS) {
                 None => { type_repr = ~""; }
-                Some(target) => {
+                Some(_) => {
                     type_repr = ~" type:?";
                     // XXX
                 }

--- a/src/rustc/middle/trans/alt.rs
+++ b/src/rustc/middle/trans/alt.rs
@@ -628,7 +628,7 @@ fn compile_submatch(bcx: block, m: match_, vals: ~[ValueRef],
                 kind = switch;
             }
           }
-          lit(l) => {
+          lit(_) => {
             test_val = Load(bcx, val);
             let pty = node_id_type(bcx, pat_id);
             kind = if ty::type_is_integral(pty) { switch }
@@ -940,7 +940,7 @@ fn bind_irrefutable_pat(bcx: block, pat: @ast::pat, val: ValueRef,
         // Grab the class data that we care about.
         let class_fields, class_id;
         match ty::get(node_id_type(bcx, pat.id)).struct {
-            ty::ty_class(cid, substs) => {
+            ty::ty_class(cid, _) => {
                 class_id = cid;
                 class_fields = ty::lookup_class_fields(ccx.tcx, class_id);
             }

--- a/src/rustc/middle/trans/base.rs
+++ b/src/rustc/middle/trans/base.rs
@@ -2386,7 +2386,7 @@ fn maybe_instantiate_inline(ccx: @crate_ctxt, fn_id: ast::def_id)
             trans_item(ccx, *item);
             local_def(item.id)
           }
-          csearch::found(ast::ii_ctor(ctor, _, tps, _)) => {
+          csearch::found(ast::ii_ctor(ctor, _, _, _)) => {
             ccx.external.insert(fn_id, Some(ctor.node.id));
             local_def(ctor.node.id)
           }
@@ -2430,7 +2430,7 @@ fn maybe_instantiate_inline(ccx: @crate_ctxt, fn_id: ast::def_id)
             }
             local_def(mth.id)
           }
-          csearch::found(ast::ii_dtor(dtor, _, tps, _)) => {
+          csearch::found(ast::ii_dtor(dtor, _, _, _)) => {
               ccx.external.insert(fn_id, Some(dtor.node.id));
               local_def(dtor.node.id)
           }
@@ -5411,7 +5411,7 @@ fn get_item_val(ccx: @crate_ctxt, id: ast::node_id) -> ValueRef {
                 ccx.item_symbols.insert(i.id, s);
                 g
               }
-              ast::item_fn(decl, purity, _, _) => {
+              ast::item_fn(_, purity, _, _) => {
                 let llfn = if purity != ast::extern_fn {
                     register_fn(ccx, i.span, my_path, i.id)
                 } else {
@@ -5657,7 +5657,7 @@ fn push_rtcall(ccx: @crate_ctxt, name: ~str, did: ast::def_id) {
 fn gather_local_rtcalls(ccx: @crate_ctxt, crate: @ast::crate) {
     visit::visit_crate(*crate, (), visit::mk_simple_visitor(@{
         visit_item: |item| match item.node {
-          ast::item_fn(decl, _, _, _) => {
+          ast::item_fn(*) => {
             let attr_metas = attr::attr_metas(
                 attr::find_attrs_by_name(item.attrs, ~"rt"));
             do vec::iter(attr_metas) |attr_meta| {

--- a/src/rustc/middle/trans/closure.rs
+++ b/src/rustc/middle/trans/closure.rs
@@ -100,12 +100,12 @@ enum environment_value {
 
 fn ev_to_str(ccx: @crate_ctxt, ev: environment_value) -> ~str {
     match ev {
-      env_copy(v, t, lk) => fmt!("copy(%s,%s)", val_str(ccx.tn, v),
+      env_copy(v, t, _) => fmt!("copy(%s,%s)", val_str(ccx.tn, v),
                                 ty_to_str(ccx.tcx, t)),
-      env_move(v, t, lk) => fmt!("move(%s,%s)", val_str(ccx.tn, v),
+      env_move(v, t, _) => fmt!("move(%s,%s)", val_str(ccx.tn, v),
                                 ty_to_str(ccx.tcx, t)),
-      env_ref(v, t, lk) => fmt!("ref(%s,%s)", val_str(ccx.tn, v),
-                                ty_to_str(ccx.tcx, t))
+      env_ref(v, t, _) => fmt!("ref(%s,%s)", val_str(ccx.tn, v),
+                               ty_to_str(ccx.tcx, t))
     }
 }
 
@@ -224,13 +224,13 @@ fn store_environment(bcx: block,
             let src = {bcx:bcx, val:val, kind:kind};
             bcx = move_val(bcx, INIT, bound_data, src, ty);
           }
-          env_ref(val, ty, lv_owned) => {
+          env_ref(val, _, lv_owned) => {
             debug!("> storing %s into %s",
                    val_str(bcx.ccx().tn, val),
                    val_str(bcx.ccx().tn, bound_data));
             Store(bcx, val, bound_data);
           }
-          env_ref(val, ty, lv_owned_imm) => {
+          env_ref(val, _, lv_owned_imm) => {
             let addr = do_spill_noroot(bcx, val);
             Store(bcx, addr, bound_data);
           }

--- a/src/rustc/middle/trans/foreign.rs
+++ b/src/rustc/middle/trans/foreign.rs
@@ -755,7 +755,7 @@ fn trans_foreign_mod(ccx: @crate_ctxt,
 
     for vec::each(foreign_mod.items) |foreign_item| {
       match foreign_item.node {
-        ast::foreign_item_fn(fn_decl, purity, typarams) => {
+        ast::foreign_item_fn(_, _, typarams) => {
           let id = foreign_item.id;
           if abi != ast::foreign_abi_rust_intrinsic {
               let llwrapfn = get_item_val(ccx, id);

--- a/src/rustc/middle/trans/impl.rs
+++ b/src/rustc/middle/trans/impl.rs
@@ -258,12 +258,12 @@ fn trans_monomorphized_callee(bcx: block, callee_id: ast::node_id,
              ccx, node_id_type(bcx, callee_id))))
          with lval}
       }
-      typeck::vtable_trait(trait_id, tps) => {
+      typeck::vtable_trait(*) => {
         let {bcx, val} = trans_temp_expr(bcx, base);
         let fty = node_id_type(bcx, callee_id);
         trans_trait_callee(bcx, val, fty, n_method)
       }
-      typeck::vtable_param(n_param, n_bound) => {
+      typeck::vtable_param(*) => {
         fail ~"vtable_param left in monomorphized function's vtable substs";
       }
     }

--- a/src/rustc/middle/trans/shape.rs
+++ b/src/rustc/middle/trans/shape.rs
@@ -267,7 +267,7 @@ fn shape_of(ccx: @crate_ctxt, t: ty::t) -> ~[u8] {
         add_substr(s, shape_of(ccx, mt.ty));
         s
       }
-      ty::ty_evec(mt, ty::vstore_uniq) => {
+      ty::ty_evec(_, ty::vstore_uniq) => {
         shape_of(ccx, tvec::expand_boxed_vec_ty(ccx.tcx, t))
       }
 
@@ -290,7 +290,7 @@ fn shape_of(ccx: @crate_ctxt, t: ty::t) -> ~[u8] {
         s
       }
 
-      ty::ty_estr(ty::vstore_slice(r)) => {
+      ty::ty_estr(ty::vstore_slice(_)) => {
         let mut s = ~[shape_slice];
         let u8_t = ty::mk_mach_uint(ccx.tcx, ast::ty_u8);
         add_bool(s, true); // is_pod
@@ -299,7 +299,7 @@ fn shape_of(ccx: @crate_ctxt, t: ty::t) -> ~[u8] {
         s
       }
 
-      ty::ty_evec(mt, ty::vstore_slice(r)) => {
+      ty::ty_evec(mt, ty::vstore_slice(_)) => {
         let mut s = ~[shape_slice];
         add_bool(s, ty::type_is_pod(ccx.tcx, mt.ty));
         add_bool(s, false); // is_str

--- a/src/rustc/middle/trans/tvec.rs
+++ b/src/rustc/middle/trans/tvec.rs
@@ -268,10 +268,10 @@ fn trans_vstore(bcx: block, e: @ast::expr,
       ast::expr_lit(@{node: ast::lit_str(s), span: _}) => {
         return trans_estr(bcx, s, Some(v), dest);
       }
-      ast::expr_vec(es, mutbl) => {
+      ast::expr_vec(es, _) => {
         return trans_evec(bcx, individual_evec(es), v, e.id, dest);
       }
-      ast::expr_repeat(element, count_expr, mutbl) => {
+      ast::expr_repeat(element, count_expr, _) => {
         let count = ty::eval_repeat_count(bcx.tcx(), count_expr, e.span);
         return trans_evec(bcx, repeating_evec(element, count), v, e.id, dest);
       }

--- a/src/rustc/middle/ty.rs
+++ b/src/rustc/middle/ty.rs
@@ -2621,7 +2621,7 @@ fn unify_mode(cx: ctxt, modes: expected_found<ast::mode>)
       (m1, m2) if (m1 == m2) => {
         result::ok(m1)
       }
-      (ast::infer(id1), ast::infer(id2)) => {
+      (ast::infer(_), ast::infer(id2)) => {
         cx.inferred_modes.insert(id2, m1);
         result::ok(m1)
       }
@@ -2629,7 +2629,7 @@ fn unify_mode(cx: ctxt, modes: expected_found<ast::mode>)
         cx.inferred_modes.insert(id, m);
         result::ok(m1)
       }
-      (m1, m2) => {
+      (_, _) => {
         result::err(terr_mode_mismatch(modes))
       }
     }
@@ -3325,7 +3325,7 @@ fn normalize_ty(cx: ctxt, t: t) -> t {
             // This type has a vstore. Get rid of it
             mk_estr(cx, normalize_vstore(vstore)),
 
-        ty_rptr(region, mt) =>
+        ty_rptr(_, mt) =>
             // This type has a region. Get rid of it
             mk_rptr(cx, re_static, normalize_mt(cx, mt)),
 

--- a/src/rustc/middle/ty.rs
+++ b/src/rustc/middle/ty.rs
@@ -1928,7 +1928,7 @@ fn is_instantiable(cx: ctxt, r_ty: t) -> bool {
             return type_requires(cx, seen, r_ty, mt.ty);
           }
 
-          ty_ptr(mt) => {
+          ty_ptr(*) => {
             false           // unsafe ptrs can always be NULL
           }
 
@@ -2137,7 +2137,7 @@ fn type_is_enum(ty: t) -> bool {
 // constructors
 fn type_is_c_like_enum(cx: ctxt, ty: t) -> bool {
     match get(ty).struct {
-      ty_enum(did, ref substs) => {
+      ty_enum(did, _) => {
         let variants = enum_variants(cx, did);
         let some_n_ary = vec::any(*variants, |v| vec::len(v.args) > 0u);
         return !some_n_ary;

--- a/src/rustc/middle/typeck.rs
+++ b/src/rustc/middle/typeck.rs
@@ -52,7 +52,8 @@ import syntax::codemap::span;
 import pat_util::{pat_is_variant, pat_id_map};
 import middle::ty;
 import middle::ty::{arg, field, node_type_table, mk_nil,
-                    ty_param_bounds_and_ty, lookup_public_fields};
+                    ty_param_bounds_and_ty, lookup_public_fields,
+                    vstore_uniq};
 import std::smallintmap;
 import std::map;
 import std::map::{hashmap, int_hash};

--- a/src/rustc/middle/typeck.rs
+++ b/src/rustc/middle/typeck.rs
@@ -254,8 +254,8 @@ fn check_main_fn_ty(ccx: @crate_ctxt,
     let tcx = ccx.tcx;
     let main_t = ty::node_id_to_type(tcx, main_id);
     match ty::get(main_t).struct {
-      ty::ty_fn({purity: ast::impure_fn, proto: ty::proto_bare, bounds,
-                 inputs, output, ret_style: ast::return_val}) => {
+      ty::ty_fn({purity: ast::impure_fn, proto: ty::proto_bare,
+                 inputs, output, ret_style: ast::return_val, _}) => {
         match tcx.items.find(main_id) {
          Some(ast_map::node_item(it,_)) => {
              match it.node {

--- a/src/rustc/middle/typeck/check/alt.rs
+++ b/src/rustc/middle/typeck/check/alt.rs
@@ -228,7 +228,7 @@ fn check_pat(pcx: pat_ctxt, pat: @ast::pat, expected: ty::t) {
           _ => ()
         }
       }
-      ast::pat_ident(_, path, c) => {
+      ast::pat_ident(_, path, _) => {
         check_pat_variant(pcx, pat, path, Some(~[]), expected);
       }
       ast::pat_enum(path, subpats) => {

--- a/src/rustc/middle/typeck/check/regionck.rs
+++ b/src/rustc/middle/typeck/check/regionck.rs
@@ -38,7 +38,7 @@ fn encl_region_of_def(fcx: @fn_ctxt, def: ast::def) -> ty::region {
         def_local(node_id, _) | def_arg(node_id, _) | def_self(node_id) |
         def_binding(node_id, _) =>
             return encl_region(tcx, node_id),
-        def_upvar(local_id, subdef, closure_id, body_id) => {
+        def_upvar(_, subdef, closure_id, body_id) => {
             match ty_fn_proto(fcx.node_ty(closure_id)) {
                 proto_bare =>
                     tcx.sess.bug(~"proto_bare in encl_region_of_def?!"),
@@ -205,7 +205,7 @@ fn visit_expr(e: @ast::expr, &&rcx: @rcx, v: rvt) {
         };
       }
 
-      ast::expr_addr_of(_, operand) => {
+      ast::expr_addr_of(*) => {
         // FIXME(#3148) -- in some cases, we need to capture a dependency
         // between the regions found in operand the resulting region type.
         // See #3148 for more details.

--- a/src/rustc/middle/typeck/check/vtable.rs
+++ b/src/rustc/middle/typeck/check/vtable.rs
@@ -117,7 +117,7 @@ fn lookup_vtable(fcx: @fn_ctxt,
               }
               ty::bound_trait(ity) => {
                 match ty::get(ity).struct {
-                  ty::ty_trait(idid, substs, _) => {
+                  ty::ty_trait(idid, _, _) => {
                     if trait_id == idid {
                         debug!("(checking vtable) @0 relating ty to trait ty
                                 with did %?", idid);
@@ -268,7 +268,7 @@ fn fixup_ty(fcx: @fn_ctxt,
                   for this bounded type parameter: %s",
                  fixup_err_to_str(e)))
       }
-      result::err(e) => {
+      result::err(_) => {
         None
       }
     }

--- a/src/rustc/middle/typeck/coherence.rs
+++ b/src/rustc/middle/typeck/coherence.rs
@@ -597,7 +597,7 @@ struct CoherenceChecker {
         }
 
         match item.node {
-            item_impl(ty_params, trait_refs, _, ast_methods) => {
+            item_impl(_, trait_refs, _, ast_methods) => {
                 let mut methods = ~[];
 
                 for ast_methods.each |ast_method| {

--- a/src/rustc/middle/typeck/collect.rs
+++ b/src/rustc/middle/typeck/collect.rs
@@ -331,7 +331,7 @@ fn check_methods_against_trait(ccx: @crate_ctxt,
     }
     for vec::each(*ty::trait_methods(tcx, did)) |trait_m| {
         match vec::find(impl_ms, |impl_m| trait_m.ident == impl_m.mty.ident) {
-          Some({mty: impl_m, id, span}) => {
+          Some({mty: impl_m, span, _}) => {
             compare_impl_method(
                 ccx.tcx, span, impl_m, vec::len(tps),
                 trait_m, tpt.substs, selfty);
@@ -350,7 +350,7 @@ fn check_methods_against_trait(ccx: @crate_ctxt,
 
                   match vec::find(provided_methods, |provided_method|
                                 provided_method.ident == trait_m.ident) {
-                    Some(m) => {
+                    Some(_) => {
                       // If there's a provided method with the name we
                       // want, then we're fine; nothing else to do.
                     }
@@ -660,7 +660,7 @@ fn ty_of_item(ccx: @crate_ctxt, it: @ast::item)
         tcx.tcache.insert(local_def(it.id), tpt);
         return tpt;
       }
-      ast::item_trait(tps, _, ms) => {
+      ast::item_trait(tps, _, _) => {
         let {bounds, substs} = mk_substs(ccx, tps, rp);
         let t = ty::mk_trait(tcx, local_def(it.id), substs, ty::vstore_box);
         let tpt = {bounds: bounds,

--- a/src/rustc/middle/typeck/infer/assignment.rs
+++ b/src/rustc/middle/typeck/infer/assignment.rs
@@ -125,12 +125,12 @@ impl infer_ctxt {
         match (a_bnd, b_bnd) {
           (Some(a_bnd), Some(b_bnd)) => {
             match (ty::get(a_bnd).struct, ty::get(b_bnd).struct) {
-              (ty::ty_box(mt_a), ty::ty_rptr(r_b, mt_b)) => {
+              (ty::ty_box(*), ty::ty_rptr(r_b, mt_b)) => {
                 let nr_b = ty::mk_box(self.tcx, {ty: mt_b.ty,
                                                  mutbl: m_const});
                 self.crosspollinate(anmnt, a, nr_b, mt_b.mutbl, r_b)
               }
-              (ty::ty_uniq(mt_a), ty::ty_rptr(r_b, mt_b)) => {
+              (ty::ty_uniq(*), ty::ty_rptr(r_b, mt_b)) => {
                 let nr_b = ty::mk_uniq(self.tcx, {ty: mt_b.ty,
                                                   mutbl: m_const});
                 self.crosspollinate(anmnt, a, nr_b, mt_b.mutbl, r_b)
@@ -142,7 +142,7 @@ impl infer_ctxt {
                 self.crosspollinate(anmnt, a, nr_b, m_imm, r_b)
               }
 
-              (ty::ty_evec(mt_a, vs_a),
+              (ty::ty_evec(_, vs_a),
                ty::ty_evec(mt_b, ty::vstore_slice(r_b)))
               if is_borrowable(vs_a) => {
                 let nr_b = ty::mk_evec(self.tcx, {ty: mt_b.ty,

--- a/src/rustc/middle/typeck/infer/region_var_bindings.rs
+++ b/src/rustc/middle/typeck/infer/region_var_bindings.rs
@@ -508,7 +508,7 @@ impl RegionVarBindings {
             ok(ty::re_static) // nothing lives longer than static
           }
 
-          (ty::re_var(v_id), _) | (_, ty::re_var(v_id)) => {
+          (ty::re_var(*), _) | (_, ty::re_var(*)) => {
             self.combine_vars(
                 self.lubs, a, b, span,
                 |old_r, new_r| self.make_subregion(span, old_r, new_r))
@@ -531,7 +531,7 @@ impl RegionVarBindings {
             ok(r)
           }
 
-          (ty::re_var(v_id), _) | (_, ty::re_var(v_id)) => {
+          (ty::re_var(*), _) | (_, ty::re_var(*)) => {
             self.combine_vars(
                 self.glbs, a, b, span,
                 |old_r, new_r| self.make_subregion(span, new_r, old_r))

--- a/src/rustc/middle/typeck/infer/region_var_bindings.rs
+++ b/src/rustc/middle/typeck/infer/region_var_bindings.rs
@@ -1020,7 +1020,7 @@ impl RegionVarBindings {
                     self.report_error_for_expanding_node(
                         graph, dup_map, node_vid);
                   }
-                  Contraction => {
+                  Contracting => {
                     self.report_error_for_contracting_node(
                         graph, dup_map, node_vid);
                   }


### PR DESCRIPTION
I almost fixed all the unused variable warnings, and found a couple cases where we weren't properly using an enum because it wasn't imported. There were a couple I didn't know how to handle though:

```
/Users/etryzelaar/Projects/rust/rust/src/rustc/middle/ty.rs:1038:6: 1038:27 warning: unused variable: `sty`
/Users/etryzelaar/Projects/rust/rust/src/rustc/middle/ty.rs:1038       ref sty @ ty_fn(f) => {
                                                                       ^~~~~~~~~~~~~~~~~~~~~
/Users/etryzelaar/Projects/rust/rust/src/rustc/middle/ty.rs:2232:6: 2232:22 warning: unused variable: `re_bot`
/Users/etryzelaar/Projects/rust/rust/src/rustc/middle/ty.rs:2232       re_bot        => 4u
                                                                       ^~~~~~~~~~~~~~~~
/Users/etryzelaar/Projects/rust/rust/src/rustc/middle/typeck/check.rs:895:14: 895:43 warning: unused variable: `sty`
/Users/etryzelaar/Projects/rust/rust/src/rustc/middle/typeck/check.rs:895               sty @ ty::ty_fn(ref fn_ty) => {
                                                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I'm not quite sure what the `sty @ ty::ty_fn(...)` means, and `re_bot` seems like it should be a variant, but it doesn't exist.
