### PR TITLE
Add some extra description for std::net

### DIFF
--- a/src/libstd/net.rs
+++ b/src/libstd/net.rs
@@ -8,7 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Top-level module for network-related functionality
+/*!
+Top-level module for network-related functionality.
+
+Basically, including this module gives you:
+
+* `net_tcp`
+* `net_ip`
+* `net_url`
+
+See each of those three modules for documentation on what they do.
+*/
 
 pub use tcp = net_tcp;
 pub use ip = net_ip;


### PR DESCRIPTION
I got confused at what 'top-level' meant.

I figured it was bad to link to the documentation directly, since this will become outdated with a new release; is there a good way to get `rustdoc` to do this?

HAPPY NEW YEAR :confetti_ball: 
