### PR TITLE
Expose the bounds of the C stack from the runtime

### DIFF
--- a/src/libcore/gc.rs
+++ b/src/libcore/gc.rs
@@ -73,6 +73,7 @@ pub mod rustrt {
         pub unsafe fn rust_gc_metadata() -> *Word;
 
         pub unsafe fn rust_get_stack_segment() -> *StackSegment;
+        pub unsafe fn rust_get_c_stack() -> *StackSegment;
     }
 }
 

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -544,6 +544,11 @@ rust_get_stack_segment() {
     return rust_get_current_task()->stk;
 }
 
+extern "C" CDECL stk_seg *
+rust_get_c_stack() {
+    return rust_get_current_task()->get_c_stack();
+}
+
 extern "C" CDECL void
 start_task(rust_task *target, fn_env_pair *f) {
     target->start(f->f, f->env, NULL);

--- a/src/rt/rust_task.h
+++ b/src/rt/rust_task.h
@@ -367,6 +367,7 @@ public:
     void call_on_c_stack(void *args, void *fn_ptr);
     void call_on_rust_stack(void *args, void *fn_ptr);
     bool have_c_stack() { return c_stack != NULL; }
+    stk_seg *get_c_stack() { return c_stack; }
 
     rust_task_state get_state() { return state; }
     rust_cond *get_cond() { return cond; }

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -48,6 +48,7 @@ rust_task_yield
 rust_task_is_unwinding
 rust_get_task
 rust_get_stack_segment
+rust_get_c_stack
 rust_log_str
 start_task
 vec_reserve_shared_actual


### PR DESCRIPTION
This is needed to allow GC to work in SpiderMonkey.
