### PR TITLE
Avoid excessive allocations and copies in iter::to_vec

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -161,7 +161,7 @@ pub fn foldl<A,B,IA:BaseIter<A>>(self: &IA, b0: B, blk: &fn(&B, &A) -> B)
 
 #[inline(always)]
 pub fn to_vec<A:Copy,IA:BaseIter<A>>(self: &IA) -> ~[A] {
-    foldl::<A,~[A],IA>(self, ~[], |r, a| vec::append(copy (*r), ~[*a]))
+    map_to_vec(self, |&x| x)
 }
 
 #[inline(always)]


### PR DESCRIPTION
The foldl based implementation allocates lots of unneeded vectors.
iter::map_to_vec is already optimized to avoid these.

One place that benefits quite a lot from this is the metadata decoder, helping with compile times for tiny programs.
