### PR TITLE
Fix type signature for start lang item.

### DIFF
--- a/src/libcore/unstable/lang.rs
+++ b/src/libcore/unstable/lang.rs
@@ -127,6 +127,7 @@ pub unsafe fn strdup_uniq(ptr: *c_uchar, len: uint) -> ~str {
 }
 
 #[lang="start"]
+#[cfg(stage0)]
 pub fn start(main: *u8, argc: int, argv: *c_char,
              crate_map: *u8) -> int {
     use libc::getenv;
@@ -146,6 +147,31 @@ pub fn start(main: *u8, argc: int, argv: *c_char,
 
     extern {
         fn rust_start(main: *c_void, argc: c_int, argv: *c_char,
+                      crate_map: *c_void) -> c_int;
+    }
+}
+
+#[lang="start"]
+#[cfg(not(stage0))]
+pub fn start(main: *u8, argc: int, argv: **c_char,
+             crate_map: *u8) -> int {
+    use libc::getenv;
+    use rt::start;
+
+    unsafe {
+        let use_new_rt = do str::as_c_str("RUST_NEWRT") |s| {
+            getenv(s).is_null()
+        };
+        if use_new_rt {
+            return rust_start(main as *c_void, argc as c_int, argv,
+                              crate_map as *c_void) as int;
+        } else {
+            return start(main, argc, argv, crate_map);
+        }
+    }
+
+    extern {
+        fn rust_start(main: *c_void, argc: c_int, argv: **c_char,
                       crate_map: *c_void) -> c_int;
     }
 }

--- a/src/libcore/unstable/lang.rs
+++ b/src/libcore/unstable/lang.rs
@@ -134,10 +134,10 @@ pub fn start(main: *u8, argc: int, argv: *c_char,
     use rt::start;
 
     unsafe {
-        let use_new_rt = do str::as_c_str("RUST_NEWRT") |s| {
+        let use_old_rt = do str::as_c_str("RUST_NEWRT") |s| {
             getenv(s).is_null()
         };
-        if use_new_rt {
+        if use_old_rt {
             return rust_start(main as *c_void, argc as c_int, argv,
                               crate_map as *c_void) as int;
         } else {
@@ -159,10 +159,10 @@ pub fn start(main: *u8, argc: int, argv: **c_char,
     use rt::start;
 
     unsafe {
-        let use_new_rt = do str::as_c_str("RUST_NEWRT") |s| {
+        let use_old_rt = do str::as_c_str("RUST_NEWRT") |s| {
             getenv(s).is_null()
         };
-        if use_new_rt {
+        if use_old_rt {
             return rust_start(main as *c_void, argc as c_int, argv,
                               crate_map as *c_void) as int;
         } else {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2247,7 +2247,7 @@ pub fn create_main_wrapper(ccx: @CrateContext,
         fn main_name() -> ~str { return ~"WinMain@16"; }
         #[cfg(unix)]
         fn main_name() -> ~str { return ~"main"; }
-        let llfty = T_fn(~[ccx.int_type, T_ptr(T_i8())], ccx.int_type);
+        let llfty = T_fn(~[ccx.int_type, T_ptr(T_ptr(T_i8()))], ccx.int_type);
 
         // FIXME #4404 android JNI hacks
         let llfn = if *ccx.sess.building_library {


### PR DESCRIPTION
#5405

Also, renames the confusingly named `use_new_rt` in `libcore/unstable/lang.rs`
