### PR TITLE
Unwinding for ARM option2

### DIFF
--- a/src/rt/arch/arm/ccall.S
+++ b/src/rt/arch/arm/ccall.S
@@ -5,23 +5,18 @@
 
 .globl __morestack
 .hidden __morestack
+.type __morestack, %function
 __morestack:
-	mov r3, sp
+	.fnstart
+	.save {r4, fp, lr}
+	push {r4, fp, lr}
+    .movsp r4
+	mov r4, sp
 	mov sp, r2
-	
-	str r3, [sp]
-	str lr, [sp, #-4]
-	
-	sub sp, #8
-	
+	mov fp, sp
 	blx r1
-
-	add sp, #8
-	
-	ldr lr, [sp, #-4]
-	ldr r3, [sp] 
-	
-	mov sp, r3
+	mov sp, r4
+	pop {r4, fp, lr}
 	mov pc, lr
-	
+	.fnend
 

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -27,6 +27,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Assembly/Parser.h"
 #include "llvm/Assembly/PrintModulePass.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
@@ -427,6 +428,10 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
 			bool EnableSegmentedStacks) {
 
   LLVMRustInitializeTargets();
+
+  int argc = 2;
+  const char* argv[] = {"rustc", "-arm-enable-ehabi"};
+  cl::ParseCommandLineOptions(argc, argv);
 
   TargetOptions Options;
   Options.NoFramePointerElim = true;

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -429,8 +429,9 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
 
   LLVMRustInitializeTargets();
 
-  int argc = 2;
-  const char* argv[] = {"rustc", "-arm-enable-ehabi"};
+  int argc = 3;
+  const char* argv[] = {"rustc", "-arm-enable-ehabi",
+      "-arm-enable-ehabi-descriptors"};
   cl::ParseCommandLineOptions(argc, argv);
 
   TargetOptions Options;


### PR DESCRIPTION
Partial Fix for #5265
- Enabling LLVM ARM ehabi option.
- Add ARM debug information manually for ccall.s
- Compile object file using Android-NDK.

Current LLVM trunk version can generate ARM debug information for assembly files but it is incomplete for object files. Unwinding on ARM can be done with LLVM trunk(the LLVM submodule of rust has problem on generating ARM debug information). See #5368

The Android-NDK detour(0f89eab) can be removed after LLVM has complete feature of generating ARM debug information for object file.
