### PR TITLE
Fix MZ_FORCEINLINE define to work with GCC 4.7.1.

### DIFF
--- a/src/rt/miniz.cpp
+++ b/src/rt/miniz.cpp
@@ -391,7 +391,7 @@ typedef unsigned char mz_validate_uint64[sizeof(mz_uint64)==8 ? 1 : -1];
 #ifdef _MSC_VER
   #define MZ_FORCEINLINE __forceinline
 #elif defined(__GNUC__)
-  #define MZ_FORCEINLINE __attribute__((__always_inline__))
+  #define MZ_FORCEINLINE inline __attribute__((__always_inline__))
 #else
   #define MZ_FORCEINLINE
 #endif


### PR DESCRIPTION
Using just **always_inline** without inline results in several instances
of "error: always_inline function might not be inlinable".
