### PR TITLE
Translate const references to extern functions as *i8 instead of the typ...

### DIFF
--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -401,10 +401,13 @@ fn const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
           ast::expr_path(pth) => {
             assert pth.types.len() == 0;
             match cx.tcx.def_map.find(e.id) {
-                Some(ast::def_fn(def_id, _)) => {
+                Some(ast::def_fn(def_id, purity)) => {
                     assert ast_util::is_local(def_id);
                     let f = base::get_item_val(cx, def_id.node);
-                    C_struct(~[f, C_null(T_opaque_box_ptr(cx))])
+                    match purity {
+                      ast::extern_fn => llvm::LLVMConstPointerCast(f, T_ptr(T_i8())),
+                      _ => C_struct(~[f, C_null(T_opaque_box_ptr(cx))])
+                    }
                 }
                 Some(ast::def_const(def_id)) => {
                     get_const_val(cx, def_id)

--- a/src/test/run-pass/const-extern-function.rs
+++ b/src/test/run-pass/const-extern-function.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern fn foopy() {}
+
+const f: *u8 = foopy;
+const s: S = S { f: foopy };
+
+struct S {
+    f: *u8
+}
+
+fn main() {
+}


### PR DESCRIPTION
...ical closure pair. Fixes #4522.
