### PR TITLE
Cleanup substitutions and treatment of generics around traits in a number of ways

### DIFF
--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -127,7 +127,7 @@ pub enum astencode_tag { // Reserves 0x50 -- 0x6f
     tag_table_node_type_subst = 0x58,
     tag_table_freevars = 0x59,
     tag_table_tcache = 0x5a,
-    tag_table_param_bounds = 0x5b,
+    tag_table_param_defs = 0x5b,
     tag_table_inferred_modes = 0x5c,
     tag_table_mutbl = 0x5d,
     tag_table_last_use = 0x5e,

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -210,7 +210,7 @@ pub fn get_field_type(tcx: ty::ctxt, class_id: ast::def_id,
     debug!("got field data %?", the_field);
     let ty = decoder::item_type(def, the_field, tcx, cdata);
     ty::ty_param_bounds_and_ty {
-        generics: ty::Generics {bounds: @~[],
+        generics: ty::Generics {type_param_defs: @~[],
                                 region_param: None},
         ty: ty
     }

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -547,11 +547,17 @@ pub fn parse_def_id(buf: &[u8]) -> ast::def_id {
     ast::def_id { crate: crate_num, node: def_num }
 }
 
-pub fn parse_bounds_data(data: @~[u8], start: uint,
-                         crate_num: int, tcx: ty::ctxt, conv: conv_did)
-                      -> @~[ty::param_bound] {
+pub fn parse_type_param_def_data(data: @~[u8], start: uint,
+                                 crate_num: int, tcx: ty::ctxt,
+                                 conv: conv_did) -> ty::TypeParameterDef
+{
     let st = parse_state_from_data(data, crate_num, start, tcx);
-    parse_bounds(st, conv)
+    parse_type_param_def(st, conv)
+}
+
+fn parse_type_param_def(st: @mut PState, conv: conv_did) -> ty::TypeParameterDef {
+    ty::TypeParameterDef {def_id: parse_def(st, NominalType, conv),
+                          bounds: parse_bounds(st, conv)}
 }
 
 fn parse_bounds(st: @mut PState, conv: conv_did) -> @~[ty::param_bound] {

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -412,7 +412,7 @@ fn enc_fn_sig(w: @io::Writer, cx: @ctxt, fsig: &ty::FnSig) {
     enc_ty(w, cx, fsig.output);
 }
 
-pub fn enc_bounds(w: @io::Writer, cx: @ctxt, bs: @~[ty::param_bound]) {
+fn enc_bounds(w: @io::Writer, cx: @ctxt, bs: @~[ty::param_bound]) {
     for vec::each(*bs) |bound| {
         match *bound {
           ty::bound_owned => w.write_char('S'),
@@ -426,6 +426,12 @@ pub fn enc_bounds(w: @io::Writer, cx: @ctxt, bs: @~[ty::param_bound]) {
         }
     }
     w.write_char('.');
+}
+
+pub fn enc_type_param_def(w: @io::Writer, cx: @ctxt, v: &ty::TypeParameterDef) {
+    w.write_str((cx.ds)(v.def_id));
+    w.write_char('|');
+    enc_bounds(w, cx, v.bounds);
 }
 
 //

--- a/src/librustc/middle/borrowck/gather_loans.rs
+++ b/src/librustc/middle/borrowck/gather_loans.rs
@@ -29,7 +29,7 @@ use middle::pat_util;
 use middle::ty::{ty_region};
 use middle::ty;
 use util::common::indenter;
-use util::ppaux::{expr_repr, region_to_str};
+use util::ppaux::{Repr, region_to_str};
 
 use core::hashmap::{HashSet, HashMap};
 use core::vec;
@@ -282,7 +282,7 @@ pub impl GatherLoanCtxt {
                              expr: @ast::expr,
                              adjustment: &ty::AutoAdjustment) {
         debug!("guarantee_adjustments(expr=%s, adjustment=%?)",
-               expr_repr(self.tcx(), expr), adjustment);
+               expr.repr(self.tcx()), adjustment);
         let _i = indenter();
 
         match *adjustment {

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -1,0 +1,173 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Type substitutions.
+
+use core::prelude::*;
+use middle::ty;
+use util::ppaux::Repr;
+
+///////////////////////////////////////////////////////////////////////////
+// Public trait `Subst`
+//
+// Just call `foo.subst(tcx, substs)` to perform a substitution across
+// `foo`.
+
+pub trait Subst {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> Self;
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Substitution over types
+//
+// Because this is so common, we make a special optimization to avoid
+// doing anything is `substs` is a no-op.  I tried to generalize these
+// to all subst methods but ran into trouble due to the limitations of
+// our current method/trait matching algorithm. - Niko
+
+trait Subst1 {
+    fn subst1(&self, tcx: ty::ctxt, substs: &ty::substs) -> Self;
+}
+
+impl Subst for ty::t {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::t {
+        if ty::substs_is_noop(substs) {
+            return *self;
+        } else {
+            return self.subst1(tcx, substs);
+        }
+    }
+}
+
+impl Subst1 for ty::t {
+    fn subst1(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::t {
+        if !ty::type_needs_subst(*self) {
+            return *self;
+        }
+
+        match ty::get(*self).sty {
+            ty::ty_param(p) => substs.tps[p.idx],
+            ty::ty_self(_) => substs.self_ty.get(),
+            _ => {
+                ty::fold_regions_and_ty(
+                    tcx, *self,
+                    |r| match r {
+                        ty::re_bound(ty::br_self) => {
+                            match substs.self_r {
+                                None => {
+                                    tcx.sess.bug(
+                                        fmt!("ty::subst: \
+                                              Reference to self region when \
+                                              given substs with no self region, \
+                                              ty = %s",
+                                             self.repr(tcx)));
+                                }
+                                Some(self_r) => self_r
+                            }
+                        }
+                        _ => r
+                    },
+                    |t| t.subst1(tcx, substs),
+                    |t| t.subst1(tcx, substs))
+            }
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Other types
+
+impl<T:Subst> Subst for ~[T] {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ~[T] {
+        self.map(|t| t.subst(tcx, substs))
+    }
+}
+
+impl<T:Subst> Subst for @~[T] {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> @~[T] {
+        @(**self).subst(tcx, substs)
+    }
+}
+
+impl<T:Subst> Subst for Option<T> {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> Option<T> {
+        self.map(|t| t.subst(tcx, substs))
+    }
+}
+
+impl Subst for ty::TraitRef {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::TraitRef {
+        ty::TraitRef {
+            def_id: self.def_id,
+            substs: self.substs.subst(tcx, substs)
+        }
+    }
+}
+
+impl Subst for ty::substs {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::substs {
+        ty::substs {
+            self_r: self.self_r,
+            self_ty: self.self_ty.map(|typ| typ.subst(tcx, substs)),
+            tps: self.tps.map(|typ| typ.subst(tcx, substs))
+        }
+    }
+}
+
+impl Subst for ty::BareFnTy {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::BareFnTy {
+        ty::fold_bare_fn_ty(self, |t| t.subst(tcx, substs))
+    }
+}
+
+impl Subst for ty::param_bound {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::param_bound {
+        match self {
+            &ty::bound_copy |
+            &ty::bound_durable |
+            &ty::bound_owned |
+            &ty::bound_const => {
+                *self
+            }
+
+            &ty::bound_trait(tref) => {
+                ty::bound_trait(@tref.subst(tcx, substs))
+            }
+        }
+    }
+}
+
+impl Subst for ty::TypeParameterDef {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::TypeParameterDef {
+        ty::TypeParameterDef {
+            def_id: self.def_id,
+            bounds: self.bounds.subst(tcx, substs)
+        }
+    }
+}
+
+impl Subst for ty::Generics {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::Generics {
+        ty::Generics {
+            type_param_defs: self.type_param_defs.subst(tcx, substs),
+            region_param: self.region_param
+        }
+    }
+}
+
+impl Subst for ty::ty_param_bounds_and_ty {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::ty_param_bounds_and_ty {
+        ty::ty_param_bounds_and_ty {
+            generics: self.generics.subst(tcx, substs),
+            ty: self.ty.subst(tcx, substs)
+        }
+    }
+}
+

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -63,7 +63,7 @@ use middle::trans::type_of;
 use middle::trans::type_of::*;
 use middle::ty;
 use util::common::indenter;
-use util::ppaux::ty_to_str;
+use util::ppaux::{Repr, ty_to_str};
 use util::ppaux;
 
 use core::hash;
@@ -1592,11 +1592,11 @@ pub fn new_fn_ctxt_w_id(ccx: @CrateContext,
     for param_substs.each |p| { p.validate(); }
 
     debug!("new_fn_ctxt_w_id(path=%s, id=%?, impl_id=%?, \
-            param_substs=%s",
+            param_substs=%s)",
            path_str(ccx.sess, path),
            id,
            impl_id,
-           opt_param_substs_to_str(ccx.tcx, &param_substs));
+           param_substs.repr(ccx.tcx));
 
     let llbbs = mk_standard_basic_blocks(llfndecl);
     return @mut fn_ctxt_ {
@@ -1788,6 +1788,9 @@ pub fn trans_closure(ccx: @CrateContext,
     let _icx = ccx.insn_ctxt("trans_closure");
     set_uwtable(llfndecl);
 
+    debug!("trans_closure(..., param_substs=%s)",
+           param_substs.repr(ccx.tcx));
+
     // Set up arguments to the function.
     let fcx = new_fn_ctxt_w_id(ccx, path, llfndecl, id, impl_id, param_substs,
                                   Some(body.span));
@@ -1849,7 +1852,9 @@ pub fn trans_fn(ccx: @CrateContext,
     let do_time = ccx.sess.trans_stats();
     let start = if do_time { time::get_time() }
                 else { time::Timespec::new(0, 0) };
-    debug!("trans_fn(ty_self=%?)", ty_self);
+    debug!("trans_fn(ty_self=%?, param_substs=%s)",
+           ty_self,
+           param_substs.repr(ccx.tcx));
     let _icx = ccx.insn_ctxt("trans_fn");
     ccx.stats.n_fns += 1;
     let the_path_str = path_str(ccx.sess, path);

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -25,7 +25,7 @@ use middle::trans::inline;
 use middle::trans::machine;
 use middle::trans::type_of;
 use middle::ty;
-use util::ppaux::{expr_repr, ty_to_str};
+use util::ppaux::{Repr, ty_to_str};
 
 use core::libc::c_uint;
 use syntax::{ast, ast_util, ast_map};
@@ -237,7 +237,7 @@ pub fn const_expr(cx: @CrateContext, e: @ast::expr) -> ValueRef {
             llvm::LLVMDumpValue(C_undef(llty));
         }
         cx.sess.bug(fmt!("const %s of type %s has size %u instead of %u",
-                         expr_repr(cx.tcx, e), ty_to_str(cx.tcx, ety),
+                         e.repr(cx.tcx), ty_to_str(cx.tcx, ety),
                          csize, tsize));
     }
     llconst

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -86,13 +86,11 @@ pub fn maybe_instantiate_inline(ccx: @CrateContext, fn_id: ast::def_id,
           csearch::found(ast::ii_method(impl_did, mth)) => {
             ccx.stats.n_inlines += 1;
             ccx.external.insert(fn_id, Some(mth.id));
-            let ty::ty_param_bounds_and_ty {
-                generics: ty::Generics { bounds: impl_bnds, _ },
-                ty: _
-            } = ty::lookup_item_type(ccx.tcx, impl_did);
-            if translate &&
-                impl_bnds.len() + mth.generics.ty_params.len() == 0u
-            {
+            let impl_tpt = ty::lookup_item_type(ccx.tcx, impl_did);
+            let num_type_params =
+                impl_tpt.generics.type_param_defs.len() +
+                mth.generics.ty_params.len();
+            if translate && num_type_params == 0 {
                 let llfn = get_item_val(ccx, mth.id);
                 let path = vec::append(
                     ty::item_path(ccx.tcx, impl_did),

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -135,7 +135,9 @@ pub fn check_pat_variant(pcx: pat_ctxt, pat: @ast::pat, path: @ast::path,
                     ty::enum_variant_with_id(tcx, enm, var);
                 let var_tpt = ty::lookup_item_type(tcx, var);
                 vinfo.args.map(|t| {
-                    if var_tpt.generics.bounds.len() == expected_substs.tps.len() {
+                    if var_tpt.generics.type_param_defs.len() ==
+                        expected_substs.tps.len()
+                    {
                         ty::subst(tcx, expected_substs, *t)
                     }
                     else {

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -376,7 +376,14 @@ pub impl<'self> LookupContext<'self> {
 
         let tcx = self.tcx();
         let mut next_bound_idx = 0; // count only trait bounds
-        let type_param_def = tcx.ty_param_defs.get(&param_ty.def_id.node);
+        let type_param_def = match tcx.ty_param_defs.find(&param_ty.def_id.node) {
+            Some(t) => t,
+            None => {
+                tcx.sess.span_bug(
+                    self.expr.span,
+                    fmt!("No param def for %?", param_ty));
+            }
+        };
 
         for ty::each_bound_trait_and_supertraits(tcx, type_param_def.bounds)
             |bound_trait_ref|

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -94,7 +94,6 @@ use middle::typeck::{method_map_entry, method_origin, method_param};
 use middle::typeck::{method_self, method_static, method_trait, method_super};
 use middle::typeck::check::regionmanip::replace_bound_regions_in_fn_sig;
 use util::common::indenter;
-use util::ppaux::expr_repr;
 
 use core::hashmap::HashSet;
 use core::result;
@@ -149,8 +148,7 @@ pub fn lookup(
         autoderef_receiver: autoderef_receiver,
     };
     let mme = lcx.do_lookup(self_ty);
-    debug!("method lookup for %s yielded %?",
-           expr_repr(fcx.tcx(), expr), mme);
+    debug!("method lookup for %s yielded %?", expr.repr(fcx.tcx()), mme);
     return mme;
 }
 
@@ -197,9 +195,8 @@ pub impl<'self> LookupContext<'self> {
 
         debug!("do_lookup(self_ty=%s, expr=%s, self_expr=%s)",
                self.ty_to_str(self_ty),
-               expr_repr(self.tcx(), self.expr),
-               expr_repr(self.tcx(), self.self_expr));
-        let _indenter = indenter();
+               self.expr.repr(self.tcx()),
+               self.self_expr.repr(self.tcx()));
 
         // Prepare the list of candidates
         self.push_inherent_candidates(self_ty);
@@ -379,105 +376,52 @@ pub impl<'self> LookupContext<'self> {
 
         let tcx = self.tcx();
         let mut next_bound_idx = 0; // count only trait bounds
-        let bounds = tcx.ty_param_bounds.get(&param_ty.def_id.node);
+        let type_param_def = tcx.ty_param_defs.get(&param_ty.def_id.node);
 
-        for bounds.each |bound| {
-            let bound_trait_ref = match *bound {
-                ty::bound_trait(bound_t) => bound_t,
+        for ty::each_bound_trait_and_supertraits(tcx, type_param_def.bounds)
+            |bound_trait_ref|
+        {
+            let this_bound_idx = next_bound_idx;
+            next_bound_idx += 1;
 
-                ty::bound_copy | ty::bound_owned |
-                ty::bound_const | ty::bound_durable => {
-                    loop; // skip non-trait bounds
-                }
-            };
-
-            // Loop over the trait and all of its supertraits.
-            let mut worklist = ~[];
-
-            let init_trait_ref = bound_trait_ref;
-
-            // Replace any appearance of `self` with the type of the
-            // generic parameter itself.  Note that this is the only
-            // case where this replacement is necessary: in all other
-            // cases, we are either invoking a method directly from an
-            // impl or class (where the self type is not permitted),
-            // or from a trait type (in which case methods that refer
-            // to self are not permitted).
-            let init_substs = substs {
-                self_ty: Some(rcvr_ty),
-                ..copy bound_trait_ref.substs
-            };
-
-            worklist.push((init_trait_ref.def_id, init_substs));
-
-            let mut i = 0;
-            while i < worklist.len() {
-                let (init_trait_id, init_substs) = /*bad*/copy worklist[i];
-                i += 1;
-
-                // Add all the supertraits of this trait to the worklist.
-                let supertraits = ty::trait_supertraits(tcx, init_trait_id);
-                for supertraits.each |supertrait_ref| {
-                    debug!("adding supertrait: %?",
-                           supertrait_ref.def_id);
-
-                    let new_substs = ty::subst_in_substs(
-                        tcx,
-                        &init_substs,
-                        &supertrait_ref.substs);
-
-                    // Again replacing the self type
-                    let new_substs = substs {
-                        self_ty: Some(rcvr_ty),
-                        ..new_substs
-                    };
-
-                    worklist.push((supertrait_ref.def_id, new_substs));
-                }
-
-
-                let this_bound_idx = next_bound_idx;
-                next_bound_idx += 1;
-
-                let trait_methods = ty::trait_methods(tcx, init_trait_id);
-                let pos = {
-                    match trait_methods.position(|m| {
-                        m.self_ty != ast::sty_static &&
-                            m.ident == self.m_name })
-                    {
-                        Some(pos) => pos,
-                        None => {
-                            debug!("trait doesn't contain method: %?",
-                                   init_trait_id);
-                            loop; // check next trait or bound
-                        }
+            let trait_methods = ty::trait_methods(tcx, bound_trait_ref.def_id);
+            let pos = {
+                match trait_methods.position(|m| {
+                    m.self_ty != ast::sty_static &&
+                        m.ident == self.m_name })
+                {
+                    Some(pos) => pos,
+                    None => {
+                        debug!("trait doesn't contain method: %?",
+                               bound_trait_ref.def_id);
+                        loop; // check next trait or bound
                     }
-                };
-                let method = trait_methods[pos];
+                }
+            };
+            let method = trait_methods[pos];
 
-                let (rcvr_ty, rcvr_substs) =
-                    self.create_rcvr_ty_and_substs_for_method(
-                        method.self_ty,
-                        rcvr_ty,
-                        init_substs,
-                        TransformTypeNormally);
+            let (rcvr_ty, rcvr_substs) =
+                self.create_rcvr_ty_and_substs_for_method(
+                    method.self_ty,
+                    rcvr_ty,
+                    copy bound_trait_ref.substs,
+                    TransformTypeNormally);
 
-                let cand = Candidate {
-                    rcvr_ty: rcvr_ty,
-                    rcvr_substs: rcvr_substs,
-                    method_ty: method,
-                    origin: method_param(
-                        method_param {
-                            trait_id: init_trait_id,
-                            method_num: pos,
-                            param_num: param_ty.idx,
-                            bound_num: this_bound_idx,
-                        })
-                };
+            let cand = Candidate {
+                rcvr_ty: rcvr_ty,
+                rcvr_substs: rcvr_substs,
+                method_ty: method,
+                origin: method_param(
+                    method_param {
+                        trait_id: bound_trait_ref.def_id,
+                        method_num: pos,
+                        param_num: param_ty.idx,
+                        bound_num: this_bound_idx,
+                    })
+            };
 
-                debug!("pushing inherent candidate for param: %?", cand);
-                self.inherent_candidates.push(cand);
-            }
+            debug!("pushing inherent candidate for param: %?", cand);
+            self.inherent_candidates.push(cand);
         }
     }
 
@@ -499,7 +443,7 @@ pub impl<'self> LookupContext<'self> {
         };
         let method = ms[index];
 
-        /* FIXME(#3157) we should transform the vstore in accordance
+        /* FIXME(#5762) we should transform the vstore in accordance
            with the self type
 
         match method.self_type {
@@ -517,6 +461,9 @@ pub impl<'self> LookupContext<'self> {
         // `trait_ty` for `self` here, because it allows the compiler
         // to soldier on.  An error will be reported should this
         // candidate be selected if the method refers to `self`.
+        //
+        // NB: `confirm_candidate()` also relies upon this substitution
+        // for Self.
         let rcvr_substs = substs {
             self_ty: Some(self_ty),
             ../*bad*/copy *substs
@@ -1075,7 +1022,7 @@ pub impl<'self> LookupContext<'self> {
         let fty = self.fn_ty_from_origin(&candidate.origin);
 
         debug!("confirm_candidate(expr=%s, candidate=%s, fty=%s)",
-               expr_repr(tcx, self.expr),
+               self.expr.repr(tcx),
                self.cand_to_str(candidate),
                self.ty_to_str(fty));
 
@@ -1101,7 +1048,7 @@ pub impl<'self> LookupContext<'self> {
         // If they were not explicitly supplied, just construct fresh
         // type variables.
         let num_supplied_tps = self.supplied_tps.len();
-        let num_method_tps = candidate.method_ty.generics.bounds.len();
+        let num_method_tps = candidate.method_ty.generics.type_param_defs.len();
         let m_substs = {
             if num_supplied_tps == 0u {
                 self.fcx.infcx().next_ty_vars(num_method_tps)
@@ -1195,7 +1142,7 @@ pub impl<'self> LookupContext<'self> {
                   self-type through a boxed trait");
         }
 
-        if candidate.method_ty.generics.bounds.len() > 0 {
+        if candidate.method_ty.generics.has_type_params() {
             self.tcx().sess.span_err(
                 self.expr.span,
                 ~"cannot call a generic method through a boxed trait");

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -91,7 +91,7 @@ fn resolve_vtable_map_entry(fcx: @mut FnCtxt, sp: span, id: ast::node_id) {
             let vtable_map = fcx.ccx.vtable_map;
             vtable_map.insert(id, r_origins);
             debug!("writeback::resolve_vtable_map_entry(id=%d, vtables=%?)",
-                   id, r_origins.map(|v| v.to_str(fcx.tcx())));
+                   id, r_origins.repr(fcx.tcx()));
         }
     }
 

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -335,7 +335,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
                            ty::mk_bare_fn(tcx, copy m.fty));
 
         // create the type parameter definitions for `foo`, applying
-        // the substutition to any traits that appear in their bounds.
+        // the substitution to any traits that appear in their bounds.
 
         // add in the type parameters from the trait
         let mut new_type_param_defs = ~[];

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -35,6 +35,7 @@ use core::prelude::*;
 use metadata::csearch;
 use middle::ty::{substs, ty_param_bounds_and_ty};
 use middle::ty;
+use middle::subst::Subst;
 use middle::typeck::astconv::{AstConv, ty_of_arg};
 use middle::typeck::astconv::{ast_ty_to_ty};
 use middle::typeck::astconv;
@@ -186,7 +187,7 @@ pub fn get_enum_variant_types(ccx: &CrateCtxt,
 
             ast::struct_variant_kind(struct_def) => {
                 let tpt = ty_param_bounds_and_ty {
-                    generics: ty_generics(ccx, rp, generics),
+                    generics: ty_generics(ccx, rp, generics, 0),
                     ty: enum_ty
                 };
 
@@ -207,7 +208,7 @@ pub fn get_enum_variant_types(ccx: &CrateCtxt,
             None => {}
             Some(result_ty) => {
                 let tpt = ty_param_bounds_and_ty {
-                    generics: ty_generics(ccx, rp, generics),
+                    generics: ty_generics(ccx, rp, generics, 0),
                     ty: result_ty
                 };
                 tcx.tcache.insert(local_def(variant.node.id), tpt);
@@ -227,7 +228,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
             node: ast::item_trait(ref generics, _, ref ms),
             _
         }, _) => {
-            let trait_ty_generics = ty_generics(ccx, region_paramd, generics);
+            let trait_ty_generics = ty_generics(ccx, region_paramd, generics, 0);
 
             // For each method, construct a suitable ty::method and
             // store it into the `tcx.methods` table:
@@ -274,48 +275,99 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
                              trait_id: ast::node_id,
                              m: &ty::method,
                              trait_ty_generics: &ty::Generics) {
-        // We need to create a typaram that replaces self. This param goes
-        // *in between* the typarams from the trait and those from the
-        // method (since its bound can depend on the trait? or
-        // something like that).
+        // If declaration is
+        //
+        //     trait<A,B,C> {
+        //        fn foo<D,E,F>(...) -> Self;
+        //     }
+        //
+        // and we will create a function like
+        //
+        //     fn foo<A',B',C',D',E',F',G'>(...) -> D' {}
+        //
+        // Note that `Self` is replaced with an explicit type
+        // parameter D' that is sandwiched in between the trait params
+        // and the method params, and thus the indices of the method
+        // type parameters are offset by 1 (that is, the method
+        // parameters are mapped from D, E, F to E', F', and G').  The
+        // choice of this ordering is somewhat arbitrary.
+        //
+        // Also, this system is rather a hack that should be replaced
+        // with a more uniform treatment of Self (which is partly
+        // underway).
 
         // build up a subst that shifts all of the parameters over
         // by one and substitute in a new type param for self
 
+        let tcx = ccx.tcx;
+
         let dummy_defid = ast::def_id {crate: 0, node: 0};
 
-        let num_trait_bounds = trait_ty_generics.bounds.len();
+        // Represents [A',B',C']
+        let num_trait_bounds = trait_ty_generics.type_param_defs.len();
         let non_shifted_trait_tps = do vec::from_fn(num_trait_bounds) |i| {
-            ty::mk_param(ccx.tcx, i, dummy_defid)
-        };
-        let self_param = ty::mk_param(ccx.tcx, num_trait_bounds,
-                                      dummy_defid);
-        let shifted_method_tps = do vec::from_fn(m.generics.bounds.len()) |i| {
-            ty::mk_param(ccx.tcx, i + 1, dummy_defid)
+            ty::mk_param(tcx, i, dummy_defid)
         };
 
+        // Represents [D']
+        let self_param = ty::mk_param(tcx, num_trait_bounds,
+                                      dummy_defid);
+
+        // Represents [E',F',G']
+        let num_method_bounds = m.generics.type_param_defs.len();
+        let shifted_method_tps = do vec::from_fn(num_method_bounds) |i| {
+            ty::mk_param(tcx, i + 1, dummy_defid)
+        };
+
+        // build up the substitution from
+        //     A,B,C => A',B',C'
+        //     Self => D'
+        //     D,E,F => E',F',G'
         let substs = substs {
             self_r: None,
             self_ty: Some(self_param),
             tps: non_shifted_trait_tps + shifted_method_tps
         };
-        let ty = ty::subst(ccx.tcx,
+
+        // create the type of `foo`, applying the substitution above
+        let ty = ty::subst(tcx,
                            &substs,
-                           ty::mk_bare_fn(ccx.tcx, copy m.fty));
-        let trait_def = get_trait_def(ccx, local_def(trait_id));
-        let trait_ref = trait_def.trait_ref;
-        let mut new_bounds = ~[];
-        new_bounds.push_all(*trait_ty_generics.bounds);
-        new_bounds.push(@~[ty::bound_trait(trait_ref)]);
-        new_bounds.push_all(*m.generics.bounds);
-        ccx.tcx.tcache.insert(m.def_id,
-                              ty_param_bounds_and_ty {
-                                  generics: ty::Generics {
-                                      bounds: @new_bounds,
-                                      region_param: trait_ty_generics.region_param
-                                  },
-                                  ty: ty
-                              });
+                           ty::mk_bare_fn(tcx, copy m.fty));
+
+        // create the type parameter definitions for `foo`, applying
+        // the substutition to any traits that appear in their bounds.
+
+        // add in the type parameters from the trait
+        let mut new_type_param_defs = ~[];
+        let substd_type_param_defs =
+            trait_ty_generics.type_param_defs.subst(tcx, &substs);
+        new_type_param_defs.push_all(*substd_type_param_defs);
+
+        // add in the "self" type parameter
+        let self_trait_def = get_trait_def(ccx, local_def(trait_id));
+        let self_trait_ref = @self_trait_def.trait_ref.subst(tcx, &substs);
+        new_type_param_defs.push(ty::TypeParameterDef {
+            def_id: dummy_defid,
+            bounds: @~[ty::bound_trait(self_trait_ref)]
+        });
+
+        // add in the type parameters from the method
+        let substd_type_param_defs = m.generics.type_param_defs.subst(tcx, &substs);
+        new_type_param_defs.push_all(*substd_type_param_defs);
+
+        debug!("static method %s type_param_defs=%s substs=%s",
+               m.def_id.repr(tcx),
+               new_type_param_defs.repr(tcx),
+               substs.repr(tcx));
+
+        tcx.tcache.insert(m.def_id,
+                          ty_param_bounds_and_ty {
+                              generics: ty::Generics {
+                                  type_param_defs: @new_type_param_defs,
+                                  region_param: trait_ty_generics.region_param
+                              },
+                              ty: ty
+                          });
     }
 
     fn ty_method_of_trait_method(self: &CrateCtxt,
@@ -334,9 +386,10 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
         let (transformed_self_ty, fty) =
             astconv::ty_of_method(self, &rscope, *m_purity, &m_generics.lifetimes,
                                   trait_self_ty, *m_self_ty, m_decl);
+        let num_trait_type_params = trait_generics.ty_params.len();
         ty::method {
             ident: *m_ident,
-            generics: ty_generics(self, None, m_generics),
+            generics: ty_generics(self, None, m_generics, num_trait_type_params),
             transformed_self_ty: transformed_self_ty,
             fty: fty,
             self_ty: m_self_ty.node,
@@ -357,9 +410,11 @@ pub fn ensure_supertraits(ccx: &CrateCtxt,
     let tcx = ccx.tcx;
     if tcx.supertraits.contains_key(&local_def(id)) { return; }
 
+    let self_ty = ty::mk_self(ccx.tcx, local_def(id));
     let mut ty_trait_refs: ~[@ty::TraitRef] = ~[];
     for ast_trait_refs.each |&ast_trait_ref| {
-        let trait_ref = instantiate_trait_ref(ccx, ast_trait_ref, rp, generics);
+        let trait_ref = instantiate_trait_ref(ccx, ast_trait_ref, rp,
+                                              generics, self_ty);
 
         // FIXME(#5527) Could have same trait multiple times
         if ty_trait_refs.any(|other_trait| other_trait.def_id == trait_ref.def_id) {
@@ -426,15 +481,18 @@ pub fn compare_impl_method(tcx: ty::ctxt,
         }
     }
 
-    if impl_m.generics.bounds.len() != trait_m.generics.bounds.len() {
+    let num_impl_m_type_params = impl_m.generics.type_param_defs.len();
+    let num_trait_m_type_params = trait_m.generics.type_param_defs.len();
+    if num_impl_m_type_params != num_trait_m_type_params {
         tcx.sess.span_err(
             cm.span,
             fmt!("method `%s` has %u type %s, but its trait \
                   declaration has %u type %s",
-                 *tcx.sess.str_of(trait_m.ident), impl_m.generics.bounds.len(),
-                 pluralize(impl_m.generics.bounds.len(), ~"parameter"),
-                 trait_m.generics.bounds.len(),
-                 pluralize(trait_m.generics.bounds.len(), ~"parameter")));
+                 *tcx.sess.str_of(trait_m.ident),
+                 num_impl_m_type_params,
+                 pluralize(num_impl_m_type_params, ~"parameter"),
+                 num_trait_m_type_params,
+                 pluralize(num_trait_m_type_params, ~"parameter")));
         return;
     }
 
@@ -452,23 +510,23 @@ pub fn compare_impl_method(tcx: ty::ctxt,
     // FIXME(#2687)---we should be checking that the bounds of the
     // trait imply the bounds of the subtype, but it appears
     // we are...not checking this.
-    for trait_m.generics.bounds.eachi() |i, trait_param_bounds| {
+    for trait_m.generics.type_param_defs.eachi |i, trait_param_def| {
         // For each of the corresponding impl ty param's bounds...
-        let impl_param_bounds = impl_m.generics.bounds[i];
+        let impl_param_def = &impl_m.generics.type_param_defs[i];
         // Make sure the bounds lists have the same length
         // Would be nice to use the ty param names in the error message,
         // but we don't have easy access to them here
-        if impl_param_bounds.len() != trait_param_bounds.len() {
+        if impl_param_def.bounds.len() != trait_param_def.bounds.len() {
            tcx.sess.span_err(
                cm.span,
                fmt!("in method `%s`, \
                      type parameter %u has %u %s, but the same type \
                      parameter in its trait declaration has %u %s",
                     *tcx.sess.str_of(trait_m.ident),
-                    i, impl_param_bounds.len(),
-                    pluralize(impl_param_bounds.len(), ~"bound"),
-                    trait_param_bounds.len(),
-                    pluralize(trait_param_bounds.len(), ~"bound")));
+                    i, impl_param_def.bounds.len(),
+                    pluralize(impl_param_def.bounds.len(), ~"bound"),
+                    trait_param_def.bounds.len(),
+                    pluralize(trait_param_def.bounds.len(), ~"bound")));
            return;
         }
     }
@@ -492,12 +550,12 @@ pub fn compare_impl_method(tcx: ty::ctxt,
         debug!("impl_fty (pre-subst): %s", ppaux::ty_to_str(tcx, impl_fty));
         replace_bound_self(tcx, impl_fty, dummy_self_r)
     };
-    debug!("impl_fty: %s", ppaux::ty_to_str(tcx, impl_fty));
+    debug!("impl_fty (post-subst): %s", ppaux::ty_to_str(tcx, impl_fty));
     let trait_fty = {
-        let dummy_tps = do vec::from_fn(trait_m.generics.bounds.len()) |i| {
-            // hack: we don't know the def id of the impl tp, but it
-            // is not important for unification
-            ty::mk_param(tcx, i + impl_tps, ast::def_id {crate: 0, node: 0})
+        let num_trait_m_type_params = trait_m.generics.type_param_defs.len();
+        let dummy_tps = do vec::from_fn(num_trait_m_type_params) |i| {
+            ty::mk_param(tcx, i + impl_tps,
+                         impl_m.generics.type_param_defs[i].def_id)
         };
         let trait_tps = trait_substs.tps.map(
             |t| replace_bound_self(tcx, *t, dummy_self_r));
@@ -507,9 +565,11 @@ pub fn compare_impl_method(tcx: ty::ctxt,
             tps: vec::append(trait_tps, dummy_tps)
         };
         let trait_fty = ty::mk_bare_fn(tcx, copy trait_m.fty);
-        debug!("trait_fty (pre-subst): %s", ppaux::ty_to_str(tcx, trait_fty));
+        debug!("trait_fty (pre-subst): %s substs=%s",
+               trait_fty.repr(tcx), substs.repr(tcx));
         ty::subst(tcx, &substs, trait_fty)
     };
+    debug!("trait_fty (post-subst): %s", trait_fty.repr(tcx));
 
     let infcx = infer::new_infer_ctxt(tcx);
     match infer::mk_subty(infcx, false, cm.span, impl_fty, trait_fty) {
@@ -542,7 +602,8 @@ pub fn check_methods_against_trait(ccx: &CrateCtxt,
                                    impl_ms: &[ConvertedMethod])
 {
     let tcx = ccx.tcx;
-    let trait_ref = instantiate_trait_ref(ccx, a_trait_ty, rp, generics);
+    let trait_ref = instantiate_trait_ref(ccx, a_trait_ty, rp,
+                                          generics, selfty);
 
     if trait_ref.def_id.crate == ast::local_crate {
         ensure_trait_methods(ccx, trait_ref.def_id.node);
@@ -574,7 +635,7 @@ pub fn check_methods_against_trait(ccx: &CrateCtxt,
 
 pub fn convert_field(ccx: &CrateCtxt,
                      rp: Option<ty::region_variance>,
-                     bounds: @~[ty::param_bounds],
+                     type_param_defs: @~[ty::TypeParameterDef],
                      v: @ast::struct_field,
                      generics: &ast::Generics) {
     let region_parameterization =
@@ -585,7 +646,7 @@ pub fn convert_field(ccx: &CrateCtxt,
     ccx.tcx.tcache.insert(local_def(v.node.id),
                           ty::ty_param_bounds_and_ty {
                               generics: ty::Generics {
-                                  bounds: bounds,
+                                  type_param_defs: type_param_defs,
                                   region_param: rp
                               },
                               ty: tt
@@ -609,8 +670,10 @@ pub fn convert_methods(ccx: &CrateCtxt,
 {
     let tcx = ccx.tcx;
     return vec::map(ms, |m| {
+        let num_rcvr_ty_params = rcvr_ty_generics.type_param_defs.len();
         let m_ty_generics =
-            ty_generics(ccx, rcvr_ty_generics.region_param, &m.generics);
+            ty_generics(ccx, rcvr_ty_generics.region_param, &m.generics,
+                        num_rcvr_ty_params);
         let mty =
             @ty_of_method(ccx, *m, rcvr_ty_generics.region_param,
                           untransformed_rcvr_ty,
@@ -625,8 +688,9 @@ pub fn convert_methods(ccx: &CrateCtxt,
             // the tps on the receiver and those on the method itself
             ty_param_bounds_and_ty {
                 generics: ty::Generics {
-                    bounds: @(vec::append(copy *rcvr_ty_generics.bounds,
-                                          *m_ty_generics.bounds)),
+                    type_param_defs: @vec::append(
+                        copy *rcvr_ty_generics.type_param_defs,
+                        *m_ty_generics.type_param_defs),
                     region_param: rcvr_ty_generics.region_param
                 },
                 ty: fty
@@ -660,9 +724,10 @@ pub fn convert_methods(ccx: &CrateCtxt,
         // foo(); }`).
         let method_vis = m.vis.inherit_from(rcvr_visibility);
 
+        let num_rcvr_type_params = rcvr_generics.ty_params.len();
         ty::method {
             ident: m.ident,
-            generics: ty_generics(ccx, None, &m.generics),
+            generics: ty_generics(ccx, None, &m.generics, num_rcvr_type_params),
             transformed_self_ty: transformed_self_ty,
             fty: fty,
             self_ty: m.self_ty.node,
@@ -705,7 +770,7 @@ pub fn convert(ccx: &CrateCtxt, it: @ast::item) {
                                rp);
       }
       ast::item_impl(ref generics, opt_trait_ref, selfty, ref ms) => {
-        let i_ty_generics = ty_generics(ccx, rp, generics);
+        let i_ty_generics = ty_generics(ccx, rp, generics, 0);
         let region_parameterization =
             RegionParameterization::from_variance_and_generics(rp, generics);
         let selfty = ccx.to_ty(&type_rscope(region_parameterization), selfty);
@@ -741,8 +806,9 @@ pub fn convert(ccx: &CrateCtxt, it: @ast::item) {
 
           let (_, provided_methods) =
               split_trait_methods(*trait_methods);
-          let (ty_generics, _) = mk_substs(ccx, generics, rp);
           let untransformed_rcvr_ty = ty::mk_self(tcx, local_def(it.id));
+          let (ty_generics, _) = mk_item_substs(ccx, generics, rp,
+                                                Some(untransformed_rcvr_ty));
           let _ = convert_methods(ccx, provided_methods,
                                   untransformed_rcvr_ty,
                                   &ty_generics, generics,
@@ -799,7 +865,7 @@ pub fn convert_struct(ccx: &CrateCtxt,
         tcx.tcache.insert(local_def(dtor.node.id),
                           ty_param_bounds_and_ty {
                               generics: ty::Generics {
-                                  bounds: tpt.generics.bounds,
+                                  type_param_defs: tpt.generics.type_param_defs,
                                   region_param: rp
                               },
                               ty: t_dtor});
@@ -807,9 +873,9 @@ pub fn convert_struct(ccx: &CrateCtxt,
 
     // Write the type of each of the members
     for struct_def.fields.each |f| {
-       convert_field(ccx, rp, tpt.generics.bounds, *f, generics);
+       convert_field(ccx, rp, tpt.generics.type_param_defs, *f, generics);
     }
-    let (_, substs) = mk_substs(ccx, generics, rp);
+    let (_, substs) = mk_item_substs(ccx, generics, rp, None);
     let selfty = ty::mk_struct(tcx, local_def(id), substs);
 
     // If this struct is enum-like or tuple-like, create the type of its
@@ -850,7 +916,8 @@ pub fn convert_foreign(ccx: &CrateCtxt, i: @ast::foreign_item) {
 pub fn instantiate_trait_ref(ccx: &CrateCtxt,
                              ast_trait_ref: @ast::trait_ref,
                              rp: Option<ty::region_variance>,
-                             generics: &ast::Generics) -> @ty::TraitRef
+                             generics: &ast::Generics,
+                             self_ty: ty::t) -> @ty::TraitRef
 {
     /*!
      * Instantiates the path for the given trait reference, assuming that
@@ -866,7 +933,7 @@ pub fn instantiate_trait_ref(ccx: &CrateCtxt,
         ast::def_trait(trait_did) => {
             let trait_ref =
                 astconv::ast_path_to_trait_ref(
-                    ccx, &rscope, trait_did, ast_trait_ref.path);
+                    ccx, &rscope, trait_did, Some(self_ty), ast_trait_ref.path);
             ccx.tcx.trait_refs.insert(
                 ast_trait_ref.ref_id, trait_ref);
             return trait_ref;
@@ -903,7 +970,9 @@ pub fn trait_def_of_item(ccx: &CrateCtxt, it: @ast::item) -> @ty::TraitDef {
     let rp = tcx.region_paramd_items.find(&it.id).map_consume(|x| *x);
     match it.node {
         ast::item_trait(ref generics, _, _) => {
-            let (ty_generics, substs) = mk_substs(ccx, generics, rp);
+            let self_ty = ty::mk_self(tcx, def_id);
+            let (ty_generics, substs) = mk_item_substs(ccx, generics, rp,
+                                                       Some(self_ty));
             let trait_ref = @ty::TraitRef {def_id: def_id,
                                            substs: substs};
             let trait_def = @ty::TraitDef {generics: ty_generics,
@@ -937,7 +1006,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: @ast::item)
       }
       ast::item_fn(ref decl, purity, _, ref generics, _) => {
         assert!(rp.is_none());
-        let ty_generics = ty_generics(ccx, None, generics);
+        let ty_generics = ty_generics(ccx, None, generics, 0);
         let tofd = astconv::ty_of_bare_fn(ccx,
                                           &empty_rscope,
                                           purity,
@@ -946,7 +1015,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: @ast::item)
                                           decl);
         let tpt = ty_param_bounds_and_ty {
             generics: ty::Generics {
-                bounds: ty_generics.bounds,
+                type_param_defs: ty_generics.type_param_defs,
                 region_param: None
             },
             ty: ty::mk_bare_fn(ccx.tcx, tofd)
@@ -979,7 +1048,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: @ast::item)
                 }
             };
             ty_param_bounds_and_ty {
-                generics: ty_generics(ccx, rp, generics),
+                generics: ty_generics(ccx, rp, generics, 0),
                 ty: ty
             }
         };
@@ -989,7 +1058,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: @ast::item)
       }
       ast::item_enum(_, ref generics) => {
         // Create a new generic polytype.
-        let (ty_generics, substs) = mk_substs(ccx, generics, rp);
+        let (ty_generics, substs) = mk_item_substs(ccx, generics, rp, None);
         let t = ty::mk_enum(tcx, local_def(it.id), substs);
         let tpt = ty_param_bounds_and_ty {
             generics: ty_generics,
@@ -1004,7 +1073,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: @ast::item)
               fmt!("Invoked ty_of_item on trait"));
       }
       ast::item_struct(_, ref generics) => {
-          let (ty_generics, substs) = mk_substs(ccx, generics, rp);
+          let (ty_generics, substs) = mk_item_substs(ccx, generics, rp, None);
           let t = ty::mk_struct(tcx, local_def(it.id), substs);
           let tpt = ty_param_bounds_and_ty {
               generics: ty_generics,
@@ -1031,7 +1100,7 @@ pub fn ty_of_foreign_item(ccx: &CrateCtxt, it: @ast::foreign_item)
         ast::foreign_item_const(t) => {
             ty::ty_param_bounds_and_ty {
                 generics: ty::Generics {
-                    bounds: @~[],
+                    type_param_defs: @~[],
                     region_param: None,
                 },
                 ty: ast_ty_to_ty(ccx, &empty_rscope, t)
@@ -1042,16 +1111,25 @@ pub fn ty_of_foreign_item(ccx: &CrateCtxt, it: @ast::foreign_item)
 
 pub fn ty_generics(ccx: &CrateCtxt,
                    rp: Option<ty::region_variance>,
-                   generics: &ast::Generics) -> ty::Generics {
+                   generics: &ast::Generics,
+                   base_index: uint) -> ty::Generics {
     return ty::Generics {
         region_param: rp,
-        bounds: @generics.ty_params.map_to_vec(|param| {
-            match ccx.tcx.ty_param_bounds.find(&param.id) {
-                Some(&bs) => bs,
+        type_param_defs: @generics.ty_params.mapi_to_vec(|offset, param| {
+            match ccx.tcx.ty_param_defs.find(&param.id) {
+                Some(&def) => def,
                 None => {
-                    let bounds = compute_bounds(ccx, rp, generics, param.bounds);
-                    ccx.tcx.ty_param_bounds.insert(param.id, bounds);
-                    bounds
+                    let param_ty = ty::param_ty {idx: base_index + offset,
+                                                 def_id: local_def(param.id)};
+                    let bounds = compute_bounds(ccx, rp, generics,
+                                                param_ty, param.bounds);
+                    let def = ty::TypeParameterDef {
+                        def_id: local_def(param.id),
+                        bounds: bounds
+                    };
+                    debug!("def for param: %s", def.repr(ccx.tcx));
+                    ccx.tcx.ty_param_defs.insert(param.id, def);
+                    def
                 }
             }
         })
@@ -1061,6 +1139,7 @@ pub fn ty_generics(ccx: &CrateCtxt,
         ccx: &CrateCtxt,
         rp: Option<ty::region_variance>,
         generics: &ast::Generics,
+        param_ty: ty::param_ty,
         ast_bounds: @OptVec<ast::TyParamBound>) -> ty::param_bounds
     {
         /*!
@@ -1076,7 +1155,8 @@ pub fn ty_generics(ccx: &CrateCtxt,
             match b {
                 &TraitTyParamBound(b) => {
                     let li = &ccx.tcx.lang_items;
-                    let trait_ref = instantiate_trait_ref(ccx, b, rp, generics);
+                    let ty = ty::mk_param(ccx.tcx, param_ty.idx, param_ty.def_id);
+                    let trait_ref = instantiate_trait_ref(ccx, b, rp, generics, ty);
                     if trait_ref.def_id == li.owned_trait() {
                         ~[ty::bound_owned]
                     } else if trait_ref.def_id == li.copy_trait() {
@@ -1104,7 +1184,7 @@ pub fn ty_of_foreign_fn_decl(ccx: &CrateCtxt,
                              def_id: ast::def_id,
                              ast_generics: &ast::Generics)
                           -> ty::ty_param_bounds_and_ty {
-    let ty_generics = ty_generics(ccx, None, ast_generics);
+    let ty_generics = ty_generics(ccx, None, ast_generics, 0);
     let region_param_names = RegionParamNames::from_generics(ast_generics);
     let rb = in_binding_rscope(&empty_rscope, region_param_names);
     let input_tys = decl.inputs.map(|a| ty_of_arg(ccx, &rb, *a, None) );
@@ -1127,17 +1207,18 @@ pub fn ty_of_foreign_fn_decl(ccx: &CrateCtxt,
     return tpt;
 }
 
-pub fn mk_substs(ccx: &CrateCtxt,
-                 ast_generics: &ast::Generics,
-                 rp: Option<ty::region_variance>) -> (ty::Generics, ty::substs)
+pub fn mk_item_substs(ccx: &CrateCtxt,
+                      ast_generics: &ast::Generics,
+                      rp: Option<ty::region_variance>,
+                      self_ty: Option<ty::t>) -> (ty::Generics, ty::substs)
 {
     let mut i = 0;
-    let ty_generics = ty_generics(ccx, rp, ast_generics);
+    let ty_generics = ty_generics(ccx, rp, ast_generics, 0);
     let params = ast_generics.ty_params.map_to_vec(|atp| {
         let t = ty::mk_param(ccx.tcx, i, local_def(atp.id));
         i += 1u;
         t
     });
     let self_r = rscope::bound_self_region(rp);
-    (ty_generics, substs {self_r: self_r, self_ty: None, tps: params})
+    (ty_generics, substs {self_r: self_r, self_ty: self_ty, tps: params})
 }

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -274,15 +274,14 @@ pub fn super_tps<C:Combine>(
 pub fn super_self_tys<C:Combine>(
     self: &C, a: Option<ty::t>, b: Option<ty::t>) -> cres<Option<ty::t>> {
 
-    // Note: the self type parameter is (currently) always treated as
-    // *invariant* (otherwise the type system would be unsound).
-
     match (a, b) {
       (None, None) => {
         Ok(None)
       }
       (Some(a), Some(b)) => {
-        eq_tys(self, a, b).then(|| Ok(Some(a)) )
+          // FIXME(#5781) this should be eq_tys
+          // eq_tys(self, a, b).then(|| Ok(Some(a)) )
+          self.contratys(a, b).chain(|t| Ok(Some(t)))
       }
       (None, Some(_)) |
       (Some(_), None) => {

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -53,6 +53,7 @@ use core::prelude::*;
 use middle::resolve;
 use middle::ty;
 use util::common::time;
+use util::ppaux::Repr;
 use util::ppaux;
 
 use core::hashmap::HashMap;
@@ -153,14 +154,15 @@ pub enum vtable_origin {
     vtable_param(uint, uint)
 }
 
-pub impl vtable_origin {
-    fn to_str(&self, tcx: ty::ctxt) -> ~str {
+impl Repr for vtable_origin {
+    fn repr(&self, tcx: ty::ctxt) -> ~str {
         match *self {
             vtable_static(def_id, ref tys, ref vtable_res) => {
-                fmt!("vtable_static(%?:%s, %?, %?)",
-                     def_id, ty::item_path_str(tcx, def_id),
-                     tys,
-                     vtable_res.map(|o| o.to_str(tcx)))
+                fmt!("vtable_static(%?:%s, %s, %s)",
+                     def_id,
+                     ty::item_path_str(tcx, def_id),
+                     tys.repr(tcx),
+                     vtable_res.repr(tcx))
             }
 
             vtable_param(x, y) => {
@@ -222,7 +224,7 @@ pub fn lookup_def_ccx(ccx: @mut CrateCtxt, sp: span, id: ast::node_id)
 
 pub fn no_params(t: ty::t) -> ty::ty_param_bounds_and_ty {
     ty::ty_param_bounds_and_ty {
-        generics: ty::Generics {bounds: @~[],
+        generics: ty::Generics {type_param_defs: @~[],
                                 region_param: None},
         ty: t
     }

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -83,6 +83,7 @@ pub mod middle {
         pub mod asm;
     }
     pub mod ty;
+    pub mod subst;
     pub mod resolve;
     #[path = "typeck/mod.rs"]
     pub mod typeck;

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -102,6 +102,16 @@ impl<T:Copy> OptVec<T> {
             self.push(copy *e);
         }
     }
+
+    #[inline(always)]
+    fn mapi_to_vec<B>(&self, op: &fn(uint, &T) -> B) -> ~[B] {
+        let mut index = 0;
+        iter::map_to_vec(self, |a| {
+            let i = index;
+            index += 1;
+            op(i, a)
+        })
+    }
 }
 
 impl<A:Eq> Eq for OptVec<A> {

--- a/src/test/run-pass/trait-inheritance-self-in-supertype.rs
+++ b/src/test/run-pass/trait-inheritance-self-in-supertype.rs
@@ -1,0 +1,61 @@
+// Test for issue #4183: use of Self in supertraits.
+
+pub static FUZZY_EPSILON: float = 0.1;
+
+pub trait FuzzyEq<Eps> {
+    fn fuzzy_eq(&self, other: &Self) -> bool;
+    fn fuzzy_eq_eps(&self, other: &Self, epsilon: &Eps) -> bool;
+}
+
+trait Float: FuzzyEq<Self> {
+    fn two_pi() -> Self;
+}
+
+impl FuzzyEq<f32> for f32 {
+    fn fuzzy_eq(&self, other: &f32) -> bool {
+        self.fuzzy_eq_eps(other, &(FUZZY_EPSILON as f32))
+    }
+
+    fn fuzzy_eq_eps(&self, other: &f32, epsilon: &f32) -> bool {
+        f32::abs(*self - *other) < *epsilon
+    }
+}
+
+impl Float for f32 {
+    fn two_pi() -> f32 { 6.28318530717958647692528676655900576_f32 }
+}
+
+impl FuzzyEq<f64> for f64 {
+    fn fuzzy_eq(&self, other: &f64) -> bool {
+        self.fuzzy_eq_eps(other, &(FUZZY_EPSILON as f64))
+    }
+
+    fn fuzzy_eq_eps(&self, other: &f64, epsilon: &f64) -> bool {
+        f64::abs(*self - *other) < *epsilon
+    }
+}
+
+impl Float for f64 {
+    fn two_pi() -> f64 { 6.28318530717958647692528676655900576_f64 }
+}
+
+fn compare<F:Float>(f1: F) -> bool {
+    let f2 = Float::two_pi();
+    f1.fuzzy_eq(&f2)
+}
+
+pub fn main() {
+    assert!(compare::<f32>(6.28318530717958647692528676655900576));
+    assert!(compare::<f32>(6.29));
+    assert!(compare::<f32>(6.3));
+    assert!(compare::<f32>(6.19));
+    assert!(!compare::<f32>(7.28318530717958647692528676655900576));
+    assert!(!compare::<f32>(6.18));
+
+    assert!(compare::<f64>(6.28318530717958647692528676655900576));
+    assert!(compare::<f64>(6.29));
+    assert!(compare::<f64>(6.3));
+    assert!(compare::<f64>(6.19));
+    assert!(!compare::<f64>(7.28318530717958647692528676655900576));
+    assert!(!compare::<f64>(6.18));
+}


### PR DESCRIPTION
Cleanup substitutions and treatment of generics around traits in a number of ways
- In a TraitRef, use the self type consistently to refer to the Self type:
  - trait ref in `impl Trait<A,B,C> for S` has a self type of `S`.
  - trait ref in `A:Trait` has the self type `A`
  - trait ref associated with a trait decl has self type `Self`
  - trait ref associated with a supertype has self type `Self`
  - trait ref in an object type `@Trait` has no self type
- Rewrite `each_bound_traits_and_supertraits` to perform
  substitutions as it goes, and thus yield a series of trait refs
  that are always in the same 'namespace' as the type parameter
  bound given as input.  Before, we left this to the caller, but
  this doesn't work because the caller lacks adequare information
  to perform the type substitutions correctly.
- For provided methods, substitute the generics involved in the provided
  method correctly.
- Introduce TypeParameterDef, which tracks the bounds declared on a type
  parameter and brings them together with the def_id and (in the future)
  other information (maybe even the parameter's name!).
- Introduce Subst trait, which helps to cleanup a lot of the
  repetitive code involved with doing type substitution.
- Introduce Repr trait, which makes debug printouts far more convenient.

Fixes #4183.  Needed for #5656.

r? @catamorphism
