### PR TITLE
Bench harness

### DIFF
--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -33,7 +33,7 @@ mod errors;
 use std::getopts;
 use std::test;
 
-use core::result;
+use core::{result, either};
 use result::{Ok, Err};
 
 use common::config;
@@ -158,7 +158,11 @@ pub fn test_opts(config: config) -> test::TestOpts {
     test::TestOpts {
         filter: config.filter,
         run_ignored: config.run_ignored,
-        logfile: config.logfile.map(|s| s.to_str()),
+        logfile: copy config.logfile,
+        run_tests: true,
+        run_benchmarks: false,
+        save_results: option::None,
+        compare_results: option::None
     }
 }
 
@@ -210,13 +214,15 @@ pub fn make_test(config: config, testfile: &Path) -> test::TestDescAndFn {
     }
 }
 
-pub fn make_test_name(config: config, testfile: &Path) -> ~str {
-    fmt!("[%s] %s", mode_str(config.mode), testfile.to_str())
+pub fn make_test_name(config: config, testfile: &Path) -> test::TestName {
+    test::DynTestName(fmt!("[%s] %s",
+                           mode_str(config.mode),
+                           testfile.to_str()))
 }
 
 pub fn make_test_closure(config: config, testfile: &Path) -> test::TestFn {
     let testfile = testfile.to_str();
-    fn~() { runtest::run(config, testfile) }
+    test::DynTestFn(fn~() { runtest::run(config, testfile) })
 }
 
 // Local Variables:

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -85,3 +85,12 @@ pub pure fn gt<T: Ord>(v1: &T, v2: &T) -> bool {
     (*v1).gt(v2)
 }
 
+#[inline(always)]
+pub pure fn min<T: Ord>(v1: T, v2: T) -> T {
+    if v1 < v2 { v1 } else { v2 }
+}
+
+#[inline(always)]
+pub pure fn max<T: Ord>(v1: T, v2: T) -> T {
+    if v1 > v2 { v1 } else { v2 }
+}

--- a/src/libcore/either.rs
+++ b/src/libcore/either.rs
@@ -145,7 +145,7 @@ pub pure fn unwrap_right<T,U>(eith: Either<T,U>) -> U {
     }
 }
 
-impl<T, U> Either<T, U> {
+pub impl<T, U> Either<T, U> {
     #[inline(always)]
     fn either<V>(&self, f_left: fn(&T) -> V, f_right: fn(&U) -> V) -> V {
         either(f_left, f_right, self)

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -21,6 +21,7 @@ use to_str;
 use from_str;
 
 pub use cmath::c_double_targ_consts::*;
+pub use cmp::{min, max};
 
 macro_rules! delegate(
     (

--- a/src/libcore/num/int-template.rs
+++ b/src/libcore/num/int-template.rs
@@ -24,17 +24,13 @@ use vec;
 use i8;
 use i16;
 use i32;
+pub use cmp::{min, max};
 
 pub const bits : uint = inst::bits;
 pub const bytes : uint = (inst::bits / 8);
 
 pub const min_value: T = (-1 as T) << (bits - 1);
 pub const max_value: T = min_value - 1 as T;
-
-#[inline(always)]
-pub pure fn min(x: T, y: T) -> T { if x < y { x } else { y } }
-#[inline(always)]
-pub pure fn max(x: T, y: T) -> T { if x > y { x } else { y } }
 
 #[inline(always)]
 pub pure fn add(x: T, y: T) -> T { x + y }

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -39,7 +39,7 @@ pub trait One {
     static pure fn one() -> Self;
 }
 
-pub pure fn abs<T: cmp::Ord Num Zero>(v: T) -> T {
+pub pure fn abs<T: Ord Num Zero>(v: T) -> T {
     if v < Zero::zero() { v.neg() } else { v }
 }
 

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -39,6 +39,10 @@ pub trait One {
     static pure fn one() -> Self;
 }
 
+pub pure fn abs<T: cmp::Ord Num Zero>(v: T) -> T {
+    if v < Zero::zero() { v.neg() } else { v }
+}
+
 pub trait Round {
     pure fn round(&self, mode: RoundMode) -> Self;
 

--- a/src/libcore/num/uint-template.rs
+++ b/src/libcore/num/uint-template.rs
@@ -27,16 +27,13 @@ use u8;
 use u16;
 use u32;
 
+pub use cmp::{min, max};
+
 pub const bits : uint = inst::bits;
 pub const bytes : uint = (inst::bits / 8);
 
 pub const min_value: T = 0 as T;
 pub const max_value: T = 0 as T - 1 as T;
-
-#[inline(always)]
-pub pure fn min(x: T, y: T) -> T { if x < y { x } else { y } }
-#[inline(always)]
-pub pure fn max(x: T, y: T) -> T { if x > y { x } else { y } }
 
 #[inline(always)]
 pub pure fn add(x: T, y: T) -> T { x + y }

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -127,15 +127,15 @@ pub fn check_expr(sess: Session,
                               items without type parameters");
             }
             match def_map.find(&e.id) {
-              Some(def_const(def_id)) |
-                Some(def_fn(def_id, _)) |
-                Some(def_variant(_, def_id)) |
-                Some(def_struct(def_id)) => {
+                Some(def_variant(_, _)) |
+                Some(def_struct(_)) => { }
+
+                Some(def_const(def_id)) |
+                Some(def_fn(def_id, _)) => {
                 if !ast_util::is_local(def_id) {
                     sess.span_err(
                         e.span, ~"paths in constants may only refer to \
-                                 crate-local constants, functions, or \
-                                 structs");
+                                 crate-local constants or functions");
                 }
               }
               Some(def) => {

--- a/src/libstd/stats.rs
+++ b/src/libstd/stats.rs
@@ -1,0 +1,96 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core::vec;
+use core::f64;
+use core::cmp;
+use core::num;
+use sort;
+
+// NB: this can probably be rewritten in terms of num::Num
+// to be less f64-specific.
+
+pub trait Stats {
+    fn sum(self) -> f64;
+    fn min(self) -> f64;
+    fn max(self) -> f64;
+    fn mean(self) -> f64;
+    fn median(self) -> f64;
+    fn var(self) -> f64;
+    fn std_dev(self) -> f64;
+    fn std_dev_pct(self) -> f64;
+    fn median_abs_dev(self) -> f64;
+    fn median_abs_dev_pct(self) -> f64;
+}
+
+impl &[f64] : Stats {
+    fn sum(self) -> f64 {
+        vec::foldl(0.0, self, |p,q| p + *q)
+    }
+
+    fn min(self) -> f64 {
+        assert self.len() != 0;
+        vec::foldl(self[0], self, |p,q| cmp::min(p, *q))
+    }
+
+    fn max(self) -> f64 {
+        assert self.len() != 0;
+        vec::foldl(self[0], self, |p,q| cmp::max(p, *q))
+    }
+
+    fn mean(self) -> f64 {
+        assert self.len() != 0;
+        self.sum() / (self.len() as f64)
+    }
+
+    fn median(self) -> f64 {
+        assert self.len() != 0;
+        let tmp = vec::to_mut(vec::from_slice(self));
+        sort::tim_sort(tmp);
+        if tmp.len() & 1 == 0 {
+            let m = tmp.len() / 2;
+            (tmp[m] + tmp[m-1]) / 2.0
+        } else {
+            tmp[tmp.len() / 2]
+        }
+    }
+
+    fn var(self) -> f64 {
+        if self.len() == 0 {
+            0.0
+        } else {
+            let mean = self.mean();
+            let mut v = 0.0;
+            for self.each |s| {
+                let x = *s - mean;
+                v += x*x;
+            }
+            v/(self.len() as f64)
+        }
+    }
+
+    fn std_dev(self) -> f64 {
+        f64::sqrt(self.var())
+    }
+
+    fn std_dev_pct(self) -> f64 {
+        (self.std_dev() / self.mean()) * 100.0
+    }
+
+    fn median_abs_dev(self) -> f64 {
+        let med = self.median();
+        let abs_devs = self.map(|v| num::abs(med - *v));
+        abs_devs.median()
+    }
+
+    fn median_abs_dev_pct(self) -> f64 {
+        (self.median_abs_dev() / self.median()) * 100.0
+    }
+}

--- a/src/libstd/stats.rs
+++ b/src/libstd/stats.rs
@@ -52,7 +52,7 @@ impl &[f64] : Stats {
 
     fn median(self) -> f64 {
         assert self.len() != 0;
-        let tmp = vec::to_mut(vec::from_slice(self));
+        let tmp = vec::cast_to_mut(vec::from_slice(self));
         sort::tim_sort(tmp);
         if tmp.len() & 1 == 0 {
             let m = tmp.len() / 2;

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -98,6 +98,7 @@ pub mod base64;
 pub mod rl;
 pub mod workcache;
 pub mod bigint;
+pub mod stats;
 
 #[cfg(unicode)]
 mod unicode;

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -115,6 +115,7 @@ pub mod serialize;
 #[doc(hidden)] // FIXME #3538
 mod std {
     pub use serialize;
+    pub use test;
 }
 
 // Local Variables:

--- a/src/test/run-pass/test-ignore-cfg.rs
+++ b/src/test/run-pass/test-ignore-cfg.rs
@@ -26,13 +26,13 @@ fn shouldnotignore() {
 #[test]
 fn checktests() {
     // Pull the tests out of the secreturn test module
-    let tests = __test::tests();
+    let tests = __test::tests;
 
     assert vec::any(
         tests,
-        |t| t.desc.name == ~"shouldignore" && t.desc.ignore);
+        |t| t.desc.name.to_str() == ~"shouldignore" && t.desc.ignore);
 
     assert vec::any(
         tests,
-        |t| t.desc.name == ~"shouldnotignore" && !t.desc.ignore);
+        |t| t.desc.name.to_str() == ~"shouldnotignore" && !t.desc.ignore);
 }


### PR DESCRIPTION
This is scaffolding for the new #[bench] attribute for marking unit tests as benchmarks. They are run with the --bench flag that the test runner now accepts. The runner automatically calibrates a test loop to an appropriate count to get a good per-iteration measurement.
