### PR TITLE
make iterator objects a bit nicer to use

### DIFF
--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -1,5 +1,17 @@
+Version 0.7 (July 2013)
+-----------------------
+
+   * ??? changes, numerous bugfixes
+
+   * Semantic changes
+      * The `self` parameter no longer implicitly means `&'self self`, and can be explicitly marked
+        with a lifetime.
+
+   * Libraries
+      * New `core::iterator` module for external iterator objects
+
 Version 0.6 (April 2013)
----------------------------
+------------------------
 
    * ~2100 changes, numerous bugfixes
 

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -996,7 +996,7 @@ mod test_treemap {
                         (&x5, &y5)];
         let mut i = 0;
 
-        for advance(&mut b) |x| {
+        for b.advance |x| {
             assert!(expected[i] == x);
             i += 1;
 
@@ -1005,7 +1005,7 @@ mod test_treemap {
             }
         }
 
-        for advance(&mut b) |x| {
+        for b.advance |x| {
             assert!(expected[i] == x);
             i += 1;
         }
@@ -1209,7 +1209,7 @@ mod test_set {
 
         let x = x;
         let y = y;
-        let mut z = ZipIterator::new(x.iter(), y.iter());
+        let mut z = x.iter().zip(y.iter());
 
         // FIXME: #5801: this needs a type hint to compile...
         let result: Option<(&uint, & &'static str)> = z.next();


### PR DESCRIPTION
Can now use them like `x.transform(|i| i + 3).zip(y.filter(|i| i % 2)`.
