### PR TITLE
Fix typo in grammar: underscore, not minus, can appear amongst hex digit...

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -297,7 +297,7 @@ the following forms:
 num_lit : nonzero_dec [ dec_digit | '_' ] * num_suffix ?
         | '0' [       [ dec_digit | '_' ] + num_suffix ?
               | 'b'   [ '1' | '0' | '_' ] + int_suffix ?
-              | 'x'   [ hex_digit | '-' ] + int_suffix ? ] ;
+              | 'x'   [ hex_digit | '_' ] + int_suffix ? ] ;
 
 num_suffix : int_suffix | float_suffix ;
 


### PR DESCRIPTION
...s.  I freely admit I have not run a "make check" on this (trivial) change.
