### PR TITLE
librustc: Make `a.b()` always a method call

### DIFF
--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -1047,7 +1047,7 @@ pub mod fsync {
             option::None => (),
             option::Some(level) => {
               // fail hard if not succesful
-              assert(self.arg.fsync_fn(self.arg.val, level) != -1);
+              assert((self.arg.fsync_fn)(self.arg.val, level) != -1);
             }
           }
         }

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -646,6 +646,9 @@ fn check_loans_in_expr(expr: @ast::expr,
       ast::expr_call(f, args, _) => {
         self.check_call(expr, Some(f), f.id, f.span, args);
       }
+      ast::expr_method_call(_, _, _, args, _) => {
+        self.check_call(expr, None, expr.callee_id, expr.span, args);
+      }
       ast::expr_index(_, rval) |
       ast::expr_binary(_, _, rval)
       if self.bccx.method_map.contains_key(expr.id) => {

--- a/src/librustc/middle/borrowck/gather_loans.rs
+++ b/src/librustc/middle/borrowck/gather_loans.rs
@@ -125,6 +125,25 @@ fn req_loans_in_expr(ex: @ast::expr,
         visit::visit_expr(ex, self, vt);
       }
 
+      ast::expr_method_call(_, _, _, args, _) => {
+        let arg_tys = ty::ty_fn_args(ty::node_id_to_type(self.tcx(),
+                                                         ex.callee_id));
+        let scope_r = ty::re_scope(ex.id);
+        for vec::each2(args, arg_tys) |arg, arg_ty| {
+            match ty::resolved_mode(self.tcx(), arg_ty.mode) {
+              ast::by_ref => {
+                let arg_cmt = self.bccx.cat_expr(*arg);
+                self.guarantee_valid(arg_cmt, m_imm,  scope_r);
+              }
+               ast::by_val | ast::by_move | ast::by_copy => {}
+            }
+        }
+
+        // XXX: Do something with the method receiver?
+
+        visit::visit_expr(ex, self, vt);
+      }
+
       ast::expr_match(ex_v, arms) => {
         let cmt = self.bccx.cat_expr(ex_v);
         for arms.each |arm| {

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -339,6 +339,18 @@ fn check_expr(e: @expr, cx: ctx, v: visit::vt<ctx>) {
             }
         }
       }
+      expr_method_call(_, _, _, args, _) => {
+        for ty::ty_fn_args(ty::node_id_to_type(cx.tcx, e.callee_id)).eachi
+                |i, arg_t| {
+            match ty::arg_mode(cx.tcx, *arg_t) {
+              by_copy => maybe_copy(cx, args[i],
+                     Some(("function arguments must be copyable",
+                           "try changing the function to take a \
+                            reference instead"))),
+              by_ref | by_val | by_move => ()
+            }
+        }
+      }
       expr_field(lhs, _, _) => {
         // If this is a method call with a by-val argument, we need
         // to check the copy

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -530,7 +530,8 @@ impl &mem_categorization_ctxt {
           ast::expr_swap(*) | ast::expr_assign(*) |
           ast::expr_assign_op(*) | ast::expr_fn(*) | ast::expr_fn_block(*) |
           ast::expr_assert(*) | ast::expr_ret(*) |
-          ast::expr_loop_body(*) | ast::expr_do_body(*) | ast::expr_unary(*) |
+          ast::expr_loop_body(*) | ast::expr_do_body(*) |
+          ast::expr_unary(*) | ast::expr_method_call(*) |
           ast::expr_copy(*) | ast::expr_cast(*) | ast::expr_fail(*) |
           ast::expr_vstore(*) | ast::expr_vec(*) | ast::expr_tup(*) |
           ast::expr_if(*) | ast::expr_log(*) |

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -258,7 +258,7 @@ fn resolve_expr(expr: @ast::expr, cx: ctxt, visitor: visit::vt<ctxt>) {
       // FIXME #3387
       // ast::expr_index(*) | ast::expr_binary(*) |
       // ast::expr_unary(*) |
-      ast::expr_call(*) => {
+      ast::expr_call(*) | ast::expr_method_call(*) => {
         debug!("node %d: %s", expr.id, pprust::expr_to_str(expr,
                                                            cx.sess.intr()));
         new_cx.parent = Some(expr.id);

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -16,12 +16,11 @@ use syntax::ast::{def_foreign_mod, def_id, def_label, def_local, def_mod};
 use syntax::ast::{def_prim_ty, def_region, def_self, def_ty, def_ty_param};
 use syntax::ast::{def_typaram_binder, def_static_method};
 use syntax::ast::{def_upvar, def_use, def_variant, expr, expr_assign_op};
-use syntax::ast::{expr_binary, expr_cast, expr_field, expr_fn};
-use syntax::ast::{expr_fn_block, expr_index, expr_path};
+use syntax::ast::{expr_binary, expr_break, expr_cast, expr_field, expr_fn};
+use syntax::ast::{expr_fn_block, expr_index, expr_method_call, expr_path};
 use syntax::ast::{def_prim_ty, def_region, def_self, def_ty, def_ty_param};
 use syntax::ast::{def_upvar, def_use, def_variant, div, eq};
 use syntax::ast::{enum_variant_kind, expr, expr_again, expr_assign_op};
-use syntax::ast::{expr_binary, expr_break, expr_cast, expr_field, expr_fn};
 use syntax::ast::{expr_fn_block, expr_index, expr_loop};
 use syntax::ast::{expr_path, expr_struct, expr_unary, fn_decl};
 use syntax::ast::{foreign_item, foreign_item_const, foreign_item_fn, ge};
@@ -5005,6 +5004,10 @@ impl Resolver {
     fn record_candidate_traits_for_expr_if_necessary(expr: @expr) {
         match expr.node {
             expr_field(_, ident, _) => {
+                let traits = self.search_for_traits_containing_method(ident);
+                self.trait_map.insert(expr.id, traits);
+            }
+            expr_method_call(_, ident, _, _, _) => {
                 let traits = self.search_for_traits_containing_method(ident);
                 self.trait_map.insert(expr.id, traits);
             }

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -292,6 +292,38 @@ fn trans_call(in_cx: block,
         |cx| trans(cx, f), args, dest, DontAutorefArg)
 }
 
+fn trans_method_call(in_cx: block,
+                     call_ex: @ast::expr,
+                     rcvr: @ast::expr,
+                     args: CallArgs,
+                     dest: expr::Dest)
+                  -> block {
+    let _icx = in_cx.insn_ctxt("trans_method_call");
+    trans_call_inner(
+        in_cx,
+        call_ex.info(),
+        node_id_type(in_cx, call_ex.callee_id),
+        expr_ty(in_cx, call_ex),
+        |cx| {
+            match cx.ccx().maps.method_map.find(call_ex.id) {
+                Some(origin) => {
+                    meth::trans_method_callee(cx,
+                                              call_ex.callee_id,
+                                              rcvr,
+                                              origin)
+                }
+                None => {
+                    cx.tcx().sess.span_bug(call_ex.span,
+                                           ~"method call expr wasn't in \
+                                             method map")
+                }
+            }
+        },
+        args,
+        dest,
+        DontAutorefArg)
+}
+
 fn trans_rtcall(bcx: block, name: ~str, args: ~[ValueRef], dest: expr::Dest)
     -> block
 {

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -592,6 +592,13 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
             return callee::trans_call(
                 bcx, expr, f, callee::ArgExprs(args), expr.id, dest);
         }
+        ast::expr_method_call(rcvr, _, _, args, _) => {
+            return callee::trans_method_call(bcx,
+                                             expr,
+                                             rcvr,
+                                             callee::ArgExprs(args),
+                                             dest);
+        }
         ast::expr_binary(_, lhs, rhs) => {
             // if not overloaded, would be RvalueDatumExpr
             return trans_overloaded_op(bcx, expr, lhs, ~[rhs], dest,

--- a/src/librustc/middle/trans/reachable.rs
+++ b/src/librustc/middle/trans/reachable.rs
@@ -170,6 +170,18 @@ fn traverse_inline_body(cx: ctx, body: blk) {
               _ => ()
             }
           }
+          expr_method_call(*) => {
+            match cx.method_map.find(e.id) {
+              Some({origin: typeck::method_static(did), _}) => {
+                traverse_def_id(cx, did);
+              }
+              Some(_) => {}
+              None => {
+                cx.tcx.sess.span_bug(e.span, ~"expr_method_call not in \
+                                               method map");
+              }
+            }
+          }
           _ => ()
         }
         visit::visit_expr(e, cx, v);

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3352,6 +3352,7 @@ fn expr_kind(tcx: ctxt,
         }
 
         ast::expr_call(*) |
+        ast::expr_method_call(*) |
         ast::expr_rec(*) |
         ast::expr_struct(*) |
         ast::expr_tup(*) |

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1100,24 +1100,22 @@ fn check_expr_with_unifier(fcx: @fn_ctxt,
         return bot;
     }
 
-    // A generic function for doing all of the checking for call expressions
-    fn check_call(fcx: @fn_ctxt, sp: span, call_expr_id: ast::node_id,
-                  f: @ast::expr, args: ~[@ast::expr]) -> bool {
-
-        // Index expressions need to be handled seperately, to inform
-        // them that they appear in call position.
-        let mut bot = match f.node {
-          ast::expr_field(base, field, tys) => {
-            check_field(fcx, f, true, base, field, tys)
-          }
-          _ => check_expr(fcx, f, None)
-        };
-        let fn_ty = fcx.expr_ty(f);
+    // A generic function for doing all of the checking for call or
+    // method expressions
+    fn check_call_or_method(fcx: @fn_ctxt,
+                            sp: span,
+                            call_expr_id: ast::node_id,
+                            fn_ty: ty::t,
+                            expr: @ast::expr,
+                            args: ~[@ast::expr],
+                            bot: bool)
+                         -> bool {
+        let mut bot = bot;
 
         // Call the generic checker.
         let fty = {
             let r = check_call_inner(fcx, sp, call_expr_id,
-                                     fn_ty, f, args, DontDerefArgs);
+                                     fn_ty, expr, args, DontDerefArgs);
             bot |= r.bot;
             r.fty
         };
@@ -1136,6 +1134,79 @@ fn check_expr_with_unifier(fcx: @fn_ctxt,
               return bot;
           }
         }
+    }
+
+    // A generic function for doing all of the checking for call expressions
+    fn check_call(fcx: @fn_ctxt, sp: span, call_expr_id: ast::node_id,
+                  f: @ast::expr, args: ~[@ast::expr]) -> bool {
+
+        // Index expressions need to be handled separately, to inform them
+        // that they appear in call position.
+        let mut bot = match f.node {
+            ast::expr_field(base, field, tys) => {
+                check_field(fcx, f, true, base, field, tys)
+            }
+            _ => check_expr(fcx, f, None)
+        };
+
+        check_call_or_method(fcx,
+                             sp,
+                             call_expr_id,
+                             fcx.expr_ty(f),
+                             f,
+                             args,
+                             bot)
+    }
+
+    // Checks a method call.
+    fn check_method_call(fcx: @fn_ctxt,
+                         expr: @ast::expr,
+                         rcvr: @ast::expr,
+                         method_name: ast::ident,
+                         args: ~[@ast::expr],
+                         tps: ~[@ast::Ty])
+                      -> bool {
+        let bot = check_expr(fcx, rcvr, None);
+        let expr_t = structurally_resolved_type(fcx,
+                                                expr.span,
+                                                fcx.expr_ty(rcvr));
+
+        let tps = tps.map(|ast_ty| fcx.to_ty(*ast_ty));
+        match method::lookup(fcx,
+                             expr,
+                             rcvr,
+                             expr.callee_id,
+                             method_name,
+                             expr_t,
+                             tps,
+                             DontDerefArgs) {
+            Some(entry) => {
+                fcx.ccx.method_map.insert(expr.id, entry);
+            }
+            None => {
+                fcx.type_error_message(expr.span,
+                  |actual| {
+                      fmt!("type `%s` does not implement any method in scope \
+                            named `%s`",
+                           actual,
+                           fcx.ccx.tcx.sess.str_of(method_name))
+                  },
+                  expr_t,
+                  None);
+
+                // Add error type for the result
+                fcx.write_ty(expr.id, ty::mk_err(fcx.ccx.tcx));
+                fcx.write_ty(expr.callee_id, ty::mk_err(fcx.ccx.tcx));
+            }
+        }
+
+        check_call_or_method(fcx,
+                             expr.span,
+                             expr.id,
+                             fcx.node_ty(expr.callee_id),
+                             expr,
+                             args,
+                             bot)
     }
 
     // A generic function for checking for or for-each loops
@@ -2086,6 +2157,9 @@ fn check_expr_with_unifier(fcx: @fn_ctxt,
       }
       ast::expr_call(f, args, _) => {
         bot = check_call(fcx, expr.span, expr.id, f, args);
+      }
+      ast::expr_method_call(rcvr, ident, tps, args, _) => {
+        bot = check_method_call(fcx, expr, rcvr, ident, args, tps);
       }
       ast::expr_cast(e, t) => {
         bot = check_expr(fcx, e, None);

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -199,6 +199,17 @@ fn visit_expr(expr: @ast::expr, &&rcx: @rcx, v: rvt) {
             }
         }
 
+        ast::expr_method_call(rcvr, _, _, args, _) => {
+            // Check for a.b() where b is a method.  Ensure that
+            // any types in the callee are valid for the entire
+            // method call.
+
+            constrain_auto_ref(rcx, rcvr);
+            for args.each |arg| {
+                constrain_auto_ref(rcx, *arg);
+            }
+        }
+
         ast::expr_cast(source, _) => {
             // Determine if we are casting `source` to an trait
             // instance.  If so, we have to be sure that the type of

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -557,7 +557,7 @@ fn early_resolve_expr(ex: @ast::expr, &&fcx: @fn_ctxt, is_early: bool) {
       // Must resolve bounds on methods with bounded params
       ast::expr_field(*) | ast::expr_binary(*) |
       ast::expr_unary(*) | ast::expr_assign_op(*) |
-      ast::expr_index(*) => {
+      ast::expr_index(*) | ast::expr_method_call(*) => {
         match ty::method_call_bounds(cx.tcx, cx.method_map, ex.id) {
           Some(bounds) => {
             if has_trait_bounds(*bounds) {

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -158,6 +158,11 @@ fn visit_expr(e: @ast::expr, wbcx: wb_ctxt, v: wb_vt) {
         maybe_resolve_type_vars_for_node(wbcx, e.span, e.callee_id);
       }
 
+      ast::expr_method_call(*) => {
+        // We must always have written in a callee ID type for these.
+        resolve_type_vars_for_node(wbcx, e.span, e.callee_id);
+      }
+
       _ => ()
     }
     visit::visit_expr(e, wbcx, v);

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -714,7 +714,7 @@ impl blk_check_mode : cmp::Eq {
 #[auto_serialize]
 #[auto_deserialize]
 type expr = {id: node_id, callee_id: node_id, node: expr_, span: span};
-// Extra node ID is only used for index, assign_op, unary, binary
+// Extra node ID is only used for index, assign_op, unary, binary, method call
 
 #[auto_serialize]
 #[auto_deserialize]
@@ -728,6 +728,7 @@ enum expr_ {
     expr_vec(~[@expr], mutability),
     expr_rec(~[field], Option<@expr>),
     expr_call(@expr, ~[@expr], bool), // True iff last argument is a block
+    expr_method_call(@expr, ident, ~[@Ty], ~[@expr], bool), // Ditto
     expr_tup(~[@expr]),
     expr_binary(binop, @expr, @expr),
     expr_unary(unop, @expr),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -409,6 +409,13 @@ fn noop_fold_expr(e: expr_, fld: ast_fold) -> expr_ {
                       fld.map_exprs(|x| fld.fold_expr(x), args),
                       blk)
           }
+          expr_method_call(f, i, tps, args, blk) => {
+            expr_method_call(fld.fold_expr(f),
+                             fld.fold_ident(i),
+                             vec::map(tps, |x| fld.fold_ty(*x)),
+                             fld.map_exprs(|x| fld.fold_expr(x), args),
+                             blk)
+          }
           expr_binary(binop, lhs, rhs) => {
             expr_binary(binop, fld.fold_expr(lhs), fld.fold_expr(rhs))
           }

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -6,9 +6,13 @@ use ast_util::operator_prec;
 
 fn expr_requires_semi_to_be_stmt(e: @ast::expr) -> bool {
     match e.node {
-      ast::expr_if(*) | ast::expr_match(*) | ast::expr_block(_)
-      | ast::expr_while(*) | ast::expr_loop(*)
-      | ast::expr_call(_, _, true) => false,
+      ast::expr_if(*)
+      | ast::expr_match(*)
+      | ast::expr_block(_)
+      | ast::expr_while(*)
+      | ast::expr_loop(*)
+      | ast::expr_call(_, _, true)
+      | ast::expr_method_call(_, _, _, _, true) => false,
       _ => true
     }
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -34,10 +34,10 @@ use ast::{_mod, add, arg, arm, attribute,
              expr_call, expr_cast, expr_copy, expr_do_body, expr_fail,
              expr_field, expr_fn, expr_fn_block, expr_if, expr_index,
              expr_lit, expr_log, expr_loop, expr_loop_body, expr_mac,
-             expr_paren, expr_path, expr_rec, expr_repeat, expr_ret,
-             expr_swap, expr_struct, expr_tup, expr_unary, expr_unary_move,
-             expr_vec, expr_vstore, expr_vstore_mut_box, expr_while,
-             extern_fn, field, fn_decl,
+             expr_method_call, expr_paren, expr_path, expr_rec, expr_repeat,
+             expr_ret, expr_swap, expr_struct, expr_tup, expr_unary,
+             expr_unary_move, expr_vec, expr_vstore, expr_vstore_mut_box,
+             expr_while, extern_fn, field, fn_decl,
              foreign_item, foreign_item_const, foreign_item_fn, foreign_mod,
              ident, impure_fn, infer, inherited,
              item, item_, item_class, item_const, item_enum, item_fn,
@@ -1212,8 +1212,26 @@ impl Parser {
                         self.expect(token::LT);
                         self.parse_seq_to_gt(Some(token::COMMA),
                                              |p| p.parse_ty(false))
-                    } else { ~[] };
-                    e = self.mk_expr(lo, hi, expr_field(e, i, tys));
+                    } else {
+                        ~[]
+                    };
+
+                    // expr.f() method call
+                    match copy self.token {
+                        token::LPAREN if self.permits_call() => {
+                            let es = self.parse_unspanned_seq(
+                                token::LPAREN, token::RPAREN,
+                                seq_sep_trailing_disallowed(token::COMMA),
+                                |p| p.parse_expr());
+                            hi = self.span.hi;
+
+                            let nd = expr_method_call(e, i, tys, es, false);
+                            e = self.mk_expr(lo, hi, move nd);
+                        }
+                        _ => {
+                            e = self.mk_expr(lo, hi, expr_field(e, i, tys));
+                        }
+                    }
                   }
                   _ => self.unexpected()
                 }
@@ -1674,7 +1692,16 @@ impl Parser {
             @{node: expr_call(f, args, true),
               .. *e}
           }
-          expr_path(*) | expr_field(*) | expr_call(*) | expr_paren(*) => {
+          expr_method_call(f, i, tps, args, false) => {
+            let block = self.parse_lambda_block_expr();
+            let last_arg = self.mk_expr(block.span.lo, block.span.hi,
+                                    ctor(block));
+            let args = vec::append(args, ~[last_arg]);
+            @{node: expr_method_call(f, i, tps, args, true),
+              .. *e}
+          }
+          expr_path(*) | expr_field(*) | expr_call(*) | expr_method_call(*) |
+          expr_paren(*) => {
             let block = self.parse_lambda_block_expr();
             let last_arg = self.mk_expr(block.span.lo, block.span.hi,
                                     ctor(block));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -408,6 +408,11 @@ fn visit_expr<E>(ex: @expr, e: E, v: vt<E>) {
         visit_exprs(args, e, v);
         (v.visit_expr)(callee, e, v);
       }
+      expr_method_call(callee, _, tys, args, _) => {
+        (v.visit_expr)(callee, e, v);
+        for tys.each |tp| { (v.visit_ty)(*tp, e, v); }
+        visit_exprs(args, e, v);
+      }
       expr_binary(_, a, b) => {
         (v.visit_expr)(a, e, v); (v.visit_expr)(b, e, v);
       }


### PR DESCRIPTION
r? @nikomatsakis 
