### PR TITLE
Change vec::{head,tail,init,last} to return references

### DIFF
--- a/src/librust/rust.rc
+++ b/src/librust/rust.rc
@@ -130,7 +130,7 @@ fn cmd_help(args: &[~str]) -> ValidUsage {
                     UsgExec(commandline) => {
                         let words = str::words(commandline);
                         let (prog, args) = (words.head(), words.tail());
-                        run::run_program(prog, args);
+                        run::run_program(*prog, args);
                     }
                 }
                 Valid
@@ -186,7 +186,10 @@ fn do_command(command: &Command, args: &[~str]) -> ValidUsage {
         Exec(commandline) => {
             let words = str::words(commandline);
             let (prog, prog_args) = (words.head(), words.tail());
-            let exitstatus = run::run_program(prog, prog_args + args);
+            let exitstatus = run::run_program(
+                *prog,
+                vec::append(vec::from_slice(prog_args), args)
+            );
             os::set_exit_status(exitstatus);
             Valid
         }
@@ -221,11 +224,12 @@ fn usage() {
 }
 
 pub fn main() {
-    let args = os::args().tail();
+    let os_args = os::args();
+    let args = os_args.tail();
 
     if !args.is_empty() {
         for commands.each |command| {
-            if command.cmd == args.head() {
+            if command.cmd == *args.head() {
                 let result = do_command(command, args.tail());
                 if result.is_valid() { return; }
             }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -65,7 +65,7 @@ struct cache_entry {
     metas: @~[@ast::meta_item]
 }
 
-fn dump_crates(+crate_cache: @mut ~[cache_entry]) {
+fn dump_crates(crate_cache: @mut ~[cache_entry]) {
     debug!("resolved crates:");
     for crate_cache.each |entry| {
         debug!("cnum: %?", entry.cnum);

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -81,7 +81,9 @@ fn warn_if_multiple_versions(e: @mut Env,
 
     if crate_cache.len() != 0u {
         let name = loader::crate_name_from_metas(
-            /*bad*/copy *crate_cache.last().metas);
+            *crate_cache[crate_cache.len() - 1].metas
+        );
+
         let (matches, non_matches) =
             partition(crate_cache.map_to_vec(|&entry| {
                 let othername = loader::crate_name_from_metas(

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -558,7 +558,10 @@ pub fn maybe_get_item_ast(intr: @ident_interner, cdata: cmd, tcx: ty::ctxt,
                        -> csearch::found_ast {
     debug!("Looking up item: %d", id);
     let item_doc = lookup_item(id, cdata.data);
-    let path = vec::init(item_path(intr, item_doc));
+    let path = {
+        let item_path = item_path(intr, item_doc);
+        vec::from_slice(item_path.init())
+    };
     match decode_inlined_item(cdata, tcx, path, item_doc) {
       Some(ref ii) => csearch::found((/*bad*/copy *ii)),
       None => {
@@ -566,8 +569,7 @@ pub fn maybe_get_item_ast(intr: @ident_interner, cdata: cmd, tcx: ty::ctxt,
           Some(did) => {
             let did = translate_def_id(cdata, did);
             let parent_item = lookup_item(did.node, cdata.data);
-            match decode_inlined_item(cdata, tcx, path,
-                                               parent_item) {
+            match decode_inlined_item(cdata, tcx, path, parent_item) {
               Some(ref ii) => csearch::found_parent(did, (/*bad*/copy *ii)),
               None => csearch::not_found
             }

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -84,11 +84,12 @@ fn libname(cx: Context) -> (~str, ~str) {
     (str::from_slice(dll_prefix), str::from_slice(dll_suffix))
 }
 
-fn find_library_crate_aux(cx: Context,
-                          (prefix, suffix): (~str, ~str),
-                          filesearch: filesearch::FileSearch) ->
-   Option<(~str, @~[u8])> {
-    let crate_name = crate_name_from_metas(/*bad*/copy cx.metas);
+fn find_library_crate_aux(
+    cx: Context,
+    (prefix, suffix): (~str, ~str),
+    filesearch: filesearch::FileSearch
+) -> Option<(~str, @~[u8])> {
+    let crate_name = crate_name_from_metas(cx.metas);
     let prefix: ~str = prefix + *crate_name + ~"-";
     let suffix: ~str = /*bad*/copy suffix;
 
@@ -140,7 +141,7 @@ fn find_library_crate_aux(cx: Context,
     }
 }
 
-pub fn crate_name_from_metas(+metas: &[@ast::meta_item]) -> @~str {
+pub fn crate_name_from_metas(metas: &[@ast::meta_item]) -> @~str {
     let name_items = attr::find_meta_items_by_name(metas, ~"name");
     match vec::last_opt(name_items) {
         Some(i) => {

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -143,9 +143,9 @@ fn find_library_crate_aux(
 
 pub fn crate_name_from_metas(metas: &[@ast::meta_item]) -> @~str {
     let name_items = attr::find_meta_items_by_name(metas, ~"name");
-    match vec::last_opt(name_items) {
+    match name_items.last_opt() {
         Some(i) => {
-            match attr::get_meta_item_value_str(i) {
+            match attr::get_meta_item_value_str(*i) {
                 Some(n) => n,
                 // FIXME (#2406): Probably want a warning here since the user
                 // is using the wrong type of meta item.

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -97,7 +97,7 @@ fn find_library_crate_aux(
     filesearch::search(filesearch, |path| {
         debug!("inspecting file %s", path.to_str());
         let f: ~str = path.filename().get();
-        if !(str::starts_with(f, prefix) && str::ends_with(f, suffix)) {
+        if !(f.starts_with(prefix) && f.ends_with(suffix)) {
             debug!("skipping %s, doesn't look like %s*%s", path.to_str(),
                    prefix, suffix);
             option::None::<()>

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -105,7 +105,7 @@ pub fn encode_inlined_item(ecx: @e::EncodeContext,
 pub fn decode_inlined_item(cdata: @cstore::crate_metadata,
                            tcx: ty::ctxt,
                            maps: Maps,
-                           +path: ast_map::path,
+                           path: ast_map::path,
                            par_doc: ebml::Doc)
                         -> Option<ast::inlined_item> {
     let dcx = @DecodeContext {

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -71,7 +71,7 @@ pub fn check_expr(cx: @MatchCheckCtxt, ex: @expr, &&s: (), v: visit::vt<()>) {
                                             arm.pats);
         }
 
-        check_arms(cx, (/*bad*/copy *arms));
+        check_arms(cx, *arms);
         /* Check for exhaustiveness */
          // Check for empty enum, because is_useful only works on inhabited
          // types.
@@ -108,12 +108,12 @@ pub fn check_expr(cx: @MatchCheckCtxt, ex: @expr, &&s: (), v: visit::vt<()>) {
 }
 
 // Check for unreachable patterns
-pub fn check_arms(cx: @MatchCheckCtxt, arms: ~[arm]) {
+pub fn check_arms(cx: @MatchCheckCtxt, arms: &[arm]) {
     let mut seen = ~[];
     for arms.each |arm| {
         for arm.pats.each |pat| {
             let v = ~[*pat];
-            match is_useful(cx, copy seen, v) {
+            match is_useful(cx, &seen, v) {
               not_useful => {
                 cx.tcx.sess.span_err(pat.span, ~"unreachable pattern");
               }

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -26,7 +26,7 @@ pub fn pat_id_map(dm: resolve::DefMap, pat: @pat) -> PatIdMap {
     do pat_bindings(dm, pat) |_bm, p_id, _s, n| {
       map.insert(path_to_ident(n), p_id);
     };
-    return map;
+    map
 }
 
 pub fn pat_is_variant_or_struct(dm: resolve::DefMap, pat: @pat) -> bool {

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1438,7 +1438,7 @@ pub impl Resolver {
                                 type_value_ns => AnyNS
                             };
 
-                            let source_ident = full_path.idents.last();
+                            let source_ident = *full_path.idents.last();
                             let subclass = @SingleImport(binding,
                                                          source_ident,
                                                          ns);
@@ -4087,7 +4087,7 @@ pub impl Resolver {
 
                 // First, check to see whether the name is a primitive type.
                 if path.idents.len() == 1 {
-                    let name = path.idents.last();
+                    let name = *path.idents.last();
 
                     match self.primitive_type_table
                             .primitive_types
@@ -4110,7 +4110,7 @@ pub impl Resolver {
                                 debug!("(resolving type) resolved `%s` to \
                                         type %?",
                                        *self.session.str_of(
-                                            path.idents.last()),
+                                            *path.idents.last()),
                                        def);
                                 result_def = Some(def);
                             }
@@ -4296,7 +4296,7 @@ pub impl Resolver {
                                 path.span,
                                 fmt!("not an enum variant: %s",
                                      *self.session.str_of(
-                                         path.idents.last())));
+                                         *path.idents.last())));
                         }
                         None => {
                             self.session.span_err(path.span,
@@ -4418,7 +4418,7 @@ pub impl Resolver {
                                                      namespace);
         }
 
-        return self.resolve_identifier(path.idents.last(),
+        return self.resolve_identifier(*path.idents.last(),
                                        namespace,
                                        check_ribs,
                                        path.span);
@@ -4552,7 +4552,7 @@ pub impl Resolver {
             }
         }
 
-        let name = path.idents.last();
+        let name = *path.idents.last();
         match self.resolve_definition_of_name_in_module(containing_module,
                                                         name,
                                                         namespace,
@@ -4601,7 +4601,7 @@ pub impl Resolver {
             }
         }
 
-        let name = path.idents.last();
+        let name = *path.idents.last();
         match self.resolve_definition_of_name_in_module(containing_module,
                                                         name,
                                                         namespace,

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2207,7 +2207,7 @@ pub fn register_fn_fuller(ccx: @CrateContext,
            ast_map::path_to_str(path, ccx.sess.parse_sess.interner));
 
     let ps = if attr::attrs_contains_name(attrs, "no_mangle") {
-        path_elt_to_str(path.last(), ccx.sess.parse_sess.interner)
+        path_elt_to_str(*path.last(), ccx.sess.parse_sess.interner)
     } else {
         mangle_exported_name(ccx, /*bad*/copy path, node_type)
     };

--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -71,8 +71,8 @@ pub impl FnType {
             let llretptr = GEPi(bcx, llargbundle, [0u, n]);
             let llretloc = Load(bcx, llretptr);
                 llargvals = ~[llretloc];
-                atys = vec::tail(atys);
-                attrs = vec::tail(attrs);
+                atys = vec::from_slice(atys.tail());
+                attrs = vec::from_slice(attrs.tail());
         }
 
         while i < n {
@@ -131,8 +131,8 @@ pub impl FnType {
         let mut attrs = /*bad*/copy self.attrs;
         let mut j = 0u;
         let llretptr = if self.sret {
-            atys = vec::tail(atys);
-            attrs = vec::tail(attrs);
+            atys = vec::from_slice(atys.tail());
+            attrs = vec::from_slice(attrs.tail());
             j = 1u;
             get_param(llwrapfn, 0u)
         } else if self.ret_ty.cast {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -792,12 +792,14 @@ pub fn create_arg(bcx: block, arg: ast::arg, sp: span)
         match arg.pat.node {
             ast::pat_ident(_, path, _) => {
                 // XXX: This is wrong; it should work for multiple bindings.
-                let mdnode = create_var(tg,
-                                        context.node,
-                                        *cx.sess.str_of(path.idents.last()),
-                                        filemd.node,
-                                        loc.line as int,
-                                        tymd.node);
+                let mdnode = create_var(
+                    tg,
+                    context.node,
+                    *cx.sess.str_of(*path.idents.last()),
+                    filemd.node,
+                    loc.line as int,
+                    tymd.node
+                );
 
                 let mdval = @Metadata {
                     node: mdnode,

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3815,7 +3815,7 @@ pub fn item_path(cx: ctxt, id: ast::def_id) -> ast_map::path {
           }
 
           ast_map::node_variant(ref variant, _, path) => {
-            vec::append_one(vec::init(*path),
+            vec::append_one(vec::from_slice(vec::init(*path)),
                             ast_map::path_name((*variant).node.name))
           }
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -132,7 +132,7 @@ pub fn parse_config_(
     match getopts::getopts(args, opts) {
         result::Ok(matches) => {
             if matches.free.len() == 1 {
-                let input_crate = Path(vec::head(matches.free));
+                let input_crate = Path(copy *matches.free.head());
                 config_from_opts(&input_crate, &matches, program_output)
             } else if matches.free.is_empty() {
                 result::Err(~"no crates specified")

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -130,18 +130,18 @@ pub fn parse_config_(
     let args = args.tail();
     let opts = vec::unzip(opts()).first();
     match getopts::getopts(args, opts) {
-        result::Ok(matches) => {
+        Ok(matches) => {
             if matches.free.len() == 1 {
-                let input_crate = Path(copy *matches.free.head());
+                let input_crate = Path(*matches.free.head());
                 config_from_opts(&input_crate, &matches, program_output)
             } else if matches.free.is_empty() {
-                result::Err(~"no crates specified")
+                Err(~"no crates specified")
             } else {
-                result::Err(~"multiple crates specified")
+                Err(~"multiple crates specified")
             }
         }
-        result::Err(f) => {
-            result::Err(getopts::fail_str(f))
+        Err(f) => {
+            Err(getopts::fail_str(f))
         }
     }
 }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -262,7 +262,7 @@ fn should_find_pandoc() {
         output_format: PandocHtml,
         .. default_config(&Path("test"))
     };
-    let mock_program_output: ~fn(&str, &[~str]) -> ProgramOutput = |prog, _| {
+    let mock_program_output: ~fn(&str, &[~str]) -> ProgramOutput = |_, _| {
         ProgramOutput { status: 0, out: ~"pandoc 1.8.2.1", err: ~"" }
     };
     let result = maybe_find_pandoc(&config, None, mock_program_output);

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -144,14 +144,14 @@ fn parse_desc(desc: ~str) -> Option<~str> {
 fn first_sentence(s: ~str) -> Option<~str> {
     let paras = paragraphs(s);
     if !paras.is_empty() {
-        let first_para = vec::head(paras);
-        Some(str::replace(first_sentence_(first_para), ~"\n", ~" "))
+        let first_para = paras.head();
+        Some(str::replace(first_sentence_(*first_para), ~"\n", ~" "))
     } else {
         None
     }
 }
 
-fn first_sentence_(s: ~str) -> ~str {
+fn first_sentence_(s: &str) -> ~str {
     let mut dotcount = 0;
     // The index of the character following a single dot. This allows
     // Things like [0..1) to appear in the brief description
@@ -169,16 +169,16 @@ fn first_sentence_(s: ~str) -> ~str {
         }
     };
     match idx {
-      Some(idx) if idx > 2u => {
-        str::slice(s, 0u, idx - 1u)
-      }
-      _ => {
-        if str::ends_with(s, ~".") {
-            str::slice(s, 0u, str::len(s))
-        } else {
-            copy s
+        Some(idx) if idx > 2u => {
+            str::from_slice(str::view(s, 0, idx - 1))
         }
-      }
+        _ => {
+            if str::ends_with(s, ~".") {
+                str::from_slice(s)
+            } else {
+                str::from_slice(s)
+            }
+        }
     }
 }
 

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -142,7 +142,7 @@ fn parse_desc(desc: ~str) -> Option<~str> {
 }
 
 fn first_sentence(s: ~str) -> Option<~str> {
-    let paras = paragraphs(copy s);
+    let paras = paragraphs(s);
     if !paras.is_empty() {
         let first_para = vec::head(paras);
         Some(str::replace(first_sentence_(first_para), ~"\n", ~" "))
@@ -182,7 +182,7 @@ fn first_sentence_(s: ~str) -> ~str {
     }
 }
 
-fn paragraphs(s: ~str) -> ~[~str] {
+fn paragraphs(s: &str) -> ~[~str] {
     let lines = str::lines_any(s);
     let mut whitespace_lines = 0;
     let mut accum = ~"";

--- a/src/librustdoc/unindent_pass.rs
+++ b/src/librustdoc/unindent_pass.rs
@@ -79,7 +79,7 @@ fn unindent(s: &str) -> ~str {
 
     if !lines.is_empty() {
         let unindented = ~[lines.head().trim()]
-            + do vec::tail(lines).map |line| {
+            + do lines.tail().map |line| {
             if str::is_whitespace(*line) {
                 copy *line
             } else {

--- a/src/librustdoc/unindent_pass.rs
+++ b/src/librustdoc/unindent_pass.rs
@@ -78,7 +78,7 @@ fn unindent(s: &str) -> ~str {
     };
 
     if !lines.is_empty() {
-        let unindented = ~[str::trim(vec::head(lines))]
+        let unindented = ~[lines.head().trim()]
             + do vec::tail(lines).map |line| {
             if str::is_whitespace(*line) {
                 copy *line

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -57,7 +57,7 @@ pub fn parse_name(id: ~str) -> result::Result<~str, ~str> {
         }
     }
 
-    result::Ok(parts.last())
+    result::Ok(copy *parts.last())
 }
 
 struct ListenerFn {
@@ -516,9 +516,11 @@ pub fn get_pkg(id: ~str,
         return result::Err(~"package not found");
     }
 
-    result::Ok(sort::merge_sort(possibs, |v1, v2| {
+    let possibs = sort::merge_sort(possibs, |v1, v2| {
         v1.vers <= v2.vers
-    }).last())
+    });
+
+    result::Ok(copy *possibs.last())
 }
 
 pub fn add_pkg(pkg: &Package) -> bool {

--- a/src/libstd/bigint.rs
+++ b/src/libstd/bigint.rs
@@ -346,7 +346,7 @@ pub impl BigUint {
         }
 
         let mut shift = 0;
-        let mut n = other.data.last();
+        let mut n = *other.data.last();
         while n < (1 << BigDigit::bits - 2) {
             n <<= 1;
             shift += 1;
@@ -384,7 +384,7 @@ pub impl BigUint {
             }
 
             let an = vec::slice(a.data, a.data.len() - n, a.data.len());
-            let bn = b.data.last();
+            let bn = *b.data.last();
             let mut d = ~[];
             let mut carry = 0;
             for vec::rev_each(an) |elt| {

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -759,7 +759,7 @@ pub fn Decoder(json: Json) -> Decoder {
 priv impl Decoder {
     fn peek(&self) -> &self/Json {
         if self.stack.len() == 0 { self.stack.push(&self.json); }
-        vec::last(self.stack)
+        self.stack[self.stack.len() - 1]
     }
 
     fn pop(&self) -> &self/Json {

--- a/src/libstd/priority_queue.rs
+++ b/src/libstd/priority_queue.rs
@@ -197,7 +197,7 @@ mod tests {
         let mut sorted = merge_sort(data, le);
         let mut heap = from_vec(data);
         while !heap.is_empty() {
-            assert *heap.top() == sorted.last();
+            assert heap.top() == sorted.last();
             assert heap.pop() == sorted.pop();
         }
     }

--- a/src/libstd/workcache.rs
+++ b/src/libstd/workcache.rs
@@ -174,7 +174,7 @@ pub impl Database {
         let k = json_encode(&(fn_name, declared_inputs));
         match self.db_cache.find(&k) {
             None => None,
-            Some(&v) => Some(json_decode(copy v))
+            Some(v) => Some(json_decode(*v))
         }
     }
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -31,7 +31,7 @@ pub pure fn path_name_i(idents: &[ident], intr: @token::ident_interner)
 }
 
 
-pub pure fn path_to_ident(p: @path) -> ident { vec::last(p.idents) }
+pub pure fn path_to_ident(p: @path) -> ident { copy *p.idents.last() }
 
 pub pure fn local_def(id: node_id) -> def_id {
     ast::def_id { crate: local_crate, node: id }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -229,7 +229,7 @@ fn last_meta_item_by_name(items: &[@ast::meta_item], name: &str)
     -> Option<@ast::meta_item> {
 
     let items = attr::find_meta_items_by_name(items, name);
-    vec::last_opt(items)
+    items.last_opt().map(|item| **item)
 }
 
 pub fn last_meta_item_value_str_by_name(items: &[@ast::meta_item], name: &str)

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -167,7 +167,7 @@ pub fn tt_next_token(r: @mut TtReader) -> TokenAndSpan {
     while r.cur.idx >= r.cur.readme.len() {
         /* done with this set; pop or repeat? */
         if ! r.cur.dotdotdoted
-            || r.repeat_idx.last() == r.repeat_len.last() - 1 {
+            || { *r.repeat_idx.last() == *r.repeat_len.last() - 1 } {
 
             match r.cur.up {
               None => {

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -93,7 +93,7 @@ fn recurse_or_fail(depth: int, st: Option<State>) {
                 fn_box: || @Cons((), fn_box()),
                 tuple: (@Cons((), st.tuple.first()),
                         ~Cons((), @*st.tuple.second())),
-                vec: st.vec + ~[@Cons((), st.vec.last())],
+                vec: st.vec + ~[@Cons((), *st.vec.last())],
                 res: r(@Cons((), st.res._l))
             }
           }

--- a/src/test/run-pass/zip-same-length.rs
+++ b/src/test/run-pass/zip-same-length.rs
@@ -35,5 +35,5 @@ pub fn main() {
     let ps = vec::zip(chars, ints);
 
     assert (ps.head() == &('a', 1u));
-    assert (ps.last() == (j as char, 10u));
+    assert (ps.last() == &(j as char, 10u));
 }

--- a/src/test/run-pass/zip-same-length.rs
+++ b/src/test/run-pass/zip-same-length.rs
@@ -10,7 +10,6 @@
 
 // In this case, the code should compile and should
 // succeed at runtime
-use core::vec::{head, last, same_length, zip};
 
 fn enum_chars(start: u8, end: u8) -> ~[char] {
     assert start < end;
@@ -33,8 +32,8 @@ pub fn main() {
     let chars = enum_chars(a, j);
     let ints = enum_uints(k, l);
 
-    let ps = zip(chars, ints);
+    let ps = vec::zip(chars, ints);
 
-    assert (head(ps) == ('a', 1u));
-    assert (last(ps) == (j as char, 10u));
+    assert (ps.head() == &('a', 1u));
+    assert (ps.last() == (j as char, 10u));
 }


### PR DESCRIPTION
This patch series changes a handful of vec functions to return references instead of copies. The one downside with making this change is that these functions aren't usable in a couple cases now due to some purity complaints. For example, this [change](https://github.com/erickt/rust/commit/c31e81a532fc07e89be33cadb5109d167aa725f4#L1R87). I couldn't figure out a way to get `last` to work on a `@mut ~[...]` type, so I ended up having to use `*crate_cache[crate_cache.len() - 1].metas`.
