### PR TITLE
Add debug info tests

### DIFF
--- a/configure
+++ b/configure
@@ -619,6 +619,7 @@ do
     make_dir $h/test/bench
     make_dir $h/test/perf
     make_dir $h/test/pretty
+    make_dir $h/test/debug-info
     make_dir $h/test/doc-tutorial
     make_dir $h/test/doc-tutorial-ffi
     make_dir $h/test/doc-tutorial-macros

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -103,7 +103,8 @@ cleantestlibs:
          -name '*.dSYM' -o    \
          -name '*.libaux' -o      \
          -name '*.out' -o     \
-         -name '*.err'        \
+         -name '*.err' -o     \
+	 -name '*.debugger.script' \
          | xargs rm -rf
 
 
@@ -284,6 +285,7 @@ CFAIL_RC := $(wildcard $(S)src/test/compile-fail/*.rc)
 CFAIL_RS := $(wildcard $(S)src/test/compile-fail/*.rs)
 BENCH_RS := $(wildcard $(S)src/test/bench/*.rs)
 PRETTY_RS := $(wildcard $(S)src/test/pretty/*.rs)
+DEBUGINFO_RS := $(wildcard $(S)src/test/pretty/*.rs)
 
 # perf tests are the same as bench tests only they run under
 # a performance monitor.
@@ -296,6 +298,7 @@ CFAIL_TESTS := $(CFAIL_RC) $(CFAIL_RS)
 BENCH_TESTS := $(BENCH_RS)
 PERF_TESTS := $(PERF_RS)
 PRETTY_TESTS := $(PRETTY_RS)
+DEBUGINFO_TESTS := $(DEBUGINFO_RS)
 
 CTEST_SRC_BASE_rpass = run-pass
 CTEST_BUILD_BASE_rpass = run-pass
@@ -326,6 +329,11 @@ CTEST_SRC_BASE_perf = bench
 CTEST_BUILD_BASE_perf = perf
 CTEST_MODE_perf = run-pass
 CTEST_RUNTOOL_perf = $(CTEST_PERF_RUNTOOL)
+
+CTEST_SRC_BASE_debuginfo = debug-info
+CTEST_BUILD_BASE_debuginfo = debug-info
+CTEST_MODE_debuginfo = debug-info
+CTEST_RUNTOOL_debuginfo = $(CTEST_RUNTOOL)
 
 define DEF_CTEST_VARS
 
@@ -358,6 +366,7 @@ CTEST_DEPS_rfail_$(1)-T-$(2)-H-$(3) = $$(RFAIL_TESTS)
 CTEST_DEPS_cfail_$(1)-T-$(2)-H-$(3) = $$(CFAIL_TESTS)
 CTEST_DEPS_bench_$(1)-T-$(2)-H-$(3) = $$(BENCH_TESTS)
 CTEST_DEPS_perf_$(1)-T-$(2)-H-$(3) = $$(PERF_TESTS)
+CTEST_DEPS_debuginfo_$(1)-T-$(2)-H-$(3) = $$(DEBUGINFO_TESTS)
 
 endef
 
@@ -388,7 +397,7 @@ $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
 
 endef
 
-CTEST_NAMES = rpass rpass-full rfail cfail bench perf
+CTEST_NAMES = rpass rpass-full rfail cfail bench perf debuginfo
 
 $(foreach host,$(CFG_TARGET_TRIPLES), \
  $(eval $(foreach target,$(CFG_TARGET_TRIPLES), \
@@ -496,6 +505,7 @@ TEST_GROUPS = \
 	cfail \
 	bench \
 	perf \
+	debuginfo \
 	doc \
 	$(foreach docname,$(DOC_TEST_NAMES),$(docname)) \
 	pretty \

--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -1,5 +1,5 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
+// Copyright 2012-2013 The Rust Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -18,6 +18,7 @@ pub enum mode {
     mode_run_fail,
     mode_run_pass,
     mode_pretty,
+    mode_debug_info,
 }
 
 pub type config = {

--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -41,6 +41,7 @@ use common::mode_run_pass;
 use common::mode_run_fail;
 use common::mode_compile_fail;
 use common::mode_pretty;
+use common::mode_debug_info;
 use common::mode;
 use util::logv;
 
@@ -131,6 +132,7 @@ pub fn str_mode(s: ~str) -> mode {
       ~"run-fail" => mode_run_fail,
       ~"run-pass" => mode_run_pass,
       ~"pretty" => mode_pretty,
+      ~"debug-info" => mode_debug_info,
       _ => die!(~"invalid mode")
     }
 }
@@ -140,7 +142,8 @@ pub fn mode_str(mode: mode) -> ~str {
       mode_compile_fail => ~"compile-fail",
       mode_run_fail => ~"run-fail",
       mode_run_pass => ~"run-pass",
-      mode_pretty => ~"pretty"
+      mode_pretty => ~"pretty",
+      mode_debug_info => ~"debug-info",
     }
 }
 

--- a/src/test/debug-info/simple.rs
+++ b/src/test/debug-info/simple.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-test
+// compile-flags:-g
+// debugger:break 20
+// debugger:run
+// debugger:print x
+// check:$1 = 42
+
+fn main() {
+    let x = 42;
+    debug!("The answer is %d", x);
+}

--- a/src/test/debug-info/struct.rs
+++ b/src/test/debug-info/struct.rs
@@ -1,0 +1,33 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-test
+// compile-flags:-g
+// debugger:break 32
+// debugger:run
+// debugger:print pair
+// check:$1 = {
+// check:x = 1,
+// check:y = 2,
+// check:}
+// debugger:print pair.x
+// check:$2 = 1
+// debugger:print pair.y
+// check:$3 = 2
+
+struct Pair {
+    x: int,
+    y: int
+}
+
+fn main() {
+    let pair = Pair { x: 1, y: 2 };
+    debug!("x = %d, y = %d", pair.x, pair.y);
+}


### PR DESCRIPTION
Fixes #2195.

The testing procedure mimics the way clang/llvm does their debuginfo tests - it creates a debugging commands script from directives in the header file which gdb runs in batch mode with the executable, and then checks if output is as expected. I have two very simple tests included, and they're both ignored because rust doesn't seem to emit good enough symbols for them to pass (by the way, I'll see if I can help fix that).

Note that once debug info tests are enabled, gdb will become a dependency for 'make check'.

(This replaces a pull request based on an earlier commit.)
