### PR TITLE
Refine the link_args that are propagated

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -818,7 +818,11 @@ pub fn link_binary(sess: Session,
     do cstore::iter_crate_data(cstore) |crate_num, _| {
         let link_args = csearch::get_link_args_for_crate(cstore, crate_num);
         do vec::consume(link_args) |_, link_arg| {
-            cc_args.push(link_arg);
+            // Linker arguments that don't begin with - are likely file names,
+            // so they should not be necessary.
+            if link_arg.starts_with("-") {
+              cc_args.push(link_arg);
+            }
         }
     }
 


### PR DESCRIPTION
The original change bit Servo because rust-harfbuzz includes libharfbuzz.a in its link_args. This works fine in the rust-harfbuzz subdirectory where the static library resides, but when this is propagated to servo_gfx, the lirbrary can no longer be found since it's a relative path.
