### PR TITLE
add a Set trait

### DIFF
--- a/src/libcore/container.rs
+++ b/src/libcore/container.rs
@@ -1,0 +1,24 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Container traits
+
+pub trait Set<T> {
+    /// Return true if the set contains a value
+    pure fn contains(&self, value: &T) -> bool;
+
+    /// Add a value to the set. Return true if the value was not already
+    /// present in the set.
+    fn insert(&mut self, value: T) -> bool;
+
+    /// Remove a value from the set. Return true if the value was
+    /// present in the set.
+    fn remove(&mut self, value: &T) -> bool;
+}

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -122,6 +122,7 @@ pub mod to_bytes;
 pub mod clone;
 pub mod io;
 pub mod hash;
+pub mod container;
 
 
 /* Common data structures */

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -14,6 +14,7 @@
 
 #[forbid(deprecated_mode)];
 
+use core::container::Set;
 use core::cmp::{Eq, Ord};
 use core::option::{Option, Some, None};
 use core::prelude::*;
@@ -197,6 +198,21 @@ impl <T: Eq Ord> TreeSet<T>: Eq {
     pure fn ne(&self, other: &TreeSet<T>) -> bool { self.map != other.map }
 }
 
+impl <T: Ord> TreeSet<T>: Set<T> {
+    /// Return true if the set contains a value
+    pure fn contains(&self, value: &T) -> bool {
+        self.map.contains_key(value)
+    }
+
+    /// Add a value to the set. Return true if the value was not already
+    /// present in the set.
+    fn insert(&mut self, value: T) -> bool { self.map.insert(value, ()) }
+
+    /// Remove a value from the set. Return true if the value was
+    /// present in the set.
+    fn remove(&mut self, value: &T) -> bool { self.map.remove(value) }
+}
+
 impl <T: Ord> TreeSet<T> {
     /// Create an empty TreeSet
     static pure fn new() -> TreeSet<T> { TreeSet{map: TreeMap::new()} }
@@ -214,19 +230,6 @@ impl <T: Ord> TreeSet<T> {
     pure fn each_reverse(&self, f: fn(&T) -> bool) {
         self.map.each_key_reverse(f)
     }
-
-    /// Return true if the set contains a value
-    pure fn contains(&self, value: &T) -> bool {
-        self.map.contains_key(value)
-    }
-
-    /// Add a value to the set. Return true if the value was not
-    /// already present in the set.
-    fn insert(&mut self, value: T) -> bool { self.map.insert(value, ()) }
-
-    /// Remove a value from the set. Return true if the value was
-    /// present in the set.
-    fn remove(&mut self, value: &T) -> bool { self.map.remove(value) }
 
     /// Get a lazy iterator over the values in the set.
     /// Requires that it be frozen (immutable).


### PR DESCRIPTION
Closes #2640, and now that `()` is zero-size it makes the most sense to just implement sets as (opaque) adaptors on top of map types.

I haven't added `map::HashSet` because that module needs a lot of work first. It doesn't use explicit self, and the mutability is all messed up (and will require a lot of porting). I think I'll just add a new Map trait to the container module and throw out most of `map` after converting everything to the new trait.
