### PR TITLE
SIMD for Rust

### DIFF
--- a/src/libcore/num/int-template.rs
+++ b/src/libcore/num/int-template.rs
@@ -122,7 +122,7 @@ pub fn range_rev(hi: T, lo: T, it: &fn(T) -> bool) {
 /// Computes the bitwise complement
 #[inline(always)]
 pub fn compl(i: T) -> T {
-    -1 as T ^ i
+    i ^ (-1 as T)
 }
 
 /// Computes the absolute value

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -292,6 +292,9 @@ fn enc_sty(w: @io::Writer, cx: @ctxt, st: ty::sty) {
         w.write_char('v');
         enc_vstore(w, cx, v);
       }
+      ty::ty_multi(*) => {
+        fail!();
+      }
       ty::ty_unboxed_vec(mt) => { w.write_char('U'); enc_mt(w, cx, mt); }
       ty::ty_closure(ref f) => {
         w.write_char('f');

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -963,20 +963,28 @@ pub fn ExtractElement(cx: block, VecVal: ValueRef, Index: ValueRef) ->
 }
 
 pub fn InsertElement(cx: block, VecVal: ValueRef, EltVal: ValueRef,
-                 Index: ValueRef) {
+                     Index: ValueRef) -> ValueRef {
     unsafe {
-        if cx.unreachable { return; }
+        if cx.unreachable { return llvm::LLVMGetUndef(T_nil()); }
         count_insn(cx, "insertelement");
-        llvm::LLVMBuildInsertElement(B(cx), VecVal, EltVal, Index, noname());
+        llvm::LLVMBuildInsertElement(B(cx), VecVal, EltVal, Index, noname())
     }
 }
 
 pub fn ShuffleVector(cx: block, V1: ValueRef, V2: ValueRef,
-                     Mask: ValueRef) {
+                     Mask: ValueRef) -> ValueRef {
     unsafe {
-        if cx.unreachable { return; }
+        if cx.unreachable { return llvm::LLVMGetUndef(T_nil()); }
         count_insn(cx, "shufflevector");
-        llvm::LLVMBuildShuffleVector(B(cx), V1, V2, Mask, noname());
+        llvm::LLVMBuildShuffleVector(B(cx), V1, V2, Mask, noname())
+    }
+}
+
+pub fn VectorSplat(cx: block, NumElts: uint, EltVal: ValueRef) -> ValueRef {
+    unsafe {
+        let Undef = llvm::LLVMGetUndef(T_vector(val_ty(EltVal), NumElts));
+        let VecVal = InsertElement(cx, Undef, EltVal, C_i32(0));
+        ShuffleVector(cx, VecVal, Undef, C_null(T_vector(T_i32(), NumElts)))
     }
 }
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -984,6 +984,12 @@ pub fn T_array(t: TypeRef, n: uint) -> TypeRef {
     }
 }
 
+pub fn T_vector(t: TypeRef, n: uint) -> TypeRef {
+    unsafe {
+        return llvm::LLVMVectorType(t, n as c_uint);
+    }
+}
+
 // Interior vector.
 pub fn T_vec2(targ_cfg: @session::config, t: TypeRef) -> TypeRef {
     return T_struct(~[T_int(targ_cfg), // fill

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1379,7 +1379,7 @@ fn trans_eager_binop(bcx: block,
         if ty::type_is_bot(lhs_t) { rhs_t }
         else { lhs_t }
     };
-    let is_float = ty::type_is_fp(intype);
+    let is_float = ty::type_uses_fp(intype);
 
     let rhs = base::cast_shift_expr_rhs(bcx, op, lhs, rhs);
 

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1589,6 +1589,7 @@ pub enum cast_kind {
     cast_integral,
     cast_float,
     cast_enum,
+    cast_multi,
     cast_other,
 }
 
@@ -1601,6 +1602,7 @@ pub fn cast_type_kind(t: ty::t) -> cast_kind {
         ty::ty_uint(*)    => cast_integral,
         ty::ty_bool       => cast_integral,
         ty::ty_enum(*)    => cast_enum,
+        ty::ty_multi(*)   => cast_multi,
         _                 => cast_other
     }
 }
@@ -1661,6 +1663,10 @@ fn trans_imm_cast(bcx: block, expr: @ast::expr,
                     cast_float => SIToFP(bcx, lldiscrim_a, ll_t_out),
                     _ => ccx.sess.bug(~"translating unsupported cast.")
                 }
+            }
+            (cast_integral, cast_multi) |
+            (cast_float, cast_multi) => {
+                VectorSplat(bcx, ty::multi_size(t_out), llexpr)
             }
             _ => ccx.sess.bug(~"translating unsupported cast.")
         };

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -188,6 +188,9 @@ pub impl Reflector {
               let extra = extra + self.c_mt(mt);
               self.visit(~"evec_" + name, extra)
           }
+          ty::ty_multi(*) => {
+              fail!();
+          }
           ty::ty_box(ref mt) => {
               let extra = self.c_mt(mt);
               self.visit(~"box", extra)

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -146,6 +146,9 @@ pub fn sizing_type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
         ty::ty_evec(mt, ty::vstore_fixed(size)) => {
             T_array(sizing_type_of(cx, mt.ty), size)
         }
+        ty::ty_multi(t, n) => {
+            T_vector(sizing_type_of(cx, t), n)
+        }
 
         ty::ty_unboxed_vec(mt) => T_vec(cx, sizing_type_of(cx, mt.ty)),
 
@@ -251,6 +254,10 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
 
       ty::ty_evec(ref mt, ty::vstore_fixed(n)) => {
         T_array(type_of(cx, mt.ty), n)
+      }
+
+      ty::ty_multi(t, n) => {
+        T_vector(type_of(cx, t), n)
       }
 
       ty::ty_bare_fn(_) => T_ptr(type_of_fn_from_ty(cx, t)),

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2410,6 +2410,14 @@ pub fn type_is_fp(ty: t) -> bool {
     }
 }
 
+pub fn type_uses_fp(ty: t) -> bool {
+    match get(ty).sty {
+        ty_infer(FloatVar(_)) | ty_float(_) => true,
+        ty_multi(t, _) => type_uses_fp(t),
+        _ => false
+    }
+}
+
 pub fn type_is_numeric(ty: t) -> bool {
     return type_is_integral(ty) || type_is_fp(ty);
 }
@@ -4143,6 +4151,7 @@ pub fn is_binopable(_cx: ctxt, ty: t, op: ast::binop) -> bool {
           ty_bool => tycat_bool,
           ty_int(_) | ty_uint(_) | ty_infer(IntVar(_)) => tycat_int,
           ty_float(_) | ty_infer(FloatVar(_)) => tycat_float,
+          ty_multi(ty, _) => tycat(ty),
           ty_tup(_) | ty_enum(_, _) => tycat_struct,
           ty_bot => tycat_bot,
           _ => tycat_other

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1581,6 +1581,13 @@ pub fn type_is_sequence(ty: t) -> bool {
     }
 }
 
+pub fn type_is_multi(ty: t) -> bool {
+    match get(ty).sty {
+        ty_multi(*) => true,
+        _ => false
+    }
+}
+
 pub fn type_is_str(ty: t) -> bool {
     match get(ty).sty {
       ty_estr(_) => true,
@@ -1594,6 +1601,20 @@ pub fn sequence_element_type(cx: ctxt, ty: t) -> t {
       ty_evec(mt, _) | ty_unboxed_vec(mt) => return mt.ty,
       _ => cx.sess.bug(
           ~"sequence_element_type called on non-sequence value"),
+    }
+}
+
+pub fn multi_type(ty: t) -> t {
+    match get(ty).sty {
+        ty_multi(t, _) => t,
+        _ => fail!(~"multi_type called on invalid type")
+    }
+}
+
+pub fn multi_size(ty: t) -> uint {
+    match get(ty).sty {
+        ty_multi(_, n) => n,
+        _ => fail!(~"multi_size called on invalid type")
     }
 }
 
@@ -1680,8 +1701,8 @@ pub fn type_is_scalar(ty: t) -> bool {
 }
 
 pub fn type_is_immediate(ty: t) -> bool {
-    return type_is_scalar(ty) || type_is_boxed(ty) ||
-        type_is_unique(ty) || type_is_region_ptr(ty);
+    return type_is_scalar(ty) || type_is_multi(ty) ||
+        type_is_boxed(ty) || type_is_unique(ty) || type_is_region_ptr(ty);
 }
 
 pub fn type_needs_drop(cx: ctxt, ty: t) -> bool {

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -477,6 +477,9 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + Durable>(
           }
         }
       }
+      ast::ty_multi(*) => {
+        fail!();
+      }
       ast::ty_infer => {
         // ty_infer should only appear as the type of arguments or return
         // values in a fn_expr, or as the type of local variables.  Both of

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -477,8 +477,8 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + Durable>(
           }
         }
       }
-      ast::ty_multi(*) => {
-        fail!();
+      ast::ty_multi(t, n) => {
+        ty::mk_multi(tcx, ast_ty_to_ty(self, rscope, t), n)
       }
       ast::ty_infer => {
         // ty_infer should only appear as the type of arguments or return

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -783,8 +783,8 @@ pub impl<'self> LookupContext<'self> {
             ty_infer(IntVar(_)) |
             ty_infer(FloatVar(_)) |
             ty_self(_) | ty_param(*) | ty_nil | ty_bot | ty_bool |
-            ty_int(*) | ty_uint(*) |
-            ty_float(*) | ty_enum(*) | ty_ptr(*) | ty_struct(*) | ty_tup(*) |
+            ty_int(*) | ty_uint(*) | ty_float(*) | ty_multi(*) |
+            ty_enum(*) | ty_ptr(*) | ty_struct(*) | ty_tup(*) |
             ty_estr(*) | ty_evec(*) | ty_trait(*) | ty_closure(*) => {
                 self.search_for_some_kind_of_autorefd_method(
                     AutoPtr, autoderefs, [m_const, m_imm, m_mutbl],

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2636,6 +2636,9 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                     if type_is_c_like_enum(fcx,expr.span,t_e)
                         && t_1_is_scalar {
                         /* this case is allowed */
+                    } else if ty::type_is_multi(t_1) {
+                        demand::suptype(fcx, e.span,
+                                        ty::multi_type(t_1), t_e);
                     } else if type_is_region_ptr(fcx, expr.span, t_e) &&
                         type_is_unsafe_ptr(fcx, expr.span, t_1) {
 

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -27,7 +27,7 @@ use middle::ty::{lookup_item_type, subst};
 use middle::ty::{substs, t, ty_bool, ty_bot, ty_box, ty_enum, ty_err};
 use middle::ty::{ty_estr, ty_evec, ty_float, ty_infer, ty_int, ty_nil};
 use middle::ty::{ty_opaque_box, ty_param, ty_param_bounds_and_ty, ty_ptr};
-use middle::ty::{ty_rptr, ty_self, ty_struct, ty_trait, ty_tup};
+use middle::ty::{ty_rptr, ty_self, ty_struct, ty_trait, ty_tup, ty_multi};
 use middle::ty::{ty_type, ty_uint, ty_uniq, ty_bare_fn, ty_closure};
 use middle::ty::{ty_opaque_closure_ptr, ty_unboxed_vec};
 use middle::ty::{type_is_ty_var};
@@ -90,8 +90,8 @@ pub fn get_base_type(inference_context: @mut InferCtxt,
         ty_nil | ty_bot | ty_bool | ty_int(*) | ty_uint(*) | ty_float(*) |
         ty_estr(*) | ty_evec(*) | ty_bare_fn(*) | ty_closure(*) | ty_tup(*) |
         ty_infer(*) | ty_param(*) | ty_self(*) | ty_type | ty_opaque_box |
-        ty_opaque_closure_ptr(*) | ty_unboxed_vec(*) | ty_err | ty_box(_) |
-        ty_uniq(_) | ty_ptr(_) | ty_rptr(_, _) => {
+        ty_opaque_closure_ptr(*) | ty_unboxed_vec(*) | ty_multi(*) | ty_err |
+        ty_box(*) | ty_uniq(*) | ty_ptr(*) | ty_rptr(*) => {
             debug!("(getting base type) no base type; found %?",
                    get(original_type).sty);
             None

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -15,7 +15,7 @@ use middle::ty::{br_fresh, ctxt, field, method};
 use middle::ty::{mt, t, param_bound, param_ty};
 use middle::ty::{re_bound, re_free, re_scope, re_infer, re_static, Region,
                  re_empty};
-use middle::ty::{ty_bool, ty_bot, ty_box, ty_struct, ty_enum};
+use middle::ty::{ty_bool, ty_bot, ty_box, ty_struct, ty_enum, ty_multi};
 use middle::ty::{ty_err, ty_estr, ty_evec, ty_float, ty_bare_fn, ty_closure};
 use middle::ty::{ty_nil, ty_opaque_box, ty_opaque_closure_ptr, ty_param};
 use middle::ty::{ty_ptr, ty_rptr, ty_self, ty_tup, ty_type, ty_uniq};
@@ -457,6 +457,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
         vstore_ty_to_str(cx, mt, vs)
       }
       ty_estr(vs) => fmt!("%s%s", vstore_to_str(cx, vs), ~"str"),
+      ty_multi(t, n) => fmt!("%s^%u", ty_to_str(cx, t), n),
       ty_opaque_box => ~"@?",
       ty_opaque_closure_ptr(ast::BorrowedSigil) => ~"closure&",
       ty_opaque_closure_ptr(ast::ManagedSigil) => ~"closure@",

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -861,6 +861,7 @@ pub enum ty_ {
     ty_uniq(mt),
     ty_vec(mt),
     ty_fixed_length_vec(mt, @expr),
+    ty_multi(@Ty, uint),
     ty_ptr(mt),
     ty_rptr(Option<@Lifetime>, mt),
     ty_closure(@TyClosure),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -611,6 +611,7 @@ pub fn noop_fold_ty(t: &ty_, fld: @ast_fold) -> ty_ {
                 fld.fold_expr(e)
             )
         }
+        ty_multi(t, n) => ty_multi(fld.fold_ty(t), n),
         ty_mac(ref mac) => ty_mac(fold_mac(*mac))
     }
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -429,6 +429,9 @@ pub fn print_type(s: @ps, ty: @ast::Ty) {
         print_expr(s, v);
         word(s.s, ~"]");
       }
+      ast::ty_multi(*) => {
+          fail!();
+      }
       ast::ty_mac(_) => {
           fail!(~"print_type doesn't know how to print a ty_mac");
       }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -429,8 +429,10 @@ pub fn print_type(s: @ps, ty: @ast::Ty) {
         print_expr(s, v);
         word(s.s, ~"]");
       }
-      ast::ty_multi(*) => {
-          fail!();
+      ast::ty_multi(t, n) => {
+          print_type(s, t);
+          word(s.s, ~" ^ ");
+          word(s.s, n.to_str());
       }
       ast::ty_mac(_) => {
           fail!(~"print_type doesn't know how to print a ty_mac");

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -255,6 +255,7 @@ pub fn visit_ty<E: Copy>(t: @Ty, e: E, v: vt<E>) {
             (v.visit_ty)(mt.ty, e, v);
             (v.visit_expr)(ex, e, v);
         },
+        ty_multi(t, _) => (v.visit_ty)(t, e, v),
         ty_nil | ty_bot | ty_mac(_) | ty_infer => ()
     }
 }

--- a/src/test/compile-fail/simd-cast.rs
+++ b/src/test/compile-fail/simd-cast.rs
@@ -1,0 +1,7 @@
+type i32x4 = i32 ^ 4;
+
+fn test(e: f32) {
+    e as i32x4; //~ ERROR expected `i32` but found `f32`
+}
+
+fn main() {}

--- a/src/test/compile-fail/simd-type.rs
+++ b/src/test/compile-fail/simd-type.rs
@@ -1,0 +1,3 @@
+type v = f32 ^ 0; //~ ERROR expected SIMD vector length
+
+fn main() {}

--- a/src/test/run-pass/simd-binop.rs
+++ b/src/test/run-pass/simd-binop.rs
@@ -1,0 +1,18 @@
+type i32x4 = i32 ^ 4;
+type f64x2 = f64 ^ 2;
+
+fn test_int(e: i32) {
+    let v = e as i32x4;
+    v + v;
+    v - v;
+    v * v;
+}
+
+fn test_float(e: f64) {
+    let v = e as f64x2;
+    v + v;
+    v - v;
+    v * v;
+}
+
+fn main() {}

--- a/src/test/run-pass/simd-cast.rs
+++ b/src/test/run-pass/simd-cast.rs
@@ -1,0 +1,7 @@
+type i32x4 = i32 ^ 4;
+
+fn test(e: i32) {
+    e as i32x4;
+}
+
+fn main() {}

--- a/src/test/run-pass/simd-type.rs
+++ b/src/test/run-pass/simd-type.rs
@@ -1,0 +1,4 @@
+type i32x4 = i32 ^ 4;
+type f64x2 = f64 ^ 2;
+
+fn main() {}


### PR DESCRIPTION
Fix #3499.

This is a work in progress.

`T ^ N` (temporary syntax) parses to `ast::ty_multi(@Ty, uint)` and converts to `ty::ty_multi(t, uint)` and lowers to LLVM SIMD vector type `<n x t>`. Metadata support and reflection support are missing. There are minimal tests.

Casting scalar to vector broadcasts, and element-wise vector arithmetics is implemented. There should be a way to load from vectors to SIMD vector (since terminology is confusing, let's call this "multi"), which needs design.

Some TODOs are OpenCL-style swizzling, type conversion, more SIMD operations (such as saturated arithmetics), etc.
