### PR TITLE
doc/rust.md: Demonstrate the `f::<T>()` syntax more often

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -908,6 +908,11 @@ function defined above on `[1, 2]` will instantiate type parameter `T`
 with `int`, and require the closure parameter to have type
 `fn(int)`.
 
+The type parameters can also be explicitly supplied in a trailing
+[path](#paths) component after the function name. This might be necessary
+if there is not sufficient context to determine the type parameters. For
+example, `sys::size_of::<u32>() == 4`.
+
 Since a parameter type is opaque to the generic function, the set of
 operations that can be performed on it is limited. Values of parameter
 type can always be moved, but they can only be copied when the
@@ -2040,12 +2045,14 @@ an optional reference slot to serve as the function's output, bound to the
 `lval` on the right hand side of the call. If the function eventually returns,
 then the expression completes.
 
-An example of a call expression:
+Some examples of call expressions:
 
 ~~~~
 # fn add(x: int, y: int) -> int { 0 }
+# use core::from_str::FromStr::from_str;
 
 let x: int = add(1, 2);
+let pi = from_str::<f32>("3.14");
 ~~~~
 
 ### Lambda expressions


### PR DESCRIPTION
I have seen a few people confused on how to explicitly instantiate generic functions, since the syntax differs from C++'s and C#'s, which is probably where most people asking questions about generic functions are coming from. The only use of the `::<T>` syntax in the reference right now is in the section on paths, which is possibly not where someone trying to find out about generic functions is going to start looking. The tutorial doesn't mention it at all, but I think it's all right to make the reference a tiny bit more redundant and avoid stuffing the tutorial with syntax details.

---

The "Generic functions" subsection mentions that generic functions are instantiated based on context, so let's also mention right away (with a link to the #paths section) that an explicit form is available.

This also adds an example that explicitly instantiates a generic function to the function call expression section.
