### PR TITLE
core: Rename to_mut and from_mut to cast_to_mut and cast_from_mut

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -273,7 +273,7 @@ fn check_expected_errors(expected_errors: ~[errors::expected_error],
                          procres: procres) {
 
     // true if we found the error in question
-    let found_flags = vec::to_mut(vec::from_elem(
+    let found_flags = vec::cast_to_mut(vec::from_elem(
         vec::len(expected_errors), false));
 
     if procres.status == 0 {

--- a/src/libcore/dvec.rs
+++ b/src/libcore/dvec.rs
@@ -145,7 +145,7 @@ impl<A> DVec<A> {
     #[inline(always)]
     fn swap_mut(f: &fn(v: ~[mut A]) -> ~[mut A]) {
         do self.swap |v| {
-            vec::from_mut(f(vec::to_mut(move v)))
+            vec::cast_from_mut(f(vec::cast_to_mut(move v)))
         }
     }
 

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -84,7 +84,7 @@ pub fn as_c_charp<T>(s: &str, f: fn(*c_char) -> T) -> T {
 
 pub fn fill_charp_buf(f: fn(*mut c_char, size_t) -> bool)
     -> Option<~str> {
-    let buf = vec::to_mut(vec::from_elem(tmpbuf_sz, 0u8 as c_char));
+    let buf = vec::cast_to_mut(vec::from_elem(tmpbuf_sz, 0u8 as c_char));
     do vec::as_mut_buf(buf) |b, sz| {
         if f(b, sz as size_t) unsafe {
             Some(str::raw::from_buf(b as *u8))
@@ -111,7 +111,7 @@ pub mod win32 {
             let mut res = None;
             let mut done = false;
             while !done {
-                let buf = vec::to_mut(vec::from_elem(n as uint, 0u16));
+                let buf = vec::cast_to_mut(vec::from_elem(n as uint, 0u16));
                 do vec::as_mut_buf(buf) |b, _sz| {
                     let k : DWORD = f(b, tmpbuf_sz as DWORD);
                     if k == (0 as DWORD) {
@@ -1269,7 +1269,7 @@ mod tests {
           };
           assert (ostream as uint != 0u);
           let s = ~"hello";
-          let mut buf = vec::to_mut(str::to_bytes(s) + ~[0 as u8]);
+          let mut buf = vec::cast_to_mut(str::to_bytes(s) + ~[0 as u8]);
           do vec::as_mut_buf(buf) |b, _len| {
               assert (libc::fwrite(b as *c_void, 1u as size_t,
                                    (str::len(s) + 1u) as size_t, ostream)

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -209,12 +209,12 @@ pub pure fn build_sized_opt<A>(size: Option<uint>,
 }
 
 /// Produces a mut vector from an immutable vector.
-pub pure fn to_mut<T>(v: ~[T]) -> ~[mut T] {
+pub pure fn cast_to_mut<T>(v: ~[T]) -> ~[mut T] {
     unsafe { ::cast::transmute(v) }
 }
 
 /// Produces an immutable vector from a mut vector.
-pub pure fn from_mut<T>(v: ~[mut T]) -> ~[T] {
+pub pure fn cast_from_mut<T>(v: ~[mut T]) -> ~[T] {
     unsafe { ::cast::transmute(v) }
 }
 
@@ -552,7 +552,7 @@ pub fn consume<T>(v: ~[T], f: fn(uint, v: T)) unsafe {
 }
 
 pub fn consume_mut<T>(v: ~[mut T], f: fn(uint, v: T)) {
-    consume(vec::from_mut(v), f)
+    consume(vec::cast_from_mut(v), f)
 }
 
 /// Remove the last element from a vector and return it
@@ -718,7 +718,7 @@ pub pure fn append_one<T>(lhs: ~[T], x: T) -> ~[T] {
 
 #[inline(always)]
 pub pure fn append_mut<T: Copy>(lhs: ~[mut T], rhs: &[const T]) -> ~[mut T] {
-    to_mut(append(from_mut(lhs), rhs))
+    cast_to_mut(append(cast_from_mut(lhs), rhs))
 }
 
 /**
@@ -3271,22 +3271,22 @@ mod tests {
     }
 
     #[test]
-    fn to_mut_no_copy() {
+    fn cast_to_mut_no_copy() {
         unsafe {
             let x = ~[1, 2, 3];
             let addr = raw::to_ptr(x);
-            let x_mut = to_mut(x);
+            let x_mut = cast_to_mut(x);
             let addr_mut = raw::to_ptr(x_mut);
             assert addr == addr_mut;
         }
     }
 
     #[test]
-    fn from_mut_no_copy() {
+    fn cast_from_mut_no_copy() {
         unsafe {
             let x = ~[mut 1, 2, 3];
             let addr = raw::to_ptr(x);
-            let x_imm = from_mut(x);
+            let x_imm = cast_from_mut(x);
             let addr_imm = raw::to_ptr(x_imm);
             assert addr == addr_imm;
         }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -661,11 +661,11 @@ fn Liveness(ir: @IrMaps, specials: Specials) -> Liveness {
         tcx: ir.tcx,
         s: specials,
         successors:
-            vec::to_mut(
+            vec::cast_to_mut(
                 vec::from_elem(ir.num_live_nodes,
                                invalid_node())),
         users:
-            vec::to_mut(
+            vec::cast_to_mut(
                 vec::from_elem(ir.num_live_nodes * ir.num_vars,
                                invalid_users())),
         loop_scope: DVec(),

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -985,7 +985,7 @@ fn pick_col(m: &[@Match]) -> uint {
           _ => 0u
         }
     }
-    let scores = vec::to_mut(vec::from_elem(m[0].pats.len(), 0u));
+    let scores = vec::cast_to_mut(vec::from_elem(m[0].pats.len(), 0u));
     for vec::each(m) |br| {
         let mut i = 0u;
         for vec::each(br.pats) |p| { scores[i] += score(*p); i += 1u; }

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -297,14 +297,14 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
     }
 
     let words = (ty_size(ty) + 7) / 8;
-    let cls = vec::to_mut(vec::from_elem(words, no_class));
+    let cls = vec::cast_to_mut(vec::from_elem(words, no_class));
     if words > 4 {
         all_mem(cls);
-        return vec::from_mut(move cls);
+        return vec::cast_from_mut(move cls);
     }
     classify(ty, cls, 0, 0);
     fixup(ty, cls);
-    return vec::from_mut(move cls);
+    return vec::cast_from_mut(move cls);
 }
 
 fn llreg_ty(cls: &[x86_64_reg_class]) -> TypeRef {

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -68,7 +68,7 @@ fn type_uses_for(ccx: @crate_ctxt, fn_id: def_id, n_tps: uint)
     // Conservatively assume full use for recursive loops
     ccx.type_use_cache.insert(fn_id, vec::from_elem(n_tps, 3u));
 
-    let cx = {ccx: ccx, uses: vec::to_mut(vec::from_elem(n_tps, 0u))};
+    let cx = {ccx: ccx, uses: vec::cast_to_mut(vec::from_elem(n_tps, 0u))};
     match ty::get(ty::lookup_item_type(cx.ccx.tcx, fn_id).ty).sty {
         ty::ty_fn(ref fn_ty) => {
             for vec::each(fn_ty.sig.inputs) |arg| {
@@ -84,7 +84,7 @@ fn type_uses_for(ccx: @crate_ctxt, fn_id: def_id, n_tps: uint)
     }
 
     if fn_id_loc.crate != local_crate {
-        let uses = vec::from_mut(copy cx.uses);
+        let uses = vec::cast_from_mut(copy cx.uses);
         ccx.type_use_cache.insert(fn_id, copy uses);
         return uses;
     }
@@ -167,7 +167,7 @@ fn type_uses_for(ccx: @crate_ctxt, fn_id: def_id, n_tps: uint)
                                 ccx.tcx.sess.parse_sess.interner)));
       }
     }
-    let uses = vec::from_mut(copy cx.uses);
+    let uses = vec::cast_from_mut(copy cx.uses);
     // XXX: Bad copy, use @vec instead?
     ccx.type_use_cache.insert(fn_id, copy uses);
     uses

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3024,7 +3024,7 @@ fn check_bounds_are_used(ccx: @crate_ctxt,
 
     // make a vector of booleans initially false, set to true when used
     if tps.len() == 0u { return; }
-    let tps_used = vec::to_mut(vec::from_elem(tps.len(), false));
+    let tps_used = vec::cast_to_mut(vec::from_elem(tps.len(), false));
 
     ty::walk_regions_and_ty(
         ccx.tcx, ty,

--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -13,7 +13,7 @@
 use core::ops;
 use core::prelude::*;
 use core::uint;
-use core::vec::{to_mut, from_elem};
+use core::vec::{cast_to_mut, from_elem};
 use core::vec;
 
 struct SmallBitv {
@@ -231,7 +231,7 @@ pub fn Bitv (nbits: uint, init: bool) -> Bitv {
         let nelems = nbits/uint_bits +
                      if nbits % uint_bits == 0 {0} else {1};
         let elem = if init {!0} else {0};
-        let s = to_mut(from_elem(nelems, elem));
+        let s = cast_to_mut(from_elem(nelems, elem));
         Big(~BigBitv(move s))
     };
     Bitv {rep: move rep, nbits: nbits}
@@ -516,7 +516,7 @@ impl Bitv: Clone {
             Bitv{nbits: self.nbits, rep: Small(~SmallBitv{bits: b.bits})}
           }
           Big(ref b) => {
-            let st = to_mut(from_elem(self.nbits / uint_bits + 1, 0));
+            let st = cast_to_mut(from_elem(self.nbits / uint_bits + 1, 0));
             let len = st.len();
             for uint::range(0, len) |i| { st[i] = b.storage[i]; };
             Bitv{nbits: self.nbits, rep: Big(~BigBitv{storage: move st})}

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -222,7 +222,7 @@ pub type Result = result::Result<Matches, Fail_>;
 pub fn getopts(args: &[~str], opts: &[Opt]) -> Result unsafe {
     let n_opts = opts.len();
     fn f(_x: uint) -> ~[Optval] { return ~[]; }
-    let vals = vec::to_mut(vec::from_fn(n_opts, f));
+    let vals = vec::cast_to_mut(vec::from_fn(n_opts, f));
     let mut free: ~[~str] = ~[];
     let l = args.len();
     let mut i = 0;
@@ -337,7 +337,7 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result unsafe {
         i += 1;
     }
     return Ok(Matches {opts: vec::from_slice(opts),
-               vals: vec::from_mut(move vals),
+               vals: vec::cast_from_mut(move vals),
                free: free});
 }
 

--- a/src/libstd/map.rs
+++ b/src/libstd/map.rs
@@ -450,7 +450,7 @@ pub mod chained {
     }
 
     fn chains<K,V>(nchains: uint) -> ~[mut Option<@Entry<K,V>>] {
-        vec::to_mut(vec::from_elem(nchains, None))
+        vec::cast_to_mut(vec::from_elem(nchains, None))
     }
 
     pub fn mk<K:Eq IterBytes Hash, V: Copy>() -> T<K,V> {

--- a/src/libstd/md4.rs
+++ b/src/libstd/md4.rs
@@ -47,7 +47,7 @@ pub pure fn md4(msg: &[u8]) -> {a: u32, b: u32, c: u32, d: u32} {
 
     let mut i = 0u;
     let e = vec::len(msg);
-    let x = vec::to_mut(vec::from_elem(16u, 0u32));
+    let x = vec::cast_to_mut(vec::from_elem(16u, 0u32));
     while i < e {
         let aa = a, bb = b, cc = c, dd = d;
 

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -176,7 +176,7 @@ pub fn concat(v: ~[Rope]) -> Rope {
     //Copy `v` into a mut vector
     let mut len = vec::len(v);
     if len == 0u { return node::Empty; }
-    let ropes = vec::to_mut(vec::from_elem(len, v[0]));
+    let ropes = vec::cast_to_mut(vec::from_elem(len, v[0]));
     for uint::range(1u, len) |i| {
        ropes[i] = v[i];
     }
@@ -720,7 +720,7 @@ pub mod node {
             //Firstly, split `str` in slices of hint_max_leaf_char_len
             let mut leaves = uint::div_ceil(char_len, hint_max_leaf_char_len);
             //Number of leaves
-            let nodes  = vec::to_mut(vec::from_elem(leaves, candidate));
+            let nodes  = vec::cast_to_mut(vec::from_elem(leaves, candidate));
 
             let mut i = 0u;
             let mut offset = byte_start;
@@ -832,7 +832,7 @@ pub mod node {
     }
 
     pub fn serialize_node(node: @Node) -> ~str unsafe {
-        let mut buf = vec::to_mut(vec::from_elem(byte_len(node), 0u8));
+        let mut buf = vec::cast_to_mut(vec::from_elem(byte_len(node), 0u8));
         let mut offset = 0u;//Current position in the buffer
         let it = leaf_iterator::start(node);
         loop {
@@ -1158,7 +1158,8 @@ pub mod node {
         }
 
         pub fn start(node: @Node) -> T {
-            let stack = vec::to_mut(vec::from_elem(height(node)+1u, node));
+            let stack = vec::cast_to_mut(
+                vec::from_elem(height(node)+1u, node));
             return {
                 stack:         move stack,
                 mut stackpos:  0

--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -259,13 +259,13 @@ pub fn sha1() -> Sha1 {
         }
     }
     let st = {
-        h: vec::to_mut(vec::from_elem(digest_buf_len, 0u32)),
+        h: vec::cast_to_mut(vec::from_elem(digest_buf_len, 0u32)),
         mut len_low: 0u32,
         mut len_high: 0u32,
-        msg_block: vec::to_mut(vec::from_elem(msg_block_len, 0u8)),
+        msg_block: vec::cast_to_mut(vec::from_elem(msg_block_len, 0u8)),
         mut msg_block_idx: 0u,
         mut computed: false,
-        work_buf: @vec::to_mut(vec::from_elem(work_buf_len, 0u32))
+        work_buf: @vec::cast_to_mut(vec::from_elem(work_buf_len, 0u32))
     };
     let sh = (move st) as Sha1;
     sh.reset();

--- a/src/libstd/sort.rs
+++ b/src/libstd/sort.rs
@@ -457,7 +457,7 @@ impl<T: Copy Ord> MergeState<T> {
                 base2: uint, len2: uint) {
         assert len1 != 0 && len2 != 0 && base1+len1 == base2;
 
-        let tmp = vec::to_mut(vec::slice(array, base1, base1+len1));
+        let tmp = vec::cast_to_mut(vec::slice(array, base1, base1+len1));
 
         let mut c1 = 0;
         let mut c2 = base2;
@@ -560,7 +560,7 @@ impl<T: Copy Ord> MergeState<T> {
                 base2: uint, len2: uint) {
         assert len1 != 1 && len2 != 0 && base1 + len1 == base2;
 
-        let tmp = vec::to_mut(vec::slice(array, base2, base2+len2));
+        let tmp = vec::cast_to_mut(vec::slice(array, base2, base2+len2));
 
         let mut c1 = base1 + len1 - 1;
         let mut c2 = len2 - 1;
@@ -816,7 +816,7 @@ mod test_qsort {
 
         do quick_sort(names) |x, y| { int::le(*x, *y) };
 
-        let immut_names = vec::from_mut(move names);
+        let immut_names = vec::cast_from_mut(move names);
 
         let pairs = vec::zip_slice(expected, immut_names);
         for vec::each(pairs) |p| {
@@ -1025,7 +1025,7 @@ mod big_tests {
         let res = do vec::from_fn(num) |i| {
             arr[i % size]
         };
-        vec::to_mut(move res)
+        vec::cast_to_mut(move res)
     }
 
     fn makeRange(n: uint) -> ~[uint] {
@@ -1051,7 +1051,7 @@ mod big_tests {
             let arr = do vec::from_fn(n) |_i| {
                 rng.gen_float()
             };
-            let arr = vec::to_mut(move arr);
+            let arr = vec::cast_to_mut(move arr);
 
             tim_sort(arr); // *sort
             isSorted(arr);
@@ -1123,7 +1123,7 @@ mod big_tests {
             let arr = do vec::from_fn(n) |_i| {
                 @rng.gen_float()
             };
-            let arr = vec::to_mut(move arr);
+            let arr = vec::cast_to_mut(move arr);
 
             tim_sort(arr); // *sort
             isSorted(arr);

--- a/src/libstd/sync.rs
+++ b/src/libstd/sync.rs
@@ -97,7 +97,7 @@ fn new_sem_and_signal(count: int, num_condvars: uint)
     for num_condvars.times {
         queues.push(new_waitqueue());
     }
-    new_sem(count, vec::to_mut(move queues))
+    new_sem(count, vec::cast_to_mut(move queues))
 }
 
 #[doc(hidden)]

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -304,9 +304,9 @@ fn sort_meta_items(+items: ~[@ast::meta_item]) -> ~[@ast::meta_item] {
     }
 
     // This is sort of stupid here, converting to a vec of mutables and back
-    let v: ~[mut @ast::meta_item] = vec::to_mut(items);
+    let v: ~[mut @ast::meta_item] = vec::cast_to_mut(items);
     std::sort::quick_sort(v, lteq);
-    vec::from_mut(move v)
+    vec::cast_from_mut(move v)
 }
 
 fn remove_meta_items_by_name(items: ~[@ast::meta_item], name: ~str) ->

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -142,9 +142,9 @@ fn mk_printer(out: io::Writer, linewidth: uint) -> printer {
     // fall behind.
     let n: uint = 3 * linewidth;
     debug!("mk_printer %u", linewidth);
-    let token: ~[mut token] = vec::to_mut(vec::from_elem(n, EOF));
-    let size: ~[mut int] = vec::to_mut(vec::from_elem(n, 0));
-    let scan_stack: ~[mut uint] = vec::to_mut(vec::from_elem(n, 0u));
+    let token: ~[mut token] = vec::cast_to_mut(vec::from_elem(n, EOF));
+    let size: ~[mut int] = vec::cast_to_mut(vec::from_elem(n, 0));
+    let scan_stack: ~[mut uint] = vec::cast_to_mut(vec::from_elem(n, 0u));
     printer_(@{out: out,
                buf_len: n,
                mut margin: linewidth as int,

--- a/src/test/bench/graph500-bfs.rs
+++ b/src/test/bench/graph500-bfs.rs
@@ -122,7 +122,7 @@ fn gen_search_keys(graph: graph, n: uint) -> ~[node_id] {
  */
 fn bfs(graph: graph, key: node_id) -> bfs_result {
     let marks : ~[mut node_id] 
-        = vec::to_mut(vec::from_elem(vec::len(graph), -1i64));
+        = vec::cast_to_mut(vec::from_elem(vec::len(graph), -1i64));
 
     let Q = deque::create();
 
@@ -141,7 +141,7 @@ fn bfs(graph: graph, key: node_id) -> bfs_result {
         };
     }
 
-    vec::from_mut(move marks)
+    vec::cast_from_mut(move marks)
 }
 
 /**

--- a/src/test/bench/shootout-fannkuchredux.rs
+++ b/src/test/bench/shootout-fannkuchredux.rs
@@ -14,9 +14,9 @@ extern mod std;
 fn fannkuch(n: int) -> int {
     fn perm1init(i: uint) -> int { return i as int; }
 
-    let perm = vec::to_mut(vec::from_elem(n as uint, 0));
-    let perm1 = vec::to_mut(vec::from_fn(n as uint, |i| perm1init(i)));
-    let count = vec::to_mut(vec::from_elem(n as uint, 0));
+    let perm = vec::cast_to_mut(vec::from_elem(n as uint, 0));
+    let perm1 = vec::cast_to_mut(vec::from_fn(n as uint, |i| perm1init(i)));
+    let count = vec::cast_to_mut(vec::from_elem(n as uint, 0));
     let mut f = 0;
     let mut i = 0;
     let mut k = 0;

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -151,7 +151,7 @@ fn main() {
    // initialize each sequence sorter
    let sizes = ~[1,2,3,4,6,12,18];
     let streams = vec::map(sizes, |_sz| Some(stream()));
-    let streams = vec::to_mut(move streams);
+    let streams = vec::cast_to_mut(move streams);
     let mut from_child = ~[];
     let to_child   = vec::mapi(sizes, |ii, sz| {
         let sz = *sz;

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -45,7 +45,7 @@ fn eval_At_times_u(u: &[const float], Au: &[mut float]) {
 }
 
 fn eval_AtA_times_u(u: &[const float], AtAu: &[mut float]) {
-    let v = vec::to_mut(vec::from_elem(vec::len(u), 0.0));
+    let v = vec::cast_to_mut(vec::from_elem(vec::len(u), 0.0));
     eval_A_times_u(u, v);
     eval_At_times_u(v, AtAu);
 }
@@ -62,8 +62,8 @@ fn main() {
 
     let N = uint::from_str(args[1]).get();
 
-    let u = vec::to_mut(vec::from_elem(N, 1.0));
-    let v = vec::to_mut(vec::from_elem(N, 0.0));
+    let u = vec::cast_to_mut(vec::from_elem(N, 1.0));
+    let v = vec::cast_to_mut(vec::from_elem(N, 0.0));
     let mut i = 0u;
     while i < 10u {
         eval_AtA_times_u(u, v);

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -42,7 +42,7 @@ fn read_grid(f: io::Reader) -> grid_t {
     assert f.read_line() == ~"9,9"; /* assert first line is exactly "9,9" */
 
     let g = vec::from_fn(10u, {|_i|
-        vec::to_mut(vec::from_elem(10u, 0 as u8))
+        vec::cast_to_mut(vec::from_elem(10u, 0 as u8))
     });
     while !f.eof() {
         let comps = str::split_char(str::trim(f.read_line()), ',');
@@ -142,7 +142,7 @@ fn main() {
         // FIXME create sudoku inline since nested vec consts dont work yet
         // (#3733)
         let g = vec::from_fn(10u, |_i| {
-            vec::to_mut(vec::from_elem(10u, 0 as u8))
+            vec::cast_to_mut(vec::from_elem(10u, 0 as u8))
         });
         g[0][1] = 4u8;
         g[0][3] = 6u8;

--- a/src/test/run-pass/import-in-block.rs
+++ b/src/test/run-pass/import-in-block.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 fn main() {
-    use vec::to_mut;
-    log(debug, vec::len(to_mut(~[1, 2])));
+    use vec::cast_to_mut;
+    log(debug, vec::len(cast_to_mut(~[1, 2])));
     {
         use vec::*;
         log(debug, len(~[2]));

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -72,7 +72,7 @@ fn AsciiArt(width: uint, height: uint, fill: char) -> AsciiArt
             {
                 let mut line = ~[];   
                 vec::grow_set(&mut line, width-1, &'.', '.');
-                push(vec::to_mut(line));
+                push(vec::cast_to_mut(line));
             }
         };
 


### PR DESCRIPTION
Solution to issue #3355 asking for the renaming of vec::to_mut/from_mut to cast_to_mut/cast_from_mut
