### PR TITLE
use native log2 function and enable freebsd tests in uv_ll

### DIFF
--- a/src/libcore/cmath.rs
+++ b/src/libcore/cmath.rs
@@ -65,9 +65,6 @@ extern mod c_double {
     // renamed: to be consitent with log as ln
     #[link_name="log1p"] pure fn ln1p(n: c_double) -> c_double;
     pure fn log10(n: c_double) -> c_double;
-    #[cfg(target_os="linux")]
-    #[cfg(target_os="macos")]
-    #[cfg(target_os="win32")]
     pure fn log2(n: c_double) -> c_double;
     #[link_name="ilogb"] pure fn ilog_radix(n: c_double) -> c_int;
     pure fn modf(n: c_double, &iptr: c_double) -> c_double;
@@ -143,9 +140,6 @@ extern mod c_float {
     #[link_name="logf"] pure fn ln(n: c_float) -> c_float;
     #[link_name="logbf"] pure fn log_radix(n: c_float) -> c_float;
     #[link_name="log1pf"] pure fn ln1p(n: c_float) -> c_float;
-    #[cfg(target_os="linux")]
-    #[cfg(target_os="macos")]
-    #[cfg(target_os="win32")]
     #[link_name="log2f"] pure fn log2(n: c_float) -> c_float;
     #[link_name="log10f"] pure fn log10(n: c_float) -> c_float;
     #[link_name="ilogbf"] pure fn ilog_radix(n: c_float) -> c_int;

--- a/src/libcore/f32.rs
+++ b/src/libcore/f32.rs
@@ -152,23 +152,8 @@ pure fn signbit(x: f32) -> int {
     if is_negative(x) { return 1; } else { return 0; }
 }
 
-#[cfg(target_os="linux")]
-#[cfg(target_os="macos")]
-#[cfg(target_os="win32")]
 pure fn logarithm(n: f32, b: f32) -> f32 {
     return log2(n) / log2(b);
-}
-
-#[cfg(target_os="freebsd")]
-pure fn logarithm(n: f32, b: f32) -> f32 {
-    // FIXME (#2000): check if it is good to use log2 instead of ln here;
-    // in theory should be faster since the radix is 2
-    return ln(n) / ln(b);
-}
-
-#[cfg(target_os="freebsd")]
-pure fn log2(n: f32) -> f32 {
-    return ln(n) / consts::ln_2;
 }
 
 impl f32: num::Num {

--- a/src/libcore/f64.rs
+++ b/src/libcore/f64.rs
@@ -179,23 +179,8 @@ pure fn signbit(x: f64) -> int {
     if is_negative(x) { return 1; } else { return 0; }
 }
 
-#[cfg(target_os="linux")]
-#[cfg(target_os="macos")]
-#[cfg(target_os="win32")]
 pure fn logarithm(n: f64, b: f64) -> f64 {
     return log2(n) / log2(b);
-}
-
-#[cfg(target_os="freebsd")]
-pure fn logarithm(n: f64, b: f64) -> f64 {
-    // FIXME (#2000): check if it is good to use log2 instead of ln here; in
-    // theory should be faster since the radix is 2
-    return ln(n) / ln(b);
-}
-
-#[cfg(target_os="freebsd")]
-pure fn log2(n: f64) -> f64 {
-    return ln(n) / consts::ln_2;
 }
 
 impl f64: num::Num {

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -1522,7 +1522,6 @@ mod test {
 
     // struct size tests
     #[test]
-    #[ignore(cfg(target_os = "freebsd"))]
     fn test_uv_ll_struct_size_uv_tcp_t() {
         let foreign_handle_size = rustrt::rust_uv_helper_uv_tcp_t_size();
         let rust_handle_size = sys::size_of::<uv_tcp_t>();
@@ -1532,7 +1531,6 @@ mod test {
         assert foreign_handle_size as uint == rust_handle_size;
     }
     #[test]
-    #[ignore(cfg(target_os = "freebsd"))]
     fn test_uv_ll_struct_size_uv_connect_t() {
         let foreign_handle_size =
             rustrt::rust_uv_helper_uv_connect_t_size();
@@ -1543,7 +1541,6 @@ mod test {
         assert foreign_handle_size as uint == rust_handle_size;
     }
     #[test]
-    #[ignore(cfg(target_os = "freebsd"))]
     fn test_uv_ll_struct_size_uv_buf_t() {
         let foreign_handle_size =
             rustrt::rust_uv_helper_uv_buf_t_size();
@@ -1554,7 +1551,6 @@ mod test {
         assert foreign_handle_size as uint == rust_handle_size;
     }
     #[test]
-    #[ignore(cfg(target_os = "freebsd"))]
     fn test_uv_ll_struct_size_uv_write_t() {
         let foreign_handle_size =
             rustrt::rust_uv_helper_uv_write_t_size();
@@ -1566,7 +1562,6 @@ mod test {
     }
 
     #[test]
-    #[ignore(cfg(target_os = "freebsd"))]
     fn test_uv_ll_struct_size_sockaddr_in() {
         let foreign_handle_size =
             rustrt::rust_uv_helper_sockaddr_in_size();
@@ -1577,7 +1572,6 @@ mod test {
         assert foreign_handle_size as uint == rust_handle_size;
     }
     #[test]
-    #[ignore(cfg(target_os = "freebsd"))]
     fn test_uv_ll_struct_size_sockaddr_in6() {
         let foreign_handle_size =
             rustrt::rust_uv_helper_sockaddr_in6_size();
@@ -1605,7 +1599,6 @@ mod test {
     }
 
     #[test]
-    #[ignore(cfg(target_os = "freebsd"))]
     fn test_uv_ll_struct_size_uv_async_t() {
         let foreign_handle_size =
             rustrt::rust_uv_helper_uv_async_t_size();
@@ -1617,7 +1610,6 @@ mod test {
     }
 
     #[test]
-    #[ignore(cfg(target_os = "freebsd"))]
     fn test_uv_ll_struct_size_uv_timer_t() {
         let foreign_handle_size =
             rustrt::rust_uv_helper_uv_timer_t_size();
@@ -1629,7 +1621,6 @@ mod test {
     }
 
     #[test]
-    #[ignore(cfg(target_os = "freebsd"))]
     #[ignore(cfg(target_os = "win32"))]
     fn test_uv_ll_struct_size_uv_getaddrinfo_t() {
         let foreign_handle_size =
@@ -1641,7 +1632,6 @@ mod test {
         assert foreign_handle_size as uint == rust_handle_size;
     }
     #[test]
-    #[ignore(cfg(target_os = "freebsd"))]
     #[ignore(cfg(target_os = "macos"))]
     #[ignore(cfg(target_os = "win32"))]
     fn test_uv_ll_struct_size_addrinfo() {


### PR DESCRIPTION
FreeBSD 9.0 has log2 and log2f functions. There is no need to write our own version.
