### PR TITLE
Rename copy_overlapping_memory() to copy_memory()

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -26,12 +26,6 @@ use vec;
 #[abi = "cdecl"]
 extern mod libc_ {
     #[rust_stack]
-    unsafe fn memcpy(dest: *mut c_void,
-                     src: *const c_void,
-                     n: libc::size_t)
-                  -> *c_void;
-
-    #[rust_stack]
     unsafe fn memmove(dest: *mut c_void,
                       src: *const c_void,
                       n: libc::size_t)
@@ -119,23 +113,10 @@ pub pure fn is_not_null<T>(ptr: *const T) -> bool { !is_null(ptr) }
  * Copies data from one location to another
  *
  * Copies `count` elements (not bytes) from `src` to `dst`. The source
- * and destination may not overlap.
- */
-#[inline(always)]
-pub unsafe fn copy_memory<T>(dst: *mut T, src: *const T, count: uint) {
-    let n = count * sys::size_of::<T>();
-    libc_::memcpy(dst as *mut c_void, src as *c_void, n as size_t);
-}
-
-/**
- * Copies data from one location to another
- *
- * Copies `count` elements (not bytes) from `src` to `dst`. The source
  * and destination may overlap.
  */
 #[inline(always)]
-pub unsafe fn copy_overlapping_memory<T>(dst: *mut T, src: *const T,
-                                         count: uint) {
+pub unsafe fn copy_memory<T>(dst: *mut T, src: *const T, count: uint) {
     let n = count * sys::size_of::<T>();
     libc_::memmove(dst as *mut c_void, src as *c_void, n as size_t);
 }
@@ -145,7 +126,6 @@ pub unsafe fn set_memory<T>(dst: *mut T, c: int, count: uint) {
     let n = count * sys::size_of::<T>();
     libc_::memset(dst as *mut c_void, c as libc::c_int, n as size_t);
 }
-
 
 /**
   Transform a region pointer - &T - to an unsafe pointer - *T.

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -2095,24 +2095,6 @@ pub mod raw {
             }
         }
     }
-
-    /**
-      * Copies data from one vector to another.
-      *
-      * Copies `count` bytes from `src` to `dst`. The source and destination
-      * may overlap.
-      */
-    pub unsafe fn copy_overlapping_memory<T>(dst: &[mut T], src: &[const T],
-                                             count: uint) {
-        assert dst.len() >= count;
-        assert src.len() >= count;
-
-        do as_mut_buf(dst) |p_dst, _len_dst| {
-            do as_const_buf(src) |p_src, _len_src| {
-                ptr::copy_overlapping_memory(p_dst, p_src, count)
-            }
-        }
-    }
 }
 
 /// Operations on `[u8]`
@@ -2166,23 +2148,11 @@ pub mod bytes {
       * Copies data from one vector to another.
       *
       * Copies `count` bytes from `src` to `dst`. The source and destination
-      * may not overlap.
+      * may overlap.
       */
     pub fn copy_memory(dst: &[mut u8], src: &[const u8], count: uint) {
         // Bound checks are done at vec::raw::copy_memory.
         unsafe { vec::raw::copy_memory(dst, src, count) }
-    }
-
-    /**
-      * Copies data from one vector to another.
-      *
-      * Copies `count` bytes from `src` to `dst`. The source and destination
-      * may overlap.
-      */
-    pub fn copy_overlapping_memory(dst: &[mut u8], src: &[const u8],
-                                   count: uint) {
-        // Bound checks are done at vec::raw::copy_overlapping_memory.
-        unsafe { vec::raw::copy_overlapping_memory(dst, src, count) }
     }
 }
 


### PR DESCRIPTION
As per my discussion with @brson in issue #4189, this change makes `vec` and `ptr`'s `copy_memory()` functions use the safer `libc_::memmove()` instead of `libc_::memcpy()`.

This change does _not_ remove `libc::funcs::c95::string::memcpy()` itself.
