### PR TITLE
Make some string operations UTF-8 safe

### DIFF
--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -248,12 +248,14 @@ pub fn start_program(prog: &str, args: &[~str]) -> Program {
 }
 
 fn read_all(rd: io::Reader) -> ~str {
-    let mut buf = ~"";
-    while !rd.eof() {
-        let bytes = rd.read_bytes(4096u);
-        buf += str::from_bytes(bytes);
-    }
-    move buf
+    let buf = io::with_bytes_writer(|wr| {
+        let mut bytes = [mut 0, ..4096];
+        while !rd.eof() {
+            let nread = rd.read(bytes, bytes.len());
+            wr.write(bytes.view(0, nread));
+        }
+    });
+    str::from_bytes(buf)
 }
 
 /**
@@ -341,13 +343,15 @@ fn writeclose(fd: c_int, s: ~str) {
 fn readclose(fd: c_int) -> ~str {
     let file = os::fdopen(fd);
     let reader = io::FILE_reader(file, false);
-    let mut buf = ~"";
-    while !reader.eof() {
-        let bytes = reader.read_bytes(4096u);
-        buf += str::from_bytes(bytes);
-    }
+    let buf = io::with_bytes_writer(|writer| {
+        let mut bytes = [mut 0, ..4096];
+        while !reader.eof() {
+            let nread = reader.read(bytes, bytes.len());
+            writer.write(bytes.view(0, nread));
+        }
+    });
     os::fclose(file);
-    move buf
+    str::from_bytes(buf)
 }
 
 /// Waits for a process to exit and returns the exit code

--- a/src/rustdoc/markdown_writer.rs
+++ b/src/rustdoc/markdown_writer.rs
@@ -136,13 +136,15 @@ fn readclose(fd: libc::c_int) -> ~str {
     // Copied from run::program_output
     let file = os::fdopen(fd);
     let reader = io::FILE_reader(file, false);
-    let mut buf = ~"";
-    while !reader.eof() {
-        let bytes = reader.read_bytes(4096u);
-        buf += str::from_bytes(bytes);
-    }
+    let buf = io::with_bytes_writer(|writer| {
+        let mut bytes = [mut 0, ..4096];
+        while !reader.eof() {
+            let nread = reader.read(bytes, bytes.len());
+            writer.write(bytes.view(0, nread));
+        }
+    });
     os::fclose(file);
-    return buf;
+    str::from_bytes(buf)
 }
 
 fn generic_writer(+process: fn~(markdown: ~str)) -> Writer {


### PR DESCRIPTION
Currently `run::program_output` and `rustdoc` may fail at the assertion `str::is_utf8(vv)` due to the partial read of multi-byte character.
Fixed that issue by reading whole input first and then converting it to `~str`.
