### PR TITLE
fix build for when 'python' is python3

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -152,7 +152,7 @@ else
 
 doc/rust.g: rust.md $(S)src/etc/extract_grammar.py
 	@$(call E, extract_grammar: $@)
-	$(Q)$(S)src/etc/extract_grammar.py $< >$@
+	$(Q)$(CFG_PYTHON) $(S)src/etc/extract_grammar.py $< >$@
 
 verify-grammar: doc/rust.g
 	@$(call E, LLnextgen: $<)

--- a/mk/snap.mk
+++ b/mk/snap.mk
@@ -14,10 +14,10 @@ define DEF_SNAP_FOR_STAGE_H
 
 ifdef CFG_INSTALL_SNAP
 snap-stage$(1)-H-$(2): $$(HSREQ$(1)_H_$(2))
-	$(S)src/etc/make-snapshot.py stage$(1) $(2) install
+	$(CFG_PYTHON) $(S)src/etc/make-snapshot.py stage$(1) $(2) install
 else
 snap-stage$(1)-H-$(2): $$(HSREQ$(1)_H_$(2))
-	$(S)src/etc/make-snapshot.py stage$(1) $(2)
+	$(CFG_PYTHON) $(S)src/etc/make-snapshot.py stage$(1) $(2)
 endif
 
 endef

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -11,7 +11,7 @@ $(HBIN0_H_$(CFG_HOST_TRIPLE))/rustc$(X):		\
 ifdef CFG_ENABLE_LOCAL_RUST
 	$(Q)$(S)src/etc/local_stage0.sh $(CFG_HOST_TRIPLE) $(CFG_LOCAL_RUST_ROOT)
 else 
-	$(Q)$(S)src/etc/get-snapshot.py $(CFG_HOST_TRIPLE) $(SNAPSHOT_FILE)
+	$(Q)$(CFG_PYTHON) $(S)src/etc/get-snapshot.py $(CFG_HOST_TRIPLE) $(SNAPSHOT_FILE)
 ifdef CFG_ENABLE_PAX_FLAGS
 	@$(call E, apply PaX flags: $@)
 	@"$(CFG_PAXCTL)" -cm "$@"

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -701,7 +701,7 @@ tmp/$(FT).rc tmp/$(FT_DRIVER).rs: \
 		$(RPASS_TESTS) \
 		$(S)src/etc/combine-tests.py
 	@$(call E, check: building combined stage2 test runner)
-	$(Q)$(S)src/etc/combine-tests.py
+	$(Q)$(CFG_PYTHON) $(S)src/etc/combine-tests.py
 
 define DEF_CHECK_FAST_FOR_T_H
 # $(1) unused

--- a/src/etc/sugarise-doc-comments.py
+++ b/src/etc/sugarise-doc-comments.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #
 # this script attempts to turn doc comment attributes (#[doc = "..."])


### PR DESCRIPTION
There's also a bonus fix of a shebang that was inconsistent with the others.

It would be really nice if OS X and Debian included the python2 symlink per [PEP 394](http://www.python.org/dev/peps/pep-0394/), but sadly that's not the case. The nasty thing about this bug is that it's going to keep coming back as long as those files have a shebang that works on some systems but not others. Testing for this bug is as simple as making the `mk/*.py` files non-executable before building - is that something that could be done on the buildbot?
