### PR TITLE
JSON pretting printing and bugfix

### DIFF
--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -11,11 +11,14 @@ import io::WriterUtil;
 import map;
 import map::hashmap;
 import map::map;
+import sort;
 
 export Json;
 export Error;
 export to_writer;
+export to_writer_pretty;
 export to_str;
+export to_str_pretty;
 export from_reader;
 export from_str;
 export eq;
@@ -88,8 +91,8 @@ fn to_writer(wr: io::Writer, j: Json) {
 /// Serializes a json value into a io::writer
 fn to_writer_pretty(wr: io::Writer, j: Json, indent: uint) {
     fn spaces(n: uint) -> ~str {
-        let ss = ~"";
-        n.times { str::push_str(ss, " "); }
+        let mut ss = ~"";
+        for n.times { str::push_str(ss, " "); }
         return ss;
     }
 
@@ -97,7 +100,7 @@ fn to_writer_pretty(wr: io::Writer, j: Json, indent: uint) {
       Num(n) => wr.write_str(float::to_str(n, 6u)),
       String(s) => wr.write_str(escape_str(*s)),
       Boolean(b) => wr.write_str(if b { ~"true" } else { ~"false" }),
-      List(v) => {
+      List(vv) => {
         // [
         wr.write_str(spaces(indent));
         wr.write_str("[ ");
@@ -107,7 +110,7 @@ fn to_writer_pretty(wr: io::Writer, j: Json, indent: uint) {
         //   elem ]
         let inner_indent = indent + 2;
         let mut first = true;
-        for (*v).each |item| {
+        for (*vv).each |item| {
             if !first {
                 wr.write_str(~",\n");
                 wr.write_str(spaces(inner_indent));
@@ -119,7 +122,16 @@ fn to_writer_pretty(wr: io::Writer, j: Json, indent: uint) {
         // ]
         wr.write_str(~" ]");
       }
-      Dict(d) => {
+      Dict(dd) => {
+        // convert from a dictionary
+        let mut pairs = ~[];
+        for dd.each |key, value| {
+            vec::push(pairs, (key, value));
+        }
+
+        // sort by key strings
+        let sorted_pairs = sort::merge_sort(|a,b| *a <= *b, pairs);
+
         // {
         wr.write_str(spaces(indent));
         wr.write_str(~"{ ");
@@ -129,7 +141,8 @@ fn to_writer_pretty(wr: io::Writer, j: Json, indent: uint) {
         //   k: v }
         let inner_indent = indent + 2;
         let mut first = true;
-        for d.each |key, value| {
+        for sorted_pairs.each |kv| {
+            let (key, value) = kv;
             if !first {
                 wr.write_str(~",\n");
                 wr.write_str(spaces(inner_indent));

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -101,14 +101,20 @@ fn to_writer_pretty(wr: io::Writer, j: Json, indent: uint) {
       String(s) => wr.write_str(escape_str(*s)),
       Boolean(b) => wr.write_str(if b { ~"true" } else { ~"false" }),
       List(vv) => {
+        if vv.len() == 0u {
+            wr.write_str(~"[]");
+            return;
+        }
+
+        let inner_indent = indent + 2;
+
         // [
-        wr.write_str(spaces(indent));
-        wr.write_str("[ ");
+        wr.write_str("[\n");
+        wr.write_str(spaces(inner_indent));
 
         // [ elem,
         //   elem,
         //   elem ]
-        let inner_indent = indent + 2;
         let mut first = true;
         for (*vv).each |item| {
             if !first {
@@ -120,9 +126,18 @@ fn to_writer_pretty(wr: io::Writer, j: Json, indent: uint) {
         };
 
         // ]
-        wr.write_str(~" ]");
+        wr.write_str("\n");
+        wr.write_str(spaces(indent));
+        wr.write_str(~"]");
       }
       Dict(dd) => {
+        if dd.size() == 0u {
+            wr.write_str(~"{}");
+            return;
+        }
+
+        let inner_indent = indent + 2;
+
         // convert from a dictionary
         let mut pairs = ~[];
         for dd.each |key, value| {
@@ -133,13 +148,12 @@ fn to_writer_pretty(wr: io::Writer, j: Json, indent: uint) {
         let sorted_pairs = sort::merge_sort(|a,b| *a <= *b, pairs);
 
         // {
-        wr.write_str(spaces(indent));
-        wr.write_str(~"{ ");
+        wr.write_str(~"{\n");
+        wr.write_str(spaces(inner_indent));
 
         // { k: v,
         //   k: v,
         //   k: v }
-        let inner_indent = indent + 2;
         let mut first = true;
         for sorted_pairs.each |kv| {
             let (key, value) = kv;
@@ -149,13 +163,15 @@ fn to_writer_pretty(wr: io::Writer, j: Json, indent: uint) {
             }
             first = false;
             let key = str::append(escape_str(key), ~": ");
-            let key_indent = str::len(key);
+            let key_indent = inner_indent + str::len(key);
             wr.write_str(key);
             to_writer_pretty(wr, value, key_indent);
         };
 
         // }
-        wr.write_str(~" }");
+        wr.write_str(~"\n");
+        wr.write_str(spaces(indent));
+        wr.write_str(~"}");
       }
       Null => wr.write_str(~"null")
     }
@@ -877,6 +893,12 @@ mod tests {
         assert from_str(~"\"\\r\"") == Ok(String(@~"\r"));
         assert from_str(~"\"\\t\"") == Ok(String(@~"\t"));
         assert from_str(~" \"foo\" ") == Ok(String(@~"foo"));
+    }
+
+    #[test]
+    fn test_unicode_hex_escapes_in_str() {
+        assert from_str(~"\"\\u12ab\"") == Ok(String(@~"\u12ab"));
+        assert from_str(~"\"\\uAB12\"") == Ok(String(@~"\uAB12"));
     }
 
     #[test]

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -85,6 +85,69 @@ fn to_writer(wr: io::Writer, j: Json) {
     }
 }
 
+/// Serializes a json value into a io::writer
+fn to_writer_pretty(wr: io::Writer, j: Json, indent: uint) {
+    fn spaces(n: uint) -> ~str {
+        let ss = ~"";
+        n.times { str::push_str(ss, " "); }
+        return ss;
+    }
+
+    match j {
+      Num(n) => wr.write_str(float::to_str(n, 6u)),
+      String(s) => wr.write_str(escape_str(*s)),
+      Boolean(b) => wr.write_str(if b { ~"true" } else { ~"false" }),
+      List(v) => {
+        // [
+        wr.write_str(spaces(indent));
+        wr.write_str("[ ");
+
+        // [ elem,
+        //   elem,
+        //   elem ]
+        let inner_indent = indent + 2;
+        let mut first = true;
+        for (*v).each |item| {
+            if !first {
+                wr.write_str(~",\n");
+                wr.write_str(spaces(inner_indent));
+            }
+            first = false;
+            to_writer_pretty(wr, item, inner_indent);
+        };
+
+        // ]
+        wr.write_str(~" ]");
+      }
+      Dict(d) => {
+        // {
+        wr.write_str(spaces(indent));
+        wr.write_str(~"{ ");
+
+        // { k: v,
+        //   k: v,
+        //   k: v }
+        let inner_indent = indent + 2;
+        let mut first = true;
+        for d.each |key, value| {
+            if !first {
+                wr.write_str(~",\n");
+                wr.write_str(spaces(inner_indent));
+            }
+            first = false;
+            let key = str::append(escape_str(key), ~": ");
+            let key_indent = str::len(key);
+            wr.write_str(key);
+            to_writer_pretty(wr, value, key_indent);
+        };
+
+        // }
+        wr.write_str(~" }");
+      }
+      Null => wr.write_str(~"null")
+    }
+}
+
 fn escape_str(s: ~str) -> ~str {
     let mut escaped = ~"\"";
     do str::chars_iter(s) |c| {
@@ -108,6 +171,11 @@ fn escape_str(s: ~str) -> ~str {
 /// Serializes a json value into a string
 fn to_str(j: Json) -> ~str {
     io::with_str_writer(|wr| to_writer(wr, j))
+}
+
+/// Serializes a json value into a string, with whitespace and sorting
+fn to_str_pretty(j: Json) -> ~str {
+    io::with_str_writer(|wr| to_writer_pretty(wr, j, 0))
 }
 
 type Parser_ = {

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -427,17 +427,25 @@ impl Parser {
                       while i < 4u {
                           match self.next_char() {
                             '0' to '9' => {
-                              n = n * 10u +
-                                  (self.ch as uint) - ('0' as uint);
-                            }
-                            _ => return self.error(~"invalid \\u escape")
+                              n = n * 16u + (self.ch as uint)
+                                          - ('0'     as uint);
+                            },
+                            'a' | 'A' => n = n * 16u + 10u,
+                            'b' | 'B' => n = n * 16u + 11u,
+                            'c' | 'C' => n = n * 16u + 12u,
+                            'd' | 'D' => n = n * 16u + 13u,
+                            'e' | 'E' => n = n * 16u + 14u,
+                            'f' | 'F' => n = n * 16u + 15u,
+                            _ => return self.error(
+                                   ~"invalid \\u escape (unrecognized hex)")
                           }
                           i += 1u;
                       }
 
                       // Error out if we didn't parse 4 digits.
                       if i != 4u {
-                          return self.error(~"invalid \\u escape");
+                          return self.error(
+                            ~"invalid \\u escape (not four digits)");
                       }
 
                       str::push_char(res, n as char);


### PR DESCRIPTION
These commits (1) add a pretty-printing function for JSON data, and (2) fix a bug in the handling of `\u` style escaped unicode in JSON strings.

Note: this set needs to be rebased on top of incoming, but since incoming is broken I haven't bothered yet.  It passes all the tests under `CFG_DISABLE_VALGRIND=1 make check` on master.
