### PR TITLE
Introduce a T_err type for type errors

### DIFF
--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -318,6 +318,7 @@ fn enc_sty(w: io::Writer, cx: @ctxt, st: ty::sty) {
           debug!("~~~~ %s", ~"]");
           w.write_char(']');
       }
+      ty::ty_err => fail ~"Shouldn't encode error type"
     }
 }
 

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -266,6 +266,7 @@ impl reflector {
           // Miscallaneous extra types
           ty::ty_trait(_, _, _) => self.leaf(~"trait"),
           ty::ty_infer(_) => self.leaf(~"infer"),
+          ty::ty_err => self.leaf(~"err"),
           ty::ty_param(p) => self.visit(~"param", ~[self.c_uint(p.idx)]),
           ty::ty_self => self.leaf(~"self"),
           ty::ty_type => self.leaf(~"type"),

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -179,6 +179,7 @@ fn type_of(cx: @crate_ctxt, t: ty::t) -> TypeRef {
       ty::ty_self => cx.tcx.sess.unimpl(~"type_of: ty_self"),
       ty::ty_infer(*) => cx.tcx.sess.bug(~"type_of with ty_infer"),
       ty::ty_param(*) => cx.tcx.sess.bug(~"type_of with ty_param"),
+      ty::ty_err(*) => cx.tcx.sess.bug(~"type_of with ty_err")
     };
 
     cx.lltypes.insert(t, llty);

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -697,6 +697,8 @@ impl LookupContext {
                     |m,r| ty::mk_rptr(tcx, r, {ty:self_ty, mutbl:m}))
             }
 
+            ty_err => None,
+
             ty_opaque_closure_ptr(_) | ty_unboxed_vec(_) |
             ty_opaque_box | ty_type | ty_infer(TyVar(_)) => {
                 self.bug(fmt!("Unexpected type: %s",

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -476,13 +476,7 @@ fn demand_suptype(vcx: &VtableContext, sp: span, e: ty::t, a: ty::t) {
     match infer::mk_subty(vcx.infcx, false, sp, a, e) {
         result::Ok(()) => {} // Ok.
         result::Err(ref err) => {
-            vcx.tcx().sess.span_err(
-                sp,
-                fmt!("mismatched types: expected `%s` but found `%s` (%s)",
-                     vcx.infcx.ty_to_str(e),
-                     vcx.infcx.ty_to_str(a),
-                     ty::type_err_to_str(vcx.tcx(), err)));
-            ty::note_and_explain_type_err(vcx.tcx(), err);
+            vcx.infcx.report_mismatched_types(sp, e, a, err);
         }
     }
 }

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -13,7 +13,7 @@ use middle::ty::{DerivedMethodInfo, ProvidedMethodSource, get};
 use middle::ty::{lookup_item_type, subst, t, ty_bot, ty_box, ty_class};
 use middle::ty::{ty_bool, ty_enum, ty_int, ty_nil, ty_ptr, ty_rptr, ty_uint};
 use middle::ty::{ty_float, ty_estr, ty_evec, ty_rec, ty_uniq};
-use middle::ty::{ty_fn, ty_trait, ty_tup, ty_infer};
+use middle::ty::{ty_err, ty_fn, ty_trait, ty_tup, ty_infer};
 use middle::ty::{ty_param, ty_self, ty_type, ty_opaque_box};
 use middle::ty::{ty_opaque_closure_ptr, ty_unboxed_vec, type_is_ty_var};
 use middle::typeck::infer::{infer_ctxt, can_mk_subty};
@@ -76,7 +76,7 @@ fn get_base_type(inference_context: infer_ctxt, span: span, original_type: t)
         ty_estr(*) | ty_evec(*) | ty_rec(*) |
         ty_fn(*) | ty_tup(*) | ty_infer(*) |
         ty_param(*) | ty_self | ty_type | ty_opaque_box |
-        ty_opaque_closure_ptr(*) | ty_unboxed_vec(*) => {
+        ty_opaque_closure_ptr(*) | ty_unboxed_vec(*) | ty_err => {
             debug!("(getting base type) no base type; found %?",
                    get(original_type).sty);
             None

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -9,7 +9,7 @@ use middle::ty::{mt, t, param_bound};
 use middle::ty::{re_bound, re_free, re_scope, re_infer, re_static, Region};
 use middle::ty::{ReSkolemized, ReVar};
 use middle::ty::{ty_bool, ty_bot, ty_box, ty_class, ty_enum};
-use middle::ty::{ty_estr, ty_evec, ty_float, ty_fn, ty_trait, ty_int};
+use middle::ty::{ty_err, ty_estr, ty_evec, ty_float, ty_fn, ty_trait, ty_int};
 use middle::ty::{ty_nil, ty_opaque_box, ty_opaque_closure_ptr, ty_param};
 use middle::ty::{ty_ptr, ty_rec, ty_rptr, ty_self, ty_tup};
 use middle::ty::{ty_type, ty_uniq, ty_uint, ty_infer};
@@ -390,6 +390,7 @@ fn ty_to_str(cx: ctxt, typ: t) -> ~str {
                   f.meta.ret_style)
       }
       ty_infer(infer_ty) => infer_ty.to_str(),
+      ty_err => ~"[type error]",
       ty_param({idx: id, _}) => {
         ~"'" + str::from_bytes(~[('a' as u8) + (id as u8)])
       }

--- a/src/test/compile-fail/cast-from-nil.rs
+++ b/src/test/compile-fail/cast-from-nil.rs
@@ -1,2 +1,2 @@
-// error-pattern: cast from nil: () as u32
+// error-pattern: cast from nil: `()` as `u32`
 fn main() { let u = (assert true) as u32; }

--- a/src/test/compile-fail/cast-to-nil.rs
+++ b/src/test/compile-fail/cast-to-nil.rs
@@ -1,2 +1,2 @@
-// error-pattern: cast to nil: u32 as ()
+// error-pattern: cast to nil: `u32` as `()`
 fn main() { let u = 0u32 as (); }

--- a/src/test/compile-fail/extern-no-call.rs
+++ b/src/test/compile-fail/extern-no-call.rs
@@ -1,4 +1,4 @@
-// error-pattern:expected function or foreign function but found *u8
+// error-pattern:expected function or foreign function but found `*u8`
 extern fn f() {
 }
 

--- a/src/test/compile-fail/issue-1871.rs
+++ b/src/test/compile-fail/issue-1871.rs
@@ -1,11 +1,12 @@
-// xfail-test
+// Tests that we don't generate a spurious error about f.honk's type
+// being undeterminable
 fn main() {
   let f = 42;
 
   let _g = if f < 5 {
-      f.honk();
+      f.honk() //~ ERROR attempted access of field `honk`
   }
   else {
-    12
+      ()
   };
 }

--- a/src/test/compile-fail/issue-2149.rs
+++ b/src/test/compile-fail/issue-2149.rs
@@ -11,5 +11,5 @@ impl<A> ~[A]: vec_monad<A> {
    }
 }
 fn main() {
-    ["hi"].bind({|x| [x] });
+    ["hi"].bind({|x| [x] }); //~ ERROR attempted access of field `bind`
 }


### PR DESCRIPTION
This allows more errors to be non-fatal, as per #1871.

I only went through and started changing span_fatal to span_err in
check.rs. There are probably more errors that could be made
non-fatal.

r? @graydon
