### PR TITLE
Fix example in 13.3

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2419,10 +2419,10 @@ these two files:
 pub fn explore() -> &str { "world" }
 ~~~~
 
-~~~~ {.xfail-test}
+~~~~
 // main.rs
 extern mod world;
-fn main() { io::println("hello " + world::explore()); }
+fn main() { io::println(~"hello " + world::explore()); }
 ~~~~
 
 Now compile and run like this (adjust to your platform if necessary):


### PR DESCRIPTION
Before this fix, compiling produced the following error:

```
main.rs:3:24: 3:52 error: binary operation + cannot be applied to type `&static/str`
main.rs:3 fn main() { io::println("hello " + world::explore()); }
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
```
