### PR TITLE
Add a 'start' lang item and use it instead of rust_start

### DIFF
--- a/src/libcore/rt.rs
+++ b/src/libcore/rt.rs
@@ -11,7 +11,7 @@
 //! Runtime calls emitted by the compiler.
 
 use cast::transmute;
-use libc::{c_char, c_uchar, c_void, size_t, uintptr_t};
+use libc::{c_char, c_uchar, c_void, size_t, uintptr_t, c_int};
 use managed::raw::BoxRepr;
 use str;
 use sys;
@@ -119,6 +119,21 @@ pub unsafe fn check_not_borrowed(a: *u8) {
 #[lang="strdup_uniq"]
 pub unsafe fn strdup_uniq(ptr: *c_uchar, len: uint) -> ~str {
     str::raw::from_buf_len(ptr, len)
+}
+
+#[lang="start"]
+pub fn start(main: *u8, argc: int, argv: *c_char,
+             crate_map: *u8) -> int {
+
+    extern {
+        fn rust_start(main: *c_void, argc: c_int, argv: *c_char,
+                      crate_map: *c_void) -> c_int;
+    }
+
+    unsafe {
+        return rust_start(main as *c_void, argc as c_int, argv,
+                          crate_map as *c_void) as int;
+    }
 }
 
 // Local Variables:

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -838,9 +838,6 @@ pub fn link_binary(sess: Session,
         }
     }
 
-    // Always want the runtime linked in
-    cc_args.push(~"-lrustrt");
-
     // On linux librt and libdl are an indirect dependencies via rustrt,
     // and binutils 2.22+ won't add them automatically
     if sess.targ_cfg.os == session::os_linux {
@@ -879,6 +876,9 @@ pub fn link_binary(sess: Session,
     if sess.targ_cfg.os != session::os_android {
     cc_args.push(~"-lmorestack");
     }
+
+    // Always want the runtime linked in
+    cc_args.push(~"-lrustrt");
 
     // FIXME (#2397): At some point we want to rpath our guesses as to where
     // extern libraries might live, based on the addl_lib_search_paths

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -75,16 +75,18 @@ pub enum LangItem {
     ReturnToMutFnLangItem,      // 31
     CheckNotBorrowedFnLangItem, // 32
     StrDupUniqFnLangItem,       // 33
+
+    StartFnLangItem,            // 34
 }
 
 pub struct LanguageItems {
-    items: [ Option<def_id> * 34 ]
+    items: [ Option<def_id> * 35 ]
 }
 
 pub impl LanguageItems {
     static pub fn new(&self) -> LanguageItems {
         LanguageItems {
-            items: [ None, ..34 ]
+            items: [ None, ..35 ]
         }
     }
 
@@ -135,6 +137,8 @@ pub impl LanguageItems {
             31 => "return_to_mut",
             32 => "check_not_borrowed",
             33 => "strdup_uniq",
+
+            34 => "start",
 
             _ => "???"
         }
@@ -248,6 +252,9 @@ pub impl LanguageItems {
     pub fn strdup_uniq_fn(&const self) -> def_id {
         self.items[StrDupUniqFnLangItem as uint].get()
     }
+    pub fn start_fn(&const self) -> def_id {
+        self.items[StartFnLangItem as uint].get()
+    }
 }
 
 fn LanguageItemCollector(crate: @crate,
@@ -296,6 +303,7 @@ fn LanguageItemCollector(crate: @crate,
     item_refs.insert(@~"check_not_borrowed",
                      CheckNotBorrowedFnLangItem as uint);
     item_refs.insert(@~"strdup_uniq", StrDupUniqFnLangItem as uint);
+    item_refs.insert(@~"start", StartFnLangItem as uint);
 
     LanguageItemCollector {
         crate: crate,


### PR DESCRIPTION
r?
#3406

Pretty straightforward. I'm using opaque pointers instead trying to get trans and core to agree on the types of the main function and crate map. One oddity is that this required changing the order of the `-lrustrt` argument to the linker in order to resolve `upcall_new_stack`. Linkers are mysterious.
