### PR TITLE
rust-mode.el uses the 'cl macros, so it should actually require them

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -7,6 +7,7 @@
 
 (require 'cm-mode)
 (require 'cc-mode)
+(eval-when-compile (require 'cl))
 
 (defun rust-electric-brace (arg)
   (interactive "*P")


### PR DESCRIPTION
Without this change, rust-mode doesn't work if 'cl hasn't been required
by something else, apparently.  I'm not entirely sure what changed such
that I started seeing this problem instead of not, but maybe the emacs
world has been making progress towards not loading 'cl at runtime if
it's only needed at compile time.
