### PR TITLE
rt: get rid of rust_fn and replace with fn_env_pair plus a little cleanup.

### DIFF
--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -249,24 +249,16 @@ debug_opaque(type_desc *t, uint8_t *front) {
     }
 }
 
-// FIXME (#2667) this no longer reflects the actual structure of boxes!
-struct rust_box {
-    RUST_REFCOUNTED(rust_box)
-
-    // FIXME (#2667) `data` could be aligned differently from the actual
-    // box body data
-    uint8_t data[];
-};
-
 extern "C" CDECL void
-debug_box(type_desc *t, rust_box *box) {
+debug_box(type_desc *t, rust_opaque_box *box) {
     rust_task *task = rust_get_current_task();
     LOG(task, stdlib, "debug_box(0x%" PRIxPTR ")", box);
     debug_tydesc_helper(t);
     LOG(task, stdlib, "  refcount %" PRIdPTR,
         box->ref_count - 1);  // -1 because we ref'ed for this call
+    uint8_t *data = (uint8_t *)box_body(box);
     for (uintptr_t i = 0; i < t->size; ++i) {
-        LOG(task, stdlib, "  byte %" PRIdPTR ": 0x%" PRIx8, i, box->data[i]);
+        LOG(task, stdlib, "  byte %" PRIdPTR ": 0x%" PRIx8, i, data[i]);
     }
 }
 
@@ -288,20 +280,15 @@ debug_tag(type_desc *t, rust_tag *tag) {
             tag->variant[i]);
 }
 
-struct rust_fn {
-    uintptr_t *thunk;
-    rust_box *closure;
-};
-
 extern "C" CDECL void
-debug_fn(type_desc *t, rust_fn *fn) {
+debug_fn(type_desc *t, fn_env_pair *fn) {
     rust_task *task = rust_get_current_task();
     LOG(task, stdlib, "debug_fn");
     debug_tydesc_helper(t);
-    LOG(task, stdlib, "  thunk at 0x%" PRIxPTR, fn->thunk);
-    LOG(task, stdlib, "  closure at 0x%" PRIxPTR, fn->closure);
-    if (fn->closure) {
-        LOG(task, stdlib, "    refcount %" PRIdPTR, fn->closure->ref_count);
+    LOG(task, stdlib, " fn at 0x%" PRIxPTR, fn->f);
+    LOG(task, stdlib, "  env at 0x%" PRIxPTR, fn->env);
+    if (fn->env) {
+        LOG(task, stdlib, "    refcount %" PRIdPTR, fn->env->ref_count);
     }
 }
 
@@ -388,11 +375,6 @@ rust_path_exists(char *path) {
 extern "C" CDECL FILE* rust_get_stdin() {return stdin;}
 extern "C" CDECL FILE* rust_get_stdout() {return stdout;}
 extern "C" CDECL FILE* rust_get_stderr() {return stderr;}
-
-extern "C" CDECL int
-rust_ptr_eq(type_desc *t, rust_box *a, rust_box *b) {
-    return a == b;
-}
 
 #if defined(__WIN32__)
 extern "C" CDECL void

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -241,13 +241,12 @@ debug_opaque(type_desc *t, uint8_t *front) {
     rust_task *task = rust_get_current_task();
     LOG(task, stdlib, "debug_opaque");
     debug_tydesc_helper(t);
+    // Account for alignment. `front` may not indeed be the
+    // front byte of the passed-in argument
+    if (((uintptr_t)front % t->align) != 0) {
+        front = (uint8_t *)align_to((uintptr_t)front, (size_t)t->align);
+    }
     for (uintptr_t i = 0; i < t->size; ++front, ++i) {
-
-        // Account for alignment. `front` may not indeed be the
-        // front byte of the passed-in argument
-        if (((uintptr_t)front % t->align) != 0)
-            front = (uint8_t *)align_to((uintptr_t)front, (size_t)t->align);
-
         LOG(task, stdlib, "  byte %" PRIdPTR ": 0x%" PRIx8, i, *front);
     }
 }

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -241,10 +241,13 @@ debug_opaque(type_desc *t, uint8_t *front) {
     rust_task *task = rust_get_current_task();
     LOG(task, stdlib, "debug_opaque");
     debug_tydesc_helper(t);
-    // FIXME (#2667) may want to actually account for alignment.
-    // `front` may not indeed be the front byte of the passed-in
-    // argument.
     for (uintptr_t i = 0; i < t->size; ++front, ++i) {
+
+        // Account for alignment. `front` may not indeed be the
+        // front byte of the passed-in argument
+        if (((uintptr_t)front % t->align) != 0)
+            front = (uint8_t *)align_to((uintptr_t)front, (size_t)t->align);
+
         LOG(task, stdlib, "  byte %" PRIdPTR ": 0x%" PRIx8, i, *front);
     }
 }

--- a/src/rt/rust_refcount.h
+++ b/src/rt/rust_refcount.h
@@ -17,14 +17,6 @@
 // Refcounting defines
 typedef unsigned long ref_cnt_t;
 
-#define RUST_REFCOUNTED(T) \
-  RUST_REFCOUNTED_WITH_DTOR(T, delete (T*)this)
-
-#define RUST_REFCOUNTED_WITH_DTOR(T, dtor)      \
-  intptr_t ref_count;      \
-  void ref() { ++ref_count; } \
-  void deref() { if (--ref_count == 0) { dtor; } }
-
 #define RUST_ATOMIC_REFCOUNT()                                             \
 private:                                                                   \
    intptr_t ref_count;                                                     \

--- a/src/rt/rust_task.h
+++ b/src/rt/rust_task.h
@@ -168,8 +168,6 @@
 #define RED_ZONE_SIZE RZ_MAC_32
 #endif
 
-struct rust_box;
-
 struct frame_glue_fns {
     uintptr_t mark_glue_off;
     uintptr_t drop_glue_off;

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -39,7 +39,6 @@ rust_list_files2
 rust_log_console_on
 rust_log_console_off
 rust_process_wait
-rust_ptr_eq
 rust_run_program
 rust_sched_current_nonlazy_threads
 rust_sched_threads


### PR DESCRIPTION
Closes #1190.

Also, got rid of `rust_ptr_eq` since it isn't used any as well the `RUST_REFCOUNTED` macros.

Fixes #2667: alignment & wrong structure.
