### PR TITLE
rt: remove unused 'rust_compare_and_swap_ptr'

### DIFF
--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -776,12 +776,6 @@ rust_osmain_sched_id() {
     return task->kernel->osmain_sched_id();
 }
 
-extern "C" CDECL bool
-rust_compare_and_swap_ptr(intptr_t *address,
-                          intptr_t oldval, intptr_t newval) {
-    return sync::compare_and_swap(address, oldval, newval);
-}
-
 extern "C" void
 rust_task_inhibit_kill(rust_task *task) {
     task->inhibit_kill();

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -154,7 +154,6 @@ rust_dbg_call
 rust_dbg_do_nothing
 rust_dbg_breakpoint
 rust_osmain_sched_id
-rust_compare_and_swap_ptr
 rust_task_inhibit_kill
 rust_task_allow_kill
 rust_task_inhibit_yield


### PR DESCRIPTION
Simple removal of rust_compare_and_swap_ptr from rt, as per Issue #4836
