### PR TITLE
Allow lint modes to be used on unused variables and dead assignments

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -83,9 +83,8 @@ pub enum lint {
 
     legacy_modes,
 
-    // FIXME(#3266)--make liveness warnings lintable
-    // unused_variable,
-    // dead_assignment
+    unused_variable,
+    dead_assignment,
 }
 
 pub fn level_to_str(lv: level) -> &'static str {
@@ -257,21 +256,19 @@ pub fn get_lint_dict() -> LintDict {
             default: deny
         }),
 
-        /* FIXME(#3266)--make liveness warnings lintable
-        (@~"unused_variable",
-         @LintSpec {
+        (~"unused_variable",
+         LintSpec {
             lint: unused_variable,
             desc: "detect variables which are not used in any way",
             default: warn
-         }),
+        }),
 
-        (@~"dead_assignment",
-         @LintSpec {
+        (~"dead_assignment",
+         LintSpec {
             lint: dead_assignment,
             desc: "detect assignments that will never be read",
             default: warn
-         }),
-        */
+        }),
     ];
     let mut map = HashMap::new();
     do vec::consume(v) |_, (k, v)| {

--- a/src/test/compile-fail/liveness-unused.rs
+++ b/src/test/compile-fail/liveness-unused.rs
@@ -8,38 +8,57 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[deny(unused_variable)];
+#[deny(dead_assignment)];
+
 fn f1(x: int) {
-    //~^ WARNING unused variable: `x`
+    //~^ ERROR unused variable: `x`
 }
 
 fn f1b(x: &mut int) {
-    //~^ WARNING unused variable: `x`
+    //~^ ERROR unused variable: `x`
 }
+
+#[allow(unused_variable)]
+fn f1c(x: int) {}
 
 fn f2() {
     let x = 3;
-    //~^ WARNING unused variable: `x`
+    //~^ ERROR unused variable: `x`
 }
 
 fn f3() {
     let mut x = 3;
-    //~^ WARNING variable `x` is assigned to, but never used
+    //~^ ERROR variable `x` is assigned to, but never used
     x += 4;
-    //~^ WARNING value assigned to `x` is never read
+    //~^ ERROR value assigned to `x` is never read
 }
 
 fn f3b() {
     let mut z = 3;
-    //~^ WARNING variable `z` is assigned to, but never used
+    //~^ ERROR variable `z` is assigned to, but never used
     loop {
         z += 4;
     }
 }
 
+#[allow(unused_variable)]
+fn f3c() {
+    let mut z = 3;
+    loop { z += 4; }
+}
+
+#[allow(unused_variable)]
+#[allow(dead_assignment)]
+fn f3d() {
+    let mut x = 3;
+    x += 4;
+}
+
 fn f4() {
     match Some(3) {
       Some(i) => {
-        //~^ WARNING unused variable: `i`
+        //~^ ERROR unused variable: `i`
       }
       None => {}
     }
@@ -57,16 +76,5 @@ fn f4b() -> int {
     }
 }
 
-// leave this in here just to trigger compile-fail:
-struct r {
-    x: (),
-}
-
-impl Drop for r {
-    fn finalize(&self) {}
-}
-
 fn main() {
-    let x = r { x: () };
-    || { copy x; }; //~ ERROR copying a value of non-copyable type
 }


### PR DESCRIPTION
This leaves the default lint modes at `warn`, but now the unused variable and dead assignment warnings are configurable on a per-item basis. As described in #3266, this just involved carrying around a couple ids to pass over to `span_lint`. I personally would prefer to keep the `_` prefix as well.

This closes #3266.
