### PR TITLE
core::rand - adding task local lazily initialized rng, as per #3439

### DIFF
--- a/src/libcore/rand.rs
+++ b/src/libcore/rand.rs
@@ -487,6 +487,14 @@ pub mod tests {
         assert r.shuffle(~[]) == empty;
         assert r.shuffle(~[1, 1, 1]) == ~[1, 1, 1];
     }
+
+    #[test]
+    pub fn task_rng() {
+        let r = rand::task_rng();
+        r.gen_int();
+        assert r.shuffle(~[1, 1, 1]) == ~[1, 1, 1];
+        assert r.gen_uint_range(0u, 1u) == 0u;
+    }
 }
 
 


### PR DESCRIPTION
This adds a task-local random number generator, seeded by the system, as per this issue: https://github.com/mozilla/rust/issues/3439. The intended use is like:

```
rand::task_rng().gen_int()
```

Though of course you could do:

```
let rng : Rng = rand::task_rng();
rng.shuffle(...);
```
