### PR TITLE
Fix ICE after incorrect number of args in calls

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1198,7 +1198,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
 
                     tcx.sess.span_err(sp, msg);
 
-                    vec::from_fn(expected_arg_count, |_| ty::mk_err(tcx))
+                    vec::from_fn(supplied_arg_count, |_| ty::mk_err(tcx))
                 };
 
                 sig.output

--- a/src/test/compile-fail/issue-4935.rs
+++ b/src/test/compile-fail/issue-4935.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regresion test for issue #4935
+
+fn foo(a: uint) {}
+fn main() { foo(5, 6) } //~ ERROR this function takes 1 parameter but 2 parameters were supplied


### PR DESCRIPTION
Actually a trivial fix. Fixes the issue #4935.
