### PR TITLE
get rid of LinearMap's find_copy method

### DIFF
--- a/src/libcargo/cargo.rc
+++ b/src/libcargo/cargo.rc
@@ -465,20 +465,20 @@ fn parse_source(name: ~str, j: &json::Json) -> @Source {
 
     match *j {
         json::Object(j) => {
-            let mut url = match j.find_copy(&~"url") {
-                Some(json::String(u)) => u,
+            let mut url = match j.find(&~"url") {
+                Some(&json::String(u)) => copy u,
                 _ => fail ~"needed 'url' field in source"
             };
-            let method = match j.find_copy(&~"method") {
-                Some(json::String(u)) => u,
+            let method = match j.find(&~"method") {
+                Some(&json::String(u)) => copy u,
                 _ => assume_source_method(url)
             };
-            let key = match j.find_copy(&~"key") {
-                Some(json::String(u)) => Some(u),
+            let key = match j.find(&~"key") {
+                Some(&json::String(u)) => Some(copy u),
                 _ => None
             };
-            let keyfp = match j.find_copy(&~"keyfp") {
-                Some(json::String(u)) => Some(u),
+            let keyfp = match j.find(&~"keyfp") {
+                Some(&json::String(u)) => Some(copy u),
                 _ => None
             };
             if method == ~"file" {
@@ -512,8 +512,8 @@ fn try_parse_sources(filename: &Path, sources: map::HashMap<~str, @Source>) {
 }
 
 fn load_one_source_package(src: @Source, p: &json::Object) {
-    let name = match p.find_copy(&~"name") {
-        Some(json::String(n)) => {
+    let name = match p.find(&~"name") {
+        Some(&json::String(n)) => {
             if !valid_pkg_name(n) {
                 warn(~"malformed source json: "
                      + src.name + ~", '" + n + ~"'"+
@@ -529,15 +529,15 @@ fn load_one_source_package(src: @Source, p: &json::Object) {
         }
     };
 
-    let uuid = match p.find_copy(&~"uuid") {
-        Some(json::String(n)) => {
+    let uuid = match p.find(&~"uuid") {
+        Some(&json::String(n)) => {
             if !is_uuid(n) {
                 warn(~"malformed source json: "
                      + src.name + ~", '" + n + ~"'"+
                      ~" is an invalid uuid");
                 return;
             }
-            n
+            copy n
         }
         _ => {
             warn(~"malformed source json: " + src.name + ~" (missing uuid)");
@@ -545,16 +545,16 @@ fn load_one_source_package(src: @Source, p: &json::Object) {
         }
     };
 
-    let url = match p.find_copy(&~"url") {
-        Some(json::String(n)) => n,
+    let url = match p.find(&~"url") {
+        Some(&json::String(n)) => copy n,
         _ => {
             warn(~"malformed source json: " + src.name + ~" (missing url)");
             return;
         }
     };
 
-    let method = match p.find_copy(&~"method") {
-        Some(json::String(n)) => n,
+    let method = match p.find(&~"method") {
+        Some(&json::String(n)) => copy n,
         _ => {
             warn(~"malformed source json: "
                  + src.name + ~" (missing method)");
@@ -562,14 +562,14 @@ fn load_one_source_package(src: @Source, p: &json::Object) {
         }
     };
 
-    let reference = match p.find_copy(&~"ref") {
-        Some(json::String(n)) => Some(n),
+    let reference = match p.find(&~"ref") {
+        Some(&json::String(n)) => Some(copy n),
         _ => None
     };
 
     let mut tags = ~[];
-    match p.find_copy(&~"tags") {
-        Some(json::List(js)) => {
+    match p.find(&~"tags") {
+        Some(&json::List(js)) => {
           for js.each |j| {
                 match *j {
                     json::String(ref j) => tags.grow(1u, j),
@@ -580,8 +580,8 @@ fn load_one_source_package(src: @Source, p: &json::Object) {
         _ => ()
     }
 
-    let description = match p.find_copy(&~"description") {
-        Some(json::String(n)) => n,
+    let description = match p.find(&~"description") {
+        Some(&json::String(n)) => copy n,
         _ => {
             warn(~"malformed source json: " + src.name
                  + ~" (missing description)");

--- a/src/libcore/hashmap.rs
+++ b/src/libcore/hashmap.rs
@@ -389,24 +389,6 @@ pub mod linear {
         }
     }
 
-    impl<K: Hash IterBytes Eq, V: Copy> LinearMap<K, V> {
-        pure fn find_copy(&self, k: &K) -> Option<V> {
-            match self.bucket_for_key(self.buckets, k) {
-                FoundEntry(idx) => {
-                    // FIXME (#3148): Once we rewrite found_entry, this
-                    // failure case won't be necessary
-                    match self.buckets[idx] {
-                        Some(Bucket {value: copy value, _}) => {Some(value)}
-                        None => fail ~"LinearMap::find: internal logic error"
-                    }
-                }
-                TableFull | FoundHole(_) => {
-                    None
-                }
-            }
-        }
-    }
-
     impl<K: Hash IterBytes Eq, V: Eq> LinearMap<K, V>: Eq {
         pure fn eq(&self, other: &LinearMap<K, V>) -> bool {
             if self.len() != other.len() { return false; }
@@ -560,8 +542,8 @@ pub mod test {
         }
         assert m.len() == 0;
         assert m2.len() == 2;
-        assert m2.find_copy(&1) == Some(2);
-        assert m2.find_copy(&2) == Some(3);
+        assert m2.get(&1) == &2;
+        assert m2.get(&2) == &3;
     }
 
     #[test]

--- a/src/libstd/workcache.rs
+++ b/src/libstd/workcache.rs
@@ -167,15 +167,27 @@ struct Database {
 }
 
 impl Database {
-
-    fn prepare(&mut self,
-               fn_name: &str,
-               declared_inputs: &WorkMap) ->
-        Option<(WorkMap, WorkMap, ~str)> {
+    #[cfg(stage0)]
+    #[cfg(stage1)]
+    fn prepare(&mut self, fn_name: &str,
+               declared_inputs: &WorkMap) -> Option<(WorkMap, WorkMap, ~str)>
+    {
         let k = json_encode(&(fn_name, declared_inputs));
-        match self.db_cache.find_copy(&k) {
+        let db_cache = copy self.db_cache;
+        match db_cache.find(&k) {
             None => None,
-            Some(v) => Some(json_decode(v))
+            Some(&v) => Some(json_decode(copy v))
+        }
+    }
+
+    #[cfg(stage2)]
+    fn prepare(&mut self, fn_name: &str,
+               declared_inputs: &WorkMap) -> Option<(WorkMap, WorkMap, ~str)>
+    {
+        let k = json_encode(&(fn_name, declared_inputs));
+        match self.db_cache.find(&k) {
+            None => None,
+            Some(&v) => Some(json_decode(copy v))
         }
     }
 

--- a/src/test/run-pass/issue-2804.rs
+++ b/src/test/run-pass/issue-2804.rs
@@ -23,9 +23,9 @@ enum object
 
 fn lookup(table: ~json::Object, key: ~str, default: ~str) -> ~str
 {
-    match table.find_copy(&key)
+    match table.find(&key)
     {
-        option::Some(std::json::String(copy s)) =>
+        option::Some(&std::json::String(copy s)) =>
         {
             copy s
         }


### PR DESCRIPTION
As with the now removed `get_copy` method, this is the same as just doing a copy in the caller and doesn't offer an advantage in either simplicity or performance (it also doesn't work with `Clone`). It duplicated the implementation of the `find` too.

This was still necessary until the recent changes to the borrow checker that allow reborrowing `&mut` as `&`. The update to `workcache.rs` shows an example of the benefit from that change (`find_copy` or copying the entire map was required before).
