### PR TITLE
(RFC for isue #4869) libcore: remove default to_str implementations for pointer types

### DIFF
--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -94,15 +94,6 @@ impl<A:ToStr> ToStr for ~[A] {
     }
 }
 
-impl<A:ToStr> ToStr for @A {
-    #[inline(always)]
-    pure fn to_str(&self) -> ~str { ~"@" + (**self).to_str() }
-}
-impl<A:ToStr> ToStr for ~A {
-    #[inline(always)]
-    pure fn to_str(&self) -> ~str { ~"~" + (**self).to_str() }
-}
-
 #[cfg(test)]
 #[allow(non_implicitly_copyable_typarams)]
 mod tests {
@@ -127,19 +118,12 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_vectors() {
         let x: ~[int] = ~[];
-        assert x.to_str() == ~"~[]";
-        assert (~[1]).to_str() == ~"~[1]";
-        assert (~[1, 2, 3]).to_str() == ~"~[1, 2, 3]";
+        assert x.to_str() == ~"[]";
+        assert (~[1]).to_str() == ~"[1]";
+        assert (~[1, 2, 3]).to_str() == ~"[1, 2, 3]";
         assert (~[~[], ~[1], ~[1, 1]]).to_str() ==
-               ~"~[~[], ~[1], ~[1, 1]]";
-    }
-
-    #[test]
-    fn test_pointer_types() {
-        assert (@1).to_str() == ~"@1";
-        assert (~(true, false)).to_str() == ~"~(true, false)";
+               ~"[[], [1], [1, 1]]";
     }
 }


### PR DESCRIPTION
See issue #4869. I'm not quite sure what constitutes "consensus from the core team" (cf. discussion in the issue), but this at least demonstrates that the proposed change is pretty straightforward.

After this change, there are no new test failures. I've un-ignored the `to_str` vectors test; it's not at all obvious to me why it'd be problematic, and it passes on my Linux machine.
