### PR TITLE
add a TotalOrd trait and reimplement TreeMap with it

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -37,6 +37,70 @@ pub trait Eq {
     pure fn ne(&self, other: &Self) -> bool;
 }
 
+#[deriving_eq]
+pub enum Ordering { Less, Equal, Greater }
+
+/// Trait for types that form a total order
+pub trait TotalOrd {
+    pure fn cmp(&self, other: &Self) -> Ordering;
+}
+
+pure fn icmp<T: Ord>(a: &T, b: &T) -> Ordering {
+    if *a < *b { Less }
+    else if *a > *b { Greater }
+    else { Equal }
+}
+
+impl TotalOrd for u8 {
+    #[inline(always)]
+    pure fn cmp(&self, other: &u8) -> Ordering { icmp(self, other) }
+}
+
+impl TotalOrd for u16 {
+    #[inline(always)]
+    pure fn cmp(&self, other: &u16) -> Ordering { icmp(self, other) }
+}
+
+impl TotalOrd for u32 {
+    #[inline(always)]
+    pure fn cmp(&self, other: &u32) -> Ordering { icmp(self, other) }
+}
+
+impl TotalOrd for u64 {
+    #[inline(always)]
+    pure fn cmp(&self, other: &u64) -> Ordering { icmp(self, other) }
+}
+
+impl TotalOrd for i8 {
+    #[inline(always)]
+    pure fn cmp(&self, other: &i8) -> Ordering { icmp(self, other) }
+}
+
+impl TotalOrd for i16 {
+    #[inline(always)]
+    pure fn cmp(&self, other: &i16) -> Ordering { icmp(self, other) }
+}
+
+impl TotalOrd for i32 {
+    #[inline(always)]
+    pure fn cmp(&self, other: &i32) -> Ordering { icmp(self, other) }
+}
+
+impl TotalOrd for i64 {
+    #[inline(always)]
+    pure fn cmp(&self, other: &i64) -> Ordering { icmp(self, other) }
+}
+
+impl TotalOrd for int {
+    #[inline(always)]
+    pure fn cmp(&self, other: &int) -> Ordering { icmp(self, other) }
+}
+
+impl TotalOrd for uint {
+    #[inline(always)]
+    pure fn cmp(&self, other: &uint) -> Ordering { icmp(self, other) }
+}
+
 /**
 * Trait for values that can be compared for a sort-order.
 *
@@ -93,4 +157,16 @@ pub pure fn min<T:Ord>(v1: T, v2: T) -> T {
 #[inline(always)]
 pub pure fn max<T:Ord>(v1: T, v2: T) -> T {
     if v1 > v2 { v1 } else { v2 }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_int() {
+        assert 5.cmp(&10) == Less;
+        assert 10.cmp(&5) == Greater;
+        assert 5.cmp(&5) == Equal;
+        assert (-5).cmp(&12) == Less;
+        assert 12.cmp(-5) == Greater;
+    }
 }

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -27,7 +27,7 @@ pub use clone::Clone;
 pub use cmp::{Eq, Ord, TotalOrd, Ordering, Less, Equal, Greater};
 pub use container::{Container, Mutable, Map, Set};
 pub use hash::Hash;
-pub use iter::{BaseIter, ExtendedIter, EqIter, CopyableIter};
+pub use iter::{BaseIter, ReverseIter, ExtendedIter, EqIter, CopyableIter};
 pub use iter::{CopyableOrderedIter, CopyableNonstrictIter, Times};
 pub use num::NumCast;
 pub use path::GenericPath;

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -24,7 +24,7 @@ pub use result::{Result, Ok, Err};
 /* Reexported types and traits */
 
 pub use clone::Clone;
-pub use cmp::{Eq, Ord};
+pub use cmp::{Eq, Ord, TotalOrd, Ordering, Less, Equal, Greater};
 pub use container::{Container, Mutable, Map, Set};
 pub use hash::Hash;
 pub use iter::{BaseIter, ExtendedIter, EqIter, CopyableIter};

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -20,7 +20,7 @@
 use at_vec;
 use cast;
 use char;
-use cmp::{Eq, Ord};
+use cmp::{Eq, Ord, TotalOrd, Ordering, Less, Equal, Greater};
 use libc;
 use libc::size_t;
 use io::WriterUtil;
@@ -771,6 +771,35 @@ pub pure fn eq(a: &~str, b: &~str) -> bool {
 #[cfg(test)]
 pub pure fn eq(a: &~str, b: &~str) -> bool {
     eq_slice(*a, *b)
+}
+
+pure fn cmp(a: &str, b: &str) -> Ordering {
+    let low = uint::min(a.len(), b.len());
+
+    for uint::range(0, low) |idx| {
+        match a[idx].cmp(&b[idx]) {
+          Greater => return Greater,
+          Less => return Less,
+          Equal => ()
+        }
+    }
+
+    a.len().cmp(&b.len())
+}
+
+#[cfg(notest)]
+impl TotalOrd for &str {
+    pure fn cmp(&self, other: & &self/str) -> Ordering { cmp(*self, *other) }
+}
+
+#[cfg(notest)]
+impl TotalOrd for ~str {
+    pure fn cmp(&self, other: &~str) -> Ordering { cmp(*self, *other) }
+}
+
+#[cfg(notest)]
+impl TotalOrd for @str {
+    pure fn cmp(&self, other: &@str) -> Ordering { cmp(*self, *other) }
 }
 
 /// Bytewise slice less than
@@ -2382,6 +2411,7 @@ mod tests {
     use ptr;
     use str::*;
     use vec;
+    use cmp::{TotalOrd, Less, Equal, Greater};
 
     #[test]
     fn test_eq() {
@@ -3388,4 +3418,12 @@ mod tests {
         assert view("abcdef", 1, 5).to_managed() == @"bcde";
     }
 
+    #[test]
+    fn test_total_ord() {
+        "1234".cmp(& &"123") == Greater;
+        "123".cmp(& &"1234") == Less;
+        "1234".cmp(& &"1234") == Equal;
+        "12345555".cmp(& &"123456") == Less;
+        "22".cmp(& &"1234") == Greater;
+    }
 }


### PR DESCRIPTION
This allows `TreeMap`/`TreeSet` to fully express their requirements and reduces the comparisons from ~1.5 per level to 1 which really helps for string keys.

I also added `ReverseIter` to the prelude exports because I forgot when I originally added it.
