### PR TITLE
auto: Use x86-64 CABI for foreign function on arm target

### DIFF
--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -42,7 +42,7 @@ use syntax::parse::token::special_idents;
 
 fn abi_info(arch: session::arch) -> cabi::ABIInfo {
     return match arch {
-        arch_x86_64 => x86_64_abi_info(),
+        arch_x86_64 | arch_arm => x86_64_abi_info(),
         _ => cabi::llvm_abi_info()
     }
 }


### PR DESCRIPTION
Fixed CABI problem on arm target.

Related issue: #4513
Related commit: 
- https://github.com/mozilla/rust/commit/987f824f2#L16R1497  
  (use x86_64 abi for arm target)
- https://github.com/mozilla/rust/commit/b72d4d70a#L2R46
- https://github.com/mozilla/rust/commit/b72d4d70a#L2R923 
  (accidentally use default abi for arm target)
