### PR TITLE
Make vec::view a method too.

### DIFF
--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -1625,6 +1625,7 @@ impl<T: Copy> &[const T]: CopyableVector<T> {
 }
 
 trait ImmutableVector<T> {
+    pure fn view(start: uint, end: uint) -> &[T];
     pure fn foldr<U: Copy>(z: U, p: fn(T, U) -> U) -> U;
     pure fn iter(f: fn(T));
     pure fn iteri(f: fn(uint, T));
@@ -1647,6 +1648,10 @@ trait ImmutableEqVector<T: Eq> {
 
 /// Extension methods for vectors
 impl<T> &[T]: ImmutableVector<T> {
+    /// Return a slice that points into another slice.
+    pure fn view(start: uint, end: uint) -> &[T] {
+        view(self, start, end)
+    }
     /// Reduce a vector from right to left
     #[inline]
     pure fn foldr<U: Copy>(z: U, p: fn(T, U) -> U) -> U { foldr(self, z, p) }
@@ -2909,17 +2914,14 @@ mod tests {
         assert capacity(v) == 10u;
     }
 
-/*
     #[test]
-    #[ignore] // region inference doesn't work well enough for this yet.
     fn test_view() {
         let v = ~[1, 2, 3, 4, 5];
-        let v = view(v, 1u, 3u);
+        let v = v.view(1u, 3u);
         assert(len(v) == 2u);
         assert(v[0] == 2);
         assert(v[1] == 3);
     }
-*/
 }
 
 // Local Variables:


### PR DESCRIPTION
I was surprised to find that there is no method equivalent of vec::view.

There may be a reason for this, but if not, please accept this.
