### PR TITLE
core: Allocate threads on demand, not on scheduler startup

### DIFF
--- a/src/libcore/task.rs
+++ b/src/libcore/task.rs
@@ -1655,8 +1655,8 @@ extern mod rustrt {
 
     fn rust_get_sched_id() -> sched_id;
     fn rust_new_sched(num_threads: libc::uintptr_t) -> sched_id;
-    fn rust_max_sched_threads() -> libc::size_t;
     fn rust_sched_threads() -> libc::size_t;
+    fn rust_sched_current_nonlazy_threads() -> libc::size_t;
     fn rust_num_threads() -> libc::uintptr_t;
 
     fn get_task_id() -> task_id;
@@ -2430,7 +2430,7 @@ fn test_sched_thread_per_core() {
 
     do spawn_sched(ThreadPerCore) {
         let cores = rustrt::rust_num_threads();
-        let reported_threads = rustrt::rust_max_sched_threads();
+        let reported_threads = rustrt::rust_sched_threads();
         assert(cores as uint == reported_threads as uint);
         chan.send(());
     }
@@ -2443,9 +2443,9 @@ fn test_spawn_thread_on_demand() {
     let (chan, port) = pipes::stream();
 
     do spawn_sched(ManualThreads(2)) {
-        let max_threads = rustrt::rust_max_sched_threads();
+        let max_threads = rustrt::rust_sched_threads();
         assert(max_threads as int == 2);
-        let running_threads = rustrt::rust_sched_threads();
+        let running_threads = rustrt::rust_sched_current_nonlazy_threads();
         assert(running_threads as int == 1);
 
         let (chan2, port2) = pipes::stream();
@@ -2454,7 +2454,7 @@ fn test_spawn_thread_on_demand() {
             chan2.send(());
         }
 
-        let running_threads2 = rustrt::rust_sched_threads();
+        let running_threads2 = rustrt::rust_sched_current_nonlazy_threads();
         assert(running_threads2 as int == 2);
 
         port2.recv();

--- a/src/libcore/task.rs
+++ b/src/libcore/task.rs
@@ -1655,7 +1655,8 @@ extern mod rustrt {
 
     fn rust_get_sched_id() -> sched_id;
     fn rust_new_sched(num_threads: libc::uintptr_t) -> sched_id;
-    fn sched_threads() -> libc::size_t;
+    fn rust_max_sched_threads() -> libc::size_t;
+    fn rust_sched_threads() -> libc::size_t;
     fn rust_num_threads() -> libc::uintptr_t;
 
     fn get_task_id() -> task_id;
@@ -2429,8 +2430,34 @@ fn test_sched_thread_per_core() {
 
     do spawn_sched(ThreadPerCore) {
         let cores = rustrt::rust_num_threads();
-        let reported_threads = rustrt::sched_threads();
+        let reported_threads = rustrt::rust_max_sched_threads();
         assert(cores as uint == reported_threads as uint);
+        chan.send(());
+    }
+
+    port.recv();
+}
+
+#[test]
+fn test_spawn_thread_on_demand() {
+    let (chan, port) = pipes::stream();
+
+    do spawn_sched(ManualThreads(2)) {
+        let max_threads = rustrt::rust_max_sched_threads();
+        assert(max_threads as int == 2);
+        let running_threads = rustrt::rust_sched_threads();
+        assert(running_threads as int == 1);
+
+        let (chan2, port2) = pipes::stream();
+
+        do spawn() {
+            chan2.send(());
+        }
+
+        let running_threads2 = rustrt::rust_sched_threads();
+        assert(running_threads2 as int == 2);
+
+        port2.recv();
         chan.send(());
     }
 

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -26,7 +26,7 @@ export run_tests_console;
 
 #[abi = "cdecl"]
 extern mod rustrt {
-    fn rust_max_sched_threads() -> libc::size_t;
+    fn rust_sched_threads() -> libc::size_t;
 }
 
 // The name of a test. By convention this follows the rules for rust
@@ -330,7 +330,7 @@ const sched_overcommit : uint = 1u;
 const sched_overcommit : uint = 4u;
 
 fn get_concurrency() -> uint {
-    let threads = rustrt::rust_max_sched_threads() as uint;
+    let threads = rustrt::rust_sched_threads() as uint;
     if threads == 1u { 1u }
     else { threads * sched_overcommit }
 }

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -26,7 +26,7 @@ export run_tests_console;
 
 #[abi = "cdecl"]
 extern mod rustrt {
-    fn sched_threads() -> libc::size_t;
+    fn rust_max_sched_threads() -> libc::size_t;
 }
 
 // The name of a test. By convention this follows the rules for rust
@@ -330,7 +330,7 @@ const sched_overcommit : uint = 1u;
 const sched_overcommit : uint = 4u;
 
 fn get_concurrency() -> uint {
-    let threads = rustrt::sched_threads() as uint;
+    let threads = rustrt::rust_max_sched_threads() as uint;
     if threads == 1u { 1u }
     else { threads * sched_overcommit }
 }

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -627,9 +627,15 @@ start_task(rust_task *target, fn_env_pair *f) {
 }
 
 extern "C" CDECL size_t
-sched_threads() {
+rust_sched_threads() {
     rust_task *task = rust_get_current_task();
     return task->sched->number_of_threads();
+}
+
+extern "C" CDECL size_t
+rust_max_sched_threads() {
+    rust_task *task = rust_get_current_task();
+    return task->sched->max_number_of_threads();
 }
 
 extern "C" CDECL rust_port*

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -627,13 +627,13 @@ start_task(rust_task *target, fn_env_pair *f) {
 }
 
 extern "C" CDECL size_t
-rust_sched_threads() {
+rust_sched_current_nonlazy_threads() {
     rust_task *task = rust_get_current_task();
     return task->sched->number_of_threads();
 }
 
 extern "C" CDECL size_t
-rust_max_sched_threads() {
+rust_sched_threads() {
     rust_task *task = rust_get_current_task();
     return task->sched->max_number_of_threads();
 }

--- a/src/rt/rust_kernel.cpp
+++ b/src/rt/rust_kernel.cpp
@@ -31,9 +31,10 @@ rust_kernel::rust_kernel(rust_env *env) :
 
     // Create the single threaded scheduler that will run on the platform's
     // main thread
-    rust_manual_sched_launcher_factory launchfac;
-    osmain_scheduler = create_scheduler(&launchfac, 1, false);
-    osmain_driver = launchfac.get_driver();
+    rust_manual_sched_launcher_factory *launchfac =
+        new rust_manual_sched_launcher_factory();
+    osmain_scheduler = create_scheduler(launchfac, 1, false);
+    osmain_driver = launchfac->get_driver();
     sched_reaper.start();
 }
 
@@ -79,8 +80,9 @@ void rust_kernel::free(void *mem) {
 
 rust_sched_id
 rust_kernel::create_scheduler(size_t num_threads) {
-    rust_thread_sched_launcher_factory launchfac;
-    return create_scheduler(&launchfac, num_threads, true);
+    rust_thread_sched_launcher_factory *launchfac =
+        new rust_thread_sched_launcher_factory();
+    return create_scheduler(launchfac, num_threads, true);
 }
 
 rust_sched_id

--- a/src/rt/rust_scheduler.h
+++ b/src/rt/rust_scheduler.h
@@ -30,19 +30,17 @@ private:
     uintptr_t live_tasks;
     size_t cur_thread;
     bool may_exit;
+    bool killed;
 
+    rust_sched_launcher_factory *launchfac;
     array_list<rust_sched_launcher *> threads;
-    const size_t num_threads;
+    const size_t max_num_threads;
 
     rust_sched_id id;
 
-    void create_task_threads(rust_sched_launcher_factory *launchfac,
-                             bool killed);
     void destroy_task_threads();
 
-    rust_sched_launcher *
-    create_task_thread(rust_sched_launcher_factory *launchfac, int id,
-                       bool killed);
+    rust_sched_launcher *create_task_thread(int id);
     void destroy_task_thread(rust_sched_launcher *thread);
 
     void exit();
@@ -51,7 +49,7 @@ private:
     void delete_this();
 
 public:
-    rust_scheduler(rust_kernel *kernel, size_t num_threads,
+    rust_scheduler(rust_kernel *kernel, size_t max_num_threads,
                    rust_sched_id id, bool allow_exit, bool killed,
                    rust_sched_launcher_factory *launchfac);
 
@@ -62,6 +60,7 @@ public:
 
     void release_task();
 
+    size_t max_number_of_threads();
     size_t number_of_threads();
     // Called by each thread when it terminates. When all threads
     // terminate the scheduler does as well.

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -30,6 +30,7 @@ rand_new_seeded
 rand_next
 rand_seed
 rust_get_sched_id
+rust_max_sched_threads
 rust_new_sched
 rust_new_task_in_sched
 rust_num_threads
@@ -48,6 +49,7 @@ rust_port_size
 rust_process_wait
 rust_ptr_eq
 rust_run_program
+rust_sched_threads
 rust_set_exit_status
 rust_start
 rust_getcwd
@@ -58,7 +60,6 @@ rust_get_task
 rust_get_stack_segment
 rust_task_weaken
 rust_task_unweaken
-sched_threads
 shape_log_str
 start_task
 vec_reserve_shared_actual

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -30,7 +30,6 @@ rand_new_seeded
 rand_next
 rand_seed
 rust_get_sched_id
-rust_max_sched_threads
 rust_new_sched
 rust_new_task_in_sched
 rust_num_threads
@@ -49,6 +48,7 @@ rust_port_size
 rust_process_wait
 rust_ptr_eq
 rust_run_program
+rust_sched_current_nonlazy_threads
 rust_sched_threads
 rust_set_exit_status
 rust_start

--- a/src/test/run-pass/morestack6.rs
+++ b/src/test/run-pass/morestack6.rs
@@ -8,7 +8,7 @@ extern mod rustrt {
     fn last_os_error() -> ~str;
     fn rust_getcwd() -> ~str;
     fn get_task_id() -> libc::intptr_t;
-    fn rust_max_sched_threads();
+    fn rust_sched_threads();
     fn rust_get_task();
 }
 
@@ -16,7 +16,7 @@ fn calllink01() { rustrt::rust_get_sched_id(); }
 fn calllink02() { rustrt::last_os_error(); }
 fn calllink03() { rustrt::rust_getcwd(); }
 fn calllink08() { rustrt::get_task_id(); }
-fn calllink09() { rustrt::rust_max_sched_threads(); }
+fn calllink09() { rustrt::rust_sched_threads(); }
 fn calllink10() { rustrt::rust_get_task(); }
 
 fn runtest(f: fn~(), frame_backoff: u32) {

--- a/src/test/run-pass/morestack6.rs
+++ b/src/test/run-pass/morestack6.rs
@@ -8,7 +8,7 @@ extern mod rustrt {
     fn last_os_error() -> ~str;
     fn rust_getcwd() -> ~str;
     fn get_task_id() -> libc::intptr_t;
-    fn sched_threads();
+    fn rust_max_sched_threads();
     fn rust_get_task();
 }
 
@@ -16,7 +16,7 @@ fn calllink01() { rustrt::rust_get_sched_id(); }
 fn calllink02() { rustrt::last_os_error(); }
 fn calllink03() { rustrt::rust_getcwd(); }
 fn calllink08() { rustrt::get_task_id(); }
-fn calllink09() { rustrt::sched_threads(); }
+fn calllink09() { rustrt::rust_max_sched_threads(); }
 fn calllink10() { rustrt::rust_get_task(); }
 
 fn runtest(f: fn~(), frame_backoff: u32) {


### PR DESCRIPTION
API change: rust_kernel::create_scheduler() or
rust_scheduler::rust_scheduler() respecitevly now take ownership of the
launch factory argument, it is needed to create new threads on demand.

Also renames rustrt::sched_threads() to rustrt::rust_sched_threads() for
consistency. Added rustrt::rust_max_sched_threads() to return the
maximal number of scheduled threads of the current scheduler.

Fixes #3493.
## 

I'm not sure if the launch factory argument should be kernel-allocated (like the scheduler) or not. At the moment it's a simple heap allocation, please tell me if should change that.
