### PR TITLE
configure: check for pandoc version properly.

### DIFF
--- a/configure
+++ b/configure
@@ -363,11 +363,12 @@ fi
 
 if [ ! -z "$CFG_PANDOC" ]
 then
-	PANDOC_VER_LINE=$(pandoc --version | grep '^pandoc ')
-	PANDOC_VER=${PANDOC_VER_LINE#pandoc }
-	PV_MAJOR_MINOR=${PANDOC_VER%.[0-9]}
-	PV_MAJOR=${PV_MAJOR_MINOR%.[0-9]}
-	PV_MINOR=${PV_MAJOR_MINOR#[0-9].}
+    PANDOC_VER_LINE=$(pandoc --version | grep '^pandoc ')
+    PANDOC_VER=${PANDOC_VER_LINE#pandoc }
+    PV_MAJOR_MINOR=${PANDOC_VER%.[0-9]*}
+    PV_MAJOR=${PV_MAJOR_MINOR%%[.][0-9]*}
+    PV_MINOR=${PV_MAJOR_MINOR#[0-9]*[.]}
+    PV_MINOR=${PV_MINOR%%[.][0-9]*}
     if [ "$PV_MAJOR" -lt "1" ] || [ "$PV_MINOR" -lt "8" ]
     then
 		step_msg "pandoc $PV_MAJOR.$PV_MINOR is too old. disabling"


### PR DESCRIPTION
Current configure was broken for pandoc versions of the form x.x.x.x

i.e. 1.8.1.1 would give PV_MAJOR=1.8 and PV_MINOR=8.1 instead of PV_MAJOR=1 and PV_MINOR=8
