### PR TITLE
Turn off type_use on x86. #4127

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -246,7 +246,10 @@ impl Session {
     fn borrowck_note_pure() -> bool { self.debugging_opt(borrowck_note_pure) }
     fn borrowck_note_loan() -> bool { self.debugging_opt(borrowck_note_loan) }
     fn no_monomorphic_collapse() -> bool {
-        self.debugging_opt(no_monomorphic_collapse)
+        // FIXME #4127: Type use is causing mysterious bustage on 32-bit archs
+        let type_use_unreliable = self.targ_cfg.arch == arch_x86;
+
+        self.debugging_opt(no_monomorphic_collapse) || type_use_unreliable
     }
 
     fn str_of(id: ast::ident) -> ~str {


### PR DESCRIPTION
r? @graydon

This should work around the windows bustage. Tested on x86 linux. Testing now on windows. This may also fix #4054.
