### PR TITLE
Auto-borrow trait types

### DIFF
--- a/src/librustc/middle/borrowck/gather_loans.rs
+++ b/src/librustc/middle/borrowck/gather_loans.rs
@@ -307,6 +307,11 @@ impl gather_loan_ctxt {
                                              autoref.mutbl,
                                              autoref.region)
                     }
+                    ty::AutoBorrowTrait => {
+                        self.guarantee_valid(cmt,
+                                             autoref.mutbl,
+                                             autoref.region);
+                    }
                 }
             }
         }

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -119,7 +119,8 @@ use base::*;
 use syntax::print::pprust::{expr_to_str};
 use util::ppaux::ty_to_str;
 use util::common::indenter;
-use ty::{AutoPtr, AutoBorrowVec, AutoBorrowVecRef, AutoBorrowFn};
+use ty::{AutoPtr, AutoBorrowVec, AutoBorrowVecRef, AutoBorrowFn,
+         AutoBorrowTrait};
 use callee::{AutorefArg, DoAutorefArg, DontAutorefArg};
 use middle::ty::MoveValue;
 
@@ -196,7 +197,7 @@ fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
                 None => datum,
                 Some(ref autoref) => {
                     match autoref.kind {
-                        AutoPtr => {
+                        AutoPtr | AutoBorrowTrait => {
                             unpack_datum!(bcx, auto_ref(bcx, datum))
                         }
                         AutoBorrowVec => {

--- a/src/librustc/middle/typeck/infer/assignment.rs
+++ b/src/librustc/middle/typeck/infer/assignment.rs
@@ -194,6 +194,14 @@ priv impl Assign {
                                         a, nr_b, m_imm, b_f.meta.region)
                     }
 
+                    (ty::ty_trait(_, _, vs_1),
+                     ty::ty_trait(t_2, s_2, ty::vstore_slice(r_b))) => {
+                        let nr_b = ty::mk_trait(self.infcx.tcx, t_2, s_2,
+                                                vs_1);
+                        self.try_assign(0, ty::AutoBorrowTrait, a, nr_b,
+                                        m_const, r_b)
+                    }
+
                     // check for &T being assigned to *T:
                     (ty::ty_rptr(_, ref a_t), ty::ty_ptr(ref b_t)) => {
                         match Sub(*self).mts(*a_t, *b_t) {

--- a/src/test/run-pass/issue-3794.rs
+++ b/src/test/run-pass/issue-3794.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test
 trait T {
     fn print(&self);
 }


### PR DESCRIPTION
r? @nikomatsakis - Allow @A to be used where &A is expected, if A is a trait. As per
issue #3794
