### PR TITLE
core: Add to_bytes method to StrSlice trait

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -2273,6 +2273,7 @@ pub trait StrSlice {
     pure fn to_owned(&self) -> ~str;
     pure fn to_managed(&self) -> @str;
     pure fn char_at(&self, i: uint) -> char;
+    fn to_bytes(&self) -> ~[u8];
 }
 
 /// Extension methods for strings
@@ -2416,6 +2417,8 @@ impl StrSlice for &self/str {
 
     #[inline]
     pure fn char_at(&self, i: uint) -> char { char_at(*self, i) }
+
+    fn to_bytes(&self) -> ~[u8] { to_bytes(*self) }
 }
 
 pub trait OwnedStr {


### PR DESCRIPTION
r?

I want to use this function as a method. There's probably a better way to design this but the existing `ToBytes` trait is not what I am looking for (it has a parameter to indicate the byte order).
