### PR TITLE
Fix various doc tests

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -594,16 +594,16 @@ and may optionally begin with any number of `attributes` that apply to the conta
 Atributes on the anonymous crate module define important metadata that influences
 the behavior of the compiler.
 
-~~~~~~~~{.xfail-test}
+~~~~~~~~
 // Linkage attributes
-#[ link(name = "projx"
+#[ link(name = "projx",
         vers = "2.5",
         uuid = "9cccc5d5-aceb-4af5-8285-811211826b82") ];
 
 // Additional metadata attributes
-#[ desc = "Project X",
-   license = "BSD" ];
-   author = "Jane Doe" ];
+#[ desc = "Project X" ];
+#[ license = "BSD" ];
+#[ author = "Jane Doe" ];
 
 // Specify the output type
 #[ crate_type = "lib" ];

--- a/doc/tutorial-tasks.md
+++ b/doc/tutorial-tasks.md
@@ -220,7 +220,7 @@ let result = port.recv();
 The `Port` and `Chan` pair created by `stream` enables efficient communication
 between a single sender and a single receiver, but multiple senders cannot use
 a single `Chan`, and multiple receivers cannot use a single `Port`.  What if our
-example needed to computer multiple results across a number of tasks? The
+example needed to compute multiple results across a number of tasks? The
 following program is ill-typed:
 
 ~~~ {.xfail-test}

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2393,7 +2393,7 @@ override the name used to search for the crate.
 
 Our example crate declared this set of `link` attributes:
 
-~~~~ {.xfail-test}
+~~~~
 #[link(name = "farm", vers = "2.5", author = "mjh")];
 ~~~~
 

--- a/src/etc/extract-tests.py
+++ b/src/etc/extract-tests.py
@@ -2,11 +2,11 @@
 
 # Script for extracting compilable fragments from markdown
 # documentation. See prep.js for a description of the format
-# recognized by this tool. Expects a directory fragements/ to exist
+# recognized by this tool. Expects a directory fragments/ to exist
 # under the current directory, and writes the fragments in there as
 # individual .rs files.
 
-import sys, re;
+import sys, re
 
 if len(sys.argv) < 3:
     print("Please provide an input filename")
@@ -26,7 +26,7 @@ chapter_n = 0
 while cur < len(lines):
     line = lines[cur]
     cur += 1
-    chap = re.match("# (.*)", line);
+    chap = re.match("# (.*)", line)
     if chap:
         chapter = re.sub(r"\W", "_", chap.group(1)).lower()
         chapter_n = 1
@@ -51,14 +51,30 @@ while cur < len(lines):
             else:
                 # Lines beginning with '# ' are turned into valid code
                 line = re.sub("^# ", "", line)
-                # Allow elipses in code snippets
+                # Allow ellipses in code snippets
                 line = re.sub("\.\.\.", "", line)
                 block += line
         if not ignore:
             if not re.search(r"\bfn main\b", block):
                 block = "fn main() {\n" + block + "\n}\n"
             if not re.search(r"\bextern mod std\b", block):
-                block = "extern mod std;\n" + block;
+                block = "extern mod std;\n" + block
+            block = """#[ forbid(ctypes) ];
+#[ forbid(deprecated_mode) ];
+#[ forbid(deprecated_pattern) ];
+#[ forbid(implicit_copies) ];
+#[ forbid(non_implicitly_copyable_typarams) ];
+#[ forbid(path_statement) ];
+#[ forbid(type_limits) ];
+#[ forbid(unrecognized_lint) ];
+#[ forbid(unused_imports) ];
+#[ forbid(vecs_implicitly_copyable) ];
+#[ forbid(while_true) ];
+
+#[ warn(deprecated_self) ];
+#[ warn(non_camel_case_types) ];
+#[ warn(structural_records) ];\n
+""" + block
             if xfail:
                 block = "// xfail-test\n" + block
             filename = (dest + "/" + str(chapter)


### PR DESCRIPTION
The manual's `link` attribute example code did not compile! For new users that copy and paste example code (like I did), this is pretty frustrating. The master and 0.5 branches have the same doc bug. Since this is a small fix for a frustrating problem, you might consider cherry picking this fix to those branches.

OpenSSL's `SHA1()` function takes a `size_t`, according the Darwin and Linux header files. The FFI tutorial was inconsistently using both `uint` and `libc::c_uint`.

Enable lint warnings for doc tests. I thought this would be a good way to ensure that the docs' example code uses the latest coding style. Is the big, multi-line """ ... """ string too ugly?

For lint warnings that many doc tests fail (e.g. `deprecated_self`, `non_camel_case_types`, `structural_records`), I just enabled them as `#[ warn(...) ]` as a reminder to possibly `forbid` them in the future.

Also fix some typos and remove some semicolons (!!) from the doc test generator Python script.
