### PR TITLE
librustc: adjust logic for cfg attribute and add not predicate.

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -208,11 +208,11 @@ actual:\n\
                         testfile: &Path, src: ~str) -> ProcRes {
         compose_and_run_compiler(
             config, props, testfile,
-            make_typecheck_args(config, testfile),
+            make_typecheck_args(config, props, testfile),
             Some(src))
     }
 
-    fn make_typecheck_args(config: config, testfile: &Path) -> ProcArgs {
+    fn make_typecheck_args(config: config, props: TestProps, testfile: &Path) -> ProcArgs {
         let prog = config.rustc_path;
         let mut args = ~[~"-",
                          ~"--no-trans", ~"--lib",
@@ -220,6 +220,7 @@ actual:\n\
                          ~"-L",
                          aux_output_dir_name(config, testfile).to_str()];
         args += split_maybe_args(config.rustcflags);
+        args += split_maybe_args(props.compile_flags);
         return ProcArgs {prog: prog.to_str(), args: args};
     }
 }

--- a/src/test/compile-fail/test-cfg.rs
+++ b/src/test/compile-fail/test-cfg.rs
@@ -1,0 +1,18 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --cfg foo
+
+#[cfg(foo, bar)] // foo AND bar
+fn foo() {}
+
+fn main() {
+    foo(); //~ ERROR unresolved name: `foo`.
+}

--- a/src/test/run-pass/cfgs-on-items.rs
+++ b/src/test/run-pass/cfgs-on-items.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-fast
 // compile-flags: --cfg fooA --cfg fooB
 
 // fooA AND !bar

--- a/src/test/run-pass/cfgs-on-items.rs
+++ b/src/test/run-pass/cfgs-on-items.rs
@@ -13,7 +13,7 @@
 #[cfg(fooA, not(bar))] // fooA AND !bar
 fn foo1() -> int { 1 }
 
-#[cfg(not(fooA, bar))] // !(fooA AND bar)
+#[cfg(not(fooA, bar))] // !fooA AND !bar
 fn foo2() -> int { 2 }
 
 #[cfg(fooC)]

--- a/src/test/run-pass/cfgs-on-items.rs
+++ b/src/test/run-pass/cfgs-on-items.rs
@@ -1,0 +1,27 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --cfg fooA --cfg fooB
+
+#[cfg(fooA, not(bar))] // fooA AND !bar
+fn foo1() -> int { 1 }
+
+#[cfg(not(fooA, bar))] // !(fooA AND bar)
+fn foo2() -> int { 2 }
+
+#[cfg(fooC)]
+#[cfg(fooB, not(bar))] // fooB AND !bar
+fn foo2() -> int { 3 } // fooC OR (fooB AND !bar)
+
+
+fn main() {
+    fail_unless!(1 == foo1());
+    fail_unless!(3 == foo2());
+}

--- a/src/test/run-pass/cfgs-on-items.rs
+++ b/src/test/run-pass/cfgs-on-items.rs
@@ -10,15 +10,18 @@
 
 // compile-flags: --cfg fooA --cfg fooB
 
-#[cfg(fooA, not(bar))] // fooA AND !bar
+// fooA AND !bar
+#[cfg(fooA, not(bar))]
 fn foo1() -> int { 1 }
 
-#[cfg(not(fooA, bar))] // !fooA AND !bar
+// !fooA AND !bar
+#[cfg(not(fooA, bar))]
 fn foo2() -> int { 2 }
 
+// fooC OR (fooB AND !bar)
 #[cfg(fooC)]
-#[cfg(fooB, not(bar))] // fooB AND !bar
-fn foo2() -> int { 3 } // fooC OR (fooB AND !bar)
+#[cfg(fooB, not(bar))]
+fn foo2() -> int { 3 }
 
 
 fn main() {


### PR DESCRIPTION
This adopts the syntax from #2119. No more annoying workarounds involving wrapping in mods!
