### PR TITLE
Warn about unsafe blocks in unsafe functions

### DIFF
--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -156,9 +156,7 @@ pub impl PacketHeader {
     unsafe fn unblock(&self) {
         let old_task = swap_task(&mut self.blocked_task, ptr::null());
         if !old_task.is_null() {
-            unsafe {
-                rustrt::rust_task_deref(old_task)
-            }
+            rustrt::rust_task_deref(old_task)
         }
         match swap_state_acq(&mut self.state, Empty) {
           Empty | Blocked => (),

--- a/src/libcore/rt/sched/local_sched.rs
+++ b/src/libcore/rt/sched/local_sched.rs
@@ -80,10 +80,8 @@ pub unsafe fn unsafe_borrow() -> &mut Scheduler {
 }
 
 pub unsafe fn unsafe_borrow_io() -> &mut IoFactoryObject {
-    unsafe {
-        let sched = unsafe_borrow();
-        return sched.event_loop.io().unwrap();
-    }
+    let sched = unsafe_borrow();
+    return sched.event_loop.io().unwrap();
 }
 
 fn tls_key() -> tls::Key {

--- a/src/libcore/rt/uvio.rs
+++ b/src/libcore/rt/uvio.rs
@@ -11,7 +11,7 @@
 use option::*;
 use result::*;
 
-use super::io::net::ip::{IpAddr, Ipv4}; // n.b. Ipv4 is used only in tests
+use super::io::net::ip::IpAddr;
 use super::uv::*;
 use super::rtio::*;
 use ops::Drop;
@@ -19,6 +19,7 @@ use cell::{Cell, empty_cell};
 use cast::transmute;
 use super::sched::{Scheduler, local_sched};
 
+#[cfg(test)] use super::io::net::ip::Ipv4;
 #[cfg(test)] use super::sched::Task;
 #[cfg(test)] use unstable::run_in_bare_thread;
 #[cfg(test)] use uint;

--- a/src/libcore/rt/uvll.rs
+++ b/src/libcore/rt/uvll.rs
@@ -98,7 +98,7 @@ pub enum uv_req_type {
 
 pub unsafe fn malloc_handle(handle: uv_handle_type) -> *c_void {
     assert!(handle != UV_UNKNOWN_HANDLE && handle != UV_HANDLE_TYPE_MAX);
-    let size = unsafe { rust_uv_handle_size(handle as uint) };
+    let size = rust_uv_handle_size(handle as uint);
     let p = malloc(size);
     assert!(p.is_not_null());
     return p;
@@ -110,7 +110,7 @@ pub unsafe fn free_handle(v: *c_void) {
 
 pub unsafe fn malloc_req(req: uv_req_type) -> *c_void {
     assert!(req != UV_UNKNOWN_REQ && req != UV_REQ_TYPE_MAX);
-    let size = unsafe { rust_uv_req_size(req as uint) };
+    let size = rust_uv_req_size(req as uint);
     let p = malloc(size);
     assert!(p.is_not_null());
     return p;

--- a/src/libcore/str/ascii.rs
+++ b/src/libcore/str/ascii.rs
@@ -196,6 +196,7 @@ impl ToStrConsume for ~[Ascii] {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/libcore/unstable.rs
+++ b/src/libcore/unstable.rs
@@ -262,18 +262,16 @@ pub impl<T:Owned> Exclusive<T> {
     // the exclusive. Supporting that is a work in progress.
     #[inline(always)]
     unsafe fn with<U>(&self, f: &fn(x: &mut T) -> U) -> U {
-        unsafe {
-            let rec = get_shared_mutable_state(&self.x);
-            do (*rec).lock.lock {
-                if (*rec).failed {
-                    fail!(
-                        ~"Poisoned exclusive - another task failed inside!");
-                }
-                (*rec).failed = true;
-                let result = f(&mut (*rec).data);
-                (*rec).failed = false;
-                result
+        let rec = get_shared_mutable_state(&self.x);
+        do (*rec).lock.lock {
+            if (*rec).failed {
+                fail!(
+                    ~"Poisoned exclusive - another task failed inside!");
             }
+            (*rec).failed = true;
+            let result = f(&mut (*rec).data);
+            (*rec).failed = false;
+            result
         }
     }
 

--- a/src/libcore/unstable/weak_task.rs
+++ b/src/libcore/unstable/weak_task.rs
@@ -43,11 +43,11 @@ pub unsafe fn weaken_task(f: &fn(Port<ShutdownMsg>)) {
     let task = get_task_id();
     // Expect the weak task service to be alive
     assert!(service.try_send(RegisterWeakTask(task, shutdown_chan)));
-    unsafe { rust_dec_kernel_live_count(); }
+    rust_dec_kernel_live_count();
     do (|| {
         f(shutdown_port.take())
     }).finally || {
-        unsafe { rust_inc_kernel_live_count(); }
+        rust_inc_kernel_live_count();
         // Service my have already exited
         service.send(UnregisterWeakTask(task));
     }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -26,7 +26,7 @@ use core::char;
 use core::hash::Streaming;
 use core::hash;
 use core::io::WriterUtil;
-use core::libc::{c_int, c_uint, c_char};
+use core::libc::{c_int, c_uint};
 use core::os::consts::{macos, freebsd, linux, android, win32};
 use core::os;
 use core::ptr;

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -70,7 +70,7 @@ use core::hash;
 use core::hashmap::{HashMap, HashSet};
 use core::int;
 use core::io;
-use core::libc::{c_uint, c_ulonglong};
+use core::libc::c_uint;
 use core::uint;
 use std::time;
 use syntax::ast::ident;

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2628,13 +2628,11 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
             let class_ty = ty::lookup_item_type(tcx, parent_id).ty;
             // This code shouldn't be reached if the class is generic
             assert!(!ty::type_has_params(class_ty));
-            let lldty = unsafe {
-                T_fn(~[
+            let lldty = T_fn(~[
                     T_ptr(T_i8()),
                     T_ptr(type_of(ccx, class_ty))
                 ],
-                T_nil())
-            };
+                T_nil());
             let s = get_dtor_symbol(ccx, /*bad*/copy *pt, dt.node.id, None);
 
             /* Make the declaration for the dtor */

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -514,7 +514,7 @@ pub struct substs {
 }
 
 mod primitives {
-    use super::{sty, t_box_};
+    use super::t_box_;
 
     use syntax::ast;
 

--- a/src/libstd/arc.rs
+++ b/src/libstd/arc.rs
@@ -177,15 +177,13 @@ pub impl<T:Owned> MutexARC<T> {
      */
     #[inline(always)]
     unsafe fn access<U>(&self, blk: &fn(x: &mut T) -> U) -> U {
-        unsafe {
-            let state = get_shared_mutable_state(&self.x);
-            // Borrowck would complain about this if the function were
-            // not already unsafe. See borrow_rwlock, far below.
-            do (&(*state).lock).lock {
-                check_poison(true, (*state).failed);
-                let _z = PoisonOnFail(&mut (*state).failed);
-                blk(&mut (*state).data)
-            }
+        let state = get_shared_mutable_state(&self.x);
+        // Borrowck would complain about this if the function were
+        // not already unsafe. See borrow_rwlock, far below.
+        do (&(*state).lock).lock {
+            check_poison(true, (*state).failed);
+            let _z = PoisonOnFail(&mut (*state).failed);
+            blk(&mut (*state).data)
         }
     }
 
@@ -195,16 +193,14 @@ pub impl<T:Owned> MutexARC<T> {
         &self,
         blk: &fn(x: &'x mut T, c: &'c Condvar) -> U) -> U
     {
-        unsafe {
-            let state = get_shared_mutable_state(&self.x);
-            do (&(*state).lock).lock_cond |cond| {
-                check_poison(true, (*state).failed);
-                let _z = PoisonOnFail(&mut (*state).failed);
-                blk(&mut (*state).data,
-                    &Condvar {is_mutex: true,
-                              failed: &mut (*state).failed,
-                              cond: cond })
-            }
+        let state = get_shared_mutable_state(&self.x);
+        do (&(*state).lock).lock_cond |cond| {
+            check_poison(true, (*state).failed);
+            let _z = PoisonOnFail(&mut (*state).failed);
+            blk(&mut (*state).data,
+                &Condvar {is_mutex: true,
+                          failed: &mut (*state).failed,
+                          cond: cond })
         }
     }
 }

--- a/src/test/compile-fail/unused-unsafe.rs
+++ b/src/test/compile-fail/unused-unsafe.rs
@@ -12,30 +12,50 @@
 
 #[deny(unused_unsafe)];
 
-use core::libc;
+extern mod foo {
+    fn bar();
+}
 
 fn callback<T>(_f: &fn() -> T) -> T { fail!() }
+unsafe fn unsf() {}
 
 fn bad1() { unsafe {} }                  //~ ERROR: unnecessary `unsafe` block
 fn bad2() { unsafe { bad1() } }          //~ ERROR: unnecessary `unsafe` block
-unsafe fn bad4() { unsafe {} }           //~ ERROR: unnecessary `unsafe` block
-fn bad5() { unsafe { do callback {} } }  //~ ERROR: unnecessary `unsafe` block
+unsafe fn bad3() { unsafe {} }           //~ ERROR: unnecessary `unsafe` block
+fn bad4() { unsafe { do callback {} } }  //~ ERROR: unnecessary `unsafe` block
+unsafe fn bad5() { unsafe { unsf() } }   //~ ERROR: unnecessary `unsafe` block
+fn bad6() {
+    unsafe {                             //~ ERROR: unnecessary `unsafe` block
+        unsafe {                         // don't put the warning here
+            unsf()
+        }
+    }
+}
+unsafe fn bad7() {
+    unsafe {                             //~ ERROR: unnecessary `unsafe` block
+        unsafe {                         //~ ERROR: unnecessary `unsafe` block
+            unsf()
+        }
+    }
+}
 
-unsafe fn good0() { libc::exit(1) }
-fn good1() { unsafe { libc::exit(1) } }
+unsafe fn good0() { unsf() }
+fn good1() { unsafe { unsf() } }
 fn good2() {
     /* bug uncovered when implementing warning about unused unsafe blocks. Be
        sure that when purity is inherited that the source of the unsafe-ness
        is tracked correctly */
     unsafe {
-        unsafe fn what() -> ~[~str] { libc::exit(2) }
+        unsafe fn what() -> ~[~str] { fail!() }
 
         do callback {
             what();
         }
     }
 }
+unsafe fn good3() { foo::bar() }
+fn good4() { unsafe { foo::bar() } }
 
 #[allow(unused_unsafe)] fn allowed() { unsafe {} }
 
-fn main() { }
+fn main() {}


### PR DESCRIPTION
Because unsafe functions are never warned about, then all `unsafe` blocks in unsafe functions should definitely be warned about (no need to be redundant). This fixes this case, adds tests, cleans up remaining cases, and then fixes a few other import warnings being spit out.
