### PR TITLE
Turn old `drop` blocks into `Drop` traits

### DIFF
--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -474,7 +474,10 @@ impl<R:Reader,C> Reader for Wrapper<R, C> {
 
 pub struct FILERes {
     f: *libc::FILE,
-    drop {
+}
+
+impl Drop for FILERes {
+    fn finalize(&self) {
         unsafe {
             libc::fclose(self.f);
         }
@@ -683,7 +686,10 @@ impl Writer for fd_t {
 
 pub struct FdRes {
     fd: fd_t,
-    drop {
+}
+
+impl Drop for FdRes {
+    fn finalize(&self) {
         unsafe {
             libc::close(self.fd);
         }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -450,7 +450,10 @@ fn test_unwrap_str() {
 fn test_unwrap_resource() {
     struct R {
        i: @mut int,
-       drop { *(self.i) += 1; }
+    }
+
+    impl ::ops::Drop for R {
+       fn finalize(&self) { *(self.i) += 1; }
     }
 
     fn R(i: @mut int) -> R {

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -346,7 +346,10 @@ pub unsafe fn get_buffer<T>(p: *PacketHeader) -> ~Buffer<T> {
 struct BufferResource<T> {
     buffer: ~Buffer<T>,
 
-    drop {
+}
+
+impl<T> ::ops::Drop for BufferResource<T> {
+    fn finalize(&self) {
         unsafe {
             let b = move_it!(self.buffer);
             //let p = ptr::addr_of(*b);

--- a/src/libcore/private.rs
+++ b/src/libcore/private.rs
@@ -126,7 +126,10 @@ struct ArcData<T> {
 
 struct ArcDestruct<T> {
     mut data: *libc::c_void,
-    drop {
+}
+
+impl<T> Drop for ArcDestruct<T>{
+    fn finalize(&self) {
         unsafe {
             if self.data.is_null() {
                 return; // Happens when destructing an unwrapper's handle.
@@ -178,7 +181,10 @@ pub unsafe fn unwrap_shared_mutable_state<T:Owned>(rc: SharedMutableState<T>)
     struct DeathThroes<T> {
         mut ptr:      Option<~ArcData<T>>,
         mut response: Option<comm::ChanOne<bool>>,
-        drop {
+    }
+
+    impl<T> Drop for DeathThroes<T>{
+        fn finalize(&self) {
             unsafe {
                 let response = option::swap_unwrap(&mut self.response);
                 // In case we get killed early, we need to tell the person who
@@ -311,7 +317,10 @@ type rust_little_lock = *libc::c_void;
 
 struct LittleLock {
     l: rust_little_lock,
-    drop {
+}
+
+impl Drop for LittleLock {
+    fn finalize(&self) {
         unsafe {
             rustrt::rust_destroy_little_lock(self.l);
         }

--- a/src/libcore/rand.rs
+++ b/src/libcore/rand.rs
@@ -365,7 +365,10 @@ impl Rng {
 
 struct RandRes {
     rng: *rust_rng,
-    drop {
+}
+
+impl Drop for RandRes {
+    fn finalize(&self) {
         unsafe {
             rustrt::rand_free(self.rng);
         }

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -248,7 +248,10 @@ pub fn start_program(prog: &str, args: &[~str]) -> Program {
     }
     struct ProgRes {
         r: ProgRepr,
-        drop {
+    }
+
+    impl Drop for ProgRes {
+        fn finalize(&self) {
             unsafe {
                 // FIXME #4943: This is bad.
                 destroy_repr(cast::transmute(&self.r));

--- a/src/libcore/task/spawn.rs
+++ b/src/libcore/task/spawn.rs
@@ -308,8 +308,11 @@ struct TCB {
     mut ancestors: AncestorList,
     is_main:       bool,
     notifier:      Option<AutoNotify>,
+}
+
+impl Drop for TCB {
     // Runs on task exit.
-    drop {
+    fn finalize(&self) {
         unsafe {
             // If we are failing, the whole taskgroup needs to die.
             if rt::rust_task_is_unwinding(self.me) {
@@ -353,7 +356,10 @@ fn TCB(me: *rust_task, tasks: TaskGroupArc, ancestors: AncestorList,
 struct AutoNotify {
     notify_chan: Chan<TaskResult>,
     mut failed:  bool,
-    drop {
+}
+
+impl Drop for AutoNotify {
+    fn finalize(&self) {
         let result = if self.failed { Failure } else { Success };
         self.notify_chan.send(result);
     }

--- a/src/libcore/util.rs
+++ b/src/libcore/util.rs
@@ -66,7 +66,10 @@ pub fn replace<T>(dest: &mut T, src: T) -> T {
 /// A non-copyable dummy type.
 pub struct NonCopyable {
     i: (),
-    drop { }
+}
+
+impl Drop for NonCopyable {
+    fn finalize(&self) { }
 }
 
 pub fn NonCopyable() -> NonCopyable { NonCopyable { i: () } }

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1458,7 +1458,10 @@ pub fn struct_tys(struct_ty: TypeRef) -> ~[TypeRef] {
 
 pub struct target_data_res {
     TD: TargetDataRef,
-    drop {
+}
+
+impl Drop for target_data_res {
+    fn finalize(&self) {
         unsafe {
             llvm::LLVMDisposeTargetData(self.TD);
         }
@@ -1492,7 +1495,10 @@ pub fn mk_target_data(string_rep: ~str) -> TargetData {
 
 pub struct pass_manager_res {
     PM: PassManagerRef,
-    drop {
+}
+
+impl Drop for pass_manager_res {
+    fn finalize(&self) {
         unsafe {
             llvm::LLVMDisposePassManager(self.PM);
         }
@@ -1525,7 +1531,10 @@ pub fn mk_pass_manager() -> PassManager {
 
 pub struct object_file_res {
     ObjectFile: ObjectFileRef,
-    drop {
+}
+
+impl Drop for object_file_res {
+    fn finalize(&self) {
         unsafe {
             llvm::LLVMDisposeObjectFile(self.ObjectFile);
         }
@@ -1559,7 +1568,10 @@ pub fn mk_object_file(llmb: MemoryBufferRef) -> Option<ObjectFile> {
 
 pub struct section_iter_res {
     SI: SectionIteratorRef,
-    drop {
+}
+
+impl Drop for section_iter_res {
+    fn finalize(&self) {
         unsafe {
             llvm::LLVMDisposeSectionIterator(self.SI);
         }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -90,7 +90,10 @@ use syntax::{ast, ast_util, codemap, ast_map};
 
 pub struct icx_popper {
     ccx: @CrateContext,
-    drop {
+}
+
+impl Drop for icx_popper {
+    fn finalize(&self) {
       if self.ccx.sess.count_llvm_insns() {
           self.ccx.stats.llvm_insn_ctxt.pop();
       }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -141,7 +141,10 @@ pub struct Stats {
 
 pub struct BuilderRef_res {
     B: BuilderRef,
-    drop {
+}
+
+impl Drop for BuilderRef_res {
+    fn finalize(&self) {
         unsafe {
             llvm::LLVMDisposeBuilder(self.B);
         }

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -336,7 +336,10 @@ pub fn monitor(+f: fn~(diagnostic::Emitter)) {
 
         struct finally {
             ch: SharedChan<monitor_msg>,
-            drop { self.ch.send(done); }
+        }
+
+        impl Drop for finally {
+            fn finalize(&self) { self.ch.send(done); }
         }
 
         let _finally = finally { ch: ch };

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -32,7 +32,10 @@ pub fn indent<R>(op: fn() -> R) -> R {
 
 pub struct _indenter {
     _i: (),
-    drop { debug!("<<"); }
+}
+
+impl Drop for _indenter {
+    fn finalize(&self) { debug!("<<"); }
 }
 
 pub fn _indenter(_i: ()) -> _indenter {

--- a/src/librustdoc/demo.rs
+++ b/src/librustdoc/demo.rs
@@ -125,7 +125,10 @@ mod blade_runner {
  */
 struct Bored {
   bored: bool,
-  drop { log(error, self.bored); }
+}
+
+impl Drop for Bored {
+  fn finalize(&self) { log(error, self.bored); }
 }
 
 /**

--- a/src/libstd/task_pool.rs
+++ b/src/libstd/task_pool.rs
@@ -28,7 +28,10 @@ pub struct TaskPool<T> {
     channels: ~[Chan<Msg<T>>],
     mut next_index: uint,
 
-    drop {
+}
+
+impl<T> Drop for TaskPool<T> {
+    fn finalize(&self) {
         for self.channels.each |channel| {
             channel.send(Quit);
         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -243,7 +243,11 @@ pub struct Parser {
     /// Used to determine the path to externally loaded source files
     mod_path_stack: @mut ~[~str],
 
-    drop {} /* do not copy the parser; its state is tied to outside state */
+}
+
+impl Drop for Parser {
+    /* do not copy the parser; its state is tied to outside state */
+    fn finalize(&self) {}
 }
 
 pub impl Parser {

--- a/src/test/auxiliary/moves_based_on_type_lib.rs
+++ b/src/test/auxiliary/moves_based_on_type_lib.rs
@@ -12,7 +12,10 @@
 
 pub struct S {
     x: int,
-    drop {
+}
+
+impl Drop for S {
+    fn finalize(&self) {
         io::println("goodbye");
     }
 }

--- a/src/test/compile-fail/use-after-move-self-based-on-type.rs
+++ b/src/test/compile-fail/use-after-move-self-based-on-type.rs
@@ -1,6 +1,9 @@
 struct S {
     x: int,
-    drop {}
+}
+
+impl Drop for S {
+    fn finalize(&self) {}
 }
 
 impl S {

--- a/src/test/run-fail/too-much-recursion-unwinding.rs
+++ b/src/test/run-fail/too-much-recursion-unwinding.rs
@@ -21,7 +21,10 @@ fn recurse() {
 
 struct r {
     recursed: *mut bool,
-    drop {
+}
+
+impl Drop for r {
+    fn finalize(&self) {
         unsafe {
             if !*(self.recursed) {
                 *(self.recursed) = true;

--- a/src/test/run-fail/unwind-resource-fail.rs
+++ b/src/test/run-fail/unwind-resource-fail.rs
@@ -12,7 +12,10 @@
 
 struct r {
     i: int,
-    drop { fail!(~"squirrel") }
+}
+
+impl Drop for r {
+    fn finalize(&self) { fail!(~"squirrel") }
 }
 
 fn r(i: int) -> r { r { i: i } }

--- a/src/test/run-fail/unwind-resource-fail2.rs
+++ b/src/test/run-fail/unwind-resource-fail2.rs
@@ -13,7 +13,10 @@
 
 struct r {
     i: int,
-    drop { fail!(~"wombat") }
+}
+
+impl Drop for r {
+    fn finalize(&self) { fail!(~"wombat") }
 }
 
 fn r(i: int) -> r { r { i: i } }

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -54,7 +54,10 @@ struct AsciiArt
 
     // This struct can be quite large so we'll disable copying: developers need
     // to either pass these structs around via borrowed pointers or move them.
-    drop {}
+}
+
+impl Drop for AsciiArt {
+    fn finalize(&self) {}
 }
 
 // It's common to define a constructor sort of function to create struct instances.


### PR DESCRIPTION
This removes all but 6 uses of `drop {}` from the entire codebase. Removing any of the remaining uses causes various non-trivial bugs; I'll start reporting them once this gets merged.
