### PR TITLE
core: add macro_rules! for "condition! { c: in -> out; }".

### DIFF
--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -242,6 +242,7 @@ mod core {
     pub const debug : u32 = 4_u32;
 
     pub use cmp;
+    pub use condition;
 }
 
 

--- a/src/librustc/front/intrinsic_inject.rs
+++ b/src/librustc/front/intrinsic_inject.rs
@@ -17,7 +17,7 @@ export inject_intrinsic;
 fn inject_intrinsic(sess: Session,
                     crate: @ast::crate) -> @ast::crate {
 
-    let intrinsic_module = @include_str!("intrinsic.rs");
+    let intrinsic_module = @(include_str!("intrinsic.rs").to_owned());
 
     let item = parse::parse_item_from_source_str(~"<intrinsic>",
                                                  intrinsic_module,

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -138,7 +138,7 @@ fn run(repl: Repl, input: ~str) -> Repl {
     };
 
     debug!("building driver input");
-    let head = include_str!("wrapper.rs");
+    let head = include_str!("wrapper.rs").to_owned();
     let foot = fmt!("%s\nfn main() {\n%s\n\nprint({\n%s\n})\n}",
                     repl.view_items, repl.stmts, input);
     let wrapped = driver::str_input(head + foot);

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -286,12 +286,30 @@ fn core_macros() -> ~str {
 
     macro_rules! die(
         ($msg: expr) => (
-            core::sys::begin_unwind($msg, file!(), line!())
+            core::sys::begin_unwind($msg,
+                                    file!().to_owned(), line!())
         );
         () => (
             die!(~\"explicit failure\")
         )
     )
+
+    macro_rules! condition (
+
+        { $c:ident: $in:ty -> $out:ty; } => {
+
+            mod $c {
+                fn key(_x: @core::condition::Handler<$in,$out>) { }
+
+                pub const cond : core::condition::Condition<$in,$out> =
+                    core::condition::Condition {
+                    name: stringify!(c),
+                    key: key
+                };
+            }
+        }
+    )
+
 }";
 }
 

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -11,7 +11,7 @@
 use ext::base::*;
 use codemap::{span, Loc, FileMap};
 use print::pprust;
-use ext::build::{mk_base_vec_e, mk_uint, mk_u8, mk_uniq_str};
+use ext::build::{mk_base_vec_e, mk_uint, mk_u8, mk_base_str};
 
 export expand_line;
 export expand_col;
@@ -46,19 +46,19 @@ fn expand_file(cx: ext_ctxt, sp: span, tts: ~[ast::token_tree])
     base::check_zero_tts(cx, sp, tts, "file!");
     let Loc { file: @FileMap { name: filename, _ }, _ } =
         cx.codemap().lookup_char_pos(sp.lo);
-    base::mr_expr(mk_uniq_str(cx, sp, filename))
+    base::mr_expr(mk_base_str(cx, sp, filename))
 }
 
 fn expand_stringify(cx: ext_ctxt, sp: span, tts: ~[ast::token_tree])
     -> base::mac_result {
     let s = pprust::tts_to_str(tts, cx.parse_sess().interner);
-    base::mr_expr(mk_uniq_str(cx, sp, s))
+    base::mr_expr(mk_base_str(cx, sp, s))
 }
 
 fn expand_mod(cx: ext_ctxt, sp: span, tts: ~[ast::token_tree])
     -> base::mac_result {
     base::check_zero_tts(cx, sp, tts, "module_path!");
-    base::mr_expr(mk_uniq_str(cx, sp,
+    base::mr_expr(mk_base_str(cx, sp,
                               str::connect(cx.mod_path().map(
                                   |x| cx.str_of(*x)), ~"::")))
 }
@@ -83,7 +83,7 @@ fn expand_include_str(cx: ext_ctxt, sp: span, tts: ~[ast::token_tree])
       }
     }
 
-    base::mr_expr(mk_uniq_str(cx, sp, result::unwrap(res)))
+    base::mr_expr(mk_base_str(cx, sp, result::unwrap(res)))
 }
 
 fn expand_include_bin(cx: ext_ctxt, sp: span, tts: ~[ast::token_tree])

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -19,7 +19,7 @@ use std::map::{Map, HashMap};
 use io::{Reader, ReaderUtil};
 
 macro_rules! bench (
-    ($id:ident) => (maybe_run_test(argv, stringify!($id), $id))
+    ($id:ident) => (maybe_run_test(argv, stringify!($id).to_owned(), $id))
 )
 
 fn main() {

--- a/src/test/run-pass/html-literals.rs
+++ b/src/test/run-pass/html-literals.rs
@@ -39,7 +39,8 @@ macro_rules! parse_node (
     ) => (
         parse_node!(
             [$(: $tags ($(:$tag_nodes),*))*];
-            [$(:$head_nodes,)* :tag(stringify!($head), ~[$($nodes),*])];
+            [$(:$head_nodes,)* :tag(stringify!($head).to_owned(),
+                                    ~[$($nodes),*])];
             $($rest)*
         )
     );
@@ -75,7 +76,7 @@ macro_rules! parse_node (
     ) => (
         parse_node!(
             [$(: $tags ($(:$tag_nodes),*))*];
-            [$(:$nodes,)* :text(stringify!($word))];
+            [$(:$nodes,)* :text(stringify!($word).to_owned())];
             $($rest)*
         )
     );

--- a/src/test/run-pass/syntax-extension-source-utils.rs
+++ b/src/test/run-pass/syntax-extension-source-utils.rs
@@ -16,20 +16,20 @@ mod m1 {
     #[legacy_exports];
     mod m2 {
         #[legacy_exports];
-        fn where_am_i() -> ~str { module_path!() }
+        fn where_am_i() -> ~str { (module_path!()).to_owned() }
     }
 }
 
 fn main() {
     assert(line!() == 24);
     assert(col!() == 11);
-    assert(file!().ends_with(~"syntax-extension-source-utils.rs"));
-    assert(stringify!((2*3) + 5) == ~"( 2 * 3 ) + 5");
-    assert(include!("syntax-extension-source-utils-files/includeme.fragment")
+    assert(file!().to_owned().ends_with(~"syntax-extension-source-utils.rs"));
+    assert(stringify!((2*3) + 5).to_owned() == ~"( 2 * 3 ) + 5");
+    assert(include!("syntax-extension-source-utils-files/includeme.fragment").to_owned()
            == ~"victory robot 6");
 
     assert(
-        include_str!("syntax-extension-source-utils-files/includeme.fragment")
+        include_str!("syntax-extension-source-utils-files/includeme.fragment").to_owned()
         .starts_with(~"/* this is for "));
     assert(
         include_bin!("syntax-extension-source-utils-files/includeme.fragment")


### PR DESCRIPTION
This just adds a condition! macro. Also, in passing, adjusts other string-producing syntax extensions to make string literals rather than ~"" expressions.
