### PR TITLE
auto: Add json enum encoding

### DIFF
--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -130,12 +130,11 @@ pub impl Encoder: serialize::Encoder {
         // element provides the enum variant name
         self.wr.write_char('[');
         self.wr.write_str(escape_str(name));
-        self.wr.write_char(',');
         f();
         self.wr.write_char(']');
     }
     fn emit_enum_variant_arg(&self, idx: uint, f: fn()) {
-        if idx != 0 {self.wr.write_char(',');}
+        self.wr.write_char(',');
         f();
     }
 

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -132,7 +132,7 @@ pub impl Encoder: serialize::Encoder {
 
         // other enums are encoded as vectors:
         // Kangaroo(34,"William") => ["Kangaroo",[34,"William"]]
-        
+
         // the default expansion for enums is more verbose than I'd like;
         // specifically, the inner pair of brackets seems superfluous,
         // BUT the design of the enumeration framework and the requirements
@@ -140,10 +140,11 @@ pub impl Encoder: serialize::Encoder {
         // be encoded "naked"--with no commas--and that the option name
         // can't be followed by just a comma, because there might not
         // be any elements in the tuple.
-        
-        // FIXME : this would be more precise and less frightening
+
+        // this would be more precise and less frightening
         // with fully-qualified option names. To get that information,
-        // we'd have to change the expansion of auto-encode to pass those along.
+        // we'd have to change the expansion of auto-encode to pass
+        // those along.
 
         if (name == ~"Some") {
             f();
@@ -170,6 +171,7 @@ pub impl Encoder: serialize::Encoder {
         f();
         self.wr.write_char(']');
     }
+
     fn emit_owned_vec(&self, len: uint, f: fn()) {
         self.emit_borrowed_vec(len, f)
     }

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -121,21 +121,21 @@ pub impl Encoder: serialize::Encoder {
     fn emit_owned(&self, f: fn()) { f() }
     fn emit_managed(&self, f: fn()) { f() }
 
-    fn emit_enum(&self, name: &str, f: fn()) {
+    fn emit_enum(&self, _name: &str, f: fn()) {
         f()
     }
-    
-    fn emit_enum_variant(&self, _name: &str, id: uint, _cnt: uint, f: fn()) {
+
+    fn emit_enum_variant(&self, name: &str, _id: uint, _cnt: uint, f: fn()) {
         // emitting enums as arrays where the first
         // element provides the enum variant name
         self.wr.write_char('[');
-        self.wr.write_str(escape_str(_name));
+        self.wr.write_str(escape_str(name));
         self.wr.write_char(',');
         f();
         self.wr.write_char(']');
     }
-    fn emit_enum_variant_arg(&self, _idx: uint, f: fn()) {
-        if _idx != 0 {self.wr.write_char(',');}
+    fn emit_enum_variant_arg(&self, idx: uint, f: fn()) {
+        if idx != 0 {self.wr.write_char(',');}
         f();
     }
 

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -141,7 +141,7 @@ pub impl Encoder: serialize::Encoder {
         // can't be followed by just a comma, because there might not
         // be any elements in the tuple.
 
-        // this would be more precise and less frightening
+        // FIXME #4872: this would be more precise and less frightening
         // with fully-qualified option names. To get that information,
         // we'd have to change the expansion of auto-encode to pass
         // those along.

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -122,9 +122,15 @@ pub impl Encoder: serialize::Encoder {
     fn emit_managed(&self, f: fn()) { f() }
 
     fn emit_enum(&self, name: &str, f: fn()) {
-        if name != "option" { die!(~"only supports option enum") }
-        f()
+        // emitting enums as arrays where the first
+        // element provides the enum variant name
+        self.wr.write_char('[');
+        self.wr.write_str(name);
+        self.wr.write_char(',');
+        f();
+        self.wr.write_char(']');
     }
+    
     fn emit_enum_variant(&self, _name: &str, id: uint, _cnt: uint, f: fn()) {
         if id == 0 {
             self.emit_nil();

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -122,24 +122,21 @@ pub impl Encoder: serialize::Encoder {
     fn emit_managed(&self, f: fn()) { f() }
 
     fn emit_enum(&self, name: &str, f: fn()) {
+        f()
+    }
+    
+    fn emit_enum_variant(&self, _name: &str, id: uint, _cnt: uint, f: fn()) {
         // emitting enums as arrays where the first
         // element provides the enum variant name
         self.wr.write_char('[');
-        self.wr.write_str(name);
+        self.wr.write_str(escape_str(_name));
         self.wr.write_char(',');
         f();
         self.wr.write_char(']');
     }
-    
-    fn emit_enum_variant(&self, _name: &str, id: uint, _cnt: uint, f: fn()) {
-        if id == 0 {
-            self.emit_nil();
-        } else {
-            f()
-        }
-    }
     fn emit_enum_variant_arg(&self, _idx: uint, f: fn()) {
-        f()
+        if _idx != 0 {self.wr.write_char(',');}
+        f();
     }
 
     fn emit_borrowed_vec(&self, _len: uint, f: fn()) {

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -1189,87 +1189,88 @@ mod test {
             self.add_to_log (CallToOther)
         }
     }
-    
+
     pub impl Encoder for TestEncoder {
         fn emit_nil(&self) { self.add_to_log(CallToEmitNil) }
-        
+
         fn emit_uint(&self, +v: uint) {self.add_to_log(CallToEmitUint(v)); }
         fn emit_u64(&self, +_v: u64) { self.add_unknown_to_log(); }
-    fn emit_u32(&self, +_v: u32) { self.add_unknown_to_log(); }
-    fn emit_u16(&self, +_v: u16) { self.add_unknown_to_log(); }
-    fn emit_u8(&self, +_v: u8)   { self.add_unknown_to_log(); }
+        fn emit_u32(&self, +_v: u32) { self.add_unknown_to_log(); }
+        fn emit_u16(&self, +_v: u16) { self.add_unknown_to_log(); }
+        fn emit_u8(&self, +_v: u8)   { self.add_unknown_to_log(); }
 
-    fn emit_int(&self, +_v: int) { self.add_unknown_to_log(); }
-    fn emit_i64(&self, +_v: i64) { self.add_unknown_to_log(); }
-    fn emit_i32(&self, +_v: i32) { self.add_unknown_to_log(); }
-    fn emit_i16(&self, +_v: i16) { self.add_unknown_to_log(); }
-    fn emit_i8(&self, +_v: i8)   { self.add_unknown_to_log(); }
+        fn emit_int(&self, +_v: int) { self.add_unknown_to_log(); }
+        fn emit_i64(&self, +_v: i64) { self.add_unknown_to_log(); }
+        fn emit_i32(&self, +_v: i32) { self.add_unknown_to_log(); }
+        fn emit_i16(&self, +_v: i16) { self.add_unknown_to_log(); }
+        fn emit_i8(&self, +_v: i8)   { self.add_unknown_to_log(); }
 
-    fn emit_bool(&self, +_v: bool) { self.add_unknown_to_log(); }
+        fn emit_bool(&self, +_v: bool) { self.add_unknown_to_log(); }
 
-    fn emit_f64(&self, +_v: f64) { self.add_unknown_to_log(); }
-    fn emit_f32(&self, +_v: f32) { self.add_unknown_to_log(); }
-    fn emit_float(&self, +_v: float) { self.add_unknown_to_log(); }
+        fn emit_f64(&self, +_v: f64) { self.add_unknown_to_log(); }
+        fn emit_f32(&self, +_v: f32) { self.add_unknown_to_log(); }
+        fn emit_float(&self, +_v: float) { self.add_unknown_to_log(); }
 
-    fn emit_char(&self, +_v: char) { self.add_unknown_to_log(); }
+        fn emit_char(&self, +_v: char) { self.add_unknown_to_log(); }
 
-    fn emit_borrowed_str(&self, +_v: &str) { self.add_unknown_to_log(); }
-    fn emit_owned_str(&self, +_v: &str) { self.add_unknown_to_log(); }
-    fn emit_managed_str(&self, +_v: &str) { self.add_unknown_to_log(); }
+        fn emit_borrowed_str(&self, +_v: &str) { self.add_unknown_to_log(); }
+        fn emit_owned_str(&self, +_v: &str) { self.add_unknown_to_log(); }
+        fn emit_managed_str(&self, +_v: &str) { self.add_unknown_to_log(); }
 
-    fn emit_borrowed(&self, f: fn()) { self.add_unknown_to_log(); f() }
-    fn emit_owned(&self, f: fn()) { self.add_unknown_to_log(); f() }
-    fn emit_managed(&self, f: fn()) { self.add_unknown_to_log(); f() }
+        fn emit_borrowed(&self, f: fn()) { self.add_unknown_to_log(); f() }
+        fn emit_owned(&self, f: fn()) { self.add_unknown_to_log(); f() }
+        fn emit_managed(&self, f: fn()) { self.add_unknown_to_log(); f() }
 
-    fn emit_enum(&self, name: &str, f: fn()) {
-        self.add_to_log(CallToEmitEnum(name.to_str())); f(); }
+        fn emit_enum(&self, name: &str, f: fn()) {
+            self.add_to_log(CallToEmitEnum(name.to_str())); f(); }
 
-    fn emit_enum_variant(&self, name: &str, +id: uint, +cnt: uint, f: fn()) {
-        self.add_to_log(CallToEmitEnumVariant (name.to_str(),id,cnt)); f();
+        fn emit_enum_variant(&self, name: &str, +id: uint,
+                             +cnt: uint, f: fn()) {
+            self.add_to_log(CallToEmitEnumVariant (name.to_str(),id,cnt));
+            f();
+        }
+
+        fn emit_enum_variant_arg(&self, +idx: uint, f: fn()) {
+            self.add_to_log(CallToEmitEnumVariantArg (idx)); f();
+        }
+
+        fn emit_borrowed_vec(&self, +_len: uint, f: fn()) {
+            self.add_unknown_to_log(); f();
+        }
+
+        fn emit_owned_vec(&self, +_len: uint, f: fn()) {
+            self.add_unknown_to_log(); f();
+        }
+        fn emit_managed_vec(&self, +_len: uint, f: fn()) {
+            self.add_unknown_to_log(); f();
+        }
+        fn emit_vec_elt(&self, +_idx: uint, f: fn()) {
+            self.add_unknown_to_log(); f();
+        }
+
+        fn emit_rec(&self, f: fn()) {
+            self.add_unknown_to_log(); f();
+        }
+        fn emit_struct(&self, _name: &str, +_len: uint, f: fn()) {
+            self.add_unknown_to_log(); f();
+        }
+        fn emit_field(&self, _name: &str, +_idx: uint, f: fn()) {
+            self.add_unknown_to_log(); f();
+        }
+
+        fn emit_tup(&self, +_len: uint, f: fn()) {
+            self.add_unknown_to_log(); f();
+        }
+        fn emit_tup_elt(&self, +_idx: uint, f: fn()) {
+            self.add_unknown_to_log(); f();
+        }
     }
 
-    fn emit_enum_variant_arg(&self, +idx: uint, f: fn()) {
-        self.add_to_log(CallToEmitEnumVariantArg (idx)); f();
-    }
 
-    fn emit_borrowed_vec(&self, +_len: uint, f: fn()) {
-        self.add_unknown_to_log(); f();
-    }
-
-    fn emit_owned_vec(&self, +_len: uint, f: fn()) {
-        self.add_unknown_to_log(); f();
-    }
-    fn emit_managed_vec(&self, +_len: uint, f: fn()) {
-        self.add_unknown_to_log(); f();
-    }
-    fn emit_vec_elt(&self, +_idx: uint, f: fn()) {
-        self.add_unknown_to_log(); f();
-    }
-
-    fn emit_rec(&self, f: fn()) {
-        self.add_unknown_to_log(); f();
-    }
-    fn emit_struct(&self, _name: &str, +_len: uint, f: fn()) {
-        self.add_unknown_to_log(); f();
-    }
-    fn emit_field(&self, _name: &str, +_idx: uint, f: fn()) {
-        self.add_unknown_to_log(); f();
-    }
-        
-    fn emit_tup(&self, +_len: uint, f: fn()) {
-        self.add_unknown_to_log(); f();
-    }
-    fn emit_tup_elt(&self, +_idx: uint, f: fn()) {
-        self.add_unknown_to_log(); f();
-    }
-}
-
-    
     #[auto_decode]
     #[auto_encode]
     struct Node {id: uint}
 
-    
     fn to_call_log (val: Encodable<TestEncoder>) -> ~[call] {
         let mut te = TestEncoder {call_log: ~[]};
         val.encode(&te);

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -1160,8 +1160,7 @@ mod test {
     use core::io;
     use core::str;
     use std;
-    
-    
+
     #[auto_decode]
     #[auto_encode]
     struct Node {id: uint}
@@ -1171,9 +1170,11 @@ mod test {
         val.encode(~std::json::Encoder(bw as io::Writer));
         str::from_bytes(bw.bytes.data)
     }
-    
+
     #[test] fn encode_test () {
-        check_equal (to_json_str(Node{id:34} as Encodable::<std::json::Encoder>),~"{\"id\":34}");
+        check_equal (to_json_str(Node{id:34}
+                                 as Encodable::<std::json::Encoder>),
+                     ~"{\"id\":34}");
     }
 
     #[auto_encode]
@@ -1185,7 +1186,8 @@ mod test {
     #[test] fn json_enum_encode_test () {
         check_equal (to_json_str(Book(9) as Encodable::<std::json::Encoder>),
                      ~"[\"Book\",9]");
-        check_equal (to_json_str(Magazine(~"Paris Match") as Encodable::<std::json::Encoder>),
+        check_equal (to_json_str(Magazine(~"Paris Match")
+                                 as Encodable::<std::json::Encoder>),
                      ~"[\"Magazine\",\"Paris Match\"]");
     }
 }

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -1155,39 +1155,148 @@ fn mk_enum_deser_body(
 #[cfg(test)]
 mod test {
     use std::serialize::Encodable;
+    use std::serialize::Encoder;
     use core::dvec::*;
     use util::testing::*;
     use core::io;
     use core::str;
+    use core::option::Option;
+    use core::option::Some;
+    use core::option::None;
     use std;
 
+    // just adding the ones I want to test, for now:
+    #[deriving_eq]
+    pub enum call {
+        CallToEmitEnum(~str),
+        CallToEmitEnumVariant(~str, uint, uint),
+        CallToEmitEnumVariantArg(uint),
+        CallToEmitUint(uint),
+        CallToEmitNil,
+        // all of the ones I was too lazy to handle:
+        CallToOther
+    }
+    // using a mutable field rather than changing the
+    // type of self in every method of every encoder everywhere.
+    pub struct TestEncoder {mut call_log : ~[call]}
+
+    pub impl TestEncoder {
+        // these self's should be &mut self's, as well....
+        fn add_to_log (&self, c : call) {
+            self.call_log.push(copy c);
+        }
+        fn add_unknown_to_log (&self) {
+            self.add_to_log (CallToOther)
+        }
+    }
+    
+    pub impl Encoder for TestEncoder {
+        fn emit_nil(&self) { self.add_to_log(CallToEmitNil) }
+        
+        fn emit_uint(&self, +v: uint) {self.add_to_log(CallToEmitUint(v)); }
+        fn emit_u64(&self, +_v: u64) { self.add_unknown_to_log(); }
+    fn emit_u32(&self, +_v: u32) { self.add_unknown_to_log(); }
+    fn emit_u16(&self, +_v: u16) { self.add_unknown_to_log(); }
+    fn emit_u8(&self, +_v: u8)   { self.add_unknown_to_log(); }
+
+    fn emit_int(&self, +_v: int) { self.add_unknown_to_log(); }
+    fn emit_i64(&self, +_v: i64) { self.add_unknown_to_log(); }
+    fn emit_i32(&self, +_v: i32) { self.add_unknown_to_log(); }
+    fn emit_i16(&self, +_v: i16) { self.add_unknown_to_log(); }
+    fn emit_i8(&self, +_v: i8)   { self.add_unknown_to_log(); }
+
+    fn emit_bool(&self, +_v: bool) { self.add_unknown_to_log(); }
+
+    fn emit_f64(&self, +_v: f64) { self.add_unknown_to_log(); }
+    fn emit_f32(&self, +_v: f32) { self.add_unknown_to_log(); }
+    fn emit_float(&self, +_v: float) { self.add_unknown_to_log(); }
+
+    fn emit_char(&self, +_v: char) { self.add_unknown_to_log(); }
+
+    fn emit_borrowed_str(&self, +_v: &str) { self.add_unknown_to_log(); }
+    fn emit_owned_str(&self, +_v: &str) { self.add_unknown_to_log(); }
+    fn emit_managed_str(&self, +_v: &str) { self.add_unknown_to_log(); }
+
+    fn emit_borrowed(&self, f: fn()) { self.add_unknown_to_log(); f() }
+    fn emit_owned(&self, f: fn()) { self.add_unknown_to_log(); f() }
+    fn emit_managed(&self, f: fn()) { self.add_unknown_to_log(); f() }
+
+    fn emit_enum(&self, name: &str, f: fn()) {
+        self.add_to_log(CallToEmitEnum(name.to_str())); f(); }
+
+    fn emit_enum_variant(&self, name: &str, +id: uint, +cnt: uint, f: fn()) {
+        self.add_to_log(CallToEmitEnumVariant (name.to_str(),id,cnt)); f();
+    }
+
+    fn emit_enum_variant_arg(&self, +idx: uint, f: fn()) {
+        self.add_to_log(CallToEmitEnumVariantArg (idx)); f();
+    }
+
+    fn emit_borrowed_vec(&self, +_len: uint, f: fn()) {
+        self.add_unknown_to_log(); f();
+    }
+
+    fn emit_owned_vec(&self, +_len: uint, f: fn()) {
+        self.add_unknown_to_log(); f();
+    }
+    fn emit_managed_vec(&self, +_len: uint, f: fn()) {
+        self.add_unknown_to_log(); f();
+    }
+    fn emit_vec_elt(&self, +_idx: uint, f: fn()) {
+        self.add_unknown_to_log(); f();
+    }
+
+    fn emit_rec(&self, f: fn()) {
+        self.add_unknown_to_log(); f();
+    }
+    fn emit_struct(&self, _name: &str, +_len: uint, f: fn()) {
+        self.add_unknown_to_log(); f();
+    }
+    fn emit_field(&self, _name: &str, +_idx: uint, f: fn()) {
+        self.add_unknown_to_log(); f();
+    }
+        
+    fn emit_tup(&self, +_len: uint, f: fn()) {
+        self.add_unknown_to_log(); f();
+    }
+    fn emit_tup_elt(&self, +_idx: uint, f: fn()) {
+        self.add_unknown_to_log(); f();
+    }
+}
+
+    
     #[auto_decode]
     #[auto_encode]
     struct Node {id: uint}
 
-    fn to_json_str (val: Encodable<std::json::Encoder>) -> ~str{
-        let bw = @io::BytesWriter {bytes: DVec(), pos: 0};
-        val.encode(~std::json::Encoder(bw as io::Writer));
-        str::from_bytes(bw.bytes.data)
+    
+    fn to_call_log (val: Encodable<TestEncoder>) -> ~[call] {
+        let mut te = TestEncoder {call_log: ~[]};
+        val.encode(&te);
+        te.call_log
     }
-
+/*
     #[test] fn encode_test () {
-        check_equal (to_json_str(Node{id:34}
+        check_equal (to_call_log(Node{id:34}
                                  as Encodable::<std::json::Encoder>),
-                     ~"{\"id\":34}");
+                     ~[CallToEnum (~"Node"),
+                       CallToEnumVariant]);
     }
-
+*/
     #[auto_encode]
-    enum written {
-        Book(int),
+    enum Written {
+        Book(uint,uint),
         Magazine(~str)
     }
 
-    #[test] fn json_enum_encode_test () {
-        check_equal (to_json_str(Book(9) as Encodable::<std::json::Encoder>),
-                     ~"[\"Book\",9]");
-        check_equal (to_json_str(Magazine(~"Paris Match")
-                                 as Encodable::<std::json::Encoder>),
-                     ~"[\"Magazine\",\"Paris Match\"]");
-    }
+    #[test] fn encode_enum_test () {
+        check_equal (to_call_log(Book(34,44)
+                                 as Encodable::<TestEncoder>),
+                     ~[CallToEmitEnum (~"Written"),
+                       CallToEmitEnumVariant (~"Book",0,2),
+                       CallToEmitEnumVariantArg (0),
+                       CallToEmitUint (34),
+                       CallToEmitEnumVariantArg (1),
+                       CallToEmitUint (44)]);
+        }
 }


### PR DESCRIPTION
r?

I added code to the JSON encoder to support the serialization of enums.  Before this, the JSON serializer only handled Option, and encoded None as 'null'. Following this change, all enums are encoded as arrays containing the enum name followed by the encoded fields. This appears consistent with the unstated invariant that the resulting output can be mapped back to the input _if_ there's a decoder around that knows the types that were in existence when the serialization occurred.

Also, added test cases.
