### PR TITLE
Fix issue #2626 by un-ignoring the mysterious test_leaks, 

### DIFF
--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -520,7 +520,7 @@ mod tests {
     use run;
 
     // Regression test for memory leaks
-    #[ignore(cfg(windows))] // FIXME (#2626)
+    #[test]
     fn test_leaks() {
         run::run_program("echo", []);
         run::start_program("echo", []);


### PR DESCRIPTION
which does currently seem to work on win32 (and linux).

Just mentioning issue #2626 again to make sure github picks it up.
