### PR TITLE
Update macro tutorial (+ minor release note edit)

### DIFF
--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -11,7 +11,7 @@ Version 0.5 (December 2012)
       * Static methods improved to work in more situations
       * Completed the transition from the `#fmt` extension syntax to `fmt!`
       * Removed old fixed length vector syntax - `[T]/N`
-      * Item macros
+      * Item and statement macros
       * Remove `<-` move operator
       * Tuple structs - `struct Foo(Bar, Baz)`. Will replace newtype enums.
       * Eq impls can be derived with #[deriving_eq]

--- a/doc/tutorial-macros.md
+++ b/doc/tutorial-macros.md
@@ -117,6 +117,12 @@ transcriber (therefore `() => ((1,2,3))` is a macro that expands to a tuple
 expression, `() => (let $x=$val)` is a macro that expands to a statement, and
 `() => (1,2,3)` is a macro that expands to a syntax errror).
 
+Except for permissibility of `$name` (and `$(...)*`, discussed below), the
+right-hand side of a macro definition follows the same rules as ordinary
+Rust syntax. In particular, macro invocations (including invocations of the
+macro currently being defined) are permitted in expression, statement, and
+item locations.
+
 ## Interpolation location
 
 The interpolation `$argument_name` may appear in any location consistent with


### PR DESCRIPTION
This is based on an IRC conversation about the difference between where `mac!(...)` and `$arg` can go.
