### PR TITLE
rand: Fix infinite recursion

### DIFF
--- a/src/libcore/rand.rs
+++ b/src/libcore/rand.rs
@@ -690,7 +690,7 @@ pub fn task_rng() -> @IsaacRng {
 
 // Allow direct chaining with `task_rng`
 impl<R: Rng> Rng for @R {
-    fn next(&self) -> u32 { (*self).next() }
+    fn next(&self) -> u32 { (**self).next() }
 }
 
 /**


### PR DESCRIPTION
`self` has type `&@Rand`, so `*self` will be of type `@Rand` which causes
this same impl to be called again.

Fixes #6061
