### PR TITLE
Normalize target-triple so that llvm can recognize target os correctly

### DIFF
--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -433,10 +433,10 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
   Options.EnableSegmentedStacks = EnableSegmentedStacks;
 
   std::string Err;
-  const Target *TheTarget = TargetRegistry::lookupTarget(triple, Err);
+  std::string Trip(Triple::normalize(triple));
   std::string FeaturesStr;
-  std::string Trip(triple);
   std::string CPUStr("generic");
+  const Target *TheTarget = TargetRegistry::lookupTarget(Trip, Err);
   TargetMachine *Target =
     TheTarget->createTargetMachine(Trip, CPUStr, FeaturesStr,
 				   Options, Reloc::PIC_,


### PR DESCRIPTION
LLVM could not recognize target-os when target-triple was given as like 'arm-linux-androideabi'.
Normalizing target-triple fill the missing elements. 
In the case of 'arm-linux-androideabi', nomalized target-triple will be "arm-unknown-linux-androideabi" and this let llvm recognize the triple correctly. (arch: arm, vendor: unknown, os: linux, environment: android)
