### PR TITLE
typo fix in doc/rust.md

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1117,6 +1117,7 @@ a = Cat{ name: ~"Spotty", weight: 2.7 };
 
 In this example, `Cat` is a _struct-like enum variant_,
 whereas `Dog` is simply called an enum variant.
+
 ### Constants
 
 ~~~~~~~~ {.ebnf .gram}


### PR DESCRIPTION
Added a newline to make header be a header.

(re-did pull request because I screwed up the last one)
