### PR TITLE
Add non-exhaustive check for match guards

### DIFF
--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -101,7 +101,11 @@ pub fn check_expr(cx: @MatchCheckCtxt, ex: @expr, &&s: (), v: visit::vt<()>) {
           _ => { /* We assume only enum types can be uninhabited */ }
        }
        let arms = vec::concat(arms.filter_mapped(unguarded_pat));
-       check_exhaustive(cx, ex.span, arms);
+       if arms.is_empty() {
+           cx.tcx.sess.span_err(ex.span, ~"non-exhaustive patterns");
+       } else {
+           check_exhaustive(cx, ex.span, arms);
+       }
      }
      _ => ()
     }

--- a/src/test/compile-fail/match-non-exhaustive.rs
+++ b/src/test/compile-fail/match-non-exhaustive.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    match 0 { 1 => () } //~ ERROR non-exhaustive patterns
+    match 0 { 0 if false => () } //~ ERROR non-exhaustive patterns
+}


### PR DESCRIPTION
Fix ICE while there is no remained arms after checking guards.

This fix #3601 also.
