### PR TITLE
convert most of libcore and libstd to structs, work around tzset race

### DIFF
--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -158,17 +158,10 @@ fn run_tests(config: config) {
 }
 
 fn test_opts(config: config) -> test::TestOpts {
-    {filter:
-         match config.filter {
-           option::Some(s) => option::Some(s),
-           option::None => option::None
-         },
-     run_ignored: config.run_ignored,
-     logfile:
-         match config.logfile {
-           option::Some(s) => option::Some(s.to_str()),
-           option::None => option::None
-         }
+    test::TestOpts {
+        filter: config.filter,
+        run_ignored: config.run_ignored,
+        logfile: config.logfile.map(|s| s.to_str()),
     }
 }
 

--- a/src/libcore/extfmt.rs
+++ b/src/libcore/extfmt.rs
@@ -466,7 +466,7 @@ pub mod ct {
 // Functions used by the fmt extension at runtime. For now there are a lot of
 // decisions made a runtime. If it proves worthwhile then some of these
 // conditions can be evaluated at compile-time. For now though it's cleaner to
-// implement it 0this way, I think.
+// implement it this way, I think.
 #[doc(hidden)]
 pub mod rt {
     use float;

--- a/src/libcore/extfmt.rs
+++ b/src/libcore/extfmt.rs
@@ -376,13 +376,23 @@ pub mod ct {
     fn test_parse_fmt_string() {
         assert parse_fmt_string("foo %s bar", die) == ~[
             PieceString(~"foo "),
-            PieceConv(Conv {param: None, flags: ~[], width: CountImplied,
-                            precision: CountImplied, ty: TyStr}),
+            PieceConv(Conv {
+                param: None,
+                flags: ~[],
+                width: CountImplied,
+                precision: CountImplied,
+                ty: TyStr,
+            }),
             PieceString(~" bar")];
 
         assert parse_fmt_string("%s", die) == ~[
-            PieceConv(Conv {param: None, flags: ~[], width: CountImplied,
-                            precision: CountImplied, ty: TyStr })];
+            PieceConv(Conv {
+                param: None,
+                flags: ~[],
+                width: CountImplied,
+                precision: CountImplied,
+                ty: TyStr,
+            })];
 
         assert parse_fmt_string("%%%%", die) == ~[
             PieceString(~"%"), PieceString(~"%")];
@@ -486,7 +496,18 @@ pub mod rt {
 
     pub enum Ty { TyDefault, TyBits, TyHexUpper, TyHexLower, TyOctal, }
 
+    #[cfg(stage0)]
     pub type Conv = {flags: u32, width: Count, precision: Count, ty: Ty};
+
+    #[cfg(stage1)]
+    #[cfg(stage2)]
+    #[cfg(stage3)]
+    pub struct Conv {
+        flags: u32,
+        width: Count,
+        precision: Count,
+        ty: Ty,
+    }
 
     pub pure fn conv_int(cv: Conv, i: int) -> ~str {
         let radix = 10;

--- a/src/libcore/gc.rs
+++ b/src/libcore/gc.rs
@@ -87,7 +87,10 @@ unsafe fn get_safe_point_count() -> uint {
     return *module_meta;
 }
 
-type SafePoint = { sp_meta: *Word, fn_meta: *Word };
+struct SafePoint {
+    sp_meta: *Word,
+    fn_meta: *Word,
+}
 
 // Returns the safe point metadata for the given program counter, if
 // any.
@@ -106,7 +109,10 @@ unsafe fn is_safe_point(pc: *Word) -> Option<SafePoint> {
         let sp: **Word = bump(safe_points, spi*3);
         let sp_loc = *sp;
         if sp_loc == pc {
-            return Some({sp_meta: *bump(sp, 1), fn_meta: *bump(sp, 2)});
+            return Some(SafePoint {
+                sp_meta: *bump(sp, 1),
+                fn_meta: *bump(sp, 2),
+            });
         }
         spi += 1;
     }

--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -1108,10 +1108,13 @@ pub mod fsync {
     // Artifacts that need to fsync on destruction
     pub struct Res<t: Copy> {
         arg: Arg<t>,
-        drop {
+    }
+
+    impl<T: Copy> Res<T>: Drop {
+        fn finalize(&self) {
           match self.arg.opt_level {
-            option::None => (),
-            option::Some(level) => {
+            None => (),
+            Some(level) => {
               // fail hard if not succesful
               assert((self.arg.fsync_fn)(self.arg.val, level) != -1);
             }

--- a/src/libcore/iter-trait/dlist.rs
+++ b/src/libcore/iter-trait/dlist.rs
@@ -10,12 +10,13 @@
 
 mod inst {
     use dlist;
+    use dlist::DList;
     use managed;
     use option::{Option, Some};
     use option;
 
     #[allow(non_camel_case_types)]
-    pub type IMPL_T<A> = dlist::DList<A>;
+    pub type IMPL_T<A> = @DList<A>;
 
     /**
     * Iterates through the current contents.
@@ -36,11 +37,11 @@ mod inst {
             }
             if !nobe.linked ||
                 (!((nobe.prev.is_some()
-                    || managed::ptr_eq(*self.hd.expect(~"headless dlist?"),
-                                   *nobe))
+                    || managed::ptr_eq(self.hd.expect(~"headless dlist?"),
+                                       nobe))
                    && (nobe.next.is_some()
-                    || managed::ptr_eq(*self.tl.expect(~"tailless dlist?"),
-                                   *nobe)))) {
+                    || managed::ptr_eq(self.tl.expect(~"tailless dlist?"),
+                                       nobe)))) {
                 fail ~"Removing a dlist node during iteration is forbidden!"
             }
             link = nobe.next_link();

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -132,7 +132,7 @@ pub struct BufferHeader {
     // thing along.
 }
 
-pub fn BufferHeader() -> BufferHeader{
+pub fn BufferHeader() -> BufferHeader {
     BufferHeader {
         ref_count: 0
     }

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -201,10 +201,10 @@ impl PacketHeader {
 }
 
 #[doc(hidden)]
-pub type Packet<T: Owned> = {
+pub struct Packet<T: Owned> {
     header: PacketHeader,
     mut payload: Option<T>,
-};
+}
 
 #[doc(hidden)]
 pub trait HasBuffer {
@@ -223,9 +223,9 @@ impl<T: Owned> Packet<T>: HasBuffer {
 
 #[doc(hidden)]
 pub fn mk_packet<T: Owned>() -> Packet<T> {
-    {
+    Packet {
         header: PacketHeader(),
-        mut payload: None
+        payload: None,
     }
 }
 
@@ -233,9 +233,9 @@ pub fn mk_packet<T: Owned>() -> Packet<T> {
 fn unibuffer<T: Owned>() -> ~Buffer<Packet<T>> {
     let b = ~{
         header: BufferHeader(),
-        data: {
+        data: Packet {
             header: PacketHeader(),
-            mut payload: None,
+            payload: None,
         }
     };
 
@@ -1011,7 +1011,9 @@ pub trait Peekable<T> {
 }
 
 #[doc(hidden)]
-type Chan_<T:Owned> = { mut endp: Option<streamp::client::Open<T>> };
+struct Chan_<T:Owned> {
+    mut endp: Option<streamp::client::Open<T>>,
+}
 
 /// An endpoint that can send many messages.
 pub enum Chan<T:Owned> {
@@ -1019,7 +1021,9 @@ pub enum Chan<T:Owned> {
 }
 
 #[doc(hidden)]
-type Port_<T:Owned> = { mut endp: Option<streamp::server::Open<T>> };
+struct Port_<T:Owned> {
+    mut endp: Option<streamp::server::Open<T>>,
+}
 
 /// An endpoint that can receive many messages.
 pub enum Port<T:Owned> {
@@ -1034,7 +1038,7 @@ These allow sending or receiving an unlimited number of messages.
 pub fn stream<T:Owned>() -> (Port<T>, Chan<T>) {
     let (c, s) = streamp::init();
 
-    (Port_({ mut endp: Some(move s) }), Chan_({ mut endp: Some(move c) }))
+    (Port_(Port_ { endp: Some(s) }), Chan_(Chan_{ endp: Some(c) }))
 }
 
 impl<T: Owned> Chan<T>: GenericChan<T> {

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -140,10 +140,19 @@ pub fn BufferHeader() -> BufferHeader{
 
 // This is for protocols to associate extra data to thread around.
 #[doc(hidden)]
+#[cfg(stage0)]
 type Buffer<T: Owned> = {
     header: BufferHeader,
     data: T,
 };
+#[doc(hidden)]
+#[cfg(stage1)]
+#[cfg(stage2)]
+#[cfg(stage3)]
+pub struct Buffer<T: Owned> {
+    header: BufferHeader,
+    data: T,
+}
 
 struct PacketHeader {
     mut state: State,
@@ -230,8 +239,28 @@ pub fn mk_packet<T: Owned>() -> Packet<T> {
 }
 
 #[doc(hidden)]
+#[cfg(stage0)]
 fn unibuffer<T: Owned>() -> ~Buffer<Packet<T>> {
     let b = ~{
+        header: BufferHeader(),
+        data: Packet {
+            header: PacketHeader(),
+            payload: None,
+        }
+    };
+
+    unsafe {
+        b.data.header.buffer = reinterpret_cast(&b);
+    }
+    move b
+}
+
+#[doc(hidden)]
+#[cfg(stage1)]
+#[cfg(stage2)]
+#[cfg(stage3)]
+fn unibuffer<T: Owned>() -> ~Buffer<Packet<T>> {
+    let b = ~Buffer {
         header: BufferHeader(),
         data: Packet {
             header: PacketHeader(),

--- a/src/libcore/rand.rs
+++ b/src/libcore/rand.rs
@@ -42,7 +42,10 @@ pub trait Rng {
 }
 
 /// A value with a particular weight compared to other values
-pub type Weighted<T> = { weight: uint, item: T };
+pub struct Weighted<T> {
+    weight: uint,
+    item: T,
+}
 
 /// Extension methods for random number generators
 impl Rng {
@@ -312,12 +315,12 @@ pub fn seeded_rng(seed: &~[u8]) -> Rng {
     }
 }
 
-type XorShiftState = {
+struct XorShiftState {
     mut x: u32,
     mut y: u32,
     mut z: u32,
-    mut w: u32
-};
+    mut w: u32,
+}
 
 impl XorShiftState: Rng {
     fn next() -> u32 {
@@ -338,7 +341,7 @@ pub pure fn xorshift() -> Rng {
 }
 
 pub pure fn seeded_xorshift(x: u32, y: u32, z: u32, w: u32) -> Rng {
-    {mut x: x, mut y: y, mut z: z, mut w: w} as Rng
+    XorShiftState { x: x, y: y, z: z, w: w } as Rng
 }
 
 
@@ -492,21 +495,24 @@ pub mod tests {
     #[test]
     pub fn choose_weighted() {
         let r = rand::Rng();
-        assert r.choose_weighted(~[{weight: 1u, item: 42}]) == 42;
         assert r.choose_weighted(~[
-            {weight: 0u, item: 42},
-            {weight: 1u, item: 43}
+            rand::Weighted { weight: 1u, item: 42 },
+        ]) == 42;
+        assert r.choose_weighted(~[
+            rand::Weighted { weight: 0u, item: 42 },
+            rand::Weighted { weight: 1u, item: 43 },
         ]) == 43;
     }
 
     #[test]
     pub fn choose_weighted_option() {
         let r = rand::Rng();
-        assert r.choose_weighted_option(~[{weight: 1u, item: 42}]) ==
-               Some(42);
         assert r.choose_weighted_option(~[
-            {weight: 0u, item: 42},
-            {weight: 1u, item: 43}
+            rand::Weighted { weight: 1u, item: 42 },
+        ]) == Some(42);
+        assert r.choose_weighted_option(~[
+            rand::Weighted { weight: 0u, item: 42 },
+            rand::Weighted { weight: 1u, item: 43 },
         ]) == Some(43);
         let v: Option<int> = r.choose_weighted_option([]);
         assert v.is_none();
@@ -518,9 +524,9 @@ pub mod tests {
         let empty: ~[int] = ~[];
         assert r.weighted_vec(~[]) == empty;
         assert r.weighted_vec(~[
-            {weight: 0u, item: 3u},
-            {weight: 1u, item: 2u},
-            {weight: 2u, item: 1u}
+            rand::Weighted { weight: 0u, item: 3u },
+            rand::Weighted { weight: 1u, item: 2u },
+            rand::Weighted { weight: 2u, item: 1u },
         ]) == ~[2u, 1u, 1u];
     }
 

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -220,11 +220,13 @@ pub fn start_program(prog: &str, args: &[~str]) -> Program {
             libc::close(pipe_err.out);
         }
 
-        type ProgRepr = {pid: pid_t,
-                         mut in_fd: c_int,
-                         out_file: *libc::FILE,
-                         err_file: *libc::FILE,
-                         mut finished: bool};
+        struct ProgRepr {
+            pid: pid_t,
+            mut in_fd: c_int,
+            out_file: *libc::FILE,
+            err_file: *libc::FILE,
+            mut finished: bool,
+        }
 
         fn close_repr_input(r: &ProgRepr) {
             let invalid_fd = -1i32;
@@ -274,12 +276,15 @@ pub fn start_program(prog: &str, args: &[~str]) -> Program {
             fn finish() -> int { finish_repr(&self.r) }
             fn destroy() { destroy_repr(&self.r); }
         }
-        let repr = {pid: pid,
-                    mut in_fd: pipe_input.out,
-                    out_file: os::fdopen(pipe_output.in),
-                    err_file: os::fdopen(pipe_err.in),
-                    mut finished: false};
-        return ProgRes(move repr) as Program;
+        let repr = ProgRepr {
+            pid: pid,
+            in_fd: pipe_input.out,
+            out_file: os::fdopen(pipe_output.in),
+            err_file: os::fdopen(pipe_err.in),
+            finished: false,
+        };
+
+        ProgRes(repr) as Program
     }
 }
 

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -2027,10 +2027,10 @@ pub mod raw {
         unboxed: UnboxedVecRepr
     }
 
-    pub type SliceRepr = {
+    pub struct SliceRepr {
         mut data: *u8,
         mut len: uint
-    };
+    }
 
     /**
      * Sets the length of a vector

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -287,7 +287,7 @@ fn get_lint_settings_level(settings: lint_settings,
 // This is kind of unfortunate. It should be somewhere else, or we should use
 // a persistent data structure...
 fn clone_lint_modes(modes: lint_modes) -> lint_modes {
-    smallintmap::SmallIntMap_(@{v: copy modes.v})
+    smallintmap::SmallIntMap_(@smallintmap::SmallIntMap_ { v: copy modes.v })
 }
 
 type ctxt_ = {dict: lint_dict,

--- a/src/libstd/arena.rs
+++ b/src/libstd/arena.rs
@@ -68,7 +68,11 @@ const tydesc_drop_glue_index: size_t = 3 as size_t;
 // The way arena uses arrays is really deeply awful. The arrays are
 // allocated, and have capacities reserved, but the fill for the array
 // will always stay at 0.
-type Chunk = {data: @[u8], mut fill: uint, is_pod: bool};
+struct Chunk {
+    data: @[u8],
+    mut fill: uint,
+    is_pod: bool,
+}
 
 pub struct Arena {
     // The head is seperated out from the list as a unbenchmarked
@@ -93,13 +97,19 @@ impl Arena : Drop {
 fn chunk(size: uint, is_pod: bool) -> Chunk {
     let mut v: @[const u8] = @[];
     unsafe { at_vec::raw::reserve(&mut v, size); }
-    { data: unsafe { cast::transmute(v) }, mut fill: 0u, is_pod: is_pod }
+    Chunk {
+        data: unsafe { cast::transmute(v) },
+        fill: 0u,
+        is_pod: is_pod,
+    }
 }
 
 pub fn arena_with_size(initial_size: uint) -> Arena {
-    return Arena {mut head: chunk(initial_size, false),
-                  mut pod_head: chunk(initial_size, true),
-                  mut chunks: @Nil};
+    Arena {
+        head: chunk(initial_size, false),
+        pod_head: chunk(initial_size, true),
+        chunks: @Nil,
+    }
 }
 
 pub fn Arena() -> Arena {

--- a/src/libstd/deque.rs
+++ b/src/libstd/deque.rs
@@ -61,10 +61,12 @@ pub fn create<T: Copy>() -> Deque<T> {
         match (*elts).get_elt(i) { Some(move t) => t, _ => fail }
     }
 
-    type Repr<T> = {mut nelts: uint,
-                    mut lo: uint,
-                    mut hi: uint,
-                    elts: DVec<Cell<T>>};
+    struct Repr<T> {
+        mut nelts: uint,
+        mut lo: uint,
+        mut hi: uint,
+        elts: DVec<Cell<T>>,
+    }
 
     impl <T: Copy> Repr<T>: Deque<T> {
         fn size() -> uint { return self.nelts; }
@@ -119,15 +121,14 @@ pub fn create<T: Copy>() -> Deque<T> {
         }
     }
 
-    let repr: Repr<T> = {
-        mut nelts: 0u,
-        mut lo: 0u,
-        mut hi: 0u,
-        elts:
-            dvec::from_vec(
-                vec::from_elem(initial_capacity, None))
+    let repr: Repr<T> = Repr {
+        nelts: 0u,
+        lo: 0u,
+        hi: 0u,
+        elts: dvec::from_vec(vec::from_elem(initial_capacity, None)),
     };
-    (move repr) as Deque::<T>
+
+    repr as Deque::<T>
 }
 
 #[cfg(test)]
@@ -254,7 +255,11 @@ mod tests {
         Onepar(int), Twopar(int, int), Threepar(int, int, int),
     }
 
-    type RecCy = {x: int, y: int, t: Taggy};
+    struct RecCy {
+        x: int,
+        y: int,
+        t: Taggy,
+    }
 
     impl Taggy : Eq {
         pure fn eq(&self, other: &Taggy) -> bool {
@@ -335,10 +340,10 @@ mod tests {
 
     #[test]
     fn test_param_reccy() {
-        let reccy1: RecCy = {x: 1, y: 2, t: One(1)};
-        let reccy2: RecCy = {x: 345, y: 2, t: Two(1, 2)};
-        let reccy3: RecCy = {x: 1, y: 777, t: Three(1, 2, 3)};
-        let reccy4: RecCy = {x: 19, y: 252, t: Two(17, 42)};
+        let reccy1 = RecCy { x: 1, y: 2, t: One(1) };
+        let reccy2 = RecCy { x: 345, y: 2, t: Two(1, 2) };
+        let reccy3 = RecCy { x: 1, y: 777, t: Three(1, 2, 3) };
+        let reccy4 = RecCy { x: 19, y: 252, t: Two(17, 42) };
         test_parameterized::<RecCy>(reccy1, reccy2, reccy3, reccy4);
     }
 }

--- a/src/libstd/map.rs
+++ b/src/libstd/map.rs
@@ -107,7 +107,11 @@ pub trait Map<K:Eq IterBytes Hash Copy, V: Copy> {
 }
 
 pub mod util {
-    pub type Rational = {num: int, den: int}; // : int::positive(*.den);
+    pub struct Rational {
+        // : int::positive(*.den);
+        num: int,
+        den: int,
+    }
 
     pub pure fn rational_leq(x: Rational, y: Rational) -> bool {
         // NB: Uses the fact that rationals have positive denominators WLOG:
@@ -265,9 +269,11 @@ pub mod chained {
 
                 // consider rehashing if more 3/4 full
                 let nchains = vec::len(self.chains);
-                let load = {num: (self.count + 1u) as int,
-                            den: nchains as int};
-                if !util::rational_leq(load, {num:3, den:4}) {
+                let load = util::Rational {
+                    num: (self.count + 1u) as int,
+                    den: nchains as int,
+                };
+                if !util::rational_leq(load, util::Rational {num:3, den:4}) {
                     self.rehash();
                 }
 
@@ -324,9 +330,11 @@ pub mod chained {
 
                 // consider rehashing if more 3/4 full
                 let nchains = vec::len(self.chains);
-                let load = {num: (self.count + 1u) as int,
-                            den: nchains as int};
-                if !util::rational_leq(load, {num:3, den:4}) {
+                let load = util::Rational {
+                    num: (self.count + 1u) as int,
+                    den: nchains as int,
+                };
+                if !util::rational_leq(load, util::Rational {num:3, den:4}) {
                     self.rehash();
                 }
 

--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -284,7 +284,10 @@ mod tests {
     #[test]
     fn test() {
         unsafe {
-            type Test = {input: ~str, output: ~[u8]};
+            struct Test {
+                input: ~str,
+                output: ~[u8],
+            }
 
             fn a_million_letter_a() -> ~str {
                 let mut i = 0;
@@ -297,47 +300,64 @@ mod tests {
             }
             // Test messages from FIPS 180-1
 
-            let fips_180_1_tests: ~[Test] =
-                ~[{input: ~"abc",
-                  output:
-                      ~[0xA9u8, 0x99u8, 0x3Eu8, 0x36u8,
-                       0x47u8, 0x06u8, 0x81u8, 0x6Au8,
-                       0xBAu8, 0x3Eu8, 0x25u8, 0x71u8,
-                       0x78u8, 0x50u8, 0xC2u8, 0x6Cu8,
-                       0x9Cu8, 0xD0u8, 0xD8u8, 0x9Du8]},
-                 {input:
-                      ~"abcdbcdecdefdefgefghfghighij" +
-                      ~"hijkijkljklmklmnlmnomnopnopq",
-                  output:
-                      ~[0x84u8, 0x98u8, 0x3Eu8, 0x44u8,
-                       0x1Cu8, 0x3Bu8, 0xD2u8, 0x6Eu8,
-                       0xBAu8, 0xAEu8, 0x4Au8, 0xA1u8,
-                       0xF9u8, 0x51u8, 0x29u8, 0xE5u8,
-                       0xE5u8, 0x46u8, 0x70u8, 0xF1u8]},
-                 {input: a_million_letter_a(),
-                  output:
-                      ~[0x34u8, 0xAAu8, 0x97u8, 0x3Cu8,
-                       0xD4u8, 0xC4u8, 0xDAu8, 0xA4u8,
-                       0xF6u8, 0x1Eu8, 0xEBu8, 0x2Bu8,
-                       0xDBu8, 0xADu8, 0x27u8, 0x31u8,
-                       0x65u8, 0x34u8, 0x01u8, 0x6Fu8]}];
+            let fips_180_1_tests = ~[
+                Test {
+                    input: ~"abc",
+                    output: ~[
+                        0xA9u8, 0x99u8, 0x3Eu8, 0x36u8,
+                        0x47u8, 0x06u8, 0x81u8, 0x6Au8,
+                        0xBAu8, 0x3Eu8, 0x25u8, 0x71u8,
+                        0x78u8, 0x50u8, 0xC2u8, 0x6Cu8,
+                        0x9Cu8, 0xD0u8, 0xD8u8, 0x9Du8,
+                    ],
+                },
+                Test {
+                    input:
+                         ~"abcdbcdecdefdefgefghfghighij" +
+                         ~"hijkijkljklmklmnlmnomnopnopq",
+                    output: ~[
+                        0x84u8, 0x98u8, 0x3Eu8, 0x44u8,
+                        0x1Cu8, 0x3Bu8, 0xD2u8, 0x6Eu8,
+                        0xBAu8, 0xAEu8, 0x4Au8, 0xA1u8,
+                        0xF9u8, 0x51u8, 0x29u8, 0xE5u8,
+                        0xE5u8, 0x46u8, 0x70u8, 0xF1u8,
+                    ],
+                },
+                Test {
+                    input: a_million_letter_a(),
+                    output: ~[
+                        0x34u8, 0xAAu8, 0x97u8, 0x3Cu8,
+                        0xD4u8, 0xC4u8, 0xDAu8, 0xA4u8,
+                        0xF6u8, 0x1Eu8, 0xEBu8, 0x2Bu8,
+                        0xDBu8, 0xADu8, 0x27u8, 0x31u8,
+                        0x65u8, 0x34u8, 0x01u8, 0x6Fu8,
+                    ],
+                },
+            ];
             // Examples from wikipedia
 
-            let wikipedia_tests: ~[Test] =
-                ~[{input: ~"The quick brown fox jumps over the lazy dog",
-                  output:
-                      ~[0x2fu8, 0xd4u8, 0xe1u8, 0xc6u8,
-                       0x7au8, 0x2du8, 0x28u8, 0xfcu8,
-                       0xedu8, 0x84u8, 0x9eu8, 0xe1u8,
-                       0xbbu8, 0x76u8, 0xe7u8, 0x39u8,
-                       0x1bu8, 0x93u8, 0xebu8, 0x12u8]},
-                 {input: ~"The quick brown fox jumps over the lazy cog",
-                  output:
-                      ~[0xdeu8, 0x9fu8, 0x2cu8, 0x7fu8,
-                       0xd2u8, 0x5eu8, 0x1bu8, 0x3au8,
-                       0xfau8, 0xd3u8, 0xe8u8, 0x5au8,
-                       0x0bu8, 0xd1u8, 0x7du8, 0x9bu8,
-                       0x10u8, 0x0du8, 0xb4u8, 0xb3u8]}];
+            let wikipedia_tests = ~[
+                Test {
+                    input: ~"The quick brown fox jumps over the lazy dog",
+                    output: ~[
+                        0x2fu8, 0xd4u8, 0xe1u8, 0xc6u8,
+                        0x7au8, 0x2du8, 0x28u8, 0xfcu8,
+                        0xedu8, 0x84u8, 0x9eu8, 0xe1u8,
+                        0xbbu8, 0x76u8, 0xe7u8, 0x39u8,
+                        0x1bu8, 0x93u8, 0xebu8, 0x12u8,
+                    ],
+                },
+                Test {
+                    input: ~"The quick brown fox jumps over the lazy cog",
+                    output: ~[
+                        0xdeu8, 0x9fu8, 0x2cu8, 0x7fu8,
+                        0xd2u8, 0x5eu8, 0x1bu8, 0x3au8,
+                        0xfau8, 0xd3u8, 0xe8u8, 0x5au8,
+                        0x0bu8, 0xd1u8, 0x7du8, 0x9bu8,
+                        0x10u8, 0x0du8, 0xb4u8, 0xb3u8,
+                    ],
+                },
+            ];
             let tests = fips_180_1_tests + wikipedia_tests;
             fn check_vec_eq(v0: ~[u8], v1: ~[u8]) {
                 assert (vec::len::<u8>(v0) == vec::len::<u8>(v1));

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -25,7 +25,9 @@ use core::prelude::*;
 
 // FIXME (#2347): Should not be @; there's a bug somewhere in rustc that
 // requires this to be.
-type SmallIntMap_<T: Copy> = {v: DVec<Option<T>>};
+struct SmallIntMap_<T: Copy> {
+    v: DVec<Option<T>>,
+}
 
 pub enum SmallIntMap<T:Copy> {
     SmallIntMap_(@SmallIntMap_<T>)
@@ -34,7 +36,7 @@ pub enum SmallIntMap<T:Copy> {
 /// Create a smallintmap
 pub fn mk<T: Copy>() -> SmallIntMap<T> {
     let v = DVec();
-    return SmallIntMap_(@{v: move v});
+    SmallIntMap_(@SmallIntMap_ { v: v } )
 }
 
 /**

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -902,7 +902,6 @@ mod tests {
     use core::uint;
     use core::vec;
 
-    #[test]
     fn test_get_time() {
         const some_recent_date: i64 = 1325376000i64; // 2012-01-01T00:00:00Z
         const some_future_date: i64 = 1577836800i64; // 2020-01-01T00:00:00Z
@@ -926,7 +925,6 @@ mod tests {
         }
     }
 
-    #[test]
     fn test_precise_time() {
         let s0 = precise_time_s();
         let ns1 = precise_time_ns();
@@ -944,7 +942,6 @@ mod tests {
         assert ns2 >= ns1;
     }
 
-    #[test]
     fn test_at_utc() {
         os::setenv(~"TZ", ~"America/Los_Angeles");
         tzset();
@@ -966,7 +963,6 @@ mod tests {
         assert utc.tm_nsec == 54321_i32;
     }
 
-    #[test]
     fn test_at() {
         os::setenv(~"TZ", ~"America/Los_Angeles");
         tzset();
@@ -995,7 +991,6 @@ mod tests {
         assert local.tm_nsec == 54321_i32;
     }
 
-    #[test]
     fn test_to_timespec() {
         os::setenv(~"TZ", ~"America/Los_Angeles");
         tzset();
@@ -1007,7 +1002,6 @@ mod tests {
         assert utc.to_local().to_timespec() == time;
     }
 
-    #[test]
     fn test_conversions() {
         os::setenv(~"TZ", ~"America/Los_Angeles");
         tzset();
@@ -1024,7 +1018,6 @@ mod tests {
         assert utc.to_local().to_utc() == utc;
     }
 
-    #[test]
     fn test_strptime() {
         os::setenv(~"TZ", ~"America/Los_Angeles");
         tzset();
@@ -1179,8 +1172,6 @@ mod tests {
         assert test(~"%", ~"%%");
     }
 
-    #[test]
-    #[ignore(reason = "randomred")]
     fn test_ctime() {
         os::setenv(~"TZ", ~"America/Los_Angeles");
         tzset();
@@ -1195,8 +1186,6 @@ mod tests {
         assert local.ctime() == ~"Fri Feb 13 15:31:30 2009";
     }
 
-    #[test]
-    #[ignore(reason = "randomred")]
     fn test_strftime() {
         os::setenv(~"TZ", ~"America/Los_Angeles");
         tzset();
@@ -1270,7 +1259,6 @@ mod tests {
         assert utc.rfc3339() == ~"2009-02-13T23:31:30Z";
     }
 
-    #[test]
     fn test_timespec_eq_ord() {
         use core::cmp::{eq, ge, gt, le, lt, ne};
 
@@ -1302,5 +1290,21 @@ mod tests {
         assert gt(b, a);
         assert gt(c, b);
         assert gt(d, c);
+    }
+
+    #[test]
+    fn run_tests() {
+        // The tests race on tzset. So instead of having many independent
+        // tests, we will just call the functions now.
+        test_get_time();
+        test_precise_time();
+        test_at_utc();
+        test_at();
+        test_to_timespec();
+        test_conversions();
+        test_strptime();
+        test_ctime();
+        test_strftime();
+        test_timespec_eq_ord();
     }
 }

--- a/src/libstd/uv_iotask.rs
+++ b/src/libstd/uv_iotask.rs
@@ -111,7 +111,7 @@ fn run_loop(iotask_ch: Chan<IoTask>) {
         ll::async_init(loop_ptr, async_handle, wake_up_cb);
 
         // initialize our loop data and store it in the loop
-        let data: IoTaskLoopData = {
+        let data = IoTaskLoopData {
             async_handle: async_handle,
             msg_po: Port()
         };
@@ -134,10 +134,10 @@ fn run_loop(iotask_ch: Chan<IoTask>) {
 }
 
 // data that lives for the lifetime of the high-evel oo
-type IoTaskLoopData = {
+struct IoTaskLoopData {
     async_handle: *ll::uv_async_t,
-    msg_po: Port<IoTaskMsg>
-};
+    msg_po: Port<IoTaskMsg>,
+}
 
 fn send_msg(iotask: IoTask, msg: IoTaskMsg) {
     unsafe {
@@ -214,10 +214,10 @@ mod test {
             ll::close(handle, async_close_cb);
         }
     }
-    type AhData = {
+    struct AhData {
         iotask: IoTask,
-        exit_ch: oldcomm::Chan<()>
-    };
+        exit_ch: oldcomm::Chan<()>,
+    }
     fn impl_uv_iotask_async(iotask: IoTask) {
         unsafe {
             let async_handle = ll::async_t();

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -41,10 +41,10 @@ use core::str;
 use core::vec;
 
 // libuv struct mappings
-pub type uv_ip4_addr = {
+pub struct uv_ip4_addr {
     ip: ~[u8],
-    port: int
-};
+    port: int,
+}
 pub type uv_ip6_addr = uv_ip4_addr;
 
 pub enum uv_handle_type {
@@ -67,31 +67,31 @@ pub enum uv_handle_type {
 
 pub type handle_type = libc::c_uint;
 
-pub type uv_handle_fields = {
+pub struct uv_handle_fields {
    loop_handle: *libc::c_void,
    type_: handle_type,
    close_cb: *u8,
    mut data: *libc::c_void,
-};
+}
 
 // unix size: 8
-pub type uv_err_t = {
+pub struct uv_err_t {
     code: libc::c_int,
     sys_errno_: libc::c_int
-};
+}
 
 // don't create one of these directly. instead,
 // count on it appearing in libuv callbacks or embedded
 // in other types as a pointer to be used in other
 // operations (so mostly treat it as opaque, once you
 // have it in this form..)
-pub type uv_stream_t = {
-    fields: uv_handle_fields
-};
+pub struct uv_stream_t {
+    fields: uv_handle_fields,
+}
 
 // 64bit unix size: 272
 #[cfg(unix)]
-pub type uv_tcp_t = {
+pub struct uv_tcp_t {
     fields: uv_handle_fields,
     a00: *u8, a01: *u8, a02: *u8, a03: *u8,
     a04: *u8, a05: *u8, a06: *u8, a07: *u8,
@@ -101,24 +101,24 @@ pub type uv_tcp_t = {
     a20: *u8, a21: *u8, a22: *u8, a23: *u8,
     a24: *u8, a25: *u8, a26: *u8, a27: *u8,
     a28: *u8,
-    a30: uv_tcp_t_32bit_unix_riders
-};
+    a30: uv_tcp_t_32bit_unix_riders,
+}
 // 32bit unix size: 328 (164)
 #[cfg(target_arch="x86_64")]
-pub type uv_tcp_t_32bit_unix_riders = {
-    a29: *u8
-};
+pub struct uv_tcp_t_32bit_unix_riders {
+    a29: *u8,
+}
 #[cfg(target_arch="x86")]
 #[cfg(target_arch="arm")]
-pub type uv_tcp_t_32bit_unix_riders = {
+pub struct uv_tcp_t_32bit_unix_riders {
     a29: *u8, a30: *u8, a31: *u8,
     a32: *u8, a33: *u8, a34: *u8,
-    a35: *u8, a36: *u8
-};
+    a35: *u8, a36: *u8,
+}
 
 // 32bit win32 size: 240 (120)
 #[cfg(windows)]
-pub type uv_tcp_t = {
+pub struct uv_tcp_t {
     fields: uv_handle_fields,
     a00: *u8, a01: *u8, a02: *u8, a03: *u8,
     a04: *u8, a05: *u8, a06: *u8, a07: *u8,
@@ -126,140 +126,140 @@ pub type uv_tcp_t = {
     a12: *u8, a13: *u8, a14: *u8, a15: *u8,
     a16: *u8, a17: *u8, a18: *u8, a19: *u8,
     a20: *u8, a21: *u8, a22: *u8, a23: *u8,
-    a24: *u8, a25: *u8
-};
+    a24: *u8, a25: *u8,
+}
 
 // unix size: 48
 #[cfg(unix)]
-pub type uv_connect_t = {
+pub struct uv_connect_t {
     a00: *u8, a01: *u8, a02: *u8, a03: *u8,
-    a04: *u8, a05: *u8
-};
+    a04: *u8, a05: *u8,
+}
 // win32 size: 88 (44)
 #[cfg(windows)]
-pub type uv_connect_t = {
+pub struct uv_connect_t {
     a00: *u8, a01: *u8, a02: *u8, a03: *u8,
     a04: *u8, a05: *u8, a06: *u8, a07: *u8,
-    a08: *u8, a09: *u8, a10: *u8
-};
+    a08: *u8, a09: *u8, a10: *u8,
+}
 
 // unix size: 16
-pub type uv_buf_t = {
+pub struct uv_buf_t {
     base: *u8,
-    len: libc::size_t
-};
+    len: libc::size_t,
+}
 // no gen stub method.. should create
 // it via uv::direct::buf_init()
 
 // unix size: 144
 #[cfg(unix)]
-pub type uv_write_t = {
+pub struct uv_write_t {
     fields: uv_handle_fields,
     a00: *u8, a01: *u8, a02: *u8, a03: *u8,
     a04: *u8, a05: *u8, a06: *u8, a07: *u8,
     a08: *u8, a09: *u8, a10: *u8, a11: *u8,
     a12: *u8,
-    a14: uv_write_t_32bit_unix_riders
-};
+    a14: uv_write_t_32bit_unix_riders,
+}
 #[cfg(target_arch="x86_64")]
-pub type uv_write_t_32bit_unix_riders = {
-    a13: *u8
-};
+pub struct uv_write_t_32bit_unix_riders {
+    a13: *u8,
+}
 #[cfg(target_arch="x86")]
 #[cfg(target_arch="arm")]
-pub type uv_write_t_32bit_unix_riders = {
-    a13: *u8, a14: *u8
-};
+pub struct uv_write_t_32bit_unix_riders {
+    a13: *u8, a14: *u8,
+}
 // win32 size: 136 (68)
 #[cfg(windows)]
-pub type uv_write_t = {
+pub struct uv_write_t {
     fields: uv_handle_fields,
     a00: *u8, a01: *u8, a02: *u8, a03: *u8,
     a04: *u8, a05: *u8, a06: *u8, a07: *u8,
     a08: *u8, a09: *u8, a10: *u8, a11: *u8,
-    a12: *u8
-};
+    a12: *u8,
+}
 // 64bit unix size: 120
 // 32bit unix size: 152 (76)
 #[cfg(unix)]
-pub type uv_async_t = {
+pub struct uv_async_t {
     fields: uv_handle_fields,
     a00: *u8, a01: *u8, a02: *u8, a03: *u8,
     a04: *u8, a05: *u8, a06: *u8, a07: *u8,
     a08: *u8, a09: *u8,
-    a11: uv_async_t_32bit_unix_riders
-};
+    a11: uv_async_t_32bit_unix_riders,
+}
 #[cfg(target_arch="x86_64")]
-pub type uv_async_t_32bit_unix_riders = {
-    a10: *u8
-};
+pub struct uv_async_t_32bit_unix_riders {
+    a10: *u8,
+}
 #[cfg(target_arch="x86")]
 #[cfg(target_arch="arm")]
-pub type uv_async_t_32bit_unix_riders = {
-    a10: *u8, a11: *u8, a12: *u8, a13: *u8
-};
+pub struct uv_async_t_32bit_unix_riders {
+    a10: *u8, a11: *u8, a12: *u8, a13: *u8,
+}
 // win32 size 132 (68)
 #[cfg(windows)]
-pub type uv_async_t = {
+pub struct uv_async_t {
     fields: uv_handle_fields,
     a00: *u8, a01: *u8, a02: *u8, a03: *u8,
     a04: *u8, a05: *u8, a06: *u8, a07: *u8,
     a08: *u8, a09: *u8, a10: *u8, a11: *u8,
-    a12: *u8
-};
+    a12: *u8,
+}
 
 // 64bit unix size: 128
 // 32bit unix size: 84
 #[cfg(unix)]
-pub type uv_timer_t = {
+pub struct uv_timer_t {
     fields: uv_handle_fields,
     a00: *u8, a01: *u8, a02: *u8, a03: *u8,
     a04: *u8, a05: *u8, a06: *u8, a07: *u8,
     a08: *u8, a09: *u8,
-    a11: uv_timer_t_32bit_unix_riders
-};
+    a11: uv_timer_t_32bit_unix_riders,
+}
 #[cfg(target_arch="x86_64")]
-pub type uv_timer_t_32bit_unix_riders = {
-    a10: *u8, a11: *u8
-};
+pub struct uv_timer_t_32bit_unix_riders {
+    a10: *u8, a11: *u8,
+}
 #[cfg(target_arch="x86")]
 #[cfg(target_arch="arm")]
-pub type uv_timer_t_32bit_unix_riders = {
+pub struct uv_timer_t_32bit_unix_riders {
     a10: *u8, a11: *u8, a12: *u8, a13: *u8,
-    a14: *u8, a15: *u8, a16: *u8
-};
+    a14: *u8, a15: *u8, a16: *u8,
+}
 // win32 size: 64
 #[cfg(windows)]
-pub type uv_timer_t = {
+pub struct uv_timer_t {
     fields: uv_handle_fields,
     a00: *u8, a01: *u8, a02: *u8, a03: *u8,
     a04: *u8, a05: *u8, a06: *u8, a07: *u8,
-    a08: *u8, a09: *u8, a10: *u8, a11: *u8
-};
+    a08: *u8, a09: *u8, a10: *u8, a11: *u8,
+}
 
 // unix size: 16
-pub type sockaddr_in = {
+pub struct sockaddr_in {
     mut sin_family: u16,
     mut sin_port: u16,
     mut sin_addr: u32, // in_addr: this is an opaque, per-platform struct
-    mut sin_zero: (u8, u8, u8, u8, u8, u8, u8, u8)
-};
+    mut sin_zero: (u8, u8, u8, u8, u8, u8, u8, u8),
+}
 
 // unix size: 28 .. FIXME #1645
 // stuck with 32 becuse of rust padding structs?
 #[cfg(target_arch="x86_64")]
-pub type sockaddr_in6 = {
+pub struct sockaddr_in6 {
     a0: *u8, a1: *u8,
-    a2: *u8, a3: *u8
-};
+    a2: *u8, a3: *u8,
+}
 #[cfg(target_arch="x86")]
 #[cfg(target_arch="arm")]
-pub type sockaddr_in6 = {
+pub struct sockaddr_in6 {
     a0: *u8, a1: *u8,
     a2: *u8, a3: *u8,
     a4: *u8, a5: *u8,
-    a6: *u8, a7: *u8
-};
+    a6: *u8, a7: *u8,
+}
 
 // unix size: 28 .. FIXME #1645
 // stuck with 32 becuse of rust padding structs?
@@ -267,25 +267,25 @@ pub type addr_in = addr_in_impl::addr_in;
 #[cfg(unix)]
 pub mod addr_in_impl {
     #[cfg(target_arch="x86_64")]
-    pub type addr_in = {
+    pub struct addr_in {
         a0: *u8, a1: *u8,
-        a2: *u8, a3: *u8
-    };
+        a2: *u8, a3: *u8,
+    }
     #[cfg(target_arch="x86")]
 #[cfg(target_arch="arm")]
-    pub type addr_in = {
+    pub struct addr_in {
         a0: *u8, a1: *u8,
         a2: *u8, a3: *u8,
         a4: *u8, a5: *u8,
         a6: *u8, a7: *u8,
-    };
+    }
 }
 #[cfg(windows)]
 pub mod addr_in_impl {
-    pub type addr_in = {
+    pub struct addr_in {
         a0: *u8, a1: *u8,
-        a2: *u8, a3: *u8
-    };
+        a2: *u8, a3: *u8,
+    }
 }
 
 // unix size: 48, 32bit: 32
@@ -294,42 +294,60 @@ pub type addrinfo = addrinfo_impl::addrinfo;
 #[cfg(target_os="android")]
 pub mod addrinfo_impl {
     #[cfg(target_arch="x86_64")]
-    pub type addrinfo = {
+    pub struct addrinfo {
         a00: *u8, a01: *u8, a02: *u8, a03: *u8,
-        a04: *u8, a05: *u8
-    };
+        a04: *u8, a05: *u8,
+    }
     #[cfg(target_arch="x86")]
     #[cfg(target_arch="arm")]
-    pub type addrinfo = {
+    pub struct addrinfo {
         a00: *u8, a01: *u8, a02: *u8, a03: *u8,
-        a04: *u8, a05: *u8, a06: *u8, a07: *u8
-    };
+        a04: *u8, a05: *u8, a06: *u8, a07: *u8,
+    }
 }
 #[cfg(target_os="macos")]
 #[cfg(target_os="freebsd")]
 pub mod addrinfo_impl {
-    pub type addrinfo = {
+    pub struct addrinfo {
         a00: *u8, a01: *u8, a02: *u8, a03: *u8,
-        a04: *u8, a05: *u8
-    };
+        a04: *u8, a05: *u8,
+    }
 }
 #[cfg(windows)]
 pub mod addrinfo_impl {
-    pub type addrinfo = {
+    pub struct addrinfo {
         a00: *u8, a01: *u8, a02: *u8, a03: *u8,
-        a04: *u8, a05: *u8
-    };
+        a04: *u8, a05: *u8,
+    }
 }
 
 // unix size: 72
-pub type uv_getaddrinfo_t = {
+pub struct uv_getaddrinfo_t {
     a00: *u8, a01: *u8, a02: *u8, a03: *u8, a04: *u8, a05: *u8,
-    a06: *u8, a07: *u8, a08: *u8
-};
+    a06: *u8, a07: *u8, a08: *u8,
+}
 
 pub mod uv_ll_struct_stubgen {
-    use uv_ll::{uv_async_t, uv_connect_t, uv_getaddrinfo_t, uv_tcp_t};
-    use uv_ll::{uv_timer_t, uv_write_t};
+    use uv_ll::{
+        uv_async_t,
+        uv_connect_t,
+        uv_getaddrinfo_t,
+        uv_handle_fields,
+        uv_tcp_t,
+        uv_timer_t,
+        uv_write_t,
+    };
+
+    #[cfg(target_os = "linux")]
+    #[cfg(target_os = "android")]
+    #[cfg(target_os = "macos")]
+    #[cfg(target_os = "freebsd")]
+    use uv_ll::{
+        uv_async_t_32bit_unix_riders,
+        uv_tcp_t_32bit_unix_riders,
+        uv_timer_t_32bit_unix_riders,
+        uv_write_t_32bit_unix_riders,
+    };
 
     use core::ptr;
 
@@ -343,9 +361,12 @@ pub mod uv_ll_struct_stubgen {
             return gen_stub_arch();
             #[cfg(target_arch="x86_64")]
             pub fn gen_stub_arch() -> uv_tcp_t {
-                return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                                close_cb: ptr::null(),
-                                mut data: ptr::null() },
+                uv_tcp_t {
+                    fields: uv_handle_fields {
+                        loop_handle: ptr::null(), type_: 0u32,
+                        close_cb: ptr::null(),
+                        data: ptr::null(),
+                    },
                     a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
                     a03: 0 as *u8,
                     a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
@@ -361,17 +382,18 @@ pub mod uv_ll_struct_stubgen {
                     a24: 0 as *u8, a25: 0 as *u8, a26: 0 as *u8,
                     a27: 0 as *u8,
                     a28: 0 as *u8,
-                    a30: {
-                        a29: 0 as *u8
-                    }
-                };
+                    a30: uv_tcp_t_32bit_unix_riders { a29: 0 as *u8 },
+                }
             }
             #[cfg(target_arch="x86")]
             #[cfg(target_arch="arm")]
             pub fn gen_stub_arch() -> uv_tcp_t {
-                return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                                close_cb: ptr::null(),
-                                mut data: ptr::null() },
+                uv_tcp_t {
+                    fields: uv_handle_fields {
+                        loop_handle: ptr::null(), type_: 0u32,
+                        close_cb: ptr::null(),
+                        data: ptr::null(),
+                    },
                     a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
                     a03: 0 as *u8,
                     a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
@@ -387,19 +409,22 @@ pub mod uv_ll_struct_stubgen {
                     a24: 0 as *u8, a25: 0 as *u8, a26: 0 as *u8,
                     a27: 0 as *u8,
                     a28: 0 as *u8,
-                    a30: {
+                    a30: uv_tcp_t_32bit_unix_riders {
                         a29: 0 as *u8, a30: 0 as *u8, a31: 0 as *u8,
                         a32: 0 as *u8, a33: 0 as *u8, a34: 0 as *u8,
-                        a35: 0 as *u8, a36: 0 as *u8
-                    }
-                };
+                        a35: 0 as *u8, a36: 0 as *u8,
+                    },
+                }
             }
         }
         #[cfg(windows)]
         pub fn gen_stub_os() -> uv_tcp_t {
-            return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                            close_cb: ptr::null(),
-                            mut data: ptr::null() },
+            uv_tcp_t {
+                fields: uv_handle_fields {
+                    loop_handle: ptr::null(), type_: 0u32,
+                    close_cb: ptr::null(),
+                    data: ptr::null(),
+                },
                 a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
                 a03: 0 as *u8,
                 a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
@@ -412,58 +437,62 @@ pub mod uv_ll_struct_stubgen {
                 a19: 0 as *u8,
                 a20: 0 as *u8, a21: 0 as *u8, a22: 0 as *u8,
                 a23: 0 as *u8,
-                a24: 0 as *u8, a25: 0 as *u8
-            };
+                a24: 0 as *u8, a25: 0 as *u8,
+            }
         }
     }
     #[cfg(unix)]
     pub fn gen_stub_uv_connect_t() -> uv_connect_t {
-        return {
+        uv_connect_t {
             a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
             a03: 0 as *u8,
-            a04: 0 as *u8, a05: 0 as *u8
-        };
+            a04: 0 as *u8, a05: 0 as *u8,
+        }
     }
     #[cfg(windows)]
     pub fn gen_stub_uv_connect_t() -> uv_connect_t {
-        return {
+        uv_connect_t {
             a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
             a03: 0 as *u8,
             a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
             a07: 0 as *u8,
-            a08: 0 as *u8, a09: 0 as *u8, a10: 0 as *u8
-        };
+            a08: 0 as *u8, a09: 0 as *u8, a10: 0 as *u8,
+        }
     }
     #[cfg(unix)]
     pub fn gen_stub_uv_async_t() -> uv_async_t {
         return gen_stub_arch();
         #[cfg(target_arch = "x86_64")]
         pub fn gen_stub_arch() -> uv_async_t {
-            return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                            close_cb: ptr::null(),
-                            mut data: ptr::null() },
+            uv_async_t {
+                fields: uv_handle_fields {
+                    loop_handle: ptr::null(), type_: 0u32,
+                    close_cb: ptr::null(),
+                    data: ptr::null(),
+                },
                 a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
                 a03: 0 as *u8,
                 a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
                 a07: 0 as *u8,
                 a08: 0 as *u8, a09: 0 as *u8,
-                a11: {
-                    a10: 0 as *u8
-                }
-            };
+                a11: uv_async_t_32bit_unix_riders { a10: 0 as *u8 },
+            }
         }
         #[cfg(target_arch = "x86")]
         #[cfg(target_arch="arm")]
         pub fn gen_stub_arch() -> uv_async_t {
-            return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                            close_cb: ptr::null(),
-                            mut data: ptr::null() },
+            uv_async_t {
+                fields: uv_handle_fields {
+                    loop_handle: ptr::null(), type_: 0u32,
+                    close_cb: ptr::null(),
+                    data: ptr::null(),
+                },
                 a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
                 a03: 0 as *u8,
                 a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
                 a07: 0 as *u8,
                 a08: 0 as *u8, a09: 0 as *u8,
-                a11: {
+                a11: uv_async_t_32bit_unix_riders {
                     a10: 0 as *u8, a11: 0 as *u8,
                     a12: 0 as *u8, a13: 0 as *u8
                 }
@@ -472,107 +501,133 @@ pub mod uv_ll_struct_stubgen {
     }
     #[cfg(windows)]
     pub fn gen_stub_uv_async_t() -> uv_async_t {
-        return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                        close_cb: ptr::null(),
-                        mut data: ptr::null() },
+        uv_async_t {
+            fields: uv_handle_fields {
+                loop_handle: ptr::null(), type_: 0u32,
+                close_cb: ptr::null(),
+                data: ptr::null(),
+            },
             a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
             a03: 0 as *u8,
             a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
             a07: 0 as *u8,
             a08: 0 as *u8, a09: 0 as *u8, a10: 0 as *u8,
             a11: 0 as *u8,
-            a12: 0 as *u8
-        };
+            a12: 0 as *u8,
+        }
     }
     #[cfg(unix)]
     pub fn gen_stub_uv_timer_t() -> uv_timer_t {
         return gen_stub_arch();
         #[cfg(target_arch = "x86_64")]
         pub fn gen_stub_arch() -> uv_timer_t {
-            return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                            close_cb: ptr::null(),
-                            mut data: ptr::null() },
+            uv_timer_t {
+                fields: uv_handle_fields {
+                    loop_handle: ptr::null(), type_: 0u32,
+                    close_cb: ptr::null(),
+                    data: ptr::null(),
+                },
                 a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
                 a03: 0 as *u8,
                 a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
                 a07: 0 as *u8,
                 a08: 0 as *u8, a09: 0 as *u8,
-                a11: {
+                a11: uv_timer_t_32bit_unix_riders {
                     a10: 0 as *u8, a11: 0 as *u8
-                }
-            };
+                },
+            }
         }
         #[cfg(target_arch = "x86")]
         #[cfg(target_arch="arm")]
         pub fn gen_stub_arch() -> uv_timer_t {
-            return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                            close_cb: ptr::null(),
-                            mut data: ptr::null() },
+            uv_timer_t {
+                fields: uv_handle_fields {
+                    loop_handle: ptr::null(), type_: 0u32,
+                    close_cb: ptr::null(),
+                    data: ptr::null(),
+                },
                 a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
                 a03: 0 as *u8,
                 a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
                 a07: 0 as *u8,
                 a08: 0 as *u8, a09: 0 as *u8,
-                a11: {
+                a11: uv_timer_t_32bit_unix_riders {
                     a10: 0 as *u8, a11: 0 as *u8,
                     a12: 0 as *u8, a13: 0 as *u8,
                     a14: 0 as *u8, a15: 0 as *u8,
-                    a16: 0 as *u8
-                }
-            };
+                    a16: 0 as *u8,
+                },
+            }
         }
     }
     #[cfg(windows)]
     pub fn gen_stub_uv_timer_t() -> uv_timer_t {
-        return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                        close_cb: ptr::null(),
-                        mut data: ptr::null() },
+        uv_timer_t {
+            fields: uv_handle_fields {
+                loop_handle: ptr::null(), type_: 0u32,
+                close_cb: ptr::null(),
+                data: ptr::null(),
+            },
             a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
             a03: 0 as *u8,
             a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
             a07: 0 as *u8,
             a08: 0 as *u8, a09: 0 as *u8, a10: 0 as *u8,
-            a11: 0 as *u8
-        };
+            a11: 0 as *u8,
+        }
     }
     #[cfg(unix)]
     pub fn gen_stub_uv_write_t() -> uv_write_t {
         return gen_stub_arch();
         #[cfg(target_arch="x86_64")]
         pub fn gen_stub_arch() -> uv_write_t {
-            return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                            close_cb: ptr::null(),
-                            mut data: ptr::null() },
+            uv_write_t {
+                fields: uv_handle_fields {
+                    loop_handle: ptr::null(), type_: 0u32,
+                    close_cb: ptr::null(),
+                    data: ptr::null(),
+                },
                 a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
                 a03: 0 as *u8,
                 a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
                 a07: 0 as *u8,
                 a08: 0 as *u8, a09: 0 as *u8, a10: 0 as *u8,
                 a11: 0 as *u8,
-                a12: 0 as *u8, a14: { a13: 0 as *u8 }
-            };
+                a12: 0 as *u8,
+                a14: uv_write_t_32bit_unix_riders { a13: 0 as *u8 },
+            }
         }
         #[cfg(target_arch="x86")]
         #[cfg(target_arch="arm")]
         pub fn gen_stub_arch() -> uv_write_t {
-            return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                            close_cb: ptr::null(),
-                            mut data: ptr::null() },
+            uv_write_t {
+                fields: uv_handle_fields {
+                    loop_handle: ptr::null(), type_: 0u32,
+                    close_cb: ptr::null(),
+                    data: ptr::null(),
+                },
                 a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
                 a03: 0 as *u8,
                 a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
                 a07: 0 as *u8,
                 a08: 0 as *u8, a09: 0 as *u8, a10: 0 as *u8,
                 a11: 0 as *u8,
-                a12: 0 as *u8, a14: { a13: 0 as *u8, a14: 0 as *u8 }
+                a12: 0 as *u8,
+                a14: uv_write_t_32bit_unix_riders {
+                    a13: 0 as *u8,
+                    a14: 0 as *u8,
+                }
             };
         }
     }
     #[cfg(windows)]
     pub fn gen_stub_uv_write_t() -> uv_write_t {
-        return { fields: { loop_handle: ptr::null(), type_: 0u32,
-                        close_cb: ptr::null(),
-                        mut data: ptr::null() },
+        uv_write_t {
+            fields: uv_handle_fields {
+                loop_handle: ptr::null(), type_: 0u32,
+                close_cb: ptr::null(),
+                data: ptr::null(),
+            },
             a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8,
             a03: 0 as *u8,
             a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8,
@@ -583,7 +638,7 @@ pub mod uv_ll_struct_stubgen {
         };
     }
     pub fn gen_stub_uv_getaddrinfo_t() -> uv_getaddrinfo_t {
-        {
+        uv_getaddrinfo_t {
             a00: 0 as *u8, a01: 0 as *u8, a02: 0 as *u8, a03: 0 as *u8,
             a04: 0 as *u8, a05: 0 as *u8, a06: 0 as *u8, a07: 0 as *u8,
             a08: 0 as *u8
@@ -851,7 +906,7 @@ pub unsafe fn async_send(async_handle: *uv_async_t) {
     return rustrt::rust_uv_async_send(async_handle);
 }
 pub unsafe fn buf_init(input: *u8, len: uint) -> uv_buf_t {
-    let out_buf = { base: ptr::null(), len: 0 as libc::size_t };
+    let out_buf = uv_buf_t { base: ptr::null(), len: 0 as libc::size_t };
     let out_buf_ptr = ptr::addr_of(&out_buf);
     log(debug, fmt!("buf_init - input %u len %u out_buf: %u",
                      input as uint,
@@ -1043,13 +1098,13 @@ pub unsafe fn get_last_err_data(uv_loop: *libc::c_void) -> uv_err_data {
     let err_ptr = ptr::addr_of(&err);
     let err_name = str::raw::from_c_str(err_name(err_ptr));
     let err_msg = str::raw::from_c_str(strerror(err_ptr));
-    { err_name: err_name, err_msg: err_msg }
+    uv_err_data { err_name: err_name, err_msg: err_msg }
 }
 
-pub type uv_err_data = {
+pub struct uv_err_data {
     err_name: ~str,
-    err_msg: ~str
-};
+    err_msg: ~str,
+}
 
 pub unsafe fn is_ipv4_addrinfo(input: *addrinfo) -> bool {
     rustrt::rust_uv_is_ipv4_addrinfo(input)
@@ -1090,11 +1145,11 @@ pub mod test {
         tcp_read_error
     }
 
-    type request_wrapper = {
+    struct request_wrapper {
         write_req: *uv_write_t,
         req_buf: *~[uv_buf_t],
-        read_chan: *oldcomm::Chan<~str>
-    };
+        read_chan: *oldcomm::Chan<~str>,
+    }
 
     extern fn after_close_cb(handle: *libc::c_void) {
         log(debug, fmt!("after uv_close! handle ptr: %?",
@@ -1424,18 +1479,18 @@ pub mod test {
         }
     }
 
-    type tcp_server_data = {
+    struct tcp_server_data {
         client: *uv_tcp_t,
         server: *uv_tcp_t,
         server_kill_msg: ~str,
         server_resp_buf: *~[uv_buf_t],
         server_chan: *oldcomm::Chan<~str>,
-        server_write_req: *uv_write_t
-    };
+        server_write_req: *uv_write_t,
+    }
 
-    type async_handle_data = {
-        continue_chan: *oldcomm::Chan<bool>
-    };
+    struct async_handle_data {
+        continue_chan: *oldcomm::Chan<bool>,
+    }
 
     extern fn async_close_cb(handle: *libc::c_void) {
         log(debug, fmt!("SERVER: closing async cb... h: %?",
@@ -1489,7 +1544,7 @@ pub mod test {
                 { continue_chan: continue_chan };
             let async_data_ptr = ptr::addr_of(&async_data);
 
-            let server_data: tcp_server_data = {
+            let server_data = tcp_server_data {
                 client: tcp_client_ptr,
                 server: tcp_server_ptr,
                 server_kill_msg: kill_server_msg,

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -172,6 +172,15 @@ fn mk_struct_e(cx: ext_ctxt, sp: span,
                              mk_fields(sp, fields),
                                     option::None::<@ast::expr>))
 }
+fn mk_global_struct_e(cx: ext_ctxt, sp: span,
+               ctor_path: ~[ast::ident],
+               fields: ~[{ident: ast::ident, ex: @ast::expr}]) ->
+    @ast::expr {
+    mk_expr(cx, sp,
+            ast::expr_struct(mk_raw_path_global(sp, ctor_path),
+                             mk_fields(sp, fields),
+                                    option::None::<@ast::expr>))
+}
 fn mk_glob_use(cx: ext_ctxt, sp: span,
                path: ~[ast::ident]) -> @ast::view_item {
     let glob = @ast::spanned {

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -357,10 +357,10 @@ impl protocol: gen_init {
     fn gen_init_bounded(ext_cx: ext_ctxt) -> @ast::expr {
         debug!("gen_init_bounded");
         let buffer_fields = self.gen_buffer_init(ext_cx);
-        let buffer = quote_expr!(
-            ~{header: ::pipes::BufferHeader(),
-              data: $buffer_fields}
-        );
+        let buffer = quote_expr!(~::pipes::Buffer {
+            header: ::pipes::BufferHeader(),
+            data: $buffer_fields,
+        });
 
         let entangle_body = ext_cx.block_expr(
             ext_cx.block(

--- a/src/test/run-pass/auto-encode.rs
+++ b/src/test/run-pass/auto-encode.rs
@@ -123,29 +123,33 @@ impl CLike : cmp::Eq {
     pure fn eq(&self, other: &CLike) -> bool {
         (*self) as int == *other as int
     }
-    pure fn ne(&self, other: &CLike) -> bool { !(*self).eq(other) }
+    pure fn ne(&self, other: &CLike) -> bool { !self.eq(other) }
 }
 
 #[auto_encode]
 #[auto_decode]
-type Spanned<T> = {lo: uint, hi: uint, node: T};
+struct Spanned<T> {
+    lo: uint,
+    hi: uint,
+    node: T,
+}
 
 impl<T:cmp::Eq> Spanned<T> : cmp::Eq {
     pure fn eq(&self, other: &Spanned<T>) -> bool {
-        (*self).lo == other.lo &&
-        (*self).hi == other.hi &&
-        (*self).node == other.node
+        self.lo == other.lo &&
+        self.hi == other.hi &&
+        self.node == other.node
     }
-    pure fn ne(&self, other: &Spanned<T>) -> bool { !(*self).eq(other) }
+    pure fn ne(&self, other: &Spanned<T>) -> bool { !self.eq(other) }
 }
 
 #[auto_encode]
 #[auto_decode]
-type SomeRec = {v: ~[uint]};
+struct SomeStruct { v: ~[uint] }
 
 #[auto_encode]
 #[auto_decode]
-enum AnEnum = SomeRec;
+enum AnEnum = SomeStruct;
 
 #[auto_encode]
 #[auto_decode]
@@ -168,12 +172,12 @@ fn main() {
                            @Plus(@Val(22u), @Val(5u)))");
     test_ebml(a);
 
-    let a = &{lo: 0u, hi: 5u, node: 22u};
-    test_prettyprint(a, &~"{lo: 0u, hi: 5u, node: 22u}");
+    let a = &Spanned {lo: 0u, hi: 5u, node: 22u};
+    test_prettyprint(a, &~"Spanned {lo: 0u, hi: 5u, node: 22u}");
     test_ebml(a);
 
-    let a = &AnEnum({v: ~[1u, 2u, 3u]});
-    test_prettyprint(a, &~"AnEnum({v: ~[1u, 2u, 3u]})");
+    let a = &AnEnum(SomeStruct {v: ~[1u, 2u, 3u]});
+    test_prettyprint(a, &~"AnEnum(SomeStruct {v: ~[1u, 2u, 3u]})");
     test_ebml(a);
 
     let a = &Point {x: 3u, y: 5u};

--- a/src/test/run-pass/pipe-pingpong-bounded.rs
+++ b/src/test/run-pass/pipe-pingpong-bounded.rs
@@ -27,7 +27,7 @@ mod pingpong {
     };
 
     pub fn init() -> (client::ping, server::ping) {
-        let buffer = ~{
+        let buffer = ~Buffer {
             header: BufferHeader(),
             data: {
                 ping: mk_packet::<ping>(),


### PR DESCRIPTION
Good morning,

This patch converts most of the libcore and libstd records into structs. I believe all that's left is extfmt and pipes, which needs a compiler change. It also removes record support for auto-encode, with the idea of simplifying down it down for eventual merger with the deriving macro. Finally, it includes what I hope is a fix for the randomred time tests by merging all those tests into one call so there are no more races on tzset.
