### PR TITLE
configure: simplify pandoc version recognition.

### DIFF
--- a/configure
+++ b/configure
@@ -406,12 +406,13 @@ fi
 
 if [ ! -z "$CFG_PANDOC" ]
 then
-    PANDOC_VER_LINE=$(pandoc --version | grep '^pandoc ')
-    PANDOC_VER=${PANDOC_VER_LINE#pandoc }
-    PV_MAJOR_MINOR=${PANDOC_VER%.[0-9]*}
-    PV_MAJOR=${PV_MAJOR_MINOR%%[.][0-9]*}
-    PV_MINOR=${PV_MAJOR_MINOR#[0-9]*[.]}
-    PV_MINOR=${PV_MINOR%%[.][0-9]*}
+    PV_MAJOR_MINOR=$(pandoc --version | grep '^pandoc ' |
+        # extract the first 2 version fields, ignore everything else
+        sed 's/pandoc \([0-9]*\)\.\([0-9]*\).*/\1 \2/')
+
+    # these patterns are shell globs, *not* regexps
+    PV_MAJOR=${PV_MAJOR_MINOR% *}
+    PV_MINOR=${PV_MAJOR_MINOR#* }
     if [ "$PV_MAJOR" -lt "1" ] || [ "$PV_MINOR" -lt "8" ]
     then
 		step_msg "pandoc $PV_MAJOR.$PV_MINOR is too old. disabling"


### PR DESCRIPTION
The version recognition was failing for pandoc version 1.11, thinking the
minor version was 1 rather than 11, and thus not building the documentation.
