### PR TITLE
Fix std::getopts::opts_present() to check value.

### DIFF
--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -369,9 +369,9 @@ pub fn opt_count(mm: &Matches, nm: &str) -> uint {
 pub fn opts_present(mm: &Matches, names: &[~str]) -> bool {
     for vec::each(names) |nm| {
         match find_opt(mm.opts, mkname(*nm)) {
-          Some(_) => return true,
-          None    => ()
-        }
+            Some(id) if !mm.vals[id].is_empty() => return true,
+            _ => (),
+        };
     }
     false
 }
@@ -1174,7 +1174,7 @@ mod tests {
     #[test]
     pub fn test_multi() {
         let args = ~[~"-e", ~"foo", ~"--encrypt", ~"foo"];
-        let opts = ~[optopt(~"e"), optopt(~"encrypt")];
+        let opts = ~[optopt(~"e"), optopt(~"encrypt"), optopt(~"f")];
         let matches = &match getopts(args, opts) {
           result::Ok(m) => m,
           result::Err(_) => fail!()
@@ -1183,6 +1183,7 @@ mod tests {
         fail_unless!(opts_present(matches, ~[~"encrypt"]));
         fail_unless!(opts_present(matches, ~[~"encrypt", ~"e"]));
         fail_unless!(opts_present(matches, ~[~"e", ~"encrypt"]));
+        fail_unless!(!opts_present(matches, ~[~"f"]));
         fail_unless!(!opts_present(matches, ~[~"thing"]));
         fail_unless!(!opts_present(matches, ~[]));
 


### PR DESCRIPTION
Currently the opts_present() function only checks to see if the option is
configured in the match, but doesn't actually check to see if the option
value has been set.  This means that opt_present('h') may return false while
opts_present([~'h']) returns true.

Add a test case to catch this condition and fix opts_present() to check
the value before returning true.

Note, there is another API difference between these two functions that this
does not address.  Currently if you pass a non-configured option to
opt_present() the program will fail!(), but opts_present() simply returns
false.  If it is acceptable to standardize on the fail!() then opts_present()
should probably be implemented in terms of the opt_present() function.
