### PR TITLE
modernize smallintmap module

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -34,8 +34,8 @@ use core::uint;
 use core::vec;
 use std::map::{Map, HashMap};
 use std::map;
-use std::smallintmap::{Map, SmallIntMap};
-use std::smallintmap;
+use std::oldsmallintmap::{Map, SmallIntMap};
+use std::oldsmallintmap;
 use syntax::ast_util::{path_to_ident};
 use syntax::attr;
 use syntax::codemap::span;
@@ -248,7 +248,7 @@ pub type lint_settings = {
 };
 
 pub fn mk_lint_settings() -> lint_settings {
-    {default_settings: smallintmap::mk(),
+    {default_settings: oldsmallintmap::mk(),
      settings_map: HashMap()}
 }
 
@@ -273,7 +273,8 @@ pub fn get_lint_settings_level(settings: lint_settings,
 // This is kind of unfortunate. It should be somewhere else, or we should use
 // a persistent data structure...
 fn clone_lint_modes(modes: lint_modes) -> lint_modes {
-    smallintmap::SmallIntMap_(@smallintmap::SmallIntMap_ { v: copy modes.v })
+    oldsmallintmap::SmallIntMap_(@oldsmallintmap::SmallIntMap_
+    {v: copy modes.v})
 }
 
 type ctxt_ = {dict: lint_dict,
@@ -393,7 +394,7 @@ fn build_settings_item(i: @ast::item, &&cx: ctxt, v: visit::vt<ctxt>) {
 
 pub fn build_settings_crate(sess: session::Session, crate: @ast::crate) {
     let cx = ctxt_({dict: get_lint_dict(),
-                    curr: smallintmap::mk(),
+                    curr: oldsmallintmap::mk(),
                     is_default: true,
                     sess: sess});
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -76,7 +76,7 @@ use core::option::{is_none, is_some};
 use core::option;
 use core::uint;
 use std::map::HashMap;
-use std::smallintmap;
+use std::oldsmallintmap;
 use std::{map, time, list};
 use syntax::ast_map::{path, path_elt_to_str, path_mod, path_name};
 use syntax::ast_util::{def_id_of_def, local_def, path_to_ident};

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -42,7 +42,7 @@ use core::to_bytes;
 use core::uint;
 use core::vec;
 use std::map::HashMap;
-use std::{map, smallintmap};
+use std::{map, oldsmallintmap};
 use syntax::ast::*;
 use syntax::ast_util::{is_local, local_def};
 use syntax::ast_util;
@@ -785,7 +785,7 @@ type type_cache = HashMap<ast::def_id, ty_param_bounds_and_ty>;
 
 type constness_cache = HashMap<ast::def_id, const_eval::constness>;
 
-pub type node_type_table = @smallintmap::SmallIntMap<t>;
+pub type node_type_table = @oldsmallintmap::SmallIntMap<t>;
 
 fn mk_rcache() -> creader_cache {
     type val = {cnum: int, pos: uint, len: uint};
@@ -837,7 +837,7 @@ pub fn mk_ctxt(s: session::Session,
         def_map: dm,
         region_map: region_map,
         region_paramd_items: region_paramd_items,
-        node_types: @smallintmap::mk(),
+        node_types: @oldsmallintmap::mk(),
         node_type_substs: map::HashMap(),
         items: amap,
         intrinsic_defs: map::HashMap(),
@@ -2799,7 +2799,7 @@ pub fn br_hashmap<V:Copy>() -> HashMap<bound_region, V> {
 
 pub fn node_id_to_type(cx: ctxt, id: ast::node_id) -> t {
     //io::println(fmt!("%?/%?", id, cx.node_types.size()));
-    match smallintmap::find(*cx.node_types, id as uint) {
+    match oldsmallintmap::find(*cx.node_types, id as uint) {
        Some(t) => t,
        None => cx.sess.bug(
            fmt!("node_id_to_type: no type for node `%s`",
@@ -3175,7 +3175,7 @@ pub fn expr_kind(tcx: ctxt,
         }
 
         ast::expr_cast(*) => {
-            match smallintmap::find(*tcx.node_types, expr.id as uint) {
+            match oldsmallintmap::find(*tcx.node_types, expr.id as uint) {
                 Some(t) => {
                     if ty::type_is_immediate(t) {
                         RvalueDatumExpr

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -281,7 +281,7 @@ use core::result;
 use core::vec;
 use std::list::Nil;
 use std::map::HashMap;
-use std::smallintmap;
+use std::oldsmallintmap;
 use syntax::ast::{ret_style, purity};
 use syntax::ast::{m_const, m_imm, m_mutbl};
 use syntax::ast::{unsafe_fn, impure_fn, pure_fn, extern_fn};
@@ -353,7 +353,7 @@ pub fn fixup_err_to_str(f: fixup_err) -> ~str {
 
 fn new_ValsAndBindings<V:Copy, T:Copy>() -> ValsAndBindings<V, T> {
     ValsAndBindings {
-        vals: smallintmap::mk(),
+        vals: oldsmallintmap::mk(),
         mut bindings: ~[]
     }
 }

--- a/src/librustc/middle/typeck/infer/unify.rs
+++ b/src/librustc/middle/typeck/infer/unify.rs
@@ -10,7 +10,7 @@
 
 use core::prelude::*;
 use core::result;
-use std::smallintmap::SmallIntMap;
+use std::oldsmallintmap::SmallIntMap;
 
 use middle::ty::{Vid, expected_found, IntVarValue};
 use middle::ty;

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -69,7 +69,7 @@ use std::list::{List, Nil, Cons};
 use std::list;
 use std::map::HashMap;
 use std::map;
-use std::smallintmap;
+use std::oldsmallintmap;
 use syntax::ast::{provided, required, spanned};
 use syntax::ast_map::node_id_to_str;
 use syntax::ast_util::{local_def, respan, split_trait_methods};
@@ -212,7 +212,7 @@ pub enum crate_ctxt {
 // Functions that write types into the node type table
 pub fn write_ty_to_tcx(tcx: ty::ctxt, node_id: ast::node_id, ty: ty::t) {
     debug!("write_ty_to_tcx(%d, %s)", node_id, ppaux::ty_to_str(tcx, ty));
-    smallintmap::insert(*tcx.node_types, node_id as uint, ty);
+    oldsmallintmap::insert(*tcx.node_types, node_id as uint, ty);
 }
 pub fn write_substs_to_tcx(tcx: ty::ctxt,
                            node_id: ast::node_id,

--- a/src/libstd/oldsmallintmap.rs
+++ b/src/libstd/oldsmallintmap.rs
@@ -172,7 +172,7 @@ impl<V: Copy> SmallIntMap<V>: ops::Index<uint, V> {
 
 #[cfg(test)]
 mod tests {
-    use smallintmap::{mk, SmallIntMap};
+    use super::{mk, SmallIntMap};
 
     use core::option::None;
 

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -95,6 +95,10 @@ impl<V> SmallIntMap<V>: Container {
     pure fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
+impl<V> SmallIntMap<V>: Mutable {
+    fn clear(&mut self) { self.v.set(~[]) }
+}
+
 /// Implements the map::map interface for smallintmap
 impl<V: Copy> SmallIntMap<V> {
     #[inline(always)]
@@ -110,9 +114,6 @@ impl<V: Copy> SmallIntMap<V> {
         let old = self.v.get_elt(key);
         self.v.set_elt(key, None);
         old.is_some()
-    }
-    fn clear() {
-        self.v.set(~[]);
     }
     pure fn contains_key(key: uint) -> bool {
         contains_key(self, key)
@@ -189,6 +190,19 @@ mod tests {
         map.insert(14, 22);
         assert map.len() == 3;
         assert !map.is_empty();
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut map = mk();
+        map.insert(5, 20);
+        map.insert(11, 12);
+        map.insert(14, 22);
+        map.clear();
+        assert map.is_empty();
+        assert map.find(5).is_none();
+        assert map.find(11).is_none();
+        assert map.find(14).is_none();
     }
 
     #[test]

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -1,0 +1,237 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/*!
+ * A simple map based on a vector for small integer keys. Space requirements
+ * are O(highest integer key).
+ */
+#[forbid(deprecated_mode)];
+
+use core::container::{Container, Mutable, Map, Set};
+use core::dvec::DVec;
+use core::ops;
+use core::option::{Some, None};
+use core::option;
+use core::prelude::*;
+
+// FIXME (#2347): Should not be @; there's a bug somewhere in rustc that
+// requires this to be.
+struct SmallIntMap_<T> {
+    v: DVec<Option<T>>,
+}
+
+pub enum SmallIntMap<T> {
+    SmallIntMap_(@SmallIntMap_<T>)
+}
+
+/// Create a smallintmap
+pub fn mk<T: Copy>() -> SmallIntMap<T> {
+    let v = DVec();
+    SmallIntMap_(@SmallIntMap_ { v: v } )
+}
+
+/**
+ * Add a value to the map. If the map already contains a value for
+ * the specified key then the original value is replaced.
+ */
+#[inline(always)]
+pub fn insert<T: Copy>(self: SmallIntMap<T>, key: uint, val: T) {
+    //io::println(fmt!("%?", key));
+    self.v.grow_set_elt(key, &None, Some(val));
+}
+
+/**
+ * Get the value for the specified key. If the key does not exist
+ * in the map then returns none
+ */
+pub pure fn find<T: Copy>(self: SmallIntMap<T>, key: uint) -> Option<T> {
+    if key < self.v.len() { return self.v.get_elt(key); }
+    return None::<T>;
+}
+
+/**
+ * Get the value for the specified key
+ *
+ * # Failure
+ *
+ * If the key does not exist in the map
+ */
+pub pure fn get<T: Copy>(self: SmallIntMap<T>, key: uint) -> T {
+    match find(self, key) {
+      None => {
+        error!("smallintmap::get(): key not present");
+        fail;
+      }
+      Some(move v) => return v
+    }
+}
+
+/// Returns true if the map contains a value for the specified key
+pub pure fn contains_key<T: Copy>(self: SmallIntMap<T>, key: uint) -> bool {
+    return !find(self, key).is_none();
+}
+
+impl<V> SmallIntMap<V>: Container {
+    /// Return the number of elements in the map
+    pure fn len(&self) -> uint {
+        let mut sz = 0u;
+        for self.v.each |item| {
+            match *item {
+              Some(_) => sz += 1u,
+              _ => ()
+            }
+        }
+        sz
+    }
+
+    /// Return true if the map contains no elements
+    pure fn is_empty(&self) -> bool { self.len() == 0 }
+}
+
+impl<V> SmallIntMap<V>: Mutable {
+    fn clear(&mut self) { self.v.set(~[]) }
+}
+
+/// Implements the map::map interface for smallintmap
+impl<V: Copy> SmallIntMap<V> {
+    #[inline(always)]
+    fn insert(key: uint, value: V) -> bool {
+        let exists = contains_key(self, key);
+        insert(self, key, value);
+        return !exists;
+    }
+    fn remove(key: uint) -> bool {
+        if key >= self.v.len() {
+            return false;
+        }
+        let old = self.v.get_elt(key);
+        self.v.set_elt(key, None);
+        old.is_some()
+    }
+    pure fn contains_key(key: uint) -> bool {
+        contains_key(self, key)
+    }
+    pure fn contains_key_ref(key: &uint) -> bool {
+        contains_key(self, *key)
+    }
+    pure fn get(key: uint) -> V { get(self, key) }
+    pure fn find(key: uint) -> Option<V> { find(self, key) }
+
+    fn update_with_key(key: uint, val: V, ff: fn(uint, V, V) -> V) -> bool {
+        match self.find(key) {
+            None            => return self.insert(key, val),
+            Some(copy orig) => return self.insert(key, ff(key, orig, val)),
+        }
+    }
+
+    fn update(key: uint, newval: V, ff: fn(V, V) -> V) -> bool {
+        return self.update_with_key(key, newval, |_k, v, v1| ff(v,v1));
+    }
+
+    pure fn each(it: fn(key: uint, value: V) -> bool) {
+        self.each_ref(|k, v| it(*k, *v))
+    }
+    pure fn each_key(it: fn(key: uint) -> bool) {
+        self.each_ref(|k, _v| it(*k))
+    }
+    pure fn each_value(it: fn(value: V) -> bool) {
+        self.each_ref(|_k, v| it(*v))
+    }
+    pure fn each_ref(it: fn(key: &uint, value: &V) -> bool) {
+        let mut idx = 0u, l = self.v.len();
+        while idx < l {
+            match self.v.get_elt(idx) {
+              Some(ref elt) => if !it(&idx, elt) { break },
+              None => ()
+            }
+            idx += 1u;
+        }
+    }
+    pure fn each_key_ref(blk: fn(key: &uint) -> bool) {
+        self.each_ref(|k, _v| blk(k))
+    }
+    pure fn each_value_ref(blk: fn(value: &V) -> bool) {
+        self.each_ref(|_k, v| blk(v))
+    }
+}
+
+impl<V: Copy> SmallIntMap<V>: ops::Index<uint, V> {
+    pure fn index(&self, key: uint) -> V {
+        unsafe {
+            get(*self, key)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mk, SmallIntMap};
+
+    use core::option::None;
+
+    #[test]
+    fn test_len() {
+        let mut map = mk();
+        assert map.len() == 0;
+        assert map.is_empty();
+        map.insert(5, 20);
+        assert map.len() == 1;
+        assert !map.is_empty();
+        map.insert(11, 12);
+        assert map.len() == 2;
+        assert !map.is_empty();
+        map.insert(14, 22);
+        assert map.len() == 3;
+        assert !map.is_empty();
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut map = mk();
+        map.insert(5, 20);
+        map.insert(11, 12);
+        map.insert(14, 22);
+        map.clear();
+        assert map.is_empty();
+        assert map.find(5).is_none();
+        assert map.find(11).is_none();
+        assert map.find(14).is_none();
+    }
+
+    #[test]
+    fn test_insert_with_key() {
+        let map: SmallIntMap<uint> = mk();
+
+        // given a new key, initialize it with this new count, given
+        // given an existing key, add more to its count
+        fn addMoreToCount(_k: uint, v0: uint, v1: uint) -> uint {
+            v0 + v1
+        }
+
+        fn addMoreToCount_simple(v0: uint, v1: uint) -> uint {
+            v0 + v1
+        }
+
+        // count integers
+        map.update(3, 1, addMoreToCount_simple);
+        map.update_with_key(9, 1, addMoreToCount);
+        map.update(3, 7, addMoreToCount_simple);
+        map.update_with_key(5, 3, addMoreToCount);
+        map.update_with_key(3, 2, addMoreToCount);
+
+        // check the total counts
+        assert map.find(3).get() == 10;
+        assert map.find(5).get() == 3;
+        assert map.find(9).get() == 1;
+
+        // sadly, no sevens were counted
+        assert None == map.find(7);
+    }
+}

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -14,9 +14,9 @@
  */
 #[forbid(deprecated_mode)];
 
-use map;
 use map::StdMap;
 
+use core::container::{Container, Mutable, Map, Set};
 use core::dvec::DVec;
 use core::ops;
 use core::option::{Some, None};
@@ -80,9 +80,9 @@ pub pure fn contains_key<T: Copy>(self: SmallIntMap<T>, key: uint) -> bool {
     return !find(self, key).is_none();
 }
 
-/// Implements the map::map interface for smallintmap
-impl<V: Copy> SmallIntMap<V>: map::StdMap<uint, V> {
-    pure fn size() -> uint {
+impl<V> SmallIntMap<V>: Container {
+    /// Return the number of elements in the map
+    pure fn len(&self) -> uint {
         let mut sz = 0u;
         for self.v.each |item| {
             match *item {
@@ -92,6 +92,14 @@ impl<V: Copy> SmallIntMap<V>: map::StdMap<uint, V> {
         }
         sz
     }
+
+    /// Return true if the map contains no elements
+    pure fn is_empty(&self) -> bool { self.len() == 0 }
+}
+
+/// Implements the map::map interface for smallintmap
+impl<V: Copy> SmallIntMap<V>: StdMap<uint, V> {
+    pure fn size() -> uint { self.len() }
     #[inline(always)]
     fn insert(key: uint, value: V) -> bool {
         let exists = contains_key(self, key);
@@ -165,8 +173,8 @@ impl<V: Copy> SmallIntMap<V>: ops::Index<uint, V> {
 }
 
 /// Cast the given smallintmap to a map::map
-pub fn as_map<V: Copy>(s: SmallIntMap<V>) -> map::StdMap<uint, V> {
-    s as map::StdMap::<uint, V>
+pub fn as_map<V: Copy>(s: SmallIntMap<V>) -> StdMap<uint, V> {
+    s as StdMap::<uint, V>
 }
 
 #[cfg(test)]
@@ -175,6 +183,22 @@ mod tests {
 
     use core::option::None;
     use core::option;
+
+    #[test]
+    fn test_len() {
+        let mut map = mk();
+        assert map.len() == 0;
+        assert map.is_empty();
+        map.insert(5, 20);
+        assert map.len() == 1;
+        assert !map.is_empty();
+        map.insert(11, 12);
+        assert map.len() == 2;
+        assert !map.is_empty();
+        map.insert(14, 22);
+        assert map.len() == 3;
+        assert !map.is_empty();
+    }
 
     #[test]
     fn test_insert_with_key() {

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -15,77 +15,20 @@
 #[forbid(deprecated_mode)];
 
 use core::container::{Container, Mutable, Map, Set};
-use core::dvec::DVec;
-use core::ops;
 use core::option::{Some, None};
-use core::option;
 use core::prelude::*;
 
-// FIXME (#2347): Should not be @; there's a bug somewhere in rustc that
-// requires this to be.
-struct SmallIntMap_<T> {
-    v: DVec<Option<T>>,
-}
-
-pub enum SmallIntMap<T> {
-    SmallIntMap_(@SmallIntMap_<T>)
-}
-
-/// Create a smallintmap
-pub fn mk<T: Copy>() -> SmallIntMap<T> {
-    let v = DVec();
-    SmallIntMap_(@SmallIntMap_ { v: v } )
-}
-
-/**
- * Add a value to the map. If the map already contains a value for
- * the specified key then the original value is replaced.
- */
-#[inline(always)]
-pub fn insert<T: Copy>(self: SmallIntMap<T>, key: uint, val: T) {
-    //io::println(fmt!("%?", key));
-    self.v.grow_set_elt(key, &None, Some(val));
-}
-
-/**
- * Get the value for the specified key. If the key does not exist
- * in the map then returns none
- */
-pub pure fn find<T: Copy>(self: SmallIntMap<T>, key: uint) -> Option<T> {
-    if key < self.v.len() { return self.v.get_elt(key); }
-    return None::<T>;
-}
-
-/**
- * Get the value for the specified key
- *
- * # Failure
- *
- * If the key does not exist in the map
- */
-pub pure fn get<T: Copy>(self: SmallIntMap<T>, key: uint) -> T {
-    match find(self, key) {
-      None => {
-        error!("smallintmap::get(): key not present");
-        fail;
-      }
-      Some(move v) => return v
-    }
-}
-
-/// Returns true if the map contains a value for the specified key
-pub pure fn contains_key<T: Copy>(self: SmallIntMap<T>, key: uint) -> bool {
-    return !find(self, key).is_none();
+pub struct SmallIntMap<T> {
+    priv v: ~[Option<T>],
 }
 
 impl<V> SmallIntMap<V>: Container {
     /// Return the number of elements in the map
     pure fn len(&self) -> uint {
-        let mut sz = 0u;
+        let mut sz = 0;
         for self.v.each |item| {
-            match *item {
-              Some(_) => sz += 1u,
-              _ => ()
+            if item.is_some() {
+                sz += 1;
             }
         }
         sz
@@ -96,118 +39,136 @@ impl<V> SmallIntMap<V>: Container {
 }
 
 impl<V> SmallIntMap<V>: Mutable {
-    fn clear(&mut self) { self.v.set(~[]) }
+    /// Clear the map, removing all key-value pairs.
+    fn clear(&mut self) { self.v.clear() }
 }
 
-/// Implements the map::map interface for smallintmap
-impl<V: Copy> SmallIntMap<V> {
-    #[inline(always)]
-    fn insert(key: uint, value: V) -> bool {
-        let exists = contains_key(self, key);
-        insert(self, key, value);
-        return !exists;
-    }
-    fn remove(key: uint) -> bool {
-        if key >= self.v.len() {
-            return false;
-        }
-        let old = self.v.get_elt(key);
-        self.v.set_elt(key, None);
-        old.is_some()
-    }
-    pure fn contains_key(key: uint) -> bool {
-        contains_key(self, key)
-    }
-    pure fn contains_key_ref(key: &uint) -> bool {
-        contains_key(self, *key)
-    }
-    pure fn get(key: uint) -> V { get(self, key) }
-    pure fn find(key: uint) -> Option<V> { find(self, key) }
-
-    fn update_with_key(key: uint, val: V, ff: fn(uint, V, V) -> V) -> bool {
-        match self.find(key) {
-            None            => return self.insert(key, val),
-            Some(copy orig) => return self.insert(key, ff(key, orig, val)),
-        }
+impl<V> SmallIntMap<V>: Map<uint, V> {
+    /// Return true if the map contains a value for the specified key
+    pure fn contains_key(&self, key: &uint) -> bool {
+        self.find(key).is_some()
     }
 
-    fn update(key: uint, newval: V, ff: fn(V, V) -> V) -> bool {
-        return self.update_with_key(key, newval, |_k, v, v1| ff(v,v1));
-    }
-
-    pure fn each(it: fn(key: uint, value: V) -> bool) {
-        self.each_ref(|k, v| it(*k, *v))
-    }
-    pure fn each_key(it: fn(key: uint) -> bool) {
-        self.each_ref(|k, _v| it(*k))
-    }
-    pure fn each_value(it: fn(value: V) -> bool) {
-        self.each_ref(|_k, v| it(*v))
-    }
-    pure fn each_ref(it: fn(key: &uint, value: &V) -> bool) {
-        let mut idx = 0u, l = self.v.len();
-        while idx < l {
-            match self.v.get_elt(idx) {
-              Some(ref elt) => if !it(&idx, elt) { break },
+    /// Visit all key-value pairs
+    pure fn each(&self, it: fn(key: &uint, value: &V) -> bool) {
+        for uint::range(0, self.v.len()) |i| {
+            match self.v[i] {
+              Some(ref elt) => if !it(&i, elt) { break },
               None => ()
             }
-            idx += 1u;
         }
     }
-    pure fn each_key_ref(blk: fn(key: &uint) -> bool) {
-        self.each_ref(|k, _v| blk(k))
+
+    /// Visit all keys
+    pure fn each_key(&self, blk: fn(key: &uint) -> bool) {
+        self.each(|k, _| blk(k))
     }
-    pure fn each_value_ref(blk: fn(value: &V) -> bool) {
-        self.each_ref(|_k, v| blk(v))
+
+    /// Visit all values
+    pure fn each_value(&self, blk: fn(value: &V) -> bool) {
+        self.each(|_, v| blk(v))
+    }
+
+    /// Return the value corresponding to the key in the map
+    pure fn find(&self, key: &uint) -> Option<&self/V> {
+        if *key < self.v.len() {
+            match self.v[*key] {
+              Some(ref value) => Some(value),
+              None => None
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Insert a key-value pair into the map. An existing value for a
+    /// key is replaced by the new value. Return true if the key did
+    /// not already exist in the map.
+    fn insert(&mut self, key: uint, value: V) -> bool {
+        let exists = self.contains_key(&key);
+        let len = self.v.len();
+        if len <= key {
+            vec::grow_fn(&mut self.v, key - len + 1, |_| None);
+        }
+        self.v[key] = Some(value);
+        !exists
+    }
+
+    /// Remove a key-value pair from the map. Return true if the key
+    /// was present in the map, otherwise false.
+    fn remove(&mut self, key: &uint) -> bool {
+        if *key >= self.v.len() {
+            return false;
+        }
+        let removed = self.v[*key].is_some();
+        self.v[*key] = None;
+        removed
     }
 }
 
-impl<V: Copy> SmallIntMap<V>: ops::Index<uint, V> {
-    pure fn index(&self, key: uint) -> V {
-        unsafe {
-            get(*self, key)
+pub impl<V> SmallIntMap<V> {
+    /// Create an empty SmallIntMap
+    static pure fn new() -> SmallIntMap<V> { SmallIntMap{v: ~[]} }
+
+    pure fn get(&self, key: &uint) -> &self/V {
+        self.find(key).expect("key not present")
+    }
+}
+
+pub impl<V: Copy> SmallIntMap<V> {
+    // FIXME: #4733, remove after the next snapshot
+    #[cfg(stage2)]
+    fn update_with_key(&mut self, key: uint, val: V,
+                       ff: fn(uint, V, V) -> V) -> bool {
+        match self.find(&key) {
+          None => self.insert(key, val),
+          Some(orig) => self.insert(key, ff(key, copy *orig, val)),
         }
+    }
+
+    // FIXME: #4733, remove after the next snapshot
+    #[cfg(stage2)]
+    fn update(&mut self, key: uint, newval: V, ff: fn(V, V) -> V) -> bool {
+        self.update_with_key(key, newval, |_k, v, v1| ff(v,v1))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{mk, SmallIntMap};
-
-    use core::option::None;
+    use super::SmallIntMap;
 
     #[test]
     fn test_len() {
-        let mut map = mk();
+        let mut map = SmallIntMap::new();
         assert map.len() == 0;
         assert map.is_empty();
-        map.insert(5, 20);
+        assert map.insert(5, 20);
         assert map.len() == 1;
         assert !map.is_empty();
-        map.insert(11, 12);
+        assert map.insert(11, 12);
         assert map.len() == 2;
         assert !map.is_empty();
-        map.insert(14, 22);
+        assert map.insert(14, 22);
         assert map.len() == 3;
         assert !map.is_empty();
     }
 
     #[test]
     fn test_clear() {
-        let mut map = mk();
-        map.insert(5, 20);
-        map.insert(11, 12);
-        map.insert(14, 22);
+        let mut map = SmallIntMap::new();
+        assert map.insert(5, 20);
+        assert map.insert(11, 12);
+        assert map.insert(14, 22);
         map.clear();
         assert map.is_empty();
-        assert map.find(5).is_none();
-        assert map.find(11).is_none();
-        assert map.find(14).is_none();
+        assert map.find(&5).is_none();
+        assert map.find(&11).is_none();
+        assert map.find(&14).is_none();
     }
 
     #[test]
     fn test_insert_with_key() {
-        let map: SmallIntMap<uint> = mk();
+        let mut map = SmallIntMap::new();
 
         // given a new key, initialize it with this new count, given
         // given an existing key, add more to its count
@@ -227,11 +188,11 @@ mod tests {
         map.update_with_key(3, 2, addMoreToCount);
 
         // check the total counts
-        assert map.find(3).get() == 10;
-        assert map.find(5).get() == 3;
-        assert map.find(9).get() == 1;
+        assert map.find(&3).get() == &10;
+        assert map.find(&5).get() == &3;
+        assert map.find(&9).get() == &1;
 
         // sadly, no sevens were counted
-        assert None == map.find(7);
+        assert map.find(&7).is_none();
     }
 }

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -14,8 +14,6 @@
  */
 #[forbid(deprecated_mode)];
 
-use map::StdMap;
-
 use core::container::{Container, Mutable, Map, Set};
 use core::dvec::DVec;
 use core::ops;
@@ -98,8 +96,7 @@ impl<V> SmallIntMap<V>: Container {
 }
 
 /// Implements the map::map interface for smallintmap
-impl<V: Copy> SmallIntMap<V>: StdMap<uint, V> {
-    pure fn size() -> uint { self.len() }
+impl<V: Copy> SmallIntMap<V> {
     #[inline(always)]
     fn insert(key: uint, value: V) -> bool {
         let exists = contains_key(self, key);
@@ -170,11 +167,6 @@ impl<V: Copy> SmallIntMap<V>: ops::Index<uint, V> {
             get(*self, key)
         }
     }
-}
-
-/// Cast the given smallintmap to a map::map
-pub fn as_map<V: Copy>(s: SmallIntMap<V>) -> StdMap<uint, V> {
-    s as StdMap::<uint, V>
 }
 
 #[cfg(test)]

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -174,7 +174,6 @@ mod tests {
     use smallintmap::{mk, SmallIntMap};
 
     use core::option::None;
-    use core::option;
 
     #[test]
     fn test_len() {
@@ -214,9 +213,9 @@ mod tests {
         map.update_with_key(3, 2, addMoreToCount);
 
         // check the total counts
-        assert 10 == option::get(map.find(3));
-        assert  3 == option::get(map.find(5));
-        assert  1 == option::get(map.find(9));
+        assert map.find(3).get() == 10;
+        assert map.find(5).get() == 3;
+        assert map.find(9).get() == 1;
 
         // sadly, no sevens were counted
         assert None == map.find(7);

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -82,6 +82,7 @@ pub mod list;
 pub mod map;
 pub mod priority_queue;
 pub mod rope;
+pub mod smallintmap;
 pub mod oldsmallintmap;
 pub mod sort;
 pub mod treemap;

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -82,7 +82,7 @@ pub mod list;
 pub mod map;
 pub mod priority_queue;
 pub mod rope;
-pub mod smallintmap;
+pub mod oldsmallintmap;
 pub mod sort;
 pub mod treemap;
 

--- a/src/test/bench/std-smallintmap.rs
+++ b/src/test/bench/std-smallintmap.rs
@@ -8,22 +8,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Microbenchmark for the oldsmallintmap library
+// Microbenchmark for the smallintmap library
 
 extern mod std;
-use std::oldsmallintmap;
-use std::oldsmallintmap::SmallIntMap;
+use std::smallintmap::SmallIntMap;
 use io::WriterUtil;
 
-fn append_sequential(min: uint, max: uint, map: SmallIntMap<uint>) {
+fn append_sequential(min: uint, max: uint, map: &mut SmallIntMap<uint>) {
     for uint::range(min, max) |i| {
         map.insert(i, i + 22u);
     }
 }
 
-fn check_sequential(min: uint, max: uint, map: SmallIntMap<uint>) {
+fn check_sequential(min: uint, max: uint, map: &SmallIntMap<uint>) {
     for uint::range(min, max) |i| {
-        assert map.get(i) == i + 22u;
+        assert *map.get(&i) == i + 22u;
     }
 }
 
@@ -43,11 +42,11 @@ fn main() {
     let mut appendf = 0.0;
 
     for uint::range(0u, rep) |_r| {
-        let map = oldsmallintmap::mk();
+        let mut map = SmallIntMap::new();
         let start = std::time::precise_time_s();
-        append_sequential(0u, max, map);
+        append_sequential(0u, max, &mut map);
         let mid = std::time::precise_time_s();
-        check_sequential(0u, max, map);
+        check_sequential(0u, max, &map);
         let end = std::time::precise_time_s();
 
         checkf += (end - mid) as float;

--- a/src/test/bench/std-smallintmap.rs
+++ b/src/test/bench/std-smallintmap.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Microbenchmark for the smallintmap library
+// Microbenchmark for the oldsmallintmap library
 
 extern mod std;
-use std::smallintmap;
-use std::smallintmap::SmallIntMap;
+use std::oldsmallintmap;
+use std::oldsmallintmap::SmallIntMap;
 use io::WriterUtil;
 
 fn append_sequential(min: uint, max: uint, map: SmallIntMap<uint>) {
@@ -43,7 +43,7 @@ fn main() {
     let mut appendf = 0.0;
 
     for uint::range(0u, rep) |_r| {
-        let map = smallintmap::mk();
+        let map = oldsmallintmap::mk();
         let start = std::time::precise_time_s();
         append_sequential(0u, max, map);
         let mid = std::time::precise_time_s();


### PR DESCRIPTION
This makes it a proper owned data structure without an @ box and a mutable field (from DVec), and implements the core::container::Map trait.

The old module is still around as `oldsmallintmap.rs` and migrating over to the new module seems like it will involve dealing with switching to explicit self and getting rid of mutable fields in the librustc code (at least without boxing it in @ again). I gave it a try but it turned into a bigger mess than I felt like dealing with today.

Closes #4693 and #2347, and another bug can be opened about migrating away from the old module.
