### PR TITLE
libsyntax: Remove the "by-mutable-ref" obsolete syntax error; it blocks ...

### DIFF
--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -23,7 +23,6 @@ pub enum ObsoleteSyntax {
     ObsoleteClassTraits,
     ObsoletePrivSection,
     ObsoleteModeInFnType,
-    ObsoleteByMutRefMode,
     ObsoleteMoveInit,
     ObsoleteBinaryMove
 }
@@ -105,10 +104,6 @@ impl Parser : ObsoleteReporter {
                 "mode without identifier in fn type",
                 "to use a (deprecated) mode in a fn type, you should \
                  give the argument an explicit name (like `&&v: int`)"
-            ),
-            ObsoleteByMutRefMode => (
-                "by-mutable-reference mode",
-                "Declare an argument of type &mut T instead"
             ),
             ObsoleteMoveInit => (
                 "initializer-by-move",

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -20,8 +20,7 @@ use obsolete::{
     ObsoleteLowerCaseKindBounds, ObsoleteLet,
     ObsoleteFieldTerminator, ObsoleteStructCtor,
     ObsoleteWith, ObsoleteClassMethod, ObsoleteClassTraits,
-    ObsoleteModeInFnType, ObsoleteByMutRefMode,
-    ObsoleteMoveInit, ObsoleteBinaryMove,
+    ObsoleteModeInFnType, ObsoleteMoveInit, ObsoleteBinaryMove,
 };
 use ast::{_mod, add, arg, arm, attribute,
              bind_by_ref, bind_by_implicit_ref, bind_by_value, bind_by_move,
@@ -627,12 +626,7 @@ impl Parser {
     }
 
     fn parse_arg_mode() -> mode {
-        if self.eat(token::BINOP(token::AND)) {
-            self.obsolete(copy self.span,
-                          ObsoleteByMutRefMode);
-            // Bogus mode, but doesn't matter since it's an error
-            expl(by_ref)
-        } else if self.eat(token::BINOP(token::MINUS)) {
+        if self.eat(token::BINOP(token::MINUS)) {
             expl(by_move)
         } else if self.eat(token::ANDAND) {
             expl(by_ref)
@@ -642,7 +636,9 @@ impl Parser {
             } else {
                 expl(by_copy)
             }
-        } else { infer(self.get_id()) }
+        } else {
+            infer(self.get_id())
+        }
     }
 
     fn is_named_argument() -> bool {

--- a/src/test/run-pass/fn-pattern-expected-type-2.rs
+++ b/src/test/run-pass/fn-pattern-expected-type-2.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let v = [ (1, 2), (3, 4), (5, 6) ];
+    for v.each |&(x, y)| {
+        io::println(y.to_str());
+        io::println(x.to_str());
+    }
+}
+


### PR DESCRIPTION
...useful function argument patterns. Add a test for the latter.

r? @brson
