### PR TITLE
Refactor self-info

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -289,7 +289,8 @@ fn parse_ty(st: @mut PState, conv: conv_did) -> ty::t {
         return ty::mk_param(st.tcx, parse_int(st) as uint, did);
       }
       's' => {
-        return ty::mk_self(st.tcx);
+        let did = parse_def(st, TypeParameter, conv);
+        return ty::mk_self(st.tcx, did);
       }
       '@' => return ty::mk_box(st.tcx, parse_mt(st, conv)),
       '~' => return ty::mk_uniq(st.tcx, parse_mt(st, conv)),

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -312,8 +312,10 @@ fn enc_sty(w: @io::Writer, cx: @ctxt, +st: ty::sty) {
         w.write_char('|');
         w.write_str(uint::to_str(id));
       }
-      ty::ty_self => {
+      ty::ty_self(did) => {
         w.write_char('s');
+        w.write_str((cx.ds)(did));
+        w.write_char('|');
       }
       ty::ty_type => w.write_char('Y'),
       ty::ty_opaque_closure_ptr(p) => {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -297,7 +297,7 @@ pub impl Reflector {
               let extra = ~[self.c_uint(p.idx)];
               self.visit(~"param", extra)
           }
-          ty::ty_self => self.leaf(~"self"),
+          ty::ty_self(*) => self.leaf(~"self"),
           ty::ty_type => self.leaf(~"type"),
           ty::ty_opaque_box => self.leaf(~"opaque_box"),
           ty::ty_opaque_closure_ptr(ck) => {

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -144,7 +144,7 @@ pub fn sizing_type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
             T_struct(adt::sizing_fields_of(cx, repr))
         }
 
-        ty::ty_self | ty::ty_infer(*) | ty::ty_param(*) | ty::ty_err(*) => {
+        ty::ty_self(_) | ty::ty_infer(*) | ty::ty_param(*) | ty::ty_err(*) => {
             cx.tcx.sess.bug(
                 fmt!("fictitious type %? in sizing_type_of()",
                      ty::get(t).sty))
@@ -251,7 +251,7 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
                                               did,
                                               /*bad*/ copy substs.tps))
       }
-      ty::ty_self => cx.tcx.sess.unimpl(~"type_of: ty_self"),
+      ty::ty_self(*) => cx.tcx.sess.unimpl(~"type_of: ty_self"),
       ty::ty_infer(*) => cx.tcx.sess.bug(~"type_of with ty_infer"),
       ty::ty_param(*) => cx.tcx.sess.bug(~"type_of with ty_param"),
       ty::ty_err(*) => cx.tcx.sess.bug(~"type_of with ty_err")

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -64,7 +64,7 @@ use middle::typeck::{CrateCtxt, write_substs_to_tcx, write_ty_to_tcx};
 
 use core::result;
 use core::vec;
-use syntax::ast;
+use syntax::{ast, ast_util};
 use syntax::codemap::span;
 use syntax::print::pprust::{lifetime_to_str, path_to_str};
 use syntax::parse::token::special_idents;
@@ -400,12 +400,13 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + Durable>(
             check_path_args(tcx, path, NO_TPS | NO_REGIONS);
             ty::mk_param(tcx, n, id)
           }
-          ast::def_self_ty(_) => {
+          ast::def_self_ty(id) => {
             // n.b.: resolve guarantees that the self type only appears in a
             // trait, which we rely upon in various places when creating
             // substs
             check_path_args(tcx, path, NO_TPS | NO_REGIONS);
-            ty::mk_self(tcx)
+            let did = ast_util::local_def(id);
+            ty::mk_self(tcx, did)
           }
           _ => {
             tcx.sess.span_fatal(ast_ty.span,

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -307,12 +307,9 @@ pub impl LookupContext/&self {
                         self_ty, did, substs, store);
                     self.push_inherent_impl_candidates_for_type(did);
                 }
-                ty_self => {
+                ty_self(self_did) => {
                     // Call is of the form "self.foo()" and appears in one
                     // of a trait's default method implementations.
-                    let self_did = self.fcx.self_info.expect(
-                        ~"self_impl_def_id is undefined (`self` may not \
-                          be in scope here").def_id;
                     let substs = substs {
                         self_r: None,
                         self_ty: None,
@@ -932,7 +929,7 @@ pub impl LookupContext/&self {
             ty_bare_fn(*) | ty_box(*) | ty_uniq(*) | ty_rptr(*) |
             ty_infer(IntVar(_)) |
             ty_infer(FloatVar(_)) |
-            ty_self | ty_param(*) | ty_nil | ty_bot | ty_bool |
+            ty_self(_) | ty_param(*) | ty_nil | ty_bot | ty_bool |
             ty_int(*) | ty_uint(*) |
             ty_float(*) | ty_enum(*) | ty_ptr(*) | ty_struct(*) | ty_tup(*) |
             ty_estr(*) | ty_evec(*) | ty_trait(*) | ty_closure(*) => {

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -48,7 +48,7 @@ pub fn replace_bound_regions_in_fn_sig(
                 _}, _}) => {
         let region = ty::re_bound(ty::br_self);
         let ty = ty::mk_rptr(tcx, region,
-                             ty::mt { ty: ty::mk_self(tcx), mutbl: m });
+                             ty::mt { ty: ty::mk_nil(tcx), mutbl: m });
         all_tys.push(ty);
       }
       _ => {}

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -40,18 +40,8 @@ pub fn replace_bound_regions_in_fn_sig(
 
     let mut all_tys = ty::tys_in_fn_sig(fn_sig);
 
-    match self_info {
-      Some(SelfInfo {
-            explicit_self: codemap::spanned {
-                node: ast::sty_region(_, m),
-                // FIXME(#4846) ------^ Use this lifetime instead of self
-                _}, _}) => {
-        let region = ty::re_bound(ty::br_self);
-        let ty = ty::mk_rptr(tcx, region,
-                             ty::mt { ty: ty::mk_nil(tcx), mutbl: m });
-        all_tys.push(ty);
-      }
-      _ => {}
+    for self_info.each |self_info| {
+        all_tys.push(self_info.self_ty);
     }
 
     for self_ty.each |t| { all_tys.push(*t) }

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -283,8 +283,8 @@ pub fn resolve_type_vars_in_fn(fcx: @mut FnCtxt,
     let visit = mk_visitor();
     (visit.visit_block)(blk, wbcx, visit);
     for self_info.each |self_info| {
-        if self_info.explicit_self.node == ast::sty_static { break; }
-        resolve_type_vars_for_node(wbcx, self_info.explicit_self.span,
+        resolve_type_vars_for_node(wbcx,
+                                   self_info.span,
                                    self_info.self_id);
     }
     for decl.inputs.each |arg| {

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -94,7 +94,7 @@ pub fn get_base_type(inference_context: @mut InferCtxt,
 
         ty_nil | ty_bot | ty_bool | ty_int(*) | ty_uint(*) | ty_float(*) |
         ty_estr(*) | ty_evec(*) | ty_bare_fn(*) | ty_closure(*) | ty_tup(*) |
-        ty_infer(*) | ty_param(*) | ty_self | ty_type | ty_opaque_box |
+        ty_infer(*) | ty_param(*) | ty_self(*) | ty_type | ty_opaque_box |
         ty_opaque_closure_ptr(*) | ty_unboxed_vec(*) | ty_err | ty_box(_) |
         ty_uniq(_) | ty_ptr(_) | ty_rptr(_, _) => {
             debug!("(getting base type) no base type; found %?",

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -443,7 +443,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
                    str::from_bytes(~[('a' as u8) + (id as u8)]))
           }
       }
-      ty_self => ~"self",
+      ty_self(*) => ~"self",
       ty_enum(did, ref substs) | ty_struct(did, ref substs) => {
         let path = ty::item_path(cx, did);
         let base = ast_map::path_to_str(path, cx.sess.intr());

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -185,7 +185,7 @@ pub enum def {
                       /* trait */  Option<def_id>,
                       purity),
     def_self(node_id, bool /* is_implicit */),
-    def_self_ty(node_id),
+    def_self_ty(/* trait id */ node_id),
     def_mod(def_id),
     def_foreign_mod(def_id),
     def_const(def_id),


### PR DESCRIPTION
Refactor the self-info so that the def-id is carried in ty_self()and the fn_ctxt doesn't need any self_info field at all. Pull out explicit self transformation into `check_method`. Step towards fixing `fn(&self)` to have a distinct lifetime. (cc #4846) 

r? @catamorphism
