### PR TITLE
Fix for issue 4875

### DIFF
--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -275,6 +275,10 @@ pub fn resolve_type_vars_in_fn(fcx: @mut FnCtxt,
                 |_bm, pat_id, span, _path| {
             resolve_type_vars_for_node(wbcx, span, pat_id);
         }
+        // Privacy needs the type for the whole pattern, not just each binding
+        if !pat_util::pat_is_binding(fcx.tcx().def_map, arg.pat) {
+            resolve_type_vars_for_node(wbcx, arg.pat.span, arg.pat.id);
+        }
     }
     return wbcx.success;
 }

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -208,7 +208,7 @@ pub struct CrateCtxt {
 // Functions that write types into the node type table
 pub fn write_ty_to_tcx(tcx: ty::ctxt, node_id: ast::node_id, ty: ty::t) {
     debug!("write_ty_to_tcx(%d, %s)", node_id, ppaux::ty_to_str(tcx, ty));
-    oldsmallintmap::insert(*tcx.node_types, node_id as uint, ty);
+    tcx.node_types.insert(node_id as uint, ty);
 }
 pub fn write_substs_to_tcx(tcx: ty::ctxt,
                            node_id: ast::node_id,

--- a/src/test/run-pass/issue-4875.rs
+++ b/src/test/run-pass/issue-4875.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// regression test for issue 4875
+
+pub struct Foo<T> {
+    data: T,
+}
+
+fn foo<T>(Foo{_}: Foo<T>) {
+}
+
+pub fn main() {
+}
+


### PR DESCRIPTION
It looks like the type for the whole pattern wasn't being written back, so when privacy tried to look it up everything died.
