### PR TITLE
Update region inference for traits

### DIFF
--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -16,7 +16,6 @@ use middle::ty;
 use middle::typeck;
 use util::ppaux;
 
-use core::option;
 use syntax::ast::*;
 use syntax::codemap;
 use syntax::{visit, ast_util, ast_map};

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -19,7 +19,6 @@ use middle::typeck::method_map;
 use middle::moves;
 use util::ppaux::ty_to_str;
 
-use core::option;
 use core::uint;
 use core::vec;
 use std::sort;

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -18,7 +18,6 @@ use middle::ty;
 use middle::typeck;
 use util::ppaux::{ty_to_str, tys_to_str};
 
-use core::option;
 use core::str;
 use core::vec;
 use std::oldmap::HashMap;

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -69,7 +69,6 @@ use core::hash;
 use core::int;
 use core::io;
 use core::libc::{c_uint, c_ulonglong};
-use core::option;
 use core::uint;
 use std::oldmap::HashMap;
 use std::{oldmap, time, list};

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -18,41 +18,59 @@ use syntax::ast;
 use syntax::codemap::span;
 
 pub trait region_scope {
-    pure fn anon_region(&self, span: span) -> Result<ty::Region, ~str>;
-    pure fn self_region(&self, span: span) -> Result<ty::Region, ~str>;
-    pure fn named_region(&self, span: span, id: ast::ident)
+    fn anon_region(&self, span: span) -> Result<ty::Region, ~str>;
+    fn self_region(&self, span: span) -> Result<ty::Region, ~str>;
+    fn named_region(&self, span: span, id: ast::ident)
                       -> Result<ty::Region, ~str>;
 }
 
 pub enum empty_rscope { empty_rscope }
-
 impl region_scope for empty_rscope {
-    pure fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
-        result::Ok(ty::re_static)
+    fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
+        Ok(ty::re_static)
     }
-    pure fn self_region(&self, _span: span) -> Result<ty::Region, ~str> {
+    fn self_region(&self, _span: span) -> Result<ty::Region, ~str> {
         result::Err(~"only the static region is allowed here")
     }
-    pure fn named_region(&self, _span: span, _id: ast::ident)
+    fn named_region(&self, _span: span, _id: ast::ident)
         -> Result<ty::Region, ~str> {
         result::Err(~"only the static region is allowed here")
     }
 }
 
-pub enum type_rscope = Option<ty::region_variance>;
-
-impl region_scope for type_rscope {
-    pure fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
-        match **self {
-          Some(_) => result::Ok(ty::re_bound(ty::br_self)),
-          None => result::Err(~"to use region types here, the containing \
-                                type must be declared with a region bound")
+pub struct MethodRscope {
+    self_ty: ast::self_ty_,
+    region_parameterization: Option<ty::region_variance>
+}
+impl region_scope for MethodRscope {
+    fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
+        result::Err(~"anonymous region types are not permitted here")
+    }
+    fn self_region(&self, _span: span) -> Result<ty::Region, ~str> {
+        assert self.region_parameterization.is_some() ||
+            self.self_ty.is_borrowed();
+        result::Ok(ty::re_bound(ty::br_self))
+    }
+    fn named_region(&self, span: span, id: ast::ident)
+                      -> Result<ty::Region, ~str> {
+        do empty_rscope.named_region(span, id).chain_err |_e| {
+            result::Err(~"region is not in scope here")
         }
     }
-    pure fn self_region(&self, span: span) -> Result<ty::Region, ~str> {
+}
+
+pub enum type_rscope = Option<ty::region_variance>;
+impl region_scope for type_rscope {
+    fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
+        // if the anon or self region is used, region parameterization should
+        // have inferred that this type is RP
+        assert self.is_some();
+        result::Ok(ty::re_bound(ty::br_self))
+    }
+    fn self_region(&self, span: span) -> Result<ty::Region, ~str> {
         self.anon_region(span)
     }
-    pure fn named_region(&self, span: span, id: ast::ident)
+    fn named_region(&self, span: span, id: ast::ident)
                       -> Result<ty::Region, ~str> {
         do empty_rscope.named_region(span, id).chain_err |_e| {
             result::Err(~"named regions other than `self` are not \
@@ -70,50 +88,55 @@ pub fn bound_self_region(rp: Option<ty::region_variance>)
 }
 
 pub struct anon_rscope { anon: ty::Region, base: @region_scope }
-pub fn in_anon_rscope<RS:region_scope + Copy + Durable>(self: RS,
-                                                        r: ty::Region)
-                                                     -> @anon_rscope {
-    @anon_rscope {anon: r, base: @self as @region_scope}
+pub fn in_anon_rscope<RS:region_scope + Copy + Durable>(
+    self: &RS,
+    r: ty::Region) -> anon_rscope
+{
+    let base = @(copy *self) as @region_scope;
+    anon_rscope {anon: r, base: base}
 }
-
-impl region_scope for @anon_rscope {
-    pure fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
+impl region_scope for anon_rscope {
+    fn anon_region(&self,
+                   _span: span) -> Result<ty::Region, ~str>
+    {
         result::Ok(self.anon)
     }
-    pure fn self_region(&self, span: span) -> Result<ty::Region, ~str> {
+    fn self_region(&self,
+                   span: span) -> Result<ty::Region, ~str>
+    {
         self.base.self_region(span)
     }
-    pure fn named_region(&self, span: span, id: ast::ident)
-                      -> Result<ty::Region, ~str> {
+    fn named_region(&self,
+                    span: span,
+                    id: ast::ident) -> Result<ty::Region, ~str>
+    {
         self.base.named_region(span, id)
     }
 }
 
 pub struct binding_rscope {
-    base: region_scope,
-    anon_bindings: uint,
+    base: @region_scope,
+    anon_bindings: @mut uint,
 }
 
-pub fn in_binding_rscope<RS:region_scope + Copy + Durable>(self: RS)
-    -> @mut binding_rscope {
-    let base = @self as @region_scope;
-    @mut binding_rscope { base: base, anon_bindings: 0 }
+pub fn in_binding_rscope<RS:region_scope + Copy + Durable>(self: &RS)
+    -> binding_rscope {
+    let base = @(copy *self) as @region_scope;
+    binding_rscope { base: base, anon_bindings: @mut 0 }
 }
-
-impl region_scope for @mut binding_rscope {
-    pure fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
-        // XXX: Unsafe to work around purity
-        unsafe {
-            let idx = self.anon_bindings;
-            self.anon_bindings += 1;
-            result::Ok(ty::re_bound(ty::br_anon(idx)))
-        }
+impl region_scope for binding_rscope {
+    fn anon_region(&self, _span: span) -> Result<ty::Region, ~str> {
+        let idx = *self.anon_bindings;
+        *self.anon_bindings += 1;
+        result::Ok(ty::re_bound(ty::br_anon(idx)))
     }
-    pure fn self_region(&self, span: span) -> Result<ty::Region, ~str> {
+    fn self_region(&self, span: span) -> Result<ty::Region, ~str> {
         self.base.self_region(span)
     }
-    pure fn named_region(&self, span: span, id: ast::ident)
-                      -> Result<ty::Region, ~str> {
+    fn named_region(&self,
+                    span: span,
+                    id: ast::ident) -> Result<ty::Region, ~str>
+    {
         do self.base.named_region(span, id).chain_err |_e| {
             result::Ok(ty::re_bound(ty::br_named(id)))
         }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1017,6 +1017,15 @@ pub enum self_ty_ {
     sty_uniq(mutability)                // by-unique-pointer self: `~self`
 }
 
+impl self_ty_ {
+    fn is_borrowed(&self) -> bool {
+        match *self {
+            sty_region(_) => true,
+            _ => false
+        }
+    }
+}
+
 pub type self_ty = spanned<self_ty_>;
 
 #[auto_encode]

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -30,7 +30,6 @@ use print::pprust;
 use core::char;
 use core::dvec::DVec;
 use core::io;
-use core::option;
 use core::str;
 use core::u64;
 use core::vec;

--- a/src/test/compile-fail/map-types.rs
+++ b/src/test/compile-fail/map-types.rs
@@ -17,5 +17,5 @@ fn main() {
     let x: @Map<~str, ~str> = @LinearMap::new::<~str, ~str>() as
         Map::<~str, ~str>;
     let y: @Map<uint, ~str> = @x;
-    //~^ ERROR mismatched types: expected `@core::container::Map/&<uint,~str>`
+    //~^ ERROR mismatched types: expected `@core::container::Map<uint,~str>`
 }

--- a/src/test/run-pass/regions-parameterization-self-types-issue-5224.rs
+++ b/src/test/run-pass/regions-parameterization-self-types-issue-5224.rs
@@ -1,0 +1,28 @@
+// Test how region-parameterization inference
+// interacts with explicit self types.
+//
+// Issue #5224.
+
+trait Getter {
+    // This trait does not need to be
+    // region-parameterized, because 'self
+    // is bound in the self type:
+    fn get(&self) -> &'self int;
+}
+
+struct Foo {
+    field: int
+}
+
+impl Getter for Foo {
+    fn get(&self) -> &'self int { &self.field }
+}
+
+fn get_int<G: Getter>(g: &G) -> int {
+    *g.get()
+}
+
+fn main() {
+    let foo = Foo { field: 22 };
+    assert get_int(&foo) == 22;
+}


### PR DESCRIPTION
Update region inference for traits so that a method with explicit self doesn't incorrectly cause the entire trait to be tagged as being region-parameterized.

Fixes #5224.

r? @pcwalton
