### PR TITLE
 Change the behaviour of core::run::Program.destroy to  forcibly terminate the program

### DIFF
--- a/src/libcore/libc.rs
+++ b/src/libcore/libc.rs
@@ -864,6 +864,7 @@ pub mod consts {
             pub static F_TLOCK : int = 2;
             pub static F_ULOCK : int = 0;
             pub static SIGKILL : int = 9;
+            pub static SIGTERM : int = 15;
         }
         pub mod posix01 {
         }
@@ -932,6 +933,7 @@ pub mod consts {
             pub static F_TLOCK : int = 2;
             pub static F_ULOCK : int = 0;
             pub static SIGKILL : int = 9;
+            pub static SIGTERM : int = 15;
         }
         pub mod posix01 {
         }
@@ -1001,6 +1003,7 @@ pub mod consts {
             pub static F_TLOCK : int = 2;
             pub static F_ULOCK : int = 0;
             pub static SIGKILL : int = 9;
+            pub static SIGTERM : int = 15;
         }
         pub mod posix01 {
         }

--- a/src/libcore/libc.rs
+++ b/src/libcore/libc.rs
@@ -863,6 +863,7 @@ pub mod consts {
             pub static F_TEST : int = 3;
             pub static F_TLOCK : int = 2;
             pub static F_ULOCK : int = 0;
+            pub static SIGKILL : int = 9;
         }
         pub mod posix01 {
         }
@@ -930,6 +931,7 @@ pub mod consts {
             pub static F_TEST : int = 3;
             pub static F_TLOCK : int = 2;
             pub static F_ULOCK : int = 0;
+            pub static SIGKILL : int = 9;
         }
         pub mod posix01 {
         }
@@ -998,6 +1000,7 @@ pub mod consts {
             pub static F_TEST : int = 3;
             pub static F_TLOCK : int = 2;
             pub static F_ULOCK : int = 0;
+            pub static SIGKILL : int = 9;
         }
         pub mod posix01 {
         }
@@ -1482,6 +1485,17 @@ pub mod funcs {
                              -> ssize_t;
             }
         }
+
+        #[nolink]
+        #[abi = "cdecl"]
+        pub mod signal {
+            use libc::types::os::arch::c95::{c_int};
+            use libc::types::os::arch::posix88::{pid_t};
+
+            pub extern {
+                unsafe fn kill(pid: pid_t, sig: c_int) -> c_int;
+            }
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -1623,6 +1637,7 @@ pub mod funcs {
     pub mod extra {
 
         pub mod kernel32 {
+            use libc::types::os::arch::c95::{c_uint};
             use libc::types::os::arch::extra::{BOOL, DWORD, HMODULE};
             use libc::types::os::arch::extra::{LPCWSTR, LPWSTR, LPTCH};
             use libc::types::os::arch::extra::{LPSECURITY_ATTRIBUTES};
@@ -1663,6 +1678,7 @@ pub mod funcs {
                                        findFileData: HANDLE)
                     -> BOOL;
                 unsafe fn FindClose(findFile: HANDLE) -> BOOL;
+                unsafe fn TerminateProcess(hProcess: HANDLE, uExitCode: c_uint) -> BOOL;
             }
         }
 

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -44,13 +44,13 @@ pub trait Program {
     /// Returns the process id of the program
     fn get_id(&mut self) -> pid_t;
 
-    /// Returns an io::writer that can be used to write to stdin
+    /// Returns an io::Writer that can be used to write to stdin
     fn input(&mut self) -> @io::Writer;
 
-    /// Returns an io::reader that can be used to read from stdout
+    /// Returns an io::Reader that can be used to read from stdout
     fn output(&mut self) -> @io::Reader;
 
-    /// Returns an io::reader that can be used to read from stderr
+    /// Returns an io::Reader that can be used to read from stderr
     fn err(&mut self) -> @io::Reader;
 
     /// Closes the handle to the child processes standard input
@@ -200,9 +200,9 @@ pub fn run_program(prog: &str, args: &[~str]) -> int {
 }
 
 /**
- * Spawns a process and returns a program
+ * Spawns a process and returns a Program
  *
- * The returned value is a boxed class containing a <program> object that can
+ * The returned value is a boxed class containing a <Program> object that can
  * be used for sending and receiving data over the standard file descriptors.
  * The class will ensure that file descriptors are closed properly.
  *


### PR DESCRIPTION
As proposed in issue #5632.

I added some new stuff to libc - hopefully correctly. I only added a single signal constant (SIGKILL) because adding more seems complicated by differences between platforms - and since it is not required for issue #5632 then I figure that I can use a further pull request to flesh out the SIG\* constants more.
