### PR TITLE
generate dll file name based on target os

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -82,7 +82,7 @@ fn is_test_ignored(config: config, testfile: &Path) -> bool {
     return found;
 
     fn xfail_target() -> ~str {
-        ~"xfail-" + os::sysname()
+        ~"xfail-" + str::from_slice(os::SYSNAME)
     }
 }
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -501,7 +501,8 @@ fn make_lib_name(config: config, auxfile: &Path, testfile: &Path) -> Path {
 }
 
 fn make_exe_name(config: config, testfile: &Path) -> Path {
-    Path(output_base_name(config, testfile).to_str() + os::exe_suffix())
+    Path(output_base_name(config, testfile).to_str() +
+            str::from_slice(os::EXE_SUFFIX))
 }
 
 fn make_run_args(config: config, _props: test_props, testfile: &Path) ->

--- a/src/libcargo/cargo.rc
+++ b/src/libcargo/cargo.rc
@@ -805,7 +805,7 @@ fn install_one_crate(c: &Cargo, path: &Path, cf: &Path) {
       Some(bp) => bp
     };
     let newv = os::list_dir_path(&buildpath);
-    let exec_suffix = os::exe_suffix();
+    let exec_suffix = str::from_slice(os::EXE_SUFFIX);
     for newv.each |ct| {
         if (exec_suffix != ~"" && str::ends_with(ct.to_str(),
                                                  exec_suffix)) ||

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -378,13 +378,7 @@ fn dup2(src: c_int, dst: c_int) -> c_int {
 
 
 pub fn dll_filename(base: &str) -> ~str {
-    return pre() + str::from_slice(base) + dll_suffix();
-
-    #[cfg(unix)]
-    fn pre() -> ~str { ~"lib" }
-
-    #[cfg(windows)]
-    fn pre() -> ~str { ~"" }
+    return dll_prefix() + str::from_slice(base) + dll_suffix();
 }
 
 
@@ -879,33 +873,49 @@ pub fn family() -> ~str { ~"unix" }
 
 #[cfg(windows)]
 pub fn family() -> ~str { ~"windows" }
+    
 
-#[cfg(target_os = "macos")]
 mod consts {
-    pub fn sysname() -> ~str { ~"macos" }
-    pub fn exe_suffix() -> ~str { ~"" }
-    pub fn dll_suffix() -> ~str { ~".dylib" }
-}
 
-#[cfg(target_os = "freebsd")]
-mod consts {
-    pub fn sysname() -> ~str { ~"freebsd" }
-    pub fn exe_suffix() -> ~str { ~"" }
-    pub fn dll_suffix() -> ~str { ~".so" }
-}
+    #[cfg(target_os = "macos")]
+    use os::consts::macos::*;
 
-#[cfg(target_os = "linux")]
-mod consts {
-    pub fn sysname() -> ~str { ~"linux" }
-    pub fn exe_suffix() -> ~str { ~"" }
-    pub fn dll_suffix() -> ~str { ~".so" }
-}
+    #[cfg(target_os = "freebsd")]
+    use os::consts::freebsd::*;
 
-#[cfg(target_os = "win32")]
-mod consts {
-    pub fn sysname() -> ~str { ~"win32" }
-    pub fn exe_suffix() -> ~str { ~".exe" }
-    pub fn dll_suffix() -> ~str { ~".dll" }
+    #[cfg(target_os = "linux")]
+    use os::consts::linux::*;
+
+    #[cfg(target_os = "win32")]
+    use os::consts::win32::*;
+
+    pub mod macos {
+        pub fn sysname() -> ~str { ~"macos" }
+        pub fn dll_prefix() -> ~str { ~"lib" }
+        pub fn dll_suffix() -> ~str { ~".dylib" }
+        pub fn exe_suffix() -> ~str { ~"" }
+    }
+
+    pub mod freebsd {
+        pub fn sysname() -> ~str { ~"freebsd" }
+        pub fn dll_prefix() -> ~str { ~"lib" }
+        pub fn dll_suffix() -> ~str { ~".so" }
+        pub fn exe_suffix() -> ~str { ~"" }
+    }
+
+    pub mod linux {
+        pub fn sysname() -> ~str { ~"linux" }
+        pub fn dll_prefix() -> ~str { ~"lib" }
+        pub fn dll_suffix() -> ~str { ~".so" }
+        pub fn exe_suffix() -> ~str { ~"" }
+    }
+    
+    pub mod win32 {
+        pub fn sysname() -> ~str { ~"win32" }
+        pub fn dll_prefix() -> ~str { ~"" }
+        pub fn dll_suffix() -> ~str { ~".dll" }
+        pub fn exe_suffix() -> ~str { ~".exe" }
+    }
 }
 
 #[cfg(target_arch = "x86")]

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -873,7 +873,7 @@ pub fn family() -> ~str { ~"unix" }
 
 #[cfg(windows)]
 pub fn family() -> ~str { ~"windows" }
-    
+
 
 mod consts {
 
@@ -909,7 +909,7 @@ mod consts {
         pub fn dll_suffix() -> ~str { ~".so" }
         pub fn exe_suffix() -> ~str { ~"" }
     }
-    
+
     pub mod win32 {
         pub fn sysname() -> ~str { ~"win32" }
         pub fn dll_prefix() -> ~str { ~"" }

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -378,7 +378,8 @@ fn dup2(src: c_int, dst: c_int) -> c_int {
 
 
 pub fn dll_filename(base: &str) -> ~str {
-    return dll_prefix() + str::from_slice(base) + dll_suffix();
+    return str::from_slice(DLL_PREFIX) + str::from_slice(base) +
+           str::from_slice(DLL_SUFFIX)
 }
 
 
@@ -868,14 +869,22 @@ extern {
     pub fn _NSGetArgv() -> ***c_char;
 }
 
-#[cfg(unix)]
-pub fn family() -> ~str { ~"unix" }
-
-#[cfg(windows)]
-pub fn family() -> ~str { ~"windows" }
-
-
 mod consts {
+
+    #[cfg(unix)]
+    use os::consts::unix::*;
+
+    #[cfg(windows)]
+    use os::consts::windows::*;
+
+    pub mod unix {
+        pub const FAMILY: &str = "unix";
+    }
+
+    pub mod windows {
+        pub const FAMILY: &str = "windows";
+    }
+
 
     #[cfg(target_os = "macos")]
     use os::consts::macos::*;
@@ -890,42 +899,53 @@ mod consts {
     use os::consts::win32::*;
 
     pub mod macos {
-        pub fn sysname() -> ~str { ~"macos" }
-        pub fn dll_prefix() -> ~str { ~"lib" }
-        pub fn dll_suffix() -> ~str { ~".dylib" }
-        pub fn exe_suffix() -> ~str { ~"" }
+        pub const SYSNAME: &str = "macos";
+        pub const DLL_PREFIX: &str = "lib";
+        pub const DLL_SUFFIX: &str = ".dylib";
+        pub const EXE_SUFFIX: &str = "";
     }
 
     pub mod freebsd {
-        pub fn sysname() -> ~str { ~"freebsd" }
-        pub fn dll_prefix() -> ~str { ~"lib" }
-        pub fn dll_suffix() -> ~str { ~".so" }
-        pub fn exe_suffix() -> ~str { ~"" }
+        pub const SYSNAME: &str = "freebsd";
+        pub const DLL_PREFIX: &str = "lib";
+        pub const DLL_SUFFIX: &str = ".so";
+        pub const EXE_SUFFIX: &str = "";
     }
 
     pub mod linux {
-        pub fn sysname() -> ~str { ~"linux" }
-        pub fn dll_prefix() -> ~str { ~"lib" }
-        pub fn dll_suffix() -> ~str { ~".so" }
-        pub fn exe_suffix() -> ~str { ~"" }
+        pub const SYSNAME: &str = "linux";
+        pub const DLL_PREFIX: &str = "lib";
+        pub const DLL_SUFFIX: &str = ".so";
+        pub const EXE_SUFFIX: &str = "";
     }
 
     pub mod win32 {
-        pub fn sysname() -> ~str { ~"win32" }
-        pub fn dll_prefix() -> ~str { ~"" }
-        pub fn dll_suffix() -> ~str { ~".dll" }
-        pub fn exe_suffix() -> ~str { ~".exe" }
+        pub const SYSNAME: &str = "win32";
+        pub const DLL_PREFIX: &str = "";
+        pub const DLL_SUFFIX: &str = ".dll";
+        pub const EXE_SUFFIX: &str = ".exe";
+    }
+
+
+    #[cfg(target_arch = "x86")]
+    use os::consts::x86::*;
+
+    #[cfg(target_arch = "x86_64")]
+    use os::consts::x86_64::*;
+
+    #[cfg(target_arch = "arm")]
+    use os::consts::arm::*;
+
+    pub mod x86 {
+        pub const ARCH: &str = "x86";
+    }
+    pub mod x86_64 {
+        pub const ARCH: &str = "x86_64";
+    }
+    pub mod arm {
+        pub const ARCH: &str = "arm";
     }
 }
-
-#[cfg(target_arch = "x86")]
-pub fn arch() -> ~str { ~"x86" }
-
-#[cfg(target_arch = "x86_64")]
-pub fn arch() -> ~str { ~"x86_64" }
-
-#[cfg(target_arch = "arm")]
-pub fn arch() -> str { ~"arm" }
 
 #[cfg(test)]
 #[allow(non_implicitly_copyable_typarams)]

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -667,16 +667,14 @@ fn mangle_internal_name_by_seq(ccx: @crate_ctxt, flav: ~str) -> ~str {
 
 fn output_dll_filename(os: session::os, lm: &link_meta) -> ~str {
     let libname = fmt!("%s-%s-%s", lm.name, lm.extras_hash, lm.vers);
-    match os {
-        session::os_macos =>
-            macos::dll_prefix() + libname + macos::dll_suffix(),
-        session::os_freebsd =>
-            freebsd::dll_prefix() + libname + macos::dll_suffix(),
-        session::os_linux =>
-            freebsd::dll_prefix() + libname + macos::dll_suffix(),
-        session::os_win32 =>
-            win32::dll_prefix() + libname + win32::dll_suffix(),
-    }
+    let (dll_prefix, dll_suffix) = match os {
+        session::os_win32 => (win32::DLL_PREFIX, win32::DLL_SUFFIX),
+        session::os_macos => (macos::DLL_PREFIX, macos::DLL_SUFFIX),
+        session::os_linux => (linux::DLL_PREFIX, linux::DLL_SUFFIX),
+        session::os_freebsd => (freebsd::DLL_PREFIX, freebsd::DLL_SUFFIX),
+    };
+    return str::from_slice(dll_prefix) + libname +
+           str::from_slice(dll_suffix);
 }
 
 // If the user wants an exe generated we need to invoke

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -40,6 +40,8 @@ use syntax::ast_map::{path, path_mod, path_name};
 use syntax::attr;
 use syntax::print::pprust;
 
+use core::os::consts::{macos, freebsd, linux, win32};
+
 enum output_type {
     output_type_none,
     output_type_bitcode,
@@ -662,6 +664,21 @@ fn mangle_internal_name_by_seq(ccx: @crate_ctxt, flav: ~str) -> ~str {
     return fmt!("%s_%u", flav, (ccx.names)(flav).repr);
 }
 
+
+fn output_dll_filename(os: session::os, lm: &link_meta) -> ~str {
+    let libname = fmt!("%s-%s-%s", lm.name, lm.extras_hash, lm.vers);
+    match os {
+        session::os_macos =>
+            macos::dll_prefix() + libname + macos::dll_suffix(),
+        session::os_freebsd =>
+            freebsd::dll_prefix() + libname + macos::dll_suffix(),
+        session::os_linux =>
+            freebsd::dll_prefix() + libname + macos::dll_suffix(),
+        session::os_win32 => 
+            win32::dll_prefix() + libname + win32::dll_suffix(),
+    }
+}
+
 // If the user wants an exe generated we need to invoke
 // cc to link the object file with some libs
 fn link_binary(sess: Session,
@@ -679,10 +696,9 @@ fn link_binary(sess: Session,
     }
 
     let output = if sess.building_library {
-        let long_libname =
-            os::dll_filename(fmt!("%s-%s-%s",
-                                  lm.name, lm.extras_hash, lm.vers));
-        debug!("link_meta.name:  %s", lm.name);
+        let long_libname = output_dll_filename(sess.targ_cfg.os, &lm);
+        
+		debug!("link_meta.name:  %s", lm.name);
         debug!("long_libname: %s", long_libname);
         debug!("out_filename: %s", out_filename.to_str());
         debug!("dirname(out_filename): %s", out_filename.dir_path().to_str());

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -674,7 +674,7 @@ fn output_dll_filename(os: session::os, lm: &link_meta) -> ~str {
             freebsd::dll_prefix() + libname + macos::dll_suffix(),
         session::os_linux =>
             freebsd::dll_prefix() + libname + macos::dll_suffix(),
-        session::os_win32 => 
+        session::os_win32 =>
             win32::dll_prefix() + libname + win32::dll_suffix(),
     }
 }
@@ -697,8 +697,7 @@ fn link_binary(sess: Session,
 
     let output = if sess.building_library {
         let long_libname = output_dll_filename(sess.targ_cfg.os, &lm);
-        
-		debug!("link_meta.name:  %s", lm.name);
+        debug!("link_meta.name:  %s", lm.name);
         debug!("long_libname: %s", long_libname);
         debug!("out_filename: %s", out_filename.to_str());
         debug!("dirname(out_filename): %s", out_filename.dir_path().to_str());

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -85,9 +85,9 @@ fn default_configuration(sess: Session, argv0: ~str, input: input) ->
     };
 
     return ~[ // Target bindings.
-         attr::mk_word_item(os::family()),
-         mk(~"target_os", os::sysname()),
-         mk(~"target_family", os::family()),
+         attr::mk_word_item(str::from_slice(os::FAMILY)),
+         mk(~"target_os", str::from_slice(os::SYSNAME)),
+         mk(~"target_family", str::from_slice(os::FAMILY)),
          mk(~"target_arch", arch),
          mk(~"target_word_size", wordsz),
          mk(~"target_libc", libc),

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -80,15 +80,15 @@ fn find_library_crate(cx: ctxt) -> Option<{ident: ~str, data: @~[u8]}> {
 
 fn libname(cx: ctxt) -> {prefix: ~str, suffix: ~str} {
     if cx.static { return {prefix: ~"lib", suffix: ~".rlib"}; }
-    match cx.os {
-      os_win32 => return {prefix: win32::dll_prefix(),
-                          suffix: win32::dll_suffix()},
-      os_macos => return {prefix: macos::dll_prefix(),
-                          suffix: macos::dll_suffix()},
-      os_linux => return {prefix: linux::dll_prefix(),
-                          suffix: linux::dll_suffix()},
-      os_freebsd => return {prefix: freebsd::dll_prefix(),
-                            suffix: freebsd::dll_suffix()}
+    let (dll_prefix, dll_suffix) = match cx.os {
+        os_win32 => (win32::DLL_PREFIX, win32::DLL_SUFFIX),
+        os_macos => (macos::DLL_PREFIX, macos::DLL_SUFFIX),
+        os_linux => (linux::DLL_PREFIX, linux::DLL_SUFFIX),
+        os_freebsd => (freebsd::DLL_PREFIX, freebsd::DLL_SUFFIX),
+    };
+    return {
+        prefix: str::from_slice(dll_prefix),
+        suffix: str::from_slice(dll_suffix)
     }
 }
 

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -81,13 +81,13 @@ fn find_library_crate(cx: ctxt) -> Option<{ident: ~str, data: @~[u8]}> {
 fn libname(cx: ctxt) -> {prefix: ~str, suffix: ~str} {
     if cx.static { return {prefix: ~"lib", suffix: ~".rlib"}; }
     match cx.os {
-      os_win32 => return {prefix: win32::dll_prefix(), 
+      os_win32 => return {prefix: win32::dll_prefix(),
                           suffix: win32::dll_suffix()},
       os_macos => return {prefix: macos::dll_prefix(),
                           suffix: macos::dll_suffix()},
-      os_linux => return {prefix: linux::dll_prefix(), 
+      os_linux => return {prefix: linux::dll_prefix(),
                           suffix: linux::dll_suffix()},
-      os_freebsd => return {prefix: freebsd::dll_prefix(), 
+      os_freebsd => return {prefix: freebsd::dll_prefix(),
                             suffix: freebsd::dll_suffix()}
     }
 }

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -31,6 +31,8 @@ use core::str;
 use core::uint;
 use core::vec;
 
+use core::os::consts::{macos, freebsd, linux, win32};
+
 export os;
 export os_macos, os_win32, os_linux, os_freebsd;
 export ctxt;
@@ -79,10 +81,14 @@ fn find_library_crate(cx: ctxt) -> Option<{ident: ~str, data: @~[u8]}> {
 fn libname(cx: ctxt) -> {prefix: ~str, suffix: ~str} {
     if cx.static { return {prefix: ~"lib", suffix: ~".rlib"}; }
     match cx.os {
-      os_win32 => return {prefix: ~"", suffix: ~".dll"},
-      os_macos => return {prefix: ~"lib", suffix: ~".dylib"},
-      os_linux => return {prefix: ~"lib", suffix: ~".so"},
-      os_freebsd => return {prefix: ~"lib", suffix: ~".so"}
+      os_win32 => return {prefix: win32::dll_prefix(), 
+                          suffix: win32::dll_suffix()},
+      os_macos => return {prefix: macos::dll_prefix(),
+                          suffix: macos::dll_suffix()},
+      os_linux => return {prefix: linux::dll_prefix(), 
+                          suffix: linux::dll_suffix()},
+      os_freebsd => return {prefix: freebsd::dll_prefix(), 
+                            suffix: freebsd::dll_suffix()}
     }
 }
 


### PR DESCRIPTION
Fix for #4119.

generate dll file name base on the given target os, using `core::os::consts` which now contains constant values for all of the supported targets.

the functions on `core::os::consts` are changed to constant strings
for example, `fn sysname() -> ~str { ~"linux" }` will be `const SYSNAME: &str = "linux"`
