### PR TITLE
Update more uses of Option, Some and None to camel case

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -149,7 +149,7 @@ pub pure fn chain_ref<T, U>(opt: &Option<T>,
 #[inline(always)]
 pub pure fn or<T>(opta: Option<T>, optb: Option<T>) -> Option<T> {
     /*!
-     * Returns the leftmost some() value, or none if both are none.
+     * Returns the leftmost Some() value, or None if both are None.
      */
     match move opta {
         Some(move opta) => Some(move opta),

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -114,10 +114,10 @@ variables from reassigned if there may be pointers to their interior)
 Finally, in some cases, both dangers can arise.  For example, something
 like the following:
 
-    let mut x = ~some(5);
+    let mut x = ~Some(5);
     match x {
-      ~some(ref y) => { ... }
-      ~none => { ... }
+      ~Some(ref y) => { ... }
+      ~None => { ... }
     }
 
 In this case, if `x` to be reassigned or `*x` were to be mutated, then

--- a/src/librustc/middle/borrowck/preserve.rs
+++ b/src/librustc/middle/borrowck/preserve.rs
@@ -226,8 +226,8 @@ priv impl &preserve_ctxt {
             //
             // As an example, consider this scenario:
             //
-            //    let mut x = @some(3);
-            //    match *x { Some(y) {...} none {...} }
+            //    let mut x = @Some(3);
+            //    match *x { Some(y) {...} None {...} }
             //
             // Technically, the value `x` need only be rooted
             // in the `some` arm.  However, we evaluate `x` in trans
@@ -236,8 +236,8 @@ priv impl &preserve_ctxt {
             //
             // As a second example, consider *this* scenario:
             //
-            //    let x = @mut @some(3);
-            //    match x { @@some(y) {...} @@none {...} }
+            //    let x = @mut @Some(3);
+            //    match x { @@Some(y) {...} @@None {...} }
             //
             // Here again, `x` need only be rooted in the `some` arm.
             // In this case, the value which needs to be rooted is

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -100,8 +100,8 @@ fn type_of(cx: @crate_ctxt, t: ty::t) -> TypeRef {
     // Replace any typedef'd types with their equivalent non-typedef
     // type. This ensures that all LLVM nominal types that contain
     // Rust types are defined as the same LLVM types.  If we don't do
-    // this then, e.g. `option<{myfield: bool}>` would be a different
-    // type than `option<myrec>`.
+    // this then, e.g. `Option<{myfield: bool}>` would be a different
+    // type than `Option<myrec>`.
     let t_norm = ty::normalize_ty(cx.tcx, t);
 
     if t != t_norm {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2696,7 +2696,7 @@ fn check_instantiable(tcx: ty::ctxt,
     if !ty::is_instantiable(tcx, item_ty) {
         tcx.sess.span_err(sp, fmt!("this type cannot be instantiated \
                   without an instance of itself; \
-                  consider using `option<%s>`",
+                  consider using `Option<%s>`",
                                    ppaux::ty_to_str(tcx, item_ty)));
     }
 }

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -492,13 +492,13 @@ fn lattice_var_and_t<L:LatticeDir Combine,
     match self.bnd(a_bounds) {
         Some(ref a_bnd) => {
             // If a has an upper bound, return the LUB(a.ub, b)
-            debug!("bnd=some(%s)", a_bnd.inf_str(self.infcx()));
+            debug!("bnd=Some(%s)", a_bnd.inf_str(self.infcx()));
             lattice_dir_op(a_bnd, b)
         }
         None => {
             // If a does not have an upper bound, make b the upper bound of a
             // and then return b.
-            debug!("bnd=none");
+            debug!("bnd=None");
             let a_bounds = self.with_bnd(a_bounds, *b);
             do self.combine_fields().bnds(&a_bounds.lb, &a_bounds.ub).then {
                 self.infcx().set(vb, a_id, Root(a_bounds, nde_a.rank));

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -468,7 +468,7 @@ fn read_future(sock: &TcpSocket, timeout_msecs: uint)
  *     }
  *     // this callback is ran when a new connection arrives
  *     {|new_conn, kill_ch|
- *     let cont_po = core::comm::port::<option<tcp_err_data>>();
+ *     let cont_po = core::comm::port::<Option<tcp_err_data>>();
  *     let cont_ch = core::comm::chan(cont_po);
  *     task::spawn {||
  *         let accept_result = net::tcp::accept(new_conn);
@@ -484,9 +484,9 @@ fn read_future(sock: &TcpSocket, timeout_msecs: uint)
  *     };
  *     match core::comm::recv(cont_po) {
  *       // shut down listen()
- *       some(err_data) { core::comm::send(kill_chan, some(err_data)) }
+ *       Some(err_data) { core::comm::send(kill_chan, Some(err_data)) }
  *       // wait for next connection
- *       none {}
+ *       None {}
  *     }
  * };
  * ~~~~~~~~~~~
@@ -593,7 +593,7 @@ pub fn accept(new_conn: TcpNewConnection)
  * callback's arguments are:
  *     * `new_conn` - an opaque type that can be passed to
  *     `net::tcp::accept` in order to be converted to a `tcp_socket`.
- *     * `kill_ch` - channel of type `core::comm::chan<option<tcp_err_data>>`.
+ *     * `kill_ch` - channel of type `core::comm::chan<Option<tcp_err_data>>`.
  *     this channel can be used to send a message to cause `listen` to begin
  *     closing the underlying libuv data structures.
  *

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -893,7 +893,7 @@ pub mod node {
      * # Return value
      *
      * * `option::None` if no transformation happened
-     * * `option::some(x)` otherwise, in which case `x` has the same contents
+     * * `option::Some(x)` otherwise, in which case `x` has the same contents
      *    as `node` bot lower height and/or fragmentation.
      */
     pub fn bal(node: @Node) -> Option<@Node> {

--- a/src/libstd/timer.rs
+++ b/src/libstd/timer.rs
@@ -100,11 +100,11 @@ pub fn sleep(iotask: IoTask, msecs: uint) {
 }
 
 /**
- * Receive on a port for (up to) a specified time, then return an `option<T>`
+ * Receive on a port for (up to) a specified time, then return an `Option<T>`
  *
  * This call will block to receive on the provided port for up to the
  * specified timeout. Depending on whether the provided port receives in that
- * time period, `recv_timeout` will return an `option<T>` representing the
+ * time period, `recv_timeout` will return an `Option<T>` representing the
  * result.
  *
  * # Arguments
@@ -115,9 +115,9 @@ pub fn sleep(iotask: IoTask, msecs: uint) {
  *
  * # Returns
  *
- * An `option<T>` representing the outcome of the call. If the call `recv`'d
+ * An `Option<T>` representing the outcome of the call. If the call `recv`'d
  * on the provided port in the allotted timeout period, then the result will
- * be a `some(T)`. If not, then `none` will be returned.
+ * be a `Some(T)`. If not, then `None` will be returned.
  */
 pub fn recv_timeout<T: Copy Owned>(iotask: IoTask,
                                    msecs: uint,

--- a/src/libstd/timer.rs
+++ b/src/libstd/timer.rs
@@ -255,7 +255,7 @@ mod test {
             };
 
             match recv_timeout(hl_loop, 10u, test_po) {
-              some(val) => {
+              Some(val) => {
                 assert val == expected;
                 successes += 1;
               }

--- a/src/test/compile-fail/issue-2354.rs
+++ b/src/test/compile-fail/issue-2354.rs
@@ -15,9 +15,9 @@
   xfailed for now (see Issue #2354)
  */
 fn foo() { //~ ERROR this open brace is not closed
-  match some(x) {
-      some(y) { fail; }
-      none    { fail; }
+  match Some(x) {
+      Some(y) { fail; }
+      None    { fail; }
 }
 
 fn bar() {

--- a/src/test/compile-fail/pat-ref-enum.rs
+++ b/src/test/compile-fail/pat-ref-enum.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn matcher(x: option<int>) {
+fn matcher(x: Option<int>) {
     match x {
-      ref some(i) => {} //~ ERROR expected identifier, found enum pattern
-      none => {}
+      ref Some(i) => {} //~ ERROR expected identifier, found enum pattern
+      None => {}
     }
 }
 

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -69,8 +69,8 @@ fn main() {
     let stmt = quote_stmt!(let x = 20;);
     check_pp(ext_cx, *stmt, pprust::print_stmt, ~"let x = 20;");
 
-    let pat = quote_pat!(some(_));
-    check_pp(ext_cx, pat, pprust::print_refutable_pat, ~"some(_)");
+    let pat = quote_pat!(Some(_));
+    check_pp(ext_cx, pat, pprust::print_refutable_pat, ~"Some(_)");
 
 }
 

--- a/src/test/run-pass/bind-by-move.rs
+++ b/src/test/run-pass/bind-by-move.rs
@@ -16,9 +16,9 @@ fn dispose(+_x: arc::ARC<bool>) unsafe { }
 
 fn main() {
     let p = arc::arc(true);
-    let x = some(p);
+    let x = Some(p);
     match move x {
-        some(move z) => { dispose(z); },
-        none => fail
+        Some(move z) => { dispose(z); },
+        None => fail
     }
 }

--- a/src/test/run-pass/class-impl-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-parameterized-trait.rs
@@ -55,8 +55,8 @@ class cat : map<int, bool> {
   fn contains_key(&&k: int) -> bool { k <= self.meows }
   fn get(&&k:int) -> bool { k <= self.meows }
   fn [](&&k:int) -> bool { k <= self.meows }
-  fn find(&&k:int) -> option<bool> { some(self.get(k)) }
-  fn remove(&&k:int) -> option<bool> { self.meows -= k; some(true) }
+  fn find(&&k:int) -> Option<bool> { Some(self.get(k)) }
+  fn remove(&&k:int) -> Option<bool> { self.meows -= k; Some(true) }
   fn each(f: fn(&&int, &&bool) -> bool) {
     let mut n = int::abs(self.meows);
     while n > 0 {

--- a/src/test/run-pass/class-implements-multiple-traits.rs
+++ b/src/test/run-pass/class-implements-multiple-traits.rs
@@ -23,7 +23,7 @@ trait noisy {
 }
 
 trait scratchy {
-  fn scratch() -> option<furniture>;
+  fn scratch() -> Option<furniture>;
 }
 
 trait bitey {
@@ -72,13 +72,13 @@ class cat : noisy, scratchy, bitey {
 
   fn speak() -> int { self.meow() as int }
   fn meow_count() -> uint { *self.meows }
-  fn scratch() -> option<furniture> {
+  fn scratch() -> Option<furniture> {
     let all = ~[chair, couch, bed];
     log(error, self.scratched);
-    let mut rslt = none;
+    let mut rslt = None;
     for each(all) |thing| { if !self.scratched.contains(thing) {
           self.scratched.push(thing);
-          return some(thing); }}
+          return Some(thing); }}
     rslt
   }
   fn bite() -> body_part {

--- a/src/test/run-pass/class-trait-bounded-param.rs
+++ b/src/test/run-pass/class-trait-bounded-param.rs
@@ -23,7 +23,7 @@ class keys<K: Copy, V: Copy, M: Copy map<K,V>>
     }
 
     fn each(blk: fn(K) -> bool) { self.map.each(|k, _v| blk(k) ) }
-    fn size_hint() -> option<uint> { some(self.map.size()) }
+    fn size_hint() -> Option<uint> { Some(self.map.size()) }
     fn eachi(blk: fn(uint, K) -> bool) { iter::eachi(self, blk) }
 }
 

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -310,8 +310,8 @@ fn main() {
 //    Commented out because of option::get error
 
     let (client_, server_) = pingpong::init();
-    let client_ = ~mut some(client_);
-    let server_ = ~mut some(server_);
+    let client_ = ~mut Some(client_);
+    let server_ = ~mut Some(server_);
 
     task::spawn {|move client_|
         let mut client__ = none;

--- a/src/test/run-pass/issue-2869.rs
+++ b/src/test/run-pass/issue-2869.rs
@@ -9,15 +9,15 @@
 // except according to those terms.
 
 // xfail-test
-enum pat { pat_ident(option<uint>) }
+enum pat { pat_ident(Option<uint>) }
 
 fn f(pat: pat) -> bool { true }
 
 fn num_bindings(pat: pat) -> uint {
     match pat {
       pat_ident(_) if f(pat) { 0 }
-      pat_ident(none) { 1 }
-      pat_ident(some(sub)) { sub }
+      pat_ident(None) { 1 }
+      pat_ident(Some(sub)) { sub }
     }
 }
 

--- a/src/test/run-pass/region-return-interior-of-option-in-self.rs
+++ b/src/test/run-pass/region-return-interior-of-option-in-self.rs
@@ -15,14 +15,14 @@ struct cell<T> {
 }
 
 struct cells<T> {
-    vals: ~[option<cell<T>>];
+    vals: ~[Option<cell<T>>];
 }
 
 impl<T> &cells<T> {
     fn get(idx: uint) -> &self/T {
         match self.vals[idx] {
-          some(ref v) => &v.value,
-          none => fail
+          Some(ref v) => &v.value,
+          None => fail
         }
     }
 }


### PR DESCRIPTION
I've updated most of the outstanding lowercase uses of Option, Some and None. I was inspired by the error message (corrected in 7ff7489dc62bdcc0dbd507c52cba90d47cfdd129) as it was slightly misleading.

There are still outstanding uses of the lowercase None. If this is useful, I'll go back and work through that list as well.

I haven't added any new regression tests. I wasn't sure they were appropriate in this case. Almost all of these changes are to places that the tests don't really cover: comments, xfailed tests and error and debug messages.

make check: summary of 23 test runs: 4252 passed; 0 failed; 280 ignored :)
