### PR TITLE
libsyntax: Cleanup pipes syntax extension.

### DIFF
--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -67,57 +67,57 @@ pub impl append_types for @ast::path {
 }
 
 pub trait ext_ctxt_ast_builder {
-    fn ty_param(id: ast::ident, +bounds: ~[ast::ty_param_bound])
+    fn ty_param(&self, id: ast::ident, +bounds: ~[ast::ty_param_bound])
         -> ast::ty_param;
-    fn arg(name: ident, ty: @ast::Ty) -> ast::arg;
-    fn expr_block(e: @ast::expr) -> ast::blk;
-    fn fn_decl(+inputs: ~[ast::arg], output: @ast::Ty) -> ast::fn_decl;
-    fn item(name: ident, span: span, +node: ast::item_) -> @ast::item;
-    fn item_fn_poly(name: ident,
+    fn arg(&self, name: ident, ty: @ast::Ty) -> ast::arg;
+    fn expr_block(&self, e: @ast::expr) -> ast::blk;
+    fn fn_decl(&self, +inputs: ~[ast::arg], output: @ast::Ty) -> ast::fn_decl;
+    fn item(&self, name: ident, span: span, +node: ast::item_) -> @ast::item;
+    fn item_fn_poly(&self, name: ident,
                     +inputs: ~[ast::arg],
                     output: @ast::Ty,
                     +ty_params: ~[ast::ty_param],
                     +body: ast::blk) -> @ast::item;
-    fn item_fn(name: ident,
+    fn item_fn(&self, name: ident,
                +inputs: ~[ast::arg],
                output: @ast::Ty,
                +body: ast::blk) -> @ast::item;
-    fn item_enum_poly(name: ident,
+    fn item_enum_poly(&self, name: ident,
                       span: span,
                       +enum_definition: ast::enum_def,
                       +ty_params: ~[ast::ty_param]) -> @ast::item;
-    fn item_enum(name: ident, span: span,
+    fn item_enum(&self, name: ident, span: span,
                  +enum_definition: ast::enum_def) -> @ast::item;
-    fn item_struct_poly(name: ident, span: span,
+    fn item_struct_poly(&self, name: ident, span: span,
                         struct_def: ast::struct_def,
                         ty_params: ~[ast::ty_param]) -> @ast::item;
-    fn item_struct(name: ident, span: span,
+    fn item_struct(&self, name: ident, span: span,
                    struct_def: ast::struct_def) -> @ast::item;
-    fn struct_expr(path: @ast::path, fields: ~[ast::field]) -> @ast::expr;
-    fn variant(name: ident, span: span, +tys: ~[@ast::Ty]) -> ast::variant;
-    fn item_mod(name: ident, span: span, +items: ~[@ast::item]) -> @ast::item;
-    fn ty_path_ast_builder(path: @ast::path) -> @ast::Ty;
-    fn item_ty_poly(name: ident,
+    fn struct_expr(&self, path: @ast::path, fields: ~[ast::field]) -> @ast::expr;
+    fn variant(&self, name: ident, span: span, +tys: ~[@ast::Ty]) -> ast::variant;
+    fn item_mod(&self, name: ident, span: span, +items: ~[@ast::item]) -> @ast::item;
+    fn ty_path_ast_builder(&self, path: @ast::path) -> @ast::Ty;
+    fn item_ty_poly(&self, name: ident,
                     span: span,
                     ty: @ast::Ty,
                     +params: ~[ast::ty_param]) -> @ast::item;
-    fn item_ty(name: ident, span: span, ty: @ast::Ty) -> @ast::item;
-    fn ty_vars(+ty_params: ~[ast::ty_param]) -> ~[@ast::Ty];
-    fn ty_vars_global(+ty_params: ~[ast::ty_param]) -> ~[@ast::Ty];
-    fn ty_field_imm(name: ident, ty: @ast::Ty) -> ast::ty_field;
-    fn field_imm(name: ident, e: @ast::expr) -> ast::field;
-    fn block(+stmts: ~[@ast::stmt], e: @ast::expr) -> ast::blk;
-    fn stmt_let(ident: ident, e: @ast::expr) -> @ast::stmt;
-    fn stmt_expr(e: @ast::expr) -> @ast::stmt;
-    fn block_expr(b: ast::blk) -> @ast::expr;
-    fn ty_option(ty: @ast::Ty) -> @ast::Ty;
-    fn ty_infer() -> @ast::Ty;
-    fn ty_nil_ast_builder() -> @ast::Ty;
-    fn strip_bounds(bounds: &[ast::ty_param]) -> ~[ast::ty_param];
+    fn item_ty(&self, name: ident, span: span, ty: @ast::Ty) -> @ast::item;
+    fn ty_vars(&self, +ty_params: ~[ast::ty_param]) -> ~[@ast::Ty];
+    fn ty_vars_global(&self, +ty_params: ~[ast::ty_param]) -> ~[@ast::Ty];
+    fn ty_field_imm(&self, name: ident, ty: @ast::Ty) -> ast::ty_field;
+    fn field_imm(&self, name: ident, e: @ast::expr) -> ast::field;
+    fn block(&self, +stmts: ~[@ast::stmt], e: @ast::expr) -> ast::blk;
+    fn stmt_let(&self, ident: ident, e: @ast::expr) -> @ast::stmt;
+    fn stmt_expr(&self, e: @ast::expr) -> @ast::stmt;
+    fn block_expr(&self, b: ast::blk) -> @ast::expr;
+    fn ty_option(&self, ty: @ast::Ty) -> @ast::Ty;
+    fn ty_infer(&self) -> @ast::Ty;
+    fn ty_nil_ast_builder(&self) -> @ast::Ty;
+    fn strip_bounds(&self, bounds: &[ast::ty_param]) -> ~[ast::ty_param];
 }
 
 pub impl ext_ctxt_ast_builder for ext_ctxt {
-    fn ty_option(ty: @ast::Ty) -> @ast::Ty {
+    fn ty_option(&self, ty: @ast::Ty) -> @ast::Ty {
         self.ty_path_ast_builder(path_global(~[
             self.ident_of(~"core"),
             self.ident_of(~"option"),
@@ -125,7 +125,7 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         ], dummy_sp()).add_ty(ty))
     }
 
-    fn block_expr(b: ast::blk) -> @ast::expr {
+    fn block_expr(&self, b: ast::blk) -> @ast::expr {
         @expr {
             id: self.next_id(),
             callee_id: self.next_id(),
@@ -134,24 +134,24 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         }
     }
 
-    fn stmt_expr(e: @ast::expr) -> @ast::stmt {
+    fn stmt_expr(&self, e: @ast::expr) -> @ast::stmt {
         @spanned { node: ast::stmt_expr(e, self.next_id()),
                    span: dummy_sp()}
     }
 
-    fn stmt_let(ident: ident, e: @ast::expr) -> @ast::stmt {
-        let ext_cx = self;
+    fn stmt_let(&self, ident: ident, e: @ast::expr) -> @ast::stmt {
+        let ext_cx = *self;
         quote_stmt!( let $ident = $e; )
     }
 
-    fn field_imm(name: ident, e: @ast::expr) -> ast::field {
+    fn field_imm(&self, name: ident, e: @ast::expr) -> ast::field {
         spanned {
             node: ast::field_ { mutbl: ast::m_imm, ident: name, expr: e },
             span: dummy_sp(),
         }
     }
 
-    fn ty_field_imm(name: ident, ty: @ast::Ty) -> ast::ty_field {
+    fn ty_field_imm(&self, name: ident, ty: @ast::Ty) -> ast::ty_field {
         spanned {
             node: ast::ty_field_ {
                 ident: name,
@@ -161,7 +161,7 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         }
     }
 
-    fn ty_infer() -> @ast::Ty {
+    fn ty_infer(&self) -> @ast::Ty {
         @ast::Ty {
             id: self.next_id(),
             node: ast::ty_infer,
@@ -169,13 +169,13 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         }
     }
 
-    fn ty_param(id: ast::ident, +bounds: ~[ast::ty_param_bound])
+    fn ty_param(&self, id: ast::ident, +bounds: ~[ast::ty_param_bound])
         -> ast::ty_param
     {
         ast::ty_param { ident: id, id: self.next_id(), bounds: @bounds }
     }
 
-    fn arg(name: ident, ty: @ast::Ty) -> ast::arg {
+    fn arg(&self, name: ident, ty: @ast::Ty) -> ast::arg {
         ast::arg {
             mode: ast::infer(self.next_id()),
             is_mutbl: false,
@@ -192,7 +192,7 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         }
     }
 
-    fn block(+stmts: ~[@ast::stmt], e: @ast::expr) -> ast::blk {
+    fn block(&self, +stmts: ~[@ast::stmt], e: @ast::expr) -> ast::blk {
         let blk = ast::blk_ {
             view_items: ~[],
             stmts: stmts,
@@ -204,11 +204,11 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         spanned { node: blk, span: dummy_sp() }
     }
 
-    fn expr_block(e: @ast::expr) -> ast::blk {
+    fn expr_block(&self, e: @ast::expr) -> ast::blk {
         self.block(~[], e)
     }
 
-    fn fn_decl(+inputs: ~[ast::arg],
+    fn fn_decl(&self, +inputs: ~[ast::arg],
                output: @ast::Ty) -> ast::fn_decl {
         ast::fn_decl {
             inputs: inputs,
@@ -217,8 +217,7 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         }
     }
 
-    fn item(name: ident,
-            span: span,
+    fn item(&self, name: ident, span: span,
             +node: ast::item_) -> @ast::item {
 
         // XXX: Would be nice if our generated code didn't violate
@@ -241,7 +240,7 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
                      span: span }
     }
 
-    fn item_fn_poly(name: ident,
+    fn item_fn_poly(&self, name: ident,
                     +inputs: ~[ast::arg],
                     output: @ast::Ty,
                     +ty_params: ~[ast::ty_param],
@@ -254,37 +253,36 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
                                body))
     }
 
-    fn item_fn(name: ident,
+    fn item_fn(&self, name: ident,
                +inputs: ~[ast::arg],
                output: @ast::Ty,
                +body: ast::blk) -> @ast::item {
         self.item_fn_poly(name, inputs, output, ~[], body)
     }
 
-    fn item_enum_poly(name: ident,
-                      span: span,
+    fn item_enum_poly(&self, name: ident, span: span,
                       +enum_definition: ast::enum_def,
                       +ty_params: ~[ast::ty_param]) -> @ast::item {
         self.item(name, span, ast::item_enum(enum_definition, ty_params))
     }
 
-    fn item_enum(name: ident, span: span,
+    fn item_enum(&self, name: ident, span: span,
                  +enum_definition: ast::enum_def) -> @ast::item {
         self.item_enum_poly(name, span, enum_definition, ~[])
     }
 
-    fn item_struct(name: ident, span: span,
+    fn item_struct(&self, name: ident, span: span,
                    struct_def: ast::struct_def) -> @ast::item {
         self.item_struct_poly(name, span, struct_def, ~[])
     }
 
-    fn item_struct_poly(name: ident, span: span,
+    fn item_struct_poly(&self, name: ident, span: span,
                         struct_def: ast::struct_def,
                         ty_params: ~[ast::ty_param]) -> @ast::item {
         self.item(name, span, ast::item_struct(@struct_def, ty_params))
     }
 
-    fn struct_expr(path: @ast::path, fields: ~[ast::field]) -> @ast::expr {
+    fn struct_expr(&self, path: @ast::path, fields: ~[ast::field]) -> @ast::expr {
         @ast::expr {
             id: self.next_id(),
             callee_id: self.next_id(),
@@ -293,8 +291,7 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         }
     }
 
-    fn variant(name: ident,
-               span: span,
+    fn variant(&self, name: ident, span: span,
                +tys: ~[@ast::Ty]) -> ast::variant {
         let args = do tys.map |ty| {
             ast::variant_arg { ty: *ty, id: self.next_id() }
@@ -313,9 +310,9 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         }
     }
 
-    fn item_mod(name: ident,
-                span: span,
+    fn item_mod(&self, name: ident, span: span,
                 +items: ~[@ast::item]) -> @ast::item {
+
         // XXX: Total hack: import `core::kinds::Owned` to work around a
         // parser bug whereby `fn f<T: ::kinds::Owned>` doesn't parse.
         let vi = ast::view_item_import(~[
@@ -353,7 +350,7 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         )
     }
 
-    fn ty_path_ast_builder(path: @ast::path) -> @ast::Ty {
+    fn ty_path_ast_builder(&self, path: @ast::path) -> @ast::Ty {
         @ast::Ty {
             id: self.next_id(),
             node: ast::ty_path(path, self.next_id()),
@@ -361,7 +358,7 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         }
     }
 
-    fn ty_nil_ast_builder() -> @ast::Ty {
+    fn ty_nil_ast_builder(&self) -> @ast::Ty {
         @ast::Ty {
             id: self.next_id(),
             node: ast::ty_nil,
@@ -369,29 +366,27 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         }
     }
 
-    fn strip_bounds(bounds: &[ast::ty_param]) -> ~[ast::ty_param] {
+    fn strip_bounds(&self, bounds: &[ast::ty_param]) -> ~[ast::ty_param] {
         do bounds.map |ty_param| {
             ast::ty_param { bounds: @~[], ..copy *ty_param }
         }
     }
 
-    fn item_ty_poly(name: ident,
-                    span: span,
-                    ty: @ast::Ty,
+    fn item_ty_poly(&self, name: ident, span: span, ty: @ast::Ty,
                     +params: ~[ast::ty_param]) -> @ast::item {
         self.item(name, span, ast::item_ty(ty, params))
     }
 
-    fn item_ty(name: ident, span: span, ty: @ast::Ty) -> @ast::item {
+    fn item_ty(&self, name: ident, span: span, ty: @ast::Ty) -> @ast::item {
         self.item_ty_poly(name, span, ty, ~[])
     }
 
-    fn ty_vars(+ty_params: ~[ast::ty_param]) -> ~[@ast::Ty] {
+    fn ty_vars(&self, +ty_params: ~[ast::ty_param]) -> ~[@ast::Ty] {
         ty_params.map(|p| self.ty_path_ast_builder(
             path(~[p.ident], dummy_sp())))
     }
 
-    fn ty_vars_global(+ty_params: ~[ast::ty_param]) -> ~[@ast::Ty] {
+    fn ty_vars_global(&self, +ty_params: ~[ast::ty_param]) -> ~[@ast::Ty] {
         ty_params.map(|p| self.ty_path_ast_builder(
             path(~[p.ident], dummy_sp())))
     }

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -93,9 +93,12 @@ pub trait ext_ctxt_ast_builder {
                         ty_params: ~[ast::ty_param]) -> @ast::item;
     fn item_struct(&self, name: ident, span: span,
                    struct_def: ast::struct_def) -> @ast::item;
-    fn struct_expr(&self, path: @ast::path, fields: ~[ast::field]) -> @ast::expr;
-    fn variant(&self, name: ident, span: span, +tys: ~[@ast::Ty]) -> ast::variant;
-    fn item_mod(&self, name: ident, span: span, +items: ~[@ast::item]) -> @ast::item;
+    fn struct_expr(&self, path: @ast::path,
+                   fields: ~[ast::field]) -> @ast::expr;
+    fn variant(&self, name: ident, span: span,
+               +tys: ~[@ast::Ty]) -> ast::variant;
+    fn item_mod(&self, name: ident, span: span,
+                +items: ~[@ast::item]) -> @ast::item;
     fn ty_path_ast_builder(&self, path: @ast::path) -> @ast::Ty;
     fn item_ty_poly(&self, name: ident,
                     span: span,
@@ -282,7 +285,8 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         self.item(name, span, ast::item_struct(@struct_def, ty_params))
     }
 
-    fn struct_expr(&self, path: @ast::path, fields: ~[ast::field]) -> @ast::expr {
+    fn struct_expr(&self, path: @ast::path,
+                   fields: ~[ast::field]) -> @ast::expr {
         @ast::expr {
             id: self.next_id(),
             callee_id: self.next_id(),

--- a/src/libsyntax/ext/pipes/check.rs
+++ b/src/libsyntax/ext/pipes/check.rs
@@ -38,10 +38,10 @@ use ext::pipes::proto::{state, protocol, next_state};
 use ext::pipes::proto;
 
 pub impl proto::visitor<(), (), ()> for ext_ctxt {
-    fn visit_proto(_proto: protocol,
+    fn visit_proto(&self, _proto: protocol,
                    _states: &[()]) { }
 
-    fn visit_state(state: state, _m: &[()]) {
+    fn visit_state(&self, state: state, _m: &[()]) {
         if state.messages.len() == 0 {
             self.span_warn(
                 state.span, // use a real span!
@@ -51,7 +51,7 @@ pub impl proto::visitor<(), (), ()> for ext_ctxt {
         }
     }
 
-    fn visit_message(name: ~str, _span: span, _tys: &[@ast::Ty],
+    fn visit_message(&self, name: ~str, _span: span, _tys: &[@ast::Ty],
                      this: state, next: Option<next_state>) {
         match next {
           Some(next_state { state: ref next, tys: next_tys }) => {

--- a/src/libsyntax/ext/pipes/parse_proto.rs
+++ b/src/libsyntax/ext/pipes/parse_proto.rs
@@ -17,13 +17,13 @@ use parse::token;
 use core::prelude::*;
 
 pub trait proto_parser {
-    fn parse_proto(id: ~str) -> protocol;
-    fn parse_state(proto: protocol);
-    fn parse_message(state: state);
+    fn parse_proto(&self, id: ~str) -> protocol;
+    fn parse_state(&self, proto: protocol);
+    fn parse_message(&self, state: state);
 }
 
 pub impl proto_parser for parser::Parser {
-    fn parse_proto(id: ~str) -> protocol {
+    fn parse_proto(&self, id: ~str) -> protocol {
         let proto = protocol(id, self.span);
 
         self.parse_seq_to_before_end(token::EOF,
@@ -33,7 +33,7 @@ pub impl proto_parser for parser::Parser {
         return proto;
     }
 
-    fn parse_state(proto: protocol) {
+    fn parse_state(&self, proto: protocol) {
         let id = self.parse_ident();
         let name = *self.interner.get(id);
 
@@ -63,7 +63,7 @@ pub impl proto_parser for parser::Parser {
             |self| self.parse_message(state));
     }
 
-    fn parse_message(state: state) {
+    fn parse_message(&self, state: state) {
         let mname = *self.interner.get(self.parse_ident());
 
         let args = if self.token == token::LPAREN {

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -345,7 +345,9 @@ pub impl gen_init for protocol {
     }
 
     fn gen_buffer_init(ext_cx: ext_ctxt) -> @ast::expr {
-        ext_cx.rec(self.states.map_to_vec(|s| {
+        ext_cx.struct_expr(path(~[ext_cx.ident_of(~"__Buffer")],
+                                dummy_sp()),
+                      self.states.map_to_vec(|s| {
             let fty = s.to_ty(ext_cx);
             ext_cx.field_imm(ext_cx.ident_of(s.name),
                              quote_expr!(
@@ -409,13 +411,27 @@ pub impl gen_init for protocol {
             let ty = s.to_ty(cx);
             let fty = quote_ty!( ::pipes::Packet<$ty> );
 
-            cx.ty_field_imm(cx.ident_of(s.name), fty)
+            @spanned {
+                node: ast::struct_field_ {
+                    kind: ast::named_field(
+                            cx.ident_of(s.name),
+                            ast::struct_immutable,
+                            ast::inherited),
+                    id: cx.next_id(),
+                    ty: fty
+                },
+                span: dummy_sp()
+            }
         };
 
-        cx.item_ty_poly(
+        cx.item_struct_poly(
             cx.ident_of(~"__Buffer"),
             dummy_sp(),
-            cx.ty_rec(fields),
+            ast::struct_def {
+                fields: fields,
+                dtor: None,
+                ctor_id: None
+            },
             cx.strip_bounds(params))
     }
 

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -27,28 +27,28 @@ use core::to_str::ToStr;
 use core::vec;
 
 pub trait gen_send {
-    fn gen_send(cx: ext_ctxt, try: bool) -> @ast::item;
-    fn to_ty(cx: ext_ctxt) -> @ast::Ty;
+    fn gen_send(&self, cx: ext_ctxt, try: bool) -> @ast::item;
+    fn to_ty(&self, cx: ext_ctxt) -> @ast::Ty;
 }
 
 pub trait to_type_decls {
-    fn to_type_decls(cx: ext_ctxt) -> ~[@ast::item];
-    fn to_endpoint_decls(cx: ext_ctxt, dir: direction) -> ~[@ast::item];
+    fn to_type_decls(&self, cx: ext_ctxt) -> ~[@ast::item];
+    fn to_endpoint_decls(&self, cx: ext_ctxt, dir: direction) -> ~[@ast::item];
 }
 
 pub trait gen_init {
-    fn gen_init(cx: ext_ctxt) -> @ast::item;
-    fn compile(cx: ext_ctxt) -> @ast::item;
-    fn buffer_ty_path(cx: ext_ctxt) -> @ast::Ty;
-    fn gen_buffer_type(cx: ext_ctxt) -> @ast::item;
-    fn gen_buffer_init(ext_cx: ext_ctxt) -> @ast::expr;
-    fn gen_init_bounded(ext_cx: ext_ctxt) -> @ast::expr;
+    fn gen_init(&self, cx: ext_ctxt) -> @ast::item;
+    fn compile(&self, cx: ext_ctxt) -> @ast::item;
+    fn buffer_ty_path(&self, cx: ext_ctxt) -> @ast::Ty;
+    fn gen_buffer_type(&self, cx: ext_ctxt) -> @ast::item;
+    fn gen_buffer_init(&self, ext_cx: ext_ctxt) -> @ast::expr;
+    fn gen_init_bounded(&self, ext_cx: ext_ctxt) -> @ast::expr;
 }
 
 pub impl gen_send for message {
-    fn gen_send(cx: ext_ctxt, try: bool) -> @ast::item {
+    fn gen_send(&self, cx: ext_ctxt, try: bool) -> @ast::item {
         debug!("pipec: gen_send");
-        match self {
+        match *self {
           message(ref _id, span, tys, this,
                   Some(next_state {state: ref next, tys: next_tys})) => {
             debug!("pipec: next state exists");
@@ -195,14 +195,14 @@ pub impl gen_send for message {
           }
         }
 
-    fn to_ty(cx: ext_ctxt) -> @ast::Ty {
+    fn to_ty(&self, cx: ext_ctxt) -> @ast::Ty {
         cx.ty_path_ast_builder(path(~[cx.ident_of(self.name())], self.span())
           .add_tys(cx.ty_vars_global(self.get_params())))
     }
 }
 
 pub impl to_type_decls for state {
-    fn to_type_decls(cx: ext_ctxt) -> ~[@ast::item] {
+    fn to_type_decls(&self, cx: ext_ctxt) -> ~[@ast::item] {
         debug!("pipec: to_type_decls");
         // This compiles into two different type declarations. Say the
         // state is called ping. This will generate both `ping` and
@@ -253,7 +253,7 @@ pub impl to_type_decls for state {
         ]
     }
 
-    fn to_endpoint_decls(cx: ext_ctxt, dir: direction) -> ~[@ast::item] {
+    fn to_endpoint_decls(&self, cx: ext_ctxt, dir: direction) -> ~[@ast::item] {
         debug!("pipec: to_endpoint_decls");
         let dir = match dir {
           send => (*self).dir,
@@ -306,7 +306,7 @@ pub impl to_type_decls for state {
 }
 
 pub impl gen_init for protocol {
-    fn gen_init(cx: ext_ctxt) -> @ast::item {
+    fn gen_init(&self, cx: ext_ctxt) -> @ast::item {
         let ext_cx = cx;
 
         debug!("gen_init");
@@ -344,7 +344,7 @@ pub impl gen_init for protocol {
                            body.to_source(cx)))
     }
 
-    fn gen_buffer_init(ext_cx: ext_ctxt) -> @ast::expr {
+    fn gen_buffer_init(&self, ext_cx: ext_ctxt) -> @ast::expr {
         ext_cx.struct_expr(path(~[ext_cx.ident_of(~"__Buffer")],
                                 dummy_sp()),
                       self.states.map_to_vec(|s| {
@@ -356,7 +356,7 @@ pub impl gen_init for protocol {
         }))
     }
 
-    fn gen_init_bounded(ext_cx: ext_ctxt) -> @ast::expr {
+    fn gen_init_bounded(&self, ext_cx: ext_ctxt) -> @ast::expr {
         debug!("gen_init_bounded");
         let buffer_fields = self.gen_buffer_init(ext_cx);
         let buffer = quote_expr!(~::pipes::Buffer {
@@ -382,7 +382,7 @@ pub impl gen_init for protocol {
         })
     }
 
-    fn buffer_ty_path(cx: ext_ctxt) -> @ast::Ty {
+    fn buffer_ty_path(&self, cx: ext_ctxt) -> @ast::Ty {
         let mut params: ~[ast::ty_param] = ~[];
         for (copy self.states).each |s| {
             for s.ty_params.each |tp| {
@@ -398,7 +398,7 @@ pub impl gen_init for protocol {
                                .add_tys(cx.ty_vars_global(params)))
     }
 
-    fn gen_buffer_type(cx: ext_ctxt) -> @ast::item {
+    fn gen_buffer_type(&self, cx: ext_ctxt) -> @ast::item {
         let ext_cx = cx;
         let mut params: ~[ast::ty_param] = ~[];
         let fields = do (copy self.states).map_to_vec |s| {
@@ -435,7 +435,7 @@ pub impl gen_init for protocol {
             cx.strip_bounds(params))
     }
 
-    fn compile(cx: ext_ctxt) -> @ast::item {
+    fn compile(&self, cx: ext_ctxt) -> @ast::item {
         let mut items = ~[self.gen_init(cx)];
         let mut client_states = ~[];
         let mut server_states = ~[];

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -33,7 +33,8 @@ pub trait gen_send {
 
 pub trait to_type_decls {
     fn to_type_decls(&self, cx: ext_ctxt) -> ~[@ast::item];
-    fn to_endpoint_decls(&self, cx: ext_ctxt, dir: direction) -> ~[@ast::item];
+    fn to_endpoint_decls(&self, cx: ext_ctxt,
+                         dir: direction) -> ~[@ast::item];
 }
 
 pub trait gen_init {
@@ -253,7 +254,8 @@ pub impl to_type_decls for state {
         ]
     }
 
-    fn to_endpoint_decls(&self, cx: ext_ctxt, dir: direction) -> ~[@ast::item] {
+    fn to_endpoint_decls(&self, cx: ext_ctxt,
+                         dir: direction) -> ~[@ast::item] {
         debug!("pipec: to_endpoint_decls");
         let dir = match dir {
           send => (*self).dir,

--- a/src/libsyntax/ext/pipes/proto.rs
+++ b/src/libsyntax/ext/pipes/proto.rs
@@ -19,19 +19,8 @@ use core::cmp;
 use core::dvec::DVec;
 use core::to_str::ToStr;
 
+#[deriving_eq]
 pub enum direction { send, recv }
-
-pub impl cmp::Eq for direction {
-    pure fn eq(&self, other: &direction) -> bool {
-        match ((*self), (*other)) {
-            (send, send) => true,
-            (recv, recv) => true,
-            (send, _) => false,
-            (recv, _) => false,
-        }
-    }
-    pure fn ne(&self, other: &direction) -> bool { !(*self).eq(other) }
-}
 
 pub impl ToStr for direction {
     pure fn to_str(&self) -> ~str {
@@ -82,36 +71,36 @@ pub impl message {
     }
 }
 
-pub enum state {
-    state_(@{
-        id: uint,
-        name: ~str,
-        ident: ast::ident,
-        span: span,
-        dir: direction,
-        ty_params: ~[ast::ty_param],
-        messages: DVec<message>,
-        proto: protocol,
-    }),
+pub type state = @state_;
+
+pub struct state_ {
+    id: uint,
+    name: ~str,
+    ident: ast::ident,
+    span: span,
+    dir: direction,
+    ty_params: ~[ast::ty_param],
+    messages: DVec<message>,
+    proto: protocol
 }
 
-pub impl state {
-    fn add_message(name: ~str, span: span,
+pub impl state_ {
+    fn add_message(@self, name: ~str, span: span,
                    +data: ~[@ast::Ty], next: Option<next_state>) {
         self.messages.push(message(name, span, data, self,
                                    next));
     }
 
-    fn filename() -> ~str {
-        (*self).proto.filename()
+    fn filename(&self) -> ~str {
+        self.proto.filename()
     }
 
-    fn data_name() -> ast::ident {
+    fn data_name(&self) -> ast::ident {
         self.ident
     }
 
     /// Returns the type that is used for the messages.
-    fn to_ty(cx: ext_ctxt) -> @ast::Ty {
+    fn to_ty(&self, cx: ext_ctxt) -> @ast::Ty {
         cx.ty_path_ast_builder
             (path(~[cx.ident_of(self.name)],self.span).add_tys(
                 cx.ty_vars(self.ty_params)))
@@ -119,7 +108,7 @@ pub impl state {
 
     /// Iterate over the states that can be reached in one message
     /// from this state.
-    fn reachable(f: fn(state) -> bool) {
+    fn reachable(&self, f: fn(state) -> bool) {
         for self.messages.each |m| {
             match *m {
               message(_, _, _, _, Some(next_state { state: ref id, _ })) => {
@@ -199,7 +188,7 @@ pub impl protocol {
                       +ty_params: ~[ast::ty_param]) -> state {
         let messages = DVec();
 
-        let state = state_(@{
+        let state = @state_ {
             id: self.states.len(),
             name: name,
             ident: ident,
@@ -208,7 +197,7 @@ pub impl protocol {
             ty_params: ty_params,
             messages: messages,
             proto: self
-        });
+        };
 
         self.states.push(state);
         state

--- a/src/libsyntax/ext/pipes/proto.rs
+++ b/src/libsyntax/ext/pipes/proto.rs
@@ -32,8 +32,8 @@ pub impl ToStr for direction {
 }
 
 pub impl direction {
-    fn reverse() -> direction {
-        match self {
+    fn reverse(&self) -> direction {
+        match *self {
           send => recv,
           recv => send
         }
@@ -51,21 +51,21 @@ pub enum message {
 }
 
 pub impl message {
-    fn name() -> ~str {
-        match self {
+    fn name(&self) -> ~str {
+        match *self {
           message(ref id, _, _, _, _) => (*id)
         }
     }
 
-    fn span() -> span {
-        match self {
+    fn span(&self) -> span {
+        match *self {
           message(_, span, _, _, _) => span
         }
     }
 
     /// Return the type parameters actually used by this message
-    fn get_params() -> ~[ast::ty_param] {
-        match self {
+    fn get_params(&self) -> ~[ast::ty_param] {
+        match *self {
           message(_, _, _, this, _) => this.ty_params
         }
     }
@@ -146,23 +146,23 @@ pub struct protocol_ {
 
 pub impl protocol_ {
     /// Get a state.
-    fn get_state(name: ~str) -> state {
+    fn get_state(&self, name: ~str) -> state {
         self.states.find(|i| i.name == name).get()
     }
 
-    fn get_state_by_id(id: uint) -> state { self.states[id] }
+    fn get_state_by_id(&self, id: uint) -> state { self.states[id] }
 
-    fn has_state(name: ~str) -> bool {
+    fn has_state(&self, name: ~str) -> bool {
         self.states.find(|i| i.name == name).is_some()
     }
 
-    fn filename() -> ~str {
+    fn filename(&self) -> ~str {
         ~"proto://" + self.name
     }
 
-    fn num_states() -> uint { self.states.len() }
+    fn num_states(&self) -> uint { self.states.len() }
 
-    fn has_ty_params() -> bool {
+    fn has_ty_params(&self) -> bool {
         for self.states.each |s| {
             if s.ty_params.len() > 0 {
                 return true;
@@ -170,21 +170,14 @@ pub impl protocol_ {
         }
         false
     }
-    fn is_bounded() -> bool {
+    fn is_bounded(&self) -> bool {
         let bounded = self.bounded.get();
         bounded
-        //if bounded && self.has_ty_params() {
-        //    debug!("protocol %s has is bounded, but type parameters\
-        //            are not yet supported.",
-        //           *self.name);
-        //    false
-        //}
-        //else { bounded }
     }
 }
 
 pub impl protocol {
-    fn add_state_poly(name: ~str, ident: ast::ident, dir: direction,
+    fn add_state_poly(&self, name: ~str, ident: ast::ident, dir: direction,
                       +ty_params: ~[ast::ty_param]) -> state {
         let messages = DVec();
 
@@ -196,7 +189,7 @@ pub impl protocol {
             dir: dir,
             ty_params: ty_params,
             messages: messages,
-            proto: self
+            proto: *self
         };
 
         self.states.push(state);
@@ -205,9 +198,9 @@ pub impl protocol {
 }
 
 pub trait visitor<Tproto, Tstate, Tmessage> {
-    fn visit_proto(proto: protocol, st: &[Tstate]) -> Tproto;
-    fn visit_state(state: state, m: &[Tmessage]) -> Tstate;
-    fn visit_message(name: ~str, spane: span, tys: &[@ast::Ty],
+    fn visit_proto(&self, proto: protocol, st: &[Tstate]) -> Tproto;
+    fn visit_state(&self, state: state, m: &[Tmessage]) -> Tstate;
+    fn visit_message(&self, name: ~str, spane: span, tys: &[@ast::Ty],
                      this: state, next: Option<next_state>) -> Tmessage;
 }
 


### PR DESCRIPTION
Removes the last use of structural records in the pipes extension and with that, libcore has no more structural records.
Also, explicit-self-ification.
