### PR TITLE
Support assignability for struct fields

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1669,9 +1669,11 @@ fn check_expr_with_unifier(fcx: @fn_ctxt,
                     let expected_field_type =
                         ty::lookup_field_type(
                             tcx, class_id, field_id, substitutions);
-                    bot |= check_expr(fcx,
-                                      field.node.expr,
-                                      Some(expected_field_type));
+                    bot |=
+                        check_expr_with_assignability(
+                            fcx,
+                            field.node.expr,
+                            expected_field_type);
                     class_field_map.insert(
                         field.node.ident, (field_id, true));
                     fields_found += 1;

--- a/src/test/run-pass/struct-field-assignability.rs
+++ b/src/test/run-pass/struct-field-assignability.rs
@@ -1,0 +1,9 @@
+struct Foo {
+    x: &int
+}
+
+fn main() {
+    let f = Foo { x: @3 };
+    assert *f.x == 3;
+}
+


### PR DESCRIPTION
On my branch for fn inference, assignability becomes important to handle bare fn to closure conversion.  To support things like the visitor pattern, then, it is necessary to support assignability on struct fields.  Besides, we ought to anyhow.
