### PR TITLE
move dlist from core -> std

### DIFF
--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -189,7 +189,6 @@ pub mod container;
 pub mod option;
 pub mod result;
 pub mod either;
-pub mod dlist;
 pub mod hashmap;
 pub mod cell;
 pub mod trie;

--- a/src/libstd/dlist.rs
+++ b/src/libstd/dlist.rs
@@ -18,12 +18,8 @@ Do not use ==, !=, <, etc on doubly-linked lists -- it may not terminate.
 
 */
 
-use iter;
-use iter::BaseIter;
-use kinds::Copy;
-use managed;
-use option::{None, Option, Some};
-use vec;
+use core::prelude::*;
+use core::managed;
 
 pub type DListLink<T> = Option<@mut DListNode<T>>;
 
@@ -540,10 +536,8 @@ impl<T> BaseIter<T> for @mut DList<T> {
 
 #[cfg(test)]
 mod tests {
-    use dlist::{DList, concat, from_vec, new_dlist_node};
-    use iter;
-    use option::{None, Some};
-    use vec;
+    use super::*;
+    use core::prelude::*;
 
     #[test]
     pub fn test_dlist_concat() {

--- a/src/libstd/serialize.rs
+++ b/src/libstd/serialize.rs
@@ -17,10 +17,10 @@ Core encoding and decoding interfaces.
 #[forbid(non_camel_case_types)];
 
 use core::prelude::*;
-use core::dlist::DList;
 use core::hashmap::linear::{LinearMap, LinearSet};
 use core::trie::{TrieMap, TrieSet};
 use deque::Deque;
+use dlist::DList;
 use treemap::{TreeMap, TreeSet};
 
 pub trait Encoder {

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -75,6 +75,7 @@ pub mod priority_queue;
 pub mod rope;
 pub mod smallintmap;
 pub mod sort;
+pub mod dlist;
 pub mod treemap;
 
 // And ... other stuff


### PR DESCRIPTION
Closes #3549

The issue report has some reasoning, but I'd like to add that I don't think managed pointers belong in core. It's _possible_ to write a safe doubly-linked list on top of `unsafe`, but it would be much more limited and I don't think there's much of a use case - it would lose a lot of flexibility. You're probably better off using a vector, hash table, tree, heap or ring buffer in almost every case.
