### PR TITLE
generate dll file name based on target os. issue #4119

### DIFF
--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -850,7 +850,7 @@ pub fn family() -> ~str { ~"unix" }
 
 #[cfg(windows)]
 pub fn family() -> ~str { ~"windows" }
-    
+
 
 mod consts {
 
@@ -886,7 +886,7 @@ mod consts {
         pub fn dll_suffix() -> ~str { ~".so" }
         pub fn exe_suffix() -> ~str { ~"" }
     }
-    
+
     pub mod win32 {
         pub fn sysname() -> ~str { ~"win32" }
         pub fn dll_prefix() -> ~str { ~"" }

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -355,13 +355,7 @@ fn dup2(src: c_int, dst: c_int) -> c_int {
 
 
 pub fn dll_filename(base: &str) -> ~str {
-    return pre() + str::from_slice(base) + dll_suffix();
-
-    #[cfg(unix)]
-    fn pre() -> ~str { ~"lib" }
-
-    #[cfg(windows)]
-    fn pre() -> ~str { ~"" }
+    return dll_prefix() + str::from_slice(base) + dll_suffix();
 }
 
 
@@ -856,33 +850,49 @@ pub fn family() -> ~str { ~"unix" }
 
 #[cfg(windows)]
 pub fn family() -> ~str { ~"windows" }
+    
 
-#[cfg(target_os = "macos")]
 mod consts {
-    pub fn sysname() -> ~str { ~"macos" }
-    pub fn exe_suffix() -> ~str { ~"" }
-    pub fn dll_suffix() -> ~str { ~".dylib" }
-}
 
-#[cfg(target_os = "freebsd")]
-mod consts {
-    pub fn sysname() -> ~str { ~"freebsd" }
-    pub fn exe_suffix() -> ~str { ~"" }
-    pub fn dll_suffix() -> ~str { ~".so" }
-}
+    #[cfg(target_os = "macos")]
+    use os::consts::macos::*;
 
-#[cfg(target_os = "linux")]
-mod consts {
-    pub fn sysname() -> ~str { ~"linux" }
-    pub fn exe_suffix() -> ~str { ~"" }
-    pub fn dll_suffix() -> ~str { ~".so" }
-}
+    #[cfg(target_os = "freebsd")]
+    use os::consts::freebsd::*;
 
-#[cfg(target_os = "win32")]
-mod consts {
-    pub fn sysname() -> ~str { ~"win32" }
-    pub fn exe_suffix() -> ~str { ~".exe" }
-    pub fn dll_suffix() -> ~str { ~".dll" }
+    #[cfg(target_os = "linux")]
+    use os::consts::linux::*;
+
+    #[cfg(target_os = "win32")]
+    use os::consts::win32::*;
+
+    pub mod macos {
+        pub fn sysname() -> ~str { ~"macos" }
+        pub fn dll_prefix() -> ~str { ~"lib" }
+        pub fn dll_suffix() -> ~str { ~".dylib" }
+        pub fn exe_suffix() -> ~str { ~"" }
+    }
+
+    pub mod freebsd {
+        pub fn sysname() -> ~str { ~"freebsd" }
+        pub fn dll_prefix() -> ~str { ~"lib" }
+        pub fn dll_suffix() -> ~str { ~".so" }
+        pub fn exe_suffix() -> ~str { ~"" }
+    }
+
+    pub mod linux {
+        pub fn sysname() -> ~str { ~"linux" }
+        pub fn dll_prefix() -> ~str { ~"lib" }
+        pub fn dll_suffix() -> ~str { ~".so" }
+        pub fn exe_suffix() -> ~str { ~"" }
+    }
+    
+    pub mod win32 {
+        pub fn sysname() -> ~str { ~"win32" }
+        pub fn dll_prefix() -> ~str { ~"" }
+        pub fn dll_suffix() -> ~str { ~".dll" }
+        pub fn exe_suffix() -> ~str { ~".exe" }
+    }
 }
 
 #[cfg(target_arch = "x86")]

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -642,7 +642,7 @@ fn output_dll_filename(os: session::os, lm: &link_meta) -> ~str {
             freebsd::dll_prefix() + libname + macos::dll_suffix(),
         session::os_linux =>
             freebsd::dll_prefix() + libname + macos::dll_suffix(),
-        session::os_win32 => 
+        session::os_win32 =>
             win32::dll_prefix() + libname + win32::dll_suffix(),
     }
 }
@@ -665,8 +665,7 @@ fn link_binary(sess: Session,
 
     let output = if sess.building_library {
         let long_libname = output_dll_filename(sess.targ_cfg.os, &lm);
-        
-		debug!("link_meta.name:  %s", lm.name);
+        debug!("link_meta.name:  %s", lm.name);
         debug!("long_libname: %s", long_libname);
         debug!("out_filename: %s", out_filename.to_str());
         debug!("dirname(out_filename): %s", out_filename.dir_path().to_str());

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -26,6 +26,7 @@ use lib::llvm::{ModuleRef, mk_pass_manager, mk_target_data, True, False,
 use metadata::filesearch;
 use syntax::ast_map::{path, path_mod, path_name};
 use io::{Writer, WriterUtil};
+use os::consts::{macos, freebsd, linux, win32};
 
 enum output_type {
     output_type_none,
@@ -631,6 +632,21 @@ fn mangle_internal_name_by_seq(ccx: @crate_ctxt, flav: ~str) -> ~str {
     return fmt!("%s_%u", flav, (ccx.names)(flav).repr);
 }
 
+
+fn output_dll_filename(os: session::os, lm: &link_meta) -> ~str {
+    let libname = fmt!("%s-%s-%s", lm.name, lm.extras_hash, lm.vers);
+    match os {
+        session::os_macos =>
+            macos::dll_prefix() + libname + macos::dll_suffix(),
+        session::os_freebsd =>
+            freebsd::dll_prefix() + libname + macos::dll_suffix(),
+        session::os_linux =>
+            freebsd::dll_prefix() + libname + macos::dll_suffix(),
+        session::os_win32 => 
+            win32::dll_prefix() + libname + win32::dll_suffix(),
+    }
+}
+
 // If the user wants an exe generated we need to invoke
 // cc to link the object file with some libs
 fn link_binary(sess: Session,
@@ -648,10 +664,9 @@ fn link_binary(sess: Session,
     }
 
     let output = if sess.building_library {
-        let long_libname =
-            os::dll_filename(fmt!("%s-%s-%s",
-                                  lm.name, lm.extras_hash, lm.vers));
-        debug!("link_meta.name:  %s", lm.name);
+        let long_libname = output_dll_filename(sess.targ_cfg.os, &lm);
+        
+		debug!("link_meta.name:  %s", lm.name);
         debug!("long_libname: %s", long_libname);
         debug!("out_filename: %s", out_filename.to_str());
         debug!("dirname(out_filename): %s", out_filename.dir_path().to_str());

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -18,6 +18,7 @@ use lib::llvm::{False, llvm, mk_object_file, mk_section_iter};
 use metadata::filesearch::FileSearch;
 use io::WriterUtil;
 use syntax::parse::token::ident_interner;
+use core::os::consts::{macos, freebsd, linux, win32};
 
 export os;
 export os_macos, os_win32, os_linux, os_freebsd;
@@ -67,10 +68,14 @@ fn find_library_crate(cx: ctxt) -> Option<{ident: ~str, data: @~[u8]}> {
 fn libname(cx: ctxt) -> {prefix: ~str, suffix: ~str} {
     if cx.static { return {prefix: ~"lib", suffix: ~".rlib"}; }
     match cx.os {
-      os_win32 => return {prefix: ~"", suffix: ~".dll"},
-      os_macos => return {prefix: ~"lib", suffix: ~".dylib"},
-      os_linux => return {prefix: ~"lib", suffix: ~".so"},
-      os_freebsd => return {prefix: ~"lib", suffix: ~".so"}
+      os_win32 => return {prefix: win32::dll_prefix(), 
+                          suffix: win32::dll_suffix()},
+      os_macos => return {prefix: macos::dll_prefix(),
+                          suffix: macos::dll_suffix()},
+      os_linux => return {prefix: linux::dll_prefix(), 
+                          suffix: linux::dll_suffix()},
+      os_freebsd => return {prefix: freebsd::dll_prefix(), 
+                            suffix: freebsd::dll_suffix()}
     }
 }
 

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -68,13 +68,13 @@ fn find_library_crate(cx: ctxt) -> Option<{ident: ~str, data: @~[u8]}> {
 fn libname(cx: ctxt) -> {prefix: ~str, suffix: ~str} {
     if cx.static { return {prefix: ~"lib", suffix: ~".rlib"}; }
     match cx.os {
-      os_win32 => return {prefix: win32::dll_prefix(), 
+      os_win32 => return {prefix: win32::dll_prefix(),
                           suffix: win32::dll_suffix()},
       os_macos => return {prefix: macos::dll_prefix(),
                           suffix: macos::dll_suffix()},
-      os_linux => return {prefix: linux::dll_prefix(), 
+      os_linux => return {prefix: linux::dll_prefix(),
                           suffix: linux::dll_suffix()},
-      os_freebsd => return {prefix: freebsd::dll_prefix(), 
+      os_freebsd => return {prefix: freebsd::dll_prefix(),
                             suffix: freebsd::dll_suffix()}
     }
 }


### PR DESCRIPTION
generate dll file name base on the given target os, using `core::os::consts` which now contains constant values for all of the supported targets.
