### PR TITLE
vector cleanup and turning ast::spanned into a struct

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -344,7 +344,7 @@ mod test {
     use syntax::ast_util;
 
     fn make_crate_type_attr(+t: ~str) -> ast::attribute {
-        ast_util::respan(ast_util::dummy_sp(), {
+        ast_util::respan(ast_util::dummy_sp(), ast::attribute_ {
             style: ast::attr_outer,
             value: ast_util::respan(ast_util::dummy_sp(),
                 ast::meta_name_value(

--- a/src/librustc/front/core_inject.rs
+++ b/src/librustc/front/core_inject.rs
@@ -45,22 +45,21 @@ fn inject_libcore_ref(sess: Session,
     let precursor = @fold::AstFoldFns {
         fold_crate: |crate, span, fld| {
             let n1 = sess.next_node_id();
-            let vi1 = @{node: ast::view_item_use(sess.ident_of(~"core"),
-                                                 ~[],
-                                                 n1),
-                        attrs: ~[
-                            spanned({
-                                style: ast::attr_inner,
-                                value: spanned(ast::meta_name_value(
-                                    ~"vers",
-                                    spanned(ast::lit_str(
-                                        @CORE_VERSION.to_str()))
-                                )),
-                                is_sugared_doc: false
-                            })
-                        ],
-                        vis: ast::private,
-                        span: dummy_sp()};
+            let vi1 = @ast::view_item {
+                node: ast::view_item_use(sess.ident_of(~"core"), ~[], n1),
+                attrs: ~[
+                    spanned(ast::attribute_ {
+                        style: ast::attr_inner,
+                        value: spanned(ast::meta_name_value(
+                            ~"vers",
+                            spanned(ast::lit_str(@CORE_VERSION.to_str()))
+                        )),
+                        is_sugared_doc: false
+                    })
+                ],
+                vis: ast::private,
+                span: dummy_sp()
+            };
 
             let vis = vec::append(~[vi1], crate.module.view_items);
             let mut new_module = {
@@ -88,10 +87,10 @@ fn inject_libcore_ref(sess: Session,
             };
 
             let vp = @spanned(ast::view_path_glob(prelude_path, n2));
-            let vi2 = @{node: ast::view_item_import(~[vp]),
-                        attrs: ~[],
-                        vis: ast::private,
-                        span: dummy_sp()};
+            let vi2 = @ast::view_item { node: ast::view_item_import(~[vp]),
+                                        attrs: ~[],
+                                        vis: ast::private,
+                                        span: dummy_sp() };
 
             let vis = vec::append(~[vi2], module.view_items);
 

--- a/src/librustc/front/core_inject.rs
+++ b/src/librustc/front/core_inject.rs
@@ -76,7 +76,7 @@ fn inject_libcore_ref(sess: Session,
         fold_mod: |module, fld| {
             let n2 = sess.next_node_id();
 
-            let prelude_path = @{
+            let prelude_path = @ast::path {
                 span: dummy_sp(),
                 global: false,
                 idents: ~[

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -245,11 +245,19 @@ fn nospan<T: Copy>(t: T) -> ast::spanned<T> {
 }
 
 fn path_node(+ids: ~[ast::ident]) -> @ast::path {
-    @{span: dummy_sp(), global: false, idents: ids, rp: None, types: ~[]}
+    @ast::path { span: dummy_sp(),
+                 global: false,
+                 idents: ids,
+                 rp: None,
+                 types: ~[] }
 }
 
 fn path_node_global(+ids: ~[ast::ident]) -> @ast::path {
-    @{span: dummy_sp(), global: true, idents: ids, rp: None, types: ~[]}
+    @ast::path { span: dummy_sp(),
+                 global: true,
+                 idents: ids,
+                 rp: None,
+                 types: ~[] }
 }
 
 fn mk_std(cx: test_ctxt) -> @ast::view_item {

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -269,7 +269,7 @@ fn mk_std(cx: test_ctxt) -> @ast::view_item {
     let vi = ast::view_item_use(cx.sess.ident_of(~"std"),
                                 ~[@mi],
                                 cx.sess.next_node_id());
-    let vi = {
+    let vi = ast::view_item {
         node: vi,
         attrs: ~[],
         vis: ast::private,

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -226,13 +226,14 @@ fn mk_test_module(cx: test_ctxt) -> @ast::item {
     // This attribute tells resolve to let us call unexported functions
     let resolve_unexported_attr =
         attr::mk_attr(attr::mk_word_item(~"!resolve_unexported"));
-    let item: ast::item =
-        {ident: cx.sess.ident_of(~"__test"),
-         attrs: ~[resolve_unexported_attr],
-         id: cx.sess.next_node_id(),
-         node: item_,
-         vis: ast::public,
-         span: dummy_sp()};
+    let item = ast::item {
+        ident: cx.sess.ident_of(~"__test"),
+        attrs: ~[resolve_unexported_attr],
+        id: cx.sess.next_node_id(),
+        node: item_,
+        vis: ast::public,
+        span: dummy_sp(),
+    };
 
     debug!("Synthetic test module:\n%s\n",
            pprust::item_to_str(@copy item, cx.sess.intr()));
@@ -294,13 +295,14 @@ fn mk_tests(cx: test_ctxt) -> @ast::item {
     let body = nospan(body_);
 
     let item_ = ast::item_fn(decl, ast::impure_fn, ~[], body);
-    let item: ast::item =
-        {ident: cx.sess.ident_of(~"tests"),
-         attrs: ~[],
-         id: cx.sess.next_node_id(),
-         node: item_,
-         vis: ast::public,
-         span: dummy_sp()};
+    let item = ast::item {
+        ident: cx.sess.ident_of(~"tests"),
+        attrs: ~[],
+        id: cx.sess.next_node_id(),
+        node: item_,
+        vis: ast::public,
+        span: dummy_sp(),
+    };
     return @item;
 }
 
@@ -504,13 +506,14 @@ fn mk_main(cx: test_ctxt) -> @ast::item {
     let body = ast::spanned { node: body_, span: dummy_sp() };
 
     let item_ = ast::item_fn(decl, ast::impure_fn, ~[], body);
-    let item: ast::item =
-        {ident: cx.sess.ident_of(~"main"),
-         attrs: ~[],
-         id: cx.sess.next_node_id(),
-         node: item_,
-         vis: ast::public,
-         span: dummy_sp()};
+    let item = ast::item {
+        ident: cx.sess.ident_of(~"main"),
+        attrs: ~[],
+        id: cx.sess.next_node_id(),
+        node: item_,
+        vis: ast::public,
+        span: dummy_sp(),
+    };
     return @item;
 }
 

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1034,10 +1034,14 @@ fn get_attributes(md: ebml::Doc) -> ~[ast::attribute] {
             assert (vec::len(meta_items) == 1u);
             let meta_item = meta_items[0];
             attrs.push(
-                ast::spanned { node: { style: ast::attr_outer,
-                                       value: /*bad*/copy *meta_item,
-                                       is_sugared_doc: false },
-                               span: ast_util::dummy_sp()});
+                ast::spanned {
+                    node: ast::attribute_ {
+                        style: ast::attr_outer,
+                        value: /*bad*/copy *meta_item,
+                        is_sugared_doc: false,
+                    },
+                    span: ast_util::dummy_sp()
+                });
         };
       }
       option::None => ()

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -273,7 +273,8 @@ fn encode_enum_variant_info(ecx: @encode_ctxt, ebml_w: writer::Encoder,
                             ty_params: ~[ty_param]) {
     let mut disr_val = 0;
     let mut i = 0;
-    let vi = ty::enum_variants(ecx.tcx, {crate: local_crate, node: id});
+    let vi = ty::enum_variants(ecx.tcx,
+                               ast::def_id { crate: local_crate, node: id });
     for variants.each |variant| {
         index.push({val: variant.node.id, pos: ebml_w.writer.tell()});
         ebml_w.start_tag(tag_items_data_item);

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -470,7 +470,7 @@ fn parse_def_id(buf: &[u8]) -> ast::def_id {
        None => fail (fmt!("internal error: parse_def_id: id expected, but \
                                found %?", def_part))
     };
-    return {crate: crate_num, node: def_num};
+    ast::def_id { crate: crate_num, node: def_num }
 }
 
 fn parse_bounds_data(data: @~[u8], start: uint,

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -101,9 +101,11 @@ fn parse_path(st: @pstate) -> @ast::path {
           ':' => { next(st); next(st); }
           c => {
             if c == '(' {
-                return @{span: ast_util::dummy_sp(),
-                      global: false, idents: idents,
-                      rp: None, types: ~[]};
+                return @ast::path { span: ast_util::dummy_sp(),
+                                    global: false,
+                                    idents: idents,
+                                    rp: None,
+                                    types: ~[] };
             } else { idents.push(parse_ident_(st, is_last)); }
           }
         }

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -176,7 +176,7 @@ impl extended_decode_ctxt {
     }
     fn tr_intern_def_id(did: ast::def_id) -> ast::def_id {
         assert did.crate == ast::local_crate;
-        {crate: ast::local_crate, node: self.tr_id(did.node)}
+        ast::def_id { crate: ast::local_crate, node: self.tr_id(did.node) }
     }
     fn tr_span(_span: span) -> span {
         ast_util::dummy_sp() // FIXME (#1972): handle span properly
@@ -785,7 +785,7 @@ fn encode_side_tables_for_id(ecx: @e::encode_ctxt,
         }
     }
 
-    let lid = {crate: ast::local_crate, node: id};
+    let lid = ast::def_id { crate: ast::local_crate, node: id };
     do option::iter(&tcx.tcache.find(lid)) |tpbt| {
         do ebml_w.tag(c::tag_table_tcache) {
             ebml_w.id(id);
@@ -988,7 +988,7 @@ fn decode_side_tables(xcx: extended_decode_ctxt,
                 dcx.tcx.freevars.insert(id, fv_info);
             } else if tag == (c::tag_table_tcache as uint) {
                 let tpbt = val_dsr.read_ty_param_bounds_and_ty(xcx);
-                let lid = {crate: ast::local_crate, node: id};
+                let lid = ast::def_id { crate: ast::local_crate, node: id };
                 dcx.tcx.tcache.insert(lid, tpbt);
             } else if tag == (c::tag_table_param_bounds as uint) {
                 let bounds = val_dsr.read_bounds(xcx);

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -288,10 +288,12 @@ fn simplify_ast(ii: ast::inlined_item) -> ast::inlined_item {
       }
       ast::ii_dtor(ref dtor, nm, ref tps, parent_id) => {
         let dtor_body = fld.fold_block((*dtor).node.body);
-        ast::ii_dtor(ast::spanned { node: { body: dtor_body,
-                                            .. /*bad*/copy (*dtor).node },
-                                    .. (/*bad*/copy *dtor) },
-                     nm, /*bad*/copy *tps, parent_id)
+        ast::ii_dtor(
+            ast::spanned {
+                node: ast::struct_dtor_ { body: dtor_body,
+                                          .. /*bad*/copy (*dtor).node },
+                .. (/*bad*/copy *dtor) },
+            nm, /*bad*/copy *tps, parent_id)
       }
     }
 }
@@ -327,12 +329,15 @@ fn renumber_ast(xcx: extended_decode_ctxt, ii: ast::inlined_item)
         let dtor_id = fld.new_id((*dtor).node.id);
         let new_parent = xcx.tr_def_id(parent_id);
         let new_self = fld.new_id((*dtor).node.self_id);
-        ast::ii_dtor(ast::spanned { node: { id: dtor_id,
-                                            attrs: dtor_attrs,
-                                            self_id: new_self,
-                                            body: dtor_body },
-                                    .. (/*bad*/copy *dtor)},
-          nm, new_params, new_parent)
+        ast::ii_dtor(
+            ast::spanned {
+                node: ast::struct_dtor_ { id: dtor_id,
+                                          attrs: dtor_attrs,
+                                          self_id: new_self,
+                                          body: dtor_body },
+                .. (/*bad*/copy *dtor)
+            },
+            nm, new_params, new_parent)
       }
      }
 }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -359,7 +359,7 @@ impl LanguageItemCollector {
         do iter_crate_data(crate_store) |crate_number, _crate_metadata| {
             for each_lang_item(crate_store, crate_number)
                     |node_id, item_index| {
-                let def_id = { crate: crate_number, node: node_id };
+                let def_id = def_id { crate: crate_number, node: node_id };
                 self.collect_item(item_index, def_id);
             }
         }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -817,7 +817,7 @@ fn Resolver(session: Session, lang_items: LanguageItems,
 
     (*graph_root).define_module(Public,
                                 NoParentLink,
-                                Some({ crate: 0, node: 0 }),
+                                Some(def_id { crate: 0, node: 0 }),
                                 NormalModuleKind,
                                 has_legacy_export_attr(crate.node.attrs),
                                 crate.span);
@@ -1139,7 +1139,7 @@ impl Resolver {
                     self.add_child(ident, parent, ForbidDuplicateModules, sp);
 
                 let parent_link = self.get_parent_link(new_parent, ident);
-                let def_id = { crate: 0, node: item.id };
+                let def_id = def_id { crate: 0, node: item.id };
                 (*name_bindings).define_module(privacy,
                                                parent_link,
                                                Some(def_id),
@@ -1163,7 +1163,7 @@ impl Resolver {
 
                         let parent_link = self.get_parent_link(new_parent,
                                                                ident);
-                        let def_id = { crate: 0, node: item.id };
+                        let def_id = def_id { crate: 0, node: item.id };
                         (*name_bindings).define_module(privacy,
                                                        parent_link,
                                                        Some(def_id),
@@ -1600,7 +1600,7 @@ impl Resolver {
                             self.add_child(name, parent, ForbidDuplicateTypes,
                                            view_item.span);
 
-                        let def_id = { crate: crate_id, node: 0 };
+                        let def_id = def_id { crate: crate_id, node: 0 };
                         let parent_link = ModuleParentLink
                             (self.get_module_from_parent(new_parent), name);
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2479,8 +2479,9 @@ fn trans_constant(ccx: @crate_ctxt, it: @ast::item) {
     let _icx = ccx.insn_ctxt("trans_constant");
     match it.node {
       ast::item_enum(ref enum_definition, _) => {
-        let vi = ty::enum_variants(ccx.tcx, {crate: ast::local_crate,
-                                             node: it.id});
+        let vi = ty::enum_variants(ccx.tcx,
+                                   ast::def_id { crate: ast::local_crate,
+                                                 node: it.id });
         let mut i = 0;
         let path = item_path(ccx, it);
         for vec::each((*enum_definition).variants) |variant| {

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -126,7 +126,7 @@ fn get_const_val(cx: @crate_ctxt, def_id: ast::def_id) -> ValueRef {
     }
     if !cx.const_values.contains_key(def_id.node) {
         match cx.tcx.items.get(def_id.node) {
-            ast_map::node_item(@{
+            ast_map::node_item(@ast::item {
                 node: ast::item_const(_, subexpr), _
             }, _) => {
                 trans_const(cx, subexpr, def_id.node);

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -327,7 +327,7 @@ fn method_with_name(ccx: @crate_ctxt, impl_id: ast::def_id,
                     name: ast::ident) -> ast::def_id {
     if impl_id.crate == ast::local_crate {
         match ccx.tcx.items.get(impl_id.node) {
-          ast_map::node_item(@{
+          ast_map::node_item(@ast::item {
                 node: ast::item_impl(_, _, _, ref ms),
                 _
             }, _) => {
@@ -344,7 +344,7 @@ fn method_with_name_or_default(ccx: @crate_ctxt, impl_id: ast::def_id,
                                name: ast::ident) -> ast::def_id {
     if impl_id.crate == ast::local_crate {
         match ccx.tcx.items.get(impl_id.node) {
-          ast_map::node_item(@{
+          ast_map::node_item(@ast::item {
                 node: ast::item_impl(_, _, _, ref ms), _
           }, _) => {
               let did = method_from_methods(/*bad*/copy *ms, name);

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -167,7 +167,7 @@ fn monomorphic_fn(ccx: @crate_ctxt,
     });
 
     let lldecl = match map_node {
-      ast_map::node_item(i@@{
+      ast_map::node_item(i@@ast::item {
                 // XXX: Bad copy.
                 node: ast::item_fn(copy decl, _, _, ref body),
                 _

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -94,7 +94,8 @@ fn type_uses_for(ccx: @crate_ctxt, fn_id: def_id, n_tps: uint)
                                      fn_id_loc))
     };
     match map_node {
-      ast_map::node_item(@{node: item_fn(_, _, _, ref body), _}, _) |
+      ast_map::node_item(@ast::item { node: item_fn(_, _, _, ref body),
+                                      _ }, _) |
       ast_map::node_method(@{body: ref body, _}, _, _) => {
         handle_body(cx, (*body));
       }

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -107,7 +107,8 @@ fn type_uses_for(ccx: @crate_ctxt, fn_id: def_id, n_tps: uint)
       ast_map::node_variant(_, _, _) => {
         for uint::range(0u, n_tps) |n| { cx.uses[n] |= use_repr;}
       }
-      ast_map::node_foreign_item(i@@{node: foreign_item_fn(*), _},
+      ast_map::node_foreign_item(i@@foreign_item { node: foreign_item_fn(*),
+                                                   _ },
                                  abi, _) => {
         if abi == foreign_abi_rust_intrinsic {
             let flags = match cx.ccx.sess.str_of(i.ident) {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3609,7 +3609,7 @@ fn store_trait_methods(cx: ctxt, id: ast::node_id, ms: @~[method]) {
 fn provided_trait_methods(cx: ctxt, id: ast::def_id) -> ~[ast::ident] {
     if is_local(id) {
         match cx.items.find(id.node) {
-            Some(ast_map::node_item(@{
+            Some(ast_map::node_item(@ast::item {
                         node: item_trait(_, _, ref ms),
                         _
                     }, _)) =>
@@ -3690,7 +3690,7 @@ fn impl_traits(cx: ctxt, id: ast::def_id, vstore: vstore) -> ~[t] {
     if id.crate == ast::local_crate {
         debug!("(impl_traits) searching for trait impl %?", id);
         match cx.items.find(id.node) {
-           Some(ast_map::node_item(@{
+           Some(ast_map::node_item(@ast::item {
                         node: ast::item_impl(_, opt_trait, _, _),
                         _},
                     _)) => {
@@ -3797,7 +3797,7 @@ fn ty_dtor(cx: ctxt, struct_id: def_id) -> DtorKind {
 
     if is_local(struct_id) {
        match cx.items.find(struct_id.node) {
-           Some(ast_map::node_item(@{
+           Some(ast_map::node_item(@ast::item {
                node: ast::item_struct(@{ dtor: Some(ref dtor), _ }, _),
                _
            }, _)) =>
@@ -3900,7 +3900,7 @@ fn enum_variants(cx: ctxt, id: ast::def_id) -> @~[VariantInfo] {
           expr, since check_enum_variants also updates the enum_var_cache
          */
         match cx.items.get(id.node) {
-          ast_map::node_item(@{
+          ast_map::node_item(@ast::item {
                     node: ast::item_enum(ref enum_definition, _),
                     _
                 }, _) => {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3798,7 +3798,9 @@ fn ty_dtor(cx: ctxt, struct_id: def_id) -> DtorKind {
     if is_local(struct_id) {
        match cx.items.find(struct_id.node) {
            Some(ast_map::node_item(@ast::item {
-               node: ast::item_struct(@{ dtor: Some(ref dtor), _ }, _),
+               node: ast::item_struct(@ast::struct_def { dtor: Some(ref dtor),
+                                                         _ },
+                                      _),
                _
            }, _)) =>
                LegacyDtor(local_def((*dtor).node.id)),

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1008,14 +1008,19 @@ pub fn impl_self_ty(vcx: &VtableContext,
     let {n_tps, region_param, raw_ty} = if did.crate == ast::local_crate {
         let region_param = tcx.region_paramd_items.find(did.node);
         match tcx.items.find(did.node) {
-          Some(ast_map::node_item(@{node: ast::item_impl(ref ts, _, st, _),
-                                  _}, _)) => {
+          Some(ast_map::node_item(@ast::item {
+                  node: ast::item_impl(ref ts, _, st, _),
+                  _
+              }, _)) => {
             {n_tps: ts.len(),
              region_param: region_param,
              raw_ty: vcx.ccx.to_ty(rscope::type_rscope(region_param), st)}
           }
-          Some(ast_map::node_item(@{node: ast::item_struct(_, ref ts),
-                                    id: class_id, _},_)) => {
+          Some(ast_map::node_item(@ast::item {
+                  node: ast::item_struct(_, ref ts),
+                  id: class_id,
+                  _
+              },_)) => {
               /* If the impl is a class, the self ty is just the class ty
                  (doing a no-op subst for the ty params; in the next step,
                  we substitute in fresh vars for them)
@@ -1768,7 +1773,7 @@ fn check_expr_with_unifier(fcx: @fn_ctxt,
             region_parameterized =
                 tcx.region_paramd_items.find(class_id.node);
             match tcx.items.find(class_id.node) {
-                Some(ast_map::node_item(@{
+                Some(ast_map::node_item(@ast::item {
                         node: ast::item_struct(_, ref type_parameters),
                         _
                     }, _)) => {
@@ -1851,7 +1856,7 @@ fn check_expr_with_unifier(fcx: @fn_ctxt,
             region_parameterized =
                 tcx.region_paramd_items.find(enum_id.node);
             match tcx.items.find(enum_id.node) {
-                Some(ast_map::node_item(@{
+                Some(ast_map::node_item(@ast::item {
                         node: ast::item_enum(_, ref type_parameters),
                         _
                     }, _)) => {

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -928,7 +928,8 @@ impl CoherenceChecker {
         do iter_crate_data(crate_store) |crate_number, _crate_metadata| {
             self.add_impls_for_module(impls_seen,
                                       crate_store,
-                                      { crate: crate_number, node: 0 });
+                                      def_id { crate: crate_number,
+                                               node: 0 });
 
             for each_path(crate_store, crate_number) |path_entry| {
                 match path_entry.def_like {

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -282,7 +282,7 @@ fn ensure_trait_methods(ccx: @crate_ctxt, id: ast::node_id, trait_ty: ty::t) {
     let tcx = ccx.tcx;
     let region_paramd = tcx.region_paramd_items.find(id);
     match tcx.items.get(id) {
-      ast_map::node_item(@{
+      ast_map::node_item(@ast::item {
                 node: ast::item_trait(ref params, _, ref ms),
                 _
             }, _) => {

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -73,8 +73,8 @@ fn collect_item_types(ccx: @crate_ctxt, crate: @ast::crate) {
             match /*bad*/copy crate_item.node {
               ast::item_mod(m) => {
                 for m.items.each |intrinsic_item| {
-                    let def_id = { crate: ast::local_crate,
-                                  node: intrinsic_item.id };
+                    let def_id = ast::def_id { crate: ast::local_crate,
+                                               node: intrinsic_item.id };
                     let substs = {self_r: None, self_ty: None, tps: ~[]};
 
                     match intrinsic_item.node {
@@ -254,7 +254,7 @@ fn ensure_trait_methods(ccx: @crate_ctxt, id: ast::node_id, trait_ty: ty::t) {
         // build up a subst that shifts all of the parameters over
         // by one and substitute in a new type param for self
 
-        let dummy_defid = {crate: 0, node: 0};
+        let dummy_defid = ast::def_id {crate: 0, node: 0};
 
         let non_shifted_trait_tps = do vec::from_fn(trait_bounds.len()) |i| {
             ty::mk_param(ccx.tcx, i, dummy_defid)
@@ -458,7 +458,7 @@ fn compare_impl_method(tcx: ty::ctxt,
         let dummy_tps = do vec::from_fn((*trait_m.tps).len()) |i| {
             // hack: we don't know the def id of the impl tp, but it
             // is not important for unification
-            ty::mk_param(tcx, i + impl_tps, {crate: 0, node: 0})
+            ty::mk_param(tcx, i + impl_tps, ast::def_id {crate: 0, node: 0})
         };
         let trait_tps = trait_substs.tps.map(
             |t| replace_bound_self(tcx, *t, dummy_self_r));

--- a/src/librustdoc/attr_pass.rs
+++ b/src/librustdoc/attr_pass.rs
@@ -167,7 +167,7 @@ fn fold_enum(
             let variant = *variant;
             let desc = do astsrv::exec(srv) |ctxt| {
                 match ctxt.ast_map.get(doc_id) {
-                  ast_map::node_item(@{
+                  ast_map::node_item(@ast::item {
                     node: ast::item_enum(enum_definition, _), _
                   }, _) => {
                     let ast_variant = option::get(
@@ -226,7 +226,7 @@ fn merge_method_attrs(
     // Create an assoc list from method name to attributes
     let attrs: ~[(~str, Option<~str>)] = do astsrv::exec(srv) |ctxt| {
         match ctxt.ast_map.get(item_id) {
-          ast_map::node_item(@{
+          ast_map::node_item(@ast::item {
             node: ast::item_trait(_, _, methods), _
           }, _) => {
             vec::map(methods, |method| {
@@ -240,7 +240,7 @@ fn merge_method_attrs(
                 }
             })
           }
-          ast_map::node_item(@{
+          ast_map::node_item(@ast::item {
             node: ast::item_impl(_, _, _, methods), _
           }, _) => {
             vec::map(methods, |method| {

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -371,7 +371,7 @@ fn fold_struct(
 fn strip_struct_extra_stuff(item: @ast::item) -> @ast::item {
     let node = match item.node {
         ast::item_struct(def, tys) => {
-            let def = @{
+            let def = @ast::struct_def {
                 dtor: None, // Remove the drop { } block
                 .. *def
             };

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -68,7 +68,7 @@ fn fold_fn(
 fn get_fn_sig(srv: astsrv::Srv, fn_id: doc::AstId) -> Option<~str> {
     do astsrv::exec(srv) |ctxt| {
         match ctxt.ast_map.get(fn_id) {
-          ast_map::node_item(@{
+          ast_map::node_item(@ast::item {
             ident: ident,
             node: ast::item_fn(decl, _, tys, _), _
           }, _) |
@@ -104,7 +104,7 @@ fn fold_const(
     {
         sig: Some(do astsrv::exec(srv) |ctxt| {
             match ctxt.ast_map.get(doc.id()) {
-              ast_map::node_item(@{
+              ast_map::node_item(@ast::item {
                 node: ast::item_const(ty, _), _
               }, _) => {
                 pprust::ty_to_str(ty, extract::interner())
@@ -134,7 +134,7 @@ fn fold_enum(
             let variant = *variant;
             let sig = do astsrv::exec(srv) |ctxt| {
                 match ctxt.ast_map.get(doc_id) {
-                  ast_map::node_item(@{
+                  ast_map::node_item(@ast::item {
                     node: ast::item_enum(enum_definition, _), _
                   }, _) => {
                     let ast_variant =
@@ -193,7 +193,7 @@ fn get_method_sig(
 ) -> Option<~str> {
     do astsrv::exec(srv) |ctxt| {
         match ctxt.ast_map.get(item_id) {
-          ast_map::node_item(@{
+          ast_map::node_item(@ast::item {
             node: ast::item_trait(_, _, methods), _
           }, _) => {
             match vec::find(methods, |method| {
@@ -225,7 +225,7 @@ fn get_method_sig(
                 _ => fail ~"method not found"
             }
           }
-          ast_map::node_item(@{
+          ast_map::node_item(@ast::item {
             node: ast::item_impl(_, _, _, methods), _
           }, _) => {
             match vec::find(methods, |method| {
@@ -263,7 +263,7 @@ fn fold_impl(
 
     let (trait_types, self_ty) = do astsrv::exec(srv) |ctxt| {
         match ctxt.ast_map.get(doc.id()) {
-          ast_map::node_item(@{
+          ast_map::node_item(@ast::item {
             node: ast::item_impl(_, opt_trait_type, self_ty, _), _
           }, _) => {
             let trait_types = opt_trait_type.map_default(~[], |p| {
@@ -319,7 +319,7 @@ fn fold_type(
     {
         sig: do astsrv::exec(srv) |ctxt| {
             match ctxt.ast_map.get(doc.id()) {
-              ast_map::node_item(@{
+              ast_map::node_item(@ast::item {
                 ident: ident,
                 node: ast::item_ty(ty, params), _
               }, _) => {
@@ -380,7 +380,7 @@ fn strip_struct_extra_stuff(item: @ast::item) -> @ast::item {
         _ => fail ~"not a struct"
     };
 
-    @{
+    @ast::item {
         attrs: ~[], // Remove the attributes
         node: node,
         .. *item

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -72,7 +72,7 @@ fn get_fn_sig(srv: astsrv::Srv, fn_id: doc::AstId) -> Option<~str> {
             ident: ident,
             node: ast::item_fn(decl, _, tys, _), _
           }, _) |
-          ast_map::node_foreign_item(@{
+          ast_map::node_foreign_item(@ast::foreign_item {
             ident: ident,
             node: ast::foreign_item_fn(decl, _, tys), _
           }, _, _) => {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1458,11 +1458,11 @@ impl visibility : cmp::Eq {
 
 #[auto_encode]
 #[auto_decode]
-type struct_field_ = {
+struct struct_field_ {
     kind: struct_field_kind,
     id: node_id,
-    ty: @Ty
-};
+    ty: @Ty,
+}
 
 type struct_field = spanned<struct_field_>;
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -122,7 +122,11 @@ enum ty_param_bound {
 
 #[auto_encode]
 #[auto_decode]
-type ty_param = {ident: ident, id: node_id, bounds: @~[ty_param_bound]};
+struct ty_param {
+    ident: ident,
+    id: node_id,
+    bounds: @~[ty_param_bound]
+}
 
 #[auto_encode]
 #[auto_decode]

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1568,10 +1568,12 @@ type struct_dtor = spanned<struct_dtor_>;
 
 #[auto_encode]
 #[auto_decode]
-type struct_dtor_ = {id: node_id,
-                    attrs: ~[attribute],
-                    self_id: node_id,
-                    body: blk};
+struct struct_dtor_ {
+    id: node_id,
+    attrs: ~[attribute],
+    self_id: node_id,
+    body: blk,
+}
 
 #[auto_encode]
 #[auto_decode]

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1357,7 +1357,10 @@ type variant = spanned<variant_>;
 
 #[auto_encode]
 #[auto_decode]
-type path_list_ident_ = {name: ident, id: node_id};
+struct path_list_ident_ {
+    name: ident,
+    id: node_id,
+}
 
 type path_list_ident = spanned<path_list_ident_>;
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -80,11 +80,13 @@ type fn_ident = Option<ident>;
 
 #[auto_encode]
 #[auto_decode]
-type path = {span: span,
-             global: bool,
-             idents: ~[ident],
-             rp: Option<@region>,
-             types: ~[@Ty]};
+struct path {
+    span: span,
+    global: bool,
+    idents: ~[ident],
+    rp: Option<@region>,
+    types: ~[@Ty],
+}
 
 type crate_num = int;
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1575,13 +1575,14 @@ type struct_dtor_ = {id: node_id,
 
 #[auto_encode]
 #[auto_decode]
-type foreign_item =
-    {ident: ident,
-     attrs: ~[attribute],
-     node: foreign_item_,
-     id: node_id,
-     span: span,
-     vis: visibility};
+struct foreign_item {
+    ident: ident,
+    attrs: ~[attribute],
+    node: foreign_item_,
+    id: node_id,
+    span: span,
+    vis: visibility,
+}
 
 #[auto_encode]
 #[auto_decode]

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1394,8 +1394,12 @@ enum view_path_ {
 
 #[auto_encode]
 #[auto_decode]
-type view_item = {node: view_item_, attrs: ~[attribute],
-                  vis: visibility, span: span};
+struct view_item {
+    node: view_item_,
+    attrs: ~[attribute],
+    vis: visibility,
+    span: span,
+}
 
 #[auto_encode]
 #[auto_decode]
@@ -1425,7 +1429,11 @@ impl attr_style : cmp::Eq {
 // doc-comments are promoted to attributes that have is_sugared_doc = true
 #[auto_encode]
 #[auto_decode]
-type attribute_ = {style: attr_style, value: meta_item, is_sugared_doc: bool};
+struct attribute_ {
+    style: attr_style,
+    value: meta_item,
+    is_sugared_doc: bool,
+}
 
 /*
   trait_refs appear in impls.

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -94,7 +94,10 @@ type node_id = int;
 
 #[auto_encode]
 #[auto_decode]
-type def_id = {crate: crate_num, node: node_id};
+struct def_id {
+    crate: crate_num,
+    node: node_id,
+}
 
 impl def_id : cmp::Eq {
     pure fn eq(&self, other: &def_id) -> bool {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1502,7 +1502,7 @@ impl struct_field_kind : cmp::Eq {
 
 #[auto_encode]
 #[auto_decode]
-type struct_def = {
+struct struct_def {
     fields: ~[@struct_field], /* fields */
     /* (not including ctor or dtor) */
     /* dtor is optional */
@@ -1510,7 +1510,7 @@ type struct_def = {
     /* ID of the constructor. This is only used for tuple- or enum-like
      * structs. */
     ctor_id: Option<node_id>
-};
+}
 
 /*
   FIXME (#3300): Should allow items to be anonymous. Right now

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1518,9 +1518,14 @@ type struct_def = {
  */
 #[auto_encode]
 #[auto_decode]
-type item = {ident: ident, attrs: ~[attribute],
-             id: node_id, node: item_,
-             vis: visibility, span: span};
+struct item {
+    ident: ident,
+    attrs: ~[attribute],
+    id: node_id,
+    node: item_,
+    vis: visibility,
+    span: span,
+}
 
 #[auto_encode]
 #[auto_decode]

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -185,8 +185,12 @@ fn map_fn(fk: visit::fn_kind, decl: fn_decl, body: blk,
     match fk {
         visit::fk_dtor(tps, ref attrs, self_id, parent_id) => {
             let dt = @spanned {
-                node: {id: id, attrs: (*attrs), self_id: self_id,
-                     body: /* FIXME (#2543) */ copy body},
+                node: ast::struct_dtor_ {
+                    id: id,
+                    attrs: (*attrs),
+                    self_id: self_id,
+                    body: /* FIXME (#2543) */ copy body,
+                },
                 span: sp,
             };
             cx.map.insert(id, node_dtor(/* FIXME (#2543) */ copy tps, dt,

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -294,8 +294,11 @@ fn default_block(+stmts1: ~[@stmt], expr1: Option<@expr>, id1: node_id) ->
 }
 
 fn ident_to_path(s: span, +i: ident) -> @path {
-    @{span: s, global: false, idents: ~[i],
-      rp: None, types: ~[]}
+    @ast::path { span: s,
+                 global: false,
+                 idents: ~[i],
+                 rp: None,
+                 types: ~[] }
 }
 
 fn ident_to_pat(id: node_id, s: span, +i: ident) -> @pat {

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -54,7 +54,9 @@ pure fn path_name_i(idents: &[ident], intr: @token::ident_interner) -> ~str {
 
 pure fn path_to_ident(p: @path) -> ident { vec::last(p.idents) }
 
-pure fn local_def(id: node_id) -> def_id { {crate: local_crate, node: id} }
+pure fn local_def(id: node_id) -> def_id {
+    ast::def_id { crate: local_crate, node: id }
+}
 
 pure fn is_local(did: ast::def_id) -> bool { did.crate == local_crate }
 

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -91,19 +91,20 @@ fn mk_word_item(name: ~str) -> @ast::meta_item {
 }
 
 fn mk_attr(item: @ast::meta_item) -> ast::attribute {
-    return dummy_spanned({style: ast::attr_inner, value: *item,
-                       is_sugared_doc: false});
+    dummy_spanned(ast::attribute_ { style: ast::attr_inner,
+                                    value: *item,
+                                    is_sugared_doc: false })
 }
 
 fn mk_sugared_doc_attr(text: ~str,
                        +lo: BytePos, +hi: BytePos) -> ast::attribute {
     let lit = spanned(lo, hi, ast::lit_str(@text));
-    let attr = {
+    let attr = ast::attribute_ {
         style: doc_comment_style(text),
         value: spanned(lo, hi, ast::meta_name_value(~"doc", lit)),
         is_sugared_doc: true
     };
-    return spanned(lo, hi, attr);
+    spanned(lo, hi, attr)
 }
 
 /* Conversion */

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -141,7 +141,7 @@ fn expand_auto_encode(
 
                     ~[filter_attrs(*item), ser_impl]
                 },
-                ast::item_struct(@{ fields, _}, tps) => {
+                ast::item_struct(@ast::struct_def { fields, _}, tps) => {
                     let ser_impl = mk_struct_ser_impl(
                         cx,
                         item.span,
@@ -207,7 +207,7 @@ fn expand_auto_decode(
 
                     ~[filter_attrs(*item), deser_impl]
                 },
-                ast::item_struct(@{ fields, _}, tps) => {
+                ast::item_struct(@ast::struct_def { fields, _}, tps) => {
                     let deser_impl = mk_struct_deser_impl(
                         cx,
                         item.span,

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -121,8 +121,10 @@ fn expand_auto_encode(
     }
 
     fn filter_attrs(item: @ast::item) -> @ast::item {
-        @{attrs: item.attrs.filtered(|a| !is_auto_encode(a)),
-          .. *item}
+        @ast::item {
+            attrs: item.attrs.filtered(|a| !is_auto_encode(a)),
+            .. *item
+        }
     }
 
     do vec::flat_map(in_items) |item| {
@@ -185,8 +187,10 @@ fn expand_auto_decode(
     }
 
     fn filter_attrs(item: @ast::item) -> @ast::item {
-        @{attrs: item.attrs.filtered(|a| !is_auto_decode(a)),
-          .. *item}
+        @ast::item {
+            attrs: item.attrs.filtered(|a| !is_auto_decode(a)),
+            .. *item
+        }
     }
 
     do vec::flat_map(in_items) |item| {
@@ -444,7 +448,7 @@ fn mk_impl(
         tps.map(|tp| cx.ty_path(span, ~[tp.ident], ~[]))
     );
 
-    @{
+    @ast::item {
         // This is a new-style impl declaration.
         // XXX: clownshoes
         ident: parse::token::special_idents::clownshoes_extensions,

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -264,21 +264,45 @@ priv impl ext_ctxt {
     }
 
     fn path(span: span, strs: ~[ast::ident]) -> @ast::path {
-        @{span: span, global: false, idents: strs, rp: None, types: ~[]}
+        @ast::path {
+            span: span,
+            global: false,
+            idents: strs,
+            rp: None,
+            types: ~[]
+        }
     }
 
     fn path_global(span: span, strs: ~[ast::ident]) -> @ast::path {
-        @{span: span, global: true, idents: strs, rp: None, types: ~[]}
+        @ast::path {
+            span: span,
+            global: true,
+            idents: strs,
+            rp: None,
+            types: ~[]
+        }
     }
 
     fn path_tps(span: span, strs: ~[ast::ident],
                 tps: ~[@ast::Ty]) -> @ast::path {
-        @{span: span, global: false, idents: strs, rp: None, types: tps}
+        @ast::path {
+            span: span,
+            global: false,
+            idents: strs,
+            rp: None,
+            types: tps
+        }
     }
 
     fn path_tps_global(span: span, strs: ~[ast::ident],
                        tps: ~[@ast::Ty]) -> @ast::path {
-        @{span: span, global: true, idents: strs, rp: None, types: tps}
+        @ast::path {
+            span: span,
+            global: true,
+            idents: strs,
+            rp: None,
+            types: tps
+        }
     }
 
     fn ty_path(span: span, strs: ~[ast::ident],
@@ -289,11 +313,9 @@ priv impl ext_ctxt {
     }
 
     fn binder_pat(span: span, nm: ast::ident) -> @ast::pat {
-        let path = @{span: span, global: false, idents: ~[nm],
-                     rp: None, types: ~[]};
         @{id: self.next_id(),
           node: ast::pat_ident(ast::bind_by_ref(ast::m_imm),
-                               path,
+                               self.path(span, ~[nm]),
                                None),
           span: span}
     }

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -251,7 +251,7 @@ priv impl ext_ctxt {
             span: span,
         });
 
-        {
+        ast::ty_param {
             ident: ident,
             id: self.next_id(),
             bounds: @vec::append(~[bound], *bounds)
@@ -425,7 +425,7 @@ fn mk_impl(
                 span: span,
             });
 
-            {
+            ast::ty_param {
                 ident: tp.ident,
                 id: cx.next_id(),
                 bounds: @vec::append(~[t_bound], *tp.bounds)

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -173,10 +173,10 @@ fn mk_glob_use(cx: ext_ctxt, sp: span,
         node: ast::view_path_glob(mk_raw_path(sp, path), cx.next_id()),
         span: sp,
     };
-    @{node: ast::view_item_import(~[glob]),
-      attrs: ~[],
-      vis: ast::private,
-      span: sp}
+    @ast::view_item { node: ast::view_item_import(~[glob]),
+                      attrs: ~[],
+                      vis: ast::private,
+                      span: sp }
 }
 fn mk_local(cx: ext_ctxt, sp: span, mutbl: bool,
             ident: ast::ident, ex: @ast::expr) -> @ast::stmt {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -313,6 +313,6 @@ fn mk_ty_param(cx: ext_ctxt,
                ident: ast::ident,
                bounds: @~[ast::ty_param_bound])
             -> ast::ty_param {
-    { ident: ident, id: cx.next_id(), bounds: bounds }
+    ast::ty_param { ident: ident, id: cx.next_id(), bounds: bounds }
 }
 

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -53,20 +53,29 @@ fn mk_unary(cx: ext_ctxt, sp: span, op: ast::unop, e: @ast::expr)
     mk_expr(cx, sp, ast::expr_unary(op, e))
 }
 fn mk_raw_path(sp: span, idents: ~[ast::ident]) -> @ast::path {
-    let p : @ast::path = @{span: sp, global: false, idents: idents,
-                           rp: None, types: ~[]};
+    let p = @ast::path { span: sp,
+                         global: false,
+                         idents: idents,
+                         rp: None,
+                         types: ~[] };
     return p;
 }
 fn mk_raw_path_(sp: span,
                 idents: ~[ast::ident],
                 +types: ~[@ast::Ty])
              -> @ast::path {
-    @{ span: sp, global: false, idents: idents, rp: None, types: move types }
+    @ast::path { span: sp,
+                 global: false,
+                 idents: idents,
+                 rp: None,
+                 types: move types }
 }
 fn mk_raw_path_global(sp: span, idents: ~[ast::ident]) -> @ast::path {
-    let p : @ast::path = @{span: sp, global: true, idents: idents,
-                           rp: None, types: ~[]};
-    return p;
+    @ast::path { span: sp,
+                 global: true,
+                 idents: idents,
+                 rp: None,
+                 types: ~[] }
 }
 fn mk_path(cx: ext_ctxt, sp: span, idents: ~[ast::ident]) ->
     @ast::expr {

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -36,9 +36,11 @@ fn expand_syntax_ext(cx: ext_ctxt, sp: span, tts: ~[ast::token_tree])
 
     let e = @{id: cx.next_id(),
               callee_id: cx.next_id(),
-              node: ast::expr_path(@{span: sp, global: false,
-                                     idents: ~[res],
-                                     rp: None, types: ~[]}),
+              node: ast::expr_path(@ast::path { span: sp,
+                                                global: false,
+                                                idents: ~[res],
+                                                rp: None,
+                                                types: ~[] }),
               span: sp};
     mr_expr(e)
 }

--- a/src/libsyntax/ext/deriving.rs
+++ b/src/libsyntax/ext/deriving.rs
@@ -111,7 +111,7 @@ fn expand_deriving(cx: ext_ctxt,
 }
 
 fn create_impl_item(cx: ext_ctxt, span: span, +item: item_) -> @item {
-    @{
+    @ast::item {
         ident: clownshoes_extensions,
         attrs: ~[],
         id: cx.next_id(),

--- a/src/libsyntax/ext/deriving.rs
+++ b/src/libsyntax/ext/deriving.rs
@@ -13,6 +13,7 @@
 
 use core::prelude::*;
 
+use ast;
 use ast::{TraitTyParamBound, Ty, and, bind_by_ref, binop, deref, enum_def};
 use ast::{enum_variant_kind, expr, expr_match, ident, item, item_};
 use ast::{item_enum, item_impl, item_struct, m_imm, meta_item, method};
@@ -218,7 +219,7 @@ fn create_derived_impl(cx: ext_ctxt,
     let impl_ty_params = dvec::unwrap(move impl_ty_params);
 
     // Create the reference to the trait.
-    let trait_path = {
+    let trait_path = ast::path {
         span: span,
         global: true,
         idents: trait_path.map(|x| *x),

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -229,12 +229,12 @@ impl ext_ctxt: ext_ctxt_ast_builder {
             is_sugared_doc: false
         });
 
-        @{ident: name,
-         attrs: ~[non_camel_case_attribute],
-         id: self.next_id(),
-         node: node,
-         vis: ast::public,
-         span: span}
+        @ast::item { ident: name,
+                     attrs: ~[non_camel_case_attribute],
+                     id: self.next_id(),
+                     node: node,
+                     vis: ast::public,
+                     span: span }
     }
 
     fn item_fn_poly(name: ident,

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -219,7 +219,7 @@ impl ext_ctxt: ext_ctxt_ast_builder {
 
         // XXX: Would be nice if our generated code didn't violate
         // Rust coding conventions
-        let non_camel_case_attribute = respan(dummy_sp(), {
+        let non_camel_case_attribute = respan(dummy_sp(), ast::attribute_ {
             style: ast::attr_outer,
             value: respan(dummy_sp(),
                           ast::meta_list(~"allow", ~[
@@ -306,7 +306,7 @@ impl ext_ctxt: ext_ctxt_ast_builder {
                 span: ast_util::dummy_sp()
             }
         ]);
-        let vi = @{
+        let vi = @ast::view_item {
             node: vi,
             attrs: ~[],
             vis: ast::private,

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -177,7 +177,7 @@ impl ext_ctxt: ext_ctxt_ast_builder {
     fn ty_param(id: ast::ident, +bounds: ~[ast::ty_param_bound])
         -> ast::ty_param
     {
-        {ident: id, id: self.next_id(), bounds: @bounds}
+        ast::ty_param { ident: id, id: self.next_id(), bounds: @bounds }
     }
 
     fn arg(name: ident, ty: @ast::Ty) -> ast::arg {

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -34,19 +34,19 @@ mod syntax {
 }
 
 fn path(ids: ~[ident], span: span) -> @ast::path {
-    @{span: span,
-      global: false,
-      idents: ids,
-      rp: None,
-      types: ~[]}
+    @ast::path { span: span,
+                 global: false,
+                 idents: ids,
+                 rp: None,
+                 types: ~[] }
 }
 
 fn path_global(ids: ~[ident], span: span) -> @ast::path {
-    @{span: span,
-      global: true,
-      idents: ids,
-      rp: None,
-      types: ~[]}
+    @ast::path { span: span,
+                 global: true,
+                 idents: ids,
+                 rp: None,
+                 types: ~[] }
 }
 
 trait append_types {
@@ -56,13 +56,13 @@ trait append_types {
 
 impl @ast::path: append_types {
     fn add_ty(ty: @ast::Ty) -> @ast::path {
-        @{types: vec::append_one(self.types, ty),
-          .. *self}
+        @ast::path { types: vec::append_one(self.types, ty),
+                     .. *self}
     }
 
     fn add_tys(+tys: ~[@ast::Ty]) -> @ast::path {
-        @{types: vec::append(self.types, tys),
-          .. *self}
+        @ast::path { types: vec::append(self.types, tys),
+                     .. *self}
     }
 }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -216,9 +216,9 @@ fn noop_fold_item(&&i: @item, fld: ast_fold) -> Option<@item> {
 
 fn noop_fold_struct_field(&&sf: @struct_field, fld: ast_fold)
                        -> @struct_field {
-    @spanned { node: { kind: copy sf.node.kind,
-                       id: sf.node.id,
-                       ty: fld.fold_ty(sf.node.ty) },
+    @spanned { node: ast::struct_field_ { kind: copy sf.node.kind,
+                                          id: sf.node.id,
+                                          ty: fld.fold_ty(sf.node.ty) },
                span: sf.span }
 }
 
@@ -293,9 +293,9 @@ fn fold_trait_ref(&&p: @trait_ref, fld: ast_fold) -> @trait_ref {
 }
 
 fn fold_struct_field(&&f: @struct_field, fld: ast_fold) -> @struct_field {
-    @spanned { node: { kind: copy f.node.kind,
-                       id: fld.new_id(f.node.id),
-                       ty: fld.fold_ty(f.node.ty) },
+    @spanned { node: ast::struct_field_ { kind: copy f.node.kind,
+                                          id: fld.new_id(f.node.id),
+                                          ty: fld.fold_ty(f.node.ty) },
                span: fld.new_span(f.span) }
 }
 
@@ -693,10 +693,14 @@ impl ast_fold_fns: ast_fold {
         return (self.fold_item)(i, self as ast_fold);
     }
     fn fold_struct_field(&&sf: @struct_field) -> @struct_field {
-        @spanned { node: { kind: copy sf.node.kind,
-                           id: sf.node.id,
-                           ty: (self as ast_fold).fold_ty(sf.node.ty) },
-                   span: (self.new_span)(sf.span) }
+        @spanned {
+            node: ast::struct_field_ {
+                kind: copy sf.node.kind,
+                id: sf.node.id,
+                ty: (self as ast_fold).fold_ty(sf.node.ty),
+            },
+            span: (self.new_span)(sf.span),
+        }
     }
     fn fold_item_underscore(i: item_) ->
        item_ {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -114,10 +114,14 @@ fn fold_meta_item_(&&mi: @meta_item, fld: ast_fold) -> @meta_item {
 }
 //used in noop_fold_item and noop_fold_crate
 fn fold_attribute_(at: attribute, fld: ast_fold) -> attribute {
-    spanned { node: { style: at.node.style,
-                      value: *fold_meta_item_(@at.node.value, fld),
-                      is_sugared_doc: at.node.is_sugared_doc },
-              span: fld.new_span(at.span) }
+    spanned {
+        node: ast::attribute_ {
+            style: at.node.style,
+            value: *fold_meta_item_(@at.node.value, fld),
+            is_sugared_doc: at.node.is_sugared_doc,
+        },
+        span: fld.new_span(at.span),
+    }
 }
 //used in noop_fold_foreign_item and noop_fold_fn_decl
 fn fold_arg_(a: arg, fld: ast_fold) -> arg {
@@ -679,11 +683,13 @@ impl ast_fold_fns: ast_fold {
     }
     fn fold_view_item(&&x: @view_item) ->
        @view_item {
-        return @{node: (self.fold_view_item)(x.node, self as ast_fold),
-              attrs: vec::map(x.attrs, |a|
+        @ast::view_item {
+            node: (self.fold_view_item)(x.node, self as ast_fold),
+            attrs: vec::map(x.attrs, |a|
                   fold_attribute_(*a, self as ast_fold)),
-              vis: x.vis,
-              span: (self.new_span)(x.span)};
+            vis: x.vis,
+            span: (self.new_span)(x.span),
+        }
     }
     fn fold_foreign_item(&&x: @foreign_item)
         -> @foreign_item {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -206,12 +206,12 @@ fn noop_fold_foreign_item(&&ni: @foreign_item, fld: ast_fold)
 fn noop_fold_item(&&i: @item, fld: ast_fold) -> Option<@item> {
     let fold_attribute = |x| fold_attribute_(x, fld);
 
-    return Some(@{ident: fld.fold_ident(i.ident),
-               attrs: vec::map(i.attrs, |e| fold_attribute(*e)),
-               id: fld.new_id(i.id),
-               node: fld.fold_item_underscore(i.node),
-               vis: i.vis,
-               span: fld.new_span(i.span)});
+    Some(@ast::item { ident: fld.fold_ident(i.ident),
+                      attrs: i.attrs.map(|e| fold_attribute(*e)),
+                      id: fld.new_id(i.id),
+                      node: fld.fold_item_underscore(i.node),
+                      vis: i.vis,
+                      span: fld.new_span(i.span) })
 }
 
 fn noop_fold_struct_field(&&sf: @struct_field, fld: ast_fold)

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -281,7 +281,7 @@ fn fold_struct_def(struct_def: @ast::struct_def, fld: ast_fold)
                                             .. dtor.node},
                   span: dtor.span }
     };
-    return @{
+    return @ast::struct_def {
         fields: vec::map(struct_def.fields, |f| fold_struct_field(*f, fld)),
         dtor: dtor,
         ctor_id: option::map(&struct_def.ctor_id, |cid| fld.new_id(*cid))
@@ -582,7 +582,7 @@ fn noop_fold_variant(v: variant_, fld: ast_fold) -> variant_ {
                                                     .. dtor.node},
                           .. *dtor }
             };
-            kind = struct_variant_kind(@{
+            kind = struct_variant_kind(@ast::struct_def {
                 fields: vec::map(struct_def.fields,
                                  |f| fld.fold_struct_field(*f)),
                 dtor: dtor,

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -178,25 +178,29 @@ fn noop_fold_foreign_item(&&ni: @foreign_item, fld: ast_fold)
     let fold_arg = |x| fold_arg_(x, fld);
     let fold_attribute = |x| fold_attribute_(x, fld);
 
-    return @{ident: fld.fold_ident(ni.ident),
-          attrs: vec::map(ni.attrs, |x| fold_attribute(*x)),
-          node:
-              match ni.node {
+    @ast::foreign_item {
+        ident: fld.fold_ident(ni.ident),
+        attrs: vec::map(ni.attrs, |x| fold_attribute(*x)),
+        node:
+            match ni.node {
                 foreign_item_fn(fdec, purity, typms) => {
-                  foreign_item_fn(
-                      {inputs: vec::map(fdec.inputs, |a| fold_arg(*a)),
-                       output: fld.fold_ty(fdec.output),
-                       cf: fdec.cf},
-                      purity,
-                      fold_ty_params(typms, fld))
+                    foreign_item_fn(
+                        {
+                            inputs: fdec.inputs.map(|a| fold_arg(*a)),
+                            output: fld.fold_ty(fdec.output),
+                            cf: fdec.cf,
+                        },
+                        purity,
+                        fold_ty_params(typms, fld))
                 }
                 foreign_item_const(t) => {
-                  foreign_item_const(fld.fold_ty(t))
+                    foreign_item_const(fld.fold_ty(t))
                 }
-              },
-          id: fld.new_id(ni.id),
-          span: fld.new_span(ni.span),
-          vis: ni.vis};
+            },
+        id: fld.new_id(ni.id),
+        span: fld.new_span(ni.span),
+        vis: ni.vis,
+    }
 }
 
 fn noop_fold_item(&&i: @item, fld: ast_fold) -> Option<@item> {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -276,8 +276,9 @@ fn fold_struct_def(struct_def: @ast::struct_def, fld: ast_fold)
     let dtor = do option::map(&struct_def.dtor) |dtor| {
         let dtor_body = fld.fold_block(dtor.node.body);
         let dtor_id   = fld.new_id(dtor.node.id);
-        spanned { node: { body: dtor_body,
-                          id: dtor_id, .. dtor.node},
+        spanned { node: ast::struct_dtor_ { body: dtor_body,
+                                            id: dtor_id,
+                                            .. dtor.node},
                   span: dtor.span }
     };
     return @{
@@ -576,8 +577,9 @@ fn noop_fold_variant(v: variant_, fld: ast_fold) -> variant_ {
             let dtor = do option::map(&struct_def.dtor) |dtor| {
                 let dtor_body = fld.fold_block(dtor.node.body);
                 let dtor_id   = fld.new_id(dtor.node.id);
-                spanned { node: { body: dtor_body,
-                                  id: dtor_id, .. dtor.node},
+                spanned { node: ast::struct_dtor_ { body: dtor_body,
+                                                    id: dtor_id,
+                                                    .. dtor.node},
                           .. *dtor }
             };
             kind = struct_variant_kind(@{

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -148,13 +148,13 @@ fn fold_ty_param_bound(tpb: ty_param_bound, fld: ast_fold) -> ty_param_bound {
 }
 
 fn fold_ty_param(tp: ty_param, fld: ast_fold) -> ty_param {
-    {ident: /* FIXME (#2543) */ copy tp.ident,
-     id: fld.new_id(tp.id),
-     bounds: @vec::map(*tp.bounds, |x| fold_ty_param_bound(*x, fld) )}
+    ast::ty_param { ident: /* FIXME (#2543) */ copy tp.ident,
+                    id: fld.new_id(tp.id),
+                    bounds: @tp.bounds.map(|x| fold_ty_param_bound(*x, fld) )}
 }
 
 fn fold_ty_params(tps: ~[ty_param], fld: ast_fold) -> ~[ty_param] {
-    vec::map(tps, |x| fold_ty_param(*x, fld) )
+    tps.map(|x| fold_ty_param(*x, fld))
 }
 
 fn noop_fold_crate(c: crate_, fld: ast_fold) -> crate_ {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -614,10 +614,11 @@ fn noop_fold_ident(&&i: ident, _fld: ast_fold) -> ident {
 }
 
 fn noop_fold_path(&&p: path, fld: ast_fold) -> path {
-    return {span: fld.new_span(p.span), global: p.global,
-         idents: vec::map(p.idents, |x| fld.fold_ident(*x)),
-         rp: p.rp,
-         types: vec::map(p.types, |x| fld.fold_ty(*x))};
+    ast::path { span: fld.new_span(p.span),
+                global: p.global,
+                idents: p.idents.map(|x| fld.fold_ident(*x)),
+                rp: p.rp,
+                types: p.types.map(|x| fld.fold_ty(*x)) }
 }
 
 fn noop_fold_local(l: local_, fld: ast_fold) -> local_ {

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -72,8 +72,9 @@ impl Parser: parser_attr {
         let meta_item = self.parse_meta_item();
         self.expect(token::RBRACKET);
         let mut hi = self.span.hi;
-        return spanned(lo, hi, {style: style, value: *meta_item,
-                             is_sugared_doc: false});
+        return spanned(lo, hi, ast::attribute_ { style: style,
+                                                 value: *meta_item,
+                                                 is_sugared_doc: false });
     }
 
     // Parse attributes that appear after the opening of an item, each
@@ -101,8 +102,9 @@ impl Parser: parser_attr {
                     // It's not really an inner attribute
                     let outer_attr =
                         spanned(attr.span.lo, attr.span.hi,
-                            {style: ast::attr_outer, value: attr.node.value,
-                             is_sugared_doc: false});
+                            ast::attribute_ { style: ast::attr_outer,
+                                              value: attr.node.value,
+                                              is_sugared_doc: false });
                     next_outer_attrs += ~[outer_attr];
                     break;
                 }

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -81,7 +81,8 @@ impl Parser {
         let lo = self.span.lo;
         let ident = self.parse_ident();
         let hi = self.span.hi;
-        return spanned(lo, hi, {name: ident, id: self.get_id()});
+        spanned(lo, hi, ast::path_list_ident_ { name: ident,
+                                                id: self.get_id() })
     }
 
     fn parse_value_ident() -> ast::ident {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2844,7 +2844,7 @@ impl Parser {
         let _ = self.get_id();  // XXX: Workaround for crazy bug.
         let new_id = self.get_id();
         (class_name,
-         item_struct(@{
+         item_struct(@ast::struct_def {
              fields: fields,
              dtor: actual_dtor,
              ctor_id: if is_tuple_like { Some(new_id) } else { None }
@@ -3340,7 +3340,7 @@ impl Parser {
                       span: d_s }
         };
 
-        return @{
+        return @ast::struct_def {
             fields: fields,
             dtor: actual_dtor,
             ctor_id: None

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3276,12 +3276,12 @@ impl Parser {
         // extern mod foo;
         let metadata = self.parse_optional_meta();
         self.expect(token::SEMI);
-        return iovi_view_item(@{
+        iovi_view_item(@ast::view_item {
             node: view_item_use(ident, metadata, self.get_id()),
             attrs: attrs,
             vis: visibility,
             span: mk_sp(lo, self.last_span.hi)
-        });
+        })
     }
 
     fn parse_type_decl() -> {lo: BytePos, ident: ident} {
@@ -3573,7 +3573,7 @@ impl Parser {
         } else if self.eat_keyword(~"use") {
             let view_item = self.parse_use();
             self.expect(token::SEMI);
-            return iovi_view_item(@{
+            return iovi_view_item(@ast::view_item {
                 node: view_item,
                 attrs: attrs,
                 vis: visibility,
@@ -3582,7 +3582,7 @@ impl Parser {
         } else if self.eat_keyword(~"export") {
             let view_paths = self.parse_view_paths();
             self.expect(token::SEMI);
-            return iovi_view_item(@{
+            return iovi_view_item(@ast::view_item {
                 node: view_item_export(view_paths),
                 attrs: attrs,
                 vis: visibility,
@@ -3780,8 +3780,10 @@ impl Parser {
             fail;
         };
         self.expect(token::SEMI);
-        @{node: node, attrs: attrs,
-          vis: vis, span: mk_sp(lo, self.last_span.hi)}
+        @ast::view_item { node: node,
+                          attrs: attrs,
+                          vis: vis,
+                          span: mk_sp(lo, self.last_span.hi) }
     }
 
     fn parse_items_and_view_items(+first_item_attrs: ~[attribute],

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2150,11 +2150,11 @@ impl Parser {
         let name = self.parse_ident();
         self.expect(token::COLON);
         let ty = self.parse_ty(false);
-        return @spanned(lo, self.last_span.hi, {
+        @spanned(lo, self.last_span.hi, ast::struct_field_ {
             kind: named_field(name, is_mutbl, pr),
             id: self.get_id(),
             ty: ty
-        });
+        })
     }
 
     fn parse_stmt(+first_item_attrs: ~[attribute]) -> @stmt {
@@ -2816,7 +2816,7 @@ impl Parser {
                                                  seq_sep_trailing_allowed
                                                     (token::COMMA)) |p| {
                 let lo = p.span.lo;
-                let struct_field_ = {
+                let struct_field_ = ast::struct_field_ {
                     kind: unnamed_field,
                     id: self.get_id(),
                     ty: p.parse_ty(false)
@@ -2893,7 +2893,9 @@ impl Parser {
             self.parse_method();
             // bogus value
             @spanned(self.span.lo, self.span.hi,
-                     { kind: unnamed_field, id: self.get_id(),
+                     ast::struct_field_ {
+                       kind: unnamed_field,
+                       id: self.get_id(),
                        ty: @{id: self.get_id(),
                              node: ty_nil,
                              span: copy self.span} })

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2621,12 +2621,12 @@ impl Parser {
     fn mk_item(+lo: BytePos, +hi: BytePos, +ident: ident,
                +node: item_, vis: visibility,
                +attrs: ~[attribute]) -> @item {
-        return @{ident: ident,
-              attrs: attrs,
-              id: self.get_id(),
-              node: node,
-              vis: vis,
-              span: mk_sp(lo, hi)};
+        @ast::item { ident: ident,
+                     attrs: attrs,
+                     id: self.get_id(),
+                     node: node,
+                     vis: vis,
+                     span: mk_sp(lo, hi) }
     }
 
     fn parse_item_fn(purity: purity) -> item_info {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3123,12 +3123,12 @@ impl Parser {
         let (decl, _) = self.parse_fn_decl(|p| p.parse_arg());
         let mut hi = self.span.hi;
         self.expect(token::SEMI);
-        return @{ident: t.ident,
-                 attrs: attrs,
-                 node: foreign_item_fn(decl, purity, t.tps),
-                 id: self.get_id(),
-                 span: mk_sp(lo, hi),
-                 vis: vis};
+        @ast::foreign_item { ident: t.ident,
+                             attrs: attrs,
+                             node: foreign_item_fn(decl, purity, t.tps),
+                             id: self.get_id(),
+                             span: mk_sp(lo, hi),
+                             vis: vis }
     }
 
     fn parse_item_foreign_const(vis: ast::visibility,
@@ -3140,12 +3140,12 @@ impl Parser {
         let ty = self.parse_ty(false);
         let hi = self.span.hi;
         self.expect(token::SEMI);
-        return @{ident: ident,
-                 attrs: attrs,
-                 node: foreign_item_const(move ty),
-                 id: self.get_id(),
-                 span: mk_sp(lo, hi),
-                 vis: vis};
+        @ast::foreign_item { ident: ident,
+                             attrs: attrs,
+                             node: foreign_item_const(ty),
+                             id: self.get_id(),
+                             span: mk_sp(lo, hi),
+                             vis: vis }
     }
 
     fn parse_fn_purity() -> purity {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2458,7 +2458,7 @@ impl Parser {
     fn parse_ty_param() -> ty_param {
         let ident = self.parse_ident();
         let bounds = self.parse_optional_ty_param_bounds();
-        return {ident: ident, id: self.get_id(), bounds: bounds};
+        ast::ty_param { ident: ident, id: self.get_id(), bounds: bounds }
     }
 
     fn parse_ty_params() -> ~[ty_param] {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -802,8 +802,11 @@ impl Parser {
                 break;
             }
         }
-        @{span: mk_sp(lo, self.last_span.hi), global: global,
-          idents: ids, rp: None, types: ~[]}
+        @ast::path { span: mk_sp(lo, self.last_span.hi),
+                     global: global,
+                     idents: ids,
+                     rp: None,
+                     types: ~[] }
     }
 
     fn parse_value_path() -> @path {
@@ -849,9 +852,10 @@ impl Parser {
             }
         };
 
-        return @{span: mk_sp(lo, tps.span.hi),
-              rp: rp,
-              types: tps.node,.. *path};
+        @ast::path { span: mk_sp(lo, tps.span.hi),
+                     rp: rp,
+                     types: tps.node,
+                     .. *path }
     }
 
     fn parse_mutability() -> mutability {
@@ -2730,18 +2734,27 @@ impl Parser {
                          typarams: ~[ty_param]) -> @path {
         let s = self.last_span;
 
-        @{span: s, global: false, idents: ~[i],
-          rp: None,
-          types: vec::map(typarams, |tp| {
-              @{id: self.get_id(),
-                node: ty_path(ident_to_path(s, tp.ident), self.get_id()),
-                span: s}})
+        @ast::path {
+             span: s,
+             global: false,
+             idents: ~[i],
+             rp: None,
+             types: do typarams.map |tp| {
+                @{
+                    id: self.get_id(),
+                    node: ty_path(ident_to_path(s, tp.ident), self.get_id()),
+                    span: s
+                }
+            }
          }
     }
 
     fn ident_to_path(i: ident) -> @path {
-        @{span: self.last_span, global: false, idents: ~[i],
-          rp: None, types: ~[]}
+        @ast::path { span: self.last_span,
+                     global: false,
+                     idents: ~[i],
+                     rp: None,
+                     types: ~[] }
     }
 
     fn parse_trait_ref() -> @trait_ref {
@@ -3661,8 +3674,11 @@ impl Parser {
                 let id = self.parse_ident();
                 path.push(id);
             }
-            let path = @{span: mk_sp(lo, self.span.hi), global: false,
-                         idents: path, rp: None, types: ~[]};
+            let path = @ast::path { span: mk_sp(lo, self.span.hi),
+                                    global: false,
+                                    idents: path,
+                                    rp: None,
+                                    types: ~[] };
             return @spanned(lo, self.span.hi,
                          view_path_simple(first_ident, path, namespace,
                                           self.get_id()));
@@ -3686,9 +3702,11 @@ impl Parser {
                         token::LBRACE, token::RBRACE,
                         seq_sep_trailing_allowed(token::COMMA),
                         |p| p.parse_path_list_ident());
-                    let path = @{span: mk_sp(lo, self.span.hi),
-                                 global: false, idents: path,
-                                 rp: None, types: ~[]};
+                    let path = @ast::path { span: mk_sp(lo, self.span.hi),
+                                            global: false,
+                                            idents: path,
+                                            rp: None,
+                                            types: ~[] };
                     return @spanned(lo, self.span.hi,
                                  view_path_list(path, idents, self.get_id()));
                   }
@@ -3696,9 +3714,11 @@ impl Parser {
                   // foo::bar::*
                   token::BINOP(token::STAR) => {
                     self.bump();
-                    let path = @{span: mk_sp(lo, self.span.hi),
-                                 global: false, idents: path,
-                                 rp: None, types: ~[]};
+                    let path = @ast::path { span: mk_sp(lo, self.span.hi),
+                                            global: false,
+                                            idents: path,
+                                            rp: None,
+                                            types: ~[] };
                     return @spanned(lo, self.span.hi,
                                  view_path_glob(path, self.get_id()));
                   }
@@ -3710,8 +3730,11 @@ impl Parser {
           _ => ()
         }
         let last = path[vec::len(path) - 1u];
-        let path = @{span: mk_sp(lo, self.span.hi), global: false,
-                     idents: path, rp: None, types: ~[]};
+        let path = @ast::path { span: mk_sp(lo, self.span.hi),
+                                global: false,
+                                idents: path,
+                                rp: None,
+                                types: ~[] };
         return @spanned(lo, self.span.hi,
                      view_path_simple(last, path, namespace, self.get_id()));
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2836,16 +2836,16 @@ impl Parser {
 
         let actual_dtor = do the_dtor.map |dtor| {
             let (d_body, d_attrs, d_s) = *dtor;
-            spanned { node: { id: self.get_id(),
-                              attrs: d_attrs,
-                              self_id: self.get_id(),
-                              body: d_body},
+            spanned { node: ast::struct_dtor_ { id: self.get_id(),
+                                                attrs: d_attrs,
+                                                self_id: self.get_id(),
+                                                body: d_body},
                        span: d_s}};
         let _ = self.get_id();  // XXX: Workaround for crazy bug.
         let new_id = self.get_id();
         (class_name,
          item_struct(@{
-             fields: move fields,
+             fields: fields,
              dtor: actual_dtor,
              ctor_id: if is_tuple_like { Some(new_id) } else { None }
          }, ty_params),
@@ -3333,15 +3333,15 @@ impl Parser {
         self.bump();
         let mut actual_dtor = do the_dtor.map |dtor| {
             let (d_body, d_attrs, d_s) = *dtor;
-            spanned { node: { id: self.get_id(),
-                              attrs: d_attrs,
-                              self_id: self.get_id(),
-                              body: d_body },
+            spanned { node: ast::struct_dtor_ { id: self.get_id(),
+                                                attrs: d_attrs,
+                                                self_id: self.get_id(),
+                                                body: d_body },
                       span: d_s }
         };
 
         return @{
-            fields: move fields,
+            fields: fields,
             dtor: actual_dtor,
             ctor_id: None
         };


### PR DESCRIPTION
Just some code I have queued up in my repository I'd like to upstream. I'm converting all the `#[auto_encode]`ed code to use structs, so this is the first step. Plus it includes some vector cleanup and a function to partition vectors.
