### PR TITLE
new trait serialization, copyless bytes/str writer, and a str form_slice

### DIFF
--- a/src/fuzzer/fuzzer.rs
+++ b/src/fuzzer/fuzzer.rs
@@ -219,12 +219,8 @@ fn under(n: uint, it: fn(uint)) {
     while i < n { it(i); i += 1u; }
 }
 
-fn devnull() -> io::Writer { io::mem_buffer_writer(io::mem_buffer()) }
-
 fn as_str(f: fn@(io::Writer)) -> ~str {
-    let buf = io::mem_buffer();
-    f(io::mem_buffer_writer(buf));
-    io::mem_buffer_str(buf)
+    io::with_str_writer(f)
 }
 
 fn check_variants_of_ast(crate: ast::crate, codemap: codemap::codemap,

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1967,10 +1967,10 @@ mod raw {
    export
       from_buf,
       from_buf_len,
-      from_buf_len_nocopy,
       from_c_str,
       from_c_str_len,
       from_bytes,
+      form_slice,
       slice_bytes,
       view_bytes,
       push_byte,
@@ -2003,14 +2003,6 @@ mod raw {
         return ::unsafe::transmute(move v);
     }
 
-    /// Create a Rust string from a *u8 buffer of the given length
-    /// without copying
-    unsafe fn from_buf_len_nocopy(buf: &a / *u8, len: uint) -> &a / str {
-        let v = (*buf, len + 1);
-        assert is_utf8(::unsafe::reinterpret_cast(&v));
-        return ::unsafe::transmute(move v);
-    }
-
     /// Create a Rust string from a null-terminated C string
     unsafe fn from_c_str(c_str: *libc::c_char) -> ~str {
         from_buf(::unsafe::reinterpret_cast(&c_str))
@@ -2030,6 +2022,13 @@ mod raw {
 
     /// Converts a byte to a string.
     unsafe fn from_byte(u: u8) -> ~str { raw::from_bytes([u]) }
+
+    /// Form a slice from a *u8 buffer of the given length without copying.
+    unsafe fn buf_as_slice<T>(buf: *u8, len: uint, f: fn(&& &str) -> T) -> T {
+        let v = (*buf, len + 1);
+        assert is_utf8(::unsafe::reinterpret_cast(&v));
+        f(::unsafe::transmute(move v))
+    }
 
     /**
      * Takes a bytewise (not UTF-8) slice from a string.

--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -99,10 +99,9 @@ pure fn refcount<T>(+t: @T) -> uint {
 
 pure fn log_str<T>(t: T) -> ~str {
     unsafe {
-        let buffer = io::mem_buffer();
-        let writer = io::mem_buffer_writer(buffer);
-        repr::write_repr(writer, &t);
-        return io::mem_buffer_str(buffer);  // XXX: Extra malloc and copy.
+        do io::with_str_writer |wr| {
+            repr::write_repr(wr, &t)
+        }
     }
 }
 

--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -373,10 +373,10 @@ trait ToBytes {
 
 impl<A: IterBytes> A: ToBytes {
     fn to_bytes(lsb0: bool) -> ~[u8] {
-        let buf = io::mem_buffer();
-        for self.iter_bytes(lsb0) |bytes| {
-            buf.write(bytes)
+        do io::with_bytes_writer |wr| {
+            for self.iter_bytes(lsb0) |bytes| {
+                wr.write(bytes)
+            }
         }
-        io::mem_buffer_buf(buf)
     }
 }

--- a/src/libstd/ebml.rs
+++ b/src/libstd/ebml.rs
@@ -631,10 +631,11 @@ fn test_option_int() {
 
     fn test_v(v: Option<int>) {
         debug!("v == %?", v);
-        let mbuf = io::mem_buffer();
-        let ebml_w = ebml::Writer(io::mem_buffer_writer(mbuf));
-        serialize_0(ebml_w, v);
-        let ebml_doc = ebml::Doc(@io::mem_buffer_buf(mbuf));
+        let bytes = do io::with_bytes_writer |wr| {
+            let ebml_w = ebml::Writer(wr);
+            serialize_0(ebml_w, v);
+        };
+        let ebml_doc = ebml::Doc(@bytes);
         let deser = ebml_deserializer(ebml_doc);
         let v1 = deserialize_0(deser);
         debug!("v1 == %?", v1);

--- a/src/libstd/serialization2.rs
+++ b/src/libstd/serialization2.rs
@@ -1,0 +1,269 @@
+//! Support code for serialization.
+
+/*
+Core serialization interfaces.
+*/
+
+trait Serializer {
+    // Primitive types:
+    fn emit_nil();
+    fn emit_uint(v: uint);
+    fn emit_u64(v: u64);
+    fn emit_u32(v: u32);
+    fn emit_u16(v: u16);
+    fn emit_u8(v: u8);
+    fn emit_int(v: int);
+    fn emit_i64(v: i64);
+    fn emit_i32(v: i32);
+    fn emit_i16(v: i16);
+    fn emit_i8(v: i8);
+    fn emit_bool(v: bool);
+    fn emit_float(v: float);
+    fn emit_f64(v: f64);
+    fn emit_f32(v: f32);
+    fn emit_str(v: &str);
+
+    // Compound types:
+    fn emit_enum(name: &str, f: fn());
+    fn emit_enum_variant(v_name: &str, v_id: uint, sz: uint, f: fn());
+    fn emit_enum_variant_arg(idx: uint, f: fn());
+    fn emit_vec(len: uint, f: fn());
+    fn emit_vec_elt(idx: uint, f: fn());
+    fn emit_box(f: fn());
+    fn emit_uniq(f: fn());
+    fn emit_rec(f: fn());
+    fn emit_rec_field(f_name: &str, f_idx: uint, f: fn());
+    fn emit_tup(sz: uint, f: fn());
+    fn emit_tup_elt(idx: uint, f: fn());
+}
+
+trait Deserializer {
+    // Primitive types:
+    fn read_nil() -> ();
+
+    fn read_uint() -> uint;
+    fn read_u64() -> u64;
+    fn read_u32() -> u32;
+    fn read_u16() -> u16;
+    fn read_u8() -> u8;
+
+    fn read_int() -> int;
+    fn read_i64() -> i64;
+    fn read_i32() -> i32;
+    fn read_i16() -> i16;
+    fn read_i8() -> i8;
+
+
+    fn read_bool() -> bool;
+
+    fn read_str() -> ~str;
+
+    fn read_f64() -> f64;
+    fn read_f32() -> f32;
+    fn read_float() -> float;
+
+    // Compound types:
+    fn read_enum<T>(name: ~str, f: fn() -> T) -> T;
+    fn read_enum_variant<T>(f: fn(uint) -> T) -> T;
+    fn read_enum_variant_arg<T>(idx: uint, f: fn() -> T) -> T;
+    fn read_vec<T>(f: fn(uint) -> T) -> T;
+    fn read_vec_elt<T>(idx: uint, f: fn() -> T) -> T;
+    fn read_box<T>(f: fn() -> T) -> T;
+    fn read_uniq<T>(f: fn() -> T) -> T;
+    fn read_rec<T>(f: fn() -> T) -> T;
+    fn read_rec_field<T>(f_name: ~str, f_idx: uint, f: fn() -> T) -> T;
+    fn read_tup<T>(sz: uint, f: fn() -> T) -> T;
+    fn read_tup_elt<T>(idx: uint, f: fn() -> T) -> T;
+}
+
+trait Serializable {
+    fn serialize<S: Serializer>(s: S);
+    static fn deserialize<D: Deserializer>(d: D) -> self;
+}
+
+impl uint: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_uint(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> uint { d.read_uint() }
+}
+
+impl u8: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_u8(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> u8 { d.read_u8() }
+}
+
+impl u16: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_u16(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> u16 { d.read_u16() }
+}
+
+impl u32: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_u32(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> u32 { d.read_u32() }
+}
+
+impl u64: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_u64(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> u64 { d.read_u64() }
+}
+
+impl int: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_int(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> int { d.read_int() }
+}
+
+impl i8: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_i8(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> i8 { d.read_i8() }
+}
+
+impl i16: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_i16(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> i16 { d.read_i16() }
+}
+
+impl i32: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_i32(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> i32 { d.read_i32() }
+}
+
+impl i64: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_i64(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> i64 { d.read_i64() }
+}
+
+impl ~str: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_str(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> ~str { d.read_str() }
+}
+
+impl float: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_float(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> float { d.read_float() }
+}
+
+impl f32: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_f32(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> f32 { d.read_f32() }
+}
+
+impl f64: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_f64(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> f64 { d.read_f64() }
+}
+
+impl bool: Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_bool(self) }
+    static fn deserialize<D: Deserializer>(d: D) -> bool { d.read_bool() }
+}
+
+impl (): Serializable {
+    fn serialize<S: Serializer>(s: S) { s.emit_nil() }
+    static fn deserialize<D: Deserializer>(d: D) -> () { d.read_nil() }
+}
+
+impl<T: Serializable> @T: Serializable {
+    fn serialize<S: Serializer>(s: S) {
+        s.emit_box(|| (*self).serialize(s))
+    }
+
+    static fn deserialize<D: Deserializer>(d: D) -> @T {
+        d.read_box(|| deserialize(d))
+    }
+}
+
+impl<T: Serializable> ~[T]: Serializable {
+    fn serialize<S: Serializer>(s: S) {
+        do s.emit_vec(self.len()) {
+            for self.eachi |i, e| {
+                s.emit_vec_elt(i, || e.serialize(s))
+            }
+        }
+    }
+
+    static fn deserialize<D: Deserializer>(d: D) -> ~[T] {
+        do d.read_vec |len| {
+            do vec::from_fn(len) |i| {
+                d.read_vec_elt(i, || deserialize(d))
+            }
+        }
+    }
+}
+
+
+impl<T: Serializable> Option<T>: Serializable {
+    fn serialize<S: Serializer>(s: S) {
+        do s.emit_enum(~"option") {
+            match self {
+              None => do s.emit_enum_variant(~"none", 0u, 0u) {
+              },
+
+              Some(v) => do s.emit_enum_variant(~"some", 1u, 1u) {
+                s.emit_enum_variant_arg(0u, || v.serialize(s))
+              }
+            }
+        }
+    }
+
+    static fn deserialize<D: Deserializer>(d: D) -> Option<T> {
+        do d.read_enum(~"option") {
+            do d.read_enum_variant |i| {
+                match i {
+                  0 => None,
+                  1 => Some(d.read_enum_variant_arg(0u, || deserialize(d))),
+                  _ => fail(#fmt("Bad variant for option: %u", i))
+                }
+            }
+        }
+    }
+}
+
+impl<A: Serializable, B: Serializable> (A, B): Serializable {
+    fn serialize<S: Serializer>(s: S) {
+        match self {
+            (a, b) => {
+                do s.emit_tup(2) {
+                    s.emit_tup_elt(0, || a.serialize(s));
+                    s.emit_tup_elt(1, || b.serialize(s));
+                }
+            }
+        }
+    }
+
+    static fn deserialize<D: Deserializer>(d: D) -> (A, B) {
+        do d.read_tup(2) {
+            (
+                d.read_tup_elt(0, || deserialize(d)),
+                d.read_tup_elt(1, || deserialize(d))
+            )
+        }
+    }
+}
+
+impl<
+    A: Serializable,
+    B: Serializable,
+    C: Serializable
+> (A, B, C): Serializable {
+    fn serialize<S: Serializer>(s: S) {
+        match self {
+            (a, b, c) => {
+                do s.emit_tup(3) {
+                    s.emit_tup_elt(0, || a.serialize(s));
+                    s.emit_tup_elt(1, || b.serialize(s));
+                    s.emit_tup_elt(2, || c.serialize(s));
+                }
+            }
+        }
+    }
+
+    static fn deserialize<D: Deserializer>(d: D) -> (A, B, C) {
+        do d.read_tup(3) {
+            (
+                d.read_tup_elt(0, || deserialize(d)),
+                d.read_tup_elt(1, || deserialize(d)),
+                d.read_tup_elt(2, || deserialize(d))
+            )
+        }
+    }
+}
+

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -24,7 +24,7 @@ export bitv, deque, fun_treemap, list, map;
 export smallintmap, sort, treemap;
 export rope, arena, par;
 export ebml, dbg, getopts, json, rand, sha1, term, time, prettyprint;
-export test, tempfile, serialization;
+export test, tempfile, serialization, serialization2;
 export cmp;
 export base64;
 export cell;
@@ -92,6 +92,7 @@ mod unicode;
 
 mod test;
 mod serialization;
+mod serialization2;
 
 // Local Variables:
 // mode: rust;

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -233,36 +233,33 @@ fn print_failures(st: ConsoleTestState) {
 
 #[test]
 fn should_sort_failures_before_printing_them() {
-    let buffer = io::mem_buffer();
-    let writer = io::mem_buffer_writer(buffer);
+    let s = do io::with_str_writer |wr| {
+        let test_a = {
+            name: ~"a",
+            testfn: fn~() { },
+            ignore: false,
+            should_fail: false
+        };
 
-    let test_a = {
-        name: ~"a",
-        testfn: fn~() { },
-        ignore: false,
-        should_fail: false
+        let test_b = {
+            name: ~"b",
+            testfn: fn~() { },
+            ignore: false,
+            should_fail: false
+        };
+
+        let st =
+            @{out: wr,
+              log_out: option::None,
+              use_color: false,
+              mut total: 0u,
+              mut passed: 0u,
+              mut failed: 0u,
+              mut ignored: 0u,
+              mut failures: ~[test_b, test_a]};
+
+        print_failures(st);
     };
-
-    let test_b = {
-        name: ~"b",
-        testfn: fn~() { },
-        ignore: false,
-        should_fail: false
-    };
-
-    let st =
-        @{out: writer,
-          log_out: option::None,
-          use_color: false,
-          mut total: 0u,
-          mut passed: 0u,
-          mut failed: 0u,
-          mut ignored: 0u,
-          mut failures: ~[test_b, test_a]};
-
-    print_failures(st);
-
-    let s = io::mem_buffer_str(buffer);
 
     let apos = option::get(str::find_str(s, ~"a"));
     let bpos = option::get(str::find_str(s, ~"b"));

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -125,13 +125,13 @@ fn path_to_str(&&p: @ast::path, intr: ident_interner) -> ~str {
 
 fn fun_to_str(decl: ast::fn_decl, name: ast::ident,
               params: ~[ast::ty_param], intr: ident_interner) -> ~str {
-    let buffer = io::mem_buffer();
-    let s = rust_printer(io::mem_buffer_writer(buffer), intr);
-    print_fn(s, decl, None, name, params, None);
-    end(s); // Close the head box
-    end(s); // Close the outer box
-    eof(s.s);
-    io::mem_buffer_str(buffer)
+    do io::with_str_writer |wr| {
+        let s = rust_printer(wr, intr);
+        print_fn(s, decl, None, name, params, None);
+        end(s); // Close the head box
+        end(s); // Close the outer box
+        eof(s.s);
+    }
 }
 
 #[test]
@@ -148,15 +148,15 @@ fn test_fun_to_str() {
 }
 
 fn block_to_str(blk: ast::blk, intr: ident_interner) -> ~str {
-    let buffer = io::mem_buffer();
-    let s = rust_printer(io::mem_buffer_writer(buffer), intr);
-    // containing cbox, will be closed by print-block at }
-    cbox(s, indent_unit);
-    // head-ibox, will be closed by print-block after {
-    ibox(s, 0u);
-    print_block(s, blk);
-    eof(s.s);
-    io::mem_buffer_str(buffer)
+    do io::with_str_writer |wr| {
+        let s = rust_printer(wr, intr);
+        // containing cbox, will be closed by print-block at }
+        cbox(s, indent_unit);
+        // head-ibox, will be closed by print-block after {
+        ibox(s, 0u);
+        print_block(s, blk);
+        eof(s.s);
+    }
 }
 
 fn meta_item_to_str(mi: @ast::meta_item, intr: ident_interner) -> ~str {
@@ -2027,11 +2027,11 @@ fn print_string(s: ps, st: ~str) {
 }
 
 fn to_str<T>(t: T, f: fn@(ps, T), intr: ident_interner) -> ~str {
-    let buffer = io::mem_buffer();
-    let s = rust_printer(io::mem_buffer_writer(buffer), intr);
-    f(s, t);
-    eof(s.s);
-    io::mem_buffer_str(buffer)
+    do io::with_str_writer |wr| {
+        let s = rust_printer(wr, intr);
+        f(s, t);
+        eof(s.s);
+    }
 }
 
 fn next_comment(s: ps) -> Option<comments::cmnt> {

--- a/src/rustc/metadata/tyencode.rs
+++ b/src/rustc/metadata/tyencode.rs
@@ -45,12 +45,13 @@ fn enc_ty(w: io::Writer, cx: @ctxt, t: ty::t) {
     match cx.abbrevs {
       ac_no_abbrevs => {
         let result_str = match cx.tcx.short_names_cache.find(t) {
-          Some(s) => *s,
-          None => {
-            let buf = io::mem_buffer();
-            enc_sty(io::mem_buffer_writer(buf), cx, ty::get(t).sty);
-            cx.tcx.short_names_cache.insert(t, @io::mem_buffer_str(buf));
-            io::mem_buffer_str(buf)
+            Some(s) => *s,
+            None => {
+                let s = do io::with_str_writer |wr| {
+                    enc_sty(wr, cx, ty::get(t).sty);
+                };
+                cx.tcx.short_names_cache.insert(t, @s);
+                s
           }
         };
         w.write_str(result_str);

--- a/src/rustc/middle/astencode.rs
+++ b/src/rustc/middle/astencode.rs
@@ -1012,10 +1012,11 @@ fn mk_ctxt() -> fake_ext_ctxt {
 
 #[cfg(test)]
 fn roundtrip(in_item: @ast::item) {
-    let mbuf = io::mem_buffer();
-    let ebml_w = ebml::Writer(io::mem_buffer_writer(mbuf));
-    encode_item_ast(ebml_w, in_item);
-    let ebml_doc = ebml::Doc(@io::mem_buffer_buf(mbuf));
+    let bytes = do io::with_bytes_writer |wr| {
+        let ebml_w = ebml::Writer(wr);
+        encode_item_ast(ebml_w, in_item);
+    };
+    let ebml_doc = ebml::Doc(@bytes);
     let out_item = decode_item_ast(ebml_doc);
 
     let exp_str =

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -85,14 +85,14 @@ fn main() {
 
 fn check_pp<T>(cx: fake_ext_ctxt,
                expr: T, f: fn(pprust::ps, T), expect: ~str) {
-    let buf = mem_buffer();
-    let pp = pprust::rust_printer(buf as io::Writer,cx.parse_sess().interner);
-    f(pp, expr);
-    pp::eof(pp.s);
-    let str = mem_buffer_str(buf);
-    stdout().write_line(str);
+    let s = do io::with_str_writer |wr| {
+        let pp = pprust::rust_printer(wr, cx.parse_sess().interner);
+        f(pp, expr);
+        pp::eof(pp.s);
+    }
+    stdout().write_line(s);
     if expect != ~"" {
-        error!("expect: '%s', got: '%s'", expect, str);
+        error!("expect: '%s', got: '%s'", expect, s);
         assert str == expect;
     }
 }

--- a/src/test/run-pass/auto_serialize.rs
+++ b/src/test/run-pass/auto_serialize.rs
@@ -21,10 +21,11 @@ fn test_ser_and_deser<A:Eq>(a1: A,
     assert s == expected;
 
     // check the EBML serializer:
-    let buf = io::mem_buffer();
-    let w = ebml::Writer(buf as io::Writer);
-    ebml_ser_fn(w, a1);
-    let d = ebml::Doc(@io::mem_buffer_buf(buf));
+    let bytes = do io::with_bytes_writer |wr| {
+        let w = ebml::Writer(wr);
+        ebml_ser_fn(w, a1);
+    };
+    let d = ebml::Doc(@bytes);
     let a2 = ebml_deser_fn(ebml::ebml_deserializer(d));
     io::print(~"\na1 = ");
     io_ser_fn(io::stdout(), a1);


### PR DESCRIPTION
This is my version of a new trait-based serialization. It's a pretty straightforward port to traits. I named it serialization2 as we'll need to do the snapshot-dance in order to replace the old serialization. After we get this into a snapshot, I'll upgrade ebml, json, and the auto serializer to use it.

Also, this patch includes a new rewrite of the io bytes writer to cut down on the copies, and replacing the unwieldy `str::raw::from_buf_len_nocopy` with a `str::raw::form_slice` that matches the vec function.
