### PR TITLE
auto: bool is not an integral type

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2435,7 +2435,7 @@ pub fn type_structurally_contains_uniques(cx: ctxt, ty: t) -> bool {
 
 pub fn type_is_integral(ty: t) -> bool {
     match get(ty).sty {
-      ty_infer(IntVar(_)) | ty_int(_) | ty_uint(_) | ty_bool => true,
+      ty_infer(IntVar(_)) | ty_int(_) | ty_uint(_) => true,
       _ => false
     }
 }

--- a/src/test/compile-fail/unop-neg-bool.rs
+++ b/src/test/compile-fail/unop-neg-bool.rs
@@ -1,0 +1,3 @@
+fn main() {
+    -true; //~ ERROR cannot apply unary operator `-` to type `bool`
+}


### PR DESCRIPTION
`ty::type_is_integral` returns `true` for `ty_bool`. This causes `-true` to compile, instead of resulting in a type error.
