### PR TITLE
Cleanup how we handle proto in types, remove unsound subtyping

### DIFF
--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -524,15 +524,19 @@ fn noop_fold_ty(t: ty_, fld: ast_fold) -> ty_ {
       ty_ptr(mt) => ty_ptr(fold_mt(mt, fld)),
       ty_rptr(region, mt) => ty_rptr(region, fold_mt(mt, fld)),
       ty_rec(fields) => ty_rec(vec::map(fields, |f| fold_field(*f, fld))),
-      ty_fn(proto, purity, onceness, bounds, decl) =>
-        ty_fn(proto,
-              purity,
-              onceness,
-              @vec::map(*bounds, |x| fold_ty_param_bound(*x, fld)),
-              fold_fn_decl(decl, fld)),
+      ty_fn(f) =>
+        ty_fn(@TyFn {
+            proto: f.proto,
+            purity: f.purity,
+            region: f.region,
+            onceness: f.onceness,
+            bounds: @vec::map(*f.bounds, |x| fold_ty_param_bound(*x, fld)),
+            decl: fold_fn_decl(f.decl, fld)
+        }),
       ty_tup(tys) => ty_tup(vec::map(tys, |ty| fld.fold_ty(*ty))),
       ty_path(path, id) => ty_path(fld.fold_path(path), fld.new_id(id)),
-      ty_fixed_length(t, vs) => ty_fixed_length(fld.fold_ty(t), vs),
+      ty_fixed_length_vec(mt, vs) =>
+        ty_fixed_length_vec(fold_mt(mt, fld), vs),
       ty_mac(mac) => ty_mac(fold_mac(mac))
     }
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -50,8 +50,8 @@ use ast::{_mod, add, arg, arm, attribute,
              match_tok, method, mode, module_ns, mt, mul, mutability,
              named_field, neg, noreturn, not, pat, pat_box, pat_enum,
              pat_ident, pat_lit, pat_range, pat_rec, pat_region, pat_struct,
-             pat_tup, pat_uniq, pat_wild, path, private, proto, proto_bare,
-             proto_block, proto_box, proto_uniq, provided, public, pure_fn,
+             pat_tup, pat_uniq, pat_wild, path, private, Proto, ProtoBare,
+             ProtoBorrowed, ProtoBox, ProtoUniq, provided, public, pure_fn,
              purity, re_static, re_self, re_anon, re_named, region,
              rem, required, ret_style,
              return_val, self_ty, shl, shr, stmt, stmt_decl, stmt_expr,
@@ -61,14 +61,14 @@ use ast::{_mod, add, arg, arm, attribute,
              tt_tok, tt_nonterminal, tuple_variant_kind, Ty, ty_, ty_bot,
              ty_box, ty_field, ty_fn, ty_infer, ty_mac, ty_method, ty_nil,
              ty_param, ty_param_bound, ty_path, ty_ptr, ty_rec, ty_rptr,
-             ty_tup, ty_u32, ty_uniq, ty_vec, ty_fixed_length, type_value_ns,
-             uniq, unnamed_field, unsafe_blk, unsafe_fn,
+             ty_tup, ty_u32, ty_uniq, ty_vec, ty_fixed_length_vec,
+             type_value_ns, uniq, unnamed_field, unsafe_blk, unsafe_fn,
              variant, view_item, view_item_, view_item_export,
              view_item_import, view_item_use, view_path, view_path_glob,
              view_path_list, view_path_simple, visibility, vstore, vstore_box,
              vstore_fixed, vstore_slice, vstore_uniq,
              expr_vstore_fixed, expr_vstore_slice, expr_vstore_box,
-             expr_vstore_uniq};
+             expr_vstore_uniq, TyFn, Onceness, Once, Many};
 
 export file_type;
 export Parser;
@@ -287,29 +287,89 @@ impl Parser {
 
     pure fn id_to_str(id: ident) -> @~str { self.sess.interner.get(id) }
 
-    fn parse_ty_fn(purity: ast::purity, onceness: ast::Onceness) -> ty_ {
-        let proto, bounds;
+    fn token_is_fn_keyword(+tok: token::Token) -> bool {
+        self.token_is_keyword(~"pure", tok) ||
+            self.token_is_keyword(~"unsafe", tok) ||
+            self.token_is_keyword(~"once", tok) ||
+            self.token_is_keyword(~"fn", tok) ||
+            self.token_is_keyword(~"extern", tok)
+    }
+
+    fn parse_ty_fn(pre_proto: Option<ast::Proto>,
+                       pre_region_name: Option<ident>) -> ty_
+    {
+        /*
+
+        (&|~|@) [r/] [pure|unsafe] [once] fn [:K] (S) -> T
+        ^~~~~~^ ^~~^ ^~~~~~~~~~~~^ ^~~~~^    ^~~^ ^~^    ^
+           |     |     |             |        |    |     |
+           |     |     |             |        |    |   Return type
+           |     |     |             |        |  Argument types
+           |     |     |             |    Environment bounds
+           |     |     |          Once-ness (a.k.a., affine)
+           |     |   Purity
+           | Lifetime bound
+        Allocation type
+
+        */
+
+        // At this point, the allocation type and lifetime bound have been
+        // parsed.
+
+        let purity = parse_purity(&self);
+        let onceness = parse_onceness(&self);
+
+        let bounds, post_proto;
         if self.eat_keyword(~"extern") {
             self.expect_keyword(~"fn");
-            proto = ast::proto_bare;
+            post_proto = Some(ast::ProtoBare);
             bounds = @~[];
         } else {
             self.expect_keyword(~"fn");
-            proto = self.parse_fn_ty_proto();
+            post_proto = self.parse_fn_ty_proto();
             bounds = self.parse_optional_ty_param_bounds();
         };
-        ty_fn(proto, purity, onceness, bounds, self.parse_ty_fn_decl())
+
+        let proto = match (pre_proto, post_proto) {
+            (None, None) => ast::ProtoBorrowed,
+            (Some(p), None) | (None, Some(p)) => p,
+            (Some(_), Some(_)) => {
+                self.fatal(~"Cannot combine prefix and postfix \
+                             syntax for closure kind; note that \
+                             postfix syntax is obsolete");
+            }
+        };
+
+        let region = if pre_region_name.is_some() {
+            Some(self.region_from_name(pre_region_name))
+        } else {
+            None
+        };
+
+        return ty_fn(@TyFn {
+            proto: proto,
+            region: region,
+            purity: purity,
+            onceness: onceness,
+            bounds: bounds,
+            decl: self.parse_ty_fn_decl()
+        });
+
+        fn parse_purity(self: &Parser) -> purity {
+            if self.eat_keyword(~"pure") {
+                return pure_fn;
+            } else if self.eat_keyword(~"unsafe") {
+                return unsafe_fn;
+            } else {
+                return impure_fn;
+            }
+        }
+
+        fn parse_onceness(self: &Parser) -> Onceness {
+            if self.eat_keyword(~"once") {Once} else {Many}
+        }
     }
 
-    fn parse_ty_fn_with_onceness(purity: ast::purity) -> ty_ {
-        let onceness = self.parse_optional_onceness();
-        self.parse_ty_fn(purity, onceness)
-    }
-
-    fn parse_ty_fn_with_purity_and_onceness() -> ty_ {
-        let purity = self.parse_optional_purity();
-        self.parse_ty_fn_with_onceness(purity)
-    }
 
     fn parse_ty_fn_decl() -> fn_decl {
         let inputs = do self.parse_unspanned_seq(
@@ -449,23 +509,6 @@ impl Parser {
         }
     }
 
-    // Parses something like "&x/" (note the trailing slash)
-    fn parse_region_with_sep() -> @region {
-        let name =
-            match copy self.token {
-              token::IDENT(sid, _) => {
-                if self.look_ahead(1u) == token::BINOP(token::SLASH) {
-                    self.bump(); self.bump();
-                    Some(sid)
-                } else {
-                    None
-                }
-              }
-              _ => { None }
-            };
-        self.region_from_name(name)
-    }
-
     fn parse_ty(colons_before_params: bool) -> @Ty {
         maybe_whole!(self, nt_ty);
 
@@ -498,10 +541,10 @@ impl Parser {
             }
         } else if self.token == token::AT {
             self.bump();
-            ty_box(self.parse_mt())
+            self.parse_box_or_uniq_pointee(ast::ProtoBox, ty_box)
         } else if self.token == token::TILDE {
             self.bump();
-            ty_uniq(self.parse_mt())
+            self.parse_box_or_uniq_pointee(ast::ProtoUniq, ty_uniq)
         } else if self.token == token::BINOP(token::STAR) {
             self.bump();
             ty_ptr(self.parse_mt())
@@ -516,51 +559,77 @@ impl Parser {
             ty_rec(elems)
         } else if self.token == token::LBRACKET {
             self.expect(token::LBRACKET);
-            let mut t = ty_vec(self.parse_mt());
+            let mt = self.parse_mt();
 
             // Parse the `* 3` in `[ int * 3 ]`
-            match self.maybe_parse_fixed_vstore_with_star() {
-                None => {}
-                Some(suffix) => {
-                    t = ty_fixed_length(@{
-                        id: self.get_id(),
-                        node: t,
-                        span: mk_sp(lo, self.last_span.hi)
-                    }, suffix)
-                }
-            }
+            let t = match self.maybe_parse_fixed_vstore_with_star() {
+                None => ty_vec(mt),
+                Some(suffix) => ty_fixed_length_vec(mt, suffix)
+            };
             self.expect(token::RBRACKET);
             t
         } else if self.token == token::BINOP(token::AND) {
             self.bump();
-            let region = self.parse_region_with_sep();
-            let mt = self.parse_mt();
-            ty_rptr(region, mt)
-        } else if self.eat_keyword(~"once") {
-            self.parse_ty_fn(ast::impure_fn, ast::Once)
-        } else if self.eat_keyword(~"pure") {
-            self.parse_ty_fn_with_onceness(ast::pure_fn)
-        } else if self.eat_keyword(~"unsafe") {
-            self.parse_ty_fn_with_onceness(ast::unsafe_fn)
-        } else if self.is_keyword(~"fn") {
-            self.parse_ty_fn_with_onceness(ast::impure_fn)
-        } else if self.eat_keyword(~"extern") {
-            self.expect_keyword(~"fn");
-            ty_fn(proto_bare, ast::impure_fn, ast::Many, @~[],
-                  self.parse_ty_fn_decl())
+            self.parse_borrowed_pointee()
+        } else if self.token_is_fn_keyword(self.token) {
+            self.parse_ty_fn(None, None)
         } else if self.token == token::MOD_SEP || is_ident(self.token) {
             let path = self.parse_path_with_tps(colons_before_params);
             ty_path(path, self.get_id())
         } else { self.fatal(~"expected type"); };
 
         let sp = mk_sp(lo, self.last_span.hi);
-        return {
-            let node =
-                self.try_convert_ty_to_obsolete_fixed_length_vstore(sp, t);
-            @{id: self.get_id(),
-              node: node,
-              span: sp}
+        return @{id: self.get_id(), node: t, span: sp};
+    }
+
+    fn parse_box_or_uniq_pointee(
+        proto: ast::Proto,
+        ctor: &fn(+v: mt) -> ty_) -> ty_
+    {
+        // @foo/fn() or @fn() are parsed directly as fn types:
+        match copy self.token {
+            token::IDENT(rname, _) => {
+                if self.look_ahead(1u) == token::BINOP(token::SLASH) &&
+                    self.token_is_fn_keyword(self.look_ahead(2u))
+                {
+                    self.bump(); self.bump();
+                    return self.parse_ty_fn(Some(proto), Some(rname));
+                } else if self.token_is_fn_keyword(self.token) {
+                    return self.parse_ty_fn(Some(proto), None);
+                }
+            }
+            _ => {}
+        }
+
+        // other things are parsed as @ + a type.  Note that constructs like
+        // @[] and @str will be resolved during typeck to slices and so forth,
+        // rather than boxed ptrs.  But the special casing of str/vec is not
+        // reflected in the AST type.
+        let mt = self.parse_mt();
+        ctor(mt)
+    }
+
+    fn parse_borrowed_pointee() -> ty_ {
+        // look for `&foo/` and interpret `foo` as the region name:
+        let rname = match copy self.token {
+            token::IDENT(sid, _) => {
+                if self.look_ahead(1u) == token::BINOP(token::SLASH) {
+                    self.bump(); self.bump();
+                    Some(sid)
+                } else {
+                    None
+                }
+            }
+            _ => { None }
         };
+
+        if self.token_is_fn_keyword(self.token) {
+            return self.parse_ty_fn(Some(ProtoBorrowed), rname);
+        }
+
+        let r = self.region_from_name(rname);
+        let mt = self.parse_mt();
+        return ty_rptr(r, mt);
     }
 
     fn parse_arg_mode() -> mode {
@@ -691,16 +760,19 @@ impl Parser {
         }
     }
 
-    fn maybe_parse_fixed_vstore_with_star() -> Option<Option<uint>> {
+    fn maybe_parse_fixed_vstore_with_star() -> Option<uint> {
         if self.eat(token::BINOP(token::STAR)) {
             match copy self.token {
-              token::UNDERSCORE => {
-                self.bump(); Some(None)
-              }
-              token::LIT_INT_UNSUFFIXED(i) if i >= 0i64 => {
-                self.bump(); Some(Some(i as uint))
-              }
-              _ => None
+                token::LIT_INT_UNSUFFIXED(i) if i >= 0i64 => {
+                    self.bump();
+                    Some(i as uint)
+                }
+                _ => {
+                    self.fatal(
+                        fmt!("expected integral vector length \
+                              but found `%s`",
+                             token_to_str(self.reader, self.token)));
+                }
             }
         } else {
             None
@@ -909,11 +981,13 @@ impl Parser {
         } else if self.eat_keyword(~"match") {
             return self.parse_alt_expr();
         } else if self.eat_keyword(~"fn") {
-            let proto = self.parse_fn_ty_proto();
-            match proto {
-              proto_bare => self.fatal(~"fn expr are deprecated, use fn@"),
-              _ => { /* fallthrough */ }
-            }
+            let opt_proto = self.parse_fn_ty_proto();
+            let proto = match opt_proto {
+                None | Some(ast::ProtoBare) => {
+                    self.fatal(~"fn expr are deprecated, use fn@")
+                }
+                Some(p) => { p }
+            };
             return self.parse_fn_expr(proto);
         } else if self.eat_keyword(~"unsafe") {
             return self.parse_block_expr(lo, unsafe_blk);
@@ -1054,9 +1128,6 @@ impl Parser {
             hi = lit.span.hi;
             ex = expr_lit(@lit);
         }
-
-        let (hi, ex) =
-            self.try_convert_expr_to_obsolete_fixed_length_vstore(lo, hi, ex);
 
         return self.mk_expr(lo, hi, ex);
     }
@@ -1495,7 +1566,7 @@ impl Parser {
         return self.mk_expr(q.lo, q.hi, expr_if(q.cond, q.then, q.els));
     }
 
-    fn parse_fn_expr(proto: proto) -> @expr {
+    fn parse_fn_expr(proto: Proto) -> @expr {
         let lo = self.last_span.lo;
 
         // if we want to allow fn expression argument types to be inferred in
@@ -3188,23 +3259,23 @@ impl Parser {
         (id, item_enum(enum_definition, ty_params), None)
     }
 
-    fn parse_fn_ty_proto() -> proto {
+    fn parse_fn_ty_proto() -> Option<Proto> {
         match self.token {
-          token::AT => {
-            self.bump();
-            proto_box
-          }
-          token::TILDE => {
-            self.bump();
-            proto_uniq
-          }
-          token::BINOP(token::AND) => {
-            self.bump();
-            proto_block
-          }
-          _ => {
-            proto_block
-          }
+            token::AT => {
+                self.bump();
+                Some(ProtoBox)
+            }
+            token::TILDE => {
+                self.bump();
+                Some(ProtoUniq)
+            }
+            token::BINOP(token::AND) => {
+                self.bump();
+                Some(ProtoBorrowed)
+            }
+            _ => {
+                None
+            }
         }
     }
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -15,7 +15,7 @@ enum vt<E> { mk_vt(visitor<E>), }
 enum fn_kind {
     fk_item_fn(ident, ~[ty_param], purity), //< an item declared with fn()
     fk_method(ident, ~[ty_param], @method),
-    fk_anon(proto, capture_clause),  //< an anonymous function like fn@(...)
+    fk_anon(Proto, capture_clause),  //< an anonymous function like fn@(...)
     fk_fn_block(capture_clause),     //< a block {||...}
     fk_dtor(~[ty_param], ~[attribute], node_id /* self id */,
             def_id /* parent class id */) // class destructor
@@ -203,13 +203,13 @@ fn visit_ty<E>(t: @Ty, e: E, v: vt<E>) {
       ty_tup(ts) => for ts.each |tt| {
         v.visit_ty(*tt, e, v);
       },
-      ty_fn(_, _, _, bounds, decl) => {
-        for decl.inputs.each |a| { v.visit_ty(a.ty, e, v); }
-        visit_ty_param_bounds(bounds, e, v);
-        v.visit_ty(decl.output, e, v);
+      ty_fn(f) => {
+        for f.decl.inputs.each |a| { v.visit_ty(a.ty, e, v); }
+        visit_ty_param_bounds(f.bounds, e, v);
+        v.visit_ty(f.decl.output, e, v);
       }
       ty_path(p, _) => visit_path(p, e, v),
-      ty_fixed_length(t, _) => v.visit_ty(t, e, v),
+      ty_fixed_length_vec(mt, _) => v.visit_ty(mt.ty, e, v),
       ty_nil |
       ty_bot |
       ty_mac(_) |

--- a/src/rustc/front/test.rs
+++ b/src/rustc/front/test.rs
@@ -406,7 +406,7 @@ fn mk_test_wrapper(cx: test_ctxt,
     let wrapper_expr: ast::expr = {
         id: cx.sess.next_node_id(),
         callee_id: cx.sess.next_node_id(),
-        node: ast::expr_fn(ast::proto_bare, wrapper_decl,
+        node: ast::expr_fn(ast::ProtoBare, wrapper_decl,
                            wrapper_body, @~[]),
         span: span
     };

--- a/src/rustc/middle/borrowck/check_loans.rs
+++ b/src/rustc/middle/borrowck/check_loans.rs
@@ -234,7 +234,7 @@ impl check_loan_ctxt {
     fn is_stack_closure(id: ast::node_id) -> bool {
         let fn_ty = ty::node_id_to_type(self.tcx(), id);
         let proto = ty::ty_fn_proto(fn_ty);
-        return ty::is_blockish(proto);
+        return proto == ast::ProtoBorrowed;
     }
 
     fn is_allowed_pure_arg(expr: @ast::expr) -> bool {

--- a/src/rustc/middle/borrowck/gather_loans.rs
+++ b/src/rustc/middle/borrowck/gather_loans.rs
@@ -241,9 +241,15 @@ impl gather_loan_ctxt {
                                              autoref.mutbl,
                                              autoref.region)
                     }
-                    ty::AutoSlice => {
+                    ty::AutoBorrowVec => {
                         let cmt_index = mcx.cat_index(expr, cmt);
                         self.guarantee_valid(cmt_index,
+                                             autoref.mutbl,
+                                             autoref.region)
+                    }
+                    ty::AutoBorrowFn => {
+                        let cmt_deref = mcx.cat_deref_fn(expr, cmt, 0);
+                        self.guarantee_valid(cmt_deref,
                                              autoref.mutbl,
                                              autoref.region)
                     }

--- a/src/rustc/middle/capture.rs
+++ b/src/rustc/middle/capture.rs
@@ -58,7 +58,7 @@ fn check_capture_clause(tcx: ty::ctxt,
 
 fn compute_capture_vars(tcx: ty::ctxt,
                         fn_expr_id: ast::node_id,
-                        fn_proto: ty::fn_proto,
+                        fn_proto: ast::Proto,
                         cap_clause: ast::capture_clause) -> ~[capture_var] {
     let freevars = freevars::get_freevars(tcx, fn_expr_id);
     let cap_map = map::HashMap();
@@ -101,7 +101,7 @@ fn compute_capture_vars(tcx: ty::ctxt,
     // named and add that
 
     let implicit_mode;
-    if ty::is_blockish(fn_proto) {
+    if fn_proto == ast::ProtoBorrowed {
         implicit_mode = cap_ref;
     } else {
         implicit_mode = cap_copy;

--- a/src/rustc/middle/check_loop.rs
+++ b/src/rustc/middle/check_loop.rs
@@ -24,8 +24,8 @@ fn check_crate(tcx: ty::ctxt, crate: @crate) {
                 v.visit_block(b, {in_loop: false, can_ret: false}, v);
               }
               expr_loop_body(@{node: expr_fn_block(_, b, _), _}) => {
-                let blk = ty::is_blockish(ty::ty_fn_proto(ty::expr_ty(tcx,
-                                                                      e)));
+                let proto = ty::ty_fn_proto(ty::expr_ty(tcx, e));
+                let blk = (proto == ProtoBorrowed);
                 v.visit_block(b, {in_loop: true, can_ret: blk}, v);
               }
               expr_break(_) => {

--- a/src/rustc/middle/freevars.rs
+++ b/src/rustc/middle/freevars.rs
@@ -40,7 +40,7 @@ fn collect_freevars(def_map: resolve::DefMap, blk: ast::blk)
     let walk_expr = fn@(expr: @ast::expr, &&depth: int, v: visit::vt<int>) {
             match expr.node {
               ast::expr_fn(proto, _, _, _) => {
-                if proto != ast::proto_bare {
+                if proto != ast::ProtoBare {
                     visit::visit_expr(expr, depth + 1, v);
                 }
               }

--- a/src/rustc/middle/kind.rs
+++ b/src/rustc/middle/kind.rs
@@ -159,12 +159,10 @@ fn with_appropriate_checker(cx: ctx, id: node_id, b: fn(check_fn)) {
 
     let fty = ty::node_id_to_type(cx.tcx, id);
     match ty::ty_fn_proto(fty) {
-      ty::proto_vstore(ty::vstore_uniq) => b(check_for_uniq),
-      ty::proto_vstore(ty::vstore_box) => b(check_for_box),
-      ty::proto_bare => b(check_for_bare),
-      ty::proto_vstore(ty::vstore_slice(_)) => b(check_for_block),
-      ty::proto_vstore(ty::vstore_fixed(_)) =>
-        fail ~"fixed vstore not allowed here"
+        ProtoUniq => b(check_for_uniq),
+        ProtoBox => b(check_for_box),
+        ProtoBare => b(check_for_bare),
+        ProtoBorrowed => b(check_for_block),
     }
 }
 

--- a/src/rustc/middle/lint.rs
+++ b/src/rustc/middle/lint.rs
@@ -841,28 +841,14 @@ fn check_fn_deprecated_modes(tcx: ty::ctxt, fn_ty: ty::t, decl: ast::fn_decl,
                         let span = arg_ast.ty.span;
                         // Recurse to check fn-type argument
                         match arg_ast.ty.node {
-                            ast::ty_fn(_, _, _, _, decl) => {
+                            ast::ty_fn(f) => {
                                 check_fn_deprecated_modes(tcx, arg_ty.ty,
-                                                          decl, span, id);
+                                                          f.decl, span, id);
                             }
                             ast::ty_path(*) => {
                                 // This is probably a typedef, so we can't
                                 // see the actual fn decl
                                 // e.g. fn foo(f: InitOp<T>)
-                            }
-                            ast::ty_rptr(_, mt)
-                            | ast::ty_box(mt)
-                            | ast::ty_uniq(mt) => {
-                                // Functions with preceding sigil are parsed
-                                // as pointers of functions
-                                match mt.ty.node {
-                                    ast::ty_fn(_, _, _, _, decl) => {
-                                        check_fn_deprecated_modes(
-                                            tcx, arg_ty.ty,
-                                            decl, span, id);
-                                    }
-                                    _ => fail
-                                }
                             }
                             _ => {
                                 tcx.sess.span_warn(span, ~"what");
@@ -889,10 +875,10 @@ fn check_item_deprecated_modes(tcx: ty::ctxt, it: @ast::item) {
     match it.node {
         ast::item_ty(ty, _) => {
             match ty.node {
-                ast::ty_fn(_, _, _, _, decl) => {
+                ast::ty_fn(f) => {
                     let fn_ty = ty::node_id_to_type(tcx, it.id);
                     check_fn_deprecated_modes(
-                        tcx, fn_ty, decl, ty.span, it.id)
+                        tcx, fn_ty, f.decl, ty.span, it.id)
                 }
                 _ => ()
             }

--- a/src/rustc/middle/mem_categorization.rs
+++ b/src/rustc/middle/mem_categorization.rs
@@ -305,15 +305,27 @@ fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
         Some(deref_ptr(uniq_ptr))
       }
 
+      ty::ty_fn(f) if f.meta.proto == ast::ProtoUniq => {
+        Some(deref_ptr(uniq_ptr))
+      }
+
       ty::ty_rptr(r, _) |
       ty::ty_evec(_, ty::vstore_slice(r)) |
       ty::ty_estr(ty::vstore_slice(r)) => {
         Some(deref_ptr(region_ptr(r)))
       }
 
+      ty::ty_fn(f) if f.meta.proto == ast::ProtoBorrowed => {
+        Some(deref_ptr(region_ptr(f.meta.region)))
+      }
+
       ty::ty_box(*) |
       ty::ty_evec(_, ty::vstore_box) |
       ty::ty_estr(ty::vstore_box) => {
+        Some(deref_ptr(gc_ptr))
+      }
+
+      ty::ty_fn(f) if f.meta.proto == ast::ProtoBox => {
         Some(deref_ptr(gc_ptr))
       }
 
@@ -563,22 +575,23 @@ impl &mem_categorization_ctxt {
             let ty = ty::node_id_to_type(self.tcx, fn_node_id);
             let proto = ty::ty_fn_proto(ty);
             match proto {
-              ty::proto_vstore(ty::vstore_slice(_)) => {
-                let upcmt = self.cat_def(id, span, expr_ty, *inner);
-                @{id:id, span:span,
-                  cat:cat_stack_upvar(upcmt), lp:upcmt.lp,
-                  mutbl:upcmt.mutbl, ty:upcmt.ty}
-              }
-              ty::proto_bare |
-              ty::proto_vstore(ty::vstore_uniq) |
-              ty::proto_vstore(ty::vstore_box) => {
-                // FIXME #2152 allow mutation of moved upvars
-                @{id:id, span:span,
-                  cat:cat_special(sk_heap_upvar), lp:None,
-                  mutbl:m_imm, ty:expr_ty}
-              }
-              ty::proto_vstore(ty::vstore_fixed(_)) =>
-                fail ~"fixed vstore not allowed here"
+                ast::ProtoBorrowed => {
+                    let upcmt = self.cat_def(id, span, expr_ty, *inner);
+                    @{id:id, span:span,
+                      cat:cat_stack_upvar(upcmt), lp:upcmt.lp,
+                      mutbl:upcmt.mutbl, ty:upcmt.ty}
+                }
+                ast::ProtoUniq | ast::ProtoBox => {
+                    // FIXME #2152 allow mutation of moved upvars
+                    @{id:id, span:span,
+                      cat:cat_special(sk_heap_upvar), lp:None,
+                      mutbl:m_imm, ty:expr_ty}
+                }
+                ast::ProtoBare => {
+                    self.tcx.sess.span_bug(
+                        span,
+                        fmt!("Upvar in a bare closure?"));
+                }
             }
           }
 
@@ -648,16 +661,16 @@ impl &mem_categorization_ctxt {
                              base_cmt: cmt,
                              f_name: ast::ident,
                              field_id: ast::node_id) -> cmt {
-        let f_mutbl = match field_mutbl(self.tcx, base_cmt.ty, f_name,
-                                        field_id) {
-          Some(f_mutbl) => f_mutbl,
-          None => {
-            self.tcx.sess.span_bug(
-                node.span(),
-                fmt!("Cannot find field `%s` in type `%s`",
-                     self.tcx.sess.str_of(f_name),
-                     ty_to_str(self.tcx, base_cmt.ty)));
-          }
+        let f_mutbl = match field_mutbl(self.tcx, base_cmt.ty,
+                                        f_name, field_id) {
+            Some(f_mutbl) => f_mutbl,
+            None => {
+                self.tcx.sess.span_bug(
+                    node.span(),
+                    fmt!("Cannot find field `%s` in type `%s`",
+                         self.tcx.sess.str_of(f_name),
+                         ty_to_str(self.tcx, base_cmt.ty)));
+            }
         };
         let m = self.inherited_mutability(base_cmt.mutbl, f_mutbl);
         let f_comp = comp_field(f_name, f_mutbl);
@@ -667,9 +680,24 @@ impl &mem_categorization_ctxt {
           mutbl: m, ty: self.tcx.ty(node)}
     }
 
+    fn cat_deref_fn<N:ast_node>(node: N,
+                                base_cmt: cmt,
+                                deref_cnt: uint) -> cmt
+    {
+        // Bit of a hack: the "dereference" of a function pointer like
+        // `@fn()` is a mere logical concept. We interpret it as
+        // dereferencing the environment pointer; of course, we don't
+        // know what type lies at the other end, so we just call it
+        // `()`.
+
+        let mt = {ty: ty::mk_tup(self.tcx, ~[]), mutbl: m_imm};
+        return self.cat_deref_common(node, base_cmt, deref_cnt, mt);
+    }
+
     fn cat_deref<N:ast_node>(node: N,
                              base_cmt: cmt,
-                             deref_cnt: uint) -> cmt {
+                             deref_cnt: uint) -> cmt
+    {
         let mt = match ty::deref(self.tcx, base_cmt.ty, true) {
             Some(mt) => mt,
             None => {
@@ -680,6 +708,14 @@ impl &mem_categorization_ctxt {
             }
         };
 
+        return self.cat_deref_common(node, base_cmt, deref_cnt, mt);
+    }
+
+    fn cat_deref_common<N:ast_node>(node: N,
+                                    base_cmt: cmt,
+                                    deref_cnt: uint,
+                                    mt: ty::mt) -> cmt
+    {
         match deref_kind(self.tcx, base_cmt.ty) {
             deref_ptr(ptr) => {
                 let lp = do base_cmt.lp.chain_ref |l| {

--- a/src/rustc/middle/trans/closure.rs
+++ b/src/rustc/middle/trans/closure.rs
@@ -144,9 +144,7 @@ fn mk_closure_tys(tcx: ty::ctxt,
     return cdata_ty;
 }
 
-fn allocate_cbox(bcx: block,
-                 ck: ty::closure_kind,
-                 cdata_ty: ty::t)
+fn allocate_cbox(bcx: block, proto: ast::Proto, cdata_ty: ty::t)
     -> Result
 {
     let _icx = bcx.insn_ctxt("closure::allocate_cbox");
@@ -163,15 +161,23 @@ fn allocate_cbox(bcx: block,
     }
 
     // Allocate and initialize the box:
-    match ck {
-      ty::ck_box => malloc_raw(bcx, cdata_ty, heap_shared),
-      ty::ck_uniq => malloc_raw(bcx, cdata_ty, heap_exchange),
-      ty::ck_block => {
-          let cbox_ty = tuplify_box_ty(tcx, cdata_ty);
-          let llbox = base::alloc_ty(bcx, cbox_ty);
-          nuke_ref_count(bcx, llbox);
-          rslt(bcx, llbox)
-      }
+    match proto {
+        ast::ProtoBox => {
+            malloc_raw(bcx, cdata_ty, heap_shared)
+        }
+        ast::ProtoUniq => {
+            malloc_raw(bcx, cdata_ty, heap_exchange)
+        }
+        ast::ProtoBorrowed => {
+            let cbox_ty = tuplify_box_ty(tcx, cdata_ty);
+            let llbox = base::alloc_ty(bcx, cbox_ty);
+            nuke_ref_count(bcx, llbox);
+            rslt(bcx, llbox)
+        }
+        ast::ProtoBare => {
+            let cdata_llty = type_of(bcx.ccx(), cdata_ty);
+            rslt(bcx, C_null(cdata_llty))
+        }
     }
 }
 
@@ -187,7 +193,7 @@ type closure_result = {
 // Otherwise, it is stack allocated and copies pointers to the upvars.
 fn store_environment(bcx: block,
                      bound_values: ~[EnvValue],
-                     ck: ty::closure_kind) -> closure_result {
+                     proto: ast::Proto) -> closure_result {
     let _icx = bcx.insn_ctxt("closure::store_environment");
     let ccx = bcx.ccx(), tcx = ccx.tcx;
 
@@ -195,7 +201,7 @@ fn store_environment(bcx: block,
     let cdata_ty = mk_closure_tys(tcx, bound_values);
 
     // allocate closure in the heap
-    let Result {bcx: bcx, val: llbox} = allocate_cbox(bcx, ck, cdata_ty);
+    let Result {bcx: bcx, val: llbox} = allocate_cbox(bcx, proto, cdata_ty);
     let mut temp_cleanups = ~[];
 
     // cbox_ty has the form of a tuple: (a, b, c) we want a ptr to a
@@ -243,7 +249,7 @@ fn store_environment(bcx: block,
 // collects the upvars and packages them up for store_environment.
 fn build_closure(bcx0: block,
                  cap_vars: ~[capture::capture_var],
-                 ck: ty::closure_kind,
+                 proto: ast::Proto,
                  include_ret_handle: Option<ValueRef>) -> closure_result {
     let _icx = bcx0.insn_ctxt("closure::build_closure");
     // If we need to, package up the iterator body to call
@@ -257,7 +263,7 @@ fn build_closure(bcx0: block,
         let datum = expr::trans_local_var(bcx, cap_var.def);
         match cap_var.mode {
             capture::cap_ref => {
-                assert ck == ty::ck_block;
+                assert proto == ast::ProtoBorrowed;
                 env_vals.push(EnvValue {action: EnvRef,
                                         datum: datum});
             }
@@ -298,7 +304,7 @@ fn build_closure(bcx0: block,
                                 datum: ret_datum});
     }
 
-    return store_environment(bcx, env_vals, ck);
+    return store_environment(bcx, env_vals, proto);
 }
 
 // Given an enclosing block context, a new function context, a closure type,
@@ -308,7 +314,7 @@ fn load_environment(fcx: fn_ctxt,
                     cdata_ty: ty::t,
                     cap_vars: ~[capture::capture_var],
                     load_ret_handle: bool,
-                    ck: ty::closure_kind) {
+                    proto: ast::Proto) {
     let _icx = fcx.insn_ctxt("closure::load_environment");
     let bcx = raw_block(fcx, false, fcx.llloadenv);
 
@@ -322,9 +328,9 @@ fn load_environment(fcx: fn_ctxt,
           capture::cap_drop => { /* ignore */ }
           _ => {
             let mut upvarptr = GEPi(bcx, llcdata, [0u, i]);
-            match ck {
-              ty::ck_block => { upvarptr = Load(bcx, upvarptr); }
-              ty::ck_uniq | ty::ck_box => ()
+            match proto {
+                ast::ProtoBorrowed => { upvarptr = Load(bcx, upvarptr); }
+                ast::ProtoBox | ast::ProtoUniq | ast::ProtoBare => {}
             }
             let def_id = ast_util::def_id_of_def(cap_var.def);
             fcx.llupvars.insert(def_id.node, upvarptr);
@@ -341,7 +347,7 @@ fn load_environment(fcx: fn_ctxt,
 }
 
 fn trans_expr_fn(bcx: block,
-                 proto: ty::fn_proto,
+                 proto: ast::Proto,
                  decl: ast::fn_decl,
                  body: ast::blk,
                  id: ast::node_id,
@@ -365,16 +371,16 @@ fn trans_expr_fn(bcx: block,
     let s = mangle_internal_name_by_path_and_seq(ccx, sub_path, ~"expr_fn");
     let llfn = decl_internal_cdecl_fn(ccx.llmod, s, llfnty);
 
-    let trans_closure_env = fn@(ck: ty::closure_kind) -> Result {
+    let trans_closure_env = fn@(proto: ast::Proto) -> Result {
         let cap_vars = capture::compute_capture_vars(ccx.tcx, id, proto,
                                                      cap_clause);
         let ret_handle = match is_loop_body { Some(x) => x, None => None };
-        let {llbox, cdata_ty, bcx} = build_closure(bcx, cap_vars, ck,
+        let {llbox, cdata_ty, bcx} = build_closure(bcx, cap_vars, proto,
                                                    ret_handle);
         trans_closure(ccx, sub_path, decl, body, llfn, no_self,
                       bcx.fcx.param_substs, id, None, |fcx| {
             load_environment(fcx, cdata_ty, cap_vars,
-                             ret_handle.is_some(), ck);
+                             ret_handle.is_some(), proto);
                       }, |bcx| {
             if is_loop_body.is_some() {
                 Store(bcx, C_bool(true), bcx.fcx.llretptr);
@@ -384,22 +390,13 @@ fn trans_expr_fn(bcx: block,
     };
 
     let Result {bcx: bcx, val: closure} = match proto {
-        ty::proto_vstore(ty::vstore_slice(_)) => {
-            trans_closure_env(ty::ck_block)
+        ast::ProtoBorrowed | ast::ProtoBox | ast::ProtoUniq => {
+            trans_closure_env(proto)
         }
-        ty::proto_vstore(ty::vstore_box) => {
-            trans_closure_env(ty::ck_box)
-        }
-        ty::proto_vstore(ty::vstore_uniq) => {
-            trans_closure_env(ty::ck_uniq)
-        }
-        ty::proto_bare => {
+        ast::ProtoBare => {
             trans_closure(ccx, sub_path, decl, body, llfn, no_self, None,
                           id, None, |_fcx| { }, |_bcx| { });
             rslt(bcx, C_null(T_opaque_box_ptr(ccx)))
-        }
-        ty::proto_vstore(ty::vstore_fixed(_)) => {
-            fail ~"vstore_fixed unexpected"
         }
     };
     fill_fn_pair(bcx, dest_addr, llfn, closure);
@@ -412,45 +409,45 @@ fn make_fn_glue(
     v: ValueRef,
     t: ty::t,
     glue_fn: fn@(block, v: ValueRef, t: ty::t) -> block)
-    -> block {
+    -> block
+{
     let _icx = cx.insn_ctxt("closure::make_fn_glue");
     let bcx = cx;
     let tcx = cx.tcx();
 
-    let fn_env = fn@(ck: ty::closure_kind) -> block {
-        let box_cell_v = GEPi(cx, v, [0u, abi::fn_field_box]);
-        let box_ptr_v = Load(cx, box_cell_v);
-        do with_cond(cx, IsNotNull(cx, box_ptr_v)) |bcx| {
-            let closure_ty = ty::mk_opaque_closure_ptr(tcx, ck);
-            glue_fn(bcx, box_cell_v, closure_ty)
-        }
-    };
-
     let proto = ty::ty_fn_proto(t);
     match proto {
-        ty::proto_bare | ty::proto_vstore(ty::vstore_slice(_)) => bcx,
-        ty::proto_vstore(ty::vstore_uniq) => fn_env(ty::ck_uniq),
-        ty::proto_vstore(ty::vstore_box) => fn_env(ty::ck_box),
-        ty::proto_vstore(ty::vstore_fixed(_)) => {
-            cx.sess().bug(~"Closure with fixed vstore");
+        ast::ProtoBare | ast::ProtoBorrowed => bcx,
+        ast::ProtoUniq | ast::ProtoBox => {
+            let box_cell_v = GEPi(cx, v, [0u, abi::fn_field_box]);
+            let box_ptr_v = Load(cx, box_cell_v);
+            do with_cond(cx, IsNotNull(cx, box_ptr_v)) |bcx| {
+                let closure_ty = ty::mk_opaque_closure_ptr(tcx, proto);
+                glue_fn(bcx, box_cell_v, closure_ty)
+            }
         }
     }
 }
 
 fn make_opaque_cbox_take_glue(
     bcx: block,
-    ck: ty::closure_kind,
+    proto: ast::Proto,
     cboxptr: ValueRef)     // ptr to ptr to the opaque closure
-    -> block {
+    -> block
+{
     // Easy cases:
     let _icx = bcx.insn_ctxt("closure::make_opaque_cbox_take_glue");
-    match ck {
-        ty::ck_block => return bcx,
-        ty::ck_box => {
+    match proto {
+        ast::ProtoBare | ast::ProtoBorrowed => {
+            return bcx;
+        }
+        ast::ProtoBox => {
             glue::incr_refcnt_of_boxed(bcx, Load(bcx, cboxptr));
             return bcx;
         }
-        ty::ck_uniq => { /* hard case: */ }
+        ast::ProtoUniq => {
+            /* hard case */
+        }
     }
 
     // Hard case, a deep copy:
@@ -492,34 +489,38 @@ fn make_opaque_cbox_take_glue(
 
 fn make_opaque_cbox_drop_glue(
     bcx: block,
-    ck: ty::closure_kind,
+    proto: ast::Proto,
     cboxptr: ValueRef)     // ptr to the opaque closure
     -> block {
     let _icx = bcx.insn_ctxt("closure::make_opaque_cbox_drop_glue");
-    match ck {
-        ty::ck_block => bcx,
-        ty::ck_box => {
+    match proto {
+        ast::ProtoBare | ast::ProtoBorrowed => bcx,
+        ast::ProtoBox => {
             glue::decr_refcnt_maybe_free(
                 bcx, Load(bcx, cboxptr),
-                ty::mk_opaque_closure_ptr(bcx.tcx(), ck))
+                ty::mk_opaque_closure_ptr(bcx.tcx(), proto))
         }
-        ty::ck_uniq => {
+        ast::ProtoUniq => {
             glue::free_ty(
                 bcx, cboxptr,
-                ty::mk_opaque_closure_ptr(bcx.tcx(), ck))
+                ty::mk_opaque_closure_ptr(bcx.tcx(), proto))
         }
     }
 }
 
 fn make_opaque_cbox_free_glue(
     bcx: block,
-    ck: ty::closure_kind,
+    proto: ast::Proto,
     cbox: ValueRef)     // ptr to ptr to the opaque closure
     -> block {
     let _icx = bcx.insn_ctxt("closure::make_opaque_cbox_free_glue");
-    match ck {
-      ty::ck_block => return bcx,
-      ty::ck_box | ty::ck_uniq => { /* hard cases: */ }
+    match proto {
+        ast::ProtoBare | ast::ProtoBorrowed => {
+            return bcx;
+        }
+        ast::ProtoBox | ast::ProtoUniq => {
+            /* hard cases */
+        }
     }
 
     let ccx = bcx.ccx();
@@ -537,10 +538,12 @@ fn make_opaque_cbox_free_glue(
                                     abi::tydesc_field_drop_glue, None);
 
         // Free the ty descr (if necc) and the box itself
-        match ck {
-            ty::ck_block => fail ~"Impossible",
-            ty::ck_box => glue::trans_free(bcx, cbox),
-            ty::ck_uniq => glue::trans_unique_free(bcx, cbox)
+        match proto {
+            ast::ProtoBox => glue::trans_free(bcx, cbox),
+            ast::ProtoUniq => glue::trans_unique_free(bcx, cbox),
+            ast::ProtoBare | ast::ProtoBorrowed => {
+                bcx.sess().bug(~"impossible")
+            }
         }
     }
 }

--- a/src/rustc/middle/trans/foreign.rs
+++ b/src/rustc/middle/trans/foreign.rs
@@ -997,10 +997,9 @@ fn trans_intrinsic(ccx: @crate_ctxt, decl: ValueRef, item: @ast::foreign_item,
                 ty::mk_mach_uint(bcx.tcx(), ast::ty_u8));
             let fty = ty::mk_fn(bcx.tcx(), FnTyBase {
                 meta: FnMeta {purity: ast::impure_fn,
-                              proto:
-                                  ty::proto_vstore(ty::vstore_slice(
-                                      ty::re_bound(ty::br_anon(0)))),
+                              proto: ast::ProtoBorrowed,
                               onceness: ast::Many,
+                              region: ty::re_bound(ty::br_anon(0)),
                               bounds: @~[],
                               ret_style: ast::return_val},
                 sig: FnSig {inputs: ~[{mode: ast::expl(ast::by_val),

--- a/src/rustc/middle/trans/monomorphize.rs
+++ b/src/rustc/middle/trans/monomorphize.rs
@@ -251,18 +251,19 @@ fn normalize_for_monomorphization(tcx: ty::ctxt, ty: ty::t) -> Option<ty::t> {
                 FnTyBase {meta: FnMeta {purity: ast::impure_fn,
                                         proto: fty.meta.proto,
                                         onceness: ast::Many,
+                                        region: ty::re_static,
                                         bounds: @~[],
                                         ret_style: ast::return_val},
                           sig: FnSig {inputs: ~[],
                                       output: ty::mk_nil(tcx)}}))
         }
         ty::ty_trait(_, _, _) => {
-            let box_proto = ty::proto_vstore(ty::vstore_box);
             Some(ty::mk_fn(
                 tcx,
                 FnTyBase {meta: FnMeta {purity: ast::impure_fn,
-                                        proto: box_proto,
+                                        proto: ast::ProtoBox,
                                         onceness: ast::Many,
+                                        region: ty::re_static,
                                         bounds: @~[],
                                         ret_style: ast::return_val},
                           sig: FnSig {inputs: ~[],

--- a/src/rustc/middle/trans/reflect.rs
+++ b/src/rustc/middle/trans/reflect.rs
@@ -186,14 +186,7 @@ impl reflector {
               ast::impure_fn => 2u,
               ast::extern_fn => 3u
             };
-            let protoval = match fty.meta.proto {
-              ty::proto_bare => 0u,
-              ty::proto_vstore(ty::vstore_uniq) => 2u,
-              ty::proto_vstore(ty::vstore_box) => 3u,
-              ty::proto_vstore(ty::vstore_slice(_)) => 4u,
-              ty::proto_vstore(ty::vstore_fixed(_)) =>
-                fail ~"fixed unexpected"
-            };
+            let protoval = ast_proto_constant(fty.meta.proto);
             let retval = match fty.meta.ret_style {
               ast::noreturn => 0u,
               ast::return_val => 1u
@@ -278,11 +271,7 @@ impl reflector {
           ty::ty_type => self.leaf(~"type"),
           ty::ty_opaque_box => self.leaf(~"opaque_box"),
           ty::ty_opaque_closure_ptr(ck) => {
-            let ckval = match ck {
-              ty::ck_block => 0u,
-              ty::ck_box => 1u,
-              ty::ck_uniq => 2u
-            };
+            let ckval = ast_proto_constant(ck);
             self.visit(~"closure_ptr", ~[self.c_uint(ckval)])
           }
         }
@@ -308,4 +297,13 @@ fn emit_calls_to_trait_visit_ty(bcx: block, t: ty::t,
     r.visit_ty(t);
     Br(r.bcx, final.llbb);
     return final;
+}
+
+fn ast_proto_constant(proto: ast::Proto) -> uint {
+    match proto {
+        ast::ProtoBare => 0u,
+        ast::ProtoUniq => 2u,
+        ast::ProtoBox => 3u,
+        ast::ProtoBorrowed => 4u,
+    }
 }

--- a/src/rustc/middle/trans/type_use.rs
+++ b/src/rustc/middle/trans/type_use.rs
@@ -213,16 +213,13 @@ fn mark_for_expr(cx: ctx, e: @expr) {
       }
       expr_fn(*) | expr_fn_block(*) => {
         match ty::ty_fn_proto(ty::expr_ty(cx.ccx.tcx, e)) {
-          ty::proto_bare | ty::proto_vstore(ty::vstore_uniq) => {}
-          ty::proto_vstore(ty::vstore_box) |
-          ty::proto_vstore(ty::vstore_slice(_)) => {
+          ast::ProtoBare | ast::ProtoUniq => {}
+          ast::ProtoBox | ast::ProtoBorrowed => {
             for vec::each(*freevars::get_freevars(cx.ccx.tcx, e.id)) |fv| {
                 let node_id = ast_util::def_id_of_def(fv.def).node;
                 node_type_needs(cx, use_repr, node_id);
             }
           }
-          ty::proto_vstore(ty::vstore_fixed(_)) =>
-            fail ~"vstore_fixed not allowed here"
         }
       }
       expr_assign(val, _) | expr_swap(val, _) | expr_assign_op(_, val, _) |

--- a/src/rustc/middle/typeck/check/method.rs
+++ b/src/rustc/middle/typeck/check/method.rs
@@ -625,7 +625,7 @@ impl LookupContext {
             ty_evec(mt, vstore_uniq) |
             ty_evec(mt, vstore_fixed(_)) => {
                 self.search_for_some_kind_of_autorefd_method(
-                    AutoSlice, autoderefs, [m_const, m_imm, m_mutbl],
+                    AutoBorrowVec, autoderefs, [m_const, m_imm, m_mutbl],
                     |m,r| ty::mk_evec(tcx,
                                       {ty:mt.ty, mutbl:m},
                                       vstore_slice(r)))
@@ -635,7 +635,7 @@ impl LookupContext {
             ty_estr(vstore_uniq) |
             ty_estr(vstore_fixed(_)) => {
                 self.search_for_some_kind_of_autorefd_method(
-                    AutoSlice, autoderefs, [m_imm],
+                    AutoBorrowVec, autoderefs, [m_imm],
                     |_m,r| ty::mk_estr(tcx, vstore_slice(r)))
             }
 

--- a/src/rustc/middle/typeck/collect.rs
+++ b/src/rustc/middle/typeck/collect.rs
@@ -133,9 +133,10 @@ fn get_enum_variant_types(ccx: @crate_ctxt,
                 });
                 result_ty = Some(ty::mk_fn(tcx, FnTyBase {
                     meta: FnMeta {purity: ast::pure_fn,
-                                  proto: ty::proto_vstore(ty::vstore_box),
+                                  proto: ast::ProtoBare,
                                   onceness: ast::Many,
                                   bounds: @~[],
+                                  region: ty::re_static,
                                   ret_style: ast::return_val},
                     sig: FnSig {inputs: args,
                                 output: enum_ty}
@@ -604,9 +605,10 @@ fn convert_struct(ccx: @crate_ctxt,
         // Write the dtor type
         let t_dtor = ty::mk_fn(
             tcx,
-            ty_of_fn_decl(ccx, type_rscope(rp), ast::proto_bare,
-                          ast::impure_fn, ast::Many, @~[],
-                          ast_util::dtor_dec(), None, dtor.span));
+            ty_of_fn_decl(
+                ccx, type_rscope(rp), ast::ProtoBare,
+                ast::impure_fn, ast::Many, /*bounds:*/ @~[], /*opt_region:*/ None,
+                ast_util::dtor_dec(), None, dtor.span));
         write_ty_to_tcx(tcx, dtor.node.id, t_dtor);
         tcx.tcache.insert(local_def(dtor.node.id),
                           {bounds: tpt.bounds,
@@ -643,9 +645,10 @@ fn convert_struct(ccx: @crate_ctxt,
                 let ctor_fn_ty = ty::mk_fn(tcx, FnTyBase {
                     meta: FnMeta {
                         purity: ast::pure_fn,
-                        proto: ty::proto_bare,
+                        proto: ast::ProtoBare,
                         onceness: ast::Many,
                         bounds: @~[],
+                        region: ty::re_static,
                         ret_style: ast::return_val,
                     },
                     sig: FnSig {
@@ -684,15 +687,10 @@ fn ty_of_method(ccx: @crate_ctxt,
                 rp: Option<ty::region_variance>) -> ty::method {
     {ident: m.ident,
      tps: ty_param_bounds(ccx, m.tps),
-     fty: ty_of_fn_decl(ccx,
-                        type_rscope(rp),
-                        ast::proto_bare,
-                        m.purity,
-                        ast::Many,
-                        @~[],
-                        m.decl,
-                        None,
-                        m.span),
+     fty: ty_of_fn_decl(ccx, type_rscope(rp), ast::ProtoBare,
+                        m.purity, ast::Many,
+                        /*bounds:*/ @~[], /*opt_region:*/ None,
+                        m.decl, None, m.span),
      self_ty: m.self_ty.node,
      vis: m.vis,
      def_id: local_def(m.id)}
@@ -704,15 +702,10 @@ fn ty_of_ty_method(self: @crate_ctxt,
                    id: ast::def_id) -> ty::method {
     {ident: m.ident,
      tps: ty_param_bounds(self, m.tps),
-     fty: ty_of_fn_decl(self,
-                        type_rscope(rp),
-                        ast::proto_bare,
-                        m.purity,
-                        ast::Many,
-                        @~[],
-                        m.decl,
-                        None,
-                        m.span),
+     fty: ty_of_fn_decl(self, type_rscope(rp), ast::ProtoBare,
+                        m.purity, ast::Many,
+                        /*bounds:*/ @~[], /*opt_region:*/ None,
+                        m.decl, None, m.span),
      // assume public, because this is only invoked on trait methods
      self_ty: m.self_ty.node,
      vis: ast::public,
@@ -767,15 +760,10 @@ fn ty_of_item(ccx: @crate_ctxt, it: @ast::item)
       }
       ast::item_fn(decl, purity, tps, _) => {
         let bounds = ty_param_bounds(ccx, tps);
-        let tofd = ty_of_fn_decl(ccx,
-                                 empty_rscope,
-                                 ast::proto_bare,
-                                 purity,
-                                 ast::Many,
-                                 @~[],
-                                 decl,
-                                 None,
-                                 it.span);
+        let tofd = ty_of_fn_decl(ccx, empty_rscope,
+                                 ast::ProtoBare, purity, ast::Many,
+                                 /*bounds:*/ @~[], /*opt_region:*/ None,
+                                 decl, None, it.span);
         let tpt = {bounds: bounds,
                    region_param: None,
                    ty: ty::mk_fn(ccx.tcx, tofd)};
@@ -930,9 +918,10 @@ fn ty_of_foreign_fn_decl(ccx: @crate_ctxt,
 
     let t_fn = ty::mk_fn(ccx.tcx, FnTyBase {
         meta: FnMeta {purity: purity,
-                      proto: ty::proto_bare,
                       onceness: ast::Many,
+                      proto: ast::ProtoBare,
                       bounds: @~[],
+                      region: ty::re_static,
                       ret_style: ast::return_val},
         sig: FnSig {inputs: input_tys,
                     output: output_ty}

--- a/src/rustc/middle/typeck/infer/glb.rs
+++ b/src/rustc/middle/typeck/infer/glb.rs
@@ -71,22 +71,8 @@ impl Glb: combine {
         Lub(*self).tys(a, b)
     }
 
-    fn protos(p1: ty::fn_proto, p2: ty::fn_proto) -> cres<ty::fn_proto> {
-        match (p1, p2) {
-            (ty::proto_vstore(ty::vstore_slice(_)), _) => Ok(p2),
-            (_, ty::proto_vstore(ty::vstore_slice(_))) => Ok(p1),
-            (ty::proto_vstore(v1), ty::proto_vstore(v2)) => {
-                self.infcx.try(|| {
-                    do self.vstores(terr_fn, v1, v2).chain |vs| {
-                        Ok(ty::proto_vstore(vs))
-                    }
-                }).chain_err(|_err| {
-                    // XXX: Totally unsound, but fixed up later.
-                    Ok(ty::proto_bare)
-                })
-            }
-            _ => Ok(ty::proto_bare)
-        }
+    fn protos(p1: ast::Proto, p2: ast::Proto) -> cres<ast::Proto> {
+        if p1 == p2 {Ok(p1)} else {Ok(ast::ProtoBare)}
     }
 
     fn purities(a: purity, b: purity) -> cres<purity> {

--- a/src/rustc/middle/typeck/infer/lub.rs
+++ b/src/rustc/middle/typeck/infer/lub.rs
@@ -54,21 +54,12 @@ impl Lub: combine {
         Glb(*self).tys(a, b)
     }
 
-    // XXX: Wrong.
-    fn protos(p1: ty::fn_proto, p2: ty::fn_proto) -> cres<ty::fn_proto> {
+    fn protos(p1: ast::Proto, p2: ast::Proto) -> cres<ast::Proto> {
         match (p1, p2) {
-            (ty::proto_bare, _) => Ok(p2),
-            (_, ty::proto_bare) => Ok(p1),
-            (ty::proto_vstore(v1), ty::proto_vstore(v2)) => {
-                self.infcx.try(|| {
-                    do self.vstores(terr_fn, v1, v2).chain |vs| {
-                        Ok(ty::proto_vstore(vs))
-                    }
-                }).chain_err(|_err| {
-                    // XXX: Totally unsound, but fixed up later.
-                    Ok(ty::proto_vstore(ty::vstore_slice(ty::re_static)))
-                })
-            }
+            (ast::ProtoBare, _) => Ok(p2),
+            (_, ast::ProtoBare) => Ok(p1),
+            _ if p1 == p2 => Ok(p1),
+            _ => Err(ty::terr_proto_mismatch(expected_found(&self, p1, p2)))
         }
     }
 

--- a/src/rustc/middle/typeck/infer/sub.rs
+++ b/src/rustc/middle/typeck/infer/sub.rs
@@ -63,27 +63,11 @@ impl Sub: combine {
         }
     }
 
-    fn protos(a: ty::fn_proto, b: ty::fn_proto) -> cres<ty::fn_proto> {
-        match (a, b) {
-            (ty::proto_bare, _) =>
-                Ok(ty::proto_bare),
-
-            (ty::proto_vstore(ty::vstore_box),
-             ty::proto_vstore(ty::vstore_slice(_))) =>
-                Ok(ty::proto_vstore(ty::vstore_box)),
-
-            (ty::proto_vstore(ty::vstore_uniq),
-             ty::proto_vstore(ty::vstore_slice(_))) =>
-                Ok(ty::proto_vstore(ty::vstore_uniq)),
-
-            (_, ty::proto_bare) =>
-                Err(ty::terr_proto_mismatch(expected_found(&self, a, b))),
-
-            (ty::proto_vstore(vs_a), ty::proto_vstore(vs_b)) => {
-                do self.vstores(ty::terr_fn, vs_a, vs_b).chain |vs_c| {
-                    Ok(ty::proto_vstore(vs_c))
-                }
-            }
+    fn protos(p1: ast::Proto, p2: ast::Proto) -> cres<ast::Proto> {
+        match (p1, p2) {
+            (ast::ProtoBare, _) => Ok(p1),
+            _ if p1 == p2 => Ok(p1),
+            _ => Err(ty::terr_proto_mismatch(expected_found(&self, p1, p2)))
         }
     }
 

--- a/src/test/compile-fail/block-coerce-no.rs
+++ b/src/test/compile-fail/block-coerce-no.rs
@@ -2,11 +2,11 @@
 // other tycons.
 
 fn coerce(b: fn()) -> extern fn() {
-    fn lol(f: extern fn(fn()) -> extern fn(),
-           g: fn()) -> extern fn() { return f(g); }
-    fn fn_id(f: extern fn()) -> extern fn() { return f }
+    fn lol(+f: extern fn(+v: fn()) -> extern fn(),
+           +g: fn()) -> extern fn() { return f(g); }
+    fn fn_id(+f: extern fn()) -> extern fn() { return f }
     return lol(fn_id, b);
-    //~^ ERROR mismatched types: expected `fn(fn&()) -> fn()`
+    //~^ ERROR mismatched types
 }
 
 fn main() {

--- a/src/test/compile-fail/extern-wrong-value-type.rs
+++ b/src/test/compile-fail/extern-wrong-value-type.rs
@@ -1,8 +1,7 @@
-// error-pattern:expected `fn&()` but found `*u8`
 extern fn f() {
 }
 
 fn main() {
     // extern functions are *u8 types
-    let _x: fn() = f;
+    let _x: fn() = f; //~ ERROR mismatched types: expected `&fn()` but found `*u8`
 }

--- a/src/test/compile-fail/issue-1896-1.rs
+++ b/src/test/compile-fail/issue-1896-1.rs
@@ -1,7 +1,7 @@
 type boxedFn = { theFn: fn () -> uint };
 
 fn createClosure (closedUint: uint) -> boxedFn {
-    { theFn: fn@ () -> uint { closedUint } }
+    { theFn: fn@ () -> uint { closedUint } } //~ ERROR mismatched types
 }
 
 fn main () {

--- a/src/test/compile-fail/issue-1896-2.rs
+++ b/src/test/compile-fail/issue-1896-2.rs
@@ -5,6 +5,6 @@ fn add(n: int) -> fn@(int) -> int {
 fn main()
 {
       assert add(3)(4) == 7;
-        let add3 : fn(int)->int = add(3);
-          assert add3(4) == 7;
+      let add3 : fn(int)->int = add(3); //~ ERROR mismatched types
+      assert add3(4) == 7;
 }

--- a/src/test/compile-fail/issue-1896-3.rs
+++ b/src/test/compile-fail/issue-1896-3.rs
@@ -12,6 +12,6 @@ fn main()
     let add2 : &(fn@(int)->int) = &add(2);
     assert (*add2)(5) == 7;
 
-    let add3 : fn(int)->int = add(3);
+    let add3 : fn(int)->int = add(3); //~ ERROR mismatched types
     assert add3(4) == 7;
 }

--- a/src/test/compile-fail/issue-1896.rs
+++ b/src/test/compile-fail/issue-1896.rs
@@ -3,6 +3,7 @@ type t<T> = { f: fn() -> T };
 fn f<T>(_x: t<T>) {}
 
 fn main() {
-    let x: t<()> = { f: { || () } };
-    f(x); //~ ERROR copying a noncopyable value
+    let x: t<()> = { f: { || () } }; //~ ERROR expected & closure, found @ closure
+    //~^ ERROR in field `f`, expected & closure, found @ closure
+    f(x);
 }

--- a/src/test/compile-fail/missing-do.rs
+++ b/src/test/compile-fail/missing-do.rs
@@ -4,6 +4,6 @@ fn foo(f: fn()) { f() }
 
 fn main() {
     ~"" || 42; //~ ERROR binary operation || cannot be applied to type `~str`
-    foo || {}; //~ ERROR binary operation || cannot be applied to type `fn(fn&())`
+    foo || {}; //~ ERROR binary operation || cannot be applied to type `fn(&fn())`
     //~^ NOTE did you forget the 'do' keyword for the call?
 }

--- a/src/test/compile-fail/obsolete-syntax.rs
+++ b/src/test/compile-fail/obsolete-syntax.rs
@@ -56,22 +56,11 @@ fn obsolete_with() {
     //~^ ERROR obsolete syntax: with
 }
 
-fn obsolete_fixed_length_vec() {
-    let foo: [int]/1;
-    //~^ ERROR obsolete syntax: fixed-length vector
-    foo = [1]/_;
-    //~^ ERROR obsolete syntax: fixed-length vector
-    let foo: [int]/1;
-    //~^ ERROR obsolete syntax: fixed-length vector
-    foo = [1]/1;
-    //~^ ERROR obsolete syntax: fixed-length vector
-}
-
 fn obsolete_moves() {
     let mut x = 0;
     let y <- x;
     //~^ ERROR obsolete syntax: initializer-by-move
-    y <- x; 
+    y <- x;
     //~^ ERROR obsolete syntax: binary move
 }
 

--- a/src/test/compile-fail/pure-subtyping.rs
+++ b/src/test/compile-fail/pure-subtyping.rs
@@ -1,35 +1,37 @@
 // Test rules governing higher-order pure fns.
 
+fn take<T>(_v: T) {}
+
 fn assign_to_pure(x: pure fn(), y: fn(), z: unsafe fn()) {
-    let a: pure fn() = x;
-    let b: pure fn() = y; //~ ERROR expected pure fn but found impure fn
-    let c: pure fn() = z; //~ ERROR expected pure fn but found unsafe fn
+    take::<pure fn()>(x);
+    take::<pure fn()>(y); //~ ERROR expected pure fn but found impure fn
+    take::<pure fn()>(z); //~ ERROR expected pure fn but found unsafe fn
 }
 
 fn assign_to_impure(x: pure fn(), y: fn(), z: unsafe fn()) {
-    let h: fn() = x;
-    let i: fn() = y;
-    let j: fn() = z; //~ ERROR expected impure fn but found unsafe fn
+    take::<fn()>(x);
+    take::<fn()>(y);
+    take::<fn()>(z); //~ ERROR expected impure fn but found unsafe fn
 }
 
 fn assign_to_unsafe(x: pure fn(), y: fn(), z: unsafe fn()) {
-    let m: unsafe fn() = x;
-    let n: unsafe fn() = y;
-    let o: unsafe fn() = z;
+    take::<unsafe fn()>(x);
+    take::<unsafe fn()>(y);
+    take::<unsafe fn()>(z);
 }
 
 fn assign_to_pure2(x: pure fn@(), y: fn@(), z: unsafe fn@()) {
-    let a: pure fn() = x;
-    let b: pure fn() = y; //~ ERROR expected pure fn but found impure fn
-    let c: pure fn() = z; //~ ERROR expected pure fn but found unsafe fn
+    take::<pure fn()>(x);
+    take::<pure fn()>(y); //~ ERROR expected pure fn but found impure fn
+    take::<pure fn()>(z); //~ ERROR expected pure fn but found unsafe fn
 
-    let a: pure fn~() = x; //~ ERROR fn storage differs: expected ~ but found @
-    let b: pure fn~() = y; //~ ERROR fn storage differs: expected ~ but found @
-    let c: pure fn~() = z; //~ ERROR fn storage differs: expected ~ but found @
+    take::<pure fn~()>(x); //~ ERROR expected ~ closure, found @ closure
+    take::<pure fn~()>(y); //~ ERROR expected ~ closure, found @ closure
+    take::<pure fn~()>(z); //~ ERROR expected ~ closure, found @ closure
 
-    let a: unsafe fn~() = x; //~ ERROR fn storage differs: expected ~ but found @
-    let b: unsafe fn~() = y; //~ ERROR fn storage differs: expected ~ but found @
-    let c: unsafe fn~() = z; //~ ERROR fn storage differs: expected ~ but found @
+    take::<unsafe fn~()>(x); //~ ERROR expected ~ closure, found @ closure
+    take::<unsafe fn~()>(y); //~ ERROR expected ~ closure, found @ closure
+    take::<unsafe fn~()>(z); //~ ERROR expected ~ closure, found @ closure
 }
 
 fn main() {

--- a/src/test/compile-fail/regions-freevar.rs
+++ b/src/test/compile-fail/regions-freevar.rs
@@ -2,8 +2,7 @@ fn wants_static_fn(_x: &static/fn()) {}
 
 fn main() {
     let i = 3;
-    do wants_static_fn {
+    do wants_static_fn { //~ ERROR cannot infer an appropriate lifetime due to conflicting requirements
         debug!("i=%d", i);
-          //~^ ERROR captured variable does not outlive the enclosing closure
     }
 }

--- a/src/test/compile-fail/sendfn-is-not-a-lambda.rs
+++ b/src/test/compile-fail/sendfn-is-not-a-lambda.rs
@@ -4,5 +4,5 @@ fn test(f: fn@(uint) -> uint) -> uint {
 
 fn main() {
     let f = fn~(x: uint) -> uint { return 4u; };
-    log(debug, test(f)); //~ ERROR expected `fn@(uint) -> uint`
+    log(debug, test(f)); //~ ERROR expected @ closure, found ~ closure
 }

--- a/src/test/pretty/disamb-stmt-expr.rs
+++ b/src/test/pretty/disamb-stmt-expr.rs
@@ -4,7 +4,7 @@
 // preserved.  They are needed to disambiguate `{return n+1}; - 0` from
 // `({return n+1}-0)`.
 
-fn id(f: fn&() -> int) -> int { f() }
+fn id(f: &fn() -> int) -> int { f() }
 
 fn wsucc(n: int) -> int { (do id || { 1 }) - 0 }
 fn main() { }

--- a/src/test/pretty/fn-types.rs
+++ b/src/test/pretty/fn-types.rs
@@ -1,7 +1,7 @@
 // pp-exact
 
 fn from_foreign_fn(x: extern fn()) { }
-fn from_stack_closure(x: fn&()) { }
-fn from_box_closure(x: fn@()) { }
-fn from_unique_closure(x: fn~()) { }
+fn from_stack_closure(x: &fn()) { }
+fn from_box_closure(x: @fn()) { }
+fn from_unique_closure(x: ~fn()) { }
 fn main() { }

--- a/src/test/run-pass/issue-2185.rs
+++ b/src/test/run-pass/issue-2185.rs
@@ -1,3 +1,4 @@
+// xfail-test FIXME #2263
 // xfail-fast
 // This test had to do with an outdated version of the iterable trait.
 // However, the condition it was testing seemed complex enough to

--- a/src/test/run-pass/task-killjoin-rsrc.rs
+++ b/src/test/run-pass/task-killjoin-rsrc.rs
@@ -37,7 +37,7 @@ fn joinable(+f: fn~()) -> comm::Port<bool> {
     }
     let p = comm::Port();
     let c = comm::Chan(&p);
-    do task::spawn_unlinked { wrapper(c, copy f) };
+    do task::spawn_unlinked { wrapper(c, f) };
     p
 }
 


### PR DESCRIPTION
Fixes #1896 which was never truly fixed, just masked.
The given tests would have failed had they used `~fn()` and
not `@fn()`.  They now result in compilation errors.

Fixes #2978.

Necessary first step for #2202, #2263.

r? @pcwalton
