### PR TITLE
Restore Num trait and use macros to implement and test NumCast

### DIFF
--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -99,7 +99,7 @@ pub use vec::{OwnedVector, OwnedCopyableVector};
 pub use iter::{BaseIter, ExtendedIter, EqIter, CopyableIter};
 pub use iter::{CopyableOrderedIter, CopyableNonstrictIter, Times};
 
-pub use num::NumCast;
+pub use num::{Num, NumCast};
 pub use ptr::Ptr;
 pub use to_str::ToStr;
 pub use clone::Clone;

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -555,18 +555,6 @@ impl num::FromStrRadix for f32 {
     }
 }
 
-#[test]
-pub fn test_num() {
-    let ten: f32 = num::cast(10);
-    let two: f32 = num::cast(2);
-
-    assert!((ten.add(&two)    == num::cast(12)));
-    assert!((ten.sub(&two)    == num::cast(8)));
-    assert!((ten.mul(&two)    == num::cast(20)));
-    assert!((ten.div(&two)    == num::cast(5)));
-    assert!((ten.modulo(&two) == num::cast(0)));
-}
-
 //
 // Local Variables:
 // mode: rust

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -12,7 +12,6 @@
 
 use cmath;
 use libc::{c_float, c_int};
-use num::NumCast;
 use num::strconv;
 use num;
 use option::Option;
@@ -285,30 +284,6 @@ impl num::Zero for f32 {
 impl num::One for f32 {
     #[inline(always)]
     fn one() -> f32 { 1.0 }
-}
-
-impl NumCast for f32 {
-    /**
-     * Cast `n` to an `f32`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> f32 { n.to_f32() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self          }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
 }
 
 #[cfg(notest)]
@@ -590,51 +565,6 @@ pub fn test_num() {
     assert!((ten.mul(&two)    == num::cast(20)));
     assert!((ten.div(&two)    == num::cast(5)));
     assert!((ten.modulo(&two) == num::cast(0)));
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u     == 20f32.to_uint()));
-    assert!((20u8    == 20f32.to_u8()));
-    assert!((20u16   == 20f32.to_u16()));
-    assert!((20u32   == 20f32.to_u32()));
-    assert!((20u64   == 20f32.to_u64()));
-    assert!((20i     == 20f32.to_int()));
-    assert!((20i8    == 20f32.to_i8()));
-    assert!((20i16   == 20f32.to_i16()));
-    assert!((20i32   == 20f32.to_i32()));
-    assert!((20i64   == 20f32.to_i64()));
-    assert!((20f     == 20f32.to_float()));
-    assert!((20f32   == 20f32.to_f32()));
-    assert!((20f64   == 20f32.to_f64()));
-
-    assert!((20f32 == NumCast::from(20u)));
-    assert!((20f32 == NumCast::from(20u8)));
-    assert!((20f32 == NumCast::from(20u16)));
-    assert!((20f32 == NumCast::from(20u32)));
-    assert!((20f32 == NumCast::from(20u64)));
-    assert!((20f32 == NumCast::from(20i)));
-    assert!((20f32 == NumCast::from(20i8)));
-    assert!((20f32 == NumCast::from(20i16)));
-    assert!((20f32 == NumCast::from(20i32)));
-    assert!((20f32 == NumCast::from(20i64)));
-    assert!((20f32 == NumCast::from(20f)));
-    assert!((20f32 == NumCast::from(20f32)));
-    assert!((20f32 == NumCast::from(20f64)));
-
-    assert!((20f32 == num::cast(20u)));
-    assert!((20f32 == num::cast(20u8)));
-    assert!((20f32 == num::cast(20u16)));
-    assert!((20f32 == num::cast(20u32)));
-    assert!((20f32 == num::cast(20u64)));
-    assert!((20f32 == num::cast(20i)));
-    assert!((20f32 == num::cast(20i8)));
-    assert!((20f32 == num::cast(20i16)));
-    assert!((20f32 == num::cast(20i32)));
-    assert!((20f32 == num::cast(20i64)));
-    assert!((20f32 == num::cast(20f)));
-    assert!((20f32 == num::cast(20f32)));
-    assert!((20f32 == num::cast(20f64)));
 }
 
 //

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -12,7 +12,6 @@
 
 use cmath;
 use libc::{c_double, c_int};
-use num::NumCast;
 use num::strconv;
 use num;
 use option::Option;
@@ -297,30 +296,6 @@ impl cmp::Ord for f64 {
     fn ge(&self, other: &f64) -> bool { (*self) >= (*other) }
     #[inline(always)]
     fn gt(&self, other: &f64) -> bool { (*self) > (*other) }
-}
-
-impl NumCast for f64 {
-    /**
-     * Cast `n` to an `f64`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> f64 { n.to_f64() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self          }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
 }
 
 impl num::Zero for f64 {
@@ -612,51 +587,6 @@ pub fn test_num() {
     assert!((ten.mul(&two)    == num::cast(20)));
     assert!((ten.div(&two)    == num::cast(5)));
     assert!((ten.modulo(&two) == num::cast(0)));
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20f64.to_uint()));
-    assert!((20u8  == 20f64.to_u8()));
-    assert!((20u16 == 20f64.to_u16()));
-    assert!((20u32 == 20f64.to_u32()));
-    assert!((20u64 == 20f64.to_u64()));
-    assert!((20i   == 20f64.to_int()));
-    assert!((20i8  == 20f64.to_i8()));
-    assert!((20i16 == 20f64.to_i16()));
-    assert!((20i32 == 20f64.to_i32()));
-    assert!((20i64 == 20f64.to_i64()));
-    assert!((20f   == 20f64.to_float()));
-    assert!((20f32 == 20f64.to_f32()));
-    assert!((20f64 == 20f64.to_f64()));
-
-    assert!((20f64 == NumCast::from(20u)));
-    assert!((20f64 == NumCast::from(20u8)));
-    assert!((20f64 == NumCast::from(20u16)));
-    assert!((20f64 == NumCast::from(20u32)));
-    assert!((20f64 == NumCast::from(20u64)));
-    assert!((20f64 == NumCast::from(20i)));
-    assert!((20f64 == NumCast::from(20i8)));
-    assert!((20f64 == NumCast::from(20i16)));
-    assert!((20f64 == NumCast::from(20i32)));
-    assert!((20f64 == NumCast::from(20i64)));
-    assert!((20f64 == NumCast::from(20f)));
-    assert!((20f64 == NumCast::from(20f32)));
-    assert!((20f64 == NumCast::from(20f64)));
-
-    assert!((20f64 == num::cast(20u)));
-    assert!((20f64 == num::cast(20u8)));
-    assert!((20f64 == num::cast(20u16)));
-    assert!((20f64 == num::cast(20u32)));
-    assert!((20f64 == num::cast(20u64)));
-    assert!((20f64 == num::cast(20i)));
-    assert!((20f64 == num::cast(20i8)));
-    assert!((20f64 == num::cast(20i16)));
-    assert!((20f64 == num::cast(20i32)));
-    assert!((20f64 == num::cast(20i64)));
-    assert!((20f64 == num::cast(20f)));
-    assert!((20f64 == num::cast(20f32)));
-    assert!((20f64 == num::cast(20f64)));
 }
 
 //

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -577,18 +577,6 @@ impl num::FromStrRadix for f64 {
     }
 }
 
-#[test]
-pub fn test_num() {
-    let ten: f64 = num::cast(10);
-    let two: f64 = num::cast(2);
-
-    assert!((ten.add(&two)    == num::cast(12)));
-    assert!((ten.sub(&two)    == num::cast(8)));
-    assert!((ten.mul(&two)    == num::cast(20)));
-    assert!((ten.div(&two)    == num::cast(5)));
-    assert!((ten.modulo(&two) == num::cast(0)));
-}
-
 //
 // Local Variables:
 // mode: rust

--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -21,7 +21,6 @@
 // PORT this must match in width according to architecture
 
 use f64;
-use num::NumCast;
 use num::strconv;
 use num;
 use option::Option;
@@ -417,30 +416,6 @@ impl num::One for float {
     fn one() -> float { 1.0 }
 }
 
-impl NumCast for float {
-    /**
-     * Cast `n` to a `float`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> float { n.to_float() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self          }
-}
-
 impl num::Round for float {
     #[inline(always)]
     fn round(&self, mode: num::RoundMode) -> float {
@@ -698,51 +673,6 @@ pub fn test_num() {
     assert!((ten.mul(&two)    == num::cast(20)));
     assert!((ten.div(&two)    == num::cast(5)));
     assert!((ten.modulo(&two) == num::cast(0)));
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20f.to_uint()));
-    assert!((20u8  == 20f.to_u8()));
-    assert!((20u16 == 20f.to_u16()));
-    assert!((20u32 == 20f.to_u32()));
-    assert!((20u64 == 20f.to_u64()));
-    assert!((20i   == 20f.to_int()));
-    assert!((20i8  == 20f.to_i8()));
-    assert!((20i16 == 20f.to_i16()));
-    assert!((20i32 == 20f.to_i32()));
-    assert!((20i64 == 20f.to_i64()));
-    assert!((20f   == 20f.to_float()));
-    assert!((20f32 == 20f.to_f32()));
-    assert!((20f64 == 20f.to_f64()));
-
-    assert!((20f == NumCast::from(20u)));
-    assert!((20f == NumCast::from(20u8)));
-    assert!((20f == NumCast::from(20u16)));
-    assert!((20f == NumCast::from(20u32)));
-    assert!((20f == NumCast::from(20u64)));
-    assert!((20f == NumCast::from(20i)));
-    assert!((20f == NumCast::from(20i8)));
-    assert!((20f == NumCast::from(20i16)));
-    assert!((20f == NumCast::from(20i32)));
-    assert!((20f == NumCast::from(20i64)));
-    assert!((20f == NumCast::from(20f)));
-    assert!((20f == NumCast::from(20f32)));
-    assert!((20f == NumCast::from(20f64)));
-
-    assert!((20f == num::cast(20u)));
-    assert!((20f == num::cast(20u8)));
-    assert!((20f == num::cast(20u16)));
-    assert!((20f == num::cast(20u32)));
-    assert!((20f == num::cast(20u64)));
-    assert!((20f == num::cast(20i)));
-    assert!((20f == num::cast(20i8)));
-    assert!((20f == num::cast(20i16)));
-    assert!((20f == num::cast(20i32)));
-    assert!((20f == num::cast(20i64)));
-    assert!((20f == num::cast(20f)));
-    assert!((20f == num::cast(20f32)));
-    assert!((20f == num::cast(20f64)));
 }
 
 

--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -663,18 +663,6 @@ pub fn test_round() {
     assert!(round(-3.5) == -4.0);
 }
 
-#[test]
-pub fn test_num() {
-    let ten: float = num::cast(10);
-    let two: float = num::cast(2);
-
-    assert!((ten.add(&two)    == num::cast(12)));
-    assert!((ten.sub(&two)    == num::cast(8)));
-    assert!((ten.mul(&two)    == num::cast(20)));
-    assert!((ten.div(&two)    == num::cast(5)));
-    assert!((ten.modulo(&two) == num::cast(0)));
-}
-
 
 //
 // Local Variables:

--- a/src/libcore/num/int-template.rs
+++ b/src/libcore/num/int-template.rs
@@ -398,18 +398,6 @@ fn test_int_from_str_overflow() {
 }
 
 #[test]
-pub fn test_num() {
-    let ten: T = num::cast(10);
-    let two: T = num::cast(2);
-
-    assert!((ten.add(&two)    == num::cast(12)));
-    assert!((ten.sub(&two)    == num::cast(8)));
-    assert!((ten.mul(&two)    == num::cast(20)));
-    assert!((ten.div(&two)    == num::cast(5)));
-    assert!((ten.modulo(&two) == num::cast(0)));
-}
-
-#[test]
 pub fn test_ranges() {
     let mut l = ~[];
 

--- a/src/libcore/num/int-template/i16.rs
+++ b/src/libcore/num/int-template/i16.rs
@@ -10,78 +10,7 @@
 
 //! Operations and constants for `i16`
 
-use num::NumCast;
-
 mod inst {
     pub type T = i16;
     pub static bits: uint = ::u16::bits;
-}
-
-impl NumCast for i16 {
-    /**
-     * Cast `n` to a `i16`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> i16 { n.to_i16() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self          }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20i16.to_uint()));
-    assert!((20u8  == 20i16.to_u8()));
-    assert!((20u16 == 20i16.to_u16()));
-    assert!((20u32 == 20i16.to_u32()));
-    assert!((20u64 == 20i16.to_u64()));
-    assert!((20i   == 20i16.to_int()));
-    assert!((20i8  == 20i16.to_i8()));
-    assert!((20i16 == 20i16.to_i16()));
-    assert!((20i32 == 20i16.to_i32()));
-    assert!((20i64 == 20i16.to_i64()));
-    assert!((20f   == 20i16.to_float()));
-    assert!((20f32 == 20i16.to_f32()));
-    assert!((20f64 == 20i16.to_f64()));
-
-    assert!((20i16 == NumCast::from(20u)));
-    assert!((20i16 == NumCast::from(20u8)));
-    assert!((20i16 == NumCast::from(20u16)));
-    assert!((20i16 == NumCast::from(20u32)));
-    assert!((20i16 == NumCast::from(20u64)));
-    assert!((20i16 == NumCast::from(20i)));
-    assert!((20i16 == NumCast::from(20i8)));
-    assert!((20i16 == NumCast::from(20i16)));
-    assert!((20i16 == NumCast::from(20i32)));
-    assert!((20i16 == NumCast::from(20i64)));
-    assert!((20i16 == NumCast::from(20f)));
-    assert!((20i16 == NumCast::from(20f32)));
-    assert!((20i16 == NumCast::from(20f64)));
-
-    assert!((20i16 == num::cast(20u)));
-    assert!((20i16 == num::cast(20u8)));
-    assert!((20i16 == num::cast(20u16)));
-    assert!((20i16 == num::cast(20u32)));
-    assert!((20i16 == num::cast(20u64)));
-    assert!((20i16 == num::cast(20i)));
-    assert!((20i16 == num::cast(20i8)));
-    assert!((20i16 == num::cast(20i16)));
-    assert!((20i16 == num::cast(20i32)));
-    assert!((20i16 == num::cast(20i64)));
-    assert!((20i16 == num::cast(20f)));
-    assert!((20i16 == num::cast(20f32)));
-    assert!((20i16 == num::cast(20f64)));
 }

--- a/src/libcore/num/int-template/i32.rs
+++ b/src/libcore/num/int-template/i32.rs
@@ -10,78 +10,7 @@
 
 //! Operations and constants for `i32`
 
-use num::NumCast;
-
 mod inst {
     pub type T = i32;
     pub static bits: uint = ::u32::bits;
-}
-
-impl NumCast for i32 {
-    /**
-     * Cast `n` to a `i32`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> i32 { n.to_i32() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self          }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20i32.to_uint()));
-    assert!((20u8  == 20i32.to_u8()));
-    assert!((20u16 == 20i32.to_u16()));
-    assert!((20u32 == 20i32.to_u32()));
-    assert!((20u64 == 20i32.to_u64()));
-    assert!((20i   == 20i32.to_int()));
-    assert!((20i8  == 20i32.to_i8()));
-    assert!((20i16 == 20i32.to_i16()));
-    assert!((20i32 == 20i32.to_i32()));
-    assert!((20i64 == 20i32.to_i64()));
-    assert!((20f   == 20i32.to_float()));
-    assert!((20f32 == 20i32.to_f32()));
-    assert!((20f64 == 20i32.to_f64()));
-
-    assert!((20i32 == NumCast::from(20u)));
-    assert!((20i32 == NumCast::from(20u8)));
-    assert!((20i32 == NumCast::from(20u16)));
-    assert!((20i32 == NumCast::from(20u32)));
-    assert!((20i32 == NumCast::from(20u64)));
-    assert!((20i32 == NumCast::from(20i)));
-    assert!((20i32 == NumCast::from(20i8)));
-    assert!((20i32 == NumCast::from(20i16)));
-    assert!((20i32 == NumCast::from(20i32)));
-    assert!((20i32 == NumCast::from(20i64)));
-    assert!((20i32 == NumCast::from(20f)));
-    assert!((20i32 == NumCast::from(20f32)));
-    assert!((20i32 == NumCast::from(20f64)));
-
-    assert!((20i32 == num::cast(20u)));
-    assert!((20i32 == num::cast(20u8)));
-    assert!((20i32 == num::cast(20u16)));
-    assert!((20i32 == num::cast(20u32)));
-    assert!((20i32 == num::cast(20u64)));
-    assert!((20i32 == num::cast(20i)));
-    assert!((20i32 == num::cast(20i8)));
-    assert!((20i32 == num::cast(20i16)));
-    assert!((20i32 == num::cast(20i32)));
-    assert!((20i32 == num::cast(20i64)));
-    assert!((20i32 == num::cast(20f)));
-    assert!((20i32 == num::cast(20f32)));
-    assert!((20i32 == num::cast(20f64)));
 }

--- a/src/libcore/num/int-template/i64.rs
+++ b/src/libcore/num/int-template/i64.rs
@@ -10,78 +10,7 @@
 
 //! Operations and constants for `i64`
 
-use num::NumCast;
-
 mod inst {
     pub type T = i64;
     pub static bits: uint = ::u64::bits;
-}
-
-impl NumCast for i64 {
-    /**
-     * Cast `n` to a `i64`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> i64 { n.to_i64() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self          }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20i64.to_uint()));
-    assert!((20u8  == 20i64.to_u8()));
-    assert!((20u16 == 20i64.to_u16()));
-    assert!((20u32 == 20i64.to_u32()));
-    assert!((20u64 == 20i64.to_u64()));
-    assert!((20i   == 20i64.to_int()));
-    assert!((20i8  == 20i64.to_i8()));
-    assert!((20i16 == 20i64.to_i16()));
-    assert!((20i32 == 20i64.to_i32()));
-    assert!((20i64 == 20i64.to_i64()));
-    assert!((20f   == 20i64.to_float()));
-    assert!((20f32 == 20i64.to_f32()));
-    assert!((20f64 == 20i64.to_f64()));
-
-    assert!((20i64 == NumCast::from(20u)));
-    assert!((20i64 == NumCast::from(20u8)));
-    assert!((20i64 == NumCast::from(20u16)));
-    assert!((20i64 == NumCast::from(20u32)));
-    assert!((20i64 == NumCast::from(20u64)));
-    assert!((20i64 == NumCast::from(20i)));
-    assert!((20i64 == NumCast::from(20i8)));
-    assert!((20i64 == NumCast::from(20i16)));
-    assert!((20i64 == NumCast::from(20i32)));
-    assert!((20i64 == NumCast::from(20i64)));
-    assert!((20i64 == NumCast::from(20f)));
-    assert!((20i64 == NumCast::from(20f32)));
-    assert!((20i64 == NumCast::from(20f64)));
-
-    assert!((20i64 == num::cast(20u)));
-    assert!((20i64 == num::cast(20u8)));
-    assert!((20i64 == num::cast(20u16)));
-    assert!((20i64 == num::cast(20u32)));
-    assert!((20i64 == num::cast(20u64)));
-    assert!((20i64 == num::cast(20i)));
-    assert!((20i64 == num::cast(20i8)));
-    assert!((20i64 == num::cast(20i16)));
-    assert!((20i64 == num::cast(20i32)));
-    assert!((20i64 == num::cast(20i64)));
-    assert!((20i64 == num::cast(20f)));
-    assert!((20i64 == num::cast(20f32)));
-    assert!((20i64 == num::cast(20f64)));
 }

--- a/src/libcore/num/int-template/i8.rs
+++ b/src/libcore/num/int-template/i8.rs
@@ -10,78 +10,7 @@
 
 //! Operations and constants for `i8`
 
-use num::NumCast;
-
 mod inst {
     pub type T = i8;
     pub static bits: uint = ::u8::bits;
-}
-
-impl NumCast for i8 {
-    /**
-     * Cast `n` to a `i8`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> i8 { n.to_i8() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self          }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20i8.to_uint()));
-    assert!((20u8  == 20i8.to_u8()));
-    assert!((20u16 == 20i8.to_u16()));
-    assert!((20u32 == 20i8.to_u32()));
-    assert!((20u64 == 20i8.to_u64()));
-    assert!((20i   == 20i8.to_int()));
-    assert!((20i8  == 20i8.to_i8()));
-    assert!((20i16 == 20i8.to_i16()));
-    assert!((20i32 == 20i8.to_i32()));
-    assert!((20i64 == 20i8.to_i64()));
-    assert!((20f   == 20i8.to_float()));
-    assert!((20f32 == 20i8.to_f32()));
-    assert!((20f64 == 20i8.to_f64()));
-
-    assert!((20i8 == NumCast::from(20u)));
-    assert!((20i8 == NumCast::from(20u8)));
-    assert!((20i8 == NumCast::from(20u16)));
-    assert!((20i8 == NumCast::from(20u32)));
-    assert!((20i8 == NumCast::from(20u64)));
-    assert!((20i8 == NumCast::from(20i)));
-    assert!((20i8 == NumCast::from(20i8)));
-    assert!((20i8 == NumCast::from(20i16)));
-    assert!((20i8 == NumCast::from(20i32)));
-    assert!((20i8 == NumCast::from(20i64)));
-    assert!((20i8 == NumCast::from(20f)));
-    assert!((20i8 == NumCast::from(20f32)));
-    assert!((20i8 == NumCast::from(20f64)));
-
-    assert!((20i8 == num::cast(20u)));
-    assert!((20i8 == num::cast(20u8)));
-    assert!((20i8 == num::cast(20u16)));
-    assert!((20i8 == num::cast(20u32)));
-    assert!((20i8 == num::cast(20u64)));
-    assert!((20i8 == num::cast(20i)));
-    assert!((20i8 == num::cast(20i8)));
-    assert!((20i8 == num::cast(20i16)));
-    assert!((20i8 == num::cast(20i32)));
-    assert!((20i8 == num::cast(20i64)));
-    assert!((20i8 == num::cast(20f)));
-    assert!((20i8 == num::cast(20f32)));
-    assert!((20i8 == num::cast(20f64)));
 }

--- a/src/libcore/num/int-template/int.rs
+++ b/src/libcore/num/int-template/int.rs
@@ -10,8 +10,6 @@
 
 //! Operations and constants for `int`
 
-use num::NumCast;
-
 pub use self::inst::pow;
 
 mod inst {
@@ -56,73 +54,4 @@ mod inst {
         assert!((::int::min_value <= 0));
         assert!((::int::min_value + ::int::max_value + 1 == 0));
     }
-}
-
-impl NumCast for int {
-    /**
-     * Cast `n` to a `int`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> int { n.to_int() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self          }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20i.to_uint()));
-    assert!((20u8  == 20i.to_u8()));
-    assert!((20u16 == 20i.to_u16()));
-    assert!((20u32 == 20i.to_u32()));
-    assert!((20u64 == 20i.to_u64()));
-    assert!((20i   == 20i.to_int()));
-    assert!((20i8  == 20i.to_i8()));
-    assert!((20i16 == 20i.to_i16()));
-    assert!((20i32 == 20i.to_i32()));
-    assert!((20i64 == 20i.to_i64()));
-    assert!((20f   == 20i.to_float()));
-    assert!((20f32 == 20i.to_f32()));
-    assert!((20f64 == 20i.to_f64()));
-
-    assert!((20i == NumCast::from(20u)));
-    assert!((20i == NumCast::from(20u8)));
-    assert!((20i == NumCast::from(20u16)));
-    assert!((20i == NumCast::from(20u32)));
-    assert!((20i == NumCast::from(20u64)));
-    assert!((20i == NumCast::from(20i)));
-    assert!((20i == NumCast::from(20i8)));
-    assert!((20i == NumCast::from(20i16)));
-    assert!((20i == NumCast::from(20i32)));
-    assert!((20i == NumCast::from(20i64)));
-    assert!((20i == NumCast::from(20f)));
-    assert!((20i == NumCast::from(20f32)));
-    assert!((20i == NumCast::from(20f64)));
-
-    assert!((20i == num::cast(20u)));
-    assert!((20i == num::cast(20u8)));
-    assert!((20i == num::cast(20u16)));
-    assert!((20i == num::cast(20u32)));
-    assert!((20i == num::cast(20u64)));
-    assert!((20i == num::cast(20i)));
-    assert!((20i == num::cast(20i8)));
-    assert!((20i == num::cast(20i16)));
-    assert!((20i == num::cast(20i32)));
-    assert!((20i == num::cast(20i64)));
-    assert!((20i == num::cast(20f)));
-    assert!((20i == num::cast(20f32)));
-    assert!((20i == num::cast(20f64)));
 }

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -16,6 +16,28 @@ use kinds::Copy;
 
 pub mod strconv;
 
+pub trait Num: Eq + Zero + One
+             + Neg<Self>
+             + Add<Self,Self>
+             + Sub<Self,Self>
+             + Mul<Self,Self>
+             + Div<Self,Self>
+             + Modulo<Self,Self> {}
+
+impl Num for u8 {}
+impl Num for u16 {}
+impl Num for u32 {}
+impl Num for u64 {}
+impl Num for uint {}
+impl Num for i8 {}
+impl Num for i16 {}
+impl Num for i32 {}
+impl Num for i64 {}
+impl Num for int {}
+impl Num for f32 {}
+impl Num for f64 {}
+impl Num for float {}
+
 pub trait IntConvertible {
     fn to_int(&self) -> int;
     fn from_int(n: int) -> Self;

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -202,6 +202,35 @@ pub fn pow_with_uint<T:NumCast+One+Zero+Copy+Div<T,T>+Mul<T,T>>(
     total
 }
 
+#[cfg(test)]
+fn test_num<T:Num + NumCast>(ten: T, two: T) {
+    assert!(ten.add(&two)    == cast(12));
+    assert!(ten.sub(&two)    == cast(8));
+    assert!(ten.mul(&two)    == cast(20));
+    assert!(ten.div(&two)    == cast(5));
+    assert!(ten.modulo(&two) == cast(0));
+
+    assert!(ten.add(&two)    == ten + two);
+    assert!(ten.sub(&two)    == ten - two);
+    assert!(ten.mul(&two)    == ten * two);
+    assert!(ten.div(&two)    == ten / two);
+    assert!(ten.modulo(&two) == ten % two);
+}
+
+#[test] fn test_u8_num()    { test_num(10u8,  2u8)  }
+#[test] fn test_u16_num()   { test_num(10u16, 2u16) }
+#[test] fn test_u32_num()   { test_num(10u32, 2u32) }
+#[test] fn test_u64_num()   { test_num(10u64, 2u64) }
+#[test] fn test_uint_num()  { test_num(10u,   2u)   }
+#[test] fn test_i8_num()    { test_num(10i8,  2i8)  }
+#[test] fn test_i16_num()   { test_num(10i16, 2i16) }
+#[test] fn test_i32_num()   { test_num(10i32, 2i32) }
+#[test] fn test_i64_num()   { test_num(10i64, 2i64) }
+#[test] fn test_int_num()   { test_num(10i,   2i)   }
+#[test] fn test_f32_num()   { test_num(10f32, 2f32) }
+#[test] fn test_f64_num()   { test_num(10f64, 2f64) }
+#[test] fn test_float_num() { test_num(10f,   2f)   }
+
 macro_rules! test_cast_20(
     ($_20:expr) => ({
         let _20 = $_20;
@@ -263,26 +292,3 @@ macro_rules! test_cast_20(
 #[test] fn test_f32_cast()   { test_cast_20!(20f32) }
 #[test] fn test_f64_cast()   { test_cast_20!(20f64) }
 #[test] fn test_float_cast() { test_cast_20!(20f)   }
-
-#[test]
-fn test_generic_cast() {
-    use ops::Add;
-
-    fn add_2<T: Add<T,T> + NumCast>(n: T) -> T {
-        n + cast(2)
-    }
-
-    assert!(add_2(1u)   == 3u);
-    assert!(add_2(1u8)  == 3u8);
-    assert!(add_2(1u16) == 3u16);
-    assert!(add_2(1u32) == 3u32);
-    assert!(add_2(1u64) == 3u64);
-    assert!(add_2(1i)   == 3i);
-    assert!(add_2(1i8)  == 3i8);
-    assert!(add_2(1i16) == 3i16);
-    assert!(add_2(1i32) == 3i32);
-    assert!(add_2(1i64) == 3i64);
-    assert!(add_2(1f)   == 3f);
-    assert!(add_2(1f32) == 3f32);
-    assert!(add_2(1f64) == 3f64);
-}

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -89,10 +89,10 @@ pub trait NumCast {
 macro_rules! impl_num_cast(
     ($T:ty, $conv:ident) => (
         // FIXME #4375: This enclosing module is necessary because
-        // of a bug with macros expanding into multiple items 
+        // of a bug with macros expanding into multiple items
         pub mod $conv {
             use num::NumCast;
-            
+
             #[cfg(notest)]
             impl NumCast for $T {
                 #[doc = "Cast `n` to a `$T`"]
@@ -183,7 +183,7 @@ pub fn pow_with_uint<T:NumCast+One+Zero+Copy+Div<T,T>+Mul<T,T>>(
 macro_rules! test_cast_20(
     ($_20:expr) => ({
         let _20 = $_20;
-        
+
         assert!(20u   == _20.to_uint());
         assert!(20u8  == _20.to_u8());
         assert!(20u16 == _20.to_u16());
@@ -245,11 +245,11 @@ macro_rules! test_cast_20(
 #[test]
 fn test_generic_cast() {
     use ops::Add;
-    
+
     fn add_2<T: Add<T,T> + NumCast>(n: T) -> T {
         n + cast(2)
     }
-    
+
     assert!(add_2(1u)   == 3u);
     assert!(add_2(1u8)  == 3u8);
     assert!(add_2(1u16) == 3u16);

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -49,7 +49,7 @@ pub enum RoundMode {
 }
 
 /**
- * Cast a number the the enclosing type
+ * Cast from one machine scalar to another
  *
  * # Example
  *
@@ -64,7 +64,7 @@ pub fn cast<T:NumCast,U:NumCast>(n: T) -> U {
 }
 
 /**
- * An interface for generic numeric type casts
+ * An interface for casting between machine scalars
  */
 pub trait NumCast {
     fn from<T:NumCast>(n: T) -> Self;

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -241,3 +241,26 @@ macro_rules! test_cast_20(
 #[test] fn test_f32_cast()   { test_cast_20!(20f32) }
 #[test] fn test_f64_cast()   { test_cast_20!(20f64) }
 #[test] fn test_float_cast() { test_cast_20!(20f)   }
+
+#[test]
+fn test_generic_cast() {
+    use ops::Add;
+    
+    fn add_2<T: Add<T,T> + NumCast>(n: T) -> T {
+        n + cast(2)
+    }
+    
+    assert!(add_2(1u)   == 3u);
+    assert!(add_2(1u8)  == 3u8);
+    assert!(add_2(1u16) == 3u16);
+    assert!(add_2(1u32) == 3u32);
+    assert!(add_2(1u64) == 3u64);
+    assert!(add_2(1i)   == 3i);
+    assert!(add_2(1i8)  == 3i8);
+    assert!(add_2(1i16) == 3i16);
+    assert!(add_2(1i32) == 3i32);
+    assert!(add_2(1i64) == 3i64);
+    assert!(add_2(1f)   == 3f);
+    assert!(add_2(1f32) == 3f32);
+    assert!(add_2(1f64) == 3f64);
+}

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -110,37 +110,29 @@ pub trait NumCast {
 
 macro_rules! impl_num_cast(
     ($T:ty, $conv:ident) => (
-        // FIXME #4375: This enclosing module is necessary because
-        // of a bug with macros expanding into multiple items
-        pub mod $conv {
-            use num::NumCast;
-
-            #[cfg(notest)]
-            impl NumCast for $T {
-                #[doc = "Cast `n` to a `$T`"]
-                #[inline(always)]
-                fn from<N:NumCast>(n: N) -> $T {
-                    // `$conv` could be generated using `concat_idents!`, but that
-                    // macro seems to be broken at the moment
-                    n.$conv()
-                }
-
-                #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-                #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-                #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-                #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-                #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-                #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-                #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-                #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-                #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-                #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-                #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-                #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-                #[inline(always)] fn to_float(&self) -> float { *self as float }
+        impl NumCast for $T {
+            #[inline(always)]
+            fn from<N:NumCast>(n: N) -> $T {
+                // `$conv` could be generated using `concat_idents!`, but that
+                // macro seems to be broken at the moment
+                n.$conv()
             }
+
+            #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
+            #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
+            #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
+            #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
+            #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
+
+            #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
+            #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
+            #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
+            #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
+            #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
+
+            #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
+            #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
+            #[inline(always)] fn to_float(&self) -> float { *self as float }
         }
     )
 )

--- a/src/libcore/num/uint-template.rs
+++ b/src/libcore/num/uint-template.rs
@@ -412,18 +412,6 @@ pub fn test_ranges() {
 }
 
 #[test]
-pub fn test_num() {
-    let ten: T = num::cast(10);
-    let two: T = num::cast(2);
-
-    assert!((ten.add(&two)    == num::cast(12)));
-    assert!((ten.sub(&two)    == num::cast(8)));
-    assert!((ten.mul(&two)    == num::cast(20)));
-    assert!((ten.div(&two)    == num::cast(5)));
-    assert!((ten.modulo(&two) == num::cast(0)));
-}
-
-#[test]
 #[should_fail]
 #[ignore(cfg(windows))]
 fn test_range_step_zero_step_up() {

--- a/src/libcore/num/uint-template/u16.rs
+++ b/src/libcore/num/uint-template/u16.rs
@@ -10,80 +10,9 @@
 
 //! Operations and constants for `u16`
 
-use num::NumCast;
-
 mod inst {
     pub type T = u16;
     #[allow(non_camel_case_types)]
     pub type T_SIGNED = i16;
     pub static bits: uint = 16;
-}
-
-impl NumCast for u16 {
-    /**
-     * Cast `n` to a `u16`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> u16 { n.to_u16() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self          }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20u16.to_uint()));
-    assert!((20u8  == 20u16.to_u8()));
-    assert!((20u16 == 20u16.to_u16()));
-    assert!((20u32 == 20u16.to_u32()));
-    assert!((20u64 == 20u16.to_u64()));
-    assert!((20i   == 20u16.to_int()));
-    assert!((20i8  == 20u16.to_i8()));
-    assert!((20i16 == 20u16.to_i16()));
-    assert!((20i32 == 20u16.to_i32()));
-    assert!((20i64 == 20u16.to_i64()));
-    assert!((20f   == 20u16.to_float()));
-    assert!((20f32 == 20u16.to_f32()));
-    assert!((20f64 == 20u16.to_f64()));
-
-    assert!((20u16 == NumCast::from(20u)));
-    assert!((20u16 == NumCast::from(20u8)));
-    assert!((20u16 == NumCast::from(20u16)));
-    assert!((20u16 == NumCast::from(20u32)));
-    assert!((20u16 == NumCast::from(20u64)));
-    assert!((20u16 == NumCast::from(20i)));
-    assert!((20u16 == NumCast::from(20i8)));
-    assert!((20u16 == NumCast::from(20i16)));
-    assert!((20u16 == NumCast::from(20i32)));
-    assert!((20u16 == NumCast::from(20i64)));
-    assert!((20u16 == NumCast::from(20f)));
-    assert!((20u16 == NumCast::from(20f32)));
-    assert!((20u16 == NumCast::from(20f64)));
-
-    assert!((20u16 == num::cast(20u)));
-    assert!((20u16 == num::cast(20u8)));
-    assert!((20u16 == num::cast(20u16)));
-    assert!((20u16 == num::cast(20u32)));
-    assert!((20u16 == num::cast(20u64)));
-    assert!((20u16 == num::cast(20i)));
-    assert!((20u16 == num::cast(20i8)));
-    assert!((20u16 == num::cast(20i16)));
-    assert!((20u16 == num::cast(20i32)));
-    assert!((20u16 == num::cast(20i64)));
-    assert!((20u16 == num::cast(20f)));
-    assert!((20u16 == num::cast(20f32)));
-    assert!((20u16 == num::cast(20f64)));
 }

--- a/src/libcore/num/uint-template/u32.rs
+++ b/src/libcore/num/uint-template/u32.rs
@@ -10,80 +10,9 @@
 
 //! Operations and constants for `u32`
 
-use num::NumCast;
-
 mod inst {
     pub type T = u32;
     #[allow(non_camel_case_types)]
     pub type T_SIGNED = i32;
     pub static bits: uint = 32;
-}
-
-impl NumCast for u32 {
-    /**
-     * Cast `n` to a `u32`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> u32 { n.to_u32() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self          }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20u64.to_uint()));
-    assert!((20u8  == 20u64.to_u8()));
-    assert!((20u16 == 20u64.to_u16()));
-    assert!((20u32 == 20u64.to_u32()));
-    assert!((20u64 == 20u64.to_u64()));
-    assert!((20i   == 20u64.to_int()));
-    assert!((20i8  == 20u64.to_i8()));
-    assert!((20i16 == 20u64.to_i16()));
-    assert!((20i32 == 20u64.to_i32()));
-    assert!((20i64 == 20u64.to_i64()));
-    assert!((20f   == 20u64.to_float()));
-    assert!((20f32 == 20u64.to_f32()));
-    assert!((20f64 == 20u64.to_f64()));
-
-    assert!((20u64 == NumCast::from(20u)));
-    assert!((20u64 == NumCast::from(20u8)));
-    assert!((20u64 == NumCast::from(20u16)));
-    assert!((20u64 == NumCast::from(20u32)));
-    assert!((20u64 == NumCast::from(20u64)));
-    assert!((20u64 == NumCast::from(20i)));
-    assert!((20u64 == NumCast::from(20i8)));
-    assert!((20u64 == NumCast::from(20i16)));
-    assert!((20u64 == NumCast::from(20i32)));
-    assert!((20u64 == NumCast::from(20i64)));
-    assert!((20u64 == NumCast::from(20f)));
-    assert!((20u64 == NumCast::from(20f32)));
-    assert!((20u64 == NumCast::from(20f64)));
-
-    assert!((20u64 == num::cast(20u)));
-    assert!((20u64 == num::cast(20u8)));
-    assert!((20u64 == num::cast(20u16)));
-    assert!((20u64 == num::cast(20u32)));
-    assert!((20u64 == num::cast(20u64)));
-    assert!((20u64 == num::cast(20i)));
-    assert!((20u64 == num::cast(20i8)));
-    assert!((20u64 == num::cast(20i16)));
-    assert!((20u64 == num::cast(20i32)));
-    assert!((20u64 == num::cast(20i64)));
-    assert!((20u64 == num::cast(20f)));
-    assert!((20u64 == num::cast(20f32)));
-    assert!((20u64 == num::cast(20f64)));
 }

--- a/src/libcore/num/uint-template/u64.rs
+++ b/src/libcore/num/uint-template/u64.rs
@@ -10,80 +10,9 @@
 
 //! Operations and constants for `u64`
 
-use num::NumCast;
-
 mod inst {
     pub type T = u64;
     #[allow(non_camel_case_types)]
     pub type T_SIGNED = i64;
     pub static bits: uint = 64;
-}
-
-impl NumCast for u64 {
-    /**
-     * Cast `n` to a `u64`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> u64 { n.to_u64() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self          }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20u64.to_uint()));
-    assert!((20u8  == 20u64.to_u8()));
-    assert!((20u16 == 20u64.to_u16()));
-    assert!((20u32 == 20u64.to_u32()));
-    assert!((20u64 == 20u64.to_u64()));
-    assert!((20i   == 20u64.to_int()));
-    assert!((20i8  == 20u64.to_i8()));
-    assert!((20i16 == 20u64.to_i16()));
-    assert!((20i32 == 20u64.to_i32()));
-    assert!((20i64 == 20u64.to_i64()));
-    assert!((20f   == 20u64.to_float()));
-    assert!((20f32 == 20u64.to_f32()));
-    assert!((20f64 == 20u64.to_f64()));
-
-    assert!((20u64 == NumCast::from(20u)));
-    assert!((20u64 == NumCast::from(20u8)));
-    assert!((20u64 == NumCast::from(20u16)));
-    assert!((20u64 == NumCast::from(20u32)));
-    assert!((20u64 == NumCast::from(20u64)));
-    assert!((20u64 == NumCast::from(20i)));
-    assert!((20u64 == NumCast::from(20i8)));
-    assert!((20u64 == NumCast::from(20i16)));
-    assert!((20u64 == NumCast::from(20i32)));
-    assert!((20u64 == NumCast::from(20i64)));
-    assert!((20u64 == NumCast::from(20f)));
-    assert!((20u64 == NumCast::from(20f32)));
-    assert!((20u64 == NumCast::from(20f64)));
-
-    assert!((20u64 == num::cast(20u)));
-    assert!((20u64 == num::cast(20u8)));
-    assert!((20u64 == num::cast(20u16)));
-    assert!((20u64 == num::cast(20u32)));
-    assert!((20u64 == num::cast(20u64)));
-    assert!((20u64 == num::cast(20i)));
-    assert!((20u64 == num::cast(20i8)));
-    assert!((20u64 == num::cast(20i16)));
-    assert!((20u64 == num::cast(20i32)));
-    assert!((20u64 == num::cast(20i64)));
-    assert!((20u64 == num::cast(20f)));
-    assert!((20u64 == num::cast(20f32)));
-    assert!((20u64 == num::cast(20f64)));
 }

--- a/src/libcore/num/uint-template/u8.rs
+++ b/src/libcore/num/uint-template/u8.rs
@@ -12,8 +12,6 @@
 
 pub use self::inst::is_ascii;
 
-use num::NumCast;
-
 mod inst {
     pub type T = u8;
     #[allow(non_camel_case_types)]
@@ -24,73 +22,4 @@ mod inst {
     // parent module so that they appear in core::u8 and not core::u8::u8;
 
     pub fn is_ascii(x: T) -> bool { return 0 as T == x & 128 as T; }
-}
-
-impl NumCast for u8 {
-    /**
-     * Cast `n` to a `u8`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> u8 { n.to_u8() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self          }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self as uint  }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u     == 20u8.to_uint()));
-    assert!((20u8    == 20u8.to_u8()));
-    assert!((20u16   == 20u8.to_u16()));
-    assert!((20u32   == 20u8.to_u32()));
-    assert!((20u64   == 20u8.to_u64()));
-    assert!((20i     == 20u8.to_int()));
-    assert!((20i8    == 20u8.to_i8()));
-    assert!((20i16   == 20u8.to_i16()));
-    assert!((20i32   == 20u8.to_i32()));
-    assert!((20i64   == 20u8.to_i64()));
-    assert!((20f     == 20u8.to_float()));
-    assert!((20f32   == 20u8.to_f32()));
-    assert!((20f64   == 20u8.to_f64()));
-
-    assert!((20u8 == NumCast::from(20u)));
-    assert!((20u8 == NumCast::from(20u8)));
-    assert!((20u8 == NumCast::from(20u16)));
-    assert!((20u8 == NumCast::from(20u32)));
-    assert!((20u8 == NumCast::from(20u64)));
-    assert!((20u8 == NumCast::from(20i)));
-    assert!((20u8 == NumCast::from(20i8)));
-    assert!((20u8 == NumCast::from(20i16)));
-    assert!((20u8 == NumCast::from(20i32)));
-    assert!((20u8 == NumCast::from(20i64)));
-    assert!((20u8 == NumCast::from(20f)));
-    assert!((20u8 == NumCast::from(20f32)));
-    assert!((20u8 == NumCast::from(20f64)));
-
-    assert!((20u8 == num::cast(20u)));
-    assert!((20u8 == num::cast(20u8)));
-    assert!((20u8 == num::cast(20u16)));
-    assert!((20u8 == num::cast(20u32)));
-    assert!((20u8 == num::cast(20u64)));
-    assert!((20u8 == num::cast(20i)));
-    assert!((20u8 == num::cast(20i8)));
-    assert!((20u8 == num::cast(20i16)));
-    assert!((20u8 == num::cast(20i32)));
-    assert!((20u8 == num::cast(20i64)));
-    assert!((20u8 == num::cast(20f)));
-    assert!((20u8 == num::cast(20f32)));
-    assert!((20u8 == num::cast(20f64)));
 }

--- a/src/libcore/num/uint-template/uint.rs
+++ b/src/libcore/num/uint-template/uint.rs
@@ -10,8 +10,6 @@
 
 //! Operations and constants for `uint`
 
-use num::NumCast;
-
 pub use self::inst::{
     div_ceil, div_round, div_floor, iterate,
     next_power_of_two
@@ -208,73 +206,4 @@ pub mod inst {
         for ten.times { accum += 1; }
         assert!((accum == 10));
     }
-}
-
-impl NumCast for uint {
-    /**
-     * Cast `n` to a `uint`
-     */
-    #[inline(always)]
-    fn from<N:NumCast>(n: N) -> uint { n.to_uint() }
-
-    #[inline(always)] fn to_u8(&self)    -> u8    { *self as u8    }
-    #[inline(always)] fn to_u16(&self)   -> u16   { *self as u16   }
-    #[inline(always)] fn to_u32(&self)   -> u32   { *self as u32   }
-    #[inline(always)] fn to_u64(&self)   -> u64   { *self as u64   }
-    #[inline(always)] fn to_uint(&self)  -> uint  { *self          }
-
-    #[inline(always)] fn to_i8(&self)    -> i8    { *self as i8    }
-    #[inline(always)] fn to_i16(&self)   -> i16   { *self as i16   }
-    #[inline(always)] fn to_i32(&self)   -> i32   { *self as i32   }
-    #[inline(always)] fn to_i64(&self)   -> i64   { *self as i64   }
-    #[inline(always)] fn to_int(&self)   -> int   { *self as int   }
-
-    #[inline(always)] fn to_f32(&self)   -> f32   { *self as f32   }
-    #[inline(always)] fn to_f64(&self)   -> f64   { *self as f64   }
-    #[inline(always)] fn to_float(&self) -> float { *self as float }
-}
-
-#[test]
-fn test_numcast() {
-    assert!((20u   == 20u.to_uint()));
-    assert!((20u8  == 20u.to_u8()));
-    assert!((20u16 == 20u.to_u16()));
-    assert!((20u32 == 20u.to_u32()));
-    assert!((20u64 == 20u.to_u64()));
-    assert!((20i   == 20u.to_int()));
-    assert!((20i8  == 20u.to_i8()));
-    assert!((20i16 == 20u.to_i16()));
-    assert!((20i32 == 20u.to_i32()));
-    assert!((20i64 == 20u.to_i64()));
-    assert!((20f   == 20u.to_float()));
-    assert!((20f32 == 20u.to_f32()));
-    assert!((20f64 == 20u.to_f64()));
-
-    assert!((20u == NumCast::from(20u)));
-    assert!((20u == NumCast::from(20u8)));
-    assert!((20u == NumCast::from(20u16)));
-    assert!((20u == NumCast::from(20u32)));
-    assert!((20u == NumCast::from(20u64)));
-    assert!((20u == NumCast::from(20i)));
-    assert!((20u == NumCast::from(20i8)));
-    assert!((20u == NumCast::from(20i16)));
-    assert!((20u == NumCast::from(20i32)));
-    assert!((20u == NumCast::from(20i64)));
-    assert!((20u == NumCast::from(20f)));
-    assert!((20u == NumCast::from(20f32)));
-    assert!((20u == NumCast::from(20f64)));
-
-    assert!((20u == num::cast(20u)));
-    assert!((20u == num::cast(20u8)));
-    assert!((20u == num::cast(20u16)));
-    assert!((20u == num::cast(20u32)));
-    assert!((20u == num::cast(20u64)));
-    assert!((20u == num::cast(20i)));
-    assert!((20u == num::cast(20i8)));
-    assert!((20u == num::cast(20i16)));
-    assert!((20u == num::cast(20i32)));
-    assert!((20u == num::cast(20i64)));
-    assert!((20u == num::cast(20f)));
-    assert!((20u == num::cast(20f32)));
-    assert!((20u == num::cast(20f64)));
 }

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -34,7 +34,7 @@ pub use hash::Hash;
 pub use iter::{BaseIter, ReverseIter, MutableIter, ExtendedIter, EqIter};
 pub use iter::{CopyableIter, CopyableOrderedIter, CopyableNonstrictIter};
 pub use iter::Times;
-pub use num::NumCast;
+pub use num::{Num, NumCast};
 pub use path::GenericPath;
 pub use path::Path;
 pub use path::PosixPath;

--- a/src/test/run-pass/trait-inheritance-num.rs
+++ b/src/test/run-pass/trait-inheritance-num.rs
@@ -16,7 +16,7 @@ use core::cmp::{Eq, Ord};
 use core::num::NumCast::from;
 use std::cmp::FuzzyEq;
 
-pub trait NumExt: NumCast + Eq + Ord {}
+pub trait NumExt: Num + NumCast + Eq + Ord {}
 
 pub trait FloatExt: NumExt + FuzzyEq<Self> {}
 

--- a/src/test/run-pass/trait-inheritance-num1.rs
+++ b/src/test/run-pass/trait-inheritance-num1.rs
@@ -11,7 +11,7 @@
 use core::cmp::Ord;
 use core::num::NumCast::from;
 
-pub trait NumExt: NumCast + Ord { }
+pub trait NumExt: Num + NumCast + Ord { }
 
 fn greater_than_one<T:NumExt>(n: &T) -> bool {
     *n > from(1)

--- a/src/test/run-pass/trait-inheritance-num2.rs
+++ b/src/test/run-pass/trait-inheritance-num2.rs
@@ -38,7 +38,7 @@ impl TypeExt for f64 {}
 impl TypeExt for float {}
 
 
-pub trait NumExt: TypeExt + Eq + Ord + NumCast {}
+pub trait NumExt: TypeExt + Eq + Ord + Num + NumCast {}
 
 impl NumExt for u8 {}
 impl NumExt for u16 {}

--- a/src/test/run-pass/trait-inheritance-num3.rs
+++ b/src/test/run-pass/trait-inheritance-num3.rs
@@ -11,7 +11,7 @@
 use core::cmp::{Eq, Ord};
 use core::num::NumCast::from;
 
-pub trait NumExt: Eq + Ord + NumCast {}
+pub trait NumExt: Eq + Ord + Num + NumCast {}
 
 impl NumExt for f32 {}
 

--- a/src/test/run-pass/trait-inheritance-num5.rs
+++ b/src/test/run-pass/trait-inheritance-num5.rs
@@ -11,7 +11,7 @@
 use core::cmp::{Eq, Ord};
 use core::num::NumCast::from;
 
-pub trait NumExt: Eq + NumCast {}
+pub trait NumExt: Eq + Num + NumCast {}
 
 impl NumExt for f32 {}
 impl NumExt for int {}


### PR DESCRIPTION
This restores the trait that was lost in 216e85fadf465c25fe7bc4a9f06f8162ec12b552. `Num` will eventually be broken up into a more fine-grained trait hierarchy in the future once a design can be agreed upon.

To contribute to the discussion about the future of Rust's numeric traits, please see issue #4819 and the [wiki page](https://github.com/mozilla/rust/wiki/Bikeshed-Numeric-Traits).

I have also switched to [implementing NumCast using macros](https://github.com/bjz/rust/commit/353ce872e287edf3764ca416d2a8cd8e1f54329b). This removes a significant number of lines of code.
