### PR TITLE
Make staticness mismatch a fatal error

### DIFF
--- a/src/test/compile-fail/issue-3969.rs
+++ b/src/test/compile-fail/issue-3969.rs
@@ -1,0 +1,15 @@
+struct Bike {
+    name: ~str,
+}
+
+trait BikeMethods {
+    fn woops(&const self) -> ~str;
+}
+
+pub impl Bike : BikeMethods {
+    static fn woops(&const self) -> ~str { ~"foo" }
+    //~^ ERROR method `woops` is declared as static in its impl, but not in its trait
+}
+
+pub fn main() {
+}

--- a/src/test/compile-fail/staticness-mismatch.rs
+++ b/src/test/compile-fail/staticness-mismatch.rs
@@ -4,7 +4,7 @@ trait foo {
 }
 
 impl int: foo {
-    fn bar() {} //~ ERROR self type does not match the trait method's
+    fn bar() {} //~ ERROR method `bar` is declared as static in its trait, but not in its impl
 }
 
 fn main() {}


### PR DESCRIPTION
Exit with a fatal error, instead of recording a non-fatal error,
when we encounter an impl method that's static when its corresponding
trait method isn't (or vice versa). This is because code later on in
the typechecker will expect the staticness of the two methods to be
consistent and ICE otherwise.

As per #3969

r? @nikomatsakis
