### PR TITLE
cleaning up, adding tests

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -172,15 +172,15 @@ fn fun_to_str(decl: ast::fn_decl, name: ast::ident,
 
 #[test]
 fn test_fun_to_str() {
-    let decl: ast::fn_decl = {
+    let decl: ast::fn_decl = ast::fn_decl {
         inputs: ~[],
-        output: @{id: 0,
+        output: @ast::Ty {id: 0,
                   node: ast::ty_nil,
                   span: ast_util::dummy_sp()},
-        purity: ast::impure_fn,
+        //purity: ast::impure_fn,
         cf: ast::return_val
     };
-    assert fun_to_str(decl, "a", ~[]) == "fn a()";
+    assert fun_to_str(decl, "abba", ~[]) == "fn abba()";
 }
 
 fn block_to_str(blk: ast::blk, intr: @ident_interner) -> ~str {
@@ -214,7 +214,7 @@ fn test_variant_to_str() {
         attrs: ~[],
         args: ~[],
         id: 0,
-        disr_expr: none
+        disr_expr: None
     });
 
     let varstr = variant_to_str(var);

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -29,7 +29,7 @@ fn mk<T:Eq IterBytes Hash Const Copy>() -> Interner<T> {
     move ((move hi) as Interner::<T>)
 }
 
-fn mk_prefill<T:Eq IterBytes Hash Const Copy>(init: ~[T]) -> Interner<T> {
+fn mk_prefill<T:Eq IterBytes Hash Const Copy>(init: &[T]) -> Interner<T> {
     let rv = mk();
     for init.each() |v| { rv.intern(*v); }
     return rv;
@@ -69,4 +69,46 @@ impl <T:Eq IterBytes Hash Const Copy> hash_interner<T>: Interner<T> {
     pure fn get(idx: uint) -> T { self.vect.get_elt(idx) }
 
     fn len() -> uint { return self.vect.len(); }
+}
+
+
+#[test]
+#[should_fail]
+fn i1 () {
+    let i : Interner<@~str> = mk();
+    i.get(13);
+} 
+
+#[test]
+fn i2 () {
+    let i : Interner<@~str> = mk();
+    // first one is zero:
+    assert i.intern (@~"dog") == 0;
+    // re-use gets the same entry:
+    assert i.intern (@~"dog") == 0;
+    // different string gets a different #:
+    assert i.intern (@~"cat") == 1;
+    assert i.intern (@~"cat") == 1;
+    // dog is still at zero
+    assert i.intern (@~"dog") == 0;
+    // gensym gets 3
+    assert i.gensym (@~"zebra" ) == 2;
+    // gensym of same string gets new number :
+    assert i.gensym (@~"zebra" ) == 3;
+    // gensym of *existing* string gets new number:
+    assert i.gensym (@~"dog") == 4;
+    assert i.get(0) == @~"dog";
+    assert i.get(1) == @~"cat";
+    assert i.get(2) == @~"zebra";
+    assert i.get(3) == @~"zebra";
+    assert i.get(4) == @~"dog";
+} 
+
+#[test]
+fn i3 () {
+    let i : Interner<@~str> = mk_prefill([@~"Alan",@~"Bob",@~"Carol"]);
+    assert i.get(0) == @~"Alan";
+    assert i.get(1) == @~"Bob";
+    assert i.get(2) == @~"Carol";
+    assert i.intern(@~"Bob") == 1;
 }


### PR DESCRIPTION
The new tests for the interner appear to pass, after changing an owned to a borrowed pointer. The test cases in pprint didn't compile before, and still don't.
