### PR TITLE
Fewer warnings, and correct str::each_char_reverse behaviour

### DIFF
--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -51,7 +51,6 @@ Implicitly, all crates behave as if they included the following prologue:
 #[warn(vecs_implicitly_copyable)];
 #[deny(non_camel_case_types)];
 #[allow(deprecated_mutable_fields)];
-#[deny(deprecated_self)];
 #[allow(deprecated_drop)];
 
 // On Linux, link to the runtime with -lrt.

--- a/src/libcore/repr.rs
+++ b/src/libcore/repr.rs
@@ -24,7 +24,6 @@ use managed;
 use ptr;
 use reflect;
 use reflect::{MovePtr, MovePtrAdaptor, align};
-use str;
 use sys;
 use to_str::ToStr;
 use vec::UnboxedVecRepr;

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1020,22 +1020,21 @@ pub fn each_chari(s: &str, it: &fn(uint, char) -> bool) {
 /// Iterates over the chars in a string in reverse
 #[inline(always)]
 pub fn each_char_reverse(s: &str, it: &fn(char) -> bool) {
-    let mut pos = 0;
-    let len = s.char_len();
-    while pos > 0 {
-        let CharRange {ch, next} = char_range_at_reverse(s, pos);
-        pos = next;
-        if !it(ch) { break; }
-    }
+    each_chari_reverse(s, |_, c| it(c))
 }
 
 // Iterates over the chars in a string in reverse, with indices
 #[inline(always)]
 pub fn each_chari_reverse(s: &str, it: &fn(uint, char) -> bool) {
+    let mut pos = s.len();
     let mut ch_pos = s.char_len();
-    for s.each_char_reverse |ch| {
+    while pos > 0 {
+        let CharRange {ch, next} = char_range_at_reverse(s, pos);
+        pos = next;
         ch_pos -= 1;
+
         if !it(ch_pos, ch) { break; }
+
     }
 }
 
@@ -3661,10 +3660,10 @@ mod tests {
     fn test_each_char_reverse() {
         let s = ~"ศไทย中华Việt Nam";
         let v = ~['ศ','ไ','ท','ย','中','华','V','i','ệ','t',' ','N','a','m'];
-        let mut pos = 0;
+        let mut pos = v.len();
         for s.each_char_reverse |ch| {
+            pos -= 1;
             fail_unless!(ch == v[pos]);
-            pos += 1;
         }
     }
 

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -2547,7 +2547,6 @@ impl<A:Clone> Clone for ~[A] {
 #[cfg(test)]
 mod tests {
     use option::{None, Option, Some};
-    use option;
     use sys;
     use vec::*;
     use cmp::*;

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -25,7 +25,6 @@
 #[allow(non_camel_case_types)];
 #[allow(deprecated_mode)];
 #[allow(deprecated_pattern)];
-#[deny(deprecated_self)];
 
 extern mod core(vers = "0.6");
 extern mod std(vers = "0.6");

--- a/src/librust/rust.rc
+++ b/src/librust/rust.rc
@@ -12,8 +12,6 @@
 // FIXME #2238 Make commands run and test emit proper file endings on winds
 // FIXME #2238 Make run only accept source that emits an executable
 
-#[deny(deprecated_self)];
-
 #[link(name = "rust",
        vers = "0.6",
        uuid = "4a24da33-5cc8-4037-9352-2cbe9bd9d27c",

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -25,7 +25,6 @@ use util::common::time;
 use util::ppaux;
 
 use core::int;
-use core::io::WriterUtil;
 use core::io;
 use core::os;
 use core::str;

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -56,8 +56,6 @@ use syntax::{visit, ast_util};
 // primitives in the stdlib are explicitly annotated to only take sendable
 // types.
 
-use core::hashmap::linear::LinearSet;
-
 pub static try_adding: &'static str = "Try adding a move";
 
 pub type rval_map = HashMap<node_id, ()>;

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -24,7 +24,6 @@
 #[allow(non_camel_case_types)];
 #[allow(deprecated_mode)];
 #[warn(deprecated_pattern)];
-#[deny(deprecated_self)];
 
 #[no_core];
 

--- a/src/librustdoc/rustdoc.rc
+++ b/src/librustdoc/rustdoc.rc
@@ -22,7 +22,6 @@
 #[no_core];
 
 #[allow(non_implicitly_copyable_typarams)];
-#[deny(deprecated_self)];
 
 extern mod core(vers = "0.6");
 extern mod std(vers = "0.6");

--- a/src/librustdoc/trim_pass.rs
+++ b/src/librustdoc/trim_pass.rs
@@ -18,8 +18,6 @@ is interpreted as the brief description.
 use pass::Pass;
 use text_pass;
 
-use core::str;
-
 pub fn mk_pass() -> Pass {
     text_pass::mk_pass(~"trim", |s| s.trim().to_owned() )
 }

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -22,7 +22,6 @@
 
 #[allow(vecs_implicitly_copyable,
         non_implicitly_copyable_typarams)];
-#[deny(deprecated_self)];
 
 extern mod core(vers = "0.6");
 extern mod std(vers = "0.6");

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -20,7 +20,6 @@
 #[no_core];
 #[allow(vecs_implicitly_copyable,
         non_implicitly_copyable_typarams)];
-#[deny(deprecated_self)];
 
 extern mod core(vers = "0.6");
 extern mod std(vers = "0.6");

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -28,7 +28,6 @@ not required in or otherwise suitable for the core library.
 
 #[allow(vecs_implicitly_copyable)];
 #[deny(non_camel_case_types)];
-#[deny(deprecated_self)];
 #[allow(deprecated_mutable_fields)];
 
 #[no_core];


### PR DESCRIPTION
Kills some warnings, and implements str::each_char_reverse so that it actually iterates. The test case wasn't detecting a failure, since the loop body was never executed.
