### PR TITLE
Revert map.each to something which takes two parameters rather than a tuple.  

### DIFF
--- a/src/libcore/container.rs
+++ b/src/libcore/container.rs
@@ -29,6 +29,9 @@ pub trait Map<K, V>: Mutable {
     /// Return true if the map contains a value for the specified key
     fn contains_key(&self, key: &K) -> bool;
 
+    // Visits all keys and values
+    fn each(&self, f: &fn(&K, &V) -> bool);
+
     /// Visit all keys
     fn each_key(&self, f: &fn(&K) -> bool);
 

--- a/src/libcore/trie.rs
+++ b/src/libcore/trie.rs
@@ -28,24 +28,6 @@ pub struct TrieMap<T> {
     priv length: uint
 }
 
-impl<'self,T> BaseIter<(uint, &'self T)> for TrieMap<T> {
-    /// Visit all key-value pairs in order
-    #[inline(always)]
-    fn each(&self, f: &fn(&(uint, &'self T)) -> bool) {
-        self.root.each(f);
-    }
-    #[inline(always)]
-    fn size_hint(&self) -> Option<uint> { Some(self.len()) }
-}
-
-impl<'self,T> ReverseIter<(uint, &'self T)> for TrieMap<T> {
-    /// Visit all key-value pairs in reverse order
-    #[inline(always)]
-    fn each_reverse(&self, f: &fn(&(uint, &'self T)) -> bool) {
-        self.root.each_reverse(f);
-    }
-}
-
 impl<T> Container for TrieMap<T> {
     /// Return the number of elements in the map
     #[inline(always)]
@@ -72,16 +54,22 @@ impl<T> Map<uint, T> for TrieMap<T> {
         self.find(key).is_some()
     }
 
+    /// Visit all key-value pairs in order
+    #[inline(always)]
+    fn each(&self, f: &fn(&uint, &'self T) -> bool) {
+        self.root.each(f);
+    }
+
     /// Visit all keys in order
     #[inline(always)]
     fn each_key(&self, f: &fn(&uint) -> bool) {
-        self.each(|&(k, _)| f(&k))
+        self.each(|k, _| f(k))
     }
 
     /// Visit all values in order
     #[inline(always)]
     fn each_value(&self, f: &fn(&T) -> bool) {
-        self.each(|&(_, v)| f(v))
+        self.each(|_, v| f(v))
     }
 
     /// Iterate over the map and mutate the contained values
@@ -148,16 +136,22 @@ pub impl<T> TrieMap<T> {
         TrieMap{root: TrieNode::new(), length: 0}
     }
 
+    /// Visit all key-value pairs in reverse order
+    #[inline(always)]
+    fn each_reverse(&self, f: &fn(&uint, &'self T) -> bool) {
+        self.root.each_reverse(f);
+    }
+
     /// Visit all keys in reverse order
     #[inline(always)]
     fn each_key_reverse(&self, f: &fn(&uint) -> bool) {
-        self.each_reverse(|&(k, _)| f(&k))
+        self.each_reverse(|k, _| f(k))
     }
 
     /// Visit all values in reverse order
     #[inline(always)]
     fn each_value_reverse(&self, f: &fn(&T) -> bool) {
-        self.each_reverse(|&(_, v)| f(v))
+        self.each_reverse(|_, v| f(v))
     }
 }
 
@@ -239,22 +233,22 @@ impl<T> TrieNode<T> {
 }
 
 impl<T> TrieNode<T> {
-    fn each(&self, f: &fn(&(uint, &'self T)) -> bool) -> bool {
+    fn each(&self, f: &fn(&uint, &'self T) -> bool) -> bool {
         for uint::range(0, self.children.len()) |idx| {
             match self.children[idx] {
                 Internal(ref x) => if !x.each(f) { return false },
-                External(k, ref v) => if !f(&(k, v)) { return false },
+                External(k, ref v) => if !f(&k, v) { return false },
                 Nothing => ()
             }
         }
         true
     }
 
-    fn each_reverse(&self, f: &fn(&(uint, &'self T)) -> bool) -> bool {
+    fn each_reverse(&self, f: &fn(&uint, &'self T) -> bool) -> bool {
         for uint::range_rev(self.children.len(), 0) |idx| {
             match self.children[idx - 1] {
                 Internal(ref x) => if !x.each_reverse(f) { return false },
-                External(k, ref v) => if !f(&(k, v)) { return false },
+                External(k, ref v) => if !f(&k, v) { return false },
                 Nothing => ()
             }
         }
@@ -438,8 +432,8 @@ mod tests {
         assert!(m.insert(1, 2));
 
         let mut n = 0;
-        for m.each |&(k, v)| {
-            assert!(k == n);
+        for m.each |k, v| {
+            assert!(*k == n);
             assert!(*v == n * 2);
             n += 1;
         }
@@ -454,11 +448,11 @@ mod tests {
         }
 
         let mut n = uint::max_value - 9999;
-        for m.each |&(k, v)| {
+        for m.each |k, v| {
             if n == uint::max_value - 5000 { break }
             assert!(n < uint::max_value - 5000);
 
-            assert!(k == n);
+            assert!(*k == n);
             assert!(*v == n / 2);
             n += 1;
         }
@@ -475,8 +469,8 @@ mod tests {
         assert!(m.insert(1, 2));
 
         let mut n = 4;
-        for m.each_reverse |&(k, v)| {
-            assert!(k == n);
+        for m.each_reverse |k, v| {
+            assert!(*k == n);
             assert!(*v == n * 2);
             n -= 1;
         }
@@ -491,11 +485,11 @@ mod tests {
         }
 
         let mut n = uint::max_value;
-        for m.each_reverse |&(k, v)| {
+        for m.each_reverse |k, v| {
             if n == uint::max_value - 5000 { break }
             assert!(n > uint::max_value - 5000);
 
-            assert!(k == n);
+            assert!(*k == n);
             assert!(*v == n / 2);
             n -= 1;
         }

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -86,7 +86,7 @@ pub fn have_crate_data(cstore: &CStore, cnum: ast::crate_num) -> bool {
 
 pub fn iter_crate_data(cstore: &CStore,
                        i: &fn(ast::crate_num, @crate_metadata)) {
-    for cstore.metas.each |&(&k, &v)| {
+    for cstore.metas.each |&k, &v| {
         i(k, v);
     }
 }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -397,7 +397,7 @@ pub impl<'self> LanguageItemCollector<'self> {
     }
 
     fn check_completeness(&self) {
-        for self.item_refs.each |&(&key, &item_ref)| {
+        for self.item_refs.each |&key, &item_ref| {
             match self.items.items[item_ref] {
                 None => {
                     self.session.err(fmt!("no item found for `%s`", *key));

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -460,7 +460,7 @@ pub fn build_settings_crate(sess: session::Session, crate: @ast::crate) {
 
     do cx.with_lint_attrs(/*bad*/copy crate.node.attrs) |cx| {
         // Copy out the default settings
-        for cx.curr.each |&(k, &v)| {
+        for cx.curr.each |&k, &v| {
             sess.lint_settings.default_settings.insert(k, v);
         }
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -842,7 +842,7 @@ pub fn determine_rp_in_crate(sess: Session,
     debug!("%s", {
         debug!("Region variance results:");
         let region_paramd_items = cx.region_paramd_items;
-        for region_paramd_items.each |&(&key, &value)| {
+        for region_paramd_items.each |&key, &value| {
             debug!("item %? (%s) is parameterized with variance %?",
                    key,
                    ast_map::node_id_to_str(ast_map, key,

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2369,7 +2369,7 @@ pub impl Resolver {
 
         // Add all resolved imports from the containing module.
         for containing_module.import_resolutions.each
-                |&(ident, target_import_resolution)| {
+                |ident, target_import_resolution| {
 
             debug!("(resolving glob import) writing module resolution \
                     %? into `%s`",
@@ -2457,13 +2457,13 @@ pub impl Resolver {
         };
 
         // Add all children from the containing module.
-        for containing_module.children.each |&(ident, name_bindings)| {
+        for containing_module.children.each |ident, name_bindings| {
             merge_import_resolution(ident, *name_bindings);
         }
 
         // Add external module children from the containing module.
         for containing_module.external_module_children.each
-                |&(ident, module)| {
+                |ident, module| {
             let name_bindings =
                 @mut Resolver::create_name_bindings_from_module(*module);
             merge_import_resolution(ident, name_bindings);
@@ -3111,7 +3111,7 @@ pub impl Resolver {
     fn add_exports_for_module(@mut self,
                               exports2: &mut ~[Export2],
                               module_: @mut Module) {
-        for module_.children.each |&(ident, namebindings)| {
+        for module_.children.each |ident, namebindings| {
             debug!("(computing exports) maybe export '%s'",
                    *self.session.str_of(*ident));
             self.add_exports_of_namebindings(&mut *exports2,
@@ -3126,7 +3126,7 @@ pub impl Resolver {
                                              false);
         }
 
-        for module_.import_resolutions.each |&(ident, importresolution)| {
+        for module_.import_resolutions.each |ident, importresolution| {
             if importresolution.privacy != Public {
                 debug!("(computing exports) not reexporting private `%s`",
                        *self.session.str_of(*ident));
@@ -3934,7 +3934,7 @@ pub impl Resolver {
         for arm.pats.eachi() |i, p| {
             let map_i = self.binding_mode_map(*p);
 
-            for map_0.each |&(&key, &binding_0)| {
+            for map_0.each |&key, &binding_0| {
                 match map_i.find(&key) {
                   None => {
                     self.session.span_err(
@@ -3955,7 +3955,7 @@ pub impl Resolver {
                 }
             }
 
-            for map_i.each |&(&key, &binding)| {
+            for map_i.each |&key, &binding| {
                 if !map_0.contains_key(&key) {
                     self.session.span_err(
                         binding.span,
@@ -5248,7 +5248,7 @@ pub impl Resolver {
         }
 
         debug!("Import resolutions:");
-        for module_.import_resolutions.each |&(name, import_resolution)| {
+        for module_.import_resolutions.each |name, import_resolution| {
             let mut value_repr;
             match import_resolution.target_for_namespace(ValueNS) {
                 None => { value_repr = ~""; }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2848,7 +2848,7 @@ pub fn create_module_map(ccx: @CrateContext) -> ValueRef {
         lib::llvm::SetLinkage(map, lib::llvm::InternalLinkage);
     }
     let mut elts: ~[ValueRef] = ~[];
-    for ccx.module_data.each |&(key, &val)| {
+    for ccx.module_data.each |key, &val| {
         let elt = C_struct(~[p2i(ccx, C_cstr(ccx, @/*bad*/ copy *key)),
                             p2i(ccx, val)]);
         elts.push(elt);
@@ -3139,7 +3139,7 @@ pub fn trans_crate(sess: session::Session,
         }
 
         if ccx.sess.count_llvm_insns() {
-            for ccx.stats.llvm_insns.each |&(&k, &v)| {
+            for ccx.stats.llvm_insns.each |&k, &v| {
                 io::println(fmt!("%-7u %s", v, k));
             }
         }

--- a/src/librustc/middle/typeck/infer/region_inference.rs
+++ b/src/librustc/middle/typeck/infer/region_inference.rs
@@ -1223,7 +1223,7 @@ pub impl RegionVarBindings {
 
         // It would be nice to write this using map():
         let mut edges = vec::with_capacity(num_edges);
-        for self.constraints.each |&(constraint, span)| {
+        for self.constraints.each |constraint, span| {
             edges.push(GraphEdge {
                 next_edge: [uint::max_value, uint::max_value],
                 constraint: *constraint,

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -177,7 +177,7 @@ Available lint options:
                      padded(max_key, ~"name"), ~"default", ~"meaning"));
     io::println(fmt!("    %s  %7.7s  %s\n",
                      padded(max_key, ~"----"), ~"-------", ~"-------"));
-    for lint_dict.each |&(k, v)| {
+    for lint_dict.each |k, v| {
         let k = str::replace(*k, ~"_", ~"-");
         io::println(fmt!("    %s  %7.7s  %s",
                          padded(max_key, k),

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -926,7 +926,7 @@ impl Eq for Json {
                     &Object(ref d1) => {
                         if d0.len() == d1.len() {
                             let mut equal = true;
-                            for d0.each |&(k, v0)| {
+                            for d0.each |k, v0| {
                                 match d1.find(k) {
                                     Some(v1) if v0 == v1 => { },
                                     _ => { equal = false; break }
@@ -989,12 +989,12 @@ impl Ord for Json {
                         let mut d1_flat = ~[];
 
                         // FIXME #4430: this is horribly inefficient...
-                        for d0.each |&(k, v)| {
+                        for d0.each |k, v| {
                              d0_flat.push((@copy *k, @copy *v));
                         }
                         d0_flat.qsort();
 
-                        for d1.each |&(k, v)| {
+                        for d1.each |k, v| {
                             d1_flat.push((@copy *k, @copy *v));
                         }
                         d1_flat.qsort();
@@ -1125,7 +1125,7 @@ impl<A:ToJson> ToJson for ~[A] {
 impl<A:ToJson + Copy> ToJson for HashMap<~str, A> {
     fn to_json(&self) -> Json {
         let mut d = HashMap::new();
-        for self.each |&(key, value)| {
+        for self.each |key, value| {
             d.insert(copy *key, value.to_json());
         }
         Object(~d)

--- a/src/libstd/net_url.rs
+++ b/src/libstd/net_url.rs
@@ -216,7 +216,7 @@ pub fn encode_form_urlencoded(m: &HashMap<~str, ~[~str]>) -> ~str {
     let mut out = ~"";
     let mut first = true;
 
-    for m.each |&(key, values)| {
+    for m.each |key, values| {
         let key = encode_plus(*key);
 
         for values.each |value| {

--- a/src/libstd/serialize.rs
+++ b/src/libstd/serialize.rs
@@ -595,7 +595,7 @@ impl<
     fn encode(&self, e: &E) {
         do e.emit_map(self.len()) {
             let mut i = 0;
-            for self.each |&(key, val)| {
+            for self.each |key, val| {
                 e.emit_map_elt_key(i, || key.encode(e));
                 e.emit_map_elt_val(i, || val.encode(e));
                 i += 1;
@@ -659,7 +659,7 @@ impl<
     fn encode(&self, e: &E) {
         do e.emit_map(self.len()) {
             let mut i = 0;
-            for self.each |&(key, val)| {
+            for self.each |key, val| {
                 e.emit_map_elt_key(i, || key.encode(e));
                 e.emit_map_elt_val(i, || val.encode(e));
                 i += 1;
@@ -717,7 +717,7 @@ impl<
     fn encode(&self, e: &E) {
         do e.emit_map(self.len()) {
             let mut i = 0;
-            for self.each |&(key, val)| {
+            for self.each |key, val| {
                 e.emit_map_elt_key(i, || key.encode(e));
                 e.emit_map_elt_val(i, || val.encode(e));
                 i += 1;

--- a/src/libstd/workcache.rs
+++ b/src/libstd/workcache.rs
@@ -145,7 +145,7 @@ impl WorkMap {
 impl<S:Encoder> Encodable<S> for WorkMap {
     fn encode(&self, s: &S) {
         let mut d = ~[];
-        for self.each |&(k, v)| {
+        for self.each |k, v| {
             d.push((copy *k, copy *v))
         }
         sort::tim_sort(d);
@@ -319,7 +319,7 @@ impl TPrep for Prep {
     }
 
     fn all_fresh(&self, cat: &str, map: &WorkMap) -> bool {
-        for map.each |&(k, v)| {
+        for map.each |k, v| {
             if ! self.is_fresh(cat, k.kind, k.name, *v) {
                 return false;
             }

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -48,7 +48,7 @@ fn sort_and_fmt(mm: &HashMap<~[u8], uint>, total: uint) -> ~str {
    let mut pairs = ~[];
 
    // map -> [(k,%)]
-   for mm.each |&(&key, &val)| {
+   for mm.each |&key, &val| {
       pairs.push((key, pct(val, total)));
    }
 

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -49,18 +49,6 @@ pub impl<T> cat<T> {
     }
 }
 
-impl<'self,T> BaseIter<(int, &'self T)> for cat<T> {
-    fn each(&self, f: &fn(&(int, &'self T)) -> bool) {
-        let mut n = int::abs(self.meows);
-        while n > 0 {
-            if !f(&(n, &self.name)) { break; }
-            n -= 1;
-        }
-    }
-
-    fn size_hint(&self) -> Option<uint> { Some(self.len()) }
-}
-
 impl<T> Container for cat<T> {
     fn len(&const self) -> uint { self.meows as uint }
     fn is_empty(&const self) -> bool { self.meows == 0 }
@@ -71,17 +59,25 @@ impl<T> Mutable for cat<T> {
 }
 
 impl<T> Map<int, T> for cat<T> {
+    fn each(&self, f: &fn(&int, &T) -> bool) {
+        let mut n = int::abs(self.meows);
+        while n > 0 {
+            if !f(&n, &self.name) { break; }
+            n -= 1;
+        }
+    }
+
     fn contains_key(&self, k: &int) -> bool { *k <= self.meows }
 
     fn each_key(&self, f: &fn(v: &int) -> bool) {
-        for self.each |&(k, _)| { if !f(&k) { break; } loop;};
+        for self.each |k, _| { if !f(k) { break; } loop;};
     }
 
     fn each_value(&self, f: &fn(v: &T) -> bool) {
-        for self.each |&(_, v)| { if !f(v) { break; } loop;};
+        for self.each |_, v| { if !f(v) { break; } loop;};
     }
 
-    fn mutate_values(&mut self, f: &fn(&int, &mut T) -> bool) {
+    fn mutate_values(&mut self, _f: &fn(&int, &mut T) -> bool) {
         fail!(~"nope")
     }
 
@@ -98,7 +94,7 @@ impl<T> Map<int, T> for cat<T> {
         }
     }
 
-    fn find_mut(&mut self, k: &int) -> Option<&'self mut T> { fail!() }
+    fn find_mut(&mut self, _k: &int) -> Option<&'self mut T> { fail!() }
 
     fn remove(&mut self, k: &int) -> bool {
         if self.find(k).is_some() {


### PR DESCRIPTION
Revert map.each to something which takes two parameters rather than a tuple.  The current setup iterates over `BaseIter<(&'self K, &'self V)>` where 'self is a lifetime declared _in the `each()` method_.  You can't place such a type in the impl declaration.  The compiler currently allows it, but this will not be legal under #5656 and I'm pretty sure it's not sound now.  It's too bad that maps can't implement `BaseIter` (at least not over a tuple as they do here) but I think it has to be this way for the time being.

r? @thestinger
