### PR TITLE
Inline numeric operations for floats.

### DIFF
--- a/src/libcore/float.rs
+++ b/src/libcore/float.rs
@@ -436,14 +436,22 @@ impl float : Ord {
 }
 
 impl float: num::Num {
+    #[inline(always)]
     pub pure fn add(other: &float)    -> float { return self + *other; }
+    #[inline(always)]
     pub pure fn sub(other: &float)    -> float { return self - *other; }
+    #[inline(always)]
     pub pure fn mul(other: &float)    -> float { return self * *other; }
+    #[inline(always)]
     pub pure fn div(other: &float)    -> float { return self / *other; }
+    #[inline(always)]
     pure fn modulo(other: &float) -> float { return self % *other; }
+    #[inline(always)]
     pure fn neg()                  -> float { return -self;        }
 
+    #[inline(always)]
     pure fn to_int()         -> int   { return self as int; }
+    #[inline(always)]
     static pure fn from_int(n: int) -> float { return n as float;  }
 }
 


### PR DESCRIPTION
These are just single instruction anyway, so there's no reason not to inline them. This resulted in a pretty dramatic performance improvement on some of my generic matrix math code.
