### PR TITLE
Revamp foreign code not to consider the Rust modes.  This requires

### DIFF
--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -61,7 +61,7 @@ pub mod rustrt {
         unsafe fn rust_getcwd() -> ~str;
         unsafe fn rust_path_is_dir(path: *libc::c_char) -> c_int;
         unsafe fn rust_path_exists(path: *libc::c_char) -> c_int;
-        unsafe fn rust_list_files2(&&path: ~str) -> ~[~str];
+        unsafe fn rust_list_files2(path: &~str) -> ~[~str];
         unsafe fn rust_process_wait(handle: c_int) -> c_int;
         unsafe fn rust_set_exit_status(code: libc::intptr_t);
     }
@@ -621,7 +621,8 @@ pub fn list_dir(p: &Path) -> ~[~str] {
         #[cfg(windows)]
         fn star(p: &Path) -> Path { p.push("*") }
 
-        do rustrt::rust_list_files2(star(p).to_str()).filtered |filename| {
+        let s = star(p).to_str();
+        do rustrt::rust_list_files2(&s).filtered |filename| {
             *filename != ~"." && *filename != ~".."
         }
     }

--- a/src/libcore/unstable.rs
+++ b/src/libcore/unstable.rs
@@ -45,7 +45,7 @@ mod rustrt {
         pub unsafe fn rust_lock_little_lock(lock: rust_little_lock);
         pub unsafe fn rust_unlock_little_lock(lock: rust_little_lock);
 
-        pub unsafe fn rust_raw_thread_start(f: &fn()) -> *raw_thread;
+        pub unsafe fn rust_raw_thread_start(f: &(&fn())) -> *raw_thread;
         pub unsafe fn rust_raw_thread_join_delete(thread: *raw_thread);
     }
 }
@@ -70,7 +70,7 @@ pub unsafe fn run_in_bare_thread(f: ~fn()) {
             let closure: &fn() = || {
                 f()
             };
-            let thread = rustrt::rust_raw_thread_start(closure);
+            let thread = rustrt::rust_raw_thread_start(&closure);
             rustrt::rust_raw_thread_join_delete(thread);
             chan.send(());
         }

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -757,7 +757,7 @@ pub fn trans_arg_expr(bcx: block,
 
         if formal_ty.ty != arg_datum.ty {
             // this could happen due to e.g. subtyping
-            let llformal_ty = type_of::type_of_explicit_arg(ccx, formal_ty);
+            let llformal_ty = type_of::type_of_explicit_arg(ccx, &formal_ty);
             debug!("casting actual type (%s) to match formal (%s)",
                    bcx.val_str(val), bcx.llty_str(llformal_ty));
             val = PointerCast(bcx, val, llformal_ty);

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -21,24 +21,22 @@ use util::ppaux;
 use core::option::None;
 use syntax::ast;
 
-pub fn type_of_explicit_arg(ccx: @CrateContext, arg: ty::arg) -> TypeRef {
-    let llty = type_of(ccx, arg.ty);
+pub fn arg_is_indirect(ccx: @CrateContext, arg: &ty::arg) -> bool {
     match ty::resolved_mode(ccx.tcx, arg.mode) {
-        ast::by_val => llty,
-        ast::by_copy => {
-            if ty::type_is_immediate(arg.ty) {
-                llty
-            } else {
-                T_ptr(llty)
-            }
-        }
-        _ => T_ptr(llty)
+        ast::by_val => false,
+        ast::by_copy => !ty::type_is_immediate(arg.ty),
+        ast::by_ref => true
     }
+}
+
+pub fn type_of_explicit_arg(ccx: @CrateContext, arg: &ty::arg) -> TypeRef {
+    let llty = type_of(ccx, arg.ty);
+    if arg_is_indirect(ccx, arg) {T_ptr(llty)} else {llty}
 }
 
 pub fn type_of_explicit_args(ccx: @CrateContext,
                              inputs: &[ty::arg]) -> ~[TypeRef] {
-    inputs.map(|arg| type_of_explicit_arg(ccx, *arg))
+    inputs.map(|arg| type_of_explicit_arg(ccx, arg))
 }
 
 pub fn type_of_fn(cx: @CrateContext, inputs: &[ty::arg],

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -30,10 +30,10 @@ pub mod rustrt {
 
         pub unsafe fn rust_tzset();
         // FIXME: The i64 values can be passed by-val when #2064 is fixed.
-        pub unsafe fn rust_gmtime(&&sec: i64, &&nsec: i32, &&result: Tm);
-        pub unsafe fn rust_localtime(&&sec: i64, &&nsec: i32, &&result: Tm);
-        pub unsafe fn rust_timegm(&&tm: Tm, sec: &mut i64);
-        pub unsafe fn rust_mktime(&&tm: Tm, sec: &mut i64);
+        pub unsafe fn rust_gmtime(sec: i64, nsec: i32, result: &mut Tm);
+        pub unsafe fn rust_localtime(sec: i64, nsec: i32, result: &mut Tm);
+        pub unsafe fn rust_timegm(tm: &Tm, sec: &mut i64);
+        pub unsafe fn rust_mktime(tm: &Tm, sec: &mut i64);
     }
 }
 
@@ -172,7 +172,7 @@ pub fn at_utc(clock: Timespec) -> Tm {
     unsafe {
         let mut Timespec { sec, nsec } = clock;
         let mut tm = empty_tm();
-        rustrt::rust_gmtime(sec, nsec, tm);
+        rustrt::rust_gmtime(sec, nsec, &mut tm);
         tm
     }
 }
@@ -187,7 +187,7 @@ pub fn at(clock: Timespec) -> Tm {
     unsafe {
         let mut Timespec { sec, nsec } = clock;
         let mut tm = empty_tm();
-        rustrt::rust_localtime(sec, nsec, tm);
+        rustrt::rust_localtime(sec, nsec, &mut tm);
         tm
     }
 }
@@ -217,9 +217,9 @@ pub impl Tm {
         unsafe {
             let mut sec = 0i64;
             if self.tm_gmtoff == 0_i32 {
-                rustrt::rust_timegm(*self, &mut sec);
+                rustrt::rust_timegm(self, &mut sec);
             } else {
-                rustrt::rust_mktime(*self, &mut sec);
+                rustrt::rust_mktime(self, &mut sec);
             }
             Timespec::new(sec, self.tm_nsec)
         }

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -486,18 +486,18 @@ rust_tzset() {
 }
 
 extern "C" CDECL void
-rust_gmtime(int64_t *sec, int32_t *nsec, rust_tm *timeptr) {
+rust_gmtime(int64_t sec, int32_t nsec, rust_tm *timeptr) {
     tm tm;
-    time_t s = *sec;
+    time_t s = sec;
     GMTIME(&s, &tm);
 
-    tm_to_rust_tm(&tm, timeptr, 0, "UTC", *nsec);
+    tm_to_rust_tm(&tm, timeptr, 0, "UTC", nsec);
 }
 
 extern "C" CDECL void
-rust_localtime(int64_t *sec, int32_t *nsec, rust_tm *timeptr) {
+rust_localtime(int64_t sec, int32_t nsec, rust_tm *timeptr) {
     tm tm;
-    time_t s = *sec;
+    time_t s = sec;
     LOCALTIME(&s, &tm);
 
 #if defined(__WIN32__)
@@ -509,7 +509,7 @@ rust_localtime(int64_t *sec, int32_t *nsec, rust_tm *timeptr) {
     const char *zone = tm.tm_zone;
 #endif
 
-    tm_to_rust_tm(&tm, timeptr, gmtoff, zone, *nsec);
+    tm_to_rust_tm(&tm, timeptr, gmtoff, zone, nsec);
 }
 
 extern "C" CDECL void
@@ -868,6 +868,38 @@ extern "C" void
 rust_dec_kernel_live_count() {
     rust_task *task = rust_get_current_task();
     task->kernel->dec_live_count();
+}
+
+// These functions are used in the unit tests for C ABI calls.
+
+extern "C" CDECL uint32_t
+rust_dbg_extern_identity_u32(uint32_t u) {
+    return u;
+}
+
+extern "C" CDECL uint64_t
+rust_dbg_extern_identity_u64(uint64_t u) {
+    return u;
+}
+
+struct TwoU64s {
+    uint64_t one;
+    uint64_t two;
+};
+
+extern "C" CDECL TwoU64s
+rust_dbg_extern_identity_TwoU64s(TwoU64s u) {
+    return u;
+}
+
+extern "C" CDECL double
+rust_dbg_extern_identity_double(double u) {
+    return u;
+}
+
+extern "C" CDECL char
+rust_dbg_extern_identity_u8(char u) {
+    return u;
 }
 
 //

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -188,3 +188,8 @@ rust_get_global_data_ptr
 rust_inc_kernel_live_count
 rust_dec_kernel_live_count
 rust_get_exchange_count_ptr
+rust_dbg_extern_identity_u32
+rust_dbg_extern_identity_u64
+rust_dbg_extern_identity_TwoU64s
+rust_dbg_extern_identity_double
+rust_dbg_extern_identity_u8

--- a/src/test/run-pass/extern-pass-TwoU64s-ref.rs
+++ b/src/test/run-pass/extern-pass-TwoU64s-ref.rs
@@ -1,0 +1,29 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we ignore modes when calling extern functions.
+
+#[deriving_eq]
+struct TwoU64s {
+    one: u64, two: u64
+}
+
+pub extern {
+    pub fn rust_dbg_extern_identity_TwoU64s(&&u: TwoU64s) -> TwoU64s;
+}
+
+fn main() {
+    unsafe {
+        let x = TwoU64s {one: 22, two: 23};
+        let y = rust_dbg_extern_identity_TwoU64s(x);
+        fail_unless!(x == y);
+    }
+}
+

--- a/src/test/run-pass/extern-pass-TwoU64s.rs
+++ b/src/test/run-pass/extern-pass-TwoU64s.rs
@@ -1,0 +1,30 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test a foreign function that accepts and returns a struct
+// by value.
+
+#[deriving_eq]
+struct TwoU64s {
+    one: u64, two: u64
+}
+
+pub extern {
+    pub fn rust_dbg_extern_identity_TwoU64s(v: TwoU64s) -> TwoU64s;
+}
+
+fn main() {
+    unsafe {
+        let x = TwoU64s {one: 22, two: 23};
+        let y = rust_dbg_extern_identity_TwoU64s(x);
+        fail_unless!(x == y);
+    }
+}
+

--- a/src/test/run-pass/extern-pass-char.rs
+++ b/src/test/run-pass/extern-pass-char.rs
@@ -1,0 +1,22 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test a function that takes/returns a u8.
+
+pub extern {
+    pub fn rust_dbg_extern_identity_u8(v: u8) -> u8;
+}
+
+fn main() {
+    unsafe {
+        fail_unless!(22_u8 == rust_dbg_extern_identity_u8(22_u8));
+    }
+}
+

--- a/src/test/run-pass/extern-pass-double.rs
+++ b/src/test/run-pass/extern-pass-double.rs
@@ -1,0 +1,20 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub extern {
+    pub fn rust_dbg_extern_identity_double(v: f64) -> f64;
+}
+
+fn main() {
+    unsafe {
+        fail_unless!(22.0_f64 == rust_dbg_extern_identity_double(22.0_f64));
+    }
+}
+

--- a/src/test/run-pass/extern-pass-u32.rs
+++ b/src/test/run-pass/extern-pass-u32.rs
@@ -1,0 +1,22 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test a function that takes/returns a u32.
+
+pub extern {
+    pub fn rust_dbg_extern_identity_u32(v: u32) -> u32;
+}
+
+fn main() {
+    unsafe {
+        fail_unless!(22_u32 == rust_dbg_extern_identity_u32(22_u32));
+    }
+}
+

--- a/src/test/run-pass/extern-pass-u64.rs
+++ b/src/test/run-pass/extern-pass-u64.rs
@@ -1,0 +1,22 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test a call to a function that takes/returns a u64.
+
+pub extern {
+    pub fn rust_dbg_extern_identity_u64(v: u64) -> u64;
+}
+
+fn main() {
+    unsafe {
+        fail_unless!(22_u64 == rust_dbg_extern_identity_u64(22_u64));
+    }
+}
+


### PR DESCRIPTION
Revamp foreign code not to consider the Rust modes.  This requires
adjusting a few foreign functions that were declared with by-ref
mode.  This also allows us to remove by-val mode in the near future.

With copy mode, though, we have to be careful because Rust will implicitly pass
somethings by pointer but this may not be the C ABI rules.  For example, rust
will pass a `struct Foo` as a `Foo*`.  So I added some code into the adapters to
fix this (though the C ABI rules may put the pointer back, oh well).

This patch also includes a lint mode for the use of by-ref mode
in foreign functions as the semantics of this have changed.

r? @brson
