### PR TITLE
Change the unit type to have size 0.

### DIFF
--- a/src/libcore/oldcomm.rs
+++ b/src/libcore/oldcomm.rs
@@ -91,7 +91,8 @@ pub enum Chan<T: Owned> {
 /// Constructs a port
 pub fn Port<T: Owned>() -> Port<T> {
     unsafe {
-        Port_(@PortPtr(rustrt::new_port(sys::size_of::<T>() as size_t)))
+        Port_(@PortPtr(rustrt::new_port(sys::nonzero_size_of::<T>()
+                                        as size_t)))
     }
 }
 

--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -88,6 +88,17 @@ pub pure fn size_of<T>() -> uint {
 }
 
 /**
+ * Returns the size of a type, or 1 if the actual size is zero.
+ *
+ * Useful for building structures containing variable-length arrays.
+ */
+#[inline(always)]
+pub pure fn nonzero_size_of<T>() -> uint {
+    let s = size_of::<T>();
+    if s == 0 { 1 } else { s }
+}
+
+/**
  * Returns the ABI-required minimum alignment of a type
  *
  * This is the alignment used for struct fields. It may be smaller
@@ -146,7 +157,7 @@ pub pure fn begin_unwind_(msg: *c_char, file: *c_char, line: size_t) -> ! {
 #[cfg(test)]
 pub mod tests {
     use cast;
-    use sys::{Closure, pref_align_of, size_of};
+    use sys::{Closure, pref_align_of, size_of, nonzero_size_of};
 
     #[test]
     pub fn size_of_basic() {
@@ -169,6 +180,14 @@ pub mod tests {
     pub fn size_of_64() {
         assert size_of::<uint>() == 8u;
         assert size_of::<*uint>() == 8u;
+    }
+
+    #[test]
+    pub fn nonzero_size_of_basic() {
+        type Z = [i8 * 0];
+        assert size_of::<Z>() == 0u;
+        assert nonzero_size_of::<Z>() == 1u;
+        assert nonzero_size_of::<uint>() == size_of::<uint>();
     }
 
     #[test]

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1330,9 +1330,10 @@ fn type_to_str_inner(names: type_names, +outer0: ~[TypeRef], ty: TypeRef) ->
             let mut s: ~str = ~"{";
             let n_elts = llvm::LLVMCountStructElementTypes(ty) as uint;
             let mut elts = vec::from_elem(n_elts, 0 as TypeRef);
-            llvm::LLVMGetStructElementTypes(ty,
-                                            ptr::to_mut_unsafe_ptr(
-                                                &mut elts[0]));
+            if elts.len() > 0 {
+                llvm::LLVMGetStructElementTypes(
+                    ty, ptr::to_mut_unsafe_ptr(&mut elts[0]));
+            }
             s += tys_str(names, outer, elts);
             s += ~"}";
             return s;
@@ -1398,8 +1399,10 @@ fn struct_element_types(struct_ty: TypeRef) -> ~[TypeRef] {
         let mut buf: ~[TypeRef] =
             vec::from_elem(count as uint,
                            cast::transmute::<uint,TypeRef>(0));
-        llvm::LLVMGetStructElementTypes(struct_ty,
-                                        ptr::to_mut_unsafe_ptr(&mut buf[0]));
+        if buf.len() > 0 {
+            llvm::LLVMGetStructElementTypes(
+                struct_ty, ptr::to_mut_unsafe_ptr(&mut buf[0]));
+        }
         return move buf;
     }
 }

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -638,8 +638,8 @@ fn trans_arg_expr(bcx: block,
                     let arg_ty = expr_ty(bcx, arg_expr);
                     let proto = ty::ty_fn_proto(arg_ty);
                     let bcx = closure::trans_expr_fn(
-                        bcx, proto, decl, /*bad*/copy *body, blk.id, cap,
-                        Some(ret_flag), expr::SaveIn(scratch));
+                        bcx, proto, decl, /*bad*/copy *body, arg_expr.id,
+                        blk.id, cap, Some(ret_flag), expr::SaveIn(scratch));
                     DatumBlock {bcx: bcx,
                                 datum: Datum {val: scratch,
                                               ty: scratch_ty,

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -633,7 +633,7 @@ fn trans_arg_expr(bcx: block,
                         _
                     }) =>
                 {
-                    let scratch_ty = expr_ty(bcx, blk);
+                    let scratch_ty = expr_ty(bcx, arg_expr);
                     let scratch = alloc_ty(bcx, scratch_ty);
                     let arg_ty = expr_ty(bcx, arg_expr);
                     let proto = ty::ty_fn_proto(arg_ty);

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -394,15 +394,17 @@ fn trans_expr_fn(bcx: block,
      * - `proto`
      * - `decl`
      * - `body`
-     * - `outer_id`: The id of the closure expression with the correct type.
-     *   This is usually the same as as `user_id`, but in the case of a `for` loop,
-     *   the `outer_id` will have the return type of boolean, and the `user_id` will
-     *   have the return type of `nil`.
-     * - `user_id`: The id of the closure as the user expressed it.  Generally
-         the same as `outer_id`
+     * - `outer_id`: The id of the closure expression with the correct
+     *   type.  This is usually the same as as `user_id`, but in the
+     *   case of a `for` loop, the `outer_id` will have the return
+     *   type of boolean, and the `user_id` will have the return type
+     *   of `nil`.
+     * - `user_id`: The id of the closure as the user expressed it.
+         Generally the same as `outer_id`
      * - `cap_clause`: information about captured variables, if any.
      * - `is_loop_body`: `Some()` if this is part of a `for` loop.
-     * - `dest`: where to write the closure value, which must be a (fn ptr, env) pair
+     * - `dest`: where to write the closure value, which must be a
+         (fn ptr, env) pair
      */
 
     let _icx = bcx.insn_ctxt("closure::trans_expr_fn");

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -722,28 +722,13 @@ impl block {
 
 // LLVM type constructors.
 fn T_void() -> TypeRef {
-    // Note: For the time being llvm is kinda busted here, it has the notion
-    // of a 'void' type that can only occur as part of the signature of a
-    // function, but no general unit type of 0-sized value. This is, afaict,
-    // vestigial from its C heritage, and we'll be attempting to submit a
-    // patch upstream to fix it. In the mean time we only model function
-    // outputs (Rust functions and C functions) using T_void, and model the
-    // Rust general purpose nil type you can construct as 1-bit (always
-    // zero). This makes the result incorrect for now -- things like a tuple
-    // of 10 nil values will have 10-bit size -- but it doesn't seem like we
-    // have any other options until it's fixed upstream.
-
     unsafe {
         return llvm::LLVMVoidType();
     }
 }
 
 fn T_nil() -> TypeRef {
-    // NB: See above in T_void().
-
-    unsafe {
-        return llvm::LLVMInt1Type();
-    }
+    return T_struct(~[])
 }
 
 fn T_metadata() -> TypeRef { unsafe { return llvm::LLVMMetadataType(); } }
@@ -1098,9 +1083,7 @@ fn C_floating(s: ~str, t: TypeRef) -> ValueRef {
 }
 
 fn C_nil() -> ValueRef {
-    // NB: See comment above in T_void().
-
-    return C_integral(T_i1(), 0u64, False);
+    return C_struct(~[]);
 }
 
 fn C_bool(b: bool) -> ValueRef {

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -564,8 +564,10 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
         ast::expr_fn(proto, copy decl, ref body, cap_clause) => {
             // Don't use this function for anything real. Use the one in
             // astconv instead.
-            return closure::trans_expr_fn(bcx, proto, decl, /*bad*/copy *body,
-                                          expr.id, cap_clause, None, dest);
+            return closure::trans_expr_fn(bcx, proto, decl,
+                                          /*bad*/copy *body,
+                                          expr.id, expr.id,
+                                          cap_clause, None, dest);
         }
         ast::expr_fn_block(ref decl, ref body, cap_clause) => {
             let expr_ty = expr_ty(bcx, expr);
@@ -576,7 +578,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
                            ty_to_str(tcx, expr_ty));
                     return closure::trans_expr_fn(
                         bcx, fn_ty.meta.proto, /*bad*/copy *decl,
-                        /*bad*/copy *body, expr.id,
+                        /*bad*/copy *body, expr.id, expr.id,
                         cap_clause, None, dest);
                 }
                 _ => {
@@ -595,6 +597,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
                                 fn_ty.meta.proto,
                                 decl,
                                 /*bad*/copy *body,
+                                expr.id,
                                 blk.id,
                                 cap,
                                 Some(None),

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -132,6 +132,17 @@ pub fn llsize_of(cx: @crate_ctxt, t: TypeRef) -> ValueRef {
     }
 }
 
+// Returns the "default" size of t (see above), or 1 if the size would
+// be zero.  This is important for things like vectors that expect
+// space to be consumed.
+pub fn nonzero_llsize_of(cx: @crate_ctxt, t: TypeRef) -> ValueRef {
+    if llbitsize_of_real(cx, t) == 0 {
+        unsafe { llvm::LLVMConstInt(cx.int_type, 1, False) }
+    } else {
+        llsize_of(cx, t)
+    }
+}
+
 // Returns the preferred alignment of the given type for the current target.
 // The preffered alignment may be larger than the alignment used when
 // packing the type into structs. This will be used for things like

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -17,7 +17,7 @@ use middle::trans::datum::*;
 use middle::trans::expr::{Dest, Ignore, SaveIn};
 use middle::trans::expr;
 use middle::trans::glue;
-use middle::trans::shape::llsize_of;
+use middle::trans::shape::{llsize_of, nonzero_llsize_of};
 use middle::trans::type_of;
 use middle::ty;
 use util::common::indenter;
@@ -96,7 +96,7 @@ fn alloc_vec(bcx: block, unit_ty: ty::t, elts: uint, heap: heap) -> Result {
     let _icx = bcx.insn_ctxt("tvec::alloc_uniq");
     let ccx = bcx.ccx();
     let llunitty = type_of::type_of(ccx, unit_ty);
-    let unit_sz = llsize_of(ccx, llunitty);
+    let unit_sz = nonzero_llsize_of(ccx, llunitty);
 
     let fill = Mul(bcx, C_uint(ccx, elts), unit_sz);
     let alloc = if elts < 4u { Mul(bcx, C_int(ccx, 4), unit_sz) }
@@ -418,7 +418,8 @@ fn vec_types(bcx: block, vec_ty: ty::t) -> VecTypes {
     let ccx = bcx.ccx();
     let unit_ty = ty::sequence_element_type(bcx.tcx(), vec_ty);
     let llunit_ty = type_of::type_of(ccx, unit_ty);
-    let llunit_size = llsize_of(ccx, llunit_ty);
+    let llunit_size = nonzero_llsize_of(ccx, llunit_ty);
+
     VecTypes {vec_ty: vec_ty,
               unit_ty: unit_ty,
               llunit_ty: llunit_ty,


### PR DESCRIPTION
Notable issues: unit/bool confusion on for loops' return types, fixed mostly by @nikomatsakis; vectors and oldcomm pipes expecting nonzero size, fixed by introducing and using "nonzero size of" (greater of actual size or 1); and a few places that assumed all `T_struct`s would have at least one field.

Fixes #808.
