### PR TITLE
 librustc: Implement #[disable_unwinding] and use it in librustc to avoid falling off FastISel so much

### DIFF
--- a/src/libcargo/pgp.rs
+++ b/src/libcargo/pgp.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use core::os;
+use core::path::Path;
 use core::run;
 
 fn gpgv(args: ~[~str]) -> { status: int, out: ~str, err: ~str } {

--- a/src/libcore/at_vec.rs
+++ b/src/libcore/at_vec.rs
@@ -15,8 +15,10 @@
 #[forbid(deprecated_pattern)];
 
 use cast::transmute;
+use kinds::Copy;
 use iter;
 use libc;
+use option::Option;
 use ptr::addr_of;
 use sys;
 use uint;
@@ -150,6 +152,10 @@ pub pure fn from_elem<T: Copy>(n_elts: uint, t: T) -> @[T] {
 
 #[cfg(notest)]
 pub mod traits {
+    use at_vec::append;
+    use kinds::Copy;
+    use ops::Add;
+
     pub impl<T: Copy> @[T] : Add<&[const T],@[T]> {
         #[inline(always)]
         pure fn add(&self, rhs: & &self/[const T]) -> @[T] {
@@ -162,8 +168,10 @@ pub mod traits {
 pub mod traits {}
 
 pub mod raw {
-    use at_vec::{rusti, rustrt};
+    use at_vec::{capacity, rusti, rustrt};
+    use cast::transmute;
     use libc;
+    use ptr::addr_of;
     use ptr;
     use sys;
     use uint;

--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -19,6 +19,7 @@
 use bool;
 use cmp;
 use cmp::Eq;
+use option::{None, Option, Some};
 
 /// Negation / inverse
 pub pure fn not(v: bool) -> bool { !v }

--- a/src/libcore/cast.rs
+++ b/src/libcore/cast.rs
@@ -108,6 +108,8 @@ pub unsafe fn copy_lifetime_vec<S,T>(_ptr: &a/[S], ptr: &T) -> &a/T {
 
 #[cfg(test)]
 pub mod tests {
+    use cast::{bump_box_refcount, reinterpret_cast, transmute};
+
     #[test]
     pub fn test_reinterpret_cast() {
         assert 1u == unsafe { reinterpret_cast(&1) };

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -16,6 +16,7 @@
 
 use char;
 use cmp::Eq;
+use option::{None, Option, Some};
 use str;
 use u32;
 use uint;

--- a/src/libcore/condition.rs
+++ b/src/libcore/condition.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use prelude::*;
 use task;
 
 // helper for transmutation, shown below.

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -53,6 +53,9 @@ Implicitly, all crates behave as if they included the following prologue:
 #[warn(vecs_implicitly_copyable)];
 #[deny(non_camel_case_types)];
 
+/* The Prelude. */
+
+pub mod prelude;
 
 /* Primitive types */
 
@@ -243,6 +246,8 @@ pub mod core {
 
     pub use cmp;
     pub use condition;
+    pub use option;
+    pub use kinds;
 }
 
 

--- a/src/libcore/dlist.rs
+++ b/src/libcore/dlist.rs
@@ -22,7 +22,9 @@ Do not use ==, !=, <, etc on doubly-linked lists -- it may not terminate.
 #[forbid(deprecated_mode)];
 #[forbid(deprecated_pattern)];
 
+use kinds::Copy;
 use managed;
+use option::{None, Option, Some};
 use option;
 use vec;
 
@@ -94,13 +96,13 @@ impl<T> DListNode<T> {
 }
 
 /// Creates a new dlist node with the given data.
-pure fn new_dlist_node<T>(data: T) -> DListNode<T> {
+pub pure fn new_dlist_node<T>(data: T) -> DListNode<T> {
     DListNode(@{data: move data, mut linked: false,
                  mut prev: None, mut next: None})
 }
 
 /// Creates a new, empty dlist.
-pure fn DList<T>() -> DList<T> {
+pub pure fn DList<T>() -> DList<T> {
     DList_(@{mut size: 0, mut hd: None, mut tl: None})
 }
 
@@ -120,7 +122,7 @@ pub fn from_vec<T: Copy>(vec: &[T]) -> DList<T> {
 
 /// Produce a list from a list of lists, leaving no elements behind in the
 /// input. O(number of sub-lists).
-fn concat<T>(lists: DList<DList<T>>) -> DList<T> {
+pub fn concat<T>(lists: DList<DList<T>>) -> DList<T> {
     let result = DList();
     while !lists.is_empty() {
         result.append(lists.pop().get());
@@ -474,7 +476,9 @@ impl<T: Copy> DList<T> {
 mod tests {
     #[legacy_exports];
 
+    use dlist::{DList, concat, from_vec, new_dlist_node};
     use iter;
+    use option::{None, Some};
     use vec;
 
     #[test]

--- a/src/libcore/dvec.rs
+++ b/src/libcore/dvec.rs
@@ -25,6 +25,7 @@ Note that recursive use is not permitted.
 
 use cast;
 use cast::reinterpret_cast;
+use prelude::*;
 use ptr::null;
 use vec;
 

--- a/src/libcore/either.rs
+++ b/src/libcore/either.rs
@@ -14,10 +14,11 @@
 
 //! A type that represents one of two alternatives
 
-use cmp;
 use cmp::Eq;
-use result;
+use cmp;
+use kinds::Copy;
 use result::Result;
+use result;
 use vec;
 
 /// The either type

--- a/src/libcore/extfmt.rs
+++ b/src/libcore/extfmt.rs
@@ -82,6 +82,7 @@ debug!("hello, %s!", "world");
 
 use cmp::Eq;
 use option::{Some, None};
+use prelude::*;
 use str;
 
 /*
@@ -99,6 +100,7 @@ use str;
 #[doc(hidden)]
 pub mod ct {
     use char;
+    use prelude::*;
     use str;
     use vec;
 

--- a/src/libcore/float.rs
+++ b/src/libcore/float.rs
@@ -31,6 +31,7 @@ use cmp;
 use f64;
 use num;
 use num::Num::from_int;
+use option::{None, Option, Some};
 use str;
 use uint;
 

--- a/src/libcore/gc.rs
+++ b/src/libcore/gc.rs
@@ -42,6 +42,7 @@ with destructors.
 use cast;
 use io;
 use libc::{size_t, uintptr_t};
+use option::{None, Option, Some};
 use ptr;
 use send_map::linear::LinearMap;
 use stackwalk;

--- a/src/libcore/int-template.rs
+++ b/src/libcore/int-template.rs
@@ -21,6 +21,7 @@ use from_str::FromStr;
 use iter;
 use num;
 use num::Num::from_int;
+use prelude::*;
 use str;
 use uint;
 use vec;

--- a/src/libcore/int-template/int.rs
+++ b/src/libcore/int-template/int.rs
@@ -50,8 +50,8 @@ mod inst {
 
     #[test]
     fn test_overflows() {
-        assert (max_value > 0);
-        assert (min_value <= 0);
-        assert (min_value + max_value + 1 == 0);
+        assert (::int::max_value > 0);
+        assert (::int::min_value <= 0);
+        assert (::int::min_value + ::int::max_value + 1 == 0);
     }
 }

--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -28,6 +28,7 @@ use libc::consts::os::posix88::*;
 use libc::consts::os::extra::*;
 use option;
 use os;
+use prelude::*;
 use ptr;
 use result;
 use str;
@@ -35,7 +36,7 @@ use uint;
 use vec;
 
 #[allow(non_camel_case_types)] // not sure what to do about this
-type fd_t = c_int;
+pub type fd_t = c_int;
 
 #[abi = "cdecl"]
 extern mod rustrt {
@@ -452,12 +453,12 @@ impl<T: Reader, C> {base: T, cleanup: C}: Reader {
     fn tell(&self) -> uint { self.base.tell() }
 }
 
-struct FILERes {
+pub struct FILERes {
     f: *libc::FILE,
     drop { libc::fclose(self.f); }
 }
 
-fn FILERes(f: *libc::FILE) -> FILERes {
+pub fn FILERes(f: *libc::FILE) -> FILERes {
     FILERes {
         f: f
     }
@@ -629,12 +630,12 @@ impl fd_t: Writer {
     }
 }
 
-struct FdRes {
+pub struct FdRes {
     fd: fd_t,
     drop { libc::close(self.fd); }
 }
 
-fn FdRes(fd: fd_t) -> FdRes {
+pub fn FdRes(fd: fd_t) -> FdRes {
     FdRes {
         fd: fd
     }
@@ -1028,7 +1029,10 @@ pub fn read_whole_file(file: &Path) -> Result<~[u8], ~str> {
 // fsync related
 
 pub mod fsync {
+    use io::{FILERes, FdRes, fd_t};
+    use kinds::Copy;
     use libc;
+    use option::Option;
     use option;
     use os;
 
@@ -1113,8 +1117,11 @@ pub mod fsync {
 
 #[cfg(test)]
 mod tests {
+    use debug;
     use i32;
+    use io::{BytesWriter, SeekCur, SeekEnd, SeekSet};
     use io;
+    use path::Path;
     use result;
     use str;
     use u64;

--- a/src/libcore/iter-trait.rs
+++ b/src/libcore/iter-trait.rs
@@ -16,7 +16,10 @@
 #[forbid(deprecated_pattern)];
 
 use cmp::{Eq, Ord};
+use iter::BaseIter;
 use iter;
+use kinds::Copy;
+use option::Option;
 
 use self::inst::{IMPL_T, EACH, SIZE_HINT};
 

--- a/src/libcore/iter-trait/dlist.rs
+++ b/src/libcore/iter-trait/dlist.rs
@@ -11,6 +11,7 @@
 mod inst {
     use dlist;
     use managed;
+    use option::{Option, Some};
     use option;
 
     #[allow(non_camel_case_types)]

--- a/src/libcore/iter-trait/dvec.rs
+++ b/src/libcore/iter-trait/dvec.rs
@@ -10,6 +10,7 @@
 
 mod inst {
     use dvec;
+    use option::{Option, Some};
 
     #[allow(non_camel_case_types)]
     pub type IMPL_T<A> = dvec::DVec<A>;

--- a/src/libcore/iter-trait/option.rs
+++ b/src/libcore/iter-trait/option.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 mod inst {
+    use option::{None, Option, Some};
+
     #[allow(non_camel_case_types)]
     pub type IMPL_T<A> = Option<A>;
 

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -18,6 +18,8 @@ The iteration traits and common implementation
 #[forbid(deprecated_pattern)];
 
 use cmp::{Eq, Ord};
+use kinds::Copy;
+use option::{None, Option, Some};
 use vec;
 
 /// A function used to initialize the elements of a sequence

--- a/src/libcore/libc.rs
+++ b/src/libcore/libc.rs
@@ -164,7 +164,7 @@ pub use libc::funcs::posix88::unistd::{getpid, isatty, lseek, pipe, read};
 pub use libc::funcs::posix88::unistd::{rmdir, unlink, write};
 
 
-mod types {
+pub mod types {
 
     // Types tend to vary *per architecture* so we pull their definitions out
     // into this module.
@@ -230,6 +230,8 @@ mod types {
                 pub type uintptr_t = uint;
             }
             pub mod posix88 {
+                use prelude::*;
+
                 pub type off_t = i32;
                 pub type dev_t = u64;
                 pub type ino_t = u32;
@@ -528,33 +530,6 @@ mod types {
     pub mod os {
         pub mod common {
             pub mod posix01 {
-                pub type nlink_t = u16;
-                pub type blksize_t = i64;
-                pub type blkcnt_t = i32;
-                pub struct stat {
-                    st_dev: dev_t,
-                    st_mode: mode_t,
-                    st_nlink: nlink_t,
-                    st_ino: ino_t,
-                    st_uid: uid_t,
-                    st_gid: gid_t,
-                    st_rdev: dev_t,
-                    st_atime: time_t,
-                    st_atime_nsec: c_long,
-                    st_mtime: time_t,
-                    st_mtime_nsec: c_long,
-                    st_ctime: time_t,
-                    st_ctime_nsec: c_long,
-                    st_birthtime: time_t,
-                    st_birthtime_nsec: c_long,
-                    st_size: off_t,
-                    st_blocks: blkcnt_t,
-                    st_blksize: blksize_t,
-                    st_flags: uint32_t,
-                    st_gen: uint32_t,
-                    st_lspare: int32_t,
-                    st_qspare: [int64_t * 2],
-                }
             }
         }
 
@@ -596,6 +571,34 @@ mod types {
                 pub type ssize_t = i32;
             }
             pub mod posix01 {
+                pub type nlink_t = u16;
+                pub type blksize_t = i64;
+                pub type blkcnt_t = i32;
+
+                pub struct stat {
+                    st_dev: dev_t,
+                    st_mode: mode_t,
+                    st_nlink: nlink_t,
+                    st_ino: ino_t,
+                    st_uid: uid_t,
+                    st_gid: gid_t,
+                    st_rdev: dev_t,
+                    st_atime: time_t,
+                    st_atime_nsec: c_long,
+                    st_mtime: time_t,
+                    st_mtime_nsec: c_long,
+                    st_ctime: time_t,
+                    st_ctime_nsec: c_long,
+                    st_birthtime: time_t,
+                    st_birthtime_nsec: c_long,
+                    st_size: off_t,
+                    st_blocks: blkcnt_t,
+                    st_blksize: blksize_t,
+                    st_flags: uint32_t,
+                    st_gen: uint32_t,
+                    st_lspare: int32_t,
+                    st_qspare: [int64_t * 2],
+                }
             }
             pub mod posix08 {
             }
@@ -643,6 +646,40 @@ mod types {
                 pub type ssize_t = i64;
             }
             pub mod posix01 {
+                use libc::types::common::c99::{int32_t, int64_t};
+                use libc::types::common::c99::{uint32_t};
+                use libc::types::os::arch::c95::{c_long, time_t};
+                use libc::types::os::arch::posix88::{dev_t, gid_t, ino_t};
+                use libc::types::os::arch::posix88::{mode_t, off_t, uid_t};
+
+                pub type nlink_t = u16;
+                pub type blksize_t = i64;
+                pub type blkcnt_t = i32;
+
+                pub struct stat {
+                    st_dev: dev_t,
+                    st_mode: mode_t,
+                    st_nlink: nlink_t,
+                    st_ino: ino_t,
+                    st_uid: uid_t,
+                    st_gid: gid_t,
+                    st_rdev: dev_t,
+                    st_atime: time_t,
+                    st_atime_nsec: c_long,
+                    st_mtime: time_t,
+                    st_mtime_nsec: c_long,
+                    st_ctime: time_t,
+                    st_ctime_nsec: c_long,
+                    st_birthtime: time_t,
+                    st_birthtime_nsec: c_long,
+                    st_size: off_t,
+                    st_blocks: blkcnt_t,
+                    st_blksize: blksize_t,
+                    st_flags: uint32_t,
+                    st_gen: uint32_t,
+                    st_lspare: int32_t,
+                    st_qspare: [int64_t * 2],
+                }
             }
             pub mod posix08 {
             }
@@ -934,6 +971,11 @@ pub mod funcs {
     // or anything. The same is not true of POSIX.
 
     pub mod c95 {
+        use libc::types::common::c95::{FILE, c_void, fpos_t};
+        use libc::types::common::posix88::dirent_t;
+        use libc::types::os::arch::c95::{c_char, c_double, c_int, c_long};
+        use libc::types::os::arch::c95::{c_uint, c_ulong, c_void, size_t};
+
         #[nolink]
         #[abi = "cdecl"]
         pub extern mod ctype {
@@ -1174,6 +1216,14 @@ pub mod funcs {
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "freebsd")]
     pub mod posix88 {
+        use libc::types::common::c95::{FILE, c_void};
+        use libc::types::common::posix88::{DIR, dirent_t};
+        use libc::types::os::arch::c95::{c_char, c_int, c_long, c_uint};
+        use libc::types::os::arch::c95::{size_t};
+        use libc::types::os::arch::posix01::stat;
+        use libc::types::os::arch::posix88::{gid_t, mode_t, off_t, pid_t};
+        use libc::types::os::arch::posix88::{ssize_t, uid_t};
+
         #[nolink]
         #[abi = "cdecl"]
         pub extern mod stat_ {
@@ -1282,6 +1332,10 @@ pub mod funcs {
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "freebsd")]
     pub mod posix01 {
+        use libc::types::os::arch::c95::{c_char, c_int, size_t};
+        use libc::types::os::arch::posix01::stat;
+        use libc::types::os::arch::posix88::{pid_t, ssize_t};
+
         #[nolink]
         #[abi = "cdecl"]
         pub extern mod stat_ {
@@ -1349,6 +1403,9 @@ pub mod funcs {
     #[nolink]
     #[abi = "cdecl"]
     pub extern mod bsd44 {
+        use libc::types::common::c95::{c_void};
+        use libc::types::os::arch::c95::{c_char, c_int, c_uint, size_t};
+
         fn sysctl(name: *c_int, namelen: c_uint,
                   oldp: *mut c_void, oldlenp: *mut size_t,
                   newp: *c_void, newlen: size_t) -> c_int;
@@ -1371,6 +1428,8 @@ pub mod funcs {
     #[nolink]
     #[abi = "cdecl"]
     pub extern mod extra {
+        use libc::types::os::arch::c95::{c_char, c_int};
+
         fn _NSGetExecutablePath(buf: *mut c_char,
                                 bufsize: *mut u32) -> c_int;
     }

--- a/src/libcore/managed.rs
+++ b/src/libcore/managed.rs
@@ -15,10 +15,12 @@
 #[forbid(deprecated_pattern)];
 
 use cmp::{Eq, Ord};
-use intrinsic::TyDesc;
+use prelude::*;
 use ptr;
 
 pub mod raw {
+    use intrinsic::TyDesc;
+
     pub struct BoxHeaderRepr {
         ref_count: uint,
         type_desc: *TyDesc,

--- a/src/libcore/oldcomm.rs
+++ b/src/libcore/oldcomm.rs
@@ -52,11 +52,13 @@ use either::Either;
 use iter;
 use libc;
 use libc::size_t;
+use prelude::*;
 use ptr;
 use result;
 use sys;
 use task;
 use vec;
+
 // After snapshot, change p2::addr_of => addr_of
 
 /**

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -45,6 +45,7 @@ let unwrapped_msg = match move msg {
 #[forbid(deprecated_pattern)];
 
 use cmp::Eq;
+use kinds::Copy;
 use option;
 use ptr;
 use str;

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -38,6 +38,7 @@ use libc::{c_char, c_void, c_int, c_uint, size_t, ssize_t};
 use libc::{mode_t, pid_t, FILE};
 use option;
 use option::{Some, None};
+use prelude::*;
 use private;
 use ptr;
 use str;
@@ -140,6 +141,7 @@ mod global_env {
     use either;
     use libc;
     use oldcomm;
+    use option::Option;
     use private;
     use str;
     use task;
@@ -213,6 +215,7 @@ mod global_env {
     mod impl_ {
         use cast;
         use libc;
+        use option::Option;
         use option;
         use ptr;
         use str;
@@ -781,7 +784,7 @@ unsafe fn load_argc_and_argv(argc: c_int, argv: **c_char) -> ~[~str] {
  * Returns a list of the command line arguments.
  */
 #[cfg(target_os = "macos")]
-fn real_args() -> ~[~str] {
+pub fn real_args() -> ~[~str] {
     unsafe {
         let (argc, argv) = (*_NSGetArgc() as c_int,
                             *_NSGetArgv() as **c_char);
@@ -791,7 +794,7 @@ fn real_args() -> ~[~str] {
 
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "freebsd")]
-fn real_args() -> ~[~str] {
+pub fn real_args() -> ~[~str] {
     unsafe {
         let argc = rustrt::rust_get_argc();
         let argv = rustrt::rust_get_argv();
@@ -800,7 +803,7 @@ fn real_args() -> ~[~str] {
 }
 
 #[cfg(windows)]
-fn real_args() -> ~[~str] {
+pub fn real_args() -> ~[~str] {
     let mut nArgs: c_int = 0;
     let lpArgCount = ptr::to_mut_unsafe_ptr(&mut nArgs);
     let lpCmdLine = GetCommandLineW();
@@ -920,9 +923,15 @@ pub fn arch() -> str { ~"arm" }
 #[cfg(test)]
 #[allow(non_implicitly_copyable_typarams)]
 mod tests {
+    use debug;
+    use libc::{c_int, c_void, size_t};
     use libc;
+    use option::{None, Option, Some};
     use option;
+    use os::{as_c_charp, env, getcwd, getenv, make_absolute, real_args};
+    use os::{remove_file, setenv}; 
     use os;
+    use path::Path;
     use rand;
     use run;
     use str;
@@ -930,7 +939,7 @@ mod tests {
 
     #[test]
     pub fn last_os_error() {
-        log(debug, last_os_error());
+        log(debug, os::last_os_error());
     }
 
     #[test]

--- a/src/libcore/path.rs
+++ b/src/libcore/path.rs
@@ -20,8 +20,10 @@ Cross-platform file path handling
 
 use cmp::Eq;
 use libc;
+use option::{None, Option, Some};
 use ptr;
 use str;
+use to_str::ToStr;
 
 #[deriving_eq]
 pub struct WindowsPath {
@@ -750,6 +752,8 @@ pub pure fn normalize(components: &[~str]) -> ~[~str] {
 // Various windows helpers, and tests for the impl.
 pub mod windows {
     use libc;
+    use option::{None, Option, Some};
+    use to_str::ToStr;
 
     #[inline(always)]
     pub pure fn is_sep(u: u8) -> bool {
@@ -792,7 +796,8 @@ pub mod windows {
 
 #[cfg(test)]
 mod tests {
-    use path::windows;
+    use option::{None, Some};
+    use path::{PosixPath, WindowsPath, windows};
     use str;
 
     #[test]

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -90,11 +90,13 @@ bounded and unbounded protocols allows for less code duplication.
 use cmp::Eq;
 use cast::{forget, reinterpret_cast, transmute};
 use either::{Either, Left, Right};
+use kinds::Owned;
 use libc;
 use option;
 use option::unwrap;
 use pipes;
 use ptr;
+use prelude::*;
 use private;
 use task;
 use vec;
@@ -1238,6 +1240,8 @@ pub fn try_send_one<T: Owned>(chan: ChanOne<T>, data: T)
 }
 
 pub mod rt {
+    use option::{None, Option, Some};
+
     // These are used to hide the option constructors from the
     // compiler because their names are changing
     pub fn make_some<T>(val: T) -> Option<T> { Some(move val) }
@@ -1246,7 +1250,8 @@ pub mod rt {
 
 #[cfg(test)]
 pub mod test {
-    use pipes::oneshot;
+    use either::{Either, Left, Right};
+    use pipes::{Chan, Port, oneshot, recv_one, stream};
     use pipes;
 
     #[test]

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -1,0 +1,92 @@
+// This file is imported into every module by default.
+
+/* Reexported core operators */
+
+pub use kinds::{Const, Copy, Owned, Durable};
+pub use ops::{Drop};
+pub use ops::{Add, Sub, Mul, Div, Modulo, Neg};
+pub use ops::{BitAnd, BitOr, BitXor};
+pub use ops::{Shl, Shr, Index};
+pub use option::{Option, Some, None};
+pub use result::{Result, Ok, Err};
+
+/* Reexported types and traits */
+
+pub use path::Path;
+pub use path::GenericPath;
+pub use path::WindowsPath;
+pub use path::PosixPath;
+
+pub use tuple::{CopyableTuple, ImmutableTuple, ExtendedTupleOps};
+pub use str::{StrSlice, Trimmable};
+pub use vec::{ConstVector, CopyableVector, ImmutableVector};
+pub use vec::{ImmutableEqVector, ImmutableCopyableVector};
+pub use vec::{MutableVector, MutableCopyableVector};
+pub use iter::{BaseIter, ExtendedIter, EqIter, CopyableIter};
+pub use iter::{CopyableOrderedIter, CopyableNonstrictIter, Times};
+
+pub use num::Num;
+pub use ptr::Ptr;
+pub use to_str::ToStr;
+pub use clone::Clone;
+
+pub use cmp::{Eq, Ord};
+pub use hash::Hash;
+pub use to_bytes::IterBytes;
+
+/* Reexported modules */
+
+pub use at_vec;
+pub use cast;
+pub use char;
+pub use cmp;
+pub use dvec;
+pub use either;
+pub use extfmt;
+pub use f32;
+pub use f64;
+pub use float;
+pub use i16;
+pub use i32;
+pub use i64;
+pub use i8;
+pub use int;
+pub use io;
+pub use iter;
+pub use libc;
+pub use num;
+pub use oldcomm;
+pub use ops;
+pub use option;
+pub use os;
+pub use path;
+pub use pipes;
+pub use private;
+pub use ptr;
+pub use rand;
+pub use result;
+pub use str;
+pub use sys;
+pub use task;
+pub use to_str;
+pub use u16;
+pub use u32;
+pub use u64;
+pub use u8;
+pub use uint;
+pub use vec;
+
+/*
+ * Export the log levels as global constants. Higher levels mean
+ * more-verbosity. Error is the bottom level, default logging level is
+ * warn-and-below.
+ */
+
+/// The error log level
+pub const error : u32 = 1_u32;
+/// The warning log level
+pub const warn : u32 = 2_u32;
+/// The info log level
+pub const info : u32 = 3_u32;
+/// The debug log level
+pub const debug : u32 = 4_u32;

--- a/src/libcore/private.rs
+++ b/src/libcore/private.rs
@@ -21,6 +21,7 @@ use libc;
 use oldcomm;
 use option;
 use pipes;
+use prelude::*;
 use ptr;
 use result;
 use task;
@@ -580,8 +581,11 @@ pub fn unwrap_exclusive<T: Owned>(arc: Exclusive<T>) -> T {
 
 #[cfg(test)]
 pub mod tests {
+    use core::option::{None, Some};
+
     use option;
     use pipes;
+    use private::{exclusive, unwrap_exclusive};
     use result;
     use task;
     use uint;

--- a/src/libcore/rand.rs
+++ b/src/libcore/rand.rs
@@ -15,6 +15,7 @@
 #[forbid(deprecated_pattern)];
 
 use int;
+use prelude::*;
 use str;
 use task;
 use u32;
@@ -362,7 +363,8 @@ pub fn random() -> uint {
 
 #[cfg(test)]
 pub mod tests {
-    use option::Option;
+    use debug;
+    use option::{None, Option, Some};
     use rand;
 
     #[test]

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -19,6 +19,8 @@ use cmp;
 use cmp::Eq;
 use either;
 use either::Either;
+use kinds::Copy;
+use option::{None, Option, Some};
 use vec;
 
 /// The result type
@@ -382,6 +384,7 @@ pub pure fn unwrap_err<T, U>(res: Result<T, U>) -> U {
 mod tests {
     #[legacy_exports];
 
+    use result::{Err, Ok, Result, chain, get, get_err};
     use result;
 
     fn op1() -> result::Result<int, ~str> { result::Ok(666) }

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -20,6 +20,7 @@ use libc::{pid_t, c_void, c_int};
 use oldcomm;
 use option::{Some, None};
 use os;
+use prelude::*;
 use ptr;
 use run;
 use str;
@@ -349,7 +350,7 @@ pub fn program_output(prog: &str, args: &[~str]) ->
     return {status: status, out: move outs, err: move errs};
 }
 
-fn writeclose(fd: c_int, s: ~str) {
+pub fn writeclose(fd: c_int, s: ~str) {
     use io::WriterUtil;
 
     error!("writeclose %d, %s", fd as int, s);
@@ -359,7 +360,7 @@ fn writeclose(fd: c_int, s: ~str) {
     os::close(fd);
 }
 
-fn readclose(fd: c_int) -> ~str {
+pub fn readclose(fd: c_int) -> ~str {
     let file = os::fdopen(fd);
     let reader = io::FILE_reader(file, false);
     let buf = io::with_bytes_writer(|writer| {
@@ -417,8 +418,11 @@ pub fn waitpid(pid: pid_t) -> int {
 
 #[cfg(test)]
 mod tests {
+    use debug;
     use io::WriterUtil;
+    use option::{None, Some};
     use os;
+    use run::{readclose, writeclose};
     use run;
 
     // Regression test for memory leaks

--- a/src/libcore/send_map.rs
+++ b/src/libcore/send_map.rs
@@ -20,6 +20,7 @@ Sendable hash maps.  Very much a work in progress.
 
 use cmp::Eq;
 use hash::Hash;
+use prelude::*;
 use to_bytes::IterBytes;
 
 pub trait SendMap<K:Eq Hash, V: Copy> {
@@ -45,9 +46,14 @@ pub trait SendMap<K:Eq Hash, V: Copy> {
 
 /// Open addressing with linear probing.
 pub mod linear {
+    use cmp::Eq;
     use cmp;
+    use hash::Hash;
+    use kinds::Copy;
+    use option::{None, Option, Some};
     use option;
     use rand;
+    use to_bytes::IterBytes;
     use uint;
     use vec;
 
@@ -457,6 +463,7 @@ pub mod linear {
 
 #[test]
 pub mod test {
+    use option::{None, Some};
     use send_map::linear::LinearMap;
     use send_map::linear;
     use uint;

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -27,6 +27,7 @@ use cmp::{Eq, Ord};
 use libc;
 use libc::size_t;
 use io::WriterUtil;
+use option::{None, Option, Some};
 use ptr;
 use str;
 use to_str::ToStr;
@@ -1949,6 +1950,7 @@ pub mod raw {
     use libc;
     use ptr;
     use str::raw;
+    use str::{as_buf, is_utf8, len, reserve_at_least};
     use vec;
 
     /// Create a Rust string from a null-terminated *u8 buffer
@@ -2129,6 +2131,9 @@ impl ~str: Trimmable {
 
 #[cfg(notest)]
 pub mod traits {
+    use ops::Add;
+    use str::append;
+
     impl ~str : Add<&str,~str> {
         #[inline(always)]
         pure fn add(&self, rhs: & &self/str) -> ~str {
@@ -2308,10 +2313,11 @@ impl &str: StrSlice {
 #[cfg(test)]
 mod tests {
     use char;
+    use debug;
     use libc::c_char;
     use libc;
     use ptr;
-    use str::raw;
+    use str::*;
     use vec;
 
     #[test]

--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -146,6 +146,7 @@ pub pure fn begin_unwind_(msg: *c_char, file: *c_char, line: size_t) -> ! {
 #[cfg(test)]
 pub mod tests {
     use cast;
+    use sys::{Closure, pref_align_of, size_of};
 
     #[test]
     pub fn size_of_basic() {

--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -121,8 +121,16 @@ pub pure fn log_str<T>(t: &T) -> ~str {
     }
 }
 
+condition! {
+    failing: () -> ();
+}
+
 /** Initiate task failure */
 pub pure fn begin_unwind(msg: ~str, file: ~str, line: uint) -> ! {
+    unsafe {
+        failing::cond.raise_default(&(), || ());
+    }
+
     do str::as_buf(msg) |msg_buf, _msg_len| {
         do str::as_buf(file) |file_buf, _file_len| {
             unsafe {
@@ -136,6 +144,10 @@ pub pure fn begin_unwind(msg: ~str, file: ~str, line: uint) -> ! {
 
 // XXX: Temorary until rt::rt_fail_ goes away
 pub pure fn begin_unwind_(msg: *c_char, file: *c_char, line: size_t) -> ! {
+    unsafe {
+        failing::cond.raise(&());
+    }
+
     unsafe {
         gc::cleanup_stack_for_failure();
         rustrt::rust_upcall_fail(msg, file, line);

--- a/src/libcore/task/local_data.rs
+++ b/src/libcore/task/local_data.rs
@@ -26,6 +26,7 @@ magic.
 
 */
 
+use prelude::*;
 use rt;
 use task::local_data_priv::{local_get, local_pop, local_modify, local_set};
 use task;

--- a/src/libcore/task/local_data_priv.rs
+++ b/src/libcore/task/local_data_priv.rs
@@ -11,9 +11,11 @@
 #[doc(hidden)]; // FIXME #3538
 
 use cast;
+use cmp::Eq;
 use dvec;
 use libc;
 use option;
+use prelude::*;
 use task::rt;
 use task::local_data::LocalDataKey;
 

--- a/src/libcore/task/mod.rs
+++ b/src/libcore/task/mod.rs
@@ -48,6 +48,7 @@ use option;
 use result::Result;
 use pipes::{stream, Chan, Port};
 use pipes;
+use prelude::*;
 use ptr;
 use result;
 use task::local_data_priv::{local_get, local_set};

--- a/src/libcore/task/spawn.rs
+++ b/src/libcore/task/spawn.rs
@@ -76,13 +76,19 @@
 use cast;
 use oldcomm;
 use option;
+use pipes::{Chan, Port};
 use pipes;
+use prelude::*;
 use private;
 use ptr;
 use send_map;
-use task::rt;
+use task::local_data_priv::{local_get, local_set};
 use task::rt::rust_task;
 use task::rt::rust_closure;
+use task::rt;
+use task::{Failure, ManualThreads, PlatformThread, SchedOpts, SingleThreaded};
+use task::{Success, TaskOpts, TaskResult, ThreadPerCore, ThreadPerTask};
+use task::{default_task_opts, unkillable};
 use uint;
 use util;
 

--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -20,6 +20,7 @@ The `ToBytes` and `IterBytes` traits
 
 use io;
 use io::Writer;
+use option::{None, Option, Some};
 use str;
 
 pub type Cb = fn(buf: &[const u8]) -> bool;
@@ -181,6 +182,8 @@ pub mod x32 {
 
 #[cfg(target_word_size = "64")]
 pub mod x64 {
+    use to_bytes::{Cb, IterBytes};
+
     pub impl uint: IterBytes {
         #[inline(always)]
         pure fn iter_bytes(&self, lsb0: bool, f: Cb) {

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -18,6 +18,7 @@ The `ToStr` trait for converting to strings
 #[forbid(deprecated_mode)];
 #[forbid(deprecated_pattern)];
 
+use kinds::Copy;
 use str;
 use vec;
 

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -15,6 +15,7 @@
 //! Operations on tuples
 
 use cmp::{Eq, Ord};
+use kinds::Copy;
 use vec;
 
 pub trait CopyableTuple<T, U> {

--- a/src/libcore/uint-template.rs
+++ b/src/libcore/uint-template.rs
@@ -19,6 +19,7 @@ use cmp::{Eq, Ord};
 use from_str::FromStr;
 use iter;
 use num;
+use option::{None, Option, Some};
 use str;
 use uint;
 use vec;

--- a/src/libcore/util.rs
+++ b/src/libcore/util.rs
@@ -19,6 +19,7 @@ Miscellaneous helpers for common patterns.
 #[forbid(deprecated_pattern)];
 
 use cmp::Eq;
+use prelude::*;
 
 /// The identity function.
 #[inline(always)]
@@ -104,6 +105,10 @@ pub fn unreachable() -> ! {
 
 mod tests {
     #[legacy_exports];
+
+    use option::{None, Some};
+    use util::{NonCopyable, id, replace, swap};
+
     #[test]
     fn identity_crisis() {
         // Writing a test for the identity function. How did it come to this?

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -16,10 +16,12 @@
 
 use cast;
 use cmp::{Eq, Ord};
+use iter::BaseIter;
 use iter;
+use kinds::Copy;
 use libc;
 use libc::size_t;
-use option::{Some, None};
+use option::{None, Option, Some};
 use ptr;
 use ptr::addr_of;
 use sys;
@@ -673,7 +675,7 @@ pub pure fn append_one<T>(lhs: ~[T], x: T) -> ~[T] {
 }
 
 #[inline(always)]
-pure fn append_mut<T: Copy>(lhs: ~[mut T], rhs: &[const T]) -> ~[mut T] {
+pub pure fn append_mut<T: Copy>(lhs: ~[mut T], rhs: &[const T]) -> ~[mut T] {
     to_mut(append(from_mut(lhs), rhs))
 }
 
@@ -1517,6 +1519,10 @@ impl<T: Ord> @[T] : Ord {
 
 #[cfg(notest)]
 pub mod traits {
+    use kinds::Copy;
+    use ops::Add;
+    use vec::{append, append_mut};
+
     impl<T: Copy> ~[T] : Add<&[const T],~[T]> {
         #[inline(always)]
         pure fn add(&self, rhs: & &self/[const T]) -> ~[T] {
@@ -1839,10 +1845,14 @@ pub struct UnboxedVecRepr {
 
 /// Unsafe operations
 pub mod raw {
+    use kinds::Copy;
     use managed;
+    use option::{None, Some};
     use option;
+    use ptr::addr_of;
     use ptr;
     use sys;
+    use vec::{UnboxedVecRepr, as_const_buf, as_mut_buf, len, with_capacity};
     use vec::rusti;
 
     /// The internal representation of a (boxed) vector
@@ -1986,8 +1996,9 @@ pub mod raw {
 pub mod bytes {
     use libc;
     use uint;
-    use vec;
+    use vec::len;
     use vec::raw;
+    use vec;
 
     /// Bytewise string comparison
     pub pure fn cmp(a: &~[u8], b: &~[u8]) -> int {
@@ -2278,8 +2289,9 @@ impl<A:Copy> @[A] : iter::CopyableNonstrictIter<A> {
 
 #[cfg(test)]
 mod tests {
+    use option::{None, Option, Some};
     use option;
-    use vec::raw;
+    use vec::*;
 
     fn square(n: uint) -> uint { return n * n; }
 

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use back::rpath;
 use driver::session;
 use lib::llvm::llvm;
@@ -40,7 +42,7 @@ use syntax::ast_map::{path, path_mod, path_name};
 use syntax::attr;
 use syntax::print::pprust;
 
-enum output_type {
+pub enum output_type {
     output_type_none,
     output_type_bitcode,
     output_type_assembly,
@@ -56,14 +58,14 @@ impl output_type : cmp::Eq {
     pure fn ne(&self, other: &output_type) -> bool { !(*self).eq(other) }
 }
 
-fn llvm_err(sess: Session, msg: ~str) -> ! unsafe {
+pub fn llvm_err(sess: Session, msg: ~str) -> ! unsafe {
     let cstr = llvm::LLVMRustGetLastError();
     if cstr == ptr::null() {
         sess.fatal(msg);
     } else { sess.fatal(msg + ~": " + str::raw::from_c_str(cstr)); }
 }
 
-fn WriteOutputFile(sess: Session,
+pub fn WriteOutputFile(sess: Session,
         PM: lib::llvm::PassManagerRef, M: ModuleRef,
         Triple: *c_char,
         // FIXME: When #2334 is fixed, change
@@ -81,10 +83,14 @@ fn WriteOutputFile(sess: Session,
 pub mod jit {
     #[legacy_exports];
 
+    use back::link::llvm_err;
     use lib::llvm::llvm;
+    use lib::llvm::{ModuleRef, PassManagerRef, mk_target_data};
     use metadata::cstore;
+    use session::Session;
 
     use core::cast;
+    use core::libc::c_int;
     use core::ptr;
     use core::str;
 
@@ -156,11 +162,19 @@ mod write {
     #[legacy_exports];
 
     use back::link::jit;
+    use back::link::{ModuleRef, WriteOutputFile, output_type};
+    use back::link::{output_type_assembly, output_type_bitcode};
+    use back::link::{output_type_exe, output_type_llvm_assembly};
+    use back::link::{output_type_object};
     use driver::session;
     use lib::llvm::llvm;
+    use lib::llvm::{False, True, mk_pass_manager, mk_target_data};
     use lib;
+    use session::Session;
 
     use core::char;
+    use core::libc::{c_char, c_int, c_uint};
+    use core::path::Path;
     use core::str;
     use core::vec;
 

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use driver::session;
 use metadata::cstore;
 use metadata::filesearch;
@@ -19,7 +21,13 @@ use core::vec;
 use std::map::HashMap;
 use std::map;
 
+export get_absolute_rpath;
+export get_install_prefix_rpath;
+export get_relative_to;
 export get_rpath_flags;
+export get_rpath_relative_to_output;
+export minimize_rpaths;
+export rpaths_to_flags;
 
 pure fn not_win32(os: session::os) -> bool {
   match os {
@@ -201,6 +209,11 @@ fn minimize_rpaths(rpaths: &[Path]) -> ~[Path] {
 mod test {
     #[legacy_exports];
 
+    use core::prelude::*;
+
+    use back::rpath::{get_absolute_rpath, get_install_prefix_rpath};
+    use back::rpath::{get_relative_to, get_rpath_relative_to_output};
+    use back::rpath::{minimize_rpaths, rpaths_to_flags};
     use driver::session;
 
     use core::os;

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -9,6 +9,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use back::link;
 use back::{x86, x86_64};
 use front;
@@ -828,7 +830,13 @@ fn list_metadata(sess: Session, path: &Path, out: io::Writer) {
 mod test {
     #[legacy_exports];
 
+    use core::prelude::*;
+
+    use driver::driver::{build_configuration, build_session};
+    use driver::driver::{build_session_options, optgroups, str_input};
+
     use core::vec;
+    use std::getopts::groups::getopts;
     use std::getopts;
     use syntax::attr;
     use syntax::diagnostic;

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
 
 use back::link;
 use back::target_strs;
@@ -332,6 +333,12 @@ fn sess_os_to_meta_os(os: os) -> metadata::loader::os {
 #[cfg(test)]
 mod test {
     #[legacy_exports];
+
+    use core::prelude::*;
+
+    use driver::session::{bin_crate, building_library, lib_crate};
+    use driver::session::{unknown_crate};
+
     use syntax::ast;
     use syntax::ast_util;
 

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use syntax::{ast, fold, attr};
 
 use core::option;

--- a/src/librustc/front/core_inject.rs
+++ b/src/librustc/front/core_inject.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use driver::session::Session;
 
 use core::vec;
@@ -70,10 +72,18 @@ fn inject_libcore_ref(sess: Session,
         fold_mod: |module, fld| {
             let n2 = sess.next_node_id();
 
-            let vp = @spanned(
-                ast::view_path_glob(ident_to_path(dummy_sp(),
-                                                  sess.ident_of(~"core")),
-                                    n2));
+            let prelude_path = @{
+                span: dummy_sp(),
+                global: false,
+                idents: ~[
+                    sess.ident_of(~"core"),
+                    sess.ident_of(~"prelude")
+                ],
+                rp: None,
+                types: ~[]
+            };
+
+            let vp = @spanned(ast::view_path_glob(prelude_path, n2));
             let vi2 = @{node: ast::view_item_import(~[vp]),
                         attrs: ~[],
                         vis: ast::private,

--- a/src/librustc/front/intrinsic_inject.rs
+++ b/src/librustc/front/intrinsic_inject.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use driver::session::Session;
 use syntax::parse;
 use syntax::ast;

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -10,6 +10,8 @@
 
 // Code that generates a test runner to run all the tests in a crate
 
+use core::prelude::*;
+
 use driver::session;
 use front::config;
 use session::Session;

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use core::cast;
 use core::cmp;
 use core::int;

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -10,6 +10,8 @@
 
 //! Validates all used crates and extern libraries and loads their metadata
 
+use core::prelude::*;
+
 use metadata::cstore;
 use metadata::common::*;
 use metadata::decoder;

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -10,6 +10,8 @@
 
 // Searching for information from the cstore
 
+use core::prelude::*;
+
 use metadata::common::*;
 use metadata::cstore;
 use metadata::decoder;

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -11,6 +11,8 @@
 // The crate store - a central repo for information collected about external
 // crates and libraries
 
+use core::prelude::*;
+
 use metadata::creader;
 use metadata::cstore;
 use metadata::decoder;

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -10,6 +10,8 @@
 
 // Decoding metadata from a single crate's metadata
 
+use core::prelude::*;
+
 use cmd = metadata::cstore::crate_metadata;
 use dvec::DVec;
 use hash::{Hash, HashUtil};

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -10,6 +10,8 @@
 
 // Metadata encoding
 
+use core::prelude::*;
+
 use metadata::common::*;
 use metadata::csearch;
 use metadata::cstore;

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -12,6 +12,8 @@
 // FIXME (#2658): I'm not happy how this module turned out. Should
 // probably just be folded into cstore.
 
+use core::prelude::*;
+
 use core::option;
 use core::os;
 use core::result::Result;

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -10,6 +10,8 @@
 
 //! Finds crate binaries and loads their metadata
 
+use core::prelude::*;
+
 use lib::llvm::{False, llvm, mk_object_file, mk_section_iter};
 use metadata::decoder;
 use metadata::encoder;

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -13,6 +13,8 @@
 // tjc note: Would be great to have a `match check` macro equivalent
 // for some of these
 
+use core::prelude::*;
+
 use middle::ty;
 use middle::ty::{FnTyBase, FnMeta, FnSig};
 

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -10,6 +10,8 @@
 
 // Type encoding
 
+use core::prelude::*;
+
 use middle::ty;
 use middle::ty::vid;
 

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use c = metadata::common;
 use cstore = metadata::cstore;
 use driver::session::Session;

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -15,17 +15,29 @@
 // 1. assignments are always made to mutable locations;
 // 2. loans made in overlapping scopes do not conflict
 // 3. assignments do not affect things loaned out as immutable
-// 4. moves to dnot affect things loaned out in any way
+// 4. moves do not affect things loaned out in any way
 
+use core::prelude::*;
+
+use middle::borrowck::{Loan, bckerr, borrowck_ctxt, cmt, inherent_mutability};
+use middle::borrowck::{req_maps, save_and_restore};
+use middle::mem_categorization::{cat_arg, cat_binding, cat_deref, cat_local};
+use middle::mem_categorization::{cat_rvalue, cat_special};
+use middle::mem_categorization::{loan_path, lp_arg, lp_comp, lp_deref};
+use middle::mem_categorization::{lp_local};
 use middle::ty::{CopyValue, MoveValue, ReadValue};
 use middle::ty;
+use util::ppaux::ty_to_str;
 
 use core::cmp;
 use core::dvec::DVec;
 use core::uint;
 use core::vec;
+use std::map::HashMap;
+use syntax::ast::{m_const, m_imm, m_mutbl};
 use syntax::ast;
 use syntax::ast_util;
+use syntax::codemap::span;
 use syntax::print::pprust;
 use syntax::visit;
 

--- a/src/librustc/middle/borrowck/gather_loans.rs
+++ b/src/librustc/middle/borrowck/gather_loans.rs
@@ -16,16 +16,26 @@
 // their associated scopes.  In phase two, checking loans, we will then make
 // sure that all of these loans are honored.
 
+use core::prelude::*;
+
 use middle::borrowck::preserve::{preserve_condition, pc_ok, pc_if_pure};
-use middle::mem_categorization::{mem_categorization_ctxt, opt_deref_kind};
+use middle::borrowck::{Loan, bckres, borrowck_ctxt, err_mutbl, req_maps};
+use middle::mem_categorization::{cat_binding, cat_discr, cmt, comp_variant};
+use middle::mem_categorization::{mem_categorization_ctxt};
+use middle::mem_categorization::{opt_deref_kind};
 use middle::pat_util;
 use middle::ty::{ty_region};
 use middle::ty;
+use util::common::indenter;
+use util::ppaux::{expr_repr, region_to_str};
 
 use core::dvec;
 use core::send_map::linear::LinearMap;
 use core::vec;
+use std::map::HashMap;
+use syntax::ast::{m_const, m_imm, m_mutbl};
 use syntax::ast;
+use syntax::codemap::span;
 use syntax::print::pprust;
 use syntax::visit;
 

--- a/src/librustc/middle/borrowck/loan.rs
+++ b/src/librustc/middle/borrowck/loan.rs
@@ -12,9 +12,19 @@
 // Loan(Ex, M, S) = Ls holds if ToAddr(Ex) will remain valid for the entirety
 // of the scope S, presuming that the returned set of loans `Ls` are honored.
 
-use middle::ty;
+use core::prelude::*;
 
-use core::result::{Result, Ok, Err};
+use middle::borrowck::{Loan, bckres, borrowck_ctxt, cmt, err_mutbl};
+use middle::borrowck::{err_out_of_scope};
+use middle::mem_categorization::{cat_arg, cat_binding, cat_discr, cat_comp};
+use middle::mem_categorization::{cat_deref, cat_discr, cat_local};
+use middle::mem_categorization::{cat_special, cat_stack_upvar, comp_field};
+use middle::mem_categorization::{comp_index, comp_variant, region_ptr};
+use middle::ty;
+use util::common::indenter;
+
+use core::result::{Err, Ok, Result};
+use syntax::ast::{m_const, m_imm, m_mutbl};
 use syntax::ast;
 
 export public_methods;

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -226,6 +226,8 @@ Borrowck results in two maps.
 
 #[legacy_exports];
 
+use core::prelude::*;
+
 use middle::liveness;
 use middle::mem_categorization::*;
 use middle::region;
@@ -258,9 +260,6 @@ pub mod gather_loans;
 pub mod loan;
 #[legacy_exports]
 pub mod preserve;
-
-export check_crate, root_map, mutbl_map;
-export check_loans, gather_loans, loan, preserve;
 
 fn check_crate(tcx: ty::ctxt,
                method_map: typeck::method_map,
@@ -410,7 +409,7 @@ impl bckerr : cmp::Eq {
 type bckres<T> = Result<T, bckerr>;
 
 /// a complete record of a loan that was granted
-struct Loan {lp: @loan_path, cmt: cmt, mutbl: ast::mutability}
+pub struct Loan {lp: @loan_path, cmt: cmt, mutbl: ast::mutability}
 
 /// maps computed by `gather_loans` that are then used by `check_loans`
 ///
@@ -418,7 +417,7 @@ struct Loan {lp: @loan_path, cmt: cmt, mutbl: ast::mutability}
 ///   for the duration of that block/expr
 /// - `pure_map`: map from block/expr that must be pure to the error message
 ///   that should be reported if they are not pure
-type req_maps = {
+pub type req_maps = {
     req_loan_map: HashMap<ast::node_id, @DVec<Loan>>,
     pure_map: HashMap<ast::node_id, bckerr>
 };

--- a/src/librustc/middle/borrowck/preserve.rs
+++ b/src/librustc/middle/borrowck/preserve.rs
@@ -13,8 +13,19 @@
 // the scope S.
 //
 
-use middle::ty;
+use core::prelude::*;
 
+use middle::borrowck::{bckerr, bckerr_code, bckres, borrowck_ctxt, cmt};
+use middle::borrowck::{err_mut_uniq, err_mut_variant, err_out_of_root_scope};
+use middle::borrowck::{err_out_of_scope, err_root_not_permitted};
+use middle::mem_categorization::{cat_arg, cat_binding, cat_comp, cat_deref};
+use middle::mem_categorization::{cat_discr, cat_local, cat_special};
+use middle::mem_categorization::{cat_stack_upvar, comp_field, comp_index};
+use middle::mem_categorization::{comp_variant, region_ptr};
+use middle::ty;
+use util::common::indenter;
+
+use syntax::ast::{m_const, m_imm, m_mutbl};
 use syntax::ast;
 
 export public_methods, preserve_condition, pc_ok, pc_if_pure;

--- a/src/librustc/middle/capture.rs
+++ b/src/librustc/middle/capture.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::freevars;
 use middle::ty;
 

--- a/src/librustc/middle/check_alt.rs
+++ b/src/librustc/middle/check_alt.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::const_eval::{compare_const_vals, lookup_const_by_id};
 use middle::const_eval::{eval_const_expr, const_val, const_int, const_bool};
 use middle::pat_util::*;

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use driver::session::Session;
 use middle::resolve;
 use middle::ty;

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::resolve;
 use middle::ty;
 use middle;

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::freevars::freevar_entry;
 use middle::freevars;
 use middle::lint::{non_implicitly_copyable_typarams, implicit_copies};

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -19,6 +19,8 @@
 //
 // * Functions called by the compiler itself.
 
+use core::prelude::*;
+
 use driver::session::Session;
 use metadata::csearch::{each_path, get_item_attrs};
 use metadata::cstore::{iter_crate_data};
@@ -33,7 +35,7 @@ use core::ptr;
 use std::map::HashMap;
 use str_eq = str::eq;
 
-struct LanguageItems {
+pub struct LanguageItems {
     mut const_trait: Option<def_id>,
     mut copy_trait: Option<def_id>,
     mut owned_trait: Option<def_id>,
@@ -64,8 +66,11 @@ struct LanguageItems {
 }
 
 mod language_items {
-    #[legacy_exports];
-    fn make() -> LanguageItems {
+    use middle::lang_items::LanguageItems;
+
+    use core::option::None;
+
+    pub fn make() -> LanguageItems {
         LanguageItems {
             const_trait: None,
             copy_trait: None,

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use driver::session::Session;
 use driver::session;
 use middle::pat_util::{pat_bindings};

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -102,6 +102,8 @@
  *   to return explicitly.
  */
 
+use core::prelude::*;
+
 use middle::capture::{cap_move, cap_drop, cap_copy, cap_ref};
 use middle::capture;
 use middle::pat_util;

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -46,6 +46,8 @@
  * then an index to jump forward to the relevant item.
  */
 
+use core::prelude::*;
+
 use middle::ty;
 use middle::typeck;
 use util::ppaux::{ty_to_str, region_to_str};
@@ -135,7 +137,7 @@ impl categorization : cmp::Eq {
 }
 
 // different kinds of pointers:
-enum ptr_kind {
+pub enum ptr_kind {
     uniq_ptr,
     gc_ptr,
     region_ptr(ty::Region),
@@ -176,7 +178,7 @@ impl ptr_kind : cmp::Eq {
 
 // I am coining the term "components" to mean "pieces of a data
 // structure accessible without a dereference":
-enum comp_kind {
+pub enum comp_kind {
     comp_tuple,                  // elt in a tuple
     comp_anon_field,             // anonymous field (in e.g.
                                  // struct Foo(int, int);
@@ -268,7 +270,7 @@ impl cmt_ : cmp::Eq {
 // a loan path is like a category, but it exists only when the data is
 // interior to the stack frame.  loan paths are used as the key to a
 // map indicating what is borrowed at any point in time.
-enum loan_path {
+pub enum loan_path {
     lp_local(ast::node_id),
     lp_arg(ast::node_id),
     lp_deref(@loan_path, ptr_kind),

--- a/src/librustc/middle/mode.rs
+++ b/src/librustc/middle/mode.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::pat_util;
 use middle::ty;
 use middle::ty::{CopyValue, MoveValue, ReadValue, ValueMode, ctxt};

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::resolve;
 use middle::ty::{CopyValue, MoveValue, ReadValue};
 use middle::ty;

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -11,6 +11,8 @@
 // A pass that checks to make sure private fields and methods aren't used
 // outside their scopes.
 
+use core::prelude::*;
+
 use middle::ty::{ty_struct, ty_enum};
 use middle::ty;
 use middle::typeck::{method_map, method_origin, method_param, method_self};

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -17,6 +17,8 @@ region parameterized.
 
 */
 
+use core::prelude::*;
+
 use driver::session::Session;
 use metadata::csearch;
 use middle::resolve;

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use driver::session::Session;
 use metadata::csearch::{each_path, get_method_names_if_trait};
 use metadata::csearch::{get_static_methods_if_impl, get_type_name_if_impl};
@@ -3077,77 +3079,6 @@ impl Resolver {
                self.module_to_str(containing_module));
 
         return Success(PrefixFound(containing_module, i));
-
-        /*
-        // If we reached the end, return the containing module.
-        if i == module_path.len() {
-            return ModulePrefixResult {
-                result: Success(containing_module),
-                prefix_len: i
-            };
-        }
-
-        // Is the containing module the current module? If so, we allow
-        // globs to be unresolved.
-        let allow_globs = core::managed::ptr_eq(containing_module, module_);
-
-        let name = module_path.get_elt(i);
-        i += 1;
-
-        let resolve_result = self.resolve_name_in_module(containing_module,
-                                                         name,
-                                                         TypeNS,
-                                                         Xray,
-                                                         allow_globs);
-        match resolve_result {
-            Success(target) => {
-                match target.bindings.type_def {
-                    Some(ref type_def) => {
-                        match (*type_def).module_def {
-                            None => {
-                                error!("!!! (resolving crate-relative \
-                                        module) module wasn't actually a \
-                                        module!");
-                                return ModulePrefixResult {
-                                    result: Failed,
-                                    prefix_len: i
-                                };
-                            }
-                            Some(module_def) => {
-                                return ModulePrefixResult {
-                                    result: Success(module_def),
-                                    prefix_len: i
-                                };
-                            }
-                        }
-                    }
-                    None => {
-                        error!("!!! (resolving crate-relative module) module
-                                wasn't actually a module!");
-                        return ModulePrefixResult {
-                            result: Failed,
-                            prefix_len: i
-                        };
-                    }
-                }
-            }
-            Indeterminate => {
-                debug!("(resolving crate-relative module) indeterminate; \
-                        bailing");
-                return ModulePrefixResult {
-                    result: Indeterminate,
-                    prefix_len: i
-                };
-            }
-            Failed => {
-                debug!("(resolving crate-relative module) failed to resolve");
-                return ModulePrefixResult {
-                    result: Failed,
-                    prefix_len: i
-                };
-            }
-        }
-        */
     }
 
     fn name_is_exported(module_: @Module, name: ident) -> bool {
@@ -3167,7 +3098,6 @@ impl Resolver {
                               xray: XrayFlag,
                               allow_globs: bool)
                            -> ResolveResult<Target> {
-
         debug!("(resolving name in module) resolving `%s` in `%s`",
                self.session.str_of(name),
                self.module_to_str(module_));
@@ -4816,7 +4746,7 @@ impl Resolver {
         }
 
         return self.resolve_item_by_identifier_in_lexical_scope(identifier,
-                                                             namespace);
+                                                                namespace);
     }
 
     // XXX: Merge me with resolve_name_in_module?
@@ -5033,7 +4963,7 @@ impl Resolver {
         match self.resolve_item_in_lexical_scope(self.current_module,
                                                  ident,
                                                  namespace,
-                                                 SearchThroughModules) {
+                                                 DontSearchThroughModules) {
             Success(target) => {
                 match (*target.bindings).def_for_namespace(namespace) {
                     None => {

--- a/src/librustc/middle/trans/alt.rs
+++ b/src/librustc/middle/trans/alt.rs
@@ -142,6 +142,8 @@
  *
  */
 
+use core::prelude::*;
+
 use back::abi;
 use lib::llvm::llvm;
 use lib::llvm::{ValueRef, BasicBlockRef};

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -23,6 +23,8 @@
 //     but many TypeRefs correspond to one ty::t; for instance, tup(int, int,
 //     int) and rec(x=int, y=int, z=int) will have the same TypeRef.
 
+use core::prelude::*;
+
 use back::link::{mangle_exported_name};
 use back::link::{mangle_internal_name_by_path_and_seq};
 use back::link::{mangle_internal_name_by_path};

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -16,6 +16,8 @@
 // and methods are represented as just a fn ptr and not a full
 // closure.
 
+use core::prelude::*;
+
 use lib::llvm::ValueRef;
 use middle::trans::base::{get_item_val, trans_external_path};
 use middle::trans::build::*;

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use back::abi;
 use back::link::{mangle_internal_name_by_path_and_seq};
 use back::link::{mangle_internal_name_by_path};

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -213,7 +213,8 @@ type crate_ctxt = {
      // is not emitted by LLVM's GC pass when no functions use GC.
      mut uses_gc: bool,
      dbg_cx: Option<debuginfo::debug_ctxt>,
-     mut do_not_commit_warning_issued: bool};
+     mut do_not_commit_warning_issued: bool,
+     unwinding_enabled: bool};
 
 // Types used for llself.
 struct ValSelfData {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -13,6 +13,8 @@
 
 */
 
+use core::prelude::*;
+
 use back::{link, abi, upcall};
 use driver::session;
 use driver::session::Session;

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::const_eval;
 use middle::trans::base::get_insn_ctxt;
 use middle::trans::common::*;

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use lib::llvm::ValueRef;
 use middle::trans::base::*;
 use middle::trans::callee;

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -95,6 +95,8 @@
  * methods themselves.  Most are only suitable for some types of
  * values. */
 
+use core::prelude::*;
+
 use lib::llvm::ValueRef;
 use middle::trans::base::*;
 use middle::trans::build::*;

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use driver::session;
 use lib::llvm::ValueRef;
 use lib::llvm::llvm;

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -111,6 +111,8 @@ lvalues are *never* stored by value.
 
 */
 
+use core::prelude::*;
+
 use lib::llvm::ValueRef;
 use middle::resolve;
 use middle::trans::base::*;

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -11,6 +11,8 @@
 // The classification code for the x86_64 ABI is taken from the clay language
 // https://github.com/jckarter/clay/blob/master/compiler/src/externals.cpp
 
+use core::prelude::*;
+
 use back::{link, abi};
 use driver::session::arch_x86_64;
 use lib::llvm::{SequentiallyConsistent, Acquire, Release, Xchg};

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -12,6 +12,8 @@
 //
 // Code relating to taking, dropping, etc as well as type descriptors.
 
+use core::prelude::*;
+
 use lib::llvm::{ValueRef, TypeRef};
 use middle::trans::base::*;
 use middle::trans::callee;

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::astencode;
 use middle::trans::base::{get_insn_ctxt};
 use middle::trans::base::{impl_owned_self, impl_self, no_self};

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use back::{link, abi};
 use driver;
 use lib::llvm::llvm::LLVMGetParam;

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use back::link::mangle_exported_name;
 use middle::trans::base::{get_insn_ctxt};
 use middle::trans::base::{set_inline_hint_if_appr, set_inline_hint};

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -10,6 +10,8 @@
 
 #[warn(deprecated_pattern)];
 
+use core::prelude::*;
+
 use driver::session;
 use metadata::csearch;
 use metadata;

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -52,17 +52,24 @@
  * an rptr (`&r.T`) use the region `r` that appears in the rptr.
  */
 
-use middle::ty::{FnTyBase, FnMeta, FnSig};
+use core::prelude::*;
+
+use middle::pat_util::pat_id_map;
+use middle::ty::{FnTyBase, FnMeta, FnSig, ty_param_substs_and_ty};
 use middle::ty;
 use middle::typeck::check::fn_ctxt;
 use middle::typeck::collect;
 use middle::typeck::rscope::{anon_rscope, binding_rscope, empty_rscope};
 use middle::typeck::rscope::{in_anon_rscope, in_binding_rscope};
 use middle::typeck::rscope::{region_scope, type_rscope};
+use middle::typeck::{crate_ctxt, write_substs_to_tcx, write_ty_to_tcx};
 
 use core::result;
 use core::vec;
 use syntax::ast;
+use syntax::codemap::span;
+use syntax::print::pprust::path_to_str;
+use util::common::indent;
 
 pub trait ast_conv {
     fn tcx() -> ty::ctxt;

--- a/src/librustc/middle/typeck/check/alt.rs
+++ b/src/librustc/middle/typeck/check/alt.rs
@@ -8,16 +8,23 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use middle::pat_util::{pat_is_binding, pat_is_const};
+use core::prelude::*;
+
+use middle::pat_util::{PatIdMap, pat_id_map, pat_is_binding, pat_is_const};
 use middle::pat_util::{pat_is_variant_or_struct};
 use middle::ty;
 use middle::typeck::check::demand;
+use middle::typeck::check::{check_block, check_expr_with, fn_ctxt};
+use middle::typeck::check::{instantiate_path, lookup_def, lookup_local};
+use middle::typeck::check::{structure_of, valid_range_bounds};
+use middle::typeck::require_same_types;
 
 use core::vec;
 use std::map::HashMap;
 use syntax::ast;
 use syntax::ast_util::walk_pat;
 use syntax::ast_util;
+use syntax::codemap::span;
 use syntax::print::pprust;
 
 fn check_alt(fcx: @fn_ctxt,

--- a/src/librustc/middle/typeck/check/demand.rs
+++ b/src/librustc/middle/typeck/check/demand.rs
@@ -12,8 +12,10 @@ use middle::ty;
 use middle::typeck::check::fn_ctxt;
 use middle::typeck::infer;
 
+use core::result::{Err, Ok};
 use core::result;
 use syntax::ast;
+use syntax::codemap::span;
 
 // Requires that the two types unify, and prints an error message if they
 // don't.

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -79,19 +79,29 @@ obtained the type `Foo`, we would never match this method.
 
 */
 
+use core::prelude::*;
+
 use middle::resolve::{Impl, MethodInfo};
 use middle::resolve;
 use middle::ty::*;
 use middle::ty;
-use middle::typeck::check;
+use middle::typeck::check::{fn_ctxt, impl_self_ty};
+use middle::typeck::check::{structurally_resolved_type};
+use middle::typeck::check::vtable::VtableContext;
 use middle::typeck::check::vtable;
+use middle::typeck::check;
 use middle::typeck::coherence::get_base_type_def_id;
 use middle::typeck::infer;
+use middle::typeck::{method_map_entry, method_origin, method_param};
+use middle::typeck::{method_self, method_static, method_trait};
+use util::common::indenter;
+use util::ppaux::expr_repr;
 
 use core::dvec::DVec;
 use core::result;
 use core::uint;
 use core::vec;
+use std::map::HashMap;
 use syntax::ast::{def_id, sty_by_ref, sty_value, sty_region, sty_box};
 use syntax::ast::{sty_uniq, sty_static, node_id, by_copy, by_ref};
 use syntax::ast::{m_const, m_mutbl, m_imm};
@@ -99,6 +109,7 @@ use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_map::node_id_to_str;
 use syntax::ast_util::dummy_sp;
+use syntax::codemap::span;
 
 fn lookup(
     fcx: @fn_ctxt,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -76,10 +76,14 @@ type parameter).
 
 */
 
+use core::prelude::*;
+
 use middle::capture;
 use middle::const_eval;
+use middle::pat_util::pat_id_map;
 use middle::pat_util;
-use middle::ty::{TyVid, vid, FnTyBase, FnMeta, FnSig, VariantInfo_};
+use middle::ty::{TyVid, vid, FnTyBase, FnMeta, FnSig, VariantInfo_, field};
+use middle::ty::{ty_param_bounds_and_ty, ty_param_substs_and_ty};
 use middle::ty;
 use middle::typeck::astconv::{ast_conv, ast_path_to_ty};
 use middle::typeck::astconv::{ast_region_to_region, ast_ty_to_ty};
@@ -87,12 +91,18 @@ use middle::typeck::astconv;
 use middle::typeck::check::method::TransformTypeNormally;
 use middle::typeck::check::regionmanip::replace_bound_regions_in_fn_ty;
 use middle::typeck::check::vtable::{LocationInfo, VtableContext};
+use middle::typeck::crate_ctxt;
 use middle::typeck::infer::{resolve_type, force_tvar};
 use middle::typeck::infer;
 use middle::typeck::rscope::{anon_rscope, binding_rscope, bound_self_region};
 use middle::typeck::rscope::{empty_rscope, in_anon_rscope};
 use middle::typeck::rscope::{in_binding_rscope, region_scope, type_rscope};
 use middle::typeck::rscope;
+use middle::typeck::{isr_alist, lookup_def_ccx, method_map_entry};
+use middle::typeck::{method_origin, method_self, method_trait, no_params};
+use middle::typeck::{require_same_types};
+use util::common::{block_query, indenter, loop_query};
+use util::ppaux::{bound_region_to_str, expr_repr};
 use util::ppaux;
 
 use core::either;
@@ -102,15 +112,19 @@ use core::result::{Result, Ok, Err};
 use core::result;
 use core::str;
 use core::vec;
+use std::list::Nil;
 use std::map::HashMap;
 use std::map;
-use syntax::ast::ty_i;
+use syntax::ast::{provided, required, spanned, ty_i};
 use syntax::ast;
 use syntax::ast_map;
-use syntax::ast_util::{is_local, visibility_to_privacy, Private, Public};
+use syntax::ast_util::{Private, Public, is_local, local_def, respan};
+use syntax::ast_util::{visibility_to_privacy};
 use syntax::ast_util;
+use syntax::codemap::span;
 use syntax::codemap;
 use syntax::parse::token::special_idents;
+use syntax::print::pprust::{expr_to_str, pat_to_str};
 use syntax::print::pprust;
 use syntax::visit;
 use syntax;
@@ -129,6 +143,15 @@ export DerefArgs;
 export DontDerefArgs;
 export DoDerefArgs;
 export check_item_types;
+export check_block;
+export check_expr_with;
+export fn_ctxt;
+export lookup_def;
+export structure_of;
+export self_info;
+export structurally_resolved_type;
+export instantiate_path;
+export valid_range_bounds;
 
 #[legacy_exports]
 pub mod alt;

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -27,19 +27,25 @@ this point a bit better.
 
 */
 
+use core::prelude::*;
+
 use middle::freevars::get_freevars;
 use middle::pat_util::pat_bindings;
 use middle::ty::{encl_region, re_scope};
 use middle::ty::{ty_fn_proto, vstore_box, vstore_fixed, vstore_slice};
 use middle::ty::{vstore_uniq};
 use middle::ty;
-use middle::typeck::infer::{resolve_and_force_all_but_regions, fres};
+use middle::typeck::check::fn_ctxt;
+use middle::typeck::check::lookup_def;
+use middle::typeck::infer::{fres, resolve_and_force_all_but_regions};
+use middle::typeck::infer::{resolve_type};
 use util::ppaux::{note_and_explain_region, ty_to_str};
 
 use core::result;
 use syntax::ast::{ProtoBare, ProtoBox, ProtoUniq, ProtoBorrowed};
 use syntax::ast::{def_arg, def_binding, def_local, def_self, def_upvar};
 use syntax::ast;
+use syntax::codemap::span;
 use syntax::print::pprust;
 use syntax::visit;
 

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -11,9 +11,16 @@
 // #[warn(deprecated_mode)];
 // #[warn(deprecated_pattern)];
 
+use core::prelude::*;
+
 use middle::ty;
+use middle::typeck::check::self_info;
+use middle::typeck::isr_alist;
+use util::common::indenter;
+use util::ppaux::region_to_str;
 use util::ppaux;
 
+use std::list::Cons;
 use syntax::ast;
 use syntax::print::pprust::{expr_to_str};
 

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -8,22 +8,30 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::resolve;
 use middle::ty;
 use middle::typeck::check::{fn_ctxt, impl_self_ty};
+use middle::typeck::check::{structurally_resolved_type};
 use middle::typeck::infer::{fixup_err_to_str, infer_ctxt};
 use middle::typeck::infer::{resolve_and_force_all_but_regions, resolve_type};
 use middle::typeck::infer;
+use middle::typeck::{crate_ctxt, vtable_origin, vtable_param, vtable_res};
+use middle::typeck::{vtable_static, vtable_trait};
 use util::common::indenter;
+use util::ppaux::tys_to_str;
 use util::ppaux;
 
 use core::result;
 use core::uint;
 use core::vec;
 use result::{Result, Ok, Err};
+use std::map::HashMap;
 use syntax::ast;
 use syntax::ast_util;
 use syntax::codemap::span;
+use syntax::print::pprust::expr_to_str;
 use syntax::print::pprust;
 use syntax::visit;
 

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -12,17 +12,24 @@
 // unresolved type variables and replaces "ty_var" types with their
 // substitutions.
 
+use core::prelude::*;
+
 use middle::pat_util;
 use middle::ty;
-use middle::typeck::check::{fn_ctxt, lookup_local};
+use middle::typeck::check::{fn_ctxt, lookup_local, self_info};
 use middle::typeck::infer::{force_all, resolve_all, resolve_region};
 use middle::typeck::infer::{resolve_type};
 use middle::typeck::infer;
+use middle::typeck::{vtable_param, vtable_trait, write_substs_to_tcx};
+use middle::typeck::{write_ty_to_tcx};
 use util::ppaux;
 
 use core::result::{Result, Ok, Err};
 use core::vec;
+use std::map::HashMap;
 use syntax::ast;
+use syntax::codemap::span;
+use syntax::print::pprust::pat_to_str;
 use syntax::visit;
 
 export resolve_type_vars_in_fn;

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -14,6 +14,8 @@
 // has at most one implementation for each type. Then we build a mapping from
 // each trait in the system to its implementations.
 
+use core::prelude::*;
+
 use driver;
 use metadata::csearch::{ProvidedTraitMethodInfo, each_path, get_impl_traits};
 use metadata::csearch::{get_impls_for_mod};
@@ -24,12 +26,14 @@ use middle::resolve::{Impl, MethodInfo};
 use middle::ty::{ProvidedMethodSource, ProvidedMethodInfo, bound_copy, get};
 use middle::ty::{kind_can_be_copied, lookup_item_type, param_bounds, subst};
 use middle::ty::{t, ty_bool, ty_bot, ty_box, ty_enum, ty_err, ty_estr};
-use middle::ty::{ty_evec, ty_float, ty_fn, ty_infer, ty_int, ty_nil, ty_ptr};
-use middle::ty::{ty_rec, ty_rptr, ty_struct, ty_trait, ty_tup, ty_uint};
-use middle::ty::{ty_param, ty_self, ty_type, ty_opaque_box, ty_uniq};
+use middle::ty::{ty_evec, ty_float, ty_fn, ty_infer, ty_int, ty_nil};
+use middle::ty::{ty_opaque_box, ty_param, ty_param_bounds_and_ty, ty_ptr};
+use middle::ty::{ty_rec, ty_rptr, ty_self, ty_struct, ty_trait, ty_tup};
+use middle::ty::{ty_type, ty_uint, ty_uniq};
 use middle::ty::{ty_opaque_closure_ptr, ty_unboxed_vec, type_kind_ext};
 use middle::ty::{type_is_ty_var};
 use middle::ty;
+use middle::typeck::crate_ctxt;
 use middle::typeck::infer::{infer_ctxt, can_mk_subty};
 use middle::typeck::infer::{new_infer_ctxt, resolve_ivar};
 use middle::typeck::infer::{resolve_nested_tvar, resolve_type};
@@ -41,7 +45,7 @@ use syntax::ast::{trait_ref};
 use syntax::ast;
 use syntax::ast_map::node_item;
 use syntax::ast_map;
-use syntax::ast_util::{def_id_of_def, dummy_sp};
+use syntax::ast_util::{def_id_of_def, dummy_sp, local_def};
 use syntax::attr;
 use syntax::codemap::span;
 use syntax::parse;

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -30,8 +30,11 @@ are represented as `ty_param()` instances.
 
 */
 
+use core::prelude::*;
+
 use metadata::csearch;
 use middle::ty::{FnMeta, FnSig, FnTyBase, InstantiatedTraitRef};
+use middle::ty::{ty_param_substs_and_ty};
 use middle::ty;
 use middle::typeck::astconv::{ast_conv, ty_of_fn_decl, ty_of_arg};
 use middle::typeck::astconv::{ast_ty_to_ty};
@@ -39,7 +42,8 @@ use middle::typeck::astconv;
 use middle::typeck::infer;
 use middle::typeck::rscope::*;
 use middle::typeck::rscope;
-use util::common::pluralize;
+use middle::typeck::{crate_ctxt, lookup_def_tcx, no_params, write_ty_to_tcx};
+use util::common::{indenter, pluralize};
 use util::ppaux;
 use util::ppaux::bound_to_str;
 
@@ -48,9 +52,12 @@ use core::option;
 use core::vec;
 use syntax::ast;
 use syntax::ast_map;
-use syntax::ast_util::trait_method_to_ty_method;
+use syntax::ast_util::{local_def, split_trait_methods};
+use syntax::ast_util::{trait_method_to_ty_method};
 use syntax::ast_util;
+use syntax::codemap::span;
 use syntax::codemap;
+use syntax::print::pprust::path_to_str;
 use syntax::visit;
 
 fn collect_item_types(ccx: @crate_ctxt, crate: @ast::crate) {

--- a/src/librustc/middle/typeck/infer/assignment.rs
+++ b/src/librustc/middle/typeck/infer/assignment.rs
@@ -58,11 +58,18 @@
 // A.  But this upper-bound might be stricter than what is truly
 // needed.
 
+use core::prelude::*;
+
+use middle::ty::TyVar;
 use middle::ty;
+use middle::typeck::infer::{ares, cres};
 use middle::typeck::infer::combine::combine_fields;
+use middle::typeck::infer::sub::Sub;
 use middle::typeck::infer::to_str::ToStr;
+use util::common::{indent, indenter};
 
 use core::option;
+use syntax::ast::{m_const, m_imm, m_mutbl};
 use syntax::ast;
 
 fn to_ares(+c: cres<ty::t>) -> ares {

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -54,14 +54,22 @@
 // terms of error reporting, although we do not do that properly right
 // now.
 
+use core::prelude::*;
+
+use middle::ty::{FloatVar, FnTyBase, FnMeta, FnSig, IntVar, TyVar};
 use middle::ty;
-use middle::ty::{FnTyBase, FnMeta, FnSig};
+use middle::typeck::infer::glb::Glb;
+use middle::typeck::infer::lub::Lub;
 use middle::typeck::infer::sub::Sub;
 use middle::typeck::infer::to_str::ToStr;
+use middle::typeck::infer::{cres, infer_ctxt, ures};
+use util::common::indent;
 
+use core::result::{iter_vec2, map_vec2};
 use core::vec;
-use syntax::ast::Onceness;
+use syntax::ast::{Onceness, purity, ret_style};
 use syntax::ast;
+use syntax::codemap::span;
 
 fn macros() { include!("macros.rs"); } // FIXME(#3114): Macro import/export.
 

--- a/src/librustc/middle/typeck/infer/floating.rs
+++ b/src/librustc/middle/typeck/infer/floating.rs
@@ -14,8 +14,10 @@ Code related to floating-point type inference.
 
 */
 
+use core::prelude::*;
+
+use middle::ty::{get, ty_float};
 use middle::ty;
-use middle::ty::ty_float;
 use middle::typeck::infer::to_str::ToStr;
 
 use core::uint;

--- a/src/librustc/middle/typeck/infer/glb.rs
+++ b/src/librustc/middle/typeck/infer/glb.rs
@@ -8,13 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::ty;
 use middle::typeck::infer::combine::*;
 use middle::typeck::infer::lattice::*;
+use middle::typeck::infer::glb::Glb;
+use middle::typeck::infer::lub::Lub;
 use middle::typeck::infer::sub::Sub;
 use middle::typeck::infer::to_str::ToStr;
+use util::ppaux::mt_to_str;
 
-use syntax::ast::{Many, Once};
+use syntax::ast::{Many, Once, extern_fn, impure_fn, m_const, m_imm, m_mutbl};
+use syntax::ast::{noreturn, pure_fn, ret_style, return_val, unsafe_fn};
 
 enum Glb = combine_fields;  // "greatest lower bound" (common subtype)
 

--- a/src/librustc/middle/typeck/infer/integral.rs
+++ b/src/librustc/middle/typeck/infer/integral.rs
@@ -14,6 +14,9 @@ Code related to integral type inference.
 
 */
 
+use core::prelude::*;
+
+use middle::ty::{get, ty_int, ty_uint};
 use middle::ty;
 use middle::typeck::infer::to_str::ToStr;
 

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -8,8 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use middle::ty::TyVar;
 use middle::ty;
+use middle::typeck::infer::*;
 use middle::typeck::infer::combine::*;
+use middle::typeck::infer::glb::Glb;
+use middle::typeck::infer::lub::Lub;
 use middle::typeck::infer::unify::*;
 use middle::typeck::infer::to_str::ToStr;
 

--- a/src/librustc/middle/typeck/infer/lub.rs
+++ b/src/librustc/middle/typeck/infer/lub.rs
@@ -8,14 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use middle::ty::RegionVid;
 use middle::ty;
 use middle::typeck::infer::combine::*;
+use middle::typeck::infer::glb::Glb;
 use middle::typeck::infer::lattice::*;
 use middle::typeck::infer::sub::Sub;
 use middle::typeck::infer::to_str::ToStr;
+use middle::typeck::isr_alist;
+use util::ppaux::mt_to_str;
 
 use std::list;
-use syntax::ast::{Many, Once};
+use syntax::ast::{Many, Once, extern_fn, m_const, impure_fn, noreturn};
+use syntax::ast::{pure_fn, ret_style, return_val, unsafe_fn};
 
 fn macros() { include!("macros.rs"); } // FIXME(#3114): Macro import/export.
 

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -259,6 +259,8 @@ section on "Type Combining" below for details.
 #[warn(deprecated_mode)];
 #[warn(deprecated_pattern)];
 
+use core::prelude::*;
+
 use middle::ty::{TyVid, IntVid, FloatVid, RegionVid, vid};
 use middle::ty::{mk_fn, type_is_bot};
 use middle::ty::{ty_int, ty_uint, get, terr_fn, TyVar, IntVar, FloatVar};
@@ -280,21 +282,25 @@ use middle::typeck::infer::resolve::{resolver};
 use middle::typeck::infer::sub::Sub;
 use middle::typeck::infer::to_str::ToStr;
 use middle::typeck::infer::unify::{vals_and_bindings, root};
+use middle::typeck::isr_alist;
 use util::common::{indent, indenter};
-use util::ppaux::{ty_to_str, mt_to_str};
+use util::ppaux::{bound_region_to_str, ty_to_str, mt_to_str};
 
 use core::cmp::Eq;
 use core::dvec::DVec;
 use core::result::{Result, Ok, Err, map_vec, map_vec2, iter_vec2};
 use core::result;
 use core::vec;
+use std::list::Nil;
 use std::map::HashMap;
 use std::smallintmap;
 use syntax::ast::{ret_style, purity};
 use syntax::ast::{m_const, m_imm, m_mutbl};
 use syntax::ast::{unsafe_fn, impure_fn, pure_fn, extern_fn};
+use syntax::ast;
 use syntax::ast_util::dummy_sp;
-use syntax::{ast, ast_util};
+use syntax::ast_util;
+use syntax::codemap::span;
 
 export infer_ctxt;
 export new_infer_ctxt;
@@ -325,6 +331,13 @@ export resolve;
 export sub;
 export to_str;
 export unify;
+export uok;
+export cyclic_ty, unresolved_ty, region_var_bound_by_region_var;
+export bound, bounds;
+export ures;
+export ares;
+export infer_ctxt;
+export fixup_err;
 
 #[legacy_exports]
 mod assignment;
@@ -557,7 +570,7 @@ impl<T:Copy Eq> cres<T>: CresCompare<T> {
     }
 }
 
-fn uok() -> ures {
+pub fn uok() -> ures {
     Ok(())
 }
 

--- a/src/librustc/middle/typeck/infer/region_inference.rs
+++ b/src/librustc/middle/typeck/infer/region_inference.rs
@@ -440,7 +440,7 @@ not: `fn(&a, &a)` and `fn(&x, &x)`.  In this case, we'll get `F=fn(&g,
 &h)` where `Tainted($g) = {$g, $a, $x}` and `Tainted($h) = {$h, $a,
 $x}`.  Both of these sets contain exactly one bound variable from each
 side, so we'll map them both to `&a`, resulting in `fn(&a, &a)`.
-Horray!
+Hooray!
 
 ### Why are these correct?
 
@@ -453,13 +453,16 @@ write it)
 #[warn(deprecated_mode)];
 #[warn(deprecated_pattern)];
 
+use core::prelude::*;
+
 use middle::region::is_subregion_of;
 use middle::region;
 use middle::ty;
 use middle::ty::{Region, RegionVid, re_static, re_infer, re_free, re_bound};
 use middle::ty::{re_scope, ReVar, ReSkolemized};
+use middle::typeck::infer::cres;
 use middle::typeck::infer::to_str::ToStr;
-use syntax::codemap;
+use util::common::indenter;
 use util::ppaux::note_and_explain_region;
 
 use core::cmp;
@@ -472,6 +475,8 @@ use result::{Ok, Err};
 use std::map::HashMap;
 use std::cell::{Cell, empty_cell};
 use std::list::{List, Nil, Cons};
+use syntax::codemap::span;
+use syntax::codemap;
 
 export RegionVarBindings;
 export make_subregion;

--- a/src/librustc/middle/typeck/infer/resolve.rs
+++ b/src/librustc/middle/typeck/infer/resolve.rs
@@ -46,12 +46,19 @@
 // future).  If you want to resolve everything but one type, you are
 // probably better off writing `resolve_all - resolve_ivar`.
 
+use middle::ty::{FloatVar, FloatVid, IntVar, IntVid, RegionVid, TyVar, TyVid};
+use middle::ty::{type_is_bot};
 use middle::ty;
+use middle::typeck::infer::{cyclic_ty, fixup_err, fres, infer_ctxt};
+use middle::typeck::infer::{region_var_bound_by_region_var, unresolved_ty};
 use middle::typeck::infer::floating::*;
 use middle::typeck::infer::floating;
 use middle::typeck::infer::integral::*;
 use middle::typeck::infer::integral;
 use middle::typeck::infer::to_str::ToStr;
+use middle::typeck::infer::unify::root;
+use util::common::indent;
+use util::ppaux::ty_to_str;
 
 use core::uint;
 use core::vec;

--- a/src/librustc/middle/typeck/infer/sub.rs
+++ b/src/librustc/middle/typeck/infer/sub.rs
@@ -8,12 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::ty;
+use middle::typeck::check::regionmanip::replace_bound_regions_in_fn_ty;
 use middle::typeck::infer::combine::*;
+use middle::typeck::infer::cres;
+use middle::typeck::infer::glb::Glb;
+use middle::typeck::infer::infer_ctxt;
+use middle::typeck::infer::lub::Lub;
 use middle::typeck::infer::to_str::ToStr;
 use middle::typeck::infer::unify::*;
+use util::ppaux::bound_region_to_str;
 
+use std::list::Nil;
 use std::list;
+use syntax::ast::{m_const, purity, ret_style};
 
 fn macros() { include!("macros.rs"); } // FIXME(#3114): Macro import/export.
 

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -16,21 +16,22 @@ Note: This module is only compiled when doing unit testing.
 
 */
 
+use driver::diagnostic;
+use driver::driver::{optgroups, build_session_options, build_session};
+use driver::driver::{str_input, build_configuration};
+use middle::lang_items::{LanguageItems, language_items};
+use middle::ty::{FnTyBase, FnMeta, FnSig};
+use util::ppaux::ty_to_str;
+
+use std::getopts::groups::{optopt, optmulti, optflag, optflagopt, getopts};
+use std::getopts::groups;
+use std::getopts::{opt_present};
+use std::getopts;
 use std::getopts;
 use std::map::HashMap;
-use std::getopts;
-use std::getopts::{opt_present};
-use std::getopts::groups;
-use std::getopts::groups::{optopt, optmulti, optflag, optflagopt, getopts};
-use driver::driver::{optgroups, build_session_options, build_session,
-                     str_input, build_configuration};
-use driver::diagnostic;
-use syntax::{ast, attr, parse};
-use syntax::parse::parse_crate_from_source_str;
-use middle::lang_items::{LanguageItems, language_items};
-use util::ppaux::ty_to_str;
 use syntax::ast_util::dummy_sp;
-use middle::ty::{FnTyBase, FnMeta, FnSig};
+use syntax::parse::parse_crate_from_source_str;
+use syntax::{ast, attr, parse};
 
 struct Env {
     crate: @ast::crate,

--- a/src/librustc/middle/typeck/infer/to_str.rs
+++ b/src/librustc/middle/typeck/infer/to_str.rs
@@ -8,10 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
+use middle::ty::vid;
 use middle::ty;
-use middle::typeck::infer::integral::int_ty_set;
+use middle::typeck::infer::{bound, bounds};
 use middle::typeck::infer::floating::float_ty_set;
+use middle::typeck::infer::infer_ctxt;
+use middle::typeck::infer::integral::int_ty_set;
 use middle::typeck::infer::unify::{redirect, root, var_value};
+use util::ppaux::{mt_to_str, ty_to_str};
 use util::ppaux;
 
 use core::uint;

--- a/src/librustc/middle/typeck/infer/unify.rs
+++ b/src/librustc/middle/typeck/infer/unify.rs
@@ -8,13 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
+use middle::ty::vid;
 use middle::ty;
+use middle::typeck::infer::{bound, bounds, cres, uok, ures};
 use middle::typeck::infer::combine::combine;
 use middle::typeck::infer::floating::*;
 use middle::typeck::infer::floating;
+use middle::typeck::infer::infer_ctxt;
 use middle::typeck::infer::integral::*;
 use middle::typeck::infer::integral;
 use middle::typeck::infer::to_str::ToStr;
+use util::common::{indent, indenter};
 
 use core::result;
 use std::smallintmap::SmallIntMap;

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -50,6 +50,8 @@ independently:
 
 #[legacy_exports];
 
+use core::prelude::*;
+
 use metadata::csearch;
 use middle::pat_util::{pat_id_map, PatIdMap};
 use middle::resolve;
@@ -99,6 +101,12 @@ export infer;
 export collect;
 export coherence;
 export deriving;
+export crate_ctxt;
+export write_ty_to_tcx, write_substs_to_tcx;
+export no_params;
+export isr_alist;
+export require_same_types;
+export lookup_def_ccx, lookup_def_tcx;
 
 #[legacy_exports]
 #[path = "check/mod.rs"]
@@ -224,7 +232,7 @@ type crate_ctxt_ = {// A mapping from method call sites to traits that have
                     coherence_info: @coherence::CoherenceInfo,
                     tcx: ty::ctxt};
 
-enum crate_ctxt {
+pub enum crate_ctxt {
     crate_ctxt_(crate_ctxt_)
 }
 

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -8,11 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::ty;
 
 use core::result::Result;
 use core::result;
 use syntax::ast;
+use syntax::codemap::span;
 use syntax::parse::token::special_idents;
 
 trait region_scope {

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -22,6 +22,8 @@
 #[legacy_modes];
 #[legacy_exports];
 
+#[disable_unwinding];
+
 #[allow(vecs_implicitly_copyable)];
 #[allow(non_camel_case_types)];
 #[allow(deprecated_mode)];
@@ -377,11 +379,12 @@ diagnostic emitter which records when we hit a fatal error. If the task
 fails without recording a fatal error then we've encountered a compiler
 bug and need to present an error.
 */
+#[cfg(stage0)]
 fn monitor(+f: fn~(diagnostic::emitter)) {
     let p = oldcomm::Port();
     let ch = oldcomm::Chan(&p);
 
-    match do task::try |move f| {
+    do task::spawn |move f| {
 
         // The 'diagnostics emitter'. Every error, warning, etc. should
         // go through this function.
@@ -401,9 +404,33 @@ fn monitor(+f: fn~(diagnostic::emitter)) {
         let _finally = finally { ch: ch };
 
         f(demitter)
-    } {
-        result::Ok(_) => { /* fallthrough */ }
-        result::Err(_) => {
+    }
+}
+#[cfg(stage1)]
+#[cfg(stage2)]
+fn monitor(+f: fn~(diagnostic::emitter)) {
+    do task::spawn |move f| {
+        let p = oldcomm::Port::<monitor_msg>();
+        let ch = oldcomm::Chan::<monitor_msg>(&p);
+
+        // The 'diagnostics emitter'. Every error, warning, etc. should
+        // go through this function.
+        let demitter = fn@(cmsp: Option<(@codemap::CodeMap, codemap::span)>,
+                           msg: &str, lvl: diagnostic::level) {
+            if lvl == diagnostic::fatal {
+                oldcomm::send(ch, fatal);
+            }
+            diagnostic::emit(cmsp, msg, lvl);
+        };
+
+        struct finally {
+            ch: oldcomm::Chan<monitor_msg>,
+            drop { oldcomm::send(self.ch, done); }
+        }
+
+        let _finally = finally { ch: ch };
+
+        do sys::failing::cond.trap(|_| {
             // Task failed without emitting a fatal diagnostic
             if oldcomm::recv(p) == done {
                 diagnostic::emit(
@@ -421,8 +448,10 @@ fn monitor(+f: fn~(diagnostic::emitter)) {
                     diagnostic::emit(None, *note, diagnostic::note)
                 }
             }
-            // Fail so the process returns a failure code
-            fail;
+
+            libc::exit(1)
+        }).in {
+            f(demitter)
         }
     }
 }

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use syntax::ast;
 use syntax::codemap::{span};
 use syntax::visit;

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use middle::ty;
 use middle::ty::{arg, canon_mode};
 use middle::ty::{bound_copy, bound_const, bound_durable, bound_owned,

--- a/src/librustdoc/astsrv.rs
+++ b/src/librustdoc/astsrv.rs
@@ -17,6 +17,8 @@ query AST-related information, shielding the rest of Rustdoc from its
 non-sendableness.
 */
 
+use core::prelude::*;
+
 use parse;
 use util;
 

--- a/src/librustdoc/attr_parser.rs
+++ b/src/librustdoc/attr_parser.rs
@@ -15,6 +15,8 @@ The attribute parser provides methods for pulling documentation out of
 an AST's attributes.
 */
 
+use core::prelude::*;
+
 use core::str;
 use core::tuple;
 use core::vec;

--- a/src/librustdoc/attr_pass.rs
+++ b/src/librustdoc/attr_pass.rs
@@ -16,6 +16,8 @@ corresponding AST nodes. The information gathered here is the basis
 of the natural-language documentation for a crate.
 */
 
+use core::prelude::*;
+
 use astsrv;
 use attr_parser;
 use doc::ItemUtils;
@@ -23,6 +25,7 @@ use doc;
 use extract::to_str;
 use fold::Fold;
 use fold;
+use pass::Pass;
 
 use core::option;
 use core::vec;

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use core::cmp;
 use core::os;
 use core::result;

--- a/src/librustdoc/demo.rs
+++ b/src/librustdoc/demo.rs
@@ -21,6 +21,8 @@
  * tests on this file
  */
 
+use core::prelude::*;
+
 /// The base price of a muffin on a non-holiday
 const price_of_a_muffin: float = 70f;
 

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -15,11 +15,14 @@ If the first paragraph of a long description is short enough then it
 is interpreted as the brief description.
 */
 
+use core::prelude::*;
+
 use astsrv;
 use doc::ItemUtils;
 use doc;
 use fold::Fold;
 use fold;
+use pass::Pass;
 
 use core::str;
 use core::vec;

--- a/src/librustdoc/doc.rs
+++ b/src/librustdoc/doc.rs
@@ -10,7 +10,10 @@
 
 //! The document model
 
+use core::prelude::*;
+
 use doc;
+use pass::Pass;
 
 use core::cmp;
 use core::option;

--- a/src/librustdoc/escape_pass.rs
+++ b/src/librustdoc/escape_pass.rs
@@ -10,6 +10,7 @@
 
 //! Escapes text sequences
 
+use pass::Pass;
 use text_pass;
 
 use core::str;

--- a/src/librustdoc/extract.rs
+++ b/src/librustdoc/extract.rs
@@ -10,6 +10,8 @@
 
 //! Converts the Rust AST to the rustdoc document model
 
+use core::prelude::*;
+
 use astsrv;
 use doc::ItemUtils;
 use doc;

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -8,10 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use astsrv;
 use doc;
 use extract;
 use parse;
+use pass::Pass;
 
 use core::vec;
 use std::par;

--- a/src/librustdoc/markdown_index_pass.rs
+++ b/src/librustdoc/markdown_index_pass.rs
@@ -10,6 +10,8 @@
 
 //! Build indexes as appropriate for the markdown pass
 
+use core::prelude::*;
+
 use astsrv;
 use config;
 use doc::ItemUtils;
@@ -18,6 +20,7 @@ use fold::Fold;
 use fold;
 use markdown_pass;
 use markdown_writer;
+use pass::Pass;
 
 use core::str;
 use std::par;

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -10,6 +10,8 @@
 
 //! Generate markdown from a document tree
 
+use core::prelude::*;
+
 use astsrv;
 use attr_pass;
 use config;
@@ -25,6 +27,7 @@ use markdown_writer::WriterUtils;
 use markdown_writer::WriterFactory;
 use markdown_writer;
 use page_pass;
+use pass::Pass;
 use path_pass;
 use sectionalize_pass;
 use sort_pass;

--- a/src/librustdoc/markdown_writer.rs
+++ b/src/librustdoc/markdown_writer.rs
@@ -8,9 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use config;
 use doc::ItemUtils;
 use doc;
+use pass::Pass;
 
 use core::io::ReaderUtil;
 use core::io;

--- a/src/librustdoc/page_pass.rs
+++ b/src/librustdoc/page_pass.rs
@@ -15,12 +15,15 @@ Each page corresponds is a logical section. There may be pages for
 individual modules, pages for the crate, indexes, etc.
 */
 
+use core::prelude::*;
+
 use astsrv;
 use config;
 use doc::{ItemUtils, PageUtils};
 use doc;
 use fold::Fold;
 use fold;
+use pass::Pass;
 use sort_pass;
 use util::NominalOp;
 use util;

--- a/src/librustdoc/parse.rs
+++ b/src/librustdoc/parse.rs
@@ -10,6 +10,8 @@
 
 //! AST-parsing helpers
 
+use core::prelude::*;
+
 use rustc::driver::driver::{file_input, str_input};
 use rustc::driver::driver;
 use rustc::driver::session;

--- a/src/librustdoc/pass.rs
+++ b/src/librustdoc/pass.rs
@@ -8,9 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use astsrv;
 use doc;
 use extract;
+use time;
 
 use core::vec;
 

--- a/src/librustdoc/path_pass.rs
+++ b/src/librustdoc/path_pass.rs
@@ -10,12 +10,15 @@
 
 //! Records the full path to items
 
+use core::prelude::*;
+
 use astsrv;
 use doc::ItemUtils;
 use doc;
 use extract;
 use fold::Fold;
 use fold;
+use pass::Pass;
 
 use syntax::ast;
 

--- a/src/librustdoc/prune_hidden_pass.rs
+++ b/src/librustdoc/prune_hidden_pass.rs
@@ -16,6 +16,7 @@ use doc::ItemUtils;
 use doc;
 use fold::Fold;
 use fold;
+use pass::Pass;
 
 use core::vec;
 use std::map::HashMap;

--- a/src/librustdoc/prune_private_pass.rs
+++ b/src/librustdoc/prune_private_pass.rs
@@ -12,10 +12,13 @@
 
 #[legacy_exports];
 
+use core::prelude::*;
+
 use astsrv;
 use doc;
 use fold::Fold;
 use fold;
+use pass::Pass;
 
 use core::util;
 use core::vec;

--- a/src/librustdoc/sectionalize_pass.rs
+++ b/src/librustdoc/sectionalize_pass.rs
@@ -10,6 +10,8 @@
 
 //! Breaks rustdocs into sections according to their headers
 
+use core::prelude::*;
+
 use astsrv;
 use attr_pass;
 use doc::ItemUtils;
@@ -17,6 +19,7 @@ use doc;
 use extract;
 use fold::Fold;
 use fold;
+use pass::Pass;
 
 use core::str;
 use core::vec;

--- a/src/librustdoc/sort_item_name_pass.rs
+++ b/src/librustdoc/sort_item_name_pass.rs
@@ -14,6 +14,7 @@ use astsrv;
 use doc::ItemUtils;
 use doc;
 use extract;
+use pass::Pass;
 use sort_pass;
 
 pub fn mk_pass() -> Pass {

--- a/src/librustdoc/sort_item_type_pass.rs
+++ b/src/librustdoc/sort_item_type_pass.rs
@@ -10,10 +10,13 @@
 
 //! Sorts items by type
 
+use core::prelude::*;
+
 use astsrv;
 use doc::ItemUtils;
 use doc;
 use extract;
+use pass::Pass;
 use sort_pass;
 
 pub fn mk_pass() -> Pass {

--- a/src/librustdoc/sort_pass.rs
+++ b/src/librustdoc/sort_pass.rs
@@ -10,12 +10,15 @@
 
 //! A general sorting pass
 
+use core::prelude::*;
+
 use astsrv;
 use doc::ItemUtils;
 use doc;
 use extract;
 use fold::Fold;
 use fold;
+use pass::Pass;
 use util::NominalOp;
 
 use std::sort;

--- a/src/librustdoc/text_pass.rs
+++ b/src/librustdoc/text_pass.rs
@@ -10,11 +10,14 @@
 
 //! Generic pass for performing an operation on all descriptions
 
+use core::prelude::*;
+
 use astsrv;
 use doc::ItemUtils;
 use doc;
 use fold::Fold;
 use fold;
+use pass::Pass;
 use util::NominalOp;
 
 use std::par;

--- a/src/librustdoc/trim_pass.rs
+++ b/src/librustdoc/trim_pass.rs
@@ -17,6 +17,7 @@ is interpreted as the brief description.
 
 use doc::ItemUtils;
 use doc;
+use pass::Pass;
 use text_pass;
 
 use core::str;

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -10,6 +10,8 @@
 
 //! Pulls type information out of the AST and attaches it to the document
 
+use core::prelude::*;
+
 use astsrv;
 use doc::ItemUtils;
 use doc;
@@ -17,6 +19,7 @@ use extract::to_str;
 use extract;
 use fold::Fold;
 use fold;
+use pass::Pass;
 
 use core::vec;
 use std::map::HashMap;

--- a/src/librustdoc/unindent_pass.rs
+++ b/src/librustdoc/unindent_pass.rs
@@ -19,6 +19,9 @@ instances where the string containing the doc comment is opened in the
 middle of a line, and each of the following lines is indented.
 */
 
+use core::prelude::*;
+
+use pass::Pass;
 use text_pass;
 
 use core::str;

--- a/src/librustdoc/util.rs
+++ b/src/librustdoc/util.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use core::oldcomm;
 use core::task;
 

--- a/src/libstd/arc.rs
+++ b/src/libstd/arc.rs
@@ -20,6 +20,7 @@ use sync::{Mutex, mutex_with_condvars, RWlock, rwlock_with_condvars};
 
 use core::cast;
 use core::pipes;
+use core::prelude::*;
 use core::private::{SharedMutableState, shared_mutable_state};
 use core::private::{clone_shared_mutable_state, unwrap_shared_mutable_state};
 use core::private::{get_shared_mutable_state, get_shared_immutable_state};
@@ -470,6 +471,9 @@ impl<T: Const Owned> &RWReadMode<T> {
 mod tests {
     #[legacy_exports];
 
+    use core::prelude::*;
+
+    use arc::*;
     use arc;
 
     use core::oldcomm::*;

--- a/src/libstd/arena.rs
+++ b/src/libstd/arena.rs
@@ -42,6 +42,7 @@ use core::at_vec;
 use core::cast::reinterpret_cast;
 use core::cast;
 use core::libc::size_t;
+use core::prelude::*;
 use core::ptr;
 use core::sys::TypeDesc;
 use core::sys;

--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -11,6 +11,7 @@
 #[forbid(deprecated_mode)];
 
 use core::ops;
+use core::prelude::*;
 use core::uint;
 use core::vec::{to_mut, from_elem};
 use core::vec;
@@ -578,6 +579,9 @@ impl Bitv: ops::Index<uint,bool> {
 mod tests {
     #[legacy_exports];
 
+    use core::prelude::*;
+
+    use bitv::*;
     use bitv;
 
     use core::uint;

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -40,6 +40,7 @@
 use core::libc;
 use core::oldcomm;
 use core::option;
+use core::prelude::*;
 use core::ptr;
 use core::task;
 
@@ -152,6 +153,10 @@ pub unsafe fn ptr<T>(t: CVec<T>) -> *mut T {
 
 #[cfg(test)]
 mod tests {
+    use core::prelude::*;
+
+    use c_vec::*;
+
     use core::libc::*;
     use core::libc;
 

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -11,6 +11,7 @@
 #[forbid(deprecated_mode)];
 
 use core::option;
+use core::prelude::*;
 
 /// A dynamic, mutable location.
 ///

--- a/src/libstd/comm.rs
+++ b/src/libstd/comm.rs
@@ -20,6 +20,7 @@ Higher level communication abstractions.
 use core::pipes::{GenericChan, GenericSmartChan, GenericPort};
 use core::pipes::{Chan, Port, Selectable, Peekable};
 use core::pipes;
+use core::prelude::*;
 
 /// An extension of `pipes::stream` that allows both sending and receiving.
 pub struct DuplexStream<T: Owned, U: Owned> {
@@ -80,6 +81,8 @@ pub fn DuplexStream<T: Owned, U: Owned>()
 #[cfg(test)]
 mod test {
     #[legacy_exports];
+    use comm::DuplexStream;
+
     #[test]
     fn DuplexStream1() {
         let (left, right) = DuplexStream();

--- a/src/libstd/deque.rs
+++ b/src/libstd/deque.rs
@@ -15,6 +15,7 @@
 use core::cmp::Eq;
 use core::dvec::DVec;
 use core::dvec;
+use core::prelude::*;
 use core::uint;
 use core::vec;
 
@@ -131,6 +132,9 @@ pub fn create<T: Copy>() -> Deque<T> {
 
 #[cfg(test)]
 mod tests {
+    use core::prelude::*;
+
+    use deque::*;
     use deque;
 
     #[test]

--- a/src/libstd/ebml.rs
+++ b/src/libstd/ebml.rs
@@ -14,6 +14,7 @@ use serialize;
 
 use core::io;
 use core::ops;
+use core::prelude::*;
 use core::str;
 use core::vec;
 
@@ -33,18 +34,18 @@ struct EbmlState {
     data_pos: uint,
 }
 
-struct Doc {
+pub struct Doc {
     data: @~[u8],
     start: uint,
     end: uint,
 }
 
-struct TaggedDoc {
+pub struct TaggedDoc {
     tag: uint,
     doc: Doc,
 }
 
-enum EbmlEncoderTag {
+pub enum EbmlEncoderTag {
     EsUint, EsU64, EsU32, EsU16, EsU8,
     EsInt, EsI64, EsI32, EsI16, EsI8,
     EsBool,
@@ -60,11 +61,16 @@ enum EbmlEncoderTag {
 // --------------------------------------
 
 pub mod reader {
+    use ebml::{Doc, EbmlEncoderTag, EsBool, EsEnum, EsEnumBody, EsEnumVid};
+    use ebml::{EsF32, EsF64, EsFloat, EsI16, EsI32, EsI64, EsI8, EsInt};
+    use ebml::{EsLabel, EsOpaque, EsStr, EsU16, EsU32, EsU64, EsU8, EsUint};
+    use ebml::{EsVec, EsVecElt, EsVecLen, TaggedDoc};
     use serialize;
 
     use core::int;
     use core::io;
     use core::ops;
+    use core::prelude::*;
     use core::str;
     use core::vec;
 
@@ -398,6 +404,11 @@ pub mod reader {
 }
 
 pub mod writer {
+    use ebml::{Doc, EbmlEncoderTag, EsBool, EsEnum, EsEnumBody, EsEnumVid};
+    use ebml::{EsF32, EsF64, EsFloat, EsI16, EsI32, EsI64, EsI8, EsInt};
+    use ebml::{EsLabel, EsOpaque, EsStr, EsU16, EsU32, EsU64, EsU8, EsUint};
+    use ebml::{EsVec, EsVecElt, EsVecLen, TaggedDoc};
+
     use core::io;
     use core::str;
     use core::vec;
@@ -668,6 +679,7 @@ mod tests {
     use serialize;
 
     use core::io;
+    use core::option::{None, Option, Some};
 
     #[test]
     fn test_option_int() {

--- a/src/libstd/flatpipes.rs
+++ b/src/libstd/flatpipes.rs
@@ -42,6 +42,7 @@ use core::io;
 use core::pipes::GenericChan;
 use core::pipes::GenericPort;
 use core::pipes;
+use core::prelude::*;
 use core::sys::size_of;
 use core::uint;
 use core::vec;
@@ -160,14 +161,15 @@ POD are not equivelant.
 
 */
 pub mod pod {
-
-    use core::io::{Reader, Writer};
-    use core::pipes::{Port, Chan};
-    use core::pipes;
     use flatpipes::flatteners::{PodUnflattener, PodFlattener};
     use flatpipes::bytepipes::{ReaderBytePort, WriterByteChan};
     use flatpipes::bytepipes::{PipeBytePort, PipeByteChan};
     use flatpipes::{FlatPort, FlatChan};
+
+    use core::io::{Reader, Writer};
+    use core::pipes::{Port, Chan};
+    use core::pipes;
+    use core::prelude::*;
 
     pub type ReaderPort<T: Copy Owned, R> =
         FlatPort<T, PodUnflattener<T>, ReaderBytePort<R>>;
@@ -326,12 +328,14 @@ pub impl<T,F:Flattener<T>,C:ByteChan> FlatChan<T, F, C> {
 
 pub mod flatteners {
     use ebml;
+    use flatpipes::{ByteChan, BytePort, Flattener, Unflattener};
     use flatpipes::util::BufReader;
     use json;
     use serialize::{Encoder, Decoder, Encodable, Decodable};
 
     use core::cast;
     use core::io::{Writer, Reader, BytesWriter, ReaderUtil};
+    use core::prelude::*;
     use core::ptr;
     use core::sys::size_of;
     use core::vec;
@@ -496,9 +500,12 @@ pub mod flatteners {
 }
 
 pub mod bytepipes {
+    use flatpipes::{ByteChan, BytePort};
+
     use core::io::{Writer, Reader, ReaderUtil};
     use core::pipes::{Port, Chan};
     use core::pipes;
+    use core::prelude::*;
 
     pub struct ReaderBytePort<R: Reader> {
         reader: R
@@ -622,6 +629,7 @@ pub mod bytepipes {
 mod util {
     use core::io::{Reader, BytesReader};
     use core::io;
+    use core::prelude::*;
 
     pub struct BufReader {
         buf: ~[u8],
@@ -675,6 +683,7 @@ mod util {
 
 #[cfg(test)]
 mod test {
+    use core::prelude::*;
 
     // XXX: json::Decoder doesn't work because of problems related to
     // its interior pointers
@@ -688,6 +697,7 @@ mod test {
     use flatpipes::pod;
     use flatpipes::serial;
     use flatpipes::util::BufReader;
+    use flatpipes::{BytePort, FlatChan, FlatPort};
     use net::ip;
     use net::tcp::TcpSocketBuf;
 
@@ -695,6 +705,7 @@ mod test {
     use core::int;
     use core::io::BytesReader;
     use core::io;
+    use core::prelude::*;
     use core::result;
     use core::sys;
     use core::task;
@@ -918,6 +929,10 @@ mod test {
     // Tests that the different backends behave the same when the
     // binary streaming protocol is broken
     mod broken_protocol {
+        use core::prelude::*;
+
+        use flatpipes::{BytePort, FlatPort};
+        use flatpipes::flatteners::PodUnflattener;
         use flatpipes::pod;
         use flatpipes::util::BufReader;
 

--- a/src/libstd/fun_treemap.rs
+++ b/src/libstd/fun_treemap.rs
@@ -23,6 +23,7 @@
 
 use core::cmp::{Eq, Ord};
 use core::option::{Some, None};
+use core::prelude::*;
 
 pub type Treemap<K, V> = @TreeNode<K, V>;
 

--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -26,6 +26,7 @@ use core::cast;
 use core::either::Either;
 use core::option;
 use core::pipes::{recv, oneshot, ChanOne, PortOne, send_one, recv_one};
+use core::prelude::*;
 use core::task;
 
 #[doc = "The future type"]
@@ -145,6 +146,10 @@ pub fn spawn<A:Owned>(blk: fn~() -> A) -> Future<A> {
 
 #[allow(non_implicitly_copyable_typarams)]
 pub mod test {
+    use core::prelude::*;
+
+    use future::*;
+
     use core::pipes::oneshot;
     use core::task;
 

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -75,6 +75,7 @@
 #[forbid(deprecated_mode)];
 
 use core::cmp::Eq;
+use core::prelude::*;
 use core::result::{Err, Ok};
 use core::result;
 use core::option;
@@ -83,16 +84,16 @@ use core::str;
 use core::vec;
 
 #[deriving_eq]
-enum Name {
+pub enum Name {
     Long(~str),
     Short(char),
 }
 
 #[deriving_eq]
-enum HasArg { Yes, No, Maybe, }
+pub enum HasArg { Yes, No, Maybe, }
 
 #[deriving_eq]
-enum Occur { Req, Optional, Multi, }
+pub enum Occur { Req, Optional, Multi, }
 
 /// A description of a possible option
 #[deriving_eq]
@@ -453,8 +454,10 @@ enum FailType {
  *  groups of short and long option names, together.
  */
 pub mod groups {
-    use getopts::Result;
+    use getopts::{HasArg, Long, Maybe, Multi, No, Occur, Opt, Optional, Req};
+    use getopts::{Result, Short, Yes};
 
+    use core::prelude::*;
     use core::str;
     use core::vec;
 
@@ -569,7 +572,7 @@ pub mod groups {
     /*
      * Parse command line args with the provided long format options
      */
-    pub fn getopts(args: &[~str], opts: &[OptGroup]) -> Result {
+    pub fn getopts(args: &[~str], opts: &[OptGroup]) -> ::getopts::Result {
         ::getopts::getopts(args, vec::flat_map(opts, long_to_short))
     }
 
@@ -633,9 +636,11 @@ pub mod groups {
 #[cfg(test)]
 mod tests {
     #[legacy_exports];
+    use core::prelude::*;
+
     use opt = getopts;
     use getopts::groups::OptGroup;
-    use getopts::groups;
+    use getopts::*;
 
     use core::result::{Err, Ok};
     use core::result;

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -23,6 +23,7 @@ use core::cmp::{Eq, Ord};
 use core::float;
 use core::io::{WriterUtil, ReaderUtil};
 use core::io;
+use core::prelude::*;
 use core::send_map::linear;
 use core::str;
 use core::to_str;
@@ -1193,6 +1194,10 @@ impl Error: to_str::ToStr {
 
 #[cfg(test)]
 mod tests {
+    use core::prelude::*;
+
+    use json::*;
+
     use core::result;
     use core::send_map::linear;
 

--- a/src/libstd/list.rs
+++ b/src/libstd/list.rs
@@ -14,6 +14,7 @@
 use core::cmp::Eq;
 use core::option;
 use core::option::*;
+use core::prelude::*;
 use core::vec;
 
 #[deriving_eq]
@@ -162,6 +163,7 @@ pub pure fn each<T>(l: @List<T>, f: fn(&T) -> bool) {
 mod tests {
     #[legacy_exports];
 
+    use list::*;
     use list;
 
     use core::option;

--- a/src/libstd/map.rs
+++ b/src/libstd/map.rs
@@ -18,6 +18,7 @@ use core::io;
 use core::ops;
 use core::to_str::ToStr;
 use core::mutable::Mut;
+use core::prelude::*;
 use core::send_map::linear::LinearMap;
 use core::to_bytes::IterBytes;
 use core::uint;
@@ -120,11 +121,12 @@ pub mod util {
 // FIXME (#2344): package this up and export it as a datatype usable for
 // external code that doesn't want to pay the cost of a box.
 pub mod chained {
-    use map::util;
+    use map::{Map, util};
 
     use core::io;
     use core::ops;
     use core::option;
+    use core::prelude::*;
     use core::uint;
     use core::vec;
 
@@ -615,6 +617,7 @@ impl<K: Eq IterBytes Hash Copy, V: Copy> @Mut<LinearMap<K, V>>:
 mod tests {
     use map;
 
+    use core::option::None;
     use core::option;
     use core::uint;
 

--- a/src/libstd/net_ip.rs
+++ b/src/libstd/net_ip.rs
@@ -13,6 +13,7 @@
 
 use core::libc;
 use core::oldcomm;
+use core::prelude::*;
 use core::ptr;
 use core::result;
 use core::str;
@@ -47,7 +48,7 @@ pub enum IpAddr {
 }
 
 /// Human-friendly feedback on why a parse_addr attempt failed
-type ParseAddrErr = {
+pub type ParseAddrErr = {
     err_msg: ~str
 };
 
@@ -147,8 +148,12 @@ pub fn get_addr(node: &str, iotask: iotask)
 }
 
 pub mod v4 {
+    use net::ip::{IpAddr, Ipv4, Ipv6, ParseAddrErr};
     use uv::ll;
+    use uv_ip4_addr = uv::ll::ip4_addr;
+    use uv_ip4_name = uv::ll::ip4_name;
 
+    use core::prelude::*;
     use core::ptr;
     use core::result;
     use core::str;
@@ -241,6 +246,11 @@ pub mod v4 {
     }
 }
 pub mod v6 {
+    use net::ip::{IpAddr, Ipv6, ParseAddrErr};
+    use uv_ip6_addr = uv::ll::ip6_addr;
+    use uv_ip6_name = uv::ll::ip6_name;
+
+    use core::prelude::*;
     use core::result;
     use core::str;
 
@@ -350,6 +360,9 @@ extern fn get_addr_cb(handle: *uv_getaddrinfo_t, status: libc::c_int,
 
 #[cfg(test)]
 mod test {
+    use core::prelude::*;
+
+    use net_ip::*;
     use net_ip::v4;
     use net_ip::v6;
     use uv;

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -24,6 +24,7 @@ use core::io;
 use core::libc::size_t;
 use core::libc;
 use core::oldcomm;
+use core::prelude::*;
 use core::ptr;
 use core::result::{Result};
 use core::result;
@@ -86,7 +87,7 @@ pub type TcpErrData = {
     err_msg: ~str
 };
 /// Details returned as part of a `result::err` result from `tcp::listen`
-enum TcpListenErrData {
+pub enum TcpListenErrData {
     /**
      * Some unplanned-for error. The first and second fields correspond
      * to libuv's `err_name` and `err_msg` fields, respectively.
@@ -374,7 +375,7 @@ pub fn read_stop(sock: &TcpSocket,
  * * `timeout_msecs` - a `uint` value, in msecs, to wait before dropping the
  * read attempt. Pass `0u` to wait indefinitely
  */
-fn read(sock: &TcpSocket, timeout_msecs: uint)
+pub fn read(sock: &TcpSocket, timeout_msecs: uint)
     -> result::Result<~[u8],TcpErrData> {
     let socket_data = ptr::addr_of(&(*(sock.socket_data)));
     read_common_impl(socket_data, timeout_msecs)
@@ -1270,12 +1271,16 @@ type TcpBufferedSocketData = {
 
 //#[cfg(test)]
 mod test {
-    use net;
     use net::ip;
+    use net::tcp::{GenericListenErr, TcpConnectErrData, TcpListenErrData};
+    use net::tcp::{TcpSocket, accept, connect, listen, read, socket_buf};
+    use net;
+    use uv::iotask::IoTask;
     use uv;
 
     use core::io;
     use core::oldcomm;
+    use core::prelude::*;
     use core::result;
     use core::str;
     use core::task;

--- a/src/libstd/net_url.rs
+++ b/src/libstd/net_url.rs
@@ -19,6 +19,7 @@ use core::dvec::DVec;
 use core::from_str::FromStr;
 use core::io::{Reader, ReaderUtil};
 use core::io;
+use core::prelude::*;
 use core::send_map::linear::LinearMap;
 use core::send_map;
 use core::str;
@@ -735,6 +736,10 @@ impl Url: to_bytes::IterBytes {
 #[cfg(test)]
 mod tests {
     #[legacy_exports];
+
+    use core::prelude::*;
+
+    use net_url::*;
     use net_url::UserInfo;
 
     use core::result;

--- a/src/libstd/par.rs
+++ b/src/libstd/par.rs
@@ -11,6 +11,7 @@
 #[forbid(deprecated_mode)];
 
 use core::cast;
+use core::prelude::*;
 use core::ptr;
 use core::sys;
 use core::uint;

--- a/src/libstd/priority_queue.rs
+++ b/src/libstd/priority_queue.rs
@@ -2,6 +2,7 @@
 //! A priority queue implemented with a binary heap
 
 use core::cmp::Ord;
+use core::prelude::*;
 use core::ptr::addr_of;
 use core::vec;
 

--- a/src/libstd/rl.rs
+++ b/src/libstd/rl.rs
@@ -12,6 +12,7 @@
 // state without mutexes.
 
 use core::libc::{c_char, c_int};
+use core::prelude::*;
 use core::str;
 use core::task;
 

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -38,6 +38,7 @@
 use core::cast;
 use core::char;
 use core::option;
+use core::prelude::*;
 use core::str;
 use core::uint;
 use core::vec;
@@ -448,7 +449,9 @@ pub fn loop_leaves(rope: Rope, it: fn(node::Leaf) -> bool) -> bool{
 
 pub mod iterator {
     pub mod leaf {
-        use rope::node;
+        use rope::{Rope, node};
+
+        use core::prelude::*;
 
         pub fn start(rope: Rope) -> node::leaf_iterator::T {
             match (rope) {
@@ -461,7 +464,9 @@ pub mod iterator {
         }
     }
     pub mod char {
-        use rope::node;
+        use rope::{Rope, node};
+
+        use core::prelude::*;
 
         pub fn start(rope: Rope) -> node::char_iterator::T {
             match (rope) {
@@ -560,6 +565,7 @@ pub mod node {
     use core::cast;
     use core::char;
     use core::option;
+    use core::prelude::*;
     use core::str;
     use core::uint;
     use core::vec;
@@ -1135,7 +1141,10 @@ pub mod node {
     }
 
     pub mod leaf_iterator {
+        use rope::node::{Concat, Leaf, Node, height};
+
         use core::option;
+        use core::prelude::*;
         use core::vec;
 
         pub type T = {
@@ -1175,9 +1184,11 @@ pub mod node {
     }
 
     pub mod char_iterator {
+        use rope::node::{Leaf, Node};
         use rope::node::leaf_iterator;
 
         use core::option;
+        use core::prelude::*;
         use core::str;
 
         pub type T = {
@@ -1259,8 +1270,7 @@ pub mod node {
 
 #[cfg(test)]
 mod tests {
-    use rope::iterator;
-    use rope::node;
+    use rope::*;
 
     use core::option;
     use core::str;

--- a/src/libstd/serialize.rs
+++ b/src/libstd/serialize.rs
@@ -18,6 +18,7 @@ Core encoding and decoding interfaces.
 #[forbid(non_camel_case_types)];
 
 use core::at_vec;
+use core::prelude::*;
 use core::vec;
 
 pub trait Encoder {

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -21,6 +21,7 @@ use core::dvec::DVec;
 use core::ops;
 use core::option::{Some, None};
 use core::option;
+use core::prelude::*;
 
 // FIXME (#2347): Should not be @; there's a bug somewhere in rustc that
 // requires this to be.
@@ -168,6 +169,8 @@ pub fn as_map<V: Copy>(s: SmallIntMap<V>) -> map::Map<uint, V> {
 
 #[cfg(test)]
 mod tests {
+    use smallintmap::{mk, SmallIntMap};
+
     use core::option::None;
     use core::option;
 

--- a/src/libstd/sort.rs
+++ b/src/libstd/sort.rs
@@ -13,6 +13,7 @@
 
 use core::cmp::{Eq, Ord};
 use core::dvec::DVec;
+use core::prelude::*;
 use core::util;
 use core::vec::{len, push};
 use core::vec;
@@ -715,6 +716,10 @@ fn copy_vec<T: Copy>(dest: &[mut T], s1: uint,
 mod test_qsort3 {
     #[legacy_exports];
 
+    use core::prelude::*;
+
+    use sort::*;
+
     use core::vec;
 
     fn check_sort(v1: &[mut int], v2: &[mut int]) {
@@ -757,6 +762,10 @@ mod test_qsort3 {
 #[cfg(test)]
 mod test_qsort {
     #[legacy_exports];
+
+    use core::prelude::*;
+
+    use sort::*;
 
     use core::int;
     use core::vec;
@@ -821,6 +830,10 @@ mod test_qsort {
 #[cfg(test)]
 mod tests {
     #[legacy_exports];
+
+    use core::prelude::*;
+
+    use sort::*;
 
     use core::vec;
 
@@ -887,6 +900,10 @@ mod tests {
 
 #[cfg(test)]
 mod test_tim_sort {
+    use core::prelude::*;
+
+    use sort::tim_sort;
+
     use core::rand;
     use core::vec;
 
@@ -980,6 +997,10 @@ mod test_tim_sort {
 
 #[cfg(test)]
 mod big_tests {
+    use core::prelude::*;
+
+    use sort::*;
+
     use core::rand;
     use core::task;
     use core::uint;

--- a/src/libstd/sync.rs
+++ b/src/libstd/sync.rs
@@ -19,6 +19,7 @@
 
 use core::option;
 use core::pipes;
+use core::prelude::*;
 use core::private::{Exclusive, exclusive};
 use core::ptr;
 use core::task;
@@ -708,6 +709,10 @@ impl &RWlockReadMode {
 #[cfg(test)]
 mod tests {
     #[legacy_exports];
+
+    use core::prelude::*;
+
+    use sync::*;
 
     use core::cast;
     use core::option;

--- a/src/libstd/task_pool.rs
+++ b/src/libstd/task_pool.rs
@@ -14,6 +14,7 @@
 use core::io;
 use core::pipes::{Chan, Port};
 use core::pipes;
+use core::prelude::*;
 use core::task::{SchedMode, SingleThreaded};
 use core::task;
 use core::vec;

--- a/src/libstd/tempfile.rs
+++ b/src/libstd/tempfile.rs
@@ -13,6 +13,7 @@
 #[forbid(deprecated_mode)];
 
 use core::os;
+use core::prelude::*;
 use core::rand;
 use core::str;
 

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -29,6 +29,7 @@ use core::io;
 use core::libc::size_t;
 use core::oldcomm;
 use core::option;
+use core::prelude::*;
 use core::result;
 use core::str;
 use core::task::TaskBuilder;
@@ -79,7 +80,7 @@ pub type TestOpts = {filter: Option<~str>, run_ignored: bool,
 type OptRes = Either<TestOpts, ~str>;
 
 // Parses command line arguments into test options
-fn parse_opts(args: &[~str]) -> OptRes {
+pub fn parse_opts(args: &[~str]) -> OptRes {
     let args_ = vec::tail(args);
     let opts = ~[getopts::optflag(~"ignored"), getopts::optopt(~"logfile")];
     let matches =
@@ -283,9 +284,9 @@ enum TestEvent {
 
 type MonitorMsg = (TestDesc, TestResult);
 
-fn run_tests(opts: &TestOpts, tests: &[TestDesc],
+fn run_tests(opts: &TestOpts,
+             tests: &[TestDesc],
              callback: fn@(e: TestEvent)) {
-
     let mut filtered_tests = filter_tests(opts, tests);
     callback(TeFiltered(copy filtered_tests));
 
@@ -340,8 +341,9 @@ fn get_concurrency() -> uint {
 }
 
 #[allow(non_implicitly_copyable_typarams)]
-fn filter_tests(opts: &TestOpts,
-                tests: &[TestDesc]) -> ~[TestDesc] {
+pub fn filter_tests(opts: &TestOpts,
+                    tests: &[TestDesc])
+                 -> ~[TestDesc] {
     let mut filtered = vec::slice(tests, 0, tests.len());
 
     // Remove tests that don't match the test filter
@@ -393,7 +395,7 @@ fn filter_tests(opts: &TestOpts,
 
 type TestFuture = {test: TestDesc, wait: fn@() -> TestResult};
 
-fn run_test(test: TestDesc, monitor_ch: oldcomm::Chan<MonitorMsg>) {
+pub fn run_test(test: TestDesc, monitor_ch: oldcomm::Chan<MonitorMsg>) {
     if test.ignore {
         oldcomm::send(monitor_ch, (copy test, TrIgnored));
         return;
@@ -424,6 +426,8 @@ fn calc_result(test: &TestDesc, task_succeeded: bool) -> TestResult {
 #[cfg(test)]
 mod tests {
     #[legacy_exports];
+
+    use test::{TrFailed, TrIgnored, TrOk, filter_tests, parse_opts, run_test};
 
     use core::either;
     use core::oldcomm;

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -16,6 +16,7 @@ use core::libc::{c_char, c_int, c_long, size_t, time_t};
 use core::i32;
 use core::io::{Reader, ReaderUtil};
 use core::io;
+use core::prelude::*;
 use core::result::{Result, Ok, Err};
 use core::str;
 
@@ -856,6 +857,8 @@ priv fn do_strftime(format: &str, tm: &Tm) -> ~str {
 #[cfg(test)]
 mod tests {
     #[legacy_exports];
+
+    use time::*;
 
     use core::float;
     use core::os;

--- a/src/libstd/timer.rs
+++ b/src/libstd/timer.rs
@@ -19,6 +19,7 @@ use uv::iotask::IoTask;
 use core::either;
 use core::libc;
 use core::oldcomm;
+use core::prelude::*;
 use core::ptr;
 use core;
 
@@ -164,6 +165,9 @@ extern fn delayed_send_close_cb(handle: *uv::ll::uv_timer_t) unsafe {
 mod test {
     #[legacy_exports];
 
+    use core::prelude::*;
+
+    use timer::*;
     use uv;
 
     use core::iter;

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -18,8 +18,8 @@
 #[forbid(deprecated_mode)];
 
 use core::cmp::{Eq, Ord};
-use core::option::{Some, None};
-use Option = core::Option;
+use core::option::{Option, Some, None};
+use core::prelude::*;
 
 pub type TreeMap<K: Copy Eq Ord, V: Copy> = @mut TreeEdge<K, V>;
 
@@ -107,6 +107,9 @@ pub fn equals<K: Copy Eq Ord, V: Copy Eq>(t1: &const TreeEdge<K, V>,
 mod tests {
     #[legacy_exports];
 
+    use treemap::*;
+
+    use core::option::{None, Option, Some};
     use core::str;
 
     #[test]

--- a/src/libstd/uv_global_loop.rs
+++ b/src/libstd/uv_global_loop.rs
@@ -123,8 +123,11 @@ fn spawn_loop() -> IoTask {
 
 #[cfg(test)]
 mod test {
+    use core::prelude::*;
+
     use uv::iotask;
     use uv::ll;
+    use uv_global_loop::*;
 
     use core::iter;
     use core::libc;

--- a/src/libstd/uv_iotask.rs
+++ b/src/libstd/uv_iotask.rs
@@ -21,6 +21,7 @@ use ll = uv_ll;
 use core::libc::c_void;
 use core::libc;
 use core::oldcomm::{Port, Chan, listen};
+use core::prelude::*;
 use core::ptr::addr_of;
 use core::task::TaskBuilder;
 use core::task;
@@ -176,7 +177,10 @@ extern fn tear_down_close_cb(handle: *ll::uv_async_t) unsafe {
 
 #[cfg(test)]
 mod test {
+    use core::prelude::*;
+
     use uv::ll;
+    use uv_iotask::*;
 
     use core::iter;
     use core::libc;

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -34,6 +34,7 @@
 
 use core::libc::size_t;
 use core::libc;
+use core::prelude::*;
 use core::ptr::to_unsafe_ptr;
 use core::ptr;
 use core::str;
@@ -319,6 +320,9 @@ pub type uv_getaddrinfo_t = {
 };
 
 pub mod uv_ll_struct_stubgen {
+    use uv_ll::{uv_async_t, uv_connect_t, uv_getaddrinfo_t, uv_tcp_t};
+    use uv_ll::{uv_timer_t, uv_write_t};
+
     use core::ptr;
 
     pub fn gen_stub_uv_tcp_t() -> uv_tcp_t {
@@ -1040,6 +1044,10 @@ pub unsafe fn addrinfo_as_sockaddr_in6(input: *addrinfo) -> *sockaddr_in6 {
 
 #[cfg(test)]
 pub mod test {
+    use core::prelude::*;
+
+    use uv_ll::*;
+
     use core::libc;
     use core::oldcomm;
     use core::ptr;

--- a/src/libstd/workcache.rs
+++ b/src/libstd/workcache.rs
@@ -16,6 +16,7 @@ use core::either::{Either, Left, Right};
 use core::io;
 use core::option;
 use core::pipes::{recv, oneshot, PortOne, send_one};
+use core::prelude::*;
 use core::result;
 use core::run;
 use core::send_map::linear::LinearMap;

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -12,10 +12,10 @@
 
 use ast;
 use codemap::{span, FileName};
-use parse::token;
 
 use core::cast;
 use core::cmp;
+use core::option::{None, Option, Some};
 use core::ptr;
 use core::task;
 use core::to_bytes;
@@ -29,7 +29,8 @@ type spanned<T> = {node: T, span: span};
 /* can't import macros yet, so this is copied from token.rs. See its comment
  * there. */
 macro_rules! interner_key (
-    () => (cast::transmute::<(uint, uint), &fn(+v: @@token::ident_interner)>(
+    () => (cast::transmute::<(uint, uint),
+            &fn(+v: @@::parse::token::ident_interner)>(
         (-3 as uint, 0u)))
 )
 
@@ -768,10 +769,10 @@ type capture_clause = @~[capture_item];
 #[auto_decode]
 #[doc="For macro invocations; parsing is delegated to the macro"]
 enum token_tree {
-    tt_tok(span, token::Token),
+    tt_tok(span, ::parse::token::Token),
     tt_delim(~[token_tree]),
     // These only make sense for right-hand-sides of MBE macros
-    tt_seq(span, ~[token_tree], Option<token::Token>, bool),
+    tt_seq(span, ~[token_tree], Option<::parse::token::Token>, bool),
     tt_nonterminal(span, ident)
 }
 
@@ -833,10 +834,10 @@ type matcher = spanned<matcher_>;
 #[auto_decode]
 enum matcher_ {
     // match one token
-    match_tok(token::Token),
+    match_tok(::parse::token::Token),
     // match repetitions of a sequence: body, separator, zero ok?,
     // lo, hi position-in-match-array used:
-    match_seq(~[matcher], Option<token::Token>, bool, uint, uint),
+    match_seq(~[matcher], Option<::parse::token::Token>, bool, uint, uint),
     // parse a Rust NT: name to bind, name of NT, position in match array:
     match_nonterminal(ident, ident, uint)
 }
@@ -1149,7 +1150,7 @@ type fn_decl =
 
 #[auto_encode]
 #[auto_decode]
-enum purity {
+pub enum purity {
     pure_fn, // declared with "pure fn"
     unsafe_fn, // declared with "unsafe fn"
     impure_fn, // declared with "fn"

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast::*;
 use ast;
 use ast_util::{path_to_ident, stmt_id};

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -8,10 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast::*;
 use ast;
 use ast_util;
 use codemap::{span, BytePos};
+use parse::token;
 use visit;
 
 use core::cmp;

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -10,6 +10,8 @@
 
 // Functions dealing with attributes and meta_items
 
+use core::prelude::*;
+
 use ast;
 use ast_util::{spanned, dummy_spanned};
 use attr;

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -21,6 +21,8 @@ source code snippets, etc.
 
 */
 
+use core::prelude::*;
+
 use ast_util;
 
 use core::cmp;

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use codemap::span;
 use codemap;
 

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -88,10 +88,14 @@ node twice.
 
 */
 
+use core::prelude::*;
+
+use ast;
 use ast_util;
 use attr;
 use codemap::span;
 use ext::base::*;
+use parse;
 
 use core::vec;
 use std::map;
@@ -421,7 +425,7 @@ fn mk_impl(
     @{
         // This is a new-style impl declaration.
         // XXX: clownshoes
-        ident: ast::token::special_idents::clownshoes_extensions,
+        ident: parse::token::special_idents::clownshoes_extensions,
         attrs: ~[],
         id: cx.next_id(),
         node: ast::item_impl(trait_tps, opt_trait, ty, ~[f(ty)]),

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast;
 use ast_util::dummy_sp;
 use codemap;

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast;
 use codemap;
 use codemap::span;

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ext::base::*;
 use ext::base;
 

--- a/src/libsyntax/ext/deriving.rs
+++ b/src/libsyntax/ext/deriving.rs
@@ -11,6 +11,8 @@
 /// The compiler code necessary to implement the #[deriving_eq] and
 /// #[deriving_iter_bytes] extensions.
 
+use core::prelude::*;
+
 use ast::{Ty, and, bind_by_ref, binop, deref, enum_def, enum_variant_kind};
 use ast::{expr, expr_match, ident, item, item_, item_struct, item_enum};
 use ast::{item_impl, m_imm, meta_item, method, named_field, or, pat};

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast::{crate, expr_, expr_mac, mac_invoc_tt};
 use ast::{tt_delim, tt_tok, item_mac, stmt_, stmt_mac, stmt_expr, stmt_semi};
 use ast;

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -299,7 +299,7 @@ fn core_macros() -> ~str {
 
         { $c:ident: $in:ty -> $out:ty; } => {
 
-            mod $c {
+            pub mod $c {
                 fn key(_x: @::core::condition::Handler<$in,$out>) { }
 
                 pub const cond : ::core::condition::Condition<$in,$out> =

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -16,6 +16,8 @@
  * compiler syntax extension plugin interface.
  */
 
+use core::prelude::*;
+
 use ast;
 use codemap::span;
 use ext::base::*;

--- a/src/libsyntax/ext/pipes/check.rs
+++ b/src/libsyntax/ext/pipes/check.rs
@@ -29,7 +29,10 @@ that.
 
 */
 
+use core::prelude::*;
+
 use ast;
+use codemap::span;
 use ext::base::ext_ctxt;
 use ext::pipes::proto::{state, protocol, next_state};
 use ext::pipes::proto;

--- a/src/libsyntax/ext/pipes/liveness.rs
+++ b/src/libsyntax/ext/pipes/liveness.rs
@@ -37,6 +37,11 @@ updating the states using rule (2) until there are no changes.
 
 */
 
+use core::prelude::*;
+
+use ext::base::ext_ctxt;
+use ext::pipes::protocol;
+
 use core::str;
 use std::bitv::{Bitv};
 

--- a/src/libsyntax/ext/pipes/mod.rs
+++ b/src/libsyntax/ext/pipes/mod.rs
@@ -53,6 +53,8 @@ use ext::pipes::proto::{visit, protocol};
 use parse::lexer::{new_tt_reader, reader};
 use parse::parser::Parser;
 
+use core::option::None;
+
 #[legacy_exports]
 mod ast_builder;
 #[legacy_exports]

--- a/src/libsyntax/ext/pipes/parse_proto.rs
+++ b/src/libsyntax/ext/pipes/parse_proto.rs
@@ -10,10 +10,11 @@
 
 // Parsing pipes protocols from token trees.
 
+use ext::pipes::pipec::*;
 use parse::parser;
 use parse::token;
 
-use ext::pipes::pipec::*;
+use core::prelude::*;
 
 trait proto_parser {
     fn parse_proto(id: ~str) -> protocol;

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -20,6 +20,7 @@ use parse::*;
 use util::interner;
 
 use core::dvec::DVec;
+use core::prelude::*;
 use core::str;
 use core::to_str::ToStr;
 use core::vec;
@@ -385,7 +386,8 @@ impl protocol: gen_init {
             }
         }
 
-        cx.ty_path_ast_builder(path(~[cx.ident_of(~"__Buffer")], self.span)
+        cx.ty_path_ast_builder(path(~[cx.ident_of(~"super"),
+                                      cx.ident_of(~"__Buffer")], self.span)
                                .add_tys(cx.ty_vars_global(params)))
     }
 

--- a/src/libsyntax/ext/pipes/proto.rs
+++ b/src/libsyntax/ext/pipes/proto.rs
@@ -8,7 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast;
+use codemap::span;
+use ext::base::ext_ctxt;
 use ext::pipes::ast_builder::{path, append_types};
 
 use core::cmp;

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -18,6 +18,7 @@ use parse::token::*;
 use parse::token;
 use parse;
 
+use core::prelude::*;
 use core::str;
 
 /**
@@ -33,6 +34,7 @@ use core::str;
 
 pub mod rt {
     use ast;
+    use ext::base::ext_ctxt;
     use parse;
     use print::pprust;
 

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -16,6 +16,7 @@ use ext::build::{mk_base_vec_e, mk_uint, mk_u8, mk_base_str};
 use print::pprust;
 
 use core::io;
+use core::prelude::*;
 use core::result;
 use core::str;
 use core::vec;

--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -8,17 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use ast::tt_delim;
 use ast;
 use codemap::span;
-use ext::base;
 use ext::base::ext_ctxt;
-use ast::tt_delim;
+use ext::base;
 use parse::lexer::{new_tt_reader, reader};
 use parse::parser::Parser;
 
+use core::option::None;
+
 fn expand_trace_macros(cx: ext_ctxt, sp: span,
-                       tt: ~[ast::token_tree]) -> base::mac_result
-{
+                       tt: ~[ast::token_tree]) -> base::mac_result {
     let sess = cx.parse_sess();
     let cfg = cx.cfg();
     let tt_rdr = new_tt_reader(cx.parse_sess().span_diagnostic,

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast::{ident, matcher_, matcher, match_tok, match_nonterminal, match_seq};
 use ast::{tt_delim};
 use ast;

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast;
 use ast::{token_tree, tt_delim, tt_tok, tt_seq, tt_nonterminal,ident};
 use ast_util;

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast::*;
 use ast;
 use codemap::span;

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -8,8 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast;
 use ast_util::spanned;
+use codemap::BytePos;
 use parse::common::*; //resolve bug?
 use parse::token;
 

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast;
-use codemap::{CodeMap, FileMap, CharPos};
+use codemap::{BytePos, CharPos, CodeMap, FileMap};
 use diagnostic;
 use parse::lexer::{is_whitespace, get_str_from, reader};
 use parse::lexer::{string_reader, bump, is_eof, nextch};

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -8,12 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast;
 use ast_util::spanned;
+use codemap::BytePos;
 use parse::lexer::reader;
 use parse::parser::Parser;
 use parse::token;
 
+use core::option::{None, Option, Some};
 use core::option;
 use std::map::HashMap;
 

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -8,13 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast;
 use ast_util;
 use codemap::{span, CodeMap, CharPos, BytePos};
 use codemap;
 use diagnostic::span_handler;
 use ext::tt::transcribe::{tt_next_token};
-use ext::tt::transcribe::{tt_reader,  new_tt_reader, dup_tt_reader};
+use ext::tt::transcribe::{tt_reader, new_tt_reader, dup_tt_reader};
 use parse::token;
 
 use core::char;

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -10,8 +10,6 @@
 
 //! The main parser interface
 
-#[legacy_exports];
-
 use ast::node_id;
 use ast;
 use codemap::{span, CodeMap, FileMap, CharPos, BytePos};
@@ -24,70 +22,47 @@ use parse::token::{ident_interner, mk_ident_interner};
 use util::interner;
 
 use core::io;
+use core::option::{None, Option, Some};
+use core::path::Path;
+use core::result::{Err, Ok, Result};
 use core::result;
 
-export parser;
-export common;
-export lexer;
-export token;
-export comments;
-export prec;
-export classify;
-export attr;
-export obsolete;
-
-export parse_sess;
-export new_parse_sess, new_parse_sess_special_handler;
-export next_node_id;
-export new_parser_from_file, new_parser_etc_from_file;
-export new_parser_from_source_str;
-export new_parser_from_tts;
-export new_sub_parser_from_file;
-export parse_crate_from_file, parse_crate_from_crate_file;
-export parse_crate_from_source_str;
-export parse_expr_from_source_str, parse_item_from_source_str;
-export parse_stmt_from_source_str;
-export parse_tts_from_source_str;
-export parse_from_source_str;
-
-
 #[legacy_exports]
-mod lexer;
+pub mod lexer;
 #[legacy_exports]
-mod parser;
+pub mod parser;
 #[legacy_exports]
-mod token;
+pub mod token;
 #[legacy_exports]
-mod comments;
+pub mod comments;
 #[legacy_exports]
-mod attr;
+pub mod attr;
 #[legacy_exports]
 
 /// Common routines shared by parser mods
 #[legacy_exports]
-mod common;
+pub mod common;
 
 /// Functions dealing with operator precedence
 #[legacy_exports]
-mod prec;
+pub mod prec;
 
 /// Routines the parser uses to classify AST nodes
 #[legacy_exports]
-mod classify;
+pub mod classify;
 
 /// Reporting obsolete syntax
 #[legacy_exports]
-mod obsolete;
+pub mod obsolete;
 
-
-type parse_sess = @{
+pub type parse_sess = @{
     cm: @codemap::CodeMap,
     mut next_id: node_id,
     span_diagnostic: span_handler,
     interner: @ident_interner,
 };
 
-fn new_parse_sess(demitter: Option<emitter>) -> parse_sess {
+pub fn new_parse_sess(demitter: Option<emitter>) -> parse_sess {
     let cm = @CodeMap::new();
     return @{cm: cm,
              mut next_id: 1,
@@ -96,7 +71,7 @@ fn new_parse_sess(demitter: Option<emitter>) -> parse_sess {
             };
 }
 
-fn new_parse_sess_special_handler(sh: span_handler, cm: @codemap::CodeMap)
+pub fn new_parse_sess_special_handler(sh: span_handler, cm: @codemap::CodeMap)
     -> parse_sess {
     return @{cm: cm,
              mut next_id: 1,
@@ -105,15 +80,17 @@ fn new_parse_sess_special_handler(sh: span_handler, cm: @codemap::CodeMap)
              };
 }
 
-fn parse_crate_from_file(input: &Path, cfg: ast::crate_cfg,
+pub fn parse_crate_from_file(input: &Path, cfg: ast::crate_cfg,
                          sess: parse_sess) -> @ast::crate {
     let p = new_crate_parser_from_file(sess, cfg, input);
     let r = p.parse_crate_mod(cfg);
     return r;
 }
 
-fn parse_crate_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
-                               sess: parse_sess) -> @ast::crate {
+pub fn parse_crate_from_source_str(name: ~str,
+                                   source: @~str,
+                                   cfg: ast::crate_cfg,
+                                   sess: parse_sess) -> @ast::crate {
     let p = new_parser_from_source_str(sess, cfg, name,
                                        codemap::FssNone, source);
     let r = p.parse_crate_mod(cfg);
@@ -121,8 +98,10 @@ fn parse_crate_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
     return r;
 }
 
-fn parse_expr_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
-                              sess: parse_sess) -> @ast::expr {
+pub fn parse_expr_from_source_str(name: ~str,
+                                  source: @~str,
+                                  cfg: ast::crate_cfg,
+                                  sess: parse_sess) -> @ast::expr {
     let p = new_parser_from_source_str(sess, cfg, name,
                                        codemap::FssNone, source);
     let r = p.parse_expr();
@@ -130,9 +109,12 @@ fn parse_expr_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
     return r;
 }
 
-fn parse_item_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
-                              +attrs: ~[ast::attribute],
-                              sess: parse_sess) -> Option<@ast::item> {
+pub fn parse_item_from_source_str(name: ~str,
+                                  source: @~str,
+                                  cfg: ast::crate_cfg,
+                                  +attrs: ~[ast::attribute],
+                                  sess: parse_sess)
+                               -> Option<@ast::item> {
     let p = new_parser_from_source_str(sess, cfg, name,
                                        codemap::FssNone, source);
     let r = p.parse_item(attrs);
@@ -140,9 +122,11 @@ fn parse_item_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
     return r;
 }
 
-fn parse_stmt_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
-                              +attrs: ~[ast::attribute],
-                              sess: parse_sess) -> @ast::stmt {
+pub fn parse_stmt_from_source_str(name: ~str,
+                                  source: @~str,
+                                  cfg: ast::crate_cfg,
+                                  +attrs: ~[ast::attribute],
+                                  sess: parse_sess) -> @ast::stmt {
     let p = new_parser_from_source_str(sess, cfg, name,
                                        codemap::FssNone, source);
     let r = p.parse_stmt(attrs);
@@ -150,8 +134,10 @@ fn parse_stmt_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
     return r;
 }
 
-fn parse_tts_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
-                             sess: parse_sess) -> ~[ast::token_tree] {
+pub fn parse_tts_from_source_str(name: ~str,
+                                 source: @~str,
+                                 cfg: ast::crate_cfg,
+                                 sess: parse_sess) -> ~[ast::token_tree] {
     let p = new_parser_from_source_str(sess, cfg, name,
                                        codemap::FssNone, source);
     p.quote_depth += 1u;
@@ -160,7 +146,7 @@ fn parse_tts_from_source_str(name: ~str, source: @~str, cfg: ast::crate_cfg,
     return r;
 }
 
-fn parse_from_source_str<T>(f: fn (p: Parser) -> T,
+pub fn parse_from_source_str<T>(f: fn (p: Parser) -> T,
                             name: ~str, ss: codemap::FileSubstr,
                             source: @~str, cfg: ast::crate_cfg,
                             sess: parse_sess)
@@ -176,7 +162,7 @@ fn parse_from_source_str<T>(f: fn (p: Parser) -> T,
     move r
 }
 
-fn next_node_id(sess: parse_sess) -> node_id {
+pub fn next_node_id(sess: parse_sess) -> node_id {
     let rv = sess.next_id;
     sess.next_id += 1;
     // ID 0 is reserved for the crate and doesn't actually exist in the AST
@@ -184,7 +170,7 @@ fn next_node_id(sess: parse_sess) -> node_id {
     return rv;
 }
 
-fn new_parser_from_source_str(sess: parse_sess, cfg: ast::crate_cfg,
+pub fn new_parser_from_source_str(sess: parse_sess, cfg: ast::crate_cfg,
                               +name: ~str, +ss: codemap::FileSubstr,
                               source: @~str) -> Parser {
     let filemap = sess.cm.new_filemap_w_substr(name, ss, source);
@@ -193,7 +179,7 @@ fn new_parser_from_source_str(sess: parse_sess, cfg: ast::crate_cfg,
     return Parser(sess, cfg, srdr as reader);
 }
 
-fn new_parser_from_file(sess: parse_sess, cfg: ast::crate_cfg,
+pub fn new_parser_from_file(sess: parse_sess, cfg: ast::crate_cfg,
                         path: &Path) -> Result<Parser, ~str> {
     match io::read_whole_file_str(path) {
       result::Ok(move src) => {
@@ -211,7 +197,7 @@ fn new_parser_from_file(sess: parse_sess, cfg: ast::crate_cfg,
 
 /// Create a new parser for an entire crate, handling errors as appropriate
 /// if the file doesn't exist
-fn new_crate_parser_from_file(sess: parse_sess, cfg: ast::crate_cfg,
+pub fn new_crate_parser_from_file(sess: parse_sess, cfg: ast::crate_cfg,
                               path: &Path) -> Parser {
     match new_parser_from_file(sess, cfg, path) {
         Ok(move parser) => move parser,
@@ -223,7 +209,7 @@ fn new_crate_parser_from_file(sess: parse_sess, cfg: ast::crate_cfg,
 
 /// Create a new parser based on a span from an existing parser. Handles
 /// error messages correctly when the file does not exist.
-fn new_sub_parser_from_file(sess: parse_sess, cfg: ast::crate_cfg,
+pub fn new_sub_parser_from_file(sess: parse_sess, cfg: ast::crate_cfg,
                             path: &Path, sp: span) -> Parser {
     match new_parser_from_file(sess, cfg, path) {
         Ok(move parser) => move parser,
@@ -233,7 +219,7 @@ fn new_sub_parser_from_file(sess: parse_sess, cfg: ast::crate_cfg,
     }
 }
 
-fn new_parser_from_tts(sess: parse_sess, cfg: ast::crate_cfg,
+pub fn new_parser_from_tts(sess: parse_sess, cfg: ast::crate_cfg,
                        tts: ~[ast::token_tree]) -> Parser {
     let trdr = lexer::new_tt_reader(sess.span_diagnostic, sess.interner,
                                     None, tts);

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -17,10 +17,13 @@ Obsolete syntax that becomes too hard to parse can be
 removed.
 */
 
+use core::prelude::*;
+
 use ast::{expr, expr_lit, lit_nil};
 use ast;
 use ast_util::{respan};
 use codemap::span;
+use parse::parser::Parser;
 use parse::token::Token;
 use parse::token;
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast::{ProtoBox, ProtoUniq, provided, public, pure_fn, purity, re_static};
 use ast::{_mod, add, arg, arm, attribute, bind_by_ref, bind_infer};
 use ast::{bind_by_value, bind_by_move, bitand, bitor, bitxor, blk};
@@ -33,23 +35,24 @@ use ast::{lit_bool, lit_float, lit_float_unsuffixed, lit_int};
 use ast::{lit_int_unsuffixed, lit_nil, lit_str, lit_uint, local, m_const};
 use ast::{m_imm, m_mutbl, mac_, mac_invoc_tt, matcher, match_nonterminal};
 use ast::{match_seq, match_tok, method, mode, module_ns, mt, mul, mutability};
-use ast::{named_field, neg, noreturn, not, pat, pat_box, pat_enum, pat_ident};
-use ast::{pat_lit, pat_range, pat_rec, pat_region, pat_struct, pat_tup};
-use ast::{pat_uniq, pat_wild, path, private, Proto, ProtoBare, ProtoBorrowed};
-use ast::{re_self, re_anon, re_named, region, rem, required, ret_style};
-use ast::{return_val, self_ty, shl, shr, stmt, stmt_decl, stmt_expr};
-use ast::{stmt_semi, stmt_mac, struct_def, struct_field, struct_immutable};
-use ast::{struct_mutable, struct_variant_kind, subtract, sty_box, sty_by_ref};
-use ast::{sty_region, sty_static, sty_uniq, sty_value, token_tree};
-use ast::{trait_method, trait_ref, tt_delim, tt_seq, tt_tok, tt_nonterminal};
-use ast::{tuple_variant_kind, Ty, ty_, ty_bot, ty_box, ty_field, ty_fn};
-use ast::{ty_fixed_length_vec, type_value_ns, uniq, unnamed_field};
-use ast::{ty_infer, ty_mac, ty_method, ty_nil, ty_param, ty_param_bound};
-use ast::{ty_path, ty_ptr, ty_rec, ty_rptr, ty_tup, ty_u32, ty_uniq, ty_vec};
-use ast::{unsafe_blk, unsafe_fn, variant, view_item, view_item_};
-use ast::{view_item_export, view_item_import, view_item_use, view_path};
-use ast::{view_path_glob, view_path_list, view_path_simple, visibility};
-use ast::{vstore, vstore_box, vstore_fixed, vstore_slice, vstore_uniq};
+use ast::{named_field, neg, node_id, noreturn, not, pat, pat_box, pat_enum};
+use ast::{pat_ident, pat_lit, pat_range, pat_rec, pat_region, pat_struct};
+use ast::{pat_tup, pat_uniq, pat_wild, path, private, Proto, ProtoBare};
+use ast::{ProtoBorrowed, re_self, re_anon, re_named, region, rem, required};
+use ast::{ret_style, return_val, self_ty, shl, shr, stmt, stmt_decl};
+use ast::{stmt_expr, stmt_semi, stmt_mac, struct_def, struct_field};
+use ast::{struct_immutable, struct_mutable, struct_variant_kind, subtract};
+use ast::{sty_box, sty_by_ref, sty_region, sty_static, sty_uniq, sty_value};
+use ast::{token_tree, trait_method, trait_ref, tt_delim, tt_seq, tt_tok};
+use ast::{tt_nonterminal, tuple_variant_kind, Ty, ty_, ty_bot, ty_box};
+use ast::{ty_field, ty_fixed_length_vec, ty_fn, ty_infer, ty_mac, ty_method};
+use ast::{ty_nil, ty_param, ty_param_bound, ty_path, ty_ptr, ty_rec, ty_rptr};
+use ast::{ty_tup, ty_u32, ty_uniq, ty_vec, type_value_ns, uniq};
+use ast::{unnamed_field, unsafe_blk, unsafe_fn, variant, view_item};
+use ast::{view_item_, view_item_export, view_item_import, view_item_use};
+use ast::{view_path, view_path_glob, view_path_list, view_path_simple};
+use ast::{visibility, vstore, vstore_box, vstore_fixed, vstore_slice};
+use ast::{vstore_uniq};
 use ast;
 use ast_util::{spanned, respan, mk_sp, ident_to_path, operator_prec};
 use ast_util;
@@ -69,6 +72,7 @@ use parse::prec::{as_prec, token_to_binop};
 use parse::token::{can_begin_expr, is_ident, is_ident_or_path};
 use parse::token::{is_plain_ident, INTERPOLATED, special_idents};
 use parse::token;
+use parse::{new_sub_parser_from_file, next_node_id, parse_sess};
 use print::pprust::expr_to_str;
 use util::interner::Interner;
 

--- a/src/libsyntax/parse/prec.rs
+++ b/src/libsyntax/parse/prec.rs
@@ -12,9 +12,11 @@ export as_prec;
 export unop_prec;
 export token_to_binop;
 
+use ast::*;
 use parse::token::*;
 use parse::token::Token;
-use ast::*;
+
+use core::prelude::*;
 
 /// Unary operators have higher precedence than binary
 const unop_prec: uint = 100u;

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast;
 use ast_util;
 use parse::token;

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use core::cmp;
 use core::dvec::DVec;
 use core::io::WriterUtil;

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast::{required, provided};
 use ast;
 use ast_util;
@@ -16,9 +18,9 @@ use attr;
 use codemap::{CodeMap, BytePos};
 use codemap;
 use diagnostic;
-use parse::classify::*;
+use parse::classify::{expr_is_simple_block, expr_requires_semi_to_be_stmt};
+use parse::classify::{stmt_ends_with_semi};
 use parse::token::ident_interner;
-use parse::token;
 use parse::{comments, lexer, token};
 use parse;
 use print::pp::{break_offset, word, printer, space, zerobreak, hardbreak};

--- a/src/libsyntax/syntax.rc
+++ b/src/libsyntax/syntax.rc
@@ -19,6 +19,8 @@
 #[legacy_modes];
 #[legacy_exports];
 
+#[disable_unwinding];
+
 #[allow(vecs_implicitly_copyable)];
 #[allow(non_camel_case_types)];
 #[allow(deprecated_mode)];

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -11,12 +11,12 @@
 // An "interner" is a data structure that associates values with uint tags and
 // allows bidirectional lookup; i.e. given a value, one can easily find the
 // type, and vice versa.
-use std::map;
+
+use core::prelude::*;
+
+use core::dvec::DVec;
 use std::map::HashMap;
-use dvec::DVec;
-use cmp::Eq;
-use hash::Hash;
-use to_bytes::IterBytes;
+use std::map;
 
 type hash_interner<T: Const> =
     {map: HashMap<T, uint>,

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::prelude::*;
+
 use ast::*;
 use ast;
 use ast_util;

--- a/src/test/bench/task-perf-word-count-generic.rs
+++ b/src/test/bench/task-perf-word-count-generic.rs
@@ -115,6 +115,8 @@ fn box<T>(+x: T) -> box<T> {
 }
 
 mod map_reduce {
+    use core::oldcomm::*;
+
     use std::map;
 
     pub type putter<K: Owned, V: Owned> = fn(&K, V);

--- a/src/test/compile-fail/copy-into-closure.rs
+++ b/src/test/compile-fail/copy-into-closure.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn closure2(+x: util::NonCopyable) -> (util::NonCopyable,
-                                       fn@() -> util::NonCopyable) {
+fn closure2(+x: core::util::NonCopyable)
+        -> (core::util::NonCopyable, fn@() -> core::util::NonCopyable) {
     let f = fn@(copy x) -> util::NonCopyable {
         //~^ ERROR copying a noncopyable value
         //~^^ NOTE non-copyable value cannot be copied into a @fn closure

--- a/src/test/compile-fail/issue-2718-a.rs
+++ b/src/test/compile-fail/issue-2718-a.rs
@@ -15,8 +15,8 @@ struct send_packet<T: Copy> {
 
 mod pingpong {
     #[legacy_exports];
-    type ping = send_packet<pong>;
-    enum pong = send_packet<ping>; //~ ERROR illegal recursive enum type; wrap the inner value in a box to make it representable
+    type ping = ::send_packet<pong>;
+    enum pong = ::send_packet<ping>; //~ ERROR illegal recursive enum type; wrap the inner value in a box to make it representable
 }
 
 fn main() {}

--- a/src/test/run-pass/export-non-interference2.rs
+++ b/src/test/run-pass/export-non-interference2.rs
@@ -15,7 +15,7 @@ mod foo {
 
     mod bar {
         #[legacy_exports];
-        fn y() { x(); }
+        fn y() { ::foo::x(); }
     }
 
     fn x() { debug!("x"); }

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -250,7 +250,7 @@ pub mod pingpong {
         pub fn do_ping(-c: ping) -> pong {
             let (sp, rp) = ::pipes::entangle();
 
-            ::pipes::send(move c, ping(move sp));
+            ::pipes::send(move c, pingpong::ping(move sp));
             move rp
         }
 
@@ -259,7 +259,7 @@ pub mod pingpong {
             if packet.is_none() {
                 fail ~"sender closed the connection"
             }
-            (liberate_pong(option::unwrap(move packet)), ())
+            (pingpong::liberate_pong(option::unwrap(move packet)), ())
         }
     }
 
@@ -274,12 +274,12 @@ pub mod pingpong {
             if packet.is_none() {
                 fail ~"sender closed the connection"
             }
-            (liberate_ping(option::unwrap(move packet)), ())
+            (pingpong::liberate_ping(option::unwrap(move packet)), ())
         }
 
         pub fn do_pong(-c: pong) -> ping {
             let (sp, rp) = ::pipes::entangle();
-            ::pipes::send(move c, pong(move sp));
+            ::pipes::send(move c, pingpong::pong(move sp));
             move rp
         }
     }

--- a/src/test/run-pass/static-impl.rs
+++ b/src/test/run-pass/static-impl.rs
@@ -19,12 +19,12 @@ trait plus {
 
 mod a {
     #[legacy_exports];
-    impl uint: plus { fn plus() -> int { self as int + 20 } }
+    impl uint: ::plus { fn plus() -> int { self as int + 20 } }
 }
 
 mod b {
     #[legacy_exports];
-    impl ~str: plus { fn plus() -> int { 200 } }
+    impl ~str: ::plus { fn plus() -> int { 200 } }
 }
 
 trait uint_utils {


### PR DESCRIPTION
This is a 1.9x speedup in LLVM passes for unoptimized builds.

r? @graydon
