### PR TITLE
Feature/memory

### DIFF
--- a/src/rt/boxed_region.h
+++ b/src/rt/boxed_region.h
@@ -35,6 +35,11 @@ private:
         return v;
     }
 
+private:
+    // private and undefined to disable copying
+    boxed_region(const boxed_region& rhs);
+    boxed_region& operator=(const boxed_region& rhs);
+    
 public:
     boxed_region(rust_env *e, memory_region *br)
         : env(e)

--- a/src/rt/circular_buffer.h
+++ b/src/rt/circular_buffer.h
@@ -26,6 +26,11 @@ public:
     size_t size();
 
 private:
+    // private and undefined to disable copying
+    circular_buffer(const circular_buffer& rhs);
+    circular_buffer& operator=(const circular_buffer& rhs);
+    
+private:
     size_t initial_size();
     void grow();
     void shrink();

--- a/src/rt/memory_region.cpp
+++ b/src/rt/memory_region.cpp
@@ -77,6 +77,10 @@ memory_region::realloc(void *mem, size_t orig_size) {
 
     size_t size = orig_size + HEADER_SIZE;
     alloc_header *newMem = (alloc_header *)::realloc(alloc, size);
+    if (newMem == NULL) {
+        fprintf(stderr, "memory_region::realloc> Out of memory allocating %ld bytes", size);
+        abort();
+    }
 
 #   if RUSTRT_TRACK_ALLOCATIONS >= 1
     assert(newMem->magic == MAGIC);
@@ -108,6 +112,10 @@ memory_region::malloc(size_t size, const char *tag, bool zero) {
     size_t old_size = size;
     size += HEADER_SIZE;
     alloc_header *mem = (alloc_header *)::malloc(size);
+    if (mem == NULL) {
+        fprintf(stderr, "memory_region::malloc> Out of memory allocating %ld bytes", size);
+        abort();
+    }
 
 #   if RUSTRT_TRACK_ALLOCATIONS >= 1
     mem->magic = MAGIC;

--- a/src/rt/memory_region.h
+++ b/src/rt/memory_region.h
@@ -59,6 +59,11 @@ private:
     void release_alloc(void *mem);
     void claim_alloc(void *mem);
 
+private:
+    // private and undefined to disable copying
+    memory_region(const memory_region& rhs);
+    memory_region& operator=(const memory_region& rhs);
+    
 public:
     memory_region(rust_env *env, bool synchronized);
     memory_region(memory_region *parent);

--- a/src/rt/rust_sched_launcher.h
+++ b/src/rt/rust_sched_launcher.h
@@ -13,6 +13,11 @@ public:
 private:
     rust_sched_loop sched_loop;
 
+private:
+    // private and undefined to disable copying
+    rust_sched_launcher(const rust_sched_launcher& rhs);
+    rust_sched_launcher& operator=(const rust_sched_launcher& rhs);
+    
 protected:
     rust_sched_driver driver;
 

--- a/src/rt/rust_sched_loop.h
+++ b/src/rt/rust_sched_loop.h
@@ -72,6 +72,11 @@ private:
 
     void pump_loop();
 
+private:
+    // private and undefined to disable copying
+    rust_sched_loop(const rust_sched_loop& rhs);
+    rust_sched_loop& operator=(const rust_sched_loop& rhs);
+    
 public:
     rust_kernel *kernel;
     rust_scheduler *sched;

--- a/src/rt/rust_scheduler.h
+++ b/src/rt/rust_scheduler.h
@@ -48,6 +48,11 @@ private:
     // Called when refcount reaches zero
     void delete_this();
 
+private:
+    // private and undefined to disable copying
+    rust_scheduler(const rust_scheduler& rhs);
+    rust_scheduler& operator=(const rust_scheduler& rhs);
+    
 public:
     rust_scheduler(rust_kernel *kernel, size_t max_num_threads,
                    rust_sched_id id, bool allow_exit, bool killed,

--- a/src/rt/rust_signal.h
+++ b/src/rt/rust_signal.h
@@ -16,6 +16,12 @@ class rust_signal {
 public:
     virtual void signal() = 0;
     virtual ~rust_signal() {}
+    rust_signal() {}
+
+private:
+    // private and undefined to disable copying
+    rust_signal(const rust_signal& rhs);
+    rust_signal& operator=(const rust_signal& rhs);
 };
 
 #endif /* RUST_SIGNAL_H */

--- a/src/rt/rust_task.h
+++ b/src/rt/rust_task.h
@@ -295,6 +295,11 @@ private:
     void wakeup_inner(rust_cond *from);
     bool blocked_on(rust_cond *cond);
 
+private:
+    // private and undefined to disable copying
+    rust_task(const rust_task& rhs);
+    rust_task& operator=(const rust_task& rhs);
+    
 public:
 
     // Only a pointer to 'name' is kept, so it must live as long as this task.

--- a/src/rt/util/array_list.h
+++ b/src/rt/util/array_list.h
@@ -6,25 +6,32 @@
 #include <stddef.h>
 
 /**
- * A simple, resizable array list.
+ * A simple, resizable array list. Note that this only works with POD types
+ * (because data is grown via realloc).
  */
 template<typename T> class array_list {
     static const size_t INITIAL_CAPACITY = 8;
     size_t _size;
     T * _data;
     size_t _capacity;
+private:
+    // private and left undefined to disable copying
+    array_list(const array_list& rhs);
+    array_list& operator=(const array_list& rhs);
 public:
     array_list();
     ~array_list();
-    size_t size();
+    size_t size() const;
     int32_t append(T value);
     int32_t push(T value);
     bool pop(T *value);
     bool replace(T old_value, T new_value);
-    int32_t index_of(T value);
-    bool is_empty();
+    int32_t index_of(T value) const;
+    bool is_empty() const;
     T* data();
+    const T* data() const;
     T & operator[](size_t index);
+    const T & operator[](size_t index) const;
 };
 
 template<typename T>
@@ -40,7 +47,7 @@ array_list<T>::~array_list() {
 }
 
 template<typename T> size_t
-array_list<T>::size() {
+array_list<T>::size() const {
     return _size;
 }
 
@@ -87,7 +94,7 @@ array_list<T>::replace(T old_value, T new_value) {
 }
 
 template<typename T> int32_t
-array_list<T>::index_of(T value) {
+array_list<T>::index_of(T value) const {
     for (size_t i = 0; i < _size; i++) {
         if (_data[i] == value) {
             return i;
@@ -101,13 +108,23 @@ array_list<T>::operator[](size_t index) {
     return _data[index];
 }
 
+template<typename T> const T &
+array_list<T>::operator[](size_t index) const {
+    return _data[index];
+}
+
 template<typename T> bool
-array_list<T>::is_empty() {
+array_list<T>::is_empty() const {
     return _size == 0;
 }
 
 template<typename T> T*
 array_list<T>::data() {
+    return _data;
+}
+
+template<typename T> const T*
+array_list<T>::data() const {
     return _data;
 }
 

--- a/src/rt/util/array_list.h
+++ b/src/rt/util/array_list.h
@@ -4,6 +4,7 @@
 
 #include <inttypes.h>
 #include <stddef.h>
+#include <new>
 
 /**
  * A simple, resizable array list. Note that this only works with POD types
@@ -59,8 +60,12 @@ array_list<T>::append(T value) {
 template<typename T> int32_t
 array_list<T>::push(T value) {
     if (_size == _capacity) {
-        _capacity = _capacity * 2;
-        _data = (T *) realloc(_data, _capacity * sizeof(T));
+        size_t new_capacity = _capacity * 2;
+        void* buffer = realloc(_data, new_capacity * sizeof(T));
+        if (buffer == NULL)
+            throw std::bad_alloc();
+        _data = (T *) buffer;
+        _capacity = new_capacity;
     }
     _data[_size ++] = value;
     return _size - 1;
@@ -105,11 +110,13 @@ array_list<T>::index_of(T value) const {
 
 template<typename T> T &
 array_list<T>::operator[](size_t index) {
+    assert(index < size());
     return _data[index];
 }
 
 template<typename T> const T &
 array_list<T>::operator[](size_t index) const {
+    assert(index < size());
     return _data[index];
 }
 

--- a/src/rt/util/array_list.h
+++ b/src/rt/util/array_list.h
@@ -25,7 +25,7 @@ public:
     size_t size() const;
     int32_t append(T value);
     int32_t push(T value);
-    bool pop(T *value);
+    void pop(T *value);
     bool replace(T old_value, T new_value);
     int32_t index_of(T value) const;
     bool is_empty() const;
@@ -71,17 +71,14 @@ array_list<T>::push(T value) {
     return _size - 1;
 }
 
-template<typename T> bool
+template<typename T> void
 array_list<T>::pop(T *value) {
-    if (_size == 0) {
-        return false;
-    }
+    assert(_size > 0);
     if (value != NULL) {
         *value = _data[-- _size];
     } else {
         -- _size;
     }
-    return true;
 }
 
 /**

--- a/src/rt/util/array_list.h
+++ b/src/rt/util/array_list.h
@@ -62,8 +62,10 @@ array_list<T>::push(T value) {
     if (_size == _capacity) {
         size_t new_capacity = _capacity * 2;
         void* buffer = realloc(_data, new_capacity * sizeof(T));
-        if (buffer == NULL)
-            throw std::bad_alloc();
+        if (buffer == NULL) {
+            fprintf(stderr, "array_list::push> Out of memory allocating %ld bytes", new_capacity * sizeof(T));
+            abort();
+        }
         _data = (T *) buffer;
         _capacity = new_capacity;
     }

--- a/src/rt/util/hash_map.h
+++ b/src/rt/util/hash_map.h
@@ -26,6 +26,10 @@ template<typename K, typename V> class hash_map {
         UT_hash_handle hh;
     };
     map_entry * _head;
+private:
+    // private and left undefined to disable copying
+    hash_map(const hash_map& rhs);
+    hash_map& operator=(const hash_map& rhs);
 public:
     hash_map();
     ~hash_map();
@@ -54,7 +58,7 @@ public:
      * true if the value was found and updates the specified *value parameter
      * with the associated value, or false otherwise.
      */
-    bool get(K key, V *value);
+    bool get(K key, V *value) const;
 
     /**
      * Removes a key-value pair from this hash map.
@@ -71,7 +75,7 @@ public:
      * returns:
      * true if the specified key exists in this hash map, or false otherwise.
      */
-    bool contains(K key);
+    bool contains(K key) const;
 
     /**
      * Removes the value associated with the specified key from this hash map.
@@ -86,9 +90,9 @@ public:
     /**
      * Returns the number of key-value pairs in this hash map.
      */
-    size_t count();
+    size_t count() const;
 
-    bool is_empty() {
+    bool is_empty() const {
         return count() == 0;
     }
 
@@ -124,7 +128,7 @@ hash_map<K,V>::put(K key, V value) {
 }
 
 template<typename K, typename V> bool
-hash_map<K,V>::get(K key, V *value) {
+hash_map<K,V>::get(K key, V *value) const {
     map_entry *entry = NULL;
     HASH_FIND(hh, _head, &key, sizeof(K), entry);
     if (entry == NULL) {
@@ -146,7 +150,7 @@ hash_map<K,V>::set(K key, V value) {
 }
 
 template<typename K, typename V> bool
-hash_map<K,V>::contains(K key) {
+hash_map<K,V>::contains(K key) const {
     V value;
     return get(key, &value);
 }
@@ -184,7 +188,7 @@ hash_map<K,V>::remove(K key) {
 }
 
 template<typename K, typename V> size_t
-hash_map<K,V>::count() {
+hash_map<K,V>::count() const {
     return HASH_CNT(hh, _head);
 }
 

--- a/src/rt/util/indexed_list.h
+++ b/src/rt/util/indexed_list.h
@@ -45,14 +45,15 @@ public:
      * Same as pop(), except that it returns NULL if the list is empty.
      */
     virtual T* pop_value();
-    virtual size_t length() {
+    virtual size_t length() const {
         return list.size();
     }
-    virtual bool is_empty() {
+    virtual bool is_empty() const {
         return list.is_empty();
     }
     virtual int32_t remove(T* value);
     virtual T * operator[](int32_t index);
+    virtual const T * operator[](int32_t index) const;
     virtual ~indexed_list() {}
 };
 
@@ -99,6 +100,13 @@ indexed_list<T>::pop_value() {
 
 template <typename T> T *
 indexed_list<T>::operator[](int32_t index) {
+    T *value = list[index];
+    assert(value->list_index == index);
+    return value;
+}
+
+template <typename T> const T *
+indexed_list<T>::operator[](int32_t index) const {
     T *value = list[index];
     assert(value->list_index == index);
     return value;

--- a/src/rt/util/indexed_list.h
+++ b/src/rt/util/indexed_list.h
@@ -17,6 +17,7 @@
 
 class indexed_list_object {
 public:
+    virtual ~indexed_list_object() {}
     int32_t list_index;
 };
 
@@ -39,22 +40,22 @@ public:
 template<typename T> class indexed_list {
     array_list<T*> list;
 public:
-    virtual int32_t append(T *value);
-    virtual bool pop(T **value);
+    int32_t append(T *value);
+    bool pop(T **value);
     /**
      * Same as pop(), except that it returns NULL if the list is empty.
      */
-    virtual T* pop_value();
-    virtual size_t length() const {
+    T* pop_value();
+    size_t length() const {
         return list.size();
     }
-    virtual bool is_empty() const {
+    bool is_empty() const {
         return list.is_empty();
     }
-    virtual int32_t remove(T* value);
-    virtual T * operator[](int32_t index);
-    virtual const T * operator[](int32_t index) const;
-    virtual ~indexed_list() {}
+    int32_t remove(T* value);
+    T * operator[](int32_t index);
+    const T * operator[](int32_t index) const;
+    ~indexed_list() {}
 };
 
 template<typename T> int32_t


### PR DESCRIPTION
Was looking at why my server leaked memory like a sieve. Pretty sure it is because cycles of managed pointers are not collected until task cleanup.

Along the way towards discovering this I made some small improvements to the runtime code. For the most part they are fixes to make it harder to misuse the classes.
