### PR TITLE
Replace rust_atomic_increment/decrement and rust_compare_and_swap_ptr with intrinsics.

### DIFF
--- a/src/libcore/private.rs
+++ b/src/libcore/private.rs
@@ -5,7 +5,6 @@
 
 #[doc(hidden)];
 
-use compare_and_swap = rustrt::rust_compare_and_swap_ptr;
 use task::TaskBuilder;
 use task::atomically;
 
@@ -39,12 +38,27 @@ type rust_port_id = uint;
 
 type GlobalPtr = *libc::uintptr_t;
 
+// TODO: Remove once snapshots have atomic_cxchg
+#[cfg(stage0)]
+fn compare_and_swap(address: &mut libc::uintptr_t,
+                    oldval: libc::uintptr_t,
+                    newval: libc::uintptr_t) -> bool {
+    rustrt::rust_compare_and_swap_ptr(address, oldval, newval)
+}
+
+#[cfg(stage1)]
+#[cfg(stage2)]
+#[cfg(stage3)]
+fn compare_and_swap(address: &mut int, oldval: int, newval: int) -> bool {
+    let old = rusti::atomic_cxchg(address, oldval, newval);
+    old == oldval
+}
+
 /**
  * Atomically gets a channel from a pointer to a pointer-sized memory location
  * or, if no channel exists creates and installs a new channel and sets up a
  * new task to receive from it.
  */
-#[cfg(stage0)]
 pub unsafe fn chan_from_global_ptr<T: Send>(
     global: GlobalPtr,
     task_fn: fn() -> task::TaskBuilder,
@@ -87,69 +101,7 @@ pub unsafe fn chan_from_global_ptr<T: Send>(
         log(debug,~"BEFORE COMPARE AND SWAP");
         let swapped = compare_and_swap(
             cast::reinterpret_cast(&global),
-            0u, cast::reinterpret_cast(&ch));
-        log(debug,fmt!("AFTER .. swapped? %?", swapped));
-
-        if swapped {
-            // Success!
-            comm::send(setup_ch, Proceed);
-            ch
-        } else {
-            // Somebody else got in before we did
-            comm::send(setup_ch, Abort);
-            cast::reinterpret_cast(&*global)
-        }
-    } else {
-        log(debug, ~"global != 0");
-        cast::reinterpret_cast(&*global)
-    }
-}
-
-#[cfg(stage1)] #[cfg(stage2)] #[cfg(stage3)]    
-pub unsafe fn chan_from_global_ptr<T: Send>(
-    global: GlobalPtr,
-    task_fn: fn() -> task::TaskBuilder,
-    f: fn~(comm::Port<T>)
-) -> comm::Chan<T> {
-
-    enum Msg {
-        Proceed,
-        Abort
-    }
-
-    log(debug,~"ENTERING chan_from_global_ptr, before is_prob_zero check");
-    let is_probably_zero = *global == 0u;
-    log(debug,~"after is_prob_zero check");
-    if is_probably_zero {
-        log(debug,~"is probably zero...");
-        // There's no global channel. We must make it
-
-        let (setup_po, setup_ch) = do task_fn().spawn_conversation
-            |move f, setup_po, setup_ch| {
-            let po = comm::Port::<T>();
-            let ch = comm::Chan(&po);
-            comm::send(setup_ch, ch);
-
-            // Wait to hear if we are the official instance of
-            // this global task
-            match comm::recv::<Msg>(setup_po) {
-              Proceed => f(move po),
-              Abort => ()
-            }
-        };
-
-        log(debug,~"before setup recv..");
-        // This is the proposed global channel
-        let ch = comm::recv(setup_po);
-        // 0 is our sentinal value. It is not a valid channel
-        assert *ch != 0;
-
-        // Install the channel
-        log(debug,~"BEFORE COMPARE AND SWAP");
-        rusti::atomic_cxchg(
-            cast::reinterpret_cast(&global),
             0, cast::reinterpret_cast(&ch));
-        let swapped = *global != 0;
         log(debug,fmt!("AFTER .. swapped? %?", swapped));
 
         if swapped {
@@ -405,7 +357,6 @@ fn ArcDestruct<T>(data: *libc::c_void) -> ArcDestruct<T> {
     }
 }
 
-#[cfg(stage0)]
 pub unsafe fn unwrap_shared_mutable_state<T: Send>(rc: SharedMutableState<T>)
         -> T {
     struct DeathThroes<T> {
@@ -435,74 +386,6 @@ pub unsafe fn unwrap_shared_mutable_state<T: Send>(rc: SharedMutableState<T>)
         let serverp: libc::uintptr_t = cast::transmute(move server);
         // Try to put our server end in the unwrapper slot.
         if rustrt::rust_compare_and_swap_ptr(&mut ptr.unwrapper, 0, serverp) {
-            // Got in. Step 0: Tell destructor not to run. We are now it.
-            rc.data = ptr::null();
-            // Step 1 - drop our own reference.
-            let new_count = rusti::atomic_xsub(&mut ptr.count, 1) - 1;
-            //assert new_count >= 0;
-            if new_count == 0 {
-                // We were the last owner. Can unwrap immediately.
-                // Also we have to free the server endpoints.
-                let _server: UnwrapProto = cast::transmute(move serverp);
-                option::swap_unwrap(&mut ptr.data)
-                // drop glue takes over.
-            } else {
-                // The *next* person who sees the refcount hit 0 will wake us.
-                let end_result =
-                    DeathThroes { ptr: Some(move ptr),
-                                  response: Some(move c2) };
-                let mut p1 = Some(move p1); // argh
-                do task::rekillable {
-                    pipes::recv_one(option::swap_unwrap(&mut p1));
-                }
-                // Got here. Back in the 'unkillable' without getting killed.
-                // Recover ownership of ptr, then take the data out.
-                let ptr = option::swap_unwrap(&mut end_result.ptr);
-                option::swap_unwrap(&mut ptr.data)
-                // drop glue takes over.
-            }
-        } else {
-            // Somebody else was trying to unwrap. Avoid guaranteed deadlock.
-            cast::forget(move ptr);
-            // Also we have to free the (rejected) server endpoints.
-            let _server: UnwrapProto = cast::transmute(move serverp);
-            fail ~"Another task is already unwrapping this ARC!";
-        }
-    }
-}
-
-#[cfg(stage1)] #[cfg(stage2)] #[cfg(stage3)]    
-pub unsafe fn unwrap_shared_mutable_state<T: Send>(rc: SharedMutableState<T>)
-        -> T {
-    struct DeathThroes<T> {
-        mut ptr:      Option<~ArcData<T>>,
-        mut response: Option<pipes::ChanOne<bool>>,
-        drop unsafe {
-            let response = option::swap_unwrap(&mut self.response);
-            // In case we get killed early, we need to tell the person who
-            // tried to wake us whether they should hand-off the data to us.
-            if task::failing() {
-                pipes::send_one(move response, false);
-                // Either this swap_unwrap or the one below (at "Got here")
-                // ought to run.
-                cast::forget(option::swap_unwrap(&mut self.ptr));
-            } else {
-                assert self.ptr.is_none();
-                pipes::send_one(move response, true);
-            }
-        }
-    }
-
-    do task::unkillable {
-        let ptr: ~ArcData<T> = cast::reinterpret_cast(&rc.data);
-        let (c1,p1) = pipes::oneshot(); // ()
-        let (c2,p2) = pipes::oneshot(); // bool
-        let server: UnwrapProto = ~mut Some((move c1,move p2));
-        let serverp: libc::uintptr_t = cast::transmute(move server);
-        // Try to put our server end in the unwrapper slot.
-        rusti::atomic_cxchg(cast::reinterpret_cast(&ptr.unwrapper),
-                            0, serverp as int);
-        if ptr.unwrapper != 0 {
             // Got in. Step 0: Tell destructor not to run. We are now it.
             rc.data = ptr::null();
             // Step 1 - drop our own reference.

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -830,16 +830,6 @@ rust_compare_and_swap_ptr(intptr_t *address,
     return sync::compare_and_swap(address, oldval, newval);
 }
 
-extern "C" CDECL intptr_t
-rust_atomic_increment(intptr_t *address) {
-    return sync::increment(address);
-}
-
-extern "C" CDECL intptr_t
-rust_atomic_decrement(intptr_t *address) {
-    return sync::decrement(address);
-}
-
 extern "C" CDECL void
 rust_task_weaken(rust_port_id chan) {
     rust_task *task = rust_get_current_task();

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -178,8 +178,6 @@ rust_dbg_do_nothing
 rust_dbg_breakpoint
 rust_osmain_sched_id
 rust_compare_and_swap_ptr
-rust_atomic_increment
-rust_atomic_decrement
 rust_global_env_chan_ptr
 rust_port_take
 rust_port_drop

--- a/src/rustc/lib/llvm.rs
+++ b/src/rustc/lib/llvm.rs
@@ -843,6 +843,9 @@ extern mod llvm {
                         Name: *c_char) -> ValueRef;
 
     /* Atomic Operations */
+    fn LLVMBuildAtomicCmpXchg(B: BuilderRef, LHS: ValueRef,
+                              CMP: ValueRef, RHS: ValueRef,
+                              ++Order: AtomicOrdering) -> ValueRef;
     fn LLVMBuildAtomicRMW(B: BuilderRef, ++Op: AtomicBinOp,
                           LHS: ValueRef, RHS: ValueRef,
                           ++Order: AtomicOrdering) -> ValueRef;

--- a/src/rustc/middle/trans/build.rs
+++ b/src/rustc/middle/trans/build.rs
@@ -813,6 +813,11 @@ fn Resume(cx: block, Exn: ValueRef) -> ValueRef {
 }
 
 // Atomic Operations
+fn AtomicCmpXchg(cx: block, dst: ValueRef,
+                 cmp: ValueRef, src: ValueRef,
+                 order: AtomicOrdering) -> ValueRef {
+    llvm::LLVMBuildAtomicCmpXchg(B(cx), dst, cmp, src, order)
+}
 fn AtomicRMW(cx: block, op: AtomicBinOp,
              dst: ValueRef, src: ValueRef,
              order: AtomicOrdering) -> ValueRef {

--- a/src/rustc/middle/trans/foreign.rs
+++ b/src/rustc/middle/trans/foreign.rs
@@ -799,6 +799,30 @@ fn trans_intrinsic(ccx: @crate_ctxt, decl: ValueRef, item: @ast::foreign_item,
                                Some(substs), Some(item.span));
     let mut bcx = top_scope_block(fcx, None), lltop = bcx.llbb;
     match ccx.sess.str_of(item.ident) {
+        ~"atomic_cxchg" => {
+            let old = AtomicCmpXchg(bcx,
+                                    get_param(decl, first_real_arg),
+                                    get_param(decl, first_real_arg + 1u),
+                                    get_param(decl, first_real_arg + 2u),
+                                    SequentiallyConsistent);
+            Store(bcx, old, fcx.llretptr);
+        }
+        ~"atomic_cxchg_acq" => {
+            let old = AtomicCmpXchg(bcx,
+                                    get_param(decl, first_real_arg),
+                                    get_param(decl, first_real_arg + 1u),
+                                    get_param(decl, first_real_arg + 2u),
+                                    Acquire);
+            Store(bcx, old, fcx.llretptr);
+        }
+        ~"atomic_cxchg_rel" => {
+            let old = AtomicCmpXchg(bcx,
+                                    get_param(decl, first_real_arg),
+                                    get_param(decl, first_real_arg + 1u),
+                                    get_param(decl, first_real_arg + 2u),
+                                    Release);
+            Store(bcx, old, fcx.llretptr);
+        }
         ~"atomic_xchg" => {
             let old = AtomicRMW(bcx, Xchg,
                                 get_param(decl, first_real_arg),

--- a/src/rustc/middle/trans/type_use.rs
+++ b/src/rustc/middle/trans/type_use.rs
@@ -98,11 +98,12 @@ fn type_uses_for(ccx: @crate_ctxt, fn_id: def_id, n_tps: uint)
 
                 ~"get_tydesc" | ~"needs_drop" => use_tydesc,
 
-                ~"atomic_xchg"     | ~"atomic_xadd"     |
-                ~"atomic_xsub"     | ~"atomic_xchg_acq" |
-                ~"atomic_xadd_acq" | ~"atomic_xsub_acq" |
-                ~"atomic_xchg_rel" | ~"atomic_xadd_rel" |
-                ~"atomic_xsub_rel" => 0,
+                ~"atomic_cxchg"    | ~"atomic_cxchg_acq"|
+                ~"atomic_cxchg_rel"| ~"atomic_xchg"     |
+                ~"atomic_xadd"     | ~"atomic_xsub"     |
+                ~"atomic_xchg_acq" | ~"atomic_xadd_acq" |
+                ~"atomic_xsub_acq" | ~"atomic_xchg_rel" |
+                ~"atomic_xadd_rel" | ~"atomic_xsub_rel" => 0,
 
                 ~"visit_tydesc"  | ~"forget" | ~"addr_of" |
                 ~"frame_address" | ~"morestack_addr" => 0,

--- a/src/rustc/middle/typeck/check.rs
+++ b/src/rustc/middle/typeck/check.rs
@@ -2605,7 +2605,15 @@ fn check_intrinsic_type(ccx: @crate_ctxt, it: @ast::foreign_item) {
       }
       ~"needs_drop" => (1u, ~[], ty::mk_bool(tcx)),
 
-      ~"atomic_xchg"     | ~"atomic_xadd"     | ~"atomic_xsub" |
+      ~"atomic_cxchg"    | ~"atomic_cxchg_acq"| ~"atomic_cxchg_rel" => {
+        (0u, ~[arg(ast::by_copy,
+                   ty::mk_mut_rptr(tcx, ty::re_bound(ty::br_anon(0)),
+                                   ty::mk_int(tcx))),
+               arg(ast::by_copy, ty::mk_int(tcx)),
+               arg(ast::by_copy, ty::mk_int(tcx))],
+         ty::mk_int(tcx))
+      }
+      ~"atomic_xchg"     | ~"atomic_xadd"     | ~"atomic_xsub"     |
       ~"atomic_xchg_acq" | ~"atomic_xadd_acq" | ~"atomic_xsub_acq" |
       ~"atomic_xchg_rel" | ~"atomic_xadd_rel" | ~"atomic_xsub_rel" => {
         (0u, ~[arg(ast::by_copy,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -482,6 +482,14 @@ extern "C" LLVMTypeRef LLVMMetadataType(void) {
   return LLVMMetadataTypeInContext(LLVMGetGlobalContext());
 }
 
+extern "C" LLVMValueRef LLVMBuildAtomicCmpXchg(LLVMBuilderRef B,
+                                               LLVMValueRef target,
+                                               LLVMValueRef old,
+                                               LLVMValueRef source,
+                                               AtomicOrdering order) {
+    return wrap(unwrap(B)->CreateAtomicCmpXchg(unwrap(target), unwrap(old),
+                                               unwrap(source), order));
+}
 extern "C" LLVMValueRef LLVMBuildAtomicRMW(LLVMBuilderRef B,
                                            AtomicRMWInst::BinOp op,
                                            LLVMValueRef target,

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -84,6 +84,7 @@ LLVMArrayType
 LLVMBasicBlockAsValue
 LLVMBlockAddress
 LLVMBuildAShr
+LLVMBuildAtomicCmpXchg
 LLVMBuildAtomicRMW
 LLVMBuildAdd
 LLVMBuildAggregateRet

--- a/src/test/auxiliary/cci_intrinsic.rs
+++ b/src/test/auxiliary/cci_intrinsic.rs
@@ -2,6 +2,10 @@
 #[abi = "rust-intrinsic"]
 extern mod rusti {
     #[legacy_exports];
+    fn atomic_cxchg(dst: &mut int, old: int, src: int) -> int;
+    fn atomic_cxchg_acq(dst: &mut int, old: int, src: int) -> int;
+    fn atomic_cxchg_rel(dst: &mut int, old: int, src: int) -> int;
+
     fn atomic_xchg(dst: &mut int, src: int) -> int;
     fn atomic_xchg_acq(dst: &mut int, src: int) -> int;
     fn atomic_xchg_rel(dst: &mut int, src: int) -> int;

--- a/src/test/run-pass/intrinsic-atomics.rs
+++ b/src/test/run-pass/intrinsic-atomics.rs
@@ -1,6 +1,10 @@
 #[abi = "rust-intrinsic"]
 extern mod rusti {
     #[legacy_exports];
+    fn atomic_cxchg(dst: &mut int, old: int, src: int) -> int;
+    fn atomic_cxchg_acq(dst: &mut int, old: int, src: int) -> int;
+    fn atomic_cxchg_rel(dst: &mut int, old: int, src: int) -> int;
+
     fn atomic_xchg(dst: &mut int, src: int) -> int;
     fn atomic_xchg_acq(dst: &mut int, src: int) -> int;
     fn atomic_xchg_rel(dst: &mut int, src: int) -> int;
@@ -16,6 +20,15 @@ extern mod rusti {
 
 fn main() {
     let x = ~mut 1;
+
+    assert rusti::atomic_cxchg(x, 1, 2) == 1;
+    assert *x == 2;
+
+    assert rusti::atomic_cxchg_acq(x, 1, 3) == 2;
+    assert *x == 2;
+
+    assert rusti::atomic_cxchg_rel(x, 2, 1) == 2;
+    assert *x == 1;
 
     assert rusti::atomic_xchg(x, 0) == 1;
     assert *x == 0;


### PR DESCRIPTION
Issue #3527

Added some new intrinsics: (compare and exchange)

```
atomic_cxchg
atomic_cxchg_acq
atomic_cxchg_rel
```

Though I had to basically copy/paste two functions since the new intrinsic wouldn't be available in stage0 so `rust_compare_and_swap_ptr` is still used in libcore for stage0.
