### PR TITLE
s/moved variable/moved value/

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1662,7 +1662,7 @@ fn check_fn(_fk: visit::fn_kind, _decl: fn_decl,
 enum ReadKind {
     PossiblyUninitializedVariable,
     PossiblyUninitializedField,
-    MovedVariable
+    MovedValue
 }
 
 impl @Liveness {
@@ -1815,7 +1815,7 @@ impl @Liveness {
                            lnk: LiveNodeKind,
                            var: Variable) {
 
-        // the only time that it is possible to have a moved variable
+        // the only time that it is possible to have a moved value
         // used by ExitNode would be arguments or fields in a ctor.
         // we give a slightly different error message in those cases.
         if lnk == ExitNode {
@@ -1837,7 +1837,7 @@ impl @Liveness {
             }
         }
 
-        self.report_illegal_read(move_span, lnk, var, MovedVariable);
+        self.report_illegal_read(move_span, lnk, var, MovedValue);
         self.tcx.sess.span_note(
             move_span, ~"move of variable occurred here");
 
@@ -1852,7 +1852,7 @@ impl @Liveness {
             ~"possibly uninitialized variable"
           }
           PossiblyUninitializedField => ~"possibly uninitialized field",
-          MovedVariable => ~"moved variable"
+          MovedValue => ~"moved value"
         };
         let name = (*self.ir).variable_name(var);
         match lnk {

--- a/src/test/compile-fail/alt-vec-tail-move.rs
+++ b/src/test/compile-fail/alt-vec-tail-move.rs
@@ -4,5 +4,5 @@ fn main() {
         [1, 2, ..move tail] => tail,
         _ => core::util::unreachable()
     };
-    a[0] = 0; //~ ERROR: use of moved variable
+    a[0] = 0; //~ ERROR: use of moved value
 }

--- a/src/test/compile-fail/cap-clause-use-after-move.rs
+++ b/src/test/compile-fail/cap-clause-use-after-move.rs
@@ -11,5 +11,5 @@
 fn main() {
     let x = 5;
     let _y = fn~(move x) { }; //~ WARNING captured variable `x` not used in closure
-    let _z = x; //~ ERROR use of moved variable: `x`
+    let _z = x; //~ ERROR use of moved value: `x`
 }

--- a/src/test/compile-fail/liveness-move-from-mode.rs
+++ b/src/test/compile-fail/liveness-move-from-mode.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let x: int = 25;
     loop {
-        take(move x); //~ ERROR use of moved variable: `x`
+        take(move x); //~ ERROR use of moved value: `x`
         //~^ NOTE move of variable occurred here
     }
 }

--- a/src/test/compile-fail/liveness-move-in-loop.rs
+++ b/src/test/compile-fail/liveness-move-in-loop.rs
@@ -18,10 +18,10 @@ fn main() {
             loop {
                 loop {
 // tjc: Not sure why it prints the same error twice
-                    x = move y; //~ ERROR use of moved variable
-                    //~^ NOTE move of variable occurred here
-                    //~^^ ERROR use of moved variable
-                    //~^^^ NOTE move of variable occurred here
+                    x = move y; //~ ERROR use of moved value
+                    //~^ NOTE move of value occurred here
+                    //~^^ ERROR use of moved value
+                    //~^^^ NOTE move of value occurred here
 
                     copy x;
                 }

--- a/src/test/compile-fail/liveness-move-in-while.rs
+++ b/src/test/compile-fail/liveness-move-in-while.rs
@@ -16,9 +16,9 @@ fn main() {
         log(debug, y);
 // tjc: not sure why it prints the same error twice
         while true { while true { while true { x = move y; copy x; } } }
-        //~^ ERROR use of moved variable: `y`
-        //~^^ NOTE move of variable occurred here
-        //~^^^ ERROR use of moved variable: `y`
-        //~^^^^ NOTE move of variable occurred here
+        //~^ ERROR use of moved value: `y`
+        //~^^ NOTE move of value occurred here
+        //~^^^ ERROR use of moved value: `y`
+        //~^^^^ NOTE move of value occurred here
     }
 }

--- a/src/test/compile-fail/liveness-use-after-move.rs
+++ b/src/test/compile-fail/liveness-use-after-move.rs
@@ -10,7 +10,7 @@
 
 fn main() {
     let x = @5;
-    let y = move x; //~ NOTE move of variable occurred here
-    log(debug, *x); //~ ERROR use of moved variable: `x`
+    let y = move x; //~ NOTE move of value occurred here
+    log(debug, *x); //~ ERROR use of moved value: `x`
     copy y;
 }

--- a/src/test/compile-fail/liveness-use-after-send.rs
+++ b/src/test/compile-fail/liveness-use-after-send.rs
@@ -19,8 +19,8 @@ enum _chan<T> = int;
 // Tests that "log(debug, message);" is flagged as using
 // message after the send deinitializes it
 fn test00_start(ch: _chan<int>, message: int, _count: int) {
-    send(ch, move message); //~ NOTE move of variable occurred here
-    log(debug, message); //~ ERROR use of moved variable: `message`
+    send(ch, move message); //~ NOTE move of value occurred here
+    log(debug, message); //~ ERROR use of moved value: `message`
 }
 
 fn main() { fail; }

--- a/src/test/compile-fail/move-based-on-type-tuple.rs
+++ b/src/test/compile-fail/move-based-on-type-tuple.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn dup(x: ~int) -> ~(~int,~int) { ~(x, x) } //~ ERROR use of moved variable
+fn dup(x: ~int) -> ~(~int,~int) { ~(x, x) } //~ ERROR use of moved value
 fn main() {
     dup(~3);
 }

--- a/src/test/compile-fail/moves-based-on-type-capture-clause-bad.rs
+++ b/src/test/compile-fail/moves-based-on-type-capture-clause-bad.rs
@@ -3,6 +3,6 @@ fn main() {
     do task::spawn {
         io::println(x);
     }
-    io::println(x); //~ ERROR use of moved variable
+    io::println(x); //~ ERROR use of moved value
 }
 

--- a/src/test/compile-fail/no-capture-arc.rs
+++ b/src/test/compile-fail/no-capture-arc.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: use of moved variable
+// error-pattern: use of moved value
 
 extern mod std;
 use std::arc;

--- a/src/test/compile-fail/no-reuse-move-arc.rs
+++ b/src/test/compile-fail/no-reuse-move-arc.rs
@@ -16,12 +16,12 @@ fn main() {
     let v = ~[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let arc_v = arc::ARC(v);
 
-    do task::spawn() |move arc_v| { //~ NOTE move of variable occurred here
+    do task::spawn() |move arc_v| { //~ NOTE move of value occurred here
         let v = *arc::get(&arc_v);
         assert v[3] == 4;
     };
 
-    assert (*arc::get(&arc_v))[2] == 3; //~ ERROR use of moved variable: `arc_v`
+    assert (*arc::get(&arc_v))[2] == 3; //~ ERROR use of moved value: `arc_v`
 
     log(info, arc_v);
 }

--- a/src/test/compile-fail/unary-move.rs
+++ b/src/test/compile-fail/unary-move.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: use of moved variable
+// error-pattern: use of moved value
 
 fn main() {
     let x = 3;

--- a/src/test/compile-fail/use-after-move-based-on-type.rs
+++ b/src/test/compile-fail/use-after-move-based-on-type.rs
@@ -11,6 +11,6 @@
 fn main() {
     let x = ~"Hello!";
     let _y = x;
-    io::println(x); //~ ERROR use of moved variable
+    io::println(x); //~ ERROR use of moved value
 }
 

--- a/src/test/compile-fail/use-after-move-self-based-on-type.rs
+++ b/src/test/compile-fail/use-after-move-self-based-on-type.rs
@@ -6,7 +6,7 @@ struct S {
 impl S {
     fn foo(self) -> int {
         self.bar();
-        return self.x;  //~ ERROR use of moved variable
+        return self.x;  //~ ERROR use of moved value
     }
 
     fn bar(self) {}

--- a/src/test/compile-fail/use-after-move-self.rs
+++ b/src/test/compile-fail/use-after-move-self.rs
@@ -5,7 +5,7 @@ struct S {
 impl S {
     fn foo(self) -> int {
         (move self).bar();
-        return self.x;  //~ ERROR use of moved variable
+        return self.x;  //~ ERROR use of moved value
     }
 
     fn bar(self) {}


### PR DESCRIPTION
I believe this implements the change I mentioned a few days ago. The tree appears to compile following this change.

r? @nikomatsakis
