### PR TITLE
os::make_absolute() and WindowsPath Refactoring and Fixes

### DIFF
--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -565,17 +565,13 @@ pub fn path_exists(p: &Path) -> bool {
  *
  * If the given path is relative, return it prepended with the current working
  * directory. If the given path is already an absolute path, return it
- * as is.
+ * as is.  This is a shortcut for calling os::getcwd().unsafe_join(p)
  */
 // NB: this is here rather than in path because it is a form of environment
 // querying; what it does depends on the process working directory, not just
 // the input paths.
 pub fn make_absolute(p: &Path) -> Path {
-    if p.is_absolute {
-        copy *p
-    } else {
-        getcwd().push_many(p.components)
-    }
+    getcwd().unsafe_join(p)
 }
 
 


### PR DESCRIPTION
This pull request moves the logic from os::make_absolute() into the path module and fixes path joining for Windows.  It does this by adding an `unsafe_join()` function that implements the operating system's path joining semantics.

Additionally it also adds an `is_restricted()` method to the trait which will return true if the path points to a windows device file.
