### PR TITLE
Remove uses of last-use analysis

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1827,7 +1827,7 @@ fn map<T, U>(vector: &[T], function: fn(v: &T) -> U) -> ~[U] {
     for vec::each(vector) |element| {
         accumulator.push(function(element));
     }
-    return accumulator;
+    return (move accumulator);
 }
 ~~~~
 

--- a/src/cargo/cargo.rs
+++ b/src/cargo/cargo.rs
@@ -705,7 +705,7 @@ fn configure(opts: Options) -> Cargo {
              ~" or package manager to get it to work correctly");
     }
 
-    c
+    move c
 }
 
 fn for_each_package(c: &Cargo, b: fn(s: @Source, p: &Package)) {
@@ -1615,10 +1615,10 @@ fn dump_sources(c: &Cargo) {
                     _ => ()
                 }
 
-                hash.insert(copy k, json::Object(chash));
+                hash.insert(copy k, json::Object(move chash));
             }
 
-            json::to_writer(writer, &json::Object(hash))
+            json::to_writer(writer, &json::Object(move hash))
         }
         result::Err(e) => {
             error(fmt!("could not dump sources: %s", e));

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -145,7 +145,7 @@ fn make_tests(config: config) -> ~[test::TestDesc] {
             tests.push(make_test(config, file))
         }
     }
-    return tests;
+    move tests
 }
 
 fn is_test(config: config, testfile: &Path) -> bool {

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -60,12 +60,12 @@ fn run(lib_path: ~str,
     writeclose(pipe_in.out, input);
     let p = pipes::PortSet();
     let ch = p.chan();
-    do task::spawn_sched(task::SingleThreaded) {
+    do task::spawn_sched(task::SingleThreaded) |move ch| {
         let errput = readclose(pipe_err.in);
         ch.send((2, errput));
     }
     let ch = p.chan();
-    do task::spawn_sched(task::SingleThreaded) {
+    do task::spawn_sched(task::SingleThreaded) |move ch| {
         let output = readclose(pipe_out.in);
         ch.send((1, output));
     }

--- a/src/libcore/cast.rs
+++ b/src/libcore/cast.rs
@@ -122,9 +122,9 @@ pub mod tests {
     pub fn test_transmute() {
         unsafe {
             let x = @1;
-            let x: *int = transmute(x);
+            let x: *int = transmute(move x);
             assert *x == 1;
-            let _x: @int = transmute(x);
+            let _x: @int = transmute(move x);
         }
     }
 

--- a/src/libcore/cleanup.rs
+++ b/src/libcore/cleanup.rs
@@ -142,7 +142,7 @@ pub unsafe fn annihilate() {
         assert (*box).header.prev == null();
 
         debug!("freeing box: %x", box as uint);
-        rt_free(transmute(box));
+        rt_free(transmute(move box));
     }
 }
 

--- a/src/libcore/extfmt.rs
+++ b/src/libcore/extfmt.rs
@@ -301,7 +301,7 @@ pub mod rt {
                 unsafe { str::unshift_char(&mut s, ' ') };
             }
         }
-        return unsafe { pad(cv, s, PadSigned) };
+        return unsafe { pad(cv, move s, PadSigned) };
     }
     pub pure fn conv_uint(cv: Conv, u: uint) -> ~str {
         let prec = get_int_precision(cv);
@@ -313,7 +313,7 @@ pub mod rt {
               TyBits => uint_to_str_prec(u, 2u, prec),
               TyOctal => uint_to_str_prec(u, 8u, prec)
             };
-        return unsafe { pad(cv, rs, PadUnsigned) };
+        return unsafe { pad(cv, move rs, PadUnsigned) };
     }
     pub pure fn conv_bool(cv: Conv, b: bool) -> ~str {
         let s = if b { ~"true" } else { ~"false" };
@@ -323,7 +323,7 @@ pub mod rt {
     }
     pub pure fn conv_char(cv: Conv, c: char) -> ~str {
         let mut s = str::from_char(c);
-        return unsafe { pad(cv, s, PadNozero) };
+        return unsafe { pad(cv, move s, PadNozero) };
     }
     pub pure fn conv_str(cv: Conv, s: &str) -> ~str {
         // For strings, precision is the maximum characters
@@ -336,7 +336,7 @@ pub mod rt {
             s.to_unique()
           }
         };
-        return unsafe { pad(cv, unpadded, PadNozero) };
+        return unsafe { pad(cv, move unpadded, PadNozero) };
     }
     pub pure fn conv_float(cv: Conv, f: float) -> ~str {
         let (to_str, digits) = match cv.precision {
@@ -351,7 +351,7 @@ pub mod rt {
                 s = ~" " + s;
             }
         }
-        return unsafe { pad(cv, s, PadFloat) };
+        return unsafe { pad(cv, move s, PadFloat) };
     }
     pub pure fn conv_poly<T>(cv: Conv, v: &T) -> ~str {
         let s = sys::log_str(v);
@@ -411,14 +411,14 @@ pub mod rt {
     pub fn pad(cv: Conv, s: ~str, mode: PadMode) -> ~str {
         let mut s = move s; // sadtimes
         let uwidth : uint = match cv.width {
-          CountImplied => return s,
+          CountImplied => return (move s),
           CountIs(width) => {
               // FIXME: width should probably be uint (see Issue #1996)
               width as uint
           }
         };
         let strlen = str::char_len(s);
-        if uwidth <= strlen { return s; }
+        if uwidth <= strlen { return (move s); }
         let mut padchar = ' ';
         let diff = uwidth - strlen;
         if have_flag(cv.flags, flag_left_justify) {

--- a/src/libcore/future.rs
+++ b/src/libcore/future.rs
@@ -179,8 +179,8 @@ pub mod test {
     #[test]
     pub fn test_from_port() {
         let (po, ch) = future_pipe::init();
-        future_pipe::server::completed(ch, ~"whale");
-        let f = from_port(po);
+        future_pipe::server::completed(move ch, ~"whale");
+        let f = from_port(move po);
         assert get(&f) == ~"whale";
     }
 
@@ -238,7 +238,7 @@ pub mod test {
     pub fn test_sendable_future() {
         let expected = ~"schlorf";
         let f = do spawn |copy expected| { copy expected };
-        do task::spawn {
+        do task::spawn |move f, move expected| {
             let actual = get(&f);
             assert actual == expected;
         }

--- a/src/libcore/hash.rs
+++ b/src/libcore/hash.rs
@@ -438,7 +438,7 @@ pub fn test_siphash() {
         for vec::each(*r) |b| {
             s += uint::to_str(*b as uint, 16u);
         }
-        return s;
+        move s
     }
 
     while t < 64 {

--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -737,7 +737,7 @@ pub fn BytesWriter() -> BytesWriter {
 pub fn with_bytes_writer(f: fn(Writer)) -> ~[u8] {
     let wr = @BytesWriter();
     f(wr as Writer);
-    wr.buf.check_out(|buf| buf)
+    wr.buf.check_out(|buf| move buf)
 }
 
 pub fn with_str_writer(f: fn(Writer)) -> ~str {
@@ -747,7 +747,7 @@ pub fn with_str_writer(f: fn(Writer)) -> ~str {
     v.push(0);
     assert str::is_utf8(v);
 
-    unsafe { move ::cast::transmute(v) }
+    unsafe { move ::cast::transmute(move v) }
 }
 
 // Utility functions

--- a/src/libcore/mutable.rs
+++ b/src/libcore/mutable.rs
@@ -24,7 +24,7 @@ struct Data<T> {
 pub type Mut<T> = Data<T>;
 
 pub fn Mut<T>(t: T) -> Mut<T> {
-    Data {value: t, mode: ReadOnly}
+    Data {value: move t, mode: ReadOnly}
 }
 
 pub fn unwrap<T>(m: Mut<T>) -> T {
@@ -32,7 +32,7 @@ pub fn unwrap<T>(m: Mut<T>) -> T {
     // is in use, as that would be a move from a borrowed value.
     assert (m.mode as uint) == (ReadOnly as uint);
     let Data {value: move value, mode: _} = move m;
-    return value;
+    move value
 }
 
 impl<T> Data<T> {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -120,7 +120,7 @@ pub pure fn chain<T, U>(opt: Option<T>,
      */
 
     match move opt {
-        Some(move t) => f(t),
+        Some(move t) => f(move t),
         None => None
     }
 }
@@ -294,7 +294,7 @@ impl<T: Copy> Option<T> {
      *
      * Fails if the value equals `none`
      */
-    pure fn expect(reason: ~str) -> T { expect(&self, reason) }
+    pure fn expect(reason: ~str) -> T { expect(&self, move reason) }
     /// Applies a function zero or more times until the result is none.
     pure fn while_some(blk: fn(v: T) -> Option<T>) { while_some(self, blk) }
 }
@@ -324,8 +324,8 @@ impl<T: Eq> Option<T> : Eq {
 fn test_unwrap_ptr() {
     let x = ~0;
     let addr_x = ptr::addr_of(&(*x));
-    let opt = Some(x);
-    let y = unwrap(opt);
+    let opt = Some(move x);
+    let y = unwrap(move opt);
     let addr_y = ptr::addr_of(&(*y));
     assert addr_x == addr_y;
 }
@@ -356,8 +356,8 @@ fn test_unwrap_resource() {
     let i = @mut 0;
     {
         let x = R(i);
-        let opt = Some(x);
-        let _y = unwrap(opt);
+        let opt = Some(move x);
+        let _y = unwrap(move opt);
     }
     assert *i == 1;
 }

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -739,7 +739,7 @@ unsafe fn load_argc_and_argv(argc: c_int, argv: **c_char) -> ~[~str] {
     for uint::range(0, argc as uint) |i| {
         vec::push(&mut args, str::raw::from_c_str(*argv.offset(i)));
     }
-    return args;
+    move args
 }
 
 /**
@@ -903,7 +903,7 @@ mod tests {
         let rng: rand::Rng = rand::Rng();
         let n = ~"TEST" + rng.gen_str(10u);
         assert getenv(n).is_none();
-        n
+        move n
     }
 
     #[test]
@@ -937,7 +937,7 @@ mod tests {
         let n = make_rand_name();
         setenv(n, s);
         log(debug, s);
-        assert getenv(n) == option::Some(s);
+        assert getenv(n) == option::Some(move s);
     }
 
     #[test]
@@ -963,7 +963,7 @@ mod tests {
             // MingW seems to set some funky environment variables like
             // "=C:=C:\MinGW\msys\1.0\bin" and "!::=::\" that are returned
             // from env() but not visible from getenv().
-            assert v2.is_none() || v2 == option::Some(v);
+            assert v2.is_none() || v2 == option::Some(move v);
         }
     }
 
@@ -976,7 +976,7 @@ mod tests {
         assert !vec::contains(e, &(copy n, ~"VALUE"));
 
         e = env();
-        assert vec::contains(e, &(n, ~"VALUE"));
+        assert vec::contains(e, &(move n, ~"VALUE"));
     }
 
     #[test]

--- a/src/libcore/path.rs
+++ b/src/libcore/path.rs
@@ -96,7 +96,7 @@ impl PosixPath : GenericPath {
         let mut components = str::split_nonempty(s, |c| c == '/');
         let is_absolute = (s.len() != 0 && s[0] == '/' as u8);
         return PosixPath { is_absolute: is_absolute,
-                           components: components }
+                           components: move components }
     }
 
     pure fn dirname() -> ~str {
@@ -192,7 +192,7 @@ impl PosixPath : GenericPath {
           Some(ref f) => ~[copy *f]
         };
         return PosixPath { is_absolute: false,
-                           components: cs }
+                           components: move cs }
     }
 
     pure fn push_rel(other: &PosixPath) -> PosixPath {
@@ -208,7 +208,8 @@ impl PosixPath : GenericPath {
                 |c| windows::is_sep(c as u8));
             unsafe { v.push_all_move(move ss); }
         }
-        PosixPath { components: move v, ..self }
+        PosixPath { is_absolute: self.is_absolute,
+                    components: move v }
     }
 
     pure fn push(s: &str) -> PosixPath {
@@ -223,13 +224,18 @@ impl PosixPath : GenericPath {
         if cs.len() != 0 {
             unsafe { cs.pop(); }
         }
-        return PosixPath { components: move cs, ..self }
+        return PosixPath {
+            is_absolute: self.is_absolute,
+            components: move cs
+        }
+                          //..self }
     }
 
     pure fn normalize() -> PosixPath {
         return PosixPath {
-            components: normalize(self.components),
-            ..self
+            is_absolute: self.is_absolute,
+            components: normalize(self.components)
+          //  ..self
         }
     }
 }
@@ -286,10 +292,10 @@ impl WindowsPath : GenericPath {
         let mut components =
             str::split_nonempty(rest, |c| windows::is_sep(c as u8));
         let is_absolute = (rest.len() != 0 && windows::is_sep(rest[0]));
-        return WindowsPath { host: host,
-                             device: device,
+        return WindowsPath { host: move host,
+                             device: move device,
                              is_absolute: is_absolute,
-                             components: components }
+                             components: move components }
     }
 
     pure fn dirname() -> ~str {
@@ -386,7 +392,7 @@ impl WindowsPath : GenericPath {
         return WindowsPath { host: None,
                              device: None,
                              is_absolute: false,
-                             components: cs }
+                             components: move cs }
     }
 
     pure fn push_rel(other: &WindowsPath) -> WindowsPath {
@@ -402,7 +408,13 @@ impl WindowsPath : GenericPath {
                 |c| windows::is_sep(c as u8));
             unsafe { v.push_all_move(move ss); }
         }
-        return WindowsPath { components: move v, ..self }
+        // tedious, but as-is, we can't use ..self
+        return WindowsPath {
+            host: copy self.host,
+            device: copy self.device,
+            is_absolute: self.is_absolute,
+            components: move v
+        }
     }
 
     pure fn push(s: &str) -> WindowsPath {
@@ -417,13 +429,20 @@ impl WindowsPath : GenericPath {
         if cs.len() != 0 {
             unsafe { cs.pop(); }
         }
-        return WindowsPath { components: move cs, ..self }
+        return WindowsPath {
+            host: copy self.host,
+            device: copy self.device,
+            is_absolute: self.is_absolute,
+            components: move cs
+        }
     }
 
     pure fn normalize() -> WindowsPath {
         return WindowsPath {
-            components: normalize(self.components),
-            ..self
+            host: copy self.host,
+            device: copy self.device,
+            is_absolute: self.is_absolute,
+            components: normalize(self.components)
         }
     }
 }

--- a/src/libcore/repr.rs
+++ b/src/libcore/repr.rs
@@ -156,7 +156,7 @@ impl ReprVisitor {
     fn visit_ptr_inner(ptr: *c_void, inner: *TyDesc) -> bool {
         let mut u = ReprVisitor(ptr, self.writer);
         let v = reflect::MovePtrAdaptor(move u);
-        visit_tydesc(inner, v as @TyVisitor);
+        visit_tydesc(inner, (move v) as @TyVisitor);
         true
     }
 
@@ -453,7 +453,7 @@ pub fn write_repr2<T>(writer: @Writer, object: &T) {
     let tydesc = intrinsic::get_tydesc::<T>();
     let mut u = ReprVisitor(ptr, writer);
     let v = reflect::MovePtrAdaptor(move u);
-    visit_tydesc(tydesc, v as @TyVisitor)
+    visit_tydesc(tydesc, (move v) as @TyVisitor)
 }
 
 #[test]
@@ -992,7 +992,7 @@ pub fn write_repr<T>(writer: @Writer, object: &T) {
     unsafe {
         let ptr = ptr::to_unsafe_ptr(object) as *c_void;
         let tydesc = sys::get_type_desc::<T>();
-        let tydesc = cast::transmute(tydesc);
+        let tydesc = cast::transmute(move tydesc);
 
         let repr_printer = @ReprPrinter {
             ptr: ptr,

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -106,7 +106,7 @@ pub pure fn to_either<T: Copy, U: Copy>(res: &Result<U, T>)
 pub fn chain<T, U: Copy, V: Copy>(res: Result<T, V>, op: fn(t: T)
     -> Result<U, V>) -> Result<U, V> {
     match move res {
-        Ok(move t) => op(t),
+        Ok(move t) => op(move t),
         Err(move e) => Err(e)
     }
 }

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -226,7 +226,7 @@ pub fn start_program(prog: &str, args: &[~str]) -> Program {
 
     fn ProgRes(r: ProgRepr) -> ProgRes {
         ProgRes {
-            r: r
+            r: move r
         }
     }
 
@@ -313,10 +313,10 @@ pub fn program_output(prog: &str, args: &[~str]) ->
         let stream = comm::recv(p);
         match stream {
             (1, copy s) => {
-                outs = s;
+                outs = move s;
             }
             (2, copy s) => {
-                errs = s;
+                errs = move s;
             }
             (n, _) => {
                 fail(fmt!("program_output received an unexpected file \

--- a/src/libcore/send_map.rs
+++ b/src/libcore/send_map.rs
@@ -185,8 +185,8 @@ pub mod linear {
                     debug!("insert fresh (%?->%?) at idx %?, hash %?",
                            k, v, idx, hash);
                     self.buckets[idx] = Some(Bucket {hash: hash,
-                                                     key: k,
-                                                     value: v});
+                                                     key: move k,
+                                                     value: move v});
                     self.size += 1;
                     true
                 }
@@ -194,8 +194,8 @@ pub mod linear {
                     debug!("insert overwrite (%?->%?) at idx %?, hash %?",
                            k, v, idx, hash);
                     self.buckets[idx] = Some(Bucket {hash: hash,
-                                                     key: k,
-                                                     value: v});
+                                                     key: move k,
+                                                     value: move v});
                     false
                 }
             }
@@ -230,7 +230,7 @@ pub mod linear {
                 None => None,
                 Some(move bucket) => {
                     let Bucket { value: move value, _ } = move bucket;
-                    Some(value)
+                    Some(move value)
                 },
             };
 
@@ -243,7 +243,7 @@ pub mod linear {
             }
             self.size -= 1;
 
-            value
+            move value
 
         }
 
@@ -297,9 +297,9 @@ pub mod linear {
                 self.expand();
             }
 
-            self.insert_internal(hash, k, v);
+            self.insert_internal(hash, move k, move v);
 
-            old_value
+            move old_value
         }
 
         fn consume(&mut self, f: fn(K, V)) {
@@ -307,7 +307,7 @@ pub mod linear {
             self.buckets <-> buckets;
             self.size = 0;
 
-            do vec::consume(buckets) |_i, bucket| {
+            do vec::consume(move buckets) |_i, bucket| {
                 match move bucket {
                     None => { },
                     Some(move bucket) => {
@@ -316,7 +316,7 @@ pub mod linear {
                             value: move value,
                             _
                         } = move bucket;
-                        f(key, value)
+                        f(move key, move value)
                     }
                 }
             }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -2562,23 +2562,23 @@ mod tests {
     #[test]
     fn test_unsafe_slice() {
         unsafe {
-            assert ~"ab" == raw::slice_bytes(~"abc", 0u, 2u);
-            assert ~"bc" == raw::slice_bytes(~"abc", 1u, 3u);
-            assert ~"" == raw::slice_bytes(~"abc", 1u, 1u);
+            assert ~"ab" == raw::slice_bytes(~"abc", 0, 2);
+            assert ~"bc" == raw::slice_bytes(~"abc", 1, 3);
+            assert ~"" == raw::slice_bytes(~"abc", 1, 1);
             fn a_million_letter_a() -> ~str {
                 let mut i = 0;
                 let mut rs = ~"";
                 while i < 100000 { push_str(&mut rs, ~"aaaaaaaaaa"); i += 1; }
-                return rs;
+                move rs
             }
             fn half_a_million_letter_a() -> ~str {
                 let mut i = 0;
                 let mut rs = ~"";
                 while i < 100000 { push_str(&mut rs, ~"aaaaa"); i += 1; }
-                return rs;
+                move rs
             }
             assert half_a_million_letter_a() ==
-                raw::slice_bytes(a_million_letter_a(), 0u, 500000u);
+                raw::slice_bytes(a_million_letter_a(), 0u, 500000);
         }
     }
 
@@ -2664,16 +2664,16 @@ mod tests {
 
     #[test]
     fn test_slice() {
-        assert ~"ab" == slice(~"abc", 0u, 2u);
-        assert ~"bc" == slice(~"abc", 1u, 3u);
-        assert ~"" == slice(~"abc", 1u, 1u);
-        assert ~"\u65e5" == slice(~"\u65e5\u672c", 0u, 3u);
+        assert ~"ab" == slice(~"abc", 0, 2);
+        assert ~"bc" == slice(~"abc", 1, 3);
+        assert ~"" == slice(~"abc", 1, 1);
+        assert ~"\u65e5" == slice(~"\u65e5\u672c", 0, 3);
 
         let data = ~"ประเทศไทย中华";
-        assert ~"ป" == slice(data, 0u, 3u);
-        assert ~"ร" == slice(data, 3u, 6u);
-        assert ~"" == slice(data, 3u, 3u);
-        assert ~"华" == slice(data, 30u, 33u);
+        assert ~"ป" == slice(data, 0, 3);
+        assert ~"ร" == slice(data, 3, 6);
+        assert ~"" == slice(data, 3, 3);
+        assert ~"华" == slice(data, 30, 33);
 
         fn a_million_letter_X() -> ~str {
             let mut i = 0;
@@ -2682,13 +2682,13 @@ mod tests {
                 push_str(&mut rs, ~"华华华华华华华华华华");
                 i += 1;
             }
-            return rs;
+            move rs
         }
         fn half_a_million_letter_X() -> ~str {
             let mut i = 0;
             let mut rs = ~"";
             while i < 100000 { push_str(&mut rs, ~"华华华华华"); i += 1; }
-            return rs;
+            move rs
         }
         assert half_a_million_letter_X() ==
             slice(a_million_letter_X(), 0u, 3u * 500000u);

--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -153,7 +153,7 @@ pub mod tests {
 
         assert f(20) == 30;
 
-        let original_closure: Closure = cast::transmute(f);
+        let original_closure: Closure = cast::transmute(move f);
 
         let actual_function_pointer = original_closure.code;
         let environment = original_closure.env;
@@ -163,7 +163,7 @@ pub mod tests {
             env: environment
         };
 
-        let new_f: fn(int) -> int = cast::transmute(new_closure);
+        let new_f: fn(int) -> int = cast::transmute(move new_closure);
         assert new_f(20) == 30;
     }
 }

--- a/src/libcore/task/spawn.rs
+++ b/src/libcore/task/spawn.rs
@@ -312,8 +312,8 @@ fn TCB(me: *rust_task, tasks: TaskGroupArc, ancestors: AncestorList,
 
     TCB {
         me: me,
-        tasks: tasks,
-        ancestors: ancestors,
+        tasks: move tasks,
+        ancestors: move ancestors,
         is_main: is_main,
         notifier: move notifier
     }
@@ -330,7 +330,7 @@ struct AutoNotify {
 
 fn AutoNotify(chan: Chan<Notification>) -> AutoNotify {
     AutoNotify {
-        notify_chan: chan,
+        notify_chan: move chan,
         failed: true // Un-set above when taskgroup successfully made.
     }
 }
@@ -652,7 +652,7 @@ fn test_spawn_raw_unsupervise() {
         mut notify_chan: None,
         .. default_task_opts()
     };
-    do spawn_raw(opts) {
+    do spawn_raw(move opts) {
         fail;
     }
 }
@@ -667,7 +667,7 @@ fn test_spawn_raw_notify_success() {
         notify_chan: Some(move notify_ch),
         .. default_task_opts()
     };
-    do spawn_raw(opts) |move task_ch| {
+    do spawn_raw(move opts) |move task_ch| {
         task_ch.send(get_task());
     }
     let task_ = task_po.recv();
@@ -683,10 +683,10 @@ fn test_spawn_raw_notify_failure() {
 
     let opts = {
         linked: false,
-        notify_chan: Some(notify_ch),
+        notify_chan: Some(move notify_ch),
         .. default_task_opts()
     };
-    do spawn_raw(opts) {
+    do spawn_raw(move opts) |move task_ch| {
         task_ch.send(get_task());
         fail;
     }

--- a/src/libcore/util.rs
+++ b/src/libcore/util.rs
@@ -100,7 +100,7 @@ mod tests {
         let x = ~[(5, false)];
         //FIXME #3387 assert x.eq(id(copy x));
         let y = copy x;
-        assert x.eq(&id(y));
+        assert x.eq(&id(move y));
     }
     #[test]
     fn test_swap() {

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -340,15 +340,15 @@ pub fn splitn<T: Copy>(v: &[T], n: uint, f: fn(t: &T) -> bool) -> ~[~[T]] {
  */
 pub fn rsplit<T: Copy>(v: &[T], f: fn(t: &T) -> bool) -> ~[~[T]] {
     let ln = len(v);
-    if (ln == 0u) { return ~[] }
+    if (ln == 0) { return ~[] }
 
     let mut end = ln;
     let mut result = ~[];
-    while end > 0u {
-        match rposition_between(v, 0u, end, f) {
+    while end > 0 {
+        match rposition_between(v, 0, end, f) {
             None => break,
             Some(i) => {
-                result.push(slice(v, i + 1u, end));
+                result.push(slice(v, i + 1, end));
                 end = i;
             }
         }
@@ -416,7 +416,7 @@ pub fn shift<T>(v: &mut ~[T]) -> T {
 pub fn unshift<T>(v: &mut ~[T], x: T) {
     let mut vv = ~[move x];
     *v <-> vv;
-    v.push_all_move(vv);
+    v.push_all_move(move vv);
 }
 
 pub fn consume<T>(v: ~[T], f: fn(uint, v: T)) unsafe {
@@ -433,7 +433,7 @@ pub fn consume<T>(v: ~[T], f: fn(uint, v: T)) unsafe {
 }
 
 pub fn consume_mut<T>(v: ~[mut T], f: fn(uint, v: T)) {
-    consume(vec::from_mut(v), f)
+    consume(vec::from_mut(move v), f)
 }
 
 /// Remove the last element from a vector and return it
@@ -591,7 +591,7 @@ pub pure fn append_one<T>(lhs: ~[T], x: T) -> ~[T] {
 
 #[inline(always)]
 pure fn append_mut<T: Copy>(lhs: ~[mut T], rhs: &[const T]) -> ~[mut T] {
-    to_mut(append(from_mut(lhs), rhs))
+    to_mut(append(from_mut(move lhs), rhs))
 }
 
 /**
@@ -1621,7 +1621,7 @@ impl<T> ~[T]: MutableVector<T> {
     }
 
     fn unshift(&mut self, x: T) {
-        unshift(self, x)
+        unshift(self, move x)
     }
 
     fn swap_remove(&mut self, index: uint) -> T {
@@ -2208,7 +2208,7 @@ mod tests {
     #[test]
     fn test_dedup() {
         fn case(a: ~[uint], b: ~[uint]) {
-            let mut v = a;
+            let mut v = move a;
             v.dedup();
             assert(v == b);
         }
@@ -2464,13 +2464,13 @@ mod tests {
         let v1 = ~[1, 2, 3];
         let v2 = ~[4, 5, 6];
 
-        let z1 = zip(v1, v2);
+        let z1 = zip(move v1, move v2);
 
         assert ((1, 4) == z1[0]);
         assert ((2, 5) == z1[1]);
         assert ((3, 6) == z1[2]);
 
-        let (left, right) = unzip(z1);
+        let (left, right) = unzip(move z1);
 
         assert ((1, 4) == (left[0], right[0]));
         assert ((2, 5) == (left[1], right[1]));
@@ -2768,7 +2768,7 @@ mod tests {
         unsafe {
             let x = ~[1, 2, 3];
             let addr = raw::to_ptr(x);
-            let x_mut = to_mut(x);
+            let x_mut = to_mut(move x);
             let addr_mut = raw::to_ptr(x_mut);
             assert addr == addr_mut;
         }
@@ -2779,7 +2779,7 @@ mod tests {
         unsafe {
             let x = ~[mut 1, 2, 3];
             let addr = raw::to_ptr(x);
-            let x_imm = from_mut(x);
+            let x_imm = from_mut(move x);
             let addr_imm = raw::to_ptr(x_imm);
             assert addr == addr_imm;
         }
@@ -2977,7 +2977,7 @@ mod tests {
     fn test_consume_fail() {
         let v = ~[(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
         let mut i = 0;
-        do consume(v) |_i, _elt| {
+        do consume(move v) |_i, _elt| {
             if i == 2 {
                 fail
             }
@@ -2991,7 +2991,7 @@ mod tests {
     fn test_consume_mut_fail() {
         let v = ~[mut (~0, @0), (~0, @0), (~0, @0), (~0, @0)];
         let mut i = 0;
-        do consume_mut(v) |_i, _elt| {
+        do consume_mut(move v) |_i, _elt| {
             if i == 2 {
                 fail
             }
@@ -3034,7 +3034,7 @@ mod tests {
     fn test_map_consume_fail() {
         let v = ~[(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
         let mut i = 0;
-        do map_consume(v) |_elt| {
+        do map_consume(move v) |_elt| {
             if i == 2 {
                 fail
             }

--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -96,7 +96,7 @@ struct BigBitv {
 }
 
 fn BigBitv(storage: ~[mut uint]) -> BigBitv {
-    BigBitv {storage: storage}
+    BigBitv {storage: move storage}
 }
 
 /**
@@ -223,7 +223,7 @@ pub fn Bitv (nbits: uint, init: bool) -> Bitv {
         let s = to_mut(from_elem(nelems, elem));
         Big(~BigBitv(move s))
     };
-    Bitv {rep: rep, nbits: nbits}
+    Bitv {rep: move rep, nbits: nbits}
 }
 
 priv impl Bitv {
@@ -301,7 +301,7 @@ impl Bitv {
             let st = to_mut(from_elem(self.nbits / uint_bits + 1, 0));
             let len = st.len();
             for uint::range(0, len) |i| { st[i] = b.storage[i]; };
-            Bitv{nbits: self.nbits, rep: Big(~BigBitv{storage: st})}
+            Bitv{nbits: self.nbits, rep: Big(~BigBitv{storage: move st})}
           }
         }
     }

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -57,7 +57,7 @@ fn test_basic() {
     let value = value_cell.take();
     assert value == ~10;
     assert value_cell.is_empty();
-    value_cell.put_back(value);
+    value_cell.put_back(move value);
     assert !value_cell.is_empty();
 }
 

--- a/src/libstd/comm.rs
+++ b/src/libstd/comm.rs
@@ -52,12 +52,12 @@ pub fn DuplexStream<T: Send, U: Send>()
     let (c2, p1) = pipes::stream();
     let (c1, p2) = pipes::stream();
     (DuplexStream {
-        chan: c1,
-        port: p1
+        chan: move c1,
+        port: move p1
     },
      DuplexStream {
-         chan: c2,
-         port: p2
+         chan: move c2,
+         port: move p2
      })
 }
 

--- a/src/libstd/net_ip.rs
+++ b/src/libstd/net_ip.rs
@@ -128,7 +128,7 @@ pub mod v4 {
      */
     pub fn parse_addr(ip: &str) -> IpAddr {
         match try_parse_addr(ip) {
-          result::Ok(copy addr) => addr,
+          result::Ok(move addr) => move addr,
           result::Err(ref err_data) => fail err_data.err_msg
         }
     }
@@ -214,7 +214,7 @@ pub mod v6 {
      */
     pub fn parse_addr(ip: &str) -> IpAddr {
         match try_parse_addr(ip) {
-          result::Ok(copy addr) => addr,
+          result::Ok(move addr) => move addr,
           result::Err(copy err_data) => fail err_data.err_msg
         }
     }
@@ -353,7 +353,7 @@ mod test {
         }
         // note really sure how to realiably test/assert
         // this.. mostly just wanting to see it work, atm.
-        let results = result::unwrap(ga_result);
+        let results = result::unwrap(move ga_result);
         log(debug, fmt!("test_get_addr: Number of results for %s: %?",
                         localhost_name, vec::len(results)));
         for vec::each(results) |r| {
@@ -366,7 +366,7 @@ mod test {
         }
         // at least one result.. this is going to vary from system
         // to system, based on stuff like the contents of /etc/hosts
-        assert vec::len(results) > 0;
+        assert !results.is_empty();
     }
     #[test]
     #[ignore(reason = "valgrind says it's leaky")]

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -562,7 +562,8 @@ pub fn listen(host_ip: ip::IpAddr, port: uint, backlog: uint,
           new_connect_cb: fn~(TcpNewConnection,
                                comm::Chan<Option<TcpErrData>>))
     -> result::Result<(), TcpListenErrData> unsafe {
-    do listen_common(move host_ip, port, backlog, iotask, on_establish_cb)
+    do listen_common(move host_ip, port, backlog, iotask,
+                     move on_establish_cb)
         // on_connect_cb
         |move new_connect_cb, handle| unsafe {
             let server_data_ptr = uv::ll::get_data_for_uv_handle(handle)

--- a/src/libstd/sort.rs
+++ b/src/libstd/sort.rs
@@ -250,7 +250,7 @@ mod test_qsort {
 
         sort::quick_sort(|x, y| { int::le(*x, *y) }, names);
 
-        let immut_names = vec::from_mut(names);
+        let immut_names = vec::from_mut(move names);
 
         let pairs = vec::zip(expected, immut_names);
         for vec::each(pairs) |p| {

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -130,7 +130,7 @@ pub fn run_tests_console(opts: &TestOpts,
                 st.failed += 1u;
                 write_failed(st.out, st.use_color);
                 st.out.write_line(~"");
-                st.failures.push(test);
+                st.failures.push(move test);
               }
               TrIgnored => {
                 st.ignored += 1u;
@@ -249,7 +249,7 @@ fn should_sort_failures_before_printing_them() {
               mut passed: 0u,
               mut failed: 0u,
               mut ignored: 0u,
-              mut failures: ~[test_b, test_a]};
+              mut failures: ~[move test_b, move test_a]};
 
         print_failures(st);
     };
@@ -534,9 +534,9 @@ mod tests {
             for vec::each(names) |name| {
                 let test = {name: *name, testfn: copy testfn, ignore: false,
                             should_fail: false};
-                tests.push(test);
+                tests.push(move test);
             }
-            tests
+            move tests
         };
         let filtered = filter_tests(&opts, tests);
 
@@ -549,7 +549,7 @@ mod tests {
               ~"test::parse_ignored_flag",
               ~"test::sort_tests"];
 
-        let pairs = vec::zip(expected, filtered);
+        let pairs = vec::zip(expected, move filtered);
 
         for vec::each(pairs) |p| {
             match *p {

--- a/src/libstd/timer.rs
+++ b/src/libstd/timer.rs
@@ -55,7 +55,7 @@ pub fn delayed_send<T: Send>(iotask: IoTask,
             // delayed_send_cb has been processed by libuv
             core::comm::recv(timer_done_po);
             // notify the caller immediately
-            core::comm::send(ch, copy(val));
+            core::comm::send(ch, move(val));
             // uv_close for this timer has been processed
             core::comm::recv(timer_done_po);
     };

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -231,7 +231,7 @@ fn mk_ctxt(parse_sess: parse::parse_sess,
         mut mod_path: ~[],
         mut trace_mac: false
     };
-    move (imp as ext_ctxt)
+    move ((move imp) as ext_ctxt)
 }
 
 fn expr_to_str(cx: ext_ctxt, expr: @ast::expr, error: ~str) -> ~str {

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -345,7 +345,7 @@ fn parse(sess: parse_sess, cfg: ast::crate_cfg, rdr: reader, ms: ~[matcher])
                      built-in NTs %s or %u other options.",
                     nts, next_eis.len()));
             } else if (bb_eis.len() == 0u && next_eis.len() == 0u) {
-                return failure(sp, ~"No rules expected the token "
+                return failure(sp, ~"No rules expected the token: "
                             + to_str(rdr.interner(), tok));
             } else if (next_eis.len() > 0u) {
                 /* Now process the next token */

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -16,7 +16,7 @@ fn mk<T:Eq IterBytes Hash Const Copy>() -> interner<T> {
     let m = map::HashMap::<T, uint>();
     let hi: hash_interner<T> =
         {map: m, vect: DVec()};
-    move (hi as interner::<T>)
+    move ((move hi) as interner::<T>)
 }
 
 fn mk_prefill<T:Eq IterBytes Hash Const Copy>(init: ~[T]) -> interner<T> {

--- a/src/rustc/middle/kind.rs
+++ b/src/rustc/middle/kind.rs
@@ -89,8 +89,11 @@ fn check_crate(tcx: ty::ctxt,
     tcx.sess.abort_if_errors();
 }
 
+// bool flag is only used for checking closures,
+// where it refers to whether a var is 'move' in the
+// capture clause
 type check_fn = fn@(ctx, node_id, Option<@freevar_entry>,
-                    bool, ty::t, sp: span);
+                   bool, ty::t, sp: span);
 
 // Yields the appropriate function to check the kind of closed over
 // variables. `id` is the node_id for some expression that creates the
@@ -111,7 +114,6 @@ fn with_appropriate_checker(cx: ctx, id: node_id, b: fn(check_fn)) {
                              "to copy values into a ~fn closure, use a \
                               capture clause: `fn~(copy x)` or `|copy x|`")));
         }
-
         // check that only immutable variables are implicitly copied in
         for fv.each |fv| {
             check_imm_free_var(cx, fv.def, fv.span);
@@ -132,7 +134,6 @@ fn with_appropriate_checker(cx: ctx, id: node_id, b: fn(check_fn)) {
                              "to copy values into a @fn closure, use a \
                               capture clause: `fn~(copy x)` or `|copy x|`")));
         }
-
         // check that only immutable variables are implicitly copied in
         for fv.each |fv| {
             check_imm_free_var(cx, fv.def, fv.span);
@@ -151,7 +152,7 @@ fn with_appropriate_checker(cx: ctx, id: node_id, b: fn(check_fn)) {
     }
 
     fn check_for_bare(cx: ctx, _id: node_id, _fv: Option<@freevar_entry>,
-                      _is_move: bool,_var_t: ty::t, sp: span) {
+                      _is_move: bool, _var_t: ty::t, sp: span) {
         cx.tcx.sess.span_err(sp, ~"attempted dynamic environment capture");
     }
 
@@ -189,6 +190,7 @@ fn check_fn(fk: visit::fn_kind, decl: fn_decl, body: blk, sp: span,
             let cap_def = cx.tcx.def_map.get(cap_item.id);
             let cap_def_id = ast_util::def_id_of_def(cap_def).node;
             let ty = ty::node_id_to_type(cx.tcx, cap_def_id);
+            // Here's where is_move isn't always false...
             chk(cx, fn_id, None, cap_item.is_move, ty, cap_item.span);
             cap_def_id
         };
@@ -201,17 +203,10 @@ fn check_fn(fk: visit::fn_kind, decl: fn_decl, body: blk, sp: span,
             // skip over free variables that appear in the cap clause
             if captured_vars.contains(&id) { loop; }
 
-            // if this is the last use of the variable, then it will be
-            // a move and not a copy
-            let is_move = {
-                match cx.last_use_map.find(fn_id) {
-                  Some(vars) => (*vars).contains(&id),
-                  None => false
-                }
-            };
-
             let ty = ty::node_id_to_type(cx.tcx, id);
-            chk(cx, fn_id, Some(*fv), is_move, ty, fv.span);
+            // is_move is always false here. See the let captured_vars...
+            // code above for where it's not always false.
+            chk(cx, fn_id, Some(*fv), false, ty, fv.span);
         }
     }
 
@@ -220,7 +215,9 @@ fn check_fn(fk: visit::fn_kind, decl: fn_decl, body: blk, sp: span,
 
 fn check_block(b: blk, cx: ctx, v: visit::vt<ctx>) {
     match b.node.expr {
-      Some(ex) => maybe_copy(cx, ex, None),
+      Some(ex) => maybe_copy(cx, ex,
+         Some(("Tail expressions in blocks must be copyable",
+                                   "(Try adding a move)"))),
       _ => ()
     }
     visit::visit_block(b, cx, v);
@@ -281,33 +278,45 @@ fn check_expr(e: @expr, cx: ctx, v: visit::vt<ctx>) {
       expr_assign(_, ex) |
       expr_unary(box(_), ex) | expr_unary(uniq(_), ex) |
       expr_ret(Some(ex)) => {
-        maybe_copy(cx, ex, None);
+        maybe_copy(cx, ex, Some(("Returned values must be copyable",
+                                 "Try adding a move")));
       }
       expr_cast(source, _) => {
-        maybe_copy(cx, source, None);
+        maybe_copy(cx, source, Some(("Casted values must be copyable",
+                                     "Try adding a move")));
         check_cast_for_escaping_regions(cx, source, e);
       }
-      expr_copy(expr) => check_copy_ex(cx, expr, false, None),
+      expr_copy(expr) => check_copy_ex(cx, expr, false,
+          Some(("Explicit copy requires a copyable argument", ""))),
       // Vector add copies, but not "implicitly"
-      expr_assign_op(_, _, ex) => check_copy_ex(cx, ex, false, None),
+      expr_assign_op(_, _, ex) => check_copy_ex(cx, ex, false,
+                                   Some(("Assignment with operation requires \
+                                          a copyable argument", ""))),
       expr_binary(add, ls, rs) => {
-        check_copy_ex(cx, ls, false, None);
-        check_copy_ex(cx, rs, false, None);
+        let reason = Some(("Binary operators require copyable arguments",
+                           ""));
+        check_copy_ex(cx, ls, false, reason);
+        check_copy_ex(cx, rs, false, reason);
       }
-      expr_rec(fields, def) => {
-        for fields.each |field| { maybe_copy(cx, field.node.expr, None); }
+      expr_rec(fields, def) | expr_struct(_, fields, def) => {
+        for fields.each |field| { maybe_copy(cx, field.node.expr,
+                                   Some(("Record or struct fields require \
+                                          copyable arguments", ""))); }
         match def {
           Some(ex) => {
             // All noncopyable fields must be overridden
             let t = ty::expr_ty(cx.tcx, ex);
             let ty_fields = match ty::get(t).sty {
               ty::ty_rec(f) => f,
-              _ => cx.tcx.sess.span_bug(ex.span, ~"bad expr type in record")
+              ty::ty_class(did, substs) =>
+                  ty::class_items_as_fields(cx.tcx, did, &substs),
+              _ => cx.tcx.sess.span_bug(ex.span,
+                                        ~"bad base expr type in record")
             };
             for ty_fields.each |tf| {
                 if !vec::any(fields, |f| f.node.ident == tf.ident ) &&
                     !ty::kind_can_be_copied(ty::type_kind(cx.tcx, tf.mt.ty)) {
-                    cx.tcx.sess.span_err(ex.span,
+                    cx.tcx.sess.span_err(e.span,
                                          ~"copying a noncopyable value");
                 }
             }
@@ -316,16 +325,16 @@ fn check_expr(e: @expr, cx: ctx, v: visit::vt<ctx>) {
         }
       }
       expr_tup(exprs) | expr_vec(exprs, _) => {
-        for exprs.each |expr| { maybe_copy(cx, *expr, None); }
+        for exprs.each |expr| { maybe_copy(cx, *expr,
+                    Some(("Tuple or vec elements must be copyable", ""))); }
       }
       expr_call(f, args, _) => {
-        let mut i = 0u;
-        for ty::ty_fn_args(ty::expr_ty(cx.tcx, f)).each |arg_t| {
+        for ty::ty_fn_args(ty::expr_ty(cx.tcx, f)).eachi |i, arg_t| {
             match ty::arg_mode(cx.tcx, *arg_t) {
-              by_copy => maybe_copy(cx, args[i], None),
+              by_copy => maybe_copy(cx, args[i],
+                     Some(("Callee takes its argument by copy", ""))),
               by_ref | by_val | by_move => ()
             }
-            i += 1u;
         }
       }
       expr_field(lhs, _, _) => {
@@ -334,7 +343,9 @@ fn check_expr(e: @expr, cx: ctx, v: visit::vt<ctx>) {
         match cx.method_map.find(e.id) {
             Some(ref mme) => {
                 match ty::arg_mode(cx.tcx, mme.self_arg) {
-                    by_copy => maybe_copy(cx, lhs, None),
+                    by_copy => maybe_copy(cx, lhs,
+                      Some(("Method call takes its self argument by copy",
+                            ""))),
                     by_ref | by_val | by_move => ()
                 }
             }
@@ -344,10 +355,12 @@ fn check_expr(e: @expr, cx: ctx, v: visit::vt<ctx>) {
       expr_repeat(element, count_expr, _) => {
         let count = ty::eval_repeat_count(cx.tcx, count_expr, e.span);
         if count == 1 {
-            maybe_copy(cx, element, None);
+            maybe_copy(cx, element, Some(("Trivial repeat takes its element \
+                                           by copy", "")));
         } else {
             let element_ty = ty::expr_ty(cx.tcx, element);
-            check_copy(cx, element.id, element_ty, element.span, true, None);
+            check_copy(cx, element.id, element_ty, element.span, true,
+                       Some(("Repeat takes its elements by copy", "")));
         }
       }
       _ => { }
@@ -360,7 +373,9 @@ fn check_stmt(stmt: @stmt, cx: ctx, v: visit::vt<ctx>) {
       stmt_decl(@{node: decl_local(locals), _}, _) => {
         for locals.each |local| {
             match local.node.init {
-              Some({op: init_assign, expr}) => maybe_copy(cx, expr, None),
+              Some({op: init_assign, expr}) =>
+                  maybe_copy(cx, expr, Some(("Initializer statement \
+                              takes its right-hand side by copy", ""))),
               _ => {}
             }
         }
@@ -433,9 +448,6 @@ fn is_nullary_variant(cx: ctx, ex: @expr) -> bool {
 fn check_copy_ex(cx: ctx, ex: @expr, implicit_copy: bool,
                  why: Option<(&str,&str)>) {
     if ty::expr_is_lval(cx.tcx, cx.method_map, ex) &&
-
-        // this is a move
-        !cx.last_use_map.contains_key(ex.id) &&
 
         // a reference to a constant like `none`... no need to warn
         // about *this* even if the type is Option<~int>

--- a/src/rustc/middle/liveness.rs
+++ b/src/rustc/middle/liveness.rs
@@ -1461,7 +1461,15 @@ fn check_expr(expr: @expr, &&self: @Liveness, vt: vt<@Liveness>) {
             match ty::resolved_mode(self.tcx, arg_ty.mode) {
                 by_val | by_copy | by_ref => {}
                 by_move => {
-                    self.check_move_from_expr(*arg_expr, vt);
+                    if ty::expr_is_lval(self.tcx, self.ir.method_map,
+                                        *arg_expr) {
+                        // Probably a bad error message (what's an rvalue?)
+                        // but I can't think of anything better
+                        self.tcx.sess.span_err(arg_expr.span,
+                          #fmt("Move mode argument must be an rvalue: try \
+                          (move %s) instead", expr_to_str(*arg_expr,
+                                                self.tcx.sess.intr())));
+                    }
                 }
             }
         }

--- a/src/rustc/middle/trans/alt.rs
+++ b/src/rustc/middle/trans/alt.rs
@@ -1202,7 +1202,7 @@ fn trans_alt_inner(scope_cx: block,
         arm_cxs.push(bcx);
     }
 
-    return controlflow::join_blocks(scope_cx, dvec::unwrap(arm_cxs));
+    return controlflow::join_blocks(scope_cx, dvec::unwrap(move arm_cxs));
 
     fn mk_fail(bcx: block, sp: span, msg: ~str,
                done: @mut Option<BasicBlockRef>) -> BasicBlockRef {

--- a/src/rustc/middle/trans/closure.rs
+++ b/src/rustc/middle/trans/closure.rs
@@ -244,7 +244,6 @@ fn store_environment(bcx: block,
 fn build_closure(bcx0: block,
                  cap_vars: ~[capture::capture_var],
                  ck: ty::closure_kind,
-                 id: ast::node_id,
                  include_ret_handle: Option<ValueRef>) -> closure_result {
     let _icx = bcx0.insn_ctxt("closure::build_closure");
     // If we need to, package up the iterator body to call
@@ -255,7 +254,7 @@ fn build_closure(bcx0: block,
     let mut env_vals = ~[];
     for vec::each(cap_vars) |cap_var| {
         debug!("Building closure: captured variable %?", *cap_var);
-        let datum = expr::trans_local_var(bcx, id, cap_var.def);
+        let datum = expr::trans_local_var(bcx, cap_var.def);
         match cap_var.mode {
             capture::cap_ref => {
                 assert ck == ty::ck_block;
@@ -370,7 +369,7 @@ fn trans_expr_fn(bcx: block,
         let cap_vars = capture::compute_capture_vars(ccx.tcx, id, proto,
                                                      cap_clause);
         let ret_handle = match is_loop_body { Some(x) => x, None => None };
-        let {llbox, cdata_ty, bcx} = build_closure(bcx, cap_vars, ck, id,
+        let {llbox, cdata_ty, bcx} = build_closure(bcx, cap_vars, ck,
                                                    ret_handle);
         trans_closure(ccx, sub_path, decl, body, llfn, no_self,
                       bcx.fcx.param_substs, id, |fcx| {

--- a/src/rustc/middle/trans/common.rs
+++ b/src/rustc/middle/trans/common.rs
@@ -511,7 +511,7 @@ fn block_(llbb: BasicBlockRef, parent: Option<block>, -kind: block_kind,
         terminated: false,
         unreachable: false,
         parent: parent,
-        kind: kind,
+        kind: move kind,
         is_lpad: is_lpad,
         node_info: node_info,
         fcx: fcx

--- a/src/rustc/middle/typeck/infer/combine.rs
+++ b/src/rustc/middle/typeck/infer/combine.rs
@@ -88,9 +88,9 @@ fn expected_found<C: combine,T>(
     self: &C, +a: T, +b: T) -> ty::expected_found<T> {
 
     if self.a_is_expected() {
-        ty::expected_found {expected: a, found: b}
+        ty::expected_found {expected: move a, found: move b}
     } else {
-        ty::expected_found {expected: b, found: a}
+        ty::expected_found {expected: move b, found: move a}
     }
 }
 

--- a/src/rustdoc/astsrv.rs
+++ b/src/rustdoc/astsrv.rs
@@ -57,14 +57,14 @@ fn from_file<T>(file: ~str, owner: SrvOwner<T>) -> T {
 fn run<T>(owner: SrvOwner<T>, source: ~str, +parse: Parser) -> T {
 
     let srv_ = Srv({
-        ch: do task::spawn_listener |po| {
+        ch: do task::spawn_listener |move parse, po| {
             act(po, source, parse);
         }
     });
 
     let res = owner(srv_);
     comm::send(srv_.ch, Exit);
-    return res;
+    move res
 }
 
 fn act(po: comm::Port<Msg>, source: ~str, parse: Parser) {
@@ -97,7 +97,7 @@ fn exec<T:Send>(
     let msg = HandleRequest(fn~(move f, ctxt: Ctxt) {
         comm::send(ch, f(ctxt))
     });
-    comm::send(srv.ch, msg);
+    comm::send(srv.ch, move msg);
     comm::recv(po)
 }
 

--- a/src/rustdoc/attr_pass.rs
+++ b/src/rustdoc/attr_pass.rs
@@ -93,7 +93,7 @@ fn parse_item_attrs<T:Send>(
     srv: astsrv::Srv,
     id: doc::AstId,
     +parse_attrs: fn~(~[ast::attribute]) -> T) -> T {
-    do astsrv::exec(srv) |ctxt| {
+    do astsrv::exec(srv) |move parse_attrs, ctxt| {
         let attrs = match ctxt.ast_map.get(id) {
           ast_map::node_item(item, _) => item.attrs,
           ast_map::node_foreign_item(item, _, _) => item.attrs,

--- a/src/rustdoc/fold.rs
+++ b/src/rustdoc/fold.rs
@@ -71,18 +71,18 @@ fn mk_fold<T:Copy>(
 ) -> Fold<T> {
     Fold({
         ctxt: ctxt,
-        fold_doc: fold_doc,
-        fold_crate: fold_crate,
-        fold_item: fold_item,
-        fold_mod: fold_mod,
-        fold_nmod: fold_nmod,
-        fold_fn: fold_fn,
-        fold_const: fold_const,
-        fold_enum: fold_enum,
-        fold_trait: fold_trait,
-        fold_impl: fold_impl,
-        fold_type: fold_type,
-        fold_struct: fold_struct,
+        fold_doc: move fold_doc,
+        fold_crate: move fold_crate,
+        fold_item: move fold_item,
+        fold_mod: move fold_mod,
+        fold_nmod: move fold_nmod,
+        fold_fn: move fold_fn,
+        fold_const: move fold_const,
+        fold_enum: move fold_enum,
+        fold_trait: move fold_trait,
+        fold_impl: move fold_impl,
+        fold_type: move fold_type,
+        fold_struct: move fold_struct
     })
 }
 

--- a/src/rustdoc/markdown_writer.rs
+++ b/src/rustdoc/markdown_writer.rs
@@ -146,7 +146,8 @@ fn readclose(fd: libc::c_int) -> ~str {
 }
 
 fn generic_writer(+process: fn~(markdown: ~str)) -> Writer {
-    let ch = do task::spawn_listener |po: comm::Port<WriteInstr>| {
+    let ch = do task::spawn_listener
+        |move process, po: comm::Port<WriteInstr>| {
         let mut markdown = ~"";
         let mut keep_going = true;
         while keep_going {
@@ -155,7 +156,7 @@ fn generic_writer(+process: fn~(markdown: ~str)) -> Writer {
               Done => keep_going = false
             }
         }
-        process(markdown);
+        process(move markdown);
     };
 
     fn~(+instr: WriteInstr) {
@@ -274,22 +275,22 @@ fn future_writer_factory(
         let writer_ch = comm::Chan(&writer_po);
         do task::spawn {
             let (writer, future) = future_writer();
-            comm::send(writer_ch, writer);
+            comm::send(writer_ch, move writer);
             let s = future::get(&future);
             comm::send(markdown_ch, (page, s));
         }
         comm::recv(writer_po)
     };
 
-    (writer_factory, markdown_po)
+    (move writer_factory, markdown_po)
 }
 
 fn future_writer() -> (Writer, future::Future<~str>) {
     let (chan, port) = pipes::stream();
-    let writer = fn~(+instr: WriteInstr) {
+    let writer = fn~(move chan, +instr: WriteInstr) {
         chan.send(copy instr);
     };
-    let future = do future::from_fn {
+    let future = do future::from_fn |move port| {
         let mut res = ~"";
         loop {
             match port.recv() {
@@ -299,5 +300,5 @@ fn future_writer() -> (Writer, future::Future<~str>) {
         }
         res
     };
-    (writer, future)
+    (move writer, move future)
 }

--- a/src/rustdoc/page_pass.rs
+++ b/src/rustdoc/page_pass.rs
@@ -46,7 +46,7 @@ fn make_doc_from_pages(page_port: PagePort) -> doc::Doc {
     loop {
         let val = comm::recv(page_port);
         if val.is_some() {
-            pages += ~[option::unwrap(val)];
+            pages += ~[option::unwrap(move val)];
         } else {
             break;
         }

--- a/src/rustdoc/rustdoc.rs
+++ b/src/rustdoc/rustdoc.rs
@@ -87,5 +87,5 @@ fn time<T>(what: ~str, f: fn() -> T) -> T {
     let rv = f();
     let end = std::time::precise_time_s();
     info!("time: %3.3f s    %s", end - start, what);
-    return rv;
+    move rv
 }

--- a/src/rustdoc/sort_pass.rs
+++ b/src/rustdoc/sort_pass.rs
@@ -10,7 +10,7 @@ type ItemLtEq = pure fn~(v1: &doc::ItemTag, v2:  &doc::ItemTag) -> bool;
 fn mk_pass(name: ~str, +lteq: ItemLtEq) -> Pass {
     {
         name: name,
-        f: fn~(srv: astsrv::Srv, doc: doc::Doc) -> doc::Doc {
+        f: fn~(move lteq, srv: astsrv::Srv, doc: doc::Doc) -> doc::Doc {
             run(srv, doc, lteq)
         }
     }

--- a/src/rustdoc/text_pass.rs
+++ b/src/rustdoc/text_pass.rs
@@ -7,7 +7,7 @@ export mk_pass;
 fn mk_pass(name: ~str, +op: fn~(~str) -> ~str) -> Pass {
     {
         name: name,
-        f: fn~(srv: astsrv::Srv, doc: doc::Doc) -> doc::Doc {
+        f: fn~(move op, srv: astsrv::Srv, doc: doc::Doc) -> doc::Doc {
             run(srv, doc, op)
         }
     }

--- a/src/test/auxiliary/cci_class_6.rs
+++ b/src/test/auxiliary/cci_class_6.rs
@@ -21,7 +21,7 @@ fn cat<U>(in_x : uint, in_y : int, -in_info: ~[U]) -> cat<U> {
     cat {
         meows: in_x,
         how_hungry: in_y,
-        info: in_info
+        info: move in_info
     }
 }
 

--- a/src/test/auxiliary/test_comm.rs
+++ b/src/test/auxiliary/test_comm.rs
@@ -7,7 +7,6 @@
 
 use libc::size_t;
 
-export port::{};
 export port;
 export recv;
 
@@ -65,13 +64,13 @@ fn recv<T: Send>(p: port<T>) -> T { recv_((**p).po) }
 
 /// Receive on a raw port pointer
 fn recv_<T: Send>(p: *rust_port) -> T {
-    let yield = 0u;
+    let yield = 0;
     let yieldp = ptr::addr_of(&yield);
     let mut res;
     res = rusti::init::<T>();
     rustrt::port_recv(ptr::addr_of(&res) as *uint, p, yieldp);
 
-    if yield != 0u {
+    if yield != 0 {
         // Data isn't available yet, so res has not been initialized.
         task::yield();
     } else {
@@ -79,7 +78,7 @@ fn recv_<T: Send>(p: *rust_port) -> T {
         // this is a good place to yield
         task::yield();
     }
-    return res;
+    move res
 }
 
 

--- a/src/test/bench/graph500-bfs.rs
+++ b/src/test/bench/graph500-bfs.rs
@@ -119,7 +119,7 @@ fn bfs(graph: graph, key: node_id) -> bfs_result {
     Q.add_back(key);
     marks[key] = key;
 
-    while Q.size() > 0u {
+    while Q.size() > 0 {
         let t = Q.pop_front();
 
         do graph[t].each() |k| {
@@ -131,7 +131,7 @@ fn bfs(graph: graph, key: node_id) -> bfs_result {
         };
     }
 
-    vec::from_mut(marks)
+    vec::from_mut(move marks)
 }
 
 /**
@@ -167,11 +167,11 @@ fn bfs2(graph: graph, key: node_id) -> bfs_result {
         }
     }
 
-    let mut i = 0u;
+    let mut i = 0;
     while vec::any(colors, is_gray) {
         // Do the BFS.
         log(info, fmt!("PBFS iteration %?", i));
-        i += 1u;
+        i += 1;
         colors = do colors.mapi() |i, c| {
             let c : color = *c;
             match c {
@@ -245,13 +245,13 @@ fn pbfs(&&graph: arc::ARC<graph>, key: node_id) -> bfs_result {
         i += 1;
         let old_len = colors.len();
 
-        let color = arc::ARC(colors);
+        let color = arc::ARC(move colors);
 
         let color_vec = arc::get(&color); // FIXME #3387 requires this temp
         colors = do par::mapi_factory(*color_vec) {
             let colors = arc::clone(&color);
             let graph = arc::clone(&graph);
-            fn~(+i: uint, +c: color) -> color {
+            fn~(move graph, move colors, +i: uint, +c: color) -> color {
                 let c : color = c;
                 let colors = arc::get(&colors);
                 let graph = arc::get(&graph);
@@ -388,7 +388,7 @@ fn main() {
     let args = os::args();
     let args = if os::getenv(~"RUST_BENCH").is_some() {
         ~[~"", ~"15", ~"48"]
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         ~[~"", ~"10", ~"16"]
     } else {
         args
@@ -400,21 +400,21 @@ fn main() {
     let do_sequential = true;
 
     let start = time::precise_time_s();
-    let edges = make_edges(scale, 16u);
+    let edges = make_edges(scale, 16);
     let stop = time::precise_time_s();
 
     io::stdout().write_line(fmt!("Generated %? edges in %? seconds.",
                                  vec::len(edges), stop - start));
 
     let start = time::precise_time_s();
-    let graph = make_graph(1u << scale, edges);
+    let graph = make_graph(1 << scale, edges);
     let stop = time::precise_time_s();
 
-    let mut total_edges = 0u;
+    let mut total_edges = 0;
     vec::each(graph, |edges| { total_edges += edges.len(); true });
 
     io::stdout().write_line(fmt!("Generated graph with %? edges in %? seconds.",
-                                 total_edges / 2u,
+                                 total_edges / 2,
                                  stop - start));
 
     let mut total_seq = 0.0;

--- a/src/test/bench/msgsend-pipes-shared.rs
+++ b/src/test/bench/msgsend-pipes-shared.rs
@@ -19,7 +19,7 @@ use io::WriterUtil;
 use pipes::{Port, Chan, SharedChan};
 
 macro_rules! move_out (
-    { $x:expr } => { unsafe { let y <- *ptr::addr_of(&($x)); y } }
+    { $x:expr } => { unsafe { let y <- *ptr::addr_of(&($x)); move y } }
 )
 
 enum request {
@@ -50,26 +50,26 @@ fn run(args: &[~str]) {
     let (to_parent, from_child) = pipes::stream();
     let (to_child, from_parent) = pipes::stream();
 
-    let to_child = SharedChan(to_child);
+    let to_child = SharedChan(move to_child);
 
     let size = uint::from_str(args[1]).get();
     let workers = uint::from_str(args[2]).get();
     let num_bytes = 100;
     let start = std::time::precise_time_s();
     let mut worker_results = ~[];
-    for uint::range(0u, workers) |i| {
+    for uint::range(0, workers) |_i| {
         let to_child = to_child.clone();
         do task::task().future_result(|+r| {
-            worker_results.push(r);
-        }).spawn {
-            for uint::range(0u, size / workers) |_i| {
+            worker_results.push(move r);
+        }).spawn |move to_child| {
+            for uint::range(0, size / workers) |_i| {
                 //error!("worker %?: sending %? bytes", i, num_bytes);
                 to_child.send(bytes(num_bytes));
             }
             //error!("worker %? exiting", i);
         };
     }
-    do task::spawn {
+    do task::spawn |move from_parent, move to_parent| {
         server(from_parent, to_parent);
     }
 

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -15,7 +15,7 @@ use io::WriterUtil;
 use pipes::{Port, PortSet, Chan};
 
 macro_rules! move_out (
-    { $x:expr } => { unsafe { let y <- *ptr::addr_of(&($x)); y } }
+    { $x:expr } => { unsafe { let y <- *ptr::addr_of(&($x)); move y } }
 )
 
 enum request {
@@ -46,27 +46,27 @@ fn run(args: &[~str]) {
     let (to_parent, from_child) = pipes::stream();
     let (to_child, from_parent_) = pipes::stream();
     let from_parent = PortSet();
-    from_parent.add(from_parent_);
+    from_parent.add(move from_parent_);
 
     let size = uint::from_str(args[1]).get();
     let workers = uint::from_str(args[2]).get();
     let num_bytes = 100;
     let start = std::time::precise_time_s();
     let mut worker_results = ~[];
-    for uint::range(0u, workers) |i| {
+    for uint::range(0, workers) |_i| {
         let (to_child, from_parent_) = pipes::stream();
-        from_parent.add(from_parent_);
+        from_parent.add(move from_parent_);
         do task::task().future_result(|+r| {
-            worker_results.push(r);
-        }).spawn {
-            for uint::range(0u, size / workers) |_i| {
+            worker_results.push(move r);
+        }).spawn |move to_child| {
+            for uint::range(0, size / workers) |_i| {
                 //error!("worker %?: sending %? bytes", i, num_bytes);
                 to_child.send(bytes(num_bytes));
             }
             //error!("worker %? exiting", i);
         };
     }
-    do task::spawn {
+    do task::spawn |move from_parent, move to_parent| {
         server(from_parent, to_parent);
     }
 

--- a/src/test/bench/msgsend-ring-rw-arcs.rs
+++ b/src/test/bench/msgsend-ring-rw-arcs.rs
@@ -33,7 +33,7 @@ fn recv(p: &pipe) -> uint {
 
 fn init() -> (pipe,pipe) {
     let x = arc::RWARC(~[]);
-    ((&x).clone(), x)
+    ((&x).clone(), move x)
 }
 
 
@@ -41,18 +41,18 @@ fn thread_ring(i: uint,
                count: uint,
                +num_chan: pipe,
                +num_port: pipe) {
-    let mut num_chan <- Some(num_chan);
-    let mut num_port <- Some(num_port);
+    let mut num_chan <- Some(move num_chan);
+    let mut num_port <- Some(move num_port);
     // Send/Receive lots of messages.
     for uint::range(0u, count) |j| {
         //error!("task %?, iter %?", i, j);
         let mut num_chan2 = option::swap_unwrap(&mut num_chan);
         let mut num_port2 = option::swap_unwrap(&mut num_port);
         send(&num_chan2, i * j);
-        num_chan = Some(num_chan2);
+        num_chan = Some(move num_chan2);
         let _n = recv(&num_port2);
         //log(error, _n);
-        num_port = Some(num_port2);
+        num_port = Some(move num_port2);
     };
 }
 
@@ -70,7 +70,7 @@ fn main() {
     let msg_per_task = uint::from_str(args[2]).get();
 
     let (num_chan, num_port) = init();
-    let mut num_chan = Some(num_chan);
+    let mut num_chan = Some(move num_chan);
 
     let start = time::precise_time_s();
 
@@ -82,7 +82,7 @@ fn main() {
         let (new_chan, num_port) = init();
         let num_chan2 = ~mut None;
         *num_chan2 <-> num_chan;
-        let num_port = ~mut Some(num_port);
+        let num_port = ~mut Some(move num_port);
         let new_future = do future::spawn
             |move num_chan2, move num_port| {
             let mut num_chan = None;
@@ -90,15 +90,15 @@ fn main() {
             let mut num_port1 = None;
             num_port1 <-> *num_port;
             thread_ring(i, msg_per_task,
-                        option::unwrap(num_chan),
-                        option::unwrap(num_port1))
+                        option::unwrap(move num_chan),
+                        option::unwrap(move num_port1))
         };
-        futures.push(new_future);
-        num_chan = Some(new_chan);
+        futures.push(move new_future);
+        num_chan = Some(move new_chan);
     };
 
     // do our iteration
-    thread_ring(0u, msg_per_task, option::unwrap(num_chan), num_port);
+    thread_ring(0, msg_per_task, option::unwrap(move num_chan), move num_port);
 
     // synchronize
     for futures.each |f| { future::get(f) };

--- a/src/test/bench/msgsend-ring.rs
+++ b/src/test/bench/msgsend-ring.rs
@@ -52,7 +52,7 @@ fn main() {
             get_chan_chan.send(Chan(&p));
             thread_ring(i, msg_per_task, num_chan,  p)
         };
-        futures.push(new_future);
+        futures.push(move new_future);
         
         num_chan = get_chan.recv();
     };

--- a/src/test/bench/msgsend.rs
+++ b/src/test/bench/msgsend.rs
@@ -35,12 +35,12 @@ fn run(args: ~[~str]) {
     let workers = uint::from_str(args[2]).get();
     let start = std::time::precise_time_s();
     let mut worker_results = ~[];
-    for uint::range(0u, workers) |_i| {
+    for uint::range(0, workers) |_i| {
         do task::task().future_result(|+r| {
-            worker_results.push(r);
+            worker_results.push(move r);
         }).spawn {
-            for uint::range(0u, size / workers) |_i| {
-                comm::send(to_child, bytes(100u));
+            for uint::range(0, size / workers) |_i| {
+                comm::send(to_child, bytes(100));
             }
         };
     }

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -124,7 +124,7 @@ fn make_sequence_processor(sz: uint, from_parent: pipes::Port<~[u8]>,
    };
 
    //comm::send(to_parent, fmt!("yay{%u}", sz));
-    to_parent.send(buffer);
+    to_parent.send(move buffer);
 }
 
 // given a FASTA file on stdin, process sequence THREE
@@ -143,25 +143,25 @@ fn main() {
 
 
    // initialize each sequence sorter
-   let sizes = ~[1u,2u,3u,4u,6u,12u,18u];
+   let sizes = ~[1,2,3,4,6,12,18];
     let streams = vec::map(sizes, |_sz| Some(stream()));
-    let streams = vec::to_mut(streams);
+    let streams = vec::to_mut(move streams);
     let mut from_child = ~[];
     let to_child   = vec::mapi(sizes, |ii, sz| {
         let sz = *sz;
         let mut stream = None;
         stream <-> streams[ii];
-        let (to_parent_, from_child_) = option::unwrap(stream);
+        let (to_parent_, from_child_) = option::unwrap(move stream);
 
-        from_child.push(from_child_);
+        from_child.push(move from_child_);
 
         let (to_child, from_parent) = pipes::stream();
 
-        do task::spawn_with(from_parent) |from_parent| {
+        do task::spawn_with(move from_parent) |move to_parent_, from_parent| {
             make_sequence_processor(sz, from_parent, to_parent_);
         };
         
-        to_child
+        move to_child
     });
          
    

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -34,15 +34,15 @@ fn fib(n: int) -> int {
         } else {
             let p = pipes::PortSet();
             let ch = p.chan();
-            task::spawn(|| pfib(ch, n - 1) );
+            task::spawn(|move ch| pfib(ch, n - 1) );
             let ch = p.chan();
-            task::spawn(|| pfib(ch, n - 2) );
+            task::spawn(|move ch| pfib(ch, n - 2) );
             c.send(p.recv() + p.recv());
         }
     }
 
     let (ch, p) = pipes::stream();
-    let t = task::spawn(|| pfib(ch, n) );
+    let _t = task::spawn(|move ch| pfib(ch, n) );
     p.recv()
 }
 
@@ -73,7 +73,7 @@ fn stress(num_tasks: int) {
     let mut results = ~[];
     for range(0, num_tasks) |i| {
         do task::task().future_result(|+r| {
-            results.push(r);
+            results.push(move r);
         }).spawn {
             stress_task(i);
         }
@@ -104,7 +104,7 @@ fn main() {
         let out = io::stdout();
 
         for range(1, max + 1) |n| {
-            for range(0, num_trials) |i| {
+            for range(0, num_trials) |_i| {
                 let start = time::precise_time_ns();
                 let fibn = fib(n);
                 let stop = time::precise_time_ns();

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -78,7 +78,8 @@ fn recurse_or_fail(depth: int, st: Option<st>) {
                 box: @Cons((), st.box),
                 unique: ~Cons((), @*st.unique),
                 fn_box: fn@() -> @nillist { @Cons((), fn_box()) },
-                fn_unique: fn~() -> ~nillist { ~Cons((), @*fn_unique()) },
+                fn_unique: fn~(move fn_unique) -> ~nillist
+                    { ~Cons((), @*fn_unique()) },
                 tuple: (@Cons((), st.tuple.first()),
                         ~Cons((), @*st.tuple.second())),
                 vec: st.vec + ~[@Cons((), st.vec.last())],
@@ -87,6 +88,6 @@ fn recurse_or_fail(depth: int, st: Option<st>) {
           }
         };
 
-        recurse_or_fail(depth, Some(st));
+        recurse_or_fail(depth, Some(move st));
     }
 }

--- a/src/test/bench/task-perf-jargon-metal-smoke.rs
+++ b/src/test/bench/task-perf-jargon-metal-smoke.rs
@@ -9,14 +9,14 @@ fn child_generation(gens_left: uint, -c: pipes::Chan<()>) {
     // This used to be O(n^2) in the number of generations that ever existed.
     // With this code, only as many generations are alive at a time as tasks
     // alive at a time,
-    let c = ~mut Some(c);
-    do task::spawn_supervised {
+    let c = ~mut Some(move c);
+    do task::spawn_supervised |move c| {
         let c = option::swap_unwrap(c);
         if gens_left & 1 == 1 {
             task::yield(); // shake things up a bit
         }
         if gens_left > 0 {
-            child_generation(gens_left - 1, c); // recurse
+            child_generation(gens_left - 1, move c); // recurse
         } else {
             c.send(())
         }
@@ -27,14 +27,14 @@ fn main() {
     let args = os::args();
     let args = if os::getenv(~"RUST_BENCH").is_some() {
         ~[~"", ~"100000"]
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         ~[~"", ~"100"]
     } else {
         copy args
     };
 
     let (c,p) = pipes::stream();
-    child_generation(uint::from_str(args[1]).get(), c);
+    child_generation(uint::from_str(args[1]).get(), move c);
     if p.try_recv().is_none() {
         fail ~"it happened when we slumbered";
     }

--- a/src/test/bench/task-perf-linked-failure.rs
+++ b/src/test/bench/task-perf-linked-failure.rs
@@ -31,9 +31,9 @@ fn grandchild_group(num_tasks: uint) {
 
 fn spawn_supervised_blocking(myname: &str, +f: fn~()) {
     let mut res = None;
-    task::task().future_result(|+r| res = Some(r)).supervised().spawn(f);
+    task::task().future_result(|+r| res = Some(move r)).supervised().spawn(move f);
     error!("%s group waiting", myname);
-    let x = future::get(&option::unwrap(res));
+    let x = future::get(&option::unwrap(move res));
     assert x == task::Success;
 }
 

--- a/src/test/compile-fail/borrowck-loan-blocks-move.rs
+++ b/src/test/compile-fail/borrowck-loan-blocks-move.rs
@@ -4,7 +4,7 @@ fn take(-_v: ~int) {
 fn box_imm() {
     let v = ~3;
     let _w = &v; //~ NOTE loan of immutable local variable granted here
-    take(v); //~ ERROR moving out of immutable local variable prohibited due to outstanding loan
+    take(move v); //~ ERROR moving out of immutable local variable prohibited due to outstanding loan
 }
 
 fn main() {

--- a/src/test/compile-fail/copy-into-closure.rs
+++ b/src/test/compile-fail/copy-into-closure.rs
@@ -4,7 +4,7 @@ fn closure1(+x: ~str) -> (~str, fn@() -> ~str) {
         //~^ WARNING implicitly copying a non-implicitly-copyable value
         //~^^ NOTE to copy values into a @fn closure, use a capture clause
     };
-    (x,f)
+    (move x,f)
 }
 
 fn closure2(+x: util::NonCopyable) -> (util::NonCopyable,
@@ -15,7 +15,7 @@ fn closure2(+x: util::NonCopyable) -> (util::NonCopyable,
         //~^^ NOTE non-copyable value cannot be copied into a @fn closure
         //~^^^ ERROR copying a noncopyable value
     };
-    (x,f)
+    (move x,f)
 }
 fn closure3(+x: util::NonCopyable) {
     do task::spawn {

--- a/src/test/compile-fail/functional-struct-update.rs
+++ b/src/test/compile-fail/functional-struct-update.rs
@@ -1,0 +1,16 @@
+struct Bar {
+    x: int,
+    drop { io::println("Goodbye, cruel world"); }
+}
+
+struct Foo {
+    x: int,
+    y: Bar
+}
+
+fn main() {
+    let a = Foo { x: 1, y: Bar { x: 5 } };
+    let c = Foo { x: 4, .. a}; //~ ERROR copying a noncopyable value
+    io::println(fmt!("%?", c));
+}
+

--- a/src/test/compile-fail/issue-1965.rs
+++ b/src/test/compile-fail/issue-1965.rs
@@ -2,6 +2,6 @@
 fn test(-x: uint) {}
 
 fn main() {
-    let i = 3u;
-    for uint::range(0u, 10u) |_x| {test(i)}
+    let i = 3;
+    for uint::range(0, 10) |_x| {test(move i)}
 }

--- a/src/test/compile-fail/issue-2548.rs
+++ b/src/test/compile-fail/issue-2548.rs
@@ -21,7 +21,7 @@ fn main() {
         let mut res = foo(x);
         
         let mut v = ~[mut];
-        v <- ~[mut res] + v; //~ ERROR instantiating a type parameter with an incompatible type (needs `copy`, got `owned`, missing `copy`)
+        v <- ~[mut (move res)] + v; //~ ERROR instantiating a type parameter with an incompatible type (needs `copy`, got `owned`, missing `copy`)
         assert (v.len() == 2);
     }
 

--- a/src/test/compile-fail/liveness-move-from-args.rs
+++ b/src/test/compile-fail/liveness-move-from-args.rs
@@ -1,19 +1,19 @@
 fn take(-_x: int) { }
 
 fn from_by_value_arg(++x: int) {
-    take(x);  //~ ERROR illegal move from argument `x`, which is not copy or move mode
+    take(move x);  //~ ERROR illegal move from argument `x`, which is not copy or move mode
 }
 
 fn from_by_ref_arg(&&x: int) {
-    take(x);  //~ ERROR illegal move from argument `x`, which is not copy or move mode
+    take(move x);  //~ ERROR illegal move from argument `x`, which is not copy or move mode
 }
 
 fn from_copy_arg(+x: int) {
-    take(x);
+    take(move x);
 }
 
 fn from_move_arg(-x: int) {
-    take(x);
+    take(move x);
 }
 
 fn main() {

--- a/src/test/compile-fail/liveness-move-from-mode.rs
+++ b/src/test/compile-fail/liveness-move-from-mode.rs
@@ -4,7 +4,7 @@ fn main() {
 
     let x: int = 25;
     loop {
-        take(x); //~ ERROR use of moved variable: `x`
+        take(move x); //~ ERROR use of moved variable: `x`
         //~^ NOTE move of variable occurred here
     }
 }

--- a/src/test/compile-fail/liveness-unused.rs
+++ b/src/test/compile-fail/liveness-unused.rs
@@ -54,5 +54,5 @@ struct r {
 }
 fn main() {
     let x = r { x: () };
-    fn@() { copy x; }; //~ ERROR copying a noncopyable value
+    fn@(move x) { copy x; }; //~ ERROR copying a noncopyable value
 }

--- a/src/test/compile-fail/liveness-use-after-send.rs
+++ b/src/test/compile-fail/liveness-use-after-send.rs
@@ -9,7 +9,7 @@ enum _chan<T> = int;
 // Tests that "log(debug, message);" is flagged as using
 // message after the send deinitializes it
 fn test00_start(ch: _chan<int>, message: int, _count: int) {
-    send(ch, message); //~ NOTE move of variable occurred here
+    send(ch, move message); //~ NOTE move of variable occurred here
     log(debug, message); //~ ERROR use of moved variable: `message`
 }
 

--- a/src/test/compile-fail/unique-unique-kind.rs
+++ b/src/test/compile-fail/unique-unique-kind.rs
@@ -3,5 +3,5 @@ fn f<T: Send>(_i: T) {
 
 fn main() {
     let i = ~@100;
-    f(i); //~ ERROR missing `send`
+    f(move i); //~ ERROR missing `send`
 }

--- a/src/test/compile-fail/unsendable-class.rs
+++ b/src/test/compile-fail/unsendable-class.rs
@@ -17,5 +17,5 @@ fn main() {
   let cat = ~"kitty";
   let po = comm::Port();         //~ ERROR missing `send`
   let ch = comm::Chan(&po);       //~ ERROR missing `send`
-  comm::send(ch, foo(42, @cat)); //~ ERROR missing `send`
+  comm::send(ch, foo(42, @(move cat))); //~ ERROR missing `send`
 }

--- a/src/test/run-fail/port-type.rs
+++ b/src/test/run-fail/port-type.rs
@@ -12,7 +12,7 @@ fn echo<T: Send>(c: Chan<T>, oc: Chan<Chan<T>>) {
     send(oc, Chan(&p));
 
     let x = recv(p);
-    send(c, x);
+    send(c, move x);
 }
 
 fn main() { fail ~"meep"; }

--- a/src/test/run-fail/unwind-box-res.rs
+++ b/src/test/run-fail/unwind-box-res.rs
@@ -20,7 +20,7 @@ fn r(v: *int) -> r {
 fn main() unsafe {
     let i1 = ~0;
     let i1p = cast::reinterpret_cast(&i1);
-    cast::forget(i1);
+    cast::forget(move i1);
     let x = @r(i1p);
     failfn();
     log(error, x);

--- a/src/test/run-fail/unwind-move.rs
+++ b/src/test/run-fail/unwind-move.rs
@@ -1,9 +1,9 @@
 // error-pattern:fail
-fn f(-a: @int) {
+fn f(-_a: @int) {
     fail;
 }
 
 fn main() {
     let a = @0;
-    f(a);
+    f(move a);
 }

--- a/src/test/run-pass/argument-passing.rs
+++ b/src/test/run-pass/argument-passing.rs
@@ -12,7 +12,7 @@ fn f2(a: int, f: fn(int)) -> int { f(1); return a; }
 
 fn main() {
     let mut a = {mut x: 1}, b = 2, c = 3;
-    assert (f1(a, &mut b, c) == 6);
+    assert (f1(a, &mut b, move c) == 6);
     assert (a.x == 0);
     assert (b == 10);
     assert (f2(a.x, |x| a.x = 50 ) == 0);

--- a/src/test/run-pass/auto-ref-sliceable.rs
+++ b/src/test/run-pass/auto-ref-sliceable.rs
@@ -4,7 +4,7 @@ trait Pushable<T> {
 
 impl<T> ~[T]: Pushable<T> {
     fn push_val(&mut self, +t: T) {
-        self.push(t);
+        self.push(move t);
     }
 }
 

--- a/src/test/run-pass/fn-bare-spawn.rs
+++ b/src/test/run-pass/fn-bare-spawn.rs
@@ -1,7 +1,7 @@
 // This is what the signature to spawn should look like with bare functions
 
 fn spawn<T: Send>(val: T, f: extern fn(T)) {
-    f(val);
+    f(move val);
 }
 
 fn f(+i: int) {

--- a/src/test/run-pass/functional-struct-update.rs
+++ b/src/test/run-pass/functional-struct-update.rs
@@ -5,7 +5,7 @@ struct Foo {
 
 fn main() {
     let a = Foo { x: 1, y: 2 };
-    let c = Foo { x: 4, .. a };
+    let c = Foo { x: 4, .. a};
     io::println(fmt!("%?", c));
 }
 

--- a/src/test/run-pass/intrinsic-move-val.rs
+++ b/src/test/run-pass/intrinsic-move-val.rs
@@ -8,6 +8,6 @@ extern mod rusti {
 fn main() {
     let mut x = @1;
     let mut y = @2;
-    rusti::move_val(&mut y, x);
+    rusti::move_val(&mut y, move x);
     assert *y == 1;
 }

--- a/src/test/run-pass/issue-2185.rs
+++ b/src/test/run-pass/issue-2185.rs
@@ -28,7 +28,7 @@ fn foldl<A,B,IA:iterable<A>>(self: IA, +b0: B, blk: fn(B, A) -> B) -> B {
     do self.iter |a| {
         b <- blk(b, a);
     }
-    return b;
+    move b
 }
 
 fn range(lo: uint, hi: uint, it: fn(uint)) {

--- a/src/test/run-pass/issue-2834.rs
+++ b/src/test/run-pass/issue-2834.rs
@@ -9,7 +9,7 @@ proto! streamp (
 
 fn rendezvous() {
     let (c, s) = streamp::init();
-    let streams: ~[streamp::client::open<int>] = ~[c];
+    let streams: ~[streamp::client::open<int>] = ~[move c];
 
     error!("%?", streams[0]);
 }

--- a/src/test/run-pass/issue-2904.rs
+++ b/src/test/run-pass/issue-2904.rs
@@ -48,7 +48,7 @@ fn square_from_char(c: char) -> square {
 }
 
 fn read_board_grid<rdr: Owned io::Reader>(+in: rdr) -> ~[~[square]] {
-    let in = in as io::Reader;
+    let in = (move in) as io::Reader;
     let mut grid = ~[];
     for in.each_line |line| {
         let mut row = ~[];

--- a/src/test/run-pass/issue-2930.rs
+++ b/src/test/run-pass/issue-2930.rs
@@ -7,5 +7,5 @@ proto! stream (
 fn main() {
     let (bc, _bp) = stream::init();
 
-    stream::client::send(bc, ~"abc");
+    stream::client::send(move bc, ~"abc");
 }

--- a/src/test/run-pass/issue-3168.rs
+++ b/src/test/run-pass/issue-3168.rs
@@ -2,15 +2,15 @@
 
 fn main() {
     let (c,p) = pipes::stream();
-    do task::try {
+    do task::try |move c| {
         let (c2,p2) = pipes::stream();
-        do task::spawn {
+        do task::spawn |move p2| {
             p2.recv();
-            error!("brother fails");
+            error!("sibling fails");
             fail;
         }   
         let (c3,p3) = pipes::stream();
-        c.send(c3);
+        c.send(move c3);
         c2.send(());
         error!("child blocks");
         p3.recv();

--- a/src/test/run-pass/issue-3176.rs
+++ b/src/test/run-pass/issue-3176.rs
@@ -4,19 +4,19 @@ use pipes::{Select2, Selectable};
 
 fn main() {
     let (c,p) = pipes::stream();
-    do task::try {
+    do task::try |move c| {
         let (c2,p2) = pipes::stream();
-        do task::spawn {
+        do task::spawn |move p2| {
             p2.recv();
-            error!("brother fails");
+            error!("sibling fails");
             fail;
         }   
         let (c3,p3) = pipes::stream();
-        c.send(c3);
+        c.send(move c3);
         c2.send(());
         error!("child blocks");
         let (c, p) = pipes::stream();
-        (p, p3).select();
+        (move p, move p3).select();
         c.send(());
     };  
     error!("parent tries");

--- a/src/test/run-pass/issue-3668.rs
+++ b/src/test/run-pass/issue-3668.rs
@@ -1,3 +1,4 @@
+// xfail-test
 struct P { child: Option<@mut P> }
 trait PTrait {
    fn getChildOption() -> Option<@P>;

--- a/src/test/run-pass/issue-3668.rs
+++ b/src/test/run-pass/issue-3668.rs
@@ -1,0 +1,13 @@
+struct P { child: Option<@mut P> }
+trait PTrait {
+   fn getChildOption() -> Option<@P>;
+}
+
+impl P: PTrait {
+   fn getChildOption() -> Option<@P> {
+       const childVal: @P = self.child.get();
+       fail;
+   }
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-3688-2.rs
+++ b/src/test/run-pass/issue-3688-2.rs
@@ -1,5 +1,6 @@
-   fn f(x:int) {
-       const child: int = x + 1;
-   }
+// xfail-test
+fn f(x:int) {
+    const child: int = x + 1;
+}
 
 fn main() {}

--- a/src/test/run-pass/issue-3688-2.rs
+++ b/src/test/run-pass/issue-3688-2.rs
@@ -1,0 +1,5 @@
+   fn f(x:int) {
+       const child: int = x + 1;
+   }
+
+fn main() {}

--- a/src/test/run-pass/last-use-corner-cases.rs
+++ b/src/test/run-pass/last-use-corner-cases.rs
@@ -5,7 +5,7 @@ fn main() {
     // Make sure closing over can be a last use
     let q = ~10;
     let addr = ptr::addr_of(&(*q));
-    let f = fn@() -> *int { ptr::addr_of(&(*q)) };
+    let f = fn@(move q) -> *int { ptr::addr_of(&(*q)) };
     assert addr == f();
 
     // But only when it really is the last use

--- a/src/test/run-pass/last-use-in-block.rs
+++ b/src/test/run-pass/last-use-in-block.rs
@@ -3,14 +3,14 @@
 fn lp<T>(s: ~str, f: fn(~str) -> T) -> T {
     while false {
         let r = f(s);
-        return r;
+        return (move r);
     }
     fail;
 }
 
 fn apply<T>(s: ~str, f: fn(~str) -> T) -> T {
     fn g<T>(s: ~str, f: fn(~str) -> T) -> T {f(s)}
-    g(s, |v| { let r = f(v); r })
+    g(s, |v| { let r = f(v); move r })
 }
 
 fn main() {}

--- a/src/test/run-pass/liveness-move-in-loop.rs
+++ b/src/test/run-pass/liveness-move-in-loop.rs
@@ -5,7 +5,7 @@ fn the_loop() {
     loop {
         let x = 5;
         if x > 3 {
-            list += ~[take(x)];
+            list += ~[take(move x)];
         } else {
             break;
         }

--- a/src/test/run-pass/log-linearized.rs
+++ b/src/test/run-pass/log-linearized.rs
@@ -9,7 +9,7 @@ type smallintmap<T> = @{mut v: ~[mut option<T>]};
 
 fn mk<T>() -> smallintmap<T> {
     let v: ~[mut option<T>] = ~[mut];
-    return @{mut v: v};
+    return @{mut v: move v};
 }
 
 fn f<T,U>() {

--- a/src/test/run-pass/monomorphized-callees-with-ty-params-3314.rs
+++ b/src/test/run-pass/monomorphized-callees-with-ty-params-3314.rs
@@ -15,7 +15,7 @@ struct F<A> { a: A }
 
 impl<A: Copy Serializable> F<A>: Serializable {
     fn serialize<S: Serializer>(s: S) {
-        self.a.serialize(s);
+        self.a.serialize(move s);
     }
 }
 

--- a/src/test/run-pass/move-arg-2-unique.rs
+++ b/src/test/run-pass/move-arg-2-unique.rs
@@ -3,7 +3,7 @@ fn test(-foo: ~~[int]) { assert (foo[0] == 10); }
 fn main() {
     let x = ~~[10];
     // Test forgetting a local by move-in
-    test(x);
+    test(move x);
 
     // Test forgetting a temporary by move-in.
     test(~~[10]);

--- a/src/test/run-pass/move-arg-2.rs
+++ b/src/test/run-pass/move-arg-2.rs
@@ -3,7 +3,7 @@ fn test(-foo: @~[int]) { assert (foo[0] == 10); }
 fn main() {
     let x = @~[10];
     // Test forgetting a local by move-in
-    test(x);
+    test(move x);
 
     // Test forgetting a temporary by move-in.
     test(@~[10]);

--- a/src/test/run-pass/move-arg.rs
+++ b/src/test/run-pass/move-arg.rs
@@ -1,3 +1,3 @@
 fn test(-foo: int) { assert (foo == 10); }
 
-fn main() { let x = 10; test(x); }
+fn main() { let x = 10; test(move x); }

--- a/src/test/run-pass/move-nullary-fn.rs
+++ b/src/test/run-pass/move-nullary-fn.rs
@@ -2,7 +2,7 @@
 fn f2(-thing: fn@()) { }
 
 fn f(-thing: fn@()) {
-    f2(thing);
+    f2(move thing);
 }
 
 fn main() {

--- a/src/test/run-pass/non-legacy-modes.rs
+++ b/src/test/run-pass/non-legacy-modes.rs
@@ -3,7 +3,7 @@ struct X {
 }
 
 fn apply<T>(x: T, f: fn(T)) {
-    f(x);
+    f(move x);
 }
 
 fn check_int(x: int) {

--- a/src/test/run-pass/option-unwrap.rs
+++ b/src/test/run-pass/option-unwrap.rs
@@ -9,7 +9,7 @@ struct dtor {
 
 fn unwrap<T>(+o: Option<T>) -> T {
     match move o {
-      Some(move v) => v,
+      Some(move v) => move v,
       None => fail
     }
 }
@@ -19,7 +19,7 @@ fn main() {
 
     {
         let b = Some(dtor { x:x });
-        let c = unwrap(b);
+        let c = unwrap(move b);
     }
 
     assert *x == 0;

--- a/src/test/run-pass/pipe-detect-term.rs
+++ b/src/test/run-pass/pipe-detect-term.rs
@@ -19,7 +19,7 @@ fn main() {
     let iotask = uv::global_loop::get();
     
     pipes::spawn_service(oneshot::init, |p| { 
-        match try_recv(p) {
+        match try_recv(move p) {
           Some(*) => { fail }
           None => { }
         }
@@ -34,11 +34,11 @@ fn main() {
 fn failtest() {
     let (c, p) = oneshot::init();
 
-    do task::spawn_with(c) |_c| { 
+    do task::spawn_with(move c) |_c| { 
         fail;
     }
 
-    error!("%?", recv(p));
+    error!("%?", recv(move p));
     // make sure we get killed if we missed it in the receive.
     loop { task::yield() }
 }

--- a/src/test/run-pass/pipe-peek.rs
+++ b/src/test/run-pass/pipe-peek.rs
@@ -15,7 +15,7 @@ fn main() {
 
     assert !pipes::peek(&p);
 
-    oneshot::client::signal(c);
+    oneshot::client::signal(move c);
 
     assert pipes::peek(&p);
 }

--- a/src/test/run-pass/pipe-pingpong-proto.rs
+++ b/src/test/run-pass/pipe-pingpong-proto.rs
@@ -20,35 +20,35 @@ mod test {
     fn client(-chan: pingpong::client::ping) {
         use pingpong::client;
 
-        let chan = client::ping(chan);
+        let chan = client::ping(move chan);
         log(error, ~"Sent ping");
-        let pong(_chan) = recv(chan);
+        let pong(_chan) = recv(move chan);
         log(error, ~"Received pong");
     }
     
     fn server(-chan: pingpong::server::ping) {
         use pingpong::server;
 
-        let ping(chan) = recv(chan);
+        let ping(chan) = recv(move chan);
         log(error, ~"Received ping");
-        let _chan = server::pong(chan);
+        let _chan = server::pong(move chan);
         log(error, ~"Sent pong");
     }
 }
 
 fn main() {
     let (client_, server_) = pingpong::init();
-    let client_ = ~mut Some(client_);
-    let server_ = ~mut Some(server_);
+    let client_ = ~mut Some(move client_);
+    let server_ = ~mut Some(move server_);
 
     do task::spawn |move client_| {
         let mut client__ = None;
         *client_ <-> client__;
-        test::client(option::unwrap(client__));
+        test::client(option::unwrap(move client__));
     };
     do task::spawn |move server_| {
         let mut server_ˊ = None;
         *server_ <-> server_ˊ;
-        test::server(option::unwrap(server_ˊ));
+        test::server(option::unwrap(move server_ˊ));
     };
 }

--- a/src/test/run-pass/pipe-presentation-examples.rs
+++ b/src/test/run-pass/pipe-presentation-examples.rs
@@ -22,10 +22,10 @@ macro_rules! select_if (
         ], )*
     } => {
         if $index == $count {
-            match move pipes::try_recv($port) {
+            match move pipes::try_recv(move $port) {
               $(Some($message($($(move $x,)+)* move next)) => {
-                let $next = next;
-                $e
+                let $next = move next;
+                move $e
               })+
               _ => fail
             }
@@ -90,33 +90,33 @@ fn render(_buffer: &Buffer) {
 }
 
 fn draw_frame(+channel: double_buffer::client::acquire) {
-    let channel = request(channel);
+    let channel = request(move channel);
     select! (
         channel => {
             give_buffer(buffer) -> channel {
                 render(&buffer);
-                release(channel, move buffer)
+                release(move channel, move buffer)
             }
         }
     );
 }
 
 fn draw_two_frames(+channel: double_buffer::client::acquire) {
-    let channel = request(channel);
+    let channel = request(move channel);
     let channel = select! (
         channel => {
             give_buffer(buffer) -> channel {
                 render(&buffer);
-                release(channel, move buffer)
+                release(move channel, move buffer)
             }
         }
     );
-    let channel = request(channel);
+    let channel = request(move channel);
     select! (
         channel => {
             give_buffer(buffer) -> channel {
                 render(&buffer);
-                release(channel, move buffer)
+                release(move channel, move buffer)
             }
         }
     );

--- a/src/test/run-pass/pipe-select-macro.rs
+++ b/src/test/run-pass/pipe-select-macro.rs
@@ -1,3 +1,5 @@
+// tjc: un-xfail after snapshot
+// xfail-test
 // xfail-pretty
 
 // Protocols

--- a/src/test/run-pass/pipe-select.rs
+++ b/src/test/run-pass/pipe-select.rs
@@ -27,24 +27,24 @@ fn main() {
     
     let c = pipes::spawn_service(stream::init, |p| { 
         error!("waiting for pipes");
-        let stream::send(x, p) = recv(p);
+        let stream::send(x, p) = recv(move p);
         error!("got pipes");
         let (left, right) : (oneshot::server::waiting,
                              oneshot::server::waiting)
-            = x;
+            = move x;
         error!("selecting");
-        let (i, _, _) = select(~[left, right]);
+        let (i, _, _) = select(~[move left, move right]);
         error!("selected");
         assert i == 0;
 
         error!("waiting for pipes");
-        let stream::send(x, _) = recv(p);
+        let stream::send(x, _) = recv(move p);
         error!("got pipes");
         let (left, right) : (oneshot::server::waiting,
                              oneshot::server::waiting)
-            = x;
+            = move x;
         error!("selecting");
-        let (i, m, _) = select(~[left, right]);
+        let (i, m, _) = select(~[move left, move right]);
         error!("selected %?", i);
         if m.is_some() {
             assert i == 1;
@@ -54,20 +54,20 @@ fn main() {
     let (c1, p1) = oneshot::init();
     let (_c2, p2) = oneshot::init();
 
-    let c = send(c, (p1, p2));
+    let c = send(move c, (move p1, move p2));
     
     sleep(iotask, 100);
 
-    signal(c1);
+    signal(move c1);
 
     let (_c1, p1) = oneshot::init();
     let (c2, p2) = oneshot::init();
 
-    send(c, (p1, p2));
+    send(move c, (move p1, move p2));
 
     sleep(iotask, 100);
 
-    signal(c2);
+    signal(move c2);
 
     test_select2();
 }
@@ -76,26 +76,26 @@ fn test_select2() {
     let (ac, ap) = stream::init();
     let (bc, bp) = stream::init();
 
-    stream::client::send(ac, 42);
+    stream::client::send(move ac, 42);
 
-    match pipes::select2(ap, bp) {
+    match pipes::select2(move ap, move bp) {
       either::Left(*) => { }
       either::Right(*) => { fail }
     }
 
-    stream::client::send(bc, ~"abc");
+    stream::client::send(move bc, ~"abc");
 
     error!("done with first select2");
 
     let (ac, ap) = stream::init();
     let (bc, bp) = stream::init();
 
-    stream::client::send(bc, ~"abc");
+    stream::client::send(move bc, ~"abc");
 
-    match pipes::select2(ap, bp) {
+    match pipes::select2(move ap, move bp) {
       either::Left(*) => { fail }
       either::Right(*) => { }
     }
 
-    stream::client::send(ac, 42);
+    stream::client::send(move ac, 42);
 }

--- a/src/test/run-pass/pipe-sleep.rs
+++ b/src/test/run-pass/pipe-sleep.rs
@@ -14,10 +14,10 @@ proto! oneshot (
 fn main() {
     use oneshot::client::*;
 
-    let c = pipes::spawn_service(oneshot::init, |p| { recv(p); });
+    let c = pipes::spawn_service(oneshot::init, |p| { recv(move p); });
 
     let iotask = uv::global_loop::get();
     sleep(iotask, 500);
     
-    signal(c);
+    signal(move c);
 }

--- a/src/test/run-pass/regions-copy-closure.rs
+++ b/src/test/run-pass/regions-copy-closure.rs
@@ -2,8 +2,8 @@ struct closure_box {
     cl: &fn(),
 }
 
-fn box_it(x: &r/fn()) -> closure_box/&r {
-    closure_box {cl: x}
+fn box_it(+x: &r/fn()) -> closure_box/&r {
+    closure_box {cl: move x}
 }
 
 fn main() {

--- a/src/test/run-pass/regions-static-closure.rs
+++ b/src/test/run-pass/regions-static-closure.rs
@@ -2,8 +2,8 @@ struct closure_box {
     cl: &fn(),
 }
 
-fn box_it(x: &r/fn()) -> closure_box/&r {
-    closure_box {cl: x}
+fn box_it(+x: &r/fn()) -> closure_box/&r {
+    closure_box {cl: move x}
 }
 
 fn call_static_closure(cl: closure_box/&static) {
@@ -12,5 +12,5 @@ fn call_static_closure(cl: closure_box/&static) {
 
 fn main() {
     let cl_box = box_it(|| debug!("Hello, world!"));
-    call_static_closure(cl_box);
+    call_static_closure(move cl_box);
 }

--- a/src/test/run-pass/resource-assign-is-not-copy.rs
+++ b/src/test/run-pass/resource-assign-is-not-copy.rs
@@ -14,8 +14,8 @@ fn main() {
     // Even though these look like copies, they are guaranteed not to be
     {
         let a = r(i);
-        let b = (a, 10);
-        let (c, _d) = b;
+        let b = (move a, 10);
+        let (c, _d) = move b;
         log(debug, c);
     }
     assert *i == 1;

--- a/src/test/run-pass/resource-cycle.rs
+++ b/src/test/run-pass/resource-cycle.rs
@@ -24,10 +24,10 @@ enum t = {
 fn main() unsafe {
     let i1 = ~0;
     let i1p = cast::reinterpret_cast(&i1);
-    cast::forget(i1);
+    cast::forget(move i1);
     let i2 = ~0;
     let i2p = cast::reinterpret_cast(&i2);
-    cast::forget(i2);
+    cast::forget(move i2);
 
     let x1 = @t({
         mut next: None,
@@ -35,7 +35,7 @@ fn main() unsafe {
           let rs = r(i1p);
           debug!("r = %x",
                  cast::reinterpret_cast::<*r, uint>(&ptr::addr_of(&rs)));
-          rs }
+          move rs }
     });
     
     debug!("x1 = %x, x1.r = %x",
@@ -48,7 +48,7 @@ fn main() unsafe {
           let rs = r(i2p);
           debug!("r2 = %x",
                  cast::reinterpret_cast::<*r, uint>(&ptr::addr_of(&rs)));
-          rs
+          move rs
             }
     });
     

--- a/src/test/run-pass/resource-cycle2.rs
+++ b/src/test/run-pass/resource-cycle2.rs
@@ -27,10 +27,10 @@ enum t = {
 fn main() unsafe {
     let i1 = ~0xA;
     let i1p = cast::reinterpret_cast(&i1);
-    cast::forget(i1);
+    cast::forget(move i1);
     let i2 = ~0xA;
     let i2p = cast::reinterpret_cast(&i2);
-    cast::forget(i2);
+    cast::forget(move i2);
 
     let u1 = {a: 0xB, b: 0xC, c: i1p};
     let u2 = {a: 0xB, b: 0xC, c: i2p};

--- a/src/test/run-pass/resource-cycle3.rs
+++ b/src/test/run-pass/resource-cycle3.rs
@@ -34,10 +34,10 @@ enum t = {
 fn main() unsafe {
     let i1 = ~0xA;
     let i1p = cast::reinterpret_cast(&i1);
-    cast::forget(i1);
+    cast::forget(move i1);
     let i2 = ~0xA;
     let i2p = cast::reinterpret_cast(&i2);
-    cast::forget(i2);
+    cast::forget(move i2);
 
     let u1 = {a: 0xB, b: 0xC, c: i1p};
     let u2 = {a: 0xB, b: 0xC, c: i2p};

--- a/src/test/run-pass/rt-sched-1.rs
+++ b/src/test/run-pass/rt-sched-1.rs
@@ -35,6 +35,6 @@ fn main() unsafe {
     };
     let fptr = cast::reinterpret_cast(&ptr::addr_of(&f));
     rustrt::start_task(new_task_id, fptr);
-    cast::forget(f);
+    cast::forget(move f);
     comm::recv(po);
 }

--- a/src/test/run-pass/select-macro.rs
+++ b/src/test/run-pass/select-macro.rs
@@ -17,18 +17,18 @@ macro_rules! select_if (
         $count:expr,
         $port:path => [
             $(type_this $message:path$(($(x $x: ident),+))dont_type_this*
-              -> $next:ident => { $e:expr }),+
+              -> $next:ident => { move $e:expr }),+
         ]
         $(, $ports:path => [
             $(type_this $messages:path$(($(x $xs: ident),+))dont_type_this*
-              -> $nexts:ident => { $es:expr }),+
+              -> $nexts:ident => { move $es:expr }),+
         ] )*
     } => {
         if $index == $count {
             match move pipes::try_recv($port) {
               $(Some($message($($(move $x,)+)* move next)) => {
-                let $next = next;
-                $e
+                let $next = move next;
+                move $e
               })+
               _ => fail
             }
@@ -38,7 +38,7 @@ macro_rules! select_if (
                 $count + 1
                 $(, $ports => [
                     $(type_this $messages$(($(x $xs),+))dont_type_this*
-                      -> $nexts => { $es }),+
+                      -> $nexts => { move $es }),+
                 ])*
             )
         }
@@ -54,7 +54,7 @@ macro_rules! select (
     } => {
         let index = pipes::selecti([$(($port).header()),+]/_);
         select_if!(index, 0 $(, $port => [
-            $(type_this $message$(($(x $x),+))dont_type_this* -> $next => { $e }),+
+            $(type_this $message$(($(x $x),+))dont_type_this* -> $next => { move $e }),+
         ])+)
     }
 )

--- a/src/test/run-pass/static-method-test.rs
+++ b/src/test/run-pass/static-method-test.rs
@@ -13,13 +13,13 @@ fn andand<T: bool_like Copy>(x1: T, x2: T) -> T {
 
 impl bool: bool_like {
     static fn select<A>(&&b: bool, +x1: A, +x2: A) -> A {
-        if b { x1 } else { x2 }
+        if b { move x1 } else { move x2 }
     }
 }
 
 impl int: bool_like {
     static fn select<A>(&&b: int, +x1: A, +x2: A) -> A {
-        if b != 0 { x1 } else { x2 }
+        if b != 0 { move x1 } else { move x2 }
     }
 }
 

--- a/src/test/run-pass/task-comm-0.rs
+++ b/src/test/run-pass/task-comm-0.rs
@@ -19,7 +19,7 @@ fn test05_start(ch : Chan<int>) {
 
 fn test05() {
     let (ch, po) = pipes::stream();
-    task::spawn(|| test05_start(ch) );
+    task::spawn(|move ch| test05_start(ch) );
     let mut value = po.recv();
     log(error, value);
     value = po.recv();

--- a/src/test/run-pass/task-comm-10.rs
+++ b/src/test/run-pass/task-comm-10.rs
@@ -5,7 +5,7 @@ extern mod std;
 
 fn start(c: pipes::Chan<pipes::Chan<~str>>) {
     let (ch, p) = pipes::stream();
-    c.send(ch);
+    c.send(move ch);
 
     let mut a;
     let mut b;
@@ -14,12 +14,12 @@ fn start(c: pipes::Chan<pipes::Chan<~str>>) {
     log(error, a);
     b = p.recv();
     assert b == ~"B";
-    log(error, b);
+    log(error, move b);
 }
 
 fn main() {
     let (ch, p) = pipes::stream();
-    let child = task::spawn(|| start(ch) );
+    let child = task::spawn(|move ch| start(ch) );
 
     let c = p.recv();
     c.send(~"A");

--- a/src/test/run-pass/task-comm-11.rs
+++ b/src/test/run-pass/task-comm-11.rs
@@ -5,11 +5,11 @@ extern mod std;
 
 fn start(c: pipes::Chan<pipes::Chan<int>>) {
     let (ch, p) = pipes::stream();
-    c.send(ch);
+    c.send(move ch);
 }
 
 fn main() {
     let (ch, p) = pipes::stream();
-    let child = task::spawn(|| start(ch) );
+    let child = task::spawn(|move ch| start(ch) );
     let c = p.recv();
 }

--- a/src/test/run-pass/task-comm-12.rs
+++ b/src/test/run-pass/task-comm-12.rs
@@ -7,7 +7,7 @@ fn start(&&task_number: int) { debug!("Started / Finished task."); }
 fn test00() {
     let i: int = 0;
     let mut result = None;
-    do task::task().future_result(|+r| { result = Some(r); }).spawn {
+    do task::task().future_result(|+r| { result = Some(move r); }).spawn {
         start(i)
     }
 
@@ -19,7 +19,7 @@ fn test00() {
     }
 
     // Try joining tasks that have already finished.
-    future::get(&option::unwrap(result));
+    future::get(&option::unwrap(move result));
 
     debug!("Joined task.");
 }

--- a/src/test/run-pass/task-comm-13.rs
+++ b/src/test/run-pass/task-comm-13.rs
@@ -12,6 +12,6 @@ fn start(c: pipes::Chan<int>, start: int, number_of_messages: int) {
 fn main() {
     debug!("Check that we don't deadlock.");
     let (ch, p) = pipes::stream();
-    task::try(|| start(ch, 0, 10) );
+    task::try(|move ch| start(ch, 0, 10) );
     debug!("Joined task");
 }

--- a/src/test/run-pass/task-comm-14.rs
+++ b/src/test/run-pass/task-comm-14.rs
@@ -9,8 +9,8 @@ fn main() {
     while (i > 0) {
         log(debug, i);
         let (ch, p) = pipes::stream();
-        po.add(p);
-        task::spawn(|copy i| child(i, ch) );
+        po.add(move p);
+        task::spawn(|move ch, copy i| child(i, ch) );
         i = i - 1;
     }
 

--- a/src/test/run-pass/task-comm-15.rs
+++ b/src/test/run-pass/task-comm-15.rs
@@ -18,6 +18,6 @@ fn main() {
     // the child's point of view the receiver may die. We should
     // drop messages on the floor in this case, and not crash!
     let (ch, p) = pipes::stream();
-    task::spawn(|| start(ch, 10));
+    task::spawn(|move ch| start(ch, 10));
     p.recv();
 }

--- a/src/test/run-pass/task-comm-16.rs
+++ b/src/test/run-pass/task-comm-16.rs
@@ -91,7 +91,7 @@ fn test_tag() {
 fn test_chan() {
     let (ch, po) = pipes::stream();
     let (ch0, po0) = pipes::stream();
-    ch.send(ch0);
+    ch.send(move ch0);
     let ch1 = po.recv();
     // Does the transmitted channel still work?
 

--- a/src/test/run-pass/task-comm-3.rs
+++ b/src/test/run-pass/task-comm-3.rs
@@ -34,8 +34,8 @@ fn test00() {
     while i < number_of_tasks {
         let ch = po.chan();
         do task::task().future_result(|+r| {
-            results.push(r);
-        }).spawn |copy i| {
+            results.push(move r);
+        }).spawn |move ch, copy i| {
             test00_start(ch, i, number_of_messages)
         }
         i = i + 1;

--- a/src/test/run-pass/task-comm-7.rs
+++ b/src/test/run-pass/task-comm-7.rs
@@ -17,19 +17,19 @@ fn test00() {
     let number_of_messages: int = 10;
 
     let c = p.chan();
-    do task::spawn {
+    do task::spawn |move c| {
         test00_start(c, number_of_messages * 0, number_of_messages);
     }
     let c = p.chan();
-    do task::spawn {
+    do task::spawn |move c| {
         test00_start(c, number_of_messages * 1, number_of_messages);
     }
     let c = p.chan();
-    do task::spawn {
+    do task::spawn |move c| {
         test00_start(c, number_of_messages * 2, number_of_messages);
     }
     let c = p.chan();
-    do task::spawn {
+    do task::spawn |move c| {
         test00_start(c, number_of_messages * 3, number_of_messages);
     }
 

--- a/src/test/run-pass/task-comm-9.rs
+++ b/src/test/run-pass/task-comm-9.rs
@@ -18,7 +18,8 @@ fn test00() {
     let ch = p.chan();
 
     let mut result = None;
-    do task::task().future_result(|+r| { result = Some(r); }).spawn {
+    do task::task().future_result(|+r| { result = Some(move r); }).spawn
+          |move ch| {
         test00_start(ch, number_of_messages);
     }
 
@@ -29,7 +30,7 @@ fn test00() {
         i += 1;
     }
 
-    future::get(&option::unwrap(result));
+    future::get(&option::unwrap(move result));
 
     assert (sum == number_of_messages * (number_of_messages - 1) / 2);
 }

--- a/src/test/run-pass/task-comm.rs
+++ b/src/test/run-pass/task-comm.rs
@@ -40,7 +40,7 @@ fn test00() {
     while i < number_of_tasks {
         i = i + 1;
         do task::task().future_result(|+r| {
-            results.push(r);
+            results.push(move r);
         }).spawn |copy i| {
             test00_start(ch, i, number_of_messages);
         }
@@ -127,7 +127,7 @@ fn test06() {
     while i < number_of_tasks {
         i = i + 1;
         do task::task().future_result(|+r| {
-            results.push(r);
+            results.push(move r);
         }).spawn |copy i| {
             test06_start(i);
         };

--- a/src/test/run-pass/trait-to-str.rs
+++ b/src/test/run-pass/trait-to-str.rs
@@ -30,7 +30,7 @@ fn main() {
     assert indirect(~[10, 20]) == ~"[10, 20]!";
 
     fn indirect2<T: to_str>(x: T) -> ~str {
-        indirect(x)
+        indirect(move x)
     }
     assert indirect2(~[1]) == ~"[1]!";
 }

--- a/src/test/run-pass/unique-fn-arg-move.rs
+++ b/src/test/run-pass/unique-fn-arg-move.rs
@@ -4,5 +4,5 @@ fn f(-i: ~int) {
 
 fn main() {
     let i = ~100;
-    f(i);
+    f(move i);
 }

--- a/src/test/run-pass/yield.rs
+++ b/src/test/run-pass/yield.rs
@@ -4,13 +4,13 @@ use task::*;
 
 fn main() {
     let mut result = None;
-    task::task().future_result(|+r| { result = Some(r); }).spawn(child);
+    task::task().future_result(|+r| { result = Some(move r); }).spawn(child);
     error!("1");
     yield();
     error!("2");
     yield();
     error!("3");
-    future::get(&option::unwrap(result));
+    future::get(&option::unwrap(move result));
 }
 
 fn child() {

--- a/src/test/run-pass/yield1.rs
+++ b/src/test/run-pass/yield1.rs
@@ -4,10 +4,10 @@ use task::*;
 
 fn main() {
     let mut result = None;
-    task::task().future_result(|+r| { result = Some(r); }).spawn(child);
+    task::task().future_result(|+r| { result = Some(move r); }).spawn(child);
     error!("1");
     yield();
-    future::get(&option::unwrap(result));
+    future::get(&option::unwrap(move result));
 }
 
 fn child() { error!("2"); }


### PR DESCRIPTION
This pull request removes the reliance of kind checking and trans on last-use analysis. This means two main things:
1. Kind checking doesn't treat last-uses of vars as implicit moves, so you have to insert explicit moves to avoid warnings and errors.
2. Trans doesn't automatically translate last uses as moves. It ignores the results of last use.

There is also one separate change (I know, I know) which is to change the kind checker to make struct fields non-copyable as per #3481.

Only 9abc7f0 , c4155f5, and c6780fb  need any review. The other patches are mostly just inserting implicit moves.

I had said that these patches caused a performance regression, but on further investigation, it doesn't. Either the performance hit comes from code I already checked in long ago (adding explicit moves), or -- more likely -- I was comparing between optimized and unoptimized builds :-( So I'm pretty confident that merging this pull request won't harm performance significantly.

I know we are potentially going to implement @nmatsakis's type-based move proposal, but in the meantime, this work is done and we might as well merge it to avoid the problems described in #2633.
