### PR TITLE
Emacs: Update emacs mode to be more similar to the vim mode.

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -66,22 +66,17 @@
                     "trait" "struct" "fn" "enum"
                     "impl"))
       (puthash word 'def table))
-    (dolist (word '("again" "assert"
-                    "break"
-                    "copy"
-                    "do" "drop"
-                    "else" "export" "extern"
-                    "fail" "for"
-                    "if" "use"
-                    "let" "log" "loop"
-                    "move" "new"
-                    "pure" "pub" "priv"
-                    "ref" "return" "static"
-                    "unchecked" "unsafe"
-                    "while"))
+    (dolist (word '("as" "break"
+                    "copy" "do" "drop" "else"
+                    "extern" "for" "if" "let" "log"
+                    "loop" "once" "priv" "pub" "pure"
+                    "ref" "return" "static" "unsafe" "use"
+                    "while" "while"
+                    "assert"
+                    "mut"))
       (puthash word t table))
     (puthash "match" 'alt table)
-    (dolist (word '("true" "false")) (puthash word 'atom table))
+    (dolist (word '("self" "true" "false")) (puthash word 'atom table))
     table))
 ;; FIXME type-context keywords
 


### PR DESCRIPTION
Copy the keyword list from rust.vim, and add `self` so that it is highlighted
(being liberal with the correct categories).

I'm not quite willing to dive in to clean up the emacs code yet, but at least this gets a (more) modern syntax highlighting list.
