### PR TITLE
Allow casting integers to unsafe pointers in constant expressions. 

### DIFF
--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -109,7 +109,7 @@ pub fn check_expr(sess: Session,
           expr_lit(_) => (),
           expr_cast(_, _) => {
             let ety = ty::expr_ty(tcx, e);
-            if !ty::type_is_numeric(ety) {
+            if !ty::type_is_numeric(ety) && !ty::type_is_unsafe_ptr(ety) {
                 sess.span_err(e.span, ~"can not cast to `" +
                               ppaux::ty_to_str(tcx, ety) +
                               ~"` in a constant expression");

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -328,6 +328,9 @@ pub fn const_expr(cx: @CrateContext, e: @ast::expr) -> ValueRef {
               (expr::cast_pointer, expr::cast_pointer) => {
                 llvm::LLVMConstPointerCast(v, llty)
               }
+              (expr::cast_integral, expr::cast_pointer) => {
+                llvm::LLVMConstIntToPtr(v, llty)
+              }
               _ => {
                 cx.sess.impossible_case(e.span,
                                         ~"bad combination of types for cast")

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -122,7 +122,7 @@ pub fn const_autoderef(cx: @CrateContext, ty: ty::t, v: ValueRef)
     let mut v1 = v;
     loop {
         // Only rptrs can be autoderef'ed in a const context.
-        match ty::get(ty).sty {
+        match ty::get(t1).sty {
             ty::ty_rptr(_, mt) => {
                 t1 = mt.ty;
                 v1 = const_deref(cx, v1);
@@ -320,6 +320,9 @@ pub fn const_expr(cx: @CrateContext, e: @ast::expr) -> ValueRef {
               (expr::cast_float, expr::cast_integral) => {
                 if ty::type_is_signed(ety) { llvm::LLVMConstFPToSI(v, llty) }
                 else { llvm::LLVMConstFPToUI(v, llty) }
+              }
+              (expr::cast_pointer, expr::cast_pointer) => {
+                llvm::LLVMConstPointerCast(v, llty)
               }
               _ => {
                 cx.sess.impossible_case(e.span,

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -138,6 +138,7 @@ use middle::trans::consts;
 use middle::trans::controlflow;
 use middle::trans::datum::*;
 use middle::trans::debuginfo;
+use middle::trans::inline;
 use middle::trans::machine;
 use middle::trans::meth;
 use middle::trans::tvec;
@@ -983,15 +984,54 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
         match def {
             ast::def_const(did) => {
                 let const_ty = expr_ty(bcx, ref_expr);
-                let val = if did.crate == ast::local_crate {
+
+                #[cfg(stage0)]
+                fn get_did(_ccx: @CrateContext, did: ast::def_id)
+                    -> ast::def_id {
+                    did
+                }
+
+                #[cfg(stage1)]
+                #[cfg(stage2)]
+                #[cfg(stage3)]
+                fn get_did(ccx: @CrateContext, did: ast::def_id)
+                    -> ast::def_id {
+                    if did.crate != ast::local_crate {
+                        inline::maybe_instantiate_inline(ccx, did, true)
+                    } else {
+                        did
+                    }
+                }
+
+                #[cfg(stage0)]
+                fn get_val(bcx: block, did: ast::def_id, const_ty: ty::t)
+                    -> ValueRef {
+                    let ccx = bcx.ccx();
+                    if did.crate == ast::local_crate {
+                        // The LLVM global has the type of its initializer,
+                        // which may not be equal to the enum's type for
+                        // non-C-like enums.
+                        PointerCast(bcx, base::get_item_val(ccx, did.node),
+                                    T_ptr(type_of(bcx.ccx(), const_ty)))
+                    } else {
+                        base::trans_external_path(ccx, did, const_ty)
+                    }
+                }
+
+                #[cfg(stage1)]
+                #[cfg(stage2)]
+                #[cfg(stage3)]
+                fn get_val(bcx: block, did: ast::def_id, const_ty: ty::t)
+                    -> ValueRef {
                     // The LLVM global has the type of its initializer,
                     // which may not be equal to the enum's type for
                     // non-C-like enums.
-                    PointerCast(bcx, base::get_item_val(ccx, did.node),
+                    PointerCast(bcx, base::get_item_val(bcx.ccx(), did.node),
                                 T_ptr(type_of(bcx.ccx(), const_ty)))
-                } else {
-                    base::trans_external_path(ccx, did, const_ty)
-                };
+                }
+
+                let did = get_did(ccx, did);
+                let val = get_val(bcx, did, const_ty);
                 DatumBlock {
                     bcx: bcx,
                     datum: Datum {val: val,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -93,7 +93,7 @@ use middle::typeck::check::method::TransformTypeNormally;
 use middle::typeck::check::regionmanip::replace_bound_regions_in_fn_sig;
 use middle::typeck::check::vtable::{LocationInfo, VtableContext};
 use middle::typeck::CrateCtxt;
-use middle::typeck::infer::{resolve_type, force_tvar};
+use middle::typeck::infer::{resolve_type, force_tvar, mk_eqty};
 use middle::typeck::infer;
 use middle::typeck::rscope::{anon_rscope, binding_rscope, bound_self_region};
 use middle::typeck::rscope::{empty_rscope, in_anon_rscope};
@@ -2457,6 +2457,55 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
             let t_1_is_scalar = type_is_scalar(fcx, expr.span, t_1);
             if type_is_c_like_enum(fcx,expr.span,t_e) && t_1_is_scalar {
                 /* this case is allowed */
+            } else if type_is_region_ptr(fcx, expr.span, t_e) &&
+                      type_is_unsafe_ptr(fcx, expr.span, t_1) {
+
+                fn is_vec(t: ty::t) -> bool {
+                    match ty::get(t).sty {
+                      ty::ty_evec(_,_) => true,
+                      _ => false
+                    }
+                }
+                fn types_compatible(fcx: @mut FnCtxt, sp: span, t1: ty::t,
+                                    t2: ty::t) -> bool {
+                    if !is_vec(t1) {
+                        false
+                    } else {
+                        let el = ty::sequence_element_type(fcx.tcx(), t1);
+                        infer::mk_eqty(fcx.infcx(), false, sp, el, t2).is_ok()
+                    }
+                }
+
+                // Due to the limitations of LLVM global constants,
+                // region pointers end up pointing at copies of
+                // vector elements instead of the original values.
+                // To allow unsafe pointers to work correctly, we
+                // need to special-case obtaining an unsafe pointer
+                // from a region pointer to a vector.
+
+                /* this cast is only allowed from &static/[T] to *T or
+                   &static/T to *T. */
+                let te = structurally_resolved_type(fcx, e.span, t_e);
+                match (&ty::get(te).sty, &ty::get(t_1).sty) {
+                  (&ty::ty_rptr(re, mt1), &ty::ty_ptr(mt2))
+                    if types_compatible(fcx, e.span, mt1.ty, mt2.ty) => {
+                      match fcx.mk_subr(true, expr.span, ty::re_static, re) {
+                        result::Ok(()) => {
+                          /* this case is allowed for const expresisons */
+                        }
+                        result::Err(_) => {
+                          fcx.type_error_message(expr.span, |actual| {
+                              fmt!("non-static region to unsafe pointer \
+                                    cast: `%s` as `%s`", actual,
+                                   fcx.infcx().ty_to_str(t_1))
+                          }, t_e, None);
+                        }
+                      }
+                  }
+                  _ => {
+                    demand::coerce(fcx, e.span, t_1, e);
+                  }
+                }
             } else if !(type_is_scalar(fcx,expr.span,t_e) && t_1_is_scalar) {
                 /*
                 If more type combinations should be supported than are
@@ -3084,6 +3133,16 @@ pub fn type_is_integral(fcx: @mut FnCtxt, sp: span, typ: ty::t) -> bool {
 pub fn type_is_scalar(fcx: @mut FnCtxt, sp: span, typ: ty::t) -> bool {
     let typ_s = structurally_resolved_type(fcx, sp, typ);
     return ty::type_is_scalar(typ_s);
+}
+
+pub fn type_is_unsafe_ptr(fcx: @mut FnCtxt, sp: span, typ: ty::t) -> bool {
+    let typ_s = structurally_resolved_type(fcx, sp, typ);
+    return ty::type_is_unsafe_ptr(typ_s);
+}
+
+pub fn type_is_region_ptr(fcx: @mut FnCtxt, sp: span, typ: ty::t) -> bool {
+    let typ_s = structurally_resolved_type(fcx, sp, typ);
+    return ty::type_is_region_ptr(typ_s);
 }
 
 pub fn type_is_c_like_enum(fcx: @mut FnCtxt, sp: span, typ: ty::t) -> bool {

--- a/src/test/auxiliary/cci_const.rs
+++ b/src/test/auxiliary/cci_const.rs
@@ -1,0 +1,16 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub extern fn bar() {
+}
+
+pub const foopy: &static/str = "hi there";
+pub const uint_val: uint = 12;
+pub const uint_expr: uint = (1 << uint_val) - 1;

--- a/src/test/compile-fail/cast-vector-to-unsafe-nonstatic.rs
+++ b/src/test/compile-fail/cast-vector-to-unsafe-nonstatic.rs
@@ -1,0 +1,14 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let foo = ['h' as u8, 'i' as u8, 0 as u8];
+    let bar = &foo as *u8; //~ ERROR mismatched types
+}

--- a/src/test/compile-fail/const-cast-different-types.rs
+++ b/src/test/compile-fail/const-cast-different-types.rs
@@ -1,0 +1,16 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const a: &static/str = &"foo";
+const b: *u8 = a as *u8; //~ ERROR non-scalar cast
+const c: *u8 = &a as *u8; //~ ERROR mismatched types
+
+fn main() {
+}

--- a/src/test/compile-fail/const-cast-wrong-type.rs
+++ b/src/test/compile-fail/const-cast-wrong-type.rs
@@ -1,0 +1,15 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const a: [u8 * 3] = ['h' as u8, 'i' as u8, 0 as u8];
+const b: *i8 = &a as *i8; //~ ERROR mismatched types
+
+fn main() {
+}

--- a/src/test/run-pass/const-cast-ptr-int.rs
+++ b/src/test/run-pass/const-cast-ptr-int.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const a: *u8 = 0 as *u8;
+
+fn main() {
+    assert a == ptr::null();
+}

--- a/src/test/run-pass/const-cast.rs
+++ b/src/test/run-pass/const-cast.rs
@@ -1,0 +1,21 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern fn foo() {}
+
+const x: *u8 = foo;
+const y: *libc::c_void = x as *libc::c_void;
+const a: &int = &10;
+const b: *int = a as *int;
+
+fn main() {
+    assert x as *libc::c_void == y;
+    assert a as *int == b;
+}

--- a/src/test/run-pass/const-cross-crate-const.rs
+++ b/src/test/run-pass/const-cross-crate-const.rs
@@ -1,0 +1,25 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:cci_const.rs
+
+extern mod cci_const;
+const foo: &str = cci_const::foopy;
+const a: uint = cci_const::uint_val;
+const b: uint = cci_const::uint_expr + 5;
+
+fn main() {
+    assert a == 12;
+    let foo2 = a;
+    assert foo2 == cci_const::uint_val;
+    assert b == cci_const::uint_expr + 5;
+    assert foo == cci_const::foopy;
+}

--- a/src/test/run-pass/const-cross-crate-extern.rs
+++ b/src/test/run-pass/const-cross-crate-extern.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:cci_const.rs
+
+extern mod cci_const;
+use cci_const::bar;
+const foo: *u8 = bar;
+
+fn main() {
+    assert foo == cci_const::bar;
+}

--- a/src/test/run-pass/const-deref.rs
+++ b/src/test/run-pass/const-deref.rs
@@ -1,0 +1,16 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const a: [u8 * 1] = ['h' as u8];
+const b: u8 = (&a)[0];
+
+fn main() {
+    assert b == a[0];
+}

--- a/src/test/run-pass/const-str-ptr.rs
+++ b/src/test/run-pass/const-str-ptr.rs
@@ -1,0 +1,22 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const a: [u8 * 3] = ['h' as u8, 'i' as u8, 0 as u8];
+const c: &[u8 * 3] = &a;
+const b: *u8 = c as *u8;
+
+fn main() {
+    let foo = &a as *u8;
+    assert unsafe { str::raw::from_bytes(a) } == ~"hi\x00";
+    assert unsafe { str::raw::from_buf(foo) } == ~"hi";
+    assert unsafe { str::raw::from_buf(b) } == ~"hi";
+    assert unsafe { *b == a[0] };
+    assert unsafe { *(&c[0] as *u8) == a[0] };
+}


### PR DESCRIPTION
This is necessary for things like null pointers, for which ptr::null() is unusable.

r? @nikomatsakis 
