### PR TITLE
De-mode libsyntax/librustc

### DIFF
--- a/src/libcore/comm.rs
+++ b/src/libcore/comm.rs
@@ -112,8 +112,6 @@ pub mod streamp {
 
     #[allow(non_camel_case_types)]
     pub mod server {
-        priv use core::kinds::Owned;
-
         #[allow(non_camel_case_types)]
         pub type Open<T> = ::core::pipes::RecvPacket<super::Open<T>>;
     }
@@ -388,8 +386,6 @@ pub mod oneshot {
 
     #[allow(non_camel_case_types)]
     pub mod server {
-        priv use core::kinds::Owned;
-
         #[allow(non_camel_case_types)]
         pub type Oneshot<T> =
             ::core::pipes::RecvPacketBuffered<super::Oneshot<T>,

--- a/src/libcore/rt/sched/local_sched.rs
+++ b/src/libcore/rt/sched/local_sched.rs
@@ -66,18 +66,16 @@ pub fn borrow(f: &fn(&mut Scheduler)) {
 /// Because this leaves the Scheduler in thread-local storage it is possible
 /// For the Scheduler pointer to be aliased
 pub unsafe fn unsafe_borrow() -> &mut Scheduler {
-    unsafe {
-        let key = tls_key();
-        let mut void_sched: *mut c_void = tls::get(key);
-        assert!(void_sched.is_not_null());
-        {
-            let void_sched_ptr = &mut void_sched;
-            let sched: &mut ~Scheduler = {
-                transmute::<&mut *mut c_void, &mut ~Scheduler>(void_sched_ptr)
-            };
-            let sched: &mut Scheduler = &mut **sched;
-            return sched;
-        }
+    let key = tls_key();
+    let mut void_sched: *mut c_void = tls::get(key);
+    assert!(void_sched.is_not_null());
+    {
+        let void_sched_ptr = &mut void_sched;
+        let sched: &mut ~Scheduler = {
+            transmute::<&mut *mut c_void, &mut ~Scheduler>(void_sched_ptr)
+        };
+        let sched: &mut Scheduler = &mut **sched;
+        return sched;
     }
 }
 

--- a/src/libcore/rt/uv/net.rs
+++ b/src/libcore/rt/uv/net.rs
@@ -388,7 +388,7 @@ fn connect_read() {
                 vec_to_uv_buf(vec::from_elem(size, 0))
             };
             do stream_watcher.read_start(alloc)
-                |stream_watcher, nread, buf, status| {
+                |stream_watcher, _nread, buf, status| {
 
                 let buf = vec_from_uv_buf(buf);
                 rtdebug!("read cb!");

--- a/src/libcore/stackwalk.rs
+++ b/src/libcore/stackwalk.rs
@@ -64,9 +64,7 @@ fn test_simple_deep() {
         if i == 0 { return }
 
         for walk_stack |_frame| {
-            unsafe {
-                breakpoint();
-            }
+            breakpoint();
         }
         run(i - 1);
     }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -3346,7 +3346,7 @@ mod tests {
     #[test]
     fn test_shift_byte() {
         let mut s = ~"ABC";
-        let b = unsafe { raw::shift_byte(&mut s) };
+        let b = raw::shift_byte(&mut s);
         assert!((s == ~"BC"));
         assert!((b == 65u8));
     }
@@ -3354,7 +3354,7 @@ mod tests {
     #[test]
     fn test_pop_byte() {
         let mut s = ~"ABC";
-        let b = unsafe { raw::pop_byte(&mut s) };
+        let b = raw::pop_byte(&mut s);
         assert!((s == ~"AB"));
         assert!((b == 67u8));
     }

--- a/src/libcore/task/local_data.rs
+++ b/src/libcore/task/local_data.rs
@@ -150,32 +150,28 @@ fn test_tls_modify() {
 
 #[test]
 fn test_tls_crust_automorestack_memorial_bug() {
-    unsafe {
-        // This might result in a stack-canary clobber if the runtime fails to
-        // set sp_limit to 0 when calling the cleanup extern - it might
-        // automatically jump over to the rust stack, which causes next_c_sp
-        // to get recorded as something within a rust stack segment. Then a
-        // subsequent upcall (esp. for logging, think vsnprintf) would run on
-        // a stack smaller than 1 MB.
-        fn my_key(_x: @~str) { }
-        do task::spawn {
-            unsafe { local_data_set(my_key, @~"hax"); }
-        }
+    // This might result in a stack-canary clobber if the runtime fails to
+    // set sp_limit to 0 when calling the cleanup extern - it might
+    // automatically jump over to the rust stack, which causes next_c_sp
+    // to get recorded as something within a rust stack segment. Then a
+    // subsequent upcall (esp. for logging, think vsnprintf) would run on
+    // a stack smaller than 1 MB.
+    fn my_key(_x: @~str) { }
+    do task::spawn {
+        unsafe { local_data_set(my_key, @~"hax"); }
     }
 }
 
 #[test]
 fn test_tls_multiple_types() {
-    unsafe {
-        fn str_key(_x: @~str) { }
-        fn box_key(_x: @@()) { }
-        fn int_key(_x: @int) { }
-        do task::spawn {
-            unsafe {
-                local_data_set(str_key, @~"string data");
-                local_data_set(box_key, @@());
-                local_data_set(int_key, @42);
-            }
+    fn str_key(_x: @~str) { }
+    fn box_key(_x: @@()) { }
+    fn int_key(_x: @int) { }
+    do task::spawn {
+        unsafe {
+            local_data_set(str_key, @~"string data");
+            local_data_set(box_key, @@());
+            local_data_set(int_key, @42);
         }
     }
 }

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -160,7 +160,7 @@ pub fn stash_ty_if(c: @fn(@ast::Ty, test_mode)->bool,
 
 pub struct StolenStuff {exprs: ~[ast::expr], tys: ~[ast::Ty]}
 
-pub fn steal(crate: ast::crate, tm: test_mode) -> StolenStuff {
+pub fn steal(crate: @ast::crate, tm: test_mode) -> StolenStuff {
     let exprs = @mut ~[];
     let tys = @mut ~[];
     let v = visit::mk_simple_visitor(@visit::SimpleVisitor {
@@ -197,7 +197,7 @@ pub fn safe_to_replace_ty(t: &ast::ty_, _tm: test_mode) -> bool {
 }
 
 // Replace the |i|th expr (in fold order) of |crate| with |newexpr|.
-pub fn replace_expr_in_crate(crate: ast::crate, i: uint,
+pub fn replace_expr_in_crate(crate: @ast::crate, i: uint,
                              newexpr: ast::expr, tm: test_mode) ->
    ast::crate {
     let j: @mut uint = @mut 0u;
@@ -222,13 +222,13 @@ pub fn replace_expr_in_crate(crate: ast::crate, i: uint,
         .. *fold::default_ast_fold()
     };
     let af = fold::make_fold(afp);
-    let crate2: @ast::crate = @af.fold_crate(&crate);
+    let crate2: @ast::crate = @af.fold_crate(crate);
     *crate2
 }
 
 
 // Replace the |i|th ty (in fold order) of |crate| with |newty|.
-pub fn replace_ty_in_crate(crate: ast::crate, i: uint, newty: ast::Ty,
+pub fn replace_ty_in_crate(crate: @ast::crate, i: uint, newty: ast::Ty,
                            tm: test_mode) -> ast::crate {
     let j: @mut uint = @mut 0u;
     fn fold_ty_rep(j_: @mut uint,
@@ -248,7 +248,7 @@ pub fn replace_ty_in_crate(crate: ast::crate, i: uint, newty: ast::Ty,
         .. *fold::default_ast_fold()
     };
     let af = fold::make_fold(afp);
-    let crate2: @ast::crate = @af.fold_crate(&crate);
+    let crate2: @ast::crate = @af.fold_crate(crate);
     *crate2
 }
 
@@ -261,7 +261,7 @@ pub fn as_str(f: @fn(+x: @io::Writer)) -> ~str {
     io::with_str_writer(f)
 }
 
-pub fn check_variants_of_ast(crate: ast::crate, codemap: @codemap::CodeMap,
+pub fn check_variants_of_ast(crate: @ast::crate, codemap: @codemap::CodeMap,
                              filename: &Path, cx: Context) {
     let stolen = steal(crate, cx.mode);
     let extra_exprs = do common_exprs().filtered |a| {
@@ -275,13 +275,13 @@ pub fn check_variants_of_ast(crate: ast::crate, codemap: @codemap::CodeMap,
 }
 
 pub fn check_variants_T<T: Copy>(
-  crate: ast::crate,
+  crate: @ast::crate,
   codemap: @codemap::CodeMap,
   filename: &Path,
   thing_label: ~str,
   things: ~[T],
   stringifier: @fn(@T, @syntax::parse::token::ident_interner) -> ~str,
-  replacer: @fn(ast::crate, uint, T, test_mode) -> ast::crate,
+  replacer: @fn(@ast::crate, uint, T, test_mode) -> ast::crate,
   cx: Context
   ) {
     error!("%s contains %u %s objects", filename.to_str(),
@@ -323,7 +323,7 @@ pub fn check_variants_T<T: Copy>(
                                           last_part(filename.to_str()),
                                           thing_label, i, j);
                     let safe_to_run = !(content_is_dangerous_to_run(*str3)
-                                        || has_raw_pointers(*crate2));
+                                        || has_raw_pointers(crate2));
                     check_whole_compiler(*str3, &Path(file_label),
                                          safe_to_run);
                   }
@@ -480,7 +480,7 @@ pub fn parse_and_print(code: @~str) -> ~str {
     }
 }
 
-pub fn has_raw_pointers(c: ast::crate) -> bool {
+pub fn has_raw_pointers(c: @ast::crate) -> bool {
     let has_rp = @mut false;
     fn visit_ty(flag: @mut bool, t: @ast::Ty) {
         match t.node {
@@ -634,7 +634,7 @@ pub fn check_variants(files: &[Path], cx: Context) {
                        pprust::no_ann(),
                        false)))
         });
-        check_variants_of_ast(*crate, sess.cm, file, cx);
+        check_variants_of_ast(crate, sess.cm, file, cx);
     }
 }
 

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -48,7 +48,7 @@ pub enum output_type {
     output_type_exe,
 }
 
-pub fn llvm_err(sess: Session, +msg: ~str) -> ! {
+pub fn llvm_err(sess: Session, msg: ~str) -> ! {
     unsafe {
         let cstr = llvm::LLVMRustGetLastError();
         if cstr == ptr::null() {
@@ -153,7 +153,7 @@ pub mod jit {
                     code: entry,
                     env: ptr::null()
                 };
-                let func: &fn(++argv: ~[@~str]) = cast::transmute(closure);
+                let func: &fn(argv: ~[@~str]) = cast::transmute(closure);
 
                 func(~[sess.opts.binary]);
             }
@@ -519,7 +519,7 @@ pub fn build_link_meta(sess: Session, c: &ast::crate, output: &Path,
 
     // This calculates CMH as defined above
     fn crate_meta_extras_hash(symbol_hasher: &hash::State,
-                              +cmh_items: ~[@ast::meta_item],
+                              cmh_items: ~[@ast::meta_item],
                               dep_hashes: ~[~str]) -> @str {
         fn len_and_str(s: &str) -> ~str {
             fmt!("%u_%s", s.len(), s)
@@ -568,7 +568,7 @@ pub fn build_link_meta(sess: Session, c: &ast::crate, output: &Path,
                        name, default));
     }
 
-    fn crate_meta_name(sess: Session, output: &Path, +opt_name: Option<@str>)
+    fn crate_meta_name(sess: Session, output: &Path, opt_name: Option<@str>)
                     -> @str {
         return match opt_name {
               Some(v) => v,
@@ -703,7 +703,7 @@ pub fn mangle(sess: Session, ss: path) -> ~str {
 }
 
 pub fn exported_name(sess: Session,
-                     +path: path,
+                     path: path,
                      hash: &str,
                      vers: &str) -> ~str {
     return mangle(sess,
@@ -713,7 +713,7 @@ pub fn exported_name(sess: Session,
 }
 
 pub fn mangle_exported_name(ccx: @CrateContext,
-                            +path: path,
+                            path: path,
                             t: ty::t) -> ~str {
     let hash = get_symbol_hash(ccx, t);
     return exported_name(ccx.sess, path,
@@ -733,17 +733,17 @@ pub fn mangle_internal_name_by_type_only(ccx: @CrateContext,
 }
 
 pub fn mangle_internal_name_by_path_and_seq(ccx: @CrateContext,
-                                            +path: path,
-                                            +flav: ~str) -> ~str {
+                                            path: path,
+                                            flav: ~str) -> ~str {
     return mangle(ccx.sess,
                   vec::append_one(path, path_name((ccx.names)(flav))));
 }
 
-pub fn mangle_internal_name_by_path(ccx: @CrateContext, +path: path) -> ~str {
+pub fn mangle_internal_name_by_path(ccx: @CrateContext, path: path) -> ~str {
     return mangle(ccx.sess, path);
 }
 
-pub fn mangle_internal_name_by_seq(ccx: @CrateContext, +flav: ~str) -> ~str {
+pub fn mangle_internal_name_by_seq(ccx: @CrateContext, flav: ~str) -> ~str {
     return fmt!("%s_%u", flav, (ccx.names)(flav).repr);
 }
 
@@ -768,7 +768,7 @@ pub fn link_binary(sess: Session,
                    out_filename: &Path,
                    lm: LinkMeta) {
     // Converts a library file-stem into a cc -l argument
-    fn unlib(config: @session::config, +stem: ~str) -> ~str {
+    fn unlib(config: @session::config, stem: ~str) -> ~str {
         if stem.starts_with("lib") &&
             config.os != session::os_win32 {
             stem.slice(3, stem.len()).to_owned()

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -215,7 +215,7 @@ pub impl Session_ {
     fn unimpl(@self, msg: ~str) -> ! {
         self.span_diagnostic.handler().unimpl(msg)
     }
-    fn span_lint_level(@self, level: lint::level, sp: span, +msg: ~str) {
+    fn span_lint_level(@self, level: lint::level, sp: span, msg: ~str) {
         match level {
           lint::allow => { },
           lint::warn => self.span_warn(sp, msg),
@@ -228,7 +228,7 @@ pub impl Session_ {
                  expr_id: ast::node_id,
                  item_id: ast::node_id,
                  span: span,
-                 +msg: ~str) {
+                 msg: ~str) {
         let level = lint::get_lint_settings_level(
             self.lint_settings, lint_mode, expr_id, item_id);
         self.span_lint_level(level, span, msg);
@@ -278,7 +278,7 @@ pub impl Session_ {
     fn str_of(@self, id: ast::ident) -> @~str {
         self.parse_sess.interner.get(id)
     }
-    fn ident_of(@self, +st: ~str) -> ast::ident {
+    fn ident_of(@self, st: ~str) -> ast::ident {
         self.parse_sess.interner.intern(@st)
     }
     fn intr(@self) -> @syntax::parse::token::ident_interner {
@@ -361,7 +361,7 @@ mod test {
     use syntax::ast;
     use syntax::codemap;
 
-    fn make_crate_type_attr(+t: ~str) -> ast::attribute {
+    fn make_crate_type_attr(t: ~str) -> ast::attribute {
         codemap::respan(codemap::dummy_sp(), ast::attribute_ {
             style: ast::attr_outer,
             value: @codemap::respan(codemap::dummy_sp(),

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -15,7 +15,7 @@ use syntax::{ast, fold, attr};
 use core::option;
 use core::vec;
 
-type in_cfg_pred = @fn(+attrs: ~[ast::attribute]) -> bool;
+type in_cfg_pred = @fn(attrs: ~[ast::attribute]) -> bool;
 
 struct Context {
     in_cfg: in_cfg_pred
@@ -49,12 +49,12 @@ pub fn strip_items(crate: @ast::crate, in_cfg: in_cfg_pred)
     return res;
 }
 
-fn filter_item(cx: @Context, &&item: @ast::item) ->
+fn filter_item(cx: @Context, item: @ast::item) ->
    Option<@ast::item> {
     if item_in_cfg(cx, item) { option::Some(item) } else { option::None }
 }
 
-fn filter_view_item(cx: @Context, &&view_item: @ast::view_item
+fn filter_view_item(cx: @Context, view_item: @ast::view_item
                    )-> Option<@ast::view_item> {
     if view_item_in_cfg(cx, view_item) {
         option::Some(view_item)
@@ -74,7 +74,7 @@ fn fold_mod(cx: @Context, m: &ast::_mod, fld: @fold::ast_fold) -> ast::_mod {
     }
 }
 
-fn filter_foreign_item(cx: @Context, &&item: @ast::foreign_item) ->
+fn filter_foreign_item(cx: @Context, item: @ast::foreign_item) ->
    Option<@ast::foreign_item> {
     if foreign_item_in_cfg(cx, item) {
         option::Some(item)
@@ -115,7 +115,7 @@ fn fold_item_underscore(cx: @Context, item: &ast::item_,
     fold::noop_fold_item_underscore(&item, fld)
 }
 
-fn filter_stmt(cx: @Context, &&stmt: @ast::stmt) ->
+fn filter_stmt(cx: @Context, stmt: @ast::stmt) ->
    Option<@ast::stmt> {
     match stmt.node {
       ast::stmt_decl(decl, _) => {
@@ -173,12 +173,12 @@ fn trait_method_in_cfg(cx: @Context, meth: &ast::trait_method) -> bool {
 
 // Determine if an item should be translated in the current crate
 // configuration based on the item's attributes
-fn in_cfg(+cfg: ast::crate_cfg, +attrs: ~[ast::attribute]) -> bool {
+fn in_cfg(cfg: ast::crate_cfg, attrs: ~[ast::attribute]) -> bool {
     metas_in_cfg(cfg, attr::attr_metas(attrs))
 }
 
 pub fn metas_in_cfg(cfg: ast::crate_cfg,
-                    +metas: ~[@ast::meta_item]) -> bool {
+                    metas: ~[@ast::meta_item]) -> bool {
     // The "cfg" attributes on the item
     let cfg_metas = attr::find_meta_items_by_name(metas, ~"cfg");
 

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -138,7 +138,7 @@ fn fold_crate(cx: @mut TestCtxt,
 }
 
 
-fn fold_item(cx: @mut TestCtxt, &&i: @ast::item, fld: @fold::ast_fold)
+fn fold_item(cx: @mut TestCtxt, i: @ast::item, fld: @fold::ast_fold)
           -> Option<@ast::item> {
     cx.path.push(i.ident);
     debug!("current path: %s",
@@ -336,7 +336,7 @@ fn nospan<T:Copy>(t: T) -> codemap::spanned<T> {
     codemap::spanned { node: t, span: dummy_sp() }
 }
 
-fn path_node(+ids: ~[ast::ident]) -> @ast::Path {
+fn path_node(ids: ~[ast::ident]) -> @ast::Path {
     @ast::Path { span: dummy_sp(),
                 global: false,
                 idents: ids,
@@ -344,7 +344,7 @@ fn path_node(+ids: ~[ast::ident]) -> @ast::Path {
                 types: ~[] }
 }
 
-fn path_node_global(+ids: ~[ast::ident]) -> @ast::Path {
+fn path_node_global(ids: ~[ast::ident]) -> @ast::Path {
     @ast::Path { span: dummy_sp(),
                  global: true,
                  idents: ids,
@@ -381,7 +381,7 @@ fn mk_test_descs(cx: &TestCtxt) -> @ast::expr {
     debug!("building test vector from %u tests", cx.testfns.len());
     let mut descs = ~[];
     for cx.testfns.each |test| {
-        descs.push(mk_test_desc_and_fn_rec(cx, *test));
+        descs.push(mk_test_desc_and_fn_rec(cx, test));
     }
 
     let sess = cx.sess;
@@ -400,7 +400,7 @@ fn mk_test_descs(cx: &TestCtxt) -> @ast::expr {
     }
 }
 
-fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: Test) -> @ast::expr {
+fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: &Test) -> @ast::expr {
     let span = test.span;
     let path = /*bad*/copy test.path;
 

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1929,7 +1929,7 @@ pub fn type_to_str(names: @TypeNames, ty: TypeRef) -> @str {
     return type_to_str_inner(names, [], ty);
 }
 
-pub fn type_to_str_inner(names: @TypeNames, +outer0: &[TypeRef], ty: TypeRef)
+pub fn type_to_str_inner(names: @TypeNames, outer0: &[TypeRef], ty: TypeRef)
                       -> @str {
     unsafe {
         match type_has_name(names, ty) {

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -30,7 +30,7 @@ use syntax::ast;
 // Traverses an AST, reading all the information about use'd crates and extern
 // libraries necessary for later resolving, typechecking, linking, etc.
 pub fn read_crates(diag: @span_handler,
-                   crate: ast::crate,
+                   crate: @ast::crate,
                    cstore: @mut cstore::CStore,
                    filesearch: @FileSearch,
                    os: loader::os,
@@ -126,7 +126,7 @@ struct Env {
     intr: @ident_interner
 }
 
-fn visit_crate(e: @mut Env, c: ast::crate) {
+fn visit_crate(e: @mut Env, c: &ast::crate) {
     let cstore = e.cstore;
     let link_args = attr::find_attrs_by_name(c.node.attrs, "link_args");
 
@@ -204,7 +204,7 @@ fn visit_item(e: @mut Env, i: @ast::item) {
     }
 }
 
-fn metas_with(ident: @~str, key: @~str, +metas: ~[@ast::meta_item])
+fn metas_with(ident: @~str, key: @~str, metas: ~[@ast::meta_item])
     -> ~[@ast::meta_item] {
     let name_items = attr::find_meta_items_by_name(metas, *key);
     if name_items.is_empty() {
@@ -214,7 +214,7 @@ fn metas_with(ident: @~str, key: @~str, +metas: ~[@ast::meta_item])
     }
 }
 
-fn metas_with_ident(ident: @~str, +metas: ~[@ast::meta_item])
+fn metas_with_ident(ident: @~str, metas: ~[@ast::meta_item])
     -> ~[@ast::meta_item] {
     metas_with(ident, @~"name", metas)
 }
@@ -232,7 +232,7 @@ fn existing_match(e: @mut Env, metas: &[@ast::meta_item], hash: @~str)
 
 fn resolve_crate(e: @mut Env,
                  ident: ast::ident,
-                 +metas: ~[@ast::meta_item],
+                 metas: ~[@ast::meta_item],
                  hash: @~str,
                  span: span)
               -> ast::crate_num {
@@ -251,7 +251,7 @@ fn resolve_crate(e: @mut Env,
             is_static: e.statik,
             intr: e.intr
         };
-        let (lident, ldata) = loader::load_library_crate(load_ctxt);
+        let (lident, ldata) = loader::load_library_crate(&load_ctxt);
 
         let cfilename = Path(lident);
         let cdata = ldata;

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -35,9 +35,9 @@ pub trait FileSearch {
     fn get_target_lib_file_path(&self, file: &Path) -> Path;
 }
 
-pub fn mk_filesearch(maybe_sysroot: Option<Path>,
+pub fn mk_filesearch(maybe_sysroot: &Option<Path>,
                      target_triple: &str,
-                     +addl_lib_search_paths: ~[Path])
+                     addl_lib_search_paths: ~[Path])
                   -> @FileSearch {
     struct FileSearchImpl {
         sysroot: Path,
@@ -117,8 +117,8 @@ fn get_or_default_sysroot() -> Path {
     }
 }
 
-fn get_sysroot(maybe_sysroot: Option<Path>) -> Path {
-    match maybe_sysroot {
+fn get_sysroot(maybe_sysroot: &Option<Path>) -> Path {
+    match *maybe_sysroot {
       option::Some(ref sr) => (/*bad*/copy *sr),
       option::None => get_or_default_sysroot()
     }

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -55,7 +55,7 @@ pub struct Context {
     intr: @ident_interner
 }
 
-pub fn load_library_crate(cx: Context) -> (~str, @~[u8]) {
+pub fn load_library_crate(cx: &Context) -> (~str, @~[u8]) {
     match find_library_crate(cx) {
       Some(ref t) => return (/*bad*/copy *t),
       None => {
@@ -66,12 +66,12 @@ pub fn load_library_crate(cx: Context) -> (~str, @~[u8]) {
     }
 }
 
-fn find_library_crate(cx: Context) -> Option<(~str, @~[u8])> {
+fn find_library_crate(cx: &Context) -> Option<(~str, @~[u8])> {
     attr::require_unique_names(cx.diag, cx.metas);
     find_library_crate_aux(cx, libname(cx), cx.filesearch)
 }
 
-fn libname(cx: Context) -> (~str, ~str) {
+fn libname(cx: &Context) -> (~str, ~str) {
     if cx.is_static { return (~"lib", ~".rlib"); }
     let (dll_prefix, dll_suffix) = match cx.os {
         os_win32 => (win32::DLL_PREFIX, win32::DLL_SUFFIX),
@@ -85,7 +85,7 @@ fn libname(cx: Context) -> (~str, ~str) {
 }
 
 fn find_library_crate_aux(
-    cx: Context,
+    cx: &Context,
     (prefix, suffix): (~str, ~str),
     filesearch: @filesearch::FileSearch
 ) -> Option<(~str, @~[u8])> {

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -116,16 +116,16 @@ fn enc_mt(w: @io::Writer, cx: @ctxt, mt: ty::mt) {
 }
 
 fn enc_opt<T>(w: @io::Writer, t: Option<T>, enc_f: &fn(T)) {
-    match &t {
-      &None => w.write_char('n'),
-      &Some(ref v) => {
+    match t {
+      None => w.write_char('n'),
+      Some(v) => {
         w.write_char('s');
-        enc_f((*v));
+        enc_f(v);
       }
     }
 }
 
-fn enc_substs(w: @io::Writer, cx: @ctxt, substs: ty::substs) {
+fn enc_substs(w: @io::Writer, cx: @ctxt, substs: &ty::substs) {
     do enc_opt(w, substs.self_r) |r| { enc_region(w, cx, r) }
     do enc_opt(w, substs.self_ty) |t| { enc_ty(w, cx, t) }
     w.write_char('[');
@@ -210,7 +210,7 @@ pub fn enc_vstore(w: @io::Writer, cx: @ctxt, v: ty::vstore) {
 pub fn enc_trait_ref(w: @io::Writer, cx: @ctxt, s: &ty::TraitRef) {
     w.write_str((cx.ds)(s.def_id));
     w.write_char('|');
-    enc_substs(w, cx, s.substs);
+    enc_substs(w, cx, &s.substs);
 }
 
 pub fn enc_trait_store(w: @io::Writer, cx: @ctxt, s: ty::TraitStore) {
@@ -224,7 +224,7 @@ pub fn enc_trait_store(w: @io::Writer, cx: @ctxt, s: ty::TraitStore) {
     }
 }
 
-fn enc_sty(w: @io::Writer, cx: @ctxt, +st: ty::sty) {
+fn enc_sty(w: @io::Writer, cx: @ctxt, st: ty::sty) {
     match st {
       ty::ty_nil => w.write_char('n'),
       ty::ty_bot => w.write_char('z'),
@@ -259,14 +259,14 @@ fn enc_sty(w: @io::Writer, cx: @ctxt, +st: ty::sty) {
         w.write_str(&"t[");
         w.write_str((cx.ds)(def));
         w.write_char('|');
-        enc_substs(w, cx, (*substs));
+        enc_substs(w, cx, substs);
         w.write_char(']');
       }
       ty::ty_trait(def, ref substs, store, mt) => {
         w.write_str(&"x[");
         w.write_str((cx.ds)(def));
         w.write_char('|');
-        enc_substs(w, cx, (*substs));
+        enc_substs(w, cx, substs);
         enc_trait_store(w, cx, store);
         enc_mutability(w, mt);
         w.write_char(']');
@@ -330,7 +330,7 @@ fn enc_sty(w: @io::Writer, cx: @ctxt, +st: ty::sty) {
           w.write_str(s);
           debug!("~~~~ %s", ~"|");
           w.write_char('|');
-          enc_substs(w, cx, (*substs));
+          enc_substs(w, cx, substs);
           debug!("~~~~ %s", ~"]");
           w.write_char(']');
       }

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -79,7 +79,7 @@ enum impurity_cause {
 }
 
 pub fn check_loans(bccx: @BorrowckCtxt,
-                   +req_maps: ReqMaps,
+                   req_maps: ReqMaps,
                    crate: @ast::crate) {
     let clcx = @mut CheckLoanCtxt {
         bccx: bccx,
@@ -94,7 +94,7 @@ pub fn check_loans(bccx: @BorrowckCtxt,
                                            visit_block: check_loans_in_block,
                                            visit_fn: check_loans_in_fn,
                                            .. *visit::default_visitor()});
-    visit::visit_crate(*crate, clcx, vt);
+    visit::visit_crate(crate, clcx, vt);
 }
 
 #[deriving(Eq)]
@@ -619,7 +619,7 @@ fn check_loans_in_fn(fk: &visit::fn_kind,
                      body: &ast::blk,
                      sp: span,
                      id: ast::node_id,
-                     &&self: @mut CheckLoanCtxt,
+                     self: @mut CheckLoanCtxt,
                      visitor: visit::vt<@mut CheckLoanCtxt>) {
     let is_stack_closure = self.is_stack_closure(id);
     let fty = ty::node_id_to_type(self.tcx(), id);
@@ -726,13 +726,13 @@ fn check_loans_in_fn(fk: &visit::fn_kind,
 }
 
 fn check_loans_in_local(local: @ast::local,
-                        &&self: @mut CheckLoanCtxt,
+                        self: @mut CheckLoanCtxt,
                         vt: visit::vt<@mut CheckLoanCtxt>) {
     visit::visit_local(local, self, vt);
 }
 
 fn check_loans_in_expr(expr: @ast::expr,
-                       &&self: @mut CheckLoanCtxt,
+                       self: @mut CheckLoanCtxt,
                        vt: visit::vt<@mut CheckLoanCtxt>) {
     debug!("check_loans_in_expr(expr=%?/%s)",
            expr.id, pprust::expr_to_str(expr, self.tcx().sess.intr()));
@@ -794,7 +794,7 @@ fn check_loans_in_expr(expr: @ast::expr,
 }
 
 fn check_loans_in_block(blk: &ast::blk,
-                        &&self: @mut CheckLoanCtxt,
+                        self: @mut CheckLoanCtxt,
                         vt: visit::vt<@mut CheckLoanCtxt>) {
     do save_and_restore_managed(self.declared_purity) {
         self.check_for_conflicting_loans(blk.node.id);

--- a/src/librustc/middle/borrowck/gather_loans.rs
+++ b/src/librustc/middle/borrowck/gather_loans.rs
@@ -88,7 +88,7 @@ pub fn gather_loans(bccx: @BorrowckCtxt, crate: @ast::crate) -> ReqMaps {
                                           visit_fn: req_loans_in_fn,
                                           visit_stmt: add_stmt_to_map,
                                           .. *visit::default_visitor()});
-    visit::visit_crate(*crate, glcx, v);
+    visit::visit_crate(crate, glcx, v);
     let @GatherLoanCtxt{req_maps, _} = glcx;
     return req_maps;
 }
@@ -98,7 +98,7 @@ fn req_loans_in_fn(fk: &visit::fn_kind,
                    body: &ast::blk,
                    sp: span,
                    id: ast::node_id,
-                   &&self: @mut GatherLoanCtxt,
+                   self: @mut GatherLoanCtxt,
                    v: visit::vt<@mut GatherLoanCtxt>) {
     // see explanation attached to the `root_ub` field:
     let old_item_id = self.item_ub;
@@ -119,7 +119,7 @@ fn req_loans_in_fn(fk: &visit::fn_kind,
 }
 
 fn req_loans_in_expr(ex: @ast::expr,
-                     &&self: @mut GatherLoanCtxt,
+                     self: @mut GatherLoanCtxt,
                      vt: visit::vt<@mut GatherLoanCtxt>) {
     let bccx = self.bccx;
     let tcx = bccx.tcx;
@@ -489,7 +489,7 @@ pub impl GatherLoanCtxt {
                  cmt: cmt,
                  loan_kind: LoanKind,
                  scope_r: ty::Region,
-                 +loans: ~[Loan]) {
+                 loans: ~[Loan]) {
         if loans.len() == 0 {
             return;
         }
@@ -555,7 +555,7 @@ pub impl GatherLoanCtxt {
 
     fn add_loans_to_scope_id(&mut self,
                              scope_id: ast::node_id,
-                             +loans: ~[Loan]) {
+                             loans: ~[Loan]) {
         debug!("adding %u loans to scope_id %?: %s",
                loans.len(), scope_id,
                str::connect(loans.map(|l| self.bccx.loan_to_repr(l)), ", "));
@@ -665,7 +665,7 @@ pub impl GatherLoanCtxt {
 // Setting up info that preserve needs.
 // This is just the most convenient place to do it.
 fn add_stmt_to_map(stmt: @ast::stmt,
-                   &&self: @mut GatherLoanCtxt,
+                   self: @mut GatherLoanCtxt,
                    vt: visit::vt<@mut GatherLoanCtxt>) {
     match stmt.node {
         ast::stmt_expr(_, id) | ast::stmt_semi(_, id) => {

--- a/src/librustc/middle/borrowck/loan.rs
+++ b/src/librustc/middle/borrowck/loan.rs
@@ -257,10 +257,10 @@ pub impl LoanContext {
     }
 
     fn issue_loan(&mut self,
-                  +cmt: cmt,
-                  +scope_ub: ty::Region,
-                  +loan_kind: LoanKind,
-                  +owns_lent_data: bool) -> bckres<()> {
+                  cmt: cmt,
+                  scope_ub: ty::Region,
+                  loan_kind: LoanKind,
+                  owns_lent_data: bool) -> bckres<()> {
         // Subtle: the `scope_ub` is the maximal lifetime of `cmt`.
         // Therefore, if `cmt` owns the data being lent, then the
         // scope of the loan must be less than `scope_ub`, or else the

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -443,7 +443,7 @@ pub impl LoanKind {
 /// Creates and returns a new root_map
 
 impl to_bytes::IterBytes for root_map_key {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.id, &self.derefs, lsb0, f);
     }
 }
@@ -529,11 +529,11 @@ pub impl BorrowckCtxt {
         self.note_and_explain_bckerr(err);
     }
 
-    fn span_err(&self, s: span, +m: ~str) {
+    fn span_err(&self, s: span, m: ~str) {
         self.tcx.sess.span_err(s, m);
     }
 
-    fn span_note(&self, s: span, +m: ~str) {
+    fn span_note(&self, s: span, m: ~str) {
         self.tcx.sess.span_note(s, m);
     }
 

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -26,7 +26,7 @@ pub fn check_crate(sess: Session,
                    def_map: resolve::DefMap,
                    method_map: typeck::method_map,
                    tcx: ty::ctxt) {
-    visit::visit_crate(*crate, false, visit::mk_vt(@visit::Visitor {
+    visit::visit_crate(crate, false, visit::mk_vt(@visit::Visitor {
         visit_item: |a,b,c| check_item(sess, ast_map, def_map, a, b, c),
         visit_pat: check_pat,
         visit_expr: |a,b,c|
@@ -40,7 +40,7 @@ pub fn check_item(sess: Session,
                   ast_map: ast_map::map,
                   def_map: resolve::DefMap,
                   it: @item,
-                  &&_is_const: bool,
+                  _is_const: bool,
                   v: visit::vt<bool>) {
     match it.node {
       item_const(_, ex) => {
@@ -58,7 +58,7 @@ pub fn check_item(sess: Session,
     }
 }
 
-pub fn check_pat(p: @pat, &&_is_const: bool, v: visit::vt<bool>) {
+pub fn check_pat(p: @pat, _is_const: bool, v: visit::vt<bool>) {
     fn is_str(e: @expr) -> bool {
         match e.node {
             expr_vstore(
@@ -87,7 +87,7 @@ pub fn check_expr(sess: Session,
                   method_map: typeck::method_map,
                   tcx: ty::ctxt,
                   e: @expr,
-                  &&is_const: bool,
+                  is_const: bool,
                   v: visit::vt<bool>) {
     if is_const {
         match e.node {
@@ -224,7 +224,7 @@ pub fn check_item_recursion(sess: Session,
     });
     (visitor.visit_item)(it, env, visitor);
 
-    fn visit_item(it: @item, &&env: env, v: visit::vt<env>) {
+    fn visit_item(it: @item, env: env, v: visit::vt<env>) {
         if env.idstack.contains(&(it.id)) {
             env.sess.span_fatal(env.root_it.span, ~"recursive constant");
         }
@@ -233,7 +233,7 @@ pub fn check_item_recursion(sess: Session,
         env.idstack.pop();
     }
 
-    fn visit_expr(e: @expr, &&env: env, v: visit::vt<env>) {
+    fn visit_expr(e: @expr, env: env, v: visit::vt<env>) {
         match e.node {
           expr_path(*) => {
             match env.def_map.find(&e.id) {

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -20,7 +20,7 @@ pub struct Context {
 }
 
 pub fn check_crate(tcx: ty::ctxt, crate: @crate) {
-    visit::visit_crate(*crate,
+    visit::visit_crate(crate,
                        Context { in_loop: false, can_ret: true },
                        visit::mk_vt(@visit::Visitor {
         visit_item: |i, _cx, v| {

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -229,7 +229,7 @@ pub fn process_crate(crate: @ast::crate,
         visit_expr_post: |e| { classify(e, tcx); },
         .. *visit::default_simple_visitor()
     });
-    visit::visit_crate(*crate, (), v);
+    visit::visit_crate(crate, (), v);
     tcx.sess.abort_if_errors();
 }
 
@@ -426,8 +426,8 @@ pub fn lit_to_const(lit: @lit) -> const_val {
     }
 }
 
-pub fn compare_const_vals(a: const_val, b: const_val) -> int {
-  match (&a, &b) {
+pub fn compare_const_vals(a: &const_val, b: &const_val) -> int {
+  match (a, b) {
     (&const_int(a), &const_int(b)) => {
         if a == b {
             0
@@ -478,7 +478,7 @@ pub fn compare_const_vals(a: const_val, b: const_val) -> int {
 }
 
 pub fn compare_lit_exprs(tcx: middle::ty::ctxt, a: @expr, b: @expr) -> int {
-  compare_const_vals(eval_const_expr(tcx, a), eval_const_expr(tcx, b))
+  compare_const_vals(&eval_const_expr(tcx, a), &eval_const_expr(tcx, b))
 }
 
 pub fn lit_expr_eq(tcx: middle::ty::ctxt, a: @expr, b: @expr) -> bool {
@@ -486,7 +486,7 @@ pub fn lit_expr_eq(tcx: middle::ty::ctxt, a: @expr, b: @expr) -> bool {
 }
 
 pub fn lit_eq(a: @lit, b: @lit) -> bool {
-    compare_const_vals(lit_to_const(a), lit_to_const(b)) == 0
+    compare_const_vals(&lit_to_const(a), &lit_to_const(b)) == 0
 }
 
 

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -42,9 +42,9 @@ fn collect_freevars(def_map: resolve::DefMap, blk: &ast::blk)
     let seen = @mut HashMap::new();
     let refs = @mut ~[];
 
-    fn ignore_item(_i: @ast::item, &&_depth: int, _v: visit::vt<int>) { }
+    fn ignore_item(_i: @ast::item, _depth: int, _v: visit::vt<int>) { }
 
-    let walk_expr: @fn(expr: @ast::expr, &&depth: int, v: visit::vt<int>) =
+    let walk_expr: @fn(expr: @ast::expr, depth: int, v: visit::vt<int>) =
         |expr, depth, v| {
             match expr.node {
               ast::expr_fn_block(*) => visit::visit_expr(expr, depth + 1, v),
@@ -107,7 +107,7 @@ pub fn annotate_freevars(def_map: resolve::DefMap, crate: @ast::crate) ->
         visit::mk_simple_visitor(@visit::SimpleVisitor {
             visit_fn: walk_fn,
             .. *visit::default_simple_visitor()});
-    visit::visit_crate(*crate, (), visitor);
+    visit::visit_crate(crate, (), visitor);
 
     return freevars;
 }

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -81,7 +81,7 @@ pub fn check_crate(tcx: ty::ctxt,
         visit_block: check_block,
         .. *visit::default_visitor()
     });
-    visit::visit_crate(*crate, ctx, visit);
+    visit::visit_crate(crate, ctx, visit);
     tcx.sess.abort_if_errors();
 }
 
@@ -573,7 +573,7 @@ pub fn check_cast_for_escaping_regions(
             true
         });
 
-    fn is_re_scope(+r: ty::Region) -> bool {
+    fn is_re_scope(r: ty::Region) -> bool {
         match r {
             ty::re_scope(*) => true,
             _ => false

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -370,7 +370,7 @@ pub impl<'self> LanguageItemCollector<'self> {
 
     fn collect_local_language_items(&self) {
         let this = ptr::addr_of(&self);
-        visit_crate(*self.crate, (), mk_simple_visitor(@SimpleVisitor {
+        visit_crate(self.crate, (), mk_simple_visitor(@SimpleVisitor {
             visit_item: |item| {
                 for item.attrs.each |attribute| {
                     unsafe {

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -348,7 +348,7 @@ pub impl Context {
         }
     }
 
-    fn span_lint(&self, level: level, span: span, +msg: ~str) {
+    fn span_lint(&self, level: level, span: span, msg: ~str) {
         self.sess.span_lint_level(level, span, msg);
     }
 
@@ -438,7 +438,7 @@ pub impl Context {
 }
 
 
-fn build_settings_item(i: @ast::item, &&cx: Context, v: visit::vt<Context>) {
+fn build_settings_item(i: @ast::item, cx: Context, v: visit::vt<Context>) {
     do cx.with_lint_attrs(/*bad*/copy i.attrs) |cx| {
         if !cx.is_default {
             cx.sess.lint_settings.settings_map.insert(i.id, cx.curr);
@@ -481,7 +481,7 @@ pub fn build_settings_crate(sess: session::Session, crate: @ast::crate) {
             visit_item: build_settings_item,
             .. *visit::default_visitor()
         });
-        visit::visit_crate(*crate, cx, visit);
+        visit::visit_crate(crate, cx, visit);
     }
 
     sess.abort_if_errors();
@@ -1088,7 +1088,7 @@ pub fn check_crate(tcx: ty::ctxt, crate: @ast::crate) {
             check_fn(tcx, fk, decl, body, span, id),
         .. *visit::default_simple_visitor()
     });
-    visit::visit_crate(*crate, (), v);
+    visit::visit_crate(crate, (), v);
 
     tcx.sess.abort_if_errors();
 }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -182,7 +182,7 @@ pub fn check_crate(tcx: ty::ctxt,
                                    capture_map,
                                    last_use_map,
                                    0);
-    visit::visit_crate(*crate, initial_maps, visitor);
+    visit::visit_crate(crate, initial_maps, visitor);
     tcx.sess.abort_if_errors();
     return last_use_map;
 }
@@ -358,7 +358,7 @@ pub impl IrMaps {
         }
     }
 
-    fn set_captures(&mut self, node_id: node_id, +cs: ~[CaptureInfo]) {
+    fn set_captures(&mut self, node_id: node_id, cs: ~[CaptureInfo]) {
         self.capture_info_map.insert(node_id, @cs);
     }
 
@@ -402,7 +402,7 @@ pub impl IrMaps {
     }
 }
 
-fn visit_item(item: @item, &&self: @mut IrMaps, v: vt<@mut IrMaps>) {
+fn visit_item(item: @item, self: @mut IrMaps, v: vt<@mut IrMaps>) {
     do with(&mut self.cur_item, item.id) {
         visit::visit_item(item, self, v)
     }
@@ -413,7 +413,7 @@ fn visit_fn(fk: &visit::fn_kind,
             body: &blk,
             sp: span,
             id: node_id,
-            &&self: @mut IrMaps,
+            self: @mut IrMaps,
             v: vt<@mut IrMaps>) {
     debug!("visit_fn: id=%d", id);
     let _i = ::util::common::indenter();
@@ -489,7 +489,7 @@ fn visit_fn(fk: &visit::fn_kind,
     lsets.warn_about_unused_args(decl, entry_ln);
 }
 
-fn visit_local(local: @local, &&self: @mut IrMaps, vt: vt<@mut IrMaps>) {
+fn visit_local(local: @local, self: @mut IrMaps, vt: vt<@mut IrMaps>) {
     let def_map = self.tcx.def_map;
     do pat_util::pat_bindings(def_map, local.node.pat) |_bm, p_id, sp, path| {
         debug!("adding local variable %d", p_id);
@@ -509,7 +509,7 @@ fn visit_local(local: @local, &&self: @mut IrMaps, vt: vt<@mut IrMaps>) {
     visit::visit_local(local, self, vt);
 }
 
-fn visit_arm(arm: &arm, &&self: @mut IrMaps, vt: vt<@mut IrMaps>) {
+fn visit_arm(arm: &arm, self: @mut IrMaps, vt: vt<@mut IrMaps>) {
     let def_map = self.tcx.def_map;
     for arm.pats.each |pat| {
         do pat_util::pat_bindings(def_map, *pat) |bm, p_id, sp, path| {
@@ -528,7 +528,7 @@ fn visit_arm(arm: &arm, &&self: @mut IrMaps, vt: vt<@mut IrMaps>) {
     visit::visit_arm(arm, self, vt);
 }
 
-fn visit_expr(expr: @expr, &&self: @mut IrMaps, vt: vt<@mut IrMaps>) {
+fn visit_expr(expr: @expr, self: @mut IrMaps, vt: vt<@mut IrMaps>) {
     match expr.node {
       // live nodes required for uses or definitions of variables:
       expr_path(_) => {
@@ -1510,7 +1510,7 @@ pub impl Liveness {
 // _______________________________________________________________________
 // Checking for error conditions
 
-fn check_local(local: @local, &&self: @Liveness, vt: vt<@Liveness>) {
+fn check_local(local: @local, self: @Liveness, vt: vt<@Liveness>) {
     match local.node.init {
       Some(_) => {
 
@@ -1544,14 +1544,14 @@ fn check_local(local: @local, &&self: @Liveness, vt: vt<@Liveness>) {
     visit::visit_local(local, self, vt);
 }
 
-fn check_arm(arm: &arm, &&self: @Liveness, vt: vt<@Liveness>) {
+fn check_arm(arm: &arm, self: @Liveness, vt: vt<@Liveness>) {
     do self.arm_pats_bindings(arm.pats) |ln, var, sp, id| {
         self.warn_about_unused(sp, id, ln, var);
     }
     visit::visit_arm(arm, self, vt);
 }
 
-fn check_expr(expr: @expr, &&self: @Liveness, vt: vt<@Liveness>) {
+fn check_expr(expr: @expr, self: @Liveness, vt: vt<@Liveness>) {
     match expr.node {
       expr_path(_) => {
         for self.variable_from_def_map(expr.id, expr.span).each |var| {
@@ -1632,7 +1632,7 @@ fn check_expr(expr: @expr, &&self: @Liveness, vt: vt<@Liveness>) {
 
 fn check_fn(_fk: &visit::fn_kind, _decl: &fn_decl,
             _body: &blk, _sp: span, _id: node_id,
-            &&_self: @Liveness, _v: vt<@Liveness>) {
+            _self: @Liveness, _v: vt<@Liveness>) {
     // do not check contents of nested fns
 }
 

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -285,7 +285,7 @@ pub fn compute_moves(tcx: ty::ctxt,
             capture_map: @mut HashMap::new()
         }
     };
-    visit::visit_crate(*crate, visit_cx, visitor);
+    visit::visit_crate(crate, visit_cx, visitor);
     return visit_cx.move_maps;
 }
 
@@ -293,7 +293,7 @@ pub fn compute_moves(tcx: ty::ctxt,
 // Expressions
 
 fn compute_modes_for_expr(expr: @expr,
-                          &&cx: VisitContext,
+                          cx: VisitContext,
                           v: vt<VisitContext>)
 {
     cx.consume_expr(expr, v);
@@ -760,7 +760,7 @@ pub impl VisitContext {
 
     fn arms_have_by_move_bindings(&self,
                                   moves_map: MovesMap,
-                                  +arms: &[arm]) -> bool
+                                  arms: &[arm]) -> bool
     {
         for arms.each |arm| {
             for arm.pats.each |pat| {

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -604,6 +604,6 @@ pub fn check_crate(tcx: ty::ctxt,
         },
         .. *visit::default_visitor()
     });
-    visit::visit_crate(*crate, method_map, visitor);
+    visit::visit_crate(crate, method_map, visitor);
 }
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -496,7 +496,7 @@ pub fn resolve_crate(sess: Session,
         visit_local: resolve_local,
         .. *visit::default_visitor()
     });
-    visit::visit_crate(*crate, cx, visitor);
+    visit::visit_crate(crate, cx, visitor);
     return region_maps;
 }
 
@@ -549,8 +549,8 @@ pub struct DetermineRpCtxt {
     ambient_variance: region_variance,
 }
 
-pub fn join_variance(++variance1: region_variance,
-                     ++variance2: region_variance)
+pub fn join_variance(variance1: region_variance,
+                     variance2: region_variance)
                   -> region_variance {
     match (variance1, variance2) {
       (rv_invariant, _) => {rv_invariant}
@@ -570,8 +570,8 @@ pub fn join_variance(++variance1: region_variance,
 /// appears in a co-variant position.  This implies that this
 /// occurrence of `r` is contra-variant with respect to the current
 /// item, and hence the function returns `rv_contravariant`.
-pub fn add_variance(+ambient_variance: region_variance,
-                    +variance: region_variance)
+pub fn add_variance(ambient_variance: region_variance,
+                    variance: region_variance)
                  -> region_variance {
     match (ambient_variance, variance) {
       (rv_invariant, _) => rv_invariant,
@@ -719,7 +719,7 @@ pub impl DetermineRpCtxt {
 }
 
 pub fn determine_rp_in_item(item: @ast::item,
-                            &&cx: @mut DetermineRpCtxt,
+                            cx: @mut DetermineRpCtxt,
                             visitor: visit::vt<@mut DetermineRpCtxt>) {
     do cx.with(item.id, true) {
         visit::visit_item(item, cx, visitor);
@@ -731,7 +731,7 @@ pub fn determine_rp_in_fn(fk: &visit::fn_kind,
                           body: &ast::blk,
                           _: span,
                           _: ast::node_id,
-                          &&cx: @mut DetermineRpCtxt,
+                          cx: @mut DetermineRpCtxt,
                           visitor: visit::vt<@mut DetermineRpCtxt>) {
     do cx.with(cx.item_id, false) {
         do cx.with_ambient_variance(rv_contravariant) {
@@ -747,7 +747,7 @@ pub fn determine_rp_in_fn(fk: &visit::fn_kind,
 }
 
 pub fn determine_rp_in_ty_method(ty_m: &ast::ty_method,
-                                 &&cx: @mut DetermineRpCtxt,
+                                 cx: @mut DetermineRpCtxt,
                                  visitor: visit::vt<@mut DetermineRpCtxt>) {
     do cx.with(cx.item_id, false) {
         visit::visit_ty_method(ty_m, cx, visitor);
@@ -755,7 +755,7 @@ pub fn determine_rp_in_ty_method(ty_m: &ast::ty_method,
 }
 
 pub fn determine_rp_in_ty(ty: @ast::Ty,
-                          &&cx: @mut DetermineRpCtxt,
+                          cx: @mut DetermineRpCtxt,
                           visitor: visit::vt<@mut DetermineRpCtxt>) {
     // we are only interested in types that will require an item to
     // be region-parameterized.  if cx.item_id is zero, then this type
@@ -871,7 +871,7 @@ pub fn determine_rp_in_ty(ty: @ast::Ty,
     }
 
     fn visit_mt(mt: ast::mt,
-                &&cx: @mut DetermineRpCtxt,
+                cx: @mut DetermineRpCtxt,
                 visitor: visit::vt<@mut DetermineRpCtxt>) {
         // mutability is invariant
         if mt.mutbl == ast::m_mutbl {
@@ -886,7 +886,7 @@ pub fn determine_rp_in_ty(ty: @ast::Ty,
 
 pub fn determine_rp_in_struct_field(
         cm: @ast::struct_field,
-        &&cx: @mut DetermineRpCtxt,
+        cx: @mut DetermineRpCtxt,
         visitor: visit::vt<@mut DetermineRpCtxt>) {
     match cm.node.kind {
       ast::named_field(_, ast::struct_mutable, _) => {
@@ -903,7 +903,7 @@ pub fn determine_rp_in_struct_field(
 
 pub fn determine_rp_in_crate(sess: Session,
                              ast_map: ast_map::map,
-                             +def_map: resolve::DefMap,
+                             def_map: resolve::DefMap,
                              crate: @ast::crate)
                           -> region_paramd_items {
     let cx = @mut DetermineRpCtxt {
@@ -927,7 +927,7 @@ pub fn determine_rp_in_crate(sess: Session,
         visit_struct_field: determine_rp_in_struct_field,
         .. *visit::default_visitor()
     });
-    visit::visit_crate(*crate, cx, visitor);
+    visit::visit_crate(crate, cx, visitor);
 
     // Propagate indirect dependencies
     //

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -785,7 +785,7 @@ pub fn enter_region<'r>(bcx: block,
 // on a set of enum variants or a literal.
 pub fn get_options(bcx: block, m: &[@Match], col: uint) -> ~[Opt] {
     let ccx = bcx.ccx();
-    fn add_to_set(tcx: ty::ctxt, set: &mut ~[Opt], +val: Opt) {
+    fn add_to_set(tcx: ty::ctxt, set: &mut ~[Opt], val: Opt) {
         if set.any(|l| opt_eq(tcx, l, &val)) {return;}
         set.push(val);
     }

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -41,7 +41,7 @@ enum x86_64_reg_class {
     memory_class
 }
 
-fn is_sse(++c: x86_64_reg_class) -> bool {
+fn is_sse(c: x86_64_reg_class) -> bool {
     return match c {
         sse_fs_class | sse_fv_class |
         sse_ds_class | sse_dv_class => true,

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -444,7 +444,7 @@ pub fn body_contains_ret(body: &ast::blk) -> bool {
 }
 
 // See [Note-arg-mode]
-pub fn trans_call_inner(++in_cx: block,
+pub fn trans_call_inner(in_cx: block,
                         call_info: Option<NodeInfo>,
                         fn_expr_ty: ty::t,
                         ret_ty: ty::t,
@@ -592,7 +592,7 @@ pub enum CallArgs<'self> {
     ArgVals(&'self [ValueRef])
 }
 
-pub fn trans_ret_slot(+bcx: block, +fn_ty: ty::t, +dest: expr::Dest)
+pub fn trans_ret_slot(bcx: block, fn_ty: ty::t, dest: expr::Dest)
                       -> ValueRef {
     let retty = ty::ty_fn_ret(fn_ty);
 
@@ -610,12 +610,12 @@ pub fn trans_ret_slot(+bcx: block, +fn_ty: ty::t, +dest: expr::Dest)
     }
 }
 
-pub fn trans_args(+cx: block,
-                  +args: CallArgs,
-                  +fn_ty: ty::t,
-                  +ret_flag: Option<ValueRef>,
-                  +autoref_arg: AutorefArg,
-                  +llargs: &mut ~[ValueRef]) -> block
+pub fn trans_args(cx: block,
+                  args: CallArgs,
+                  fn_ty: ty::t,
+                  ret_flag: Option<ValueRef>,
+                  autoref_arg: AutorefArg,
+                  llargs: &mut ~[ValueRef]) -> block
 {
     let _icx = cx.insn_ctxt("trans_args");
     let mut temp_cleanups = ~[];
@@ -663,9 +663,9 @@ pub enum AutorefArg {
 pub fn trans_arg_expr(bcx: block,
                       formal_ty: ty::arg,
                       arg_expr: @ast::expr,
-                      +temp_cleanups: &mut ~[ValueRef],
-                      +ret_flag: Option<ValueRef>,
-                      +autoref_arg: AutorefArg) -> Result {
+                      temp_cleanups: &mut ~[ValueRef],
+                      ret_flag: Option<ValueRef>,
+                      autoref_arg: AutorefArg) -> Result {
     let _icx = bcx.insn_ctxt("trans_arg_expr");
     let ccx = bcx.ccx();
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -59,9 +59,9 @@ use syntax::parse::token::ident_interner;
 use syntax::{ast, ast_map};
 use syntax::abi::{X86, X86_64, Arm, Mips};
 
-pub type namegen = @fn(+s: ~str) -> ident;
+pub type namegen = @fn(s: ~str) -> ident;
 pub fn new_namegen(intr: @ident_interner) -> namegen {
-    let f: @fn(+s: ~str) -> ident = |prefix| {
+    let f: @fn(s: ~str) -> ident = |prefix| {
         intr.gensym(@fmt!("%s_%u",
                           prefix,
                           intr.gensym(@prefix).repr))
@@ -395,7 +395,7 @@ pub struct cleanup_path {
     dest: BasicBlockRef
 }
 
-pub fn scope_clean_changed(+scope_info: &mut scope_info) {
+pub fn scope_clean_changed(scope_info: &mut scope_info) {
     if scope_info.cleanup_paths.len() > 0u { scope_info.cleanup_paths = ~[]; }
     scope_info.landing_pad = None;
 }
@@ -626,7 +626,7 @@ pub struct block_ {
     fcx: fn_ctxt
 }
 
-pub fn block_(llbb: BasicBlockRef, parent: Option<block>, +kind: block_kind,
+pub fn block_(llbb: BasicBlockRef, parent: Option<block>, kind: block_kind,
               is_lpad: bool, node_info: Option<NodeInfo>, fcx: fn_ctxt)
     -> block_ {
 
@@ -644,7 +644,7 @@ pub fn block_(llbb: BasicBlockRef, parent: Option<block>, +kind: block_kind,
 
 pub type block = @mut block_;
 
-pub fn mk_block(llbb: BasicBlockRef, parent: Option<block>, +kind: block_kind,
+pub fn mk_block(llbb: BasicBlockRef, parent: Option<block>, kind: block_kind,
             is_lpad: bool, node_info: Option<NodeInfo>, fcx: fn_ctxt)
     -> block {
     @mut block_(llbb, parent, kind, is_lpad, node_info, fcx)
@@ -663,7 +663,7 @@ pub fn rslt(bcx: block, val: ValueRef) -> Result {
 }
 
 pub impl Result {
-    fn unpack(&self, +bcx: &mut block) -> ValueRef {
+    fn unpack(&self, bcx: &mut block) -> ValueRef {
         *bcx = self.bcx;
         return self.val;
     }
@@ -683,7 +683,7 @@ pub fn val_str(tn: @TypeNames, v: ValueRef) -> @str {
     return ty_str(tn, val_ty(v));
 }
 
-pub fn in_scope_cx(cx: block, f: &fn(+si: &mut scope_info)) {
+pub fn in_scope_cx(cx: block, f: &fn(si: &mut scope_info)) {
     let mut cur = cx;
     loop {
         {
@@ -1252,7 +1252,7 @@ pub fn C_bytes_plus_null(bytes: &[u8]) -> ValueRef {
     }
 }
 
-pub fn C_shape(ccx: @CrateContext, +bytes: ~[u8]) -> ValueRef {
+pub fn C_shape(ccx: @CrateContext, bytes: ~[u8]) -> ValueRef {
     unsafe {
         let llshape = C_bytes_plus_null(bytes);
         let name = fmt!("shape%u", (ccx.names)(~"shape").repr);
@@ -1325,7 +1325,7 @@ pub struct mono_id_ {
 pub type mono_id = @mono_id_;
 
 impl to_bytes::IterBytes for mono_param_id {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
             mono_precise(t, ref mids) =>
                 to_bytes::iter_bytes_3(&0u8, &ty::type_id(t), mids, lsb0, f),
@@ -1339,7 +1339,7 @@ impl to_bytes::IterBytes for mono_param_id {
 }
 
 impl to_bytes::IterBytes for mono_id_ {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.def, &self.params, lsb0, f);
     }
 }
@@ -1433,7 +1433,7 @@ pub fn resolve_vtables_in_fn_ctxt(fcx: fn_ctxt, vts: typeck::vtable_res)
 
 // Apply the typaram substitutions in the fn_ctxt to a vtable. This should
 // eliminate any vtable_params.
-pub fn resolve_vtable_in_fn_ctxt(fcx: fn_ctxt, +vt: typeck::vtable_origin)
+pub fn resolve_vtable_in_fn_ctxt(fcx: fn_ctxt, vt: typeck::vtable_origin)
     -> typeck::vtable_origin {
     let tcx = fcx.ccx.tcx;
     match vt {
@@ -1479,7 +1479,7 @@ pub fn find_vtable(tcx: ty::ctxt, ps: &param_substs,
     /*bad*/ copy ps.vtables.get()[vtable_off]
 }
 
-pub fn dummy_substs(+tps: ~[ty::t]) -> ty::substs {
+pub fn dummy_substs(tps: ~[ty::t]) -> ty::substs {
     substs {
         self_r: Some(ty::re_bound(ty::br_self)),
         self_ty: None,

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -39,7 +39,7 @@ pub fn trans_block(bcx: block, b: &ast::blk, dest: expr::Dest) -> block {
     };
     for vec::each(b.node.stmts) |s| {
         debuginfo::update_source_pos(bcx, b.span);
-        bcx = trans_stmt(bcx, **s);
+        bcx = trans_stmt(bcx, *s);
     }
     match b.node.expr {
         Some(e) => {

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -159,7 +159,7 @@ pub impl DatumMode {
 }
 
 impl to_bytes::IterBytes for DatumMode {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as uint).iter_bytes(lsb0, f)
     }
 }
@@ -811,7 +811,7 @@ pub impl Datum {
 }
 
 pub impl DatumBlock {
-    fn unpack(&self, +bcx: &mut block) -> Datum {
+    fn unpack(&self, bcx: &mut block) -> Datum {
         *bcx = self.bcx;
         return self.datum;
     }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -104,7 +104,7 @@ pub struct DebugContext {
     crate_file: ~str
 }
 
-pub fn mk_ctxt(+crate: ~str, intr: @ident_interner) -> DebugContext {
+pub fn mk_ctxt(crate: ~str, intr: @ident_interner) -> DebugContext {
     DebugContext {
         llmetadata: @mut HashMap::new(),
         names: new_namegen(intr),
@@ -249,7 +249,7 @@ fn get_file_path_and_dir(work_dir: &str, full_path: &str) -> (~str, ~str) {
     }, work_dir.to_owned())
 }
 
-fn create_file(cx: @CrateContext, +full_path: ~str)
+fn create_file(cx: @CrateContext, full_path: ~str)
     -> @Metadata<FileMetadata> {
     let cache = get_cache(cx);;
     let tg = FileDescriptorTag;
@@ -589,7 +589,7 @@ fn create_boxed_type(cx: @CrateContext, contents: ty::t,
 fn create_composite_type(type_tag: int, name: &str, file: ValueRef,
                          line: int, size: int, align: int, offset: int,
                          derived: Option<ValueRef>,
-                         +members: Option<~[ValueRef]>)
+                         members: Option<~[ValueRef]>)
     -> ValueRef {
     let lldata = ~[lltag(type_tag),
                   file,

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1572,7 +1572,7 @@ fn trans_binary(bcx: block,
 fn trans_overloaded_op(bcx: block,
                        expr: @ast::expr,
                        rcvr: @ast::expr,
-                       +args: ~[@ast::expr],
+                       args: ~[@ast::expr],
                        ret_ty: ty::t,
                        dest: Dest)
                        -> block {
@@ -1746,6 +1746,6 @@ fn trans_assign_op(bcx: block,
     return result_datum.copy_to_datum(bcx, DROP_EXISTING, dst_datum);
 }
 
-fn shorten(+x: ~str) -> ~str {
+fn shorten(x: ~str) -> ~str {
     if x.len() > 60 { x.substr(0, 60).to_owned() } else { x }
 }

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -39,7 +39,7 @@ use syntax::{ast, ast_util};
 use syntax::{attr, ast_map};
 use syntax::opt_vec;
 use syntax::parse::token::special_idents;
-use syntax::abi::{Architecture, X86, X86_64, Arm, Mips};
+use syntax::abi::{X86, X86_64, Arm, Mips};
 use syntax::abi::{RustIntrinsic, Rust, Stdcall, Fastcall,
                   Cdecl, Aapcs, C};
 
@@ -139,7 +139,7 @@ type shim_ret_builder<'self> =
               llretval: ValueRef);
 
 fn build_shim_fn_(ccx: @CrateContext,
-                  +shim_name: ~str,
+                  shim_name: ~str,
                   llbasefn: ValueRef,
                   tys: &ShimTypes,
                   cc: lib::llvm::CallConv,
@@ -544,7 +544,7 @@ pub fn trans_foreign_mod(ccx: @CrateContext,
 pub fn trans_intrinsic(ccx: @CrateContext,
                        decl: ValueRef,
                        item: @ast::foreign_item,
-                       +path: ast_map::path,
+                       path: ast_map::path,
                        substs: @param_substs,
                        ref_id: Option<ast::node_id>) {
     debug!("trans_intrinsic(item.ident=%s)", *ccx.sess.str_of(item.ident));
@@ -1089,7 +1089,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
  *     }
  */
 pub fn trans_foreign_fn(ccx: @CrateContext,
-                        +path: ast_map::path,
+                        path: ast_map::path,
                         decl: &ast::fn_decl,
                         body: &ast::blk,
                         llwrapfn: ValueRef,
@@ -1097,7 +1097,7 @@ pub fn trans_foreign_fn(ccx: @CrateContext,
     let _icx = ccx.insn_ctxt("foreign::build_foreign_fn");
 
     fn build_rust_fn(ccx: @CrateContext,
-                     +path: ast_map::path,
+                     path: ast_map::path,
                      decl: &ast::fn_decl,
                      body: &ast::blk,
                      id: ast::node_id)
@@ -1125,7 +1125,7 @@ pub fn trans_foreign_fn(ccx: @CrateContext,
     }
 
     fn build_shim_fn(ccx: @CrateContext,
-                     +path: ast_map::path,
+                     path: ast_map::path,
                      llrustfn: ValueRef,
                      tys: &ShimTypes)
                      -> ValueRef {
@@ -1266,7 +1266,7 @@ pub fn trans_foreign_fn(ccx: @CrateContext,
 
 pub fn register_foreign_fn(ccx: @CrateContext,
                            sp: span,
-                           +path: ast_map::path,
+                           path: ast_map::path,
                            node_id: ast::node_id,
                            attrs: &[ast::attribute])
                            -> ValueRef {

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -321,7 +321,7 @@ pub fn lazily_emit_tydesc_glue(ccx: @CrateContext,
 }
 
 // See [Note-arg-mode]
-pub fn call_tydesc_glue_full(++bcx: block,
+pub fn call_tydesc_glue_full(bcx: block,
                              v: ValueRef,
                              tydesc: ValueRef,
                              field: uint,
@@ -388,7 +388,7 @@ pub fn call_tydesc_glue_full(++bcx: block,
 }
 
 // See [Note-arg-mode]
-pub fn call_tydesc_glue(++cx: block, v: ValueRef, t: ty::t, field: uint)
+pub fn call_tydesc_glue(cx: block, v: ValueRef, t: ty::t, field: uint)
     -> block {
     let _icx = cx.insn_ctxt("call_tydesc_glue");
     let ti = get_tydesc(cx.ccx(), t);
@@ -713,7 +713,7 @@ pub fn declare_tydesc(ccx: @CrateContext, t: ty::t) -> @mut tydesc_info {
 pub type glue_helper = @fn(block, ValueRef, ty::t);
 
 pub fn declare_generic_glue(ccx: @CrateContext, t: ty::t, llfnty: TypeRef,
-                            +name: ~str) -> ValueRef {
+                            name: ~str) -> ValueRef {
     let _icx = ccx.insn_ctxt("declare_generic_glue");
     let name = name;
     //XXX this triggers duplicate LLVM symbols

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -54,7 +54,7 @@ pub fn maybe_instantiate_inline(ccx: @CrateContext, fn_id: ast::def_id,
           csearch::found(ast::ii_item(item)) => {
             ccx.external.insert(fn_id, Some(item.id));
             ccx.stats.n_inlines += 1;
-            if translate { trans_item(ccx, *item); }
+            if translate { trans_item(ccx, item); }
             local_def(item.id)
           }
           csearch::found(ast::ii_foreign(item)) => {
@@ -76,7 +76,7 @@ pub fn maybe_instantiate_inline(ccx: @CrateContext, fn_id: ast::def_id,
               _ => ccx.sess.bug(~"maybe_instantiate_inline: item has a \
                     non-enum parent")
             }
-            if translate { trans_item(ccx, *item); }
+            if translate { trans_item(ccx, item); }
             local_def(my_id)
           }
           csearch::found_parent(_, _) => {

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -42,7 +42,7 @@ for non-monomorphized methods only.  Other methods will
 be generated once they are invoked with specific type parameters,
 see `trans::base::lval_static_fn()` or `trans::base::monomorphic_fn()`.
 */
-pub fn trans_impl(ccx: @CrateContext, +path: path, name: ast::ident,
+pub fn trans_impl(ccx: @CrateContext, path: path, name: ast::ident,
                   methods: &[@ast::method], generics: &ast::Generics,
                   self_ty: Option<ty::t>, id: ast::node_id) {
     let _icx = ccx.insn_ctxt("impl::trans_impl");
@@ -89,7 +89,7 @@ Translates a (possibly monomorphized) method body.
 - `impl_id`: the node ID of the impl this method is inside
 */
 pub fn trans_method(ccx: @CrateContext,
-                    +path: path,
+                    path: path,
                     method: &ast::method,
                     param_substs: Option<@param_substs>,
                     base_self_ty: Option<ty::t>,
@@ -443,7 +443,7 @@ pub fn trans_monomorphized_callee(bcx: block,
                                   mentry: typeck::method_map_entry,
                                   trait_id: ast::def_id,
                                   n_method: uint,
-                                  +vtbl: typeck::vtable_origin)
+                                  vtbl: typeck::vtable_origin)
                                -> Callee {
     let _icx = bcx.insn_ctxt("impl::trans_monomorphized_callee");
     return match vtbl {
@@ -724,7 +724,7 @@ pub fn trans_trait_callee_from_llval(bcx: block,
 }
 
 pub fn vtable_id(ccx: @CrateContext,
-                 +origin: typeck::vtable_origin)
+                 origin: typeck::vtable_origin)
               -> mono_id {
     match origin {
         typeck::vtable_static(impl_id, substs, sub_vtables) => {
@@ -747,7 +747,7 @@ pub fn vtable_id(ccx: @CrateContext,
 }
 
 pub fn get_vtable(ccx: @CrateContext,
-                  +origin: typeck::vtable_origin)
+                  origin: typeck::vtable_origin)
                -> ValueRef {
     // XXX: Bad copy.
     let hash_id = vtable_id(ccx, copy origin);

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -221,9 +221,9 @@ pub fn monomorphic_fn(ccx: @CrateContext,
         let this_tv = vec::find(*tvs, |tv| { tv.id.node == fn_id.node}).get();
         let d = mk_lldecl();
         set_inline_hint(d);
-        match (*v).node.kind {
+        match v.node.kind {
             ast::tuple_variant_kind(ref args) => {
-                trans_enum_variant(ccx, enum_item.id, *v, /*bad*/copy *args,
+                trans_enum_variant(ccx, enum_item.id, v, /*bad*/copy *args,
                                    this_tv.disr_val, psubsts, d);
             }
             ast::struct_variant_kind(_) =>

--- a/src/librustc/middle/trans/reachable.rs
+++ b/src/librustc/middle/trans/reachable.rs
@@ -49,13 +49,13 @@ pub fn find_reachable(crate_mod: &_mod, exp_map2: resolve::ExportMap2,
             method_map: method_map,
             rmap: &mut rmap
         };
-        traverse_public_mod(cx, ast::crate_node_id, crate_mod);
-        traverse_all_resources_and_impls(cx, crate_mod);
+        traverse_public_mod(&cx, ast::crate_node_id, crate_mod);
+        traverse_all_resources_and_impls(&cx, crate_mod);
     }
     return @rmap;
 }
 
-fn traverse_exports(cx: ctx, mod_id: node_id) -> bool {
+fn traverse_exports(cx: &ctx, mod_id: node_id) -> bool {
     let mut found_export = false;
     match cx.exp_map2.find(&mod_id) {
       Some(ref exp2s) => {
@@ -69,7 +69,7 @@ fn traverse_exports(cx: ctx, mod_id: node_id) -> bool {
     return found_export;
 }
 
-fn traverse_def_id(cx: ctx, did: def_id) {
+fn traverse_def_id(cx: &ctx, did: def_id) {
     if did.crate != local_crate { return; }
     match cx.tcx.items.find(&did.node) {
         None => (), // This can happen for self, for example
@@ -85,7 +85,7 @@ fn traverse_def_id(cx: ctx, did: def_id) {
     }
 }
 
-fn traverse_public_mod(cx: ctx, mod_id: node_id, m: &_mod) {
+fn traverse_public_mod(cx: &ctx, mod_id: node_id, m: &_mod) {
     if !traverse_exports(cx, mod_id) {
         // No exports, so every local item is exported
         for m.items.each |item| {
@@ -94,7 +94,7 @@ fn traverse_public_mod(cx: ctx, mod_id: node_id, m: &_mod) {
     }
 }
 
-fn traverse_public_item(cx: ctx, item: @item) {
+fn traverse_public_item(cx: &ctx, item: @item) {
     // XXX: it shouldn't be necessary to do this
     let rmap: &mut HashSet<node_id> = cx.rmap;
     if rmap.contains(&item.id) { return; }
@@ -139,7 +139,9 @@ fn traverse_public_item(cx: ctx, item: @item) {
         }
       }
       item_ty(t, _) => {
-        traverse_ty(t, cx, mk_ty_visitor());
+        traverse_ty(t, cx,
+                    visit::mk_vt(@visit::Visitor {visit_ty: traverse_ty,
+                                                  ..*visit::default_visitor()}))
       }
       item_const(*) |
       item_enum(*) | item_trait(*) => (),
@@ -147,12 +149,7 @@ fn traverse_public_item(cx: ctx, item: @item) {
     }
 }
 
-fn mk_ty_visitor() -> visit::vt<ctx> {
-    visit::mk_vt(@visit::Visitor {visit_ty: traverse_ty,
-                                  ..*visit::default_visitor()})
-}
-
-fn traverse_ty<'a>(ty: @Ty, cx: ctx<'a>, v: visit::vt<ctx<'a>>) {
+fn traverse_ty<'a, 'b>(ty: @Ty, cx: &'b ctx<'a>, v: visit::vt<&'b ctx<'a>>) {
     // XXX: it shouldn't be necessary to do this
     let rmap: &mut HashSet<node_id> = cx.rmap;
     if rmap.contains(&ty.id) { return; }
@@ -175,8 +172,9 @@ fn traverse_ty<'a>(ty: @Ty, cx: ctx<'a>, v: visit::vt<ctx<'a>>) {
     }
 }
 
-fn traverse_inline_body(cx: ctx, body: &blk) {
-    fn traverse_expr<'a>(e: @expr, cx: ctx<'a>, v: visit::vt<ctx<'a>>) {
+fn traverse_inline_body(cx: &ctx, body: &blk) {
+    fn traverse_expr<'a, 'b>(e: @expr, cx: &'b ctx<'a>,
+                             v: visit::vt<&'b ctx<'a>>) {
         match e.node {
           expr_path(_) => {
             match cx.tcx.def_map.find(&e.id) {
@@ -221,7 +219,7 @@ fn traverse_inline_body(cx: ctx, body: &blk) {
     // Don't ignore nested items: for example if a generic fn contains a
     // generic impl (as in deque::create), we need to monomorphize the
     // impl as well
-    fn traverse_item(i: @item, cx: ctx, _v: visit::vt<ctx>) {
+    fn traverse_item(i: @item, cx: &ctx, _v: visit::vt<&ctx>) {
       traverse_public_item(cx, i);
     }
     visit::visit_block(body, cx, visit::mk_vt(@visit::Visitor {
@@ -231,7 +229,7 @@ fn traverse_inline_body(cx: ctx, body: &blk) {
     }));
 }
 
-fn traverse_all_resources_and_impls(cx: ctx, crate_mod: &_mod) {
+fn traverse_all_resources_and_impls(cx: &ctx, crate_mod: &_mod) {
     visit::visit_mod(
         crate_mod,
         codemap::dummy_sp(),

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -121,7 +121,7 @@ pub impl Reflector {
 
     fn bracketed(&mut self,
                  bracket_name: ~str,
-                 +extra: ~[ValueRef],
+                 extra: ~[ValueRef],
                  inner: &fn(&mut Reflector)) {
         // XXX: Bad copy.
         self.visit(~"enter_" + bracket_name, copy extra);
@@ -145,7 +145,7 @@ pub impl Reflector {
         }
     }
 
-    fn leaf(&mut self, +name: ~str) {
+    fn leaf(&mut self, name: ~str) {
         self.visit(name, ~[]);
     }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -126,7 +126,7 @@ pub struct creader_cache_key {
 type creader_cache = @mut HashMap<creader_cache_key, t>;
 
 impl to_bytes::IterBytes for creader_cache_key {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_3(&self.cnum, &self.pos, &self.len, lsb0, f);
     }
 }
@@ -150,7 +150,7 @@ impl cmp::Eq for intern_key {
 }
 
 impl to_bytes::IterBytes for intern_key {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         unsafe {
             (*self.sty).iter_bytes(lsb0, f);
         }
@@ -390,13 +390,13 @@ pub struct FnSig {
 }
 
 impl to_bytes::IterBytes for BareFnTy {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_3(&self.purity, &self.abis, &self.sig, lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for ClosureTy {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_5(&self.purity, &self.sigil, &self.onceness,
                                &self.region, &self.sig, lsb0, f)
     }
@@ -685,7 +685,7 @@ pub enum InferTy {
 }
 
 impl to_bytes::IterBytes for InferTy {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
           TyVar(ref tv) => to_bytes::iter_bytes_2(&0u8, tv, lsb0, f),
           IntVar(ref iv) => to_bytes::iter_bytes_2(&1u8, iv, lsb0, f),
@@ -702,7 +702,7 @@ pub enum InferRegion {
 }
 
 impl to_bytes::IterBytes for InferRegion {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
             ReVar(ref rv) => to_bytes::iter_bytes_2(&0u8, rv, lsb0, f),
             ReSkolemized(ref v, _) => to_bytes::iter_bytes_2(&1u8, v, lsb0, f)
@@ -790,25 +790,25 @@ impl ToStr for IntVarValue {
 }
 
 impl to_bytes::IterBytes for TyVid {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.to_uint().iter_bytes(lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for IntVid {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.to_uint().iter_bytes(lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for FloatVid {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.to_uint().iter_bytes(lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for RegionVid {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.to_uint().iter_bytes(lsb0, f)
     }
 }
@@ -877,7 +877,7 @@ pub fn mk_ctxt(s: session::Session,
                freevars: freevars::freevar_map,
                region_maps: @mut middle::region::RegionMaps,
                region_paramd_items: middle::region::region_paramd_items,
-               +lang_items: middle::lang_items::LanguageItems,
+               lang_items: middle::lang_items::LanguageItems,
                crate: @ast::crate)
             -> ctxt {
     let mut legacy_modes = false;
@@ -942,7 +942,7 @@ pub fn mk_ctxt(s: session::Session,
 
 // Interns a type/name combination, stores the resulting box in cx.interner,
 // and returns the box as cast to an unsafe ptr (see comments for t above).
-fn mk_t(cx: ctxt, +st: sty) -> t {
+fn mk_t(cx: ctxt, st: sty) -> t {
     // Check for primitive types.
     match st {
         ty_nil => return mk_nil(cx),
@@ -1141,7 +1141,7 @@ pub fn mk_estr(cx: ctxt, t: vstore) -> t {
     mk_t(cx, ty_estr(t))
 }
 
-pub fn mk_enum(cx: ctxt, did: ast::def_id, +substs: substs) -> t {
+pub fn mk_enum(cx: ctxt, did: ast::def_id, substs: substs) -> t {
     // take a copy of substs so that we own the vectors inside
     mk_t(cx, ty_enum(did, substs))
 }
@@ -1192,13 +1192,13 @@ pub fn mk_mut_unboxed_vec(cx: ctxt, ty: t) -> t {
     mk_t(cx, ty_unboxed_vec(mt {ty: ty, mutbl: ast::m_imm}))
 }
 
-pub fn mk_tup(cx: ctxt, +ts: ~[t]) -> t { mk_t(cx, ty_tup(ts)) }
+pub fn mk_tup(cx: ctxt, ts: ~[t]) -> t { mk_t(cx, ty_tup(ts)) }
 
-pub fn mk_closure(cx: ctxt, +fty: ClosureTy) -> t {
+pub fn mk_closure(cx: ctxt, fty: ClosureTy) -> t {
     mk_t(cx, ty_closure(fty))
 }
 
-pub fn mk_bare_fn(cx: ctxt, +fty: BareFnTy) -> t {
+pub fn mk_bare_fn(cx: ctxt, fty: BareFnTy) -> t {
     mk_t(cx, ty_bare_fn(fty))
 }
 
@@ -1217,7 +1217,7 @@ pub fn mk_ctor_fn(cx: ctxt, input_tys: &[ty::t], output: ty::t) -> t {
 
 pub fn mk_trait(cx: ctxt,
                 did: ast::def_id,
-                +substs: substs,
+                substs: substs,
                 store: TraitStore,
                 mutability: ast::mutability)
              -> t {
@@ -1225,7 +1225,7 @@ pub fn mk_trait(cx: ctxt,
     mk_t(cx, ty_trait(did, substs, store, mutability))
 }
 
-pub fn mk_struct(cx: ctxt, struct_id: ast::def_id, +substs: substs) -> t {
+pub fn mk_struct(cx: ctxt, struct_id: ast::def_id, substs: substs) -> t {
     // take a copy of substs so that we own the vectors inside
     mk_t(cx, ty_struct(struct_id, substs))
 }
@@ -1236,7 +1236,7 @@ pub fn mk_int_var(cx: ctxt, v: IntVid) -> t { mk_infer(cx, IntVar(v)) }
 
 pub fn mk_float_var(cx: ctxt, v: FloatVid) -> t { mk_infer(cx, FloatVar(v)) }
 
-pub fn mk_infer(cx: ctxt, +it: InferTy) -> t { mk_t(cx, ty_infer(it)) }
+pub fn mk_infer(cx: ctxt, it: InferTy) -> t { mk_t(cx, ty_infer(it)) }
 
 pub fn mk_self(cx: ctxt, did: ast::def_id) -> t { mk_t(cx, ty_self(did)) }
 
@@ -2672,7 +2672,7 @@ impl cmp::TotalEq for bound_region {
 }
 
 impl to_bytes::IterBytes for vstore {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
           vstore_fixed(ref u) =>
           to_bytes::iter_bytes_2(&0u8, u, lsb0, f),
@@ -2687,7 +2687,7 @@ impl to_bytes::IterBytes for vstore {
 }
 
 impl to_bytes::IterBytes for substs {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
           to_bytes::iter_bytes_3(&self.self_r,
                                  &self.self_ty,
                                  &self.tps, lsb0, f)
@@ -2695,28 +2695,28 @@ impl to_bytes::IterBytes for substs {
 }
 
 impl to_bytes::IterBytes for mt {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
           to_bytes::iter_bytes_2(&self.ty,
                                  &self.mutbl, lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for field {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
           to_bytes::iter_bytes_2(&self.ident,
                                  &self.mt, lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for arg {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.mode,
                                &self.ty, lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for FnSig {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.inputs,
                                &self.output,
                                lsb0, f);
@@ -2724,7 +2724,7 @@ impl to_bytes::IterBytes for FnSig {
 }
 
 impl to_bytes::IterBytes for sty {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
           ty_nil => 0u8.iter_bytes(lsb0, f),
           ty_bool => 1u8.iter_bytes(lsb0, f),
@@ -3383,7 +3383,7 @@ pub fn occurs_check(tcx: ctxt, sp: span, vid: TyVid, rt: t) {
 // Maintains a little union-set tree for inferred modes.  `canon()` returns
 // the current head value for `m0`.
 fn canon<T:Copy + cmp::Eq>(tbl: &mut HashMap<ast::node_id, ast::inferable<T>>,
-                         +m0: ast::inferable<T>) -> ast::inferable<T> {
+                           m0: ast::inferable<T>) -> ast::inferable<T> {
     match m0 {
         ast::infer(id) => {
             let m1 = match tbl.find(&id) {

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -248,7 +248,7 @@ pub static NO_TPS: uint = 2;
 // internal notion of a type. `getter` is a function that returns the type
 // corresponding to a definition ID:
 pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + Durable>(
-    self: &AC, rscope: &RS, &&ast_ty: @ast::Ty) -> ty::t {
+    self: &AC, rscope: &RS, ast_ty: @ast::Ty) -> ty::t {
 
     fn ast_mt_to_mt<AC:AstConv, RS:region_scope + Copy + Durable>(
         self: &AC, rscope: &RS, mt: &ast::mt) -> ty::mt {

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -44,7 +44,7 @@ pub fn check_match(fcx: @mut FnCtxt,
             block_region: ty::re_scope(arm.body.node.id)
         };
 
-        for arm.pats.each |p| { check_pat(pcx, *p, pattern_ty);}
+        for arm.pats.each |p| { check_pat(&pcx, *p, pattern_ty);}
     }
 
     // Now typecheck the blocks.
@@ -99,7 +99,7 @@ pub struct pat_ctxt {
     block_region: ty::Region, // Region for the block of the arm
 }
 
-pub fn check_pat_variant(pcx: pat_ctxt, pat: @ast::pat, path: @ast::Path,
+pub fn check_pat_variant(pcx: &pat_ctxt, pat: @ast::pat, path: @ast::Path,
                          subpats: &Option<~[@ast::pat]>, expected: ty::t) {
 
     // Typecheck the path.
@@ -247,7 +247,7 @@ pub fn check_pat_variant(pcx: pat_ctxt, pat: @ast::pat, path: @ast::Path,
 /// `substitutions` are the type substitutions applied to this struct type
 /// (e.g. K,V in HashMap<K,V>).
 /// `etc` is true if the pattern said '...' and false otherwise.
-pub fn check_struct_pat_fields(pcx: pat_ctxt,
+pub fn check_struct_pat_fields(pcx: &pat_ctxt,
                                span: span,
                                path: @ast::Path,
                                fields: &[ast::field_pat],
@@ -299,7 +299,7 @@ pub fn check_struct_pat_fields(pcx: pat_ctxt,
     }
 }
 
-pub fn check_struct_pat(pcx: pat_ctxt, pat_id: ast::node_id, span: span,
+pub fn check_struct_pat(pcx: &pat_ctxt, pat_id: ast::node_id, span: span,
                         expected: ty::t, path: @ast::Path,
                         fields: &[ast::field_pat], etc: bool,
                         class_id: ast::def_id, substitutions: &ty::substs) {
@@ -337,7 +337,7 @@ pub fn check_struct_pat(pcx: pat_ctxt, pat_id: ast::node_id, span: span,
                             substitutions, etc);
 }
 
-pub fn check_struct_like_enum_variant_pat(pcx: pat_ctxt,
+pub fn check_struct_like_enum_variant_pat(pcx: &pat_ctxt,
                                           pat_id: ast::node_id,
                                           span: span,
                                           expected: ty::t,
@@ -375,7 +375,7 @@ pub fn check_struct_like_enum_variant_pat(pcx: pat_ctxt,
 
 // Pattern checking is top-down rather than bottom-up so that bindings get
 // their types immediately.
-pub fn check_pat(pcx: pat_ctxt, pat: @ast::pat, expected: ty::t) {
+pub fn check_pat(pcx: &pat_ctxt, pat: @ast::pat, expected: ty::t) {
     let fcx = pcx.fcx;
     let tcx = pcx.fcx.ccx.tcx;
 

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1298,7 +1298,7 @@ pub impl<'self> LookupContext<'self> {
         ty::item_path_str(self.tcx(), did)
     }
 
-    fn bug(&self, +s: ~str) -> ! {
+    fn bug(&self, s: ~str) -> ! {
         self.tcx().sess.bug(s)
     }
 }

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -413,12 +413,9 @@ fn constrain_derefs(rcx: @mut Rcx,
 
         match ty::deref(tcx, derefd_ty, true) {
             Some(mt) => derefd_ty = mt.ty,
-            None => {
-                tcx.sess.span_bug(
-                    deref_expr.span,
-                    fmt!("%?'th deref is of a non-deref'able type `%s`",
-                         i, rcx.fcx.infcx().ty_to_str(derefd_ty)));
-            }
+            /* if this type can't be dereferenced, then there's already an error
+               in the session saying so. Just bail out for now */
+            None => break
         }
     }
 }

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -159,11 +159,11 @@ fn regionck_visitor() -> rvt {
                                   .. *visit::default_visitor()})
 }
 
-fn visit_item(_item: @ast::item, &&_rcx: @mut Rcx, _v: rvt) {
+fn visit_item(_item: @ast::item, _rcx: @mut Rcx, _v: rvt) {
     // Ignore items
 }
 
-fn visit_local(l: @ast::local, &&rcx: @mut Rcx, v: rvt) {
+fn visit_local(l: @ast::local, rcx: @mut Rcx, v: rvt) {
     // Check to make sure that the regions in all local variables are
     // within scope.
     //
@@ -194,11 +194,11 @@ fn visit_local(l: @ast::local, &&rcx: @mut Rcx, v: rvt) {
     }
 }
 
-fn visit_block(b: &ast::blk, &&rcx: @mut Rcx, v: rvt) {
+fn visit_block(b: &ast::blk, rcx: @mut Rcx, v: rvt) {
     visit::visit_block(b, rcx, v);
 }
 
-fn visit_expr(expr: @ast::expr, &&rcx: @mut Rcx, v: rvt) {
+fn visit_expr(expr: @ast::expr, rcx: @mut Rcx, v: rvt) {
     debug!("regionck::visit_expr(e=%s)", rcx.fcx.expr_to_str(expr));
 
     for rcx.fcx.inh.adjustments.find(&expr.id).each |&adjustment| {
@@ -333,7 +333,7 @@ fn visit_expr(expr: @ast::expr, &&rcx: @mut Rcx, v: rvt) {
     visit::visit_expr(expr, rcx, v);
 }
 
-fn visit_stmt(s: @ast::stmt, &&rcx: @mut Rcx, v: rvt) {
+fn visit_stmt(s: @ast::stmt, rcx: @mut Rcx, v: rvt) {
     visit::visit_stmt(s, rcx, v);
 }
 
@@ -973,10 +973,10 @@ pub mod guarantor {
     }
 
     fn apply_autoderefs(
-        +rcx: @mut Rcx,
-        +expr: @ast::expr,
-        +autoderefs: uint,
-        +ct: ExprCategorizationType)
+        rcx: @mut Rcx,
+        expr: @ast::expr,
+        autoderefs: uint,
+        ct: ExprCategorizationType)
      -> ExprCategorizationType {
         let mut ct = ct;
         let tcx = rcx.fcx.ccx.tcx;

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -135,7 +135,7 @@ fn lookup_vtables(vcx: &VtableContext,
 }
 
 fn fixup_substs(vcx: &VtableContext, location_info: &LocationInfo,
-                id: ast::def_id, +substs: ty::substs,
+                id: ast::def_id, substs: ty::substs,
                 is_early: bool) -> Option<ty::substs> {
     let tcx = vcx.tcx();
     // use a dummy type just to package up the substs that need fixing up
@@ -480,7 +480,7 @@ pub fn location_info_for_expr(expr: @ast::expr) -> LocationInfo {
 }
 
 pub fn early_resolve_expr(ex: @ast::expr,
-                          &&fcx: @mut FnCtxt,
+                          fcx: @mut FnCtxt,
                           is_early: bool) {
     debug!("vtable: early_resolve_expr() ex with id %? (early: %b): %s",
            ex.id, is_early, expr_to_str(ex, fcx.tcx().sess.intr()));
@@ -656,7 +656,7 @@ pub fn early_resolve_expr(ex: @ast::expr,
 }
 
 fn resolve_expr(ex: @ast::expr,
-                &&fcx: @mut FnCtxt,
+                fcx: @mut FnCtxt,
                 v: visit::vt<@mut FnCtxt>) {
     early_resolve_expr(ex, fcx, false);
     visit::visit_expr(ex, fcx, v);

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -212,12 +212,12 @@ struct WbCtxt {
 
 type wb_vt = visit::vt<@mut WbCtxt>;
 
-fn visit_stmt(s: @ast::stmt, &&wbcx: @mut WbCtxt, v: wb_vt) {
+fn visit_stmt(s: @ast::stmt, wbcx: @mut WbCtxt, v: wb_vt) {
     if !wbcx.success { return; }
     resolve_type_vars_for_node(wbcx, s.span, ty::stmt_node_id(s));
     visit::visit_stmt(s, wbcx, v);
 }
-fn visit_expr(e: @ast::expr, &&wbcx: @mut WbCtxt, v: wb_vt) {
+fn visit_expr(e: @ast::expr, wbcx: @mut WbCtxt, v: wb_vt) {
     if !wbcx.success { return; }
     resolve_type_vars_for_node(wbcx, e.span, e.id);
     resolve_method_map_entry(wbcx.fcx, e.span, e.id);
@@ -256,12 +256,12 @@ fn visit_expr(e: @ast::expr, &&wbcx: @mut WbCtxt, v: wb_vt) {
     }
     visit::visit_expr(e, wbcx, v);
 }
-fn visit_block(b: &ast::blk, &&wbcx: @mut WbCtxt, v: wb_vt) {
+fn visit_block(b: &ast::blk, wbcx: @mut WbCtxt, v: wb_vt) {
     if !wbcx.success { return; }
     resolve_type_vars_for_node(wbcx, b.span, b.node.id);
     visit::visit_block(b, wbcx, v);
 }
-fn visit_pat(p: @ast::pat, &&wbcx: @mut WbCtxt, v: wb_vt) {
+fn visit_pat(p: @ast::pat, wbcx: @mut WbCtxt, v: wb_vt) {
     if !wbcx.success { return; }
     resolve_type_vars_for_node(wbcx, p.span, p.id);
     debug!("Type for pattern binding %s (id %d) resolved to %s",
@@ -271,7 +271,7 @@ fn visit_pat(p: @ast::pat, &&wbcx: @mut WbCtxt, v: wb_vt) {
                                    p.id)));
     visit::visit_pat(p, wbcx, v);
 }
-fn visit_local(l: @ast::local, &&wbcx: @mut WbCtxt, v: wb_vt) {
+fn visit_local(l: @ast::local, wbcx: @mut WbCtxt, v: wb_vt) {
     if !wbcx.success { return; }
     let var_ty = wbcx.fcx.local_ty(l.span, l.node.id);
     match resolve_type(wbcx.fcx.infcx(), var_ty, resolve_all | force_all) {
@@ -293,7 +293,7 @@ fn visit_local(l: @ast::local, &&wbcx: @mut WbCtxt, v: wb_vt) {
     }
     visit::visit_local(l, wbcx, v);
 }
-fn visit_item(_item: @ast::item, &&_wbcx: @mut WbCtxt, _v: wb_vt) {
+fn visit_item(_item: @ast::item, _wbcx: @mut WbCtxt, _v: wb_vt) {
     // Ignore items
 }
 

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -203,7 +203,7 @@ pub impl CoherenceChecker {
         // Check implementations and traits. This populates the tables
         // containing the inherent methods and extension methods. It also
         // builds up the trait inheritance table.
-        visit_crate(*crate, (), mk_simple_visitor(@SimpleVisitor {
+        visit_crate(crate, (), mk_simple_visitor(@SimpleVisitor {
             visit_item: |item| {
 //                debug!("(checking coherence) item '%s'",
 //                       self.crate_context.tcx.sess.str_of(item.ident));
@@ -655,7 +655,7 @@ pub impl CoherenceChecker {
 
     // Privileged scope checking
     fn check_privileged_scopes(self, crate: @crate) {
-        visit_crate(*crate, (), mk_vt(@Visitor {
+        visit_crate(crate, (), mk_vt(@Visitor {
             visit_item: |item, _context, visitor| {
                 match item.node {
                     item_mod(ref module_) => {

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -111,7 +111,7 @@ pub fn collect_item_types(ccx: @mut CrateCtxt, crate: @ast::crate) {
     }
 
     visit::visit_crate(
-        *crate, (),
+        crate, (),
         visit::mk_simple_visitor(@visit::SimpleVisitor {
             visit_item: |a| convert(ccx, a),
             visit_foreign_item: |a|convert_foreign(ccx, a),

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -124,7 +124,7 @@ pub struct CombineFields {
 }
 
 pub fn expected_found<C:Combine,T>(
-        self: &C, +a: T, +b: T) -> ty::expected_found<T> {
+        self: &C, a: T, b: T) -> ty::expected_found<T> {
     if self.a_is_expected() {
         ty::expected_found {expected: a, found: b}
     } else {

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -77,8 +77,8 @@ pub impl CombineFields {
     fn var_sub_var<T:Copy + InferStr + LatticeValue,
                    V:Copy + Eq + ToStr + Vid + UnifyVid<Bounds<T>>>(
         &self,
-        +a_id: V,
-        +b_id: V) -> ures
+        a_id: V,
+        b_id: V) -> ures
     {
         /*!
          *
@@ -130,8 +130,8 @@ pub impl CombineFields {
     fn var_sub_t<T:Copy + InferStr + LatticeValue,
                  V:Copy + Eq + ToStr + Vid + UnifyVid<Bounds<T>>>(
         &self,
-        +a_id: V,
-        +b: T) -> ures
+        a_id: V,
+        b: T) -> ures
     {
         /*!
          *
@@ -154,8 +154,8 @@ pub impl CombineFields {
     fn t_sub_var<T:Copy + InferStr + LatticeValue,
                  V:Copy + Eq + ToStr + Vid + UnifyVid<Bounds<T>>>(
         &self,
-        +a: T,
-        +b_id: V) -> ures
+        a: T,
+        b_id: V) -> ures
     {
         /*!
          *
@@ -206,7 +206,7 @@ pub impl CombineFields {
     fn set_var_to_merged_bounds<T:Copy + InferStr + LatticeValue,
                                 V:Copy+Eq+ToStr+Vid+UnifyVid<Bounds<T>>>(
         &self,
-        +v_id: V,
+        v_id: V,
         a: &Bounds<T>,
         b: &Bounds<T>,
         rank: uint) -> ures
@@ -296,7 +296,7 @@ pub impl CombineFields {
 pub trait LatticeDir {
     fn combine_fields(&self) -> CombineFields;
     fn bnd<T:Copy>(&self, b: &Bounds<T>) -> Option<T>;
-    fn with_bnd<T:Copy>(&self, b: &Bounds<T>, +t: T) -> Bounds<T>;
+    fn with_bnd<T:Copy>(&self, b: &Bounds<T>, t: T) -> Bounds<T>;
 }
 
 pub trait TyLatticeDir {
@@ -306,7 +306,7 @@ pub trait TyLatticeDir {
 impl LatticeDir for Lub {
     fn combine_fields(&self) -> CombineFields { **self }
     fn bnd<T:Copy>(&self, b: &Bounds<T>) -> Option<T> { b.ub }
-    fn with_bnd<T:Copy>(&self, b: &Bounds<T>, +t: T) -> Bounds<T> {
+    fn with_bnd<T:Copy>(&self, b: &Bounds<T>, t: T) -> Bounds<T> {
         Bounds { ub: Some(t), ..*b }
     }
 }
@@ -320,7 +320,7 @@ impl TyLatticeDir for Lub {
 impl LatticeDir for Glb {
     fn combine_fields(&self) -> CombineFields { **self }
     fn bnd<T:Copy>(&self, b: &Bounds<T>) -> Option<T> { b.lb }
-    fn with_bnd<T:Copy>(&self, b: &Bounds<T>, +t: T) -> Bounds<T> {
+    fn with_bnd<T:Copy>(&self, b: &Bounds<T>, t: T) -> Bounds<T> {
         Bounds { lb: Some(t), ..*b }
     }
 }
@@ -401,8 +401,8 @@ pub fn lattice_vars<L:LatticeDir + Combine,
                     T:Copy + InferStr + LatticeValue,
                     V:Copy + Eq + ToStr + Vid + UnifyVid<Bounds<T>>>(
     self: &L,                           // defines whether we want LUB or GLB
-    +a_vid: V,                          // first variable
-    +b_vid: V,                          // second variable
+    a_vid: V,                          // first variable
+    b_vid: V,                          // second variable
     lattice_dir_op: LatticeDirOp<T>)    // LUB or GLB operation on types
     -> cres<LatticeVarResult<V,T>> {
     let nde_a = self.infcx().get(a_vid);
@@ -447,7 +447,7 @@ pub fn lattice_var_and_t<L:LatticeDir + Combine,
                          T:Copy + InferStr + LatticeValue,
                          V:Copy + Eq + ToStr + Vid + UnifyVid<Bounds<T>>>(
     self: &L,
-    +a_id: V,
+    a_id: V,
     b: &T,
     lattice_dir_op: LatticeDirOp<T>)
     -> cres<T> {

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -643,8 +643,8 @@ pub impl InferCtxt {
 }
 
 fn next_simple_var<V:Copy,T:Copy>(
-        +counter: &mut uint,
-        +bindings: &mut ValsAndBindings<V,Option<T>>)
+        counter: &mut uint,
+        bindings: &mut ValsAndBindings<V,Option<T>>)
      -> uint {
     let id = *counter;
     *counter += 1;

--- a/src/librustc/middle/typeck/infer/region_inference.rs
+++ b/src/librustc/middle/typeck/infer/region_inference.rs
@@ -563,7 +563,7 @@ enum Constraint {
 }
 
 impl to_bytes::IterBytes for Constraint {
-   fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+   fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
           ConstrainVarSubVar(ref v0, ref v1) =>
           to_bytes::iter_bytes_3(&0u8, v0, v1, lsb0, f),
@@ -584,7 +584,7 @@ struct TwoRegions {
 }
 
 impl to_bytes::IterBytes for TwoRegions {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.a, &self.b, lsb0, f)
     }
 }
@@ -729,7 +729,7 @@ pub impl RegionVarBindings {
         re_bound(br_fresh(sc))
     }
 
-    fn add_constraint(&mut self, +constraint: Constraint, span: span) {
+    fn add_constraint(&mut self, constraint: Constraint, span: span) {
         // cannot add constraints once regions are resolved
         assert!(self.values.is_empty());
 
@@ -995,7 +995,7 @@ pub impl RegionVarBindings {
 
         return result_set;
 
-        fn consider_adding_edge(+result_set: ~[Region],
+        fn consider_adding_edge(result_set: ~[Region],
                                 r: &Region,
                                 r1: &Region,
                                 r2: &Region) -> ~[Region]
@@ -1030,7 +1030,7 @@ priv impl RegionVarBindings {
         rm.is_subregion_of(sub, sup)
     }
 
-    fn lub_concrete_regions(&self, +a: Region, +b: Region) -> Region {
+    fn lub_concrete_regions(&self, a: Region, b: Region) -> Region {
         match (a, b) {
           (re_static, _) | (_, re_static) => {
             re_static // nothing lives longer than static
@@ -1122,8 +1122,8 @@ priv impl RegionVarBindings {
     }
 
     fn glb_concrete_regions(&self,
-                            +a: Region,
-                            +b: Region)
+                            a: Region,
+                            b: Region)
                          -> cres<Region> {
         debug!("glb_concrete_regions(%?, %?)", a, b);
         match (a, b) {
@@ -1330,7 +1330,7 @@ pub impl RegionVarBindings {
 
         return (graph);
 
-        fn insert_edge(+graph: &mut Graph,
+        fn insert_edge(graph: &mut Graph,
                        node_id: RegionVid,
                        edge_dir: Direction,
                        edge_idx: uint) {
@@ -1457,9 +1457,9 @@ pub impl RegionVarBindings {
             }
         };
 
-        fn check_node(+self: &mut RegionVarBindings,
+        fn check_node(self: &mut RegionVarBindings,
                       a_vid: RegionVid,
-                      +a_node: &mut GraphNode,
+                      a_node: &mut GraphNode,
                       a_region: Region,
                       b_region: Region)
                    -> bool {
@@ -1471,9 +1471,9 @@ pub impl RegionVarBindings {
             false
         }
 
-        fn adjust_node(+self: &mut RegionVarBindings,
+        fn adjust_node(self: &mut RegionVarBindings,
                        a_vid: RegionVid,
-                       +a_node: &mut GraphNode,
+                       a_node: &mut GraphNode,
                        a_region: Region,
                        b_region: Region)
                     -> bool {

--- a/src/librustc/middle/typeck/infer/unify.rs
+++ b/src/librustc/middle/typeck/infer/unify.rs
@@ -42,7 +42,7 @@ pub trait UnifyVid<T> {
 pub impl InferCtxt {
     fn get<T:Copy, V:Copy+Eq+Vid+UnifyVid<T>>(
         &mut self,
-        +vid: V) -> Node<V, T>
+        vid: V) -> Node<V, T>
     {
         /*!
          *
@@ -88,8 +88,8 @@ pub impl InferCtxt {
 
     fn set<T:Copy + InferStr,V:Copy + Vid + ToStr + UnifyVid<T>>(
             &mut self,
-            +vid: V,
-            +new_v: VarValue<V, T>) {
+            vid: V,
+            new_v: VarValue<V, T>) {
         /*!
          *
          * Sets the value for `vid` to `new_v`.  `vid` MUST be a root node!
@@ -147,9 +147,9 @@ pub trait SimplyUnifiable {
     fn to_type_err(expected_found<Self>) -> ty::type_err;
 }
 
-pub fn mk_err<T:SimplyUnifiable>(+a_is_expected: bool,
-                                  +a_t: T,
-                                  +b_t: T) -> ures {
+pub fn mk_err<T:SimplyUnifiable>(a_is_expected: bool,
+                                 a_t: T,
+                                 b_t: T) -> ures {
     if a_is_expected {
         Err(SimplyUnifiable::to_type_err(
             ty::expected_found {expected: a_t, found: b_t}))
@@ -163,9 +163,9 @@ pub impl InferCtxt {
     fn simple_vars<T:Copy + Eq + InferStr + SimplyUnifiable,
                    V:Copy + Eq + Vid + ToStr + UnifyVid<Option<T>>>(
             &mut self,
-            +a_is_expected: bool,
-            +a_id: V,
-            +b_id: V)
+            a_is_expected: bool,
+            a_id: V,
+            b_id: V)
          -> ures {
         /*!
          *
@@ -201,9 +201,9 @@ pub impl InferCtxt {
     fn simple_var_t<T:Copy + Eq + InferStr + SimplyUnifiable,
                     V:Copy + Eq + Vid + ToStr + UnifyVid<Option<T>>>(
             &mut self,
-            +a_is_expected: bool,
-            +a_id: V,
-            +b: T)
+            a_is_expected: bool,
+            a_id: V,
+            b: T)
          -> ures {
         /*!
          *

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -194,7 +194,7 @@ pub fn write_ty_to_tcx(tcx: ty::ctxt, node_id: ast::node_id, ty: ty::t) {
 }
 pub fn write_substs_to_tcx(tcx: ty::ctxt,
                            node_id: ast::node_id,
-                           +substs: ~[ty::t]) {
+                           substs: ~[ty::t]) {
     if substs.len() > 0u {
         debug!("write_substs_to_tcx(%d, %?)", node_id,
                substs.map(|t| ppaux::ty_to_str(tcx, *t)));
@@ -397,7 +397,7 @@ fn check_for_entry_fn(ccx: @mut CrateCtxt) {
 }
 
 pub fn check_crate(tcx: ty::ctxt,
-                   +trait_map: resolve::TraitMap,
+                   trait_map: resolve::TraitMap,
                    crate: @ast::crate)
                 -> (method_map, vtable_map) {
     let time_passes = tcx.sess.time_passes();

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -272,7 +272,7 @@ pub struct binding_rscope {
 
 pub fn in_binding_rscope<RS:region_scope + Copy + Durable>(
         self: &RS,
-        +region_param_names: RegionParamNames)
+        region_param_names: RegionParamNames)
      -> binding_rscope {
     let base = @copy *self;
     let base = base as @region_scope;

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -18,12 +18,10 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-#[legacy_modes];
-
 #[allow(non_implicitly_copyable_typarams)];
 #[allow(non_camel_case_types)];
-#[allow(deprecated_mode)];
-#[warn(deprecated_pattern)];
+#[deny(deprecated_pattern)];
+#[deny(deprecated_mode)];
 
 #[no_core];
 
@@ -259,12 +257,12 @@ pub fn run_compiler(args: &~[~str], demitter: diagnostic::Emitter) {
     let odir = odir.map(|o| Path(*o));
     let ofile = getopts::opt_maybe_str(matches, ~"o");
     let ofile = ofile.map(|o| Path(*o));
-    let cfg = build_configuration(sess, binary, input);
+    let cfg = build_configuration(sess, binary, &input);
     let pretty = getopts::opt_default(matches, ~"pretty", "normal").map(
                     |a| parse_pretty(sess, *a));
     match pretty {
       Some::<pp_mode>(ppm) => {
-        pretty_print_input(sess, cfg, input, ppm);
+        pretty_print_input(sess, cfg, &input, ppm);
         return;
       }
       None::<pp_mode> => {/* continue */ }
@@ -282,7 +280,7 @@ pub fn run_compiler(args: &~[~str], demitter: diagnostic::Emitter) {
         return;
     }
 
-    compile_input(sess, cfg, input, &odir, &ofile);
+    compile_input(sess, cfg, &input, &odir, &ofile);
 }
 
 #[deriving(Eq)]
@@ -303,7 +301,7 @@ diagnostic emitter which records when we hit a fatal error. If the task
 fails without recording a fatal error then we've encountered a compiler
 bug and need to present an error.
 */
-pub fn monitor(+f: ~fn(diagnostic::Emitter)) {
+pub fn monitor(f: ~fn(diagnostic::Emitter)) {
     use core::comm::*;
     let (p, ch) = stream();
     let ch = SharedChan::new(ch);

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -63,12 +63,12 @@ pub fn field_exprs(fields: ~[ast::field]) -> ~[@ast::expr] {
 
 // Takes a predicate p, returns true iff p is true for any subexpressions
 // of b -- skipping any inner loops (loop, while, loop_body)
-pub fn loop_query(b: &ast::blk, p: @fn(ast::expr_) -> bool) -> bool {
+pub fn loop_query(b: &ast::blk, p: @fn(&ast::expr_) -> bool) -> bool {
     let rs = @mut false;
     let visit_expr: @fn(@ast::expr,
-                        &&flag: @mut bool,
-                        v: visit::vt<@mut bool>) = |e, &&flag, v| {
-        *flag |= p(e.node);
+                        flag: @mut bool,
+                        v: visit::vt<@mut bool>) = |e, flag, v| {
+        *flag |= p(&e.node);
         match e.node {
           // Skip inner loops, since a break in the inner loop isn't a
           // break inside the outer loop
@@ -89,8 +89,8 @@ pub fn loop_query(b: &ast::blk, p: @fn(ast::expr_) -> bool) -> bool {
 pub fn block_query(b: &ast::blk, p: @fn(@ast::expr) -> bool) -> bool {
     let rs = @mut false;
     let visit_expr: @fn(@ast::expr,
-                        &&flag: @mut bool,
-                        v: visit::vt<@mut bool>) = |e, &&flag, v| {
+                        flag: @mut bool,
+                        v: visit::vt<@mut bool>) = |e, flag, v| {
         *flag |= p(e);
         visit::visit_expr(e, flag, v)
     };
@@ -108,7 +108,7 @@ pub fn local_rhs_span(l: @ast::local, def: span) -> span {
     }
 }
 
-pub fn pluralize(n: uint, +s: ~str) -> ~str {
+pub fn pluralize(n: uint, s: ~str) -> ~str {
     if n == 1 { s }
     else { str::concat([s, ~"s"]) }
 }

--- a/src/librustdoc/astsrv.rs
+++ b/src/librustdoc/astsrv.rs
@@ -117,7 +117,7 @@ fn build_ctxt(sess: Session,
     let ast = syntax::ext::expand::expand_crate(sess.parse_sess,
                                                 copy sess.opts.cfg, ast);
     let ast = front::test::modify_for_testing(sess, ast);
-    let ast_map = ast_map::map_crate(sess.diagnostic(), *ast);
+    let ast_map = ast_map::map_crate(sess.diagnostic(), ast);
 
     Ctxt {
         ast: ast,

--- a/src/librustdoc/parse.rs
+++ b/src/librustdoc/parse.rs
@@ -39,5 +39,5 @@ pub fn from_str_sess(sess: session::Session, source: ~str) -> @ast::crate {
 }
 
 fn cfg(sess: session::Session, input: driver::input) -> ast::crate_cfg {
-    driver::build_configuration(sess, @~"rustdoc", input)
+    driver::build_configuration(sess, @~"rustdoc", &input)
 }

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -93,7 +93,7 @@ fn record(repl: Repl, blk: @ast::blk, intr: @token::ident_interner) -> Repl {
             for blk.node.stmts.each |stmt| {
                 match stmt.node {
                     ast::stmt_decl(*) | ast::stmt_mac(*) => {
-                        pprust::print_stmt(pp, **stmt);
+                        pprust::print_stmt(pp, *stmt);
                         writer.write_line(~"");
                     }
                     ast::stmt_expr(expr, _) | ast::stmt_semi(expr, _) => {
@@ -101,7 +101,7 @@ fn record(repl: Repl, blk: @ast::blk, intr: @token::ident_interner) -> Repl {
                             ast::expr_assign(*) |
                             ast::expr_assign_op(*) |
                             ast::expr_swap(*) => {
-                                pprust::print_stmt(pp, **stmt);
+                                pprust::print_stmt(pp, *stmt);
                                 writer.write_line(~"");
                             }
                             _ => {}
@@ -147,13 +147,13 @@ fn run(repl: Repl, input: ~str) -> Repl {
     debug!("building driver configuration");
     let cfg = driver::build_configuration(sess,
                                           @repl.binary,
-                                          wrapped);
+                                          &wrapped);
 
-    let outputs = driver::build_output_filenames(wrapped, &None, &None, sess);
+    let outputs = driver::build_output_filenames(&wrapped, &None, &None, sess);
     debug!("calling compile_upto");
-    let (crate, _) = driver::compile_upto(sess, cfg, wrapped,
-                                                 driver::cu_everything,
-                                                 Some(outputs));
+    let (crate, _) = driver::compile_upto(sess, cfg, &wrapped,
+                                          driver::cu_everything,
+                                          Some(outputs));
 
     let mut opt = None;
 
@@ -198,9 +198,9 @@ fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
         let input = driver::file_input(src_path);
         let sess = driver::build_session(options, diagnostic::emit);
         *sess.building_library = true;
-        let cfg = driver::build_configuration(sess, @binary, input);
+        let cfg = driver::build_configuration(sess, @binary, &input);
         let outputs = driver::build_output_filenames(
-            input, &None, &None, sess);
+            &input, &None, &None, sess);
         // If the library already exists and is newer than the source
         // file, skip compilation and return None.
         let mut should_compile = true;
@@ -228,7 +228,7 @@ fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
         }
         if (should_compile) {
             io::println(fmt!("compiling %s...", src_filename));
-            driver::compile_upto(sess, cfg, input, driver::cu_everything,
+            driver::compile_upto(sess, cfg, &input, driver::cu_everything,
                                  Some(outputs));
             true
         } else { false }

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -37,7 +37,7 @@ use std::{getopts};
 use syntax::{ast, diagnostic};
 use util::*;
 use path_util::{dest_dir, normalize};
-use rustc::driver::session::{lib_crate, bin_crate, unknown_crate, crate_type};
+use rustc::driver::session::{lib_crate, bin_crate, crate_type};
 
 mod conditions;
 mod usage;
@@ -82,8 +82,8 @@ impl PkgScript {
         };
         let input = driver::file_input(script);
         let sess = driver::build_session(options, diagnostic::emit);
-        let cfg = driver::build_configuration(sess, @binary, input);
-        let (crate, _) = driver::compile_upto(sess, cfg, input,
+        let cfg = driver::build_configuration(sess, @binary, &input);
+        let (crate, _) = driver::compile_upto(sess, cfg, &input,
                                               driver::cu_parse, None);
         let work_dir = dest_dir(id);
 
@@ -112,7 +112,7 @@ impl PkgScript {
         // Collect together any user-defined commands in the package script
         let crate = util::ready_crate(sess, self.crate);
         debug!("Building output filenames with script name %s",
-               driver::source_name(self.input));
+               driver::source_name(&self.input));
         match filesearch::get_rustpkg_sysroot() {
             Ok(r) => {
                 let root = r.pop().pop().pop().pop(); // :-\

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -12,7 +12,7 @@ use core::*;
 use core::cmp::Ord;
 use core::hash::Streaming;
 use rustc::driver::{driver, session};
-use rustc::driver::session::{lib_crate, bin_crate, unknown_crate};
+use rustc::driver::session::{lib_crate, unknown_crate};
 use rustc::metadata::filesearch;
 use std::getopts::groups::getopts;
 use std::semver;
@@ -25,7 +25,7 @@ use syntax::{ast, attr, codemap, diagnostic, fold};
 use syntax::ast::{meta_name_value, meta_list, attribute, crate_};
 use syntax::attr::{mk_attr};
 use rustc::back::link::output_type_exe;
-use rustc::driver::session::{lib_crate, bin_crate, unknown_crate, crate_type};
+use rustc::driver::session::{lib_crate, unknown_crate, crate_type};
 
 pub type ExitCode = int; // For now
 
@@ -516,9 +516,9 @@ pub fn compile_crate_from_input(input: driver::input,
                                 binary: ~str,
                                 what: driver::compile_upto) -> @ast::crate {
     debug!("Calling build_output_filenames with %?", build_dir_opt);
-    let outputs = driver::build_output_filenames(input, &build_dir_opt, &Some(out_file), sess);
+    let outputs = driver::build_output_filenames(&input, &build_dir_opt, &Some(out_file), sess);
     debug!("Outputs are %? and output type = %?", outputs, sess.opts.output_type);
-    let cfg = driver::build_configuration(sess, @binary, input);
+    let cfg = driver::build_configuration(sess, @binary, &input);
     match crate_opt {
         Some(c) => {
             debug!("Calling compile_rest, outputs = %?", outputs);
@@ -528,7 +528,7 @@ pub fn compile_crate_from_input(input: driver::input,
         }
         None => {
             debug!("Calling compile_upto, outputs = %?", outputs);
-            let (crate, _) = driver::compile_upto(sess, cfg, input,
+            let (crate, _) = driver::compile_upto(sess, cfg, &input,
                                                   driver::cu_parse, Some(outputs));
 
             // Inject the inferred link_meta info if it's not already there

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -159,8 +159,8 @@ mod tests {
 
             assert!(mem as int != 0);
 
-            return unsafe { c_vec_with_dtor(mem as *mut u8, n as uint,
-                                         || unsafe { free(mem) }) };
+            return c_vec_with_dtor(mem as *mut u8, n as uint,
+                                   || unsafe { free(mem) });
         }
     }
 
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn test_and_I_mean_it() {
         let cv = malloc(16u as size_t);
-        let p = unsafe { ptr(cv) };
+        let p = ptr(cv);
 
         set(cv, 0u, 32u8);
         set(cv, 1u, 33u8);

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -1287,18 +1287,16 @@ mod tests {
           node::Content(x) => {
             let str = @mut ~"";
             fn aux(str: @mut ~str, node: @node::Node) {
-                unsafe {
-                    match (*node) {
-                      node::Leaf(x) => {
-                        *str += str::slice(
-                            *x.content, x.byte_offset,
-                            x.byte_offset + x.byte_len).to_owned();
-                      }
-                      node::Concat(ref x) => {
-                        aux(str, x.left);
-                        aux(str, x.right);
-                      }
-                    }
+                match (*node) {
+                  node::Leaf(x) => {
+                    *str += str::slice(
+                        *x.content, x.byte_offset,
+                        x.byte_offset + x.byte_len).to_owned();
+                  }
+                  node::Concat(ref x) => {
+                    aux(str, x.left);
+                    aux(str, x.right);
+                  }
                 }
             }
             aux(str, x);

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -1422,10 +1422,8 @@ mod test {
     }
 
     extern fn server_after_close_cb(handle: *libc::c_void) {
-        unsafe {
-            debug!("SERVER server stream closed, should exit. h: %?",
-                       handle);
-        }
+        debug!("SERVER server stream closed, should exit. h: %?",
+                   handle);
     }
 
     extern fn client_stream_after_close_cb(handle: *libc::c_void) {
@@ -1709,48 +1707,46 @@ mod test {
     // this is the impl for a test that is (maybe) ran on a
     // per-platform/arch basis below
     pub fn impl_uv_tcp_server_and_request() {
-        unsafe {
-            let bind_ip = ~"0.0.0.0";
-            let request_ip = ~"127.0.0.1";
-            let port = 8886;
-            let kill_server_msg = ~"does a dog have buddha nature?";
-            let server_resp_msg = ~"mu!";
-            let (client_port, client_chan) = stream::<~str>();
-            let client_chan = SharedChan::new(client_chan);
-            let (server_port, server_chan) = stream::<~str>();
-            let server_chan = SharedChan::new(server_chan);
+        let bind_ip = ~"0.0.0.0";
+        let request_ip = ~"127.0.0.1";
+        let port = 8886;
+        let kill_server_msg = ~"does a dog have buddha nature?";
+        let server_resp_msg = ~"mu!";
+        let (client_port, client_chan) = stream::<~str>();
+        let client_chan = SharedChan::new(client_chan);
+        let (server_port, server_chan) = stream::<~str>();
+        let server_chan = SharedChan::new(server_chan);
 
-            let (continue_port, continue_chan) = stream::<bool>();
-            let continue_chan = SharedChan::new(continue_chan);
+        let (continue_port, continue_chan) = stream::<bool>();
+        let continue_chan = SharedChan::new(continue_chan);
 
-            let kill_server_msg_copy = copy kill_server_msg;
-            let server_resp_msg_copy = copy server_resp_msg;
-            do task::spawn_sched(task::ManualThreads(1)) {
-                impl_uv_tcp_server(bind_ip, port,
-                                   copy kill_server_msg_copy,
-                                   copy server_resp_msg_copy,
-                                   server_chan.clone(),
-                                   continue_chan.clone());
-            };
+        let kill_server_msg_copy = copy kill_server_msg;
+        let server_resp_msg_copy = copy server_resp_msg;
+        do task::spawn_sched(task::ManualThreads(1)) {
+            impl_uv_tcp_server(bind_ip, port,
+                               copy kill_server_msg_copy,
+                               copy server_resp_msg_copy,
+                               server_chan.clone(),
+                               continue_chan.clone());
+        };
 
-            // block until the server up is.. possibly a race?
-            debug!(~"before receiving on server continue_port");
-            continue_port.recv();
-            debug!(~"received on continue port, set up tcp client");
+        // block until the server up is.. possibly a race?
+        debug!(~"before receiving on server continue_port");
+        continue_port.recv();
+        debug!(~"received on continue port, set up tcp client");
 
-            let kill_server_msg_copy = copy kill_server_msg;
-            do task::spawn_sched(task::ManualThreads(1u)) {
-                impl_uv_tcp_request(request_ip, port,
-                                   kill_server_msg_copy,
-                                   client_chan.clone());
-            };
+        let kill_server_msg_copy = copy kill_server_msg;
+        do task::spawn_sched(task::ManualThreads(1u)) {
+            impl_uv_tcp_request(request_ip, port,
+                               kill_server_msg_copy,
+                               client_chan.clone());
+        };
 
-            let msg_from_client = server_port.recv();
-            let msg_from_server = client_port.recv();
+        let msg_from_client = server_port.recv();
+        let msg_from_server = client_port.recv();
 
-            assert!(str::contains(msg_from_client, kill_server_msg));
-            assert!(str::contains(msg_from_server, server_resp_msg));
-        }
+        assert!(str::contains(msg_from_client, kill_server_msg));
+        assert!(str::contains(msg_from_server, server_resp_msg));
     }
 
     // FIXME don't run on fbsd or linux 32 bit(#2064)
@@ -1784,17 +1780,15 @@ mod test {
 
     fn struct_size_check_common<TStruct>(t_name: ~str,
                                          foreign_size: libc::c_uint) {
-        unsafe {
-            let rust_size = sys::size_of::<TStruct>();
-            let sizes_match = foreign_size as uint == rust_size;
-            if !sizes_match {
-                let output = fmt!(
-                    "STRUCT_SIZE FAILURE: %s -- actual: %u expected: %u",
-                    t_name, rust_size, foreign_size as uint);
-                debug!(output);
-            }
-            assert!(sizes_match);
+        let rust_size = sys::size_of::<TStruct>();
+        let sizes_match = foreign_size as uint == rust_size;
+        if !sizes_match {
+            let output = fmt!(
+                "STRUCT_SIZE FAILURE: %s -- actual: %u expected: %u",
+                t_name, rust_size, foreign_size as uint);
+            debug!(output);
         }
+        assert!(sizes_match);
     }
 
     // struct size tests

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -255,13 +255,13 @@ pub impl AbiSet {
 }
 
 impl to_bytes::IterBytes for Abi {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.index().iter_bytes(lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for AbiSet {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.bits.iter_bytes(lsb0, f)
     }
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -97,7 +97,7 @@ impl<D:Decoder> Decodable<D> for ident {
 }
 
 impl to_bytes::IterBytes for ident {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.repr.iter_bytes(lsb0, f)
     }
 }
@@ -284,7 +284,7 @@ pub enum binding_mode {
 }
 
 impl to_bytes::IterBytes for binding_mode {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
           bind_by_copy => 0u8.iter_bytes(lsb0, f),
 
@@ -330,7 +330,7 @@ pub enum pat_ {
 pub enum mutability { m_mutbl, m_imm, m_const, }
 
 impl to_bytes::IterBytes for mutability {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -345,7 +345,7 @@ pub enum Sigil {
 }
 
 impl to_bytes::IterBytes for Sigil {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as uint).iter_bytes(lsb0, f)
     }
 }
@@ -428,7 +428,7 @@ pub enum inferable<T> {
 }
 
 impl<T:to_bytes::IterBytes> to_bytes::IterBytes for inferable<T> {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
           expl(ref t) =>
           to_bytes::iter_bytes_2(&0u8, t, lsb0, f),
@@ -446,7 +446,7 @@ impl<T:to_bytes::IterBytes> to_bytes::IterBytes for inferable<T> {
 pub enum rmode { by_ref, by_copy }
 
 impl to_bytes::IterBytes for rmode {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -781,7 +781,7 @@ impl ToStr for int_ty {
 }
 
 impl to_bytes::IterBytes for int_ty {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -798,7 +798,7 @@ impl ToStr for uint_ty {
 }
 
 impl to_bytes::IterBytes for uint_ty {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -815,7 +815,7 @@ impl ToStr for float_ty {
 }
 
 impl to_bytes::IterBytes for float_ty {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -860,7 +860,7 @@ impl ToStr for Onceness {
 }
 
 impl to_bytes::IterBytes for Onceness {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as uint).iter_bytes(lsb0, f);
     }
 }
@@ -911,7 +911,7 @@ pub enum ty_ {
 }
 
 impl to_bytes::IterBytes for Ty {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.span.lo, &self.span.hi, lsb0, f);
     }
 }
@@ -979,7 +979,7 @@ impl ToStr for purity {
 }
 
 impl to_bytes::IterBytes for purity {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -994,7 +994,7 @@ pub enum ret_style {
 }
 
 impl to_bytes::IterBytes for ret_style {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -1268,7 +1268,7 @@ pub enum item_ {
 pub enum struct_mutability { struct_mutable, struct_immutable }
 
 impl to_bytes::IterBytes for struct_mutability {
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -39,7 +39,7 @@ pub fn local_def(id: node_id) -> def_id {
 
 pub fn is_local(did: ast::def_id) -> bool { did.crate == local_crate }
 
-pub fn stmt_id(s: stmt) -> node_id {
+pub fn stmt_id(s: &stmt) -> node_id {
     match s.node {
       stmt_decl(_, id) => id,
       stmt_expr(_, id) => id,
@@ -200,7 +200,7 @@ pub fn is_call_expr(e: @expr) -> bool {
 // This makes def_id hashable
 impl to_bytes::IterBytes for def_id {
     #[inline(always)]
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.crate, &self.node, lsb0, f);
     }
 }
@@ -211,7 +211,7 @@ pub fn block_from_expr(e: @expr) -> blk {
 }
 
 pub fn default_block(
-    +stmts1: ~[@stmt],
+    stmts1: ~[@stmt],
     expr1: Option<@expr>,
     id1: node_id
 ) -> blk_ {
@@ -224,7 +224,7 @@ pub fn default_block(
     }
 }
 
-pub fn ident_to_path(s: span, +i: ident) -> @Path {
+pub fn ident_to_path(s: span, i: ident) -> @Path {
     @ast::Path { span: s,
                  global: false,
                  idents: ~[i],
@@ -232,7 +232,7 @@ pub fn ident_to_path(s: span, +i: ident) -> @Path {
                  types: ~[] }
 }
 
-pub fn ident_to_pat(id: node_id, s: span, +i: ident) -> @pat {
+pub fn ident_to_pat(id: node_id, s: span, i: ident) -> @pat {
     @ast::pat { id: id,
                 node: pat_ident(bind_by_copy, ident_to_path(s, i), None),
                 span: s }
@@ -300,7 +300,7 @@ pub fn struct_field_visibility(field: ast::struct_field) -> visibility {
 pub trait inlined_item_utils {
     fn ident(&self) -> ident;
     fn id(&self) -> ast::node_id;
-    fn accept<E>(&self, e: E, v: visit::vt<E>);
+    fn accept<E: Copy>(&self, e: E, v: visit::vt<E>);
 }
 
 impl inlined_item_utils for inlined_item {
@@ -322,7 +322,7 @@ impl inlined_item_utils for inlined_item {
         }
     }
 
-    fn accept<E>(&self, e: E, v: visit::vt<E>) {
+    fn accept<E: Copy>(&self, e: E, v: visit::vt<E>) {
         match *self {
             ii_item(i) => (v.visit_item)(i, e, v),
             ii_foreign(i) => (v.visit_foreign_item)(i, e, v),
@@ -435,7 +435,7 @@ pub fn id_visitor(vfn: @fn(node_id)) -> visit::vt<()> {
 
         visit_local: |l| vfn(l.node.id),
         visit_block: |b| vfn(b.node.id),
-        visit_stmt: |s| vfn(ast_util::stmt_id(*s)),
+        visit_stmt: |s| vfn(ast_util::stmt_id(s)),
         visit_arm: |_| {},
         visit_pat: |p| vfn(p.id),
         visit_decl: |_| {},
@@ -491,7 +491,7 @@ pub fn id_visitor(vfn: @fn(node_id)) -> visit::vt<()> {
     })
 }
 
-pub fn visit_ids_for_inlined_item(item: inlined_item, vfn: @fn(node_id)) {
+pub fn visit_ids_for_inlined_item(item: &inlined_item, vfn: @fn(node_id)) {
     item.accept((), id_visitor(vfn));
 }
 
@@ -505,7 +505,7 @@ pub fn compute_id_range(visit_ids_fn: &fn(@fn(node_id))) -> id_range {
     id_range { min: *min, max: *max }
 }
 
-pub fn compute_id_range_for_inlined_item(item: inlined_item) -> id_range {
+pub fn compute_id_range_for_inlined_item(item: &inlined_item) -> id_range {
     compute_id_range(|f| visit_ids_for_inlined_item(item, f))
 }
 
@@ -609,7 +609,7 @@ pub fn mk_rename (id:ident, to:Name, tail:SyntaxContext, table: &mut SCTable)
 pub fn mk_sctable() -> SCTable { ~[EmptyCtxt] }
 
 /// Add a value to the end of a vec, return its index
-fn idx_push<T>(vec: &mut ~[T], +val: T) -> uint {
+fn idx_push<T>(vec: &mut ~[T], val: T) -> uint {
     vec.push(val);
     vec.len() - 1
 }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -31,12 +31,12 @@ pub fn mk_name_value_item_str(name: @~str, value: @~str)
     mk_name_value_item(name, value_lit)
 }
 
-pub fn mk_name_value_item(name: @~str, +value: ast::lit)
+pub fn mk_name_value_item(name: @~str, value: ast::lit)
         -> @ast::meta_item {
     @dummy_spanned(ast::meta_name_value(name, value))
 }
 
-pub fn mk_list_item(name: @~str, +items: ~[@ast::meta_item]) ->
+pub fn mk_list_item(name: @~str, items: ~[@ast::meta_item]) ->
    @ast::meta_item {
     @dummy_spanned(ast::meta_list(name, items))
 }
@@ -51,8 +51,8 @@ pub fn mk_attr(item: @ast::meta_item) -> ast::attribute {
                                     is_sugared_doc: false })
 }
 
-pub fn mk_sugared_doc_attr(+text: ~str,
-                           +lo: BytePos, +hi: BytePos) -> ast::attribute {
+pub fn mk_sugared_doc_attr(text: ~str,
+                           lo: BytePos, hi: BytePos) -> ast::attribute {
     let style = doc_comment_style(text);
     let lit = spanned(lo, hi, ast::lit_str(@text));
     let attr = ast::attribute_ {

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -71,7 +71,7 @@ impl Sub<BytePos, BytePos> for BytePos {
 }
 
 impl to_bytes::IterBytes for BytePos {
-    fn iter_bytes(&self, +lsb0: bool, &&f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (**self).iter_bytes(lsb0, f)
     }
 }
@@ -89,7 +89,7 @@ impl cmp::Ord for CharPos {
 }
 
 impl to_bytes::IterBytes for CharPos {
-    fn iter_bytes(&self, +lsb0: bool, &&f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (**self).iter_bytes(lsb0, f)
     }
 }
@@ -141,20 +141,20 @@ impl<D:Decoder> Decodable<D> for span {
     }
 }
 
-pub fn spanned<T>(+lo: BytePos, +hi: BytePos, +t: T) -> spanned<T> {
+pub fn spanned<T>(lo: BytePos, hi: BytePos, t: T) -> spanned<T> {
     respan(mk_sp(lo, hi), t)
 }
 
-pub fn respan<T>(sp: span, +t: T) -> spanned<T> {
+pub fn respan<T>(sp: span, t: T) -> spanned<T> {
     spanned {node: t, span: sp}
 }
 
-pub fn dummy_spanned<T>(+t: T) -> spanned<T> {
+pub fn dummy_spanned<T>(t: T) -> spanned<T> {
     respan(dummy_sp(), t)
 }
 
 /* assuming that we're not in macro expansion */
-pub fn mk_sp(+lo: BytePos, +hi: BytePos) -> span {
+pub fn mk_sp(lo: BytePos, hi: BytePos) -> span {
     span {lo: lo, hi: hi, expn_info: None}
 }
 
@@ -247,7 +247,7 @@ pub impl FileMap {
     // UNCHECKED INVARIANT: these offsets must be added in the right
     // order and must be in the right places; there is shared knowledge
     // about what ends a line between this file and parse.rs
-    fn next_line(&self, +pos: BytePos) {
+    fn next_line(&self, pos: BytePos) {
         // the new charpos must be > the last one (or it's the first one).
         let lines = &mut *self.lines;
         assert!((lines.len() == 0) || (lines[lines.len() - 1] < pos));
@@ -287,14 +287,14 @@ pub impl CodeMap {
     }
 
     /// Add a new FileMap to the CodeMap and return it
-    fn new_filemap(&self, +filename: FileName, src: @~str) -> @FileMap {
+    fn new_filemap(&self, filename: FileName, src: @~str) -> @FileMap {
         return self.new_filemap_w_substr(filename, FssNone, src);
     }
 
     fn new_filemap_w_substr(
         &self,
-        +filename: FileName,
-        +substr: FileSubstr,
+        filename: FileName,
+        substr: FileSubstr,
         src: @~str
     ) -> @FileMap {
         let files = &mut *self.files;
@@ -325,11 +325,11 @@ pub impl CodeMap {
     }
 
     /// Lookup source information about a BytePos
-    pub fn lookup_char_pos(&self, +pos: BytePos) -> Loc {
+    pub fn lookup_char_pos(&self, pos: BytePos) -> Loc {
         return self.lookup_pos(pos);
     }
 
-    pub fn lookup_char_pos_adj(&self, +pos: BytePos) -> LocWithOpt
+    pub fn lookup_char_pos_adj(&self, pos: BytePos) -> LocWithOpt
     {
         let loc = self.lookup_char_pos(pos);
         match (loc.file.substr) {
@@ -405,7 +405,7 @@ pub impl CodeMap {
 
 priv impl CodeMap {
 
-    fn lookup_filemap_idx(&self, +pos: BytePos) -> uint {
+    fn lookup_filemap_idx(&self, pos: BytePos) -> uint {
         let files = &*self.files;
         let len = files.len();
         let mut a = 0u;
@@ -440,7 +440,7 @@ priv impl CodeMap {
         return FileMapAndLine {fm: f, line: a};
     }
 
-    fn lookup_pos(&self, +pos: BytePos) -> Loc {
+    fn lookup_pos(&self, pos: BytePos) -> Loc {
         let FileMapAndLine {fm: f, line: a} = self.lookup_line(pos);
         let line = a + 1u; // Line numbers start at 1
         let chpos = self.bytepos_to_local_charpos(pos);
@@ -466,7 +466,7 @@ priv impl CodeMap {
                     lo.line, lo.col.to_uint(), hi.line, hi.col.to_uint())
     }
 
-    fn lookup_byte_offset(&self, +bpos: BytePos)
+    fn lookup_byte_offset(&self, bpos: BytePos)
         -> FileMapAndBytePos {
         let idx = self.lookup_filemap_idx(bpos);
         let fm = self.files[idx];
@@ -476,7 +476,7 @@ priv impl CodeMap {
 
     // Converts an absolute BytePos to a CharPos relative to the file it is
     // located in
-    fn bytepos_to_local_charpos(&self, +bpos: BytePos) -> CharPos {
+    fn bytepos_to_local_charpos(&self, bpos: BytePos) -> CharPos {
         debug!("codemap: converting %? to char pos", bpos);
         let idx = self.lookup_filemap_idx(bpos);
         let map = self.files[idx];

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -239,7 +239,7 @@ priv impl @ext_ctxt {
         }
     }
 
-    fn expr(&self, span: span, +node: ast::expr_) -> @ast::expr {
+    fn expr(&self, span: span, node: ast::expr_) -> @ast::expr {
         @ast::expr {
             id: self.next_id(),
             callee_id: self.next_id(),
@@ -248,7 +248,7 @@ priv impl @ext_ctxt {
         }
     }
 
-    fn path(&self, span: span, +strs: ~[ast::ident]) -> @ast::Path {
+    fn path(&self, span: span, strs: ~[ast::ident]) -> @ast::Path {
         @ast::Path {
             span: span,
             global: false,
@@ -258,7 +258,7 @@ priv impl @ext_ctxt {
         }
     }
 
-    fn path_global(&self, span: span, +strs: ~[ast::ident]) -> @ast::Path {
+    fn path_global(&self, span: span, strs: ~[ast::ident]) -> @ast::Path {
         @ast::Path {
             span: span,
             global: true,
@@ -271,8 +271,8 @@ priv impl @ext_ctxt {
     fn path_tps(
         &self,
         span: span,
-        +strs: ~[ast::ident],
-        +tps: ~[@ast::Ty]
+        strs: ~[ast::ident],
+        tps: ~[@ast::Ty]
     ) -> @ast::Path {
         @ast::Path {
             span: span,
@@ -286,8 +286,8 @@ priv impl @ext_ctxt {
     fn path_tps_global(
         &self,
         span: span,
-        +strs: ~[ast::ident],
-        +tps: ~[@ast::Ty]
+        strs: ~[ast::ident],
+        tps: ~[@ast::Ty]
     ) -> @ast::Path {
         @ast::Path {
             span: span,
@@ -301,8 +301,8 @@ priv impl @ext_ctxt {
     fn ty_path(
         &self,
         span: span,
-        +strs: ~[ast::ident],
-        +tps: ~[@ast::Ty]
+        strs: ~[ast::ident],
+        tps: ~[@ast::Ty]
     ) -> @ast::Ty {
         @ast::Ty {
             id: self.next_id(),
@@ -349,13 +349,13 @@ priv impl @ext_ctxt {
                                 span: span}))
     }
 
-    fn lambda(&self, +blk: ast::blk) -> @ast::expr {
+    fn lambda(&self, blk: ast::blk) -> @ast::expr {
         let ext_cx = *self;
         let blk_e = self.expr(copy blk.span, ast::expr_block(copy blk));
         quote_expr!( || $blk_e )
     }
 
-    fn blk(&self, span: span, +stmts: ~[@ast::stmt]) -> ast::blk {
+    fn blk(&self, span: span, stmts: ~[@ast::stmt]) -> ast::blk {
         codemap::spanned {
             node: ast::blk_ {
                 view_items: ~[],
@@ -381,19 +381,19 @@ priv impl @ext_ctxt {
         }
     }
 
-    fn expr_path(&self, span: span, +strs: ~[ast::ident]) -> @ast::expr {
+    fn expr_path(&self, span: span, strs: ~[ast::ident]) -> @ast::expr {
         self.expr(span, ast::expr_path(self.path(span, strs)))
     }
 
     fn expr_path_global(
         &self,
         span: span,
-        +strs: ~[ast::ident]
+        strs: ~[ast::ident]
     ) -> @ast::expr {
         self.expr(span, ast::expr_path(self.path_global(span, strs)))
     }
 
-    fn expr_var(&self, span: span, +var: ~str) -> @ast::expr {
+    fn expr_var(&self, span: span, var: ~str) -> @ast::expr {
         self.expr_path(span, ~[self.ident_of(var)])
     }
 
@@ -410,7 +410,7 @@ priv impl @ext_ctxt {
         &self,
         span: span,
         expr: @ast::expr,
-        +args: ~[@ast::expr]
+        args: ~[@ast::expr]
     ) -> @ast::expr {
         self.expr(span, ast::expr_call(expr, args, ast::NoSugar))
     }
@@ -420,7 +420,7 @@ priv impl @ext_ctxt {
         span: span,
         expr: @ast::expr,
         ident: ast::ident,
-        +args: ~[@ast::expr]
+        args: ~[@ast::expr]
     ) -> @ast::expr {
         self.expr(span, ast::expr_method_call(expr, ident, ~[], args, ast::NoSugar))
     }
@@ -429,7 +429,7 @@ priv impl @ext_ctxt {
         self.lambda(self.expr_blk(expr))
     }
 
-    fn lambda_stmts(&self, span: span, +stmts: ~[@ast::stmt]) -> @ast::expr {
+    fn lambda_stmts(&self, span: span, stmts: ~[@ast::stmt]) -> @ast::expr {
         self.lambda(self.blk(span, stmts))
     }
 }
@@ -597,7 +597,7 @@ fn mk_deser_impl(
 fn mk_ser_method(
     cx: @ext_ctxt,
     span: span,
-    +ser_body: ast::blk
+    ser_body: ast::blk
 ) -> @ast::method {
     let ty_s = @ast::Ty {
         id: cx.next_id(),
@@ -660,7 +660,7 @@ fn mk_deser_method(
     cx: @ext_ctxt,
     span: span,
     ty: @ast::Ty,
-    +deser_body: ast::blk
+    deser_body: ast::blk
 ) -> @ast::method {
     let ty_d = @ast::Ty {
         id: cx.next_id(),
@@ -864,7 +864,7 @@ fn mk_enum_ser_impl(
     cx: @ext_ctxt,
     span: span,
     ident: ast::ident,
-    +enum_def: ast::enum_def,
+    enum_def: ast::enum_def,
     generics: &ast::Generics
 ) -> @ast::item {
     let body = mk_enum_ser_body(
@@ -881,7 +881,7 @@ fn mk_enum_deser_impl(
     cx: @ext_ctxt,
     span: span,
     ident: ast::ident,
-    +enum_def: ast::enum_def,
+    enum_def: ast::enum_def,
     generics: &ast::Generics
 ) -> @ast::item {
     let body = mk_enum_deser_body(
@@ -974,7 +974,7 @@ fn mk_enum_ser_body(
     cx: @ext_ctxt,
     span: span,
     name: ast::ident,
-    +variants: ~[ast::variant]
+    variants: ~[ast::variant]
 ) -> @ast::expr {
     let arms = do variants.mapi |v_idx, variant| {
         match variant.node.kind {
@@ -1219,37 +1219,37 @@ mod test {
     impl Encoder for TestEncoder {
         fn emit_nil(&self) { self.add_to_log(CallToEmitNil) }
 
-        fn emit_uint(&self, +v: uint) {self.add_to_log(CallToEmitUint(v)); }
-        fn emit_u64(&self, +_v: u64) { self.add_unknown_to_log(); }
-        fn emit_u32(&self, +_v: u32) { self.add_unknown_to_log(); }
-        fn emit_u16(&self, +_v: u16) { self.add_unknown_to_log(); }
-        fn emit_u8(&self, +_v: u8)   { self.add_unknown_to_log(); }
+        fn emit_uint(&self, v: uint) {self.add_to_log(CallToEmitUint(v)); }
+        fn emit_u64(&self, _v: u64) { self.add_unknown_to_log(); }
+        fn emit_u32(&self, _v: u32) { self.add_unknown_to_log(); }
+        fn emit_u16(&self, _v: u16) { self.add_unknown_to_log(); }
+        fn emit_u8(&self, _v: u8)   { self.add_unknown_to_log(); }
 
-        fn emit_int(&self, +_v: int) { self.add_unknown_to_log(); }
-        fn emit_i64(&self, +_v: i64) { self.add_unknown_to_log(); }
-        fn emit_i32(&self, +_v: i32) { self.add_unknown_to_log(); }
-        fn emit_i16(&self, +_v: i16) { self.add_unknown_to_log(); }
-        fn emit_i8(&self, +_v: i8)   { self.add_unknown_to_log(); }
+        fn emit_int(&self, _v: int) { self.add_unknown_to_log(); }
+        fn emit_i64(&self, _v: i64) { self.add_unknown_to_log(); }
+        fn emit_i32(&self, _v: i32) { self.add_unknown_to_log(); }
+        fn emit_i16(&self, _v: i16) { self.add_unknown_to_log(); }
+        fn emit_i8(&self, _v: i8)   { self.add_unknown_to_log(); }
 
-        fn emit_bool(&self, +_v: bool) { self.add_unknown_to_log(); }
+        fn emit_bool(&self, _v: bool) { self.add_unknown_to_log(); }
 
-        fn emit_f64(&self, +_v: f64) { self.add_unknown_to_log(); }
-        fn emit_f32(&self, +_v: f32) { self.add_unknown_to_log(); }
-        fn emit_float(&self, +_v: float) { self.add_unknown_to_log(); }
+        fn emit_f64(&self, _v: f64) { self.add_unknown_to_log(); }
+        fn emit_f32(&self, _v: f32) { self.add_unknown_to_log(); }
+        fn emit_float(&self, _v: float) { self.add_unknown_to_log(); }
 
-        fn emit_char(&self, +_v: char) { self.add_unknown_to_log(); }
-        fn emit_str(&self, +_v: &str) { self.add_unknown_to_log(); }
+        fn emit_char(&self, _v: char) { self.add_unknown_to_log(); }
+        fn emit_str(&self, _v: &str) { self.add_unknown_to_log(); }
 
         fn emit_enum(&self, name: &str, f: &fn()) {
             self.add_to_log(CallToEmitEnum(name.to_str())); f(); }
 
-        fn emit_enum_variant(&self, name: &str, +id: uint,
-                             +cnt: uint, f: &fn()) {
+        fn emit_enum_variant(&self, name: &str, id: uint,
+                             cnt: uint, f: &fn()) {
             self.add_to_log(CallToEmitEnumVariant (name.to_str(),id,cnt));
             f();
         }
 
-        fn emit_enum_variant_arg(&self, +idx: uint, f: &fn()) {
+        fn emit_enum_variant_arg(&self, idx: uint, f: &fn()) {
             self.add_to_log(CallToEmitEnumVariantArg (idx)); f();
         }
 
@@ -1261,10 +1261,10 @@ mod test {
             self.emit_enum_variant_arg(idx, f)
         }
 
-        fn emit_struct(&self, name: &str, +len: uint, f: &fn()) {
+        fn emit_struct(&self, name: &str, len: uint, f: &fn()) {
             self.add_to_log(CallToEmitStruct (name.to_str(),len)); f();
         }
-        fn emit_struct_field(&self, name: &str, +idx: uint, f: &fn()) {
+        fn emit_struct_field(&self, name: &str, idx: uint, f: &fn()) {
             self.add_to_log(CallToEmitField (name.to_str(),idx)); f();
         }
 
@@ -1294,10 +1294,10 @@ mod test {
             f();
         }
 
-        fn emit_seq(&self, +_len: uint, f: &fn()) {
+        fn emit_seq(&self, _len: uint, f: &fn()) {
             self.add_unknown_to_log(); f();
         }
-        fn emit_seq_elt(&self, +_idx: uint, f: &fn()) {
+        fn emit_seq_elt(&self, _idx: uint, f: &fn()) {
             self.add_unknown_to_log(); f();
         }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -238,7 +238,7 @@ pub trait ext_ctxt {
     fn ident_of(@mut self, st: ~str) -> ast::ident;
 }
 
-pub fn mk_ctxt(parse_sess: @mut parse::ParseSess, +cfg: ast::crate_cfg)
+pub fn mk_ctxt(parse_sess: @mut parse::ParseSess, cfg: ast::crate_cfg)
             -> @ext_ctxt {
     struct CtxtRepr {
         parse_sess: @mut parse::ParseSess,
@@ -439,7 +439,7 @@ pub enum MapChain<K,V> {
 impl <K: Eq + Hash + IterBytes ,V: Copy> MapChain<K,V>{
 
     // Constructor. I don't think we need a zero-arg one.
-    fn new(+init: ~HashMap<K,@V>) -> @mut MapChain<K,V> {
+    fn new(init: ~HashMap<K,@V>) -> @mut MapChain<K,V> {
         @mut BaseMapChain(init)
     }
 
@@ -509,7 +509,7 @@ impl <K: Eq + Hash + IterBytes ,V: Copy> MapChain<K,V>{
     }
 
     // insert the binding into the top-level map
-    fn insert (&mut self, +key: K, +ext: @V) -> bool {
+    fn insert (&mut self, key: K, ext: @V) -> bool {
         // can't abstract over get_map because of flow sensitivity...
         match *self {
             BaseMapChain (~ref mut map) => map.insert(key, ext),

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -27,7 +27,7 @@ pub struct Field {
 
 pub fn mk_expr(cx: @ext_ctxt,
                sp: codemap::span,
-               +expr: ast::expr_)
+               expr: ast::expr_)
             -> @ast::expr {
     @ast::expr {
         id: cx.next_id(),
@@ -63,12 +63,12 @@ pub fn mk_unary(cx: @ext_ctxt, sp: span, op: ast::unop, e: @ast::expr)
     cx.next_id(); // see ast_util::op_expr_callee_id
     mk_expr(cx, sp, ast::expr_unary(op, e))
 }
-pub fn mk_raw_path(sp: span, +idents: ~[ast::ident]) -> @ast::Path {
+pub fn mk_raw_path(sp: span, idents: ~[ast::ident]) -> @ast::Path {
     mk_raw_path_(sp, idents, ~[])
 }
 pub fn mk_raw_path_(sp: span,
-                    +idents: ~[ast::ident],
-                    +types: ~[@ast::Ty])
+                    idents: ~[ast::ident],
+                    types: ~[@ast::Ty])
                  -> @ast::Path {
     @ast::Path { span: sp,
                  global: false,
@@ -76,23 +76,23 @@ pub fn mk_raw_path_(sp: span,
                  rp: None,
                  types: types }
 }
-pub fn mk_raw_path_global(sp: span, +idents: ~[ast::ident]) -> @ast::Path {
+pub fn mk_raw_path_global(sp: span, idents: ~[ast::ident]) -> @ast::Path {
     mk_raw_path_global_(sp, idents, ~[])
 }
 pub fn mk_raw_path_global_(sp: span,
-                           +idents: ~[ast::ident],
-                           +types: ~[@ast::Ty]) -> @ast::Path {
+                           idents: ~[ast::ident],
+                           types: ~[@ast::Ty]) -> @ast::Path {
     @ast::Path { span: sp,
                  global: true,
                  idents: idents,
                  rp: None,
                  types: types }
 }
-pub fn mk_path(cx: @ext_ctxt, sp: span, +idents: ~[ast::ident])
+pub fn mk_path(cx: @ext_ctxt, sp: span, idents: ~[ast::ident])
             -> @ast::expr {
     mk_expr(cx, sp, ast::expr_path(mk_raw_path(sp, idents)))
 }
-pub fn mk_path_global(cx: @ext_ctxt, sp: span, +idents: ~[ast::ident])
+pub fn mk_path_global(cx: @ext_ctxt, sp: span, idents: ~[ast::ident])
                    -> @ast::expr {
     mk_expr(cx, sp, ast::expr_path(mk_raw_path_global(sp, idents)))
 }
@@ -100,7 +100,7 @@ pub fn mk_access_(cx: @ext_ctxt, sp: span, p: @ast::expr, m: ast::ident)
                -> @ast::expr {
     mk_expr(cx, sp, ast::expr_field(p, m, ~[]))
 }
-pub fn mk_access(cx: @ext_ctxt, sp: span, +p: ~[ast::ident], m: ast::ident)
+pub fn mk_access(cx: @ext_ctxt, sp: span, p: ~[ast::ident], m: ast::ident)
               -> @ast::expr {
     let pathexpr = mk_path(cx, sp, p);
     return mk_access_(cx, sp, pathexpr, m);
@@ -115,25 +115,25 @@ pub fn mk_method_call(cx: @ext_ctxt,
                       sp: span,
                       rcvr_expr: @ast::expr,
                       method_ident: ast::ident,
-                      +args: ~[@ast::expr]) -> @ast::expr {
+                      args: ~[@ast::expr]) -> @ast::expr {
     mk_expr(cx, sp, ast::expr_method_call(rcvr_expr, method_ident, ~[], args, ast::NoSugar))
 }
 pub fn mk_call_(cx: @ext_ctxt, sp: span, fn_expr: @ast::expr,
-                +args: ~[@ast::expr]) -> @ast::expr {
+                args: ~[@ast::expr]) -> @ast::expr {
     mk_expr(cx, sp, ast::expr_call(fn_expr, args, ast::NoSugar))
 }
-pub fn mk_call(cx: @ext_ctxt, sp: span, +fn_path: ~[ast::ident],
-               +args: ~[@ast::expr]) -> @ast::expr {
+pub fn mk_call(cx: @ext_ctxt, sp: span, fn_path: ~[ast::ident],
+               args: ~[@ast::expr]) -> @ast::expr {
     let pathexpr = mk_path(cx, sp, fn_path);
     return mk_call_(cx, sp, pathexpr, args);
 }
-pub fn mk_call_global(cx: @ext_ctxt, sp: span, +fn_path: ~[ast::ident],
-                      +args: ~[@ast::expr]) -> @ast::expr {
+pub fn mk_call_global(cx: @ext_ctxt, sp: span, fn_path: ~[ast::ident],
+                      args: ~[@ast::expr]) -> @ast::expr {
     let pathexpr = mk_path_global(cx, sp, fn_path);
     return mk_call_(cx, sp, pathexpr, args);
 }
 // e = expr, t = type
-pub fn mk_base_vec_e(cx: @ext_ctxt, sp: span, +exprs: ~[@ast::expr])
+pub fn mk_base_vec_e(cx: @ext_ctxt, sp: span, exprs: ~[@ast::expr])
                   -> @ast::expr {
     let vecexpr = ast::expr_vec(exprs, ast::m_imm);
     mk_expr(cx, sp, vecexpr)
@@ -143,20 +143,20 @@ pub fn mk_vstore_e(cx: @ext_ctxt, sp: span, expr: @ast::expr,
    @ast::expr {
     mk_expr(cx, sp, ast::expr_vstore(expr, vst))
 }
-pub fn mk_uniq_vec_e(cx: @ext_ctxt, sp: span, +exprs: ~[@ast::expr])
+pub fn mk_uniq_vec_e(cx: @ext_ctxt, sp: span, exprs: ~[@ast::expr])
                   -> @ast::expr {
     mk_vstore_e(cx, sp, mk_base_vec_e(cx, sp, exprs), ast::expr_vstore_uniq)
 }
-pub fn mk_slice_vec_e(cx: @ext_ctxt, sp: span, +exprs: ~[@ast::expr])
+pub fn mk_slice_vec_e(cx: @ext_ctxt, sp: span, exprs: ~[@ast::expr])
                    -> @ast::expr {
     mk_vstore_e(cx, sp, mk_base_vec_e(cx, sp, exprs),
                 ast::expr_vstore_slice)
 }
-pub fn mk_base_str(cx: @ext_ctxt, sp: span, +s: ~str) -> @ast::expr {
+pub fn mk_base_str(cx: @ext_ctxt, sp: span, s: ~str) -> @ast::expr {
     let lit = ast::lit_str(@s);
     return mk_lit(cx, sp, lit);
 }
-pub fn mk_uniq_str(cx: @ext_ctxt, sp: span, +s: ~str) -> @ast::expr {
+pub fn mk_uniq_str(cx: @ext_ctxt, sp: span, s: ~str) -> @ast::expr {
     mk_vstore_e(cx, sp, mk_base_str(cx, sp, s), ast::expr_vstore_uniq)
 }
 pub fn mk_field(sp: span, f: &Field) -> ast::field {
@@ -170,8 +170,8 @@ pub fn mk_fields(sp: span, fields: ~[Field]) -> ~[ast::field] {
 }
 pub fn mk_struct_e(cx: @ext_ctxt,
                    sp: span,
-                   +ctor_path: ~[ast::ident],
-                   +fields: ~[Field])
+                   ctor_path: ~[ast::ident],
+                   fields: ~[Field])
                 -> @ast::expr {
     mk_expr(cx, sp,
             ast::expr_struct(mk_raw_path(sp, ctor_path),
@@ -180,8 +180,8 @@ pub fn mk_struct_e(cx: @ext_ctxt,
 }
 pub fn mk_global_struct_e(cx: @ext_ctxt,
                           sp: span,
-                          +ctor_path: ~[ast::ident],
-                          +fields: ~[Field])
+                          ctor_path: ~[ast::ident],
+                          fields: ~[Field])
                        -> @ast::expr {
     mk_expr(cx, sp,
             ast::expr_struct(mk_raw_path_global(sp, ctor_path),
@@ -190,7 +190,7 @@ pub fn mk_global_struct_e(cx: @ext_ctxt,
 }
 pub fn mk_glob_use(cx: @ext_ctxt,
                    sp: span,
-                   +path: ~[ast::ident]) -> @ast::view_item {
+                   path: ~[ast::ident]) -> @ast::view_item {
     let glob = @codemap::spanned {
         node: ast::view_path_glob(mk_raw_path(sp, path), cx.next_id()),
         span: sp,
@@ -226,8 +226,8 @@ pub fn mk_local(cx: @ext_ctxt, sp: span, mutbl: bool,
     @codemap::spanned { node: ast::stmt_decl(@decl, cx.next_id()), span: sp }
 }
 pub fn mk_block(cx: @ext_ctxt, span: span,
-                +view_items: ~[@ast::view_item],
-                +stmts: ~[@ast::stmt],
+                view_items: ~[@ast::view_item],
+                stmts: ~[@ast::stmt],
                 expr: Option<@ast::expr>) -> @ast::expr {
     let blk = codemap::spanned {
         node: ast::blk_ {
@@ -243,7 +243,7 @@ pub fn mk_block(cx: @ext_ctxt, span: span,
 }
 pub fn mk_block_(cx: @ext_ctxt,
                  span: span,
-                 +stmts: ~[@ast::stmt])
+                 stmts: ~[@ast::stmt])
               -> ast::blk {
     codemap::spanned {
         node: ast::blk_ {
@@ -307,7 +307,7 @@ pub fn mk_copy(cx: @ext_ctxt, sp: span, e: @ast::expr) -> @ast::expr {
 pub fn mk_managed(cx: @ext_ctxt, sp: span, e: @ast::expr) -> @ast::expr {
     mk_expr(cx, sp, ast::expr_unary(ast::box(ast::m_imm), e))
 }
-pub fn mk_pat(cx: @ext_ctxt, span: span, +pat: ast::pat_) -> @ast::pat {
+pub fn mk_pat(cx: @ext_ctxt, span: span, pat: ast::pat_) -> @ast::pat {
     @ast::pat { id: cx.next_id(), node: pat, span: span }
 }
 pub fn mk_pat_wild(cx: @ext_ctxt, span: span) -> @ast::pat {
@@ -335,7 +335,7 @@ pub fn mk_pat_ident_with_binding_mode(cx: @ext_ctxt,
 pub fn mk_pat_enum(cx: @ext_ctxt,
                    span: span,
                    path: @ast::Path,
-                   +subpats: ~[@ast::pat])
+                   subpats: ~[@ast::pat])
                 -> @ast::pat {
     let pat = ast::pat_enum(path, Some(subpats));
     mk_pat(cx, span, pat)
@@ -343,7 +343,7 @@ pub fn mk_pat_enum(cx: @ext_ctxt,
 pub fn mk_pat_struct(cx: @ext_ctxt,
                      span: span,
                      path: @ast::Path,
-                     +field_pats: ~[ast::field_pat])
+                     field_pats: ~[ast::field_pat])
                   -> @ast::pat {
     let pat = ast::pat_struct(path, field_pats, false);
     mk_pat(cx, span, pat)
@@ -360,7 +360,7 @@ pub fn mk_stmt(cx: @ext_ctxt, span: span, expr: @ast::expr) -> @ast::stmt {
 }
 pub fn mk_ty_path(cx: @ext_ctxt,
                   span: span,
-                  +idents: ~[ ast::ident ])
+                  idents: ~[ ast::ident ])
                -> @ast::Ty {
     let ty = build::mk_raw_path(span, idents);
     let ty = ast::ty_path(ty, cx.next_id());
@@ -369,7 +369,7 @@ pub fn mk_ty_path(cx: @ext_ctxt,
 }
 pub fn mk_ty_path_global(cx: @ext_ctxt,
                          span: span,
-                         +idents: ~[ ast::ident ])
+                         idents: ~[ ast::ident ])
                       -> @ast::Ty {
     let ty = build::mk_raw_path_global(span, idents);
     let ty = ast::ty_path(ty, cx.next_id());
@@ -399,7 +399,7 @@ pub fn mk_ty_infer(cx: @ext_ctxt, span: span) -> @ast::Ty {
 }
 pub fn mk_trait_ref_global(cx: @ext_ctxt,
                            span: span,
-                           +idents: ~[ ast::ident ])
+                           idents: ~[ ast::ident ])
     -> @ast::trait_ref
 {
     mk_trait_ref_(cx, build::mk_raw_path_global(span, idents))
@@ -430,12 +430,12 @@ pub fn mk_arg(cx: @ext_ctxt,
         id: cx.next_id()
     }
 }
-pub fn mk_fn_decl(+inputs: ~[ast::arg], output: @ast::Ty) -> ast::fn_decl {
+pub fn mk_fn_decl(inputs: ~[ast::arg], output: @ast::Ty) -> ast::fn_decl {
     ast::fn_decl { inputs: inputs, output: output, cf: ast::return_val }
 }
 pub fn mk_trait_ty_param_bound_global(cx: @ext_ctxt,
                                       span: span,
-                                      +idents: ~[ast::ident])
+                                      idents: ~[ast::ident])
                                    -> ast::TyParamBound {
     ast::TraitTyParamBound(mk_trait_ref_global(cx, span, idents))
 }

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -91,7 +91,7 @@ fn create_derived_encodable_impl(
 fn create_encode_method(
     cx: @ext_ctxt,
     span: span,
-    +statements: ~[@stmt]
+    statements: ~[@stmt]
 ) -> @method {
     // Create the `e` parameter.
     let e_arg_type = build::mk_ty_rptr(

--- a/src/libsyntax/ext/deriving/iter_bytes.rs
+++ b/src/libsyntax/ext/deriving/iter_bytes.rs
@@ -64,7 +64,7 @@ fn create_derived_iter_bytes_impl(cx: @ext_ctxt,
 // signature of the `iter_bytes` method.
 fn create_iter_bytes_method(cx: @ext_ctxt,
                             span: span,
-                            +statements: ~[@stmt])
+                            statements: ~[@stmt])
                          -> @method {
     // Create the `lsb0` parameter.
     let bool_ident = cx.ident_of(~"bool");

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -142,7 +142,7 @@ pub fn expand_deriving(cx: @ext_ctxt,
     result
 }
 
-fn create_impl_item(cx: @ext_ctxt, span: span, +item: item_) -> @item {
+fn create_impl_item(cx: @ext_ctxt, span: span, item: item_) -> @item {
     let doc_attr = respan(span,
                           ast::lit_str(@~"Automatically derived."));
     let doc_attr = respan(span, ast::meta_name_value(@~"doc", doc_attr));

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -237,8 +237,8 @@ macro_rules! without_macro_scoping(
 
 // Support for item-position macro invocations, exactly the same
 // logic as for expression-position macro invocations.
-pub fn expand_item_mac(+extsbox: @mut SyntaxEnv,
-                       cx: @ext_ctxt, &&it: @ast::item,
+pub fn expand_item_mac(extsbox: @mut SyntaxEnv,
+                       cx: @ext_ctxt, it: @ast::item,
                        fld: @ast_fold)
                     -> Option<@ast::item> {
     let (pth, tts) = match it.node {

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -34,7 +34,7 @@ mod syntax {
     pub use parse;
 }
 
-pub fn path(+ids: ~[ident], span: span) -> @ast::Path {
+pub fn path(ids: ~[ident], span: span) -> @ast::Path {
     @ast::Path { span: span,
                  global: false,
                  idents: ids,
@@ -42,7 +42,7 @@ pub fn path(+ids: ~[ident], span: span) -> @ast::Path {
                  types: ~[] }
 }
 
-pub fn path_global(+ids: ~[ident], span: span) -> @ast::Path {
+pub fn path_global(ids: ~[ident], span: span) -> @ast::Path {
     @ast::Path { span: span,
                  global: true,
                  idents: ids,
@@ -52,7 +52,7 @@ pub fn path_global(+ids: ~[ident], span: span) -> @ast::Path {
 
 pub trait append_types {
     fn add_ty(&self, ty: @ast::Ty) -> @ast::Path;
-    fn add_tys(&self, +tys: ~[@ast::Ty]) -> @ast::Path;
+    fn add_tys(&self, tys: ~[@ast::Ty]) -> @ast::Path;
 }
 
 impl append_types for @ast::Path {
@@ -63,7 +63,7 @@ impl append_types for @ast::Path {
         }
     }
 
-    fn add_tys(&self, +tys: ~[@ast::Ty]) -> @ast::Path {
+    fn add_tys(&self, tys: ~[@ast::Ty]) -> @ast::Path {
         @ast::Path {
             types: vec::append(copy self.types, tys),
             .. copy **self
@@ -76,63 +76,63 @@ pub trait ext_ctxt_ast_builder {
         -> ast::TyParam;
     fn arg(&self, name: ident, ty: @ast::Ty) -> ast::arg;
     fn expr_block(&self, e: @ast::expr) -> ast::blk;
-    fn fn_decl(&self, +inputs: ~[ast::arg], output: @ast::Ty) -> ast::fn_decl;
-    fn item(&self, name: ident, span: span, +node: ast::item_) -> @ast::item;
+    fn fn_decl(&self, inputs: ~[ast::arg], output: @ast::Ty) -> ast::fn_decl;
+    fn item(&self, name: ident, span: span, node: ast::item_) -> @ast::item;
     fn item_fn_poly(&self,
                     ame: ident,
-                    +inputs: ~[ast::arg],
+                    inputs: ~[ast::arg],
                     output: @ast::Ty,
-                    +generics: Generics,
-                    +body: ast::blk) -> @ast::item;
+                    generics: Generics,
+                    body: ast::blk) -> @ast::item;
     fn item_fn(&self,
                name: ident,
-               +inputs: ~[ast::arg],
+               inputs: ~[ast::arg],
                output: @ast::Ty,
-               +body: ast::blk) -> @ast::item;
+               body: ast::blk) -> @ast::item;
     fn item_enum_poly(&self,
                       name: ident,
                       span: span,
-                      +enum_definition: ast::enum_def,
-                      +generics: Generics) -> @ast::item;
+                      enum_definition: ast::enum_def,
+                      generics: Generics) -> @ast::item;
     fn item_enum(&self,
                  name: ident,
                  span: span,
-                 +enum_definition: ast::enum_def) -> @ast::item;
+                 enum_definition: ast::enum_def) -> @ast::item;
     fn item_struct_poly(&self,
                         name: ident,
                         span: span,
-                        +struct_def: ast::struct_def,
-                        +generics: Generics) -> @ast::item;
+                        struct_def: ast::struct_def,
+                        generics: Generics) -> @ast::item;
     fn item_struct(&self,
                    name: ident,
                    span: span,
-                   +struct_def: ast::struct_def) -> @ast::item;
+                   struct_def: ast::struct_def) -> @ast::item;
     fn struct_expr(&self,
                    path: @ast::Path,
-                   +fields: ~[ast::field]) -> @ast::expr;
+                   fields: ~[ast::field]) -> @ast::expr;
     fn variant(&self,
                name: ident,
                span: span,
-               +tys: ~[@ast::Ty]) -> ast::variant;
+               tys: ~[@ast::Ty]) -> ast::variant;
     fn item_mod(&self,
                 name: ident,
                 span: span,
-                +items: ~[@ast::item]) -> @ast::item;
+                items: ~[@ast::item]) -> @ast::item;
     fn ty_path_ast_builder(&self, path: @ast::Path) -> @ast::Ty;
     fn item_ty_poly(&self,
                     name: ident,
                     span: span,
                     ty: @ast::Ty,
-                    +generics: Generics) -> @ast::item;
+                    generics: Generics) -> @ast::item;
     fn item_ty(&self, name: ident, span: span, ty: @ast::Ty) -> @ast::item;
     fn ty_vars(&self, ty_params: &OptVec<ast::TyParam>) -> ~[@ast::Ty];
     fn ty_vars_global(&self, ty_params: &OptVec<ast::TyParam>) -> ~[@ast::Ty];
     fn ty_field_imm(&self, name: ident, ty: @ast::Ty) -> ast::ty_field;
     fn field_imm(&self, name: ident, e: @ast::expr) -> ast::field;
-    fn block(&self, +stmts: ~[@ast::stmt], e: @ast::expr) -> ast::blk;
+    fn block(&self, stmts: ~[@ast::stmt], e: @ast::expr) -> ast::blk;
     fn stmt_let(&self, ident: ident, e: @ast::expr) -> @ast::stmt;
     fn stmt_expr(&self, e: @ast::expr) -> @ast::stmt;
-    fn block_expr(&self, +b: ast::blk) -> @ast::expr;
+    fn block_expr(&self, b: ast::blk) -> @ast::expr;
     fn ty_option(&self, ty: @ast::Ty) -> @ast::Ty;
     fn ty_infer(&self) -> @ast::Ty;
     fn ty_nil_ast_builder(&self) -> @ast::Ty;
@@ -148,7 +148,7 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
         ], dummy_sp()).add_ty(ty))
     }
 
-    fn block_expr(&self, +b: ast::blk) -> @ast::expr {
+    fn block_expr(&self, b: ast::blk) -> @ast::expr {
         @expr {
             id: self.next_id(),
             callee_id: self.next_id(),
@@ -215,7 +215,7 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
         }
     }
 
-    fn block(&self, +stmts: ~[@ast::stmt], e: @ast::expr) -> ast::blk {
+    fn block(&self, stmts: ~[@ast::stmt], e: @ast::expr) -> ast::blk {
         let blk = ast::blk_ {
             view_items: ~[],
             stmts: stmts,
@@ -231,7 +231,7 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
         self.block(~[], e)
     }
 
-    fn fn_decl(&self, +inputs: ~[ast::arg],
+    fn fn_decl(&self, inputs: ~[ast::arg],
                output: @ast::Ty) -> ast::fn_decl {
         ast::fn_decl {
             inputs: inputs,
@@ -241,7 +241,7 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
     }
 
     fn item(&self, name: ident, span: span,
-            +node: ast::item_) -> @ast::item {
+            node: ast::item_) -> @ast::item {
 
         // XXX: Would be nice if our generated code didn't violate
         // Rust coding conventions
@@ -265,10 +265,10 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
     }
 
     fn item_fn_poly(&self, name: ident,
-                    +inputs: ~[ast::arg],
+                    inputs: ~[ast::arg],
                     output: @ast::Ty,
-                    +generics: Generics,
-                    +body: ast::blk) -> @ast::item {
+                    generics: Generics,
+                    body: ast::blk) -> @ast::item {
         self.item(name,
                   dummy_sp(),
                   ast::item_fn(self.fn_decl(inputs, output),
@@ -280,9 +280,9 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
 
     fn item_fn(&self,
                name: ident,
-               +inputs: ~[ast::arg],
+               inputs: ~[ast::arg],
                output: @ast::Ty,
-               +body: ast::blk
+               body: ast::blk
     ) -> @ast::item {
         self.item_fn_poly(
             name,
@@ -294,13 +294,13 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
     }
 
     fn item_enum_poly(&self, name: ident, span: span,
-                      +enum_definition: ast::enum_def,
-                      +generics: Generics) -> @ast::item {
+                      enum_definition: ast::enum_def,
+                      generics: Generics) -> @ast::item {
         self.item(name, span, ast::item_enum(enum_definition, generics))
     }
 
     fn item_enum(&self, name: ident, span: span,
-                 +enum_definition: ast::enum_def) -> @ast::item {
+                 enum_definition: ast::enum_def) -> @ast::item {
         self.item_enum_poly(name, span, enum_definition,
                             ast_util::empty_generics())
     }
@@ -308,7 +308,7 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
     fn item_struct(
         &self, name: ident,
         span: span,
-        +struct_def: ast::struct_def
+        struct_def: ast::struct_def
     ) -> @ast::item {
         self.item_struct_poly(
             name,
@@ -322,14 +322,14 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
         &self,
         name: ident,
         span: span,
-        +struct_def: ast::struct_def,
-        +generics: Generics
+        struct_def: ast::struct_def,
+        generics: Generics
     ) -> @ast::item {
         self.item(name, span, ast::item_struct(@struct_def, generics))
     }
 
     fn struct_expr(&self, path: @ast::Path,
-                   +fields: ~[ast::field]) -> @ast::expr {
+                   fields: ~[ast::field]) -> @ast::expr {
         @ast::expr {
             id: self.next_id(),
             callee_id: self.next_id(),
@@ -339,7 +339,7 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
     }
 
     fn variant(&self, name: ident, span: span,
-               +tys: ~[@ast::Ty]) -> ast::variant {
+               tys: ~[@ast::Ty]) -> ast::variant {
         let args = do tys.map |ty| {
             ast::variant_arg { ty: *ty, id: self.next_id() }
         };
@@ -358,7 +358,7 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
     }
 
     fn item_mod(&self, name: ident, span: span,
-                +items: ~[@ast::item]) -> @ast::item {
+                items: ~[@ast::item]) -> @ast::item {
 
         // XXX: Total hack: import `core::kinds::Owned` to work around a
         // parser bug whereby `fn f<T:::kinds::Owned>` doesn't parse.
@@ -425,7 +425,7 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
     }
 
     fn item_ty_poly(&self, name: ident, span: span, ty: @ast::Ty,
-                    +generics: Generics) -> @ast::item {
+                    generics: Generics) -> @ast::item {
         self.item(name, span, ast::item_ty(ty, generics))
     }
 

--- a/src/libsyntax/ext/pipes/parse_proto.rs
+++ b/src/libsyntax/ext/pipes/parse_proto.rs
@@ -19,13 +19,13 @@ use parse::token;
 use core::prelude::*;
 
 pub trait proto_parser {
-    fn parse_proto(&self, +id: ~str) -> protocol;
+    fn parse_proto(&self, id: ~str) -> protocol;
     fn parse_state(&self, proto: protocol);
     fn parse_message(&self, state: state);
 }
 
 impl proto_parser for parser::Parser {
-    fn parse_proto(&self, +id: ~str) -> protocol {
+    fn parse_proto(&self, id: ~str) -> protocol {
         let proto = protocol(id, *self.span);
 
         self.parse_seq_to_before_end(

--- a/src/libsyntax/ext/pipes/proto.rs
+++ b/src/libsyntax/ext/pipes/proto.rs
@@ -81,8 +81,8 @@ pub struct state_ {
 }
 
 pub impl state_ {
-    fn add_message(@self, +name: ~str, span: span,
-                   +data: ~[@ast::Ty], +next: Option<next_state>) {
+    fn add_message(@self, name: ~str, span: span,
+                   data: ~[@ast::Ty], next: Option<next_state>) {
         self.messages.push(message(name, span, data, self,
                                    next));
     }
@@ -119,11 +119,11 @@ pub impl state_ {
 
 pub type protocol = @mut protocol_;
 
-pub fn protocol(+name: ~str, +span: span) -> protocol {
+pub fn protocol(name: ~str, span: span) -> protocol {
     @mut protocol_(name, span)
 }
 
-pub fn protocol_(+name: ~str, span: span) -> protocol_ {
+pub fn protocol_(name: ~str, span: span) -> protocol_ {
     protocol_ {
         name: name,
         span: span,
@@ -177,10 +177,10 @@ pub impl protocol_ {
 
 pub impl protocol_ {
     fn add_state_poly(@mut self,
-                      +name: ~str,
+                      name: ~str,
                       ident: ast::ident,
                       dir: direction,
-                      +generics: ast::Generics)
+                      generics: ast::Generics)
                    -> state {
         let messages = @mut ~[];
         let states = &*self.states;

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -419,7 +419,7 @@ fn ids_ext(cx: @ext_ctxt, strs: ~[~str]) -> ~[ast::ident] {
     strs.map(|str| cx.parse_sess().interner.intern(@copy *str))
 }
 
-fn id_ext(cx: @ext_ctxt, +str: ~str) -> ast::ident {
+fn id_ext(cx: @ext_ctxt, str: ~str) -> ast::ident {
     cx.parse_sess().interner.intern(@str)
 }
 
@@ -734,8 +734,8 @@ fn expand_tts(cx: @ext_ctxt,
 
 fn expand_parse_call(cx: @ext_ctxt,
                      sp: span,
-                     +parse_method: ~str,
-                     +arg_exprs: ~[@ast::expr],
+                     parse_method: ~str,
+                     arg_exprs: ~[@ast::expr],
                      tts: &[ast::token_tree]) -> @ast::expr {
     let tts_expr = expand_tts(cx, sp, tts);
 

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -98,9 +98,9 @@ pub enum matcher_pos_up { /* to break a circularity */
     matcher_pos_up(Option<~MatcherPos>)
 }
 
-pub fn is_some(&&mpu: matcher_pos_up) -> bool {
-    match &mpu {
-      &matcher_pos_up(None) => false,
+pub fn is_some(mpu: &matcher_pos_up) -> bool {
+    match *mpu {
+      matcher_pos_up(None) => false,
       _ => true
     }
 }
@@ -115,9 +115,9 @@ pub struct MatcherPos {
     sp_lo: BytePos,
 }
 
-pub fn copy_up(&& mpu: matcher_pos_up) -> ~MatcherPos {
-    match &mpu {
-      &matcher_pos_up(Some(ref mp)) => copy (*mp),
+pub fn copy_up(mpu: &matcher_pos_up) -> ~MatcherPos {
+    match *mpu {
+      matcher_pos_up(Some(ref mp)) => copy (*mp),
       _ => fail!()
     }
 }
@@ -132,7 +132,7 @@ pub fn count_names(ms: &[matcher]) -> uint {
 }
 
 #[allow(non_implicitly_copyable_typarams)]
-pub fn initial_matcher_pos(+ms: ~[matcher], +sep: Option<Token>, lo: BytePos)
+pub fn initial_matcher_pos(ms: ~[matcher], sep: Option<Token>, lo: BytePos)
                         -> ~MatcherPos {
     let mut match_idx_hi = 0u;
     for ms.each |elt| {
@@ -220,7 +220,7 @@ pub enum parse_result {
 
 pub fn parse_or_else(
     sess: @mut ParseSess,
-    +cfg: ast::crate_cfg,
+    cfg: ast::crate_cfg,
     rdr: @reader,
     ms: ~[matcher]
 ) -> HashMap<ident, @named_match> {
@@ -257,7 +257,7 @@ pub fn parse(
             /* at end of sequence */
             if idx >= len {
                 // can't move out of `match`es, so:
-                if is_some(ei.up) {
+                if is_some(&ei.up) {
                     // hack: a matcher sequence is repeating iff it has a
                     // parent (the top level is just a container)
 
@@ -267,7 +267,7 @@ pub fn parse(
                     if idx == len {
                         // pop from the matcher position
 
-                        let mut new_pos = copy_up(ei.up);
+                        let mut new_pos = copy_up(&ei.up);
 
                         // update matches (the MBE "parse tree") by appending
                         // each tree as a subtree.
@@ -394,7 +394,7 @@ pub fn parse(
                 match ei.elts[ei.idx].node {
                   match_nonterminal(_, name, idx) => {
                     ei.matches[idx].push(@matched_nonterminal(
-                        parse_nt(rust_parser, *sess.interner.get(name))));
+                        parse_nt(&rust_parser, *sess.interner.get(name))));
                     ei.idx += 1u;
                   }
                   _ => fail!()
@@ -411,7 +411,7 @@ pub fn parse(
     }
 }
 
-pub fn parse_nt(p: Parser, name: ~str) -> nonterminal {
+pub fn parse_nt(p: &Parser, name: ~str) -> nonterminal {
     match name {
       ~"item" => match p.parse_item(~[]) {
         Some(i) => token::nt_item(i),

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -53,7 +53,7 @@ pub struct TtReader {
 pub fn new_tt_reader(sp_diag: @span_handler,
                      itr: @ident_interner,
                      interp: Option<HashMap<ident,@named_match>>,
-                     +src: ~[ast::token_tree])
+                     src: ~[ast::token_tree])
                   -> @mut TtReader {
     let r = @mut TtReader {
         sp_diag: sp_diag,
@@ -109,7 +109,7 @@ pub fn dup_tt_reader(r: @mut TtReader) -> @mut TtReader {
 fn lookup_cur_matched_by_matched(r: &mut TtReader,
                                       start: @named_match)
                                    -> @named_match {
-    fn red(+ad: @named_match, idx: &uint) -> @named_match {
+    fn red(ad: @named_match, idx: &uint) -> @named_match {
         match *ad {
           matched_nonterminal(_) => {
             // end of the line; duplicate henceforth

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -27,11 +27,11 @@ pub enum OptVec<T> {
     Vec(~[T])
 }
 
-pub fn with<T>(+t: T) -> OptVec<T> {
+pub fn with<T>(t: T) -> OptVec<T> {
     Vec(~[t])
 }
 
-pub fn from<T>(+t: ~[T]) -> OptVec<T> {
+pub fn from<T>(t: ~[T]) -> OptVec<T> {
     if t.len() == 0 {
         Empty
     } else {
@@ -40,7 +40,7 @@ pub fn from<T>(+t: ~[T]) -> OptVec<T> {
 }
 
 impl<T> OptVec<T> {
-    fn push(&mut self, +t: T) {
+    fn push(&mut self, t: T) {
         match *self {
             Vec(ref mut v) => {
                 v.push(t);
@@ -91,7 +91,7 @@ impl<T> OptVec<T> {
     }
 }
 
-pub fn take_vec<T>(+v: OptVec<T>) -> ~[T] {
+pub fn take_vec<T>(v: OptVec<T>) -> ~[T] {
     match v {
         Empty => ~[],
         Vec(v) => v
@@ -99,7 +99,7 @@ pub fn take_vec<T>(+v: OptVec<T>) -> ~[T] {
 }
 
 impl<T:Copy> OptVec<T> {
-    fn prepend(&self, +t: T) -> OptVec<T> {
+    fn prepend(&self, t: T) -> OptVec<T> {
         let mut v0 = ~[t];
         match *self {
             Empty => {}
@@ -157,7 +157,7 @@ impl<A> BaseIter<A> for OptVec<A> {
 
 impl<A> iter::ExtendedIter<A> for OptVec<A> {
     #[inline(always)]
-    fn eachi(&self, blk: &fn(+v: uint, v: &A) -> bool) {
+    fn eachi(&self, blk: &fn(v: uint, v: &A) -> bool) {
         iter::eachi(self, blk)
     }
     #[inline(always)]
@@ -169,7 +169,7 @@ impl<A> iter::ExtendedIter<A> for OptVec<A> {
         iter::any(self, blk)
     }
     #[inline(always)]
-    fn foldl<B>(&self, +b0: B, blk: &fn(&B, &A) -> B) -> B {
+    fn foldl<B>(&self, b0: B, blk: &fn(&B, &A) -> B) -> B {
         iter::foldl(self, b0, blk)
     }
     #[inline(always)]

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -40,7 +40,7 @@ pub fn expr_is_simple_block(e: @ast::expr) -> bool {
     }
 }
 
-pub fn stmt_ends_with_semi(stmt: ast::stmt) -> bool {
+pub fn stmt_ends_with_semi(stmt: &ast::stmt) -> bool {
     return match stmt.node {
         ast::stmt_decl(d, _) => {
             match d.node {

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -319,7 +319,7 @@ pub struct lit {
 
 pub fn gather_comments_and_literals(span_diagnostic:
                                     @diagnostic::span_handler,
-                                    +path: ~str,
+                                    path: ~str,
                                     srdr: @io::Reader)
                                  -> (~[cmnt], ~[lit]) {
     let src = @str::from_bytes(srdr.read_whole_stream());

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -28,13 +28,13 @@ pub struct SeqSep {
     trailing_sep_allowed: bool
 }
 
-pub fn seq_sep_trailing_disallowed(+t: token::Token) -> SeqSep {
+pub fn seq_sep_trailing_disallowed(t: token::Token) -> SeqSep {
     SeqSep {
         sep: Some(t),
         trailing_sep_allowed: false,
     }
 }
-pub fn seq_sep_trailing_allowed(+t: token::Token) -> SeqSep {
+pub fn seq_sep_trailing_allowed(t: token::Token) -> SeqSep {
     SeqSep {
         sep: Some(t),
         trailing_sep_allowed: true,

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -126,7 +126,7 @@ pub fn parse_crate_from_source_str(
 pub fn parse_expr_from_source_str(
     name: ~str,
     source: @~str,
-    +cfg: ast::crate_cfg,
+    cfg: ast::crate_cfg,
     sess: @mut ParseSess
 ) -> @ast::expr {
     let p = new_parser_from_source_str(
@@ -142,8 +142,8 @@ pub fn parse_expr_from_source_str(
 pub fn parse_item_from_source_str(
     name: ~str,
     source: @~str,
-    +cfg: ast::crate_cfg,
-    +attrs: ~[ast::attribute],
+    cfg: ast::crate_cfg,
+    attrs: ~[ast::attribute],
     sess: @mut ParseSess
 ) -> Option<@ast::item> {
     let p = new_parser_from_source_str(
@@ -159,7 +159,7 @@ pub fn parse_item_from_source_str(
 pub fn parse_meta_from_source_str(
     name: ~str,
     source: @~str,
-    +cfg: ast::crate_cfg,
+    cfg: ast::crate_cfg,
     sess: @mut ParseSess
 ) -> @ast::meta_item {
     let p = new_parser_from_source_str(
@@ -175,8 +175,8 @@ pub fn parse_meta_from_source_str(
 pub fn parse_stmt_from_source_str(
     name: ~str,
     source: @~str,
-    +cfg: ast::crate_cfg,
-    +attrs: ~[ast::attribute],
+    cfg: ast::crate_cfg,
+    attrs: ~[ast::attribute],
     sess: @mut ParseSess
 ) -> @ast::stmt {
     let p = new_parser_from_source_str(
@@ -192,7 +192,7 @@ pub fn parse_stmt_from_source_str(
 pub fn parse_tts_from_source_str(
     name: ~str,
     source: @~str,
-    +cfg: ast::crate_cfg,
+    cfg: ast::crate_cfg,
     sess: @mut ParseSess
 ) -> ~[ast::token_tree] {
     let p = new_parser_from_source_str(
@@ -207,20 +207,20 @@ pub fn parse_tts_from_source_str(
 }
 
 pub fn parse_from_source_str<T>(
-    f: &fn (Parser) -> T,
+    f: &fn(&Parser) -> T,
     name: ~str, ss: codemap::FileSubstr,
     source: @~str,
-    +cfg: ast::crate_cfg,
+    cfg: ast::crate_cfg,
     sess: @mut ParseSess
 ) -> T {
     let p = new_parser_from_source_str(
         sess,
         cfg,
-        /*bad*/ copy name,
-        /*bad*/ copy ss,
+        name,
+        ss,
         source
     );
-    let r = f(p);
+    let r = f(&p);
     if !p.reader.is_eof() {
         p.reader.fatal(~"expected end-of-string");
     }
@@ -236,9 +236,9 @@ pub fn next_node_id(sess: @mut ParseSess) -> node_id {
 }
 
 pub fn new_parser_from_source_str(sess: @mut ParseSess,
-                                  +cfg: ast::crate_cfg,
-                                  +name: ~str,
-                                  +ss: codemap::FileSubstr,
+                                  cfg: ast::crate_cfg,
+                                  name: ~str,
+                                  ss: codemap::FileSubstr,
                                   source: @~str)
                                -> Parser {
     let filemap = sess.cm.new_filemap_w_substr(name, ss, source);
@@ -254,7 +254,7 @@ pub fn new_parser_from_source_str(sess: @mut ParseSess,
 /// that draws from that string
 pub fn new_parser_result_from_file(
     sess: @mut ParseSess,
-    +cfg: ast::crate_cfg,
+    cfg: ast::crate_cfg,
     path: &Path
 ) -> Result<Parser, ~str> {
     match io::read_whole_file_str(path) {
@@ -274,7 +274,7 @@ pub fn new_parser_result_from_file(
 /// if the file doesn't exist
 pub fn new_parser_from_file(
     sess: @mut ParseSess,
-    +cfg: ast::crate_cfg,
+    cfg: ast::crate_cfg,
     path: &Path
 ) -> Parser {
     match new_parser_result_from_file(sess, cfg, path) {
@@ -289,7 +289,7 @@ pub fn new_parser_from_file(
 /// error messages correctly when the file does not exist.
 pub fn new_sub_parser_from_file(
     sess: @mut ParseSess,
-    +cfg: ast::crate_cfg,
+    cfg: ast::crate_cfg,
     path: &Path,
     sp: span
 ) -> Parser {
@@ -303,8 +303,8 @@ pub fn new_sub_parser_from_file(
 
 pub fn new_parser_from_tts(
     sess: @mut ParseSess,
-    +cfg: ast::crate_cfg,
-    +tts: ~[ast::token_tree]
+    cfg: ast::crate_cfg,
+    tts: ~[ast::token_tree]
 ) -> Parser {
     let trdr = lexer::new_tt_reader(
         copy sess.span_diagnostic,
@@ -316,7 +316,7 @@ pub fn new_parser_from_tts(
 }
 
 // abort if necessary
-pub fn maybe_aborted<T>(+result : T, p: Parser) -> T {
+pub fn maybe_aborted<T>(result : T, p: Parser) -> T {
     p.abort_if_errors();
     result
 }

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -66,7 +66,7 @@ pub enum ObsoleteSyntax {
 
 impl to_bytes::IterBytes for ObsoleteSyntax {
     #[inline(always)]
-    fn iter_bytes(&self, +lsb0: bool, f: to_bytes::Cb) {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as uint).iter_bytes(lsb0, f);
     }
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -201,7 +201,7 @@ macro_rules! maybe_whole (
 )
 
 
-fn maybe_append(+lhs: ~[attribute], rhs: Option<~[attribute]>)
+fn maybe_append(lhs: ~[attribute], rhs: Option<~[attribute]>)
              -> ~[attribute] {
     match rhs {
         None => lhs,
@@ -220,8 +220,8 @@ struct ParsedItemsAndViewItems {
 /* ident is handled by common.rs */
 
 pub fn Parser(sess: @mut ParseSess,
-              +cfg: ast::crate_cfg,
-              +rdr: @reader)
+              cfg: ast::crate_cfg,
+              rdr: @reader)
            -> Parser {
     let tok0 = copy rdr.next_token();
     let interner = rdr.interner();
@@ -299,7 +299,7 @@ pub impl Parser {
         *self.tokens_consumed += 1u;
     }
     // EFFECT: replace the current token and span with the given one
-    fn replace_token(&self, +next: token::Token, +lo: BytePos, +hi: BytePos) {
+    fn replace_token(&self, next: token::Token, lo: BytePos, hi: BytePos) {
         *self.token = next;
         *self.span = mk_sp(lo, hi);
     }
@@ -713,7 +713,7 @@ pub impl Parser {
     fn parse_box_or_uniq_pointee(
         &self,
         sigil: ast::Sigil,
-        ctor: &fn(+v: mt) -> ty_) -> ty_
+        ctor: &fn(v: mt) -> ty_) -> ty_
     {
         // @'foo fn() or @foo/fn() or @fn() are parsed directly as fn types:
         match *self.token {
@@ -1112,7 +1112,7 @@ pub impl Parser {
         spanned(lo, e.span.hi, ast::field_ { mutbl: m, ident: i, expr: e })
     }
 
-    fn mk_expr(&self, +lo: BytePos, +hi: BytePos, +node: expr_) -> @expr {
+    fn mk_expr(&self, lo: BytePos, hi: BytePos, node: expr_) -> @expr {
         @expr {
             id: self.get_id(),
             callee_id: self.get_id(),
@@ -1121,7 +1121,7 @@ pub impl Parser {
         }
     }
 
-    fn mk_mac_expr(&self, +lo: BytePos, +hi: BytePos, +m: mac_) -> @expr {
+    fn mk_mac_expr(&self, lo: BytePos, hi: BytePos, m: mac_) -> @expr {
         @expr {
             id: self.get_id(),
             callee_id: self.get_id(),
@@ -1897,7 +1897,7 @@ pub impl Parser {
 
     fn parse_sugary_call_expr(&self, keyword: ~str,
                               sugar: CallSugar,
-                              ctor: &fn(+v: @expr) -> expr_) -> @expr {
+                              ctor: &fn(v: @expr) -> expr_) -> @expr {
         let lo = self.last_span;
         // Parse the callee `foo` in
         //    for foo || {
@@ -2472,7 +2472,7 @@ pub impl Parser {
         })
     }
 
-    fn parse_stmt(&self, +first_item_attrs: ~[attribute]) -> @stmt {
+    fn parse_stmt(&self, first_item_attrs: ~[attribute]) -> @stmt {
         maybe_whole!(self, nt_stmt);
 
         fn check_expected_item(p: &Parser, current_attrs: &[attribute]) {
@@ -2612,7 +2612,7 @@ pub impl Parser {
 
     // parse the rest of a block expression or function body
     fn parse_block_tail_(&self, lo: BytePos, s: blk_check_mode,
-                         +first_item_attrs: ~[attribute]) -> blk {
+                         first_item_attrs: ~[attribute]) -> blk {
         let mut stmts = ~[];
         let mut expr = None;
 
@@ -2658,7 +2658,7 @@ pub impl Parser {
                                     expr = Some(e);
                                 }
                                 copy t => {
-                                    if classify::stmt_ends_with_semi(*stmt) {
+                                    if classify::stmt_ends_with_semi(stmt) {
                                         self.fatal(
                                             fmt!(
                                                 "expected `;` or `}` after \
@@ -2696,7 +2696,7 @@ pub impl Parser {
                         _ => { // All other kinds of statements:
                             stmts.push(stmt);
 
-                            if classify::stmt_ends_with_semi(*stmt) {
+                            if classify::stmt_ends_with_semi(stmt) {
                                 self.expect(&token::SEMI);
                             }
                         }
@@ -2891,7 +2891,7 @@ pub impl Parser {
         &fn(&Parser) -> arg_or_capture_item
     ) -> (self_ty, fn_decl) {
         fn maybe_parse_self_ty(
-            cnstr: &fn(+v: mutability) -> ast::self_ty_,
+            cnstr: &fn(v: mutability) -> ast::self_ty_,
             p: &Parser
         ) -> ast::self_ty_ {
             // We need to make sure it isn't a mode or a type
@@ -3064,9 +3064,9 @@ pub impl Parser {
         (id, generics)
     }
 
-    fn mk_item(&self, +lo: BytePos, +hi: BytePos, +ident: ident,
-               +node: item_, vis: visibility,
-               +attrs: ~[attribute]) -> @item {
+    fn mk_item(&self, lo: BytePos, hi: BytePos, ident: ident,
+               node: item_, vis: visibility,
+               attrs: ~[attribute]) -> @item {
         @ast::item { ident: ident,
                      attrs: attrs,
                      id: self.get_id(),
@@ -3305,7 +3305,7 @@ pub impl Parser {
          None)
     }
 
-    fn token_is_pound_or_doc_comment(&self, ++tok: token::Token) -> bool {
+    fn token_is_pound_or_doc_comment(&self, tok: token::Token) -> bool {
         match tok {
             token::POUND | token::DOC_COMMENT(_) => true,
             _ => false
@@ -3340,7 +3340,7 @@ pub impl Parser {
         a_var
     }
 
-    fn parse_dtor(&self, +attrs: ~[attribute]) -> class_contents {
+    fn parse_dtor(&self, attrs: ~[attribute]) -> class_contents {
         let lo = self.last_span.lo;
         let body = self.parse_block();
         dtor_decl(body, attrs, mk_sp(lo, self.last_span.hi))
@@ -3392,7 +3392,7 @@ pub impl Parser {
     // given a termination token and a vector of already-parsed
     // attributes (of length 0 or 1), parse all of the items in a module
     fn parse_mod_items(&self, term: token::Token,
-                       +first_item_attrs: ~[attribute]) -> _mod {
+                       first_item_attrs: ~[attribute]) -> _mod {
         // parse all of the items up to closing or an attribute.
         // view items are legal here.
         let ParsedItemsAndViewItems {
@@ -3553,7 +3553,7 @@ pub impl Parser {
                                     outer_attrs, id_sp)
     }
 
-    fn eval_src_mod_from_path(&self, prefix: Path, +path: Path,
+    fn eval_src_mod_from_path(&self, prefix: Path, path: Path,
                               outer_attrs: ~[ast::attribute],
                               id_sp: span
                              ) -> (ast::item_, ~[ast::attribute]) {
@@ -3576,7 +3576,7 @@ pub impl Parser {
         let m0 = p0.parse_mod_items(token::EOF, first_item_outer_attrs);
         return (ast::item_mod(m0), mod_attrs);
 
-        fn cdir_path_opt(+default: ~str, attrs: ~[ast::attribute]) -> ~str {
+        fn cdir_path_opt(default: ~str, attrs: ~[ast::attribute]) -> ~str {
             match ::attr::first_attr_value_str_by_name(attrs, ~"path") {
                 Some(d) => copy *d,
                 None => default
@@ -3584,7 +3584,7 @@ pub impl Parser {
         }
     }
 
-    fn parse_item_foreign_fn(&self,  +attrs: ~[attribute]) -> @foreign_item {
+    fn parse_item_foreign_fn(&self,  attrs: ~[attribute]) -> @foreign_item {
         let lo = self.span.lo;
         let vis = self.parse_visibility();
         let purity = self.parse_fn_purity();
@@ -3601,7 +3601,7 @@ pub impl Parser {
     }
 
     fn parse_item_foreign_const(&self, vis: ast::visibility,
-                                +attrs: ~[attribute]) -> @foreign_item {
+                                attrs: ~[attribute]) -> @foreign_item {
         let lo = self.span.lo;
 
         // XXX: Obsolete; remove after snap.
@@ -3638,7 +3638,7 @@ pub impl Parser {
         else { self.unexpected(); }
     }
 
-    fn parse_foreign_item(&self, +attrs: ~[attribute]) -> @foreign_item {
+    fn parse_foreign_item(&self, attrs: ~[attribute]) -> @foreign_item {
         let vis = self.parse_visibility();
         if self.is_keyword(&~"const") || self.is_keyword(&~"static") {
             self.parse_item_foreign_const(vis, attrs)
@@ -3648,8 +3648,8 @@ pub impl Parser {
     }
 
     fn parse_foreign_mod_items(&self, sort: ast::foreign_mod_sort,
-                               +abis: AbiSet,
-                               +first_item_attrs: ~[attribute])
+                               abis: AbiSet,
+                               first_item_attrs: ~[attribute])
                             -> foreign_mod {
         // Shouldn't be any view items since we've already parsed an item attr
         let ParsedItemsAndViewItems {
@@ -3987,7 +3987,7 @@ pub impl Parser {
     // flags; on failure, return iovi_none.
     fn parse_item_or_view_item(
         &self,
-        +attrs: ~[attribute],
+        attrs: ~[attribute],
         items_allowed: bool,
         foreign_items_allowed: bool,
         macros_allowed: bool
@@ -4198,7 +4198,7 @@ pub impl Parser {
         return iovi_none;
     }
 
-    fn parse_item(&self, +attrs: ~[attribute]) -> Option<@ast::item> {
+    fn parse_item(&self, attrs: ~[attribute]) -> Option<@ast::item> {
         match self.parse_item_or_view_item(attrs, true, false, true) {
             iovi_none =>
                 None,
@@ -4337,7 +4337,7 @@ pub impl Parser {
     // parse a view item.
     fn parse_view_item(
         &self,
-        +attrs: ~[attribute],
+        attrs: ~[attribute],
         vis: visibility
     ) -> @view_item {
         let lo = self.span.lo;
@@ -4363,7 +4363,7 @@ pub impl Parser {
     // - mod_items uses VIEW_ITEMS_AND_ITEMS_ALLOWED
     // - block_tail_ uses IMPORTS_AND_ITEMS_ALLOWED
     // - foreign_mod_items uses FOREIGN_ITEMS_ALLOWED
-    fn parse_items_and_view_items(&self, +first_item_attrs: ~[attribute],
+    fn parse_items_and_view_items(&self, first_item_attrs: ~[attribute],
                                   mode: view_item_parse_mode,
                                   macros_allowed: bool)
                                 -> ParsedItemsAndViewItems {

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -104,7 +104,7 @@ pub impl token {
     }
 }
 
-pub fn tok_str(++t: token) -> ~str {
+pub fn tok_str(t: token) -> ~str {
     match t {
         STRING(s, len) => return fmt!("STR(%s,%d)", *s, len),
         BREAK(_) => return ~"BREAK",
@@ -398,7 +398,7 @@ pub impl Printer {
         self.right %= self.buf_len;
         assert!((self.right != self.left));
     }
-    fn advance_left(&mut self, ++x: token, L: int) {
+    fn advance_left(&mut self, x: token, L: int) {
         debug!("advnce_left ~[%u,%u], sizeof(%u)=%d", self.left, self.right,
                self.left, L);
         if L >= 0 {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -134,7 +134,7 @@ pub fn print_crate(cm: @CodeMap,
     print_crate_(s, crate);
 }
 
-pub fn print_crate_(s: @ps, &&crate: @ast::crate) {
+pub fn print_crate_(s: @ps, crate: @ast::crate) {
     print_mod(s, &crate.node.module, crate.node.attrs);
     print_remaining_comments(s);
     eof(s.s);
@@ -164,7 +164,7 @@ pub fn tts_to_str(tts: &[ast::token_tree], intr: @ident_interner) -> ~str {
     to_str(tts, print_tts, intr)
 }
 
-pub fn stmt_to_str(s: ast::stmt, intr: @ident_interner) -> ~str {
+pub fn stmt_to_str(s: &ast::stmt, intr: @ident_interner) -> ~str {
     to_str(s, print_stmt, intr)
 }
 
@@ -177,7 +177,7 @@ pub fn generics_to_str(generics: &ast::Generics,
     to_str(generics, print_generics, intr)
 }
 
-pub fn path_to_str(&&p: @ast::Path, intr: @ident_interner) -> ~str {
+pub fn path_to_str(p: @ast::Path, intr: @ident_interner) -> ~str {
     to_str(p, |a,b| print_path(a, b, false), intr)
 }
 
@@ -312,7 +312,7 @@ pub fn synth_comment(s: @ps, text: ~str) {
     word(s.s, ~"*/");
 }
 
-pub fn commasep<IN>(s: @ps, b: breaks, elts: &[IN], op: &fn(@ps, IN)) {
+pub fn commasep<IN: Copy>(s: @ps, b: breaks, elts: &[IN], op: &fn(@ps, IN)) {
     box(s, 0u, b);
     let mut first = true;
     for elts.each |elt| {
@@ -323,8 +323,8 @@ pub fn commasep<IN>(s: @ps, b: breaks, elts: &[IN], op: &fn(@ps, IN)) {
 }
 
 
-pub fn commasep_cmnt<IN>(s: @ps, b: breaks, elts: &[IN], op: &fn(@ps, IN),
-                         get_span: &fn(IN) -> codemap::span) {
+pub fn commasep_cmnt<IN: Copy>(s: @ps, b: breaks, elts: &[IN], op: &fn(@ps, IN),
+                               get_span: &fn(IN) -> codemap::span) {
     box(s, 0u, b);
     let len = elts.len();
     let mut i = 0u;
@@ -343,7 +343,7 @@ pub fn commasep_cmnt<IN>(s: @ps, b: breaks, elts: &[IN], op: &fn(@ps, IN),
 }
 
 pub fn commasep_exprs(s: @ps, b: breaks, exprs: &[@ast::expr]) {
-    fn expr_span(&&expr: @ast::expr) -> codemap::span { return expr.span; }
+    fn expr_span(expr: @ast::expr) -> codemap::span { return expr.span; }
     commasep_cmnt(s, b, exprs, print_expr, expr_span);
 }
 
@@ -371,7 +371,7 @@ pub fn print_opt_lifetime(s: @ps, lifetime: Option<@ast::Lifetime>) {
     }
 }
 
-pub fn print_type(s: @ps, &&ty: @ast::Ty) {
+pub fn print_type(s: @ps, ty: @ast::Ty) {
     maybe_print_comment(s, ty.span.lo);
     ibox(s, 0u);
     match ty.node {
@@ -465,7 +465,7 @@ pub fn print_foreign_item(s: @ps, item: @ast::foreign_item) {
     }
 }
 
-pub fn print_item(s: @ps, &&item: @ast::item) {
+pub fn print_item(s: @ps, item: @ast::item) {
     hardbreak_if_not_bol(s);
     maybe_print_comment(s, item.span.lo);
     print_outer_attributes(s, item.attrs);
@@ -760,7 +760,7 @@ pub fn print_tt(s: @ps, tt: ast::token_tree) {
     }
 }
 
-pub fn print_tts(s: @ps, &&tts: &[ast::token_tree]) {
+pub fn print_tts(s: @ps, tts: &[ast::token_tree]) {
     ibox(s, 0);
     for tts.eachi |i, tt| {
         if i != 0 {
@@ -872,7 +872,7 @@ pub fn print_attribute(s: @ps, attr: ast::attribute) {
 }
 
 
-pub fn print_stmt(s: @ps, st: ast::stmt) {
+pub fn print_stmt(s: @ps, st: &ast::stmt) {
     maybe_print_comment(s, st.span.lo);
     match st.node {
       ast::stmt_decl(decl, _) => {
@@ -950,7 +950,7 @@ pub fn print_possibly_embedded_block_(s: @ps,
 
     for blk.node.view_items.each |vi| { print_view_item(s, *vi); }
     for blk.node.stmts.each |st| {
-        print_stmt(s, **st);
+        print_stmt(s, *st);
     }
     match blk.node.expr {
       Some(expr) => {
@@ -1089,7 +1089,7 @@ pub fn print_call_post(s: @ps,
     }
 }
 
-pub fn print_expr(s: @ps, &&expr: @ast::expr) {
+pub fn print_expr(s: @ps, expr: @ast::expr) {
     fn print_field(s: @ps, field: ast::field) {
         ibox(s, indent_unit);
         if field.node.mutbl == ast::m_mutbl { word_nbsp(s, ~"mut"); }
@@ -1454,7 +1454,7 @@ pub fn print_decl(s: @ps, decl: @ast::decl) {
             word_nbsp(s, ~"mut");
         }
 
-        fn print_local(s: @ps, &&loc: @ast::local) {
+        fn print_local(s: @ps, loc: @ast::local) {
             ibox(s, indent_unit);
             print_local_decl(s, loc);
             end(s);
@@ -1485,7 +1485,7 @@ pub fn print_for_decl(s: @ps, loc: @ast::local, coll: @ast::expr) {
     print_expr(s, coll);
 }
 
-pub fn print_path(s: @ps, &&path: @ast::Path, colons_before_params: bool) {
+pub fn print_path(s: @ps, path: @ast::Path, colons_before_params: bool) {
     maybe_print_comment(s, path.span.lo);
     if path.global { word(s.s, ~"::"); }
     let mut first = true;
@@ -1513,15 +1513,15 @@ pub fn print_path(s: @ps, &&path: @ast::Path, colons_before_params: bool) {
     }
 }
 
-pub fn print_irrefutable_pat(s: @ps, &&pat: @ast::pat) {
+pub fn print_irrefutable_pat(s: @ps, pat: @ast::pat) {
     print_pat(s, pat, false)
 }
 
-pub fn print_refutable_pat(s: @ps, &&pat: @ast::pat) {
+pub fn print_refutable_pat(s: @ps, pat: @ast::pat) {
     print_pat(s, pat, true)
 }
 
-pub fn print_pat(s: @ps, &&pat: @ast::pat, refutable: bool) {
+pub fn print_pat(s: @ps, pat: @ast::pat, refutable: bool) {
     maybe_print_comment(s, pat.span.lo);
     let ann_node = node_pat(s, pat);
     (s.ann.pre)(ann_node);
@@ -1758,12 +1758,12 @@ pub fn print_bounds(s: @ps, bounds: @OptVec<ast::TyParamBound>) {
     }
 }
 
-pub fn print_lifetime(s: @ps, &&lifetime: &ast::Lifetime) {
+pub fn print_lifetime(s: @ps, lifetime: &ast::Lifetime) {
     word(s.s, ~"'");
     print_ident(s, lifetime.ident);
 }
 
-pub fn print_generics(s: @ps, &&generics: &ast::Generics) {
+pub fn print_generics(s: @ps, generics: &ast::Generics) {
     let total = generics.lifetimes.len() + generics.ty_params.len();
     if total > 0 {
         word(s.s, ~"<");
@@ -1790,7 +1790,7 @@ pub fn print_generics(s: @ps, &&generics: &ast::Generics) {
     }
 }
 
-pub fn print_meta_item(s: @ps, &&item: @ast::meta_item) {
+pub fn print_meta_item(s: @ps, item: @ast::meta_item) {
     ibox(s, indent_unit);
     match item.node {
       ast::meta_word(name) => word(s.s, *name),
@@ -1814,7 +1814,7 @@ pub fn print_meta_item(s: @ps, &&item: @ast::meta_item) {
     end(s);
 }
 
-pub fn print_view_path(s: @ps, &&vp: @ast::view_path) {
+pub fn print_view_path(s: @ps, vp: @ast::view_path) {
     match vp.node {
       ast::view_path_simple(ident, path, namespace, _) => {
         if namespace == ast::module_ns {
@@ -2006,7 +2006,7 @@ pub fn print_remaining_comments(s: @ps) {
     }
 }
 
-pub fn print_literal(s: @ps, &&lit: @ast::lit) {
+pub fn print_literal(s: @ps, lit: @ast::lit) {
     maybe_print_comment(s, lit.span.lo);
     match next_lit(s, lit.span.lo) {
       Some(ref ltrl) => {
@@ -2137,7 +2137,7 @@ pub fn print_string(s: @ps, st: &str) {
     word(s.s, ~"\"");
 }
 
-pub fn to_str<T>(t: T, f: @fn(@ps, T), intr: @ident_interner) -> ~str {
+pub fn to_str<T: Copy>(t: T, f: @fn(@ps, T), intr: @ident_interner) -> ~str {
     do io::with_str_writer |wr| {
         let s = rust_printer(wr, intr);
         f(s, t);

--- a/src/libsyntax/syntax.rc
+++ b/src/libsyntax/syntax.rc
@@ -17,11 +17,10 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-#[legacy_modes];
-
 #[allow(vecs_implicitly_copyable)];
 #[allow(non_camel_case_types)];
-#[allow(deprecated_mode)];
+#[deny(deprecated_mode)];
+#[deny(deprecated_pattern)];
 
 #[no_core];
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -101,7 +101,7 @@ pub struct Visitor<E> {
 
 pub type visitor<E> = @Visitor<E>;
 
-pub fn default_visitor<E>() -> visitor<E> {
+pub fn default_visitor<E: Copy>() -> visitor<E> {
     return @Visitor {
         visit_mod: |a,b,c,d,e|visit_mod::<E>(a, b, c, d, e),
         visit_view_item: |a,b,c|visit_view_item::<E>(a, b, c),
@@ -127,18 +127,18 @@ pub fn default_visitor<E>() -> visitor<E> {
     };
 }
 
-pub fn visit_crate<E>(c: crate, e: E, v: vt<E>) {
+pub fn visit_crate<E: Copy>(c: &crate, e: E, v: vt<E>) {
     (v.visit_mod)(&c.node.module, c.span, crate_node_id, e, v);
 }
 
-pub fn visit_mod<E>(m: &_mod, _sp: span, _id: node_id, e: E, v: vt<E>) {
+pub fn visit_mod<E: Copy>(m: &_mod, _sp: span, _id: node_id, e: E, v: vt<E>) {
     for m.view_items.each |vi| { (v.visit_view_item)(*vi, e, v); }
     for m.items.each |i| { (v.visit_item)(*i, e, v); }
 }
 
 pub fn visit_view_item<E>(_vi: @view_item, _e: E, _v: vt<E>) { }
 
-pub fn visit_local<E>(loc: @local, e: E, v: vt<E>) {
+pub fn visit_local<E: Copy>(loc: @local, e: E, v: vt<E>) {
     (v.visit_pat)(loc.node.pat, e, v);
     (v.visit_ty)(loc.node.ty, e, v);
     match loc.node.init {
@@ -147,11 +147,11 @@ pub fn visit_local<E>(loc: @local, e: E, v: vt<E>) {
     }
 }
 
-fn visit_trait_ref<E>(tref: @ast::trait_ref, e: E, v: vt<E>) {
+fn visit_trait_ref<E: Copy>(tref: @ast::trait_ref, e: E, v: vt<E>) {
     visit_path(tref.path, e, v);
 }
 
-pub fn visit_item<E>(i: @item, e: E, v: vt<E>) {
+pub fn visit_item<E: Copy>(i: @item, e: E, v: vt<E>) {
     match i.node {
         item_const(t, ex) => {
             (v.visit_ty)(t, e, v);
@@ -216,10 +216,10 @@ pub fn visit_item<E>(i: @item, e: E, v: vt<E>) {
     }
 }
 
-pub fn visit_enum_def<E>(enum_definition: ast::enum_def,
-                         tps: &Generics,
-                         e: E,
-                         v: vt<E>) {
+pub fn visit_enum_def<E: Copy>(enum_definition: ast::enum_def,
+                               tps: &Generics,
+                               e: E,
+                               v: vt<E>) {
     for enum_definition.variants.each |vr| {
         match vr.node.kind {
             tuple_variant_kind(ref variant_args) => {
@@ -237,7 +237,7 @@ pub fn visit_enum_def<E>(enum_definition: ast::enum_def,
 
 pub fn skip_ty<E>(_t: @Ty, _e: E, _v: vt<E>) {}
 
-pub fn visit_ty<E>(t: @Ty, e: E, v: vt<E>) {
+pub fn visit_ty<E: Copy>(t: @Ty, e: E, v: vt<E>) {
     match t.node {
         ty_box(mt) | ty_uniq(mt) |
         ty_vec(mt) | ty_ptr(mt) | ty_rptr(_, mt) => {
@@ -265,11 +265,11 @@ pub fn visit_ty<E>(t: @Ty, e: E, v: vt<E>) {
     }
 }
 
-pub fn visit_path<E>(p: @Path, e: E, v: vt<E>) {
+pub fn visit_path<E: Copy>(p: @Path, e: E, v: vt<E>) {
     for p.types.each |tp| { (v.visit_ty)(*tp, e, v); }
 }
 
-pub fn visit_pat<E>(p: @pat, e: E, v: vt<E>) {
+pub fn visit_pat<E: Copy>(p: @pat, e: E, v: vt<E>) {
     match p.node {
         pat_enum(path, ref children) => {
             visit_path(path, e, v);
@@ -315,7 +315,7 @@ pub fn visit_pat<E>(p: @pat, e: E, v: vt<E>) {
     }
 }
 
-pub fn visit_foreign_item<E>(ni: @foreign_item, e: E, v: vt<E>) {
+pub fn visit_foreign_item<E: Copy>(ni: @foreign_item, e: E, v: vt<E>) {
     match ni.node {
         foreign_item_fn(ref fd, _, ref generics) => {
             visit_fn_decl(fd, e, v);
@@ -327,8 +327,8 @@ pub fn visit_foreign_item<E>(ni: @foreign_item, e: E, v: vt<E>) {
     }
 }
 
-pub fn visit_ty_param_bounds<E>(bounds: @OptVec<TyParamBound>,
-                                e: E, v: vt<E>) {
+pub fn visit_ty_param_bounds<E: Copy>(bounds: @OptVec<TyParamBound>,
+                                      e: E, v: vt<E>) {
     for bounds.each |bound| {
         match *bound {
             TraitTyParamBound(ty) => visit_trait_ref(ty, e, v),
@@ -337,13 +337,13 @@ pub fn visit_ty_param_bounds<E>(bounds: @OptVec<TyParamBound>,
     }
 }
 
-pub fn visit_generics<E>(generics: &Generics, e: E, v: vt<E>) {
+pub fn visit_generics<E: Copy>(generics: &Generics, e: E, v: vt<E>) {
     for generics.ty_params.each |tp| {
         visit_ty_param_bounds(tp.bounds, e, v);
     }
 }
 
-pub fn visit_fn_decl<E>(fd: &fn_decl, e: E, v: vt<E>) {
+pub fn visit_fn_decl<E: Copy>(fd: &fn_decl, e: E, v: vt<E>) {
     for fd.inputs.each |a| {
         (v.visit_pat)(a.pat, e, v);
         (v.visit_ty)(a.ty, e, v);
@@ -355,7 +355,7 @@ pub fn visit_fn_decl<E>(fd: &fn_decl, e: E, v: vt<E>) {
 // visit_fn() and check for fk_method().  I named this visit_method_helper()
 // because it is not a default impl of any method, though I doubt that really
 // clarifies anything. - Niko
-pub fn visit_method_helper<E>(m: &method, e: E, v: vt<E>) {
+pub fn visit_method_helper<E: Copy>(m: &method, e: E, v: vt<E>) {
     (v.visit_fn)(
         &fk_method(
             /* FIXME (#2543) */ copy m.ident,
@@ -390,28 +390,28 @@ pub fn visit_struct_dtor_helper<E>(dtor: struct_dtor, generics: &Generics,
 
 }
 
-pub fn visit_fn<E>(fk: &fn_kind, decl: &fn_decl, body: &blk, _sp: span,
-                   _id: node_id, e: E, v: vt<E>) {
+pub fn visit_fn<E: Copy>(fk: &fn_kind, decl: &fn_decl, body: &blk, _sp: span,
+                         _id: node_id, e: E, v: vt<E>) {
     visit_fn_decl(decl, e, v);
     let generics = generics_of_fn(fk);
     (v.visit_generics)(&generics, e, v);
     (v.visit_block)(body, e, v);
 }
 
-pub fn visit_ty_method<E>(m: &ty_method, e: E, v: vt<E>) {
+pub fn visit_ty_method<E: Copy>(m: &ty_method, e: E, v: vt<E>) {
     for m.decl.inputs.each |a| { (v.visit_ty)(a.ty, e, v); }
     (v.visit_generics)(&m.generics, e, v);
     (v.visit_ty)(m.decl.output, e, v);
 }
 
-pub fn visit_trait_method<E>(m: &trait_method, e: E, v: vt<E>) {
+pub fn visit_trait_method<E: Copy>(m: &trait_method, e: E, v: vt<E>) {
     match *m {
       required(ref ty_m) => (v.visit_ty_method)(ty_m, e, v),
       provided(m) => visit_method_helper(m, e, v)
     }
 }
 
-pub fn visit_struct_def<E>(
+pub fn visit_struct_def<E: Copy>(
     sd: @struct_def,
     _nm: ast::ident,
     generics: &Generics,
@@ -433,15 +433,15 @@ pub fn visit_struct_def<E>(
     }
 }
 
-pub fn visit_struct_field<E>(sf: @struct_field, e: E, v: vt<E>) {
+pub fn visit_struct_field<E: Copy>(sf: @struct_field, e: E, v: vt<E>) {
     (v.visit_ty)(sf.node.ty, e, v);
 }
 
-pub fn visit_struct_method<E>(m: @method, e: E, v: vt<E>) {
+pub fn visit_struct_method<E: Copy>(m: @method, e: E, v: vt<E>) {
     visit_method_helper(m, e, v);
 }
 
-pub fn visit_block<E>(b: &blk, e: E, v: vt<E>) {
+pub fn visit_block<E: Copy>(b: &blk, e: E, v: vt<E>) {
     for b.node.view_items.each |vi| {
         (v.visit_view_item)(*vi, e, v);
     }
@@ -460,7 +460,7 @@ pub fn visit_stmt<E>(s: @stmt, e: E, v: vt<E>) {
     }
 }
 
-pub fn visit_decl<E>(d: @decl, e: E, v: vt<E>) {
+pub fn visit_decl<E: Copy>(d: @decl, e: E, v: vt<E>) {
     match d.node {
         decl_local(ref locs) => {
             for locs.each |loc| {
@@ -475,7 +475,7 @@ pub fn visit_expr_opt<E>(eo: Option<@expr>, e: E, v: vt<E>) {
     match eo { None => (), Some(ex) => (v.visit_expr)(ex, e, v) }
 }
 
-pub fn visit_exprs<E>(exprs: &[@expr], e: E, v: vt<E>) {
+pub fn visit_exprs<E: Copy>(exprs: &[@expr], e: E, v: vt<E>) {
     for exprs.each |ex| { (v.visit_expr)(*ex, e, v); }
 }
 
@@ -483,7 +483,7 @@ pub fn visit_mac<E>(_m: mac, _e: E, _v: vt<E>) {
     /* no user-serviceable parts inside */
 }
 
-pub fn visit_expr<E>(ex: @expr, e: E, v: vt<E>) {
+pub fn visit_expr<E: Copy>(ex: @expr, e: E, v: vt<E>) {
     match ex.node {
         expr_vstore(x, _) => (v.visit_expr)(x, e, v),
         expr_vec(ref es, _) => visit_exprs(*es, e, v),
@@ -588,7 +588,7 @@ pub fn visit_expr<E>(ex: @expr, e: E, v: vt<E>) {
     (v.visit_expr_post)(ex, e, v);
 }
 
-pub fn visit_arm<E>(a: &arm, e: E, v: vt<E>) {
+pub fn visit_arm<E: Copy>(a: &arm, e: E, v: vt<E>) {
     for a.pats.each |p| { (v.visit_pat)(*p, e, v); }
     visit_expr_opt(a.guard, e, v);
     (v.visit_block)(&a.body, e, v);
@@ -655,67 +655,67 @@ pub fn mk_simple_visitor(v: simple_visitor) -> vt<()> {
         m: &_mod,
         sp: span,
         id: node_id,
-        &&e: (),
+        e: (),
         v: vt<()>
     ) {
         f(m, sp, id);
         visit_mod(m, sp, id, e, v);
     }
-    fn v_view_item(f: @fn(@view_item), vi: @view_item, &&e: (), v: vt<()>) {
+    fn v_view_item(f: @fn(@view_item), vi: @view_item, e: (), v: vt<()>) {
         f(vi);
         visit_view_item(vi, e, v);
     }
-    fn v_foreign_item(f: @fn(@foreign_item), ni: @foreign_item, &&e: (),
+    fn v_foreign_item(f: @fn(@foreign_item), ni: @foreign_item, e: (),
                       v: vt<()>) {
         f(ni);
         visit_foreign_item(ni, e, v);
     }
-    fn v_item(f: @fn(@item), i: @item, &&e: (), v: vt<()>) {
+    fn v_item(f: @fn(@item), i: @item, e: (), v: vt<()>) {
         f(i);
         visit_item(i, e, v);
     }
-    fn v_local(f: @fn(@local), l: @local, &&e: (), v: vt<()>) {
+    fn v_local(f: @fn(@local), l: @local, e: (), v: vt<()>) {
         f(l);
         visit_local(l, e, v);
     }
-    fn v_block(f: @fn(&ast::blk), bl: &ast::blk, &&e: (), v: vt<()>) {
+    fn v_block(f: @fn(&ast::blk), bl: &ast::blk, e: (), v: vt<()>) {
         f(bl);
         visit_block(bl, e, v);
     }
-    fn v_stmt(f: @fn(@stmt), st: @stmt, &&e: (), v: vt<()>) {
+    fn v_stmt(f: @fn(@stmt), st: @stmt, e: (), v: vt<()>) {
         f(st);
         visit_stmt(st, e, v);
     }
-    fn v_arm(f: @fn(&arm), a: &arm, &&e: (), v: vt<()>) {
+    fn v_arm(f: @fn(&arm), a: &arm, e: (), v: vt<()>) {
         f(a);
         visit_arm(a, e, v);
     }
-    fn v_pat(f: @fn(@pat), p: @pat, &&e: (), v: vt<()>) {
+    fn v_pat(f: @fn(@pat), p: @pat, e: (), v: vt<()>) {
         f(p);
         visit_pat(p, e, v);
     }
-    fn v_decl(f: @fn(@decl), d: @decl, &&e: (), v: vt<()>) {
+    fn v_decl(f: @fn(@decl), d: @decl, e: (), v: vt<()>) {
         f(d);
         visit_decl(d, e, v);
     }
-    fn v_expr(f: @fn(@expr), ex: @expr, &&e: (), v: vt<()>) {
+    fn v_expr(f: @fn(@expr), ex: @expr, e: (), v: vt<()>) {
         f(ex);
         visit_expr(ex, e, v);
     }
-    fn v_expr_post(f: @fn(@expr), ex: @expr, &&_e: (), _v: vt<()>) {
+    fn v_expr_post(f: @fn(@expr), ex: @expr, _e: (), _v: vt<()>) {
         f(ex);
     }
-    fn v_ty(f: @fn(@Ty), ty: @Ty, &&e: (), v: vt<()>) {
+    fn v_ty(f: @fn(@Ty), ty: @Ty, e: (), v: vt<()>) {
         f(ty);
         visit_ty(ty, e, v);
     }
-    fn v_ty_method(f: @fn(&ty_method), ty: &ty_method, &&e: (), v: vt<()>) {
+    fn v_ty_method(f: @fn(&ty_method), ty: &ty_method, e: (), v: vt<()>) {
         f(ty);
         visit_ty_method(ty, e, v);
     }
     fn v_trait_method(f: @fn(&trait_method),
                       m: &trait_method,
-                      &&e: (),
+                      e: (),
                       v: vt<()>) {
         f(m);
         visit_trait_method(m, e, v);
@@ -726,7 +726,7 @@ pub fn mk_simple_visitor(v: simple_visitor) -> vt<()> {
         nm: ident,
         generics: &Generics,
         id: node_id,
-        &&e: (),
+        e: (),
         v: vt<()>
     ) {
         f(sd, nm, generics, id);
@@ -735,7 +735,7 @@ pub fn mk_simple_visitor(v: simple_visitor) -> vt<()> {
     fn v_generics(
         f: @fn(&Generics),
         ps: &Generics,
-        &&e: (),
+        e: (),
         v: vt<()>
     ) {
         f(ps);
@@ -748,20 +748,20 @@ pub fn mk_simple_visitor(v: simple_visitor) -> vt<()> {
         body: &blk,
         sp: span,
         id: node_id,
-        &&e: (),
+        e: (),
         v: vt<()>
     ) {
         f(fk, decl, body, sp, id);
         visit_fn(fk, decl, body, sp, id, e, v);
     }
-    let visit_ty: @fn(@Ty, &&x: (), vt<()>) =
+    let visit_ty: @fn(@Ty, x: (), vt<()>) =
         |a,b,c| v_ty(v.visit_ty, a, b, c);
-    fn v_struct_field(f: @fn(@struct_field), sf: @struct_field, &&e: (),
+    fn v_struct_field(f: @fn(@struct_field), sf: @struct_field, e: (),
                       v: vt<()>) {
         f(sf);
         visit_struct_field(sf, e, v);
     }
-    fn v_struct_method(f: @fn(@method), m: @method, &&e: (), v: vt<()>) {
+    fn v_struct_method(f: @fn(@method), m: @method, e: (), v: vt<()>) {
         f(m);
         visit_struct_method(m, e, v);
     }

--- a/src/test/compile-fail/deref-non-pointer.rs
+++ b/src/test/compile-fail/deref-non-pointer.rs
@@ -8,9 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:cannot be dereferenced
 fn main() {
-  match *1 {
+  match *1 { //~ ERROR: cannot be dereferenced
       _ => { fail!(); }
   }
 }


### PR DESCRIPTION
This closes #4364. I came into rust after modes had begun to be phased out, so I'm not exactly sure what they all did. My strategy was basically to turn on the compilation warnings and then when everything compiles and passes all the tests it's all good.

In most cases, I just dropped the mode, but in others I converted things to use `&` pointers when otherwise a move would happen.

This depends on #5963. When running the tests, everything passed except for a few compile-fail tests. These tests leaked memory, causing the task to abort differently. By suppressing the ICE from #5963, no leaks happen and the tests all pass. I would have looked into where the leaks were coming from, but I wasn't sure where or how to debug them (I found `RUSTRT_TRACK_ALLOCATIONS`, but it wasn't all that useful).
