### PR TITLE
configure: error on unsupported target-triples and arm-linux-androideabi...

### DIFF
--- a/configure
+++ b/configure
@@ -536,6 +536,7 @@ fi
 CFG_PREFIX=${CFG_PREFIX%/}
 CFG_HOST_TRIPLES="$(echo $CFG_HOST_TRIPLES | tr ',' ' ')"
 CFG_TARGET_TRIPLES="$(echo $CFG_TARGET_TRIPLES | tr ',' ' ')"
+CFG_SUPPORTED_TARGET_TRIPLES="$(grep ^CC_*=* mk/platform.mk | sed 's,^[^_]*_,,' | sed 's/\([^=]*\).*/\1/' | xargs)"
 
 # copy host-triples to target-triples so that hosts are a subset of targets
 V_TEMP=""
@@ -548,8 +549,22 @@ CFG_TARGET_TRIPLES=$V_TEMP
 # check target-specific tool-chains
 for i in $CFG_TARGET_TRIPLES
 do
+    L_CHECK=false
+    for j in $CFG_SUPPORTED_TARGET_TRIPLES
+    do
+        if [ $i = $j ]
+        then
+            L_CHECK=true
+        fi
+    done
+
+    if [ $L_CHECK = false ]
+    then
+        err "unsupported target triples \"$i\" found"
+    fi
+
     case $i in
-        arm-unknown-android)
+        arm-linux-androideabi)
 
             if [ ! -f $CFG_ANDROID_CROSS_PATH/bin/arm-linux-androideabi-gcc ]
             then


### PR DESCRIPTION
In order to mitigate typo of target-triples, error notification of unsupported target triples which defined in mk/platform.mk added.

minor fix for arm-linux-androideabi added.
