### PR TITLE
Less bad copy throughout libsyntax/librustc

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -190,8 +190,7 @@ pub mod write {
             let opts = sess.opts;
             if sess.time_llvm_passes() { llvm::LLVMRustEnableTimePasses(); }
             let mut pm = mk_pass_manager();
-            let td = mk_target_data(
-                /*bad*/copy sess.targ_cfg.target_strs.data_layout);
+            let td = mk_target_data(sess.targ_cfg.target_strs.data_layout);
             llvm::LLVMAddTargetData(td.lltd, pm.llpm);
             // FIXME (#2812): run the linter here also, once there are llvm-c
             // bindings for it.
@@ -834,8 +833,9 @@ pub fn link_binary(sess: Session,
     // to be found at compile time so it is still entirely up to outside
     // forces to make sure that library can be found at runtime.
 
-    let addl_paths = /*bad*/copy sess.opts.addl_lib_search_paths;
-    for addl_paths.each |path| { cc_args.push(~"-L" + path.to_str()); }
+    for sess.opts.addl_lib_search_paths.each |path| {
+        cc_args.push(~"-L" + path.to_str());
+    }
 
     // The names of the extern libraries
     let used_libs = cstore::get_used_libraries(cstore);

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -45,8 +45,8 @@ pub fn get_rpath_flags(sess: session::Session, out_filename: &Path)
     // where rustrt is and we know every rust program needs it
     let libs = vec::append_one(libs, get_sysroot_absolute_rt_lib(sess));
 
-    let target_triple = /*bad*/copy sess.opts.target_triple;
-    let rpaths = get_rpaths(os, &sysroot, output, libs, target_triple);
+    let rpaths = get_rpaths(os, &sysroot, output, libs,
+                            sess.opts.target_triple);
     rpaths_to_flags(rpaths)
 }
 
@@ -140,8 +140,8 @@ pub fn get_relative_to(abs1: &Path, abs2: &Path) -> Path {
     let abs2 = abs2.normalize();
     debug!("finding relative path from %s to %s",
            abs1.to_str(), abs2.to_str());
-    let split1 = /*bad*/copy abs1.components;
-    let split2 = /*bad*/copy abs2.components;
+    let split1: &[~str] = abs1.components;
+    let split2: &[~str] = abs2.components;
     let len1 = vec::len(split1);
     let len2 = vec::len(split2);
     fail_unless!(len1 > 0);

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -132,15 +132,12 @@ pub fn build_configuration(sess: Session, +argv0: ~str, input: input) ->
 }
 
 // Convert strings provided as --cfg [cfgspec] into a crate_cfg
-fn parse_cfgspecs(cfgspecs: ~[~str],
+fn parse_cfgspecs(+cfgspecs: ~[~str],
                   demitter: diagnostic::Emitter) -> ast::crate_cfg {
-    let mut meta = ~[];
-    for cfgspecs.each |s| {
+    do vec::map_consume(cfgspecs) |s| {
         let sess = parse::new_parse_sess(Some(demitter));
-        let m = parse::parse_meta_from_source_str(~"cfgspec", @/*bad*/ copy *s, ~[], sess);
-        meta.push(m)
+        parse::parse_meta_from_source_str(~"cfgspec", @s, ~[], sess)
     }
-    return meta;
 }
 
 pub enum input {
@@ -566,9 +563,9 @@ pub fn build_session_options(+binary: ~str,
     let debug_map = session::debugging_opts_map();
     for debug_flags.each |debug_flag| {
         let mut this_bit = 0u;
-        for debug_map.each |pair| {
-            let (name, _, bit) = /*bad*/copy *pair;
-            if name == *debug_flag { this_bit = bit; break; }
+        for debug_map.each |tuple| {
+            let (name, bit) = match *tuple { (ref a, _, b) => (a, b) };
+            if name == debug_flag { this_bit = bit; break; }
         }
         if this_bit == 0u {
             early_error(demitter, fmt!("unknown debug flag: %s", *debug_flag))
@@ -633,7 +630,7 @@ pub fn build_session_options(+binary: ~str,
     let target =
         match target_opt {
             None => host_triple(),
-            Some(ref s) => (/*bad*/copy *s)
+            Some(s) => s
         };
 
     let addl_lib_search_paths =

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1647,7 +1647,7 @@ pub struct TargetData {
     dtor: @target_data_res
 }
 
-pub fn mk_target_data(string_rep: ~str) -> TargetData {
+pub fn mk_target_data(string_rep: &str) -> TargetData {
     let lltd =
         str::as_c_str(string_rep, |buf| unsafe {
             llvm::LLVMCreateTargetData(buf)

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -142,8 +142,8 @@ fn visit_crate(e: @mut Env, c: ast::crate) {
 }
 
 fn visit_view_item(e: @mut Env, i: @ast::view_item) {
-    match /*bad*/copy i.node {
-      ast::view_item_extern_mod(ident, meta_items, id) => {
+    match i.node {
+      ast::view_item_extern_mod(ident, /*bad*/copy meta_items, id) => {
         debug!("resolving extern mod stmt. ident: %?, meta: %?",
                ident, meta_items);
         let cnum = resolve_crate(e, ident, meta_items, @~"", i.span);
@@ -154,8 +154,8 @@ fn visit_view_item(e: @mut Env, i: @ast::view_item) {
 }
 
 fn visit_item(e: @mut Env, i: @ast::item) {
-    match /*bad*/copy i.node {
-      ast::item_foreign_mod(fm) => {
+    match i.node {
+      ast::item_foreign_mod(ref fm) => {
         match attr::foreign_abi(i.attrs) {
           either::Right(abi) => {
             if abi != ast::foreign_abi_cdecl &&

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -645,7 +645,7 @@ fn encode_info_for_item(ecx: @EncodeContext, ebml_w: writer::Encoder,
     debug!("encoding info for item at %s",
            ecx.tcx.sess.codemap.span_to_str(item.span));
 
-    match /*bad*/copy item.node {
+    match item.node {
       item_const(_, _) => {
         add_to_index();
         ebml_w.start_tag(tag_items_data_item);
@@ -1189,10 +1189,10 @@ fn synthesize_crate_attrs(ecx: @EncodeContext,
             if *attr::get_attr_name(attr) != ~"link" {
                 /*bad*/copy *attr
             } else {
-                match /*bad*/copy attr.node.value.node {
-                  meta_list(_, l) => {
+                match attr.node.value.node {
+                  meta_list(_, ref l) => {
                     found_link_attr = true;;
-                    synthesize_link_attr(ecx, l)
+                    synthesize_link_attr(ecx, /*bad*/copy *l)
                   }
                   _ => /*bad*/copy *attr
                 }

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -639,14 +639,14 @@ fn encode_vtable_origin(ecx: @e::EncodeContext,
                       ebml_w: writer::Encoder,
                       vtable_origin: typeck::vtable_origin) {
     do ebml_w.emit_enum(~"vtable_origin") {
-        match /*bad*/copy vtable_origin {
-          typeck::vtable_static(def_id, tys, vtable_res) => {
+        match vtable_origin {
+          typeck::vtable_static(def_id, ref tys, vtable_res) => {
             do ebml_w.emit_enum_variant(~"vtable_static", 0u, 3u) {
                 do ebml_w.emit_enum_variant_arg(0u) {
                     ebml_w.emit_def_id(def_id)
                 }
                 do ebml_w.emit_enum_variant_arg(1u) {
-                    ebml_w.emit_tys(ecx, /*bad*/copy tys);
+                    ebml_w.emit_tys(ecx, /*bad*/copy *tys);
                 }
                 do ebml_w.emit_enum_variant_arg(2u) {
                     encode_vtable_res(ecx, ebml_w, vtable_res);

--- a/src/librustc/middle/borrowck/gather_loans.rs
+++ b/src/librustc/middle/borrowck/gather_loans.rs
@@ -139,7 +139,7 @@ fn req_loans_in_expr(ex: @ast::expr,
     }
 
     // Special checks for various kinds of expressions:
-    match /*bad*/copy ex.node {
+    match ex.node {
       ast::expr_addr_of(mutbl, base) => {
         let base_cmt = self.bccx.cat_expr(base);
 
@@ -150,10 +150,10 @@ fn req_loans_in_expr(ex: @ast::expr,
         visit::visit_expr(ex, self, vt);
       }
 
-      ast::expr_call(f, args, _) => {
+      ast::expr_call(f, ref args, _) => {
         let arg_tys = ty::ty_fn_args(ty::expr_ty(self.tcx(), f));
         let scope_r = ty::re_scope(ex.id);
-        for vec::each2(args, arg_tys) |arg, arg_ty| {
+        for vec::each2(*args, arg_tys) |arg, arg_ty| {
             match ty::resolved_mode(self.tcx(), arg_ty.mode) {
                 ast::by_ref => {
                     let arg_cmt = self.bccx.cat_expr(*arg);
@@ -165,11 +165,11 @@ fn req_loans_in_expr(ex: @ast::expr,
         visit::visit_expr(ex, self, vt);
       }
 
-      ast::expr_method_call(rcvr, _, _, args, _) => {
+      ast::expr_method_call(rcvr, _, _, ref args, _) => {
         let arg_tys = ty::ty_fn_args(ty::node_id_to_type(self.tcx(),
                                                          ex.callee_id));
         let scope_r = ty::re_scope(ex.id);
-        for vec::each2(args, arg_tys) |arg, arg_ty| {
+        for vec::each2(*args, arg_tys) |arg, arg_ty| {
             match ty::resolved_mode(self.tcx(), arg_ty.mode) {
                 ast::by_ref => {
                     let arg_cmt = self.bccx.cat_expr(*arg);

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -243,8 +243,8 @@ pub fn is_useful(cx: @MatchCheckCtxt, m: &matrix, v: &[@pat]) -> useful {
               }
               ty::ty_unboxed_vec(*) | ty::ty_evec(*) => {
                 let max_len = do m.foldr(0) |r, max_len| {
-                  match /*bad*/copy r[0].node {
-                    pat_vec(before, _, after) => {
+                  match r[0].node {
+                    pat_vec(ref before, _, ref after) => {
                       uint::max(before.len() + after.len(), max_len)
                     }
                     _ => max_len
@@ -299,7 +299,7 @@ pub fn is_useful_specialized(cx: @MatchCheckCtxt,
 
 pub fn pat_ctor_id(cx: @MatchCheckCtxt, p: @pat) -> Option<ctor> {
     let pat = raw_pat(p);
-    match /*bad*/copy pat.node {
+    match pat.node {
       pat_wild => { None }
       pat_ident(_, _, _) | pat_enum(_, _) => {
         match cx.tcx.def_map.find(&pat.id) {
@@ -324,7 +324,7 @@ pub fn pat_ctor_id(cx: @MatchCheckCtxt, p: @pat) -> Option<ctor> {
       pat_box(_) | pat_uniq(_) | pat_tup(_) | pat_region(*) => {
         Some(single)
       }
-      pat_vec(before, slice, after) => {
+      pat_vec(ref before, slice, ref after) => {
         match slice {
           Some(_) => None,
           None => Some(vec(before.len() + after.len()))
@@ -448,8 +448,8 @@ pub fn missing_ctor(cx: @MatchCheckCtxt,
 }
 
 pub fn ctor_arity(cx: @MatchCheckCtxt, ctor: ctor, ty: ty::t) -> uint {
-    match /*bad*/copy ty::get(ty).sty {
-      ty::ty_tup(fs) => fs.len(),
+    match ty::get(ty).sty {
+      ty::ty_tup(ref fs) => fs.len(),
       ty::ty_box(_) | ty::ty_uniq(_) | ty::ty_rptr(*) => 1u,
       ty::ty_enum(eid, _) => {
           let id = match ctor { variant(id) => id,
@@ -704,7 +704,7 @@ pub fn is_refutable(cx: @MatchCheckCtxt, pat: &pat) -> bool {
       _ => ()
     }
 
-    match /*bad*/copy pat.node {
+    match pat.node {
       pat_box(sub) | pat_uniq(sub) | pat_region(sub) |
       pat_ident(_, _, Some(sub)) => {
         is_refutable(cx, sub)
@@ -715,13 +715,13 @@ pub fn is_refutable(cx: @MatchCheckCtxt, pat: &pat) -> bool {
         false
       }
       pat_lit(_) | pat_range(_, _) => { true }
-      pat_struct(_, fields, _) => {
+      pat_struct(_, ref fields, _) => {
         fields.any(|f| is_refutable(cx, f.pat))
       }
-      pat_tup(elts) => {
+      pat_tup(ref elts) => {
         elts.any(|elt| is_refutable(cx, *elt))
       }
-      pat_enum(_, Some(args)) => {
+      pat_enum(_, Some(ref args)) => {
         args.any(|a| is_refutable(cx, *a))
       }
       pat_enum(_,_) => { false }

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -81,7 +81,7 @@ pub fn classify(e: @expr,
       Some(x) => x,
       None => {
         let cn =
-            match /*bad*/copy e.node {
+            match e.node {
               ast::expr_lit(lit) => {
                 match lit.node {
                   ast::lit_str(*) |
@@ -101,9 +101,9 @@ pub fn classify(e: @expr,
                      classify(b, def_map, tcx))
               }
 
-              ast::expr_tup(es) |
-              ast::expr_vec(es, ast::m_imm) => {
-                join_all(vec::map(es, |e| classify(*e, def_map, tcx)))
+              ast::expr_tup(ref es) |
+              ast::expr_vec(ref es, ast::m_imm) => {
+                join_all(vec::map(*es, |e| classify(*e, def_map, tcx)))
               }
 
               ast::expr_vstore(e, vstore) => {

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -56,7 +56,7 @@ fn collect_freevars(def_map: resolve::DefMap, blk: &ast::blk)
                     Some(df) => {
                       let mut def = df;
                       while i < depth {
-                        match copy def {
+                        match def {
                           ast::def_upvar(_, inner, _, _) => { def = *inner; }
                           _ => break
                         }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -360,8 +360,8 @@ pub impl Context {
             let metas =
                 attr::attr_metas(attr::find_attrs_by_name(attrs, level_name));
             for metas.each |meta| {
-                match /*bad*/copy meta.node {
-                  ast::meta_list(_, metas) => {
+                match meta.node {
+                  ast::meta_list(_, ref metas) => {
                     for metas.each |meta| {
                         match meta.node {
                           ast::meta_word(ref lintname) => {
@@ -653,8 +653,8 @@ fn check_item_type_limits(cx: ty::ctxt, it: @ast::item) {
 }
 
 fn check_item_default_methods(cx: ty::ctxt, item: @ast::item) {
-    match /*bad*/copy item.node {
-        ast::item_trait(_, _, methods) => {
+    match item.node {
+        ast::item_trait(_, _, ref methods) => {
             for methods.each |method| {
                 match *method {
                     ast::required(*) => {}

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1106,7 +1106,7 @@ pub fn field_mutbl(tcx: ty::ctxt,
                    node_id: ast::node_id)
                 -> Option<ast::mutability> {
     // Need to refactor so that struct/enum fields can be treated uniformly.
-    match /*bad*/copy ty::get(base_ty).sty {
+    match ty::get(base_ty).sty {
       ty::ty_struct(did, _) => {
         for ty::lookup_struct_fields(tcx, did).each |fld| {
             if fld.ident == f_name {

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -375,8 +375,8 @@ pub fn check_crate(tcx: ty::ctxt,
             visit::visit_expr(expr, method_map, visitor);
         },
         visit_pat: |pattern, method_map, visitor| {
-            match /*bad*/copy pattern.node {
-                pat_struct(_, fields, _) => {
+            match pattern.node {
+                pat_struct(_, ref fields, _) => {
                     match ty::get(ty::pat_ty(tcx, pattern)).sty {
                         ty_struct(id, _) => {
                             if id.crate != local_crate ||

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -70,10 +70,9 @@ pub fn count_insn(cx: block, category: &str) {
         let mut s = ~".";
         i = 0u;
         while i < len {
-            let e = /*bad*/copy v[i];
-            i = mm.get(&e);
+            i = mm.get(&v[i]);
             s += ~"/";
-            s += e;
+            s += v[i];
             i += 1u;
         }
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1291,14 +1291,14 @@ pub type mono_id = @mono_id_;
 
 impl to_bytes::IterBytes for mono_param_id {
     pure fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
-        match /*bad*/copy *self {
-          mono_precise(t, mids) =>
-          to_bytes::iter_bytes_3(&0u8, &ty::type_id(t), &mids, lsb0, f),
+        match *self {
+            mono_precise(t, ref mids) =>
+                to_bytes::iter_bytes_3(&0u8, &ty::type_id(t), mids, lsb0, f),
 
-          mono_any => 1u8.iter_bytes(lsb0, f),
+            mono_any => 1u8.iter_bytes(lsb0, f),
 
-          mono_repr(ref a, ref b, ref c, ref d) =>
-          to_bytes::iter_bytes_5(&2u8, a, b, c, d, lsb0, f)
+            mono_repr(ref a, ref b, ref c, ref d) =>
+                to_bytes::iter_bytes_5(&2u8, a, b, c, d, lsb0, f)
         }
     }
 }
@@ -1340,7 +1340,7 @@ pub fn path_str(sess: session::Session, p: &[path_elt]) -> ~str {
 }
 
 pub fn monomorphize_type(bcx: block, t: ty::t) -> ty::t {
-    match /*bad*/copy bcx.fcx.param_substs {
+    match bcx.fcx.param_substs {
         Some(substs) => {
             ty::subst_tps(bcx.tcx(), substs.tys, substs.self_ty, t)
         }
@@ -1367,7 +1367,7 @@ pub fn expr_ty_adjusted(bcx: block, ex: @ast::expr) -> ty::t {
 pub fn node_id_type_params(bcx: block, id: ast::node_id) -> ~[ty::t] {
     let tcx = bcx.tcx();
     let params = ty::node_id_to_type_params(tcx, id);
-    match /*bad*/copy bcx.fcx.param_substs {
+    match bcx.fcx.param_substs {
       Some(substs) => {
         do vec::map(params) |t| {
             ty::subst_tps(tcx, substs.tys, substs.self_ty, *t)
@@ -1396,7 +1396,7 @@ pub fn resolve_vtable_in_fn_ctxt(fcx: fn_ctxt, +vt: typeck::vtable_origin)
     let tcx = fcx.ccx.tcx;
     match vt {
         typeck::vtable_static(trait_id, tys, sub) => {
-            let tys = match /*bad*/copy fcx.param_substs {
+            let tys = match fcx.param_substs {
                 Some(substs) => {
                     do vec::map(tys) |t| {
                         ty::subst_tps(tcx, substs.tys, substs.self_ty, *t)

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -520,7 +520,7 @@ fn create_struct(cx: @CrateContext, t: ty::t, fields: ~[ty::field],
     return mdval;
 }
 
-fn create_tuple(cx: @CrateContext, t: ty::t, elements: ~[ty::t], span: span)
+fn create_tuple(cx: @CrateContext, t: ty::t, elements: &[ty::t], span: span)
     -> @Metadata<TyDescMetadata> {
     let fname = filename_from_span(cx, span);
     let file_node = create_file(cx, fname);
@@ -648,46 +648,46 @@ fn create_ty(cx: @CrateContext, t: ty::t, span: span)
     }*/
 
     let sty = copy ty::get(t).sty;
-    match copy sty {
+    match sty {
         ty::ty_nil | ty::ty_bot | ty::ty_bool | ty::ty_int(_) | ty::ty_uint(_)
         | ty::ty_float(_) => create_basic_type(cx, t, span),
         ty::ty_estr(_vstore) => {
             cx.sess.span_bug(span, ~"debuginfo for estr NYI")
         },
-        ty::ty_enum(_did, _substs) => {
+        ty::ty_enum(_did, ref _substs) => {
             cx.sess.span_bug(span, ~"debuginfo for enum NYI")
         }
-        ty::ty_box(_mt) => {
+        ty::ty_box(ref _mt) => {
             cx.sess.span_bug(span, ~"debuginfo for box NYI")
         },
-        ty::ty_uniq(_mt) => {
+        ty::ty_uniq(ref _mt) => {
             cx.sess.span_bug(span, ~"debuginfo for uniq NYI")
         },
-        ty::ty_evec(_mt, _vstore) => {
+        ty::ty_evec(ref _mt, ref _vstore) => {
             cx.sess.span_bug(span, ~"debuginfo for evec NYI")
         },
-        ty::ty_ptr(mt) => {
+        ty::ty_ptr(ref mt) => {
             let pointee = create_ty(cx, mt.ty, span);
             create_pointer_type(cx, t, span, pointee)
         },
-        ty::ty_rptr(_region, _mt) => {
+        ty::ty_rptr(ref _region, ref _mt) => {
             cx.sess.span_bug(span, ~"debuginfo for rptr NYI")
         },
-        ty::ty_bare_fn(_barefnty) => {
+        ty::ty_bare_fn(ref _barefnty) => {
             cx.sess.span_bug(span, ~"debuginfo for bare_fn NYI")
         },
-        ty::ty_closure(_closurety) => {
+        ty::ty_closure(ref _closurety) => {
             cx.sess.span_bug(span, ~"debuginfo for closure NYI")
         },
-        ty::ty_trait(_did, _substs, _vstore) => {
+        ty::ty_trait(_did, ref _substs, ref _vstore) => {
             cx.sess.span_bug(span, ~"debuginfo for trait NYI")
         },
-        ty::ty_struct(did, substs) => {
-            let fields = ty::struct_fields(cx.tcx, did, &substs);
+        ty::ty_struct(did, ref substs) => {
+            let fields = ty::struct_fields(cx.tcx, did, substs);
             create_struct(cx, t, fields, span)
         },
-        ty::ty_tup(elements) => {
-            create_tuple(cx, t, elements, span)
+        ty::ty_tup(ref elements) => {
+            create_tuple(cx, t, *elements, span)
         },
         _ => cx.sess.bug(~"debuginfo: unexpected type in create_ty")
     }
@@ -853,8 +853,8 @@ pub fn create_function(fcx: fn_ctxt) -> @Metadata<SubProgramMetadata> {
 
     let (ident, ret_ty, id) = match cx.tcx.items.get(&fcx.id) {
       ast_map::node_item(item, _) => {
-        match /*bad*/copy item.node {
-          ast::item_fn(decl, _, _, _) => {
+        match item.node {
+          ast::item_fn(ref decl, _, _, _) => {
             (item.ident, decl.output, item.id)
           }
           _ => fcx.ccx.sess.span_bug(item.span, ~"create_function: item \
@@ -865,8 +865,8 @@ pub fn create_function(fcx: fn_ctxt) -> @Metadata<SubProgramMetadata> {
           (method.ident, method.decl.output, method.id)
       }
       ast_map::node_expr(expr) => {
-        match /*bad*/copy expr.node {
-          ast::expr_fn_block(decl, _) => {
+        match expr.node {
+          ast::expr_fn_block(ref decl, _) => {
             ((dbg_cx.names)(~"fn"), decl.output, expr.id)
           }
           _ => fcx.ccx.sess.span_bug(expr.span,

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -792,7 +792,7 @@ pub fn emit_tydescs(ccx: @CrateContext) {
         // tydesc type. Then we'll recast each function to its real type when
         // calling it.
         let take_glue =
-            match copy ti.take_glue {
+            match ti.take_glue {
               None => { ccx.stats.n_null_glues += 1u; C_null(glue_fn_ty) }
               Some(v) => {
                 unsafe {
@@ -802,7 +802,7 @@ pub fn emit_tydescs(ccx: @CrateContext) {
               }
             };
         let drop_glue =
-            match copy ti.drop_glue {
+            match ti.drop_glue {
               None => { ccx.stats.n_null_glues += 1u; C_null(glue_fn_ty) }
               Some(v) => {
                 unsafe {
@@ -812,7 +812,7 @@ pub fn emit_tydescs(ccx: @CrateContext) {
               }
             };
         let free_glue =
-            match copy ti.free_glue {
+            match ti.free_glue {
               None => { ccx.stats.n_null_glues += 1u; C_null(glue_fn_ty) }
               Some(v) => {
                 unsafe {
@@ -822,7 +822,7 @@ pub fn emit_tydescs(ccx: @CrateContext) {
               }
             };
         let visit_glue =
-            match copy ti.visit_glue {
+            match ti.visit_glue {
               None => { ccx.stats.n_null_glues += 1u; C_null(glue_fn_ty) }
               Some(v) => {
                 unsafe {

--- a/src/librustc/middle/trans/reachable.rs
+++ b/src/librustc/middle/trans/reachable.rs
@@ -98,7 +98,7 @@ fn traverse_public_mod(cx: ctx, mod_id: node_id, m: &_mod) {
 fn traverse_public_item(cx: ctx, item: @item) {
     if cx.rmap.contains_key(&item.id) { return; }
     cx.rmap.insert(item.id, ());
-    match /*bad*/copy item.node {
+    match item.node {
       item_mod(ref m) => traverse_public_mod(cx, item.id, m),
       item_foreign_mod(ref nm) => {
           if !traverse_exports(cx, item.id) {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -75,7 +75,7 @@ pub impl Reflector {
         PointerCast(bcx, static_ti.tydesc, T_ptr(self.tydesc_ty))
     }
 
-    fn c_mt(&mut self, mt: ty::mt) -> ~[ValueRef] {
+    fn c_mt(&mut self, mt: &ty::mt) -> ~[ValueRef] {
         ~[self.c_uint(mt.mutbl as uint),
           self.c_tydesc(mt.ty)]
     }
@@ -151,7 +151,7 @@ pub impl Reflector {
         debug!("reflect::visit_ty %s",
                ty_to_str(bcx.ccx().tcx, t));
 
-        match /*bad*/copy ty::get(t).sty {
+        match ty::get(t).sty {
           ty::ty_bot => self.leaf(~"bot"),
           ty::ty_nil => self.leaf(~"nil"),
           ty::ty_bool => self.leaf(~"bool"),
@@ -170,7 +170,7 @@ pub impl Reflector {
           ty::ty_float(ast::ty_f32) => self.leaf(~"f32"),
           ty::ty_float(ast::ty_f64) => self.leaf(~"f64"),
 
-          ty::ty_unboxed_vec(mt) => {
+          ty::ty_unboxed_vec(ref mt) => {
               let values = self.c_mt(mt);
               self.visit(~"vec", values)
           }
@@ -179,30 +179,30 @@ pub impl Reflector {
               let (name, extra) = self.vstore_name_and_extra(t, vst);
               self.visit(~"estr_" + name, extra)
           }
-          ty::ty_evec(mt, vst) => {
+          ty::ty_evec(ref mt, vst) => {
               let (name, extra) = self.vstore_name_and_extra(t, vst);
               let extra = extra + self.c_mt(mt);
               self.visit(~"evec_" + name, extra)
           }
-          ty::ty_box(mt) => {
+          ty::ty_box(ref mt) => {
               let extra = self.c_mt(mt);
               self.visit(~"box", extra)
           }
-          ty::ty_uniq(mt) => {
+          ty::ty_uniq(ref mt) => {
               let extra = self.c_mt(mt);
               self.visit(~"uniq", extra)
           }
-          ty::ty_ptr(mt) => {
+          ty::ty_ptr(ref mt) => {
               let extra = self.c_mt(mt);
               self.visit(~"ptr", extra)
           }
-          ty::ty_rptr(_, mt) => {
+          ty::ty_rptr(_, ref mt) => {
               let extra = self.c_mt(mt);
               self.visit(~"rptr", extra)
           }
 
-          ty::ty_tup(tys) => {
-              let extra = ~[self.c_uint(vec::len(tys))]
+          ty::ty_tup(ref tys) => {
+              let extra = ~[self.c_uint(tys.len())]
                   + self.c_size_and_align(t);
               do self.bracketed(~"tup", extra) |this| {
                   for tys.eachi |i, t| {
@@ -254,7 +254,7 @@ pub impl Reflector {
                       let extra = ~[this.c_uint(i),
                                     this.c_slice(
                                         bcx.ccx().sess.str_of(field.ident))]
-                          + this.c_mt(field.mt);
+                          + this.c_mt(&field.mt);
                       this.visit(~"class_field", extra);
                   }
               }
@@ -293,7 +293,7 @@ pub impl Reflector {
           ty::ty_trait(_, _, _) => self.leaf(~"trait"),
           ty::ty_infer(_) => self.leaf(~"infer"),
           ty::ty_err => self.leaf(~"err"),
-          ty::ty_param(p) => {
+          ty::ty_param(ref p) => {
               let extra = ~[self.c_uint(p.idx)];
               self.visit(~"param", extra)
           }

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -361,7 +361,7 @@ pub fn write_content(bcx: block,
            bcx.expr_to_str(vstore_expr));
     let _indenter = indenter();
 
-    match /*bad*/copy content_expr.node {
+    match content_expr.node {
         ast::expr_lit(@codemap::spanned { node: ast::lit_str(s), _ }) => {
             match dest {
                 Ignore => {
@@ -376,7 +376,7 @@ pub fn write_content(bcx: block,
                 }
             }
         }
-        ast::expr_vec(elements, _) => {
+        ast::expr_vec(ref elements, _) => {
             match dest {
                 Ignore => {
                     for elements.each |element| {
@@ -467,11 +467,11 @@ pub fn vec_types(bcx: block, vec_ty: ty::t) -> VecTypes {
 pub fn elements_required(bcx: block, content_expr: @ast::expr) -> uint {
     //! Figure out the number of elements we need to store this content
 
-    match /*bad*/copy content_expr.node {
+    match content_expr.node {
         ast::expr_lit(@codemap::spanned { node: ast::lit_str(s), _ }) => {
             s.len() + 1
         },
-        ast::expr_vec(es, _) => es.len(),
+        ast::expr_vec(ref es, _) => es.len(),
         ast::expr_repeat(_, count_expr, _) => {
             ty::eval_repeat_count(bcx.tcx(), count_expr)
         }

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -176,7 +176,7 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
     }
 
     // XXX: This is a terrible terrible copy.
-    let llty = match /*bad*/copy ty::get(t).sty {
+    let llty = match ty::get(t).sty {
       ty::ty_nil | ty::ty_bot => T_nil(),
       ty::ty_bool => T_bool(),
       ty::ty_int(t) => T_int_ty(cx, t),
@@ -199,22 +199,22 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
       ty::ty_estr(ty::vstore_box) => {
         T_box_ptr(T_box(cx, T_vec(cx, T_i8())))
       }
-      ty::ty_evec(mt, ty::vstore_box) => {
+      ty::ty_evec(ref mt, ty::vstore_box) => {
         T_box_ptr(T_box(cx, T_vec(cx, type_of(cx, mt.ty))))
       }
-      ty::ty_box(mt) => T_box_ptr(T_box(cx, type_of(cx, mt.ty))),
+      ty::ty_box(ref mt) => T_box_ptr(T_box(cx, type_of(cx, mt.ty))),
       ty::ty_opaque_box => T_box_ptr(T_box(cx, T_i8())),
-      ty::ty_uniq(mt) => T_unique_ptr(T_unique(cx, type_of(cx, mt.ty))),
-      ty::ty_evec(mt, ty::vstore_uniq) => {
+      ty::ty_uniq(ref mt) => T_unique_ptr(T_unique(cx, type_of(cx, mt.ty))),
+      ty::ty_evec(ref mt, ty::vstore_uniq) => {
         T_unique_ptr(T_unique(cx, T_vec(cx, type_of(cx, mt.ty))))
       }
-      ty::ty_unboxed_vec(mt) => {
+      ty::ty_unboxed_vec(ref mt) => {
         T_vec(cx, type_of(cx, mt.ty))
       }
-      ty::ty_ptr(mt) => T_ptr(type_of(cx, mt.ty)),
-      ty::ty_rptr(_, mt) => T_ptr(type_of(cx, mt.ty)),
+      ty::ty_ptr(ref mt) => T_ptr(type_of(cx, mt.ty)),
+      ty::ty_rptr(_, ref mt) => T_ptr(type_of(cx, mt.ty)),
 
-      ty::ty_evec(mt, ty::vstore_slice(_)) => {
+      ty::ty_evec(ref mt, ty::vstore_slice(_)) => {
         T_struct(~[T_ptr(type_of(cx, mt.ty)),
                    T_uint_ty(cx, ast::ty_u)])
       }
@@ -228,7 +228,7 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
         T_array(T_i8(), n + 1u /* +1 for trailing null */)
       }
 
-      ty::ty_evec(mt, ty::vstore_fixed(n)) => {
+      ty::ty_evec(ref mt, ty::vstore_fixed(n)) => {
         T_array(type_of(cx, mt.ty), n)
       }
 

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1051,7 +1051,7 @@ pub impl LookupContext/&self {
 
             let mut j = i + 1;
             while j < candidates.len() {
-                let candidate_b = /*bad*/copy candidates[j];
+                let candidate_b = &candidates[j];
                 debug!("attempting to merge %? and %?",
                        candidate_a, candidate_b);
                 let candidates_same = match (&candidate_a.origin,

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -192,7 +192,7 @@ pub fn visit_expr(expr: @ast::expr, &&rcx: @mut Rcx, v: rvt) {
         }
     }
 
-    match /*bad*/copy expr.node {
+    match expr.node {
         ast::expr_path(*) => {
             // Avoid checking the use of local variables, as we
             // already check their definitions.  The def'n always
@@ -207,7 +207,7 @@ pub fn visit_expr(expr: @ast::expr, &&rcx: @mut Rcx, v: rvt) {
             }
         }
 
-        ast::expr_call(callee, args, _) => {
+        ast::expr_call(callee, ref args, _) => {
             // Check for a.b() where b is a method.  Ensure that
             // any types in the callee are valid for the entire
             // method call.
@@ -236,7 +236,7 @@ pub fn visit_expr(expr: @ast::expr, &&rcx: @mut Rcx, v: rvt) {
             }
         }
 
-        ast::expr_method_call(rcvr, _, _, args, _) => {
+        ast::expr_method_call(rcvr, _, _, ref args, _) => {
             // Check for a.b() where b is a method.  Ensure that
             // any types in the callee are valid for the entire
             // method call.

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -610,7 +610,7 @@ pub impl CoherenceChecker {
     fn check_privileged_scopes(self, crate: @crate) {
         visit_crate(*crate, (), mk_vt(@Visitor {
             visit_item: |item, _context, visitor| {
-                match /*bad*/copy item.node {
+                match item.node {
                     item_mod(ref module_) => {
                         // Then visit the module items.
                         visit_mod(module_, item.span, item.id, (), visitor);
@@ -738,8 +738,8 @@ pub impl CoherenceChecker {
             }
         }
 
-        match /*bad*/copy item.node {
-            item_impl(_, trait_refs, _, ast_methods) => {
+        match item.node {
+            item_impl(_, ref trait_refs, _, ref ast_methods) => {
                 let mut methods = ~[];
                 for ast_methods.each |ast_method| {
                     methods.push(method_to_MethodInfo(*ast_method));

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -228,9 +228,9 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
                             trait_ty: ty::t) {
     fn store_methods<T>(ccx: &CrateCtxt,
                         id: ast::node_id,
-                        stuff: ~[T],
+                        stuff: &[T],
                         f: &fn(v: &T) -> ty::method) {
-        ty::store_trait_methods(ccx.tcx, id, @vec::map(stuff, f));
+        ty::store_trait_methods(ccx.tcx, id, @stuff.map(f));
     }
 
     fn make_static_method_ty(ccx: &CrateCtxt,
@@ -285,7 +285,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
                 node: ast::item_trait(ref generics, _, ref ms),
                 _
             }, _) => {
-        store_methods::<ast::trait_method>(ccx, id, (/*bad*/copy *ms), |m| {
+        store_methods::<ast::trait_method>(ccx, id, *ms, |m| {
             let def_id;
             match *m {
                 ast::required(ref ty_method) => {
@@ -502,7 +502,7 @@ pub fn check_methods_against_trait(ccx: &CrateCtxt,
                                    rp: Option<ty::region_variance>,
                                    selfty: ty::t,
                                    a_trait_ty: @ast::trait_ref,
-                                   impl_ms: ~[ConvertedMethod]) {
+                                   impl_ms: &[ConvertedMethod]) {
 
     let tcx = ccx.tcx;
     let (did, tpt) = instantiate_trait_ref(ccx, a_trait_ty, rp);
@@ -643,8 +643,7 @@ pub fn convert(ccx: &CrateCtxt, it: @ast::item) {
         // XXX: Bad copy of `ms` below.
         let cms = convert_methods(ccx, *ms, rp, i_bounds);
         for trait_ref.each |t| {
-            check_methods_against_trait(ccx, generics, rp, selfty,
-                                        *t, /*bad*/copy cms);
+            check_methods_against_trait(ccx, generics, rp, selfty, *t, cms);
         }
       }
       ast::item_trait(ref generics, ref supertraits, ref trait_methods) => {
@@ -656,7 +655,7 @@ pub fn convert(ccx: &CrateCtxt, it: @ast::item) {
         ensure_supertraits(ccx, it.id, it.span, rp, *supertraits);
 
         let (_, provided_methods) =
-            split_trait_methods(/*bad*/copy *trait_methods);
+            split_trait_methods(*trait_methods);
         let (bounds, _) = mk_substs(ccx, generics, rp);
         let _ = convert_methods(ccx, provided_methods, rp, bounds);
       }

--- a/src/librustc/middle/typeck/infer/glb.rs
+++ b/src/librustc/middle/typeck/infer/glb.rs
@@ -41,7 +41,7 @@ impl Combine for Glb {
     fn lub(&self) -> Lub { Lub(**self) }
     fn glb(&self) -> Glb { Glb(**self) }
 
-    fn mts(&self, a: ty::mt, b: ty::mt) -> cres<ty::mt> {
+    fn mts(&self, a: &ty::mt, b: &ty::mt) -> cres<ty::mt> {
         let tcx = self.infcx.tcx;
 
         debug!("%s.mts(%s, %s)",

--- a/src/librustc/middle/typeck/infer/lub.rs
+++ b/src/librustc/middle/typeck/infer/lub.rs
@@ -47,7 +47,7 @@ impl Combine for Lub {
     fn lub(&self) -> Lub { Lub(**self) }
     fn glb(&self) -> Glb { Glb(**self) }
 
-    fn mts(&self, a: ty::mt, b: ty::mt) -> cres<ty::mt> {
+    fn mts(&self, a: &ty::mt, b: &ty::mt) -> cres<ty::mt> {
         let tcx = self.infcx.tcx;
 
         debug!("%s.mts(%s, %s)",

--- a/src/librustc/middle/typeck/infer/resolve.rs
+++ b/src/librustc/middle/typeck/infer/resolve.rs
@@ -150,7 +150,7 @@ pub impl ResolveState {
             return typ;
         }
 
-        match /*bad*/ copy ty::get(typ).sty {
+        match ty::get(typ).sty {
             ty::ty_infer(TyVar(vid)) => {
                 self.resolve_ty_var(vid)
             }

--- a/src/librustc/middle/typeck/infer/sub.rs
+++ b/src/librustc/middle/typeck/infer/sub.rs
@@ -69,7 +69,7 @@ impl Combine for Sub {
         }
     }
 
-    fn mts(&self, a: ty::mt, b: ty::mt) -> cres<ty::mt> {
+    fn mts(&self, a: &ty::mt, b: &ty::mt) -> cres<ty::mt> {
         debug!("mts(%s <: %s)", a.inf_str(self.infcx), b.inf_str(self.infcx));
 
         if a.mutbl != b.mutbl && b.mutbl != m_const {
@@ -80,11 +80,11 @@ impl Combine for Sub {
           m_mutbl => {
             // If supertype is mut, subtype must match exactly
             // (i.e., invariant if mut):
-            eq_tys(self, a.ty, b.ty).then(|| Ok(a) )
+            eq_tys(self, a.ty, b.ty).then(|| Ok(copy *a) )
           }
           m_imm | m_const => {
             // Otherwise we can be covariant:
-            self.tys(a.ty, b.ty).chain(|_t| Ok(a) )
+            self.tys(a.ty, b.ty).chain(|_t| Ok(copy *a) )
           }
         }
     }

--- a/src/librustc/middle/typeck/infer/to_str.rs
+++ b/src/librustc/middle/typeck/infer/to_str.rs
@@ -43,7 +43,7 @@ impl InferStr for FnSig {
 
 impl InferStr for ty::mt {
     fn inf_str(&self, cx: &InferCtxt) -> ~str {
-        mt_to_str(cx.tcx, *self)
+        mt_to_str(cx.tcx, self)
     }
 }
 

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -218,7 +218,7 @@ pub fn region_to_str_space(cx: ctxt, prefix: &str, region: Region) -> ~str {
     }
 }
 
-pub fn mt_to_str(cx: ctxt, m: mt) -> ~str {
+pub fn mt_to_str(cx: ctxt, m: &mt) -> ~str {
     let mstr = match m.mutbl {
       ast::m_mutbl => "mut ",
       ast::m_imm => "",
@@ -391,7 +391,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
                        &m.fty.sig) + ~";"
     }
     fn field_to_str(cx: ctxt, f: field) -> ~str {
-        return *cx.sess.str_of(f.ident) + ~": " + mt_to_str(cx, f.mt);
+        return *cx.sess.str_of(f.ident) + ~": " + mt_to_str(cx, &f.mt);
     }
 
     // if there is an id, print that instead of the structural type:
@@ -402,7 +402,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
     }*/
 
     // pretty print the structural type representation:
-    return match /*bad*/copy ty::get(typ).sty {
+    return match ty::get(typ).sty {
       ty_nil => ~"()",
       ty_bot => ~"!",
       ty_bool => ~"bool",
@@ -413,15 +413,15 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_uint(t) => ast_util::uint_ty_to_str(t),
       ty_float(ast::ty_f) => ~"float",
       ty_float(t) => ast_util::float_ty_to_str(t),
-      ty_box(tm) => ~"@" + mt_to_str(cx, tm),
-      ty_uniq(tm) => ~"~" + mt_to_str(cx, tm),
-      ty_ptr(tm) => ~"*" + mt_to_str(cx, tm),
-      ty_rptr(r, tm) => {
+      ty_box(ref tm) => ~"@" + mt_to_str(cx, tm),
+      ty_uniq(ref tm) => ~"~" + mt_to_str(cx, tm),
+      ty_ptr(ref tm) => ~"*" + mt_to_str(cx, tm),
+      ty_rptr(r, ref tm) => {
         region_to_str_space(cx, ~"&", r) + mt_to_str(cx, tm)
       }
-      ty_unboxed_vec(tm) => { ~"unboxed_vec<" + mt_to_str(cx, tm) + ~">" }
+      ty_unboxed_vec(ref tm) => { ~"unboxed_vec<" + mt_to_str(cx, tm) + ~">" }
       ty_type => ~"type",
-      ty_tup(elems) => {
+      ty_tup(ref elems) => {
         let strs = elems.map(|elem| ty_to_str(cx, *elem));
         ~"(" + str::connect(strs, ~",") + ~")"
       }
@@ -455,7 +455,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
         let ty = parameterized(cx, base, substs.self_r, substs.tps);
         fmt!("%s%s", trait_store_to_str(cx, s), ty)
       }
-      ty_evec(mt, vs) => {
+      ty_evec(ref mt, vs) => {
         vstore_ty_to_str(cx, fmt!("%s", mt_to_str(cx, mt)), vs)
       }
       ty_estr(vs) => fmt!("%s%s", vstore_to_str(cx, vs), ~"str"),

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -65,7 +65,7 @@ fn pieces_to_expr(cx: @ext_ctxt, sp: span,
     // Produces an AST expression that represents a RT::conv record,
     // which tells the RT::conv* functions how to perform the conversion
 
-    fn make_rt_conv_expr(cx: @ext_ctxt, sp: span, cnv: Conv) -> @ast::expr {
+    fn make_rt_conv_expr(cx: @ext_ctxt, sp: span, cnv: &Conv) -> @ast::expr {
         fn make_flags(cx: @ext_ctxt, sp: span, flags: ~[Flag]) -> @ast::expr {
             let mut tmp_expr = make_rt_path_expr(cx, sp, @~"flag_none");
             for flags.each |f| {
@@ -139,7 +139,7 @@ fn pieces_to_expr(cx: @ext_ctxt, sp: span,
         make_conv_struct(cx, sp, rt_conv_flags, rt_conv_width,
                          rt_conv_precision, rt_conv_ty)
     }
-    fn make_conv_call(cx: @ext_ctxt, sp: span, conv_type: ~str, cnv: Conv,
+    fn make_conv_call(cx: @ext_ctxt, sp: span, conv_type: ~str, cnv: &Conv,
                       arg: @ast::expr) -> @ast::expr {
         let fname = ~"conv_" + conv_type;
         let path = make_path_vec(cx, @fname);
@@ -148,11 +148,11 @@ fn pieces_to_expr(cx: @ext_ctxt, sp: span,
         return mk_call_global(cx, arg.span, path, args);
     }
 
-    fn make_new_conv(cx: @ext_ctxt, sp: span, cnv: Conv, arg: @ast::expr) ->
+    fn make_new_conv(cx: @ext_ctxt, sp: span, cnv: &Conv, arg: @ast::expr) ->
        @ast::expr {
         // FIXME: Move validation code into core::extfmt (Issue #2249)
 
-        fn is_signed_type(cnv: Conv) -> bool {
+        fn is_signed_type(cnv: &Conv) -> bool {
             match cnv.ty {
               TyInt(s) => match s {
                 Signed => return true,
@@ -220,7 +220,7 @@ fn pieces_to_expr(cx: @ext_ctxt, sp: span,
                        mk_addr_of(cx, sp, arg))
         }
     }
-    fn log_conv(c: Conv) {
+    fn log_conv(c: &Conv) {
         match c.param {
           Some(p) => { debug!("param: %s", p.to_str()); }
           _ => debug!("param: none")
@@ -285,12 +285,12 @@ fn pieces_to_expr(cx: @ext_ctxt, sp: span,
                                   ~"for the given format string");
             }
             debug!("Building conversion:");
-            log_conv(/*bad*/ copy *conv);
+            log_conv(conv);
             let arg_expr = args[n];
             let c_expr = make_new_conv(
                 cx,
                 fmt_sp,
-                /*bad*/ copy *conv,
+                conv,
                 arg_expr
             );
             piece_exprs.push(c_expr);

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -220,7 +220,7 @@ fn trim_whitespace_prefix_and_push_line(lines: &mut ~[~str],
         if col < len {
             s1 = str::slice(s, col, len);
         } else { s1 = ~""; }
-    } else { s1 = /*bad*/ copy s; }
+    } else { s1 = s; }
     debug!("pushing line: %s", s1);
     lines.push(s1);
 }
@@ -357,8 +357,8 @@ pub fn gather_comments_and_literals(span_diagnostic:
         let TokenAndSpan {tok: tok, sp: sp} = rdr.peek();
         if token::is_lit(&tok) {
             let s = get_str_from(rdr, bstart);
-            literals.push(lit {lit: /*bad*/ copy s, pos: sp.lo});
             debug!("tok lit: %s", s);
+            literals.push(lit {lit: s, pos: sp.lo});
         } else {
             debug!("tok: %s", token::to_str(rdr.interner, &tok));
         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1438,7 +1438,7 @@ pub impl Parser {
                     let (s, z) = p.parse_sep_and_zerok();
                     tt_seq(
                         mk_sp(sp.lo ,p.span.hi),
-                        /*bad*/ copy seq.node,
+                        seq.node,
                         s,
                         z
                     )
@@ -1855,7 +1855,7 @@ pub impl Parser {
         // Turn on the restriction to stop at | or || so we can parse
         // them as the lambda arguments
         let e = self.parse_expr_res(RESTRICT_NO_BAR_OR_DOUBLEBAR_OP);
-        match /*bad*/ copy e.node {
+        match e.node {
             expr_call(f, args, NoSugar) => {
                 let block = self.parse_lambda_block_expr();
                 let last_arg = self.mk_expr(block.span.lo, block.span.hi,
@@ -2129,7 +2129,7 @@ pub impl Parser {
         let lo = self.span.lo;
         let mut hi = self.span.hi;
         let mut pat;
-        match copy *self.token {
+        match *self.token {
           token::UNDERSCORE => { self.bump(); pat = pat_wild; }
           token::AT => {
             self.bump();
@@ -2237,7 +2237,7 @@ pub impl Parser {
             self.expect(&token::RBRACKET);
             pat = ast::pat_vec(before, slice, after);
           }
-          copy tok => {
+          tok => {
             if !is_ident_or_path(&tok)
                 || self.is_keyword(&~"true")
                 || self.is_keyword(&~"false")
@@ -3341,6 +3341,7 @@ pub impl Parser {
                                             VIEW_ITEMS_AND_ITEMS_ALLOWED,
                                             true);
         let mut items: ~[@item] = starting_items;
+        let attrs_remaining_len = attrs_remaining.len();
 
         // looks like this code depends on the invariant that
         // outer attributes can't occur on view items (or macros
@@ -3349,7 +3350,7 @@ pub impl Parser {
         while *self.token != term {
             let mut attrs = self.parse_outer_attributes();
             if first {
-                attrs = vec::append(/*bad*/ copy attrs_remaining, attrs);
+                attrs = attrs_remaining + attrs;
                 first = false;
             }
             debug!("parse_mod_items: parse_item_or_view_item(attrs=%?)",
@@ -3378,7 +3379,7 @@ pub impl Parser {
             debug!("parse_mod_items: attrs=%?", attrs);
         }
 
-        if first && attrs_remaining.len() > 0u {
+        if first && attrs_remaining_len > 0u {
             // We parsed attributes for the first item but didn't find it
             self.fatal(~"expected item");
         }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -134,7 +134,7 @@ pub fn print_crate(cm: @CodeMap,
 }
 
 pub fn print_crate_(s: @ps, &&crate: @ast::crate) {
-    print_mod(s, crate.node.module, crate.node.attrs);
+    print_mod(s, &crate.node.module, crate.node.attrs);
     print_remaining_comments(s);
     eof(s.s);
 }
@@ -310,7 +310,7 @@ pub fn synth_comment(s: @ps, text: ~str) {
     word(s.s, ~"*/");
 }
 
-pub fn commasep<IN>(s: @ps, b: breaks, elts: ~[IN], op: &fn(@ps, IN)) {
+pub fn commasep<IN>(s: @ps, b: breaks, elts: &[IN], op: &fn(@ps, IN)) {
     box(s, 0u, b);
     let mut first = true;
     for elts.each |elt| {
@@ -321,7 +321,7 @@ pub fn commasep<IN>(s: @ps, b: breaks, elts: ~[IN], op: &fn(@ps, IN)) {
 }
 
 
-pub fn commasep_cmnt<IN>(s: @ps, b: breaks, elts: ~[IN], op: &fn(@ps, IN),
+pub fn commasep_cmnt<IN>(s: @ps, b: breaks, elts: &[IN], op: &fn(@ps, IN),
                          get_span: &fn(IN) -> codemap::span) {
     box(s, 0u, b);
     let len = vec::len::<IN>(elts);
@@ -340,12 +340,12 @@ pub fn commasep_cmnt<IN>(s: @ps, b: breaks, elts: ~[IN], op: &fn(@ps, IN),
     end(s);
 }
 
-pub fn commasep_exprs(s: @ps, b: breaks, exprs: ~[@ast::expr]) {
+pub fn commasep_exprs(s: @ps, b: breaks, exprs: &[@ast::expr]) {
     fn expr_span(&&expr: @ast::expr) -> codemap::span { return expr.span; }
     commasep_cmnt(s, b, exprs, print_expr, expr_span);
 }
 
-pub fn print_mod(s: @ps, _mod: ast::_mod, attrs: ~[ast::attribute]) {
+pub fn print_mod(s: @ps, _mod: &ast::_mod, attrs: ~[ast::attribute]) {
     print_inner_attributes(s, attrs);
     for _mod.view_items.each |vitem| {
         print_view_item(s, *vitem);
@@ -353,7 +353,7 @@ pub fn print_mod(s: @ps, _mod: ast::_mod, attrs: ~[ast::attribute]) {
     for _mod.items.each |item| { print_item(s, *item); }
 }
 
-pub fn print_foreign_mod(s: @ps, nmod: ast::foreign_mod,
+pub fn print_foreign_mod(s: @ps, nmod: &ast::foreign_mod,
                          attrs: ~[ast::attribute]) {
     print_inner_attributes(s, attrs);
     for nmod.view_items.each |vitem| {
@@ -376,12 +376,12 @@ pub fn print_type(s: @ps, &&ty: @ast::Ty) {
 pub fn print_type_ex(s: @ps, &&ty: @ast::Ty, print_colons: bool) {
     maybe_print_comment(s, ty.span.lo);
     ibox(s, 0u);
-    match /*bad*/ copy ty.node {
+    match ty.node {
       ast::ty_nil => word(s.s, ~"()"),
       ast::ty_bot => word(s.s, ~"!"),
-      ast::ty_box(mt) => { word(s.s, ~"@"); print_mt(s, mt); }
-      ast::ty_uniq(mt) => { word(s.s, ~"~"); print_mt(s, mt); }
-      ast::ty_vec(mt) => {
+      ast::ty_box(ref mt) => { word(s.s, ~"@"); print_mt(s, mt); }
+      ast::ty_uniq(ref mt) => { word(s.s, ~"~"); print_mt(s, mt); }
+      ast::ty_vec(ref mt) => {
         word(s.s, ~"[");
         match mt.mutbl {
           ast::m_mutbl => word_space(s, ~"mut"),
@@ -391,15 +391,15 @@ pub fn print_type_ex(s: @ps, &&ty: @ast::Ty, print_colons: bool) {
         print_type(s, mt.ty);
         word(s.s, ~"]");
       }
-      ast::ty_ptr(mt) => { word(s.s, ~"*"); print_mt(s, mt); }
-      ast::ty_rptr(lifetime, mt) => {
+      ast::ty_ptr(ref mt) => { word(s.s, ~"*"); print_mt(s, mt); }
+      ast::ty_rptr(lifetime, ref mt) => {
           word(s.s, ~"&");
           print_opt_lifetime(s, lifetime);
           print_mt(s, mt);
       }
-      ast::ty_tup(elts) => {
+      ast::ty_tup(ref elts) => {
         popen(s);
-        commasep(s, inconsistent, elts, print_type);
+        commasep(s, inconsistent, *elts, print_type);
         if elts.len() == 1 {
             word(s.s, ~",");
         }
@@ -416,7 +416,7 @@ pub fn print_type_ex(s: @ps, &&ty: @ast::Ty, print_colons: bool) {
                       None, None);
       }
       ast::ty_path(path, _) => print_path(s, path, print_colons),
-      ast::ty_fixed_length_vec(mt, v) => {
+      ast::ty_fixed_length_vec(ref mt, v) => {
         word(s.s, ~"[");
         match mt.mutbl {
             ast::m_mutbl => word_space(s, ~"mut"),
@@ -443,7 +443,7 @@ pub fn print_foreign_item(s: @ps, item: @ast::foreign_item) {
     hardbreak_if_not_bol(s);
     maybe_print_comment(s, item.span.lo);
     print_outer_attributes(s, item.attrs);
-    match /*bad*/ copy item.node {
+    match item.node {
       ast::foreign_item_fn(ref decl, purity, ref generics) => {
         print_fn(s, decl, Some(purity), item.ident, generics, None,
                  ast::inherited);
@@ -469,7 +469,7 @@ pub fn print_item(s: @ps, &&item: @ast::item) {
     print_outer_attributes(s, item.attrs);
     let ann_node = node_item(s, item);
     (s.ann.pre)(ann_node);
-    match /*bad*/ copy item.node {
+    match item.node {
       ast::item_const(ty, expr) => {
         head(s, visibility_qualified(item.vis, ~"const"));
         print_ident(s, item.ident);
@@ -497,7 +497,7 @@ pub fn print_item(s: @ps, &&item: @ast::item) {
         word(s.s, ~" ");
         print_block_with_attrs(s, body, item.attrs);
       }
-      ast::item_mod(_mod) => {
+      ast::item_mod(ref _mod) => {
         head(s, visibility_qualified(item.vis, ~"mod"));
         print_ident(s, item.ident);
         nbsp(s);
@@ -505,7 +505,7 @@ pub fn print_item(s: @ps, &&item: @ast::item) {
         print_mod(s, _mod, item.attrs);
         bclose(s, item.span);
       }
-      ast::item_foreign_mod(nmod) => {
+      ast::item_foreign_mod(ref nmod) => {
         head(s, visibility_qualified(item.vis, ~"extern"));
         print_string(s, *s.intr.get(nmod.abi));
         nbsp(s);
@@ -767,15 +767,15 @@ pub fn print_tts(s: @ps, &&tts: &[ast::token_tree]) {
 
 pub fn print_variant(s: @ps, v: ast::variant) {
     print_visibility(s, v.node.vis);
-    match /*bad*/ copy v.node.kind {
-        ast::tuple_variant_kind(args) => {
+    match v.node.kind {
+        ast::tuple_variant_kind(ref args) => {
             print_ident(s, v.node.name);
             if !args.is_empty() {
                 popen(s);
                 fn print_variant_arg(s: @ps, arg: ast::variant_arg) {
                     print_type(s, arg.ty);
                 }
-                commasep(s, consistent, args, print_variant_arg);
+                commasep(s, consistent, *args, print_variant_arg);
                 pclose(s);
             }
         }
@@ -1103,7 +1103,7 @@ pub fn print_expr(s: @ps, &&expr: @ast::expr) {
     ibox(s, indent_unit);
     let ann_node = node_expr(s, expr);
     (s.ann.pre)(ann_node);
-    match /*bad*/ copy expr.node {
+    match expr.node {
         ast::expr_vstore(e, v) => match v {
             ast::expr_vstore_fixed(_) => {
                 print_expr(s, e);
@@ -1115,14 +1115,14 @@ pub fn print_expr(s: @ps, &&expr: @ast::expr) {
                 print_expr(s, e);
             }
         },
-      ast::expr_vec(exprs, mutbl) => {
+      ast::expr_vec(ref exprs, mutbl) => {
         ibox(s, indent_unit);
         word(s.s, ~"[");
         if mutbl == ast::m_mutbl {
             word(s.s, ~"mut");
-            if vec::len(exprs) > 0u { nbsp(s); }
+            if exprs.len() > 0u { nbsp(s); }
         }
-        commasep_exprs(s, inconsistent, exprs);
+        commasep_exprs(s, inconsistent, *exprs);
         word(s.s, ~"]");
         end(s);
       }
@@ -1159,29 +1159,29 @@ pub fn print_expr(s: @ps, &&expr: @ast::expr) {
         }
         word(s.s, ~"}");
       }
-      ast::expr_tup(exprs) => {
+      ast::expr_tup(ref exprs) => {
         popen(s);
-        commasep_exprs(s, inconsistent, exprs);
+        commasep_exprs(s, inconsistent, *exprs);
         if exprs.len() == 1 {
             word(s.s, ~",");
         }
         pclose(s);
       }
-      ast::expr_call(func, args, sugar) => {
-        let mut base_args = copy args;
+      ast::expr_call(func, ref args, sugar) => {
+        let mut base_args = copy *args;
         let blk = print_call_pre(s, sugar, &mut base_args);
         print_expr(s, func);
         print_call_post(s, sugar, &blk, &mut base_args);
       }
-      ast::expr_method_call(func, ident, tys, args, sugar) => {
-        let mut base_args = copy args;
+      ast::expr_method_call(func, ident, ref tys, ref args, sugar) => {
+        let mut base_args = copy *args;
         let blk = print_call_pre(s, sugar, &mut base_args);
         print_expr(s, func);
         word(s.s, ~".");
         print_ident(s, ident);
-        if vec::len(tys) > 0u {
+        if tys.len() > 0u {
             word(s.s, ~"::<");
-            commasep(s, inconsistent, tys, print_type);
+            commasep(s, inconsistent, *tys, print_type);
             word(s.s, ~">");
         }
         print_call_post(s, sugar, &blk, &mut base_args);
@@ -1356,13 +1356,13 @@ pub fn print_expr(s: @ps, &&expr: @ast::expr) {
         word_space(s, ~"=");
         print_expr(s, rhs);
       }
-      ast::expr_field(expr, id, tys) => {
+      ast::expr_field(expr, id, ref tys) => {
         print_expr(s, expr);
         word(s.s, ~".");
         print_ident(s, id);
-        if vec::len(tys) > 0u {
+        if tys.len() > 0u {
             word(s.s, ~"::<");
-            commasep(s, inconsistent, tys, print_type);
+            commasep(s, inconsistent, *tys, print_type);
             word(s.s, ~">");
         }
       }
@@ -1454,15 +1454,15 @@ pub fn print_local_decl(s: @ps, loc: @ast::local) {
 
 pub fn print_decl(s: @ps, decl: @ast::decl) {
     maybe_print_comment(s, decl.span.lo);
-    match /*bad*/ copy decl.node {
-      ast::decl_local(locs) => {
+    match decl.node {
+      ast::decl_local(ref locs) => {
         space_if_not_bol(s);
         ibox(s, indent_unit);
         word_nbsp(s, ~"let");
 
         // if any are mut, all are mut
-        if vec::any(locs, |l| l.node.is_mutbl) {
-            fail_unless!(vec::all(locs, |l| l.node.is_mutbl));
+        if locs.any(|l| l.node.is_mutbl) {
+            fail_unless!(locs.all(|l| l.node.is_mutbl));
             word_nbsp(s, ~"mut");
         }
 
@@ -1479,7 +1479,7 @@ pub fn print_decl(s: @ps, decl: @ast::decl) {
               _ => ()
             }
         }
-        commasep(s, consistent, locs, print_local);
+        commasep(s, consistent, *locs, print_local);
         end(s);
       }
       ast::decl_item(item) => print_item(s, item)
@@ -1539,7 +1539,7 @@ pub fn print_pat(s: @ps, &&pat: @ast::pat, refutable: bool) {
     (s.ann.pre)(ann_node);
     /* Pat isn't normalized, but the beauty of it
      is that it doesn't matter */
-    match /*bad*/ copy pat.node {
+    match pat.node {
       ast::pat_wild => word(s.s, ~"_"),
       ast::pat_ident(binding_mode, path, sub) => {
           if refutable {
@@ -1563,14 +1563,14 @@ pub fn print_pat(s: @ps, &&pat: @ast::pat, refutable: bool) {
               None => ()
           }
       }
-      ast::pat_enum(path, args_) => {
+      ast::pat_enum(path, ref args_) => {
         print_path(s, path, true);
-        match args_ {
+        match *args_ {
           None => word(s.s, ~"(*)"),
-          Some(args) => {
+          Some(ref args) => {
             if !args.is_empty() {
               popen(s);
-              commasep(s, inconsistent, args,
+              commasep(s, inconsistent, *args,
                        |s, p| print_pat(s, p, refutable));
               pclose(s);
             } else { }
@@ -1851,7 +1851,7 @@ pub fn print_view_path(s: @ps, &&vp: @ast::view_path) {
     }
 }
 
-pub fn print_view_paths(s: @ps, vps: ~[@ast::view_path]) {
+pub fn print_view_paths(s: @ps, vps: &[@ast::view_path]) {
     commasep(s, inconsistent, vps, print_view_path);
 }
 
@@ -1860,7 +1860,7 @@ pub fn print_view_item(s: @ps, item: @ast::view_item) {
     maybe_print_comment(s, item.span.lo);
     print_outer_attributes(s, item.attrs);
     print_visibility(s, item.vis);
-    match /*bad*/ copy item.node {
+    match item.node {
         ast::view_item_extern_mod(id, mta, _) => {
             head(s, ~"extern mod");
             print_ident(s, id);
@@ -1871,9 +1871,9 @@ pub fn print_view_item(s: @ps, item: @ast::view_item) {
             }
         }
 
-        ast::view_item_use(vps) => {
+        ast::view_item_use(ref vps) => {
             head(s, ~"use");
-            print_view_paths(s, vps);
+            print_view_paths(s, *vps);
         }
     }
     word(s.s, ~";");
@@ -1889,7 +1889,7 @@ pub fn print_mutability(s: @ps, mutbl: ast::mutability) {
     }
 }
 
-pub fn print_mt(s: @ps, mt: ast::mt) {
+pub fn print_mt(s: @ps, mt: &ast::mt) {
     print_mutability(s, mt.mutbl);
     print_type(s, mt.ty);
 }
@@ -1942,7 +1942,7 @@ pub fn print_ty_fn(s: @ps,
     print_onceness(s, onceness);
     word(s.s, ~"fn");
     match id { Some(id) => { word(s.s, ~" "); print_ident(s, id); } _ => () }
-    match /*bad*/ copy generics { Some(g) => print_generics(s, g), _ => () }
+    match generics { Some(g) => print_generics(s, g), _ => () }
     zerobreak(s.s);
 
     popen(s);


### PR DESCRIPTION
Removes a lot of instances of `/*bad*/ copy` throughout libsyntax/librustc. On the plus side, this shaves about 2s off of the runtime when compiling `librustc` with optimizations.

Ideally I would have run a profiler to figure out which copies are the most critical to remove, but in reality there was a liberal amount of `git grep`s along with some spot checking and removing the easy ones.
