### PR TITLE
Copy libsyntax from local Rust to stage0.

### DIFF
--- a/src/etc/local_stage0.sh
+++ b/src/etc/local_stage0.sh
@@ -46,3 +46,4 @@ cp ${PREFIX}/lib/rustc/${TARG_DIR}/${LIBDIR}/* ${TARG_DIR}/stage0/${LIBDIR}/
 cp ${PREFIX}/lib/librust*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/
 cp ${PREFIX}/lib/libcore*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/
 cp ${PREFIX}/lib/libstd*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/
+cp ${PREFIX}/lib/libsyntax*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/


### PR DESCRIPTION
The `local_stage0.sh` script was not updated after commit 7dcbaed renamed
librustsyntax to libsyntax.

Currently, `./configure --enable-local-rust --local-rust-root=FOO && make` will
fail due to the missing libsyntax; this change corrects this.
