### PR TITLE
Use task local random when initializing LinearMap

### DIFF
--- a/src/libcore/hashmap.rs
+++ b/src/libcore/hashmap.rs
@@ -62,7 +62,7 @@ pub mod linear {
 
     pub fn linear_map_with_capacity<K: Eq Hash, V>(
         initial_capacity: uint) -> LinearMap<K, V> {
-        let r = rand::Rng();
+        let r = rand::task_rng();
         linear_map_with_capacity_and_keys(r.gen_u64(), r.gen_u64(),
                                           initial_capacity)
     }


### PR DESCRIPTION
I have a project for rust which makes extensive use of hash maps. I recently changed everything over to `LinearMap`, and was then profiling some very slow portions of the program.

I ended up finding that an absurd amount of time was spent in the `read` syscall, all from invocations of the function `rng::Rng`. I found that each time a hash map was created, a new random object was created. To get around this, this change just uses the task local random instead of creating a new one every time.

I'm not super familiar with how the hashing algorithm works using these random numbers, so I'm not sure if this would affect the quality of hashing or anything like that. If this does mess up something with that, I imagine that there should still be a faster way of creating a new map?

Regardless, my one test I was running went from a runtime of 1 minute to 12 seconds, to it was a pretty big win in that respect!
