### PR TITLE
libsyntax: don't parse ////, /***/ as doc comments

### DIFF
--- a/src/etc/licenseck.py
+++ b/src/etc/licenseck.py
@@ -8,7 +8,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-license0 = """// Copyright 2012-2013 The Rust Project Developers. See the
+license0 = """\
+// Copyright 2012-2013 The Rust Project Developers. See the
 // COPYRIGHT file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,7 +20,8 @@ license0 = """// Copyright 2012-2013 The Rust Project Developers. See the
 // except according to those terms.
 """
 
-license1 = """// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+license1 = """\
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -30,7 +32,8 @@ license1 = """// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // except according to those terms.
 """
 
-license2 = """// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+license2 = """\
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -41,7 +44,8 @@ license2 = """// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // except according to those terms.
 """
 
-license3 = """# Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+license3 = """\
+# Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.
 #
@@ -52,7 +56,19 @@ license3 = """# Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 # except according to those terms.
 """
 
-licenses = [license0, license1, license2, license3]
+license4 = """\
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+"""
+
+licenses = [license0, license1, license2, license3, license4]
 
 exceptions = [
     "rt/rust_android_dummy.cpp", # BSD, chromium

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -15,6 +15,7 @@ use codemap::{BytePos, CharPos, CodeMap, FileMap, Pos};
 use diagnostic;
 use parse::lexer::{is_whitespace, get_str_from, reader};
 use parse::lexer::{StringReader, bump, is_eof, nextch, TokenAndSpan};
+use parse::lexer::{is_line_non_doc_comment, is_block_non_doc_comment};
 use parse::lexer;
 use parse::token;
 use parse;
@@ -46,9 +47,9 @@ impl cmnt_style : cmp::Eq {
 pub type cmnt = {style: cmnt_style, lines: ~[~str], pos: BytePos};
 
 pub fn is_doc_comment(s: ~str) -> bool {
-    s.starts_with(~"///") ||
+    (s.starts_with(~"///") && !is_line_non_doc_comment(s)) ||
     s.starts_with(~"//!") ||
-    s.starts_with(~"/**") ||
+    (s.starts_with(~"/**") && !is_block_non_doc_comment(s)) ||
     s.starts_with(~"/*!")
 }
 
@@ -231,47 +232,56 @@ fn read_block_comment(rdr: @mut StringReader,
     bump(rdr);
     bump(rdr);
 
+    let mut curr_line = ~"/*";
+
     // doc-comments are not really comments, they are attributes
     if rdr.curr == '*' || rdr.curr == '!' {
         while !(rdr.curr == '*' && nextch(rdr) == '/') && !is_eof(rdr) {
+            str::push_char(&mut curr_line, rdr.curr);
             bump(rdr);
         }
         if !is_eof(rdr) {
+            curr_line += ~"*/";
             bump(rdr);
             bump(rdr);
         }
-        return;
-    }
-
-    let mut curr_line = ~"/*";
-    let mut level: int = 1;
-    while level > 0 {
-        debug!("=== block comment level %d", level);
-        if is_eof(rdr) {(rdr as reader).fatal(~"unterminated block comment");}
-        if rdr.curr == '\n' {
-            trim_whitespace_prefix_and_push_line(&mut lines, curr_line, col);
-            curr_line = ~"";
-            bump(rdr);
-        } else {
-            str::push_char(&mut curr_line, rdr.curr);
-            if rdr.curr == '/' && nextch(rdr) == '*' {
+        if !is_block_non_doc_comment(curr_line) { return; }
+        assert !curr_line.contains_char('\n');
+        lines.push(curr_line);
+    } else {
+        let mut level: int = 1;
+        while level > 0 {
+            debug!("=== block comment level %d", level);
+            if is_eof(rdr) {
+                (rdr as reader).fatal(~"unterminated block comment");
+            }
+            if rdr.curr == '\n' {
+                trim_whitespace_prefix_and_push_line(&mut lines, curr_line,
+                                                     col);
+                curr_line = ~"";
                 bump(rdr);
-                bump(rdr);
-                curr_line += ~"*";
-                level += 1;
             } else {
-                if rdr.curr == '*' && nextch(rdr) == '/' {
+                str::push_char(&mut curr_line, rdr.curr);
+                if rdr.curr == '/' && nextch(rdr) == '*' {
                     bump(rdr);
                     bump(rdr);
-                    curr_line += ~"/";
-                    level -= 1;
-                } else { bump(rdr); }
+                    curr_line += ~"*";
+                    level += 1;
+                } else {
+                    if rdr.curr == '*' && nextch(rdr) == '/' {
+                        bump(rdr);
+                        bump(rdr);
+                        curr_line += ~"/";
+                        level -= 1;
+                    } else { bump(rdr); }
+                }
             }
         }
+        if str::len(curr_line) != 0 {
+            trim_whitespace_prefix_and_push_line(&mut lines, curr_line, col);
+        }
     }
-    if str::len(curr_line) != 0 {
-        trim_whitespace_prefix_and_push_line(&mut lines, curr_line, col);
-    }
+
     let mut style = if code_to_the_left { trailing } else { isolated };
     consume_non_eol_whitespace(rdr);
     if !is_eof(rdr) && rdr.curr != '\n' && vec::len(lines) == 1u {

--- a/src/test/pretty/doc-comments.rs
+++ b/src/test/pretty/doc-comments.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,6 +19,14 @@ fn b() {
     //! some single line inner-docs
 }
 
+//////////////////////////////////
+// some single-line non-doc comment preceded by a separator
+
+//////////////////////////////////           
+/// some single-line outer-docs preceded by a separator
+/// (and trailing whitespaces)
+fn c() { }
+
 /*
  * some multi-line non-doc comment
  */
@@ -26,17 +34,28 @@ fn b() {
 /**
  * some multi-line outer-docs
  */
-fn c() { }
+fn d() { }
 
-fn d() {
+fn e() {
     /*!
      * some multi-line inner-docs
      */
 }
 
-#[doc = "unsugared outer doc-comments work also"]
-fn e() { }
+/********************************/
+/*
+ * some multi-line non-doc comment preceded by a separator
+ */
 
-fn f() {
+/********************************/
+/**
+ * some multi-line outer-docs preceded by a separator
+ */
+fn f() { }
+
+#[doc = "unsugared outer doc-comments work also"]
+fn g() { }
+
+fn h() {
     #[doc = "as do inner ones"];
 }


### PR DESCRIPTION
This is a natural extension of #4887, and handles the following three cases:

```
a line with only /s
////////////////////////////////////////////

a line with only /s followed by whitespace
////////////////////////////////////////////         

a block comment with only *s between two /s
/********************************/
```
