### PR TITLE
Add support for Ubuntu named clang packages.

### DIFF
--- a/configure
+++ b/configure
@@ -516,7 +516,7 @@ then
                       | cut -d ' ' -f 2)
 
     case $CFG_CLANG_VERSION in
-        (3.0svn | 3.0 | 3.1 | 3.2 | 4.0 | 4.1)
+        (3.0svn | 3.0 | 3.1* | 3.2* | 4.0* | 4.1*)
         step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
         CFG_C_COMPILER="clang"
         ;;


### PR DESCRIPTION
Ubuntu's clang packages have additional information appended to the end of
the version which causes the current clang version checker to fail.
- Building Rust v0.5 with clang v3.0-6ubuntu3 fails.
- Building Rust v0.5, incoming with clang v3.1-5ppa (backported from Debian)
  works.

Closes #4441.
