### PR TITLE
Fix the len() method on LinearMap during popping

### DIFF
--- a/src/libcore/hashmap.rs
+++ b/src/libcore/hashmap.rs
@@ -220,6 +220,9 @@ pub mod linear {
                 },
             };
 
+            /* re-inserting buckets may cause changes in size, so remember what
+               our new size is ahead of time before we start insertions */
+            let size = self.size - 1;
             idx = self.next_bucket(idx, len_buckets);
             while self.buckets[idx].is_some() {
                 let mut bucket = None;
@@ -227,7 +230,7 @@ pub mod linear {
                 self.insert_opt_bucket(bucket);
                 idx = self.next_bucket(idx, len_buckets);
             }
-            self.size -= 1;
+            self.size = size;
 
             value
         }


### PR DESCRIPTION
I found while using `LinearMap` that it would often get its size out of sync with the actual number of elements. I found out that during `pop` the invocations of `insert_opt_bucket` might increment the size even though nothing new was being inserted.

I tried to create a simple test case or two, but I was unable to recreate the exact sequence of operations which would lead to the bug being triggered.
