### PR TITLE
librustc: use new `[ty, .. len]` syntax for fixed vector errors.

### DIFF
--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -248,7 +248,7 @@ pub fn trait_store_to_str(cx: ctxt, s: ty::TraitStore) -> ~str {
 pub fn vstore_ty_to_str(cx: ctxt, ty: ~str, vs: ty::vstore) -> ~str {
     match vs {
       ty::vstore_fixed(_) => {
-        fmt!("[%s * %s]", ty, vstore_to_str(cx, vs))
+        fmt!("[%s, .. %s]", ty, vstore_to_str(cx, vs))
       }
       ty::vstore_slice(_) => {
         fmt!("%s %s", vstore_to_str(cx, vs), ty)

--- a/src/test/compile-fail/issue-2149.rs
+++ b/src/test/compile-fail/issue-2149.rs
@@ -22,6 +22,6 @@ impl<A> vec_monad<A> for ~[A] {
 }
 fn main() {
     ["hi"].bind(|x| [x] );
-    //~^ ERROR type `[&'static str * 1]` does not implement any method in scope named `bind`
+    //~^ ERROR type `[&'static str, .. 1]` does not implement any method in scope named `bind`
     //~^^ ERROR Unconstrained region variable
 }

--- a/src/test/compile-fail/issue-4517.rs
+++ b/src/test/compile-fail/issue-4517.rs
@@ -2,5 +2,5 @@ fn bar(int_param: int) {}
 
 fn main() {
      let foo: [u8, ..4] = [1u8, ..4u8];
-     bar(foo); //~ ERROR mismatched types: expected `int` but found `[u8 * 4]` (expected int but found vector)
+     bar(foo); //~ ERROR mismatched types: expected `int` but found `[u8, .. 4]` (expected int but found vector)
 }


### PR DESCRIPTION
Currently error messages say `mismatched types: expected `uint` but found `[uint * 10]` (expected uint but found vector)` rather than `[uint, .. 10]`.
