### PR TITLE
Remove 'Local Variable' comments

### DIFF
--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -223,10 +223,3 @@ pub fn make_test_closure(config: config, testfile: &Path) -> test::TestFn {
     let testfile = testfile.to_str();
     test::DynTestFn(|| runtest::run(config, testfile))
 }
-
-// Local Variables:
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -263,12 +263,3 @@ mod core {
     pub use sys;
     pub use pipes;
 }
-
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libcore/either.rs
+++ b/src/libcore/either.rs
@@ -263,13 +263,3 @@ fn test_partition_empty() {
     assert_eq!(vec::len(lefts), 0u);
     assert_eq!(vec::len(rights), 0u);
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -1954,13 +1954,3 @@ mod tests {
         }
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libcore/libc.rs
+++ b/src/libcore/libc.rs
@@ -1846,12 +1846,3 @@ pub mod funcs {
         }
     }
 }
-
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libcore/num/cmath.rs
+++ b/src/libcore/num/cmath.rs
@@ -267,14 +267,3 @@ pub mod c_double_targ_consts {
 }
 
 */
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//
-

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -986,13 +986,3 @@ mod tests {
         assert_eq!(Primitive::bytes::<f32>(), sys::size_of::<f32>());
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -1033,13 +1033,3 @@ mod tests {
         assert_eq!(Primitive::bytes::<f64>(), sys::size_of::<f64>());
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -1139,13 +1139,3 @@ mod tests {
         assert_eq!(to_str_digits(-infinity, 10u), ~"-inf");
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -565,11 +565,3 @@ fn test_get_or_zero() {
     let no_stuff: Option<int> = None;
     assert!(no_stuff.get_or_zero() == 0);
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libcore/rand.rs
+++ b/src/libcore/rand.rs
@@ -1073,12 +1073,3 @@ mod tests {
         }
     }
 }
-
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -639,11 +639,3 @@ mod tests {
         test_destroy_actually_kills(true);
     }
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -343,11 +343,3 @@ mod tests {
     #[should_fail]
     fn fail_owned() { FailWithCause::fail_with(~"cause", file!(), line!())  }
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libcore/unstable/extfmt.rs
+++ b/src/libcore/unstable/extfmt.rs
@@ -688,11 +688,3 @@ mod test {
         let _s = fmt!("%s", s);
     }
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libcore/unstable/lang.rs
+++ b/src/libcore/unstable/lang.rs
@@ -183,11 +183,3 @@ pub fn start(main: *u8, argc: int, argv: **c_char,
                       crate_map: *c_void) -> c_int;
     }
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -693,10 +693,3 @@ pub fn main() {
 
     error!("Fuzzer done");
 }
-
-// Local Variables:
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/back/abi.rs
+++ b/src/librustc/back/abi.rs
@@ -77,12 +77,3 @@ pub fn bzero_glue_name() -> ~str { return ~"rust_bzero_glue"; }
 pub fn yield_glue_name() -> ~str { return ~"rust_yield_glue"; }
 
 pub fn no_op_type_glue_name() -> ~str { return ~"rust_no_op_type_glue"; }
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/back/arm.rs
+++ b/src/librustc/back/arm.rs
@@ -72,14 +72,3 @@ pub fn get_target_strs(target_os: session::os) -> target_strs::t {
         cc_args: ~[~"-marm"]
     };
 }
-
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -949,13 +949,3 @@ pub fn link_args(sess: Session,
 
     return args;
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/back/mips.rs
+++ b/src/librustc/back/mips.rs
@@ -72,14 +72,3 @@ pub fn get_target_strs(target_os: session::os) -> target_strs::t {
         cc_args: ~[]
     };
 }
-
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/back/upcall.rs
+++ b/src/librustc/back/upcall.rs
@@ -59,12 +59,3 @@ pub fn declare_upcalls(targ_cfg: @session::config,
             nothrow(dv(~"reset_stack_limit", ~[]))
     }
 }
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/back/x86.rs
+++ b/src/librustc/back/x86.rs
@@ -55,13 +55,3 @@ pub fn get_target_strs(target_os: session::os) -> target_strs::t {
         cc_args: ~[~"-m32"]
     };
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/back/x86_64.rs
+++ b/src/librustc/back/x86_64.rs
@@ -63,13 +63,3 @@ pub fn get_target_strs(target_os: session::os) -> target_strs::t {
         cc_args: ~[~"-m64"]
     };
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -951,11 +951,3 @@ mod test {
         assert!((vec::len(test_items) == 1u));
     }
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -430,10 +430,3 @@ mod test {
         assert!(building_library(lib_crate, crate, true));
     }
 }
-
-// Local Variables:
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -194,11 +194,3 @@ pub fn metas_in_cfg(cfg: ast::crate_cfg,
         })
     })
 }
-
-
-// Local Variables:
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -456,11 +456,3 @@ fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: &Test) -> @ast::expr {
     );
     e
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -2196,13 +2196,3 @@ pub fn mk_section_iter(llof: ObjectFileRef) -> SectionIter {
         }
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -328,11 +328,3 @@ fn resolve_crate_deps(e: @mut Env, cdata: @~[u8]) -> cstore::cnum_map {
     }
     return @mut cnum_map;
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -243,11 +243,3 @@ pub fn get_link_args_for_crate(cstore: @mut cstore::CStore,
     let cdata = cstore::get_crate_data(cstore, crate_num);
     decoder::get_link_args_for_crate(cdata)
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -161,11 +161,3 @@ pub fn get_dep_hashes(cstore: &CStore) -> ~[~str] {
 
     sorted.map(|ch| /*bad*/copy *ch.hash)
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1176,11 +1176,3 @@ pub fn get_link_args_for_crate(cdata: cmd) -> ~[~str] {
     }
     result
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1420,12 +1420,3 @@ pub fn encoded_ty(tcx: ty::ctxt, t: ty::t) -> ~str {
         tyencode::enc_ty(wr, cx, t);
     }
 }
-
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -567,13 +567,3 @@ fn parse_bounds(st: @mut PState, conv: conv_did) -> @~[ty::param_bound] {
     }
     @bounds
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -416,13 +416,3 @@ pub fn enc_type_param_def(w: @io::Writer, cx: @ctxt, v: &ty::TypeParameterDef) {
     w.write_char('|');
     enc_bounds(w, cx, v.bounds);
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -253,11 +253,3 @@ pub fn check_item_recursion(sess: Session,
         visit::visit_expr(e, env, v);
     }
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -862,11 +862,3 @@ pub fn check_legality_of_move_bindings(cx: @MatchCheckCtxt,
         (vt.visit_pat)(*pat, false, vt);
     }
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -484,12 +484,3 @@ pub fn lit_expr_eq(tcx: middle::ty::ctxt, a: @expr, b: @expr) -> bool {
 pub fn lit_eq(a: @lit, b: @lit) -> bool {
     compare_const_vals(&lit_to_const(a), &lit_to_const(b)) == 0
 }
-
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -119,11 +119,3 @@ pub fn get_freevars(tcx: ty::ctxt, fid: ast::node_id) -> freevar_info {
 pub fn has_freevars(tcx: ty::ctxt, fid: ast::node_id) -> bool {
     return vec::len(*get_freevars(tcx, fid)) != 0u;
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -587,13 +587,3 @@ pub fn check_kind_bounds_of_cast(cx: Context, source: @expr, target: @expr) {
         _ => {} // Nothing to do.
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -946,13 +946,3 @@ pub fn check_crate(tcx: ty::ctxt, crate: @ast::crate) {
 
     tcx.sess.abort_if_errors();
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1862,11 +1862,3 @@ pub fn bind_irrefutable_pat(bcx: block,
     }
     return bcx;
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -3172,12 +3172,3 @@ pub fn trans_crate(sess: session::Session,
         return (llmod, link_meta);
     }
 }
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -1086,13 +1086,3 @@ pub fn AtomicRMW(cx: block, op: AtomicBinOp,
         llvm::LLVMBuildAtomicRMW(B(cx), op, dst, src, order)
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1521,13 +1521,3 @@ pub fn dummy_substs(tps: ~[ty::t]) -> ty::substs {
 pub fn bool_to_i1(bcx: block, llval: ValueRef) -> ValueRef {
     build::ICmp(bcx, lib::llvm::IntNE, llval, C_bool(false))
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -594,13 +594,3 @@ pub fn iter_vec_unboxed(bcx: block, body_ptr: ValueRef, vec_ty: ty::t,
     let dataptr = get_dataptr(bcx, body_ptr);
     return iter_vec_raw(bcx, dataptr, vec_ty, fill, f);
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4370,11 +4370,3 @@ pub fn visitor_object_ty(tcx: ctxt) -> (@TraitRef, t) {
     (trait_ref,
      mk_trait(tcx, trait_ref.def_id, copy trait_ref.substs, BoxTraitStore, ast::m_imm))
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -426,12 +426,3 @@ pub fn check_crate(tcx: ty::ctxt,
     tcx.sess.abort_if_errors();
     (ccx.method_map, ccx.vtable_map)
 }
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -357,11 +357,3 @@ pub fn main() {
         run_compiler(&args, demitter);
     }
 }
-
-
-// Local Variables:
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -112,13 +112,3 @@ pub fn pluralize(n: uint, s: ~str) -> ~str {
 
 // A set of node IDs (used to keep track of which node IDs are for statements)
 pub type stmt_set = @mut HashSet<ast::node_id>;
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -739,11 +739,3 @@ impl Repr for ty::vstore {
         vstore_to_str(tcx, *self)
     }
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End

--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -1507,13 +1507,3 @@ mod tests {
         }
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libstd/dbg.rs
+++ b/src/libstd/dbg.rs
@@ -76,11 +76,3 @@ fn test_breakpoint_should_not_abort_process_when_not_under_gdb() {
     // the process under normal circumstances
     breakpoint();
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -1374,11 +1374,3 @@ Options:
         assert!(usage == expected)
     }
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libstd/list.rs
+++ b/src/libstd/list.rs
@@ -242,11 +242,3 @@ mod tests {
             == list::append(list::from_vec(~[1,2]), list::from_vec(~[3,4])));
     }
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -412,11 +412,3 @@ mod tests {
         }
     }
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libstd/sort.rs
+++ b/src/libstd/sort.rs
@@ -1202,11 +1202,3 @@ mod big_tests {
         }
     }
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -121,11 +121,3 @@ pub mod std {
     pub use serialize;
     pub use test;
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libstd/term.rs
+++ b/src/libstd/term.rs
@@ -76,10 +76,3 @@ pub fn fg(writer: @io::Writer, color: u8) {
 pub fn bg(writer: @io::Writer, color: u8) {
     return set_color(writer, '4' as u8, color);
 }
-
-// Local Variables:
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -960,12 +960,3 @@ mod tests {
         }
     }
 }
-
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1346,12 +1346,3 @@ mod test {
 }
 
 */
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -404,11 +404,3 @@ pub fn node_item_query<Result>(items: map, id: node_id,
         _ => fail!(error_msg)
     }
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -832,11 +832,3 @@ mod test {
     }
 
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -341,13 +341,3 @@ pub fn require_unique_names(diagnostic: @span_handler,
         }
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -522,15 +522,3 @@ mod test {
         fm.next_line(BytePos(2));
     }
 }
-
-
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -187,15 +187,3 @@ pub fn expand_asm(cx: @ext_ctxt, sp: span, tts: &[ast::token_tree])
         span: sp
     })
 }
-
-
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -543,13 +543,3 @@ mod test {
         assert_eq!(*(m.find(&@~"def").get()),16);
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -34,13 +34,3 @@ pub fn expand_syntax_ext(cx: @ext_ctxt, sp: span, tts: &[ast::token_tree])
     };
     MRExpr(e)
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -721,11 +721,3 @@ mod test {
     }
 
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -322,12 +322,3 @@ fn pieces_to_expr(cx: @ext_ctxt, sp: span,
 
     return mk_block(cx, fmt_sp, ~[], stms, Some(buf()));
 }
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -150,13 +150,3 @@ fn res_rel_file(cx: @ext_ctxt, sp: codemap::span, arg: &Path) -> Path {
         copy *arg
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -438,11 +438,3 @@ pub fn parse_nt(p: &Parser, name: ~str) -> nonterminal {
       _ => p.fatal(~"Unsupported builtin nonterminal parser: " + name)
     }
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -859,13 +859,3 @@ impl AstFoldExtensions for @ast_fold {
 pub fn make_fold(afp: ast_fold_fns) -> @ast_fold {
     afp as @ast_fold
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -179,13 +179,3 @@ impl parser_attr for Parser {
         }
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -892,13 +892,3 @@ mod test {
         assert_eq!(tok, token::LIFETIME(id));
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -674,13 +674,3 @@ mod test {
         string_to_expr(@~"a::z.froob(b,@(987+3))");
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4509,14 +4509,3 @@ pub impl Parser {
         }
     }
 }
-
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -556,11 +556,3 @@ pub fn reserved_keyword_table() -> HashSet<~str> {
     }
     return words;
 }
-
-
-// Local Variables:
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -587,14 +587,3 @@ pub fn hardbreak_tok_offset(off: int) -> token {
 }
 
 pub fn hardbreak_tok() -> token { return hardbreak_tok_offset(0); }
-
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2280,13 +2280,3 @@ mod test {
         assert_eq!(&varstr,&~"pub principal_skinner");
     }
 }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -757,11 +757,3 @@ pub fn mk_simple_visitor(v: simple_visitor) -> vt<()> {
             v_struct_method(v.visit_struct_method, a, b, c)
     });
 }
-
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/test/run-pass/item-attributes.rs
+++ b/src/test/run-pass/item-attributes.rs
@@ -195,13 +195,3 @@ fn test_fn_inner() {
 }
 
 pub fn main() { }
-
-//
-// Local Variables:
-// mode: rust
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:
-//

--- a/src/test/run-pass/spawn.rs
+++ b/src/test/run-pass/spawn.rs
@@ -18,11 +18,3 @@ pub fn main() {
 }
 
 fn child(&&i: int) { error!(i); assert!((i == 10)); }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/test/run-pass/spawn2.rs
+++ b/src/test/run-pass/spawn2.rs
@@ -32,11 +32,3 @@ fn child(&&args: (int, int, int, int, int, int, int, int, int)) {
     assert!((i8 == 80));
     assert!((i9 == 90));
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/test/run-pass/task-killjoin-rsrc.rs
+++ b/src/test/run-pass/task-killjoin-rsrc.rs
@@ -83,11 +83,3 @@ fn supervisor() {
 pub fn main() {
     join(joinable(supervisor));
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:

--- a/src/test/run-pass/task-killjoin.rs
+++ b/src/test/run-pass/task-killjoin.rs
@@ -33,11 +33,3 @@ fn supervisor() {
 pub fn main() {
     task::spawn_unlinked(supervisor)
 }
-
-// Local Variables:
-// mode: rust;
-// fill-column: 78;
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// buffer-file-coding-system: utf-8-unix
-// End:


### PR DESCRIPTION
I have noticed these comments scattered across the codebase. They appear to be vestigial Emacs formatting settings and they don't appear in newer files. For the sake of consistency it's probably best to remove them.
