### PR TITLE
Fix path-qualified and cross-crate constants in match patterns.

### DIFF
--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -916,6 +916,11 @@ pub impl mem_categorization_ctxt {
                         self.cat_pattern(cmt_field, *subpat, op);
                     }
                 }
+                Some(ast::def_const(*)) => {
+                    for subpats.each |subpat| {
+                        self.cat_pattern(cmt, *subpat, op);
+                    }
+                }
                 _ => {
                     self.tcx.sess.span_bug(
                         pat.span,

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -43,7 +43,7 @@ pub fn pat_is_variant_or_struct(dm: resolve::DefMap, pat: @pat) -> bool {
 
 pub fn pat_is_const(dm: resolve::DefMap, pat: &pat) -> bool {
     match pat.node {
-        pat_ident(_, _, None) => {
+        pat_ident(_, _, None) | pat_enum(*) => {
             match dm.find(&pat.id) {
                 Some(def_const(*)) => true,
                 _ => false

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -4333,23 +4333,24 @@ pub impl Resolver {
                 }
 
                 pat_enum(path, _) => {
-                    // This must be an enum variant or struct.
+                    // This must be an enum variant, struct or const.
                     match self.resolve_path(path, ValueNS, false, visitor) {
                         Some(def @ def_variant(*)) |
-                                Some(def @ def_struct(*)) => {
+                        Some(def @ def_struct(*))  |
+                        Some(def @ def_const(*)) => {
                             self.record_def(pattern.id, def);
                         }
                         Some(_) => {
                             self.session.span_err(
                                 path.span,
-                                fmt!("not an enum variant or struct: %s",
+                                fmt!("not an enum variant, struct or const: %s",
                                      *self.session.str_of(
                                          *path.idents.last())));
                         }
                         None => {
                             self.session.span_err(path.span,
-                                                  ~"unresolved enum variant \
-                                                    or struct");
+                                                  ~"unresolved enum variant, \
+                                                    struct or const");
                         }
                     }
 

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -366,6 +366,7 @@ pub fn check_pat(pcx: pat_ctxt, pat: @ast::pat, expected: ty::t) {
         }
         fcx.write_ty(pat.id, b_ty);
       }
+      ast::pat_enum(*) |
       ast::pat_ident(*) if pat_is_const(tcx.def_map, pat) => {
         let const_did = ast_util::def_id_of_def(tcx.def_map.get(&pat.id));
         let const_tpt = ty::lookup_item_type(tcx, const_did);

--- a/src/test/run-pass/cross-crate-const-pat.rs
+++ b/src/test/run-pass/cross-crate-const-pat.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:cci_const.rs
+
+extern mod cci_const;
+
+fn main() {
+    let x = cci_const::uint_val;
+    match x {
+        cci_const::uint_val => {}
+        _ => {}
+    }
+}


### PR DESCRIPTION
r? @pcwalton 
