### PR TITLE
Make debug!, etc. macros not require a format string

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -409,14 +409,38 @@ pub fn core_macros() -> ~str {
 ~"pub mod macros {
     macro_rules! ignore (($($x:tt)*) => (()))
 
-    macro_rules! error ( ($( $arg:expr ),+) => (
-        log(::core::error, fmt!( $($arg),+ )) ))
-    macro_rules! warn ( ($( $arg:expr ),+) => (
-        log(::core::warn, fmt!( $($arg),+ )) ))
-    macro_rules! info ( ($( $arg:expr ),+) => (
-        log(::core::info, fmt!( $($arg),+ )) ))
-    macro_rules! debug ( ($( $arg:expr ),+) => (
-        log(::core::debug, fmt!( $($arg),+ )) ))
+    macro_rules! error (
+        ($arg:expr) => (
+            log(::core::error, fmt!( \"%?\", $arg ))
+        );
+        ($( $arg:expr ),+) => (
+            log(::core::error, fmt!( $($arg),+ ))
+        )
+    )
+    macro_rules! warn (
+        ($arg:expr) => (
+            log(::core::warn, fmt!( \"%?\", $arg ))
+        );
+        ($( $arg:expr ),+) => (
+            log(::core::warn, fmt!( $($arg),+ ))
+        )
+    )
+    macro_rules! info (
+        ($arg:expr) => (
+            log(::core::info, fmt!( \"%?\", $arg ))
+        );
+        ($( $arg:expr ),+) => (
+            log(::core::info, fmt!( $($arg),+ ))
+        )
+    )
+    macro_rules! debug (
+        ($arg:expr) => (
+            log(::core::debug, fmt!( \"%?\", $arg ))
+        );
+        ($( $arg:expr ),+) => (
+            log(::core::debug, fmt!( $($arg),+ ))
+        )
+    )
 
     macro_rules! fail(
         ($msg: expr) => (

--- a/src/test/run-pass/log-poly.rs
+++ b/src/test/run-pass/log-poly.rs
@@ -1,0 +1,10 @@
+enum Numbers {
+    Three
+}
+
+fn main() {
+    debug!(1);
+    info!(2.0);
+    warn!(Three);
+    error!(~[4]);
+}


### PR DESCRIPTION
r?

`log` can  polymorphically log anything, but debug!, etc. requires a format string. With this patch you can equivalently write `debug!(foo)` or `debug!("%?", foo)`.

I'm doing this because I was trying to remove `log` (replacing it with nothing, at least temporarily), but there are a number of logging statements that just want to print an arbitrary value and don't care about the format string.

I'm not entirely convinced this is a good change, since it overloads the implementation of these macros and makes their usage slightly more nuanced.
