### PR TITLE
Consolidate codes dealing with LLVM struct type

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1379,12 +1379,7 @@ pub fn type_to_str_inner(names: @TypeNames, +outer0: &[TypeRef], ty: TypeRef)
                         type_to_str_inner(names, outer, out_ty)).to_managed();
           }
           Struct => {
-            let n_elts = llvm::LLVMCountStructElementTypes(ty) as uint;
-            let mut elts = vec::from_elem(n_elts, 0 as TypeRef);
-            if !elts.is_empty() {
-                llvm::LLVMGetStructElementTypes(
-                    ty, ptr::to_mut_unsafe_ptr(&mut elts[0]));
-            }
+            let elts = struct_tys(ty);
             // See [Note at-str]
             return fmt!("{%s}", tys_str(names, outer, elts)).to_managed();
           }
@@ -1445,17 +1440,16 @@ pub fn fn_ty_param_tys(fn_ty: TypeRef) -> ~[TypeRef] {
     }
 }
 
-pub fn struct_element_types(struct_ty: TypeRef) -> ~[TypeRef] {
+pub fn struct_tys(struct_ty: TypeRef) -> ~[TypeRef] {
     unsafe {
-        let count = llvm::LLVMCountStructElementTypes(struct_ty);
-        let mut buf: ~[TypeRef] =
-            vec::from_elem(count as uint,
-                           cast::transmute::<uint,TypeRef>(0));
-        if buf.len() > 0 {
-            llvm::LLVMGetStructElementTypes(
-                struct_ty, ptr::to_mut_unsafe_ptr(&mut buf[0]));
+        let n_elts = llvm::LLVMCountStructElementTypes(struct_ty) as uint;
+        if n_elts == 0 {
+            return ~[];
         }
-        return buf;
+        let mut elts = vec::from_elem(n_elts, ptr::null());
+        llvm::LLVMGetStructElementTypes(
+            struct_ty, ptr::to_mut_unsafe_ptr(&mut elts[0]));
+        return elts;
     }
 }
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2150,11 +2150,6 @@ pub fn trans_mod(ccx: @CrateContext, m: ast::_mod) {
     }
 }
 
-pub fn get_pair_fn_ty(llpairty: TypeRef) -> TypeRef {
-    // Bit of a kludge: pick the fn typeref out of the pair.
-    return struct_elt(llpairty, 0u);
-}
-
 pub fn register_fn(ccx: @CrateContext,
                    sp: span,
                    +path: path,

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -14,6 +14,7 @@
 use lib::llvm::{llvm, TypeRef, ValueRef, Integer, Pointer, Float, Double};
 use lib::llvm::{Struct, Array, Attribute};
 use lib::llvm::{StructRetAttribute, ByValAttribute};
+use lib::llvm::struct_tys;
 use middle::trans::common::*;
 use middle::trans::cabi::*;
 
@@ -63,19 +64,6 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
     fn align(off: uint, ty: TypeRef) -> uint {
         let a = ty_align(ty);
         return (off + a - 1u) / a * a;
-    }
-
-    fn struct_tys(ty: TypeRef) -> ~[TypeRef] {
-        unsafe {
-            let n = llvm::LLVMCountStructElementTypes(ty);
-        if (n == 0) {
-            return ~[];
-        }
-            let mut elts = vec::from_elem(n as uint, ptr::null());
-            llvm::LLVMGetStructElementTypes(ty,
-                ptr::to_mut_unsafe_ptr(&mut elts[0]));
-            return elts;
-        }
     }
 
     fn ty_align(ty: TypeRef) -> uint {

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -380,7 +380,7 @@ pub fn trans_rtcall_or_lang_call_with_type_params(bcx: block,
                                                     fty);
                     let mut llfnty = type_of::type_of(callee.bcx.ccx(),
                                                       substituted);
-                    llfnty = T_ptr(struct_elt(llfnty, 0));
+                    llfnty = lib::llvm::struct_tys(llfnty)[0];
                     new_llval = PointerCast(callee.bcx, fn_data.llfn, llfnty);
                 }
                 _ => fail!()

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -645,19 +645,6 @@ pub fn val_str(tn: @TypeNames, v: ValueRef) -> @str {
     return ty_str(tn, val_ty(v));
 }
 
-// Returns the nth element of the given LLVM structure type.
-pub fn struct_elt(llstructty: TypeRef, n: uint) -> TypeRef {
-    unsafe {
-        let elt_count = llvm::LLVMCountStructElementTypes(llstructty) as uint;
-        assert (n < elt_count);
-        let mut elt_tys = vec::from_elem(elt_count, T_nil());
-        llvm::LLVMGetStructElementTypes(
-            llstructty,
-            ptr::to_mut_unsafe_ptr(&mut elt_tys[0]));
-        return llvm::LLVMGetElementType(elt_tys[n]);
-    }
-}
-
 pub fn in_scope_cx(cx: block, f: &fn(&mut scope_info)) {
     let mut cur = cx;
     loop {


### PR DESCRIPTION
Note on `struct_elt`: the comment is wrong, it actually dereferences the nth element of LLVM struct type if it is a pointer. That's why `T_ptr` is removed in `callee.rs`.
