### PR TITLE
librustc: Allow rvalues to be borrowed as &mut.

### DIFF
--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -310,8 +310,8 @@ pub impl<'self> CheckLoanCtxt<'self> {
         // We don't use cat_expr() here because we don't want to treat
         // auto-ref'd parameters in overloaded operators as rvalues.
         let cmt = match self.bccx.tcx.adjustments.find(&expr.id) {
-            None => self.bccx.cat_expr_unadjusted(expr),
-            Some(&adj) => self.bccx.cat_expr_autoderefd(expr, adj)
+            None => self.bccx.cat_expr_unadjusted(expr, false),
+            Some(&adj) => self.bccx.cat_expr_autoderefd(expr, adj, false)
         };
 
         debug!("check_assignment(cmt=%s)", cmt.repr(self.tcx()));

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -248,7 +248,14 @@ pub impl GatherLoanCtxt {
                 let mcx = &mc::mem_categorization_ctxt {
                     tcx: self.tcx(),
                     method_map: self.bccx.method_map};
-                let cmt = mcx.cat_expr_autoderefd(expr, autoderefs);
+                let mutbl = match *autoref {
+                    ty::AutoPtr(_, m) => m,
+                    ty::AutoBorrowVec(_, m) => m,
+                    ty::AutoBorrowVecRef(_, m) => m,
+                    ty::AutoUnsafe(m) => m,
+                    _ => ast::m_imm
+                };
+                let cmt = mcx.cat_expr_autoderefd(expr, autoderefs, mutbl == m_mutbl);
                 debug!("after autoderef, cmt=%s", cmt.repr(self.tcx()));
 
                 match *autoref {

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -424,12 +424,12 @@ pub impl BorrowckCtxt {
         mc::cat_expr(self.tcx, self.method_map, expr)
     }
 
-    fn cat_expr_unadjusted(&self, expr: @ast::expr, mutbl: bool) -> cmt {
+    fn cat_expr_unadjusted(&self, expr: @ast::expr, mutbl: bool) -> mc::cmt {
         mc::cat_expr_unadjusted(self.tcx, self.method_map, expr, mutbl)
     }
 
     fn cat_expr_autoderefd(&self, expr: @ast::expr,
-                           adj: @ty::AutoAdjustment, mutbl: bool) -> cmt {
+                           adj: @ty::AutoAdjustment, mutbl: bool) -> mc::cmt {
         match *adj {
             ty::AutoAddEnv(*) => {
                 // no autoderefs

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -424,23 +424,23 @@ pub impl BorrowckCtxt {
         mc::cat_expr(self.tcx, self.method_map, expr)
     }
 
-    fn cat_expr_unadjusted(&self, expr: @ast::expr) -> mc::cmt {
-        mc::cat_expr_unadjusted(self.tcx, self.method_map, expr)
+    fn cat_expr_unadjusted(&self, expr: @ast::expr, mutbl: bool) -> cmt {
+        mc::cat_expr_unadjusted(self.tcx, self.method_map, expr, mutbl)
     }
 
     fn cat_expr_autoderefd(&self, expr: @ast::expr,
-                           adj: @ty::AutoAdjustment) -> mc::cmt {
+                           adj: @ty::AutoAdjustment, mutbl: bool) -> cmt {
         match *adj {
             ty::AutoAddEnv(*) => {
                 // no autoderefs
-                mc::cat_expr_unadjusted(self.tcx, self.method_map, expr)
+                mc::cat_expr_unadjusted(self.tcx, self.method_map, expr, mutbl)
             }
 
             ty::AutoDerefRef(
                 ty::AutoDerefRef {
                     autoderefs: autoderefs, _}) => {
                 mc::cat_expr_autoderefd(self.tcx, self.method_map, expr,
-                                        autoderefs)
+                                        autoderefs, mutbl)
             }
         }
     }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -352,7 +352,14 @@ pub impl mem_categorization_ctxt {
                 // Equivalent to &*expr or something similar.
                 // Result is an rvalue.
                 let expr_ty = ty::expr_ty_adjusted(self.tcx, expr);
-                self.cat_rvalue(expr, expr_ty, autoref.mutbl == m_mutbl)
+                let mutbl = match autoref {
+                    ty::AutoPtr(_, m) => m,
+                    ty::AutoBorrowVec(_, m) => m,
+                    ty::AutoBorrowVecRef(_, m) => m,
+                    ty::AutoUnsafe(m) => m,
+                    _ => ast::m_imm
+                };
+                self.cat_rvalue(expr, expr_ty, mutbl == m_mutbl)
             }
 
             Some(

--- a/src/test/run-pass/rvalue-borrow-as-mut.rs
+++ b/src/test/run-pass/rvalue-borrow-as-mut.rs
@@ -1,0 +1,27 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo {
+    x: int
+}
+
+impl Foo {
+    fn bar(&mut self) {
+        self.x = 21;
+    }
+    fn baz(&self) {
+        
+    }
+}
+
+pub fn main() {
+    Foo { x: 42 }.bar();
+    Foo { x: 42 }.baz();
+}


### PR DESCRIPTION
#5967
