### PR TITLE
Quote misc

### DIFF
--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -7,7 +7,7 @@ Version 0.5 (December 2012)
       * Removed `<-` move operator
       * Completed the transition from the `#fmt` extension syntax to `fmt!`
       * Removed old fixed length vector syntax - `[T]/N`
-      * New token-based quasi-quoter, `quote!`
+      * New token-based quasi-quoters, `quote_tokens!`, `quote_expr!`, etc.
       * Macros may now expand to items and statements
       * `a.b()` is always parsed as a method call, never as a field projection
       * `Eq` and `IterBytes` implementations can be automatically generated

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -163,6 +163,7 @@ trait ext_ctxt {
     fn codemap() -> @CodeMap;
     fn parse_sess() -> parse::parse_sess;
     fn cfg() -> ast::crate_cfg;
+    fn call_site() -> span;
     fn print_backtrace();
     fn backtrace() -> Option<@ExpnInfo>;
     fn mod_push(mod_name: ast::ident);
@@ -195,6 +196,12 @@ fn mk_ctxt(parse_sess: parse::parse_sess,
         fn codemap() -> @CodeMap { self.parse_sess.cm }
         fn parse_sess() -> parse::parse_sess { self.parse_sess }
         fn cfg() -> ast::crate_cfg { self.cfg }
+        fn call_site() -> span {
+            match self.backtrace {
+                Some(@ExpandedFrom({call_site: cs, _})) => cs,
+                None => self.bug(~"missing top span")
+            }
+        }
         fn print_backtrace() { }
         fn backtrace() -> Option<@ExpnInfo> { self.backtrace }
         fn mod_push(i: ast::ident) { self.mod_path.push(i); }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -123,8 +123,8 @@ fn syntax_expander_table() -> HashMap<~str, syntax_extension> {
         ~"quote_tokens", builtin_normal_tt(ext::quote::expand_quote_tokens));
     syntax_expanders.insert(~"quote_expr",
                             builtin_normal_tt(ext::quote::expand_quote_expr));
-    syntax_expanders.insert(~"quote_type",
-                            builtin_normal_tt(ext::quote::expand_quote_type));
+    syntax_expanders.insert(~"quote_ty",
+                            builtin_normal_tt(ext::quote::expand_quote_ty));
     syntax_expanders.insert(~"quote_item",
                             builtin_normal_tt(ext::quote::expand_quote_item));
     syntax_expanders.insert(~"quote_pat",

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -145,6 +145,24 @@ fn mk_glob_use(cx: ext_ctxt, sp: span,
       vis: ast::private,
       span: sp}
 }
+fn mk_local(cx: ext_ctxt, sp: span, mutbl: bool,
+            ident: ast::ident, ex: @ast::expr) -> @ast::stmt {
+
+    let pat : @ast::pat = @{id: cx.next_id(),
+                            node: ast::pat_ident(ast::bind_by_value,
+                                                 mk_raw_path(sp, ~[ident]),
+                                                 None),
+                           span: sp};
+    let ty : @ast::Ty = @{ id: cx.next_id(), node: ast::ty_infer, span: sp };
+    let local : @ast::local = @{node: {is_mutbl: mutbl,
+                                       ty: ty,
+                                       pat: pat,
+                                       init: Some(ex),
+                                       id: cx.next_id()},
+                                span: sp};
+    let decl = {node: ast::decl_local(~[local]), span: sp};
+    @{ node: ast::stmt_decl(@decl, cx.next_id()), span: sp }
+}
 fn mk_block(cx: ext_ctxt, sp: span,
             view_items: ~[@ast::view_item],
             stmts: ~[@ast::stmt],

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -17,6 +17,7 @@ use ast::{ident, node_id};
 use ast_util::{ident_to_path, respan, dummy_sp};
 use codemap::span;
 use ext::base::mk_ctxt;
+use quote::rt::*;
 
 // Transitional reexports so qquote can find the paths it is looking for
 mod syntax {
@@ -121,6 +122,7 @@ impl ext_ctxt: ext_ctxt_ast_builder {
           span: dummy_sp()}
     }
 
+    #[cfg(stage0)]
     fn stmt_let(ident: ident, e: @ast::expr) -> @ast::stmt {
         // If the quasiquoter could interpolate idents, this is all
         // we'd need.
@@ -142,6 +144,13 @@ impl ext_ctxt: ext_ctxt_ast_builder {
               span: dummy_sp()}]),
                                span: dummy_sp()}, self.next_id()),
          span: dummy_sp()}
+     }
+
+    #[cfg(stage1)]
+    #[cfg(stage2)]
+    fn stmt_let(ident: ident, e: @ast::expr) -> @ast::stmt {
+        let ext_cx = self;
+        quote_stmt!( let $ident = $e; )
     }
 
     fn field_imm(name: ident, e: @ast::expr) -> ast::field {

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -62,11 +62,11 @@ pub fn expand_quote_pat(cx: ext_ctxt,
                                     ~[e_refutable], tts))
 }
 
-pub fn expand_quote_type(cx: ext_ctxt,
-                         sp: span,
-                         tts: ~[ast::token_tree]) -> base::mac_result {
+pub fn expand_quote_ty(cx: ext_ctxt,
+                       sp: span,
+                       tts: ~[ast::token_tree]) -> base::mac_result {
     let e_param_colons = build::mk_lit(cx, sp, ast::lit_bool(false));
-    base::mr_expr(expand_parse_call(cx, sp, ~"parse_type",
+    base::mr_expr(expand_parse_call(cx, sp, ~"parse_ty",
                                     ~[e_param_colons], tts))
 }
 

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -19,7 +19,7 @@ use token::*;
 *
 * Quasiquoting works via token trees.
 *
-* This is registered as a expression syntax extension called quote! that lifts
+* This is registered as a set of expression syntax extension called quote! that lifts
 * its argument token-tree to an AST representing the construction of the same
 * token tree, with ast::tt_nonterminal nodes interpreted as antiquotes
 * (splices).
@@ -146,16 +146,12 @@ fn mk_span(cx: ext_ctxt, qsp: span, sp: span) -> @ast::expr {
 }
 
 // Lift an ident to the expr that evaluates to that ident.
-//
-// NB: this identifies the interner used when re-parsing the token tree
-// with the interner used during initial parse. This is _wrong_ and we
-// should be emitting a &str here and the token type should be ok with
-// &static/str or &session/str. Longer-term issue.
 fn mk_ident(cx: ext_ctxt, sp: span, ident: ast::ident) -> @ast::expr {
-    build::mk_struct_e(cx, sp,
-                       ids_ext(cx, ~[~"ident"]),
-                       ~[{ident: id_ext(cx, ~"repr"),
-                          ex: build::mk_uint(cx, sp, ident.repr) }])
+    let e_meth = build::mk_access(cx, sp,
+                                  ids_ext(cx, ~[~"ext_cx"]),
+                                  id_ext(cx, ~"ident_of"));
+    let e_str = build::mk_uniq_str(cx, sp, cx.str_of(ident));
+    build::mk_call_(cx, sp, e_meth, ~[e_str])
 }
 
 fn mk_bytepos(cx: ext_ctxt, sp: span, bpos: BytePos) -> @ast::expr {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -496,6 +496,7 @@ fn print_item(s: ps, &&item: @ast::item) {
       ast::item_foreign_mod(nmod) => {
         head(s, visibility_qualified(item.vis, ~"extern"));
         print_string(s, *s.intr.get(nmod.abi));
+        nbsp(s);
         match nmod.sort {
             ast::named => {
                 word_nbsp(s, ~"mod");

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -8,14 +8,13 @@ fn syntax_extension(ext_cx: @ext_ctxt) {
     let e_toks : ~[syntax::ast::token_tree] = quote_tokens!(1 + 2);
     let p_toks : ~[syntax::ast::token_tree] = quote_tokens!((x, 1 .. 4, *));
 
-    let _a: @syntax::ast::expr = quote_expr!(1 + 2);
+    let a: @syntax::ast::expr = quote_expr!(1 + 2);
     let _b: Option<@syntax::ast::item> = quote_item!( const foo : int = $e_toks; );
     let _c: @syntax::ast::pat = quote_pat!( (x, 1 .. 4, *) );
-    let _d: @syntax::ast::stmt = quote_stmt!( let x = $e_toks; );
+    let _d: @syntax::ast::stmt = quote_stmt!( let x = $a; );
     let _e: @syntax::ast::expr = quote_expr!( match foo { $p_toks => 10 } );
 }
 
 fn main() {
-    let _x: ~[syntax::ast::token_tree] = quote_tokens!(a::Foo::foo());
 }
 


### PR DESCRIPTION
This gets the new token-tree quasiquoter up to the point of being able to stand in for of `#ast` in the pipe protocol compiler; `#ast` is only there in `#[cfg(stage0)]`, whereas it's `quote_expr!` and `quote_type!` in `#[cfg(stage1)]` and `[#cfg(stage2)]`.  Also makes the splicing machinery much more robust and extensible (you are allowed to splice anything that implements `ToTokens`).

While this looks like a lot of sound and noise for nothing, it enables (post-snapshot) cutting out substantial portions of the redundant macro machinery in the frontend. `#ast` and the quasiquoter is sort of the last thread holding it in place (from _last_ summer).
