### PR TITLE
rebase rust llvm patches on top of llvm HEAD

### DIFF
--- a/src/rustc/lib/llvm.rs
+++ b/src/rustc/lib/llvm.rs
@@ -28,19 +28,19 @@ enum Linkage {
     AvailableExternallyLinkage = 1,
     LinkOnceAnyLinkage = 2,
     LinkOnceODRLinkage = 3,
-    WeakAnyLinkage = 4,
-    WeakODRLinkage = 5,
-    AppendingLinkage = 6,
-    InternalLinkage = 7,
-    PrivateLinkage = 8,
-    DLLImportLinkage = 9,
-    DLLExportLinkage = 10,
-    ExternalWeakLinkage = 11,
-    GhostLinkage = 12,
-    CommonLinkage = 13,
-    LinkerPrivateLinkage = 14,
-    LinkerPrivateWeakLinkage = 15,
-    LinkerPrivateWeakDefAutoLinkage = 16,
+    LinkOnceODRAutoHideLinkage = 4,
+    WeakAnyLinkage = 5,
+    WeakODRLinkage = 6,
+    AppendingLinkage = 7,
+    InternalLinkage = 8,
+    PrivateLinkage = 9,
+    DLLImportLinkage = 10,
+    DLLExportLinkage = 11,
+    ExternalWeakLinkage = 12,
+    GhostLinkage = 13,
+    CommonLinkage = 14,
+    LinkerPrivateLinkage = 15,
+    LinkerPrivateWeakLinkage = 16,
 }
 
 enum Attribute {
@@ -91,6 +91,7 @@ enum IntPredicate {
 
 // enum for the LLVM RealPredicate type
 enum RealPredicate {
+    RealPredicateFalse = 0,
     RealOEQ = 1,
     RealOGT = 2,
     RealOGE = 3,
@@ -105,6 +106,7 @@ enum RealPredicate {
     RealULT = 12,
     RealULE = 13,
     RealUNE = 14,
+    RealPredicateTrue = 15,
 }
 
 // enum for the LLVM TypeKind type - must stay in sync with the def of

--- a/src/rustc/middle/trans/closure.rs
+++ b/src/rustc/middle/trans/closure.rs
@@ -363,7 +363,7 @@ fn trans_expr_fn(bcx: block,
     let llfnty = type_of_fn_from_ty(ccx, fty);
     let sub_path = vec::append_one(bcx.fcx.path,
                                    path_name(special_idents::anon));
-    let s = mangle_internal_name_by_path(ccx, sub_path);
+    let s = mangle_internal_name_by_path_and_seq(ccx, sub_path, ~"expr_fn");
     let llfn = decl_internal_cdecl_fn(ccx.llmod, s, llfnty);
 
     let trans_closure_env = fn@(ck: ty::closure_kind) -> Result {


### PR DESCRIPTION
This fixes  #3142, and depends on https://github.com/brson/llvm/pull/3 being accepted. Along the way I found a particularly interesting bug. Two closures in a method shared the same mangled name, which caused a rather confusing collision. I solved this by changing `trans_expr_fn` to use `mangle_internal_name_by_path_and_seq`, but to be perfectly honest, I have no idea why we never hit this before.
