### PR TITLE
Implement #[deriving_eq] on tuple like structs

### DIFF
--- a/src/test/run-pass/deriving-via-extension-struct-empty.rs
+++ b/src/test/run-pass/deriving-via-extension-struct-empty.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deriving_eq]
+struct Foo;
+
+pub fn main() {
+  assert Foo == Foo;
+  assert !(Foo != Foo);
+}

--- a/src/test/run-pass/deriving-via-extension-struct-tuple.rs
+++ b/src/test/run-pass/deriving-via-extension-struct-tuple.rs
@@ -1,0 +1,26 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deriving_eq]
+struct Foo(int, int, ~str);
+
+pub fn main() {
+  let a1 = Foo(5, 6, ~"abc");
+  let a2 = Foo(5, 6, ~"abc");
+  let b = Foo(5, 7, ~"def");
+
+  assert a1 == a1;
+  assert a1 == a2;
+  assert !(a1 == b);
+
+  assert a1 != b;
+  assert !(a1 != a1);
+  assert !(a1 != a2);
+}


### PR DESCRIPTION
Previously an unimplemented error was thrown when using #[deriving_eq] on tuple-like struct definitions.
