### PR TITLE
rustc: Use position method in check::method -  rs=trivial

### DIFF
--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -438,10 +438,9 @@ pub impl LookupContext {
 
                 let trait_methods = ty::trait_methods(tcx, init_trait_id);
                 let pos = {
-                    // FIXME #3453 can't use trait_methods.position
-                    match vec::position(*trait_methods,
-                                        |m| (m.self_ty != ast::sty_static &&
-                                             m.ident == self.m_name))
+                    match trait_methods.position(|m| {
+                        m.self_ty != ast::sty_static &&
+                            m.ident == self.m_name })
                     {
                         Some(pos) => pos,
                         None => {
@@ -624,9 +623,7 @@ pub impl LookupContext {
         }
 
         let idx = {
-            // FIXME #3453 can't use impl_info.methods.position
-            match vec::position(impl_info.methods,
-                                |m| m.ident == self.m_name) {
+            match impl_info.methods.position(|m| m.ident == self.m_name) {
                 Some(idx) => idx,
                 None => { return; } // No method with the right name.
             }

--- a/src/test/run-pass/vec-position.rs
+++ b/src/test/run-pass/vec-position.rs
@@ -1,0 +1,16 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    let mut v = ~[1, 2, 3];
+    assert v.position(|x| *x == 1) == Some(0);
+    assert v.position(|x| *x == 3) == Some(2);
+    assert v.position(|x| *x == 17) == None;
+}


### PR DESCRIPTION
...because it appears to work now. Removes a FIXME.
