### PR TITLE
Update wording in tutorial

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -495,7 +495,7 @@ omitted.
 
 A powerful application of pattern matching is *destructuring*:
 matching in order to bind names to the contents of data
-types. Remember that `(float, float)` is a tuple of two floats:
+types. Assumming that `(float, float)` is a tuple of two floats:
 
 ~~~~
 fn angle(vector: (float, float)) -> float {


### PR DESCRIPTION
The sentence "Remember that `(float, float)` is a tuple of two floats" sounds like I missed a section on tuples,
when in fact it has not come yet. Change the wording to say "assume" since the reader is taking on good faith
at this point that the code snippet does represent a two-item tuple.
