### PR TITLE
libcore: Fix assertion failure in vec::windowe.

### DIFF
--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -1516,6 +1516,7 @@ pub fn each_permutation<T:Copy>(v: &[T], put: &fn(ts: &[T]) -> bool) {
 #[cfg(stage0)] // XXX: lifetimes!
 pub fn windowed<T>(n: uint, v: &[T], it: &fn(&[T]) -> bool) {
     assert!(1u <= n);
+    if n > v.len() { return; }
     for uint::range(0, v.len() - n + 1) |i| {
         if !it(v.slice(i, i+n)) { return }
     }
@@ -1525,6 +1526,7 @@ pub fn windowed<T>(n: uint, v: &[T], it: &fn(&[T]) -> bool) {
 #[cfg(stage3)]
 pub fn windowed<'r, T>(n: uint, v: &'r [T], it: &fn(&'r [T]) -> bool) {
     assert!(1u <= n);
+    if n > v.len() { return; }
     for uint::range(0, v.len() - n + 1) |i| {
         if !it(v.slice(i, i + n)) { return }
     }
@@ -3833,6 +3835,7 @@ mod tests {
         t(3, &[&[1,2,3],&[2,3,4],&[3,4,5],&[4,5,6]]);
         t(4, &[&[1,2,3,4],&[2,3,4,5],&[3,4,5,6]]);
         t(7, &[]);
+        t(8, &[]);
     }
 
     #[test]


### PR DESCRIPTION
vec::windowed fails if given window size is greater than vector length + 1.

``` rust
for vec::windowed(7, &[1,2,3,4,5,6]) |vs| { fail!(); } // => do nothing
for vec::windowed(8, &[1,2,3,4,5,6]) |vs| { fail!(); } // => assertion failure in vec::slice
```
