### PR TITLE
Rename memcpy, memmove, memset

### DIFF
--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -503,7 +503,7 @@ impl BytesReader: Reader {
         let count = uint::min(len, self.bytes.len() - self.pos);
 
         let view = vec::view(self.bytes, self.pos, self.bytes.len());
-        vec::bytes::memcpy(bytes, view, count);
+        vec::bytes::copy_memory(bytes, view, count);
 
         self.pos += count;
 
@@ -950,7 +950,7 @@ impl BytesWriter: Writer {
 
             {
                 let view = vec::mut_view(bytes, self.pos, count);
-                vec::bytes::memcpy(view, v, v_len);
+                vec::bytes::copy_memory(view, v, v_len);
             }
 
             self.pos += v_len;

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -114,7 +114,7 @@ pub pure fn is_not_null<T>(ptr: *const T) -> bool { !is_null(ptr) }
  * and destination may not overlap.
  */
 #[inline(always)]
-pub unsafe fn memcpy<T>(dst: *mut T, src: *const T, count: uint) {
+pub unsafe fn copy_memory<T>(dst: *mut T, src: *const T, count: uint) {
     let n = count * sys::size_of::<T>();
     libc_::memcpy(dst as *mut c_void, src as *c_void, n as size_t);
 }
@@ -126,13 +126,13 @@ pub unsafe fn memcpy<T>(dst: *mut T, src: *const T, count: uint) {
  * and destination may overlap.
  */
 #[inline(always)]
-pub unsafe fn memmove<T>(dst: *mut T, src: *const T, count: uint) {
+pub unsafe fn copy_overlapping_memory<T>(dst: *mut T, src: *const T, count: uint) {
     let n = count * sys::size_of::<T>();
     libc_::memmove(dst as *mut c_void, src as *c_void, n as size_t);
 }
 
 #[inline(always)]
-pub unsafe fn memset<T>(dst: *mut T, c: int, count: uint) {
+pub unsafe fn set_memory<T>(dst: *mut T, c: int, count: uint) {
     let n = count * sys::size_of::<T>();
     libc_::memset(dst as *mut c_void, c as libc::c_int, n as size_t);
 }
@@ -306,13 +306,13 @@ pub fn test() {
         let mut v0 = ~[32000u16, 32001u16, 32002u16];
         let mut v1 = ~[0u16, 0u16, 0u16];
 
-        ptr::memcpy(ptr::mut_offset(vec::raw::to_mut_ptr(v1), 1u),
+        ptr::copy_memory(ptr::mut_offset(vec::raw::to_mut_ptr(v1), 1u),
                     ptr::offset(vec::raw::to_ptr(v0), 1u), 1u);
         assert (v1[0] == 0u16 && v1[1] == 32001u16 && v1[2] == 0u16);
-        ptr::memcpy(vec::raw::to_mut_ptr(v1),
+        ptr::copy_memory(vec::raw::to_mut_ptr(v1),
                     ptr::offset(vec::raw::to_ptr(v0), 2u), 1u);
         assert (v1[0] == 32002u16 && v1[1] == 32001u16 && v1[2] == 0u16);
-        ptr::memcpy(ptr::mut_offset(vec::raw::to_mut_ptr(v1), 2u),
+        ptr::copy_memory(ptr::mut_offset(vec::raw::to_mut_ptr(v1), 2u),
                     vec::raw::to_ptr(v0), 1u);
         assert (v1[0] == 32002u16 && v1[1] == 32001u16 && v1[2] == 32000u16);
     }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -169,7 +169,7 @@ pub fn push_str_no_overallocate(lhs: &mut ~str, rhs: &str) {
             do as_buf(rhs) |rbuf, _rlen| {
                 let dst = ptr::offset(lbuf, llen);
                 let dst = ::cast::transmute_mut_unsafe(dst);
-                ptr::memcpy(dst, rbuf, rlen);
+                ptr::copy_memory(dst, rbuf, rlen);
             }
         }
         raw::set_len(lhs, llen + rlen);
@@ -186,7 +186,7 @@ pub fn push_str(lhs: &mut ~str, rhs: &str) {
             do as_buf(rhs) |rbuf, _rlen| {
                 let dst = ptr::offset(lbuf, llen);
                 let dst = ::cast::transmute_mut_unsafe(dst);
-                ptr::memcpy(dst, rbuf, rlen);
+                ptr::copy_memory(dst, rbuf, rlen);
             }
         }
         raw::set_len(lhs, llen + rlen);
@@ -1967,7 +1967,7 @@ pub mod raw {
     pub unsafe fn from_buf_len(buf: *const u8, len: uint) -> ~str {
         let mut v: ~[u8] = vec::with_capacity(len + 1);
         vec::as_mut_buf(v, |vbuf, _len| {
-            ptr::memcpy(vbuf, buf as *u8, len)
+            ptr::copy_memory(vbuf, buf as *u8, len)
         });
         vec::raw::set_len(&mut v, len);
         v.push(0u8);
@@ -2024,7 +2024,7 @@ pub mod raw {
                 do vec::as_imm_buf(v) |vbuf, _vlen| {
                     let vbuf = ::cast::transmute_mut_unsafe(vbuf);
                     let src = ptr::offset(sbuf, begin);
-                    ptr::memcpy(vbuf, src, end - begin);
+                    ptr::copy_memory(vbuf, src, end - begin);
                 }
                 vec::raw::set_len(&mut v, end - begin);
                 v.push(0u8);

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -469,7 +469,7 @@ pub fn shift<T>(v: &mut ~[T]) -> T unsafe {
     // We still should have room to work where what last element was
     assert capacity(v) >= ln;
     // Pretend like we have the original length so we can use
-    // the vector memcpy to overwrite the hole we just made
+    // the vector copy_memory to overwrite the hole we just made
     raw::set_len(v, ln);
 
     // Memcopy the head element (the one we want) to the location we just
@@ -477,12 +477,12 @@ pub fn shift<T>(v: &mut ~[T]) -> T unsafe {
     // positions
     let first_slice = view(*v, 0, 1);
     let last_slice = mut_view(*v, next_ln, ln);
-    raw::memcpy(last_slice, first_slice, 1);
+    raw::copy_memory(last_slice, first_slice, 1);
 
     // Memcopy everything to the left one element
     let init_slice = mut_view(*v, 0, next_ln);
     let tail_slice = view(*v, 1, ln);
-    raw::memcpy(init_slice, tail_slice, next_ln);
+    raw::copy_memory(init_slice, tail_slice, next_ln);
 
     // Set the new length. Now the vector is back to normal
     raw::set_len(v, next_ln);
@@ -2071,7 +2071,7 @@ pub mod raw {
     pub unsafe fn from_buf_raw<T>(ptr: *T, elts: uint) -> ~[T] {
         let mut dst = with_capacity(elts);
         set_len(&mut dst, elts);
-        as_mut_buf(dst, |p_dst, _len_dst| ptr::memcpy(p_dst, ptr, elts));
+        as_mut_buf(dst, |p_dst, _len_dst| ptr::copy_memory(p_dst, ptr, elts));
         dst
     }
 
@@ -2081,13 +2081,13 @@ pub mod raw {
       * Copies `count` bytes from `src` to `dst`. The source and destination
       * may overlap.
       */
-    pub unsafe fn memcpy<T>(dst: &[mut T], src: &[const T], count: uint) {
+    pub unsafe fn copy_memory<T>(dst: &[mut T], src: &[const T], count: uint) {
         assert dst.len() >= count;
         assert src.len() >= count;
 
         do as_mut_buf(dst) |p_dst, _len_dst| {
             do as_const_buf(src) |p_src, _len_src| {
-                ptr::memcpy(p_dst, p_src, count)
+                ptr::copy_memory(p_dst, p_src, count)
             }
         }
     }
@@ -2098,13 +2098,13 @@ pub mod raw {
       * Copies `count` bytes from `src` to `dst`. The source and destination
       * may overlap.
       */
-    pub unsafe fn memmove<T>(dst: &[mut T], src: &[const T], count: uint) {
+    pub unsafe fn copy_overlapping_memory<T>(dst: &[mut T], src: &[const T], count: uint) {
         assert dst.len() >= count;
         assert src.len() >= count;
 
         do as_mut_buf(dst) |p_dst, _len_dst| {
             do as_const_buf(src) |p_src, _len_src| {
-                ptr::memmove(p_dst, p_src, count)
+                ptr::copy_overlapping_memory(p_dst, p_src, count)
             }
         }
     }
@@ -2163,9 +2163,9 @@ pub mod bytes {
       * Copies `count` bytes from `src` to `dst`. The source and destination
       * may not overlap.
       */
-    pub fn memcpy(dst: &[mut u8], src: &[const u8], count: uint) {
-        // Bound checks are done at vec::raw::memcpy.
-        unsafe { vec::raw::memcpy(dst, src, count) }
+    pub fn copy_memory(dst: &[mut u8], src: &[const u8], count: uint) {
+        // Bound checks are done at vec::raw::copy_memory.
+        unsafe { vec::raw::copy_memory(dst, src, count) }
     }
 
     /**
@@ -2174,9 +2174,9 @@ pub mod bytes {
       * Copies `count` bytes from `src` to `dst`. The source and destination
       * may overlap.
       */
-    pub fn memmove(dst: &[mut u8], src: &[const u8], count: uint) {
-        // Bound checks are done at vec::raw::memmove.
-        unsafe { vec::raw::memmove(dst, src, count) }
+    pub fn copy_overlapping_memory(dst: &[mut u8], src: &[const u8], count: uint) {
+        // Bound checks are done at vec::raw::copy_overlapping_memory.
+        unsafe { vec::raw::copy_overlapping_memory(dst, src, count) }
     }
 }
 
@@ -3879,10 +3879,10 @@ mod tests {
     #[test]
     #[should_fail]
     #[ignore(cfg(windows))]
-    fn test_memcpy_oob() unsafe {
+    fn test_copy_memory_oob() unsafe {
         let a = [mut 1, 2, 3, 4];
         let b = [1, 2, 3, 4, 5];
-        raw::memcpy(a, b, 5);
+        raw::copy_memory(a, b, 5);
     }
 
 }

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -826,7 +826,7 @@ impl TcpSocketBuf: io::Reader {
         let mut data = ~[];
         self.data.buf <-> data;
 
-        vec::bytes::memcpy(buf, vec::view(data, 0, data.len()), count);
+        vec::bytes::copy_memory(buf, vec::view(data, 0, data.len()), count);
 
         self.data.buf.push_all(vec::view(data, count, data.len()));
 


### PR DESCRIPTION
This is to prevent any confusion with the C equivalents.

Closes #4203.
