### PR TITLE
Vim: improvements on comments

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -110,7 +110,7 @@ syn match     rustFloat       display "\<[0-9][0-9_]*\.[0-9_]\+\%([eE][+-]\=[0-9
 syn match     rustLifetime    display "\'\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"
 syn match   rustCharacter   "'\([^'\\]\|\\\(['nrt\\\"]\|x\x\{2}\|u\x\{4}\|U\x\{8}\)\)'"
 
-syn region    rustComment     start="/\*" end="\*/" contains=rustComment,rustTodo
+syn region    rustComment     start="/\*" end="\*/" contains=rustTodo
 syn region    rustComment     start="//" skip="\\$" end="$" contains=rustTodo keepend
 
 syn keyword rustTodo contained TODO FIXME XXX NB

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -113,8 +113,8 @@ syn match   rustCharacter   "'\([^'\\]\|\\\(['nrt\\\"]\|x\x\{2}\|u\x\{4}\|U\x\{8
 syn region    rustCommentDoc  start="/\*\*" end="\*/"
 syn region    rustCommentDoc  start="///" skip="\\$" end="$" keepend
 syn match     rustComment     "/\*\*/"
-syn region    rustComment     start="/\*[^\*]" end="\*/" contains=rustTodo
-syn region    rustComment     start="//[^/]" skip="\\$" end="$" contains=rustTodo keepend
+syn region    rustComment     start="/\*\([^\*]\|$\)" end="\*/" contains=rustTodo
+syn region    rustComment     start="//\([^/]\|$\)" skip="\\$" end="$" contains=rustTodo keepend
 
 syn keyword rustTodo contained TODO FIXME XXX NB
 

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -110,8 +110,11 @@ syn match     rustFloat       display "\<[0-9][0-9_]*\.[0-9_]\+\%([eE][+-]\=[0-9
 syn match     rustLifetime    display "\'\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"
 syn match   rustCharacter   "'\([^'\\]\|\\\(['nrt\\\"]\|x\x\{2}\|u\x\{4}\|U\x\{8}\)\)'"
 
-syn region    rustComment     start="/\*" end="\*/" contains=rustTodo
-syn region    rustComment     start="//" skip="\\$" end="$" contains=rustTodo keepend
+syn region    rustCommentDoc  start="/\*\*" end="\*/"
+syn region    rustCommentDoc  start="///" skip="\\$" end="$" keepend
+syn match     rustComment     "/\*\*/"
+syn region    rustComment     start="/\*[^\*]" end="\*/" contains=rustTodo
+syn region    rustComment     start="//[^/]" skip="\\$" end="$" contains=rustTodo keepend
 
 syn keyword rustTodo contained TODO FIXME XXX NB
 
@@ -134,6 +137,7 @@ hi def link rustConditional   Conditional
 hi def link rustIdentifier    Identifier
 hi def link rustModPath       Include
 hi def link rustFuncName      Function
+hi def link rustCommentDoc    SpecialComment
 hi def link rustComment       Comment
 hi def link rustMacro         Macro
 hi def link rustType          Type


### PR DESCRIPTION
1. disable nested comment which is not supported now
2. add syntax highlight for rustCommentDoc e.g. `/** doc */` or `/// doc`.
