### PR TITLE
librustc: Make the default sigil for block lambdas `&` instead of `@`.

### DIFF
--- a/src/libcore/task/spawn.rs
+++ b/src/libcore/task/spawn.rs
@@ -608,7 +608,7 @@ pub fn spawn_raw(opts: TaskOpts, f: fn~()) {
                 };
             if result {
                 // Unwinding function in case any ancestral enlisting fails
-                let bail = |tg: TaskGroupInner| {
+                let bail: @fn(TaskGroupInner) = |tg| {
                     leave_taskgroup(tg, child, false)
                 };
                 // Attempt to join every ancestor group.

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -66,10 +66,10 @@ export encode_def_id;
 
 type abbrev_map = map::HashMap<ty::t, tyencode::ty_abbrev>;
 
-type encode_inlined_item = fn@(ecx: @encode_ctxt,
-                               ebml_w: writer::Encoder,
-                               path: ast_map::path,
-                               ii: ast::inlined_item);
+pub type encode_inlined_item = fn@(ecx: @encode_ctxt,
+                                   ebml_w: writer::Encoder,
+                                   path: ast_map::path,
+                                   ii: ast::inlined_item);
 
 type encode_parms = {
     diag: span_handler,
@@ -571,7 +571,7 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: writer::Encoder,
                      index: @mut ~[entry<int>]) {
         index.push({val: item.id, pos: ebml_w.writer.tell()});
     }
-    let add_to_index = |copy ebml_w| add_to_index_(item, ebml_w, index);
+    let add_to_index: &fn() = || add_to_index_(item, ebml_w, index);
 
     debug!("encoding info for item at %s",
            ecx.tcx.sess.codemap.span_to_str(item.span));

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1608,8 +1608,9 @@ fn trans_match_inner(scope_cx: block,
         if ty::type_is_empty(tcx, t) {
             // Special case for empty types
             let fail_cx = @mut None;
-            Some(|| mk_fail(scope_cx, discr_expr.span,
-                            ~"scrutinizing value that can't exist", fail_cx))
+            let f: mk_fail = || mk_fail(scope_cx, discr_expr.span,
+                            ~"scrutinizing value that can't exist", fail_cx);
+            Some(f)
         } else {
             None
         }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2688,7 +2688,7 @@ fn fill_crate_map(ccx: @crate_ctxt, map: ValueRef) {
 
 fn crate_ctxt_to_encode_parms(cx: @crate_ctxt) -> encoder::encode_parms {
     // XXX: Bad copy of `c`, whatever it is.
-    let encode_inlined_item =
+    let encode_inlined_item: encoder::encode_inlined_item =
         |a,b,c,d| astencode::encode_inlined_item(a, b, copy c, d, cx.maps);
 
     return {

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -403,16 +403,16 @@ fn trans_expr_fn(bcx: block,
                                                  ~"expr_fn");
     let llfn = decl_internal_cdecl_fn(ccx.llmod, s, llfnty);
 
-    // XXX: Bad copies.
-    let trans_closure_env = |proto, copy body, copy sub_path, copy decl| {
+    let trans_closure_env: &fn(ast::Proto) -> Result = |proto| {
         let cap_vars = capture::compute_capture_vars(ccx.tcx, id, proto,
                                                      cap_clause);
         let ret_handle = match is_loop_body { Some(x) => x, None => None };
         // XXX: Bad copy.
         let {llbox, cdata_ty, bcx} = build_closure(bcx, copy cap_vars, proto,
                                                    ret_handle);
-        trans_closure(ccx, /*bad*/copy sub_path, decl, body, llfn, no_self,
-                      /*bad*/copy bcx.fcx.param_substs, id, None, |fcx| {
+        trans_closure(ccx, /*bad*/copy sub_path, decl, /*bad*/copy body, llfn,
+                      no_self, /*bad*/copy bcx.fcx.param_substs, id, None,
+                      |fcx| {
             load_environment(fcx, cdata_ty, cap_vars,
                              ret_handle.is_some(), proto);
                       }, |bcx| {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -440,8 +440,14 @@ fn add_clean_temp_mem(bcx: block, val: ValueRef, t: ty::t) {
 }
 fn add_clean_free(cx: block, ptr: ValueRef, heap: heap) {
     let free_fn = match heap {
-      heap_shared => |a| glue::trans_free(a, ptr),
-      heap_exchange => |a| glue::trans_unique_free(a, ptr)
+      heap_shared => {
+        let f: @fn(block) -> block = |a| glue::trans_free(a, ptr);
+        f
+      }
+      heap_exchange => {
+        let f: @fn(block) -> block = |a| glue::trans_unique_free(a, ptr);
+        f
+      }
     };
     do in_scope_cx(cx) |scope_info| {
         scope_info.cleanups.push(clean_temp(ptr, free_fn,

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -153,7 +153,7 @@ fn monomorphic_fn(ccx: @crate_ctxt,
                          ~[path_name((ccx.names)(ccx.sess.str_of(name)))]);
     let s = mangle_exported_name(ccx, /*bad*/copy pt, mono_ty);
 
-    let mk_lldecl = |/*bad*/copy s| {
+    let mk_lldecl = || {
         let lldecl = decl_internal_cdecl_fn(ccx.llmod, /*bad*/copy s, llfty);
         ccx.monomorphized.insert(hash_id, lldecl);
         lldecl

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1556,7 +1556,7 @@ fn check_expr_with_unifier(fcx: @fn_ctxt,
                      fn_ty.meta.onceness)
                 }
                 _ => {
-                    (None, ast::impure_fn, ast::ProtoBox, ast::Many)
+                    (None, ast::impure_fn, ast::ProtoBorrowed, ast::Many)
                 }
             }
         };

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -58,8 +58,9 @@ fn field_exprs(fields: ~[ast::field]) -> ~[@ast::expr] {
 // of b -- skipping any inner loops (loop, while, loop_body)
 fn loop_query(b: ast::blk, p: fn@(ast::expr_) -> bool) -> bool {
     let rs = @mut false;
-    let visit_expr =
-        |e: @ast::expr, &&flag: @mut bool, v: visit::vt<@mut bool>| {
+    let visit_expr: @fn(@ast::expr,
+                        &&flag: @mut bool,
+                        v: visit::vt<@mut bool>) = |e, &&flag, v| {
         *flag |= p(e.node);
         match e.node {
           // Skip inner loops, since a break in the inner loop isn't a
@@ -80,8 +81,9 @@ fn loop_query(b: ast::blk, p: fn@(ast::expr_) -> bool) -> bool {
 // of b -- skipping any inner loops (loop, while, loop_body)
 fn block_query(b: ast::blk, p: fn@(@ast::expr) -> bool) -> bool {
     let rs = @mut false;
-    let visit_expr =
-        |e: @ast::expr, &&flag: @mut bool, v: visit::vt<@mut bool>| {
+    let visit_expr: @fn(@ast::expr,
+                        &&flag: @mut bool,
+                        v: visit::vt<@mut bool>) = |e, &&flag, v| {
         *flag |= p(e);
         visit::visit_expr(e, flag, v)
     };

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -213,7 +213,9 @@ fn print_diagnostic(topic: ~str, lvl: level, msg: &str) {
 fn collect(messages: @DVec<~str>)
     -> fn@(Option<(@codemap::CodeMap, span)>, &str, level)
 {
-    |_o, msg: &str, _l| { messages.push(msg.to_str()); }
+    let f: @fn(Option<(@codemap::CodeMap, span)>, &str, level) =
+        |_o, msg: &str, _l| { messages.push(msg.to_str()); };
+    f
 }
 
 fn emit(cmsp: Option<(@codemap::CodeMap, span)>, msg: &str, lvl: level) {

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -136,8 +136,8 @@ fn add_new_extension(cx: ext_ctxt, sp: span, name: ident,
         cx.span_fatal(best_fail_spot, best_fail_msg);
     }
 
-    let exp = |cx, sp, arg| generic_extension(cx, sp, name,
-                                              arg, lhses, rhses);
+    let exp: @fn(ext_ctxt, span, ~[ast::token_tree]) -> mac_result =
+        |cx, sp, arg| generic_extension(cx, sp, name, arg, lhses, rhses);
 
     return mr_def({
         name: *cx.parse_sess().interner.get(name),

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -641,7 +641,8 @@ fn mk_simple_visitor(v: simple_visitor) -> vt<()> {
         f(fk, decl, body, sp, id);
         visit_fn(fk, decl, body, sp, id, e, v);
     }
-    let visit_ty = |a,b,c| v_ty(v.visit_ty, a, b, c);
+    let visit_ty: @fn(@Ty, &&x: (), vt<()>) =
+        |a,b,c| v_ty(v.visit_ty, a, b, c);
     fn v_struct_field(f: fn@(@struct_field), sf: @struct_field, &&e: (),
                       v: vt<()>) {
         f(sf);


### PR DESCRIPTION
r? @nikomatsakis 
