### PR TITLE
std: Constify the bytes sent to Sha1::input

### DIFF
--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -37,7 +37,7 @@ use core::vec;
 /// The SHA-1 interface
 trait Sha1 {
     /// Provide message input as bytes
-    fn input((&[u8]));
+    fn input((&[const u8]));
     /// Provide message input as string
     fn input_str((&str));
     /**
@@ -75,9 +75,9 @@ pub fn sha1() -> Sha1 {
          mut computed: bool,
          work_buf: @~[mut u32]};
 
-    fn add_input(st: &Sha1State, msg: &[u8]) {
+    fn add_input(st: &Sha1State, msg: &[const u8]) {
         assert (!st.computed);
-        for vec::each(msg) |element| {
+        for vec::each_const(msg) |element| {
             st.msg_block[st.msg_block_idx] = *element;
             st.msg_block_idx += 1u;
             st.len_low += 8u32;
@@ -243,7 +243,7 @@ pub fn sha1() -> Sha1 {
             self.h[4] = 0xC3D2E1F0u32;
             self.computed = false;
         }
-        fn input(msg: &[u8]) { add_input(&self, msg); }
+        fn input(msg: &[const u8]) { add_input(&self, msg); }
         fn input_str(msg: &str) {
             let bs = str::to_bytes(msg);
             add_input(&self, bs);


### PR DESCRIPTION
The Sha1 API takes the data to be hashed as &[u8]. This patch changes the type to &[const u8]. I'm not well-versed in the const semantics of Rust, but I imagine this is a reasonable thing to do, and this change makes the API compatible with to_bytes::IterBytes, which returns data in chunks of type &[const u8].

After making this change, 'make check' reports no failures for me.

(By the way, is there a reason for the double parentheses around the function argument lists in the Sha1 trait?)
