### PR TITLE
The null case of a nullable-poiner enum might not be nullary.

### DIFF
--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -409,8 +409,8 @@ pub fn num_args(r: &Repr, discr: int) -> uint {
             st.fields.len() - (if dtor { 1 } else { 0 })
         }
         General(ref cases) => cases[discr as uint].fields.len() - 1,
-        NullablePointer{ nonnull: ref nonnull, nndiscr, _ } => {
-            if discr == nndiscr { nonnull.fields.len() } else { 0 }
+        NullablePointer{ nonnull: ref nonnull, nndiscr, nullfields: ref nullfields, _ } => {
+            if discr == nndiscr { nonnull.fields.len() } else { nullfields.len() }
         }
     }
 }

--- a/src/test/run-pass/issue-6117.rs
+++ b/src/test/run-pass/issue-6117.rs
@@ -1,0 +1,16 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    match Left(@17) {
+        Right(()) => {}
+        _ => {}
+    }
+}


### PR DESCRIPTION
Cases like `Either<@int,()>` have a null case with at most one value but
a nonzero number of fields; if we misreport this, then bad things can
happen inside of, for example, pattern matching.

Closes #6117.
