### PR TITLE
Fix an ICE when dereferencing types which cannot be dereferenced

### DIFF
--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -413,12 +413,9 @@ fn constrain_derefs(rcx: @mut Rcx,
 
         match ty::deref(tcx, derefd_ty, true) {
             Some(mt) => derefd_ty = mt.ty,
-            None => {
-                tcx.sess.span_bug(
-                    deref_expr.span,
-                    fmt!("%?'th deref is of a non-deref'able type `%s`",
-                         i, rcx.fcx.infcx().ty_to_str(derefd_ty)));
-            }
+            /* if this type can't be dereferenced, then there's already an error
+               in the session saying so. Just bail out for now */
+            None => break
         }
     }
 }

--- a/src/test/compile-fail/deref-non-pointer.rs
+++ b/src/test/compile-fail/deref-non-pointer.rs
@@ -8,9 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:cannot be dereferenced
 fn main() {
-  match *1 {
+  match *1 { //~ ERROR: cannot be dereferenced
       _ => { fail!(); }
   }
 }


### PR DESCRIPTION
I ran across this when working on some other changes, and it looked like it wasn't too hard to "fix". I'm not very familiar with this code, but it looks like if an error was already generated there's no need to generate and ICE as well when parts of the program can just be ignored for more incorrectness.
