### PR TITLE
librustc: Get rid of structural records save for front/test.rs.

### DIFF
--- a/src/librustc/back/arm.rs
+++ b/src/librustc/back/arm.rs
@@ -14,7 +14,7 @@ use session::sess_os_to_meta_os;
 use metadata::loader::meta_section_name;
 
 pub fn get_target_strs(target_os: session::os) -> target_strs::t {
-    return {
+    return target_strs::t {
         module_asm: ~"",
 
         meta_sect_name: meta_section_name(sess_os_to_meta_os(target_os)),

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -686,7 +686,9 @@ pub fn exported_name(sess: Session,
             path_name(sess.ident_of(vers.to_owned()))));
 }
 
-pub fn mangle_exported_name(ccx: @CrateContext, +path: path, t: ty::t) -> ~str {
+pub fn mangle_exported_name(ccx: @CrateContext,
+                            +path: path,
+                            t: ty::t) -> ~str {
     let hash = get_symbol_hash(ccx, t);
     return exported_name(ccx.sess, path,
                          hash,

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -16,10 +16,10 @@ use lib::llvm::llvm;
 use lib::llvm::{ModuleRef, mk_pass_manager, mk_target_data, True, False};
 use lib::llvm::{PassManagerRef, FileType};
 use lib;
-use metadata::common::link_meta;
+use metadata::common::LinkMeta;
 use metadata::filesearch;
 use metadata::{encoder, cstore};
-use middle::trans::common::crate_ctxt;
+use middle::trans::common::CrateContext;
 use middle::ty;
 use session::Session;
 use session;
@@ -451,15 +451,16 @@ pub mod write {
  */
 
 pub fn build_link_meta(sess: Session, c: &ast::crate, output: &Path,
-                   symbol_hasher: &hash::State) -> link_meta {
+                   symbol_hasher: &hash::State) -> LinkMeta {
 
-    type provided_metas =
-        {name: Option<@str>,
-         vers: Option<@str>,
-         cmh_items: ~[@ast::meta_item]};
+    struct ProvidedMetas {
+        name: Option<@str>,
+        vers: Option<@str>,
+        cmh_items: ~[@ast::meta_item]
+    }
 
     fn provided_link_metas(sess: Session, c: &ast::crate) ->
-       provided_metas {
+       ProvidedMetas {
         let mut name = None;
         let mut vers = None;
         let mut cmh_items = ~[];
@@ -480,7 +481,12 @@ pub fn build_link_meta(sess: Session, c: &ast::crate, output: &Path,
                 }
             } else { cmh_items.push(*meta); }
         }
-        return {name: name, vers: vers, cmh_items: cmh_items};
+
+        ProvidedMetas {
+            name: name,
+            vers: vers,
+            cmh_items: cmh_items
+        }
     }
 
     // This calculates CMH as defined above
@@ -563,8 +569,11 @@ pub fn build_link_meta(sess: Session, c: &ast::crate, output: &Path,
             };
     }
 
-    let {name: opt_name, vers: opt_vers,
-         cmh_items: cmh_items} = provided_link_metas(sess, c);
+    let ProvidedMetas {
+        name: opt_name,
+        vers: opt_vers,
+        cmh_items: cmh_items
+    } = provided_link_metas(sess, c);
     let name = crate_meta_name(sess, output, opt_name);
     let vers = crate_meta_vers(sess, opt_vers);
     let dep_hashes = cstore::get_dep_hashes(sess.cstore);
@@ -572,7 +581,11 @@ pub fn build_link_meta(sess: Session, c: &ast::crate, output: &Path,
         crate_meta_extras_hash(symbol_hasher, cmh_items,
                                dep_hashes);
 
-    return {name: name, vers: vers, extras_hash: extras_hash};
+    LinkMeta {
+        name: name,
+        vers: vers,
+        extras_hash: extras_hash
+    }
 }
 
 pub fn truncated_hash_result(symbol_hasher: &hash::State) -> ~str {
@@ -584,7 +597,7 @@ pub fn truncated_hash_result(symbol_hasher: &hash::State) -> ~str {
 
 // This calculates STH for a symbol, as defined above
 pub fn symbol_hash(tcx: ty::ctxt, symbol_hasher: &hash::State, t: ty::t,
-               link_meta: link_meta) -> @str {
+               link_meta: LinkMeta) -> @str {
     // NB: do *not* use abbrevs here as we want the symbol names
     // to be independent of one another in the crate.
 
@@ -601,7 +614,7 @@ pub fn symbol_hash(tcx: ty::ctxt, symbol_hasher: &hash::State, t: ty::t,
     hash.to_managed()
 }
 
-pub fn get_symbol_hash(ccx: @crate_ctxt, t: ty::t) -> @str {
+pub fn get_symbol_hash(ccx: @CrateContext, t: ty::t) -> @str {
     match ccx.type_hashcodes.find(&t) {
       Some(h) => h,
       None => {
@@ -673,14 +686,14 @@ pub fn exported_name(sess: Session,
             path_name(sess.ident_of(vers.to_owned()))));
 }
 
-pub fn mangle_exported_name(ccx: @crate_ctxt, +path: path, t: ty::t) -> ~str {
+pub fn mangle_exported_name(ccx: @CrateContext, +path: path, t: ty::t) -> ~str {
     let hash = get_symbol_hash(ccx, t);
     return exported_name(ccx.sess, path,
                          hash,
                          ccx.link_meta.vers);
 }
 
-pub fn mangle_internal_name_by_type_only(ccx: @crate_ctxt,
+pub fn mangle_internal_name_by_type_only(ccx: @CrateContext,
                                          t: ty::t,
                                          name: &str) -> ~str {
     let s = ppaux::ty_to_short_str(ccx.tcx, t);
@@ -691,23 +704,23 @@ pub fn mangle_internal_name_by_type_only(ccx: @crate_ctxt,
           path_name(ccx.sess.ident_of(hash.to_owned()))]);
 }
 
-pub fn mangle_internal_name_by_path_and_seq(ccx: @crate_ctxt,
+pub fn mangle_internal_name_by_path_and_seq(ccx: @CrateContext,
                                             +path: path,
                                             +flav: ~str) -> ~str {
     return mangle(ccx.sess,
                   vec::append_one(path, path_name((ccx.names)(flav))));
 }
 
-pub fn mangle_internal_name_by_path(ccx: @crate_ctxt, +path: path) -> ~str {
+pub fn mangle_internal_name_by_path(ccx: @CrateContext, +path: path) -> ~str {
     return mangle(ccx.sess, path);
 }
 
-pub fn mangle_internal_name_by_seq(ccx: @crate_ctxt, +flav: ~str) -> ~str {
+pub fn mangle_internal_name_by_seq(ccx: @CrateContext, +flav: ~str) -> ~str {
     return fmt!("%s_%u", flav, (ccx.names)(flav).repr);
 }
 
 
-pub fn output_dll_filename(os: session::os, lm: link_meta) -> ~str {
+pub fn output_dll_filename(os: session::os, lm: LinkMeta) -> ~str {
     let libname = fmt!("%s-%s-%s", lm.name, lm.extras_hash, lm.vers);
     let (dll_prefix, dll_suffix) = match os {
         session::os_win32 => (win32::DLL_PREFIX, win32::DLL_SUFFIX),
@@ -725,7 +738,7 @@ pub fn output_dll_filename(os: session::os, lm: link_meta) -> ~str {
 pub fn link_binary(sess: Session,
                    obj_filename: &Path,
                    out_filename: &Path,
-                   lm: link_meta) {
+                   lm: LinkMeta) {
     // Converts a library file-stem into a cc -l argument
     fn unlib(config: @session::config, +stem: ~str) -> ~str {
         if stem.starts_with("lib") &&

--- a/src/librustc/back/target_strs.rs
+++ b/src/librustc/back/target_strs.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 
-pub type t = {
+pub struct t {
     module_asm: ~str,
     meta_sect_name: ~str,
     data_layout: ~str,
     target_triple: ~str,
     cc_args: ~[~str]
-};
+}

--- a/src/librustc/back/upcall.rs
+++ b/src/librustc/back/upcall.rs
@@ -15,17 +15,18 @@ use middle::trans::common::{T_fn, T_i1, T_i8, T_i32,
                                T_int, T_nil,
                                T_opaque_vec, T_ptr, T_unique_ptr,
                                T_size_t, T_void, T_vec2};
-use lib::llvm::{type_names, ModuleRef, ValueRef, TypeRef};
+use lib::llvm::{TypeNames, ModuleRef, ValueRef, TypeRef};
 
-pub type upcalls =
-    {trace: ValueRef,
-     call_shim_on_c_stack: ValueRef,
-     call_shim_on_rust_stack: ValueRef,
-     rust_personality: ValueRef,
-     reset_stack_limit: ValueRef};
+pub struct Upcalls {
+    trace: ValueRef,
+    call_shim_on_c_stack: ValueRef,
+    call_shim_on_rust_stack: ValueRef,
+    rust_personality: ValueRef,
+    reset_stack_limit: ValueRef
+}
 
 pub fn declare_upcalls(targ_cfg: @session::config,
-                       llmod: ModuleRef) -> @upcalls {
+                       llmod: ModuleRef) -> @Upcalls {
     fn decl(llmod: ModuleRef, prefix: ~str, name: ~str,
             tys: ~[TypeRef], rv: TypeRef) ->
        ValueRef {
@@ -43,22 +44,23 @@ pub fn declare_upcalls(targ_cfg: @session::config,
 
     let int_t = T_int(targ_cfg);
 
-    return @{trace: dv(~"trace", ~[T_ptr(T_i8()),
+    @Upcalls {
+        trace: dv(~"trace", ~[T_ptr(T_i8()),
                               T_ptr(T_i8()),
                               int_t]),
-          call_shim_on_c_stack:
-              d(~"call_shim_on_c_stack",
-                // arguments: void *args, void *fn_ptr
-                ~[T_ptr(T_i8()), T_ptr(T_i8())],
-                int_t),
-          call_shim_on_rust_stack:
-              d(~"call_shim_on_rust_stack",
-                ~[T_ptr(T_i8()), T_ptr(T_i8())], int_t),
-          rust_personality:
-              nothrow(d(~"rust_personality", ~[], T_i32())),
-          reset_stack_limit:
-              nothrow(dv(~"reset_stack_limit", ~[]))
-         };
+        call_shim_on_c_stack:
+            d(~"call_shim_on_c_stack",
+              // arguments: void *args, void *fn_ptr
+              ~[T_ptr(T_i8()), T_ptr(T_i8())],
+              int_t),
+        call_shim_on_rust_stack:
+            d(~"call_shim_on_rust_stack",
+              ~[T_ptr(T_i8()), T_ptr(T_i8())], int_t),
+        rust_personality:
+            nothrow(d(~"rust_personality", ~[], T_i32())),
+        reset_stack_limit:
+            nothrow(dv(~"reset_stack_limit", ~[]))
+    }
 }
 //
 // Local Variables:

--- a/src/librustc/back/x86.rs
+++ b/src/librustc/back/x86.rs
@@ -15,7 +15,7 @@ use metadata::loader::meta_section_name;
 use session::sess_os_to_meta_os;
 
 pub fn get_target_strs(target_os: session::os) -> target_strs::t {
-    return {
+    return target_strs::t {
         module_asm: ~"",
 
         meta_sect_name: meta_section_name(sess_os_to_meta_os(target_os)),

--- a/src/librustc/back/x86_64.rs
+++ b/src/librustc/back/x86_64.rs
@@ -15,7 +15,7 @@ use metadata::loader::meta_section_name;
 use session::sess_os_to_meta_os;
 
 pub fn get_target_strs(target_os: session::os) -> target_strs::t {
-    return {
+    return target_strs::t {
         module_asm: ~"",
 
         meta_sect_name: meta_section_name(sess_os_to_meta_os(target_os)),

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -37,13 +37,14 @@ pub enum arch { arch_x86, arch_x86_64, arch_arm, }
 
 pub enum crate_type { bin_crate, lib_crate, unknown_crate, }
 
-pub type config =
-    {os: os,
-     arch: arch,
-     target_strs: target_strs::t,
-     int_type: int_ty,
-     uint_type: uint_ty,
-     float_type: float_ty};
+pub struct config {
+    os: os,
+    arch: arch,
+    target_strs: target_strs::t,
+    int_type: int_ty,
+    uint_type: uint_ty,
+    float_type: float_ty
+}
 
 pub const verbose: uint = 1 << 0;
 pub const time_passes: uint = 1 << 1;
@@ -113,35 +114,38 @@ pub enum OptLevel {
     Aggressive // -O3
 }
 
-pub type options =
+pub struct options {
     // The crate config requested for the session, which may be combined
     // with additional crate configurations during the compile process
-    {crate_type: crate_type,
-     static: bool,
-     gc: bool,
-     optimize: OptLevel,
-     debuginfo: bool,
-     extra_debuginfo: bool,
-     lint_opts: ~[(lint::lint, lint::level)],
-     save_temps: bool,
-     jit: bool,
-     output_type: back::link::output_type,
-     addl_lib_search_paths: ~[Path],
-     maybe_sysroot: Option<Path>,
-     target_triple: ~str,
-     // User-specified cfg meta items. The compiler itself will add additional
-     // items to the crate config, and during parsing the entire crate config
-     // will be added to the crate AST node.  This should not be used for
-     // anything except building the full crate config prior to parsing.
-     cfg: ast::crate_cfg,
-     binary: ~str,
-     test: bool,
-     parse_only: bool,
-     no_trans: bool,
-     debugging_opts: uint,
-    };
+    crate_type: crate_type,
+    is_static: bool,
+    gc: bool,
+    optimize: OptLevel,
+    debuginfo: bool,
+    extra_debuginfo: bool,
+    lint_opts: ~[(lint::lint, lint::level)],
+    save_temps: bool,
+    jit: bool,
+    output_type: back::link::output_type,
+    addl_lib_search_paths: ~[Path],
+    maybe_sysroot: Option<Path>,
+    target_triple: ~str,
+    // User-specified cfg meta items. The compiler itself will add additional
+    // items to the crate config, and during parsing the entire crate config
+    // will be added to the crate AST node.  This should not be used for
+    // anything except building the full crate config prior to parsing.
+    cfg: ast::crate_cfg,
+    binary: ~str,
+    test: bool,
+    parse_only: bool,
+    no_trans: bool,
+    debugging_opts: uint,
+}
 
-pub type crate_metadata = {name: ~str, data: ~[u8]};
+pub struct crate_metadata {
+    name: ~str,
+    data: ~[u8]
+}
 
 pub struct Session_ {
     targ_cfg: @config,
@@ -155,7 +159,7 @@ pub struct Session_ {
     filesearch: filesearch::FileSearch,
     building_library: @mut bool,
     working_dir: Path,
-    lint_settings: lint::lint_settings
+    lint_settings: lint::LintSettings
 }
 
 pub type Session = @Session_;
@@ -266,9 +270,9 @@ pub impl Session {
 
 /// Some reasonable defaults
 pub fn basic_options() -> @options {
-    @{
+    @options {
         crate_type: session::lib_crate,
-        static: false,
+        is_static: false,
         gc: false,
         optimize: No,
         debuginfo: false,

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1289,32 +1289,36 @@ pub fn SetLinkage(Global: ValueRef, Link: Linkage) {
 
 /* Memory-managed object interface to type handles. */
 
-pub type type_names = @{type_names: HashMap<TypeRef, @str>,
-                    named_types: HashMap<@str, TypeRef>};
+pub struct TypeNames {
+    type_names: HashMap<TypeRef, @str>,
+    named_types: HashMap<@str, TypeRef>
+}
 
-pub fn associate_type(tn: type_names, s: @str, t: TypeRef) {
+pub fn associate_type(tn: @TypeNames, s: @str, t: TypeRef) {
     assert tn.type_names.insert(t, s);
     assert tn.named_types.insert(s, t);
 }
 
-pub fn type_has_name(tn: type_names, t: TypeRef) -> Option<@str> {
+pub fn type_has_name(tn: @TypeNames, t: TypeRef) -> Option<@str> {
     return tn.type_names.find(&t);
 }
 
-pub fn name_has_type(tn: type_names, s: @str) -> Option<TypeRef> {
+pub fn name_has_type(tn: @TypeNames, s: @str) -> Option<TypeRef> {
     return tn.named_types.find(&s);
 }
 
-pub fn mk_type_names() -> type_names {
-    @{type_names: HashMap(),
-      named_types: HashMap()}
+pub fn mk_type_names() -> @TypeNames {
+    @TypeNames {
+        type_names: HashMap(),
+        named_types: HashMap()
+    }
 }
 
-pub fn type_to_str(names: type_names, ty: TypeRef) -> @str {
+pub fn type_to_str(names: @TypeNames, ty: TypeRef) -> @str {
     return type_to_str_inner(names, [], ty);
 }
 
-pub fn type_to_str_inner(names: type_names, +outer0: &[TypeRef], ty: TypeRef)
+pub fn type_to_str_inner(names: @TypeNames, +outer0: &[TypeRef], ty: TypeRef)
                       -> @str {
     unsafe {
         match type_has_name(names, ty) {
@@ -1326,7 +1330,7 @@ pub fn type_to_str_inner(names: type_names, +outer0: &[TypeRef], ty: TypeRef)
 
         let kind = llvm::LLVMGetTypeKind(ty);
 
-        fn tys_str(names: type_names, outer: &[TypeRef],
+        fn tys_str(names: @TypeNames, outer: &[TypeRef],
                    tys: ~[TypeRef]) -> @str {
             let mut s = ~"";
             let mut first: bool = true;
@@ -1464,14 +1468,21 @@ pub fn target_data_res(TD: TargetDataRef) -> target_data_res {
     }
 }
 
-pub type target_data = {lltd: TargetDataRef, dtor: @target_data_res};
+pub struct TargetData {
+    lltd: TargetDataRef,
+    dtor: @target_data_res
+}
 
-pub fn mk_target_data(string_rep: ~str) -> target_data {
+pub fn mk_target_data(string_rep: ~str) -> TargetData {
     let lltd =
         str::as_c_str(string_rep, |buf| unsafe {
             llvm::LLVMCreateTargetData(buf)
         });
-    return {lltd: lltd, dtor: @target_data_res(lltd)};
+
+    TargetData {
+        lltd: lltd,
+        dtor: @target_data_res(lltd)
+    }
 }
 
 /* Memory-managed interface to pass managers. */
@@ -1491,12 +1502,19 @@ pub fn pass_manager_res(PM: PassManagerRef) -> pass_manager_res {
     }
 }
 
-pub type pass_manager = {llpm: PassManagerRef, dtor: @pass_manager_res};
+pub struct PassManager {
+    llpm: PassManagerRef,
+    dtor: @pass_manager_res
+}
 
-pub fn mk_pass_manager() -> pass_manager {
+pub fn mk_pass_manager() -> PassManager {
     unsafe {
         let llpm = llvm::LLVMCreatePassManager();
-        return {llpm: llpm, dtor: @pass_manager_res(llpm)};
+
+        PassManager {
+            llpm: llpm,
+            dtor: @pass_manager_res(llpm)
+        }
     }
 }
 
@@ -1517,13 +1535,20 @@ pub fn object_file_res(ObjFile: ObjectFileRef) -> object_file_res {
     }
 }
 
-pub type object_file = {llof: ObjectFileRef, dtor: @object_file_res};
+pub struct ObjectFile {
+    llof: ObjectFileRef,
+    dtor: @object_file_res
+}
 
-pub fn mk_object_file(llmb: MemoryBufferRef) -> Option<object_file> {
+pub fn mk_object_file(llmb: MemoryBufferRef) -> Option<ObjectFile> {
     unsafe {
         let llof = llvm::LLVMCreateObjectFile(llmb);
-        if llof as int == 0 { return option::None::<object_file>; }
-        return option::Some({llof: llof, dtor: @object_file_res(llof)});
+        if llof as int == 0 { return option::None::<ObjectFile>; }
+
+        option::Some(ObjectFile {
+            llof: llof,
+            dtor: @object_file_res(llof)
+        })
     }
 }
 
@@ -1544,12 +1569,18 @@ pub fn section_iter_res(SI: SectionIteratorRef) -> section_iter_res {
     }
 }
 
-pub type section_iter = {llsi: SectionIteratorRef, dtor: @section_iter_res};
+pub struct SectionIter {
+    llsi: SectionIteratorRef,
+    dtor: @section_iter_res
+}
 
-pub fn mk_section_iter(llof: ObjectFileRef) -> section_iter {
+pub fn mk_section_iter(llof: ObjectFileRef) -> SectionIter {
     unsafe {
         let llsi = llvm::LLVMGetSections(llof);
-        return {llsi: llsi, dtor: @section_iter_res(llsi)};
+        SectionIter {
+            llsi: llsi,
+            dtor: @section_iter_res(llsi)
+        }
     }
 }
 

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -156,5 +156,9 @@ pub const tag_lang_items_item_node_id: uint = 0x75;
 pub const tag_item_unnamed_field: uint = 0x76;
 pub const tag_items_data_item_struct_ctor: uint = 0x77;
 
-pub type link_meta = {name: @str, vers: @str, extras_hash: @str};
+pub struct LinkMeta {
+    name: @str,
+    vers: @str,
+    extras_hash: @str
+}
 

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -61,12 +61,12 @@ pub fn read_crates(diag: span_handler,
     warn_if_multiple_versions(e, diag, e.crate_cache);
 }
 
-type cache_entry = {
+struct cache_entry {
     cnum: int,
     span: span,
     hash: ~str,
     metas: @~[@ast::meta_item]
-};
+}
 
 fn dump_crates(+crate_cache: @mut ~[cache_entry]) {
     debug!("resolved crates:");
@@ -243,7 +243,7 @@ fn resolve_crate(e: @mut Env,
 
     match existing_match(e, metas, hash) {
       None => {
-        let load_ctxt: loader::ctxt = {
+        let load_ctxt = loader::Context {
             diag: e.diag,
             filesearch: e.filesearch,
             span: span,
@@ -251,13 +251,13 @@ fn resolve_crate(e: @mut Env,
             metas: metas,
             hash: hash,
             os: e.os,
-            static: e.statik,
+            is_static: e.statik,
             intr: e.intr
         };
-        let cinfo = loader::load_library_crate(load_ctxt);
+        let (lident, ldata) = loader::load_library_crate(load_ctxt);
 
-        let cfilename = Path(cinfo.ident);
-        let cdata = cinfo.data;
+        let cfilename = Path(lident);
+        let cdata = ldata;
 
         let attrs = decoder::get_crate_attributes(cdata);
         let linkage_metas = attr::find_linkage_metas(attrs);
@@ -265,8 +265,12 @@ fn resolve_crate(e: @mut Env,
 
         // Claim this crate number and cache it
         let cnum = e.next_crate_num;
-        e.crate_cache.push({cnum: cnum, span: span,
-                            hash: hash, metas: @linkage_metas});
+        e.crate_cache.push(cache_entry {
+            cnum: cnum,
+            span: span,
+            hash: hash,
+            metas: @linkage_metas
+        });
         e.next_crate_num += 1;
 
         // Now resolve the crates referenced by this crate
@@ -278,8 +282,12 @@ fn resolve_crate(e: @mut Env,
               option::Some(ref v) => (/*bad*/copy *v),
               option::None => /*bad*/copy *e.intr.get(ident)
             };
-        let cmeta = @{name: cname, data: cdata,
-                      cnum_map: cnum_map, cnum: cnum};
+        let cmeta = @cstore::crate_metadata {
+            name: cname,
+            data: cdata,
+            cnum_map: cnum_map,
+            cnum: cnum
+        };
 
         let cstore = e.cstore;
         cstore::set_crate_data(cstore, cnum, cmeta);

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -17,7 +17,7 @@ use metadata::common::*;
 use metadata::cstore;
 use metadata::decoder;
 use metadata;
-use middle::ty;
+use middle::{ty, resolve};
 
 use core::dvec::DVec;
 use core::vec;
@@ -110,7 +110,7 @@ pub fn get_enum_variants(tcx: ty::ctxt, def: ast::def_id)
 
 pub fn get_impls_for_mod(cstore: @mut cstore::CStore, def: ast::def_id,
                          name: Option<ast::ident>)
-                      -> @~[@decoder::_impl] {
+                      -> @~[@resolve::Impl] {
     let cdata = cstore::get_crate_data(cstore, def.crate);
     do decoder::get_impls_for_mod(cstore.intr, cdata, def.node, name) |cnum| {
         cstore::get_crate_data(cstore, cnum)
@@ -204,9 +204,11 @@ pub fn get_field_type(tcx: ty::ctxt, class_id: ast::def_id,
                  class_id, def) );
     debug!("got field data %?", the_field);
     let ty = decoder::item_type(def, the_field, tcx, cdata);
-    return {bounds: @~[],
-            region_param: None,
-            ty: ty};
+    ty::ty_param_bounds_and_ty {
+        bounds: @~[],
+        region_param: None,
+        ty: ty
+    }
 }
 
 // Given a def_id for an impl or class, return the traits it implements,

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -33,13 +33,15 @@ use syntax::parse::token::ident_interner;
 // own crate numbers.
 pub type cnum_map = oldmap::HashMap<ast::crate_num, ast::crate_num>;
 
-pub type crate_metadata = @{name: ~str,
-                            data: @~[u8],
-                            cnum_map: cnum_map,
-                            cnum: ast::crate_num};
+pub struct crate_metadata {
+    name: ~str,
+    data: @~[u8],
+    cnum_map: cnum_map,
+    cnum: ast::crate_num
+}
 
 pub struct CStore {
-    priv metas: oldmap::HashMap<ast::crate_num, crate_metadata>,
+    priv metas: oldmap::HashMap<ast::crate_num, @crate_metadata>,
     priv extern_mod_crate_map: extern_mod_crate_map,
     priv used_crate_files: ~[Path],
     priv used_libraries: ~[~str],
@@ -64,7 +66,7 @@ pub fn mk_cstore(intr: @ident_interner) -> CStore {
 }
 
 pub fn get_crate_data(cstore: @mut CStore, cnum: ast::crate_num)
-                   -> crate_metadata {
+                   -> @crate_metadata {
     return cstore.metas.get(&cnum);
 }
 
@@ -80,7 +82,7 @@ pub fn get_crate_vers(cstore: @mut CStore, cnum: ast::crate_num) -> ~str {
 
 pub fn set_crate_data(cstore: @mut CStore,
                       cnum: ast::crate_num,
-                      data: crate_metadata) {
+                      data: @crate_metadata) {
     let metas = cstore.metas;
     metas.insert(cnum, data);
 }
@@ -90,7 +92,7 @@ pub fn have_crate_data(cstore: @mut CStore, cnum: ast::crate_num) -> bool {
 }
 
 pub fn iter_crate_data(cstore: @mut CStore,
-                       i: fn(ast::crate_num, crate_metadata)) {
+                       i: fn(ast::crate_num, @crate_metadata)) {
     let metas = cstore.metas;
     for metas.each |&k, &v| {
         i(k, v);
@@ -144,7 +146,7 @@ pub fn find_extern_mod_stmt_cnum(cstore: @mut CStore,
 // returns hashes of crates directly used by this crate. Hashes are
 // sorted by crate name.
 pub fn get_dep_hashes(cstore: @mut CStore) -> ~[~str] {
-    type crate_hash = {name: ~str, hash: ~str};
+    struct crate_hash { name: ~str, hash: ~str }
     let mut result = ~[];
 
     let extern_mod_crate_map = cstore.extern_mod_crate_map;
@@ -152,7 +154,10 @@ pub fn get_dep_hashes(cstore: @mut CStore) -> ~[~str] {
         let cdata = cstore::get_crate_data(cstore, cnum);
         let hash = decoder::get_crate_hash(cdata.data);
         debug!("Add hash[%s]: %s", cdata.name, hash);
-        result.push({name: /*bad*/copy cdata.name, hash: hash});
+        result.push(crate_hash {
+            name: /*bad*/copy cdata.name,
+            hash: hash
+        });
     }
 
     pure fn lteq(a: &crate_hash, b: &crate_hash) -> bool {

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -13,7 +13,7 @@
 
 use core::prelude::*;
 
-use cmd = metadata::cstore::crate_metadata;
+use metadata::cstore::crate_metadata;
 use dvec::DVec;
 use hash::{Hash, HashUtil};
 use io::WriterUtil;
@@ -24,7 +24,7 @@ use metadata::cstore;
 use metadata::decoder;
 use metadata::tydecode::{parse_ty_data, parse_def_id, parse_bounds_data};
 use metadata::tydecode::{parse_ident};
-use middle::ty;
+use middle::{ty, resolve};
 use util::ppaux::ty_to_str;
 
 use core::cmp;
@@ -46,6 +46,8 @@ use syntax::parse::token::{ident_interner, special_idents};
 use syntax::print::pprust;
 use syntax::{ast, ast_util};
 use syntax::codemap;
+
+type cmd = @crate_metadata;
 
 // A function that takes a def_id relative to the crate being searched and
 // returns a def_id relative to the compilation environment, i.e. if we hit a
@@ -98,6 +100,7 @@ fn lookup_item(item_id: int, data: @~[u8]) -> ebml::Doc {
     }
 }
 
+#[deriving_eq]
 enum Family {
     Const,                 // c
     Fn,                    // f
@@ -119,13 +122,6 @@ enum Family {
     PublicField,           // g
     PrivateField,          // j
     InheritedField         // N
-}
-
-impl cmp::Eq for Family {
-    pure fn eq(&self, other: &Family) -> bool {
-        ((*self) as uint) == ((*other) as uint)
-    }
-    pure fn ne(&self, other: &Family) -> bool { !(*self).eq(other) }
 }
 
 fn item_family(item: ebml::Doc) -> Family {
@@ -360,9 +356,11 @@ pub fn get_type(cdata: cmd, id: ast::node_id, tcx: ty::ctxt)
         item_ty_param_bounds(item, tcx, cdata)
     } else { @~[] };
     let rp = item_ty_region_param(item);
-    return {bounds: tp_bounds,
-            region_param: rp,
-            ty: t};
+    ty::ty_param_bounds_and_ty {
+        bounds: tp_bounds,
+        region_param: rp,
+        ty: t
+    }
 }
 
 pub fn get_region_param(cdata: cmd, id: ast::node_id)
@@ -544,7 +542,7 @@ pub fn get_item_path(intr: @ident_interner, cdata: cmd, id: ast::node_id)
 }
 
 pub type decode_inlined_item = fn(
-    cdata: cstore::crate_metadata,
+    cdata: @cstore::crate_metadata,
     tcx: ty::ctxt,
     path: ast_map::path,
     par_doc: ebml::Doc) -> Option<ast::inlined_item>;
@@ -606,20 +604,6 @@ pub fn get_enum_variants(intr: @ident_interner, cdata: cmd, id: ast::node_id,
     return infos;
 }
 
-// NB: These types are duplicated in resolve.rs
-pub type method_info = {
-    did: ast::def_id,
-    n_tps: uint,
-    ident: ast::ident,
-    self_type: ast::self_ty_
-};
-
-pub type _impl = {
-    did: ast::def_id,
-    ident: ast::ident,
-    methods: ~[@method_info]
-};
-
 fn get_self_ty(item: ebml::Doc) -> ast::self_ty_ {
     fn get_mutability(ch: u8) -> ast::mutability {
         match ch as char {
@@ -650,16 +634,17 @@ fn get_self_ty(item: ebml::Doc) -> ast::self_ty_ {
 }
 
 fn item_impl_methods(intr: @ident_interner, cdata: cmd, item: ebml::Doc,
-                     base_tps: uint) -> ~[@method_info] {
+                     base_tps: uint) -> ~[@resolve::MethodInfo] {
     let mut rslt = ~[];
     for reader::tagged_docs(item, tag_item_impl_method) |doc| {
         let m_did = reader::with_doc_data(doc, |d| parse_def_id(d));
         let mth_item = lookup_item(m_did.node, cdata.data);
         let self_ty = get_self_ty(mth_item);
-        rslt.push(@{did: translate_def_id(cdata, m_did),
-                   n_tps: item_ty_param_count(mth_item) - base_tps,
-                   ident: item_name(intr, mth_item),
-                   self_type: self_ty});
+        rslt.push(@resolve::MethodInfo {
+                    did: translate_def_id(cdata, m_did),
+                    n_tps: item_ty_param_count(mth_item) - base_tps,
+                    ident: item_name(intr, mth_item),
+                    self_type: self_ty});
     }
     rslt
 }
@@ -669,7 +654,7 @@ pub fn get_impls_for_mod(intr: @ident_interner,
                          m_id: ast::node_id,
                          name: Option<ast::ident>,
                          get_cdata: &fn(ast::crate_num) -> cmd)
-                      -> @~[@_impl] {
+                      -> @~[@resolve::Impl] {
     let data = cdata.data;
     let mod_item = lookup_item(m_id, data);
     let mut result = ~[];
@@ -686,7 +671,7 @@ pub fn get_impls_for_mod(intr: @ident_interner,
         let nm = item_name(intr, item);
         if match name { Some(n) => { n == nm } None => { true } } {
            let base_tps = item_ty_param_count(item);
-           result.push(@{
+           result.push(@resolve::Impl {
                 did: local_did, ident: nm,
                 methods: item_impl_methods(intr, impl_cdata, item, base_tps)
             });
@@ -714,8 +699,14 @@ pub fn get_trait_methods(intr: @ident_interner, cdata: cmd, id: ast::node_id,
             }
         };
         let self_ty = get_self_ty(mth);
-        result.push({ident: name, tps: bounds, fty: fty, self_ty: self_ty,
-                     vis: ast::public, def_id: def_id});
+        result.push(ty::method {
+            ident: name,
+            tps: bounds,
+            fty: fty,
+            self_ty: self_ty,
+            vis: ast::public,
+            def_id: def_id
+        });
     }
     debug!("get_trait_methods: }");
     @result
@@ -746,8 +737,14 @@ pub fn get_provided_trait_methods(intr: @ident_interner, cdata: cmd,
         };
 
         let self_ty = get_self_ty(mth);
-        let ty_method = {ident: name, tps: bounds, fty: fty, self_ty: self_ty,
-                         vis: ast::public, def_id: did};
+        let ty_method = ty::method {
+            ident: name,
+            tps: bounds,
+            fty: fty,
+            self_ty: self_ty,
+            vis: ast::public,
+            def_id: did
+        };
         let provided_trait_method_info = ProvidedTraitMethodInfo {
             ty: ty_method,
             def_id: did
@@ -915,12 +912,13 @@ fn family_names_type(fam: Family) -> bool {
     match fam { Type | Mod | Trait => true, _ => false }
 }
 
-fn read_path(d: ebml::Doc) -> {path: ~str, pos: uint} {
+fn read_path(d: ebml::Doc) -> (~str, uint) {
     let desc = reader::doc_data(d);
     let pos = io::u64_from_be_bytes(desc, 0u, 4u) as uint;
     let pathbytes = vec::slice::<u8>(desc, 4u, vec::len::<u8>(desc));
     let path = str::from_bytes(pathbytes);
-    return {path: path, pos: pos};
+
+    (path, pos)
 }
 
 fn describe_def(items: ebml::Doc, id: ast::def_id) -> ~str {
@@ -1030,8 +1028,12 @@ pub fn get_crate_attributes(data: @~[u8]) -> ~[ast::attribute] {
     return get_attributes(reader::Doc(data));
 }
 
-pub type crate_dep = {cnum: ast::crate_num, name: ast::ident,
-                      vers: ~str, hash: ~str};
+pub struct crate_dep {
+    cnum: ast::crate_num,
+    name: ast::ident,
+    vers: ~str,
+    hash: ~str
+}
 
 pub fn get_crate_deps(intr: @ident_interner, data: @~[u8]) -> ~[crate_dep] {
     let mut deps: ~[crate_dep] = ~[];
@@ -1042,10 +1044,12 @@ pub fn get_crate_deps(intr: @ident_interner, data: @~[u8]) -> ~[crate_dep] {
         str::from_bytes(reader::doc_data(reader::get_doc(doc, tag_)))
     }
     for reader::tagged_docs(depsdoc, tag_crate_dep) |depdoc| {
-        deps.push({cnum: crate_num,
-                  name: intr.intern(@docstr(depdoc, tag_crate_dep_name)),
-                  vers: docstr(depdoc, tag_crate_dep_vers),
-                  hash: docstr(depdoc, tag_crate_dep_hash)});
+        deps.push(crate_dep {
+            cnum: crate_num,
+            name: intr.intern(@docstr(depdoc, tag_crate_dep_name)),
+            vers: docstr(depdoc, tag_crate_dep_vers),
+            hash: docstr(depdoc, tag_crate_dep_hash)
+        });
         crate_num += 1;
     };
     return deps;

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1071,7 +1071,8 @@ fn encode_attributes(ebml_w: writer::Encoder, attrs: &[attribute]) {
 // metadata that Rust cares about for linking crates. This attribute requires
 // 'name' and 'vers' items, so if the user didn't provide them we will throw
 // them in anyway with default values.
-fn synthesize_crate_attrs(ecx: @EncodeContext, crate: &crate) -> ~[attribute] {
+fn synthesize_crate_attrs(ecx: @EncodeContext,
+                          crate: &crate) -> ~[attribute] {
 
     fn synthesize_link_attr(ecx: @EncodeContext, +items: ~[@meta_item]) ->
        attribute {

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -55,22 +55,22 @@ use writer = std::ebml::writer;
 // used by astencode:
 type abbrev_map = oldmap::HashMap<ty::t, tyencode::ty_abbrev>;
 
-pub type encode_inlined_item = fn@(ecx: @encode_ctxt,
+pub type encode_inlined_item = fn@(ecx: @EncodeContext,
                                    ebml_w: writer::Encoder,
                                    path: &[ast_map::path_elt],
                                    ii: ast::inlined_item);
 
-pub type encode_parms = {
+pub struct EncodeParams {
     diag: span_handler,
     tcx: ty::ctxt,
     reachable: HashMap<ast::node_id, ()>,
     reexports2: middle::resolve::ExportMap2,
     item_symbols: HashMap<ast::node_id, ~str>,
     discrim_symbols: HashMap<ast::node_id, ~str>,
-    link_meta: link_meta,
+    link_meta: LinkMeta,
     cstore: @mut cstore::CStore,
     encode_inlined_item: encode_inlined_item
-};
+}
 
 struct Stats {
     inline_bytes: uint,
@@ -85,7 +85,7 @@ struct Stats {
     n_inlines: uint
 }
 
-pub enum encode_ctxt = {
+pub struct EncodeContext {
     diag: span_handler,
     tcx: ty::ctxt,
     stats: @mut Stats,
@@ -93,21 +93,21 @@ pub enum encode_ctxt = {
     reexports2: middle::resolve::ExportMap2,
     item_symbols: HashMap<ast::node_id, ~str>,
     discrim_symbols: HashMap<ast::node_id, ~str>,
-    link_meta: link_meta,
+    link_meta: LinkMeta,
     cstore: @mut cstore::CStore,
     encode_inlined_item: encode_inlined_item,
     type_abbrevs: abbrev_map
-};
+}
 
-pub fn reachable(ecx: @encode_ctxt, id: node_id) -> bool {
+pub fn reachable(ecx: @EncodeContext, id: node_id) -> bool {
     ecx.reachable.contains_key(&id)
 }
 
-fn encode_name(ecx: @encode_ctxt, ebml_w: writer::Encoder, name: ident) {
+fn encode_name(ecx: @EncodeContext, ebml_w: writer::Encoder, name: ident) {
     ebml_w.wr_tagged_str(tag_paths_data_name, ecx.tcx.sess.str_of(name));
 }
 
-fn encode_impl_type_basename(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_impl_type_basename(ecx: @EncodeContext, ebml_w: writer::Encoder,
                              name: ident) {
     ebml_w.wr_tagged_str(tag_item_impl_type_basename,
                          ecx.tcx.sess.str_of(name));
@@ -117,7 +117,7 @@ pub fn encode_def_id(ebml_w: writer::Encoder, id: def_id) {
     ebml_w.wr_tagged_str(tag_def_id, def_to_str(id));
 }
 
-fn encode_region_param(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_region_param(ecx: @EncodeContext, ebml_w: writer::Encoder,
                        it: @ast::item) {
     let opt_rp = ecx.tcx.region_paramd_items.find(&it.id);
     for opt_rp.each |rp| {
@@ -137,20 +137,25 @@ fn encode_mutability(ebml_w: writer::Encoder, mt: struct_mutability) {
     }
 }
 
-type entry<T> = {val: T, pos: uint};
+struct entry<T> {
+    val: T,
+    pos: uint
+}
 
-fn add_to_index(ecx: @encode_ctxt, ebml_w: writer::Encoder, path: &[ident],
+fn add_to_index(ecx: @EncodeContext, ebml_w: writer::Encoder, path: &[ident],
                 index: &mut ~[entry<~str>], name: ident) {
     let mut full_path = ~[];
     full_path.push_all(path);
     full_path.push(name);
     index.push(
-        {val: ast_util::path_name_i(full_path,
-                                    ecx.tcx.sess.parse_sess.interner),
-         pos: ebml_w.writer.tell()});
+        entry {
+            val: ast_util::path_name_i(full_path,
+                                       ecx.tcx.sess.parse_sess.interner),
+            pos: ebml_w.writer.tell()
+        });
 }
 
-fn encode_trait_ref(ebml_w: writer::Encoder, ecx: @encode_ctxt,
+fn encode_trait_ref(ebml_w: writer::Encoder, ecx: @EncodeContext,
                     t: @trait_ref) {
     ebml_w.start_tag(tag_impl_trait);
     encode_type(ecx, ebml_w, node_id_to_type(ecx.tcx, t.ref_id));
@@ -167,7 +172,7 @@ fn encode_family(ebml_w: writer::Encoder, c: char) {
 
 pub fn def_to_str(did: def_id) -> ~str { fmt!("%d:%d", did.crate, did.node) }
 
-fn encode_ty_type_param_bounds(ebml_w: writer::Encoder, ecx: @encode_ctxt,
+fn encode_ty_type_param_bounds(ebml_w: writer::Encoder, ecx: @EncodeContext,
                                params: @~[ty::param_bounds]) {
     let ty_str_ctxt = @tyencode::ctxt {
         diag: ecx.diag,
@@ -182,7 +187,7 @@ fn encode_ty_type_param_bounds(ebml_w: writer::Encoder, ecx: @encode_ctxt,
     }
 }
 
-fn encode_type_param_bounds(ebml_w: writer::Encoder, ecx: @encode_ctxt,
+fn encode_type_param_bounds(ebml_w: writer::Encoder, ecx: @EncodeContext,
                             params: &[ty_param]) {
     let ty_param_bounds =
         @params.map(|param| ecx.tcx.ty_param_bounds.get(&param.id));
@@ -196,7 +201,7 @@ fn encode_variant_id(ebml_w: writer::Encoder, vid: def_id) {
     ebml_w.end_tag();
 }
 
-pub fn write_type(ecx: @encode_ctxt, ebml_w: writer::Encoder, typ: ty::t) {
+pub fn write_type(ecx: @EncodeContext, ebml_w: writer::Encoder, typ: ty::t) {
     let ty_str_ctxt = @tyencode::ctxt {
         diag: ecx.diag,
         ds: def_to_str,
@@ -206,7 +211,7 @@ pub fn write_type(ecx: @encode_ctxt, ebml_w: writer::Encoder, typ: ty::t) {
     tyencode::enc_ty(ebml_w.writer, ty_str_ctxt, typ);
 }
 
-pub fn write_vstore(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+pub fn write_vstore(ecx: @EncodeContext, ebml_w: writer::Encoder,
                     vstore: ty::vstore) {
     let ty_str_ctxt = @tyencode::ctxt {
         diag: ecx.diag,
@@ -217,13 +222,13 @@ pub fn write_vstore(ecx: @encode_ctxt, ebml_w: writer::Encoder,
     tyencode::enc_vstore(ebml_w.writer, ty_str_ctxt, vstore);
 }
 
-fn encode_type(ecx: @encode_ctxt, ebml_w: writer::Encoder, typ: ty::t) {
+fn encode_type(ecx: @EncodeContext, ebml_w: writer::Encoder, typ: ty::t) {
     ebml_w.start_tag(tag_items_data_item_type);
     write_type(ecx, ebml_w, typ);
     ebml_w.end_tag();
 }
 
-fn encode_symbol(ecx: @encode_ctxt, ebml_w: writer::Encoder, id: node_id) {
+fn encode_symbol(ecx: @EncodeContext, ebml_w: writer::Encoder, id: node_id) {
     ebml_w.start_tag(tag_items_data_item_symbol);
     let sym = match ecx.item_symbols.find(&id) {
       Some(ref x) => (/*bad*/copy *x),
@@ -236,14 +241,14 @@ fn encode_symbol(ecx: @encode_ctxt, ebml_w: writer::Encoder, id: node_id) {
     ebml_w.end_tag();
 }
 
-fn encode_discriminant(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_discriminant(ecx: @EncodeContext, ebml_w: writer::Encoder,
                        id: node_id) {
     ebml_w.start_tag(tag_items_data_item_symbol);
     ebml_w.writer.write(str::to_bytes(ecx.discrim_symbols.get(&id)));
     ebml_w.end_tag();
 }
 
-fn encode_disr_val(_ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_disr_val(_ecx: @EncodeContext, ebml_w: writer::Encoder,
                    disr_val: int) {
     ebml_w.start_tag(tag_disr_val);
     ebml_w.writer.write(str::to_bytes(int::to_str(disr_val)));
@@ -256,7 +261,7 @@ fn encode_parent_item(ebml_w: writer::Encoder, id: def_id) {
     ebml_w.end_tag();
 }
 
-fn encode_enum_variant_info(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_enum_variant_info(ecx: @EncodeContext, ebml_w: writer::Encoder,
                             id: node_id, variants: &[variant],
                             path: &[ast_map::path_elt],
                             index: @mut ~[entry<int>],
@@ -266,7 +271,7 @@ fn encode_enum_variant_info(ecx: @encode_ctxt, ebml_w: writer::Encoder,
     let vi = ty::enum_variants(ecx.tcx,
                                ast::def_id { crate: local_crate, node: id });
     for variants.each |variant| {
-        index.push({val: variant.node.id, pos: ebml_w.writer.tell()});
+        index.push(entry {val: variant.node.id, pos: ebml_w.writer.tell()});
         ebml_w.start_tag(tag_items_data_item);
         encode_def_id(ebml_w, local_def(variant.node.id));
         encode_family(ebml_w, 'v');
@@ -296,9 +301,9 @@ fn encode_enum_variant_info(ecx: @encode_ctxt, ebml_w: writer::Encoder,
     }
 }
 
-fn encode_path(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_path(ecx: @EncodeContext, ebml_w: writer::Encoder,
                path: &[ast_map::path_elt], name: ast_map::path_elt) {
-    fn encode_path_elt(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+    fn encode_path_elt(ecx: @EncodeContext, ebml_w: writer::Encoder,
                        elt: ast_map::path_elt) {
         let (tag, name) = match elt {
           ast_map::path_mod(name) => (tag_path_elt_mod, name),
@@ -317,7 +322,7 @@ fn encode_path(ecx: @encode_ctxt, ebml_w: writer::Encoder,
     }
 }
 
-fn encode_info_for_mod(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_info_for_mod(ecx: @EncodeContext, ebml_w: writer::Encoder,
                        md: _mod, id: node_id, path: &[ast_map::path_elt],
                        name: ident) {
     ebml_w.start_tag(tag_items_data_item);
@@ -422,7 +427,7 @@ fn encode_method_sort(ebml_w: writer::Encoder, sort: char) {
 }
 
 /* Returns an index of items in this class */
-fn encode_info_for_struct(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_info_for_struct(ecx: @EncodeContext, ebml_w: writer::Encoder,
                          path: &[ast_map::path_elt],
                          fields: &[@struct_field],
                          global_index: @mut~[entry<int>]) -> ~[entry<int>] {
@@ -443,8 +448,8 @@ fn encode_info_for_struct(ecx: @encode_ctxt, ebml_w: writer::Encoder,
         };
 
         let id = field.node.id;
-        index.push({val: id, pos: ebml_w.writer.tell()});
-        global_index.push({val: id, pos: ebml_w.writer.tell()});
+        index.push(entry {val: id, pos: ebml_w.writer.tell()});
+        global_index.push(entry {val: id, pos: ebml_w.writer.tell()});
         ebml_w.start_tag(tag_items_data_item);
         debug!("encode_info_for_struct: doing %s %d",
                tcx.sess.str_of(nm), id);
@@ -460,7 +465,7 @@ fn encode_info_for_struct(ecx: @encode_ctxt, ebml_w: writer::Encoder,
 }
 
 // This is for encoding info for ctors and dtors
-fn encode_info_for_ctor(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_info_for_ctor(ecx: @EncodeContext, ebml_w: writer::Encoder,
                         id: node_id, ident: ident, path: &[ast_map::path_elt],
                         item: Option<inlined_item>, tps: &[ty_param]) {
         ebml_w.start_tag(tag_items_data_item);
@@ -485,13 +490,13 @@ fn encode_info_for_ctor(ecx: @encode_ctxt, ebml_w: writer::Encoder,
         ebml_w.end_tag();
 }
 
-fn encode_info_for_struct_ctor(ecx: @encode_ctxt,
+fn encode_info_for_struct_ctor(ecx: @EncodeContext,
                                ebml_w: writer::Encoder,
                                path: &[ast_map::path_elt],
                                name: ast::ident,
                                ctor_id: node_id,
                                index: @mut ~[entry<int>]) {
-    index.push({ val: ctor_id, pos: ebml_w.writer.tell() });
+    index.push(entry { val: ctor_id, pos: ebml_w.writer.tell() });
 
     ebml_w.start_tag(tag_items_data_item);
     encode_def_id(ebml_w, local_def(ctor_id));
@@ -507,7 +512,7 @@ fn encode_info_for_struct_ctor(ecx: @encode_ctxt,
     ebml_w.end_tag();
 }
 
-fn encode_info_for_method(ecx: @encode_ctxt,
+fn encode_info_for_method(ecx: @EncodeContext,
                           ebml_w: writer::Encoder,
                           impl_path: &[ast_map::path_elt],
                           should_inline: bool,
@@ -566,7 +571,7 @@ fn should_inline(attrs: &[attribute]) -> bool {
 }
 
 
-fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_info_for_item(ecx: @EncodeContext, ebml_w: writer::Encoder,
                         item: @item, index: @mut ~[entry<int>],
                         path: &[ast_map::path_elt]) {
 
@@ -581,7 +586,7 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: writer::Encoder,
 
     fn add_to_index_(item: @item, ebml_w: writer::Encoder,
                      index: @mut ~[entry<int>]) {
-        index.push({val: item.id, pos: ebml_w.writer.tell()});
+        index.push(entry { val: item.id, pos: ebml_w.writer.tell() });
     }
     let add_to_index: &fn() = || add_to_index_(item, ebml_w, index);
 
@@ -673,7 +678,7 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: writer::Encoder,
                                          struct_def.fields, index);
         /* Encode the dtor */
         do struct_def.dtor.iter |dtor| {
-            index.push({val: dtor.node.id, pos: ebml_w.writer.tell()});
+            index.push(entry {val: dtor.node.id, pos: ebml_w.writer.tell()});
           encode_info_for_ctor(ecx,
                                ebml_w,
                                dtor.node.id,
@@ -788,7 +793,7 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: writer::Encoder,
         impl_path += ~[ast_map::path_name(item.ident)];
 
         for methods.each |m| {
-            index.push({val: m.id, pos: ebml_w.writer.tell()});
+            index.push(entry {val: m.id, pos: ebml_w.writer.tell()});
             encode_info_for_method(ecx, ebml_w, impl_path,
                                    should_inline(m.attrs),
                                    item.id, *m,
@@ -855,7 +860,7 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: writer::Encoder,
             let ty_m = ast_util::trait_method_to_ty_method(*m);
             if ty_m.self_ty.node != ast::sty_static { loop; }
 
-            index.push({val: ty_m.id, pos: ebml_w.writer.tell()});
+            index.push(entry { val: ty_m.id, pos: ebml_w.writer.tell() });
 
             ebml_w.start_tag(tag_items_data_item);
             encode_def_id(ebml_w, local_def(ty_m.id));
@@ -874,7 +879,7 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: writer::Encoder,
 
         // Finally, output all the provided methods as items.
         for provided_methods.each |m| {
-            index.push({val: m.id, pos: ebml_w.writer.tell()});
+            index.push(entry { val: m.id, pos: ebml_w.writer.tell() });
             encode_info_for_method(ecx, ebml_w, /*bad*/copy path,
                                    true, item.id, *m, /*bad*/copy m.tps);
         }
@@ -883,14 +888,14 @@ fn encode_info_for_item(ecx: @encode_ctxt, ebml_w: writer::Encoder,
     }
 }
 
-fn encode_info_for_foreign_item(ecx: @encode_ctxt,
+fn encode_info_for_foreign_item(ecx: @EncodeContext,
                                 ebml_w: writer::Encoder,
                                 nitem: @foreign_item,
                                 index: @mut ~[entry<int>],
                                 +path: ast_map::path,
                                 abi: foreign_abi) {
     if !reachable(ecx, nitem.id) { return; }
-    index.push({val: nitem.id, pos: ebml_w.writer.tell()});
+    index.push(entry { val: nitem.id, pos: ebml_w.writer.tell() });
 
     ebml_w.start_tag(tag_items_data_item);
     match /*bad*/copy nitem.node {
@@ -917,11 +922,11 @@ fn encode_info_for_foreign_item(ecx: @encode_ctxt,
     ebml_w.end_tag();
 }
 
-fn encode_info_for_items(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_info_for_items(ecx: @EncodeContext, ebml_w: writer::Encoder,
                          crate: &crate) -> ~[entry<int>] {
     let index = @mut ~[];
     ebml_w.start_tag(tag_items_data);
-    index.push({val: crate_node_id, pos: ebml_w.writer.tell()});
+    index.push(entry { val: crate_node_id, pos: ebml_w.writer.tell() });
     encode_info_for_mod(ecx, ebml_w, crate.node.module,
                         crate_node_id, ~[],
                         syntax::parse::token::special_idents::invalid);
@@ -1066,9 +1071,9 @@ fn encode_attributes(ebml_w: writer::Encoder, attrs: &[attribute]) {
 // metadata that Rust cares about for linking crates. This attribute requires
 // 'name' and 'vers' items, so if the user didn't provide them we will throw
 // them in anyway with default values.
-fn synthesize_crate_attrs(ecx: @encode_ctxt, crate: &crate) -> ~[attribute] {
+fn synthesize_crate_attrs(ecx: @EncodeContext, crate: &crate) -> ~[attribute] {
 
-    fn synthesize_link_attr(ecx: @encode_ctxt, +items: ~[@meta_item]) ->
+    fn synthesize_link_attr(ecx: @EncodeContext, +items: ~[@meta_item]) ->
        attribute {
 
         assert !ecx.link_meta.name.is_empty();
@@ -1115,21 +1120,22 @@ fn synthesize_crate_attrs(ecx: @encode_ctxt, crate: &crate) -> ~[attribute] {
     return attrs;
 }
 
-fn encode_crate_deps(ecx: @encode_ctxt,
+fn encode_crate_deps(ecx: @EncodeContext,
                      ebml_w: writer::Encoder,
                      cstore: @mut cstore::CStore) {
-    fn get_ordered_deps(ecx: @encode_ctxt, cstore: @mut cstore::CStore)
+    fn get_ordered_deps(ecx: @EncodeContext, cstore: @mut cstore::CStore)
                      -> ~[decoder::crate_dep] {
-        type hashkv = @{key: crate_num, val: cstore::crate_metadata};
         type numdep = decoder::crate_dep;
 
         // Pull the cnums and name,vers,hash out of cstore
         let mut deps: ~[numdep] = ~[];
         do cstore::iter_crate_data(cstore) |key, val| {
-            let dep = {cnum: key,
-                       name: ecx.tcx.sess.ident_of(/*bad*/copy val.name),
-                       vers: decoder::get_crate_vers(val.data),
-                       hash: decoder::get_crate_hash(val.data)};
+            let dep = decoder::crate_dep {
+                cnum: key,
+                name: ecx.tcx.sess.ident_of(/*bad*/copy val.name),
+                vers: decoder::get_crate_vers(val.data),
+                hash: decoder::get_crate_hash(val.data)
+            };
             deps.push(dep);
         };
 
@@ -1161,7 +1167,7 @@ fn encode_crate_deps(ecx: @encode_ctxt,
     ebml_w.end_tag();
 }
 
-fn encode_lang_items(ecx: @encode_ctxt, ebml_w: writer::Encoder) {
+fn encode_lang_items(ecx: @EncodeContext, ebml_w: writer::Encoder) {
     ebml_w.start_tag(tag_lang_items);
 
     for ecx.tcx.lang_items.each_item |def_id, i| {
@@ -1185,7 +1191,7 @@ fn encode_lang_items(ecx: @encode_ctxt, ebml_w: writer::Encoder) {
     ebml_w.end_tag();   // tag_lang_items
 }
 
-fn encode_crate_dep(ecx: @encode_ctxt, ebml_w: writer::Encoder,
+fn encode_crate_dep(ecx: @EncodeContext, ebml_w: writer::Encoder,
                     dep: decoder::crate_dep) {
     ebml_w.start_tag(tag_crate_dep);
     ebml_w.start_tag(tag_crate_dep_name);
@@ -1213,7 +1219,7 @@ pub const metadata_encoding_version : &[u8] = &[0x72, //'r' as u8,
                                                 0x74, //'t' as u8,
                                                 0, 0, 0, 1 ];
 
-pub fn encode_metadata(parms: encode_parms, crate: &crate) -> ~[u8] {
+pub fn encode_metadata(parms: EncodeParams, crate: &crate) -> ~[u8] {
     let wr = @io::BytesWriter();
     let mut stats = Stats {
         inline_bytes: 0,
@@ -1226,7 +1232,7 @@ pub fn encode_metadata(parms: encode_parms, crate: &crate) -> ~[u8] {
         total_bytes: 0,
         n_inlines: 0
     };
-    let ecx: @encode_ctxt = @encode_ctxt({
+    let ecx = @EncodeContext {
         diag: parms.diag,
         tcx: parms.tcx,
         stats: @mut stats,
@@ -1238,7 +1244,7 @@ pub fn encode_metadata(parms: encode_parms, crate: &crate) -> ~[u8] {
         cstore: parms.cstore,
         encode_inlined_item: parms.encode_inlined_item,
         type_abbrevs: ty::new_ty_hash()
-     });
+     };
 
     let ebml_w = writer::Encoder(wr as io::Writer);
 

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -38,10 +38,12 @@ pub trait FileSearch {
 pub fn mk_filesearch(maybe_sysroot: Option<Path>,
                      target_triple: &str,
                      +addl_lib_search_paths: ~[Path]) -> FileSearch {
-    type filesearch_impl = {sysroot: Path,
-                            addl_lib_search_paths: ~[Path],
-                            target_triple: ~str};
-    impl FileSearch for filesearch_impl {
+    struct FileSearchImpl {
+        sysroot: Path,
+        addl_lib_search_paths: ~[Path],
+        target_triple: ~str
+    }
+    impl FileSearch for FileSearchImpl {
         fn sysroot() -> Path { /*bad*/copy self.sysroot }
         fn lib_search_paths() -> ~[Path] {
             let mut paths = /*bad*/copy self.addl_lib_search_paths;
@@ -69,9 +71,11 @@ pub fn mk_filesearch(maybe_sysroot: Option<Path>,
 
     let sysroot = get_sysroot(maybe_sysroot);
     debug!("using sysroot = %s", sysroot.to_str());
-    {sysroot: sysroot,
-     addl_lib_search_paths: addl_lib_search_paths,
-     target_triple: str::from_slice(target_triple)} as FileSearch
+    FileSearchImpl {
+        sysroot: sysroot,
+        addl_lib_search_paths: addl_lib_search_paths,
+        target_triple: str::from_slice(target_triple)
+    } as FileSearch
 }
 
 pub fn search<T: Copy>(filesearch: FileSearch, pick: pick<T>) -> Option<T> {

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -43,7 +43,7 @@ pub enum os {
     os_freebsd
 }
 
-pub type ctxt = {
+pub struct Context {
     diag: span_handler,
     filesearch: FileSearch,
     span: span,
@@ -51,11 +51,11 @@ pub type ctxt = {
     metas: ~[@ast::meta_item],
     hash: ~str,
     os: os,
-    static: bool,
+    is_static: bool,
     intr: @ident_interner
-};
+}
 
-pub fn load_library_crate(cx: ctxt) -> {ident: ~str, data: @~[u8]} {
+pub fn load_library_crate(cx: Context) -> (~str, @~[u8]) {
     match find_library_crate(cx) {
       Some(ref t) => return (/*bad*/copy *t),
       None => {
@@ -66,13 +66,13 @@ pub fn load_library_crate(cx: ctxt) -> {ident: ~str, data: @~[u8]} {
     }
 }
 
-fn find_library_crate(cx: ctxt) -> Option<{ident: ~str, data: @~[u8]}> {
+fn find_library_crate(cx: Context) -> Option<(~str, @~[u8])> {
     attr::require_unique_names(cx.diag, cx.metas);
     find_library_crate_aux(cx, libname(cx), cx.filesearch)
 }
 
-fn libname(cx: ctxt) -> {prefix: ~str, suffix: ~str} {
-    if cx.static { return {prefix: ~"lib", suffix: ~".rlib"}; }
+fn libname(cx: Context) -> (~str, ~str) {
+    if cx.is_static { return (~"lib", ~".rlib"); }
     let (dll_prefix, dll_suffix) = match cx.os {
         os_win32 => (win32::DLL_PREFIX, win32::DLL_SUFFIX),
         os_macos => (macos::DLL_PREFIX, macos::DLL_SUFFIX),
@@ -80,19 +80,16 @@ fn libname(cx: ctxt) -> {prefix: ~str, suffix: ~str} {
         os_android => (android::DLL_PREFIX, android::DLL_SUFFIX),
         os_freebsd => (freebsd::DLL_PREFIX, freebsd::DLL_SUFFIX),
     };
-    return {
-        prefix: str::from_slice(dll_prefix),
-        suffix: str::from_slice(dll_suffix)
-    }
+
+    (str::from_slice(dll_prefix), str::from_slice(dll_suffix))
 }
 
-fn find_library_crate_aux(cx: ctxt,
-                          nn: {prefix: ~str, suffix: ~str},
+fn find_library_crate_aux(cx: Context,
+                          (prefix, suffix): (~str, ~str),
                           filesearch: filesearch::FileSearch) ->
-   Option<{ident: ~str, data: @~[u8]}> {
+   Option<(~str, @~[u8])> {
     let crate_name = crate_name_from_metas(/*bad*/copy cx.metas);
-    let prefix: ~str = nn.prefix + crate_name + ~"-";
-    let suffix: ~str = /*bad*/copy nn.suffix;
+    let prefix: ~str = prefix + crate_name + ~"-";
 
     let mut matches = ~[];
     filesearch::search(filesearch, |path| {
@@ -112,7 +109,7 @@ fn find_library_crate_aux(cx: ctxt,
                     option::None::<()>
                 } else {
                     debug!("found %s with matching metadata", path.to_str());
-                    matches.push({ident: path.to_str(), data: cvec});
+                    matches.push((path.to_str(), cvec));
                     option::None::<()>
                 }
               }
@@ -132,9 +129,9 @@ fn find_library_crate_aux(cx: ctxt,
         cx.diag.span_err(
             cx.span, fmt!("multiple matching crates for `%s`", crate_name));
         cx.diag.handler().note(~"candidates:");
-        for matches.each |match_| {
-            cx.diag.handler().note(fmt!("path: %s", match_.ident));
-            let attrs = decoder::get_crate_attributes(match_.data);
+        for matches.each |&(ident, data)| {
+            cx.diag.handler().note(fmt!("path: %s", ident));
+            let attrs = decoder::get_crate_attributes(data);
             note_linkage_attrs(cx.intr, cx.diag, attrs);
         }
         cx.diag.handler().abort_if_errors();

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -39,7 +39,11 @@ pub struct ctxt {
 // Compact string representation for ty.t values. API ty_str & parse_from_str.
 // Extra parameters are for converting to/from def_ids in the string rep.
 // Whatever format you choose should not contain pipe characters.
-pub type ty_abbrev = {pos: uint, len: uint, s: @~str};
+pub struct ty_abbrev {
+    pos: uint,
+    len: uint,
+    s: @~str
+}
 
 pub enum abbrev_ctxt {
     ac_no_abbrevs,
@@ -100,7 +104,7 @@ pub fn enc_ty(w: io::Writer, cx: @ctxt, t: ty::t) {
                 // I.e. it's actually an abbreviation.
                 let s = ~"#" + uint::to_str_radix(pos, 16u) + ~":" +
                     uint::to_str_radix(len, 16u) + ~"#";
-                let a = {pos: pos, len: len, s: @s};
+                let a = ty_abbrev { pos: pos, len: len, s: @s };
                 abbrevs.insert(t, a);
             }
             return;

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -565,7 +565,8 @@ fn encode_method_map_entry(ecx: @e::EncodeContext,
 }
 
 impl read_method_map_entry_helper for reader::Decoder {
-    fn read_method_map_entry(xcx: @ExtendedDecodeContext) -> method_map_entry {
+    fn read_method_map_entry(xcx: @ExtendedDecodeContext)
+        -> method_map_entry {
         do self.read_rec {
             method_map_entry {
                 self_arg: self.read_field(~"self_arg", 0u, || {
@@ -672,7 +673,8 @@ fn encode_vtable_origin(ecx: @e::EncodeContext,
 
 trait vtable_decoder_helpers {
     fn read_vtable_res(xcx: @ExtendedDecodeContext) -> typeck::vtable_res;
-    fn read_vtable_origin(xcx: @ExtendedDecodeContext) -> typeck::vtable_origin;
+    fn read_vtable_origin(xcx: @ExtendedDecodeContext)
+        -> typeck::vtable_origin;
 }
 
 impl vtable_decoder_helpers for reader::Decoder {

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -62,34 +62,30 @@ pub struct Maps {
     capture_map: middle::moves::CaptureMap,
 }
 
-type decode_ctxt = @{
-    cdata: cstore::crate_metadata,
+struct DecodeContext {
+    cdata: @cstore::crate_metadata,
     tcx: ty::ctxt,
     maps: Maps
-};
+}
 
-type extended_decode_ctxt_ = {
-    dcx: decode_ctxt,
+struct ExtendedDecodeContext {
+    dcx: @DecodeContext,
     from_id_range: ast_util::id_range,
     to_id_range: ast_util::id_range
-};
-
-enum extended_decode_ctxt {
-    extended_decode_ctxt_(@extended_decode_ctxt_)
 }
 
 trait tr {
-    fn tr(xcx: extended_decode_ctxt) -> Self;
+    fn tr(xcx: @ExtendedDecodeContext) -> Self;
 }
 
 trait tr_intern {
-    fn tr_intern(xcx: extended_decode_ctxt) -> ast::def_id;
+    fn tr_intern(xcx: @ExtendedDecodeContext) -> ast::def_id;
 }
 
 // ______________________________________________________________________
 // Top-level methods.
 
-pub fn encode_inlined_item(ecx: @e::encode_ctxt,
+pub fn encode_inlined_item(ecx: @e::EncodeContext,
                            ebml_w: writer::Encoder,
                            path: &[ast_map::path_elt],
                            ii: ast::inlined_item,
@@ -112,13 +108,17 @@ pub fn encode_inlined_item(ecx: @e::encode_ctxt,
            ebml_w.writer.tell());
 }
 
-pub fn decode_inlined_item(cdata: cstore::crate_metadata,
+pub fn decode_inlined_item(cdata: @cstore::crate_metadata,
                            tcx: ty::ctxt,
                            maps: Maps,
                            +path: ast_map::path,
                            par_doc: ebml::Doc)
                         -> Option<ast::inlined_item> {
-    let dcx = @{cdata: cdata, tcx: tcx, maps: maps};
+    let dcx = @DecodeContext {
+        cdata: cdata,
+        tcx: tcx,
+        maps: maps
+    };
     match par_doc.opt_child(c::tag_ast) {
       None => None,
       Some(ast_doc) => {
@@ -127,9 +127,11 @@ pub fn decode_inlined_item(cdata: cstore::crate_metadata,
         let ast_dsr = &reader::Decoder(ast_doc);
         let from_id_range = Decodable::decode(ast_dsr);
         let to_id_range = reserve_id_range(dcx.tcx.sess, from_id_range);
-        let xcx = extended_decode_ctxt_(@{dcx: dcx,
-                                          from_id_range: from_id_range,
-                                          to_id_range: to_id_range});
+        let xcx = @ExtendedDecodeContext {
+            dcx: dcx,
+            from_id_range: from_id_range,
+            to_id_range: to_id_range
+        };
         let raw_ii = decode_ast(ast_doc);
         let ii = renumber_ast(xcx, raw_ii);
         debug!("Fn named: %s", tcx.sess.str_of(ii.ident()));
@@ -165,8 +167,8 @@ fn reserve_id_range(sess: Session,
     ast_util::id_range { min: to_id_min, max: to_id_min }
 }
 
-impl extended_decode_ctxt {
-    fn tr_id(id: ast::node_id) -> ast::node_id {
+impl ExtendedDecodeContext {
+    fn tr_id(&self, id: ast::node_id) -> ast::node_id {
         /*!
          *
          * Translates an internal id, meaning a node id that is known
@@ -182,7 +184,7 @@ impl extended_decode_ctxt {
         assert !ast_util::empty(self.from_id_range);
         (id - self.from_id_range.min + self.to_id_range.min)
     }
-    fn tr_def_id(did: ast::def_id) -> ast::def_id {
+    fn tr_def_id(&self, did: ast::def_id) -> ast::def_id {
         /*!
          *
          * Translates an EXTERNAL def-id, converting the crate number
@@ -207,7 +209,7 @@ impl extended_decode_ctxt {
 
         decoder::translate_def_id(self.dcx.cdata, did)
     }
-    fn tr_intern_def_id(did: ast::def_id) -> ast::def_id {
+    fn tr_intern_def_id(&self, did: ast::def_id) -> ast::def_id {
         /*!
          *
          * Translates an INTERNAL def-id, meaning a def-id that is
@@ -219,25 +221,25 @@ impl extended_decode_ctxt {
         assert did.crate == ast::local_crate;
         ast::def_id { crate: ast::local_crate, node: self.tr_id(did.node) }
     }
-    fn tr_span(_span: span) -> span {
+    fn tr_span(&self, _span: span) -> span {
         codemap::dummy_sp() // FIXME (#1972): handle span properly
     }
 }
 
 impl tr_intern for ast::def_id {
-    fn tr_intern(xcx: extended_decode_ctxt) -> ast::def_id {
+    fn tr_intern(xcx: @ExtendedDecodeContext) -> ast::def_id {
         xcx.tr_intern_def_id(self)
     }
 }
 
 impl tr for ast::def_id {
-    fn tr(xcx: extended_decode_ctxt) -> ast::def_id {
+    fn tr(xcx: @ExtendedDecodeContext) -> ast::def_id {
         xcx.tr_def_id(self)
     }
 }
 
 impl tr for span {
-    fn tr(xcx: extended_decode_ctxt) -> span {
+    fn tr(xcx: @ExtendedDecodeContext) -> span {
         xcx.tr_span(self)
     }
 }
@@ -253,12 +255,12 @@ impl<S: serialize::Encoder> def_id_encoder_helpers for S {
 }
 
 trait def_id_decoder_helpers {
-    fn read_def_id(xcx: extended_decode_ctxt) -> ast::def_id;
+    fn read_def_id(xcx: @ExtendedDecodeContext) -> ast::def_id;
 }
 
 impl<D: serialize::Decoder> def_id_decoder_helpers for D {
 
-    fn read_def_id(xcx: extended_decode_ctxt) -> ast::def_id {
+    fn read_def_id(xcx: @ExtendedDecodeContext) -> ast::def_id {
         let did: ast::def_id = Decodable::decode(&self);
         did.tr(xcx)
     }
@@ -351,7 +353,7 @@ fn decode_ast(par_doc: ebml::Doc) -> ast::inlined_item {
     Decodable::decode(d)
 }
 
-fn renumber_ast(xcx: extended_decode_ctxt, ii: ast::inlined_item)
+fn renumber_ast(xcx: @ExtendedDecodeContext, ii: ast::inlined_item)
     -> ast::inlined_item {
     let fld = fold::make_fold(@fold::AstFoldFns{
         new_id: |a| xcx.tr_id(a),
@@ -396,14 +398,14 @@ fn encode_def(ebml_w: writer::Encoder, def: ast::def) {
     def.encode(&ebml_w)
 }
 
-fn decode_def(xcx: extended_decode_ctxt, doc: ebml::Doc) -> ast::def {
+fn decode_def(xcx: @ExtendedDecodeContext, doc: ebml::Doc) -> ast::def {
     let dsr = &reader::Decoder(doc);
     let def: ast::def = Decodable::decode(dsr);
     def.tr(xcx)
 }
 
 impl tr for ast::def {
-    fn tr(xcx: extended_decode_ctxt) -> ast::def {
+    fn tr(xcx: @ExtendedDecodeContext) -> ast::def {
         match self {
           ast::def_fn(did, p) => { ast::def_fn(did.tr(xcx), p) }
           ast::def_static_method(did, did2_opt, p) => {
@@ -448,7 +450,7 @@ impl tr for ast::def {
 // Encoding and decoding of adjustment information
 
 impl tr for ty::AutoAdjustment {
-    fn tr(xcx: extended_decode_ctxt) -> ty::AutoAdjustment {
+    fn tr(xcx: @ExtendedDecodeContext) -> ty::AutoAdjustment {
         ty::AutoAdjustment {
             autoderefs: self.autoderefs,
             autoref: self.autoref.map(|ar| ar.tr(xcx)),
@@ -457,7 +459,7 @@ impl tr for ty::AutoAdjustment {
 }
 
 impl tr for ty::AutoRef {
-    fn tr(xcx: extended_decode_ctxt) -> ty::AutoRef {
+    fn tr(xcx: @ExtendedDecodeContext) -> ty::AutoRef {
         ty::AutoRef {
             kind: self.kind,
             region: self.region.tr(xcx),
@@ -467,7 +469,7 @@ impl tr for ty::AutoRef {
 }
 
 impl tr for ty::Region {
-    fn tr(xcx: extended_decode_ctxt) -> ty::Region {
+    fn tr(xcx: @ExtendedDecodeContext) -> ty::Region {
         match self {
             ty::re_bound(br) => ty::re_bound(br.tr(xcx)),
             ty::re_free(id, br) => ty::re_free(xcx.tr_id(id), br.tr(xcx)),
@@ -478,7 +480,7 @@ impl tr for ty::Region {
 }
 
 impl tr for ty::bound_region {
-    fn tr(xcx: extended_decode_ctxt) -> ty::bound_region {
+    fn tr(xcx: @ExtendedDecodeContext) -> ty::bound_region {
         match self {
             ty::br_anon(_) | ty::br_named(_) | ty::br_self |
             ty::br_fresh(_) => self,
@@ -496,18 +498,18 @@ fn encode_freevar_entry(ebml_w: writer::Encoder, fv: @freevar_entry) {
 }
 
 trait ebml_decoder_helper {
-    fn read_freevar_entry(xcx: extended_decode_ctxt) -> freevar_entry;
+    fn read_freevar_entry(xcx: @ExtendedDecodeContext) -> freevar_entry;
 }
 
 impl ebml_decoder_helper for reader::Decoder {
-    fn read_freevar_entry(xcx: extended_decode_ctxt) -> freevar_entry {
+    fn read_freevar_entry(xcx: @ExtendedDecodeContext) -> freevar_entry {
         let fv: freevar_entry = Decodable::decode(&self);
         fv.tr(xcx)
     }
 }
 
 impl tr for freevar_entry {
-    fn tr(xcx: extended_decode_ctxt) -> freevar_entry {
+    fn tr(xcx: @ExtendedDecodeContext) -> freevar_entry {
         freevar_entry {
             def: self.def.tr(xcx),
             span: self.span.tr(xcx),
@@ -519,18 +521,18 @@ impl tr for freevar_entry {
 // Encoding and decoding of CaptureVar information
 
 trait capture_var_helper {
-    fn read_capture_var(xcx: extended_decode_ctxt) -> moves::CaptureVar;
+    fn read_capture_var(xcx: @ExtendedDecodeContext) -> moves::CaptureVar;
 }
 
 impl capture_var_helper for reader::Decoder {
-    fn read_capture_var(xcx: extended_decode_ctxt) -> moves::CaptureVar {
+    fn read_capture_var(xcx: @ExtendedDecodeContext) -> moves::CaptureVar {
         let cvar: moves::CaptureVar = Decodable::decode(&self);
         cvar.tr(xcx)
     }
 }
 
 impl tr for moves::CaptureVar {
-    fn tr(xcx: extended_decode_ctxt) -> moves::CaptureVar {
+    fn tr(xcx: @ExtendedDecodeContext) -> moves::CaptureVar {
         moves::CaptureVar {
             def: self.def.tr(xcx),
             span: self.span.tr(xcx),
@@ -543,10 +545,10 @@ impl tr for moves::CaptureVar {
 // Encoding and decoding of method_map_entry
 
 trait read_method_map_entry_helper {
-    fn read_method_map_entry(xcx: extended_decode_ctxt) -> method_map_entry;
+    fn read_method_map_entry(xcx: @ExtendedDecodeContext) -> method_map_entry;
 }
 
-fn encode_method_map_entry(ecx: @e::encode_ctxt,
+fn encode_method_map_entry(ecx: @e::EncodeContext,
                               ebml_w: writer::Encoder,
                               mme: method_map_entry) {
     do ebml_w.emit_rec {
@@ -563,7 +565,7 @@ fn encode_method_map_entry(ecx: @e::encode_ctxt,
 }
 
 impl read_method_map_entry_helper for reader::Decoder {
-    fn read_method_map_entry(xcx: extended_decode_ctxt) -> method_map_entry {
+    fn read_method_map_entry(xcx: @ExtendedDecodeContext) -> method_map_entry {
         do self.read_rec {
             method_map_entry {
                 self_arg: self.read_field(~"self_arg", 0u, || {
@@ -584,7 +586,7 @@ impl read_method_map_entry_helper for reader::Decoder {
 }
 
 impl tr for method_origin {
-    fn tr(xcx: extended_decode_ctxt) -> method_origin {
+    fn tr(xcx: @ExtendedDecodeContext) -> method_origin {
         match self {
           typeck::method_static(did) => {
               typeck::method_static(did.tr(xcx))
@@ -613,7 +615,7 @@ impl tr for method_origin {
 // ______________________________________________________________________
 // Encoding and decoding vtable_res
 
-fn encode_vtable_res(ecx: @e::encode_ctxt,
+fn encode_vtable_res(ecx: @e::EncodeContext,
                      ebml_w: writer::Encoder,
                      dr: typeck::vtable_res) {
     // can't autogenerate this code because automatic code of
@@ -625,7 +627,7 @@ fn encode_vtable_res(ecx: @e::encode_ctxt,
     }
 }
 
-fn encode_vtable_origin(ecx: @e::encode_ctxt,
+fn encode_vtable_origin(ecx: @e::EncodeContext,
                       ebml_w: writer::Encoder,
                       vtable_origin: typeck::vtable_origin) {
     do ebml_w.emit_enum(~"vtable_origin") {
@@ -669,16 +671,16 @@ fn encode_vtable_origin(ecx: @e::encode_ctxt,
 }
 
 trait vtable_decoder_helpers {
-    fn read_vtable_res(xcx: extended_decode_ctxt) -> typeck::vtable_res;
-    fn read_vtable_origin(xcx: extended_decode_ctxt) -> typeck::vtable_origin;
+    fn read_vtable_res(xcx: @ExtendedDecodeContext) -> typeck::vtable_res;
+    fn read_vtable_origin(xcx: @ExtendedDecodeContext) -> typeck::vtable_origin;
 }
 
 impl vtable_decoder_helpers for reader::Decoder {
-    fn read_vtable_res(xcx: extended_decode_ctxt) -> typeck::vtable_res {
+    fn read_vtable_res(xcx: @ExtendedDecodeContext) -> typeck::vtable_res {
         @self.read_to_vec(|| self.read_vtable_origin(xcx) )
     }
 
-    fn read_vtable_origin(xcx: extended_decode_ctxt)
+    fn read_vtable_origin(xcx: @ExtendedDecodeContext)
         -> typeck::vtable_origin {
         do self.read_enum(~"vtable_origin") {
             do self.read_enum_variant |i| {
@@ -731,7 +733,7 @@ trait get_ty_str_ctxt {
     fn ty_str_ctxt() -> @tyencode::ctxt;
 }
 
-impl get_ty_str_ctxt for @e::encode_ctxt {
+impl get_ty_str_ctxt for @e::EncodeContext {
     fn ty_str_ctxt() -> @tyencode::ctxt {
         @tyencode::ctxt {diag: self.tcx.sess.diagnostic(),
                         ds: e::def_to_str,
@@ -742,46 +744,46 @@ impl get_ty_str_ctxt for @e::encode_ctxt {
 }
 
 trait ebml_writer_helpers {
-    fn emit_arg(ecx: @e::encode_ctxt, arg: ty::arg);
-    fn emit_ty(ecx: @e::encode_ctxt, ty: ty::t);
-    fn emit_vstore(ecx: @e::encode_ctxt, vstore: ty::vstore);
-    fn emit_tys(ecx: @e::encode_ctxt, tys: ~[ty::t]);
-    fn emit_bounds(ecx: @e::encode_ctxt, bs: ty::param_bounds);
-    fn emit_tpbt(ecx: @e::encode_ctxt, tpbt: ty::ty_param_bounds_and_ty);
+    fn emit_arg(ecx: @e::EncodeContext, arg: ty::arg);
+    fn emit_ty(ecx: @e::EncodeContext, ty: ty::t);
+    fn emit_vstore(ecx: @e::EncodeContext, vstore: ty::vstore);
+    fn emit_tys(ecx: @e::EncodeContext, tys: ~[ty::t]);
+    fn emit_bounds(ecx: @e::EncodeContext, bs: ty::param_bounds);
+    fn emit_tpbt(ecx: @e::EncodeContext, tpbt: ty::ty_param_bounds_and_ty);
 }
 
 impl ebml_writer_helpers for writer::Encoder {
-    fn emit_ty(ecx: @e::encode_ctxt, ty: ty::t) {
+    fn emit_ty(ecx: @e::EncodeContext, ty: ty::t) {
         do self.emit_opaque {
             e::write_type(ecx, self, ty)
         }
     }
 
-    fn emit_vstore(ecx: @e::encode_ctxt, vstore: ty::vstore) {
+    fn emit_vstore(ecx: @e::EncodeContext, vstore: ty::vstore) {
         do self.emit_opaque {
             e::write_vstore(ecx, self, vstore)
         }
     }
 
-    fn emit_arg(ecx: @e::encode_ctxt, arg: ty::arg) {
+    fn emit_arg(ecx: @e::EncodeContext, arg: ty::arg) {
         do self.emit_opaque {
             tyencode::enc_arg(self.writer, ecx.ty_str_ctxt(), arg);
         }
     }
 
-    fn emit_tys(ecx: @e::encode_ctxt, tys: ~[ty::t]) {
+    fn emit_tys(ecx: @e::EncodeContext, tys: ~[ty::t]) {
         do self.emit_from_vec(tys) |ty| {
             self.emit_ty(ecx, *ty)
         }
     }
 
-    fn emit_bounds(ecx: @e::encode_ctxt, bs: ty::param_bounds) {
+    fn emit_bounds(ecx: @e::EncodeContext, bs: ty::param_bounds) {
         do self.emit_opaque {
             tyencode::enc_bounds(self.writer, ecx.ty_str_ctxt(), bs)
         }
     }
 
-    fn emit_tpbt(ecx: @e::encode_ctxt, tpbt: ty::ty_param_bounds_and_ty) {
+    fn emit_tpbt(ecx: @e::EncodeContext, tpbt: ty::ty_param_bounds_and_ty) {
         do self.emit_rec {
             do self.emit_field(~"bounds", 0) {
                 do self.emit_from_vec(*tpbt.bounds) |bs| {
@@ -813,7 +815,7 @@ impl write_tag_and_id for writer::Encoder {
     }
 }
 
-fn encode_side_tables_for_ii(ecx: @e::encode_ctxt,
+fn encode_side_tables_for_ii(ecx: @e::EncodeContext,
                              maps: Maps,
                              ebml_w: writer::Encoder,
                              ii: ast::inlined_item) {
@@ -830,7 +832,7 @@ fn encode_side_tables_for_ii(ecx: @e::encode_ctxt,
     }
 }
 
-fn encode_side_tables_for_id(ecx: @e::encode_ctxt,
+fn encode_side_tables_for_id(ecx: @e::EncodeContext,
                              maps: Maps,
                              ebml_w: writer::Encoder,
                              id: ast::node_id) {
@@ -989,19 +991,19 @@ impl doc_decoder_helpers for ebml::Doc {
 }
 
 trait ebml_decoder_decoder_helpers {
-    fn read_arg(xcx: extended_decode_ctxt) -> ty::arg;
-    fn read_ty(xcx: extended_decode_ctxt) -> ty::t;
-    fn read_tys(xcx: extended_decode_ctxt) -> ~[ty::t];
-    fn read_bounds(xcx: extended_decode_ctxt) -> @~[ty::param_bound];
-    fn read_ty_param_bounds_and_ty(xcx: extended_decode_ctxt)
+    fn read_arg(xcx: @ExtendedDecodeContext) -> ty::arg;
+    fn read_ty(xcx: @ExtendedDecodeContext) -> ty::t;
+    fn read_tys(xcx: @ExtendedDecodeContext) -> ~[ty::t];
+    fn read_bounds(xcx: @ExtendedDecodeContext) -> @~[ty::param_bound];
+    fn read_ty_param_bounds_and_ty(xcx: @ExtendedDecodeContext)
                                 -> ty::ty_param_bounds_and_ty;
-    fn convert_def_id(xcx: extended_decode_ctxt,
+    fn convert_def_id(xcx: @ExtendedDecodeContext,
                       source: DefIdSource,
                       did: ast::def_id) -> ast::def_id;
 }
 
 impl ebml_decoder_decoder_helpers for reader::Decoder {
-    fn read_arg(xcx: extended_decode_ctxt) -> ty::arg {
+    fn read_arg(xcx: @ExtendedDecodeContext) -> ty::arg {
         do self.read_opaque |doc| {
             tydecode::parse_arg_data(
                 doc.data, xcx.dcx.cdata.cnum, doc.start, xcx.dcx.tcx,
@@ -1009,7 +1011,7 @@ impl ebml_decoder_decoder_helpers for reader::Decoder {
         }
     }
 
-    fn read_ty(xcx: extended_decode_ctxt) -> ty::t {
+    fn read_ty(xcx: @ExtendedDecodeContext) -> ty::t {
         // Note: regions types embed local node ids.  In principle, we
         // should translate these node ids into the new decode
         // context.  However, we do not bother, because region types
@@ -1036,11 +1038,11 @@ impl ebml_decoder_decoder_helpers for reader::Decoder {
         }
     }
 
-    fn read_tys(xcx: extended_decode_ctxt) -> ~[ty::t] {
+    fn read_tys(xcx: @ExtendedDecodeContext) -> ~[ty::t] {
         self.read_to_vec(|| self.read_ty(xcx) )
     }
 
-    fn read_bounds(xcx: extended_decode_ctxt) -> @~[ty::param_bound] {
+    fn read_bounds(xcx: @ExtendedDecodeContext) -> @~[ty::param_bound] {
         do self.read_opaque |doc| {
             tydecode::parse_bounds_data(
                 doc.data, doc.start, xcx.dcx.cdata.cnum, xcx.dcx.tcx,
@@ -1048,11 +1050,11 @@ impl ebml_decoder_decoder_helpers for reader::Decoder {
         }
     }
 
-    fn read_ty_param_bounds_and_ty(xcx: extended_decode_ctxt)
+    fn read_ty_param_bounds_and_ty(xcx: @ExtendedDecodeContext)
         -> ty::ty_param_bounds_and_ty
     {
         do self.read_rec {
-            {
+            ty::ty_param_bounds_and_ty {
                 bounds: self.read_field(~"bounds", 0u, || {
                     @self.read_to_vec(|| self.read_bounds(xcx) )
                 }),
@@ -1066,7 +1068,7 @@ impl ebml_decoder_decoder_helpers for reader::Decoder {
         }
     }
 
-    fn convert_def_id(xcx: extended_decode_ctxt,
+    fn convert_def_id(xcx: @ExtendedDecodeContext,
                       source: tydecode::DefIdSource,
                       did: ast::def_id) -> ast::def_id {
         /*!
@@ -1092,7 +1094,7 @@ impl ebml_decoder_decoder_helpers for reader::Decoder {
     }
 }
 
-fn decode_side_tables(xcx: extended_decode_ctxt,
+fn decode_side_tables(xcx: @ExtendedDecodeContext,
                       ast_doc: ebml::Doc) {
     let dcx = xcx.dcx;
     let tbl_doc = ast_doc[c::tag_table as uint];

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -21,7 +21,7 @@ use core::prelude::*;
 
 use middle::moves;
 use middle::borrowck::{Loan, bckerr, BorrowckCtxt, inherent_mutability};
-use middle::borrowck::{req_maps, root_map_key, save_and_restore_managed};
+use middle::borrowck::{ReqMaps, root_map_key, save_and_restore_managed};
 use middle::borrowck::{MoveError, MoveOk, MoveFromIllegalCmt};
 use middle::borrowck::{MoveWhileBorrowed};
 use middle::mem_categorization::{cat_arg, cat_binding, cat_comp, cat_deref};
@@ -45,7 +45,7 @@ use syntax::visit;
 
 struct CheckLoanCtxt {
     bccx: @BorrowckCtxt,
-    req_maps: req_maps,
+    req_maps: ReqMaps,
 
     reported: HashMap<ast::node_id, ()>,
 
@@ -66,7 +66,7 @@ enum purity_cause {
 }
 
 pub fn check_loans(bccx: @BorrowckCtxt,
-                   req_maps: req_maps,
+                   req_maps: ReqMaps,
                    crate: @ast::crate) {
     let clcx = @mut CheckLoanCtxt {
         bccx: bccx,

--- a/src/librustc/middle/borrowck/gather_loans.rs
+++ b/src/librustc/middle/borrowck/gather_loans.rs
@@ -22,7 +22,7 @@ use middle::borrowck::preserve::{PreserveCondition, PcOk, PcIfPure};
 use middle::borrowck::{Loan, bckerr, bckres, BorrowckCtxt, err_mutbl};
 use middle::borrowck::{LoanKind, TotalFreeze, PartialFreeze,
                        TotalTake, PartialTake, Immobile};
-use middle::borrowck::{req_maps};
+use middle::borrowck::ReqMaps;
 use middle::borrowck::loan;
 use middle::mem_categorization::{cat_binding, cat_discr, cmt, comp_variant};
 use middle::mem_categorization::{mem_categorization_ctxt};
@@ -47,7 +47,7 @@ use syntax::visit;
 ///
 /// - `bccx`: the the borrow check context
 /// - `req_maps`: the maps computed by `gather_loans()`, see def'n of the
-///   type `req_maps` for more info
+///   struct `ReqMaps` for more info
 /// - `item_ub`: the id of the block for the enclosing fn/method item
 /// - `root_ub`: the id of the outermost block for which we can root
 ///   an `@T`.  This is the id of the innermost enclosing
@@ -73,16 +73,16 @@ use syntax::visit;
 /// because it would have to be rooted for a region greater than `root_ub`.
 struct GatherLoanCtxt {
     bccx: @BorrowckCtxt,
-    req_maps: req_maps,
+    req_maps: ReqMaps,
     item_ub: ast::node_id,
     root_ub: ast::node_id,
     ignore_adjustments: LinearSet<ast::node_id>
 }
 
-pub fn gather_loans(bccx: @BorrowckCtxt, crate: @ast::crate) -> req_maps {
+pub fn gather_loans(bccx: @BorrowckCtxt, crate: @ast::crate) -> ReqMaps {
     let glcx = @mut GatherLoanCtxt {
         bccx: bccx,
-        req_maps: {req_loan_map: HashMap(), pure_map: HashMap()},
+        req_maps: ReqMaps { req_loan_map: HashMap(), pure_map: HashMap() },
         item_ub: 0,
         root_ub: 0,
         ignore_adjustments: LinearSet::new()

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -400,9 +400,11 @@ pub enum LoanKind {
 }
 
 /// a complete record of a loan that was granted
-pub struct Loan {lp: @loan_path,
-                 cmt: cmt,
-                 kind: LoanKind}
+pub struct Loan {
+    lp: @loan_path,
+    cmt: cmt,
+    kind: LoanKind
+}
 
 /// maps computed by `gather_loans` that are then used by `check_loans`
 ///
@@ -410,10 +412,10 @@ pub struct Loan {lp: @loan_path,
 ///   for the duration of that block/expr
 /// - `pure_map`: map from block/expr that must be pure to the error message
 ///   that should be reported if they are not pure
-pub type req_maps = {
+pub struct ReqMaps {
     req_loan_map: HashMap<ast::node_id, @DVec<Loan>>,
     pure_map: HashMap<ast::node_id, bckerr>
-};
+}
 
 pub fn save_and_restore<T:Copy,U>(save_and_restore_t: &mut T,
                                   f: &fn() -> U) -> U {

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -45,7 +45,7 @@ pub fn check_crate(tcx: ty::ctxt, crate: @crate) {
                                      }, v);
               }
               expr_fn_block(_, ref b) => {
-                (v.visit_block)((*b), Context { 
+                (v.visit_block)((*b), Context {
                                          in_loop: false,
                                          can_ret: false
                                       }, v);

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -14,34 +14,49 @@ use middle::ty;
 use syntax::ast::*;
 use syntax::visit;
 
-pub type ctx = {in_loop: bool, can_ret: bool};
+pub struct Context {
+    in_loop: bool,
+    can_ret: bool
+}
 
 pub fn check_crate(tcx: ty::ctxt, crate: @crate) {
     visit::visit_crate(*crate,
-                       {in_loop: false, can_ret: true},
+                       Context { in_loop: false, can_ret: true },
                        visit::mk_vt(@visit::Visitor {
         visit_item: |i, _cx, v| {
-            visit::visit_item(i, {in_loop: false, can_ret: true}, v);
+            visit::visit_item(i, Context {
+                                    in_loop: false,
+                                    can_ret: true
+                                 }, v);
         },
-        visit_expr: |e: @expr, cx: ctx, v: visit::vt<ctx>| {
+        visit_expr: |e: @expr, cx: Context, v: visit::vt<Context>| {
             match e.node {
               expr_while(e, ref b) => {
                 (v.visit_expr)(e, cx, v);
-                (v.visit_block)((*b), {in_loop: true,.. cx}, v);
+                (v.visit_block)((*b), Context { in_loop: true,.. cx }, v);
               }
               expr_loop(ref b, _) => {
-                (v.visit_block)((*b), {in_loop: true,.. cx}, v);
+                (v.visit_block)((*b), Context { in_loop: true,.. cx }, v);
               }
               expr_fn(*) => {
-                visit::visit_expr(e, {in_loop: false, can_ret: true}, v);
+                visit::visit_expr(e, Context {
+                                        in_loop: false,
+                                        can_ret: true
+                                     }, v);
               }
               expr_fn_block(_, ref b) => {
-                (v.visit_block)((*b), {in_loop: false, can_ret: false}, v);
+                (v.visit_block)((*b), Context { 
+                                         in_loop: false,
+                                         can_ret: false
+                                      }, v);
               }
               expr_loop_body(@expr {node: expr_fn_block(_, ref b), _}) => {
                 let sigil = ty::ty_closure_sigil(ty::expr_ty(tcx, e));
                 let blk = (sigil == BorrowedSigil);
-                (v.visit_block)((*b), {in_loop: true, can_ret: blk}, v);
+                (v.visit_block)((*b), Context {
+                                         in_loop: true,
+                                         can_ret: blk
+                                      }, v);
               }
               expr_break(_) => {
                 if !cx.in_loop {

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -102,165 +102,205 @@ pub fn level_to_str(lv: level) -> &static/str {
     }
 }
 
+#[deriving_eq]
 pub enum level {
     allow, warn, deny, forbid
 }
 
-impl cmp::Eq for level {
-    pure fn eq(&self, other: &level) -> bool {
-        ((*self) as uint) == ((*other) as uint)
-    }
-    pure fn ne(&self, other: &level) -> bool { !(*self).eq(other) }
+struct LintSpec {
+    lint: lint,
+    desc: &static/str,
+    default: level
 }
 
-type lint_spec = @{lint: lint,
-                   desc: &static/str,
-                   default: level};
-
-pub type lint_dict = HashMap<~str,lint_spec>;
+pub type LintDict = HashMap<~str, @LintSpec>;
 
 /*
   Pass names should not contain a '-', as the compiler normalizes
   '-' to '_' in command-line flags
  */
-pub fn get_lint_dict() -> lint_dict {
+pub fn get_lint_dict() -> LintDict {
     let v = ~[
         (~"ctypes",
-         @{lint: ctypes,
-           desc: "proper use of core::libc types in foreign modules",
-           default: warn}),
+         @LintSpec {
+            lint: ctypes,
+            desc: "proper use of core::libc types in foreign modules",
+            default: warn
+         }),
 
         (~"unused_imports",
-         @{lint: unused_imports,
-           desc: "imports that are never used",
-           default: allow}),
+         @LintSpec {
+			lint: unused_imports,
+            desc: "imports that are never used",
+            default: allow
+         }),
 
         (~"while_true",
-         @{lint: while_true,
-           desc: "suggest using loop { } instead of while(true) { }",
-           default: warn}),
+         @LintSpec {
+			lint: while_true,
+            desc: "suggest using loop { } instead of while(true) { }",
+            default: warn
+         }),
 
         (~"path_statement",
-         @{lint: path_statement,
-           desc: "path statements with no effect",
-           default: warn}),
+         @LintSpec {
+			lint: path_statement,
+            desc: "path statements with no effect",
+            default: warn
+         }),
 
         (~"unrecognized_lint",
-         @{lint: unrecognized_lint,
-           desc: "unrecognized lint attribute",
-           default: warn}),
+         @LintSpec {
+			lint: unrecognized_lint,
+            desc: "unrecognized lint attribute",
+            default: warn
+         }),
 
         (~"non_implicitly_copyable_typarams",
-         @{lint: non_implicitly_copyable_typarams,
-           desc: "passing non implicitly copyable types as copy type params",
-           default: warn}),
+         @LintSpec {
+			lint: non_implicitly_copyable_typarams,
+            desc: "passing non implicitly copyable types as copy type params",
+            default: warn
+         }),
 
         (~"vecs_implicitly_copyable",
-         @{lint: vecs_implicitly_copyable,
-           desc: "make vecs and strs not implicitly copyable \
+         @LintSpec {
+			lint: vecs_implicitly_copyable,
+            desc: "make vecs and strs not implicitly copyable \
                   (only checked at top level)",
-           default: warn}),
+            default: warn
+         }),
 
         (~"implicit_copies",
-         @{lint: implicit_copies,
-           desc: "implicit copies of non implicitly copyable data",
-           default: warn}),
+         @LintSpec {
+			lint: implicit_copies,
+            desc: "implicit copies of non implicitly copyable data",
+            default: warn
+         }),
 
         (~"deprecated_mode",
-         @{lint: deprecated_mode,
-           desc: "warn about deprecated uses of modes",
-           default: warn}),
+         @LintSpec {
+			lint: deprecated_mode,
+            desc: "warn about deprecated uses of modes",
+            default: warn
+         }),
 
         (~"deprecated_pattern",
-         @{lint: deprecated_pattern,
-           desc: "warn about deprecated uses of pattern bindings",
-           default: allow}),
+         @LintSpec {
+			lint: deprecated_pattern,
+            desc: "warn about deprecated uses of pattern bindings",
+            default: allow
+         }),
 
         (~"non_camel_case_types",
-         @{lint: non_camel_case_types,
-           desc: "types, variants and traits should have camel case names",
-           default: allow}),
+         @LintSpec {
+			lint: non_camel_case_types,
+            desc: "types, variants and traits should have camel case names",
+            default: allow
+         }),
 
         (~"managed_heap_memory",
-         @{lint: managed_heap_memory,
-           desc: "use of managed (@ type) heap memory",
-           default: allow}),
+         @LintSpec {
+			lint: managed_heap_memory,
+            desc: "use of managed (@ type) heap memory",
+            default: allow
+         }),
 
         (~"owned_heap_memory",
-         @{lint: owned_heap_memory,
-           desc: "use of owned (~ type) heap memory",
-           default: allow}),
+         @LintSpec {
+			lint: owned_heap_memory,
+            desc: "use of owned (~ type) heap memory",
+            default: allow
+         }),
 
         (~"heap_memory",
-         @{lint: heap_memory,
-           desc: "use of any (~ type or @ type) heap memory",
-           default: allow}),
+         @LintSpec {
+			lint: heap_memory,
+            desc: "use of any (~ type or @ type) heap memory",
+            default: allow
+         }),
 
         (~"structural_records",
-         @{lint: structural_records,
-           desc: "use of any structural records",
-           default: deny}),
+         @LintSpec {
+			lint: structural_records,
+            desc: "use of any structural records",
+            default: deny
+         }),
 
         (~"legacy modes",
-         @{lint: legacy_modes,
-           desc: "allow legacy modes",
-           default: forbid}),
+         @LintSpec {
+			lint: legacy_modes,
+            desc: "allow legacy modes",
+            default: forbid
+         }),
 
         (~"type_limits",
-         @{lint: type_limits,
-           desc: "comparisons made useless by limits of the types involved",
-           default: warn}),
+         @LintSpec {
+			lint: type_limits,
+            desc: "comparisons made useless by limits of the types involved",
+            default: warn
+         }),
 
         (~"default_methods",
-         @{lint: default_methods,
-           desc: "allow default methods",
-           default: deny}),
+         @LintSpec {
+			lint: default_methods,
+            desc: "allow default methods",
+            default: deny
+         }),
 
         (~"deprecated_self",
-         @{lint: deprecated_self,
-           desc: "warn about deprecated uses of `self`",
-           default: warn}),
+         @LintSpec {
+			lint: deprecated_self,
+            desc: "warn about deprecated uses of `self`",
+            default: warn
+         }),
 
         /* FIXME(#3266)--make liveness warnings lintable
         (~"unused_variable",
-         @{lint: unused_variable,
-           desc: "detect variables which are not used in any way",
-           default: warn}),
+         @LintSpec {
+			lint: unused_variable,
+            desc: "detect variables which are not used in any way",
+            default: warn
+         }),
 
         (~"dead_assignment",
-         @{lint: dead_assignment,
-           desc: "detect assignments that will never be read",
-           default: warn}),
+         @LintSpec {
+			lint: dead_assignment,
+            desc: "detect assignments that will never be read",
+            default: warn
+         }),
         */
     ];
     oldmap::hash_from_vec(v)
 }
 
 // This is a highly not-optimal set of data structure decisions.
-type lint_modes = SmallIntMap<level>;
-type lint_mode_map = HashMap<ast::node_id, lint_modes>;
+type LintModes = SmallIntMap<level>;
+type LintModeMap = HashMap<ast::node_id, LintModes>;
 
 // settings_map maps node ids of items with non-default lint settings
 // to their settings; default_settings contains the settings for everything
 // not in the map.
-pub type lint_settings = {
-    default_settings: lint_modes,
-    settings_map: lint_mode_map
-};
-
-pub fn mk_lint_settings() -> lint_settings {
-    {default_settings: oldsmallintmap::mk(),
-     settings_map: HashMap()}
+pub struct LintSettings {
+    default_settings: LintModes,
+    settings_map: LintModeMap
 }
 
-pub fn get_lint_level(modes: lint_modes, lint: lint) -> level {
+pub fn mk_lint_settings() -> LintSettings {
+    LintSettings {
+        default_settings: oldsmallintmap::mk(),
+        settings_map: HashMap()
+    }
+}
+
+pub fn get_lint_level(modes: LintModes, lint: lint) -> level {
     match modes.find(lint as uint) {
       Some(c) => c,
       None => allow
     }
 }
 
-pub fn get_lint_settings_level(settings: lint_settings,
+pub fn get_lint_settings_level(settings: LintSettings,
                                lint_mode: lint,
                                _expr_id: ast::node_id,
                                item_id: ast::node_id)
@@ -273,26 +313,24 @@ pub fn get_lint_settings_level(settings: lint_settings,
 
 // This is kind of unfortunate. It should be somewhere else, or we should use
 // a persistent data structure...
-fn clone_lint_modes(modes: lint_modes) -> lint_modes {
+fn clone_lint_modes(modes: LintModes) -> LintModes {
     oldsmallintmap::SmallIntMap_(@oldsmallintmap::SmallIntMap_
     {v: copy modes.v})
 }
 
-type ctxt_ = {dict: lint_dict,
-              curr: lint_modes,
-              is_default: bool,
-              sess: Session};
-
-enum ctxt {
-    ctxt_(ctxt_)
+struct Context {
+    dict: LintDict,
+    curr: LintModes,
+    is_default: bool,
+    sess: Session
 }
 
-impl ctxt {
-    fn get_level(lint: lint) -> level {
+impl Context {
+    fn get_level(&self, lint: lint) -> level {
         get_lint_level(self.curr, lint)
     }
 
-    fn set_level(lint: lint, level: level) {
+    fn set_level(&self, lint: lint, level: level) {
         if level == allow {
             self.curr.remove(lint as uint);
         } else {
@@ -300,7 +338,7 @@ impl ctxt {
         }
     }
 
-    fn span_lint(level: level, span: span, +msg: ~str) {
+    fn span_lint(&self, level: level, span: span, +msg: ~str) {
         self.sess.span_lint_level(level, span, msg);
     }
 
@@ -309,9 +347,9 @@ impl ctxt {
      * current lint context, call the provided function, then reset the
      * lints in effect to their previous state.
      */
-    fn with_lint_attrs(attrs: ~[ast::attribute], f: fn(ctxt)) {
+    fn with_lint_attrs(&self, attrs: ~[ast::attribute], f: fn(Context)) {
 
-        let mut new_ctxt = self;
+        let mut new_ctxt = *self;
         let mut triples = ~[];
 
         for [allow, warn, deny, forbid].each |level| {
@@ -371,10 +409,11 @@ impl ctxt {
                 // this shouldn't actually be a problem...
 
                 let c = clone_lint_modes(new_ctxt.curr);
-                new_ctxt =
-                    ctxt_({is_default: false,
-                           curr: c,
-                           .. *new_ctxt});
+                new_ctxt = Context {
+                    is_default: false,
+                    curr: c,
+                    .. new_ctxt
+                };
                 new_ctxt.set_level(lint.lint, level);
               }
             }
@@ -384,7 +423,7 @@ impl ctxt {
 }
 
 
-fn build_settings_item(i: @ast::item, &&cx: ctxt, v: visit::vt<ctxt>) {
+fn build_settings_item(i: @ast::item, &&cx: Context, v: visit::vt<Context>) {
     do cx.with_lint_attrs(/*bad*/copy i.attrs) |cx| {
         if !cx.is_default {
             cx.sess.lint_settings.settings_map.insert(i.id, cx.curr);
@@ -394,10 +433,12 @@ fn build_settings_item(i: @ast::item, &&cx: ctxt, v: visit::vt<ctxt>) {
 }
 
 pub fn build_settings_crate(sess: session::Session, crate: @ast::crate) {
-    let cx = ctxt_({dict: get_lint_dict(),
-                    curr: oldsmallintmap::mk(),
-                    is_default: true,
-                    sess: sess});
+    let cx = Context {
+        dict: get_lint_dict(),
+        curr: oldsmallintmap::mk(),
+        is_default: true,
+        sess: sess
+    };
 
     // Install defaults.
     for cx.dict.each_value |&spec| {
@@ -416,7 +457,10 @@ pub fn build_settings_crate(sess: session::Session, crate: @ast::crate) {
             sess.lint_settings.default_settings.insert(k, v);
         }
 
-        let cx = ctxt_({is_default: true,.. *cx});
+        let cx = Context {
+            is_default: true,
+            .. cx
+        };
 
         let visit = visit::mk_vt(@visit::Visitor {
             visit_item: build_settings_item,

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -130,42 +130,42 @@ pub fn get_lint_dict() -> LintDict {
 
         (~"unused_imports",
          @LintSpec {
-			lint: unused_imports,
+            lint: unused_imports,
             desc: "imports that are never used",
             default: allow
          }),
 
         (~"while_true",
          @LintSpec {
-			lint: while_true,
+            lint: while_true,
             desc: "suggest using loop { } instead of while(true) { }",
             default: warn
          }),
 
         (~"path_statement",
          @LintSpec {
-			lint: path_statement,
+            lint: path_statement,
             desc: "path statements with no effect",
             default: warn
          }),
 
         (~"unrecognized_lint",
          @LintSpec {
-			lint: unrecognized_lint,
+            lint: unrecognized_lint,
             desc: "unrecognized lint attribute",
             default: warn
          }),
 
         (~"non_implicitly_copyable_typarams",
          @LintSpec {
-			lint: non_implicitly_copyable_typarams,
+            lint: non_implicitly_copyable_typarams,
             desc: "passing non implicitly copyable types as copy type params",
             default: warn
          }),
 
         (~"vecs_implicitly_copyable",
          @LintSpec {
-			lint: vecs_implicitly_copyable,
+            lint: vecs_implicitly_copyable,
             desc: "make vecs and strs not implicitly copyable \
                   (only checked at top level)",
             default: warn
@@ -173,84 +173,84 @@ pub fn get_lint_dict() -> LintDict {
 
         (~"implicit_copies",
          @LintSpec {
-			lint: implicit_copies,
+            lint: implicit_copies,
             desc: "implicit copies of non implicitly copyable data",
             default: warn
          }),
 
         (~"deprecated_mode",
          @LintSpec {
-			lint: deprecated_mode,
+            lint: deprecated_mode,
             desc: "warn about deprecated uses of modes",
             default: warn
          }),
 
         (~"deprecated_pattern",
          @LintSpec {
-			lint: deprecated_pattern,
+            lint: deprecated_pattern,
             desc: "warn about deprecated uses of pattern bindings",
             default: allow
          }),
 
         (~"non_camel_case_types",
          @LintSpec {
-			lint: non_camel_case_types,
+            lint: non_camel_case_types,
             desc: "types, variants and traits should have camel case names",
             default: allow
          }),
 
         (~"managed_heap_memory",
          @LintSpec {
-			lint: managed_heap_memory,
+            lint: managed_heap_memory,
             desc: "use of managed (@ type) heap memory",
             default: allow
          }),
 
         (~"owned_heap_memory",
          @LintSpec {
-			lint: owned_heap_memory,
+            lint: owned_heap_memory,
             desc: "use of owned (~ type) heap memory",
             default: allow
          }),
 
         (~"heap_memory",
          @LintSpec {
-			lint: heap_memory,
+            lint: heap_memory,
             desc: "use of any (~ type or @ type) heap memory",
             default: allow
          }),
 
         (~"structural_records",
          @LintSpec {
-			lint: structural_records,
+            lint: structural_records,
             desc: "use of any structural records",
             default: deny
          }),
 
         (~"legacy modes",
          @LintSpec {
-			lint: legacy_modes,
+            lint: legacy_modes,
             desc: "allow legacy modes",
             default: forbid
          }),
 
         (~"type_limits",
          @LintSpec {
-			lint: type_limits,
+            lint: type_limits,
             desc: "comparisons made useless by limits of the types involved",
             default: warn
          }),
 
         (~"default_methods",
          @LintSpec {
-			lint: default_methods,
+            lint: default_methods,
             desc: "allow default methods",
             default: deny
          }),
 
         (~"deprecated_self",
          @LintSpec {
-			lint: deprecated_self,
+            lint: deprecated_self,
             desc: "warn about deprecated uses of `self`",
             default: warn
          }),
@@ -258,14 +258,14 @@ pub fn get_lint_dict() -> LintDict {
         /* FIXME(#3266)--make liveness warnings lintable
         (~"unused_variable",
          @LintSpec {
-			lint: unused_variable,
+            lint: unused_variable,
             desc: "detect variables which are not used in any way",
             default: warn
          }),
 
         (~"dead_assignment",
          @LintSpec {
-			lint: dead_assignment,
+            lint: dead_assignment,
             desc: "detect assignments that will never be read",
             default: warn
          }),

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -99,14 +99,18 @@ pub type BindingMap = HashMap<ident,binding_info>;
 // FIXME #4946: This kind of duplicates information kept in
 // ty::method. Maybe it should go away.
 
-pub type MethodInfo = {
+pub struct MethodInfo {
     did: def_id,
     n_tps: uint,
     ident: ident,
     self_type: self_ty_
-};
+}
 
-pub type Impl = { did: def_id, ident: ident, methods: ~[@MethodInfo] };
+pub struct Impl {
+    did: def_id,
+    ident: ident,
+    methods: ~[@MethodInfo]
+}
 
 // Trait method resolution
 pub type TraitMap = @HashMap<node_id,@DVec<def_id>>;
@@ -5318,21 +5322,23 @@ pub impl Resolver {
     }
 }
 
+pub struct CrateMap {
+    def_map: DefMap,
+    exp_map2: ExportMap2,
+    trait_map: TraitMap
+}
+
 /// Entry point to crate resolution.
 pub fn resolve_crate(session: Session,
                      lang_items: LanguageItems,
                      crate: @crate)
-                  -> {
-                    def_map: DefMap,
-                    exp_map2: ExportMap2,
-                    trait_map: TraitMap
-                  } {
+                  -> CrateMap {
     let resolver = @Resolver(session, lang_items, crate);
     resolver.resolve(resolver);
-    return {
+    CrateMap {
         def_map: resolver.def_map,
         exp_map2: resolver.export_map2,
         trait_map: resolver.trait_map
-    };
+    }
 }
 

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -854,7 +854,7 @@ pub fn extract_variant_args(bcx: block,
         GEP_enum(bcx, blobptr, vdefs_tg, vdefs_var,
                  /*bad*/copy enum_ty_substs, i)
     };
-    
+
     ExtractedBlock { vals: args, bcx: bcx }
 }
 

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -189,7 +189,7 @@ pub enum Lit {
 // range)
 pub enum Opt {
     lit(Lit),
-    var(/* disr val */int, /* variant dids */{enm: def_id, var: def_id}),
+    var(/* disr val */int, /* variant dids (enm, var) */(def_id, def_id)),
     range(@ast::expr, @ast::expr),
     vec_len_eq(uint),
     vec_len_ge(uint)
@@ -287,7 +287,7 @@ pub fn variant_opt(tcx: ty::ctxt, pat_id: ast::node_id) -> Opt {
             let variants = ty::enum_variants(tcx, enum_id);
             for vec::each(*variants) |v| {
                 if var_id == v.id {
-                    return var(v.disr_val, {enm: enum_id, var: var_id});
+                    return var(v.disr_val, (enum_id, var_id));
                 }
             }
             ::core::util::unreachable();
@@ -760,7 +760,7 @@ pub fn enter_region(bcx: block,
 // Returns the options in one column of matches. An option is something that
 // needs to be conditionally matched at runtime; for example, the discriminant
 // on a set of enum variants or a literal.
-pub fn get_options(ccx: @crate_ctxt, m: &[@Match], col: uint) -> ~[Opt] {
+pub fn get_options(ccx: @CrateContext, m: &[@Match], col: uint) -> ~[Opt] {
     fn add_to_set(tcx: ty::ctxt, set: &DVec<Opt>, val: Opt) {
         if set.any(|l| opt_eq(tcx, l, &val)) {return;}
         set.push(val);
@@ -819,36 +819,43 @@ pub fn get_options(ccx: @crate_ctxt, m: &[@Match], col: uint) -> ~[Opt] {
     return dvec::unwrap(found);
 }
 
+pub struct ExtractedBlock {
+    vals: ~[ValueRef],
+    bcx: block
+}
+
 pub fn extract_variant_args(bcx: block,
                             pat_id: ast::node_id,
-                            vdefs: {enm: def_id, var: def_id},
+                            vdefs: (def_id, def_id),
                             val: ValueRef)
-                         -> {vals: ~[ValueRef], bcx: block} {
+                         -> ExtractedBlock {
+    let (enm, evar) = vdefs;
     let _icx = bcx.insn_ctxt("match::extract_variant_args");
     let ccx = bcx.fcx.ccx;
     let enum_ty_substs = match ty::get(node_id_type(bcx, pat_id)).sty {
       ty::ty_enum(id, ref substs) => {
-        assert id == vdefs.enm;
+        assert id == enm;
         /*bad*/copy (*substs).tps
       }
       _ => bcx.sess().bug(~"extract_variant_args: pattern has non-enum type")
     };
     let mut blobptr = val;
-    let variants = ty::enum_variants(ccx.tcx, vdefs.enm);
-    let size = ty::enum_variant_with_id(ccx.tcx, vdefs.enm,
-                                        vdefs.var).args.len();
+    let variants = ty::enum_variants(ccx.tcx, enm);
+    let size = ty::enum_variant_with_id(ccx.tcx, enm,
+                                        evar).args.len();
     if size > 0u && (*variants).len() != 1u {
         let enumptr =
             PointerCast(bcx, val, T_opaque_enum_ptr(ccx));
         blobptr = GEPi(bcx, enumptr, [0u, 1u]);
     }
-    let vdefs_tg = vdefs.enm;
-    let vdefs_var = vdefs.var;
+    let vdefs_tg = enm;
+    let vdefs_var = evar;
     let args = do vec::from_fn(size) |i| {
         GEP_enum(bcx, blobptr, vdefs_tg, vdefs_var,
                  /*bad*/copy enum_ty_substs, i)
     };
-    return {vals: args, bcx: bcx};
+    
+    ExtractedBlock { vals: args, bcx: bcx }
 }
 
 pub fn extract_vec_elems(bcx: block,
@@ -856,7 +863,7 @@ pub fn extract_vec_elems(bcx: block,
                          elem_count: uint,
                          tail: bool,
                          val: ValueRef)
-                      -> {vals: ~[ValueRef], bcx: block} {
+                      -> ExtractedBlock {
     let _icx = bcx.insn_ctxt("match::extract_vec_elems");
     let vt = tvec::vec_types(bcx, node_id_type(bcx, pat_id));
     let unboxed = load_if_immediate(bcx, val, vt.vec_ty);
@@ -885,7 +892,8 @@ pub fn extract_vec_elems(bcx: block,
         elems.push(scratch.val);
         scratch.add_clean(bcx);
     }
-    return {vals: elems, bcx: bcx};
+
+    ExtractedBlock { vals: elems, bcx: bcx }
 }
 
 // NB: This function does not collect fields from struct-like enum variants.
@@ -1360,8 +1368,8 @@ pub fn compile_submatch(bcx: block,
     let mut test_val = val;
     if opts.len() > 0u {
         match opts[0] {
-            var(_, vdef) => {
-                if (*ty::enum_variants(tcx, vdef.enm)).len() == 1u {
+            var(_, (enm, _)) => {
+                if (*ty::enum_variants(tcx, enm)).len() == 1u {
                     kind = single;
                 } else {
                     let enumptr =

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -37,7 +37,7 @@ use lib::llvm::{ModuleRef, ValueRef, TypeRef, BasicBlockRef};
 use lib::llvm::{True, False};
 use lib::llvm::{llvm, mk_target_data, mk_type_names};
 use lib;
-use metadata::common::link_meta;
+use metadata::common::LinkMeta;
 use metadata::{csearch, cstore, decoder, encoder};
 use middle::astencode;
 use middle::borrowck::RootInfo;
@@ -90,7 +90,7 @@ use syntax::visit::vt;
 use syntax::{ast, ast_util, codemap, ast_map};
 
 pub struct icx_popper {
-    ccx: @crate_ctxt,
+    ccx: @CrateContext,
     drop {
       if self.ccx.sess.count_llvm_insns() {
           self.ccx.stats.llvm_insn_ctxt.pop();
@@ -98,7 +98,7 @@ pub struct icx_popper {
     }
 }
 
-pub fn icx_popper(ccx: @crate_ctxt) -> icx_popper {
+pub fn icx_popper(ccx: @CrateContext) -> icx_popper {
     icx_popper {
         ccx: ccx
     }
@@ -108,7 +108,7 @@ pub trait get_insn_ctxt {
     fn insn_ctxt(s: &str) -> icx_popper;
 }
 
-pub impl get_insn_ctxt for @crate_ctxt {
+pub impl get_insn_ctxt for @CrateContext {
     fn insn_ctxt(s: &str) -> icx_popper {
         debug!("new insn_ctxt: %s", s);
         if self.sess.count_llvm_insns() {
@@ -130,11 +130,11 @@ pub impl get_insn_ctxt for fn_ctxt {
     }
 }
 
-pub fn log_fn_time(ccx: @crate_ctxt, +name: ~str, start: time::Timespec,
+pub fn log_fn_time(ccx: @CrateContext, +name: ~str, start: time::Timespec,
                    end: time::Timespec) {
     let elapsed = 1000 * ((end.sec - start.sec) as int) +
         ((end.nsec as int) - (start.nsec as int)) / 1000000;
-    ccx.stats.fn_times.push({ident: name, time: elapsed});
+    ccx.stats.fn_times.push((name, elapsed));
 }
 
 pub fn decl_fn(llmod: ModuleRef, name: &str, cc: lib::llvm::CallConv,
@@ -339,38 +339,45 @@ pub fn malloc_raw(bcx: block, t: ty::t, heap: heap) -> Result {
     malloc_raw_dyn(bcx, t, heap, llsize_of(bcx.ccx(), type_of(bcx.ccx(), t)))
 }
 
+pub struct MallocResult {
+    bcx: block,
+    box: ValueRef,
+    body: ValueRef
+}
+
 // malloc_general_dyn: usefully wraps malloc_raw_dyn; allocates a box,
 // and pulls out the body
 pub fn malloc_general_dyn(bcx: block, t: ty::t, heap: heap, size: ValueRef)
-    -> {bcx: block, box: ValueRef, body: ValueRef} {
+    -> MallocResult {
     let _icx = bcx.insn_ctxt("malloc_general");
     let Result {bcx: bcx, val: llbox} = malloc_raw_dyn(bcx, t, heap, size);
     let non_gc_box = non_gc_box_cast(bcx, llbox);
     let body = GEPi(bcx, non_gc_box, [0u, abi::box_field_body]);
-    return {bcx: bcx, box: llbox, body: body};
+    
+    MallocResult { bcx: bcx, box: llbox, body: body }
 }
 
 pub fn malloc_general(bcx: block, t: ty::t, heap: heap)
-    -> {bcx: block, box: ValueRef, body: ValueRef} {
+    -> MallocResult {
     malloc_general_dyn(bcx, t, heap,
                        llsize_of(bcx.ccx(), type_of(bcx.ccx(), t)))
 }
 pub fn malloc_boxed(bcx: block, t: ty::t)
-    -> {bcx: block, box: ValueRef, body: ValueRef} {
+    -> MallocResult {
     malloc_general(bcx, t, heap_shared)
 }
 pub fn malloc_unique(bcx: block, t: ty::t)
-    -> {bcx: block, box: ValueRef, body: ValueRef} {
+    -> MallocResult {
     malloc_general(bcx, t, heap_exchange)
 }
 
 // Type descriptor and type glue stuff
 
-pub fn get_tydesc_simple(ccx: @crate_ctxt, t: ty::t) -> ValueRef {
+pub fn get_tydesc_simple(ccx: @CrateContext, t: ty::t) -> ValueRef {
     get_tydesc(ccx, t).tydesc
 }
 
-pub fn get_tydesc(ccx: @crate_ctxt, t: ty::t) -> @mut tydesc_info {
+pub fn get_tydesc(ccx: @CrateContext, t: ty::t) -> @mut tydesc_info {
     match ccx.tydescs.find(&t) {
       Some(inf) => inf,
       _ => {
@@ -455,7 +462,7 @@ pub fn set_glue_inlining(f: ValueRef, t: ty::t) {
 
 // Double-check that we never ask LLVM to declare the same symbol twice. It
 // silently mangles such symbols, breaking our linkage model.
-pub fn note_unique_llvm_symbol(ccx: @crate_ctxt, +sym: ~str) {
+pub fn note_unique_llvm_symbol(ccx: @CrateContext, +sym: ~str) {
     if ccx.all_llvm_symbols.contains_key(&sym) {
         ccx.sess.bug(~"duplicate LLVM symbol: " + sym);
     }
@@ -463,7 +470,7 @@ pub fn note_unique_llvm_symbol(ccx: @crate_ctxt, +sym: ~str) {
 }
 
 
-pub fn get_res_dtor(ccx: @crate_ctxt, did: ast::def_id,
+pub fn get_res_dtor(ccx: @CrateContext, did: ast::def_id,
                     parent_id: ast::def_id, substs: ~[ty::t])
    -> ValueRef {
     let _icx = ccx.insn_ctxt("trans_res_dtor");
@@ -472,7 +479,8 @@ pub fn get_res_dtor(ccx: @crate_ctxt, did: ast::def_id,
             inline::maybe_instantiate_inline(ccx, did, true)
         } else { did };
         assert did.crate == ast::local_crate;
-        monomorphize::monomorphic_fn(ccx, did, substs, None, None, None).val
+        let (val, _) = monomorphize::monomorphic_fn(ccx, did, substs, None, None, None);
+        val
     } else if did.crate == ast::local_crate {
         get_item_val(ccx, did.node)
     } else {
@@ -488,7 +496,7 @@ pub fn get_res_dtor(ccx: @crate_ctxt, did: ast::def_id,
 }
 
 // Structural comparison: a rather involved form of glue.
-pub fn maybe_name_value(cx: @crate_ctxt, v: ValueRef, s: ~str) {
+pub fn maybe_name_value(cx: @CrateContext, v: ValueRef, s: ~str) {
     if cx.sess.opts.save_temps {
         let _: () = str::as_c_str(s, |buf| {
             unsafe {
@@ -784,7 +792,7 @@ pub fn null_env_ptr(bcx: block) -> ValueRef {
     C_null(T_opaque_box_ptr(bcx.ccx()))
 }
 
-pub fn trans_external_path(ccx: @crate_ctxt, did: ast::def_id, t: ty::t)
+pub fn trans_external_path(ccx: @CrateContext, did: ast::def_id, t: ty::t)
     -> ValueRef {
     let name = csearch::get_symbol(ccx.sess.cstore, did).to_managed(); // Sad
     match ty::get(t).sty {
@@ -800,7 +808,7 @@ pub fn trans_external_path(ccx: @crate_ctxt, did: ast::def_id, t: ty::t)
     };
 }
 
-pub fn get_discrim_val(cx: @crate_ctxt, span: span, enum_did: ast::def_id,
+pub fn get_discrim_val(cx: @CrateContext, span: span, enum_did: ast::def_id,
                        variant_did: ast::def_id) -> ValueRef {
     // Can't use `discrims` from the crate context here because
     // those discriminants have an extra level of indirection,
@@ -990,7 +998,7 @@ pub fn add_root_cleanup(bcx: block,
         let mut bcx_sid = bcx;
         loop {
             bcx_sid = match bcx_sid.node_info {
-              Some({id, _}) if id == scope_id => {
+              Some(NodeInfo { id, _ }) if id == scope_id => {
                 return bcx_sid
               }
               _ => {
@@ -1042,16 +1050,15 @@ pub fn trans_trace(bcx: block, sp_opt: Option<span>, +trace_str: ~str) {
     let _icx = bcx.insn_ctxt("trans_trace");
     add_comment(bcx, trace_str);
     let V_trace_str = C_cstr(bcx.ccx(), trace_str);
-    let {V_filename, V_line} = match sp_opt {
+    let (V_filename, V_line) = match sp_opt {
       Some(sp) => {
         let sess = bcx.sess();
         let loc = sess.parse_sess.cm.lookup_char_pos(sp.lo);
-        {V_filename: C_cstr(bcx.ccx(), /*bad*/copy loc.file.name),
-         V_line: loc.line as int}
+        (C_cstr(bcx.ccx(), /*bad*/copy loc.file.name),
+         loc.line as int)
       }
       None => {
-        {V_filename: C_cstr(bcx.ccx(), ~"<runtime>"),
-         V_line: 0}
+        (C_cstr(bcx.ccx(), ~"<runtime>"), 0)
       }
     };
     let ccx = bcx.ccx();
@@ -1161,7 +1168,7 @@ pub fn trans_stmt(cx: block, s: ast::stmt) -> block {
 // You probably don't want to use this one. See the
 // next three functions instead.
 pub fn new_block(cx: fn_ctxt, parent: Option<block>, +kind: block_kind,
-                 is_lpad: bool, +name: ~str, opt_node_info: Option<node_info>)
+                 is_lpad: bool, +name: ~str, opt_node_info: Option<NodeInfo>)
     -> block {
 
     let s = if cx.ccx.sess.opts.save_temps || cx.ccx.sess.opts.debuginfo {
@@ -1197,14 +1204,14 @@ pub fn simple_block_scope() -> block_kind {
 }
 
 // Use this when you're at the top block of a function or the like.
-pub fn top_scope_block(fcx: fn_ctxt, opt_node_info: Option<node_info>)
+pub fn top_scope_block(fcx: fn_ctxt, opt_node_info: Option<NodeInfo>)
                     -> block {
     return new_block(fcx, None, simple_block_scope(), false,
                   ~"function top level", opt_node_info);
 }
 
 pub fn scope_block(bcx: block,
-                   opt_node_info: Option<node_info>,
+                   opt_node_info: Option<NodeInfo>,
                    +n: ~str) -> block {
     return new_block(bcx.fcx, Some(bcx), simple_block_scope(), bcx.is_lpad,
                   n, opt_node_info);
@@ -1214,7 +1221,7 @@ pub fn loop_scope_block(bcx: block,
                         loop_break: block,
                         loop_label: Option<ident>,
                         +n: ~str,
-                        opt_node_info: Option<node_info>) -> block {
+                        opt_node_info: Option<NodeInfo>) -> block {
     return new_block(bcx.fcx, Some(bcx), block_scope(scope_info {
         loop_break: Some(loop_break),
         loop_label: loop_label,
@@ -1302,7 +1309,10 @@ pub fn cleanup_and_leave(bcx: block,
             }
             let sub_cx = sub_block(bcx, ~"cleanup");
             Br(bcx, sub_cx.llbb);
-            (*inf).cleanup_paths.push({target: leave, dest: sub_cx.llbb});
+            (*inf).cleanup_paths.push(cleanup_path {
+                target: leave,
+                dest: sub_cx.llbb
+            });
             bcx = trans_block_cleanups_(sub_cx, block_cleanups(cur), is_lpad);
           }
           _ => ()
@@ -1336,7 +1346,7 @@ pub fn leave_block(bcx: block, out_of: block) -> block {
 }
 
 pub fn with_scope(bcx: block,
-                  opt_node_info: Option<node_info>,
+                  opt_node_info: Option<NodeInfo>,
                   +name: ~str,
                   f: fn(block) -> block) -> block {
     let _icx = bcx.insn_ctxt("with_scope");
@@ -1351,7 +1361,7 @@ pub fn with_scope(bcx: block,
 }
 
 pub fn with_scope_result(bcx: block,
-                         opt_node_info: Option<node_info>,
+                         opt_node_info: Option<NodeInfo>,
                          +name: ~str,
                          f: fn(block) -> Result) -> Result {
     let _icx = bcx.insn_ctxt("with_scope_result");
@@ -1361,7 +1371,7 @@ pub fn with_scope_result(bcx: block,
     rslt(leave_block(bcx, scope_cx), val)
 }
 
-pub fn with_scope_datumblock(bcx: block, opt_node_info: Option<node_info>,
+pub fn with_scope_datumblock(bcx: block, opt_node_info: Option<NodeInfo>,
                              +name: ~str, f: fn(block) -> datum::DatumBlock)
                           -> datum::DatumBlock {
     use middle::trans::datum::DatumBlock;
@@ -1529,14 +1539,20 @@ pub fn arrayalloca(cx: block, t: TypeRef, v: ValueRef) -> ValueRef {
         base::raw_block(cx.fcx, false, cx.fcx.llstaticallocas), t, v);
 }
 
+pub struct BasicBlocks {
+    sa: BasicBlockRef,
+    rt: BasicBlockRef
+}
+
 // Creates the standard set of basic blocks for a function
-pub fn mk_standard_basic_blocks(llfn: ValueRef) ->
-   {sa: BasicBlockRef, rt: BasicBlockRef} {
+pub fn mk_standard_basic_blocks(llfn: ValueRef) -> BasicBlocks {
     unsafe {
-        {sa: str::as_c_str(~"static_allocas",
+        BasicBlocks {
+            sa: str::as_c_str(~"static_allocas",
                            |buf| llvm::LLVMAppendBasicBlock(llfn, buf)),
-         rt: str::as_c_str(~"return",
-                           |buf| llvm::LLVMAppendBasicBlock(llfn, buf))}
+            rt: str::as_c_str(~"return",
+                           |buf| llvm::LLVMAppendBasicBlock(llfn, buf))
+        }
     }
 }
 
@@ -1547,7 +1563,7 @@ pub fn mk_standard_basic_blocks(llfn: ValueRef) ->
 //  - create_llargs_for_fn_args.
 //  - new_fn_ctxt
 //  - trans_args
-pub fn new_fn_ctxt_w_id(ccx: @crate_ctxt,
+pub fn new_fn_ctxt_w_id(ccx: @CrateContext,
                         +path: path,
                         llfndecl: ValueRef,
                         id: ast::node_id,
@@ -1577,7 +1593,7 @@ pub fn new_fn_ctxt_w_id(ccx: @crate_ctxt,
     };
 }
 
-pub fn new_fn_ctxt(ccx: @crate_ctxt,
+pub fn new_fn_ctxt(ccx: @CrateContext,
                    +path: path,
                    llfndecl: ValueRef,
                    sp: Option<span>)
@@ -1735,7 +1751,7 @@ pub enum self_arg { impl_self(ty::t), impl_owned_self(ty::t), no_self, }
 // trans_closure: Builds an LLVM function out of a source function.
 // If the function closes over its environment a closure will be
 // returned.
-pub fn trans_closure(ccx: @crate_ctxt,
+pub fn trans_closure(ccx: @CrateContext,
                      +path: path,
                      decl: &ast::fn_decl,
                      body: &ast::blk,
@@ -1799,7 +1815,7 @@ pub fn trans_closure(ccx: @crate_ctxt,
 
 // trans_fn: creates an LLVM function corresponding to a source language
 // function.
-pub fn trans_fn(ccx: @crate_ctxt,
+pub fn trans_fn(ccx: @CrateContext,
                 +path: path,
                 decl: &ast::fn_decl,
                 body: &ast::blk,
@@ -1829,7 +1845,7 @@ pub fn trans_fn(ccx: @crate_ctxt,
     }
 }
 
-pub fn trans_enum_variant(ccx: @crate_ctxt,
+pub fn trans_enum_variant(ccx: @CrateContext,
                           enum_id: ast::node_id,
                           variant: ast::variant,
                           args: ~[ast::variant_arg],
@@ -1894,7 +1910,7 @@ pub fn trans_enum_variant(ccx: @crate_ctxt,
 
 // NB: In theory this should be merged with the function above. But the AST
 // structures are completely different, so very little code would be shared.
-pub fn trans_tuple_struct(ccx: @crate_ctxt,
+pub fn trans_tuple_struct(ccx: @CrateContext,
                           fields: ~[@ast::struct_field],
                           ctor_id: ast::node_id,
                           param_substs: Option<@param_substs>,
@@ -1947,7 +1963,7 @@ pub fn trans_tuple_struct(ccx: @crate_ctxt,
     finish_fn(fcx, lltop);
 }
 
-pub fn trans_struct_dtor(ccx: @crate_ctxt,
+pub fn trans_struct_dtor(ccx: @CrateContext,
                          +path: path,
                          body: &ast::blk,
                          dtor_id: ast::node_id,
@@ -1986,7 +2002,7 @@ pub fn trans_struct_dtor(ccx: @crate_ctxt,
   lldecl
 }
 
-pub fn trans_enum_def(ccx: @crate_ctxt, enum_definition: ast::enum_def,
+pub fn trans_enum_def(ccx: @CrateContext, enum_definition: ast::enum_def,
                       id: ast::node_id, degen: bool,
                       path: @ast_map::path, vi: @~[ty::VariantInfo],
                       i: &mut uint) {
@@ -2020,7 +2036,7 @@ pub fn trans_enum_def(ccx: @crate_ctxt, enum_definition: ast::enum_def,
     }
 }
 
-pub fn trans_item(ccx: @crate_ctxt, item: ast::item) {
+pub fn trans_item(ccx: @CrateContext, item: ast::item) {
     let _icx = ccx.insn_ctxt("trans_item");
     let path = match ccx.tcx.items.get(&item.id) {
         ast_map::node_item(_, p) => p,
@@ -2087,7 +2103,7 @@ pub fn trans_item(ccx: @crate_ctxt, item: ast::item) {
     }
 }
 
-pub fn trans_struct_def(ccx: @crate_ctxt, struct_def: @ast::struct_def,
+pub fn trans_struct_def(ccx: @CrateContext, struct_def: @ast::struct_def,
                         path: @ast_map::path,
                         id: ast::node_id) {
     // Translate the destructor.
@@ -2114,7 +2130,7 @@ pub fn trans_struct_def(ccx: @crate_ctxt, struct_def: @ast::struct_def,
 // separate modules in the compiled program.  That's because modules exist
 // only as a convenience for humans working with the code, to organize names
 // and control visibility.
-pub fn trans_mod(ccx: @crate_ctxt, m: ast::_mod) {
+pub fn trans_mod(ccx: @CrateContext, m: ast::_mod) {
     let _icx = ccx.insn_ctxt("trans_mod");
     for vec::each(m.items) |item| {
         trans_item(ccx, **item);
@@ -2126,7 +2142,7 @@ pub fn get_pair_fn_ty(llpairty: TypeRef) -> TypeRef {
     return struct_elt(llpairty, 0u);
 }
 
-pub fn register_fn(ccx: @crate_ctxt,
+pub fn register_fn(ccx: @CrateContext,
                    sp: span,
                    +path: path,
                    node_id: ast::node_id,
@@ -2136,7 +2152,7 @@ pub fn register_fn(ccx: @crate_ctxt,
     register_fn_full(ccx, sp, path, node_id, attrs, t)
 }
 
-pub fn register_fn_full(ccx: @crate_ctxt,
+pub fn register_fn_full(ccx: @CrateContext,
                         sp: span,
                         +path: path,
                         node_id: ast::node_id,
@@ -2148,7 +2164,7 @@ pub fn register_fn_full(ccx: @crate_ctxt,
                        lib::llvm::CCallConv, llfty)
 }
 
-pub fn register_fn_fuller(ccx: @crate_ctxt,
+pub fn register_fn_fuller(ccx: @CrateContext,
                           sp: span,
                           +path: path,
                           node_id: ast::node_id,
@@ -2189,12 +2205,12 @@ pub fn is_main_fn(sess: &Session, node_id: ast::node_id) -> bool {
 
 // Create a _rust_main(args: ~[str]) function which will be called from the
 // runtime rust_start function
-pub fn create_main_wrapper(ccx: @crate_ctxt, _sp: span, main_llfn: ValueRef) {
+pub fn create_main_wrapper(ccx: @CrateContext, _sp: span, main_llfn: ValueRef) {
 
     let llfn = create_main(ccx, main_llfn);
     create_entry_fn(ccx, llfn);
 
-    fn create_main(ccx: @crate_ctxt, main_llfn: ValueRef) -> ValueRef {
+    fn create_main(ccx: @CrateContext, main_llfn: ValueRef) -> ValueRef {
         let nt = ty::mk_nil(ccx.tcx);
         let llfty = type_of_fn(ccx, ~[], nt);
         let llfdecl = decl_fn(ccx.llmod, ~"_rust_main",
@@ -2216,7 +2232,7 @@ pub fn create_main_wrapper(ccx: @crate_ctxt, _sp: span, main_llfn: ValueRef) {
         return llfdecl;
     }
 
-    fn create_entry_fn(ccx: @crate_ctxt, rust_main: ValueRef) {
+    fn create_entry_fn(ccx: @CrateContext, rust_main: ValueRef) {
         #[cfg(windows)]
         fn main_name() -> ~str { return ~"WinMain@16"; }
         #[cfg(unix)]
@@ -2281,7 +2297,7 @@ pub fn fill_fn_pair(bcx: block, pair: ValueRef, llfn: ValueRef,
     Store(bcx, llenvblobptr, env_cell);
 }
 
-pub fn item_path(ccx: @crate_ctxt, i: @ast::item) -> path {
+pub fn item_path(ccx: @CrateContext, i: @ast::item) -> path {
     vec::append(
         /*bad*/copy *match ccx.tcx.items.get(&i.id) {
             ast_map::node_item(_, p) => p,
@@ -2293,7 +2309,7 @@ pub fn item_path(ccx: @crate_ctxt, i: @ast::item) -> path {
 
 /* If there's already a symbol for the dtor with <id> and substs <substs>,
    return it; otherwise, create one and register it, returning it as well */
-pub fn get_dtor_symbol(ccx: @crate_ctxt,
+pub fn get_dtor_symbol(ccx: @CrateContext,
                        +path: path,
                        id: ast::node_id,
                        substs: Option<@param_substs>)
@@ -2331,7 +2347,7 @@ pub fn get_dtor_symbol(ccx: @crate_ctxt,
   }
 }
 
-pub fn get_item_val(ccx: @crate_ctxt, id: ast::node_id) -> ValueRef {
+pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
     debug!("get_item_val(id=`%?`)", id);
     let tcx = ccx.tcx;
     match ccx.item_vals.find(&id) {
@@ -2500,7 +2516,7 @@ pub fn get_item_val(ccx: @crate_ctxt, id: ast::node_id) -> ValueRef {
     }
 }
 
-pub fn register_method(ccx: @crate_ctxt,
+pub fn register_method(ccx: @CrateContext,
                        id: ast::node_id,
                        pth: @ast_map::path,
                        m: @ast::method) -> ValueRef {
@@ -2513,7 +2529,7 @@ pub fn register_method(ccx: @crate_ctxt,
 }
 
 // The constant translation pass.
-pub fn trans_constant(ccx: @crate_ctxt, it: @ast::item) {
+pub fn trans_constant(ccx: @CrateContext, it: @ast::item) {
     let _icx = ccx.insn_ctxt("trans_constant");
     match it.node {
       ast::item_enum(ref enum_definition, _) => {
@@ -2550,7 +2566,7 @@ pub fn trans_constant(ccx: @crate_ctxt, it: @ast::item) {
     }
 }
 
-pub fn trans_constants(ccx: @crate_ctxt, crate: &ast::crate) {
+pub fn trans_constants(ccx: @CrateContext, crate: &ast::crate) {
     visit::visit_crate(
         *crate, (),
         visit::mk_simple_visitor(@visit::SimpleVisitor {
@@ -2564,7 +2580,7 @@ pub fn vp2i(cx: block, v: ValueRef) -> ValueRef {
     return PtrToInt(cx, v, ccx.int_type);
 }
 
-pub fn p2i(ccx: @crate_ctxt, v: ValueRef) -> ValueRef {
+pub fn p2i(ccx: @CrateContext, v: ValueRef) -> ValueRef {
     unsafe {
         return llvm::LLVMConstPtrToInt(v, ccx.int_type);
     }
@@ -2784,7 +2800,7 @@ pub fn trap(bcx: block) {
     }
 }
 
-pub fn decl_gc_metadata(ccx: @crate_ctxt, llmod_id: ~str) {
+pub fn decl_gc_metadata(ccx: @CrateContext, llmod_id: ~str) {
     if !ccx.sess.opts.gc || !ccx.uses_gc {
         return;
     }
@@ -2802,7 +2818,7 @@ pub fn decl_gc_metadata(ccx: @crate_ctxt, llmod_id: ~str) {
     }
 }
 
-pub fn create_module_map(ccx: @crate_ctxt) -> ValueRef {
+pub fn create_module_map(ccx: @CrateContext) -> ValueRef {
     let elttype = T_struct(~[ccx.int_type, ccx.int_type]);
     let maptype = T_array(elttype, ccx.module_data.len() + 1);
     let map = str::as_c_str(~"_rust_mod_map", |buf| {
@@ -2828,7 +2844,7 @@ pub fn create_module_map(ccx: @crate_ctxt) -> ValueRef {
 }
 
 
-pub fn decl_crate_map(sess: session::Session, mapmeta: link_meta,
+pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
                       llmod: ModuleRef) -> ValueRef {
     let targ_cfg = sess.targ_cfg;
     let int_type = T_int(targ_cfg);
@@ -2853,7 +2869,7 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: link_meta,
     return map;
 }
 
-pub fn fill_crate_map(ccx: @crate_ctxt, map: ValueRef) {
+pub fn fill_crate_map(ccx: @CrateContext, map: ValueRef) {
     let mut subcrates: ~[ValueRef] = ~[];
     let mut i = 1;
     let cstore = ccx.sess.cstore;
@@ -2894,12 +2910,12 @@ pub fn fill_crate_map(ccx: @crate_ctxt, map: ValueRef) {
     }
 }
 
-pub fn crate_ctxt_to_encode_parms(cx: @crate_ctxt) -> encoder::encode_parms {
+pub fn crate_ctxt_to_encode_parms(cx: @CrateContext) -> encoder::EncodeParams {
     let encode_inlined_item: encoder::encode_inlined_item =
         |ecx, ebml_w, path, ii|
         astencode::encode_inlined_item(ecx, ebml_w, path, ii, cx.maps);
 
-    return {
+    encoder::EncodeParams {
         diag: cx.sess.diagnostic(),
         tcx: cx.tcx,
         reachable: cx.reachable,
@@ -2909,10 +2925,10 @@ pub fn crate_ctxt_to_encode_parms(cx: @crate_ctxt) -> encoder::encode_parms {
         link_meta: /*bad*/copy cx.link_meta,
         cstore: cx.sess.cstore,
         encode_inlined_item: encode_inlined_item
-    };
+    }
 }
 
-pub fn write_metadata(cx: @crate_ctxt, crate: &ast::crate) {
+pub fn write_metadata(cx: @CrateContext, crate: &ast::crate) {
     if !*cx.sess.building_library { return; }
     let encode_parms = crate_ctxt_to_encode_parms(cx);
     let llmeta = C_bytes(encoder::encode_metadata(encode_parms, crate));
@@ -2940,7 +2956,7 @@ pub fn write_metadata(cx: @crate_ctxt, crate: &ast::crate) {
 }
 
 // Writes the current ABI version into the crate.
-pub fn write_abi_version(ccx: @crate_ctxt) {
+pub fn write_abi_version(ccx: @CrateContext) {
     mk_global(ccx, ~"rust_abi_version", C_uint(ccx, abi::abi_version),
                      false);
 }
@@ -2950,7 +2966,7 @@ pub fn trans_crate(sess: session::Session,
                    tcx: ty::ctxt,
                    output: &Path,
                    emap2: resolve::ExportMap2,
-                   maps: astencode::Maps) -> (ModuleRef, link_meta) {
+                   maps: astencode::Maps) -> (ModuleRef, LinkMeta) {
 
     let symbol_hasher = @hash::default_state();
     let link_meta =
@@ -3003,7 +3019,7 @@ pub fn trans_crate(sess: session::Session,
             None
         };
 
-        let ccx = @crate_ctxt {
+        let ccx = @CrateContext {
               sess: sess,
               llmod: llmod,
               td: td,

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -353,7 +353,7 @@ pub fn malloc_general_dyn(bcx: block, t: ty::t, heap: heap, size: ValueRef)
     let Result {bcx: bcx, val: llbox} = malloc_raw_dyn(bcx, t, heap, size);
     let non_gc_box = non_gc_box_cast(bcx, llbox);
     let body = GEPi(bcx, non_gc_box, [0u, abi::box_field_body]);
-    
+
     MallocResult { bcx: bcx, box: llbox, body: body }
 }
 
@@ -479,7 +479,9 @@ pub fn get_res_dtor(ccx: @CrateContext, did: ast::def_id,
             inline::maybe_instantiate_inline(ccx, did, true)
         } else { did };
         assert did.crate == ast::local_crate;
-        let (val, _) = monomorphize::monomorphic_fn(ccx, did, substs, None, None, None);
+        let (val, _) =
+            monomorphize::monomorphic_fn(ccx, did, substs, None, None, None);
+
         val
     } else if did.crate == ast::local_crate {
         get_item_val(ccx, did.node)
@@ -2205,7 +2207,8 @@ pub fn is_main_fn(sess: &Session, node_id: ast::node_id) -> bool {
 
 // Create a _rust_main(args: ~[str]) function which will be called from the
 // runtime rust_start function
-pub fn create_main_wrapper(ccx: @CrateContext, _sp: span, main_llfn: ValueRef) {
+pub fn create_main_wrapper(ccx: @CrateContext,
+                           _sp: span, main_llfn: ValueRef) {
 
     let llfn = create_main(ccx, main_llfn);
     create_entry_fn(ccx, llfn);
@@ -2910,7 +2913,8 @@ pub fn fill_crate_map(ccx: @CrateContext, map: ValueRef) {
     }
 }
 
-pub fn crate_ctxt_to_encode_parms(cx: @CrateContext) -> encoder::EncodeParams {
+pub fn crate_ctxt_to_encode_parms(cx: @CrateContext)
+    -> encoder::EncodeParams {
     let encode_inlined_item: encoder::encode_inlined_item =
         |ecx, ebml_w, path, ii|
         astencode::encode_inlined_item(ecx, ebml_w, path, ii, cx.maps);

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -131,7 +131,7 @@ pub impl EnvAction {
 }
 
 pub impl EnvValue {
-    fn to_str(ccx: @crate_ctxt) -> ~str {
+    fn to_str(ccx: @CrateContext) -> ~str {
         fmt!("%s(%s)", self.action.to_str(), self.datum.to_str(ccx))
     }
 }
@@ -192,11 +192,11 @@ pub fn allocate_cbox(bcx: block, sigil: ast::Sigil, cdata_ty: ty::t)
     }
 }
 
-pub type closure_result = {
-    llbox: ValueRef,     // llvalue of ptr to closure
-    cdata_ty: ty::t,      // type of the closure data
-    bcx: block     // final bcx
-};
+pub struct ClosureResult {
+    llbox: ValueRef, // llvalue of ptr to closure
+    cdata_ty: ty::t, // type of the closure data
+    bcx: block       // final bcx
+}
 
 // Given a block context and a list of tydescs and values to bind
 // construct a closure out of them. If copying is true, it is a
@@ -204,7 +204,7 @@ pub type closure_result = {
 // Otherwise, it is stack allocated and copies pointers to the upvars.
 pub fn store_environment(bcx: block,
                          bound_values: ~[EnvValue],
-                         sigil: ast::Sigil) -> closure_result {
+                         sigil: ast::Sigil) -> ClosureResult {
     let _icx = bcx.insn_ctxt("closure::store_environment");
     let ccx = bcx.ccx(), tcx = ccx.tcx;
 
@@ -254,7 +254,7 @@ pub fn store_environment(bcx: block,
         revoke_clean(bcx, *cleanup);
     }
 
-    return {llbox: llbox, cdata_ty: cdata_ty, bcx: bcx};
+    ClosureResult { llbox: llbox, cdata_ty: cdata_ty, bcx: bcx }
 }
 
 // Given a context and a list of upvars, build a closure. This just
@@ -262,7 +262,7 @@ pub fn store_environment(bcx: block,
 pub fn build_closure(bcx0: block,
                      cap_vars: &[moves::CaptureVar],
                      sigil: ast::Sigil,
-                     include_ret_handle: Option<ValueRef>) -> closure_result {
+                     include_ret_handle: Option<ValueRef>) -> ClosureResult {
     let _icx = bcx0.insn_ctxt("closure::build_closure");
     // If we need to, package up the iterator body to call
     let mut bcx = bcx0;;
@@ -302,7 +302,7 @@ pub fn build_closure(bcx0: block,
         // Return value (we just pass a by-ref () and cast it later to
         // the right thing):
         let ret_true = match bcx.fcx.loop_ret {
-            Some({retptr, _}) => retptr,
+            Some((retptr, _)) => retptr,
             None => bcx.fcx.llretptr
         };
         let ret_casted = PointerCast(bcx, ret_true, T_ptr(T_nil()));
@@ -360,7 +360,7 @@ pub fn load_environment(fcx: fn_ctxt,
         let flagptr = Load(bcx, GEPi(bcx, llcdata, [0u, i]));
         let retptr = Load(bcx,
                           GEPi(bcx, llcdata, [0u, i+1u]));
-        fcx.loop_ret = Some({flagptr: flagptr, retptr: retptr});
+        fcx.loop_ret = Some((flagptr, retptr));
     }
 }
 
@@ -418,8 +418,8 @@ pub fn trans_expr_fn(bcx: block,
             let cap_vars = ccx.maps.capture_map.get(&user_id);
             let ret_handle = match is_loop_body {Some(x) => x,
                                                  None => None};
-            let {llbox, cdata_ty, bcx} = build_closure(bcx, cap_vars, sigil,
-                                                       ret_handle);
+            let ClosureResult {llbox, cdata_ty, bcx}
+                = build_closure(bcx, cap_vars, sigil, ret_handle);
             trans_closure(ccx, sub_path, decl,
                           body, llfn, no_self,
                           /*bad*/ copy bcx.fcx.param_substs, user_id, None,

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -21,9 +21,9 @@ use driver::session;
 use driver::session::Session;
 use lib::llvm::{ModuleRef, ValueRef, TypeRef, BasicBlockRef, BuilderRef};
 use lib::llvm::{True, False, Bool};
-use lib::llvm::{llvm, target_data, type_names, associate_type, name_has_type};
+use lib::llvm::{llvm, TargetData, TypeNames, associate_type, name_has_type};
 use lib;
-use metadata::common::link_meta;
+use metadata::common::LinkMeta;
 use metadata::{csearch};
 use middle::astencode;
 use middle::resolve;
@@ -136,7 +136,7 @@ pub struct Stats {
     n_closures: uint,
     llvm_insn_ctxt: @mut ~[~str],
     llvm_insns: HashMap<~str, uint>,
-    fn_times: @mut ~[{ident: ~str, time: int}]
+    fn_times: @mut ~[(~str, int)] // (ident, time)
 }
 
 pub struct BuilderRef_res {
@@ -157,18 +157,18 @@ pub fn BuilderRef_res(B: BuilderRef) -> BuilderRef_res {
 type ExternMap = HashMap<@str, ValueRef>;
 
 // Crate context.  Every crate we compile has one of these.
-pub struct crate_ctxt {
+pub struct CrateContext {
      sess: session::Session,
      llmod: ModuleRef,
-     td: target_data,
-     tn: type_names,
+     td: TargetData,
+     tn: @TypeNames,
      externs: ExternMap,
      intrinsics: HashMap<~str, ValueRef>,
      item_vals: HashMap<ast::node_id, ValueRef>,
      exp_map2: resolve::ExportMap2,
      reachable: reachable::map,
      item_symbols: HashMap<ast::node_id, ~str>,
-     link_meta: link_meta,
+     link_meta: LinkMeta,
      enum_sizes: HashMap<ty::t, uint>,
      discrims: HashMap<ast::def_id, ValueRef>,
      discrim_symbols: HashMap<ast::node_id, ~str>,
@@ -212,7 +212,7 @@ pub struct crate_ctxt {
      tcx: ty::ctxt,
      maps: astencode::Maps,
      stats: @mut Stats,
-     upcalls: @upcall::upcalls,
+     upcalls: @upcall::Upcalls,
      tydesc_type: TypeRef,
      int_type: TypeRef,
      float_type: TypeRef,
@@ -225,7 +225,7 @@ pub struct crate_ctxt {
      // decl_gc_metadata knows whether to link to the module metadata, which
      // is not emitted by LLVM's GC pass when no functions use GC.
      mut uses_gc: bool,
-     dbg_cx: Option<debuginfo::debug_ctxt>,
+     dbg_cx: Option<debuginfo::DebugContext>,
      mut do_not_commit_warning_issued: bool
 }
 
@@ -291,8 +291,8 @@ pub struct fn_ctxt_ {
     // outputting the resume instruction.
     mut personality: Option<ValueRef>,
     // If this is a for-loop body that returns, this holds the pointers needed
-    // for that
-    mut loop_ret: Option<{flagptr: ValueRef, retptr: ValueRef}>,
+    // for that (flagptr, retptr)
+    mut loop_ret: Option<(ValueRef, ValueRef)>,
 
     // Maps arguments to allocas created for them in llallocas.
     llargs: HashMap<ast::node_id, local_val>,
@@ -319,12 +319,12 @@ pub struct fn_ctxt_ {
     path: path,
 
     // This function's enclosing crate context.
-    ccx: @crate_ctxt
+    ccx: @CrateContext
 }
 
 pub type fn_ctxt = @fn_ctxt_;
 
-pub fn warn_not_to_commit(ccx: @crate_ctxt, msg: ~str) {
+pub fn warn_not_to_commit(ccx: @CrateContext, msg: ~str) {
     if !ccx.do_not_commit_warning_issued {
         ccx.do_not_commit_warning_issued = true;
         ccx.sess.warn(msg + ~" -- do not commit like this!");
@@ -350,7 +350,10 @@ pub enum cleanup {
 
 // Used to remember and reuse existing cleanup paths
 // target: none means the path ends in an resume instruction
-pub type cleanup_path = {target: Option<BasicBlockRef>, dest: BasicBlockRef};
+pub struct cleanup_path {
+    target: Option<BasicBlockRef>,
+    dest: BasicBlockRef
+}
 
 pub fn scope_clean_changed(scope_info: scope_info) {
     if scope_info.cleanup_paths.len() > 0u { scope_info.cleanup_paths = ~[]; }
@@ -372,7 +375,7 @@ pub fn cleanup_type(cx: ty::ctxt, ty: ty::t) -> cleantype {
 // non-immediates, we must add an additional level of indirection, which
 // allows us to alloca a pointer with the right addrspace.
 pub fn root_for_cleanup(bcx: block, v: ValueRef, t: ty::t)
-    -> {root: ValueRef, rooted: bool} {
+    -> (ValueRef, bool) {
     let ccx = bcx.ccx();
 
     let addrspace = base::get_tydesc(ccx, t).addrspace;
@@ -380,9 +383,9 @@ pub fn root_for_cleanup(bcx: block, v: ValueRef, t: ty::t)
         let llty = type_of::type_of_rooted(ccx, t);
         let root = base::alloca(bcx, llty);
         build::Store(bcx, build::PointerCast(bcx, v, llty), root);
-        {root: root, rooted: true}
+        (root, true)
     } else {
-        {root: v, rooted: false}
+        (v, false)
     }
 }
 
@@ -391,7 +394,7 @@ pub fn add_clean(bcx: block, val: ValueRef, t: ty::t) {
     debug!("add_clean(%s, %s, %s)",
            bcx.to_str(), val_str(bcx.ccx().tn, val),
            ty_to_str(bcx.ccx().tcx, t));
-    let {root, rooted} = root_for_cleanup(bcx, val, t);
+    let (root, rooted) = root_for_cleanup(bcx, val, t);
     let cleanup_type = cleanup_type(bcx.tcx(), t);
     do in_scope_cx(bcx) |scope_info| {
         scope_info.cleanups.push(
@@ -419,7 +422,7 @@ pub fn add_clean_temp_mem(bcx: block, val: ValueRef, t: ty::t) {
     debug!("add_clean_temp_mem(%s, %s, %s)",
            bcx.to_str(), val_str(bcx.ccx().tn, val),
            ty_to_str(bcx.ccx().tcx, t));
-    let {root, rooted} = root_for_cleanup(bcx, val, t);
+    let (root, rooted) = root_for_cleanup(bcx, val, t);
     let cleanup_type = cleanup_type(bcx.tcx(), t);
     do in_scope_cx(bcx) |scope_info| {
         scope_info.cleanups.push(
@@ -432,7 +435,7 @@ pub fn add_clean_frozen_root(bcx: block, val: ValueRef, t: ty::t) {
     debug!("add_clean_frozen_root(%s, %s, %s)",
            bcx.to_str(), val_str(bcx.ccx().tn, val),
            ty_to_str(bcx.ccx().tcx, t));
-    let {root, rooted} = root_for_cleanup(bcx, val, t);
+    let (root, rooted) = root_for_cleanup(bcx, val, t);
     let cleanup_type = cleanup_type(bcx.tcx(), t);
     do in_scope_cx(bcx) |scope_info| {
         scope_info.cleanups.push(
@@ -530,18 +533,18 @@ pub struct scope_info {
 }
 
 pub trait get_node_info {
-    fn info() -> Option<node_info>;
+    fn info() -> Option<NodeInfo>;
 }
 
 pub impl get_node_info for @ast::expr {
-    fn info() -> Option<node_info> {
-        Some({id: self.id, span: self.span})
+    fn info() -> Option<NodeInfo> {
+        Some(NodeInfo { id: self.id, span: self.span })
     }
 }
 
 pub impl get_node_info for ast::blk {
-    fn info() -> Option<node_info> {
-        Some({id: self.node.id, span: self.span})
+    fn info() -> Option<NodeInfo> {
+        Some(NodeInfo { id: self.node.id, span: self.span })
     }
 }
 
@@ -549,15 +552,15 @@ pub impl get_node_info for ast::blk {
 pub type optional_boxed_ast_expr = Option<@ast::expr>;
 
 pub impl get_node_info for optional_boxed_ast_expr {
-    fn info() -> Option<node_info> {
+    fn info() -> Option<NodeInfo> {
         self.chain_ref(|s| s.info())
     }
 }
 
-pub type node_info = {
+pub struct NodeInfo {
     id: ast::node_id,
     span: span
-};
+}
 
 // Basic block context.  We create a block context for each basic block
 // (single-entry, single-exit sequence of instructions) we generate from Rust
@@ -579,14 +582,14 @@ pub struct block_ {
     // Is this block part of a landing pad?
     is_lpad: bool,
     // info about the AST node this block originated from, if any
-    node_info: Option<node_info>,
+    node_info: Option<NodeInfo>,
     // The function context for the function to which this block is
     // attached.
     fcx: fn_ctxt
 }
 
 pub fn block_(llbb: BasicBlockRef, parent: Option<block>, -kind: block_kind,
-              is_lpad: bool, node_info: Option<node_info>, fcx: fn_ctxt)
+              is_lpad: bool, node_info: Option<NodeInfo>, fcx: fn_ctxt)
     -> block_ {
 
     block_ {
@@ -606,7 +609,7 @@ pub fn block_(llbb: BasicBlockRef, parent: Option<block>, -kind: block_kind,
 pub enum block = @block_;
 
 pub fn mk_block(llbb: BasicBlockRef, parent: Option<block>, -kind: block_kind,
-            is_lpad: bool, node_info: Option<node_info>, fcx: fn_ctxt)
+            is_lpad: bool, node_info: Option<NodeInfo>, fcx: fn_ctxt)
     -> block {
     block(@block_(llbb, parent, kind, is_lpad, node_info, fcx))
 }
@@ -630,7 +633,7 @@ pub impl Result {
     }
 }
 
-pub fn ty_str(tn: type_names, t: TypeRef) -> @str {
+pub fn ty_str(tn: @TypeNames, t: TypeRef) -> @str {
     return lib::llvm::type_to_str(tn, t);
 }
 
@@ -640,7 +643,7 @@ pub fn val_ty(v: ValueRef) -> TypeRef {
     }
 }
 
-pub fn val_str(tn: type_names, v: ValueRef) -> @str {
+pub fn val_str(tn: @TypeNames, v: ValueRef) -> @str {
     return ty_str(tn, val_ty(v));
 }
 
@@ -684,7 +687,7 @@ pub fn block_parent(cx: block) -> block {
 // Accessors
 
 pub impl block {
-    pure fn ccx() -> @crate_ctxt { self.fcx.ccx }
+    pure fn ccx() -> @CrateContext { self.fcx.ccx }
     pure fn tcx() -> ty::ctxt { self.fcx.ccx.tcx }
     pure fn sess() -> Session { self.fcx.ccx.sess }
 
@@ -774,7 +777,7 @@ pub fn T_int(targ_cfg: @session::config) -> TypeRef {
     };
 }
 
-pub fn T_int_ty(cx: @crate_ctxt, t: ast::int_ty) -> TypeRef {
+pub fn T_int_ty(cx: @CrateContext, t: ast::int_ty) -> TypeRef {
     match t {
       ast::ty_i => cx.int_type,
       ast::ty_char => T_char(),
@@ -785,7 +788,7 @@ pub fn T_int_ty(cx: @crate_ctxt, t: ast::int_ty) -> TypeRef {
     }
 }
 
-pub fn T_uint_ty(cx: @crate_ctxt, t: ast::uint_ty) -> TypeRef {
+pub fn T_uint_ty(cx: @CrateContext, t: ast::uint_ty) -> TypeRef {
     match t {
       ast::ty_u => cx.int_type,
       ast::ty_u8 => T_i8(),
@@ -795,7 +798,7 @@ pub fn T_uint_ty(cx: @crate_ctxt, t: ast::uint_ty) -> TypeRef {
     }
 }
 
-pub fn T_float_ty(cx: @crate_ctxt, t: ast::float_ty) -> TypeRef {
+pub fn T_float_ty(cx: @CrateContext, t: ast::float_ty) -> TypeRef {
     match t {
       ast::ty_f => cx.float_type,
       ast::ty_f32 => T_f32(),
@@ -825,7 +828,7 @@ pub fn T_fn(inputs: ~[TypeRef], output: TypeRef) -> TypeRef {
     }
 }
 
-pub fn T_fn_pair(cx: @crate_ctxt, tfn: TypeRef) -> TypeRef {
+pub fn T_fn_pair(cx: @CrateContext, tfn: TypeRef) -> TypeRef {
     return T_struct(~[T_ptr(tfn), T_opaque_cbox_ptr(cx)]);
 }
 
@@ -895,7 +898,7 @@ pub fn T_task(targ_cfg: @session::config) -> TypeRef {
     return t;
 }
 
-pub fn T_tydesc_field(cx: @crate_ctxt, field: uint) -> TypeRef {
+pub fn T_tydesc_field(cx: @CrateContext, field: uint) -> TypeRef {
     // Bit of a kludge: pick the fn typeref out of the tydesc..
 
     unsafe {
@@ -910,7 +913,7 @@ pub fn T_tydesc_field(cx: @crate_ctxt, field: uint) -> TypeRef {
     }
 }
 
-pub fn T_generic_glue_fn(cx: @crate_ctxt) -> TypeRef {
+pub fn T_generic_glue_fn(cx: @CrateContext) -> TypeRef {
     let s = @"glue_fn";
     match name_has_type(cx.tn, s) {
       Some(t) => return t,
@@ -951,7 +954,7 @@ pub fn T_vec2(targ_cfg: @session::config, t: TypeRef) -> TypeRef {
                   T_array(t, 0u)]); // elements
 }
 
-pub fn T_vec(ccx: @crate_ctxt, t: TypeRef) -> TypeRef {
+pub fn T_vec(ccx: @CrateContext, t: TypeRef) -> TypeRef {
     return T_vec2(ccx.sess.targ_cfg, t);
 }
 
@@ -973,16 +976,16 @@ pub fn tuplify_box_ty(tcx: ty::ctxt, t: ty::t) -> ty::t {
                          t]);
 }
 
-pub fn T_box_header_fields(cx: @crate_ctxt) -> ~[TypeRef] {
+pub fn T_box_header_fields(cx: @CrateContext) -> ~[TypeRef] {
     let ptr = T_ptr(T_i8());
     return ~[cx.int_type, T_ptr(cx.tydesc_type), ptr, ptr];
 }
 
-pub fn T_box_header(cx: @crate_ctxt) -> TypeRef {
+pub fn T_box_header(cx: @CrateContext) -> TypeRef {
     return T_struct(T_box_header_fields(cx));
 }
 
-pub fn T_box(cx: @crate_ctxt, t: TypeRef) -> TypeRef {
+pub fn T_box(cx: @CrateContext, t: TypeRef) -> TypeRef {
     return T_struct(vec::append(T_box_header_fields(cx), ~[t]));
 }
 
@@ -992,15 +995,15 @@ pub fn T_box_ptr(t: TypeRef) -> TypeRef {
     }
 }
 
-pub fn T_opaque_box(cx: @crate_ctxt) -> TypeRef {
+pub fn T_opaque_box(cx: @CrateContext) -> TypeRef {
     return T_box(cx, T_i8());
 }
 
-pub fn T_opaque_box_ptr(cx: @crate_ctxt) -> TypeRef {
+pub fn T_opaque_box_ptr(cx: @CrateContext) -> TypeRef {
     return T_box_ptr(T_opaque_box(cx));
 }
 
-pub fn T_unique(cx: @crate_ctxt, t: TypeRef) -> TypeRef {
+pub fn T_unique(cx: @CrateContext, t: TypeRef) -> TypeRef {
     return T_struct(vec::append(T_box_header_fields(cx), ~[t]));
 }
 
@@ -1010,21 +1013,21 @@ pub fn T_unique_ptr(t: TypeRef) -> TypeRef {
     }
 }
 
-pub fn T_port(cx: @crate_ctxt, _t: TypeRef) -> TypeRef {
+pub fn T_port(cx: @CrateContext, _t: TypeRef) -> TypeRef {
     return T_struct(~[cx.int_type]); // Refcount
 
 }
 
-pub fn T_chan(cx: @crate_ctxt, _t: TypeRef) -> TypeRef {
+pub fn T_chan(cx: @CrateContext, _t: TypeRef) -> TypeRef {
     return T_struct(~[cx.int_type]); // Refcount
 
 }
 
-pub fn T_taskptr(cx: @crate_ctxt) -> TypeRef { return T_ptr(cx.task_type); }
+pub fn T_taskptr(cx: @CrateContext) -> TypeRef { return T_ptr(cx.task_type); }
 
 
 // This type must never be used directly; it must always be cast away.
-pub fn T_typaram(tn: type_names) -> TypeRef {
+pub fn T_typaram(tn: @TypeNames) -> TypeRef {
     let s = @"typaram";
     match name_has_type(tn, s) {
       Some(t) => return t,
@@ -1035,21 +1038,21 @@ pub fn T_typaram(tn: type_names) -> TypeRef {
     return t;
 }
 
-pub fn T_typaram_ptr(tn: type_names) -> TypeRef {
+pub fn T_typaram_ptr(tn: @TypeNames) -> TypeRef {
     return T_ptr(T_typaram(tn));
 }
 
-pub fn T_opaque_cbox_ptr(cx: @crate_ctxt) -> TypeRef {
+pub fn T_opaque_cbox_ptr(cx: @CrateContext) -> TypeRef {
     // closures look like boxes (even when they are fn~ or fn&)
     // see trans_closure.rs
     return T_opaque_box_ptr(cx);
 }
 
-pub fn T_enum_discrim(cx: @crate_ctxt) -> TypeRef {
+pub fn T_enum_discrim(cx: @CrateContext) -> TypeRef {
     return cx.int_type;
 }
 
-pub fn T_opaque_enum(cx: @crate_ctxt) -> TypeRef {
+pub fn T_opaque_enum(cx: @CrateContext) -> TypeRef {
     let s = @"opaque_enum";
     match name_has_type(cx.tn, s) {
       Some(t) => return t,
@@ -1060,15 +1063,15 @@ pub fn T_opaque_enum(cx: @crate_ctxt) -> TypeRef {
     return t;
 }
 
-pub fn T_opaque_enum_ptr(cx: @crate_ctxt) -> TypeRef {
+pub fn T_opaque_enum_ptr(cx: @CrateContext) -> TypeRef {
     return T_ptr(T_opaque_enum(cx));
 }
 
-pub fn T_captured_tydescs(cx: @crate_ctxt, n: uint) -> TypeRef {
+pub fn T_captured_tydescs(cx: @CrateContext, n: uint) -> TypeRef {
     return T_struct(vec::from_elem::<TypeRef>(n, T_ptr(cx.tydesc_type)));
 }
 
-pub fn T_opaque_trait(cx: @crate_ctxt, vstore: ty::vstore) -> TypeRef {
+pub fn T_opaque_trait(cx: @CrateContext, vstore: ty::vstore) -> TypeRef {
     match vstore {
         ty::vstore_box => {
             T_struct(~[T_ptr(cx.tydesc_type), T_opaque_box_ptr(cx)])
@@ -1126,11 +1129,11 @@ pub fn C_i64(i: i64) -> ValueRef {
     return C_integral(T_i64(), i as u64, True);
 }
 
-pub fn C_int(cx: @crate_ctxt, i: int) -> ValueRef {
+pub fn C_int(cx: @CrateContext, i: int) -> ValueRef {
     return C_integral(cx.int_type, i as u64, True);
 }
 
-pub fn C_uint(cx: @crate_ctxt, i: uint) -> ValueRef {
+pub fn C_uint(cx: @CrateContext, i: uint) -> ValueRef {
     return C_integral(cx.int_type, i as u64, False);
 }
 
@@ -1141,7 +1144,7 @@ pub fn C_u8(i: uint) -> ValueRef {
 
 // This is a 'c-like' raw string, which differs from
 // our boxed-and-length-annotated strings.
-pub fn C_cstr(cx: @crate_ctxt, +s: ~str) -> ValueRef {
+pub fn C_cstr(cx: @CrateContext, +s: ~str) -> ValueRef {
     unsafe {
         match cx.const_cstr_cache.find(&s) {
           Some(llval) => return llval,
@@ -1166,7 +1169,7 @@ pub fn C_cstr(cx: @crate_ctxt, +s: ~str) -> ValueRef {
 
 // NB: Do not use `do_spill_noroot` to make this into a constant string, or
 // you will be kicked off fast isel. See issue #4352 for an example of this.
-pub fn C_estr_slice(cx: @crate_ctxt, +s: ~str) -> ValueRef {
+pub fn C_estr_slice(cx: @CrateContext, +s: ~str) -> ValueRef {
     unsafe {
         let len = str::len(s);
         let cs = llvm::LLVMConstPointerCast(C_cstr(cx, s), T_ptr(T_i8()));
@@ -1241,7 +1244,7 @@ pub fn C_bytes_plus_null(bytes: ~[u8]) -> ValueRef {
     }
 }
 
-pub fn C_shape(ccx: @crate_ctxt, +bytes: ~[u8]) -> ValueRef {
+pub fn C_shape(ccx: @CrateContext, +bytes: ~[u8]) -> ValueRef {
     unsafe {
         let llshape = C_bytes_plus_null(bytes);
         let name = fmt!("shape%u", (ccx.names)(~"shape").repr);

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -20,7 +20,7 @@ use middle::ty;
 
 use syntax::{ast, ast_util, codemap, ast_map};
 
-pub fn const_lit(cx: @crate_ctxt, e: @ast::expr, lit: ast::lit)
+pub fn const_lit(cx: @CrateContext, e: @ast::expr, lit: ast::lit)
     -> ValueRef {
     let _icx = cx.insn_ctxt("trans_lit");
     match lit.node {
@@ -59,7 +59,7 @@ pub fn const_lit(cx: @crate_ctxt, e: @ast::expr, lit: ast::lit)
     }
 }
 
-pub fn const_ptrcast(cx: @crate_ctxt, a: ValueRef, t: TypeRef) -> ValueRef {
+pub fn const_ptrcast(cx: @CrateContext, a: ValueRef, t: TypeRef) -> ValueRef {
     unsafe {
         let b = llvm::LLVMConstPointerCast(a, T_ptr(t));
         assert cx.const_globals.insert(b as int, a);
@@ -67,7 +67,7 @@ pub fn const_ptrcast(cx: @crate_ctxt, a: ValueRef, t: TypeRef) -> ValueRef {
     }
 }
 
-pub fn const_vec(cx: @crate_ctxt, e: @ast::expr, es: &[@ast::expr])
+pub fn const_vec(cx: @CrateContext, e: @ast::expr, es: &[@ast::expr])
     -> (ValueRef, ValueRef, TypeRef) {
     unsafe {
         let vec_ty = ty::expr_ty(cx.tcx, e);
@@ -86,7 +86,7 @@ pub fn const_vec(cx: @crate_ctxt, e: @ast::expr, es: &[@ast::expr])
     }
 }
 
-pub fn const_deref(cx: @crate_ctxt, v: ValueRef) -> ValueRef {
+pub fn const_deref(cx: @CrateContext, v: ValueRef) -> ValueRef {
     unsafe {
         let v = match cx.const_globals.find(&(v as int)) {
             Some(v) => v,
@@ -98,7 +98,7 @@ pub fn const_deref(cx: @crate_ctxt, v: ValueRef) -> ValueRef {
     }
 }
 
-pub fn const_get_elt(cx: @crate_ctxt, v: ValueRef, us: &[c_uint])
+pub fn const_get_elt(cx: @CrateContext, v: ValueRef, us: &[c_uint])
                   -> ValueRef {
     unsafe {
         let r = do vec::as_imm_buf(us) |p, len| {
@@ -112,7 +112,7 @@ pub fn const_get_elt(cx: @crate_ctxt, v: ValueRef, us: &[c_uint])
     }
 }
 
-pub fn const_autoderef(cx: @crate_ctxt, ty: ty::t, v: ValueRef)
+pub fn const_autoderef(cx: @CrateContext, ty: ty::t, v: ValueRef)
     -> (ty::t, ValueRef) {
     let mut t1 = ty;
     let mut v1 = v;
@@ -128,7 +128,7 @@ pub fn const_autoderef(cx: @crate_ctxt, ty: ty::t, v: ValueRef)
     }
 }
 
-pub fn get_const_val(cx: @crate_ctxt, def_id: ast::def_id) -> ValueRef {
+pub fn get_const_val(cx: @CrateContext, def_id: ast::def_id) -> ValueRef {
     if !ast_util::is_local(def_id) {
         cx.tcx.sess.bug(~"cross-crate constants");
     }
@@ -145,7 +145,7 @@ pub fn get_const_val(cx: @crate_ctxt, def_id: ast::def_id) -> ValueRef {
     cx.const_values.get(&def_id.node)
 }
 
-pub fn const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
+pub fn const_expr(cx: @CrateContext, e: @ast::expr) -> ValueRef {
     unsafe {
         let _icx = cx.insn_ctxt("const_expr");
         return match /*bad*/copy e.node {
@@ -483,7 +483,7 @@ pub fn const_expr(cx: @crate_ctxt, e: @ast::expr) -> ValueRef {
     }
 }
 
-pub fn trans_const(ccx: @crate_ctxt, _e: @ast::expr, id: ast::node_id) {
+pub fn trans_const(ccx: @CrateContext, _e: @ast::expr, id: ast::node_id) {
     unsafe {
         let _icx = ccx.insn_ctxt("trans_const");
         let g = base::get_item_val(ccx, id);

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -289,7 +289,7 @@ pub fn trans_ret(bcx: block, e: Option<@ast::expr>) -> block {
     let _icx = bcx.insn_ctxt("trans_ret");
     let mut bcx = bcx;
     let retptr = match copy bcx.fcx.loop_ret {
-      Some({flagptr, retptr}) => {
+      Some((flagptr, retptr)) => {
         // This is a loop body return. Must set continue flag (our retptr)
         // to false, return flag to true, and then store the value in the
         // parent's retptr.
@@ -375,16 +375,15 @@ fn trans_fail_value(bcx: block,
                  -> block {
     let _icx = bcx.insn_ctxt("trans_fail_value");
     let ccx = bcx.ccx();
-    let {V_filename, V_line} = match sp_opt {
+    let (V_filename, V_line) = match sp_opt {
       Some(sp) => {
         let sess = bcx.sess();
         let loc = sess.parse_sess.cm.lookup_char_pos(sp.lo);
-        {V_filename: C_cstr(bcx.ccx(), /*bad*/copy loc.file.name),
-         V_line: loc.line as int}
+        (C_cstr(bcx.ccx(), /*bad*/copy loc.file.name),
+         loc.line as int)
       }
       None => {
-        {V_filename: C_cstr(bcx.ccx(), ~"<runtime>"),
-         V_line: 0}
+        (C_cstr(bcx.ccx(), ~"<runtime>"), 0)
       }
     };
     let V_str = PointerCast(bcx, V_fail_str, T_ptr(T_i8()));

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -396,7 +396,7 @@ pub impl Datum {
         }
     }
 
-    fn to_str(ccx: &crate_ctxt) -> ~str {
+    fn to_str(ccx: &CrateContext) -> ~str {
         fmt!("Datum { val=%s, ty=%s, mode=%?, source=%? }",
              val_str(ccx.tn, self.val),
              ty_to_str(ccx.tcx, self.ty),
@@ -835,7 +835,7 @@ pub impl DatumBlock {
         rslt(self.bcx, self.datum.to_appropriate_llval(self.bcx))
     }
 
-    fn ccx() -> @crate_ctxt {
+    fn ccx() -> @CrateContext {
         self.bcx.ccx()
     }
 

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -147,7 +147,7 @@ struct LocalVarMetadata {
 struct TyDescMetadata {
     hash: uint
 }
-struct BlockMetadata { 
+struct BlockMetadata {
     start: codemap::Loc,
     end: codemap::Loc
 }
@@ -262,7 +262,8 @@ fn get_file_path_and_dir(work_dir: &str, full_path: &str) -> (~str, ~str) {
     }, str::from_slice(work_dir))
 }
 
-fn create_file(cx: @CrateContext, +full_path: ~str) -> @Metadata<FileMetadata> {
+fn create_file(cx: @CrateContext, +full_path: ~str)
+    -> @Metadata<FileMetadata> {
     let cache = get_cache(cx);;
     let tg = FileDescriptorTag;
     match cached_metadata::<@Metadata<FileMetadata>>(

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -94,7 +94,7 @@ fn llnull() -> ValueRef {
     }
 }
 
-fn add_named_metadata(cx: @crate_ctxt, name: ~str, val: ValueRef) {
+fn add_named_metadata(cx: @CrateContext, name: ~str, val: ValueRef) {
     str::as_c_str(name, |sbuf| {
         unsafe {
             llvm::LLVMAddNamedMetadataOperand(cx.llmod, sbuf, val)
@@ -104,16 +104,18 @@ fn add_named_metadata(cx: @crate_ctxt, name: ~str, val: ValueRef) {
 
 ////////////////
 
-pub type debug_ctxt = {
+pub struct DebugContext {
     llmetadata: metadata_cache,
     names: namegen,
     crate_file: ~str
-};
+}
 
-pub fn mk_ctxt(+crate: ~str, intr: @ident_interner) -> debug_ctxt {
-    {llmetadata: oldmap::HashMap(),
-     names: new_namegen(intr),
-     crate_file: crate}
+pub fn mk_ctxt(+crate: ~str, intr: @ident_interner) -> DebugContext {
+    DebugContext {
+        llmetadata: oldmap::HashMap(),
+        names: new_namegen(intr),
+        crate_file: crate
+    }
 }
 
 fn update_cache(cache: metadata_cache, mdtag: int, val: debug_metadata) {
@@ -125,28 +127,48 @@ fn update_cache(cache: metadata_cache, mdtag: int, val: debug_metadata) {
     cache.insert(mdtag, vec::append_one(existing, val));
 }
 
-type metadata<T> = {node: ValueRef, data: T};
+struct Metadata<T> {
+    node: ValueRef,
+    data: T
+}
 
-type file_md = {path: ~str};
-type compile_unit_md = {name: ~str};
-type subprogram_md = {id: ast::node_id};
-type local_var_md = {id: ast::node_id};
-type tydesc_md = {hash: uint};
-type block_md = {start: codemap::Loc, end: codemap::Loc};
-type argument_md = {id: ast::node_id};
-type retval_md = {id: ast::node_id};
+struct FileMetadata {
+    path: ~str
+}
+struct CompileUnitMetadata {
+    name: ~str
+}
+struct SubProgramMetadata {
+    id: ast::node_id
+}
+struct LocalVarMetadata {
+    id: ast::node_id
+}
+struct TyDescMetadata {
+    hash: uint
+}
+struct BlockMetadata { 
+    start: codemap::Loc,
+    end: codemap::Loc
+}
+struct ArgumentMetadata {
+    id: ast::node_id
+}
+struct RetvalMetadata {
+    id: ast::node_id
+}
 
 type metadata_cache = HashMap<int, ~[debug_metadata]>;
 
 enum debug_metadata {
-    file_metadata(@metadata<file_md>),
-    compile_unit_metadata(@metadata<compile_unit_md>),
-    subprogram_metadata(@metadata<subprogram_md>),
-    local_var_metadata(@metadata<local_var_md>),
-    tydesc_metadata(@metadata<tydesc_md>),
-    block_metadata(@metadata<block_md>),
-    argument_metadata(@metadata<argument_md>),
-    retval_metadata(@metadata<retval_md>),
+    file_metadata(@Metadata<FileMetadata>),
+    compile_unit_metadata(@Metadata<CompileUnitMetadata>),
+    subprogram_metadata(@Metadata<SubProgramMetadata>),
+    local_var_metadata(@Metadata<LocalVarMetadata>),
+    tydesc_metadata(@Metadata<TyDescMetadata>),
+    block_metadata(@Metadata<BlockMetadata>),
+    argument_metadata(@Metadata<ArgumentMetadata>),
+    retval_metadata(@Metadata<RetvalMetadata>),
 }
 
 fn cast_safely<T: Copy, U>(val: T) -> U {
@@ -189,12 +211,12 @@ fn cached_metadata<T: Copy>(cache: metadata_cache,
     }
 }
 
-fn create_compile_unit(cx: @crate_ctxt) -> @metadata<compile_unit_md> {
+fn create_compile_unit(cx: @CrateContext) -> @Metadata<CompileUnitMetadata> {
     unsafe {
         let cache = get_cache(cx);
         let crate_name = /*bad*/copy (/*bad*/copy cx.dbg_cx).get().crate_file;
         let tg = CompileUnitTag;
-        match cached_metadata::<@metadata<compile_unit_md>>(cache, tg,
+        match cached_metadata::<@Metadata<CompileUnitMetadata>>(cache, tg,
                             |md| md.data.name == crate_name) {
           option::Some(md) => return md,
           option::None => ()
@@ -215,14 +237,19 @@ fn create_compile_unit(cx: @crate_ctxt) -> @metadata<compile_unit_md> {
                             ];
         let unit_node = llmdnode(unit_metadata);
         add_named_metadata(cx, ~"llvm.dbg.cu", unit_node);
-        let mdval = @{node: unit_node, data: {name: crate_name}};
+        let mdval = @Metadata {
+            node: unit_node,
+            data: CompileUnitMetadata {
+                name: crate_name
+            }
+        };
         update_cache(cache, tg, compile_unit_metadata(mdval));
 
         return mdval;
     }
 }
 
-fn get_cache(cx: @crate_ctxt) -> metadata_cache {
+fn get_cache(cx: @CrateContext) -> metadata_cache {
     (/*bad*/copy cx.dbg_cx).get().llmetadata
 }
 
@@ -235,10 +262,10 @@ fn get_file_path_and_dir(work_dir: &str, full_path: &str) -> (~str, ~str) {
     }, str::from_slice(work_dir))
 }
 
-fn create_file(cx: @crate_ctxt, +full_path: ~str) -> @metadata<file_md> {
+fn create_file(cx: @CrateContext, +full_path: ~str) -> @Metadata<FileMetadata> {
     let cache = get_cache(cx);;
     let tg = FileDescriptorTag;
-    match cached_metadata::<@metadata<file_md>>(
+    match cached_metadata::<@Metadata<FileMetadata>>(
         cache, tg, |md| md.data.path == full_path) {
         option::Some(md) => return md,
         option::None => ()
@@ -253,7 +280,12 @@ fn create_file(cx: @crate_ctxt, +full_path: ~str) -> @metadata<file_md> {
                    llstr(work_dir),
                    unit_node];
     let val = llmdnode(file_md);
-    let mdval = @{node: val, data: {path: full_path}};
+    let mdval = @Metadata {
+        node: val,
+        data: FileMetadata {
+            path: full_path
+        }
+    };
     update_cache(cache, tg, file_metadata(mdval));
     return mdval;
 }
@@ -262,7 +294,7 @@ fn line_from_span(cm: @codemap::CodeMap, sp: span) -> uint {
     cm.lookup_char_pos(sp.lo).line
 }
 
-fn create_block(cx: block) -> @metadata<block_md> {
+fn create_block(cx: block) -> @Metadata<BlockMetadata> {
     let cache = get_cache(cx.ccx());
     let mut cx = cx;
     while cx.node_info.is_none() {
@@ -277,7 +309,7 @@ fn create_block(cx: block) -> @metadata<block_md> {
     let fname = /*bad*/copy start.file.name;
     let end = cx.sess().codemap.lookup_char_pos(sp.hi);
     let tg = LexicalBlockTag;
-    /*match cached_metadata::<@metadata<block_md>>(
+    /*match cached_metadata::<@Metadata<BlockMetadata>>(
         cache, tg,
         {|md| start == md.data.start && end == md.data.end}) {
       option::Some(md) { return md; }
@@ -301,22 +333,28 @@ fn create_block(cx: block) -> @metadata<block_md> {
                   lli32(unique_id)
                  ];
     let val = llmdnode(lldata);
-    let mdval = @{node: val, data: {start: start, end: end}};
+    let mdval = @Metadata {
+        node: val,
+        data: BlockMetadata {
+            start: start,
+            end: end
+        }
+    };
     //update_cache(cache, tg, block_metadata(mdval));
     return mdval;
 }
 
-fn size_and_align_of(cx: @crate_ctxt, t: ty::t) -> (int, int) {
+fn size_and_align_of(cx: @CrateContext, t: ty::t) -> (int, int) {
     let llty = type_of::type_of(cx, t);
     (machine::llsize_of_real(cx, llty) as int,
      machine::llalign_of_pref(cx, llty) as int)
 }
 
-fn create_basic_type(cx: @crate_ctxt, t: ty::t, span: span)
-    -> @metadata<tydesc_md> {
+fn create_basic_type(cx: @CrateContext, t: ty::t, span: span)
+    -> @Metadata<TyDescMetadata> {
     let cache = get_cache(cx);
     let tg = BasicTypeDescriptorTag;
-    match cached_metadata::<@metadata<tydesc_md>>(
+    match cached_metadata::<@Metadata<TyDescMetadata>>(
         cache, tg, |md| ty::type_id(t) == md.data.hash) {
       option::Some(md) => return md,
       option::None => ()
@@ -339,18 +377,23 @@ fn create_basic_type(cx: @crate_ctxt, t: ty::t, span: span)
                   lli32(0), //XXX flags?
                   lli32(encoding)];
     let llnode = llmdnode(lldata);
-    let mdval = @{node: llnode, data: {hash: ty::type_id(t)}};
+    let mdval = @Metadata {
+        node: llnode,
+        data: TyDescMetadata {
+            hash: ty::type_id(t)
+        }
+    };
     update_cache(cache, tg, tydesc_metadata(mdval));
     add_named_metadata(cx, ~"llvm.dbg.ty", llnode);
     return mdval;
 }
 
-fn create_pointer_type(cx: @crate_ctxt, t: ty::t, span: span,
-                       pointee: @metadata<tydesc_md>)
-    -> @metadata<tydesc_md> {
+fn create_pointer_type(cx: @CrateContext, t: ty::t, span: span,
+                       pointee: @Metadata<TyDescMetadata>)
+    -> @Metadata<TyDescMetadata> {
     let tg = PointerTypeTag;
     /*let cache = cx.llmetadata;
-    match cached_metadata::<@metadata<tydesc_md>>(
+    match cached_metadata::<@Metadata<TyDescMetadata>>(
         cache, tg, {|md| ty::hash_ty(t) == ty::hash_ty(md.data.hash)}) {
       option::Some(md) { return md; }
       option::None {}
@@ -361,7 +404,12 @@ fn create_pointer_type(cx: @crate_ctxt, t: ty::t, span: span,
     //let cu_node = create_compile_unit(cx, fname);
     let llnode = create_derived_type(tg, file_node.node, ~"", 0, size * 8,
                                      align * 8, 0, pointee.node);
-    let mdval = @{node: llnode, data: {hash: ty::type_id(t)}};
+    let mdval = @Metadata {
+        node: llnode,
+        data: TyDescMetadata {
+            hash: ty::type_id(t)
+        }
+    };
     //update_cache(cache, tg, tydesc_metadata(mdval));
     add_named_metadata(cx, ~"llvm.dbg.ty", llnode);
     return mdval;
@@ -388,7 +436,7 @@ fn finish_structure(cx: @mut StructCtxt) -> ValueRef {
                                  option::Some(/*bad*/copy cx.members));
 }
 
-fn create_structure(file: @metadata<file_md>, +name: ~str, line: int)
+fn create_structure(file: @Metadata<FileMetadata>, +name: ~str, line: int)
                  -> @mut StructCtxt {
     let cx = @mut StructCtxt {
         file: file.node,
@@ -429,8 +477,8 @@ fn add_member(cx: @mut StructCtxt,
     cx.total_size += size * 8;
 }
 
-fn create_record(cx: @crate_ctxt, t: ty::t, fields: ~[ast::ty_field],
-                 span: span) -> @metadata<tydesc_md> {
+fn create_record(cx: @CrateContext, t: ty::t, fields: ~[ast::ty_field],
+                 span: span) -> @Metadata<TyDescMetadata> {
     let fname = filename_from_span(cx, span);
     let file_node = create_file(cx, fname);
     let scx = create_structure(file_node,
@@ -447,16 +495,21 @@ fn create_record(cx: @crate_ctxt, t: ty::t, fields: ~[ast::ty_field],
                    line_from_span(cx.sess.codemap, field.span) as int,
                    size as int, align as int, ty_md.node);
     }
-    let mdval = @{node: finish_structure(scx), data:{hash: ty::type_id(t)}};
+    let mdval = @Metadata {
+        node: finish_structure(scx),
+        data: TyDescMetadata {
+            hash: ty::type_id(t)
+        }
+    };
     return mdval;
 }
 
-fn create_boxed_type(cx: @crate_ctxt, outer: ty::t, _inner: ty::t,
-                     span: span, boxed: @metadata<tydesc_md>)
-    -> @metadata<tydesc_md> {
+fn create_boxed_type(cx: @CrateContext, outer: ty::t, _inner: ty::t,
+                     span: span, boxed: @Metadata<TyDescMetadata>)
+    -> @Metadata<TyDescMetadata> {
     //let tg = StructureTypeTag;
     /*let cache = cx.llmetadata;
-    match cached_metadata::<@metadata<tydesc_md>>(
+    match cached_metadata::<@Metadata<TyDescMetadata>>(
         cache, tg, {|md| ty::hash_ty(outer) == ty::hash_ty(md.data.hash)}) {
       option::Some(md) { return md; }
       option::None {}
@@ -473,7 +526,12 @@ fn create_boxed_type(cx: @crate_ctxt, outer: ty::t, _inner: ty::t,
                8, //XXX just a guess
                boxed.node);
     let llnode = finish_structure(scx);
-    let mdval = @{node: llnode, data: {hash: ty::type_id(outer)}};
+    let mdval = @Metadata {
+        node: llnode,
+        data: TyDescMetadata {
+            hash: ty::type_id(outer)
+        }
+    };
     //update_cache(cache, tg, tydesc_metadata(mdval));
     add_named_metadata(cx, ~"llvm.dbg.ty", llnode);
     return mdval;
@@ -509,9 +567,9 @@ fn create_composite_type(type_tag: int, +name: ~str, file: ValueRef,
     return llmdnode(lldata);
 }
 
-fn create_vec(cx: @crate_ctxt, vec_t: ty::t, elem_t: ty::t,
+fn create_vec(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t,
               vec_ty_span: codemap::span, elem_ty: @ast::Ty)
-    -> @metadata<tydesc_md> {
+    -> @Metadata<TyDescMetadata> {
     let fname = filename_from_span(cx, vec_ty_span);
     let file_node = create_file(cx, fname);
     let elem_ty_md = create_ty(cx, elem_t, elem_ty);
@@ -530,13 +588,18 @@ fn create_vec(cx: @crate_ctxt, vec_t: ty::t, elem_t: ty::t,
     add_member(scx, ~"data", 0, 0, // clang says the size should be 0
                sys::min_align_of::<u8>() as int, data_ptr);
     let llnode = finish_structure(scx);
-    return @{node: llnode, data: {hash: ty::type_id(vec_t)}};
+    @Metadata {
+        node: llnode,
+        data: TyDescMetadata {
+            hash: ty::type_id(vec_t)
+        }
+    }
 }
 
-fn create_ty(_cx: @crate_ctxt, _t: ty::t, _ty: @ast::Ty)
-    -> @metadata<tydesc_md> {
+fn create_ty(_cx: @CrateContext, _t: ty::t, _ty: @ast::Ty)
+    -> @Metadata<TyDescMetadata> {
     /*let cache = get_cache(cx);
-    match cached_metadata::<@metadata<tydesc_md>>(
+    match cached_metadata::<@Metadata<TyDescMetadata>>(
         cache, tg, {|md| t == md.data.hash}) {
       option::Some(md) { return md; }
       option::None {}
@@ -555,7 +618,7 @@ fn create_ty(_cx: @crate_ctxt, _t: ty::t, _ty: @ast::Ty)
 
     fail!();
     /*
-    fn t_to_ty(cx: crate_ctxt, t: ty::t, span: span) -> @ast::ty {
+    fn t_to_ty(cx: CrateContext, t: ty::t, span: span) -> @ast::ty {
         let ty = match ty::get(t).struct {
           ty::ty_nil { ast::ty_nil }
           ty::ty_bot { ast::ty_bot }
@@ -637,7 +700,7 @@ fn create_ty(_cx: @crate_ctxt, _t: ty::t, _ty: @ast::Ty)
     */
 }
 
-fn filename_from_span(cx: @crate_ctxt, sp: codemap::span) -> ~str {
+fn filename_from_span(cx: @CrateContext, sp: codemap::span) -> ~str {
     /*bad*/copy cx.sess.codemap.lookup_char_pos(sp.lo).file.name
 }
 
@@ -655,12 +718,12 @@ fn create_var(type_tag: int, context: ValueRef, +name: ~str, file: ValueRef,
 }
 
 pub fn create_local_var(bcx: block, local: @ast::local)
-    -> @metadata<local_var_md> {
+    -> @Metadata<LocalVarMetadata> {
     unsafe {
         let cx = bcx.ccx();
         let cache = get_cache(cx);
         let tg = AutoVariableTag;
-        match cached_metadata::<@metadata<local_var_md>>(
+        match cached_metadata::<@Metadata<LocalVarMetadata>>(
             cache, tg, |md| md.data.id == local.node.id) {
           option::Some(md) => return md,
           option::None => ()
@@ -681,7 +744,12 @@ pub fn create_local_var(bcx: block, local: @ast::local)
         };
         let mdnode = create_var(tg, context, cx.sess.str_of(name),
                                 filemd.node, loc.line as int, tymd.node);
-        let mdval = @{node: mdnode, data: {id: local.node.id}};
+        let mdval = @Metadata {
+            node: mdnode,
+            data: LocalVarMetadata {
+                id: local.node.id
+            }
+        };
         update_cache(cache, AutoVariableTag, local_var_metadata(mdval));
 
         let llptr = match bcx.fcx.lllocals.find(&local.node.id) {
@@ -706,12 +774,12 @@ pub fn create_local_var(bcx: block, local: @ast::local)
 }
 
 pub fn create_arg(bcx: block, arg: ast::arg, sp: span)
-    -> Option<@metadata<argument_md>> {
+    -> Option<@Metadata<ArgumentMetadata>> {
     unsafe {
         let fcx = bcx.fcx, cx = fcx.ccx;
         let cache = get_cache(cx);
         let tg = ArgVariableTag;
-        match cached_metadata::<@metadata<argument_md>>(
+        match cached_metadata::<@Metadata<ArgumentMetadata>>(
             cache, ArgVariableTag, |md| md.data.id == arg.id) {
           option::Some(md) => return Some(md),
           option::None => ()
@@ -733,7 +801,12 @@ pub fn create_arg(bcx: block, arg: ast::arg, sp: span)
                                         loc.line as int,
                                         tymd.node);
 
-                let mdval = @{node: mdnode, data: {id: arg.id}};
+                let mdval = @Metadata {
+                    node: mdnode,
+                    data: ArgumentMetadata {
+                        id: arg.id
+                    }
+                };
                 update_cache(cache, tg, argument_metadata(mdval));
 
                 let llptr = match fcx.llargs.get(&arg.id) {
@@ -769,7 +842,7 @@ pub fn update_source_pos(cx: block, s: span) {
     }
 }
 
-pub fn create_function(fcx: fn_ctxt) -> @metadata<subprogram_md> {
+pub fn create_function(fcx: fn_ctxt) -> @Metadata<SubProgramMetadata> {
     let cx = fcx.ccx;
     let dbg_cx = (/*bad*/copy cx.dbg_cx).get();
 
@@ -816,7 +889,7 @@ pub fn create_function(fcx: fn_ctxt) -> @metadata<subprogram_md> {
     log(debug, id);
 
     let cache = get_cache(cx);
-    match cached_metadata::<@metadata<subprogram_md>>(
+    match cached_metadata::<@Metadata<SubProgramMetadata>>(
         cache, SubprogramTag, |md| md.data.id == id) {
       option::Some(md) => return md,
       option::None => ()
@@ -860,7 +933,12 @@ pub fn create_function(fcx: fn_ctxt) -> @metadata<subprogram_md> {
                       ];
     let val = llmdnode(fn_metadata);
     add_named_metadata(cx, ~"llvm.dbg.sp", val);
-    let mdval = @{node: val, data: {id: id}};
+    let mdval = @Metadata {
+        node: val,
+        data: SubProgramMetadata {
+            id: id
+        }
+    };
     update_cache(cache, SubprogramTag, subprogram_metadata(mdval));
 
     return mdval;

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -157,7 +157,7 @@ pub enum Dest {
 }
 
 impl Dest {
-    fn to_str(ccx: @crate_ctxt) -> ~str {
+    fn to_str(ccx: @CrateContext) -> ~str {
         match self {
             SaveIn(v) => fmt!("SaveIn(%s)", val_str(ccx.tn, v)),
             Ignore => ~"Ignore"
@@ -1272,7 +1272,7 @@ fn trans_unary_datum(bcx: block,
                         contents_ty: ty::t,
                         heap: heap) -> DatumBlock {
         let _icx = bcx.insn_ctxt("trans_boxed_expr");
-        let {bcx, box: bx, body} =
+        let base::MallocResult { bcx, box: bx, body } =
             base::malloc_general(bcx, contents_ty, heap);
         add_clean_free(bcx, bx, heap);
         let bcx = trans_into(bcx, contents, SaveIn(body));
@@ -1565,34 +1565,34 @@ fn trans_imm_cast(bcx: block, expr: @ast::expr,
     let s_in = k_in == cast_integral && ty::type_is_signed(t_in);
 
     let newval =
-        match {in: k_in, out: k_out} {
-            {in: cast_integral, out: cast_integral} => {
+        match (k_in, k_out) {
+            (cast_integral, cast_integral) => {
                 int_cast(bcx, ll_t_out, ll_t_in, llexpr, s_in)
             }
-            {in: cast_float, out: cast_float} => {
+            (cast_float, cast_float) => {
                 float_cast(bcx, ll_t_out, ll_t_in, llexpr)
             }
-            {in: cast_integral, out: cast_float} => {
+            (cast_integral, cast_float) => {
                 if s_in {
                     SIToFP(bcx, llexpr, ll_t_out)
                 } else { UIToFP(bcx, llexpr, ll_t_out) }
             }
-            {in: cast_float, out: cast_integral} => {
+            (cast_float, cast_integral) => {
                 if ty::type_is_signed(t_out) {
                     FPToSI(bcx, llexpr, ll_t_out)
                 } else { FPToUI(bcx, llexpr, ll_t_out) }
             }
-            {in: cast_integral, out: cast_pointer} => {
+            (cast_integral, cast_pointer) => {
                 IntToPtr(bcx, llexpr, ll_t_out)
             }
-            {in: cast_pointer, out: cast_integral} => {
+            (cast_pointer, cast_integral) => {
                 PtrToInt(bcx, llexpr, ll_t_out)
             }
-            {in: cast_pointer, out: cast_pointer} => {
+            (cast_pointer, cast_pointer) => {
                 PointerCast(bcx, llexpr, ll_t_out)
             }
-            {in: cast_enum, out: cast_integral} |
-            {in: cast_enum, out: cast_float} => {
+            (cast_enum, cast_integral) |
+            (cast_enum, cast_float) => {
                 let bcx = bcx;
                 let in_tid = match ty::get(t_in).sty {
                     ty::ty_enum(did, _) => did,

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -47,23 +47,23 @@ fn abi_info(arch: session::arch) -> cabi::ABIInfo {
     }
 }
 
-pub fn link_name(ccx: @crate_ctxt, i: @ast::foreign_item) -> ~str {
+pub fn link_name(ccx: @CrateContext, i: @ast::foreign_item) -> ~str {
     match attr::first_attr_value_str_by_name(i.attrs, ~"link_name") {
         None => ccx.sess.str_of(i.ident),
         option::Some(ref ln) => (/*bad*/copy *ln)
     }
 }
 
-type c_stack_tys = {
+struct c_stack_tys {
     arg_tys: ~[TypeRef],
     ret_ty: TypeRef,
     ret_def: bool,
     bundle_ty: TypeRef,
     shim_fn_ty: TypeRef,
     fn_ty: cabi::FnType
-};
+}
 
-fn c_arg_and_ret_lltys(ccx: @crate_ctxt,
+fn c_arg_and_ret_lltys(ccx: @CrateContext,
                        id: ast::node_id) -> (~[TypeRef], TypeRef, ty::t) {
     match ty::get(ty::node_id_to_type(ccx.tcx, id)).sty {
         ty::ty_bare_fn(ref fn_ty) => {
@@ -75,7 +75,7 @@ fn c_arg_and_ret_lltys(ccx: @crate_ctxt,
     }
 }
 
-fn c_stack_tys(ccx: @crate_ctxt,
+fn c_stack_tys(ccx: @CrateContext,
                id: ast::node_id) -> @c_stack_tys {
     let (llargtys, llretty, ret_ty) = c_arg_and_ret_lltys(ccx, id);
     // XXX: Bad copy.
@@ -83,7 +83,7 @@ fn c_stack_tys(ccx: @crate_ctxt,
     let ret_def = !ty::type_is_bot(ret_ty) && !ty::type_is_nil(ret_ty);
     let fn_ty = abi_info(ccx.sess.targ_cfg.arch).
                     compute_info(llargtys, llretty, ret_def);
-    return @{
+    return @c_stack_tys {
         arg_tys: llargtys,
         ret_ty: llretty,
         ret_def: ret_def,
@@ -99,7 +99,7 @@ type shim_arg_builder = fn(bcx: block, tys: @c_stack_tys,
 type shim_ret_builder = fn(bcx: block, tys: @c_stack_tys,
                            llargbundle: ValueRef, llretval: ValueRef);
 
-fn build_shim_fn_(ccx: @crate_ctxt,
+fn build_shim_fn_(ccx: @CrateContext,
                   +shim_name: ~str,
                   llbasefn: ValueRef,
                   tys: @c_stack_tys,
@@ -136,7 +136,7 @@ type wrap_arg_builder = fn(bcx: block, tys: @c_stack_tys,
 type wrap_ret_builder = fn(bcx: block, tys: @c_stack_tys,
                            llargbundle: ValueRef);
 
-fn build_wrap_fn_(ccx: @crate_ctxt,
+fn build_wrap_fn_(ccx: @CrateContext,
                   tys: @c_stack_tys,
                   llshimfn: ValueRef,
                   llwrapfn: ValueRef,
@@ -201,13 +201,13 @@ fn build_wrap_fn_(ccx: @crate_ctxt,
 // stack pointer appropriately to avoid a round of copies.  (In fact, the shim
 // function itself is unnecessary). We used to do this, in fact, and will
 // perhaps do so in the future.
-pub fn trans_foreign_mod(ccx: @crate_ctxt,
+pub fn trans_foreign_mod(ccx: @CrateContext,
                          foreign_mod: ast::foreign_mod,
                          abi: ast::foreign_abi) {
 
     let _icx = ccx.insn_ctxt("foreign::trans_foreign_mod");
 
-    fn build_shim_fn(ccx: @crate_ctxt,
+    fn build_shim_fn(ccx: @CrateContext,
                      foreign_item: @ast::foreign_item,
                      tys: @c_stack_tys,
                      cc: lib::llvm::CallConv) -> ValueRef {
@@ -235,7 +235,7 @@ pub fn trans_foreign_mod(ccx: @crate_ctxt,
                            build_args, build_ret);
     }
 
-    fn base_fn(ccx: @crate_ctxt, +lname: ~str, tys: @c_stack_tys,
+    fn base_fn(ccx: @CrateContext, +lname: ~str, tys: @c_stack_tys,
                cc: lib::llvm::CallConv) -> ValueRef {
         // Declare the "prototype" for the base function F:
         do tys.fn_ty.decl_fn |fnty| {
@@ -245,7 +245,7 @@ pub fn trans_foreign_mod(ccx: @crate_ctxt,
 
     // FIXME (#2535): this is very shaky and probably gets ABIs wrong all
     // over the place
-    fn build_direct_fn(ccx: @crate_ctxt, decl: ValueRef,
+    fn build_direct_fn(ccx: @CrateContext, decl: ValueRef,
                        item: @ast::foreign_item, tys: @c_stack_tys,
                        cc: lib::llvm::CallConv) {
         let fcx = new_fn_ctxt(ccx, ~[], decl, None);
@@ -264,7 +264,7 @@ pub fn trans_foreign_mod(ccx: @crate_ctxt,
         finish_fn(fcx, lltop);
     }
 
-    fn build_wrap_fn(ccx: @crate_ctxt,
+    fn build_wrap_fn(ccx: @CrateContext,
                      tys: @c_stack_tys,
                      llshimfn: ValueRef,
                      llwrapfn: ValueRef) {
@@ -328,7 +328,7 @@ pub fn trans_foreign_mod(ccx: @crate_ctxt,
     }
 }
 
-pub fn trans_intrinsic(ccx: @crate_ctxt,
+pub fn trans_intrinsic(ccx: @CrateContext,
                        decl: ValueRef,
                        item: @ast::foreign_item,
                        +path: ast_map::path,
@@ -838,7 +838,7 @@ pub fn trans_intrinsic(ccx: @crate_ctxt,
     finish_fn(fcx, lltop);
 }
 
-pub fn trans_foreign_fn(ccx: @crate_ctxt,
+pub fn trans_foreign_fn(ccx: @CrateContext,
                         +path: ast_map::path,
                         decl: &ast::fn_decl,
                         body: &ast::blk,
@@ -846,7 +846,7 @@ pub fn trans_foreign_fn(ccx: @crate_ctxt,
                         id: ast::node_id) {
     let _icx = ccx.insn_ctxt("foreign::build_foreign_fn");
 
-    fn build_rust_fn(ccx: @crate_ctxt, +path: ast_map::path,
+    fn build_rust_fn(ccx: @CrateContext, +path: ast_map::path,
                      decl: &ast::fn_decl, body: &ast::blk,
                      id: ast::node_id) -> ValueRef {
         let _icx = ccx.insn_ctxt("foreign::foreign::build_rust_fn");
@@ -862,7 +862,7 @@ pub fn trans_foreign_fn(ccx: @crate_ctxt,
         return llfndecl;
     }
 
-    fn build_shim_fn(ccx: @crate_ctxt, +path: ast_map::path,
+    fn build_shim_fn(ccx: @CrateContext, +path: ast_map::path,
                      llrustfn: ValueRef, tys: @c_stack_tys) -> ValueRef {
         let _icx = ccx.insn_ctxt("foreign::foreign::build_shim_fn");
 
@@ -899,7 +899,7 @@ pub fn trans_foreign_fn(ccx: @crate_ctxt,
                            build_args, build_ret);
     }
 
-    fn build_wrap_fn(ccx: @crate_ctxt, llshimfn: ValueRef,
+    fn build_wrap_fn(ccx: @CrateContext, llshimfn: ValueRef,
                      llwrapfn: ValueRef, tys: @c_stack_tys) {
 
         let _icx = ccx.insn_ctxt("foreign::foreign::build_wrap_fn");
@@ -932,7 +932,7 @@ pub fn trans_foreign_fn(ccx: @crate_ctxt,
     build_wrap_fn(ccx, llshimfn, llwrapfn, tys)
 }
 
-pub fn register_foreign_fn(ccx: @crate_ctxt,
+pub fn register_foreign_fn(ccx: @CrateContext,
                            sp: span,
                            +path: ast_map::path,
                            node_id: ast::node_id,
@@ -950,7 +950,7 @@ pub fn register_foreign_fn(ccx: @crate_ctxt,
     }
 }
 
-fn abi_of_foreign_fn(ccx: @crate_ctxt, i: @ast::foreign_item)
+fn abi_of_foreign_fn(ccx: @CrateContext, i: @ast::foreign_item)
     -> ast::foreign_abi {
     match attr::first_attr_value_str_by_name(i.attrs, ~"abi") {
       None => match ccx.tcx.items.get(&i.id) {

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -142,7 +142,7 @@ pub fn free_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
     }
 }
 
-pub fn lazily_emit_all_tydesc_glue(ccx: @crate_ctxt,
+pub fn lazily_emit_all_tydesc_glue(ccx: @CrateContext,
                                    static_ti: @mut tydesc_info) {
     lazily_emit_tydesc_glue(ccx, abi::tydesc_field_take_glue, static_ti);
     lazily_emit_tydesc_glue(ccx, abi::tydesc_field_drop_glue, static_ti);
@@ -204,7 +204,7 @@ pub fn simplified_glue_type(tcx: ty::ctxt, field: uint, t: ty::t) -> ty::t {
     return t;
 }
 
-pub pure fn cast_glue(ccx: @crate_ctxt, ti: @mut tydesc_info, v: ValueRef)
+pub pure fn cast_glue(ccx: @CrateContext, ti: @mut tydesc_info, v: ValueRef)
                    -> ValueRef {
     unsafe {
         let llfnty = type_of_glue_fn(ccx, ti.ty);
@@ -212,7 +212,7 @@ pub pure fn cast_glue(ccx: @crate_ctxt, ti: @mut tydesc_info, v: ValueRef)
     }
 }
 
-pub fn lazily_emit_simplified_tydesc_glue(ccx: @crate_ctxt,
+pub fn lazily_emit_simplified_tydesc_glue(ccx: @CrateContext,
                                           field: uint,
                                           ti: @mut tydesc_info) -> bool {
     let _icx = ccx.insn_ctxt("lazily_emit_simplified_tydesc_glue");
@@ -239,7 +239,7 @@ pub fn lazily_emit_simplified_tydesc_glue(ccx: @crate_ctxt,
 }
 
 
-pub fn lazily_emit_tydesc_glue(ccx: @crate_ctxt,
+pub fn lazily_emit_tydesc_glue(ccx: @CrateContext,
                                field: uint,
                                ti: @mut tydesc_info) {
     let _icx = ccx.insn_ctxt("lazily_emit_tydesc_glue");
@@ -636,7 +636,7 @@ pub fn incr_refcnt_of_boxed(cx: block, box_ptr: ValueRef) {
 
 
 // Chooses the addrspace for newly declared types.
-pub fn declare_tydesc_addrspace(ccx: @crate_ctxt, t: ty::t) -> addrspace {
+pub fn declare_tydesc_addrspace(ccx: @CrateContext, t: ty::t) -> addrspace {
     if !ty::type_needs_drop(ccx.tcx, t) {
         return default_addrspace;
     } else if ty::type_is_immediate(t) {
@@ -650,7 +650,7 @@ pub fn declare_tydesc_addrspace(ccx: @crate_ctxt, t: ty::t) -> addrspace {
 }
 
 // Generates the declaration for (but doesn't emit) a type descriptor.
-pub fn declare_tydesc(ccx: @crate_ctxt, t: ty::t) -> @mut tydesc_info {
+pub fn declare_tydesc(ccx: @CrateContext, t: ty::t) -> @mut tydesc_info {
     let _icx = ccx.insn_ctxt("declare_tydesc");
     // If emit_tydescs already ran, then we shouldn't be creating any new
     // tydescs.
@@ -698,7 +698,7 @@ pub fn declare_tydesc(ccx: @crate_ctxt, t: ty::t) -> @mut tydesc_info {
 
 pub type glue_helper = fn@(block, ValueRef, ty::t);
 
-pub fn declare_generic_glue(ccx: @crate_ctxt, t: ty::t, llfnty: TypeRef,
+pub fn declare_generic_glue(ccx: @CrateContext, t: ty::t, llfnty: TypeRef,
                             +name: ~str) -> ValueRef {
     let _icx = ccx.insn_ctxt("declare_generic_glue");
     let name = name;
@@ -717,7 +717,7 @@ pub fn declare_generic_glue(ccx: @crate_ctxt, t: ty::t, llfnty: TypeRef,
     return llfn;
 }
 
-pub fn make_generic_glue_inner(ccx: @crate_ctxt,
+pub fn make_generic_glue_inner(ccx: @CrateContext,
                                t: ty::t,
                                llfn: ValueRef,
                                helper: glue_helper)
@@ -742,7 +742,7 @@ pub fn make_generic_glue_inner(ccx: @crate_ctxt,
     return llfn;
 }
 
-pub fn make_generic_glue(ccx: @crate_ctxt, t: ty::t, llfn: ValueRef,
+pub fn make_generic_glue(ccx: @CrateContext, t: ty::t, llfn: ValueRef,
                          helper: glue_helper, name: ~str)
                       -> ValueRef {
     let _icx = ccx.insn_ctxt("make_generic_glue");
@@ -758,7 +758,7 @@ pub fn make_generic_glue(ccx: @crate_ctxt, t: ty::t, llfn: ValueRef,
     return llval;
 }
 
-pub fn emit_tydescs(ccx: @crate_ctxt) {
+pub fn emit_tydescs(ccx: @CrateContext) {
     let _icx = ccx.insn_ctxt("emit_tydescs");
     // As of this point, allow no more tydescs to be created.
     ccx.finished_tydescs = true;

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -27,7 +27,7 @@ use syntax::ast_util::local_def;
 // `translate` will be true if this function is allowed to translate the
 // item and false otherwise. Currently, this parameter is set to false when
 // translating default methods.
-pub fn maybe_instantiate_inline(ccx: @crate_ctxt, fn_id: ast::def_id,
+pub fn maybe_instantiate_inline(ccx: @CrateContext, fn_id: ast::def_id,
                                 translate: bool)
     -> ast::def_id {
     let _icx = ccx.insn_ctxt("maybe_instantiate_inline");
@@ -86,8 +86,11 @@ pub fn maybe_instantiate_inline(ccx: @crate_ctxt, fn_id: ast::def_id,
           csearch::found(ast::ii_method(impl_did, mth)) => {
             ccx.stats.n_inlines += 1;
             ccx.external.insert(fn_id, Some(mth.id));
-            let {bounds: impl_bnds, region_param: _, ty: _} =
-                ty::lookup_item_type(ccx.tcx, impl_did);
+            let ty::ty_param_bounds_and_ty {
+                bounds: impl_bnds,
+                region_param: _,
+                ty: _
+            } = ty::lookup_item_type(ccx.tcx, impl_did);
             if translate && (*impl_bnds).len() + mth.tps.len() == 0u {
                 let llfn = get_item_val(ccx, mth.id);
                 let path = vec::append(

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -33,7 +33,7 @@ pub type tag_metrics = {
 };
 
 // Returns the number of bytes clobbered by a Store to this type.
-pub fn llsize_of_store(cx: @crate_ctxt, t: TypeRef) -> uint {
+pub fn llsize_of_store(cx: @CrateContext, t: TypeRef) -> uint {
     unsafe {
         return llvm::LLVMStoreSizeOfType(cx.td.lltd, t) as uint;
     }
@@ -41,7 +41,7 @@ pub fn llsize_of_store(cx: @crate_ctxt, t: TypeRef) -> uint {
 
 // Returns the number of bytes between successive elements of type T in an
 // array of T. This is the "ABI" size. It includes any ABI-mandated padding.
-pub fn llsize_of_alloc(cx: @crate_ctxt, t: TypeRef) -> uint {
+pub fn llsize_of_alloc(cx: @CrateContext, t: TypeRef) -> uint {
     unsafe {
         return llvm::LLVMABISizeOfType(cx.td.lltd, t) as uint;
     }
@@ -55,7 +55,7 @@ pub fn llsize_of_alloc(cx: @crate_ctxt, t: TypeRef) -> uint {
 // that LLVM *does* distinguish between e.g. a 1-bit value and an 8-bit value
 // at the codegen level! In general you should prefer `llbitsize_of_real`
 // below.
-pub fn llsize_of_real(cx: @crate_ctxt, t: TypeRef) -> uint {
+pub fn llsize_of_real(cx: @CrateContext, t: TypeRef) -> uint {
     unsafe {
         let nbits = llvm::LLVMSizeOfTypeInBits(cx.td.lltd, t) as uint;
         if nbits & 7u != 0u {
@@ -68,14 +68,14 @@ pub fn llsize_of_real(cx: @crate_ctxt, t: TypeRef) -> uint {
 }
 
 /// Returns the "real" size of the type in bits.
-pub fn llbitsize_of_real(cx: @crate_ctxt, t: TypeRef) -> uint {
+pub fn llbitsize_of_real(cx: @CrateContext, t: TypeRef) -> uint {
     unsafe {
         llvm::LLVMSizeOfTypeInBits(cx.td.lltd, t) as uint
     }
 }
 
 /// Returns the size of the type as an LLVM constant integer value.
-pub fn llsize_of(cx: @crate_ctxt, t: TypeRef) -> ValueRef {
+pub fn llsize_of(cx: @CrateContext, t: TypeRef) -> ValueRef {
     // Once upon a time, this called LLVMSizeOf, which does a
     // getelementptr(1) on a null pointer and casts to an int, in
     // order to obtain the type size as a value without requiring the
@@ -89,7 +89,7 @@ pub fn llsize_of(cx: @crate_ctxt, t: TypeRef) -> ValueRef {
 // Returns the "default" size of t (see above), or 1 if the size would
 // be zero.  This is important for things like vectors that expect
 // space to be consumed.
-pub fn nonzero_llsize_of(cx: @crate_ctxt, t: TypeRef) -> ValueRef {
+pub fn nonzero_llsize_of(cx: @CrateContext, t: TypeRef) -> ValueRef {
     if llbitsize_of_real(cx, t) == 0 {
         unsafe { llvm::LLVMConstInt(cx.int_type, 1, False) }
     } else {
@@ -101,7 +101,7 @@ pub fn nonzero_llsize_of(cx: @crate_ctxt, t: TypeRef) -> ValueRef {
 // The preffered alignment may be larger than the alignment used when
 // packing the type into structs. This will be used for things like
 // allocations inside a stack frame, which LLVM has a free hand in.
-pub fn llalign_of_pref(cx: @crate_ctxt, t: TypeRef) -> uint {
+pub fn llalign_of_pref(cx: @CrateContext, t: TypeRef) -> uint {
     unsafe {
         return llvm::LLVMPreferredAlignmentOfType(cx.td.lltd, t) as uint;
     }
@@ -110,7 +110,7 @@ pub fn llalign_of_pref(cx: @crate_ctxt, t: TypeRef) -> uint {
 // Returns the minimum alignment of a type required by the plattform.
 // This is the alignment that will be used for struct fields, arrays,
 // and similar ABI-mandated things.
-pub fn llalign_of_min(cx: @crate_ctxt, t: TypeRef) -> uint {
+pub fn llalign_of_min(cx: @CrateContext, t: TypeRef) -> uint {
     unsafe {
         return llvm::LLVMABIAlignmentOfType(cx.td.lltd, t) as uint;
     }
@@ -119,7 +119,7 @@ pub fn llalign_of_min(cx: @crate_ctxt, t: TypeRef) -> uint {
 // Returns the "default" alignment of t, which is calculated by casting
 // null to a record containing a single-bit followed by a t value, then
 // doing gep(0,1) to get at the trailing (and presumably padded) t cell.
-pub fn llalign_of(cx: @crate_ctxt, t: TypeRef) -> ValueRef {
+pub fn llalign_of(cx: @CrateContext, t: TypeRef) -> ValueRef {
     unsafe {
         return llvm::LLVMConstIntCast(
             lib::llvm::llvm::LLVMAlignOf(t), cx.int_type, False);
@@ -127,7 +127,7 @@ pub fn llalign_of(cx: @crate_ctxt, t: TypeRef) -> ValueRef {
 }
 
 // Computes the size of the data part of an enum.
-pub fn static_size_of_enum(cx: @crate_ctxt, t: ty::t) -> uint {
+pub fn static_size_of_enum(cx: @CrateContext, t: ty::t) -> uint {
     if cx.enum_sizes.contains_key(&t) {
         return cx.enum_sizes.get(&t);
     }

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -36,13 +36,13 @@ use syntax::ast_map::{path, path_mod, path_name};
 use syntax::ast_util::local_def;
 use syntax::parse::token::special_idents;
 
-pub fn monomorphic_fn(ccx: @crate_ctxt,
+pub fn monomorphic_fn(ccx: @CrateContext,
                       fn_id: ast::def_id,
                       real_substs: ~[ty::t],
                       vtables: Option<typeck::vtable_res>,
                       impl_did_opt: Option<ast::def_id>,
                       ref_id: Option<ast::node_id>) ->
-                      {val: ValueRef, must_cast: bool} {
+                      (ValueRef, bool) {
     let _icx = ccx.insn_ctxt("monomorphic_fn");
     let mut must_cast = false;
     let substs = vec::map(real_substs, |t| {
@@ -73,7 +73,7 @@ pub fn monomorphic_fn(ccx: @crate_ctxt,
       Some(val) => {
         debug!("leaving monomorphic fn %s",
                ty::item_path_str(ccx.tcx, fn_id));
-        return {val: val, must_cast: must_cast};
+        return (val, must_cast);
       }
       None => ()
     }
@@ -94,8 +94,7 @@ pub fn monomorphic_fn(ccx: @crate_ctxt,
       => (pt, i.ident, i.span),
       ast_map::node_foreign_item(*) => {
         // Foreign externs don't have to be monomorphized.
-        return {val: get_item_val(ccx, fn_id.node),
-                must_cast: true};
+        return (get_item_val(ccx, fn_id.node), true);
       }
       ast_map::node_dtor(_, dtor, _, pt) =>
           (pt, special_idents::dtor, dtor.span),
@@ -261,7 +260,7 @@ pub fn monomorphic_fn(ccx: @crate_ctxt,
     ccx.monomorphizing.insert(fn_id, depth);
 
     debug!("leaving monomorphic fn %s", ty::item_path_str(ccx.tcx, fn_id));
-    {val: lldecl, must_cast: must_cast}
+    (lldecl, must_cast)
 }
 
 pub fn normalize_for_monomorphization(tcx: ty::ctxt,
@@ -319,7 +318,7 @@ pub fn normalize_for_monomorphization(tcx: ty::ctxt,
     }
 }
 
-pub fn make_mono_id(ccx: @crate_ctxt, item: ast::def_id, substs: ~[ty::t],
+pub fn make_mono_id(ccx: @CrateContext, item: ast::def_id, substs: ~[ty::t],
                     vtables: Option<typeck::vtable_res>,
                     impl_did_opt: Option<ast::def_id>,
                     param_uses: Option<~[type_use::type_uses]>) -> mono_id {

--- a/src/librustc/middle/trans/shape.rs
+++ b/src/librustc/middle/trans/shape.rs
@@ -40,7 +40,7 @@ pub struct Ctxt {
     pad2: u32
 }
 
-pub fn mk_global(ccx: @crate_ctxt,
+pub fn mk_global(ccx: @CrateContext,
                  name: ~str,
                  llval: ValueRef,
                  internal: bool)

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -81,7 +81,7 @@ pub fn alloc_raw(bcx: block, unit_ty: ty::t,
     let vecbodyty = ty::mk_mut_unboxed_vec(bcx.tcx(), unit_ty);
     let vecsize = Add(bcx, alloc, llsize_of(ccx, ccx.opaque_vec_type));
 
-    let {bcx, box: bx, body} =
+    let MallocResult {bcx, box: bx, body} =
         base::malloc_general_dyn(bcx, vecbodyty, heap, vecsize);
     Store(bcx, fill, GEPi(bcx, body, [0u, abi::vec_elt_fill]));
     Store(bcx, alloc, GEPi(bcx, body, [0u, abi::vec_elt_alloc]));
@@ -144,7 +144,7 @@ pub struct VecTypes {
 }
 
 pub impl VecTypes {
-    fn to_str(ccx: @crate_ctxt) -> ~str {
+    fn to_str(ccx: @CrateContext) -> ~str {
         fmt!("VecTypes {vec_ty=%s, unit_ty=%s, llunit_ty=%s, llunit_size=%s}",
              ty_to_str(ccx.tcx, self.vec_ty),
              ty_to_str(ccx.tcx, self.unit_ty),

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -20,7 +20,7 @@ use util::ppaux;
 use std::oldmap::HashMap;
 use syntax::ast;
 
-pub fn type_of_explicit_arg(ccx: @crate_ctxt, arg: ty::arg) -> TypeRef {
+pub fn type_of_explicit_arg(ccx: @CrateContext, arg: ty::arg) -> TypeRef {
     let llty = type_of(ccx, arg.ty);
     match ty::resolved_mode(ccx.tcx, arg.mode) {
         ast::by_val => llty,
@@ -35,12 +35,12 @@ pub fn type_of_explicit_arg(ccx: @crate_ctxt, arg: ty::arg) -> TypeRef {
     }
 }
 
-pub fn type_of_explicit_args(ccx: @crate_ctxt,
+pub fn type_of_explicit_args(ccx: @CrateContext,
                              inputs: &[ty::arg]) -> ~[TypeRef] {
     inputs.map(|arg| type_of_explicit_arg(ccx, *arg))
 }
 
-pub fn type_of_fn(cx: @crate_ctxt, inputs: &[ty::arg],
+pub fn type_of_fn(cx: @CrateContext, inputs: &[ty::arg],
                   output: ty::t) -> TypeRef {
     unsafe {
         let mut atys: ~[TypeRef] = ~[];
@@ -58,7 +58,7 @@ pub fn type_of_fn(cx: @crate_ctxt, inputs: &[ty::arg],
 }
 
 // Given a function type and a count of ty params, construct an llvm type
-pub fn type_of_fn_from_ty(cx: @crate_ctxt, fty: ty::t) -> TypeRef {
+pub fn type_of_fn_from_ty(cx: @CrateContext, fty: ty::t) -> TypeRef {
     match ty::get(fty).sty {
         ty::ty_closure(ref f) => type_of_fn(cx, f.sig.inputs, f.sig.output),
         ty::ty_bare_fn(ref f) => type_of_fn(cx, f.sig.inputs, f.sig.output),
@@ -68,7 +68,7 @@ pub fn type_of_fn_from_ty(cx: @crate_ctxt, fty: ty::t) -> TypeRef {
     }
 }
 
-pub fn type_of_non_gc_box(cx: @crate_ctxt, t: ty::t) -> TypeRef {
+pub fn type_of_non_gc_box(cx: @CrateContext, t: ty::t) -> TypeRef {
     assert !ty::type_needs_infer(t);
 
     let t_norm = ty::normalize_ty(cx.tcx, t);
@@ -101,7 +101,7 @@ pub fn type_of_non_gc_box(cx: @crate_ctxt, t: ty::t) -> TypeRef {
 //     recursive types. For example, `static_size_of_enum()` relies on this
 //     behavior.
 
-pub fn sizing_type_of(cx: @crate_ctxt, t: ty::t) -> TypeRef {
+pub fn sizing_type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
     if cx.llsizingtypes.contains_key(&t) {
         return cx.llsizingtypes.get(&t);
     }
@@ -178,7 +178,7 @@ pub fn sizing_type_of(cx: @crate_ctxt, t: ty::t) -> TypeRef {
 }
 
 // NB: If you update this, be sure to update `sizing_type_of()` as well.
-pub fn type_of(cx: @crate_ctxt, t: ty::t) -> TypeRef {
+pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
     debug!("type_of %?: %?", t, ty::get(t));
 
     // Check the cache.
@@ -325,7 +325,7 @@ pub fn type_of(cx: @crate_ctxt, t: ty::t) -> TypeRef {
     return llty;
 }
 
-pub fn enum_body_types(cx: @crate_ctxt, did: ast::def_id, t: ty::t)
+pub fn enum_body_types(cx: @CrateContext, did: ast::def_id, t: ty::t)
                     -> ~[TypeRef] {
     let univar = ty::enum_is_univariant(cx.tcx, did);
     if !univar {
@@ -345,7 +345,7 @@ pub fn enum_body_types(cx: @crate_ctxt, did: ast::def_id, t: ty::t)
     }
 }
 
-pub fn fill_type_of_enum(cx: @crate_ctxt,
+pub fn fill_type_of_enum(cx: @CrateContext,
                          did: ast::def_id,
                          t: ty::t,
                          llty: TypeRef) {
@@ -356,7 +356,7 @@ pub fn fill_type_of_enum(cx: @crate_ctxt,
 // Want refinements! (Or case classes, I guess
 pub enum named_ty { a_struct, an_enum }
 
-pub fn llvm_type_name(cx: @crate_ctxt,
+pub fn llvm_type_name(cx: @CrateContext,
                       what: named_ty,
                       did: ast::def_id,
                       tps: ~[ty::t]) -> ~str {
@@ -376,7 +376,7 @@ pub fn llvm_type_name(cx: @crate_ctxt,
     );
 }
 
-pub fn type_of_dtor(ccx: @crate_ctxt, self_ty: ty::t) -> TypeRef {
+pub fn type_of_dtor(ccx: @CrateContext, self_ty: ty::t) -> TypeRef {
     unsafe {
         T_fn(~[T_ptr(type_of(ccx, ty::mk_nil(ccx.tcx))), // output pointer
                T_ptr(type_of(ccx, self_ty))],            // self arg
@@ -384,14 +384,14 @@ pub fn type_of_dtor(ccx: @crate_ctxt, self_ty: ty::t) -> TypeRef {
     }
 }
 
-pub fn type_of_rooted(ccx: @crate_ctxt, t: ty::t) -> TypeRef {
+pub fn type_of_rooted(ccx: @CrateContext, t: ty::t) -> TypeRef {
     let addrspace = base::get_tydesc(ccx, t).addrspace;
     debug!("type_of_rooted %s in addrspace %u",
            ty_to_str(ccx.tcx, t), addrspace as uint);
     return T_root(type_of(ccx, t), addrspace);
 }
 
-pub fn type_of_glue_fn(ccx: @crate_ctxt, t: ty::t) -> TypeRef {
+pub fn type_of_glue_fn(ccx: @CrateContext, t: ty::t) -> TypeRef {
     let tydescpp = T_ptr(T_ptr(ccx.tydesc_type));
     let llty = T_ptr(type_of(ccx, t));
     return T_fn(~[T_ptr(T_nil()), T_ptr(T_nil()), tydescpp, llty],

--- a/src/librustc/middle/trans/uniq.rs
+++ b/src/librustc/middle/trans/uniq.rs
@@ -42,8 +42,11 @@ pub fn duplicate(bcx: block, src_box: ValueRef, src_ty: ty::t) -> Result {
     let body_datum = src_datum.box_body(bcx);
 
     // Malloc space in exchange heap and copy src into it
-    let {bcx: bcx, box: dst_box, body: dst_body} =
-        malloc_unique(bcx, body_datum.ty);
+    let MallocResult {
+        bcx: bcx,
+        box: dst_box,
+        body: dst_body
+    } = malloc_unique(bcx, body_datum.ty);
     body_datum.copy_to(bcx, datum::INIT, dst_body);
 
     // Copy the type descriptor

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -117,8 +117,11 @@ pub fn ast_path_to_substs_and_ty<AC: AstConv, RS: region_scope Copy Durable>(
         path: @ast::path)
      -> ty_param_substs_and_ty {
     let tcx = self.tcx();
-    let {bounds: decl_bounds, region_param: decl_rp, ty: decl_ty} =
-        self.get_item_ty(did);
+    let ty::ty_param_bounds_and_ty {
+        bounds: decl_bounds,
+        region_param: decl_rp,
+        ty: decl_ty
+    } = self.get_item_ty(did);
 
     debug!("ast_path_to_substs_and_ty: did=%? decl_rp=%?",
            did, decl_rp);
@@ -159,7 +162,8 @@ pub fn ast_path_to_substs_and_ty<AC: AstConv, RS: region_scope Copy Durable>(
 
     let substs = substs {self_r:self_r, self_ty:None, tps:tps};
     let ty = ty::subst(tcx, &substs, decl_ty);
-    {substs: substs, ty: ty}
+
+    ty_param_substs_and_ty { substs: substs, ty: ty }
 }
 
 pub fn ast_path_to_ty<AC: AstConv, RS: region_scope Copy Durable>(
@@ -172,11 +176,14 @@ pub fn ast_path_to_ty<AC: AstConv, RS: region_scope Copy Durable>(
     // Look up the polytype of the item and then substitute the provided types
     // for any type/region parameters.
     let tcx = self.tcx();
-    let {substs: substs, ty: ty} =
-        ast_path_to_substs_and_ty(self, rscope, did, path);
+    let ty::ty_param_substs_and_ty {
+        substs: substs,
+        ty: ty
+    } = ast_path_to_substs_and_ty(self, rscope, did, path);
     write_ty_to_tcx(tcx, path_id, ty);
     write_substs_to_tcx(tcx, path_id, /*bad*/copy substs.tps);
-    return {substs: substs, ty: ty};
+
+    ty_param_substs_and_ty { substs: substs, ty: ty }
 }
 
 pub const NO_REGIONS: uint = 1;

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -93,10 +93,10 @@ pub fn check_pat_variant(pcx: pat_ctxt, pat: @ast::pat, path: @ast::path,
         ty::ty_enum(_, ref expected_substs) => {
             // Lookup the enum and variant def ids:
             let v_def = lookup_def(pcx.fcx, path.span, pat.id);
-            let v_def_ids = ast_util::variant_def_ids(v_def);
+            let (enm, var) = ast_util::variant_def_ids(v_def);
 
             // Assign the pattern the type of the *enum*, not the variant.
-            let enum_tpt = ty::lookup_item_type(tcx, v_def_ids.enm);
+            let enum_tpt = ty::lookup_item_type(tcx, enm);
             instantiate_path(pcx.fcx, path, enum_tpt, pat.span, pat.id,
                              pcx.block_region);
 
@@ -108,9 +108,8 @@ pub fn check_pat_variant(pcx: pat_ctxt, pat: @ast::pat, path: @ast::path,
             // Get the expected types of the arguments.
             arg_types = {
                 let vinfo =
-                    ty::enum_variant_with_id(
-                        tcx, v_def_ids.enm, v_def_ids.var);
-                let var_tpt = ty::lookup_item_type(tcx, v_def_ids.var);
+                    ty::enum_variant_with_id(tcx, enm, var);
+                let var_tpt = ty::lookup_item_type(tcx, var);
                 vinfo.args.map(|t| {
                     if var_tpt.bounds.len() == expected_substs.tps.len() {
                         ty::subst(tcx, expected_substs, *t)

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -641,8 +641,10 @@ pub impl LookupContext {
             ccx: self.fcx.ccx,
             infcx: self.fcx.infcx()
         };
-        let {substs: impl_substs, ty: impl_ty} =
-            impl_self_ty(&vcx, location_info, impl_info.did);
+        let ty::ty_param_substs_and_ty {
+            substs: impl_substs,
+            ty: impl_ty
+        } = impl_self_ty(&vcx, location_info, impl_info.did);
 
         let (impl_ty, impl_substs) =
             self.create_rcvr_ty_and_substs_for_method(

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -137,12 +137,12 @@ pub mod regionck;
 pub mod demand;
 pub mod method;
 
-pub type self_info = {
+pub struct SelfInfo {
     self_ty: ty::t,
     self_id: ast::node_id,
     def_id: ast::def_id,
     explicit_self: ast::self_ty
-};
+}
 
 /// Fields that are part of a `FnCtxt` which are inherited by
 /// closures defined within the function.  For example:
@@ -171,7 +171,7 @@ pub struct FnCtxt {
 
     // Refers to whichever `self` is in scope, even this FnCtxt is
     // for a nested closure that captures `self`
-    self_info: Option<self_info>,
+    self_info: Option<SelfInfo>,
     ret_ty: ty::t,
     // Used by loop bodies that return from the outer function
     indirect_ret_ty: Option<ty::t>,
@@ -246,7 +246,7 @@ pub fn check_bare_fn(ccx: @mut CrateCtxt,
                      decl: &ast::fn_decl,
                      body: ast::blk,
                      id: ast::node_id,
-                     self_info: Option<self_info>) {
+                     self_info: Option<SelfInfo>) {
     let fty = ty::node_id_to_type(ccx.tcx, id);
     match ty::get(fty).sty {
         ty::ty_bare_fn(ref fn_ty) => {
@@ -259,7 +259,7 @@ pub fn check_bare_fn(ccx: @mut CrateCtxt,
 }
 
 pub fn check_fn(ccx: @mut CrateCtxt,
-                +self_info: Option<self_info>,
+                +self_info: Option<SelfInfo>,
                 purity: ast::purity,
                 sigil: Option<ast::Sigil>,
                 fn_sig: &ty::FnSig,
@@ -277,7 +277,7 @@ pub fn check_fn(ccx: @mut CrateCtxt,
     // types with free ones.  The free region references will be bound
     // the node_id of the body block.
 
-    let {isr, self_info, fn_sig} = {
+    let (isr, self_info, fn_sig) = {
         let old_isr = option::map_default(&old_fcx, @Nil,
                                           |fcx| fcx.in_scope_regions);
         replace_bound_regions_in_fn_sig(tcx, old_isr, self_info, fn_sig,
@@ -326,7 +326,7 @@ pub fn check_fn(ccx: @mut CrateCtxt,
         }
     };
 
-    // Update the self_info to contain an accurate self type (taking
+    // Update the SelfInfo to contain an accurate self type (taking
     // into account explicit self).
     let self_info = do self_info.chain_ref |self_info| {
         // If the self type is sty_static, we don't have a self ty.
@@ -341,7 +341,7 @@ pub fn check_fn(ccx: @mut CrateCtxt,
                 self_info.self_ty,
                 self_info.explicit_self.node,
                 TransformTypeNormally);
-            Some({self_ty: ty,.. *self_info})
+            Some(SelfInfo { self_ty: ty,.. *self_info })
         }
     };
 
@@ -383,7 +383,7 @@ pub fn check_fn(ccx: @mut CrateCtxt,
                      decl: &ast::fn_decl,
                      body: ast::blk,
                      arg_tys: &[ty::t],
-                     self_info: Option<self_info>) {
+                     self_info: Option<SelfInfo>) {
         let tcx = fcx.ccx.tcx;
 
         let assign = fn@(nid: ast::node_id, ty_opt: Option<ty::t>) {
@@ -491,10 +491,12 @@ pub fn check_method(ccx: @mut CrateCtxt,
                     method: @ast::method,
                     self_ty: ty::t,
                     self_impl_def_id: ast::def_id) {
-    let self_info = {self_ty: self_ty,
-                     self_id: method.self_id,
-                     def_id: self_impl_def_id,
-                     explicit_self: method.self_ty };
+    let self_info = SelfInfo {
+        self_ty: self_ty,
+        self_id: method.self_id,
+        def_id: self_impl_def_id,
+        explicit_self: method.self_ty
+    };
     check_bare_fn(ccx, &method.decl, method.body, method.id, Some(self_info));
 }
 
@@ -528,12 +530,15 @@ pub fn check_struct(ccx: @mut CrateCtxt,
     let self_ty = ty::node_id_to_type(tcx, id);
 
     do struct_def.dtor.iter() |dtor| {
-        let class_t = { self_ty: self_ty,
-                        self_id: dtor.node.self_id,
-                        def_id: local_def(id),
-                        explicit_self:
-                            spanned { node: ast::sty_by_ref,
-                                      span: codemap::dummy_sp() } };
+        let class_t = SelfInfo {
+            self_ty: self_ty,
+            self_id: dtor.node.self_id,
+            def_id: local_def(id),
+            explicit_self: spanned {
+                node: ast::sty_by_ref,
+                span: codemap::dummy_sp()
+            }
+        };
         // typecheck the dtor
         let dtor_dec = ast_util::dtor_dec();
         check_bare_fn(ccx, &dtor_dec,
@@ -1050,16 +1055,15 @@ pub fn impl_self_ty(vcx: &VtableContext,
                  -> ty_param_substs_and_ty {
     let tcx = vcx.tcx();
 
-    let {n_tps, region_param, raw_ty} = if did.crate == ast::local_crate {
+    let (n_tps, region_param, raw_ty) = if did.crate == ast::local_crate {
         let region_param = tcx.region_paramd_items.find(&did.node);
         match tcx.items.find(&did.node) {
           Some(ast_map::node_item(@ast::item {
                   node: ast::item_impl(ref ts, _, st, _),
                   _
               }, _)) => {
-            {n_tps: ts.len(),
-             region_param: region_param,
-             raw_ty: vcx.ccx.to_ty(rscope::type_rscope(region_param), st)}
+            (ts.len(), region_param,
+                vcx.ccx.to_ty(rscope::type_rscope(region_param), st))
           }
           Some(ast_map::node_item(@ast::item {
                   node: ast::item_struct(_, ref ts),
@@ -1070,23 +1074,20 @@ pub fn impl_self_ty(vcx: &VtableContext,
                  (doing a no-op subst for the ty params; in the next step,
                  we substitute in fresh vars for them)
                */
-              {n_tps: ts.len(),
-               region_param: region_param,
-               raw_ty: ty::mk_struct(tcx, local_def(class_id),
+              (ts.len(), region_param,
+                  ty::mk_struct(tcx, local_def(class_id),
                       substs {
                         self_r: rscope::bound_self_region(region_param),
                         self_ty: None,
                         tps: ty::ty_params_to_tys(tcx, /*bad*/copy *ts)
-                      })}
+                      }))
           }
           _ => { tcx.sess.bug(~"impl_self_ty: unbound item or item that \
                doesn't have a self_ty"); }
         }
     } else {
         let ity = ty::lookup_item_type(tcx, did);
-        {n_tps: vec::len(*ity.bounds),
-         region_param: ity.region_param,
-         raw_ty: ity.ty}
+        (vec::len(*ity.bounds), ity.region_param, ity.ty)
     };
 
     let self_r = if region_param.is_some() {
@@ -1099,7 +1100,8 @@ pub fn impl_self_ty(vcx: &VtableContext,
 
     let substs = substs { self_r: self_r, self_ty: None, tps: tps };
     let substd_ty = ty::subst(tcx, &substs, raw_ty);
-    {substs: substs, ty: substd_ty}
+
+    ty_param_substs_and_ty { substs: substs, ty: substd_ty }
 }
 
 // Only for fields! Returns <none> for methods>
@@ -1163,7 +1165,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         let ret_ty = match structure_of(fcx, sp, in_fty) {
             ty::ty_bare_fn(ty::BareFnTy {sig: ref sig, _}) |
             ty::ty_closure(ty::ClosureTy {sig: ref sig, _}) => {
-                let {fn_sig: sig, _} =
+                let (_, _, sig) =
                     replace_bound_regions_in_fn_sig(
                         tcx, @Nil, None, sig,
                         |_br| fcx.infcx().next_region_var(
@@ -1628,7 +1630,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
             match expected_sty {
                 Some(ty::ty_closure(ref cenv)) => {
                     let id = expr.id;
-                    let {fn_sig: sig, _} =
+                    let (_, _, sig) =
                         replace_bound_regions_in_fn_sig(
                             tcx, @Nil, None, &cenv.sig,
                             |br| ty::re_bound(ty::br_cap_avoid(id, @br)));
@@ -2929,7 +2931,7 @@ pub fn ty_param_bounds_and_ty_for_def(fcx: @mut FnCtxt,
       }
       ast::def_fn(_, ast::extern_fn) => {
         // extern functions are just u8 pointers
-        return {
+        return ty_param_bounds_and_ty {
             bounds: @~[],
             region_param: None,
             ty: ty::mk_ptr(

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -315,8 +315,10 @@ pub fn lookup_vtable(vcx: &VtableContext,
                             // of the thing that we're trying to cast
                             // to some_trait.  If not, then we try the next
                             // impl.
-                            let {substs: substs, ty: for_ty} =
-                                impl_self_ty(vcx, location_info, im.did);
+                            let ty::ty_param_substs_and_ty {
+                                substs: substs,
+                                ty: for_ty
+                            } = impl_self_ty(vcx, location_info, im.did);
                             match infer::mk_subty(vcx.infcx,
                                                   false,
                                                   location_info.span,

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -17,7 +17,7 @@ use core::prelude::*;
 use middle::pat_util;
 use middle::ty::arg;
 use middle::ty;
-use middle::typeck::check::{FnCtxt, self_info};
+use middle::typeck::check::{FnCtxt, SelfInfo};
 use middle::typeck::infer::{force_all, resolve_all, resolve_region};
 use middle::typeck::infer::{resolve_type};
 use middle::typeck::infer;
@@ -261,7 +261,7 @@ pub fn resolve_type_vars_in_expr(fcx: @mut FnCtxt, e: @ast::expr) -> bool {
 pub fn resolve_type_vars_in_fn(fcx: @mut FnCtxt,
                                decl: &ast::fn_decl,
                                blk: ast::blk,
-                               self_info: Option<self_info>) -> bool {
+                               self_info: Option<SelfInfo>) -> bool {
     let wbcx = @mut WbCtxt { fcx: fcx, success: true };
     let visit = mk_visitor();
     (visit.visit_block)(blk, wbcx, visit);

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -145,7 +145,7 @@ pub fn get_base_type_def_id(inference_context: @mut InferCtxt,
 
 
 pub fn method_to_MethodInfo(ast_method: @method) -> @MethodInfo {
-    @{
+    @MethodInfo {
         did: local_def(ast_method.id),
         n_tps: ast_method.tps.len(),
         ident: ast_method.ident,
@@ -345,7 +345,7 @@ pub impl CoherenceChecker {
 
             let provided_method_info =
                 @ProvidedMethodInfo {
-                    method_info: @{
+                    method_info: @MethodInfo {
                         did: new_did,
                         n_tps: trait_method.tps.len(),
                         ident: trait_method.ident,
@@ -792,7 +792,7 @@ pub impl CoherenceChecker {
                     }
                 }
 
-                return @{
+                return @Impl {
                     did: local_def(item.id),
                     ident: item.ident,
                     methods: methods
@@ -925,7 +925,7 @@ pub impl CoherenceChecker {
 
             let provided_method_info =
                 @ProvidedMethodInfo {
-                    method_info: @{
+                    method_info: @MethodInfo {
                         did: new_did,
                         n_tps: trait_method_info.ty.tps.len(),
                         ident: trait_method_info.ty.ident,

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -34,7 +34,7 @@ use core::prelude::*;
 
 use metadata::csearch;
 use middle::ty::{InstantiatedTraitRef, arg};
-use middle::ty::{substs, ty_param_substs_and_ty};
+use middle::ty::{substs, ty_param_bounds_and_ty, ty_param_substs_and_ty};
 use middle::ty;
 use middle::typeck::astconv::{AstConv, ty_of_arg};
 use middle::typeck::astconv::{ast_ty_to_ty};
@@ -174,9 +174,11 @@ pub fn get_enum_variant_types(ccx: @mut CrateCtxt,
             }
 
             ast::struct_variant_kind(struct_def) => {
-                let tpt = {bounds: ty_param_bounds(ccx, ty_params),
-                           region_param: rp,
-                           ty: enum_ty};
+                let tpt = ty_param_bounds_and_ty {
+                    bounds: ty_param_bounds(ccx, ty_params),
+                    region_param: rp,
+                    ty: enum_ty
+                };
 
                 convert_struct(ccx,
                                rp,
@@ -203,9 +205,11 @@ pub fn get_enum_variant_types(ccx: @mut CrateCtxt,
         match result_ty {
             None => {}
             Some(result_ty) => {
-                let tpt = {bounds: ty_param_bounds(ccx, ty_params),
-                           region_param: rp,
-                           ty: result_ty};
+                let tpt = ty_param_bounds_and_ty {
+                    bounds: ty_param_bounds(ccx, ty_params),
+                    region_param: rp,
+                    ty: result_ty
+                };
                 tcx.tcache.insert(local_def(variant.node.id), tpt);
                 write_ty_to_tcx(tcx, variant.node.id, result_ty);
             }
@@ -261,9 +265,10 @@ pub fn ensure_trait_methods(ccx: @mut CrateCtxt,
         let bounds = @(*trait_bounds + ~[@~[ty::bound_trait(trait_ty)]]
                        + *m.tps);
         ccx.tcx.tcache.insert(local_def(am.id),
-                              {bounds: bounds,
-                               region_param: rp,
-                               ty: ty});
+                              ty_param_bounds_and_ty {
+                                bounds: bounds,
+                                region_param: rp,
+                                ty: ty});
     }
 
 
@@ -541,9 +546,11 @@ pub fn convert_field(ccx: @mut CrateCtxt,
     write_ty_to_tcx(ccx.tcx, v.node.id, tt);
     /* add the field to the tcache */
     ccx.tcx.tcache.insert(local_def(v.node.id),
-                          {bounds: bounds,
-                           region_param: rp,
-                           ty: tt});
+                          ty::ty_param_bounds_and_ty {
+                              bounds: bounds,
+                              region_param: rp,
+                              ty: tt
+                          });
 }
 
 pub struct ConvertedMethod {
@@ -569,9 +576,11 @@ pub fn convert_methods(ccx: @mut CrateCtxt,
 
             // n.b.: the type of a method is parameterized by both
             // the tps on the receiver and those on the method itself
-            {bounds: @(vec::append(/*bad*/copy *rcvr_bounds, *bounds)),
-             region_param: rp,
-             ty: fty});
+            ty_param_bounds_and_ty {
+                bounds: @(vec::append(/*bad*/copy *rcvr_bounds, *bounds)),
+                region_param: rp,
+                ty: fty
+            });
         write_ty_to_tcx(tcx, m.id, fty);
         ConvertedMethod {mty: mty, id: m.id,
                          span: m.span, body_id: m.body.node.id}
@@ -615,9 +624,10 @@ pub fn convert(ccx: @mut CrateCtxt, it: @ast::item) {
         let selfty = ccx.to_ty(type_rscope(rp), selfty);
         write_ty_to_tcx(tcx, it.id, selfty);
         tcx.tcache.insert(local_def(it.id),
-                          {bounds: i_bounds,
-                           region_param: rp,
-                           ty: selfty});
+                          ty_param_bounds_and_ty {
+                            bounds: i_bounds,
+                            region_param: rp,
+                            ty: selfty});
 
         // XXX: Bad copy of `ms` below.
         let cms = convert_methods(ccx, /*bad*/copy *ms, rp, i_bounds);
@@ -636,7 +646,7 @@ pub fn convert(ccx: @mut CrateCtxt, it: @ast::item) {
 
         let (_, provided_methods) =
             split_trait_methods(/*bad*/copy *trait_methods);
-        let {bounds, _} = mk_substs(ccx, /*bad*/copy *tps, rp);
+        let (bounds, _) = mk_substs(ccx, /*bad*/copy *tps, rp);
         let _ = convert_methods(ccx, provided_methods, rp, bounds);
       }
       ast::item_struct(struct_def, tps) => {
@@ -682,16 +692,17 @@ pub fn convert_struct(ccx: @mut CrateCtxt,
                 ast_util::dtor_dec()));
         write_ty_to_tcx(tcx, dtor.node.id, t_dtor);
         tcx.tcache.insert(local_def(dtor.node.id),
-                          {bounds: tpt.bounds,
-                           region_param: rp,
-                           ty: t_dtor});
+                          ty_param_bounds_and_ty {
+                            bounds: tpt.bounds,
+                            region_param: rp,
+                            ty: t_dtor});
     };
 
     // Write the type of each of the members
     for struct_def.fields.each |f| {
        convert_field(ccx, rp, tpt.bounds, *f);
     }
-    let {bounds: _, substs: substs} = mk_substs(ccx, tps, rp);
+    let (_, substs) = mk_substs(ccx, tps, rp);
     let selfty = ty::mk_struct(tcx, local_def(id), substs);
 
     // If this struct is enum-like or tuple-like, create the type of its
@@ -711,7 +722,7 @@ pub fn convert_struct(ccx: @mut CrateCtxt,
                             &local_def(field.node.id)).ty);
                 let ctor_fn_ty = ty::mk_ctor_fn(tcx, inputs, selfty);
                 write_ty_to_tcx(tcx, ctor_id, ctor_fn_ty);
-                tcx.tcache.insert(local_def(ctor_id), {
+                tcx.tcache.insert(local_def(ctor_id), ty_param_bounds_and_ty {
                     bounds: tpt.bounds,
                     region_param: tpt.region_param,
                     ty: ctor_fn_ty
@@ -733,27 +744,31 @@ pub fn convert_foreign(ccx: @mut CrateCtxt, i: @ast::foreign_item) {
 pub fn ty_of_method(ccx: @mut CrateCtxt,
                     m: @ast::method,
                     rp: Option<ty::region_variance>) -> ty::method {
-    {ident: m.ident,
-     tps: ty_param_bounds(ccx, m.tps),
-     fty: astconv::ty_of_bare_fn(ccx, type_rscope(rp), m.purity,
-                                 ast::RustAbi, m.decl),
-     self_ty: m.self_ty.node,
-     vis: m.vis,
-     def_id: local_def(m.id)}
+    ty::method {
+        ident: m.ident,
+        tps: ty_param_bounds(ccx, m.tps),
+        fty: astconv::ty_of_bare_fn(ccx, type_rscope(rp), m.purity,
+                                    ast::RustAbi, m.decl),
+        self_ty: m.self_ty.node,
+        vis: m.vis,
+        def_id: local_def(m.id)
+    }
 }
 
 pub fn ty_of_ty_method(self: @mut CrateCtxt,
                        m: ast::ty_method,
                        rp: Option<ty::region_variance>,
                        id: ast::def_id) -> ty::method {
-    {ident: m.ident,
-     tps: ty_param_bounds(self, m.tps),
-     fty: astconv::ty_of_bare_fn(self, type_rscope(rp), m.purity,
-                                 ast::RustAbi, m.decl),
-     // assume public, because this is only invoked on trait methods
-     self_ty: m.self_ty.node,
-     vis: ast::public,
-     def_id: id}
+    ty::method {
+        ident: m.ident,
+        tps: ty_param_bounds(self, m.tps),
+        fty: astconv::ty_of_bare_fn(self, type_rscope(rp), m.purity,
+                                    ast::RustAbi, m.decl),
+        // assume public, because this is only invoked on trait methods
+        self_ty: m.self_ty.node,
+        vis: ast::public,
+        def_id: id
+    }
 }
 
 /*
@@ -805,9 +820,11 @@ pub fn ty_of_item(ccx: @mut CrateCtxt, it: @ast::item)
         let bounds = ty_param_bounds(ccx, tps);
         let tofd = astconv::ty_of_bare_fn(ccx, empty_rscope, purity,
                                           ast::RustAbi, decl);
-        let tpt = {bounds: bounds,
-                   region_param: None,
-                   ty: ty::mk_bare_fn(ccx.tcx, tofd)};
+        let tpt = ty_param_bounds_and_ty {
+            bounds: bounds,
+            region_param: None,
+            ty: ty::mk_bare_fn(ccx.tcx, tofd)
+        };
         debug!("type of %s (id %d) is %s",
                tcx.sess.str_of(it.ident),
                it.id,
@@ -833,9 +850,11 @@ pub fn ty_of_item(ccx: @mut CrateCtxt, it: @ast::item)
                     ty::mk_with_id(tcx, t0, def_id)
                 }
             };
-            {bounds: ty_param_bounds(ccx, tps),
-             region_param: rp,
-             ty: ty}
+            ty_param_bounds_and_ty {
+                bounds: ty_param_bounds(ccx, tps),
+                region_param: rp,
+                ty: ty
+            }
         };
 
         tcx.tcache.insert(local_def(it.id), tpt);
@@ -843,29 +862,35 @@ pub fn ty_of_item(ccx: @mut CrateCtxt, it: @ast::item)
       }
       ast::item_enum(_, tps) => {
         // Create a new generic polytype.
-        let {bounds: bounds, substs: substs} = mk_substs(ccx, tps, rp);
+        let (bounds, substs) = mk_substs(ccx, tps, rp);
         let t = ty::mk_enum(tcx, local_def(it.id), substs);
-        let tpt = {bounds: bounds,
-                   region_param: rp,
-                   ty: t};
+        let tpt = ty_param_bounds_and_ty {
+            bounds: bounds,
+            region_param: rp,
+            ty: t
+        };
         tcx.tcache.insert(local_def(it.id), tpt);
         return tpt;
       }
       ast::item_trait(tps, _, _) => {
-        let {bounds: bounds, substs: substs} = mk_substs(ccx, tps, rp);
+        let (bounds, substs) = mk_substs(ccx, tps, rp);
         let t = ty::mk_trait(tcx, local_def(it.id), substs, ty::vstore_box);
-        let tpt = {bounds: bounds,
-                   region_param: rp,
-                   ty: t};
+        let tpt = ty_param_bounds_and_ty {
+            bounds: bounds,
+            region_param: rp,
+            ty: t
+        };
         tcx.tcache.insert(local_def(it.id), tpt);
         return tpt;
       }
       ast::item_struct(_, tps) => {
-          let {bounds: bounds, substs: substs} = mk_substs(ccx, tps, rp);
+          let (bounds, substs) = mk_substs(ccx, tps, rp);
           let t = ty::mk_struct(tcx, local_def(it.id), substs);
-          let tpt = {bounds: bounds,
-                     region_param: rp,
-                     ty: t};
+          let tpt = ty_param_bounds_and_ty {
+            bounds: bounds,
+            region_param: rp,
+            ty: t
+          };
           tcx.tcache.insert(local_def(it.id), tpt);
           return tpt;
       }
@@ -883,7 +908,7 @@ pub fn ty_of_foreign_item(ccx: @mut CrateCtxt, it: @ast::foreign_item)
       }
       ast::foreign_item_const(t) => {
         let rb = in_binding_rscope(empty_rscope);
-        return {
+        return ty::ty_param_bounds_and_ty {
             bounds: @~[],
             region_param: None,
             ty: ast_ty_to_ty(ccx, rb, t)
@@ -964,32 +989,33 @@ pub fn ty_of_foreign_fn_decl(ccx: @mut CrateCtxt,
             purity: ast::unsafe_fn,
             sig: ty::FnSig {inputs: input_tys, output: output_ty}
         });
-    let tpt = {bounds: bounds, region_param: None, ty: t_fn};
+    let tpt = ty_param_bounds_and_ty {
+        bounds: bounds,
+        region_param: None,
+        ty: t_fn
+    };
     ccx.tcx.tcache.insert(def_id, tpt);
     return tpt;
 }
 
 pub fn mk_ty_params(ccx: @mut CrateCtxt, atps: ~[ast::ty_param])
-    -> {bounds: @~[ty::param_bounds], params: ~[ty::t]} {
+    -> (@~[ty::param_bounds], ~[ty::t]) {
 
     let mut i = 0u;
     let bounds = ty_param_bounds(ccx, atps);
-    {bounds: bounds,
-     params: vec::map(atps, |atp| {
+    (bounds,
+     vec::map(atps, |atp| {
          let t = ty::mk_param(ccx.tcx, i, local_def(atp.id));
          i += 1u;
          t
-     })}
+     }))
 }
 
 pub fn mk_substs(ccx: @mut CrateCtxt,
                  +atps: ~[ast::ty_param],
                  rp: Option<ty::region_variance>)
-              -> {bounds: @~[ty::param_bounds], substs: ty::substs} {
-    let {bounds, params} = mk_ty_params(ccx, atps);
+              -> (@~[ty::param_bounds], ty::substs) {
+    let (bounds, params) = mk_ty_params(ccx, atps);
     let self_r = rscope::bound_self_region(rp);
-    {
-        bounds: bounds,
-        substs: substs { self_r: self_r, self_ty: None, tps: params }
-    }
+    (bounds, substs { self_r: self_r, self_ty: None, tps: params })
 }

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -138,7 +138,7 @@ pub impl CombineFields {
         let node_a = self.infcx.get(a_id);
         let a_id = node_a.root;
         let a_bounds = &node_a.possible_types;
-        let b_bounds = &{lb: None, ub: Some(b)};
+        let b_bounds = &Bounds { lb: None, ub: Some(b) };
 
         debug!("var_sub_t(%s=%s <: %s)",
                a_id.to_str(),
@@ -159,7 +159,7 @@ pub impl CombineFields {
          *
          * Make a concrete type (`a`) a subtype of the variable `b_id` */
 
-        let a_bounds = &{lb: Some(a), ub: None};
+        let a_bounds = &Bounds { lb: Some(a), ub: None };
         let node_b = self.infcx.get(b_id);
         let b_id = node_b.root;
         let b_bounds = &node_b.possible_types;
@@ -251,7 +251,7 @@ pub impl CombineFields {
         let () = if_ok!(self.bnds(&b.lb, &a.ub));
         let ub = if_ok!(self.merge_bnd(&a.ub, &b.ub, LatticeValue::glb));
         let lb = if_ok!(self.merge_bnd(&a.lb, &b.lb, LatticeValue::lub));
-        let bounds = {lb: lb, ub: ub};
+        let bounds = Bounds { lb: lb, ub: ub };
         debug!("merge(%s): bounds=%s",
                v_id.to_str(),
                bounds.inf_str(self.infcx));
@@ -305,7 +305,7 @@ pub impl LatticeDir for Lub {
     fn combine_fields() -> CombineFields { *self }
     fn bnd<T:Copy>(b: &Bounds<T>) -> Option<T> { b.ub }
     fn with_bnd<T:Copy>(b: &Bounds<T>, +t: T) -> Bounds<T> {
-        {ub: Some(t), ..*b}
+        Bounds { ub: Some(t), ..*b }
     }
 }
 
@@ -319,7 +319,7 @@ pub impl LatticeDir for Glb {
     fn combine_fields() -> CombineFields { *self }
     fn bnd<T:Copy>(b: &Bounds<T>) -> Option<T> { b.lb }
     fn with_bnd<T:Copy>(b: &Bounds<T>, +t: T) -> Bounds<T> {
-        {lb: Some(t), ..*b}
+        Bounds { lb: Some(t), ..*b }
     }
 }
 

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -299,7 +299,10 @@ pub mod unify;
 pub mod coercion;
 
 pub type Bound<T> = Option<T>;
-pub type Bounds<T> = {lb: Bound<T>, ub: Bound<T>};
+pub struct Bounds<T> {
+    lb: Bound<T>,
+    ub: Bound<T>
+}
 
 pub type cres<T> = Result<T,ty::type_err>; // "combine result"
 pub type ures = cres<()>; // "unify result"
@@ -644,7 +647,7 @@ impl @mut InferCtxt {
         let id = self.ty_var_counter;
         self.ty_var_counter += 1;
         let vals = self.ty_var_bindings.vals;
-        vals.insert(id, Root({lb: None, ub: None}, 0u));
+        vals.insert(id, Root(Bounds { lb: None, ub: None }, 0u));
         return TyVid(id);
     }
 
@@ -750,7 +753,7 @@ impl @mut InferCtxt {
             span: span,
             fsig: &ty::FnSig)
          -> (ty::FnSig, isr_alist) {
-        let {fn_sig: fn_sig, isr: isr, _} =
+        let(isr, _, fn_sig) =
             replace_bound_regions_in_fn_sig(self.tcx, @Nil, None, fsig, |br| {
                 // N.B.: The name of the bound region doesn't have anything to
                 // do with the region variable that's created for it.  The

--- a/src/librustc/middle/typeck/infer/resolve.rs
+++ b/src/librustc/middle/typeck/infer/resolve.rs
@@ -51,7 +51,7 @@ use core::prelude::*;
 use middle::ty::{FloatVar, FloatVid, IntVar, IntVid, RegionVid, TyVar, TyVid};
 use middle::ty::{type_is_bot, IntType, UintType};
 use middle::ty;
-use middle::typeck::infer::{cyclic_ty, fixup_err, fres, InferCtxt};
+use middle::typeck::infer::{Bounds, cyclic_ty, fixup_err, fres, InferCtxt};
 use middle::typeck::infer::{region_var_bound_by_region_var, unresolved_ty};
 use middle::typeck::infer::to_str::InferStr;
 use middle::typeck::infer::unify::Root;
@@ -223,10 +223,11 @@ pub impl ResolveState {
             let bounds = nde.possible_types;
 
             let t1 = match bounds {
-              { ub:_, lb:Some(t) } if !type_is_bot(t) => self.resolve_type(t),
-              { ub:Some(t), lb:_ } => self.resolve_type(t),
-              { ub:_, lb:Some(t) } => self.resolve_type(t),
-              { ub:None, lb:None } => {
+              Bounds { ub:_, lb:Some(t) } if !type_is_bot(t) 
+                => self.resolve_type(t),
+              Bounds { ub:Some(t), lb:_ } => self.resolve_type(t),
+              Bounds { ub:_, lb:Some(t) } => self.resolve_type(t),
+              Bounds { ub:None, lb:None } => {
                 if self.should(force_tvar) {
                     self.err = Some(unresolved_ty(vid));
                 }

--- a/src/librustc/middle/typeck/infer/resolve.rs
+++ b/src/librustc/middle/typeck/infer/resolve.rs
@@ -223,7 +223,7 @@ pub impl ResolveState {
             let bounds = nde.possible_types;
 
             let t1 = match bounds {
-              Bounds { ub:_, lb:Some(t) } if !type_is_bot(t) 
+              Bounds { ub:_, lb:Some(t) } if !type_is_bot(t)
                 => self.resolve_type(t),
               Bounds { ub:Some(t), lb:_ } => self.resolve_type(t),
               Bounds { ub:_, lb:Some(t) } => self.resolve_type(t),

--- a/src/librustc/middle/typeck/infer/sub.rs
+++ b/src/librustc/middle/typeck/infer/sub.rs
@@ -160,7 +160,7 @@ pub impl Combine for Sub {
 
         // Second, we instantiate each bound region in the supertype with a
         // fresh concrete region.
-        let {fn_sig: b_sig, isr: skol_isr, _} = {
+        let (skol_isr, _, b_sig) = {
             do replace_bound_regions_in_fn_sig(self.infcx.tcx, @Nil,
                                               None, b) |br| {
                 let skol = self.infcx.region_vars.new_skolemized(br);

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -235,7 +235,11 @@ pub fn lookup_def_ccx(ccx: @mut CrateCtxt, sp: span, id: ast::node_id)
 }
 
 pub fn no_params(t: ty::t) -> ty::ty_param_bounds_and_ty {
-    {bounds: @~[], region_param: None, ty: t}
+    ty::ty_param_bounds_and_ty {
+        bounds: @~[],
+        region_param: None,
+        ty: t
+    }
 }
 
 pub fn require_same_types(

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -68,10 +68,10 @@ pub fn bound_self_region(rp: Option<ty::region_variance>)
     }
 }
 
-pub enum anon_rscope = {anon: ty::Region, base: region_scope};
+pub struct anon_rscope { anon: ty::Region, base: region_scope }
 pub fn in_anon_rscope<RS: region_scope Copy Durable>(self: RS, r: ty::Region)
     -> @anon_rscope {
-    @anon_rscope({anon: r, base: self as region_scope})
+    @anon_rscope { anon: r, base: self as region_scope }
 }
 pub impl region_scope for @anon_rscope {
     pure fn anon_region(_span: span) -> Result<ty::Region, ~str> {

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -19,7 +19,6 @@
 #[crate_type = "lib"];
 
 #[legacy_modes];
-#[legacy_records];
 
 #[allow(non_implicitly_copyable_typarams)];
 #[allow(non_camel_case_types)];

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -131,7 +131,7 @@ fn record(repl: Repl, blk: @ast::blk, intr: @token::ident_interner) -> Repl {
 
 /// Run an input string in a Repl, returning the new Repl.
 fn run(repl: Repl, input: ~str) -> Repl {
-    let options: @session::options = @{
+    let options = @session::options {
         crate_type: session::unknown_crate,
         binary: repl.binary,
         addl_lib_search_paths: repl.lib_search_paths.map(|p| Path(*p)),
@@ -157,7 +157,7 @@ fn run(repl: Repl, input: ~str) -> Repl {
 
     let outputs = driver::build_output_filenames(wrapped, &None, &None, sess);
     debug!("calling compile_upto");
-    let {crate: crate, tcx: _} = driver::compile_upto(sess, cfg, wrapped,
+    let (crate, _) = driver::compile_upto(sess, cfg, wrapped,
                                                  driver::cu_everything,
                                                  Some(outputs));
 
@@ -196,7 +196,7 @@ fn run(repl: Repl, input: ~str) -> Repl {
 fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
     match do task::try {
         let src_path = Path(src_filename);
-        let options: @session::options = @{
+        let options = @session::options {
             binary: binary,
             addl_lib_search_paths: ~[os::getcwd()],
             .. *session::basic_options()

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -64,7 +64,7 @@ impl PackageScript {
         }
 
         let binary = os::args()[0];
-        let options: @session::options = @{
+        let options = @session::options {
             binary: binary,
             crate_type: session::bin_crate,
             .. *session::basic_options()
@@ -72,7 +72,7 @@ impl PackageScript {
         let input = driver::file_input(script);
         let sess = driver::build_session(options, diagnostic::emit);
         let cfg = driver::build_configuration(sess, binary, input);
-        let {crate, _} = driver::compile_upto(sess, cfg, input,
+        let (crate, _) = driver::compile_upto(sess, cfg, input,
                                               driver::cu_parse, None);
         let mut id = None;
         let mut vers = None;

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -599,7 +599,7 @@ pub fn compile_input(sysroot: Option<Path>, input: driver::input, dir: &Path,
     let test_dir = dir.push(~"test");
     let binary = os::args()[0];
     let matches = getopts(flags, driver::optgroups()).get();
-    let options = @{
+    let options = @session::options {
         crate_type: session::unknown_crate,
         optimize: if opt { session::Aggressive } else { session::No },
         test: test,
@@ -612,7 +612,7 @@ pub fn compile_input(sysroot: Option<Path>, input: driver::input, dir: &Path,
         crate_cfg.push(attr::mk_word_item(cfg));
     }
 
-    let options = @{
+    let options = @session::options {
         cfg: vec::append(options.cfg, crate_cfg),
         .. *options
     };
@@ -620,7 +620,7 @@ pub fn compile_input(sysroot: Option<Path>, input: driver::input, dir: &Path,
     let cfg = driver::build_configuration(sess, binary, input);
     let mut outputs = driver::build_output_filenames(input, &None, &None,
                                                      sess);
-    let {crate, _} = driver::compile_upto(sess, cfg, input, driver::cu_parse,
+    let (crate, _) = driver::compile_upto(sess, cfg, input, driver::cu_parse,
                                           Some(outputs));
 
     let mut name = None;

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -48,10 +48,10 @@ pub pure fn stmt_id(s: stmt) -> node_id {
     }
 }
 
-pub fn variant_def_ids(d: def) -> {enm: def_id, var: def_id} {
+pub fn variant_def_ids(d: def) -> (def_id, def_id) {
     match d {
       def_variant(enum_id, var_id) => {
-        return {enm: enum_id, var: var_id}
+        return (enum_id, var_id);
       }
       _ => fail!(~"non-variant in variant_def_ids")
     }


### PR DESCRIPTION
Didn't de-record-ize `front::test` since it meant some changes in libsyntax and when I first attempted it I got LLVM asserts. I shall address it in a subsequent commit hopefully if it turns out not to be a big issue.

Also, removed the duplicate definitions for MethodInfo and Impl in `metadata::decoder`. So there's now only the definition in `middle::resolve`. 
