### PR TITLE
Remove parse value ident

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -105,6 +105,10 @@ pub struct Lifetime {
     ident: ident
 }
 
+// a "Path" is essentially Rust's notion of a name;
+// for instance: core::cmp::Eq  .  It's represented
+// as a sequence of identifiers, along with a bunch
+// of supporting information.
 #[auto_encode]
 #[auto_decode]
 #[deriving_eq]

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -36,6 +36,7 @@ struct TtFrame {
 pub struct TtReader {
     sp_diag: span_handler,
     interner: @ident_interner,
+    // the unzipped tree:
     cur: @mut TtFrame,
     /* for MBE-style macro transcription */
     interpolations: std::oldmap::HashMap<ident, @named_match>,

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -119,10 +119,6 @@ pub impl Parser {
                                                 id: self.get_id() })
     }
 
-    fn parse_value_ident(&self) -> ast::ident {
-        return self.parse_ident();
-    }
-
     // consume token 'tok' if it exists. Returns true if the given
     // token was present, false otherwise.
     fn eat(&self, tok: &token::Token) -> bool {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -457,7 +457,7 @@ pub impl Parser {
             let pur = p.parse_fn_purity();
             // NB: at the moment, trait methods are public by default; this
             // could change.
-            let ident = p.parse_method_name();
+            let ident = p.parse_ident();
 
             let generics = p.parse_generics();
 
@@ -2102,11 +2102,7 @@ pub impl Parser {
             }
 
             let lo1 = self.last_span.lo;
-            let fieldname = if self.look_ahead(1u) == token::COLON {
-                self.parse_ident()
-            } else {
-                self.parse_value_ident()
-            };
+            let fieldname = self.parse_ident();
             let hi1 = self.last_span.lo;
             let fieldpath = ast_util::ident_to_path(mk_sp(lo1, hi1),
                                                     fieldname);
@@ -2946,7 +2942,7 @@ pub impl Parser {
     }
 
     fn parse_fn_header(&self) -> (ident, ast::Generics) {
-        let id = self.parse_value_ident();
+        let id = self.parse_ident();
         let generics = self.parse_generics();
         (id, generics)
     }
@@ -2969,10 +2965,6 @@ pub impl Parser {
         (ident, item_fn(decl, purity, generics, body), Some(inner_attrs))
     }
 
-    fn parse_method_name(&self) -> ident {
-        self.parse_value_ident()
-    }
-
     fn parse_method(&self) -> @method {
         let attrs = self.parse_outer_attributes();
         let lo = self.span.lo;
@@ -2982,7 +2974,7 @@ pub impl Parser {
 
         let visa = self.parse_visibility();
         let pur = self.parse_fn_purity();
-        let ident = self.parse_method_name();
+        let ident = self.parse_ident();
         let generics = self.parse_generics();
         let (self_ty, decl) = do self.parse_fn_decl_with_self() |p| {
             p.parse_arg()
@@ -3106,7 +3098,7 @@ pub impl Parser {
     }
 
     fn parse_item_struct(&self) -> item_info {
-        let class_name = self.parse_value_ident();
+        let class_name = self.parse_ident();
         self.parse_region_param();
         let generics = self.parse_generics();
         if self.eat(&token::COLON) {
@@ -3334,7 +3326,7 @@ pub impl Parser {
     }
 
     fn parse_item_const(&self) -> item_info {
-        let id = self.parse_value_ident();
+        let id = self.parse_ident();
         self.expect(&token::COLON);
         let ty = self.parse_ty(false);
         self.expect(&token::EQ);
@@ -3732,7 +3724,7 @@ pub impl Parser {
                 kind = enum_variant_kind(nested_enum_def);
                 needs_comma = false;
             } else {
-                ident = self.parse_value_ident();
+                ident = self.parse_ident();
                 if self.eat(&token::LBRACE) {
                     // Parse a struct variant.
                     all_nullary = false;


### PR DESCRIPTION
After the removal of the "restricted keyword" feature in 0c82c00dc4f49aeb9b57c92c9a40ae35d8a1ee29 , there's no longer any difference between parse_ident() and parse_value_ident(), and therefore no difference between parse parse_path_without_tps() and parse_value_path().  I've collapsed all of these, removing the redundant functions and eliminating the need for two higher-order arguments.
