### PR TITLE
Issue 1458

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -744,7 +744,10 @@ enum expr_ {
     expr_struct(@path, ~[field], Option<@expr>),
 
     // A vector literal constructed from one repeated element.
-    expr_repeat(@expr /* element */, @expr /* count */, mutability)
+    expr_repeat(@expr /* element */, @expr /* count */, mutability),
+
+    // No-op: used solely so we can pretty-print faithfully
+    expr_paren(@expr)
 }
 
 #[auto_serialize]

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -494,7 +494,8 @@ fn noop_fold_expr(e: expr_, fld: ast_fold) -> expr_ {
             expr_struct(fld.fold_path(path),
                         vec::map(fields, |x| fold_field(*x)),
                         option::map(&maybe_expr, |x| fld.fold_expr(*x)))
-          }
+          },
+          expr_paren(ex) => expr_paren(fld.fold_expr(ex))
         }
 }
 

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -36,39 +36,3 @@ fn stmt_ends_with_semi(stmt: ast::stmt) -> bool {
       }
     }
 }
-
-fn need_parens(expr: @ast::expr, outer_prec: uint) -> bool {
-    match expr.node {
-      ast::expr_binary(op, _, _) => operator_prec(op) < outer_prec,
-      ast::expr_cast(_, _) => parse::prec::as_prec < outer_prec,
-      // This may be too conservative in some cases
-      ast::expr_assign(_, _) => true,
-      ast::expr_swap(_, _) => true,
-      ast::expr_assign_op(_, _, _) => true,
-      ast::expr_ret(_) => true,
-      ast::expr_assert(_) => true,
-      ast::expr_log(_, _, _) => true,
-      _ => !parse::classify::expr_requires_semi_to_be_stmt(expr)
-    }
-}
-
-fn ends_in_lit_int(ex: @ast::expr) -> bool {
-    match ex.node {
-      ast::expr_lit(node) => match node {
-        @{node: ast::lit_int(_, ast::ty_i), _}
-        | @{node: ast::lit_int_unsuffixed(_), _} => true,
-        _ => false
-      },
-      ast::expr_binary(_, _, sub) | ast::expr_unary(_, sub) |
-      ast::expr_copy(sub) | ast::expr_assign(_, sub) |
-      ast::expr_assign_op(_, _, sub) | ast::expr_swap(_, sub) |
-      ast::expr_log(_, _, sub) | ast::expr_assert(sub) => {
-        ends_in_lit_int(sub)
-      }
-      ast::expr_fail(osub) | ast::expr_ret(osub) => match osub {
-        Some(ex) => ends_in_lit_int(ex),
-        _ => false
-      },
-      _ => false
-    }
-}

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -462,6 +462,7 @@ fn visit_expr<E>(ex: @expr, e: E, v: vt<E>) {
         v.visit_expr(x, e, v);
       }
       expr_mac(mac) => visit_mac(mac, e, v),
+      expr_paren(x) => v.visit_expr(x, e, v),
     }
     v.visit_expr_post(ex, e, v);
 }

--- a/src/rustc/middle/check_const.rs
+++ b/src/rustc/middle/check_const.rs
@@ -98,6 +98,8 @@ fn check_expr(sess: Session, def_map: resolve::DefMap,
               }
             }
           }
+          expr_paren(e) => { check_expr(sess, def_map, method_map,
+                                         tcx, e, is_const, v); }
           expr_vstore(_, expr_vstore_slice) |
           expr_vstore(_, expr_vstore_fixed(_)) |
           expr_vec(_, m_imm) |

--- a/src/rustc/middle/const_eval.rs
+++ b/src/rustc/middle/const_eval.rs
@@ -72,7 +72,8 @@ fn classify(e: @expr,
               }
 
               ast::expr_copy(inner) |
-              ast::expr_unary(_, inner) => {
+              ast::expr_unary(_, inner) |
+              ast::expr_paren(inner) => {
                 classify(inner, def_map, tcx)
               }
 
@@ -376,6 +377,7 @@ fn eval_const_expr_partial(tcx: middle::ty::ctxt, e: @expr)
       expr_lit(lit) => Ok(lit_to_const(lit)),
       // If we have a vstore, just keep going; it has to be a string
       expr_vstore(e, _) => eval_const_expr_partial(tcx, e),
+      expr_paren(e)     => eval_const_expr_partial(tcx, e),
       _ => Err(~"Unsupported constant expr")
     }
 }

--- a/src/rustc/middle/liveness.rs
+++ b/src/rustc/middle/liveness.rs
@@ -554,7 +554,7 @@ fn visit_expr(expr: @expr, &&self: @IrMaps, vt: vt<@IrMaps>) {
       expr_break(_) | expr_again(_) | expr_lit(_) | expr_ret(*) |
       expr_block(*) | expr_unary_move(*) | expr_assign(*) |
       expr_swap(*) | expr_assign_op(*) | expr_mac(*) | expr_struct(*) |
-      expr_repeat(*) => {
+      expr_repeat(*) | expr_paren(*) => {
           visit::visit_expr(expr, self, vt);
       }
     }
@@ -1253,7 +1253,8 @@ impl Liveness {
           expr_loop_body(e) |
           expr_do_body(e) |
           expr_cast(e, _) |
-          expr_unary(_, e) => {
+          expr_unary(_, e) |
+          expr_paren(e) => {
             self.propagate_through_expr(e, succ)
           }
 
@@ -1550,7 +1551,7 @@ fn check_expr(expr: @expr, &&self: @Liveness, vt: vt<@Liveness>) {
       expr_cast(*) | expr_unary(*) | expr_fail(*) |
       expr_ret(*) | expr_break(*) | expr_again(*) | expr_lit(_) |
       expr_block(*) | expr_swap(*) | expr_mac(*) | expr_addr_of(*) |
-      expr_struct(*) | expr_repeat(*) => {
+      expr_struct(*) | expr_repeat(*) | expr_paren(*) => {
         visit::visit_expr(expr, self, vt);
       }
     }

--- a/src/rustc/middle/mem_categorization.rs
+++ b/src/rustc/middle/mem_categorization.rs
@@ -481,6 +481,8 @@ impl &mem_categorization_ctxt {
             self.cat_def(expr.id, expr.span, expr_ty, def)
           }
 
+          ast::expr_paren(e) => self.cat_expr_unadjusted(e),
+
           ast::expr_addr_of(*) | ast::expr_call(*) |
           ast::expr_swap(*) | ast::expr_assign(*) |
           ast::expr_assign_op(*) | ast::expr_fn(*) | ast::expr_fn_block(*) |

--- a/src/rustc/middle/trans/consts.rs
+++ b/src/rustc/middle/trans/consts.rs
@@ -361,6 +361,7 @@ fn const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
           _ => cx.sess.span_bug(e.span, ~"expected to find a const def")
         }
       }
+        ast::expr_paren(e) => { return const_expr(cx, e); }
       _ => cx.sess.span_bug(e.span,
             ~"bad constant expression type in consts::const_expr")
     };

--- a/src/rustc/middle/trans/type_use.rs
+++ b/src/rustc/middle/trans/type_use.rs
@@ -267,6 +267,7 @@ fn mark_for_expr(cx: ctx, e: @expr) {
               }
           }
       }
+      expr_paren(e) => mark_for_expr(cx, e),
       expr_match(*) | expr_block(_) | expr_if(*) |
       expr_while(*) | expr_fail(_) | expr_break(_) | expr_again(_) |
       expr_unary(_, _) | expr_lit(_) | expr_assert(_) |

--- a/src/rustc/middle/ty.rs
+++ b/src/rustc/middle/ty.rs
@@ -2872,24 +2872,6 @@ fn is_pred_ty(fty: t) -> bool {
     is_fn_ty(fty) && type_is_bool(ty_fn_ret(fty))
 }
 
-/*
-fn ty_var_id(typ: t) -> TyVid {
-    match get(typ).sty {
-      ty_infer(TyVar(vid)) => return vid,
-      _ => { error!("ty_var_id called on non-var ty"); fail; }
-    }
-}
-
-fn int_var_id(typ: t) -> IntVid {
-    match get(typ).sty {
-      ty_infer(IntVar(vid)) => return vid,
-      _ => { error!("ty_var_integral_id called on ty other than \
-                  ty_var_integral");
-         fail; }
-    }
-}
-*/
-
 // Type accessors for AST nodes
 fn block_ty(cx: ctxt, b: &ast::blk) -> t {
     return node_id_to_type(cx, b.node.id);
@@ -3093,6 +3075,8 @@ fn expr_kind(tcx: ctxt,
         ast::expr_vstore(_, ast::expr_vstore_uniq) => {
             RvalueDatumExpr
         }
+
+        ast::expr_paren(e) => expr_kind(tcx, method_map, e),
 
         ast::expr_mac(*) => {
             tcx.sess.span_bug(

--- a/src/rustc/middle/typeck/check/alt.rs
+++ b/src/rustc/middle/typeck/check/alt.rs
@@ -132,6 +132,10 @@ fn check_pat_variant(pcx: pat_ctxt, pat: @ast::pat, path: @ast::path,
     instantiate_path(pcx.fcx, path, enum_tpt, pat.span, pat.id,
                      pcx.block_region);
 
+    // structure_of requires type variables to be resolved.
+    // So when we pass in <expected>, it's an error if it
+    // contains type variables.
+
     // Take the enum type params out of `expected`.
     match structure_of(pcx.fcx, pat.span, expected) {
       ty::ty_enum(_, ref expected_substs) => {
@@ -151,7 +155,7 @@ fn check_pat_variant(pcx: pat_ctxt, pat: @ast::pat, path: @ast::path,
             None => arg_len,
             Some(ps) => ps.len()
         };
-        if arg_len > 0u {
+        if arg_len > 0 {
             // N-ary variant.
             if arg_len != subpats_len {
                 let s = fmt!("this pattern has %u field%s, but the \
@@ -168,7 +172,7 @@ fn check_pat_variant(pcx: pat_ctxt, pat: @ast::pat, path: @ast::path,
                   check_pat(pcx, *subpat, *arg_ty);
                 }
             };
-        } else if subpats_len > 0u {
+        } else if subpats_len > 0 {
             tcx.sess.span_fatal
                 (pat.span, fmt!("this pattern has %u field%s, \
                                  but the corresponding variant has no fields",

--- a/src/rustc/middle/typeck/check/vtable.rs
+++ b/src/rustc/middle/typeck/check/vtable.rs
@@ -486,6 +486,11 @@ fn early_resolve_expr(ex: @ast::expr, &&fcx: @fn_ctxt, is_early: bool) {
           _ => ()
         }
       }
+
+      ast::expr_paren(e) => {
+          early_resolve_expr(e, fcx, is_early);
+      }
+
       // Must resolve bounds on methods with bounded params
       ast::expr_field(*) | ast::expr_binary(*) |
       ast::expr_unary(*) | ast::expr_assign_op(*) |

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 // Microbenchmarks for various functions in core and std
 
 extern mod std;

--- a/src/test/bench/msgsend-pipes-shared.rs
+++ b/src/test/bench/msgsend-pipes-shared.rs
@@ -8,8 +8,6 @@
 // different scalability characteristics compared to the select
 // version.
 
-// xfail-pretty
-
 #[legacy_modes];
 
 extern mod std;

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -4,8 +4,6 @@
 //
 // I *think* it's the same, more or less.
 
-// xfail-pretty
-
 #[legacy_modes];
 
 extern mod std;

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -5,8 +5,6 @@
 
 // This also serves as a pipes test, because ARCs are implemented with pipes.
 
-// xfail-pretty
-
 extern mod std;
 use std::time;
 use std::arc;

--- a/src/test/bench/msgsend-ring-pipes.rs
+++ b/src/test/bench/msgsend-ring-pipes.rs
@@ -6,8 +6,6 @@
 
 // This version uses automatically compiled channel contracts.
 
-// xfail-pretty
-
 extern mod std;
 use std::time;
 use std::future;

--- a/src/test/bench/msgsend-ring-rw-arcs.rs
+++ b/src/test/bench/msgsend-ring-rw-arcs.rs
@@ -5,8 +5,6 @@
 
 // This also serves as a pipes test, because ARCs are implemented with pipes.
 
-// xfail-pretty
-
 extern mod std;
 use std::time;
 use std::arc;

--- a/src/test/bench/pingpong.rs
+++ b/src/test/bench/pingpong.rs
@@ -1,7 +1,5 @@
 // Compare bounded and unbounded protocol performance.
 
-// xfail-pretty
-
 extern mod std;
 
 use pipes::{spawn_service, recv};

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -1,5 +1,4 @@
 // -*- rust -*-
-// xfail-pretty
 
 /*
   A parallel version of fibonacci numbers.

--- a/src/test/compile-fail/qquote-1.rs
+++ b/src/test/compile-fail/qquote-1.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 
 extern mod std;
 extern mod syntax;

--- a/src/test/compile-fail/qquote-2.rs
+++ b/src/test/compile-fail/qquote-2.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 
 extern mod std;
 use syntax;

--- a/src/test/compile-fail/trait-cast.rs
+++ b/src/test/compile-fail/trait-cast.rs
@@ -3,6 +3,9 @@ trait foo<T> { }
 fn bar(x: foo<uint>) -> foo<int> {
     return (x as foo::<int>);
     //~^ ERROR mismatched types: expected `@foo<int>` but found `@foo<uint>`
+    //~^^ ERROR mismatched types: expected `@foo<int>` but found `@foo<uint>`
+    // This is unfortunate -- new handling of parens means the error message
+    // gets printed twice
 }
 
 fn main() {}

--- a/src/test/run-fail/zip-different-lengths.rs
+++ b/src/test/run-fail/zip-different-lengths.rs
@@ -8,7 +8,7 @@ fn enum_chars(start: u8, end: u8) -> ~[char] {
     assert start < end;
     let mut i = start;
     let mut r = ~[];
-    while i <= end { r.push(i as char); i += 1u as u8; }
+    while i <= end { r.push(i as char); i += 1 as u8; }
     return r;
 }
 
@@ -16,16 +16,16 @@ fn enum_uints(start: uint, end: uint) -> ~[uint] {
     assert start < end;
     let mut i = start;
     let mut r = ~[];
-    while i <= end { r.push(i); i += 1u; }
+    while i <= end { r.push(i); i += 1; }
     return r;
 }
 
 fn main() {
-    let a = 'a' as u8, j = 'j' as u8, k = 1u, l = 9u;
+    let a = 'a' as u8, j = 'j' as u8, k = 1, l = 9;
     let chars = enum_chars(a, j);
     let ints = enum_uints(k, l);
 
-    assert (same_length(chars, ints));
+    assert same_length(chars, ints);
     let ps = zip(chars, ints);
     fail ~"the impossible happened";
 }

--- a/src/test/run-pass/fat-arrow-alt.rs
+++ b/src/test/run-pass/fat-arrow-alt.rs
@@ -1,5 +1,4 @@
 // -*- rust -*-
-// xfail-pretty
 
 enum color {
     red,

--- a/src/test/run-pass/html-literals.rs
+++ b/src/test/run-pass/html-literals.rs
@@ -1,6 +1,5 @@
 // A test of the macro system. Can we do HTML literals?
 
-// xfail-pretty
 
 /*
 

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -1,5 +1,4 @@
 // tjc: I don't know why
-// xfail-pretty
 mod pipes {
     #[legacy_exports];
     use cast::{forget, transmute};

--- a/src/test/run-pass/pipe-bank-proto.rs
+++ b/src/test/run-pass/pipe-bank-proto.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 
 // An example of the bank protocol from eholk's blog post.
 //

--- a/src/test/run-pass/pipe-detect-term.rs
+++ b/src/test/run-pass/pipe-detect-term.rs
@@ -1,6 +1,5 @@
 // Make sure that we can detect when one end of the pipe is closed.
 
-// xfail-pretty
 // xfail-win32
 
 extern mod std;

--- a/src/test/run-pass/pipe-peek.rs
+++ b/src/test/run-pass/pipe-peek.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 
 extern mod std;
 use std::timer::sleep;

--- a/src/test/run-pass/pipe-pingpong-bounded.rs
+++ b/src/test/run-pass/pipe-pingpong-bounded.rs
@@ -2,7 +2,6 @@
 // experiment with what code the compiler should generate for bounded
 // protocols.
 
-// xfail-pretty
 
 // This was generated initially by the pipe compiler, but it's been
 // modified in hopefully straightforward ways.

--- a/src/test/run-pass/pipe-pingpong-proto.rs
+++ b/src/test/run-pass/pipe-pingpong-proto.rs
@@ -1,6 +1,5 @@
 // An example to make sure the protocol parsing syntax extension works.
 
-// xfail-pretty
 
 proto! pingpong (
     ping:send {

--- a/src/test/run-pass/pipe-presentation-examples.rs
+++ b/src/test/run-pass/pipe-presentation-examples.rs
@@ -3,7 +3,6 @@
 // Code is easier to write in emacs, and it's good to be sure all the
 // code samples compile (or not) as they should.
 
-// xfail-pretty
 
 use double_buffer::client::*;
 use double_buffer::give_buffer;

--- a/src/test/run-pass/pipe-sleep.rs
+++ b/src/test/run-pass/pipe-sleep.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 
 extern mod std;
 use std::timer::sleep;

--- a/src/test/run-pass/rec-align-u32.rs
+++ b/src/test/run-pass/rec-align-u32.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 // Issue #2303
 
 #[abi = "rust-intrinsic"]

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 // Issue #2303
 
 #[abi = "rust-intrinsic"]

--- a/src/test/run-pass/reexport-star.rs
+++ b/src/test/run-pass/reexport-star.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 // FIXME #3654
 
 mod a {

--- a/src/test/run-pass/syntax-extension-source-utils.rs
+++ b/src/test/run-pass/syntax-extension-source-utils.rs
@@ -11,10 +11,10 @@ mod m1 {
 }
 
 fn main() {
-    assert(line!() == 14u);
-    assert(col!() == 11u);
+    assert(line!() == 14);
+    assert(col!() == 11);
     assert(file!().ends_with(~"syntax-extension-source-utils.rs"));
-    assert(stringify!((2*3) + 5) == ~"2 * 3 + 5");
+    assert(stringify!((2*3) + 5) == ~"(2 * 3) + 5");
     assert(include!("syntax-extension-source-utils-files/includeme.fragment")
            == ~"victory robot 6");
 

--- a/src/test/run-pass/test-ignore-cfg.rs
+++ b/src/test/run-pass/test-ignore-cfg.rs
@@ -1,6 +1,5 @@
 // compile-flags: --test --cfg ignorecfg
 // xfail-fast
-// xfail-pretty
 
 extern mod std;
 

--- a/src/test/run-pass/unreachable-code-1.rs
+++ b/src/test/run-pass/unreachable-code-1.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 
 fn id(x: bool) -> bool { x }
 

--- a/src/test/run-pass/unreachable-code.rs
+++ b/src/test/run-pass/unreachable-code.rs
@@ -1,4 +1,3 @@
-// xfail-pretty
 
 fn id(x: bool) -> bool { x }
 


### PR DESCRIPTION
This is a pull request to implement @graydon 's suggestion, way back in #1458, of preserving parenthesization in the AST.

I have the feeling that WRT trans and typeck, there could be fewer explicit special cases for `expr_paren`. This has something to do with the `adjustments` table in the type context, and I don't entirely understand how it works. At any rate, this passes tests. Suggestions welcome.

Unfortunately, the test from #1458 still doesn't work, for apparently-separate reasons.

r? @graydon
