### PR TITLE
Partial fix for #2687---impl method must only be subtype of trait method...

### DIFF
--- a/src/test/compile-fail/trait-impl-method-mismatch.rs
+++ b/src/test/compile-fail/trait-impl-method-mismatch.rs
@@ -1,0 +1,25 @@
+trait Mumbo {
+    pure fn jumbo(&self, x: @uint) -> uint;
+    fn jambo(&self, x: @const uint) -> uint;
+    fn jbmbo(&self) -> @uint;
+}
+
+impl uint: Mumbo {
+    // Cannot have a larger effect than the trait:
+    fn jumbo(&self, x: @uint) { *self + *x; }
+    //~^ ERROR expected pure fn but found impure fn
+
+    // Cannot accept a narrower range of parameters:
+    fn jambo(&self, x: @uint) { *self + *x; }
+    //~^ ERROR values differ in mutability
+
+    // Cannot return a wider range of values:
+    fn jbmbo(&self) -> @const uint { @const 0 }
+    //~^ ERROR values differ in mutability
+}
+
+fn main() {}
+
+
+
+

--- a/src/test/compile-fail/trait-impl-subtype.rs
+++ b/src/test/compile-fail/trait-impl-subtype.rs
@@ -1,0 +1,21 @@
+trait Mumbo {
+    fn jumbo(&self, x: @uint) -> uint;
+}
+
+impl uint: Mumbo {
+    // Note: this method def is ok, it is more accepting and
+    // less effecting than the trait method:
+    pure fn jumbo(&self, x: @const uint) -> uint { *self + *x }
+}
+
+fn main() {
+    let a = 3u;
+    let b = a.jumbo(@mut 6);
+
+    let x = @a as @Mumbo;
+    let y = x.jumbo(@mut 6); //~ ERROR values differ in mutability
+    let z = x.jumbo(@6);
+}
+
+
+


### PR DESCRIPTION
..., not exact match.  Not a complete fix, but it's a start.  r? @pcwalton
