### PR TITLE
clean up tempfile module and rm FIXME

### DIFF
--- a/src/libstd/tempfile.rs
+++ b/src/libstd/tempfile.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,26 +19,18 @@ use core::str;
 
 pub fn mkdtemp(tmpdir: &Path, suffix: &str) -> Option<Path> {
     let r = rand::Rng();
-    let mut i = 0u;
-    while (i < 1000u) {
-        let p = tmpdir.push(r.gen_str(16u) +
-                            str::from_slice(suffix));
-        if os::make_dir(&p, 0x1c0i32) {  // FIXME: u+rwx (#2349)
+    for 1000.times {
+        let p = tmpdir.push(r.gen_str(16) + suffix);
+        if os::make_dir(&p, 0x1c0) { // 700
             return Some(p);
         }
-        i += 1u;
     }
-    return None;
+    None
 }
 
 #[test]
 fn test_mkdtemp() {
-    let r = mkdtemp(&Path("."), "foobar");
-    match r {
-        Some(ref p) => {
-            os::remove_dir(p);
-            assert(str::ends_with(p.to_str(), "foobar"));
-        }
-        _ => assert(false)
-    }
+    let p = mkdtemp(&Path("."), "foobar").unwrap();
+    os::remove_dir(&p);
+    assert str::ends_with(p.to_str(), "foobar");
 }


### PR DESCRIPTION
I can't really think of a use case for a randomized directory name which other users have read/write permissions on. If there is some edge case, it can be dealt with by doing a chmod after the fact (but you can't do the security retroactively).

Closes #2349.
