### PR TITLE
(RFC) replace old_iter::repeat with the Times trait

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1977,7 +1977,7 @@ struct TimeBomb {
 
 impl Drop for TimeBomb {
     fn finalize(&self) {
-        for old_iter::repeat(self.explosivity) {
+        for self.explosivity.times {
             println("blam!");
         }
     }

--- a/src/libcore/old_iter.rs
+++ b/src/libcore/old_iter.rs
@@ -239,26 +239,6 @@ pub fn position<A,IA:BaseIter<A>>(this: &IA, f: &fn(&A) -> bool)
 // it would have to be implemented with foldr, which is too inefficient.
 
 #[inline(always)]
-#[cfg(stage0)]
-pub fn repeat(times: uint, blk: &fn() -> bool) {
-    let mut i = 0;
-    while i < times {
-        if !blk() { break }
-        i += 1;
-    }
-}
-#[inline(always)]
-#[cfg(not(stage0))]
-pub fn repeat(times: uint, blk: &fn() -> bool) -> bool {
-    let mut i = 0;
-    while i < times {
-        if !blk() { return false; }
-        i += 1;
-    }
-    return true;
-}
-
-#[inline(always)]
 pub fn min<A:Copy + Ord,IA:BaseIter<A>>(this: &IA) -> A {
     match do foldl::<A,Option<A>,IA>(this, None) |a, b| {
         match a {

--- a/src/libcore/task/mod.rs
+++ b/src/libcore/task/mod.rs
@@ -619,7 +619,7 @@ fn test_spawn_unlinked_unsup_no_fail_down() { // grandchild sends on a port
         let ch = ch.clone();
         do spawn_unlinked {
             // Give middle task a chance to fail-but-not-kill-us.
-            for old_iter::repeat(16) { task::yield(); }
+            for 16.times { task::yield(); }
             ch.send(()); // If killed first, grandparent hangs.
         }
         fail!(); // Shouldn't kill either (grand)parent or (grand)child.
@@ -634,7 +634,7 @@ fn test_spawn_unlinked_unsup_no_fail_up() { // child unlinked fails
 fn test_spawn_unlinked_sup_no_fail_up() { // child unlinked fails
     do spawn_supervised { fail!(); }
     // Give child a chance to fail-but-not-kill-us.
-    for old_iter::repeat(16) { task::yield(); }
+    for 16.times { task::yield(); }
 }
 #[test] #[should_fail] #[ignore(cfg(windows))]
 fn test_spawn_unlinked_sup_fail_down() {
@@ -709,7 +709,7 @@ fn test_spawn_failure_propagate_grandchild() {
             loop { task::yield(); }
         }
     }
-    for old_iter::repeat(16) { task::yield(); }
+    for 16.times { task::yield(); }
     fail!();
 }
 
@@ -721,7 +721,7 @@ fn test_spawn_failure_propagate_secondborn() {
             loop { task::yield(); }
         }
     }
-    for old_iter::repeat(16) { task::yield(); }
+    for 16.times { task::yield(); }
     fail!();
 }
 
@@ -733,7 +733,7 @@ fn test_spawn_failure_propagate_nephew_or_niece() {
             loop { task::yield(); }
         }
     }
-    for old_iter::repeat(16) { task::yield(); }
+    for 16.times { task::yield(); }
     fail!();
 }
 
@@ -745,7 +745,7 @@ fn test_spawn_linked_sup_propagate_sibling() {
             loop { task::yield(); }
         }
     }
-    for old_iter::repeat(16) { task::yield(); }
+    for 16.times { task::yield(); }
     fail!();
 }
 
@@ -904,8 +904,7 @@ fn test_spawn_sched_blocking() {
 
         // Testing that a task in one scheduler can block in foreign code
         // without affecting other schedulers
-        for old_iter::repeat(20u) {
-
+        for 20u.times {
             let (start_po, start_ch) = stream();
             let (fin_po, fin_ch) = stream();
 
@@ -1024,7 +1023,7 @@ fn test_unkillable() {
 
     // We want to do this after failing
     do spawn_unlinked {
-        for old_iter::repeat(10) { yield() }
+        for 10.times { yield() }
         ch.send(());
     }
 
@@ -1059,7 +1058,7 @@ fn test_unkillable_nested() {
 
     // We want to do this after failing
     do spawn_unlinked || {
-        for old_iter::repeat(10) { yield() }
+        for 10.times { yield() }
         ch.send(());
     }
 

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -629,7 +629,7 @@ mod test {
         let doc = (page_pass::mk_pass(config::DocPerMod).f)(srv, doc);
         write_markdown(doc, writer_factory);
         // We expect two pages to have been written
-        for old_iter::repeat(2) {
+        for 2.times {
             po.recv();
         }
     }
@@ -641,7 +641,7 @@ mod test {
             ~"#[link(name = \"core\")]; mod a { }");
         let doc = (page_pass::mk_pass(config::DocPerMod).f)(srv, doc);
         write_markdown(doc, writer_factory);
-        for old_iter::repeat(2) {
+        for 2.times {
             let (page, markdown) = po.recv();
             match page {
                 doc::CratePage(_) => {

--- a/src/libstd/base64.rs
+++ b/src/libstd/base64.rs
@@ -10,10 +10,6 @@
 
 //! Base64 binary-to-text encoding
 
-use core::old_iter;
-use core::str;
-use core::vec;
-
 pub trait ToBase64 {
     fn to_base64(&self) -> ~str;
 }
@@ -152,7 +148,7 @@ impl FromBase64 for ~[u8] {
         while i < len {
             let mut n = 0u;
 
-            for old_iter::repeat(4u) {
+            for 4u.times {
                 let ch = self[i] as char;
                 n <<= 6u;
 

--- a/src/libstd/timer.rs
+++ b/src/libstd/timer.rs
@@ -188,7 +188,7 @@ mod test {
     #[test]
     fn test_gl_timer_sleep_stress1() {
         let hl_loop = &uv::global_loop::get();
-        for old_iter::repeat(50u) {
+        for 50u.times {
             sleep(hl_loop, 1u);
         }
     }
@@ -208,8 +208,7 @@ mod test {
 
         };
 
-        for old_iter::repeat(repeat) {
-
+        for repeat.times {
             let ch = ch.clone();
             for spec.each |spec| {
                 let (times, maxms) = *spec;
@@ -218,7 +217,7 @@ mod test {
                 do task::spawn {
                     use core::rand::*;
                     let mut rng = rng();
-                    for old_iter::repeat(times) {
+                    for times.times {
                         sleep(&hl_loop_clone, rng.next() as uint % maxms);
                     }
                     ch.send(());
@@ -226,7 +225,7 @@ mod test {
             }
         }
 
-        for old_iter::repeat(repeat * spec.len()) {
+        for (repeat * spec.len()).times {
             po.recv()
         }
     }
@@ -244,7 +243,7 @@ mod test {
         let mut failures = 0;
         let hl_loop = uv::global_loop::get();
 
-        for old_iter::repeat(times as uint) {
+        for (times as uint).times {
             task::yield();
 
             let expected = rand::rng().gen_str(16u);
@@ -273,7 +272,7 @@ mod test {
         let mut failures = 0;
         let hl_loop = uv::global_loop::get();
 
-        for old_iter::repeat(times as uint) {
+        for (times as uint).times {
             let mut rng = rand::rng();
             let expected = Cell(rng.gen_str(16u));
             let (test_po, test_ch) = stream::<~str>();

--- a/src/libstd/uv_global_loop.rs
+++ b/src/libstd/uv_global_loop.rs
@@ -215,7 +215,7 @@ mod test {
         let (exit_po, exit_ch) = stream::<()>();
         let exit_ch = SharedChan::new(exit_ch);
         let cycles = 5000u;
-        for old_iter::repeat(cycles) {
+        for cycles.times {
             let exit_ch_clone = exit_ch.clone();
             task::spawn_sched(task::ManualThreads(1u), || {
                 let hl_loop = &get_gl();
@@ -223,7 +223,7 @@ mod test {
                 exit_ch_clone.send(());
             });
         };
-        for old_iter::repeat(cycles) {
+        for cycles.times {
             exit_po.recv();
         };
         debug!(~"test_stress_gl_uv_global_loop_high_level_global_timer"+

--- a/src/libstd/uv_iotask.rs
+++ b/src/libstd/uv_iotask.rs
@@ -284,7 +284,7 @@ fn test_uv_iotask_async() {
     // impl_uv_hl_async() runs have been called, at least.
     let (work_exit_po, work_exit_ch) = stream::<()>();
     let work_exit_ch = SharedChan::new(work_exit_ch);
-    for old_iter::repeat(7u) {
+    for 7u.times {
         let iotask_clone = iotask.clone();
         let work_exit_ch_clone = work_exit_ch.clone();
         do task::spawn_sched(task::ManualThreads(1u)) {
@@ -294,7 +294,7 @@ fn test_uv_iotask_async() {
             work_exit_ch_clone.send(());
         };
     };
-    for old_iter::repeat(7u) {
+    for 7u.times {
         debug!("waiting");
         work_exit_po.recv();
     };

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -30,7 +30,7 @@ fn main() {
 }
 
 fn run(repeat: int, depth: int) {
-    for old_iter::repeat(repeat as uint) {
+    for (repeat as uint).times {
         debug!("starting %.4f", precise_time_s());
         do task::try {
             recurse_or_fail(depth, None)

--- a/src/test/run-fail/extern-fail.rs
+++ b/src/test/run-fail/extern-fail.rs
@@ -37,7 +37,7 @@ fn count(n: uint) -> uint {
 }
 
 fn main() {
-    for old_iter::repeat(10u) {
+    for 10u.times {
         do task::spawn {
             let result = count(5u);
             debug!("result = %?", result);

--- a/src/test/run-pass/bitv-perf-test.rs
+++ b/src/test/run-pass/bitv-perf-test.rs
@@ -21,5 +21,5 @@ fn bitv_test() -> bool {
 }
 
 pub fn main() {
-    do old_iter::repeat(10000) || {bitv_test()};
+    do 10000.times || {bitv_test()};
 }

--- a/src/test/run-pass/extern-stress.rs
+++ b/src/test/run-pass/extern-stress.rs
@@ -34,7 +34,7 @@ fn count(n: uint) -> uint {
 }
 
 pub fn main() {
-    for old_iter::repeat(100u) {
+    for 100u.times {
         do task::spawn {
             assert!(count(5u) == 16u);
         };

--- a/src/test/run-pass/extern-yield.rs
+++ b/src/test/run-pass/extern-yield.rs
@@ -31,7 +31,7 @@ fn count(n: uint) -> uint {
 }
 
 pub fn main() {
-    for old_iter::repeat(10u) {
+    for 10u.times {
         do task::spawn {
             let result = count(5u);
             debug!("result = %?", result);


### PR DESCRIPTION
I don't have a strong opinion on the function vs. method, but there's no point in having both. I'd like to make a `repeat` adaptor like Python/Haskell for turning a value into an infinite stream of the value, so this has to at least be renamed.
