### PR TITLE
more work on container traits

### DIFF
--- a/src/libcore/container.rs
+++ b/src/libcore/container.rs
@@ -10,9 +10,35 @@
 
 //! Container traits
 
+#[forbid(deprecated_mode)];
+#[forbid(deprecated_pattern)];
+
 pub trait Mutable {
     /// Clear the container, removing all values.
     fn clear(&mut self);
+}
+
+pub trait Map<K, V>: Mutable {
+    /// Return true if the map contains a value for the specified key
+    pure fn contains_key(&self, key: &K) -> bool;
+
+    /// Visit all key-value pairs
+    pure fn each(&self, f: fn(&K, &V) -> bool);
+
+    /// Visit all keys
+    pure fn each_key(&self, f: fn(&K) -> bool);
+
+    /// Visit all values
+    pure fn each_value(&self, f: fn(&V) -> bool);
+
+    /// Insert a key-value pair into the map. An existing value for a
+    /// key is replaced by the new value. Return true if the key did
+    /// not already exist in the map.
+    fn insert(&mut self, key: K, value: V) -> bool;
+
+    /// Remove a key-value pair from the map. Return true if the key
+    /// was present in the map, otherwise false.
+    fn remove(&mut self, key: &K) -> bool;
 }
 
 pub trait Set<T>: Mutable {

--- a/src/libcore/container.rs
+++ b/src/libcore/container.rs
@@ -13,7 +13,15 @@
 #[forbid(deprecated_mode)];
 #[forbid(deprecated_pattern)];
 
-pub trait Mutable {
+pub trait Container {
+    /// Return the number of elements in the container
+    pure fn len(&self) -> uint;
+
+    /// Return true if the container contains no elements
+    pure fn is_empty(&self) -> bool;
+}
+
+pub trait Mutable: Container {
     /// Clear the container, removing all values.
     fn clear(&mut self);
 }

--- a/src/libcore/container.rs
+++ b/src/libcore/container.rs
@@ -10,7 +10,12 @@
 
 //! Container traits
 
-pub trait Set<T> {
+pub trait Mutable {
+    /// Clear the container, removing all values.
+    fn clear(&mut self);
+}
+
+pub trait Set<T>: Mutable {
     /// Return true if the set contains a value
     pure fn contains(&self, value: &T) -> bool;
 

--- a/src/libcore/send_map.rs
+++ b/src/libcore/send_map.rs
@@ -31,7 +31,6 @@ pub trait SendMap<K:Eq Hash, V: Copy> {
     fn pop(&mut self, k: &K) -> Option<V>;
     fn swap(&mut self, k: K, +v: V) -> Option<V>;
     fn consume(&mut self, f: fn(K, V));
-    fn clear(&mut self);
     pure fn len(&const self) -> uint;
     pure fn is_empty(&const self) -> bool;
     pure fn contains_key(&const self, k: &K) -> bool;
@@ -47,7 +46,7 @@ pub trait SendMap<K:Eq Hash, V: Copy> {
 /// Open addressing with linear probing.
 pub mod linear {
     use iter::BaseIter;
-    use container::Set;
+    use container::{Mutable, Set};
     use cmp::Eq;
     use cmp;
     use hash::Hash;
@@ -279,6 +278,15 @@ pub mod linear {
         }
     }
 
+    impl <K: Hash IterBytes Eq, V> LinearMap<K, V>: Mutable {
+        fn clear(&mut self) {
+            for uint::range(0, self.buckets.len()) |idx| {
+                self.buckets[idx] = None;
+            }
+            self.size = 0;
+        }
+    }
+
     impl<K:Hash IterBytes Eq,V> LinearMap<K,V> {
         fn insert(&mut self, k: K, v: V) -> bool {
             if self.size >= self.resize_at {
@@ -345,13 +353,6 @@ pub mod linear {
                     }
                 }
             }
-        }
-
-        fn clear(&mut self) {
-            for uint::range(0, self.buckets.len()) |idx| {
-                self.buckets[idx] = None;
-            }
-            self.size = 0;
         }
 
         pure fn len(&const self) -> uint {
@@ -480,6 +481,10 @@ pub mod linear {
         pure fn ne(&self, other: &LinearSet<T>) -> bool {
             self.map != other.map
         }
+    }
+
+    impl <T: Hash IterBytes Eq> LinearSet<T>: Mutable {
+        fn clear(&mut self) { self.map.clear() }
     }
 
     impl <T: Hash IterBytes Eq> LinearSet<T>: Set<T> {

--- a/src/libcore/send_map.rs
+++ b/src/libcore/send_map.rs
@@ -26,7 +26,7 @@ use to_bytes::IterBytes;
 /// Open addressing with linear probing.
 pub mod linear {
     use iter::BaseIter;
-    use container::{Mutable, Map, Set};
+    use container::{Container, Mutable, Map, Set};
     use cmp::Eq;
     use cmp;
     use hash::Hash;
@@ -258,6 +258,11 @@ pub mod linear {
         }
     }
 
+    impl <K: Hash IterBytes Eq, V> LinearMap<K, V>: Container {
+        pure fn len(&self) -> uint { self.size }
+        pure fn is_empty(&self) -> bool { self.len() == 0 }
+    }
+
     impl <K: Hash IterBytes Eq, V> LinearMap<K, V>: Mutable {
         fn clear(&mut self) {
             for uint::range(0, self.buckets.len()) |idx| {
@@ -364,14 +369,6 @@ pub mod linear {
             }
         }
 
-        pure fn len(&const self) -> uint {
-            self.size
-        }
-
-        pure fn is_empty(&const self) -> bool {
-            self.len() == 0
-        }
-
         pure fn find_ref(&self, k: &K) -> Option<&self/V> {
             match self.bucket_for_key(self.buckets, k) {
                 FoundEntry(idx) => {
@@ -464,6 +461,11 @@ pub mod linear {
         }
     }
 
+    impl <T: Hash IterBytes Eq> LinearSet<T>: Container {
+        pure fn len(&self) -> uint { self.map.len() }
+        pure fn is_empty(&self) -> bool { self.map.is_empty() }
+    }
+
     impl <T: Hash IterBytes Eq> LinearSet<T>: Mutable {
         fn clear(&mut self) { self.map.clear() }
     }
@@ -486,12 +488,6 @@ pub mod linear {
     impl <T: Hash IterBytes Eq> LinearSet<T> {
         /// Create an empty LinearSet
         static fn new() -> LinearSet<T> { LinearSet{map: LinearMap()} }
-
-        /// Return the number of elements in the set
-        pure fn len(&self) -> uint { self.map.len() }
-
-        /// Return true if the set contains no elements
-        pure fn is_empty(&self) -> bool { self.map.is_empty() }
     }
 }
 

--- a/src/libstd/priority_queue.rs
+++ b/src/libstd/priority_queue.rs
@@ -10,7 +10,7 @@
 
 //! A priority queue implemented with a binary heap
 
-use core::container::Mutable;
+use core::container::{Container, Mutable};
 use core::cmp::Ord;
 use core::prelude::*;
 use core::ptr::addr_of;
@@ -23,6 +23,14 @@ extern "C" mod rusti {
 
 pub struct PriorityQueue <T: Ord>{
     priv data: ~[T],
+}
+
+impl <T: Ord> PriorityQueue<T>: Container {
+    /// Returns the length of the queue
+    pure fn len(&self) -> uint { self.data.len() }
+
+    /// Returns true if a queue contains no elements
+    pure fn is_empty(&self) -> bool { self.data.is_empty() }
 }
 
 impl <T: Ord> PriorityQueue<T>: Mutable {
@@ -38,12 +46,6 @@ impl <T: Ord> PriorityQueue<T> {
     pure fn maybe_top(&self) -> Option<&self/T> {
         if self.is_empty() { None } else { Some(self.top()) }
     }
-
-    /// Returns the length of the queue
-    pure fn len(&self) -> uint { self.data.len() }
-
-    /// Returns true if a queue contains no elements
-    pure fn is_empty(&self) -> bool { self.data.is_empty() }
 
     /// Returns true if a queue contains some elements
     pure fn is_not_empty(&self) -> bool { self.data.is_not_empty() }

--- a/src/libstd/priority_queue.rs
+++ b/src/libstd/priority_queue.rs
@@ -10,6 +10,7 @@
 
 //! A priority queue implemented with a binary heap
 
+use core::container::Mutable;
 use core::cmp::Ord;
 use core::prelude::*;
 use core::ptr::addr_of;
@@ -22,6 +23,11 @@ extern "C" mod rusti {
 
 pub struct PriorityQueue <T: Ord>{
     priv data: ~[T],
+}
+
+impl <T: Ord> PriorityQueue<T>: Mutable {
+    /// Drop all items from the queue
+    fn clear(&mut self) { self.data.truncate(0) }
 }
 
 impl <T: Ord> PriorityQueue<T> {
@@ -50,9 +56,6 @@ impl <T: Ord> PriorityQueue<T> {
     fn reserve_at_least(&mut self, n: uint) {
         vec::reserve_at_least(&mut self.data, n)
     }
-
-    /// Drop all items from the queue
-    fn clear(&mut self) { self.data.truncate(0) }
 
     /// Pop the greatest item from the queue - fails if empty
     fn pop(&mut self) -> T {

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -14,7 +14,7 @@
 
 #[forbid(deprecated_mode)];
 
-use core::container::{Mutable, Set};
+use core::container::{Mutable, Map, Set};
 use core::cmp::{Eq, Ord};
 use core::option::{Option, Some, None};
 use core::prelude::*;
@@ -75,6 +75,39 @@ impl <K: Ord, V> TreeMap<K, V>: Mutable {
     }
 }
 
+impl <K: Ord, V> TreeMap<K, V>: Map<K, V> {
+    /// Return true if the map contains a value for the specified key
+    pure fn contains_key(&self, key: &K) -> bool {
+        self.find(key).is_some()
+    }
+
+    /// Visit all key-value pairs in order
+    pure fn each(&self, f: fn(&K, &V) -> bool) { each(&self.root, f) }
+
+    /// Visit all keys in order
+    pure fn each_key(&self, f: fn(&K) -> bool) { self.each(|k, _| f(k)) }
+
+    /// Visit all values in order
+    pure fn each_value(&self, f: fn(&V) -> bool) { self.each(|_, v| f(v)) }
+
+    /// Insert a key-value pair into the map. An existing value for a
+    /// key is replaced by the new value. Return true if the key did
+    /// not already exist in the map.
+    fn insert(&mut self, key: K, value: V) -> bool {
+        let ret = insert(&mut self.root, key, value);
+        if ret { self.length += 1 }
+        ret
+    }
+
+    /// Remove a key-value pair from the map. Return true if the key
+    /// was present in the map, otherwise false.
+    fn remove(&mut self, key: &K) -> bool {
+        let ret = remove(&mut self.root, key);
+        if ret { self.length -= 1 }
+        ret
+    }
+}
+
 impl <K: Ord, V> TreeMap<K, V> {
     /// Create an empty TreeMap
     static pure fn new() -> TreeMap<K, V> { TreeMap{root: None, length: 0} }
@@ -87,15 +120,6 @@ impl <K: Ord, V> TreeMap<K, V> {
 
     /// Return true if the map contains some elements
     pure fn is_not_empty(&self) -> bool { self.root.is_some() }
-
-    /// Visit all key-value pairs in order
-    pure fn each(&self, f: fn(&K, &V) -> bool) { each(&self.root, f) }
-
-    /// Visit all keys in order
-    pure fn each_key(&self, f: fn(&K) -> bool) { self.each(|k, _| f(k)) }
-
-    /// Visit all values in order
-    pure fn each_value(&self, f: fn(&V) -> bool) { self.each(|_, v| f(v)) }
 
     /// Visit all key-value pairs in reverse order
     pure fn each_reverse(&self, f: fn(&K, &V) -> bool) {
@@ -110,11 +134,6 @@ impl <K: Ord, V> TreeMap<K, V> {
     /// Visit all values in reverse order
     pure fn each_value_reverse(&self, f: fn(&V) -> bool) {
         self.each_reverse(|_, v| f(v))
-    }
-
-    /// Return true if the map contains a value for the specified key
-    pure fn contains_key(&self, key: &K) -> bool {
-        self.find(key).is_some()
     }
 
     /// Return the value corresponding to the key in the map
@@ -135,23 +154,6 @@ impl <K: Ord, V> TreeMap<K, V> {
               None => return None
             }
         }
-    }
-
-    /// Insert a key-value pair into the map. An existing value for a
-    /// key is replaced by the new value. Return true if the key did
-    /// not already exist in the map.
-    fn insert(&mut self, key: K, value: V) -> bool {
-        let ret = insert(&mut self.root, key, value);
-        if ret { self.length += 1 }
-        ret
-    }
-
-    /// Remove a key-value pair from the map. Return true if the key
-    /// was present in the map, otherwise false.
-    fn remove(&mut self, key: &K) -> bool {
-        let ret = remove(&mut self.root, key);
-        if ret { self.length -= 1 }
-        ret
     }
 
     /// Get a lazy iterator over the key-value pairs in the map.

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -14,7 +14,7 @@
 
 #[forbid(deprecated_mode)];
 
-use core::container::{Mutable, Map, Set};
+use core::container::{Container, Mutable, Map, Set};
 use core::cmp::{Eq, Ord};
 use core::option::{Option, Some, None};
 use core::prelude::*;
@@ -67,6 +67,14 @@ impl <K: Eq Ord, V: Eq> TreeMap<K, V>: Eq {
     pure fn ne(&self, other: &TreeMap<K, V>) -> bool { !self.eq(other) }
 }
 
+impl <K: Ord, V> TreeMap<K, V>: Container {
+    /// Return the number of elements in the map
+    pure fn len(&self) -> uint { self.length }
+
+    /// Return true if the map contains no elements
+    pure fn is_empty(&self) -> bool { self.root.is_none() }
+}
+
 impl <K: Ord, V> TreeMap<K, V>: Mutable {
     /// Clear the map, removing all key-value pairs.
     fn clear(&mut self) {
@@ -111,12 +119,6 @@ impl <K: Ord, V> TreeMap<K, V>: Map<K, V> {
 impl <K: Ord, V> TreeMap<K, V> {
     /// Create an empty TreeMap
     static pure fn new() -> TreeMap<K, V> { TreeMap{root: None, length: 0} }
-
-    /// Return the number of elements in the map
-    pure fn len(&self) -> uint { self.length }
-
-    /// Return true if the map contains no elements
-    pure fn is_empty(&self) -> bool { self.root.is_none() }
 
     /// Return true if the map contains some elements
     pure fn is_not_empty(&self) -> bool { self.root.is_some() }
@@ -206,6 +208,14 @@ impl <T: Eq Ord> TreeSet<T>: Eq {
     pure fn ne(&self, other: &TreeSet<T>) -> bool { self.map != other.map }
 }
 
+impl <T: Ord> TreeSet<T>: Container {
+    /// Return the number of elements in the map
+    pure fn len(&self) -> uint { self.map.len() }
+
+    /// Return true if the map contains no elements
+    pure fn is_empty(&self) -> bool { self.map.is_empty() }
+}
+
 impl <T: Ord> TreeSet<T>: Mutable {
     /// Clear the set, removing all values.
     fn clear(&mut self) { self.map.clear() }
@@ -229,12 +239,6 @@ impl <T: Ord> TreeSet<T>: Set<T> {
 impl <T: Ord> TreeSet<T> {
     /// Create an empty TreeSet
     static pure fn new() -> TreeSet<T> { TreeSet{map: TreeMap::new()} }
-
-    /// Return the number of elements in the set
-    pure fn len(&self) -> uint { self.map.len() }
-
-    /// Return true if the set contains no elements
-    pure fn is_empty(&self) -> bool { self.map.is_empty() }
 
     /// Return true if the set contains some elements
     pure fn is_not_empty(&self) -> bool { self.map.is_not_empty() }

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -64,9 +64,7 @@ impl <K: Eq Ord, V: Eq> TreeMap<K, V>: Eq {
             true
         }
     }
-    pure fn ne(&self, other: &TreeMap<K, V>) -> bool {
-        !self.eq(other)
-    }
+    pure fn ne(&self, other: &TreeMap<K, V>) -> bool { !self.eq(other) }
 }
 
 impl <K: Ord, V> TreeMap<K, V> {

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -14,7 +14,7 @@
 
 #[forbid(deprecated_mode)];
 
-use core::container::Set;
+use core::container::{Mutable, Set};
 use core::cmp::{Eq, Ord};
 use core::option::{Option, Some, None};
 use core::prelude::*;
@@ -65,6 +65,14 @@ impl <K: Eq Ord, V: Eq> TreeMap<K, V>: Eq {
         }
     }
     pure fn ne(&self, other: &TreeMap<K, V>) -> bool { !self.eq(other) }
+}
+
+impl <K: Ord, V> TreeMap<K, V>: Mutable {
+    /// Clear the map, removing all key-value pairs.
+    fn clear(&mut self) {
+        self.root = None;
+        self.length = 0
+    }
 }
 
 impl <K: Ord, V> TreeMap<K, V> {
@@ -194,6 +202,11 @@ impl <T: Ord> TreeSet<T>: iter::BaseIter<T> {
 impl <T: Eq Ord> TreeSet<T>: Eq {
     pure fn eq(&self, other: &TreeSet<T>) -> bool { self.map == other.map }
     pure fn ne(&self, other: &TreeSet<T>) -> bool { self.map != other.map }
+}
+
+impl <T: Ord> TreeSet<T>: Mutable {
+    /// Clear the set, removing all values.
+    fn clear(&mut self) { self.map.clear() }
 }
 
 impl <T: Ord> TreeSet<T>: Set<T> {
@@ -625,6 +638,20 @@ mod test_treemap {
     }
 
     #[test]
+    fn test_clear() {
+        let mut m = TreeMap::new();
+        m.clear();
+        assert m.insert(5, 11);
+        assert m.insert(12, -3);
+        assert m.insert(19, 2);
+        m.clear();
+        assert m.find(&5).is_none();
+        assert m.find(&12).is_none();
+        assert m.find(&19).is_none();
+        assert m.is_empty();
+    }
+
+    #[test]
     fn u8_map() {
         let mut m = TreeMap::new();
 
@@ -843,6 +870,20 @@ mod test_treemap {
 #[cfg(test)]
 mod test_set {
     use super::*;
+
+    #[test]
+    fn test_clear() {
+        let mut s = TreeSet::new();
+        s.clear();
+        assert s.insert(5);
+        assert s.insert(12);
+        assert s.insert(19);
+        s.clear();
+        assert !s.contains(&5);
+        assert !s.contains(&12);
+        assert !s.contains(&19);
+        assert s.is_empty();
+    }
 
     #[test]
     fn test_disjoint() {


### PR DESCRIPTION
This expands the container module from just `Set` to the following:

`Container` -> `Mutable` -> {`Map`, `Set`}

The `Map` trait is implemented by `TreeMap` and `LinearMap` to replace to never implemented `SendMap` trait. It's incomplete at the moment (missing `find` for now - need to break `LinearMap`'s API and update users of it) and `TreeMap` will need to be extended to support `pop`, `get` and `consume` to get rid of the `LinearMap` anonymous implementation. I think I'll drop the current `find` and `get` on `LinearMap` because they don't offer anything over doing the copy in the caller.

Currently causes a segfault in stage1... not sure what to do about that (core.rc and std.rc compile okay with rustc from incoming).
