### PR TITLE
rt: Remove dead code from schedule_task()

### DIFF
--- a/src/rt/rust_sched_loop.cpp
+++ b/src/rt/rust_sched_loop.cpp
@@ -100,6 +100,7 @@ rust_sched_loop::kill_all_tasks() {
 
 size_t
 rust_sched_loop::number_of_live_tasks() {
+    lock.must_have_lock();
     return running_tasks.length() + blocked_tasks.length();
 }
 
@@ -148,14 +149,10 @@ rust_sched_loop::release_task(rust_task *task) {
 rust_task *
 rust_sched_loop::schedule_task() {
     lock.must_have_lock();
-    assert(this);
     if (running_tasks.length() > 0) {
         size_t k = isaac_rand(&rctx);
-        // Look around for a runnable task, starting at k.
-        for(size_t j = 0; j < running_tasks.length(); ++j) {
-            size_t  i = (j + k) % running_tasks.length();
-            return (rust_task *)running_tasks[i];
-        }
+        size_t i = k % running_tasks.length();
+        return (rust_task *)running_tasks[i];
     }
     return NULL;
 }


### PR DESCRIPTION
1. `schedule_task()` had a useless loop left over from when the `running_tasks` list was searched linearly for a runnable task.
2. `schedule_task()` asserted `this` is not null. This is not a very useful assertion, especially since the function already dereferenced `this->lock`. :)
3. `number_of_live_tasks()` accessed `running_tasks` and `blocked_tasks` lists without a lock.
