### PR TITLE
Made Tm_ a struct instead of a record and added serialization support to...

### DIFF
--- a/src/test/run-pass/auto_serialize.rs
+++ b/src/test/run-pass/auto_serialize.rs
@@ -10,6 +10,7 @@ use EBWriter = std::ebml::Writer;
 use io::Writer;
 use std::serialization::{Serializable, Deserializable, deserialize};
 use std::prettyprint;
+use std::time;
 
 fn test_prettyprint<A: Serializable<prettyprint::Serializer>>(
     a: &A,
@@ -183,5 +184,8 @@ fn main() {
 
     let a = &B;
     test_prettyprint(a, &~"B");
+    test_ebml(a);
+
+    let a = &time::now();
     test_ebml(a);
 }


### PR DESCRIPTION
... Tm and Tm_.

Not entirely clear what the best way to do this is. Right now we persist the entire
struct which seems to be both portable and exactly round-trippable.
