### PR TITLE
Rename --enable-pax-marks to --enable-pax-flags.

### DIFF
--- a/configure
+++ b/configure
@@ -295,7 +295,7 @@ opt manage-submodules 1 "let the build manage the git submodules"
 opt mingw-cross 0 "cross-compile for win32 using mingw"
 opt clang 0 "prefer clang to gcc for building the runtime"
 opt local-rust 0 "use an installed rustc rather than downloading a snapshot"
-opt pax-marks 0 "apply PaX markings to rustc binaries (required for GRSecurity/PaX-patched kernels)"
+opt pax-flags 0 "apply PaX flags to rustc binaries (required for GRSecurity/PaX-patched kernels)"
 valopt prefix "/usr/local" "set installation prefix"
 valopt local-rust-root "/usr/local" "set prefix for local rust binary"
 valopt llvm-root "" "set LLVM root"
@@ -362,12 +362,12 @@ fi
 
 if [ "$CFG_OSTYPE" = "unknown-linux-gnu" ]
 then
-    if [ ! -z "$CFG_ENABLE_PAX_MARKS" -a -z "$CFG_PAXCTL" ]
+    if [ ! -z "$CFG_ENABLE_PAX_FLAGS" -a -z "$CFG_PAXCTL" ]
     then
         err "enabled PaX markings but no paxctl binary found"
     fi
 
-    if [ -z "$CFG_DISABLE_PAX_MARKS" ]
+    if [ -z "$CFG_DISABLE_PAX_FLAGS" ]
     then
         # GRSecurity/PaX detection. This can be very flaky.
         GRSEC_DETECTED=
@@ -395,9 +395,9 @@ then
             step_msg "GRSecurity: yes"
             if [ ! -z "$CFG_PAXCTL" ]
             then
-                CFG_ENABLE_PAX_MARKS=1
+                CFG_ENABLE_PAX_FLAGS=1
             else
-                warn "GRSecurity kernel detected but no paxctl binary found: not setting CFG_ENABLE_PAX_MARKS"
+                warn "GRSecurity kernel detected but no paxctl binary found: not setting CFG_ENABLE_PAX_FLAGS"
             fi
         else
             step_msg "GRSecurity: no"
@@ -750,9 +750,9 @@ putvar CFG_C_COMPILER
 putvar CFG_LIBDIR
 putvar CFG_DISABLE_MANAGE_SUBMODULES
 
-if [ ! -z "$CFG_ENABLE_PAX_MARKS" ]
+if [ ! -z "$CFG_ENABLE_PAX_FLAGS" ]
 then
-    putvar CFG_ENABLE_PAX_MARKS
+    putvar CFG_ENABLE_PAX_FLAGS
     putvar CFG_PAXCTL
 fi
 

--- a/configure
+++ b/configure
@@ -344,8 +344,11 @@ probe CFG_PDFLATEX         pdflatex
 probe CFG_XETEX            xetex
 probe CFG_LUATEX           luatex
 probe CFG_NODE             nodejs node
-probe CFG_PAXCTL           paxctl /sbin/paxctl
-probe CFG_ZCAT             zcat
+if [ "$CFG_OSTYPE" = "unknown-linux-gnu" ]
+then
+    probe CFG_PAXCTL           paxctl /sbin/paxctl
+    probe CFG_ZCAT             zcat
+fi
 
 if [ ! -z "$CFG_PANDOC" ]
 then
@@ -370,8 +373,7 @@ then
         GRSEC_DETECTED=
 
         # /dev/grsec only exists if CONFIG_GRKERNSEC_NO_RBAC is not set.
-        # /proc is normally only available to root and users in the CONFIG_GRKERNSEC_PROC_GID group,
-        # and /proc/sys/kernel/grsecurity is not available if ÇONFIG_GRKERNSEC_SYSCTL is not set.
+        # /proc/sys/kernel/grsecurity is not available if ÇONFIG_GRKERNSEC_SYSCTL is not set.
         if [ -e /dev/grsec -o -d /proc/sys/kernel/grsecurity ]
         then
             GRSEC_DETECTED=1

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -12,8 +12,8 @@ ifdef CFG_ENABLE_LOCAL_RUST
 	$(Q)$(S)src/etc/local_stage0.sh $(CFG_HOST_TRIPLE) $(CFG_LOCAL_RUST_ROOT)
 else 
 	$(Q)$(S)src/etc/get-snapshot.py $(CFG_HOST_TRIPLE) $(SNAPSHOT_FILE)
-ifdef CFG_ENABLE_PAX_MARKS
-	@$(call E, apply PaX markings: $@)
+ifdef CFG_ENABLE_PAX_FLAGS
+	@$(call E, apply PaX flags: $@)
 	@"$(CFG_PAXCTL)" -cm "$@"
 endif
 endif 

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -29,8 +29,8 @@ $$(TBIN$(1)_T_$(2)_H_$(3))/rustc$$(X):				\
 		$$(TLIBRUSTC_DEFAULT$(1)_T_$(2)_H_$(3))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$<
-ifdef CFG_ENABLE_PAX_MARKS
-	@$$(call E, apply PaX markings: $$@)
+ifdef CFG_ENABLE_PAX_FLAGS
+	@$$(call E, apply PaX flags: $$@)
 	@"$(CFG_PAXCTL)" -cm "$$@"
 endif
 


### PR DESCRIPTION
This patch renames the pax-marks option to the more appropriate pax-flags. It also removes certain tool detection at OSes that won't ever need them and fixes a small GRSecurity detection documentation error.
