### PR TITLE
fix issue #3222

### DIFF
--- a/src/rustc/middle/trans/alt.rs
+++ b/src/rustc/middle/trans/alt.rs
@@ -58,8 +58,7 @@ fn trans_opt(bcx: block, o: opt) -> opt_result {
             return single_result(rslt(bcx, *cell));
           }
           _ => {
-            return single_result(
-                rslt(bcx, consts::const_expr(ccx, l)));
+            return single_result(trans_temp_expr(bcx, l));
           }
         }
       }
@@ -636,13 +635,14 @@ fn compile_submatch(bcx: block, m: match_, vals: ~[ValueRef],
             }
           }
           lit(_) => {
-            test_val = Load(bcx, val);
             let pty = node_id_type(bcx, pat_id);
+            test_val = load_if_immediate(bcx, val, pty);
             kind = if ty::type_is_integral(pty) { switch }
                    else { compare };
           }
           range(_, _) => {
-            test_val = Load(bcx, val);
+            let pty = node_id_type(bcx, pat_id);
+            test_val = load_if_immediate(bcx, val, pty);
             kind = compare;
           }
         }

--- a/src/test/run-pass/alt-borrowed_str.rs
+++ b/src/test/run-pass/alt-borrowed_str.rs
@@ -1,0 +1,51 @@
+// -*- rust -*-
+fn f1(ref_string: &str) {
+    match ref_string {
+        "a" => io::println("found a"),
+        "b" => io::println("found b"),
+        _ => io::println("not found")
+    }
+}
+
+fn f2(ref_string: &str) {
+    match ref_string {
+        "a" => io::println("found a"),
+        "b" => io::println("found b"),
+        s => io::println(fmt!("not found (%s)", s))
+    }
+}
+
+fn g1(ref_1: &str, ref_2: &str) {
+    match (ref_1, ref_2) {
+        ("a", "b") => io::println("found a,b"),
+        ("b", "c") => io::println("found b,c"),
+        _ => io::println("not found")
+    }
+}
+
+fn g2(ref_1: &str, ref_2: &str) {
+    match (ref_1, ref_2) {
+        ("a", "b") => io::println("found a,b"),
+        ("b", "c") => io::println("found b,c"),
+        (s1, s2) => io::println(fmt!("not found (%s, %s)", s1, s2))
+    }
+}
+
+fn main() {
+    f1(@"a");
+    f1(~"b");
+    f1(&"c");
+    f1("d");
+    f2(@"a");
+    f2(~"b");
+    f2(&"c");
+    f2("d");
+    g1(@"a", @"b");
+    g1(~"b", ~"c");
+    g1(&"c", &"d");
+    g1("d", "e");
+    g2(@"a", @"b");
+    g2(~"b", ~"c");
+    g2(&"c", &"d");
+    g2("d", "e");
+}


### PR DESCRIPTION
Borrowed strings have one indirection less than other strings. With the matched expression, an extra Load was done. With patterns, constant strings weren't Store/Load as needed.

I add a test: src/test/run-pass/alt-borrowed_str.rs

I start watching rust 2 weeks ago. Even if I did my best to make something consistent, the LLVM generator is quite hard to understand: I may have miss something. Please, before merging, check I didn't break the model.
