### PR TITLE
rt/arch/arm: fix syntax used for noexec stack

### DIFF
--- a/src/rt/arch/arm/_context.S
+++ b/src/rt/arch/arm/_context.S
@@ -1,6 +1,6 @@
 // Mark stack as non-executable
 #if defined(__linux__) && defined(__ELF__)
-.section	.note.GNU-stack, "", @progbits
+.section	.note.GNU-stack, "", %progbits
 #endif
 
 .text

--- a/src/rt/arch/arm/ccall.S
+++ b/src/rt/arch/arm/ccall.S
@@ -1,6 +1,6 @@
 // Mark stack as non-executable
 #if defined(__linux__) && defined(__ELF__)
-.section	.note.GNU-stack, "", @progbits
+.section	.note.GNU-stack, "", %progbits
 #endif
 
 .text

--- a/src/rt/arch/arm/morestack.S
+++ b/src/rt/arch/arm/morestack.S
@@ -1,6 +1,6 @@
 // Mark stack as non-executable
 #if defined(__linux__) && defined(__ELF__)
-.section	.note.GNU-stack, "", @progbits
+.section	.note.GNU-stack, "", %progbits
 #endif
 
 .text

--- a/src/rt/arch/arm/record_sp.S
+++ b/src/rt/arch/arm/record_sp.S
@@ -1,6 +1,6 @@
 // Mark stack as non-executable
 #if defined(__linux__) && defined(__ELF__)
-.section	.note.GNU-stack, "", @progbits
+.section	.note.GNU-stack, "", %progbits
 #endif
 
 .text


### PR DESCRIPTION
Turns out @ isn't valid for the ARM assembler.
