### PR TITLE
Issue #4709 RFC: reseed task_rng

### DIFF
--- a/src/rt/rust_sched_loop.h
+++ b/src/rt/rust_sched_loop.h
@@ -73,6 +73,8 @@ private:
     bool killed;
 
     rust_signal *pump_signal;
+    randctx rctx;
+    uint32_t idle_randcnt;
 
     void prepare_c_stack(rust_task *task);
     void unprepare_c_stack();
@@ -102,7 +104,6 @@ public:
     size_t min_stack_size;
     memory_region local_region;
 
-    randctx rctx;
     const char *const name; // Used for debugging
 
     // Only a pointer to 'name' is kept, so it must live as long as this
@@ -119,6 +120,7 @@ public:
 
     void on_pump_loop(rust_signal *signal);
     rust_sched_loop_state run_single_turn();
+    void idle();
 
     void log_state();
 

--- a/src/rt/rust_util.cpp
+++ b/src/rt/rust_util.cpp
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#include "rust_util.h"
 #include "rust_type.h"
-
 
 // A hardcoded type descriptor for strings, since the runtime needs to
 // be able to create them.
@@ -24,6 +24,77 @@ struct type_desc str_body_tydesc = {
     NULL, // shape
     NULL, // shape_tables
 };
+
+// Initialization helpers for ISAAC RNG
+
+void isaac_seed(rust_kernel* kernel, uint8_t* dest, size_t size)
+{
+#ifdef __WIN32__
+    HCRYPTPROV hProv;
+    kernel->win32_require
+        (_T("CryptAcquireContext"),
+         CryptAcquireContext(&hProv, NULL, NULL, PROV_RSA_FULL,
+                             CRYPT_VERIFYCONTEXT|CRYPT_SILENT));
+    kernel->win32_require
+        (_T("CryptGenRandom"), CryptGenRandom(hProv, size, (BYTE*) dest));
+    kernel->win32_require
+        (_T("CryptReleaseContext"), CryptReleaseContext(hProv, 0));
+#else
+    int fd = open("/dev/urandom", O_RDONLY);
+    if (fd == -1)
+        kernel->fatal("error opening /dev/urandom: %s", strerror(errno));
+    size_t amount = 0;
+    do {
+        ssize_t ret = read(fd, dest+amount, size-amount);
+        if (ret < 0)
+            kernel->fatal("error reading /dev/urandom: %s", strerror(errno));
+        else if (ret == 0)
+            kernel->fatal("somehow hit eof reading from /dev/urandom");
+        amount += (size_t)ret;
+    } while (amount < size);
+    int ret = close(fd);
+    // FIXME #3697: Why does this fail sometimes?
+    if (ret != 0)
+        kernel->log(log_warn, "error closing /dev/urandom: %s",
+            strerror(errno));
+#endif
+}
+
+void isaac_init(rust_kernel *kernel, randctx *rctx, rust_vec_box* user_seed)
+{
+    memset(rctx, 0, sizeof(randctx));
+
+    const char *env_seed = kernel->env->rust_seed;
+    if (user_seed != NULL) {
+        // ignore bytes after the required length
+        size_t seed_len = user_seed->body.fill < sizeof(rctx->randrsl)
+            ? user_seed->body.fill : sizeof(rctx->randrsl);
+        memcpy(&rctx->randrsl, user_seed->body.data, seed_len);
+    } else if (env_seed != NULL) {
+        ub4 seed = (ub4) atoi(env_seed);
+        for (size_t i = 0; i < RANDSIZ; i++) {
+            memcpy(&rctx->randrsl[i], &seed, sizeof(ub4));
+            seed = (seed + 0x7ed55d16) + (seed << 12);
+        }
+    } else {
+        isaac_seed(kernel, (uint8_t*) &rctx->randrsl, sizeof(rctx->randrsl));
+    }
+
+    randinit(rctx, 1);
+}
+
+void isaac_reseed(rust_kernel *kernel, randctx *rctx)
+{
+    uint32_t new_seed[RANDSIZ];
+    isaac_seed(kernel, (uint8_t*) new_seed, RANDSIZ * sizeof(uint32_t));
+
+    // Stir new seed into PRNG's entropy pool.
+    for (size_t i = 0; i < RANDSIZ; i++) {
+      rctx->randrsl[i] ^= new_seed[i];
+    }
+
+    randinit(rctx, 1);
+}
 
 //
 // Local Variables:

--- a/src/rt/rust_util.h
+++ b/src/rt/rust_util.h
@@ -138,62 +138,9 @@ inline size_t get_box_size(size_t body_size, size_t body_align) {
 
 // Initialization helpers for ISAAC RNG
 
-inline void isaac_seed(rust_kernel* kernel, uint8_t* dest, size_t size)
-{
-#ifdef __WIN32__
-    HCRYPTPROV hProv;
-    kernel->win32_require
-        (_T("CryptAcquireContext"),
-         CryptAcquireContext(&hProv, NULL, NULL, PROV_RSA_FULL,
-                             CRYPT_VERIFYCONTEXT|CRYPT_SILENT));
-    kernel->win32_require
-        (_T("CryptGenRandom"), CryptGenRandom(hProv, size, (BYTE*) dest));
-    kernel->win32_require
-        (_T("CryptReleaseContext"), CryptReleaseContext(hProv, 0));
-#else
-    int fd = open("/dev/urandom", O_RDONLY);
-    if (fd == -1)
-        kernel->fatal("error opening /dev/urandom: %s", strerror(errno));
-    size_t amount = 0;
-    do {
-        ssize_t ret = read(fd, dest+amount, size-amount);
-        if (ret < 0)
-            kernel->fatal("error reading /dev/urandom: %s", strerror(errno));
-        else if (ret == 0)
-            kernel->fatal("somehow hit eof reading from /dev/urandom");
-        amount += (size_t)ret;
-    } while (amount < size);
-    int ret = close(fd);
-    // FIXME #3697: Why does this fail sometimes?
-    if (ret != 0)
-        kernel->log(log_warn, "error closing /dev/urandom: %s",
-            strerror(errno));
-#endif
-}
-
-inline void
-isaac_init(rust_kernel *kernel, randctx *rctx, rust_vec_box* user_seed)
-{
-    memset(rctx, 0, sizeof(randctx));
-
-    char *env_seed = kernel->env->rust_seed;
-    if (user_seed != NULL) {
-        // ignore bytes after the required length
-        size_t seed_len = user_seed->body.fill < sizeof(rctx->randrsl)
-            ? user_seed->body.fill : sizeof(rctx->randrsl);
-        memcpy(&rctx->randrsl, user_seed->body.data, seed_len);
-    } else if (env_seed != NULL) {
-        ub4 seed = (ub4) atoi(env_seed);
-        for (size_t i = 0; i < RANDSIZ; i ++) {
-            memcpy(&rctx->randrsl[i], &seed, sizeof(ub4));
-            seed = (seed + 0x7ed55d16) + (seed << 12);
-        }
-    } else {
-        isaac_seed(kernel, (uint8_t*) &rctx->randrsl, sizeof(rctx->randrsl));
-    }
-
-    randinit(rctx, 1);
-}
+void isaac_seed(rust_kernel* kernel, uint8_t* dest, size_t size);
+void isaac_init(rust_kernel *kernel, randctx *rctx, rust_vec_box* user_seed);
+void isaac_reseed(rust_kernel *kernel, randctx *rctx);
 
 //
 // Local Variables:


### PR DESCRIPTION
@graydon for issue #4709.

The first change (commit 294b4a9) is straightforward. It adds a new `isaac_reseed()` function and uninlines `isaac_seed()` and `isaac_init()`.

The second change (commit 2ef8a32) is more questionable. It adds a `rust_sched_loop::idle()` function, which is called when `rust_sched_driver::start_main_loop()` has no runnable tasks. `idle()` checks whether `rctx` has drained its entropy pool, i.e. generated more than 256 random `uint32_t`s. If not reseeded, `rctx` will be stirring the same entropy bits to generate new random numbers.

Possible improvements:
- Add a minimum and/or maximum reseed frequency to `idle()`. For example, Schneier and Ferguson's Fortuna PRNG doesn't reseed more often 10 times per second.
- Reseed less frequently than 256 random numbers (isaac's `RANDSIZ`)?
- If Rust's task scheduler supported alarm tasks to be run after a specified timeout, they could be used for periodic cleanup work like reseeding the RNG.

This change also adds a fast path to `rust_sched_loop::schedule_task()` when there is only 1 runnable task to avoid depleting `task_rng`'s precious entropy.
