### PR TITLE
stop zeroing exchange heap allocations and some other more minor allocations

### DIFF
--- a/src/libcore/private/exchange_alloc.rs
+++ b/src/libcore/private/exchange_alloc.rs
@@ -14,7 +14,7 @@ use c_malloc = libc::malloc;
 use c_free = libc::free;
 use managed::raw::{BoxHeaderRepr, BoxRepr};
 use cast::transmute;
-use ptr::{set_memory, null};
+use ptr::null;
 use intrinsic::TyDesc;
 
 pub unsafe fn malloc(td: *TypeDesc, size: uint) -> *c_void {
@@ -24,10 +24,6 @@ pub unsafe fn malloc(td: *TypeDesc, size: uint) -> *c_void {
         let total_size = get_box_size(size, (*td).align);
         let p = c_malloc(total_size as size_t);
         assert p.is_not_null();
-
-        // FIXME #4761: Would be very nice to not memset all allocations
-        let p: *mut u8 = transmute(p);
-        set_memory(p, 0, total_size);
 
         // FIXME #3475: Converting between our two different tydesc types
         let td: *TyDesc = transmute(td);

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -1253,7 +1253,7 @@ pub mod test {
                       as *request_wrapper;
                 let buf_base = get_base_from_buf(buf);
                 let buf_len = get_len_from_buf(buf);
-                let bytes = vec::from_buf(buf_base, buf_len as uint);
+                let bytes = vec::from_buf(buf_base, nread as uint);
                 let read_chan = (*client_data).read_chan.clone();
                 let msg_from_server = str::from_bytes(bytes);
                 read_chan.send(msg_from_server);
@@ -1445,7 +1445,7 @@ pub mod test {
                                 buf_base as uint,
                                 buf_len as uint,
                                 nread));
-                let bytes = vec::from_buf(buf_base, buf_len);
+                let bytes = vec::from_buf(buf_base, nread as uint);
                 let request_str = str::from_bytes(bytes);
 
                 let client_data = get_data_for_uv_handle(
@@ -1453,7 +1453,7 @@ pub mod test {
 
                 let server_kill_msg = (*client_data).server_kill_msg;
                 let write_req = (*client_data).server_write_req;
-                if (str::contains(request_str, server_kill_msg)) {
+                if str::contains(request_str, server_kill_msg) {
                     log(debug, ~"SERVER: client req contains kill_msg!");
                     log(debug, ~"SERVER: sending response to client");
                     read_stop(client_stream_ptr);

--- a/src/rt/memory_region.cpp
+++ b/src/rt/memory_region.cpp
@@ -121,8 +121,10 @@ memory_region::realloc(void *mem, size_t orig_size) {
 }
 
 void *
-memory_region::malloc(size_t size, const char *tag, bool zero) {
+memory_region::malloc(size_t size, const char *tag) {
+#   if RUSTRT_TRACK_ALLOCATIONS >= 1
     size_t old_size = size;
+#   endif
     size += HEADER_SIZE;
     alloc_header *mem = (alloc_header *)::malloc(size);
     if (mem == NULL) {
@@ -143,16 +145,7 @@ memory_region::malloc(size_t size, const char *tag, bool zero) {
     void *data = get_data(mem);
     claim_alloc(data);
 
-    if(zero) {
-        memset(data, 0, old_size);
-    }
-
     return data;
-}
-
-void *
-memory_region::calloc(size_t size, const char *tag) {
-    return malloc(size, tag, true);
 }
 
 memory_region::~memory_region() {

--- a/src/rt/memory_region.h
+++ b/src/rt/memory_region.h
@@ -77,8 +77,7 @@ private:
 public:
     memory_region(rust_env *env, bool synchronized);
     memory_region(memory_region *parent);
-    void *malloc(size_t size, const char *tag, bool zero = true);
-    void *calloc(size_t size, const char *tag);
+    void *malloc(size_t size, const char *tag);
     void *realloc(void *mem, size_t size);
     void free(void *mem);
     ~memory_region();

--- a/src/rt/rust_exchange_alloc.cpp
+++ b/src/rt/rust_exchange_alloc.cpp
@@ -28,11 +28,6 @@ rust_exchange_alloc::malloc(size_t size) {
 }
 
 void *
-rust_exchange_alloc::calloc(size_t size) {
-  return this->malloc(size);
-}
-
-void *
 rust_exchange_alloc::realloc(void *ptr, size_t size) {
   void *new_ptr = ::realloc(ptr, size);
   assert(new_ptr);

--- a/src/rt/rust_exchange_alloc.cpp
+++ b/src/rt/rust_exchange_alloc.cpp
@@ -18,12 +18,9 @@
 uintptr_t exchange_count = 0;
 
 void *
-rust_exchange_alloc::malloc(size_t size, bool zero) {
+rust_exchange_alloc::malloc(size_t size) {
   void *value = ::malloc(size);
   assert(value);
-  if (zero) {
-    memset(value, 0, size);
-  }
 
   sync::increment(exchange_count);
 

--- a/src/rt/rust_exchange_alloc.h
+++ b/src/rt/rust_exchange_alloc.h
@@ -16,7 +16,7 @@
 
 class rust_exchange_alloc {
  public:
-    void *malloc(size_t size, bool zero = true);
+    void *malloc(size_t size);
     void *calloc(size_t size);
     void *realloc(void *mem, size_t size);
     void free(void *mem);

--- a/src/rt/rust_exchange_alloc.h
+++ b/src/rt/rust_exchange_alloc.h
@@ -17,7 +17,6 @@
 class rust_exchange_alloc {
  public:
     void *malloc(size_t size);
-    void *calloc(size_t size);
     void *realloc(void *mem, size_t size);
     void free(void *mem);
 };

--- a/src/rt/rust_kernel.cpp
+++ b/src/rt/rust_kernel.cpp
@@ -80,11 +80,6 @@ rust_kernel::malloc(size_t size, const char *tag) {
 }
 
 void *
-rust_kernel::calloc(size_t size, const char *tag) {
-    return exchange_alloc.calloc(size);
-}
-
-void *
 rust_kernel::realloc(void *mem, size_t size) {
     return exchange_alloc.realloc(mem, size);
 }

--- a/src/rt/rust_kernel.h
+++ b/src/rt/rust_kernel.h
@@ -133,7 +133,6 @@ public:
     void fatal(char const *fmt, ...);
 
     void *malloc(size_t size, const char *tag);
-    void *calloc(size_t size, const char *tag);
     void *realloc(void *mem, size_t size);
     void free(void *mem);
     rust_exchange_alloc *region() { return &exchange_alloc; }

--- a/src/rt/rust_stack.cpp
+++ b/src/rt/rust_stack.cpp
@@ -58,7 +58,7 @@ check_stack_canary(stk_seg *stk) {
 stk_seg *
 create_stack(memory_region *region, size_t sz) {
     size_t total_sz = sizeof(stk_seg) + sz;
-    stk_seg *stk = (stk_seg *)region->malloc(total_sz, "stack", false);
+    stk_seg *stk = (stk_seg *)region->malloc(total_sz, "stack");
     memset(stk, 0, sizeof(stk_seg));
     stk->end = (uintptr_t) &stk->data[sz];
     add_stack_canary(stk);

--- a/src/rt/rust_stack.cpp
+++ b/src/rt/rust_stack.cpp
@@ -75,7 +75,7 @@ destroy_stack(memory_region *region, stk_seg *stk) {
 stk_seg *
 create_exchange_stack(rust_exchange_alloc *exchange, size_t sz) {
     size_t total_sz = sizeof(stk_seg) + sz;
-    stk_seg *stk = (stk_seg *)exchange->malloc(total_sz, false);
+    stk_seg *stk = (stk_seg *)exchange->malloc(total_sz);
     memset(stk, 0, sizeof(stk_seg));
     stk->end = (uintptr_t) &stk->data[sz];
     add_stack_canary(stk);

--- a/src/rt/rust_task.cpp
+++ b/src/rt/rust_task.cpp
@@ -450,11 +450,6 @@ rust_task::backtrace() {
 #endif
 }
 
-void *
-rust_task::calloc(size_t size, const char *tag) {
-    return local_region.calloc(size, tag);
-}
-
 size_t
 rust_task::get_next_stack_size(size_t min, size_t current, size_t requested) {
     LOG(this, mem, "calculating new stack size for 0x%" PRIxPTR, this);


### PR DESCRIPTION
I removed the unused wrappers methods named `calloc` because they relied on the malloc wrapper having a `bool zero = true` default parameter (which resulted in some accidental zeroing). Perhaps wrapping the actual calloc function would be useful, but I don't know of an existing use case that could use it so I just removed these.

This gives an ~1% performance improvement for TreeMap, which does a lot of small allocations. Vectors use `realloc` which didn't zero before these changes so there's no measurable change in performance.
