### PR TITLE
clear *everything* from the tmp directory

### DIFF
--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -48,7 +48,7 @@ clean-misc:
 	$(Q)rm -f $(RUSTLLVM_LIB_OBJS) $(RUSTLLVM_OBJS_OBJS) $(RUSTLLVM_DEF)
 	$(Q)rm -Rf $(DOCS)
 	$(Q)rm -Rf $(GENERATED)
-	$(Q)rm -f tmp/*.log tmp/*.rc tmp/*.rs tmp/*.ok
+	$(Q)rm -f tmp/*
 	$(Q)rm -Rf rust-stage0-*.tar.bz2 $(PKG_NAME)-*.tar.gz dist
 	$(Q)rm -Rf $(foreach ext, \
                  html aux cp fn ky log pdf pg toc tp vr cps, \


### PR DESCRIPTION
The `.tmp` files were missed before. I don't think there's a need to use
*.ext instead of just *.
