### PR TITLE
Disallow dereferencing enum types when the variant is private

### DIFF
--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -99,7 +99,7 @@ fn maybe_get_item_ast(tcx: ty::ctxt, def: ast::def_id,
 }
 
 fn get_enum_variants(tcx: ty::ctxt, def: ast::def_id)
-    -> ~[ty::variant_info] {
+    -> ~[ty::VariantInfo] {
     let cstore = tcx.cstore;
     let cdata = cstore::get_crate_data(cstore, def.crate);
     return decoder::get_enum_variants(cstore.intr, cdata, def.node, tcx)

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -612,11 +612,11 @@ fn maybe_get_item_ast(intr: @ident_interner, cdata: cmd, tcx: ty::ctxt,
 }
 
 fn get_enum_variants(intr: @ident_interner, cdata: cmd, id: ast::node_id,
-                     tcx: ty::ctxt) -> ~[ty::variant_info] {
+                     tcx: ty::ctxt) -> ~[ty::VariantInfo] {
     let data = cdata.data;
     let items = Reader::get_doc(Reader::Doc(data), tag_items);
     let item = find_item(id, items);
-    let mut infos: ~[ty::variant_info] = ~[];
+    let mut infos: ~[ty::VariantInfo] = ~[];
     let variant_ids = enum_variant_ids(item, cdata);
     let mut disr_val = 0;
     for variant_ids.each |did| {
@@ -634,8 +634,11 @@ fn get_enum_variants(intr: @ident_interner, cdata: cmd, id: ast::node_id,
           Some(val) => { disr_val = val; }
           _         => { /* empty */ }
         }
-        infos.push(@{args: arg_tys, ctor_ty: ctor_ty, name: name,
-                           id: *did, disr_val: disr_val});
+        infos.push(@ty::VariantInfo_{args: arg_tys,
+                       ctor_ty: ctor_ty, name: name,
+                  // I'm not even sure if we encode visibility
+                  // for variants -- TEST -- tjc
+                  id: *did, disr_val: disr_val, vis: ast::inherited});
         disr_val += 1;
     }
     return infos;

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -517,7 +517,7 @@ fn iter_structural_ty(cx: block, av: ValueRef, t: ty::t,
     let _icx = cx.insn_ctxt("iter_structural_ty");
 
     fn iter_variant(cx: block, a_tup: ValueRef,
-                    variant: ty::variant_info,
+                    variant: ty::VariantInfo,
                     tps: ~[ty::t], tid: ast::def_id,
                     f: val_and_ty_fn) -> block {
         let _icx = cx.insn_ctxt("iter_variant");
@@ -1802,7 +1802,7 @@ fn trans_class_dtor(ccx: @crate_ctxt, path: path,
 
 fn trans_enum_def(ccx: @crate_ctxt, enum_definition: ast::enum_def,
                   id: ast::node_id, tps: ~[ast::ty_param], degen: bool,
-                  path: @ast_map::path, vi: @~[ty::variant_info],
+                  path: @ast_map::path, vi: @~[ty::VariantInfo],
                   i: &mut uint) {
     for vec::each(enum_definition.variants) |variant| {
         let disr_val = vi[*i].disr_val;

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1,4 +1,3 @@
-// #[warn(deprecated_mode)];
 #[warn(deprecated_pattern)];
 
 use std::{map, smallintmap};
@@ -158,7 +157,7 @@ export resolved_mode;
 export arg_mode;
 export unify_mode;
 export set_default_mode;
-export variant_info;
+export VariantInfo, VariantInfo_;
 export walk_ty, maybe_walk_ty;
 export occurs_check;
 export param_ty;
@@ -404,7 +403,7 @@ type ctxt =
       needs_unwind_cleanup_cache: HashMap<t, bool>,
       kind_cache: HashMap<t, Kind>,
       ast_ty_to_ty_cache: HashMap<@ast::Ty, ast_ty_to_ty_cache_entry>,
-      enum_var_cache: HashMap<def_id, @~[variant_info]>,
+      enum_var_cache: HashMap<def_id, @~[VariantInfo]>,
       trait_method_cache: HashMap<def_id, @~[method]>,
       ty_param_bounds: HashMap<ast::node_id, param_bounds>,
       inferred_modes: HashMap<ast::node_id, ast::mode>,
@@ -3938,19 +3937,28 @@ fn struct_ctor_id(cx: ctxt, struct_did: ast::def_id) -> Option<ast::def_id> {
 }
 
 // Enum information
-type variant_info = @{args: ~[t], ctor_ty: t, name: ast::ident,
-                      id: ast::def_id, disr_val: int};
+struct VariantInfo_ {
+    args: ~[t],
+    ctor_ty: t,
+    name: ast::ident,
+    id: ast::def_id,
+    disr_val: int,
+    vis: visibility
+}
+
+type VariantInfo = @VariantInfo_;
 
 fn substd_enum_variants(cx: ctxt,
                         id: ast::def_id,
-                        substs: &substs) -> ~[variant_info] {
+                        substs: &substs) -> ~[VariantInfo] {
     do vec::map(*enum_variants(cx, id)) |variant_info| {
         let substd_args = vec::map(variant_info.args,
                                    |aty| subst(cx, substs, *aty));
 
         let substd_ctor_ty = subst(cx, substs, variant_info.ctor_ty);
 
-        @{args: substd_args, ctor_ty: substd_ctor_ty, ..**variant_info}
+        @VariantInfo_{args: substd_args, ctor_ty: substd_ctor_ty,
+                      ..**variant_info}
     }
 }
 
@@ -4061,7 +4069,7 @@ fn item_path(cx: ctxt, id: ast::def_id) -> ast_map::path {
 }
 
 fn enum_is_univariant(cx: ctxt, id: ast::def_id) -> bool {
-    vec::len(*enum_variants(cx, id)) == 1u
+    enum_variants(cx, id).len() == 1
 }
 
 fn type_is_empty(cx: ctxt, t: t) -> bool {
@@ -4071,7 +4079,7 @@ fn type_is_empty(cx: ctxt, t: t) -> bool {
      }
 }
 
-fn enum_variants(cx: ctxt, id: ast::def_id) -> @~[variant_info] {
+fn enum_variants(cx: ctxt, id: ast::def_id) -> @~[VariantInfo] {
     match cx.enum_var_cache.find(id) {
       Some(variants) => return variants,
       _ => { /* fallthrough */ }
@@ -4111,11 +4119,12 @@ fn enum_variants(cx: ctxt, id: ast::def_id) -> @~[variant_info] {
                           }
                           _ => disr_val += 1
                         }
-                        @{args: arg_tys,
+                        @VariantInfo_{args: arg_tys,
                           ctor_ty: ctor_ty,
                           name: variant.node.name,
                           id: ast_util::local_def(variant.node.id),
-                          disr_val: disr_val
+                          disr_val: disr_val,
+                          vis: variant.node.vis
                          }
                     }
                     ast::struct_variant_kind(_) => {
@@ -4137,13 +4146,13 @@ fn enum_variants(cx: ctxt, id: ast::def_id) -> @~[variant_info] {
 
 // Returns information about the enum variant with the given ID:
 fn enum_variant_with_id(cx: ctxt, enum_id: ast::def_id,
-                        variant_id: ast::def_id) -> variant_info {
+                        variant_id: ast::def_id) -> VariantInfo {
     let variants = enum_variants(cx, enum_id);
-    let mut i = 0u;
-    while i < vec::len::<variant_info>(*variants) {
+    let mut i = 0;
+    while i < variants.len() {
         let variant = variants[i];
         if variant.id == variant_id { return variant; }
-        i += 1u;
+        i += 1;
     }
     cx.sess.bug(~"enum_variant_with_id(): no variant exists with that ID");
 }

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -45,7 +45,8 @@ use syntax::{ast, ast_util, ast_map};
 use ast::spanned;
 use ast::{required, provided};
 use syntax::ast_map::node_id_to_str;
-use syntax::ast_util::{local_def, respan, split_trait_methods};
+use syntax::ast_util::{local_def, respan, split_trait_methods,
+                       has_legacy_export_attr};
 use syntax::visit;
 use metadata::csearch;
 use util::common::{block_query, loop_query};
@@ -372,7 +373,8 @@ fn check_crate(tcx: ty::ctxt,
                             method_map: std::map::HashMap(),
                             vtable_map: std::map::HashMap(),
                             coherence_info: @coherence::CoherenceInfo(),
-                            tcx: tcx});
+                            tcx: tcx
+                           });
     collect::collect_item_types(ccx, crate);
     coherence::check_coherence(ccx, crate);
     deriving::check_deriving(ccx, crate);

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -91,7 +91,6 @@ fn pluralize(n: uint, s: ~str) -> ~str {
     else { str::concat([s, ~"s"]) }
 }
 
-
 //
 // Local Variables:
 // mode: rust

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -91,6 +91,7 @@ fn pluralize(n: uint, s: ~str) -> ~str {
     else { str::concat([s, ~"s"]) }
 }
 
+
 //
 // Local Variables:
 // mode: rust

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -391,6 +391,16 @@ fn node_id_to_str(map: map, id: node_id, itr: @ident_interner) -> ~str {
       }
     }
 }
+
+fn node_item_query<Result>(items: map, id: node_id,
+                           query: fn(@item) -> Result,
+                           error_msg: ~str) -> Result {
+    match items.find(id) {
+        Some(node_item(it, _)) => query(it),
+        _ => fail(error_msg)
+    }
+}
+
 // Local Variables:
 // mode: rust
 // fill-column: 78;

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -611,6 +611,46 @@ fn struct_def_is_tuple_like(struct_def: @ast::struct_def) -> bool {
     struct_def.ctor_id.is_some()
 }
 
+
+fn visibility_to_privacy(visibility: visibility,
+                         legacy_exports: bool) -> Privacy {
+    if legacy_exports {
+        match visibility {
+            inherited | public => Public,
+            private => Private
+        }
+    } else {
+        match visibility {
+            public => Public,
+            inherited | private => Private
+        }
+    }
+}
+
+enum Privacy {
+    Private,
+    Public
+}
+
+impl Privacy : cmp::Eq {
+    pure fn eq(&self, other: &Privacy) -> bool {
+        ((*self) as uint) == ((*other) as uint)
+    }
+    pure fn ne(&self, other: &Privacy) -> bool { !(*self).eq(other) }
+}
+
+fn has_legacy_export_attr(attrs: &[attribute]) -> bool {
+    for attrs.each |attribute| {
+        match attribute.node.value.node {
+          meta_word(w) if w == ~"legacy_exports" => {
+            return true;
+          }
+          _ => {}
+        }
+    }
+    return false;
+}
+
 // Local Variables:
 // mode: rust
 // fill-column: 78;

--- a/src/test/auxiliary/private_variant_1.rs
+++ b/src/test/auxiliary/private_variant_1.rs
@@ -1,0 +1,5 @@
+mod super_sekrit {
+    pub enum sooper_sekrit {
+        pub quux, priv baz
+    }
+}

--- a/src/test/compile-fail/issue-818.rs
+++ b/src/test/compile-fail/issue-818.rs
@@ -1,0 +1,14 @@
+mod ctr {
+
+    pub enum ctr { priv mkCtr(int) }
+
+    pub fn new(i: int) -> ctr { mkCtr(i) }
+    pub fn inc(c: ctr) -> ctr { mkCtr(*c + 1) }
+}
+
+
+fn main() {
+    let c = ctr::new(42);
+    let c2 = ctr::inc(c);
+    assert *c2 == 5; //~ ERROR can only dereference enums with a single, public variant
+}

--- a/src/test/compile-fail/private_variant_2.rs
+++ b/src/test/compile-fail/private_variant_2.rs
@@ -1,0 +1,7 @@
+// xfail-test
+// aux-build:private_variant_1.rs
+extern mod private_variant_1;
+
+fn main() {
+    let _x = private_variant_1::super_sekrit::baz; //~ ERROR baz is private
+}


### PR DESCRIPTION
If an enum type's only variant is private, disallow dereferencing
values of its type, as per #818.

Due to #4082, this only applies to enums that are in the same crate.

r? @pcwalton
