### PR TITLE
Made fail! and assert! accept both &'static str and ~str, as well as a fmt! like format list.

### DIFF
--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -1101,7 +1101,7 @@ fn mk_enum_deser_body(
     };
 
     let quoted_expr = copy quote_expr!(
-      ::core::sys::begin_unwind(~"explicit failure", ~"empty", 1);
+      ::core::sys::FailWithCause::fail_with("explicit failure", "empty", 1);
     ).node;
 
     let impossible_case = ast::arm {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -474,11 +474,12 @@ pub fn mk_unreachable(cx: @ext_ctxt, span: span) -> @ast::expr {
         ~[
             cx.ident_of(~"core"),
             cx.ident_of(~"sys"),
-            cx.ident_of(~"begin_unwind"),
+            cx.ident_of(~"FailWithCause"),
+            cx.ident_of(~"fail_with"),
         ],
         ~[
-            mk_uniq_str(cx, span, ~"internal error: entered unreachable code"),
-            mk_uniq_str(cx, span, loc.file.name),
+            mk_base_str(cx, span, ~"internal error: entered unreachable code"),
+            mk_base_str(cx, span, loc.file.name),
             mk_uint(cx, span, loc.line),
         ]
     )

--- a/src/test/compile-fail/die-not-static.rs
+++ b/src/test/compile-fail/die-not-static.rs
@@ -1,0 +1,7 @@
+// error-pattern:illegal borrow: borrowed value does not live long enough
+
+fn main() {
+    let v = ~"test";
+    let sslice = str::slice(v, 0, v.len());
+    fail!(sslice);
+}

--- a/src/test/compile-fail/die-not-unique.rs
+++ b/src/test/compile-fail/die-not-unique.rs
@@ -1,5 +1,0 @@
-// error-pattern:mismatched types
-
-fn main() {
-    fail!("test");
-}

--- a/src/test/compile-fail/fail-expr.rs
+++ b/src/test/compile-fail/fail-expr.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types
+// error-pattern:failed to find an implementation of trait core::sys::FailWithCause for int
 
 fn main() { fail!(5); }

--- a/src/test/compile-fail/fail-type-err.rs
+++ b/src/test/compile-fail/fail-type-err.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:expected `~str` but found `~[int]`
+// error-pattern:failed to find an implementation of trait core::sys::FailWithCause for ~[int]
 fn main() { fail!(~[0i]); }

--- a/src/test/run-fail/assert-eq-macro-fail.rs
+++ b/src/test/run-fail/assert-eq-macro-fail.rs
@@ -1,4 +1,4 @@
-// error-pattern:expected: 15, given: 14
+// error-pattern:left: 14 != right: 15
 
 #[deriving(Eq)]
 struct Point { x : int }

--- a/src/test/run-fail/assert-macro-explicit.rs
+++ b/src/test/run-fail/assert-macro-explicit.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task failed at 'assertion failed: false'
+
+fn main() {
+    assert!(false);
+}

--- a/src/test/run-fail/assert-macro-fmt.rs
+++ b/src/test/run-fail/assert-macro-fmt.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task failed at 'test-assert-fmt 42 rust'
+
+fn main() {
+    assert!(false, "test-assert-fmt %d %s", 42, "rust");
+}

--- a/src/test/run-fail/assert-macro-owned.rs
+++ b/src/test/run-fail/assert-macro-owned.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task failed at 'test-assert-owned'
+
+fn main() {
+    assert!(false, ~"test-assert-owned");
+}

--- a/src/test/run-fail/assert-macro-static.rs
+++ b/src/test/run-fail/assert-macro-static.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task failed at 'test-assert-static'
+
+fn main() {
+    assert!(false, "test-assert-static");
+}

--- a/src/test/run-fail/fail-macro-explicit.rs
+++ b/src/test/run-fail/fail-macro-explicit.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task failed at 'explicit failure'
+
+fn main() {
+    fail!();
+}

--- a/src/test/run-fail/fail-macro-fmt.rs
+++ b/src/test/run-fail/fail-macro-fmt.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task failed at 'test-fail-fmt 42 rust'
+
+fn main() {
+    fail!("test-fail-fmt %d %s", 42, "rust");
+}

--- a/src/test/run-fail/fail-macro-owned.rs
+++ b/src/test/run-fail/fail-macro-owned.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task failed at 'test-fail-owned'
+
+fn main() {
+    fail!(~"test-fail-owned");
+}

--- a/src/test/run-fail/fail-macro-static.rs
+++ b/src/test/run-fail/fail-macro-static.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task failed at 'test-fail-static'
+
+fn main() {
+    fail!("test-fail-static");
+}


### PR DESCRIPTION
r? @brson

Unwinding through macros now happens as a call to the trait function `FailWithCause::fail_with()`, which consumes self, allowing to use a more generic failure object in the future.
