### PR TITLE
Removed deprecated `str()` functions.

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -556,7 +556,7 @@ let mut x = 5;
 loop {
     x += x - 3;
     if x % 5 == 0 { break; }
-    io::println(int::str(x));
+    io::println(int::to_str(x));
 }
 ~~~~
 

--- a/src/libcore/num/int-template.rs
+++ b/src/libcore/num/int-template.rs
@@ -265,11 +265,6 @@ pub pure fn to_str_radix(num: T, radix: uint) -> ~str {
     buf
 }
 
-/// Convert to a string.
-/// *Deprecated*, use to_str() instead.
-#[inline(always)]
-pub pure fn str(i: T) -> ~str { to_str(i) }
-
 impl ToStr for T {
     #[inline(always)]
     pure fn to_str(&self) -> ~str {

--- a/src/libcore/num/uint-template.rs
+++ b/src/libcore/num/uint-template.rs
@@ -229,11 +229,6 @@ pub pure fn to_str_radix(num: T, radix: uint) -> ~str {
     buf
 }
 
-/// Convert to a string.
-/// *Deprecated*, use to_str() instead.
-#[inline(always)]
-pub pure fn str(i: T) -> ~str { to_str(i) }
-
 impl ToStr for T {
     #[inline(always)]
     pure fn to_str(&self) -> ~str {

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -290,7 +290,7 @@ pub fn check_variants_T<T: Copy>(
 
     if L < 100 {
         do under(uint::min(L, 20)) |i| {
-            log(error, ~"Replacing... #" + uint::str(i));
+            log(error, ~"Replacing... #" + uint::to_str(i));
             let fname = str::from_slice(filename.to_str());
             do under(uint::min(L, 30)) |j| {
                 log(error, ~"With... " + stringifier(@things[j], intr));
@@ -415,7 +415,7 @@ pub fn check_running(exe_filename: &Path) -> happiness {
             }
             rc => {
               failed(~"Rust program ran but exited with status " +
-                     int::str(rc))
+                     int::to_str(rc))
             }
         }
     }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -307,7 +307,7 @@ fn enc_sty(w: io::Writer, cx: @ctxt, +st: ty::sty) {
         w.write_char('p');
         w.write_str((cx.ds)(did));
         w.write_char('|');
-        w.write_str(uint::str(id));
+        w.write_str(uint::to_str(id));
       }
       ty::ty_self => {
         w.write_char('s');

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -117,7 +117,7 @@ pub fn annotate_freevars(def_map: resolve::DefMap, crate: @ast::crate) ->
 
 pub fn get_freevars(tcx: ty::ctxt, fid: ast::node_id) -> freevar_info {
     match tcx.freevars.find(&fid) {
-      None => fail!(~"get_freevars: " + int::str(fid) + ~" has no freevars"),
+      None => fail!(~"get_freevars: "+int::to_str(fid)+~" has no freevars"),
       Some(d) => return d
     }
 }

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -842,7 +842,7 @@ priv fn do_strftime(format: &str, tm: &Tm) -> ~str {
           //'U' {}
           'u' => {
             let i = tm.tm_wday as int;
-            int::str(if i == 0 { 7 } else { i })
+            int::to_str(if i == 0 { 7 } else { i })
           }
           //'V' {}
           'v' => {
@@ -852,10 +852,10 @@ priv fn do_strftime(format: &str, tm: &Tm) -> ~str {
                 parse_type('Y', tm))
           }
           //'W' {}
-          'w' => int::str(tm.tm_wday as int),
+          'w' => int::to_str(tm.tm_wday as int),
           //'X' {}
           //'x' {}
-          'Y' => int::str(tm.tm_year as int + 1900),
+          'Y' => int::to_str(tm.tm_year as int + 1900),
           'y' => fmt!("%02d", (tm.tm_year as int + 1900) % 100),
           'Z' => copy tm.tm_zone,
           'z' => {
@@ -902,15 +902,15 @@ mod tests {
         const some_future_date: i64 = 1577836800i64; // 2020-01-01T00:00:00Z
 
         let tv1 = get_time();
-        log(debug, ~"tv1=" + uint::str(tv1.sec as uint) + ~" sec + "
-                   + uint::str(tv1.nsec as uint) + ~" nsec");
+        log(debug, ~"tv1=" + uint::to_str(tv1.sec as uint) + ~" sec + "
+                   + uint::to_str(tv1.nsec as uint) + ~" nsec");
 
         assert tv1.sec > some_recent_date;
         assert tv1.nsec < 1000000000i32;
 
         let tv2 = get_time();
-        log(debug, ~"tv2=" + uint::str(tv2.sec as uint) + ~" sec + "
-                   + uint::str(tv2.nsec as uint) + ~" nsec");
+        log(debug, ~"tv2=" + uint::to_str(tv2.sec as uint) + ~" sec + "
+                   + uint::to_str(tv2.nsec as uint) + ~" nsec");
 
         assert tv2.sec >= tv1.sec;
         assert tv2.sec < some_future_date;
@@ -927,13 +927,13 @@ mod tests {
         log(debug, ~"s0=" + float::to_str_digits(s0, 9u) + ~" sec");
         assert s0 > 0.;
         let ns0 = (s0 * 1000000000.) as u64;
-        log(debug, ~"ns0=" + u64::str(ns0) + ~" ns");
+        log(debug, ~"ns0=" + u64::to_str(ns0) + ~" ns");
 
-        log(debug, ~"ns1=" + u64::str(ns1) + ~" ns");
+        log(debug, ~"ns1=" + u64::to_str(ns1) + ~" ns");
         assert ns1 >= ns0;
 
         let ns2 = precise_time_ns();
-        log(debug, ~"ns2=" + u64::str(ns2) + ~" ns");
+        log(debug, ~"ns2=" + u64::to_str(ns2) + ~" ns");
         assert ns2 >= ns1;
     }
 

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -122,7 +122,7 @@ fn main() {
                 let elapsed = stop - start;
 
                 out.write_line(fmt!("%d\t%d\t%s", n, fibn,
-                                    u64::str(elapsed)));
+                                    u64::to_str(elapsed)));
             }
         }
     }

--- a/src/test/run-pass/monad.rs
+++ b/src/test/run-pass/monad.rs
@@ -36,7 +36,7 @@ impl<A> option_monad<A> for Option<A> {
 }
 
 fn transform(x: Option<int>) -> Option<~str> {
-    x.bind(|n| Some(*n + 1) ).bind(|n| Some(int::str(*n)) )
+    x.bind(|n| Some(*n + 1) ).bind(|n| Some(int::to_str(*n)) )
 }
 
 pub fn main() {

--- a/src/test/run-pass/static-impl.rs
+++ b/src/test/run-pass/static-impl.rs
@@ -30,7 +30,7 @@ trait uint_utils {
 }
 
 impl uint_utils for uint {
-    fn str() -> ~str { uint::str(self) }
+    fn str() -> ~str { uint::to_str(self) }
     fn multi(f: fn(uint)) {
         let mut c = 0u;
         while c < self { f(c); c += 1u; }

--- a/src/test/run-pass/trait-generic.rs
+++ b/src/test/run-pass/trait-generic.rs
@@ -14,7 +14,7 @@ trait to_str {
     fn to_str() -> ~str;
 }
 impl to_str for int {
-    fn to_str() -> ~str { int::str(self) }
+    fn to_str() -> ~str { int::to_str(self) }
 }
 impl to_str for ~str {
     fn to_str() -> ~str { copy self }

--- a/src/test/run-pass/trait-to-str.rs
+++ b/src/test/run-pass/trait-to-str.rs
@@ -21,7 +21,7 @@ trait to_str {
 }
 
 impl to_str for int {
-    fn to_str() -> ~str { int::str(self) }
+    fn to_str() -> ~str { int::to_str(self) }
 }
 
 impl<T:to_str> to_str for ~[T] {


### PR DESCRIPTION
Removed deprecated `str()` functions in int-template.rs and uint-template.rs
