### PR TITLE
add nonempty encoding for spans

### DIFF
--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -140,7 +140,7 @@ impl cmp::Eq for span {
 
 impl<S:Encoder> Encodable<S> for span {
     /* Note #1972 -- spans are encoded but not decoded */
-    fn encode(&self, _s: &S) { }
+    fn encode(&self, _s: &S) { _s.emit_nil() }
 }
 
 impl<D:Decoder> Decodable<D> for span {

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -297,10 +297,9 @@ mod test {
     use std;
     use core::io;
     use core::option::None;
-    use core::str;
     use util::testing::*;
 
-    #[test] fn to_json_str (val: @Encodable<std::json::Encoder>) -> ~str {
+    #[test] fn to_json_str<E : Encodable<std::json::Encoder>>(val: @E) -> ~str {
         do io::with_str_writer |writer| {
             val.encode(~std::json::Encoder(writer));
         }
@@ -312,7 +311,7 @@ mod test {
             @~"fn foo (x : int) { x; }",
             ~[],
             new_parse_sess(None));
-        check_equal(to_json_str(@tts as Encodable::<std::json::Encoder>),
+        check_equal(to_json_str(@tts),
                     ~"[[\"tt_tok\",[null,[\"IDENT\",[\"fn\",false]]]],\
                       [\"tt_tok\",[null,[\"IDENT\",[\"foo\",false]]]],\
                       [\"tt_delim\",[[[\"tt_tok\",[null,[\"LPAREN\",[]]]],\

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -312,18 +312,18 @@ mod test {
             @~"fn foo (x : int) { x; }",
             ~[],
             new_parse_sess(None));
-        check_equal(to_json_str(@tts as @Encodable<std::json::Encoder>),
-                    ~"[[\"tt_tok\",[,[\"IDENT\",[\"fn\",false]]]],\
-                      [\"tt_tok\",[,[\"IDENT\",[\"foo\",false]]]],\
-                      [\"tt_delim\",[[[\"tt_tok\",[,[\"LPAREN\",[]]]],\
-                      [\"tt_tok\",[,[\"IDENT\",[\"x\",false]]]],\
-                      [\"tt_tok\",[,[\"COLON\",[]]]],\
-                      [\"tt_tok\",[,[\"IDENT\",[\"int\",false]]]],\
-                      [\"tt_tok\",[,[\"RPAREN\",[]]]]]]],\
-                      [\"tt_delim\",[[[\"tt_tok\",[,[\"LBRACE\",[]]]],\
-                      [\"tt_tok\",[,[\"IDENT\",[\"x\",false]]]],\
-                      [\"tt_tok\",[,[\"SEMI\",[]]]],\
-                      [\"tt_tok\",[,[\"RBRACE\",[]]]]]]]]"
+        check_equal(to_json_str(@tts as Encodable::<std::json::Encoder>),
+                    ~"[[\"tt_tok\",[null,[\"IDENT\",[\"fn\",false]]]],\
+                      [\"tt_tok\",[null,[\"IDENT\",[\"foo\",false]]]],\
+                      [\"tt_delim\",[[[\"tt_tok\",[null,[\"LPAREN\",[]]]],\
+                      [\"tt_tok\",[null,[\"IDENT\",[\"x\",false]]]],\
+                      [\"tt_tok\",[null,[\"COLON\",[]]]],\
+                      [\"tt_tok\",[null,[\"IDENT\",[\"int\",false]]]],\
+                      [\"tt_tok\",[null,[\"RPAREN\",[]]]]]]],\
+                      [\"tt_delim\",[[[\"tt_tok\",[null,[\"LBRACE\",[]]]],\
+                      [\"tt_tok\",[null,[\"IDENT\",[\"x\",false]]]],\
+                      [\"tt_tok\",[null,[\"SEMI\",[]]]],\
+                      [\"tt_tok\",[null,[\"RBRACE\",[]]]]]]]]"
                    );
         let ast1 = new_parser_from_tts(new_parse_sess(None),~[],tts)
             .parse_item(~[]);


### PR DESCRIPTION
r? @nikomatsakis 
r? @erickt 

Before this change, encoding an object containing a codemap::span
using the JSON encodeng produced invalid JSON, for instance:
[{"span":,"global":false,"idents":["abc"]}]
Since the decoder for codemap::span's ignores its argument, I
conjecture that this will not damage decoding, and should improve
it for many decoders.
