### PR TITLE
Change Decoder::read_option to allow returning arbitrary types; inline some malloc wrapper fns

### DIFF
--- a/src/libcore/unstable/lang.rs
+++ b/src/libcore/unstable/lang.rs
@@ -64,6 +64,7 @@ pub unsafe fn fail_borrowed() {
 
 // FIXME #4942: Make these signatures agree with exchange_alloc's signatures
 #[lang="exchange_malloc"]
+#[inline(always)]
 pub unsafe fn exchange_malloc(td: *c_char, size: uintptr_t) -> *c_char {
     transmute(exchange_alloc::malloc(transmute(td), transmute(size)))
 }
@@ -72,11 +73,13 @@ pub unsafe fn exchange_malloc(td: *c_char, size: uintptr_t) -> *c_char {
 // inside a landing pad may corrupt the state of the exception handler. If a
 // problem occurs, call exit instead.
 #[lang="exchange_free"]
+#[inline(always)]
 pub unsafe fn exchange_free(ptr: *c_char) {
     exchange_alloc::free(transmute(ptr))
 }
 
 #[lang="malloc"]
+#[inline(always)]
 pub unsafe fn local_malloc(td: *c_char, size: uintptr_t) -> *c_char {
     return rustrt::rust_upcall_malloc(td, size);
 }
@@ -85,6 +88,7 @@ pub unsafe fn local_malloc(td: *c_char, size: uintptr_t) -> *c_char {
 // inside a landing pad may corrupt the state of the exception handler. If a
 // problem occurs, call exit instead.
 #[lang="free"]
+#[inline(always)]
 pub unsafe fn local_free(ptr: *c_char) {
     rustrt::rust_upcall_free(ptr);
 }
@@ -117,6 +121,7 @@ pub unsafe fn check_not_borrowed(a: *u8) {
 }
 
 #[lang="strdup_uniq"]
+#[inline(always)]
 pub unsafe fn strdup_uniq(ptr: *c_uchar, len: uint) -> ~str {
     str::raw::from_buf_len(ptr, len)
 }

--- a/src/libstd/ebml.rs
+++ b/src/libstd/ebml.rs
@@ -411,13 +411,13 @@ pub mod reader {
         }
 
         #[cfg(stage0)]
-        fn read_option<T>(&self, f: &fn() -> T) -> Option<T> {
+        fn read_option<T>(&self, f: &fn(bool) -> T) -> T {
             debug!("read_option()");
             do self.read_enum("Option") || {
                 do self.read_enum_variant |idx| {
                     match idx {
-                        0 => None,
-                        1 => Some(f()),
+                        0 => f(false),
+                        1 => f(true),
                         _ => fail!(),
                     }
                 }
@@ -427,13 +427,13 @@ pub mod reader {
         #[cfg(stage1)]
         #[cfg(stage2)]
         #[cfg(stage3)]
-        fn read_option<T>(&self, f: &fn() -> T) -> Option<T> {
+        fn read_option<T>(&self, f: &fn(bool) -> T) -> T {
             debug!("read_option()");
             do self.read_enum("Option") || {
                 do self.read_enum_variant(["None", "Some"]) |idx| {
                     match idx {
-                        0 => None,
-                        1 => Some(f()),
+                        0 => f(false),
+                        1 => f(true),
                         _ => fail!(),
                     }
                 }

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -980,10 +980,10 @@ impl<'self> serialize::Decoder for Decoder<'self> {
         }
     }
 
-    fn read_option<T>(&self, f: &fn() -> T) -> Option<T> {
+    fn read_option<T>(&self, f: &fn(bool) -> T) -> T {
         match *self.peek() {
-            Null => { self.pop(); None }
-            _ => Some(f()),
+            Null => { self.pop(); f(false) }
+            _ => f(true),
         }
     }
 }

--- a/src/libstd/serialize.rs
+++ b/src/libstd/serialize.rs
@@ -118,7 +118,7 @@ pub trait Decoder {
     fn read_tup_elt<T>(&self, idx: uint, f: &fn() -> T) -> T;
 
     // Specialized types:
-    fn read_option<T>(&self, f: &fn() -> T) -> Option<T>;
+    fn read_option<T>(&self, f: &fn(bool) -> T) -> T;
 }
 
 pub trait Encodable<S:Encoder> {
@@ -395,7 +395,13 @@ impl<S:Encoder,T:Encodable<S>> Encodable<S> for Option<T> {
 
 impl<D:Decoder,T:Decodable<D>> Decodable<D> for Option<T> {
     fn decode(d: &D) -> Option<T> {
-        d.read_option(|| Decodable::decode(d))
+        do d.read_option |b| {
+            if b {
+                Some(Decodable::decode(d))
+            } else {
+                None
+            }
+        }
     }
 }
 


### PR DESCRIPTION
@nikomatsakis pointed out that `fn read_option<T>(&self, f: &fn() -> T) -> Option<T>` should have this syntax so it can work with custom option types: `fn read_option<T>(&self, f: &fn(bool) -> T) -> T`.

Also, this also includes some `#[inline(always)]` on the memory functions in `src/libcore/unstable/lang.rs` to reduce one level of indirection when allocating memory.
