### PR TITLE
rt: regression patch for ARM assembly code

### DIFF
--- a/src/rt/arch/arm/_context.S
+++ b/src/rt/arch/arm/_context.S
@@ -1,8 +1,3 @@
-// Mark stack as non-executable
-#if defined(__linux__) && defined(__ELF__)
-.section	.note.GNU-stack, "", @progbits
-#endif
-
 .text
 .code 32
 .arm

--- a/src/rt/arch/arm/ccall.S
+++ b/src/rt/arch/arm/ccall.S
@@ -1,8 +1,3 @@
-// Mark stack as non-executable
-#if defined(__linux__) && defined(__ELF__)
-.section	.note.GNU-stack, "", @progbits
-#endif
-
 .text
 .code 32
 .arm

--- a/src/rt/arch/arm/morestack.S
+++ b/src/rt/arch/arm/morestack.S
@@ -1,8 +1,3 @@
-// Mark stack as non-executable
-#if defined(__linux__) && defined(__ELF__)
-.section	.note.GNU-stack, "", @progbits
-#endif
-
 .text
 .code 32
 .arm

--- a/src/rt/arch/arm/record_sp.S
+++ b/src/rt/arch/arm/record_sp.S
@@ -1,8 +1,3 @@
-// Mark stack as non-executable
-#if defined(__linux__) && defined(__ELF__)
-.section	.note.GNU-stack, "", @progbits
-#endif
-
 .text
 .code 32
 .arm


### PR DESCRIPTION
Regression Path for ARM build failure on #5647

no need to add extra header for ARM assmebly code. already "RW" not "RWX"

readelf -lW arm-linux-androideabi/lib/libcore-c3ca5d77d81b46c1-0.6.so arm-linux-androideabi/lib/librustrt.so arm-linux-androideabi/lib/libstd-4782a756585a81-0.6.so  | grep GNU_STACK

  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0
