### PR TITLE
cell: public field is unsafe

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -20,7 +20,7 @@ Similar to a mutable option type, but friendlier.
 */
 
 pub struct Cell<T> {
-    value: Option<T>
+    priv value: Option<T>
 }
 
 impl<T:cmp::Eq> cmp::Eq for Cell<T> {


### PR DESCRIPTION
``` rust
use core::cell;

fn main() {
    let x = cell::Cell(Some(~"foo"));
    let y = x.value.get_ref().get_ref();
    do x.with_mut_ref |z| { *z = None; }
    println(*y) // boom!
}
```
