### PR TITLE
Fix xfail'd ARC test

### DIFF
--- a/src/test/run-pass/bind-by-move.rs
+++ b/src/test/run-pass/bind-by-move.rs
@@ -8,14 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test
 // xfail-fast
 extern mod std;
 use std::arc;
-fn dispose(+_x: arc::ARC<bool>) unsafe { }
+fn dispose(+_x: arc::ARC<bool>) { unsafe { } }
 
 pub fn main() {
-    let p = arc::arc(true);
+    let p = arc::ARC(true);
     let x = Some(p);
     match x {
         Some(z) => { dispose(z); },


### PR DESCRIPTION
Update an old test to pass. I'm not 100% sure what the intent of the test was, but it's hard to see how I could have corrupted the intent of the test from the tiny changes I made.
