### PR TITLE
Use both DESTDIR and prefix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -537,8 +537,8 @@ endif
 
 ifneq ($(findstring install,$(MAKECMDGOALS)),)
   ifdef DESTDIR
-    CFG_INFO := $(info cfg: setting CFG_PREFIX via DESTDIR, $(DESTDIR))
-    CFG_PREFIX:=$(DESTDIR)
+    CFG_INFO := $(info cfg: setting CFG_PREFIX via DESTDIR, $(DESTDIR)/$(CFG_PREFIX))
+    CFG_PREFIX:=$(DESTDIR)/$(CFG_PREFIX)
     export CFG_PREFIX
   endif
 


### PR DESCRIPTION
The DESTDIR variable is not intended as a prefix substitute, but
as an additonal staging pre-path. Concatenate the two when available.

Signed-off-by: Luca Bruno lucab@debian.org
