### PR TITLE
Check type when struct is matched against enum-like pattern

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2823,7 +2823,7 @@ pub pure fn ty_fn_ret(fty: t) -> t {
     }
 }
 
-fn is_fn_ty(fty: t) -> bool {
+pub fn is_fn_ty(fty: t) -> bool {
     match get(fty).sty {
         ty_bare_fn(_) => true,
         ty_closure(_) => true,

--- a/src/test/compile-fail/match-struct.rs
+++ b/src/test/compile-fail/match-struct.rs
@@ -1,0 +1,11 @@
+// error-pattern: mismatched types
+
+struct S { a: int }
+enum E { C(int) }
+
+fn main() {
+    match S { a: 1 } {
+        C(_) => (),
+        _ => ()
+    }
+}


### PR DESCRIPTION
Previously check always succeeded because struct type was derived from the matched expression, not the matched pattern.

Fix #4849.
