### PR TITLE
add default Clone impl for all copyable types

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,14 +8,34 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/**
-Clonable types are copied with the clone method
-*/
+#[forbid(deprecated_mode)];
+#[forbid(deprecated_pattern)];
+
+use prelude::Copy;
+
+/// Clonable types are copied with the clone method
 pub trait Clone {
     fn clone(&self) -> self;
 }
 
-impl (): Clone {
+impl <T: Copy> T: Clone {
     #[inline(always)]
-    fn clone(&self) -> () { () }
+    fn clone(&self) -> T { copy *self }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_int() {
+        let x = 5;
+        let y = x.clone();
+        assert x == y;
+    }
+
+    #[test]
+    fn test_str() {
+        let x = ~"foo";
+        let y = x.clone();
+        assert x == y;
+    }
 }


### PR DESCRIPTION
This provides a default implementation of `Clone` for all copyable types, which allows generic code to start using `Clone` instead of `Copy`.

I don't think there will be a need to expose `Copy` outside of this module once stuff is migrated.
