### PR TITLE
Bugfix for macros that call macros and for `trace_macro!`

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -244,10 +244,14 @@ fn core_macros() -> ~str {
     return
 ~"{
     macro_rules! ignore (($($x:tt)*) => (()))
-    #macro[[#error[f, ...], log(core::error, #fmt[f, ...])]];
-    #macro[[#warn[f, ...], log(core::warn, #fmt[f, ...])]];
-    #macro[[#info[f, ...], log(core::info, #fmt[f, ...])]];
-    #macro[[#debug[f, ...], log(core::debug, #fmt[f, ...])]];
+    macro_rules! error ( ($( $arg:expr ),+) => (
+        log(core::error, fmt!( $($arg),+ )) ))
+    macro_rules! warn ( ($( $arg:expr ),+) => (
+        log(core::warn, fmt!( $($arg),+ )) ))
+    macro_rules! info ( ($( $arg:expr ),+) => (
+        log(core::info, fmt!( $($arg),+ )) ))
+    macro_rules! debug ( ($( $arg:expr ),+) => (
+        log(core::debug, fmt!( $($arg),+ )) ))
 }";
 }
 

--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -15,12 +15,16 @@ fn expand_trace_macros(cx: ext_ctxt, sp: span,
     let rdr = tt_rdr as reader;
     let rust_parser = Parser(sess, cfg, rdr.dup());
 
-    let arg = cx.str_of(rust_parser.parse_ident());
-    match arg {
-      ~"true"  => cx.set_trace_macros(true),
-      ~"false" => cx.set_trace_macros(false),
-      _ => cx.span_fatal(sp, ~"trace_macros! only accepts `true` or `false`")
+    if rust_parser.is_keyword(~"true") {
+        cx.set_trace_macros(true);
+    } else if rust_parser.is_keyword(~"false") {
+        cx.set_trace_macros(false);
+    } else {
+        cx.span_fatal(sp, ~"trace_macros! only accepts `true` or `false`")
     }
+
+    rust_parser.bump();
+
     let rust_parser = Parser(sess, cfg, rdr.dup());
     let result = rust_parser.parse_expr();
     base::mr_expr(result)

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -368,11 +368,7 @@ fn parse(sess: parse_sess, cfg: ast::crate_cfg, rdr: reader, ms: ~[matcher])
                 }
                 cur_eis.push(move ei);
 
-                /* this would fail if zero-length tokens existed */
-                while rdr.peek().sp.lo < rust_parser.span.lo {
-                    rdr.next_token();
-                } /* except for EOF... */
-                while rust_parser.token == EOF && rdr.peek().tok != EOF {
+                for rust_parser.tokens_consumed.times() || {
                     rdr.next_token();
                 }
             }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -192,6 +192,7 @@ fn Parser(sess: parse_sess, cfg: ast::crate_cfg,
         buffer: [mut {tok: tok0.tok, sp: span0}, ..4],
         buffer_start: 0,
         buffer_end: 0,
+        tokens_consumed: 0u,
         restriction: UNRESTRICTED,
         quote_depth: 0u,
         keywords: token::keyword_table(),
@@ -210,6 +211,7 @@ struct Parser {
     mut buffer: [mut {tok: token::Token, sp: span} * 4],
     mut buffer_start: int,
     mut buffer_end: int,
+    mut tokens_consumed: uint,
     mut restriction: restriction,
     mut quote_depth: uint, // not (yet) related to the quasiquoter
     reader: reader,
@@ -236,6 +238,7 @@ impl Parser {
         };
         self.token = next.tok;
         self.span = next.sp;
+        self.tokens_consumed += 1u;
     }
     fn swap(next: token::Token, +lo: BytePos, +hi: BytePos) {
         self.token = next;


### PR DESCRIPTION
This should make #3516 easier to do (the `#macro`s in expand.rs have been removed). 
