### PR TITLE
Lifetime defaults

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1144,22 +1144,23 @@ Constants are declared with the `const` keyword.
 A constant item must have an expression giving its definition.
 The definition expression of a constant is limited to expression forms that can be evaluated at compile time.
 
-Constants must be explicitly typed. The type may be ```bool```, ```char```, a number, or a type derived from
-those primitive types. The derived types are borrowed pointers, static arrays, tuples, and structs.
+Constants must be explicitly typed. The type may be ```bool```, ```char```, a number, or a type derived from those primitive types.
+The derived types are borrowed pointers, static arrays, tuples, and structs.
+Borrowed pointers must be have the `'static` lifetime.
 
 ~~~~
 const bit1: uint = 1 << 0;
 const bit2: uint = 1 << 1;
 
 const bits: [uint * 2] = [bit1, bit2];
-const string: &str = "bitstring";
+const string: &'static str = "bitstring";
 
 struct BitsNStrings {
     mybits: [uint *2],
-    mystring: &str
+    mystring: &'self str
 }
 
-const bits_n_strings: BitsNStrings = BitsNStrings {
+const bits_n_strings: BitsNStrings<'static> = BitsNStrings {
     mybits: bits,
     mystring: string
 };
@@ -1630,7 +1631,7 @@ The following are examples of structure expressions:
 ~~~~
 # struct Point { x: float, y: float }
 # struct TuplePoint(float, float);
-# mod game { pub struct User { name: &str, age: uint, score: uint } }
+# mod game { pub struct User<'self> { name: &'self str, age: uint, score: uint } }
 # struct Cookie; fn some_fn<T>(t: T) {}
 Point {x: 10f, y: 20f};
 TuplePoint(10f, 20f);
@@ -2556,8 +2557,8 @@ order specified by the tuple type.
 An example of a tuple type and its use:
 
 ~~~~
-type Pair = (int,&str);
-let p: Pair = (10,"hello");
+type Pair<'self> = (int,&'self str);
+let p: Pair<'static> = (10,"hello");
 let (a, b) = p;
 assert b != "world";
 ~~~~
@@ -2718,7 +2719,7 @@ fn add(x: int, y: int) -> int {
 
 let mut x = add(5,7);
 
-type Binop = fn(int,int) -> int;
+type Binop<'self> = &'self fn(int,int) -> int;
 let bo: Binop = add;
 x = bo(5,7);
 ~~~~~~~~

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1951,7 +1951,7 @@ trait Printable {
 Traits may be implemented for specific types with [impls]. An impl
 that implements a trait includes the name of the trait at the start of
 the definition, as in the following impls of `Printable` for `int`
-and `&str`.
+and `~str`.
 
 [impls]: #functions-and-methods
 
@@ -1961,12 +1961,12 @@ impl Printable for int {
     fn print(&self) { io::println(fmt!("%d", *self)) }
 }
 
-impl Printable for &str {
+impl Printable for ~str {
     fn print(&self) { io::println(*self) }
 }
 
 # 1.print();
-# ("foo").print();
+# (~"foo").print();
 ~~~~
 
 Methods defined in an implementation of a trait may be called just like

--- a/src/libcore/at_vec.rs
+++ b/src/libcore/at_vec.rs
@@ -168,7 +168,7 @@ pub mod traits {
     use kinds::Copy;
     use ops::Add;
 
-    impl<T:Copy> Add<&[const T],@[T]> for @[T] {
+    impl<T:Copy> Add<&self/[const T],@[T]> for @[T] {
         #[inline(always)]
         pure fn add(&self, rhs: & &self/[const T]) -> @[T] {
             append(*self, (*rhs))

--- a/src/libcore/cleanup.rs
+++ b/src/libcore/cleanup.rs
@@ -22,8 +22,8 @@ use cast::transmute;
  * NB: These must match the representation in the C++ runtime.
  */
 
-type DropGlue = fn(**TypeDesc, *c_void);
-type FreeGlue = fn(**TypeDesc, *c_void);
+type DropGlue = &self/fn(**TypeDesc, *c_void);
+type FreeGlue = &self/fn(**TypeDesc, *c_void);
 
 type TaskID = uintptr_t;
 

--- a/src/libcore/condition.rs
+++ b/src/libcore/condition.rs
@@ -22,10 +22,10 @@ pub struct Handler<T, U> {
 
 pub struct Condition<T, U> {
     name: &static/str,
-    key: task::local_data::LocalDataKey<Handler<T, U>>
+    key: task::local_data::LocalDataKey/&self<Handler<T, U>>
 }
 
-pub impl<T, U> Condition<T, U> {
+pub impl<T, U> Condition/&self<T, U> {
     fn trap(&self, h: &self/fn(T) -> U) -> Trap/&self<T, U> {
         unsafe {
             let p : *RustClosure = ::cast::transmute(&h);
@@ -65,11 +65,11 @@ pub impl<T, U> Condition<T, U> {
 }
 
 struct Trap<T, U> {
-    cond: &Condition<T, U>,
+    cond: &self/Condition/&self<T, U>,
     handler: @Handler<T, U>
 }
 
-pub impl<T, U> Trap<T, U> {
+pub impl<T, U> Trap/&self<T, U> {
     fn in<V>(&self, inner: &self/fn() -> V) -> V {
         unsafe {
             let _g = Guard { cond: self.cond };
@@ -81,10 +81,10 @@ pub impl<T, U> Trap<T, U> {
 }
 
 struct Guard<T, U> {
-    cond: &Condition<T, U>
+    cond: &self/Condition/&self<T, U>
 }
 
-impl<T, U> Drop for Guard<T, U> {
+impl<T, U> Drop for Guard/&self<T, U> {
     fn finalize(&self) {
         unsafe {
             debug!("Guard: popping handler from TLS");

--- a/src/libcore/container.rs
+++ b/src/libcore/container.rs
@@ -10,7 +10,6 @@
 
 //! Container traits
 
-use cmp::Equiv;
 use option::Option;
 
 pub trait Container {

--- a/src/libcore/gc.rs
+++ b/src/libcore/gc.rs
@@ -115,7 +115,7 @@ unsafe fn is_safe_point(pc: *Word) -> Option<SafePoint> {
     return None;
 }
 
-type Visitor = fn(root: **Word, tydesc: *Word) -> bool;
+type Visitor = &self/fn(root: **Word, tydesc: *Word) -> bool;
 
 // Walks the list of roots for the given safe point, and calls visitor
 // on each root.

--- a/src/libcore/hash.rs
+++ b/src/libcore/hash.rs
@@ -298,7 +298,7 @@ impl io::Writer for SipState {
     }
 }
 
-impl Streaming for &SipState {
+impl Streaming for SipState {
 
     #[inline(always)]
     fn input(&self, buf: &[const u8]) {

--- a/src/libcore/hashmap.rs
+++ b/src/libcore/hashmap.rs
@@ -268,7 +268,9 @@ pub mod linear {
         }
     }
 
-    impl<K:Hash + IterBytes + Eq,V> BaseIter<(&K, &V)> for LinearMap<K, V> {
+    impl<K:Hash + IterBytes + Eq,V>
+        BaseIter<(&self/K, &self/V)> for LinearMap<K, V>
+    {
         /// Visit all key-value pairs
         pure fn each(&self, blk: fn(&(&self/K, &self/V)) -> bool) {
             for uint::range(0, self.buckets.len()) |i| {

--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -585,11 +585,11 @@ pub fn file_reader(path: &Path) -> Result<@Reader, ~str> {
 
 // Byte readers
 pub struct BytesReader {
-    bytes: &[u8],
+    bytes: &self/[u8],
     mut pos: uint
 }
 
-impl Reader for BytesReader {
+impl Reader for BytesReader/&self {
     fn read(&self, bytes: &mut [u8], len: uint) -> uint {
         let count = uint::min(len, self.bytes.len() - self.pos);
 

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -20,7 +20,7 @@ use option::{None, Option, Some};
 use vec;
 
 /// A function used to initialize the elements of a sequence
-pub type InitOp<T> = &fn(uint) -> T;
+pub type InitOp<T> = &self/fn(uint) -> T;
 
 pub trait BaseIter<A> {
     pure fn each(&self, blk: fn(v: &A) -> bool);

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -1028,11 +1028,11 @@ pub mod consts {
     pub use os::consts::windows::*;
 
     pub mod unix {
-        pub const FAMILY: &str = "unix";
+        pub const FAMILY: &static/str = "unix";
     }
 
     pub mod windows {
-        pub const FAMILY: &str = "windows";
+        pub const FAMILY: &static/str = "windows";
     }
 
     #[cfg(target_os = "macos")]
@@ -1051,38 +1051,38 @@ pub mod consts {
     pub use os::consts::win32::*;
 
     pub mod macos {
-        pub const SYSNAME: &str = "macos";
-        pub const DLL_PREFIX: &str = "lib";
-        pub const DLL_SUFFIX: &str = ".dylib";
-        pub const EXE_SUFFIX: &str = "";
+        pub const SYSNAME: &static/str = "macos";
+        pub const DLL_PREFIX: &static/str = "lib";
+        pub const DLL_SUFFIX: &static/str = ".dylib";
+        pub const EXE_SUFFIX: &static/str = "";
     }
 
     pub mod freebsd {
-        pub const SYSNAME: &str = "freebsd";
-        pub const DLL_PREFIX: &str = "lib";
-        pub const DLL_SUFFIX: &str = ".so";
-        pub const EXE_SUFFIX: &str = "";
+        pub const SYSNAME: &static/str = "freebsd";
+        pub const DLL_PREFIX: &static/str = "lib";
+        pub const DLL_SUFFIX: &static/str = ".so";
+        pub const EXE_SUFFIX: &static/str = "";
     }
 
     pub mod linux {
-        pub const SYSNAME: &str = "linux";
-        pub const DLL_PREFIX: &str = "lib";
-        pub const DLL_SUFFIX: &str = ".so";
-        pub const EXE_SUFFIX: &str = "";
+        pub const SYSNAME: &static/str = "linux";
+        pub const DLL_PREFIX: &static/str = "lib";
+        pub const DLL_SUFFIX: &static/str = ".so";
+        pub const EXE_SUFFIX: &static/str = "";
     }
 
     pub mod android {
-        pub const SYSNAME: &str = "android";
-        pub const DLL_PREFIX: &str = "lib";
-        pub const DLL_SUFFIX: &str = ".so";
-        pub const EXE_SUFFIX: &str = "";
+        pub const SYSNAME: &static/str = "android";
+        pub const DLL_PREFIX: &static/str = "lib";
+        pub const DLL_SUFFIX: &static/str = ".so";
+        pub const EXE_SUFFIX: &static/str = "";
     }
 
     pub mod win32 {
-        pub const SYSNAME: &str = "win32";
-        pub const DLL_PREFIX: &str = "";
-        pub const DLL_SUFFIX: &str = ".dll";
-        pub const EXE_SUFFIX: &str = ".exe";
+        pub const SYSNAME: &static/str = "win32";
+        pub const DLL_PREFIX: &static/str = "";
+        pub const DLL_SUFFIX: &static/str = ".dll";
+        pub const EXE_SUFFIX: &static/str = ".exe";
     }
 
 
@@ -1099,16 +1099,16 @@ pub mod consts {
     use os::consts::mips::*;
 
     pub mod x86 {
-        pub const ARCH: &str = "x86";
+        pub const ARCH: &'static str = "x86";
     }
     pub mod x86_64 {
-        pub const ARCH: &str = "x86_64";
+        pub const ARCH: &'static str = "x86_64";
     }
     pub mod arm {
-        pub const ARCH: &str = "arm";
+        pub const ARCH: &'static str = "arm";
     }
     pub mod mips {
-        pub const ARCH: &str = "mips";
+        pub const ARCH: &'static str = "mips";
     }
 }
 

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -440,7 +440,7 @@ pub fn try_recv<T:Owned,Tbuffer:Owned>(p: RecvPacketBuffered<T, Tbuffer>)
     let p = unsafe { &*p_ };
 
     struct DropState {
-        p: &PacketHeader,
+        p: &self/PacketHeader,
 
         drop {
             if task::failing() {

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -264,7 +264,7 @@ impl<T> Ord for *const T {
 
 // Equality for region pointers
 #[cfg(notest)]
-impl<T:Eq> Eq for &const T {
+impl<T:Eq> Eq for &self/const T {
     #[inline(always)]
     pure fn eq(&self, other: & &self/const T) -> bool {
         return *(*self) == *(*other);
@@ -277,7 +277,7 @@ impl<T:Eq> Eq for &const T {
 
 // Comparison for region pointers
 #[cfg(notest)]
-impl<T:Ord> Ord for &const T {
+impl<T:Ord> Ord for &self/const T {
     #[inline(always)]
     pure fn lt(&self, other: & &self/const T) -> bool {
         *(*self) < *(*other)

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -787,7 +787,7 @@ pure fn cmp(a: &str, b: &str) -> Ordering {
 }
 
 #[cfg(notest)]
-impl TotalOrd for &str {
+impl TotalOrd for &'self str {
     pure fn cmp(&self, other: & &self/str) -> Ordering { cmp(*self, *other) }
 }
 
@@ -833,7 +833,7 @@ pure fn gt(a: &str, b: &str) -> bool {
 }
 
 #[cfg(notest)]
-impl Eq for &str {
+impl Eq for &self/str {
     #[inline(always)]
     pure fn eq(&self, other: & &self/str) -> bool {
         eq_slice((*self), (*other))
@@ -875,7 +875,7 @@ impl Ord for ~str {
 }
 
 #[cfg(notest)]
-impl Ord for &str {
+impl Ord for &self/str {
     #[inline(always)]
     pure fn lt(&self, other: & &self/str) -> bool { lt((*self), (*other)) }
     #[inline(always)]
@@ -899,7 +899,7 @@ impl Ord for @str {
 }
 
 #[cfg(notest)]
-impl Equiv<~str> for &str {
+impl Equiv<~str> for &'self str {
     #[inline(always)]
     pure fn equiv(&self, other: &~str) -> bool { eq_slice(*self, *other) }
 }
@@ -2226,7 +2226,7 @@ pub mod traits {
     use ops::Add;
     use str::append;
 
-    impl Add<&str,~str> for ~str {
+    impl Add<&self/str,~str> for ~str {
         #[inline(always)]
         pure fn add(&self, rhs: & &self/str) -> ~str {
             append(copy *self, (*rhs))
@@ -2270,7 +2270,7 @@ pub trait StrSlice {
 }
 
 /// Extension methods for strings
-impl StrSlice for &str {
+impl StrSlice for &self/str {
     /**
      * Return true if a predicate matches all characters or if the string
      * contains no characters

--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -19,7 +19,7 @@ use libc::{c_void, c_char, size_t};
 use repr;
 use str;
 
-pub type FreeGlue = fn(*TypeDesc, *c_void);
+pub type FreeGlue = &self/fn(*TypeDesc, *c_void);
 
 // Corresponds to runtime type_desc type
 pub enum TypeDesc = {

--- a/src/libcore/task/local_data.rs
+++ b/src/libcore/task/local_data.rs
@@ -44,7 +44,7 @@ use task::rt;
  *
  * These two cases aside, the interface is safe.
  */
-pub type LocalDataKey<T> = &fn(v: @T);
+pub type LocalDataKey<T> = &self/fn(v: @T);
 
 /**
  * Remove a task-local data value from the table, returning the

--- a/src/libcore/task/spawn.rs
+++ b/src/libcore/task/spawn.rs
@@ -123,7 +123,7 @@ struct TaskGroupData {
 }
 type TaskGroupArc = unstable::Exclusive<Option<TaskGroupData>>;
 
-type TaskGroupInner = &mut Option<TaskGroupData>;
+type TaskGroupInner = &self/mut Option<TaskGroupData>;
 
 // A taskgroup is 'dead' when nothing can cause it to fail; only members can.
 pure fn taskgroup_is_dead(tg: &TaskGroupData) -> bool {

--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -19,7 +19,7 @@ use io::Writer;
 use option::{None, Option, Some};
 use str;
 
-pub type Cb = &fn(buf: &[const u8]) -> bool;
+pub type Cb = &self/fn(buf: &[const u8]) -> bool;
 
 /**
  * A trait to implement in order to make a type hashable;
@@ -197,7 +197,7 @@ impl IterBytes for int {
     }
 }
 
-impl<A:IterBytes> IterBytes for &[A] {
+impl<A:IterBytes> IterBytes for &self/[A] {
     #[inline(always)]
     pure fn iter_bytes(&self, lsb0: bool, f: Cb) {
         for (*self).each |elt| {
@@ -352,7 +352,7 @@ pub pure fn iter_bytes_7<A: IterBytes,
     g.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
 }
 
-impl IterBytes for &str {
+impl IterBytes for &self/str {
     #[inline(always)]
     pure fn iter_bytes(&self, _lsb0: bool, f: Cb) {
         do str::byte_slice(*self) |bytes| {
@@ -389,7 +389,7 @@ impl<A:IterBytes> IterBytes for Option<A> {
     }
 }
 
-impl<A:IterBytes> IterBytes for &A {
+impl<A:IterBytes> IterBytes for &self/A {
     #[inline(always)]
     pure fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (**self).iter_bytes(lsb0, f);

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -32,7 +32,7 @@ impl ToStr for ~str {
     #[inline(always)]
     pure fn to_str(&self) -> ~str { copy *self }
 }
-impl ToStr for &str {
+impl ToStr for &self/str {
     #[inline(always)]
     pure fn to_str(&self) -> ~str { ::str::from_slice(*self) }
 }
@@ -72,7 +72,7 @@ impl<A:ToStr,B:ToStr,C:ToStr> ToStr for (A, B, C) {
     }
 }
 
-impl<A:ToStr> ToStr for &[A] {
+impl<A:ToStr> ToStr for &self/[A] {
     #[inline(always)]
     pure fn to_str(&self) -> ~str {
         unsafe {

--- a/src/libcore/trie.rs
+++ b/src/libcore/trie.rs
@@ -29,7 +29,7 @@ pub struct TrieMap<T> {
     priv length: uint
 }
 
-impl<T> BaseIter<(uint, &T)> for TrieMap<T> {
+impl<T> BaseIter<(uint, &'self T)> for TrieMap<T> {
     /// Visit all key-value pairs in order
     #[inline(always)]
     pure fn each(&self, f: fn(&(uint, &self/T)) -> bool) {
@@ -39,7 +39,7 @@ impl<T> BaseIter<(uint, &T)> for TrieMap<T> {
     pure fn size_hint(&self) -> Option<uint> { Some(self.len()) }
 }
 
-impl<T> ReverseIter<(uint, &T)> for TrieMap<T> {
+impl<T> ReverseIter<(uint, &'self T)> for TrieMap<T> {
     /// Visit all key-value pairs in reverse order
     #[inline(always)]
     pure fn each_reverse(&self, f: fn(&(uint, &self/T)) -> bool) {

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -71,7 +71,7 @@ pub trait ExtendedTupleOps<A,B> {
     fn map<C>(&self, f: &fn(a: &A, b: &B) -> C) -> ~[C];
 }
 
-impl<A:Copy,B:Copy> ExtendedTupleOps<A,B> for (&[A], &[B]) {
+impl<A:Copy,B:Copy> ExtendedTupleOps<A,B> for (&self/[A], &self/[B]) {
     #[inline(always)]
     fn zip(&self) -> ~[(A, B)] {
         match *self {

--- a/src/libcore/unstable/finally.rs
+++ b/src/libcore/unstable/finally.rs
@@ -31,7 +31,7 @@ pub trait Finally<T> {
     fn finally(&self, dtor: &fn()) -> T;
 }
 
-impl<T> Finally<T> for &fn() -> T {
+impl<T> Finally<T> for &self/fn() -> T {
     fn finally(&self, dtor: &fn()) -> T {
         let _d = Finallyalizer {
             dtor: dtor
@@ -42,10 +42,10 @@ impl<T> Finally<T> for &fn() -> T {
 }
 
 struct Finallyalizer {
-    dtor: &fn()
+    dtor: &self/fn()
 }
 
-impl Drop for Finallyalizer {
+impl Drop for Finallyalizer/&self {
     fn finalize(&self) {
         (self.dtor)();
     }

--- a/src/libcore/unstable/global.rs
+++ b/src/libcore/unstable/global.rs
@@ -42,7 +42,7 @@ use sys::Closure;
 #[cfg(test)] use task::spawn;
 #[cfg(test)] use uint;
 
-pub type GlobalDataKey<T> = &fn(v: T);
+pub type GlobalDataKey<T> = &self/fn(v: T);
 
 pub unsafe fn global_data_clone_create<T:Owned + Clone>(
     key: GlobalDataKey<T>, create: &fn() -> ~T) -> T {

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -1549,7 +1549,7 @@ pure fn eq<T:Eq>(a: &[T], b: &[T]) -> bool {
 }
 
 #[cfg(notest)]
-impl<T:Eq> Eq for &[T] {
+impl<T:Eq> Eq for &self/[T] {
     #[inline(always)]
     pure fn eq(&self, other: & &self/[T]) -> bool { eq((*self), (*other)) }
     #[inline(always)]
@@ -1574,7 +1574,7 @@ impl<T:Eq> Eq for @[T] {
 }
 
 #[cfg(notest)]
-impl<T:Eq> Equiv<~[T]> for &[T] {
+impl<T:Eq> Equiv<~[T]> for &'self [T] {
     #[inline(always)]
     pure fn equiv(&self, other: &~[T]) -> bool { eq(*self, *other) }
 }
@@ -1596,7 +1596,7 @@ pure fn cmp<T: TotalOrd>(a: &[T], b: &[T]) -> Ordering {
 }
 
 #[cfg(notest)]
-impl<T: TotalOrd> TotalOrd for &[T] {
+impl<T: TotalOrd> TotalOrd for &'self [T] {
     #[inline(always)]
     pure fn cmp(&self, other: & &self/[T]) -> Ordering { cmp(*self, *other) }
 }
@@ -1633,7 +1633,7 @@ pure fn ge<T:Ord>(a: &[T], b: &[T]) -> bool { !lt(a, b) }
 pure fn gt<T:Ord>(a: &[T], b: &[T]) -> bool { lt(b, a)  }
 
 #[cfg(notest)]
-impl<T:Ord> Ord for &[T] {
+impl<T:Ord> Ord for &self/[T] {
     #[inline(always)]
     pure fn lt(&self, other: & &self/[T]) -> bool { lt((*self), (*other)) }
     #[inline(always)]
@@ -1674,7 +1674,7 @@ pub mod traits {
     use ops::Add;
     use vec::append;
 
-    impl<T:Copy> Add<&[const T],~[T]> for ~[T] {
+    impl<T:Copy> Add<&self/[const T],~[T]> for ~[T] {
         #[inline(always)]
         pure fn add(&self, rhs: & &self/[const T]) -> ~[T] {
             append(copy *self, (*rhs))
@@ -1682,7 +1682,7 @@ pub mod traits {
     }
 }
 
-impl<T> Container for &[const T] {
+impl<T> Container for &self/[const T] {
     /// Returns true if a vector contains no elements
     #[inline]
     pure fn is_empty(&self) -> bool { is_empty(*self) }
@@ -1697,7 +1697,7 @@ pub trait CopyableVector<T> {
 }
 
 /// Extension methods for vectors
-impl<T: Copy> CopyableVector<T> for &[const T] {
+impl<T: Copy> CopyableVector<T> for &'self [const T] {
     /// Returns a copy of the elements from [`start`..`end`) from `v`.
     #[inline]
     pure fn slice(&self, start: uint, end: uint) -> ~[T] {
@@ -1725,7 +1725,7 @@ pub trait ImmutableVector<T> {
 }
 
 /// Extension methods for vectors
-impl<T> ImmutableVector<T> for &[T] {
+impl<T> ImmutableVector<T> for &self/[T] {
     /// Return a slice that points into another slice.
     #[inline]
     pure fn view(&self, start: uint, end: uint) -> &self/[T] {
@@ -1828,7 +1828,7 @@ pub trait ImmutableEqVector<T:Eq> {
     pure fn rposition_elem(&self, t: &T) -> Option<uint>;
 }
 
-impl<T:Eq> ImmutableEqVector<T> for &[T] {
+impl<T:Eq> ImmutableEqVector<T> for &self/[T] {
     /**
      * Find the first index matching some predicate
      *
@@ -1873,7 +1873,7 @@ pub trait ImmutableCopyableVector<T> {
 }
 
 /// Extension methods for vectors
-impl<T:Copy> ImmutableCopyableVector<T> for &[T] {
+impl<T:Copy> ImmutableCopyableVector<T> for &self/[T] {
     /**
      * Construct a new vector from the elements of a vector for which some
      * predicate holds.
@@ -2266,7 +2266,7 @@ pub mod bytes {
 // This cannot be used with iter-trait.rs because of the region pointer
 // required in the slice.
 
-impl<A> iter::BaseIter<A> for &[A] {
+impl<A> iter::BaseIter<A> for &self/[A] {
     pub pure fn each(&self, blk: fn(v: &A) -> bool) {
         // FIXME(#2263)---should be able to call each(self, blk)
         for each(*self) |e| {
@@ -2304,7 +2304,7 @@ impl<A> iter::BaseIter<A> for @[A] {
     pure fn size_hint(&self) -> Option<uint> { Some(len(*self)) }
 }
 
-impl<A> iter::ExtendedIter<A> for &[A] {
+impl<A> iter::ExtendedIter<A> for &self/[A] {
     pub pure fn eachi(&self, blk: fn(uint, v: &A) -> bool) {
         iter::eachi(self, blk)
     }
@@ -2381,7 +2381,7 @@ impl<A> iter::ExtendedIter<A> for @[A] {
     }
 }
 
-impl<A:Eq> iter::EqIter<A> for &[A] {
+impl<A:Eq> iter::EqIter<A> for &self/[A] {
     pub pure fn contains(&self, x: &A) -> bool { iter::contains(self, x) }
     pub pure fn count(&self, x: &A) -> uint { iter::count(self, x) }
 }
@@ -2398,7 +2398,7 @@ impl<A:Eq> iter::EqIter<A> for @[A] {
     pub pure fn count(&self, x: &A) -> uint { iter::count(self, x) }
 }
 
-impl<A:Copy> iter::CopyableIter<A> for &[A] {
+impl<A:Copy> iter::CopyableIter<A> for &self/[A] {
     pure fn filter_to_vec(&self, pred: fn(&A) -> bool) -> ~[A] {
         iter::filter_to_vec(self, pred)
     }
@@ -2430,7 +2430,7 @@ impl<A:Copy> iter::CopyableIter<A> for @[A] {
     }
 }
 
-impl<A:Copy + Ord> iter::CopyableOrderedIter<A> for &[A] {
+impl<A:Copy + Ord> iter::CopyableOrderedIter<A> for &self/[A] {
     pure fn min(&self) -> A { iter::min(self) }
     pure fn max(&self) -> A { iter::max(self) }
 }
@@ -2447,7 +2447,7 @@ impl<A:Copy + Ord> iter::CopyableOrderedIter<A> for @[A] {
     pure fn max(&self) -> A { iter::max(self) }
 }
 
-impl<A:Copy> iter::CopyableNonstrictIter<A> for &[A] {
+impl<A:Copy> iter::CopyableNonstrictIter<A> for &self/[A] {
     pure fn each_val(&const self, f: fn(A) -> bool) {
         let mut i = 0;
         while i < self.len() {

--- a/src/librust/rust.rc
+++ b/src/librust/rust.rc
@@ -36,23 +36,23 @@ impl ValidUsage {
 }
 
 enum Action {
-    Exec(&str),
-    Call(&fn(args: &[~str]) -> ValidUsage)
+    Exec(&self/str),
+    Call(&self/fn(args: &[~str]) -> ValidUsage)
 }
 
 enum UsageSource {
-    UsgExec(&str),
-    UsgStr(&str)
+    UsgExec(&self/str),
+    UsgStr(&self/str)
 }
 
 struct Command {
-    cmd: &str,
-    action: Action,
-    usage_line: &str,
-    usage_full: UsageSource
+    cmd: &self/str,
+    action: Action/&self,
+    usage_line: &self/str,
+    usage_full: UsageSource/&self
 }
 
-const commands: &[Command] = &[
+const commands: &static/[Command/&static] = &[
     Command{
         cmd: "build",
         action: Exec("rustc"),

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -68,7 +68,7 @@ fn lookup_hash(d: ebml::Doc, eq_fn: fn(x:&[u8]) -> bool, hash: uint) ->
     None
 }
 
-pub type GetCrateDataCb = &fn(ast::crate_num) -> cmd;
+pub type GetCrateDataCb = &self/fn(ast::crate_num) -> cmd;
 
 pub fn maybe_find_item(item_id: int, items: ebml::Doc) -> Option<ebml::Doc> {
     fn eq_item(bytes: &[u8], item_id: int) -> bool {
@@ -546,7 +546,7 @@ pub fn get_item_path(intr: @ident_interner, cdata: cmd, id: ast::node_id)
     item_path(intr, lookup_item(id, cdata.data))
 }
 
-pub type decode_inlined_item = fn(
+pub type decode_inlined_item = &self/fn(
     cdata: @cstore::crate_metadata,
     tcx: ty::ctxt,
     path: ast_map::path,

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1276,11 +1276,12 @@ fn encode_hash(ebml_w: writer::Encoder, hash: &str) {
 }
 
 // NB: Increment this as you change the metadata encoding version.
-pub const metadata_encoding_version : &[u8] = &[0x72, //'r' as u8,
-                                                0x75, //'u' as u8,
-                                                0x73, //'s' as u8,
-                                                0x74, //'t' as u8,
-                                                0, 0, 0, 1 ];
+pub const metadata_encoding_version : &static/[u8] =
+    &[0x72, //'r' as u8,
+      0x75, //'u' as u8,
+      0x73, //'s' as u8,
+      0x74, //'t' as u8,
+      0, 0, 0, 1 ];
 
 pub fn encode_metadata(parms: EncodeParams, crate: &crate) -> ~[u8] {
     let wr = @io::BytesWriter();

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -21,7 +21,7 @@ use core::result::Result;
 use core::result;
 use core::str;
 
-pub type pick<T> = fn(path: &Path) -> Option<T>;
+pub type pick<T> = &self/fn(path: &Path) -> Option<T>;
 
 pub fn pick_file(file: Path, path: &Path) -> Option<Path> {
     if path.file_path() == file { option::Some(copy *path) }

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -49,7 +49,7 @@ pub enum DefIdSource {
     // Identifies a type parameter (`fn foo<X>() { ... }`).
     TypeParameter
 }
-type conv_did = fn(source: DefIdSource, ast::def_id) -> ast::def_id;
+type conv_did = &self/fn(source: DefIdSource, ast::def_id) -> ast::def_id;
 
 pub struct PState {
     data: @~[u8],

--- a/src/librustc/middle/borrowck/preserve.rs
+++ b/src/librustc/middle/borrowck/preserve.rs
@@ -64,7 +64,7 @@ pub impl BorrowckCtxt {
 }
 
 struct PreserveCtxt {
-    bccx: &BorrowckCtxt,
+    bccx: &self/BorrowckCtxt,
 
     // the region scope for which we must preserve the memory
     scope_region: ty::Region,
@@ -79,7 +79,7 @@ struct PreserveCtxt {
     root_managed_data: bool
 }
 
-pub impl PreserveCtxt {
+pub impl PreserveCtxt/&self {
     fn tcx(&self) -> ty::ctxt { self.bccx.tcx }
 
     fn preserve(&self, cmt: cmt) -> bckres<PreserveCondition> {

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -55,7 +55,7 @@ use syntax::{visit, ast_util};
 // primitives in the stdlib are explicitly annotated to only take sendable
 // types.
 
-pub const try_adding: &str = "Try adding a move";
+pub const try_adding: &static/str = "Try adding a move";
 
 pub type rval_map = HashMap<node_id, ()>;
 

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -312,7 +312,7 @@ fn LanguageItemCollector(crate: @crate,
 }
 
 struct LanguageItemCollector {
-    items: &mut LanguageItems,
+    items: &self/mut LanguageItems,
 
     crate: @crate,
     session: Session,
@@ -320,7 +320,7 @@ struct LanguageItemCollector {
     item_refs: HashMap<@~str, uint>,
 }
 
-pub impl LanguageItemCollector {
+pub impl LanguageItemCollector/&self {
     fn match_and_collect_meta_item(&self, item_def_id: def_id,
                                    meta_item: @meta_item) {
         match meta_item.node {

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -212,9 +212,9 @@ pub impl<T> ResolveResult<T> {
 }
 
 pub enum TypeParameters/& {
-    NoTypeParameters,              //< No type parameters.
-    HasTypeParameters(&Generics,   //< Type parameters.
-                      node_id,     //< ID of the enclosing item
+    NoTypeParameters,                  //< No type parameters.
+    HasTypeParameters(&self/Generics,  //< Type parameters.
+                      node_id,         //< ID of the enclosing item
 
                       // The index to start numbering the type parameters at.
                       // This is zero if this is the outermost set of type

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -328,13 +328,13 @@ pub type BindingsMap = HashMap<ident, BindingInfo>;
 
 pub struct ArmData {
     bodycx: block,
-    arm: &ast::arm,
+    arm: &self/ast::arm,
     bindings_map: BindingsMap
 }
 
 pub struct Match {
     pats: ~[@ast::pat],
-    data: @ArmData
+    data: @ArmData/&self
 }
 
 pub fn match_to_str(bcx: block, m: &Match) -> ~str {
@@ -392,7 +392,7 @@ pub fn expand_nested_bindings(bcx: block, m: &[@Match/&r],
     }
 }
 
-pub type enter_pat = fn(@ast::pat) -> Option<~[@ast::pat]>;
+pub type enter_pat = &self/fn(@ast::pat) -> Option<~[@ast::pat]>;
 
 pub fn assert_is_binding_or_wild(bcx: block, p: @ast::pat) {
     if !pat_is_binding_or_wild(bcx.tcx().def_map, p) {

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -550,8 +550,8 @@ pub fn trans_call_inner(
 
 
 pub enum CallArgs {
-    ArgExprs(&[@ast::expr]),
-    ArgVals(&[ValueRef])
+    ArgExprs(&self/[@ast::expr]),
+    ArgVals(&self/[ValueRef])
 }
 
 pub struct Args {

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -97,11 +97,11 @@ fn c_stack_tys(ccx: @CrateContext,
     };
 }
 
-type shim_arg_builder = fn(bcx: block, tys: @c_stack_tys,
-                           llargbundle: ValueRef) -> ~[ValueRef];
+type shim_arg_builder = &self/fn(bcx: block, tys: @c_stack_tys,
+                                 llargbundle: ValueRef) -> ~[ValueRef];
 
-type shim_ret_builder = fn(bcx: block, tys: @c_stack_tys,
-                           llargbundle: ValueRef, llretval: ValueRef);
+type shim_ret_builder = &self/fn(bcx: block, tys: @c_stack_tys,
+                                 llargbundle: ValueRef, llretval: ValueRef);
 
 fn build_shim_fn_(ccx: @CrateContext,
                   +shim_name: ~str,
@@ -133,12 +133,12 @@ fn build_shim_fn_(ccx: @CrateContext,
     return llshimfn;
 }
 
-type wrap_arg_builder = fn(bcx: block, tys: @c_stack_tys,
-                           llwrapfn: ValueRef,
-                           llargbundle: ValueRef);
+type wrap_arg_builder = &self/fn(bcx: block, tys: @c_stack_tys,
+                                 llwrapfn: ValueRef,
+                                 llargbundle: ValueRef);
 
-type wrap_ret_builder = fn(bcx: block, tys: @c_stack_tys,
-                           llargbundle: ValueRef);
+type wrap_ret_builder = &self/fn(bcx: block, tys: @c_stack_tys,
+                                 llargbundle: ValueRef);
 
 fn build_wrap_fn_(ccx: @CrateContext,
                   tys: @c_stack_tys,

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -520,7 +520,7 @@ pub fn get_base_and_len(bcx: block,
 
 pub type val_and_ty_fn = @fn(block, ValueRef, ty::t) -> Result;
 
-pub type iter_vec_block = &fn(block, ValueRef, ty::t) -> block;
+pub type iter_vec_block = &self/fn(block, ValueRef, ty::t) -> block;
 
 pub fn iter_vec_raw(bcx: block, data_ptr: ValueRef, vec_ty: ty::t,
                     fill: ValueRef, f: iter_vec_block) -> block {

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -58,14 +58,14 @@ use middle::ty::{arg, field, substs};
 use middle::ty::{ty_param_substs_and_ty};
 use middle::ty;
 use middle::typeck::rscope::{in_binding_rscope};
-use middle::typeck::rscope::{region_scope, type_rscope};
+use middle::typeck::rscope::{region_scope, type_rscope, RegionError};
 use middle::typeck::{CrateCtxt, write_substs_to_tcx, write_ty_to_tcx};
 
 use core::result;
 use core::vec;
 use syntax::ast;
 use syntax::codemap::span;
-use syntax::print::pprust::path_to_str;
+use syntax::print::pprust::{region_to_str, path_to_str};
 use util::common::indenter;
 
 pub trait AstConv {
@@ -76,17 +76,31 @@ pub trait AstConv {
     fn ty_infer(&self, span: span) -> ty::t;
 }
 
-pub fn get_region_reporting_err(tcx: ty::ctxt,
-                                span: span,
-                                res: Result<ty::Region, ~str>)
-                             -> ty::Region {
-
+pub fn get_region_reporting_err(
+    tcx: ty::ctxt,
+    span: span,
+    a_r: Option<@ast::region>,
+    res: Result<ty::Region, RegionError>) -> ty::Region
+{
     match res {
-      result::Ok(r) => r,
-      result::Err(ref e) => {
-        tcx.sess.span_err(span, (/*bad*/copy *e));
-        ty::re_static
-      }
+        result::Ok(r) => r,
+        result::Err(ref e) => {
+            let descr = match a_r {
+                None => ~"anonymous lifetime",
+                Some(a) if a.node == ast::re_anon => {
+                    ~"anonymous lifetime"
+                }
+                Some(a) => {
+                    fmt!("lifetime %s",
+                         region_to_str(a, tcx.sess.intr()))
+                }
+            };
+            tcx.sess.span_err(
+                span,
+                fmt!("Illegal %s: %s",
+                     descr, e.msg));
+            e.replacement
+        }
     }
 }
 
@@ -103,7 +117,7 @@ pub fn ast_region_to_region<AC:AstConv,RS:region_scope + Copy + Durable>(
         ast::re_named(id) => rscope.named_region(span, id)
     };
 
-    get_region_reporting_err(self.tcx(), span, res)
+    get_region_reporting_err(self.tcx(), span, Some(a_r), res)
 }
 
 pub fn ast_path_to_substs_and_ty<AC:AstConv,RS:region_scope + Copy + Durable>(
@@ -139,7 +153,7 @@ pub fn ast_path_to_substs_and_ty<AC:AstConv,RS:region_scope + Copy + Durable>(
       }
       (Some(_), None) => {
         let res = rscope.anon_region(path.span);
-        let r = get_region_reporting_err(self.tcx(), path.span, res);
+        let r = get_region_reporting_err(self.tcx(), path.span, None, res);
         Some(r)
       }
       (Some(_), Some(r)) => {
@@ -521,7 +535,7 @@ pub fn ty_of_closure<AC:AstConv,RS:region_scope + Copy + Durable>(
                 ast::BorrowedSigil => {
                     // &fn() defaults to an anonymous region:
                     let r_result = rscope.anon_region(span);
-                    get_region_reporting_err(self.tcx(), span, r_result)
+                    get_region_reporting_err(self.tcx(), span, None, r_result)
                 }
             }
         }

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -57,7 +57,7 @@ use core::prelude::*;
 use middle::ty::{arg, field, substs};
 use middle::ty::{ty_param_substs_and_ty};
 use middle::ty;
-use middle::typeck::rscope::{in_anon_rscope, in_binding_rscope};
+use middle::typeck::rscope::{in_binding_rscope};
 use middle::typeck::rscope::{region_scope, type_rscope};
 use middle::typeck::{CrateCtxt, write_substs_to_tcx, write_ty_to_tcx};
 
@@ -315,8 +315,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + Durable>(
       }
       ast::ty_rptr(region, mt) => {
         let r = ast_region_to_region(self, rscope, ast_ty.span, region);
-        let anon_rscope = in_anon_rscope(rscope, r);
-        mk_pointer(self, &anon_rscope, mt, ty::vstore_slice(r),
+        mk_pointer(self, rscope, mt, ty::vstore_slice(r),
                    |tmt| ty::mk_rptr(tcx, r, tmt))
       }
       ast::ty_tup(fields) => {

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -143,7 +143,7 @@ pub struct LookupContext {
     self_expr: @ast::expr,
     callee_id: node_id,
     m_name: ast::ident,
-    supplied_tps: &[ty::t],
+    supplied_tps: &self/[ty::t],
     impl_dups: HashMap<def_id, ()>,
     inherent_candidates: DVec<Candidate>,
     extension_candidates: DVec<Candidate>,
@@ -176,7 +176,7 @@ pub enum TransformTypeFlag {
     TransformTypeForObject,
 }
 
-pub impl LookupContext {
+pub impl LookupContext/&self {
     fn do_lookup(&self, self_ty: ty::t) -> Option<method_map_entry> {
         debug!("do_lookup(self_ty=%s, expr=%s, self_expr=%s)",
                self.ty_to_str(self_ty),

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+n// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -95,7 +95,7 @@ use middle::typeck::check::vtable::{LocationInfo, VtableContext};
 use middle::typeck::CrateCtxt;
 use middle::typeck::infer::{resolve_type, force_tvar};
 use middle::typeck::infer;
-use middle::typeck::rscope::{anon_rscope, binding_rscope, bound_self_region};
+use middle::typeck::rscope::{binding_rscope, bound_self_region};
 use middle::typeck::rscope::{in_binding_rscope, region_scope, type_rscope};
 use middle::typeck::rscope;
 use middle::typeck::{isr_alist, lookup_def_ccx, method_map_entry};

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -649,9 +649,10 @@ impl AstConv for FnCtxt {
 
 pub impl FnCtxt {
     fn infcx(&self) -> @mut infer::InferCtxt { self.inh.infcx }
-    fn search_in_scope_regions(&self,
-                               br: ty::bound_region)
-                            -> Result<ty::Region, ~str> {
+    fn search_in_scope_regions(
+        &self,
+        br: ty::bound_region) -> Result<ty::Region, ~str>
+    {
         let in_scope_regions = self.in_scope_regions;
         match in_scope_regions.find(br) {
             Some(r) => result::Ok(r),
@@ -683,9 +684,9 @@ impl region_scope for FnCtxt {
 }
 
 pub impl FnCtxt {
-    fn tag(@mut self) -> ~str { fmt!("%x", ptr::addr_of(&(*self)) as uint) }
+    fn tag(&self) -> ~str { fmt!("%x", ptr::addr_of(&(*self)) as uint) }
 
-    fn local_ty(@mut self, span: span, nid: ast::node_id) -> ty::t {
+    fn local_ty(&self, span: span, nid: ast::node_id) -> ty::t {
         match self.inh.locals.find(&nid) {
             Some(t) => t,
             None => {
@@ -696,7 +697,7 @@ pub impl FnCtxt {
         }
     }
 
-    fn expr_to_str(@mut self, expr: @ast::expr) -> ~str {
+    fn expr_to_str(&self, expr: @ast::expr) -> ~str {
         fmt!("expr(%?:%s)", expr.id,
              pprust::expr_to_str(expr, self.tcx().sess.intr()))
     }
@@ -706,13 +707,13 @@ pub impl FnCtxt {
     }
 
     #[inline(always)]
-    fn write_ty(@mut self, node_id: ast::node_id, ty: ty::t) {
+    fn write_ty(&self, node_id: ast::node_id, ty: ty::t) {
         debug!("write_ty(%d, %s) in fcx %s",
                node_id, ppaux::ty_to_str(self.tcx(), ty), self.tag());
         self.inh.node_types.insert(node_id, ty);
     }
 
-    fn write_substs(@mut self, node_id: ast::node_id, +substs: ty::substs) {
+    fn write_substs(&self, node_id: ast::node_id, +substs: ty::substs) {
         if !ty::substs_is_noop(&substs) {
             debug!("write_substs(%d, %s) in fcx %s",
                    node_id,
@@ -722,7 +723,7 @@ pub impl FnCtxt {
         }
     }
 
-    fn write_ty_substs(@mut self,
+    fn write_ty_substs(&self,
                        node_id: ast::node_id,
                        ty: ty::t,
                        +substs: ty::substs) {
@@ -731,7 +732,7 @@ pub impl FnCtxt {
         self.write_substs(node_id, substs);
     }
 
-    fn write_autoderef_adjustment(@mut self,
+    fn write_autoderef_adjustment(&self,
                                   node_id: ast::node_id,
                                   derefs: uint) {
         if derefs == 0 { return; }
@@ -743,33 +744,33 @@ pub impl FnCtxt {
         );
     }
 
-    fn write_adjustment(@mut self,
+    fn write_adjustment(&self,
                         node_id: ast::node_id,
                         adj: @ty::AutoAdjustment) {
         debug!("write_adjustment(node_id=%?, adj=%?)", node_id, adj);
         self.inh.adjustments.insert(node_id, adj);
     }
 
-    fn write_nil(@mut self, node_id: ast::node_id) {
+    fn write_nil(&self, node_id: ast::node_id) {
         self.write_ty(node_id, ty::mk_nil(self.tcx()));
     }
-    fn write_bot(@mut self, node_id: ast::node_id) {
+    fn write_bot(&self, node_id: ast::node_id) {
         self.write_ty(node_id, ty::mk_bot(self.tcx()));
     }
 
-    fn to_ty(@mut self, ast_t: @ast::Ty) -> ty::t {
+    fn to_ty(&self, ast_t: @ast::Ty) -> ty::t {
         ast_ty_to_ty(self, self, ast_t)
     }
 
-    fn expr_to_str(@mut self, expr: @ast::expr) -> ~str {
+    fn expr_to_str(&self, expr: @ast::expr) -> ~str {
         expr_repr(self.tcx(), expr)
     }
 
-    fn pat_to_str(@mut self, pat: @ast::pat) -> ~str {
+    fn pat_to_str(&self, pat: @ast::pat) -> ~str {
         pat_repr(self.tcx(), pat)
     }
 
-    fn expr_ty(@mut self, ex: @ast::expr) -> ty::t {
+    fn expr_ty(&self, ex: @ast::expr) -> ty::t {
         match self.inh.node_types.find(&ex.id) {
             Some(t) => t,
             None => {
@@ -779,7 +780,7 @@ pub impl FnCtxt {
             }
         }
     }
-    fn node_ty(@mut self, id: ast::node_id) -> ty::t {
+    fn node_ty(&self, id: ast::node_id) -> ty::t {
         match self.inh.node_types.find(&id) {
             Some(t) => t,
             None => {
@@ -792,7 +793,7 @@ pub impl FnCtxt {
             }
         }
     }
-    fn node_ty_substs(@mut self, id: ast::node_id) -> ty::substs {
+    fn node_ty_substs(&self, id: ast::node_id) -> ty::substs {
         match self.inh.node_type_substs.find(&id) {
             Some(ref ts) => (/*bad*/copy *ts),
             None => {
@@ -805,12 +806,12 @@ pub impl FnCtxt {
             }
         }
     }
-    fn opt_node_ty_substs(@mut self, id: ast::node_id) -> Option<ty::substs> {
+    fn opt_node_ty_substs(&self, id: ast::node_id) -> Option<ty::substs> {
         self.inh.node_type_substs.find(&id)
     }
 
 
-    fn mk_subty(@mut self,
+    fn mk_subty(&self,
                 a_is_expected: bool,
                 span: span,
                 sub: ty::t,
@@ -819,14 +820,14 @@ pub impl FnCtxt {
         infer::mk_subty(self.infcx(), a_is_expected, span, sub, sup)
     }
 
-    fn can_mk_subty(@mut self,
+    fn can_mk_subty(&self,
                     sub: ty::t,
                     sup: ty::t)
                  -> Result<(), ty::type_err> {
         infer::can_mk_subty(self.infcx(), sub, sup)
     }
 
-    fn mk_assignty(@mut self, expr: @ast::expr, sub: ty::t, sup: ty::t)
+    fn mk_assignty(&self, expr: @ast::expr, sub: ty::t, sup: ty::t)
                 -> Result<(), ty::type_err> {
         match infer::mk_coercety(self.infcx(), false, expr.span, sub, sup) {
             Ok(None) => result::Ok(()),
@@ -838,14 +839,14 @@ pub impl FnCtxt {
         }
     }
 
-    fn can_mk_assignty(@mut self,
+    fn can_mk_assignty(&self,
                        sub: ty::t,
                        sup: ty::t)
                     -> Result<(), ty::type_err> {
         infer::can_mk_coercety(self.infcx(), sub, sup)
     }
 
-    fn mk_eqty(@mut self,
+    fn mk_eqty(&self,
                a_is_expected: bool,
                span: span,
                sub: ty::t,
@@ -854,7 +855,7 @@ pub impl FnCtxt {
         infer::mk_eqty(self.infcx(), a_is_expected, span, sub, sup)
     }
 
-    fn mk_subr(@mut self,
+    fn mk_subr(&self,
                a_is_expected: bool,
                span: span,
                sub: ty::Region,
@@ -863,7 +864,7 @@ pub impl FnCtxt {
         infer::mk_subr(self.infcx(), a_is_expected, span, sub, sup)
     }
 
-    fn require_unsafe(@mut self, sp: span, op: ~str) {
+    fn require_unsafe(&self, sp: span, op: ~str) {
         match self.purity {
           ast::unsafe_fn => {/*ok*/}
           _ => {
@@ -873,7 +874,8 @@ pub impl FnCtxt {
           }
         }
     }
-    fn with_region_lb<R>(@mut self, lb: ast::node_id, f: fn() -> R) -> R {
+
+    fn with_region_lb<R>(@mut self, lb: ast::node_id, f: &fn() -> R) -> R {
         let old_region_lb = self.region_lb;
         self.region_lb = lb;
         let v = f();
@@ -881,7 +883,7 @@ pub impl FnCtxt {
         v
     }
 
-    fn region_var_if_parameterized(@mut self,
+    fn region_var_if_parameterized(&self,
                                    rp: Option<ty::region_variance>,
                                    span: span,
                                    lower_bound: ty::Region)
@@ -890,7 +892,7 @@ pub impl FnCtxt {
             |_rp| self.infcx().next_region_var_with_lb(span, lower_bound))
     }
 
-    fn type_error_message(@mut self,
+    fn type_error_message(&self,
                           sp: span,
                           mk_msg: &fn(~str) -> ~str,
                           actual_ty: ty::t,
@@ -898,7 +900,7 @@ pub impl FnCtxt {
         self.infcx().type_error_message(sp, mk_msg, actual_ty, err);
     }
 
-    fn report_mismatched_return_types(@mut self,
+    fn report_mismatched_return_types(&self,
                                       sp: span,
                                       e: ty::t,
                                       a: ty::t,
@@ -919,12 +921,12 @@ pub impl FnCtxt {
         }
     }
 
-    fn report_mismatched_types(@mut self,
+    fn report_mismatched_types(&self,
                                sp: span,
                                e: ty::t,
                                a: ty::t,
                                err: &ty::type_err) {
-            self.infcx().report_mismatched_types(sp, e, a, err)
+        self.infcx().report_mismatched_types(sp, e, a, err)
     }
 }
 

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -58,7 +58,7 @@ pub trait LatticeValue {
                  -> cres<Self>;
 }
 
-pub type LatticeOp<T> = &fn(cf: &CombineFields, a: &T, b: &T) -> cres<T>;
+pub type LatticeOp<T> = &self/fn(cf: &CombineFields, a: &T, b: &T) -> cres<T>;
 
 impl LatticeValue for ty::t {
     static fn sub(&self, cf: &CombineFields, a: &ty::t, b: &ty::t) -> ures {
@@ -378,7 +378,7 @@ pub fn super_lattice_tys<L:LatticeDir + TyLatticeDir + Combine>(
     }
 }
 
-pub type LatticeDirOp<T> = &fn(a: &T, b: &T) -> cres<T>;
+pub type LatticeDirOp<T> = &self/fn(a: &T, b: &T) -> cres<T>;
 
 pub enum LatticeVarResult<V,T> {
     VarResult(V),

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -17,24 +17,33 @@ use core::result;
 use syntax::ast;
 use syntax::codemap::span;
 
+pub struct RegionError {
+    msg: ~str,
+    replacement: ty::Region
+}
+
 pub trait region_scope {
-    fn anon_region(&self, span: span) -> Result<ty::Region, ~str>;
-    fn self_region(&self, span: span) -> Result<ty::Region, ~str>;
+    fn anon_region(&self, span: span) -> Result<ty::Region, RegionError>;
+    fn self_region(&self, span: span) -> Result<ty::Region, RegionError>;
     fn named_region(&self, span: span, id: ast::ident)
-                      -> Result<ty::Region, ~str>;
+                      -> Result<ty::Region, RegionError>;
 }
 
 pub enum empty_rscope { empty_rscope }
 impl region_scope for empty_rscope {
-    fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
-        result::Err(~"only the static region is allowed here")
+    fn anon_region(&self, _span: span) -> Result<ty::Region, RegionError> {
+        result::Err(RegionError {
+            msg: ~"only 'static is allowed here",
+            replacement: ty::re_static
+        })
     }
-    fn self_region(&self, _span: span) -> Result<ty::Region, ~str> {
-        result::Err(~"only the static region is allowed here")
+    fn self_region(&self, _span: span) -> Result<ty::Region, RegionError> {
+        self.anon_region(_span)
     }
     fn named_region(&self, _span: span, _id: ast::ident)
-        -> Result<ty::Region, ~str> {
-        result::Err(~"only the static region is allowed here")
+        -> Result<ty::Region, RegionError>
+    {
+        self.anon_region(_span)
     }
 }
 
@@ -43,38 +52,59 @@ pub struct MethodRscope {
     region_parameterization: Option<ty::region_variance>
 }
 impl region_scope for MethodRscope {
-    fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
-        result::Err(~"anonymous region types are not permitted here")
+    fn anon_region(&self, _span: span) -> Result<ty::Region, RegionError> {
+        result::Err(RegionError {
+            msg: ~"anonymous lifetimes are not permitted here",
+            replacement: ty::re_bound(ty::br_self)
+        })
     }
-    fn self_region(&self, _span: span) -> Result<ty::Region, ~str> {
+    fn self_region(&self, _span: span) -> Result<ty::Region, RegionError> {
         assert self.region_parameterization.is_some() ||
             self.self_ty.is_borrowed();
         result::Ok(ty::re_bound(ty::br_self))
     }
     fn named_region(&self, span: span, id: ast::ident)
-                      -> Result<ty::Region, ~str> {
+                      -> Result<ty::Region, RegionError> {
         do empty_rscope.named_region(span, id).chain_err |_e| {
-            result::Err(~"region is not in scope here")
+            result::Err(RegionError {
+                msg: ~"lifetime is not in scope",
+                replacement: ty::re_bound(ty::br_self)
+            })
         }
     }
 }
 
 pub enum type_rscope = Option<ty::region_variance>;
-impl region_scope for type_rscope {
-    fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
-        result::Err(~"anonymous region types are not permitted here")
+impl type_rscope {
+    priv fn replacement(&self) -> ty::Region {
+        if self.is_some() {
+            ty::re_bound(ty::br_self)
+        } else {
+            ty::re_static
+        }
     }
-    fn self_region(&self, _span: span) -> Result<ty::Region, ~str> {
+}
+impl region_scope for type_rscope {
+    fn anon_region(&self, _span: span) -> Result<ty::Region, RegionError> {
+        result::Err(RegionError {
+            msg: ~"anonymous lifetimes are not permitted here",
+            replacement: self.replacement()
+        })
+    }
+    fn self_region(&self, _span: span) -> Result<ty::Region, RegionError> {
         // if the self region is used, region parameterization should
         // have inferred that this type is RP
         assert self.is_some();
         result::Ok(ty::re_bound(ty::br_self))
     }
     fn named_region(&self, span: span, id: ast::ident)
-                      -> Result<ty::Region, ~str> {
+                      -> Result<ty::Region, RegionError> {
         do empty_rscope.named_region(span, id).chain_err |_e| {
-            result::Err(~"named regions other than `self` are not \
-                          allowed as part of a type declaration")
+            result::Err(RegionError {
+                msg: ~"only 'self is allowed allowed as \
+                       part of a type declaration",
+                replacement: self.replacement()
+            })
         }
     }
 }
@@ -98,17 +128,17 @@ pub fn in_binding_rscope<RS:region_scope + Copy + Durable>(self: &RS)
     binding_rscope { base: base, anon_bindings: @mut 0 }
 }
 impl region_scope for binding_rscope {
-    fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
+    fn anon_region(&self, _span: span) -> Result<ty::Region, RegionError> {
         let idx = *self.anon_bindings;
         *self.anon_bindings += 1;
         result::Ok(ty::re_bound(ty::br_anon(idx)))
     }
-    fn self_region(&self, span: span) -> Result<ty::Region, ~str> {
+    fn self_region(&self, span: span) -> Result<ty::Region, RegionError> {
         self.base.self_region(span)
     }
     fn named_region(&self,
                     span: span,
-                    id: ast::ident) -> Result<ty::Region, ~str>
+                    id: ast::ident) -> Result<ty::Region, RegionError>
     {
         do self.base.named_region(span, id).chain_err |_e| {
             result::Ok(ty::re_bound(ty::br_named(id)))

--- a/src/librustdoc/astsrv.rs
+++ b/src/librustdoc/astsrv.rs
@@ -36,7 +36,7 @@ pub struct Ctxt {
     ast_map: ast_map::map
 }
 
-type SrvOwner<T> = &fn(srv: Srv) -> T;
+type SrvOwner<T> = &'self fn(srv: Srv) -> T;
 pub type CtxtHandler<T> = ~fn(ctxt: Ctxt) -> T;
 type Parser = ~fn(Session, s: ~str) -> @ast::crate;
 

--- a/src/libstd/arena.rs
+++ b/src/libstd/arena.rs
@@ -160,9 +160,9 @@ unsafe fn un_bitpack_tydesc_ptr(p: uint) -> (*TypeDesc, bool) {
     (reinterpret_cast(&(p & !1)), p & 1 == 1)
 }
 
-pub impl &Arena {
+pub impl Arena {
     // Functions for the POD part of the arena
-    fn alloc_pod_grow(n_bytes: uint, align: uint) -> *u8 {
+    fn alloc_pod_grow(&self, n_bytes: uint, align: uint) -> *u8 {
         // Allocate a new chunk.
         let chunk_size = at_vec::capacity(self.pod_head.data);
         let new_min_chunk_size = uint::max(n_bytes, chunk_size);
@@ -174,7 +174,7 @@ pub impl &Arena {
     }
 
     #[inline(always)]
-    fn alloc_pod_inner(n_bytes: uint, align: uint) -> *u8 {
+    fn alloc_pod_inner(&self, n_bytes: uint, align: uint) -> *u8 {
         let head = &mut self.pod_head;
 
         let start = round_up_to(head.fill, align);
@@ -193,7 +193,7 @@ pub impl &Arena {
     }
 
     #[inline(always)]
-    fn alloc_pod<T>(op: fn() -> T) -> &self/T {
+    fn alloc_pod<T>(&self, op: fn() -> T) -> &self/T {
         unsafe {
             let tydesc = sys::get_type_desc::<T>();
             let ptr = self.alloc_pod_inner((*tydesc).size, (*tydesc).align);
@@ -204,7 +204,7 @@ pub impl &Arena {
     }
 
     // Functions for the non-POD part of the arena
-    fn alloc_nonpod_grow(n_bytes: uint, align: uint) -> (*u8, *u8) {
+    fn alloc_nonpod_grow(&self, n_bytes: uint, align: uint) -> (*u8, *u8) {
         // Allocate a new chunk.
         let chunk_size = at_vec::capacity(self.head.data);
         let new_min_chunk_size = uint::max(n_bytes, chunk_size);
@@ -216,7 +216,7 @@ pub impl &Arena {
     }
 
     #[inline(always)]
-    fn alloc_nonpod_inner(n_bytes: uint, align: uint) -> (*u8, *u8) {
+    fn alloc_nonpod_inner(&self, n_bytes: uint, align: uint) -> (*u8, *u8) {
         let head = &mut self.head;
 
         let tydesc_start = head.fill;
@@ -238,7 +238,7 @@ pub impl &Arena {
     }
 
     #[inline(always)]
-    fn alloc_nonpod<T>(op: fn() -> T) -> &self/T {
+    fn alloc_nonpod<T>(&self, op: fn() -> T) -> &self/T {
         unsafe {
             let tydesc = sys::get_type_desc::<T>();
             let (ty_ptr, ptr) =
@@ -260,7 +260,7 @@ pub impl &Arena {
 
     // The external interface
     #[inline(always)]
-    fn alloc<T>(op: fn() -> T) -> &self/T {
+    fn alloc<T>(&self, op: fn() -> T) -> &self/T {
         unsafe {
             if !rusti::needs_drop::<T>() {
                 self.alloc_pod(op)

--- a/src/libstd/base64.rs
+++ b/src/libstd/base64.rs
@@ -16,7 +16,7 @@ pub trait ToBase64 {
     pure fn to_base64() -> ~str;
 }
 
-impl ToBase64 for &[u8] {
+impl ToBase64 for &self/[u8] {
     pure fn to_base64() -> ~str {
         let chars = str::chars(
           ~"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
@@ -69,7 +69,7 @@ impl ToBase64 for &[u8] {
     }
 }
 
-impl ToBase64 for &str {
+impl ToBase64 for &self/str {
     pure fn to_base64() -> ~str {
         str::to_bytes(self).to_base64()
     }

--- a/src/libstd/bigint.rs
+++ b/src/libstd/bigint.rs
@@ -1045,7 +1045,9 @@ mod biguint_tests {
         assert BigUint::new(~[0, 0, -1]).to_uint() == uint::max_value;
     }
 
-    const sum_triples: &[(&[BigDigit], &[BigDigit], &[BigDigit])] = &[
+    const sum_triples: &static/[(&static/[BigDigit],
+                                 &static/[BigDigit],
+                                 &static/[BigDigit])] = &[
         (&[],          &[],       &[]),
         (&[],          &[ 1],     &[ 1]),
         (&[ 1],        &[ 1],     &[ 2]),
@@ -1083,7 +1085,9 @@ mod biguint_tests {
         }
     }
 
-    const mul_triples: &[(&[BigDigit], &[BigDigit], &[BigDigit])] = &[
+    const mul_triples: &static/[(&static/[BigDigit],
+                                 &static/[BigDigit],
+                                 &static/[BigDigit])] = &[
         (&[],               &[],               &[]),
         (&[],               &[ 1],             &[]),
         (&[ 2],             &[],               &[]),
@@ -1107,8 +1111,10 @@ mod biguint_tests {
         (&[ 0,  0,  1],     &[ 0,  0,  0,  1], &[0, 0,  0,  0,  0,  1])
     ];
 
-    const divmod_quadruples: &[(&[BigDigit], &[BigDigit],
-                                &[BigDigit], &[BigDigit])]
+    const divmod_quadruples: &static/[(&static/[BigDigit],
+                                       &static/[BigDigit],
+                                       &static/[BigDigit],
+                                       &static/[BigDigit])]
         = &[
             (&[ 1],        &[ 2], &[],               &[1]),
             (&[ 1,  1],    &[ 2], &[-1/2+1],         &[1]),
@@ -1393,7 +1399,9 @@ mod bigint_tests {
         ).to_uint() == 0;
     }
 
-    const sum_triples: &[(&[BigDigit], &[BigDigit], &[BigDigit])] = &[
+    const sum_triples: &static/[(&static/[BigDigit],
+                                 &static/[BigDigit],
+                                 &static/[BigDigit])] = &[
         (&[],          &[],       &[]),
         (&[],          &[ 1],     &[ 1]),
         (&[ 1],        &[ 1],     &[ 2]),
@@ -1443,7 +1451,9 @@ mod bigint_tests {
         }
     }
 
-    const mul_triples: &[(&[BigDigit], &[BigDigit], &[BigDigit])] = &[
+    const mul_triples: &static/[(&static/[BigDigit],
+                                 &static/[BigDigit],
+                                 &static/[BigDigit])] = &[
         (&[],               &[],               &[]),
         (&[],               &[ 1],             &[]),
         (&[ 2],             &[],               &[]),
@@ -1467,8 +1477,10 @@ mod bigint_tests {
         (&[ 0,  0,  1],     &[ 0,  0,  0,  1], &[0, 0,  0,  0,  0,  1])
     ];
 
-    const divmod_quadruples: &[(&[BigDigit], &[BigDigit],
-                                &[BigDigit], &[BigDigit])]
+    const divmod_quadruples: &static/[(&static/[BigDigit],
+                                       &static/[BigDigit],
+                                       &static/[BigDigit],
+                                       &static/[BigDigit])]
         = &[
             (&[ 1],        &[ 2], &[],               &[1]),
             (&[ 1,  1],    &[ 2], &[-1/2+1],         &[1]),

--- a/src/libstd/flatpipes.rs
+++ b/src/libstd/flatpipes.rs
@@ -468,8 +468,8 @@ pub mod flatteners {
         static fn from_writer(w: Writer) -> Self;
     }
 
-    impl FromReader for json::Decoder {
-        static fn from_reader(r: Reader) -> json::Decoder {
+    impl FromReader for json::Decoder/&self {
+        static fn from_reader(r: Reader) -> json::Decoder/&self {
             match json::from_reader(r) {
                 Ok(json) => {
                     json::Decoder(json)

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -749,14 +749,14 @@ pub fn from_str(s: &str) -> Result<Json, Error> {
 
 pub struct Decoder {
     priv json: Json,
-    priv mut stack: ~[&Json],
+    priv mut stack: ~[&self/Json],
 }
 
 pub fn Decoder(json: Json) -> Decoder {
     Decoder { json: json, stack: ~[] }
 }
 
-priv impl Decoder {
+priv impl Decoder/&self {
     fn peek(&self) -> &self/Json {
         if self.stack.len() == 0 { self.stack.push(&self.json); }
         self.stack[self.stack.len() - 1]
@@ -768,7 +768,7 @@ priv impl Decoder {
     }
 }
 
-impl serialize::Decoder for Decoder {
+impl serialize::Decoder for Decoder/&self {
     fn read_nil(&self) -> () {
         debug!("read_nil");
         match *self.pop() {

--- a/src/libstd/serialize.rs
+++ b/src/libstd/serialize.rs
@@ -213,7 +213,7 @@ impl<D:Decoder> Decodable<D> for i64 {
     }
 }
 
-impl<S:Encoder> Encodable<S> for &str {
+impl<S:Encoder> Encodable<S> for &self/str {
     fn encode(&self, s: &S) { s.emit_borrowed_str(*self) }
 }
 
@@ -286,7 +286,7 @@ impl<D:Decoder> Decodable<D> for () {
     }
 }
 
-impl<S:Encoder,T:Encodable<S>> Encodable<S> for &T {
+impl<S:Encoder,T:Encodable<S>> Encodable<S> for &self/T {
     fn encode(&self, s: &S) {
         s.emit_borrowed(|| (**self).encode(s))
     }
@@ -316,7 +316,7 @@ impl<D:Decoder,T:Decodable<D>> Decodable<D> for @T {
     }
 }
 
-impl<S:Encoder,T:Encodable<S>> Encodable<S> for &[T] {
+impl<S:Encoder,T:Encodable<S>> Encodable<S> for &self/[T] {
     fn encode(&self, s: &S) {
         do s.emit_borrowed_vec(self.len()) {
             for self.eachi |i, e| {

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -22,7 +22,7 @@ pub struct SmallIntMap<T> {
     priv v: ~[Option<T>],
 }
 
-impl<V> BaseIter<(uint, &V)> for SmallIntMap<V> {
+impl<V> BaseIter<(uint, &self/V)> for SmallIntMap<V> {
     /// Visit all key-value pairs in order
     pure fn each(&self, it: fn(&(uint, &self/V)) -> bool) {
         for uint::range(0, self.v.len()) |i| {
@@ -36,7 +36,7 @@ impl<V> BaseIter<(uint, &V)> for SmallIntMap<V> {
     pure fn size_hint(&self) -> Option<uint> { Some(self.len()) }
 }
 
-impl<V> ReverseIter<(uint, &V)> for SmallIntMap<V> {
+impl<V> ReverseIter<(uint, &self/V)> for SmallIntMap<V> {
     /// Visit all key-value pairs in reverse order
     pure fn each_reverse(&self, it: fn(&(uint, &self/V)) -> bool) {
         for uint::range_rev(self.v.len(), 0) |i| {

--- a/src/libstd/sort.rs
+++ b/src/libstd/sort.rs
@@ -17,7 +17,7 @@ use core::util;
 use core::vec::{len, push};
 use core::vec;
 
-type Le<T> = pure fn(v1: &T, v2: &T) -> bool;
+type Le<T> = &self/pure fn(v1: &T, v2: &T) -> bool;
 
 /**
  * Merge sort. Returns a new vector containing the sorted list.
@@ -169,7 +169,7 @@ pub trait Sort {
     fn qsort(self);
 }
 
-impl<T:Copy + Ord + Eq> Sort for &mut [T] {
+impl<T:Copy + Ord + Eq> Sort for &self/mut [T] {
     fn qsort(self) { quick_sort3(self); }
 }
 
@@ -1178,11 +1178,10 @@ mod big_tests {
 
     struct LVal {
         val: uint,
-        key: fn(@uint),
-
+        key: &self/fn(@uint),
     }
 
-    impl Drop for LVal {
+    impl Drop for LVal/&self {
         fn finalize(&self) {
             let x = unsafe { task::local_data::local_data_get(self.key) };
             match x {
@@ -1196,7 +1195,7 @@ mod big_tests {
         }
     }
 
-    impl Ord for LVal {
+    impl Ord for LVal/&self {
         pure fn lt(&self, other: &a/LVal/&self) -> bool {
             (*self).val < other.val
         }

--- a/src/libstd/stats.rs
+++ b/src/libstd/stats.rs
@@ -30,7 +30,7 @@ pub trait Stats {
     fn median_abs_dev_pct(self) -> f64;
 }
 
-impl Stats for &[f64] {
+impl Stats for &self/[f64] {
     fn sum(self) -> f64 {
         vec::foldl(0.0, self, |p,q| p + *q)
     }

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -94,7 +94,7 @@ impl<K: Ord + TotalOrd, V> Ord for TreeMap<K, V> {
     }
 }
 
-impl<K: TotalOrd, V> BaseIter<(&K, &V)> for TreeMap<K, V> {
+impl<'self, K: TotalOrd, V> BaseIter<(&'self K, &'self V)> for TreeMap<K, V> {
     /// Visit all key-value pairs in order
     pure fn each(&self, f: fn(&(&self/K, &self/V)) -> bool) {
         each(&self.root, f)
@@ -102,7 +102,10 @@ impl<K: TotalOrd, V> BaseIter<(&K, &V)> for TreeMap<K, V> {
     pure fn size_hint(&self) -> Option<uint> { Some(self.len()) }
 }
 
-impl<K: TotalOrd, V> ReverseIter<(&K, &V)> for TreeMap<K, V> {
+impl<'self, K: TotalOrd, V>
+    ReverseIter<(&'self K, &'self V)>
+    for TreeMap<K, V>
+{
     /// Visit all key-value pairs in reverse order
     pure fn each_reverse(&self, f: fn(&(&self/K, &self/V)) -> bool) {
         each_reverse(&self.root, f);
@@ -195,8 +198,8 @@ pub impl<K: TotalOrd, V> TreeMap<K, V> {
 
 /// Lazy forward iterator over a map
 pub struct TreeMapIterator<K, V> {
-    priv stack: ~[&~TreeNode<K, V>],
-    priv node: &Option<~TreeNode<K, V>>
+    priv stack: ~[&self/~TreeNode<K, V>],
+    priv node: &self/Option<~TreeNode<K, V>>
 }
 
 /// Advance the iterator to the next node (in order) and return a
@@ -494,7 +497,7 @@ pub impl <T: TotalOrd> TreeSet<T> {
 
 /// Lazy forward iterator over a set
 pub struct TreeSetIterator<T> {
-    priv iter: TreeMapIterator<T, ()>
+    priv iter: TreeMapIterator/&self<T, ()>
 }
 
 /// Advance the iterator to the next node (in order). If this iterator is

--- a/src/libstd/workcache.rs
+++ b/src/libstd/workcache.rs
@@ -168,7 +168,8 @@ struct Database {
 }
 
 pub impl Database {
-    fn prepare(&mut self, fn_name: &str,
+    fn prepare(&mut self,
+               fn_name: &str,
                declared_inputs: &WorkMap) -> Option<(WorkMap, WorkMap, ~str)>
     {
         let k = json_encode(&(fn_name, declared_inputs));
@@ -233,7 +234,9 @@ fn json_encode<T:Encodable<json::Encoder>>(t: &T) -> ~str {
     }
 }
 
-fn json_decode<T:Decodable<json::Decoder>>(s: &str) -> T {
+fn json_decode<T:Decodable<json::Decoder/&static>>( // FIXME(#5121)
+    s: &str) -> T
+{
     do io::with_str_reader(s) |rdr| {
         let j = result::unwrap(json::from_reader(rdr));
         Decodable::decode(&json::Decoder(j))
@@ -261,7 +264,9 @@ pub impl Context {
         Context{db: db, logger: lg, cfg: cfg, freshness: LinearMap::new()}
     }
 
-    fn prep<T:Owned + Encodable<json::Encoder> + Decodable<json::Decoder>>(
+    fn prep<T:Owned +
+              Encodable<json::Encoder> +
+              Decodable<json::Decoder/&static>>( // FIXME(#5121)
                   @self,
                   fn_name:&str,
                   blk: fn(@Mut<Prep>)->Work<T>) -> Work<T> {
@@ -277,7 +282,9 @@ trait TPrep {
     fn declare_input(&self, kind:&str, name:&str, val:&str);
     fn is_fresh(&self, cat:&str, kind:&str, name:&str, val:&str) -> bool;
     fn all_fresh(&self, cat:&str, map:&WorkMap) -> bool;
-    fn exec<T:Owned + Encodable<json::Encoder> + Decodable<json::Decoder>>(
+    fn exec<T:Owned +
+              Encodable<json::Encoder> +
+              Decodable<json::Decoder/&static>>( // FIXME(#5121)
         &self, blk: ~fn(&Exec) -> T) -> Work<T>;
 }
 
@@ -316,7 +323,9 @@ impl TPrep for @Mut<Prep> {
         return true;
     }
 
-    fn exec<T:Owned + Encodable<json::Encoder> + Decodable<json::Decoder>>(
+    fn exec<T:Owned +
+              Encodable<json::Encoder> +
+              Decodable<json::Decoder/&static>>( // FIXME(#5121)
             &self, blk: ~fn(&Exec) -> T) -> Work<T> {
         let mut bo = Some(blk);
 
@@ -355,14 +364,18 @@ impl TPrep for @Mut<Prep> {
     }
 }
 
-pub impl<T:Owned+Encodable<json::Encoder>+Decodable<json::Decoder>> Work<T> {
+pub impl<T:Owned +
+         Encodable<json::Encoder> +
+         Decodable<json::Decoder/&static>> Work<T> { // FIXME(#5121)
     static fn new(p: @Mut<Prep>, e: Either<T,PortOne<(Exec,T)>>) -> Work<T> {
         Work { prep: p, res: Some(e) }
     }
 }
 
 // FIXME (#3724): movable self. This should be in impl Work.
-fn unwrap<T:Owned + Encodable<json::Encoder> + Decodable<json::Decoder>>(
+fn unwrap<T:Owned +
+            Encodable<json::Encoder> +
+            Decodable<json::Decoder/&static>>( // FIXME(#5121)
         w: Work<T>) -> T {
     let mut ww = w;
     let mut s = None;

--- a/src/libsyntax/ext/deriving.rs
+++ b/src/libsyntax/ext/deriving.rs
@@ -46,18 +46,16 @@ pub impl Junction {
     }
 }
 
-type ExpandDerivingStructDefFn = &fn(ext_ctxt,
-                                     span,
-                                     x: &struct_def,
-                                     ident,
-                                     y: &Generics)
-                                  -> @item;
-type ExpandDerivingEnumDefFn = &fn(ext_ctxt,
-                                   span,
-                                   x: &enum_def,
-                                   ident,
-                                   y: &Generics)
-                                -> @item;
+type ExpandDerivingStructDefFn = &self/fn(ext_ctxt,
+                                          span,
+                                          x: &struct_def,
+                                          ident,
+                                          y: &Generics) -> @item;
+type ExpandDerivingEnumDefFn = &self/fn(ext_ctxt,
+                                        span,
+                                        x: &enum_def,
+                                        ident,
+                                        y: &Generics) -> @item;
 
 pub fn expand_deriving_eq(cx: ext_ctxt,
                           span: span,

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -442,11 +442,12 @@ pub fn core_macros() -> ~str {
             mod $c {
                 fn key(_x: @::core::condition::Handler<$in,$out>) { }
 
-                pub const cond : ::core::condition::Condition<$in,$out> =
+                pub const cond :
+                    ::core::condition::Condition/&static<$in,$out> =
                     ::core::condition::Condition {
-                    name: stringify!($c),
-                    key: key
-                };
+                        name: stringify!($c),
+                        key: key
+                    };
             }
         }
     )

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1817,6 +1817,7 @@ pub fn print_generics(s: @ps, &&generics: &ast::Generics) {
                 let lifetime = generics.lifetimes.get(idx);
                 print_lifetime(s, lifetime);
             } else {
+                let idx = idx - generics.lifetimes.len();
                 let param = generics.ty_params.get(idx);
                 print_ident(s, param.ident);
                 print_bounds(s, param.bounds);

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -35,8 +35,8 @@ use core::u64;
 use core::vec;
 
 // The @ps is stored here to prevent recursive type.
-pub enum ann_node/& {
-    node_block(@ps, &ast::blk),
+pub enum ann_node<'self> {
+    node_block(@ps, &'self ast::blk),
     node_item(@ps, @ast::item),
     node_expr(@ps, @ast::expr),
     node_pat(@ps, @ast::pat),

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -147,6 +147,10 @@ pub fn expr_to_str(e: @ast::expr, intr: @ident_interner) -> ~str {
     to_str(e, print_expr, intr)
 }
 
+pub fn region_to_str(e: @ast::region, intr: @ident_interner) -> ~str {
+    to_str(e, |s, e| print_region(s, ~"&", e, ~""), intr)
+}
+
 pub fn tt_to_str(tt: ast::token_tree, intr: @ident_interner) -> ~str {
     to_str(tt, print_tt, intr)
 }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -28,14 +28,14 @@ use opt_vec::OptVec;
 // hold functions that take visitors. A vt enum is used to break the cycle.
 pub enum vt<E> { mk_vt(visitor<E>), }
 
-pub enum fn_kind {
-    fk_item_fn(ident, &Generics, purity),   // fn foo()
-    fk_method(ident, &Generics, &method),   // fn foo(&self)
+pub enum fn_kind<'self> {
+    fk_item_fn(ident, &'self Generics, purity),   // fn foo()
+    fk_method(ident, &'self Generics, &'self method),   // fn foo(&self)
     fk_anon(ast::Sigil),                    // fn@(x, y) { ... }
     fk_fn_block,                            // |x, y| ...
     fk_dtor( // class destructor
-        &Generics,
-        &[attribute],
+        &'self Generics,
+        &'self [attribute],
         node_id /* self id */,
         def_id /* parent class id */
     )

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -12,7 +12,10 @@ extern mod std;
 use std::arena;
 use methods = std::arena::Arena;
 
-enum tree/& { nil, node(&tree, &tree, int), }
+enum tree {
+    nil,
+    node(&'self tree<'self>, &'self tree<'self>, int),
+}
 
 fn item_check(t: &tree) -> int {
     match *t {
@@ -23,9 +26,9 @@ fn item_check(t: &tree) -> int {
     }
 }
 
-fn bottom_up_tree(arena: &r/arena::Arena,
+fn bottom_up_tree(arena: &'r arena::Arena,
                   item: int,
-                  depth: int) -> &r/tree {
+                  depth: int) -> &'r tree<'r> {
     if depth > 0 {
         return arena.alloc(
             || node(bottom_up_tree(arena, 2 * item - 1, depth - 1),

--- a/src/test/compile-fail/auto-ref-borrowck-failure.rs
+++ b/src/test/compile-fail/auto-ref-borrowck-failure.rs
@@ -18,7 +18,7 @@ trait Stuff {
     fn printme();
 }
 
-impl Stuff for &mut Foo {
+impl Stuff for &'self mut Foo {
     fn printme() {
         io::println(fmt!("%d", self.x));
     }

--- a/src/test/compile-fail/auto-ref-slice-plus-ref.rs
+++ b/src/test/compile-fail/auto-ref-slice-plus-ref.rs
@@ -23,6 +23,6 @@ trait MyIter {
     pure fn test_mut(&mut self);
 }
 
-impl MyIter for &[int] {
+impl MyIter for &'self [int] {
     pure fn test_mut(&mut self) { }
 }

--- a/src/test/compile-fail/borrowck-autoref-3261.rs
+++ b/src/test/compile-fail/borrowck-autoref-3261.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 enum X = Either<(uint,uint),extern fn()>;
-pub impl &X {
+pub impl &'self X {
     fn with(blk: fn(x: &Either<(uint,uint),extern fn()>)) {
         blk(&**self)
     }

--- a/src/test/compile-fail/borrowck-borrowed-uniq-rvalue-2.rs
+++ b/src/test/compile-fail/borrowck-borrowed-uniq-rvalue-2.rs
@@ -9,16 +9,16 @@
 // except according to those terms.
 
 struct defer {
-    x: &[&str],
+    x: &'self [&'self str],
 }
 
-impl Drop for defer {
+impl Drop for defer<'self> {
     fn finalize(&self) {
         error!("%?", self.x);
     }
 }
 
-fn defer(x: &r/[&r/str]) -> defer/&r {
+fn defer(x: &'r [&'r str]) -> defer<'r> {
     defer {
         x: x
     }

--- a/src/test/compile-fail/issue-1896-1.rs
+++ b/src/test/compile-fail/issue-1896-1.rs
@@ -8,11 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct boxedFn { theFn: ~fn() -> uint }
+struct boxedFn { theFn: &'self fn() -> uint }
 
 fn createClosure (closedUint: uint) -> boxedFn {
-    let result: @fn() -> uint = || closedUint;
-    boxedFn { theFn: result } //~ ERROR mismatched types
+    boxedFn {theFn: @fn () -> uint { closedUint }} //~ ERROR illegal borrow
 }
 
 fn main () {

--- a/src/test/compile-fail/issue-1896-1.rs
+++ b/src/test/compile-fail/issue-1896-1.rs
@@ -11,7 +11,8 @@
 struct boxedFn { theFn: &'self fn() -> uint }
 
 fn createClosure (closedUint: uint) -> boxedFn {
-    boxedFn {theFn: @fn () -> uint { closedUint }} //~ ERROR illegal borrow
+    let theFn: @fn() -> uint = || closedUint;
+    boxedFn {theFn: theFn} //~ ERROR illegal borrow
 }
 
 fn main () {

--- a/src/test/compile-fail/issue-3154.rs
+++ b/src/test/compile-fail/issue-3154.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct thing<Q> {
-    x: &Q
+    x: &'self Q
 }
 
 fn thing<Q>(x: &Q) -> thing<Q> {

--- a/src/test/compile-fail/issue-3311.rs
+++ b/src/test/compile-fail/issue-3311.rs
@@ -10,17 +10,17 @@
 
 #[legacy_mode]
 struct Foo {
-    s: &str,
+    s: &'self str,
     u: ~()
 }
 
-pub impl Foo {
+pub impl Foo<'self> {
     fn get_s(&self) -> &self/str {
         self.s
     }
 }
 
-fn bar(s: &str, f: fn(Option<Foo>)) {
+fn bar(s: &str, f: &fn(Option<Foo>)) {
     f(Some(Foo {s: s, u: ~()}));
 }
 

--- a/src/test/compile-fail/issue-4523.rs
+++ b/src/test/compile-fail/issue-4523.rs
@@ -10,7 +10,7 @@
 
 fn foopy() {}
 
-const f: fn() = foopy; //~ ERROR mismatched types: expected `&static/fn()`
+const f: &'static fn() = foopy; //~ ERROR mismatched types: expected `&static/fn()`
 
 fn main () {
     f();

--- a/src/test/compile-fail/kindck-owned-trait-scoped.rs
+++ b/src/test/compile-fail/kindck-owned-trait-scoped.rs
@@ -12,11 +12,11 @@
 // be parameterized by a region due to the &self/int constraint.
 
 trait foo {
-    fn foo(i: &self/int) -> int;
+    fn foo(i: &'self int) -> int;
 }
 
-impl<T:Copy> foo for T {
-    fn foo(i: &self/int) -> int {*i}
+impl<T:Copy> foo<'self> for T {
+    fn foo(i: &'self int) -> int {*i}
 }
 
 fn to_foo<T:Copy>(t: T) {

--- a/src/test/compile-fail/regions-bounds.rs
+++ b/src/test/compile-fail/regions-bounds.rs
@@ -12,25 +12,25 @@
 // nominal types (but not on other types) and that they are type
 // checked.
 
-enum an_enum = &int;
+enum an_enum = &'self int;
 trait a_trait {
     fn foo() -> &'self int;
 }
 struct a_class { x:&'self int }
 
-fn a_fn1(e: an_enum/&a) -> an_enum/&b {
+fn a_fn1(e: an_enum<'a>) -> an_enum<'b> {
     return e; //~ ERROR mismatched types: expected `an_enum/&b` but found `an_enum/&a`
 }
 
-fn a_fn2(e: a_trait/&a) -> a_trait/&b {
+fn a_fn2(e: a_trait<'a>) -> a_trait<'b> {
     return e; //~ ERROR mismatched types: expected `@a_trait/&b` but found `@a_trait/&a`
 }
 
-fn a_fn3(e: a_class/&a) -> a_class/&b {
+fn a_fn3(e: a_class<'a>) -> a_class<'b> {
     return e; //~ ERROR mismatched types: expected `a_class/&b` but found `a_class/&a`
 }
 
-fn a_fn4(e: int/&a) -> int/&b {
+fn a_fn4(e: int<'a>) -> int<'b> {
     //~^ ERROR region parameters are not allowed on this type
     //~^^ ERROR region parameters are not allowed on this type
     return e;

--- a/src/test/compile-fail/regions-creating-enums.rs
+++ b/src/test/compile-fail/regions-creating-enums.rs
@@ -12,7 +12,7 @@
 
 enum ast {
     num(uint),
-    add(&ast, &ast)
+    add(&'self ast<'self>, &'self ast<'self>)
 }
 
 fn build() {

--- a/src/test/compile-fail/regions-creating-enums3.rs
+++ b/src/test/compile-fail/regions-creating-enums3.rs
@@ -10,10 +10,10 @@
 
 enum ast {
     num(uint),
-    add(&ast, &ast)
+    add(&'self ast<'self>, &'self ast<'self>)
 }
 
-fn mk_add_bad1(x: &a/ast, y: &b/ast) -> ast/&a {
+fn mk_add_bad1(x: &'a ast<'a>, y: &'b ast<'b>) -> ast<'a> {
     add(x, y) //~ ERROR cannot infer an appropriate lifetime
 }
 

--- a/src/test/compile-fail/regions-creating-enums4.rs
+++ b/src/test/compile-fail/regions-creating-enums4.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum ast {
+enum ast<'self> {
     num(uint),
-    add(&ast, &ast)
+    add(&'self ast<'self>, &'self ast<'self>)
 }
 
-fn mk_add_bad2(x: &a/ast, y: &a/ast, z: &ast) -> ast {
+fn mk_add_bad2(x: &'a ast<'a>, y: &'a ast<'a>, z: &ast) -> ast {
     add(x, y)
          //~^ ERROR cannot infer an appropriate lifetime
 }

--- a/src/test/compile-fail/regions-escape-via-trait-or-not.rs
+++ b/src/test/compile-fail/regions-escape-via-trait-or-not.rs
@@ -12,7 +12,7 @@ trait deref {
     fn get() -> int;
 }
 
-impl deref for &int {
+impl deref for &'self int {
     fn get() -> int {
         *self
     }

--- a/src/test/compile-fail/regions-glb-free-free.rs
+++ b/src/test/compile-fail/regions-glb-free-free.rs
@@ -11,19 +11,19 @@
 mod argparse {
     extern mod std;
 
-    pub struct Flag {
-        name: &str,
-        desc: &str,
+    pub struct Flag<'self> {
+        name: &'self str,
+        desc: &'self str,
         max_count: uint,
         value: uint
     }
 
-    pub fn flag(name: &r/str, desc: &r/str) -> Flag/&r {
+    pub fn flag(name: &'r str, desc: &'r str) -> Flag<'r> {
         Flag { name: name, desc: desc, max_count: 1, value: 0 }
     }
 
-    pub impl Flag {
-        fn set_desc(self, s: &str) -> Flag {
+    pub impl Flag<'self> {
+        fn set_desc(self, s: &str) -> Flag<'self> {
             Flag { //~ ERROR cannot infer an appropriate lifetime
                 name: self.name,
                 desc: s,

--- a/src/test/compile-fail/regions-in-consts.rs
+++ b/src/test/compile-fail/regions-in-consts.rs
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-const c_x: &blk/int = &22; //~ ERROR only the static region is allowed here
-const c_y: &static/int = &22;
+const c_x: &'blk int = &22; //~ ERROR only the static region is allowed here
+const c_y: &int = &22; //~ ERROR only the static region is allowed here
+const c_z: &'static int = &22;
 
 fn main() {
 }

--- a/src/test/compile-fail/regions-in-consts.rs
+++ b/src/test/compile-fail/regions-in-consts.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-const c_x: &'blk int = &22; //~ ERROR only the static region is allowed here
-const c_y: &int = &22; //~ ERROR only the static region is allowed here
+const c_x: &'blk int = &22; //~ ERROR Illegal lifetime &blk: only 'static is allowed here
+const c_y: &int = &22; //~ ERROR Illegal anonymous lifetime: only 'static is allowed here
 const c_z: &'static int = &22;
 
 fn main() {

--- a/src/test/compile-fail/regions-in-enums.rs
+++ b/src/test/compile-fail/regions-in-enums.rs
@@ -10,7 +10,7 @@
 
 enum yes0<'lt> {
     // This will eventually be legal (and in fact the only way):
-    X3(&'lt uint) //~ ERROR named regions other than `self` are not allowed as part of a type declaration
+    X3(&'lt uint) //~ ERROR Illegal lifetime &lt: only 'self is allowed allowed as part of a type declaration
 }
 
 enum yes1 {
@@ -18,7 +18,7 @@ enum yes1 {
 }
 
 enum yes2 {
-    X5(&'foo uint) //~ ERROR named regions other than `self` are not allowed as part of a type declaration
+    X5(&'foo uint) //~ ERROR Illegal lifetime &foo: only 'self is allowed allowed as part of a type declaration
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-in-structs.rs
+++ b/src/test/compile-fail/regions-in-structs.rs
@@ -8,28 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct yes0 {
-  x: &uint,
+struct yes0<'self> {
+  x: &uint, //~ ERROR anonymous region types are not permitted here
 }
 
-impl Drop for yes0 {
-    fn finalize(&self) {}
+struct yes1<'self> {
+  x: &'self uint,
 }
 
-struct yes1 {
-  x: &self/uint,
-}
-
-impl Drop for yes1 {
-    fn finalize(&self) {}
-}
-
-struct yes2 {
-  x: &foo/uint, //~ ERROR named regions other than `self` are not allowed as part of a type declaration
-}
-
-impl Drop for yes2 {
-    fn finalize(&self) {}
+struct yes2<'self> {
+  x: &'foo uint, //~ ERROR named regions other than `self` are not allowed as part of a type declaration
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-in-structs.rs
+++ b/src/test/compile-fail/regions-in-structs.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct yes0<'self> {
-  x: &uint, //~ ERROR anonymous region types are not permitted here
+  x: &uint, //~ ERROR Illegal anonymous lifetime: anonymous lifetimes are not permitted here
 }
 
 struct yes1<'self> {
@@ -17,7 +17,7 @@ struct yes1<'self> {
 }
 
 struct yes2<'self> {
-  x: &'foo uint, //~ ERROR named regions other than `self` are not allowed as part of a type declaration
+  x: &'foo uint, //~ ERROR Illegal lifetime &foo: only 'self is allowed allowed as part of a type declaration
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-in-type-items.rs
+++ b/src/test/compile-fail/regions-in-type-items.rs
@@ -9,15 +9,15 @@
 // except according to those terms.
 
 type item_ty_yes0 = {
-    x: &uint
+    x: &uint //~ ERROR anonymous region types are not permitted here
 };
 
 type item_ty_yes1 = {
-    x: &self/uint
+    x: &'self uint
 };
 
 type item_ty_yes2 = {
-    x: &foo/uint //~ ERROR named regions other than `self` are not allowed as part of a type declaration
+    x: &'foo uint //~ ERROR named regions other than `self` are not allowed as part of a type declaration
 };
 
 fn main() {}

--- a/src/test/compile-fail/regions-in-type-items.rs
+++ b/src/test/compile-fail/regions-in-type-items.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 type item_ty_yes0 = {
-    x: &uint //~ ERROR anonymous region types are not permitted here
+    x: &uint //~ ERROR Illegal anonymous lifetime: anonymous lifetimes are not permitted here
 };
 
 type item_ty_yes1 = {
@@ -17,7 +17,7 @@ type item_ty_yes1 = {
 };
 
 type item_ty_yes2 = {
-    x: &'foo uint //~ ERROR named regions other than `self` are not allowed as part of a type declaration
+    x: &'foo uint //~ ERROR Illegal lifetime &foo: only 'self is allowed allowed as part of a type declaration
 };
 
 fn main() {}

--- a/src/test/compile-fail/regions-infer-at-fn-not-param.rs
+++ b/src/test/compile-fail/regions-infer-at-fn-not-param.rs
@@ -8,25 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct param1 {
-    g: &fn()
+struct parameterized1 {
+    g: &'self fn()
 }
 
-struct param2 {
-    g: fn()
-}
-
-struct not_param1 {
+struct not_parameterized1 {
     g: @fn()
 }
 
-struct not_param2 {
+struct not_parameterized2 {
     g: @fn()
 }
 
-fn take1(p: param1) -> param1 { p } //~ ERROR mismatched types
-fn take2(p: param2) -> param2 { p } //~ ERROR mismatched types
-fn take3(p: not_param1) -> not_param1 { p }
-fn take4(p: not_param2) -> not_param2 { p }
+fn take1(p: parameterized1) -> parameterized1 { p } //~ ERROR mismatched types
+fn take3(p: not_parameterized1) -> not_parameterized1 { p }
+fn take4(p: not_parameterized2) -> not_parameterized2 { p }
 
 fn main() {}

--- a/src/test/compile-fail/regions-infer-contravariance-due-to-immutability.rs
+++ b/src/test/compile-fail/regions-infer-contravariance-due-to-immutability.rs
@@ -9,18 +9,18 @@
 // except according to those terms.
 
 struct contravariant {
-    f: &int
+    f: &'self int
 }
 
-fn to_same_lifetime(bi: contravariant/&r) {
-    let bj: contravariant/&r = bi;
+fn to_same_lifetime(bi: contravariant<'r>) {
+    let bj: contravariant<'r> = bi;
 }
 
-fn to_shorter_lifetime(bi: contravariant/&r) {
-    let bj: contravariant/&blk = bi;
+fn to_shorter_lifetime(bi: contravariant<'r>) {
+    let bj: contravariant<'blk> = bi;
 }
 
-fn to_longer_lifetime(bi: contravariant/&r) -> contravariant/&static {
+fn to_longer_lifetime(bi: contravariant<'r>) -> contravariant/&static {
     bi //~ ERROR mismatched types
 }
 

--- a/src/test/compile-fail/regions-infer-invariance-due-to-arg-and-ret.rs
+++ b/src/test/compile-fail/regions-infer-invariance-due-to-arg-and-ret.rs
@@ -13,18 +13,18 @@
 // You cannot convert between regions.
 
 struct invariant {
-    f: fn(x: &self/int) -> &self/int
+    f: &'self fn(x: &'self int) -> &'self int
 }
 
-fn to_same_lifetime(bi: invariant/&r) {
-    let bj: invariant/&r = bi;
+fn to_same_lifetime(bi: invariant<'r>) {
+    let bj: invariant<'r> = bi;
 }
 
-fn to_shorter_lifetime(bi: invariant/&r) {
-    let bj: invariant/&blk = bi; //~ ERROR mismatched types
+fn to_shorter_lifetime(bi: invariant<'r>) {
+    let bj: invariant<'blk> = bi; //~ ERROR mismatched types
 }
 
-fn to_longer_lifetime(bi: invariant/&r) -> invariant/&static {
+fn to_longer_lifetime(bi: invariant<'r>) -> invariant/&static {
     bi //~ ERROR mismatched types
 }
 

--- a/src/test/compile-fail/regions-infer-invariance-due-to-mutability-1.rs
+++ b/src/test/compile-fail/regions-infer-invariance-due-to-mutability-1.rs
@@ -9,18 +9,18 @@
 // except according to those terms.
 
 struct invariant {
-    f: @mut &int
+    f: @mut &'self int
 }
 
-fn to_same_lifetime(bi: invariant/&r) {
-    let bj: invariant/&r = bi;
+fn to_same_lifetime(bi: invariant<'r>) {
+    let bj: invariant<'r> = bi;
 }
 
-fn to_shorter_lifetime(bi: invariant/&r) {
-    let bj: invariant/&blk = bi; //~ ERROR mismatched types
+fn to_shorter_lifetime(bi: invariant<'r>) {
+    let bj: invariant<'blk> = bi; //~ ERROR mismatched types
 }
 
-fn to_longer_lifetime(bi: invariant/&r) -> invariant/&static {
+fn to_longer_lifetime(bi: invariant<'r>) -> invariant<'static> {
     bi //~ ERROR mismatched types
 }
 

--- a/src/test/compile-fail/regions-infer-invariance-due-to-mutability-2.rs
+++ b/src/test/compile-fail/regions-infer-invariance-due-to-mutability-2.rs
@@ -8,19 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct invariant {
-    f: @mut [&int]
+struct invariant<'self> {
+    f: @mut [&'self int]
 }
 
-fn to_same_lifetime(bi: invariant/&r) {
-    let bj: invariant/&r = bi;
+fn to_same_lifetime(bi: invariant<'r>) {
+    let bj: invariant<'r> = bi;
 }
 
-fn to_shorter_lifetime(bi: invariant/&r) {
-    let bj: invariant/&blk = bi; //~ ERROR mismatched types
+fn to_shorter_lifetime(bi: invariant<'r>) {
+    let bj: invariant<'blk> = bi; //~ ERROR mismatched types
 }
 
-fn to_longer_lifetime(bi: invariant/&r) -> invariant/&static {
+fn to_longer_lifetime(bi: invariant<'r>) -> invariant<'static> {
     bi //~ ERROR mismatched types
 }
 

--- a/src/test/compile-fail/regions-infer-invariance-due-to-mutability.rs
+++ b/src/test/compile-fail/regions-infer-invariance-due-to-mutability.rs
@@ -9,18 +9,18 @@
 // except according to those terms.
 
 struct invariant {
-    f: &int
+    f: @mut &'self int
 }
 
-fn to_same_lifetime(bi: invariant/&r) {
-    let bj: invariant/&r = bi;
+fn to_same_lifetime(bi: invariant<'r>) {
+    let bj: invariant<'r> = bi;
 }
 
-fn to_shorter_lifetime(bi: invariant/&r) {
-    let bj: invariant/&blk = bi;
-}   
+fn to_shorter_lifetime(bi: invariant<'r>) {
+    let bj: invariant<'blk> = bi; //~ ERROR mismatched types
+}
 
-fn to_longer_lifetime(bi: invariant/&r) -> invariant/&static {
+fn to_longer_lifetime(bi: invariant<'r>) -> invariant/&static {
     bi //~ ERROR mismatched types
 }
 

--- a/src/test/compile-fail/regions-infer-not-param.rs
+++ b/src/test/compile-fail/regions-infer-not-param.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct direct {
-    f: &int
+struct direct<'self> {
+    f: &'self int
 }
 
 struct indirect1 {
@@ -21,7 +21,7 @@ struct indirect2 {
 }
 
 struct indirect3 {
-    g: @fn(direct/&self)
+    g: @fn(direct<'self>)
 }
 
 fn take_direct(p: direct) -> direct { p } //~ ERROR mismatched types

--- a/src/test/compile-fail/regions-infer-paramd-indirect.rs
+++ b/src/test/compile-fail/regions-infer-paramd-indirect.rs
@@ -11,17 +11,17 @@
 // Check that we correctly infer that b and c must be region
 // parameterized because they reference a which requires a region.
 
-type a = &int;
-type b = @a;
-type c = {f: @b};
+type a<'self> = &'self int;
+type b<'self> = @a<'self>;
+type c<'self> = {f: @b<'self>};
 
-trait set_f {
-    fn set_f_ok(b: @b/&self);
+trait set_f<'self> {
+    fn set_f_ok(b: @b<'self>);
     fn set_f_bad(b: @b);
 }
 
-impl set_f for c {
-    fn set_f_ok(b: @b/&self) {
+impl<'self> set_f<'self> for c<'self> {
+    fn set_f_ok(b: @b<'self>) {
         self.f = b;
     }
 

--- a/src/test/compile-fail/regions-infer-paramd-method.rs
+++ b/src/test/compile-fail/regions-infer-paramd-method.rs
@@ -11,22 +11,22 @@
 // Here: foo is parameterized because it contains a method that
 // refers to self.
 
-trait foo {
-    fn self_int() -> &self/int;
+trait foo<'self> {
+    fn self_int() -> &'self int;
 
     fn any_int() -> &int;
 }
 
-struct with_foo {
-    f: foo
+struct with_foo<'self> {
+    f: foo<'self>
 }
 
 trait set_foo_foo {
-    fn set_foo(&mut self, f: foo);
+    fn set_foo(&mut self, f: @foo);
 }
 
-impl set_foo_foo for with_foo {
-    fn set_foo(&mut self, f: foo) {
+impl<'self> set_foo_foo for with_foo<'self> {
+    fn set_foo(&mut self, f: @foo) {
         self.f = f; //~ ERROR mismatched types: expected `@foo/&self` but found `@foo/&`
     }
 }

--- a/src/test/compile-fail/regions-steal-closure.rs
+++ b/src/test/compile-fail/regions-steal-closure.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct closure_box {
-    cl: &fn()
+struct closure_box<'self> {
+    cl: &'self fn()
 }
 
-fn box_it(x: &r/fn()) -> closure_box/&r {
+fn box_it(x: &'r fn()) -> closure_box<'r> {
     closure_box {cl: x}
 }
 

--- a/src/test/compile-fail/regions-trait-1.rs
+++ b/src/test/compile-fail/regions-trait-1.rs
@@ -15,13 +15,13 @@ trait get_ctxt {
     fn get_ctxt() -> &ctxt;
 }
 
-struct has_ctxt { c: &ctxt }
+struct has_ctxt { c: &'self ctxt }
 
-impl get_ctxt for has_ctxt {
+impl get_ctxt for has_ctxt<'self> {
 
     // Here an error occurs because we used `&self` but
     // the definition used `&`:
-    fn get_ctxt() -> &self/ctxt { //~ ERROR method `get_ctxt` has an incompatible type
+    fn get_ctxt() -> &'self ctxt { //~ ERROR method `get_ctxt` has an incompatible type
         self.c
     }
 

--- a/src/test/compile-fail/regions-trait-2.rs
+++ b/src/test/compile-fail/regions-trait-2.rs
@@ -10,13 +10,13 @@
 
 struct ctxt { v: uint }
 
-trait get_ctxt {
-    fn get_ctxt() -> &self/ctxt;
+trait get_ctxt<'self> {
+    fn get_ctxt() -> &'self ctxt;
 }
 
-struct has_ctxt { c: &ctxt }
+struct has_ctxt<'self> { c: &'self ctxt }
 
-impl get_ctxt for has_ctxt {
+impl<'self> get_ctxt<'self> for has_ctxt<'self> {
     fn get_ctxt() -> &self/ctxt { self.c }
 }
 

--- a/src/test/run-pass/assignability-trait.rs
+++ b/src/test/run-pass/assignability-trait.rs
@@ -16,7 +16,7 @@ trait iterable<A> {
     fn iterate(blk: fn(x: &A) -> bool);
 }
 
-impl<A> iterable<A> for &[A] {
+impl<A> iterable<A> for &self/[A] {
     fn iterate(f: fn(x: &A) -> bool) {
         for vec::each(self) |e| {
             if !f(e) { break; }

--- a/src/test/run-pass/auto-ref-slice-plus-ref.rs
+++ b/src/test/run-pass/auto-ref-slice-plus-ref.rs
@@ -16,12 +16,12 @@ trait MyIter {
     pure fn test_const(&const self);
 }
 
-impl MyIter for &[int] {
+impl MyIter for &'self [int] {
     pure fn test_imm(&self) { assert self[0] == 1 }
     pure fn test_const(&const self) { assert self[0] == 1 }
 }
 
-impl MyIter for &str {
+impl MyIter for &'self str {
     pure fn test_imm(&self) { assert *self == "test" }
     pure fn test_const(&const self) { assert *self == "test" }
 }

--- a/src/test/run-pass/auto-ref.rs
+++ b/src/test/run-pass/auto-ref.rs
@@ -16,7 +16,7 @@ trait Stuff {
     fn printme();
 }
 
-impl Stuff for &Foo {
+impl Stuff for &self/Foo {
     fn printme() {
         io::println(fmt!("%d", self.x));
     }

--- a/src/test/run-pass/borrow-by-val-method-receiver.rs
+++ b/src/test/run-pass/borrow-by-val-method-receiver.rs
@@ -12,7 +12,7 @@ trait Foo {
     fn foo(self);
 }
 
-impl Foo for &[int] {
+impl Foo for &'self [int] {
     fn foo(self) {}
 }
 

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -49,8 +49,8 @@ pub impl<T> cat<T> {
     }
 }
 
-impl<T> BaseIter<(int, &T)> for cat<T> {
-    pure fn each(&self, f: fn(&(int, &self/T)) -> bool) {
+impl<T> BaseIter<(int, &'self T)> for cat<T> {
+    pure fn each(&self, f: fn(&(int, &'self T)) -> bool) {
         let mut n = int::abs(self.meows);
         while n > 0 {
             if !f(&(n, &self.name)) { break; }
@@ -86,7 +86,7 @@ impl<T> Map<int, T> for cat<T> {
         true
     }
 
-    pure fn find(&self, k: &int) -> Option<&self/T> {
+    pure fn find(&self, k: &int) -> Option<&'self T> {
         if *k <= self.meows {
             Some(&self.name)
         } else {
@@ -104,7 +104,7 @@ impl<T> Map<int, T> for cat<T> {
 }
 
 pub impl<T> cat<T> {
-    pure fn get(&self, k: &int) -> &self/T {
+    pure fn get(&self, k: &int) -> &'self T {
         match self.find(k) {
           Some(v) => { v }
           None    => { fail!(~"epic fail"); }

--- a/src/test/run-pass/coerce-reborrow-mut-vec-rcvr.rs
+++ b/src/test/run-pass/coerce-reborrow-mut-vec-rcvr.rs
@@ -2,7 +2,7 @@ trait Reverser {
     fn reverse(&self);
 }
 
-impl Reverser for &mut [uint] {
+impl Reverser for &'self mut [uint] {
     fn reverse(&self) {
         vec::reverse(*self);
     }

--- a/src/test/run-pass/const-enum-vec-index.rs
+++ b/src/test/run-pass/const-enum-vec-index.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 enum E { V1(int), V0 }
-const C: &[E] = &[V0, V1(0xDEADBEE)];
+const C: &'static [E] = &[V0, V1(0xDEADBEE)];
 const C0: E = C[0];
 const C1: E = C[1];
 

--- a/src/test/run-pass/const-fields-and-indexing.rs
+++ b/src/test/run-pass/const-fields-and-indexing.rs
@@ -10,7 +10,7 @@
 
 const x : [int * 4] = [1,2,3,4];
 const p : int = x[2];
-const y : &[int] = &[1,2,3,4];
+const y : &'static [int] = &[1,2,3,4];
 const q : int = y[2];
 
 struct S {a: int, b: int}

--- a/src/test/run-pass/const-fn-val.rs
+++ b/src/test/run-pass/const-fn-val.rs
@@ -12,9 +12,9 @@ fn foo() -> int {
     return 0xca7f000d;
 }
 
-struct Bar { f: &fn() -> int }
+struct Bar { f: &'self fn() -> int }
 
-const b : Bar = Bar { f: foo };
+const b : Bar/&static = Bar { f: foo };
 
 pub fn main() {
     assert (b.f)() == 0xca7f000d;

--- a/src/test/run-pass/const-region-ptrs.rs
+++ b/src/test/run-pass/const-region-ptrs.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 
-struct Pair { a: int, b: &int }
+struct Pair { a: int, b: &'self int }
 
-const x: &int = &10;
+const x: &'static int = &10;
 
-const y: &Pair = &Pair {a: 15, b: x};
+const y: &'static Pair<'static> = &Pair {a: 15, b: x};
 
 pub fn main() {
     io::println(fmt!("x = %?", *x));

--- a/src/test/run-pass/const-struct.rs
+++ b/src/test/run-pass/const-struct.rs
@@ -22,7 +22,7 @@ impl cmp::Eq for foo {
 
 const x : foo = foo { a:1, b:2, c: 3 };
 const y : foo = foo { b:2, c:3, a: 1 };
-const z : &foo = &foo { a: 10, b: 22, c: 12 };
+const z : &'static foo = &foo { a: 10, b: 22, c: 12 };
 
 pub fn main() {
     assert x.b == 2;

--- a/src/test/run-pass/const-vec-of-fns.rs
+++ b/src/test/run-pass/const-vec-of-fns.rs
@@ -16,10 +16,9 @@
  */
 
 fn f() { }
-const bare_fns: &[extern fn()] = &[f, f];
-// NOTE Why does this not type without the struct?
-struct S(&fn());
-const closures: &[S] = &[S(f), S(f)];
+const bare_fns: &'static [extern fn()] = &[f, f];
+struct S<'self>(&'self fn());
+const closures: &'static [S<'static>] = &[S(f), S(f)];
 
 pub fn main() {
     for bare_fns.each |&bare_fn| { bare_fn() }

--- a/src/test/run-pass/const-vecs-and-slices.rs
+++ b/src/test/run-pass/const-vecs-and-slices.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 const x : [int * 4] = [1,2,3,4];
-const y : &[int] = &[1,2,3,4];
+const y : &'static [int] = &[1,2,3,4];
 
 pub fn main() {
     io::println(fmt!("%?", x[1]));

--- a/src/test/run-pass/infer-with-expected.rs
+++ b/src/test/run-pass/infer-with-expected.rs
@@ -16,7 +16,7 @@
 fn eat_tup(_r: ~@(int, @fn(Pair) -> int)) {}
 fn eat_rec(_r: @~Rec) {}
 
-struct Rec { a: int, b: fn(Pair) -> int }
+struct Rec { a: int, b: &'self fn(Pair) -> int }
 struct Pair { x: int, y: int }
 
 pub fn main() {

--- a/src/test/run-pass/issue-2502.rs
+++ b/src/test/run-pass/issue-2502.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 struct font {
-    fontbuf: &self/~[u8],
+    fontbuf: &'self ~[u8],
 }
 
-pub impl font {
+pub impl font/&self {
     fn buf() -> &self/~[u8] {
         self.fontbuf
     }

--- a/src/test/run-pass/issue-2735-2.rs
+++ b/src/test/run-pass/issue-2735-2.rs
@@ -10,16 +10,16 @@
 
 // This test should behave exactly like issue-2735-3
 struct defer {
-    b: &mut bool,
+    b: &'self mut bool,
 }
 
-impl Drop for defer {
+impl Drop for defer/&self {
     fn finalize(&self) {
         *(self.b) = true;
     }
 }
 
-fn defer(b: &r/mut bool) -> defer/&r {
+fn defer(b: &'r mut bool) -> defer/&r {
     defer {
         b: b
     }

--- a/src/test/run-pass/issue-2735-3.rs
+++ b/src/test/run-pass/issue-2735-3.rs
@@ -10,16 +10,16 @@
 
 // This test should behave exactly like issue-2735-2
 struct defer {
-    b: &mut bool,
+    b: &'self mut bool,
 }
 
-impl Drop for defer {
+impl Drop for defer/&self {
     fn finalize(&self) {
         *(self.b) = true;
     }
 }
 
-fn defer(b: &r/mut bool) -> defer/&r {
+fn defer(b: &'r mut bool) -> defer/&r {
     defer {
         b: b
     }

--- a/src/test/run-pass/issue-2748-a.rs
+++ b/src/test/run-pass/issue-2748-a.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 struct CMap {
-    buf: &[u8],
+    buf: &'self [u8],
 }
 
-fn CMap(buf: &r/[u8]) -> CMap/&r {
+fn CMap(buf: &'r [u8]) -> CMap/&r {
     CMap {
         buf: buf
     }

--- a/src/test/run-pass/issue-3447.rs
+++ b/src/test/run-pass/issue-3447.rs
@@ -9,12 +9,12 @@
 // except according to those terms.
 
 struct list<T> {
-    element: &self/T,
-    next: Option<@mut list<T>>
+    element: &'self T,
+    next: Option<@mut list<'self, T>>
 }
 
-pub impl<T> list<T>{
-    fn addEnd(&mut self, element: &self/T) {
+pub impl<'self, T> list<'self, T>{
+    fn addEnd(&mut self, element: &'self T) {
         let newList = list {
             element: element,
             next: option::None

--- a/src/test/run-pass/issue-5243.rs
+++ b/src/test/run-pass/issue-5243.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Check that merely have lifetime parameters is not
+// Check that merely having lifetime parameters is not
 // enough for trans to consider this as non-monomorphic,
 // which led to various assertions and failures in turn.
 
@@ -16,7 +16,7 @@ struct S<'self> {
     v: &'self int
 }
 
-fn f<'lt>(_s: &S<'lt>) {}
+fn f<'lt>(_s: &'lt S<'lt>) {}
 
 fn main() {
     f(& S { v: &42 });

--- a/src/test/run-pass/rcvr-borrowed-to-region.rs
+++ b/src/test/run-pass/rcvr-borrowed-to-region.rs
@@ -13,7 +13,7 @@ trait get {
 }
 
 // Note: impl on a slice
-impl get for &int {
+impl get for &'self int {
     fn get() -> int {
         return *self;
     }

--- a/src/test/run-pass/rcvr-borrowed-to-slice.rs
+++ b/src/test/run-pass/rcvr-borrowed-to-slice.rs
@@ -13,7 +13,7 @@ trait sum {
 }
 
 // Note: impl on a slice
-impl sum for &[int] {
+impl sum for &'self [int] {
     fn sum() -> int {
         let mut sum = 0;
         for vec::each(self) |e| { sum += *e; }

--- a/src/test/run-pass/regions-copy-closure.rs
+++ b/src/test/run-pass/regions-copy-closure.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 struct closure_box {
-    cl: &fn(),
+    cl: &'self fn(),
 }
 
-fn box_it(+x: &r/fn()) -> closure_box/&r {
+fn box_it(+x: &'r fn()) -> closure_box/&r {
     closure_box {cl: x}
 }
 

--- a/src/test/run-pass/regions-creating-enums2.rs
+++ b/src/test/run-pass/regions-creating-enums2.rs
@@ -10,10 +10,10 @@
 
 enum ast {
     num(uint),
-    add(&ast, &ast)
+    add(&'self ast<'self>, &'self ast<'self>)
 }
 
-fn mk_add_ok(x: &r/ast, y: &r/ast) -> ast/&r {
+fn mk_add_ok(x: &'r ast<'r>, y: &'r ast<'r>) -> ast<'r> {
     add(x, y)
 }
 

--- a/src/test/run-pass/regions-creating-enums5.rs
+++ b/src/test/run-pass/regions-creating-enums5.rs
@@ -10,10 +10,10 @@
 
 enum ast {
     num(uint),
-    add(&ast, &ast)
+    add(&'self ast<'self>, &'self ast<'self>)
 }
 
-fn mk_add_ok(x: &a/ast, y: &a/ast, z: &ast) -> ast/&a {
+fn mk_add_ok(x: &'a ast<'a>, y: &'a ast<'a>, z: &ast) -> ast<'a> {
     add(x, y)
 }
 

--- a/src/test/run-pass/regions-infer-contravariance-due-to-ret.rs
+++ b/src/test/run-pass/regions-infer-contravariance-due-to-ret.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct boxed_int {
-    f: &int,
+    f: &'self int,
 }
 
 fn max(bi: &r/boxed_int, f: &r/int) -> int {

--- a/src/test/run-pass/regions-infer-contravariance.rs
+++ b/src/test/run-pass/regions-infer-contravariance.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 struct boxed_int {
-    f: &int,
+    f: &'self int,
 }
 
-fn get(bi: &r/boxed_int) -> &r/int {
+fn get(bi: &'r boxed_int<'r>) -> &'r int {
     bi.f
 }
 

--- a/src/test/run-pass/regions-mock-trans-impls.rs
+++ b/src/test/run-pass/regions-mock-trans-impls.rs
@@ -17,19 +17,19 @@ use core::cast;
 use std::arena::Arena;
 
 struct Bcx {
-    fcx: &Fcx
+    fcx: &'self Fcx<'self>
 }
 
 struct Fcx {
-    arena: &Arena,
-    ccx: &Ccx
+    arena: &'self Arena,
+    ccx: &'self Ccx
 }
 
 struct Ccx {
     x: int
 }
 
-fn h(bcx : &r/Bcx) -> &r/Bcx {
+fn h(bcx : &'r Bcx<'r>) -> &'r Bcx<'r> {
     return bcx.fcx.arena.alloc(|| Bcx { fcx: bcx.fcx });
 }
 

--- a/src/test/run-pass/regions-mock-trans.rs
+++ b/src/test/run-pass/regions-mock-trans.rs
@@ -11,26 +11,26 @@
 enum arena = ();
 
 struct Bcx {
-    fcx: &Fcx
+    fcx: &'self Fcx<'self>
 }
 
 struct Fcx {
-    arena: &arena,
-    ccx: &Ccx
+    arena: &'self arena,
+    ccx: &'self Ccx
 }
 
 struct Ccx {
     x: int
 }
 
-fn alloc(_bcx : &arena) -> &Bcx {   
+fn alloc(_bcx : &'a arena) -> &'a Bcx<'a> {
     unsafe {
         return cast::reinterpret_cast(
             &libc::malloc(sys::size_of::<Bcx/&blk>() as libc::size_t));
     }
 }
 
-fn h(bcx : &Bcx) -> &Bcx {
+fn h(bcx : &'a Bcx<'a>) -> &'a Bcx<'a> {
     return alloc(bcx.fcx.arena);
 }
 

--- a/src/test/run-pass/regions-nullary-variant.rs
+++ b/src/test/run-pass/regions-nullary-variant.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 enum roption {
-    a, b(&uint)
+    a, b(&'self uint)
 }
 
-fn mk(cond: bool, ptr: &r/uint) -> roption/&r {
+fn mk(cond: bool, ptr: &'r uint) -> roption<'r> {
     if cond {a} else {b(ptr)}
 }
 

--- a/src/test/run-pass/regions-self-in-enums.rs
+++ b/src/test/run-pass/regions-self-in-enums.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 enum int_wrapper {
-    int_wrapper_ctor(&int)
+    int_wrapper_ctor(&'self int)
 }
 
 pub fn main() {

--- a/src/test/run-pass/regions-static-closure.rs
+++ b/src/test/run-pass/regions-static-closure.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 struct closure_box {
-    cl: &fn(),
+    cl: &'self fn(),
 }
 
-fn box_it(+x: &r/fn()) -> closure_box/&r {
+fn box_it(+x: &'r fn()) -> closure_box<'r> {
     closure_box {cl: x}
 }
 

--- a/src/test/run-pass/regions-trait.rs
+++ b/src/test/run-pass/regions-trait.rs
@@ -14,9 +14,9 @@ trait get_ctxt {
     fn get_ctxt() -> &self/Ctxt;
 }
 
-struct HasCtxt { c: &Ctxt }
+struct HasCtxt { c: &'self Ctxt }
 
-impl get_ctxt for HasCtxt {
+impl get_ctxt<'self> for HasCtxt<'self> {
     fn get_ctxt() -> &self/Ctxt {
         self.c
     }

--- a/src/test/run-pass/struct-field-assignability.rs
+++ b/src/test/run-pass/struct-field-assignability.rs
@@ -1,5 +1,5 @@
 struct Foo {
-    x: &int
+    x: &'self int
 }
 
 pub fn main() {


### PR DESCRIPTION
Work towards #4846.
- Institute new region defaults where all omitted regions get a fresh lifetime.
- Require explicit region names except in functions.
- Fix a bug in region parameterization inference.  I've been putting this off because it will not be important when we remove RP inference in favor of explicit declarations, but then it was blocking this patch.

r? @pcwalton
