### PR TITLE
Fix subtle error in caching during kind computation that could cause lin...

### DIFF
--- a/src/libcargo/cargo.rc
+++ b/src/libcargo/cargo.rc
@@ -457,7 +457,7 @@ pub fn parse_source(name: ~str, j: &json::Json) -> @Source {
     }
 
     match *j {
-        json::Object(j) => {
+        json::Object(ref j) => {
             let mut url = match j.find(&~"url") {
                 Some(&json::String(u)) => copy u,
                 _ => die!(~"needed 'url' field in source")
@@ -563,7 +563,7 @@ pub fn load_one_source_package(src: @Source, p: &json::Object) {
 
     let mut tags = ~[];
     match p.find(&~"tags") {
-        Some(&json::List(js)) => {
+        Some(&json::List(ref js)) => {
           for js.each |j| {
                 match *j {
                     json::String(ref j) => tags.grow(1u, j),
@@ -635,11 +635,11 @@ pub fn load_source_packages(c: &Cargo, src: @Source) {
     if !os::path_exists(&pkgfile) { return; }
     let pkgstr = io::read_whole_file_str(&pkgfile);
     match json::from_str(pkgstr.get()) {
-        Ok(json::List(js)) => {
+        Ok(json::List(ref js)) => {
           for js.each |j| {
                 match *j {
-                    json::Object(p) => {
-                        load_one_source_package(src, p);
+                    json::Object(ref p) => {
+                        load_one_source_package(src, *p);
                     }
                     _ => {
                         warn(~"malformed source json: " + src.name +

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -220,6 +220,16 @@ pub pure fn connect(v: &[~str], sep: &str) -> ~str {
     s
 }
 
+/// Concatenate a vector of strings, placing a given separator between each
+pub pure fn connect_slices(v: &[&str], sep: &str) -> ~str {
+    let mut s = ~"", first = true;
+    for vec::each(v) |ss| {
+        if first { first = false; } else { unsafe { push_str(&mut s, sep); } }
+        unsafe { push_str(&mut s, *ss) };
+    }
+    s
+}
+
 /// Given a string, make a new string with repeated copies of it
 pub pure fn repeat(ss: &str, nn: uint) -> ~str {
     let mut acc = ~"";
@@ -2665,6 +2675,17 @@ mod tests {
         let v: ~[~str] = ~[];
         t(v, ~" ", ~"");
         t(~[~"hi"], ~" ", ~"hi");
+    }
+
+    #[test]
+    fn test_connect_slices() {
+        fn t(v: &[&str], sep: &str, s: &str) {
+            assert connect_slices(v, sep) == s.to_str();
+        }
+        t(["you", "know", "I'm", "no", "good"],
+          " ", "you know I'm no good");
+        t([], " ", "");
+        t(["hi"], " ", "hi");
     }
 
     #[test]

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -925,8 +925,8 @@ fn check_fn_deprecated_modes(tcx: ty::ctxt, fn_ty: ty::t, decl: ast::fn_decl,
 
                     ast::infer(_) => {
                         if tcx.legacy_modes {
-                            let kind = ty::type_kind(tcx, arg_ty.ty);
-                            if !ty::kind_is_safe_for_default_mode(kind) {
+                            let kind = ty::type_contents(tcx, arg_ty.ty);
+                            if !kind.is_safe_for_default_mode(tcx) {
                                 tcx.sess.span_lint(
                                     deprecated_mode, id, id,
                                     span,

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -374,7 +374,7 @@ impl VisitContext {
          * not implicitly copyable.
          */
 
-        let result = if ty::type_implicitly_moves(self.tcx, ty) {
+        let result = if ty::type_moves_by_default(self.tcx, ty) {
             MoveInWhole
         } else {
             Read
@@ -495,7 +495,7 @@ impl VisitContext {
                     // moves-by-default:
                     let consume_with = with_fields.any(|tf| {
                         !fields.any(|f| f.node.ident == tf.ident) &&
-                            ty::type_implicitly_moves(self.tcx, tf.mt.ty)
+                            ty::type_moves_by_default(self.tcx, tf.mt.ty)
                     });
 
                     if consume_with {
@@ -830,7 +830,7 @@ impl VisitContext {
                 let fvar_ty = ty::node_id_to_type(self.tcx, fvar_def_id);
                 debug!("fvar_def_id=%? fvar_ty=%s",
                        fvar_def_id, ppaux::ty_to_str(self.tcx, fvar_ty));
-                let mode = if ty::type_implicitly_moves(self.tcx, fvar_ty) {
+                let mode = if ty::type_moves_by_default(self.tcx, fvar_ty) {
                     CapMove
                 } else {
                     CapCopy

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -24,13 +24,13 @@ use metadata::cstore::{CStore, iter_crate_data};
 use metadata::decoder::{dl_def, dl_field, dl_impl};
 use middle::resolve::{Impl, MethodInfo};
 use middle::ty::{ProvidedMethodSource, ProvidedMethodInfo, bound_copy, get};
-use middle::ty::{kind_can_be_copied, lookup_item_type, param_bounds, subst};
+use middle::ty::{lookup_item_type, param_bounds, subst};
 use middle::ty::{substs, t, ty_bool, ty_bot, ty_box, ty_enum, ty_err};
 use middle::ty::{ty_estr, ty_evec, ty_float, ty_infer, ty_int, ty_nil};
 use middle::ty::{ty_opaque_box, ty_param, ty_param_bounds_and_ty, ty_ptr};
 use middle::ty::{ty_rec, ty_rptr, ty_self, ty_struct, ty_trait, ty_tup};
 use middle::ty::{ty_type, ty_uint, ty_uniq, ty_bare_fn, ty_closure};
-use middle::ty::{ty_opaque_closure_ptr, ty_unboxed_vec, type_kind_ext};
+use middle::ty::{ty_opaque_closure_ptr, ty_unboxed_vec};
 use middle::ty::{type_is_ty_var};
 use middle::ty;
 use middle::typeck::CrateCtxt;
@@ -578,11 +578,10 @@ pub impl CoherenceChecker {
                                 for bounds.each |bound| {
                                     match *bound {
                                         bound_copy => {
-                                            let kind = type_kind_ext(
+                                            if !ty::type_is_copyable(
                                                 self.inference_context.tcx,
-                                                resolved_ty,
-                                                true);
-                                            if !kind_can_be_copied(kind) {
+                                                resolved_ty)
+                                            {
                                                 might_unify = false;
                                                 break;
                                             }

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -832,7 +832,7 @@ pub impl Decoder: serialize::Decoder {
     fn read_owned_vec<T>(&self, f: fn(uint) -> T) -> T {
         debug!("read_owned_vec()");
         let len = match *self.peek() {
-            List(list) => list.len(),
+            List(ref list) => list.len(),
             _ => die!(~"not a list"),
         };
         let res = f(len);

--- a/src/test/compile-fail/bad-method-typaram-kind.rs
+++ b/src/test/compile-fail/bad-method-typaram-kind.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn foo<T>() {
-    1u.bar::<T>(); //~ ERROR: missing `copy`
+    1u.bar::<T>(); //~ ERROR: does not fulfill `Copy`
 }
 
 trait bar {

--- a/src/test/compile-fail/copy-a-resource.rs
+++ b/src/test/compile-fail/copy-a-resource.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: copying a noncopyable value
-
 struct foo {
   i: int,
 }
@@ -24,4 +22,9 @@ fn foo(i:int) -> foo {
     }
 }
 
-fn main() { let x = move foo(10); let y = copy x; log(error, x); }
+fn main() {
+    let x = move foo(10);
+    let _y = copy x;
+    //~^ ERROR copying a value of non-copyable type `foo`
+    log(error, x);
+}

--- a/src/test/compile-fail/issue-2548.rs
+++ b/src/test/compile-fail/issue-2548.rs
@@ -34,7 +34,7 @@ fn main() {
         let mut res = foo(x);
 
         let mut v = ~[mut];
-        v = move ~[mut (move res)] + v; //~ ERROR instantiating a type parameter with an incompatible type (needs `copy`, got `&static`, missing `copy`)
+        v = move ~[mut (move res)] + v; //~ ERROR does not fulfill `Copy`
         assert (v.len() == 2);
     }
 

--- a/src/test/compile-fail/issue-2823.rs
+++ b/src/test/compile-fail/issue-2823.rs
@@ -20,6 +20,6 @@ impl C : Drop {
 
 fn main() {
     let c = C{ x: 2};
-    let d = copy c; //~ ERROR copying a noncopyable value
+    let d = copy c; //~ ERROR copying a value of non-copyable type `C`
     error!("%?", d.x);
 }

--- a/src/test/compile-fail/kindck-nonsendable-1.rs
+++ b/src/test/compile-fail/kindck-nonsendable-1.rs
@@ -12,7 +12,7 @@ fn foo(_x: @uint) {}
 
 fn main() {
     let x = @3u;
-    let _ = fn~() { foo(x); }; //~ ERROR not a sendable value
-    let _ = fn~(copy x) { foo(x); }; //~ ERROR not a sendable value
-    let _ = fn~(move x) { foo(x); }; //~ ERROR not a sendable value
+    let _ = fn~() { foo(x); }; //~ ERROR value has non-owned type `@uint`
+    let _ = fn~(copy x) { foo(x); }; //~ ERROR value has non-owned type `@uint`
+    let _ = fn~(move x) { foo(x); }; //~ ERROR value has non-owned type `@uint`
 }

--- a/src/test/compile-fail/kindck-owned.rs
+++ b/src/test/compile-fail/kindck-owned.rs
@@ -18,12 +18,12 @@ fn copy2<T: Copy &static>(t: T) -> fn@() -> T {
 
 fn main() {
     let x = &3;
-    copy2(&x); //~ ERROR missing `&static`
+    copy2(&x); //~ ERROR does not fulfill `&static`
 
     copy2(@3);
-    copy2(@&x); //~ ERROR missing `&static`
+    copy2(@&x); //~ ERROR does not fulfill `&static`
 
     copy2(fn@() {});
-    copy2(fn~() {}); //~ ERROR missing `copy`
-    copy2(fn&() {}); //~ ERROR missing `&static`
+    copy2(fn~() {}); //~ ERROR does not fulfill `Copy`
+    copy2(fn&() {}); //~ ERROR does not fulfill `&static`
 }

--- a/src/test/compile-fail/liveness-unused.rs
+++ b/src/test/compile-fail/liveness-unused.rs
@@ -68,5 +68,5 @@ impl r : Drop {
 
 fn main() {
     let x = r { x: () };
-    fn@(move x) { copy x; }; //~ ERROR copying a noncopyable value
+    fn@(move x) { copy x; }; //~ ERROR copying a value of non-copyable type
 }

--- a/src/test/compile-fail/moves-based-on-type-cyclic-types-issue-4821.rs
+++ b/src/test/compile-fail/moves-based-on-type-cyclic-types-issue-4821.rs
@@ -1,0 +1,34 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test for a subtle failure computing kinds of cyclic types, in which
+// temporary kinds wound up being stored in a cache and used later.
+// See middle::ty::type_contents() for more information.
+
+extern mod std;
+use core::cmp::Ord;
+use core::option::swap_unwrap;
+
+struct List { key: int, next: Option<~List> }
+
+fn foo(node: ~List) -> int {
+    let r = match node.next {
+        Some(right) => consume(right),
+        None => 0
+    };
+    consume(node) + r //~ ERROR use of partially moved value: `node`
+}
+
+fn consume(v: ~List) -> int {
+    v.key
+}
+
+fn main() {}
+

--- a/src/test/compile-fail/no-send-res-ports.rs
+++ b/src/test/compile-fail/no-send-res-ports.rs
@@ -29,7 +29,7 @@ fn main() {
 
     do task::spawn {
         let mut y = None;
-        *x <-> y; //~ ERROR not a sendable value
+        *x <-> y; //~ ERROR value has non-owned type
         log(error, y);
     }
 }

--- a/src/test/compile-fail/non-const.rs
+++ b/src/test/compile-fail/non-const.rs
@@ -42,14 +42,14 @@ fn r2(x:@mut int) -> r2 {
 
 fn main() {
     foo({f: 3});
-    foo({mut f: 3}); //~ ERROR missing `const`
+    foo({mut f: 3}); //~ ERROR does not fulfill `Const`
     foo(~[1]);
-    foo(~[mut 1]); //~ ERROR missing `const`
+    foo(~[mut 1]); //~ ERROR does not fulfill `Const`
     foo(~1);
-    foo(~mut 1); //~ ERROR missing `const`
+    foo(~mut 1); //~ ERROR does not fulfill `Const`
     foo(@1);
-    foo(@mut 1); //~ ERROR missing `const`
+    foo(@mut 1); //~ ERROR does not fulfill `Const`
     foo(r(1)); // this is okay now.
-    foo(r2(@mut 1)); //~ ERROR missing `const`
-    foo({f: {mut f: 1}}); //~ ERROR missing `const`
+    foo(r2(@mut 1)); //~ ERROR does not fulfill `Const`
+    foo({f: {mut f: 1}}); //~ ERROR does not fulfill `Const`
 }

--- a/src/test/compile-fail/non-copyable-void.rs
+++ b/src/test/compile-fail/non-copyable-void.rs
@@ -13,6 +13,6 @@ fn main() {
     let y : *libc::c_void = x as *libc::c_void;
     unsafe {
         let _z = copy *y;
-        //~^ ERROR copying a noncopyable value
+        //~^ ERROR copying a value of non-copyable type
     }
 }

--- a/src/test/compile-fail/noncopyable-class.rs
+++ b/src/test/compile-fail/noncopyable-class.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: copying a noncopyable value
-
 // Test that a class with a non-copyable field can't be
 // copied
 struct bar {
@@ -38,4 +36,8 @@ fn foo(i:int) -> foo {
     }
 }
 
-fn main() { let x = move foo(10); let y = copy x; log(error, x); }
+fn main() {
+    let x = move foo(10);
+    let _y = copy x; //~ ERROR copying a value of non-copyable type
+    log(error, x);
+}

--- a/src/test/compile-fail/noncopyable-match-pattern.rs
+++ b/src/test/compile-fail/noncopyable-match-pattern.rs
@@ -11,7 +11,7 @@
 fn main() {
     let x = Some(private::exclusive(false));
     match x {
-        Some(copy z) => { //~ ERROR copying a noncopyable value
+        Some(copy z) => { //~ ERROR copying a value of non-copyable type
             do z.with |b| { assert !*b; }
         }
         None => die!()

--- a/src/test/compile-fail/pinned-deep-copy.rs
+++ b/src/test/compile-fail/pinned-deep-copy.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: copying a noncopyable value
-
 struct r {
   i: @mut int,
 }
@@ -31,7 +29,7 @@ fn main() {
     {
         // Can't do this copy
         let x = ~~~{y: r(i)};
-        let z = copy x;
+        let _z = copy x; //~ ERROR copying a value of non-copyable type
         log(debug, x);
     }
     log(error, *i);

--- a/src/test/compile-fail/record-with-resource.rs
+++ b/src/test/compile-fail/record-with-resource.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: copying a noncopyable value
-
 struct my_resource {
   x: int,
 }
@@ -29,7 +27,7 @@ fn my_resource(x: int) -> my_resource {
 fn main() {
     {
         let a = {x: 0, y: my_resource(20)};
-        let b = {x: 2,.. copy a};
+        let b = {x: 2,.. copy a}; //~ ERROR copying a value of non-copyable type
         log(error, (a, b));
     }
 }

--- a/src/test/compile-fail/repeat-to-run-dtor-twice.rs
+++ b/src/test/compile-fail/repeat-to-run-dtor-twice.rs
@@ -24,6 +24,6 @@ impl Foo : Drop {
 
 fn main() {
     let a = Foo { x: 3 };
-    let _ = [ a, ..5 ];     //~ ERROR copying a noncopyable value
+    let _ = [ a, ..5 ];     //~ ERROR copying a value of non-copyable type
 }
 

--- a/src/test/compile-fail/unique-object-noncopyable.rs
+++ b/src/test/compile-fail/unique-object-noncopyable.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 trait Foo {
-    fn f();
+    fn f(&self);
 }
 
 struct Bar {
@@ -21,14 +21,14 @@ impl Bar : Drop {
 }
 
 impl Bar : Foo {
-    fn f() {
+    fn f(&self) {
         io::println("hi");
     }
 }
 
 fn main() {
     let x = ~Bar { x: 10 };
-    let y = (move x) as ~Foo;   //~ ERROR uniquely-owned trait objects must be copyable
-    let _z = copy y;
+    let y: ~Foo = x as ~Foo;
+    let _z = copy y; //~ ERROR copying a value of non-copyable type
 }
 

--- a/src/test/compile-fail/unique-pinned-nocopy.rs
+++ b/src/test/compile-fail/unique-pinned-nocopy.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: copying a noncopyable value
-
 struct r {
   b:bool,
 }
@@ -20,6 +18,6 @@ impl r : Drop {
 
 fn main() {
     let i = move ~r { b: true };
-    let j = copy i;
+    let _j = copy i; //~ ERROR copying a value of non-copyable type
     log(debug, i);
 }

--- a/src/test/compile-fail/unique-unique-kind.rs
+++ b/src/test/compile-fail/unique-unique-kind.rs
@@ -13,5 +13,5 @@ fn f<T: Owned>(_i: T) {
 
 fn main() {
     let i = ~@100;
-    f(move i); //~ ERROR missing `owned`
+    f(move i); //~ ERROR does not fulfill `Owned`
 }

--- a/src/test/compile-fail/unique-vec-res.rs
+++ b/src/test/compile-fail/unique-vec-res.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: copying a noncopyable value
-
 struct r {
   i: @mut int,
 }
@@ -20,7 +18,7 @@ impl r : Drop {
     }
 }
 
-fn f<T>(+i: ~[T], +j: ~[T]) {
+fn f<T>(+_i: ~[T], +_j: ~[T]) {
 }
 
 fn main() {
@@ -29,6 +27,8 @@ fn main() {
     let r1 = move ~[~r { i: i1 }];
     let r2 = move ~[~r { i: i2 }];
     f(copy r1, copy r2);
+    //~^ ERROR copying a value of non-copyable type
+    //~^^ ERROR copying a value of non-copyable type
     log(debug, (r2, *i1));
     log(debug, (r1, *i2));
 }

--- a/src/test/compile-fail/unsendable-class.rs
+++ b/src/test/compile-fail/unsendable-class.rs
@@ -25,6 +25,6 @@ fn foo(i:int, j: @~str) -> foo {
 
 fn main() {
   let cat = ~"kitty";
-    let (_, ch) = pipes::stream(); //~ ERROR missing `owned`
-  ch.send(foo(42, @(move cat))); //~ ERROR missing `owned`
+    let (_, ch) = pipes::stream(); //~ ERROR does not fulfill `Owned`
+  ch.send(foo(42, @(move cat))); //~ ERROR does not fulfill `Owned`
 }

--- a/src/test/run-pass/explicit-self-objects-uniq.rs
+++ b/src/test/run-pass/explicit-self-objects-uniq.rs
@@ -26,8 +26,6 @@ pub fn main() {
     let x = ~S { x: 3 };
     let y = x as ~Foo;
     y.f();
-    y.f();
-    y.f();
 }
 
 

--- a/src/test/run-pass/unique-object.rs
+++ b/src/test/run-pass/unique-object.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 trait Foo {
-    fn f();
+    fn f(&self) -> int;
 }
 
 struct Bar {
@@ -17,16 +17,14 @@ struct Bar {
 }
 
 impl Bar : Foo {
-    fn f() {
-        io::println("hi");
+    fn f(&self) -> int {
+        self.x
     }
 }
 
 pub fn main() {
     let x = ~Bar { x: 10 };
     let y = x as ~Foo;
-    let z = copy y;
-    y.f();
-    z.f();
+    assert y.f() == 10;
 }
 


### PR DESCRIPTION
...ear

values to be copied.  Rewrite kind computation so that instead of directly
computing the kind it computes what kinds of values are present in the type,
and then derive kinds based on that. I find this easier to think about.

Fixes #4821.

r? @catamorphism
