### PR TITLE
ARM test automation

### DIFF
--- a/configure
+++ b/configure
@@ -439,6 +439,10 @@ then
     probe CFG_ZCAT             zcat
 fi
 
+step_msg "looking for target specific programs"
+
+probe CFG_ADB        adb
+
 if [ ! -z "$CFG_PANDOC" ]
 then
     PV_MAJOR_MINOR=$(pandoc --version | grep '^pandoc ' |

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -104,7 +104,7 @@ $(foreach target,$(CFG_TARGET_TRIPLES), \
       $(eval $(call DEF_RUNNABLE_STATUS,$(target),true))), \
     $(if $(findstring $(target),"arm-linux-androideabi"), \
       $(if $(findstring adb,$(shell which adb)), \
-        $(if $(findstring device,$(shell adb devices 2>/dev/null | grep -E '^[A-Za-z0-9]+[[:blank:]]+device')), \
+        $(if $(findstring device,$(shell adb devices 2>/dev/null | grep -E '^[A-Za-z0-9-]+[[:blank:]]+device')), \
           $(info check: $(target) test set is runnable \
             $(info check: adb device attached) \
             $(eval $(call DEF_RUNNABLE_STATUS,$(target),true))), \
@@ -129,9 +129,8 @@ CFG_ADB_PATH := $(shell which adb)
 CFG_ADB_TEST_DIR=/system/tmp
 
 $(info check: device $(CFG_ADB_TEST_DIR) \
+ $(shell $(CFG_ADB_PATH) remount 1>/dev/null) \
  $(shell $(CFG_ADB_PATH) shell mkdir $(CFG_ADB_TEST_DIR) 1>/dev/null) \
- $(shell $(CFG_ADB_PATH) shell rm $(CFG_ADB_TEST_DIR)/*-arm-linux-androideabi 1>/dev/null) \
- $(shell $(CFG_ADB_PATH) shell rm $(CFG_ADB_TEST_DIR)/*.so 1>/dev/null) \
  )
 endif
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -502,12 +502,13 @@ ifeq ($(CFG_ADB_DEVICE),true)
 CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
 		--compile-lib-path $$(HLIB$(1)_H_$(3))				\
         --run-lib-path $$(TLIB$(1)_T_$(2)_H_$(3))			\
-        --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))			\
-        --aux-base $$(S)src/test/auxiliary/                 \
+        --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))	\
+        --aux-base $$(S)src/test/auxiliary/					\
         --stage-id stage$(1)-$(2)							\
         --host $(CFG_BUILD_TRIPLE)                          \
         --target $(2)                                       \
         --adb-path=$(CFG_ADB_PATH)                          \
+        --adb-test-dir=$(CFG_ADB_TEST_DIR)                  \
         --rustcflags "$(RUSTC_FLAGS_$(2)) $$(CFG_RUSTC_FLAGS) --target=$(2)" \
         $$(CTEST_TESTARGS)
 
@@ -516,7 +517,7 @@ else
 CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
 		--compile-lib-path $$(HLIB$(1)_H_$(3))				\
         --run-lib-path $$(TLIB$(1)_T_$(2)_H_$(3))			\
-        --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))			\
+        --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))	\
         --aux-base $$(S)src/test/auxiliary/                 \
         --stage-id stage$(1)-$(2)							\
         --host $(CFG_BUILD_TRIPLE)                          \

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -505,7 +505,7 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
         --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))			\
         --aux-base $$(S)src/test/auxiliary/                 \
         --stage-id stage$(1)-$(2)							\
-        --host $(3)                                         \
+        --host $(CFG_BUILD_TRIPLE)                          \
         --target $(2)                                       \
         --adb-path=$(CFG_ADB_PATH)                          \
         --rustcflags "$(RUSTC_FLAGS_$(2)) $$(CFG_RUSTC_FLAGS) --target=$(2)" \
@@ -519,7 +519,7 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
         --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))			\
         --aux-base $$(S)src/test/auxiliary/                 \
         --stage-id stage$(1)-$(2)							\
-        --host $(3)                                         \
+        --host $(CFG_BUILD_TRIPLE)                          \
         --target $(2)                                       \
         --rustcflags "$(RUSTC_FLAGS_$(2)) $$(CFG_RUSTC_FLAGS) --target=$(2)" \
         $$(CTEST_TESTARGS)

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -497,9 +497,8 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
 		--compile-lib-path $$(HLIB$(1)_H_$(3))				\
         --run-lib-path $$(TLIB$(1)_T_$(2)_H_$(3))			\
         --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))			\
-        --aux-base $$(S)src/test/auxiliary/					\
+        --aux-base $$(S)src/test/auxiliary/                 \
         --stage-id stage$(1)-$(2)							\
-        --host $(CFG_BUILD_TRIPLE)                          \
         --target $(2)                                       \
         --adb-path=$(CFG_ADB)                          \
         --adb-test-dir=$(CFG_ADB_TEST_DIR)                  \

--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -70,8 +70,11 @@ pub struct config {
     // Target System to be executed
     target: ~str,
 
-    // Extra parameter to run arm-linux-androideabi
+    // Extra parameter to run adb on arm-linux-androideabi
     adb_path: ~str,
+
+    // Extra parameter to run test sute on arm-linux-androideabi
+    adb_test_dir: ~str,
 
     // check if can be run or not
     flag_runnable: bool,

--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -64,10 +64,7 @@ pub struct config {
     // Run tests using the new runtime
     newrt: bool,
 
-    // Host System to be built
-    host: ~str,
-
-    // Target System to be executed
+    // Target system to be tested
     target: ~str,
 
     // Extra parameter to run adb on arm-linux-androideabi
@@ -76,8 +73,8 @@ pub struct config {
     // Extra parameter to run test sute on arm-linux-androideabi
     adb_test_dir: ~str,
 
-    // check if can be run or not
-    flag_runnable: bool,
+    // status whether android device available or not
+    adb_device_status: bool,
 
     // Explain what's going on
     verbose: bool

--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -64,6 +64,18 @@ pub struct config {
     // Run tests using the new runtime
     newrt: bool,
 
+    // Host System to be built
+    host: ~str,
+
+    // Target System to be executed
+    target: ~str,
+
+    // Extra parameter to run arm-linux-androideabi
+    adb_path: ~str,
+
+    // check if can be run or not
+    flag_runnable: bool,
+
     // Explain what's going on
     verbose: bool
 

--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -63,7 +63,8 @@ pub fn parse_config(args: ~[~str]) -> config {
           getopts::optflag(~"newrt"),
           getopts::optopt(~"host"),
           getopts::optopt(~"target"),
-          getopts::optopt(~"adb-path")
+          getopts::optopt(~"adb-path"),
+          getopts::optopt(~"adb-test-dir")
          ];
 
     assert!(!args.is_empty());
@@ -100,6 +101,7 @@ pub fn parse_config(args: ~[~str]) -> config {
         host: opt_str(getopts::opt_maybe_str(matches, ~"host")),
         target: opt_str(getopts::opt_maybe_str(matches, ~"target")),
         adb_path: opt_str(getopts::opt_maybe_str(matches, ~"adb-path")),
+        adb_test_dir: opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")),
         flag_runnable:
             if (getopts::opt_maybe_str(matches, ~"host") ==
                 getopts::opt_maybe_str(matches, ~"target")) { true }
@@ -136,6 +138,7 @@ pub fn log_config(config: config) {
     logv(c, fmt!("host: %s", config.host));
     logv(c, fmt!("target: %s", config.target));
     logv(c, fmt!("adb_path: %s", config.adb_path));
+    logv(c, fmt!("adb_test_dir: %s", config.adb_test_dir));
     logv(c, fmt!("flag_runnable: %b", config.flag_runnable));
     logv(c, fmt!("verbose: %b", config.verbose));
     logv(c, fmt!("\n"));

--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -108,11 +108,13 @@ pub fn parse_config(args: ~[~str]) -> config {
             else {
                 match getopts::opt_maybe_str(matches, ~"target") {
                     Some(~"arm-linux-androideabi") => {
-                        if (getopts::opt_maybe_str(matches, ~"adb-path") !=
-                            option::None) { true }
+                        if (opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
+                            ~"(none)" &&
+                            opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
+                            ~"") { true }
                         else { false }
                     }
-                    _ => { false }
+                    _ => { true }
                 }
             },
         verbose: getopts::opt_present(matches, ~"verbose")

--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -60,7 +60,11 @@ pub fn parse_config(args: ~[~str]) -> config {
           getopts::optflag(~"verbose"),
           getopts::optopt(~"logfile"),
           getopts::optflag(~"jit"),
-          getopts::optflag(~"newrt")];
+          getopts::optflag(~"newrt"),
+          getopts::optopt(~"host"),
+          getopts::optopt(~"target"),
+          getopts::optopt(~"adb-path")
+         ];
 
     assert!(!args.is_empty());
     let args_ = vec::tail(args);
@@ -93,6 +97,22 @@ pub fn parse_config(args: ~[~str]) -> config {
         rustcflags: getopts::opt_maybe_str(matches, ~"rustcflags"),
         jit: getopts::opt_present(matches, ~"jit"),
         newrt: getopts::opt_present(matches, ~"newrt"),
+        host: opt_str(getopts::opt_maybe_str(matches, ~"host")),
+        target: opt_str(getopts::opt_maybe_str(matches, ~"target")),
+        adb_path: opt_str(getopts::opt_maybe_str(matches, ~"adb-path")),
+        flag_runnable:
+            if (getopts::opt_maybe_str(matches, ~"host") ==
+                getopts::opt_maybe_str(matches, ~"target")) { true }
+            else {
+                match getopts::opt_maybe_str(matches, ~"target") {
+                    Some(~"arm-linux-androideabi") => {
+                        if (getopts::opt_maybe_str(matches, ~"adb-path") !=
+                            option::None) { true }
+                        else { false }
+                    }
+                    _ => { false }
+                }
+            },
         verbose: getopts::opt_present(matches, ~"verbose")
     }
 }
@@ -113,6 +133,10 @@ pub fn log_config(config: config) {
     logv(c, fmt!("rustcflags: %s", opt_str(config.rustcflags)));
     logv(c, fmt!("jit: %b", config.jit));
     logv(c, fmt!("newrt: %b", config.newrt));
+    logv(c, fmt!("host: %s", config.host));
+    logv(c, fmt!("target: %s", config.target));
+    logv(c, fmt!("adb_path: %s", config.adb_path));
+    logv(c, fmt!("flag_runnable: %b", config.flag_runnable));
     logv(c, fmt!("verbose: %b", config.verbose));
     logv(c, fmt!("\n"));
 }

--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -61,7 +61,6 @@ pub fn parse_config(args: ~[~str]) -> config {
           getopts::optopt(~"logfile"),
           getopts::optflag(~"jit"),
           getopts::optflag(~"newrt"),
-          getopts::optopt(~"host"),
           getopts::optopt(~"target"),
           getopts::optopt(~"adb-path"),
           getopts::optopt(~"adb-test-dir")
@@ -98,25 +97,18 @@ pub fn parse_config(args: ~[~str]) -> config {
         rustcflags: getopts::opt_maybe_str(matches, ~"rustcflags"),
         jit: getopts::opt_present(matches, ~"jit"),
         newrt: getopts::opt_present(matches, ~"newrt"),
-        host: opt_str(getopts::opt_maybe_str(matches, ~"host")),
         target: opt_str(getopts::opt_maybe_str(matches, ~"target")),
         adb_path: opt_str(getopts::opt_maybe_str(matches, ~"adb-path")),
         adb_test_dir: opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")),
-        flag_runnable:
-            if (getopts::opt_maybe_str(matches, ~"host") ==
-                getopts::opt_maybe_str(matches, ~"target")) { true }
-            else {
-                match getopts::opt_maybe_str(matches, ~"target") {
-                    Some(~"arm-linux-androideabi") => {
-                        if (opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
-                            ~"(none)" &&
-                            opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
-                            ~"") { true }
-                        else { false }
-                    }
-                    _ => { true }
-                }
-            },
+        adb_device_status:
+            if (opt_str(getopts::opt_maybe_str(matches, ~"target")) ==
+                ~"arm-linux-androideabi") {
+                if (opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
+                    ~"(none)" &&
+                    opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
+                    ~"") { true }
+                else { false }
+            } else { false },
         verbose: getopts::opt_present(matches, ~"verbose")
     }
 }
@@ -137,11 +129,10 @@ pub fn log_config(config: config) {
     logv(c, fmt!("rustcflags: %s", opt_str(config.rustcflags)));
     logv(c, fmt!("jit: %b", config.jit));
     logv(c, fmt!("newrt: %b", config.newrt));
-    logv(c, fmt!("host: %s", config.host));
     logv(c, fmt!("target: %s", config.target));
     logv(c, fmt!("adb_path: %s", config.adb_path));
     logv(c, fmt!("adb_test_dir: %s", config.adb_test_dir));
-    logv(c, fmt!("flag_runnable: %b", config.flag_runnable));
+    logv(c, fmt!("adb_device_status: %b", config.adb_device_status));
     logv(c, fmt!("verbose: %b", config.verbose));
     logv(c, fmt!("\n"));
 }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -524,7 +524,7 @@ fn exec_compiled_test(config: config, props: TestProps,
                 // execute program
                 logv(config, fmt!("executing (%s) %s", config.target, cmdline));
 
-                // NOTE : adb shell dose not forward to each stdout and stderr of internal result 
+                // NOTE : adb shell dose not forward to each stdout and stderr of internal result
                 //        but forward to stdout only
                 let mut newargs_out = ~[];
                 let mut newargs_err = ~[];

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -512,7 +512,7 @@ fn exec_compiled_test(config: config, props: TestProps,
 
                 // copy to target
                 let copy_result = procsrv::run(~"", config.adb_path,
-                    ~[~"push", args.prog, ~"/system/tmp"],
+                    ~[~"push", args.prog, config.adb_test_dir],
                     ~[(~"",~"")], Some(~""));
 
                 if config.verbose {
@@ -534,16 +534,13 @@ fn exec_compiled_test(config: config, props: TestProps,
 
                 let mut newcmd_out = ~"";
                 let mut newcmd_err = ~"";
-                newcmd_out.push_str(~"LD_LIBRARY_PATH=/system/tmp; ");
-                newcmd_err.push_str(~"LD_LIBRARY_PATH=/system/tmp; ");
-                newcmd_out.push_str(~"export LD_LIBRARY_PATH; ");
-                newcmd_err.push_str(~"export LD_LIBRARY_PATH; ");
-                newcmd_out.push_str(~"cd /system/tmp; ");
-                newcmd_err.push_str(~"cd /system/tmp; ");
-                newcmd_out.push_str("./");
-                newcmd_err.push_str("./");
-                newcmd_out.push_str(prog_short);
-                newcmd_err.push_str(prog_short);
+                newcmd_out.push_str(fmt!(
+                    "LD_LIBRARY_PATH=%s; export LD_LIBRARY_PATH; cd %s; ./%s",
+                    config.adb_test_dir, config.adb_test_dir, prog_short));
+
+                newcmd_err.push_str(fmt!(
+                    "LD_LIBRARY_PATH=%s; export LD_LIBRARY_PATH; cd %s; ./%s",
+                    config.adb_test_dir, config.adb_test_dir, prog_short));
 
                 for vec::each(subargs) |tv| {
                     newcmd_out.push_str(" ");
@@ -617,7 +614,7 @@ fn compose_and_run_compiler(
                         if (file.filetype() == Some(~".so")) {
 
                             let copy_result = procsrv::run(~"", config.adb_path,
-                                ~[~"push", file.to_str(), ~"/system/tmp"],
+                                ~[~"push", file.to_str(), config.adb_test_dir],
                                 ~[(~"",~"")], Some(~""));
 
                             if config.verbose {

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -77,8 +77,10 @@ fn run_rfail_test(config: config, props: TestProps, testfile: &Path) {
         fatal_ProcRes(~"run-fail test isn't valgrind-clean!", ProcRes);
     }
 
-    check_correct_failure_status(ProcRes);
-    check_error_patterns(props, testfile, ProcRes);
+    if (config.flag_runnable) {
+        check_correct_failure_status(ProcRes);
+        check_error_patterns(props, testfile, ProcRes);
+    }
 }
 
 fn check_correct_failure_status(ProcRes: ProcRes) {
@@ -483,10 +485,96 @@ fn exec_compiled_test(config: config, props: TestProps,
         props.exec_env
     };
 
-    compose_and_run(config, testfile,
-                    make_run_args(config, props, testfile),
-                    env,
-                    config.run_lib_path, None)
+    if (config.host == config.target) {
+        compose_and_run(config, testfile,
+                        make_run_args(config, props, testfile),
+                        env,
+                        config.run_lib_path, None)
+    }
+    else {
+        let args = make_run_args(config, props, testfile);
+        let cmdline = make_cmdline(~"", args.prog, args.args);
+
+        let defaultRes = match config.mode {
+            mode_run_fail => ProcRes {status: 101, stdout: ~"", stderr: ~"", cmdline: cmdline},
+            _             => ProcRes {status: 0, stdout: ~"", stderr: ~"", cmdline: cmdline}
+        };
+
+        match (config.target, config.flag_runnable) {
+
+            (~"arm-linux-androideabi", true) => {
+
+                // get bare program string
+                let mut tvec = ~[];
+                let tstr = args.prog;
+                for str::each_split_char(tstr, '/') |ts| { tvec.push(ts.to_owned()) }
+                let prog_short = tvec.pop();
+
+                // copy to target
+                let copy_result = procsrv::run(~"", config.adb_path,
+                    ~[~"push", args.prog, ~"/system/tmp"],
+                    ~[(~"",~"")], Some(~""));
+
+                if config.verbose {
+                    io::stdout().write_str(fmt!("push (%s) %s %s %s",
+                        config.target, args.prog,
+                        copy_result.out, copy_result.err));
+                }
+
+                // execute program
+                logv(config, fmt!("executing (%s) %s", config.target, cmdline));
+
+                // NOTE : adb shell dose not forward to each stdout and stderr of internal result 
+                //        but forward to stdout only
+                let mut newargs_out = ~[];
+                let mut newargs_err = ~[];
+                let subargs = args.args;
+                newargs_out.push(~"shell");
+                newargs_err.push(~"shell");
+
+                let mut newcmd_out = ~"";
+                let mut newcmd_err = ~"";
+                newcmd_out.push_str(~"LD_LIBRARY_PATH=/system/tmp; ");
+                newcmd_err.push_str(~"LD_LIBRARY_PATH=/system/tmp; ");
+                newcmd_out.push_str(~"export LD_LIBRARY_PATH; ");
+                newcmd_err.push_str(~"export LD_LIBRARY_PATH; ");
+                newcmd_out.push_str(~"cd /system/tmp; ");
+                newcmd_err.push_str(~"cd /system/tmp; ");
+                newcmd_out.push_str("./");
+                newcmd_err.push_str("./");
+                newcmd_out.push_str(prog_short);
+                newcmd_err.push_str(prog_short);
+
+                for vec::each(subargs) |tv| {
+                    newcmd_out.push_str(" ");
+                    newcmd_err.push_str(" ");
+                    newcmd_out.push_str(tv.to_owned());
+                    newcmd_err.push_str(tv.to_owned());
+                }
+
+                newcmd_out.push_str(" 2>/dev/null");
+                newcmd_err.push_str(" 1>/dev/null");
+
+                newargs_out.push(newcmd_out);
+                newargs_err.push(newcmd_err);
+
+                let exe_result_out = procsrv::run(~"", config.adb_path,
+                    newargs_out, ~[(~"",~"")], Some(~""));
+                let exe_result_err = procsrv::run(~"", config.adb_path,
+                    newargs_err, ~[(~"",~"")], Some(~""));
+
+                dump_output(config, testfile, exe_result_out.out, exe_result_err.out);
+
+                match exe_result_err.out {
+                    ~"" => ProcRes {status: exe_result_out.status, stdout: exe_result_out.out,
+                        stderr: exe_result_err.out, cmdline: cmdline },
+                    _   => ProcRes {status: 101, stdout: exe_result_out.out,
+                        stderr: exe_result_err.out, cmdline: cmdline }
+                }
+            }
+            _=> defaultRes
+        }
+    }
 }
 
 fn compose_and_run_compiler(
@@ -515,6 +603,33 @@ fn compose_and_run_compiler(
                 fmt!("auxiliary build of %s failed to compile: ",
                      abs_ab.to_str()),
                 auxres);
+        }
+        if (config.host != config.target)
+        {
+            match (config.target, config.flag_runnable) {
+
+                (~"arm-linux-androideabi", true) => {
+
+                    let tstr = aux_output_dir_name(config, testfile).to_str();
+
+                    for os::list_dir_path(&Path(tstr)).each |file| {
+
+                        if (file.filetype() == Some(~".so")) {
+
+                            let copy_result = procsrv::run(~"", config.adb_path,
+                                ~[~"push", file.to_str(), ~"/system/tmp"],
+                                ~[(~"",~"")], Some(~""));
+
+                            if config.verbose {
+                                io::stdout().write_str(fmt!("push (%s) %s %s %s",
+                                    config.target, file.to_str(),
+                                    copy_result.out, copy_result.err));
+                            }
+                        }
+                    }
+                }
+                _=> ()
+            }
         }
     }
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -77,17 +77,18 @@ fn run_rfail_test(config: config, props: TestProps, testfile: &Path) {
         fatal_ProcRes(~"run-fail test isn't valgrind-clean!", ProcRes);
     }
 
-    if (config.host == config.target) {
-        check_correct_failure_status(ProcRes);
-        check_error_patterns(props, testfile, ProcRes);
-    } else {
-        match (config.target, config.flag_runnable) {
+    match config.target {
 
-            (~"arm-linux-androideabi", false) => { }
-            _ => {
+        ~"arm-linux-androideabi" => {
+            if (config.adb_device_status) {
                 check_correct_failure_status(ProcRes);
                 check_error_patterns(props, testfile, ProcRes);
             }
+        }
+
+        _=> {
+            check_correct_failure_status(ProcRes);
+            check_error_patterns(props, testfile, ProcRes);
         }
     }
 }
@@ -494,99 +495,21 @@ fn exec_compiled_test(config: config, props: TestProps,
         props.exec_env
     };
 
-    if (config.host == config.target) {
-        compose_and_run(config, testfile,
-                        make_run_args(config, props, testfile),
-                        env,
-                        config.run_lib_path, None)
-    } else {
-        let args = make_run_args(config, props, testfile);
-        let cmdline = make_cmdline(~"", args.prog, args.args);
+    match config.target {
 
-        match (config.target, config.flag_runnable) {
-
-            (~"arm-linux-androideabi", true) => {
-
-                // get bare program string
-                let mut tvec = ~[];
-                let tstr = args.prog;
-                for str::each_split_char(tstr, '/') |ts| { tvec.push(ts.to_owned()) }
-                let prog_short = tvec.pop();
-
-                // copy to target
-                let copy_result = procsrv::run(~"", config.adb_path,
-                    ~[~"push", args.prog, config.adb_test_dir],
-                    ~[(~"",~"")], Some(~""));
-
-                if config.verbose {
-                    io::stdout().write_str(fmt!("push (%s) %s %s %s",
-                        config.target, args.prog,
-                        copy_result.out, copy_result.err));
-                }
-
-                // execute program
-                logv(config, fmt!("executing (%s) %s", config.target, cmdline));
-
-                // NOTE: adb shell dose not forward stdout and stderr of internal result
-                //       to stdout and stderr seperately but to stdout only
-                let mut newargs_out = ~[];
-                let mut newargs_err = ~[];
-                let subargs = args.args;
-                newargs_out.push(~"shell");
-                newargs_err.push(~"shell");
-
-                let mut newcmd_out = ~"";
-                let mut newcmd_err = ~"";
-
-                newcmd_out.push_str(fmt!("LD_LIBRARY_PATH=%s %s/%s",
-                    config.adb_test_dir, config.adb_test_dir, prog_short));
-
-                newcmd_err.push_str(fmt!("LD_LIBRARY_PATH=%s %s/%s",
-                    config.adb_test_dir, config.adb_test_dir, prog_short));
-
-                for vec::each(subargs) |tv| {
-                    newcmd_out.push_str(" ");
-                    newcmd_err.push_str(" ");
-                    newcmd_out.push_str(tv.to_owned());
-                    newcmd_err.push_str(tv.to_owned());
-                }
-
-                newcmd_out.push_str(" 2>/dev/null");
-                newcmd_err.push_str(" 1>/dev/null");
-
-                newargs_out.push(newcmd_out);
-                newargs_err.push(newcmd_err);
-
-                let exe_result_out = procsrv::run(~"", config.adb_path,
-                    newargs_out, ~[(~"",~"")], Some(~""));
-                let exe_result_err = procsrv::run(~"", config.adb_path,
-                    newargs_err, ~[(~"",~"")], Some(~""));
-
-                dump_output(config, testfile, exe_result_out.out, exe_result_err.out);
-
-                match exe_result_err.out {
-                    ~"" => ProcRes {status: exe_result_out.status, stdout: exe_result_out.out,
-                        stderr: exe_result_err.out, cmdline: cmdline },
-                    _   => ProcRes {status: 101, stdout: exe_result_out.out,
-                        stderr: exe_result_err.out, cmdline: cmdline }
-                }
+        ~"arm-linux-androideabi" => {
+            if (config.adb_device_status) {
+                _arm_exec_compiled_test(config, props, testfile)
+            } else {
+                _dummy_exec_compiled_test(config, props, testfile)
             }
+        }
 
-            (~"arm-linux-androideabi", false) => {
-                match config.mode {
-                    mode_run_fail => ProcRes {status: 101, stdout: ~"",
-                                             stderr: ~"", cmdline: cmdline},
-                    _             => ProcRes {status: 0, stdout: ~"",
-                                             stderr: ~"", cmdline: cmdline}
-                }
-            }
-
-            _=> {
-                compose_and_run(config, testfile,
-                                make_run_args(config, props, testfile),
-                                env,
-                                config.run_lib_path, None)
-            }
+        _=> {
+            compose_and_run(config, testfile,
+                            make_run_args(config, props, testfile),
+                            env,
+                            config.run_lib_path, None)
         }
     }
 }
@@ -618,32 +541,16 @@ fn compose_and_run_compiler(
                      abs_ab.to_str()),
                 auxres);
         }
-        if (config.host != config.target)
-        {
-            match (config.target, config.flag_runnable) {
 
-                (~"arm-linux-androideabi", true) => {
+        match config.target {
 
-                    let tstr = aux_output_dir_name(config, testfile).to_str();
-
-                    for os::list_dir_path(&Path(tstr)).each |file| {
-
-                        if (file.filetype() == Some(~".so")) {
-
-                            let copy_result = procsrv::run(~"", config.adb_path,
-                                ~[~"push", file.to_str(), config.adb_test_dir],
-                                ~[(~"",~"")], Some(~""));
-
-                            if config.verbose {
-                                io::stdout().write_str(fmt!("push (%s) %s %s %s",
-                                    config.target, file.to_str(),
-                                    copy_result.out, copy_result.err));
-                            }
-                        }
-                    }
+            ~"arm-linux-androideabi" => {
+                if (config.adb_device_status) {
+                    _arm_push_aux_shared_library(config, testfile);
                 }
-                _=> ()
             }
+
+            _=> { }
         }
     }
 
@@ -828,4 +735,109 @@ stderr:\n\
              err, ProcRes.cmdline, ProcRes.stdout, ProcRes.stderr);
     io::stdout().write_str(msg);
     fail!();
+}
+
+fn _arm_exec_compiled_test(config: config, props: TestProps,
+                      testfile: &Path) -> ProcRes {
+
+    let args = make_run_args(config, props, testfile);
+    let cmdline = make_cmdline(~"", args.prog, args.args);
+
+    // get bare program string
+    let mut tvec = ~[];
+    let tstr = args.prog;
+    for str::each_split_char(tstr, '/') |ts| { tvec.push(ts.to_owned()) }
+    let prog_short = tvec.pop();
+
+    // copy to target
+    let copy_result = procsrv::run(~"", config.adb_path,
+        ~[~"push", args.prog, config.adb_test_dir],
+        ~[(~"",~"")], Some(~""));
+
+    if config.verbose {
+        io::stdout().write_str(fmt!("push (%s) %s %s %s",
+            config.target, args.prog,
+            copy_result.out, copy_result.err));
+    }
+
+    // execute program
+    logv(config, fmt!("executing (%s) %s", config.target, cmdline));
+
+    // adb shell dose not forward stdout and stderr of internal result
+    // to stdout and stderr seperately but to stdout only
+    let mut newargs_out = ~[];
+    let mut newargs_err = ~[];
+    let subargs = args.args;
+    newargs_out.push(~"shell");
+    newargs_err.push(~"shell");
+
+    let mut newcmd_out = ~"";
+    let mut newcmd_err = ~"";
+
+    newcmd_out.push_str(fmt!("LD_LIBRARY_PATH=%s %s/%s",
+        config.adb_test_dir, config.adb_test_dir, prog_short));
+
+    newcmd_err.push_str(fmt!("LD_LIBRARY_PATH=%s %s/%s",
+        config.adb_test_dir, config.adb_test_dir, prog_short));
+
+    for vec::each(subargs) |tv| {
+        newcmd_out.push_str(" ");
+        newcmd_err.push_str(" ");
+        newcmd_out.push_str(tv.to_owned());
+        newcmd_err.push_str(tv.to_owned());
+    }
+
+    newcmd_out.push_str(" 2>/dev/null");
+    newcmd_err.push_str(" 1>/dev/null");
+
+    newargs_out.push(newcmd_out);
+    newargs_err.push(newcmd_err);
+
+    let exe_result_out = procsrv::run(~"", config.adb_path,
+        newargs_out, ~[(~"",~"")], Some(~""));
+    let exe_result_err = procsrv::run(~"", config.adb_path,
+        newargs_err, ~[(~"",~"")], Some(~""));
+
+    dump_output(config, testfile, exe_result_out.out, exe_result_err.out);
+
+    match exe_result_err.out {
+        ~"" => ProcRes {status: exe_result_out.status, stdout: exe_result_out.out,
+            stderr: exe_result_err.out, cmdline: cmdline },
+        _   => ProcRes {status: 101, stdout: exe_result_out.out,
+            stderr: exe_result_err.out, cmdline: cmdline }
+    }
+}
+
+fn _dummy_exec_compiled_test(config: config, props: TestProps,
+                      testfile: &Path) -> ProcRes {
+
+    let args = make_run_args(config, props, testfile);
+    let cmdline = make_cmdline(~"", args.prog, args.args);
+
+    match config.mode {
+        mode_run_fail => ProcRes {status: 101, stdout: ~"",
+                                 stderr: ~"", cmdline: cmdline},
+        _             => ProcRes {status: 0, stdout: ~"",
+                                 stderr: ~"", cmdline: cmdline}
+    }
+}
+
+fn _arm_push_aux_shared_library(config: config, testfile: &Path) {
+    let tstr = aux_output_dir_name(config, testfile).to_str();
+
+    for os::list_dir_path(&Path(tstr)).each |file| {
+
+        if (file.filetype() == Some(~".so")) {
+
+            let copy_result = procsrv::run(~"", config.adb_path,
+                ~[~"push", file.to_str(), config.adb_test_dir],
+                ~[(~"",~"")], Some(~""));
+
+            if config.verbose {
+                io::stdout().write_str(fmt!("push (%s) %s %s %s",
+                    config.target, file.to_str(),
+                    copy_result.out, copy_result.err));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Support #5297

install.mk : install-runtime-target added for conveneice
                 automatically push runtime library to android device

test.mk : expanded to support android test automation with adb

compiletest : expanded to support android test automation with adb
