### PR TITLE
libsyntax: refactor the parser to consider foreign items as items

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1906,7 +1906,7 @@ pub mod raw {
     }
 
     /// Converts a vector of bytes to a string.
-    pub pub unsafe fn from_bytes(v: &[const u8]) -> ~str {
+    pub unsafe fn from_bytes(v: &[const u8]) -> ~str {
         do vec::as_const_buf(v) |buf, len| {
             from_buf_len(buf, len)
         }

--- a/src/test/compile-fail/duplicate-visibility.rs
+++ b/src/test/compile-fail/duplicate-visibility.rs
@@ -1,0 +1,4 @@
+// error-pattern:unmatched visibility `pub`
+extern {
+    pub pub fn foo();
+}


### PR DESCRIPTION
parse_item_or_view_item() would drop visibility if none of the conditions
following it would hold. This was the case when parsing extern {} blocks,
where the function was only used to parse view items, but discarded the
visibility of the first not-view item.
