### PR TITLE
Use backticks for the unsafe keyword in error messages

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -262,7 +262,7 @@ pub fn get_lint_dict() -> LintDict {
         (~"unused_unsafe",
          LintSpec {
             lint: unused_unsafe,
-            desc: "unnecessary use of an \"unsafe\" block",
+            desc: "unnecessary use of an `unsafe` block",
             default: warn
         }),
 
@@ -949,7 +949,7 @@ fn check_item_unused_unsafe(cx: ty::ctxt, it: @ast::item) {
                 if !cx.used_unsafe.contains(&blk.node.id) {
                     cx.sess.span_lint(unused_unsafe, blk.node.id, it.id,
                                       blk.span,
-                                      ~"unnecessary \"unsafe\" block");
+                                      ~"unnecessary `unsafe` block");
                 }
             }
             _ => ()

--- a/src/test/compile-fail/unused-unsafe.rs
+++ b/src/test/compile-fail/unused-unsafe.rs
@@ -16,10 +16,10 @@ use core::libc;
 
 fn callback<T>(_f: &fn() -> T) -> T { fail!() }
 
-fn bad1() { unsafe {} }                  //~ ERROR: unnecessary "unsafe" block
-fn bad2() { unsafe { bad1() } }          //~ ERROR: unnecessary "unsafe" block
-unsafe fn bad4() { unsafe {} }           //~ ERROR: unnecessary "unsafe" block
-fn bad5() { unsafe { do callback {} } }  //~ ERROR: unnecessary "unsafe" block
+fn bad1() { unsafe {} }                  //~ ERROR: unnecessary `unsafe` block
+fn bad2() { unsafe { bad1() } }          //~ ERROR: unnecessary `unsafe` block
+unsafe fn bad4() { unsafe {} }           //~ ERROR: unnecessary `unsafe` block
+fn bad5() { unsafe { do callback {} } }  //~ ERROR: unnecessary `unsafe` block
 
 unsafe fn good0() { libc::exit(1) }
 fn good1() { unsafe { libc::exit(1) } }


### PR DESCRIPTION
It seems that the general convention of error messages is to have keywords in backticks, so it's probably a good idea to keep doing that.
