### PR TITLE
Reflect on char as u32, not uint (which may be u64).

### DIFF
--- a/src/libcore/repr.rs
+++ b/src/libcore/repr.rs
@@ -286,7 +286,7 @@ impl ReprVisitor : TyVisitor {
     fn visit_f32() -> bool { self.write::<f32>() }
     fn visit_f64() -> bool { self.write::<f64>() }
 
-    fn visit_char() -> bool { self.write::<uint>() }
+    fn visit_char() -> bool { self.write::<u32>() }
 
     // Type no longer exists, vestigial function.
     fn visit_str() -> bool { fail; }


### PR DESCRIPTION
Fixes mozilla/rust#4473.
