### PR TITLE
Unused move crash fix

### DIFF
--- a/src/rustc/middle/trans/datum.rs
+++ b/src/rustc/middle/trans/datum.rs
@@ -542,6 +542,25 @@ impl Datum {
         };
     }
 
+    fn dropnzero_val(bcx: block) -> block {
+        if !ty::type_needs_drop(bcx.tcx(), self.ty) {
+            return bcx;
+        }
+
+        return match self.mode {
+            ByRef => {
+                glue::drop_ty(bcx, self.val, self.ty);
+                zero_mem(bcx, self.val, self.ty);
+                return bcx;
+            }
+            ByValue => {
+                glue::drop_ty_immediate(bcx, self.val, self.ty);
+                zero_mem(bcx, self.val, self.ty);
+                return bcx;
+            }
+        };
+    }
+
     fn box_body(bcx: block) -> Datum {
         /*!
          *

--- a/src/rustc/middle/trans/datum.rs
+++ b/src/rustc/middle/trans/datum.rs
@@ -542,25 +542,6 @@ impl Datum {
         };
     }
 
-    fn dropnzero_val(bcx: block) -> block {
-        if !ty::type_needs_drop(bcx.tcx(), self.ty) {
-            return bcx;
-        }
-
-        return match self.mode {
-            ByRef => {
-                glue::drop_ty(bcx, self.val, self.ty);
-                zero_mem(bcx, self.val, self.ty);
-                return bcx;
-            }
-            ByValue => {
-                glue::drop_ty_immediate(bcx, self.val, self.ty);
-                zero_mem(bcx, self.val, self.ty);
-                return bcx;
-            }
-        };
-    }
-
     fn box_body(bcx: block) -> Datum {
         /*!
          *

--- a/src/rustc/middle/trans/expr.rs
+++ b/src/rustc/middle/trans/expr.rs
@@ -573,7 +573,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
             if bcx.expr_is_lval(a) {
                 let datum = unpack_datum!(bcx, trans_to_datum(bcx, a));
                 return match dest {
-                    Ignore => datum.drop_val(bcx),
+                    Ignore => datum.dropnzero_val(bcx),
                     SaveIn(addr) => datum.move_to(bcx, INIT, addr)
                 };
             } else {

--- a/src/rustc/middle/trans/expr.rs
+++ b/src/rustc/middle/trans/expr.rs
@@ -159,6 +159,12 @@ impl Dest : cmp::Eq {
     pure fn ne(other: &Dest) -> bool { !self.eq(other) }
 }
 
+fn drop_and_cancel_clean(dat: Datum, bcx: block) -> block {
+    let bcx = dat.drop_val(bcx);
+    dat.cancel_clean(bcx);
+    return bcx;
+}
+
 fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
     debug!("trans_to_datum(expr=%s)", bcx.expr_to_str(expr));
 
@@ -573,7 +579,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
             if bcx.expr_is_lval(a) {
                 let datum = unpack_datum!(bcx, trans_to_datum(bcx, a));
                 return match dest {
-                    Ignore => datum.dropnzero_val(bcx),
+                    Ignore => drop_and_cancel_clean(datum, bcx),
                     SaveIn(addr) => datum.move_to(bcx, INIT, addr)
                 };
             } else {

--- a/src/test/run-pass/unused-move.rs
+++ b/src/test/run-pass/unused-move.rs
@@ -1,0 +1,9 @@
+// Issue #3878
+// Issue Name: Unused move causes a crash
+// Abstract: zero-fill to block after drop
+
+fn main()
+{
+    let y = ~1;
+    move y;
+}


### PR DESCRIPTION
- dropnzero_val fn added
- zero-mem for not needed drop situation placed in Ignore

Tested / referenced for #3878
