### PR TITLE
Variety of small cleanups

### DIFF
--- a/src/libcore/dvec.rs
+++ b/src/libcore/dvec.rs
@@ -56,7 +56,7 @@ pub enum DVec<A> {
 }
 
 /// Creates a new, empty dvec
-pub fn DVec<A>() -> DVec<A> {
+pub pure fn DVec<A>() -> DVec<A> {
     DVec_({mut data: ~[]})
 }
 

--- a/src/libcore/extfmt.rs
+++ b/src/libcore/extfmt.rs
@@ -329,11 +329,11 @@ pub mod rt {
         // For strings, precision is the maximum characters
         // displayed
         let mut unpadded = match cv.precision {
-          CountImplied => s.to_unique(),
+          CountImplied => s.to_owned(),
           CountIs(max) => if max as uint < str::char_len(s) {
             str::substr(s, 0u, max as uint)
           } else {
-            s.to_unique()
+            s.to_owned()
           }
         };
         return unsafe { pad(cv, move unpadded, PadNozero) };

--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -119,8 +119,8 @@ impl<T: Reader> T : ReaderUtil {
             }
             return (i, 0);
         }
-        let mut bytes: ~[u8] = ~[];
-        let mut chars: ~[char] = ~[];
+        let mut bytes = ~[];
+        let mut chars = ~[];
         // might need more bytes, but reading n will never over-read
         let mut nbread = n;
         while nbread > 0 {

--- a/src/libcore/logging.rs
+++ b/src/libcore/logging.rs
@@ -32,7 +32,7 @@ pub fn console_off() {
 #[cfg(notest)]
 #[lang="log_type"]
 pub fn log_type<T>(level: u32, object: &T) {
-    let bytes = do io::with_bytes_writer() |writer| {
+    let bytes = do io::with_bytes_writer |writer| {
         repr::write_repr(writer, object);
     };
     unsafe {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -225,7 +225,7 @@ pub fn swap_unwrap<T>(opt: &mut Option<T>) -> T {
 
 pub pure fn unwrap_expect<T>(opt: Option<T>, reason: &str) -> T {
     //! As unwrap, but with a specified failure message.
-    if opt.is_none() { fail reason.to_unique(); }
+    if opt.is_none() { fail reason.to_owned(); }
     unwrap(move opt)
 }
 

--- a/src/libcore/repr.rs
+++ b/src/libcore/repr.rs
@@ -559,7 +559,7 @@ impl ReprPrinter {
         unsafe {
             self.align(sys::min_align_of::<T>());
             let value_addr: &T = transmute(copy self.ptr);
-            (*value_addr).write_repr(self.writer);
+            value_addr.write_repr(self.writer);
             self.bump(sys::size_of::<T>());
             true
         }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -2135,7 +2135,7 @@ pub trait StrSlice {
     pure fn trim() -> ~str;
     pure fn trim_left() -> ~str;
     pure fn trim_right() -> ~str;
-    pure fn to_unique() -> ~str;
+    pure fn to_owned() -> ~str;
     pure fn to_managed() -> @str;
     pure fn char_at(i: uint) -> char;
 }
@@ -2258,7 +2258,7 @@ impl &str: StrSlice {
     pure fn trim_right() -> ~str { trim_right(self) }
 
     #[inline]
-    pure fn to_unique() -> ~str { self.slice(0, self.len()) }
+    pure fn to_owned() -> ~str { self.slice(0, self.len()) }
 
     #[inline]
     pure fn to_managed() -> @str {

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -2262,9 +2262,8 @@ impl &str: StrSlice {
 
     #[inline]
     pure fn to_managed() -> @str {
-        let v = at_vec::from_fn(self.len() + 1, |i| {
-            if i == self.len() { 0 } else { self[i] }
-        });
+        let bytes = as_bytes_slice(self);
+        let v = at_vec::from_fn(bytes.len(), |i| bytes[i]);
         unsafe { ::cast::transmute(v) }
     }
 

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -897,7 +897,7 @@ pub impl Deserializer: serialization::Deserializer {
                 // FIXME(#3148) This hint should not be necessary.
                 let obj: &self/~Object = obj;
 
-                match obj.find_ref(&name.to_unique()) {
+                match obj.find_ref(&name.to_owned()) {
                     None => fail fmt!("no such field: %s", name),
                     Some(json) => {
                         self.stack.push(json);

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -90,9 +90,7 @@ fn attr_meta(attr: ast::attribute) -> @ast::meta_item { @attr.node.value }
 
 // Get the meta_items from inside a vector of attributes
 fn attr_metas(attrs: ~[ast::attribute]) -> ~[@ast::meta_item] {
-    let mut mitems = ~[];
-    for attrs.each |a| { mitems.push(attr_meta(*a)); }
-    return mitems;
+    do attrs.map |a| { attr_meta(*a) }
 }
 
 fn desugar_doc_attr(attr: &ast::attribute) -> ast::attribute {

--- a/src/rustc/back/upcall.rs
+++ b/src/rustc/back/upcall.rs
@@ -27,8 +27,7 @@ fn declare_upcalls(targ_cfg: @session::config,
     fn decl(llmod: ModuleRef, prefix: ~str, name: ~str,
             tys: ~[TypeRef], rv: TypeRef) ->
        ValueRef {
-        let mut arg_tys: ~[TypeRef] = ~[];
-        for tys.each |t| { arg_tys.push(*t); }
+        let arg_tys = tys.map(|t| *t);
         let fn_ty = T_fn(arg_tys, rv);
         return base::decl_cdecl_fn(llmod, prefix + name, fn_ty);
     }

--- a/src/rustc/metadata/decoder.rs
+++ b/src/rustc/metadata/decoder.rs
@@ -598,13 +598,12 @@ fn get_enum_variants(intr: @ident_interner, cdata: cmd, id: ast::node_id,
         let ctor_ty = item_type({crate: cdata.cnum, node: id}, item,
                                 tcx, cdata);
         let name = item_name(intr, item);
-        let mut arg_tys: ~[ty::t] = ~[];
-        match ty::get(ctor_ty).sty {
-          ty::ty_fn(f) => {
-            for f.sig.inputs.each |a| { arg_tys.push(a.ty); }
-          }
-          _ => { /* Nullary enum variant. */ }
-        }
+        let arg_tys = match ty::get(ctor_ty).sty {
+          ty::ty_fn(f) => f.sig.inputs.map(|a| a.ty),
+
+          // Nullary enum variant.
+          _ => ~[],
+        };
         match variant_disr_val(item) {
           Some(val) => { disr_val = val; }
           _         => { /* empty */ }

--- a/src/rustc/metadata/encoder.rs
+++ b/src/rustc/metadata/encoder.rs
@@ -1162,7 +1162,7 @@ fn encode_metadata(parms: encode_parms, crate: @crate) -> ~[u8] {
 
     if (parms.tcx.sess.meta_stats()) {
 
-        do wr.buf.borrow |v| {
+        do wr.bytes.borrow |v| {
             do v.each |e| {
                 if *e == 0 {
                     ecx.stats.zero_bytes += 1;
@@ -1195,7 +1195,7 @@ fn encode_metadata(parms: encode_parms, crate: @crate) -> ~[u8] {
 
     (do str::as_bytes(&~"rust\x00\x00\x00\x01") |bytes| {
         vec::slice(*bytes, 0, 8)
-    }) + flate::deflate_bytes(wr.buf.check_out(|buf| buf))
+    }) + flate::deflate_bytes(wr.bytes.check_out(|buf| buf))
 }
 
 // Get the encoded string for a type

--- a/src/rustc/middle/trans/build.rs
+++ b/src/rustc/middle/trans/build.rs
@@ -433,8 +433,7 @@ fn GEP(cx: block, Pointer: ValueRef, Indices: ~[ValueRef]) -> ValueRef {
 //
 // XXX: Use a small-vector optimization to avoid allocations here.
 fn GEPi(cx: block, base: ValueRef, ixs: &[uint]) -> ValueRef {
-    let mut v: ~[ValueRef] = ~[];
-    for vec::each(ixs) |i| { v.push(C_i32(*i as i32)); }
+    let v = do vec::map(ixs) |i| { C_i32(*i as i32) };
     count_insn(cx, "gepi");
     return InBoundsGEP(cx, base, v);
 }

--- a/src/rustc/util/common.rs
+++ b/src/rustc/util/common.rs
@@ -34,9 +34,7 @@ type flag = HashMap<~str, ()>;
 fn field_expr(f: ast::field) -> @ast::expr { return f.node.expr; }
 
 fn field_exprs(fields: ~[ast::field]) -> ~[@ast::expr] {
-    let mut es = ~[];
-    for fields.each |f| { es.push(f.node.expr); }
-    return es;
+    fields.map(|f| f.node.expr)
 }
 
 // Takes a predicate p, returns true iff p is true for any subexpressions

--- a/src/rustc/util/ppaux.rs
+++ b/src/rustc/util/ppaux.rs
@@ -282,8 +282,7 @@ fn ty_to_str(cx: ctxt, typ: t) -> ~str {
           _ => { }
         }
         s += ~"(";
-        let mut strs = ~[];
-        for inputs.each |a| { strs.push(fn_input_to_str(cx, *a)); }
+        let strs = inputs.map(|a| fn_input_to_str(cx, *a));
         s += str::connect(strs, ~", ");
         s += ~")";
         if ty::get(output).sty != ty_nil {
@@ -338,13 +337,11 @@ fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_unboxed_vec(tm) => { ~"unboxed_vec<" + mt_to_str(cx, tm) + ~">" }
       ty_type => ~"type",
       ty_rec(elems) => {
-        let mut strs: ~[~str] = ~[];
-        for elems.each |fld| { strs.push(field_to_str(cx, *fld)); }
+        let strs = elems.map(|fld| field_to_str(cx, *fld));
         ~"{" + str::connect(strs, ~",") + ~"}"
       }
       ty_tup(elems) => {
-        let mut strs = ~[];
-        for elems.each |elem| { strs.push(ty_to_str(cx, *elem)); }
+        let strs = elems.map(|elem| ty_to_str(cx, *elem));
         ~"(" + str::connect(strs, ~",") + ~")"
       }
       ty_fn(ref f) => {


### PR DESCRIPTION
This pull request includes:
- Rewriting io::ByteBuf as the struct io::BytesWriter
- Making with_bytes_writer/with_bytes_reader pure (#3758)
- Renaming str::to_unique to str::to_owned
- Other minor cleanups
