### PR TITLE
Replaced many instances of reinterpret_cast with transmute

### DIFF
--- a/src/libcore/at_vec.rs
+++ b/src/libcore/at_vec.rs
@@ -41,7 +41,7 @@ pub mod rustrt {
 pub fn capacity<T>(v: @[T]) -> uint {
     unsafe {
         let repr: **raw::VecRepr =
-            ::cast::reinterpret_cast(&addr_of(&v));
+            ::cast::transmute(addr_of(&v));
         (**repr).unboxed.alloc / sys::size_of::<T>()
     }
 }
@@ -208,7 +208,7 @@ pub mod raw {
      */
     #[inline(always)]
     pub unsafe fn set_len<T>(v: @[T], new_len: uint) {
-        let repr: **mut VecRepr = ::cast::reinterpret_cast(&addr_of(&v));
+        let repr: **mut VecRepr = ::cast::transmute(addr_of(&v));
         (**repr).unboxed.fill = new_len * sys::size_of::<T>();
     }
 
@@ -226,7 +226,7 @@ pub mod raw {
 
     #[inline(always)] // really pretty please
     pub unsafe fn push_fast<T>(v: &mut @[T], initval: T) {
-        let repr: **mut VecRepr = ::cast::reinterpret_cast(&v);
+        let repr: **mut VecRepr = ::cast::transmute(v);
         let fill = (**repr).unboxed.fill;
         (**repr).unboxed.fill += sys::size_of::<T>();
         let p = addr_of(&((**repr).unboxed.data));

--- a/src/libcore/gc.rs
+++ b/src/libcore/gc.rs
@@ -77,14 +77,14 @@ pub mod rustrt {
 }
 
 unsafe fn bump<T, U>(ptr: *T, count: uint) -> *U {
-    return cast::reinterpret_cast(&ptr::offset(ptr, count));
+    return cast::transmute(ptr::offset(ptr, count));
 }
 
 unsafe fn align_to_pointer<T>(ptr: *T) -> *T {
     let align = sys::min_align_of::<*T>();
-    let ptr: uint = cast::reinterpret_cast(&ptr);
+    let ptr: uint = cast::transmute(ptr);
     let ptr = (ptr + (align - 1)) & -align;
-    return cast::reinterpret_cast(&ptr);
+    return cast::transmute(ptr);
 }
 
 unsafe fn get_safe_point_count() -> uint {
@@ -129,8 +129,8 @@ type Visitor<'self> = &'self fn(root: **Word, tydesc: *Word) -> bool;
 // Walks the list of roots for the given safe point, and calls visitor
 // on each root.
 unsafe fn walk_safe_point(fp: *Word, sp: SafePoint, visitor: Visitor) {
-    let fp_bytes: *u8 = cast::reinterpret_cast(&fp);
-    let sp_meta: *u32 = cast::reinterpret_cast(&sp.sp_meta);
+    let fp_bytes: *u8 = cast::transmute(fp);
+    let sp_meta: *u32 = cast::transmute(sp.sp_meta);
 
     let num_stack_roots = *sp_meta as uint;
     let num_reg_roots = *ptr::offset(sp_meta, 1) as uint;
@@ -171,9 +171,9 @@ unsafe fn walk_safe_point(fp: *Word, sp: SafePoint, visitor: Visitor) {
 
 // Is fp contained in segment?
 unsafe fn is_frame_in_segment(fp: *Word, segment: *StackSegment) -> bool {
-    let begin: Word = cast::reinterpret_cast(&segment);
-    let end: Word = cast::reinterpret_cast(&(*segment).end);
-    let frame: Word = cast::reinterpret_cast(&fp);
+    let begin: Word = cast::transmute(segment);
+    let end: Word = cast::transmute((*segment).end);
+    let frame: Word = cast::transmute(fp);
 
     return begin <= frame && frame <= end;
 }
@@ -339,7 +339,7 @@ pub fn cleanup_stack_for_failure() {
         // own stack roots on the stack anyway.
         let sentinel_box = ~0;
         let sentinel: **Word = if expect_sentinel() {
-            cast::reinterpret_cast(&ptr::addr_of(&sentinel_box))
+            cast::transmute(ptr::addr_of(&sentinel_box))
         } else {
             ptr::null()
         };

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -239,10 +239,10 @@ pub fn getenv(n: &str) -> Option<~str> {
     unsafe {
         do with_env_lock {
             let s = str::as_c_str(n, |s| libc::getenv(s));
-            if ptr::null::<u8>() == cast::reinterpret_cast(&s) {
+            if ptr::null::<u8>() == cast::transmute(s) {
                 option::None::<~str>
             } else {
-                let s = cast::reinterpret_cast(&s);
+                let s = cast::transmute(s);
                 option::Some::<~str>(str::raw::from_buf(s))
             }
         }
@@ -644,7 +644,7 @@ pub fn make_dir(p: &Path, mode: c_int) -> bool {
             // FIXME: turn mode into something useful? #2623
             do as_utf16_p(p.to_str()) |buf| {
                 libc::CreateDirectoryW(buf, unsafe {
-                    cast::reinterpret_cast(&0)
+                    cast::transmute(0)
                 })
                     != (0 as libc::BOOL)
             }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -86,11 +86,11 @@ pub unsafe fn position<T>(buf: *T, f: &fn(&T) -> bool) -> uint {
 
 /// Create an unsafe null pointer
 #[inline(always)]
-pub fn null<T>() -> *T { unsafe { cast::reinterpret_cast(&0u) } }
+pub fn null<T>() -> *T { unsafe { cast::transmute(0u) } }
 
 /// Create an unsafe mutable null pointer
 #[inline(always)]
-pub fn mut_null<T>() -> *mut T { unsafe { cast::reinterpret_cast(&0u) } }
+pub fn mut_null<T>() -> *mut T { unsafe { cast::transmute(0u) } }
 
 /// Returns true if the pointer is equal to the null pointer.
 #[inline(always)]
@@ -134,7 +134,7 @@ pub unsafe fn set_memory<T>(dst: *mut T, c: int, count: uint) {
 */
 #[inline(always)]
 pub fn to_unsafe_ptr<T>(thing: &T) -> *T {
-    unsafe { cast::reinterpret_cast(&thing) }
+    unsafe { cast::transmute(thing) }
 }
 
 /**
@@ -144,7 +144,7 @@ pub fn to_unsafe_ptr<T>(thing: &T) -> *T {
 */
 #[inline(always)]
 pub fn to_const_unsafe_ptr<T>(thing: &const T) -> *const T {
-    unsafe { cast::reinterpret_cast(&thing) }
+    unsafe { cast::transmute(thing) }
 }
 
 /**
@@ -154,7 +154,7 @@ pub fn to_const_unsafe_ptr<T>(thing: &const T) -> *const T {
 */
 #[inline(always)]
 pub fn to_mut_unsafe_ptr<T>(thing: &mut T) -> *mut T {
-    unsafe { cast::reinterpret_cast(&thing) }
+    unsafe { cast::transmute(thing) }
 }
 
 /**
@@ -167,7 +167,7 @@ pub fn to_mut_unsafe_ptr<T>(thing: &mut T) -> *mut T {
 #[inline(always)]
 pub fn to_uint<T>(thing: &T) -> uint {
     unsafe {
-        cast::reinterpret_cast(&thing)
+        cast::transmute(thing)
     }
 }
 
@@ -259,8 +259,8 @@ impl<T> Eq for *const T {
     #[inline(always)]
     fn eq(&self, other: &*const T) -> bool {
         unsafe {
-            let a: uint = cast::reinterpret_cast(&(*self));
-            let b: uint = cast::reinterpret_cast(&(*other));
+            let a: uint = cast::transmute(*self);
+            let b: uint = cast::transmute(*other);
             return a == b;
         }
     }
@@ -274,32 +274,32 @@ impl<T> Ord for *const T {
     #[inline(always)]
     fn lt(&self, other: &*const T) -> bool {
         unsafe {
-            let a: uint = cast::reinterpret_cast(&(*self));
-            let b: uint = cast::reinterpret_cast(&(*other));
+            let a: uint = cast::transmute(*self);
+            let b: uint = cast::transmute(*other);
             return a < b;
         }
     }
     #[inline(always)]
     fn le(&self, other: &*const T) -> bool {
         unsafe {
-            let a: uint = cast::reinterpret_cast(&(*self));
-            let b: uint = cast::reinterpret_cast(&(*other));
+            let a: uint = cast::transmute(*self);
+            let b: uint = cast::transmute(*other);
             return a <= b;
         }
     }
     #[inline(always)]
     fn ge(&self, other: &*const T) -> bool {
         unsafe {
-            let a: uint = cast::reinterpret_cast(&(*self));
-            let b: uint = cast::reinterpret_cast(&(*other));
+            let a: uint = cast::transmute(*self);
+            let b: uint = cast::transmute(*other);
             return a >= b;
         }
     }
     #[inline(always)]
     fn gt(&self, other: &*const T) -> bool {
         unsafe {
-            let a: uint = cast::reinterpret_cast(&(*self));
-            let b: uint = cast::reinterpret_cast(&(*other));
+            let a: uint = cast::transmute(*self);
+            let b: uint = cast::transmute(*other);
             return a > b;
         }
     }
@@ -350,7 +350,7 @@ pub mod ptr_tests {
             struct Pair {mut fst: int, mut snd: int};
             let mut p = Pair {fst: 10, snd: 20};
             let pptr: *mut Pair = &mut p;
-            let iptr: *mut int = cast::reinterpret_cast(&pptr);
+            let iptr: *mut int = cast::transmute(pptr);
             assert!((*iptr == 10));;
             *iptr = 30;
             assert!((*iptr == 30));

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -147,7 +147,7 @@ fn with_envp<T>(env: &Option<~[(~str,~str)]>,
         }
         ptrs.push(ptr::null());
         vec::as_imm_buf(ptrs, |p, _len|
-            unsafe { cb(::cast::reinterpret_cast(&p)) }
+            unsafe { cb(::cast::transmute(p)) }
         )
       }
       _ => cb(ptr::null())
@@ -167,12 +167,12 @@ fn with_envp<T>(env: &Option<~[(~str,~str)]>,
             for vec::each(*es) |e| {
                 let (k,v) = copy *e;
                 let t = fmt!("%s=%s", k, v);
-                let mut v : ~[u8] = ::cast::reinterpret_cast(&t);
+                let mut v : ~[u8] = ::cast::transmute(t);
                 blk += v;
                 ::cast::forget(v);
             }
             blk += ~[0_u8];
-            vec::as_imm_buf(blk, |p, _len| cb(::cast::reinterpret_cast(&p)))
+            vec::as_imm_buf(blk, |p, _len| cb(::cast::transmute(p)))
           }
           _ => cb(ptr::null())
         }

--- a/src/libcore/stackwalk.rs
+++ b/src/libcore/stackwalk.rs
@@ -10,7 +10,7 @@
 
 #[doc(hidden)]; // FIXME #3538
 
-use cast::reinterpret_cast;
+use cast::transmute;
 
 pub type Word = uint;
 
@@ -30,16 +30,16 @@ pub fn walk_stack(visit: &fn(Frame) -> bool) {
 
     do frame_address |frame_pointer| {
         let mut frame_address: *Word = unsafe {
-            reinterpret_cast(&frame_pointer)
+            transmute(frame_pointer)
         };
         loop {
             let fr = Frame(frame_address);
 
-            debug!("frame: %x", unsafe { reinterpret_cast(&fr.fp) });
+            debug!("frame: %x", unsafe { transmute(fr.fp) });
             visit(fr);
 
             unsafe {
-                let next_fp: **Word = reinterpret_cast(&frame_address);
+                let next_fp: **Word = transmute(frame_address);
                 frame_address = *next_fp;
                 if *frame_address == 0u {
                     debug!("encountered task_start_wrapper. ending walk");

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -121,7 +121,7 @@ pub fn push_char(s: &mut ~str, ch: char) {
         reserve_at_least(&mut *s, new_len);
         let off = len;
         do as_buf(*s) |buf, _len| {
-            let buf: *mut u8 = ::cast::reinterpret_cast(&buf);
+            let buf: *mut u8 = ::cast::transmute(buf);
             if nb == 1u {
                 *ptr::mut_offset(buf, off) =
                     code as u8;
@@ -2023,9 +2023,9 @@ pub fn as_bytes<T>(s: &const ~str, f: &fn(&~[u8]) -> T) -> T {
  */
 pub fn as_bytes_slice<'a>(s: &'a str) -> &'a [u8] {
     unsafe {
-        let (ptr, len): (*u8, uint) = ::cast::reinterpret_cast(&s);
+        let (ptr, len): (*u8, uint) = ::cast::transmute(s);
         let outgoing_tuple: (*u8, uint) = (ptr, len - 1);
-        return ::cast::reinterpret_cast(&outgoing_tuple);
+        return ::cast::transmute(outgoing_tuple);
     }
 }
 
@@ -2067,7 +2067,7 @@ pub fn as_c_str<T>(s: &str, f: &fn(*libc::c_char) -> T) -> T {
 #[inline(always)]
 pub fn as_buf<T>(s: &str, f: &fn(*u8, uint) -> T) -> T {
     unsafe {
-        let v : *(*u8,uint) = ::cast::reinterpret_cast(&ptr::addr_of(&s));
+        let v : *(*u8,uint) = ::cast::transmute(ptr::addr_of(&s));
         let (buf,len) = *v;
         f(buf, len)
     }
@@ -2217,12 +2217,12 @@ pub mod raw {
 
     /// Create a Rust string from a null-terminated C string
     pub unsafe fn from_c_str(c_str: *libc::c_char) -> ~str {
-        from_buf(::cast::reinterpret_cast(&c_str))
+        from_buf(::cast::transmute(c_str))
     }
 
     /// Create a Rust string from a `*c_char` buffer of the given length
     pub unsafe fn from_c_str_len(c_str: *libc::c_char, len: uint) -> ~str {
-        from_buf_len(::cast::reinterpret_cast(&c_str), len)
+        from_buf_len(::cast::transmute(c_str), len)
     }
 
     /// Converts a vector of bytes to a new owned string.
@@ -2246,7 +2246,7 @@ pub mod raw {
     pub unsafe fn buf_as_slice<T>(buf: *u8, len: uint,
                               f: &fn(v: &str) -> T) -> T {
         let v = (buf, len + 1);
-        assert!(is_utf8(::cast::reinterpret_cast(&v)));
+        assert!(is_utf8(::cast::transmute(v)));
         f(::cast::transmute(v))
     }
 
@@ -2294,7 +2294,7 @@ pub mod raw {
              assert!((end <= n));
 
              let tuple = (ptr::offset(sbuf, begin), end - begin + 1);
-             ::cast::reinterpret_cast(&tuple)
+             ::cast::transmute(tuple)
         }
     }
 
@@ -2303,7 +2303,7 @@ pub mod raw {
         let new_len = s.len() + 1;
         reserve_at_least(&mut *s, new_len);
         do as_buf(*s) |buf, len| {
-            let buf: *mut u8 = ::cast::reinterpret_cast(&buf);
+            let buf: *mut u8 = ::cast::transmute(buf);
             *ptr::mut_offset(buf, len) = b;
         }
         set_len(&mut *s, new_len);

--- a/src/libcore/task/local_data_priv.rs
+++ b/src/libcore/task/local_data_priv.rs
@@ -25,8 +25,8 @@ impl<T:Durable> LocalData for @T { }
 impl Eq for @LocalData {
     fn eq(&self, other: &@LocalData) -> bool {
         unsafe {
-            let ptr_a: (uint, uint) = cast::reinterpret_cast(&(*self));
-            let ptr_b: (uint, uint) = cast::reinterpret_cast(other);
+            let ptr_a: (uint, uint) = cast::transmute(*self);
+            let ptr_b: (uint, uint) = cast::transmute(*other);
             return ptr_a == ptr_b;
         }
     }
@@ -44,7 +44,7 @@ extern fn cleanup_task_local_map(map_ptr: *libc::c_void) {
         assert!(!map_ptr.is_null());
         // Get and keep the single reference that was created at the
         // beginning.
-        let _map: TaskLocalMap = cast::reinterpret_cast(&map_ptr);
+        let _map: TaskLocalMap = cast::transmute(map_ptr);
         // All local_data will be destroyed along with the map.
     }
 }
@@ -61,7 +61,7 @@ unsafe fn get_task_local_map(task: *rust_task) -> TaskLocalMap {
         let map: TaskLocalMap = @mut ~[];
         // Use reinterpret_cast -- transmute would take map away from us also.
         rt::rust_set_task_local_data(
-            task, cast::reinterpret_cast(&map));
+            task, cast::transmute(map));
         rt::rust_task_local_data_atexit(task, cleanup_task_local_map);
         // Also need to reference it an extra time to keep it for now.
         let nonmut = cast::transmute::<TaskLocalMap,
@@ -152,7 +152,7 @@ pub unsafe fn local_set<T:Durable>(
     // own on it can be dropped when the box is destroyed. The unsafe pointer
     // does not have a reference associated with it, so it may become invalid
     // when the box is destroyed.
-    let data_ptr = cast::reinterpret_cast(&data);
+    let data_ptr = cast::transmute(data);
     let data_box = @data as @LocalData;
     // Construct new entry to store in the map.
     let new_entry = Some((keyval, data_ptr, data_box));

--- a/src/libcore/unstable.rs
+++ b/src/libcore/unstable.rs
@@ -121,7 +121,7 @@ impl<T> Drop for ArcDestruct<T>{
     fn finalize(&self) {
         unsafe {
             do task::unkillable {
-                let mut data: ~ArcData<T> = cast::reinterpret_cast(&self.data);
+                let mut data: ~ArcData<T> = cast::transmute(self.data);
                 let new_count =
                     intrinsics::atomic_xsub(&mut data.count, 1) - 1;
                 assert!(new_count >= 0);
@@ -160,7 +160,7 @@ pub unsafe fn shared_mutable_state<T:Owned>(data: T) ->
 pub unsafe fn get_shared_mutable_state<T:Owned>(
     rc: *SharedMutableState<T>) -> *mut T
 {
-    let ptr: ~ArcData<T> = cast::reinterpret_cast(&(*rc).data);
+    let ptr: ~ArcData<T> = cast::transmute((*rc).data);
     assert!(ptr.count > 0);
     let r = cast::transmute(ptr.data.get_ref());
     cast::forget(ptr);
@@ -169,7 +169,7 @@ pub unsafe fn get_shared_mutable_state<T:Owned>(
 #[inline(always)]
 pub unsafe fn get_shared_immutable_state<'a,T:Owned>(
         rc: &'a SharedMutableState<T>) -> &'a T {
-    let ptr: ~ArcData<T> = cast::reinterpret_cast(&(*rc).data);
+    let ptr: ~ArcData<T> = cast::transmute((*rc).data);
     assert!(ptr.count > 0);
     // Cast us back into the correct region
     let r = cast::transmute_region(ptr.data.get_ref());
@@ -179,7 +179,7 @@ pub unsafe fn get_shared_immutable_state<'a,T:Owned>(
 
 pub unsafe fn clone_shared_mutable_state<T:Owned>(rc: &SharedMutableState<T>)
         -> SharedMutableState<T> {
-    let mut ptr: ~ArcData<T> = cast::reinterpret_cast(&(*rc).data);
+    let mut ptr: ~ArcData<T> = cast::transmute((*rc).data);
     let new_count = intrinsics::atomic_xadd(&mut ptr.count, 1) + 1;
     assert!(new_count >= 2);
     cast::forget(ptr);

--- a/src/libcore/unstable/global.rs
+++ b/src/libcore/unstable/global.rs
@@ -25,7 +25,7 @@ which case the value should be cached locally whenever possible to
 avoid hitting the mutex.
 */
 
-use cast::{transmute, reinterpret_cast};
+use cast::{transmute};
 use clone::Clone;
 use kinds::Owned;
 use libc::{c_void};
@@ -223,7 +223,7 @@ fn get_global_state() -> Exclusive<GlobalState> {
 
 fn key_ptr<T:Owned>(key: GlobalDataKey<T>) -> uint {
     unsafe {
-        let closure: Closure = reinterpret_cast(&key);
+        let closure: Closure = transmute(key);
         return transmute(closure.code);
     }
 }

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -279,8 +279,8 @@ pub fn slice<'r,T>(v: &'r [T], start: uint, end: uint) -> &'r [T] {
     assert!(end <= len(v));
     do as_imm_buf(v) |p, _len| {
         unsafe {
-            ::cast::reinterpret_cast(
-                &(ptr::offset(p, start),
+            ::cast::transmute(
+                (ptr::offset(p, start),
                   (end - start) * sys::nonzero_size_of::<T>()))
         }
     }
@@ -294,8 +294,8 @@ pub fn mut_slice<'r,T>(v: &'r mut [T], start: uint, end: uint)
     assert!(end <= v.len());
     do as_mut_buf(v) |p, _len| {
         unsafe {
-            ::cast::reinterpret_cast(
-                &(ptr::mut_offset(p, start),
+            ::cast::transmute(
+                (ptr::mut_offset(p, start),
                   (end - start) * sys::nonzero_size_of::<T>()))
         }
     }
@@ -309,8 +309,8 @@ pub fn const_slice<'r,T>(v: &'r const [T], start: uint, end: uint)
     assert!(end <= len(v));
     do as_const_buf(v) |p, _len| {
         unsafe {
-            ::cast::reinterpret_cast(
-                &(ptr::const_offset(p, start),
+            ::cast::transmute(
+                (ptr::const_offset(p, start),
                   (end - start) * sys::nonzero_size_of::<T>()))
         }
     }
@@ -1617,7 +1617,7 @@ pub fn as_imm_buf<T,U>(s: &[T],
 
     unsafe {
         let v : *(*T,uint) =
-            ::cast::reinterpret_cast(&addr_of(&s));
+            ::cast::transmute(addr_of(&s));
         let (buf,len) = *v;
         f(buf, len / sys::nonzero_size_of::<T>())
     }
@@ -1628,7 +1628,7 @@ pub fn as_imm_buf<T,U>(s: &[T],
 pub fn as_const_buf<T,U>(s: &const [T], f: &fn(*const T, uint) -> U) -> U {
     unsafe {
         let v : *(*const T,uint) =
-            ::cast::reinterpret_cast(&addr_of(&s));
+            ::cast::transmute(addr_of(&s));
         let (buf,len) = *v;
         f(buf, len / sys::nonzero_size_of::<T>())
     }
@@ -1639,7 +1639,7 @@ pub fn as_const_buf<T,U>(s: &const [T], f: &fn(*const T, uint) -> U) -> U {
 pub fn as_mut_buf<T,U>(s: &mut [T], f: &fn(*mut T, uint) -> U) -> U {
     unsafe {
         let v : *(*mut T,uint) =
-            ::cast::reinterpret_cast(&addr_of(&s));
+            ::cast::transmute(addr_of(&s));
         let (buf,len) = *v;
         f(buf, len / sys::nonzero_size_of::<T>())
     }
@@ -2468,21 +2468,21 @@ pub mod raw {
     #[inline(always)]
     pub unsafe fn to_ptr<T>(v: &[T]) -> *T {
         let repr: **SliceRepr = ::cast::transmute(&v);
-        ::cast::reinterpret_cast(&addr_of(&((**repr).data)))
+        ::cast::transmute(addr_of(&((**repr).data)))
     }
 
     /** see `to_ptr()` */
     #[inline(always)]
     pub unsafe fn to_const_ptr<T>(v: &const [T]) -> *const T {
         let repr: **SliceRepr = ::cast::transmute(&v);
-        ::cast::reinterpret_cast(&addr_of(&((**repr).data)))
+        ::cast::transmute(addr_of(&((**repr).data)))
     }
 
     /** see `to_ptr()` */
     #[inline(always)]
     pub unsafe fn to_mut_ptr<T>(v: &mut [T]) -> *mut T {
         let repr: **SliceRepr = ::cast::transmute(&v);
-        ::cast::reinterpret_cast(&addr_of(&((**repr).data)))
+        ::cast::transmute(addr_of(&((**repr).data)))
     }
 
     /**
@@ -2495,7 +2495,7 @@ pub mod raw {
                                     f: &fn(v: &[T]) -> U) -> U {
         let pair = (p, len * sys::nonzero_size_of::<T>());
         let v : *(&'blk [T]) =
-            ::cast::reinterpret_cast(&addr_of(&pair));
+            ::cast::transmute(addr_of(&pair));
         f(*v)
     }
 
@@ -2509,7 +2509,7 @@ pub mod raw {
                                         f: &fn(v: &mut [T]) -> U) -> U {
         let pair = (p, len * sys::nonzero_size_of::<T>());
         let v : *(&'blk mut [T]) =
-            ::cast::reinterpret_cast(&addr_of(&pair));
+            ::cast::transmute(addr_of(&pair));
         f(*v)
     }
 

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -212,7 +212,7 @@ fn get_metadata_section(os: os,
                 let csz = llvm::LLVMGetSectionSize(si.llsi) as uint;
                 let mut found = None;
                 unsafe {
-                    let cvbuf: *u8 = cast::reinterpret_cast(&cbuf);
+                    let cvbuf: *u8 = cast::transmute(cbuf);
                     let vlen = vec::len(encoder::metadata_encoding_version);
                     debug!("checking %u bytes of metadata-version stamp",
                            vlen);

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -177,7 +177,7 @@ pub fn IndirectBr(cx: block, Addr: ValueRef, NumDests: uint) {
 pub fn noname() -> *libc::c_char {
     unsafe {
         static cnull: uint = 0u;
-        return cast::reinterpret_cast(&ptr::addr_of(&cnull));
+        return cast::transmute(ptr::addr_of(&cnull));
     }
 }
 
@@ -834,8 +834,8 @@ pub fn Phi(cx: block, Ty: TypeRef, vals: &[ValueRef], bbs: &[BasicBlockRef])
 pub fn AddIncomingToPhi(phi: ValueRef, val: ValueRef, bb: BasicBlockRef) {
     unsafe {
         if llvm::LLVMIsUndef(phi) == lib::llvm::True { return; }
-        let valptr = cast::reinterpret_cast(&ptr::addr_of(&val));
-        let bbptr = cast::reinterpret_cast(&ptr::addr_of(&bb));
+        let valptr = cast::transmute(ptr::addr_of(&val));
+        let bbptr = cast::transmute(ptr::addr_of(&bb));
         llvm::LLVMAddIncoming(phi, valptr, bbptr, 1 as c_uint);
     }
 }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1239,7 +1239,7 @@ pub fn C_array(ty: TypeRef, elts: &[ValueRef]) -> ValueRef {
 pub fn C_bytes(bytes: &[u8]) -> ValueRef {
     unsafe {
         return llvm::LLVMConstString(
-            cast::reinterpret_cast(&vec::raw::to_ptr(bytes)),
+            cast::transmute(vec::raw::to_ptr(bytes)),
             bytes.len() as c_uint, True);
     }
 }
@@ -1247,7 +1247,7 @@ pub fn C_bytes(bytes: &[u8]) -> ValueRef {
 pub fn C_bytes_plus_null(bytes: &[u8]) -> ValueRef {
     unsafe {
         return llvm::LLVMConstString(
-            cast::reinterpret_cast(&vec::raw::to_ptr(bytes)),
+            cast::transmute(vec::raw::to_ptr(bytes)),
             bytes.len() as c_uint, False);
     }
 }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -84,7 +84,7 @@ fn llunused() -> ValueRef {
 }
 fn llnull() -> ValueRef {
     unsafe {
-        cast::reinterpret_cast(&ptr::null::<ValueRef>())
+        cast::transmute(ptr::null::<ValueRef>())
     }
 }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -337,10 +337,8 @@ pub type t = *t_opaque;
 
 pub fn get(t: t) -> t_box {
     unsafe {
-        let t2 = cast::reinterpret_cast::<t, t_box>(&t);
-        let t3 = t2;
-        cast::forget(t2);
-        t3
+        let t2: t_box = cast::transmute(t);
+        t2
     }
 }
 

--- a/src/libstd/arena.rs
+++ b/src/libstd/arena.rs
@@ -36,7 +36,7 @@ use list;
 use list::{List, Cons, Nil};
 
 use core::at_vec;
-use core::cast::reinterpret_cast;
+use core::cast::transmute;
 use core::cast;
 use core::libc::size_t;
 use core::prelude::*;
@@ -135,7 +135,7 @@ unsafe fn destroy_chunk(chunk: &Chunk) {
     let fill = chunk.fill;
 
     while idx < fill {
-        let tydesc_data: *uint = reinterpret_cast(&ptr::offset(buf, idx));
+        let tydesc_data: *uint = transmute(ptr::offset(buf, idx));
         let (tydesc, is_done) = un_bitpack_tydesc_ptr(*tydesc_data);
         let size = (*tydesc).size, align = (*tydesc).align;
 
@@ -161,12 +161,12 @@ unsafe fn destroy_chunk(chunk: &Chunk) {
 // during an initializer.
 #[inline(always)]
 unsafe fn bitpack_tydesc_ptr(p: *TypeDesc, is_done: bool) -> uint {
-    let p_bits: uint = reinterpret_cast(&p);
+    let p_bits: uint = transmute(p);
     p_bits | (is_done as uint)
 }
 #[inline(always)]
 unsafe fn un_bitpack_tydesc_ptr(p: uint) -> (*TypeDesc, bool) {
-    (reinterpret_cast(&(p & !1)), p & 1 == 1)
+    (transmute(p & !1), p & 1 == 1)
 }
 
 pub impl Arena {
@@ -207,9 +207,9 @@ pub impl Arena {
         unsafe {
             let tydesc = sys::get_type_desc::<T>();
             let ptr = self.alloc_pod_inner((*tydesc).size, (*tydesc).align);
-            let ptr: *mut T = reinterpret_cast(&ptr);
+            let ptr: *mut T = transmute(ptr);
             rusti::move_val_init(&mut (*ptr), op());
-            return reinterpret_cast(&ptr);
+            return transmute(ptr);
         }
     }
 
@@ -221,9 +221,9 @@ pub impl Arena {
         unsafe {
             let tydesc = sys::get_type_desc::<T>();
             let ptr = self.alloc_pod_inner((*tydesc).size, (*tydesc).align);
-            let ptr: *mut T = reinterpret_cast(&ptr);
+            let ptr: *mut T = transmute(ptr);
             rusti::move_val_init(&mut (*ptr), op());
-            return reinterpret_cast(&ptr);
+            return transmute(ptr);
         }
     }
 
@@ -268,18 +268,18 @@ pub impl Arena {
             let tydesc = sys::get_type_desc::<T>();
             let (ty_ptr, ptr) =
                 self.alloc_nonpod_inner((*tydesc).size, (*tydesc).align);
-            let ty_ptr: *mut uint = reinterpret_cast(&ty_ptr);
-            let ptr: *mut T = reinterpret_cast(&ptr);
+            let ty_ptr: *mut uint = transmute(ty_ptr);
+            let ptr: *mut T = transmute(ptr);
             // Write in our tydesc along with a bit indicating that it
             // has *not* been initialized yet.
-            *ty_ptr = reinterpret_cast(&tydesc);
+            *ty_ptr = transmute(tydesc);
             // Actually initialize it
             rusti::move_val_init(&mut(*ptr), op());
             // Now that we are done, update the tydesc to indicate that
             // the object is there.
             *ty_ptr = bitpack_tydesc_ptr(tydesc, true);
 
-            return reinterpret_cast(&ptr);
+            return transmute(ptr);
         }
     }
 
@@ -292,18 +292,18 @@ pub impl Arena {
             let tydesc = sys::get_type_desc::<T>();
             let (ty_ptr, ptr) =
                 self.alloc_nonpod_inner((*tydesc).size, (*tydesc).align);
-            let ty_ptr: *mut uint = reinterpret_cast(&ty_ptr);
-            let ptr: *mut T = reinterpret_cast(&ptr);
+            let ty_ptr: *mut uint = transmute(ty_ptr);
+            let ptr: *mut T = transmute(ptr);
             // Write in our tydesc along with a bit indicating that it
             // has *not* been initialized yet.
-            *ty_ptr = reinterpret_cast(&tydesc);
+            *ty_ptr = transmute(tydesc);
             // Actually initialize it
             rusti::move_val_init(&mut(*ptr), op());
             // Now that we are done, update the tydesc to indicate that
             // the object is there.
             *ty_ptr = bitpack_tydesc_ptr(tydesc, true);
 
-            return reinterpret_cast(&ptr);
+            return transmute(ptr);
         }
     }
 

--- a/src/libstd/dbg.rs
+++ b/src/libstd/dbg.rs
@@ -10,7 +10,7 @@
 
 //! Unsafe debugging functions for inspecting values.
 
-use core::cast::reinterpret_cast;
+use core::cast::transmute;
 use core::ptr;
 use core::sys;
 
@@ -64,9 +64,9 @@ pub fn debug_fn<T>(x: T) {
 }
 
 pub unsafe fn ptr_cast<T, U>(x: @T) -> @U {
-    reinterpret_cast(
-        &rustrt::debug_ptrcast(sys::get_type_desc::<T>(),
-                              reinterpret_cast(&x)))
+    transmute(
+        rustrt::debug_ptrcast(sys::get_type_desc::<T>(),
+                              transmute(x)))
 }
 
 /// Triggers a debugger breakpoint

--- a/src/libstd/par.rs
+++ b/src/libstd/par.rs
@@ -65,7 +65,7 @@ fn map_slices<A:Copy + Owned,B:Copy + Owned>(
                                      len * sys::size_of::<A>());
                         info!("pre-slice: %?", (base, slice));
                         let slice : &[A] =
-                            cast::reinterpret_cast(&slice);
+                            cast::transmute(slice);
                         info!("slice: %?",
                                        (base, vec::len(slice), end - base));
                         assert!((vec::len(slice) == end - base));

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -839,7 +839,7 @@ pub mod node {
                   option::Some(x) => {
                     //FIXME (#2744): Replace with memcpy or something similar
                     let mut local_buf: ~[u8] =
-                        cast::reinterpret_cast(&*x.content);
+                        cast::transmute(*x.content);
                     let mut i = x.byte_offset;
                     while i < x.byte_len {
                         buf[offset] = local_buf[i];

--- a/src/libstd/sync.rs
+++ b/src/libstd/sync.rs
@@ -833,7 +833,7 @@ mod tests {
         let ptr = ptr::addr_of(&(*sharedstate));
         do task::spawn || {
             let sharedstate: &mut int =
-                unsafe { cast::reinterpret_cast(&ptr) };
+                unsafe { cast::transmute(ptr) };
             access_shared(sharedstate, m2, 10);
             c.send(());
 
@@ -1111,7 +1111,7 @@ mod tests {
         let ptr = ptr::addr_of(&(*sharedstate));
         do task::spawn || {
             let sharedstate: &mut int =
-                unsafe { cast::reinterpret_cast(&ptr) };
+                unsafe { cast::transmute(ptr) };
             access_shared(sharedstate, &x2, mode1, 10);
             c.send(());
         }


### PR DESCRIPTION
As the name suggests this replaces many instances of cast::reinterpret_cast by cast::transmute. It's essentially the boring part of fixing #5163, the remaining reinterpret_casts should be more tricky to remove (unless I missed a boring case).

r? @catamorphism
