### PR TITLE
Rename identifiers that still use 'alt' to use 'match'

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -275,8 +275,8 @@ fn compile_upto(sess: Session, cfg: ast::crate_cfg,
         time(time_passes, ~"mode computation", ||
              middle::mode::compute_modes(ty_cx, method_map, crate));
 
-        time(time_passes, ~"alt checking", ||
-             middle::check_alt::check_crate(ty_cx, method_map, crate));
+        time(time_passes, ~"match checking", ||
+             middle::check_match::check_crate(ty_cx, method_map, crate));
 
         let last_use_map =
             time(time_passes, ~"liveness checking", ||

--- a/src/librustc/middle/borrowck/gather_loans.rs
+++ b/src/librustc/middle/borrowck/gather_loans.rs
@@ -506,7 +506,7 @@ impl gather_loan_ctxt {
                   discr_cmt: cmt,
                   root_pat: @ast::pat,
                   arm_id: ast::node_id,
-                  alt_id: ast::node_id) {
+                  match_id: ast::node_id) {
         do self.bccx.cat_pattern(discr_cmt, root_pat) |cmt, pat| {
             match pat.node {
               ast::pat_ident(bm, _, _) if self.pat_is_binding(pat) => {
@@ -514,11 +514,11 @@ impl gather_loan_ctxt {
                   ast::bind_by_value | ast::bind_by_move => {
                     // copying does not borrow anything, so no check
                     // is required
-                    // as for move, check::alt ensures it's from an rvalue.
+                    // as for move, check::_match ensures it's from an rvalue.
                   }
                   ast::bind_by_ref(mutbl) => {
                     // ref x or ref x @ p --- creates a ptr which must
-                    // remain valid for the scope of the alt
+                    // remain valid for the scope of the match
 
                     // find the region of the resulting pointer (note that
                     // the type of such a pattern will *always* be a
@@ -531,7 +531,7 @@ impl gather_loan_ctxt {
                     // of the function of this node in method preserve():
                     let arm_scope = ty::re_scope(arm_id);
                     if self.bccx.is_subregion_of(scope_r, arm_scope) {
-                        let cmt_discr = self.bccx.cat_discr(cmt, alt_id);
+                        let cmt_discr = self.bccx.cat_discr(cmt, match_id);
                         self.guarantee_valid(cmt_discr, mutbl, scope_r);
                     } else {
                         self.guarantee_valid(cmt, mutbl, scope_r);

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -494,8 +494,8 @@ impl borrowck_ctxt {
         cat_variant(self.tcx, self.method_map, arg, enum_did, cmt)
     }
 
-    fn cat_discr(cmt: cmt, alt_id: ast::node_id) -> cmt {
-        return @{cat:cat_discr(cmt, alt_id),.. *cmt};
+    fn cat_discr(cmt: cmt, match_id: ast::node_id) -> cmt {
+        return @{cat:cat_discr(cmt, match_id),.. *cmt};
     }
 
     fn cat_pattern(cmt: cmt, pat: @ast::pat, op: fn(cmt, @ast::pat)) {

--- a/src/librustc/middle/borrowck/preserve.rs
+++ b/src/librustc/middle/borrowck/preserve.rs
@@ -195,15 +195,15 @@ priv impl &preserve_ctxt {
                 self.attempt_root(cmt, base, derefs)
             }
           }
-          cat_discr(base, alt_id) => {
-            // Subtle: in an alt, we must ensure that each binding
+          cat_discr(base, match_id) => {
+            // Subtle: in a match, we must ensure that each binding
             // variable remains valid for the duration of the arm in
             // which it appears, presuming that this arm is taken.
             // But it is inconvenient in trans to root something just
             // for one arm.  Therefore, we insert a cat_discr(),
             // basically a special kind of category that says "if this
             // value must be dynamically rooted, root it for the scope
-            // `alt_id`.
+            // `match_id`.
             //
             // As an example, consider this scenario:
             //
@@ -213,7 +213,7 @@ priv impl &preserve_ctxt {
             // Technically, the value `x` need only be rooted
             // in the `some` arm.  However, we evaluate `x` in trans
             // before we know what arm will be taken, so we just
-            // always root it for the duration of the alt.
+            // always root it for the duration of the match.
             //
             // As a second example, consider *this* scenario:
             //
@@ -225,7 +225,7 @@ priv impl &preserve_ctxt {
             // found only when checking which pattern matches: but
             // this check is done before entering the arm.  Therefore,
             // even in this case we just choose to keep the value
-            // rooted for the entire alt.  This means the value will be
+            // rooted for the entire match.  This means the value will be
             // rooted even if the none arm is taken.  Oh well.
             //
             // At first, I tried to optimize the second case to only
@@ -247,12 +247,12 @@ priv impl &preserve_ctxt {
             // Nonetheless, if you decide to optimize this case in the
             // future, you need only adjust where the cat_discr()
             // node appears to draw the line between what will be rooted
-            // in the *arm* vs the *alt*.
+            // in the *arm* vs the *match*.
 
-            let alt_rooting_ctxt =
-                preserve_ctxt({scope_region: ty::re_scope(alt_id),
+            let match_rooting_ctxt =
+                preserve_ctxt({scope_region: ty::re_scope(match_id),
                                .. **self});
-            (&alt_rooting_ctxt).preserve(base)
+            (&match_rooting_ctxt).preserve(base)
           }
         }
     }

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -46,7 +46,7 @@ use syntax::ast::*;
 //        & and * pointers
 //        copies of general constants
 //
-//        (in theory, probably not at first: if/alt on integer-const
+//        (in theory, probably not at first: if/match on integer-const
 //         conditions / descriminants)
 //
 //   - Non-constants: everything else.

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -904,7 +904,7 @@ impl &mem_categorization_ctxt {
         //     local(x)->@->@
         //
         // where the id of `local(x)` is the id of the `x` that appears
-        // in the alt, the id of `local(x)->@` is the `@y` pattern,
+        // in the match, the id of `local(x)->@` is the `@y` pattern,
         // and the id of `local(x)->@->@` is the id of the `y` pattern.
 
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -71,7 +71,7 @@ struct ctxt {
     // that when we visit it we can view it as a parent.
     root_exprs: HashMap<ast::node_id, ()>,
 
-    // The parent scope is the innermost block, statement, call, or alt
+    // The parent scope is the innermost block, statement, call, or match
     // expression during the execution of which the current expression
     // will be evaluated.  Generally speaking, the innermost parent
     // scope is also the closest suitable ancestor in the AST tree.

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -245,7 +245,7 @@ enum opt_result {
     range_result(Result, Result),
 }
 fn trans_opt(bcx: block, o: &Opt) -> opt_result {
-    let _icx = bcx.insn_ctxt("alt::trans_opt");
+    let _icx = bcx.insn_ctxt("match::trans_opt");
     let ccx = bcx.ccx();
     let mut bcx = bcx;
     match *o {
@@ -463,8 +463,8 @@ fn enter_default(bcx: block, dm: DefMap, m: &[@Match/&r],
 }
 
 // <pcwalton> nmatsakis: what does enter_opt do?
-// <pcwalton> in trans/alt
-// <pcwalton> trans/alt.rs is like stumbling around in a dark cave
+// <pcwalton> in trans/match
+// <pcwalton> trans/match.rs is like stumbling around in a dark cave
 // <nmatsakis> pcwalton: the enter family of functions adjust the set of
 //             patterns as needed
 // <nmatsakis> yeah, at some point I kind of achieved some level of
@@ -810,7 +810,7 @@ fn extract_variant_args(bcx: block, pat_id: ast::node_id,
                         val: ValueRef)
     -> {vals: ~[ValueRef], bcx: block}
 {
-    let _icx = bcx.insn_ctxt("alt::extract_variant_args");
+    let _icx = bcx.insn_ctxt("match::extract_variant_args");
     let ccx = bcx.fcx.ccx;
     let enum_ty_substs = match ty::get(node_id_type(bcx, pat_id)).sty {
       ty::ty_enum(id, ref substs) => {
@@ -841,7 +841,7 @@ fn extract_vec_elems(bcx: block, pat_id: ast::node_id,
                      elem_count: uint, tail: bool, val: ValueRef)
     -> {vals: ~[ValueRef], bcx: block}
 {
-    let _icx = bcx.insn_ctxt("alt::extract_vec_elems");
+    let _icx = bcx.insn_ctxt("match::extract_vec_elems");
     let vt = tvec::vec_types(bcx, node_id_type(bcx, pat_id));
     let unboxed = load_if_immediate(bcx, val, vt.vec_ty);
     let (base, len) = tvec::get_base_and_len(bcx, unboxed, vt.vec_ty);
@@ -909,7 +909,7 @@ fn root_pats_as_necessary(bcx: block, m: &[@Match],
         match bcx.ccx().maps.root_map.find({id:pat_id, derefs:0u}) {
             None => (),
             Some(scope_id) => {
-                // Note: the scope_id will always be the id of the alt.  See
+                // Note: the scope_id will always be the id of the match.  See
                 // the extended comment in rustc::middle::borrowck::preserve()
                 // for details (look for the case covering cat_discr).
 
@@ -1201,7 +1201,7 @@ fn compile_submatch(bcx: block,
       For an empty match, a fall-through case must exist
      */
     assert(m.len() > 0u || chk.is_some());
-    let _icx = bcx.insn_ctxt("alt::compile_submatch");
+    let _icx = bcx.insn_ctxt("match::compile_submatch");
     let mut bcx = bcx;
     let tcx = bcx.tcx(), dm = tcx.def_map;
     if m.len() == 0u {
@@ -1520,22 +1520,22 @@ fn compile_submatch(bcx: block,
     }
 }
 
-fn trans_alt(bcx: block,
-             alt_expr: @ast::expr,
+fn trans_match(bcx: block,
+             match_expr: @ast::expr,
              discr_expr: @ast::expr,
              arms: ~[ast::arm],
              dest: Dest) -> block {
-    let _icx = bcx.insn_ctxt("alt::trans_alt");
-    do with_scope(bcx, alt_expr.info(), ~"alt") |bcx| {
-        trans_alt_inner(bcx, discr_expr, arms, dest)
+    let _icx = bcx.insn_ctxt("match::trans_match");
+    do with_scope(bcx, match_expr.info(), ~"match") |bcx| {
+        trans_match_inner(bcx, discr_expr, arms, dest)
     }
 }
 
-fn trans_alt_inner(scope_cx: block,
+fn trans_match_inner(scope_cx: block,
                    discr_expr: @ast::expr,
                    arms: &[ast::arm],
                    dest: Dest) -> block {
-    let _icx = scope_cx.insn_ctxt("alt::trans_alt_inner");
+    let _icx = scope_cx.insn_ctxt("match::trans_match_inner");
     let mut bcx = scope_cx;
     let tcx = bcx.tcx();
 
@@ -1655,18 +1655,18 @@ enum IrrefutablePatternBindingMode {
     BindArgument
 }
 
-// Not alt-related, but similar to the pattern-munging code above
+// Not match-related, but similar to the pattern-munging code above
 fn bind_irrefutable_pat(bcx: block,
                         pat: @ast::pat,
                         val: ValueRef,
                         make_copy: bool,
                         binding_mode: IrrefutablePatternBindingMode)
                      -> block {
-    let _icx = bcx.insn_ctxt("alt::bind_irrefutable_pat");
+    let _icx = bcx.insn_ctxt("match::bind_irrefutable_pat");
     let ccx = bcx.fcx.ccx;
     let mut bcx = bcx;
 
-    // Necessary since bind_irrefutable_pat is called outside trans_alt
+    // Necessary since bind_irrefutable_pat is called outside trans_match
     match /*bad*/copy pat.node {
         ast::pat_ident(_, _,inner) => {
             if pat_is_variant_or_struct(bcx.tcx().def_map, pat) {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -41,7 +41,7 @@ use metadata::{csearch, cstore, decoder, encoder};
 use middle::astencode;
 use middle::pat_util::*;
 use middle::resolve;
-use middle::trans::alt;
+use middle::trans::_match;
 use middle::trans::build::*;
 use middle::trans::callee;
 use middle::trans::common::*;
@@ -1045,11 +1045,11 @@ fn init_local(bcx: block, local: @ast::local) -> block {
            bcx.to_str());
     add_clean(bcx, llptr, ty);
 
-    return alt::bind_irrefutable_pat(bcx,
-                                     local.node.pat,
-                                     llptr,
-                                     false,
-                                     alt::BindLocal);
+    return _match::bind_irrefutable_pat(bcx,
+                                       local.node.pat,
+                                       llptr,
+                                       false,
+                                       _match::BindLocal);
 }
 
 fn trans_stmt(cx: block, s: ast::stmt) -> block {
@@ -1597,11 +1597,11 @@ fn copy_args_to_allocas(fcx: fn_ctxt,
             }
         }
 
-        bcx = alt::bind_irrefutable_pat(bcx,
-                                        args[arg_n].pat,
-                                        llarg,
-                                        false,
-                                        alt::BindArgument);
+        bcx = _match::bind_irrefutable_pat(bcx,
+                                          args[arg_n].pat,
+                                          llarg,
+                                          false,
+                                          _match::BindArgument);
 
         fcx.llargs.insert(arg_id, local_mem(llarg));
 

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -266,7 +266,7 @@ fn create_block(cx: block) -> @metadata<block_md> {
     let fname = /*bad*/copy start.file.name;
     let end = cx.sess().codemap.lookup_char_pos(sp.hi);
     let tg = LexicalBlockTag;
-    /*alt cached_metadata::<@metadata<block_md>>(
+    /*match cached_metadata::<@metadata<block_md>>(
         cache, tg,
         {|md| start == md.data.start && end == md.data.end}) {
       option::Some(md) { return md; }

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -528,7 +528,8 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
             return controlflow::trans_if(bcx, cond, (*thn), els, dest);
         }
         ast::expr_match(discr, ref arms) => {
-            return alt::trans_alt(bcx, expr, discr, /*bad*/copy *arms, dest);
+            return _match::trans_match(bcx, expr, discr, /*bad*/copy *arms,
+                                       dest);
         }
         ast::expr_block(ref blk) => {
             return do base::with_scope(bcx, (*blk).info(),

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -21,10 +21,10 @@ use syntax::ast_util::walk_pat;
 use syntax::ast_util;
 use syntax::print::pprust;
 
-fn check_alt(fcx: @fn_ctxt,
-             expr: @ast::expr,
-             discrim: @ast::expr,
-             arms: ~[ast::arm]) -> bool {
+fn check_match(fcx: @fn_ctxt,
+               expr: @ast::expr,
+               discrim: @ast::expr,
+               arms: ~[ast::arm]) -> bool {
     let tcx = fcx.ccx.tcx;
     let mut bot;
 
@@ -37,7 +37,7 @@ fn check_alt(fcx: @fn_ctxt,
         let pcx = pat_ctxt {
             fcx: fcx,
             map: pat_id_map(tcx.def_map, arm.pats[0]),
-            alt_region: ty::re_scope(expr.id),
+            match_region: ty::re_scope(expr.id),
             block_region: ty::re_scope(arm.body.node.id)
         };
 
@@ -65,7 +65,7 @@ fn check_alt(fcx: @fn_ctxt,
 struct pat_ctxt {
     fcx: @fn_ctxt,
     map: PatIdMap,
-    alt_region: ty::Region,   // Region for the alt as a whole
+    match_region: ty::Region, // Region for the match as a whole
     block_region: ty::Region, // Region for the block of the arm
 }
 
@@ -389,7 +389,7 @@ fn check_pat(pcx: pat_ctxt, pat: @ast::pat, expected: ty::t) {
         }
         fcx.write_ty(pat.id, typ);
 
-        debug!("(checking alt) writing type for pat id %d", pat.id);
+        debug!("(checking match) writing type for pat id %d", pat.id);
 
         match sub {
           Some(p) => check_pat(pcx, p, expected),

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -85,7 +85,7 @@ use middle::ty;
 use middle::typeck::astconv::{ast_conv, ast_path_to_ty};
 use middle::typeck::astconv::{ast_region_to_region, ast_ty_to_ty};
 use middle::typeck::astconv;
-use middle::typeck::check::alt::pat_ctxt;
+use middle::typeck::check::_match::pat_ctxt;
 use middle::typeck::check::method::TransformTypeNormally;
 use middle::typeck::check::regionmanip::replace_bound_regions_in_fn_ty;
 use middle::typeck::check::vtable::{LocationInfo, VtableContext};
@@ -117,7 +117,7 @@ use syntax::print::pprust;
 use syntax::visit;
 use syntax;
 
-export alt;
+export _match;
 export vtable;
 export writeback;
 export regionmanip;
@@ -133,7 +133,7 @@ export DoDerefArgs;
 export check_item_types;
 
 #[legacy_exports]
-pub mod alt;
+pub mod _match;
 #[legacy_exports]
 pub mod vtable;
 #[legacy_exports]
@@ -427,10 +427,10 @@ fn check_fn(ccx: @crate_ctxt,
             let pcx = pat_ctxt {
                 fcx: fcx,
                 map: pat_id_map(tcx.def_map, input.pat),
-                alt_region: region,
+                match_region: region,
                 block_region: region,
             };
-            alt::check_pat(pcx, input.pat, *arg_ty);
+            _match::check_pat(pcx, input.pat, *arg_ty);
         }
 
         // Add explicitly-declared locals.
@@ -2124,7 +2124,7 @@ fn check_expr_with_unifier(fcx: @fn_ctxt,
         bot = !may_break(tcx, expr.id, (*body));
       }
       ast::expr_match(discrim, ref arms) => {
-        bot = alt::check_alt(fcx, expr, discrim, (/*bad*/copy *arms));
+        bot = _match::check_match(fcx, expr, discrim, (/*bad*/copy *arms));
       }
       ast::expr_fn(proto, ref decl, ref body, cap_clause) => {
         check_expr_fn(fcx, expr, Some(proto),
@@ -2517,10 +2517,10 @@ fn check_decl_local(fcx: @fn_ctxt, local: @ast::local) -> bool {
     let pcx = pat_ctxt {
         fcx: fcx,
         map: pat_id_map(tcx.def_map, local.node.pat),
-        alt_region: region,
+        match_region: region,
         block_region: region,
     };
-    alt::check_pat(pcx, local.node.pat, t);
+    _match::check_pat(pcx, local.node.pat, t);
     return bot;
 }
 

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -77,7 +77,7 @@ mod middle {
         #[legacy_exports]
         mod base;
         #[legacy_exports]
-        mod alt;
+        mod _match;
         #[legacy_exports]
         mod uniq;
         #[legacy_exports]
@@ -109,7 +109,7 @@ mod middle {
     #[legacy_exports]
     mod check_loop;
     #[legacy_exports]
-    mod check_alt;
+    mod check_match;
     #[legacy_exports]
     mod check_const;
     #[legacy_exports]

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -158,7 +158,7 @@ fn re_scope_id_to_str(cx: ctxt, node_id: ast::node_id) -> ~str {
                  cx.sess.codemap.span_to_str(expr.span))
           }
           ast::expr_match(*) => {
-            fmt!("<alt at %s>",
+            fmt!("<match at %s>",
                  cx.sess.codemap.span_to_str(expr.span))
           }
           ast::expr_assign_op(*) |

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -245,7 +245,7 @@ fn parse(sess: parse_sess, cfg: ast::crate_cfg, rdr: reader, ms: ~[matcher])
 
             /* at end of sequence */
             if idx >= len {
-                // can't move out of `alt`s, so:
+                // can't move out of `match`es, so:
                 if is_some(ei.up) {
                     // hack: a matcher sequence is repeating iff it has a
                     // parent (the top level is just a container)

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -940,7 +940,7 @@ impl Parser {
         } else if self.eat_keyword(~"loop") {
             return self.parse_loop_expr();
         } else if self.eat_keyword(~"match") {
-            return self.parse_alt_expr();
+            return self.parse_match_expr();
         } else if self.eat_keyword(~"fn") {
             let opt_proto = self.parse_fn_ty_proto();
             let proto = match opt_proto {
@@ -1722,7 +1722,7 @@ impl Parser {
         return expr_rec(fields, base);
     }
 
-    fn parse_alt_expr() -> @expr {
+    fn parse_match_expr() -> @expr {
         let lo = self.last_span.lo;
         let discriminant = self.parse_expr();
         self.expect(token::LBRACE);

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -83,7 +83,7 @@ fn rust_printer(writer: io::Writer, intr: @ident_interner) -> ps {
 }
 
 const indent_unit: uint = 4u;
-const alt_indent_unit: uint = 2u;
+const match_indent_unit: uint = 2u;
 
 const default_columns: uint = 78u;
 
@@ -1251,7 +1251,7 @@ fn print_expr(s: ps, &&expr: @ast::expr) {
         print_block(s, (*blk));
       }
       ast::expr_match(expr, ref arms) => {
-        cbox(s, alt_indent_unit);
+        cbox(s, match_indent_unit);
         ibox(s, 4);
         word_nbsp(s, ~"match");
         print_expr(s, expr);
@@ -1260,7 +1260,7 @@ fn print_expr(s: ps, &&expr: @ast::expr) {
         let len = (*arms).len();
         for (*arms).eachi |i, arm| {
             space(s.s);
-            cbox(s, alt_indent_unit);
+            cbox(s, match_indent_unit);
             ibox(s, 0u);
             let mut first = true;
             for arm.pats.each |p| {
@@ -1293,7 +1293,7 @@ fn print_expr(s: ps, &&expr: @ast::expr) {
                             ast::expr_block(ref blk) => {
                                 // the block will close the pattern's ibox
                                 print_block_unclosed_indent(
-                                    s, (*blk), alt_indent_unit);
+                                    s, (*blk), match_indent_unit);
                             }
                             _ => {
                                 end(s); // close the ibox for the pattern
@@ -1310,10 +1310,10 @@ fn print_expr(s: ps, &&expr: @ast::expr) {
                 }
             } else {
                 // the block will close the pattern's ibox
-                print_block_unclosed_indent(s, arm.body, alt_indent_unit);
+                print_block_unclosed_indent(s, arm.body, match_indent_unit);
             }
         }
-        bclose_(s, expr.span, alt_indent_unit);
+        bclose_(s, expr.span, match_indent_unit);
       }
       ast::expr_fn(proto, decl, ref body, cap_clause) => {
         // containing cbox, will be closed by print-block at }


### PR DESCRIPTION
This'll be less confusing for anyone who works on match in future.

(One slightly annoying thing, though, is that I had to use "_match" in a couple of places where "match" couldn't appear because it's a keyword.)
