### PR TITLE
Add check for 'file' command which is necessary for 32-bit userspace detection.

### DIFF
--- a/configure
+++ b/configure
@@ -237,7 +237,7 @@ need_cmd uname
 need_cmd date
 need_cmd tr
 need_cmd sed
-
+need_cmd file
 
 msg "inspecting environment"
 


### PR DESCRIPTION
Without 'file' it assumes a 32 bit userspace even with a 64 bit kernel, which is incorrect in most cases.
