### PR TITLE
Remove code that was awaiting a snapshot

### DIFF
--- a/src/libcore/comm.rs
+++ b/src/libcore/comm.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Transitional -- needs snapshot
-#[allow(structural_records)];
-
 use either::{Either, Left, Right};
 use kinds::Owned;
 use option;

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -227,10 +227,6 @@ pub const debug : u32 = 4_u32;
 
 // The runtime interface used by the compiler
 #[cfg(notest)] pub mod rt;
-// The runtime and compiler interface to fmt!
-#[cfg(stage0)]
-#[path = "private/extfmt.rs"]
-pub mod extfmt;
 // Private APIs
 pub mod private;
 

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -82,8 +82,6 @@ bounded and unbounded protocols allows for less code duplication.
 
 */
 
-#[allow(structural_records)]; // Macros -- needs another snapshot
-
 use cmp::Eq;
 use cast::{forget, reinterpret_cast, transmute};
 use cell::Cell;

--- a/src/libcore/private/finally.rs
+++ b/src/libcore/private/finally.rs
@@ -26,33 +26,10 @@ do || {
 use ops::Drop;
 use task::{spawn, failing};
 
-#[cfg(stage0)]
-pub trait Finally<T> {
-    fn finally(&self, +dtor: &fn()) -> T;
-}
-
-#[cfg(stage1)]
-#[cfg(stage2)]
-#[cfg(stage3)]
 pub trait Finally<T> {
     fn finally(&self, dtor: &fn()) -> T;
 }
 
-#[cfg(stage0)]
-impl<T> Finally<T> for &fn() -> T {
-    // FIXME #4518: Should not require a mode here
-    fn finally(&self, +dtor: &fn()) -> T {
-        let _d = Finallyalizer {
-            dtor: dtor
-        };
-
-        (*self)()
-    }
-}
-
-#[cfg(stage1)]
-#[cfg(stage2)]
-#[cfg(stage3)]
 impl<T> Finally<T> for &fn() -> T {
     fn finally(&self, dtor: &fn()) -> T {
         let _d = Finallyalizer {

--- a/src/libcore/stackwalk.rs
+++ b/src/libcore/stackwalk.rs
@@ -10,9 +10,6 @@
 
 #[doc(hidden)]; // FIXME #3538
 
-#[legacy_modes]; // tjc: remove after snapshot
-#[allow(deprecated_mode)];
-
 use cast::reinterpret_cast;
 use ptr::offset;
 use sys::size_of;

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -553,10 +553,7 @@ impl get_node_info for ast::blk {
     }
 }
 
-// XXX: Work around a trait parsing bug. remove after snapshot
-pub type optional_boxed_ast_expr = Option<@ast::expr>;
-
-impl get_node_info for optional_boxed_ast_expr {
+impl get_node_info for Option<@ast::expr> {
     fn info(&self) -> Option<NodeInfo> {
         self.chain_ref(|s| s.info())
     }

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -46,34 +46,10 @@ extern mod rustrt {
 // colons. This way if some test runner wants to arrange the tests
 // hierarchically it may.
 
-#[cfg(stage0)]
-pub enum TestName {
-    // Stage0 doesn't understand sendable &static/str yet
-    StaticTestName(&static/[u8]),
-    DynTestName(~str)
-}
-
-#[cfg(stage0)]
-impl ToStr for TestName {
-    pure fn to_str(&self) -> ~str {
-        match self {
-            &StaticTestName(s) => str::from_bytes(s),
-            &DynTestName(s) => s.to_str()
-        }
-    }
-}
-
-#[cfg(stage1)]
-#[cfg(stage2)]
-#[cfg(stage3)]
 pub enum TestName {
     StaticTestName(&static/str),
     DynTestName(~str)
 }
-
-#[cfg(stage1)]
-#[cfg(stage2)]
-#[cfg(stage3)]
 impl ToStr for TestName {
     pure fn to_str(&self) -> ~str {
         match self {

--- a/src/test/pretty/record-trailing-comma.rs
+++ b/src/test/pretty/record-trailing-comma.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// NOTE this is a pretty-printer bug that I fixed, but it's
-// not in the snapshot yet. After a new snapshot, can un-xfail
-// xfail-pretty
 // pp-exact
 struct Thing {
     x: int,

--- a/src/test/pretty/record-trailing-comma.rs
+++ b/src/test/pretty/record-trailing-comma.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test
 // pp-exact
 struct Thing {
     x: int,

--- a/src/test/run-pass/pipe-select-macro.rs
+++ b/src/test/run-pass/pipe-select-macro.rs
@@ -8,9 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// tjc: un-xfail after snapshot
 // xfail-test
-// xfail-pretty
 
 // Protocols
 proto! foo (


### PR DESCRIPTION
- Disallow structural records everywhere
- Remove all #[cfg(stage0)] stuff
- Remove the last deprecated modes in libcore
- Un-xfail a test
