### PR TITLE
Allow custom messages on assert statements

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -456,6 +456,11 @@ pub fn core_macros() -> ~str {
             if !$cond {
                 ::core::sys::fail_assert(stringify!($cond), file!(), line!())
             }
+        };
+        ($cond:expr, $msg:expr) => {
+            if !$cond {
+                ::core::sys::fail_assert($msg, file!(), line!())
+            }
         }
     )
 

--- a/src/test/run-fail/issue-2761.rs
+++ b/src/test/run-fail/issue-2761.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:custom message
+
+fn main() {
+    fail_unless!(false, "custom message");
+}


### PR DESCRIPTION
This would close #2761. I figured that if you're supplying your own custom message, you probably don't mind the stringification of the condition to not be in the message.
