### PR TITLE
Remove a stray new operator in rust_task.h

### DIFF
--- a/src/rt/rust_task.h
+++ b/src/rt/rust_task.h
@@ -396,12 +396,6 @@ public:
     void allow_yield();
 };
 
-// FIXME (#2697): It would be really nice to be able to get rid of this.
-inline void *operator new[](size_t size, rust_task *task, const char *tag) {
-    return task->malloc(size, tag);
-}
-
-
 template <typename T> struct task_owned {
     inline void *operator new(size_t size, rust_task *task,
                                              const char *tag) {


### PR DESCRIPTION
Closes #2697

I guess all of the uses weren't around any more, because everything continued to compile (at least on OSX). If bors doesn't like it for another platform I can try to track it down as well.
