### PR TITLE
Fix consts of nullary univariant enum type.

### DIFF
--- a/src/test/run-pass/const-nullary-univariant-enum.rs
+++ b/src/test/run-pass/const-nullary-univariant-enum.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Foo {
+    Bar = 0xDEADBEE
+}
+
+const X: Foo = Bar;
+
+fn main() {
+    assert((X as uint) == 0xDEADBEE);
+}


### PR DESCRIPTION
Currently such consts cause an internal compiler error, but there aren't any tests for them; these changes fix these problems.
