### PR TITLE
Issue 2263 fn subtyping

### DIFF
--- a/src/libcore/at_vec.rs
+++ b/src/libcore/at_vec.rs
@@ -136,9 +136,20 @@ pub pure fn from_elem<T: Copy>(n_elts: uint, t: T) -> @[T] {
 #[cfg(notest)]
 pub mod traits {
     #[legacy_exports];
+
+    #[cfg(stage0)]
     pub impl<T: Copy> @[T] : Add<&[const T],@[T]> {
         #[inline(always)]
         pure fn add(rhs: & &[const T]) -> @[T] {
+            append(self, (*rhs))
+        }
+    }
+
+    #[cfg(stage1)]
+    #[cfg(stage2)]
+    pub impl<T: Copy> @[T] : Add<&[const T],@[T]> {
+        #[inline(always)]
+        pure fn add(rhs: & &self/[const T]) -> @[T] {
             append(self, (*rhs))
         }
     }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -226,17 +226,35 @@ impl<T> *const T : Ord {
 }
 
 // Equality for region pointers
+#[cfg(stage0)]
 impl<T:Eq> &const T : Eq {
     pure fn eq(other: & &const T) -> bool { return *self == *(*other); }
     pure fn ne(other: & &const T) -> bool { return *self != *(*other); }
 }
 
+#[cfg(stage1)]
+#[cfg(stage2)]
+impl<T:Eq> &const T : Eq {
+    pure fn eq(other: & &self/const T) -> bool { return *self == *(*other); }
+    pure fn ne(other: & &self/const T) -> bool { return *self != *(*other); }
+}
+
 // Comparison for region pointers
+#[cfg(stage0)]
 impl<T:Ord> &const T : Ord {
     pure fn lt(other: & &const T) -> bool { *self < *(*other) }
     pure fn le(other: & &const T) -> bool { *self <= *(*other) }
     pure fn ge(other: & &const T) -> bool { *self >= *(*other) }
     pure fn gt(other: & &const T) -> bool { *self > *(*other) }
+}
+
+#[cfg(stage1)]
+#[cfg(stage2)]
+impl<T:Ord> &const T : Ord {
+    pure fn lt(other: & &self/const T) -> bool { *self < *(*other) }
+    pure fn le(other: & &self/const T) -> bool { *self <= *(*other) }
+    pure fn ge(other: & &self/const T) -> bool { *self >= *(*other) }
+    pure fn gt(other: & &self/const T) -> bool { *self > *(*other) }
 }
 
 #[test]

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -735,6 +735,7 @@ pure fn gt(a: &str, b: &str) -> bool {
     !le(a, b)
 }
 
+#[cfg(stage0)]
 impl &str : Eq {
     #[inline(always)]
     pure fn eq(other: & &str) -> bool {
@@ -742,6 +743,17 @@ impl &str : Eq {
     }
     #[inline(always)]
     pure fn ne(other: & &str) -> bool { !self.eq(other) }
+}
+
+#[cfg(stage1)]
+#[cfg(stage2)]
+impl &str : Eq {
+    #[inline(always)]
+    pure fn eq(other: & &self/str) -> bool {
+        eq_slice(self, (*other))
+    }
+    #[inline(always)]
+    pure fn ne(other: & &self/str) -> bool { !self.eq(other) }
 }
 
 impl ~str : Eq {
@@ -773,6 +785,7 @@ impl ~str : Ord {
     pure fn gt(other: &~str) -> bool { gt(self, (*other)) }
 }
 
+#[cfg(stage0)]
 impl &str : Ord {
     #[inline(always)]
     pure fn lt(other: & &str) -> bool { lt(self, (*other)) }
@@ -782,6 +795,19 @@ impl &str : Ord {
     pure fn ge(other: & &str) -> bool { ge(self, (*other)) }
     #[inline(always)]
     pure fn gt(other: & &str) -> bool { gt(self, (*other)) }
+}
+
+#[cfg(stage1)]
+#[cfg(stage2)]
+impl &str : Ord {
+    #[inline(always)]
+    pure fn lt(other: & &self/str) -> bool { lt(self, (*other)) }
+    #[inline(always)]
+    pure fn le(other: & &self/str) -> bool { le(self, (*other)) }
+    #[inline(always)]
+    pure fn ge(other: & &self/str) -> bool { ge(self, (*other)) }
+    #[inline(always)]
+    pure fn gt(other: & &self/str) -> bool { gt(self, (*other)) }
 }
 
 impl @str : Ord {
@@ -2096,9 +2122,19 @@ impl ~str: Trimmable {
 
 #[cfg(notest)]
 pub mod traits {
+    #[cfg(stage0)]
     impl ~str : Add<&str,~str> {
         #[inline(always)]
         pure fn add(rhs: & &str) -> ~str {
+            append(copy self, (*rhs))
+        }
+    }
+
+    #[cfg(stage1)]
+    #[cfg(stage2)]
+    impl ~str : Add<&str,~str> {
+        #[inline(always)]
+        pure fn add(rhs: & &self/str) -> ~str {
             append(copy self, (*rhs))
         }
     }
@@ -2558,7 +2594,7 @@ mod tests {
         assert find_str_between(data, ~"ab", 2u, 4u).is_none();
 
         let mut data = ~"ประเทศไทย中华Việt Nam";
-        data += data;
+        data = data + data;
         assert find_str_between(data, ~"", 0u, 43u) == Some(0u);
         assert find_str_between(data, ~"", 6u, 43u) == Some(6u);
 

--- a/src/rustc/metadata/tyencode.rs
+++ b/src/rustc/metadata/tyencode.rs
@@ -147,7 +147,7 @@ fn enc_region(w: io::Writer, cx: @ctxt, r: ty::Region) {
       ty::re_static => {
         w.write_char('t');
       }
-      ty::re_var(_) => {
+      ty::re_infer(_) => {
         // these should not crop up after typeck
         cx.diag.handler().bug(~"Cannot encode region variables");
       }

--- a/src/rustc/middle/astencode.rs
+++ b/src/rustc/middle/astencode.rs
@@ -387,7 +387,7 @@ impl ty::Region: tr {
             ty::re_bound(br) => ty::re_bound(br.tr(xcx)),
             ty::re_free(id, br) => ty::re_free(xcx.tr_id(id), br.tr(xcx)),
             ty::re_scope(id) => ty::re_scope(xcx.tr_id(id)),
-            ty::re_static | ty::re_var(*) => self,
+            ty::re_static | ty::re_infer(*) => self,
         }
     }
 }

--- a/src/rustc/middle/kind.rs
+++ b/src/rustc/middle/kind.rs
@@ -580,7 +580,7 @@ fn check_cast_for_escaping_regions(
     match target_substs.self_r {
       Some(ty::re_scope(*)) => { return; /* case (1) */ }
       None | Some(ty::re_static) | Some(ty::re_free(*)) => {}
-      Some(ty::re_bound(*)) | Some(ty::re_var(*)) => {
+      Some(ty::re_bound(*)) | Some(ty::re_infer(*)) => {
         cx.tcx.sess.span_bug(
             source.span,
             fmt!("bad region found in kind: %?", target_substs.self_r));

--- a/src/rustc/middle/region.rs
+++ b/src/rustc/middle/region.rs
@@ -112,18 +112,18 @@ fn is_subregion_of(region_map: region_map,
                    super_region: ty::Region) -> bool {
     sub_region == super_region ||
         match (sub_region, super_region) {
-          (_, ty::re_static) => {
-            true
-          }
+            (_, ty::re_static) => {
+                true
+            }
 
-          (ty::re_scope(sub_scope), ty::re_scope(super_scope)) |
-          (ty::re_scope(sub_scope), ty::re_free(super_scope, _)) => {
-            scope_contains(region_map, super_scope, sub_scope)
-          }
+            (ty::re_scope(sub_scope), ty::re_scope(super_scope)) |
+            (ty::re_scope(sub_scope), ty::re_free(super_scope, _)) => {
+                scope_contains(region_map, super_scope, sub_scope)
+            }
 
-          _ => {
-            false
-          }
+            _ => {
+                false
+            }
         }
 }
 

--- a/src/rustc/middle/typeck/check/regionmanip.rs
+++ b/src/rustc/middle/typeck/check/regionmanip.rs
@@ -97,7 +97,7 @@ fn replace_bound_regions_in_fn_ty(
                       r: ty::Region) -> isr_alist {
             match r {
               ty::re_free(_, _) | ty::re_static | ty::re_scope(_) |
-              ty::re_var(_) => {
+              ty::re_infer(_) => {
                 isr
               }
               ty::re_bound(br) => {
@@ -165,7 +165,7 @@ fn replace_bound_regions_in_fn_ty(
               ty::re_static |
               ty::re_scope(_) |
               ty::re_free(_, _) |
-              ty::re_var(_) => r
+              ty::re_infer(_) => r
             }
         }
     }

--- a/src/rustc/middle/typeck/infer.rs
+++ b/src/rustc/middle/typeck/infer.rs
@@ -262,7 +262,7 @@ use util::common::{indent, indenter};
 use ast::{unsafe_fn, impure_fn, pure_fn, extern_fn};
 use ast::{m_const, m_imm, m_mutbl};
 use dvec::DVec;
-use region_var_bindings::{RegionVarBindings};
+use region_inference::{RegionVarBindings};
 use ast_util::dummy_sp;
 use cmp::Eq;
 
@@ -628,7 +628,7 @@ impl infer_ctxt {
     }
 
     fn next_region_var_nb(span: span) -> ty::Region {
-        ty::re_var(self.region_vars.new_region_var(span))
+        ty::re_infer(ty::ReVar(self.region_vars.new_region_var(span)))
     }
 
     fn next_region_var_with_lb(span: span,

--- a/src/rustc/middle/typeck/infer/macros.rs
+++ b/src/rustc/middle/typeck/infer/macros.rs
@@ -1,0 +1,12 @@
+{
+
+macro_rules! if_ok(
+    ($inp: expr) => (
+        match $inp {
+            Ok(move v) => { move v }
+            Err(move e) => { return Err(e); }
+        }
+    )
+);
+
+}

--- a/src/rustc/middle/typeck/infer/resolve.rs
+++ b/src/rustc/middle/typeck/infer/resolve.rs
@@ -148,21 +148,21 @@ impl resolve_state {
     fn resolve_region(orig: ty::Region) -> ty::Region {
         debug!("Resolve_region(%s)", orig.to_str(self.infcx));
         match orig {
-          ty::re_var(rid) => self.resolve_region_var(rid),
+          ty::re_infer(ty::ReVar(rid)) => self.resolve_region_var(rid),
           _ => orig
         }
     }
 
     fn resolve_region_var(rid: RegionVid) -> ty::Region {
         if !self.should(resolve_rvar) {
-            return ty::re_var(rid)
+            return ty::re_infer(ty::ReVar(rid));
         }
         self.infcx.region_vars.resolve_var(rid)
     }
 
     fn assert_not_rvar(rid: RegionVid, r: ty::Region) {
         match r {
-          ty::re_var(rid2) => {
+          ty::re_infer(ty::ReVar(rid2)) => {
             self.err = Some(region_var_bound_by_region_var(rid, rid2));
           }
           _ => { }

--- a/src/rustc/middle/typeck/infer/to_str.rs
+++ b/src/rustc/middle/typeck/infer/to_str.rs
@@ -23,6 +23,12 @@ impl ty::Region: ToStr {
     }
 }
 
+impl ty::FnTy: ToStr {
+    fn to_str(cx: infer_ctxt) -> ~str {
+        ty::mk_fn(cx.tcx, self).to_str(cx)
+    }
+}
+
 impl<V:Copy ToStr> bound<V>: ToStr {
     fn to_str(cx: infer_ctxt) -> ~str {
         match self {

--- a/src/rustc/rustc.rc
+++ b/src/rustc/rustc.rc
@@ -133,7 +133,7 @@ mod middle {
             #[legacy_exports]
             mod lub;
             #[legacy_exports]
-            mod region_var_bindings;
+            mod region_inference;
             #[legacy_exports]
             mod resolve;
             #[legacy_exports]

--- a/src/rustc/util/ppaux.rs
+++ b/src/rustc/util/ppaux.rs
@@ -6,7 +6,8 @@ use middle::ty::{bound_copy, bound_const, bound_owned, bound_send,
 use middle::ty::{bound_region, br_anon, br_named, br_self, br_cap_avoid};
 use middle::ty::{ck_block, ck_box, ck_uniq, ctxt, field, method};
 use middle::ty::{mt, t, param_bound};
-use middle::ty::{re_bound, re_free, re_scope, re_var, re_static, Region};
+use middle::ty::{re_bound, re_free, re_scope, re_infer, re_static, Region};
+use middle::ty::{ReSkolemized, ReVar};
 use middle::ty::{ty_bool, ty_bot, ty_box, ty_class, ty_enum};
 use middle::ty::{ty_estr, ty_evec, ty_float, ty_fn, ty_trait, ty_int};
 use middle::ty::{ty_nil, ty_opaque_box, ty_opaque_closure_ptr, ty_param};
@@ -95,7 +96,7 @@ fn explain_region_and_span(cx: ctxt, region: ty::Region)
 
       // I believe these cases should not occur (except when debugging,
       // perhaps)
-      re_var(_) | re_bound(_) => {
+      re_infer(_) | re_bound(_) => {
         (fmt!("lifetime %?", region), None)
       }
     };
@@ -184,8 +185,9 @@ fn region_to_str(cx: ctxt, region: Region) -> ~str {
       re_scope(_) => ~"&",
       re_bound(br) => bound_region_to_str(cx, br),
       re_free(_, br) => bound_region_to_str(cx, br),
-      re_var(_)    => ~"&",
-      re_static     => ~"&static"
+      re_infer(ReSkolemized(_, br)) => bound_region_to_str(cx, br),
+      re_infer(ReVar(_)) => ~"&",
+      re_static => ~"&static"
     }
 }
 

--- a/src/test/compile-fail/regions-fn-subtyping.rs
+++ b/src/test/compile-fail/regions-fn-subtyping.rs
@@ -1,24 +1,47 @@
-// Here, `f` is a function that takes a pointer `x` and a function
-// `g`, where `g` requires its argument `y` to be in the same region
-// that `x` is in.
-fn has_same_region(f: fn(x: &a/int, g: fn(y: &a/int))) {
-    // Somewhat counterintuitively, this fails because, in
-    // `wants_two_regions`, the `g` argument needs to be able to
-    // accept any region.  That is, the type that `has_same_region`
-    // expects is *not* a subtype of the type that `wants_two_regions`
-    // expects.
-    wants_two_regions(f); //~ ERROR mismatched types
+fn of<T>() -> @fn(T) { fail; }
+fn subtype<T>(x: @fn(T)) { fail; }
+
+fn test_fn<T>(_x: &x/T, _y: &y/T, _z: &z/T) {
+    // Here, x, y, and z are free.  Other letters
+    // are bound.  Note that the arrangement
+    // subtype::<T1>(of::<T2>()) will typecheck
+    // iff T1 <: T2.
+
+    subtype::<fn(&a/T)>(
+        of::<fn(&a/T)>());
+
+    subtype::<fn(&a/T)>(
+        of::<fn(&b/T)>());
+
+    subtype::<fn(&b/T)>(
+        of::<fn(&x/T)>());
+
+    subtype::<fn(&x/T)>(
+        of::<fn(&b/T)>());  //~ ERROR mismatched types
+
+    subtype::<fn(&a/T, &b/T)>(
+        of::<fn(&a/T, &a/T)>());
+
+    subtype::<fn(&a/T, &a/T)>(
+        of::<fn(&a/T, &b/T)>()); //~ ERROR mismatched types
+
+    subtype::<fn(&a/T, &b/T)>(
+        of::<fn(&x/T, &y/T)>());
+
+    subtype::<fn(&x/T, &y/T)>(
+        of::<fn(&a/T, &b/T)>()); //~ ERROR mismatched types
+
+    subtype::<fn(&x/T) -> @fn(&a/T)>(
+        of::<fn(&x/T) -> @fn(&a/T)>());
+
+    subtype::<fn(&a/T) -> @fn(&a/T)>(
+        of::<fn(&a/T) -> @fn(&b/T)>()); //~ ERROR mismatched types
+
+    subtype::<fn(&a/T) -> @fn(&a/T)>(
+        of::<fn(&x/T) -> @fn(&b/T)>()); //~ ERROR mismatched types
+
+    subtype::<fn(&a/T) -> @fn(&b/T)>(
+        of::<fn(&a/T) -> @fn(&a/T)>());
 }
 
-fn wants_two_regions(_f: fn(x: &int, g: fn(y: &int))) {
-    // Suppose we were to write code here that passed some arbitrary
-    // &int and some arbitrary fn(&int) to whatever's passed in as _f.
-    // This would be fine as far as the type annotation on the formal
-    // parameter _f goes, but if _f were `f` we'd be in trouble since
-    // `f` can't handle those arguments.
-}
-
-fn main() {
-}
-
-
+fn main() {}

--- a/src/test/run-pass/string-self-append.rs
+++ b/src/test/run-pass/string-self-append.rs
@@ -8,7 +8,7 @@ fn main() {
     while i > 0 {
         log(error, str::len(a));
         assert (str::len(a) == expected_len);
-        a += a;
+        a = a + a; // FIXME(#3387)---can't write a += a
         i -= 1;
         expected_len *= 2u;
     }

--- a/src/test/run-pass/vec-ivec-deadlock.rs
+++ b/src/test/run-pass/vec-ivec-deadlock.rs
@@ -1,1 +1,5 @@
-fn main() { let a = ~[1, 2, 3, 4, 5]; let mut b = ~[a, a]; b += b; }
+fn main() {
+    let a = ~[1, 2, 3, 4, 5];
+    let mut b = ~[a, a];
+    b = b + b; // FIXME(#3387)---can't write b += b
+}

--- a/src/test/run-pass/vec-self-append.rs
+++ b/src/test/run-pass/vec-self-append.rs
@@ -3,7 +3,7 @@ extern mod std;
 fn test_heap_to_heap() {
     // a spills onto the heap
     let mut a = ~[0, 1, 2, 3, 4];
-    a += a;
+    a = a + a; // FIXME(#3387)---can't write a += a
     assert (vec::len(a) == 10u);
     assert (a[0] == 0);
     assert (a[1] == 1);
@@ -21,7 +21,7 @@ fn test_stack_to_heap() {
     // a is entirely on the stack
     let mut a = ~[0, 1, 2];
     // a spills to the heap
-    a += a;
+    a = a + a; // FIXME(#3387)---can't write a += a
     assert (vec::len(a) == 6u);
     assert (a[0] == 0);
     assert (a[1] == 1);
@@ -39,7 +39,7 @@ fn test_loop() {
     while i > 0 {
         log(error, vec::len(a));
         assert (vec::len(a) == expected_len);
-        a += a;
+        a = a + a; // FIXME(#3387)---can't write a += a
         i -= 1;
         expected_len *= 2u;
     }


### PR DESCRIPTION
Requires only that the impl method signature be a subtype of the trait method signature.  Not a complete fix for #2263 but it's a step in the right direction.
