### PR TITLE
Modernize bitv and implement a bit vector set

### DIFF
--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -164,22 +164,22 @@ impl BigBitv {
 
     #[inline(always)]
     fn union(&mut self, b: &BigBitv, nbits: uint) -> bool {
-        self.process(b, nbits, lor)
+        self.process(b, nbits, |w1, w2| w1 | w2)
     }
 
     #[inline(always)]
     fn intersect(&mut self, b: &BigBitv, nbits: uint) -> bool {
-        self.process(b, nbits, land)
+        self.process(b, nbits, |w1, w2| w1 & w2)
     }
 
     #[inline(always)]
     fn become(&mut self, b: &BigBitv, nbits: uint) -> bool {
-        self.process(b, nbits, right)
+        self.process(b, nbits, |_, w| w)
     }
 
     #[inline(always)]
     fn difference(&mut self, b: &BigBitv, nbits: uint) -> bool {
-        self.process(b, nbits, difference)
+        self.process(b, nbits, |w1, w2| w1 & !w2)
     }
 
     #[inline(always)]
@@ -556,13 +556,9 @@ pub fn from_fn(len: uint, f: fn(index: uint) -> bool) -> Bitv {
     bitv
 }
 
-pure fn lor(w0: uint, w1: uint) -> uint { return w0 | w1; }
 
-pure fn land(w0: uint, w1: uint) -> uint { return w0 & w1; }
 
-pure fn difference(w0: uint, w1: uint) -> uint { return w0 & !w1; }
 
-pure fn right(_w0: uint, w1: uint) -> uint { return w1; }
 
 impl ops::Index<uint,bool> for Bitv {
     pure fn index(&self, i: uint) -> bool {

--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -112,8 +112,8 @@ struct BigBitv {
  */
 #[inline(always)]
 fn big_mask(nbits: uint, elem: uint) -> uint {
-    let rmd = nbits % uint_bits;
-    let nelems = nbits/uint_bits + if rmd == 0 {0} else {1};
+    let rmd = nbits % uint::bits;
+    let nelems = nbits/uint::bits + if rmd == 0 {0} else {1};
 
     if elem < nelems - 1 || rmd == 0 {
         !0
@@ -184,16 +184,16 @@ impl BigBitv {
 
     #[inline(always)]
     pure fn get(&self, i: uint) -> bool {
-        let w = i / uint_bits;
-        let b = i % uint_bits;
+        let w = i / uint::bits;
+        let b = i % uint::bits;
         let x = 1 & self.storage[w] >> b;
         x == 1
     }
 
     #[inline(always)]
     fn set(&mut self, i: uint, x: bool) {
-        let w = i / uint_bits;
-        let b = i % uint_bits;
+        let w = i / uint::bits;
+        let b = i % uint::bits;
         let flag = 1 << b;
         self.storage[w] = if x { self.storage[w] | flag }
                           else { self.storage[w] & !flag };
@@ -263,8 +263,8 @@ impl Bitv {
             Small(~SmallBitv::new(if init {!0} else {0}))
         }
         else {
-            let nelems = nbits/uint_bits +
-                         if nbits % uint_bits == 0 {0} else {1};
+            let nelems = nbits/uint::bits +
+                         if nbits % uint::bits == 0 {0} else {1};
             let elem = if init {!0} else {0};
             let s = from_elem(nelems, elem);
             Big(~BigBitv::new(s))
@@ -514,7 +514,7 @@ impl Clone for Bitv {
             Bitv{nbits: self.nbits, rep: Small(~SmallBitv{bits: b.bits})}
           }
           Big(ref b) => {
-            let mut st = from_elem(self.nbits / uint_bits + 1, 0);
+            let mut st = from_elem(self.nbits / uint::bits + 1, 0);
             let len = st.len();
             for uint::range(0, len) |i| { st[i] = b.storage[i]; };
             Bitv{nbits: self.nbits, rep: Big(~BigBitv{storage: st})}
@@ -555,8 +555,6 @@ pub fn from_fn(len: uint, f: fn(index: uint) -> bool) -> Bitv {
     }
     bitv
 }
-
-const uint_bits: uint = 32u + (1u << 32u >> 27u);
 
 pure fn lor(w0: uint, w1: uint) -> uint { return w0 | w1; }
 

--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -16,25 +16,25 @@ use core::vec;
 
 struct SmallBitv {
     /// only the lowest nbits of this value are used. the rest is undefined.
-    bits: u32
+    bits: uint
 }
 
 /// a mask that has a 1 for each defined bit in a small_bitv, assuming n bits
 #[inline(always)]
-fn small_mask(nbits: uint) -> u32 {
+fn small_mask(nbits: uint) -> uint {
     (1 << nbits) - 1
 }
 
 impl SmallBitv {
-    static fn new(bits: u32) -> SmallBitv {
+    static fn new(bits: uint) -> SmallBitv {
         SmallBitv {bits: bits}
     }
 
     #[inline(always)]
-    fn bits_op(&mut self, right_bits: u32, nbits: uint,
-               f: fn(u32, u32) -> u32) -> bool {
+    fn bits_op(&mut self, right_bits: uint, nbits: uint,
+               f: fn(uint, uint) -> uint) -> bool {
         let mask = small_mask(nbits);
-        let old_b: u32 = self.bits;
+        let old_b: uint = self.bits;
         let new_b = f(old_b, right_bits);
         self.bits = new_b;
         mask & old_b != mask & new_b
@@ -71,7 +71,7 @@ impl SmallBitv {
             self.bits |= 1<<i;
         }
         else {
-            self.bits &= !(1<<i as u32);
+            self.bits &= !(1<<i as uint);
         }
     }
 
@@ -259,7 +259,7 @@ priv impl Bitv {
 
 impl Bitv {
     static fn new(nbits: uint, init: bool) -> Bitv {
-        let rep = if nbits <= 32 {
+        let rep = if nbits <= uint::bits {
             Small(~SmallBitv::new(if init {!0} else {0}))
         }
         else {

--- a/src/test/bench/core-set.rs
+++ b/src/test/bench/core-set.rs
@@ -1,0 +1,180 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern mod std;
+use core::hashmap::linear::LinearSet;
+use std::bitv::BitvSet;
+use std::treemap::TreeSet;
+use core::io::WriterUtil;
+
+struct Results {
+    sequential_ints: float,
+    random_ints: float,
+    delete_ints: float,
+
+    sequential_strings: float,
+    random_strings: float,
+    delete_strings: float
+}
+
+fn timed(result: &mut float, op: fn()) {
+    let start = std::time::precise_time_s();
+    op();
+    let end = std::time::precise_time_s();
+    *result = (end - start);
+}
+
+impl Results {
+    fn bench_int<T: Set<uint>>(&mut self, rng: @rand::Rng, num_keys: uint,
+                               rand_cap: uint, f: fn() -> T) {
+        {
+            let mut set = f();
+            do timed(&mut self.sequential_ints) {
+                for uint::range(0, num_keys) |i| {
+                    set.insert(i);
+                }
+
+                for uint::range(0, num_keys) |i| {
+                    assert set.contains(&i);
+                }
+            }
+        }
+
+        {
+            let mut set = f();
+            do timed(&mut self.random_ints) {
+                for num_keys.times {
+                    set.insert((rng.next() as uint) % rand_cap);
+                }
+            }
+        }
+
+        {
+            let mut set = f();
+            for uint::range(0, num_keys) |i| {
+                set.insert(i);
+            }
+
+            do timed(&mut self.delete_ints) {
+                for uint::range(0, num_keys) |i| {
+                    assert set.remove(&i);
+                }
+            }
+        }
+    }
+
+    fn bench_str<T: Set<~str>>(&mut self, rng: @rand::Rng, num_keys: uint,
+                               f: fn() -> T) {
+        {
+            let mut set = f();
+            do timed(&mut self.sequential_strings) {
+                for uint::range(0, num_keys) |i| {
+                    let s = uint::to_str(i);
+                    set.insert(s);
+                }
+
+                for uint::range(0, num_keys) |i| {
+                    let s = uint::to_str(i);
+                    assert set.contains(&s);
+                }
+            }
+        }
+
+        {
+            let mut set = f();
+            do timed(&mut self.random_strings) {
+                for num_keys.times {
+                    let s = uint::to_str(rng.next() as uint);
+                    set.insert(s);
+                }
+            }
+        }
+
+        {
+            let mut set = f();
+            for uint::range(0, num_keys) |i| {
+                set.insert(uint::to_str(i));
+            }
+            do timed(&mut self.delete_strings) {
+                for uint::range(0, num_keys) |i| {
+                    assert set.remove(&uint::to_str(i));
+                }
+            }
+        }
+    }
+}
+
+fn write_header(header: &str) {
+    io::stdout().write_str(header);
+    io::stdout().write_str("\n");
+}
+
+fn write_row(label: &str, value: float) {
+    io::stdout().write_str(fmt!("%30s %f s\n", label, value));
+}
+
+fn write_results(label: &str, results: &Results) {
+    write_header(label);
+    write_row("sequential_ints", results.sequential_ints);
+    write_row("random_ints", results.random_ints);
+    write_row("delete_ints", results.delete_ints);
+    write_row("sequential_strings", results.sequential_strings);
+    write_row("random_strings", results.random_strings);
+    write_row("delete_strings", results.delete_strings);
+}
+
+fn empty_results() -> Results {
+    Results {
+        sequential_ints: 0f,
+        random_ints: 0f,
+        delete_ints: 0f,
+
+        sequential_strings: 0f,
+        random_strings: 0f,
+        delete_strings: 0f,
+    }
+}
+
+fn main() {
+    let args = os::args();
+    let num_keys = {
+        if args.len() == 2 {
+            uint::from_str(args[1]).get()
+        } else {
+            100 // woefully inadequate for any real measurement
+        }
+    };
+
+    let seed = ~[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let max = 200000;
+
+    {
+        let rng = rand::seeded_rng(&seed);
+        let mut results = empty_results();
+        results.bench_int(rng, num_keys, max, || LinearSet::new::<uint>());
+        results.bench_str(rng, num_keys, || LinearSet::new::<~str>());
+        write_results("core::hashmap::LinearSet", &results);
+    }
+
+    {
+        let rng = rand::seeded_rng(&seed);
+        let mut results = empty_results();
+        results.bench_int(rng, num_keys, max, || TreeSet::new::<uint>());
+        results.bench_str(rng, num_keys, || TreeSet::new::<~str>());
+        write_results("std::treemap::TreeSet", &results);
+    }
+
+    {
+        let rng = rand::seeded_rng(&seed);
+        let mut results = empty_results();
+        results.bench_int(rng, num_keys, max, || BitvSet::new());
+        write_results("std::bitv::BitvSet", &results);
+    }
+}

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -58,7 +58,7 @@ pub fn solve_grid(g: grid_t) {
     fn next_color(mut g: grid, row: u8, col: u8, start_color: u8) -> bool {
         if start_color < 10u8 {
             // colors not yet used
-            let avail = bitv::Bitv(10u, false);
+            let mut avail = bitv::Bitv::new(10u, false);
             for u8::range(start_color, 10u8) |color| {
                 avail.set(color as uint, true);
             }
@@ -80,7 +80,7 @@ pub fn solve_grid(g: grid_t) {
 
     // find colors available in neighbourhood of (row, col)
     fn drop_colors(g: grid, avail: bitv::Bitv, row: u8, col: u8) {
-        fn drop_color(g: grid, colors: bitv::Bitv, row: u8, col: u8) {
+        fn drop_color(g: grid, mut colors: bitv::Bitv, row: u8, col: u8) {
             let color = g[row][col];
             if color != 0u8 { colors.set(color as uint, false); }
         }

--- a/src/test/run-pass/bitv-perf-test.rs
+++ b/src/test/run-pass/bitv-perf-test.rs
@@ -14,8 +14,8 @@ extern mod std;
 use std::bitv::*;
 
 fn bitv_test() -> bool {
-    let v1 = ~Bitv(31, false);
-    let v2 = ~Bitv(31, true);
+    let mut v1 = ~Bitv::new(31, false);
+    let v2 = ~Bitv::new(31, true);
     v1.union(v2);
     true
 }


### PR DESCRIPTION
These commits take the old bitv implementation and modernize it with an explicit self, some minor touchups, and using what I think is some more recent patterns (like `::new` instead of `Type()`).

Additionally, this adds an implementation of `container::Set` on top of a bit vector to have as a set of `uint`s. I initially tried to parameterize the type for the set to be `T: NumCast` but I was hitting build problems in stage0 which I think means that it's not in a snapshot yet, so it's just hardcoded as a set of `uint`s now. In the future perhaps it could be parameterized. I'm not sure if it would really add anything, though, so maybe it's nicer to be hardcoded anyway.

I also added some extra methods to do normal bit vector operations on the set in-place, but these aren't a part of the `Set` trait right now. I haven't benchmarked any of these operations just yet, but I imagine that there's quite a lot of room for optimization here and there.
