### PR TITLE
re-xfail some tests that fail on x86

### DIFF
--- a/src/test/run-pass/tag-align-dyn-u64.rs
+++ b/src/test/run-pass/tag-align-dyn-u64.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test
+
 enum a_tag<A> {
     a_tag(A)
 }

--- a/src/test/run-pass/tag-align-dyn-variants.rs
+++ b/src/test/run-pass/tag-align-dyn-variants.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test
+
 enum a_tag<A,B> {
     varA(A),
     varB(B)

--- a/src/test/run-pass/tag-align-u64.rs
+++ b/src/test/run-pass/tag-align-u64.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test
 
 enum a_tag {
     a_tag(u64)


### PR DESCRIPTION
These were accidentally un-xfail'ed since they pass on x64. They don't yet on x86.
