### PR TITLE
Move rustrt::last_os_error into core

### DIFF
--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -607,7 +607,7 @@ impl *libc::FILE: Writer {
                                         *self);
                 if nout != len as size_t {
                     error!("error writing buffer");
-                    log(error, os::last_os_error());
+                    log(error, os::last_error());
                     die!();
                 }
             }
@@ -657,7 +657,7 @@ impl fd_t: Writer {
                     let nout = libc::write(*self, vb, len as size_t);
                     if nout < 0 as ssize_t {
                         error!("error writing buffer");
-                        log(error, os::last_os_error());
+                        log(error, os::last_error());
                         die!();
                     }
                     count += nout as uint;
@@ -731,7 +731,7 @@ pub fn mk_file_writer(path: &Path, flags: &[FileFlag])
     };
     if fd < (0 as c_int) {
         result::Err(fmt!("error opening %s: %s", path.to_str(),
-                         os::last_os_error()))
+                         os::last_error()))
     } else {
         result::Ok(fd_writer(fd, true))
     }

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -62,8 +62,11 @@ extern mod rustrt {
     unsafe fn rust_path_exists(path: *libc::c_char) -> c_int;
     unsafe fn rust_list_files2(&&path: ~str) -> ~[~str];
     unsafe fn rust_process_wait(handle: c_int) -> c_int;
-    unsafe fn last_os_error() -> ~str;
     unsafe fn rust_set_exit_status(code: libc::intptr_t);
+}
+
+extern mod rustllvm {
+    unsafe fn LLVMGetLastError() -> *libc::c_char;
 }
 
 pub const tmpbuf_sz : uint = 1000u;
@@ -767,9 +770,12 @@ pub fn remove_file(p: &Path) -> bool {
 }
 
 /// Get a string representing the platform-dependent last error
-pub fn last_os_error() -> ~str {
+pub fn last_error() -> ~str {
     unsafe {
-        rustrt::last_os_error()
+        let e = rustllvm::LLVMGetLastError();
+        let err_str = str::raw::from_c_str(e);
+        libc::free(e as *libc::c_void);
+        err_str
     }
 }
 
@@ -1000,8 +1006,8 @@ mod tests {
     use vec;
 
     #[test]
-    pub fn last_os_error() {
-        log(debug, os::last_os_error());
+    pub fn last_error() {
+        log(debug, os::last_error());
     }
 
     #[test]

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -14,7 +14,6 @@ rust_gmtime
 rust_localtime
 rust_timegm
 rust_mktime
-last_os_error
 new_task
 precise_time_ns
 rand_free

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -30,6 +30,7 @@
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetMachine.h"
+#include "llvm/Support/Errno.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/SourceMgr.h"
@@ -70,6 +71,13 @@ LLVMRustCreateMemoryBufferWithContentsOfFile(const char *Path) {
 
 extern "C" const char *LLVMRustGetLastError(void) {
   return LLVMRustError;
+}
+
+extern "C" const char *LLVMGetLastError(void) {
+    std::string e = StrError();
+    char *err = (char *) malloc(e.length() + 1);
+    std::strcpy(err, e.c_str());
+    return err;
 }
 
 extern "C" void LLVMAddBasicAliasAnalysisPass(LLVMPassManagerRef PM);

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -577,3 +577,4 @@ LLVMX86MMXTypeInContext
 LLVMConstNamedStruct
 LLVMStructCreateNamed
 LLVMStructSetBody
+LLVMGetLastError

--- a/src/test/auxiliary/anon-extern-mod-cross-crate-1.rs
+++ b/src/test/auxiliary/anon-extern-mod-cross-crate-1.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 #[abi = "cdecl"];
-#[link_name = "rustrt"];
+#[link_name = "rustllvm"];
 #[link(name = "anonexternmod",
        vers = "0.1")];
 
 #[crate_type = "lib"];
 extern {
-  fn last_os_error() -> ~str;
+  unsafe fn LLVMGetLastError() -> *core::libc::c_char;
 }

--- a/src/test/auxiliary/foreign_lib.rs
+++ b/src/test/auxiliary/foreign_lib.rs
@@ -10,6 +10,6 @@
 
 #[link(name="foreign_lib", vers="0.0")];
 
-pub extern mod rustrt {
-    pub fn last_os_error() -> ~str;
+pub extern mod rustllvm {
+    pub unsafe fn LLVMGetLastError() -> *core::libc::c_char;
 }

--- a/src/test/run-fail/morestack2.rs
+++ b/src/test/run-fail/morestack2.rs
@@ -17,16 +17,13 @@
 
 extern mod std;
 
-extern mod rustrt {
-    pub fn last_os_error() -> ~str;
-}
 
 fn getbig_call_c_and_fail(i: int) {
     if i != 0 {
         getbig_call_c_and_fail(i - 1);
     } else {
         unsafe {
-            rustrt::last_os_error();
+            core::os::last_error();
             die!();
         }
     }

--- a/src/test/run-pass/anon-extern-mod-cross-crate-2.rs
+++ b/src/test/run-pass/anon-extern-mod-cross-crate-2.rs
@@ -15,5 +15,7 @@ extern mod anonexternmod;
 use anonexternmod::*;
 
 pub fn main() {
-  LLVMGetLastError();
+    unsafe {
+      LLVMGetLastError();
+    }
 }

--- a/src/test/run-pass/anon-extern-mod-cross-crate-2.rs
+++ b/src/test/run-pass/anon-extern-mod-cross-crate-2.rs
@@ -15,5 +15,5 @@ extern mod anonexternmod;
 use anonexternmod::*;
 
 pub fn main() {
-  last_os_error();
+  LLVMGetLastError();
 }

--- a/src/test/run-pass/anon-extern-mod.rs
+++ b/src/test/run-pass/anon-extern-mod.rs
@@ -9,13 +9,13 @@
 // except according to those terms.
 
 #[abi = "cdecl"]
-#[link_name = "rustrt"]
+#[link_name = "rustllvm"]
 extern {
-    fn last_os_error() -> ~str;
+    unsafe fn LLVMGetLastError() -> *libc::c_char;
 }
 
 pub fn main() {
     unsafe {
-        let _ = last_os_error();
+        let _ = LLVMGetLastError();
     }
 }

--- a/src/test/run-pass/foreign-dupe.rs
+++ b/src/test/run-pass/foreign-dupe.rs
@@ -12,20 +12,20 @@
 // calling pin_task and that's having wierd side-effects.
 
 #[abi = "cdecl"]
-#[link_name = "rustrt"]
-extern mod rustrt1 {
-    pub fn last_os_error() -> ~str;
+#[link_name = "rustllvm"]
+extern mod rustllvm1 {
+    pub unsafe fn LLVMGetLastError() -> *libc::c_char;
 }
 
 #[abi = "cdecl"]
-#[link_name = "rustrt"]
-extern mod rustrt2 {
-    pub fn last_os_error() -> ~str;
+#[link_name = "rustllvm"]
+extern mod rustllvm2 {
+    pub unsafe fn LLVMGetLastError() -> *libc::c_char;
 }
 
 pub fn main() {
     unsafe {
-        rustrt1::last_os_error();
-        rustrt2::last_os_error();
+        rustllvm1::LLVMGetLastError();
+        rustllvm2::LLVMGetLastError();
     }
 }

--- a/src/test/run-pass/invoke-external-foreign.rs
+++ b/src/test/run-pass/invoke-external-foreign.rs
@@ -18,5 +18,7 @@
 extern mod foreign_lib;
 
 pub fn main() {
-    let foo = foreign_lib::rustrt::last_os_error();
+    unsafe {
+        let _foo = foreign_lib::rustllvm::LLVMGetLastError();
+    }
 }

--- a/src/test/run-pass/morestack6.rs
+++ b/src/test/run-pass/morestack6.rs
@@ -15,7 +15,6 @@ extern mod rustrt {
     pub fn debug_get_stk_seg() -> *u8;
 
     pub fn rust_get_sched_id() -> libc::intptr_t;
-    pub fn last_os_error() -> ~str;
     pub fn rust_getcwd() -> ~str;
     pub fn get_task_id() -> libc::intptr_t;
     pub fn rust_sched_threads();
@@ -23,7 +22,6 @@ extern mod rustrt {
 }
 
 fn calllink01() { unsafe { rustrt::rust_get_sched_id(); } }
-fn calllink02() { unsafe { rustrt::last_os_error(); } }
 fn calllink03() { unsafe { rustrt::rust_getcwd(); } }
 fn calllink08() { unsafe { rustrt::get_task_id(); } }
 fn calllink09() { unsafe { rustrt::rust_sched_threads(); } }

--- a/src/test/run-pass/morestack6.rs
+++ b/src/test/run-pass/morestack6.rs
@@ -54,7 +54,6 @@ fn runtest2(f: extern fn(), frame_backoff: u32, last_stk: *u8) -> u32 {
 pub fn main() {
     let fns = ~[
         calllink01,
-        calllink02,
         calllink03,
         calllink08,
         calllink09,


### PR DESCRIPTION
No need for it to be in written anew in rustrt since LLVM already provides a platform independent way of getting the error string. This pull request just makes it available in core::os.

So that's one less helper function in rustrt. (#4812)
