### PR TITLE
rustc: fix size computation of structs for the FFI

### DIFF
--- a/src/rustc/middle/trans/foreign.rs
+++ b/src/rustc/middle/trans/foreign.rs
@@ -112,9 +112,10 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
             Float => 4,
             Double => 8,
             Struct => {
-              do vec::foldl(0, struct_tys(ty)) |s, t| {
-                    s + ty_size(*t)
-                }
+              let size = do vec::foldl(0, struct_tys(ty)) |s, t| {
+                  align(s, *t) + ty_size(*t)
+              };
+              align(size, ty)
             }
             Array => {
               let len = llvm::LLVMGetArrayLength(ty) as uint;

--- a/src/test/run-pass/issue-3656.rs
+++ b/src/test/run-pass/issue-3656.rs
@@ -1,0 +1,20 @@
+// Issue #3656
+// Incorrect struct size computation in the FFI, because of not taking
+// the alignment of elements into account.
+
+use libc::*;
+
+struct KEYGEN {
+    hash_algorithm: [c_uint]/2,
+    count: uint32_t,
+    salt: *c_void,
+    salt_size: uint32_t,
+}
+
+extern {
+    // Bogus signature, just need to test if it compiles.
+    pub fn malloc(++data: KEYGEN);
+}
+
+fn main() {
+}


### PR DESCRIPTION
It didn't take alignment into account.

Fixes #3656.
