### PR TITLE
Removing iter::TimesIx

### DIFF
--- a/src/libcore/int-template.rs
+++ b/src/libcore/int-template.rs
@@ -98,23 +98,6 @@ impl T: iter::Times {
     }
 }
 
-impl T: iter::TimesIx {
-    #[inline(always)]
-    /// Like `times`, but provides an index
-    pure fn timesi(it: fn(uint) -> bool) {
-        let slf = self as uint;
-        if slf < 0u {
-            fail fmt!("The .timesi method expects a nonnegative number, \
-                       but found %?", self);
-        }
-        let mut i = 0u;
-        while i < slf {
-            if !it(i) { break }
-            i += 1u;
-        }
-    }
-}
-
 /**
  * Parse a buffer of bytes
  *

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -34,10 +34,6 @@ pub trait Times {
     pure fn times(it: fn() -> bool);
 }
 
-pub trait TimesIx{
-    pure fn timesi(it: fn(uint) -> bool);
-}
-
 pub trait CopyableIter<A:Copy> {
     pure fn filter_to_vec(pred: fn(a: A) -> bool) -> ~[A];
     pure fn map_to_vec<B>(op: fn(v: A) -> B) -> ~[B];

--- a/src/libcore/uint-template.rs
+++ b/src/libcore/uint-template.rs
@@ -88,19 +88,6 @@ impl T: iter::Times {
     }
 }
 
-impl T: iter::TimesIx {
-    #[inline(always)]
-    /// Like `times`, but with an index, `eachi`-style.
-    pure fn timesi(it: fn(uint) -> bool) {
-        let slf = self as uint;
-        let mut i = 0u;
-        while i < slf {
-            if !it(i) { break }
-            i += 1u;
-        }
-    }
-}
-
 /**
  * Parse a buffer of bytes
  *


### PR DESCRIPTION
from uint and int templating
