### PR TITLE
Make trans treat all statements as if they introduce a new scope

### DIFF
--- a/src/test/run-pass/issue-3860.rs
+++ b/src/test/run-pass/issue-3860.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test
 struct Foo { x: int }
 
 impl Foo {
@@ -19,11 +18,7 @@ impl Foo {
 
 fn main() {
     let mut x = @mut Foo { x: 3 };
-    x.stuff(); // error: internal compiler error: no enclosing scope with id 49
-    // storing the result removes the error, so replacing the above
-    // with the following, works:
-    // let _y = x.stuff()
-
-    // also making 'stuff()' not return anything fixes it
-    // I guess the "dangling &ptr" cuases issues?
+    // Neither of the next two lines should cause an error
+    let _ = x.stuff(); 
+    x.stuff();
 }


### PR DESCRIPTION
r? @graydon This is for consistency with borrowck. Changing borrowck would
also be an alternative, but I found it easier to change trans :-)

This eliminates an ICE in trans where the scope for a particular
borrow was a statement ID, but the code in trans that does cleanups
wasn't finding the block with that scope. As per #3860
