### PR TITLE
copyless io::BytesWriter and rewriting str::raw::from_buf_len_nocopy

### DIFF
--- a/src/fuzzer/fuzzer.rs
+++ b/src/fuzzer/fuzzer.rs
@@ -219,12 +219,8 @@ fn under(n: uint, it: fn(uint)) {
     while i < n { it(i); i += 1u; }
 }
 
-fn devnull() -> io::Writer { io::mem_buffer_writer(io::mem_buffer()) }
-
 fn as_str(f: fn@(io::Writer)) -> ~str {
-    let buf = io::mem_buffer();
-    f(io::mem_buffer_writer(buf));
-    io::mem_buffer_str(buf)
+    io::with_str_writer(f)
 }
 
 fn check_variants_of_ast(crate: ast::crate, codemap: codemap::codemap,

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1967,10 +1967,10 @@ mod raw {
    export
       from_buf,
       from_buf_len,
-      from_buf_len_nocopy,
       from_c_str,
       from_c_str_len,
       from_bytes,
+      form_slice,
       slice_bytes,
       view_bytes,
       push_byte,
@@ -2003,14 +2003,6 @@ mod raw {
         return ::unsafe::transmute(move v);
     }
 
-    /// Create a Rust string from a *u8 buffer of the given length
-    /// without copying
-    unsafe fn from_buf_len_nocopy(buf: &a / *u8, len: uint) -> &a / str {
-        let v = (*buf, len + 1);
-        assert is_utf8(::unsafe::reinterpret_cast(&v));
-        return ::unsafe::transmute(move v);
-    }
-
     /// Create a Rust string from a null-terminated C string
     unsafe fn from_c_str(c_str: *libc::c_char) -> ~str {
         from_buf(::unsafe::reinterpret_cast(&c_str))
@@ -2030,6 +2022,13 @@ mod raw {
 
     /// Converts a byte to a string.
     unsafe fn from_byte(u: u8) -> ~str { raw::from_bytes([u]) }
+
+    /// Form a slice from a *u8 buffer of the given length without copying.
+    unsafe fn buf_as_slice<T>(buf: *u8, len: uint, f: fn(&& &str) -> T) -> T {
+        let v = (*buf, len + 1);
+        assert is_utf8(::unsafe::reinterpret_cast(&v));
+        f(::unsafe::transmute(move v))
+    }
 
     /**
      * Takes a bytewise (not UTF-8) slice from a string.

--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -99,10 +99,9 @@ pure fn refcount<T>(+t: @T) -> uint {
 
 pure fn log_str<T>(t: T) -> ~str {
     unsafe {
-        let buffer = io::mem_buffer();
-        let writer = io::mem_buffer_writer(buffer);
-        repr::write_repr(writer, &t);
-        return io::mem_buffer_str(buffer);  // XXX: Extra malloc and copy.
+        do io::with_str_writer |wr| {
+            repr::write_repr(wr, &t)
+        }
     }
 }
 

--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -373,10 +373,10 @@ trait ToBytes {
 
 impl<A: IterBytes> A: ToBytes {
     fn to_bytes(lsb0: bool) -> ~[u8] {
-        let buf = io::mem_buffer();
-        for self.iter_bytes(lsb0) |bytes| {
-            buf.write(bytes)
+        do io::with_bytes_writer |wr| {
+            for self.iter_bytes(lsb0) |bytes| {
+                wr.write(bytes)
+            }
         }
-        io::mem_buffer_buf(buf)
     }
 }

--- a/src/libstd/ebml.rs
+++ b/src/libstd/ebml.rs
@@ -631,10 +631,11 @@ fn test_option_int() {
 
     fn test_v(v: Option<int>) {
         debug!("v == %?", v);
-        let mbuf = io::mem_buffer();
-        let ebml_w = ebml::Writer(io::mem_buffer_writer(mbuf));
-        serialize_0(ebml_w, v);
-        let ebml_doc = ebml::Doc(@io::mem_buffer_buf(mbuf));
+        let bytes = do io::with_bytes_writer |wr| {
+            let ebml_w = ebml::Writer(wr);
+            serialize_0(ebml_w, v);
+        };
+        let ebml_doc = ebml::Doc(@bytes);
         let deser = ebml_deserializer(ebml_doc);
         let v1 = deserialize_0(deser);
         debug!("v1 == %?", v1);

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -233,36 +233,33 @@ fn print_failures(st: ConsoleTestState) {
 
 #[test]
 fn should_sort_failures_before_printing_them() {
-    let buffer = io::mem_buffer();
-    let writer = io::mem_buffer_writer(buffer);
+    let s = do io::with_str_writer |wr| {
+        let test_a = {
+            name: ~"a",
+            testfn: fn~() { },
+            ignore: false,
+            should_fail: false
+        };
 
-    let test_a = {
-        name: ~"a",
-        testfn: fn~() { },
-        ignore: false,
-        should_fail: false
+        let test_b = {
+            name: ~"b",
+            testfn: fn~() { },
+            ignore: false,
+            should_fail: false
+        };
+
+        let st =
+            @{out: wr,
+              log_out: option::None,
+              use_color: false,
+              mut total: 0u,
+              mut passed: 0u,
+              mut failed: 0u,
+              mut ignored: 0u,
+              mut failures: ~[test_b, test_a]};
+
+        print_failures(st);
     };
-
-    let test_b = {
-        name: ~"b",
-        testfn: fn~() { },
-        ignore: false,
-        should_fail: false
-    };
-
-    let st =
-        @{out: writer,
-          log_out: option::None,
-          use_color: false,
-          mut total: 0u,
-          mut passed: 0u,
-          mut failed: 0u,
-          mut ignored: 0u,
-          mut failures: ~[test_b, test_a]};
-
-    print_failures(st);
-
-    let s = io::mem_buffer_str(buffer);
 
     let apos = option::get(str::find_str(s, ~"a"));
     let bpos = option::get(str::find_str(s, ~"b"));

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -125,13 +125,13 @@ fn path_to_str(&&p: @ast::path, intr: ident_interner) -> ~str {
 
 fn fun_to_str(decl: ast::fn_decl, name: ast::ident,
               params: ~[ast::ty_param], intr: ident_interner) -> ~str {
-    let buffer = io::mem_buffer();
-    let s = rust_printer(io::mem_buffer_writer(buffer), intr);
-    print_fn(s, decl, None, name, params, None);
-    end(s); // Close the head box
-    end(s); // Close the outer box
-    eof(s.s);
-    io::mem_buffer_str(buffer)
+    do io::with_str_writer |wr| {
+        let s = rust_printer(wr, intr);
+        print_fn(s, decl, None, name, params, None);
+        end(s); // Close the head box
+        end(s); // Close the outer box
+        eof(s.s);
+    }
 }
 
 #[test]
@@ -148,15 +148,15 @@ fn test_fun_to_str() {
 }
 
 fn block_to_str(blk: ast::blk, intr: ident_interner) -> ~str {
-    let buffer = io::mem_buffer();
-    let s = rust_printer(io::mem_buffer_writer(buffer), intr);
-    // containing cbox, will be closed by print-block at }
-    cbox(s, indent_unit);
-    // head-ibox, will be closed by print-block after {
-    ibox(s, 0u);
-    print_block(s, blk);
-    eof(s.s);
-    io::mem_buffer_str(buffer)
+    do io::with_str_writer |wr| {
+        let s = rust_printer(wr, intr);
+        // containing cbox, will be closed by print-block at }
+        cbox(s, indent_unit);
+        // head-ibox, will be closed by print-block after {
+        ibox(s, 0u);
+        print_block(s, blk);
+        eof(s.s);
+    }
 }
 
 fn meta_item_to_str(mi: @ast::meta_item, intr: ident_interner) -> ~str {
@@ -2027,11 +2027,11 @@ fn print_string(s: ps, st: ~str) {
 }
 
 fn to_str<T>(t: T, f: fn@(ps, T), intr: ident_interner) -> ~str {
-    let buffer = io::mem_buffer();
-    let s = rust_printer(io::mem_buffer_writer(buffer), intr);
-    f(s, t);
-    eof(s.s);
-    io::mem_buffer_str(buffer)
+    do io::with_str_writer |wr| {
+        let s = rust_printer(wr, intr);
+        f(s, t);
+        eof(s.s);
+    }
 }
 
 fn next_comment(s: ps) -> Option<comments::cmnt> {

--- a/src/rustc/metadata/tyencode.rs
+++ b/src/rustc/metadata/tyencode.rs
@@ -45,12 +45,13 @@ fn enc_ty(w: io::Writer, cx: @ctxt, t: ty::t) {
     match cx.abbrevs {
       ac_no_abbrevs => {
         let result_str = match cx.tcx.short_names_cache.find(t) {
-          Some(s) => *s,
-          None => {
-            let buf = io::mem_buffer();
-            enc_sty(io::mem_buffer_writer(buf), cx, ty::get(t).sty);
-            cx.tcx.short_names_cache.insert(t, @io::mem_buffer_str(buf));
-            io::mem_buffer_str(buf)
+            Some(s) => *s,
+            None => {
+                let s = do io::with_str_writer |wr| {
+                    enc_sty(wr, cx, ty::get(t).sty);
+                };
+                cx.tcx.short_names_cache.insert(t, @s);
+                s
           }
         };
         w.write_str(result_str);

--- a/src/rustc/middle/astencode.rs
+++ b/src/rustc/middle/astencode.rs
@@ -1012,10 +1012,11 @@ fn mk_ctxt() -> fake_ext_ctxt {
 
 #[cfg(test)]
 fn roundtrip(in_item: @ast::item) {
-    let mbuf = io::mem_buffer();
-    let ebml_w = ebml::Writer(io::mem_buffer_writer(mbuf));
-    encode_item_ast(ebml_w, in_item);
-    let ebml_doc = ebml::Doc(@io::mem_buffer_buf(mbuf));
+    let bytes = do io::with_bytes_writer |wr| {
+        let ebml_w = ebml::Writer(wr);
+        encode_item_ast(ebml_w, in_item);
+    };
+    let ebml_doc = ebml::Doc(@bytes);
     let out_item = decode_item_ast(ebml_doc);
 
     let exp_str =

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -85,14 +85,14 @@ fn main() {
 
 fn check_pp<T>(cx: fake_ext_ctxt,
                expr: T, f: fn(pprust::ps, T), expect: ~str) {
-    let buf = mem_buffer();
-    let pp = pprust::rust_printer(buf as io::Writer,cx.parse_sess().interner);
-    f(pp, expr);
-    pp::eof(pp.s);
-    let str = mem_buffer_str(buf);
-    stdout().write_line(str);
+    let s = do io::with_str_writer |wr| {
+        let pp = pprust::rust_printer(wr, cx.parse_sess().interner);
+        f(pp, expr);
+        pp::eof(pp.s);
+    }
+    stdout().write_line(s);
     if expect != ~"" {
-        error!("expect: '%s', got: '%s'", expect, str);
+        error!("expect: '%s', got: '%s'", expect, s);
         assert str == expect;
     }
 }

--- a/src/test/run-pass/auto_serialize.rs
+++ b/src/test/run-pass/auto_serialize.rs
@@ -21,10 +21,11 @@ fn test_ser_and_deser<A:Eq>(a1: A,
     assert s == expected;
 
     // check the EBML serializer:
-    let buf = io::mem_buffer();
-    let w = ebml::Writer(buf as io::Writer);
-    ebml_ser_fn(w, a1);
-    let d = ebml::Doc(@io::mem_buffer_buf(buf));
+    let bytes = do io::with_bytes_writer |wr| {
+        let w = ebml::Writer(wr);
+        ebml_ser_fn(w, a1);
+    };
+    let d = ebml::Doc(@bytes);
     let a2 = ebml_deser_fn(ebml::ebml_deserializer(d));
     io::print(~"\na1 = ");
     io_ser_fn(io::stdout(), a1);


### PR DESCRIPTION
These are simple patches that make `io::BytesWriter` more efficient by eliminating a copy. It also makes `str::raw::from_buf_len_nocopy` match `vec::raw::form_string`'s api.
