### PR TITLE
Add #[packed] attribute to create packed structs

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -387,9 +387,11 @@ fn parse_ty(st: @mut PState, conv: conv_did) -> ty::t {
       'a' => {
           assert!((next(st) == '['));
           let did = parse_def(st, NominalType, conv);
+          let packed = next(st) == '1';
+          assert!((next(st) == '|'));
           let substs = parse_substs(st, conv);
           assert!((next(st) == ']'));
-          return ty::mk_struct(st.tcx, did, substs);
+          return ty::mk_struct(st.tcx, did, substs, packed);
       }
       c => { error!("unexpected char in type string: %c", c); fail!();}
     }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -328,12 +328,18 @@ fn enc_sty(w: @io::Writer, cx: @ctxt, +st: ty::sty) {
           enc_sigil(w, p);
       }
       ty::ty_opaque_box => w.write_char('B'),
-      ty::ty_struct(def, ref substs) => {
+      ty::ty_struct(def, ref substs, packed) => {
           debug!("~~~~ %s", ~"a[");
           w.write_str(&"a[");
           let s = (cx.ds)(def);
           debug!("~~~~ %s", s);
           w.write_str(s);
+          debug!("~~~~ %s", ~"|");
+          w.write_char('|');
+          let p = if packed { '1' }
+                  else { '0' };
+          debug!("~~~~ %c", p);
+          w.write_char(p);
           debug!("~~~~ %s", ~"|");
           w.write_char('|');
           enc_substs(w, cx, (*substs));

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -459,7 +459,7 @@ pub fn ctor_arity(cx: @MatchCheckCtxt, ctor: ctor, ty: ty::t) -> uint {
             None => fail!(~"impossible case")
         }
       }
-      ty::ty_struct(cid, _) => ty::lookup_struct_fields(cx.tcx, cid).len(),
+      ty::ty_struct(cid, _, _) => ty::lookup_struct_fields(cx.tcx, cid).len(),
       ty::ty_unboxed_vec(*) | ty::ty_evec(*) => {
         match ctor {
           vec(n) => n,
@@ -589,7 +589,7 @@ pub fn specialize(cx: @MatchCheckCtxt,
                         // Grab the class data that we care about.
                         let class_fields, class_id;
                         match ty::get(left_ty).sty {
-                            ty::ty_struct(cid, _) => {
+                            ty::ty_struct(cid, _, _) => {
                                 class_id = cid;
                                 class_fields =
                                     ty::lookup_struct_fields(cx.tcx,

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -96,7 +96,7 @@ fn check_struct_safe_for_destructor(cx: Context,
             self_r: None,
             self_ty: None,
             tps: ~[]
-        });
+        }, false); // packed-ness doesn't matter for destructor safety
         if !ty::type_is_owned(cx.tcx, struct_ty) {
             cx.tcx.sess.span_err(span,
                                  ~"cannot implement a destructor on a struct \

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -188,7 +188,7 @@ pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
             Some(deref_comp(comp_variant(did)))
         }
 
-        ty::ty_struct(_, _) => {
+        ty::ty_struct(*) => {
             Some(deref_comp(comp_anon_field))
         }
 
@@ -1112,7 +1112,7 @@ pub fn field_mutbl(tcx: ty::ctxt,
                 -> Option<ast::mutability> {
     // Need to refactor so that struct/enum fields can be treated uniformly.
     match ty::get(base_ty).sty {
-      ty::ty_struct(did, _) => {
+      ty::ty_struct(did, _, _) => {
         for ty::lookup_struct_fields(tcx, did).each |fld| {
             if fld.ident == f_name {
                 let m = match fld.mutability {
@@ -1175,4 +1175,3 @@ pub impl categorization {
         }
     }
 }
-

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -477,7 +477,7 @@ pub impl VisitContext {
                     // then `with` is consumed, otherwise it is only read
                     let with_ty = ty::expr_ty(self.tcx, *with_expr);
                     let with_fields = match ty::get(with_ty).sty {
-                        ty::ty_struct(did, ref substs) => {
+                        ty::ty_struct(did, ref substs, _) => {
                             ty::struct_fields(self.tcx, did, substs)
                         }
                         ref r => {

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -437,7 +437,7 @@ pub fn check_crate(tcx: ty::ctxt,
                     // allow pointers to violate privacy
                     match ty::get(ty::type_autoderef(tcx, ty::expr_ty(tcx,
                                                           base))).sty {
-                        ty_struct(id, _)
+                        ty_struct(id, _, _)
                         if id.crate != local_crate ||
                            !privileged_items.contains(&(id.node)) => {
                             match method_map.find(&expr.id) {
@@ -462,7 +462,7 @@ pub fn check_crate(tcx: ty::ctxt,
                     // Ditto
                     match ty::get(ty::type_autoderef(tcx, ty::expr_ty(tcx,
                                                           base))).sty {
-                        ty_struct(id, _)
+                        ty_struct(id, _, _)
                         if id.crate != local_crate ||
                            !privileged_items.contains(&(id.node)) => {
                             match method_map.find(&expr.id) {
@@ -488,7 +488,7 @@ pub fn check_crate(tcx: ty::ctxt,
                 }
                 expr_struct(_, ref fields, _) => {
                     match ty::get(ty::expr_ty(tcx, expr)).sty {
-                        ty_struct(id, _) => {
+                        ty_struct(id, _, _) => {
                             if id.crate != local_crate ||
                                     !privileged_items.contains(&(id.node)) {
                                 for (*fields).each |field| {
@@ -554,7 +554,7 @@ pub fn check_crate(tcx: ty::ctxt,
             match pattern.node {
                 pat_struct(_, ref fields, _) => {
                     match ty::get(ty::pat_ty(tcx, pattern)).sty {
-                        ty_struct(id, _) => {
+                        ty_struct(id, _, _) => {
                             if id.crate != local_crate ||
                                     !privileged_items.contains(&(id.node)) {
                                 for fields.each |field| {
@@ -606,4 +606,3 @@ pub fn check_crate(tcx: ty::ctxt,
     });
     visit::visit_crate(*crate, method_map, visitor);
 }
-

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1339,7 +1339,7 @@ pub fn compile_submatch(bcx: block,
         let struct_ty = node_id_type(bcx, pat_id);
         let struct_element_count;
         match ty::get(struct_ty).sty {
-            ty::ty_struct(struct_id, _) => {
+            ty::ty_struct(struct_id, _, _) => {
                 struct_element_count =
                     ty::lookup_struct_fields(tcx, struct_id).len();
             }

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -88,6 +88,7 @@ pub enum Repr {
 struct Struct {
     size: u64,
     align: u64,
+    packed: bool,
     fields: ~[ty::t]
 }
 
@@ -109,9 +110,9 @@ pub fn represent_type(cx: @CrateContext, t: ty::t) -> @Repr {
     }
     let repr = @match ty::get(t).sty {
         ty::ty_tup(ref elems) => {
-            Univariant(mk_struct(cx, *elems), false)
+            Univariant(mk_struct(cx, *elems, false), false)
         }
-        ty::ty_struct(def_id, ref substs) => {
+        ty::ty_struct(def_id, ref substs, packed) => {
             let fields = ty::lookup_struct_fields(cx.tcx, def_id);
             let ftys = do fields.map |field| {
                 ty::lookup_field_type(cx.tcx, def_id, field.id, substs)
@@ -119,7 +120,8 @@ pub fn represent_type(cx: @CrateContext, t: ty::t) -> @Repr {
             let dtor = ty::ty_dtor(cx.tcx, def_id).is_present();
             let ftys =
                 if dtor { ftys + [ty::mk_bool(cx.tcx)] } else { ftys };
-            Univariant(mk_struct(cx, ftys), dtor)
+
+            Univariant(mk_struct(cx, ftys, packed), dtor)
         }
         ty::ty_enum(def_id, ref substs) => {
             struct Case { discr: int, tys: ~[ty::t] };
@@ -132,7 +134,7 @@ pub fn represent_type(cx: @CrateContext, t: ty::t) -> @Repr {
             };
             if cases.len() == 0 {
                 // Uninhabitable; represent as unit
-                Univariant(mk_struct(cx, ~[]), false)
+                Univariant(mk_struct(cx, ~[], false), false)
             } else if cases.all(|c| c.tys.len() == 0) {
                 // All bodies empty -> intlike
                 let discrs = cases.map(|c| c.discr);
@@ -140,7 +142,7 @@ pub fn represent_type(cx: @CrateContext, t: ty::t) -> @Repr {
             } else if cases.len() == 1 {
                 // Equivalent to a struct/tuple/newtype.
                 assert!(cases[0].discr == 0);
-                Univariant(mk_struct(cx, cases[0].tys), false)
+                Univariant(mk_struct(cx, cases[0].tys, false), false)
             } else {
                 // The general case.  Since there's at least one
                 // non-empty body, explicit discriminants should have
@@ -151,7 +153,7 @@ pub fn represent_type(cx: @CrateContext, t: ty::t) -> @Repr {
                                      ty::item_path_str(cx.tcx, def_id)))
                 }
                 let discr = ~[ty::mk_int(cx.tcx)];
-                General(cases.map(|c| mk_struct(cx, discr + c.tys)))
+                General(cases.map(|c| mk_struct(cx, discr + c.tys, false)))
             }
         }
         _ => cx.sess.bug(~"adt::represent_type called on non-ADT type")
@@ -160,12 +162,13 @@ pub fn represent_type(cx: @CrateContext, t: ty::t) -> @Repr {
     return repr;
 }
 
-fn mk_struct(cx: @CrateContext, tys: &[ty::t]) -> Struct {
+fn mk_struct(cx: @CrateContext, tys: &[ty::t], packed: bool) -> Struct {
     let lltys = tys.map(|&ty| type_of::sizing_type_of(cx, ty));
-    let llty_rec = T_struct(lltys);
+    let llty_rec = T_struct(lltys, packed);
     Struct {
         size: machine::llsize_of_alloc(cx, llty_rec) /*bad*/as u64,
         align: machine::llalign_of_min(cx, llty_rec) /*bad*/as u64,
+        packed: packed,
         fields: vec::from_slice(tys)
     }
 }
@@ -358,7 +361,8 @@ fn struct_field_ptr(bcx: block, st: &Struct, val: ValueRef, ix: uint,
 
     let val = if needs_cast {
         let real_llty = T_struct(st.fields.map(
-            |&ty| type_of::type_of(ccx, ty)));
+            |&ty| type_of::type_of(ccx, ty)),
+                                 st.packed);
         PointerCast(bcx, val, T_ptr(real_llty))
     } else {
         val

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -108,7 +108,7 @@ pub fn trans_inline_asm(bcx: block, ia: &ast::inline_asm) -> block {
     } else if numOutputs == 1 {
         val_ty(outputs[0])
     } else {
-        T_struct(outputs.map(|o| val_ty(*o)))
+        T_struct(outputs.map(|o| val_ty(*o)), false)
     };
 
     let dialect = match ia.dialect {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -938,7 +938,7 @@ pub fn get_landing_pad(bcx: block) -> BasicBlockRef {
     // The landing pad return type (the type being propagated). Not sure what
     // this represents but it's determined by the personality function and
     // this is what the EH proposal example uses.
-    let llretty = T_struct(~[T_ptr(T_i8()), T_i32()]);
+    let llretty = T_struct(~[T_ptr(T_i8()), T_i32()], false);
     // The exception handling personality function. This is the C++
     // personality function __gxx_personality_v0, wrapped in our naming
     // convention.
@@ -2832,7 +2832,7 @@ pub fn decl_gc_metadata(ccx: @CrateContext, llmod_id: &str) {
 }
 
 pub fn create_module_map(ccx: @CrateContext) -> ValueRef {
-    let elttype = T_struct(~[ccx.int_type, ccx.int_type]);
+    let elttype = T_struct(~[ccx.int_type, ccx.int_type], false);
     let maptype = T_array(elttype, ccx.module_data.len() + 1);
     let map = str::as_c_str(~"_rust_mod_map", |buf| {
         unsafe {
@@ -2872,7 +2872,7 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
     };
     let sym_name = ~"_rust_crate_map_" + mapname;
     let arrtype = T_array(int_type, n_subcrates as uint);
-    let maptype = T_struct(~[T_i32(), T_ptr(T_i8()), int_type, arrtype]);
+    let maptype = T_struct(~[T_i32(), T_ptr(T_i8()), int_type, arrtype], false);
     let map = str::as_c_str(sym_name, |buf| {
         unsafe {
             llvm::LLVMAddGlobal(llmod, maptype, buf)

--- a/src/librustc/middle/trans/cabi_mips.rs
+++ b/src/librustc/middle/trans/cabi_mips.rs
@@ -185,7 +185,6 @@ fn struct_ty(ty: TypeRef,
         fields.push(ty);
     }
 
-    // XXX: Is this meant to be always non-packed?
     return T_struct(fields, false);
 }
 

--- a/src/librustc/middle/trans/cabi_mips.rs
+++ b/src/librustc/middle/trans/cabi_mips.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -14,6 +14,7 @@ use core::libc::c_uint;
 use lib::llvm::{llvm, TypeRef, Integer, Pointer, Float, Double};
 use lib::llvm::{Struct, Array, Attribute};
 use lib::llvm::{StructRetAttribute};
+use lib::llvm::True;
 use middle::trans::common::*;
 use middle::trans::cabi::*;
 
@@ -49,8 +50,12 @@ fn ty_align(ty: TypeRef) -> uint {
             Float => 4,
             Double => 8,
             Struct => {
-              do vec::foldl(1, struct_tys(ty)) |a, t| {
-                  uint::max(a, ty_align(*t))
+              if llvm::LLVMIsPackedStruct(ty) == True {
+                1
+              } else {
+                do vec::foldl(1, struct_tys(ty)) |a, t| {
+                    uint::max(a, ty_align(*t))
+                }
               }
             }
             Array => {
@@ -72,10 +77,16 @@ fn ty_size(ty: TypeRef) -> uint {
             Float => 4,
             Double => 8,
             Struct => {
-              let size = do vec::foldl(0, struct_tys(ty)) |s, t| {
-                  align(s, *t) + ty_size(*t)
-              };
-              align(size, ty)
+                if llvm::LLVMIsPackedStruct(ty) == True {
+                    do vec::foldl(0, struct_tys(ty)) |s, t| {
+                        s + ty_size(*t)
+                    }
+                } else {
+                    let size = do vec::foldl(0, struct_tys(ty)) |s, t| {
+                        align(s, *t) + ty_size(*t)
+                    };
+                    align(size, ty)
+                }
             }
             Array => {
               let len = llvm::LLVMGetArrayLength(ty) as uint;
@@ -174,7 +185,8 @@ fn struct_ty(ty: TypeRef,
         fields.push(ty);
     }
 
-    return T_struct(fields);
+    // XXX: Is this meant to be always non-packed?
+    return T_struct(fields, false);
 }
 
 enum MIPS_ABIInfo { MIPS_ABIInfo }

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -15,6 +15,7 @@ use lib::llvm::{llvm, TypeRef, Integer, Pointer, Float, Double};
 use lib::llvm::{Struct, Array, Attribute};
 use lib::llvm::{StructRetAttribute, ByValAttribute};
 use lib::llvm::struct_tys;
+use lib::llvm::True;
 use middle::trans::common::*;
 use middle::trans::cabi::*;
 
@@ -76,10 +77,14 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
                 Float => 4,
                 Double => 8,
                 Struct => {
-                  do vec::foldl(1, struct_tys(ty)) |a, t| {
+                  if llvm::LLVMIsPackedStruct(ty) == True {
+                    1
+                  } else {
+                    do vec::foldl(1, struct_tys(ty)) |a, t| {
                       uint::max(a, ty_align(*t))
+                    }
                   }
-                }
+                },
                 Array => {
                     let elt = llvm::LLVMGetElementType(ty);
                     ty_align(elt)
@@ -99,10 +104,16 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
                 Float => 4,
                 Double => 8,
                 Struct => {
-                  let size = do vec::foldl(0, struct_tys(ty)) |s, t| {
+                  if llvm::LLVMIsPackedStruct(ty) == True {
+                    do vec::foldl(0, struct_tys(ty)) |s, t| {
+                      s + ty_size(*t)
+                    }
+                  } else {
+                    let size = do vec::foldl(0, struct_tys(ty)) |s, t| {
                       align(s, *t) + ty_size(*t)
-                  };
-                  align(size, ty)
+                    };
+                    align(size, ty)
+                  }
                 }
                 Array => {
                   let len = llvm::LLVMGetArrayLength(ty) as uint;
@@ -308,7 +319,7 @@ fn llreg_ty(cls: &[x86_64_reg_class]) -> TypeRef {
             }
             i += 1u;
         }
-        return T_struct(tys);
+        return T_struct(tys, false);
     }
 }
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -755,7 +755,7 @@ pub fn T_void() -> TypeRef {
 }
 
 pub fn T_nil() -> TypeRef {
-    return T_struct(~[])
+    return T_struct(~[], false)
 }
 
 pub fn T_metadata() -> TypeRef { unsafe { return llvm::LLVMMetadataType(); } }
@@ -838,7 +838,7 @@ pub fn T_fn(inputs: &[TypeRef], output: TypeRef) -> TypeRef {
 }
 
 pub fn T_fn_pair(cx: @CrateContext, tfn: TypeRef) -> TypeRef {
-    return T_struct(~[T_ptr(tfn), T_opaque_cbox_ptr(cx)]);
+    return T_struct(~[T_ptr(tfn), T_opaque_cbox_ptr(cx)], false);
 }
 
 pub fn T_ptr(t: TypeRef) -> TypeRef {
@@ -853,11 +853,11 @@ pub fn T_root(t: TypeRef, addrspace: addrspace) -> TypeRef {
     }
 }
 
-pub fn T_struct(elts: &[TypeRef]) -> TypeRef {
+pub fn T_struct(elts: &[TypeRef], packed: bool) -> TypeRef {
     unsafe {
         return llvm::LLVMStructType(to_ptr(elts),
                                     elts.len() as c_uint,
-                                    False);
+                                    packed as Bool);
     }
 }
 
@@ -868,16 +868,16 @@ pub fn T_named_struct(name: &str) -> TypeRef {
     }
 }
 
-pub fn set_struct_body(t: TypeRef, elts: &[TypeRef]) {
+pub fn set_struct_body(t: TypeRef, elts: &[TypeRef], packed: bool) {
     unsafe {
         llvm::LLVMStructSetBody(t,
                                 to_ptr(elts),
                                 elts.len() as c_uint,
-                                False);
+                                packed as Bool);
     }
 }
 
-pub fn T_empty_struct() -> TypeRef { return T_struct(~[]); }
+pub fn T_empty_struct() -> TypeRef { return T_struct(~[], false); }
 
 // A vtable is, in reality, a vtable pointer followed by zero or more pointers
 // to tydescs and other vtables that it closes over. But the types and number
@@ -903,7 +903,7 @@ pub fn T_task(targ_cfg: @session::config) -> TypeRef {
     let elems =
         ~[t_int, t_int, t_int, t_int,
          t_int, t_int, t_int, t_int];
-    set_struct_body(t, elems);
+    set_struct_body(t, elems, false);
     return t;
 }
 
@@ -946,7 +946,7 @@ pub fn T_tydesc(targ_cfg: @session::config) -> TypeRef {
         ~[int_type, int_type,
           glue_fn_ty, glue_fn_ty, glue_fn_ty, glue_fn_ty,
           T_ptr(T_i8()), T_ptr(T_i8())];
-    set_struct_body(tydesc, elems);
+    set_struct_body(tydesc, elems, false);
     return tydesc;
 }
 
@@ -959,8 +959,9 @@ pub fn T_array(t: TypeRef, n: uint) -> TypeRef {
 // Interior vector.
 pub fn T_vec2(targ_cfg: @session::config, t: TypeRef) -> TypeRef {
     return T_struct(~[T_int(targ_cfg), // fill
-                  T_int(targ_cfg), // alloc
-                  T_array(t, 0u)]); // elements
+                      T_int(targ_cfg), // alloc
+                      T_array(t, 0u)], // elements
+                    false);
 }
 
 pub fn T_vec(ccx: @CrateContext, t: TypeRef) -> TypeRef {
@@ -991,11 +992,11 @@ pub fn T_box_header_fields(cx: @CrateContext) -> ~[TypeRef] {
 }
 
 pub fn T_box_header(cx: @CrateContext) -> TypeRef {
-    return T_struct(T_box_header_fields(cx));
+    return T_struct(T_box_header_fields(cx), false);
 }
 
 pub fn T_box(cx: @CrateContext, t: TypeRef) -> TypeRef {
-    return T_struct(vec::append(T_box_header_fields(cx), ~[t]));
+    return T_struct(vec::append(T_box_header_fields(cx), ~[t]), false);
 }
 
 pub fn T_box_ptr(t: TypeRef) -> TypeRef {
@@ -1013,7 +1014,7 @@ pub fn T_opaque_box_ptr(cx: @CrateContext) -> TypeRef {
 }
 
 pub fn T_unique(cx: @CrateContext, t: TypeRef) -> TypeRef {
-    return T_struct(vec::append(T_box_header_fields(cx), ~[t]));
+    return T_struct(vec::append(T_box_header_fields(cx), ~[t]), false);
 }
 
 pub fn T_unique_ptr(t: TypeRef) -> TypeRef {
@@ -1023,12 +1024,12 @@ pub fn T_unique_ptr(t: TypeRef) -> TypeRef {
 }
 
 pub fn T_port(cx: @CrateContext, _t: TypeRef) -> TypeRef {
-    return T_struct(~[cx.int_type]); // Refcount
+    return T_struct(~[cx.int_type], false); // Refcount
 
 }
 
 pub fn T_chan(cx: @CrateContext, _t: TypeRef) -> TypeRef {
-    return T_struct(~[cx.int_type]); // Refcount
+    return T_struct(~[cx.int_type], false); // Refcount
 
 }
 
@@ -1046,21 +1047,22 @@ pub fn T_enum_discrim(cx: @CrateContext) -> TypeRef {
 }
 
 pub fn T_captured_tydescs(cx: @CrateContext, n: uint) -> TypeRef {
-    return T_struct(vec::from_elem::<TypeRef>(n, T_ptr(cx.tydesc_type)));
+    return T_struct(vec::from_elem::<TypeRef>(n, T_ptr(cx.tydesc_type)), false);
 }
 
 pub fn T_opaque_trait(cx: @CrateContext, store: ty::TraitStore) -> TypeRef {
     match store {
         ty::BoxTraitStore => {
-            T_struct(~[T_ptr(cx.tydesc_type), T_opaque_box_ptr(cx)])
+            T_struct(~[T_ptr(cx.tydesc_type), T_opaque_box_ptr(cx)], false)
         }
         ty::UniqTraitStore => {
             T_struct(~[T_ptr(cx.tydesc_type),
                        T_unique_ptr(T_unique(cx, T_i8())),
-                       T_ptr(cx.tydesc_type)])
+                       T_ptr(cx.tydesc_type)],
+                     false)
         }
         ty::RegionTraitStore(_) => {
-            T_struct(~[T_ptr(cx.tydesc_type), T_ptr(T_i8())])
+            T_struct(~[T_ptr(cx.tydesc_type), T_ptr(T_i8())], false)
         }
     }
 }

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -702,7 +702,7 @@ pub impl Datum {
                     }
                 };
             }
-            ty::ty_struct(did, ref substs) => {
+            ty::ty_struct(did, ref substs, _) => {
                 // Check whether this struct is a newtype struct.
                 let fields = ty::struct_fields(ccx.tcx, did, substs);
                 if fields.len() != 1 || fields[0].ident !=
@@ -858,4 +858,3 @@ pub impl DatumBlock {
         self.datum.to_str(self.ccx())
     }
 }
-

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -680,7 +680,10 @@ fn create_ty(cx: @CrateContext, t: ty::t, span: span)
         ty::ty_trait(_did, ref _substs, ref _vstore) => {
             cx.sess.span_bug(span, ~"debuginfo for trait NYI")
         },
-        ty::ty_struct(did, ref substs) => {
+
+        // The packed-ness is probably broken here. At least it's not
+        // known to be working.
+        ty::ty_struct(did, ref substs, _packed) => {
             let fields = ty::struct_fields(cx.tcx, did, substs);
             create_struct(cx, t, fields, span)
         },

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1123,7 +1123,7 @@ pub fn with_field_tys<R>(tcx: ty::ctxt,
                          node_id_opt: Option<ast::node_id>,
                          op: &fn(int, (&[ty::field])) -> R) -> R {
     match ty::get(ty).sty {
-        ty::ty_struct(did, ref substs) => {
+        ty::ty_struct(did, ref substs, _) => {
             op(0, struct_mutable_fields(tcx, did, substs))
         }
 

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -106,7 +106,8 @@ fn shim_types(ccx: @CrateContext, id: ast::node_id) -> ShimTypes {
     };
     let llsig = foreign_signature(ccx, &fn_sig);
     let bundle_ty = T_struct(vec::append_one(copy llsig.llarg_tys,
-                                             T_ptr(llsig.llret_ty)));
+                                             T_ptr(llsig.llret_ty)),
+                            false);
     let ret_def =
         !ty::type_is_bot(fn_sig.output) &&
         !ty::type_is_nil(fn_sig.output);

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -443,7 +443,7 @@ pub fn make_free_glue(bcx: block, v: ValueRef, t: ty::t) {
       ty::ty_opaque_closure_ptr(ck) => {
         closure::make_opaque_cbox_free_glue(bcx, ck, v)
       }
-      ty::ty_struct(did, ref substs) => {
+      ty::ty_struct(did, ref substs, _) => {
         // Call the dtor if there is one
         match ty::ty_dtor(bcx.tcx(), did) {
             ty::NoDtor => bcx,
@@ -533,7 +533,7 @@ pub fn make_drop_glue(bcx: block, v0: ValueRef, t: ty::t) {
       ty::ty_unboxed_vec(_) => {
         tvec::make_drop_glue_unboxed(bcx, v0, t)
       }
-      ty::ty_struct(did, ref substs) => {
+      ty::ty_struct(did, ref substs, _) => {
         let tcx = bcx.tcx();
         match ty::ty_dtor(tcx, did) {
           ty::TraitDtor(dtor) => {

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -142,9 +142,9 @@ pub fn static_size_of_enum(cx: @CrateContext, t: ty::t) -> uint {
 
                 debug!("static_size_of_enum: variant %s type %s",
                        *cx.tcx.sess.str_of(variant.name),
-                       ty_str(cx.tn, T_struct(lltypes)));
+                       ty_str(cx.tn, T_struct(lltypes, false)));
 
-                let this_size = llsize_of_real(cx, T_struct(lltypes));
+                let this_size = llsize_of_real(cx, T_struct(lltypes, false));
                 if max_size < this_size {
                     max_size = this_size;
                 }
@@ -155,4 +155,3 @@ pub fn static_size_of_enum(cx: @CrateContext, t: ty::t) -> uint {
         _ => cx.sess.bug(~"static_size_of_enum called on non-enum")
     }
 }
-

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -242,7 +242,9 @@ pub impl Reflector {
             self.visit(~"leave_fn", extra);
           }
 
-          ty::ty_struct(did, ref substs) => {
+          // Possible broken with packed-ness, at least, not known
+          // to work.
+          ty::ty_struct(did, ref substs, _packed) => {
               let bcx = self.bcx;
               let tcx = bcx.ccx().tcx;
               let fields = ty::struct_fields(tcx, did, substs);
@@ -367,4 +369,3 @@ pub fn ast_purity_constant(purity: ast::purity) -> uint {
         ast::extern_fn => 3u
     }
 }
-

--- a/src/librustc/middle/trans/shape.rs
+++ b/src/librustc/middle/trans/shape.rs
@@ -74,4 +74,3 @@ pub fn add_substr(dest: &mut ~[u8], src: ~[u8]) {
     add_u16(&mut *dest, vec::len(src) as u16);
     *dest += src;
 }
-

--- a/src/librustc/middle/trans/shape.rs
+++ b/src/librustc/middle/trans/shape.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -128,11 +128,11 @@ pub fn sizing_type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
 
         ty::ty_estr(ty::vstore_slice(*)) |
         ty::ty_evec(_, ty::vstore_slice(*)) => {
-            T_struct(~[T_ptr(T_i8()), T_ptr(T_i8())])
+            T_struct(~[T_ptr(T_i8()), T_ptr(T_i8())], false)
         }
 
         ty::ty_bare_fn(*) => T_ptr(T_i8()),
-        ty::ty_closure(*) => T_struct(~[T_ptr(T_i8()), T_ptr(T_i8())]),
+        ty::ty_closure(*) => T_struct(~[T_ptr(T_i8()), T_ptr(T_i8())], false),
         ty::ty_trait(_, _, store) => T_opaque_trait(cx, store),
 
         ty::ty_estr(ty::vstore_fixed(size)) => T_array(T_i8(), size),
@@ -142,9 +142,14 @@ pub fn sizing_type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
 
         ty::ty_unboxed_vec(mt) => T_vec(cx, sizing_type_of(cx, mt.ty)),
 
-        ty::ty_tup(*) | ty::ty_struct(*) | ty::ty_enum(*) => {
+        ty::ty_tup(*) | ty::ty_enum(*) => {
             let repr = adt::represent_type(cx, t);
-            T_struct(adt::sizing_fields_of(cx, repr))
+            T_struct(adt::sizing_fields_of(cx, repr), false)
+        }
+
+        ty::ty_struct(_, _, packed) => {
+            let repr = adt::represent_type(cx, t);
+            T_struct(adt::sizing_fields_of(cx, repr), packed)
         }
 
         ty::ty_self(_) | ty::ty_infer(*) | ty::ty_param(*) | ty::ty_err(*) => {
@@ -223,12 +228,14 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
 
       ty::ty_evec(ref mt, ty::vstore_slice(_)) => {
         T_struct(~[T_ptr(type_of(cx, mt.ty)),
-                   T_uint_ty(cx, ast::ty_u)])
+                   T_uint_ty(cx, ast::ty_u)],
+                 false)
       }
 
       ty::ty_estr(ty::vstore_slice(_)) => {
         T_struct(~[T_ptr(T_i8()),
-                   T_uint_ty(cx, ast::ty_u)])
+                   T_uint_ty(cx, ast::ty_u)],
+                 false)
       }
 
       ty::ty_estr(ty::vstore_fixed(n)) => {
@@ -245,10 +252,10 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
       ty::ty_type => T_ptr(cx.tydesc_type),
       ty::ty_tup(*) => {
           let repr = adt::represent_type(cx, t);
-          T_struct(adt::fields_of(cx, repr))
+          T_struct(adt::fields_of(cx, repr), false)
       }
       ty::ty_opaque_closure_ptr(_) => T_opaque_box_ptr(cx),
-      ty::ty_struct(did, ref substs) => {
+      ty::ty_struct(did, ref substs, _packed) => {
         // Only create the named struct, but don't fill it in. We fill it
         // in *after* placing it into the type cache. This prevents
         // infinite recursion with recursive struct types.
@@ -268,9 +275,16 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
 
     // If this was an enum or struct, fill in the type now.
     match ty::get(t).sty {
-      ty::ty_enum(*) | ty::ty_struct(*) => {
+      ty::ty_enum(*) => {
           let repr = adt::represent_type(cx, t);
-          common::set_struct_body(llty, adt::fields_of(cx, repr));
+          common::set_struct_body(llty, adt::fields_of(cx, repr),
+                                  false);
+      }
+
+      ty::ty_struct(_, _, packed) => {
+        let repr = adt::represent_type(cx, t);
+        common::set_struct_body(llty, adt::fields_of(cx, repr),
+                                packed);
       }
       _ => ()
     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -518,7 +518,7 @@ pub enum sty {
     ty_bare_fn(BareFnTy),
     ty_closure(ClosureTy),
     ty_trait(def_id, substs, TraitStore),
-    ty_struct(def_id, substs),
+    ty_struct(def_id, substs, bool), // bool is whether this is packed or not
     ty_tup(~[t]),
 
     ty_param(param_ty), // type parameter
@@ -918,7 +918,7 @@ fn mk_t_with_id(cx: ctxt, +st: sty, o_def_id: Option<ast::def_id>) -> t {
       &ty_param(_) => flags |= has_params as uint,
       &ty_infer(_) => flags |= needs_infer as uint,
       &ty_self(_) => flags |= has_self as uint,
-      &ty_enum(_, ref substs) | &ty_struct(_, ref substs) |
+      &ty_enum(_, ref substs) | &ty_struct(_, ref substs, _) |
       &ty_trait(_, ref substs, _) => {
         flags |= sflags(substs);
       }
@@ -1094,9 +1094,11 @@ pub fn mk_trait(cx: ctxt,
     mk_t(cx, ty_trait(did, substs, store))
 }
 
-pub fn mk_struct(cx: ctxt, struct_id: ast::def_id, +substs: substs) -> t {
+pub fn mk_struct(cx: ctxt, struct_id: ast::def_id, +substs: substs,
+                 packed: bool) -> t {
     // take a copy of substs so that we own the vectors inside
-    mk_t(cx, ty_struct(struct_id, substs))
+
+    mk_t(cx, ty_struct(struct_id, substs, packed))
 }
 
 pub fn mk_var(cx: ctxt, v: TyVid) -> t { mk_infer(cx, TyVar(v)) }
@@ -1195,7 +1197,7 @@ pub fn maybe_walk_ty(ty: t, f: &fn(t) -> bool) {
       ty_ptr(ref tm) | ty_rptr(_, ref tm) | ty_uniq(ref tm) => {
         maybe_walk_ty(tm.ty, f);
       }
-      ty_enum(_, ref substs) | ty_struct(_, ref substs) |
+      ty_enum(_, ref substs) | ty_struct(_, ref substs, _) |
       ty_trait(_, ref substs, _) => {
         for (*substs).tps.each |subty| { maybe_walk_ty(*subty, f); }
       }
@@ -1271,8 +1273,8 @@ fn fold_sty(sty: &sty, fldop: &fn(t) -> t) -> sty {
         ty_rptr(r, ref tm) => {
             ty_rptr(r, mt {ty: fldop(tm.ty), mutbl: tm.mutbl})
         }
-        ty_struct(did, ref substs) => {
-            ty_struct(did, fold_substs(substs, fldop))
+        ty_struct(did, ref substs, packed) => {
+            ty_struct(did, fold_substs(substs, fldop), packed)
         }
         ty_nil | ty_bot | ty_bool | ty_int(_) | ty_uint(_) | ty_float(_) |
         ty_estr(_) | ty_type | ty_opaque_closure_ptr(_) | ty_err |
@@ -1341,8 +1343,8 @@ pub fn fold_regions_and_ty(
       ty_enum(def_id, ref substs) => {
         ty::mk_enum(cx, def_id, fold_substs(substs, fldr, fldt))
       }
-      ty_struct(def_id, ref substs) => {
-        ty::mk_struct(cx, def_id, fold_substs(substs, fldr, fldt))
+      ty_struct(def_id, ref substs, packed) => {
+        ty::mk_struct(cx, def_id, fold_substs(substs, fldr, fldt), packed)
       }
       ty_trait(def_id, ref substs, st) => {
         ty::mk_trait(cx, def_id, fold_substs(substs, fldr, fldt), st)
@@ -2006,7 +2008,7 @@ pub fn type_contents(cx: ctxt, ty: t) -> TypeContents {
                 TC_NONE
             }
 
-            ty_struct(did, ref substs) => {
+            ty_struct(did, ref substs, _) => {
                 let flds = struct_fields(cx, did, substs);
                 let flds_tc = flds.foldl(
                     TC_NONE,
@@ -2188,7 +2190,7 @@ pub fn type_contents(cx: ctxt, ty: t) -> TypeContents {
             n
           }
 
-          ty_struct(did, ref substs) => {
+          ty_struct(did, ref substs, _packed) => {
             let flds = struct_fields(cx, did, substs);
             flds.foldl(0, |s, f| *s + type_size(cx, f.mt.ty))
           }
@@ -2290,11 +2292,11 @@ pub fn is_instantiable(cx: ctxt, r_ty: t) -> bool {
             false
           }
 
-          ty_struct(ref did, _) if vec::contains(*seen, did) => {
+          ty_struct(ref did, _, _) if vec::contains(*seen, did) => {
             false
           }
 
-          ty_struct(did, ref substs) => {
+          ty_struct(did, ref substs, _) => {
               seen.push(did);
               let r = vec::any(struct_fields(cx, did, substs),
                                |f| type_requires(cx, seen, r_ty, f.mt.ty));
@@ -2354,7 +2356,7 @@ pub fn type_structurally_contains(cx: ctxt,
         }
         return false;
       }
-      ty_struct(did, ref substs) => {
+      ty_struct(did, ref substs, _) => {
         for lookup_struct_fields(cx, did).each |field| {
             let ft = lookup_field_type(cx, did, field.id, substs);
             if type_structurally_contains(cx, ft, test) { return true; }
@@ -2451,7 +2453,7 @@ pub fn type_is_pod(cx: ctxt, ty: t) -> bool {
       }
       ty_param(_) => result = false,
       ty_opaque_closure_ptr(_) => result = true,
-      ty_struct(did, ref substs) => {
+      ty_struct(did, ref substs, _) => {
         result = vec::any(lookup_struct_fields(cx, did), |f| {
             let fty = ty::lookup_item_type(cx, f.id);
             let sty = subst(cx, substs, fty.ty);
@@ -2527,7 +2529,7 @@ pub fn deref_sty(cx: ctxt, sty: &sty, explicit: bool) -> Option<mt> {
         }
       }
 
-      ty_struct(did, ref substs) => {
+      ty_struct(did, ref substs, _) => {
         let fields = struct_fields(cx, did, substs);
         if fields.len() == 1 && fields[0].ident ==
                 syntax::parse::token::special_idents::unnamed_field {
@@ -2717,8 +2719,8 @@ impl to_bytes::IterBytes for sty {
 
           ty_opaque_box => 22u8.iter_bytes(lsb0, f),
 
-          ty_struct(ref did, ref substs) =>
-          to_bytes::iter_bytes_3(&23u8, did, substs, lsb0, f),
+          ty_struct(ref did, ref substs, packed) =>
+          to_bytes::iter_bytes_4(&23u8, did, substs, &packed, lsb0, f),
 
           ty_rptr(ref r, ref mt) =>
           to_bytes::iter_bytes_3(&24u8, r, mt, lsb0, f),
@@ -3390,7 +3392,7 @@ pub fn ty_sort_str(cx: ctxt, t: t) -> ~str {
       ty_bare_fn(_) => ~"extern fn",
       ty_closure(_) => ~"fn",
       ty_trait(id, _, _) => fmt!("trait %s", item_path_str(cx, id)),
-      ty_struct(id, _) => fmt!("struct %s", item_path_str(cx, id)),
+      ty_struct(id, _, _) => fmt!("struct %s", item_path_str(cx, id)),
       ty_tup(_) => ~"tuple",
       ty_infer(TyVar(_)) => ~"inferred type",
       ty_infer(IntVar(_)) => ~"integral variable",
@@ -3696,7 +3698,7 @@ pub fn impl_trait_refs(cx: ctxt, id: ast::def_id) -> ~[@TraitRef] {
 
 pub fn ty_to_def_id(ty: t) -> Option<ast::def_id> {
     match get(ty).sty {
-      ty_trait(id, _, _) | ty_struct(id, _) | ty_enum(id, _) => Some(id),
+      ty_trait(id, _, _) | ty_struct(id, _, _) | ty_enum(id, _) => Some(id),
       _ => None
     }
 }
@@ -4253,13 +4255,15 @@ pub fn normalize_ty(cx: ctxt, t: t) -> t {
                     t
             },
 
-        ty_struct(did, ref r) =>
+        ty_struct(did, ref r, packed) =>
             match (*r).self_r {
               Some(_) =>
                 // Ditto.
-                mk_struct(cx, did, substs {self_r: Some(ty::re_static),
-                                           self_ty: None,
-                                           tps: /*bad*/copy (*r).tps}),
+                mk_struct(cx, did,
+                                      substs {self_r: Some(ty::re_static),
+                                              self_ty: None,
+                                              tps: /*bad*/copy (*r).tps},
+                                      packed),
               None =>
                 t
             },

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -147,7 +147,7 @@ pub fn check_pat_variant(pcx: pat_ctxt, pat: @ast::pat, path: @ast::path,
 
             kind_name = "variant";
         }
-        ty::ty_struct(struct_def_id, ref expected_substs) => {
+        ty::ty_struct(struct_def_id, ref expected_substs, _) => {
             // Lookup the struct ctor def id
             let s_def = lookup_def(pcx.fcx, pat.span, pat.id);
             let s_def_id = ast_util::def_id_of_def(s_def);
@@ -445,7 +445,7 @@ pub fn check_pat(pcx: pat_ctxt, pat: @ast::pat, expected: ty::t) {
         // Grab the class data that we care about.
         let structure = structure_of(fcx, pat.span, expected);
         match structure {
-            ty::ty_struct(cid, ref substs) => {
+            ty::ty_struct(cid, ref substs, _) => {
                 check_struct_pat(pcx, pat.id, pat.span, expected, path,
                                  *fields, etc, cid, substs);
             }
@@ -586,4 +586,3 @@ pub fn check_pat(pcx: pat_ctxt, pat: @ast::pat, expected: ty::t) {
       }
     }
 }
-

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -319,7 +319,7 @@ pub impl<'self> LookupContext<'self> {
                     self.push_inherent_candidates_from_self(
                         self_ty, self_did, &substs);
                 }
-                ty_enum(did, _) | ty_struct(did, _) => {
+                ty_enum(did, _) | ty_struct(did, _, _) => {
                     if self.check_traits == CheckTraitsAndInherentMethods {
                         self.push_inherent_impl_candidates_for_type(did);
                     }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -123,6 +123,7 @@ use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_util::local_def;
 use syntax::ast_util;
+use syntax::attr;
 use syntax::codemap::span;
 use syntax::codemap;
 use syntax::opt_vec::OptVec;
@@ -1701,7 +1702,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         let (base_t, derefs) = do_autoderef(fcx, expr.span, expr_t);
 
         match structure_of(fcx, expr.span, base_t) {
-            ty::ty_struct(base_id, ref substs) => {
+            ty::ty_struct(base_id, ref substs, _) => {
                 // This is just for fields -- the same code handles
                 // methods in both classes and traits
 
@@ -1848,7 +1849,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
 
         if !error_happened {
             fcx.write_ty(node_id, ty::mk_struct(fcx.ccx.tcx,
-                                class_id, substitutions));
+                                class_id, substitutions, false));
         }
     }
 
@@ -1870,6 +1871,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
             match tcx.items.find(&class_id.node) {
                 Some(&ast_map::node_item(@ast::item {
                         node: ast::item_struct(_, ref generics),
+                        attrs: ref attrs,
                         _
                     }, _)) => {
 
@@ -1878,13 +1880,15 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                     let self_region =
                         bound_self_region(region_parameterized);
 
+                    let packed = attr::find_packed_attr(*attrs);
+
                     raw_type = ty::mk_struct(tcx, class_id, substs {
                         self_r: self_region,
                         self_ty: None,
                         tps: ty::ty_params_to_tys(
                             tcx,
                             generics)
-                    });
+                    }, packed);
                 }
                 _ => {
                     tcx.sess.span_bug(span,

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -114,7 +114,7 @@ pub fn type_is_defined_in_local_crate(original_type: t) -> bool {
         match get(t).sty {
             ty_enum(def_id, _) |
             ty_trait(def_id, _, _) |
-            ty_struct(def_id, _) => {
+            ty_struct(def_id, _, _) => {
                 if def_id.crate == ast::local_crate {
                     found_nominal = true;
                 }
@@ -138,7 +138,7 @@ pub fn get_base_type_def_id(inference_context: @mut InferCtxt,
         Some(base_type) => {
             match get(base_type).sty {
                 ty_enum(def_id, _) |
-                ty_struct(def_id, _) |
+                ty_struct(def_id, _, _) |
                 ty_trait(def_id, _, _) => {
                     return Some(def_id);
                 }
@@ -981,7 +981,7 @@ pub impl CoherenceChecker {
 
             let self_type = self.get_self_type_for_implementation(*impl_info);
             match ty::get(self_type.ty).sty {
-                ty::ty_struct(type_def_id, _) => {
+                ty::ty_struct(type_def_id, _, _) => {
                     tcx.destructor_for_type.insert(type_def_id,
                                                    method_def_id);
                     tcx.destructors.insert(method_def_id);
@@ -1014,4 +1014,3 @@ pub fn check_coherence(crate_context: @mut CrateCtxt, crate: @crate) {
     let coherence_checker = @CoherenceChecker(crate_context);
     coherence_checker.check_coherence(crate);
 }
-

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -537,11 +537,11 @@ pub fn super_tys<C:Combine>(
           }
       }
 
-      (ty::ty_struct(a_id, ref a_substs), ty::ty_struct(b_id, ref b_substs))
-      if a_id == b_id => {
+      (ty::ty_struct(a_id, ref a_substs, a_packed), ty::ty_struct(b_id, ref b_substs, b_packed))
+      if a_id == b_id && a_packed == b_packed => {
           let type_def = ty::lookup_item_type(tcx, a_id);
           do self.substs(&type_def.generics, a_substs, b_substs).chain |substs| {
-              Ok(ty::mk_struct(tcx, a_id, substs))
+              Ok(ty::mk_struct(tcx, a_id, substs, a_packed))
           }
       }
 
@@ -658,4 +658,3 @@ pub fn super_trait_refs<C:Combine>(
         })
     }
 }
-

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -449,7 +449,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
           }
       }
       ty_self(*) => ~"Self",
-      ty_enum(did, ref substs) | ty_struct(did, ref substs) => {
+      ty_enum(did, ref substs) | ty_struct(did, ref substs, _) => {
         let path = ty::item_path(cx, did);
         let base = ast_map::path_to_str(path, cx.sess.intr());
         parameterized(cx, base, substs.self_r, substs.tps)

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -330,6 +330,9 @@ pub fn find_inline_attr(attrs: &[ast::attribute]) -> inline_attr {
     }
 }
 
+pub fn find_packed_attr(attrs: &[ast::attribute]) -> bool {
+    attrs_contains_name(attrs, "packed")
+}
 
 pub fn require_unique_names(diagnostic: @span_handler,
                             metas: &[@ast::meta_item]) {

--- a/src/test/compile-fail/packed-struct-generic-transmute.rs
+++ b/src/test/compile-fail/packed-struct-generic-transmute.rs
@@ -1,0 +1,35 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This assumes the packed and non-packed structs are different sizes.
+
+// the error points to the start of the file, not the line with the
+// transmute
+
+// error-pattern: reinterpret_cast called on types with different size
+
+#[packed]
+struct Foo<T,S> {
+    bar: T,
+    baz: S
+}
+
+struct Oof<T, S> {
+    rab: T,
+    zab: S
+}
+
+fn main() {
+    let foo = Foo { bar: [1u8, 2, 3, 4, 5], baz: 10i32 };
+    unsafe {
+        let oof: Oof<[u8, .. 5], i32> = cast::transmute(foo);
+        debug!(oof);
+    }
+}

--- a/src/test/compile-fail/packed-struct-transmute.rs
+++ b/src/test/compile-fail/packed-struct-transmute.rs
@@ -1,0 +1,35 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This assumes the packed and non-packed structs are different sizes.
+
+// the error points to the start of the file, not the line with the
+// transmute
+
+// error-pattern: reinterpret_cast called on types with different size
+
+#[packed]
+struct Foo {
+    bar: u8,
+    baz: uint
+}
+
+struct Oof {
+    rab: u8,
+    zab: uint
+}
+
+fn main() {
+    let foo = Foo { bar: 1, baz: 10 };
+    unsafe {
+        let oof: Oof = cast::transmute(foo);
+        debug!(oof);
+    }
+}

--- a/src/test/run-pass/packed-struct-borrow-element.rs
+++ b/src/test/run-pass/packed-struct-borrow-element.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct Foo {
+    bar: u8,
+    baz: uint
+}
+
+fn main() {
+    let foo = Foo { bar: 1, baz: 2 };
+    let brw = &foo.baz;
+
+    assert_eq!(*brw, 2);
+}

--- a/src/test/run-pass/packed-struct-generic-layout.rs
+++ b/src/test/run-pass/packed-struct-generic-layout.rs
@@ -1,0 +1,35 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S<T, S> {
+    a: T,
+    b: u8,
+    c: S
+}
+
+fn main() {
+    unsafe {
+        let s = S { a: 0xff_ff_ff_ffu32, b: 1, c: 0xaa_aa_aa_aa as i32 };
+        let transd : [u8, .. 9] = cast::transmute(s);
+        // Don't worry about endianness, the numbers are palindromic.
+        assert_eq!(transd,
+                   [0xff, 0xff, 0xff, 0xff,
+                    1,
+                    0xaa, 0xaa, 0xaa, 0xaa]);
+
+
+        let s = S { a: 1u8, b: 2u8, c: 0b10000001_10000001 as i16};
+        let transd : [u8, .. 4] = cast::transmute(s);
+        // Again, no endianness problems.
+        assert_eq!(transd,
+                   [1, 2, 0b10000001, 0b10000001]);
+    }
+}

--- a/src/test/run-pass/packed-struct-generic-size.rs
+++ b/src/test/run-pass/packed-struct-generic-size.rs
@@ -1,0 +1,25 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S<T, S> {
+    a: T,
+    b: u8,
+    c: S
+}
+
+fn main() {
+    assert_eq!(sys::size_of::<S<u8, u8>>(), 3);
+
+    assert_eq!(sys::size_of::<S<u64, u16>>(), 11);
+
+    assert_eq!(sys::size_of::<S<~str, @mut [int]>>(),
+               1 + sys::size_of::<~str>() + sys::size_of::<@mut [int]>());
+}

--- a/src/test/run-pass/packed-struct-layout.rs
+++ b/src/test/run-pass/packed-struct-layout.rs
@@ -1,0 +1,34 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S4 {
+    a: u8,
+    b: [u8, .. 3],
+}
+
+#[packed]
+struct S5 {
+    a: u8,
+    b: u32
+}
+
+fn main() {
+    unsafe {
+        let s4 = S4 { a: 1, b: [2,3,4] };
+        let transd : [u8, .. 4] = cast::transmute(s4);
+        assert_eq!(transd, [1, 2, 3, 4]);
+
+        let s5 = S5 { a: 1, b: 0xff_00_00_ff };
+        let transd : [u8, .. 5] = cast::transmute(s5);
+        // Don't worry about endianness, the u32 is palindromic.
+        assert_eq!(transd, [1, 0xff, 0, 0, 0xff]);
+    }
+}

--- a/src/test/run-pass/packed-struct-match.rs
+++ b/src/test/run-pass/packed-struct-match.rs
@@ -1,0 +1,25 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct Foo {
+    bar: u8,
+    baz: uint
+}
+
+fn main() {
+    let foo = Foo { bar: 1, baz: 2 };
+    match foo {
+        Foo {bar, baz} => {
+            assert_eq!(bar, 1);
+            assert_eq!(baz, 2);
+        }
+    }
+}

--- a/src/test/run-pass/packed-struct-size.rs
+++ b/src/test/run-pass/packed-struct-size.rs
@@ -1,0 +1,58 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S4 {
+    a: u8,
+    b: [u8, .. 3],
+}
+
+#[packed]
+struct S5 {
+    a: u8,
+    b: u32
+}
+
+#[packed]
+struct S13_str {
+    a: i64,
+    b: f32,
+    c: u8,
+    d: ~str
+}
+
+enum Foo {
+    Bar = 1,
+    Baz = 2
+}
+
+#[packed]
+struct S3_Foo {
+    a: u8,
+    b: u16,
+    c: Foo
+}
+
+#[packed]
+struct S7_Option {
+    a: f32,
+    b: u8,
+    c: u16,
+    d: Option<@mut f64>
+}
+
+
+fn main() {
+    assert_eq!(sys::size_of::<S4>(), 4);
+    assert_eq!(sys::size_of::<S5>(), 5);
+    assert_eq!(sys::size_of::<S13_str>(), 13 + sys::size_of::<~str>());
+    assert_eq!(sys::size_of::<S3_Foo>(), 3 + sys::size_of::<Foo>());
+    assert_eq!(sys::size_of::<S7_Option>(), 7 + sys::size_of::<Option<@mut f64>>());
+}

--- a/src/test/run-pass/packed-struct-vec.rs
+++ b/src/test/run-pass/packed-struct-vec.rs
@@ -1,0 +1,30 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+#[deriving(Eq)]
+struct Foo {
+    bar: u8,
+    baz: u64
+}
+
+fn main() {
+    let foos = [Foo { bar: 1, baz: 2 }, .. 10];
+
+    assert_eq!(sys::size_of::<[Foo, .. 10]>(), 90);
+
+    for uint::range(0, 10) |i| {
+        assert_eq!(foos[i], Foo { bar: 1, baz: 2});
+    }
+
+    for foos.each |&foo| {
+        assert_eq!(foo, Foo { bar: 1, baz: 2 });
+    }
+}

--- a/src/test/run-pass/packed-tuple-struct-layout.rs
+++ b/src/test/run-pass/packed-tuple-struct-layout.rs
@@ -1,0 +1,28 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S4(u8,[u8, .. 3]);
+
+#[packed]
+struct S5(u8,u32);
+
+fn main() {
+    unsafe {
+        let s4 = S4(1, [2,3,4]);
+        let transd : [u8, .. 4] = cast::transmute(s4);
+        assert_eq!(transd, [1, 2, 3, 4]);
+
+        let s5 = S5(1, 0xff_00_00_ff);
+        let transd : [u8, .. 5] = cast::transmute(s5);
+        // Don't worry about endianness, the u32 is palindromic.
+        assert_eq!(transd, [1, 0xff, 0, 0, 0xff]);
+    }
+}

--- a/src/test/run-pass/packed-tuple-struct-size.rs
+++ b/src/test/run-pass/packed-tuple-struct-size.rs
@@ -1,0 +1,44 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S4(u8,[u8, .. 3]);
+
+#[packed]
+struct S5(u8, u32);
+
+#[packed]
+struct S13_str(i64, f32, u8, ~str);
+
+enum Foo {
+    Bar = 1,
+    Baz = 2
+}
+
+#[packed]
+struct S3_Foo(u8, u16, Foo);
+
+#[packed]
+struct S7_Option(f32, u8, u16, Option<@mut f64>);
+
+fn main() {
+    assert_eq!(sys::size_of::<S4>(), 4);
+
+    assert_eq!(sys::size_of::<S5>(), 5);
+
+    assert_eq!(sys::size_of::<S13_str>(),
+               13 + sys::size_of::<~str>());
+
+    assert_eq!(sys::size_of::<S3_Foo>(),
+               3 + sys::size_of::<Foo>());
+
+    assert_eq!(sys::size_of::<S7_Option>(),
+              7 + sys::size_of::<Option<@mut f64>>());
+}


### PR DESCRIPTION
This adds a `#[packed]` attribute for structs, like GCC's `__attribute__((packed))`, e.g.

``` rust
#[packed]
struct Size5 {
   a: u8,
   b: u32
}
```

It works on normal and tuple structs, but is (silently) ignored on enums.

Notes: 
- I couldn't work out a better way to store the packed-ness of a struct than in `ty::sty`.
- I have no idea if this works on any architecture other than x86-64 and i686 (although there's no particular reason why it wouldn't, it's just using the packed attribute in LLVM)
- I feel like there could be more tests, but I'm not really sure what/how to test.

Closes #1704.

~~(I'm not sure about [the XXX in cabi_mips.rs](https://github.com/mozilla/rust/pull/5758/files#L12R188), so merging this should probably wait.)~~ Resolved!
