### PR TITLE
Use moving out of self to clean up unwrap functions

### DIFF
--- a/src/libcore/dvec.rs
+++ b/src/libcore/dvec.rs
@@ -110,6 +110,9 @@ priv impl<A> DVec<A> {
             self.data = move data;
         }
     }
+
+    #[inline(always)]
+    fn unwrap(self) -> ~[A] { unwrap(self) }
 }
 
 // In theory, most everything should work with any A, but in practice

--- a/src/libcore/either.rs
+++ b/src/libcore/either.rs
@@ -142,6 +142,14 @@ pub pure fn unwrap_right<T,U>(eith: Either<T,U>) -> U {
     }
 }
 
+impl<T, U> Either<T, U> {
+    #[inline(always)]
+    fn unwrap_left(self) -> T { unwrap_left(self) }
+
+    #[inline(always)]
+    fn unwrap_right(self) -> U { unwrap_right(self) }
+}
+
 #[test]
 fn test_either_left() {
     let val = Left(10);

--- a/src/libcore/mutable.rs
+++ b/src/libcore/mutable.rs
@@ -73,6 +73,9 @@ impl<T> Data<T> {
             op(unsafe{transmute_immut(&mut self.value)})
         }
     }
+
+    #[inline(always)]
+    fn unwrap(self) -> T { unwrap(self) }
 }
 
 #[test]

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -412,7 +412,7 @@ Fails if the sender closes the connection.
 */
 pub fn recv<T: Owned, Tbuffer: Owned>(
     p: RecvPacketBuffered<T, Tbuffer>) -> T {
-    option::unwrap_expect(try_recv(move p), "connection closed")
+    try_recv(move p).expect("connection closed")
 }
 
 /** Attempts to receive a message from a pipe.
@@ -1102,7 +1102,7 @@ impl<T: Owned> PortSet<T> : GenericPort<T> {
     }
 
     fn recv() -> T {
-        option::unwrap_expect(self.try_recv(), "port_set: endpoints closed")
+        self.try_recv().expect("port_set: endpoints closed")
     }
 
 }

--- a/src/libstd/par.rs
+++ b/src/libstd/par.rs
@@ -85,7 +85,7 @@ fn map_slices<A: Copy Owned, B: Copy Owned>(
 
 /// A parallel version of map.
 pub fn map<A: Copy Owned, B: Copy Owned>(
-    xs: &[A], f: fn~((&A)) -> B) -> ~[B] {
+    xs: &[A], f: fn~(&A) -> B) -> ~[B] {
     vec::concat(map_slices(xs, || {
         fn~(_base: uint, slice : &[A], copy f) -> ~[B] {
             vec::map(slice, |x| f(x))
@@ -95,7 +95,7 @@ pub fn map<A: Copy Owned, B: Copy Owned>(
 
 /// A parallel version of mapi.
 pub fn mapi<A: Copy Owned, B: Copy Owned>(xs: &[A],
-                                    f: fn~(uint, (&A)) -> B) -> ~[B] {
+                                    f: fn~(uint, &A) -> B) -> ~[B] {
     let slices = map_slices(xs, || {
         fn~(base: uint, slice : &[A], copy f) -> ~[B] {
             vec::mapi(slice, |i, x| {
@@ -132,7 +132,7 @@ pub fn mapi_factory<A: Copy Owned, B: Copy Owned>(
 }
 
 /// Returns true if the function holds for all elements in the vector.
-pub fn alli<A: Copy Owned>(xs: &[A], f: fn~(uint, (&A)) -> bool) -> bool {
+pub fn alli<A: Copy Owned>(xs: &[A], f: fn~(uint, &A) -> bool) -> bool {
     do vec::all(map_slices(xs, || {
         fn~(base: uint, slice : &[A], copy f) -> bool {
             vec::alli(slice, |i, x| {
@@ -143,7 +143,7 @@ pub fn alli<A: Copy Owned>(xs: &[A], f: fn~(uint, (&A)) -> bool) -> bool {
 }
 
 /// Returns true if the function holds for any elements in the vector.
-pub fn any<A: Copy Owned>(xs: &[A], f: fn~(&(A)) -> bool) -> bool {
+pub fn any<A: Copy Owned>(xs: &[A], f: fn~(&A) -> bool) -> bool {
     do vec::any(map_slices(xs, || {
         fn~(_base : uint, slice: &[A], copy f) -> bool {
             vec::any(slice, |x| f(x))


### PR DESCRIPTION
Hopefully I can get this in before we finalize 0.5. This takes advantage of @pcwalton's moving out of self to make unwrap methods.
