### PR TITLE
Update rusti help text (for :clear) to match behavior

### DIFF
--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -273,7 +273,7 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
                 ~":{\\n ..lines.. \\n:}\\n - execute multiline command\n" +
                 ~":load <crate> ... - \
                   loads given crates as dynamic libraries\n" +
-                ~":clear - clear the screen\n" +
+                ~":clear - bindings\n" +
                 ~":exit - exit from the repl\n" +
                 ~":help - show this message");
         }

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -273,7 +273,7 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
                 ~":{\\n ..lines.. \\n:}\\n - execute multiline command\n" +
                 ~":load <crate> ... - \
                   loads given crates as dynamic libraries\n" +
-                ~":clear - bindings\n" +
+                ~":clear - clear the bindings\n" +
                 ~":exit - exit from the repl\n" +
                 ~":help - show this message");
         }


### PR DESCRIPTION
The old help text reads "clear the screen", but :clear seems intended to do something completely different. I'm not sure what the intent is. If it's really supposed to clear the screen, not only does it not clear the screen, it does something completely different.

```
rusti> fn foo() { println("called foo!") }
()
rusti> foo();
called foo!
()
rusti> :clear
rusti> foo();
<anon>:34:0: 34:3 error: unresolved name: `foo`.
<anon>:34 foo();
```

Per the contributor guidelines, here's the reason there's no testcase: it's a comment string.
