### PR TITLE
auto: Changes in Rust 0.6: `core::send_map` renamed to `core::hashmap`

### DIFF
--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -1,3 +1,9 @@
+Version 0.6 (?)
+---------------------------
+
+   * Libraries
+     * `core::send_map` renamed to `core::hashmap`
+
 Version 0.5 (December 2012)
 ---------------------------
 


### PR DESCRIPTION
Encountered this while trying to port rustsqlite to rust 0.6
