### PR TITLE
clone: managed boxes need to clone by shallow copy

### DIFF
--- a/src/test/run-pass/borrowck-borrow-from-expr-block.rs
+++ b/src/test/run-pass/borrowck-borrow-from-expr-block.rs
@@ -13,7 +13,7 @@ fn borrow(x: &int, f: &fn(x: &int)) {
 }
 
 fn test1(x: @~int) {
-    do borrow(&**x.clone()) |p| {
+    do borrow(&*(*x).clone()) |p| {
         let x_a = ptr::addr_of(&(**x));
         assert!((x_a as uint) != ptr::to_uint(p));
         assert!(unsafe{*x_a} == *p);


### PR DESCRIPTION
Performing a deep copy isn't ever desired for a persistent data
structure, and it requires a more complex implementation to do
correctly. A deep copy needs to check for cycles to avoid an infinite
loop.
