### PR TITLE
vim: syntax highlight for inner doc comment

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -110,11 +110,11 @@ syn match     rustFloat       display "\<[0-9][0-9_]*\.[0-9_]\+\%([eE][+-]\=[0-9
 syn match     rustLifetime    display "\'\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"
 syn match   rustCharacter   "'\([^'\\]\|\\\(['nrt\\\"]\|x\x\{2}\|u\x\{4}\|U\x\{8}\)\)'"
 
-syn region    rustCommentDoc  start="/\*\*" end="\*/"
-syn region    rustCommentDoc  start="///" skip="\\$" end="$" keepend
+syn region    rustCommentDoc  start="/\*[\*!]" end="\*/"
+syn region    rustCommentDoc  start="//[/!]" skip="\\$" end="$" keepend
 syn match     rustComment     "/\*\*/"
-syn region    rustComment     start="/\*\([^\*]\|$\)" end="\*/" contains=rustTodo
-syn region    rustComment     start="//\([^/]\|$\)" skip="\\$" end="$" contains=rustTodo keepend
+syn region    rustComment     start="/\*\([^\*!]\|$\)" end="\*/" contains=rustTodo
+syn region    rustComment     start="//\([^/!]\|$\)" skip="\\$" end="$" contains=rustTodo keepend
 
 syn keyword rustTodo contained TODO FIXME XXX NB
 


### PR DESCRIPTION
Follow-up of #5760:
Add syntax highlight for `/*! doc */` or `//! doc`.
