### PR TITLE
Forbid structural records

### DIFF
--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -12,6 +12,7 @@
 
 #[no_core];
 #[legacy_exports];
+#[legacy_records];
 
 #[allow(vecs_implicitly_copyable)];
 #[allow(non_camel_case_types)];

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -16,12 +16,12 @@ use io::ReaderUtil;
 use str;
 
 export load_errors;
-export expected_error;
+export ExpectedError;
 
-type expected_error = { line: uint, kind: ~str, msg: ~str };
+struct ExpectedError { line: uint, kind: ~str, msg: ~str }
 
 // Load any test directives embedded in the file
-fn load_errors(testfile: &Path) -> ~[expected_error] {
+fn load_errors(testfile: &Path) -> ~[ExpectedError] {
     let mut error_patterns = ~[];
     let rdr = io::file_reader(testfile).get();
     let mut line_num = 1u;
@@ -33,7 +33,7 @@ fn load_errors(testfile: &Path) -> ~[expected_error] {
     return error_patterns;
 }
 
-fn parse_expected(line_num: uint, line: ~str) -> ~[expected_error] {
+fn parse_expected(line_num: uint, line: ~str) -> ~[ExpectedError] {
     unsafe {
         let error_tag = ~"//~";
         let mut idx;
@@ -63,6 +63,7 @@ fn parse_expected(line_num: uint, line: ~str) -> ~[expected_error] {
 
         debug!("line=%u kind=%s msg=%s", line_num - adjust_line, kind, msg);
 
-        return ~[{line: line_num - adjust_line, kind: kind, msg: msg}];
+        return ~[ExpectedError{line: line_num - adjust_line, kind: kind,
+                               msg: msg}];
     }
 }

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -17,11 +17,11 @@ use io::ReaderUtil;
 use os;
 use str;
 
-export test_props;
+export TestProps;
 export load_props;
 export is_test_ignored;
 
-type test_props = {
+struct TestProps {
     // Lines that should be expected, in order, on standard out
     error_patterns: ~[~str],
     // Extra flags to pass to the compiler
@@ -33,10 +33,10 @@ type test_props = {
     aux_builds: ~[~str],
     // Environment settings to use during execution
     exec_env: ~[(~str,~str)]
-};
+}
 
 // Load any test directives embedded in the file
-fn load_props(testfile: &Path) -> test_props {
+fn load_props(testfile: &Path) -> TestProps {
     let mut error_patterns = ~[];
     let mut aux_builds = ~[];
     let mut exec_env = ~[];
@@ -64,7 +64,7 @@ fn load_props(testfile: &Path) -> test_props {
             exec_env.push(*ee);
         }
     };
-    return {
+    return TestProps {
         error_patterns: error_patterns,
         compile_flags: compile_flags,
         pp_exact: pp_exact,

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -51,13 +51,14 @@ fn target_env(_lib_path: ~str, _prog: ~str) -> ~[(~str,~str)] {
     ~[]
 }
 
+struct Result {status: int, out: ~str, err: ~str}
 
 // FIXME (#2659): This code is duplicated in core::run::program_output
 fn run(lib_path: ~str,
        prog: ~str,
        args: ~[~str],
        env: ~[(~str, ~str)],
-       input: Option<~str>) -> {status: int, out: ~str, err: ~str} {
+       input: Option<~str>) -> Result {
 
     let pipe_in = os::pipe();
     let pipe_out = os::pipe();
@@ -105,7 +106,7 @@ fn run(lib_path: ~str,
         };
         count -= 1;
     };
-    return {status: status, out: outs, err: errs};
+    return Result {status: status, out: outs, err: errs};
 }
 
 fn writeclose(fd: c_int, s: Option<~str>) {

--- a/src/libcore/extfmt.rs
+++ b/src/libcore/extfmt.rs
@@ -55,6 +55,9 @@
 #[forbid(deprecated_mode)];
 #[forbid(deprecated_pattern)];
 
+// Transitional
+#[allow(structural_records)]; // Macros -- needs a snapshot
+
 /*
 Syntax Extension: fmt
 

--- a/src/libcore/gc.rs
+++ b/src/libcore/gc.rs
@@ -38,6 +38,8 @@ with destructors.
 // NB: transitionary, de-mode-ing.
 #[forbid(deprecated_mode)];
 #[forbid(deprecated_pattern)];
+// Transitional
+#[allow(structural_records)];
 
 use cast;
 use io;

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -11,6 +11,7 @@
 // NB: transitionary, de-mode-ing.
 #[forbid(deprecated_mode)];
 #[forbid(deprecated_pattern)];
+#[allow(structural_records)];
 
 /*!
  * Higher-level interfaces to libc::* functions and operating system services.

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -87,6 +87,9 @@ bounded and unbounded protocols allows for less code duplication.
 // re-forbid after snapshot
 #[forbid(deprecated_pattern)];
 
+// Transitional -- needs snapshot
+#[allow(structural_records)];
+
 use cmp::Eq;
 use cast::{forget, reinterpret_cast, transmute};
 use either::{Either, Left, Right};

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -11,6 +11,7 @@
 // NB: transitionary, de-mode-ing.
 #[forbid(deprecated_mode)];
 #[forbid(deprecated_pattern)];
+#[allow(structural_records)];
 
 //! Process spawning
 use io;

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -213,7 +213,7 @@ fn get_lint_dict() -> lint_dict {
         (~"structural_records",
          @{lint: structural_records,
            desc: "use of any structural records",
-           default: allow}),
+           default: deny}),
 
         (~"legacy modes",
          @{lint: legacy_modes,
@@ -663,21 +663,23 @@ fn check_item_deprecated_self(cx: ty::ctxt, item: @ast::item) {
 }
 
 fn check_item_structural_records(cx: ty::ctxt, it: @ast::item) {
-    let visit = item_stopping_visitor(
-        visit::mk_simple_visitor(@visit::SimpleVisitor {
-            visit_expr: |e: @ast::expr| {
-                match e.node {
-                    ast::expr_rec(*) =>
-                    cx.sess.span_lint(
-                        structural_records, e.id, it.id,
-                        e.span,
-                        ~"structural records are deprecated"),
-                    _ => ()
-                }
-            },
-            .. *visit::default_simple_visitor()
-        }));
-    visit::visit_item(it, (), visit);
+    if !cx.legacy_records {
+        let visit = item_stopping_visitor(
+            visit::mk_simple_visitor(@visit::SimpleVisitor {
+                visit_expr: |e: @ast::expr| {
+                    match e.node {
+                        ast::expr_rec(*) =>
+                            cx.sess.span_lint(
+                                structural_records, e.id, it.id,
+                                e.span,
+                                ~"structural records are deprecated"),
+                        _ => ()
+                    }
+                },
+                .. *visit::default_simple_visitor()
+            }));
+        visit::visit_item(it, (), visit);
+    }
 }
 
 fn check_item_ctypes(cx: ty::ctxt, it: @ast::item) {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -416,6 +416,7 @@ type ctxt =
       mut next_id: uint,
       vecs_implicitly_copyable: bool,
       legacy_modes: bool,
+      legacy_records: bool,
       cstore: metadata::cstore::CStore,
       sess: session::Session,
       def_map: resolve::DefMap,
@@ -975,11 +976,16 @@ fn mk_ctxt(s: session::Session,
            +lang_items: middle::lang_items::LanguageItems,
            crate: @ast::crate) -> ctxt {
     let mut legacy_modes = false;
+    let mut legacy_records = false;
     for crate.node.attrs.each |attribute| {
         match attribute.node.value.node {
             ast::meta_word(ref w) if (*w) == ~"legacy_modes" => {
                 legacy_modes = true;
-                break;
+                if legacy_records { break; }
+            }
+            ast::meta_word(ref w) if (*w) == ~"legacy_records" => {
+                legacy_records = true;
+                if legacy_modes { break; }
             }
             _ => {}
         }
@@ -994,6 +1000,7 @@ fn mk_ctxt(s: session::Session,
       mut next_id: 0u,
       vecs_implicitly_copyable: vecs_implicitly_copyable,
       legacy_modes: legacy_modes,
+      legacy_records: legacy_records,
       cstore: s.cstore,
       sess: s,
       def_map: dm,

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -20,6 +20,7 @@
 
 #[legacy_modes];
 #[legacy_exports];
+#[legacy_records];
 
 #[allow(non_implicitly_copyable_typarams)];
 #[allow(non_camel_case_types)];

--- a/src/librustdoc/rustdoc.rc
+++ b/src/librustdoc/rustdoc.rc
@@ -21,6 +21,7 @@
 
 #[no_core];
 #[legacy_modes];
+#[legacy_records];
 
 #[allow(vecs_implicitly_copyable)];
 #[allow(non_implicitly_copyable_typarams)];

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -17,6 +17,7 @@
 
 #[crate_type = "lib"];
 
+#[legacy_records];
 #[no_core];
 
 #[allow(vecs_implicitly_copyable,

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -33,6 +33,10 @@ not required in or otherwise suitable for the core library.
 #[allow(deprecated_mode)];
 #[forbid(deprecated_pattern)];
 
+
+// Transitional
+#[legacy_records];
+
 #[no_core];
 
 extern mod core(vers = "0.6");

--- a/src/libsyntax/syntax.rc
+++ b/src/libsyntax/syntax.rc
@@ -18,6 +18,7 @@
 
 #[legacy_modes];
 #[legacy_exports];
+#[legacy_records];
 
 #[allow(vecs_implicitly_copyable)];
 #[allow(non_camel_case_types)];
@@ -40,6 +41,7 @@ pub mod syntax {
 mod attr;
 #[legacy_exports]
 mod diagnostic;
+#[legacy_records]
 mod codemap;
 #[legacy_exports]
 mod ast;
@@ -107,8 +109,8 @@ mod ext {
     #[legacy_exports]
     mod source_util;
 
-    #[legacy_exports]
     #[path = "pipes/mod.rs"]
+    #[legacy_exports]
     mod pipes;
 
     #[legacy_exports]

--- a/src/test/run-pass/pipe-detect-term.rs
+++ b/src/test/run-pass/pipe-detect-term.rs
@@ -14,6 +14,8 @@
 
 // xfail-win32
 
+#[legacy_records];
+
 extern mod std;
 use std::timer::sleep;
 use std::uv;

--- a/src/test/run-pass/pipe-peek.rs
+++ b/src/test/run-pass/pipe-peek.rs
@@ -10,6 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[legacy_records];
 
 extern mod std;
 use std::timer::sleep;

--- a/src/test/run-pass/pipe-pingpong-bounded.rs
+++ b/src/test/run-pass/pipe-pingpong-bounded.rs
@@ -17,6 +17,8 @@
 
 // This was generated initially by the pipe compiler, but it's been
 // modified in hopefully straightforward ways.
+#[legacy_records];
+
 mod pingpong {
     use core::pipes::*;
     use core::ptr;

--- a/src/test/run-pass/pipe-pingpong-proto.rs
+++ b/src/test/run-pass/pipe-pingpong-proto.rs
@@ -12,6 +12,8 @@
 
 // An example to make sure the protocol parsing syntax extension works.
 
+#[legacy_records];
+
 use core::option;
 
 proto! pingpong (

--- a/src/test/run-pass/pipe-presentation-examples.rs
+++ b/src/test/run-pass/pipe-presentation-examples.rs
@@ -15,6 +15,7 @@
 // Code is easier to write in emacs, and it's good to be sure all the
 // code samples compile (or not) as they should.
 
+#[legacy_records];
 
 use double_buffer::client::*;
 use double_buffer::give_buffer;

--- a/src/test/run-pass/pipe-select.rs
+++ b/src/test/run-pass/pipe-select.rs
@@ -13,6 +13,8 @@
 // xfail-pretty
 // xfail-win32
 
+#[legacy_records];
+
 extern mod std;
 use std::timer::sleep;
 use std::uv;

--- a/src/test/run-pass/pipe-sleep.rs
+++ b/src/test/run-pass/pipe-sleep.rs
@@ -10,6 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[legacy_records];
 
 extern mod std;
 use std::timer::sleep;


### PR DESCRIPTION
r? @pcwalton - Disallow structural records by default, allow them at the crate level where necessary. (I already pushed patches to remove uses of structural records for most run-pass and run-fail tests; haven't gotten as far as compile-fail and docs yet, so this won't build, but I won't push as-is.)
