### PR TITLE
(partially fix incoming) More hash function simplification

### DIFF
--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -66,7 +66,7 @@ fn read_line() {
 fn str_set() {
     let r = rand::Rng();
 
-    let s = map::hashmap(str::hash, str::eq);
+    let s = map::hashmap();
 
     for int::range(0, 1000) |_i| {
         map::set_add(s, r.gen_str(10));

--- a/src/test/bench/graph500-bfs.rs
+++ b/src/test/bench/graph500-bfs.rs
@@ -67,11 +67,9 @@ fn make_edges(scale: uint, edgefactor: uint) -> ~[(node_id, node_id)] {
     }
 }
 
-pure fn node_hash(n: &node_id) -> uint { *n as uint }
-
 fn make_graph(N: uint, edges: ~[(node_id, node_id)]) -> graph {
     let graph = do vec::from_fn(N) |_i| {
-        map::hashmap::<node_id, ()>(node_hash, sys::shape_eq)
+        map::hashmap::<node_id, ()>()
     };
 
     do vec::each(edges) |e| {
@@ -87,7 +85,7 @@ fn make_graph(N: uint, edges: ~[(node_id, node_id)]) -> graph {
 }
 
 fn gen_search_keys(graph: graph, n: uint) -> ~[node_id] {
-    let keys = map::hashmap::<node_id, ()>(node_hash, sys::shape_eq);
+    let keys = map::hashmap::<node_id, ()>();
     let r = rand::Rng();
 
     while keys.size() < n {

--- a/src/test/bench/task-perf-word-count-generic.rs
+++ b/src/test/bench/task-perf-word-count-generic.rs
@@ -39,13 +39,6 @@ trait hash_key {
     pure fn eq(&&k: self) -> bool;
 }
 
-fn mk_hash<K: Const hash_key, V: Copy>() -> map::hashmap<K, V> {
-    pure fn hashfn<K: Const hash_key>(k: &K) -> uint { k.hash() }
-    pure fn hasheq<K: Const hash_key>(k1: &K, k2: &K) -> bool { k1.eq(*k2) }
-
-    map::hashmap(hashfn, hasheq)
-}
-
 impl ~str: hash_key {
     pure fn hash() -> uint { str::hash(&self) }
     pure fn eq(&&x: ~str) -> bool { self == x }
@@ -175,11 +168,12 @@ mod map_reduce {
         input: K1)
     {
         // log(error, "map_task " + input);
-        let intermediates = mk_hash();
+        let intermediates = map::hashmap();
 
         do map(input) |key, val| {
             let mut c = None;
-            match intermediates.find(key) {
+            let found = intermediates.find(key);
+            match found {
               Some(_c) => { c = Some(_c); }
               None => {
                 do ctrl.swap |ctrl| {
@@ -251,7 +245,7 @@ mod map_reduce {
         // This task becomes the master control task. It task::_spawns
         // to do the rest.
 
-        let reducers = mk_hash();
+        let reducers = map::hashmap();
         let mut tasks = start_mappers(map, ctrl, inputs);
         let mut num_mappers = vec::len(inputs) as int;
 


### PR DESCRIPTION
This removes several hash functions used with hashmap().

I am now getting an error I'm, at the moment more confused by:

```
/code/rust/src/test/bench/task-perf-word-count-generic.rs:175:24: 175:42 error: failed to find an implementation of trait core::cmp::Eq for 'b
/code/rust/src/test/bench/task-perf-word-count-generic.rs:175             let found = intermediates.find(key);
                                                                                      ^~~~~~~~~~~~~~~~~~
```

Does this error message mean that the type of key used here needs to implement Eq?
