### PR TITLE
libcore: wrappers for size/align_of to act on values without needing explicit ::<type> annotations

### DIFF
--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -83,10 +83,22 @@ pub fn get_type_desc<T>() -> *TypeDesc {
     unsafe { rusti::get_tydesc::<T>() as *TypeDesc }
 }
 
+/// Returns a pointer to a type descriptor.
+#[inline(always)]
+pub fn get_type_desc_val<T>(_val: &T) -> *TypeDesc {
+    get_type_desc::<T>()
+}
+
 /// Returns the size of a type
 #[inline(always)]
 pub fn size_of<T>() -> uint {
     unsafe { rusti::size_of::<T>() }
+}
+
+/// Returns the size of the type that `_val` points to
+#[inline(always)]
+pub fn size_of_val<T>(_val: &T) -> uint {
+    size_of::<T>()
 }
 
 /**
@@ -100,6 +112,13 @@ pub fn nonzero_size_of<T>() -> uint {
     if s == 0 { 1 } else { s }
 }
 
+/// Returns the size of the type of the value that `_val` points to
+#[inline(always)]
+pub fn nonzero_size_of_val<T>(_val: &T) -> uint {
+    nonzero_size_of::<T>()
+}
+
+
 /**
  * Returns the ABI-required minimum alignment of a type
  *
@@ -111,10 +130,24 @@ pub fn min_align_of<T>() -> uint {
     unsafe { rusti::min_align_of::<T>() }
 }
 
+/// Returns the ABI-required minimum alignment of the type of the value that
+/// `_val` points to
+#[inline(always)]
+pub fn min_align_of_val<T>(_val: &T) -> uint {
+    min_align_of::<T>()
+}
+
 /// Returns the preferred alignment of a type
 #[inline(always)]
 pub fn pref_align_of<T>() -> uint {
     unsafe { rusti::pref_align_of::<T>() }
+}
+
+/// Returns the preferred alignment of the type of the value that
+/// `_val` points to
+#[inline(always)]
+pub fn pref_align_of_val<T>(_val: &T) -> uint {
+    pref_align_of::<T>()
 }
 
 /// Returns the refcount of a shared box (as just before calling this)
@@ -162,7 +195,7 @@ pub fn fail_assert(msg: &str, file: &str, line: uint) -> ! {
 #[cfg(test)]
 mod tests {
     use cast;
-    use sys::{Closure, pref_align_of, size_of, nonzero_size_of};
+    use sys::*;
 
     #[test]
     fn size_of_basic() {
@@ -189,11 +222,27 @@ mod tests {
     }
 
     #[test]
+    fn size_of_val_basic() {
+        assert_eq!(size_of_val(&1u8), 1);
+        assert_eq!(size_of_val(&1u16), 2);
+        assert_eq!(size_of_val(&1u32), 4);
+        assert_eq!(size_of_val(&1u64), 8);
+    }
+
+    #[test]
     fn nonzero_size_of_basic() {
         type Z = [i8, ..0];
         assert!(size_of::<Z>() == 0u);
         assert!(nonzero_size_of::<Z>() == 1u);
         assert!(nonzero_size_of::<uint>() == size_of::<uint>());
+    }
+
+    #[test]
+    fn nonzero_size_of_val_basic() {
+        let z = [0u8, ..0];
+        assert_eq!(size_of_val(&z), 0u);
+        assert_eq!(nonzero_size_of_val(&z), 1u);
+        assert_eq!(nonzero_size_of_val(&1u), size_of_val(&1u));
     }
 
     #[test]
@@ -217,6 +266,13 @@ mod tests {
     fn align_of_64() {
         assert!(pref_align_of::<uint>() == 8u);
         assert!(pref_align_of::<*uint>() == 8u);
+    }
+
+    #[test]
+    fn align_of_val_basic() {
+        assert_eq!(pref_align_of_val(&1u8), 1u);
+        assert_eq!(pref_align_of_val(&1u16), 2u);
+        assert_eq!(pref_align_of_val(&1u32), 4u);
     }
 
     #[test]


### PR DESCRIPTION
This allows one to write

``` rust
let x = function_with_complicated_return_type();
let size = size_of_val(&x);
```

instead of 

``` rust
let x = function_with_complicated_return_type();
let size = size_of::<ComplicatedReturnType<Foo, Bar>>();
```
