### PR TITLE
Better macro error message

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -44,7 +44,7 @@ pub fn expand_expr(extsbox: @mut SyntaxEnv,
                         cx.span_fatal(
                             pth.span,
                             fmt!("expected macro name without module \
-                                  separators, got: '%?'",pth));
+                                  separators"));
                     }
                     /* using idents and token::special_idents would make the
                     the macro names be hygienic */
@@ -328,7 +328,7 @@ pub fn expand_stmt(extsbox: @mut SyntaxEnv,
         cx.span_fatal(
             pth.span,
             fmt!("expected macro name without module \
-                  separators, got: '%?'",pth));
+                  separators"));
     }
     let extname = cx.parse_sess().interner.get(pth.idents[0]);
     let (fully_expanded, sp) = match (*extsbox).find(&extname) {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -38,10 +38,14 @@ pub fn expand_expr(extsbox: @mut SyntaxEnv,
         // entry-point for all syntax extensions.
         expr_mac(ref mac) => {
             match (*mac).node {
-                // Token-tree macros, these will be the only case when we're
-                // finished transitioning.
+                // Token-tree macros:
                 mac_invoc_tt(pth, ref tts) => {
-                    assert (vec::len(pth.idents) == 1u);
+                    if (pth.idents.len() > 1u) {
+                        cx.span_fatal(
+                            pth.span,
+                            fmt!("expected macro name without module \
+                                  separators, got: '%?'",pth));
+                    }
                     /* using idents and token::special_idents would make the
                     the macro names be hygienic */
                     let extname = cx.parse_sess().interner.get(pth.idents[0]);
@@ -320,8 +324,12 @@ pub fn expand_stmt(extsbox: @mut SyntaxEnv,
         }
         _ => return orig(s, sp, fld)
     };
-
-    assert(vec::len(pth.idents) == 1u);
+    if (pth.idents.len() > 1u) {
+        cx.span_fatal(
+            pth.span,
+            fmt!("expected macro name without module \
+                  separators, got: '%?'",pth));
+    }
     let extname = cx.parse_sess().interner.get(pth.idents[0]);
     let (fully_expanded, sp) = match (*extsbox).find(&extname) {
         None =>

--- a/src/test/compile-fail/macro-with-seps-err-msg.rs
+++ b/src/test/compile-fail/macro-with-seps-err-msg.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:expected macro name without module separators
+
+fn main() {
+    globnar::brotz!();
+}
+
+


### PR DESCRIPTION
Macro invocations with path separators (e.g. foo::bar!()) now produce a sensible error message, rather than an assertion failure. Also added compile-fail test case.

Fixes #5218 ?
