### PR TITLE
Assign correct types to struct-like enum variant constructors

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -545,7 +545,10 @@ fn iter_structural_ty(cx: block, av: ValueRef, t: ty::t,
                 j += 1u;
             }
           }
-          _ => cx.tcx().sess.bug(~"iter_variant: not a function type")
+          _ => cx.tcx().sess.bug(fmt!("iter_variant: not a function type: \
+                                       %s (variant name = %s)",
+                                      cx.ty_to_str(fn_ty),
+                                      cx.sess().str_of(variant.name)))
         }
         return cx;
     }

--- a/src/test/run-pass/enum-variants.rs
+++ b/src/test/run-pass/enum-variants.rs
@@ -1,0 +1,9 @@
+enum Animal {
+    Dog (~str, float),
+    Cat { name: ~str, weight: float }
+}
+
+fn main() {
+    let mut a: Animal = Dog(~"Cocoa", 37.2);
+    a = Cat{ name: ~"Spotty", weight: 2.7 };
+}


### PR DESCRIPTION
Before, the type was just the enum type itself, which caused an
assertion failure in iter_variant in trans::base.

As per #4229

r? @brson
