### PR TITLE
doc: Fix some typos in the tutorial and reference manual

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -3258,12 +3258,12 @@ crate name the crate is given a default name that matches the source file,
 with the extension removed. In that case, to turn on logging for a program
 compiled from, e.g. `helloworld.rs`, `RUST_LOG` should be set to `helloworld`.
 
-As a convenience, the logging spec can also be set to a special psuedo-crate,
+As a convenience, the logging spec can also be set to a special pseudo-crate,
 `::help`. In this case, when the application starts, the runtime will
 simply output a list of loaded modules containing log expressions, then exit.
 
 The Rust runtime itself generates logging information. The runtime's logs are
-generated for a number of artificial modules in the `::rt` psuedo-crate,
+generated for a number of artificial modules in the `::rt` pseudo-crate,
 and can be enabled just like the logs for any standard module. The full list
 of runtime logging modules follows.
 
@@ -3341,7 +3341,7 @@ have come and gone during the course of Rust's development:
 
 * The Newsqueak (1988), Alef (1995), and Limbo (1996) family. These
   languages were developed by Rob Pike, Phil Winterbottom, Sean Dorward and
-  others in their group at Bell labs Computing Sciences Research Center
+  others in their group at Bell Labs Computing Sciences Research Center
   (Murray Hill, NJ, USA).
 
 * The Napier (1985) and Napier88 (1988) family. These languages were

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -36,7 +36,7 @@ type system and memory model, generics, and modules. [Additional
 tutorials](#what-next) cover specific language features in greater
 depth.
 
-This tutorial assumes that the reader is already familiar with one or more
+This tutorial assumes that the reader is already familiar with one or
 more languages in the C family. Understanding of pointers and general
 memory management techniques will help.
 
@@ -1284,7 +1284,7 @@ distinct type. They support most of the same allocation options as
 vectors, though the string literal without a storage sigil (for
 example, `"foo"`) is treated differently than a comparable vector
 (`[foo]`).  Whereas plain vectors are stack-allocated fixed-length
-vectors, plain strings are region pointers to read-only
+vectors, plain strings are borrowed pointers to read-only (static)
 memory. All strings are immutable.
 
 ~~~
@@ -1947,7 +1947,7 @@ trait Printable {
 Traits may be implemented for specific types with [impls]. An impl
 that implements a trait includes the name of the trait at the start of
 the definition, as in the following impls of `Printable` for `int`
-and `~str`.
+and `&str`.
 
 [impls]: #functions-and-methods
 


### PR DESCRIPTION
The &str typo refers to the example code here:
https://github.com/cpeterso/rust/blob/master/doc/tutorial.md#declaring-and-implementing-traits
