### PR TITLE
fix issue #3535 and add colon between mode and type when dumping function

### DIFF
--- a/src/rustc/util/ppaux.rs
+++ b/src/rustc/util/ppaux.rs
@@ -261,7 +261,7 @@ fn ty_to_str(cx: ctxt, typ: t) -> ~str {
                 m == ty::default_arg_mode_for_ty(cx, ty) {
                 ~""
             } else {
-                mode_to_str(ast::expl(m))
+                mode_to_str(ast::expl(m)) + ":"
             }
           }
         };

--- a/src/test/compile-fail/unnamed_argument_mode.rs
+++ b/src/test/compile-fail/unnamed_argument_mode.rs
@@ -1,0 +1,14 @@
+//error-pattern: mismatched types
+
+fn bad(&a: int) {
+}
+
+// unnamed argument &int is now parsed x: &int
+// it's not parsed &x: int anymore
+
+fn called(f: fn(&int)) {
+}
+
+fn main() {
+called(bad);
+}

--- a/src/test/run-pass/unnamed_argument_mode.rs
+++ b/src/test/run-pass/unnamed_argument_mode.rs
@@ -1,0 +1,11 @@
+fn good(a: &int) {
+}
+
+// unnamed argument &int is now parse x: &int
+
+fn called(f: fn(&int)) {
+}
+
+fn main() {
+called(good);
+}


### PR DESCRIPTION
Now, an unnamed argument "&int" is parsed "x: int" and not "&x: int" anymore.

When dumping functions prototypes, a colon is added between mode and type.

<pre><code>fn (&a: int)</code></pre>

will be dumped:

<pre><code>fn (&:int)</code></pre>

The ambiguity between "&x: int" and "x: &int" is removed
