### PR TITLE
Bump version to 0.7-pre

### DIFF
--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -17,8 +17,8 @@
 #[allow(deprecated_mode)];
 #[allow(deprecated_pattern)];
 
-extern mod core(vers = "0.7-rc");
-extern mod std(vers = "0.7-rc");
+extern mod core(vers = "0.7-pre");
+extern mod std(vers = "0.7-pre");
 
 use core::*;
 

--- a/src/driver/driver.rs
+++ b/src/driver/driver.rs
@@ -9,24 +9,24 @@
 // except according to those terms.
 
 #[no_core];
-extern mod core(vers = "0.7-rc");
+extern mod core(vers = "0.7-pre");
 
 #[cfg(rustpkg)]
-extern mod this(name = "rustpkg", vers = "0.7-rc");
+extern mod this(name = "rustpkg", vers = "0.7-pre");
 
 #[cfg(fuzzer)]
-extern mod this(name = "fuzzer", vers = "0.7-rc");
+extern mod this(name = "fuzzer", vers = "0.7-pre");
 
 #[cfg(rustdoc)]
-extern mod this(name = "rustdoc", vers = "0.7-rc");
+extern mod this(name = "rustdoc", vers = "0.7-pre");
 
 #[cfg(rusti)]
-extern mod this(name = "rusti", vers = "0.7-rc");
+extern mod this(name = "rusti", vers = "0.7-pre");
 
 #[cfg(rust)]
-extern mod this(name = "rust", vers = "0.7-rc");
+extern mod this(name = "rust", vers = "0.7-pre");
 
 #[cfg(rustc)]
-extern mod this(name = "rustc", vers = "0.7-rc");
+extern mod this(name = "rustc", vers = "0.7-pre");
 
 fn main() { this::main() }

--- a/src/etc/kate/rust.xml
+++ b/src/etc/kate/rust.xml
@@ -7,7 +7,7 @@
 	<!ENTITY rustIdent "[a-zA-Z_][a-zA-Z_0-9]*">
 	<!ENTITY rustIntSuf "([iu](8|16|32|64)?)?">
 ]>
-<language name="Rust" version="0.7-rc" kateversion="2.4" section="Sources" extensions="*.rs;*.rc" mimetype="text/x-rust" priority="15">
+<language name="Rust" version="0.7-pre" kateversion="2.4" section="Sources" extensions="*.rs;*.rc" mimetype="text/x-rust" priority="15">
 <highlighting>
 	<list name="fn">
 		<item> fn </item>

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -48,7 +48,7 @@ they contained the following prologue:
 
 
 #[link(name = "core",
-       vers = "0.7-rc",
+       vers = "0.7-pre",
        uuid = "c70c24a7-5551-4f73-8e37-380b11d80be8",
        url = "https://github.com/mozilla/rust/tree/master/src/libcore")];
 
@@ -66,7 +66,7 @@ they contained the following prologue:
 #[allow(deprecated_drop)];
 
 // Make core testable by not duplicating lang items. See #2912
-#[cfg(test)] extern mod realcore(name = "core", vers = "0.7-rc");
+#[cfg(test)] extern mod realcore(name = "core", vers = "0.7-pre");
 #[cfg(test)] pub use kinds = realcore::kinds;
 #[cfg(test)] pub use ops = realcore::ops;
 #[cfg(test)] pub use cmp = realcore::cmp;

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -10,7 +10,7 @@
 
 
 #[link(name = "fuzzer",
-       vers = "0.7-rc",
+       vers = "0.7-pre",
        uuid = "d6418797-2736-4833-bd82-d3c684b7c1b0",
        url = "https://github.com/mozilla/rust/tree/master/src/libfuzzer")];
 
@@ -26,9 +26,9 @@
 #[allow(deprecated_mode)];
 #[allow(deprecated_pattern)];
 
-extern mod core(vers = "0.7-rc");
-extern mod std(vers = "0.7-rc");
-extern mod syntax(vers = "0.7-rc");
+extern mod core(vers = "0.7-pre");
+extern mod std(vers = "0.7-pre");
+extern mod syntax(vers = "0.7-pre");
 
 use core::*;
 use core::io::WriterUtil;

--- a/src/librust/rust.rc
+++ b/src/librust/rust.rc
@@ -13,14 +13,14 @@
 // FIXME #2238 Make run only accept source that emits an executable
 
 #[link(name = "rust",
-       vers = "0.7-rc",
+       vers = "0.7-pre",
        uuid = "4a24da33-5cc8-4037-9352-2cbe9bd9d27c",
        url = "https://github.com/mozilla/rust/tree/master/src/rust")];
 
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-extern mod core(vers = "0.7-rc");
+extern mod core(vers = "0.7-pre");
 
 use core::run;
 

--- a/src/librustc/front/core_inject.rs
+++ b/src/librustc/front/core_inject.rs
@@ -19,7 +19,7 @@ use syntax::codemap;
 use syntax::codemap::dummy_sp;
 use syntax::fold;
 
-static CORE_VERSION: &'static str = "0.7-rc";
+static CORE_VERSION: &'static str = "0.7-pre";
 
 pub fn maybe_inject_libcore_ref(sess: Session,
                                 crate: @ast::crate) -> @ast::crate {

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -265,7 +265,7 @@ mod __test {
 */
 
 fn mk_std(cx: &TestCtxt) -> @ast::view_item {
-    let vers = ast::lit_str(@~"0.7-rc");
+    let vers = ast::lit_str(@~"0.7-pre");
     let vers = nospan(vers);
     let mi = ast::meta_name_value(@~"vers", vers);
     let mi = nospan(mi);

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -10,7 +10,7 @@
 
 
 #[link(name = "rustc",
-       vers = "0.7-rc",
+       vers = "0.7-pre",
        uuid = "0ce89b41-2f92-459e-bbc1-8f5fe32f16cf",
        url = "https://github.com/mozilla/rust/tree/master/src/rustc")];
 
@@ -27,9 +27,9 @@
 
 #[no_core];
 
-extern mod core(vers = "0.7-rc");
-extern mod std(vers = "0.7-rc");
-extern mod syntax(vers = "0.7-rc");
+extern mod core(vers = "0.7-pre");
+extern mod std(vers = "0.7-pre");
+extern mod syntax(vers = "0.7-pre");
 
 use core::prelude::*;
 

--- a/src/librustdoc/rustdoc.rc
+++ b/src/librustdoc/rustdoc.rc
@@ -11,7 +11,7 @@
 //! Rustdoc - The Rust documentation generator
 
 #[link(name = "rustdoc",
-       vers = "0.7-rc",
+       vers = "0.7-pre",
        uuid = "f8abd014-b281-484d-a0c3-26e3de8e2412",
        url = "https://github.com/mozilla/rust/tree/master/src/rustdoc")];
 
@@ -23,10 +23,10 @@
 
 #[allow(non_implicitly_copyable_typarams)];
 
-extern mod core(vers = "0.7-rc");
-extern mod std(vers = "0.7-rc");
-extern mod rustc(vers = "0.7-rc");
-extern mod syntax(vers = "0.7-rc");
+extern mod core(vers = "0.7-pre");
+extern mod std(vers = "0.7-pre");
+extern mod rustc(vers = "0.7-pre");
+extern mod syntax(vers = "0.7-pre");
 
 use config::Config;
 use doc::Item;

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -11,7 +11,7 @@
 // rusti - REPL using the JIT backend
 
 #[link(name = "rusti",
-       vers = "0.7-rc",
+       vers = "0.7-pre",
        uuid = "7fb5bf52-7d45-4fee-8325-5ad3311149fc",
        url = "https://github.com/mozilla/rust/tree/master/src/rusti")];
 
@@ -23,10 +23,10 @@
 #[allow(vecs_implicitly_copyable,
         non_implicitly_copyable_typarams)];
 
-extern mod core(vers = "0.7-rc");
-extern mod std(vers = "0.7-rc");
-extern mod rustc(vers = "0.7-rc");
-extern mod syntax(vers = "0.7-rc");
+extern mod core(vers = "0.7-pre");
+extern mod std(vers = "0.7-pre");
+extern mod rustc(vers = "0.7-pre");
+extern mod syntax(vers = "0.7-pre");
 
 use core::*;
 use core::io::WriterUtil;

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -11,7 +11,7 @@
 // rustpkg - a purely function package manager and build system
 
 #[link(name = "rustpkg",
-       vers = "0.7-rc",
+       vers = "0.7-pre",
        uuid = "25de5e6e-279e-4a20-845c-4cabae92daaf",
        url = "https://github.com/mozilla/rust/tree/master/src/librustpkg")];
 
@@ -21,10 +21,10 @@
 #[allow(vecs_implicitly_copyable,
         non_implicitly_copyable_typarams)];
 
-extern mod core(vers = "0.7-rc");
-extern mod std(vers = "0.7-rc");
-extern mod rustc(vers = "0.7-rc");
-extern mod syntax(vers = "0.7-rc");
+extern mod core(vers = "0.7-pre");
+extern mod std(vers = "0.7-pre");
+extern mod rustc(vers = "0.7-pre");
+extern mod syntax(vers = "0.7-pre");
 
 use core::*;
 use core::container::Map;

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -140,7 +140,7 @@ fn add_pkg_module(ctx: @mut ReadyCtx, m: ast::_mod) -> ast::_mod {
     let ext_cx = ctx.ext_cx;
     let item = quote_item! (
         mod __pkg {
-            extern mod rustpkg (vers="0.7-rc");
+            extern mod rustpkg (vers="0.7-pre");
             static listeners : &[rustpkg::Listener] = $listeners;
             #[main]
             fn main() {

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -18,7 +18,7 @@ not required in or otherwise suitable for the core library.
 */
 
 #[link(name = "std",
-       vers = "0.7-rc",
+       vers = "0.7-pre",
        uuid = "122bed0b-c19b-4b82-b0b7-7ae8aead7297",
        url = "https://github.com/mozilla/rust/tree/master/src/libstd")];
 
@@ -32,7 +32,7 @@ not required in or otherwise suitable for the core library.
 
 #[no_core];
 
-extern mod core(vers = "0.7-rc");
+extern mod core(vers = "0.7-pre");
 use core::prelude::*;
 
 pub mod uv_ll;

--- a/src/libsyntax/syntax.rc
+++ b/src/libsyntax/syntax.rc
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #[link(name = "syntax",
-       vers = "0.7-rc",
+       vers = "0.7-pre",
        uuid = "9311401b-d6ea-4cd9-a1d9-61f89499c645")];
 
 
@@ -25,8 +25,8 @@
 
 #[no_core];
 
-extern mod core(vers = "0.7-rc");
-extern mod std(vers = "0.7-rc");
+extern mod core(vers = "0.7-pre");
+extern mod std(vers = "0.7-pre");
 
 use core::*;
 

--- a/src/test/run-pass/use.rs
+++ b/src/test/run-pass/use.rs
@@ -13,7 +13,7 @@
 #[no_core];
 extern mod core;
 extern mod zed(name = "core");
-extern mod bar(name = "core", vers = "0.7-rc");
+extern mod bar(name = "core", vers = "0.7-pre");
 
 
 use core::str;


### PR DESCRIPTION
I accidentally changed the version to `0.7-rc` when `0.7-pre` is what @graydon and I agreed on. This fixes.
