### PR TITLE
Faster each permutation

### DIFF
--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -1296,6 +1296,9 @@ pub fn reverse<T>(v: &[mut T]) {
  *
  * Reverse the elements in the vector between `start` and `end - 1`.
  *
+ * If either start or end do not represent valid positions in the vector, the
+ * vector is returned unchanged.
+ *
  * # Arguments
  *
  * * `v` - The mutable vector to be modified
@@ -1315,13 +1318,10 @@ pub fn reverse<T>(v: &[mut T]) {
  * ~~~
  *
  * `v` now contains `[1,4,3,2,5]`.
- *
- * # Safety note
- *
- * Behavior is undefined if `start` or `end` do not represent valid
- * positions in `v`.
  */
 pub fn reverse_part<T>(v : &[mut T], start : uint, end : uint) {
+    let sz = v.len();
+    if start >= sz || end > sz { return; }
     let mut i = start;
     let mut j = end - 1;
     while i < j {


### PR DESCRIPTION
This is a replacement each_permutation that is somewhat faster than the previous version (and 2x faster, according to my testing, than the versions on the mailing list in January). The algorithm is based on "Generation in lexicographic order" section in Wikipdedia (http://en.wikipedia.org/wiki/Permutation#Generation_in_lexicographic_order).

I also exposed a function to reverse a portion of a vector which is used by the algorithm and seems like it might be something someone would want.

Finally, there's a each_permutation_ref that eliminates the Copy type requirement.
