### PR TITLE
Fix options passed to gpg in cargo init

### DIFF
--- a/src/libcargo/pgp.rs
+++ b/src/libcargo/pgp.rs
@@ -102,7 +102,7 @@ fn verify(root: &Path, data: &Path, sig: &Path) -> bool {
     let path = root.push("gpg");
     let res = gpgv(~[~"--homedir", path.to_str(),
                   ~"--keyring", ~"pubring.gpg",
-                  ~"--verbose",
+                  ~"--verify",
                  sig.to_str(), data.to_str()]);
     if res.status != 0 {
         return false;


### PR DESCRIPTION
Looks like someone autoexpanded -v :)
