### PR TITLE
Add Map::insert_with_key

### DIFF
--- a/src/libstd/map.rs
+++ b/src/libstd/map.rs
@@ -773,4 +773,25 @@ mod tests {
         assert map.get(~"b") == 2;
         assert map.get(~"c") == 3;
     }
+
+    #[test]
+    fn test_insert_with_key() {
+        let map = map::HashMap::<~str, uint>();
+
+        fn inc(k: ~str, v0: uint, v1: uint) -> uint {
+            v0 + v1
+        }
+
+        map.insert_with_key(inc, ~"cat", 1);
+        map.insert_with_key(inc, ~"mongoose", 1);
+        map.insert_with_key(inc, ~"cat", 7);
+        map.insert_with_key(inc, ~"ferret", 3);
+        map.insert_with_key(inc, ~"cat", 2);
+
+        assert 10 == option::get(map.find(~"cat"));
+        assert  3 == option::get(map.find(~"ferret"));
+        assert  1 == option::get(map.find(~"mongoose"));
+
+        assert None == map.find(~"unicorn");
+    }
 }

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -103,11 +103,15 @@ impl<V: Copy> SmallIntMap<V>: map::Map<uint, V> {
     pure fn find(key: uint) -> Option<V> { find(self, key) }
     fn rehash() { fail }
 
-    fn insert_with_key(ff: fn(uint, V, V) -> V, key: uint, val: V) -> bool {
+    fn insert_with_key(key: uint, val: V, ff: fn(uint, V, V) -> V) -> bool {
         match self.find(key) {
             None            => return self.insert(key, val),
             Some(copy orig) => return self.insert(key, ff(key, orig, val)),
         }
+    }
+
+    fn insert_with(key: uint, newval: V, ff: fn(V, V) -> V) -> bool {
+        return self.insert_with_key(key, newval, |_k, v, v1| ff(v,v1));
     }
 
     pure fn each(it: fn(key: uint, value: V) -> bool) {
@@ -148,4 +152,38 @@ impl<V: Copy> SmallIntMap<V>: ops::Index<uint, V> {
 /// Cast the given smallintmap to a map::map
 pub fn as_map<V: Copy>(s: SmallIntMap<V>) -> map::Map<uint, V> {
     s as map::Map::<uint, V>
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_insert_with_key() {
+        let map: SmallIntMap<uint> = mk();
+
+        // given a new key, initialize it with this new count, given
+        // given an existing key, add more to its count
+        fn addMoreToCount(_k: uint, v0: uint, v1: uint) -> uint {
+            v0 + v1
+        }
+
+        fn addMoreToCount_simple(v0: uint, v1: uint) -> uint {
+            v0 + v1
+        }
+
+        // count integers
+        map.insert_with(3, 1, addMoreToCount_simple);
+        map.insert_with_key(9, 1, addMoreToCount);
+        map.insert_with(3, 7, addMoreToCount_simple);
+        map.insert_with_key(5, 3, addMoreToCount);
+        map.insert_with_key(3, 2, addMoreToCount);
+
+        // check the total counts
+        assert 10 == option::get(map.find(3));
+        assert  3 == option::get(map.find(5));
+        assert  1 == option::get(map.find(9));
+
+        // sadly, no sevens were counted
+        assert None == map.find(7);
+    }
 }

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -103,6 +103,13 @@ impl<V: Copy> SmallIntMap<V>: map::Map<uint, V> {
     pure fn find(key: uint) -> Option<V> { find(self, key) }
     fn rehash() { fail }
 
+    fn insert_with_key(ff: fn(uint, V, V) -> V, key: uint, val: V) -> bool {
+        match self.find(key) {
+            None            => return self.insert(key, val),
+            Some(copy orig) => return self.insert(key, ff(key, orig, val)),
+        }
+    }
+
     pure fn each(it: fn(key: uint, value: V) -> bool) {
         self.each_ref(|k, v| it(*k, *v))
     }

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -69,7 +69,7 @@ fn find(mm: HashMap<~[u8], uint>, key: ~str) -> uint {
 // given a map, increment the counter for a key
 fn update_freq(mm: HashMap<~[u8], uint>, key: &[u8]) {
     let key = vec::slice(key, 0, key.len());
-    mm.insert_with_key(|k,v,v1| {v + v1}, key, 1);
+    mm.insert_with(key, 1, |v,v1| { v+v1 });
 }
 
 // given a ~[u8], for each window call a function

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -69,10 +69,7 @@ fn find(mm: HashMap<~[u8], uint>, key: ~str) -> uint {
 // given a map, increment the counter for a key
 fn update_freq(mm: HashMap<~[u8], uint>, key: &[u8]) {
     let key = vec::slice(key, 0, key.len());
-    match mm.find(key) {
-      option::None      => { mm.insert(key, 1u      ); }
-      option::Some(val) => { mm.insert(key, 1u + val); }
-    }
+    mm.insert_with_key(|k,v,v1| {v + v1}, key, 1);
 }
 
 // given a ~[u8], for each window call a function

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -66,10 +66,7 @@ fn find(mm: HashMap<~[u8], uint>, key: ~str) -> uint {
 // given a map, increment the counter for a key
 fn update_freq(mm: HashMap<~[u8], uint>, key: &[u8]) {
     let key = vec::slice(key, 0, key.len());
-    match mm.find(key) {
-      option::None      => { mm.insert(key, 1u      ); }
-      option::Some(val) => { mm.insert(key, 1u + val); }
-    }
+    mm.insert_with_key(|k,v,v1| {v + v1}, key, 1);
 }
 
 // given a ~[u8], for each window call a function

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -66,7 +66,7 @@ fn find(mm: HashMap<~[u8], uint>, key: ~str) -> uint {
 // given a map, increment the counter for a key
 fn update_freq(mm: HashMap<~[u8], uint>, key: &[u8]) {
     let key = vec::slice(key, 0, key.len());
-    mm.insert_with_key(|k,v,v1| {v + v1}, key, 1);
+    mm.insert_with(key, 1, |v,v1| { v+v1 });
 }
 
 // given a ~[u8], for each window call a function

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -61,10 +61,17 @@ impl<T: Copy> cat<T> : Map<int, T> {
      else { None }
   }
 
-  fn insert_with_key(ff: fn(+k: int, +v0: T, +v1: T) -> T, +key: int, +val: T) -> bool {
+  fn insert_with_key(+key: int, +val: T, ff: fn(+k: int, +v0: T, +v1: T) -> T) -> bool {
     match self.find(key) {
       None            => return self.insert(key, val),
       Some(copy orig) => return self.insert(key, ff(key, orig, val))
+    }
+  }
+
+  fn insert_with(+key: int, +val: T, ff: fn(+v0: T, +v1: T) -> T) -> bool {
+    match self.find(key) {
+      None            => return self.insert(key, val),
+      Some(copy orig) => return self.insert(key, ff(orig, val))
     }
   }
 

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -61,6 +61,14 @@ impl<T: Copy> cat<T> : Map<int, T> {
      else { None }
   }
 
+  fn insert_with_key(ff: fn(+k: int, +v0: T, +v1: T) -> T, +key: int, +val: T) -> bool {
+    match self.find(key) {
+      None            => return self.insert(key, val),
+      Some(copy orig) => return self.insert(key, ff(key, orig, val))
+    }
+  }
+
+
   fn remove(+k:int) -> bool {
     match self.find(k) {
       Some(x) => {


### PR DESCRIPTION
As discussed in #2504, this adds an `insert_with_key` ([as in Haskell](http://hackage.haskell.org/packages/archive/containers/0.4.0.0/doc/html/Data-Map.html#g:5 as in Haskell)) to the `Map` trait.
