### PR TITLE
Allow constant expressions in [Type * n].

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -498,7 +498,12 @@ fn check_item(i: @ast::item, cx: ty::ctxt) {
 // not traverse into subitems, since that is handled by the outer
 // lint visitor.
 fn item_stopping_visitor<E>(v: visit::vt<E>) -> visit::vt<E> {
-    visit::mk_vt(@visit::Visitor {visit_item: |_i, _e, _v| { },.. **v})
+    visit::mk_vt(@visit::Visitor {visit_item: |_i, _e, _v| { },
+        .. **(ty_stopping_visitor(v))})
+}
+
+fn ty_stopping_visitor<E>(v: visit::vt<E>) -> visit::vt<E> {
+    visit::mk_vt(@visit::Visitor {visit_ty: |_t, _e, _v| { },.. **v})
 }
 
 fn check_item_while_true(cx: ty::ctxt, it: @ast::item) {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2169,7 +2169,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
           }
           ast::expr_repeat(element, count_expr, mutbl) => {
             let count = ty::eval_repeat_count(tcx, count_expr);
-            fcx.write_ty(count_expr.id, ty::mk_uint(tcx));
+            check_expr_with_hint(fcx, count_expr, ty::mk_uint(tcx));
             let tt = ast_expr_vstore_to_vstore(fcx, ev, count, vst);
             let t: ty::t = fcx.infcx().next_ty_var();
             bot |= check_expr_has_type(fcx, element, t);
@@ -2537,7 +2537,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
       }
       ast::expr_repeat(element, count_expr, mutbl) => {
         let count = ty::eval_repeat_count(tcx, count_expr);
-        fcx.write_ty(count_expr.id, ty::mk_uint(tcx));
+        check_expr_with_hint(fcx, count_expr, ty::mk_uint(tcx));
         let t: ty::t = fcx.infcx().next_ty_var();
         bot |= check_expr_has_type(fcx, element, t);
         let t = ty::mk_evec(tcx, ty::mt {ty: t, mutbl: mutbl},

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -916,7 +916,7 @@ pub enum ty_ {
     ty_box(mt),
     ty_uniq(mt),
     ty_vec(mt),
-    ty_fixed_length_vec(mt, uint),
+    ty_fixed_length_vec(mt, @expr),
     ty_ptr(mt),
     ty_rptr(Option<@Lifetime>, mt),
     ty_closure(@TyClosure),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -386,7 +386,6 @@ pub enum vstore {
 #[auto_decode]
 #[deriving_eq]
 pub enum expr_vstore {
-    // FIXME (#3469): Change uint to @expr (actually only constant exprs)
     expr_vstore_fixed(Option<uint>),   // [1,2,3,4]
     expr_vstore_uniq,                  // ~[1,2,3,4]
     expr_vstore_box,                   // @[1,2,3,4]

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -622,10 +622,10 @@ pub fn noop_fold_ty(t: &ty_, fld: @ast_fold) -> ty_ {
         }
         ty_tup(ref tys) => ty_tup(tys.map(|ty| fld.fold_ty(*ty))),
         ty_path(path, id) => ty_path(fld.fold_path(path), fld.new_id(id)),
-        ty_fixed_length_vec(ref mt, vs) => {
+        ty_fixed_length_vec(ref mt, e) => {
             ty_fixed_length_vec(
                 fold_mt(mt, fld),
-                vs
+                fld.fold_expr(e)
             )
         }
         ty_mac(ref mac) => ty_mac(fold_mac(*mac))

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -642,7 +642,8 @@ pub impl Parser {
                 self.obsolete(*self.last_span, ObsoleteMutVector);
             }
 
-            // Parse the `* 3` in `[ int * 3 ]`
+            // Parse the `* e` in `[ int * e ]`
+            // where `e` is a const expression
             let t = match self.maybe_parse_fixed_vstore_with_star() {
                 None => ty_vec(mt),
                 Some(suffix) => ty_fixed_length_vec(mt, suffix)
@@ -814,23 +815,9 @@ pub impl Parser {
         })
     }
 
-    fn maybe_parse_fixed_vstore_with_star(&self) -> Option<uint> {
+    fn maybe_parse_fixed_vstore_with_star(&self) -> Option<@ast::expr> {
         if self.eat(&token::BINOP(token::STAR)) {
-            match *self.token {
-                token::LIT_INT_UNSUFFIXED(i) if i >= 0i64 => {
-                    self.bump();
-                    Some(i as uint)
-                }
-                _ => {
-                    self.fatal(
-                        fmt!(
-                            "expected integral vector length \
-                            but found `%s`",
-                            token_to_str(self.reader, &copy *self.token)
-                        )
-                    );
-                }
-            }
+            Some(self.parse_expr())
         } else {
             None
         }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -425,7 +425,7 @@ pub fn print_type_ex(s: @ps, &&ty: @ast::Ty, print_colons: bool) {
         }
         print_type(s, mt.ty);
         word(s.s, ~" * ");
-        word(s.s, fmt!("%u", v));
+        word(s.s, fmt!("%?", v));
         word(s.s, ~"]");
       }
       ast::ty_mac(_) => {
@@ -1015,7 +1015,7 @@ pub fn print_mac(s: @ps, m: ast::mac) {
 
 pub fn print_vstore(s: @ps, t: ast::vstore) {
     match t {
-        ast::vstore_fixed(Some(i)) => word(s.s, fmt!("%u", i)),
+        ast::vstore_fixed(Some(i)) => word(s.s, fmt!("%?", i)),
         ast::vstore_fixed(None) => word(s.s, ~"_"),
         ast::vstore_uniq => word(s.s, ~"~"),
         ast::vstore_box => word(s.s, ~"@"),
@@ -1028,7 +1028,7 @@ pub fn print_vstore(s: @ps, t: ast::vstore) {
 
 pub fn print_expr_vstore(s: @ps, t: ast::expr_vstore) {
     match t {
-      ast::expr_vstore_fixed(Some(i)) => word(s.s, fmt!("%u", i)),
+      ast::expr_vstore_fixed(Some(i)) => word(s.s, fmt!("%?", i)),
       ast::expr_vstore_fixed(None) => word(s.s, ~"_"),
       ast::expr_vstore_uniq => word(s.s, ~"~"),
       ast::expr_vstore_box => word(s.s, ~"@"),

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -425,7 +425,7 @@ pub fn print_type_ex(s: @ps, &&ty: @ast::Ty, print_colons: bool) {
         }
         print_type(s, mt.ty);
         word(s.s, ~" * ");
-        word(s.s, fmt!("%?", v));
+        print_expr(s, v);
         word(s.s, ~"]");
       }
       ast::ty_mac(_) => {
@@ -1015,7 +1015,7 @@ pub fn print_mac(s: @ps, m: ast::mac) {
 
 pub fn print_vstore(s: @ps, t: ast::vstore) {
     match t {
-        ast::vstore_fixed(Some(i)) => word(s.s, fmt!("%?", i)),
+        ast::vstore_fixed(Some(i)) => word(s.s, fmt!("%u", i)),
         ast::vstore_fixed(None) => word(s.s, ~"_"),
         ast::vstore_uniq => word(s.s, ~"~"),
         ast::vstore_box => word(s.s, ~"@"),
@@ -1028,7 +1028,7 @@ pub fn print_vstore(s: @ps, t: ast::vstore) {
 
 pub fn print_expr_vstore(s: @ps, t: ast::expr_vstore) {
     match t {
-      ast::expr_vstore_fixed(Some(i)) => word(s.s, fmt!("%?", i)),
+      ast::expr_vstore_fixed(Some(i)) => word(s.s, fmt!("%u", i)),
       ast::expr_vstore_fixed(None) => word(s.s, ~"_"),
       ast::expr_vstore_uniq => word(s.s, ~"~"),
       ast::expr_vstore_box => word(s.s, ~"@"),

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -246,7 +246,10 @@ pub fn visit_ty<E>(t: @Ty, e: E, v: vt<E>) {
             (v.visit_ty)(f.decl.output, e, v);
         },
         ty_path(p, _) => visit_path(p, e, v),
-        ty_fixed_length_vec(ref mt, _) => (v.visit_ty)(mt.ty, e, v),
+        ty_fixed_length_vec(ref mt, ex) => {
+            (v.visit_ty)(mt.ty, e, v);
+            (v.visit_expr)(ex, e, v);
+        },
         ty_nil | ty_bot | ty_mac(_) | ty_infer => ()
     }
 }

--- a/src/test/compile-fail/non-constant-expr-for-fixed-len-vec.rs
+++ b/src/test/compile-fail/non-constant-expr-for-fixed-len-vec.rs
@@ -1,0 +1,17 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that non-constant exprs do fail as count in fixed length vec type
+
+fn main() {
+    fn bar(n: int) {
+        let _x: [int * n]; //~ ERROR expected constant expr for vector length: Non-constant path in constant expr
+    }
+}

--- a/src/test/compile-fail/non-constant-expr-for-vec-repeat.rs
+++ b/src/test/compile-fail/non-constant-expr-for-vec-repeat.rs
@@ -1,0 +1,17 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that non constant exprs fail for vector repeat syntax
+
+fn main() {
+    fn bar(n: int) {
+        let _x = [0, ..n]; //~ ERROR expected constant integer for repeat count but found variable
+    }
+}

--- a/src/test/run-pass/const-expr-in-fixed-length-vec.rs
+++ b/src/test/run-pass/const-expr-in-fixed-length-vec.rs
@@ -1,0 +1,19 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that constant expressions can be used for declaring the 
+// type of a fixed length vector.
+
+fn main() {
+
+    const FOO: int = 2;
+    let _v: [int * FOO*3];
+
+}

--- a/src/test/run-pass/const-expr-in-vec-repeat.rs
+++ b/src/test/run-pass/const-expr-in-vec-repeat.rs
@@ -1,0 +1,18 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that constant expressions can be used in vec repeat syntax. 
+
+fn main() {
+
+    const FOO: int = 2;
+    let _v = [0, ..FOO*3*2/2];
+
+}


### PR DESCRIPTION
~~So this is a partial fix for #3469. Partial because it only works for simple constant expressions like `32/2` and `2+2` and not for any actual constants.~~

For example:

```
const FOO: uint = 2+2;
let v: [int * FOO];
```

results in:

```
error: expected constant expr for vector length: Non-constant path in constant expr
```

This seems to be because at the point of error (`typeck::astconv`) the def_map doesn't contain the constant and thus it can't lookup the actual expression (`2+2` in this case).

So, feedback on what I have so far and suggestions for how to address the constant issue?
