### PR TITLE
xfail some extern ABI tests on mac

### DIFF
--- a/src/test/run-pass/extern-pass-TwoU32s.rs
+++ b/src/test/run-pass/extern-pass-TwoU32s.rs
@@ -11,6 +11,8 @@
 // Test a foreign function that accepts and returns a struct
 // by value.
 
+// xfail-macos Broken on mac i686
+
 #[deriving(Eq)]
 struct TwoU32s {
     one: u32, two: u32

--- a/src/test/run-pass/extern-pass-TwoU64s.rs
+++ b/src/test/run-pass/extern-pass-TwoU64s.rs
@@ -11,7 +11,9 @@
 // Test a foreign function that accepts and returns a struct
 // by value.
 
-// xfail-fast This works standalone on windows but not with check-fast. don't know why
+// xfail-fast This works standalone on windows but not with check-fast.
+// possibly because there is another test that uses this extern fn but gives it
+// a diferent signature
 
 #[deriving(Eq)]
 struct TwoU64s {

--- a/src/test/run-pass/extern-return-TwoU16s.rs
+++ b/src/test/run-pass/extern-return-TwoU16s.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // xfail-win32 #5745
+// xfail-macos Broken on mac i686
 
 struct TwoU16s {
     one: u16, two: u16

--- a/src/test/run-pass/extern-return-TwoU32s.rs
+++ b/src/test/run-pass/extern-return-TwoU32s.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-macos Broken on mac i686
+
 struct TwoU32s {
     one: u32, two: u32
 }

--- a/src/test/run-pass/extern-return-TwoU8s.rs
+++ b/src/test/run-pass/extern-return-TwoU8s.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // xfail-win32 #5745
+// xfail-macos Broken on mac i686
 
 struct TwoU8s {
     one: u8, two: u8


### PR DESCRIPTION
Disabling them because they are failing on incoming. Looking into a fix now.
