### PR TITLE
Two tutorial fixes - #3577 and #3578

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1817,14 +1817,29 @@ struct Stack<T> {
     elements: ~[mut T]
 }
 
-enum Maybe<T> {
-    Just(T),
-    Nothing
+enum Option<T> {
+    Some(T),
+    None
 }
 ~~~~
 
 These declarations can be instantiated to valid types like `Set<int>`,
-`Stack<int>` and `Maybe<int>`.
+`Stack<int>` and `Option<int>`.
+
+The last type in that example, `Option`, appears frequently in Rust code.
+Because Rust does not have null pointers (except in unsafe code), we need
+another way to write a function whose result isn't defined on every possible
+combination of arguments of the appropriate types. The usual way is to write
+a function that returns `Option<T>` instead of `T`.
+
+~~~~
+fn radius(shape: Shape) -> Option<float> {
+   match shape {
+       Circle(_, radius) => Some(radius),
+       Rectangle(*)      => None
+   }      
+}
+~~~~
 
 The Rust compiler compiles generic functions very efficiently by
 *monomorphizing* them. *Monomorphization* is a fancy name for a simple

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -214,6 +214,11 @@ while count < 10 {
 }
 ~~~~
 
+The name of the function that prints a line of text, `io::println`, is
+qualified: it refers to the function named `println` that's defined in the
+module `io`. In Rust, a double colon---`::`---separates parts of a
+qualified name. For more details, see the section on [crates](#crates).
+
 Although Rust can almost always infer the types of local variables, you
 can specify a variable's type by following it with a colon, then the type
 name.


### PR DESCRIPTION
Mention the `Option` type earlier on, and discuss double-colon earlier on, as per the two issues.

r? @brson
