### PR TITLE
Make either::{partition, flip, to_result} take their arguments by-value

### DIFF
--- a/src/libcore/either.rs
+++ b/src/libcore/either.rs
@@ -69,8 +69,7 @@ pub fn rights<T, U: Copy>(eithers: &[Either<T, U>]) -> ~[U] {
     }
 }
 
-// XXX bad copies. take arg by val
-pub fn partition<T: Copy, U: Copy>(eithers: &[Either<T, U>])
+pub fn partition<T, U>(eithers: ~[Either<T, U>])
     -> (~[T], ~[U]) {
     /*!
      * Extracts from a vector of either all the left values and right values
@@ -81,27 +80,25 @@ pub fn partition<T: Copy, U: Copy>(eithers: &[Either<T, U>])
 
     let mut lefts: ~[T] = ~[];
     let mut rights: ~[U] = ~[];
-    for vec::each(eithers) |elt| {
-        match *elt {
-          Left(copy l) => lefts.push(l),
-          Right(copy r) => rights.push(r)
+    do vec::consume(eithers) |_i, elt| {
+        match elt {
+          Left(l) => lefts.push(l),
+          Right(r) => rights.push(r)
         }
     }
     return (move lefts, move rights);
 }
 
-// XXX bad copies
-pub pure fn flip<T: Copy, U: Copy>(eith: &Either<T, U>) -> Either<U, T> {
+pub pure fn flip<T, U>(eith: Either<T, U>) -> Either<U, T> {
     //! Flips between left and right of a given either
 
-    match *eith {
-      Right(copy r) => Left(r),
-      Left(copy l) => Right(l)
+    match eith {
+      Right(r) => Left(r),
+      Left(l) => Right(l)
     }
 }
 
-// XXX bad copies
-pub pure fn to_result<T: Copy, U: Copy>(eith: &Either<T, U>)
+pub pure fn to_result<T, U>(eith: Either<T, U>)
     -> Result<U, T> {
     /*!
      * Converts either::t to a result::t
@@ -110,9 +107,9 @@ pub pure fn to_result<T: Copy, U: Copy>(eith: &Either<T, U>)
      * an ok result, and the "left" choice a fail
      */
 
-    match *eith {
-      Right(copy r) => result::Ok(r),
-      Left(copy l) => result::Err(l)
+    match eith {
+      Right(r) => result::Ok(r),
+      Left(l) => result::Err(l)
     }
 }
 
@@ -128,7 +125,6 @@ pub pure fn is_right<T, U>(eith: &Either<T, U>) -> bool {
     match *eith { Right(_) => true, _ => false }
 }
 
-// tjc: fix the next two after a snapshot
 pub pure fn unwrap_left<T,U>(eith: Either<T,U>) -> T {
     //! Retrieves the value in the left branch. Fails if the either is Right.
 


### PR DESCRIPTION
r? @pcwalton - Addresses an XXX
