### PR TITLE
Rename `Owned` to `Static`, `Send` to `Owned`

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -2725,11 +2725,11 @@ The kinds are:
 `Const`
   : Types of this kind are deeply immutable;
     they contain no mutable memory locations directly or indirectly via pointers.
-`Send`
+`Owned`
   : Types of this kind can be safely sent between tasks.
     This kind includes scalars, owning pointers, owned closures, and
-    structural types containing only other sendable types.
-`Owned`
+    structural types containing only other owned types. All `Owned` types are `Static`.
+`Static`
   : Types of this kind do not contain any borrowed pointers;
     this can be a useful guarantee for code that breaks borrowing assumptions using [`unsafe` operations](#unsafe-functions).
 `Copy`
@@ -2818,10 +2818,10 @@ frame they are allocated within.
 A task owns all memory it can *safely* reach through local variables,
 as well as managed, owning and borrowed pointers.
 
-When a task sends a value that has the `Send` trait to another task,
+When a task sends a value that has the `Owned` trait to another task,
 it loses ownership of the value sent and can no longer refer to it.
 This is statically guaranteed by the combined use of "move semantics",
-and the compiler-checked _meaning_ of the `Send` trait:
+and the compiler-checked _meaning_ of the `Owned` trait:
 it is only instantiated for (transitively) sendable kinds of data constructor and pointers,
 never including managed or borrowed pointers.
 
@@ -2956,7 +2956,7 @@ These include:
   - read-only and read-write shared variables with various safe mutual exclusion patterns
   - simple locks and semaphores
 
-When such facilities carry values, the values are restricted to the [`Send` type-kind](#type-kinds).
+When such facilities carry values, the values are restricted to the [`Owned` type-kind](#type-kinds).
 Restricting communication interfaces to this kind ensures that no borrowed or managed pointers move between tasks.
 Thus access to an entire data structure can be mediated through its owning "root" value;
 no further locking or copying is required to avoid data races within the substructure of such a value.

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1914,9 +1914,9 @@ types by the compiler, and may not be overridden:
   `copy` operator. All types are copyable unless they have destructors or
   contain types with destructors.
 
-* `Send` - Sendable (owned) types. All types are sendable unless they
-  contain managed boxes, managed closures, or otherwise managed
-  types. Sendable types may or may not be copyable.
+* `Owned` - Owned types. Types are owned unless they contain managed
+  boxes, managed closures, or borrowed pointers.  Owned types may or
+  may not be copyable.
 
 * `Const` - Constant (immutable) types. These are types that do not contain
   mutable fields.
@@ -1949,7 +1949,7 @@ may call it.
 ## Declaring and implementing traits
 
 A trait consists of a set of methods, without bodies, or may be empty,
-as is the case with `Copy`, `Send`, and `Const`. For example, we could
+as is the case with `Copy`, `Owned`, and `Const`. For example, we could
 declare the trait `Printable` for things that can be printed to the
 console, with a single method:
 

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -167,7 +167,7 @@ pub mod util;
 
 /* Reexported core operators */
 
-pub use kinds::{Const, Copy, Send, Owned};
+pub use kinds::{Const, Copy, Send, Static};
 pub use ops::{Drop};
 pub use ops::{Add, Sub, Mul, Div, Modulo, Neg};
 pub use ops::{BitAnd, BitOr, BitXor};

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -167,7 +167,7 @@ pub mod util;
 
 /* Reexported core operators */
 
-pub use kinds::{Const, Copy, Send, Static};
+pub use kinds::{Const, Copy, Owned, Static};
 pub use ops::{Drop};
 pub use ops::{Add, Sub, Mul, Div, Modulo, Neg};
 pub use ops::{BitAnd, BitOr, BitXor};

--- a/src/libcore/kinds.rs
+++ b/src/libcore/kinds.rs
@@ -24,7 +24,7 @@ The 4 kinds are
   scalar types and managed pointers, and exludes owned pointers. It
   also excludes types that implement `Drop`.
 
-* Send - owned types and types containing owned types.  These types
+* Owned - owned types and types containing owned types.  These types
   may be transferred across task boundaries.
 
 * Const - types that are deeply immutable. Const types are used for
@@ -44,8 +44,17 @@ pub trait Copy {
     // Empty.
 }
 
+#[cfg(stage0)]
 #[lang="send"]
-pub trait Send {
+pub trait Owned {
+    // Empty.
+}
+
+#[cfg(stage1)]
+#[cfg(stage2)]
+#[cfg(stage3)]
+#[lang="owned"]
+pub trait Owned {
     // Empty.
 }
 

--- a/src/libcore/kinds.rs
+++ b/src/libcore/kinds.rs
@@ -30,9 +30,7 @@ The 4 kinds are
 * Const - types that are deeply immutable. Const types are used for
   freezable data structures.
 
-* Owned - types that do not contain borrowed pointers. Note that this
-  meaning of 'owned' conflicts with 'owned pointers'. The two notions
-  of ownership are different.
+* Static - types that do not contain borrowed pointers.
 
 `Copy` types include both implicitly copyable types that the compiler
 will copy automatically and non-implicitly copyable types that require
@@ -56,7 +54,16 @@ pub trait Const {
     // Empty.
 }
 
+#[cfg(stage0)]
 #[lang="owned"]
-pub trait Owned {
+pub trait Static {
+    // Empty.
+}
+
+#[cfg(stage1)]
+#[cfg(stage2)]
+#[cfg(stage3)]
+#[lang="static"]
+pub trait Static {
     // Empty.
 }

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -131,7 +131,7 @@ pub fn BufferHeader() -> BufferHeader{
 
 // This is for protocols to associate extra data to thread around.
 #[doc(hidden)]
-type Buffer<T: Send> = {
+type Buffer<T: Owned> = {
     header: BufferHeader,
     data: T,
 };
@@ -180,13 +180,13 @@ impl PacketHeader {
         reinterpret_cast(&self.buffer)
     }
 
-    fn set_buffer<T: Send>(b: ~Buffer<T>) unsafe {
+    fn set_buffer<T: Owned>(b: ~Buffer<T>) unsafe {
         self.buffer = reinterpret_cast(&b);
     }
 }
 
 #[doc(hidden)]
-pub type Packet<T: Send> = {
+pub type Packet<T: Owned> = {
     header: PacketHeader,
     mut payload: Option<T>,
 };
@@ -197,14 +197,14 @@ pub trait HasBuffer {
     fn set_buffer_(b: *libc::c_void);
 }
 
-impl<T: Send> Packet<T>: HasBuffer {
+impl<T: Owned> Packet<T>: HasBuffer {
     fn set_buffer_(b: *libc::c_void) {
         self.header.buffer = b;
     }
 }
 
 #[doc(hidden)]
-pub fn mk_packet<T: Send>() -> Packet<T> {
+pub fn mk_packet<T: Owned>() -> Packet<T> {
     {
         header: PacketHeader(),
         mut payload: None
@@ -212,7 +212,7 @@ pub fn mk_packet<T: Send>() -> Packet<T> {
 }
 
 #[doc(hidden)]
-fn unibuffer<T: Send>() -> ~Buffer<Packet<T>> {
+fn unibuffer<T: Owned>() -> ~Buffer<Packet<T>> {
     let b = ~{
         header: BufferHeader(),
         data: {
@@ -228,7 +228,7 @@ fn unibuffer<T: Send>() -> ~Buffer<Packet<T>> {
 }
 
 #[doc(hidden)]
-pub fn packet<T: Send>() -> *Packet<T> {
+pub fn packet<T: Owned>() -> *Packet<T> {
     let b = unibuffer();
     let p = ptr::addr_of(&(b.data));
     // We'll take over memory management from here.
@@ -237,7 +237,7 @@ pub fn packet<T: Send>() -> *Packet<T> {
 }
 
 #[doc(hidden)]
-pub fn entangle_buffer<T: Send, Tstart: Send>(
+pub fn entangle_buffer<T: Owned, Tstart: Owned>(
     buffer: ~Buffer<T>,
     init: fn(*libc::c_void, x: &T) -> *Packet<Tstart>)
     -> (SendPacketBuffered<Tstart, T>, RecvPacketBuffered<Tstart, T>)
@@ -329,12 +329,12 @@ fn swap_state_rel(dst: &mut State, src: State) -> State {
 }
 
 #[doc(hidden)]
-pub unsafe fn get_buffer<T: Send>(p: *PacketHeader) -> ~Buffer<T> {
+pub unsafe fn get_buffer<T: Owned>(p: *PacketHeader) -> ~Buffer<T> {
     transmute((*p).buf_header())
 }
 
 // This could probably be done with SharedMutableState to avoid move_it!().
-struct BufferResource<T: Send> {
+struct BufferResource<T: Owned> {
     buffer: ~Buffer<T>,
 
     drop unsafe {
@@ -354,7 +354,7 @@ struct BufferResource<T: Send> {
     }
 }
 
-fn BufferResource<T: Send>(b: ~Buffer<T>) -> BufferResource<T> {
+fn BufferResource<T: Owned>(b: ~Buffer<T>) -> BufferResource<T> {
     //let p = ptr::addr_of(*b);
     //error!("take %?", p);
     atomic_add_acq(&mut b.header.ref_count, 1);
@@ -366,7 +366,7 @@ fn BufferResource<T: Send>(b: ~Buffer<T>) -> BufferResource<T> {
 }
 
 #[doc(hidden)]
-pub fn send<T: Send, Tbuffer: Send>(p: SendPacketBuffered<T, Tbuffer>,
+pub fn send<T: Owned, Tbuffer: Owned>(p: SendPacketBuffered<T, Tbuffer>,
                                     payload: T) -> bool {
     let header = p.header();
     let p_ = p.unwrap();
@@ -410,7 +410,8 @@ pub fn send<T: Send, Tbuffer: Send>(p: SendPacketBuffered<T, Tbuffer>,
 Fails if the sender closes the connection.
 
 */
-pub fn recv<T: Send, Tbuffer: Send>(p: RecvPacketBuffered<T, Tbuffer>) -> T {
+pub fn recv<T: Owned, Tbuffer: Owned>(
+    p: RecvPacketBuffered<T, Tbuffer>) -> T {
     option::unwrap_expect(try_recv(move p), "connection closed")
 }
 
@@ -420,7 +421,7 @@ Returns `None` if the sender has closed the connection without sending
 a message, or `Some(T)` if a message was received.
 
 */
-pub fn try_recv<T: Send, Tbuffer: Send>(p: RecvPacketBuffered<T, Tbuffer>)
+pub fn try_recv<T: Owned, Tbuffer: Owned>(p: RecvPacketBuffered<T, Tbuffer>)
     -> Option<T>
 {
     let p_ = p.unwrap();
@@ -519,7 +520,7 @@ pub fn try_recv<T: Send, Tbuffer: Send>(p: RecvPacketBuffered<T, Tbuffer>)
 }
 
 /// Returns true if messages are available.
-pub pure fn peek<T: Send, Tb: Send>(p: &RecvPacketBuffered<T, Tb>) -> bool {
+pub pure fn peek<T: Owned, Tb: Owned>(p: &RecvPacketBuffered<T, Tb>) -> bool {
     match unsafe {(*p.header()).state} {
       Empty | Terminated => false,
       Blocked => fail ~"peeking on blocked packet",
@@ -527,14 +528,14 @@ pub pure fn peek<T: Send, Tb: Send>(p: &RecvPacketBuffered<T, Tb>) -> bool {
     }
 }
 
-impl<T: Send, Tb: Send> RecvPacketBuffered<T, Tb>: Peekable<T> {
+impl<T: Owned, Tb: Owned> RecvPacketBuffered<T, Tb>: Peekable<T> {
     pure fn peek() -> bool {
         peek(&self)
     }
 }
 
 #[doc(hidden)]
-fn sender_terminate<T: Send>(p: *Packet<T>) {
+fn sender_terminate<T: Owned>(p: *Packet<T>) {
     let p = unsafe { &*p };
     match swap_state_rel(&mut p.header.state, Terminated) {
       Empty => {
@@ -563,7 +564,7 @@ fn sender_terminate<T: Send>(p: *Packet<T>) {
 }
 
 #[doc(hidden)]
-fn receiver_terminate<T: Send>(p: *Packet<T>) {
+fn receiver_terminate<T: Owned>(p: *Packet<T>) {
     let p = unsafe { &*p };
     match swap_state_rel(&mut p.header.state, Terminated) {
       Empty => {
@@ -671,7 +672,7 @@ Sometimes messages will be available on both endpoints at once. In
 this case, `select2` may return either `left` or `right`.
 
 */
-pub fn select2<A: Send, Ab: Send, B: Send, Bb: Send>(
+pub fn select2<A: Owned, Ab: Owned, B: Owned, Bb: Owned>(
     a: RecvPacketBuffered<A, Ab>,
     b: RecvPacketBuffered<B, Bb>)
     -> Either<(Option<A>, RecvPacketBuffered<B, Bb>),
@@ -714,7 +715,7 @@ pub fn select2i<A: Selectable, B: Selectable>(a: &A, b: &B) ->
  list of the remaining endpoints.
 
 */
-pub fn select<T: Send, Tb: Send>(endpoints: ~[RecvPacketBuffered<T, Tb>])
+pub fn select<T: Owned, Tb: Owned>(endpoints: ~[RecvPacketBuffered<T, Tb>])
     -> (uint, Option<T>, ~[RecvPacketBuffered<T, Tb>])
 {
     let ready = wait_many(endpoints.map(|p| p.header()));
@@ -728,14 +729,14 @@ pub fn select<T: Send, Tb: Send>(endpoints: ~[RecvPacketBuffered<T, Tb>])
 message.
 
 */
-pub type SendPacket<T: Send> = SendPacketBuffered<T, Packet<T>>;
+pub type SendPacket<T: Owned> = SendPacketBuffered<T, Packet<T>>;
 
 #[doc(hidden)]
-pub fn SendPacket<T: Send>(p: *Packet<T>) -> SendPacket<T> {
+pub fn SendPacket<T: Owned>(p: *Packet<T>) -> SendPacket<T> {
     SendPacketBuffered(p)
 }
 
-pub struct SendPacketBuffered<T: Send, Tbuffer: Send> {
+pub struct SendPacketBuffered<T: Owned, Tbuffer: Owned> {
     mut p: Option<*Packet<T>>,
     mut buffer: Option<BufferResource<Tbuffer>>,
     drop {
@@ -754,7 +755,7 @@ pub struct SendPacketBuffered<T: Send, Tbuffer: Send> {
     }
 }
 
-pub fn SendPacketBuffered<T: Send, Tbuffer: Send>(p: *Packet<T>)
+pub fn SendPacketBuffered<T: Owned, Tbuffer: Owned>(p: *Packet<T>)
     -> SendPacketBuffered<T, Tbuffer> {
         //debug!("take send %?", p);
     SendPacketBuffered {
@@ -766,7 +767,7 @@ pub fn SendPacketBuffered<T: Send, Tbuffer: Send>(p: *Packet<T>)
     }
 }
 
-impl<T: Send, Tbuffer: Send> SendPacketBuffered<T, Tbuffer> {
+impl<T: Owned, Tbuffer: Owned> SendPacketBuffered<T, Tbuffer> {
     fn unwrap() -> *Packet<T> {
         let mut p = None;
         p <-> self.p;
@@ -795,14 +796,14 @@ impl<T: Send, Tbuffer: Send> SendPacketBuffered<T, Tbuffer> {
 
 /// Represents the receive end of a pipe. It can receive exactly one
 /// message.
-pub type RecvPacket<T: Send> = RecvPacketBuffered<T, Packet<T>>;
+pub type RecvPacket<T: Owned> = RecvPacketBuffered<T, Packet<T>>;
 
 #[doc(hidden)]
-pub fn RecvPacket<T: Send>(p: *Packet<T>) -> RecvPacket<T> {
+pub fn RecvPacket<T: Owned>(p: *Packet<T>) -> RecvPacket<T> {
     RecvPacketBuffered(p)
 }
 
-pub struct RecvPacketBuffered<T: Send, Tbuffer: Send> {
+pub struct RecvPacketBuffered<T: Owned, Tbuffer: Owned> {
     mut p: Option<*Packet<T>>,
     mut buffer: Option<BufferResource<Tbuffer>>,
     drop {
@@ -821,7 +822,7 @@ pub struct RecvPacketBuffered<T: Send, Tbuffer: Send> {
     }
 }
 
-impl<T: Send, Tbuffer: Send> RecvPacketBuffered<T, Tbuffer> {
+impl<T: Owned, Tbuffer: Owned> RecvPacketBuffered<T, Tbuffer> {
     fn unwrap() -> *Packet<T> {
         let mut p = None;
         p <-> self.p;
@@ -836,7 +837,7 @@ impl<T: Send, Tbuffer: Send> RecvPacketBuffered<T, Tbuffer> {
     }
 }
 
-impl<T: Send, Tbuffer: Send> RecvPacketBuffered<T, Tbuffer> : Selectable {
+impl<T: Owned, Tbuffer: Owned> RecvPacketBuffered<T, Tbuffer> : Selectable {
     pure fn header() -> *PacketHeader {
         match self.p {
           Some(packet) => unsafe {
@@ -850,7 +851,7 @@ impl<T: Send, Tbuffer: Send> RecvPacketBuffered<T, Tbuffer> : Selectable {
     }
 }
 
-pub fn RecvPacketBuffered<T: Send, Tbuffer: Send>(p: *Packet<T>)
+pub fn RecvPacketBuffered<T: Owned, Tbuffer: Owned>(p: *Packet<T>)
     -> RecvPacketBuffered<T, Tbuffer> {
     //debug!("take recv %?", p);
     RecvPacketBuffered {
@@ -863,7 +864,7 @@ pub fn RecvPacketBuffered<T: Send, Tbuffer: Send>(p: *Packet<T>)
 }
 
 #[doc(hidden)]
-pub fn entangle<T: Send>() -> (SendPacket<T>, RecvPacket<T>) {
+pub fn entangle<T: Owned>() -> (SendPacket<T>, RecvPacket<T>) {
     let p = packet();
     (SendPacket(p), RecvPacket(p))
 }
@@ -875,7 +876,7 @@ endpoint. The send endpoint is returned to the caller and the receive
 endpoint is passed to the new task.
 
 */
-pub fn spawn_service<T: Send, Tb: Send>(
+pub fn spawn_service<T: Owned, Tb: Owned>(
     init: extern fn() -> (SendPacketBuffered<T, Tb>,
                           RecvPacketBuffered<T, Tb>),
     service: fn~(v: RecvPacketBuffered<T, Tb>))
@@ -899,7 +900,7 @@ pub fn spawn_service<T: Send, Tb: Send>(
 receive state.
 
 */
-pub fn spawn_service_recv<T: Send, Tb: Send>(
+pub fn spawn_service_recv<T: Owned, Tb: Owned>(
     init: extern fn() -> (RecvPacketBuffered<T, Tb>,
                           SendPacketBuffered<T, Tb>),
     service: fn~(v: SendPacketBuffered<T, Tb>))
@@ -922,7 +923,7 @@ pub fn spawn_service_recv<T: Send, Tb: Send>(
 // Streams - Make pipes a little easier in general.
 
 proto! streamp (
-    Open:send<T: Send> {
+    Open:send<T: Owned> {
         data(T) -> Open<T>
     }
 )
@@ -958,18 +959,18 @@ pub trait Peekable<T> {
 }
 
 #[doc(hidden)]
-type Chan_<T:Send> = { mut endp: Option<streamp::client::Open<T>> };
+type Chan_<T:Owned> = { mut endp: Option<streamp::client::Open<T>> };
 
 /// An endpoint that can send many messages.
-pub enum Chan<T:Send> {
+pub enum Chan<T:Owned> {
     Chan_(Chan_<T>)
 }
 
 #[doc(hidden)]
-type Port_<T:Send> = { mut endp: Option<streamp::server::Open<T>> };
+type Port_<T:Owned> = { mut endp: Option<streamp::server::Open<T>> };
 
 /// An endpoint that can receive many messages.
-pub enum Port<T:Send> {
+pub enum Port<T:Owned> {
     Port_(Port_<T>)
 }
 
@@ -978,13 +979,13 @@ pub enum Port<T:Send> {
 These allow sending or receiving an unlimited number of messages.
 
 */
-pub fn stream<T:Send>() -> (Chan<T>, Port<T>) {
+pub fn stream<T:Owned>() -> (Chan<T>, Port<T>) {
     let (c, s) = streamp::init();
 
     (Chan_({ mut endp: Some(move c) }), Port_({ mut endp: Some(move s) }))
 }
 
-impl<T: Send> Chan<T>: GenericChan<T> {
+impl<T: Owned> Chan<T>: GenericChan<T> {
     fn send(x: T) {
         let mut endp = None;
         endp <-> self.endp;
@@ -993,7 +994,7 @@ impl<T: Send> Chan<T>: GenericChan<T> {
     }
 }
 
-impl<T: Send> Chan<T>: GenericSmartChan<T> {
+impl<T: Owned> Chan<T>: GenericSmartChan<T> {
 
     fn try_send(x: T) -> bool {
         let mut endp = None;
@@ -1008,7 +1009,7 @@ impl<T: Send> Chan<T>: GenericSmartChan<T> {
     }
 }
 
-impl<T: Send> Port<T>: GenericPort<T> {
+impl<T: Owned> Port<T>: GenericPort<T> {
     fn recv() -> T {
         let mut endp = None;
         endp <-> self.endp;
@@ -1030,7 +1031,7 @@ impl<T: Send> Port<T>: GenericPort<T> {
     }
 }
 
-impl<T: Send> Port<T>: Peekable<T> {
+impl<T: Owned> Port<T>: Peekable<T> {
     pure fn peek() -> bool unsafe {
         let mut endp = None;
         endp <-> self.endp;
@@ -1043,7 +1044,7 @@ impl<T: Send> Port<T>: Peekable<T> {
     }
 }
 
-impl<T: Send> Port<T>: Selectable {
+impl<T: Owned> Port<T>: Selectable {
     pure fn header() -> *PacketHeader unsafe {
         match self.endp {
           Some(ref endp) => endp.header(),
@@ -1053,17 +1054,17 @@ impl<T: Send> Port<T>: Selectable {
 }
 
 /// Treat many ports as one.
-pub struct PortSet<T: Send> {
+pub struct PortSet<T: Owned> {
     mut ports: ~[pipes::Port<T>],
 }
 
-pub fn PortSet<T: Send>() -> PortSet<T>{
+pub fn PortSet<T: Owned>() -> PortSet<T>{
     PortSet {
         ports: ~[]
     }
 }
 
-impl<T: Send> PortSet<T> {
+impl<T: Owned> PortSet<T> {
 
     fn add(port: pipes::Port<T>) {
         self.ports.push(move port)
@@ -1076,7 +1077,7 @@ impl<T: Send> PortSet<T> {
     }
 }
 
-impl<T: Send> PortSet<T> : GenericPort<T> {
+impl<T: Owned> PortSet<T> : GenericPort<T> {
 
     fn try_recv() -> Option<T> {
         let mut result = None;
@@ -1106,7 +1107,7 @@ impl<T: Send> PortSet<T> : GenericPort<T> {
 
 }
 
-impl<T: Send> PortSet<T> : Peekable<T> {
+impl<T: Owned> PortSet<T> : Peekable<T> {
     pure fn peek() -> bool {
         // It'd be nice to use self.port.each, but that version isn't
         // pure.
@@ -1118,9 +1119,9 @@ impl<T: Send> PortSet<T> : Peekable<T> {
 }
 
 /// A channel that can be shared between many senders.
-pub type SharedChan<T: Send> = private::Exclusive<Chan<T>>;
+pub type SharedChan<T: Owned> = private::Exclusive<Chan<T>>;
 
-impl<T: Send> SharedChan<T>: GenericChan<T> {
+impl<T: Owned> SharedChan<T>: GenericChan<T> {
     fn send(x: T) {
         let mut xx = Some(move x);
         do self.with_imm |chan| {
@@ -1131,7 +1132,7 @@ impl<T: Send> SharedChan<T>: GenericChan<T> {
     }
 }
 
-impl<T: Send> SharedChan<T>: GenericSmartChan<T> {
+impl<T: Owned> SharedChan<T>: GenericSmartChan<T> {
     fn try_send(x: T) -> bool {
         let mut xx = Some(move x);
         do self.with_imm |chan| {
@@ -1143,19 +1144,19 @@ impl<T: Send> SharedChan<T>: GenericSmartChan<T> {
 }
 
 /// Converts a `chan` into a `shared_chan`.
-pub fn SharedChan<T:Send>(c: Chan<T>) -> SharedChan<T> {
+pub fn SharedChan<T:Owned>(c: Chan<T>) -> SharedChan<T> {
     private::exclusive(move c)
 }
 
 /// Receive a message from one of two endpoints.
-pub trait Select2<T: Send, U: Send> {
+pub trait Select2<T: Owned, U: Owned> {
     /// Receive a message or return `None` if a connection closes.
     fn try_select() -> Either<Option<T>, Option<U>>;
     /// Receive a message or fail if a connection closes.
     fn select() -> Either<T, U>;
 }
 
-impl<T: Send, U: Send,
+impl<T: Owned, U: Owned,
      Left: Selectable GenericPort<T>,
      Right: Selectable GenericPort<U>>
     (Left, Right): Select2<T, U> {
@@ -1180,18 +1181,18 @@ impl<T: Send, U: Send,
 }
 
 proto! oneshot (
-    Oneshot:send<T:Send> {
+    Oneshot:send<T:Owned> {
         send(T) -> !
     }
 )
 
 /// The send end of a oneshot pipe.
-pub type ChanOne<T: Send> = oneshot::client::Oneshot<T>;
+pub type ChanOne<T: Owned> = oneshot::client::Oneshot<T>;
 /// The receive end of a oneshot pipe.
-pub type PortOne<T: Send> = oneshot::server::Oneshot<T>;
+pub type PortOne<T: Owned> = oneshot::server::Oneshot<T>;
 
 /// Initialiase a (send-endpoint, recv-endpoint) oneshot pipe pair.
-pub fn oneshot<T: Send>() -> (ChanOne<T>, PortOne<T>) {
+pub fn oneshot<T: Owned>() -> (ChanOne<T>, PortOne<T>) {
     oneshot::init()
 }
 
@@ -1199,13 +1200,13 @@ pub fn oneshot<T: Send>() -> (ChanOne<T>, PortOne<T>) {
  * Receive a message from a oneshot pipe, failing if the connection was
  * closed.
  */
-pub fn recv_one<T: Send>(port: PortOne<T>) -> T {
+pub fn recv_one<T: Owned>(port: PortOne<T>) -> T {
     let oneshot::send(message) = recv(move port);
     move message
 }
 
 /// Receive a message from a oneshot pipe unless the connection was closed.
-pub fn try_recv_one<T: Send> (port: PortOne<T>) -> Option<T> {
+pub fn try_recv_one<T: Owned> (port: PortOne<T>) -> Option<T> {
     let message = try_recv(move port);
 
     if message.is_none() { None }
@@ -1216,7 +1217,7 @@ pub fn try_recv_one<T: Send> (port: PortOne<T>) -> Option<T> {
 }
 
 /// Send a message on a oneshot pipe, failing if the connection was closed.
-pub fn send_one<T: Send>(chan: ChanOne<T>, data: T) {
+pub fn send_one<T: Owned>(chan: ChanOne<T>, data: T) {
     oneshot::client::send(move chan, move data);
 }
 
@@ -1224,7 +1225,7 @@ pub fn send_one<T: Send>(chan: ChanOne<T>, data: T) {
  * Send a message on a oneshot pipe, or return false if the connection was
  * closed.
  */
-pub fn try_send_one<T: Send>(chan: ChanOne<T>, data: T)
+pub fn try_send_one<T: Owned>(chan: ChanOne<T>, data: T)
         -> bool {
     oneshot::client::try_send(move chan, move data).is_some()
 }

--- a/src/libcore/task/local_data.rs
+++ b/src/libcore/task/local_data.rs
@@ -47,13 +47,13 @@ use local_data_priv::{
  *
  * These two cases aside, the interface is safe.
  */
-pub type LocalDataKey<T: Owned> = &fn(v: @T);
+pub type LocalDataKey<T: Static> = &fn(v: @T);
 
 /**
  * Remove a task-local data value from the table, returning the
  * reference that was originally created to insert it.
  */
-pub unsafe fn local_data_pop<T: Owned>(
+pub unsafe fn local_data_pop<T: Static>(
     key: LocalDataKey<T>) -> Option<@T> {
 
     local_pop(rt::rust_get_task(), key)
@@ -62,7 +62,7 @@ pub unsafe fn local_data_pop<T: Owned>(
  * Retrieve a task-local data value. It will also be kept alive in the
  * table until explicitly removed.
  */
-pub unsafe fn local_data_get<T: Owned>(
+pub unsafe fn local_data_get<T: Static>(
     key: LocalDataKey<T>) -> Option<@T> {
 
     local_get(rt::rust_get_task(), key)
@@ -71,7 +71,7 @@ pub unsafe fn local_data_get<T: Owned>(
  * Store a value in task-local data. If this key already has a value,
  * that value is overwritten (and its destructor is run).
  */
-pub unsafe fn local_data_set<T: Owned>(
+pub unsafe fn local_data_set<T: Static>(
     key: LocalDataKey<T>, data: @T) {
 
     local_set(rt::rust_get_task(), key, data)
@@ -80,7 +80,7 @@ pub unsafe fn local_data_set<T: Owned>(
  * Modify a task-local data value. If the function returns 'None', the
  * data is removed (and its reference dropped).
  */
-pub unsafe fn local_data_modify<T: Owned>(
+pub unsafe fn local_data_modify<T: Static>(
     key: LocalDataKey<T>,
     modify_fn: fn(Option<@T>) -> Option<@T>) {
 

--- a/src/libcore/task/local_data_priv.rs
+++ b/src/libcore/task/local_data_priv.rs
@@ -14,7 +14,7 @@ use local_data::LocalDataKey;
 use rt::rust_task;
 
 pub trait LocalData { }
-impl<T: Owned> @T: LocalData { }
+impl<T: Static> @T: LocalData { }
 
 impl LocalData: Eq {
     pure fn eq(&self, other: &@LocalData) -> bool unsafe {
@@ -62,7 +62,7 @@ unsafe fn get_task_local_map(task: *rust_task) -> TaskLocalMap {
     }
 }
 
-unsafe fn key_to_key_value<T: Owned>(
+unsafe fn key_to_key_value<T: Static>(
     key: LocalDataKey<T>) -> *libc::c_void {
 
     // Keys are closures, which are (fnptr,envptr) pairs. Use fnptr.
@@ -72,7 +72,7 @@ unsafe fn key_to_key_value<T: Owned>(
 }
 
 // If returning Some(..), returns with @T with the map's reference. Careful!
-unsafe fn local_data_lookup<T: Owned>(
+unsafe fn local_data_lookup<T: Static>(
     map: TaskLocalMap, key: LocalDataKey<T>)
     -> Option<(uint, *libc::c_void)> {
 
@@ -90,7 +90,7 @@ unsafe fn local_data_lookup<T: Owned>(
     }
 }
 
-unsafe fn local_get_helper<T: Owned>(
+unsafe fn local_get_helper<T: Static>(
     task: *rust_task, key: LocalDataKey<T>,
     do_pop: bool) -> Option<@T> {
 
@@ -112,21 +112,21 @@ unsafe fn local_get_helper<T: Owned>(
 }
 
 
-pub unsafe fn local_pop<T: Owned>(
+pub unsafe fn local_pop<T: Static>(
     task: *rust_task,
     key: LocalDataKey<T>) -> Option<@T> {
 
     local_get_helper(task, key, true)
 }
 
-pub unsafe fn local_get<T: Owned>(
+pub unsafe fn local_get<T: Static>(
     task: *rust_task,
     key: LocalDataKey<T>) -> Option<@T> {
 
     local_get_helper(task, key, false)
 }
 
-pub unsafe fn local_set<T: Owned>(
+pub unsafe fn local_set<T: Static>(
     task: *rust_task, key: LocalDataKey<T>, data: @T) {
 
     let map = get_task_local_map(task);
@@ -158,7 +158,7 @@ pub unsafe fn local_set<T: Owned>(
     }
 }
 
-pub unsafe fn local_modify<T: Owned>(
+pub unsafe fn local_modify<T: Static>(
     task: *rust_task, key: LocalDataKey<T>,
     modify_fn: fn(Option<@T>) -> Option<@T>) {
 

--- a/src/libcore/task/mod.rs
+++ b/src/libcore/task/mod.rs
@@ -427,7 +427,7 @@ impl TaskBuilder {
         spawn::spawn_raw(move opts, (x.gen_body)(move f));
     }
     /// Runs a task, while transfering ownership of one argument to the child.
-    fn spawn_with<A: Send>(arg: A, f: fn~(v: A)) {
+    fn spawn_with<A: Owned>(arg: A, f: fn~(v: A)) {
         let arg = ~mut Some(move arg);
         do self.spawn |move arg, move f| {
             f(option::swap_unwrap(arg))
@@ -445,7 +445,7 @@ impl TaskBuilder {
      * otherwise be required to establish communication from the parent
      * to the child.
      */
-    fn spawn_listener<A: Send>(f: fn~(comm::Port<A>)) -> comm::Chan<A> {
+    fn spawn_listener<A: Owned>(f: fn~(comm::Port<A>)) -> comm::Chan<A> {
         let setup_po = comm::Port();
         let setup_ch = comm::Chan(&setup_po);
         do self.spawn |move f| {
@@ -460,7 +460,7 @@ impl TaskBuilder {
     /**
      * Runs a new task, setting up communication in both directions
      */
-    fn spawn_conversation<A: Send, B: Send>
+    fn spawn_conversation<A: Owned, B: Owned>
         (f: fn~(comm::Port<A>, comm::Chan<B>))
         -> (comm::Port<B>, comm::Chan<A>) {
         let from_child = comm::Port();
@@ -484,7 +484,7 @@ impl TaskBuilder {
      * # Failure
      * Fails if a future_result was already set for this task.
      */
-    fn try<T: Send>(f: fn~() -> T) -> Result<T,()> {
+    fn try<T: Owned>(f: fn~() -> T) -> Result<T,()> {
         let po = comm::Port();
         let ch = comm::Chan(&po);
         let mut result = None;
@@ -554,7 +554,7 @@ pub fn spawn_supervised(f: fn~()) {
     task().supervised().spawn(move f)
 }
 
-pub fn spawn_with<A:Send>(arg: A, f: fn~(v: A)) {
+pub fn spawn_with<A:Owned>(arg: A, f: fn~(v: A)) {
     /*!
      * Runs a task, while transfering ownership of one argument to the
      * child.
@@ -568,7 +568,7 @@ pub fn spawn_with<A:Send>(arg: A, f: fn~(v: A)) {
     task().spawn_with(move arg, move f)
 }
 
-pub fn spawn_listener<A:Send>(f: fn~(comm::Port<A>)) -> comm::Chan<A> {
+pub fn spawn_listener<A:Owned>(f: fn~(comm::Port<A>)) -> comm::Chan<A> {
     /*!
      * Runs a new task while providing a channel from the parent to the child
      *
@@ -578,7 +578,7 @@ pub fn spawn_listener<A:Send>(f: fn~(comm::Port<A>)) -> comm::Chan<A> {
     task().spawn_listener(move f)
 }
 
-pub fn spawn_conversation<A: Send, B: Send>
+pub fn spawn_conversation<A: Owned, B: Owned>
     (f: fn~(comm::Port<A>, comm::Chan<B>))
     -> (comm::Port<B>, comm::Chan<A>) {
     /*!
@@ -607,7 +607,7 @@ pub fn spawn_sched(mode: SchedMode, f: fn~()) {
     task().sched_mode(mode).spawn(move f)
 }
 
-pub fn try<T:Send>(f: fn~() -> T) -> Result<T,()> {
+pub fn try<T:Owned>(f: fn~() -> T) -> Result<T,()> {
     /*!
      * Execute a function in another task and return either the return value
      * of the function or result::err.

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -483,7 +483,7 @@ fn parse_bounds(st: @pstate, conv: conv_did) -> @~[ty::param_bound] {
     let mut bounds = ~[];
     loop {
         bounds.push(match next(st) {
-          'S' => ty::bound_send,
+          'S' => ty::bound_owned,
           'C' => ty::bound_copy,
           'K' => ty::bound_const,
           'O' => ty::bound_static,

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -486,7 +486,7 @@ fn parse_bounds(st: @pstate, conv: conv_did) -> @~[ty::param_bound] {
           'S' => ty::bound_send,
           'C' => ty::bound_copy,
           'K' => ty::bound_const,
-          'O' => ty::bound_owned,
+          'O' => ty::bound_static,
           'I' => ty::bound_trait(parse_ty(st, conv)),
           '.' => break,
           _ => fail ~"parse_bounds: bad bounds"

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -392,7 +392,7 @@ fn enc_ty_fn(w: io::Writer, cx: @ctxt, ft: ty::FnTy) {
 fn enc_bounds(w: io::Writer, cx: @ctxt, bs: @~[ty::param_bound]) {
     for vec::each(*bs) |bound| {
         match *bound {
-          ty::bound_send => w.write_char('S'),
+          ty::bound_owned => w.write_char('S'),
           ty::bound_copy => w.write_char('C'),
           ty::bound_const => w.write_char('K'),
           ty::bound_static => w.write_char('O'),

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -395,7 +395,7 @@ fn enc_bounds(w: io::Writer, cx: @ctxt, bs: @~[ty::param_bound]) {
           ty::bound_send => w.write_char('S'),
           ty::bound_copy => w.write_char('C'),
           ty::bound_const => w.write_char('K'),
-          ty::bound_owned => w.write_char('O'),
+          ty::bound_static => w.write_char('O'),
           ty::bound_trait(tp) => {
             w.write_char('I');
             enc_ty(w, cx, tp);

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -62,7 +62,7 @@ fn kind_to_str(k: Kind) -> ~str {
     }
 
     if ty::kind_can_be_sent(k) {
-        kinds.push(~"send");
+        kinds.push(~"owned");
     } else if ty::kind_is_static(k) {
         kinds.push(~"static");
     }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -13,7 +13,7 @@
 // Language items are items that represent concepts intrinsic to the language
 // itself. Examples are:
 //
-// * Traits that specify "kinds"; e.g. "const", "copy", "send".
+// * Traits that specify "kinds"; e.g. "const", "copy", "owned".
 //
 // * Traits that represent operators; e.g. "add", "sub", "index".
 //
@@ -35,7 +35,7 @@ use str_eq = str::eq;
 struct LanguageItems {
     mut const_trait: Option<def_id>,
     mut copy_trait: Option<def_id>,
-    mut send_trait: Option<def_id>,
+    mut owned_trait: Option<def_id>,
     mut static_trait: Option<def_id>,
 
     mut drop_trait: Option<def_id>,
@@ -68,7 +68,7 @@ mod language_items {
         LanguageItems {
             const_trait: None,
             copy_trait: None,
-            send_trait: None,
+            owned_trait: None,
             static_trait: None,
 
             drop_trait: None,
@@ -105,7 +105,7 @@ fn LanguageItemCollector(crate: @crate, session: Session,
 
     item_refs.insert(~"const", &mut items.const_trait);
     item_refs.insert(~"copy", &mut items.copy_trait);
-    item_refs.insert(~"send", &mut items.send_trait);
+    item_refs.insert(~"owned", &mut items.owned_trait);
     item_refs.insert(~"static", &mut items.static_trait);
 
     item_refs.insert(~"drop", &mut items.drop_trait);

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -36,7 +36,7 @@ struct LanguageItems {
     mut const_trait: Option<def_id>,
     mut copy_trait: Option<def_id>,
     mut send_trait: Option<def_id>,
-    mut owned_trait: Option<def_id>,
+    mut static_trait: Option<def_id>,
 
     mut drop_trait: Option<def_id>,
 
@@ -69,7 +69,7 @@ mod language_items {
             const_trait: None,
             copy_trait: None,
             send_trait: None,
-            owned_trait: None,
+            static_trait: None,
 
             drop_trait: None,
 
@@ -106,7 +106,7 @@ fn LanguageItemCollector(crate: @crate, session: Session,
     item_refs.insert(~"const", &mut items.const_trait);
     item_refs.insert(~"copy", &mut items.copy_trait);
     item_refs.insert(~"send", &mut items.send_trait);
-    item_refs.insert(~"owned", &mut items.owned_trait);
+    item_refs.insert(~"static", &mut items.static_trait);
 
     item_refs.insert(~"drop", &mut items.drop_trait);
 

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -518,7 +518,7 @@ fn combine_impl_and_methods_origins(bcx: block,
     let m_vtables = m_boundss.foldl(0, |sum, m_bounds| {
         m_bounds.foldl(*sum, |sum, m_bound| {
             (*sum) + match (*m_bound) {
-                ty::bound_copy | ty::bound_owned |
+                ty::bound_copy | ty::bound_static |
                 ty::bound_send | ty::bound_const => 0,
                 ty::bound_trait(_) => 1
             }

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -519,7 +519,7 @@ fn combine_impl_and_methods_origins(bcx: block,
         m_bounds.foldl(*sum, |sum, m_bound| {
             (*sum) + match (*m_bound) {
                 ty::bound_copy | ty::bound_static |
-                ty::bound_send | ty::bound_const => 0,
+                ty::bound_owned | ty::bound_const => 0,
                 ty::bound_trait(_) => 1
             }
         })

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -178,7 +178,7 @@ export occurs_check;
 export param_ty;
 export param_bound, param_bounds, bound_copy, bound_static;
 export param_bounds_to_str, param_bound_to_str;
-export bound_send, bound_trait;
+export bound_owned, bound_trait;
 export param_bounds_to_kind;
 export default_arg_mode_for_ty;
 export item_path;
@@ -730,7 +730,7 @@ enum type_err {
 enum param_bound {
     bound_copy,
     bound_static,
-    bound_send,
+    bound_owned,
     bound_const,
     bound_trait(t),
 }
@@ -797,7 +797,7 @@ impl param_bound : to_bytes::IterBytes {
         match *self {
           bound_copy => 0u8.iter_bytes(lsb0, f),
           bound_static => 1u8.iter_bytes(lsb0, f),
-          bound_send => 2u8.iter_bytes(lsb0, f),
+          bound_owned => 2u8.iter_bytes(lsb0, f),
           bound_const => 3u8.iter_bytes(lsb0, f),
           bound_trait(ref t) =>
           to_bytes::iter_bytes_2(&4u8, t, lsb0, f)
@@ -903,8 +903,8 @@ fn param_bounds_to_kind(bounds: param_bounds) -> Kind {
           bound_static => {
             kind = raise_kind(kind, kind_static());
           }
-          bound_send => {
-            kind = raise_kind(kind, kind_send_only() | kind_static());
+          bound_owned => {
+            kind = raise_kind(kind, kind_owned_only() | kind_static());
           }
           bound_const => {
             kind = raise_kind(kind, kind_const());
@@ -1581,7 +1581,7 @@ fn param_bound_to_str(cx: ctxt, pb: &param_bound) -> ~str {
     match *pb {
         bound_copy => ~"copy",
         bound_static => ~"static",
-        bound_send => ~"send",
+        bound_owned => ~"owned",
         bound_const => ~"const",
         bound_trait(t) => ty_to_str(cx, t)
     }
@@ -1939,8 +1939,8 @@ enum Kind { kind_(u32) }
 /// can be copied (implicitly or explicitly)
 const KIND_MASK_COPY         : u32 = 0b000000000000000000000000001_u32;
 
-/// can be sent: no shared box, borrowed ptr (must imply STATIC)
-const KIND_MASK_SEND         : u32 = 0b000000000000000000000000010_u32;
+/// cantains owned data, no shared box, borrowed ptr (must imply STATIC)
+const KIND_MASK_OWNED        : u32 = 0b000000000000000000000000010_u32;
 
 /// is static (no borrowed ptrs)
 const KIND_MASK_STATIC       : u32 = 0b000000000000000000000000100_u32;
@@ -1972,22 +1972,22 @@ fn kind_safe_for_default_mode() -> Kind {
 }
 
 fn kind_implicitly_sendable() -> Kind {
-    kind_(KIND_MASK_IMPLICIT | KIND_MASK_COPY | KIND_MASK_SEND)
+    kind_(KIND_MASK_IMPLICIT | KIND_MASK_COPY | KIND_MASK_OWNED)
 }
 
 fn kind_safe_for_default_mode_send() -> Kind {
     // similar to implicit copy, but always includes vectors and strings
     kind_(KIND_MASK_DEFAULT_MODE | KIND_MASK_IMPLICIT |
-          KIND_MASK_COPY | KIND_MASK_SEND)
+          KIND_MASK_COPY | KIND_MASK_OWNED)
 }
 
 
-fn kind_send_copy() -> Kind {
-    kind_(KIND_MASK_COPY | KIND_MASK_SEND)
+fn kind_owned_copy() -> Kind {
+    kind_(KIND_MASK_COPY | KIND_MASK_OWNED)
 }
 
-fn kind_send_only() -> Kind {
-    kind_(KIND_MASK_SEND)
+fn kind_owned_only() -> Kind {
+    kind_(KIND_MASK_OWNED)
 }
 
 fn kind_const() -> Kind {
@@ -2010,12 +2010,12 @@ fn remove_implicit(k: Kind) -> Kind {
     k - kind_(KIND_MASK_IMPLICIT | KIND_MASK_DEFAULT_MODE)
 }
 
-fn remove_send(k: Kind) -> Kind {
-    k - kind_(KIND_MASK_SEND)
+fn remove_owned(k: Kind) -> Kind {
+    k - kind_(KIND_MASK_OWNED)
 }
 
-fn remove_static_send(k: Kind) -> Kind {
-    k - kind_(KIND_MASK_STATIC) - kind_(KIND_MASK_SEND)
+fn remove_static_owned(k: Kind) -> Kind {
+    k - kind_(KIND_MASK_STATIC) - kind_(KIND_MASK_OWNED)
 }
 
 fn remove_copyable(k: Kind) -> Kind {
@@ -2062,7 +2062,7 @@ pure fn kind_can_be_copied(k: Kind) -> bool {
 }
 
 pure fn kind_can_be_sent(k: Kind) -> bool {
-    *k & KIND_MASK_SEND == KIND_MASK_SEND
+    *k & KIND_MASK_OWNED == KIND_MASK_OWNED
 }
 
 pure fn kind_is_static(k: Kind) -> bool {
@@ -2081,7 +2081,7 @@ fn meta_kind(p: FnMeta) -> Kind {
             kind_safe_for_default_mode() | kind_static()
         }
         ast::ProtoUniq => {
-            kind_send_copy() | kind_static()
+            kind_owned_copy() | kind_static()
         }
     }
 }
@@ -2102,17 +2102,17 @@ fn raise_kind(a: Kind, b: Kind) -> Kind {
 fn test_kinds() {
     // The kind "lattice" is defined by the subset operation on the
     // set of permitted operations.
-    assert kind_lteq(kind_send_copy(), kind_send_copy());
-    assert kind_lteq(kind_copyable(), kind_send_copy());
+    assert kind_lteq(kind_owned_copy(), kind_owned_copy());
+    assert kind_lteq(kind_copyable(), kind_owned_copy());
     assert kind_lteq(kind_copyable(), kind_copyable());
-    assert kind_lteq(kind_noncopyable(), kind_send_copy());
+    assert kind_lteq(kind_noncopyable(), kind_owned_copy());
     assert kind_lteq(kind_noncopyable(), kind_copyable());
     assert kind_lteq(kind_noncopyable(), kind_noncopyable());
     assert kind_lteq(kind_copyable(), kind_implicitly_copyable());
     assert kind_lteq(kind_copyable(), kind_implicitly_sendable());
-    assert kind_lteq(kind_send_copy(), kind_implicitly_sendable());
-    assert !kind_lteq(kind_send_copy(), kind_implicitly_copyable());
-    assert !kind_lteq(kind_copyable(), kind_send_only());
+    assert kind_lteq(kind_owned_copy(), kind_implicitly_sendable());
+    assert !kind_lteq(kind_owned_copy(), kind_implicitly_copyable());
+    assert !kind_lteq(kind_copyable(), kind_owned_only());
 }
 
 // Return the most permissive kind that a composite object containing a field
@@ -2152,7 +2152,7 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
         if cx.vecs_implicitly_copyable {
             kind_implicitly_sendable() | kind_const() | kind_static()
         } else {
-            kind_send_copy() | kind_const() | kind_static()
+            kind_owned_copy() | kind_const() | kind_static()
         }
       }
 
@@ -2162,7 +2162,7 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
       // Those with refcounts raise noncopyable to copyable,
       // lower sendable to copyable. Therefore just set result to copyable.
       ty_box(tm) => {
-        remove_send(mutable_type_kind(cx, tm) | kind_safe_for_default_mode())
+        remove_owned(mutable_type_kind(cx, tm) | kind_safe_for_default_mode())
       }
 
       // Trait instances are (for now) like shared boxes, basically
@@ -2192,13 +2192,13 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
       // contained type, but aren't implicitly copyable.  Fixed vectors have
       // the kind of the element they contain, taking mutability into account.
       ty_evec(tm, vstore_box) => {
-        remove_send(kind_safe_for_default_mode() | mutable_type_kind(cx, tm))
+        remove_owned(kind_safe_for_default_mode() | mutable_type_kind(cx, tm))
       }
       ty_evec(tm, vstore_slice(re_static)) => {
         kind_safe_for_default_mode() | mutable_type_kind(cx, tm)
       }
       ty_evec(tm, vstore_slice(_)) => {
-        remove_static_send(kind_safe_for_default_mode() |
+        remove_static_owned(kind_safe_for_default_mode() |
                            mutable_type_kind(cx, tm))
       }
       ty_evec(tm, vstore_fixed(_)) => {
@@ -2210,7 +2210,7 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
         kind_safe_for_default_mode() | kind_const() | kind_static()
       }
       ty_estr(vstore_slice(re_static)) => {
-        kind_safe_for_default_mode() | kind_send_copy() | kind_const()
+        kind_safe_for_default_mode() | kind_owned_copy() | kind_const()
       }
       ty_estr(vstore_slice(_)) => {
         kind_safe_for_default_mode() | kind_const()
@@ -2257,7 +2257,7 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
         let mut lowest = kind_top();
         let variants = enum_variants(cx, did);
         if vec::len(*variants) == 0u {
-            lowest = kind_send_only() | kind_static();
+            lowest = kind_owned_only() | kind_static();
         } else {
             for vec::each(*variants) |variant| {
                 for variant.args.each |aty| {
@@ -4267,7 +4267,7 @@ fn iter_bound_traits_and_supertraits(tcx: ctxt,
         let bound_trait_ty = match *bound {
             ty::bound_trait(bound_t) => bound_t,
 
-            ty::bound_copy | ty::bound_send |
+            ty::bound_copy | ty::bound_owned |
             ty::bound_const | ty::bound_static => {
                 loop; // skip non-trait bounds
             }
@@ -4684,9 +4684,9 @@ impl param_bound : cmp::Eq {
                     _ => false
                 }
             }
-            bound_send => {
+            bound_owned => {
                 match (*other) {
-                    bound_send => true,
+                    bound_owned => true,
                     _ => false
                 }
             }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -140,7 +140,7 @@ export kind_noncopyable, kind_const;
 export kind_can_be_copied, kind_can_be_sent, kind_can_be_implicitly_copied;
 export type_implicitly_moves;
 export kind_is_safe_for_default_mode;
-export kind_is_owned;
+export kind_is_static;
 export meta_kind, kind_lteq, type_kind;
 export operators;
 export type_err, terr_vstore_kind;
@@ -176,7 +176,7 @@ export VariantInfo, VariantInfo_;
 export walk_ty, maybe_walk_ty;
 export occurs_check;
 export param_ty;
-export param_bound, param_bounds, bound_copy, bound_owned;
+export param_bound, param_bounds, bound_copy, bound_static;
 export param_bounds_to_str, param_bound_to_str;
 export bound_send, bound_trait;
 export param_bounds_to_kind;
@@ -729,7 +729,7 @@ enum type_err {
 
 enum param_bound {
     bound_copy,
-    bound_owned,
+    bound_static,
     bound_send,
     bound_const,
     bound_trait(t),
@@ -796,7 +796,7 @@ impl param_bound : to_bytes::IterBytes {
     pure fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
         match *self {
           bound_copy => 0u8.iter_bytes(lsb0, f),
-          bound_owned => 1u8.iter_bytes(lsb0, f),
+          bound_static => 1u8.iter_bytes(lsb0, f),
           bound_send => 2u8.iter_bytes(lsb0, f),
           bound_const => 3u8.iter_bytes(lsb0, f),
           bound_trait(ref t) =>
@@ -900,11 +900,11 @@ fn param_bounds_to_kind(bounds: param_bounds) -> Kind {
           bound_copy => {
             kind = raise_kind(kind, kind_implicitly_copyable());
           }
-          bound_owned => {
-            kind = raise_kind(kind, kind_owned());
+          bound_static => {
+            kind = raise_kind(kind, kind_static());
           }
           bound_send => {
-            kind = raise_kind(kind, kind_send_only() | kind_owned());
+            kind = raise_kind(kind, kind_send_only() | kind_static());
           }
           bound_const => {
             kind = raise_kind(kind, kind_const());
@@ -1580,7 +1580,7 @@ fn substs_to_str(cx: ctxt, substs: &substs) -> ~str {
 fn param_bound_to_str(cx: ctxt, pb: &param_bound) -> ~str {
     match *pb {
         bound_copy => ~"copy",
-        bound_owned => ~"owned",
+        bound_static => ~"static",
         bound_send => ~"send",
         bound_const => ~"const",
         bound_trait(t) => ty_to_str(cx, t)
@@ -1939,11 +1939,11 @@ enum Kind { kind_(u32) }
 /// can be copied (implicitly or explicitly)
 const KIND_MASK_COPY         : u32 = 0b000000000000000000000000001_u32;
 
-/// can be sent: no shared box, borrowed ptr (must imply OWNED)
+/// can be sent: no shared box, borrowed ptr (must imply STATIC)
 const KIND_MASK_SEND         : u32 = 0b000000000000000000000000010_u32;
 
-/// is owned (no borrowed ptrs)
-const KIND_MASK_OWNED        : u32 = 0b000000000000000000000000100_u32;
+/// is static (no borrowed ptrs)
+const KIND_MASK_STATIC       : u32 = 0b000000000000000000000000100_u32;
 
 /// is deeply immutable
 const KIND_MASK_CONST        : u32 = 0b000000000000000000000001000_u32;
@@ -1994,8 +1994,8 @@ fn kind_const() -> Kind {
     kind_(KIND_MASK_CONST)
 }
 
-fn kind_owned() -> Kind {
-    kind_(KIND_MASK_OWNED)
+fn kind_static() -> Kind {
+    kind_(KIND_MASK_STATIC)
 }
 
 fn kind_top() -> Kind {
@@ -2014,8 +2014,8 @@ fn remove_send(k: Kind) -> Kind {
     k - kind_(KIND_MASK_SEND)
 }
 
-fn remove_owned_send(k: Kind) -> Kind {
-    k - kind_(KIND_MASK_OWNED) - kind_(KIND_MASK_SEND)
+fn remove_static_send(k: Kind) -> Kind {
+    k - kind_(KIND_MASK_STATIC) - kind_(KIND_MASK_SEND)
 }
 
 fn remove_copyable(k: Kind) -> Kind {
@@ -2065,23 +2065,23 @@ pure fn kind_can_be_sent(k: Kind) -> bool {
     *k & KIND_MASK_SEND == KIND_MASK_SEND
 }
 
-pure fn kind_is_owned(k: Kind) -> bool {
-    *k & KIND_MASK_OWNED == KIND_MASK_OWNED
+pure fn kind_is_static(k: Kind) -> bool {
+    *k & KIND_MASK_STATIC == KIND_MASK_STATIC
 }
 
 fn meta_kind(p: FnMeta) -> Kind {
     match p.proto { // XXX consider the kind bounds!
         ast::ProtoBare => {
-            kind_safe_for_default_mode_send() | kind_const() | kind_owned()
+            kind_safe_for_default_mode_send() | kind_const() | kind_static()
         }
         ast::ProtoBorrowed => {
             kind_noncopyable() | kind_(KIND_MASK_DEFAULT_MODE)
         }
         ast::ProtoBox => {
-            kind_safe_for_default_mode() | kind_owned()
+            kind_safe_for_default_mode() | kind_static()
         }
         ast::ProtoUniq => {
-            kind_send_copy() | kind_owned()
+            kind_send_copy() | kind_static()
         }
     }
 }
@@ -2144,15 +2144,15 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
       // Scalar and unique types are sendable, constant, and owned
       ty_nil | ty_bot | ty_bool | ty_int(_) | ty_uint(_) | ty_float(_) |
       ty_ptr(_) => {
-        kind_safe_for_default_mode_send() | kind_const() | kind_owned()
+        kind_safe_for_default_mode_send() | kind_const() | kind_static()
       }
 
       // Implicit copyability of strs is configurable
       ty_estr(vstore_uniq) => {
         if cx.vecs_implicitly_copyable {
-            kind_implicitly_sendable() | kind_const() | kind_owned()
+            kind_implicitly_sendable() | kind_const() | kind_static()
         } else {
-            kind_send_copy() | kind_const() | kind_owned()
+            kind_send_copy() | kind_const() | kind_static()
         }
       }
 
@@ -2166,7 +2166,7 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
       }
 
       // Trait instances are (for now) like shared boxes, basically
-      ty_trait(_, _, _) => kind_safe_for_default_mode() | kind_owned(),
+      ty_trait(_, _, _) => kind_safe_for_default_mode() | kind_static(),
 
       // Static region pointers are copyable and sendable, but not owned
       ty_rptr(re_static, mt) =>
@@ -2198,8 +2198,8 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
         kind_safe_for_default_mode() | mutable_type_kind(cx, tm)
       }
       ty_evec(tm, vstore_slice(_)) => {
-        remove_owned_send(kind_safe_for_default_mode() |
-                          mutable_type_kind(cx, tm))
+        remove_static_send(kind_safe_for_default_mode() |
+                           mutable_type_kind(cx, tm))
       }
       ty_evec(tm, vstore_fixed(_)) => {
         mutable_type_kind(cx, tm)
@@ -2207,7 +2207,7 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
 
       // All estrs are copyable; uniques and interiors are sendable.
       ty_estr(vstore_box) => {
-        kind_safe_for_default_mode() | kind_const() | kind_owned()
+        kind_safe_for_default_mode() | kind_const() | kind_static()
       }
       ty_estr(vstore_slice(re_static)) => {
         kind_safe_for_default_mode() | kind_send_copy() | kind_const()
@@ -2216,7 +2216,7 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
         kind_safe_for_default_mode() | kind_const()
       }
       ty_estr(vstore_fixed(_)) => {
-        kind_safe_for_default_mode_send() | kind_const() | kind_owned()
+        kind_safe_for_default_mode_send() | kind_const() | kind_static()
       }
 
       // Records lower to the lowest of their members.
@@ -2257,7 +2257,7 @@ fn type_kind(cx: ctxt, ty: t) -> Kind {
         let mut lowest = kind_top();
         let variants = enum_variants(cx, did);
         if vec::len(*variants) == 0u {
-            lowest = kind_send_only() | kind_owned();
+            lowest = kind_send_only() | kind_static();
         } else {
             for vec::each(*variants) |variant| {
                 for variant.args.each |aty| {
@@ -4268,7 +4268,7 @@ fn iter_bound_traits_and_supertraits(tcx: ctxt,
             ty::bound_trait(bound_t) => bound_t,
 
             ty::bound_copy | ty::bound_send |
-            ty::bound_const | ty::bound_owned => {
+            ty::bound_const | ty::bound_static => {
                 loop; // skip non-trait bounds
             }
         };
@@ -4678,9 +4678,9 @@ impl param_bound : cmp::Eq {
                     _ => false
                 }
             }
-            bound_owned => {
+            bound_static => {
                 match (*other) {
-                    bound_owned => true,
+                    bound_static => true,
                     _ => false
                 }
             }

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -79,7 +79,7 @@ fn get_region_reporting_err(tcx: ty::ctxt,
     }
 }
 
-fn ast_region_to_region<AC: ast_conv, RS: region_scope Copy Owned>(
+fn ast_region_to_region<AC: ast_conv, RS: region_scope Copy Static>(
     self: AC, rscope: RS, span: span, a_r: @ast::region) -> ty::Region {
 
     let res = match a_r.node {
@@ -92,7 +92,7 @@ fn ast_region_to_region<AC: ast_conv, RS: region_scope Copy Owned>(
     get_region_reporting_err(self.tcx(), span, res)
 }
 
-fn ast_path_to_substs_and_ty<AC: ast_conv, RS: region_scope Copy Owned>(
+fn ast_path_to_substs_and_ty<AC: ast_conv, RS: region_scope Copy Static>(
     self: AC, rscope: RS, did: ast::def_id,
     path: @ast::path) -> ty_param_substs_and_ty {
 
@@ -141,7 +141,7 @@ fn ast_path_to_substs_and_ty<AC: ast_conv, RS: region_scope Copy Owned>(
     {substs: substs, ty: ty::subst(tcx, &substs, decl_ty)}
 }
 
-fn ast_path_to_ty<AC: ast_conv, RS: region_scope Copy Owned>(
+fn ast_path_to_ty<AC: ast_conv, RS: region_scope Copy Static>(
     self: AC,
     rscope: RS,
     did: ast::def_id,
@@ -164,10 +164,10 @@ const NO_TPS: uint = 2;
 // Parses the programmer's textual representation of a type into our
 // internal notion of a type. `getter` is a function that returns the type
 // corresponding to a definition ID:
-fn ast_ty_to_ty<AC: ast_conv, RS: region_scope Copy Owned>(
+fn ast_ty_to_ty<AC: ast_conv, RS: region_scope Copy Static>(
     self: AC, rscope: RS, &&ast_ty: @ast::Ty) -> ty::t {
 
-    fn ast_mt_to_mt<AC: ast_conv, RS: region_scope Copy Owned>(
+    fn ast_mt_to_mt<AC: ast_conv, RS: region_scope Copy Static>(
         self: AC, rscope: RS, mt: ast::mt) -> ty::mt {
 
         return {ty: ast_ty_to_ty(self, rscope, mt.ty), mutbl: mt.mutbl};
@@ -176,7 +176,7 @@ fn ast_ty_to_ty<AC: ast_conv, RS: region_scope Copy Owned>(
     // Handle @, ~, and & being able to mean estrs and evecs.
     // If a_seq_ty is a str or a vec, make it an estr/evec.
     // Also handle function sigils and first-class trait types.
-    fn mk_pointer<AC: ast_conv, RS: region_scope Copy Owned>(
+    fn mk_pointer<AC: ast_conv, RS: region_scope Copy Static>(
         self: AC,
         rscope: RS,
         a_seq_ty: ast::mt,
@@ -389,7 +389,7 @@ fn ast_ty_to_ty<AC: ast_conv, RS: region_scope Copy Owned>(
     return typ;
 }
 
-fn ty_of_arg<AC: ast_conv, RS: region_scope Copy Owned>(
+fn ty_of_arg<AC: ast_conv, RS: region_scope Copy Static>(
     self: AC, rscope: RS, a: ast::arg,
     expected_ty: Option<ty::arg>) -> ty::arg {
 
@@ -438,7 +438,7 @@ fn ty_of_arg<AC: ast_conv, RS: region_scope Copy Owned>(
 type expected_tys = Option<{inputs: ~[ty::arg],
                             output: ty::t}>;
 
-fn ty_of_fn_decl<AC: ast_conv, RS: region_scope Copy Owned>(
+fn ty_of_fn_decl<AC: ast_conv, RS: region_scope Copy Static>(
     self: AC, rscope: RS,
     ast_proto: ast::Proto,
     purity: ast::purity,

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -339,7 +339,7 @@ impl LookupContext {
             let bound_trait_ty = match *bound {
                 ty::bound_trait(bound_t) => bound_t,
 
-                ty::bound_copy | ty::bound_send |
+                ty::bound_copy | ty::bound_owned |
                 ty::bound_const | ty::bound_static => {
                     loop; // skip non-trait bounds
                 }

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -340,7 +340,7 @@ impl LookupContext {
                 ty::bound_trait(bound_t) => bound_t,
 
                 ty::bound_copy | ty::bound_send |
-                ty::bound_const | ty::bound_owned => {
+                ty::bound_const | ty::bound_static => {
                     loop; // skip non-trait bounds
                 }
             };

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -34,7 +34,6 @@ use infer::{resolve_and_force_all_but_regions, fres};
 use syntax::ast::{def_arg, def_binding, def_local, def_self, def_upvar};
 use syntax::ast::{ProtoBare, ProtoBox, ProtoUniq, ProtoBorrowed};
 use middle::freevars::get_freevars;
-use middle::kind::check_owned;
 use middle::pat_util::pat_bindings;
 use middle::ty::{encl_region, re_scope};
 use middle::ty::{ty_fn_proto, vstore_box, vstore_fixed, vstore_slice};

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -868,8 +868,8 @@ fn compute_bounds(ccx: @crate_ctxt,
         match ty::get(ity).sty {
             ty::ty_trait(did, _, _) => {
                 let d = Some(did);
-                if d == li.send_trait {
-                    ~[ty::bound_send]
+                if d == li.owned_trait {
+                    ~[ty::bound_owned]
                 }
                 else if d == li.copy_trait {
                     ~[ty::bound_copy]

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -86,7 +86,7 @@ fn collect_item_types(ccx: @crate_ctxt, crate: @ast::crate) {
 }
 
 impl @crate_ctxt {
-    fn to_ty<RS: region_scope Copy Owned>(
+    fn to_ty<RS: region_scope Copy Static>(
         rs: RS, ast_ty: @ast::Ty) -> ty::t {
 
         ast_ty_to_ty(self, rs, ast_ty)
@@ -859,7 +859,7 @@ fn ty_of_foreign_item(ccx: @crate_ctxt, it: @ast::foreign_item)
 // Translate the AST's notion of ty param bounds (which are just newtyped Tys)
 // to ty's notion of ty param bounds, which can either be user-defined traits,
 // or one of the four built-in traits (formerly known as kinds): Const, Copy,
-// Owned, and Send.
+// Static, and Send.
 fn compute_bounds(ccx: @crate_ctxt,
                   ast_bounds: @~[ast::ty_param_bound]) -> ty::param_bounds {
     @do vec::flat_map(*ast_bounds) |b| {
@@ -877,8 +877,8 @@ fn compute_bounds(ccx: @crate_ctxt,
                 else if d == li.const_trait {
                     ~[ty::bound_const]
                 }
-                else if d == li.owned_trait {
-                    ~[ty::bound_owned]
+                else if d == li.static_trait {
+                    ~[ty::bound_static]
                 }
                 else {
                     // Must be a user-defined trait

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -60,7 +60,7 @@ fn bound_self_region(rp: Option<ty::region_variance>) -> Option<ty::Region> {
 }
 
 enum anon_rscope = {anon: ty::Region, base: region_scope};
-fn in_anon_rscope<RS: region_scope Copy Owned>(self: RS, r: ty::Region)
+fn in_anon_rscope<RS: region_scope Copy Static>(self: RS, r: ty::Region)
     -> @anon_rscope {
     @anon_rscope({anon: r, base: self as region_scope})
 }
@@ -80,7 +80,7 @@ struct binding_rscope {
     base: region_scope,
     mut anon_bindings: uint,
 }
-fn in_binding_rscope<RS: region_scope Copy Owned>(self: RS)
+fn in_binding_rscope<RS: region_scope Copy Static>(self: RS)
     -> @binding_rscope {
     let base = self as region_scope;
     @binding_rscope { base: base, anon_bindings: 0 }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -11,7 +11,7 @@
 use std::map::HashMap;
 use middle::ty;
 use middle::ty::{arg, canon_mode};
-use middle::ty::{bound_copy, bound_const, bound_owned, bound_send,
+use middle::ty::{bound_copy, bound_const, bound_static, bound_send,
         bound_trait};
 use middle::ty::{bound_region, br_anon, br_named, br_self, br_cap_avoid};
 use middle::ty::{ctxt, field, method};

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -11,7 +11,7 @@
 use std::map::HashMap;
 use middle::ty;
 use middle::ty::{arg, canon_mode};
-use middle::ty::{bound_copy, bound_const, bound_static, bound_send,
+use middle::ty::{bound_copy, bound_const, bound_static, bound_owned,
         bound_trait};
 use middle::ty::{bound_region, br_anon, br_named, br_self, br_cap_avoid};
 use middle::ty::{ctxt, field, method};

--- a/src/librustdoc/astsrv.rs
+++ b/src/librustdoc/astsrv.rs
@@ -95,7 +95,7 @@ fn act(po: comm::Port<Msg>, source: ~str, parse: Parser) {
     }
 }
 
-pub fn exec<T:Send>(
+pub fn exec<T:Owned>(
     srv: Srv,
     +f: fn~(ctxt: Ctxt) -> T
 ) -> T {

--- a/src/librustdoc/attr_pass.rs
+++ b/src/librustdoc/attr_pass.rs
@@ -98,7 +98,7 @@ fn fold_item(
     }
 }
 
-fn parse_item_attrs<T:Send>(
+fn parse_item_attrs<T:Owned>(
     srv: astsrv::Srv,
     id: doc::AstId,
     +parse_attrs: fn~(+a: ~[ast::attribute]) -> T) -> T {

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -92,7 +92,7 @@ fn mk_fold<T:Clone>(
     }
 }
 
-pub fn default_any_fold<T:Send Clone>(+ctxt: T) -> Fold<T> {
+pub fn default_any_fold<T:Owned Clone>(+ctxt: T) -> Fold<T> {
     mk_fold(
         move ctxt,
         |f, d| default_seq_fold_doc(f, d),
@@ -128,7 +128,7 @@ pub fn default_seq_fold<T:Clone>(+ctxt: T) -> Fold<T> {
     )
 }
 
-pub fn default_par_fold<T:Send Clone>(+ctxt: T) -> Fold<T> {
+pub fn default_par_fold<T:Owned Clone>(+ctxt: T) -> Fold<T> {
     mk_fold(
         move ctxt,
         |f, d| default_seq_fold_doc(f, d),
@@ -178,7 +178,7 @@ pub fn default_seq_fold_item<T>(
     doc
 }
 
-pub fn default_any_fold_mod<T:Send Clone>(
+pub fn default_any_fold_mod<T:Owned Clone>(
     fold: &Fold<T>,
     +doc: doc::ModDoc
 ) -> doc::ModDoc {
@@ -205,7 +205,7 @@ pub fn default_seq_fold_mod<T>(
     })
 }
 
-pub fn default_par_fold_mod<T:Send Clone>(
+pub fn default_par_fold_mod<T:Owned Clone>(
     fold: &Fold<T>,
     +doc: doc::ModDoc
 ) -> doc::ModDoc {
@@ -219,7 +219,7 @@ pub fn default_par_fold_mod<T:Send Clone>(
     })
 }
 
-pub fn default_any_fold_nmod<T:Send Clone>(
+pub fn default_any_fold_nmod<T:Owned Clone>(
     fold: &Fold<T>,
     +doc: doc::NmodDoc
 ) -> doc::NmodDoc {
@@ -246,7 +246,7 @@ pub fn default_seq_fold_nmod<T>(
     }
 }
 
-pub fn default_par_fold_nmod<T:Send Clone>(
+pub fn default_par_fold_nmod<T:Owned Clone>(
     fold: &Fold<T>,
     +doc: doc::NmodDoc
 ) -> doc::NmodDoc {

--- a/src/libstd/comm.rs
+++ b/src/libstd/comm.rs
@@ -21,24 +21,24 @@ use pipes::{GenericChan, GenericSmartChan, GenericPort,
             Chan, Port, Selectable, Peekable};
 
 /// An extension of `pipes::stream` that allows both sending and receiving.
-pub struct DuplexStream<T: Send, U: Send> {
+pub struct DuplexStream<T: Owned, U: Owned> {
     priv chan: Chan<T>,
     priv port: Port<U>,
 }
 
-impl<T: Send, U: Send> DuplexStream<T, U> : GenericChan<T> {
+impl<T: Owned, U: Owned> DuplexStream<T, U> : GenericChan<T> {
     fn send(x: T) {
         self.chan.send(move x)
     }
 }
 
-impl<T: Send, U: Send> DuplexStream<T, U> : GenericSmartChan<T> {
+impl<T: Owned, U: Owned> DuplexStream<T, U> : GenericSmartChan<T> {
     fn try_send(x: T) -> bool {
         self.chan.try_send(move x)
     }
 }
 
-impl<T: Send, U: Send> DuplexStream<T, U> : GenericPort<U> {
+impl<T: Owned, U: Owned> DuplexStream<T, U> : GenericPort<U> {
     fn recv() -> U {
         self.port.recv()
     }
@@ -48,20 +48,20 @@ impl<T: Send, U: Send> DuplexStream<T, U> : GenericPort<U> {
     }
 }
 
-impl<T: Send, U: Send> DuplexStream<T, U> : Peekable<U> {
+impl<T: Owned, U: Owned> DuplexStream<T, U> : Peekable<U> {
     pure fn peek() -> bool {
         self.port.peek()
     }
 }
 
-impl<T: Send, U: Send> DuplexStream<T, U> : Selectable {
+impl<T: Owned, U: Owned> DuplexStream<T, U> : Selectable {
     pure fn header() -> *pipes::PacketHeader {
         self.port.header()
     }
 }
 
 /// Creates a bidirectional stream.
-pub fn DuplexStream<T: Send, U: Send>()
+pub fn DuplexStream<T: Owned, U: Owned>()
     -> (DuplexStream<T, U>, DuplexStream<U, T>)
 {
     let (c2, p1) = pipes::stream();

--- a/src/libstd/deque.rs
+++ b/src/libstd/deque.rs
@@ -210,7 +210,7 @@ mod tests {
         assert (deq.get(3) == d);
     }
 
-    fn test_parameterized<T: Copy Eq Owned>(a: T, b: T, c: T, d: T) {
+    fn test_parameterized<T: Copy Eq Static>(a: T, b: T, c: T, d: T) {
         let deq: deque::Deque<T> = deque::create::<T>();
         assert (deq.size() == 0u);
         deq.add_front(a);

--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -79,7 +79,7 @@ pub fn from_value<A>(val: A) -> Future<A> {
     Future {state: Forced(~(move val))}
 }
 
-pub fn from_port<A:Send>(port: PortOne<A>) ->
+pub fn from_port<A:Owned>(port: PortOne<A>) ->
         Future<A> {
     /*!
      * Create a future from a port
@@ -111,7 +111,7 @@ pub fn from_fn<A>(f: ~fn() -> A) -> Future<A> {
     Future {state: Pending(move f)}
 }
 
-pub fn spawn<A:Send>(blk: fn~() -> A) -> Future<A> {
+pub fn spawn<A:Owned>(blk: fn~() -> A) -> Future<A> {
     /*!
      * Create a future from a unique closure.
      *

--- a/src/libstd/par.rs
+++ b/src/libstd/par.rs
@@ -29,7 +29,7 @@ const min_granularity : uint = 1024u;
  * This is used to build most of the other parallel vector functions,
  * like map or alli.
  */
-fn map_slices<A: Copy Send, B: Copy Send>(
+fn map_slices<A: Copy Owned, B: Copy Owned>(
     xs: &[A],
     f: fn() -> fn~(uint, v: &[A]) -> B)
     -> ~[B] {
@@ -84,7 +84,8 @@ fn map_slices<A: Copy Send, B: Copy Send>(
 }
 
 /// A parallel version of map.
-pub fn map<A: Copy Send, B: Copy Send>(xs: &[A], f: fn~((&A)) -> B) -> ~[B] {
+pub fn map<A: Copy Owned, B: Copy Owned>(
+    xs: &[A], f: fn~((&A)) -> B) -> ~[B] {
     vec::concat(map_slices(xs, || {
         fn~(_base: uint, slice : &[A], copy f) -> ~[B] {
             vec::map(slice, |x| f(x))
@@ -93,7 +94,7 @@ pub fn map<A: Copy Send, B: Copy Send>(xs: &[A], f: fn~((&A)) -> B) -> ~[B] {
 }
 
 /// A parallel version of mapi.
-pub fn mapi<A: Copy Send, B: Copy Send>(xs: &[A],
+pub fn mapi<A: Copy Owned, B: Copy Owned>(xs: &[A],
                                     f: fn~(uint, (&A)) -> B) -> ~[B] {
     let slices = map_slices(xs, || {
         fn~(base: uint, slice : &[A], copy f) -> ~[B] {
@@ -114,7 +115,7 @@ pub fn mapi<A: Copy Send, B: Copy Send>(xs: &[A],
  * In this case, f is a function that creates functions to run over the
  * inner elements. This is to skirt the need for copy constructors.
  */
-pub fn mapi_factory<A: Copy Send, B: Copy Send>(
+pub fn mapi_factory<A: Copy Owned, B: Copy Owned>(
     xs: &[A], f: fn() -> fn~(uint, A) -> B) -> ~[B] {
     let slices = map_slices(xs, || {
         let f = f();
@@ -131,7 +132,7 @@ pub fn mapi_factory<A: Copy Send, B: Copy Send>(
 }
 
 /// Returns true if the function holds for all elements in the vector.
-pub fn alli<A: Copy Send>(xs: &[A], f: fn~(uint, (&A)) -> bool) -> bool {
+pub fn alli<A: Copy Owned>(xs: &[A], f: fn~(uint, (&A)) -> bool) -> bool {
     do vec::all(map_slices(xs, || {
         fn~(base: uint, slice : &[A], copy f) -> bool {
             vec::alli(slice, |i, x| {
@@ -142,7 +143,7 @@ pub fn alli<A: Copy Send>(xs: &[A], f: fn~(uint, (&A)) -> bool) -> bool {
 }
 
 /// Returns true if the function holds for any elements in the vector.
-pub fn any<A: Copy Send>(xs: &[A], f: fn~(&(A)) -> bool) -> bool {
+pub fn any<A: Copy Owned>(xs: &[A], f: fn~(&(A)) -> bool) -> bool {
     do vec::any(map_slices(xs, || {
         fn~(_base : uint, slice: &[A], copy f) -> bool {
             vec::any(slice, |x| f(x))

--- a/src/libstd/sync.rs
+++ b/src/libstd/sync.rs
@@ -76,10 +76,10 @@ struct SemInner<Q> {
     blocked:   Q
 }
 #[doc(hidden)]
-enum Sem<Q: Send> = Exclusive<SemInner<Q>>;
+enum Sem<Q: Owned> = Exclusive<SemInner<Q>>;
 
 #[doc(hidden)]
-fn new_sem<Q: Send>(count: int, q: Q) -> Sem<Q> {
+fn new_sem<Q: Owned>(count: int, q: Q) -> Sem<Q> {
     Sem(exclusive(SemInner {
         mut count: count, waiters: new_waitqueue(), blocked: move q }))
 }
@@ -94,7 +94,7 @@ fn new_sem_and_signal(count: int, num_condvars: uint)
 }
 
 #[doc(hidden)]
-impl<Q: Send> &Sem<Q> {
+impl<Q: Owned> &Sem<Q> {
     fn acquire() {
         let mut waiter_nobe = None;
         unsafe {
@@ -160,9 +160,9 @@ impl &Sem<~[mut Waitqueue]> {
 #[doc(hidden)]
 type SemRelease = SemReleaseGeneric<()>;
 type SemAndSignalRelease = SemReleaseGeneric<~[mut Waitqueue]>;
-struct SemReleaseGeneric<Q: Send> { sem: &Sem<Q> }
+struct SemReleaseGeneric<Q: Owned> { sem: &Sem<Q> }
 
-impl<Q: Send> SemReleaseGeneric<Q> : Drop {
+impl<Q: Owned> SemReleaseGeneric<Q> : Drop {
     fn finalize(&self) {
         self.sem.release();
     }

--- a/src/libstd/timer.rs
+++ b/src/libstd/timer.rs
@@ -33,7 +33,7 @@ use comm = core::comm;
  * * ch - a channel of type T to send a `val` on
  * * val - a value of type T to send over the provided `ch`
  */
-pub fn delayed_send<T: Send>(iotask: IoTask,
+pub fn delayed_send<T: Owned>(iotask: IoTask,
                                   msecs: uint, ch: comm::Chan<T>, val: T) {
         unsafe {
             let timer_done_po = core::comm::Port::<()>();
@@ -109,7 +109,7 @@ pub fn sleep(iotask: IoTask, msecs: uint) {
  * on the provided port in the allotted timeout period, then the result will
  * be a `some(T)`. If not, then `none` will be returned.
  */
-pub fn recv_timeout<T: Copy Send>(iotask: IoTask,
+pub fn recv_timeout<T: Copy Owned>(iotask: IoTask,
                               msecs: uint,
                               wait_po: comm::Port<T>) -> Option<T> {
     let timeout_po = comm::Port::<()>();

--- a/src/libstd/workcache.rs
+++ b/src/libstd/workcache.rs
@@ -157,7 +157,7 @@ struct Exec {
     discovered_outputs: WorkMap
 }
 
-struct Work<T:Send> {
+struct Work<T:Owned> {
     prep: @mut Prep,
     res: Option<Either<T,PortOne<(Exec,T)>>>
 }
@@ -188,7 +188,7 @@ impl Context {
         Context {db: db, logger: lg, cfg: cfg, freshness: LinearMap()}
     }
 
-    fn prep<T:Send
+    fn prep<T:Owned
               Serializable<json::Serializer>
               Deserializable<json::Deserializer>>(
                   @self,
@@ -213,7 +213,7 @@ impl Prep {
                                      val.to_owned());
     }
 
-    fn exec<T:Send
+    fn exec<T:Owned
               Serializable<json::Serializer>
               Deserializable<json::Deserializer>>(
                   @mut self, blk: ~fn(&Exec) -> T) -> Work<T> {
@@ -250,7 +250,7 @@ impl Prep {
     }
 }
 
-impl<T:Send
+impl<T:Owned
        Serializable<json::Serializer>
        Deserializable<json::Deserializer>>
     Work<T> {
@@ -260,7 +260,7 @@ impl<T:Send
 }
 
 // FIXME (#3724): movable self. This should be in impl Work.
-fn unwrap<T:Send
+fn unwrap<T:Owned
             Serializable<json::Serializer>
             Deserializable<json::Deserializer>>(w: Work<T>) -> T {
 

--- a/src/test/auxiliary/cci_capture_clause.rs
+++ b/src/test/auxiliary/cci_capture_clause.rs
@@ -14,7 +14,7 @@ export foo;
 
 use comm::*;
 
-fn foo<T: Send Copy>(x: T) -> Port<T> {
+fn foo<T: Owned Copy>(x: T) -> Port<T> {
     let p = Port();
     let c = Chan(&p);
     do task::spawn() |copy c, copy x| {

--- a/src/test/auxiliary/test_comm.rs
+++ b/src/test/auxiliary/test_comm.rs
@@ -28,20 +28,20 @@ export recv;
  * transmitted. If a port value is copied, both copies refer to the same
  * port.  Ports may be associated with multiple `chan`s.
  */
-enum port<T: Send> {
+enum port<T: Owned> {
     port_t(@port_ptr<T>)
 }
 
 /// Constructs a port
-fn port<T: Send>() -> port<T> {
+fn port<T: Owned>() -> port<T> {
     port_t(@port_ptr(rustrt::new_port(sys::size_of::<T>() as size_t)))
 }
 
-struct port_ptr<T:Send> {
+struct port_ptr<T:Owned> {
    po: *rust_port,
 }
 
-impl<T:Send> port_ptr<T> : Drop {
+impl<T:Owned> port_ptr<T> : Drop {
     fn finalize(&self) {
         unsafe {
             debug!("in the port_ptr destructor");
@@ -63,7 +63,7 @@ impl<T:Send> port_ptr<T> : Drop {
     }
 }
 
-fn port_ptr<T: Send>(po: *rust_port) -> port_ptr<T> {
+fn port_ptr<T: Owned>(po: *rust_port) -> port_ptr<T> {
     debug!("in the port_ptr constructor");
     port_ptr {
         po: po
@@ -74,11 +74,11 @@ fn port_ptr<T: Send>(po: *rust_port) -> port_ptr<T> {
  * Receive from a port.  If no data is available on the port then the
  * task will block until data becomes available.
  */
-fn recv<T: Send>(p: port<T>) -> T { recv_((**p).po) }
+fn recv<T: Owned>(p: port<T>) -> T { recv_((**p).po) }
 
 
 /// Receive on a raw port pointer
-fn recv_<T: Send>(p: *rust_port) -> T {
+fn recv_<T: Owned>(p: *rust_port) -> T {
     let yield = 0;
     let yieldp = ptr::addr_of(&yield);
     let mut res;

--- a/src/test/bench/pingpong.rs
+++ b/src/test/bench/pingpong.rs
@@ -68,7 +68,7 @@ macro_rules! follow (
     )
 )
 
-fn switch<T: Send, Tb: Send, U>(+endp: pipes::RecvPacketBuffered<T, Tb>,
+fn switch<T: Owned, Tb: Owned, U>(+endp: pipes::RecvPacketBuffered<T, Tb>,
                       f: fn(+v: Option<T>) -> U) -> U {
     f(pipes::try_recv(move endp))
 }

--- a/src/test/compile-fail/issue-2548.rs
+++ b/src/test/compile-fail/issue-2548.rs
@@ -34,7 +34,7 @@ fn main() {
         let mut res = foo(x);
         
         let mut v = ~[mut];
-        v = move ~[mut (move res)] + v; //~ ERROR instantiating a type parameter with an incompatible type (needs `copy`, got `owned`, missing `copy`)
+        v = move ~[mut (move res)] + v; //~ ERROR instantiating a type parameter with an incompatible type (needs `copy`, got `static`, missing `copy`)
         assert (v.len() == 2);
     }
 

--- a/src/test/compile-fail/issue-2766-a.rs
+++ b/src/test/compile-fail/issue-2766-a.rs
@@ -10,10 +10,10 @@
 
 mod stream {
     #[legacy_exports];
-    enum Stream<T: Send> { send(T, server::Stream<T>), }
+    enum Stream<T: Owned> { send(T, server::Stream<T>), }
     mod server {
         #[legacy_exports];
-        impl<T: Send> Stream<T> {
+        impl<T: Owned> Stream<T> {
             fn recv() -> extern fn(+v: Stream<T>) -> stream::Stream<T> {
               // resolve really should report just one error here.
               // Change the test case when it changes.
@@ -26,7 +26,7 @@ mod stream {
                 recv
             }
         }
-        type Stream<T: Send> = pipes::RecvPacket<stream::Stream<T>>;
+        type Stream<T: Owned> = pipes::RecvPacket<stream::Stream<T>>;
     }
 }
 

--- a/src/test/compile-fail/kindck-owned-trait-scoped.rs
+++ b/src/test/compile-fail/kindck-owned-trait-scoped.rs
@@ -32,10 +32,10 @@ fn to_foo<T:Copy>(t: T) {
 fn to_foo_2<T:Copy>(t: T) -> foo {
     // Not OK---T may contain borrowed ptrs and it is going to escape
     // as part of the returned foo value
-    {f:t} as foo //~ ERROR value may contain borrowed pointers; use `owned` bound
+    {f:t} as foo //~ ERROR value may contain borrowed pointers; use `static` bound
 }
 
-fn to_foo_3<T:Copy Owned>(t: T) -> foo {
+fn to_foo_3<T:Copy Static>(t: T) -> foo {
     // OK---T may escape as part of the returned foo value, but it is
     // owned and hence does not contain borrowed ptrs
     {f:t} as foo

--- a/src/test/compile-fail/kindck-owned-trait.rs
+++ b/src/test/compile-fail/kindck-owned-trait.rs
@@ -11,10 +11,10 @@
 trait foo { fn foo(); }
 
 fn to_foo<T: Copy foo>(t: T) -> foo {
-    t as foo //~ ERROR value may contain borrowed pointers; use `owned` bound
+    t as foo //~ ERROR value may contain borrowed pointers; use `static` bound
 }
 
-fn to_foo2<T: Copy foo Owned>(t: T) -> foo {
+fn to_foo2<T: Copy foo Static>(t: T) -> foo {
     t as foo
 }
 

--- a/src/test/compile-fail/kindck-owned.rs
+++ b/src/test/compile-fail/kindck-owned.rs
@@ -12,18 +12,18 @@ fn copy1<T: Copy>(t: T) -> fn@() -> T {
     fn@() -> T { t } //~ ERROR value may contain borrowed pointers
 }
 
-fn copy2<T: Copy Owned>(t: T) -> fn@() -> T {
+fn copy2<T: Copy Static>(t: T) -> fn@() -> T {
     fn@() -> T { t }
 }
 
 fn main() {
     let x = &3;
-    copy2(&x); //~ ERROR missing `owned`
+    copy2(&x); //~ ERROR missing `static`
 
     copy2(@3);
-    copy2(@&x); //~ ERROR missing `owned`
+    copy2(@&x); //~ ERROR missing `static`
 
     copy2(fn@() {});
     copy2(fn~() {}); //~ WARNING instantiating copy type parameter with a not implicitly copyable type
-    copy2(fn&() {}); //~ ERROR missing `copy owned`
+    copy2(fn&() {}); //~ ERROR missing `copy static`
 }

--- a/src/test/compile-fail/liveness-use-after-send.rs
+++ b/src/test/compile-fail/liveness-use-after-send.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn send<T: Send>(ch: _chan<T>, -data: T) {
+fn send<T: Owned>(ch: _chan<T>, -data: T) {
     log(debug, ch);
     log(debug, data);
     fail;

--- a/src/test/compile-fail/unique-unique-kind.rs
+++ b/src/test/compile-fail/unique-unique-kind.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn f<T: Send>(_i: T) {
+fn f<T: Owned>(_i: T) {
 }
 
 fn main() {
     let i = ~@100;
-    f(move i); //~ ERROR missing `send`
+    f(move i); //~ ERROR missing `owned`
 }

--- a/src/test/compile-fail/unsendable-class.rs
+++ b/src/test/compile-fail/unsendable-class.rs
@@ -25,7 +25,7 @@ fn foo(i:int, j: @~str) -> foo {
 
 fn main() {
   let cat = ~"kitty";
-  let po = comm::Port();         //~ ERROR missing `send`
-  let ch = comm::Chan(&po);       //~ ERROR missing `send`
-  comm::send(ch, foo(42, @(move cat))); //~ ERROR missing `send`
+  let po = comm::Port();         //~ ERROR missing `owned`
+  let ch = comm::Chan(&po);       //~ ERROR missing `owned`
+  comm::send(ch, foo(42, @(move cat))); //~ ERROR missing `owned`
 }

--- a/src/test/run-fail/bug-811.rs
+++ b/src/test/run-fail/bug-811.rs
@@ -14,8 +14,8 @@ fn test00_start(ch: chan_t<int>, message: int) { send(ch, message); }
 type task_id = int;
 type port_id = int;
 
-enum chan_t<T: Send> = {task: task_id, port: port_id};
+enum chan_t<T: Owned> = {task: task_id, port: port_id};
 
-fn send<T: Send>(ch: chan_t<T>, data: T) { fail; }
+fn send<T: Owned>(ch: chan_t<T>, data: T) { fail; }
 
 fn main() { fail ~"quux"; }

--- a/src/test/run-fail/issue-2444.rs
+++ b/src/test/run-fail/issue-2444.rs
@@ -13,7 +13,7 @@
 extern mod std;
 use std::arc;
 
-enum e<T: Const Send> { e(arc::ARC<T>) }
+enum e<T: Const Owned> { e(arc::ARC<T>) }
 
 fn foo() -> e<int> {fail;}
 

--- a/src/test/run-fail/port-type.rs
+++ b/src/test/run-fail/port-type.rs
@@ -15,7 +15,7 @@ use comm::Port;
 use comm::send;
 use comm::recv;
 
-fn echo<T: Send>(c: Chan<T>, oc: Chan<Chan<T>>) {
+fn echo<T: Owned>(c: Chan<T>, oc: Chan<Chan<T>>) {
     // Tests that the type argument in port gets
     // visited
     let p = Port::<T>();

--- a/src/test/run-pass/alignment-gep-tup-like-1.rs
+++ b/src/test/run-pass/alignment-gep-tup-like-1.rs
@@ -12,7 +12,7 @@ type pair<A,B> = {
     a: A, b: B
 };
 
-fn f<A:Copy Owned>(a: A, b: u16) -> fn@() -> (A, u16) {
+fn f<A:Copy Static>(a: A, b: u16) -> fn@() -> (A, u16) {
     fn@() -> (A, u16) { (a, b) }
 }
 

--- a/src/test/run-pass/alignment-gep-tup-like-2.rs
+++ b/src/test/run-pass/alignment-gep-tup-like-2.rs
@@ -23,7 +23,7 @@ fn make_cycle<A:Copy>(a: A) {
     g.rec = Some(g);
 }
 
-fn f<A:Send Copy, B:Send Copy>(a: A, b: B) -> fn@() -> (A, B) {
+fn f<A:Owned Copy, B:Owned Copy>(a: A, b: B) -> fn@() -> (A, B) {
     fn@() -> (A, B) { (a, b) }
 }
 

--- a/src/test/run-pass/bounded-fn-type.rs
+++ b/src/test/run-pass/bounded-fn-type.rs
@@ -11,7 +11,7 @@
 fn ignore<T>(_x: T) {}
 
 fn main() {
-    let f: fn@:Send() = ||();
+    let f: fn@:Owned() = ||();
     ignore(f);
 }
 

--- a/src/test/run-pass/close-over-big-then-small-data.rs
+++ b/src/test/run-pass/close-over-big-then-small-data.rs
@@ -16,7 +16,7 @@ type pair<A,B> = {
     a: A, b: B
 };
 
-fn f<A:Copy Owned>(a: A, b: u16) -> fn@() -> (A, u16) {
+fn f<A:Copy Static>(a: A, b: u16) -> fn@() -> (A, u16) {
     fn@() -> (A, u16) { (a, b) }
 }
 

--- a/src/test/run-pass/fixed-point-bind-unique.rs
+++ b/src/test/run-pass/fixed-point-bind-unique.rs
@@ -11,11 +11,11 @@
 // xfail-fast
 #[legacy_modes];
 
-fn fix_help<A: Owned, B: Send>(f: extern fn(fn@(A) -> B, A) -> B, x: A) -> B {
+fn fix_help<A: Static, B: Send>(f: extern fn(fn@(A) -> B, A) -> B, x: A) -> B {
     return f({|a|fix_help(f, a)}, x);
 }
 
-fn fix<A: Owned, B: Send>(f: extern fn(fn@(A) -> B, A) -> B) -> fn@(A) -> B {
+fn fix<A: Static, B: Send>(f: extern fn(fn@(A) -> B, A) -> B) -> fn@(A) -> B {
     return {|a|fix_help(f, a)};
 }
 

--- a/src/test/run-pass/fixed-point-bind-unique.rs
+++ b/src/test/run-pass/fixed-point-bind-unique.rs
@@ -11,11 +11,11 @@
 // xfail-fast
 #[legacy_modes];
 
-fn fix_help<A: Static, B: Send>(f: extern fn(fn@(A) -> B, A) -> B, x: A) -> B {
+fn fix_help<A: Static, B: Owned>(f: extern fn(fn@(A) -> B, A) -> B, x: A) -> B {
     return f({|a|fix_help(f, a)}, x);
 }
 
-fn fix<A: Static, B: Send>(f: extern fn(fn@(A) -> B, A) -> B) -> fn@(A) -> B {
+fn fix<A: Static, B: Owned>(f: extern fn(fn@(A) -> B, A) -> B) -> fn@(A) -> B {
     return {|a|fix_help(f, a)};
 }
 

--- a/src/test/run-pass/fn-bare-spawn.rs
+++ b/src/test/run-pass/fn-bare-spawn.rs
@@ -10,7 +10,7 @@
 
 // This is what the signature to spawn should look like with bare functions
 
-fn spawn<T: Send>(val: T, f: extern fn(T)) {
+fn spawn<T: Owned>(val: T, f: extern fn(T)) {
     f(move val);
 }
 

--- a/src/test/run-pass/generic-alias-unique.rs
+++ b/src/test/run-pass/generic-alias-unique.rs
@@ -10,7 +10,7 @@
 
 
 
-fn id<T: Copy Send>(t: T) -> T { return t; }
+fn id<T: Copy Owned>(t: T) -> T { return t; }
 
 fn main() {
     let expected = ~100;

--- a/src/test/run-pass/issue-2734.rs
+++ b/src/test/run-pass/issue-2734.rs
@@ -11,7 +11,7 @@
 trait hax { } 
 impl <A> A: hax { } 
 
-fn perform_hax<T: Owned>(x: @T) -> hax {
+fn perform_hax<T: Static>(x: @T) -> hax {
     x as hax 
 }
 

--- a/src/test/run-pass/issue-2735.rs
+++ b/src/test/run-pass/issue-2735.rs
@@ -11,7 +11,7 @@
 trait hax { } 
 impl <A> A: hax { } 
 
-fn perform_hax<T: Owned>(x: @T) -> hax {
+fn perform_hax<T: Static>(x: @T) -> hax {
     x as hax 
 }
 

--- a/src/test/run-pass/issue-2834.rs
+++ b/src/test/run-pass/issue-2834.rs
@@ -12,7 +12,7 @@
 //
 
 proto! streamp (
-    open:send<T: Send> {
+    open:send<T: Owned> {
         data(T) -> open<T>
     }
 )

--- a/src/test/run-pass/issue-2904.rs
+++ b/src/test/run-pass/issue-2904.rs
@@ -57,7 +57,7 @@ fn square_from_char(c: char) -> square {
     }
 }
 
-fn read_board_grid<rdr: Owned io::Reader>(+in: rdr) -> ~[~[square]] {
+fn read_board_grid<rdr: Static io::Reader>(+in: rdr) -> ~[~[square]] {
     let in = (move in) as io::Reader;
     let mut grid = ~[];
     for in.each_line |line| {

--- a/src/test/run-pass/issue-2930.rs
+++ b/src/test/run-pass/issue-2930.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 proto! stream (
-    Stream:send<T:Send> {
+    Stream:send<T:Owned> {
         send(T) -> Stream<T>
     }
 )

--- a/src/test/run-pass/pipe-bank-proto.rs
+++ b/src/test/run-pass/pipe-bank-proto.rs
@@ -45,7 +45,7 @@ macro_rules! move_it (
     { $x:expr } => { unsafe { let y = move *ptr::addr_of(&($x)); move y } }
 )
 
-fn switch<T: Send, U>(+endp: pipes::RecvPacket<T>,
+fn switch<T: Owned, U>(+endp: pipes::RecvPacket<T>,
                       f: fn(+v: Option<T>) -> U) -> U {
     f(pipes::try_recv(move endp))
 }

--- a/src/test/run-pass/pipe-select.rs
+++ b/src/test/run-pass/pipe-select.rs
@@ -24,7 +24,7 @@ proto! oneshot (
 )
 
 proto! stream (
-    Stream:send<T:Send> {
+    Stream:send<T:Owned> {
         send(T) -> Stream<T>
     }
 )

--- a/src/test/run-pass/send-type-inference.rs
+++ b/src/test/run-pass/send-type-inference.rs
@@ -14,9 +14,9 @@ use comm::send;
 use comm::Port;
 
 // tests that ctrl's type gets inferred properly
-type command<K: Send, V: Send> = {key: K, val: V};
+type command<K: Owned, V: Owned> = {key: K, val: V};
 
-fn cache_server<K: Send, V: Send>(c: Chan<Chan<command<K, V>>>) {
+fn cache_server<K: Owned, V: Owned>(c: Chan<Chan<command<K, V>>>) {
     let ctrl = Port();
     send(c, Chan(&ctrl));
 }

--- a/src/test/run-pass/type-param-constraints.rs
+++ b/src/test/run-pass/type-param-constraints.rs
@@ -13,7 +13,7 @@
 
 fn p_foo<T>(pinned: T) { }
 fn s_foo<T: Copy>(shared: T) { }
-fn u_foo<T: Send>(unique: T) { }
+fn u_foo<T: Owned>(unique: T) { }
 
 struct r {
   i: int,

--- a/src/test/run-pass/uniq-cc-generic.rs
+++ b/src/test/run-pass/uniq-cc-generic.rs
@@ -18,7 +18,7 @@ type pointy = {
     d : fn~() -> uint,
 };
 
-fn make_uniq_closure<A:Send Copy>(a: A) -> fn~() -> uint {
+fn make_uniq_closure<A:Owned Copy>(a: A) -> fn~() -> uint {
     fn~() -> uint { ptr::addr_of(&a) as uint }
 }
 

--- a/src/test/run-pass/unique-kinds.rs
+++ b/src/test/run-pass/unique-kinds.rs
@@ -12,11 +12,11 @@ use cmp::Eq;
 
 fn sendable() {
 
-    fn f<T: Send Eq>(i: T, j: T) {
+    fn f<T: Owned Eq>(i: T, j: T) {
         assert i == j;
     }
 
-    fn g<T: Send Eq>(i: T, j: T) {
+    fn g<T: Owned Eq>(i: T, j: T) {
         assert i != j;
     }
 


### PR DESCRIPTION
r? @graydon
#3542

Although reception to this in the weekly meeting was pretty indifferent, I do think this is more consistent.

Note that `Static` will probably go away eventually.
