### PR TITLE
Trait inheritance for bounded type parameters

### DIFF
--- a/src/libcore/f32.rs
+++ b/src/libcore/f32.rs
@@ -138,6 +138,18 @@ pub pure fn logarithm(n: f32, b: f32) -> f32 {
     return log2(n) / log2(b);
 }
 
+impl f32 : cmp::Eq {
+    pure fn eq(&self, other: &f32) -> bool { (*self) == (*other) }
+    pure fn ne(&self, other: &f32) -> bool { (*self) != (*other) }
+}
+
+impl f32 : cmp::Ord {
+    pure fn lt(&self, other: &f32) -> bool { (*self) < (*other) }
+    pure fn le(&self, other: &f32) -> bool { (*self) <= (*other) }
+    pure fn ge(&self, other: &f32) -> bool { (*self) >= (*other) }
+    pure fn gt(&self, other: &f32) -> bool { (*self) > (*other) }
+}
+
 impl f32: num::Num {
     pure fn add(other: &f32)    -> f32 { return self + *other; }
     pure fn sub(other: &f32)    -> f32 { return self - *other; }

--- a/src/libcore/f64.rs
+++ b/src/libcore/f64.rs
@@ -157,6 +157,18 @@ pub pure fn logarithm(n: f64, b: f64) -> f64 {
     return log2(n) / log2(b);
 }
 
+impl f64 : cmp::Eq {
+    pure fn eq(&self, other: &f64) -> bool { (*self) == (*other) }
+    pure fn ne(&self, other: &f64) -> bool { (*self) != (*other) }
+}
+
+impl f64 : cmp::Ord {
+    pure fn lt(&self, other: &f64) -> bool { (*self) < (*other) }
+    pure fn le(&self, other: &f64) -> bool { (*self) <= (*other) }
+    pure fn ge(&self, other: &f64) -> bool { (*self) >= (*other) }
+    pure fn gt(&self, other: &f64) -> bool { (*self) > (*other) }
+}
+
 impl f64: num::Num {
     pure fn add(other: &f64)    -> f64 { return self + *other; }
     pure fn sub(other: &f64)    -> f64 { return self - *other; }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -37,6 +37,7 @@ pub trait Times {
 pub trait CopyableIter<A:Copy> {
     pure fn filter_to_vec(pred: fn(a: A) -> bool) -> ~[A];
     pure fn map_to_vec<B>(op: fn(v: A) -> B) -> ~[B];
+    pure fn flat_map_to_vec<B:Copy,IB: BaseIter<B>>(op: fn(A) -> IB) -> ~[B];
     pure fn to_vec() -> ~[A];
     pure fn find(p: fn(a: A) -> bool) -> Option<A>;
 }

--- a/src/libcore/path.rs
+++ b/src/libcore/path.rs
@@ -44,6 +44,9 @@ pub trait GenericPath {
     pure fn with_filestem((&str)) -> self;
     pure fn with_filetype((&str)) -> self;
 
+    pure fn dir_path() -> self;
+    pure fn file_path() -> self;
+
     pure fn push((&str)) -> self;
     pure fn push_rel((&self)) -> self;
     pure fn push_many((&[~str])) -> self;

--- a/src/libcore/reflect.rs
+++ b/src/libcore/reflect.rs
@@ -34,9 +34,7 @@ pub fn MovePtrAdaptor<V: TyVisitor MovePtr>(v: V) -> MovePtrAdaptor<V> {
     MovePtrAdaptor { inner: move v }
 }
 
-/// Abstract type-directed pointer-movement using the MovePtr trait
-impl<V: TyVisitor MovePtr> MovePtrAdaptor<V>: TyVisitor {
-
+impl<V: TyVisitor MovePtr> MovePtrAdaptor<V> {
     #[inline(always)]
     fn bump(sz: uint) {
       do self.inner.move_ptr() |p| {
@@ -60,7 +58,10 @@ impl<V: TyVisitor MovePtr> MovePtrAdaptor<V>: TyVisitor {
     fn bump_past<T>() {
         self.bump(sys::size_of::<T>());
     }
+}
 
+/// Abstract type-directed pointer-movement using the MovePtr trait
+impl<V: TyVisitor MovePtr> MovePtrAdaptor<V>: TyVisitor {
     fn visit_bot() -> bool {
         self.align_to::<()>();
         if ! self.inner.visit_bot() { return false; }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1330,16 +1330,12 @@ fn find_vtable(tcx: ty::ctxt, ps: &param_substs,
     debug!("find_vtable_in_fn_ctxt(n_param=%u, n_bound=%u, ps=%?)",
            n_param, n_bound, param_substs_to_str(tcx, ps));
 
-    let mut vtable_off = n_bound, i = 0u;
     // Vtables are stored in a flat array, finding the right one is
     // somewhat awkward
-    for vec::each(*ps.bounds) |bounds| {
-        if i >= n_param { break; }
-        for vec::each(**bounds) |bound| {
-            match *bound { ty::bound_trait(_) => vtable_off += 1u, _ => () }
-        }
-        i += 1u;
-    }
+    let first_n_bounds = ps.bounds.view(0, n_param);
+    let vtables_to_skip =
+        ty::count_traits_and_supertraits(tcx, first_n_bounds);
+    let vtable_off = vtables_to_skip + n_bound;
     ps.vtables.get()[vtable_off]
 }
 

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -243,17 +243,7 @@ fn trans_static_method_callee(bcx: block,
     // one we are interested in.
     let bound_index = {
         let trait_polyty = ty::lookup_item_type(bcx.tcx(), trait_id);
-        let mut index = 0;
-        for trait_polyty.bounds.each |param_bounds| {
-            for param_bounds.each |param_bound| {
-                match *param_bound {
-                    ty::bound_trait(_) => { index += 1; }
-                    ty::bound_copy | ty::bound_owned |
-                    ty::bound_send | ty::bound_const => {}
-                }
-            }
-        }
-        index
+        ty::count_traits_and_supertraits(bcx.tcx(), *trait_polyty.bounds)
     };
 
     let mname = if method_id.crate == ast::local_crate {

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -124,46 +124,8 @@ fn lookup_vtable_covariant(vcx: &VtableContext,
            vcx.infcx.ty_to_str(ty),
            vcx.infcx.ty_to_str(trait_ty));
 
-    let worklist = dvec::DVec();
-    worklist.push(trait_ty);
-    while worklist.len() > 0 {
-        let trait_ty = worklist.pop();
-        let result = lookup_vtable_invariant(vcx, location_info, ty, trait_ty,
-                                             allow_unsafe, is_early);
-        if result.is_some() {
-            return result;
-        }
-
-        // Add subtraits to the worklist, if applicable.
-        match ty::get(trait_ty).sty {
-            ty::ty_trait(trait_id, _, _) => {
-                let table = vcx.ccx.coherence_info.supertrait_to_subtraits;
-                match table.find(trait_id) {
-                    None => {}
-                    Some(subtraits) => {
-                        for subtraits.each |subtrait_id| {
-                            // XXX: This is wrong; subtraits should themselves
-                            // have substs.
-                            let substs =
-                                { self_r: None, self_ty: None, tps: ~[] };
-                            let trait_ty = ty::mk_trait(vcx.tcx(),
-                                                        *subtrait_id,
-                                                        substs,
-                                                        ty::vstore_box);
-                            worklist.push(trait_ty);
-                        }
-                    }
-                }
-            }
-            _ => {
-                vcx.tcx().sess.impossible_case(location_info.span,
-                                               "lookup_vtable_covariant: \
-                                                non-trait in worklist");
-            }
-        }
-    }
-
-    return None;
+    lookup_vtable_invariant(vcx, location_info, ty, trait_ty,
+                            allow_unsafe, is_early)
 }
 
 // Look up the vtable to use when treating an item of type `t` as if it has

--- a/src/libstd/map.rs
+++ b/src/libstd/map.rs
@@ -390,7 +390,7 @@ pub mod chained {
         }
     }
 
-    impl<K:Eq IterBytes Hash Copy ToStr, V: ToStr Copy> T<K, V>: ToStr {
+    impl<K:Eq IterBytes Hash Copy ToStr, V: ToStr Copy> T<K, V> {
         fn to_writer(wr: io::Writer) {
             if self.count == 0u {
                 wr.write_str(~"{}");
@@ -410,7 +410,9 @@ pub mod chained {
             };
             wr.write_str(~" }");
         }
+    }
 
+    impl<K:Eq IterBytes Hash Copy ToStr, V: ToStr Copy> T<K, V>: ToStr {
         pure fn to_str() -> ~str unsafe {
             // Meh -- this should be safe
             do io::with_str_writer |wr| { self.to_writer(wr) }

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -824,9 +824,6 @@ impl TcpSocketBuf: io::Reader {
             bytes[0] as int
         }
     }
-    fn unread_byte(amt: int) {
-        self.data.buf.unshift(amt as u8);
-    }
     fn eof() -> bool {
         self.end_of_stream
     }

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -101,7 +101,6 @@ impl<V: Copy> SmallIntMap<V>: map::Map<uint, V> {
     }
     pure fn get(key: uint) -> V { get(self, key) }
     pure fn find(key: uint) -> Option<V> { find(self, key) }
-    fn rehash() { fail }
 
     fn update_with_key(key: uint, val: V, ff: fn(uint, V, V) -> V) -> bool {
         match self.find(key) {

--- a/src/test/auxiliary/trait_inheritance_auto_xc_2_aux.rs
+++ b/src/test/auxiliary/trait_inheritance_auto_xc_2_aux.rs
@@ -1,0 +1,11 @@
+pub trait Foo { fn f() -> int; }
+pub trait Bar { fn g() -> int; }
+pub trait Baz { fn h() -> int; }
+
+pub struct A { x: int }
+
+impl A : Foo { fn f() -> int { 10 } }
+impl A : Bar { fn g() -> int { 20 } }
+impl A : Baz { fn h() -> int { 30 } }
+
+

--- a/src/test/auxiliary/trait_inheritance_auto_xc_aux.rs
+++ b/src/test/auxiliary/trait_inheritance_auto_xc_aux.rs
@@ -1,0 +1,7 @@
+trait Foo { fn f() -> int; }
+trait Bar { fn g() -> int; }
+trait Baz { fn h() -> int; }
+
+trait Quux: Foo, Bar, Baz { }
+
+impl<T: Foo Bar Baz> T: Quux { }

--- a/src/test/auxiliary/trait_inheritance_cross_trait_call_xc_aux.rs
+++ b/src/test/auxiliary/trait_inheritance_cross_trait_call_xc_aux.rs
@@ -1,0 +1,12 @@
+
+pub trait Foo {
+    fn f() -> int;
+}
+
+pub struct A {
+    x: int
+}
+
+impl A : Foo {
+    fn f() -> int { 10 }
+}

--- a/src/test/auxiliary/trait_inheritance_overloading_xc.rs
+++ b/src/test/auxiliary/trait_inheritance_overloading_xc.rs
@@ -1,9 +1,31 @@
-pub trait MyNum : Add<self,self>, Sub<self,self>, Mul<self,self> {
+use cmp::Eq;
+
+pub trait MyNum : Add<self,self>, Sub<self,self>, Mul<self,self>, Eq {
 }
 
-pub impl int : MyNum {
-    pure fn add(other: &int) -> int { self + *other }
-    pure fn sub(&self, other: &int) -> int { *self - *other }
-    pure fn mul(&self, other: &int) -> int { *self * *other }
+pub struct MyInt {
+    val: int
 }
+
+pub impl MyInt : Add<MyInt, MyInt> {
+    pure fn add(other: &MyInt) -> MyInt { mi(self.val + other.val) }
+}
+
+pub impl MyInt : Sub<MyInt, MyInt> {
+    pure fn sub(&self, other: &MyInt) -> MyInt { mi(self.val - other.val) }
+}
+
+pub impl MyInt : Mul<MyInt, MyInt> {
+    pure fn mul(&self, other: &MyInt) -> MyInt { mi(self.val * other.val) }
+}
+
+pub impl MyInt : Eq {
+    pure fn eq(&self, other: &MyInt) -> bool { self.val == other.val }
+
+    pure fn ne(&self, other: &MyInt) -> bool { !self.eq(other) }
+}
+
+pub impl MyInt : MyNum;
+
+pure fn mi(v: int) -> MyInt { MyInt { val: v } }
 

--- a/src/test/compile-fail/trait-impl-can-not-have-untraitful-methods.rs
+++ b/src/test/compile-fail/trait-impl-can-not-have-untraitful-methods.rs
@@ -1,0 +1,7 @@
+trait A { }
+
+impl int: A {
+    fn foo() { } //~ ERROR method `foo` is not a member of trait `A`
+}
+
+fn main() { }

--- a/src/test/compile-fail/trait-inheritance-missing-requirement.rs
+++ b/src/test/compile-fail/trait-inheritance-missing-requirement.rs
@@ -1,0 +1,23 @@
+// xfail-test
+// error-pattern: what
+
+trait Foo {
+    fn f();
+}
+
+trait Bar : Foo {
+    fn g();
+}
+
+struct A {
+    x: int
+}
+
+// Can't implement Bar without an impl of Foo
+impl A : Bar {
+    fn g() { }
+}
+
+fn main() {
+}
+

--- a/src/test/run-pass/trait-inheritance-auto-xc-2.rs
+++ b/src/test/run-pass/trait-inheritance-auto-xc-2.rs
@@ -1,0 +1,23 @@
+// xfail-fast
+// aux-build:trait_inheritance_auto_xc_2_aux.rs
+
+extern mod aux(name = "trait_inheritance_auto_xc_2_aux");
+
+// aux defines impls of Foo, Bar and Baz for A
+use aux::{Foo, Bar, Baz, A};
+
+// We want to extend all Foo, Bar, Bazes to Quuxes
+pub trait Quux: Foo, Bar, Baz { }
+impl<T: Foo Bar Baz> T: Quux { }
+
+fn f<T: Quux>(a: &T) {
+    assert a.f() == 10;
+    assert a.g() == 20;
+    assert a.h() == 30;
+}
+
+fn main() {
+    let a = &A { x: 3 };
+    f(a);
+}
+

--- a/src/test/run-pass/trait-inheritance-auto-xc.rs
+++ b/src/test/run-pass/trait-inheritance-auto-xc.rs
@@ -1,0 +1,24 @@
+// xfail-fast
+// aux-build:trait_inheritance_auto_xc_aux.rs
+
+extern mod aux(name = "trait_inheritance_auto_xc_aux");
+
+use aux::{Foo, Bar, Baz, Quux};
+
+struct A { x: int }
+
+impl A : Foo { fn f() -> int { 10 } }
+impl A : Bar { fn g() -> int { 20 } }
+impl A : Baz { fn h() -> int { 30 } }
+
+fn f<T: Quux>(a: &T) {
+    assert a.f() == 10;
+    assert a.g() == 20;
+    assert a.h() == 30;
+}
+
+fn main() {
+    let a = &A { x: 3 };
+    f(a);
+}
+

--- a/src/test/run-pass/trait-inheritance-auto.rs
+++ b/src/test/run-pass/trait-inheritance-auto.rs
@@ -1,0 +1,27 @@
+// Testing that this impl turns A into a Quux, because
+// A is already a Foo Bar Baz
+impl<T: Foo Bar Baz> T: Quux { }
+
+trait Foo { fn f() -> int; }
+trait Bar { fn g() -> int; }
+trait Baz { fn h() -> int; }
+
+trait Quux: Foo, Bar, Baz { }
+
+struct A { x: int }
+
+impl A : Foo { fn f() -> int { 10 } }
+impl A : Bar { fn g() -> int { 20 } }
+impl A : Baz { fn h() -> int { 30 } }
+
+fn f<T: Quux>(a: &T) {
+    assert a.f() == 10;
+    assert a.g() == 20;
+    assert a.h() == 30;
+}
+
+fn main() {
+    let a = &A { x: 3 };
+    f(a);
+}
+

--- a/src/test/run-pass/trait-inheritance-call-bound-inherited.rs
+++ b/src/test/run-pass/trait-inheritance-call-bound-inherited.rs
@@ -6,17 +6,13 @@ struct A { x: int }
 impl A : Foo { fn f() -> int { 10 } }
 impl A : Bar { fn g() -> int { 20 } }
 
-fn ff<T:Foo>(a: &T) -> int {
-    a.f()
-}
-
+// Call a function on Foo, given a T: Bar
 fn gg<T:Bar>(a: &T) -> int {
-    a.g()
+    a.f()
 }
 
 fn main() {
     let a = &A { x: 3 };
-    assert ff(a) == 10;
-    assert gg(a) == 20;
+    assert gg(a) == 10;
 }
 

--- a/src/test/run-pass/trait-inheritance-call-bound-inherited2.rs
+++ b/src/test/run-pass/trait-inheritance-call-bound-inherited2.rs
@@ -1,22 +1,21 @@
 trait Foo { fn f() -> int; }
 trait Bar : Foo { fn g() -> int; }
+trait Baz : Bar { fn h() -> int; }
 
 struct A { x: int }
 
 impl A : Foo { fn f() -> int { 10 } }
 impl A : Bar { fn g() -> int { 20 } }
+impl A : Baz { fn h() -> int { 30 } }
 
-fn ff<T:Foo>(a: &T) -> int {
+// Call a function on Foo, given a T: Baz,
+// which is inherited via Bar
+fn gg<T: Baz>(a: &T) -> int {
     a.f()
-}
-
-fn gg<T:Bar>(a: &T) -> int {
-    a.g()
 }
 
 fn main() {
     let a = &A { x: 3 };
-    assert ff(a) == 10;
-    assert gg(a) == 20;
+    assert gg(a) == 10;
 }
 

--- a/src/test/run-pass/trait-inheritance-cast-without-call-to-supertrait.rs
+++ b/src/test/run-pass/trait-inheritance-cast-without-call-to-supertrait.rs
@@ -1,0 +1,31 @@
+// Testing that we can cast to a subtrait and call subtrait
+// methods. Not testing supertrait methods
+
+trait Foo {
+    fn f() -> int;
+}
+
+trait Bar : Foo {
+    fn g() -> int;
+}
+
+struct A {
+    x: int
+}
+
+impl A : Foo {
+    fn f() -> int { 10 }
+}
+
+impl A : Bar {
+    fn g() -> int { 20 }
+}
+
+fn main() {
+    let a = &A { x: 3 };
+    let afoo = a as &Foo;
+    let abar = a as &Bar;
+    assert afoo.f() == 10;
+    assert abar.g() == 20;
+}
+

--- a/src/test/run-pass/trait-inheritance-cast.rs
+++ b/src/test/run-pass/trait-inheritance-cast.rs
@@ -1,0 +1,33 @@
+// xfail-test
+// Testing that supertrait methods can be called on subtrait object types
+// It's not clear yet that we want this
+
+trait Foo {
+    fn f() -> int;
+}
+
+trait Bar : Foo {
+    fn g() -> int;
+}
+
+struct A {
+    x: int
+}
+
+impl A : Foo {
+    fn f() -> int { 10 }
+}
+
+impl A : Bar {
+    fn g() -> int { 20 }
+}
+
+fn main() {
+    let a = &A { x: 3 };
+    let afoo = a as &Foo;
+    let abar = a as &Bar;
+    assert afoo.f() == 10;
+    assert abar.g() == 20;
+    assert abar.f() == 10;
+}
+

--- a/src/test/run-pass/trait-inheritance-cross-trait-call-xc.rs
+++ b/src/test/run-pass/trait-inheritance-cross-trait-call-xc.rs
@@ -1,0 +1,18 @@
+// xfail-fast
+// aux-build:trait_inheritance_cross_trait_call_xc_aux.rs
+
+extern mod aux(name = "trait_inheritance_cross_trait_call_xc_aux");
+
+trait Bar : aux::Foo {
+    fn g() -> int;
+}
+
+impl aux::A : Bar {
+    fn g() -> int { self.f() }
+}
+
+fn main() {
+    let a = &aux::A { x: 3 };
+    assert a.g() == 10;
+}
+

--- a/src/test/run-pass/trait-inheritance-cross-trait-call.rs
+++ b/src/test/run-pass/trait-inheritance-cross-trait-call.rs
@@ -4,19 +4,14 @@ trait Bar : Foo { fn g() -> int; }
 struct A { x: int }
 
 impl A : Foo { fn f() -> int { 10 } }
-impl A : Bar { fn g() -> int { 20 } }
 
-fn ff<T:Foo>(a: &T) -> int {
-    a.f()
-}
-
-fn gg<T:Bar>(a: &T) -> int {
-    a.g()
+impl A : Bar {
+    // Testing that this impl can call the impl of Foo
+    fn g() -> int { self.f() }
 }
 
 fn main() {
     let a = &A { x: 3 };
-    assert ff(a) == 10;
-    assert gg(a) == 20;
+    assert a.g() == 10;
 }
 

--- a/src/test/run-pass/trait-inheritance-diamond.rs
+++ b/src/test/run-pass/trait-inheritance-diamond.rs
@@ -1,0 +1,25 @@
+// B and C both require A, so D does as well, twice, but that's just fine
+
+trait A { fn a(&self) -> int; }
+trait B: A { fn b(&self) -> int; }
+trait C: A { fn c(&self) -> int; }
+trait D: B, C { fn d(&self) -> int; }
+
+struct S { bogus: () }
+
+impl S: A { fn a(&self) -> int { 10 } }
+impl S: B { fn b(&self) -> int { 20 } }
+impl S: C { fn c(&self) -> int { 30 } }
+impl S: D { fn d(&self) -> int { 40 } }
+
+fn f<T: D>(x: &T) {
+    assert x.a() == 10;
+    assert x.b() == 20;
+    assert x.c() == 30;
+    assert x.d() == 40;
+}
+
+fn main() {
+    let value = &S { bogus: () };
+    f(value);
+}

--- a/src/test/run-pass/trait-inheritance-multiple-inheritors.rs
+++ b/src/test/run-pass/trait-inheritance-multiple-inheritors.rs
@@ -1,0 +1,20 @@
+trait A { fn a(&self) -> int; }
+trait B: A { fn b(&self) -> int; }
+trait C: A { fn c(&self) -> int; }
+
+struct S { bogus: () }
+
+impl S: A { fn a(&self) -> int { 10 } }
+impl S: B { fn b(&self) -> int { 20 } }
+impl S: C { fn c(&self) -> int { 30 } }
+
+// Both B and C inherit from A
+fn f<T: B C>(x: &T) {
+    assert x.a() == 10;
+    assert x.b() == 20;
+    assert x.c() == 30;
+}
+
+fn main() {
+    f(&S { bogus: () })
+}

--- a/src/test/run-pass/trait-inheritance-multiple-params.rs
+++ b/src/test/run-pass/trait-inheritance-multiple-params.rs
@@ -1,0 +1,23 @@
+trait A { fn a(&self) -> int; }
+trait B: A { fn b(&self) -> int; }
+trait C: A { fn c(&self) -> int; }
+
+struct S { bogus: () }
+
+impl S: A { fn a(&self) -> int { 10 } }
+impl S: B { fn b(&self) -> int { 20 } }
+impl S: C { fn c(&self) -> int { 30 } }
+
+// Multiple type params, multiple levels of inheritance
+fn f<X: A, Y: B, Z: C>(x: &X, y: &Y, z: &Z) {
+    assert x.a() == 10;
+    assert y.a() == 10;
+    assert y.b() == 20;
+    assert z.a() == 10;
+    assert z.c() == 30;
+}
+
+fn main() {
+    let s = &S { bogus: () };
+    f(s, s, s);
+}

--- a/src/test/run-pass/trait-inheritance-num.rs
+++ b/src/test/run-pass/trait-inheritance-num.rs
@@ -1,0 +1,14 @@
+use cmp::{Eq, Ord};
+use num::from_int;
+
+extern mod std;
+use std::cmp::FuzzyEq;
+
+pub trait NumExt: Num, Eq, Ord {}
+
+pub trait FloatExt: NumExt, FuzzyEq {}
+
+fn greater_than_one<T:NumExt>(n: &T) -> bool { *n > from_int(1) }
+fn greater_than_one_float<T:FloatExt>(n: &T) -> bool { *n > from_int(1) }
+
+fn main() {}

--- a/src/test/run-pass/trait-inheritance-num0.rs
+++ b/src/test/run-pass/trait-inheritance-num0.rs
@@ -1,0 +1,16 @@
+// Extending Num and using inherited static methods
+
+use num::from_int;
+
+trait Num {
+    static fn from_int(i: int) -> self;
+    fn gt(&self, other: &self) -> bool;
+}
+
+pub trait NumExt: Num { }
+
+fn greater_than_one<T:NumExt>(n: &T) -> bool {
+    n.gt(&from_int(1))
+}
+
+fn main() {}

--- a/src/test/run-pass/trait-inheritance-num1.rs
+++ b/src/test/run-pass/trait-inheritance-num1.rs
@@ -1,0 +1,12 @@
+// Using the real Num from core
+
+use cmp::Ord;
+use num::from_int;
+
+pub trait NumExt: Num, Ord { }
+
+fn greater_than_one<T:NumExt>(n: &T) -> bool {
+    *n > from_int(1)
+}
+
+fn main() {}

--- a/src/test/run-pass/trait-inheritance-num2.rs
+++ b/src/test/run-pass/trait-inheritance-num2.rs
@@ -1,0 +1,96 @@
+// A more complex example of numeric extensions
+
+use cmp::{Eq, Ord};
+use num::from_int;
+
+extern mod std;
+use std::cmp::FuzzyEq;
+
+pub trait TypeExt {}
+
+
+pub impl u8: TypeExt {}
+pub impl u16: TypeExt {}
+pub impl u32: TypeExt {}
+pub impl u64: TypeExt {}
+pub impl uint: TypeExt {}
+
+pub impl i8: TypeExt {}
+pub impl i16: TypeExt {}
+pub impl i32: TypeExt {}
+pub impl i64: TypeExt {}
+pub impl int: TypeExt {}
+
+pub impl f32: TypeExt {}
+pub impl f64: TypeExt {}
+pub impl float: TypeExt {}
+
+
+pub trait NumExt: TypeExt, Eq, Ord, Num {}
+
+pub impl u8: NumExt {}
+pub impl u16: NumExt {}
+pub impl u32: NumExt {}
+pub impl u64: NumExt {}
+pub impl uint: NumExt {}
+
+pub impl i8: NumExt {}
+pub impl i16: NumExt {}
+pub impl i32: NumExt {}
+pub impl i64: NumExt {}
+pub impl int: NumExt {}
+
+pub impl f32: NumExt {}
+pub impl f64: NumExt {}
+pub impl float: NumExt {}
+
+
+pub trait UnSignedExt: NumExt {}
+
+pub impl u8: UnSignedExt {}
+pub impl u16: UnSignedExt {}
+pub impl u32: UnSignedExt {}
+pub impl u64: UnSignedExt {}
+pub impl uint: UnSignedExt {}
+
+
+pub trait SignedExt: NumExt {}
+
+pub impl i8: SignedExt {}
+pub impl i16: SignedExt {}
+pub impl i32: SignedExt {}
+pub impl i64: SignedExt {}
+pub impl int: SignedExt {}
+
+pub impl f32: SignedExt {}
+pub impl f64: SignedExt {}
+pub impl float: SignedExt {}
+
+
+pub trait IntegerExt: NumExt {}
+
+pub impl u8: IntegerExt {}
+pub impl u16: IntegerExt {}
+pub impl u32: IntegerExt {}
+pub impl u64: IntegerExt {}
+pub impl uint: IntegerExt {}
+
+pub impl i8: IntegerExt {}
+pub impl i16: IntegerExt {}
+pub impl i32: IntegerExt {}
+pub impl i64: IntegerExt {}
+pub impl int: IntegerExt {}
+
+
+pub trait FloatExt: NumExt , FuzzyEq {}
+
+pub impl f32: FloatExt {}
+pub impl f64: FloatExt {}
+pub impl float: FloatExt {}
+
+
+fn test_float_ext<T:FloatExt>(n: T) { io::println(fmt!("%?", n < n)) }
+
+fn main() {
+    test_float_ext(1f32);
+}

--- a/src/test/run-pass/trait-inheritance-num3.rs
+++ b/src/test/run-pass/trait-inheritance-num3.rs
@@ -1,0 +1,12 @@
+use cmp::{Eq, Ord};
+use num::from_int;
+
+pub trait NumExt: Eq, Ord, Num {}
+
+pub impl f32: NumExt {}
+
+fn num_eq_one<T:NumExt>(n: T) { io::println(fmt!("%?", n == from_int(1))) }
+
+fn main() {
+    num_eq_one(1f32); // you need to actually use the function to trigger the ICE
+}

--- a/src/test/run-pass/trait-inheritance-num5.rs
+++ b/src/test/run-pass/trait-inheritance-num5.rs
@@ -1,0 +1,15 @@
+use cmp::{Eq, Ord};
+use num::from_int;
+
+pub trait NumExt: Eq, Num {}
+
+pub impl f32: NumExt {}
+pub impl int: NumExt {}
+
+fn num_eq_one<T:NumExt>() -> T {
+    from_int(1)
+}
+
+fn main() {
+    num_eq_one::<int>(); // you need to actually use the function to trigger the ICE
+}

--- a/src/test/run-pass/trait-inheritance-overloading-simple.rs
+++ b/src/test/run-pass/trait-inheritance-overloading-simple.rs
@@ -1,0 +1,25 @@
+use cmp::Eq;
+
+trait MyNum : Eq { }
+
+struct MyInt { val: int }
+
+impl MyInt : Eq {
+    pure fn eq(&self, other: &MyInt) -> bool { self.val == other.val }
+    pure fn ne(&self, other: &MyInt) -> bool { !self.eq(other) }
+}
+
+impl MyInt : MyNum;
+
+fn f<T:MyNum>(x: T, y: T) -> bool {
+    return x == y;
+}
+
+pure fn mi(v: int) -> MyInt { MyInt { val: v } }
+
+fn main() {
+    let (x, y, z) = (mi(3), mi(5), mi(3));
+    assert x != y;
+    assert x == z;
+}
+

--- a/src/test/run-pass/trait-inheritance-overloading-xc-exe.rs
+++ b/src/test/run-pass/trait-inheritance-overloading-xc-exe.rs
@@ -2,18 +2,19 @@
 // aux-build:trait_inheritance_overloading_xc.rs
 
 extern mod trait_inheritance_overloading_xc;
-use trait_inheritance_overloading_xc::MyNum;
+use trait_inheritance_overloading_xc::{MyNum, MyInt};
 
 fn f<T:Copy MyNum>(x: T, y: T) -> (T, T, T) {
     return (x + y, x - y, x * y);
 }
 
-fn main() {
-    let (x, y) = (3, 5);
-    let (a, b, c) = f(x, y);
-    assert a == 8;
-    assert b == -2;
-    assert c == 15;
-}
+pure fn mi(v: int) -> MyInt { MyInt { val: v } }
 
+fn main() {
+    let (x, y) = (mi(3), mi(5));
+    let (a, b, c) = f(x, y);
+    assert a == mi(8);
+    assert b == mi(-2);
+    assert c == mi(15);
+}
 

--- a/src/test/run-pass/trait-inheritance-overloading.rs
+++ b/src/test/run-pass/trait-inheritance-overloading.rs
@@ -1,21 +1,39 @@
-trait MyNum : Add<self,self>, Sub<self,self>, Mul<self,self> {
+use cmp::Eq;
+
+trait MyNum : Add<self,self>, Sub<self,self>, Mul<self,self>, Eq { }
+
+struct MyInt { val: int }
+
+impl MyInt : Add<MyInt, MyInt> {
+    pure fn add(other: &MyInt) -> MyInt { mi(self.val + other.val) }
 }
 
-impl int : MyNum {
-    pure fn add(other: &int) -> int { self + *other }
-    pure fn sub(&self, other: &int) -> int { *self - *other }
-    pure fn mul(&self, other: &int) -> int { *self * *other }
+impl MyInt : Sub<MyInt, MyInt> {
+    pure fn sub(&self, other: &MyInt) -> MyInt { mi(self.val - other.val) }
 }
+
+impl MyInt : Mul<MyInt, MyInt> {
+    pure fn mul(&self, other: &MyInt) -> MyInt { mi(self.val * other.val) }
+}
+
+impl MyInt : Eq {
+    pure fn eq(&self, other: &MyInt) -> bool { self.val == other.val }
+    pure fn ne(&self, other: &MyInt) -> bool { !self.eq(other) }
+}
+
+impl MyInt : MyNum;
 
 fn f<T:Copy MyNum>(x: T, y: T) -> (T, T, T) {
     return (x + y, x - y, x * y);
 }
 
+pure fn mi(v: int) -> MyInt { MyInt { val: v } }
+
 fn main() {
-    let (x, y) = (3, 5);
+    let (x, y) = (mi(3), mi(5));
     let (a, b, c) = f(x, y);
-    assert a == 8;
-    assert b == -2;
-    assert c == 15;
+    assert a == mi(8);
+    assert b == mi(-2);
+    assert c == mi(15);
 }
 

--- a/src/test/run-pass/trait-inheritance-simple.rs
+++ b/src/test/run-pass/trait-inheritance-simple.rs
@@ -1,8 +1,3 @@
-// xfail-fast
-// xfail-test
-
-// Broken on 32 bit, I guess?
-
 trait Foo {
     fn f();
 }

--- a/src/test/run-pass/trait-inheritance-static.rs
+++ b/src/test/run-pass/trait-inheritance-static.rs
@@ -1,0 +1,24 @@
+trait MyNum {
+    static fn from_int(int) -> self;
+}
+
+pub trait NumExt: MyNum { }
+
+struct S { v: int }
+
+impl S: MyNum {
+    static fn from_int(i: int) -> S {
+        S {
+            v: i
+        }
+    }
+}
+
+impl S: NumExt { }
+
+fn greater_than_one<T:NumExt>() -> T { from_int(1) }
+
+fn main() {
+    let v: S = greater_than_one();
+    assert v.v == 1;
+}

--- a/src/test/run-pass/trait-inheritance-static2.rs
+++ b/src/test/run-pass/trait-inheritance-static2.rs
@@ -1,0 +1,28 @@
+trait MyEq { }
+
+trait MyNum {
+    static fn from_int(int) -> self;
+}
+
+pub trait NumExt: MyEq, MyNum { }
+
+struct S { v: int }
+
+impl S: MyEq { }
+
+impl S: MyNum {
+    static fn from_int(i: int) -> S {
+        S {
+            v: i
+        }
+    }
+}
+
+impl S: NumExt { }
+
+fn greater_than_one<T:NumExt>() -> T { from_int(1) }
+
+fn main() {
+    let v: S = greater_than_one();
+    assert v.v == 1;
+}

--- a/src/test/run-pass/trait-inheritance-subst.rs
+++ b/src/test/run-pass/trait-inheritance-subst.rs
@@ -1,0 +1,26 @@
+pub trait Add<RHS,Result> {
+    pure fn add(rhs: &RHS) -> Result;
+}
+
+trait MyNum : Add<self,self> { }
+
+struct MyInt { val: int }
+
+impl MyInt : Add<MyInt, MyInt> {
+    pure fn add(other: &MyInt) -> MyInt { mi(self.val + other.val) }
+}
+
+impl MyInt : MyNum;
+
+fn f<T:MyNum>(x: T, y: T) -> T {
+    return x.add(&y);
+}
+
+pure fn mi(v: int) -> MyInt { MyInt { val: v } }
+
+fn main() {
+    let (x, y) = (mi(3), mi(5));
+    let z = f(x, y);
+    assert z.val == 8
+}
+

--- a/src/test/run-pass/trait-inheritance-subst2.rs
+++ b/src/test/run-pass/trait-inheritance-subst2.rs
@@ -1,0 +1,36 @@
+trait Panda<T> {
+    fn chomp(bamboo: &T) -> T;
+}
+
+trait Add<RHS,Result>: Panda<RHS> {
+    fn add(rhs: &RHS) -> Result;
+}
+
+trait MyNum : Add<self,self> { }
+
+struct MyInt { val: int }
+
+impl MyInt : Panda<MyInt> {
+    fn chomp(bamboo: &MyInt) -> MyInt {
+        mi(self.val + bamboo.val)
+    }
+}
+
+impl MyInt : Add<MyInt, MyInt> {
+    fn add(other: &MyInt) -> MyInt { self.chomp(other) }
+}
+
+impl MyInt : MyNum;
+
+fn f<T:MyNum>(x: T, y: T) -> T {
+    return x.add(&y).chomp(&y);
+}
+
+fn mi(v: int) -> MyInt { MyInt { val: v } }
+
+fn main() {
+    let (x, y) = (mi(3), mi(5));
+    let z = f(x, y);
+    assert z.val == 13;
+}
+

--- a/src/test/run-pass/trait-inheritance-visibility.rs
+++ b/src/test/run-pass/trait-inheritance-visibility.rs
@@ -1,0 +1,18 @@
+mod traits {
+    pub trait Foo { fn f() -> int; }
+
+    impl int: Foo { fn f() -> int { 10 } }
+}
+
+trait Quux: traits::Foo { }
+impl<T: traits::Foo> T: Quux { }
+
+// Foo is not in scope but because Quux is we can still access
+// Foo's methods on a Quux bound typaram
+fn f<T: Quux>(x: &T) {
+    assert x.f() == 10;
+}
+
+fn main() {
+    f(&0)
+}

--- a/src/test/run-pass/trait-inheritance2.rs
+++ b/src/test/run-pass/trait-inheritance2.rs
@@ -1,0 +1,24 @@
+trait Foo { fn f() -> int; }
+trait Bar { fn g() -> int; }
+trait Baz { fn h() -> int; }
+
+trait Quux: Foo, Bar, Baz { }
+
+struct A { x: int }
+
+impl A : Foo { fn f() -> int { 10 } }
+impl A : Bar { fn g() -> int { 20 } }
+impl A : Baz { fn h() -> int { 30 } }
+impl A : Quux;
+
+fn f<T: Quux Foo Bar Baz>(a: &T) {
+    assert a.f() == 10;
+    assert a.g() == 20;
+    assert a.h() == 30;
+}
+
+fn main() {
+    let a = &A { x: 3 };
+    f(a);
+}
+


### PR DESCRIPTION
r? @pcwalton

This makes trait inheritance work for lots of test cases involving bounded type parameters, type substitutions and static methods.

Here's one with type substitutions: https://github.com/brson/rust/blob/39dbf4fe74925b1c238c8bc82911e85fd91c3d0b/src/test/run-pass/trait-inheritance-overloading.rs

And one with static methods: https://github.com/brson/rust/blob/39dbf4fe74925b1c238c8bc82911e85fd91c3d0b/src/test/run-pass/trait-inheritance-static2.rs

The basic strategy it uses is to expand bound lists to include their supertraits, in

```
trait A { } trait B: A { }
fn<T: B>() { }
```

`<T: B>` is treated in the internal vtable calculations as `<T: B A>`. This is made easier and more obvious by the limitation that each impl implements a single trait, not that trait and its supertraits.

```
trait A { fn f() }
trait B: A { fn g() }

impl S: A { fn f() }
impl S: B { fn g() }
```

This limitation makes the implementation straightforword and has no new implications for coherence. `trait B: A` just means that to instantiate B there must also be an impl of A. The trait inheritance list has strong parallels to the bounded typaram list.

I still don't understand type substitutions and why [`lookup_vtables`](https://github.com/brson/rust/blob/39dbf4fe74925b1c238c8bc82911e85fd91c3d0b/src/librustc/middle/typeck/check/vtable.rs#L52) and [`push_inherent_candidates_for_param`](https://github.com/brson/rust/blob/39dbf4fe74925b1c238c8bc82911e85fd91c3d0b/src/librustc/middle/typeck/check/method.rs#L308) do their substitutions differently. You can see that `push_inherent_candidates_for_param` is the only code that does the trait hierarchy traversal that doesn't use the new `iter_bound_traits_and_supertraits` code because it needs to thread substitutions through. I could keep going and try to abstract `iter_bound_traits_and_supertraits` into a generic fold but I figure now is the time to get review and see if this is looking ok.

Future work:
- Ensure that all supertraits have impls when implementing a trait. i.e. if I define `impl S: B { }` there should also be an `impl S: A { }` somewhere. This isn't required for soundness since the lack of A will be detected when somebody tries to actually use `S` as `A`, but it makes sense to enforce.
- Objects and inheritance. They don't work yet.
- Failure test cases
