### PR TITLE
Add constants for trait object fields, and replace "magic numbers" in GEPi() calls with them

### DIFF
--- a/src/librustc/back/abi.rs
+++ b/src/librustc/back/abi.rs
@@ -57,6 +57,13 @@ pub static n_tydesc_fields: uint = 8u;
 pub static fn_field_code: uint = 0u;
 pub static fn_field_box: uint = 1u;
 
+// The three fields of a trait object/trait instance: vtable, box, and type
+// description.
+pub static trt_field_vtable: uint = 0u;
+pub static trt_field_box: uint = 1u;
+// This field is only present in unique trait objects, so it comes last.
+pub static trt_field_tydesc: uint = 2u;
+
 pub static vec_elt_fill: uint = 0u;
 
 pub static vec_elt_alloc: uint = 1u;

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -549,12 +549,12 @@ pub fn make_drop_glue(bcx: block, v0: ValueRef, t: ty::t) {
         closure::make_closure_glue(bcx, v0, t, drop_ty)
       }
       ty::ty_trait(_, _, ty::BoxTraitStore, _) => {
-        let llbox = Load(bcx, GEPi(bcx, v0, [0u, 1u]));
+        let llbox = Load(bcx, GEPi(bcx, v0, [0u, abi::trt_field_box]));
         decr_refcnt_maybe_free(bcx, llbox, ty::mk_opaque_box(ccx.tcx))
       }
       ty::ty_trait(_, _, ty::UniqTraitStore, _) => {
-        let lluniquevalue = GEPi(bcx, v0, [0, 1]);
-        let lltydesc = Load(bcx, GEPi(bcx, v0, [0, 2]));
+        let lluniquevalue = GEPi(bcx, v0, [0, abi::trt_field_box]);
+        let lltydesc = Load(bcx, GEPi(bcx, v0, [0, abi::trt_field_tydesc]));
         call_tydesc_glue_full(bcx, lluniquevalue, lltydesc,
                               abi::tydesc_field_free_glue, None);
         bcx
@@ -613,13 +613,13 @@ pub fn make_take_glue(bcx: block, v: ValueRef, t: ty::t) {
         closure::make_closure_glue(bcx, v, t, take_ty)
       }
       ty::ty_trait(_, _, ty::BoxTraitStore, _) => {
-        let llbox = Load(bcx, GEPi(bcx, v, [0u, 1u]));
+        let llbox = Load(bcx, GEPi(bcx, v, [0u, abi::trt_field_box]));
         incr_refcnt_of_boxed(bcx, llbox);
         bcx
       }
       ty::ty_trait(_, _, ty::UniqTraitStore, _) => {
-        let llval = GEPi(bcx, v, [0, 1]);
-        let lltydesc = Load(bcx, GEPi(bcx, v, [0, 2]));
+        let llval = GEPi(bcx, v, [0, abi::trt_field_box]);
+        let lltydesc = Load(bcx, GEPi(bcx, v, [0, abi::trt_field_tydesc]));
         call_tydesc_glue_full(bcx, llval, lltydesc,
                               abi::tydesc_field_take_glue, None);
         bcx


### PR DESCRIPTION
I don't know how one would write a separate test for this sort of thing. Building the compiler, and `make check` worked, which should mean I didn't screw anything up.
