### PR TITLE
Assorted changes to numerics, including the addition of floating-point encoding/decoding methods

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -1030,7 +1030,7 @@ mod tests {
     #[test]
     fn test_significand() {
         let sig = 0.54321f32, exp = 12;
-        assert_eq!(Float::encode(sig, exp).significand(), f32_encode(sig, -exp).significand());
+        assert_eq!(Float::encode(sig, exp).significand(), f32_encode(sig, exp).significand());
         assert_eq!(Float::encode(sig, -exp).significand(), f32_encode(sig, -exp).significand());
     }
 

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -450,9 +450,6 @@ impl Real for f32 {
     fn expm1(&self) -> f32 { expm1(*self) }
 
     #[inline(always)]
-    fn ldexp(&self, n: int) -> f32 { ldexp(*self, n as c_int) }
-
-    #[inline(always)]
     fn log(&self) -> f32 { ln(*self) }
 
     #[inline(always)]
@@ -460,12 +457,6 @@ impl Real for f32 {
 
     #[inline(always)]
     fn log10(&self) -> f32 { log10(*self) }
-
-    #[inline(always)]
-    fn log_radix(&self) -> f32 { log_radix(*self) as f32 }
-
-    #[inline(always)]
-    fn ilog_radix(&self) -> int { ilog_radix(*self) as int }
 
     #[inline(always)]
     fn sqrt(&self) -> f32 { sqrt(*self) }

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -460,9 +460,6 @@ impl Real for f64 {
     fn expm1(&self) -> f64 { expm1(*self) }
 
     #[inline(always)]
-    fn ldexp(&self, n: int) -> f64 { ldexp(*self, n as c_int) }
-
-    #[inline(always)]
     fn log(&self) -> f64 { ln(*self) }
 
     #[inline(always)]
@@ -470,12 +467,6 @@ impl Real for f64 {
 
     #[inline(always)]
     fn log10(&self) -> f64 { log10(*self) }
-
-    #[inline(always)]
-    fn log_radix(&self) -> f64 { log_radix(*self) }
-
-    #[inline(always)]
-    fn ilog_radix(&self) -> int { ilog_radix(*self) as int }
 
     #[inline(always)]
     fn sqrt(&self) -> f64 { sqrt(*self) }

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -1075,7 +1075,7 @@ mod tests {
     #[test]
     fn test_significand() {
         let sig = 0.54321f64, exp = 12;
-        assert_eq!(Float::encode(sig, exp).significand(), f64_encode(sig, -exp).significand());
+        assert_eq!(Float::encode(sig, exp).significand(), f64_encode(sig, exp).significand());
         assert_eq!(Float::encode(sig, -exp).significand(), f64_encode(sig, -exp).significand());
     }
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -594,6 +594,9 @@ impl Float for f64 {
     }
 
     #[inline(always)]
+    fn radix() -> uint { 2 }
+
+    #[inline(always)]
     fn mantissa_digits() -> uint { 53 }
 
     #[inline(always)]
@@ -613,6 +616,27 @@ impl Float for f64 {
 
     #[inline(always)]
     fn max_10_exp() -> int { 308 }
+
+    /// Constructs a floating-point number from a significand and exponent
+    #[inline(always)]
+    fn encode(sig: f64, exp: int) -> f64 { ldexp(sig, exp as c_int) }
+
+    /// Splits the numder into its significand and exponent
+    #[inline(always)]
+    fn decode(&self) -> (f64, int) {
+        let mut exp = 0;
+        let sig = frexp(*self, &mut exp);
+        (sig, exp as int)
+    }
+
+    #[inline(always)]
+    fn significand(&self) -> f64 {
+        let mut _exp = 0;
+        frexp(*self, &mut _exp)
+    }
+
+    #[inline(always)]
+    fn exponent(&self) -> int { ilog_radix(*self) as int }
 
     ///
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding error. This
@@ -1027,6 +1051,39 @@ mod tests {
     fn test_primitive() {
         assert_eq!(Primitive::bits::<f64>(), sys::size_of::<f64>() * 8);
         assert_eq!(Primitive::bytes::<f64>(), sys::size_of::<f64>());
+    }
+
+    #[cfg(test)]
+    fn f64_encode(sig: f64, exp: int) -> f64 {
+        sig * (exp as f64).exp2()
+    }
+
+    #[test]
+    fn test_encode() {
+        let sig = 0.54321f64, exp = 12;
+        assert_eq!(Float::encode(sig, exp), f64_encode(sig, exp));
+        assert_eq!(Float::encode(sig, -exp), f64_encode(sig, -exp));
+    }
+
+    #[test]
+    fn test_decode() {
+        let sig = 0.54321f64, exp = 12;
+        assert_eq!(f64_encode(sig, exp).decode(), (sig, exp));
+        assert_eq!(f64_encode(sig, -exp).decode(), (sig, -exp));
+    }
+
+    #[test]
+    fn test_significand() {
+        let sig = 0.54321f64, exp = 12;
+        assert_eq!(Float::encode(sig, exp).significand(), f64_encode(sig, -exp).significand());
+        assert_eq!(Float::encode(sig, -exp).significand(), f64_encode(sig, -exp).significand());
+    }
+
+    #[test]
+    fn test_exponent() {
+        let sig = 0.54321f64, exp = 12;
+        assert_eq!(Float::encode(sig, exp).exponent(), f64_encode(sig, exp).exponent());
+        assert_eq!(Float::encode(sig, -exp).exponent(), f64_encode(sig, -exp).exponent());
     }
 }
 

--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -726,6 +726,21 @@ impl Float for float {
     #[inline(always)]
     fn is_NaN(&self) -> bool { *self != *self }
 
+    /// Returns `true` if the number is infinite
+    #[inline(always)]
+    fn is_infinite(&self) -> bool {
+        *self == Float::infinity() || *self == Float::neg_infinity()
+    }
+
+    /// Returns `true` if the number is finite
+    #[inline(always)]
+    fn is_finite(&self) -> bool {
+        !(self.is_NaN() || self.is_infinite())
+    }
+
+    #[inline(always)]
+    fn radix() -> uint { Float::radix::<f64>() }
+
     #[inline(always)]
     fn mantissa_digits() -> uint { Float::mantissa_digits::<f64>() }
 
@@ -747,17 +762,23 @@ impl Float for float {
     #[inline(always)]
     fn max_10_exp() -> int { Float::max_10_exp::<f64>() }
 
-    /// Returns `true` if the number is infinite
+    /// Constructs a floating-point number from a significand and exponent
     #[inline(always)]
-    fn is_infinite(&self) -> bool {
-        *self == Float::infinity() || *self == Float::neg_infinity()
+    fn encode(sig: float, exp: int) -> float { Float::encode(sig as f64, exp) as float  }
+
+    /// Splits the number into its significand and exponent
+    #[inline(always)]
+    fn decode(&self) -> (float, int) {
+        match (*self as f64).decode() {
+            (sig, exp) => (sig as float, exp)
+        }
     }
 
-    /// Returns `true` if the number is finite
     #[inline(always)]
-    fn is_finite(&self) -> bool {
-        !(self.is_NaN() || self.is_infinite())
-    }
+    fn significand(&self) -> float { (*self as f64).significand() as float }
+
+    #[inline(always)]
+    fn exponent(&self) -> int { (*self as f64).exponent() }
 
     ///
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding error. This
@@ -949,6 +970,39 @@ mod tests {
     fn test_primitive() {
         assert_eq!(Primitive::bits::<float>(), sys::size_of::<float>() * 8);
         assert_eq!(Primitive::bytes::<float>(), sys::size_of::<float>());
+    }
+
+    #[cfg(test)]
+    fn float_encode(sig: float, exp: int) -> float {
+        sig * (exp as float).exp2()
+    }
+
+    #[test]
+    fn test_encode() {
+        let sig = 0.54321f, exp = 12;
+        assert_eq!(Float::encode(sig, exp), float_encode(sig, exp));
+        assert_eq!(Float::encode(sig, -exp), float_encode(sig, -exp));
+    }
+
+    #[test]
+    fn test_decode() {
+        let sig = 0.54321f, exp = 12;
+        assert_eq!(float_encode(sig, exp).decode(), (sig, exp));
+        assert_eq!(float_encode(sig, -exp).decode(), (sig, -exp));
+    }
+
+    #[test]
+    fn test_significand() {
+        let sig = 0.54321f, exp = 12;
+        assert_eq!(Float::encode(sig, exp).significand(), float_encode(sig, -exp).significand());
+        assert_eq!(Float::encode(sig, -exp).significand(), float_encode(sig, -exp).significand());
+    }
+
+    #[test]
+    fn test_exponent() {
+        let sig = 0.54321f, exp = 12;
+        assert_eq!(Float::encode(sig, exp).exponent(), float_encode(sig, exp).exponent());
+        assert_eq!(Float::encode(sig, -exp).exponent(), float_encode(sig, -exp).exponent());
     }
 
     #[test]

--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -535,9 +535,6 @@ impl Real for float {
     fn expm1(&self) -> float { expm1(*self as f64) as float }
 
     #[inline(always)]
-    fn ldexp(&self, n: int) -> float { ldexp(*self as f64, n as c_int) as float }
-
-    #[inline(always)]
     fn log(&self) -> float { ln(*self as f64) as float }
 
     #[inline(always)]
@@ -545,12 +542,6 @@ impl Real for float {
 
     #[inline(always)]
     fn log10(&self) -> float { log10(*self as f64) as float }
-
-    #[inline(always)]
-    fn log_radix(&self) -> float { log_radix(*self as f64) as float }
-
-    #[inline(always)]
-    fn ilog_radix(&self) -> int { ilog_radix(*self as f64) as int }
 
     #[inline(always)]
     fn sqrt(&self) -> float { sqrt(*self) }

--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -994,7 +994,7 @@ mod tests {
     #[test]
     fn test_significand() {
         let sig = 0.54321f, exp = 12;
-        assert_eq!(Float::encode(sig, exp).significand(), float_encode(sig, -exp).significand());
+        assert_eq!(Float::encode(sig, exp).significand(), float_encode(sig, exp).significand());
         assert_eq!(Float::encode(sig, -exp).significand(), float_encode(sig, -exp).significand());
     }
 

--- a/src/libcore/num/int-template.rs
+++ b/src/libcore/num/int-template.rs
@@ -693,6 +693,32 @@ mod tests {
     }
 
     #[test]
+    fn test_even() {
+        assert_eq!((-4 as T).is_even(), true);
+        assert_eq!((-3 as T).is_even(), false);
+        assert_eq!((-2 as T).is_even(), true);
+        assert_eq!((-1 as T).is_even(), false);
+        assert_eq!((0 as T).is_even(), true);
+        assert_eq!((1 as T).is_even(), false);
+        assert_eq!((2 as T).is_even(), true);
+        assert_eq!((3 as T).is_even(), false);
+        assert_eq!((4 as T).is_even(), true);
+    }
+
+    #[test]
+    fn test_odd() {
+        assert_eq!((-4 as T).is_odd(), false);
+        assert_eq!((-3 as T).is_odd(), true);
+        assert_eq!((-2 as T).is_odd(), false);
+        assert_eq!((-1 as T).is_odd(), true);
+        assert_eq!((0 as T).is_odd(), false);
+        assert_eq!((1 as T).is_odd(), true);
+        assert_eq!((2 as T).is_odd(), false);
+        assert_eq!((3 as T).is_odd(), true);
+        assert_eq!((4 as T).is_odd(), false);
+    }
+
+    #[test]
     fn test_bitcount() {
         assert_eq!((0b010101 as T).population_count(), 3);
     }

--- a/src/libcore/num/int-template.rs
+++ b/src/libcore/num/int-template.rs
@@ -406,11 +406,11 @@ impl Integer for T {
 
     /// Returns `true` if the number can be divided by `other` without leaving a remainder
     #[inline(always)]
-    fn divisible_by(&self, other: &T) -> bool { *self % *other == 0 }
+    fn is_multiple_of(&self, other: &T) -> bool { *self % *other == 0 }
 
     /// Returns `true` if the number is divisible by `2`
     #[inline(always)]
-    fn is_even(&self) -> bool { self.divisible_by(&2) }
+    fn is_even(&self) -> bool { self.is_multiple_of(&2) }
 
     /// Returns `true` if the number is not divisible by `2`
     #[inline(always)]
@@ -680,6 +680,16 @@ mod tests {
         assert_eq!(0b1110 as T, (0b0111 as T).shl(&(1 as T)));
         assert_eq!(0b0111 as T, (0b1110 as T).shr(&(1 as T)));
         assert_eq!(-(0b11 as T) - (1 as T), (0b11 as T).not());
+    }
+
+    #[test]
+    fn test_multiple_of() {
+        assert!((6 as T).is_multiple_of(&(6 as T)));
+        assert!((6 as T).is_multiple_of(&(3 as T)));
+        assert!((6 as T).is_multiple_of(&(1 as T)));
+        assert!((-8 as T).is_multiple_of(&(4 as T)));
+        assert!((8 as T).is_multiple_of(&(-1 as T)));
+        assert!((-8 as T).is_multiple_of(&(-2 as T)));
     }
 
     #[test]

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -85,7 +85,8 @@ pub trait Integer: Num
 
     fn gcd(&self, other: &Self) -> Self;
     fn lcm(&self, other: &Self) -> Self;
-    fn divisible_by(&self, other: &Self) -> bool;
+
+    fn is_multiple_of(&self, other: &Self) -> bool;
     fn is_even(&self) -> bool;
     fn is_odd(&self) -> bool;
 }

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -138,12 +138,9 @@ pub trait Real: Signed
     fn exp(&self) -> Self;
     fn exp2(&self) -> Self;
     fn expm1(&self) -> Self;
-    fn ldexp(&self, n: int) -> Self;
     fn log(&self) -> Self;
     fn log2(&self) -> Self;
     fn log10(&self) -> Self;
-    fn log_radix(&self) -> Self;
-    fn ilog_radix(&self) -> int;
     fn sqrt(&self) -> Self;
     fn rsqrt(&self) -> Self;
     fn cbrt(&self) -> Self;

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -252,6 +252,7 @@ pub trait Float: Real
     fn is_infinite(&self) -> bool;
     fn is_finite(&self) -> bool;
 
+    fn radix() -> uint;
     fn mantissa_digits() -> uint;
     fn digits() -> uint;
     fn epsilon() -> Self;
@@ -259,6 +260,11 @@ pub trait Float: Real
     fn max_exp() -> int;
     fn min_10_exp() -> int;
     fn max_10_exp() -> int;
+
+    fn encode(sig: Self, exp: int) -> Self;
+    fn decode(&self) -> (Self, int);
+    fn significand(&self) -> Self;
+    fn exponent(&self) -> int;
 
     fn mul_add(&self, a: Self, b: Self) -> Self;
     fn next_after(&self, other: Self) -> Self;

--- a/src/libcore/num/uint-template.rs
+++ b/src/libcore/num/uint-template.rs
@@ -423,6 +423,24 @@ mod tests {
     }
 
     #[test]
+    fn test_even() {
+        assert_eq!((0 as T).is_even(), true);
+        assert_eq!((1 as T).is_even(), false);
+        assert_eq!((2 as T).is_even(), true);
+        assert_eq!((3 as T).is_even(), false);
+        assert_eq!((4 as T).is_even(), true);
+    }
+
+    #[test]
+    fn test_odd() {
+        assert_eq!((0 as T).is_odd(), false);
+        assert_eq!((1 as T).is_odd(), true);
+        assert_eq!((2 as T).is_odd(), false);
+        assert_eq!((3 as T).is_odd(), true);
+        assert_eq!((4 as T).is_odd(), false);
+    }
+
+    #[test]
     fn test_bitwise() {
         assert_eq!(0b1110 as T, (0b1100 as T).bitor(&(0b1010 as T)));
         assert_eq!(0b1000 as T, (0b1100 as T).bitand(&(0b1010 as T)));

--- a/src/libcore/num/uint-template.rs
+++ b/src/libcore/num/uint-template.rs
@@ -238,11 +238,11 @@ impl Integer for T {
 
     /// Returns `true` if the number can be divided by `other` without leaving a remainder
     #[inline(always)]
-    fn divisible_by(&self, other: &T) -> bool { *self % *other == 0 }
+    fn is_multiple_of(&self, other: &T) -> bool { *self % *other == 0 }
 
     /// Returns `true` if the number is divisible by `2`
     #[inline(always)]
-    fn is_even(&self) -> bool { self.divisible_by(&2) }
+    fn is_even(&self) -> bool { self.is_multiple_of(&2) }
 
     /// Returns `true` if the number is not divisible by `2`
     #[inline(always)]
@@ -413,6 +413,13 @@ mod tests {
         assert_eq!((8 as T).lcm(&9), 72 as T);
         assert_eq!((11 as T).lcm(&5), 55 as T);
         assert_eq!((99 as T).lcm(&17), 1683 as T);
+    }
+
+    #[test]
+    fn test_multiple_of() {
+        assert!((6 as T).is_multiple_of(&(6 as T)));
+        assert!((6 as T).is_multiple_of(&(3 as T)));
+        assert!((6 as T).is_multiple_of(&(1 as T)));
     }
 
     #[test]

--- a/src/libstd/num/rational.rs
+++ b/src/libstd/num/rational.rs
@@ -206,6 +206,9 @@ impl<T: Copy + Num + Ord>
     }
 }
 
+impl<T: Copy + Num + Ord>
+    Num for Ratio<T> {}
+
 /* Utils */
 impl<T: Copy + Num + Ord>
     Round for Ratio<T> {
@@ -245,6 +248,12 @@ impl<T: Copy + Num + Ord>
     }
 }
 
+impl<T: Copy + Num + Ord> Fractional for Ratio<T> {
+    #[inline]
+    fn recip(&self) -> Ratio<T> {
+        Ratio::new_raw(self.denom, self.numer)
+    }
+}
 
 /* String conversions */
 impl<T: ToStr> ToStr for Ratio<T> {
@@ -448,6 +457,15 @@ mod test {
         assert_eq!(_neg1_2.fract(), _neg1_2);
         assert_eq!(_1_2.fract(), _1_2);
         assert_eq!(_3_2.fract(), _1_2);
+    }
+
+    #[test]
+    fn test_recip() {
+        assert_eq!(_1 * _1.recip(), _1);
+        assert_eq!(_2 * _2.recip(), _1);
+        assert_eq!(_1_2 * _1_2.recip(), _1);
+        assert_eq!(_3_2 * _3_2.recip(), _1);
+        assert_eq!(_neg1_2 * _neg1_2.recip(), _1);
     }
 
     #[test]


### PR DESCRIPTION
This is part of the numeric trait reform (see issue #4819).

I have included the following methods to the `Float` trait:

``` rust
fn encode(sig: Self, exp: int) -> Self;
fn decode(&self) -> (Self, int);
fn significand(&self) -> Self;
fn exponent(&self) -> int;
```

The following methods have been removed from the `Real` trait, because they are specific to floating-point numbers and also because their functionality is covered by the methods mentioned above:

``` rust
fn ldexp(&self, n: int) -> Self;
fn log_radix(&self) -> Self;
fn ilog_radix(&self) -> int;
```

The `Integer::divisible_by` method has been renamed to `Integer::is_multiple_of`.
