### PR TITLE
Represent enums with nullable pointers where possible

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2007,6 +2007,11 @@ pub fn trans_enum_variant(ccx: @CrateContext,
     // XXX is there a better way to reconstruct the ty::t?
     let repr = adt::represent_type(ccx, enum_ty);
 
+    debug!("trans_enum_variant: name=%s tps=%s repr=%? enum_ty=%s",
+           unsafe { str::raw::from_c_str(llvm::LLVMGetValueName(llfndecl)) },
+           ~"[" + str::connect(ty_param_substs.map(|&t| ty_to_str(ccx.tcx, t)), ", ") + ~"]",
+           repr, ty_to_str(ccx.tcx, enum_ty));
+
     adt::trans_start_init(bcx, repr, fcx.llretptr.get(), disr);
     for vec::eachi(args) |i, va| {
         let lldestptr = adt::trans_field_ptr(bcx,

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1304,6 +1304,12 @@ pub fn is_undef(val: ValueRef) -> bool {
     }
 }
 
+pub fn is_null(val: ValueRef) -> bool {
+    unsafe {
+        llvm::LLVMIsNull(val) != False
+    }
+}
+
 // Used to identify cached monomorphized functions and vtables
 #[deriving(Eq)]
 pub enum mono_param_id {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1311,9 +1311,34 @@ pub enum mono_param_id {
     mono_any,
     mono_repr(uint /* size */,
               uint /* align */,
-              bool /* is_float */,
+              MonoDataClass,
               datum::DatumMode),
 }
+
+#[deriving(Eq)]
+pub enum MonoDataClass {
+    MonoBits,    // Anything not treated differently from arbitrary integer data
+    MonoNonNull, // Non-null pointers (used for optional-pointer optimization)
+    // FIXME(#3547)---scalars and floats are
+    // treated differently in most ABIs.  But we
+    // should be doing something more detailed
+    // here.
+    MonoFloat
+}
+
+pub fn mono_data_classify(t: ty::t) -> MonoDataClass {
+    match ty::get(t).sty {
+        ty::ty_float(_) => MonoFloat,
+        ty::ty_rptr(*) | ty::ty_uniq(*) |
+        ty::ty_box(*) | ty::ty_opaque_box(*) |
+        ty::ty_estr(ty::vstore_uniq) | ty::ty_evec(_, ty::vstore_uniq) |
+        ty::ty_estr(ty::vstore_box) | ty::ty_evec(_, ty::vstore_box) |
+        ty::ty_bare_fn(*) => MonoNonNull,
+        // Is that everything?  Would closures or slices qualify?
+        _ => MonoBits
+    }
+}
+
 
 #[deriving(Eq)]
 pub struct mono_id_ {
@@ -1335,6 +1360,12 @@ impl to_bytes::IterBytes for mono_param_id {
             mono_repr(ref a, ref b, ref c, ref d) =>
                 to_bytes::iter_bytes_5(&2u8, a, b, c, d, lsb0, f)
         }
+    }
+}
+
+impl to_bytes::IterBytes for MonoDataClass {
+    fn iter_bytes(&self, lsb0: bool, f:to_bytes::Cb) {
+        (*self as u8).iter_bytes(lsb0, f)
     }
 }
 

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -395,22 +395,14 @@ pub fn make_mono_id(ccx: @CrateContext,
                             let size = machine::llbitsize_of_real(ccx, llty);
                             let align = machine::llalign_of_pref(ccx, llty);
                             let mode = datum::appropriate_mode(subst);
-
-                            // FIXME(#3547)---scalars and floats are
-                            // treated differently in most ABIs.  But we
-                            // should be doing something more detailed
-                            // here.
-                            let is_float = match ty::get(subst).sty {
-                                ty::ty_float(_) => true,
-                                _ => false
-                            };
+                            let data_class = mono_data_classify(subst);
 
                             // Special value for nil to prevent problems
                             // with undef return pointers.
                             if size <= 8u && ty::type_is_nil(subst) {
-                                mono_repr(0u, 0u, is_float, mode)
+                                mono_repr(0u, 0u, data_class, mode)
                             } else {
-                                mono_repr(size, align, is_float, mode)
+                                mono_repr(size, align, data_class, mode)
                             }
                         } else {
                             mono_precise(subst, None)

--- a/src/test/run-pass/nullable-pointer-iotareduction.rs
+++ b/src/test/run-pass/nullable-pointer-iotareduction.rs
@@ -1,0 +1,87 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core::{option, cast};
+
+// Iota-reduction is a rule in the Calculus of (Co-)Inductive Constructions,
+// which "says that a destructor applied to an object built from a constructor
+// behaves as expected".  -- http://coq.inria.fr/doc/Reference-Manual006.html
+//
+// It's a little more complicated here, because of pointers and regions and
+// trying to get assert failure messages that at least identify which case
+// failed.
+
+enum E<T> { Thing(int, T), Nothing((), ((), ()), [i8, ..0]) }
+impl<T> E<T> {
+    fn is_none(&self) -> bool { 
+        match *self {
+            Thing(*) => false,
+            Nothing(*) => true
+        }
+    }
+    fn get_ref<'r>(&'r self) -> (int, &'r T) {
+        match *self {
+            Nothing(*) => fail!(fmt!("E::get_ref(Nothing::<%s>)",  stringify!($T))),
+            Thing(x, ref y) => (x, y)
+        }
+    }
+}
+
+macro_rules! check_option {
+    ($e:expr: $T:ty) => {{
+        // FIXME #6000: remove the copy
+        check_option!(copy $e: $T, |ptr| assert!(*ptr == $e));
+    }};
+    ($e:expr: $T:ty, |$v:ident| $chk:expr) => {{
+        assert!(option::None::<$T>.is_none());
+        let s_ = option::Some::<$T>($e);
+        let $v = s_.get_ref();
+        $chk
+    }}
+}
+
+macro_rules! check_fancy {
+    ($e:expr: $T:ty) => {{
+        // FIXME #6000: remove the copy
+        check_fancy!(copy $e: $T, |ptr| assert!(*ptr == $e));
+    }};
+    ($e:expr: $T:ty, |$v:ident| $chk:expr) => {{
+        assert!(Nothing::<$T>((), ((), ()), [23i8, ..0]).is_none());
+        let t_ = Thing::<$T>(23, $e);
+        match t_.get_ref() {
+            (23, $v) => { $chk }
+            _ => fail!(fmt!("Thing::<%s>(23, %s).get_ref() != (23, _)",
+                            stringify!($T), stringify!($e)))
+        }
+    }}
+}
+
+macro_rules! check_type {
+    ($($a:tt)*) => {{
+        check_option!($($a)*);
+        check_fancy!($($a)*);
+    }}
+}
+
+pub fn main() {
+    check_type!(&17: &int);
+    check_type!(~18: ~int);
+    check_type!(@19: @int);
+    check_type!(~"foo": ~str);
+    check_type!(@"bar": @str);
+    check_type!(~[]: ~[int]);
+    check_type!(~[20, 22]: ~[int]);
+    check_type!(@[]: @[int]);
+    check_type!(@[24, 26]: @[int]);
+    let mint: uint = unsafe { cast::transmute(main) };
+    check_type!(main: extern fn(), |pthing| {
+        assert!(mint == unsafe { cast::transmute(*pthing) })
+    });
+}

--- a/src/test/run-pass/nullable-pointer-size.rs
+++ b/src/test/run-pass/nullable-pointer-size.rs
@@ -1,0 +1,44 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum E<T> { Thing(int, T), Nothing((), ((), ()), [i8, ..0]) }
+struct S<T>(int, T);
+
+// These are macros so we get useful assert messages.
+
+macro_rules! check_option {
+    ($T:ty) => {
+        assert!(sys::size_of::<Option<$T>>() == sys::size_of::<$T>());
+    }
+}
+
+macro_rules! check_fancy {
+    ($T:ty) => {
+        assert!(sys::size_of::<E<$T>>() == sys::size_of::<S<$T>>());
+    }
+}
+
+macro_rules! check_type {
+    ($T:ty) => {{
+        check_option!($T);
+        check_fancy!($T);
+    }}
+}
+
+pub fn main() {
+    check_type!(&'static int);
+    check_type!(~int);
+    check_type!(@int);
+    check_type!(~str);
+    check_type!(@str);
+    check_type!(~[int]);
+    check_type!(@[int]);
+    check_type!(extern fn());
+}


### PR DESCRIPTION
Specifically: all enums with two variants, where one has zero size (and thus at most one inhabitant) and the other has a field where the null value would not be allowed (such as a safe pointer), are now represented by storing a null pointer in the field in question.

This is a generalization of representing `Option<~T>`, `Option<@T>`, and `Option<&T>` with nullable pointers, thus fixing Tony Hoare's “billion dollar mistake”.
