### PR TITLE
Relate the module hierarchy to directory paths in the parser

### DIFF
--- a/src/test/run-pass/mod_dir_path.rs
+++ b/src/test/run-pass/mod_dir_path.rs
@@ -1,0 +1,21 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-pretty
+// xfail-fast
+
+mod mod_dir_simple {
+    #[path2 = "test.rs"]
+    pub mod syrup;
+}
+
+fn main() {
+    assert mod_dir_simple::syrup::foo() == 10;
+}

--- a/src/test/run-pass/mod_dir_path2.rs
+++ b/src/test/run-pass/mod_dir_path2.rs
@@ -1,0 +1,22 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-pretty
+// xfail-fast
+
+#[path2 = "mod_dir_simple"]
+mod pancakes {
+    #[path2 = "test.rs"]
+    pub mod syrup;
+}
+
+fn main() {
+    assert pancakes::syrup::foo() == 10;
+}

--- a/src/test/run-pass/mod_dir_path3.rs
+++ b/src/test/run-pass/mod_dir_path3.rs
@@ -1,0 +1,21 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-pretty
+// xfail-fast
+
+#[path2 = "mod_dir_simple"]
+mod pancakes {
+    pub mod test;
+}
+
+fn main() {
+    assert pancakes::test::foo() == 10;
+}

--- a/src/test/run-pass/mod_dir_path_multi.rs
+++ b/src/test/run-pass/mod_dir_path_multi.rs
@@ -1,0 +1,27 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-pretty
+// xfail-fast
+
+#[path2 = "mod_dir_simple"]
+mod biscuits {
+    pub mod test;
+}
+
+#[path2 = "mod_dir_simple"]
+mod gravy {
+    pub mod test;
+}
+
+fn main() {
+    assert biscuits::test::foo() == 10;
+    assert gravy::test::foo() == 10;
+}

--- a/src/test/run-pass/mod_dir_simple.rs
+++ b/src/test/run-pass/mod_dir_simple.rs
@@ -1,0 +1,20 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-pretty
+// xfail-fast
+
+mod mod_dir_simple {
+    pub mod test;
+}
+
+fn main() {
+    assert mod_dir_simple::test::foo() == 10;
+}

--- a/src/test/run-pass/mod_dir_simple/test.rs
+++ b/src/test/run-pass/mod_dir_simple/test.rs
@@ -1,0 +1,11 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn foo() -> int { 10 }


### PR DESCRIPTION
r? @graydon
#4117

Introduces a temporary 'path2' attribute that will replace 'path' after
two snapshots.
