### PR TITLE
document the semantics of the clone method

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/**
-Clonable types are copied with the clone method
-*/
+/// Clonable types are copied with the clone method
 pub trait Clone {
+    /// Perform a deep copy of the object, returning a new independent clone.
+    ///
+    /// A shallow copy can be performed instead if it is indistinguishable
+    /// from a deep copy, as it is for persistent (immutable) data structures.
     fn clone(&self) -> Self;
 }
 


### PR DESCRIPTION
@pcwalton: r?

Rust already has the concept of a shallow copy as part of the language (normal by-value assignment, parameters and return values), which is treated as a move of ownership for linear types. I don't think it would make sense to implement `Clone` as a shallow copy for some types but not others except where it's semantically equivalent. This just documents what `Clone` is supposed to represent so it gets used correctly.
