### PR TITLE
Add #[packed] attribute to create packed structs

### DIFF
--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -108,7 +108,7 @@ pub fn trans_inline_asm(bcx: block, ia: &ast::inline_asm) -> block {
     } else if numOutputs == 1 {
         val_ty(outputs[0])
     } else {
-        T_struct(outputs.map(|o| val_ty(*o)))
+        T_struct(outputs.map(|o| val_ty(*o)), false)
     };
 
     let dialect = match ia.dialect {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -938,7 +938,7 @@ pub fn get_landing_pad(bcx: block) -> BasicBlockRef {
     // The landing pad return type (the type being propagated). Not sure what
     // this represents but it's determined by the personality function and
     // this is what the EH proposal example uses.
-    let llretty = T_struct(~[T_ptr(T_i8()), T_i32()]);
+    let llretty = T_struct(~[T_ptr(T_i8()), T_i32()], false);
     // The exception handling personality function. This is the C++
     // personality function __gxx_personality_v0, wrapped in our naming
     // convention.
@@ -2837,7 +2837,7 @@ pub fn decl_gc_metadata(ccx: @CrateContext, llmod_id: &str) {
 }
 
 pub fn create_module_map(ccx: @CrateContext) -> ValueRef {
-    let elttype = T_struct(~[ccx.int_type, ccx.int_type]);
+    let elttype = T_struct(~[ccx.int_type, ccx.int_type], false);
     let maptype = T_array(elttype, ccx.module_data.len() + 1);
     let map = str::as_c_str(~"_rust_mod_map", |buf| {
         unsafe {
@@ -2877,7 +2877,7 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
     };
     let sym_name = ~"_rust_crate_map_" + mapname;
     let arrtype = T_array(int_type, n_subcrates as uint);
-    let maptype = T_struct(~[T_i32(), T_ptr(T_i8()), int_type, arrtype]);
+    let maptype = T_struct(~[T_i32(), T_ptr(T_i8()), int_type, arrtype], false);
     let map = str::as_c_str(sym_name, |buf| {
         unsafe {
             llvm::LLVMAddGlobal(llmod, maptype, buf)

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -106,7 +106,8 @@ fn shim_types(ccx: @CrateContext, id: ast::node_id) -> ShimTypes {
     };
     let llsig = foreign_signature(ccx, &fn_sig);
     let bundle_ty = T_struct(vec::append_one(copy llsig.llarg_tys,
-                                             T_ptr(llsig.llret_ty)));
+                                             T_ptr(llsig.llret_ty)),
+                             false);
     let ret_def =
         !ty::type_is_bot(fn_sig.output) &&
         !ty::type_is_nil(fn_sig.output);

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -142,9 +142,9 @@ pub fn static_size_of_enum(cx: @CrateContext, t: ty::t) -> uint {
 
                 debug!("static_size_of_enum: variant %s type %s",
                        *cx.tcx.sess.str_of(variant.name),
-                       ty_str(cx.tn, T_struct(lltypes)));
+                       ty_str(cx.tn, T_struct(lltypes, false)));
 
-                let this_size = llsize_of_real(cx, T_struct(lltypes));
+                let this_size = llsize_of_real(cx, T_struct(lltypes, false));
                 if max_size < this_size {
                     max_size = this_size;
                 }

--- a/src/test/compile-fail/packed-struct-generic-transmute.rs
+++ b/src/test/compile-fail/packed-struct-generic-transmute.rs
@@ -1,0 +1,35 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This assumes the packed and non-packed structs are different sizes.
+
+// the error points to the start of the file, not the line with the
+// transmute
+
+// error-pattern: reinterpret_cast called on types with different size
+
+#[packed]
+struct Foo<T,S> {
+    bar: T,
+    baz: S
+}
+
+struct Oof<T, S> {
+    rab: T,
+    zab: S
+}
+
+fn main() {
+    let foo = Foo { bar: [1u8, 2, 3, 4, 5], baz: 10i32 };
+    unsafe {
+        let oof: Oof<[u8, .. 5], i32> = cast::transmute(foo);
+        debug!(oof);
+    }
+}

--- a/src/test/compile-fail/packed-struct-transmute.rs
+++ b/src/test/compile-fail/packed-struct-transmute.rs
@@ -1,0 +1,35 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This assumes the packed and non-packed structs are different sizes.
+
+// the error points to the start of the file, not the line with the
+// transmute
+
+// error-pattern: reinterpret_cast called on types with different size
+
+#[packed]
+struct Foo {
+    bar: u8,
+    baz: uint
+}
+
+struct Oof {
+    rab: u8,
+    zab: uint
+}
+
+fn main() {
+    let foo = Foo { bar: 1, baz: 10 };
+    unsafe {
+        let oof: Oof = cast::transmute(foo);
+        debug!(oof);
+    }
+}

--- a/src/test/run-pass/packed-struct-borrow-element.rs
+++ b/src/test/run-pass/packed-struct-borrow-element.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct Foo {
+    bar: u8,
+    baz: uint
+}
+
+fn main() {
+    let foo = Foo { bar: 1, baz: 2 };
+    let brw = &foo.baz;
+
+    assert_eq!(*brw, 2);
+}

--- a/src/test/run-pass/packed-struct-generic-layout.rs
+++ b/src/test/run-pass/packed-struct-generic-layout.rs
@@ -1,0 +1,35 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S<T, S> {
+    a: T,
+    b: u8,
+    c: S
+}
+
+fn main() {
+    unsafe {
+        let s = S { a: 0xff_ff_ff_ffu32, b: 1, c: 0xaa_aa_aa_aa as i32 };
+        let transd : [u8, .. 9] = cast::transmute(s);
+        // Don't worry about endianness, the numbers are palindromic.
+        assert_eq!(transd,
+                   [0xff, 0xff, 0xff, 0xff,
+                    1,
+                    0xaa, 0xaa, 0xaa, 0xaa]);
+
+
+        let s = S { a: 1u8, b: 2u8, c: 0b10000001_10000001 as i16};
+        let transd : [u8, .. 4] = cast::transmute(s);
+        // Again, no endianness problems.
+        assert_eq!(transd,
+                   [1, 2, 0b10000001, 0b10000001]);
+    }
+}

--- a/src/test/run-pass/packed-struct-generic-size.rs
+++ b/src/test/run-pass/packed-struct-generic-size.rs
@@ -1,0 +1,25 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S<T, S> {
+    a: T,
+    b: u8,
+    c: S
+}
+
+fn main() {
+    assert_eq!(sys::size_of::<S<u8, u8>>(), 3);
+
+    assert_eq!(sys::size_of::<S<u64, u16>>(), 11);
+
+    assert_eq!(sys::size_of::<S<~str, @mut [int]>>(),
+               1 + sys::size_of::<~str>() + sys::size_of::<@mut [int]>());
+}

--- a/src/test/run-pass/packed-struct-layout.rs
+++ b/src/test/run-pass/packed-struct-layout.rs
@@ -1,0 +1,34 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S4 {
+    a: u8,
+    b: [u8, .. 3],
+}
+
+#[packed]
+struct S5 {
+    a: u8,
+    b: u32
+}
+
+fn main() {
+    unsafe {
+        let s4 = S4 { a: 1, b: [2,3,4] };
+        let transd : [u8, .. 4] = cast::transmute(s4);
+        assert_eq!(transd, [1, 2, 3, 4]);
+
+        let s5 = S5 { a: 1, b: 0xff_00_00_ff };
+        let transd : [u8, .. 5] = cast::transmute(s5);
+        // Don't worry about endianness, the u32 is palindromic.
+        assert_eq!(transd, [1, 0xff, 0, 0, 0xff]);
+    }
+}

--- a/src/test/run-pass/packed-struct-match.rs
+++ b/src/test/run-pass/packed-struct-match.rs
@@ -1,0 +1,25 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct Foo {
+    bar: u8,
+    baz: uint
+}
+
+fn main() {
+    let foo = Foo { bar: 1, baz: 2 };
+    match foo {
+        Foo {bar, baz} => {
+            assert_eq!(bar, 1);
+            assert_eq!(baz, 2);
+        }
+    }
+}

--- a/src/test/run-pass/packed-struct-size.rs
+++ b/src/test/run-pass/packed-struct-size.rs
@@ -1,0 +1,58 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S4 {
+    a: u8,
+    b: [u8, .. 3],
+}
+
+#[packed]
+struct S5 {
+    a: u8,
+    b: u32
+}
+
+#[packed]
+struct S13_str {
+    a: i64,
+    b: f32,
+    c: u8,
+    d: ~str
+}
+
+enum Foo {
+    Bar = 1,
+    Baz = 2
+}
+
+#[packed]
+struct S3_Foo {
+    a: u8,
+    b: u16,
+    c: Foo
+}
+
+#[packed]
+struct S7_Option {
+    a: f32,
+    b: u8,
+    c: u16,
+    d: Option<@mut f64>
+}
+
+
+fn main() {
+    assert_eq!(sys::size_of::<S4>(), 4);
+    assert_eq!(sys::size_of::<S5>(), 5);
+    assert_eq!(sys::size_of::<S13_str>(), 13 + sys::size_of::<~str>());
+    assert_eq!(sys::size_of::<S3_Foo>(), 3 + sys::size_of::<Foo>());
+    assert_eq!(sys::size_of::<S7_Option>(), 7 + sys::size_of::<Option<@mut f64>>());
+}

--- a/src/test/run-pass/packed-struct-vec.rs
+++ b/src/test/run-pass/packed-struct-vec.rs
@@ -1,0 +1,30 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+#[deriving(Eq)]
+struct Foo {
+    bar: u8,
+    baz: u64
+}
+
+fn main() {
+    let foos = [Foo { bar: 1, baz: 2 }, .. 10];
+
+    assert_eq!(sys::size_of::<[Foo, .. 10]>(), 90);
+
+    for uint::range(0, 10) |i| {
+        assert_eq!(foos[i], Foo { bar: 1, baz: 2});
+    }
+
+    for foos.each |&foo| {
+        assert_eq!(foo, Foo { bar: 1, baz: 2 });
+    }
+}

--- a/src/test/run-pass/packed-tuple-struct-layout.rs
+++ b/src/test/run-pass/packed-tuple-struct-layout.rs
@@ -1,0 +1,28 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S4(u8,[u8, .. 3]);
+
+#[packed]
+struct S5(u8,u32);
+
+fn main() {
+    unsafe {
+        let s4 = S4(1, [2,3,4]);
+        let transd : [u8, .. 4] = cast::transmute(s4);
+        assert_eq!(transd, [1, 2, 3, 4]);
+
+        let s5 = S5(1, 0xff_00_00_ff);
+        let transd : [u8, .. 5] = cast::transmute(s5);
+        // Don't worry about endianness, the u32 is palindromic.
+        assert_eq!(transd, [1, 0xff, 0, 0, 0xff]);
+    }
+}

--- a/src/test/run-pass/packed-tuple-struct-size.rs
+++ b/src/test/run-pass/packed-tuple-struct-size.rs
@@ -1,0 +1,44 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[packed]
+struct S4(u8,[u8, .. 3]);
+
+#[packed]
+struct S5(u8, u32);
+
+#[packed]
+struct S13_str(i64, f32, u8, ~str);
+
+enum Foo {
+    Bar = 1,
+    Baz = 2
+}
+
+#[packed]
+struct S3_Foo(u8, u16, Foo);
+
+#[packed]
+struct S7_Option(f32, u8, u16, Option<@mut f64>);
+
+fn main() {
+    assert_eq!(sys::size_of::<S4>(), 4);
+
+    assert_eq!(sys::size_of::<S5>(), 5);
+
+    assert_eq!(sys::size_of::<S13_str>(),
+               13 + sys::size_of::<~str>());
+
+    assert_eq!(sys::size_of::<S3_Foo>(),
+               3 + sys::size_of::<Foo>());
+
+    assert_eq!(sys::size_of::<S7_Option>(),
+              7 + sys::size_of::<Option<@mut f64>>());
+}


### PR DESCRIPTION
#5758 take 2.

This adds a `#[packed]` attribute for structs, like GCC's `__attribute__((packed))`, e.g.

``` rust
#[packed]
struct Size5 {
   a: u8,
   b: u32
}
```

It works on normal and tuple structs, but is (silently) ignored on enums.

Closes #1704.
