### PR TITLE
Remove semicolons at the end of macro_rules! definitions that cause compile failure

### DIFF
--- a/doc/tutorial-macros.md
+++ b/doc/tutorial-macros.md
@@ -43,7 +43,7 @@ macro_rules! early_return(
             _ => {}
         }
     );
-);
+)
 // ...
 early_return!(input_1 special_a);
 // ...
@@ -160,7 +160,7 @@ macro_rules! early_return(
             _ => {}
         }
     );
-);
+)
 // ...
 early_return!(input_1, [special_a|special_c|special_d]);
 // ...


### PR DESCRIPTION
Code snippets had syntax errors (spurious semicolons) that I noticed when writing my own code following the tutorial.
