### PR TITLE
Remove drop block support

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -82,14 +82,13 @@ pub fn load_props(testfile: &Path) -> TestProps {
 }
 
 pub fn is_test_ignored(config: config, testfile: &Path) -> bool {
-    let mut found = false;
     for iter_header(testfile) |ln| {
         if parse_name_directive(ln, ~"xfail-test") { return true; }
         if parse_name_directive(ln, xfail_target()) { return true; }
         if config.mode == common::mode_pretty &&
            parse_name_directive(ln, ~"xfail-pretty") { return true; }
     };
-    return found;
+    return true;
 
     fn xfail_target() -> ~str {
         ~"xfail-" + str::from_slice(os::SYSNAME)

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -106,7 +106,7 @@ fn run_rpass_test(config: config, props: TestProps, testfile: &Path) {
             fatal_ProcRes(~"test run failed!", ProcRes);
         }
     } else {
-        let mut ProcRes = jit_test(config, props, testfile);
+        let ProcRes = jit_test(config, props, testfile);
 
         if ProcRes.status != 0 { fatal_ProcRes(~"jit failed!", ProcRes); }
     }

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -63,7 +63,6 @@ they contained the following prologue:
 #[warn(vecs_implicitly_copyable)];
 #[deny(non_camel_case_types)];
 #[allow(deprecated_mutable_fields)];
-#[allow(deprecated_drop)];
 
 // Make core testable by not duplicating lang items. See #2912
 #[cfg(test)] extern mod realcore(name = "core", vers = "0.7-pre");

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -100,7 +100,6 @@ pub static tag_mod_impl_trait: uint = 0x47u;
   different tags.
  */
 pub static tag_item_impl_method: uint = 0x48u;
-pub static tag_item_dtor: uint = 0x49u;
 pub static tag_item_trait_method_self_ty: uint = 0x4b;
 pub static tag_item_trait_method_self_ty_region: uint = 0x4c;
 

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -230,13 +230,6 @@ pub fn get_impl_method(cstore: @mut cstore::CStore,
     decoder::get_impl_method(cstore.intr, cdata, def.node, mname)
 }
 
-/* If def names a class with a dtor, return it. Otherwise, return none. */
-pub fn struct_dtor(cstore: @mut cstore::CStore, def: ast::def_id)
-    -> Option<ast::def_id> {
-    let cdata = cstore::get_crate_data(cstore, def.crate);
-    decoder::struct_dtor(cdata, def.node)
-}
-
 pub fn get_item_visibility(cstore: @mut cstore::CStore,
                            def_id: ast::def_id)
                         -> ast::visibility {

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -445,22 +445,6 @@ pub fn get_impl_method(intr: @ident_interner, cdata: cmd, id: ast::node_id,
     found.get()
 }
 
-pub fn struct_dtor(cdata: cmd, id: ast::node_id) -> Option<ast::def_id> {
-    let items = reader::get_doc(reader::Doc(cdata.data), tag_items);
-    let mut found = None;
-    let cls_items = match maybe_find_item(id, items) {
-            Some(it) => it,
-            None     => fail!(fmt!("struct_dtor: class id not found \
-              when looking up dtor for %d", id))
-    };
-    for reader::tagged_docs(cls_items, tag_item_dtor) |doc| {
-         let doc1 = reader::get_doc(doc, tag_def_id);
-         let did = reader::with_doc_data(doc1, |d| parse_def_id(d));
-         found = Some(translate_def_id(cdata, did));
-    };
-    found
-}
-
 pub fn get_symbol(data: @~[u8], id: ast::node_id) -> ~str {
     return item_symbol(lookup_item(id, data));
 }

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -765,26 +765,6 @@ fn encode_info_for_item(ecx: @EncodeContext, ebml_w: &writer::Encoder,
            class itself */
         let idx = encode_info_for_struct(ecx, ebml_w, path,
                                          struct_def.fields, index);
-        /* Encode the dtor */
-        for struct_def.dtor.each |dtor| {
-            index.push(entry {val: dtor.node.id, pos: ebml_w.writer.tell()});
-          encode_info_for_ctor(ecx,
-                               ebml_w,
-                               dtor.node.id,
-                               ecx.tcx.sess.ident_of(
-                                   *ecx.tcx.sess.str_of(item.ident) +
-                                   ~"_dtor"),
-                               path,
-                               if generics.ty_params.len() > 0u {
-                                   Some(ii_dtor(copy *dtor,
-                                                item.ident,
-                                                copy *generics,
-                                                local_def(item.id))) }
-                               else {
-                                   None
-                               },
-                               generics);
-        }
 
         /* Index the class*/
         add_to_index();
@@ -816,13 +796,6 @@ fn encode_info_for_item(ecx: @EncodeContext, ebml_w: &writer::Encoder,
         encode_name(ecx, ebml_w, item.ident);
         encode_path(ecx, ebml_w, path, ast_map::path_name(item.ident));
         encode_region_param(ecx, ebml_w, item);
-        /* Encode the dtor */
-        /* Encode id for dtor */
-        for struct_def.dtor.each |dtor| {
-            do ebml_w.wr_tag(tag_item_dtor) {
-                encode_def_id(ebml_w, local_def(dtor.node.id));
-            }
-        };
 
         /* Encode def_ids for each field and method
          for methods, write all the stuff get_trait_method

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -327,15 +327,6 @@ fn simplify_ast(ii: &ast::inlined_item) -> ast::inlined_item {
       ast::ii_foreign(i) => {
         ast::ii_foreign(fld.fold_foreign_item(i))
       }
-      ast::ii_dtor(ref dtor, nm, ref tps, parent_id) => {
-        let dtor_body = fld.fold_block(&dtor.node.body);
-        ast::ii_dtor(
-            codemap::spanned {
-                node: ast::struct_dtor_ { body: dtor_body,
-                                          .. /*bad*/copy (*dtor).node },
-                .. (/*bad*/copy *dtor) },
-            nm, /*bad*/copy *tps, parent_id)
-      }
     }
 }
 
@@ -362,23 +353,6 @@ fn renumber_ast(xcx: @ExtendedDecodeContext, ii: ast::inlined_item)
       }
       ast::ii_foreign(i) => {
         ast::ii_foreign(fld.fold_foreign_item(i))
-      }
-      ast::ii_dtor(ref dtor, nm, ref generics, parent_id) => {
-        let dtor_body = fld.fold_block(&dtor.node.body);
-        let dtor_attrs = fld.fold_attributes(/*bad*/copy (*dtor).node.attrs);
-        let new_generics = fold::fold_generics(generics, fld);
-        let dtor_id = fld.new_id((*dtor).node.id);
-        let new_parent = xcx.tr_def_id(parent_id);
-        let new_self = fld.new_id((*dtor).node.self_id);
-        ast::ii_dtor(
-            codemap::spanned {
-                node: ast::struct_dtor_ { id: dtor_id,
-                                          attrs: dtor_attrs,
-                                          self_id: new_self,
-                                          body: dtor_body },
-                .. (/*bad*/copy *dtor)
-            },
-            nm, new_generics, new_parent)
       }
      }
 }

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -629,8 +629,7 @@ fn check_loans_in_fn(fk: &visit::fn_kind,
 
     let declared_purity, src;
     match *fk {
-        visit::fk_item_fn(*) | visit::fk_method(*) |
-        visit::fk_dtor(*) => {
+        visit::fk_item_fn(*) | visit::fk_method(*) => {
             declared_purity = ty::ty_fn_purity(fty);
             src = id;
         }
@@ -658,8 +657,7 @@ fn check_loans_in_fn(fk: &visit::fn_kind,
                     // inherits the fn_args from enclosing ctxt
                 }
                 visit::fk_anon(*) | visit::fk_fn_block(*) |
-                visit::fk_method(*) | visit::fk_item_fn(*) |
-                visit::fk_dtor(*) => {
+                visit::fk_method(*) | visit::fk_item_fn(*) => {
                     let mut fn_args = ~[];
                     for decl.inputs.each |input| {
                         // For the purposes of purity, only consider function-

--- a/src/librustc/middle/borrowck/gather_loans.rs
+++ b/src/librustc/middle/borrowck/gather_loans.rs
@@ -104,8 +104,7 @@ fn req_loans_in_fn(fk: &visit::fn_kind,
 
     match *fk {
         visit::fk_anon(*) | visit::fk_fn_block(*) => {}
-        visit::fk_item_fn(*) | visit::fk_method(*) |
-        visit::fk_dtor(*) => {
+        visit::fk_item_fn(*) | visit::fk_method(*) => {
             self.item_ub = body.node.id;
         }
     }

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -153,17 +153,6 @@ fn check_item(item: @item, cx: Context, visitor: visit::vt<Context>) {
                     }
                 }
             }
-            item_struct(struct_def, _) => {
-                match struct_def.dtor {
-                    None => {}
-                    Some(ref dtor) => {
-                        let struct_did = def_id { crate: 0, node: item.id };
-                        check_struct_safe_for_destructor(cx,
-                                                         dtor.span,
-                                                         struct_did);
-                    }
-                }
-            }
             _ => {}
         }
     }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -57,7 +57,6 @@ pub enum lint {
     type_limits,
     default_methods,
     deprecated_mutable_fields,
-    deprecated_drop,
     unused_unsafe,
 
     managed_heap_memory,
@@ -207,13 +206,6 @@ pub fn get_lint_dict() -> LintDict {
          LintSpec {
             lint: deprecated_mutable_fields,
             desc: "deprecated mutable fields in structures",
-            default: deny
-        }),
-
-        (~"deprecated_drop",
-         LintSpec {
-            lint: deprecated_drop,
-            desc: "deprecated \"drop\" notation for the destructor",
             default: deny
         }),
 
@@ -463,7 +455,6 @@ fn check_item(i: @ast::item, cx: ty::ctxt) {
     check_item_type_limits(cx, i);
     check_item_default_methods(cx, i);
     check_item_deprecated_mutable_fields(cx, i);
-    check_item_deprecated_drop(cx, i);
     check_item_unused_unsafe(cx, i);
     check_item_unused_mut(cx, i);
 }
@@ -661,26 +652,6 @@ fn check_item_deprecated_mutable_fields(cx: ty::ctxt, item: @ast::item) {
                                           ~"mutable fields are deprecated");
                     }
                     ast::named_field(*) | ast::unnamed_field => {}
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
-fn check_item_deprecated_drop(cx: ty::ctxt, item: @ast::item) {
-    match item.node {
-        ast::item_struct(struct_def, _) => {
-            match struct_def.dtor {
-                None => {}
-                Some(ref dtor) => {
-                    cx.sess.span_lint(deprecated_drop,
-                                      item.id,
-                                      item.id,
-                                      dtor.span,
-                                      ~"`drop` notation for destructors is \
-                                        deprecated; implement the `Drop` \
-                                        trait instead");
                 }
             }
         }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -117,7 +117,7 @@ use syntax::ast::*;
 use syntax::codemap::span;
 use syntax::parse::token::special_idents;
 use syntax::print::pprust::{expr_to_str, block_to_str};
-use syntax::visit::{fk_anon, fk_dtor, fk_fn_block, fk_item_fn, fk_method};
+use syntax::visit::{fk_anon, fk_fn_block, fk_item_fn, fk_method};
 use syntax::visit::{vt};
 use syntax::{visit, ast_util};
 
@@ -439,9 +439,6 @@ fn visit_fn(fk: &visit::fn_kind,
                 }
                 sty_static => {}
             }
-        }
-        fk_dtor(_, _, self_id, _) => {
-            fn_maps.add_variable(Arg(self_id, special_idents::self_));
         }
         fk_item_fn(*) | fk_anon(*) | fk_fn_block(*) => {}
     }

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -438,8 +438,7 @@ pub fn resolve_fn(fk: &visit::fn_kind,
                   cx: ctxt,
                   visitor: visit::vt<ctxt>) {
     let fn_cx = match *fk {
-        visit::fk_item_fn(*) | visit::fk_method(*) |
-        visit::fk_dtor(*) => {
+        visit::fk_item_fn(*) | visit::fk_method(*) => {
             // Top-level functions are a root scope.
             ctxt {parent: Some(id),.. cx}
         }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -47,7 +47,7 @@ use syntax::ast::{named_field, ne, neg, node_id, pat, pat_enum, pat_ident};
 use syntax::ast::{Path, pat_lit, pat_range, pat_struct};
 use syntax::ast::{prim_ty, private, provided};
 use syntax::ast::{public, required, rem, self_ty_, shl, shr, stmt_decl};
-use syntax::ast::{struct_dtor, struct_field, struct_variant_kind};
+use syntax::ast::{struct_field, struct_variant_kind};
 use syntax::ast::{sty_static, subtract, trait_ref, tuple_variant_kind, Ty};
 use syntax::ast::{ty_bool, ty_char, ty_f, ty_f32, ty_f64, ty_float, ty_i};
 use syntax::ast::{ty_i16, ty_i32, ty_i64, ty_i8, ty_int, TyParam, ty_path};
@@ -3512,7 +3512,6 @@ pub impl Resolver {
                 self.resolve_struct(item.id,
                                     generics,
                                     struct_def.fields,
-                                    &struct_def.dtor,
                                     visitor);
             }
 
@@ -3770,7 +3769,6 @@ pub impl Resolver {
                       id: node_id,
                       generics: &Generics,
                       fields: &[@struct_field],
-                      optional_destructor: &Option<struct_dtor>,
                       visitor: ResolveVisitor) {
         // If applicable, create a rib for the type parameters.
         do self.with_type_parameter_rib(HasTypeParameters
@@ -3783,23 +3781,6 @@ pub impl Resolver {
             // Resolve fields.
             for fields.each |field| {
                 self.resolve_type(field.node.ty, visitor);
-            }
-
-            // Resolve the destructor, if applicable.
-            match *optional_destructor {
-                None => {
-                    // Nothing to do.
-                }
-                Some(ref destructor) => {
-                    self.resolve_function(NormalRibKind,
-                                          None,
-                                          NoTypeParameters,
-                                          &destructor.node.body,
-                                          HasSelfBinding
-                                            ((*destructor).node.self_id,
-                                             true),
-                                          visitor);
-                }
             }
         }
     }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -983,9 +983,6 @@ pub fn create_function(fcx: fn_ctxt) -> @Metadata<SubProgramMetadata> {
                                        expected an expr_fn_block here")
         }
       }
-      ast_map::node_dtor(_, _, did, _) => {
-        ((dbg_cx.names)(~"dtor"), ast_util::dtor_ty(), did.node)
-      }
       _ => fcx.ccx.sess.bug(~"create_function: unexpected \
                               sort of node")
     };

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -118,10 +118,6 @@ pub fn maybe_instantiate_inline(ccx: @CrateContext, fn_id: ast::def_id,
             }
             local_def(mth.id)
           }
-          csearch::found(ast::ii_dtor(ref dtor, _, _, _)) => {
-              ccx.external.insert(fn_id, Some((*dtor).node.id));
-              local_def((*dtor).node.id)
-          }
         }
       }
     }

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -13,7 +13,7 @@ use driver::session;
 use lib::llvm::ValueRef;
 use middle::trans::base::{get_insn_ctxt};
 use middle::trans::base::{set_inline_hint_if_appr, set_inline_hint};
-use middle::trans::base::{trans_enum_variant, trans_struct_dtor};
+use middle::trans::base::{trans_enum_variant};
 use middle::trans::base::{trans_fn, decl_internal_cdecl_fn};
 use middle::trans::base::{get_item_val, no_self};
 use middle::trans::base;
@@ -35,7 +35,6 @@ use syntax::ast_map;
 use syntax::ast_map::path_name;
 use syntax::ast_util::local_def;
 use syntax::opt_vec;
-use syntax::parse::token::special_idents;
 use syntax::abi::AbiSet;
 
 pub fn monomorphic_fn(ccx: @CrateContext,
@@ -116,8 +115,6 @@ pub fn monomorphic_fn(ccx: @CrateContext,
         // Foreign externs don't have to be monomorphized.
         return (get_item_val(ccx, fn_id.node), true);
       }
-      ast_map::node_dtor(_, dtor, _, pt) =>
-          (pt, special_idents::dtor, dtor.span),
       ast_map::node_trait_method(@ast::provided(m), _, pt) => {
         (pt, m.ident, m.span)
       }
@@ -242,16 +239,6 @@ pub fn monomorphic_fn(ccx: @CrateContext,
 
         meth::trans_method(ccx, pt, mth, psubsts, None, d, impl_did);
         d
-      }
-      ast_map::node_dtor(_, dtor, _, pt) => {
-        let parent_id = match ty::ty_to_def_id(ty::node_id_to_type(ccx.tcx,
-                                              dtor.node.self_id)) {
-                Some(did) => did,
-                None      => ccx.sess.span_bug(dtor.span, ~"Bad self ty in \
-                                                            dtor")
-        };
-        trans_struct_dtor(ccx, /*bad*/copy *pt, &dtor.node.body,
-          dtor.node.id, psubsts, Some(hash_id), parent_id)
       }
       ast_map::node_trait_method(@ast::provided(mth), _, pt) => {
         let d = mk_lldecl();

--- a/src/librustc/middle/trans/reachable.rs
+++ b/src/librustc/middle/trans/reachable.rs
@@ -124,17 +124,9 @@ fn traverse_public_item(cx: &ctx, item: @item) {
             }
         }
       }
-      item_struct(ref struct_def, ref generics) => {
+      item_struct(ref struct_def, _) => {
         for struct_def.ctor_id.each |&ctor_id| {
             cx.rmap.insert(ctor_id);
-        }
-        for struct_def.dtor.each |dtor| {
-            cx.rmap.insert(dtor.node.id);
-            if generics.ty_params.len() > 0u ||
-                attr::find_inline_attr(dtor.node.attrs) != attr::ia_none
-            {
-                traverse_inline_body(cx, &dtor.node.body);
-            }
         }
       }
       item_ty(t, _) => {
@@ -239,9 +231,6 @@ fn traverse_all_resources_and_impls(cx: &ctx, crate_mod: &_mod) {
             visit_item: |i, cx, v| {
                 visit::visit_item(i, cx, v);
                 match i.node {
-                    item_struct(sdef, _) if sdef.dtor.is_some() => {
-                        traverse_public_item(cx, i);
-                    }
                     item_impl(*) => {
                         traverse_public_item(cx, i);
                     }

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -157,9 +157,6 @@ pub fn type_uses_for(ccx: @CrateContext, fn_id: def_id, n_tps: uint)
             for uint::range(0u, n_tps) |n| { cx.uses[n] |= flags;}
         }
       }
-      ast_map::node_dtor(_, ref dtor, _, _) => {
-        handle_body(cx, &dtor.node.body);
-      }
       ast_map::node_struct_ctor(*) => {
         // Similarly to node_variant, this monomorphized function just uses
         // the representations of all of its type parameters.

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3748,28 +3748,8 @@ pub impl DtorKind {
    Otherwise return none. */
 pub fn ty_dtor(cx: ctxt, struct_id: def_id) -> DtorKind {
     match cx.destructor_for_type.find(&struct_id) {
-        Some(&method_def_id) => return TraitDtor(method_def_id),
-        None => {}  // Continue.
-    }
-
-    if is_local(struct_id) {
-       match cx.items.find(&struct_id.node) {
-           Some(&ast_map::node_item(@ast::item {
-               node: ast::item_struct(@ast::struct_def { dtor: Some(ref dtor),
-                                                         _ },
-                                      _),
-               _
-           }, _)) =>
-               LegacyDtor(local_def((*dtor).node.id)),
-           _ =>
-               NoDtor
-       }
-    }
-    else {
-      match csearch::struct_dtor(cx.sess.cstore, struct_id) {
+        Some(&method_def_id) => TraitDtor(method_def_id),
         None => NoDtor,
-        Some(did) => LegacyDtor(did),
-      }
     }
 }
 
@@ -3817,11 +3797,6 @@ pub fn item_path(cx: ctxt, id: ast::def_id) -> ast_map::path {
           ast_map::node_variant(ref variant, _, path) => {
             vec::append_one(vec::from_slice(vec::init(*path)),
                             ast_map::path_name((*variant).node.name))
-          }
-
-          ast_map::node_dtor(_, _, _, path) => {
-            vec::append_one(/*bad*/copy *path, ast_map::path_name(
-                syntax::parse::token::special_idents::literally_dtor))
           }
 
           ast_map::node_struct_ctor(_, item, path) => {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -557,30 +557,7 @@ pub fn check_no_duplicate_fields(tcx: ty::ctxt,
     }
 }
 
-pub fn check_struct(ccx: @mut CrateCtxt,
-                    struct_def: @ast::struct_def,
-                    id: ast::node_id,
-                    span: span) {
-    let tcx = ccx.tcx;
-    let self_ty = ty::node_id_to_type(tcx, id);
-
-    for struct_def.dtor.each |dtor| {
-        let class_t = SelfInfo {
-            self_ty: self_ty,
-            self_id: dtor.node.self_id,
-            span: dtor.span,
-        };
-        // typecheck the dtor
-        let dtor_dec = ast_util::dtor_dec();
-        check_bare_fn(
-            ccx,
-            &dtor_dec,
-            &dtor.node.body,
-            dtor.node.id,
-            Some(class_t)
-        );
-    };
-
+pub fn check_struct(ccx: @mut CrateCtxt, id: ast::node_id, span: span) {
     // Check that the class is instantiable
     check_instantiable(ccx.tcx, span, id);
 }
@@ -623,8 +600,8 @@ pub fn check_item(ccx: @mut CrateCtxt, it: @ast::item) {
             }
         }
       }
-      ast::item_struct(struct_def, _) => {
-        check_struct(ccx, struct_def, it.id, it.span);
+      ast::item_struct(*) => {
+        check_struct(ccx, it.id, it.span);
       }
       ast::item_ty(t, ref generics) => {
         let tpt_ty = ty::node_id_to_type(ccx.tcx, it.id);

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -49,7 +49,6 @@ use syntax::ast::{RegionTyParamBound, TraitTyParamBound};
 use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_util::{local_def, split_trait_methods};
-use syntax::ast_util;
 use syntax::codemap::span;
 use syntax::codemap;
 use syntax::print::pprust::{path_to_str, self_ty_to_str};
@@ -896,30 +895,6 @@ pub fn convert_struct(ccx: &CrateCtxt,
                       tpt: ty::ty_param_bounds_and_ty,
                       id: ast::node_id) {
     let tcx = ccx.tcx;
-
-    for struct_def.dtor.each |dtor| {
-        let region_parameterization =
-            RegionParameterization::from_variance_and_generics(rp, generics);
-
-        // Write the dtor type
-        let t_dtor = ty::mk_bare_fn(
-            tcx,
-            astconv::ty_of_bare_fn(
-                ccx,
-                &type_rscope(region_parameterization),
-                ast::impure_fn,
-                AbiSet::Rust(),
-                &opt_vec::Empty,
-                &ast_util::dtor_dec()));
-        write_ty_to_tcx(tcx, dtor.node.id, t_dtor);
-        tcx.tcache.insert(local_def(dtor.node.id),
-                          ty_param_bounds_and_ty {
-                              generics: ty::Generics {
-                                  type_param_defs: tpt.generics.type_param_defs,
-                                  region_param: rp
-                              },
-                              ty: t_dtor});
-    };
 
     // Write the type of each of the members
     for struct_def.fields.each |f| {

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -332,13 +332,7 @@ fn fold_struct(
 /// what I actually want
 fn strip_struct_extra_stuff(item: @ast::item) -> @ast::item {
     let node = match copy item.node {
-        ast::item_struct(def, tys) => {
-            let def = @ast::struct_def {
-                dtor: None, // Remove the drop { } block
-                .. copy *def
-            };
-            ast::item_struct(def, tys)
-        }
+        ast::item_struct(def, tys) => ast::item_struct(def, tys),
         _ => fail!(~"not a struct")
     };
 

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -435,13 +435,6 @@ mod test {
     }
 
     #[test]
-    fn should_not_serialize_struct_drop_blocks() {
-        // All we care about are the fields
-        let doc = mk_doc(~"struct S { field: (), drop { } }");
-        assert!(!(&doc.cratemod().structs()[0].sig).get().contains("drop"));
-    }
-
-    #[test]
     fn should_not_serialize_struct_attrs() {
         // All we care about are the fields
         let doc = mk_doc(~"#[wut] struct S { field: () }");

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1158,6 +1158,7 @@ pub struct struct_field_ {
     kind: struct_field_kind,
     id: node_id,
     ty: @Ty,
+    attrs: ~[attribute],
 }
 
 pub type struct_field = spanned<struct_field_>;

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1174,10 +1174,7 @@ pub enum struct_field_kind {
 #[auto_decode]
 #[deriving(Eq)]
 pub struct struct_def {
-    fields: ~[@struct_field], /* fields */
-    /* (not including ctor or dtor) */
-    /* dtor is optional */
-    dtor: Option<struct_dtor>,
+    fields: ~[@struct_field], /* fields, not including ctor */
     /* ID of the constructor. This is only used for tuple- or enum-like
      * structs. */
     ctor_id: Option<node_id>
@@ -1230,18 +1227,6 @@ impl to_bytes::IterBytes for struct_mutability {
     }
 }
 
-pub type struct_dtor = spanned<struct_dtor_>;
-
-#[auto_encode]
-#[auto_decode]
-#[deriving(Eq)]
-pub struct struct_dtor_ {
-    id: node_id,
-    attrs: ~[attribute],
-    self_id: node_id,
-    body: blk,
-}
-
 #[auto_encode]
 #[auto_decode]
 #[deriving(Eq)]
@@ -1272,7 +1257,6 @@ pub enum inlined_item {
     ii_item(@item),
     ii_method(def_id /* impl id */, @method),
     ii_foreign(@foreign_item),
-    ii_dtor(struct_dtor, ident, Generics, def_id /* parent id */)
 }
 
 /* hold off on tests ... they appear in a later merge.

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -11,7 +11,7 @@
 use ast::*;
 use ast;
 use ast_util;
-use codemap::{span, dummy_sp, spanned};
+use codemap::{span, spanned};
 use parse::token;
 use visit;
 use opt_vec;

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -302,7 +302,6 @@ impl inlined_item_utils for inlined_item {
             ii_item(i) => /* FIXME (#2543) */ copy i.ident,
             ii_foreign(i) => /* FIXME (#2543) */ copy i.ident,
             ii_method(_, m) => /* FIXME (#2543) */ copy m.ident,
-            ii_dtor(_, nm, _, _) => /* FIXME (#2543) */ copy nm
         }
     }
 
@@ -311,7 +310,6 @@ impl inlined_item_utils for inlined_item {
             ii_item(i) => i.id,
             ii_foreign(i) => i.id,
             ii_method(_, m) => m.id,
-            ii_dtor(ref dtor, _, _, _) => (*dtor).node.id
         }
     }
 
@@ -320,10 +318,6 @@ impl inlined_item_utils for inlined_item {
             ii_item(i) => (v.visit_item)(i, e, v),
             ii_foreign(i) => (v.visit_foreign_item)(i, e, v),
             ii_method(_, m) => visit::visit_method_helper(m, e, v),
-            ii_dtor(/*bad*/ copy dtor, _, ref generics, parent_id) => {
-                visit::visit_struct_dtor_helper(dtor, generics,
-                                                parent_id, e, v);
-            }
         }
     }
 }
@@ -358,20 +352,6 @@ pub fn operator_prec(op: ast::binop) -> uint {
 /// Precedence of the `as` operator, which is a binary operator
 /// not appearing in the prior table.
 pub static as_prec: uint = 11u;
-
-pub fn dtor_ty() -> @ast::Ty {
-    @ast::Ty {id: 0, node: ty_nil, span: dummy_sp()}
-}
-
-pub fn dtor_dec() -> fn_decl {
-    let nil_t = dtor_ty();
-    // dtor has no args
-    ast::fn_decl {
-        inputs: ~[],
-        output: nil_t,
-        cf: return_val,
-    }
-}
 
 pub fn empty_generics() -> Generics {
     Generics {lifetimes: opt_vec::Empty,
@@ -457,12 +437,6 @@ pub fn id_visitor(vfn: @fn(node_id)) -> visit::vt<()> {
             vfn(id);
 
             match *fk {
-                visit::fk_dtor(generics, _, self_id, parent_id) => {
-                    visit_generics(generics);
-                    vfn(id);
-                    vfn(self_id);
-                    vfn(parent_id.node);
-                }
                 visit::fk_item_fn(_, generics, _, _) => {
                     visit_generics(generics);
                 }

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -431,7 +431,6 @@ impl gen_init for protocol {
             dummy_sp(),
             ast::struct_def {
                 fields: fields,
-                dtor: None,
                 ctor_id: None
             },
             cx.strip_bounds(&generics))

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -415,7 +415,8 @@ impl gen_init for protocol {
                             ast::struct_immutable,
                             ast::inherited),
                     id: cx.next_id(),
-                    ty: fty
+                    ty: fty,
+                    attrs: ~[],
                 },
                 span: dummy_sp()
             }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -222,9 +222,12 @@ pub fn noop_fold_item(i: @item, fld: @ast_fold) -> Option<@item> {
 
 fn noop_fold_struct_field(sf: @struct_field, fld: @ast_fold)
                        -> @struct_field {
+    let fold_attribute = |x| fold_attribute_(x, fld);
+
     @spanned { node: ast::struct_field_ { kind: copy sf.node.kind,
                                           id: sf.node.id,
-                                          ty: fld.fold_ty(sf.node.ty) },
+                                          ty: fld.fold_ty(sf.node.ty),
+                                          attrs: sf.node.attrs.map(|e| fold_attribute(*e)) },
                span: sf.span }
 }
 
@@ -309,6 +312,7 @@ fn fold_struct_field(f: @struct_field, fld: @ast_fold) -> @struct_field {
             kind: copy f.node.kind,
             id: fld.new_id(f.node.id),
             ty: fld.fold_ty(f.node.ty),
+            attrs: /* FIXME (#2543) */ copy f.node.attrs,
         },
         span: fld.new_span(f.span),
     }
@@ -757,6 +761,7 @@ impl ast_fold for AstFoldFns {
                 kind: copy sf.node.kind,
                 id: sf.node.id,
                 ty: (self as @ast_fold).fold_ty(sf.node.ty),
+                attrs: copy sf.node.attrs,
             },
             span: (self.new_span)(sf.span),
         }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -290,21 +290,8 @@ pub fn noop_fold_item_underscore(i: &item_, fld: @ast_fold) -> item_ {
 
 fn fold_struct_def(struct_def: @ast::struct_def, fld: @ast_fold)
                 -> @ast::struct_def {
-    let dtor = do struct_def.dtor.map |dtor| {
-        let dtor_body = fld.fold_block(&dtor.node.body);
-        let dtor_id   = fld.new_id(dtor.node.id);
-        spanned {
-            node: ast::struct_dtor_ {
-                body: dtor_body,
-                id: dtor_id,
-                .. copy dtor.node
-            },
-            span: copy dtor.span
-        }
-    };
     @ast::struct_def {
         fields: struct_def.fields.map(|f| fold_struct_field(*f, fld)),
-        dtor: dtor,
         ctor_id: struct_def.ctor_id.map(|cid| fld.new_id(*cid)),
     }
 }
@@ -655,22 +642,9 @@ fn noop_fold_variant(v: &variant_, fld: @ast_fold) -> variant_ {
             })
         }
         struct_variant_kind(struct_def) => {
-            let dtor = do struct_def.dtor.map |dtor| {
-                let dtor_body = fld.fold_block(&dtor.node.body);
-                let dtor_id   = fld.new_id(dtor.node.id);
-                spanned {
-                    node: ast::struct_dtor_ {
-                        body: dtor_body,
-                        id: dtor_id,
-                        .. copy dtor.node
-                    },
-                    .. copy *dtor
-                }
-            };
             kind = struct_variant_kind(@ast::struct_def {
                 fields: vec::map(struct_def.fields,
                                  |f| fld.fold_struct_field(*f)),
-                dtor: dtor,
                 ctor_id: struct_def.ctor_id.map(|c| fld.new_id(*c))
             })
         }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -24,7 +24,7 @@ use parse::token::{ident_interner, mk_ident_interner};
 use core::io;
 use core::option::{None, Option, Some};
 use core::path::Path;
-use core::result::{Err, Ok, Result};
+use core::result::{Err, Ok};
 
 pub mod lexer;
 pub mod parser;

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -18,7 +18,7 @@ removed.
 */
 
 
-use ast::{expr, expr_lit, lit_nil};
+use ast::{expr, expr_lit, lit_nil, attribute};
 use ast;
 use codemap::{span, respan};
 use parse::parser::Parser;
@@ -282,13 +282,13 @@ pub impl Parser {
         }
     }
 
-    fn try_parse_obsolete_priv_section(&self) -> bool {
+    fn try_parse_obsolete_priv_section(&self, attrs: ~[attribute]) -> bool {
         if self.is_keyword(&~"priv") && self.look_ahead(1) == token::LBRACE {
             self.obsolete(copy *self.span, ObsoletePrivSection);
             self.eat_keyword(&~"priv");
             self.bump();
             while *self.token != token::RBRACE {
-                self.parse_single_struct_field(ast::private);
+                self.parse_single_struct_field(ast::private, attrs);
             }
             self.bump();
             true

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -102,11 +102,6 @@ enum restriction {
     RESTRICT_NO_BAR_OR_DOUBLEBAR_OP,
 }
 
-//  So that we can distinguish a class dtor from other class members
-
-enum class_contents { dtor_decl(blk, ~[attribute], codemap::span),
-                      members(~[@struct_field]) }
-
 type arg_or_capture_item = Either<arg, ()>;
 type item_info = (ident, item_, Option<~[attribute]>);
 
@@ -3299,7 +3294,6 @@ pub impl Parser {
         }
 
         let mut fields: ~[@struct_field];
-        let mut the_dtor: Option<(blk, ~[attribute], codemap::span)> = None;
         let is_tuple_like;
 
         if self.eat(&token::LBRACE) {
@@ -3307,26 +3301,8 @@ pub impl Parser {
             is_tuple_like = false;
             fields = ~[];
             while *self.token != token::RBRACE {
-                match self.parse_struct_decl_field() {
-                  dtor_decl(ref blk, ref attrs, s) => {
-                      match the_dtor {
-                        Some((_, _, s_first)) => {
-                          self.span_note(s, fmt!("Duplicate destructor \
-                                     declaration for class %s",
-                                     *self.interner.get(class_name)));
-                          self.span_fatal(copy s_first, ~"First destructor \
-                                                          declared here");
-                        }
-                        None => {
-                          the_dtor = Some((copy *blk, copy *attrs, s));
-                        }
-                      }
-                  }
-                  members(mms) => {
-                    for mms.each |struct_field| {
-                        fields.push(*struct_field)
-                    }
-                  }
+                for self.parse_struct_decl_field().each |struct_field| {
+                    fields.push(*struct_field)
                 }
             }
             if fields.len() == 0 {
@@ -3365,19 +3341,12 @@ pub impl Parser {
             );
         }
 
-        let actual_dtor = do the_dtor.map |dtor| {
-            let (d_body, d_attrs, d_s) = copy *dtor;
-            codemap::spanned { node: ast::struct_dtor_ { id: self.get_id(),
-                                                     attrs: d_attrs,
-                                                     self_id: self.get_id(),
-                                                     body: d_body},
-                       span: d_s}};
         let _ = self.get_id();  // XXX: Workaround for crazy bug.
         let new_id = self.get_id();
         (class_name,
          item_struct(@ast::struct_def {
              fields: fields,
-             dtor: actual_dtor,
+             dtor: None,
              ctor_id: if is_tuple_like { Some(new_id) } else { None }
          }, generics),
          None)
@@ -3420,34 +3389,28 @@ pub impl Parser {
     }
 
     // parse an element of a struct definition
-    fn parse_struct_decl_field(&self) -> class_contents {
+    fn parse_struct_decl_field(&self) -> ~[@struct_field] {
 
         if self.try_parse_obsolete_priv_section() {
-            return members(~[]);
+            return ~[];
         }
 
-        let attrs = self.parse_outer_attributes();
+        // Need this to parse comments on fields.
+        let _attrs = self.parse_outer_attributes();
 
         if self.eat_keyword(&~"priv") {
-            return members(~[self.parse_single_struct_field(private)])
+            return ~[self.parse_single_struct_field(private)]
         }
 
         if self.eat_keyword(&~"pub") {
-           return members(~[self.parse_single_struct_field(public)]);
+           return ~[self.parse_single_struct_field(public)];
         }
 
         if self.try_parse_obsolete_struct_ctor() {
-            return members(~[]);
+            return ~[];
         }
 
-        if self.eat_keyword(&~"drop") {
-            let lo = self.last_span.lo;
-            let body = self.parse_block();
-            return dtor_decl(body, attrs, mk_sp(lo, self.last_span.hi))
-        }
-        else {
-           return members(~[self.parse_single_struct_field(inherited)]);
-        }
+        return ~[self.parse_single_struct_field(inherited)];
     }
 
     // parse visiility: PUB, PRIV, or nothing
@@ -3830,44 +3793,17 @@ pub impl Parser {
     // parse a structure-like enum variant definition
     // this should probably be renamed or refactored...
     fn parse_struct_def(&self) -> @struct_def {
-        let mut the_dtor: Option<(blk, ~[attribute], codemap::span)> = None;
         let mut fields: ~[@struct_field] = ~[];
         while *self.token != token::RBRACE {
-            match self.parse_struct_decl_field() {
-                dtor_decl(ref blk, ref attrs, s) => {
-                    match the_dtor {
-                        Some((_, _, s_first)) => {
-                            self.span_note(s, ~"duplicate destructor \
-                                                declaration");
-                            self.span_fatal(copy s_first,
-                                            ~"first destructor \
-                                              declared here");
-                        }
-                        None => {
-                            the_dtor = Some((copy *blk, copy *attrs, s));
-                        }
-                    }
-                }
-                members(mms) => {
-                    for mms.each |struct_field| {
-                        fields.push(*struct_field);
-                    }
-                }
+            for self.parse_struct_decl_field().each |struct_field| {
+                fields.push(*struct_field);
             }
         }
         self.bump();
-        let actual_dtor = do the_dtor.map |dtor| {
-            let (d_body, d_attrs, d_s) = copy *dtor;
-            codemap::spanned { node: ast::struct_dtor_ { id: self.get_id(),
-                                                     attrs: d_attrs,
-                                                     self_id: self.get_id(),
-                                                     body: d_body },
-                      span: d_s }
-        };
 
         return @ast::struct_def {
             fields: fields,
-            dtor: actual_dtor,
+            dtor: None,
             ctor_id: None
         };
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3346,7 +3346,6 @@ pub impl Parser {
         (class_name,
          item_struct(@ast::struct_def {
              fields: fields,
-             dtor: None,
              ctor_id: if is_tuple_like { Some(new_id) } else { None }
          }, generics),
          None)
@@ -3803,7 +3802,6 @@ pub impl Parser {
 
         return @ast::struct_def {
             fields: fields,
-            dtor: None,
             ctor_id: None
         };
     }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -305,50 +305,47 @@ pub fn is_bar(t: &Token) -> bool {
 pub mod special_idents {
     use ast::ident;
 
-    pub static underscore : ident = ident { repr: 0u, ctxt: 0};
-    pub static anon : ident = ident { repr: 1u, ctxt: 0};
-    pub static dtor : ident = ident { repr: 2u, ctxt: 0}; // 'drop', but that's
-                                                 // reserved
-    pub static invalid : ident = ident { repr: 3u, ctxt: 0}; // ''
-    pub static unary : ident = ident { repr: 4u, ctxt: 0};
-    pub static not_fn : ident = ident { repr: 5u, ctxt: 0};
-    pub static idx_fn : ident = ident { repr: 6u, ctxt: 0};
-    pub static unary_minus_fn : ident = ident { repr: 7u, ctxt: 0};
-    pub static clownshoes_extensions : ident = ident { repr: 8u, ctxt: 0};
+    pub static underscore : ident = ident { repr: 0, ctxt: 0};
+    pub static anon : ident = ident { repr: 1, ctxt: 0};
+    pub static invalid : ident = ident { repr: 2, ctxt: 0}; // ''
+    pub static unary : ident = ident { repr: 3, ctxt: 0};
+    pub static not_fn : ident = ident { repr: 4, ctxt: 0};
+    pub static idx_fn : ident = ident { repr: 5, ctxt: 0};
+    pub static unary_minus_fn : ident = ident { repr: 6, ctxt: 0};
+    pub static clownshoes_extensions : ident = ident { repr: 7, ctxt: 0};
 
-    pub static self_ : ident = ident { repr: 9u, ctxt: 0}; // 'self'
+    pub static self_ : ident = ident { repr: 8, ctxt: 0}; // 'self'
 
     /* for matcher NTs */
-    pub static item : ident = ident { repr: 10u, ctxt: 0};
-    pub static block : ident = ident { repr: 11u, ctxt: 0};
-    pub static stmt : ident = ident { repr: 12u, ctxt: 0};
-    pub static pat : ident = ident { repr: 13u, ctxt: 0};
-    pub static expr : ident = ident { repr: 14u, ctxt: 0};
-    pub static ty : ident = ident { repr: 15u, ctxt: 0};
-    pub static ident : ident = ident { repr: 16u, ctxt: 0};
-    pub static path : ident = ident { repr: 17u, ctxt: 0};
-    pub static tt : ident = ident { repr: 18u, ctxt: 0};
-    pub static matchers : ident = ident { repr: 19u, ctxt: 0};
+    pub static item : ident = ident { repr: 9, ctxt: 0};
+    pub static block : ident = ident { repr: 10, ctxt: 0};
+    pub static stmt : ident = ident { repr: 11, ctxt: 0};
+    pub static pat : ident = ident { repr: 12, ctxt: 0};
+    pub static expr : ident = ident { repr: 13, ctxt: 0};
+    pub static ty : ident = ident { repr: 14, ctxt: 0};
+    pub static ident : ident = ident { repr: 15, ctxt: 0};
+    pub static path : ident = ident { repr: 16, ctxt: 0};
+    pub static tt : ident = ident { repr: 17, ctxt: 0};
+    pub static matchers : ident = ident { repr: 18, ctxt: 0};
 
-    pub static str : ident = ident { repr: 20u, ctxt: 0}; // for the type
+    pub static str : ident = ident { repr: 19, ctxt: 0}; // for the type
 
     /* outside of libsyntax */
-    pub static ty_visitor : ident = ident { repr: 21u, ctxt: 0};
-    pub static arg : ident = ident { repr: 22u, ctxt: 0};
-    pub static descrim : ident = ident { repr: 23u, ctxt: 0};
-    pub static clownshoe_abi : ident = ident { repr: 24u, ctxt: 0};
-    pub static clownshoe_stack_shim : ident = ident { repr: 25u, ctxt: 0};
-    pub static tydesc : ident = ident { repr: 26u, ctxt: 0};
-    pub static literally_dtor : ident = ident { repr: 27u, ctxt: 0};
-    pub static main : ident = ident { repr: 28u, ctxt: 0};
-    pub static opaque : ident = ident { repr: 29u, ctxt: 0};
-    pub static blk : ident = ident { repr: 30u, ctxt: 0};
-    pub static static : ident = ident { repr: 31u, ctxt: 0};
-    pub static intrinsic : ident = ident { repr: 32u, ctxt: 0};
-    pub static clownshoes_foreign_mod: ident = ident { repr: 33u, ctxt: 0};
-    pub static unnamed_field: ident = ident { repr: 34u, ctxt: 0};
-    pub static c_abi: ident = ident { repr: 35u, ctxt: 0};
-    pub static type_self: ident = ident { repr: 36u, ctxt: 0};    // `Self`
+    pub static ty_visitor : ident = ident { repr: 20, ctxt: 0};
+    pub static arg : ident = ident { repr: 21, ctxt: 0};
+    pub static descrim : ident = ident { repr: 22, ctxt: 0};
+    pub static clownshoe_abi : ident = ident { repr: 23, ctxt: 0};
+    pub static clownshoe_stack_shim : ident = ident { repr: 24, ctxt: 0};
+    pub static tydesc : ident = ident { repr: 25, ctxt: 0};
+    pub static main : ident = ident { repr: 26, ctxt: 0};
+    pub static opaque : ident = ident { repr: 27, ctxt: 0};
+    pub static blk : ident = ident { repr: 28, ctxt: 0};
+    pub static static : ident = ident { repr: 29, ctxt: 0};
+    pub static intrinsic : ident = ident { repr: 30, ctxt: 0};
+    pub static clownshoes_foreign_mod: ident = ident { repr: 31, ctxt: 0};
+    pub static unnamed_field: ident = ident { repr: 32, ctxt: 0};
+    pub static c_abi: ident = ident { repr: 33, ctxt: 0};
+    pub static type_self: ident = ident { repr: 34, ctxt: 0};    // `Self`
 }
 
 pub struct StringRef<'self>(&'self str);
@@ -426,41 +423,39 @@ pub fn mk_fresh_ident_interner() -> @ident_interner {
     let init_vec = ~[
         @~"_",                  // 0
         @~"anon",               // 1
-        @~"drop",               // 2
-        @~"",                   // 3
-        @~"unary",              // 4
-        @~"!",                  // 5
-        @~"[]",                 // 6
-        @~"unary-",             // 7
-        @~"__extensions__",     // 8
-        @~"self",               // 9
-        @~"item",               // 10
-        @~"block",              // 11
-        @~"stmt",               // 12
-        @~"pat",                // 13
-        @~"expr",               // 14
-        @~"ty",                 // 15
-        @~"ident",              // 16
-        @~"path",               // 17
-        @~"tt",                 // 18
-        @~"matchers",           // 19
-        @~"str",                // 20
-        @~"TyVisitor",          // 21
-        @~"arg",                // 22
-        @~"descrim",            // 23
-        @~"__rust_abi",         // 24
-        @~"__rust_stack_shim",  // 25
-        @~"TyDesc",             // 26
-        @~"dtor",               // 27
-        @~"main",               // 28
-        @~"<opaque>",           // 29
-        @~"blk",                // 30
-        @~"static",             // 31
-        @~"intrinsic",          // 32
-        @~"__foreign_mod__",    // 33
-        @~"__field__",          // 34
-        @~"C",                  // 35
-        @~"Self",               // 36
+        @~"",                   // 2
+        @~"unary",              // 3
+        @~"!",                  // 4
+        @~"[]",                 // 5
+        @~"unary-",             // 6
+        @~"__extensions__",     // 7
+        @~"self",               // 8
+        @~"item",               // 9
+        @~"block",              // 10
+        @~"stmt",               // 11
+        @~"pat",                // 12
+        @~"expr",               // 13
+        @~"ty",                 // 14
+        @~"ident",              // 15
+        @~"path",               // 16
+        @~"tt",                 // 17
+        @~"matchers",           // 18
+        @~"str",                // 19
+        @~"TyVisitor",          // 20
+        @~"arg",                // 21
+        @~"descrim",            // 22
+        @~"__rust_abi",         // 23
+        @~"__rust_stack_shim",  // 24
+        @~"TyDesc",             // 25
+        @~"main",               // 26
+        @~"<opaque>",           // 27
+        @~"blk",                // 28
+        @~"static",             // 29
+        @~"intrinsic",          // 30
+        @~"__foreign_mod__",    // 31
+        @~"__field__",          // 32
+        @~"C",                  // 33
+        @~"Self",               // 34
     ];
 
     let rv = @ident_interner {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -693,13 +693,6 @@ pub fn print_struct(s: @ps,
         nbsp(s);
         bopen(s);
         hardbreak_if_not_bol(s);
-        for struct_def.dtor.each |dtor| {
-          hardbreak_if_not_bol(s);
-          maybe_print_comment(s, dtor.span.lo);
-          print_outer_attributes(s, dtor.node.attrs);
-          head(s, ~"drop");
-          print_block(s, &dtor.node.body);
-        }
 
         for struct_def.fields.each |field| {
             match field.node.kind {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -700,6 +700,7 @@ pub fn print_struct(s: @ps,
                 ast::named_field(ident, mutability, visibility) => {
                     hardbreak_if_not_bol(s);
                     maybe_print_comment(s, field.span.lo);
+                    print_outer_attributes(s, field.node.attrs);
                     print_visibility(s, visibility);
                     if mutability == ast::struct_mutable {
                         word_nbsp(s, ~"mut");


### PR DESCRIPTION
The drop block has been deprecated for quite some time. This patch series removes support for parsing it and all the related machinery that made drop work.

As a side feature of all this, I also added the ability to annote fields in structs. This allows comments to be properly associated with an individual field. However, I didn't update `rustdoc` to integrate these comment blocks into the documentation it generates.
