### PR TITLE
Fix building of all rustc components with -g.

### DIFF
--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -769,27 +769,30 @@ fn create_function(fcx: fn_ctxt) -> @metadata<subprogram_md> {
       ast_map::node_item(item, _) => {
         match /*bad*/copy item.node {
           ast::item_fn(decl, _, _, _) => {
-            (item.ident, decl.output, item.id)
+            (item.ident, Some(decl.output), item.id)
           }
           _ => fcx.ccx.sess.span_bug(item.span, ~"create_function: item \
                                                   bound to non-function")
         }
       }
       ast_map::node_method(method, _, _) => {
-          (method.ident, method.decl.output, method.id)
+          (method.ident, Some(method.decl.output), method.id)
       }
       ast_map::node_expr(expr) => {
         match /*bad*/copy expr.node {
           ast::expr_fn(_, decl, _, _) => {
-            ((dbg_cx.names)(~"fn"), decl.output, expr.id)
+            ((dbg_cx.names)(~"fn"), Some(decl.output), expr.id)
           }
           ast::expr_fn_block(decl, _, _) => {
-            ((dbg_cx.names)(~"fn"), decl.output, expr.id)
+            ((dbg_cx.names)(~"fn"), Some(decl.output), expr.id)
           }
           _ => fcx.ccx.sess.span_bug(expr.span,
                                      ~"create_function: \
                                        expected an expr_fn or fn_block here")
         }
+      }
+      ast_map::node_dtor(_, _, did, _) => {
+        ((dbg_cx.names)(~"dtor"), None, did.node)
       }
       _ => fcx.ccx.sess.bug(~"create_function: unexpected \
                               sort of node")
@@ -807,7 +810,8 @@ fn create_function(fcx: fn_ctxt) -> @metadata<subprogram_md> {
 
     let loc = cx.sess.codemap.lookup_char_pos(sp.lo);
     let file_node = create_file(cx, loc.file.name).node;
-    let ty_node = if cx.sess.opts.extra_debuginfo {
+    let ty_node = if ret_ty.is_some() && cx.sess.opts.extra_debuginfo {
+        let ret_ty = ret_ty.unwrap();
         match ret_ty.node {
           ast::ty_nil => llnull(),
           _ => create_ty(cx, ty::node_id_to_type(cx.tcx, id), ret_ty).node


### PR DESCRIPTION
Similarly, building non-rustc with -g should also not ICE now. The output is also kind of useful in gdb if you're careful and don't use any macros/syntax extensions in your code.

r? @tjc
