### PR TITLE
Upgrade LLVM to support ARM split stacks and unwinding

### DIFF
--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -206,7 +206,8 @@ fn get_metadata_section(os: os,
         while llvm::LLVMIsSectionIteratorAtEnd(of.llof, si.llsi) == False {
             let name_buf = llvm::LLVMGetSectionName(si.llsi);
             let name = unsafe { str::raw::from_c_str(name_buf) };
-            if name == meta_section_name(os) {
+            debug!("get_matadata_section: name %s", name);
+            if name == read_meta_section_name(os) {
                 let cbuf = llvm::LLVMGetSectionContents(si.llsi);
                 let csz = llvm::LLVMGetSectionSize(si.llsi) as uint;
                 let mut found = None;
@@ -244,6 +245,16 @@ fn get_metadata_section(os: os,
 pub fn meta_section_name(os: os) -> ~str {
     match os {
       os_macos => ~"__DATA,__note.rustc",
+      os_win32 => ~".note.rustc",
+      os_linux => ~".note.rustc",
+      os_android => ~".note.rustc",
+      os_freebsd => ~".note.rustc"
+    }
+}
+
+pub fn read_meta_section_name(os: os) -> ~str {
+    match os {
+      os_macos => ~"__note.rustc",
       os_win32 => ~".note.rustc",
       os_linux => ~".note.rustc",
       os_android => ~".note.rustc",

--- a/src/rt/arch/arm/morestack.S
+++ b/src/rt/arch/arm/morestack.S
@@ -15,14 +15,19 @@
 
 // r4 and r5 are scratch registers for __morestack due to llvm
 // ARMFrameLowering::adjustForSegmentedStacks() implementation.
-    .align 2
-    .type __morestack,%function
+ .type __morestack,%function
 __morestack:
+	.fnstart
+	// Save frame pointer and return address
+	.save {r4, r5}
+	.save {lr}
+	.save {r6, fp, lr}
+    push {r6, fp, lr}
 
-    // Save frame pointer and return address
-    push {fp, lr}
-    
-    mov fp, sp
+	.movsp r6
+	mov r6, sp
+	.setfp fp, sp, #4
+	add fp, sp, #4
 
     // Save argument registers of the original function
     push {r0, r1, r2, r3, lr}
@@ -47,20 +52,20 @@ __morestack:
     mov pc, r4         // Call the original function
 
     // Switch back to rust stack
-    mov sp, fp
+    mov sp, r6
 
     // Save return value
-    push {r0, r1}
+	mov r4, r0
+	mov r5, r1
 
     // Remove the new allocated stack
     bl upcall_del_stack@plt
 
     // Restore return value
-    pop {r0, r1}
-
+	mov r0, r4
+	mov r1, r5
+	
     // Return
-    pop {fp, lr}
+    pop {r6, fp, lr}
     mov pc, lr
-.endofmorestack:
-    .size   __morestack, .endofmorestack-__morestack
-   
+    .fnend

--- a/src/rt/arch/arm/morestack.S
+++ b/src/rt/arch/arm/morestack.S
@@ -8,6 +8,59 @@
 .arm
 .align
 
-.globl __morestack
+.global upcall_new_stack
+.global upcall_del_stack
+.global __morestack
 .hidden __morestack
+
+// r4 and r5 are scratch registers for __morestack due to llvm
+// ARMFrameLowering::adjustForSegmentedStacks() implementation.
+    .align 2
+    .type __morestack,%function
 __morestack:
+
+    // Save frame pointer and return address
+    push {fp, lr}
+    
+    mov fp, sp
+
+    // Save argument registers of the original function
+    push {r0, r1, r2, r3, lr}
+
+    mov r0, r4         // The amount of stack needed
+    add r1, fp, #20    // Address of stack arguments
+    mov r2, r5         // Size of stack arguments
+    
+    // Create new stack
+    bl upcall_new_stack@plt
+
+    // Hold new stack pointer
+    mov r5, r0
+
+    // Pop the saved arguments
+    pop {r0, r1, r2, r3, lr}
+
+    // Grab the return pointer
+    add r4, lr, #16    // Skip past the return
+    mov sp, r5         // Swich to the new stack
+    mov lr, pc
+    mov pc, r4         // Call the original function
+
+    // Switch back to rust stack
+    mov sp, fp
+
+    // Save return value
+    push {r0, r1}
+
+    // Remove the new allocated stack
+    bl upcall_del_stack@plt
+
+    // Restore return value
+    pop {r0, r1}
+
+    // Return
+    pop {fp, lr}
+    mov pc, lr
+.endofmorestack:
+    .size   __morestack, .endofmorestack-__morestack
+   

--- a/src/rt/arch/arm/record_sp.S
+++ b/src/rt/arch/arm/record_sp.S
@@ -14,53 +14,18 @@
 .globl get_sp
 
 record_sp_limit:
-	mov r3, r0
-	ldr r0, =my_cpu
-	mov r1, #0
-	mov r2, #0
-    stmfd   sp!, {r3, r7}
-    ldr     r7, =345
-    swi     #0
-    ldmfd   sp!, {r3, r7}
-    movs    r0, r0
-	movmi	r0, #0
-
-	ldr r1, =my_array
-	str r3, [r1, r0]
+	mrc p15, #0, r3, c13, c0, #3
+	add r3, r3, #252
+	str r0, [r3]
 	mov pc, lr
-
 
 get_sp_limit:
-    ldr r0, =my_cpu
-	mov r1, #0
-	mov r2, #0
-    stmfd   sp!, {r4, r7}
-    ldr     r7, =345
-    swi     #0
-    ldmfd   sp!, {r4, r7}
-    movs    r0, r0
-	movmi	r0, #0
-	mov r3, r0
-
-	ldr r1, =my_array
-	ldr r0, [r1, r3]
+	mrc p15, #0, r3, c13, c0, #3
+	add r3, r3, #252
+	ldr r0, [r3]
 	mov pc, lr
-
 
 get_sp:
 	mov r0, sp
 	mov pc, lr
 
-.data
-my_cpu:	.long	0
-.global my_array
-my_array:
-	.long	0
-	.long	0
-	.long	0
-	.long	0
-	.long	0
-	.long	0
-	.long	0
-	.long	0
-.end

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -15,14 +15,12 @@
 //
 //===----------------------------------------------------------------------===
 
-#include "llvm/InlineAsm.h"
-#include "llvm/LLVMContext.h"
 #include "llvm/Linker.h"
 #include "llvm/PassManager.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/Analysis/Verifier.h"
 #include "llvm/Analysis/Passes.h"
-#include "llvm/Transforms/Scalar.h"
-#include "llvm/Transforms/IPO.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Assembly/Parser.h"
@@ -31,11 +29,9 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Target/TargetMachine.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Target/TargetOptions.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DynamicLibrary.h"
@@ -45,6 +41,10 @@
 #include "llvm/ExecutionEngine/JITMemoryManager.h"
 #include "llvm/ExecutionEngine/MCJIT.h"
 #include "llvm/ExecutionEngine/Interpreter.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Target/TargetOptions.h"
+#include "llvm/Transforms/Scalar.h"
+#include "llvm/Transforms/IPO.h"
 #include "llvm-c/Core.h"
 #include "llvm-c/BitReader.h"
 #include "llvm-c/Object.h"
@@ -216,6 +216,12 @@ public:
     llvm_unreachable("Unimplemented call");
   }
   virtual void deallocateExceptionTable(void *ET) {
+    llvm_unreachable("Unimplemented call");
+  }
+  virtual uint8_t* allocateDataSection(uintptr_t, unsigned int, unsigned int, bool) {
+    llvm_unreachable("Unimplemented call");
+  }
+  virtual bool applyPermissions(std::string*) {
     llvm_unreachable("Unimplemented call");
   }
 };
@@ -481,7 +487,7 @@ extern "C" LLVMModuleRef LLVMRustParseAssemblyFile(const char *Filename) {
   if (m) {
     return wrap(m);
   } else {
-    LLVMRustError = d.getMessage().c_str();
+    LLVMRustError = d.getMessage().data();
     return NULL;
   }
 }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -452,6 +452,8 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
   Options.NoFramePointerElim = true;
   Options.EnableSegmentedStacks = EnableSegmentedStacks;
 
+  PassManager *PM = unwrap<PassManager>(PMR);
+
   std::string Err;
   std::string Trip(Triple::normalize(triple));
   std::string FeaturesStr;
@@ -461,8 +463,9 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
     TheTarget->createTargetMachine(Trip, CPUStr, FeaturesStr,
 				   Options, Reloc::PIC_,
 				   CodeModel::Default, OptLevel);
+  Target->addAnalysisPasses(*PM);
+
   bool NoVerify = false;
-  PassManager *PM = unwrap<PassManager>(PMR);
   std::string ErrorInfo;
   raw_fd_ostream OS(path, ErrorInfo,
                     raw_fd_ostream::F_Binary);

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -383,8 +383,6 @@ LLVMInitializeInstCombine
 LLVMInitializeScalarOpts
 LLVMInitializeTarget
 LLVMInitializeTransformUtils
-LLVMInitializeARMAsmLexer
-LLVMInitializeX86AsmLexer
 LLVMInitializeARMAsmParser
 LLVMInitializeMipsAsmParser
 LLVMInitializeX86AsmParser


### PR DESCRIPTION
This branch fixes #5368 and #4489 and supersedes #5327. Since it's so difficult to complete LLVM upgrades and this isn't going to have much time to bake before 0.6 I want to hold off on merging it.
