### PR TITLE
Allow intrinsics to use #[fixed_stack_segment], and use it for numeric intrinsics

### DIFF
--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -36,7 +36,7 @@ pub use f64::{acos, asin, atan2, cbrt, ceil, copysign, cosh, floor};
 pub use f64::{erf, erfc, exp, expm1, exp2, abs_sub};
 pub use f64::{mul_add, fmax, fmin, nextafter, frexp, hypot, ldexp};
 pub use f64::{lgamma, ln, log_radix, ln1p, log10, log2, ilog_radix};
-pub use f64::{modf, pow, round, sinh, tanh, tgamma, trunc};
+pub use f64::{modf, pow, powi, round, sinh, tanh, tgamma, trunc};
 pub use f64::signbit;
 pub use f64::{j0, j1, jn, y0, y1, yn};
 

--- a/src/libcore/unstable/intrinsics.rs
+++ b/src/libcore/unstable/intrinsics.rs
@@ -70,16 +70,28 @@ pub extern "rust-intrinsic" {
     pub fn powif32(a: f32, x: i32) -> f32;
     pub fn powif64(a: f64, x: i32) -> f64;
 
+    // the following kill the stack canary without
+    // `fixed_stack_segment`. This possibly only affects the f64
+    // variants, but it's hard to be sure since it seems to only
+    // occur with fairly specific arguments.
+    #[fixed_stack_segment]
     pub fn sinf32(x: f32) -> f32;
+    #[fixed_stack_segment]
     pub fn sinf64(x: f64) -> f64;
 
+    #[fixed_stack_segment]
     pub fn cosf32(x: f32) -> f32;
+    #[fixed_stack_segment]
     pub fn cosf64(x: f64) -> f64;
 
+    #[fixed_stack_segment]
     pub fn powf32(a: f32, x: f32) -> f32;
+    #[fixed_stack_segment]
     pub fn powf64(a: f64, x: f64) -> f64;
 
+    #[fixed_stack_segment]
     pub fn expf32(x: f32) -> f32;
+    #[fixed_stack_segment]
     pub fn expf64(x: f64) -> f64;
 
     pub fn exp2f32(x: f32) -> f32;
@@ -128,4 +140,3 @@ pub extern "rust-intrinsic" {
     pub fn bswap32(x: i32) -> i32;
     pub fn bswap64(x: i64) -> i64;
 }
-

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -546,6 +546,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
                        item: @ast::foreign_item,
                        path: ast_map::path,
                        substs: @param_substs,
+                       attributes: &[ast::attribute],
                        ref_id: Option<ast::node_id>) {
     debug!("trans_intrinsic(item.ident=%s)", *ccx.sess.str_of(item.ident));
 
@@ -560,6 +561,11 @@ pub fn trans_intrinsic(ccx: @CrateContext,
                                None,
                                Some(copy substs),
                                Some(item.span));
+
+    // Set the fixed stack segment flag if necessary.
+    if attr::attrs_contains_name(attributes, "fixed_stack_segment") {
+        set_fixed_stack_segment(fcx.llfn);
+    }
 
     let mut bcx = top_scope_block(fcx, None), lltop = bcx.llbb;
     match *ccx.sess.str_of(item.ident) {

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -212,7 +212,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
       }
       ast_map::node_foreign_item(i, _, _, _) => {
           let d = mk_lldecl();
-          foreign::trans_intrinsic(ccx, d, i, pt, psubsts.get(),
+          foreign::trans_intrinsic(ccx, d, i, pt, psubsts.get(), i.attrs,
                                 ref_id);
           d
       }

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -1,6 +1,5 @@
 use core::from_str::FromStr;
 use core::uint::range;
-use core::unstable::intrinsics::sqrtf64;
 
 static PI: f64 = 3.141592653589793;
 static SOLAR_MASS: f64 = 4.0 * PI * PI;
@@ -88,7 +87,7 @@ fn advance(bodies: &mut [Planet, ..N_BODIES], dt: f64, steps: i32) {
                 d[2] = bodies[i].x[2] - bodies[j].x[2];
 
                 let d2 = d[0]*d[0] + d[1]*d[1] + d[2]*d[2];
-                let mag = dt / (d2 * sqrtf64(d2));
+                let mag = dt / (d2 * f64::sqrt(d2));
 
                 let a_mass = bodies[i].mass, b_mass = bodies[j].mass;
                 bodies[i].v[0] -= d[0] * b_mass * mag;
@@ -121,7 +120,7 @@ fn energy(bodies: &[Planet, ..N_BODIES]) -> f64 {
             for range(0, 3) |k| {
                 d[k] = bodies[i].x[k] - bodies[j].x[k];
             }
-            let dist = sqrtf64(d[0]*d[0] + d[1]*d[1] + d[2]*d[2]);
+            let dist = f64::sqrt(d[0]*d[0] + d[1]*d[1] + d[2]*d[2]);
             e -= bodies[i].mass * bodies[j].mass / dist;
         }
     }
@@ -147,4 +146,3 @@ fn main() {
 
     println(fmt!("%.9f", energy(&bodies) as float));
 }
-

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -1,6 +1,5 @@
 use core::from_str::FromStr;
 use core::iter::ExtendedMutableIter;
-use core::unstable::intrinsics::sqrtf64;
 
 #[inline]
 fn A(i: i32, j: i32) -> i32 {
@@ -49,6 +48,5 @@ fn main() {
         mult_AtAv(v, u, tmp);
     }
 
-    println(fmt!("%.9f", sqrtf64(dot(u,v) / dot(v,v)) as float));
+    println(fmt!("%.9f", f64::sqrt(dot(u,v) / dot(v,v)) as float));
 }
-


### PR DESCRIPTION
This implements the fixed_stack_segment for items with the rust-intrinsic abi, and then uses it to make f32 and f64 use intrinsics where appropriate, but without overflowing stacks and killing canaries (cf. #5686 and #5697). Hopefully.

@pcwalton, the fixed_stack_segment implementation involved mirroring its implementation in `base.rs` in `trans_closure`, but without adding the `set_no_inline` (reasoning: that would defeat the purpose of intrinsics), which is possibly incorrect.

I'm a little hazy about how the underlying structure works, so I've annotated the 4 that have caused problems so far, but there's no guarantee that the other intrinsics are entirely well-behaved.

Anyway, it has good results (the following are just summing the result of each function for 1 up to 100 million):

```
$ ./intrinsics-perf.sh f32
func   new   old   speedup
sin    0.80  2.75  3.44
cos    0.80  2.76  3.45
sqrt   0.56  2.73  4.88
ln     1.01  2.94  2.91
log10  0.97  2.90  2.99
log2   1.01  2.95  2.92
exp    0.90  2.85  3.17
exp2   0.92  2.87  3.12
pow    6.95  8.57  1.23

   geometric mean: 2.97

$ ./intrinsics-perf.sh f64
func   new   old   speedup
sin    12.08  14.06  1.16
cos    12.04  13.67  1.14
sqrt   0.49  2.73  5.57
ln     4.11  5.59  1.36
log10  5.09  6.54  1.28
log2   2.78  5.10  1.83
exp    2.00  3.97  1.99
exp2   1.71  3.71  2.17
pow    5.90  7.51  1.27

   geometric mean: 1.72
```

So about 3x faster on average for f32, and 1.7x for f64. This isn't exactly apples to apples though, since this patch also adds #[inline(always)] to all the function definitions too, which possibly gives a speedup.

(fwiw, GitHub is showing 93c0888 after d9c54f8 (since I cherry-picked the latter from #5697), but git's order is the other way.)
