### PR TITLE
 	librustc: Strdup unique strings instead of copying in byte by byte. Shaves 2MB off librustc at -O0.

### DIFF
--- a/src/libcore/rt.rs
+++ b/src/libcore/rt.rs
@@ -14,7 +14,7 @@
 //! Runtime calls emitted by the compiler.
 
 use cast::transmute;
-use libc::{c_char, c_void, size_t, uintptr_t};
+use libc::{c_char, c_uchar, c_void, size_t, uintptr_t};
 use managed::raw::BoxRepr;
 use str;
 use sys;
@@ -121,6 +121,11 @@ pub unsafe fn check_not_borrowed(a: *u8) {
     if ((*a).header.ref_count & FROZEN_BIT) != 0 {
         rt_fail_borrowed();
     }
+}
+
+#[lang="strdup_uniq"]
+pub unsafe fn strdup_uniq(ptr: *c_uchar, len: uint) -> ~str {
+    str::raw::from_buf_len(ptr, len)
 }
 
 // Local Variables:

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -74,16 +74,17 @@ pub enum LangItem {
     BorrowAsImmFnLangItem,      // 30
     ReturnToMutFnLangItem,      // 31
     CheckNotBorrowedFnLangItem, // 32
+    StrDupUniqFnLangItem,       // 33
 }
 
 struct LanguageItems {
-    items: [ Option<def_id> * 33 ]
+    items: [ Option<def_id> * 34 ]
 }
 
 impl LanguageItems {
     static pub fn new() -> LanguageItems {
         LanguageItems {
-            items: [ None, ..33 ]
+            items: [ None, ..34 ]
         }
     }
 
@@ -133,6 +134,7 @@ impl LanguageItems {
             30 => "borrow_as_imm",
             31 => "return_to_mut",
             32 => "check_not_borrowed",
+            33 => "strdup_uniq",
 
             _ => "???"
         }
@@ -243,6 +245,9 @@ impl LanguageItems {
     pub fn check_not_borrowed_fn(&const self) -> def_id {
         self.items[CheckNotBorrowedFnLangItem as uint].get()
     }
+    pub fn strdup_uniq_fn(&const self) -> def_id {
+        self.items[StrDupUniqFnLangItem as uint].get()
+    }
 }
 
 fn LanguageItemCollector(crate: @crate,
@@ -289,6 +294,7 @@ fn LanguageItemCollector(crate: @crate,
     item_refs.insert(~"return_to_mut", ReturnToMutFnLangItem as uint);
     item_refs.insert(~"check_not_borrowed",
                      CheckNotBorrowedFnLangItem as uint);
+    item_refs.insert(~"strdup_uniq", StrDupUniqFnLangItem as uint);
 
     LanguageItemCollector {
         crate: crate,

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -39,29 +39,29 @@ use syntax::visit;
 // Represents a (possibly monomorphized) top-level fn item or method
 // item.  Note that this is just the fn-ptr and is not a Rust closure
 // value (which is a pair).
-struct FnData {
+pub struct FnData {
     llfn: ValueRef,
 }
 
-struct MethodData {
+pub struct MethodData {
     llfn: ValueRef,
     llself: ValueRef,
     self_ty: ty::t,
     self_mode: ast::rmode
 }
 
-enum CalleeData {
+pub enum CalleeData {
     Closure(Datum),
     Fn(FnData),
     Method(MethodData)
 }
 
-struct Callee {
+pub struct Callee {
     bcx: block,
     data: CalleeData
 }
 
-fn trans(bcx: block, expr: @ast::expr) -> Callee {
+pub fn trans(bcx: block, expr: @ast::expr) -> Callee {
     let _icx = bcx.insn_ctxt("trans_callee");
 
     // pick out special kinds of expressions that can be called:
@@ -133,17 +133,16 @@ fn trans(bcx: block, expr: @ast::expr) -> Callee {
     }
 }
 
-fn trans_fn_ref_to_callee(bcx: block,
-                          def_id: ast::def_id,
-                          ref_id: ast::node_id) -> Callee
-{
+pub fn trans_fn_ref_to_callee(bcx: block,
+                              def_id: ast::def_id,
+                              ref_id: ast::node_id) -> Callee {
     Callee {bcx: bcx,
             data: Fn(trans_fn_ref(bcx, def_id, ref_id))}
 }
 
-fn trans_fn_ref(bcx: block,
-                def_id: ast::def_id,
-                ref_id: ast::node_id) -> FnData {
+pub fn trans_fn_ref(bcx: block,
+                    def_id: ast::def_id,
+                    ref_id: ast::node_id) -> FnData {
     /*!
      *
      * Translates a reference (with id `ref_id`) to the fn/method
@@ -158,26 +157,25 @@ fn trans_fn_ref(bcx: block,
     trans_fn_ref_with_vtables(bcx, def_id, ref_id, type_params, vtables)
 }
 
-fn trans_fn_ref_with_vtables_to_callee(bcx: block,
-                                       def_id: ast::def_id,
-                                       ref_id: ast::node_id,
-                                       +type_params: ~[ty::t],
-                                       vtables: Option<typeck::vtable_res>)
-    -> Callee
-{
+pub fn trans_fn_ref_with_vtables_to_callee(
+        bcx: block,
+        def_id: ast::def_id,
+        ref_id: ast::node_id,
+        +type_params: ~[ty::t],
+        vtables: Option<typeck::vtable_res>)
+     -> Callee {
     Callee {bcx: bcx,
             data: Fn(trans_fn_ref_with_vtables(bcx, def_id, ref_id,
                                                type_params, vtables))}
 }
 
-fn trans_fn_ref_with_vtables(
-    bcx: block,            //
-    def_id: ast::def_id,   // def id of fn
-    ref_id: ast::node_id,  // node id of use of fn; may be zero if N/A
-    +type_params: ~[ty::t], // values for fn's ty params
-    vtables: Option<typeck::vtable_res>)
-    -> FnData
-{
+pub fn trans_fn_ref_with_vtables(
+        bcx: block,            //
+        def_id: ast::def_id,   // def id of fn
+        ref_id: ast::node_id,  // node id of use of fn; may be zero if N/A
+        +type_params: ~[ty::t], // values for fn's ty params
+        vtables: Option<typeck::vtable_res>)
+     -> FnData {
     //!
     //
     // Translates a reference to a fn/method item, monomorphizing and
@@ -289,26 +287,25 @@ fn trans_fn_ref_with_vtables(
 // ______________________________________________________________________
 // Translating calls
 
-fn trans_call(in_cx: block,
-              call_ex: @ast::expr,
-              f: @ast::expr,
-              args: CallArgs,
-              id: ast::node_id,
-              dest: expr::Dest)
-    -> block
-{
+pub fn trans_call(in_cx: block,
+                  call_ex: @ast::expr,
+                  f: @ast::expr,
+                  args: CallArgs,
+                  id: ast::node_id,
+                  dest: expr::Dest)
+               -> block {
     let _icx = in_cx.insn_ctxt("trans_call");
     trans_call_inner(
         in_cx, call_ex.info(), expr_ty(in_cx, f), node_id_type(in_cx, id),
         |cx| trans(cx, f), args, dest, DontAutorefArg)
 }
 
-fn trans_method_call(in_cx: block,
-                     call_ex: @ast::expr,
-                     rcvr: @ast::expr,
-                     args: CallArgs,
-                     dest: expr::Dest)
-                  -> block {
+pub fn trans_method_call(in_cx: block,
+                         call_ex: @ast::expr,
+                         rcvr: @ast::expr,
+                         args: CallArgs,
+                         dest: expr::Dest)
+                      -> block {
     let _icx = in_cx.insn_ctxt("trans_method_call");
     trans_call_inner(
         in_cx,
@@ -335,8 +332,11 @@ fn trans_method_call(in_cx: block,
         DontAutorefArg)
 }
 
-fn trans_rtcall_or_lang_call(bcx: block, did: ast::def_id, args: ~[ValueRef],
-                             dest: expr::Dest) -> block {
+pub fn trans_rtcall_or_lang_call(bcx: block,
+                                 did: ast::def_id,
+                                 args: ~[ValueRef],
+                                 dest: expr::Dest)
+                              -> block {
     let fty = if did.crate == ast::local_crate {
         ty::node_id_to_type(bcx.ccx().tcx, did.node)
     } else {
@@ -349,11 +349,12 @@ fn trans_rtcall_or_lang_call(bcx: block, did: ast::def_id, args: ~[ValueRef],
         ArgVals(args), dest, DontAutorefArg);
 }
 
-fn trans_rtcall_or_lang_call_with_type_params(bcx: block,
-                                              did: ast::def_id,
-                                              args: ~[ValueRef],
-                                              type_params: ~[ty::t],
-                                              dest: expr::Dest) -> block {
+pub fn trans_rtcall_or_lang_call_with_type_params(bcx: block,
+                                                  did: ast::def_id,
+                                                  args: ~[ValueRef],
+                                                  type_params: ~[ty::t],
+                                                  dest: expr::Dest)
+                                               -> block {
     let fty;
     if did.crate == ast::local_crate {
         fty = ty::node_id_to_type(bcx.tcx(), did.node);
@@ -389,7 +390,7 @@ fn trans_rtcall_or_lang_call_with_type_params(bcx: block,
         ArgVals(args), dest, DontAutorefArg);
 }
 
-fn body_contains_ret(body: ast::blk) -> bool {
+pub fn body_contains_ret(body: ast::blk) -> bool {
     let cx = {mut found: false};
     visit::visit_block(body, cx, visit::mk_vt(@visit::Visitor {
         visit_item: |_i, _cx, _v| { },
@@ -407,7 +408,7 @@ fn body_contains_ret(body: ast::blk) -> bool {
 }
 
 // See [Note-arg-mode]
-fn trans_call_inner(
+pub fn trans_call_inner(
     ++in_cx: block,
     call_info: Option<node_info>,
     fn_expr_ty: ty::t,
@@ -415,8 +416,7 @@ fn trans_call_inner(
     get_callee: fn(block) -> Callee,
     args: CallArgs,
     dest: expr::Dest,
-    autoref_arg: AutorefArg) -> block
-{
+    autoref_arg: AutorefArg) -> block {
     do base::with_scope(in_cx, call_info, ~"call") |cx| {
         let ret_in_loop = match /*bad*/copy args {
           ArgExprs(args) => {
@@ -520,21 +520,19 @@ fn trans_call_inner(
     }
 }
 
-
-enum CallArgs {
+pub enum CallArgs {
     ArgExprs(~[@ast::expr]),
     ArgVals(~[ValueRef])
 }
 
-fn trans_args(cx: block,
-              llenv: ValueRef,
-              +args: CallArgs,
-              fn_ty: ty::t,
-              dest: expr::Dest,
-              ret_flag: Option<ValueRef>,
-              +autoref_arg: AutorefArg)
-    -> {bcx: block, args: ~[ValueRef], retslot: ValueRef}
-{
+pub fn trans_args(cx: block,
+                  llenv: ValueRef,
+                  +args: CallArgs,
+                  fn_ty: ty::t,
+                  dest: expr::Dest,
+                  ret_flag: Option<ValueRef>,
+                  +autoref_arg: AutorefArg)
+               -> {bcx: block, args: ~[ValueRef], retslot: ValueRef} {
     let _icx = cx.insn_ctxt("trans_args");
     let mut temp_cleanups = ~[];
     let arg_tys = ty::ty_fn_args(fn_ty);
@@ -594,21 +592,19 @@ fn trans_args(cx: block,
     return {bcx: bcx, args: llargs, retslot: llretslot};
 }
 
-enum AutorefArg {
+pub enum AutorefArg {
     DontAutorefArg,
     DoAutorefArg
 }
 
 // temp_cleanups: cleanups that should run only if failure occurs before the
 // call takes place:
-fn trans_arg_expr(bcx: block,
-                  formal_ty: ty::arg,
-                  arg_expr: @ast::expr,
-                  temp_cleanups: &mut ~[ValueRef],
-                  ret_flag: Option<ValueRef>,
-                  +autoref_arg: AutorefArg)
-    -> Result
-{
+pub fn trans_arg_expr(bcx: block,
+                      formal_ty: ty::arg,
+                      arg_expr: @ast::expr,
+                      temp_cleanups: &mut ~[ValueRef],
+                      ret_flag: Option<ValueRef>,
+                      +autoref_arg: AutorefArg) -> Result {
     let _icx = bcx.insn_ctxt("trans_arg_expr");
     let ccx = bcx.ccx();
 

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -18,9 +18,12 @@ use middle::trans::datum::*;
 
 use core::str;
 
-fn macros() { include!("macros.rs"); } // FIXME(#3114): Macro import/export.
+pub fn macros() {
+    // FIXME(#3114): Macro import/export.
+    include!("macros.rs");
+}
 
-fn trans_block(bcx: block, b: ast::blk, dest: expr::Dest) -> block {
+pub fn trans_block(bcx: block, b: ast::blk, dest: expr::Dest) -> block {
     let _icx = bcx.insn_ctxt("trans_block");
     let mut bcx = bcx;
     do block_locals(b) |local| {
@@ -42,13 +45,12 @@ fn trans_block(bcx: block, b: ast::blk, dest: expr::Dest) -> block {
     return bcx;
 }
 
-fn trans_if(bcx: block,
+pub fn trans_if(bcx: block,
             cond: @ast::expr,
             thn: ast::blk,
             els: Option<@ast::expr>,
             dest: expr::Dest)
-    -> block
-{
+         -> block {
     debug!("trans_if(bcx=%s, cond=%s, thn=%?, dest=%s)",
            bcx.to_str(), bcx.expr_to_str(cond), thn.node.id,
            dest.to_str(bcx.ccx()));
@@ -95,7 +97,7 @@ fn trans_if(bcx: block,
 
 }
 
-fn join_blocks(parent_bcx: block, in_cxs: ~[block]) -> block {
+pub fn join_blocks(parent_bcx: block, in_cxs: ~[block]) -> block {
     let out = sub_block(parent_bcx, ~"join");
     let mut reachable = false;
     for vec::each(in_cxs) |bcx| {
@@ -110,8 +112,7 @@ fn join_blocks(parent_bcx: block, in_cxs: ~[block]) -> block {
     return out;
 }
 
-fn trans_while(bcx: block, cond: @ast::expr, body: ast::blk)
-    -> block {
+pub fn trans_while(bcx: block, cond: @ast::expr, body: ast::blk) -> block {
     let _icx = bcx.insn_ctxt("trans_while");
     let next_bcx = sub_block(bcx, ~"while next");
 
@@ -149,7 +150,10 @@ fn trans_while(bcx: block, cond: @ast::expr, body: ast::blk)
     return next_bcx;
 }
 
-fn trans_loop(bcx:block, body: ast::blk, opt_label: Option<ident>) -> block {
+pub fn trans_loop(bcx:block,
+                  body: ast::blk,
+                  opt_label: Option<ident>)
+               -> block {
     let _icx = bcx.insn_ctxt("trans_loop");
     let next_bcx = sub_block(bcx, ~"next");
     let body_bcx_in = loop_scope_block(bcx, next_bcx, opt_label, ~"`loop`",
@@ -160,11 +164,10 @@ fn trans_loop(bcx:block, body: ast::blk, opt_label: Option<ident>) -> block {
     return next_bcx;
 }
 
-fn trans_log(log_ex: @ast::expr,
-             lvl: @ast::expr,
-             bcx: block,
-             e: @ast::expr) -> block
-{
+pub fn trans_log(log_ex: @ast::expr,
+                 lvl: @ast::expr,
+                 bcx: block,
+                 e: @ast::expr) -> block {
     let _icx = bcx.insn_ctxt("trans_log");
     let ccx = bcx.ccx();
     let mut bcx = bcx;
@@ -223,8 +226,10 @@ fn trans_log(log_ex: @ast::expr,
     }
 }
 
-fn trans_break_cont(bcx: block, opt_label: Option<ident>, to_end: bool)
-    -> block {
+pub fn trans_break_cont(bcx: block,
+                        opt_label: Option<ident>,
+                        to_end: bool)
+                     -> block {
     let _icx = bcx.insn_ctxt("trans_break_cont");
     // Locate closest loop block, outputting cleanup as we go.
     let mut unwind = bcx;
@@ -270,15 +275,15 @@ fn trans_break_cont(bcx: block, opt_label: Option<ident>, to_end: bool)
     return bcx;
 }
 
-fn trans_break(bcx: block, label_opt: Option<ident>) -> block {
+pub fn trans_break(bcx: block, label_opt: Option<ident>) -> block {
     return trans_break_cont(bcx, label_opt, true);
 }
 
-fn trans_cont(bcx: block, label_opt: Option<ident>) -> block {
+pub fn trans_cont(bcx: block, label_opt: Option<ident>) -> block {
     return trans_break_cont(bcx, label_opt, false);
 }
 
-fn trans_ret(bcx: block, e: Option<@ast::expr>) -> block {
+pub fn trans_ret(bcx: block, e: Option<@ast::expr>) -> block {
     let _icx = bcx.insn_ctxt("trans_ret");
     let mut bcx = bcx;
     let retptr = match copy bcx.fcx.loop_ret {
@@ -306,8 +311,12 @@ fn trans_ret(bcx: block, e: Option<@ast::expr>) -> block {
     Unreachable(bcx);
     return bcx;
 }
-fn trans_check_expr(bcx: block, chk_expr: @ast::expr,
-                    pred_expr: @ast::expr, s: ~str) -> block {
+
+pub fn trans_check_expr(bcx: block,
+                        chk_expr: @ast::expr,
+                        pred_expr: @ast::expr,
+                        s: ~str)
+                     -> block {
     let _icx = bcx.insn_ctxt("trans_check_expr");
     let expr_str = s + ~" " + expr_to_str(pred_expr, bcx.ccx().sess.intr())
         + ~" failed";
@@ -321,9 +330,10 @@ fn trans_check_expr(bcx: block, chk_expr: @ast::expr,
     }
 }
 
-fn trans_fail_expr(bcx: block,
-                   sp_opt: Option<span>,
-                   fail_expr: Option<@ast::expr>) -> block {
+pub fn trans_fail_expr(bcx: block,
+                       sp_opt: Option<span>,
+                       fail_expr: Option<@ast::expr>)
+                    -> block {
     let _icx = bcx.insn_ctxt("trans_fail_expr");
     let mut bcx = bcx;
     match fail_expr {
@@ -347,17 +357,19 @@ fn trans_fail_expr(bcx: block,
     }
 }
 
-fn trans_fail(bcx: block, sp_opt: Option<span>, +fail_str: ~str)
-    -> block
-{
+pub fn trans_fail(bcx: block,
+                  sp_opt: Option<span>,
+                  +fail_str: ~str)
+               -> block {
     let _icx = bcx.insn_ctxt("trans_fail");
     let V_fail_str = C_cstr(bcx.ccx(), fail_str);
     return trans_fail_value(bcx, sp_opt, V_fail_str);
 }
 
-fn trans_fail_value(bcx: block, sp_opt: Option<span>, V_fail_str: ValueRef)
-    -> block
-{
+fn trans_fail_value(bcx: block,
+                    sp_opt: Option<span>,
+                    V_fail_str: ValueRef)
+                 -> block {
     let _icx = bcx.insn_ctxt("trans_fail_value");
     let ccx = bcx.ccx();
     let {V_filename, V_line} = match sp_opt {
@@ -381,8 +393,8 @@ fn trans_fail_value(bcx: block, sp_opt: Option<span>, V_fail_str: ValueRef)
     return bcx;
 }
 
-fn trans_fail_bounds_check(bcx: block, sp: span,
-                           index: ValueRef, len: ValueRef) -> block {
+pub fn trans_fail_bounds_check(bcx: block, sp: span,
+                               index: ValueRef, len: ValueRef) -> block {
     let _icx = bcx.insn_ctxt("trans_fail_bounds_check");
     let ccx = bcx.ccx();
 

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -114,12 +114,12 @@ use core::uint;
 use core::vec;
 use syntax::parse::token::special_idents;
 
-enum CopyAction {
+pub enum CopyAction {
     INIT,
     DROP_EXISTING
 }
 
-struct Datum {
+pub struct Datum {
     /// The llvm value.  This is either a pointer to the Rust value or
     /// the value itself, depending on `mode` below.
     val: ValueRef,
@@ -137,12 +137,12 @@ struct Datum {
     source: DatumSource
 }
 
-struct DatumBlock {
+pub struct DatumBlock {
     bcx: block,
     datum: Datum,
 }
 
-enum DatumMode {
+pub enum DatumMode {
     /// `val` is a pointer to the actual value (and thus has type *T)
     ByRef,
 
@@ -150,7 +150,7 @@ enum DatumMode {
     ByValue,
 }
 
-impl DatumMode {
+pub impl DatumMode {
     fn is_by_ref() -> bool {
         match self { ByRef => true, ByValue => false }
     }
@@ -160,27 +160,27 @@ impl DatumMode {
     }
 }
 
-impl DatumMode: cmp::Eq {
+pub impl DatumMode: cmp::Eq {
     pure fn eq(&self, other: &DatumMode) -> bool {
         (*self) as uint == (*other as uint)
     }
     pure fn ne(&self, other: &DatumMode) -> bool { !(*self).eq(other) }
 }
 
-impl DatumMode: to_bytes::IterBytes {
+pub impl DatumMode: to_bytes::IterBytes {
     pure fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
         (*self as uint).iter_bytes(lsb0, f)
     }
 }
 
 /// See `Datum Sources` section at the head of this module.
-enum DatumSource {
+pub enum DatumSource {
     FromRvalue,
     FromLvalue,
     FromLastUseLvalue,
 }
 
-impl DatumSource {
+pub impl DatumSource {
     fn is_rvalue() -> bool {
         match self {
             FromRvalue => true,
@@ -196,16 +196,19 @@ impl DatumSource {
     }
 }
 
-fn immediate_rvalue(val: ValueRef, ty: ty::t) -> Datum {
+pub fn immediate_rvalue(val: ValueRef, ty: ty::t) -> Datum {
     return Datum {val: val, ty: ty,
                   mode: ByValue, source: FromRvalue};
 }
 
-fn immediate_rvalue_bcx(bcx: block, val: ValueRef, ty: ty::t) -> DatumBlock {
+pub fn immediate_rvalue_bcx(bcx: block,
+                            val: ValueRef,
+                            ty: ty::t)
+                         -> DatumBlock {
     return DatumBlock {bcx: bcx, datum: immediate_rvalue(val, ty)};
 }
 
-fn scratch_datum(bcx: block, ty: ty::t, zero: bool) -> Datum {
+pub fn scratch_datum(bcx: block, ty: ty::t, zero: bool) -> Datum {
     /*!
      *
      * Allocates temporary space on the stack using alloca() and
@@ -221,7 +224,7 @@ fn scratch_datum(bcx: block, ty: ty::t, zero: bool) -> Datum {
     Datum { val: scratch, ty: ty, mode: ByRef, source: FromRvalue }
 }
 
-fn appropriate_mode(ty: ty::t) -> DatumMode {
+pub fn appropriate_mode(ty: ty::t) -> DatumMode {
     /*!
     *
     * Indicates the "appropriate" mode for this value,
@@ -237,7 +240,7 @@ fn appropriate_mode(ty: ty::t) -> DatumMode {
     }
 }
 
-impl Datum {
+pub impl Datum {
     fn store_will_move() -> bool {
         match self.source {
             FromRvalue | FromLastUseLvalue => true,
@@ -348,7 +351,7 @@ impl Datum {
                 Store(bcx, self.val, dst);
             }
             ByRef => {
-                memcpy_ty(bcx, dst, self.val, self.ty);
+                base::memcpy_ty(bcx, dst, self.val, self.ty);
             }
         }
 
@@ -375,7 +378,7 @@ impl Datum {
 
         match self.mode {
             ByRef => {
-                glue::memcpy_ty(bcx, dst, self.val, self.ty);
+                base::memcpy_ty(bcx, dst, self.val, self.ty);
             }
             ByValue => {
                 Store(bcx, self.val, dst);
@@ -823,7 +826,7 @@ impl Datum {
     }
 }
 
-impl DatumBlock {
+pub impl DatumBlock {
     fn unpack(bcx: &mut block) -> Datum {
         *bcx = self.bcx;
         return self.datum;
@@ -871,7 +874,7 @@ impl DatumBlock {
     }
 }
 
-impl CopyAction : cmp::Eq {
+pub impl CopyAction : cmp::Eq {
     pure fn eq(&self, other: &CopyAction) -> bool {
         match ((*self), (*other)) {
             (INIT, INIT) => true,

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -137,20 +137,6 @@ use syntax::print::pprust::{expr_to_str};
 use syntax::ast;
 use syntax::ast::spanned;
 
-// The primary two functions for translating expressions:
-export trans_to_datum, trans_into;
-
-// More specific variants than trans_to_datum/trans_into that are useful
-// in some scenarios:
-export trans_local_var;
-
-// Other helpers, types, and so forth:
-export with_field_tys;
-export Dest, SaveIn, Ignore;
-export cast_type_kind;
-export cast_kind, cast_pointer, cast_integral, cast_float;
-export cast_enum, cast_other;
-
 // Destinations
 
 // These are passed around by the code generating functions to track the
@@ -158,7 +144,7 @@ export cast_enum, cast_other;
 
 fn macros() { include!("macros.rs"); } // FIXME(#3114): Macro import/export.
 
-enum Dest {
+pub enum Dest {
     SaveIn(ValueRef),
     Ignore,
 }
@@ -190,7 +176,7 @@ fn drop_and_cancel_clean(bcx: block, dat: Datum) -> block {
     return bcx;
 }
 
-fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
+pub fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
     debug!("trans_to_datum(expr=%s)", bcx.expr_to_str(expr));
     return match bcx.tcx().adjustments.find(expr.id) {
         None => {
@@ -271,7 +257,7 @@ fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
     }
 }
 
-fn trans_into(bcx: block, expr: @ast::expr, dest: Dest) -> block {
+pub fn trans_into(bcx: block, expr: @ast::expr, dest: Dest) -> block {
     return match bcx.tcx().adjustments.find(expr.id) {
         None => trans_into_unadjusted(bcx, expr, dest),
         Some(_) => {
@@ -830,10 +816,10 @@ fn trans_def_lvalue(bcx: block,
     }
 }
 
-fn trans_local_var(bcx: block,
-                   def: ast::def,
-                   expr_id_opt: Option<ast::node_id>)
-                -> Datum {
+pub fn trans_local_var(bcx: block,
+                       def: ast::def,
+                       expr_id_opt: Option<ast::node_id>)
+                    -> Datum {
     let _icx = bcx.insn_ctxt("trans_local_var");
 
     return match def {
@@ -949,10 +935,10 @@ fn fn_data_to_datum(bcx: block,
 // The optional node ID here is the node ID of the path identifying the enum
 // variant in use. If none, this cannot possibly an enum variant (so, if it
 // is and `node_id_opt` is none, this function fails).
-fn with_field_tys<R>(tcx: ty::ctxt,
-                     ty: ty::t,
-                     node_id_opt: Option<ast::node_id>,
-                     op: fn(bool, (&[ty::field])) -> R) -> R {
+pub fn with_field_tys<R>(tcx: ty::ctxt,
+                         ty: ty::t,
+                         node_id_opt: Option<ast::node_id>,
+                         op: fn(bool, (&[ty::field])) -> R) -> R {
     match ty::get(ty).sty {
         ty::ty_rec(ref fields) => {
             op(false, *fields)
@@ -1521,7 +1507,7 @@ fn float_cast(bcx: block, lldsttype: TypeRef, llsrctype: TypeRef,
     } else { llsrc };
 }
 
-enum cast_kind {
+pub enum cast_kind {
     cast_pointer,
     cast_integral,
     cast_float,
@@ -1547,7 +1533,7 @@ impl cast_kind : cmp::Eq {
     pure fn ne(&self, other: &cast_kind) -> bool { !(*self).eq(other) }
 }
 
-fn cast_type_kind(t: ty::t) -> cast_kind {
+pub fn cast_type_kind(t: ty::t) -> cast_kind {
     match ty::get(t).sty {
         ty::ty_float(*)   => cast_float,
         ty::ty_ptr(*)     => cast_pointer,

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -28,7 +28,7 @@ use middle::trans::uniq;
 use core::io;
 use core::str;
 
-fn trans_free(cx: block, v: ValueRef) -> block {
+pub fn trans_free(cx: block, v: ValueRef) -> block {
     let _icx = cx.insn_ctxt("trans_free");
     callee::trans_rtcall_or_lang_call(
         cx,
@@ -37,7 +37,7 @@ fn trans_free(cx: block, v: ValueRef) -> block {
         expr::Ignore)
 }
 
-fn trans_unique_free(cx: block, v: ValueRef) -> block {
+pub fn trans_unique_free(cx: block, v: ValueRef) -> block {
     let _icx = cx.insn_ctxt("trans_unique_free");
     callee::trans_rtcall_or_lang_call(
         cx,
@@ -46,7 +46,7 @@ fn trans_unique_free(cx: block, v: ValueRef) -> block {
         expr::Ignore)
 }
 
-fn take_ty(cx: block, v: ValueRef, t: ty::t) -> block {
+pub fn take_ty(cx: block, v: ValueRef, t: ty::t) -> block {
     // NB: v is an *alias* of type t here, not a direct value.
     let _icx = cx.insn_ctxt("take_ty");
     if ty::type_needs_drop(cx.tcx(), t) {
@@ -55,7 +55,7 @@ fn take_ty(cx: block, v: ValueRef, t: ty::t) -> block {
     return cx;
 }
 
-fn drop_ty(cx: block, v: ValueRef, t: ty::t) -> block {
+pub fn drop_ty(cx: block, v: ValueRef, t: ty::t) -> block {
     // NB: v is an *alias* of type t here, not a direct value.
     let _icx = cx.insn_ctxt("drop_ty");
     if ty::type_needs_drop(cx.tcx(), t) {
@@ -64,7 +64,11 @@ fn drop_ty(cx: block, v: ValueRef, t: ty::t) -> block {
     return cx;
 }
 
-fn drop_ty_root(bcx: block, v: ValueRef, rooted: bool, t: ty::t) -> block {
+pub fn drop_ty_root(bcx: block,
+                    v: ValueRef,
+                    rooted: bool,
+                    t: ty::t)
+                 -> block {
     if rooted {
         // NB: v is a raw ptr to an addrspace'd ptr to the value.
         let v = PointerCast(bcx, Load(bcx, v), T_ptr(type_of(bcx.ccx(), t)));
@@ -74,7 +78,7 @@ fn drop_ty_root(bcx: block, v: ValueRef, rooted: bool, t: ty::t) -> block {
     }
 }
 
-fn drop_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
+pub fn drop_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
     let _icx = bcx.insn_ctxt("drop_ty_immediate");
     match ty::get(t).sty {
       ty::ty_uniq(_) |
@@ -91,7 +95,7 @@ fn drop_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
     }
 }
 
-fn take_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> Result {
+pub fn take_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> Result {
     let _icx = bcx.insn_ctxt("take_ty_immediate");
     match ty::get(t).sty {
       ty::ty_box(_) | ty::ty_opaque_box |
@@ -111,7 +115,7 @@ fn take_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> Result {
     }
 }
 
-fn free_ty(cx: block, v: ValueRef, t: ty::t) -> block {
+pub fn free_ty(cx: block, v: ValueRef, t: ty::t) -> block {
     // NB: v is an *alias* of type t here, not a direct value.
     let _icx = cx.insn_ctxt("free_ty");
     if ty::type_needs_drop(cx.tcx(), t) {
@@ -120,7 +124,7 @@ fn free_ty(cx: block, v: ValueRef, t: ty::t) -> block {
     return cx;
 }
 
-fn free_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
+pub fn free_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
     let _icx = bcx.insn_ctxt("free_ty_immediate");
     match ty::get(t).sty {
       ty::ty_uniq(_) |
@@ -138,16 +142,15 @@ fn free_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
     }
 }
 
-fn lazily_emit_all_tydesc_glue(ccx: @crate_ctxt,
-                               static_ti: @tydesc_info) {
+pub fn lazily_emit_all_tydesc_glue(ccx: @crate_ctxt,
+                                   static_ti: @tydesc_info) {
     lazily_emit_tydesc_glue(ccx, abi::tydesc_field_take_glue, static_ti);
     lazily_emit_tydesc_glue(ccx, abi::tydesc_field_drop_glue, static_ti);
     lazily_emit_tydesc_glue(ccx, abi::tydesc_field_free_glue, static_ti);
     lazily_emit_tydesc_glue(ccx, abi::tydesc_field_visit_glue, static_ti);
 }
 
-fn simplified_glue_type(tcx: ty::ctxt, field: uint, t: ty::t) -> ty::t {
-
+pub fn simplified_glue_type(tcx: ty::ctxt, field: uint, t: ty::t) -> ty::t {
     if (field == abi::tydesc_field_take_glue ||
         field == abi::tydesc_field_drop_glue ||
         field == abi::tydesc_field_free_glue) &&
@@ -200,16 +203,17 @@ fn simplified_glue_type(tcx: ty::ctxt, field: uint, t: ty::t) -> ty::t {
     return t;
 }
 
-pure fn cast_glue(ccx: @crate_ctxt, ti: @tydesc_info, v: ValueRef)
-    -> ValueRef {
+pub pure fn cast_glue(ccx: @crate_ctxt, ti: @tydesc_info, v: ValueRef)
+                   -> ValueRef {
     unsafe {
         let llfnty = type_of_glue_fn(ccx, ti.ty);
         llvm::LLVMConstPointerCast(v, T_ptr(llfnty))
     }
 }
 
-fn lazily_emit_simplified_tydesc_glue(ccx: @crate_ctxt, field: uint,
-                                      ti: @tydesc_info) -> bool {
+pub fn lazily_emit_simplified_tydesc_glue(ccx: @crate_ctxt,
+                                          field: uint,
+                                          ti: @tydesc_info) -> bool {
     let _icx = ccx.insn_ctxt("lazily_emit_simplified_tydesc_glue");
     let simpl = simplified_glue_type(ccx.tcx, field, ti.ty);
     if simpl != ti.ty {
@@ -234,8 +238,9 @@ fn lazily_emit_simplified_tydesc_glue(ccx: @crate_ctxt, field: uint,
 }
 
 
-fn lazily_emit_tydesc_glue(ccx: @crate_ctxt, field: uint,
-                           ti: @tydesc_info) {
+pub fn lazily_emit_tydesc_glue(ccx: @crate_ctxt,
+                               field: uint,
+                               ti: @tydesc_info) {
     let _icx = ccx.insn_ctxt("lazily_emit_tydesc_glue");
     let llfnty = type_of_glue_fn(ccx, ti.ty);
 
@@ -299,8 +304,8 @@ fn lazily_emit_tydesc_glue(ccx: @crate_ctxt, field: uint,
 }
 
 // See [Note-arg-mode]
-fn call_tydesc_glue_full(++bcx: block, v: ValueRef, tydesc: ValueRef,
-                         field: uint, static_ti: Option<@tydesc_info>) {
+pub fn call_tydesc_glue_full(++bcx: block, v: ValueRef, tydesc: ValueRef,
+                             field: uint, static_ti: Option<@tydesc_info>) {
     let _icx = bcx.insn_ctxt("call_tydesc_glue_full");
     let ccx = bcx.ccx();
     // NB: Don't short-circuit even if this block is unreachable because
@@ -363,7 +368,7 @@ fn call_tydesc_glue_full(++bcx: block, v: ValueRef, tydesc: ValueRef,
 }
 
 // See [Note-arg-mode]
-fn call_tydesc_glue(++cx: block, v: ValueRef, t: ty::t, field: uint)
+pub fn call_tydesc_glue(++cx: block, v: ValueRef, t: ty::t, field: uint)
     -> block {
     let _icx = cx.insn_ctxt("call_tydesc_glue");
     let ti = get_tydesc(cx.ccx(), t);
@@ -371,7 +376,7 @@ fn call_tydesc_glue(++cx: block, v: ValueRef, t: ty::t, field: uint)
     return cx;
 }
 
-fn make_visit_glue(bcx: block, v: ValueRef, t: ty::t) {
+pub fn make_visit_glue(bcx: block, v: ValueRef, t: ty::t) {
     let _icx = bcx.insn_ctxt("make_visit_glue");
     let mut bcx = bcx;
     let ty_visitor_name = special_idents::ty_visitor;
@@ -382,7 +387,7 @@ fn make_visit_glue(bcx: block, v: ValueRef, t: ty::t) {
     build_return(bcx);
 }
 
-fn make_free_glue(bcx: block, v: ValueRef, t: ty::t) {
+pub fn make_free_glue(bcx: block, v: ValueRef, t: ty::t) {
     // NB: v0 is an *alias* of type t here, not a direct value.
     let _icx = bcx.insn_ctxt("make_free_glue");
     let ccx = bcx.ccx();
@@ -437,12 +442,13 @@ fn make_free_glue(bcx: block, v: ValueRef, t: ty::t) {
     build_return(bcx);
 }
 
-fn trans_struct_drop(bcx: block,
-                    v0: ValueRef,
-                    dtor_did: ast::def_id,
-                    class_did: ast::def_id,
-                    substs: &ty::substs,
-                    take_ref: bool) -> block {
+pub fn trans_struct_drop(bcx: block,
+                         v0: ValueRef,
+                         dtor_did: ast::def_id,
+                         class_did: ast::def_id,
+                         substs: &ty::substs,
+                         take_ref: bool)
+                      -> block {
     let drop_flag = GEPi(bcx, v0, struct_dtor());
     do with_cond(bcx, IsNotNull(bcx, Load(bcx, drop_flag))) |cx| {
         let mut bcx = cx;
@@ -491,7 +497,7 @@ fn trans_struct_drop(bcx: block,
 }
 
 
-fn make_drop_glue(bcx: block, v0: ValueRef, t: ty::t) {
+pub fn make_drop_glue(bcx: block, v0: ValueRef, t: ty::t) {
     // NB: v0 is an *alias* of type t here, not a direct value.
     let _icx = bcx.insn_ctxt("make_drop_glue");
     let ccx = bcx.ccx();
@@ -549,7 +555,10 @@ fn make_drop_glue(bcx: block, v0: ValueRef, t: ty::t) {
     build_return(bcx);
 }
 
-fn decr_refcnt_maybe_free(bcx: block, box_ptr: ValueRef, t: ty::t) -> block {
+pub fn decr_refcnt_maybe_free(bcx: block,
+                              box_ptr: ValueRef,
+                              t: ty::t)
+                           -> block {
     let _icx = bcx.insn_ctxt("decr_refcnt_maybe_free");
     let ccx = bcx.ccx();
 
@@ -563,7 +572,7 @@ fn decr_refcnt_maybe_free(bcx: block, box_ptr: ValueRef, t: ty::t) -> block {
 }
 
 
-fn make_take_glue(bcx: block, v: ValueRef, t: ty::t) {
+pub fn make_take_glue(bcx: block, v: ValueRef, t: ty::t) {
     let _icx = bcx.insn_ctxt("make_take_glue");
     // NB: v is a *pointer* to type t here, not a direct value.
     let bcx = match ty::get(t).sty {
@@ -612,7 +621,7 @@ fn make_take_glue(bcx: block, v: ValueRef, t: ty::t) {
     build_return(bcx);
 }
 
-fn incr_refcnt_of_boxed(cx: block, box_ptr: ValueRef) {
+pub fn incr_refcnt_of_boxed(cx: block, box_ptr: ValueRef) {
     let _icx = cx.insn_ctxt("incr_refcnt_of_boxed");
     let ccx = cx.ccx();
     let rc_ptr = GEPi(cx, box_ptr, [0u, abi::box_field_refcnt]);
@@ -623,7 +632,7 @@ fn incr_refcnt_of_boxed(cx: block, box_ptr: ValueRef) {
 
 
 // Chooses the addrspace for newly declared types.
-fn declare_tydesc_addrspace(ccx: @crate_ctxt, t: ty::t) -> addrspace {
+pub fn declare_tydesc_addrspace(ccx: @crate_ctxt, t: ty::t) -> addrspace {
     if !ty::type_needs_drop(ccx.tcx, t) {
         return default_addrspace;
     } else if ty::type_is_immediate(t) {
@@ -637,7 +646,7 @@ fn declare_tydesc_addrspace(ccx: @crate_ctxt, t: ty::t) -> addrspace {
 }
 
 // Generates the declaration for (but doesn't emit) a type descriptor.
-fn declare_tydesc(ccx: @crate_ctxt, t: ty::t) -> @tydesc_info {
+pub fn declare_tydesc(ccx: @crate_ctxt, t: ty::t) -> @tydesc_info {
     let _icx = ccx.insn_ctxt("declare_tydesc");
     // If emit_tydescs already ran, then we shouldn't be creating any new
     // tydescs.
@@ -682,10 +691,10 @@ fn declare_tydesc(ccx: @crate_ctxt, t: ty::t) -> @tydesc_info {
     return inf;
 }
 
-type glue_helper = fn@(block, ValueRef, ty::t);
+pub type glue_helper = fn@(block, ValueRef, ty::t);
 
-fn declare_generic_glue(ccx: @crate_ctxt, t: ty::t, llfnty: TypeRef,
-                        +name: ~str) -> ValueRef {
+pub fn declare_generic_glue(ccx: @crate_ctxt, t: ty::t, llfnty: TypeRef,
+                            +name: ~str) -> ValueRef {
     let _icx = ccx.insn_ctxt("declare_generic_glue");
     let name = name;
     let mut fn_nm;
@@ -703,8 +712,11 @@ fn declare_generic_glue(ccx: @crate_ctxt, t: ty::t, llfnty: TypeRef,
     return llfn;
 }
 
-fn make_generic_glue_inner(ccx: @crate_ctxt, t: ty::t,
-                           llfn: ValueRef, helper: glue_helper) -> ValueRef {
+pub fn make_generic_glue_inner(ccx: @crate_ctxt,
+                               t: ty::t,
+                               llfn: ValueRef,
+                               helper: glue_helper)
+                            -> ValueRef {
     let _icx = ccx.insn_ctxt("make_generic_glue_inner");
     let fcx = new_fn_ctxt(ccx, ~[], llfn, None);
     lib::llvm::SetLinkage(llfn, lib::llvm::InternalLinkage);
@@ -725,9 +737,9 @@ fn make_generic_glue_inner(ccx: @crate_ctxt, t: ty::t,
     return llfn;
 }
 
-fn make_generic_glue(ccx: @crate_ctxt, t: ty::t, llfn: ValueRef,
-                     helper: glue_helper, name: ~str)
-    -> ValueRef {
+pub fn make_generic_glue(ccx: @crate_ctxt, t: ty::t, llfn: ValueRef,
+                         helper: glue_helper, name: ~str)
+                      -> ValueRef {
     let _icx = ccx.insn_ctxt("make_generic_glue");
     if !ccx.sess.trans_stats() {
         return make_generic_glue_inner(ccx, t, llfn, helper);
@@ -741,7 +753,7 @@ fn make_generic_glue(ccx: @crate_ctxt, t: ty::t, llfn: ValueRef,
     return llval;
 }
 
-fn emit_tydescs(ccx: @crate_ctxt) {
+pub fn emit_tydescs(ccx: @crate_ctxt) {
     let _icx = ccx.insn_ctxt("emit_tydescs");
     // As of this point, allow no more tydescs to be created.
     ccx.finished_tydescs = true;

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -27,8 +27,8 @@ use syntax::ast_util::local_def;
 // `translate` will be true if this function is allowed to translate the
 // item and false otherwise. Currently, this parameter is set to false when
 // translating default methods.
-fn maybe_instantiate_inline(ccx: @crate_ctxt, fn_id: ast::def_id,
-                            translate: bool)
+pub fn maybe_instantiate_inline(ccx: @crate_ctxt, fn_id: ast::def_id,
+                                translate: bool)
     -> ast::def_id {
     let _icx = ccx.insn_ctxt("maybe_instantiate_inline");
     match ccx.external.find(fn_id) {

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -36,13 +36,13 @@ use syntax::ast_map::{path, path_mod, path_name};
 use syntax::ast_util::local_def;
 use syntax::parse::token::special_idents;
 
-fn monomorphic_fn(ccx: @crate_ctxt,
-                  fn_id: ast::def_id,
-                  real_substs: ~[ty::t],
-                  vtables: Option<typeck::vtable_res>,
-                  impl_did_opt: Option<ast::def_id>,
-                  ref_id: Option<ast::node_id>) ->
-                  {val: ValueRef, must_cast: bool} {
+pub fn monomorphic_fn(ccx: @crate_ctxt,
+                      fn_id: ast::def_id,
+                      real_substs: ~[ty::t],
+                      vtables: Option<typeck::vtable_res>,
+                      impl_did_opt: Option<ast::def_id>,
+                      ref_id: Option<ast::node_id>) ->
+                      {val: ValueRef, must_cast: bool} {
     let _icx = ccx.insn_ctxt("monomorphic_fn");
     let mut must_cast = false;
     let substs = vec::map(real_substs, |t| {
@@ -268,7 +268,8 @@ fn monomorphic_fn(ccx: @crate_ctxt,
     {val: lldecl, must_cast: must_cast}
 }
 
-fn normalize_for_monomorphization(tcx: ty::ctxt, ty: ty::t) -> Option<ty::t> {
+pub fn normalize_for_monomorphization(tcx: ty::ctxt,
+                                      ty: ty::t) -> Option<ty::t> {
     // FIXME[mono] could do this recursively. is that worthwhile? (#2529)
     match ty::get(ty).sty {
         ty::ty_box(*) => {
@@ -305,10 +306,10 @@ fn normalize_for_monomorphization(tcx: ty::ctxt, ty: ty::t) -> Option<ty::t> {
     }
 }
 
-fn make_mono_id(ccx: @crate_ctxt, item: ast::def_id, substs: ~[ty::t],
-                vtables: Option<typeck::vtable_res>,
-                impl_did_opt: Option<ast::def_id>,
-                param_uses: Option<~[type_use::type_uses]>) -> mono_id {
+pub fn make_mono_id(ccx: @crate_ctxt, item: ast::def_id, substs: ~[ty::t],
+                    vtables: Option<typeck::vtable_res>,
+                    impl_did_opt: Option<ast::def_id>,
+                    param_uses: Option<~[type_use::type_uses]>) -> mono_id {
     let precise_param_ids = match vtables {
       Some(vts) => {
         let bounds = ty::lookup_item_type(ccx.tcx, item).bounds;

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -50,19 +50,12 @@ use back_ = back;
 
 pub mod middle {
     pub mod trans {
-        #[legacy_exports]
         pub mod inline;
-        #[legacy_exports]
         pub mod monomorphize;
-        #[legacy_exports]
         pub mod controlflow;
-        #[legacy_exports]
         pub mod glue;
-        #[legacy_exports]
         pub mod datum;
-        #[legacy_exports]
         pub mod callee;
-        #[legacy_exports]
         pub mod expr;
         #[legacy_exports]
         pub mod common;


### PR DESCRIPTION
r? @graydon
