### PR TITLE
rustc: remove ty::LegacyDtor

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3728,7 +3728,6 @@ pub fn item_path_str(cx: ctxt, id: ast::def_id) -> ~str {
 
 pub enum DtorKind {
     NoDtor,
-    LegacyDtor(def_id),
     TraitDtor(def_id)
 }
 


### PR DESCRIPTION
This patch removes ty::LegacyDtor, which is no longer used.
