### PR TITLE
Fix the difference method on bit vectors

### DIFF
--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -59,7 +59,7 @@ impl SmallBitv {
 
     #[inline(always)]
     fn difference(s: &SmallBitv, nbits: uint) -> bool {
-        self.bits_op(s.bits, nbits, |u1, u2| u1 ^ u2)
+        self.bits_op(s.bits, nbits, |u1, u2| u1 & !u2)
     }
 
     #[inline(always)]
@@ -180,10 +180,7 @@ impl BigBitv {
 
     #[inline(always)]
     fn difference(b: &BigBitv, nbits: uint) -> bool {
-        self.invert();
-        let b = self.intersect(b, nbits);
-        self.invert();
-        b
+        self.process(b, nbits, difference)
     }
 
     #[inline(always)]
@@ -566,6 +563,8 @@ const uint_bits: uint = 32u + (1u << 32u >> 27u);
 pure fn lor(w0: uint, w1: uint) -> uint { return w0 | w1; }
 
 pure fn land(w0: uint, w1: uint) -> uint { return w0 & w1; }
+
+pure fn difference(w0: uint, w1: uint) -> uint { return w0 & !w1; }
 
 pure fn right(_w0: uint, w1: uint) -> uint { return w1; }
 
@@ -953,6 +952,34 @@ mod tests {
     fn test_to_bools() {
         let bools = ~[false, false, true, false, false, true, true, false];
         assert from_bytes([0b00100110]).to_bools() == bools;
+    }
+
+    #[test]
+    fn test_small_difference() {
+      let b1 = Bitv(3, false);
+      let b2 = Bitv(3, false);
+      b1.set(0, true);
+      b1.set(1, true);
+      b2.set(1, true);
+      b2.set(2, true);
+      assert b1.difference(&b2);
+      assert b1[0];
+      assert !b1[1];
+      assert !b1[2];
+    }
+
+    #[test]
+    fn test_big_difference() {
+      let b1 = Bitv(100, false);
+      let b2 = Bitv(100, false);
+      b1.set(0, true);
+      b1.set(40, true);
+      b2.set(40, true);
+      b2.set(80, true);
+      assert b1.difference(&b2);
+      assert b1[0];
+      assert !b1[40];
+      assert !b1[80];
     }
 }
 


### PR DESCRIPTION
I was looking into the `difference` method on the bit vector implementations, and I found that it didn't quite align with what I thought of as the difference between two sets.

For `SmallBitv`, the difference was just the xor of the two vectors, which I'm not really sure what it's supposed to represent. For `BigBitv`, it almost did the difference except that it added in lots of bits which weren't related to the two bit vectors.

I figured that the difference method should return the set-wise difference:

```
A / B = { x : x in A and x not in B }
```

so I updated both of the difference methods to do that and added some tests to do that. If this isn't right, the two implementations (SmallBitv/BigBitv) appear to do different things, so they should probably be unified to one thing anyway.
