### PR TITLE
Add debug info for boxes, vectors, and strings

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -131,6 +131,13 @@ impl get_insn_ctxt for fn_ctxt {
     }
 }
 
+fn fcx_has_nonzero_span(fcx: fn_ctxt) -> bool {
+    match fcx.span {
+        None => true,
+        Some(span) => *span.lo != 0 || *span.hi != 0
+    }
+}
+
 pub fn log_fn_time(ccx: @CrateContext, +name: ~str, start: time::Timespec,
                    end: time::Timespec) {
     let elapsed = 1000 * ((end.sec - start.sec) as int) +
@@ -1158,7 +1165,8 @@ pub fn trans_stmt(cx: block, s: ast::stmt) -> block {
                 ast::decl_local(ref locals) => {
                     for locals.each |local| {
                         bcx = init_local(bcx, *local);
-                        if cx.sess().opts.extra_debuginfo {
+                        if cx.sess().opts.extra_debuginfo
+                            && fcx_has_nonzero_span(bcx.fcx) {
                             debuginfo::create_local_var(bcx, *local);
                         }
                     }
@@ -1738,7 +1746,7 @@ pub fn copy_args_to_allocas(fcx: fn_ctxt,
 
         fcx.llargs.insert(arg_id, local_mem(llarg));
 
-        if fcx.ccx.sess.opts.extra_debuginfo {
+        if fcx.ccx.sess.opts.extra_debuginfo && fcx_has_nonzero_span(fcx) {
             debuginfo::create_arg(bcx, args[arg_n], args[arg_n].ty.span);
         }
     }
@@ -1861,7 +1869,8 @@ pub fn trans_fn(ccx: @CrateContext,
     trans_closure(ccx, path, decl, body, llfndecl, ty_self,
                   param_substs, id, impl_id,
                   |fcx| {
-                      if ccx.sess.opts.extra_debuginfo {
+                      if ccx.sess.opts.extra_debuginfo
+                          && fcx_has_nonzero_span(fcx) {
                           debuginfo::create_function(fcx);
                       }
                   },

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -946,7 +946,7 @@ pub fn create_arg(bcx: block, arg: ast::arg, sp: span)
 }
 
 pub fn update_source_pos(cx: block, s: span) {
-    if !cx.sess().opts.debuginfo {
+    if !cx.sess().opts.debuginfo || (*s.lo == 0 && *s.hi == 0) {
         return;
     }
     let cm = cx.sess().codemap;

--- a/src/test/debug-info/box.rs
+++ b/src/test/debug-info/box.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test
+
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break 29

--- a/src/test/debug-info/box.rs
+++ b/src/test/debug-info/box.rs
@@ -1,0 +1,30 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-Z extra-debug-info
+// debugger:set print pretty off
+// debugger:break 29
+// debugger:run
+// debugger:print a->boxed
+// check:$1 = 1
+// debugger:print b->boxed
+// check:$2 = {2, 3.5}
+// debugger:print c->boxed
+// check:$3 = 4
+// debugger:print d->boxed
+// check:$4 = false
+
+fn main() {
+    let a = ~1;
+    let b = ~(2, 3.5);
+    let c = @4;
+    let d = @false;
+    let _z = 0;
+}

--- a/src/test/debug-info/vec.rs
+++ b/src/test/debug-info/vec.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test
+
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break 29

--- a/src/test/debug-info/vec.rs
+++ b/src/test/debug-info/vec.rs
@@ -1,0 +1,30 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-Z extra-debug-info
+// debugger:set print pretty off
+// debugger:break 29
+// debugger:run
+// debugger:print a
+// check:$1 = {1, 2, 3}
+// debugger:print b.vec[0]
+// check:$2 = 4
+// debugger:print c->boxed.data[1]
+// check:$3 = 8
+// debugger:print d->boxed.data[2]
+// check:$4 = 12
+
+fn main() {
+    let a = [1, 2, 3];
+    let b = &[4, 5, 6];
+    let c = @[7, 8, 9];
+    let d = ~[10, 11, 12];
+    let _z = 0;
+}


### PR DESCRIPTION
This adds debugging symbol generation for boxes, bare functions, vectors, and strings, along with a tests for boxes and vectors.

Note that gdb will see them as their actual compiled representation with the refcount, tydesc, etc. fields, so if `b` refers to box, `b->boxed` will refer to its value. Also, since you seem to use the [C struct hack](http://c-faq.com/struct/structhack.html) for dynamic vectors, you won't be able to print out the whole vector at once, only one element at a time by indexing specific elements.
