### PR TITLE
Add error if RED_ZONE_SIZE doesn't get defined

### DIFF
--- a/src/rt/rust_task.h
+++ b/src/rt/rust_task.h
@@ -175,6 +175,10 @@
 #define RED_ZONE_SIZE RZ_MAC_32
 #endif
 
+#ifndef RED_ZONE_SIZE
+# error "Red zone not defined for this platform"
+#endif
+
 struct frame_glue_fns {
     uintptr_t mark_glue_off;
     uintptr_t drop_glue_off;


### PR DESCRIPTION
This has happened to two people trying to get Rust working on other platforms. Since it won't compile either way, make a nicer message for it (which will also point them straight to the correct file).
