### PR TITLE
Syntax highlighting support for GtkSourceView

### DIFF
--- a/src/etc/gedit/readme.txt
+++ b/src/etc/gedit/readme.txt
@@ -1,0 +1,11 @@
+Add syntax highlighting for Mozilla Rust in GtkSourceView (used by GEdit).
+
+
+Instructions for Ubuntu Linux 12.04+
+
+1) Close all instances of GEdit
+
+2) Copy the included "share" folder into "~/.local/"
+
+3) Open a shell in "~/.local/share/" and run "update-mime-database mime"
+

--- a/src/etc/gedit/share/gtksourceview-3.0/language-specs/rust.lang
+++ b/src/etc/gedit/share/gtksourceview-3.0/language-specs/rust.lang
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Syntax highlighting for the under-development Mozilla Rust language -->
+
+<language id="rust" _name="Rust" version="2.0" _section="Sources">
+  <metadata>
+    <property name="mimetypes">text/x-rust</property>
+    <property name="globs">*.rs;*.rc</property>
+    <property name="line-comment-start">//</property>
+    <property name="block-comment-start">/*</property>
+    <property name="block-comment-end">*/</property>
+  </metadata>
+
+  <styles>
+    <style id="comment" _name="Comment" map-to="def:comment"/>
+    <style id="string" _name="String" map-to="def:string"/>
+    <style id="char" _name="Character" map-to="def:character"/>
+    <style id="keyword" _name="Keyword" map-to="def:keyword"/>
+    <style id="type" _name="Data Type" map-to="def:type"/>
+    <style id="constant" _name="Constant" map-to="def:constant"/>
+    <style id="identifier" _name="Identifier" map-to="def:identifier"/>
+    <style id="number" _name="Number" map-to="def:decimal"/>
+    <style id="scope" _name="Scope" map-to="def:preprocessor"/>
+  </styles>
+
+  <definitions>
+
+    <context id="function" style-ref="keyword">
+		<keyword>fn</keyword>
+    </context>
+
+    <context id="type" style-ref="keyword">
+		<keyword>type</keyword>
+    </context>
+
+    <context id="keywords" style-ref="keyword">
+		<keyword>as</keyword>
+		<keyword>assert</keyword>
+		<keyword>break</keyword>
+		<keyword>const</keyword>
+		<keyword>copy</keyword>
+		<keyword>do</keyword>
+		<keyword>drop</keyword>
+		<keyword>else</keyword>
+		<keyword>enum</keyword>
+		<keyword>export</keyword>
+		<keyword>extern</keyword>
+		<keyword>fail</keyword>
+		<keyword>for</keyword>
+		<keyword>if</keyword>
+		<keyword>impl</keyword>
+		<keyword>let</keyword>
+		<keyword>log</keyword>
+		<keyword>loop</keyword>
+		<keyword>match</keyword>
+		<keyword>mod</keyword>
+		<keyword>move</keyword>
+		<keyword>mut</keyword>
+		<keyword>priv</keyword>
+		<keyword>pub</keyword>
+		<keyword>pure</keyword>
+		<keyword>ref</keyword>
+		<keyword>return</keyword>
+		<keyword>static</keyword>
+		<keyword>struct</keyword>
+		<keyword>trait</keyword>
+		<keyword>unsafe</keyword>
+		<keyword>use</keyword>
+		<keyword>while</keyword>
+    </context>
+
+    <context id="types" style-ref="type">
+		<keyword>bool</keyword>
+		<keyword>int</keyword>
+		<keyword>uint</keyword>
+		<keyword>i8</keyword>
+		<keyword>i16</keyword>
+		<keyword>i32</keyword>
+		<keyword>i64</keyword>
+		<keyword>u8</keyword>
+		<keyword>u16</keyword>
+		<keyword>u32</keyword>
+		<keyword>u64</keyword>
+		<keyword>f32</keyword>
+		<keyword>f64</keyword>
+		<keyword>float</keyword>
+		<keyword>char</keyword>
+		<keyword>str</keyword>
+		<keyword>Either</keyword>
+		<keyword>Option</keyword>
+		<keyword>Result</keyword>
+    </context>
+
+    <context id="ctypes" style-ref="type">
+		<keyword>c_float</keyword>
+		<keyword>c_double</keyword>
+		<keyword>c_void</keyword>
+		<keyword>FILE</keyword>
+		<keyword>fpos_t</keyword>
+		<keyword>DIR</keyword>
+		<keyword>dirent</keyword>
+		<keyword>c_char</keyword>
+		<keyword>c_schar</keyword>
+		<keyword>c_uchar</keyword>
+		<keyword>c_short</keyword>
+		<keyword>c_ushort</keyword>
+		<keyword>c_int</keyword>
+		<keyword>c_uint</keyword>
+		<keyword>c_long</keyword>
+		<keyword>c_ulong</keyword>
+		<keyword>size_t</keyword>
+		<keyword>ptrdiff_t</keyword>
+		<keyword>clock_t</keyword>
+		<keyword>time_t</keyword>
+		<keyword>c_longlong</keyword>
+		<keyword>c_ulonglong</keyword>
+		<keyword>intptr_t</keyword>
+		<keyword>uintptr_t</keyword>
+		<keyword>off_t</keyword>
+		<keyword>dev_t</keyword>
+		<keyword>ino_t</keyword>
+		<keyword>pid_t</keyword>
+		<keyword>mode_t</keyword>
+		<keyword>ssize_t</keyword>
+    </context>
+    
+    <context id="self" style-ref="identifier">
+		<keyword>self</keyword>
+    </context>
+    
+    <context id="constants" style-ref="constant">
+		<keyword>true</keyword>
+		<keyword>false</keyword>
+		<keyword>Some</keyword>
+		<keyword>None</keyword>
+		<keyword>Left</keyword>
+		<keyword>Right</keyword>
+		<keyword>Ok</keyword>
+		<keyword>Err</keyword>
+		<keyword>Success</keyword>
+		<keyword>Failure</keyword>
+		<keyword>Cons</keyword>
+		<keyword>Nil</keyword>
+    </context>
+
+    <context id="cconstants" style-ref="constant">
+		<keyword>EXIT_FAILURE</keyword>
+		<keyword>EXIT_SUCCESS</keyword>
+		<keyword>RAND_MAX</keyword>
+		<keyword>EOF</keyword>
+		<keyword>SEEK_SET</keyword>
+		<keyword>SEEK_CUR</keyword>
+		<keyword>SEEK_END</keyword>
+		<keyword>_IOFBF</keyword>
+		<keyword>_IONBF</keyword>
+		<keyword>_IOLBF</keyword>
+		<keyword>BUFSIZ</keyword>
+		<keyword>FOPEN_MAX</keyword>
+		<keyword>FILENAME_MAX</keyword>
+		<keyword>L_tmpnam</keyword>
+		<keyword>TMP_MAX</keyword>
+		<keyword>O_RDONLY</keyword>
+		<keyword>O_WRONLY</keyword>
+		<keyword>O_RDWR</keyword>
+		<keyword>O_APPEND</keyword>
+		<keyword>O_CREAT</keyword>
+		<keyword>O_EXCL</keyword>
+		<keyword>O_TRUNC</keyword>
+		<keyword>S_IFIFO</keyword>
+		<keyword>S_IFCHR</keyword>
+		<keyword>S_IFBLK</keyword>
+		<keyword>S_IFDIR</keyword>
+		<keyword>S_IFREG</keyword>
+		<keyword>S_IFMT</keyword>
+		<keyword>S_IEXEC</keyword>
+		<keyword>S_IWRITE</keyword>
+		<keyword>S_IREAD</keyword>
+		<keyword>S_IRWXU</keyword>
+		<keyword>S_IXUSR</keyword>
+		<keyword>S_IWUSR</keyword>
+		<keyword>S_IRUSR</keyword>
+		<keyword>F_OK</keyword>
+		<keyword>R_OK</keyword>
+		<keyword>W_OK</keyword>
+		<keyword>X_OK</keyword>
+		<keyword>STDIN_FILENO</keyword>
+		<keyword>STDOUT_FILENO</keyword>
+		<keyword>STDERR_FILENO</keyword>
+    </context>
+
+    <context id="line-comment" style-ref="comment" end-at-line-end="true" class="comment" class-disabled="no-spell-check">
+      <start>//</start>
+      <include>
+        <context ref="def:in-line-comment"/>
+      </include>
+    </context>
+
+    <context id="block-comment" style-ref="comment" class="comment" class-disabled="no-spell-check">
+      <start>/\*</start>
+      <end>\*/</end>
+      <include>
+        <context ref="def:in-comment"/>
+      </include>
+    </context>
+
+    <context id="number" style-ref="number">
+      <match extended="true">
+        (?&lt;![\w\.])
+        (
+        0x[0-9a-fA-F_]+(u8|u16|u32|u64|i8|i16|i32|i64|u|i)?|
+        0b[0-1_]+(u8|u16|u32|u64|i8|i16|i32|i64|u|i)?|
+        [0-9][0-9_]*\.[0-9_]*([eE][+-]?[0-9_]+)?(f32|f64|f)?|
+        [0-9][0-9_]*(u8|u16|u32|u64|i8|i16|i32|i64|u|i)?
+        )
+        (?![\w\.])
+      </match>
+    </context>
+
+    <context id="scope" style-ref="scope">
+      <match extended="true">
+        [a-zA-Z_][a-zA-Z0-9_]*::
+      </match>
+    </context>
+
+    <context id="string" style-ref="string" class="string" class-disabled="no-spell-check">
+      <start>"</start>
+      <end>"</end>
+      <include>
+        <context ref="def:escape"/>
+        <context ref="def:line-continue"/>
+      </include>
+    </context>
+
+    <context id="char" style-ref="char" end-at-line-end="true" class="char" class-disabled="no-spell-check">
+      <start>'</start>
+      <end>'</end>
+      <include>
+        <context ref="def:escape"/>
+      </include>
+    </context>
+
+    <context id="rust" class="no-spell-check">
+      <include>
+        <context ref="function"/>
+        <context ref="type"/>
+        <context ref="keywords"/>
+        <context ref="types"/>
+        <context ref="ctypes"/>
+        <context ref="self"/>
+        <context ref="constants"/>
+        <context ref="cconstants"/>
+        <context ref="line-comment"/>
+        <context ref="block-comment"/>
+        <context ref="number"/>
+        <context ref="scope"/>
+        <context ref="string"/>
+        <context ref="char"/>
+      </include>
+    </context>
+
+  </definitions>
+
+</language>
+

--- a/src/etc/gedit/share/mime/packages/rust.xml
+++ b/src/etc/gedit/share/mime/packages/rust.xml
@@ -1,0 +1,7 @@
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+  <mime-type type="text/x-rust">
+    <comment>Rust Source</comment>
+    <glob pattern="*.rs"/>
+    <glob pattern="*.rc"/>    
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
I copied and adapted the syntax highlighting rules from Kate, to be used in GEdit and other GtkSourceView based editors.
