### PR TITLE
Inline assembly

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -11,7 +11,7 @@ elseif exists("b:current_syntax")
 endif
 
 syn match     rustAssert      "\<assert\(\w\)*"
-syn keyword   rustKeyword     as break
+syn keyword   rustKeyword     __asm__ as break
 syn keyword   rustKeyword     copy do drop else extern
 syn keyword   rustKeyword     for if impl let log
 syn keyword   rustKeyword     loop match mod once priv pub pure

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -11,7 +11,7 @@ elseif exists("b:current_syntax")
 endif
 
 syn match     rustAssert      "\<assert\(\w\)*"
-syn keyword   rustKeyword     __asm__ as break
+syn keyword   rustKeyword     as break
 syn keyword   rustKeyword     copy do drop else extern
 syn keyword   rustKeyword     for if impl let log
 syn keyword   rustKeyword     loop match mod once priv pub pure

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -188,6 +188,12 @@ pub enum Metadata {
     MD_tbaa_struct = 5
 }
 
+// Inline Asm Dialect
+pub enum AsmDialect {
+    AD_ATT   = 0,
+    AD_Intel = 1
+}
+
 // Opaque pointer types
 pub enum Module_opaque {}
 pub type ModuleRef = *Module_opaque;
@@ -217,9 +223,9 @@ pub enum SectionIterator_opaque {}
 pub type SectionIteratorRef = *SectionIterator_opaque;
 
 pub mod llvm {
-    use super::{AtomicBinOp, AtomicOrdering, BasicBlockRef, Bool, BuilderRef};
-    use super::{ContextRef, MemoryBufferRef, ModuleRef, ObjectFileRef};
-    use super::{Opcode, PassManagerRef, PassManagerBuilderRef};
+    use super::{AsmDialect, AtomicBinOp, AtomicOrdering, BasicBlockRef};
+    use super::{Bool, BuilderRef, ContextRef, MemoryBufferRef, ModuleRef};
+    use super::{ObjectFileRef, Opcode, PassManagerRef, PassManagerBuilderRef};
     use super::{SectionIteratorRef, TargetDataRef, TypeKind, TypeRef, UseRef};
     use super::{ValueRef};
 
@@ -1437,7 +1443,8 @@ pub mod llvm {
         /** Prepares inline assembly. */
         pub unsafe fn LLVMInlineAsm(Ty: TypeRef, AsmString: *c_char,
                                     Constraints: *c_char, SideEffects: Bool,
-                                    AlignStack: Bool) -> ValueRef;
+                                    AlignStack: Bool, Dialect: AsmDialect)
+                                 -> ValueRef;
     }
 }
 

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1433,6 +1433,11 @@ pub mod llvm {
 
         /** Enables LLVM debug output. */
         pub unsafe fn LLVMSetDebug(Enabled: c_int);
+
+        /** Prepares inline assembly. */
+        pub unsafe fn LLVMInlineAsm(Ty: TypeRef, AsmString: *c_char,
+                                    Constraints: *c_char, SideEffects: Bool,
+                                    AlignStack: Bool) -> ValueRef;
     }
 }
 

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -620,7 +620,8 @@ fn visit_expr(expr: @expr, &&self: @mut IrMaps, vt: vt<@mut IrMaps>) {
       expr_do_body(*) | expr_cast(*) | expr_unary(*) | expr_break(_) |
       expr_again(_) | expr_lit(_) | expr_ret(*) | expr_block(*) |
       expr_assign(*) | expr_swap(*) | expr_assign_op(*) | expr_mac(*) |
-      expr_struct(*) | expr_repeat(*) | expr_paren(*) => {
+      expr_struct(*) | expr_repeat(*) | expr_paren(*) |
+      expr_inline_asm(*) => {
           visit::visit_expr(expr, self, vt);
       }
     }
@@ -1345,6 +1346,7 @@ pub impl Liveness {
             self.propagate_through_expr(e, succ)
           }
 
+          expr_inline_asm(*) |
           expr_lit(*) => {
             succ
           }
@@ -1618,7 +1620,7 @@ fn check_expr(expr: @expr, &&self: @Liveness, vt: vt<@Liveness>) {
       expr_cast(*) | expr_unary(*) | expr_ret(*) | expr_break(*) |
       expr_again(*) | expr_lit(_) | expr_block(*) | expr_swap(*) |
       expr_mac(*) | expr_addr_of(*) | expr_struct(*) | expr_repeat(*) |
-      expr_paren(*) => {
+      expr_paren(*) | expr_inline_asm(*) => {
         visit::visit_expr(expr, self, vt);
       }
     }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -447,7 +447,7 @@ pub impl mem_categorization_ctxt {
           ast::expr_while(*) | ast::expr_block(*) | ast::expr_loop(*) |
           ast::expr_match(*) | ast::expr_lit(*) | ast::expr_break(*) |
           ast::expr_mac(*) | ast::expr_again(*) | ast::expr_struct(*) |
-          ast::expr_repeat(*) => {
+          ast::expr_repeat(*) | ast::expr_inline_asm(*) => {
             return self.cat_rvalue(expr, expr_ty);
           }
         }

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -560,7 +560,8 @@ pub impl VisitContext {
 
             expr_break(*) |
             expr_again(*) |
-            expr_lit(*) => {}
+            expr_lit(*)   |
+            expr_inline_asm(*) => {}
 
             expr_loop(ref blk, _) => {
                 self.consume_block(blk, visitor);

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -18,7 +18,7 @@ use syntax::codemap::span;
 
 use core::prelude::*;
 use core::cast;
-use core::libc::{c_uint, c_int, c_ulonglong};
+use core::libc::{c_uint, c_int, c_ulonglong, c_char};
 use core::libc;
 use core::option::Some;
 use core::ptr;
@@ -869,6 +869,17 @@ pub fn add_comment(bcx: block, text: &str) {
             });
             Call(bcx, asm, ~[]);
         }
+    }
+}
+
+pub fn InlineAsmCall(cx: block, asm: *c_char, cons: *c_char) -> ValueRef {
+    unsafe {
+        count_insn(cx, "inlineasm");
+
+        let llfty = T_fn(~[], T_void());
+        let v = llvm::LLVMInlineAsm(llfty, asm, cons, False, False);
+
+        Call(cx, v, ~[])
     }
 }
 

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -873,12 +873,19 @@ pub fn add_comment(bcx: block, text: &str) {
 }
 
 pub fn InlineAsmCall(cx: block, asm: *c_char, cons: *c_char,
-                     volatile: lib::llvm::Bool, dia: AsmDialect) -> ValueRef {
+                     volatile: bool, alignstack: bool,
+                     dia: AsmDialect) -> ValueRef {
     unsafe {
         count_insn(cx, "inlineasm");
 
+        let volatile = if volatile { lib::llvm::True }
+                       else        { lib::llvm::False };
+        let alignstack = if alignstack { lib::llvm::True }
+                         else          { lib::llvm::False };
+
         let llfty = T_fn(~[], T_void());
-        let v = llvm::LLVMInlineAsm(llfty, asm, cons, volatile, False, dia);
+        let v = llvm::LLVMInlineAsm(llfty, asm, cons, volatile,
+                                    alignstack, dia);
 
         Call(cx, v, ~[])
     }

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use lib::llvm::llvm;
-use lib::llvm::{CallConv, TypeKind, AtomicBinOp, AtomicOrdering};
+use lib::llvm::{CallConv, TypeKind, AtomicBinOp, AtomicOrdering, AsmDialect};
 use lib::llvm::{Opcode, IntPredicate, RealPredicate, True, False};
 use lib::llvm::{ValueRef, TypeRef, BasicBlockRef, BuilderRef, ModuleRef};
 use lib;
@@ -872,12 +872,13 @@ pub fn add_comment(bcx: block, text: &str) {
     }
 }
 
-pub fn InlineAsmCall(cx: block, asm: *c_char, cons: *c_char) -> ValueRef {
+pub fn InlineAsmCall(cx: block, asm: *c_char, cons: *c_char,
+                     dia: AsmDialect) -> ValueRef {
     unsafe {
         count_insn(cx, "inlineasm");
 
         let llfty = T_fn(~[], T_void());
-        let v = llvm::LLVMInlineAsm(llfty, asm, cons, False, False);
+        let v = llvm::LLVMInlineAsm(llfty, asm, cons, False, False, dia);
 
         Call(cx, v, ~[])
     }

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -873,12 +873,12 @@ pub fn add_comment(bcx: block, text: &str) {
 }
 
 pub fn InlineAsmCall(cx: block, asm: *c_char, cons: *c_char,
-                     dia: AsmDialect) -> ValueRef {
+                     volatile: lib::llvm::Bool, dia: AsmDialect) -> ValueRef {
     unsafe {
         count_insn(cx, "inlineasm");
 
         let llfty = T_fn(~[], T_void());
-        let v = llvm::LLVMInlineAsm(llfty, asm, cons, False, False, dia);
+        let v = llvm::LLVMInlineAsm(llfty, asm, cons, volatile, False, dia);
 
         Call(cx, v, ~[])
     }

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -691,10 +691,14 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
         ast::expr_assign_op(op, dst, src) => {
             return trans_assign_op(bcx, expr, op, dst, src);
         }
-        ast::expr_inline_asm(asm, cons) => {
+        ast::expr_inline_asm(asm, cons, volatile) => {
+            // XXX: cons doesn't actual contain ALL the stuff we should
+            // be passing since the constraints for in/outputs aren't included
             do str::as_c_str(*asm) |a| {
                 do str::as_c_str(*cons) |c| {
-                    InlineAsmCall(bcx, a, c, lib::llvm::AD_ATT);
+                    let v = if volatile { lib::llvm::True }
+                            else        { lib::llvm::False };
+                    InlineAsmCall(bcx, a, c, v, lib::llvm::AD_ATT);
                 }
             }
             return bcx;

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -691,6 +691,14 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
         ast::expr_assign_op(op, dst, src) => {
             return trans_assign_op(bcx, expr, op, dst, src);
         }
+        ast::expr_inline_asm(asm, cons) => {
+            do str::as_c_str(*asm) |a| {
+                do str::as_c_str(*cons) |c| {
+                    InlineAsmCall(bcx, a, c);
+                }
+            }
+            return bcx;
+        }
         _ => {
             bcx.tcx().sess.span_bug(
                 expr.span,

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -694,7 +694,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
         ast::expr_inline_asm(asm, cons) => {
             do str::as_c_str(*asm) |a| {
                 do str::as_c_str(*cons) |c| {
-                    InlineAsmCall(bcx, a, c);
+                    InlineAsmCall(bcx, a, c, lib::llvm::AD_ATT);
                 }
             }
             return bcx;

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -691,14 +691,13 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
         ast::expr_assign_op(op, dst, src) => {
             return trans_assign_op(bcx, expr, op, dst, src);
         }
-        ast::expr_inline_asm(asm, cons, volatile) => {
+        ast::expr_inline_asm(asm, cons, volatile, alignstack) => {
             // XXX: cons doesn't actual contain ALL the stuff we should
             // be passing since the constraints for in/outputs aren't included
             do str::as_c_str(*asm) |a| {
                 do str::as_c_str(*cons) |c| {
-                    let v = if volatile { lib::llvm::True }
-                            else        { lib::llvm::False };
-                    InlineAsmCall(bcx, a, c, v, lib::llvm::AD_ATT);
+                    InlineAsmCall(bcx, a, c, volatile, alignstack,
+                                  lib::llvm::AD_ATT);
                 }
             }
             return bcx;

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -353,7 +353,7 @@ pub fn mark_for_expr(cx: Context, e: @expr) {
       expr_match(*) | expr_block(_) | expr_if(*) | expr_while(*) |
       expr_break(_) | expr_again(_) | expr_unary(_, _) | expr_lit(_) |
       expr_mac(_) | expr_addr_of(_, _) | expr_ret(_) | expr_loop(_, _) |
-      expr_loop_body(_) | expr_do_body(_) => ()
+      expr_loop_body(_) | expr_do_body(_) | expr_inline_asm(*) => ()
     }
 }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3076,6 +3076,7 @@ pub fn expr_kind(tcx: ctxt,
         ast::expr_block(*) |
         ast::expr_copy(*) |
         ast::expr_repeat(*) |
+        ast::expr_inline_asm(*) |
         ast::expr_lit(@codemap::spanned {node: lit_str(_), _}) |
         ast::expr_vstore(_, ast::expr_vstore_slice) |
         ast::expr_vstore(_, ast::expr_vstore_mut_slice) |

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2303,6 +2303,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         let region_lb = ty::re_scope(expr.id);
         instantiate_path(fcx, pth, tpt, expr.span, expr.id, region_lb);
       }
+      ast::expr_inline_asm(*) => { fcx.write_nil(id); }
       ast::expr_mac(_) => tcx.sess.bug(~"unexpanded macro"),
       ast::expr_break(_) => { fcx.write_bot(id); bot = true; }
       ast::expr_again(_) => { fcx.write_bot(id); bot = true; }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2303,7 +2303,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         let region_lb = ty::re_scope(expr.id);
         instantiate_path(fcx, pth, tpt, expr.span, expr.id, region_lb);
       }
-      ast::expr_inline_asm(*) => { 
+      ast::expr_inline_asm(*) => {
           fcx.require_unsafe(expr.span, ~"use of inline assembly");
           fcx.write_nil(id);
       }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2303,7 +2303,10 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         let region_lb = ty::re_scope(expr.id);
         instantiate_path(fcx, pth, tpt, expr.span, expr.id, region_lb);
       }
-      ast::expr_inline_asm(*) => { fcx.write_nil(id); }
+      ast::expr_inline_asm(*) => { 
+          fcx.require_unsafe(expr.span, ~"use of inline assembly");
+          fcx.write_nil(id);
+      }
       ast::expr_mac(_) => tcx.sess.bug(~"unexpanded macro"),
       ast::expr_break(_) => { fcx.write_bot(id); bot = true; }
       ast::expr_again(_) => { fcx.write_bot(id); bot = true; }

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -682,6 +682,7 @@ pub mod guarantor {
 
             // All of these expressions are rvalues and hence their
             // value is not guaranteed by a region pointer.
+            ast::expr_inline_asm(*) |
             ast::expr_mac(*) |
             ast::expr_lit(_) |
             ast::expr_unary(*) |

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -601,8 +601,8 @@ pub enum expr_ {
     expr_ret(Option<@expr>),
     expr_log(log_level, @expr, @expr),
 
-    /* asm, clobbers + constraints, volatile */
-    expr_inline_asm(@~str, @~str, bool),
+    /* asm, clobbers + constraints, volatile, align stack */
+    expr_inline_asm(@~str, @~str, bool, bool),
 
     expr_mac(mac),
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -601,7 +601,8 @@ pub enum expr_ {
     expr_ret(Option<@expr>),
     expr_log(log_level, @expr, @expr),
     
-    expr_inline_asm(@~str /* asm */, @~str /* constraints */),
+    /* asm, clobbers + constraints, volatile */
+    expr_inline_asm(@~str, @~str, bool),
 
     expr_mac(mac),
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -600,7 +600,7 @@ pub enum expr_ {
     expr_again(Option<ident>),
     expr_ret(Option<@expr>),
     expr_log(log_level, @expr, @expr),
-    
+
     /* asm, clobbers + constraints, volatile */
     expr_inline_asm(@~str, @~str, bool),
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -600,6 +600,8 @@ pub enum expr_ {
     expr_again(Option<ident>),
     expr_ret(Option<@expr>),
     expr_log(log_level, @expr, @expr),
+    
+    expr_inline_asm(@~str /* asm */, @~str /* constraints */),
 
     expr_mac(mac),
 

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -55,7 +55,6 @@ pub fn expand_asm(cx: ext_ctxt, sp: span, tts: &[ast::token_tree])
 
     let mut state = Asm;
     loop outer: {
-        
         match state {
             Asm => {
                 asm = expr_to_str(cx, p.parse_expr(),
@@ -65,11 +64,11 @@ pub fn expand_asm(cx: ext_ctxt, sp: span, tts: &[ast::token_tree])
                 while *p.token != token::EOF &&
                       *p.token != token::COLON &&
                       *p.token != token::MOD_SEP {
-                    
+
                     if outputs.len() != 0 {
                         p.eat(&token::COMMA);
                     }
-                    
+
                     let constraint = p.parse_str();
                     p.expect(&token::LPAREN);
                     let out = p.parse_expr();
@@ -82,11 +81,11 @@ pub fn expand_asm(cx: ext_ctxt, sp: span, tts: &[ast::token_tree])
                 while *p.token != token::EOF &&
                       *p.token != token::COLON &&
                       *p.token != token::MOD_SEP {
-                    
+
                     if inputs.len() != 0 {
                         p.eat(&token::COMMA);
                     }
-                    
+
                     let constraint = p.parse_str();
                     p.expect(&token::LPAREN);
                     let in = p.parse_expr();
@@ -100,11 +99,11 @@ pub fn expand_asm(cx: ext_ctxt, sp: span, tts: &[ast::token_tree])
                 while *p.token != token::EOF &&
                       *p.token != token::COLON &&
                       *p.token != token::MOD_SEP {
-                    
+
                     if clobs.len() != 0 {
                         p.eat(&token::COMMA);
                     }
-                    
+
                     let clob = ~"~{" + *p.parse_str() + ~"}";
                     clobs.push(clob);
                 }
@@ -113,7 +112,7 @@ pub fn expand_asm(cx: ext_ctxt, sp: span, tts: &[ast::token_tree])
             }
             Options => {
                 let option = *p.parse_str();
-                
+
                 if option == ~"volatile" {
                     volatile = true;
                 }
@@ -146,7 +145,7 @@ pub fn expand_asm(cx: ext_ctxt, sp: span, tts: &[ast::token_tree])
             } else if *p.token == token::EOF {
                 break outer;
             } else {
-               state 
+               state
             };
         }
     }

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -52,6 +52,7 @@ pub fn expand_asm(cx: ext_ctxt, sp: span, tts: &[ast::token_tree])
     let mut inputs = ~[];
     let mut cons = ~"";
     let mut volatile = false;
+    let mut alignstack = false;
 
     let mut state = Asm;
     loop outer: {
@@ -115,6 +116,8 @@ pub fn expand_asm(cx: ext_ctxt, sp: span, tts: &[ast::token_tree])
 
                 if option == ~"volatile" {
                     volatile = true;
+                } else if option == ~"alignstack" {
+                    alignstack = true;
                 }
 
                 if *p.token == token::COMMA {
@@ -153,7 +156,7 @@ pub fn expand_asm(cx: ext_ctxt, sp: span, tts: &[ast::token_tree])
     MRExpr(@ast::expr {
         id: cx.next_id(),
         callee_id: cx.next_id(),
-        node: ast::expr_inline_asm(@asm, @cons, volatile),
+        node: ast::expr_inline_asm(@asm, @cons, volatile, alignstack),
         span: sp
     })
 }

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -1,0 +1,54 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+
+/*
+ * Inline assembly support.
+ */
+
+use core::prelude::*;
+
+use ast;
+use codemap::span;
+use ext::base;
+use ext::base::*;
+
+pub fn expand_asm(cx: ext_ctxt, sp: span, tts: &[ast::token_tree])
+    -> base::MacResult {
+    let args = get_exprs_from_tts(cx, tts);
+    if args.len() == 0 {
+        cx.span_fatal(sp, "ast! takes at least 1 argument.");
+    }
+    let asm =
+        expr_to_str(cx, args[0],
+                    ~"inline assembly must be a string literal.");
+    let cons = if args.len() > 1 {
+        expr_to_str(cx, args[1],
+                    ~"constraints must be a string literal.")
+    } else { ~"" };
+
+    MRExpr(@ast::expr {
+        id: cx.next_id(),
+        callee_id: cx.next_id(),
+        node: ast::expr_inline_asm(@asm, @cons),
+        span: sp
+    })
+}
+
+//
+// Local Variables:
+// mode: rust
+// fill-column: 78;
+// indent-tabs-mode: nil
+// c-basic-offset: 4
+// buffer-file-coding-system: utf-8-unix
+// End:
+//

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -198,6 +198,8 @@ pub fn syntax_expander_table() -> SyntaxEnv {
                                 ext::source_util::expand_mod));
     syntax_expanders.insert(@~"proto",
                             builtin_item_tt(ext::pipes::expand_proto));
+    syntax_expanders.insert(@~"asm",
+                            builtin_normal_tt(ext::asm::expand_asm));
     syntax_expanders.insert(
         @~"trace_macros",
         builtin_normal_tt(ext::trace_macros::expand_trace_macros));

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -560,6 +560,7 @@ pub fn noop_fold_expr(e: &expr_, fld: @ast_fold) -> expr_ {
                 fld.fold_expr(e)
             )
         }
+        expr_inline_asm(*) => copy *e,
         expr_mac(ref mac) => expr_mac(fold_mac((*mac))),
         expr_struct(path, ref fields, maybe_expr) => {
             expr_struct(

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -27,7 +27,7 @@ use ast::{expr_field, expr_fn_block, expr_if, expr_index};
 use ast::{expr_lit, expr_log, expr_loop, expr_loop_body, expr_mac};
 use ast::{expr_method_call, expr_paren, expr_path, expr_repeat};
 use ast::{expr_ret, expr_swap, expr_struct, expr_tup, expr_unary};
-use ast::{expr_vec, expr_vstore, expr_vstore_mut_box};
+use ast::{expr_vec, expr_vstore, expr_vstore_mut_box, expr_inline_asm};
 use ast::{expr_vstore_fixed, expr_vstore_slice, expr_vstore_box};
 use ast::{expr_vstore_mut_slice, expr_while, extern_fn, field, fn_decl};
 use ast::{expr_vstore_uniq, TyClosure, TyBareFn, Onceness, Once, Many};
@@ -1184,6 +1184,14 @@ pub impl Parser {
                 }
             }
             hi = self.span.hi;
+        } else if self.eat_keyword(&~"__asm__") {
+            self.expect(&token::LPAREN);
+            let asm = self.parse_str();
+            self.expect(&token::COMMA);
+            let cons = self.parse_str();
+            ex = expr_inline_asm(asm, cons);
+            hi = self.span.hi;
+            self.expect(&token::RPAREN);
         } else if self.eat_keyword(&~"log") {
             self.expect(&token::LPAREN);
             let lvl = self.parse_expr();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1184,14 +1184,6 @@ pub impl Parser {
                 }
             }
             hi = self.span.hi;
-        } else if self.eat_keyword(&~"__asm__") {
-            self.expect(&token::LPAREN);
-            let asm = self.parse_str();
-            self.expect(&token::COMMA);
-            let cons = self.parse_str();
-            ex = expr_inline_asm(asm, cons);
-            hi = self.span.hi;
-            self.expect(&token::RPAREN);
         } else if self.eat_keyword(&~"log") {
             self.expect(&token::LPAREN);
             let lvl = self.parse_expr();

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -488,7 +488,6 @@ pub fn temporary_keyword_table() -> HashMap<~str, ()> {
 pub fn strict_keyword_table() -> HashMap<~str, ()> {
     let words = HashMap();
     let keys = ~[
-        ~"__asm__",
         ~"as", ~"assert",
         ~"break",
         ~"const", ~"copy",

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -488,6 +488,7 @@ pub fn temporary_keyword_table() -> HashMap<~str, ()> {
 pub fn strict_keyword_table() -> HashMap<~str, ()> {
     let words = HashMap();
     let keys = ~[
+        ~"__asm__",
         ~"as", ~"assert",
         ~"break",
         ~"const", ~"copy",

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1398,7 +1398,7 @@ pub fn print_expr(s: @ps, &&expr: @ast::expr) {
           }
         }
       }
-      ast::expr_inline_asm(a, c, v) => {
+      ast::expr_inline_asm(a, c, v, _) => {
         if v {
             word(s.s, ~"__volatile__ asm!");
         } else {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1398,8 +1398,12 @@ pub fn print_expr(s: @ps, &&expr: @ast::expr) {
           }
         }
       }
-      ast::expr_inline_asm(a, c) => {
-        word(s.s, ~"__asm__");
+      ast::expr_inline_asm(a, c, v) => {
+        if v {
+            word(s.s, ~"__volatile__ asm!");
+        } else {
+            word(s.s, ~"asm!");
+        }
         popen(s);
         print_string(s, *a);
         word_space(s, ~",");

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1402,7 +1402,7 @@ pub fn print_expr(s: @ps, &&expr: @ast::expr) {
         word(s.s, ~"__asm__");
         popen(s);
         print_string(s, *a);
-        word_space(s, ~", ");
+        word_space(s, ~",");
         print_string(s, *c);
         pclose(s);
       }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1398,6 +1398,14 @@ pub fn print_expr(s: @ps, &&expr: @ast::expr) {
           }
         }
       }
+      ast::expr_inline_asm(a, c) => {
+        word(s.s, ~"__asm__");
+        popen(s);
+        print_string(s, *a);
+        word_space(s, ~", ");
+        print_string(s, *c);
+        pclose(s);
+      }
       ast::expr_mac(ref m) => print_mac(s, (*m)),
       ast::expr_paren(e) => {
           popen(s);

--- a/src/libsyntax/syntax.rc
+++ b/src/libsyntax/syntax.rc
@@ -60,6 +60,7 @@ pub mod print {
 }
 
 pub mod ext {
+    pub mod asm;
     pub mod base;
     pub mod expand;
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -562,6 +562,7 @@ pub fn visit_expr<E>(ex: @expr, e: E, v: vt<E>) {
         }
         expr_mac(ref mac) => visit_mac((*mac), e, v),
         expr_paren(x) => (v.visit_expr)(x, e, v),
+        expr_inline_asm(*) => (),
     }
     (v.visit_expr_post)(ex, e, v);
 }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -545,9 +545,9 @@ extern "C" LLVMValueRef LLVMInlineAsm(LLVMTypeRef Ty,
                                       char *AsmString,
                                       char *Constraints,
                                       LLVMBool HasSideEffects,
-                                      LLVMBool IsAlignStack) {
+                                      LLVMBool IsAlignStack,
+                                      InlineAsm::AsmDialect Dialect) {
     return wrap(InlineAsm::get(unwrap<FunctionType>(Ty), AsmString,
                                Constraints, HasSideEffects,
-                               IsAlignStack));
-//                               IsAlignStack, InlineAsm::AD_Intel));
+                               IsAlignStack, Dialect));
 }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===
 
+#include "llvm/InlineAsm.h"
 #include "llvm/LLVMContext.h"
 #include "llvm/Linker.h"
 #include "llvm/PassManager.h"
@@ -538,4 +539,15 @@ extern "C" void LLVMSetDebug(int Enabled) {
 #ifndef NDEBUG
   DebugFlag = Enabled;
 #endif
+}
+
+extern "C" LLVMValueRef LLVMInlineAsm(LLVMTypeRef Ty,
+                                      char *AsmString,
+                                      char *Constraints,
+                                      LLVMBool HasSideEffects,
+                                      LLVMBool IsAlignStack) {
+    return wrap(InlineAsm::get(unwrap<FunctionType>(Ty), AsmString,
+                               Constraints, HasSideEffects,
+                               IsAlignStack));
+//                               IsAlignStack, InlineAsm::AD_Intel));
 }

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -583,3 +583,4 @@ LLVMX86MMXTypeInContext
 LLVMConstNamedStruct
 LLVMStructCreateNamed
 LLVMStructSetBody
+LLVMInlineAsm


### PR DESCRIPTION
Issue #98.

``` Rust
#[cfg(target_os = "macos")]
fn helloworld() {
    unsafe {
        asm!(".pushsection __RODATA, __rodata
                  msg: .asciz \"Hello World!\"
              .popsection
              lea msg(%rip), %rdi
              call _puts");
    }
}

#[cfg(target_os = "linux")]
fn helloworld() {
    unsafe {
        asm!(".pushsection .rodata
                  msg: .asciz \"Hello World!\"
              .popsection
              lea msg(%rip), %rdi
              call puts");
    }
}

fn main() {
    helloworld();
}
```

```
% rustc foo.rs
% ./foo
Hello World!
```
