### PR TITLE
librustc: Limit the typo suggestions to reasonable suggests.

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -4667,7 +4667,7 @@ pub impl Resolver {
         }
     }
 
-    fn find_best_match_for_name(@mut self, name: &str) -> Option<~str> {
+    fn find_best_match_for_name(@mut self, name: &str, max_distance: uint) -> Option<~str> {
         let this = &mut *self;
 
         let mut maybes: ~[~str] = ~[];
@@ -4695,6 +4695,7 @@ pub impl Resolver {
         if vec::len(values) > 0 &&
             values[smallest] != uint::max_value &&
             values[smallest] < str::len(name) + 2 &&
+            values[smallest] <= max_distance &&
             maybes[smallest] != name.to_owned() {
 
             Some(vec::swap_remove(&mut maybes, smallest))
@@ -4771,8 +4772,9 @@ pub impl Resolver {
                                         wrong_name));
                         }
                         else {
-                            match self.find_best_match_for_name(wrong_name) {
-
+                            // limit search to 5 to reduce the number
+                            // of stupid suggestions
+                            match self.find_best_match_for_name(wrong_name, 5) {
                                 Some(m) => {
                                     self.session.span_err(expr.span,
                                             fmt!("unresolved name: `%s`. \
@@ -5293,4 +5295,3 @@ pub fn resolve_crate(session: Session,
         trait_map: trait_map
     }
 }
-

--- a/src/test/compile-fail/issue-2281-part1.rs
+++ b/src/test/compile-fail/issue-2281-part1.rs
@@ -1,0 +1,13 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: unresolved name: `foobar`.
+
+fn main(args: ~[str]) { debug!(foobar); }


### PR DESCRIPTION
Impose a limit so that the typo suggester only shows reasonable
suggestions (i.e. don't suggest `args` when the error is `foobar`).

A tiny bit of progress on #2281.
