### PR TITLE
Omit discriminant from nullary univariant enums.

### DIFF
--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -242,13 +242,10 @@ pub fn fill_type_of_enum(cx: @crate_ctxt, did: ast::def_id, t: ty::t,
     debug!("type_of_enum %?: %?", t, ty::get(t));
 
     let lltys = {
-        let degen = ty::enum_is_univariant(cx.tcx, did);
+        let univar = ty::enum_is_univariant(cx.tcx, did);
         let size = machine::static_size_of_enum(cx, t);
-        if !degen {
+        if !univar {
             ~[T_enum_discrim(cx), T_array(T_i8(), size)]
-        }
-        else if size == 0u {
-            ~[T_enum_discrim(cx)]
         }
         else {
             ~[T_array(T_i8(), size)]


### PR DESCRIPTION
If an enum is isomorphic to unit, there's no need to use any bits to
represent it.  The only obvious reason this wasn't the case was because
the enum could be C-like and have a user-specified discriminant -- but
that value is constant, so it doesn't need to be stored.

This change means that all newtype-like enums have the same size (and
layout) as their underlying type, which might be a useful property to
have, at least in terms of making programs' low-level behavior less
surprising.
