### PR TITLE
Add a license check to tidy. #4018

### DIFF
--- a/src/etc/check-summary.py
+++ b/src/etc/check-summary.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# xfail-license
 
 import sys
 

--- a/src/etc/combine-tests.py
+++ b/src/etc/combine-tests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# xfail-license
 
 # this combines all the working run-pass tests into a single large crate so we
 # can run it "fast": spawning zillions of windows processes is our major build

--- a/src/etc/extract-tests.py
+++ b/src/etc/extract-tests.py
@@ -1,3 +1,5 @@
+# xfail-license
+
 # Script for extracting compilable fragments from markdown
 # documentation. See prep.js for a description of the format
 # recognized by this tool. Expects a directory fragements/ to exist

--- a/src/etc/extract_grammar.py
+++ b/src/etc/extract_grammar.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# xfail-license
 
 # This script is for extracting the grammar from the rust docs.
 

--- a/src/etc/get-snapshot.py
+++ b/src/etc/get-snapshot.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# xfail-license
 
 import os, tarfile, re, shutil, sys
 from snapshot import *

--- a/src/etc/latest-unix-snaps.py
+++ b/src/etc/latest-unix-snaps.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# xfail-license
 
 import os, tarfile, hashlib, re, shutil, sys
 from snapshot import *

--- a/src/etc/licenseck.py
+++ b/src/etc/licenseck.py
@@ -1,0 +1,72 @@
+# Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+license1 = """// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+"""
+
+license2 = """// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+"""
+
+license3 = """# Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+"""
+
+licenses = [license1, license2, license3]
+
+exceptions = [
+    "rt/rust_android_dummy.cpp", # BSD, chromium
+    "rt/rust_android_dummy.h", # BSD, chromium
+    "rt/isaac/randport.cpp", # public domain
+    "rt/isaac/rand.h", # public domain
+    "rt/isaac/standard.h", # public domain
+]
+
+def check_license(name, contents):
+    valid_license = False
+    for a_valid_license in licenses:
+        if contents.startswith(a_valid_license):
+            valid_license = True
+            break
+    if valid_license:
+        return True
+
+    for exception in exceptions:
+        if name.endswith(exception):
+            return True
+
+    firstlineish = contents[:100]
+    if firstlineish.find("xfail-license") != -1:
+        return True
+
+    return False
+

--- a/src/etc/make-snapshot.py
+++ b/src/etc/make-snapshot.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# xfail-license
 
 import snapshot, sys
 

--- a/src/etc/mirror-all-snapshots.py
+++ b/src/etc/mirror-all-snapshots.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# xfail-license
 
 import os, tarfile, hashlib, re, shutil
 from snapshot import *

--- a/src/etc/snapshot.py
+++ b/src/etc/snapshot.py
@@ -1,3 +1,5 @@
+# xfail-license
+
 import re, os, sys, glob, tarfile, shutil, subprocess, tempfile
 
 try:

--- a/src/etc/sugarise-doc-comments.py
+++ b/src/etc/sugarise-doc-comments.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# xfail-license
 
 #
 # this script attempts to turn doc comment attributes (#[doc = "..."])

--- a/src/etc/tidy.py
+++ b/src/etc/tidy.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
+# xfail-license
 
 import sys, fileinput, subprocess, re
+from licenseck import *
 
 err=0
 cols=78
@@ -13,13 +15,24 @@ result=config_proc.communicate()[0]
 true="true".encode('utf8')
 autocrlf=result.strip() == true if result is not None else False
 
-def report_err(s):
+def report_error_name_no(name, no, s):
     global err
-    print("%s:%d: %s" % (fileinput.filename(), fileinput.filelineno(), s))
+    print("%s:%d: %s" % (name, no, s))
     err=1
+
+def report_err(s):
+    report_error_name_no(fileinput.filename(), fileinput.filelineno(), s)
+
+def do_license_check(name, contents):
+    if not check_license(name, contents):
+        report_error_name_no(name, 1, "incorrect license")
+
 
 file_names = [s for s in sys.argv[1:] if (not s.endswith("_gen.rs"))
                                      and (not ".#" in s)]
+
+current_name = ""
+current_contents = ""
 
 try:
     for line in fileinput.input(file_names,
@@ -42,6 +55,19 @@ try:
 
         if line_len > cols:
             report_err("line longer than %d chars" % cols)
+
+        if fileinput.isfirstline() and current_name != "":
+            do_license_check(current_name, current_contents)
+
+        if fileinput.isfirstline():
+            current_name = fileinput.filename()
+            current_contents = ""
+
+        current_contents += line
+
+    if current_name != "":
+        do_license_check(current_name, current_contents)
+
 except UnicodeDecodeError, e:
     report_err("UTF-8 decoding error " + str(e))
 

--- a/src/etc/unicode.py
+++ b/src/etc/unicode.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# xfail-license
 
 # This digests UnicodeData.txt and DerivedCoreProperties.txt and emits rust
 # code covering the core properties. Since this is a pretty rare event we

--- a/src/libcargo/cargo.rc
+++ b/src/libcargo/cargo.rc
@@ -1,4 +1,3 @@
-// -*- rust -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -1,4 +1,3 @@
-// -*- rust -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers.src/libcore/os.rs
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -1,3 +1,13 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 // This file is imported into every module by default.
 
 /* Reexported core operators */

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -1,4 +1,3 @@
-// -*- rust -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -1,4 +1,3 @@
-// -*- rust -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -1,4 +1,3 @@
-// -*- rust -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/libstd/bigint.rs
+++ b/src/libstd/bigint.rs
@@ -1,3 +1,13 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 /*!
 
 A Big integer (signed version: BigInt, unsigned version: BigUint).

--- a/src/libstd/flatpipes.rs
+++ b/src/libstd/flatpipes.rs
@@ -1,3 +1,13 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 /*!
 
 Generic communication channels for things that can be represented as,

--- a/src/libstd/priority_queue.rs
+++ b/src/libstd/priority_queue.rs
@@ -1,3 +1,12 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 //! A priority queue implemented with a binary heap
 

--- a/src/rt/arch/arm/context.cpp
+++ b/src/rt/arch/arm/context.cpp
@@ -1,3 +1,4 @@
+// xfail-license
 
 #include "context.h"
 #include "../../rust_globals.h"

--- a/src/rt/arch/arm/context.h
+++ b/src/rt/arch/arm/context.h
@@ -1,4 +1,5 @@
 // -*- mode: c++ -*-
+// xfail-license
 
 #ifndef CONTEXT_H
 #define CONTEXT_H

--- a/src/rt/arch/arm/gpr.cpp
+++ b/src/rt/arch/arm/gpr.cpp
@@ -1,3 +1,5 @@
+// xfail-license
+
 #include "gpr.h"
 
 #define LOAD(rn) do { \

--- a/src/rt/arch/arm/gpr.h
+++ b/src/rt/arch/arm/gpr.h
@@ -1,3 +1,4 @@
+// xfail-license
 // General-purpose registers. This structure is used during stack crawling.
 
 #ifndef GPR_H

--- a/src/rt/arch/arm/regs.h
+++ b/src/rt/arch/arm/regs.h
@@ -1,3 +1,5 @@
+// xfail-license
+
 #define RUSTRT_RBX   0
 #define RUSTRT_RSP   1
 #define RUSTRT_RBP   2

--- a/src/rt/arch/i386/context.h
+++ b/src/rt/arch/i386/context.h
@@ -1,4 +1,3 @@
-// -*- mode: c++ -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/rt/arch/x86_64/context.h
+++ b/src/rt/arch/x86_64/context.h
@@ -1,4 +1,3 @@
-// -*- mode: c++ -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/rt/rust_kernel.h
+++ b/src/rt/rust_kernel.h
@@ -1,4 +1,3 @@
-// -*- c++ -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/rt/rust_log.h
+++ b/src/rt/rust_log.h
@@ -1,4 +1,3 @@
-// -*- c++ -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/rt/sync/lock_and_signal.h
+++ b/src/rt/sync/lock_and_signal.h
@@ -1,4 +1,3 @@
-// -*- c++ -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/rt/sync/sync.h
+++ b/src/rt/sync/sync.h
@@ -1,4 +1,3 @@
-// -*- c++ -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/rt/util/array_list.h
+++ b/src/rt/util/array_list.h
@@ -1,4 +1,3 @@
-// -*- c++ -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/rt/util/hash_map.h
+++ b/src/rt/util/hash_map.h
@@ -1,4 +1,3 @@
-// -*- c++ -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/rt/util/indexed_list.h
+++ b/src/rt/util/indexed_list.h
@@ -1,4 +1,3 @@
-// -*- c++ -*-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.


### PR DESCRIPTION
r? @graydon

This adds a check that source files contain the correct license block. It introduces the `xfail-license` comment for source with unresolved licenses and a white list of files under other licenses.

For now it only inspects files that are already checked by tidy, so it doesn't catch everything, including `.S` files and tests.
