### PR TITLE
auto: Remove interior mutability on vectors, round 2

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -322,8 +322,8 @@ fn check_expected_errors(expected_errors: ~[errors::ExpectedError],
                          ProcRes: ProcRes) {
 
     // true if we found the error in question
-    let found_flags = vec::cast_to_mut(vec::from_elem(
-        vec::len(expected_errors), false));
+    let mut found_flags = vec::from_elem(
+        vec::len(expected_errors), false);
 
     if ProcRes.status == 0 {
         fatal(~"process did not return an error status");

--- a/src/libcore/hash.rs
+++ b/src/libcore/hash.rs
@@ -165,7 +165,7 @@ struct SipState {
     mut v1: u64,
     mut v2: u64,
     mut v3: u64,
-    tail: [mut u8 * 8], // unprocessed bytes
+    mut tail: [u8 * 8], // unprocessed bytes
     mut ntail: uint,  // how many bytes in tail are valid
 }
 
@@ -179,7 +179,7 @@ fn SipState(key0: u64, key1: u64) -> SipState {
         mut v1 : 0u64,
         mut v2 : 0u64,
         mut v3 : 0u64,
-        tail : [mut 0u8,0,0,0,0,0,0,0],
+        mut tail : [0u8,0,0,0,0,0,0,0],
         mut ntail : 0u,
     };
     (&state).reset();

--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -56,7 +56,7 @@ pub trait Reader {
     /// Read up to len bytes (or EOF) and put them into bytes (which
     /// must be at least len bytes long). Return number of bytes read.
     // FIXME (#2982): This should probably return an error.
-    fn read(&self, bytes: &[mut u8], len: uint) -> uint;
+    fn read(&self, bytes: &mut [u8], len: uint) -> uint;
 
     /// Read a single byte, returning a negative value for EOF or read error.
     fn read_byte(&self) -> int;
@@ -416,7 +416,7 @@ fn convert_whence(whence: SeekStyle) -> i32 {
 }
 
 impl *libc::FILE: Reader {
-    fn read(&self, bytes: &[mut u8], len: uint) -> uint {
+    fn read(&self, bytes: &mut [u8], len: uint) -> uint {
         unsafe {
             do vec::as_mut_buf(bytes) |buf_p, buf_len| {
                 assert buf_len >= len;
@@ -461,7 +461,7 @@ struct Wrapper<T, C> {
 // duration of its lifetime.
 // FIXME there really should be a better way to do this // #2004
 impl<R: Reader, C> Wrapper<R, C>: Reader {
-    fn read(&self, bytes: &[mut u8], len: uint) -> uint {
+    fn read(&self, bytes: &mut [u8], len: uint) -> uint {
         self.base.read(bytes, len)
     }
     fn read_byte(&self) -> int { self.base.read_byte() }
@@ -528,7 +528,7 @@ pub struct BytesReader {
 }
 
 impl BytesReader: Reader {
-    fn read(&self, bytes: &[mut u8], len: uint) -> uint {
+    fn read(&self, bytes: &mut [u8], len: uint) -> uint {
         let count = uint::min(len, self.bytes.len() - self.pos);
 
         let view = vec::view(self.bytes, self.pos, self.bytes.len());

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -79,7 +79,7 @@ pub fn as_c_charp<T>(s: &str, f: fn(*c_char) -> T) -> T {
 
 pub fn fill_charp_buf(f: fn(*mut c_char, size_t) -> bool)
     -> Option<~str> {
-    let buf = vec::cast_to_mut(vec::from_elem(TMPBUF_SZ, 0u8 as c_char));
+    let mut buf = vec::from_elem(TMPBUF_SZ, 0u8 as c_char);
     do vec::as_mut_buf(buf) |b, sz| {
         if f(b, sz as size_t) {
             unsafe {
@@ -108,7 +108,7 @@ pub mod win32 {
             let mut res = None;
             let mut done = false;
             while !done {
-                let buf = vec::cast_to_mut(vec::from_elem(n as uint, 0u16));
+                let mut buf = vec::from_elem(n as uint, 0u16);
                 do vec::as_mut_buf(buf) |b, _sz| {
                     let k : DWORD = f(b, TMPBUF_SZ as DWORD);
                     if k == (0 as DWORD) {
@@ -1325,7 +1325,7 @@ mod tests {
           };
           assert (ostream as uint != 0u);
           let s = ~"hello";
-          let mut buf = vec::cast_to_mut(str::to_bytes(s) + ~[0 as u8]);
+          let mut buf = str::to_bytes(s) + ~[0 as u8];
           do vec::as_mut_buf(buf) |b, _len| {
               assert (libc::fwrite(b as *c_void, 1u as size_t,
                                    (str::len(s) + 1u) as size_t, ostream)

--- a/src/libcore/rand.rs
+++ b/src/libcore/rand.rs
@@ -350,7 +350,7 @@ impl Rng {
     }
 
     /// Shuffle a mutable vec in place
-    fn shuffle_mut<T>(values: &[mut T]) {
+    fn shuffle_mut<T>(values: &mut [T]) {
         let mut i = values.len();
         while i >= 2u {
             // invariant: elements with index >= i have been locked in place.

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -290,7 +290,7 @@ pub fn start_program(prog: &str, args: &[~str]) -> Program {
 
 fn read_all(rd: io::Reader) -> ~str {
     let buf = io::with_bytes_writer(|wr| {
-        let mut bytes = [mut 0, ..4096];
+        let mut bytes = [0, ..4096];
         while !rd.eof() {
             let nread = rd.read(bytes, bytes.len());
             wr.write(bytes.view(0, nread));
@@ -391,7 +391,7 @@ pub fn readclose(fd: c_int) -> ~str {
         let file = os::fdopen(fd);
         let reader = io::FILE_reader(file, false);
         let buf = io::with_bytes_writer(|writer| {
-            let mut bytes = [mut 0, ..4096];
+            let mut bytes = [0, ..4096];
             while !reader.eof() {
                 let nread = reader.read(bytes, bytes.len());
                 writer.write(bytes.view(0, nread));

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1002,7 +1002,7 @@ pub fn pick_col(m: &[@Match]) -> uint {
           _ => 0u
         }
     }
-    let scores = vec::cast_to_mut(vec::from_elem(m[0].pats.len(), 0u));
+    let mut scores = vec::from_elem(m[0].pats.len(), 0u);
     for vec::each(m) |br| {
         let mut i = 0u;
         for vec::each(br.pats) |p| { scores[i] += score(*p); i += 1u; }

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -127,13 +127,13 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
         }
     }
 
-    fn all_mem(cls: &[mut x86_64_reg_class]) {
+    fn all_mem(cls: &mut [x86_64_reg_class]) {
         for uint::range(0, cls.len()) |i| {
             cls[i] = memory_class;
         }
     }
 
-    fn unify(cls: &[mut x86_64_reg_class],
+    fn unify(cls: &mut [x86_64_reg_class],
              i: uint,
              newv: x86_64_reg_class) {
         if cls[i] == newv {
@@ -159,7 +159,7 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
     }
 
     fn classify_struct(tys: &[TypeRef],
-                       cls: &[mut x86_64_reg_class], i: uint,
+                       cls: &mut [x86_64_reg_class], i: uint,
                        off: uint) {
         let mut field_off = off;
         for vec::each(tys) |ty| {
@@ -170,7 +170,7 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
     }
 
     fn classify(ty: TypeRef,
-                cls: &[mut x86_64_reg_class], ix: uint,
+                cls: &mut [x86_64_reg_class], ix: uint,
                 off: uint) {
         unsafe {
             let t_align = ty_align(ty);
@@ -220,7 +220,7 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
         }
     }
 
-    fn fixup(ty: TypeRef, cls: &[mut x86_64_reg_class]) {
+    fn fixup(ty: TypeRef, cls: &mut [x86_64_reg_class]) {
         unsafe {
             let mut i = 0u;
             let llty = llvm::LLVMGetTypeKind(ty) as int;

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -270,14 +270,15 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
     }
 
     let words = (ty_size(ty) + 7) / 8;
-    let cls = vec::cast_to_mut(vec::from_elem(words, no_class));
+    let mut cls = vec::from_elem(words, no_class);
     if words > 4 {
         all_mem(cls);
-        return vec::cast_from_mut(move cls);
+        let cls = cls;
+        return move cls;
     }
     classify(ty, cls, 0, 0);
     fixup(ty, cls);
-    return vec::cast_from_mut(move cls);
+    return move cls;
 }
 
 fn llreg_ty(cls: &[x86_64_reg_class]) -> TypeRef {

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -779,7 +779,7 @@ pub impl LookupContext {
         /*!
          *
          * In the event that we are invoking a method with a receiver
-         * of a linear borrowed type like `&mut T` or `&[mut T]`,
+         * of a linear borrowed type like `&mut T` or `&mut [T]`,
          * we will "reborrow" the receiver implicitly.  For example, if
          * you have a call `r.inc()` and where `r` has type `&mut T`,
          * then we treat that like `(&mut *r).inc()`.  This avoids

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3131,7 +3131,7 @@ pub fn check_bounds_are_used(ccx: @mut CrateCtxt,
 
     // make a vector of booleans initially false, set to true when used
     if tps.len() == 0u { return; }
-    let tps_used = vec::cast_to_mut(vec::from_elem(tps.len(), false));
+    let mut tps_used = vec::from_elem(tps.len(), false);
 
     ty::walk_regions_and_ty(
         ccx.tcx, ty,

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -224,7 +224,7 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
     unsafe {
         let n_opts = opts.len();
         fn f(_x: uint) -> ~[Optval] { return ~[]; }
-        let vals = vec::cast_to_mut(vec::from_fn(n_opts, f));
+        let mut vals = vec::from_fn(n_opts, f);
         let mut free: ~[~str] = ~[];
         let l = args.len();
         let mut i = 0;
@@ -339,7 +339,7 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
             i += 1;
         }
         return Ok(Matches {opts: vec::from_slice(opts),
-                   vals: vec::cast_from_mut(move vals),
+                   vals: move vals,
                    free: free});
     }
 }

--- a/src/libstd/md4.rs
+++ b/src/libstd/md4.rs
@@ -52,7 +52,7 @@ pub pure fn md4(msg: &[u8]) -> Quad {
 
     let mut i = 0u;
     let e = vec::len(msg);
-    let x = vec::cast_to_mut(vec::from_elem(16u, 0u32));
+    let mut x = vec::from_elem(16u, 0u32);
     while i < e {
         let aa = a, bb = b, cc = c, dd = d;
 

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -174,7 +174,7 @@ pub fn concat(v: ~[Rope]) -> Rope {
     //Copy `v` into a mut vector
     let mut len = vec::len(v);
     if len == 0u { return node::Empty; }
-    let ropes = vec::cast_to_mut(vec::from_elem(len, v[0]));
+    let mut ropes = vec::from_elem(len, v[0]);
     for uint::range(1u, len) |i| {
        ropes[i] = v[i];
     }
@@ -719,7 +719,7 @@ pub mod node {
             //Firstly, split `str` in slices of hint_max_leaf_char_len
             let mut leaves = uint::div_ceil(char_len, hint_max_leaf_char_len);
             //Number of leaves
-            let nodes  = vec::cast_to_mut(vec::from_elem(leaves, candidate));
+            let mut nodes  = vec::from_elem(leaves, candidate);
 
             let mut i = 0u;
             let mut offset = byte_start;
@@ -832,7 +832,7 @@ pub mod node {
 
     pub fn serialize_node(node: @Node) -> ~str {
         unsafe {
-            let mut buf = vec::cast_to_mut(vec::from_elem(byte_len(node), 0));
+            let mut buf = vec::from_elem(byte_len(node), 0);
             let mut offset = 0u;//Current position in the buffer
             let it = leaf_iterator::start(node);
             loop {

--- a/src/libstd/sort.rs
+++ b/src/libstd/sort.rs
@@ -455,7 +455,7 @@ impl<T: Copy Ord> MergeState<T> {
                 base2: uint, len2: uint) {
         assert len1 != 0 && len2 != 0 && base1+len1 == base2;
 
-        let tmp = vec::cast_to_mut(vec::slice(array, base1, base1+len1));
+        let mut tmp = vec::slice(array, base1, base1+len1);
 
         let mut c1 = 0;
         let mut c2 = base2;
@@ -558,7 +558,7 @@ impl<T: Copy Ord> MergeState<T> {
                 base2: uint, len2: uint) {
         assert len1 != 1 && len2 != 0 && base1 + len1 == base2;
 
-        let tmp = vec::cast_to_mut(vec::slice(array, base2, base2+len2));
+        let mut tmp = vec::slice(array, base2, base2+len2);
 
         let mut c1 = base1 + len1 - 1;
         let mut c2 = len2 - 1;

--- a/src/libstd/workcache.rs
+++ b/src/libstd/workcache.rs
@@ -242,13 +242,13 @@ fn json_decode<T:Decodable<json::Decoder>>(s: &str) -> T {
 }
 
 fn digest<T:Encodable<json::Encoder>>(t: &T) -> ~str {
-    let sha = sha1::sha1();
+    let mut sha = sha1::sha1();
     sha.input_str(json_encode(t));
     sha.result_str()
 }
 
 fn digest_file(path: &Path) -> ~str {
-    let sha = sha1::sha1();
+    let mut sha = sha1::sha1();
     let s = io::read_whole_file_str(path);
     sha.input_str(*s.get_ref());
     sha.result_str()

--- a/src/test/bench/shootout-fannkuchredux.rs
+++ b/src/test/bench/shootout-fannkuchredux.rs
@@ -14,9 +14,9 @@ extern mod std;
 fn fannkuch(n: int) -> int {
     fn perm1init(i: uint) -> int { return i as int; }
 
-    let perm = vec::cast_to_mut(vec::from_elem(n as uint, 0));
-    let perm1 = vec::cast_to_mut(vec::from_fn(n as uint, |i| perm1init(i)));
-    let count = vec::cast_to_mut(vec::from_elem(n as uint, 0));
+    let mut perm = vec::from_elem(n as uint, 0);
+    let mut perm1 = vec::from_fn(n as uint, |i| perm1init(i));
+    let mut count = vec::from_elem(n as uint, 0);
     let mut f = 0;
     let mut i = 0;
     let mut k = 0;

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -149,7 +149,7 @@ fn main() {
    // initialize each sequence sorter
    let sizes = ~[1,2,3,4,6,12,18];
     let streams = vec::map(sizes, |_sz| Some(stream()));
-    let streams = vec::cast_to_mut(move streams);
+    let mut streams = move streams;
     let mut from_child = ~[];
     let to_child   = vec::mapi(sizes, |ii, sz| {
         let sz = *sz;

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -45,7 +45,7 @@ fn eval_At_times_u(u: &[const float], Au: &mut [float]) {
 }
 
 fn eval_AtA_times_u(u: &[const float], AtAu: &mut [float]) {
-    let v = vec::cast_to_mut(vec::from_elem(vec::len(u), 0.0));
+    let mut v = vec::from_elem(vec::len(u), 0.0);
     eval_A_times_u(u, v);
     eval_At_times_u(v, AtAu);
 }
@@ -62,8 +62,8 @@ fn main() {
 
     let N = uint::from_str(args[1]).get();
 
-    let u = vec::cast_to_mut(vec::from_elem(N, 1.0));
-    let v = vec::cast_to_mut(vec::from_elem(N, 0.0));
+    let mut u = vec::from_elem(N, 1.0);
+    let mut v = vec::from_elem(N, 0.0);
     let mut i = 0u;
     while i < 10u {
         eval_AtA_times_u(u, v);

--- a/src/test/compile-fail/issue-2548.rs
+++ b/src/test/compile-fail/issue-2548.rs
@@ -33,8 +33,8 @@ fn main() {
     {
         let mut res = foo(x);
 
-        let mut v = ~[mut];
-        v = move ~[mut (move res)] + v; //~ ERROR does not fulfill `Copy`
+        let mut v = ~[];
+        v = move ~[(move res)] + v; //~ instantiating a type parameter with an incompatible type `foo`, which does not fulfill `Copy`
         assert (v.len() == 2);
     }
 

--- a/src/test/run-pass/import-in-block.rs
+++ b/src/test/run-pass/import-in-block.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 pub fn main() {
+    // Once cast_to_mut is removed, pick a better function to import
+    // for this test!
     use vec::cast_to_mut;
     log(debug, vec::len(cast_to_mut(~[1, 2])));
     {


### PR DESCRIPTION
This patch finishes removing inner vector mutability from the vast majority of the compiler. Exceptions:
- core::dvec: ideally this entire type will be able to be replaced by `~[]`, but Niko asked me to hold off on removing Dvecs until he makes some fixes to borrowed pointers. 
- liveness: liveness.rs is an impenetrable neutron star of deprecated semantics.
- compile-fail: I'm not sure if a lot of these tests are testing inner mutability or mutability in general. I figure that RIMOVing this folder should wait until this syntax is removed from the parser.

I also took this chance to remove many of the inner-mutability-related functions from core::vec, or as many uses of those functions as possible where still necessary. consume_mut and append_mut have been axed. cast_to_mut and cast_from_mut are still needed in a few places.
