### PR TITLE
Remove enum layout assumptions from type visitor

### DIFF
--- a/src/libcore/repr.rs
+++ b/src/libcore/repr.rs
@@ -624,9 +624,10 @@ impl TyVisitor for ReprVisitor {
     fn visit_leave_enum(&self, _n_variants: uint,
                         _get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         _sz: uint, _align: uint) -> bool {
-        // NOTE should this assert that it's not still SearchingFor the right variant?
-        self.var_stk.pop();
-        true
+        match self.var_stk.pop() {
+            SearchingFor(*) => fail!(~"enum value matched no variant"),
+            _ => true
+        }
     }
 
     fn visit_enter_fn(&self, _purity: uint, _proto: uint,

--- a/src/librustc/front/intrinsic.rs
+++ b/src/librustc/front/intrinsic.rs
@@ -28,8 +28,7 @@ pub mod intrinsic {
         // Remaining fields not listed
     }
 
-    // FIXME: make this a 0-variant enum; trans/reflect.rs has to match it.
-    pub type Opaque = ();
+    pub enum Opaque { }
 
     pub trait TyVisitor {
         fn visit_bot(&self) -> bool;

--- a/src/librustc/front/intrinsic.rs
+++ b/src/librustc/front/intrinsic.rs
@@ -28,6 +28,9 @@ pub mod intrinsic {
         // Remaining fields not listed
     }
 
+    // FIXME: make this a 0-variant enum; trans/reflect.rs has to match it.
+    pub type Opaque = ();
+
     pub trait TyVisitor {
         fn visit_bot(&self) -> bool;
         fn visit_nil(&self) -> bool;
@@ -91,6 +94,7 @@ pub mod intrinsic {
                            sz: uint, align: uint) -> bool;
 
         fn visit_enter_enum(&self, n_variants: uint,
+                            get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                             sz: uint, align: uint) -> bool;
         fn visit_enter_enum_variant(&self, variant: uint,
                                     disr_val: int,
@@ -102,6 +106,7 @@ pub mod intrinsic {
                                     n_fields: uint,
                                     name: &str) -> bool;
         fn visit_leave_enum(&self, n_variants: uint,
+                            get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                             sz: uint, align: uint) -> bool;
 
         fn visit_enter_fn(&self, purity: uint, proto: uint,

--- a/src/librustc/front/intrinsic.rs
+++ b/src/librustc/front/intrinsic.rs
@@ -96,7 +96,7 @@ pub mod intrinsic {
                                     disr_val: int,
                                     n_fields: uint,
                                     name: &str) -> bool;
-        fn visit_enum_variant_field(&self, i: uint, inner: *TyDesc) -> bool;
+        fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *TyDesc) -> bool;
         fn visit_leave_enum_variant(&self, variant: uint,
                                     disr_val: int,
                                     n_fields: uint,

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -274,12 +274,15 @@ pub impl Reflector {
             let repr = adt::represent_type(bcx.ccx(), t);
             let variants = ty::substd_enum_variants(ccx.tcx, did, substs);
             let llptrty = T_ptr(type_of(ccx, t));
+            let (_, opaquety) = *(ccx.tcx.intrinsic_defs.find(&ccx.sess.ident_of(~"Opaque"))
+                                      .expect("Failed to resolve intrinsic::Opaque"));
+            let opaqueptrty = ty::mk_ptr(ccx.tcx, ty::mt { ty: opaquety, mutbl: ast::m_imm });
 
             let make_get_disr = || {
                 let sub_path = bcx.fcx.path + ~[path_name(special_idents::anon)];
                 let sym = mangle_internal_name_by_path_and_seq(ccx, sub_path, ~"get_disr");
                 let args = [ty::arg { mode: ast::expl(ast::by_copy),
-                                      ty: ty::mk_nil_ptr(ccx.tcx) }];
+                                      ty: opaqueptrty }];
                 let llfty = type_of_fn(ccx, args, ty::mk_int(ccx.tcx));
                 let llfdecl = decl_internal_cdecl_fn(ccx.llmod, sym, llfty);
                 let arg = unsafe {

--- a/src/test/run-pass/reflect-visit-data.rs
+++ b/src/test/run-pass/reflect-visit-data.rs
@@ -394,8 +394,8 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_enum_variant_field(&self, i: uint, inner: *TyDesc) -> bool {
-        if ! self.inner.visit_enum_variant_field(i, inner) { return false; }
+    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *TyDesc) -> bool {
+        if ! self.inner.visit_enum_variant_field(i, offset, inner) { return false; }
         true
     }
 
@@ -594,7 +594,7 @@ impl TyVisitor for my_visitor {
                                 _disr_val: int,
                                 _n_fields: uint,
                                 _name: &str) -> bool { true }
-    fn visit_enum_variant_field(&self, _i: uint, inner: *TyDesc) -> bool {
+    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, inner: *TyDesc) -> bool {
         self.visit_inner(inner)
     }
     fn visit_leave_enum_variant(&self, _variant: uint,


### PR DESCRIPTION
This takes care of one of the last remnants of assumptions about enum layout.  A type visitor is now passed a function to read a value's discriminant, then accesses fields by being passed a byte offset for each one.  The latter may not be fully general, despite the constraints imposed on representations by borrowed pointers, but works for any representations currently planned and is relatively simple.

Closes #5652.
