### PR TITLE
Fix for issue #4547

### DIFF
--- a/src/rt/rust_task.cpp
+++ b/src/rt/rust_task.cpp
@@ -124,7 +124,9 @@ cleanup_task(cleanup_args *args) {
         // assert(task->task_local_data != NULL);
         task->task_local_data_cleanup(task->task_local_data);
         task->task_local_data = NULL;
-    } else if (threw_exception && task->id == INIT_TASK_ID) {
+    }
+
+    if (threw_exception && task->id == INIT_TASK_ID) {
         // Edge case: If main never spawns any tasks, but fails anyway, TLS
         // won't be around to take down the kernel (task.rs:kill_taskgroup,
         // rust_task_kill_all). Do it here instead.

--- a/src/test/run-fail/issue-4547.rs
+++ b/src/test/run-fail/issue-4547.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//error-pattern:explicit failure
+
+// Regression test for issue 4547
+
+pub fn main() {
+  os::args();
+  fail!();
+}


### PR DESCRIPTION
It looks like the `else if` clause isn't really necessary when tearing down the task because having TLS shouldn't mean that you don't necessarily fail the sched loop.

That being said, I'm definitely as familiar with this code as I'm sure someone else is, so this may be breaking something that I'm not seeing. At the very least the test case fails before the patch and succeeds after the patch, so I could re-open pull request with it as an xfail test if the change isn't the right one.
