### PR TITLE
Only look for `main` at the crate level

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -225,6 +225,8 @@ pub fn compile_rest(sess: Session,
         time(time_passes, ~"resolution", ||
              middle::resolve::resolve_crate(sess, lang_items, crate));
 
+    time(time_passes, ~"looking for entry point", || middle::entry::find_entry_point(sess, crate));
+
     let freevars = time(time_passes, ~"freevar finding", ||
         freevars::annotate_freevars(def_map, crate));
 

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -225,7 +225,8 @@ pub fn compile_rest(sess: Session,
         time(time_passes, ~"resolution", ||
              middle::resolve::resolve_crate(sess, lang_items, crate));
 
-    time(time_passes, ~"looking for entry point", || middle::entry::find_entry_point(sess, crate));
+    time(time_passes, ~"looking for entry point",
+         || middle::entry::find_entry_point(sess, crate, ast_map));
 
     let freevars = time(time_passes, ~"freevar finding", ||
         freevars::annotate_freevars(def_map, crate));

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -1,0 +1,119 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use driver::session;
+use driver::session::Session;
+use syntax::parse::token::special_idents;
+use syntax::ast::{crate, node_id, item, item_fn};
+use syntax::codemap::span;
+use syntax::visit::{default_visitor, mk_vt, vt, Visitor, visit_crate, visit_item};
+use syntax::attr::{attrs_contains_name};
+
+struct EntryContext {
+    session: Session,
+
+    // The function that has attribute named 'main'
+    attr_main_fn: Option<(node_id, span)>,
+
+    // The functions that could be main functions
+    main_fns: ~[Option<(node_id, span)>],
+
+    // The function that has the attribute 'start' on it
+    start_fn: Option<(node_id, span)>,
+}
+
+type EntryVisitor = vt<@mut EntryContext>;
+
+pub fn find_entry_point(session: Session, crate: @crate) {
+
+    let ctxt = @mut EntryContext {
+        session: session,
+        attr_main_fn: None,
+        main_fns: ~[],
+        start_fn: None,
+    };
+
+    visit_crate(crate, ctxt, mk_vt(@Visitor {
+        visit_item: |item, ctxt, visitor| find_item(item, ctxt, visitor),
+        .. *default_visitor()
+    }));
+
+    check_duplicate_main(ctxt);
+}
+
+fn find_item(item: @item, ctxt: @mut EntryContext, visitor: EntryVisitor) {
+    match item.node {
+        item_fn(*) => {
+            // If this is the main function, we must record it in the
+            // session.
+
+            // FIXME #4404 android JNI hacks
+            if !*ctxt.session.building_library ||
+                ctxt.session.targ_cfg.os == session::os_android {
+
+                if ctxt.attr_main_fn.is_none() &&
+                    item.ident == special_idents::main {
+
+                    ctxt.main_fns.push(Some((item.id, item.span)));
+                }
+
+                if attrs_contains_name(item.attrs, ~"main") {
+                    if ctxt.attr_main_fn.is_none() {
+                        ctxt.attr_main_fn = Some((item.id, item.span));
+                    } else {
+                        ctxt.session.span_err(
+                            item.span,
+                            ~"multiple 'main' functions");
+                    }
+                }
+
+                if attrs_contains_name(item.attrs, ~"start") {
+                    if ctxt.start_fn.is_none() {
+                        ctxt.start_fn = Some((item.id, item.span));
+                    } else {
+                        ctxt.session.span_err(
+                            item.span,
+                            ~"multiple 'start' functions");
+                    }
+                }
+            }
+        }
+        _ => ()
+    }
+
+    visit_item(item, ctxt, visitor);
+}
+
+// main function checking
+//
+// be sure that there is only one main function
+fn check_duplicate_main(ctxt: @mut EntryContext) {
+    let this = &mut *ctxt;
+    if this.attr_main_fn.is_none() && this.start_fn.is_none() {
+        if this.main_fns.len() >= 1u {
+            let mut i = 1u;
+            while i < this.main_fns.len() {
+                let (_, dup_main_span) = this.main_fns[i].unwrap();
+                this.session.span_err(
+                    dup_main_span,
+                    ~"multiple 'main' functions");
+                i += 1;
+            }
+            *this.session.entry_fn = this.main_fns[0];
+            *this.session.entry_type = Some(session::EntryMain);
+        }
+    } else if !this.start_fn.is_none() {
+        *this.session.entry_fn = this.start_fn;
+        *this.session.entry_type = Some(session::EntryStart);
+    } else {
+        *this.session.entry_fn = this.attr_main_fn;
+        *this.session.entry_type = Some(session::EntryMain);
+    }
+}

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use driver::session;
 use driver::session::Session;
 use metadata::csearch::{each_path, get_trait_method_def_ids};
 use metadata::csearch::get_method_name_and_self_ty;
@@ -794,11 +793,6 @@ pub fn Resolver(session: Session,
 
         namespaces: ~[ TypeNS, ValueNS ],
 
-        attr_main_fn: None,
-        main_fns: ~[],
-
-        start_fn: None,
-
         def_map: @mut HashMap::new(),
         export_map2: @mut HashMap::new(),
         trait_map: HashMap::new(),
@@ -856,15 +850,6 @@ pub struct Resolver {
     // The four namespaces.
     namespaces: ~[Namespace],
 
-    // The function that has attribute named 'main'
-    attr_main_fn: Option<(node_id, span)>,
-
-    // The functions that could be main functions
-    main_fns: ~[Option<(node_id, span)>],
-
-    // The function that has the attribute 'start' on it
-    start_fn: Option<(node_id, span)>,
-
     def_map: DefMap,
     export_map2: ExportMap2,
     trait_map: TraitMap,
@@ -885,7 +870,6 @@ pub impl Resolver {
         self.resolve_crate();
         self.session.abort_if_errors();
 
-        self.check_duplicate_main();
         self.check_for_unused_imports_if_necessary();
     }
 
@@ -3545,40 +3529,6 @@ pub impl Resolver {
             }
 
             item_fn(ref fn_decl, _, _, ref generics, ref block) => {
-                // If this is the main function, we must record it in the
-                // session.
-
-                // FIXME #4404 android JNI hacks
-                if !*self.session.building_library ||
-                    self.session.targ_cfg.os == session::os_android {
-
-                    if self.attr_main_fn.is_none() &&
-                           item.ident == special_idents::main {
-
-                        self.main_fns.push(Some((item.id, item.span)));
-                    }
-
-                    if attrs_contains_name(item.attrs, ~"main") {
-                        if self.attr_main_fn.is_none() {
-                            self.attr_main_fn = Some((item.id, item.span));
-                        } else {
-                            self.session.span_err(
-                                    item.span,
-                                    ~"multiple 'main' functions");
-                        }
-                    }
-
-                    if attrs_contains_name(item.attrs, ~"start") {
-                        if self.start_fn.is_none() {
-                            self.start_fn = Some((item.id, item.span));
-                        } else {
-                            self.session.span_err(
-                                    item.span,
-                                    ~"multiple 'start' functions");
-                        }
-                    }
-                }
-
                 self.resolve_function(OpaqueFunctionRibKind,
                                       Some(fn_decl),
                                       HasTypeParameters
@@ -5106,35 +5056,6 @@ pub impl Resolver {
                     fmt!("cannot use `ref` binding mode with %s",
                          descr));
             }
-        }
-    }
-
-    //
-    // main function checking
-    //
-    // be sure that there is only one main function
-    //
-    fn check_duplicate_main(@mut self) {
-        let this = &mut *self;
-        if this.attr_main_fn.is_none() && this.start_fn.is_none() {
-            if this.main_fns.len() >= 1u {
-                let mut i = 1u;
-                while i < this.main_fns.len() {
-                    let (_, dup_main_span) = this.main_fns[i].unwrap();
-                    this.session.span_err(
-                        dup_main_span,
-                        ~"multiple 'main' functions");
-                    i += 1;
-                }
-                *this.session.entry_fn = this.main_fns[0];
-                *this.session.entry_type = Some(session::EntryMain);
-            }
-        } else if !this.start_fn.is_none() {
-            *this.session.entry_fn = this.start_fn;
-            *this.session.entry_type = Some(session::EntryStart);
-        } else {
-            *this.session.entry_fn = this.attr_main_fn;
-            *this.session.entry_type = Some(session::EntryMain);
         }
     }
 

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -387,7 +387,7 @@ fn check_for_entry_fn(ccx: @mut CrateCtxt) {
               Some(session::EntryStart) => check_start_fn_ty(ccx, id, sp),
               None => tcx.sess.bug(~"entry function without a type")
           },
-          None => tcx.sess.err(~"entry function not found")
+          None => tcx.sess.bug(~"type checking without entry function")
         }
     }
 }

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -96,6 +96,7 @@ pub mod middle {
     pub mod lang_items;
     pub mod privacy;
     pub mod moves;
+    pub mod entry;
 }
 
 pub mod front {

--- a/src/test/compile-fail/elided-test.rs
+++ b/src/test/compile-fail/elided-test.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: entry function not found
+// error-pattern: main function not found
 
 // Since we're not compiling a test runner this function should be elided
 // and the build will fail because main doesn't exist

--- a/src/test/compile-fail/issue-2995.rs
+++ b/src/test/compile-fail/issue-2995.rs
@@ -11,3 +11,5 @@
 fn bad (p: *int) {
     let _q: &int = p as &int; //~ ERROR non-scalar cast
 }
+
+fn main() { }

--- a/src/test/compile-fail/main-wrong-location.rs
+++ b/src/test/compile-fail/main-wrong-location.rs
@@ -8,10 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
-}
-
-mod foo {
-    fn main() { //~ ERROR multiple 'main' functions
-    }
+mod m {
+    // An inferred main entry point (that doesn't use #[main])
+    // must appear at the top of the crate
+    fn main() { } //~ NOTE here is a function named 'main'
 }

--- a/src/test/compile-fail/missing-main.rs
+++ b/src/test/compile-fail/missing-main.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:entry function not found
+// error-pattern:main function not found
 fn mian() { }

--- a/src/test/compile-fail/tag-variant-disr-dup.rs
+++ b/src/test/compile-fail/tag-variant-disr-dup.rs
@@ -19,3 +19,5 @@ enum color {
     black = 0x000000,
     white = 0x000000,
 }
+
+fn main() { }

--- a/src/test/run-pass/dupe-first-attr.rc
+++ b/src/test/run-pass/dupe-first-attr.rc
@@ -25,3 +25,5 @@ mod hello;
 
 #[cfg(target_os = "android")]
 mod hello;
+
+fn main() { }

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -22,6 +22,7 @@ mod rusti {
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "freebsd")]
 mod m {
+    #[main]
     #[cfg(target_arch = "x86")]
     pub fn main() {
         unsafe {
@@ -30,6 +31,7 @@ mod m {
         }
     }
 
+    #[main]
     #[cfg(target_arch = "x86_64")]
     pub fn main() {
         unsafe {
@@ -41,6 +43,7 @@ mod m {
 
 #[cfg(target_os = "win32")]
 mod m {
+    #[main]
     #[cfg(target_arch = "x86")]
     pub fn main() {
         unsafe {
@@ -52,6 +55,7 @@ mod m {
 
 #[cfg(target_os = "android")]
 mod m {
+    #[main]
     #[cfg(target_arch = "arm")]
     pub fn main() {
         unsafe {


### PR DESCRIPTION
r? @ILyoan

This pulls all the logic for discovering the crate entry point into a new pass (out of resolve and typeck), then changes it so that main is only looked for at the crate level (`#[main]` can still be used anywhere).

I don't understand the special android logic here and worry that I may have broken it.
