### PR TITLE
auto: Fix assorted issues with enums in constants.

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -382,6 +382,7 @@ pub extern mod llvm {
     pub unsafe fn LLVMGetUsedValue(U: UseRef) -> ValueRef;
 
     /* Operations on Users */
+    pub unsafe fn LLVMGetNumOperands(Val: ValueRef) -> c_int;
     pub unsafe fn LLVMGetOperand(Val: ValueRef, Index: c_uint) -> ValueRef;
     pub unsafe fn LLVMSetOperand(Val: ValueRef, Index: c_uint, Op: ValueRef);
 

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -381,8 +381,7 @@ pub fn const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
                       }
                   })
               };
-              let llty = type_of::type_of(cx, ety);
-              C_named_struct(llty, [C_struct(cs)])
+              C_struct([C_struct(cs)])
           }
           ast::expr_vec(es, ast::m_imm) => {
             let (v, _, _) = const_vec(cx, e, es);

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -470,7 +470,12 @@ pub fn const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
 
                 // FIXME (#1645): enum body alignment is generaly wrong.
                 if !degen {
-                    C_packed_struct(~[discrim, c_args])
+                    // A packed_struct has an alignment of 1; thus,
+                    // wrapping one around c_args will misalign it the
+                    // same way we normally misalign enum bodies
+                    // without affecting its internal alignment or
+                    // changing the alignment of the enum.
+                    C_struct(~[discrim, C_packed_struct(~[c_args])])
                 } else if size == 0 {
                     C_struct(~[discrim])
                 } else {

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -459,14 +459,12 @@ pub fn const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
           ast::expr_call(callee, args, _) => {
             match cx.tcx.def_map.find(&callee.id) {
                 Some(ast::def_struct(def_id)) => {
-                    let ety = ty::expr_ty(cx.tcx, e);
-                    let llty = type_of::type_of(cx, ety);
                     let llstructbody =
                         C_struct(args.map(|a| const_expr(cx, *a)));
                     if ty::ty_dtor(cx.tcx, def_id).is_present() {
-                        C_named_struct(llty, ~[ llstructbody, C_u8(0) ])
+                        C_struct(~[ llstructbody, C_u8(0) ])
                     } else {
-                        C_named_struct(llty, ~[ llstructbody ])
+                        C_struct(~[ llstructbody ])
                     }
                 }
             Some(ast::def_variant(tid, vid)) => {

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -434,7 +434,13 @@ pub fn const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
                     let lldiscrim = base::get_discrim_val(cx, e.span,
                                                           enum_did,
                                                           variant_did);
-                    C_struct(~[lldiscrim])
+                    // However, we still have to pad it out to the
+                    // size of the full enum; see the expr_call case,
+                    // below.
+                    let ety = ty::expr_ty(cx.tcx, e);
+                    let size = machine::static_size_of_enum(cx, ety);
+                    let padding = C_null(T_array(T_i8(), size));
+                    C_struct(~[lldiscrim, padding])
                 }
                 Some(ast::def_struct(_)) => {
                     let ety = ty::expr_ty(cx.tcx, e);

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -352,10 +352,8 @@ pub fn const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
           }
           ast::expr_addr_of(ast::m_imm, sub) => {
             let cv = const_expr(cx, sub);
-            let subty = ty::expr_ty(cx.tcx, sub),
-            llty = type_of::type_of(cx, subty);
             let gv = do str::as_c_str("const") |name| {
-                llvm::LLVMAddGlobal(cx.llmod, llty, name)
+                llvm::LLVMAddGlobal(cx.llmod, val_ty(cv), name)
             };
             llvm::LLVMSetInitializer(gv, cv);
             llvm::LLVMSetGlobalConstant(gv, True);

--- a/src/test/run-pass/const-enum-ptr.rs
+++ b/src/test/run-pass/const-enum-ptr.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E { V0, V1(int) }
+const C: &static/E = &V0;
+
+fn main() {
+    match *C {
+        V0 => (),
+        _ => die!()
+    }
+}

--- a/src/test/run-pass/const-enum-struct.rs
+++ b/src/test/run-pass/const-enum-struct.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E { V16(u16), V32(u32) }
+struct S { a: E, b: u16, c: u16 }
+const C: S = S { a: V16(0xDEAD), b: 0x600D, c: 0xBAD };
+
+fn main() {
+    let n = C.b;
+    assert n != 0xBAD;
+    assert n == 0x600D;
+}

--- a/src/test/run-pass/const-enum-struct2.rs
+++ b/src/test/run-pass/const-enum-struct2.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E { V0, V16(u16) }
+struct S { a: E, b: u16, c: u16 }
+const C: S = S { a: V0, b: 0x600D, c: 0xBAD };
+
+fn main() {
+    let n = C.b;
+    assert n != 0xBAD;
+    assert n == 0x600D;
+}

--- a/src/test/run-pass/const-enum-tuple.rs
+++ b/src/test/run-pass/const-enum-tuple.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E { V16(u16), V32(u32) }
+const C: (E, u16, u16) = (V16(0xDEAD), 0x600D, 0xBAD);
+
+fn main() {
+    let (_, n, _) = C;
+    assert n != 0xBAD;
+    assert n == 0x600D;
+}

--- a/src/test/run-pass/const-enum-tuple2.rs
+++ b/src/test/run-pass/const-enum-tuple2.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E { V0, V16(u16) }
+const C: (E, u16, u16) = (V0, 0x600D, 0xBAD);
+
+fn main() {
+    let (_, n, _) = C;
+    assert n != 0xBAD;
+    assert n == 0x600D;
+}

--- a/src/test/run-pass/const-enum-tuplestruct.rs
+++ b/src/test/run-pass/const-enum-tuplestruct.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E { V16(u16), V32(u32) }
+struct S(E, u16, u16);
+const C: S = S(V16(0xDEAD), 0x600D, 0xBAD);
+
+fn main() {
+    let S(_, n, _) = C;
+    assert n != 0xBAD;
+    assert n == 0x600D;
+}

--- a/src/test/run-pass/const-enum-tuplestruct2.rs
+++ b/src/test/run-pass/const-enum-tuplestruct2.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E { V0, V16(u16) }
+struct S(E, u16, u16);
+const C: S = S(V0, 0x600D, 0xBAD);
+
+fn main() {
+    let S(_, n, _) = C;
+    assert n != 0xBAD;
+    assert n == 0x600D;
+}

--- a/src/test/run-pass/const-enum-vec-index.rs
+++ b/src/test/run-pass/const-enum-vec-index.rs
@@ -1,0 +1,25 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E { V1(int), V0 }
+const C: &[E] = &[V0, V1(0xDEADBEE)];
+const C0: E = C[0];
+const C1: E = C[1];
+
+fn main() {
+    match C0 { 
+        V0 => (),
+        _ => die!()
+    }
+    match C1 {
+        V1(n) => assert(n == 0xDEADBEE),
+        _ => die!()
+    }
+}

--- a/src/test/run-pass/const-enum-vec-ptr.rs
+++ b/src/test/run-pass/const-enum-vec-ptr.rs
@@ -1,0 +1,23 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E { V1(int), V0 }
+const C: &static/[E] = &[V0, V1(0xDEADBEE), V0];
+
+fn main() {
+    match C[1] {
+        V1(n) => assert(n == 0xDEADBEE),
+        _ => die!()
+    }
+    match C[2] { 
+        V0 => (),
+        _ => die!()
+    }
+}

--- a/src/test/run-pass/const-enum-vector.rs
+++ b/src/test/run-pass/const-enum-vector.rs
@@ -1,0 +1,23 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E { V1(int), V0 }
+const C: [E * 3] = [V0, V1(0xDEADBEE), V0];
+
+fn main() {
+    match C[1] {
+        V1(n) => assert(n == 0xDEADBEE),
+        _ => die!()
+    }
+    match C[2] { 
+        V0 => (),
+        _ => die!()
+    }
+}


### PR DESCRIPTION
There were a bunch of problems with consts where an enum was contained within some other type (vector, tuple, struct, etc.); some of these would cause LLVM assertion failures, and some would silently read from the wrong address.  These changes should fix all of that.

It would be good if someone with access to a win32 host could do the equivalent of `make check-stageN-rpass TESTNAME=enum` on that platform before merging this.
