### PR TITLE
Convert all uses of vec::slice to vec::view Issue #3869

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -570,7 +570,8 @@ fn make_run_args(config: config, _props: TestProps, testfile: &Path) ->
         };
 
     let args = toolargs + ~[make_exe_name(config, testfile).to_str()];
-    return ProcArgs {prog: args[0], args: vec::slice(args, 1, args.len())};
+    return ProcArgs {prog: args[0],
+                     args: vec::slice(args, 1, args.len()).to_vec()};
 }
 
 fn split_maybe_args(argstr: Option<~str>) -> ~[~str] {

--- a/src/libcargo/cargo.rc
+++ b/src/libcargo/cargo.rc
@@ -1553,7 +1553,7 @@ pub fn cmd_list(c: &Cargo) {
     sync(c);
 
     if vec::len(c.opts.free) >= 3u {
-        let v = vec::view(c.opts.free, 2u, vec::len(c.opts.free));
+        let v = vec::slice(c.opts.free, 2u, vec::len(c.opts.free));
         for vec::each(v) |name| {
             if !valid_pkg_name(*name) {
                 error(fmt!("'%s' is an invalid source name", *name));

--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -246,7 +246,7 @@ impl<T: Reader> ReaderUtil for T {
             // over-read by reading 1-byte per char needed
             nbread = if ncreq > nbreq { ncreq } else { nbreq };
             if nbread > 0 {
-                bytes = vec::slice(bytes, offset, bytes.len());
+                bytes = vec::slice(bytes, offset, bytes.len()).to_vec();
             }
         }
         move chars
@@ -531,7 +531,7 @@ impl Reader for BytesReader {
     fn read(&self, bytes: &mut [u8], len: uint) -> uint {
         let count = uint::min(len, self.bytes.len() - self.pos);
 
-        let view = vec::view(self.bytes, self.pos, self.bytes.len());
+        let view = vec::slice(self.bytes, self.pos, self.bytes.len());
         vec::bytes::copy_memory(bytes, view, count);
 
         self.pos += count;
@@ -1008,7 +1008,7 @@ impl Writer for BytesWriter {
             unsafe { vec::raw::set_len(&mut bytes, count); }
 
             {
-                let view = vec::mut_view(bytes, self.pos, count);
+                let view = vec::mut_slice(bytes, self.pos, count);
                 vec::bytes::copy_memory(view, v, v_len);
             }
 

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -108,9 +108,10 @@ pub mod win32 {
             let mut res = None;
             let mut done = false;
             while !done {
-                let mut buf = vec::from_elem(n as uint, 0u16);
+                let mut k: DWORD = 0;
+                let buf = vec::cast_to_mut(vec::from_elem(n as uint, 0u16));
                 do vec::as_mut_buf(buf) |b, _sz| {
-                    let k : DWORD = f(b, TMPBUF_SZ as DWORD);
+                    k = f(b, TMPBUF_SZ as DWORD);
                     if k == (0 as DWORD) {
                         done = true;
                     } else if (k == n &&
@@ -118,10 +119,12 @@ pub mod win32 {
                                libc::ERROR_INSUFFICIENT_BUFFER as DWORD) {
                         n *= (2 as DWORD);
                     } else {
-                        let sub = vec::slice(buf, 0u, k as uint);
-                        res = option::Some(str::from_utf16(sub));
                         done = true;
                     }
+                }
+                if k != 0 && done {
+                    let sub = vec::slice(buf, 0u, k as uint);
+                    res = option::Some(str::from_utf16(sub));
                 }
             }
             return res;

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -157,7 +157,7 @@ pub fn get_relative_to(abs1: &Path, abs2: &Path) -> Path {
     let mut path = ~[];
     for uint::range(start_idx, len1 - 1) |_i| { path.push(~".."); };
 
-    path.push_all(vec::view(split2, start_idx, len2 - 1));
+    path.push_all(vec::slice(split2, start_idx, len2 - 1));
 
     if !path.is_empty() {
         return Path("").push_many(path);

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -64,7 +64,7 @@ fn lookup_hash(d: ebml::Doc, eq_fn: fn(x:&[u8]) -> bool, hash: uint) ->
     let belt = tag_index_buckets_bucket_elt;
     for reader::tagged_docs(tagged_doc.doc, belt) |elt| {
         let pos = io::u64_from_be_bytes(*elt.data, elt.start, 4u) as uint;
-        if eq_fn(vec::view(*elt.data, elt.start + 4u, elt.end)) {
+        if eq_fn(vec::slice(*elt.data, elt.start + 4u, elt.end)) {
             return Some(reader::doc_at(d.data, pos).doc);
         }
     };
@@ -75,7 +75,8 @@ pub type GetCrateDataCb = &fn(ast::crate_num) -> cmd;
 
 pub fn maybe_find_item(item_id: int, items: ebml::Doc) -> Option<ebml::Doc> {
     fn eq_item(bytes: &[u8], item_id: int) -> bool {
-        return io::u64_from_be_bytes(vec::view(bytes, 0u, 4u), 0u, 4u) as int
+        return io::u64_from_be_bytes(
+            vec::slice(bytes, 0u, 4u), 0u, 4u) as int
             == item_id;
     }
     lookup_hash(items,

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1147,7 +1147,7 @@ fn encode_crate_deps(ecx: @encode_ctxt,
         }
 
         // mut -> immutable hack for vec::map
-        return vec::slice(deps, 0u, vec::len(deps));
+        return vec::slice(deps, 0u, vec::len(deps)).to_vec();
     }
 
     // We're just going to write a list of crate 'name-hash-version's, with
@@ -1307,7 +1307,7 @@ pub fn encode_metadata(parms: encode_parms, crate: &crate) -> ~[u8] {
     //   vec::from_slice(metadata_encoding_version) +
 
     (do str::as_bytes(&~"rust\x00\x00\x00\x01") |bytes| {
-        vec::slice(*bytes, 0, 8)
+        vec::slice(*bytes, 0, 8).to_vec()
     }) + flate::deflate_bytes(wr.bytes.check_out(|buf| buf))
 }
 

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -493,8 +493,8 @@ pub fn parse_def_id(buf: &[u8]) -> ast::def_id {
         fail!();
     }
 
-    let crate_part = vec::view(buf, 0u, colon_idx);
-    let def_part = vec::view(buf, colon_idx + 1u, len);
+    let crate_part = vec::slice(buf, 0u, colon_idx);
+    let def_part = vec::slice(buf, colon_idx + 1u, len);
 
     let crate_num = match uint::parse_bytes(crate_part, 10u) {
        Some(cn) => cn as int,

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -372,9 +372,10 @@ pub fn expand_nested_bindings(bcx: block, m: &[@Match/&r],
         match br.pats[col].node {
             ast::pat_ident(_, path, Some(inner)) => {
                 let pats = vec::append(
-                    vec::slice(br.pats, 0u, col),
+                    vec::slice(br.pats, 0u, col).to_vec(),
                     vec::append(~[inner],
-                                vec::view(br.pats, col + 1u, br.pats.len())));
+                                vec::slice(br.pats, col + 1u,
+                                           br.pats.len())));
 
                 let binding_info =
                     br.data.bindings_map.get(&path_to_ident(path));
@@ -416,8 +417,8 @@ pub fn enter_match(bcx: block, dm: DefMap, m: &[@Match/&r],
             Some(sub) => {
                 let pats =
                     vec::append(
-                        vec::append(sub, vec::view(br.pats, 0u, col)),
-                        vec::view(br.pats, col + 1u, br.pats.len()));
+                        vec::append(sub, vec::slice(br.pats, 0u, col)),
+                        vec::slice(br.pats, col + 1u, br.pats.len()));
 
                 let self = br.pats[col];
                 match self.node {
@@ -1242,7 +1243,7 @@ pub fn compile_submatch(bcx: block,
         match data.arm.guard {
             Some(guard_expr) => {
                 bcx = compile_guard(bcx, guard_expr, m[0].data,
-                                    vec::view(m, 1, m.len()),
+                                    vec::slice(m, 1, m.len()),
                                     vals, chk);
             }
             _ => ()
@@ -1261,8 +1262,8 @@ pub fn compile_submatch(bcx: block,
         }
     };
 
-    let vals_left = vec::append(vec::slice(vals, 0u, col),
-                                vec::view(vals, col + 1u, vals.len()));
+    let vals_left = vec::append(vec::slice(vals, 0u, col).to_vec(),
+                                vec::slice(vals, col + 1u, vals.len()));
     let ccx = bcx.fcx.ccx;
     let mut pat_id = 0;
     for vec::each(m) |br| {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -484,8 +484,8 @@ pub fn revoke_clean(cx: block, val: ValueRef) {
             });
         for cleanup_pos.each |i| {
             scope_info.cleanups =
-                vec::append(vec::slice(scope_info.cleanups, 0u, *i),
-                            vec::view(scope_info.cleanups,
+                vec::append(vec::slice(scope_info.cleanups, 0u, *i).to_vec(),
+                            vec::slice(scope_info.cleanups,
                                       *i + 1u,
                                       scope_info.cleanups.len()));
             scope_clean_changed(scope_info);

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -561,7 +561,7 @@ pub fn combine_impl_and_methods_origins(bcx: block,
     let n_m_tps = method_ty_param_count(ccx, mth_did, impl_did);
     let {bounds: r_m_bounds, _} = ty::lookup_item_type(tcx, mth_did);
     let n_r_m_tps = r_m_bounds.len(); // rcvr + method tps
-    let m_boundss = vec::view(*r_m_bounds, n_r_m_tps - n_m_tps, n_r_m_tps);
+    let m_boundss = vec::slice(*r_m_bounds, n_r_m_tps - n_m_tps, n_r_m_tps);
 
     // Flatten out to find the number of vtables the method expects.
     let m_vtables = ty::count_traits_and_supertraits(tcx, m_boundss);

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -351,7 +351,7 @@ fn run_line(repl: &mut Repl, in: io::Reader, out: io::Writer, line: ~str)
 
             if !cmd.is_empty() {
                 let args = if len > 1 {
-                    vec::slice(split, 1, len)
+                    vec::slice(split, 1, len).to_vec()
                 } else { ~[] };
 
                 match run_cmd(repl, in, out, cmd, args) {

--- a/src/libstd/bigint.rs
+++ b/src/libstd/bigint.rs
@@ -216,8 +216,9 @@ impl Mul<BigUint, BigUint> for BigUint {
 
         pure fn cut_at(a: &BigUint, n: uint) -> (BigUint, BigUint) {
             let mid = uint::min(a.data.len(), n);
-            return (BigUint::from_slice(vec::view(a.data, mid, a.data.len())),
-                    BigUint::from_slice(vec::view(a.data, 0, mid)));
+            return (BigUint::from_slice(vec::slice(a.data, mid,
+                                                   a.data.len())),
+                    BigUint::from_slice(vec::slice(a.data, 0, mid)));
         }
 
         pure fn sub_sign(a: BigUint, b: BigUint) -> (int, BigUint) {
@@ -301,7 +302,7 @@ pub impl BigUint {
         let mut power: BigUint  = One::one();
         loop {
             let start = uint::max(end, unit_len) - unit_len;
-            match uint::parse_bytes(vec::view(buf, start, end), radix) {
+            match uint::parse_bytes(vec::slice(buf, start, end), radix) {
                 Some(d) => n += BigUint::from_uint(d) * power,
                 None    => return None
             }
@@ -380,7 +381,7 @@ pub impl BigUint {
                 return (Zero::zero(), Zero::zero(), copy *a);
             }
 
-            let an = vec::view(a.data, a.data.len() - n, a.data.len());
+            let an = vec::slice(a.data, a.data.len() - n, a.data.len());
             let bn = b.data.last();
             let mut d = ~[];
             let mut carry = 0;
@@ -487,7 +488,7 @@ pub impl BigUint {
         if n_unit == 0 { return self; }
         if self.data.len() < n_unit { return Zero::zero(); }
         return BigUint::from_slice(
-            vec::view(self.data, n_unit, self.data.len())
+            vec::slice(self.data, n_unit, self.data.len())
         );
     }
 
@@ -770,7 +771,7 @@ pub impl BigInt {
             sign  = Minus;
             start = 1;
         }
-        return BigUint::parse_bytes(vec::view(buf, start, buf.len()), radix)
+        return BigUint::parse_bytes(vec::slice(buf, start, buf.len()), radix)
             .map(|bu| BigInt::from_biguint(sign, *bu));
     }
 
@@ -885,7 +886,7 @@ mod biguint_tests {
         let data = [ &[], &[1], &[2], &[-1], &[0, 1], &[2, 1], &[1, 1, 1]  ]
             .map(|v| BigUint::from_slice(*v));
         for data.eachi |i, ni| {
-            for vec::view(data, i, data.len()).eachi |j0, nj| {
+            for vec::slice(data, i, data.len()).eachi |j0, nj| {
                 let j = j0 + i;
                 if i == j {
                     assert ni.cmp(nj) == 0;
@@ -1298,7 +1299,7 @@ mod bigint_tests {
         nums.push_all_move(vs.map(|s| BigInt::from_slice(Plus, *s)));
 
         for nums.eachi |i, ni| {
-            for vec::view(nums, i, nums.len()).eachi |j0, nj| {
+            for vec::slice(nums, i, nums.len()).eachi |j0, nj| {
                 let j = i + j0;
                 if i == j {
                     assert ni.cmp(nj) == 0;

--- a/src/libstd/ebml.rs
+++ b/src/libstd/ebml.rs
@@ -177,10 +177,12 @@ pub mod reader {
         }
     }
 
-    pub fn doc_data(d: Doc) -> ~[u8] { vec::slice::<u8>(*d.data, d.start,
-                                                        d.end) }
+    pub fn doc_data(d: Doc) -> ~[u8] {
+        vec::slice::<u8>(*d.data, d.start, d.end).to_vec()
+    }
+
     pub fn with_doc_data<T>(d: Doc, f: fn(x: &[u8]) -> T) -> T {
-        f(vec::view(*d.data, d.start, d.end))
+        f(vec::slice(*d.data, d.start, d.end))
     }
 
     pub fn doc_as_str(d: Doc) -> ~str { str::from_bytes(doc_data(d)) }

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -971,7 +971,8 @@ impl io::Writer for TcpSocketBuf {
             let w_result = write_common_impl(socket_data_ptr,
                                             vec::slice(data,
                                                        0,
-                                                       vec::len(data)));
+                                                       vec::len(data)
+                                                      ).to_vec());
             if w_result.is_err() {
                 let err_data = w_result.get_err();
                 log(debug,

--- a/src/libstd/sort.rs
+++ b/src/libstd/sort.rs
@@ -195,12 +195,12 @@ pub fn tim_sort<T: Copy Ord>(array: &mut [T]) {
     let mut idx = 0;
     let mut remaining = size;
     loop {
-        let arr = vec::mut_view(array, idx, size);
+        let arr = vec::mut_slice(array, idx, size);
         let mut run_len: uint = count_run_ascending(arr);
 
         if run_len < min_run {
             let force = if remaining <= min_run {remaining} else {min_run};
-            let slice = vec::mut_view(arr, 0, force);
+            let slice = vec::mut_slice(arr, 0, force);
             binarysort(slice, run_len);
             run_len = force;
         }
@@ -431,12 +431,12 @@ impl<T: Copy Ord> MergeState<T> {
                 arr[n+1].len = arr[n+2].len;
             }
 
-            let slice = vec::mut_view(array, b1, b1+l1);
+            let slice = vec::mut_slice(array, b1, b1+l1);
             let k = gallop_right(&const array[b2], slice, 0);
             b1 += k;
             l1 -= k;
             if l1 != 0 {
-                let slice = vec::mut_view(array, b2, b2+l2);
+                let slice = vec::mut_slice(array, b2, b2+l2);
                 let l2 = gallop_left(
                     &const array[b1+l1-1],slice,l2-1);
                 if l2 > 0 {
@@ -455,7 +455,8 @@ impl<T: Copy Ord> MergeState<T> {
                 base2: uint, len2: uint) {
         assert len1 != 0 && len2 != 0 && base1+len1 == base2;
 
-        let mut tmp = vec::slice(array, base1, base1+len1);
+        let tmp = vec::cast_to_mut(
+            vec::slice(array, base1, base1+len1).to_vec());
 
         let mut c1 = 0;
         let mut c2 = base2;
@@ -509,7 +510,7 @@ impl<T: Copy Ord> MergeState<T> {
             loop {
                 assert len1 > 1 && len2 != 0;
 
-                let tmp_view = vec::const_view(tmp, c1, c1+len1);
+                let tmp_view = vec::const_slice(tmp, c1, c1+len1);
                 count1 = gallop_right(&const array[c2], tmp_view, 0);
                 if count1 != 0 {
                     copy_vec(array, dest, tmp, c1, count1);
@@ -520,7 +521,7 @@ impl<T: Copy Ord> MergeState<T> {
                 dest += 1; c2 += 1; len2 -= 1;
                 if len2 == 0 { break_outer = true; break; }
 
-                let tmp_view = vec::const_view(array, c2, c2+len2);
+                let tmp_view = vec::const_slice(array, c2, c2+len2);
                 count2 = gallop_left(&const tmp[c1], tmp_view, 0);
                 if count2 != 0 {
                     copy_vec(array, dest, array, c2, count2);
@@ -558,7 +559,8 @@ impl<T: Copy Ord> MergeState<T> {
                 base2: uint, len2: uint) {
         assert len1 != 1 && len2 != 0 && base1 + len1 == base2;
 
-        let mut tmp = vec::slice(array, base2, base2+len2);
+        let tmp = vec::cast_to_mut(
+            vec::slice(array, base2, base2+len2).to_vec());
 
         let mut c1 = base1 + len1 - 1;
         let mut c2 = len2 - 1;
@@ -614,7 +616,7 @@ impl<T: Copy Ord> MergeState<T> {
             loop {
                 assert len2 > 1 && len1 != 0;
 
-                let tmp_view = vec::mut_view(array, base1, base1+len1);
+                let tmp_view = vec::mut_slice(array, base1, base1+len1);
                 count1 = len1 - gallop_right(
                     &const tmp[c2], tmp_view, len1-1);
 
@@ -630,7 +632,7 @@ impl<T: Copy Ord> MergeState<T> {
 
                 let count2;
                 {
-                    let tmp_view = vec::mut_view(tmp, 0, len2);
+                    let tmp_view = vec::mut_slice(tmp, 0, len2);
                     count2 = len2 - gallop_left(&const array[c1],
                                                 tmp_view,
                                                 len2-1);
@@ -710,7 +712,7 @@ fn copy_vec<T: Copy>(dest: &mut [T], s1: uint,
                     from: &[const T], s2: uint, len: uint) {
     assert s1+len <= dest.len() && s2+len <= from.len();
 
-    let slice = vec::slice(from, s2, s2+len);
+    let slice = vec::slice(from, s2, s2+len).to_vec();
     for slice.eachi |i, v| {
         dest[s1+i] = *v;
     }
@@ -1087,7 +1089,7 @@ mod big_tests {
             isSorted(arr);
 
             let mut arr = if n > 4 {
-                let part = vec::view(arr, 0, 4);
+                let part = vec::slice(arr, 0, 4);
                 multiplyVec(part, n)
             } else { move arr };
             tim_sort(arr); // ~sort
@@ -1159,7 +1161,7 @@ mod big_tests {
             isSorted(arr);
 
             let mut arr = if n > 4 {
-                let part = vec::view(arr, 0, 4);
+                let part = vec::slice(arr, 0, 4);
                 multiplyVec(part, n)
             } else { move arr };
             tim_sort(arr); // ~sort

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -231,7 +231,7 @@ fn highlight_lines(cm: @codemap::CodeMap,
     let mut elided = false;
     let mut display_lines = /* FIXME (#2543) */ copy lines.lines;
     if vec::len(display_lines) > max_lines {
-        display_lines = vec::slice(display_lines, 0u, max_lines);
+        display_lines = vec::slice(display_lines, 0u, max_lines).to_vec();
         elided = true;
     }
     // Print the offending lines

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -24,7 +24,7 @@ macro_rules! bench (
 
 fn main() {
     let argv = os::args();
-    let tests = vec::view(argv, 1, argv.len());
+    let tests = vec::slice(argv, 1, argv.len());
 
     bench!(shift_push);
     bench!(read_line);

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -77,7 +77,7 @@ fn find(mm: HashMap<~[u8], uint>, key: ~str) -> uint {
 
 // given a map, increment the counter for a key
 fn update_freq(mm: HashMap<~[u8], uint>, key: &[u8]) {
-    let key = vec::slice(key, 0, key.len());
+    let key = vec::slice(key, 0, key.len()).to_vec();
     mm.update(key, 1, |v,v1| { v+v1 });
 }
 
@@ -90,11 +90,11 @@ fn windows_with_carry(bb: &[u8], nn: uint,
 
    let len = vec::len(bb);
    while ii < len - (nn - 1u) {
-      it(vec::view(bb, ii, ii+nn));
+      it(vec::slice(bb, ii, ii+nn));
       ii += 1u;
    }
 
-   return vec::slice(bb, len - (nn - 1u), len);
+   return vec::slice(bb, len - (nn - 1u), len).to_vec();
 }
 
 fn make_sequence_processor(sz: uint, from_parent: pipes::Port<~[u8]>,

--- a/src/test/run-pass/issue-3888-2.rs
+++ b/src/test/run-pass/issue-3888-2.rs
@@ -10,8 +10,8 @@
 
 fn vec_peek<T>(v: &r/[T]) -> &r/[T] {
 // This doesn't work, and should.
-//    v.view(1, 5)
-    vec::view(v, 1, 5)
+//    v.slice(1, 5)
+    vec::slice(v, 1, 5)
 }
 
 pub fn main() {}


### PR DESCRIPTION
Issue #3869
review? @nikomatsakis 

Convert all uses of vec::slice to vec::view Issue #3869
Rename const_view to const_slice
Renamed mut_view to mut_slice
Fix windows build error.  `buf` is borrowed by the call to
`as_mut_buf()` and so we must invoke `slice()` outside of that
call.
