### PR TITLE
tutorial: Add missing struct name

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -807,10 +807,10 @@ parentheses.
 # enum Direction { North, East, South, West }
 fn point_from_direction(dir: Direction) -> Point {
     match dir {
-        North => {x:  0f, y:  1f},
-        East  => {x:  1f, y:  0f},
-        South => {x:  0f, y: -1f},
-        West  => {x: -1f, y:  0f}
+        North => Point {x:  0f, y:  1f},
+        East  => Point {x:  1f, y:  0f},
+        South => Point {x:  0f, y: -1f},
+        West  => Point {x: -1f, y:  0f}
     }
 }
 ~~~~


### PR DESCRIPTION
Without `Point` before each `{ ... }` I get the following error when
compiling the code with the compiler from the preliminary tarball made
available on Wednesday:

```
error: mismatched types: expected `Point` but found `{x: float,y: float}`
(expected class Point but found record)
```
