### PR TITLE
rustc: Fix struct returns on x86 mac for 8-byte structs

### DIFF
--- a/src/librustc/middle/trans/cabi_x86.rs
+++ b/src/librustc/middle/trans/cabi_x86.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use driver::session::os_win32;
+use driver::session::{os_win32, os_macos};
 use core::option::*;
 use lib::llvm::*;
 use lib::llvm::llvm::*;
@@ -38,12 +38,12 @@ impl ABIInfo for X86_ABIInfo {
 
         // Rules for returning structs taken from
         // http://www.angelcode.com/dev/callconv/callconv.html
+        // Clang's ABI handling is in lib/CodeGen/TargetInfo.cpp
         let sret = {
             let returning_a_struct = unsafe { LLVMGetTypeKind(rty) == Struct && ret_def };
-            let big_struct = if self.ccx.sess.targ_cfg.os != os_win32 {
-                true
-            } else {
-                llsize_of_alloc(self.ccx, rty) > 8
+            let big_struct = match self.ccx.sess.targ_cfg.os {
+                os_win32 | os_macos => llsize_of_alloc(self.ccx, rty) > 8,
+                _ => true
             };
             returning_a_struct && big_struct
         };

--- a/src/test/run-pass/extern-pass-TwoU32s.rs
+++ b/src/test/run-pass/extern-pass-TwoU32s.rs
@@ -11,8 +11,6 @@
 // Test a foreign function that accepts and returns a struct
 // by value.
 
-// xfail-macos Broken on mac i686
-
 #[deriving(Eq)]
 struct TwoU32s {
     one: u32, two: u32

--- a/src/test/run-pass/extern-return-TwoU32s.rs
+++ b/src/test/run-pass/extern-return-TwoU32s.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-macos Broken on mac i686
-
 struct TwoU32s {
     one: u32, two: u32
 }


### PR DESCRIPTION
Mac appears to follow the same ABI as MSVC. This fixes one case
but leaves others broken, like windows.
