### PR TITLE
Range checking and miscellaneous fixes tin time library

### DIFF
--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -460,7 +460,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
                 tm.tm_yday = v - 1_i32;
                 Ok(pos)
               }
-              None => Err(~"Invalid year")
+              None => Err(~"Invalid day of year")
             }
           }
           'k' => {
@@ -554,7 +554,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
                 tm.tm_wday = v;
                 Ok(pos)
               }
-              None => Err(~"Invalid weekday")
+              None => Err(~"Invalid day of week")
             }
           }
           'v' => {
@@ -569,7 +569,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             // FIXME (#2350): range check.
             match match_digits(s, pos, 1u, false) {
               Some(item) => { let (v, pos) = item; tm.tm_wday = v; Ok(pos) }
-              None => Err(~"Invalid weekday")
+              None => Err(~"Invalid day of week")
             }
           }
           //'X' {}
@@ -582,7 +582,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
                 tm.tm_year = v - 1900_i32;
                 Ok(pos)
               }
-              None => Err(~"Invalid weekday")
+              None => Err(~"Invalid year")
             }
           }
           'y' => {
@@ -593,7 +593,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
                 tm.tm_year = v - 1900_i32;
                 Ok(pos)
               }
-              None => Err(~"Invalid weekday")
+              None => Err(~"Invalid year")
             }
           }
           'Z' => {

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -551,7 +551,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             match match_digits(s, pos, 1u, false) {
               Some(item) => {
                 let (v, pos) = item;
-                tm.tm_wday = v;
+                tm.tm_wday = v-1_i32;
                 Ok(pos)
               }
               None => Err(~"Invalid day of week")
@@ -590,7 +590,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             match match_digits(s, pos, 2u, false) {
               Some(item) => {
                 let (v, pos) = item;
-                tm.tm_year = v - 1900_i32;
+                tm.tm_year = v;
                 Ok(pos)
               }
               None => Err(~"Invalid year")

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -320,8 +320,8 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
         Some((value, pos))
     }
 
-    fn match_digits_in_range(ss: &str, pos: uint, digits: uint, ws: bool, min: i32, max: i32)
-      -> Option<(i32, uint)> {
+    fn match_digits_in_range(ss: &str, pos: uint, digits: uint, ws: bool,
+                             min: i32, max: i32) -> Option<(i32, uint)> {
         match match_digits(ss, pos, digits, ws) {
           Some((val, pos)) if val >= min && val <= max => {
             Some((val, pos))
@@ -403,7 +403,8 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             Some(item) => { let (v, pos) = item; tm.tm_mon = v; Ok(pos) }
             None => Err(~"Invalid month")
           },
-          'C' => match match_digits_in_range(s, pos, 2u, false, 0_i32, 99_i32) {
+          'C' => match match_digits_in_range(s, pos, 2u, false, 0_i32,
+                                             99_i32) {
             Some(item) => {
                 let (v, pos) = item;
                   tm.tm_year += (v * 100_i32) - 1900_i32;
@@ -429,11 +430,13 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
                 .chain(|pos| parse_char(s, pos, '/'))
                 .chain(|pos| parse_type(s, pos, 'y', tm))
           }
-          'd' => match match_digits_in_range(s, pos, 2u, false, 1_i32, 31_i32) {
+          'd' => match match_digits_in_range(s, pos, 2u, false, 1_i32,
+                                             31_i32) {
             Some(item) => { let (v, pos) = item; tm.tm_mday = v; Ok(pos) }
             None => Err(~"Invalid day of the month")
           },
-          'e' => match match_digits_in_range(s, pos, 2u, true, 1_i32, 31_i32) {
+          'e' => match match_digits_in_range(s, pos, 2u, true, 1_i32,
+                                             31_i32) {
             Some(item) => { let (v, pos) = item; tm.tm_mday = v; Ok(pos) }
             None => Err(~"Invalid day of the month")
           },


### PR DESCRIPTION
This primarily adds range-checking that was requested in #2350. This is done using a helper function match_digits_in_range.

%u takes a day of the week in the range of 1-7. However it was previously treated identically to %w that takes a value in the range 0-6. Similarly, %y takes only a two-digit year and thereby subtracting 1900 from it is wrong. This is also fixed.

Further, I have also fixed the error messages in a few places where it was wrong.
