### PR TITLE
repr: represent char values as char literals rather than integers.

### DIFF
--- a/src/libcore/repr.rs
+++ b/src/libcore/repr.rs
@@ -286,7 +286,13 @@ impl ReprVisitor : TyVisitor {
     fn visit_f32() -> bool { self.write::<f32>() }
     fn visit_f64() -> bool { self.write::<f64>() }
 
-    fn visit_char() -> bool { self.write::<u32>() }
+    fn visit_char() -> bool {
+        do self.get::<char> |&ch| {
+            self.writer.write_char('\'');
+            self.writer.write_escaped_char(ch);
+            self.writer.write_char('\'');
+        }
+    }
 
     // Type no longer exists, vestigial function.
     fn visit_str() -> bool { fail; }


### PR DESCRIPTION
Follow-up on #4473 and #4477, especially @graydon’s [comment](https://github.com/mozilla/rust/pull/4477#issuecomment-12255986).
