### PR TITLE
core: io: the read_until function checks bytes not chars, so type should reflect that.

### DIFF
--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -176,7 +176,7 @@ pub trait ReaderUtil {
     fn read_bytes(&self, len: uint) -> ~[u8];
 
     /**
-    * Reads up until a specific character or EOF.
+    * Reads up until a specific byte is seen or EOF.
     *
     * The `include` parameter specifies if the character should be included
     * in the returned string.
@@ -185,7 +185,7 @@ pub trait ReaderUtil {
     *
     * None right now.
     */
-    fn read_until(&self, c: char, include: bool) -> ~str;
+    fn read_until(&self, c: u8, include: bool) -> ~str;
 
     /**
     * Reads up until the first '\n' or EOF.
@@ -577,7 +577,7 @@ impl<T:Reader> ReaderUtil for T {
         bytes
     }
 
-    fn read_until(&self, c: char, include: bool) -> ~str {
+    fn read_until(&self, c: u8, include: bool) -> ~str {
         let mut bytes = ~[];
         loop {
             let ch = self.read_byte();
@@ -593,7 +593,7 @@ impl<T:Reader> ReaderUtil for T {
     }
 
     fn read_line(&self) -> ~str {
-        self.read_until('\n', false)
+        self.read_until('\n' as u8, false)
     }
 
     fn read_chars(&self, n: uint) -> ~[char] {
@@ -667,7 +667,7 @@ impl<T:Reader> ReaderUtil for T {
     }
 
     fn read_c_str(&self) -> ~str {
-        self.read_until(0 as char, false)
+        self.read_until(0u8, false)
     }
 
     fn read_whole_stream(&self) -> ~[u8] {
@@ -693,7 +693,7 @@ impl<T:Reader> ReaderUtil for T {
             // include the \n, so that we can distinguish an entirely empty
             // line read after "...\n", and the trailing empty line in
             // "...\n\n".
-            let mut line = self.read_until('\n', true);
+            let mut line = self.read_until('\n' as u8, true);
 
             // blank line at the end of the reader is ignored
             if self.eof() && line.is_empty() { break; }


### PR DESCRIPTION
`read_until` is just doing a bytewise comparison. This means the following program prints `xyå12`, not `xy`, which it should if it was actually checking chars.

``` rust
fn main() {
    do io::with_str_reader("xyå12") |r| {
        io::println(r.read_until('å', false));
    }
}
```

This patch makes the type of read_until match what it is actually doing.
