### PR TITLE
rustpkg: Factor out tests; use a condition instead of returning an option

### DIFF
--- a/src/librustpkg/conditions.rs
+++ b/src/librustpkg/conditions.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Useful conditions
+
+pub use core::path::Path;
+
+condition! {
+    bad_path: (super::Path, ~str) -> super::Path;
+}

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -1,0 +1,83 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// rustpkg utilities having to do with paths and directories
+
+use core::path::*;
+use core::os;
+use util::PkgId;
+
+/// Returns the output directory to use.
+/// Right now is always the default, should
+/// support changing it.
+pub fn dest_dir(pkgid: PkgId) -> Path {
+    default_dest_dir(&pkgid.path)
+}
+
+/// Returns the default output directory for compilation.
+/// Creates that directory if it doesn't exist.
+pub fn default_dest_dir(pkg_dir: &Path) -> Path {
+    use core::libc::consts::os::posix88::{S_IRUSR, S_IWUSR, S_IXUSR};
+    use conditions::bad_path::cond;
+
+    // For now: assumes that pkg_dir exists and is relative
+    // to the CWD. Change this later when we do path searching.
+    let rslt = pkg_dir.push("build");
+    let is_dir = os::path_is_dir(&rslt);
+    if os::path_exists(&rslt) {
+        if is_dir {
+            rslt
+        }
+        else {
+            cond.raise((rslt, ~"Path names a file that isn't a directory"))
+        }
+    }
+    else {
+        // Create it
+        if os::make_dir(&rslt, (S_IRUSR | S_IWUSR | S_IXUSR) as i32) {
+            rslt
+        }
+        else {
+            cond.raise((rslt, ~"Could not create directory"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::{os, rand};
+    use core::path::Path;
+    use core::rand::RngUtil;
+    use path_util::*;
+
+    // Helper function to create a directory name that doesn't exist
+    pub fn mk_nonexistent(tmpdir: &Path, suffix: &str) -> Path {
+        let r = rand::Rng();
+        for 1000.times {
+            let p = tmpdir.push(r.gen_str(16) + suffix);
+            if !os::path_exists(&p) {
+                return p;
+            }
+        }
+        fail!(~"Couldn't compute a non-existent path name; this is worrisome")
+    }
+
+    #[test]
+    fn default_dir_ok() {
+        let the_path = os::tmpdir();
+        let substitute_path = Path("xyzzy");
+        assert!(default_dest_dir(&the_path) == the_path.push(~"build"));
+        let nonexistent_path = mk_nonexistent(&the_path, "quux");
+        let bogus = do ::conditions::bad_path::cond.trap(|_| { 
+            substitute_path
+        }).in { default_dest_dir(&nonexistent_path) };
+        assert!(bogus == substitute_path);
+    }
+}

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -75,7 +75,7 @@ mod test {
         let substitute_path = Path("xyzzy");
         assert!(default_dest_dir(&the_path) == the_path.push(~"build"));
         let nonexistent_path = mk_nonexistent(&the_path, "quux");
-        let bogus = do ::conditions::bad_path::cond.trap(|_| { 
+        let bogus = do ::conditions::bad_path::cond.trap(|_| {
             substitute_path
         }).in { default_dest_dir(&nonexistent_path) };
         assert!(bogus == substitute_path);

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustpkg - a purely function package manager and build system
+// rustpkg - a package manager and build system for Rust
 
 #[link(name = "rustpkg",
        vers = "0.6",
@@ -37,8 +37,11 @@ use std::net::url;
 use std::{getopts};
 use syntax::{ast, diagnostic};
 use util::{ExitCode, Pkg, PkgId};
+use path_util::dest_dir;
 
+mod conditions;
 mod usage;
+mod path_util;
 mod util;
 
 /// A PkgScript represents user-supplied custom logic for
@@ -153,46 +156,6 @@ struct Ctx {
     // Cache of hashes of things already installed
     // though I'm not sure why the value is a bool
     dep_cache: @mut HashMap<~str, bool>,
-}
-
-
-/// Returns the output directory to use.
-/// Right now is always the default, should
-/// support changing it.
-fn dest_dir(pkgid: PkgId) -> Path {
-    default_dest_dir(&pkgid.path).expect(
-        ~"couldn't make default dir?!")
-}
-
-/// Returns the default output directory for compilation.
-/// Creates that directory if it doesn't exist.
-fn default_dest_dir(pkg_dir: &Path) -> Option<Path> {
-    use core::libc::consts::os::posix88::{S_IRUSR, S_IWUSR, S_IXUSR};
-
-    // For now: assumes that pkg_dir exists and is relative
-    // to the CWD. Change this later when we do path searching.
-    let rslt = pkg_dir.push("build");
-    let is_dir = os::path_is_dir(&rslt);
-    if os::path_exists(&rslt) {
-        if is_dir {
-            Some(rslt)
-        }
-        else {
-            util::error(fmt!("%s is not a directory", rslt.to_str()));
-            None
-        }
-    }
-    else {
-        // Create it
-        if os::make_dir(&rslt, (S_IRUSR | S_IWUSR | S_IXUSR) as i32) {
-            Some(rslt)
-        }
-        else {
-            util::error(fmt!("Could not create directory %s",
-                             rslt.to_str()));
-            None // ??? should probably use conditions
-        }
-    }
 }
 
 impl Ctx {
@@ -760,10 +723,6 @@ pub struct PkgSrc {
 }
 
 condition! {
-    bad_path: (super::Path, ~str) -> super::Path;
-}
-
-condition! {
     build_err: (~str) -> ();
 }
 
@@ -785,7 +744,7 @@ impl PkgSrc {
 
 
     fn check_dir(&self) -> Path {
-        use bad_path::cond;
+        use conditions::bad_path::cond;
 
         debug!("Pushing onto root: %s | %s", self.id.path.to_str(),
                self.root.to_str());

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -1,0 +1,11 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// rustpkg unit tests

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -563,21 +563,26 @@ pub fn link_exe(src: &Path, dest: &Path) -> bool {
     }
 }
 
-#[test]
-fn test_is_cmd() {
-    assert!(is_cmd(~"build"));
-    assert!(is_cmd(~"clean"));
-    assert!(is_cmd(~"do"));
-    assert!(is_cmd(~"info"));
-    assert!(is_cmd(~"install"));
-    assert!(is_cmd(~"prefer"));
-    assert!(is_cmd(~"test"));
-    assert!(is_cmd(~"uninstall"));
-    assert!(is_cmd(~"unprefer"));
-}
+#[cfg(test)]
+mod test {
+    use super::{is_cmd, parse_name};
 
-#[test]
-fn test_parse_name() {
-    assert!(parse_name(~"org.mozilla.servo").get() == ~"servo");
-    assert!(parse_name(~"org. mozilla.servo 2131").is_err());
+    #[test]
+    fn test_is_cmd() {
+        assert!(is_cmd(~"build"));
+        assert!(is_cmd(~"clean"));
+        assert!(is_cmd(~"do"));
+        assert!(is_cmd(~"info"));
+        assert!(is_cmd(~"install"));
+        assert!(is_cmd(~"prefer"));
+        assert!(is_cmd(~"test"));
+        assert!(is_cmd(~"uninstall"));
+        assert!(is_cmd(~"unprefer"));
+    }
+    
+    #[test]
+    fn test_parse_name() {
+        assert!(parse_name(~"org.mozilla.servo").get() == ~"servo");
+        assert!(parse_name(~"org. mozilla.servo 2131").is_err());
+    }
 }

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -579,7 +579,7 @@ mod test {
         assert!(is_cmd(~"uninstall"));
         assert!(is_cmd(~"unprefer"));
     }
-    
+
     #[test]
     fn test_parse_name() {
         assert!(parse_name(~"org.mozilla.servo").get() == ~"servo");


### PR DESCRIPTION
r? @graydon

Pulled out tests into their own modules inside the files they test,
as per the draft style guidelines.

Started a new module, path_util, for utility functions to do with
paths and directories.

Changed default_dest_dir to use a condition and return Path
instead of Option<Path>.
