### PR TITLE
Task tutorial revisions

### DIFF
--- a/doc/tutorial-tasks.md
+++ b/doc/tutorial-tasks.md
@@ -198,7 +198,7 @@ do spawn |move chan| {
 }
 ~~~~
 
-Notice that `move chan` is not a normal formal parameter binding; it is a
+Notice that `move chan` is not a normal formal parameter binding; it is an
 environment capture clause for the closure.  This capture clause binds the
 variable `chan` within the closure; the keyword `move` indicates the channel
 should be transferred (as opposed to copied or captured by reference) when the

--- a/doc/tutorial-tasks.md
+++ b/doc/tutorial-tasks.md
@@ -198,11 +198,15 @@ do spawn |move chan| {
 }
 ~~~~
 
-Notice that the creation of the task closure transfers `chan` to the child
-task implicitly: the closure captures `chan` in its environment. Both `Chan`
+Notice that `move chan` is not a normal formal parameter binding; it is a
+environment capture clause for the closure.  This capture clause binds the
+variable `chan` within the closure; the keyword `move` indicates the channel
+should be transferred (as opposed to copied or captured by reference) when the
+anonymous function expression is evaluated. The resulting closure has zero
+formal parameters, as required by the type signature of `spawn`.  Both `Chan`
 and `Port` are sendable types and may be captured into tasks or otherwise
 transferred between them. In the example, the child task runs an expensive
-computation, then sends the result over the captured channel.
+computation, then sends the result over the transferred channel.
 
 Finally, the parent continues with some other expensive
 computation, then waits for the child's result to arrive on the

--- a/doc/tutorial-tasks.md
+++ b/doc/tutorial-tasks.md
@@ -394,7 +394,7 @@ before returning. Hence:
 
 ~~~
 # use pipes::{stream, Chan, Port};
-# use task::{spawn, try};
+use task::{spawn, try};
 # fn sleep_forever() { loop { task::yield() } }
 # do task::try {
 let (receiver, sender): (Port<int>, Chan<int>) = stream();


### PR DESCRIPTION
I was pretty confused by the task tutorial, since one of the code snippets seemed to contradict the surrounding text and also made use of a syntax that is not sufficiently documented.

I am attempting to improve matters.  Maybe future effort would be better spent adding better docs for environment capture clauses.  (Or working on changing their syntax?)

Anyway, this seems like these changes should be an improvement.
