### PR TITLE
Convert libstd to use the Drop trait

### DIFF
--- a/src/libstd/arc.rs
+++ b/src/libstd/arc.rs
@@ -217,7 +217,10 @@ fn check_poison(is_mutex: bool, failed: bool) {
 #[doc(hidden)]
 struct PoisonOnFail {
     failed: &mut bool,
-    drop {
+}
+
+impl PoisonOnFail : Drop {
+    fn finalize() {
         /* assert !*self.failed; -- might be false in case of cond.wait() */
         if task::failing() { *self.failed = true; }
     }

--- a/src/libstd/arena.rs
+++ b/src/libstd/arena.rs
@@ -55,7 +55,10 @@ pub struct Arena {
     priv mut head: Chunk,
     priv mut pod_head: Chunk,
     priv mut chunks: @List<Chunk>,
-    drop {
+}
+
+impl Arena : Drop {
+    fn finalize() {
         unsafe {
             destroy_chunk(&self.head);
             for list::each(self.chunks) |chunk| {

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -39,12 +39,15 @@ pub enum CVec<T> {
 
 struct DtorRes {
   dtor: Option<fn@()>,
-  drop {
+}
+
+impl DtorRes : Drop {
+    fn finalize() {
     match self.dtor {
       option::None => (),
       option::Some(f) => f()
     }
-  }
+    }
 }
 
 fn DtorRes(dtor: Option<fn@()>) -> DtorRes {

--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -23,10 +23,12 @@ use cast::copy_lifetime;
 #[doc = "The future type"]
 pub struct Future<A> {
     /*priv*/ mut state: FutureState<A>,
+}
 
-    // FIXME(#2829) -- futures should not be copyable, because they close
-    // over fn~'s that have pipes and so forth within!
-    drop {}
+// FIXME(#2829) -- futures should not be copyable, because they close
+// over fn~'s that have pipes and so forth within!
+impl<A> Future<A> : Drop {
+    fn finalize() {}
 }
 
 priv enum FutureState<A> {

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -27,11 +27,14 @@ extern mod rustrt {
  */
 struct TcpSocket {
   socket_data: @TcpSocketData,
-  drop {
+}
+
+impl TcpSocket : Drop {
+    fn finalize() {
     unsafe {
         tear_down_socket_data(self.socket_data)
     }
-  }
+    }
 }
 
 pub fn TcpSocket(socket_data: @TcpSocketData) -> TcpSocket {

--- a/src/libstd/sort.rs
+++ b/src/libstd/sort.rs
@@ -1133,7 +1133,10 @@ mod big_tests {
         val: uint,
         key: fn(@uint),
 
-        drop {
+    }
+
+    impl LVal : Drop {
+        fn finalize() {
             let x = unsafe { task::local_data::local_data_get(self.key) };
             match x {
                 Some(@y) => {

--- a/src/libstd/thread_pool.rs
+++ b/src/libstd/thread_pool.rs
@@ -13,7 +13,10 @@ pub struct ThreadPool<T> {
     channels: ~[Chan<Msg<T>>],
     mut next_index: uint,
 
-    drop {
+}
+
+impl<T> ThreadPool<T> {
+    fn finalize() {
         for self.channels.each |channel| {
             channel.send(Quit);
         }


### PR DESCRIPTION
With this code I've seen some intermittent failures when running `make -j8 check`. pcwalton seems to think this is to do with some parallel check going wrong, as I can't seem to reproduce the errors with just a usual `make check` (but they're nondeterministic errors in the first place, so that doesn't really say much). So there could be something lurking in here, but it's beyond my ken to track it down.
