### PR TITLE
Fix #3701: rustllvm conditional build

### DIFF
--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -493,5 +493,7 @@ extern "C" LLVMValueRef LLVMBuildAtomicRMW(LLVMBuilderRef B,
 }
 
 extern "C" void LLVMSetDebug(int Enabled) {
+#ifndef NDEBUG
   DebugFlag = Enabled;
+#endif
 }


### PR DESCRIPTION
DebugFlag is conditionally exported by LLVM in llvm/Support/Debug.h
in-between an #ifndef NDEBUG block; RustWrapper should not
unconditionally use it. This closes #3701.

Signed-off-by: Luca Bruno lucab@debian.org
