### PR TITLE
Simplify path_entry's closure argument

### DIFF
--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -88,7 +88,7 @@ fn each_lang_item(cstore: cstore::CStore,
 
 /// Iterates over all the paths in the given crate.
 fn each_path(cstore: cstore::CStore, cnum: ast::crate_num,
-             f: fn(decoder::path_entry) -> bool) {
+             f: fn(&str, decoder::def_like) -> bool) {
     let crate_data = cstore::get_crate_data(cstore, cnum);
     let get_crate_data: decoder::GetCrateDataCb = |cnum| {
         cstore::get_crate_data(cstore, cnum)

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1808,14 +1808,13 @@ impl Resolver {
 
         // Create all the items reachable by paths.
         for each_path(self.session.cstore, root.def_id.get().crate)
-                |path_entry| {
+                |path_string, def_like| {
 
             debug!("(building reduced graph for external crate) found path \
                         entry: %s (%?)",
-                    path_entry.path_string,
-                    path_entry.def_like);
+                    path_string, def_like);
 
-            let mut pieces = split_str(path_entry.path_string, ~"::");
+            let mut pieces = split_str(path_string, ~"::");
             let final_ident_str = pieces.pop();
             let final_ident = self.session.ident_of(final_ident_str);
 
@@ -1867,7 +1866,7 @@ impl Resolver {
                 current_module = (*child_name_bindings).get_module();
             }
 
-            match path_entry.def_like {
+            match def_like {
                 dl_def(def) => {
                     // Add the new child item.
                     let (child_name_bindings, new_parent) =

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -931,8 +931,8 @@ impl CoherenceChecker {
                                       def_id { crate: crate_number,
                                                node: 0 });
 
-            for each_path(crate_store, crate_number) |path_entry| {
-                match path_entry.def_like {
+            for each_path(crate_store, crate_number) |_p, def_like| {
+                match def_like {
                     dl_def(def_mod(def_id)) => {
                         self.add_impls_for_module(impls_seen,
                                                   crate_store,


### PR DESCRIPTION
r? @pcwalton Make the closure take two arguments instead of a single `path_entry`
struct; remove the `path_entry` type. This eliminates a bad copy.
