### PR TITLE
Make std::sync::semaphore() public

### DIFF
--- a/src/libstd/sync.rs
+++ b/src/libstd/sync.rs
@@ -360,7 +360,7 @@ impl &Sem<~[mut Waitqueue]> {
 struct Semaphore { priv sem: Sem<()> }
 
 /// Create a new semaphore with the specified count.
-fn semaphore(count: int) -> Semaphore {
+pub fn semaphore(count: int) -> Semaphore {
     Semaphore { sem: new_sem(count, ()) }
 }
 


### PR DESCRIPTION
Semaphores are useful, and I assume it was just a mistake that they were not public. If they were intended to be private, ignore this pull request (and maybe remove semaphores from the public documentation?)
