### PR TITLE
Properly suppress derived type error messages

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -151,7 +151,7 @@ export re_bound, re_free, re_scope, re_static, re_infer;
 export ReVar, ReSkolemized;
 export br_self, br_anon, br_named, br_cap_avoid, br_fresh;
 export get, type_has_params, type_needs_infer, type_has_regions;
-export type_is_region_ptr;
+export type_contains_err, type_is_region_ptr;
 export type_id;
 export tbox_has_flag;
 export ty_var_id;
@@ -475,6 +475,7 @@ enum tbox_flag {
     has_self = 2,
     needs_infer = 4,
     has_regions = 8,
+    has_ty_err = 16,
 
     // a meta-flag: subst may be required if the type has parameters, a self
     // type, or references bound regions
@@ -508,6 +509,7 @@ pure fn type_has_params(t: t) -> bool { tbox_has_flag(get(t), has_params) }
 pure fn type_has_self(t: t) -> bool { tbox_has_flag(get(t), has_self) }
 pure fn type_needs_infer(t: t) -> bool { tbox_has_flag(get(t), needs_infer) }
 pure fn type_has_regions(t: t) -> bool { tbox_has_flag(get(t), has_regions) }
+pure fn type_contains_err(t: t) -> bool { tbox_has_flag(get(t), has_ty_err) }
 pure fn type_def_id(t: t) -> Option<ast::def_id> { get(t).o_def_id }
 pure fn type_id(t: t) -> uint { get(t).id }
 
@@ -1059,7 +1061,8 @@ fn mk_t_with_id(cx: ctxt, +st: sty, o_def_id: Option<ast::def_id>) -> t {
       }
       &ty_nil | &ty_bot | &ty_bool | &ty_int(_) | &ty_float(_) | &ty_uint(_) |
       &ty_estr(_) | &ty_type | &ty_opaque_closure_ptr(_) |
-      &ty_opaque_box | &ty_err => (),
+      &ty_opaque_box => (),
+      &ty_err => flags |= has_ty_err as uint,
       &ty_param(_) => flags |= has_params as uint,
       &ty_infer(_) => flags |= needs_infer as uint,
       &ty_self => flags |= has_self as uint,

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -744,20 +744,10 @@ impl @InferCtxt {
     fn type_error_message(sp: span, mk_msg: fn(~str) -> ~str,
                           actual_ty: ty::t, err: Option<&ty::type_err>) {
         let actual_ty = self.resolve_type_vars_if_possible(actual_ty);
-        let mut actual_sty = ty::get(copy actual_ty);
 
         // Don't report an error if actual type is ty_err.
-        match actual_sty.sty {
-            ty::ty_err => return,
-            // Should really not report an error if the type
-            // has ty_err anywhere as a component, but that's
-            // annoying since we haven't written a visitor for
-            // ty::t yet
-            ty::ty_fn(ref fty) => match ty::get(fty.sig.output).sty {
-                ty::ty_err => return,
-                _ => ()
-            },
-            _           => ()
+        if ty::type_contains_err(actual_ty) {
+            return;
         }
         let error_str = err.map_default(~"", |t_err|
                          fmt!(" (%s)",


### PR DESCRIPTION
r? @nikomatsakis Previously, the typechecker suppressed many but not all errors,
by suppressing errors where the actual type was either ty_err, or
a function type whose result was ty_err. Added a has_ty_err flag
to the type flags so as to suppress errors for any types involving
ty_err.
