### PR TITLE
syntax/rustc: Improve error message for misuse of `for` loop

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1660,43 +1660,45 @@ impl Parser {
         // them as the lambda arguments
         let e = self.parse_expr_res(RESTRICT_NO_BAR_OR_DOUBLEBAR_OP);
         match e.node {
-          expr_call(f, args, false) => {
-            let block = self.parse_lambda_block_expr();
-            let last_arg = self.mk_expr(block.span.lo, block.span.hi,
-                                    ctor(block));
-            let args = vec::append(args, ~[last_arg]);
-            @expr {node: expr_call(f, args, true), .. *e}
-          }
-          expr_method_call(f, i, tps, args, false) => {
-            let block = self.parse_lambda_block_expr();
-            let last_arg = self.mk_expr(block.span.lo, block.span.hi,
-                                    ctor(block));
-            let args = vec::append(args, ~[last_arg]);
-            @expr {node: expr_method_call(f, i, tps, args, true), .. *e}
-          }
-          expr_field(f, i, tps) => {
-            let block = self.parse_lambda_block_expr();
-            let last_arg = self.mk_expr(block.span.lo, block.span.hi,
-                                    ctor(block));
-            @expr {node: expr_method_call(f, i, tps, ~[last_arg], true),
-                   .. *e}
-          }
-          expr_path(*) | expr_call(*) | expr_method_call(*) |
-          expr_paren(*) => {
-            let block = self.parse_lambda_block_expr();
-            let last_arg = self.mk_expr(block.span.lo, block.span.hi,
-                                    ctor(block));
-            self.mk_expr(lo.lo, last_arg.span.hi,
-                         expr_call(e, ~[last_arg], true))
-          }
-          _ => {
-            // There may be other types of expressions that can
-            // represent the callee in `for` and `do` expressions
-            // but they aren't represented by tests
-            debug!("sugary call on %?", e.node);
-            self.span_fatal(
-                lo, fmt!("`%s` must be followed by a block call", keyword));
-          }
+            expr_call(f, args, false) => {
+                let block = self.parse_lambda_block_expr();
+                let last_arg = self.mk_expr(block.span.lo, block.span.hi,
+                                            ctor(block));
+                let args = vec::append(args, ~[last_arg]);
+                self.mk_expr(lo.lo, block.span.hi, expr_call(f, args, true))
+            }
+            expr_method_call(f, i, tps, args, false) => {
+                let block = self.parse_lambda_block_expr();
+                let last_arg = self.mk_expr(block.span.lo, block.span.hi,
+                                            ctor(block));
+                let args = vec::append(args, ~[last_arg]);
+                self.mk_expr(lo.lo, block.span.hi,
+                             expr_method_call(f, i, tps, args, true))
+            }
+            expr_field(f, i, tps) => {
+                let block = self.parse_lambda_block_expr();
+                let last_arg = self.mk_expr(block.span.lo, block.span.hi,
+                                            ctor(block));
+                self.mk_expr(lo.lo, block.span.hi,
+                             expr_method_call(f, i, tps, ~[last_arg], true))
+            }
+            expr_path(*) | expr_call(*) | expr_method_call(*) |
+                expr_paren(*) => {
+                let block = self.parse_lambda_block_expr();
+                let last_arg = self.mk_expr(block.span.lo, block.span.hi,
+                                            ctor(block));
+                self.mk_expr(lo.lo, last_arg.span.hi,
+                             expr_call(e, ~[last_arg], true))
+            }
+            _ => {
+                // There may be other types of expressions that can
+                // represent the callee in `for` and `do` expressions
+                // but they aren't represented by tests
+                debug!("sugary call on %?", e.node);
+                self.span_fatal(
+                    lo, fmt!("`%s` must be followed by a block call",
+                             keyword));
+            }
         }
     }
 

--- a/src/test/compile-fail/bad-for-loop.rs
+++ b/src/test/compile-fail/bad-for-loop.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     fn baz(_x: fn(y: int) -> int) {}
-    for baz |_e| { } //~ ERROR should return `bool`
+    for baz |_e| { } //~ ERROR A `for` loop iterator should expect a closure that returns `bool`
 }

--- a/src/test/compile-fail/issue-3651-2.rs
+++ b/src/test/compile-fail/issue-3651-2.rs
@@ -8,18 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn not_bool(f: fn(int) -> ~str) {}
-
 fn main() {
-    for uint::range(0, 100000) |_i| { //~ ERROR A for-loop body must return (), but
-        false
-    };
-    for not_bool |_i| { //~ ERROR a `for` loop iterator should expect a closure that returns `bool`
-        ~"hi"
-    };
-    for uint::range(0, 100000) |_i| { //~ ERROR A for-loop body must return (), but
-        ~"hi"
-    };
-    for not_bool() |_i| { //~ ERROR a `for` loop iterator should expect a closure that returns `bool`
-    };
+    do 5.times {} //~ ERROR Do-block body must return bool, but returns () here. Perhaps
 }

--- a/src/test/compile-fail/issue-3651.rs
+++ b/src/test/compile-fail/issue-3651.rs
@@ -8,18 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn not_bool(f: fn(int) -> ~str) {}
-
 fn main() {
-    for uint::range(0, 100000) |_i| { //~ ERROR A for-loop body must return (), but
-        false
-    };
-    for not_bool |_i| { //~ ERROR a `for` loop iterator should expect a closure that returns `bool`
-        ~"hi"
-    };
-    for uint::range(0, 100000) |_i| { //~ ERROR A for-loop body must return (), but
-        ~"hi"
-    };
-    for not_bool() |_i| { //~ ERROR a `for` loop iterator should expect a closure that returns `bool`
-    };
+    for task::spawn { return true; } //~ ERROR A `for` loop iterator should expect a closure that
 }

--- a/src/test/compile-fail/missing-do.rs
+++ b/src/test/compile-fail/missing-do.rs
@@ -15,5 +15,5 @@ fn foo(f: fn()) { f() }
 fn main() {
     ~"" || 42; //~ ERROR binary operation || cannot be applied to type `~str`
     foo || {}; //~ ERROR binary operation || cannot be applied to type `extern fn(&fn())`
-    //~^ NOTE did you forget the 'do' keyword for the call?
+    //~^ NOTE did you forget the `do` keyword for the call?
 }


### PR DESCRIPTION
r? @brson As per #3651, print out a clearer error message when a `for` gets
used with the wrong type of iterator. Also fix spans on `for` loop
bodies, and suppress some more derived errors.
