### PR TITLE
libsyntax: refactor the parser to consider foreign items as items

### DIFF
--- a/src/test/compile-fail/duplicate-visibility.rs
+++ b/src/test/compile-fail/duplicate-visibility.rs
@@ -1,0 +1,4 @@
+// error-pattern:unmatched visibility `pub`
+extern {
+    pub pub fn foo();
+}


### PR DESCRIPTION
parse_item_or_view_item() would drop visibility if none of the conditions
following it would hold. This was the case when parsing extern {} blocks,
where the function was only used to parse view items, but discarded the
visibility of the first not-view item.
