### PR TITLE
Fix example in FFI tutorial.

### DIFF
--- a/doc/tutorial-ffi.md
+++ b/doc/tutorial-ffi.md
@@ -22,7 +22,7 @@ extern mod crypto {
 
 fn as_hex(data: ~[u8]) -> ~str {
     let mut acc = ~"";
-    for data.each |byte| { acc += fmt!("%02x", byte as uint); }
+    for data.each |&byte| { acc += fmt!("%02x", byte as uint); }
     return acc;
 }
 
@@ -33,8 +33,8 @@ fn sha1(data: ~str) -> ~str unsafe {
     return as_hex(vec::from_buf(hash, 20));
 }
 
-fn main(args: ~[~str]) {
-    io::println(sha1(args[1]));
+fn main() {
+    io::println(sha1(core::os::args()[1]));
 }
 ~~~~
 


### PR DESCRIPTION
These changes were necessary to get this example to compile. Not sure how to get command line args now, since `fn main(args: ~[~str])` produces the following compiler error:

```
main.rs:21:0: 23:1 error: Wrong type in main function: found `fn(~[~str])`, expected `fn() -> ()`
```
