### PR TITLE
Fix vector syntax in error messages

### DIFF
--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -733,10 +733,10 @@ impl @mut InferCtxt {
 
     fn report_mismatched_types(sp: span, e: ty::t, a: ty::t,
                                err: &ty::type_err) {
-        // Don't report an error if expected is ty_err
         let resolved_expected =
             self.resolve_type_vars_if_possible(e);
         let mk_msg = match ty::get(resolved_expected).sty {
+            // Don't report an error if expected is ty_err
             ty::ty_err => return,
             _ => {
                 // if I leave out : ~str, it infers &str and complains
@@ -779,4 +779,3 @@ impl @mut InferCtxt {
     }
 
 }
-

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -238,8 +238,7 @@ pub fn vstore_to_str(cx: ctxt, vs: ty::vstore) -> ~str {
       ty::vstore_fixed(n) => fmt!("%u", n),
       ty::vstore_uniq => ~"~",
       ty::vstore_box => ~"@",
-      /* FIXME(#4517) slice fmt */
-      ty::vstore_slice(r) => region_to_str(cx, r)
+      ty::vstore_slice(r) => region_to_str_adorned(cx, "&", r, "/")
     }
 }
 
@@ -248,7 +247,6 @@ pub fn vstore_ty_to_str(cx: ctxt, ty: ~str, vs: ty::vstore) -> ~str {
       ty::vstore_fixed(_) => {
         fmt!("[%s * %s]", ty, vstore_to_str(cx, vs))
       }
-      /* FIXME(#4517) slice fmt */
       ty::vstore_slice(_) => {
         fmt!("%s/%s", vstore_to_str(cx, vs), ty)
       }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -238,6 +238,7 @@ pub fn vstore_to_str(cx: ctxt, vs: ty::vstore) -> ~str {
       ty::vstore_fixed(n) => fmt!("%u", n),
       ty::vstore_uniq => ~"~",
       ty::vstore_box => ~"@",
+      /* FIXME(#4517) slice fmt */
       ty::vstore_slice(r) => region_to_str(cx, r)
     }
 }
@@ -245,12 +246,13 @@ pub fn vstore_to_str(cx: ctxt, vs: ty::vstore) -> ~str {
 pub fn vstore_ty_to_str(cx: ctxt, ty: ~str, vs: ty::vstore) -> ~str {
     match vs {
       ty::vstore_fixed(_) => {
-        fmt!("%s/%s", ty, vstore_to_str(cx, vs))
+        fmt!("[%s * %s]", ty, vstore_to_str(cx, vs))
       }
+      /* FIXME(#4517) slice fmt */
       ty::vstore_slice(_) => {
         fmt!("%s/%s", vstore_to_str(cx, vs), ty)
       }
-      _ => fmt!("%s%s", vstore_to_str(cx, vs), ty)
+      _ => fmt!("%s[%s]", vstore_to_str(cx, vs), ty)
     }
 }
 
@@ -453,13 +455,13 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_trait(did, ref substs, vs) => {
         let path = ty::item_path(cx, did);
         let base = ast_map::path_to_str(path, cx.sess.intr());
-        let result = parameterized(cx, base, substs.self_r, substs.tps);
-        vstore_ty_to_str(cx, result, vs)
+        let ty = parameterized(cx, base, substs.self_r, substs.tps);
+        fmt!("%s%s", vstore_to_str(cx, vs), ty)
       }
       ty_evec(mt, vs) => {
-        vstore_ty_to_str(cx, fmt!("[%s]", mt_to_str(cx, mt)), vs)
+        vstore_ty_to_str(cx, fmt!("%s", mt_to_str(cx, mt)), vs)
       }
-      ty_estr(vs) => vstore_ty_to_str(cx, ~"str", vs),
+      ty_estr(vs) => fmt!("%s%s", vstore_to_str(cx, vs), ~"str"),
       ty_opaque_box => ~"@?",
       ty_opaque_closure_ptr(ast::BorrowedSigil) => ~"closure&",
       ty_opaque_closure_ptr(ast::ManagedSigil) => ~"closure@",

--- a/src/test/compile-fail/issue-2149.rs
+++ b/src/test/compile-fail/issue-2149.rs
@@ -22,6 +22,6 @@ impl<A> vec_monad<A> for ~[A] {
 }
 fn main() {
     ["hi"].bind(|x| [x] );
-    //~^ ERROR type `[&staticstr * 1]` does not implement any method in scope named `bind`
+    //~^ ERROR type `[&static/str * 1]` does not implement any method in scope named `bind`
     //~^^ ERROR Unconstrained region variable
 }

--- a/src/test/compile-fail/issue-2149.rs
+++ b/src/test/compile-fail/issue-2149.rs
@@ -22,6 +22,6 @@ impl<A> vec_monad<A> for ~[A] {
 }
 fn main() {
     ["hi"].bind(|x| [x] );
-    //~^ ERROR type `[&static/str]/1` does not implement any method in scope named `bind`
+    //~^ ERROR type `[&staticstr * 1]` does not implement any method in scope named `bind`
     //~^^ ERROR Unconstrained region variable
 }

--- a/src/test/compile-fail/issue-4517.rs
+++ b/src/test/compile-fail/issue-4517.rs
@@ -1,0 +1,6 @@
+fn bar(int_param: int) {}
+
+fn main() {
+     let foo: [u8 * 4] = [1u8, ..4u8];
+     bar(foo); //~ ERROR mismatched types: expected `int` but found `[u8 * 4]` (expected int but found vector)
+}


### PR DESCRIPTION
Patch for #4517

This works for fixed vectors, but I am unclear how slices should be printed, simply '&[...]'  or...

e.i. How should regions be printed?
