### PR TITLE
libcore: make spawn_supervised documentation reflect its behaviour.

### DIFF
--- a/src/libcore/task/mod.rs
+++ b/src/libcore/task/mod.rs
@@ -466,8 +466,9 @@ pub fn spawn_unlinked(f: ~fn()) {
 
 pub fn spawn_supervised(f: ~fn()) {
     /*!
-     * Creates a child task unlinked from the current one. If either this
-     * task or the child task fails, the other will not be killed.
+     * Creates a child task supervised by the current one. If the child
+     * task fails, the parent will not be killed, but if the parent fails,
+     * the child will be killed.
      */
 
     task().supervised().spawn(f)


### PR DESCRIPTION
The doc-comment didn't reflect the [tasks tutorial](http://static.rust-lang.org/doc/tutorial-tasks.html#failure-modes), or how it works in practice.
