### PR TITLE
Fix "cannot encode region variables" error

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1581,6 +1581,8 @@ pub fn new_fn_ctxt_w_id(ccx: @CrateContext,
                         param_substs: Option<@param_substs>,
                         sp: Option<span>) -> fn_ctxt
 {
+    for param_substs.each |p| { p.validate(); }
+
     debug!("new_fn_ctxt_w_id(path=%s, id=%?, impl_id=%?, \
             param_substs=%s",
            path_str(ccx.sess, path),

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1579,7 +1579,15 @@ pub fn new_fn_ctxt_w_id(ccx: @CrateContext,
                         id: ast::node_id,
                         impl_id: Option<ast::def_id>,
                         param_substs: Option<@param_substs>,
-                        sp: Option<span>) -> fn_ctxt {
+                        sp: Option<span>) -> fn_ctxt
+{
+    debug!("new_fn_ctxt_w_id(path=%s, id=%?, impl_id=%?, \
+            param_substs=%s",
+           path_str(ccx.sess, path),
+           id,
+           impl_id,
+           opt_param_substs_to_str(ccx.tcx, &param_substs));
+
     let llbbs = mk_standard_basic_blocks(llfndecl);
     return @mut fn_ctxt_ {
           llfn: llfndecl,

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -217,7 +217,7 @@ pub fn trans_fn_ref_with_vtables(
     // - `type_params`: values for each of the fn/method's type parameters
     // - `vtables`: values for each bound on each of the type parameters
 
-    let _icx = bcx.insn_ctxt("trans_fn_with_vtables");
+    let _icx = bcx.insn_ctxt("trans_fn_ref_with_vtables");
     let ccx = bcx.ccx();
     let tcx = ccx.tcx;
 

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -228,6 +228,8 @@ pub fn trans_fn_ref_with_vtables(
            vtables);
     let _indenter = indenter();
 
+    fail_unless!(type_params.all(|t| !ty::type_needs_infer(*t)));
+
     // Polytype of the function item (may have type params)
     let fn_tpt = ty::lookup_item_type(tcx, def_id);
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -257,6 +257,11 @@ pub fn param_substs_to_str(tcx: ty::ctxt, substs: &param_substs) -> ~str {
          substs.bounds.map(|b| ty::param_bounds_to_str(tcx, *b)))
 }
 
+pub fn opt_param_substs_to_str(tcx: ty::ctxt,
+                               substs: &Option<@param_substs>) -> ~str {
+    substs.map_default(~"None", |&ps| param_substs_to_str(tcx, ps))
+}
+
 // Function context.  Every LLVM function we create will have one of
 // these.
 pub struct fn_ctxt_ {
@@ -1423,7 +1428,7 @@ pub fn resolve_vtable_in_fn_ctxt(fcx: fn_ctxt, +vt: typeck::vtable_origin)
 }
 
 pub fn find_vtable(tcx: ty::ctxt, ps: &param_substs,
-               n_param: uint, n_bound: uint)
+                   n_param: uint, n_bound: uint)
     -> typeck::vtable_origin {
     debug!("find_vtable_in_fn_ctxt(n_param=%u, n_bound=%u, ps=%?)",
            n_param, n_bound, param_substs_to_str(tcx, ps));

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -250,6 +250,13 @@ pub struct param_substs {
     self_ty: Option<ty::t>
 }
 
+pub impl param_substs {
+    fn validate(&self) {
+        for self.tys.each |t| { fail_unless!(!ty::type_needs_infer(*t)); }
+        for self.self_ty.each |t| { fail_unless!(!ty::type_needs_infer(*t)); }
+    }
+}
+
 pub fn param_substs_to_str(tcx: ty::ctxt, substs: &param_substs) -> ~str {
     fmt!("param_substs {tys:%?, vtables:%?, bounds:%?}",
          substs.tys.map(|t| ty_to_str(tcx, *t)),
@@ -1372,6 +1379,13 @@ pub fn expr_ty_adjusted(bcx: block, ex: @ast::expr) -> ty::t {
 pub fn node_id_type_params(bcx: block, id: ast::node_id) -> ~[ty::t] {
     let tcx = bcx.tcx();
     let params = ty::node_id_to_type_params(tcx, id);
+
+    if !params.all(|t| !ty::type_needs_infer(*t)) {
+        bcx.sess().bug(
+            fmt!("Type parameters for node %d include inference types: %s",
+                 id, str::connect(params.map(|t| bcx.ty_to_str(*t)), ",")));
+    }
+
     match bcx.fcx.param_substs {
       Some(substs) => {
         do vec::map(params) |t| {

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -175,6 +175,9 @@ pub fn trans_method_callee(bcx: block,
                         -> Callee {
     let _icx = bcx.insn_ctxt("impl::trans_method_callee");
 
+    debug!("trans_method_callee(callee_id=%?, self=%s, mentry=%?)",
+           callee_id, bcx.expr_to_str(self), mentry);
+
     // Replace method_self with method_static here.
     let mut origin = mentry.origin;
     match origin {
@@ -217,6 +220,8 @@ pub fn trans_method_callee(bcx: block,
         typeck::method_static(*) | typeck::method_param(*) |
         typeck::method_trait(*) => {}
     }
+
+    debug!("origin=%?", origin);
 
     match origin {
         typeck::method_static(did) => {

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -327,6 +327,7 @@ pub fn trans_static_method_callee(bcx: block,
 
     match vtbls[bound_index] {
         typeck::vtable_static(impl_did, ref rcvr_substs, rcvr_origins) => {
+            fail_unless!(rcvr_substs.all(|t| !ty::type_needs_infer(*t)));
 
             let mth_id = method_with_name(bcx.ccx(), impl_did, mname);
             let callee_substs = combine_impl_and_methods_tps(

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -67,9 +67,11 @@ pub fn monomorphic_fn(ccx: @CrateContext,
         must_cast = true;
     }
 
-    debug!("monomorphic_fn(fn_id=%? (%s), real_substs=%?, substs=%?, \
-           hash_id = %?",
+    debug!("monomorphic_fn(fn_id=%? (%s), vtables=%?, \
+            real_substs=%?, substs=%?, \
+            hash_id = %?",
            fn_id, ty::item_path_str(ccx.tcx, fn_id),
+           vtables,
            real_substs.map(|s| ty_to_str(ccx.tcx, *s)),
            substs.map(|s| ty_to_str(ccx.tcx, *s)), hash_id);
 

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -47,6 +47,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
                       impl_did_opt: Option<ast::def_id>,
                       ref_id: Option<ast::node_id>) ->
                       (ValueRef, bool) {
+    fail_unless!(real_substs.all(|t| !ty::type_needs_infer(*t)));
     let _icx = ccx.insn_ctxt("monomorphic_fn");
     let mut must_cast = false;
     let substs = vec::map(real_substs, |t| {

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -60,7 +60,7 @@ use middle::ty::{ty_param_substs_and_ty};
 use middle::ty;
 use middle::typeck::rscope::{in_binding_rscope};
 use middle::typeck::rscope::{region_scope, type_rscope, RegionError};
-use middle::typeck::{CrateCtxt, write_substs_to_tcx, write_ty_to_tcx};
+use middle::typeck::{CrateCtxt};
 
 use core::result;
 use core::vec;
@@ -186,19 +186,15 @@ pub fn ast_path_to_ty<AC:AstConv,RS:region_scope + Copy + Durable>(
         self: &AC,
         rscope: &RS,
         did: ast::def_id,
-        path: @ast::path,
-        path_id: ast::node_id)
-     -> ty_param_substs_and_ty {
+        path: @ast::path)
+     -> ty_param_substs_and_ty
+{
     // Look up the polytype of the item and then substitute the provided types
     // for any type/region parameters.
-    let tcx = self.tcx();
     let ty::ty_param_substs_and_ty {
         substs: substs,
         ty: ty
     } = ast_path_to_substs_and_ty(self, rscope, did, path);
-    write_ty_to_tcx(tcx, path_id, ty);
-    write_substs_to_tcx(tcx, path_id, /*bad*/copy substs.tps);
-
     ty_param_substs_and_ty { substs: substs, ty: ty }
 }
 
@@ -368,7 +364,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + Durable>(
         };
         match a_def {
           ast::def_ty(did) | ast::def_struct(did) => {
-            ast_path_to_ty(self, rscope, did, path, id).ty
+            ast_path_to_ty(self, rscope, did, path).ty
           }
           ast::def_prim_ty(nty) => {
             match nty {

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -215,7 +215,7 @@ pub fn visit_expr(expr: @ast::expr, &&rcx: @mut Rcx, v: rvt) {
             // `constrain_auto_ref()` on all exprs.  But that causes a
             // lot of spurious errors because of how the region
             // hierarchy is setup.
-            if rcx.fcx.ccx.method_map.contains_key(&callee.id) {
+            if rcx.fcx.inh.method_map.contains_key(&callee.id) {
                 match callee.node {
                     ast::expr_field(base, _, _) => {
                         constrain_auto_ref(rcx, base);
@@ -713,7 +713,7 @@ pub mod guarantor {
             ast::expr_repeat(*) |
             ast::expr_vec(*) => {
                 fail_unless!(!ty::expr_is_lval(
-                    rcx.fcx.tcx(), rcx.fcx.ccx.method_map, expr));
+                    rcx.fcx.tcx(), rcx.fcx.inh.method_map, expr));
                 None
             }
         }
@@ -765,7 +765,7 @@ pub mod guarantor {
         let _i = ::util::common::indenter();
 
         let guarantor = {
-            if rcx.fcx.ccx.method_map.contains_key(&expr.id) {
+            if rcx.fcx.inh.method_map.contains_key(&expr.id) {
                 None
             } else {
                 guarantor(rcx, expr)

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -42,7 +42,8 @@ use middle::typeck::astconv;
 use middle::typeck::infer;
 use middle::typeck::rscope::*;
 use middle::typeck::rscope;
-use middle::typeck::{CrateCtxt, lookup_def_tcx, no_params, write_ty_to_tcx};
+use middle::typeck::{CrateCtxt, lookup_def_tcx, no_params, write_ty_to_tcx,
+                     write_tpt_to_tcx};
 use util::common::{indenter, pluralize};
 use util::ppaux;
 
@@ -807,8 +808,10 @@ pub fn instantiate_trait_ref(ccx: &CrateCtxt, t: @ast::trait_ref,
 
     match lookup_def_tcx(ccx.tcx, t.path.span, t.ref_id) {
       ast::def_ty(t_id) => {
-        let tpt = astconv::ast_path_to_ty(ccx, &rscope, t_id, t.path,
-                                          t.ref_id);
+        let tpt = astconv::ast_path_to_ty(ccx, &rscope, t_id, t.path);
+
+        write_tpt_to_tcx(ccx.tcx, t.ref_id, &tpt);
+
         match ty::get(tpt.ty).sty {
            ty::ty_trait(*) => {
               (t_id, tpt)

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -111,6 +111,13 @@ pub fn mk_addr_of(cx: @ext_ctxt, sp: span, e: @ast::expr) -> @ast::expr {
 pub fn mk_mut_addr_of(cx: @ext_ctxt, sp: span, e: @ast::expr) -> @ast::expr {
     return mk_expr(cx, sp, ast::expr_addr_of(ast::m_mutbl, e));
 }
+pub fn mk_method_call(cx: @ext_ctxt,
+                      sp: span,
+                      rcvr_expr: @ast::expr,
+                      method_ident: ast::ident,
+                      +args: ~[@ast::expr]) -> @ast::expr {
+    mk_expr(cx, sp, ast::expr_method_call(rcvr_expr, method_ident, ~[], args, ast::NoSugar))
+}
 pub fn mk_call_(cx: @ext_ctxt, sp: span, fn_expr: @ast::expr,
                 +args: ~[@ast::expr]) -> @ast::expr {
     mk_expr(cx, sp, ast::expr_call(fn_expr, args, ast::NoSugar))

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -120,8 +120,9 @@ fn call_substructure_clone_method(cx: @ext_ctxt,
                                -> @expr {
     // Call the substructure method.
     let clone_ident = cx.ident_of(~"clone");
-    let self_method = build::mk_access_(cx, span, self_field, clone_ident);
-    build::mk_call_(cx, span, self_method, ~[])
+    build::mk_method_call(cx, span,
+                          self_field, clone_ident,
+                          ~[])
 }
 
 fn expand_deriving_clone_struct_def(cx: @ext_ctxt,

--- a/src/libsyntax/ext/deriving/eq.rs
+++ b/src/libsyntax/ext/deriving/eq.rs
@@ -147,11 +147,9 @@ fn call_substructure_eq_method(cx: @ext_ctxt,
                                junction: Junction,
                                chain_expr: &mut Option<@expr>) {
     // Call the substructure method.
-    let self_method = build::mk_access_(cx, span, self_field, method_ident);
-    let self_call = build::mk_call_(cx,
-                                    span,
-                                    self_method,
-                                    ~[ other_field_ref ]);
+    let self_call = build::mk_method_call(cx, span,
+                                          self_field, method_ident,
+                                          ~[ other_field_ref ]);
 
     // Connect to the outer expression if necessary.
     *chain_expr = match *chain_expr {

--- a/src/libsyntax/ext/deriving/iter_bytes.rs
+++ b/src/libsyntax/ext/deriving/iter_bytes.rs
@@ -125,14 +125,11 @@ fn call_substructure_iter_bytes_method(cx: @ext_ctxt,
 
     // Call the substructure method.
     let iter_bytes_ident = cx.ident_of(~"iter_bytes");
-    let self_method = build::mk_access_(cx,
-                                        span,
-                                        self_field,
-                                        iter_bytes_ident);
-    let self_call = build::mk_call_(cx,
-                                    span,
-                                    self_method,
-                                    ~[ lsb0_expr, f_expr ]);
+    let self_call = build::mk_method_call(cx,
+                                          span,
+                                          self_field,
+                                          iter_bytes_ident,
+                                          ~[ lsb0_expr, f_expr ]);
 
     // Create a statement out of this expression.
     build::mk_stmt(cx, span, self_call)

--- a/src/test/run-pass/issue-4036.rs
+++ b/src/test/run-pass/issue-4036.rs
@@ -1,0 +1,21 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #4036: Test for an issue that arose around fixing up type inference
+// byproducts in vtable records.
+
+extern mod std;
+use self::std::json;
+use self::std::serialize;
+
+pub fn main() {
+    let json = json::from_str("[1]").unwrap();
+    let _x: ~[int] = serialize::Decodable::decode(&json::Decoder(json));
+}


### PR DESCRIPTION
The basic problem was that vtables were not being resolved.  The fix uncovered another issue, which was that the syntax extensions were not creating method calls properly and were relying on outdated code in typeck, so I fixed that too.  

Resolves issues #3888, #4036, #4492.

r? @catamorphism 
