### PR TITLE
Removing some mut-fields from libcore

### DIFF
--- a/src/libcore/at_vec.rs
+++ b/src/libcore/at_vec.rs
@@ -208,7 +208,7 @@ pub mod raw {
      */
     #[inline(always)]
     pub unsafe fn set_len<T>(v: @[T], new_len: uint) {
-        let repr: **VecRepr = ::cast::reinterpret_cast(&addr_of(&v));
+        let repr: **mut VecRepr = ::cast::reinterpret_cast(&addr_of(&v));
         (**repr).unboxed.fill = new_len * sys::size_of::<T>();
     }
 
@@ -226,7 +226,7 @@ pub mod raw {
 
     #[inline(always)] // really pretty please
     pub unsafe fn push_fast<T>(v: &mut @[T], initval: T) {
-        let repr: **VecRepr = ::cast::reinterpret_cast(&v);
+        let repr: **mut VecRepr = ::cast::reinterpret_cast(&v);
         let fill = (**repr).unboxed.fill;
         (**repr).unboxed.fill += sys::size_of::<T>();
         let p = addr_of(&((**repr).unboxed.data));

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -10,7 +10,7 @@
 
 //! A mutable, nullable memory location
 
-use cast::transmute;
+use cast::transmute_mut;
 use prelude::*;
 
 /*
@@ -20,16 +20,12 @@ Similar to a mutable option type, but friendlier.
 */
 
 pub struct Cell<T> {
-    mut value: Option<T>
+    value: Option<T>
 }
 
 impl<T:cmp::Eq> cmp::Eq for Cell<T> {
     fn eq(&self, other: &Cell<T>) -> bool {
-        unsafe {
-            let frozen_self: &Option<T> = transmute(&mut self.value);
-            let frozen_other: &Option<T> = transmute(&mut other.value);
-            frozen_self == frozen_other
-        }
+        (self.value) == (other.value)
     }
     fn ne(&self, other: &Cell<T>) -> bool { !self.eq(other) }
 }
@@ -46,6 +42,7 @@ pub fn empty_cell<T>() -> Cell<T> {
 pub impl<T> Cell<T> {
     /// Yields the value, failing if the cell is empty.
     fn take(&self) -> T {
+        let mut self = unsafe { transmute_mut(self) };
         if self.is_empty() {
             fail!(~"attempt to take an empty cell");
         }
@@ -57,6 +54,7 @@ pub impl<T> Cell<T> {
 
     /// Returns the value, failing if the cell is full.
     fn put_back(&self, value: T) {
+        let mut self = unsafe { transmute_mut(self) };
         if !self.is_empty() {
             fail!(~"attempt to put a value back into a full cell");
         }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -2274,8 +2274,8 @@ pub mod raw {
 
     /// Sets the length of the string and adds the null terminator
     pub unsafe fn set_len(v: &mut ~str, new_len: uint) {
-        let v: **vec::raw::VecRepr = cast::transmute(v);
-        let repr: *vec::raw::VecRepr = *v;
+        let v: **mut vec::raw::VecRepr = cast::transmute(v);
+        let repr: *mut vec::raw::VecRepr = *v;
         (*repr).unboxed.fill = new_len + 1u;
         let null = ptr::mut_offset(cast::transmute(&((*repr).unboxed.data)),
                                    new_len);

--- a/src/libcore/unstable.rs
+++ b/src/libcore/unstable.rs
@@ -120,9 +120,9 @@ impl<T> Drop for ArcDestruct<T>{
     fn finalize(&self) {
         unsafe {
             do task::unkillable {
-                let data: ~ArcData<T> = cast::reinterpret_cast(&self.data);
+                let mut data: ~ArcData<T> = cast::reinterpret_cast(&self.data);
                 let new_count =
-                    intrinsics::atomic_xsub(cast::transmute_mut(&data.count), 1) - 1;
+                    intrinsics::atomic_xsub(&mut data.count, 1) - 1;
                 assert!(new_count >= 0);
                 if new_count == 0 {
                     // drop glue takes over.
@@ -185,8 +185,8 @@ pub unsafe fn get_shared_immutable_state<'a,T:Owned>(
 pub unsafe fn clone_shared_mutable_state<T:Owned>(rc: &SharedMutableState<T>)
         -> SharedMutableState<T> {
     unsafe {
-        let ptr: ~ArcData<T> = cast::reinterpret_cast(&(*rc).data);
-        let new_count = intrinsics::atomic_xadd(cast::transmute_mut(&ptr.count), 1) + 1;
+        let mut ptr: ~ArcData<T> = cast::reinterpret_cast(&(*rc).data);
+        let new_count = intrinsics::atomic_xadd(&mut ptr.count, 1) + 1;
         assert!(new_count >= 2);
         cast::forget(ptr);
     }

--- a/src/libcore/unstable.rs
+++ b/src/libcore/unstable.rs
@@ -106,13 +106,13 @@ fn compare_and_swap(address: &mut int, oldval: int, newval: int) -> bool {
  ****************************************************************************/
 
 struct ArcData<T> {
-    mut count:     libc::intptr_t,
+    count:     libc::intptr_t,
     // FIXME(#3224) should be able to make this non-option to save memory
-    mut data:      Option<T>,
+    data:      Option<T>,
 }
 
 struct ArcDestruct<T> {
-    mut data: *libc::c_void,
+    data: *libc::c_void,
 }
 
 #[unsafe_destructor]
@@ -122,7 +122,7 @@ impl<T> Drop for ArcDestruct<T>{
             do task::unkillable {
                 let data: ~ArcData<T> = cast::reinterpret_cast(&self.data);
                 let new_count =
-                    intrinsics::atomic_xsub(&mut data.count, 1) - 1;
+                    intrinsics::atomic_xsub(cast::transmute_mut(&data.count), 1) - 1;
                 assert!(new_count >= 0);
                 if new_count == 0 {
                     // drop glue takes over.
@@ -186,7 +186,7 @@ pub unsafe fn clone_shared_mutable_state<T:Owned>(rc: &SharedMutableState<T>)
         -> SharedMutableState<T> {
     unsafe {
         let ptr: ~ArcData<T> = cast::reinterpret_cast(&(*rc).data);
-        let new_count = intrinsics::atomic_xadd(&mut ptr.count, 1) + 1;
+        let new_count = intrinsics::atomic_xadd(cast::transmute_mut(&ptr.count), 1) + 1;
         assert!(new_count >= 2);
         cast::forget(ptr);
     }
@@ -252,7 +252,7 @@ pub impl LittleLock {
     }
 }
 
-struct ExData<T> { lock: LittleLock, mut failed: bool, mut data: T, }
+struct ExData<T> { lock: LittleLock, failed: bool, data: T, }
 /**
  * An arc over mutable data that is protected by a lock. For library use only.
  */
@@ -260,7 +260,7 @@ pub struct Exclusive<T> { x: SharedMutableState<ExData<T>> }
 
 pub fn exclusive<T:Owned>(user_data: T) -> Exclusive<T> {
     let data = ExData {
-        lock: LittleLock(), mut failed: false, mut data: user_data
+        lock: LittleLock(), failed: false, data: user_data
     };
     Exclusive { x: unsafe { shared_mutable_state(data) } }
 }

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -633,7 +633,7 @@ pub fn push<T>(v: &mut ~[T], initval: T) {
 // This doesn't bother to make sure we have space.
 #[inline(always)] // really pretty please
 unsafe fn push_fast<T>(v: &mut ~[T], initval: T) {
-    let repr: **raw::VecRepr = ::cast::transmute(v);
+    let repr: **mut raw::VecRepr = ::cast::transmute(v);
     let fill = (**repr).unboxed.fill;
     (**repr).unboxed.fill += sys::nonzero_size_of::<T>();
     let p = addr_of(&((**repr).unboxed.data));
@@ -2148,8 +2148,8 @@ pub unsafe fn from_buf<T>(ptr: *T, elts: uint) -> ~[T] {
 
 /// The internal 'unboxed' representation of a vector
 pub struct UnboxedVecRepr {
-    mut fill: uint,
-    mut alloc: uint,
+    fill: uint,
+    alloc: uint,
     data: u8
 }
 
@@ -2171,8 +2171,8 @@ pub mod raw {
     }
 
     pub struct SliceRepr {
-        mut data: *u8,
-        mut len: uint
+        data: *u8,
+        len: uint
     }
 
     /**
@@ -2184,7 +2184,7 @@ pub mod raw {
      */
     #[inline(always)]
     pub unsafe fn set_len<T>(v: &mut ~[T], new_len: uint) {
-        let repr: **VecRepr = ::cast::transmute(v);
+        let repr: **mut VecRepr = ::cast::transmute(v);
         (**repr).unboxed.fill = new_len * sys::nonzero_size_of::<T>();
     }
 


### PR DESCRIPTION
This pull request removes some mut-fields from at_vec, str, vec, unstable, and cell. Sadly in case of Cell this required using either transmute_mut (2 instances) or changing the interface. I chose the former. Perhaps it would be a good idea to merge Cell and Option, and take that opportunity to change the interface to use '&mut self' instead of '&self' (which would enable removing the transmutations) for take and put_back.

r?
