### PR TITLE
sketch: Make rust sketch barf output prettier

### DIFF
--- a/src/rt/rust_exchange_alloc.cpp
+++ b/src/rt/rust_exchange_alloc.cpp
@@ -48,8 +48,8 @@ rust_get_exchange_count_ptr() {
 void
 rust_check_exchange_count_on_exit() {
   if (exchange_count != 0) {
-    printf("exchange heap not empty on on exit");
-    printf("%d dangling allocations", (int)exchange_count);
+    printf("exchange heap not empty on exit\n");
+    printf("%d dangling allocations\n", (int)exchange_count);
     abort();
   }
 }


### PR DESCRIPTION
The last line of any command output should always have a newline. Also fixed typo, "on on"

summary of 25 test runs: 4563 passed; 0 failed; 344 ignored
