### PR TITLE
bug 4189 adding bound checks for vec::raw::memcpy and memmove

### DIFF
--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -1960,6 +1960,9 @@ pub mod raw {
       * may overlap.
       */
     pub unsafe fn memcpy<T>(dst: &[mut T], src: &[const T], count: uint) {
+        assert dst.len() >= count;
+        assert src.len() >= count;
+
         do as_mut_buf(dst) |p_dst, _len_dst| {
             do as_const_buf(src) |p_src, _len_src| {
                 ptr::memcpy(p_dst, p_src, count)
@@ -1974,6 +1977,9 @@ pub mod raw {
       * may overlap.
       */
     pub unsafe fn memmove<T>(dst: &[mut T], src: &[const T], count: uint) {
+        assert dst.len() >= count;
+        assert src.len() >= count;
+
         do as_mut_buf(dst) |p_dst, _len_dst| {
             do as_const_buf(src) |p_src, _len_src| {
                 ptr::memmove(p_dst, p_src, count)
@@ -3730,6 +3736,15 @@ mod tests {
             fail
         }
     }
+
+    #[test]
+    #[should_fail]
+    fn test_memcpy_oob() unsafe {
+        let a = [mut 1, 2, 3, 4];
+        let b = [1, 2, 3, 4, 5];
+        raw::memcpy(a, b, 5);
+    }
+
 }
 
 // Local Variables:


### PR DESCRIPTION
Nothing else to say I think.
