### PR TITLE
auto: Add support for clang 4.2 (as reported by apple clang) r=graydon

### DIFF
--- a/configure
+++ b/configure
@@ -515,7 +515,7 @@ then
                       | cut -d ' ' -f 2)
 
     case $CFG_CLANG_VERSION in
-        (3.0svn | 3.0 | 3.1* | 3.2* | 4.0* | 4.1*)
+        (3.0svn | 3.0 | 3.1* | 3.2* | 4.0* | 4.1* | 4.2*)
         step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
         CFG_C_COMPILER="clang"
         ;;


### PR DESCRIPTION
This is just a retargeting of https://github.com/mozilla/rust/pull/4753 against incoming
