### PR TITLE
Fix tuple instances for IterBytes to avoid ICE, fixes #4092

### DIFF
--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -191,6 +191,25 @@ impl<A: IterBytes> &[A]: IterBytes {
     }
 }
 
+impl<A: IterBytes, B: IterBytes> (A,B): IterBytes {
+  #[inline(always)]
+  pure fn iter_bytes(lsb0: bool, f: Cb) {
+    let &(ref a, ref b) = &self;
+    a.iter_bytes(lsb0, f);
+    b.iter_bytes(lsb0, f);
+  }
+}
+
+impl<A: IterBytes, B: IterBytes, C: IterBytes> (A,B,C): IterBytes {
+  #[inline(always)]
+  pure fn iter_bytes(lsb0: bool, f: Cb) {
+    let &(ref a, ref b, ref c) = &self;
+    a.iter_bytes(lsb0, f);
+    b.iter_bytes(lsb0, f);
+    c.iter_bytes(lsb0, f);
+  }
+}
+
 // Move this to vec, probably.
 pure fn borrow<A>(a: &x/[A]) -> &x/[A] {
     a

--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -196,8 +196,7 @@ impl<A: IterBytes, B: IterBytes> (A,B): IterBytes {
   pure fn iter_bytes(lsb0: bool, f: Cb) {
     match self {
       (ref a, ref b) => {
-        a.iter_bytes(lsb0, f);
-        b.iter_bytes(lsb0, f);
+        iter_bytes_2(a, b, lsb0, f);
       }
     }
   }
@@ -208,9 +207,7 @@ impl<A: IterBytes, B: IterBytes, C: IterBytes> (A,B,C): IterBytes {
   pure fn iter_bytes(lsb0: bool, f: Cb) {
     match self {
       (ref a, ref b, ref c) => {
-        a.iter_bytes(lsb0, f);
-        b.iter_bytes(lsb0, f);
-        c.iter_bytes(lsb0, f);
+        iter_bytes_3(a, b, c, lsb0, f);
       }
     }
   }

--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -194,19 +194,25 @@ impl<A: IterBytes> &[A]: IterBytes {
 impl<A: IterBytes, B: IterBytes> (A,B): IterBytes {
   #[inline(always)]
   pure fn iter_bytes(lsb0: bool, f: Cb) {
-    let &(ref a, ref b) = &self;
-    a.iter_bytes(lsb0, f);
-    b.iter_bytes(lsb0, f);
+    match self {
+      (ref a, ref b) => {
+        a.iter_bytes(lsb0, f);
+        b.iter_bytes(lsb0, f);
+      }
+    }
   }
 }
 
 impl<A: IterBytes, B: IterBytes, C: IterBytes> (A,B,C): IterBytes {
   #[inline(always)]
   pure fn iter_bytes(lsb0: bool, f: Cb) {
-    let &(ref a, ref b, ref c) = &self;
-    a.iter_bytes(lsb0, f);
-    b.iter_bytes(lsb0, f);
-    c.iter_bytes(lsb0, f);
+    match self {
+      (ref a, ref b, ref c) => {
+        a.iter_bytes(lsb0, f);
+        b.iter_bytes(lsb0, f);
+        c.iter_bytes(lsb0, f);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The pattern `let &(ref a, ref b) = &self`causes a compiler ICE. Avoid use of it in libcore/to_bytes.rs.
