### PR TITLE
auto: librustc: Stop loading enum variant discriminants from memory

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -813,27 +813,6 @@ pub fn get_discrim_val(cx: @crate_ctxt, span: span, enum_did: ast::def_id,
     }
 }
 
-pub fn lookup_discriminant(ccx: @crate_ctxt, vid: ast::def_id) -> ValueRef {
-    unsafe {
-        let _icx = ccx.insn_ctxt("lookup_discriminant");
-        match ccx.discrims.find(&vid) {
-            None => {
-                // It's an external discriminant that we haven't seen yet.
-                assert (vid.crate != ast::local_crate);
-                let sym = csearch::get_symbol(ccx.sess.cstore, vid);
-                let gvar = str::as_c_str(sym, |buf| {
-                    llvm::LLVMAddGlobal(ccx.llmod, ccx.int_type, buf)
-                });
-                lib::llvm::SetLinkage(gvar, lib::llvm::ExternalLinkage);
-                llvm::LLVMSetGlobalConstant(gvar, True);
-                ccx.discrims.insert(vid, gvar);
-                return gvar;
-            }
-            Some(llval) => return llval,
-        }
-    }
-}
-
 pub fn invoke(bcx: block, llfn: ValueRef, +llargs: ~[ValueRef]) -> block {
     let _icx = bcx.insn_ctxt("invoke_");
     if bcx.unreachable { return bcx; }

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -696,15 +696,15 @@ fn trans_def_dps_unadjusted(bcx: block, ref_expr: @ast::expr,
             return fn_data_to_datum(bcx, impl_did, fn_data, lldest);
         }
         ast::def_variant(tid, vid) => {
-            if ty::enum_variant_with_id(ccx.tcx, tid, vid).args.len() > 0u {
+            let variant_info = ty::enum_variant_with_id(ccx.tcx, tid, vid);
+            if variant_info.args.len() > 0u {
                 // N-ary variant.
                 let fn_data = callee::trans_fn_ref(bcx, vid, ref_expr.id);
                 return fn_data_to_datum(bcx, vid, fn_data, lldest);
             } else {
                 // Nullary variant.
                 let lldiscrimptr = GEPi(bcx, lldest, [0u, 0u]);
-                let lldiscrim_gv = base::lookup_discriminant(ccx, vid);
-                let lldiscrim = Load(bcx, lldiscrim_gv);
+                let lldiscrim = C_int(bcx.ccx(), variant_info.disr_val);
                 Store(bcx, lldiscrim, lldiscrimptr);
                 return bcx;
             }


### PR DESCRIPTION
r? @graydon
