### PR TITLE
Remove unused imports

### DIFF
--- a/src/libcore/at_vec.rs
+++ b/src/libcore/at_vec.rs
@@ -13,7 +13,6 @@
 use cast::transmute;
 use kinds::Copy;
 use iter;
-use libc;
 use option::Option;
 use ptr::addr_of;
 use sys;

--- a/src/libcore/num/cmath.rs
+++ b/src/libcore/num/cmath.rs
@@ -10,10 +10,6 @@
 
 #[doc(hidden)]; // FIXME #3538
 
-use libc::c_int;
-use libc::c_float;
-use libc::c_double;
-
 // function names are almost identical to C's libmath, a few have been
 // renamed, grep for "rename:"
 

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -19,7 +19,6 @@ use iter::BaseIter;
 use iter;
 use kinds::Copy;
 use libc;
-use libc::size_t;
 use option::{None, Option, Some};
 use unstable::intrinsics;
 use ptr;
@@ -76,9 +75,9 @@ pub fn reserve<T>(v: &mut ~[T], n: uint) {
             let td = sys::get_type_desc::<T>();
             if ((**ptr).box_header.ref_count ==
                 managed::raw::RC_MANAGED_UNIQUE) {
-                rustrt::vec_reserve_shared_actual(td, ptr, n as size_t);
+                rustrt::vec_reserve_shared_actual(td, ptr, n as libc::size_t);
             } else {
-                rustrt::vec_reserve_shared(td, ptr, n as size_t);
+                rustrt::vec_reserve_shared(td, ptr, n as libc::size_t);
             }
         }
     }
@@ -2071,7 +2070,6 @@ pub mod raw {
     use kinds::Copy;
     use managed;
     use option::{None, Some};
-    use option;
     use unstable::intrinsics;
     use ptr::addr_of;
     use ptr;

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -30,7 +30,6 @@ use syntax::ast::ident;
 use syntax::ast_map::path_mod;
 use syntax::ast_util;
 use syntax::codemap::span;
-use syntax::print::pprust::expr_to_str;
 
 pub fn trans_block(bcx: block, b: &ast::blk, dest: expr::Dest) -> block {
     let _icx = bcx.insn_ctxt("trans_block");

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1706,7 +1706,6 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         let expr_t = structurally_resolved_type(fcx, expr.span,
                                                 fcx.expr_ty(base));
         let (base_t, derefs) = do_autoderef(fcx, expr.span, expr_t);
-        let n_tys = tys.len();
 
         match structure_of(fcx, expr.span, base_t) {
             ty::ty_struct(base_id, ref substs) => {

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -26,7 +26,6 @@ use core::either::Either;
 use core::either;
 use core::io::WriterUtil;
 use core::io;
-use core::libc::size_t;
 use core::comm::{stream, Chan, Port, SharedChan};
 use core::option;
 use core::prelude::*;


### PR DESCRIPTION
Remove unused imports to get rid of warnings.
