### PR TITLE
Add debug info tests

### DIFF
--- a/configure
+++ b/configure
@@ -619,6 +619,7 @@ do
     make_dir $h/test/bench
     make_dir $h/test/perf
     make_dir $h/test/pretty
+    make_dir $h/test/debug-info
     make_dir $h/test/doc-tutorial
     make_dir $h/test/doc-tutorial-ffi
     make_dir $h/test/doc-tutorial-macros

--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -1,5 +1,5 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
+// Copyright 2012-2013 The Rust Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -18,6 +18,7 @@ pub enum mode {
     mode_run_fail,
     mode_run_pass,
     mode_pretty,
+    mode_debug_info,
 }
 
 pub type config = {

--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -1,5 +1,5 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
+// Copyright 2012-2013 The Rust Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -41,6 +41,7 @@ use common::mode_run_pass;
 use common::mode_run_fail;
 use common::mode_compile_fail;
 use common::mode_pretty;
+use common::mode_debug_info;
 use common::mode;
 use util::logv;
 
@@ -131,6 +132,7 @@ pub fn str_mode(s: ~str) -> mode {
       ~"run-fail" => mode_run_fail,
       ~"run-pass" => mode_run_pass,
       ~"pretty" => mode_pretty,
+      ~"debug-info" => mode_debug_info,
       _ => die!(~"invalid mode")
     }
 }
@@ -140,7 +142,8 @@ pub fn mode_str(mode: mode) -> ~str {
       mode_compile_fail => ~"compile-fail",
       mode_run_fail => ~"run-fail",
       mode_run_pass => ~"run-pass",
-      mode_pretty => ~"pretty"
+      mode_pretty => ~"pretty",
+      mode_debug_info => ~"debug-info"
     }
 }
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1,5 +1,5 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
+// Copyright 2012-2013 The Rust Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -43,7 +43,8 @@ pub fn run(config: config, testfile: ~str) {
       mode_compile_fail => run_cfail_test(config, props, &testfile),
       mode_run_fail => run_rfail_test(config, props, &testfile),
       mode_run_pass => run_rpass_test(config, props, &testfile),
-      mode_pretty => run_pretty_test(config, props, &testfile)
+      mode_pretty => run_pretty_test(config, props, &testfile),
+      mode_debug_info => run_debuginfo_test(config, props, &testfile)
     }
 }
 
@@ -221,6 +222,55 @@ actual:\n\
                          aux_output_dir_name(config, testfile).to_str()];
         args += split_maybe_args(config.rustcflags);
         return ProcArgs {prog: prog.to_str(), args: args};
+    }
+}
+
+fn run_debuginfo_test(config: config, props: TestProps, testfile: &Path) {
+    // compile test file (it shoud have 'compile-flags:-g' in the header)
+    let mut ProcRes = compile_test(config, props, testfile);
+    if ProcRes.status != 0 {
+        fatal_ProcRes(~"compilation failed!", ProcRes);
+    }
+
+    // write debugger script
+    let script_str = str::append(str::connect(props.debugger_cmds, "\n"),
+                                 ~"\nquit\n");
+    debug!("script_str = %s", script_str);
+    dump_output_file(config, testfile, script_str, ~"debugger.script");
+
+    // run debugger script with gdb
+    #[cfg(windows)]
+    fn debugger() -> ~str { ~"gdb.exe" }
+    #[cfg(unix)]
+    fn debugger() -> ~str { ~"gdb" }
+    let debugger_script = make_out_name(config, testfile, ~"debugger.script");
+    let debugger_opts = ~[~"-quiet", ~"-batch", ~"-nx",
+                          ~"-command=" + debugger_script.to_str(),
+                          make_exe_name(config, testfile).to_str()];
+    let ProcArgs = ProcArgs {prog: debugger(), args: debugger_opts};
+    ProcRes = compose_and_run(config, testfile, ProcArgs, ~[], ~"", None);
+    if ProcRes.status != 0 {
+        fatal(~"gdb failed to execute");
+    }
+
+    let num_check_lines = vec::len(props.check_lines);
+    if num_check_lines > 0 {
+        // check if each line in props.check_lines appears in the
+        // output (in order)
+        let mut i = 0u;
+        for str::lines(ProcRes.stdout).each |line| {
+            if props.check_lines[i].trim() == line.trim() {
+                i += 1u;
+            }
+            if i == num_check_lines {
+                // all lines checked
+                break;
+            }
+        }
+        if i != num_check_lines {
+            fatal(fmt!("line not found in debugger output: %s",
+                       props.check_lines[i]));
+        }
     }
 }
 

--- a/src/test/debug-info/simple.rs
+++ b/src/test/debug-info/simple.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-test
+// compile-flags:-g
+// debugger:break 20
+// debugger:run
+// debugger:print x
+// check:$1 = 42
+
+fn main() {
+    let x = 42;
+    debug!("The answer is %d", x);
+}

--- a/src/test/debug-info/struct.rs
+++ b/src/test/debug-info/struct.rs
@@ -1,0 +1,33 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-test
+// compile-flags:-g
+// debugger:break 32
+// debugger:run
+// debugger:print pair
+// check:$1 = {
+// check:x = 1,
+// check:y = 2,
+// check:}
+// debugger:print pair.x
+// check:$2 = 1
+// debugger:print pair.y
+// check:$3 = 2
+
+struct Pair {
+    x: int,
+    y: int
+}
+
+fn main() {
+    let pair = Pair { x: 1, y: 2 };
+    debug!("x = %d, y = %d", pair.x, pair.y);
+}


### PR DESCRIPTION
Fix for [issue 2195](https://github.com/mozilla/rust/issues/2195).

The testing procedure mimics the way clang/llvm does their debuginfo tests - it creates a debugging commands script from directives in the header file which gdb runs in batch mode with the executable, and then checks if output is as expected. I have two very simple tests included, and they're both ignored because rust doesn't seem to emit good enough symbols for them to pass (by the way, I'll see if I can help fix that).

Note that once debug info tests are enabled, gdb will become a dependency for 'make check'.
