### PR TITLE
disable deprecated_self in libsyntax

### DIFF
--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -295,12 +295,16 @@ pub impl CodeMap {
     }
 
     /// Add a new FileMap to the CodeMap and return it
-    fn new_filemap(+filename: FileName, src: @~str) -> @FileMap {
+    fn new_filemap(&self, +filename: FileName, src: @~str) -> @FileMap {
         return self.new_filemap_w_substr(filename, FssNone, src);
     }
 
-    fn new_filemap_w_substr(+filename: FileName, +substr: FileSubstr,
-                            src: @~str) -> @FileMap {
+    fn new_filemap_w_substr(
+        &self,
+        +filename: FileName,
+        +substr: FileSubstr,
+        src: @~str
+    ) -> @FileMap {
         let start_pos = if self.files.len() == 0 {
             0
         } else {

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -223,6 +223,7 @@ pub fn expand_auto_decode(
 
 priv impl ext_ctxt {
     fn bind_path(
+        &self,
         span: span,
         ident: ast::ident,
         path: @ast::path,
@@ -241,7 +242,7 @@ priv impl ext_ctxt {
         }
     }
 
-    fn expr(span: span, +node: ast::expr_) -> @ast::expr {
+    fn expr(&self, span: span, +node: ast::expr_) -> @ast::expr {
         @ast::expr {
             id: self.next_id(),
             callee_id: self.next_id(),
@@ -250,7 +251,7 @@ priv impl ext_ctxt {
         }
     }
 
-    fn path(span: span, +strs: ~[ast::ident]) -> @ast::path {
+    fn path(&self, span: span, +strs: ~[ast::ident]) -> @ast::path {
         @ast::path {
             span: span,
             global: false,
@@ -260,7 +261,7 @@ priv impl ext_ctxt {
         }
     }
 
-    fn path_global(span: span, +strs: ~[ast::ident]) -> @ast::path {
+    fn path_global(&self, span: span, +strs: ~[ast::ident]) -> @ast::path {
         @ast::path {
             span: span,
             global: true,
@@ -271,6 +272,7 @@ priv impl ext_ctxt {
     }
 
     fn path_tps(
+        &self,
         span: span,
         +strs: ~[ast::ident],
         +tps: ~[@ast::Ty]
@@ -285,6 +287,7 @@ priv impl ext_ctxt {
     }
 
     fn path_tps_global(
+        &self,
         span: span,
         +strs: ~[ast::ident],
         +tps: ~[@ast::Ty]
@@ -299,6 +302,7 @@ priv impl ext_ctxt {
     }
 
     fn ty_path(
+        &self,
         span: span,
         +strs: ~[ast::ident],
         +tps: ~[@ast::Ty]
@@ -312,7 +316,7 @@ priv impl ext_ctxt {
         }
     }
 
-    fn binder_pat(span: span, nm: ast::ident) -> @ast::pat {
+    fn binder_pat(&self, span: span, nm: ast::ident) -> @ast::pat {
         @ast::pat {
             id: self.next_id(),
             node: ast::pat_ident(
@@ -323,12 +327,12 @@ priv impl ext_ctxt {
         }
     }
 
-    fn stmt(expr: @ast::expr) -> @ast::stmt {
+    fn stmt(&self, expr: @ast::expr) -> @ast::stmt {
         @codemap::spanned { node: ast::stmt_semi(expr, self.next_id()),
                        span: expr.span }
     }
 
-    fn lit_str(span: span, s: @~str) -> @ast::expr {
+    fn lit_str(&self, span: span, s: @~str) -> @ast::expr {
         self.expr(
             span,
             ast::expr_vstore(
@@ -340,7 +344,7 @@ priv impl ext_ctxt {
                 ast::expr_vstore_uniq))
     }
 
-    fn lit_uint(span: span, i: uint) -> @ast::expr {
+    fn lit_uint(&self, span: span, i: uint) -> @ast::expr {
         self.expr(
             span,
             ast::expr_lit(
@@ -348,13 +352,13 @@ priv impl ext_ctxt {
                                 span: span}))
     }
 
-    fn lambda(+blk: ast::blk) -> @ast::expr {
-        let ext_cx = self;
+    fn lambda(&self, +blk: ast::blk) -> @ast::expr {
+        let ext_cx = *self;
         let blk_e = self.expr(copy blk.span, ast::expr_block(copy blk));
         quote_expr!( || $blk_e )
     }
 
-    fn blk(span: span, +stmts: ~[@ast::stmt]) -> ast::blk {
+    fn blk(&self, span: span, +stmts: ~[@ast::stmt]) -> ast::blk {
         codemap::spanned {
             node: ast::blk_ {
                 view_items: ~[],
@@ -367,7 +371,7 @@ priv impl ext_ctxt {
         }
     }
 
-    fn expr_blk(expr: @ast::expr) -> ast::blk {
+    fn expr_blk(&self, expr: @ast::expr) -> ast::blk {
         codemap::spanned {
             node: ast::blk_ {
                 view_items: ~[],
@@ -380,19 +384,24 @@ priv impl ext_ctxt {
         }
     }
 
-    fn expr_path(span: span, +strs: ~[ast::ident]) -> @ast::expr {
+    fn expr_path(&self, span: span, +strs: ~[ast::ident]) -> @ast::expr {
         self.expr(span, ast::expr_path(self.path(span, strs)))
     }
 
-    fn expr_path_global(span: span, +strs: ~[ast::ident]) -> @ast::expr {
+    fn expr_path_global(
+        &self,
+        span: span,
+        +strs: ~[ast::ident]
+    ) -> @ast::expr {
         self.expr(span, ast::expr_path(self.path_global(span, strs)))
     }
 
-    fn expr_var(span: span, +var: ~str) -> @ast::expr {
+    fn expr_var(&self, span: span, +var: ~str) -> @ast::expr {
         self.expr_path(span, ~[self.ident_of(var)])
     }
 
     fn expr_field(
+        &self,
         span: span,
         expr: @ast::expr,
         ident: ast::ident
@@ -401,6 +410,7 @@ priv impl ext_ctxt {
     }
 
     fn expr_call(
+        &self,
         span: span,
         expr: @ast::expr,
         +args: ~[@ast::expr]
@@ -408,11 +418,11 @@ priv impl ext_ctxt {
         self.expr(span, ast::expr_call(expr, args, ast::NoSugar))
     }
 
-    fn lambda_expr(expr: @ast::expr) -> @ast::expr {
+    fn lambda_expr(&self, expr: @ast::expr) -> @ast::expr {
         self.lambda(self.expr_blk(expr))
     }
 
-    fn lambda_stmts(span: span, +stmts: ~[@ast::stmt]) -> @ast::expr {
+    fn lambda_stmts(&self, span: span, +stmts: ~[@ast::stmt]) -> @ast::expr {
         self.lambda(self.blk(span, stmts))
     }
 }

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -167,15 +167,15 @@ pub mod rt {
     }
 
     pub trait ExtParseUtils {
-        fn parse_item(s: ~str) -> @ast::item;
-        fn parse_expr(s: ~str) -> @ast::expr;
-        fn parse_stmt(s: ~str) -> @ast::stmt;
-        fn parse_tts(s: ~str) -> ~[ast::token_tree];
+        fn parse_item(&self, s: ~str) -> @ast::item;
+        fn parse_expr(&self, s: ~str) -> @ast::expr;
+        fn parse_stmt(&self, s: ~str) -> @ast::stmt;
+        fn parse_tts(&self, s: ~str) -> ~[ast::token_tree];
     }
 
     impl ExtParseUtils for ext_ctxt {
 
-        fn parse_item(s: ~str) -> @ast::item {
+        fn parse_item(&self, s: ~str) -> @ast::item {
             let res = parse::parse_item_from_source_str(
                 ~"<quote expansion>",
                 @(copy s),
@@ -191,7 +191,7 @@ pub mod rt {
             }
         }
 
-        fn parse_stmt(s: ~str) -> @ast::stmt {
+        fn parse_stmt(&self, s: ~str) -> @ast::stmt {
             parse::parse_stmt_from_source_str(
                 ~"<quote expansion>",
                 @(copy s),
@@ -200,7 +200,7 @@ pub mod rt {
                 self.parse_sess())
         }
 
-        fn parse_expr(s: ~str) -> @ast::expr {
+        fn parse_expr(&self, s: ~str) -> @ast::expr {
             parse::parse_expr_from_source_str(
                 ~"<quote expansion>",
                 @(copy s),
@@ -208,7 +208,7 @@ pub mod rt {
                 self.parse_sess())
         }
 
-        fn parse_tts(s: ~str) -> ~[ast::token_tree] {
+        fn parse_tts(&self, s: ~str) -> ~[ast::token_tree] {
             parse::parse_tts_from_source_str(
                 ~"<quote expansion>",
                 @(copy s),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -900,8 +900,8 @@ impl ast_fold for AstFoldFns {
 }
 
 pub impl ast_fold {
-    fn fold_attributes(attrs: ~[attribute]) -> ~[attribute] {
-        attrs.map(|x| fold_attribute_(*x, self))
+    fn fold_attributes(&self, attrs: ~[attribute]) -> ~[attribute] {
+        attrs.map(|x| fold_attribute_(*x, *self))
     }
 }
 

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -21,21 +21,24 @@ use core::either::{Either, Left, Right};
 
 // a parser that can parse attributes.
 pub trait parser_attr {
-    fn parse_outer_attributes() -> ~[ast::attribute];
-    fn parse_attribute(style: ast::attr_style) -> ast::attribute;
-    fn parse_attribute_naked(style: ast::attr_style, lo: BytePos) ->
-        ast::attribute;
-    fn parse_inner_attrs_and_next() ->
+    fn parse_outer_attributes(&self) -> ~[ast::attribute];
+    fn parse_attribute(&self, style: ast::attr_style) -> ast::attribute;
+    fn parse_attribute_naked(
+        &self,
+        style: ast::attr_style,
+        lo: BytePos
+    ) -> ast::attribute;
+    fn parse_inner_attrs_and_next(&self) ->
         (~[ast::attribute], ~[ast::attribute]);
-    fn parse_meta_item() -> @ast::meta_item;
-    fn parse_meta_seq() -> ~[@ast::meta_item];
-    fn parse_optional_meta() -> ~[@ast::meta_item];
+    fn parse_meta_item(&self) -> @ast::meta_item;
+    fn parse_meta_seq(&self) -> ~[@ast::meta_item];
+    fn parse_optional_meta(&self) -> ~[@ast::meta_item];
 }
 
 impl parser_attr for Parser {
 
     // Parse attributes that appear before an item
-    fn parse_outer_attributes() -> ~[ast::attribute] {
+    fn parse_outer_attributes(&self) -> ~[ast::attribute] {
         let mut attrs: ~[ast::attribute] = ~[];
         loop {
             match *self.token {
@@ -63,13 +66,13 @@ impl parser_attr for Parser {
         return attrs;
     }
 
-    fn parse_attribute(style: ast::attr_style) -> ast::attribute {
+    fn parse_attribute(&self, style: ast::attr_style) -> ast::attribute {
         let lo = self.span.lo;
         self.expect(&token::POUND);
         return self.parse_attribute_naked(style, lo);
     }
 
-    fn parse_attribute_naked(style: ast::attr_style, lo: BytePos) ->
+    fn parse_attribute_naked(&self, style: ast::attr_style, lo: BytePos) ->
         ast::attribute {
         self.expect(&token::LBRACKET);
         let meta_item = self.parse_meta_item();
@@ -89,7 +92,7 @@ impl parser_attr for Parser {
 
     // you can make the 'next' field an Option, but the result is going to be
     // more useful as a vector.
-    fn parse_inner_attrs_and_next() ->
+    fn parse_inner_attrs_and_next(&self) ->
         (~[ast::attribute], ~[ast::attribute]) {
         let mut inner_attrs: ~[ast::attribute] = ~[];
         let mut next_outer_attrs: ~[ast::attribute] = ~[];
@@ -135,7 +138,7 @@ impl parser_attr for Parser {
         (inner_attrs, next_outer_attrs)
     }
 
-    fn parse_meta_item() -> @ast::meta_item {
+    fn parse_meta_item(&self) -> @ast::meta_item {
         let lo = self.span.lo;
         let name = self.id_to_str(self.parse_ident());
         match *self.token {
@@ -157,7 +160,7 @@ impl parser_attr for Parser {
         }
     }
 
-    fn parse_meta_seq() -> ~[@ast::meta_item] {
+    fn parse_meta_seq(&self) -> ~[@ast::meta_item] {
         copy self.parse_seq(
             &token::LPAREN,
             &token::RPAREN,
@@ -166,7 +169,7 @@ impl parser_attr for Parser {
         ).node
     }
 
-    fn parse_optional_meta() -> ~[@ast::meta_item] {
+    fn parse_optional_meta(&self) -> ~[@ast::meta_item] {
         match *self.token {
             token::LPAREN => self.parse_meta_seq(),
             _ => ~[]

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -62,7 +62,7 @@ impl to_bytes::IterBytes for ObsoleteSyntax {
 
 pub impl Parser {
     /// Reports an obsolete syntax non-fatal error.
-    fn obsolete(sp: span, kind: ObsoleteSyntax) {
+    fn obsolete(&self, sp: span, kind: ObsoleteSyntax) {
         let (kind_str, desc) = match kind {
             ObsoleteLowerCaseKindBounds => (
                 "lower-case kind bounds",
@@ -154,12 +154,12 @@ pub impl Parser {
 
     // Reports an obsolete syntax non-fatal error, and returns
     // a placeholder expression
-    fn obsolete_expr(sp: span, kind: ObsoleteSyntax) -> @expr {
+    fn obsolete_expr(&self, sp: span, kind: ObsoleteSyntax) -> @expr {
         self.obsolete(sp, kind);
         self.mk_expr(sp.lo, sp.hi, expr_lit(@respan(sp, lit_nil)))
     }
 
-    priv fn report(sp: span, kind: ObsoleteSyntax, kind_str: &str,
+    priv fn report(&self, sp: span, kind: ObsoleteSyntax, kind_str: &str,
                    desc: &str) {
         self.span_err(sp, fmt!("obsolete syntax: %s", kind_str));
 
@@ -169,7 +169,7 @@ pub impl Parser {
         }
     }
 
-    fn token_is_obsolete_ident(ident: &str, token: Token) -> bool {
+    fn token_is_obsolete_ident(&self, ident: &str, token: Token) -> bool {
         match token {
             token::IDENT(copy sid, _) => {
                 str::eq_slice(*self.id_to_str(sid), ident)
@@ -178,11 +178,11 @@ pub impl Parser {
         }
     }
 
-    fn is_obsolete_ident(ident: &str) -> bool {
+    fn is_obsolete_ident(&self, ident: &str) -> bool {
         self.token_is_obsolete_ident(ident, *self.token)
     }
 
-    fn eat_obsolete_ident(ident: &str) -> bool {
+    fn eat_obsolete_ident(&self, ident: &str) -> bool {
         if self.is_obsolete_ident(ident) {
             self.bump();
             true
@@ -191,7 +191,7 @@ pub impl Parser {
         }
     }
 
-    fn try_parse_obsolete_struct_ctor() -> bool {
+    fn try_parse_obsolete_struct_ctor(&self) -> bool {
         if self.eat_obsolete_ident("new") {
             self.obsolete(*self.last_span, ObsoleteStructCtor);
             self.parse_fn_decl(|p| p.parse_arg());
@@ -202,7 +202,7 @@ pub impl Parser {
         }
     }
 
-    fn try_parse_obsolete_with() -> bool {
+    fn try_parse_obsolete_with(&self) -> bool {
         if *self.token == token::COMMA
             && self.token_is_obsolete_ident("with",
                                             self.look_ahead(1u)) {
@@ -217,7 +217,7 @@ pub impl Parser {
         }
     }
 
-    fn try_parse_obsolete_priv_section() -> bool {
+    fn try_parse_obsolete_priv_section(&self) -> bool {
         if self.is_keyword(&~"priv") && self.look_ahead(1) == token::LBRACE {
             self.obsolete(copy *self.span, ObsoletePrivSection);
             self.eat_keyword(&~"priv");

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -359,16 +359,16 @@ pub struct ident_interner {
 }
 
 pub impl ident_interner {
-    fn intern(val: @~str) -> ast::ident {
+    fn intern(&self, val: @~str) -> ast::ident {
         ast::ident { repr: self.interner.intern(val) }
     }
-    fn gensym(val: @~str) -> ast::ident {
+    fn gensym(&self, val: @~str) -> ast::ident {
         ast::ident { repr: self.interner.gensym(val) }
     }
-    pure fn get(idx: ast::ident) -> @~str {
+    pure fn get(&self, idx: ast::ident) -> @~str {
         self.interner.get(idx.repr)
     }
-    fn len() -> uint {
+    fn len(&self) -> uint {
         self.interner.len()
     }
 }

--- a/src/libsyntax/syntax.rc
+++ b/src/libsyntax/syntax.rc
@@ -22,7 +22,7 @@
 #[allow(vecs_implicitly_copyable)];
 #[allow(non_camel_case_types)];
 #[allow(deprecated_mode)];
-#[allow(deprecated_self)];
+#[deny(deprecated_self)];
 
 #[no_core];
 


### PR DESCRIPTION
This adds an explicit `&self` to each method in libsyntax, and sets the `#[deny(deprecated_self)]` in `syntax.rc`.
