### PR TITLE
Allow impls and traits having static and instance methods with the same name

### DIFF
--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -459,7 +459,9 @@ impl LookupContext {
 
         let tcx = self.tcx();
         let ms = ty::trait_methods(tcx, did);
-        let index = match vec::position(*ms, |m| m.ident == self.m_name) {
+        let index = match vec::position(*ms,
+                                        |m| (m.self_ty != ast::sty_static &&
+                                             m.ident == self.m_name)) {
             Some(i) => i,
             None => { return; } // no method with the right name
         };
@@ -508,7 +510,9 @@ impl LookupContext {
         let tcx = self.tcx();
         let methods = ty::trait_methods(tcx, did);  // XXX: Inherited methods.
         let index;
-        match vec::position(*methods, |m| m.ident == self.m_name) {
+        match vec::position(*methods,
+                            |m| (m.self_ty != ast::sty_static &&
+                                 m.ident == self.m_name)) {
             Some(i) => index = i,
             None => return
         }
@@ -552,7 +556,8 @@ impl LookupContext {
         let idx = {
             // FIXME #3453 can't use impl_info.methods.position
             match vec::position(impl_info.methods,
-                                |m| m.ident == self.m_name) {
+                                |m| (m.self_type != ast::sty_static &&
+                                     m.ident == self.m_name)) {
                 Some(idx) => idx,
                 None => { return; } // No method with the right name.
             }

--- a/src/test/compile-fail/issue-4265.rs
+++ b/src/test/compile-fail/issue-4265.rs
@@ -1,0 +1,20 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Trait {
+  static fn bar();
+
+  fn foo() {
+    self.bar();
+    //~^ ERROR type `self` does not implement any method in scope named `bar`
+  }
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-4265.rs
+++ b/src/test/run-pass/issue-4265.rs
@@ -1,0 +1,27 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Trait {
+  static fn fun();
+  fn fun();
+}
+
+struct A {
+  v: bool
+}
+
+impl A: Trait {
+  static fn fun() {}
+  fn fun() {}
+}
+
+fn main() {
+  A { v: true }.fun();
+}


### PR DESCRIPTION
This fixes all errors described in issue #4265. `make check` runs successfully on my machine.

r? @brson
