### PR TITLE
syntax: switch tt quoter to emit ~[tt], not tt.

### DIFF
--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -79,6 +79,11 @@ fn mk_uniq_vec_e(cx: ext_ctxt, sp: span, exprs: ~[@ast::expr]) ->
    @ast::expr {
     mk_vstore_e(cx, sp, mk_base_vec_e(cx, sp, exprs), ast::expr_vstore_uniq)
 }
+fn mk_slice_vec_e(cx: ext_ctxt, sp: span, exprs: ~[@ast::expr]) ->
+   @ast::expr {
+    mk_vstore_e(cx, sp, mk_base_vec_e(cx, sp, exprs),
+                ast::expr_vstore_slice)
+}
 fn mk_fixed_vec_e(cx: ext_ctxt, sp: span, exprs: ~[@ast::expr]) ->
    @ast::expr {
     mk_vstore_e(cx, sp, mk_base_vec_e(cx, sp, exprs),

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -5,7 +5,7 @@ use ast::{crate, expr_, expr_mac, mac_invoc, mac_invoc_tt,
 use fold::*;
 use ext::base::*;
 use ext::qquote::{qq_helper};
-use parse::{parser, parse_expr_from_source_str, new_parser_from_tt};
+use parse::{parser, parse_expr_from_source_str, new_parser_from_tts};
 
 
 use codemap::{span, ExpandedFrom};

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -473,6 +473,7 @@ trait ext_ctxt_parse_utils {
     fn parse_item(s: ~str) -> @ast::item;
     fn parse_expr(s: ~str) -> @ast::expr;
     fn parse_stmt(s: ~str) -> @ast::stmt;
+    fn parse_tts(s: ~str) -> ~[ast::token_tree];
 }
 
 impl ext_ctxt: ext_ctxt_parse_utils {
@@ -503,6 +504,14 @@ impl ext_ctxt: ext_ctxt_parse_utils {
 
     fn parse_expr(s: ~str) -> @ast::expr {
         parse::parse_expr_from_source_str(
+            ~"***protocol expansion***",
+            @(copy s),
+            self.cfg(),
+            self.parse_sess())
+    }
+
+    fn parse_tts(s: ~str) -> ~[ast::token_tree] {
+        parse::parse_tts_from_source_str(
             ~"***protocol expansion***",
             @(copy s),
             self.cfg(),

--- a/src/libsyntax/parse.rs
+++ b/src/libsyntax/parse.rs
@@ -5,12 +5,13 @@ export new_parse_sess, new_parse_sess_special_handler;
 export next_node_id;
 export new_parser_from_file, new_parser_etc_from_file;
 export new_parser_from_source_str;
-export new_parser_from_tt;
+export new_parser_from_tts;
 export new_sub_parser_from_file;
 export parse_crate_from_file, parse_crate_from_crate_file;
 export parse_crate_from_source_str;
 export parse_expr_from_source_str, parse_item_from_source_str;
 export parse_stmt_from_source_str;
+export parse_tts_from_source_str;
 export parse_from_source_str;
 
 use parser::Parser;
@@ -127,6 +128,16 @@ fn parse_stmt_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
     return r;
 }
 
+fn parse_tts_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
+                             sess: parse_sess) -> ~[ast::token_tree] {
+    let p = new_parser_from_source_str(sess, cfg, name,
+                                       codemap::FssNone, source);
+    p.quote_depth += 1u;
+    let r = p.parse_all_token_trees();
+    p.abort_if_errors();
+    return r;
+}
+
 fn parse_from_source_str<T>(f: fn (p: Parser) -> T,
                             name: ~str, ss: codemap::FileSubstr,
                             source: @~str, cfg: ast::crate_cfg,
@@ -199,9 +210,9 @@ fn new_sub_parser_from_file(sess: parse_sess, cfg: ast::crate_cfg,
     }
 }
 
-fn new_parser_from_tt(sess: parse_sess, cfg: ast::crate_cfg,
-                      tt: ~[ast::token_tree]) -> Parser {
+fn new_parser_from_tts(sess: parse_sess, cfg: ast::crate_cfg,
+                       tts: ~[ast::token_tree]) -> Parser {
     let trdr = lexer::new_tt_reader(sess.span_diagnostic, sess.interner,
-                                    None, tt);
+                                    None, tts);
     return Parser(sess, cfg, trdr as reader)
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1321,6 +1321,14 @@ impl Parser {
         };
     }
 
+    fn parse_all_token_trees() -> ~[token_tree] {
+        let tts = DVec();
+        while self.token != token::EOF {
+            tts.push(self.parse_token_tree());
+        }
+        tts.get()
+    }
+
     fn parse_matchers() -> ~[matcher] {
         // unification of matchers and token_trees would vastly improve
         // the interpolation of matchers

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -1,10 +1,12 @@
+#[allow(non_implicitly_copyable_typarams)];
+
 extern mod syntax;
 
 use syntax::ext::base::ext_ctxt;
 
 fn syntax_extension(ext_cx: @ext_ctxt) {
-    let e_toks : syntax::ast::token_tree = quote_tokens!(1 + 2);
-    let p_toks : syntax::ast::token_tree = quote_tokens!((x, 1 .. 4, *));
+    let e_toks : ~[syntax::ast::token_tree] = quote_tokens!(1 + 2);
+    let p_toks : ~[syntax::ast::token_tree] = quote_tokens!((x, 1 .. 4, *));
 
     let _a: @syntax::ast::expr = quote_expr!(1 + 2);
     let _b: Option<@syntax::ast::item> = quote_item!( const foo : int = $e_toks; );
@@ -14,6 +16,6 @@ fn syntax_extension(ext_cx: @ext_ctxt) {
 }
 
 fn main() {
-    let _x: syntax::ast::token_tree = quote_tokens!(a::Foo::foo());
+    let _x: ~[syntax::ast::token_tree] = quote_tokens!(a::Foo::foo());
 }
 


### PR DESCRIPTION
This is just a small change to make the tt quasiquoter quote ~[token_tree] vectors, rather than token_tree values. It is less efficient this way but it seems like the only sensible interpretation given the semantics of token trees: their nesting is mostly incidental and doesn't actually represent the expression or item structure (for example: `if foo { ... }` is three token-trees, despite being one expression).

r? @brson
