### PR TITLE
inline the implementation of TotalOrd for integers

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -45,6 +45,7 @@ pub trait TotalOrd {
     pure fn cmp(&self, other: &Self) -> Ordering;
 }
 
+#[inline(always)]
 pure fn icmp<T: Ord>(a: &T, b: &T) -> Ordering {
     if *a < *b { Less }
     else if *a > *b { Greater }


### PR DESCRIPTION
minor little performance issue - the vector and string implementations of TotalOrd turn out badly without explicitly inlining this
