### PR TITLE
Remove spurious semicolons at the end of macro_rules! definitions.

### DIFF
--- a/doc/tutorial-macros.md
+++ b/doc/tutorial-macros.md
@@ -43,7 +43,7 @@ macro_rules! early_return(
             _ => {}
         }
     );
-);
+)
 // ...
 early_return!(input_1 special_a);
 // ...
@@ -160,7 +160,7 @@ macro_rules! early_return(
             _ => {}
         }
     );
-);
+)
 // ...
 early_return!(input_1, [special_a|special_c|special_d]);
 // ...


### PR DESCRIPTION
While learning how to use macros and writing some code, I found that there were syntax errors in the tutorial. (Maybe the code snippets should be checked and automatically generated into the Markdown, given the rapid changes in Rust?)
