### PR TITLE
LLVM versions

### DIFF
--- a/configure
+++ b/configure
@@ -533,7 +533,7 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-	(3.2svn|3.2|3.1svn|3.1|3.0svn|3.0)
+	(3.3|3.3svn|3.2|3.2svn)
 	    msg "found ok version of LLVM: $LLVM_VERSION"
 	    ;;
 	(*)


### PR DESCRIPTION
See my [post](https://mail.mozilla.org/pipermail/rust-dev/2013-April/003518.html) on the mailing list for details.

Also:
- 3.2 is newer than 3.2svn, so I changed the ordering. (3.2svn is the version used between 3.1 and 3.2.)
- 3.3svn is added. This is the version you currently get from compiling LLVM trunk.
- 3.3 is added. 3.3 is not released yet, but this is the version used by http://llvm.org/apt/.
