### PR TITLE
Adjust the die macro to only accept ~str and to work in statement positi...

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -379,7 +379,11 @@ fn core_macros() -> ~str {
     macro_rules! die(
         ($msg: expr) => (
             {
-                do core::str::as_buf($msg) |msg_buf, _msg_len| {
+                // ensure that the argument is an owned string
+                let msgptr: &~str = &{$msg};
+                // rt_fail_ returns ! so we need to constrain the type
+                // parameter on as_buf by assigning to something
+                let _: () = do core::str::as_buf(*msgptr) |msg_buf, _msg_len| {
                     do core::str::as_buf(file!()) |file_buf, _file_len| {
                         unsafe {
                             let msg_buf = core::cast::transmute(msg_buf);
@@ -388,11 +392,11 @@ fn core_macros() -> ~str {
                             core::rt::rt_fail_(msg_buf, file_buf, line)
                         }
                     }
-                }
+                };
             }
         );
         () => (
-            die!(\"explicit failure\")
+            die!(~\"explicit failure\")
         )
     )
 }";

--- a/src/test/compile-fail/die-not-unique.rs
+++ b/src/test/compile-fail/die-not-unique.rs
@@ -1,0 +1,5 @@
+// error-pattern:mismatched types
+
+fn main() {
+    die!("test");
+}

--- a/src/test/run-pass/die-macro.rs
+++ b/src/test/run-pass/die-macro.rs
@@ -1,0 +1,9 @@
+// Just testing that die!() type checks in statement position
+
+fn f() {
+    die!();
+}
+
+fn main() {
+
+}


### PR DESCRIPTION
r? @pcwalton

The error messages when failing to use `~str` are bad:

```
<core-macros>:17:37: 17:43 error: mismatched types: expected `~str` but found `&static/str` (str storage differs: expected ~ but found &static)
<core-macros>:17                 let msgptr: &~str = &{$msg};
                                                      ^~~~~~
<core-macros>:13:4: 1:0 note: in expansion of die!
/home/brian/dev/rust/src/test/compile-fail/die-not-unique.rs:4:4: 4:17 note: expansion site
<core-macros>:17:36: 17:43 error: mismatched types: expected `&~str` but found `&&static/str` (str storage differs: expected ~ but found &static)
<core-macros>:17                 let msgptr: &~str = &{$msg};
                                                     ^~~~~~~
<core-macros>:13:4: 1:0 note: in expansion of die!
/home/brian/dev/rust/src/test/compile-fail/die-not-unique.rs:4:4: 4:17 note: expansion site
error: aborting due to 2 previous errors

```
