### PR TITLE
auto: Add clang 4.2 to supported versions (that what Apple calls 3.2svn) r=graydon

### DIFF
--- a/configure
+++ b/configure
@@ -516,7 +516,7 @@ then
                       | cut -d ' ' -f 2)
 
     case $CFG_CLANG_VERSION in
-        (3.0svn | 3.0 | 3.1 | 3.2 | 4.0 | 4.1)
+        (3.0svn | 3.0 | 3.1 | 3.2 | 4.0 | 4.1 | 4.2)
         step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
         CFG_C_COMPILER="clang"
         ;;


### PR DESCRIPTION
Apple released a new XCode version with clang 3.2svn, but called it 4.2, thus breaking ./configure.
