### PR TITLE
Better highlight for repeat count error

### DIFF
--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -234,7 +234,7 @@ pub fn check_expr(e: @expr, cx: Context, v: visit::vt<Context>) {
                        "explicit copy requires a copyable argument");
         }
         expr_repeat(element, count_expr, _) => {
-            let count = ty::eval_repeat_count(cx.tcx, count_expr, e.span);
+            let count = ty::eval_repeat_count(cx.tcx, count_expr);
             if count > 1 {
                 let element_ty = ty::expr_ty(cx.tcx, element);
                 check_copy(cx, element_ty, element.span,

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -410,8 +410,7 @@ pub fn write_content(bcx: block,
                     return expr::trans_into(bcx, element, Ignore);
                 }
                 SaveIn(lldest) => {
-                    let count = ty::eval_repeat_count(bcx.tcx(), count_expr,
-                                                      count_expr.span);
+                    let count = ty::eval_repeat_count(bcx.tcx(), count_expr);
                     if count == 0 {
                         return bcx;
                     }
@@ -476,7 +475,7 @@ pub fn elements_required(bcx: block, content_expr: @ast::expr) -> uint {
         },
         ast::expr_vec(es, _) => es.len(),
         ast::expr_repeat(_, count_expr, _) => {
-            ty::eval_repeat_count(bcx.tcx(), count_expr, content_expr.span)
+            ty::eval_repeat_count(bcx.tcx(), count_expr)
         }
         _ => bcx.tcx().sess.span_bug(content_expr.span,
                                      ~"Unexpected evec content")

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4247,35 +4247,32 @@ pub fn normalize_ty(cx: ctxt, t: t) -> t {
 }
 
 // Returns the repeat count for a repeating vector expression.
-pub fn eval_repeat_count(tcx: ctxt,
-                         count_expr: @ast::expr,
-                         span: span)
-                      -> uint {
+pub fn eval_repeat_count(tcx: ctxt, count_expr: @ast::expr) -> uint {
     match const_eval::eval_const_expr_partial(tcx, count_expr) {
       Ok(ref const_val) => match *const_val {
         const_eval::const_int(count) => return count as uint,
         const_eval::const_uint(count) => return count as uint,
         const_eval::const_float(count) => {
-            tcx.sess.span_err(span,
+            tcx.sess.span_err(count_expr.span,
                               ~"expected signed or unsigned integer for \
                                 repeat count but found float");
             return count as uint;
         }
         const_eval::const_str(_) => {
-            tcx.sess.span_err(span,
+            tcx.sess.span_err(count_expr.span,
                               ~"expected signed or unsigned integer for \
                                 repeat count but found string");
             return 0;
         }
         const_eval::const_bool(_) => {
-            tcx.sess.span_err(span,
+            tcx.sess.span_err(count_expr.span,
                               ~"expected signed or unsigned integer for \
                                 repeat count but found boolean");
             return 0;
         }
       },
       Err(*) => {
-        tcx.sess.span_err(span,
+        tcx.sess.span_err(count_expr.span,
                           ~"expected constant integer for repeat count \
                             but found variable");
         return 0;

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2147,7 +2147,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
             ty::mk_evec(tcx, ty::mt {ty: t, mutbl: mutability}, tt)
           }
           ast::expr_repeat(element, count_expr, mutbl) => {
-            let count = ty::eval_repeat_count(tcx, count_expr, expr.span);
+            let count = ty::eval_repeat_count(tcx, count_expr);
             fcx.write_ty(count_expr.id, ty::mk_uint(tcx));
             let tt = ast_expr_vstore_to_vstore(fcx, ev, count, vst);
             let t: ty::t = fcx.infcx().next_ty_var();
@@ -2474,7 +2474,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         fcx.write_ty(id, typ);
       }
       ast::expr_repeat(element, count_expr, mutbl) => {
-        let count = ty::eval_repeat_count(tcx, count_expr, expr.span);
+        let count = ty::eval_repeat_count(tcx, count_expr);
         fcx.write_ty(count_expr.id, ty::mk_uint(tcx));
         let t: ty::t = fcx.infcx().next_ty_var();
         bot |= check_expr_has_type(fcx, element, t);


### PR DESCRIPTION
Before:

```
test.rs:3:21: 3:30 error: expected constant integer for repeat count but found variable
test.rs:3             let a = ~[0, ..n]; //~ ERROR expected constant integer for repeat count but found variable
                              ^~~~~~~~~
```

After:

```
test.rs:3:27: 3:28 error: expected constant integer for repeat count but found variable
test.rs:3             let a = ~[0, ..n]; //~ ERROR expected constant integer for repeat count but found variable
                                     ^
```
