### PR TITLE
core: Align cmp::le() with the other implementations

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -30,7 +30,10 @@ and `Eq` to overload the `==` and `!=` operators.
 *
 * Eventually this may be simplified to only require
 * an `eq` method, with the other generated from
-* a default implementation.
+* a default implementation. However it should
+* remain possible to implement `ne` separately, for
+* compatibility with floating-point NaN semantics
+* (cf. IEEE 754-2008 section 5.11).
 */
 #[lang="eq"]
 pub trait Eq {
@@ -43,7 +46,10 @@ pub trait Eq {
 *
 * Eventually this may be simplified to only require
 * an `le` method, with the others generated from
-* default implementations.
+* default implementations. However it should remain
+* possible to implement the others separately, for
+* compatibility with floating-point NaN semantics
+* (cf. IEEE 754-2008 section 5.11).
 */
 #[lang="ord"]
 pub trait Ord {
@@ -57,8 +63,8 @@ pub pure fn lt<T: Ord>(v1: &T, v2: &T) -> bool {
     (*v1).lt(v2)
 }
 
-pub pure fn le<T: Ord Eq>(v1: &T, v2: &T) -> bool {
-    (*v1).lt(v2) || (*v1).eq(v2)
+pub pure fn le<T: Ord>(v1: &T, v2: &T) -> bool {
+    (*v1).le(v2)
 }
 
 pub pure fn eq<T: Eq>(v1: &T, v2: &T) -> bool {


### PR DESCRIPTION
Also add comments reminding that IEEE 754 requires unusual semantics for
comparison operators as applied to NaNs (x != x, if x = NaN), in case someone
in the future wants to get clever.
