### PR TITLE
Suggest possible fix for missing library link

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1978,6 +1978,11 @@ pub impl Resolver {
                                        import_directive.module_path,
                                        *import_directive.subclass));
                     self.session.span_err(import_directive.span, msg);
+
+                    // Suggest to the user to declare library linkage.
+                    let msg2 = fmt!("possible fix: declare external link with `extern mod %s;`",
+                                    *self.session.str_of(import_directive.module_path[0]));
+                    self.session.span_note(import_directive.span, msg2);
                 }
                 Indeterminate => {
                     // Bail out. We'll come around next time.

--- a/src/test/compile-fail/import-unresolved.rs
+++ b/src/test/compile-fail/import-unresolved.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: unresolved
+use std::*;
+//-^ NOTE possible fix: declare external link with `extern mod std;`
+
+fn main(args: ~[str]) { debug!("unresolved"); }


### PR DESCRIPTION
I'm attempting to learn to write programs using Rust. One problem I encountered early on was errors about failed imports due to unresolved names. The problem was I overlooked the need to declare the link to `std` before importing names into my module.

I thought `rustc` could use a more helpful diagnostic message when it encounters this issue, so I went ahead and implemented a reference fix. Hopefully the message will be useful to future Rust programmers.
