### PR TITLE
configure: Accept llvm-3.2

### DIFF
--- a/configure
+++ b/configure
@@ -497,7 +497,7 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-	(3.1svn|3.1|3.0svn|3.0)
+	(3.2svn|3.2|3.1svn|3.1|3.0svn|3.0)
 	    msg "found ok version of LLVM: $LLVM_VERSION"
 	    ;;
 	(*)


### PR DESCRIPTION
Previously the build system only checked for llvm-3.1 - 2.8.
Now also 3.2 and 3.2svn is accepted.

Signed-off-by: Fabian Deutsch fabian.deutsch@gmx.de
