### PR TITLE
remove stray mode on callback, seems to not change anything

### DIFF
--- a/src/libcore/rt/uv/net.rs
+++ b/src/libcore/rt/uv/net.rs
@@ -81,7 +81,7 @@ pub impl StreamWatcher {
             return (*alloc_cb)(suggested_size as uint);
         }
 
-        extern fn read_cb(stream: *uvll::uv_stream_t, nread: ssize_t, ++buf: Buf) {
+        extern fn read_cb(stream: *uvll::uv_stream_t, nread: ssize_t, buf: Buf) {
             rtdebug!("buf addr: %x", buf.base as uint);
             rtdebug!("buf len: %d", buf.len as int);
             let mut stream_watcher: StreamWatcher = NativeHandle::from_native_handle(stream);


### PR DESCRIPTION
It seems nobody can figure out whether this is _supposed to_ make a difference anymore, and in testing it seems to work either way, so I removed it. One less alarming warning during a fresh build.
