### PR TITLE
Remove deprecated modes

### DIFF
--- a/src/libstd/cmp.rs
+++ b/src/libstd/cmp.rs
@@ -1,34 +1,36 @@
 #[deny(non_camel_case_types)];
+#[forbid(deprecated_mode)];
+#[forbid(deprecated_pattern)];
 /// Additional general-purpose comparison functionality.
 
 const fuzzy_epsilon: float = 1.0e-6;
 
 trait FuzzyEq {
-    pure fn fuzzy_eq(&&other: self) -> bool;
+    pure fn fuzzy_eq(other: &self) -> bool;
 }
 
 impl float: FuzzyEq {
-    pure fn fuzzy_eq(&&other: float) -> bool {
-        return float::abs(self - other) < fuzzy_epsilon;
+    pure fn fuzzy_eq(other: &float) -> bool {
+        return float::abs(self - *other) < fuzzy_epsilon;
     }
 }
 
 impl f32: FuzzyEq {
-    pure fn fuzzy_eq(&&other: f32) -> bool {
-        return f32::abs(self - other) < (fuzzy_epsilon as f32);
+    pure fn fuzzy_eq(other: &f32) -> bool {
+        return f32::abs(self - *other) < (fuzzy_epsilon as f32);
     }
 }
 
 impl f64: FuzzyEq {
-    pure fn fuzzy_eq(&&other: f64) -> bool {
-        return f64::abs(self - other) < (fuzzy_epsilon as f64);
+    pure fn fuzzy_eq(other: &f64) -> bool {
+        return f64::abs(self - *other) < (fuzzy_epsilon as f64);
     }
 }
 
 #[test]
 fn test_fuzzy_equals() {
-    assert ((1.0).fuzzy_eq(1.0));
-    assert ((1.0f32).fuzzy_eq(1.0f32));
-    assert ((1.0f64).fuzzy_eq(1.0f64));
+    assert ((&1.0).fuzzy_eq(&1.0));
+    assert ((&1.0f32).fuzzy_eq(&1.0f32));
+    assert ((&1.0f64).fuzzy_eq(&1.0f64));
 }
 

--- a/src/libstd/dbg.rs
+++ b/src/libstd/dbg.rs
@@ -1,4 +1,6 @@
 #[deny(non_camel_case_types)];
+#[forbid(deprecated_mode)];
+#[forbid(deprecated_pattern)];
 //! Unsafe debugging functions for inspecting values.
 
 import unsafe::reinterpret_cast;
@@ -26,7 +28,7 @@ fn debug_tydesc<T>() {
     rustrt::debug_tydesc(sys::get_type_desc::<T>());
 }
 
-fn debug_opaque<T>(x: T) {
+fn debug_opaque<T>(+x: T) {
     rustrt::debug_opaque(sys::get_type_desc::<T>(), ptr::addr_of(x) as *());
 }
 
@@ -34,11 +36,11 @@ fn debug_box<T>(x: @T) {
     rustrt::debug_box(sys::get_type_desc::<T>(), ptr::addr_of(x) as *());
 }
 
-fn debug_tag<T>(x: T) {
+fn debug_tag<T>(+x: T) {
     rustrt::debug_tag(sys::get_type_desc::<T>(), ptr::addr_of(x) as *());
 }
 
-fn debug_fn<T>(x: T) {
+fn debug_fn<T>(+x: T) {
     rustrt::debug_fn(sys::get_type_desc::<T>(), ptr::addr_of(x) as *());
 }
 

--- a/src/libstd/prettyprint.rs
+++ b/src/libstd/prettyprint.rs
@@ -1,3 +1,6 @@
+#[forbid(deprecated_mode)];
+#[forbid(deprecated_pattern)];
+
 import io::Writer;
 import io::WriterUtil;
 import serialization::serializer;

--- a/src/libstd/tempfile.rs
+++ b/src/libstd/tempfile.rs
@@ -1,5 +1,8 @@
 //! Temporary files and directories
 
+#[forbid(deprecated_mode)];
+#[forbid(deprecated_pattern)];
+
 import core::option;
 import option::{None, Some};
 import rand;

--- a/src/rustc/middle/trans/type_use.rs
+++ b/src/rustc/middle/trans/type_use.rs
@@ -140,7 +140,7 @@ fn type_needs_inner(cx: ctx, use: uint, ty: ty::t,
               ty::ty_fn(_) | ty::ty_ptr(_) | ty::ty_rptr(_, _)
                | ty::ty_trait(_, _, _) => false,
               ty::ty_enum(did, substs) => {
-                if option::is_none(list::find(enums_seen, |id| id == did)) {
+                if option::is_none(list::find(enums_seen, |id| *id == did)) {
                     let seen = @cons(did, enums_seen);
                     for vec::each(*ty::enum_variants(cx.ccx.tcx, did)) |v| {
                         for vec::each(v.args) |aty| {


### PR DESCRIPTION
These commits remove deprecated modes from cmp.rs, dbg.rs, rope.rs, and list.rs (and delete list::push).

~~I haven't yet managed to catch `incoming` when it was problem free, so this hasn't been all the way through a `make check`.  Let me know when `incoming` is clean...~~
