### PR TITLE
Fix sample code in the tutorial

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2043,8 +2043,9 @@ as in this version of `print_all` that copies elements.
 fn print_all<T: Printable Copy>(printable_things: ~[T]) {
     let mut i = 0;
     while i < printable_things.len() {
-        let copy_of_thing = printable_things[0];
+        let copy_of_thing = printable_things[i];
         copy_of_thing.print();
+        i += 1;
     }
 }
 ~~~


### PR DESCRIPTION
This is a small patch to fix the while loop in the second print_all function in the tutorial.
