### PR TITLE
update tutorial and manual to use new `impl Trait for Type` syntax

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1209,7 +1209,7 @@ to pointers to the trait name, used as a type.
 
 ~~~~
 # trait Shape { }
-# impl int: Shape { }
+# impl Shape for int { }
 # let mycircle = 0;
 
 let myshape: Shape = @mycircle as @Shape;
@@ -1233,7 +1233,7 @@ For example:
 trait Num {
     static pure fn from_int(n: int) -> Self;
 }
-impl float: Num {
+impl Num for float {
     static pure fn from_int(n: int) -> float { n as float }
 }
 let x: float = Num::from_int(42);
@@ -1269,8 +1269,8 @@ Likewise, supertrait methods may also be called on trait objects.
 ~~~ {.xfail-test}
 # trait Shape { fn area() -> float; }
 # trait Circle : Shape { fn radius() -> float; }
-# impl int: Shape { fn area() -> float { 0.0 } }
-# impl int: Circle { fn radius() -> float { 0.0 } }
+# impl Shape for int { fn area() -> float { 0.0 } }
+# impl Circle for int { fn radius() -> float { 0.0 } }
 # let mycircle = 0;
 
 let mycircle: Circle = @mycircle as @Circle;
@@ -1292,7 +1292,7 @@ Implementations are defined with the keyword `impl`.
 
 type Circle = {radius: float, center: Point};
 
-impl Circle: Shape {
+impl Shape for Circle {
     fn draw(s: Surface) { do_draw_circle(s, self); }
     fn bounding_box() -> BoundingBox {
         let r = self.radius;
@@ -1303,9 +1303,9 @@ impl Circle: Shape {
 ~~~~
 
 It is possible to define an implementation without referring to a trait.
-The methods in such an implementation can only be used statically
-(as direct calls on the values of the type that the implementation targets).
-In such an implementation, the type after the colon is omitted.
+The methods in such an implementation can only be used
+as direct calls on the values of the type that the implementation targets.
+In such an implementation, the trait type and `for` after `impl` are omitted.
 Such implementations are limited to nominal types (enums, structs),
 and the implementation must appear in the same module or a sub-module as the `self` type.
 
@@ -1320,10 +1320,10 @@ Implementation parameters are written after after the `impl` keyword.
 ~~~~
 # trait Seq<T> { }
 
-impl<T> ~[T]: Seq<T> {
+impl<T> Seq<T> for ~[T] {
    ...
 }
-impl u32: Seq<bool> {
+impl Seq<bool> for u32 {
    /* Treat the integer as a sequence of bits */
 }
 ~~~~
@@ -2801,7 +2801,7 @@ trait Printable {
   fn to_str() -> ~str;
 }
 
-impl int: Printable {
+impl Printable for int {
   fn to_str() -> ~str { int::to_str(self) }
 }
 
@@ -2844,7 +2844,7 @@ trait Printable {
   fn make_string() -> ~str;
 }
 
-impl ~str: Printable {
+impl Printable for ~str {
   fn make_string() -> ~str { copy self }
 }
 ~~~~~~~~

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1909,7 +1909,7 @@ struct TimeBomb {
     explosivity: uint
 }
 
-impl TimeBomb : Drop {
+impl Drop for TimeBomb {
     fn finalize(&self) {
         for iter::repeat(self.explosivity) {
             io::println("blam!");
@@ -1943,11 +1943,11 @@ and `&str`.
 
 ~~~~
 # trait Printable { fn print(&self); }
-impl int: Printable {
+impl Printable for int {
     fn print(&self) { io::println(fmt!("%d", *self)) }
 }
 
-impl &str: Printable {
+impl Printable for &str {
     fn print(&self) { io::println(*self) }
 }
 
@@ -1966,7 +1966,7 @@ trait Seq<T> {
     fn iter(&self, b: fn(v: &T));
 }
 
-impl<T> ~[T]: Seq<T> {
+impl<T> Seq<T> for ~[T] {
     fn len(&self) -> uint { vec::len(*self) }
     fn iter(&self, b: fn(v: &T)) {
         for vec::each(*self) |elt| { b(elt); }
@@ -1978,7 +1978,7 @@ The implementation has to explicitly declare the type parameter that
 it binds, `T`, before using it to specify its trait type. Rust
 requires this declaration because the `impl` could also, for example,
 specify an implementation of `Seq<int>`. The trait type (appearing
-after the colon in the `impl`) *refers* to a type, rather than
+between `impl` and `for`) *refers* to a type, rather than
 defining one.
 
 The type parameters bound by a trait are in scope in each of the
@@ -2000,7 +2000,7 @@ trait Eq {
 }
 
 // In an impl, `self` refers just to the value of the receiver
-impl int: Eq {
+impl Eq for int {
     fn equals(&self, other: &int) -> bool { *other == *self }
 }
 ~~~~
@@ -2021,10 +2021,10 @@ trait Shape { static fn new(area: float) -> Self; }
 struct Circle { radius: float }
 struct Square { length: float }
 
-impl Circle: Shape {
+impl Shape for Circle {
     static fn new(area: float) -> Circle { Circle { radius: sqrt(area / pi) } }
 }
-impl Square: Shape {
+impl Shape for Square {
     static fn new(area: float) -> Square { Square { length: sqrt(area) } }
 }
 
@@ -2084,7 +2084,7 @@ However, consider this function:
 
 ~~~~
 # type Circle = int; type Rectangle = int;
-# impl int: Drawable { fn draw(&self) {} }
+# impl Drawable for int { fn draw(&self) {} }
 # fn new_circle() -> int { 1 }
 trait Drawable { fn draw(&self); }
 
@@ -2120,9 +2120,8 @@ value to an object:
 # fn new_rectangle() -> Rectangle { true }
 # fn draw_all(shapes: &[@Drawable]) {}
 
-impl Circle: Drawable { fn draw(&self) { ... } }
-
-impl Rectangle: Drawable { fn draw(&self) { ... } }
+impl Drawable for Circle { fn draw(&self) { ... } }
+impl Drawable for Rectangle { fn draw(&self) { ... } }
 
 let c: @Circle = @new_circle();
 let r: @Rectangle = @new_rectangle();
@@ -2140,7 +2139,7 @@ for example, an `@Circle` may not be cast to an `~Drawable`.
 ~~~
 # type Circle = int; type Rectangle = int;
 # trait Drawable { fn draw(&self); }
-# impl int: Drawable { fn draw(&self) {} }
+# impl Drawable for int { fn draw(&self) {} }
 # fn new_circle() -> int { 1 }
 # fn new_rectangle() -> int { 2 }
 // A managed object
@@ -2180,10 +2179,10 @@ Now, we can implement `Circle` on a type only if we also implement `Shape`.
 # use float::sqrt;
 # fn square(x: float) -> float { x * x }
 struct CircleStruct { center: Point, radius: float }
-impl CircleStruct: Circle {
+impl Circle for CircleStruct {
     fn radius(&self) -> float { sqrt(self.area() / pi) }
 }
-impl CircleStruct: Shape {
+impl Shape for CircleStruct {
     fn area(&self) -> float { pi * square(self.radius) }
 }   
 ~~~~
@@ -2215,8 +2214,8 @@ Likewise, supertrait methods may also be called on trait objects.
 # use float::sqrt;
 # struct Point { x: float, y: float }
 # struct CircleStruct { center: Point, radius: float }
-# impl CircleStruct: Circle { fn radius(&self) -> float { sqrt(self.area() / pi) } }
-# impl CircleStruct: Shape { fn area(&self) -> float { pi * square(self.radius) } }
+# impl Circle for CircleStruct { fn radius(&self) -> float { sqrt(self.area() / pi) } }
+# impl Shape for CircleStruct { fn area(&self) -> float { pi * square(self.radius) } }
 
 let concrete = @CircleStruct{center:Point{x:3f,y:4f},radius:5f};
 let mycircle: Circle = concrete as @Circle;


### PR DESCRIPTION
Replace `impl Type: Trait` with `impl Trait for Type` throughout tutorial and manual.
