### PR TITLE
Add an auto-slice-and-ref step to method lookup. Allows ~[T] to work wit...

### DIFF
--- a/src/librustc/middle/borrowck/gather_loans.rs
+++ b/src/librustc/middle/borrowck/gather_loans.rs
@@ -295,7 +295,7 @@ impl gather_loan_ctxt {
                                              autoref.mutbl,
                                              autoref.region)
                     }
-                    ty::AutoBorrowVec => {
+                    ty::AutoBorrowVec | ty::AutoBorrowVecRef => {
                         let cmt_index = mcx.cat_index(expr, cmt);
                         self.guarantee_valid(cmt_index,
                                              autoref.mutbl,

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -119,7 +119,7 @@ use base::*;
 use syntax::print::pprust::{expr_to_str};
 use util::ppaux::ty_to_str;
 use util::common::indenter;
-use ty::{AutoPtr, AutoBorrowVec, AutoBorrowFn};
+use ty::{AutoPtr, AutoBorrowVec, AutoBorrowVecRef, AutoBorrowFn};
 use callee::{AutorefArg, DoAutorefArg, DontAutorefArg};
 use middle::ty::MoveValue;
 
@@ -202,6 +202,9 @@ fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
                         AutoBorrowVec => {
                             unpack_datum!(bcx, auto_slice(bcx, datum))
                         }
+                        AutoBorrowVecRef => {
+                            unpack_datum!(bcx, auto_slice_and_ref(bcx, datum))
+                        }
                         AutoBorrowFn => {
                             // currently, all closure types are
                             // represented precisely the same, so no
@@ -242,6 +245,11 @@ fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
         Store(bcx, base, GEPi(bcx, scratch.val, [0u, abi::slice_elt_base]));
         Store(bcx, len, GEPi(bcx, scratch.val, [0u, abi::slice_elt_len]));
         DatumBlock {bcx: bcx, datum: scratch}
+    }
+
+    fn auto_slice_and_ref(bcx: block, datum: Datum) -> DatumBlock {
+        let DatumBlock { bcx, datum } = auto_slice(bcx, datum);
+        auto_ref(bcx, datum)
     }
 }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -214,7 +214,7 @@ export DerivedMethodInfo;
 export DerivedFieldInfo;
 export AutoAdjustment;
 export AutoRef;
-export AutoRefKind, AutoPtr, AutoBorrowVec, AutoBorrowFn;
+export AutoRefKind, AutoPtr, AutoBorrowVec, AutoBorrowVecRef, AutoBorrowFn;
 export iter_bound_traits_and_supertraits;
 export count_traits_and_supertraits;
 
@@ -347,6 +347,9 @@ enum AutoRefKind {
 
     /// Convert from @[]/~[] to &[] (or str)
     AutoBorrowVec,
+
+    /// Convert from @[]/~[] to &&[] (or str)
+    AutoBorrowVecRef,
 
     /// Convert from @fn()/~fn() to &fn()
     AutoBorrowFn,

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -707,19 +707,44 @@ impl LookupContext {
             ty_evec(mt, vstore_box) |
             ty_evec(mt, vstore_uniq) |
             ty_evec(mt, vstore_fixed(_)) => {
-                self.search_for_some_kind_of_autorefd_method(
+                // First try to borrow to a slice
+                let entry = self.search_for_some_kind_of_autorefd_method(
                     AutoBorrowVec, autoderefs, [m_const, m_imm, m_mutbl],
                     |m,r| ty::mk_evec(tcx,
                                       {ty:mt.ty, mutbl:m},
-                                      vstore_slice(r)))
+                                      vstore_slice(r)));
+
+                if entry.is_some() { return entry; }
+
+                // Then try to borrow to a slice *and* borrow a pointer.
+                // NB: we do not try to autoref to a mutable pointer. That would
+                // be creating a pointer to a temporary pointer (the borrowed slice),
+                // so any update the callee makes to it can't be observed.
+                self.search_for_some_kind_of_autorefd_method(
+                    AutoBorrowVecRef, autoderefs, [m_imm],
+                    |m,r| {
+                        let slice_ty = ty::mk_evec(tcx,
+                                                   {ty:mt.ty, mutbl:mt.mutbl},
+                                                   vstore_slice(r));
+                        ty::mk_rptr(tcx, r, {ty:slice_ty, mutbl:m})
+                    })
             }
 
             ty_estr(vstore_box) |
             ty_estr(vstore_uniq) |
             ty_estr(vstore_fixed(_)) => {
-                self.search_for_some_kind_of_autorefd_method(
+                let entry = self.search_for_some_kind_of_autorefd_method(
                     AutoBorrowVec, autoderefs, [m_imm],
-                    |_m,r| ty::mk_estr(tcx, vstore_slice(r)))
+                    |_m,r| ty::mk_estr(tcx, vstore_slice(r)));
+
+                if entry.is_some() { return entry; }
+
+                self.search_for_some_kind_of_autorefd_method(
+                    AutoBorrowVecRef, autoderefs, [m_imm],
+                    |m,r| {
+                        let slice_ty = ty::mk_estr(tcx, vstore_slice(r));
+                        ty::mk_rptr(tcx, r, {ty:slice_ty, mutbl:m})
+                    })
             }
 
             ty_trait(*) | ty_fn(*) => {

--- a/src/test/compile-fail/auto-ref-slice-plus-ref.rs
+++ b/src/test/compile-fail/auto-ref-slice-plus-ref.rs
@@ -1,0 +1,18 @@
+fn main() {
+
+    // Testing that method lookup does not automatically borrow
+    // vectors to slices then automatically create a &mut self
+    // reference.  That would allow creating a mutable pointer to a
+    // temporary, which would be a source of confusion
+
+    let mut a = @[0];
+    a.test_mut(); //~ ERROR type `@[int]` does not implement any method in scope named `test_mut`
+}
+
+trait MyIter {
+    pure fn test_mut(&mut self);
+}
+
+impl &[int]: MyIter {
+    pure fn test_mut(&mut self) { }
+}

--- a/src/test/run-pass/auto-ref-slice-plus-ref.rs
+++ b/src/test/run-pass/auto-ref-slice-plus-ref.rs
@@ -1,0 +1,43 @@
+// Testing that method lookup automatically both borrows vectors to slices
+// and also references them to create the &self pointer
+
+trait MyIter {
+    pure fn test_imm(&self);
+    pure fn test_const(&const self);
+}
+
+impl &[int]: MyIter {
+    pure fn test_imm(&self) { assert self[0] == 1 }
+    pure fn test_const(&const self) { assert self[0] == 1 }
+}
+
+impl &str: MyIter {
+    pure fn test_imm(&self) { assert *self == "test" }
+    pure fn test_const(&const self) { assert *self == "test" }
+}
+
+fn main() {
+    // NB: Associativity of ~, etc. in this context is surprising. These must be parenthesized
+
+    ([1]).test_imm();
+    (~[1]).test_imm();
+    (@[1]).test_imm();
+    (&[1]).test_imm();
+    ("test").test_imm();
+    (~"test").test_imm();
+    (@"test").test_imm();
+    (&"test").test_imm();
+
+    ([1]).test_const();
+    (~[1]).test_const();
+    (@[1]).test_const();
+    (&[1]).test_const();
+    ("test").test_const();
+    (~"test").test_const();
+    (@"test").test_const();
+    (&"test").test_const();
+
+    // NB: We don't do this double autoreffing for &mut self because that would
+    // allow creating a mutable pointer to a temporary, which would be a source
+    // of confusion
+}


### PR DESCRIPTION
r? @nikomatsakis

One thing this doesn't handle is borrowing `@mut [T]` to `&self` for impls on `&[T]`. I'm not sure how to deal with that, but it hopefully is not necessary to convert `BaseIter` to explicit self.

Incidentally, the reason `~mut [T]` was working is because that is not a vector type, it is a mutable unique box containing a fixed-length vector.
