### PR TITLE
libcore: Export core::from_str::FromStr from core::prelude

### DIFF
--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -108,9 +108,6 @@ mod tests {
 
     #[test]
     fn test_bool_from_str() {
-        #[cfg(stage0)]
-        use from_str::FromStr;
-
         do all_values |v| {
             assert!(Some(v) == FromStr::from_str(to_str(v)))
         }

--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -108,6 +108,7 @@ mod tests {
 
     #[test]
     fn test_bool_from_str() {
+        #[cfg(stage0)]
         use from_str::FromStr;
 
         do all_values |v| {

--- a/src/libcore/cast.rs
+++ b/src/libcore/cast.rs
@@ -10,7 +10,9 @@
 
 //! Unsafe casting functions
 
+#[cfg(not(stage0))]
 use sys;
+#[cfg(not(stage0))]
 use unstable;
 
 pub mod rusti {

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -111,6 +111,7 @@ pub use num::{Bitwise, BitCount, Bounded};
 pub use num::{Primitive, Int, Float};
 
 pub use ptr::Ptr;
+pub use from_str::FromStr;
 pub use to_str::ToStr;
 pub use clone::Clone;
 

--- a/src/libcore/flate.rs
+++ b/src/libcore/flate.rs
@@ -16,7 +16,6 @@ Simple compression
 
 use libc;
 use libc::{c_void, size_t, c_int};
-use ptr;
 use vec;
 
 #[cfg(test)] use rand;

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -10,7 +10,6 @@
 
 //! Operations and constants for `f32`
 
-use from_str;
 use num::{Zero, One, strconv};
 use prelude::*;
 
@@ -798,7 +797,7 @@ pub fn from_str_radix(num: &str, rdx: uint) -> Option<f32> {
                              strconv::ExpNone, false, false)
 }
 
-impl from_str::FromStr for f32 {
+impl FromStr for f32 {
     #[inline(always)]
     fn from_str(val: &str) -> Option<f32> { from_str(val) }
 }

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -10,7 +10,6 @@
 
 //! Operations and constants for `f64`
 
-use from_str;
 use libc::c_int;
 use num::{Zero, One, strconv};
 use prelude::*;
@@ -840,7 +839,7 @@ pub fn from_str_radix(num: &str, rdx: uint) -> Option<f64> {
                              strconv::ExpNone, false, false)
 }
 
-impl from_str::FromStr for f64 {
+impl FromStr for f64 {
     #[inline(always)]
     fn from_str(val: &str) -> Option<f64> { from_str(val) }
 }

--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -20,7 +20,6 @@
 
 // PORT this must match in width according to architecture
 
-use from_str;
 use libc::c_int;
 use num::{Zero, One, strconv};
 use prelude::*;
@@ -289,7 +288,7 @@ pub fn from_str_radix(num: &str, radix: uint) -> Option<float> {
                              strconv::ExpNone, false, false)
 }
 
-impl from_str::FromStr for float {
+impl FromStr for float {
     #[inline(always)]
     fn from_str(val: &str) -> Option<float> { from_str(val) }
 }

--- a/src/libcore/num/int-template.rs
+++ b/src/libcore/num/int-template.rs
@@ -10,7 +10,6 @@
 
 use T = self::inst::T;
 
-use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::{Zero, One, strconv};
 use prelude::*;

--- a/src/libcore/num/uint-template.rs
+++ b/src/libcore/num/uint-template.rs
@@ -11,7 +11,6 @@
 use T = self::inst::T;
 use T_SIGNED = self::inst::T_SIGNED;
 
-use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::{Zero, One, strconv};
 use prelude::*;

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -303,7 +303,7 @@ struct BufferResource<T> {
 }
 
 #[unsafe_destructor]
-impl<T> ::ops::Drop for BufferResource<T> {
+impl<T> Drop for BufferResource<T> {
     fn finalize(&self) {
         unsafe {
             let b = move_it!(self.buffer);
@@ -639,7 +639,7 @@ pub struct SendPacketBuffered<T, Tbuffer> {
 }
 
 #[unsafe_destructor]
-impl<T:Owned,Tbuffer:Owned> ::ops::Drop for SendPacketBuffered<T,Tbuffer> {
+impl<T:Owned,Tbuffer:Owned> Drop for SendPacketBuffered<T,Tbuffer> {
     fn finalize(&self) {
         //if self.p != none {
         //    debug!("drop send %?", option::get(self.p));
@@ -708,7 +708,7 @@ pub struct RecvPacketBuffered<T, Tbuffer> {
 }
 
 #[unsafe_destructor]
-impl<T:Owned,Tbuffer:Owned> ::ops::Drop for RecvPacketBuffered<T,Tbuffer> {
+impl<T:Owned,Tbuffer:Owned> Drop for RecvPacketBuffered<T,Tbuffer> {
     fn finalize(&self) {
         //if self.p != none {
         //    debug!("drop recv %?", option::get(self.p));

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -51,6 +51,7 @@ pub use path::WindowsPath;
 pub use ptr::Ptr;
 pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr};
 pub use str::{StrSlice, OwnedStr};
+pub use from_str::{FromStr};
 pub use to_bytes::IterBytes;
 pub use to_str::{ToStr, ToStrConsume};
 pub use tuple::{CopyableTuple, ImmutableTuple, ExtendedTupleOps};

--- a/src/libstd/net_url.rs
+++ b/src/libstd/net_url.rs
@@ -13,15 +13,13 @@
 #[allow(deprecated_mode)];
 
 use core::cmp::Eq;
+#[cfg(stage0)]
 use core::from_str::FromStr;
 use core::io::{Reader, ReaderUtil};
 use core::io;
 use core::hashmap::HashMap;
 use core::str;
-use core::to_bytes::IterBytes;
 use core::to_bytes;
-use core::to_str::ToStr;
-use core::to_str;
 use core::uint;
 
 #[deriving(Clone, Eq)]
@@ -703,13 +701,13 @@ pub fn to_str(url: &Url) -> ~str {
     fmt!("%s:%s%s%s%s", url.scheme, authority, url.path, query, fragment)
 }
 
-impl to_str::ToStr for Url {
+impl ToStr for Url {
     pub fn to_str(&self) -> ~str {
         to_str(self)
     }
 }
 
-impl to_bytes::IterBytes for Url {
+impl IterBytes for Url {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.to_str().iter_bytes(lsb0, f)
     }

--- a/src/libstd/net_url.rs
+++ b/src/libstd/net_url.rs
@@ -13,8 +13,6 @@
 #[allow(deprecated_mode)];
 
 use core::cmp::Eq;
-#[cfg(stage0)]
-use core::from_str::FromStr;
 use core::io::{Reader, ReaderUtil};
 use core::io;
 use core::hashmap::HashMap;

--- a/src/libstd/num/bigint.rs
+++ b/src/libstd/num/bigint.rs
@@ -21,7 +21,6 @@ A BigInt is a combination of BigUint and Sign.
 
 use core::cmp::{Eq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater};
 use core::num::{IntConvertible, Zero, One, ToStrRadix, FromStrRadix};
-use core::*;
 
 /**
 A BigDigit is a BigUint's composing element.
@@ -141,7 +140,7 @@ impl ToStr for BigUint {
     fn to_str(&self) -> ~str { self.to_str_radix(10) }
 }
 
-impl from_str::FromStr for BigUint {
+impl FromStr for BigUint {
     #[inline(always)]
     fn from_str(s: &str) -> Option<BigUint> {
         FromStrRadix::from_str_radix(s, 10)
@@ -785,7 +784,7 @@ impl ToStr for BigInt {
     fn to_str(&self) -> ~str { self.to_str_radix(10) }
 }
 
-impl from_str::FromStr for BigInt {
+impl FromStr for BigInt {
     #[inline(always)]
     fn from_str(s: &str) -> Option<BigInt> {
         FromStrRadix::from_str_radix(s, 10)


### PR DESCRIPTION
`core::prelude`  re-exports `core::to_str::ToStr`, but doesn't re-export `core::from_str::FromStr`.
That is inconsistent.
