### PR TITLE
Implement __morestack for ARM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/llvm"]
 	path = src/llvm
-	url = git://github.com/brson/llvm.git
+	url = git://github.com/ILyoan/llvm.git
 [submodule "src/libuv"]
 	path = src/libuv
 	url = git://github.com/brson/libuv.git

--- a/src/libcore/rt/thread_local_storage.rs
+++ b/src/libcore/rt/thread_local_storage.rs
@@ -40,6 +40,7 @@ type pthread_key_t = c_ulong;
 
 #[cfg(target_os="linux")]
 #[cfg(target_os="freebsd")]
+#[cfg(target_os="android")]
 #[allow(non_camel_case_types)] // foreign type
 type pthread_key_t = c_uint;
 

--- a/src/rt/arch/arm/morestack.S
+++ b/src/rt/arch/arm/morestack.S
@@ -3,6 +3,59 @@
 .arm
 .align
 
-.globl __morestack
+.global upcall_new_stack
+.global upcall_del_stack
+.global __morestack
 .hidden __morestack
+
+// r4 and r5 are scratch registers for __morestack due to llvm
+// ARMFrameLowering::adjustForSegmentedStacks() implementation.
+    .align 2
+    .type __morestack,%function
 __morestack:
+
+    // Save frame pointer and return address
+    push {fp, lr}
+    
+    mov fp, sp
+
+    // Save argument registers of the original function
+    push {r0, r1, r2, r3, lr}
+
+    mov r0, r4         // The amount of stack needed
+    add r1, fp, #20    // Address of stack arguments
+    mov r2, r5         // Size of stack arguments
+    
+    // Create new stack
+    bl upcall_new_stack@plt
+
+    // Hold new stack pointer
+    mov r5, r0
+
+    // Pop the saved arguments
+    pop {r0, r1, r2, r3, lr}
+
+    // Grab the return pointer
+    add r4, lr, #16    // Skip past the return
+    mov sp, r5         // Swich to the new stack
+    mov lr, pc
+    mov pc, r4         // Call the original function
+
+    // Switch back to rust stack
+    mov sp, fp
+
+    // Save return value
+    push {r0, r1}
+
+    // Remove the new allocated stack
+    bl upcall_del_stack@plt
+
+    // Restore return value
+    pop {r0, r1}
+
+    // Return
+    pop {fp, lr}
+    mov pc, lr
+.endofmorestack:
+    .size   __morestack, .endofmorestack-__morestack
+   

--- a/src/rt/arch/arm/record_sp.S
+++ b/src/rt/arch/arm/record_sp.S
@@ -9,53 +9,18 @@
 .globl get_sp
 
 record_sp_limit:
-	mov r3, r0
-	ldr r0, =my_cpu
-	mov r1, #0
-	mov r2, #0
-    stmfd   sp!, {r3, r7}
-    ldr     r7, =345
-    swi     #0
-    ldmfd   sp!, {r3, r7}
-    movs    r0, r0
-	movmi	r0, #0
-
-	ldr r1, =my_array
-	str r3, [r1, r0]
+	mrc p15, #0, r3, c13, c0, #3
+	add r3, r3, #252
+	str r0, [r3]
 	mov pc, lr
-
 
 get_sp_limit:
-    ldr r0, =my_cpu
-	mov r1, #0
-	mov r2, #0
-    stmfd   sp!, {r4, r7}
-    ldr     r7, =345
-    swi     #0
-    ldmfd   sp!, {r4, r7}
-    movs    r0, r0
-	movmi	r0, #0
-	mov r3, r0
-
-	ldr r1, =my_array
-	ldr r0, [r1, r3]
+	mrc p15, #0, r3, c13, c0, #3
+	add r3, r3, #252
+	ldr r0, [r3]
 	mov pc, lr
-
 
 get_sp:
 	mov r0, sp
 	mov pc, lr
-	
-.data
-my_cpu:	.long	0
-.global my_array
-my_array:	
-	.long	0
-	.long	0
-	.long	0
-	.long	0
-	.long	0
-	.long	0
-	.long	0
-	.long	0	
-.end
+

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -433,10 +433,10 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
   Options.EnableSegmentedStacks = EnableSegmentedStacks;
 
   std::string Err;
-  const Target *TheTarget = TargetRegistry::lookupTarget(triple, Err);
+  std::string Trip(Triple::normalize(triple));
   std::string FeaturesStr;
-  std::string Trip(triple);
   std::string CPUStr("generic");
+  const Target *TheTarget = TargetRegistry::lookupTarget(Trip, Err);
   TargetMachine *Target =
     TheTarget->createTargetMachine(Trip, CPUStr, FeaturesStr,
 				   Options, Reloc::PIC_,


### PR DESCRIPTION
Fix #4489

Enabling morestack on arm-android target.
Passed all of the make check tests except `fail!` relative stuffs(See #5265). I'm going to investigate this issue.

Recompilation of LLVM will be needed to build android-enabled rustc. but you might don't need to rebuild LLVM to build android-disabled(default) rustc.
