### PR TITLE
Avoid calling to_vec() unnecessarily in parser.

### DIFF
--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -730,7 +730,7 @@ pub fn trans_arg_expr(bcx: block,
 
                     ast::by_copy => {
                         debug!("by copy arg with type %s, storing to scratch",
-                               ty_to_str(ccx.tcx, arg_datum.ty));
+                               bcx.ty_to_str(arg_datum.ty));
                         let scratch = scratch_datum(bcx, arg_datum.ty, false);
 
                         arg_datum.store_to_datum(bcx, arg_expr.id,

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -460,8 +460,8 @@ fn mk_impl(
     let ty = cx.ty_path(
         span,
         ~[ident],
-        generics.ty_params.map(
-            |tp| cx.ty_path(span, ~[tp.ident], ~[])).to_vec()
+        opt_vec::take_vec(generics.ty_params.map(
+            |tp| cx.ty_path(span, ~[tp.ident], ~[])))
     );
 
     let generics = ast::Generics {

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -394,13 +394,15 @@ impl ext_ctxt_ast_builder for ext_ctxt {
     }
 
     fn ty_vars(&self, ty_params: &OptVec<ast::TyParam>) -> ~[@ast::Ty] {
-        ty_params.map(|p| self.ty_path_ast_builder(
-            path(~[p.ident], dummy_sp()))).to_vec()
+        opt_vec::take_vec(
+            ty_params.map(|p| self.ty_path_ast_builder(
+                path(~[p.ident], dummy_sp()))))
     }
 
     fn ty_vars_global(&self,
                       ty_params: &OptVec<ast::TyParam>) -> ~[@ast::Ty] {
-        ty_params.map(|p| self.ty_path_ast_builder(
-            path(~[p.ident], dummy_sp()))).to_vec()
+        opt_vec::take_vec(
+            ty_params.map(|p| self.ty_path_ast_builder(
+                path(~[p.ident], dummy_sp()))))
     }
 }

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -31,6 +31,14 @@ pub fn with<T>(+t: T) -> OptVec<T> {
     Vec(~[t])
 }
 
+pub fn from<T>(+t: ~[T]) -> OptVec<T> {
+    if t.len() == 0 {
+        Empty
+    } else {
+        Vec(t)
+    }
+}
+
 impl<T> OptVec<T> {
     fn push(&mut self, +t: T) {
         match *self {
@@ -70,12 +78,12 @@ impl<T> OptVec<T> {
             Vec(ref v) => v.len()
         }
     }
+}
 
-    pure fn to_vec(self) -> ~[T] {
-        match self {
-            Empty => ~[],
-            Vec(v) => v
-        }
+pub fn take_vec<T>(+v: OptVec<T>) -> ~[T] {
+    match v {
+        Empty => ~[],
+        Vec(v) => v
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1157,7 +1157,7 @@ pub impl Parser {
                     let remaining_exprs =
                         self.parse_seq_to_end(token::RBRACKET,
                             seq_sep_trailing_allowed(token::COMMA),
-                            |p| p.parse_expr()).to_vec();
+                            |p| p.parse_expr());
                     ex = expr_vec(~[first_expr] + remaining_exprs, mutbl);
                 } else {
                     // Vector with one element.
@@ -1419,7 +1419,7 @@ pub impl Parser {
                 vec::append(
                     self.parse_seq_to_before_end(
                         ket, seq_sep_none(),
-                        |p| p.parse_token_tree()).to_vec(),
+                        |p| p.parse_token_tree()),
                     // the close delimiter:
                     ~[parse_any_tt_tok(self)])))
           }
@@ -2727,7 +2727,7 @@ pub impl Parser {
         let result = self.parse_seq_to_gt(
             Some(token::COMMA),
             |p| p.parse_ty(false));
-        result.to_vec()
+        opt_vec::take_vec(result)
     }
 
     fn parse_fn_decl(parse_arg_fn: fn(Parser) -> arg_or_capture_item)
@@ -2819,7 +2819,7 @@ pub impl Parser {
                     args_or_capture_items =
                         self.parse_seq_to_before_end(token::RPAREN,
                                                      sep,
-                                                     parse_arg_fn).to_vec();
+                                                     parse_arg_fn);
                 }
                 token::RPAREN => {
                     args_or_capture_items = ~[];
@@ -2835,7 +2835,7 @@ pub impl Parser {
             args_or_capture_items =
                 self.parse_seq_to_before_end(token::RPAREN,
                                              sep,
-                                             parse_arg_fn).to_vec();
+                                             parse_arg_fn);
         }
 
         self.expect(token::RPAREN);
@@ -3032,7 +3032,7 @@ pub impl Parser {
     fn parse_trait_ref_list(ket: token::Token) -> ~[@trait_ref] {
         self.parse_seq_to_before_end(
             ket, seq_sep_none(),
-            |p| p.parse_trait_ref()).to_vec()
+            |p| p.parse_trait_ref())
     }
 
     fn parse_item_struct() -> item_info {


### PR DESCRIPTION
Also, rename the OptVec-to-vector conversion method to
opt_vec::take_vec() and convert from a method into a fn
because I fear strange bugs.

This makes the deep-vector test cases parse much faster.
