### PR TITLE
Fix pretty-printer test failure by carrying the bound lifetime names thr...

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -24,6 +24,7 @@ use core::vec;
 use syntax::ast;
 use syntax::ast::*;
 use syntax::codemap::{respan, dummy_sp};
+use syntax::opt_vec;
 
 // Compact string representation for ty::t values. API ty_str &
 // parse_from_str. Extra parameters are for converting to/from def_ids in the
@@ -479,7 +480,9 @@ fn parse_sig(st: @mut PState, conv: conv_did) -> ty::FnSig {
     }
     st.pos += 1u; // eat the ']'
     let ret_ty = parse_ty(st, conv);
-    ty::FnSig {inputs: inputs, output: ret_ty}
+    ty::FnSig {bound_lifetime_names: opt_vec::Empty, // FIXME(#4846)
+               inputs: inputs,
+               output: ret_ty}
 }
 
 // Rust metadata parsing

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -40,6 +40,7 @@ use util::ppaux::ty_to_str;
 use syntax::codemap::span;
 use syntax::{ast, ast_util};
 use syntax::{attr, ast_map};
+use syntax::opt_vec;
 use syntax::parse::token::special_idents;
 
 fn abi_info(arch: session::arch) -> @cabi::ABIInfo {
@@ -615,7 +616,8 @@ pub fn trans_intrinsic(ccx: @CrateContext,
                 sigil: ast::BorrowedSigil,
                 onceness: ast::Many,
                 region: ty::re_bound(ty::br_anon(0)),
-                sig: FnSig {inputs: ~[arg {mode: ast::expl(ast::by_copy),
+                sig: FnSig {bound_lifetime_names: opt_vec::Empty,
+                            inputs: ~[arg {mode: ast::expl(ast::by_copy),
                                            ty: star_u8}],
                             output: ty::mk_nil(bcx.tcx())}
             });

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -37,6 +37,7 @@ use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_map::{path, path_mod, path_name};
 use syntax::ast_util::local_def;
+use syntax::opt_vec;
 use syntax::parse::token::special_idents;
 
 pub fn monomorphic_fn(ccx: @CrateContext,
@@ -282,7 +283,8 @@ pub fn normalize_for_monomorphization(tcx: ty::ctxt,
                 ty::BareFnTy {
                     purity: ast::impure_fn,
                     abi: ast::RustAbi,
-                    sig: FnSig {inputs: ~[],
+                    sig: FnSig {bound_lifetime_names: opt_vec::Empty,
+                                inputs: ~[],
                                 output: ty::mk_nil(tcx)}}))
         }
         ty::ty_closure(ref fty) => {
@@ -316,7 +318,8 @@ pub fn normalize_for_monomorphization(tcx: ty::ctxt,
                 sigil: sigil,
                 onceness: ast::Many,
                 region: ty::re_static,
-                sig: ty::FnSig {inputs: ~[],
+                sig: ty::FnSig {bound_lifetime_names: opt_vec::Empty,
+                                inputs: ~[],
                                 output: ty::mk_nil(tcx)}})
     }
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -45,6 +45,8 @@ use syntax::codemap::span;
 use syntax::codemap;
 use syntax::print::pprust;
 use syntax::{ast, ast_map};
+use syntax::opt_vec::OptVec;
+use syntax::opt_vec;
 use syntax;
 
 // Data types
@@ -376,10 +378,12 @@ pub struct ClosureTy {
  * Signature of a function type, which I have arbitrarily
  * decided to use to refer to the input/output types.
  *
+ * - `lifetimes` is the list of region names bound in this fn.
  * - `inputs` is the list of arguments and their modes.
  * - `output` is the return type. */
 #[deriving(Eq)]
 pub struct FnSig {
+    bound_lifetime_names: OptVec<ast::ident>,
     inputs: ~[arg],
     output: t
 }
@@ -1062,7 +1066,8 @@ pub fn mk_ctor_fn(cx: ctxt, input_tys: &[ty::t], output: ty::t) -> t {
                BareFnTy {
                    purity: ast::pure_fn,
                    abi: ast::RustAbi,
-                   sig: FnSig {inputs: input_args,
+                   sig: FnSig {bound_lifetime_names: opt_vec::Empty,
+                               inputs: input_args,
                                output: output}})
 }
 
@@ -1203,6 +1208,7 @@ pub fn fold_sig(sig: &FnSig, fldop: &fn(t) -> t) -> FnSig {
     };
 
     FnSig {
+        bound_lifetime_names: copy sig.bound_lifetime_names,
         inputs: args,
         output: fldop(sig.output)
     }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1633,7 +1633,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         // sigils.
         let expected_sty = unpack_expected(fcx, expected, |x| Some(copy *x));
         let mut error_happened = false;
-        let (expected_tys,
+        let (expected_sig,
              expected_purity,
              expected_sigil,
              expected_onceness) = {
@@ -1668,13 +1668,14 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                                                expected_onceness,
                                                None,
                                                decl,
-                                               expected_tys,
+                                               expected_sig,
                                                &opt_vec::Empty,
                                                expr.span);
 
         let mut fty_sig;
         let fty = if error_happened {
             fty_sig = FnSig {
+                bound_lifetime_names: opt_vec::Empty,
                 inputs: fn_ty.sig.inputs.map(|an_arg| {
                     arg { mode: an_arg.mode,
                          ty: ty::mk_err(tcx)
@@ -3492,6 +3493,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             onceness: ast::Once,
             region: ty::re_bound(ty::br_anon(0)),
             sig: ty::FnSig {
+                bound_lifetime_names: opt_vec::Empty,
                 inputs: ~[arg {mode: ast::expl(ast::by_copy),
                                ty: ty::mk_imm_ptr(
                                    ccx.tcx,
@@ -3723,7 +3725,8 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
     let fty = ty::mk_bare_fn(tcx, ty::BareFnTy {
         purity: ast::unsafe_fn,
         abi: ast::RustAbi,
-        sig: FnSig {inputs: inputs,
+        sig: FnSig {bound_lifetime_names: opt_vec::Empty,
+                    inputs: inputs,
                     output: output}
     });
     let i_ty = ty::lookup_item_type(ccx.tcx, local_def(it.id));

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -70,6 +70,7 @@ use core::result::{iter_vec2, map_vec2};
 use core::vec;
 use syntax::ast::{Onceness, purity, ret_style};
 use syntax::ast;
+use syntax::opt_vec;
 use syntax::codemap::span;
 
 pub trait Combine {
@@ -432,7 +433,9 @@ pub fn super_fn_sigs<C:Combine>(
     do argvecs(self, a_f.inputs, b_f.inputs)
             .chain |inputs| {
         do self.tys(a_f.output, b_f.output).chain |output| {
-            Ok(FnSig {inputs: /*bad*/copy inputs, output: output})
+            Ok(FnSig {bound_lifetime_names: opt_vec::Empty, // FIXME(#4846)
+                      inputs: /*bad*/copy inputs,
+                      output: output})
         }
     }
 }

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -156,12 +156,10 @@ impl MethodRscope {
     // trait).
     pub fn new(self_ty: ast::self_ty_,
                variance: Option<ty::region_variance>,
-               rcvr_generics: &ast::Generics,
-               method_generics: &ast::Generics)
+               rcvr_generics: &ast::Generics)
             -> MethodRscope {
         let mut region_param_names =
             RegionParamNames::from_generics(rcvr_generics);
-        region_param_names.add_generics(method_generics);
         MethodRscope {
             self_ty: self_ty,
             variance: variance,
@@ -273,18 +271,7 @@ pub struct binding_rscope {
     region_param_names: RegionParamNames,
 }
 
-pub fn in_binding_rscope<RS:region_scope + Copy + Durable>(self: &RS)
-    -> binding_rscope {
-    let base = @copy *self;
-    let base = base as @region_scope;
-    binding_rscope {
-        base: base,
-        anon_bindings: @mut 0,
-        region_param_names: RegionParamNames::new()
-    }
-}
-
-pub fn in_binding_rscope_ext<RS:region_scope + Copy + Durable>(
+pub fn in_binding_rscope<RS:region_scope + Copy + Durable>(
         self: &RS,
         +region_param_names: RegionParamNames)
      -> binding_rscope {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -904,6 +904,7 @@ pub struct TyClosure {
 pub struct TyBareFn {
     purity: purity,
     abi: Abi,
+    lifetimes: OptVec<Lifetime>,
     decl: fn_decl
 }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -615,6 +615,7 @@ pub fn noop_fold_ty(t: &ty_, fld: @ast_fold) -> ty_ {
         }
         ty_bare_fn(ref f) => {
             ty_bare_fn(@TyBareFn {
+                lifetimes: f.lifetimes,
                 purity: f.purity,
                 abi: f.abi,
                 decl: fold_fn_decl(&f.decl, fld)

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -363,10 +363,11 @@ pub impl Parser {
 
         let purity = self.parse_purity();
         self.expect_keyword(&~"fn");
-        let (decl, _) = self.parse_ty_fn_decl();
+        let (decl, lifetimes) = self.parse_ty_fn_decl();
         return ty_bare_fn(@TyBareFn {
             abi: RustAbi,
             purity: purity,
+            lifetimes: lifetimes,
             decl: decl
         });
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -14,6 +14,7 @@ use ast::{RegionTyParamBound, TraitTyParamBound, required, provided};
 use ast;
 use ast_util;
 use opt_vec::OptVec;
+use opt_vec;
 use attr;
 use codemap::{CodeMap, BytePos};
 use codemap;
@@ -402,14 +403,18 @@ pub fn print_type(s: @ps, &&ty: @ast::Ty) {
         pclose(s);
       }
       ast::ty_bare_fn(f) => {
+          let generics = ast::Generics {lifetimes: copy f.lifetimes,
+                                        ty_params: opt_vec::Empty};
           print_ty_fn(s, Some(f.abi), None, None,
                       f.purity, ast::Many, &f.decl, None,
-                      None, None);
+                      Some(&generics), None);
       }
       ast::ty_closure(f) => {
+          let generics = ast::Generics {lifetimes: copy f.lifetimes,
+                                        ty_params: opt_vec::Empty};
           print_ty_fn(s, None, Some(f.sigil), f.region,
                       f.purity, f.onceness, &f.decl, None,
-                      None, None);
+                      Some(&generics), None);
       }
       ast::ty_path(path, _) => print_path(s, path, false),
       ast::ty_fixed_length_vec(ref mt, v) => {
@@ -1923,7 +1928,8 @@ pub fn print_ty_fn(s: @ps,
                    opt_region: Option<@ast::Lifetime>,
                    purity: ast::purity,
                    onceness: ast::Onceness,
-                   decl: &ast::fn_decl, id: Option<ast::ident>,
+                   decl: &ast::fn_decl,
+                   id: Option<ast::ident>,
                    generics: Option<&ast::Generics>,
                    opt_self_ty: Option<ast::self_ty_>) {
     ibox(s, indent_unit);

--- a/src/test/run-pass/regions-fn-subtyping.rs
+++ b/src/test/run-pass/regions-fn-subtyping.rs
@@ -1,5 +1,3 @@
-// xfail-pretty
-
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.


### PR DESCRIPTION
Fix pretty-printer test failure by carrying the bound lifetime names through

the types.  Initially I thought it would be necessary to thread this data
through not only the AST but the types themselves, but then I remembered that
the pretty printer only cares about the AST.  Regardless, I have elected to
leave the changes to the types intact since they will eventually be needed.  I
left a few FIXMEs where it didn't seem worth finishing up since the code wasn't
crucial yet.
