### PR TITLE
Algebraic Datatype Renovation

### DIFF
--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -168,8 +168,8 @@ pub fn check_expr(sess: Session,
           expr_field(*) |
           expr_index(*) |
           expr_tup(*) |
-          expr_struct(*) |
-          expr_rec(*) => { }
+          expr_struct(_, _, None) |
+          expr_rec(_, None) => { }
           expr_addr_of(*) => {
                 sess.span_err(
                     e.span,

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -145,7 +145,6 @@
 use core::prelude::*;
 
 use back::abi;
-use lib;
 use lib::llvm::{llvm, ValueRef, BasicBlockRef};
 use middle::const_eval;
 use middle::borrowck::root_map_key;
@@ -170,9 +169,7 @@ use util::common::indenter;
 
 use core::dvec::DVec;
 use core::dvec;
-use core::libc::c_ulonglong;
 use std::oldmap::HashMap;
-use syntax::ast::def_id;
 use syntax::ast;
 use syntax::ast::ident;
 use syntax::ast_util::path_to_ident;

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -139,7 +139,6 @@ fn generic_fields_of(cx: @CrateContext, r: &Repr, sizing: bool)
 fn load_discr(bcx: block, scrutinee: ValueRef, min: int, max: int)
     -> ValueRef {
     let ptr = GEPi(bcx, scrutinee, [0, 0]);
-    // XXX: write tests for the edge cases here
     if max + 1 == min {
         // i.e., if the range is everything.  The lo==hi case would be
         // rejected by the LLVM verifier (it would mean either an

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -266,6 +266,14 @@ fn struct_GEP(bcx: block, st: &Struct, val: ValueRef, ix: uint,
     GEPi(bcx, val, [0, ix])
 }
 
+pub fn trans_drop_flag_ptr(bcx: block, r: &Repr, val: ValueRef) -> ValueRef {
+    match *r {
+        Univariant(_, DtorPresent) => GEPi(bcx, val, [0, 1]),
+        _ => bcx.ccx().sess.bug(~"tried to get drop flag of non-droppable \
+                                  type")
+    }
+}
+
 pub fn trans_const(ccx: @CrateContext, r: &Repr, discr: int,
                    vals: &[ValueRef]) -> ValueRef {
     match *r {

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -378,3 +378,12 @@ fn const_struct_field(ccx: @CrateContext, val: ValueRef, ix: uint)
         real_ix = real_ix + 1;
     }
 }
+
+/// Is it safe to bitcast a value to the one field of its one variant?
+pub fn is_newtypeish(r: &Repr) -> bool {
+    match *r {
+        Univariant(ref st, DtorAbsent)
+        | Univariant(ref st, NoDtor) => st.fields.len() == 1,
+        _ => false
+    }
+}

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -1,0 +1,326 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core::option::{Option, Some, None};
+use core::vec;
+use lib::llvm::{ValueRef, TypeRef};
+use middle::trans::_match;
+use middle::trans::build::*;
+use middle::trans::common::*;
+use middle::trans::machine;
+use middle::trans::type_of;
+use middle::ty;
+use syntax::ast;
+use util::ppaux::ty_to_str;
+
+
+// XXX: should this be done with boxed traits instead of ML-style?
+pub enum Repr {
+    CEnum,
+    Univariant(Struct, Destructor),
+    General(~[Struct])
+}
+
+enum Destructor {
+    DtorPresent,
+    DtorAbsent,
+    NoDtor
+}
+
+struct Struct {
+    size: u64,
+    align: u64,
+    fields: ~[ty::t]
+}
+
+
+pub fn represent_node(bcx: block, node: ast::node_id)
+    -> Repr {
+    represent_type(bcx.ccx(), node_id_type(bcx, node))
+}
+
+pub fn represent_type(cx: @CrateContext, t: ty::t) -> Repr {
+    debug!("Representing: %s", ty_to_str(cx.tcx, t));
+    // XXX: cache this
+    match ty::get(t).sty {
+        ty::ty_tup(ref elems) => {
+            Univariant(mk_struct(cx, *elems), NoDtor)
+        }
+        ty::ty_rec(ref fields) => {
+            // XXX: Are these in the right order?
+            Univariant(mk_struct(cx, fields.map(|f| f.mt.ty)), DtorAbsent)
+        }
+        ty::ty_struct(def_id, ref substs) => {
+            let fields = ty::lookup_struct_fields(cx.tcx, def_id);
+            let dt = ty::ty_dtor(cx.tcx, def_id).is_present();
+            Univariant(mk_struct(cx, fields.map(|field| {
+                ty::lookup_field_type(cx.tcx, def_id, field.id, substs)
+            })), if dt { DtorPresent } else { DtorAbsent })
+        }
+        ty::ty_enum(def_id, ref substs) => {
+            struct Case { discr: i64, tys: ~[ty::t] };
+
+            let cases = do ty::enum_variants(cx.tcx, def_id).map |vi| {
+                let arg_tys = do vi.args.map |&raw_ty| {
+                    ty::subst(cx.tcx, substs, raw_ty)
+                };
+                Case { discr: vi.disr_val /*bad*/as i64, tys: arg_tys }
+            };
+            if cases.len() == 0 {
+                // Uninhabitable; represent as unit
+                Univariant(mk_struct(cx, ~[]), NoDtor)
+            } else if cases.len() == 1 && cases[0].discr == 0 {
+                // struct, tuple, newtype, etc.
+                Univariant(mk_struct(cx, cases[0].tys), NoDtor)
+            } else if cases.all(|c| c.tys.len() == 0) {
+                CEnum
+            } else {
+                if !cases.alli(|i,c| c.discr == (i as i64)) {
+                    cx.sess.bug(fmt!("non-C-like enum %s with specified \
+                                      discriminants",
+                                     ty::item_path_str(cx.tcx, def_id)))
+                }
+                General(cases.map(|c| mk_struct(cx, c.tys)))
+            }
+        }
+        _ => cx.sess.bug(~"adt::represent_type called on non-ADT type")
+    }
+}
+
+fn mk_struct(cx: @CrateContext, tys: &[ty::t]) -> Struct {
+    let lltys = tys.map(|&ty| type_of::sizing_type_of(cx, ty));
+    let llty_rec = T_struct(lltys);
+    Struct {
+        size: machine::llsize_of_alloc(cx, llty_rec) /*bad*/as u64,
+        align: machine::llalign_of_min(cx, llty_rec) /*bad*/as u64,
+        fields: vec::from_slice(tys)
+    }
+}
+
+
+pub fn sizing_fields_of(cx: @CrateContext, r: &Repr) -> ~[TypeRef] {
+    generic_fields_of(cx, r, true)
+}
+pub fn fields_of(cx: @CrateContext, r: &Repr) -> ~[TypeRef] {
+    generic_fields_of(cx, r, false)
+}
+fn generic_fields_of(cx: @CrateContext, r: &Repr, sizing: bool)
+    -> ~[TypeRef] {
+    match *r {
+        CEnum => ~[T_enum_discrim(cx)],
+        Univariant(ref st, dt) => {
+            let f = if sizing {
+                st.fields.map(|&ty| type_of::sizing_type_of(cx, ty))
+            } else {
+                st.fields.map(|&ty| type_of::type_of(cx, ty))
+            };
+            match dt {
+                NoDtor => f,
+                DtorAbsent => ~[T_struct(f)],
+                DtorPresent => ~[T_struct(f), T_i8()]
+            }
+        }
+        General(ref sts) => {
+            ~[T_enum_discrim(cx),
+              T_array(T_i8(), sts.map(|st| st.size).max() /*bad*/as uint)]
+        }
+    }
+}
+
+pub fn trans_switch(bcx: block, r: &Repr, scrutinee: ValueRef) ->
+    (_match::branch_kind, Option<ValueRef>) {
+    // XXX: LoadRangeAssert
+    match *r {
+        CEnum => {
+            (_match::switch, Some(Load(bcx, GEPi(bcx, scrutinee, [0, 0]))))
+        }
+        Univariant(*) => {
+            (_match::single, None)
+        }
+        General(*) => {
+            (_match::switch, Some(Load(bcx, GEPi(bcx, scrutinee, [0, 0]))))
+        }
+    }
+}
+
+pub fn trans_case(bcx: block, r: &Repr, discr: int) -> _match::opt_result {
+    match *r {
+        CEnum => {
+            _match::single_result(rslt(bcx, C_int(bcx.ccx(), discr)))
+        }
+        Univariant(*) => {
+            bcx.ccx().sess.bug(~"no cases for univariants or structs")
+        }
+        General(*) => {
+            _match::single_result(rslt(bcx, C_int(bcx.ccx(), discr)))
+        }
+    }
+}
+
+pub fn trans_set_discr(bcx: block, r: &Repr, val: ValueRef, discr: int) {
+    match *r {
+        CEnum => {
+            Store(bcx, C_int(bcx.ccx(), discr), GEPi(bcx, val, [0, 0]))
+        }
+        Univariant(_, DtorPresent) => {
+            assert discr == 0;
+            Store(bcx, C_u8(1), GEPi(bcx, val, [0, 1]))
+        }
+        Univariant(*) => {
+            assert discr == 0;
+        }
+        General(*) => {
+            Store(bcx, C_int(bcx.ccx(), discr), GEPi(bcx, val, [0, 0]))
+        }
+    }
+}
+
+pub fn num_args(r: &Repr, discr: int) -> uint {
+    match *r {
+        CEnum => 0,
+        Univariant(ref st, _dt) => { assert discr == 0; st.fields.len() }
+        General(ref cases) => cases[discr as uint].fields.len()
+    }
+}
+
+pub fn trans_GEP(bcx: block, r: &Repr, val: ValueRef, discr: int, ix: uint)
+    -> ValueRef {
+    // Note: if this ever needs to generate conditionals (e.g., if we
+    // decide to do some kind of cdr-coding-like non-unique repr
+    // someday), it'll need to return a possibly-new bcx as well.
+    match *r {
+        CEnum => {
+            bcx.ccx().sess.bug(~"element access in C-like enum")
+        }
+        Univariant(ref st, dt) => {
+            assert discr == 0;
+            let val = match dt {
+                NoDtor => val,
+                DtorPresent | DtorAbsent => GEPi(bcx, val, [0, 0])
+            };
+            struct_GEP(bcx, st, val, ix)
+        }
+        General(ref cases) => {
+            struct_GEP(bcx, &cases[discr as uint],
+                       GEPi(bcx, val, [0, 1]), ix)
+        }
+    }
+}
+
+fn struct_GEP(bcx: block, st: &Struct, val: ValueRef, ix: uint)
+    -> ValueRef {
+    let ccx = bcx.ccx();
+
+    let real_llty = T_struct(st.fields.map(
+        |&ty| type_of::type_of(ccx, ty)));
+    let cast_val = PointerCast(bcx, val, T_ptr(real_llty));
+
+    GEPi(bcx, cast_val, [0, ix])
+}
+
+pub fn trans_const(ccx: @CrateContext, r: &Repr, discr: int,
+                   vals: &[ValueRef]) -> ValueRef {
+    match *r {
+        CEnum => {
+            assert vals.len() == 0;
+            C_int(ccx, discr)
+        }
+        Univariant(ref st, _dt) => {
+            assert discr == 0;
+            // consts are never destroyed, so the dtor flag is not needed
+            C_struct(build_const_struct(ccx, st, vals))
+        }
+        General(ref cases) => {
+            let case = &cases[discr as uint];
+            let max_sz = cases.map(|s| s.size).max();
+            let body = build_const_struct(ccx, case, vals);
+
+            C_struct([C_int(ccx, discr),
+                      C_packed_struct([C_struct(body)]),
+                      padding(max_sz - case.size)])
+        }
+    }
+}
+
+fn padding(size: u64) -> ValueRef {
+    C_undef(T_array(T_i8(), size /*bad*/as uint))
+}
+
+fn build_const_struct(ccx: @CrateContext, st: &Struct, vals: &[ValueRef])
+    -> ~[ValueRef] {
+    assert vals.len() == st.fields.len();
+
+    let mut offset = 0;
+    let mut cfields = ~[];
+    for st.fields.eachi |i, &ty| {
+        let llty = type_of::sizing_type_of(ccx, ty);
+        let type_align = machine::llalign_of_min(ccx, llty)
+            /*bad*/as u64;
+        let val_align = machine::llalign_of_min(ccx, val_ty(vals[i]))
+            /*bad*/as u64;
+        let target_offset = roundup(offset, type_align);
+        offset = roundup(offset, val_align);
+        if (offset != target_offset) {
+            cfields.push(padding(target_offset - offset));
+            offset = target_offset;
+        }
+        assert !is_undef(vals[i]);
+        // If that assert fails, could change it to wrap in a struct?
+        cfields.push(vals[i]);
+    }
+
+    return cfields;
+}
+
+#[always_inline]
+fn roundup(x: u64, a: u64) -> u64 { ((x + (a - 1)) / a) * a }
+
+
+pub fn const_get_discrim(ccx: @CrateContext, r: &Repr, val: ValueRef)
+    -> int {
+    match *r {
+        CEnum(*) => const_to_int(val) as int,
+        Univariant(*) => 0,
+        General(*) => const_to_int(const_get_elt(ccx, val, [0])) as int,
+    }
+}
+
+pub fn const_get_element(ccx: @CrateContext, r: &Repr, val: ValueRef,
+                         _discr: int, ix: uint) -> ValueRef {
+    // Not to be confused with common::const_get_elt.
+    match *r {
+        CEnum(*) => ccx.sess.bug(~"element access in C-like enum const"),
+        Univariant(*) => const_struct_field(ccx, val, ix),
+        General(*) => const_struct_field(ccx, const_get_elt(ccx, val,
+                                                            [1, 0]), ix)
+    }
+}
+
+fn const_struct_field(ccx: @CrateContext, val: ValueRef, ix: uint)
+    -> ValueRef {
+    // Get the ix-th non-undef element of the struct.
+    let mut real_ix = 0; // actual position in the struct
+    let mut ix = ix; // logical index relative to real_ix
+    let mut field;
+    loop {
+        loop {
+            field = const_get_elt(ccx, val, [real_ix]);
+            if !is_undef(field) {
+                break;
+            }
+            real_ix = real_ix + 1;
+        }
+        if ix == 0 {
+            return field;
+        }
+        ix = ix - 1;
+        real_ix = real_ix + 1;
+    }
+}

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -239,25 +239,6 @@ pub fn bump_ptr(bcx: block, t: ty::t, base: ValueRef, sz: ValueRef) ->
     PointerCast(bcx, bumped, typ)
 }
 
-// Replacement for the LLVM 'GEP' instruction when field indexing into a enum.
-// @llblobptr is the data part of a enum value; its actual type
-// is meaningless, as it will be cast away.
-pub fn GEP_enum(bcx: block, llblobptr: ValueRef, enum_id: ast::def_id,
-                variant_id: ast::def_id, ty_substs: &[ty::t],
-                ix: uint) -> ValueRef {
-    let _icx = bcx.insn_ctxt("GEP_enum");
-    let ccx = bcx.ccx();
-    let variant = ty::enum_variant_with_id(ccx.tcx, enum_id, variant_id);
-    assert ix < variant.args.len();
-
-    let arg_lltys = vec::map(variant.args, |aty| {
-        type_of(ccx, ty::subst_tps(ccx.tcx, ty_substs, None, *aty))
-    });
-    let typed_blobptr = PointerCast(bcx, llblobptr,
-                                    T_ptr(T_struct(arg_lltys)));
-    GEPi(bcx, typed_blobptr, [0u, ix])
-}
-
 // Returns a pointer to the body for the box. The box may be an opaque
 // box. The result will be casted to the type of body_t, if it is statically
 // known.

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -676,9 +676,10 @@ pub fn iter_structural_ty(cx: block, av: ValueRef, t: ty::t,
     let mut cx = cx;
     match /*bad*/copy ty::get(t).sty {
       ty::ty_rec(*) | ty::ty_struct(*) => {
-          do expr::with_field_tys(cx.tcx(), t, None) |_has_dtor, field_tys| {
+          let repr = adt::represent_type(cx.ccx(), t);
+          do expr::with_field_tys(cx.tcx(), t, None) |discr, field_tys| {
               for vec::eachi(field_tys) |i, field_ty| {
-                  let llfld_a = GEPi(cx, av, struct_field(i));
+                  let llfld_a = adt::trans_GEP(cx, &repr, av, discr, i);
                   cx = f(cx, llfld_a, field_ty.mt.ty);
               }
           }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -689,10 +689,11 @@ pub fn iter_structural_ty(cx: block, av: ValueRef, t: ty::t,
         cx = tvec::iter_vec_raw(cx, base, t, len, f);
       }
       ty::ty_tup(args) => {
-        for vec::eachi(args) |i, arg| {
-            let llfld_a = GEPi(cx, av, [0u, i]);
-            cx = f(cx, llfld_a, *arg);
-        }
+          let repr = adt::represent_type(cx.ccx(), t);
+          for vec::eachi(args) |i, arg| {
+              let llfld_a = adt::trans_GEP(cx, &repr, av, 0, i);
+              cx = f(cx, llfld_a, *arg);
+          }
       }
       ty::ty_enum(tid, ref substs) => {
         let variants = ty::enum_variants(cx.tcx(), tid);

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -39,6 +39,7 @@ use middle::astencode;
 use middle::borrowck::RootInfo;
 use middle::resolve;
 use middle::trans::_match;
+use middle::trans::adt;
 use middle::trans::base;
 use middle::trans::build::*;
 use middle::trans::callee;
@@ -1861,7 +1862,6 @@ pub fn trans_enum_variant(ccx: @CrateContext,
                           variant: ast::variant,
                           args: &[ast::variant_arg],
                           disr: int,
-                          is_degen: bool,
                           param_substs: Option<@param_substs>,
                           llfndecl: ValueRef) {
     let _icx = ccx.insn_ctxt("trans_enum_variant");
@@ -1890,21 +1890,15 @@ pub fn trans_enum_variant(ccx: @CrateContext,
     let arg_tys = ty::ty_fn_args(node_id_type(bcx, variant.node.id));
     let bcx = copy_args_to_allocas(fcx, bcx, fn_args, raw_llargs, arg_tys);
 
-    // Cast the enum to a type we can GEP into.
-    let llblobptr = if is_degen {
-        fcx.llretptr
-    } else {
-        let llenumptr =
-            PointerCast(bcx, fcx.llretptr, T_opaque_enum_ptr(ccx));
-        let lldiscrimptr = GEPi(bcx, llenumptr, [0u, 0u]);
-        Store(bcx, C_int(ccx, disr), lldiscrimptr);
-        GEPi(bcx, llenumptr, [0u, 1u])
-    };
-    let t_id = local_def(enum_id);
-    let v_id = local_def(variant.node.id);
+    // XXX is there a better way to reconstruct the ty::t?
+    let enum_ty = ty::subst_tps(ccx.tcx, ty_param_substs, None,
+                                ty::node_id_to_type(ccx.tcx, enum_id));
+    let repr = adt::represent_type(ccx, enum_ty);
+
+    adt::trans_set_discr(bcx, &repr, fcx.llretptr, disr);
     for vec::eachi(args) |i, va| {
-        let lldestptr = GEP_enum(bcx, llblobptr, t_id, v_id,
-                                 /*bad*/copy ty_param_substs, i);
+        let lldestptr = adt::trans_GEP(bcx, &repr, fcx.llretptr, disr, i);
+
         // If this argument to this function is a enum, it'll have come in to
         // this function as an opaque blob due to the way that type_of()
         // works. So we have to cast to the destination's view of the type.
@@ -2014,7 +2008,7 @@ pub fn trans_struct_dtor(ccx: @CrateContext,
 }
 
 pub fn trans_enum_def(ccx: @CrateContext, enum_definition: ast::enum_def,
-                      id: ast::node_id, degen: bool,
+                      id: ast::node_id,
                       path: @ast_map::path, vi: @~[ty::VariantInfo],
                       i: &mut uint) {
     for vec::each(enum_definition.variants) |variant| {
@@ -2025,7 +2019,7 @@ pub fn trans_enum_def(ccx: @CrateContext, enum_definition: ast::enum_def,
             ast::tuple_variant_kind(ref args) if args.len() > 0 => {
                 let llfn = get_item_val(ccx, variant.node.id);
                 trans_enum_variant(ccx, id, *variant, /*bad*/copy *args,
-                                   disr_val, degen, None, llfn);
+                                   disr_val, None, llfn);
             }
             ast::tuple_variant_kind(_) => {
                 // Nothing to do.
@@ -2038,7 +2032,6 @@ pub fn trans_enum_def(ccx: @CrateContext, enum_definition: ast::enum_def,
                 trans_enum_def(ccx,
                                *enum_definition,
                                id,
-                               degen,
                                path,
                                vi,
                                &mut *i);
@@ -2089,11 +2082,10 @@ pub fn trans_item(ccx: @CrateContext, item: ast::item) {
       }
       ast::item_enum(ref enum_definition, ref generics) => {
         if !generics.is_type_parameterized() {
-            let degen = (*enum_definition).variants.len() == 1u;
             let vi = ty::enum_variants(ccx.tcx, local_def(item.id));
             let mut i = 0;
             trans_enum_def(ccx, (*enum_definition), item.id,
-                           degen, path, vi, &mut i);
+                           path, vi, &mut i);
         }
       }
       ast::item_const(_, expr) => consts::trans_const(ccx, expr, item.id),

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -828,30 +828,6 @@ pub fn trans_external_path(ccx: @CrateContext, did: ast::def_id, t: ty::t)
     };
 }
 
-pub fn get_discrim_val(cx: @CrateContext, span: span, enum_did: ast::def_id,
-                       variant_did: ast::def_id) -> ValueRef {
-    // Can't use `discrims` from the crate context here because
-    // those discriminants have an extra level of indirection,
-    // and there's no LLVM constant load instruction.
-    let mut lldiscrim_opt = None;
-    for ty::enum_variants(cx.tcx, enum_did).each |variant_info| {
-        if variant_info.id == variant_did {
-            lldiscrim_opt = Some(C_int(cx,
-                                       variant_info.disr_val));
-            break;
-        }
-    }
-
-    match lldiscrim_opt {
-        None => {
-            cx.tcx.sess.span_bug(span, ~"didn't find discriminant?!");
-        }
-        Some(found_lldiscrim) => {
-            found_lldiscrim
-        }
-    }
-}
-
 pub fn invoke(bcx: block, llfn: ValueRef, +llargs: ~[ValueRef]) -> block {
     let _icx = bcx.insn_ctxt("invoke_");
     if bcx.unreachable { return bcx; }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1042,21 +1042,6 @@ pub fn T_enum_discrim(cx: @CrateContext) -> TypeRef {
     return cx.int_type;
 }
 
-pub fn T_opaque_enum(cx: @CrateContext) -> TypeRef {
-    let s = @"opaque_enum";
-    match name_has_type(cx.tn, s) {
-      Some(t) => return t,
-      _ => ()
-    }
-    let t = T_struct(~[T_enum_discrim(cx), T_i8()]);
-    associate_type(cx.tn, s, t);
-    return t;
-}
-
-pub fn T_opaque_enum_ptr(cx: @CrateContext) -> TypeRef {
-    return T_ptr(T_opaque_enum(cx));
-}
-
 pub fn T_captured_tydescs(cx: @CrateContext, n: uint) -> TypeRef {
     return T_struct(vec::from_elem::<TypeRef>(n, T_ptr(cx.tydesc_type)));
 }
@@ -1466,18 +1451,6 @@ pub fn dummy_substs(+tps: ~[ty::t]) -> ty::substs {
         self_ty: None,
         tps: tps
     }
-}
-
-pub fn struct_field(index: uint) -> [uint * 3] {
-    //! The GEPi sequence to access a field of a record/struct.
-
-    [0, 0, index]
-}
-
-pub fn struct_dtor() -> [uint * 2] {
-    //! The GEPi sequence to access the dtor of a struct.
-
-    [0, 1]
 }
 
 // Casts a Rust bool value to an i1.

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -26,6 +26,7 @@ use lib;
 use metadata::common::LinkMeta;
 use middle::astencode;
 use middle::resolve;
+use middle::trans::adt;
 use middle::trans::base;
 use middle::trans::build;
 use middle::trans::callee;
@@ -44,6 +45,7 @@ use util::ppaux::{expr_repr, ty_to_str};
 
 use core::cast;
 use core::hash;
+use core::hashmap::linear::LinearMap;
 use core::libc::{c_uint, c_longlong, c_ulonglong};
 use core::ptr;
 use core::str;
@@ -203,6 +205,7 @@ pub struct CrateContext {
      module_data: HashMap<~str, ValueRef>,
      lltypes: HashMap<ty::t, TypeRef>,
      llsizingtypes: HashMap<ty::t, TypeRef>,
+     adt_reprs: @mut LinearMap<ty::t, @adt::Repr>,
      names: namegen,
      next_addrspace: addrspace_gen,
      symbol_hasher: @hash::State,

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1016,22 +1016,6 @@ pub fn T_chan(cx: @CrateContext, _t: TypeRef) -> TypeRef {
 pub fn T_taskptr(cx: @CrateContext) -> TypeRef { return T_ptr(cx.task_type); }
 
 
-// This type must never be used directly; it must always be cast away.
-pub fn T_typaram(tn: @TypeNames) -> TypeRef {
-    let s = @"typaram";
-    match name_has_type(tn, s) {
-      Some(t) => return t,
-      _ => ()
-    }
-    let t = T_i8();
-    associate_type(tn, s, t);
-    return t;
-}
-
-pub fn T_typaram_ptr(tn: @TypeNames) -> TypeRef {
-    return T_ptr(T_typaram(tn));
-}
-
 pub fn T_opaque_cbox_ptr(cx: @CrateContext) -> TypeRef {
     // closures look like boxes (even when they are ~fn or &fn)
     // see trans_closure.rs

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -103,20 +103,6 @@ pub fn const_deref(cx: @CrateContext, v: ValueRef) -> ValueRef {
     }
 }
 
-pub fn const_get_elt(cx: @CrateContext, v: ValueRef, us: &[c_uint])
-                  -> ValueRef {
-    unsafe {
-        let r = do vec::as_imm_buf(us) |p, len| {
-            llvm::LLVMConstExtractValue(v, p, len as c_uint)
-        };
-
-        debug!("const_get_elt(v=%s, us=%?, r=%s)",
-               val_str(cx.tn, v), us, val_str(cx.tn, r));
-
-        return r;
-    }
-}
-
 pub fn const_autoderef(cx: @CrateContext, ty: ty::t, v: ValueRef)
     -> (ty::t, ValueRef) {
     let mut t1 = ty;

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -245,7 +245,7 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
               let (bt, bv) = const_autoderef(cx, bt, bv);
               do expr::with_field_tys(cx.tcx, bt, None) |discr, field_tys| {
                   let ix = ty::field_idx_strict(cx.tcx, field, field_tys);
-                  adt::const_get_element(cx, brepr, bv, discr, ix)
+                  adt::const_get_field(cx, brepr, bv, discr, ix)
               }
           }
 

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -240,16 +240,12 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
           }
           ast::expr_field(base, field, _) => {
               let bt = ty::expr_ty(cx.tcx, base);
+              let brepr = adt::represent_type(cx, bt);
               let bv = const_expr(cx, base);
               let (bt, bv) = const_autoderef(cx, bt, bv);
-              do expr::with_field_tys(cx.tcx, bt, None) |_, field_tys| {
+              do expr::with_field_tys(cx.tcx, bt, None) |discr, field_tys| {
                   let ix = ty::field_idx_strict(cx.tcx, field, field_tys);
-
-                  // Note: ideally, we'd use `struct_field()` here instead
-                  // of hardcoding [0, ix], but we can't because it yields
-                  // the wrong type and also inserts an extra 0 that is
-                  // not needed in the constant variety:
-                  const_get_elt(cx, bv, [0, ix as c_uint])
+                  adt::const_get_element(cx, &brepr, bv, discr, ix)
               }
           }
 

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -245,7 +245,7 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
               let (bt, bv) = const_autoderef(cx, bt, bv);
               do expr::with_field_tys(cx.tcx, bt, None) |discr, field_tys| {
                   let ix = ty::field_idx_strict(cx.tcx, field, field_tys);
-                  adt::const_get_element(cx, &brepr, bv, discr, ix)
+                  adt::const_get_element(cx, brepr, bv, discr, ix)
               }
           }
 
@@ -326,7 +326,7 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
               (expr::cast_enum, expr::cast_integral) |
               (expr::cast_enum, expr::cast_float)  => {
                 let repr = adt::represent_type(cx, basety);
-                let iv = C_int(cx, adt::const_get_discrim(cx, &repr, v));
+                let iv = C_int(cx, adt::const_get_discrim(cx, repr, v));
                 let ety_cast = expr::cast_type_kind(ety);
                 match ety_cast {
                     expr::cast_integral => {
@@ -356,12 +356,12 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
           ast::expr_tup(es) => {
               let ety = ty::expr_ty(cx.tcx, e);
               let repr = adt::represent_type(cx, ety);
-              adt::trans_const(cx, &repr, 0, es.map(|e| const_expr(cx, *e)))
+              adt::trans_const(cx, repr, 0, es.map(|e| const_expr(cx, *e)))
           }
           ast::expr_rec(ref fs, None) => {
               let ety = ty::expr_ty(cx.tcx, e);
               let repr = adt::represent_type(cx, ety);
-              adt::trans_const(cx, &repr, 0,
+              adt::trans_const(cx, repr, 0,
                                fs.map(|f| const_expr(cx, f.node.expr)))
           }
           ast::expr_struct(_, ref fs, None) => {
@@ -378,7 +378,7 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                           }
                       }
                   });
-                  adt::trans_const(cx, &repr, discr, cs)
+                  adt::trans_const(cx, repr, discr, cs)
               }
           }
           ast::expr_vec(es, ast::m_imm) => {
@@ -442,7 +442,7 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                     let vinfo = ty::enum_variant_with_id(cx.tcx,
                                                          enum_did,
                                                          variant_did);
-                    adt::trans_const(cx, &repr, vinfo.disr_val, [])
+                    adt::trans_const(cx, repr, vinfo.disr_val, [])
                 }
                 Some(ast::def_struct(_)) => {
                     let ety = ty::expr_ty(cx.tcx, e);
@@ -460,7 +460,7 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                   Some(ast::def_struct(_)) => {
                       let ety = ty::expr_ty(cx.tcx, e);
                       let repr = adt::represent_type(cx, ety);
-                      adt::trans_const(cx, &repr, 0,
+                      adt::trans_const(cx, repr, 0,
                                        args.map(|a| const_expr(cx, *a)))
                   }
                   Some(ast::def_variant(enum_did, variant_did)) => {
@@ -469,7 +469,7 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                       let vinfo = ty::enum_variant_with_id(cx.tcx,
                                                            enum_did,
                                                            variant_did);
-                      adt::trans_const(cx, &repr, vinfo.disr_val,
+                      adt::trans_const(cx, repr, vinfo.disr_val,
                                        args.map(|a| const_expr(cx, *a)))
                   }
                   _ => cx.sess.span_bug(e.span, ~"expected a struct or \

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -12,6 +12,7 @@ use core::prelude::*;
 
 use lib::llvm::{llvm, ValueRef, TypeRef, Bool, True, False};
 use middle::const_eval;
+use middle::trans::adt;
 use middle::trans::base;
 use middle::trans::base::get_insn_ctxt;
 use middle::trans::common::*;
@@ -328,24 +329,8 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
               }
               (expr::cast_enum, expr::cast_integral) |
               (expr::cast_enum, expr::cast_float)  => {
-                let def = ty::resolve_expr(cx.tcx, base);
-                let (enum_did, variant_did) = match def {
-                    ast::def_variant(enum_did, variant_did) => {
-                        (enum_did, variant_did)
-                    }
-                    _ => cx.sess.bug(~"enum cast source is not enum")
-                };
-                // Note that we know this is a C-like (nullary) enum
-                // variant or we wouldn't have gotten here
-                let variants = ty::enum_variants(cx.tcx, enum_did);
-                let iv = if variants.len() == 1 {
-                    // Univariants don't have a discriminant field,
-                    // because there's only one value it could have:
-                    C_integral(T_i64(),
-                               variants[0].disr_val as u64, True)
-                } else {
-                    base::get_discrim_val(cx, e.span, enum_did, variant_did)
-                };
+                let repr = adt::represent_type(cx, basety);
+                let iv = C_int(cx, adt::const_get_discrim(cx, &repr, v));
                 let ety_cast = expr::cast_type_kind(ety);
                 match ety_cast {
                     expr::cast_integral => {
@@ -373,18 +358,22 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
             gv
           }
           ast::expr_tup(es) => {
-            C_struct(es.map(|e| const_expr(cx, *e)))
+              let ety = ty::expr_ty(cx.tcx, e);
+              let repr = adt::represent_type(cx, ety);
+              adt::trans_const(cx, &repr, 0, es.map(|e| const_expr(cx, *e)))
           }
           ast::expr_rec(ref fs, None) => {
-              C_struct([C_struct(
-                  (*fs).map(|f| const_expr(cx, f.node.expr)))])
-          }
-          ast::expr_struct(_, ref fs, _) => {
               let ety = ty::expr_ty(cx.tcx, e);
-              let cs = do expr::with_field_tys(cx.tcx,
-                                               ety,
-                                               None) |_hd, field_tys| {
-                  field_tys.map(|field_ty| {
+              let repr = adt::represent_type(cx, ety);
+              adt::trans_const(cx, &repr, 0,
+                               fs.map(|f| const_expr(cx, f.node.expr)))
+          }
+          ast::expr_struct(_, ref fs, None) => {
+              let ety = ty::expr_ty(cx.tcx, e);
+              let repr = adt::represent_type(cx, ety);
+              do expr::with_field_tys(cx.tcx, ety, Some(e.id))
+                  |discr, field_tys| {
+                  let cs = field_tys.map(|field_ty| {
                       match fs.find(|f| field_ty.ident == f.node.ident) {
                           Some(ref f) => const_expr(cx, (*f).node.expr),
                           None => {
@@ -392,9 +381,9 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                                   e.span, ~"missing struct field");
                           }
                       }
-                  })
-              };
-              C_struct([C_struct(cs)])
+                  });
+                  adt::trans_const(cx, &repr, discr, cs)
+              }
           }
           ast::expr_vec(es, ast::m_imm) => {
             let (v, _, _) = const_vec(cx, e, es);
@@ -452,25 +441,12 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                     get_const_val(cx, def_id)
                 }
                 Some(ast::def_variant(enum_did, variant_did)) => {
-                    // Note that we know this is a C-like (nullary) enum
-                    // variant or we wouldn't have gotten here -- the constant
-                    // checker forbids paths that don't map to C-like enum
-                    // variants.
-                    if ty::enum_is_univariant(cx.tcx, enum_did) {
-                        // Univariants have no discriminant field.
-                        C_struct(~[])
-                    } else {
-                    let lldiscrim = base::get_discrim_val(cx, e.span,
-                                                          enum_did,
-                                                          variant_did);
-                    // However, we still have to pad it out to the
-                    // size of the full enum; see the expr_call case,
-                    // below.
                     let ety = ty::expr_ty(cx.tcx, e);
-                    let size = machine::static_size_of_enum(cx, ety);
-                    let padding = C_null(T_array(T_i8(), size));
-                    C_struct(~[lldiscrim, padding])
-                }
+                    let repr = adt::represent_type(cx, ety);
+                    let vinfo = ty::enum_variant_with_id(cx.tcx,
+                                                         enum_did,
+                                                         variant_did);
+                    adt::trans_const(cx, &repr, vinfo.disr_val, [])
                 }
                 Some(ast::def_struct(_)) => {
                     let ety = ty::expr_ty(cx.tcx, e);
@@ -478,52 +454,31 @@ fn const_expr_unchecked(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                     C_null(llty)
                 }
                 _ => {
-                    cx.sess.span_bug(e.span,
-                                     ~"expected a const, fn, or variant def")
+                    cx.sess.span_bug(e.span, ~"expected a const, fn, \
+                                               struct, or variant def")
                 }
             }
           }
           ast::expr_call(callee, args, _) => {
-            match cx.tcx.def_map.find(&callee.id) {
-                Some(ast::def_struct(def_id)) => {
-                    let llstructbody =
-                        C_struct(args.map(|a| const_expr(cx, *a)));
-                    if ty::ty_dtor(cx.tcx, def_id).is_present() {
-                        C_struct(~[ llstructbody, C_u8(0) ])
-                    } else {
-                        C_struct(~[ llstructbody ])
-                    }
-                }
-            Some(ast::def_variant(tid, vid)) => {
-                let ety = ty::expr_ty(cx.tcx, e);
-                let univar = ty::enum_is_univariant(cx.tcx, tid);
-                let size = machine::static_size_of_enum(cx, ety);
-
-                let discrim = base::get_discrim_val(cx, e.span, tid, vid);
-                let c_args = C_struct(args.map(|a| const_expr(cx, *a)));
-
-                // FIXME (#1645): enum body alignment is generaly wrong.
-                if !univar {
-                    // Pad out the data to the size of its type_of;
-                    // this is necessary if the enum is contained
-                    // within an aggregate (tuple, struct, vector) so
-                    // that the next element is at the right offset.
-                    let actual_size =
-                        machine::llsize_of_real(cx, llvm::LLVMTypeOf(c_args));
-                    let padding =
-                        C_null(T_array(T_i8(), size - actual_size));
-                    // A packed_struct has an alignment of 1; thus,
-                    // wrapping one around c_args will misalign it the
-                    // same way we normally misalign enum bodies
-                    // without affecting its internal alignment or
-                    // changing the alignment of the enum.
-                    C_struct(~[discrim, C_packed_struct(~[c_args]), padding])
-                } else {
-                    C_struct(~[c_args])
-                }
-            }
-                _ => cx.sess.span_bug(e.span, ~"expected a struct def")
-            }
+              match cx.tcx.def_map.find(&callee.id) {
+                  Some(ast::def_struct(_)) => {
+                      let ety = ty::expr_ty(cx.tcx, e);
+                      let repr = adt::represent_type(cx, ety);
+                      adt::trans_const(cx, &repr, 0,
+                                       args.map(|a| const_expr(cx, *a)))
+                  }
+                  Some(ast::def_variant(enum_did, variant_did)) => {
+                      let ety = ty::expr_ty(cx.tcx, e);
+                      let repr = adt::represent_type(cx, ety);
+                      let vinfo = ty::enum_variant_with_id(cx.tcx,
+                                                           enum_did,
+                                                           variant_did);
+                      adt::trans_const(cx, &repr, vinfo.disr_val,
+                                       args.map(|a| const_expr(cx, *a)))
+                  }
+                  _ => cx.sess.span_bug(e.span, ~"expected a struct or \
+                                                  variant def")
+              }
           }
           ast::expr_paren(e) => { return const_expr(cx, e); }
           _ => cx.sess.span_bug(e.span,

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -679,7 +679,7 @@ pub impl Datum {
                 }
 
                 let repr = adt::represent_type(ccx, self.ty);
-                assert adt::is_newtypeish(&repr);
+                assert adt::is_newtypeish(repr);
                 let ty = ty::subst(ccx.tcx, substs, variants[0].args[0]);
                 return match self.mode {
                     ByRef => {
@@ -687,7 +687,7 @@ pub impl Datum {
                         // rather than a ptr to the enum type.
                         (
                             Some(Datum {
-                                val: adt::trans_GEP(bcx, &repr, self.val,
+                                val: adt::trans_GEP(bcx, repr, self.val,
                                                     0, 0),
                                 ty: ty,
                                 mode: ByRef,
@@ -719,7 +719,7 @@ pub impl Datum {
                 }
 
                 let repr = adt::represent_type(ccx, self.ty);
-                assert adt::is_newtypeish(&repr);
+                assert adt::is_newtypeish(repr);
                 let ty = fields[0].mt.ty;
                 return match self.mode {
                     ByRef => {
@@ -729,7 +729,7 @@ pub impl Datum {
                         // destructors.
                         (
                             Some(Datum {
-                                val: adt::trans_GEP(bcx, &repr, self.val,
+                                val: adt::trans_GEP(bcx, repr, self.val,
                                                     0, 0),
                                 ty: ty,
                                 mode: ByRef,

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -687,7 +687,7 @@ pub impl Datum {
                         // rather than a ptr to the enum type.
                         (
                             Some(Datum {
-                                val: adt::trans_GEP(bcx, repr, self.val,
+                                val: adt::trans_field_ptr(bcx, repr, self.val,
                                                     0, 0),
                                 ty: ty,
                                 mode: ByRef,
@@ -729,7 +729,7 @@ pub impl Datum {
                         // destructors.
                         (
                             Some(Datum {
-                                val: adt::trans_GEP(bcx, repr, self.val,
+                                val: adt::trans_field_ptr(bcx, repr, self.val,
                                                     0, 0),
                                 ty: ty,
                                 mode: ByRef,

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -511,14 +511,13 @@ pub impl Datum {
         }
     }
 
-    fn GEPi(&self, bcx: block,
-            ixs: &[uint],
-            ty: ty::t,
-            source: DatumCleanup)
-         -> Datum {
+    fn get_element(&self, bcx: block,
+                   ty: ty::t,
+                   source: DatumCleanup,
+                   gep: fn(ValueRef) -> ValueRef) -> Datum {
         let base_val = self.to_ref_llval(bcx);
         Datum {
-            val: GEPi(bcx, base_val, ixs),
+            val: gep(base_val),
             mode: ByRef,
             ty: ty,
             source: source

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -90,6 +90,7 @@ use core::prelude::*;
 use lib;
 use lib::llvm::ValueRef;
 use middle::borrowck::{RootInfo, root_map_key};
+use middle::trans::adt;
 use middle::trans::base::*;
 use middle::trans::build::*;
 use middle::trans::callee;
@@ -677,15 +678,17 @@ pub impl Datum {
                     return (None, bcx);
                 }
 
+                let repr = adt::represent_type(ccx, self.ty);
+                assert adt::is_newtypeish(&repr);
                 let ty = ty::subst(ccx.tcx, substs, variants[0].args[0]);
                 return match self.mode {
                     ByRef => {
                         // Recast lv.val as a pointer to the newtype
                         // rather than a ptr to the enum type.
-                        let llty = T_ptr(type_of::type_of(ccx, ty));
                         (
                             Some(Datum {
-                                val: PointerCast(bcx, self.val, llty),
+                                val: adt::trans_GEP(bcx, &repr, self.val,
+                                                    0, 0),
                                 ty: ty,
                                 mode: ByRef,
                                 source: ZeroMem
@@ -715,6 +718,8 @@ pub impl Datum {
                     return (None, bcx);
                 }
 
+                let repr = adt::represent_type(ccx, self.ty);
+                assert adt::is_newtypeish(&repr);
                 let ty = fields[0].mt.ty;
                 return match self.mode {
                     ByRef => {
@@ -724,7 +729,8 @@ pub impl Datum {
                         // destructors.
                         (
                             Some(Datum {
-                                val: GEPi(bcx, self.val, [0, 0, 0]),
+                                val: adt::trans_GEP(bcx, &repr, self.val,
+                                                    0, 0),
                                 ty: ty,
                                 mode: ByRef,
                                 source: ZeroMem

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -604,7 +604,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
         }
         ast::expr_tup(ref args) => {
             let repr = adt::represent_type(bcx.ccx(), expr_ty(bcx, expr));
-            return trans_adt(bcx, &repr, 0, args.mapi(|i, arg| (i, *arg)),
+            return trans_adt(bcx, repr, 0, args.mapi(|i, arg| (i, *arg)),
                              None, dest);
         }
         ast::expr_lit(@codemap::spanned {node: ast::lit_str(s), _}) => {
@@ -726,7 +726,7 @@ fn trans_def_dps_unadjusted(bcx: block, ref_expr: @ast::expr,
                 // Nullary variant.
                 let ty = expr_ty(bcx, ref_expr);
                 let repr = adt::represent_type(ccx, ty);
-                adt::trans_set_discr(bcx, &repr, lldest,
+                adt::trans_set_discr(bcx, repr, lldest,
                                      variant_info.disr_val);
                 return bcx;
             }
@@ -891,7 +891,7 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
                 datum: do base_datum.get_element(bcx,
                                                  field_tys[ix].mt.ty,
                                                  ZeroMem) |srcval| {
-                    adt::trans_GEP(bcx, &repr, srcval, discr, ix)
+                    adt::trans_GEP(bcx, repr, srcval, discr, ix)
                 },
                 bcx: bcx
             }
@@ -1192,7 +1192,7 @@ fn trans_rec_or_struct(bcx: block,
         };
 
         let repr = adt::represent_type(bcx.ccx(), ty);
-        trans_adt(bcx, &repr, discr, numbered_fields, optbase, dest)
+        trans_adt(bcx, repr, discr, numbered_fields, optbase, dest)
     }
 }
 
@@ -1645,7 +1645,7 @@ fn trans_imm_cast(bcx: block, expr: @ast::expr,
             (cast_enum, cast_float) => {
                 let bcx = bcx;
                 let repr = adt::represent_type(ccx, t_in);
-                let lldiscrim_a = adt::trans_cast_to_int(bcx, &repr, llexpr);
+                let lldiscrim_a = adt::trans_cast_to_int(bcx, repr, llexpr);
                 match k_out {
                     cast_integral => int_cast(bcx, ll_t_out,
                                               val_ty(lldiscrim_a),

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1645,7 +1645,7 @@ fn trans_imm_cast(bcx: block, expr: @ast::expr,
             (cast_enum, cast_float) => {
                 let bcx = bcx;
                 let repr = adt::represent_type(ccx, t_in);
-                let lldiscrim_a = adt::trans_cast_to_int(bcx, repr, llexpr);
+                let lldiscrim_a = adt::trans_get_discr(bcx, repr, llexpr);
                 match k_out {
                     cast_integral => int_cast(bcx, ll_t_out,
                                               val_ty(lldiscrim_a),

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -722,14 +722,12 @@ fn trans_def_dps_unadjusted(bcx: block, ref_expr: @ast::expr,
                 let fn_data = callee::trans_fn_ref(bcx, vid, ref_expr.id);
                 Store(bcx, fn_data.llfn, lldest);
                 return bcx;
-            } else if !ty::enum_is_univariant(ccx.tcx, tid) {
-                // Nullary variant.
-                let lldiscrimptr = GEPi(bcx, lldest, [0u, 0u]);
-                let lldiscrim = C_int(bcx.ccx(), variant_info.disr_val);
-                Store(bcx, lldiscrim, lldiscrimptr);
-                return bcx;
             } else {
-                // Nullary univariant.
+                // Nullary variant.
+                let ty = expr_ty(bcx, ref_expr);
+                let repr = adt::represent_type(ccx, ty);
+                adt::trans_set_discr(bcx, &repr, lldest,
+                                     variant_info.disr_val);
                 return bcx;
             }
         }

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -468,7 +468,8 @@ pub fn trans_struct_drop(bcx: block,
                          substs: &ty::substs,
                          take_ref: bool)
                       -> block {
-    let drop_flag = GEPi(bcx, v0, struct_dtor());
+    let repr = adt::represent_type(bcx.ccx(), t);
+    let drop_flag = adt::trans_drop_flag_ptr(bcx, &repr, v0);
     do with_cond(bcx, IsNotNull(bcx, Load(bcx, drop_flag))) |cx| {
         let mut bcx = cx;
 
@@ -502,7 +503,6 @@ pub fn trans_struct_drop(bcx: block,
         Call(bcx, dtor_addr, args);
 
         // Drop the fields
-        let repr = adt::represent_type(bcx.ccx(), t);
         let field_tys =
             ty::struct_mutable_fields(bcx.tcx(), class_did,
                                               substs);

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -507,7 +507,7 @@ pub fn trans_struct_drop(bcx: block,
             ty::struct_mutable_fields(bcx.tcx(), class_did,
                                               substs);
         for vec::eachi(field_tys) |i, fld| {
-            let llfld_a = adt::trans_GEP(bcx, repr, v0, 0, i);
+            let llfld_a = adt::trans_field_ptr(bcx, repr, v0, 0, i);
             bcx = drop_ty(bcx, llfld_a, fld.mt.ty);
         }
 

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -469,7 +469,7 @@ pub fn trans_struct_drop(bcx: block,
                          take_ref: bool)
                       -> block {
     let repr = adt::represent_type(bcx.ccx(), t);
-    let drop_flag = adt::trans_drop_flag_ptr(bcx, &repr, v0);
+    let drop_flag = adt::trans_drop_flag_ptr(bcx, repr, v0);
     do with_cond(bcx, IsNotNull(bcx, Load(bcx, drop_flag))) |cx| {
         let mut bcx = cx;
 
@@ -507,7 +507,7 @@ pub fn trans_struct_drop(bcx: block,
             ty::struct_mutable_fields(bcx.tcx(), class_did,
                                               substs);
         for vec::eachi(field_tys) |i, fld| {
-            let llfld_a = adt::trans_GEP(bcx, &repr, v0, 0, i);
+            let llfld_a = adt::trans_GEP(bcx, repr, v0, 0, i);
             bcx = drop_ty(bcx, llfld_a, fld.mt.ty);
         }
 

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -19,6 +19,7 @@ use back::link::*;
 use driver::session;
 use lib;
 use lib::llvm::{llvm, ValueRef, TypeRef, True};
+use middle::trans::adt;
 use middle::trans::base::*;
 use middle::trans::callee;
 use middle::trans::closure;
@@ -447,10 +448,10 @@ pub fn make_free_glue(bcx: block, v: ValueRef, t: ty::t) {
         match ty::ty_dtor(bcx.tcx(), did) {
             ty::NoDtor => bcx,
             ty::LegacyDtor(ref dt_id) => {
-                trans_struct_drop(bcx, v, *dt_id, did, substs, false)
+                trans_struct_drop(bcx, t, v, *dt_id, did, substs, false)
             }
             ty::TraitDtor(ref dt_id) => {
-                trans_struct_drop(bcx, v, *dt_id, did, substs, true)
+                trans_struct_drop(bcx, t, v, *dt_id, did, substs, true)
             }
         }
       }
@@ -460,6 +461,7 @@ pub fn make_free_glue(bcx: block, v: ValueRef, t: ty::t) {
 }
 
 pub fn trans_struct_drop(bcx: block,
+                         t: ty::t,
                          v0: ValueRef,
                          dtor_did: ast::def_id,
                          class_did: ast::def_id,
@@ -500,11 +502,12 @@ pub fn trans_struct_drop(bcx: block,
         Call(bcx, dtor_addr, args);
 
         // Drop the fields
+        let repr = adt::represent_type(bcx.ccx(), t);
         let field_tys =
             ty::struct_mutable_fields(bcx.tcx(), class_did,
                                               substs);
         for vec::eachi(field_tys) |i, fld| {
-            let llfld_a = GEPi(bcx, v0, struct_field(i));
+            let llfld_a = adt::trans_GEP(bcx, &repr, v0, 0, i);
             bcx = drop_ty(bcx, llfld_a, fld.mt.ty);
         }
 
@@ -534,10 +537,10 @@ pub fn make_drop_glue(bcx: block, v0: ValueRef, t: ty::t) {
         let tcx = bcx.tcx();
         match ty::ty_dtor(tcx, did) {
           ty::TraitDtor(dtor) => {
-            trans_struct_drop(bcx, v0, dtor, did, substs, true)
+            trans_struct_drop(bcx, t, v0, dtor, did, substs, true)
           }
           ty::LegacyDtor(dtor) => {
-            trans_struct_drop(bcx, v0, dtor, did, substs, false)
+            trans_struct_drop(bcx, t, v0, dtor, did, substs, false)
           }
           ty::NoDtor => {
             // No dtor? Just the default case

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -196,8 +196,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
         match (*v).node.kind {
             ast::tuple_variant_kind(ref args) => {
                 trans_enum_variant(ccx, enum_item.id, *v, /*bad*/copy *args,
-                                   this_tv.disr_val, tvs.len() == 1u,
-                                   psubsts, d);
+                                   this_tv.disr_val, psubsts, d);
             }
             ast::struct_variant_kind(_) =>
                 ccx.tcx.sess.bug(~"can't monomorphize struct variants"),

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -15,12 +15,10 @@ use middle::trans::adt;
 use middle::trans::base;
 use middle::trans::common::*;
 use middle::trans::common;
-use middle::trans::machine;
 use middle::ty;
 use util::ppaux;
 
 use core::option::None;
-use core::vec;
 use syntax::ast;
 
 pub fn type_of_explicit_arg(ccx: @CrateContext, arg: ty::arg) -> TypeRef {

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -11,6 +11,7 @@
 
 use lib::llvm::llvm;
 use lib::llvm::{TypeRef};
+use middle::trans::adt;
 use middle::trans::base;
 use middle::trans::common::*;
 use middle::trans::common;
@@ -143,31 +144,11 @@ pub fn sizing_type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
 
         ty::ty_unboxed_vec(mt) => T_vec(cx, sizing_type_of(cx, mt.ty)),
 
-        ty::ty_tup(ref elems) => {
-            T_struct(elems.map(|&t| sizing_type_of(cx, t)))
+        ty::ty_tup(*) | ty::ty_rec(*) | ty::ty_struct(*)
+        | ty::ty_enum(*) => {
+            let repr = adt::represent_type(cx, t);
+            T_struct(adt::sizing_fields_of(cx, &repr))
         }
-
-        ty::ty_rec(ref fields) => {
-            T_struct(fields.map(|f| sizing_type_of(cx, f.mt.ty)))
-        }
-
-        ty::ty_struct(def_id, ref substs) => {
-            let fields = ty::lookup_struct_fields(cx.tcx, def_id);
-            let lltype = T_struct(fields.map(|field| {
-                let field_type = ty::lookup_field_type(cx.tcx,
-                                                       def_id,
-                                                       field.id,
-                                                       substs);
-                sizing_type_of(cx, field_type)
-            }));
-            if ty::ty_dtor(cx.tcx, def_id).is_present() {
-                T_struct(~[lltype, T_i8()])
-            } else {
-                lltype
-            }
-        }
-
-        ty::ty_enum(def_id, _) => T_struct(enum_body_types(cx, def_id, t)),
 
         ty::ty_self | ty::ty_infer(*) | ty::ty_param(*) | ty::ty_err(*) => {
             cx.tcx.sess.bug(
@@ -257,28 +238,13 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
         T_array(type_of(cx, mt.ty), n)
       }
 
-      ty::ty_rec(fields) => {
-        let mut tys: ~[TypeRef] = ~[];
-        for vec::each(fields) |f| {
-            let mt_ty = f.mt.ty;
-            tys.push(type_of(cx, mt_ty));
-        }
-
-        // n.b.: introduce an extra layer of indirection to match
-        // structs
-        T_struct(~[T_struct(tys)])
-      }
-
       ty::ty_bare_fn(_) => T_ptr(type_of_fn_from_ty(cx, t)),
       ty::ty_closure(_) => T_fn_pair(cx, type_of_fn_from_ty(cx, t)),
       ty::ty_trait(_, _, vstore) => T_opaque_trait(cx, vstore),
       ty::ty_type => T_ptr(cx.tydesc_type),
-      ty::ty_tup(elts) => {
-        let mut tys = ~[];
-        for vec::each(elts) |elt| {
-            tys.push(type_of(cx, *elt));
-        }
-        T_struct(tys)
+      ty::ty_tup(*) | ty::ty_rec(*) => {
+          let repr = adt::represent_type(cx, t);
+          T_struct(adt::fields_of(cx, &repr))
       }
       ty::ty_opaque_closure_ptr(_) => T_opaque_box_ptr(cx),
       ty::ty_struct(did, ref substs) => {
@@ -301,57 +267,14 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
 
     // If this was an enum or struct, fill in the type now.
     match ty::get(t).sty {
-      ty::ty_enum(did, _) => {
-        fill_type_of_enum(cx, did, t, llty);
-      }
-      ty::ty_struct(did, ref substs) => {
-        // Only instance vars are record fields at runtime.
-        let fields = ty::lookup_struct_fields(cx.tcx, did);
-        let mut tys = do vec::map(fields) |f| {
-            let t = ty::lookup_field_type(cx.tcx, did, f.id, substs);
-            type_of(cx, t)
-        };
-
-        // include a byte flag if there is a dtor so that we know when we've
-        // been dropped
-        if ty::ty_dtor(cx.tcx, did).is_present() {
-            common::set_struct_body(llty, ~[T_struct(tys), T_i8()]);
-        } else {
-            common::set_struct_body(llty, ~[T_struct(tys)]);
-        }
+      ty::ty_enum(*) | ty::ty_struct(*) => {
+          let repr = adt::represent_type(cx, t);
+          common::set_struct_body(llty, adt::fields_of(cx, &repr));
       }
       _ => ()
     }
 
     return llty;
-}
-
-pub fn enum_body_types(cx: @CrateContext, did: ast::def_id, t: ty::t)
-                    -> ~[TypeRef] {
-    let univar = ty::enum_is_univariant(cx.tcx, did);
-    if !univar {
-        let size = machine::static_size_of_enum(cx, t);
-        ~[T_enum_discrim(cx), T_array(T_i8(), size)]
-    }
-    else {
-        // Use the actual fields, so we get the alignment right.
-        match ty::get(t).sty {
-            ty::ty_enum(_, ref substs) => {
-                do ty::enum_variants(cx.tcx, did)[0].args.map |&field_ty| {
-                    sizing_type_of(cx, ty::subst(cx.tcx, substs, field_ty))
-                }
-            }
-            _ => cx.sess.bug(~"enum is not an enum")
-        }
-    }
-}
-
-pub fn fill_type_of_enum(cx: @CrateContext,
-                         did: ast::def_id,
-                         t: ty::t,
-                         llty: TypeRef) {
-    debug!("type_of_enum %?: %?", t, ty::get(t));
-    common::set_struct_body(llty, enum_body_types(cx, did, t));
 }
 
 // Want refinements! (Or case classes, I guess

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -147,7 +147,7 @@ pub fn sizing_type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
         ty::ty_tup(*) | ty::ty_rec(*) | ty::ty_struct(*)
         | ty::ty_enum(*) => {
             let repr = adt::represent_type(cx, t);
-            T_struct(adt::sizing_fields_of(cx, &repr))
+            T_struct(adt::sizing_fields_of(cx, repr))
         }
 
         ty::ty_self | ty::ty_infer(*) | ty::ty_param(*) | ty::ty_err(*) => {
@@ -244,7 +244,7 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
       ty::ty_type => T_ptr(cx.tydesc_type),
       ty::ty_tup(*) | ty::ty_rec(*) => {
           let repr = adt::represent_type(cx, t);
-          T_struct(adt::fields_of(cx, &repr))
+          T_struct(adt::fields_of(cx, repr))
       }
       ty::ty_opaque_closure_ptr(_) => T_opaque_box_ptr(cx),
       ty::ty_struct(did, ref substs) => {
@@ -269,7 +269,7 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
     match ty::get(t).sty {
       ty::ty_enum(*) | ty::ty_struct(*) => {
           let repr = adt::represent_type(cx, t);
-          common::set_struct_body(llty, adt::fields_of(cx, &repr));
+          common::set_struct_body(llty, adt::fields_of(cx, repr));
       }
       _ => ()
     }

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -65,6 +65,7 @@ pub mod middle {
         pub mod type_use;
         pub mod reachable;
         pub mod machine;
+        pub mod adt;
     }
     pub mod ty;
     pub mod resolve;

--- a/src/test/run-pass/const-enum-structlike.rs
+++ b/src/test/run-pass/const-enum-structlike.rs
@@ -1,0 +1,23 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E {
+    S0 { s: ~str },
+    S1 { u: uint }
+}
+
+const C: E = S1 { u: 23 };
+
+fn main() {
+    match C {
+        S0 { _ } => fail!(),
+        S1 { u } => assert u == 23
+    }
+}

--- a/src/test/run-pass/enum-discrim-range-overflow.rs
+++ b/src/test/run-pass/enum-discrim-range-overflow.rs
@@ -1,0 +1,31 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub enum E64 {
+	H64 = 0x7FFF_FFFF_FFFF_FFFF,
+	L64 = 0x8000_0000_0000_0000
+}
+pub enum E32 {
+	H32 = 0x7FFF_FFFF,
+	L32 = 0x8000_0000
+}
+
+pub fn f(e64: E64, e32: E32) -> (bool,bool) {
+	(match e64 {
+		H64 => true,
+		L64 => false
+	},
+	 match e32 {
+		H32 => true,
+		L32 => false
+	})
+}
+
+pub fn main() { }

--- a/src/test/run-pass/struct-order-of-eval-1.rs
+++ b/src/test/run-pass/struct-order-of-eval-1.rs
@@ -1,0 +1,16 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct S { f0: ~str, f1: int }
+
+pub fn main() {
+    let s = ~"Hello, world!";
+    let _s = S { f0: str::from_slice(s), ..S { f0: s, f1: 23 } };
+}

--- a/src/test/run-pass/struct-order-of-eval-2.rs
+++ b/src/test/run-pass/struct-order-of-eval-2.rs
@@ -1,0 +1,16 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct S { f0: ~str, f1: ~str }
+
+pub fn main() {
+    let s = ~"Hello, world!";
+    let _s = S { f1: str::from_slice(s), f0: s };
+}


### PR DESCRIPTION
This series of changes moves the representation details of algebraic datatypes (enums, and special cases like structs and tuples and (until they're fully removed) records) from various places around rustc::middle::trans into a single module, to enable future improvements in this area.

r?(@nikomatsakis), and the core developers in general; this seems like a “super-review” kind of change.
