### PR TITLE
Replace several common macros of the form #m[...] with m!(...)

### DIFF
--- a/src/libstd/net_url.rs
+++ b/src/libstd/net_url.rs
@@ -65,10 +65,10 @@ fn encode_inner(s: &str, full_url: bool) -> ~str {
                         str::push_char(&mut out, ch);
                       }
 
-                      _ => out += #fmt("%%%X", ch as uint)
+                      _ => out += fmt!("%%%X", ch as uint)
                     }
                 } else {
-                    out += #fmt("%%%X", ch as uint);
+                    out += fmt!("%%%X", ch as uint);
                 }
               }
             }
@@ -164,7 +164,7 @@ fn encode_plus(s: &str) -> ~str {
                 str::push_char(&mut out, ch);
               }
               ' ' => str::push_char(&mut out, '+'),
-              _ => out += #fmt("%%%X", ch as uint)
+              _ => out += fmt!("%%%X", ch as uint)
             }
         }
 
@@ -190,7 +190,7 @@ pub fn encode_form_urlencoded(m: HashMap<~str, @DVec<@~str>>) -> ~str {
                 first = false;
             }
 
-            out += #fmt("%s=%s", key, encode_plus(**value));
+            out += fmt!("%s=%s", key, encode_plus(**value));
         }
     }
 
@@ -332,7 +332,7 @@ pub pure fn query_to_str(query: Query) -> ~str {
         let (k, v) = copy *kv;
         // This is really safe...
         unsafe {
-          strvec += ~[#fmt("%s=%s",
+          strvec += ~[fmt!("%s=%s",
                            encode_component(k), encode_component(v))];
         }
     };
@@ -850,7 +850,7 @@ mod tests {
     fn test_url_parse_host_slash() {
         let urlstr = ~"http://0.42.42.42/";
         let url = from_str(urlstr).get();
-        #debug("url: %?", url);
+        debug!("url: %?", url);
         assert url.host == ~"0.42.42.42";
         assert url.path == ~"/";
     }
@@ -859,7 +859,7 @@ mod tests {
     fn test_url_with_underscores() {
         let urlstr = ~"http://dotcom.com/file_name.html";
         let url = from_str(urlstr).get();
-        #debug("url: %?", url);
+        debug!("url: %?", url);
         assert url.path == ~"/file_name.html";
     }
 
@@ -867,7 +867,7 @@ mod tests {
     fn test_url_with_dashes() {
         let urlstr = ~"http://dotcom.com/file-name.html";
         let url = from_str(urlstr).get();
-        #debug("url: %?", url);
+        debug!("url: %?", url);
         assert url.path == ~"/file-name.html";
     }
 

--- a/src/libstd/serialization.rs
+++ b/src/libstd/serialization.rs
@@ -375,7 +375,7 @@ pub impl<T: Deserializable> Option<T>: Deserializable {
                 match i {
                   0 => None,
                   1 => Some(d.read_enum_variant_arg(0u, || deserialize(d))),
-                  _ => fail(#fmt("Bad variant for option: %u", i))
+                  _ => fail(fmt!("Bad variant for option: %u", i))
                 }
             }
         }

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -595,8 +595,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ~str> {
 fn strftime(format: &str, tm: Tm) -> ~str {
     fn parse_type(ch: char, tm: &Tm) -> ~str {
         //FIXME (#2350): Implement missing types.
-      let die = || #fmt("strftime: can't understand this format %c ",
-                             ch);
+      let die = || fmt!("strftime: can't understand this format %c ", ch);
         match ch {
           'A' => match tm.tm_wday as int {
             0 => ~"Sunday",

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -266,7 +266,7 @@ fn print_macro_backtrace(cm: codemap::codemap, sp: span) {
         let ss = option::map_default(&ei.callie.span, @~"",
                                      |span| @codemap::span_to_str(*span, cm));
         print_diagnostic(*ss, note,
-                         fmt!("in expansion of #%s", ei.callie.name));
+                         fmt!("in expansion of %s!", ei.callie.name));
         let ss = codemap::span_to_str(ei.call_site, cm);
         print_diagnostic(ss, note, ~"expansion site");
         print_macro_backtrace(cm, ei.call_site);

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -269,21 +269,21 @@ fn get_mac_args(cx: ext_ctxt, sp: span, arg: ast::mac_arg,
               match max {
                 Some(max) if ! (min <= elts_len && elts_len <= max) => {
                   cx.span_fatal(sp,
-                                fmt!("#%s takes between %u and %u arguments.",
+                                fmt!("%s! takes between %u and %u arguments.",
                                      name, min, max));
                 }
                 None if ! (min <= elts_len) => {
-                  cx.span_fatal(sp, fmt!("#%s needs at least %u arguments.",
+                  cx.span_fatal(sp, fmt!("%s! needs at least %u arguments.",
                                          name, min));
                 }
                 _ => return elts /* we are good */
               }
           }
         _ => {
-            cx.span_fatal(sp, fmt!("#%s: malformed invocation", name))
+            cx.span_fatal(sp, fmt!("%s!: malformed invocation", name))
         }
       },
-      None => cx.span_fatal(sp, fmt!("#%s: missing arguments", name))
+      None => cx.span_fatal(sp, fmt!("%s!: missing arguments", name))
     }
 }
 

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -1,6 +1,6 @@
 
 /*
- * The compiler code necessary to support the #env extension.  Eventually this
+ * The compiler code necessary to support the env! extension.  Eventually this
  * should all get sucked into either the compiler syntax extension plugin
  * interface.
  */
@@ -15,7 +15,7 @@ fn expand_syntax_ext(cx: ext_ctxt, sp: codemap::span, arg: ast::mac_arg,
     // FIXME (#2248): if this was more thorough it would manufacture an
     // Option<str> rather than just an maybe-empty string.
 
-    let var = expr_to_str(cx, args[0], ~"#env requires a string");
+    let var = expr_to_str(cx, args[0], ~"env! requires a string");
     match os::getenv(var) {
       option::None => return mk_uniq_str(cx, sp, ~""),
       option::Some(s) => return mk_uniq_str(cx, sp, s)

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -1,7 +1,7 @@
 
 
 /*
- * The compiler code necessary to support the #fmt extension. Eventually this
+ * The compiler code necessary to support the fmt! extension. Eventually this
  * should all get sucked into either the standard library extfmt module or the
  * compiler syntax extension plugin interface.
  */
@@ -16,7 +16,7 @@ fn expand_syntax_ext(cx: ext_ctxt, sp: span, arg: ast::mac_arg,
     let args = get_mac_args_no_max(cx, sp, arg, 1u, ~"fmt");
     let fmt =
         expr_to_str(cx, args[0],
-                    ~"first argument to #fmt must be a string literal.");
+                    ~"first argument to fmt! must be a string literal.");
     let fmtspan = args[0].span;
     debug!("Format string:");
     log(debug, fmt);
@@ -76,7 +76,7 @@ fn pieces_to_expr(cx: ext_ctxt, sp: span,
                 let count_is_args = ~[count_lit];
                 return mk_call(cx, sp, count_is_path, count_is_args);
               }
-              _ => cx.span_unimpl(sp, ~"unimplemented #fmt conversion")
+              _ => cx.span_unimpl(sp, ~"unimplemented fmt! conversion")
             }
         }
         fn make_ty(cx: ext_ctxt, sp: span, t: Ty) -> @ast::expr {
@@ -133,7 +133,7 @@ fn pieces_to_expr(cx: ext_ctxt, sp: span,
               _ => return false
             }
         }
-        let unsupported = ~"conversion not supported in #fmt string";
+        let unsupported = ~"conversion not supported in fmt! string";
         match cnv.param {
           option::None => (),
           _ => cx.span_unimpl(sp, unsupported)
@@ -145,14 +145,14 @@ fn pieces_to_expr(cx: ext_ctxt, sp: span,
                 if !is_signed_type(cnv) {
                     cx.span_fatal(sp,
                                   ~"+ flag only valid in " +
-                                      ~"signed #fmt conversion");
+                                      ~"signed fmt! conversion");
                 }
               }
               FlagSpaceForSign => {
                 if !is_signed_type(cnv) {
                     cx.span_fatal(sp,
                                   ~"space flag only valid in " +
-                                      ~"signed #fmt conversions");
+                                      ~"signed fmt! conversions");
                 }
               }
               FlagLeftZeroPad => (),
@@ -252,7 +252,7 @@ fn pieces_to_expr(cx: ext_ctxt, sp: span,
             n += 1u;
             if n >= nargs {
                 cx.span_fatal(sp,
-                              ~"not enough arguments to #fmt " +
+                              ~"not enough arguments to fmt! " +
                                   ~"for the given format string");
             }
             debug!("Building conversion:");
@@ -267,7 +267,7 @@ fn pieces_to_expr(cx: ext_ctxt, sp: span,
 
     if expected_nargs < nargs {
         cx.span_fatal
-            (sp, fmt!("too many arguments to #fmt. found %u, expected %u",
+            (sp, fmt!("too many arguments to fmt!. found %u, expected %u",
                            nargs, expected_nargs));
     }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2414,7 +2414,7 @@ impl parser {
 
     fn expect_self_ident() {
         if !self.is_self_ident() {
-            self.fatal(#fmt("expected `self` but found `%s`",
+            self.fatal(fmt!("expected `self` but found `%s`",
                             token_to_str(self.reader, self.token)));
         }
         self.bump();
@@ -2696,7 +2696,7 @@ impl parser {
                   ctor_decl(a_fn_decl, attrs, blk, s) => {
                       match the_ctor {
                         Some((_, _, _, s_first)) => {
-                          self.span_note(s, #fmt("Duplicate constructor \
+                          self.span_note(s, fmt!("Duplicate constructor \
                                      declaration for class %s",
                                      *self.interner.get(class_name)));
                            self.span_fatal(copy s_first, ~"First constructor \
@@ -2710,7 +2710,7 @@ impl parser {
                   dtor_decl(blk, attrs, s) => {
                       match the_dtor {
                         Some((_, _, s_first)) => {
-                          self.span_note(s, #fmt("Duplicate destructor \
+                          self.span_note(s, fmt!("Duplicate destructor \
                                      declaration for class %s",
                                      *self.interner.get(class_name)));
                           self.span_fatal(copy s_first, ~"First destructor \

--- a/src/rustc/driver/session.rs
+++ b/src/rustc/driver/session.rs
@@ -216,7 +216,7 @@ impl session {
     // This exists to help with refactoring to eliminate impossible
     // cases later on
     fn impossible_case(sp: span, msg: &str) -> ! {
-        self.span_bug(sp, #fmt("Impossible case reached: %s", msg));
+        self.span_bug(sp, fmt!("Impossible case reached: %s", msg));
     }
     fn verbose() -> bool { self.debugging_opt(verbose) }
     fn time_passes() -> bool { self.debugging_opt(time_passes) }

--- a/src/rustc/metadata/decoder.rs
+++ b/src/rustc/metadata/decoder.rs
@@ -162,7 +162,7 @@ fn item_family(item: ebml::Doc) -> Family {
       'g' => PublicField,
       'j' => PrivateField,
       'N' => InheritedField,
-       c => fail (#fmt("unexpected family char: %c", c))
+       c => fail (fmt!("unexpected family char: %c", c))
     }
 }
 
@@ -705,7 +705,7 @@ fn get_trait_methods(intr: @ident_interner, cdata: cmd, id: ast::node_id,
                            self_ty: self_ty,
                            vis: ast::public});
     }
-    #debug("get_trait_methods: }");
+    debug!("get_trait_methods: }");
     @result
 }
 

--- a/src/rustc/middle/borrowck/gather_loans.rs
+++ b/src/rustc/middle/borrowck/gather_loans.rs
@@ -303,8 +303,8 @@ impl gather_loan_ctxt {
                   _ => {
                     self.bccx.tcx.sess.span_bug(
                         cmt.span,
-                        #fmt["loans required but scope is scope_region is %s",
-                             region_to_str(self.tcx(), scope_r)]);
+                        fmt!("loans required but scope is scope_region is %s",
+                             region_to_str(self.tcx(), scope_r)));
                   }
                 }
               }

--- a/src/rustc/middle/borrowck/preserve.rs
+++ b/src/rustc/middle/borrowck/preserve.rs
@@ -314,17 +314,17 @@ priv impl &preserve_ctxt {
           // we can only root values if the desired region is some concrete
           // scope within the fn body
           ty::re_scope(scope_id) => {
-            #debug["Considering root map entry for %s: \
+            debug!("Considering root map entry for %s: \
                     node %d:%u -> scope_id %?, root_ub %?",
                    self.bccx.cmt_to_repr(cmt), base.id,
-                   derefs, scope_id, self.root_ub];
+                   derefs, scope_id, self.root_ub);
             if self.bccx.is_subregion_of(self.scope_region, root_region) {
-                #debug["Elected to root"];
+                debug!("Elected to root");
                 let rk = {id: base.id, derefs: derefs};
                 self.bccx.root_map.insert(rk, scope_id);
                 return Ok(pc_ok);
             } else {
-                #debug["Unable to root"];
+                debug!("Unable to root");
                 return Err({cmt:cmt,
                          code:err_out_of_root_scope(root_region,
                                                     self.scope_region)});

--- a/src/rustc/middle/check_alt.rs
+++ b/src/rustc/middle/check_alt.rs
@@ -33,7 +33,7 @@ fn check_expr(tcx: ty::ctxt, ex: @expr, &&s: (), v: visit::vt<()>) {
        if arms.is_empty() {
            if !type_is_empty(tcx, pat_ty) {
                // We know the type is inhabited, so this must be wrong
-               tcx.sess.span_err(ex.span, #fmt("non-exhaustive patterns: \
+               tcx.sess.span_err(ex.span, fmt!("non-exhaustive patterns: \
                              type %s is non-empty", ty_to_str(tcx, pat_ty)));
            }
            // If the type *is* empty, it's vacuously exhaustive

--- a/src/rustc/middle/liveness.rs
+++ b/src/rustc/middle/liveness.rs
@@ -902,11 +902,11 @@ impl Liveness {
                 self.propagate_through_fn_block(decl, body)
             });
 
-        // hack to skip the loop unless #debug is enabled:
+        // hack to skip the loop unless debug! is enabled:
         debug!("^^ liveness computation results for body %d (entry=%s)",
                {
                    for uint::range(0u, self.ir.num_live_nodes) |ln_idx| {
-                       #debug["%s", self.ln_str(LiveNode(ln_idx))];
+                       debug!("%s", self.ln_str(LiveNode(ln_idx)));
                    }
                    body.node.id
                },

--- a/src/rustc/middle/resolve.rs
+++ b/src/rustc/middle/resolve.rs
@@ -918,12 +918,12 @@ impl Resolver {
               match ns.find(|n| child.defined_in_namespace(n)) {
                 Some(ns) => {
                   self.session.span_err(sp,
-                       #fmt("Duplicate definition of %s %s",
+                       fmt!("Duplicate definition of %s %s",
                             namespace_to_str(ns),
                             self.session.str_of(name)));
                   do child.span_for_namespace(ns).iter() |sp| {
                       self.session.span_note(*sp,
-                           #fmt("First definition of %s %s here:",
+                           fmt!("First definition of %s %s here:",
                                 namespace_to_str(ns),
                                 self.session.str_of(name)));
                   }

--- a/src/rustc/middle/trans/glue.rs
+++ b/src/rustc/middle/trans/glue.rs
@@ -745,7 +745,7 @@ fn emit_tydescs(ccx: @crate_ctxt) {
         // Index tydesc by addrspace.
         if ti.addrspace > gc_box_addrspace {
             let llty = T_ptr(ccx.tydesc_type);
-            let addrspace_name = #fmt("_gc_addrspace_metadata_%u",
+            let addrspace_name = fmt!("_gc_addrspace_metadata_%u",
                                       ti.addrspace as uint);
             let addrspace_gvar = str::as_c_str(addrspace_name, |buf| {
                 llvm::LLVMAddGlobal(ccx.llmod, llty, buf)

--- a/src/rustc/middle/trans/monomorphize.rs
+++ b/src/rustc/middle/trans/monomorphize.rs
@@ -37,11 +37,11 @@ fn monomorphic_fn(ccx: @crate_ctxt,
         must_cast = true;
     }
 
-    #debug["monomorphic_fn(fn_id=%? (%s), real_substs=%?, substs=%?, \
+    debug!("monomorphic_fn(fn_id=%? (%s), real_substs=%?, substs=%?, \
            hash_id = %?",
            fn_id, ty::item_path_str(ccx.tcx, fn_id),
            real_substs.map(|s| ty_to_str(ccx.tcx, *s)),
-           substs.map(|s| ty_to_str(ccx.tcx, *s)), hash_id];
+           substs.map(|s| ty_to_str(ccx.tcx, *s)), hash_id);
 
     match ccx.monomorphized.find(hash_id) {
       Some(val) => {

--- a/src/rustc/middle/ty.rs
+++ b/src/rustc/middle/ty.rs
@@ -3020,7 +3020,7 @@ fn get_field(tcx: ctxt, rec_ty: t, id: ast::ident) -> field {
     match vec::find(get_fields(rec_ty), |f| f.ident == id) {
       Some(f) => f,
       // Do we only call this when we know the field is legit?
-      None => fail (#fmt("get_field: ty doesn't have a field %s",
+      None => fail (fmt!("get_field: ty doesn't have a field %s",
                          tcx.sess.str_of(id)))
     }
 }
@@ -3335,7 +3335,7 @@ fn provided_trait_methods(cx: ctxt, id: ast::def_id) -> ~[@ast::method] {
                 match ast_util::split_trait_methods(ms) {
                    (_, p) => p
                 },
-            _ => cx.sess.bug(#fmt("provided_trait_methods: %? is not a trait",
+            _ => cx.sess.bug(fmt!("provided_trait_methods: %? is not a trait",
                                   id))
         }
     }

--- a/src/rustc/middle/typeck/collect.rs
+++ b/src/rustc/middle/typeck/collect.rs
@@ -266,7 +266,7 @@ fn compare_impl_method(tcx: ty::ctxt, sp: span,
     }
 
     if impl_m.tps.len() != trait_m.tps.len() {
-        tcx.sess.span_err(sp, #fmt("method `%s` \
+        tcx.sess.span_err(sp, fmt!("method `%s` \
            has %u type %s, but its trait declaration has %u type %s",
            tcx.sess.str_of(trait_m.ident), impl_m.tps.len(),
            pluralize(impl_m.tps.len(), ~"parameter"),
@@ -291,7 +291,7 @@ fn compare_impl_method(tcx: ty::ctxt, sp: span,
         // Would be nice to use the ty param names in the error message,
         // but we don't have easy access to them here
         if impl_param_bounds.len() != trait_param_bounds.len() {
-           tcx.sess.span_err(sp, #fmt("in method `%s`, \
+           tcx.sess.span_err(sp, fmt!("in method `%s`, \
              type parameter %u has %u %s, but the same type \
              parameter in its trait declaration has %u %s",
              tcx.sess.str_of(trait_m.ident),

--- a/src/rustdoc/attr_pass.rs
+++ b/src/rustdoc/attr_pass.rs
@@ -157,7 +157,7 @@ fn fold_enum(
 
                     attr_parser::parse_desc(ast_variant.node.attrs)
                   }
-                  _ => fail #fmt("Enum variant %s has id that's not bound \
+                  _ => fail fmt!("Enum variant %s has id that's not bound \
                          to an enum item", variant.name)
                 }
             };

--- a/src/test/bench/task-perf-linked-failure.rs
+++ b/src/test/bench/task-perf-linked-failure.rs
@@ -19,20 +19,20 @@ fn grandchild_group(num_tasks: uint) {
             comm::recv(comm::Port::<()>()); // block forever
         }
     }
-    #error["Grandchild group getting started"];
+    error!("Grandchild group getting started");
     for num_tasks.times {
         // Make sure all above children are fully spawned; i.e., enlisted in
         // their ancestor groups.
         comm::recv(po);
     }
-    #error["Grandchild group ready to go."];
+    error!("Grandchild group ready to go.");
     // Master grandchild task exits early.
 }
 
 fn spawn_supervised_blocking(myname: &str, +f: fn~()) {
     let mut res = None;
     task::task().future_result(|+r| res = Some(r)).supervised().spawn(f);
-    #error["%s group waiting", myname];
+    error!("%s group waiting", myname);
     let x = future::get(&option::unwrap(res));
     assert x == task::Success;
 }
@@ -58,10 +58,10 @@ fn main() {
                 grandchild_group(num_tasks);
             }
             // When grandchild group is ready to go, make the middle group exit.
-            #error["Middle group wakes up and exits"];
+            error!("Middle group wakes up and exits");
         }
         // Grandparent group waits for middle group to be gone, then fails
-        #error["Grandparent group wakes up and fails"];
+        error!("Grandparent group wakes up and fails");
         fail;
     };
     assert x.is_err();

--- a/src/test/compile-fail/borrowck-borrowed-uniq-rvalue-2.rs
+++ b/src/test/compile-fail/borrowck-borrowed-uniq-rvalue-2.rs
@@ -1,6 +1,6 @@
 struct defer {
     x: &[&str],
-    drop { #error["%?", self.x]; }
+    drop { error!("%?", self.x); }
 }
 
 fn defer(x: &r/[&r/str]) -> defer/&r {

--- a/src/test/compile-fail/borrowck-unary-move-2.rs
+++ b/src/test/compile-fail/borrowck-unary-move-2.rs
@@ -1,5 +1,5 @@
 struct noncopyable {
-    i: (), drop { #error["dropped"]; }
+    i: (), drop { error!("dropped"); }
 }
 
 fn noncopyable() -> noncopyable {

--- a/src/test/compile-fail/extenv-no-args.rs
+++ b/src/test/compile-fail/extenv-no-args.rs
@@ -1,3 +1,3 @@
-// error-pattern:#env takes between 1 and 1 arguments
+// error-pattern: env! takes between 1 and 1 arguments
 
 fn main() { env!(); }

--- a/src/test/compile-fail/extenv-too-many-args.rs
+++ b/src/test/compile-fail/extenv-too-many-args.rs
@@ -1,3 +1,3 @@
-// error-pattern:#env takes between 1 and 1 arguments
+// error-pattern: env! takes between 1 and 1 arguments
 
 fn main() { env!("one", "two"); }

--- a/src/test/compile-fail/extfmt-no-args.rs
+++ b/src/test/compile-fail/extfmt-no-args.rs
@@ -1,3 +1,3 @@
-// error-pattern:#fmt needs at least 1 arguments
+// error-pattern:fmt! needs at least 1 arguments
 
 fn main() { fmt!(); }

--- a/src/test/compile-fail/extfmt-non-literal.rs
+++ b/src/test/compile-fail/extfmt-non-literal.rs
@@ -1,7 +1,7 @@
 // error-pattern: literal
 
 fn main() {
-    // #fmt's first argument must be a literal.  Hopefully this
+    // fmt!'s first argument must be a literal.  Hopefully this
     // restriction can be eased eventually to just require a
     // compile-time constant.
     let x = fmt!("a" + "b");

--- a/src/test/compile-fail/extfmt-non-literal2.rs
+++ b/src/test/compile-fail/extfmt-non-literal2.rs
@@ -1,7 +1,7 @@
 // error-pattern: literal
 
 fn main() {
-    // #fmt's first argument must be a literal.  Hopefully this
+    // fmt!'s first argument must be a literal.  Hopefully this
     // restriction can be eased eventually to just require a
     // compile-time constant.
     let x = fmt!(20);

--- a/src/test/compile-fail/extfmt-unsigned-plus.rs
+++ b/src/test/compile-fail/extfmt-unsigned-plus.rs
@@ -1,4 +1,4 @@
-// error-pattern:only valid in signed #fmt conversion
+// error-pattern:only valid in signed fmt! conversion
 
 fn main() {
     // Can't use a sign on unsigned conversions

--- a/src/test/compile-fail/extfmt-unsigned-space.rs
+++ b/src/test/compile-fail/extfmt-unsigned-space.rs
@@ -1,4 +1,4 @@
-// error-pattern:only valid in signed #fmt conversion
+// error-pattern:only valid in signed fmt! conversion
 
 fn main() {
     // Can't use a space on unsigned conversions

--- a/src/test/compile-fail/issue-3099.rs
+++ b/src/test/compile-fail/issue-3099.rs
@@ -1,11 +1,11 @@
 fn a(x: ~str) -> ~str {
-    #fmt("First function with %s", x)
+    fmt!("First function with %s", x)
 }
 
 fn a(x: ~str, y: ~str) -> ~str { //~ ERROR Duplicate definition of value a
-    #fmt("Second function with %s and %s", x, y)
+    fmt!("Second function with %s and %s", x, y)
 }
 
 fn main() {
-    #info("Result: ");
+    info!("Result: ");
 }

--- a/src/test/compile-fail/regions-freevar.rs
+++ b/src/test/compile-fail/regions-freevar.rs
@@ -3,7 +3,7 @@ fn wants_static_fn(_x: &static/fn()) {}
 fn main() {
     let i = 3;
     do wants_static_fn {
-        #debug("i=%d", i);
+        debug!("i=%d", i);
           //~^ ERROR captured variable does not outlive the enclosing closure
     }
 }

--- a/src/test/run-pass/early-vtbl-resolution.rs
+++ b/src/test/run-pass/early-vtbl-resolution.rs
@@ -10,7 +10,7 @@ fn foo_func<A, B: thing<A>>(x: B) -> Option<A> { x.foo() }
 fn main() {
 
     for iter::eachi(&(Some({a: 0}))) |i, a| { 
-        #debug["%u %d", i, a.a];
+        debug!("%u %d", i, a.a);
     }
 
     let _x: Option<float> = foo_func(0);

--- a/src/test/run-pass/issue-2904.rs
+++ b/src/test/run-pass/issue-2904.rs
@@ -41,7 +41,7 @@ fn square_from_char(c: char) -> square {
       '.'  => { earth }
       ' '  => { empty }
       _ => {
-        #error("invalid square: %?", c);
+        error!("invalid square: %?", c);
         fail
       }
     }

--- a/src/test/run-pass/issue-2935.rs
+++ b/src/test/run-pass/issue-2935.rs
@@ -19,6 +19,6 @@ fn main() {
     //  x.f();
     // y.f();
     // (*z).f();
-    #error["ok so far..."];
+    error!("ok so far...");
     z.f(); //segfault
 }

--- a/src/test/run-pass/issue-2989.rs
+++ b/src/test/run-pass/issue-2989.rs
@@ -26,7 +26,7 @@ fn main() {
     let bools2 = to_bools({storage: ~[0b01100100]});
 
     for uint::range(0, 8) |i| {
-        io::println(#fmt("%u => %u vs %u", i, bools[i] as uint, bools2[i] as uint));
+        io::println(fmt!("%u => %u vs %u", i, bools[i] as uint, bools2[i] as uint));
     }
 
     assert bools == bools2;

--- a/src/test/run-pass/issue-3168.rs
+++ b/src/test/run-pass/issue-3168.rs
@@ -6,16 +6,16 @@ fn main() {
         let (c2,p2) = pipes::stream();
         do task::spawn {
             p2.recv();
-            #error["brother fails"];
+            error!("brother fails");
             fail;
         }   
         let (c3,p3) = pipes::stream();
         c.send(c3);
         c2.send(());
-        #error["child blocks"];
+        error!("child blocks");
         p3.recv();
     };  
-    #error["parent tries"];
+    error!("parent tries");
     assert !p.recv().try_send(());
-    #error("all done!");
+    error!("all done!");
 }

--- a/src/test/run-pass/issue-3176.rs
+++ b/src/test/run-pass/issue-3176.rs
@@ -8,18 +8,18 @@ fn main() {
         let (c2,p2) = pipes::stream();
         do task::spawn {
             p2.recv();
-            #error["brother fails"];
+            error!("brother fails");
             fail;
         }   
         let (c3,p3) = pipes::stream();
         c.send(c3);
         c2.send(());
-        #error["child blocks"];
+        error!("child blocks");
         let (c, p) = pipes::stream();
         (p, p3).select();
         c.send(());
     };  
-    #error["parent tries"];
+    error!("parent tries");
     assert !p.recv().try_send(());
-    #error("all done!");
+    error!("all done!");
 }

--- a/src/test/run-pass/pure-fmt.rs
+++ b/src/test/run-pass/pure-fmt.rs
@@ -1,4 +1,4 @@
-// Testing that calling #fmt (via #debug) doesn't complain about impure borrows
+// Testing that calling fmt! (via debug!) doesn't complain about impure borrows
 
 pure fn foo() {
     let a = {

--- a/src/test/run-pass/struct-literal-dtor.rs
+++ b/src/test/run-pass/struct-literal-dtor.rs
@@ -1,6 +1,6 @@
 struct foo {
     x: ~str,
-    drop { #error["%s", self.x]; }
+    drop { error!("%s", self.x); }
 }
 
 fn main() {


### PR DESCRIPTION
This commit replaces nearly all remaining uses of #fmt, #debug, #error,
and #info, and fixes some error messages...

All the tests pass with `CFG_DISABLE_VALGRIND=1 make check`.
