### PR TITLE
Fix a bug in Result::unwrap_err (and minor cleanup)

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -234,7 +234,7 @@ impl<T, E> Result<T, E> {
     pure fn unwrap(self) -> T { unwrap(self) }
 
     #[inline(always)]
-    pure fn unwrap_err(self) -> T { unwrap(self) }
+    pure fn unwrap_err(self) -> E { unwrap_err(self) }
 
     #[inline(always)]
     pure fn chain<U>(self, op: fn(T) -> Result<U,E>) -> Result<U,E> {

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -385,36 +385,22 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             None => Err(~"Invalid year")
           },
           'c' => {
-                // FIXME(#3724): cleanup
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                    move parse_type(s, pos, 'a', tm),
-                    |pos| parse_char(s, pos, ' ')),
-                    |pos| parse_type(s, pos, 'b', tm)),
-                    |pos| parse_char(s, pos, ' ')),
-                    |pos| parse_type(s, pos, 'e', tm)),
-                    |pos| parse_char(s, pos, ' ')),
-                    |pos| parse_type(s, pos, 'T', tm)),
-                    |pos| parse_char(s, pos, ' ')),
-                    |pos| parse_type(s, pos, 'Y', tm))
+            parse_type(s, pos, 'a', tm)
+                .chain(|pos| parse_char(s, pos, ' '))
+                .chain(|pos| parse_type(s, pos, 'b', tm))
+                .chain(|pos| parse_char(s, pos, ' '))
+                .chain(|pos| parse_type(s, pos, 'e', tm))
+                .chain(|pos| parse_char(s, pos, ' '))
+                .chain(|pos| parse_type(s, pos, 'T', tm))
+                .chain(|pos| parse_char(s, pos, ' '))
+                .chain(|pos| parse_type(s, pos, 'Y', tm))
           }
           'D' | 'x' => {
-                // FIXME(#3724): cleanup
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                    move parse_type(s, pos, 'm', tm),
-                    |pos| parse_char(s, pos, '/')),
-                    |pos| parse_type(s, pos, 'd', tm)),
-                    |pos| parse_char(s, pos, '/')),
-                    |pos| parse_type(s, pos, 'y', tm))
+            parse_type(s, pos, 'm', tm)
+                .chain(|pos| parse_char(s, pos, '/'))
+                .chain(|pos| parse_type(s, pos, 'd', tm))
+                .chain(|pos| parse_char(s, pos, '/'))
+                .chain(|pos| parse_type(s, pos, 'y', tm))
           }
           'd' => match match_digits(s, pos, 2u, false) {
             Some(item) => { let (v, pos) = item; tm.tm_mday = v; Ok(pos) }
@@ -425,16 +411,11 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             None => Err(~"Invalid day of the month")
           },
           'F' => {
-                // FIXME(#3724): cleanup
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                    move parse_type(s, pos, 'Y', tm),
-                    |pos| parse_char(s, pos, '-')),
-                    |pos| parse_type(s, pos, 'm', tm)),
-                    |pos| parse_char(s, pos, '-')),
-                    |pos| parse_type(s, pos, 'd', tm))
+            parse_type(s, pos, 'Y', tm)
+                .chain(|pos| parse_char(s, pos, '-'))
+                .chain(|pos| parse_type(s, pos, 'm', tm))
+                .chain(|pos| parse_char(s, pos, '-'))
+                .chain(|pos| parse_type(s, pos, 'd', tm))
           }
           'H' => {
             // FIXME (#2350): range check.
@@ -515,28 +496,18 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             None => Err(~"Invalid hour")
           },
           'R' => {
-                // FIXME(#3724): cleanup
-                result::chain(
-                result::chain(
-                    move parse_type(s, pos, 'H', tm),
-                    |pos| parse_char(s, pos, ':')),
-                    |pos| parse_type(s, pos, 'M', tm))
+            parse_type(s, pos, 'H', tm)
+                .chain(|pos| parse_char(s, pos, ':'))
+                .chain(|pos| parse_type(s, pos, 'M', tm))
           }
           'r' => {
-                // FIXME(#3724): cleanup
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                    move parse_type(s, pos, 'I', tm),
-                    |pos| parse_char(s, pos, ':')),
-                    |pos| parse_type(s, pos, 'M', tm)),
-                    |pos| parse_char(s, pos, ':')),
-                    |pos| parse_type(s, pos, 'S', tm)),
-                    |pos| parse_char(s, pos, ' ')),
-                    |pos| parse_type(s, pos, 'p', tm))
+            parse_type(s, pos, 'I', tm)
+                .chain(|pos| parse_char(s, pos, ':'))
+                .chain(|pos| parse_type(s, pos, 'M', tm))
+                .chain(|pos| parse_char(s, pos, ':'))
+                .chain(|pos| parse_type(s, pos, 'S', tm))
+                .chain(|pos| parse_char(s, pos, ' '))
+                .chain(|pos| parse_type(s, pos, 'p', tm))
           }
           'S' => {
             // FIXME (#2350): range check.
@@ -551,16 +522,11 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
           }
           //'s' {}
           'T' | 'X' => {
-                // FIXME(#3724): cleanup
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                    move parse_type(s, pos, 'H', tm),
-                    |pos| parse_char(s, pos, ':')),
-                    |pos| parse_type(s, pos, 'M', tm)),
-                    |pos| parse_char(s, pos, ':')),
-                    |pos| parse_type(s, pos, 'S', tm))
+            parse_type(s, pos, 'H', tm)
+                .chain(|pos| parse_char(s, pos, ':'))
+                .chain(|pos| parse_type(s, pos, 'M', tm))
+                .chain(|pos| parse_char(s, pos, ':'))
+                .chain(|pos| parse_type(s, pos, 'S', tm))
           }
           't' => parse_char(s, pos, '\t'),
           'u' => {
@@ -575,16 +541,11 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             }
           }
           'v' => {
-                // FIXME(#3724): cleanup
-                result::chain(
-                result::chain(
-                result::chain(
-                result::chain(
-                    move parse_type(s, pos, 'e', tm),
-                    |pos| parse_char(s, pos, '-')),
-                    |pos| parse_type(s, pos, 'b', tm)),
-                    |pos| parse_char(s, pos, '-')),
-                    |pos| parse_type(s, pos, 'Y', tm))
+            parse_type(s, pos, 'e', tm)
+                .chain(|pos|  parse_char(s, pos, '-'))
+                .chain(|pos| parse_type(s, pos, 'b', tm))
+                .chain(|pos| parse_char(s, pos, '-'))
+                .chain(|pos| parse_type(s, pos, 'Y', tm))
           }
           //'W' {}
           'w' => {


### PR DESCRIPTION
I made the mistake of writing the method `Result::unwrap` as `fn unwrap_err(&self) -> T { unwrap(self) }`. This patch fixes that bug, and also does some cleanup of time.rs.
