### PR TITLE
Proposed update to documentation to reflect 1-tuples being legal (as of 0.6)

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -2579,7 +2579,7 @@ to the record type-constructor. The differences are as follows:
 
 Tuple types and values are denoted by listing the types or values of their
 elements, respectively, in a parenthesized, comma-separated
-list. Single-element tuples are not legal; all tuples have two or more values.
+list.
 
 The members of a tuple are laid out in memory contiguously, like a record, in
 order specified by the tuple type.

--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1653,11 +1653,12 @@ Path expressions are [lvalues](#lvalues-rvalues-and-temporaries).
 
 ### Tuple expressions
 
-Tuples are written by enclosing two or more comma-separated
+Tuples are written by enclosing one or more comma-separated
 expressions in parentheses. They are used to create [tuple-typed](#tuple-types)
 values.
 
 ~~~~~~~~ {.tuple}
+(0,);
 (0f, 4.5f);
 ("a", 4u, true);
 ~~~~~~~~

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -747,7 +747,7 @@ fn area(sh: Shape) -> float {
 
 Tuples in Rust behave exactly like structs, except that their fields
 do not have names. Thus, you cannot access their fields with dot notation.
-Tuples can have any arity except for 0 or 1 (though you may consider
+Tuples can have any arity except for 0 (though you may consider
 unit, `()`, as the empty tuple if you like).
 
 ~~~~


### PR DESCRIPTION
As per [the 0.6 release notes](https://github.com/mozilla/rust/wiki/Doc-detailed-release-notes#06-april-2013) single-element tuples are legal. I spotted a couple of places in the documentation that said otherwise, and propose these changes to them.
