### PR TITLE
Add deprecated attribute.

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -60,6 +60,7 @@ enum lint {
     unrecognized_lint,
     non_implicitly_copyable_typarams,
     vecs_implicitly_copyable,
+    deprecated_item,
     deprecated_mode,
     deprecated_pattern,
     non_camel_case_types,
@@ -155,6 +156,11 @@ fn get_lint_dict() -> lint_dict {
         (~"implicit_copies",
          @{lint: implicit_copies,
            desc: ~"implicit copies of non implicitly copyable data",
+           default: warn}),
+
+        (~"deprecated_item",
+         @{lint: deprecated_item,
+           desc: ~"warn about items marked deprecated",
            default: warn}),
 
         (~"deprecated_mode",
@@ -412,6 +418,7 @@ fn check_item(i: @ast::item, cx: ty::ctxt) {
     check_item_non_camel_case_types(cx, i);
     check_item_heap(cx, i);
     check_item_structural_records(cx, i);
+    check_item_deprecated(cx, i);
     check_item_deprecated_modes(cx, i);
     check_item_type_limits(cx, i);
 }
@@ -764,6 +771,26 @@ fn check_item_non_camel_case_types(cx: ty::ctxt, it: @ast::item) {
         }
       }
       _ => ()
+    }
+}
+
+fn check_item_deprecated(tcx: ty::ctxt, it: @ast::item) {
+    let at = attr::find_attrs_by_name(it.attrs, ~"deprecated");
+
+    if at.is_not_empty() {
+        for at.each |attr| {
+            let fmt = match attr.node.value.node {
+                ast::meta_name_value(_, ref l) =>
+                    match l.node {
+                        ast::lit_str(ref reason) =>
+                            fmt!("deprecated: %s", **reason),
+                        _ =>  ~"item is deprecated" 
+                    },
+                _ => ~"item is deprecated"
+            };
+            tcx.sess.span_lint(deprecated_item, it.id, it.id, it.span,
+                fmt);
+        }
     }
 }
 

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -182,7 +182,7 @@ fn find_attrs_by_name(attrs: ~[ast::attribute], name: ~str) ->
     return vec::filter_map(attrs, filter);
 }
 
-/// Searcha list of meta items and return only those with a specific name
+/// Search a list of meta items and return only those with a specific name
 fn find_meta_items_by_name(metas: ~[@ast::meta_item], name: ~str) ->
    ~[@ast::meta_item] {
     let filter = fn@(m: &@ast::meta_item) -> Option<@ast::meta_item> {

--- a/src/test/compile-fail/lint-deprecated-items.rs
+++ b/src/test/compile-fail/lint-deprecated-items.rs
@@ -1,0 +1,10 @@
+#[forbid(deprecated_item)];
+
+type Bar = uint;
+
+#[deprecated = "use Bar instead"]
+type Foo = int;
+
+fn main() {
+    let _x: Foo = 21;
+}


### PR DESCRIPTION
#723 - Add a deprecated items check to lint.

``` rust
#[deprecated]
fn foo() {
    ...
}

#[deprecated = "use blah instead"]
fn bar() {
    ...
}
```
