### PR TITLE
rustc: fix linkage of internal static nodes.

### DIFF
--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -11,7 +11,8 @@
 use core::prelude::*;
 
 use back::abi;
-use lib::llvm::{llvm, ValueRef, TypeRef, Bool, True, False};
+use lib::llvm::{llvm, SetLinkage, InternalLinkage, PrivateLinkage,
+                ValueRef, TypeRef, Bool, True, False};
 use metadata::csearch;
 use middle::const_eval;
 use middle::trans::adt;
@@ -104,6 +105,7 @@ fn const_addr_of(cx: @CrateContext, cv: ValueRef) -> ValueRef {
         };
         llvm::LLVMSetInitializer(gv, cv);
         llvm::LLVMSetGlobalConstant(gv, True);
+        SetLinkage(gv, PrivateLinkage);
         gv
     }
 }
@@ -483,6 +485,7 @@ fn const_expr_unadjusted(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                 };
                 llvm::LLVMSetInitializer(gv, cv);
                 llvm::LLVMSetGlobalConstant(gv, True);
+                SetLinkage(gv, PrivateLinkage);
                 let p = const_ptrcast(cx, gv, llunitty);
                 C_struct(~[p, sz])
               }


### PR DESCRIPTION
re bug that @nikomatsakis was hitting: when you define a `static` (old: `const`) containing a `&` or `&[]` expression, it will create temporaries (the underlying pointee) by creating a throwaway symbol for each temporary, each with _global_ linkage, and each named `"const"`. LLVM will helpfully rename multiple copies of this throwaway symbol to `"const1"` and `"const2"` and so forth in the _same_ library. But if you have _2 libraries_ -- say, libcore and librustc -- that both do this, the dynamic linker (at least on linux) will happily do horrible things like make the slice in one library point to the bytes of the vector from the other library. This is obviously a recipe for much hilarity and head-scratching.

The solution is to change the linkage to something else, internal or (in the case of this patch) _private_.

It will require a snapshot to integrate this into stage0 and thereby fix the problem / unblock patches that were hitting this in stage1.
