### PR TITLE
Partial work making libsyntax free of vecs_implicitly_copyable

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -466,14 +466,14 @@ pub fn build_link_meta(sess: Session, c: &ast::crate, output: &Path,
         let linkage_metas = attr::find_linkage_metas(c.node.attrs);
         attr::require_unique_names(sess.diagnostic(), linkage_metas);
         for linkage_metas.each |meta| {
-            if attr::get_meta_item_name(*meta) == ~"name" {
+            if *attr::get_meta_item_name(*meta) == ~"name" {
                 match attr::get_meta_item_value_str(*meta) {
                   // Changing attr would avoid the need for the copy
                   // here
                   Some(v) => { name = Some(v.to_managed()); }
                   None => cmh_items.push(*meta)
                 }
-            } else if attr::get_meta_item_name(*meta) == ~"vers" {
+            } else if *attr::get_meta_item_name(*meta) == ~"vers" {
                 match attr::get_meta_item_value_str(*meta) {
                   Some(v) => { vers = Some(v.to_managed()); }
                   None => cmh_items.push(*meta)

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -487,12 +487,12 @@ pub fn build_link_meta(sess: Session, c: &ast::crate, output: &Path,
     fn crate_meta_extras_hash(symbol_hasher: &hash::State,
                               -cmh_items: ~[@ast::meta_item],
                               dep_hashes: ~[~str]) -> @str {
-        fn len_and_str(s: ~str) -> ~str {
-            return fmt!("%u_%s", str::len(s), s);
+        fn len_and_str(s: &str) -> ~str {
+            fmt!("%u_%s", s.len(), s)
         }
 
         fn len_and_str_lit(l: ast::lit) -> ~str {
-            return len_and_str(pprust::lit_to_str(@l));
+            len_and_str(pprust::lit_to_str(@l))
         }
 
         let cmh_items = attr::sort_meta_items(cmh_items);
@@ -615,7 +615,7 @@ pub fn get_symbol_hash(ccx: @crate_ctxt, t: ty::t) -> @str {
 
 // Name sanitation. LLVM will happily accept identifiers with weird names, but
 // gas doesn't!
-pub fn sanitize(s: ~str) -> ~str {
+pub fn sanitize(s: &str) -> ~str {
     let mut result = ~"";
     for str::chars_each(s) |c| {
         match c {
@@ -629,10 +629,10 @@ pub fn sanitize(s: ~str) -> ~str {
           'a' .. 'z'
           | 'A' .. 'Z'
           | '0' .. '9'
-          | '_' => str::push_char(&mut result, c),
+          | '_' => result.push_char(c),
           _ => {
             if c > 'z' && char::is_XID_continue(c) {
-                str::push_char(&mut result, c);
+                result.push_char(c);
             }
           }
         }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -655,7 +655,7 @@ pub fn mangle(sess: Session, ss: path) -> ~str {
 
     for ss.each |s| {
         match *s { path_name(s) | path_mod(s) => {
-          let sani = sanitize(sess.str_of(s));
+          let sani = sanitize(*sess.str_of(s));
           n += fmt!("%u%s", str::len(sani), sani);
         } }
     }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -499,15 +499,15 @@ pub fn build_link_meta(sess: Session, c: &ast::crate, output: &Path,
 
         fn hash(symbol_hasher: &hash::State, m: &@ast::meta_item) {
             match m.node {
-              ast::meta_name_value(ref key, value) => {
-                symbol_hasher.write_str(len_and_str((*key)));
+              ast::meta_name_value(key, value) => {
+                symbol_hasher.write_str(len_and_str(*key));
                 symbol_hasher.write_str(len_and_str_lit(value));
               }
-              ast::meta_word(ref name) => {
-                symbol_hasher.write_str(len_and_str((*name)));
+              ast::meta_word(name) => {
+                symbol_hasher.write_str(len_and_str(*name));
               }
-              ast::meta_list(ref name, ref mis) => {
-                symbol_hasher.write_str(len_and_str((*name)));
+              ast::meta_list(name, ref mis) => {
+                symbol_hasher.write_str(len_and_str(*name));
                 for mis.each |m_| {
                     hash(symbol_hasher, m_);
                 }

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -541,11 +541,11 @@ pub fn build_session_options(+binary: ~str,
         let flags = vec::append(getopts::opt_strs(matches, level_short),
                                 getopts::opt_strs(matches, level_name));
         for flags.each |lint_name| {
-            let lint_name = str::replace(*lint_name, ~"-", ~"_");
+            let lint_name = @str::replace(*lint_name, ~"-", ~"_");
             match lint_dict.find(&lint_name) {
               None => {
                 early_error(demitter, fmt!("unknown %s flag: %s",
-                                           level_name, lint_name));
+                                           level_name, *lint_name));
               }
               Some(lint) => {
                 lint_opts.push((lint.lint, *level));

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -62,7 +62,7 @@ pub fn anon_src() -> ~str { ~"<anon>" }
 
 pub fn source_name(input: input) -> ~str {
     match input {
-      file_input(ref ifile) => (*ifile).to_str(),
+      file_input(ref ifile) => ifile.to_str(),
       str_input(_) => anon_src()
     }
 }
@@ -112,9 +112,9 @@ pub fn default_configuration(sess: Session, +argv0: ~str, input: input) ->
 pub fn append_configuration(+cfg: ast::crate_cfg, +name: ~str)
                          -> ast::crate_cfg {
     if attr::contains_name(cfg, name) {
-        return cfg;
+        cfg
     } else {
-        return vec::append_one(cfg, attr::mk_word_item(name));
+        vec::append_one(cfg, attr::mk_word_item(name))
     }
 }
 

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -97,16 +97,16 @@ pub fn default_configuration(sess: Session, +argv0: ~str, input: input) ->
     };
 
     return ~[ // Target bindings.
-         attr::mk_word_item(str::from_slice(os::FAMILY)),
-         mk(~"target_os", tos),
-         mk(~"target_family", str::from_slice(os::FAMILY)),
-         mk(~"target_arch", arch),
-         mk(~"target_endian", end),
-         mk(~"target_word_size", wordsz),
-         mk(~"target_libc", libc),
+         attr::mk_word_item(@str::from_slice(os::FAMILY)),
+         mk(@~"target_os", @tos),
+         mk(@~"target_family", @str::from_slice(os::FAMILY)),
+         mk(@~"target_arch", @arch),
+         mk(@~"target_endian", @end),
+         mk(@~"target_word_size", @wordsz),
+         mk(@~"target_libc", @libc),
          // Build bindings.
-         mk(~"build_compiler", argv0),
-         mk(~"build_input", source_name(input))];
+         mk(@~"build_compiler", @argv0),
+         mk(@~"build_input", @source_name(input))];
 }
 
 pub fn append_configuration(+cfg: ast::crate_cfg, +name: ~str)
@@ -114,7 +114,7 @@ pub fn append_configuration(+cfg: ast::crate_cfg, +name: ~str)
     if attr::contains_name(cfg, name) {
         cfg
     } else {
-        vec::append_one(cfg, attr::mk_word_item(name))
+        vec::append_one(cfg, attr::mk_word_item(@name))
     }
 }
 
@@ -142,7 +142,7 @@ pub fn parse_cfgspecs(cfgspecs: ~[~str]) -> ast::crate_cfg {
     // meta_word variant.
     let mut words = ~[];
     for cfgspecs.each |s| {
-        words.push(attr::mk_word_item(/*bad*/copy *s));
+        words.push(attr::mk_word_item(@/*bad*/copy *s));
     }
     return words;
 }

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -346,7 +346,7 @@ pub mod test {
             style: ast::attr_outer,
             value: codemap::respan(codemap::dummy_sp(),
                 ast::meta_name_value(
-                    ~"crate_type",
+                    @~"crate_type",
                     codemap::respan(codemap::dummy_sp(),
                                      ast::lit_str(@t)))),
             is_sugared_doc: false

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -253,8 +253,8 @@ pub impl Session {
         self.debugging_opt(no_monomorphic_collapse)
     }
 
-    fn str_of(id: ast::ident) -> ~str {
-        /*bad*/copy *self.parse_sess.interner.get(id)
+    fn str_of(id: ast::ident) -> @~str {
+        self.parse_sess.interner.get(id)
     }
     fn ident_of(+st: ~str) -> ast::ident {
         self.parse_sess.interner.intern(@st)

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -310,7 +310,7 @@ pub fn building_library(req_crate_type: crate_type,
             match syntax::attr::first_attr_value_str_by_name(
                 crate.node.attrs,
                 ~"crate_type") {
-              option::Some(~"lib") => true,
+              Some(@~"lib") => true,
               _ => false
             }
         }

--- a/src/librustc/front/core_inject.rs
+++ b/src/librustc/front/core_inject.rs
@@ -51,7 +51,7 @@ fn inject_libcore_ref(sess: Session,
                     spanned(ast::attribute_ {
                         style: ast::attr_inner,
                         value: spanned(ast::meta_name_value(
-                            ~"vers",
+                            @~"vers",
                             spanned(ast::lit_str(@CORE_VERSION.to_str()))
                         )),
                         is_sugared_doc: false

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -262,7 +262,7 @@ mod __test {
 fn mk_std(cx: &TestCtxt) -> @ast::view_item {
     let vers = ast::lit_str(@~"0.6");
     let vers = nospan(vers);
-    let mi = ast::meta_name_value(~"vers", vers);
+    let mi = ast::meta_name_value(@~"vers", vers);
     let mi = nospan(mi);
     let id_std = cx.sess.ident_of(~"std");
     let vi = if is_std(cx) {

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -57,7 +57,7 @@ pub fn modify_for_testing(sess: session::Session,
     // configuration, either with the '--test' or '--cfg test'
     // command line options.
     let should_test = attr::contains(crate.node.config,
-                                     attr::mk_word_item(~"test"));
+                                     attr::mk_word_item(@~"test"));
 
     if should_test {
         generate_test_harness(sess, crate)
@@ -111,7 +111,7 @@ fn fold_mod(cx: @mut TestCtxt,
     fn nomain(cx: @mut TestCtxt, item: @ast::item) -> @ast::item {
         if !*cx.sess.building_library {
             @ast::item{attrs: item.attrs.filtered(|attr| {
-                               attr::get_attr_name(attr) != ~"main"
+                               *attr::get_attr_name(attr) != ~"main"
                            }),.. copy *item}
         } else { item }
     }
@@ -310,7 +310,7 @@ fn mk_test_module(cx: &TestCtxt) -> @ast::item {
 
     // This attribute tells resolve to let us call unexported functions
     let resolve_unexported_attr =
-        attr::mk_attr(attr::mk_word_item(~"!resolve_unexported"));
+        attr::mk_attr(attr::mk_word_item(@~"!resolve_unexported"));
 
     let item = ast::item {
         ident: cx.sess.ident_of(~"__test"),
@@ -366,7 +366,7 @@ fn is_std(cx: &TestCtxt) -> bool {
     let is_std = {
         let items = attr::find_linkage_metas(cx.crate.node.attrs);
         match attr::last_meta_item_value_str_by_name(items, ~"name") {
-          Some(~"std") => true,
+          Some(@~"std") => true,
           _ => false
         }
     };

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -111,7 +111,7 @@ fn fold_mod(cx: @mut TestCtxt,
     fn nomain(cx: @mut TestCtxt, item: @ast::item) -> @ast::item {
         if !*cx.sess.building_library {
             @ast::item{attrs: item.attrs.filtered(|attr| {
-                               attr::get_attr_name(*attr) != ~"main"
+                               attr::get_attr_name(attr) != ~"main"
                            }),.. copy *item}
         } else { item }
     }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -64,7 +64,7 @@ pub fn read_crates(diag: span_handler,
 type cache_entry = {
     cnum: int,
     span: span,
-    hash: ~str,
+    hash: @~str,
     metas: @~[@ast::meta_item]
 };
 
@@ -100,7 +100,7 @@ fn warn_if_multiple_versions(e: @mut Env,
 
         if matches.len() != 1u {
             diag.handler().warn(
-                fmt!("using multiple versions of crate `%s`", name));
+                fmt!("using multiple versions of crate `%s`", *name));
             for matches.each |match_| {
                 diag.span_note(match_.span, ~"used here");
                 let attrs = ~[
@@ -145,7 +145,7 @@ fn visit_view_item(e: @mut Env, i: @ast::view_item) {
       ast::view_item_extern_mod(ident, meta_items, id) => {
         debug!("resolving extern mod stmt. ident: %?, meta: %?",
                ident, meta_items);
-        let cnum = resolve_crate(e, ident, meta_items, ~"", i.span);
+        let cnum = resolve_crate(e, ident, meta_items, @~"", i.span);
         cstore::add_extern_mod_stmt_cnum(e.cstore, id, cnum);
       }
       _ => ()
@@ -172,21 +172,20 @@ fn visit_item(e: @mut Env, i: @ast::item) {
                 let foreign_name =
                     match attr::first_attr_value_str_by_name(i.attrs,
                                                             ~"link_name") {
-                        Some(ref nn) => {
-                            if **nn == ~"" {
+                        Some(nn) => {
+                            if *nn == ~"" {
                                 e.diag.span_fatal(
                                     i.span,
                                     ~"empty #[link_name] not allowed; use " +
                                     ~"#[nolink].");
                             }
-                            /*bad*/copy *nn
+                            nn
                         }
-                        None => @/*bad*/copy *e.intr.get(i.ident)
+                        None => e.intr.get(i.ident)
                     };
                 if attr::find_attrs_by_name(i.attrs, ~"nolink").is_empty() {
                     already_added =
-                        !cstore::add_used_library(cstore,
-                                /*bad*/ copy *foreign_name);
+                        !cstore::add_used_library(cstore, foreign_name);
                 }
                 if !link_args.is_empty() && already_added {
                     e.diag.span_fatal(i.span, ~"library '" + *foreign_name +
@@ -198,8 +197,8 @@ fn visit_item(e: @mut Env, i: @ast::item) {
 
         for link_args.each |a| {
             match attr::get_meta_item_value_str(attr::attr_meta(*a)) {
-                Some(ref linkarg) => {
-                    cstore::add_used_link_args(cstore, /*bad*/copy **linkarg);
+                Some(linkarg) => {
+                    cstore::add_used_link_args(cstore, *linkarg);
                 }
                 None => { /* fallthrough */ }
             }
@@ -209,22 +208,22 @@ fn visit_item(e: @mut Env, i: @ast::item) {
     }
 }
 
-fn metas_with(+ident: ~str, +key: ~str, +metas: ~[@ast::meta_item])
+fn metas_with(ident: @~str, key: @~str, +metas: ~[@ast::meta_item])
     -> ~[@ast::meta_item] {
-    let name_items = attr::find_meta_items_by_name(metas, key);
+    let name_items = attr::find_meta_items_by_name(metas, *key);
     if name_items.is_empty() {
-        vec::append_one(metas, attr::mk_name_value_item_str(@key, @ident))
+        vec::append_one(metas, attr::mk_name_value_item_str(key, ident))
     } else {
         metas
     }
 }
 
-fn metas_with_ident(+ident: ~str, +metas: ~[@ast::meta_item])
+fn metas_with_ident(ident: @~str, +metas: ~[@ast::meta_item])
     -> ~[@ast::meta_item] {
-    metas_with(ident, ~"name", metas)
+    metas_with(ident, @~"name", metas)
 }
 
-fn existing_match(e: @mut Env, metas: ~[@ast::meta_item], hash: ~str)
+fn existing_match(e: @mut Env, metas: ~[@ast::meta_item], hash: @~str)
                -> Option<int> {
     for e.crate_cache.each |c| {
         if loader::metadata_matches(*c.metas, metas)
@@ -238,10 +237,10 @@ fn existing_match(e: @mut Env, metas: ~[@ast::meta_item], hash: ~str)
 fn resolve_crate(e: @mut Env,
                  ident: ast::ident,
                  +metas: ~[@ast::meta_item],
-                 +hash: ~str,
+                 hash: @~str,
                  span: span)
               -> ast::crate_num {
-    let metas = metas_with_ident(/*bad*/copy *e.intr.get(ident), metas);
+    let metas = metas_with_ident(@/*bad*/copy *e.intr.get(ident), metas);
 
     match existing_match(e, metas, hash) {
       None => {
@@ -277,10 +276,10 @@ fn resolve_crate(e: @mut Env,
         let cname =
             match attr::last_meta_item_value_str_by_name(load_ctxt.metas,
                                                          ~"name") {
-                Some(ref v) => /*bad*/copy *v,
-                None => @/*bad*/copy *e.intr.get(ident),
+                Some(v) => v,
+                None => e.intr.get(ident),
             };
-        let cmeta = @{name: /*bad*/copy *cname, data: cdata,
+        let cmeta = @{name: cname, data: cdata,
                       cnum_map: cnum_map, cnum: cnum};
 
         let cstore = e.cstore;
@@ -303,10 +302,10 @@ fn resolve_crate_deps(e: @mut Env, cdata: @~[u8]) -> cstore::cnum_map {
     for decoder::get_crate_deps(e.intr, cdata).each |dep| {
         let extrn_cnum = dep.cnum;
         let cname = dep.name;
-        let cmetas = metas_with(/*bad*/copy dep.vers, ~"vers", ~[]);
+        let cmetas = metas_with(dep.vers, @~"vers", ~[]);
         debug!("resolving dep crate %s ver: %s hash: %s",
-               *e.intr.get(dep.name), dep.vers, dep.hash);
-        match existing_match(e, metas_with_ident(copy *e.intr.get(cname),
+               *e.intr.get(dep.name), *dep.vers, *dep.hash);
+        match existing_match(e, metas_with_ident(e.intr.get(cname),
                                                  copy cmetas),
                              dep.hash) {
           Some(local_cnum) => {
@@ -320,8 +319,8 @@ fn resolve_crate_deps(e: @mut Env, cdata: @~[u8]) -> cstore::cnum_map {
             // FIXME (#2404): Need better error reporting than just a bogus
             // span.
             let fake_span = dummy_sp();
-            let local_cnum = resolve_crate(e, cname, cmetas,
-                                           /*bad*/copy dep.hash, fake_span);
+            let local_cnum = resolve_crate(e, cname, cmetas, dep.hash,
+                                           fake_span);
             cnum_map.insert(extrn_cnum, local_cnum);
           }
         }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -168,39 +168,40 @@ fn visit_item(e: @mut Env, i: @ast::item) {
         let link_args = attr::find_attrs_by_name(i.attrs, "link_args");
 
         match fm.sort {
-          ast::named => {
-            let foreign_name =
-               match attr::first_attr_value_str_by_name(i.attrs,
-                                                        ~"link_name") {
-                 Some(ref nn) => {
-                   if **nn == ~"" {
-                      e.diag.span_fatal(
-                          i.span,
-                          ~"empty #[link_name] not allowed; use #[nolink].");
-                   }
-                   (/*bad*/copy *nn)
-                 }
-                None => @/*bad*/copy *e.intr.get(i.ident)
-            };
-            if attr::find_attrs_by_name(i.attrs, ~"nolink").is_empty() {
-                already_added =
-                    !cstore::add_used_library(cstore,
-                                              /*bad*/ copy *foreign_name);
+            ast::named => {
+                let foreign_name =
+                    match attr::first_attr_value_str_by_name(i.attrs,
+                                                            ~"link_name") {
+                        Some(ref nn) => {
+                            if **nn == ~"" {
+                                e.diag.span_fatal(
+                                    i.span,
+                                    ~"empty #[link_name] not allowed; use " +
+                                    ~"#[nolink].");
+                            }
+                            /*bad*/copy *nn
+                        }
+                        None => @/*bad*/copy *e.intr.get(i.ident)
+                    };
+                if attr::find_attrs_by_name(i.attrs, ~"nolink").is_empty() {
+                    already_added =
+                        !cstore::add_used_library(cstore,
+                                /*bad*/ copy *foreign_name);
+                }
+                if !link_args.is_empty() && already_added {
+                    e.diag.span_fatal(i.span, ~"library '" + *foreign_name +
+                               ~"' already added: can't specify link_args.");
+                }
             }
-            if !link_args.is_empty() && already_added {
-                e.diag.span_fatal(i.span, ~"library '" + *foreign_name +
-                           ~"' already added: can't specify link_args.");
-            }
-          }
-          ast::anonymous => { /* do nothing */ }
+            ast::anonymous => { /* do nothing */ }
         }
 
         for link_args.each |a| {
             match attr::get_meta_item_value_str(attr::attr_meta(*a)) {
-              Some(ref linkarg) => {
-                cstore::add_used_link_args(cstore, /*bad*/copy **linkarg);
-              }
-              None => {/* fallthrough */ }
+                Some(ref linkarg) => {
+                    cstore::add_used_link_args(cstore, /*bad*/copy **linkarg);
+                }
+                None => { /* fallthrough */ }
             }
         }
       }
@@ -276,8 +277,8 @@ fn resolve_crate(e: @mut Env,
         let cname =
             match attr::last_meta_item_value_str_by_name(load_ctxt.metas,
                                                          ~"name") {
-              option::Some(ref v) => (/*bad*/copy *v),
-              option::None => @/*bad*/copy *e.intr.get(ident)
+                Some(ref v) => /*bad*/copy *v,
+                None => @/*bad*/copy *e.intr.get(ident),
             };
         let cmeta = @{name: /*bad*/copy *cname, data: cdata,
                       cnum_map: cnum_map, cnum: cnum};

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -105,7 +105,7 @@ fn warn_if_multiple_versions(e: @mut Env,
                 diag.span_note(match_.span, ~"used here");
                 let attrs = ~[
                     attr::mk_attr(attr::mk_list_item(
-                        ~"link", /*bad*/copy *match_.metas))
+                        @~"link", /*bad*/copy *match_.metas))
                 ];
                 loader::note_linkage_attrs(e.intr, diag, attrs);
             }
@@ -133,7 +133,7 @@ fn visit_crate(e: @mut Env, c: ast::crate) {
     for link_args.each |a| {
         match attr::get_meta_item_value_str(attr::attr_meta(*a)) {
           Some(ref linkarg) => {
-            cstore::add_used_link_args(cstore, (/*bad*/copy *linkarg));
+            cstore::add_used_link_args(cstore, **linkarg);
           }
           None => {/* fallthrough */ }
         }
@@ -173,21 +173,22 @@ fn visit_item(e: @mut Env, i: @ast::item) {
                match attr::first_attr_value_str_by_name(i.attrs,
                                                         ~"link_name") {
                  Some(ref nn) => {
-                   if (*nn) == ~"" {
+                   if **nn == ~"" {
                       e.diag.span_fatal(
                           i.span,
                           ~"empty #[link_name] not allowed; use #[nolink].");
                    }
                    (/*bad*/copy *nn)
                  }
-                None => /*bad*/copy *e.intr.get(i.ident)
+                None => @/*bad*/copy *e.intr.get(i.ident)
             };
             if attr::find_attrs_by_name(i.attrs, ~"nolink").is_empty() {
                 already_added =
-                    !cstore::add_used_library(cstore, copy foreign_name);
+                    !cstore::add_used_library(cstore,
+                                              /*bad*/ copy *foreign_name);
             }
             if !link_args.is_empty() && already_added {
-                e.diag.span_fatal(i.span, ~"library '" + foreign_name +
+                e.diag.span_fatal(i.span, ~"library '" + *foreign_name +
                            ~"' already added: can't specify link_args.");
             }
           }
@@ -197,7 +198,7 @@ fn visit_item(e: @mut Env, i: @ast::item) {
         for link_args.each |a| {
             match attr::get_meta_item_value_str(attr::attr_meta(*a)) {
               Some(ref linkarg) => {
-                cstore::add_used_link_args(cstore, *linkarg);
+                cstore::add_used_link_args(cstore, /*bad*/copy **linkarg);
               }
               None => {/* fallthrough */ }
             }
@@ -211,7 +212,7 @@ fn metas_with(+ident: ~str, +key: ~str, +metas: ~[@ast::meta_item])
     -> ~[@ast::meta_item] {
     let name_items = attr::find_meta_items_by_name(metas, key);
     if name_items.is_empty() {
-        vec::append_one(metas, attr::mk_name_value_item_str(key, ident))
+        vec::append_one(metas, attr::mk_name_value_item_str(@key, @ident))
     } else {
         metas
     }
@@ -276,9 +277,9 @@ fn resolve_crate(e: @mut Env,
             match attr::last_meta_item_value_str_by_name(load_ctxt.metas,
                                                          ~"name") {
               option::Some(ref v) => (/*bad*/copy *v),
-              option::None => /*bad*/copy *e.intr.get(ident)
+              option::None => @/*bad*/copy *e.intr.get(ident)
             };
-        let cmeta = @{name: cname, data: cdata,
+        let cmeta = @{name: /*bad*/copy *cname, data: cdata,
                       cnum_map: cnum_map, cnum: cnum};
 
         let cstore = e.cstore;

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -80,7 +80,7 @@ pub fn get_item_path(tcx: ty::ctxt, def: ast::def_id) -> ast_map::path {
     // FIXME #1920: This path is not always correct if the crate is not linked
     // into the root namespace.
     vec::append(~[ast_map::path_mod(tcx.sess.ident_of(
-        /*bad*/copy cdata.name))], path)
+        /*bad*/copy *cdata.name))], path)
 }
 
 pub enum found_ast {

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -70,12 +70,12 @@ pub fn get_crate_data(cstore: @mut CStore, cnum: ast::crate_num)
 
 pub fn get_crate_hash(cstore: @mut CStore, cnum: ast::crate_num) -> ~str {
     let cdata = get_crate_data(cstore, cnum);
-    return decoder::get_crate_hash(cdata.data);
+    decoder::get_crate_hash(cdata.data)
 }
 
 pub fn get_crate_vers(cstore: @mut CStore, cnum: ast::crate_num) -> ~str {
     let cdata = get_crate_data(cstore, cnum);
-    return decoder::get_crate_vers(cdata.data);
+    decoder::get_crate_vers(cdata.data)
 }
 
 pub fn set_crate_data(cstore: @mut CStore,
@@ -110,21 +110,21 @@ pub fn get_used_crate_files(cstore: @mut CStore) -> ~[Path] {
 pub fn add_used_library(cstore: @mut CStore, +lib: ~str) -> bool {
     assert lib != ~"";
 
-    if vec::contains(cstore.used_libraries, &lib) { return false; }
+    if cstore.used_libraries.contains(&lib) { return false; }
     cstore.used_libraries.push(lib);
-    return true;
+    true
 }
 
 pub fn get_used_libraries(cstore: @mut CStore) -> ~[~str] {
-    return /*bad*/copy cstore.used_libraries;
+    /*bad*/copy cstore.used_libraries
 }
 
 pub fn add_used_link_args(cstore: @mut CStore, args: &str) {
-    cstore.used_link_args.push_all(str::split_char(args, ' '));
+    cstore.used_link_args.push_all(args.split_char(' '));
 }
 
 pub fn get_used_link_args(cstore: @mut CStore) -> ~[~str] {
-    return /*bad*/copy cstore.used_link_args;
+    /*bad*/copy cstore.used_link_args
 }
 
 pub fn add_extern_mod_stmt_cnum(cstore: @mut CStore,
@@ -155,21 +155,14 @@ pub fn get_dep_hashes(cstore: @mut CStore) -> ~[~str] {
         result.push({name: /*bad*/copy cdata.name, hash: hash});
     }
 
-    pure fn lteq(a: &crate_hash, b: &crate_hash) -> bool {
-        a.name <= b.name
-    }
+    let sorted = std::sort::merge_sort(result, |a, b| a.name <= b.name);
 
-    let sorted = std::sort::merge_sort(result, lteq);
     debug!("sorted:");
     for sorted.each |x| {
         debug!("  hash[%s]: %s", x.name, x.hash);
     }
 
-    fn mapper(ch: &crate_hash) -> ~str {
-        return /*bad*/copy ch.hash;
-    }
-
-    return vec::map(sorted, mapper);
+    sorted.map(|ch| /*bad*/copy ch.hash)
 }
 
 // Local Variables:

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -33,7 +33,7 @@ use syntax::parse::token::ident_interner;
 // own crate numbers.
 pub type cnum_map = oldmap::HashMap<ast::crate_num, ast::crate_num>;
 
-pub type crate_metadata = @{name: ~str,
+pub type crate_metadata = @{name: @~str,
                             data: @~[u8],
                             cnum_map: cnum_map,
                             cnum: ast::crate_num};
@@ -68,12 +68,12 @@ pub fn get_crate_data(cstore: @mut CStore, cnum: ast::crate_num)
     return cstore.metas.get(&cnum);
 }
 
-pub fn get_crate_hash(cstore: @mut CStore, cnum: ast::crate_num) -> ~str {
+pub fn get_crate_hash(cstore: @mut CStore, cnum: ast::crate_num) -> @~str {
     let cdata = get_crate_data(cstore, cnum);
     decoder::get_crate_hash(cdata.data)
 }
 
-pub fn get_crate_vers(cstore: @mut CStore, cnum: ast::crate_num) -> ~str {
+pub fn get_crate_vers(cstore: @mut CStore, cnum: ast::crate_num) -> @~str {
     let cdata = get_crate_data(cstore, cnum);
     decoder::get_crate_vers(cdata.data)
 }
@@ -107,11 +107,11 @@ pub fn get_used_crate_files(cstore: @mut CStore) -> ~[Path] {
     return /*bad*/copy cstore.used_crate_files;
 }
 
-pub fn add_used_library(cstore: @mut CStore, +lib: ~str) -> bool {
-    assert lib != ~"";
+pub fn add_used_library(cstore: @mut CStore, lib: @~str) -> bool {
+    assert *lib != ~"";
 
-    if cstore.used_libraries.contains(&lib) { return false; }
-    cstore.used_libraries.push(lib);
+    if cstore.used_libraries.contains(&*lib) { return false; }
+    cstore.used_libraries.push(/*bad*/ copy *lib);
     true
 }
 
@@ -151,7 +151,7 @@ pub fn get_dep_hashes(cstore: @mut CStore) -> ~[~str] {
     for extern_mod_crate_map.each_value |&cnum| {
         let cdata = cstore::get_crate_data(cstore, cnum);
         let hash = decoder::get_crate_hash(cdata.data);
-        debug!("Add hash[%s]: %s", cdata.name, hash);
+        debug!("Add hash[%s]: %s", *cdata.name, *hash);
         result.push({name: /*bad*/copy cdata.name, hash: hash});
     }
 
@@ -159,10 +159,10 @@ pub fn get_dep_hashes(cstore: @mut CStore) -> ~[~str] {
 
     debug!("sorted:");
     for sorted.each |x| {
-        debug!("  hash[%s]: %s", x.name, x.hash);
+        debug!("  hash[%s]: %s", *x.name, *x.hash);
     }
 
-    sorted.map(|ch| /*bad*/copy ch.hash)
+    sorted.map(|ch| /*bad*/copy *ch.hash)
 }
 
 // Local Variables:

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -962,7 +962,7 @@ fn get_meta_items(md: ebml::Doc) -> ~[@ast::meta_item] {
     for reader::tagged_docs(md, tag_meta_item_word) |meta_item_doc| {
         let nd = reader::get_doc(meta_item_doc, tag_meta_item_name);
         let n = str::from_bytes(reader::doc_data(nd));
-        items.push(attr::mk_word_item(n));
+        items.push(attr::mk_word_item(@n));
     };
     for reader::tagged_docs(md, tag_meta_item_name_value) |meta_item_doc| {
         let nd = reader::get_doc(meta_item_doc, tag_meta_item_name);
@@ -971,13 +971,13 @@ fn get_meta_items(md: ebml::Doc) -> ~[@ast::meta_item] {
         let v = str::from_bytes(reader::doc_data(vd));
         // FIXME (#623): Should be able to decode meta_name_value variants,
         // but currently the encoder just drops them
-        items.push(attr::mk_name_value_item_str(n, v));
+        items.push(attr::mk_name_value_item_str(@n, @v));
     };
     for reader::tagged_docs(md, tag_meta_item_list) |meta_item_doc| {
         let nd = reader::get_doc(meta_item_doc, tag_meta_item_name);
         let n = str::from_bytes(reader::doc_data(nd));
         let subitems = get_meta_items(meta_item_doc);
-        items.push(attr::mk_list_item(n, subitems));
+        items.push(attr::mk_list_item(@n, subitems));
     };
     return items;
 }
@@ -1073,7 +1073,7 @@ pub fn get_crate_vers(data: @~[u8]) -> ~str {
     let attrs = decoder::get_crate_attributes(data);
     return match attr::last_meta_item_value_str_by_name(
         attr::find_linkage_metas(attrs), ~"vers") {
-      Some(ref ver) => (/*bad*/copy *ver),
+      Some(ref ver) => (/*bad*/copy **ver),
       None => ~"0.0"
     };
 }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1066,16 +1066,17 @@ fn list_crate_deps(intr: @ident_interner, data: @~[u8], out: io::Writer) {
 pub fn get_crate_hash(data: @~[u8]) -> ~str {
     let cratedoc = reader::Doc(data);
     let hashdoc = reader::get_doc(cratedoc, tag_crate_hash);
-    return str::from_bytes(reader::doc_data(hashdoc));
+    str::from_bytes(reader::doc_data(hashdoc))
 }
 
 pub fn get_crate_vers(data: @~[u8]) -> ~str {
     let attrs = decoder::get_crate_attributes(data);
-    return match attr::last_meta_item_value_str_by_name(
-        attr::find_linkage_metas(attrs), ~"vers") {
-      Some(ref ver) => (/*bad*/copy **ver),
-      None => ~"0.0"
-    };
+    let linkage_attrs = attr::find_linkage_metas(attrs);
+
+    match attr::last_meta_item_value_str_by_name(linkage_attrs, ~"vers") {
+        Some(ref ver) => /*bad*/copy **ver,
+        None => ~"0.0"
+    }
 }
 
 fn iter_crate_items(intr: @ident_interner, cdata: cmd,

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1015,7 +1015,7 @@ fn list_meta_items(intr: @ident_interner,
     }
 }
 
-fn list_crate_attributes(intr: @ident_interner, md: ebml::Doc, hash: ~str,
+fn list_crate_attributes(intr: @ident_interner, md: ebml::Doc, hash: &str,
                          out: io::Writer) {
     out.write_str(fmt!("=Crate Attributes (%s)=\n", hash));
 
@@ -1031,7 +1031,7 @@ pub fn get_crate_attributes(data: @~[u8]) -> ~[ast::attribute] {
 }
 
 pub type crate_dep = {cnum: ast::crate_num, name: ast::ident,
-                      vers: ~str, hash: ~str};
+                      vers: @~str, hash: @~str};
 
 pub fn get_crate_deps(intr: @ident_interner, data: @~[u8]) -> ~[crate_dep] {
     let mut deps: ~[crate_dep] = ~[];
@@ -1044,8 +1044,8 @@ pub fn get_crate_deps(intr: @ident_interner, data: @~[u8]) -> ~[crate_dep] {
     for reader::tagged_docs(depsdoc, tag_crate_dep) |depdoc| {
         deps.push({cnum: crate_num,
                   name: intr.intern(@docstr(depdoc, tag_crate_dep_name)),
-                  vers: docstr(depdoc, tag_crate_dep_vers),
-                  hash: docstr(depdoc, tag_crate_dep_hash)});
+                  vers: @docstr(depdoc, tag_crate_dep_vers),
+                  hash: @docstr(depdoc, tag_crate_dep_hash)});
         crate_num += 1;
     };
     return deps;
@@ -1057,25 +1057,25 @@ fn list_crate_deps(intr: @ident_interner, data: @~[u8], out: io::Writer) {
     for get_crate_deps(intr, data).each |dep| {
         out.write_str(
             fmt!("%d %s-%s-%s\n",
-                 dep.cnum, *intr.get(dep.name), dep.hash, dep.vers));
+                 dep.cnum, *intr.get(dep.name), *dep.hash, *dep.vers));
     }
 
     out.write_str(~"\n");
 }
 
-pub fn get_crate_hash(data: @~[u8]) -> ~str {
+pub fn get_crate_hash(data: @~[u8]) -> @~str {
     let cratedoc = reader::Doc(data);
     let hashdoc = reader::get_doc(cratedoc, tag_crate_hash);
-    str::from_bytes(reader::doc_data(hashdoc))
+    @str::from_bytes(reader::doc_data(hashdoc))
 }
 
-pub fn get_crate_vers(data: @~[u8]) -> ~str {
+pub fn get_crate_vers(data: @~[u8]) -> @~str {
     let attrs = decoder::get_crate_attributes(data);
     let linkage_attrs = attr::find_linkage_metas(attrs);
 
     match attr::last_meta_item_value_str_by_name(linkage_attrs, ~"vers") {
-        Some(ref ver) => /*bad*/copy **ver,
-        None => ~"0.0"
+        Some(ver) => ver,
+        None => @~"0.0"
     }
 }
 
@@ -1097,7 +1097,7 @@ pub fn list_crate_metadata(intr: @ident_interner, bytes: @~[u8],
                            out: io::Writer) {
     let hash = get_crate_hash(bytes);
     let md = reader::Doc(bytes);
-    list_crate_attributes(intr, md, hash, out);
+    list_crate_attributes(intr, md, *hash, out);
     list_crate_deps(intr, bytes, out);
 }
 

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1124,7 +1124,7 @@ fn encode_crate_deps(ecx: @encode_ctxt,
         type numdep = decoder::crate_dep;
 
         // Pull the cnums and name,vers,hash out of cstore
-        let mut deps: ~[numdep] = ~[];
+        let mut deps = ~[];
         do cstore::iter_crate_data(cstore) |key, val| {
             let dep = {cnum: key,
                        name: ecx.tcx.sess.ident_of(/*bad*/copy val.name),
@@ -1134,10 +1134,7 @@ fn encode_crate_deps(ecx: @encode_ctxt,
         };
 
         // Sort by cnum
-        pure fn lteq(kv1: &numdep, kv2: &numdep) -> bool {
-            kv1.cnum <= kv2.cnum
-        }
-        std::sort::quick_sort(deps, lteq);
+        std::sort::quick_sort(deps, |kv1, kv2| kv1.cnum <= kv2.cnum);
 
         // Sanity-check the crate numbers
         let mut expected_cnum = 1;
@@ -1147,7 +1144,7 @@ fn encode_crate_deps(ecx: @encode_ctxt,
         }
 
         // mut -> immutable hack for vec::map
-        return vec::slice(deps, 0u, vec::len(deps)).to_vec();
+        deps.slice(0, deps.len())
     }
 
     // We're just going to write a list of crate 'name-hash-version's, with

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1127,7 +1127,7 @@ fn encode_crate_deps(ecx: @encode_ctxt,
         let mut deps = ~[];
         do cstore::iter_crate_data(cstore) |key, val| {
             let dep = {cnum: key,
-                       name: ecx.tcx.sess.ident_of(/*bad*/ copy val.name),
+                       name: ecx.tcx.sess.ident_of(/*bad*/ copy *val.name),
                        vers: decoder::get_crate_vers(val.data),
                        hash: decoder::get_crate_hash(val.data)};
             deps.push(dep);
@@ -1189,10 +1189,10 @@ fn encode_crate_dep(ecx: @encode_ctxt, ebml_w: writer::Encoder,
     ebml_w.writer.write(str::to_bytes(ecx.tcx.sess.str_of(dep.name)));
     ebml_w.end_tag();
     ebml_w.start_tag(tag_crate_dep_vers);
-    ebml_w.writer.write(str::to_bytes(dep.vers));
+    ebml_w.writer.write(str::to_bytes(*dep.vers));
     ebml_w.end_tag();
     ebml_w.start_tag(tag_crate_dep_hash);
-    ebml_w.writer.write(str::to_bytes(dep.hash));
+    ebml_w.writer.write(str::to_bytes(*dep.hash));
     ebml_w.end_tag();
     ebml_w.end_tag();
 }

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1075,11 +1075,11 @@ fn synthesize_crate_attrs(ecx: @encode_ctxt, crate: &crate) -> ~[attribute] {
         assert !ecx.link_meta.vers.is_empty();
 
         let name_item =
-            attr::mk_name_value_item_str(~"name",
-                                         ecx.link_meta.name.to_owned());
+            attr::mk_name_value_item_str(@~"name",
+                                         @ecx.link_meta.name.to_owned());
         let vers_item =
-            attr::mk_name_value_item_str(~"vers",
-                                         ecx.link_meta.vers.to_owned());
+            attr::mk_name_value_item_str(@~"vers",
+                                         @ecx.link_meta.vers.to_owned());
 
         let other_items =
             {
@@ -1088,7 +1088,7 @@ fn synthesize_crate_attrs(ecx: @encode_ctxt, crate: &crate) -> ~[attribute] {
             };
 
         let meta_items = vec::append(~[name_item, vers_item], other_items);
-        let link_item = attr::mk_list_item(~"link", meta_items);
+        let link_item = attr::mk_list_item(@~"link", meta_items);
 
         return attr::mk_attr(link_item);
     }
@@ -1097,7 +1097,7 @@ fn synthesize_crate_attrs(ecx: @encode_ctxt, crate: &crate) -> ~[attribute] {
     let mut found_link_attr = false;
     for crate.node.attrs.each |attr| {
         attrs.push(
-            if attr::get_attr_name(attr) != ~"link" {
+            if *attr::get_attr_name(attr) != ~"link" {
                 /*bad*/copy *attr
             } else {
                 match /*bad*/copy attr.node.value.node {

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1097,7 +1097,7 @@ fn synthesize_crate_attrs(ecx: @encode_ctxt, crate: &crate) -> ~[attribute] {
     let mut found_link_attr = false;
     for crate.node.attrs.each |attr| {
         attrs.push(
-            if attr::get_attr_name(*attr) != ~"link" {
+            if attr::get_attr_name(attr) != ~"link" {
                 /*bad*/copy *attr
             } else {
                 match /*bad*/copy attr.node.value.node {

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1017,19 +1017,19 @@ fn write_int(writer: io::Writer, &&n: int) {
 
 fn encode_meta_item(ebml_w: writer::Encoder, mi: meta_item) {
     match mi.node {
-      meta_word(ref name) => {
+      meta_word(name) => {
         ebml_w.start_tag(tag_meta_item_word);
         ebml_w.start_tag(tag_meta_item_name);
-        ebml_w.writer.write(str::to_bytes((*name)));
+        ebml_w.writer.write(str::to_bytes(*name));
         ebml_w.end_tag();
         ebml_w.end_tag();
       }
-      meta_name_value(ref name, value) => {
+      meta_name_value(name, value) => {
         match value.node {
           lit_str(value) => {
             ebml_w.start_tag(tag_meta_item_name_value);
             ebml_w.start_tag(tag_meta_item_name);
-            ebml_w.writer.write(str::to_bytes((*name)));
+            ebml_w.writer.write(str::to_bytes(*name));
             ebml_w.end_tag();
             ebml_w.start_tag(tag_meta_item_value);
             ebml_w.writer.write(str::to_bytes(*value));
@@ -1039,10 +1039,10 @@ fn encode_meta_item(ebml_w: writer::Encoder, mi: meta_item) {
           _ => {/* FIXME (#623): encode other variants */ }
         }
       }
-      meta_list(ref name, ref items) => {
+      meta_list(name, ref items) => {
         ebml_w.start_tag(tag_meta_item_list);
         ebml_w.start_tag(tag_meta_item_name);
-        ebml_w.writer.write(str::to_bytes((*name)));
+        ebml_w.writer.write(str::to_bytes(*name));
         ebml_w.end_tag();
         for items.each |inner_item| {
             encode_meta_item(ebml_w, **inner_item);
@@ -1127,7 +1127,7 @@ fn encode_crate_deps(ecx: @encode_ctxt,
         let mut deps = ~[];
         do cstore::iter_crate_data(cstore) |key, val| {
             let dep = {cnum: key,
-                       name: ecx.tcx.sess.ident_of(/*bad*/copy val.name),
+                       name: ecx.tcx.sess.ident_of(/*bad*/ copy val.name),
                        vers: decoder::get_crate_vers(val.data),
                        hash: decoder::get_crate_hash(val.data)};
             deps.push(dep);

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -104,13 +104,13 @@ pub fn reachable(ecx: @encode_ctxt, id: node_id) -> bool {
 }
 
 fn encode_name(ecx: @encode_ctxt, ebml_w: writer::Encoder, name: ident) {
-    ebml_w.wr_tagged_str(tag_paths_data_name, ecx.tcx.sess.str_of(name));
+    ebml_w.wr_tagged_str(tag_paths_data_name, *ecx.tcx.sess.str_of(name));
 }
 
 fn encode_impl_type_basename(ecx: @encode_ctxt, ebml_w: writer::Encoder,
                              name: ident) {
     ebml_w.wr_tagged_str(tag_item_impl_type_basename,
-                         ecx.tcx.sess.str_of(name));
+                         *ecx.tcx.sess.str_of(name));
 }
 
 pub fn encode_def_id(ebml_w: writer::Encoder, id: def_id) {
@@ -305,7 +305,7 @@ fn encode_path(ecx: @encode_ctxt, ebml_w: writer::Encoder,
           ast_map::path_name(name) => (tag_path_elt_name, name)
         };
 
-        ebml_w.wr_tagged_str(tag, ecx.tcx.sess.str_of(name));
+        ebml_w.wr_tagged_str(tag, *ecx.tcx.sess.str_of(name));
     }
 
     do ebml_w.wr_tag(tag_path) {
@@ -333,7 +333,7 @@ fn encode_info_for_mod(ecx: @encode_ctxt, ebml_w: writer::Encoder,
                 let (ident, did) = (item.ident, item.id);
                 debug!("(encoding info for module) ... encoding impl %s \
                         (%?/%?)",
-                        ecx.tcx.sess.str_of(ident),
+                        *ecx.tcx.sess.str_of(ident),
                         did,
                         ast_map::node_id_to_str(ecx.tcx.items, did, ecx.tcx
                                                 .sess.parse_sess.interner));
@@ -353,15 +353,15 @@ fn encode_info_for_mod(ecx: @encode_ctxt, ebml_w: writer::Encoder,
     match ecx.reexports2.find(&id) {
         Some(ref exports) => {
             debug!("(encoding info for module) found reexports for %d", id);
-            for (*exports).each |exp| {
+            for exports.each |exp| {
                 debug!("(encoding info for module) reexport '%s' for %d",
-                       exp.name, id);
+                       *exp.name, id);
                 ebml_w.start_tag(tag_items_data_item_reexport);
                 ebml_w.start_tag(tag_items_data_item_reexport_def_id);
                 ebml_w.wr_str(def_to_str(exp.def_id));
                 ebml_w.end_tag();
                 ebml_w.start_tag(tag_items_data_item_reexport_name);
-                ebml_w.wr_str(exp.name);
+                ebml_w.wr_str(*exp.name);
                 ebml_w.end_tag();
                 ebml_w.end_tag();
             }
@@ -447,7 +447,7 @@ fn encode_info_for_struct(ecx: @encode_ctxt, ebml_w: writer::Encoder,
         global_index.push({val: id, pos: ebml_w.writer.tell()});
         ebml_w.start_tag(tag_items_data_item);
         debug!("encode_info_for_struct: doing %s %d",
-               tcx.sess.str_of(nm), id);
+               *tcx.sess.str_of(nm), id);
         encode_visibility(ebml_w, vis);
         encode_name(ecx, ebml_w, nm);
         encode_path(ecx, ebml_w, path, ast_map::path_name(nm));
@@ -470,7 +470,7 @@ fn encode_info_for_ctor(ecx: @encode_ctxt, ebml_w: writer::Encoder,
         encode_type_param_bounds(ebml_w, ecx, tps);
         let its_ty = node_id_to_type(ecx.tcx, id);
         debug!("fn name = %s ty = %s its node id = %d",
-               ecx.tcx.sess.str_of(ident),
+               *ecx.tcx.sess.str_of(ident),
                ty_to_str(ecx.tcx, its_ty), id);
         encode_type(ecx, ebml_w, its_ty);
         encode_path(ecx, ebml_w, path, ast_map::path_name(ident));
@@ -515,7 +515,7 @@ fn encode_info_for_method(ecx: @encode_ctxt,
                           m: @method,
                           +all_tps: ~[ty_param]) {
     debug!("encode_info_for_method: %d %s %u", m.id,
-           ecx.tcx.sess.str_of(m.ident), all_tps.len());
+           *ecx.tcx.sess.str_of(m.ident), all_tps.len());
     ebml_w.start_tag(tag_items_data_item);
     encode_def_id(ebml_w, local_def(m.id));
     match m.self_ty.node {
@@ -678,7 +678,7 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: writer::Encoder,
                                ebml_w,
                                dtor.node.id,
                                ecx.tcx.sess.ident_of(
-                                   ecx.tcx.sess.str_of(item.ident) +
+                                   *ecx.tcx.sess.str_of(item.ident) +
                                    ~"_dtor"),
                                path,
                                if tps.len() > 0u {
@@ -1186,7 +1186,7 @@ fn encode_crate_dep(ecx: @encode_ctxt, ebml_w: writer::Encoder,
                     dep: decoder::crate_dep) {
     ebml_w.start_tag(tag_crate_dep);
     ebml_w.start_tag(tag_crate_dep_name);
-    ebml_w.writer.write(str::to_bytes(ecx.tcx.sess.str_of(dep.name)));
+    ebml_w.writer.write(str::to_bytes(*ecx.tcx.sess.str_of(dep.name)));
     ebml_w.end_tag();
     ebml_w.start_tag(tag_crate_dep_vers);
     ebml_w.writer.write(str::to_bytes(*dep.vers));

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -145,15 +145,15 @@ fn find_library_crate_aux(cx: ctxt,
 pub fn crate_name_from_metas(+metas: ~[@ast::meta_item]) -> ~str {
     let name_items = attr::find_meta_items_by_name(metas, ~"name");
     match vec::last_opt(name_items) {
-      Some(i) => {
-        match attr::get_meta_item_value_str(i) {
-          Some(ref n) => /*bad*/copy **n,
-          // FIXME (#2406): Probably want a warning here since the user
-          // is using the wrong type of meta item.
-          _ => fail!()
+        Some(i) => {
+            match attr::get_meta_item_value_str(i) {
+                Some(ref n) => /*bad*/copy **n,
+                // FIXME (#2406): Probably want a warning here since the user
+                // is using the wrong type of meta item.
+                _ => fail!()
+            }
         }
-      }
-      None => fail!(~"expected to find the crate name")
+        None => fail!(~"expected to find the crate name")
     }
 }
 

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -147,7 +147,7 @@ pub fn crate_name_from_metas(+metas: ~[@ast::meta_item]) -> ~str {
     match vec::last_opt(name_items) {
       Some(i) => {
         match attr::get_meta_item_value_str(i) {
-          Some(ref n) => (/*bad*/copy *n),
+          Some(ref n) => /*bad*/copy **n,
           // FIXME (#2406): Probably want a warning here since the user
           // is using the wrong type of meta item.
           _ => fail!()

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -49,7 +49,7 @@ pub type ctxt = {
     span: span,
     ident: ast::ident,
     metas: ~[@ast::meta_item],
-    hash: ~str,
+    hash: @~str,
     os: os,
     static: bool,
     intr: @ident_interner
@@ -91,7 +91,7 @@ fn find_library_crate_aux(cx: ctxt,
                           filesearch: filesearch::FileSearch) ->
    Option<{ident: ~str, data: @~[u8]}> {
     let crate_name = crate_name_from_metas(/*bad*/copy cx.metas);
-    let prefix: ~str = nn.prefix + crate_name + ~"-";
+    let prefix: ~str = nn.prefix + *crate_name + ~"-";
     let suffix: ~str = /*bad*/copy nn.suffix;
 
     let mut matches = ~[];
@@ -130,7 +130,7 @@ fn find_library_crate_aux(cx: ctxt,
         Some(/*bad*/copy matches[0])
     } else {
         cx.diag.span_err(
-            cx.span, fmt!("multiple matching crates for `%s`", crate_name));
+            cx.span, fmt!("multiple matching crates for `%s`", *crate_name));
         cx.diag.handler().note(~"candidates:");
         for matches.each |match_| {
             cx.diag.handler().note(fmt!("path: %s", match_.ident));
@@ -142,12 +142,12 @@ fn find_library_crate_aux(cx: ctxt,
     }
 }
 
-pub fn crate_name_from_metas(+metas: ~[@ast::meta_item]) -> ~str {
+pub fn crate_name_from_metas(+metas: &[@ast::meta_item]) -> @~str {
     let name_items = attr::find_meta_items_by_name(metas, ~"name");
     match vec::last_opt(name_items) {
         Some(i) => {
             match attr::get_meta_item_value_str(i) {
-                Some(ref n) => /*bad*/copy **n,
+                Some(n) => n,
                 // FIXME (#2406): Probably want a warning here since the user
                 // is using the wrong type of meta item.
                 _ => fail!()
@@ -167,7 +167,7 @@ pub fn note_linkage_attrs(intr: @ident_interner, diag: span_handler,
 
 fn crate_matches(crate_data: @~[u8],
                  metas: &[@ast::meta_item],
-                 hash: ~str) -> bool {
+                 hash: @~str) -> bool {
     let attrs = decoder::get_crate_attributes(crate_data);
     let linkage_metas = attr::find_linkage_metas(attrs);
     if !hash.is_empty() {

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -175,7 +175,7 @@ fn enc_bound_region(w: io::Writer, cx: @ctxt, br: ty::bound_region) {
       }
       ty::br_named(s) => {
         w.write_char('[');
-        w.write_str(cx.tcx.sess.str_of(s));
+        w.write_str(*cx.tcx.sess.str_of(s));
         w.write_char(']')
       }
       ty::br_cap_avoid(id, br) => {
@@ -282,7 +282,7 @@ fn enc_sty(w: io::Writer, cx: @ctxt, +st: ty::sty) {
       ty::ty_rec(fields) => {
         w.write_str(&"R[");
         for fields.each |field| {
-            w.write_str(cx.tcx.sess.str_of(field.ident));
+            w.write_str(*cx.tcx.sess.str_of(field.ident));
             w.write_char('=');
             enc_mt(w, cx, field.mt);
         }

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -96,7 +96,7 @@ pub fn encode_inlined_item(ecx: @e::encode_ctxt,
                            maps: Maps) {
     debug!("> Encoding inlined item: %s::%s (%u)",
            ast_map::path_to_str(path, ecx.tcx.sess.parse_sess.interner),
-           ecx.tcx.sess.str_of(ii.ident()),
+           *ecx.tcx.sess.str_of(ii.ident()),
            ebml_w.writer.tell());
 
     let id_range = ast_util::compute_id_range_for_inlined_item(ii);
@@ -108,7 +108,7 @@ pub fn encode_inlined_item(ecx: @e::encode_ctxt,
 
     debug!("< Encoded inlined fn: %s::%s (%u)",
            ast_map::path_to_str(path, ecx.tcx.sess.parse_sess.interner),
-           ecx.tcx.sess.str_of(ii.ident()),
+           *ecx.tcx.sess.str_of(ii.ident()),
            ebml_w.writer.tell());
 }
 
@@ -132,10 +132,10 @@ pub fn decode_inlined_item(cdata: cstore::crate_metadata,
                                           to_id_range: to_id_range});
         let raw_ii = decode_ast(ast_doc);
         let ii = renumber_ast(xcx, raw_ii);
-        debug!("Fn named: %s", tcx.sess.str_of(ii.ident()));
+        debug!("Fn named: %s", *tcx.sess.str_of(ii.ident()));
         debug!("< Decoded inlined fn: %s::%s",
                ast_map::path_to_str(path, tcx.sess.parse_sess.interner),
-               tcx.sess.str_of(ii.ident()));
+               *tcx.sess.str_of(ii.ident()));
         ast_map::map_decoded_item(tcx.sess.diagnostic(),
                                   dcx.tcx.items, path, ii);
         decode_side_tables(xcx, ast_doc);

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -143,13 +143,13 @@ pub fn check_exhaustive(cx: @MatchCheckCtxt, sp: span, pats: ~[@pat]) {
             match ty::get(ty).sty {
                 ty::ty_bool => {
                     match (*ctor) {
-                        val(const_bool(true)) => Some(~"true"),
-                        val(const_bool(false)) => Some(~"false"),
+                        val(const_bool(true)) => Some(@~"true"),
+                        val(const_bool(false)) => Some(@~"false"),
                         _ => None
                     }
                 }
                 ty::ty_enum(id, _) => {
-                    let vid = match (*ctor) {
+                    let vid = match *ctor {
                         variant(id) => id,
                         _ => fail!(~"check_exhaustive: non-variant ctor"),
                     };
@@ -163,8 +163,8 @@ pub fn check_exhaustive(cx: @MatchCheckCtxt, sp: span, pats: ~[@pat]) {
                     }
                 }
                 ty::ty_unboxed_vec(*) | ty::ty_evec(*) => {
-                    match (*ctor) {
-                        vec(n) => Some(fmt!("vectors of length %u", n)),
+                    match *ctor {
+                        vec(n) => Some(@fmt!("vectors of length %u", n)),
                     _ => None
                     }
                 }
@@ -173,7 +173,7 @@ pub fn check_exhaustive(cx: @MatchCheckCtxt, sp: span, pats: ~[@pat]) {
         }
     };
     let msg = ~"non-exhaustive patterns" + match ext {
-        Some(ref s) => ~": " + (*s) + ~" not covered",
+        Some(ref s) => ~": " + **s + ~" not covered",
         None => ~""
     };
     cx.tcx.sess.span_err(sp, msg);

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -134,39 +134,47 @@ pub fn raw_pat(p: @pat) -> @pat {
 pub fn check_exhaustive(cx: @MatchCheckCtxt, sp: span, pats: ~[@pat]) {
     assert(!pats.is_empty());
     let ext = match is_useful(cx, vec::map(pats, |p| ~[*p]), ~[wild()]) {
-      not_useful => return, // This is good, wildcard pattern isn't reachable
-      useful_ => None,
-      useful(ty, ref ctor) => {
-        match ty::get(ty).sty {
-          ty::ty_bool => {
-            match (*ctor) {
-              val(const_bool(true)) => Some(~"true"),
-              val(const_bool(false)) => Some(~"false"),
-              _ => None
-            }
-          }
-          ty::ty_enum(id, _) => {
-              let vid = match (*ctor) { variant(id) => id,
-              _ => fail!(~"check_exhaustive: non-variant ctor") };
-            match vec::find(*ty::enum_variants(cx.tcx, id),
-                                |v| v.id == vid) {
-                Some(v) => Some(cx.tcx.sess.str_of(v.name)),
-              None => fail!(~"check_exhaustive: bad variant in ctor")
-            }
-          }
-          ty::ty_unboxed_vec(*) | ty::ty_evec(*) => {
-            match (*ctor) {
-              vec(n) => Some(fmt!("vectors of length %u", n)),
-              _ => None
-            }
-          }
-          _ => None
+        not_useful => {
+            // This is good, wildcard pattern isn't reachable
+            return;
         }
-      }
+        useful_ => None,
+        useful(ty, ref ctor) => {
+            match ty::get(ty).sty {
+                ty::ty_bool => {
+                    match (*ctor) {
+                        val(const_bool(true)) => Some(~"true"),
+                        val(const_bool(false)) => Some(~"false"),
+                        _ => None
+                    }
+                }
+                ty::ty_enum(id, _) => {
+                    let vid = match (*ctor) {
+                        variant(id) => id,
+                        _ => fail!(~"check_exhaustive: non-variant ctor"),
+                    };
+                    let variants = ty::enum_variants(cx.tcx, id);
+
+                    match variants.find(|v| v.id == vid) {
+                        Some(v) => Some(cx.tcx.sess.str_of(v.name)),
+                        None => {
+                            fail!(~"check_exhaustive: bad variant in ctor")
+                        }
+                    }
+                }
+                ty::ty_unboxed_vec(*) | ty::ty_evec(*) => {
+                    match (*ctor) {
+                        vec(n) => Some(fmt!("vectors of length %u", n)),
+                    _ => None
+                    }
+                }
+                _ => None
+            }
+        }
     };
     let msg = ~"non-exhaustive patterns" + match ext {
-      Some(ref s) => ~": " + (*s) + ~" not covered",
-      None => ~""
+        Some(ref s) => ~": " + (*s) + ~" not covered",
+        None => ~""
     };
     cx.tcx.sess.span_err(sp, msg);
 }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -321,7 +321,7 @@ impl LanguageItemCollector {
                 match literal.node {
                     lit_str(value) => {
                         self.match_and_collect_item(item_def_id,
-                                                    (/*bad*/copy *key),
+                                                    (/*bad*/copy **key),
                                                     /*bad*/copy *value);
                     }
                     _ => {} // Skip.

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -256,45 +256,46 @@ fn LanguageItemCollector(crate: @crate,
                       -> LanguageItemCollector/&r {
     let item_refs = HashMap();
 
-    item_refs.insert(~"const", ConstTraitLangItem as uint);
-    item_refs.insert(~"copy", CopyTraitLangItem as uint);
-    item_refs.insert(~"owned", OwnedTraitLangItem as uint);
-    item_refs.insert(~"durable", DurableTraitLangItem as uint);
+    item_refs.insert(@~"const", ConstTraitLangItem as uint);
+    item_refs.insert(@~"copy", CopyTraitLangItem as uint);
+    item_refs.insert(@~"owned", OwnedTraitLangItem as uint);
+    item_refs.insert(@~"durable", DurableTraitLangItem as uint);
 
-    item_refs.insert(~"drop", DropTraitLangItem as uint);
+    item_refs.insert(@~"drop", DropTraitLangItem as uint);
 
-    item_refs.insert(~"add", AddTraitLangItem as uint);
-    item_refs.insert(~"sub", SubTraitLangItem as uint);
-    item_refs.insert(~"mul", MulTraitLangItem as uint);
-    item_refs.insert(~"div", DivTraitLangItem as uint);
-    item_refs.insert(~"modulo", ModuloTraitLangItem as uint);
-    item_refs.insert(~"neg", NegTraitLangItem as uint);
-    item_refs.insert(~"not", NotTraitLangItem as uint);
-    item_refs.insert(~"bitxor", BitXorTraitLangItem as uint);
-    item_refs.insert(~"bitand", BitAndTraitLangItem as uint);
-    item_refs.insert(~"bitor", BitOrTraitLangItem as uint);
-    item_refs.insert(~"shl", ShlTraitLangItem as uint);
-    item_refs.insert(~"shr", ShrTraitLangItem as uint);
-    item_refs.insert(~"index", IndexTraitLangItem as uint);
+    item_refs.insert(@~"add", AddTraitLangItem as uint);
+    item_refs.insert(@~"sub", SubTraitLangItem as uint);
+    item_refs.insert(@~"mul", MulTraitLangItem as uint);
+    item_refs.insert(@~"div", DivTraitLangItem as uint);
+    item_refs.insert(@~"modulo", ModuloTraitLangItem as uint);
+    item_refs.insert(@~"neg", NegTraitLangItem as uint);
+    item_refs.insert(@~"not", NotTraitLangItem as uint);
+    item_refs.insert(@~"bitxor", BitXorTraitLangItem as uint);
+    item_refs.insert(@~"bitand", BitAndTraitLangItem as uint);
+    item_refs.insert(@~"bitor", BitOrTraitLangItem as uint);
+    item_refs.insert(@~"shl", ShlTraitLangItem as uint);
+    item_refs.insert(@~"shr", ShrTraitLangItem as uint);
+    item_refs.insert(@~"index", IndexTraitLangItem as uint);
 
-    item_refs.insert(~"eq", EqTraitLangItem as uint);
-    item_refs.insert(~"ord", OrdTraitLangItem as uint);
+    item_refs.insert(@~"eq", EqTraitLangItem as uint);
+    item_refs.insert(@~"ord", OrdTraitLangItem as uint);
 
-    item_refs.insert(~"str_eq", StrEqFnLangItem as uint);
-    item_refs.insert(~"uniq_str_eq", UniqStrEqFnLangItem as uint);
-    item_refs.insert(~"annihilate", AnnihilateFnLangItem as uint);
-    item_refs.insert(~"log_type", LogTypeFnLangItem as uint);
-    item_refs.insert(~"fail_", FailFnLangItem as uint);
-    item_refs.insert(~"fail_bounds_check", FailBoundsCheckFnLangItem as uint);
-    item_refs.insert(~"exchange_malloc", ExchangeMallocFnLangItem as uint);
-    item_refs.insert(~"exchange_free", ExchangeFreeFnLangItem as uint);
-    item_refs.insert(~"malloc", MallocFnLangItem as uint);
-    item_refs.insert(~"free", FreeFnLangItem as uint);
-    item_refs.insert(~"borrow_as_imm", BorrowAsImmFnLangItem as uint);
-    item_refs.insert(~"return_to_mut", ReturnToMutFnLangItem as uint);
-    item_refs.insert(~"check_not_borrowed",
+    item_refs.insert(@~"str_eq", StrEqFnLangItem as uint);
+    item_refs.insert(@~"uniq_str_eq", UniqStrEqFnLangItem as uint);
+    item_refs.insert(@~"annihilate", AnnihilateFnLangItem as uint);
+    item_refs.insert(@~"log_type", LogTypeFnLangItem as uint);
+    item_refs.insert(@~"fail_", FailFnLangItem as uint);
+    item_refs.insert(@~"fail_bounds_check",
+                     FailBoundsCheckFnLangItem as uint);
+    item_refs.insert(@~"exchange_malloc", ExchangeMallocFnLangItem as uint);
+    item_refs.insert(@~"exchange_free", ExchangeFreeFnLangItem as uint);
+    item_refs.insert(@~"malloc", MallocFnLangItem as uint);
+    item_refs.insert(@~"free", FreeFnLangItem as uint);
+    item_refs.insert(@~"borrow_as_imm", BorrowAsImmFnLangItem as uint);
+    item_refs.insert(@~"return_to_mut", ReturnToMutFnLangItem as uint);
+    item_refs.insert(@~"check_not_borrowed",
                      CheckNotBorrowedFnLangItem as uint);
-    item_refs.insert(~"strdup_uniq", StrDupUniqFnLangItem as uint);
+    item_refs.insert(@~"strdup_uniq", StrDupUniqFnLangItem as uint);
 
     LanguageItemCollector {
         crate: crate,
@@ -310,19 +311,17 @@ struct LanguageItemCollector {
     crate: @crate,
     session: Session,
 
-    item_refs: HashMap<~str,uint>,
+    item_refs: HashMap<@~str, uint>,
 }
 
 impl LanguageItemCollector {
     fn match_and_collect_meta_item(item_def_id: def_id,
                                    meta_item: meta_item) {
         match meta_item.node {
-            meta_name_value(ref key, literal) => {
+            meta_name_value(key, literal) => {
                 match literal.node {
                     lit_str(value) => {
-                        self.match_and_collect_item(item_def_id,
-                                                    (/*bad*/copy **key),
-                                                    /*bad*/copy *value);
+                        self.match_and_collect_item(item_def_id, key, value);
                     }
                     _ => {} // Skip.
                 }
@@ -347,8 +346,8 @@ impl LanguageItemCollector {
         self.items.items[item_index] = Some(item_def_id);
     }
 
-    fn match_and_collect_item(item_def_id: def_id, key: ~str, value: ~str) {
-        if key != ~"lang" {
+    fn match_and_collect_item(item_def_id: def_id, key: @~str, value: @~str) {
+        if *key != ~"lang" {
             return;    // Didn't match.
         }
 
@@ -394,7 +393,7 @@ impl LanguageItemCollector {
         for self.item_refs.each |&key, &item_ref| {
             match self.items.items[item_ref] {
                 None => {
-                    self.session.err(fmt!("no item found for `%s`", key));
+                    self.session.err(fmt!("no item found for `%s`", *key));
                 }
                 Some(_) => {
                     // OK.

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -346,13 +346,13 @@ impl ctxt {
 
         for triples.each |pair| {
             let (meta, level, lintname) = /*bad*/copy *pair;
-            match self.dict.find(&lintname) {
+            match self.dict.find(&*lintname) {
               None => {
                 self.span_lint(
                     new_ctxt.get_level(unrecognized_lint),
                     meta.span,
                     fmt!("unknown `%s` attribute: `%s`",
-                         level_to_str(level), lintname));
+                         level_to_str(level), *lintname));
               }
               Some(lint) => {
 
@@ -363,7 +363,7 @@ impl ctxt {
                         meta.span,
                         fmt!("%s(%s) overruled by outer forbid(%s)",
                              level_to_str(level),
-                             lintname, lintname));
+                             *lintname, *lintname));
                 }
 
                 // we do multiple unneeded copies of the

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -866,18 +866,18 @@ fn check_item_non_camel_case_types(cx: ty::ctxt, it: @ast::item) {
     }
 
     match it.node {
-      ast::item_ty(*) | ast::item_struct(*) |
-      ast::item_trait(*) => {
-        check_case(cx, it.ident, it.id, it.id, it.span)
-      }
-      ast::item_enum(ref enum_definition, _) => {
-        check_case(cx, it.ident, it.id, it.id, it.span);
-        for enum_definition.variants.each |variant| {
-            check_case(cx, variant.node.name,
-                       variant.node.id, it.id, variant.span);
+        ast::item_ty(*) | ast::item_struct(*) |
+        ast::item_trait(*) => {
+            check_case(cx, it.ident, it.id, it.id, it.span)
         }
-      }
-      _ => ()
+        ast::item_enum(ref enum_definition, _) => {
+            check_case(cx, it.ident, it.id, it.id, it.span);
+            for enum_definition.variants.each |variant| {
+                check_case(cx, variant.node.name,
+                           variant.node.id, it.id, variant.span);
+            }
+        }
+        _ => ()
     }
 }
 

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -834,26 +834,23 @@ fn check_item_non_camel_case_types(cx: ty::ctxt, it: @ast::item) {
     fn is_camel_case(cx: ty::ctxt, ident: ast::ident) -> bool {
         let ident = cx.sess.str_of(ident);
         assert !ident.is_empty();
-        let ident = ident_without_trailing_underscores(ident);
+        let ident = ident_without_trailing_underscores(*ident);
         let ident = ident_without_leading_underscores(ident);
         char::is_uppercase(str::char_at(ident, 0)) &&
             !ident.contains_char('_')
     }
 
-    fn ident_without_trailing_underscores(+ident: ~str) -> ~str {
+    fn ident_without_trailing_underscores(ident: &r/str) -> &r/str {
         match str::rfind(ident, |c| c != '_') {
-            Some(idx) => (ident).slice(0, idx + 1),
-            None => { ident } // all underscores
+            Some(idx) => str::view(ident, 0, idx + 1),
+            None => ident, // all underscores
         }
     }
 
-    fn ident_without_leading_underscores(+ident: ~str) -> ~str {
+    fn ident_without_leading_underscores(ident: &r/str) -> &r/str {
         match str::find(ident, |c| c != '_') {
-          Some(idx) => ident.slice(idx, ident.len()),
-          None => {
-            // all underscores
-            ident
-          }
+            Some(idx) => str::view(ident, idx, ident.len()),
+            None => ident // all underscores
         }
     }
 

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -117,7 +117,7 @@ type lint_spec = @{lint: lint,
                    desc: &static/str,
                    default: level};
 
-pub type lint_dict = HashMap<~str,lint_spec>;
+pub type lint_dict = HashMap<@~str, lint_spec>;
 
 /*
   Pass names should not contain a '-', as the compiler normalizes
@@ -125,109 +125,109 @@ pub type lint_dict = HashMap<~str,lint_spec>;
  */
 pub fn get_lint_dict() -> lint_dict {
     let v = ~[
-        (~"ctypes",
+        (@~"ctypes",
          @{lint: ctypes,
            desc: "proper use of core::libc types in foreign modules",
            default: warn}),
 
-        (~"unused_imports",
+        (@~"unused_imports",
          @{lint: unused_imports,
            desc: "imports that are never used",
            default: allow}),
 
-        (~"while_true",
+        (@~"while_true",
          @{lint: while_true,
            desc: "suggest using loop { } instead of while(true) { }",
            default: warn}),
 
-        (~"path_statement",
+        (@~"path_statement",
          @{lint: path_statement,
            desc: "path statements with no effect",
            default: warn}),
 
-        (~"unrecognized_lint",
+        (@~"unrecognized_lint",
          @{lint: unrecognized_lint,
            desc: "unrecognized lint attribute",
            default: warn}),
 
-        (~"non_implicitly_copyable_typarams",
+        (@~"non_implicitly_copyable_typarams",
          @{lint: non_implicitly_copyable_typarams,
            desc: "passing non implicitly copyable types as copy type params",
            default: warn}),
 
-        (~"vecs_implicitly_copyable",
+        (@~"vecs_implicitly_copyable",
          @{lint: vecs_implicitly_copyable,
            desc: "make vecs and strs not implicitly copyable \
                   (only checked at top level)",
            default: warn}),
 
-        (~"implicit_copies",
+        (@~"implicit_copies",
          @{lint: implicit_copies,
            desc: "implicit copies of non implicitly copyable data",
            default: warn}),
 
-        (~"deprecated_mode",
+        (@~"deprecated_mode",
          @{lint: deprecated_mode,
            desc: "warn about deprecated uses of modes",
            default: warn}),
 
-        (~"deprecated_pattern",
+        (@~"deprecated_pattern",
          @{lint: deprecated_pattern,
            desc: "warn about deprecated uses of pattern bindings",
            default: allow}),
 
-        (~"non_camel_case_types",
+        (@~"non_camel_case_types",
          @{lint: non_camel_case_types,
            desc: "types, variants and traits should have camel case names",
            default: allow}),
 
-        (~"managed_heap_memory",
+        (@~"managed_heap_memory",
          @{lint: managed_heap_memory,
            desc: "use of managed (@ type) heap memory",
            default: allow}),
 
-        (~"owned_heap_memory",
+        (@~"owned_heap_memory",
          @{lint: owned_heap_memory,
            desc: "use of owned (~ type) heap memory",
            default: allow}),
 
-        (~"heap_memory",
+        (@~"heap_memory",
          @{lint: heap_memory,
            desc: "use of any (~ type or @ type) heap memory",
            default: allow}),
 
-        (~"structural_records",
+        (@~"structural_records",
          @{lint: structural_records,
            desc: "use of any structural records",
            default: deny}),
 
-        (~"legacy modes",
+        (@~"legacy modes",
          @{lint: legacy_modes,
            desc: "allow legacy modes",
            default: forbid}),
 
-        (~"type_limits",
+        (@~"type_limits",
          @{lint: type_limits,
            desc: "comparisons made useless by limits of the types involved",
            default: warn}),
 
-        (~"default_methods",
+        (@~"default_methods",
          @{lint: default_methods,
            desc: "allow default methods",
            default: deny}),
 
-        (~"deprecated_self",
+        (@~"deprecated_self",
          @{lint: deprecated_self,
            desc: "warn about deprecated uses of `self`",
            default: warn}),
 
         /* FIXME(#3266)--make liveness warnings lintable
-        (~"unused_variable",
+        (@~"unused_variable",
          @{lint: unused_variable,
            desc: "detect variables which are not used in any way",
            default: warn}),
 
-        (~"dead_assignment",
+        (@~"dead_assignment",
          @{lint: dead_assignment,
            desc: "detect assignments that will never be read",
            default: warn}),
@@ -344,9 +344,14 @@ impl ctxt {
             }
         }
 
-        for triples.each |pair| {
-            let (meta, level, lintname) = /*bad*/copy *pair;
-            match self.dict.find(&*lintname) {
+        for triples.each |triple| {
+            // FIXME(#3874): it would be nicer to write this...
+            // let (meta, level, lintname) = /*bad*/copy *pair;
+            let (meta, level, lintname) = match *triple {
+                (ref meta, level, lintname) => (meta, level, lintname)
+            };
+
+            match self.dict.find(&lintname) {
               None => {
                 self.span_lint(
                     new_ctxt.get_level(unrecognized_lint),

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -383,11 +383,11 @@ impl IrMaps {
         }
     }
 
-    fn variable_name(&mut self, var: Variable) -> ~str {
+    fn variable_name(&mut self, var: Variable) -> @~str {
         match copy self.var_kinds[*var] {
             Local(LocalInfo {ident: nm, _}) |
             Arg(_, nm, _) => self.tcx.sess.str_of(nm),
-            ImplicitRet => ~"<implicit-ret>"
+            ImplicitRet => @~"<implicit-ret>"
         }
     }
 
@@ -1777,7 +1777,7 @@ impl @Liveness {
                 self.tcx.sess.span_err(
                     move_expr.span,
                     fmt!("illegal move from argument `%s`, which is not \
-                          copy or move mode", self.tcx.sess.str_of(name)));
+                          copy or move mode", *self.tcx.sess.str_of(name)));
                 return;
               }
               Local(*) | ImplicitRet => {
@@ -1798,7 +1798,7 @@ impl @Liveness {
                     move_expr.span,
                     fmt!("`%s` moved into closure environment here \
                           because its type is moved by default",
-                         name));
+                         *name));
             }
             expr_path(*) => {
                 self.report_illegal_read(
@@ -1838,7 +1838,7 @@ impl @Liveness {
             move_expr.span,
             fmt!("%s`%s` moved here because %s has type %s, \
                   which is moved by default (use `copy` to override)",
-                 expr_descr, name, pronoun,
+                 expr_descr, *name, pronoun,
                  ty_to_str(self.tcx, move_expr_ty)));
     }
 
@@ -1858,12 +1858,12 @@ impl @Liveness {
           FreeVarNode(span) => {
             self.tcx.sess.span_err(
                 span,
-                fmt!("capture of %s: `%s`", msg, name));
+                fmt!("capture of %s: `%s`", msg, *name));
           }
           ExprNode(span) => {
             self.tcx.sess.span_err(
                 span,
-                fmt!("use of %s: `%s`", msg, name));
+                fmt!("use of %s: `%s`", msg, *name));
           }
           ExitNode | VarDefNode(_) => {
             self.tcx.sess.span_bug(
@@ -1873,9 +1873,9 @@ impl @Liveness {
         }
     }
 
-    fn should_warn(var: Variable) -> Option<~str> {
+    fn should_warn(var: Variable) -> Option<@~str> {
         let name = self.ir.variable_name(var);
-        if name[0] == ('_' as u8) {None} else {Some(name)}
+        if name[0] == ('_' as u8) { None } else { Some(name) }
     }
 
     fn warn_about_unused_args(decl: fn_decl, entry_ln: LiveNode) {
@@ -1913,11 +1913,11 @@ impl @Liveness {
                     // FIXME(#3266)--make liveness warnings lintable
                     self.tcx.sess.span_warn(
                         sp, fmt!("variable `%s` is assigned to, \
-                                  but never used", *name));
+                                  but never used", **name));
                 } else {
                     // FIXME(#3266)--make liveness warnings lintable
                     self.tcx.sess.span_warn(
-                        sp, fmt!("unused variable: `%s`", *name));
+                        sp, fmt!("unused variable: `%s`", **name));
                 }
             }
             return true;
@@ -1931,7 +1931,7 @@ impl @Liveness {
                 // FIXME(#3266)--make liveness warnings lintable
                 self.tcx.sess.span_warn(
                     sp,
-                    fmt!("value assigned to `%s` is never read", *name));
+                    fmt!("value assigned to `%s` is never read", **name));
             }
         }
     }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -629,7 +629,7 @@ pub impl mem_categorization_ctxt {
                 self.tcx.sess.span_bug(
                     node.span(),
                     fmt!("Cannot find field `%s` in type `%s`",
-                         self.tcx.sess.str_of(f_name),
+                         *self.tcx.sess.str_of(f_name),
                          ty_to_str(self.tcx, base_cmt.ty)));
             }
         };
@@ -995,7 +995,7 @@ pub impl mem_categorization_ctxt {
                  self.ptr_sigil(ptr), derefs)
           }
           cat_comp(cmt, comp) => {
-            fmt!("%s.%s", self.cat_to_repr(cmt.cat), self.comp_to_repr(comp))
+            fmt!("%s.%s", self.cat_to_repr(cmt.cat), *self.comp_to_repr(comp))
           }
           cat_discr(cmt, _) => self.cat_to_repr(cmt.cat)
         }
@@ -1018,13 +1018,13 @@ pub impl mem_categorization_ctxt {
         }
     }
 
-    fn comp_to_repr(&self, comp: comp_kind) -> ~str {
+    fn comp_to_repr(&self, comp: comp_kind) -> @~str {
         match comp {
           comp_field(fld, _) => self.tcx.sess.str_of(fld),
-          comp_index(*) => ~"[]",
-          comp_tuple => ~"()",
-          comp_anon_field => ~"<anonymous field>",
-          comp_variant(_) => ~"<enum>"
+          comp_index(*) => @~"[]",
+          comp_tuple => @~"()",
+          comp_anon_field => @~"<anonymous field>",
+          comp_variant(_) => @~"<enum>"
         }
     }
 
@@ -1043,7 +1043,7 @@ pub impl mem_categorization_ctxt {
           }
           lp_comp(lp, comp) => {
             fmt!("%s.%s", self.lp_to_str(lp),
-                 self.comp_to_repr(comp))
+                 *self.comp_to_repr(comp))
           }
         }
     }

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1629,7 +1629,7 @@ pub fn trans_match_inner(scope_cx: block,
             // Special case for empty types
             let fail_cx = @mut None;
             let f: mk_fail = || mk_fail(scope_cx, discr_expr.span,
-                            ~"scrutinizing value that can't exist", fail_cx);
+                            @~"scrutinizing value that can't exist", fail_cx);
             Some(f)
         } else {
             None
@@ -1661,7 +1661,7 @@ pub fn trans_match_inner(scope_cx: block,
     bcx = controlflow::join_blocks(scope_cx, dvec::unwrap(arm_cxs));
     return bcx;
 
-    fn mk_fail(bcx: block, sp: span, +msg: ~str,
+    fn mk_fail(bcx: block, sp: span, msg: @~str,
                finished: @mut Option<BasicBlockRef>) -> BasicBlockRef {
         match *finished { Some(bb) => return bb, _ => () }
         let fail_cx = sub_block(bcx, ~"case_fallthrough");

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2859,9 +2859,9 @@ pub fn fill_crate_map(ccx: @crate_ctxt, map: ValueRef) {
     let cstore = ccx.sess.cstore;
     while cstore::have_crate_data(cstore, i) {
         let cdata = cstore::get_crate_data(cstore, i);
-        let nm = ~"_rust_crate_map_" + cdata.name +
-            ~"_" + cstore::get_crate_vers(cstore, i) +
-            ~"_" + cstore::get_crate_hash(cstore, i);
+        let nm = ~"_rust_crate_map_" + *cdata.name +
+            ~"_" + *cstore::get_crate_vers(cstore, i) +
+            ~"_" + *cstore::get_crate_hash(cstore, i);
         let cr = str::as_c_str(nm, |buf| {
             unsafe {
                 llvm::LLVMAddGlobal(ccx.llmod, ccx.int_type, buf)

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -521,7 +521,7 @@ pub fn compare_scalar_types(cx: block,
             rslt(
                 controlflow::trans_fail(
                     cx, None,
-                    ~"attempt to compare values of type type"),
+                    @~"attempt to compare values of type type"),
                 C_nil())
         }
         _ => {
@@ -639,7 +639,7 @@ pub fn iter_structural_ty(cx: block, av: ValueRef, t: ty::t,
           _ => cx.tcx().sess.bug(fmt!("iter_variant: not a function type: \
                                        %s (variant name = %s)",
                                       cx.ty_to_str(fn_ty),
-                                      cx.sess().str_of(variant.name)))
+                                      *cx.sess().str_of(variant.name)))
         }
         return cx;
     }
@@ -776,7 +776,7 @@ pub fn fail_if_zero(cx: block, span: span, divmod: ast::binop,
       }
     };
     do with_cond(cx, is_zero) |bcx| {
-        controlflow::trans_fail(bcx, Some(span), /*bad*/copy text)
+        controlflow::trans_fail(bcx, Some(span), @/*bad*/copy text)
     }
 }
 
@@ -1037,20 +1037,20 @@ pub fn load_if_immediate(cx: block, v: ValueRef, t: ty::t) -> ValueRef {
     return v;
 }
 
-pub fn trans_trace(bcx: block, sp_opt: Option<span>, +trace_str: ~str) {
+pub fn trans_trace(bcx: block, sp_opt: Option<span>, trace_str: ~str) {
     if !bcx.sess().trace() { return; }
     let _icx = bcx.insn_ctxt("trans_trace");
-    add_comment(bcx, trace_str);
-    let V_trace_str = C_cstr(bcx.ccx(), trace_str);
+    add_comment(bcx, /*bad*/ copy trace_str);
+    let V_trace_str = C_cstr(bcx.ccx(), @/*bad*/ copy trace_str);
     let {V_filename, V_line} = match sp_opt {
       Some(sp) => {
         let sess = bcx.sess();
         let loc = sess.parse_sess.cm.lookup_char_pos(sp.lo);
-        {V_filename: C_cstr(bcx.ccx(), /*bad*/copy loc.file.name),
+        {V_filename: C_cstr(bcx.ccx(), @/*bad*/copy loc.file.name),
          V_line: loc.line as int}
       }
       None => {
-        {V_filename: C_cstr(bcx.ccx(), ~"<runtime>"),
+        {V_filename: C_cstr(bcx.ccx(), @~"<runtime>"),
          V_line: 0}
       }
     };
@@ -1170,7 +1170,7 @@ pub fn new_block(cx: fn_ctxt, parent: Option<block>, +kind: block_kind,
         special_idents::invalid
     };
     unsafe {
-        let llbb: BasicBlockRef = str::as_c_str(cx.ccx.sess.str_of(s), |buf| {
+        let llbb = str::as_c_str(*cx.ccx.sess.str_of(s), |buf| {
             llvm::LLVMAppendBasicBlock(cx.llfn, buf)
         });
         let bcx = mk_block(llbb,
@@ -1401,7 +1401,7 @@ pub fn alloc_local(cx: block, local: @ast::local) -> block {
     let val = alloc_ty(cx, t);
     if cx.sess().opts.debuginfo {
         do option::iter(&simple_name) |name| {
-            str::as_c_str(cx.ccx().sess.str_of(*name), |buf| {
+            str::as_c_str(*cx.ccx().sess.str_of(*name), |buf| {
                 unsafe {
                     llvm::LLVMSetValueName(val, buf)
                 }
@@ -2815,7 +2815,7 @@ pub fn create_module_map(ccx: @crate_ctxt) -> ValueRef {
     }
     let mut elts: ~[ValueRef] = ~[];
     for ccx.module_data.each |&key, &val| {
-        let elt = C_struct(~[p2i(ccx, C_cstr(ccx, key)),
+        let elt = C_struct(~[p2i(ccx, C_cstr(ccx, @/*bad*/ copy key)),
                             p2i(ccx, val)]);
         elts.push(elt);
     }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -186,7 +186,7 @@ pub struct crate_ctxt {
      // Cache generated vtables
      vtables: HashMap<mono_id, ValueRef>,
      // Cache of constant strings,
-     const_cstr_cache: HashMap<~str, ValueRef>,
+     const_cstr_cache: HashMap<@~str, ValueRef>,
 
      // Reverse-direction for const ptrs cast from globals.
      // Key is an int, cast from a ValueRef holding a *T,
@@ -1141,14 +1141,14 @@ pub fn C_u8(i: uint) -> ValueRef {
 
 // This is a 'c-like' raw string, which differs from
 // our boxed-and-length-annotated strings.
-pub fn C_cstr(cx: @crate_ctxt, s: ~str) -> ValueRef {
+pub fn C_cstr(cx: @crate_ctxt, s: @~str) -> ValueRef {
     unsafe {
         match cx.const_cstr_cache.find(&s) {
             Some(llval) => return llval,
             None => ()
         }
 
-        let sc = do str::as_c_str(s) |buf| {
+        let sc = do str::as_c_str(*s) |buf| {
             llvm::LLVMConstString(buf, s.len() as c_uint, False)
         };
         let g =
@@ -1166,9 +1166,9 @@ pub fn C_cstr(cx: @crate_ctxt, s: ~str) -> ValueRef {
 
 // NB: Do not use `do_spill_noroot` to make this into a constant string, or
 // you will be kicked off fast isel. See issue #4352 for an example of this.
-pub fn C_estr_slice(cx: @crate_ctxt, +s: ~str) -> ValueRef {
+pub fn C_estr_slice(cx: @crate_ctxt, s: @~str) -> ValueRef {
     unsafe {
-        let len = str::len(s);
+        let len = s.len();
         let cs = llvm::LLVMConstPointerCast(C_cstr(cx, s), T_ptr(T_i8()));
         C_struct(~[cs, C_uint(cx, len + 1u /* +1 for null */)])
     }
@@ -1324,7 +1324,7 @@ pub fn path_str(sess: session::Session, p: path) -> ~str {
             ast_map::path_name(s) | ast_map::path_mod(s) => {
                 if first { first = false; }
                 else { r += ~"::"; }
-                r += sess.str_of(s);
+                r += *sess.str_of(s);
             }
         }
     }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1141,15 +1141,15 @@ pub fn C_u8(i: uint) -> ValueRef {
 
 // This is a 'c-like' raw string, which differs from
 // our boxed-and-length-annotated strings.
-pub fn C_cstr(cx: @crate_ctxt, +s: ~str) -> ValueRef {
+pub fn C_cstr(cx: @crate_ctxt, s: ~str) -> ValueRef {
     unsafe {
         match cx.const_cstr_cache.find(&s) {
-          Some(llval) => return llval,
-          None => ()
+            Some(llval) => return llval,
+            None => ()
         }
 
         let sc = do str::as_c_str(s) |buf| {
-            llvm::LLVMConstString(buf, str::len(s) as c_uint, False)
+            llvm::LLVMConstString(buf, s.len() as c_uint, False)
         };
         let g =
             str::as_c_str(fmt!("str%u", (cx.names)(~"str").repr),

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -55,7 +55,7 @@ pub fn const_lit(cx: @crate_ctxt, e: @ast::expr, lit: ast::lit)
       }
       ast::lit_bool(b) => C_bool(b),
       ast::lit_nil => C_nil(),
-      ast::lit_str(s) => C_estr_slice(cx, /*bad*/copy *s)
+      ast::lit_str(s) => C_estr_slice(cx, s)
     }
 }
 

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -320,8 +320,8 @@ pub fn trans_check_expr(bcx: block,
                         s: ~str)
                      -> block {
     let _icx = bcx.insn_ctxt("trans_check_expr");
-    let expr_str = s + ~" " + expr_to_str(pred_expr, bcx.ccx().sess.intr())
-        + ~" failed";
+    let expr_str = @(s + ~" " + expr_to_str(pred_expr, bcx.ccx().sess.intr())
+        + ~" failed");
     let Result {bcx, val} = {
         do with_scope_result(bcx, chk_expr.info(), ~"check") |bcx| {
             expr::trans_to_datum(bcx, pred_expr).to_result()
@@ -329,7 +329,7 @@ pub fn trans_check_expr(bcx: block,
     };
     let val = bool_to_i1(bcx, val);
     do with_cond(bcx, Not(bcx, val)) |bcx| {
-        trans_fail(bcx, Some(pred_expr.span), /*bad*/copy expr_str)
+        trans_fail(bcx, Some(pred_expr.span), expr_str)
     }
 }
 
@@ -356,13 +356,13 @@ pub fn trans_fail_expr(bcx: block,
                     ppaux::ty_to_str(tcx, arg_datum.ty));
             }
         }
-        _ => return trans_fail(bcx, sp_opt, ~"explicit failure")
+        _ => trans_fail(bcx, sp_opt, @~"explicit failure")
     }
 }
 
 pub fn trans_fail(bcx: block,
                   sp_opt: Option<span>,
-                  +fail_str: ~str)
+                  fail_str: @~str)
                -> block {
     let _icx = bcx.insn_ctxt("trans_fail");
     let V_fail_str = C_cstr(bcx.ccx(), fail_str);
@@ -379,11 +379,11 @@ fn trans_fail_value(bcx: block,
       Some(sp) => {
         let sess = bcx.sess();
         let loc = sess.parse_sess.cm.lookup_char_pos(sp.lo);
-        {V_filename: C_cstr(bcx.ccx(), /*bad*/copy loc.file.name),
+        {V_filename: C_cstr(bcx.ccx(), @/*bad*/ copy loc.file.name),
          V_line: loc.line as int}
       }
       None => {
-        {V_filename: C_cstr(bcx.ccx(), ~"<runtime>"),
+        {V_filename: C_cstr(bcx.ccx(), @~"<runtime>"),
          V_line: 0}
       }
     };
@@ -403,7 +403,7 @@ pub fn trans_fail_bounds_check(bcx: block, sp: span,
 
     let loc = bcx.sess().parse_sess.cm.lookup_char_pos(sp.lo);
     let line = C_int(ccx, loc.line as int);
-    let filename_cstr = C_cstr(bcx.ccx(), /*bad*/copy loc.file.name);
+    let filename_cstr = C_cstr(bcx.ccx(), @/*bad*/copy loc.file.name);
     let filename = PointerCast(bcx, filename_cstr, T_ptr(T_i8()));
 
     let args = ~[filename, line, index, len];

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -49,7 +49,7 @@ fn abi_info(arch: session::arch) -> cabi::ABIInfo {
 
 pub fn link_name(ccx: @crate_ctxt, i: @ast::foreign_item) -> @~str {
     match attr::first_attr_value_str_by_name(i.attrs, ~"link_name") {
-        None => @ccx.sess.str_of(i.ident),
+        None => ccx.sess.str_of(i.ident),
         Some(ln) => ln,
     }
 }
@@ -334,13 +334,13 @@ pub fn trans_intrinsic(ccx: @crate_ctxt,
                        +path: ast_map::path,
                        substs: @param_substs,
                        ref_id: Option<ast::node_id>) {
-    debug!("trans_intrinsic(item.ident=%s)", ccx.sess.str_of(item.ident));
+    debug!("trans_intrinsic(item.ident=%s)", *ccx.sess.str_of(item.ident));
 
     // XXX: Bad copy.
     let fcx = new_fn_ctxt_w_id(ccx, path, decl, item.id, None,
                                Some(copy substs), Some(item.span));
     let mut bcx = top_scope_block(fcx, None), lltop = bcx.llbb;
-    match ccx.sess.str_of(item.ident) {
+    match *ccx.sess.str_of(item.ident) {
         ~"atomic_cxchg" => {
             let old = AtomicCmpXchg(bcx,
                                     get_param(decl, first_real_arg),

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -50,7 +50,7 @@ fn abi_info(arch: session::arch) -> cabi::ABIInfo {
 pub fn link_name(ccx: @crate_ctxt, i: @ast::foreign_item) -> ~str {
     match attr::first_attr_value_str_by_name(i.attrs, ~"link_name") {
         None => ccx.sess.str_of(i.ident),
-        option::Some(ref ln) => (/*bad*/copy *ln)
+        option::Some(ref ln) => (/*bad*/copy **ln)
     }
 }
 

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -50,7 +50,7 @@ fn abi_info(arch: session::arch) -> cabi::ABIInfo {
 pub fn link_name(ccx: @crate_ctxt, i: @ast::foreign_item) -> ~str {
     match attr::first_attr_value_str_by_name(i.attrs, ~"link_name") {
         None => ccx.sess.str_of(i.ident),
-        option::Some(ref ln) => (/*bad*/copy **ln)
+        Some(ref ln) => /*bad*/copy **ln,
     }
 }
 

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -150,7 +150,7 @@ pub fn static_size_of_enum(cx: @crate_ctxt, t: ty::t) -> uint {
                 });
 
                 debug!("static_size_of_enum: variant %s type %s",
-                       cx.tcx.sess.str_of(variant.name),
+                       *cx.tcx.sess.str_of(variant.name),
                        ty_str(cx.tn, T_struct(lltypes)));
 
                 let this_size = llsize_of_real(cx, T_struct(lltypes));

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -322,7 +322,7 @@ pub fn trans_static_method_callee(bcx: block,
         }
     };
     debug!("trans_static_method_callee: method_id=%?, callee_id=%?, \
-            name=%s", method_id, callee_id, ccx.sess.str_of(mname));
+            name=%s", method_id, callee_id, *ccx.sess.str_of(mname));
 
     let vtbls = resolve_vtables_in_fn_ctxt(
         bcx.fcx, ccx.maps.vtable_map.get(&callee_id));
@@ -794,10 +794,10 @@ pub fn make_vtable(ccx: @crate_ctxt, ptrs: ~[ValueRef]) -> ValueRef {
     unsafe {
         let _icx = ccx.insn_ctxt("impl::make_vtable");
         let tbl = C_struct(ptrs);
-        let vt_gvar =
-                str::as_c_str(ccx.sess.str_of((ccx.names)(~"vtable")), |buf| {
+        let vtable = ccx.sess.str_of((ccx.names)(~"vtable"));
+        let vt_gvar = do str::as_c_str(*vtable) |buf| {
             llvm::LLVMAddGlobal(ccx.llmod, val_ty(tbl), buf)
-        });
+        };
         llvm::LLVMSetInitializer(vt_gvar, tbl);
         llvm::LLVMSetGlobalConstant(vt_gvar, lib::llvm::True);
         lib::llvm::SetLinkage(vt_gvar, lib::llvm::InternalLinkage);
@@ -825,11 +825,11 @@ pub fn make_impl_vtable(ccx: @crate_ctxt,
                                 ty::mk_bare_fn(tcx, copy im.fty));
         if (*im.tps).len() > 0u || ty::type_has_self(fty) {
             debug!("(making impl vtable) method has self or type params: %s",
-                   tcx.sess.str_of(im.ident));
+                   *tcx.sess.str_of(im.ident));
             C_null(T_ptr(T_nil()))
         } else {
             debug!("(making impl vtable) adding method to vtable: %s",
-                   tcx.sess.str_of(im.ident));
+                   *tcx.sess.str_of(im.ident));
             let mut m_id = method_with_name(ccx, impl_id, im.ident);
             if has_tps {
                 // If the method is in another crate, need to make an inlined

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -147,7 +147,7 @@ pub fn monomorphic_fn(ccx: @crate_ctxt,
     ccx.monomorphizing.insert(fn_id, depth + 1);
 
     let pt = vec::append(/*bad*/copy *pt,
-                         ~[path_name((ccx.names)(ccx.sess.str_of(name)))]);
+                         ~[path_name((ccx.names)(*ccx.sess.str_of(name)))]);
     let s = mangle_exported_name(ccx, /*bad*/copy pt, mono_ty);
 
     let mk_lldecl = || {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -45,7 +45,7 @@ pub impl Reflector {
         C_int(self.bcx.ccx(), i)
     }
 
-    fn c_slice(&mut self, s: &str) -> ValueRef {
+    fn c_slice(&mut self, s: @~str) -> ValueRef {
         // We're careful to not use first class aggregates here because that
         // will kick us off fast isel. (Issue #4352.)
         let bcx = self.bcx;

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -45,7 +45,7 @@ pub impl Reflector {
         C_int(self.bcx.ccx(), i)
     }
 
-    fn c_slice(&mut self, +s: ~str) -> ValueRef {
+    fn c_slice(&mut self, s: &str) -> ValueRef {
         // We're careful to not use first class aggregates here because that
         // will kick us off fast isel. (Issue #4352.)
         let bcx = self.bcx;

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -263,7 +263,7 @@ pub fn trans_lit_str(bcx: block,
             unsafe {
                 let bytes = str_lit.len() + 1; // count null-terminator too
                 let llbytes = C_uint(bcx.ccx(), bytes);
-                let llcstr = C_cstr(bcx.ccx(), /*bad*/copy *str_lit);
+                let llcstr = C_cstr(bcx.ccx(), str_lit);
                 let llcstr = llvm::LLVMConstPointerCast(llcstr,
                                                         T_ptr(T_i8()));
                 Store(bcx,
@@ -299,7 +299,7 @@ pub fn trans_uniq_or_managed_vstore(bcx: block,
                 ast::expr_lit(@codemap::spanned {
                     node: ast::lit_str(s), _
                 }) => {
-                    let llptrval = C_cstr(bcx.ccx(), copy *s);
+                    let llptrval = C_cstr(bcx.ccx(), s);
                     let llptrval = PointerCast(bcx, llptrval, T_ptr(T_i8()));
                     let llsizeval = C_uint(bcx.ccx(), s.len());
                     let typ = ty::mk_estr(bcx.tcx(), ty::vstore_uniq);
@@ -362,7 +362,7 @@ pub fn write_content(bcx: block,
                 SaveIn(lldest) => {
                     let bytes = s.len() + 1; // copy null-terminator too
                     let llbytes = C_uint(bcx.ccx(), bytes);
-                    let llcstr = C_cstr(bcx.ccx(), /*bad*/copy *s);
+                    let llcstr = C_cstr(bcx.ccx(), s);
                     base::call_memcpy(bcx, lldest, llcstr, llbytes);
                     return bcx;
                 }

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -112,7 +112,7 @@ pub fn type_uses_for(ccx: @crate_ctxt, fn_id: def_id, n_tps: uint)
                                                    _ },
                                  abi, _) => {
         if abi == foreign_abi_rust_intrinsic {
-            let flags = match cx.ccx.sess.str_of(i.ident) {
+            let flags = match *cx.ccx.sess.str_of(i.ident) {
                 ~"size_of"  | ~"pref_align_of"    | ~"min_align_of" |
                 ~"init"     | ~"reinterpret_cast" |
                 ~"move_val" | ~"move_val_init" => use_repr,

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3226,7 +3226,7 @@ pub fn field_idx_strict(tcx: ty::ctxt, id: ast::ident, fields: &[field])
     for fields.each |f| { if f.ident == id { return i; } i += 1u; }
     tcx.sess.bug(fmt!(
         "No field named `%s` found in the list of fields `%?`",
-        tcx.sess.str_of(id),
+        *tcx.sess.str_of(id),
         fields.map(|f| tcx.sess.str_of(f.ident))));
 }
 
@@ -3235,7 +3235,7 @@ pub fn get_field(tcx: ctxt, rec_ty: t, id: ast::ident) -> field {
       Some(f) => f,
       // Do we only call this when we know the field is legit?
       None => fail!(fmt!("get_field: ty doesn't have a field %s",
-                         tcx.sess.str_of(id)))
+                         *tcx.sess.str_of(id)))
     }
 }
 
@@ -3465,8 +3465,8 @@ pub fn type_err_to_str(cx: ctxt, err: &type_err) -> ~str {
         terr_record_fields(values) => {
             fmt!("expected a record with field `%s` but found one with field \
                   `%s`",
-                 cx.sess.str_of(values.expected),
-                 cx.sess.str_of(values.found))
+                 *cx.sess.str_of(values.expected),
+                 *cx.sess.str_of(values.found))
         }
         terr_arg_count => ~"incorrect number of function parameters",
         terr_mode_mismatch(values) => {
@@ -3500,7 +3500,7 @@ pub fn type_err_to_str(cx: ctxt, err: &type_err) -> ~str {
                  vstore_to_str(cx, (*values).found))
         }
         terr_in_field(err, fname) => {
-            fmt!("in field `%s`, %s", cx.sess.str_of(fname),
+            fmt!("in field `%s`, %s", *cx.sess.str_of(fname),
                  type_err_to_str(cx, err))
         }
         terr_sorts(values) => {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -783,11 +783,11 @@ pub fn mk_ctxt(s: session::Session,
     let mut legacy_records = false;
     for crate.node.attrs.each |attribute| {
         match attribute.node.value.node {
-            ast::meta_word(ref w) if (*w) == ~"legacy_modes" => {
+            ast::meta_word(w) if *w == ~"legacy_modes" => {
                 legacy_modes = true;
                 if legacy_records { break; }
             }
-            ast::meta_word(ref w) if (*w) == ~"legacy_records" => {
+            ast::meta_word(w) if *w == ~"legacy_records" => {
                 legacy_records = true;
                 if legacy_modes { break; }
             }

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -231,7 +231,7 @@ pub fn check_struct_pat_fields(pcx: pat_ctxt,
                 tcx.sess.span_err(span,
                                   fmt!("struct `%s` does not have a field
                                         named `%s`", name,
-                                       tcx.sess.str_of(field.ident)));
+                                       *tcx.sess.str_of(field.ident)));
             }
         }
     }
@@ -244,7 +244,7 @@ pub fn check_struct_pat_fields(pcx: pat_ctxt,
             }
             tcx.sess.span_err(span,
                               fmt!("pattern does not mention field `%s`",
-                                   tcx.sess.str_of(field.ident)));
+                                   *tcx.sess.str_of(field.ident)));
         }
     }
 }
@@ -436,7 +436,7 @@ pub fn check_pat(pcx: pat_ctxt, pat: @ast::pat, expected: ty::t) {
                 tcx.sess.span_fatal(pat.span,
                                     fmt!("mismatched types: did not \
                                           expect a record with a field `%s`",
-                                          tcx.sess.str_of(f.ident)));
+                                          *tcx.sess.str_of(f.ident)));
               }
             }
         }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -450,7 +450,7 @@ pub fn check_fn(ccx: @mut CrateCtxt,
                   if pat_util::pat_is_binding(fcx.ccx.tcx.def_map, p) => {
                 assign(p.id, None);
                 debug!("Pattern binding %s is assigned to %s",
-                       tcx.sess.str_of(path.idents[0]),
+                       *tcx.sess.str_of(path.idents[0]),
                        fcx.infcx().ty_to_str(
                            fcx.inh.locals.get(&p.id)));
               }
@@ -508,7 +508,7 @@ pub fn check_no_duplicate_fields(tcx: ty::ctxt,
           Some(orig_sp) => {
             tcx.sess.span_err(sp, fmt!("Duplicate field \
                                    name %s in record type declaration",
-                                        tcx.sess.str_of(id)));
+                                        *tcx.sess.str_of(id)));
             tcx.sess.span_note(orig_sp, ~"First declaration of \
                                           this field occurred here");
             break;
@@ -565,7 +565,7 @@ pub fn check_item(ccx: @mut CrateCtxt, it: @ast::item) {
       ast::item_impl(_, _, ty, ms) => {
         let rp = ccx.tcx.region_paramd_items.find(&it.id);
         debug!("item_impl %s with id %d rp %?",
-               ccx.tcx.sess.str_of(it.ident), it.id, rp);
+               *ccx.tcx.sess.str_of(it.ident), it.id, rp);
         let self_ty = ccx.to_ty(rscope::type_rscope(rp), ty);
         for ms.each |m| {
             check_method(ccx, *m, self_ty, local_def(it.id));
@@ -1370,7 +1370,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                       fmt!("type `%s` does not implement any method in scope \
                             named `%s`",
                            actual,
-                           fcx.ccx.tcx.sess.str_of(method_name))
+                           *fcx.ccx.tcx.sess.str_of(method_name))
                   },
                   expr_t,
                   None);
@@ -1752,7 +1752,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                   |actual| {
                       fmt!("attempted access of field `%s` on type `%s`, but \
                             no field or method with that name was found",
-                           tcx.sess.str_of(field), actual)
+                           *tcx.sess.str_of(field), actual)
                   },
                   expr_t, None);
                 // Add error type for the result
@@ -1790,13 +1790,13 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                     tcx.sess.span_err(
                         field.span,
                         fmt!("structure has no field named `%s`",
-                             tcx.sess.str_of(field.node.ident)));
+                             *tcx.sess.str_of(field.node.ident)));
                 }
                 Some((_, true)) => {
                     tcx.sess.span_err(
                         field.span,
                         fmt!("field `%s` specified more than once",
-                             tcx.sess.str_of(field.node.ident)));
+                             *tcx.sess.str_of(field.node.ident)));
                 }
                 Some((field_id, false)) => {
                     let expected_field_type =
@@ -1824,7 +1824,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                     let (_, seen) = class_field_map.get(&name);
                     if !seen {
                         missing_fields.push(
-                            ~"`" + tcx.sess.str_of(name) + ~"`");
+                            ~"`" + *tcx.sess.str_of(name) + ~"`");
                     }
                 }
 
@@ -2543,7 +2543,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                 if !found {
                     tcx.sess.span_err(f.span,
                                         ~"unknown field in record update: " +
-                                        tcx.sess.str_of(f.node.ident));
+                                        *tcx.sess.str_of(f.node.ident));
                     fcx.write_ty(id, ty::mk_err(tcx));
                     return true;
                 }
@@ -3151,7 +3151,7 @@ pub fn check_bounds_are_used(ccx: @mut CrateCtxt,
         if !*b {
             ccx.tcx.sess.span_err(
                 span, fmt!("type parameter `%s` is unused",
-                           ccx.tcx.sess.str_of(tps[i].ident)));
+                           *ccx.tcx.sess.str_of(tps[i].ident)));
         }
     }
 }
@@ -3164,7 +3164,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
         arg {mode: ast::expl(m), ty: ty}
     }
     let tcx = ccx.tcx;
-    let (n_tps, inputs, output) = match ccx.tcx.sess.str_of(it.ident) {
+    let (n_tps, inputs, output) = match *ccx.tcx.sess.str_of(it.ident) {
       ~"size_of" |
       ~"pref_align_of" | ~"min_align_of" => (1u, ~[], ty::mk_uint(ccx.tcx)),
       ~"init" => (1u, ~[], param(ccx, 0u)),

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -204,7 +204,7 @@ pub impl CoherenceChecker {
         visit_crate(*crate, (), mk_simple_visitor(@SimpleVisitor {
             visit_item: |item| {
                 debug!("(checking coherence) item '%s'",
-                       self.crate_context.tcx.sess.str_of(item.ident));
+                       *self.crate_context.tcx.sess.str_of(item.ident));
 
                 match item.node {
                     item_impl(_, opt_trait, _, _) => {
@@ -245,7 +245,7 @@ pub impl CoherenceChecker {
         if associated_traits.len() == 0 {
             debug!("(checking implementation) no associated traits for item \
                     '%s'",
-                   self.crate_context.tcx.sess.str_of(item.ident));
+                   *self.crate_context.tcx.sess.str_of(item.ident));
 
             match get_base_type_def_id(self.inference_context,
                                        item.span,
@@ -274,7 +274,7 @@ pub impl CoherenceChecker {
                     ast_map::node_id_to_str(
                         self.crate_context.tcx.items, trait_did.node,
                         self.crate_context.tcx.sess.parse_sess.interner),
-                    self.crate_context.tcx.sess.str_of(item.ident));
+                    *self.crate_context.tcx.sess.str_of(item.ident));
 
             self.instantiate_default_methods(item.id, trait_did);
 
@@ -362,7 +362,7 @@ pub impl CoherenceChecker {
                     // method to that entry.
                     debug!("(checking implementation) adding method `%s` \
                             to entry for existing trait",
-                            self.crate_context.tcx.sess.str_of(
+                            *self.crate_context.tcx.sess.str_of(
                                 provided_method_info.method_info.ident));
                     mis.push(provided_method_info);
                 }
@@ -370,7 +370,7 @@ pub impl CoherenceChecker {
                     // If the trait doesn't have an entry yet, create one.
                     debug!("(checking implementation) creating new entry \
                             for method `%s`",
-                            self.crate_context.tcx.sess.str_of(
+                            *self.crate_context.tcx.sess.str_of(
                                 provided_method_info.method_info.ident));
                     let method_infos = @DVec();
                     method_infos.push(provided_method_info);
@@ -730,7 +730,7 @@ pub impl CoherenceChecker {
 
             tcx.sess.span_err(trait_ref_span,
                               fmt!("missing method `%s`",
-                                   tcx.sess.str_of(method.ident)));
+                                   *tcx.sess.str_of(method.ident)));
         }
     }
 
@@ -742,7 +742,7 @@ pub impl CoherenceChecker {
             for all_provided_methods.each |provided_method| {
                 debug!(
                     "(creating impl) adding provided method `%s` to impl",
-                    sess.str_of(provided_method.method_info.ident));
+                    *sess.str_of(provided_method.method_info.ident));
                 vec::push(&mut *all_methods, provided_method.method_info);
             }
         }
@@ -863,7 +863,7 @@ pub impl CoherenceChecker {
                         session.bug(fmt!(
                             "no base type for external impl \
                              with no trait: %s (type %s)!",
-                             session.str_of(implementation.ident),
+                             *session.str_of(implementation.ident),
                              ty_to_str(self.crate_context.tcx,self_type.ty)));
                     }
                     Some(_) => {

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -357,20 +357,20 @@ pub fn compare_impl_method(tcx: ty::ctxt,
             tcx.sess.span_fatal(cm.span,
                  fmt!("method `%s` is declared as \
                        static in its impl, but not in \
-                       its trait", tcx.sess.str_of(impl_m.ident)));
+                       its trait", *tcx.sess.str_of(impl_m.ident)));
         }
         else if trait_m.self_ty == ast::sty_static {
             tcx.sess.span_fatal(cm.span,
                  fmt!("method `%s` is declared as \
                        static in its trait, but not in \
-                       its impl", tcx.sess.str_of(impl_m.ident)));
+                       its impl", *tcx.sess.str_of(impl_m.ident)));
         }
         else {
             tcx.sess.span_err(
                 cm.span,
                 fmt!("method `%s`'s self type does \
                       not match the trait method's \
-                      self type", tcx.sess.str_of(impl_m.ident)));
+                      self type", *tcx.sess.str_of(impl_m.ident)));
         }
     }
 
@@ -379,7 +379,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
             cm.span,
             fmt!("method `%s` has %u type %s, but its trait \
                   declaration has %u type %s",
-                 tcx.sess.str_of(trait_m.ident), impl_m.tps.len(),
+                 *tcx.sess.str_of(trait_m.ident), impl_m.tps.len(),
                  pluralize(impl_m.tps.len(), ~"parameter"),
                  trait_m.tps.len(),
                  pluralize(trait_m.tps.len(), ~"parameter")));
@@ -391,7 +391,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
             cm.span,
             fmt!("method `%s` has %u parameters \
                   but the trait has %u",
-                 tcx.sess.str_of(trait_m.ident),
+                 *tcx.sess.str_of(trait_m.ident),
                  vec::len(impl_m.fty.sig.inputs),
                  vec::len(trait_m.fty.sig.inputs)));
         return;
@@ -412,7 +412,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
                fmt!("in method `%s`, \
                      type parameter %u has %u %s, but the same type \
                      parameter in its trait declaration has %u %s",
-                    tcx.sess.str_of(trait_m.ident),
+                    *tcx.sess.str_of(trait_m.ident),
                     i, impl_param_bounds.len(),
                     pluralize(impl_param_bounds.len(), ~"bound"),
                     trait_param_bounds.len(),
@@ -466,7 +466,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
             tcx.sess.span_err(
                 cm.span,
                 fmt!("method `%s` has an incompatible type: %s",
-                     tcx.sess.str_of(trait_m.ident),
+                     *tcx.sess.str_of(trait_m.ident),
                      ty::type_err_to_str(tcx, terr)));
             ty::note_and_explain_type_err(tcx, terr);
         }
@@ -526,7 +526,7 @@ pub fn check_methods_against_trait(ccx: @mut CrateCtxt,
                 tcx.sess.span_err(
                     impl_m.span,
                     fmt!("method `%s` is not a member of trait `%s`",
-                         tcx.sess.str_of(impl_m.mty.ident),
+                         *tcx.sess.str_of(impl_m.mty.ident),
                          path_to_str(a_trait_ty.path, tcx.sess.intr())));
             }
         }
@@ -596,7 +596,7 @@ pub fn convert(ccx: @mut CrateCtxt, it: @ast::item) {
     let tcx = ccx.tcx;
     let rp = tcx.region_paramd_items.find(&it.id);
     debug!("convert: item %s with id %d rp %?",
-           tcx.sess.str_of(it.ident), it.id, rp);
+           *tcx.sess.str_of(it.ident), it.id, rp);
     match /*bad*/copy it.node {
       // These don't define types.
       ast::item_foreign_mod(_) | ast::item_mod(_) => {}
@@ -809,7 +809,7 @@ pub fn ty_of_item(ccx: @mut CrateCtxt, it: @ast::item)
                    region_param: None,
                    ty: ty::mk_bare_fn(ccx.tcx, tofd)};
         debug!("type of %s (id %d) is %s",
-               tcx.sess.str_of(it.ident),
+               *tcx.sess.str_of(it.ident),
                it.id,
                ppaux::ty_to_str(tcx, tpt.ty));
         ccx.tcx.tcache.insert(local_def(it.id), tpt);

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -187,7 +187,7 @@ Available lint options:
     io::println(fmt!("    %s  %7.7s  %s\n",
                      padded(max_key, ~"----"), ~"-------", ~"-------"));
     for lint_dict.each |&k, &v| {
-        let k = str::replace(k, ~"_", ~"-");
+        let k = str::replace(*k, ~"_", ~"-");
         io::println(fmt!("    %s  %7.7s  %s",
                          padded(max_key, k),
                          match v.default {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -145,7 +145,8 @@ pub fn bound_region_to_str_adorned(cx: ctxt, prefix: &str,
     if cx.sess.verbose() { return fmt!("%s%?%s", prefix, br, sep); }
 
     match br {
-      br_named(id)         => fmt!("%s%s%s", prefix, cx.sess.str_of(id), sep),
+      br_named(id)         => fmt!("%s%s%s", prefix, *cx.sess.str_of(id),
+                                   sep),
       br_self              => fmt!("%sself%s", prefix, sep),
       br_anon(_)           => prefix.to_str(),
       br_fresh(_)          => prefix.to_str(),
@@ -321,7 +322,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
         match ident {
           Some(i) => {
               s.push_char(' ');
-              s.push_str(cx.sess.str_of(i));
+              s.push_str(*cx.sess.str_of(i));
           }
           _ => { }
         }
@@ -387,7 +388,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
                        &m.fty.sig) + ~";"
     }
     fn field_to_str(cx: ctxt, f: field) -> ~str {
-        return cx.sess.str_of(f.ident) + ~": " + mt_to_str(cx, f.mt);
+        return *cx.sess.str_of(f.ident) + ~": " + mt_to_str(cx, f.mt);
     }
 
     // if there is an id, print that instead of the structural type:

--- a/src/librustdoc/attr_parser.rs
+++ b/src/librustdoc/attr_parser.rs
@@ -65,9 +65,10 @@ fn doc_metas(
 
 pub fn parse_crate(attrs: ~[ast::attribute]) -> CrateAttrs {
     let link_metas = attr::find_linkage_metas(attrs);
+    let name = attr::last_meta_item_value_str_by_name(link_metas, ~"name");
 
     CrateAttrs {
-        name: attr::last_meta_item_value_str_by_name(link_metas, ~"name")
+        name: name.map(|s| copy **s)
     }
 }
 
@@ -97,7 +98,7 @@ fn should_not_extract_crate_name_if_no_name_value_in_link_attribute() {
 
 pub fn parse_desc(attrs: ~[ast::attribute]) -> Option<~str> {
     let doc_strs = do doc_metas(attrs).filter_mapped |meta| {
-        attr::get_meta_item_value_str(*meta)
+        attr::get_meta_item_value_str(*meta).map(|s| copy **s)
     };
     if doc_strs.is_empty() {
         None

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -89,7 +89,7 @@ impl PackageScript {
                     ast::meta_name_value(v, spanned {
                                                 node: ast::lit_str(s),
                                                 span: _}) => {
-                        match v {
+                        match *v {
                             ~"id" => id = Some(*s),
                             ~"vers" => vers = Some(*s),
                             _ => ()
@@ -112,7 +112,7 @@ impl PackageScript {
                     ast::meta_name_value(v, spanned {
                                                 node: ast::lit_str(s),
                                                 span: _}) => {
-                        match v {
+                        match *v {
                             ~"url" => url = Some(*s),
                             ~"target" => target = Some(*s),
                             _ => ()
@@ -133,7 +133,7 @@ impl PackageScript {
                     ast::meta_name_value(v, spanned {
                                                 node: ast::lit_str(s),
                                                 span: _}) => {
-                        match v {
+                        match *v {
                             ~"file" => file = Some(*s),
                             _ => ()
                         }
@@ -148,7 +148,7 @@ impl PackageScript {
         for crate.node.attrs.each |a| {
             match a.node.value.node {
                 ast::meta_list(v, mis) => {
-                    match v {
+                    match *v {
                         ~"pkg" => {
                             let (i, v) = load_pkg_attr(mis);
 

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -110,7 +110,7 @@ fn fold_item(ctx: @ReadyCtx, item: @ast::item,
                 ast::meta_list(_, mis) => {
                     for mis.each |mi| {
                         match mi.node {
-                            ast::meta_word(cmd) => cmds.push(cmd),
+                            ast::meta_word(cmd) => cmds.push(copy *cmd),
                             _ => {}
                         };
                     }
@@ -639,7 +639,7 @@ pub fn compile_input(sysroot: Option<Path>, input: driver::input, dir: &Path,
             match a.node {
                 ast::meta_name_value(v, spanned {node: ast::lit_str(s),
                                          span: _}) => {
-                    match v {
+                    match *v {
                         ~"name" => name = Some(*s),
                         ~"vers" => vers = Some(*s),
                         ~"uuid" => uuid = Some(*s),
@@ -657,13 +657,13 @@ pub fn compile_input(sysroot: Option<Path>, input: driver::input, dir: &Path,
         match a.node.value.node {
             ast::meta_name_value(v, spanned {node: ast::lit_str(s),
                                      span: _}) => {
-                match v {
+                match *v {
                     ~"crate_type" => crate_type = Some(*s),
                     _ => {}
                 }
             }
             ast::meta_list(v, mis) => {
-                match v {
+                match *v {
                     ~"link" => {
                         let (n, v, u) = load_link_attr(mis);
 

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -81,7 +81,7 @@ fn fold_mod(_ctx: @ReadyCtx, m: ast::_mod,
     fn strip_main(item: @ast::item) -> @ast::item {
         @ast::item {
             attrs: do item.attrs.filtered |attr| {
-                attr::get_attr_name(*attr) != ~"main"
+                *attr::get_attr_name(attr) != ~"main"
             },
             .. copy *item
         }
@@ -609,7 +609,7 @@ pub fn compile_input(sysroot: Option<Path>, input: driver::input, dir: &Path,
     let mut crate_cfg = options.cfg;
 
     for cfgs.each |&cfg| {
-        crate_cfg.push(attr::mk_word_item(cfg));
+        crate_cfg.push(attr::mk_word_item(@cfg));
     }
 
     let options = @{

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -173,9 +173,9 @@ pub type meta_item = spanned<meta_item_>;
 #[auto_decode]
 #[deriving_eq]
 pub enum meta_item_ {
-    meta_word(~str),
-    meta_list(~str, ~[@meta_item]),
-    meta_name_value(~str, lit),
+    meta_word(@~str),
+    meta_list(@~str, ~[@meta_item]),
+    meta_name_value(@~str, lit),
 }
 
 pub type blk = spanned<blk_>;

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -193,7 +193,7 @@ pub fn map_fn(fk: visit::fn_kind, decl: fn_decl, body: blk,
         cx.local_id += 1u;
     }
     match fk {
-        visit::fk_dtor(tps, ref attrs, self_id, parent_id) => {
+        visit::fk_dtor(ref tps, ref attrs, self_id, parent_id) => {
             let dt = @spanned {
                 node: ast::struct_dtor_ {
                     id: id,
@@ -203,7 +203,7 @@ pub fn map_fn(fk: visit::fn_kind, decl: fn_decl, body: blk,
                 },
                 span: sp,
             };
-            cx.map.insert(id, node_dtor(/* FIXME (#2543) */ copy tps, dt,
+            cx.map.insert(id, node_dtor(/* FIXME (#2543) */ copy *tps, dt,
                                         parent_id,
                                         @/* FIXME (#2543) */ copy cx.path));
       }
@@ -286,7 +286,7 @@ pub fn map_item(i: @item, &&cx: @mut Ctx, v: vt) {
         map_struct_def(struct_def, node_item(i, item_path), i.ident, cx,
                        v);
       }
-      item_trait(_, traits, ref methods) => {
+      item_trait(_, ref traits, ref methods) => {
         for traits.each |p| {
             cx.map.insert(p.ref_id, node_item(i, item_path));
         }

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -327,8 +327,8 @@ pub impl inlined_item_utils for inlined_item {
             ii_item(i) => (v.visit_item)(i, e, v),
             ii_foreign(i) => (v.visit_foreign_item)(i, e, v),
             ii_method(_, m) => visit::visit_method_helper(m, e, v),
-            ii_dtor(ref dtor, _, tps, parent_id) => {
-              visit::visit_struct_dtor_helper((*dtor), tps, parent_id, e, v);
+            ii_dtor(/*bad*/ copy dtor, _, /*bad*/ copy tps, parent_id) => {
+                visit::visit_struct_dtor_helper(dtor, tps, parent_id, e, v);
             }
         }
     }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -29,24 +29,24 @@ use std;
 
 /* Constructors */
 
-pub fn mk_name_value_item_str(name: ~str, value: ~str)
+pub fn mk_name_value_item_str(name: @~str, value: @~str)
                            -> @ast::meta_item {
-    let value_lit = dummy_spanned(ast::lit_str(@value));
-    return mk_name_value_item(name, value_lit);
+    let value_lit = dummy_spanned(ast::lit_str(value));
+    mk_name_value_item(name, value_lit)
 }
 
-pub fn mk_name_value_item(name: ~str, +value: ast::lit)
+pub fn mk_name_value_item(name: @~str, +value: ast::lit)
         -> @ast::meta_item {
-    return @dummy_spanned(ast::meta_name_value(name, value));
+    @dummy_spanned(ast::meta_name_value(/*bad*/ copy *name, value))
 }
 
-pub fn mk_list_item(name: ~str, +items: ~[@ast::meta_item]) ->
+pub fn mk_list_item(name: @~str, +items: ~[@ast::meta_item]) ->
    @ast::meta_item {
-    return @dummy_spanned(ast::meta_list(name, items));
+    @dummy_spanned(ast::meta_list(/*bad*/ copy *name, items))
 }
 
-pub fn mk_word_item(name: ~str) -> @ast::meta_item {
-    return @dummy_spanned(ast::meta_word(name));
+pub fn mk_word_item(name: @~str) -> @ast::meta_item {
+    @dummy_spanned(ast::meta_word(/*bad*/ copy *name))
 }
 
 pub fn mk_attr(item: @ast::meta_item) -> ast::attribute {
@@ -80,9 +80,9 @@ pub fn attr_metas(attrs: ~[ast::attribute]) -> ~[@ast::meta_item] {
 pub fn desugar_doc_attr(attr: &ast::attribute) -> ast::attribute {
     if attr.node.is_sugared_doc {
         let comment = get_meta_item_value_str(@attr.node.value).get();
-        let meta = mk_name_value_item_str(~"doc",
-                                     strip_doc_comment_decoration(comment));
-        return mk_attr(meta);
+        let meta = mk_name_value_item_str(@~"doc",
+                                     @strip_doc_comment_decoration(*comment));
+        mk_attr(meta)
     } else {
         *attr
     }
@@ -90,15 +90,15 @@ pub fn desugar_doc_attr(attr: &ast::attribute) -> ast::attribute {
 
 /* Accessors */
 
-pub fn get_attr_name(attr: &ast::attribute) -> ~str {
+pub pure fn get_attr_name(attr: &ast::attribute) -> @~str {
     get_meta_item_name(@attr.node.value)
 }
 
-pub fn get_meta_item_name(meta: @ast::meta_item) -> ~str {
+pub pure fn get_meta_item_name(meta: @ast::meta_item) -> @~str {
     match meta.node {
-      ast::meta_word(ref n) => (*n),
-      ast::meta_name_value(ref n, _) => (*n),
-      ast::meta_list(ref n, _) => (*n)
+        ast::meta_word(ref n) => @/*bad*/ copy *n,
+        ast::meta_name_value(ref n, _) => @/*bad*/ copy *n,
+        ast::meta_list(ref n, _) => @/*bad*/ copy *n,
     }
 }
 
@@ -106,13 +106,15 @@ pub fn get_meta_item_name(meta: @ast::meta_item) -> ~str {
  * Gets the string value if the meta_item is a meta_name_value variant
  * containing a string, otherwise none
  */
-pub fn get_meta_item_value_str(meta: @ast::meta_item) -> Option<~str> {
+pub fn get_meta_item_value_str(meta: @ast::meta_item) -> Option<@~str> {
     match meta.node {
-        ast::meta_name_value(_, v) => match v.node {
-            ast::lit_str(s) => option::Some(*s),
-            _ => option::None
+        ast::meta_name_value(_, v) => {
+            match v.node {
+                ast::lit_str(s) => Some(s),
+                _ => None,
+            }
         },
-        _ => option::None
+        _ => None
     }
 }
 
@@ -130,11 +132,11 @@ pub fn get_meta_item_list(meta: @ast::meta_item)
  * a tuple containing the name and string value, otherwise `none`
  */
 pub fn get_name_value_str_pair(item: @ast::meta_item)
-                            -> Option<(~str, ~str)> {
+                            -> Option<(@~str, @~str)> {
     match attr::get_meta_item_value_str(item) {
-      Some(ref value) => {
+      Some(value) => {
         let name = attr::get_meta_item_name(item);
-        Some((name, (*value)))
+        Some((name, value))
       }
       None => None
     }
@@ -147,7 +149,7 @@ pub fn get_name_value_str_pair(item: @ast::meta_item)
 pub fn find_attrs_by_name(attrs: &[ast::attribute], name: &str) ->
    ~[ast::attribute] {
     do vec::filter_mapped(attrs) |a| {
-        if name == get_attr_name(a) {
+        if name == *get_attr_name(a) {
             Some(*a)
         } else {
             None
@@ -160,7 +162,7 @@ pub fn find_meta_items_by_name(metas: &[@ast::meta_item], name: &str) ->
    ~[@ast::meta_item] {
     let mut rs = ~[];
     for metas.each |mi| {
-        if name == get_meta_item_name(*mi) {
+        if name == *get_meta_item_name(*mi) {
             rs.push(*mi)
         }
     }
@@ -213,36 +215,39 @@ pub fn attrs_contains_name(attrs: &[ast::attribute], name: &str) -> bool {
     !find_attrs_by_name(attrs, name).is_empty()
 }
 
-pub fn first_attr_value_str_by_name(attrs: ~[ast::attribute], name: ~str)
-                                 -> Option<~str> {
+pub fn first_attr_value_str_by_name(attrs: ~[ast::attribute], name: &str)
+                                 -> Option<@~str> {
 
     let mattrs = find_attrs_by_name(attrs, name);
-    if vec::len(mattrs) > 0u {
-        return get_meta_item_value_str(attr_meta(mattrs[0]));
+    if mattrs.len() > 0 {
+        get_meta_item_value_str(attr_meta(mattrs[0]))
+    } else {
+        None
     }
-    return option::None;
 }
 
-fn last_meta_item_by_name(items: ~[@ast::meta_item], name: ~str)
+fn last_meta_item_by_name(items: ~[@ast::meta_item], name: &str)
     -> Option<@ast::meta_item> {
 
     let items = attr::find_meta_items_by_name(items, name);
     vec::last_opt(items)
 }
 
-pub fn last_meta_item_value_str_by_name(items: ~[@ast::meta_item], name: ~str)
-                                     -> Option<~str> {
+pub fn last_meta_item_value_str_by_name(items: ~[@ast::meta_item], name: &str)
+                                     -> Option<@~str> {
 
     match last_meta_item_by_name(items, name) {
-      Some(item) => match attr::get_meta_item_value_str(item) {
-        Some(ref value) => Some((*value)),
+        Some(item) => {
+            match attr::get_meta_item_value_str(item) {
+                Some(value) => Some(value),
+                None => None
+            }
+        },
         None => None
-      },
-      None => None
     }
 }
 
-pub fn last_meta_item_list_by_name(items: ~[@ast::meta_item], name: ~str)
+pub fn last_meta_item_list_by_name(items: ~[@ast::meta_item], name: &str)
     -> Option<~[@ast::meta_item]> {
 
     match last_meta_item_by_name(items, name) {
@@ -255,20 +260,11 @@ pub fn last_meta_item_list_by_name(items: ~[@ast::meta_item], name: ~str)
 /* Higher-level applications */
 
 pub fn sort_meta_items(+items: ~[@ast::meta_item]) -> ~[@ast::meta_item] {
-    pure fn lteq(ma: &@ast::meta_item, mb: &@ast::meta_item) -> bool {
-        pure fn key(m: &ast::meta_item) -> ~str {
-            match m.node {
-              ast::meta_word(ref name) => (*name),
-              ast::meta_name_value(ref name, _) => (*name),
-              ast::meta_list(ref name, _) => (*name)
-            }
-        }
-        key(*ma) <= key(*mb)
-    }
-
     // This is sort of stupid here, converting to a vec of mutables and back
     let mut v = items;
-    std::sort::quick_sort(v, lteq);
+    do std::sort::quick_sort(v) |ma, mb| {
+        get_meta_item_name(*ma) <= get_meta_item_name(*mb)
+    }
 
     // There doesn't seem to be a more optimal way to do this
     do v.map |&m| {
@@ -282,14 +278,14 @@ pub fn sort_meta_items(+items: ~[@ast::meta_item]) -> ~[@ast::meta_item] {
     }
 }
 
-pub fn remove_meta_items_by_name(items: ~[@ast::meta_item], name: ~str) ->
+pub fn remove_meta_items_by_name(items: ~[@ast::meta_item], name: &str) ->
    ~[@ast::meta_item] {
 
     return vec::filter_mapped(items, |item| {
-        if get_meta_item_name(*item) != name {
-            option::Some(*item)
+        if name != *get_meta_item_name(*item) {
+            Some(*item)
         } else {
-            option::None
+            None
         }
     });
 }
@@ -310,21 +306,21 @@ pub fn find_linkage_metas(attrs: &[ast::attribute]) -> ~[@ast::meta_item] {
 pub fn foreign_abi(attrs: ~[ast::attribute])
                 -> Either<~str, ast::foreign_abi> {
     return match attr::first_attr_value_str_by_name(attrs, ~"abi") {
-      option::None => {
-        either::Right(ast::foreign_abi_cdecl)
-      }
-      option::Some(~"rust-intrinsic") => {
-        either::Right(ast::foreign_abi_rust_intrinsic)
-      }
-      option::Some(~"cdecl") => {
-        either::Right(ast::foreign_abi_cdecl)
-      }
-      option::Some(~"stdcall") => {
-        either::Right(ast::foreign_abi_stdcall)
-      }
-      option::Some(ref t) => {
-        either::Left(~"unsupported abi: " + (*t))
-      }
+        None => {
+            Right(ast::foreign_abi_cdecl)
+        }
+        Some(@~"rust-intrinsic") => {
+            Right(ast::foreign_abi_rust_intrinsic)
+        }
+        Some(@~"cdecl") => {
+            Right(ast::foreign_abi_cdecl)
+        }
+        Some(@~"stdcall") => {
+            Right(ast::foreign_abi_stdcall)
+        }
+        Some(t) => {
+            Left(~"unsupported abi: " + *t)
+        }
     };
 }
 
@@ -371,9 +367,9 @@ pub fn require_unique_names(diagnostic: span_handler,
         let name = get_meta_item_name(*meta);
 
         // FIXME: How do I silence the warnings? --pcw (#2619)
-        if !set.insert(copy name) {
+        if !set.insert(name) {
             diagnostic.span_fatal(meta.span,
-                                  fmt!("duplicate meta item `%s`", name));
+                                  fmt!("duplicate meta item `%s`", *name));
         }
     }
 }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -37,16 +37,16 @@ pub fn mk_name_value_item_str(name: @~str, value: @~str)
 
 pub fn mk_name_value_item(name: @~str, +value: ast::lit)
         -> @ast::meta_item {
-    @dummy_spanned(ast::meta_name_value(/*bad*/ copy *name, value))
+    @dummy_spanned(ast::meta_name_value(name, value))
 }
 
 pub fn mk_list_item(name: @~str, +items: ~[@ast::meta_item]) ->
    @ast::meta_item {
-    @dummy_spanned(ast::meta_list(/*bad*/ copy *name, items))
+    @dummy_spanned(ast::meta_list(name, items))
 }
 
 pub fn mk_word_item(name: @~str) -> @ast::meta_item {
-    @dummy_spanned(ast::meta_word(/*bad*/ copy *name))
+    @dummy_spanned(ast::meta_word(name))
 }
 
 pub fn mk_attr(item: @ast::meta_item) -> ast::attribute {
@@ -60,7 +60,7 @@ pub fn mk_sugared_doc_attr(text: ~str,
     let lit = spanned(lo, hi, ast::lit_str(@text));
     let attr = ast::attribute_ {
         style: doc_comment_style(text),
-        value: spanned(lo, hi, ast::meta_name_value(~"doc", lit)),
+        value: spanned(lo, hi, ast::meta_name_value(@~"doc", lit)),
         is_sugared_doc: true
     };
     spanned(lo, hi, attr)
@@ -96,9 +96,9 @@ pub pure fn get_attr_name(attr: &ast::attribute) -> @~str {
 
 pub pure fn get_meta_item_name(meta: @ast::meta_item) -> @~str {
     match meta.node {
-        ast::meta_word(ref n) => @/*bad*/ copy *n,
-        ast::meta_name_value(ref n, _) => @/*bad*/ copy *n,
-        ast::meta_list(ref n, _) => @/*bad*/ copy *n,
+        ast::meta_word(n) => n,
+        ast::meta_name_value(n, _) => n,
+        ast::meta_list(n, _) => n,
     }
 }
 
@@ -343,8 +343,8 @@ pub fn find_inline_attr(attrs: &[ast::attribute]) -> inline_attr {
     // FIXME (#2809)---validate the usage of #[inline] and #[inline(always)]
     do vec::foldl(ia_none, attrs) |ia,attr| {
         match attr.node.value.node {
-          ast::meta_word(~"inline") => ia_hint,
-          ast::meta_list(~"inline", items) => {
+          ast::meta_word(@~"inline") => ia_hint,
+          ast::meta_list(@~"inline", items) => {
             if !vec::is_empty(find_meta_items_by_name(items, ~"always")) {
                 ia_always
             } else if !vec::is_empty(

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -267,7 +267,7 @@ pub fn sort_meta_items(+items: ~[@ast::meta_item]) -> ~[@ast::meta_item] {
     }
 
     // This is sort of stupid here, converting to a vec of mutables and back
-    let mut v: ~[@ast::meta_item] = items;
+    let mut v = items;
     std::sort::quick_sort(v, lteq);
 
     // There doesn't seem to be a more optimal way to do this
@@ -371,7 +371,7 @@ pub fn require_unique_names(diagnostic: span_handler,
         let name = get_meta_item_name(*meta);
 
         // FIXME: How do I silence the warnings? --pcw (#2619)
-        if !set.insert(name) {
+        if !set.insert(copy name) {
             diagnostic.span_fatal(meta.span,
                                   fmt!("duplicate meta item `%s`", name));
         }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -90,7 +90,7 @@ pub fn desugar_doc_attr(attr: &ast::attribute) -> ast::attribute {
 
 /* Accessors */
 
-pub fn get_attr_name(attr: ast::attribute) -> ~str {
+pub fn get_attr_name(attr: &ast::attribute) -> ~str {
     get_meta_item_name(@attr.node.value)
 }
 
@@ -146,14 +146,13 @@ pub fn get_name_value_str_pair(item: @ast::meta_item)
 /// Search a list of attributes and return only those with a specific name
 pub fn find_attrs_by_name(attrs: &[ast::attribute], name: &str) ->
    ~[ast::attribute] {
-    let filter: &fn(a: &ast::attribute) -> Option<ast::attribute> = |a| {
-        if name == get_attr_name(*a) {
-            option::Some(*a)
+    do vec::filter_mapped(attrs) |a| {
+        if name == get_attr_name(a) {
+            Some(*a)
         } else {
-            option::None
+            None
         }
-    };
-    return vec::filter_mapped(attrs, filter);
+    }
 }
 
 /// Search a list of meta items and return only those with a specific name

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -114,7 +114,7 @@ pub fn expand_auto_encode(
     in_items: ~[@ast::item]
 ) -> ~[@ast::item] {
     fn is_auto_encode(a: &ast::attribute) -> bool {
-        attr::get_attr_name(*a) == ~"auto_encode"
+        attr::get_attr_name(a) == ~"auto_encode"
     }
 
     fn filter_attrs(item: @ast::item) -> @ast::item {
@@ -169,7 +169,7 @@ pub fn expand_auto_decode(
     in_items: ~[@ast::item]
 ) -> ~[@ast::item] {
     fn is_auto_decode(a: &ast::attribute) -> bool {
-        attr::get_attr_name(*a) == ~"auto_decode"
+        attr::get_attr_name(a) == ~"auto_decode"
     }
 
     fn filter_attrs(item: @ast::item) -> @ast::item {

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -114,7 +114,7 @@ pub fn expand_auto_encode(
     in_items: ~[@ast::item]
 ) -> ~[@ast::item] {
     fn is_auto_encode(a: &ast::attribute) -> bool {
-        attr::get_attr_name(a) == ~"auto_encode"
+        *attr::get_attr_name(a) == ~"auto_encode"
     }
 
     fn filter_attrs(item: @ast::item) -> @ast::item {
@@ -169,7 +169,7 @@ pub fn expand_auto_decode(
     in_items: ~[@ast::item]
 ) -> ~[@ast::item] {
     fn is_auto_decode(a: &ast::attribute) -> bool {
-        attr::get_attr_name(a) == ~"auto_decode"
+        *attr::get_attr_name(a) == ~"auto_decode"
     }
 
     fn filter_attrs(item: @ast::item) -> @ast::item {

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -127,24 +127,24 @@ pub fn expand_auto_encode(
     do vec::flat_map(in_items) |item| {
         if item.attrs.any(is_auto_encode) {
             match item.node {
-                ast::item_struct(@ast::struct_def { fields, _}, tps) => {
+                ast::item_struct(ref struct_def, ref tps) => {
                     let ser_impl = mk_struct_ser_impl(
                         cx,
                         item.span,
                         item.ident,
-                        fields,
-                        tps
+                        struct_def.fields,
+                        *tps
                     );
 
                     ~[filter_attrs(*item), ser_impl]
                 },
-                ast::item_enum(ref enum_def, tps) => {
+                ast::item_enum(ref enum_def, ref tps) => {
                     let ser_impl = mk_enum_ser_impl(
                         cx,
                         item.span,
                         item.ident,
-                        (*enum_def),
-                        tps
+                        *enum_def,
+                        *tps
                     );
 
                     ~[filter_attrs(*item), ser_impl]
@@ -182,24 +182,24 @@ pub fn expand_auto_decode(
     do vec::flat_map(in_items) |item| {
         if item.attrs.any(is_auto_decode) {
             match item.node {
-                ast::item_struct(@ast::struct_def { fields, _}, tps) => {
+                ast::item_struct(ref struct_def, ref tps) => {
                     let deser_impl = mk_struct_deser_impl(
                         cx,
                         item.span,
                         item.ident,
-                        fields,
-                        tps
+                        struct_def.fields,
+                        *tps
                     );
 
                     ~[filter_attrs(*item), deser_impl]
                 },
-                ast::item_enum(ref enum_def, tps) => {
+                ast::item_enum(ref enum_def, ref tps) => {
                     let deser_impl = mk_enum_deser_impl(
                         cx,
                         item.span,
                         item.ident,
-                        (*enum_def),
-                        tps
+                        *enum_def,
+                        *tps
                     );
 
                     ~[filter_attrs(*item), deser_impl]
@@ -410,7 +410,7 @@ fn mk_impl(
     ident: ast::ident,
     ty_param: ast::ty_param,
     path: @ast::path,
-    tps: ~[ast::ty_param],
+    tps: &[ast::ty_param],
     f: fn(@ast::Ty) -> @ast::method
 ) -> @ast::item {
     // All the type parameters need to bound to the trait.
@@ -458,7 +458,7 @@ fn mk_ser_impl(
     cx: ext_ctxt,
     span: span,
     ident: ast::ident,
-    tps: ~[ast::ty_param],
+    tps: &[ast::ty_param],
     body: @ast::expr
 ) -> @ast::item {
     // Make a path to the std::serialize::Encodable typaram.
@@ -666,8 +666,8 @@ fn mk_struct_ser_impl(
     cx: ext_ctxt,
     span: span,
     ident: ast::ident,
-    fields: ~[@ast::struct_field],
-    tps: ~[ast::ty_param]
+    fields: &[@ast::struct_field],
+    tps: &[ast::ty_param]
 ) -> @ast::item {
     let fields = do mk_struct_fields(fields).mapi |idx, field| {
         // ast for `|| self.$(name).encode(__s)`
@@ -808,7 +808,7 @@ struct field {
     mutbl: ast::mutability,
 }
 
-fn mk_struct_fields(fields: ~[@ast::struct_field]) -> ~[field] {
+fn mk_struct_fields(fields: &[@ast::struct_field]) -> ~[field] {
     do fields.map |field| {
         let (ident, mutbl) = match field.node.kind {
             ast::named_field(ident, mutbl, _) => (ident, mutbl),

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -75,9 +75,11 @@ pub enum SyntaxExtension {
     ItemTT(SyntaxExpanderTTItem),
 }
 
+type SyntaxExtensions = HashMap<~str, SyntaxExtension>;
+
 // A temporary hard-coded map of methods for expanding syntax extension
 // AST nodes into full ASTs
-pub fn syntax_expander_table() -> HashMap<~str, SyntaxExtension> {
+pub fn syntax_expander_table() -> SyntaxExtensions {
     // utility function to simplify creating NormalTT syntax extensions
     fn builtin_normal_tt(f: SyntaxExpanderTTFun) -> SyntaxExtension {
         NormalTT(SyntaxExpanderTT{expander: f, span: None})

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -75,7 +75,7 @@ pub enum SyntaxExtension {
     ItemTT(SyntaxExpanderTTItem),
 }
 
-type SyntaxExtensions = HashMap<~str, SyntaxExtension>;
+type SyntaxExtensions = HashMap<@~str, SyntaxExtension>;
 
 // A temporary hard-coded map of methods for expanding syntax extension
 // AST nodes into full ASTs
@@ -89,74 +89,74 @@ pub fn syntax_expander_table() -> SyntaxExtensions {
         ItemTT(SyntaxExpanderTTItem{expander: f, span: None})
     }
     let syntax_expanders = HashMap();
-    syntax_expanders.insert(~"macro_rules",
+    syntax_expanders.insert(@~"macro_rules",
                             builtin_item_tt(
                                 ext::tt::macro_rules::add_new_extension));
-    syntax_expanders.insert(~"fmt",
+    syntax_expanders.insert(@~"fmt",
                             builtin_normal_tt(ext::fmt::expand_syntax_ext));
     syntax_expanders.insert(
-        ~"auto_encode",
+        @~"auto_encode",
         ItemDecorator(ext::auto_encode::expand_auto_encode));
     syntax_expanders.insert(
-        ~"auto_decode",
+        @~"auto_decode",
         ItemDecorator(ext::auto_encode::expand_auto_decode));
-    syntax_expanders.insert(~"env",
+    syntax_expanders.insert(@~"env",
                             builtin_normal_tt(ext::env::expand_syntax_ext));
-    syntax_expanders.insert(~"concat_idents",
+    syntax_expanders.insert(@~"concat_idents",
                             builtin_normal_tt(
                                 ext::concat_idents::expand_syntax_ext));
-    syntax_expanders.insert(~"log_syntax",
+    syntax_expanders.insert(@~"log_syntax",
                             builtin_normal_tt(
                                 ext::log_syntax::expand_syntax_ext));
-    syntax_expanders.insert(~"deriving_eq",
+    syntax_expanders.insert(@~"deriving_eq",
                             ItemDecorator(
                                 ext::deriving::expand_deriving_eq));
-    syntax_expanders.insert(~"deriving_iter_bytes",
+    syntax_expanders.insert(@~"deriving_iter_bytes",
                             ItemDecorator(
                                 ext::deriving::expand_deriving_iter_bytes));
 
     // Quasi-quoting expanders
-    syntax_expanders.insert(~"quote_tokens",
+    syntax_expanders.insert(@~"quote_tokens",
                        builtin_normal_tt(ext::quote::expand_quote_tokens));
-    syntax_expanders.insert(~"quote_expr",
+    syntax_expanders.insert(@~"quote_expr",
                             builtin_normal_tt(ext::quote::expand_quote_expr));
-    syntax_expanders.insert(~"quote_ty",
+    syntax_expanders.insert(@~"quote_ty",
                             builtin_normal_tt(ext::quote::expand_quote_ty));
-    syntax_expanders.insert(~"quote_item",
+    syntax_expanders.insert(@~"quote_item",
                             builtin_normal_tt(ext::quote::expand_quote_item));
-    syntax_expanders.insert(~"quote_pat",
+    syntax_expanders.insert(@~"quote_pat",
                             builtin_normal_tt(ext::quote::expand_quote_pat));
-    syntax_expanders.insert(~"quote_stmt",
+    syntax_expanders.insert(@~"quote_stmt",
                             builtin_normal_tt(ext::quote::expand_quote_stmt));
 
-    syntax_expanders.insert(~"line",
+    syntax_expanders.insert(@~"line",
                             builtin_normal_tt(
                                 ext::source_util::expand_line));
-    syntax_expanders.insert(~"col",
+    syntax_expanders.insert(@~"col",
                             builtin_normal_tt(
                                 ext::source_util::expand_col));
-    syntax_expanders.insert(~"file",
+    syntax_expanders.insert(@~"file",
                             builtin_normal_tt(
                                 ext::source_util::expand_file));
-    syntax_expanders.insert(~"stringify",
+    syntax_expanders.insert(@~"stringify",
                             builtin_normal_tt(
                                 ext::source_util::expand_stringify));
-    syntax_expanders.insert(~"include",
+    syntax_expanders.insert(@~"include",
                             builtin_normal_tt(
                                 ext::source_util::expand_include));
-    syntax_expanders.insert(~"include_str",
+    syntax_expanders.insert(@~"include_str",
                             builtin_normal_tt(
                                 ext::source_util::expand_include_str));
-    syntax_expanders.insert(~"include_bin",
+    syntax_expanders.insert(@~"include_bin",
                             builtin_normal_tt(
                                 ext::source_util::expand_include_bin));
-    syntax_expanders.insert(~"module_path",
+    syntax_expanders.insert(@~"module_path",
                             builtin_normal_tt(
                                 ext::source_util::expand_mod));
-    syntax_expanders.insert(~"proto",
+    syntax_expanders.insert(@~"proto",
                             builtin_item_tt(ext::pipes::expand_proto));
     syntax_expanders.insert(
-        ~"trace_macros",
+        @~"trace_macros",
         builtin_normal_tt(ext::trace_macros::expand_trace_macros));
     return syntax_expanders;
 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -13,6 +13,7 @@ use core::prelude::*;
 use ast::{crate, expr_, expr_mac, mac_invoc_tt};
 use ast::{tt_delim, tt_tok, item_mac, stmt_, stmt_mac, stmt_expr, stmt_semi};
 use ast;
+use attr;
 use codemap::{span, ExpandedFrom};
 use ext::base::*;
 use fold::*;
@@ -99,11 +100,8 @@ pub fn expand_mod_items(exts: HashMap<~str, SyntaxExtension>, cx: ext_ctxt,
     // the item into a new set of items.
     let new_items = do vec::flat_map(module_.items) |item| {
         do vec::foldr(item.attrs, ~[*item]) |attr, items| {
-            let mname = match attr.node.value.node {
-              ast::meta_word(ref n) => (*n),
-              ast::meta_name_value(ref n, _) => (*n),
-              ast::meta_list(ref n, _) => (*n)
-            };
+            let mname = attr::get_attr_name(attr);
+
             match exts.find(&mname) {
               None | Some(NormalTT(_)) | Some(ItemTT(*)) => items,
               Some(ItemDecorator(dec_fn)) => {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -41,7 +41,7 @@ pub fn expand_expr(exts: SyntaxExtensions, cx: ext_ctxt,
                 /* using idents and token::special_idents would make the
                 the macro names be hygienic */
                 let extname = cx.parse_sess().interner.get(pth.idents[0]);
-                match exts.find(extname) {
+                match exts.find(&extname) {
                   None => {
                     cx.span_fatal(pth.span,
                                   fmt!("macro undefined: '%s'", *extname))
@@ -102,7 +102,7 @@ pub fn expand_mod_items(exts: SyntaxExtensions, cx: ext_ctxt,
         do vec::foldr(item.attrs, ~[*item]) |attr, items| {
             let mname = attr::get_attr_name(attr);
 
-            match exts.find(&*mname) {
+            match exts.find(&mname) {
               None | Some(NormalTT(_)) | Some(ItemTT(*)) => items,
               Some(ItemDecorator(dec_fn)) => {
                   cx.bt_push(ExpandedFrom({call_site: attr.span,
@@ -159,7 +159,7 @@ pub fn expand_item_mac(exts: SyntaxExtensions,
     };
 
     let extname = cx.parse_sess().interner.get(pth.idents[0]);
-    let expanded = match exts.find(extname) {
+    let expanded = match exts.find(&extname) {
         None => cx.span_fatal(pth.span,
                               fmt!("macro undefined: '%s!'", *extname)),
 
@@ -198,7 +198,7 @@ pub fn expand_item_mac(exts: SyntaxExtensions,
         MRAny(_, item_maker, _) =>
             option::chain(item_maker(), |i| {fld.fold_item(i)}),
         MRDef(ref mdef) => {
-            exts.insert((*mdef).name, (*mdef).ext);
+            exts.insert(@/*bad*/ copy mdef.name, (*mdef).ext);
             None
         }
     };
@@ -222,7 +222,7 @@ pub fn expand_stmt(exts: SyntaxExtensions, cx: ext_ctxt,
 
     assert(vec::len(pth.idents) == 1u);
     let extname = cx.parse_sess().interner.get(pth.idents[0]);
-    let (fully_expanded, sp) = match exts.find(extname) {
+    let (fully_expanded, sp) = match exts.find(&extname) {
         None =>
             cx.span_fatal(pth.span, fmt!("macro undefined: '%s'", *extname)),
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -102,11 +102,11 @@ pub fn expand_mod_items(exts: SyntaxExtensions, cx: ext_ctxt,
         do vec::foldr(item.attrs, ~[*item]) |attr, items| {
             let mname = attr::get_attr_name(attr);
 
-            match exts.find(&mname) {
+            match exts.find(&*mname) {
               None | Some(NormalTT(_)) | Some(ItemTT(*)) => items,
               Some(ItemDecorator(dec_fn)) => {
                   cx.bt_push(ExpandedFrom({call_site: attr.span,
-                                           callie: {name: copy mname,
+                                           callie: {name: /*bad*/ copy *mname,
                                                     span: None}}));
                   let r = dec_fn(cx, attr.span, attr.node.value, items);
                   cx.bt_pop();

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -23,7 +23,7 @@ use core::option;
 use core::vec;
 use std::oldmap::HashMap;
 
-pub fn expand_expr(exts: HashMap<~str, SyntaxExtension>, cx: ext_ctxt,
+pub fn expand_expr(exts: SyntaxExtensions, cx: ext_ctxt,
                    e: expr_, s: span, fld: ast_fold,
                    orig: fn@(expr_, span, ast_fold) -> (expr_, span))
                 -> (expr_, span) {
@@ -88,7 +88,7 @@ pub fn expand_expr(exts: HashMap<~str, SyntaxExtension>, cx: ext_ctxt,
 //
 // NB: there is some redundancy between this and expand_item, below, and
 // they might benefit from some amount of semantic and language-UI merger.
-pub fn expand_mod_items(exts: HashMap<~str, SyntaxExtension>, cx: ext_ctxt,
+pub fn expand_mod_items(exts: SyntaxExtensions, cx: ext_ctxt,
                         module_: ast::_mod, fld: ast_fold,
                         orig: fn@(ast::_mod, ast_fold) -> ast::_mod)
                      -> ast::_mod {
@@ -121,7 +121,7 @@ pub fn expand_mod_items(exts: HashMap<~str, SyntaxExtension>, cx: ext_ctxt,
 
 
 // When we enter a module, record it, for the sake of `module!`
-pub fn expand_item(exts: HashMap<~str, SyntaxExtension>,
+pub fn expand_item(exts: SyntaxExtensions,
                    cx: ext_ctxt, &&it: @ast::item, fld: ast_fold,
                    orig: fn@(&&v: @ast::item, ast_fold) -> Option<@ast::item>)
                 -> Option<@ast::item> {
@@ -147,7 +147,7 @@ pub fn expand_item(exts: HashMap<~str, SyntaxExtension>,
 
 // Support for item-position macro invocations, exactly the same
 // logic as for expression-position macro invocations.
-pub fn expand_item_mac(exts: HashMap<~str, SyntaxExtension>,
+pub fn expand_item_mac(exts: SyntaxExtensions,
                        cx: ext_ctxt, &&it: @ast::item,
                        fld: ast_fold) -> Option<@ast::item> {
 
@@ -206,7 +206,7 @@ pub fn expand_item_mac(exts: HashMap<~str, SyntaxExtension>,
     return maybe_it;
 }
 
-pub fn expand_stmt(exts: HashMap<~str, SyntaxExtension>, cx: ext_ctxt,
+pub fn expand_stmt(exts: SyntaxExtensions, cx: ext_ctxt,
                    && s: stmt_, sp: span, fld: ast_fold,
                    orig: fn@(&&s: stmt_, span, ast_fold) -> (stmt_, span))
                 -> (stmt_, span) {

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -228,9 +228,10 @@ pub impl ext_ctxt_ast_builder for ext_ctxt {
         let non_camel_case_attribute = respan(dummy_sp(), ast::attribute_ {
             style: ast::attr_outer,
             value: respan(dummy_sp(),
-                          ast::meta_list(~"allow", ~[
+                          ast::meta_list(@~"allow", ~[
                               @respan(dummy_sp(),
-                                      ast::meta_word(~"non_camel_case_types"))
+                                      ast::meta_word(
+                                         @~"non_camel_case_types"))
                           ])),
             is_sugared_doc: false
         });

--- a/src/libsyntax/ext/pipes/check.rs
+++ b/src/libsyntax/ext/pipes/check.rs
@@ -54,27 +54,27 @@ pub impl proto::visitor<(), (), ()> for ext_ctxt {
     fn visit_message(&self, name: ~str, _span: span, _tys: &[@ast::Ty],
                      this: state, next: Option<next_state>) {
         match next {
-          Some(next_state { state: ref next, tys: next_tys }) => {
+          Some(ref next_state) => {
             let proto = this.proto;
-            if !proto.has_state((*next)) {
+            if !proto.has_state(next_state.state) {
                 // This should be a span fatal, but then we need to
                 // track span information.
                 self.span_err(
-                    proto.get_state((*next)).span,
+                    proto.get_state(next_state.state).span,
                     fmt!("message %s steps to undefined state, %s",
-                         name, (*next)));
+                         name, next_state.state));
             }
             else {
-                let next = proto.get_state((*next));
+                let next = proto.get_state(next_state.state);
 
-                if next.ty_params.len() != next_tys.len() {
+                if next.ty_params.len() != next_state.tys.len() {
                     self.span_err(
                         next.span, // use a real span
                         fmt!("message %s target (%s) \
                               needs %u type parameters, but got %u",
                              name, next.name,
                              next.ty_params.len(),
-                             next_tys.len()));
+                             next_state.tys.len()));
                 }
             }
           }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -59,12 +59,13 @@ pub fn add_new_extension(cx: ext_ctxt, sp: span, name: ident,
                                      arg_reader as reader, argument_gram);
 
     // Extract the arguments:
-    let lhses:~[@named_match] = match argument_map.get(&lhs_nm) {
-      @matched_seq(s, _) => s,
-      _ => cx.span_bug(sp, ~"wrong-structured lhs")
+    let lhses = match argument_map.get(&lhs_nm) {
+        @matched_seq(ref s, _) => /* FIXME (#2543) */ copy *s,
+        _ => cx.span_bug(sp, ~"wrong-structured lhs")
     };
-    let rhses:~[@named_match] = match argument_map.get(&rhs_nm) {
-      @matched_seq(s, _) => s,
+
+    let rhses = match argument_map.get(&rhs_nm) {
+      @matched_seq(ref s, _) => /* FIXME (#2543) */ copy *s,
       _ => cx.span_bug(sp, ~"wrong-structured rhs")
     };
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -82,10 +82,10 @@ fn fold_meta_item_(&&mi: @meta_item, fld: ast_fold) -> @meta_item {
         node:
             match mi.node {
                 meta_word(ref id) => meta_word((*id)),
-                meta_list(ref id, mis) => {
-                    let fold_meta_item = |x|fold_meta_item_(x, fld);
-                    meta_list(/* FIXME: (#2543) */ copy (*id),
-                        vec::map(mis, |e| fold_meta_item(*e)))
+                meta_list(ref id, ref mis) => {
+                    let fold_meta_item = |x| fold_meta_item_(x, fld);
+                    meta_list(/* FIXME: (#2543) */ copy *id,
+                              mis.map(|e| fold_meta_item(*e)))
                 }
                 meta_name_value(ref id, s) => {
                     meta_name_value((*id), /* FIXME (#2543) */ copy s)
@@ -215,42 +215,44 @@ fn noop_fold_struct_field(&&sf: @struct_field, fld: ast_fold)
 pub fn noop_fold_item_underscore(i: item_, fld: ast_fold) -> item_ {
     match i {
         item_const(t, e) => item_const(fld.fold_ty(t), fld.fold_expr(e)),
-        item_fn(decl, purity, typms, ref body) => {
-            item_fn(fold_fn_decl(decl, fld),
+        item_fn(ref decl, purity, ref typms, ref body) => {
+            item_fn(fold_fn_decl(/* FIXME (#2543) */ copy *decl, fld),
                     purity,
-                    fold_ty_params(typms, fld),
-                    fld.fold_block((*body)))
+                    fold_ty_params(/* FIXME (#2543) */ copy *typms, fld),
+                    fld.fold_block(*body))
         }
         item_mod(m) => item_mod(fld.fold_mod(m)),
         item_foreign_mod(nm) => item_foreign_mod(fld.fold_foreign_mod(nm)),
         item_ty(t, typms) => item_ty(fld.fold_ty(t),
                                      fold_ty_params(typms, fld)),
-        item_enum(ref enum_definition, typms) => {
+        item_enum(ref enum_definition, ref typms) => {
             item_enum(ast::enum_def(ast::enum_def_ {
                 variants: enum_definition.variants.map(
                     |x| fld.fold_variant(*x)),
                 common: enum_definition.common.map(
                     |x| fold_struct_def(*x, fld)),
-            }), fold_ty_params(typms, fld))
+            }), fold_ty_params(/* FIXME (#2543) */ copy *typms, fld))
         }
-        item_struct(struct_def, typms) => {
-            let struct_def = fold_struct_def(struct_def, fld);
-              item_struct(struct_def, /* FIXME (#2543) */ copy typms)
+        item_struct(ref struct_def, ref typms) => {
+            let struct_def = fold_struct_def(
+                /* FIXME (#2543) */ copy *struct_def,
+                fld);
+            item_struct(struct_def, /* FIXME (#2543) */ copy *typms)
         }
-        item_impl(tps, ifce, ty, ref methods) => {
-            item_impl(fold_ty_params(tps, fld),
+        item_impl(ref tps, ifce, ty, ref methods) => {
+            item_impl(fold_ty_params(/* FIXME (#2543) */ copy *tps, fld),
                       ifce.map(|p| fold_trait_ref(*p, fld)),
                       fld.fold_ty(ty),
                       methods.map(|x| fld.fold_method(*x)))
         }
-        item_trait(tps, traits, ref methods) => {
+        item_trait(ref tps, ref traits, ref methods) => {
             let methods = do methods.map |method| {
                 match *method {
                     required(*) => copy *method,
                     provided(method) => provided(fld.fold_method(method))
                 }
             };
-            item_trait(fold_ty_params(tps, fld),
+            item_trait(fold_ty_params(/* FIXME (#2543) */ copy *tps, fld),
                        traits.map(|p| fold_trait_ref(*p, fld)),
                        methods)
         }
@@ -466,14 +468,14 @@ pub fn noop_fold_expr(e: expr_, fld: ast_fold) -> expr_ {
             expr_match(fld.fold_expr(expr),
                      vec::map((*arms), |x| fld.fold_arm(*x)))
           }
-          expr_fn(proto, decl, ref body, _) => {
+          expr_fn(proto, ref decl, ref body, _) => {
             expr_fn(proto,
-                    fold_fn_decl(decl, fld),
+                    fold_fn_decl(/* FIXME (#2543) */ copy *decl, fld),
                     fld.fold_block(*body),
                     @())
           }
-          expr_fn_block(decl, ref body) => {
-            expr_fn_block(fold_fn_decl(decl, fld),
+          expr_fn_block(ref decl, ref body) => {
+            expr_fn_block(fold_fn_decl(/* FIXME (#2543) */ copy *decl, fld),
                           fld.fold_block(*body))
           }
           expr_block(ref blk) => expr_block(fld.fold_block((*blk))),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -213,52 +213,52 @@ fn noop_fold_struct_field(&&sf: @struct_field, fld: ast_fold)
 }
 
 pub fn noop_fold_item_underscore(i: item_, fld: ast_fold) -> item_ {
-    return match i {
-          item_const(t, e) => item_const(fld.fold_ty(t), fld.fold_expr(e)),
-          item_fn(decl, purity, typms, ref body) => {
-              item_fn(fold_fn_decl(decl, fld),
-                      purity,
-                      fold_ty_params(typms, fld),
-                      fld.fold_block((*body)))
-          }
-          item_mod(m) => item_mod(fld.fold_mod(m)),
-          item_foreign_mod(nm) => item_foreign_mod(fld.fold_foreign_mod(nm)),
-          item_ty(t, typms) => item_ty(fld.fold_ty(t),
-                                       fold_ty_params(typms, fld)),
-          item_enum(ref enum_definition, typms) => {
+    match i {
+        item_const(t, e) => item_const(fld.fold_ty(t), fld.fold_expr(e)),
+        item_fn(decl, purity, typms, ref body) => {
+            item_fn(fold_fn_decl(decl, fld),
+                    purity,
+                    fold_ty_params(typms, fld),
+                    fld.fold_block((*body)))
+        }
+        item_mod(m) => item_mod(fld.fold_mod(m)),
+        item_foreign_mod(nm) => item_foreign_mod(fld.fold_foreign_mod(nm)),
+        item_ty(t, typms) => item_ty(fld.fold_ty(t),
+                                     fold_ty_params(typms, fld)),
+        item_enum(ref enum_definition, typms) => {
             item_enum(ast::enum_def(ast::enum_def_ {
                 variants: enum_definition.variants.map(
                     |x| fld.fold_variant(*x)),
                 common: enum_definition.common.map(
                     |x| fold_struct_def(*x, fld)),
             }), fold_ty_params(typms, fld))
-          }
-          item_struct(struct_def, typms) => {
+        }
+        item_struct(struct_def, typms) => {
             let struct_def = fold_struct_def(struct_def, fld);
               item_struct(struct_def, /* FIXME (#2543) */ copy typms)
-          }
-          item_impl(tps, ifce, ty, ref methods) => {
-              item_impl(fold_ty_params(tps, fld),
-                        ifce.map(|p| fold_trait_ref(*p, fld)),
-                        fld.fold_ty(ty),
-                        vec::map(*methods, |x| fld.fold_method(*x)))
-          }
-          item_trait(tps, traits, ref methods) => {
-              let methods = do (*methods).map |method| {
-                  match *method {
-                      required(*) => copy *method,
-                      provided(method) => provided(fld.fold_method(method))
-                  }
-              };
+        }
+        item_impl(tps, ifce, ty, ref methods) => {
+            item_impl(fold_ty_params(tps, fld),
+                      ifce.map(|p| fold_trait_ref(*p, fld)),
+                      fld.fold_ty(ty),
+                      methods.map(|x| fld.fold_method(*x)))
+        }
+        item_trait(tps, traits, ref methods) => {
+            let methods = do methods.map |method| {
+                match *method {
+                    required(*) => copy *method,
+                    provided(method) => provided(fld.fold_method(method))
+                }
+            };
             item_trait(fold_ty_params(tps, fld),
-                       vec::map(traits, |p| fold_trait_ref(*p, fld)),
+                       traits.map(|p| fold_trait_ref(*p, fld)),
                        methods)
-          }
-      item_mac(ref m) => {
-        // FIXME #2888: we might actually want to do something here.
-        item_mac((*m))
-      }
-        };
+        }
+        item_mac(ref m) => {
+            // FIXME #2888: we might actually want to do something here.
+            item_mac((*m))
+        }
+    }
 }
 
 fn fold_struct_def(struct_def: @ast::struct_def, fld: ast_fold)

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -126,23 +126,23 @@ impl parser_attr for Parser {
 
     fn parse_meta_item() -> @ast::meta_item {
         let lo = self.span.lo;
-        let name = *self.id_to_str(self.parse_ident());
+        let name = self.id_to_str(self.parse_ident());
         match self.token {
-          token::EQ => {
-            self.bump();
-            let lit = self.parse_lit();
-            let mut hi = self.span.hi;
-            return @spanned(lo, hi, ast::meta_name_value(name, lit));
-          }
-          token::LPAREN => {
-            let inner_items = self.parse_meta_seq();
-            let mut hi = self.span.hi;
-            return @spanned(lo, hi, ast::meta_list(name, inner_items));
-          }
-          _ => {
-            let mut hi = self.span.hi;
-            return @spanned(lo, hi, ast::meta_word(name));
-          }
+            token::EQ => {
+                self.bump();
+                let lit = self.parse_lit();
+                let mut hi = self.span.hi;
+                @spanned(lo, hi, ast::meta_name_value(name, lit))
+            }
+            token::LPAREN => {
+                let inner_items = self.parse_meta_seq();
+                let mut hi = self.span.hi;
+                @spanned(lo, hi, ast::meta_list(name, inner_items))
+            }
+            _ => {
+                let mut hi = self.span.hi;
+                @spanned(lo, hi, ast::meta_word(name))
+            }
         }
     }
 

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -46,14 +46,14 @@ impl cmp::Eq for cmnt_style {
 
 pub type cmnt = {style: cmnt_style, lines: ~[~str], pos: BytePos};
 
-pub fn is_doc_comment(s: ~str) -> bool {
+pub fn is_doc_comment(s: &str) -> bool {
     (s.starts_with(~"///") && !is_line_non_doc_comment(s)) ||
     s.starts_with(~"//!") ||
     (s.starts_with(~"/**") && !is_block_non_doc_comment(s)) ||
     s.starts_with(~"/*!")
 }
 
-pub fn doc_comment_style(comment: ~str) -> ast::attr_style {
+pub fn doc_comment_style(comment: &str) -> ast::attr_style {
     assert is_doc_comment(comment);
     if comment.starts_with(~"//!") || comment.starts_with(~"/*!") {
         ast::attr_inner
@@ -62,7 +62,7 @@ pub fn doc_comment_style(comment: ~str) -> ast::attr_style {
     }
 }
 
-pub fn strip_doc_comment_decoration(comment: ~str) -> ~str {
+pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
 
     /// remove whitespace-only lines from the start/end of lines
     fn vertical_trim(lines: ~[~str]) -> ~[~str] {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3247,11 +3247,11 @@ pub impl Parser {
         // on the mod, then we'll go and suck in another file and merge
         // its contents
         match ::attr::first_attr_value_str_by_name(outer_attrs, ~"merge") {
-            Some(ref path) => {
+            Some(path) => {
                 let prefix = Path(
                     self.sess.cm.span_to_filename(copy self.span));
                 let prefix = prefix.dir_path();
-                let path = Path((*path));
+                let path = Path(copy *path);
                 let (new_mod_item, new_attrs) = self.eval_src_mod_from_path(
                     prefix, path, ~[], id_span);
 
@@ -3280,7 +3280,7 @@ pub impl Parser {
         let file_path = match ::attr::first_attr_value_str_by_name(
             attrs, ~"path") {
 
-            Some(ref d) => (*d),
+            Some(d) => copy *d,
             None => copy *default_path
         };
         self.mod_path_stack.push(file_path)
@@ -3300,10 +3300,10 @@ pub impl Parser {
         let default_path = self.sess.interner.get(id) + ~".rs";
         let file_path = match ::attr::first_attr_value_str_by_name(
             outer_attrs, ~"path") {
-            Some(ref d) => {
-                let path = Path(*d);
+            Some(d) => {
+                let path = Path(copy *d);
                 if !path.is_absolute {
-                    mod_path.push(*d)
+                    mod_path.push(copy *d)
                 } else {
                     path
                 }
@@ -3337,7 +3337,7 @@ pub impl Parser {
 
         fn cdir_path_opt(default: ~str, attrs: ~[ast::attribute]) -> ~str {
             match ::attr::first_attr_value_str_by_name(attrs, ~"path") {
-                Some(ref d) => (*d),
+                Some(d) => copy *d,
                 None => default
             }
         }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -429,7 +429,7 @@ pub fn mk_ident_interner() -> @ident_interner {
                 ];
 
                 let rv = @ident_interner {
-                    interner: interner::mk_prefill(init_vec)
+                    interner: interner::Interner::prefill(init_vec)
                 };
 
                 task::local_data::local_data_set(interner_key!(), @rv);
@@ -443,7 +443,7 @@ pub fn mk_ident_interner() -> @ident_interner {
 /* for when we don't care about the contents; doesn't interact with TLD or
    serialization */
 pub fn mk_fake_ident_interner() -> @ident_interner {
-    @ident_interner { interner: interner::mk::<@~str>() }
+    @ident_interner { interner: interner::Interner::new() }
 }
 
 /**

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1816,13 +1816,13 @@ pub fn print_type_params(s: @ps, &&params: ~[ast::ty_param]) {
 pub fn print_meta_item(s: @ps, &&item: @ast::meta_item) {
     ibox(s, indent_unit);
     match item.node {
-      ast::meta_word(ref name) => word(s.s, *name),
-      ast::meta_name_value(ref name, value) => {
+      ast::meta_word(name) => word(s.s, *name),
+      ast::meta_name_value(name, value) => {
         word_space(s, *name);
         word_space(s, ~"=");
         print_literal(s, @value);
       }
-      ast::meta_list(ref name, ref items) => {
+      ast::meta_list(name, ref items) => {
         word(s.s, *name);
         popen(s);
         commasep(

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -495,9 +495,16 @@ pub fn print_item(s: @ps, &&item: @ast::item) {
         end(s); // end the outer cbox
 
       }
-      ast::item_fn(decl, purity, typarams, ref body) => {
-        print_fn(s, decl, Some(purity), item.ident, typarams, None,
-                 item.vis);
+      ast::item_fn(ref decl, purity, ref typarams, ref body) => {
+        print_fn(
+            s,
+            /* FIXME (#2543) */ copy *decl,
+            Some(purity),
+            item.ident,
+            /* FIXME (#2543) */ copy *typarams,
+            None,
+            item.vis
+        );
         word(s.s, ~" ");
         print_block_with_attrs(s, (*body), item.attrs);
       }
@@ -539,9 +546,15 @@ pub fn print_item(s: @ps, &&item: @ast::item) {
         word(s.s, ~";");
         end(s); // end the outer ibox
       }
-      ast::item_enum(ref enum_definition, params) => {
-        print_enum_def(s, (*enum_definition), params, item.ident,
-                       item.span, item.vis);
+      ast::item_enum(ref enum_definition, ref params) => {
+        print_enum_def(
+            s,
+            *enum_definition,
+            /* FIXME (#2543) */ copy *params,
+            item.ident,
+            item.span,
+            item.vis
+        );
       }
       ast::item_struct(struct_def, tps) => {
           head(s, visibility_qualified(item.vis, ~"struct"));
@@ -577,13 +590,13 @@ pub fn print_item(s: @ps, &&item: @ast::item) {
             bclose(s, item.span);
         }
       }
-      ast::item_trait(tps, traits, ref methods) => {
+      ast::item_trait(ref tps, ref traits, ref methods) => {
         head(s, visibility_qualified(item.vis, ~"trait"));
         print_ident(s, item.ident);
-        print_type_params(s, tps);
-        if vec::len(traits) != 0u {
+        print_type_params(s, /* FIXME (#2543) */ copy *tps);
+        if traits.len() != 0u {
             word(s.s, ~":");
-            for vec::each(traits) |trait_| {
+            for traits.each |trait_| {
                 nbsp(s);
                 print_path(s, trait_.path, false);
             }
@@ -619,7 +632,7 @@ pub fn print_enum_def(s: @ps, enum_definition: ast::enum_def,
         ident == enum_definition.variants[0].node.name;
     if newtype {
         match enum_definition.variants[0].node.kind {
-            ast::tuple_variant_kind(args) if args.len() == 1 => {}
+            ast::tuple_variant_kind(ref args) if args.len() == 1 => {}
             _ => newtype = false
         }
     }
@@ -1325,24 +1338,24 @@ pub fn print_expr(s: @ps, &&expr: @ast::expr) {
         }
         bclose_(s, expr.span, match_indent_unit);
       }
-      ast::expr_fn(sigil, decl, ref body, _) => {
+      ast::expr_fn(sigil, ref decl, ref body, _) => {
         // containing cbox, will be closed by print-block at }
         cbox(s, indent_unit);
         // head-box, will be closed by print-block at start
         ibox(s, 0u);
         print_fn_header_info(s, None, None, ast::Many,
                              Some(sigil), ast::inherited);
-        print_fn_args_and_ret(s, decl, None);
+        print_fn_args_and_ret(s, /* FIXME (#2543) */ copy *decl, None);
         space(s.s);
         print_block(s, (*body));
       }
-      ast::expr_fn_block(decl, ref body) => {
+      ast::expr_fn_block(ref decl, ref body) => {
         // in do/for blocks we don't want to show an empty
         // argument list, but at this point we don't know which
         // we are inside.
         //
         // if !decl.inputs.is_empty() {
-        print_fn_block_args(s, decl);
+        print_fn_block_args(s, /* FIXME (#2543) */ copy *decl);
         space(s.s);
         // }
         assert (*body).node.stmts.is_empty();
@@ -1809,10 +1822,15 @@ pub fn print_meta_item(s: @ps, &&item: @ast::meta_item) {
         word_space(s, ~"=");
         print_literal(s, @value);
       }
-      ast::meta_list(ref name, items) => {
+      ast::meta_list(ref name, ref items) => {
         word(s.s, (*name));
         popen(s);
-        commasep(s, consistent, items, print_meta_item);
+        commasep(
+            s,
+            consistent,
+            /* FIXME (#2543) */ copy *items,
+            print_meta_item
+        );
         pclose(s);
       }
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -897,7 +897,7 @@ pub fn print_attribute(s: @ps, attr: ast::attribute) {
     if attr.node.is_sugared_doc {
         let meta = attr::attr_meta(attr);
         let comment = attr::get_meta_item_value_str(meta).get();
-        word(s.s, comment);
+        word(s.s, *comment);
     } else {
         word(s.s, ~"#[");
         print_meta_item(s, @attr.node.value);
@@ -1816,14 +1816,14 @@ pub fn print_type_params(s: @ps, &&params: ~[ast::ty_param]) {
 pub fn print_meta_item(s: @ps, &&item: @ast::meta_item) {
     ibox(s, indent_unit);
     match item.node {
-      ast::meta_word(ref name) => word(s.s, (*name)),
+      ast::meta_word(ref name) => word(s.s, *name),
       ast::meta_name_value(ref name, value) => {
-        word_space(s, (*name));
+        word_space(s, *name);
         word_space(s, ~"=");
         print_literal(s, @value);
       }
       ast::meta_list(ref name, ref items) => {
-        word(s.s, (*name));
+        word(s.s, *name);
         popen(s);
         commasep(
             s,

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -137,11 +137,20 @@ pub fn visit_item<E>(i: @item, e: E, v: vt<E>) {
         (v.visit_ty)(t, e, v);
         (v.visit_expr)(ex, e, v);
       }
-      item_fn(decl, purity, tp, ref body) => {
-        (v.visit_fn)(fk_item_fn(/* FIXME (#2543) */ copy i.ident,
-                              /* FIXME (#2543) */ copy tp,
-                              purity), decl, (*body),
-                   i.span, i.id, e, v);
+      item_fn(ref decl, purity, ref tp, ref body) => {
+        (v.visit_fn)(
+            fk_item_fn(
+                /* FIXME (#2543) */ copy i.ident,
+                /* FIXME (#2543) */ copy *tp,
+                purity
+            ),
+            /* FIXME (#2543) */ copy *decl,
+            (*body),
+            i.span,
+            i.id,
+            e,
+            v
+        );
       }
       item_mod(m) => (v.visit_mod)(m, i.span, i.id, e, v),
       item_foreign_mod(nm) => {
@@ -152,9 +161,14 @@ pub fn visit_item<E>(i: @item, e: E, v: vt<E>) {
         (v.visit_ty)(t, e, v);
         (v.visit_ty_params)(tps, e, v);
       }
-      item_enum(ref enum_definition, tps) => {
-        (v.visit_ty_params)(tps, e, v);
-        visit_enum_def((*enum_definition), tps, e, v);
+      item_enum(ref enum_definition, ref tps) => {
+        (v.visit_ty_params)(/* FIXME (#2543) */ copy *tps, e, v);
+        visit_enum_def(
+            *enum_definition,
+            /* FIXME (#2543) */ copy *tps,
+            e,
+            v
+        );
       }
       item_impl(tps, traits, ty, methods) => {
         (v.visit_ty_params)(tps, e, v);
@@ -170,8 +184,8 @@ pub fn visit_item<E>(i: @item, e: E, v: vt<E>) {
         (v.visit_ty_params)(tps, e, v);
         (v.visit_struct_def)(struct_def, i.ident, tps, i.id, e, v);
       }
-      item_trait(tps, traits, ref methods) => {
-        (v.visit_ty_params)(tps, e, v);
+      item_trait(ref tps, ref traits, ref methods) => {
+        (v.visit_ty_params)(/* FIXME (#2543) */ copy *tps, e, v);
         for traits.each |p| { visit_path(p.path, e, v); }
         for (*methods).each |m| {
             (v.visit_trait_method)(*m, e, v);
@@ -460,13 +474,27 @@ pub fn visit_expr<E>(ex: @expr, e: E, v: vt<E>) {
         (v.visit_expr)(x, e, v);
         for (*arms).each |a| { (v.visit_arm)(*a, e, v); }
       }
-      expr_fn(proto, decl, ref body, _) => {
-        (v.visit_fn)(fk_anon(proto), decl, (*body),
-                     ex.span, ex.id, e, v);
+      expr_fn(proto, ref decl, ref body, _) => {
+        (v.visit_fn)(
+            fk_anon(proto),
+            /* FIXME (#2543) */ copy *decl,
+            *body,
+            ex.span,
+            ex.id,
+            e,
+            v
+        );
       }
-      expr_fn_block(decl, ref body) => {
-        (v.visit_fn)(fk_fn_block, decl, (*body),
-                     ex.span, ex.id, e, v);
+      expr_fn_block(ref decl, ref body) => {
+        (v.visit_fn)(
+            fk_fn_block,
+            /* FIXME (#2543) */ copy *decl,
+            *body,
+            ex.span,
+            ex.id,
+            e,
+            v
+        );
       }
       expr_block(ref b) => (v.visit_block)((*b), e, v),
       expr_assign(a, b) => {


### PR DESCRIPTION
This patch series is doing a couple things with the ultimate goal of removing `#[allow(vecs_implicitly_copyable)]`, although I'm not quite there yet. The main change is passing around `@~str`s in most places, and using `ref`s in others. As far as I could tell, there are no performance changes with these patches, and all the tests pass on my mac.
