### PR TITLE
libstd: denominator isn't quotient

### DIFF
--- a/src/libstd/num/rational.rs
+++ b/src/libstd/num/rational.rs
@@ -51,7 +51,7 @@ impl<T: Copy + Num + Ord>
     #[inline(always)]
     pub fn new(numer: T, denom: T) -> Ratio<T> {
         if denom == Zero::zero() {
-            fail!(~"quotient of 0");
+            fail!(~"denominator == 0");
         }
         let mut ret = Ratio::new_raw(numer, denom);
         ret.reduce();


### PR DESCRIPTION
A pedantic correction; the quotient is the result of `a/b`, not `b`.
