### PR TITLE
Fix cross-crate inlining of static methods

### DIFF
--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -3,7 +3,7 @@ use syntax::ast;
 use syntax::ast_util::local_def;
 use syntax::ast_map::{path, path_mod, path_name};
 use base::{trans_item, get_item_val, self_arg, trans_fn, impl_owned_self,
-           impl_self, get_insn_ctxt};
+           impl_self, no_self, get_insn_ctxt};
 
 // `translate` will be true if this function is allowed to translate the
 // item and false otherwise. Currently, this parameter is set to false when
@@ -73,14 +73,33 @@ fn maybe_instantiate_inline(ccx: @crate_ctxt, fn_id: ast::def_id,
                 let path = vec::append(
                     ty::item_path(ccx.tcx, impl_did),
                     ~[path_name(mth.ident)]);
-                let self_ty = ty::node_id_to_type(ccx.tcx, mth.self_id);
-                debug!("calling inline trans_fn with self_ty %s",
-                       ty_to_str(ccx.tcx, self_ty));
-                let self_kind;
-                match mth.self_ty.node {
-                    ast::sty_value => self_kind = impl_owned_self(self_ty),
-                    _ => self_kind = impl_self(self_ty),
-                }
+                let self_kind = {
+                    use std::smallintmap;
+                    debug!("looking up self id: %?", mth.self_id);
+                    match smallintmap::find(*ccx.tcx.node_types,
+                                            mth.self_id as uint) {
+                        Some(self_ty) => {
+                            debug!("calling inline trans_fn with self_ty %s",
+                                   ty_to_str(ccx.tcx, self_ty));
+                            match mth.self_ty.node {
+                                ast::sty_value => impl_owned_self(self_ty),
+                                _ => impl_self(self_ty),
+                            }
+                        }
+                        None => {
+                            // If we can't find the type of the
+                            // self_id, then assume that there was no
+                            // self parameter (i.e. this is a static
+                            // method). Static methods have self
+                            // did's, they just presumably don't use
+                            // them, and the encoder doesn't
+                            // distenguish between inline methods and
+                            // inline static methods. This is quite
+                            // fragile.
+                            no_self
+                        }
+                    }
+                };
                 trans_fn(ccx,
                          path,
                          mth.decl,

--- a/src/test/auxiliary/static_fn_inline_xc_aux.rs
+++ b/src/test/auxiliary/static_fn_inline_xc_aux.rs
@@ -1,0 +1,14 @@
+
+pub mod num {
+    pub trait Num2 {
+        static pure fn from_int2(n: int) -> self;
+    }
+}
+
+pub mod float {
+    impl float: num::Num2 {
+        #[inline]
+        static pure fn from_int2(n: int) -> float { return n as float;  }
+    }
+}
+

--- a/src/test/run-pass/static-fn-inline-xc.rs
+++ b/src/test/run-pass/static-fn-inline-xc.rs
@@ -1,0 +1,9 @@
+// aux-build:static_fn_inline_xc_aux.rs
+
+extern mod mycore(name ="static_fn_inline_xc_aux");
+
+use mycore::num;
+
+fn main() {
+    let _1:float = num::from_int2(1i);
+}


### PR DESCRIPTION
r? @pcwalton

This fixes translation of static methods with inline attributes, sourced from non-local crates. The problem is that maybe_instantiate_inline tries to look up the self type according to the self_did of the encoded inline method, and for static methods that did is just some random number unassociated with any type (afaict).
