### PR TITLE
libstd: export std::net_url::encode_component

### DIFF
--- a/src/libstd/net_url.rs
+++ b/src/libstd/net_url.rs
@@ -95,7 +95,7 @@ pub fn encode(s: &str) -> ~str {
  * This function is compliant with RFC 3986.
  */
 
-fn encode_component(s: &str) -> ~str {
+pub fn encode_component(s: &str) -> ~str {
     encode_inner(s, false)
 }
 


### PR DESCRIPTION
`std::net_url::encode_component` isn't exported in the 0.4 release candidate, which is breaking my cargo rust-elasticsearch. Any chance we can get it included before we release 0.4? In the worst case I could implement this in another cargo, but I would like to avoid that.
