### PR TITLE
Implement read_managed_str for the JSON deserialiser.

### DIFF
--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -782,8 +782,11 @@ pub impl Deserializer: serialization::Deserializer {
     }
 
     fn read_managed_str(&self) -> @str {
-        // FIXME(#3604): There's no way to convert from a ~str to a @str.
-        fail ~"read_managed_str()";
+        debug!("read_managed_str");
+        match *self.pop() {
+            String(ref s) => s.to_managed(),
+            _ => fail ~"not a string"
+        }
     }
 
     fn read_owned<T>(&self, f: fn() -> T) -> T {


### PR DESCRIPTION
I noticed that there is now a `.to_managed` method to convert a `~str` to a `@str`, so use this to implement the last method of the JSON deserialiser.

It mentions #3604, but this doesn't fix that issue.

(PS. I'm new here; I've read the notes for developers on the wiki, but it's entirely feasible that I'm making mistakes anyway. Sorry!)
