### PR TITLE
Revert change to stop zeroing the exchange heap

### DIFF
--- a/src/libcore/private/exchange_alloc.rs
+++ b/src/libcore/private/exchange_alloc.rs
@@ -14,7 +14,7 @@ use c_malloc = libc::malloc;
 use c_free = libc::free;
 use managed::raw::{BoxHeaderRepr, BoxRepr};
 use cast::transmute;
-use ptr::null;
+use ptr::{set_memory, null};
 use intrinsic::TyDesc;
 
 pub unsafe fn malloc(td: *TypeDesc, size: uint) -> *c_void {
@@ -24,6 +24,10 @@ pub unsafe fn malloc(td: *TypeDesc, size: uint) -> *c_void {
         let total_size = get_box_size(size, (*td).align);
         let p = c_malloc(total_size as size_t);
         assert p.is_not_null();
+
+        // FIXME #4761: Would be very nice to not memset all allocations
+        let p: *mut u8 = transmute(p);
+        set_memory(p, 0, total_size);
 
         // FIXME #3475: Converting between our two different tydesc types
         let td: *TyDesc = transmute(td);

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -1444,7 +1444,7 @@ pub mod test {
                                 buf_base as uint,
                                 buf_len as uint,
                                 nread));
-                let bytes = vec::from_buf(buf_base, nread as uint);
+                let bytes = vec::from_buf(buf_base, buf_len);
                 let request_str = str::from_bytes(bytes);
 
                 let client_data = get_data_for_uv_handle(
@@ -1452,7 +1452,7 @@ pub mod test {
 
                 let server_kill_msg = (*client_data).server_kill_msg;
                 let write_req = (*client_data).server_write_req;
-                if str::contains(request_str, server_kill_msg) {
+                if (str::contains(request_str, server_kill_msg)) {
                     log(debug, ~"SERVER: client req contains kill_msg!");
                     log(debug, ~"SERVER: sending response to client");
                     read_stop(client_stream_ptr);

--- a/src/rt/memory_region.cpp
+++ b/src/rt/memory_region.cpp
@@ -121,10 +121,8 @@ memory_region::realloc(void *mem, size_t orig_size) {
 }
 
 void *
-memory_region::malloc(size_t size, const char *tag) {
-#   if RUSTRT_TRACK_ALLOCATIONS >= 1
+memory_region::malloc(size_t size, const char *tag, bool zero) {
     size_t old_size = size;
-#   endif
     size += HEADER_SIZE;
     alloc_header *mem = (alloc_header *)::malloc(size);
     if (mem == NULL) {
@@ -145,7 +143,16 @@ memory_region::malloc(size_t size, const char *tag) {
     void *data = get_data(mem);
     claim_alloc(data);
 
+    if(zero) {
+        memset(data, 0, old_size);
+    }
+
     return data;
+}
+
+void *
+memory_region::calloc(size_t size, const char *tag) {
+    return malloc(size, tag, true);
 }
 
 memory_region::~memory_region() {

--- a/src/rt/memory_region.h
+++ b/src/rt/memory_region.h
@@ -77,7 +77,8 @@ private:
 public:
     memory_region(rust_env *env, bool synchronized);
     memory_region(memory_region *parent);
-    void *malloc(size_t size, const char *tag);
+    void *malloc(size_t size, const char *tag, bool zero = true);
+    void *calloc(size_t size, const char *tag);
     void *realloc(void *mem, size_t size);
     void free(void *mem);
     ~memory_region();

--- a/src/rt/rust_exchange_alloc.cpp
+++ b/src/rt/rust_exchange_alloc.cpp
@@ -18,13 +18,21 @@
 uintptr_t exchange_count = 0;
 
 void *
-rust_exchange_alloc::malloc(size_t size) {
+rust_exchange_alloc::malloc(size_t size, bool zero) {
   void *value = ::malloc(size);
   assert(value);
+  if (zero) {
+    memset(value, 0, size);
+  }
 
   sync::increment(exchange_count);
 
   return value;
+}
+
+void *
+rust_exchange_alloc::calloc(size_t size) {
+  return this->malloc(size);
 }
 
 void *

--- a/src/rt/rust_exchange_alloc.h
+++ b/src/rt/rust_exchange_alloc.h
@@ -16,7 +16,8 @@
 
 class rust_exchange_alloc {
  public:
-    void *malloc(size_t size);
+    void *malloc(size_t size, bool zero = true);
+    void *calloc(size_t size);
     void *realloc(void *mem, size_t size);
     void free(void *mem);
 };

--- a/src/rt/rust_kernel.cpp
+++ b/src/rt/rust_kernel.cpp
@@ -80,6 +80,11 @@ rust_kernel::malloc(size_t size, const char *tag) {
 }
 
 void *
+rust_kernel::calloc(size_t size, const char *tag) {
+    return exchange_alloc.calloc(size);
+}
+
+void *
 rust_kernel::realloc(void *mem, size_t size) {
     return exchange_alloc.realloc(mem, size);
 }

--- a/src/rt/rust_kernel.h
+++ b/src/rt/rust_kernel.h
@@ -132,6 +132,7 @@ public:
     void fatal(char const *fmt, ...);
 
     void *malloc(size_t size, const char *tag);
+    void *calloc(size_t size, const char *tag);
     void *realloc(void *mem, size_t size);
     void free(void *mem);
     rust_exchange_alloc *region() { return &exchange_alloc; }

--- a/src/rt/rust_stack.cpp
+++ b/src/rt/rust_stack.cpp
@@ -58,7 +58,7 @@ check_stack_canary(stk_seg *stk) {
 stk_seg *
 create_stack(memory_region *region, size_t sz) {
     size_t total_sz = sizeof(stk_seg) + sz;
-    stk_seg *stk = (stk_seg *)region->malloc(total_sz, "stack");
+    stk_seg *stk = (stk_seg *)region->malloc(total_sz, "stack", false);
     memset(stk, 0, sizeof(stk_seg));
     stk->end = (uintptr_t) &stk->data[sz];
     add_stack_canary(stk);
@@ -75,7 +75,7 @@ destroy_stack(memory_region *region, stk_seg *stk) {
 stk_seg *
 create_exchange_stack(rust_exchange_alloc *exchange, size_t sz) {
     size_t total_sz = sizeof(stk_seg) + sz;
-    stk_seg *stk = (stk_seg *)exchange->malloc(total_sz);
+    stk_seg *stk = (stk_seg *)exchange->malloc(total_sz, false);
     memset(stk, 0, sizeof(stk_seg));
     stk->end = (uintptr_t) &stk->data[sz];
     add_stack_canary(stk);

--- a/src/rt/rust_task.cpp
+++ b/src/rt/rust_task.cpp
@@ -450,6 +450,11 @@ rust_task::backtrace() {
 #endif
 }
 
+void *
+rust_task::calloc(size_t size, const char *tag) {
+    return local_region.calloc(size, tag);
+}
+
 size_t
 rust_task::get_next_stack_size(size_t min, size_t current, size_t requested) {
     LOG(this, mem, "calculating new stack size for 0x%" PRIxPTR, this);

--- a/src/test/run-pass/rustdocvalgrind.rs
+++ b/src/test/run-pass/rustdocvalgrind.rs
@@ -1,0 +1,22 @@
+// Regression test. This didn't valgrind after we stopped zeroing the exchange heap
+
+pub struct VariantDoc {
+    desc: Option<~str>,
+    sig: Option<~str>
+}
+
+fn main() {
+    let variants = ~[
+        VariantDoc {
+            desc: None,
+            sig: None
+        }
+    ];
+
+    let _vdoc = do vec::map(variants) |variant| {
+        VariantDoc {
+            desc: None,
+            .. copy *variant
+        }
+    };
+}


### PR DESCRIPTION
This fixes another valgrind problem, but still does not fix all the errors in rustdoc.
