### PR TITLE
allowing the entry point name to be something other than main

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2153,11 +2153,19 @@ fn register_fn_fuller(ccx: @crate_ctxt,
     ccx.item_symbols.insert(node_id, ps);
 
     // FIXME #4404 android JNI hacks
-    let is_main = is_main_name(path) && (!ccx.sess.building_library ||
+    let is_main = is_main_fn(&ccx.sess, node_id) &&
+                     (!ccx.sess.building_library ||
                       (ccx.sess.building_library &&
                        ccx.sess.targ_cfg.os == session::os_android));
     if is_main { create_main_wrapper(ccx, sp, llfn); }
     llfn
+}
+
+fn is_main_fn(sess: &Session, node_id: ast::node_id) -> bool {
+    match sess.main_fn {
+        Some((main_id, _)) => node_id == main_id,
+        None => false
+    }
 }
 
 // Create a _rust_main(args: ~[str]) function which will be called from the

--- a/src/test/compile-fail/multiple-main-2.rs
+++ b/src/test/compile-fail/multiple-main-2.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[main]
+fn bar() {
+}
+
+#[main]
+fn foo() { //~ ERROR multiple 'main' functions
+}

--- a/src/test/compile-fail/multiple-main-3.rs
+++ b/src/test/compile-fail/multiple-main-3.rs
@@ -1,0 +1,19 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[main]
+fn main1() {
+}
+
+mod foo {
+    #[main]
+    fn main2() { //~ ERROR multiple 'main' functions
+    }
+}

--- a/src/test/run-pass/attr-main-2.rs
+++ b/src/test/run-pass/attr-main-2.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    fail
+}
+
+#[main]
+fn foo() {
+}

--- a/src/test/run-pass/attr-main.rs
+++ b/src/test/run-pass/attr-main.rs
@@ -1,0 +1,13 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[main]
+fn foo() {
+}


### PR DESCRIPTION
fixed #4207

giving a function the attribute `#[main]` makes the function main.
- if there is no function with `#[main]`, the function named 'main' will be the main.
- when `--test` is given, all function with `#[main]` will be stripped out and the main function for testing will be the only function having `#[main]` attribute.
