### PR TITLE
Replace much of the REPL run code with a call to compile_upto 

### DIFF
--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -134,6 +134,7 @@ fn run(repl: Repl, input: ~str) -> Repl {
         crate_type: session::unknown_crate,
         binary: repl.binary,
         addl_lib_search_paths: repl.lib_search_paths.map(|p| Path(*p)),
+        jit: true,
         .. *session::basic_options()
     };
 
@@ -153,8 +154,12 @@ fn run(repl: Repl, input: ~str) -> Repl {
                                           repl.binary,
                                           wrapped);
 
-    debug!("parsing");
-    let mut crate = driver::parse_input(sess, cfg, wrapped);
+    let outputs = driver::build_output_filenames(wrapped, &None, &None, sess);
+    debug!("calling compile_upto");
+    let {crate: crate, tcx: _} = driver::compile_upto(sess, cfg, wrapped,
+                                                 driver::cu_everything,
+                                                 Some(outputs));
+
     let mut opt = None;
 
     for crate.node.module.items.each |item| {
@@ -177,114 +182,6 @@ fn run(repl: Repl, input: ~str) -> Repl {
         }
         _ => fail
     };
-
-    debug!("configuration");
-    crate = front::config::strip_unconfigured_items(crate);
-
-    debug!("maybe building test harness");
-    crate = front::test::modify_for_testing(sess, crate);
-
-    debug!("expansion");
-    crate = syntax::ext::expand::expand_crate(sess.parse_sess,
-                                              sess.opts.cfg,
-                                              crate);
-
-    debug!("intrinsic injection");
-    crate = front::intrinsic_inject::inject_intrinsic(sess, crate);
-
-    debug!("core injection");
-    crate = front::core_inject::maybe_inject_libcore_ref(sess, crate);
-
-    debug!("building lint settings table");
-    lint::build_settings_crate(sess, crate);
-
-    debug!("ast indexing");
-    let ast_map = syntax::ast_map::map_crate(sess.diagnostic(), *crate);
-
-    debug!("external crate/lib resolution");
-    creader::read_crates(sess.diagnostic(), *crate, sess.cstore,
-                         sess.filesearch,
-                         session::sess_os_to_meta_os(sess.targ_cfg.os),
-                         sess.opts.static, sess.parse_sess.interner);
-
-    debug!("language item collection");
-    let lang_items = middle::lang_items::collect_language_items(crate, sess);
-
-    debug!("resolution");
-    let {def_map: def_map,
-         exp_map2: exp_map2,
-         trait_map: trait_map} = middle::resolve::resolve_crate(sess,
-                                                                lang_items,
-                                                                crate);
-
-    debug!("freevar finding");
-    let freevars = freevars::annotate_freevars(def_map, crate);
-
-    debug!("region_resolution");
-    let region_map = middle::region::resolve_crate(sess, def_map, crate);
-
-    debug!("region paramaterization inference");
-    let rp_set = middle::region::determine_rp_in_crate(sess, ast_map,
-                                                       def_map, crate);
-
-    debug!("typechecking");
-    let ty_cx = ty::mk_ctxt(sess, def_map, ast_map, freevars,
-                            region_map, rp_set, move lang_items, crate);
-    let (method_map, vtable_map) = typeck::check_crate(ty_cx, trait_map,
-                                                       crate);
-
-    debug!("const marking");
-    middle::const_eval::process_crate(crate, def_map, ty_cx);
-
-    debug!("const checking");
-    middle::check_const::check_crate(sess, crate, ast_map, def_map,
-                                     method_map, ty_cx);
-
-    debug!("privacy checking");
-    middle::privacy::check_crate(ty_cx, &method_map, crate);
-
-    debug!("loop checking");
-    middle::check_loop::check_crate(ty_cx, crate);
-
-    debug!("mode computation");
-    middle::mode::compute_modes(ty_cx, method_map, crate);
-
-    debug!("alt checking");
-    middle::check_alt::check_crate(ty_cx, method_map, crate);
-
-    debug!("liveness checking");
-    let last_use_map = middle::liveness::check_crate(ty_cx,
-                                                     method_map, crate);
-
-    debug!("borrow checking");
-    let (root_map, mutbl_map) = middle::borrowck::check_crate(ty_cx,
-                                                              method_map,
-                                                              last_use_map,
-                                                              crate);
-
-    debug!("kind checking");
-    kind::check_crate(ty_cx, method_map, last_use_map, crate);
-
-    debug!("lint checking");
-    lint::check_crate(ty_cx, crate);
-
-    let maps = {mutbl_map: mutbl_map,
-                root_map: root_map,
-                last_use_map: last_use_map,
-                method_map: method_map,
-                vtable_map: vtable_map};
-
-    debug!("translation");
-    let path = ~path::GenericPath::from_str("<repl>");
-    let (llmod, _) = trans::base::trans_crate(sess, crate, ty_cx,
-                                              path,
-                                              exp_map2, maps);
-    let pm = llvm::LLVMCreatePassManager();
-
-    debug!("executing jit");
-    back::link::jit::exec(sess, pm, llmod, 0, false);
-    llvm::LLVMDisposePassManager(pm);
-
     debug!("recording input into repl history");
     record(repl, blk, sess.parse_sess.interner)
 }
@@ -380,7 +277,7 @@ fn run_cmd(repl: &mut Repl, _in: io::Reader, _out: io::Writer,
             io::println(
                 ~":{\\n ..lines.. \\n:}\\n - execute multiline command\n" +
                 ~":load <crate> ... - \
-                  loads given crates as dynamic libraries" +
+                  loads given crates as dynamic libraries\n" +
                 ~":clear - clear the screen\n" +
                 ~":exit - exit from the repl\n" +
                 ~":help - show this message");

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -281,7 +281,7 @@ void *RustMCJITMemoryManager::getPointerToNamedFunction(const std::string &Name,
   if (Name == "mknod") return (void*)(intptr_t)&mknod;
 #endif
 
-  if (Name == "__morestack") return &__morestack;
+  if (Name == "__morestack" || Name == "___morestack") return &__morestack;
 
   const char *NameStr = Name.c_str();
 


### PR DESCRIPTION
This eliminates the need to keep the two functions in sync with each other.
