### PR TITLE
libsyntax: add some more explicit copies for vecs_implicitly_copyable)

### DIFF
--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -140,7 +140,7 @@ pub fn count_names(ms: &[matcher]) -> uint {
 }
 
 #[allow(non_implicitly_copyable_typarams)]
-pub fn initial_matcher_pos(+ms: ~[matcher], sep: Option<Token>, lo: BytePos)
+pub fn initial_matcher_pos(+ms: ~[matcher], +sep: Option<Token>, lo: BytePos)
                         -> ~MatcherPos {
     let mut match_idx_hi = 0u;
     for ms.each |elt| {

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -32,7 +32,7 @@ pub fn add_new_extension(cx: ext_ctxt, sp: span, name: ident,
                          arg: ~[ast::token_tree]) -> base::MacResult {
     // these spans won't matter, anyways
     fn ms(m: matcher_) -> matcher {
-        spanned { node: m, span: dummy_sp() }
+        spanned { node: copy m, span: dummy_sp() }
     }
 
     let lhs_nm =  cx.parse_sess().interner.gensym(@~"lhs");

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -85,7 +85,7 @@ pure fn dup_tt_frame(f: @mut TtFrame) -> @mut TtFrame {
         readme: @mut (copy *f.readme),
         idx: f.idx,
         dotdotdoted: f.dotdotdoted,
-        sep: f.sep,
+        sep: copy f.sep,
         up: match f.up {
             Some(up_frame) => Some(dup_tt_frame(up_frame)),
             None => None
@@ -191,7 +191,7 @@ pub fn tt_next_token(r: @mut TtReader) -> TokenAndSpan {
             r.cur.idx = 0u;
             r.repeat_idx[r.repeat_idx.len() - 1u] += 1u;
             match r.cur.sep {
-              Some(tk) => {
+              Some(copy tk) => {
                 r.cur_tok = tk; /* repeat same span, I guess */
                 return ret_val;
               }
@@ -219,7 +219,8 @@ pub fn tt_next_token(r: @mut TtReader) -> TokenAndSpan {
             return ret_val;
           }
           tt_seq(sp, copy tts, copy sep, zerok) => {
-            match lockstep_iter_size(tt_seq(sp, copy tts, sep, zerok), r) {
+            let t = tt_seq(sp, copy tts, copy sep, zerok);
+            match lockstep_iter_size(t, r) {
               lis_unconstrained => {
                 r.sp_diag.span_fatal(
                     sp, /* blame macro writer */
@@ -246,11 +247,11 @@ pub fn tt_next_token(r: @mut TtReader) -> TokenAndSpan {
                     r.repeat_len.push(len);
                     r.repeat_idx.push(0u);
                     r.cur = @mut TtFrame {
-                        readme: @mut copy tts,
+                        readme: @mut tts,
                         idx: 0u,
                         dotdotdoted: true,
                         sep: sep,
-                        up: option::Some(r.cur)
+                        up: Some(r.cur)
                     };
                 }
               }


### PR DESCRIPTION
My merges for #5143 missed a couple other copies. This patch corrects this, and gets stage0 to compile libsyntax with `#[deny(vecs_implicitly_copyable)]`. stage1 still fails though.
