### PR TITLE
Add examples to documentation for std::base64

### DIFF
--- a/src/libstd/base64.rs
+++ b/src/libstd/base64.rs
@@ -75,6 +75,23 @@ impl<'self> ToBase64 for &'self [u8] {
     }
 }
 
+/**
+ * Convert any string (literal, `@`, `&`, `~`) to base64 encoding.
+ *
+ *
+ * *Example*:
+ *
+ * ~~~~
+ * extern mod std;
+ * use std::base64::ToBase64;
+ *
+ * fn main () {
+ *   let str = "Hello, World".to_base64();
+ *   println(fmt!("%s",str));
+ * }
+ * ~~~~
+ *
+ */
 impl<'self> ToBase64 for &'self str {
     fn to_base64(&self) -> ~str {
         str::to_bytes(*self).to_base64()
@@ -147,6 +164,34 @@ impl FromBase64 for ~[u8] {
     }
 }
 
+/**
+ * Convert any string (literal, `@`, `&`, `~`)
+ * that contains a base64 encoded value, to the byte values it encodes.
+ *
+ * You can use the `from_bytes` function in `core::str`
+ * to turn a `[u8]` into a string with characters corresponding to those values.
+ *
+ * *Example*:
+ *
+ * This is an example of going from a string literal to the base64 encoding
+ * and back to the same string.
+ *
+ * ~~~~
+ * extern mod std;
+ * use std::base64::ToBase64;
+ * use std::base64::FromBase64;
+ * use core::str;
+ *
+ * fn main () {
+ *   let hello_str = "Hello, World".to_base64();
+ *   println(fmt!("%s",hello_str));
+ *   let bytes = hello_str.from_base64();
+ *   println(fmt!("%?",bytes));
+ *   let result_str = str::from_bytes(bytes);
+ *   println(fmt!("%s",result_str));
+ * }
+ * ~~~~
+ */
 impl FromBase64 for ~str {
     fn from_base64(&self) -> ~[u8] {
         str::to_bytes(*self).from_base64()

--- a/src/libstd/base64.rs
+++ b/src/libstd/base64.rs
@@ -37,8 +37,8 @@ impl<'self> ToBase64 for &'self [u8] {
      * use std::base64::ToBase64;
      *
      * fn main () {
-     *   let str = [52,32].to_base64();
-     *   println(fmt!("%s", str));
+     *     let str = [52,32].to_base64();
+     *     println(fmt!("%s", str));
      * }
      * ~~~~
      */
@@ -102,8 +102,8 @@ impl<'self> ToBase64 for &'self str {
      * use std::base64::ToBase64;
      *
      * fn main () {
-     *   let str = "Hello, World".to_base64();
-     *   println(fmt!("%s",str));
+     *     let str = "Hello, World".to_base64();
+     *     println(fmt!("%s",str));
      * }
      * ~~~~
      *
@@ -130,10 +130,10 @@ impl FromBase64 for ~[u8] {
      * use std::base64::FromBase64;
      *
      * fn main () {
-     *   let str = [52,32].to_base64();
-     *   println(fmt!("%s", str));
-     *   let bytes = str.from_base64();
-     *   println(fmt!("%?",bytes));
+     *     let str = [52,32].to_base64();
+     *     println(fmt!("%s", str));
+     *     let bytes = str.from_base64();
+     *     println(fmt!("%?",bytes));
      * }
      * ~~~~
      */
@@ -217,12 +217,12 @@ impl FromBase64 for ~str {
      * use core::str;
      *
      * fn main () {
-     *   let hello_str = "Hello, World".to_base64();
-     *   println(fmt!("%s",hello_str));
-     *   let bytes = hello_str.from_base64();
-     *   println(fmt!("%?",bytes));
-     *   let result_str = str::from_bytes(bytes);
-     *   println(fmt!("%s",result_str));
+     *     let hello_str = "Hello, World".to_base64();
+     *     println(fmt!("%s",hello_str));
+     *     let bytes = hello_str.from_base64();
+     *     println(fmt!("%?",bytes));
+     *     let result_str = str::from_bytes(bytes);
+     *     println(fmt!("%s",result_str));
      * }
      * ~~~~
      */

--- a/src/libstd/base64.rs
+++ b/src/libstd/base64.rs
@@ -28,7 +28,7 @@ static CHARS: [char, ..64] = [
 
 impl<'self> ToBase64 for &'self [u8] {
     /**
-     * Turn a vector of `u8` bytes into a string representing them in base64.
+     * Turn a vector of `u8` bytes into a base64 string.
      *
      * *Example*:
      *
@@ -92,7 +92,7 @@ impl<'self> ToBase64 for &'self [u8] {
 
 impl<'self> ToBase64 for &'self str {
     /**
-     * Convert any string (literal, `@`, `&`, `~`) to base64 encoding.
+     * Convert any string (literal, `@`, `&`, or `~`) to base64 encoding.
      *
      *
      * *Example*:
@@ -119,8 +119,8 @@ pub trait FromBase64 {
 
 impl FromBase64 for ~[u8] {
     /**
-     * Turn a vector of `u8`s representing characters
-     * encoding byte values in base64 into the vector of `u8` byte values.
+     * Convert base64 `u8` vector into u8 byte values.
+     * Every 4 encoded characters is converted into 3 octets, modulo padding.
      *
      * *Example*:
      *
@@ -200,16 +200,15 @@ impl FromBase64 for ~[u8] {
 
 impl FromBase64 for ~str {
     /**
-     * Convert any string (literal, `@`, `&`, `~`)
-     * that contains a base64 encoded value, to the byte values it encodes.
+     * Convert any base64 encoded string (literal, `@`, `&`, or `~`)
+     * to the byte values it encodes.
      *
      * You can use the `from_bytes` function in `core::str`
      * to turn a `[u8]` into a string with characters corresponding to those values.
      *
      * *Example*:
      *
-     * This is an example of going from a string literal to the base64 encoding
-     * and back to the same string.
+     * This converts a string literal to base64 and back.
      *
      * ~~~~
      * extern mod std;

--- a/src/libstd/base64.rs
+++ b/src/libstd/base64.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/libstd/base64.rs
+++ b/src/libstd/base64.rs
@@ -26,22 +26,22 @@ static CHARS: [char, ..64] = [
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
 ];
 
-/**
- * Turn a vector of `u8` bytes into a string representing them in base64.
- *
- * *Example*:
- *
- * ~~~~
- * extern mod std;
- * use std::base64::ToBase64;
- *
- * fn main () {
- *   let str = [52,32].to_base64();
- *   println(fmt!("%s", str));
- * }
- * ~~~~
- */
 impl<'self> ToBase64 for &'self [u8] {
+    /**
+     * Turn a vector of `u8` bytes into a string representing them in base64.
+     *
+     * *Example*:
+     *
+     * ~~~~
+     * extern mod std;
+     * use std::base64::ToBase64;
+     *
+     * fn main () {
+     *   let str = [52,32].to_base64();
+     *   println(fmt!("%s", str));
+     * }
+     * ~~~~
+     */
     fn to_base64(&self) -> ~str {
         let mut s = ~"";
         unsafe {
@@ -90,24 +90,24 @@ impl<'self> ToBase64 for &'self [u8] {
     }
 }
 
-/**
- * Convert any string (literal, `@`, `&`, `~`) to base64 encoding.
- *
- *
- * *Example*:
- *
- * ~~~~
- * extern mod std;
- * use std::base64::ToBase64;
- *
- * fn main () {
- *   let str = "Hello, World".to_base64();
- *   println(fmt!("%s",str));
- * }
- * ~~~~
- *
- */
 impl<'self> ToBase64 for &'self str {
+    /**
+     * Convert any string (literal, `@`, `&`, `~`) to base64 encoding.
+     *
+     *
+     * *Example*:
+     *
+     * ~~~~
+     * extern mod std;
+     * use std::base64::ToBase64;
+     *
+     * fn main () {
+     *   let str = "Hello, World".to_base64();
+     *   println(fmt!("%s",str));
+     * }
+     * ~~~~
+     *
+     */
     fn to_base64(&self) -> ~str {
         str::to_bytes(*self).to_base64()
     }
@@ -117,26 +117,26 @@ pub trait FromBase64 {
     fn from_base64(&self) -> ~[u8];
 }
 
-/**
- * Turn a vector of `u8`s representing characters
- * encoding byte values in base64 into the vector of `u8` byte values.
- *
- * *Example*:
- *
- * ~~~~
- * extern mod std;
- * use std::base64::ToBase64;
- * use std::base64::FromBase64;
- *
- * fn main () {
- *   let str = [52,32].to_base64();
- *   println(fmt!("%s", str));
- *   let bytes = str.from_base64();
- *   println(fmt!("%?",bytes));
- * }
- * ~~~~
- */
 impl FromBase64 for ~[u8] {
+    /**
+     * Turn a vector of `u8`s representing characters
+     * encoding byte values in base64 into the vector of `u8` byte values.
+     *
+     * *Example*:
+     *
+     * ~~~~
+     * extern mod std;
+     * use std::base64::ToBase64;
+     * use std::base64::FromBase64;
+     *
+     * fn main () {
+     *   let str = [52,32].to_base64();
+     *   println(fmt!("%s", str));
+     *   let bytes = str.from_base64();
+     *   println(fmt!("%?",bytes));
+     * }
+     * ~~~~
+     */
     fn from_base64(&self) -> ~[u8] {
         if self.len() % 4u != 0u { fail!(~"invalid base64 length"); }
 
@@ -198,35 +198,35 @@ impl FromBase64 for ~[u8] {
     }
 }
 
-/**
- * Convert any string (literal, `@`, `&`, `~`)
- * that contains a base64 encoded value, to the byte values it encodes.
- *
- * You can use the `from_bytes` function in `core::str`
- * to turn a `[u8]` into a string with characters corresponding to those values.
- *
- * *Example*:
- *
- * This is an example of going from a string literal to the base64 encoding
- * and back to the same string.
- *
- * ~~~~
- * extern mod std;
- * use std::base64::ToBase64;
- * use std::base64::FromBase64;
- * use core::str;
- *
- * fn main () {
- *   let hello_str = "Hello, World".to_base64();
- *   println(fmt!("%s",hello_str));
- *   let bytes = hello_str.from_base64();
- *   println(fmt!("%?",bytes));
- *   let result_str = str::from_bytes(bytes);
- *   println(fmt!("%s",result_str));
- * }
- * ~~~~
- */
 impl FromBase64 for ~str {
+    /**
+     * Convert any string (literal, `@`, `&`, `~`)
+     * that contains a base64 encoded value, to the byte values it encodes.
+     *
+     * You can use the `from_bytes` function in `core::str`
+     * to turn a `[u8]` into a string with characters corresponding to those values.
+     *
+     * *Example*:
+     *
+     * This is an example of going from a string literal to the base64 encoding
+     * and back to the same string.
+     *
+     * ~~~~
+     * extern mod std;
+     * use std::base64::ToBase64;
+     * use std::base64::FromBase64;
+     * use core::str;
+     *
+     * fn main () {
+     *   let hello_str = "Hello, World".to_base64();
+     *   println(fmt!("%s",hello_str));
+     *   let bytes = hello_str.from_base64();
+     *   println(fmt!("%?",bytes));
+     *   let result_str = str::from_bytes(bytes);
+     *   println(fmt!("%s",result_str));
+     * }
+     * ~~~~
+     */
     fn from_base64(&self) -> ~[u8] {
         str::to_bytes(*self).from_base64()
     }

--- a/src/libstd/base64.rs
+++ b/src/libstd/base64.rs
@@ -26,6 +26,21 @@ static CHARS: [char, ..64] = [
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
 ];
 
+/**
+ * Turn a vector of `u8` bytes into a string representing them in base64.
+ *
+ * *Example*:
+ *
+ * ~~~~
+ * extern mod std;
+ * use std::base64::ToBase64;
+ *
+ * fn main () {
+ *   let str = [52,32].to_base64();
+ *   println(fmt!("%s", str));
+ * }
+ * ~~~~
+ */
 impl<'self> ToBase64 for &'self [u8] {
     fn to_base64(&self) -> ~str {
         let mut s = ~"";
@@ -102,6 +117,25 @@ pub trait FromBase64 {
     fn from_base64(&self) -> ~[u8];
 }
 
+/**
+ * Turn a vector of `u8`s representing characters
+ * encoding byte values in base64 into the vector of `u8` byte values.
+ *
+ * *Example*:
+ *
+ * ~~~~
+ * extern mod std;
+ * use std::base64::ToBase64;
+ * use std::base64::FromBase64;
+ *
+ * fn main () {
+ *   let str = [52,32].to_base64();
+ *   println(fmt!("%s", str));
+ *   let bytes = str.from_base64();
+ *   println(fmt!("%?",bytes));
+ * }
+ * ~~~~
+ */
 impl FromBase64 for ~[u8] {
     fn from_base64(&self) -> ~[u8] {
         if self.len() % 4u != 0u { fail!(~"invalid base64 length"); }


### PR DESCRIPTION
This adds examples for the methods in std::base64.

Each example is complete in the sense that you can copy-paste it into a file and compile it successfully without adding anything (imports, etc). The hardest part of figuring out how to use this was figuring out the right import statements to put at the top.
