### PR TITLE
Remove str abi fns, send_map helper fns, and other cleanup

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -348,6 +348,14 @@ fn unwrap<T, U>(+res: Result<T, U>) -> T {
     }
 }
 
+/// Unwraps a result, assuming it is an `err(U)`
+fn unwrap_err<T, U>(+res: Result<T, U>) -> U {
+    match move res {
+      Err(move u) => u,
+      Ok(_) => fail ~"unwrap called on an ok result"
+    }
+}
+
 impl<T:Eq,U:Eq> Result<T,U> : Eq {
     pure fn eq(&&other: Result<T,U>) -> bool {
         match self {

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -341,15 +341,10 @@ fn iter_vec2<S,T,U:copy>(ss: &[S], ts: &[T],
 }
 
 /// Unwraps a result, assuming it is an `ok(T)`
-fn unwrap<T, U>(-res: Result<T, U>) -> T {
-    unsafe {
-        let addr = match res {
-          Ok(x) => ptr::addr_of(x),
-          Err(_) => fail ~"error result"
-        };
-        let liberated_value = unsafe::reinterpret_cast(*addr);
-        unsafe::forget(res);
-        return liberated_value;
+fn unwrap<T, U>(+res: Result<T, U>) -> T {
+    match move res {
+      Ok(move t) => t,
+      Err(_) => fail ~"unwrap called on an err result"
     }
 }
 

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -53,7 +53,7 @@ pure fn get_ref<T, U>(res: &a/Result<T, U>) -> &a/T {
 pure fn get_err<T, U: copy>(res: Result<T, U>) -> U {
     match res {
       Err(u) => u,
-      Ok(_) => fail ~"get_error called on ok result"
+      Ok(_) => fail ~"get_err called on ok result"
     }
 }
 

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -115,11 +115,6 @@ export
    StrSlice,
    UniqueStr;
 
-#[abi = "cdecl"]
-extern mod rustrt {
-    fn str_reserve_shared(&ss: ~str, nn: libc::size_t);
-}
-
 /*
 Section: Creating a string
 */
@@ -1818,8 +1813,9 @@ pure fn as_buf<T>(s: &str, f: fn(*u8, uint) -> T) -> T {
  * * n - The number of bytes to reserve space for
  */
 fn reserve(&s: ~str, n: uint) {
-    if capacity(s) < n {
-        rustrt::str_reserve_shared(s, n as size_t);
+    unsafe {
+        let v: *mut ~[u8] = ::unsafe::reinterpret_cast(ptr::addr_of(s));
+        vec::reserve(*v, n + 1);
     }
 }
 

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -220,14 +220,9 @@ fn push_char(&s: ~str, ch: char) {
                 *ptr::mut_offset(buf, off + 5u) =
                     (code & 63u | tag_cont) as u8;
             }
-            *ptr::mut_offset(buf, off + nb) = 0u8;
         }
 
-        do as_bytes(s) |bytes| {
-            let mut mut_bytes: ~[u8] = ::unsafe::reinterpret_cast(bytes);
-            vec::unsafe::set_len(mut_bytes, new_len + 1u);
-            ::unsafe::forget(mut_bytes);
-        }
+        unsafe::set_len(s, new_len);
     }
 }
 

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -1877,7 +1877,7 @@ mod u8 {
     pure fn gt(a: &~[u8], b: &~[u8]) -> bool { cmp(a, b) > 0 }
 
     /// Byte-vec hash function
-    fn hash(s: &~[u8]) -> uint {
+    pure fn hash(s: &~[u8]) -> uint {
         hash::hash_bytes(*s) as uint
     }
 

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -102,9 +102,6 @@ extern mod rustrt {
     fn vec_reserve_shared(++t: *sys::TypeDesc,
                           ++v: **unsafe::VecRepr,
                           ++n: libc::size_t);
-    fn vec_from_buf_shared(++t: *sys::TypeDesc,
-                           ++ptr: *(),
-                           ++count: libc::size_t) -> *unsafe::VecRepr;
 }
 
 #[abi = "rust-intrinsic"]
@@ -1727,10 +1724,11 @@ mod unsafe {
      */
     #[inline(always)]
     unsafe fn from_buf<T>(ptr: *T, elts: uint) -> ~[T] {
-        return ::unsafe::reinterpret_cast(
-            rustrt::vec_from_buf_shared(sys::get_type_desc::<T>(),
-                                        ptr as *(),
-                                        elts as size_t));
+        let mut dst = ~[];
+        reserve(dst, elts);
+        set_len(dst, elts);
+        as_buf(dst, |p_dst, _len_dst| ptr::memcpy(p_dst, ptr, elts));
+        dst
     }
 
     /**

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -141,13 +141,6 @@ vec_reserve_shared(type_desc* ty, rust_vec_box** vp,
     reserve_vec_exact(task, vp, n_elts * ty->size);
 }
 
-extern "C" CDECL void
-str_reserve_shared(rust_vec_box** sp,
-                   size_t n_elts) {
-    rust_task *task = rust_get_current_task();
-    reserve_vec_exact(task, sp, n_elts + 1);
-}
-
 extern "C" CDECL rust_vec*
 rand_seed() {
     size_t size = sizeof(ub4) * RANDSIZ;

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -148,16 +148,6 @@ str_reserve_shared(rust_vec_box** sp,
     reserve_vec_exact(task, sp, n_elts + 1);
 }
 
-extern "C" CDECL void
-rust_str_push(rust_vec_box** sp, uint8_t byte) {
-    rust_task *task = rust_get_current_task();
-    size_t fill = (*sp)->body.fill;
-    reserve_vec(task, sp, fill + 1);
-    (*sp)->body.data[fill-1] = byte;
-    (*sp)->body.data[fill] = 0;
-    (*sp)->body.fill = fill + 1;
-}
-
 extern "C" CDECL rust_vec*
 rand_seed() {
     size_t size = sizeof(ub4) * RANDSIZ;

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -148,22 +148,6 @@ str_reserve_shared(rust_vec_box** sp,
     reserve_vec_exact(task, sp, n_elts + 1);
 }
 
-/**
- * Copies elements in an unsafe buffer to the given interior vector. The
- * vector must have size zero.
- */
-extern "C" CDECL rust_vec_box*
-vec_from_buf_shared(type_desc *ty, void *ptr, size_t count) {
-    rust_task *task = rust_get_current_task();
-    size_t fill = ty->size * count;
-    rust_vec_box* v = (rust_vec_box*)
-        task->kernel->malloc(fill + sizeof(rust_vec_box),
-                             "vec_from_buf");
-    v->body.fill = v->body.alloc = fill;
-    memmove(&v->body.data[0], ptr, fill);
-    return v;
-}
-
 extern "C" CDECL void
 rust_str_push(rust_vec_box** sp, uint8_t byte) {
     rust_task *task = rust_get_current_task();
@@ -515,8 +499,9 @@ void tm_to_rust_tm(tm* in_tm, rust_tm* out_tm, int32_t gmtoff,
     out_tm->tm_nsec = nsec;
 
     if (zone != NULL) {
+        rust_task *task = rust_get_current_task();
         size_t size = strlen(zone);
-        str_reserve_shared(&out_tm->tm_zone, size);
+        reserve_vec_exact(task, &out_tm->tm_zone, size + 1);
         memcpy(out_tm->tm_zone->body.data, zone, size);
         out_tm->tm_zone->body.fill = size + 1;
         out_tm->tm_zone->body.data[size] = '\0';

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -63,7 +63,6 @@ start_task
 vec_reserve_shared_actual
 vec_reserve_shared
 str_reserve_shared
-vec_from_buf_shared
 task_clear_event_reject
 task_wait_event
 task_signal_event

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -61,7 +61,6 @@ shape_log_str
 start_task
 vec_reserve_shared_actual
 vec_reserve_shared
-str_reserve_shared
 task_clear_event_reject
 task_wait_event
 task_signal_event

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -38,7 +38,6 @@ rust_getcwd
 rust_get_stdin
 rust_get_stdout
 rust_get_stderr
-rust_str_push
 rust_list_files
 rust_log_console_on
 rust_log_console_off


### PR DESCRIPTION
I noticed that the string runtime functions could be replaced with pure rust functions. Also there are some minor cleanup like switching result::unwrap with moves, helper functions like send_map::linear::str_map, and etc.
