### PR TITLE
Docs and credits minor fixes

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -170,5 +170,5 @@ See \fBAUTHORS.txt\fR in the rust source distribution. Graydon Hoare
 <\fIgraydon@mozilla.com\fR> is the project leader.
 
 .SH "COPYRIGHT"
-This work is licensed under MIT-like terms.  See \fBLICENSE.txt\fR
-in the rust source distribution.
+This work is dual-licensed under Apache 2.0 and MIT terms.  See \fBCOPYRIGHT\fR
+file in the rust source distribution.

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -18,6 +18,7 @@ PKG_FILES := \
     $(S)COPYRIGHT                              \
     $(S)LICENSE-APACHE                         \
     $(S)LICENSE-MIT                            \
+    $(S)AUTHORS.txt                            \
     $(S)README.md                              \
     $(S)configure $(S)Makefile.in              \
     $(S)man                                    \


### PR DESCRIPTION
A non-code PR to put the AUTHORS.txt file in the released tarball and to update the copyright terms in the rustc manpage as per post-dual-licensing.
