### PR TITLE
Allow pattern-matching on any strings, not just unique strings

### DIFF
--- a/src/librustc/middle/trans/alt.rs
+++ b/src/librustc/middle/trans/alt.rs
@@ -951,8 +951,18 @@ fn compare_values(cx: block, lhs: ValueRef, rhs: ValueRef, rhs_t: ty::t) ->
                                                          scratch_result.val));
             return scratch_result.to_result(bcx);
         }
+        ty::ty_estr(_) => {
+            let scratch_result = scratch_datum(cx, ty::mk_bool(cx.tcx()),
+                                               false);
+            let did = cx.tcx().lang_items.str_eq_fn.get();
+            let bcx = callee::trans_rtcall_or_lang_call(cx, did,
+                                                        ~[lhs, rhs],
+                                                        expr::SaveIn(
+                                                         scratch_result.val));
+            return scratch_result.to_result(bcx);
+        }
         _ => {
-            cx.tcx().sess.bug(~"only scalars and unique strings supported in \
+            cx.tcx().sess.bug(~"only scalars and strings supported in \
                                 compare_values");
         }
     }

--- a/src/test/run-pass/issue-3574.rs
+++ b/src/test/run-pass/issue-3574.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test
 // rustc --test match_borrowed_str.rs.rs && ./match_borrowed_str.rs
 extern mod std;
 
@@ -21,8 +20,8 @@ fn compare(x: &str, y: &str) -> bool
     }
 }
 
-#[test]
-fn tester()
+fn main()
 {
     assert compare("foo", "foo");
+    assert compare(@"foo", @"foo");
 }


### PR DESCRIPTION
As per #3574

This seemed like a pretty straightforward addition, but I thought I would pull-request just in case there was some good reason why matching on non-unique strings wasn't allowed. (It was allowed in typechecking but the compiler would fail in trans, so something should definitely be done one way or the other.)

r? @brson
