### PR TITLE
mk: cleanup - minor fixes for android check

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -239,7 +239,7 @@ CFG_PATH_MUNGE_arm-unknown-android := true
 CFG_LDPATH_arm-unknown-android :=
 CFG_RUN_arm-unknown-android=
 CFG_RUN_TARG_arm-unknown-android=
-RUSTC_FLAGS_arm-unknown-android :=--android-cross-path='$(CFG_ANDROID_CROSS_PATH)'
+RUSTC_FLAGS_arm-unknown-android :=--android-cross-path=$(CFG_ANDROID_CROSS_PATH)
 
 # i686-pc-mingw32 configuration
 CC_i686-pc-mingw32=$(CC)

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -408,7 +408,7 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
         --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))			\
         --aux-base $$(S)src/test/auxiliary/                 \
         --stage-id stage$(1)-$(2)							\
-       --rustcflags "$$(CFG_RUSTC_FLAGS) --target=$(2)"	\
+        --rustcflags "$(RUSTC_FLAGS_$(2)) $$(CFG_RUSTC_FLAGS) --target=$(2)" \
         $$(CTEST_TESTARGS)
 
 CTEST_DEPS_rpass_$(1)-T-$(2)-H-$(3) = $$(RPASS_TESTS)


### PR DESCRIPTION
This fixes a problem on compiling test suits for android target.
