### PR TITLE
Support https protocol for git submodules for rust

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/llvm"]
 	path = src/llvm
-	url = git://github.com/brson/llvm.git
+	url = https://github.com/brson/llvm.git
 [submodule "src/libuv"]
 	path = src/libuv
-	url = git://github.com/brson/libuv.git
+	url = https://github.com/brson/libuv.git


### PR DESCRIPTION
Currently submodules are using the git protocol. Git protocol is blocked
by certain corporate networks which makes it difficult to sync the submodules.

Replacing the git protocol with https in order to sync the submodules.
