### PR TITLE
Implement the new for-loop protocol

### DIFF
--- a/src/libcore/container.rs
+++ b/src/libcore/container.rs
@@ -30,16 +30,32 @@ pub trait Map<K, V>: Mutable {
     fn contains_key(&self, key: &K) -> bool;
 
     // Visits all keys and values
+    #[cfg(stage0)]
     fn each<'a>(&'a self, f: &fn(&K, &'a V) -> bool);
+    // Visits all keys and values
+    #[cfg(not(stage0))]
+    fn each<'a>(&'a self, f: &fn(&K, &'a V) -> bool) -> bool;
 
     /// Visit all keys
+    #[cfg(stage0)]
     fn each_key(&self, f: &fn(&K) -> bool);
+    /// Visit all keys
+    #[cfg(not(stage0))]
+    fn each_key(&self, f: &fn(&K) -> bool) -> bool;
 
     /// Visit all values
+    #[cfg(stage0)]
     fn each_value<'a>(&'a self, f: &fn(&'a V) -> bool);
+    /// Visit all values
+    #[cfg(not(stage0))]
+    fn each_value<'a>(&'a self, f: &fn(&'a V) -> bool) -> bool;
 
     /// Iterate over the map and mutate the contained values
+    #[cfg(stage0)]
     fn mutate_values(&mut self, f: &fn(&K, &mut V) -> bool);
+    /// Iterate over the map and mutate the contained values
+    #[cfg(not(stage0))]
+    fn mutate_values(&mut self, f: &fn(&K, &mut V) -> bool) -> bool;
 
     /// Return a reference to the value corresponding to the key
     fn find<'a>(&'a self, key: &K) -> Option<&'a V>;
@@ -65,6 +81,7 @@ pub trait Map<K, V>: Mutable {
     fn pop(&mut self, k: &K) -> Option<V>;
 }
 
+#[cfg(stage0)]
 pub trait Set<T>: Mutable {
     /// Return true if the set contains a value
     fn contains(&self, value: &T) -> bool;
@@ -98,4 +115,40 @@ pub trait Set<T>: Mutable {
 
     /// Visit the values representing the union
     fn union(&self, other: &Self, f: &fn(&T) -> bool);
+}
+
+#[cfg(not(stage0))]
+pub trait Set<T>: Mutable {
+    /// Return true if the set contains a value
+    fn contains(&self, value: &T) -> bool;
+
+    /// Add a value to the set. Return true if the value was not already
+    /// present in the set.
+    fn insert(&mut self, value: T) -> bool;
+
+    /// Remove a value from the set. Return true if the value was
+    /// present in the set.
+    fn remove(&mut self, value: &T) -> bool;
+
+    /// Return true if the set has no elements in common with `other`.
+    /// This is equivalent to checking for an empty intersection.
+    fn is_disjoint(&self, other: &Self) -> bool;
+
+    /// Return true if the set is a subset of another
+    fn is_subset(&self, other: &Self) -> bool;
+
+    /// Return true if the set is a superset of another
+    fn is_superset(&self, other: &Self) -> bool;
+
+    /// Visit the values representing the difference
+    fn difference(&self, other: &Self, f: &fn(&T) -> bool) -> bool;
+
+    /// Visit the values representing the symmetric difference
+    fn symmetric_difference(&self, other: &Self, f: &fn(&T) -> bool) -> bool;
+
+    /// Visit the values representing the intersection
+    fn intersection(&self, other: &Self, f: &fn(&T) -> bool) -> bool;
+
+    /// Visit the values representing the union
+    fn union(&self, other: &Self, f: &fn(&T) -> bool) -> bool;
 }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -40,11 +40,16 @@ much easier to implement.
 
 */
 
-use cmp::Ord;
-use option::{Option, Some, None};
+#[cfg(not(stage0))] use cmp::Ord;
+#[cfg(not(stage0))] use option::{Option, Some, None};
 
+#[cfg(stage0)]
 pub trait Times {
     fn times(&self, it: &fn() -> bool);
+}
+#[cfg(not(stage0))]
+pub trait Times {
+    fn times(&self, it: &fn() -> bool) -> bool;
 }
 
 /**
@@ -59,7 +64,8 @@ pub trait Times {
  * ~~~
  */
 #[inline(always)]
-pub fn to_vec<T>(iter: &fn(f: &fn(T) -> bool)) -> ~[T] {
+#[cfg(not(stage0))]
+pub fn to_vec<T>(iter: &fn(f: &fn(T) -> bool) -> bool) -> ~[T] {
     let mut v = ~[];
     for iter |x| { v.push(x) }
     v
@@ -77,13 +83,12 @@ pub fn to_vec<T>(iter: &fn(f: &fn(T) -> bool)) -> ~[T] {
  * ~~~~
  */
 #[inline(always)]
-pub fn any<T>(predicate: &fn(T) -> bool, iter: &fn(f: &fn(T) -> bool)) -> bool {
-    for iter |x| {
-        if predicate(x) {
-            return true
-        }
-    }
-    false
+#[cfg(not(stage0))]
+pub fn any<T>(predicate: &fn(T) -> bool,
+              iter: &fn(f: &fn(T) -> bool) -> bool) -> bool {
+    // If the predicate returns true, we break. If we ever broke, then we found
+    // something
+    !iter(|x| !predicate(x))
 }
 
 /**
@@ -97,13 +102,12 @@ pub fn any<T>(predicate: &fn(T) -> bool, iter: &fn(f: &fn(T) -> bool)) -> bool {
  * ~~~~
  */
 #[inline(always)]
-pub fn all<T>(predicate: &fn(T) -> bool, iter: &fn(f: &fn(T) -> bool)) -> bool {
-    for iter |x| {
-        if !predicate(x) {
-            return false
-        }
-    }
-    true
+#[cfg(not(stage0))]
+pub fn all<T>(predicate: &fn(T) -> bool,
+              iter: &fn(f: &fn(T) -> bool) -> bool) -> bool {
+    // If we ever break, iter will return false, so this will only return true
+    // if predicate returns true for everything.
+    iter(|x| predicate(x))
 }
 
 /**
@@ -117,7 +121,9 @@ pub fn all<T>(predicate: &fn(T) -> bool, iter: &fn(f: &fn(T) -> bool)) -> bool {
  * ~~~~
  */
 #[inline(always)]
-pub fn find<T>(predicate: &fn(&T) -> bool, iter: &fn(f: &fn(T) -> bool)) -> Option<T> {
+#[cfg(not(stage0))]
+pub fn find<T>(predicate: &fn(&T) -> bool,
+               iter: &fn(f: &fn(T) -> bool) -> bool) -> Option<T> {
     for iter |x| {
         if predicate(&x) {
             return Some(x);
@@ -137,7 +143,8 @@ pub fn find<T>(predicate: &fn(&T) -> bool, iter: &fn(f: &fn(T) -> bool)) -> Opti
  * ~~~~
  */
 #[inline]
-pub fn max<T: Ord>(iter: &fn(f: &fn(T) -> bool)) -> Option<T> {
+#[cfg(not(stage0))]
+pub fn max<T: Ord>(iter: &fn(f: &fn(T) -> bool) -> bool) -> Option<T> {
     let mut result = None;
     for iter |x| {
         match result {
@@ -163,7 +170,8 @@ pub fn max<T: Ord>(iter: &fn(f: &fn(T) -> bool)) -> Option<T> {
  * ~~~~
  */
 #[inline]
-pub fn min<T: Ord>(iter: &fn(f: &fn(T) -> bool)) -> Option<T> {
+#[cfg(not(stage0))]
+pub fn min<T: Ord>(iter: &fn(f: &fn(T) -> bool) -> bool) -> Option<T> {
     let mut result = None;
     for iter |x| {
         match result {

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -86,9 +86,34 @@ pub fn to_vec<T>(iter: &fn(f: &fn(T) -> bool) -> bool) -> ~[T] {
 #[cfg(not(stage0))]
 pub fn any<T>(predicate: &fn(T) -> bool,
               iter: &fn(f: &fn(T) -> bool) -> bool) -> bool {
-    // If the predicate returns true, we break. If we ever broke, then we found
-    // something
-    !iter(|x| !predicate(x))
+    for iter |x| {
+        if predicate(x) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Return true if `predicate` is true for all values yielded by an internal iterator.
+ *
+ * # Example:
+ *
+ * ~~~~
+ * assert!(all(|&x: &uint| x < 6, |f| uint::range(1, 6, f)));
+ * assert!(!all(|&x: &uint| x < 5, |f| uint::range(1, 6, f)));
+ * ~~~~
+ */
+#[inline(always)]
+#[cfg(stage0)]
+pub fn all<T>(predicate: &fn(T) -> bool,
+              iter: &fn(f: &fn(T) -> bool)) -> bool {
+    for iter |x| {
+        if !predicate(x) {
+            return false;
+        }
+    }
+    return true;
 }
 
 /**

--- a/src/libcore/iterator.rs
+++ b/src/libcore/iterator.rs
@@ -41,7 +41,10 @@ pub trait IteratorUtil<A> {
     fn take(self, n: uint) -> TakeIterator<Self>;
     fn scan<'r, St, B>(self, initial_state: St, f: &'r fn(&mut St, A) -> Option<B>)
         -> ScanIterator<'r, A, B, Self, St>;
+    #[cfg(stage0)]
     fn advance(&mut self, f: &fn(A) -> bool);
+    #[cfg(not(stage0))]
+    fn advance(&mut self, f: &fn(A) -> bool) -> bool;
 }
 
 /// Iterator adaptors provided for every `Iterator` implementation. The adaptor objects are also
@@ -103,13 +106,28 @@ impl<A, T: Iterator<A>> IteratorUtil<A> for T {
 
     /// A shim implementing the `for` loop iteration protocol for iterator objects
     #[inline]
+    #[cfg(stage0)]
     fn advance(&mut self, f: &fn(A) -> bool) {
         loop {
             match self.next() {
                 Some(x) => {
-                    if !f(x) { return }
+                    if !f(x) { return; }
                 }
-                None => return
+                None => { return; }
+            }
+        }
+    }
+
+    /// A shim implementing the `for` loop iteration protocol for iterator objects
+    #[inline]
+    #[cfg(not(stage0))]
+    fn advance(&mut self, f: &fn(A) -> bool) -> bool {
+        loop {
+            match self.next() {
+                Some(x) => {
+                    if !f(x) { return false; }
+                }
+                None => { return true; }
             }
         }
     }

--- a/src/libcore/num/int-template.rs
+++ b/src/libcore/num/int-template.rs
@@ -86,37 +86,62 @@ pub fn gt(x: T, y: T) -> bool { x > y }
 ///
 #[inline(always)]
 /// Iterate over the range [`start`,`start`+`step`..`stop`)
-pub fn range_step(start: T, stop: T, step: T, it: &fn(T) -> bool) {
+pub fn _range_step(start: T, stop: T, step: T, it: &fn(T) -> bool) -> bool {
     let mut i = start;
     if step == 0 {
         fail!(~"range_step called with step == 0");
     } else if step > 0 { // ascending
         while i < stop {
-            if !it(i) { break }
+            if !it(i) { return false; }
             // avoiding overflow. break if i + step > max_value
-            if i > max_value - step { break; }
+            if i > max_value - step { return true; }
             i += step;
         }
     } else { // descending
         while i > stop {
-            if !it(i) { break }
+            if !it(i) { return false; }
             // avoiding underflow. break if i + step < min_value
-            if i < min_value - step { break; }
+            if i < min_value - step { return true; }
             i += step;
         }
     }
+    return true;
+}
+
+#[cfg(stage0)]
+pub fn range_step(start: T, stop: T, step: T, it: &fn(T) -> bool) {
+    _range_step(start, stop, step, it);
+}
+#[cfg(not(stage0))]
+pub fn range_step(start: T, stop: T, step: T, it: &fn(T) -> bool) -> bool {
+    _range_step(start, stop, step, it)
 }
 
 #[inline(always)]
+#[cfg(stage0)]
 /// Iterate over the range [`lo`..`hi`)
 pub fn range(lo: T, hi: T, it: &fn(T) -> bool) {
     range_step(lo, hi, 1 as T, it);
 }
 
 #[inline(always)]
+#[cfg(not(stage0))]
+/// Iterate over the range [`lo`..`hi`)
+pub fn range(lo: T, hi: T, it: &fn(T) -> bool) -> bool {
+    range_step(lo, hi, 1 as T, it)
+}
+
+#[inline(always)]
+#[cfg(stage0)]
 /// Iterate over the range [`hi`..`lo`)
 pub fn range_rev(hi: T, lo: T, it: &fn(T) -> bool) {
     range_step(hi, lo, -1 as T, it);
+}
+#[inline(always)]
+#[cfg(not(stage0))]
+/// Iterate over the range [`hi`..`lo`)
+pub fn range_rev(hi: T, lo: T, it: &fn(T) -> bool) -> bool {
+    range_step(hi, lo, -1 as T, it)
 }
 
 /// Computes the bitwise complement

--- a/src/libcore/num/uint-template.rs
+++ b/src/libcore/num/uint-template.rs
@@ -51,41 +51,67 @@ pub fn gt(x: T, y: T) -> bool { x > y }
 ///
 /// Iterate over the range [`start`,`start`+`step`..`stop`)
 ///
-pub fn range_step(start: T,
-                       stop: T,
-                       step: T_SIGNED,
-                       it: &fn(T) -> bool) {
+pub fn _range_step(start: T,
+                   stop: T,
+                   step: T_SIGNED,
+                   it: &fn(T) -> bool) -> bool {
     let mut i = start;
     if step == 0 {
         fail!(~"range_step called with step == 0");
     }
     if step >= 0 {
         while i < stop {
-            if !it(i) { break }
+            if !it(i) { return false; }
             // avoiding overflow. break if i + step > max_value
-            if i > max_value - (step as T) { break; }
+            if i > max_value - (step as T) { return true; }
             i += step as T;
         }
     } else {
         while i > stop {
-            if !it(i) { break }
+            if !it(i) { return false; }
             // avoiding underflow. break if i + step < min_value
-            if i < min_value + ((-step) as T) { break; }
+            if i < min_value + ((-step) as T) { return true; }
             i -= -step as T;
         }
     }
+    return true;
+}
+
+#[cfg(stage0)]
+pub fn range_step(start: T, stop: T, step: T_SIGNED, it: &fn(T) -> bool) {
+    _range_step(start, stop, step, it);
+}
+#[cfg(not(stage0))]
+pub fn range_step(start: T, stop: T, step: T_SIGNED, it: &fn(T) -> bool) -> bool {
+    _range_step(start, stop, step, it)
 }
 
 #[inline(always)]
+#[cfg(stage0)]
 /// Iterate over the range [`lo`..`hi`)
 pub fn range(lo: T, hi: T, it: &fn(T) -> bool) {
     range_step(lo, hi, 1 as T_SIGNED, it);
 }
 
 #[inline(always)]
+#[cfg(not(stage0))]
+/// Iterate over the range [`lo`..`hi`)
+pub fn range(lo: T, hi: T, it: &fn(T) -> bool) -> bool {
+    range_step(lo, hi, 1 as T_SIGNED, it)
+}
+
+#[inline(always)]
+#[cfg(stage0)]
 /// Iterate over the range [`hi`..`lo`)
 pub fn range_rev(hi: T, lo: T, it: &fn(T) -> bool) {
     range_step(hi, lo, -1 as T_SIGNED, it);
+}
+
+#[inline(always)]
+#[cfg(not(stage0))]
+/// Iterate over the range [`hi`..`lo`)
+pub fn range_rev(hi: T, lo: T, it: &fn(T) -> bool) -> bool {
+    range_step(hi, lo, -1 as T_SIGNED, it)
 }
 
 /// Computes the bitwise complement

--- a/src/libcore/num/uint-template/uint.rs
+++ b/src/libcore/num/uint-template/uint.rs
@@ -154,6 +154,7 @@ pub mod inst {
         return true;
     }
 
+    #[cfg(stage0)]
     impl iter::Times for uint {
         #[inline(always)]
         ///
@@ -172,6 +173,29 @@ pub mod inst {
                 if !it() { break }
                 i -= 1;
             }
+        }
+    }
+
+    #[cfg(not(stage0))]
+    impl iter::Times for uint {
+        #[inline(always)]
+        ///
+        /// A convenience form for basic iteration. Given a uint `x`,
+        /// `for x.times { ... }` executes the given block x times.
+        ///
+        /// Equivalent to `for uint::range(0, x) |_| { ... }`.
+        ///
+        /// Not defined on all integer types to permit unambiguous
+        /// use with integer literals of inferred integer-type as
+        /// the self-value (eg. `for 100.times { ... }`).
+        ///
+        fn times(&self, it: &fn() -> bool) -> bool {
+            let mut i = *self;
+            while i > 0 {
+                if !it() { return false; }
+                i -= 1;
+            }
+            return true;
         }
     }
 

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -101,8 +101,15 @@ impl<T: Copy + Add<T,T>> Add<Option<T>, Option<T>> for Option<T> {
 impl<T> BaseIter<T> for Option<T> {
     /// Performs an operation on the contained value by reference
     #[inline(always)]
+    #[cfg(stage0)]
     fn each<'a>(&'a self, f: &fn(x: &'a T) -> bool) {
         match *self { None => (), Some(ref t) => { f(t); } }
+    }
+    /// Performs an operation on the contained value by reference
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn each<'a>(&'a self, f: &fn(x: &'a T) -> bool) -> bool {
+        match *self { None => true, Some(ref t) => { f(t) } }
     }
 
     #[inline(always)]
@@ -112,14 +119,25 @@ impl<T> BaseIter<T> for Option<T> {
 }
 
 impl<T> MutableIter<T> for Option<T> {
+    #[cfg(stage0)]
     #[inline(always)]
     fn each_mut<'a>(&'a mut self, f: &fn(&'a mut T) -> bool) {
         match *self { None => (), Some(ref mut t) => { f(t); } }
     }
+    #[cfg(not(stage0))]
+    #[inline(always)]
+    fn each_mut<'a>(&'a mut self, f: &fn(&'a mut T) -> bool) -> bool {
+        match *self { None => true, Some(ref mut t) => { f(t) } }
+    }
 }
 
 impl<A> ExtendedIter<A> for Option<A> {
+    #[cfg(stage0)]
     pub fn eachi(&self, blk: &fn(uint, v: &A) -> bool) {
+        old_iter::eachi(self, blk)
+    }
+    #[cfg(not(stage0))]
+    pub fn eachi(&self, blk: &fn(uint, v: &A) -> bool) -> bool {
         old_iter::eachi(self, blk)
     }
     pub fn all(&self, blk: &fn(&A) -> bool) -> bool {

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -550,6 +550,7 @@ pub fn tmpdir() -> Path {
     }
 }
 /// Recursively walk a directory structure
+#[cfg(stage0)]
 pub fn walk_dir(p: &Path, f: &fn(&Path) -> bool) {
 
     walk_dir_(p, f);
@@ -576,6 +577,14 @@ pub fn walk_dir(p: &Path, f: &fn(&Path) -> bool) {
         }
         return keepgoing;
     }
+}
+/// Recursively walk a directory structure
+#[cfg(not(stage0))]
+pub fn walk_dir(p: &Path, f: &fn(&Path) -> bool) -> bool {
+    list_dir(p).each(|q| {
+        let path = &p.push(*q);
+        f(path) && (!path_is_dir(path) || walk_dir(path, f))
+    })
 }
 
 /// Indicates whether a path represents a directory

--- a/src/libcore/stackwalk.rs
+++ b/src/libcore/stackwalk.rs
@@ -24,6 +24,7 @@ pub fn Frame(fp: *Word) -> Frame {
     }
 }
 
+#[cfg(stage0)]
 pub fn walk_stack(visit: &fn(Frame) -> bool) {
 
     debug!("beginning stack walk");
@@ -50,6 +51,35 @@ pub fn walk_stack(visit: &fn(Frame) -> bool) {
             }
         }
     }
+}
+#[cfg(not(stage0))]
+pub fn walk_stack(visit: &fn(Frame) -> bool) -> bool {
+
+    debug!("beginning stack walk");
+
+    do frame_address |frame_pointer| {
+        let mut frame_address: *Word = unsafe {
+            transmute(frame_pointer)
+        };
+        loop {
+            let fr = Frame(frame_address);
+
+            debug!("frame: %x", unsafe { transmute(fr.fp) });
+            visit(fr);
+
+            unsafe {
+                let next_fp: **Word = transmute(frame_address);
+                frame_address = *next_fp;
+                if *frame_address == 0u {
+                    debug!("encountered task_start_wrapper. ending walk");
+                    // This is the task_start_wrapper_frame. There is
+                    // no stack beneath it and it is a foreign frame.
+                    break;
+                }
+            }
+        }
+    }
+    return true;
 }
 
 #[test]

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -566,14 +566,30 @@ pub fn slice<'a>(s: &'a str, begin: uint, end: uint) -> &'a str {
 }
 
 /// Splits a string into substrings at each occurrence of a given character
+#[cfg(stage0)]
 pub fn each_split_char<'a>(s: &'a str, sep: char, it: &fn(&'a str) -> bool) {
+    each_split_char_inner(s, sep, len(s), true, true, it);
+}
+
+/// Splits a string into substrings at each occurrence of a given character
+#[cfg(not(stage0))]
+pub fn each_split_char<'a>(s: &'a str, sep: char,
+                           it: &fn(&'a str) -> bool) -> bool {
     each_split_char_inner(s, sep, len(s), true, true, it)
 }
 
 /// Like `each_split_char`, but a trailing empty string is omitted
+#[cfg(stage0)]
 pub fn each_split_char_no_trailing<'a>(s: &'a str,
                                        sep: char,
                                        it: &fn(&'a str) -> bool) {
+    each_split_char_inner(s, sep, len(s), true, false, it);
+}
+/// Like `each_split_char`, but a trailing empty string is omitted
+#[cfg(not(stage0))]
+pub fn each_split_char_no_trailing<'a>(s: &'a str,
+                                       sep: char,
+                                       it: &fn(&'a str) -> bool) -> bool {
     each_split_char_inner(s, sep, len(s), true, false, it)
 }
 
@@ -583,17 +599,39 @@ pub fn each_split_char_no_trailing<'a>(s: &'a str,
  *
  * The character must be a valid UTF-8/ASCII character
  */
+#[cfg(stage0)]
 pub fn each_splitn_char<'a>(s: &'a str,
                             sep: char,
                             count: uint,
                             it: &fn(&'a str) -> bool) {
+    each_split_char_inner(s, sep, count, true, true, it);
+}
+/**
+ * Splits a string into substrings at each occurrence of a given
+ * character up to 'count' times.
+ *
+ * The character must be a valid UTF-8/ASCII character
+ */
+#[cfg(not(stage0))]
+pub fn each_splitn_char<'a>(s: &'a str,
+                            sep: char,
+                            count: uint,
+                            it: &fn(&'a str) -> bool) -> bool {
     each_split_char_inner(s, sep, count, true, true, it)
 }
 
 /// Like `each_split_char`, but omits empty strings
+#[cfg(stage0)]
 pub fn each_split_char_nonempty<'a>(s: &'a str,
                                     sep: char,
                                     it: &fn(&'a str) -> bool) {
+    each_split_char_inner(s, sep, len(s), false, false, it);
+}
+/// Like `each_split_char`, but omits empty strings
+#[cfg(not(stage0))]
+pub fn each_split_char_nonempty<'a>(s: &'a str,
+                                    sep: char,
+                                    it: &fn(&'a str) -> bool) -> bool {
     each_split_char_inner(s, sep, len(s), false, false, it)
 }
 
@@ -602,7 +640,7 @@ fn each_split_char_inner<'a>(s: &'a str,
                              count: uint,
                              allow_empty: bool,
                              allow_trailing_empty: bool,
-                             it: &fn(&'a str) -> bool) {
+                             it: &fn(&'a str) -> bool) -> bool {
     if sep < 128u as char {
         let b = sep as u8, l = len(s);
         let mut done = 0u;
@@ -610,7 +648,9 @@ fn each_split_char_inner<'a>(s: &'a str,
         while i < l && done < count {
             if s[i] == b {
                 if allow_empty || start < i {
-                    if !it( unsafe{ raw::slice_bytes(s, start, i) } ) { return; }
+                    if !it( unsafe{ raw::slice_bytes(s, start, i) } ) {
+                        return false;
+                    }
                 }
                 start = i + 1u;
                 done += 1u;
@@ -619,24 +659,41 @@ fn each_split_char_inner<'a>(s: &'a str,
         }
         // only slice a non-empty trailing substring
         if allow_trailing_empty || start < l {
-            if !it( unsafe{ raw::slice_bytes(s, start, l) } ) { return; }
+            if !it( unsafe{ raw::slice_bytes(s, start, l) } ) { return false; }
         }
-    } else {
-        each_split_inner(s, |cur| cur == sep, count, allow_empty, allow_trailing_empty, it)
+        return true;
     }
+    return each_split_inner(s, |cur| cur == sep, count,
+                            allow_empty, allow_trailing_empty, it)
 }
 
 /// Splits a string into substrings using a character function
+#[cfg(stage0)]
 pub fn each_split<'a>(s: &'a str,
                       sepfn: &fn(char) -> bool,
                       it: &fn(&'a str) -> bool) {
+    each_split_inner(s, sepfn, len(s), true, true, it);
+}
+/// Splits a string into substrings using a character function
+#[cfg(not(stage0))]
+pub fn each_split<'a>(s: &'a str,
+                      sepfn: &fn(char) -> bool,
+                      it: &fn(&'a str) -> bool) -> bool {
     each_split_inner(s, sepfn, len(s), true, true, it)
 }
 
 /// Like `each_split`, but a trailing empty string is omitted
+#[cfg(stage0)]
 pub fn each_split_no_trailing<'a>(s: &'a str,
                                   sepfn: &fn(char) -> bool,
                                   it: &fn(&'a str) -> bool) {
+    each_split_inner(s, sepfn, len(s), true, false, it);
+}
+/// Like `each_split`, but a trailing empty string is omitted
+#[cfg(not(stage0))]
+pub fn each_split_no_trailing<'a>(s: &'a str,
+                                  sepfn: &fn(char) -> bool,
+                                  it: &fn(&'a str) -> bool) -> bool {
     each_split_inner(s, sepfn, len(s), true, false, it)
 }
 
@@ -644,17 +701,37 @@ pub fn each_split_no_trailing<'a>(s: &'a str,
  * Splits a string into substrings using a character function, cutting at
  * most `count` times.
  */
+#[cfg(stage0)]
 pub fn each_splitn<'a>(s: &'a str,
                        sepfn: &fn(char) -> bool,
                        count: uint,
                        it: &fn(&'a str) -> bool) {
+    each_split_inner(s, sepfn, count, true, true, it);
+}
+/**
+ * Splits a string into substrings using a character function, cutting at
+ * most `count` times.
+ */
+#[cfg(not(stage0))]
+pub fn each_splitn<'a>(s: &'a str,
+                       sepfn: &fn(char) -> bool,
+                       count: uint,
+                       it: &fn(&'a str) -> bool) -> bool {
     each_split_inner(s, sepfn, count, true, true, it)
 }
 
 /// Like `each_split`, but omits empty strings
+#[cfg(stage0)]
 pub fn each_split_nonempty<'a>(s: &'a str,
                                sepfn: &fn(char) -> bool,
                                it: &fn(&'a str) -> bool) {
+    each_split_inner(s, sepfn, len(s), false, false, it);
+}
+/// Like `each_split`, but omits empty strings
+#[cfg(not(stage0))]
+pub fn each_split_nonempty<'a>(s: &'a str,
+                               sepfn: &fn(char) -> bool,
+                               it: &fn(&'a str) -> bool) -> bool {
     each_split_inner(s, sepfn, len(s), false, false, it)
 }
 
@@ -663,14 +740,16 @@ fn each_split_inner<'a>(s: &'a str,
                         count: uint,
                         allow_empty: bool,
                         allow_trailing_empty: bool,
-                        it: &fn(&'a str) -> bool) {
+                        it: &fn(&'a str) -> bool) -> bool {
     let l = len(s);
     let mut i = 0u, start = 0u, done = 0u;
     while i < l && done < count {
         let CharRange {ch, next} = char_range_at(s, i);
         if sepfn(ch) {
             if allow_empty || start < i {
-                if !it( unsafe{ raw::slice_bytes(s, start, i) } ) { return; }
+                if !it( unsafe{ raw::slice_bytes(s, start, i) } ) {
+                    return false;
+                }
             }
             start = next;
             done += 1u;
@@ -678,12 +757,15 @@ fn each_split_inner<'a>(s: &'a str,
         i = next;
     }
     if allow_trailing_empty || start < l {
-        if !it( unsafe{ raw::slice_bytes(s, start, l) } ) { return;  }
+        if !it( unsafe{ raw::slice_bytes(s, start, l) } ) { return false; }
     }
+    return true;
 }
 
 // See Issue #1932 for why this is a naive search
-fn iter_matches<'a,'b>(s: &'a str, sep: &'b str, f: &fn(uint, uint) -> bool) {
+#[cfg(stage0)]
+fn iter_matches<'a,'b>(s: &'a str, sep: &'b str,
+                       f: &fn(uint, uint) -> bool) {
     let sep_len = len(sep), l = len(s);
     assert!(sep_len > 0u);
     let mut i = 0u, match_start = 0u, match_i = 0u;
@@ -709,7 +791,38 @@ fn iter_matches<'a,'b>(s: &'a str, sep: &'b str, f: &fn(uint, uint) -> bool) {
         }
     }
 }
+// See Issue #1932 for why this is a naive search
+#[cfg(not(stage0))]
+fn iter_matches<'a,'b>(s: &'a str, sep: &'b str,
+                       f: &fn(uint, uint) -> bool) -> bool {
+    let sep_len = len(sep), l = len(s);
+    assert!(sep_len > 0u);
+    let mut i = 0u, match_start = 0u, match_i = 0u;
 
+    while i < l {
+        if s[i] == sep[match_i] {
+            if match_i == 0u { match_start = i; }
+            match_i += 1u;
+            // Found a match
+            if match_i == sep_len {
+                if !f(match_start, i + 1u) { return false; }
+                match_i = 0u;
+            }
+            i += 1u;
+        } else {
+            // Failed match, backtrack
+            if match_i > 0u {
+                match_i = 0u;
+                i = match_start + 1u;
+            } else {
+                i += 1u;
+            }
+        }
+    }
+    return true;
+}
+
+#[cfg(stage0)]
 fn iter_between_matches<'a,'b>(s: &'a str,
                                sep: &'b str,
                                f: &fn(uint, uint) -> bool) {
@@ -719,6 +832,17 @@ fn iter_between_matches<'a,'b>(s: &'a str,
         last_end = to;
     }
     f(last_end, len(s));
+}
+#[cfg(not(stage0))]
+fn iter_between_matches<'a,'b>(s: &'a str,
+                               sep: &'b str,
+                               f: &fn(uint, uint) -> bool) -> bool {
+    let mut last_end = 0u;
+    for iter_matches(s, sep) |from, to| {
+        if !f(last_end, from) { return false; }
+        last_end = to;
+    }
+    return f(last_end, len(s));
 }
 
 /**
@@ -732,6 +856,7 @@ fn iter_between_matches<'a,'b>(s: &'a str,
  * assert!(v == ["", "XXX", "YYY", ""]);
  * ~~~
  */
+#[cfg(stage0)]
 pub fn each_split_str<'a,'b>(s: &'a str,
                              sep: &'b str,
                              it: &fn(&'a str) -> bool) {
@@ -739,7 +864,28 @@ pub fn each_split_str<'a,'b>(s: &'a str,
         if !it( unsafe { raw::slice_bytes(s, from, to) } ) { return; }
     }
 }
+/**
+ * Splits a string into a vector of the substrings separated by a given string
+ *
+ * # Example
+ *
+ * ~~~
+ * let mut v = ~[];
+ * for each_split_str(".XXX.YYY.", ".") |subs| { v.push(subs); }
+ * assert!(v == ["", "XXX", "YYY", ""]);
+ * ~~~
+ */
+#[cfg(not(stage0))]
+pub fn each_split_str<'a,'b>(s: &'a str,
+                             sep: &'b str,
+                             it: &fn(&'a str) -> bool) -> bool {
+    for iter_between_matches(s, sep) |from, to| {
+        if !it( unsafe { raw::slice_bytes(s, from, to) } ) { return false; }
+    }
+    return true;
+}
 
+#[cfg(stage0)]
 pub fn each_split_str_nonempty<'a,'b>(s: &'a str,
                                       sep: &'b str,
                                       it: &fn(&'a str) -> bool) {
@@ -748,6 +894,18 @@ pub fn each_split_str_nonempty<'a,'b>(s: &'a str,
             if !it( unsafe { raw::slice_bytes(s, from, to) } ) { return; }
         }
     }
+}
+
+#[cfg(not(stage0))]
+pub fn each_split_str_nonempty<'a,'b>(s: &'a str,
+                                      sep: &'b str,
+                                      it: &fn(&'a str) -> bool) -> bool {
+    for iter_between_matches(s, sep) |from, to| {
+        if to > from {
+            if !it( unsafe { raw::slice_bytes(s, from, to) } ) { return false; }
+        }
+    }
+    return true;
 }
 
 /// Levenshtein Distance between two strings
@@ -787,7 +945,15 @@ pub fn levdistance(s: &str, t: &str) -> uint {
 /**
  * Splits a string into substrings separated by LF ('\n').
  */
+#[cfg(stage0)]
 pub fn each_line<'a>(s: &'a str, it: &fn(&'a str) -> bool) {
+    each_split_char_no_trailing(s, '\n', it);
+}
+/**
+ * Splits a string into substrings separated by LF ('\n').
+ */
+#[cfg(not(stage0))]
+pub fn each_line<'a>(s: &'a str, it: &fn(&'a str) -> bool) -> bool {
     each_split_char_no_trailing(s, '\n', it)
 }
 
@@ -795,6 +961,7 @@ pub fn each_line<'a>(s: &'a str, it: &fn(&'a str) -> bool) {
  * Splits a string into substrings separated by LF ('\n')
  * and/or CR LF ("\r\n")
  */
+#[cfg(stage0)]
 pub fn each_line_any<'a>(s: &'a str, it: &fn(&'a str) -> bool) {
     for each_line(s) |s| {
         let l = s.len();
@@ -805,9 +972,31 @@ pub fn each_line_any<'a>(s: &'a str, it: &fn(&'a str) -> bool) {
         }
     }
 }
+/**
+ * Splits a string into substrings separated by LF ('\n')
+ * and/or CR LF ("\r\n")
+ */
+#[cfg(not(stage0))]
+pub fn each_line_any<'a>(s: &'a str, it: &fn(&'a str) -> bool) -> bool {
+    for each_line(s) |s| {
+        let l = s.len();
+        if l > 0u && s[l - 1u] == '\r' as u8 {
+            if !it( unsafe { raw::slice_bytes(s, 0, l - 1) } ) { return false; }
+        } else {
+            if !it( s ) { return false; }
+        }
+    }
+    return true;
+}
 
 /// Splits a string into substrings separated by whitespace
+#[cfg(stage0)]
 pub fn each_word<'a>(s: &'a str, it: &fn(&'a str) -> bool) {
+    each_split_nonempty(s, char::is_whitespace, it);
+}
+/// Splits a string into substrings separated by whitespace
+#[cfg(not(stage0))]
+pub fn each_word<'a>(s: &'a str, it: &fn(&'a str) -> bool) -> bool {
     each_split_nonempty(s, char::is_whitespace, it)
 }
 
@@ -820,9 +1009,9 @@ pub fn each_word<'a>(s: &'a str, it: &fn(&'a str) -> bool) {
  *  Fails during iteration if the string contains a non-whitespace
  *  sequence longer than the limit.
  */
-pub fn each_split_within<'a>(ss: &'a str,
-                             lim: uint,
-                             it: &fn(&'a str) -> bool) {
+pub fn _each_split_within<'a>(ss: &'a str,
+                              lim: uint,
+                              it: &fn(&'a str) -> bool) -> bool {
     // Just for fun, let's write this as an state machine:
 
     enum SplitWithinState {
@@ -880,6 +1069,20 @@ pub fn each_split_within<'a>(ss: &'a str,
         machine(fake_i, ' ');
         fake_i += 1;
     }
+    return cont;
+}
+
+#[cfg(stage0)]
+pub fn each_split_within<'a>(ss: &'a str,
+                             lim: uint,
+                             it: &fn(&'a str) -> bool) {
+    _each_split_within(ss, lim, it);
+}
+#[cfg(not(stage0))]
+pub fn each_split_within<'a>(ss: &'a str,
+                             lim: uint,
+                             it: &fn(&'a str) -> bool) -> bool {
+    _each_split_within(ss, lim, it)
 }
 
 /**
@@ -1158,12 +1361,20 @@ pub fn map(ss: &str, ff: &fn(char) -> char) -> ~str {
 
 /// Iterate over the bytes in a string
 #[inline(always)]
+#[cfg(stage0)]
 pub fn each(s: &str, it: &fn(u8) -> bool) {
+    eachi(s, |_i, b| it(b))
+}
+/// Iterate over the bytes in a string
+#[inline(always)]
+#[cfg(not(stage0))]
+pub fn each(s: &str, it: &fn(u8) -> bool) -> bool {
     eachi(s, |_i, b| it(b))
 }
 
 /// Iterate over the bytes in a string, with indices
 #[inline(always)]
+#[cfg(stage0)]
 pub fn eachi(s: &str, it: &fn(uint, u8) -> bool) {
     let mut pos = 0;
     let len = s.len();
@@ -1174,14 +1385,36 @@ pub fn eachi(s: &str, it: &fn(uint, u8) -> bool) {
     }
 }
 
+/// Iterate over the bytes in a string, with indices
+#[inline(always)]
+#[cfg(not(stage0))]
+pub fn eachi(s: &str, it: &fn(uint, u8) -> bool) -> bool {
+    let mut pos = 0;
+    let len = s.len();
+
+    while pos < len {
+        if !it(pos, s[pos]) { return false; }
+        pos += 1;
+    }
+    return true;
+}
+
 /// Iterate over the bytes in a string in reverse
 #[inline(always)]
+#[cfg(stage0)]
 pub fn each_reverse(s: &str, it: &fn(u8) -> bool) {
+    eachi_reverse(s, |_i, b| it(b) )
+}
+/// Iterate over the bytes in a string in reverse
+#[inline(always)]
+#[cfg(not(stage0))]
+pub fn each_reverse(s: &str, it: &fn(u8) -> bool) -> bool {
     eachi_reverse(s, |_i, b| it(b) )
 }
 
 /// Iterate over the bytes in a string in reverse, with indices
 #[inline(always)]
+#[cfg(stage0)]
 pub fn eachi_reverse(s: &str, it: &fn(uint, u8) -> bool) {
     let mut pos = s.len();
     while pos > 0 {
@@ -1189,9 +1422,21 @@ pub fn eachi_reverse(s: &str, it: &fn(uint, u8) -> bool) {
         if !it(pos, s[pos]) { break; }
     }
 }
+/// Iterate over the bytes in a string in reverse, with indices
+#[inline(always)]
+#[cfg(not(stage0))]
+pub fn eachi_reverse(s: &str, it: &fn(uint, u8) -> bool) -> bool {
+    let mut pos = s.len();
+    while pos > 0 {
+        pos -= 1;
+        if !it(pos, s[pos]) { return false; }
+    }
+    return true;
+}
 
 /// Iterate over each char of a string, without allocating
 #[inline(always)]
+#[cfg(stage0)]
 pub fn each_char(s: &str, it: &fn(char) -> bool) {
     let mut i = 0;
     let len = len(s);
@@ -1201,9 +1446,23 @@ pub fn each_char(s: &str, it: &fn(char) -> bool) {
         i = next;
     }
 }
+/// Iterate over each char of a string, without allocating
+#[inline(always)]
+#[cfg(not(stage0))]
+pub fn each_char(s: &str, it: &fn(char) -> bool) -> bool {
+    let mut i = 0;
+    let len = len(s);
+    while i < len {
+        let CharRange {ch, next} = char_range_at(s, i);
+        if !it(ch) { return false; }
+        i = next;
+    }
+    return true;
+}
 
 /// Iterates over the chars in a string, with indices
 #[inline(always)]
+#[cfg(stage0)]
 pub fn each_chari(s: &str, it: &fn(uint, char) -> bool) {
     let mut pos = 0;
     let mut ch_pos = 0u;
@@ -1215,15 +1474,38 @@ pub fn each_chari(s: &str, it: &fn(uint, char) -> bool) {
         ch_pos += 1u;
     }
 }
+/// Iterates over the chars in a string, with indices
+#[inline(always)]
+#[cfg(not(stage0))]
+pub fn each_chari(s: &str, it: &fn(uint, char) -> bool) -> bool {
+    let mut pos = 0;
+    let mut ch_pos = 0u;
+    let len = s.len();
+    while pos < len {
+        let CharRange {ch, next} = char_range_at(s, pos);
+        pos = next;
+        if !it(ch_pos, ch) { return false; }
+        ch_pos += 1u;
+    }
+    return true;
+}
 
 /// Iterates over the chars in a string in reverse
 #[inline(always)]
+#[cfg(stage0)]
 pub fn each_char_reverse(s: &str, it: &fn(char) -> bool) {
+    each_chari_reverse(s, |_, c| it(c))
+}
+/// Iterates over the chars in a string in reverse
+#[inline(always)]
+#[cfg(not(stage0))]
+pub fn each_char_reverse(s: &str, it: &fn(char) -> bool) -> bool {
     each_chari_reverse(s, |_, c| it(c))
 }
 
 // Iterates over the chars in a string in reverse, with indices
 #[inline(always)]
+#[cfg(stage0)]
 pub fn each_chari_reverse(s: &str, it: &fn(uint, char) -> bool) {
     let mut pos = s.len();
     let mut ch_pos = s.char_len();
@@ -1235,6 +1517,21 @@ pub fn each_chari_reverse(s: &str, it: &fn(uint, char) -> bool) {
         if !it(ch_pos, ch) { break; }
 
     }
+}
+// Iterates over the chars in a string in reverse, with indices
+#[inline(always)]
+#[cfg(not(stage0))]
+pub fn each_chari_reverse(s: &str, it: &fn(uint, char) -> bool) -> bool {
+    let mut pos = s.len();
+    let mut ch_pos = s.char_len();
+    while pos > 0 {
+        let CharRange {ch, next} = char_range_at_reverse(s, pos);
+        pos = next;
+        ch_pos -= 1;
+
+        if !it(ch_pos, ch) { return false; }
+    }
+    return true;
 }
 
 /*
@@ -2473,14 +2770,22 @@ pub trait StrSlice<'self> {
     fn contains<'a>(&self, needle: &'a str) -> bool;
     fn contains_char(&self, needle: char) -> bool;
     fn char_iter(&self) -> StrCharIterator<'self>;
-    fn each(&self, it: &fn(u8) -> bool);
-    fn eachi(&self, it: &fn(uint, u8) -> bool);
-    fn each_reverse(&self, it: &fn(u8) -> bool);
-    fn eachi_reverse(&self, it: &fn(uint, u8) -> bool);
-    fn each_char(&self, it: &fn(char) -> bool);
-    fn each_chari(&self, it: &fn(uint, char) -> bool);
-    fn each_char_reverse(&self, it: &fn(char) -> bool);
-    fn each_chari_reverse(&self, it: &fn(uint, char) -> bool);
+    #[cfg(stage0)]      fn each(&self, it: &fn(u8) -> bool);
+    #[cfg(not(stage0))] fn each(&self, it: &fn(u8) -> bool) -> bool;
+    #[cfg(stage0)]      fn eachi(&self, it: &fn(uint, u8) -> bool);
+    #[cfg(not(stage0))] fn eachi(&self, it: &fn(uint, u8) -> bool) -> bool;
+    #[cfg(stage0)]      fn each_reverse(&self, it: &fn(u8) -> bool);
+    #[cfg(not(stage0))] fn each_reverse(&self, it: &fn(u8) -> bool) -> bool;
+    #[cfg(stage0)]      fn eachi_reverse(&self, it: &fn(uint, u8) -> bool);
+    #[cfg(not(stage0))] fn eachi_reverse(&self, it: &fn(uint, u8) -> bool) -> bool;
+    #[cfg(stage0)]      fn each_char(&self, it: &fn(char) -> bool);
+    #[cfg(not(stage0))] fn each_char(&self, it: &fn(char) -> bool) -> bool;
+    #[cfg(stage0)]      fn each_chari(&self, it: &fn(uint, char) -> bool);
+    #[cfg(not(stage0))] fn each_chari(&self, it: &fn(uint, char) -> bool) -> bool;
+    #[cfg(stage0)]      fn each_char_reverse(&self, it: &fn(char) -> bool);
+    #[cfg(not(stage0))] fn each_char_reverse(&self, it: &fn(char) -> bool) -> bool;
+    #[cfg(stage0)]      fn each_chari_reverse(&self, it: &fn(uint, char) -> bool);
+    #[cfg(not(stage0))] fn each_chari_reverse(&self, it: &fn(uint, char) -> bool) -> bool;
     fn ends_with(&self, needle: &str) -> bool;
     fn is_empty(&self) -> bool;
     fn is_whitespace(&self) -> bool;
@@ -2488,9 +2793,18 @@ pub trait StrSlice<'self> {
     fn len(&self) -> uint;
     fn char_len(&self) -> uint;
     fn slice(&self, begin: uint, end: uint) -> &'self str;
+    #[cfg(stage0)]
     fn each_split(&self, sepfn: &fn(char) -> bool, it: &fn(&'self str) -> bool);
+    #[cfg(not(stage0))]
+    fn each_split(&self, sepfn: &fn(char) -> bool, it: &fn(&'self str) -> bool) -> bool;
+    #[cfg(stage0)]
     fn each_split_char(&self, sep: char, it: &fn(&'self str) -> bool);
+    #[cfg(not(stage0))]
+    fn each_split_char(&self, sep: char, it: &fn(&'self str) -> bool) -> bool;
+    #[cfg(stage0)]
     fn each_split_str<'a>(&self, sep: &'a str, it: &fn(&'self str) -> bool);
+    #[cfg(not(stage0))]
+    fn each_split_str<'a>(&self, sep: &'a str, it: &fn(&'self str) -> bool) -> bool;
     fn starts_with<'a>(&self, needle: &'a str) -> bool;
     fn substr(&self, begin: uint, n: uint) -> &'self str;
     fn escape_default(&self) -> ~str;
@@ -2543,37 +2857,84 @@ impl<'self> StrSlice<'self> for &'self str {
 
     /// Iterate over the bytes in a string
     #[inline]
+    #[cfg(stage0)]
     fn each(&self, it: &fn(u8) -> bool) { each(*self, it) }
-    /// Iterate over the bytes in a string, with indices
-    #[inline]
-    fn eachi(&self, it: &fn(uint, u8) -> bool) { eachi(*self, it) }
     /// Iterate over the bytes in a string
     #[inline]
-    fn each_reverse(&self, it: &fn(u8) -> bool) {
-        each_reverse(*self, it)
+    #[cfg(not(stage0))]
+    fn each(&self, it: &fn(u8) -> bool) -> bool { each(*self, it) }
+    /// Iterate over the bytes in a string, with indices
+    #[inline]
+    #[cfg(stage0)]
+    fn eachi(&self, it: &fn(uint, u8) -> bool) { eachi(*self, it) }
+    /// Iterate over the bytes in a string, with indices
+    #[inline]
+    #[cfg(not(stage0))]
+    fn eachi(&self, it: &fn(uint, u8) -> bool) -> bool { eachi(*self, it) }
+    /// Iterate over the bytes in a string
+    #[inline]
+    #[cfg(stage0)]
+    fn each_reverse(&self, it: &fn(u8) -> bool) { each_reverse(*self, it) }
+    /// Iterate over the bytes in a string
+    #[inline]
+    #[cfg(not(stage0))]
+    fn each_reverse(&self, it: &fn(u8) -> bool) -> bool { each_reverse(*self, it) }
+    /// Iterate over the bytes in a string, with indices
+    #[inline]
+    #[cfg(stage0)]
+    fn eachi_reverse(&self, it: &fn(uint, u8) -> bool) {
+        eachi_reverse(*self, it)
     }
     /// Iterate over the bytes in a string, with indices
     #[inline]
-    fn eachi_reverse(&self, it: &fn(uint, u8) -> bool) {
+    #[cfg(not(stage0))]
+    fn eachi_reverse(&self, it: &fn(uint, u8) -> bool) -> bool {
         eachi_reverse(*self, it)
     }
     /// Iterate over the chars in a string
     #[inline]
+    #[cfg(stage0)]
     fn each_char(&self, it: &fn(char) -> bool) { each_char(*self, it) }
+    /// Iterate over the chars in a string
+    #[inline]
+    #[cfg(not(stage0))]
+    fn each_char(&self, it: &fn(char) -> bool) -> bool { each_char(*self, it) }
     /// Iterate over the chars in a string, with indices
     #[inline]
+    #[cfg(stage0)]
     fn each_chari(&self, it: &fn(uint, char) -> bool) {
+        each_chari(*self, it)
+    }
+    /// Iterate over the chars in a string, with indices
+    #[inline]
+    #[cfg(not(stage0))]
+    fn each_chari(&self, it: &fn(uint, char) -> bool) -> bool {
         each_chari(*self, it)
     }
     /// Iterate over the chars in a string in reverse
     #[inline]
+    #[cfg(stage0)]
     fn each_char_reverse(&self, it: &fn(char) -> bool) {
+        each_char_reverse(*self, it)
+    }
+    /// Iterate over the chars in a string in reverse
+    #[inline]
+    #[cfg(not(stage0))]
+    fn each_char_reverse(&self, it: &fn(char) -> bool) -> bool {
         each_char_reverse(*self, it)
     }
     /// Iterate over the chars in a string in reverse, with indices from the
     /// end
     #[inline]
+    #[cfg(stage0)]
     fn each_chari_reverse(&self, it: &fn(uint, char) -> bool) {
+        each_chari_reverse(*self, it)
+    }
+    /// Iterate over the chars in a string in reverse, with indices from the
+    /// end
+    #[inline]
+    #[cfg(not(stage0))]
+    fn each_chari_reverse(&self, it: &fn(uint, char) -> bool) -> bool {
         each_chari_reverse(*self, it)
     }
     /// Returns true if one string ends with another
@@ -2617,14 +2978,30 @@ impl<'self> StrSlice<'self> for &'self str {
     }
     /// Splits a string into substrings using a character function
     #[inline]
+    #[cfg(stage0)]
     fn each_split(&self, sepfn: &fn(char) -> bool, it: &fn(&'self str) -> bool) {
+        each_split(*self, sepfn, it)
+    }
+    /// Splits a string into substrings using a character function
+    #[inline]
+    #[cfg(not(stage0))]
+    fn each_split(&self, sepfn: &fn(char) -> bool, it: &fn(&'self str) -> bool) -> bool {
         each_split(*self, sepfn, it)
     }
     /**
      * Splits a string into substrings at each occurrence of a given character
      */
     #[inline]
+    #[cfg(stage0)]
     fn each_split_char(&self, sep: char, it: &fn(&'self str) -> bool) {
+        each_split_char(*self, sep, it)
+    }
+    /**
+     * Splits a string into substrings at each occurrence of a given character
+     */
+    #[inline]
+    #[cfg(not(stage0))]
+    fn each_split_char(&self, sep: char, it: &fn(&'self str) -> bool) -> bool {
         each_split_char(*self, sep, it)
     }
     /**
@@ -2632,7 +3009,17 @@ impl<'self> StrSlice<'self> for &'self str {
      * string
      */
     #[inline]
+    #[cfg(stage0)]
     fn each_split_str<'a>(&self, sep: &'a str, it: &fn(&'self str) -> bool) {
+        each_split_str(*self, sep, it)
+    }
+    /**
+     * Splits a string into a vector of the substrings separated by a given
+     * string
+     */
+    #[inline]
+    #[cfg(not(stage0))]
+    fn each_split_str<'a>(&self, sep: &'a str, it: &fn(&'self str) -> bool) -> bool {
         each_split_str(*self, sep, it)
     }
     /// Returns true if one string starts with another

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -3404,7 +3404,7 @@ mod tests {
         let lf = ~"\nMary had a little lamb\nLittle lamb\n";
         let crlf = ~"\r\nMary had a little lamb\r\nLittle lamb\r\n";
 
-        fn t(s: &str, f: &fn(&str, &fn(&str) -> bool), u: &[~str]) {
+        fn t(s: &str, f: &fn(&str, &fn(&str) -> bool) -> bool, u: &[~str]) {
             let mut v = ~[];
             for f(s) |s| { v.push(s.to_owned()) }
             assert!(vec::all2(v, u, |a,b| a == b));
@@ -3424,7 +3424,7 @@ mod tests {
 
     #[test]
     fn test_words () {
-        fn t(s: &str, f: &fn(&str, &fn(&str) -> bool), u: &[~str]) {
+        fn t(s: &str, f: &fn(&str, &fn(&str) -> bool) -> bool, u: &[~str]) {
             let mut v = ~[];
             for f(s) |s| { v.push(s.to_owned()) }
             assert!(vec::all2(v, u, |a,b| a == b));

--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -21,6 +21,11 @@ use str;
 
 pub type Cb<'self> = &'self fn(buf: &[u8]) -> bool;
 
+#[cfg(stage0)]
+pub trait IterBytes {
+    fn iter_bytes(&self, lsb0: bool, f: Cb);
+}
+
 /**
  * A trait to implement in order to make a type hashable;
  * This works in combination with the trait `Hash::Hash`, and
@@ -28,6 +33,7 @@ pub type Cb<'self> = &'self fn(buf: &[u8]) -> bool;
  * modified when default methods and trait inheritence are
  * completed.
  */
+#[cfg(not(stage0))]
 pub trait IterBytes {
     /**
      * Call the provided callback `f` one or more times with
@@ -43,9 +49,10 @@ pub trait IterBytes {
      * left-to-right in declaration order, regardless of
      * underlying memory endianness.
      */
-    fn iter_bytes(&self, lsb0: bool, f: Cb);
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool;
 }
 
+#[cfg(stage0)]
 impl IterBytes for bool {
     #[inline(always)]
     fn iter_bytes(&self, _lsb0: bool, f: Cb) {
@@ -54,7 +61,17 @@ impl IterBytes for bool {
         ]);
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for bool {
+    #[inline(always)]
+    fn iter_bytes(&self, _lsb0: bool, f: Cb) -> bool {
+        f([
+            *self as u8
+        ])
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for u8 {
     #[inline(always)]
     fn iter_bytes(&self, _lsb0: bool, f: Cb) {
@@ -63,7 +80,17 @@ impl IterBytes for u8 {
         ]);
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for u8 {
+    #[inline(always)]
+    fn iter_bytes(&self, _lsb0: bool, f: Cb) -> bool {
+        f([
+            *self
+        ])
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for u16 {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
@@ -80,7 +107,25 @@ impl IterBytes for u16 {
         }
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for u16 {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        if lsb0 {
+            f([
+                *self as u8,
+                (*self >> 8) as u8
+            ])
+        } else {
+            f([
+                (*self >> 8) as u8,
+                *self as u8
+            ])
+        }
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for u32 {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
@@ -101,7 +146,29 @@ impl IterBytes for u32 {
         }
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for u32 {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        if lsb0 {
+            f([
+                *self as u8,
+                (*self >> 8) as u8,
+                (*self >> 16) as u8,
+                (*self >> 24) as u8,
+            ])
+        } else {
+            f([
+                (*self >> 24) as u8,
+                (*self >> 16) as u8,
+                (*self >> 8) as u8,
+                *self as u8
+            ])
+        }
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for u64 {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
@@ -130,73 +197,157 @@ impl IterBytes for u64 {
         }
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for u64 {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        if lsb0 {
+            f([
+                *self as u8,
+                (*self >> 8) as u8,
+                (*self >> 16) as u8,
+                (*self >> 24) as u8,
+                (*self >> 32) as u8,
+                (*self >> 40) as u8,
+                (*self >> 48) as u8,
+                (*self >> 56) as u8
+            ])
+        } else {
+            f([
+                (*self >> 56) as u8,
+                (*self >> 48) as u8,
+                (*self >> 40) as u8,
+                (*self >> 32) as u8,
+                (*self >> 24) as u8,
+                (*self >> 16) as u8,
+                (*self >> 8) as u8,
+                *self as u8
+            ])
+        }
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for i8 {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for i8 {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (*self as u8).iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for i16 {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (*self as u16).iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for i16 {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (*self as u16).iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for i32 {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (*self as u32).iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for i32 {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (*self as u32).iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for i64 {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (*self as u64).iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for i64 {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (*self as u64).iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for char {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (*self as u32).iter_bytes(lsb0, f)
     }
 }
-
-#[cfg(target_word_size = "32")]
-pub mod x32 {
-    use to_bytes::{Cb, IterBytes};
-
-    impl IterBytes for uint {
-        #[inline(always)]
-        fn iter_bytes(&self, lsb0: bool, f: Cb) {
-            (*self as u32).iter_bytes(lsb0, f)
-        }
+#[cfg(not(stage0))]
+impl IterBytes for char {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (*self as u32).iter_bytes(lsb0, f)
     }
 }
 
-#[cfg(target_word_size = "64")]
-pub mod x64 {
-    use to_bytes::{Cb, IterBytes};
-
-    impl IterBytes for uint {
-        #[inline(always)]
-        fn iter_bytes(&self, lsb0: bool, f: Cb) {
-            (*self as u64).iter_bytes(lsb0, f)
-        }
+#[cfg(target_word_size = "32", stage0)]
+impl IterBytes for uint {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) {
+        (*self as u32).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(target_word_size = "32", not(stage0))]
+impl IterBytes for uint {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (*self as u32).iter_bytes(lsb0, f)
     }
 }
 
+#[cfg(target_word_size = "64", stage0)]
+impl IterBytes for uint {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) {
+        (*self as u64).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(target_word_size = "64", not(stage0))]
+impl IterBytes for uint {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (*self as u64).iter_bytes(lsb0, f)
+    }
+}
+
+#[cfg(stage0)]
 impl IterBytes for int {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (*self as uint).iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for int {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (*self as uint).iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl<'self,A:IterBytes> IterBytes for &'self [A] {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
@@ -207,7 +358,15 @@ impl<'self,A:IterBytes> IterBytes for &'self [A] {
         }
     }
 }
+#[cfg(not(stage0))]
+impl<'self,A:IterBytes> IterBytes for &'self [A] {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        self.each(|elt| elt.iter_bytes(lsb0, |b| f(b)))
+    }
+}
 
+#[cfg(stage0)]
 impl<A:IterBytes,B:IterBytes> IterBytes for (A,B) {
   #[inline(always)]
   fn iter_bytes(&self, lsb0: bool, f: Cb) {
@@ -218,7 +377,17 @@ impl<A:IterBytes,B:IterBytes> IterBytes for (A,B) {
     }
   }
 }
+#[cfg(not(stage0))]
+impl<A:IterBytes,B:IterBytes> IterBytes for (A,B) {
+  #[inline(always)]
+  fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+    match *self {
+      (ref a, ref b) => { a.iter_bytes(lsb0, f) && b.iter_bytes(lsb0, f) }
+    }
+  }
+}
 
+#[cfg(stage0)]
 impl<A:IterBytes,B:IterBytes,C:IterBytes> IterBytes for (A,B,C) {
   #[inline(always)]
   fn iter_bytes(&self, lsb0: bool, f: Cb) {
@@ -229,26 +398,57 @@ impl<A:IterBytes,B:IterBytes,C:IterBytes> IterBytes for (A,B,C) {
     }
   }
 }
+#[cfg(not(stage0))]
+impl<A:IterBytes,B:IterBytes,C:IterBytes> IterBytes for (A,B,C) {
+  #[inline(always)]
+  fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+    match *self {
+      (ref a, ref b, ref c) => {
+        a.iter_bytes(lsb0, f) && b.iter_bytes(lsb0, f) && c.iter_bytes(lsb0, f)
+      }
+    }
+  }
+}
 
 // Move this to vec, probably.
 fn borrow<'x,A>(a: &'x [A]) -> &'x [A] {
     a
 }
 
+#[cfg(stage0)]
 impl<A:IterBytes> IterBytes for ~[A] {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         borrow(*self).iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl<A:IterBytes> IterBytes for ~[A] {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        borrow(*self).iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl<A:IterBytes> IterBytes for @[A] {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         borrow(*self).iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl<A:IterBytes> IterBytes for @[A] {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        borrow(*self).iter_bytes(lsb0, f)
+    }
+}
 
+// NOTE: remove all of these after a snapshot, the new for-loop iteration
+//       protocol makes these unnecessary.
+
+#[cfg(stage0)]
 pub fn iter_bytes_2<A:IterBytes,B:IterBytes>(a: &A, b: &B,
                                             lsb0: bool, z: Cb) {
     let mut flag = true;
@@ -256,11 +456,17 @@ pub fn iter_bytes_2<A:IterBytes,B:IterBytes>(a: &A, b: &B,
     if !flag { return; }
     b.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
 }
+#[cfg(not(stage0))]
+pub fn iter_bytes_2<A:IterBytes,B:IterBytes>(a: &A, b: &B,
+                                             lsb0: bool, z: Cb) -> bool {
+    a.iter_bytes(lsb0, z) && b.iter_bytes(lsb0, z)
+}
 
+#[cfg(stage0)]
 pub fn iter_bytes_3<A: IterBytes,
-                B: IterBytes,
-                C: IterBytes>(a: &A, b: &B, c: &C,
-                              lsb0: bool, z: Cb) {
+                    B: IterBytes,
+                    C: IterBytes>(a: &A, b: &B, c: &C,
+                                  lsb0: bool, z: Cb) {
     let mut flag = true;
     a.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
     if !flag { return; }
@@ -268,7 +474,14 @@ pub fn iter_bytes_3<A: IterBytes,
     if !flag { return; }
     c.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
 }
+#[cfg(not(stage0))]
+pub fn iter_bytes_3<A: IterBytes,
+                    B: IterBytes,
+                    C: IterBytes>(a: &A, b: &B, c: &C, lsb0: bool, z: Cb) -> bool {
+    a.iter_bytes(lsb0, z) && b.iter_bytes(lsb0, z) && c.iter_bytes(lsb0, z)
+}
 
+#[cfg(stage0)]
 pub fn iter_bytes_4<A: IterBytes,
                 B: IterBytes,
                 C: IterBytes,
@@ -284,7 +497,18 @@ pub fn iter_bytes_4<A: IterBytes,
     if !flag { return; }
     d.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
 }
+#[cfg(not(stage0))]
+pub fn iter_bytes_4<A: IterBytes,
+                B: IterBytes,
+                C: IterBytes,
+                D: IterBytes>(a: &A, b: &B, c: &C,
+                              d: &D,
+                              lsb0: bool, z: Cb) -> bool {
+    a.iter_bytes(lsb0, z) && b.iter_bytes(lsb0, z) && c.iter_bytes(lsb0, z) &&
+        d.iter_bytes(lsb0, z)
+}
 
+#[cfg(stage0)]
 pub fn iter_bytes_5<A: IterBytes,
                 B: IterBytes,
                 C: IterBytes,
@@ -303,55 +527,19 @@ pub fn iter_bytes_5<A: IterBytes,
     if !flag { return; }
     e.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
 }
-
-pub fn iter_bytes_6<A: IterBytes,
+#[cfg(not(stage0))]
+pub fn iter_bytes_5<A: IterBytes,
                 B: IterBytes,
                 C: IterBytes,
                 D: IterBytes,
-                E: IterBytes,
-                F: IterBytes>(a: &A, b: &B, c: &C,
-                              d: &D, e: &E, f: &F,
-                              lsb0: bool, z: Cb) {
-    let mut flag = true;
-    a.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    b.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    c.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    d.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    e.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    f.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
+                E: IterBytes>(a: &A, b: &B, c: &C,
+                              d: &D, e: &E,
+                              lsb0: bool, z: Cb) -> bool {
+    a.iter_bytes(lsb0, z) && b.iter_bytes(lsb0, z) && c.iter_bytes(lsb0, z) &&
+        d.iter_bytes(lsb0, z) && e.iter_bytes(lsb0, z)
 }
 
-pub fn iter_bytes_7<A: IterBytes,
-                B: IterBytes,
-                C: IterBytes,
-                D: IterBytes,
-                E: IterBytes,
-                F: IterBytes,
-                G: IterBytes>(a: &A, b: &B, c: &C,
-                              d: &D, e: &E, f: &F,
-                              g: &G,
-                              lsb0: bool, z: Cb) {
-    let mut flag = true;
-    a.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    b.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    c.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    d.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    e.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    f.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-    if !flag { return; }
-    g.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
-}
-
+#[cfg(stage0)]
 impl<'self> IterBytes for &'self str {
     #[inline(always)]
     fn iter_bytes(&self, _lsb0: bool, f: Cb) {
@@ -360,7 +548,17 @@ impl<'self> IterBytes for &'self str {
         }
     }
 }
+#[cfg(not(stage0))]
+impl<'self> IterBytes for &'self str {
+    #[inline(always)]
+    fn iter_bytes(&self, _lsb0: bool, f: Cb) -> bool {
+        do str::byte_slice(*self) |bytes| {
+            f(bytes)
+        }
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for ~str {
     #[inline(always)]
     fn iter_bytes(&self, _lsb0: bool, f: Cb) {
@@ -369,7 +567,17 @@ impl IterBytes for ~str {
         }
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for ~str {
+    #[inline(always)]
+    fn iter_bytes(&self, _lsb0: bool, f: Cb) -> bool {
+        do str::byte_slice(*self) |bytes| {
+            f(bytes)
+        }
+    }
+}
 
+#[cfg(stage0)]
 impl IterBytes for @str {
     #[inline(always)]
     fn iter_bytes(&self, _lsb0: bool, f: Cb) {
@@ -378,7 +586,17 @@ impl IterBytes for @str {
         }
     }
 }
+#[cfg(not(stage0))]
+impl IterBytes for @str {
+    #[inline(always)]
+    fn iter_bytes(&self, _lsb0: bool, f: Cb) -> bool {
+        do str::byte_slice(*self) |bytes| {
+            f(bytes)
+        }
+    }
+}
 
+#[cfg(stage0)]
 impl<A:IterBytes> IterBytes for Option<A> {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
@@ -388,34 +606,78 @@ impl<A:IterBytes> IterBytes for Option<A> {
         }
     }
 }
+#[cfg(not(stage0))]
+impl<A:IterBytes> IterBytes for Option<A> {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        match *self {
+          Some(ref a) => 0u8.iter_bytes(lsb0, f) && a.iter_bytes(lsb0, f),
+          None => 1u8.iter_bytes(lsb0, f)
+        }
+    }
+}
 
+#[cfg(stage0)]
 impl<'self,A:IterBytes> IterBytes for &'self A {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (**self).iter_bytes(lsb0, f);
     }
 }
+#[cfg(not(stage0))]
+impl<'self,A:IterBytes> IterBytes for &'self A {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (**self).iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl<A:IterBytes> IterBytes for @A {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (**self).iter_bytes(lsb0, f);
     }
 }
+#[cfg(not(stage0))]
+impl<A:IterBytes> IterBytes for @A {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (**self).iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl<A:IterBytes> IterBytes for ~A {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (**self).iter_bytes(lsb0, f);
     }
 }
+#[cfg(not(stage0))]
+impl<A:IterBytes> IterBytes for ~A {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (**self).iter_bytes(lsb0, f)
+    }
+}
 
 // NB: raw-pointer IterBytes does _not_ dereference
 // to the target; it just gives you the pointer-bytes.
+#[cfg(stage0)]
 impl<A> IterBytes for *const A {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) {
         (*self as uint).iter_bytes(lsb0, f);
+    }
+}
+// NB: raw-pointer IterBytes does _not_ dereference
+// to the target; it just gives you the pointer-bytes.
+#[cfg(not(stage0))]
+impl<A> IterBytes for *const A {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (*self as uint).iter_bytes(lsb0, f)
     }
 }
 

--- a/src/libcore/trie.rs
+++ b/src/libcore/trie.rs
@@ -57,26 +57,58 @@ impl<T> Map<uint, T> for TrieMap<T> {
 
     /// Visit all key-value pairs in order
     #[inline(always)]
+    #[cfg(stage0)]
     fn each<'a>(&'a self, f: &fn(&uint, &'a T) -> bool) {
         self.root.each(f);
     }
 
+    /// Visit all key-value pairs in order
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn each<'a>(&'a self, f: &fn(&uint, &'a T) -> bool) -> bool {
+        self.root.each(f)
+    }
+
     /// Visit all keys in order
     #[inline(always)]
+    #[cfg(stage0)]
     fn each_key(&self, f: &fn(&uint) -> bool) {
+        self.each(|k, _| f(k))
+    }
+
+    /// Visit all keys in order
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn each_key(&self, f: &fn(&uint) -> bool) -> bool {
         self.each(|k, _| f(k))
     }
 
     /// Visit all values in order
     #[inline(always)]
+    #[cfg(stage0)]
     fn each_value<'a>(&'a self, f: &fn(&'a T) -> bool) {
+        self.each(|_, v| f(v))
+    }
+
+    /// Visit all values in order
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn each_value<'a>(&'a self, f: &fn(&'a T) -> bool) -> bool {
         self.each(|_, v| f(v))
     }
 
     /// Iterate over the map and mutate the contained values
     #[inline(always)]
+    #[cfg(stage0)]
     fn mutate_values(&mut self, f: &fn(&uint, &mut T) -> bool) {
         self.root.mutate_values(f);
+    }
+
+    /// Iterate over the map and mutate the contained values
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn mutate_values(&mut self, f: &fn(&uint, &mut T) -> bool) -> bool {
+        self.root.mutate_values(f)
     }
 
     /// Return a reference to the value corresponding to the key
@@ -151,19 +183,41 @@ pub impl<T> TrieMap<T> {
 
     /// Visit all key-value pairs in reverse order
     #[inline(always)]
+    #[cfg(stage0)]
     fn each_reverse<'a>(&'a self, f: &fn(&uint, &'a T) -> bool) {
         self.root.each_reverse(f);
     }
 
+    /// Visit all key-value pairs in reverse order
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn each_reverse<'a>(&'a self, f: &fn(&uint, &'a T) -> bool) -> bool {
+        self.root.each_reverse(f)
+    }
+
     /// Visit all keys in reverse order
     #[inline(always)]
+    #[cfg(stage0)]
     fn each_key_reverse(&self, f: &fn(&uint) -> bool) {
+        self.each_reverse(|k, _| f(k))
+    }
+    /// Visit all keys in reverse order
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn each_key_reverse(&self, f: &fn(&uint) -> bool) -> bool {
         self.each_reverse(|k, _| f(k))
     }
 
     /// Visit all values in reverse order
     #[inline(always)]
+    #[cfg(stage0)]
     fn each_value_reverse(&self, f: &fn(&T) -> bool) {
+        self.each_reverse(|_, v| f(v))
+    }
+    /// Visit all values in reverse order
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn each_value_reverse(&self, f: &fn(&T) -> bool) -> bool {
         self.each_reverse(|_, v| f(v))
     }
 }
@@ -175,7 +229,10 @@ pub struct TrieSet {
 impl BaseIter<uint> for TrieSet {
     /// Visit all values in order
     #[inline(always)]
+    #[cfg(stage0)]
     fn each(&self, f: &fn(&uint) -> bool) { self.map.each_key(f) }
+    #[cfg(not(stage0))]
+    fn each(&self, f: &fn(&uint) -> bool) -> bool { self.map.each_key(f) }
     #[inline(always)]
     fn size_hint(&self) -> Option<uint> { Some(self.len()) }
 }
@@ -183,7 +240,12 @@ impl BaseIter<uint> for TrieSet {
 impl ReverseIter<uint> for TrieSet {
     /// Visit all values in reverse order
     #[inline(always)]
+    #[cfg(stage0)]
     fn each_reverse(&self, f: &fn(&uint) -> bool) {
+        self.map.each_key_reverse(f)
+    }
+    #[cfg(not(stage0))]
+    fn each_reverse(&self, f: &fn(&uint) -> bool) -> bool {
         self.map.each_key_reverse(f)
     }
 }

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -1489,13 +1489,14 @@ pub fn reversed<T:Copy>(v: &const [T]) -> ~[T] {
  * ~~~
  */
 #[inline(always)]
-pub fn each<'r,T>(v: &'r [T], f: &fn(&'r T) -> bool) {
+pub fn _each<'r,T>(v: &'r [T], f: &fn(&'r T) -> bool) -> bool {
     //             ^^^^
     // NB---this CANNOT be &const [T]!  The reason
     // is that you are passing it to `f()` using
     // an immutable.
 
-    do vec::as_imm_buf(v) |p, n| {
+    let mut broke = false;
+    do as_imm_buf(v) |p, n| {
         let mut n = n;
         let mut p = p;
         while n > 0u {
@@ -1506,42 +1507,69 @@ pub fn each<'r,T>(v: &'r [T], f: &fn(&'r T) -> bool) {
             }
             n -= 1u;
         }
+        broke = n > 0;
     }
+    return true;
 }
+
+#[cfg(stage0)]
+pub fn each<'r,T>(v: &'r [T], f: &fn(&'r T) -> bool) { _each(v, f); }
+#[cfg(not(stage0))]
+pub fn each<'r,T>(v: &'r [T], f: &fn(&'r T) -> bool) -> bool { _each(v, f) }
 
 /// Like `each()`, but for the case where you have
 /// a vector with mutable contents and you would like
 /// to mutate the contents as you iterate.
 #[inline(always)]
-pub fn each_mut<'r,T>(v: &'r mut [T], f: &fn(elem: &'r mut T) -> bool) {
-    do vec::as_mut_buf(v) |p, n| {
+pub fn _each_mut<'r,T>(v: &'r mut [T], f: &fn(elem: &'r mut T) -> bool) -> bool {
+    let mut broke = false;
+    do as_mut_buf(v) |p, n| {
         let mut n = n;
         let mut p = p;
         while n > 0 {
             unsafe {
                 let q: &'r mut T = cast::transmute_mut_region(&mut *p);
-                if !f(q) {
-                    break;
-                }
+                if !f(q) { break; }
                 p = p.offset(1);
             }
             n -= 1;
         }
+        broke = n > 0;
     }
+    return broke;
+}
+
+#[cfg(stage0)]
+pub fn each_mut<'r,T>(v: &'r mut [T], f: &fn(elem: &'r mut T) -> bool) {
+    _each_mut(v, f);
+}
+#[cfg(not(stage0))]
+pub fn each_mut<'r,T>(v: &'r mut [T], f: &fn(elem: &'r mut T) -> bool) -> bool {
+    _each_mut(v, f)
 }
 
 /// Like `each()`, but for the case where you have a vector that *may or may
 /// not* have mutable contents.
 #[inline(always)]
-pub fn each_const<T>(v: &const [T], f: &fn(elem: &const T) -> bool) {
+pub fn _each_const<T>(v: &const [T], f: &fn(elem: &const T) -> bool) -> bool {
     let mut i = 0;
     let n = v.len();
     while i < n {
         if !f(&const v[i]) {
-            return;
+            return false;
         }
         i += 1;
     }
+    return true;
+}
+
+#[cfg(stage0)]
+pub fn each_const<t>(v: &const [t], f: &fn(elem: &const t) -> bool) {
+    _each_const(v, f);
+}
+#[cfg(not(stage0))]
+pub fn each_const<t>(v: &const [t], f: &fn(elem: &const t) -> bool) -> bool {
+    _each_const(v, f)
 }
 
 /**
@@ -1550,12 +1578,20 @@ pub fn each_const<T>(v: &const [T], f: &fn(elem: &const T) -> bool) {
  * Return true to continue, false to break.
  */
 #[inline(always)]
-pub fn eachi<'r,T>(v: &'r [T], f: &fn(uint, v: &'r T) -> bool) {
+pub fn _eachi<'r,T>(v: &'r [T], f: &fn(uint, v: &'r T) -> bool) -> bool {
     let mut i = 0;
     for each(v) |p| {
-        if !f(i, p) { return; }
+        if !f(i, p) { return false; }
         i += 1;
     }
+    return true;
+}
+
+#[cfg(stage0)]
+pub fn eachi<'r,T>(v: &'r [T], f: &fn(uint, v: &'r T) -> bool) { _eachi(v, f); }
+#[cfg(not(stage0))]
+pub fn eachi<'r,T>(v: &'r [T], f: &fn(uint, v: &'r T) -> bool) -> bool {
+    _eachi(v, f)
 }
 
 /**
@@ -1564,14 +1600,26 @@ pub fn eachi<'r,T>(v: &'r [T], f: &fn(uint, v: &'r T) -> bool) {
  * Return true to continue, false to break.
  */
 #[inline(always)]
-pub fn eachi_mut<'r,T>(v: &'r mut [T], f: &fn(uint, v: &'r mut T) -> bool) {
+pub fn _eachi_mut<'r,T>(v: &'r mut [T],
+                        f: &fn(uint, v: &'r mut T) -> bool) -> bool {
     let mut i = 0;
     for each_mut(v) |p| {
         if !f(i, p) {
-            return;
+            return false;
         }
         i += 1;
     }
+    return true;
+}
+
+#[cfg(stage0)]
+pub fn eachi_mut<'r,T>(v: &'r mut [T], f: &fn(uint, v: &'r mut T) -> bool) {
+    _eachi_mut(v, f);
+}
+#[cfg(not(stage0))]
+pub fn eachi_mut<'r,T>(v: &'r mut [T],
+                       f: &fn(uint, v: &'r mut T) -> bool) -> bool {
+    _eachi_mut(v, f)
 }
 
 /**
@@ -1580,8 +1628,17 @@ pub fn eachi_mut<'r,T>(v: &'r mut [T], f: &fn(uint, v: &'r mut T) -> bool) {
  * Return true to continue, false to break.
  */
 #[inline(always)]
+pub fn _each_reverse<'r,T>(v: &'r [T], blk: &fn(v: &'r T) -> bool) -> bool {
+    _eachi_reverse(v, |_i, v| blk(v))
+}
+
+#[cfg(stage0)]
 pub fn each_reverse<'r,T>(v: &'r [T], blk: &fn(v: &'r T) -> bool) {
-    eachi_reverse(v, |_i, v| blk(v))
+    _each_reverse(v, blk);
+}
+#[cfg(not(stage0))]
+pub fn each_reverse<'r,T>(v: &'r [T], blk: &fn(v: &'r T) -> bool) -> bool {
+    _each_reverse(v, blk)
 }
 
 /**
@@ -1590,14 +1647,26 @@ pub fn each_reverse<'r,T>(v: &'r [T], blk: &fn(v: &'r T) -> bool) {
  * Return true to continue, false to break.
  */
 #[inline(always)]
-pub fn eachi_reverse<'r,T>(v: &'r [T], blk: &fn(i: uint, v: &'r T) -> bool) {
+pub fn _eachi_reverse<'r,T>(v: &'r [T],
+                            blk: &fn(i: uint, v: &'r T) -> bool) -> bool {
     let mut i = v.len();
     while i > 0 {
         i -= 1;
         if !blk(i, &v[i]) {
-            return;
+            return false;
         }
     }
+    return true;
+}
+
+#[cfg(stage0)]
+pub fn eachi_reverse<'r,T>(v: &'r [T], blk: &fn(i: uint, v: &'r T) -> bool) {
+    _eachi_reverse(v, blk);
+}
+#[cfg(not(stage0))]
+pub fn eachi_reverse<'r,T>(v: &'r [T],
+                           blk: &fn(i: uint, v: &'r T) -> bool) -> bool {
+    _eachi_reverse(v, blk)
 }
 
 /**
@@ -1608,13 +1677,23 @@ pub fn eachi_reverse<'r,T>(v: &'r [T], blk: &fn(i: uint, v: &'r T) -> bool) {
  * Both vectors must have the same length
  */
 #[inline]
-pub fn each2<U, T>(v1: &[U], v2: &[T], f: &fn(u: &U, t: &T) -> bool) {
+pub fn _each2<U, T>(v1: &[U], v2: &[T], f: &fn(u: &U, t: &T) -> bool) -> bool {
     assert!(len(v1) == len(v2));
     for uint::range(0u, len(v1)) |i| {
         if !f(&v1[i], &v2[i]) {
-            return;
+            return false;
         }
     }
+    return true;
+}
+
+#[cfg(stage0)]
+pub fn each2<U, T>(v1: &[U], v2: &[T], f: &fn(u: &U, t: &T) -> bool) {
+    _each2(v1, v2, f);
+}
+#[cfg(not(stage0))]
+pub fn each2<U, T>(v1: &[U], v2: &[T], f: &fn(u: &U, t: &T) -> bool) -> bool {
+    _each2(v1, v2, f)
 }
 
 /**
@@ -1627,7 +1706,8 @@ pub fn each2<U, T>(v1: &[U], v2: &[T], f: &fn(u: &U, t: &T) -> bool) {
  * The total number of permutations produced is `len(v)!`.  If `v` contains
  * repeated elements, then some permutations are repeated.
  */
-pub fn each_permutation<T:Copy>(v: &[T], put: &fn(ts: &[T]) -> bool) {
+#[cfg(not(stage0))]
+pub fn each_permutation<T:Copy>(v: &[T], put: &fn(ts: &[T]) -> bool) -> bool {
     let ln = len(v);
     if ln <= 1 {
         put(v);
@@ -1641,12 +1721,13 @@ pub fn each_permutation<T:Copy>(v: &[T], put: &fn(ts: &[T]) -> bool) {
             rest.push_all(const_slice(v, i+1u, ln));
             for each_permutation(rest) |permutation| {
                 if !put(append(~[elt], permutation)) {
-                    return;
+                    return false;
                 }
             }
             i += 1u;
         }
     }
+    return true;
 }
 
 /**
@@ -1932,8 +2013,14 @@ pub trait ImmutableVector<'self, T> {
     fn initn(&self, n: uint) -> &'self [T];
     fn last(&self) -> &'self T;
     fn last_opt(&self) -> Option<&'self T>;
+    #[cfg(stage0)]
     fn each_reverse(&self, blk: &fn(&T) -> bool);
+    #[cfg(not(stage0))]
+    fn each_reverse(&self, blk: &fn(&T) -> bool) -> bool;
+    #[cfg(stage0)]
     fn eachi_reverse(&self, blk: &fn(uint, &T) -> bool);
+    #[cfg(not(stage0))]
+    fn eachi_reverse(&self, blk: &fn(uint, &T) -> bool) -> bool;
     fn foldr<'a, U>(&'a self, z: U, p: &fn(t: &'a T, u: U) -> U) -> U;
     fn map<U>(&self, f: &fn(t: &T) -> U) -> ~[U];
     fn mapi<U>(&self, f: &fn(uint, t: &T) -> U) -> ~[U];
@@ -1995,13 +2082,27 @@ impl<'self,T> ImmutableVector<'self, T> for &'self [T] {
 
     /// Iterates over a vector's elements in reverse.
     #[inline]
+    #[cfg(stage0)]
     fn each_reverse(&self, blk: &fn(&T) -> bool) {
+        each_reverse(*self, blk)
+    }
+    /// Iterates over a vector's elements in reverse.
+    #[inline]
+    #[cfg(not(stage0))]
+    fn each_reverse(&self, blk: &fn(&T) -> bool) -> bool {
         each_reverse(*self, blk)
     }
 
     /// Iterates over a vector's elements and indices in reverse.
+    #[cfg(stage0)]
     #[inline]
     fn eachi_reverse(&self, blk: &fn(uint, &T) -> bool) {
+        eachi_reverse(*self, blk)
+    }
+    /// Iterates over a vector's elements and indices in reverse.
+    #[cfg(not(stage0))]
+    #[inline]
+    fn eachi_reverse(&self, blk: &fn(uint, &T) -> bool) -> bool {
         eachi_reverse(*self, blk)
     }
 
@@ -2555,44 +2656,81 @@ pub mod bytes {
 // ITERATION TRAIT METHODS
 
 impl<'self,A> old_iter::BaseIter<A> for &'self [A] {
+    #[cfg(stage0)]
     #[inline(always)]
-    fn each<'a>(&'a self, blk: &fn(v: &'a A) -> bool) { each(*self, blk) }
+    fn each<'a>(&'a self, blk: &fn(v: &'a A) -> bool) {
+        each(*self, blk)
+    }
+    #[cfg(not(stage0))]
+    #[inline(always)]
+    fn each<'a>(&'a self, blk: &fn(v: &'a A) -> bool) -> bool {
+        each(*self, blk)
+    }
     #[inline(always)]
     fn size_hint(&self) -> Option<uint> { Some(self.len()) }
 }
 
 // FIXME(#4148): This should be redundant
 impl<A> old_iter::BaseIter<A> for ~[A] {
+    #[cfg(stage0)]
     #[inline(always)]
-    fn each<'a>(&'a self, blk: &fn(v: &'a A) -> bool) { each(*self, blk) }
+    fn each<'a>(&'a self, blk: &fn(v: &'a A) -> bool) {
+        each(*self, blk)
+    }
+    #[cfg(not(stage0))]
+    #[inline(always)]
+    fn each<'a>(&'a self, blk: &fn(v: &'a A) -> bool) -> bool {
+        each(*self, blk)
+    }
     #[inline(always)]
     fn size_hint(&self) -> Option<uint> { Some(self.len()) }
 }
 
 // FIXME(#4148): This should be redundant
 impl<A> old_iter::BaseIter<A> for @[A] {
+    #[cfg(stage0)]
     #[inline(always)]
-    fn each<'a>(&'a self, blk: &fn(v: &'a A) -> bool) { each(*self, blk) }
+    fn each<'a>(&'a self, blk: &fn(v: &'a A) -> bool) {
+        each(*self, blk)
+    }
+    #[cfg(not(stage0))]
+    #[inline(always)]
+    fn each<'a>(&'a self, blk: &fn(v: &'a A) -> bool) -> bool {
+        each(*self, blk)
+    }
     #[inline(always)]
     fn size_hint(&self) -> Option<uint> { Some(self.len()) }
 }
 
 impl<'self,A> old_iter::MutableIter<A> for &'self mut [A] {
+    #[cfg(stage0)]
     #[inline(always)]
     fn each_mut<'a>(&'a mut self, blk: &fn(v: &'a mut A) -> bool) {
+        each_mut(*self, blk)
+    }
+    #[cfg(not(stage0))]
+    #[inline(always)]
+    fn each_mut<'a>(&'a mut self, blk: &fn(v: &'a mut A) -> bool) -> bool {
         each_mut(*self, blk)
     }
 }
 
 // FIXME(#4148): This should be redundant
 impl<A> old_iter::MutableIter<A> for ~[A] {
+    #[cfg(stage0)]
     #[inline(always)]
     fn each_mut<'a>(&'a mut self, blk: &fn(v: &'a mut A) -> bool) {
+        each_mut(*self, blk)
+    }
+    #[cfg(not(stage0))]
+    #[inline(always)]
+    fn each_mut<'a>(&'a mut self, blk: &fn(v: &'a mut A) -> bool) -> bool {
         each_mut(*self, blk)
     }
 }
 
 // FIXME(#4148): This should be redundant
+#[cfg(stage0)]
 impl<A> old_iter::MutableIter<A> for @mut [A] {
     #[inline(always)]
     fn each_mut(&mut self, blk: &fn(v: &mut A) -> bool) {
@@ -2600,8 +2738,21 @@ impl<A> old_iter::MutableIter<A> for @mut [A] {
     }
 }
 
+#[cfg(not(stage0))]
+impl<A> old_iter::MutableIter<A> for @mut [A] {
+    #[inline(always)]
+    fn each_mut(&mut self, blk: &fn(v: &mut A) -> bool) -> bool {
+        each_mut(*self, blk)
+    }
+}
+
 impl<'self,A> old_iter::ExtendedIter<A> for &'self [A] {
+    #[cfg(stage0)]
     pub fn eachi(&self, blk: &fn(uint, v: &A) -> bool) {
+        old_iter::eachi(self, blk)
+    }
+    #[cfg(not(stage0))]
+    pub fn eachi(&self, blk: &fn(uint, v: &A) -> bool) -> bool {
         old_iter::eachi(self, blk)
     }
     pub fn all(&self, blk: &fn(&A) -> bool) -> bool {
@@ -2627,14 +2778,25 @@ impl<'self,A> old_iter::ExtendedIter<A> for &'self [A] {
 
 impl<'self,A> old_iter::ExtendedMutableIter<A> for &'self mut [A] {
     #[inline(always)]
+    #[cfg(stage0)]
     pub fn eachi_mut(&mut self, blk: &fn(uint, v: &mut A) -> bool) {
+        eachi_mut(*self, blk)
+    }
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    pub fn eachi_mut(&mut self, blk: &fn(uint, v: &mut A) -> bool) -> bool {
         eachi_mut(*self, blk)
     }
 }
 
 // FIXME(#4148): This should be redundant
 impl<A> old_iter::ExtendedIter<A> for ~[A] {
+    #[cfg(stage0)]
     pub fn eachi(&self, blk: &fn(uint, v: &A) -> bool) {
+        old_iter::eachi(self, blk)
+    }
+    #[cfg(not(stage0))]
+    pub fn eachi(&self, blk: &fn(uint, v: &A) -> bool) -> bool {
         old_iter::eachi(self, blk)
     }
     pub fn all(&self, blk: &fn(&A) -> bool) -> bool {
@@ -2660,7 +2822,12 @@ impl<A> old_iter::ExtendedIter<A> for ~[A] {
 
 // FIXME(#4148): This should be redundant
 impl<A> old_iter::ExtendedIter<A> for @[A] {
+    #[cfg(stage0)]
     pub fn eachi(&self, blk: &fn(uint, v: &A) -> bool) {
+        old_iter::eachi(self, blk)
+    }
+    #[cfg(not(stage0))]
+    pub fn eachi(&self, blk: &fn(uint, v: &A) -> bool) -> bool {
         old_iter::eachi(self, blk)
     }
     pub fn all(&self, blk: &fn(&A) -> bool) -> bool {

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -1744,12 +1744,36 @@ pub fn each_permutation<T:Copy>(v: &[T], put: &fn(ts: &[T]) -> bool) -> bool {
  * ~~~
  *
  */
+#[cfg(stage0)]
 pub fn windowed<'r, T>(n: uint, v: &'r [T], it: &fn(&'r [T]) -> bool) {
     assert!(1u <= n);
     if n > v.len() { return; }
     for uint::range(0, v.len() - n + 1) |i| {
         if !it(v.slice(i, i + n)) { return }
     }
+}
+/**
+ * Iterate over all contiguous windows of length `n` of the vector `v`.
+ *
+ * # Example
+ *
+ * Print the adjacent pairs of a vector (i.e. `[1,2]`, `[2,3]`, `[3,4]`)
+ *
+ * ~~~
+ * for windowed(2, &[1,2,3,4]) |v| {
+ *     io::println(fmt!("%?", v));
+ * }
+ * ~~~
+ *
+ */
+#[cfg(not(stage0))]
+pub fn windowed<'r, T>(n: uint, v: &'r [T], it: &fn(&'r [T]) -> bool) -> bool {
+    assert!(1u <= n);
+    if n > v.len() { return true; }
+    for uint::range(0, v.len() - n + 1) |i| {
+        if !it(v.slice(i, i + n)) { return false; }
+    }
+    return true;
 }
 
 /**
@@ -4566,7 +4590,7 @@ mod tests {
             }
             i += 0;
             false
-        }
+        };
     }
 
     #[test]
@@ -4581,7 +4605,7 @@ mod tests {
             }
             i += 0;
             false
-        }
+        };
     }
 
     #[test]

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -44,14 +44,24 @@ pub fn get_type_param_count(cstore: @mut cstore::CStore, def: ast::def_id)
 }
 
 /// Iterates over all the language items in the given crate.
+#[cfg(stage0)]
 pub fn each_lang_item(cstore: @mut cstore::CStore,
                       cnum: ast::crate_num,
                       f: &fn(ast::node_id, uint) -> bool) {
     let crate_data = cstore::get_crate_data(cstore, cnum);
     decoder::each_lang_item(crate_data, f)
 }
+/// Iterates over all the language items in the given crate.
+#[cfg(not(stage0))]
+pub fn each_lang_item(cstore: @mut cstore::CStore,
+                      cnum: ast::crate_num,
+                      f: &fn(ast::node_id, uint) -> bool) -> bool {
+    let crate_data = cstore::get_crate_data(cstore, cnum);
+    decoder::each_lang_item(crate_data, f)
+}
 
 /// Iterates over all the paths in the given crate.
+#[cfg(stage0)]
 pub fn each_path(cstore: @mut cstore::CStore,
                  cnum: ast::crate_num,
                  f: &fn(&str, decoder::def_like) -> bool) {
@@ -60,6 +70,17 @@ pub fn each_path(cstore: @mut cstore::CStore,
         cstore::get_crate_data(cstore, cnum)
     };
     decoder::each_path(cstore.intr, crate_data, get_crate_data, f);
+}
+/// Iterates over all the paths in the given crate.
+#[cfg(not(stage0))]
+pub fn each_path(cstore: @mut cstore::CStore,
+                 cnum: ast::crate_num,
+                 f: &fn(&str, decoder::def_like) -> bool) -> bool {
+    let crate_data = cstore::get_crate_data(cstore, cnum);
+    let get_crate_data: decoder::GetCrateDataCb = |cnum| {
+        cstore::get_crate_data(cstore, cnum)
+    };
+    decoder::each_path(cstore.intr, crate_data, get_crate_data, f)
 }
 
 pub fn get_item_path(tcx: ty::ctxt, def: ast::def_id) -> ast_map::path {

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -196,12 +196,22 @@ fn item_def_id(d: ebml::Doc, cdata: cmd) -> ast::def_id {
                                                     |d| parse_def_id(d)));
 }
 
+#[cfg(stage0)]
 fn each_reexport(d: ebml::Doc, f: &fn(ebml::Doc) -> bool) {
     for reader::tagged_docs(d, tag_items_data_item_reexport) |reexport_doc| {
         if !f(reexport_doc) {
             return;
         }
     }
+}
+#[cfg(not(stage0))]
+fn each_reexport(d: ebml::Doc, f: &fn(ebml::Doc) -> bool) -> bool {
+    for reader::tagged_docs(d, tag_items_data_item_reexport) |reexport_doc| {
+        if !f(reexport_doc) {
+            return false;
+        }
+    }
+    return true;
 }
 
 fn variant_disr_val(d: ebml::Doc) -> Option<int> {
@@ -454,6 +464,7 @@ fn def_like_to_def(def_like: def_like) -> ast::def {
 }
 
 /// Iterates over the language items in the given crate.
+#[cfg(stage0)]
 pub fn each_lang_item(cdata: cmd, f: &fn(ast::node_id, uint) -> bool) {
     let root = reader::Doc(cdata.data);
     let lang_items = reader::get_doc(root, tag_lang_items);
@@ -469,11 +480,29 @@ pub fn each_lang_item(cdata: cmd, f: &fn(ast::node_id, uint) -> bool) {
         }
     }
 }
+/// Iterates over the language items in the given crate.
+#[cfg(not(stage0))]
+pub fn each_lang_item(cdata: cmd, f: &fn(ast::node_id, uint) -> bool) -> bool {
+    let root = reader::Doc(cdata.data);
+    let lang_items = reader::get_doc(root, tag_lang_items);
+    for reader::tagged_docs(lang_items, tag_lang_items_item) |item_doc| {
+        let id_doc = reader::get_doc(item_doc, tag_lang_items_item_id);
+        let id = reader::doc_as_u32(id_doc) as uint;
+        let node_id_doc = reader::get_doc(item_doc,
+                                          tag_lang_items_item_node_id);
+        let node_id = reader::doc_as_u32(node_id_doc) as ast::node_id;
+
+        if !f(node_id, id) {
+            return false;
+        }
+    }
+    return true;
+}
 
 /// Iterates over all the paths in the given crate.
-pub fn each_path(intr: @ident_interner, cdata: cmd,
-                 get_crate_data: GetCrateDataCb,
-                 f: &fn(&str, def_like) -> bool) {
+pub fn _each_path(intr: @ident_interner, cdata: cmd,
+                  get_crate_data: GetCrateDataCb,
+                  f: &fn(&str, def_like) -> bool) -> bool {
     let root = reader::Doc(cdata.data);
     let items = reader::get_doc(root, tag_items);
     let items_data = reader::get_doc(items, tag_items_data);
@@ -555,10 +584,20 @@ pub fn each_path(intr: @ident_interner, cdata: cmd,
         }
     }
 
-    // If broken, stop here.
-    if broken {
-        return;
-    }
+    return broken;
+}
+
+#[cfg(stage0)]
+pub fn each_path(intr: @ident_interner, cdata: cmd,
+                 get_crate_data: GetCrateDataCb,
+                 f: &fn(&str, def_like) -> bool) {
+    _each_path(intr, cdata, get_crate_data, f);
+}
+#[cfg(not(stage0))]
+pub fn each_path(intr: @ident_interner, cdata: cmd,
+                 get_crate_data: GetCrateDataCb,
+                 f: &fn(&str, def_like) -> bool) -> bool {
+    _each_path(intr, cdata, get_crate_data, f)
 }
 
 pub fn get_item_path(intr: @ident_interner, cdata: cmd, id: ast::node_id)

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1391,11 +1391,10 @@ pub fn encode_metadata(parms: EncodeParams, crate: &crate) -> ~[u8] {
     ecx.stats.total_bytes = *wr.pos;
 
     if (tcx.sess.meta_stats()) {
-        do wr.bytes.each |e| {
+        for wr.bytes.each |e| {
             if *e == 0 {
                 ecx.stats.zero_bytes += 1;
             }
-            true
         }
 
         io::println("metadata stats:");

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -21,7 +21,10 @@ pub fn pick_file(file: Path, path: &Path) -> Option<Path> {
 
 pub trait FileSearch {
     fn sysroot(&self) -> @Path;
+    #[cfg(stage0)]
     fn for_each_lib_search_path(&self, f: &fn(&Path) -> bool);
+    #[cfg(not(stage0))]
+    fn for_each_lib_search_path(&self, f: &fn(&Path) -> bool) -> bool;
     fn get_target_lib_path(&self) -> Path;
     fn get_target_lib_file_path(&self, file: &Path) -> Path;
 }
@@ -37,6 +40,7 @@ pub fn mk_filesearch(maybe_sysroot: &Option<@Path>,
     }
     impl FileSearch for FileSearchImpl {
         fn sysroot(&self) -> @Path { self.sysroot }
+        #[cfg(stage0)]
         fn for_each_lib_search_path(&self, f: &fn(&Path) -> bool) {
             debug!("filesearch: searching additional lib search paths");
             // a little weird
@@ -59,6 +63,30 @@ pub fn mk_filesearch(maybe_sysroot: &Option<@Path>,
               result::Ok(ref p) => f(p),
               result::Err(_) => true
            };
+        }
+        #[cfg(not(stage0))]
+        fn for_each_lib_search_path(&self, f: &fn(&Path) -> bool) -> bool {
+            debug!("filesearch: searching additional lib search paths");
+            // a little weird
+            self.addl_lib_search_paths.each(f);
+
+            debug!("filesearch: searching target lib path");
+            if !f(&make_target_lib_path(self.sysroot,
+                                        self.target_triple)) {
+                return false;
+            }
+            debug!("filesearch: searching rustpkg lib path nearest");
+            if match get_rustpkg_lib_path_nearest() {
+                    result::Ok(ref p) => f(p),
+                    result::Err(_) => true
+                } {
+                    return true;
+                }
+           debug!("filesearch: searching rustpkg lib path");
+           match get_rustpkg_lib_path() {
+              result::Ok(ref p) => f(p),
+              result::Err(_) => true
+           }
         }
         fn get_target_lib_path(&self) -> Path {
             make_target_lib_path(self.sysroot, self.target_triple)

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -67,6 +67,7 @@ enum MoveError {
 pub impl<'self> CheckLoanCtxt<'self> {
     fn tcx(&self) -> ty::ctxt { self.bccx.tcx }
 
+    #[cfg(stage0)]
     fn each_issued_loan(&self,
                         scope_id: ast::node_id,
                         op: &fn(&Loan) -> bool)
@@ -84,7 +85,27 @@ pub impl<'self> CheckLoanCtxt<'self> {
             }
         }
     }
+    #[cfg(not(stage0))]
+    fn each_issued_loan(&self,
+                        scope_id: ast::node_id,
+                        op: &fn(&Loan) -> bool) -> bool
+    {
+        //! Iterates over each loan that that has been issued
+        //! on entrance to `scope_id`, regardless of whether it is
+        //! actually *in scope* at that point.  Sometimes loans
+        //! are issued for future scopes and thus they may have been
+        //! *issued* but not yet be in effect.
 
+        for self.dfcx.each_bit_on_entry(scope_id) |loan_index| {
+            let loan = &self.all_loans[loan_index];
+            if !op(loan) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    #[cfg(stage0)]
     fn each_in_scope_loan(&self,
                           scope_id: ast::node_id,
                           op: &fn(&Loan) -> bool)
@@ -101,7 +122,26 @@ pub impl<'self> CheckLoanCtxt<'self> {
             }
         }
     }
+    #[cfg(not(stage0))]
+    fn each_in_scope_loan(&self,
+                          scope_id: ast::node_id,
+                          op: &fn(&Loan) -> bool) -> bool
+    {
+        //! Like `each_issued_loan()`, but only considers loans that are
+        //! currently in scope.
 
+        let region_maps = self.tcx().region_maps;
+        for self.each_issued_loan(scope_id) |loan| {
+            if region_maps.is_subscope_of(scope_id, loan.kill_scope) {
+                if !op(loan) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    #[cfg(stage0)]
     fn each_in_scope_restriction(&self,
                                  scope_id: ast::node_id,
                                  loan_path: @LoanPath,
@@ -119,6 +159,26 @@ pub impl<'self> CheckLoanCtxt<'self> {
                 }
             }
         }
+    }
+    #[cfg(not(stage0))]
+    fn each_in_scope_restriction(&self,
+                                 scope_id: ast::node_id,
+                                 loan_path: @LoanPath,
+                                 op: &fn(&Loan, &Restriction) -> bool) -> bool
+    {
+        //! Iterates through all the in-scope restrictions for the
+        //! given `loan_path`
+
+        for self.each_in_scope_loan(scope_id) |loan| {
+            for loan.restrictions.each |restr| {
+                if restr.loan_path == loan_path {
+                    if !op(loan, restr) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
     }
 
     fn loans_generated_by(&self, scope_id: ast::node_id) -> ~[uint] {

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -182,6 +182,7 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
     }
 
 
+    #[cfg(stage0)]
     pub fn each_bit_on_entry(&self,
                              id: ast::node_id,
                              f: &fn(uint) -> bool) {
@@ -194,7 +195,21 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
                id, bits_to_str(on_entry));
         self.each_bit(on_entry, f);
     }
+    #[cfg(not(stage0))]
+    pub fn each_bit_on_entry(&self,
+                             id: ast::node_id,
+                             f: &fn(uint) -> bool) -> bool {
+        //! Iterates through each bit that is set on entry to `id`.
+        //! Only useful after `propagate()` has been called.
 
+        let (start, end) = self.compute_id_range(id);
+        let on_entry = vec::slice(self.on_entry, start, end);
+        debug!("each_bit_on_entry(id=%?, on_entry=%s)",
+               id, bits_to_str(on_entry));
+        self.each_bit(on_entry, f)
+    }
+
+    #[cfg(stage0)]
     pub fn each_gen_bit(&self,
                         id: ast::node_id,
                         f: &fn(uint) -> bool) {
@@ -206,7 +221,20 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
                id, bits_to_str(gens));
         self.each_bit(gens, f)
     }
+    #[cfg(not(stage0))]
+    pub fn each_gen_bit(&self,
+                        id: ast::node_id,
+                        f: &fn(uint) -> bool) -> bool {
+        //! Iterates through each bit in the gen set for `id`.
 
+        let (start, end) = self.compute_id_range(id);
+        let gens = vec::slice(self.gens, start, end);
+        debug!("each_gen_bit(id=%?, gens=%s)",
+               id, bits_to_str(gens));
+        self.each_bit(gens, f)
+    }
+
+    #[cfg(stage0)]
     fn each_bit(&self,
                 words: &[uint],
                 f: &fn(uint) -> bool) {
@@ -235,6 +263,39 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
                 }
             }
         }
+    }
+    #[cfg(not(stage0))]
+    fn each_bit(&self,
+                words: &[uint],
+                f: &fn(uint) -> bool) -> bool {
+        //! Helper for iterating over the bits in a bit set.
+
+        for words.eachi |word_index, &word| {
+            if word != 0 {
+                let base_index = word_index * uint::bits;
+                for uint::range(0, uint::bits) |offset| {
+                    let bit = 1 << offset;
+                    if (word & bit) != 0 {
+                        // NB: we round up the total number of bits
+                        // that we store in any given bit set so that
+                        // it is an even multiple of uint::bits.  This
+                        // means that there may be some stray bits at
+                        // the end that do not correspond to any
+                        // actual value.  So before we callback, check
+                        // whether the bit_index is greater than the
+                        // actual value the user specified and stop
+                        // iterating if so.
+                        let bit_index = base_index + offset;
+                        if bit_index >= self.bits_per_id {
+                            return true;
+                        } else if !f(bit_index) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        return true;
     }
 }
 

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -86,12 +86,17 @@ pub impl LanguageItems {
         }
     }
 
+    #[cfg(stage0)]
     fn each_item(&self, f: &fn(def_id: def_id, i: uint) -> bool) {
         for self.items.eachi |i, &item| {
             if !f(item.get(), i) {
                 break;
             }
         }
+    }
+    #[cfg(not(stage0))]
+    fn each_item(&self, f: &fn(def_id: def_id, i: uint) -> bool) -> bool {
+        self.items.eachi(|i, &item| f(item.get(), i))
     }
 
     pub fn item_name(index: uint) -> &'static str {

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2408,14 +2408,14 @@ pub impl Resolver {
         let merge_import_resolution = |ident,
                                        name_bindings: @mut NameBindings| {
             let dest_import_resolution;
-            match module_.import_resolutions.find(ident) {
+            match module_.import_resolutions.find(&ident) {
                 None => {
                     // Create a new import resolution from this child.
                     dest_import_resolution = @mut ImportResolution(privacy,
                                                                    span,
                                                                    state);
                     module_.import_resolutions.insert
-                        (*ident, dest_import_resolution);
+                        (ident, dest_import_resolution);
                 }
                 Some(&existing_import_resolution) => {
                     dest_import_resolution = existing_import_resolution;
@@ -2424,7 +2424,7 @@ pub impl Resolver {
 
             debug!("(resolving glob import) writing resolution `%s` in `%s` \
                     to `%s`, privacy=%?",
-                   *self.session.str_of(*ident),
+                   *self.session.str_of(ident),
                    self.module_to_str(containing_module),
                    self.module_to_str(module_),
                    copy dest_import_resolution.privacy);
@@ -2443,13 +2443,13 @@ pub impl Resolver {
         };
 
         // Add all children from the containing module.
-        for containing_module.children.each |ident, name_bindings| {
+        for containing_module.children.each |&ident, name_bindings| {
             merge_import_resolution(ident, *name_bindings);
         }
 
         // Add external module children from the containing module.
         for containing_module.external_module_children.each
-                |ident, module| {
+                |&ident, module| {
             let name_bindings =
                 @mut Resolver::create_name_bindings_from_module(*module);
             merge_import_resolution(ident, name_bindings);

--- a/src/librustc/middle/resolve_stage0.rs
+++ b/src/librustc/middle/resolve_stage0.rs
@@ -2424,14 +2424,14 @@ pub impl Resolver {
         let merge_import_resolution = |ident,
                                        name_bindings: @mut NameBindings| {
             let dest_import_resolution;
-            match module_.import_resolutions.find(ident) {
+            match module_.import_resolutions.find(&ident) {
                 None => {
                     // Create a new import resolution from this child.
                     dest_import_resolution = @mut ImportResolution(privacy,
                                                                    span,
                                                                    state);
                     module_.import_resolutions.insert
-                        (*ident, dest_import_resolution);
+                        (ident, dest_import_resolution);
                 }
                 Some(existing_import_resolution) => {
                     dest_import_resolution = *existing_import_resolution;
@@ -2440,7 +2440,7 @@ pub impl Resolver {
 
             debug!("(resolving glob import) writing resolution `%s` in `%s` \
                     to `%s`, privacy=%?",
-                   *self.session.str_of(*ident),
+                   *self.session.str_of(ident),
                    self.module_to_str(containing_module),
                    self.module_to_str(module_),
                    copy dest_import_resolution.privacy);
@@ -2459,13 +2459,13 @@ pub impl Resolver {
         };
 
         // Add all children from the containing module.
-        for containing_module.children.each |ident, name_bindings| {
+        for containing_module.children.each |&ident, name_bindings| {
             merge_import_resolution(ident, *name_bindings);
         }
 
         // Add external module children from the containing module.
         for containing_module.external_module_children.each
-                |ident, module| {
+                |&ident, module| {
             let name_bindings =
                 @mut Resolver::create_name_bindings_from_module(*module);
             merge_import_resolution(ident, name_bindings);

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -550,7 +550,14 @@ pub fn trans_call_inner(in_cx: block,
                 // drop the value if it is not being saved.
                 unsafe {
                     if llvm::LLVMIsUndef(llretslot) != lib::llvm::True {
-                        if ty::type_is_immediate(ret_ty) {
+                        if ty::type_is_nil(ret_ty) {
+                            // When implementing the for-loop sugar syntax, the
+                            // type of the for-loop is nil, but the function
+                            // it's invoking returns a bool. This is a special
+                            // case to ignore instead of invoking the Store
+                            // below into a scratch pointer of a mismatched
+                            // type.
+                        } else if ty::type_is_immediate(ret_ty) {
                             let llscratchptr = alloc_ty(bcx, ret_ty);
                             Store(bcx, llresult, llscratchptr);
                             bcx = glue::drop_ty(bcx, llscratchptr, ret_ty);

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1369,6 +1369,7 @@ pub struct mono_id_ {
 
 pub type mono_id = @mono_id_;
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for mono_param_id {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
@@ -1382,16 +1383,44 @@ impl to_bytes::IterBytes for mono_param_id {
         }
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for mono_param_id {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        match *self {
+            mono_precise(t, ref mids) =>
+                to_bytes::iter_bytes_3(&0u8, &ty::type_id(t), mids, lsb0, f),
 
+            mono_any => 1u8.iter_bytes(lsb0, f),
+
+            mono_repr(ref a, ref b, ref c, ref d) =>
+                to_bytes::iter_bytes_5(&2u8, a, b, c, d, lsb0, f)
+        }
+    }
+}
+
+#[cfg(stage0)]
 impl to_bytes::IterBytes for MonoDataClass {
     fn iter_bytes(&self, lsb0: bool, f:to_bytes::Cb) {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for MonoDataClass {
+    fn iter_bytes(&self, lsb0: bool, f:to_bytes::Cb) -> bool {
+        (*self as u8).iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for mono_id_ {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.def, &self.params, lsb0, f);
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for mono_id_ {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        to_bytes::iter_bytes_2(&self.def, &self.params, lsb0, f)
     }
 }
 

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -155,8 +155,15 @@ pub impl DatumMode {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for DatumMode {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        (*self as uint).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for DatumMode {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (*self as uint).iter_bytes(lsb0, f)
     }
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4537,18 +4537,9 @@ pub fn each_bound_trait_and_supertraits(tcx: ctxt,
 // list.
 #[cfg(not(stage0))]
 pub fn each_bound_trait_and_supertraits(tcx: ctxt,
-                                        bounds: param_bounds,
-                                        f: &fn(&TraitRef) -> bool) -> bool {
-    for bounds.each |bound| {
-        let bound_trait_ref = match *bound {
-            ty::bound_trait(bound_t) => bound_t,
-
-            ty::bound_copy | ty::bound_owned |
-            ty::bound_const | ty::bound_durable => {
-                loop; // skip non-trait bounds
-            }
-        };
-
+                                        bounds: &ParamBounds,
+                                        f: &fn(@TraitRef) -> bool) -> bool {
+    for bounds.trait_bounds.each |&bound_trait_ref| {
         let mut supertrait_set = HashMap::new();
         let mut trait_refs = ~[];
         let mut i = 0;

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -121,9 +121,16 @@ pub struct creader_cache_key {
 
 type creader_cache = @mut HashMap<creader_cache_key, t>;
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for creader_cache_key {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_3(&self.cnum, &self.pos, &self.len, lsb0, f);
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for creader_cache_key {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        to_bytes::iter_bytes_3(&self.cnum, &self.pos, &self.len, lsb0, f)
     }
 }
 
@@ -145,10 +152,19 @@ impl cmp::Eq for intern_key {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for intern_key {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         unsafe {
             (*self.sty).iter_bytes(lsb0, f);
+        }
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for intern_key {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        unsafe {
+            (*self.sty).iter_bytes(lsb0, f)
         }
     }
 }
@@ -382,14 +398,29 @@ pub struct FnSig {
     output: t
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for BareFnTy {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_3(&self.purity, &self.abis, &self.sig, lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for BareFnTy {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        to_bytes::iter_bytes_3(&self.purity, &self.abis, &self.sig, lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for ClosureTy {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        to_bytes::iter_bytes_5(&self.purity, &self.sigil, &self.onceness,
+                               &self.region, &self.sig, lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for ClosureTy {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         to_bytes::iter_bytes_5(&self.purity, &self.sigil, &self.onceness,
                                &self.region, &self.sig, lsb0, f)
     }
@@ -705,8 +736,19 @@ pub enum InferTy {
     FloatVar(FloatVid)
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for InferTy {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        match *self {
+          TyVar(ref tv) => to_bytes::iter_bytes_2(&0u8, tv, lsb0, f),
+          IntVar(ref iv) => to_bytes::iter_bytes_2(&1u8, iv, lsb0, f),
+          FloatVar(ref fv) => to_bytes::iter_bytes_2(&2u8, fv, lsb0, f),
+        }
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for InferTy {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         match *self {
           TyVar(ref tv) => to_bytes::iter_bytes_2(&0u8, tv, lsb0, f),
           IntVar(ref iv) => to_bytes::iter_bytes_2(&1u8, iv, lsb0, f),
@@ -722,8 +764,18 @@ pub enum InferRegion {
     ReSkolemized(uint, bound_region)
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for InferRegion {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        match *self {
+            ReVar(ref rv) => to_bytes::iter_bytes_2(&0u8, rv, lsb0, f),
+            ReSkolemized(ref v, _) => to_bytes::iter_bytes_2(&1u8, v, lsb0, f)
+        }
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for InferRegion {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         match *self {
             ReVar(ref rv) => to_bytes::iter_bytes_2(&0u8, rv, lsb0, f),
             ReSkolemized(ref v, _) => to_bytes::iter_bytes_2(&1u8, v, lsb0, f)
@@ -810,26 +862,54 @@ impl ToStr for IntVarValue {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for TyVid {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.to_uint().iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for TyVid {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        self.to_uint().iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for IntVid {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.to_uint().iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for IntVid {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        self.to_uint().iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for FloatVid {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.to_uint().iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for FloatVid {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        self.to_uint().iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for RegionVid {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        self.to_uint().iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for RegionVid {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         self.to_uint().iter_bytes(lsb0, f)
     }
 }
@@ -2637,6 +2717,7 @@ impl cmp::TotalEq for bound_region {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for vstore {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
@@ -2651,7 +2732,23 @@ impl to_bytes::IterBytes for vstore {
         }
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for vstore {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        match *self {
+          vstore_fixed(ref u) =>
+          to_bytes::iter_bytes_2(&0u8, u, lsb0, f),
 
+          vstore_uniq => 1u8.iter_bytes(lsb0, f),
+          vstore_box => 2u8.iter_bytes(lsb0, f),
+
+          vstore_slice(ref r) =>
+          to_bytes::iter_bytes_2(&3u8, r, lsb0, f),
+        }
+    }
+}
+
+#[cfg(stage0)]
 impl to_bytes::IterBytes for substs {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
           to_bytes::iter_bytes_3(&self.self_r,
@@ -2659,21 +2756,46 @@ impl to_bytes::IterBytes for substs {
                                  &self.tps, lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for substs {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+          to_bytes::iter_bytes_3(&self.self_r,
+                                 &self.self_ty,
+                                 &self.tps, lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for mt {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
           to_bytes::iter_bytes_2(&self.ty,
                                  &self.mutbl, lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for mt {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+          to_bytes::iter_bytes_2(&self.ty,
+                                 &self.mutbl, lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for field {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
           to_bytes::iter_bytes_2(&self.ident,
                                  &self.mt, lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for field {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+          to_bytes::iter_bytes_2(&self.ident,
+                                 &self.mt, lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for FnSig {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.inputs,
@@ -2681,9 +2803,93 @@ impl to_bytes::IterBytes for FnSig {
                                lsb0, f);
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for FnSig {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        to_bytes::iter_bytes_2(&self.inputs,
+                               &self.output,
+                               lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for sty {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        match *self {
+          ty_nil => 0u8.iter_bytes(lsb0, f),
+          ty_bool => 1u8.iter_bytes(lsb0, f),
+
+          ty_int(ref t) =>
+          to_bytes::iter_bytes_2(&2u8, t, lsb0, f),
+
+          ty_uint(ref t) =>
+          to_bytes::iter_bytes_2(&3u8, t, lsb0, f),
+
+          ty_float(ref t) =>
+          to_bytes::iter_bytes_2(&4u8, t, lsb0, f),
+
+          ty_estr(ref v) =>
+          to_bytes::iter_bytes_2(&5u8, v, lsb0, f),
+
+          ty_enum(ref did, ref substs) =>
+          to_bytes::iter_bytes_3(&6u8, did, substs, lsb0, f),
+
+          ty_box(ref mt) =>
+          to_bytes::iter_bytes_2(&7u8, mt, lsb0, f),
+
+          ty_evec(ref mt, ref v) =>
+          to_bytes::iter_bytes_3(&8u8, mt, v, lsb0, f),
+
+          ty_unboxed_vec(ref mt) =>
+          to_bytes::iter_bytes_2(&9u8, mt, lsb0, f),
+
+          ty_tup(ref ts) =>
+          to_bytes::iter_bytes_2(&10u8, ts, lsb0, f),
+
+          ty_bare_fn(ref ft) =>
+          to_bytes::iter_bytes_2(&12u8, ft, lsb0, f),
+
+          ty_self(ref did) => to_bytes::iter_bytes_2(&13u8, did, lsb0, f),
+
+          ty_infer(ref v) =>
+          to_bytes::iter_bytes_2(&14u8, v, lsb0, f),
+
+          ty_param(ref p) =>
+          to_bytes::iter_bytes_2(&15u8, p, lsb0, f),
+
+          ty_type => 16u8.iter_bytes(lsb0, f),
+          ty_bot => 17u8.iter_bytes(lsb0, f),
+
+          ty_ptr(ref mt) =>
+          to_bytes::iter_bytes_2(&18u8, mt, lsb0, f),
+
+          ty_uniq(ref mt) =>
+          to_bytes::iter_bytes_2(&19u8, mt, lsb0, f),
+
+          ty_trait(ref did, ref substs, ref v, ref mutbl) =>
+          to_bytes::iter_bytes_5(&20u8, did, substs, v, mutbl, lsb0, f),
+
+          ty_opaque_closure_ptr(ref ck) =>
+          to_bytes::iter_bytes_2(&21u8, ck, lsb0, f),
+
+          ty_opaque_box => 22u8.iter_bytes(lsb0, f),
+
+          ty_struct(ref did, ref substs) =>
+          to_bytes::iter_bytes_3(&23u8, did, substs, lsb0, f),
+
+          ty_rptr(ref r, ref mt) =>
+          to_bytes::iter_bytes_3(&24u8, r, mt, lsb0, f),
+
+          ty_err => 25u8.iter_bytes(lsb0, f),
+
+          ty_closure(ref ct) =>
+          to_bytes::iter_bytes_2(&26u8, ct, lsb0, f),
+        }
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for sty {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         match *self {
           ty_nil => 0u8.iter_bytes(lsb0, f),
           ty_bool => 1u8.iter_bytes(lsb0, f),
@@ -4284,6 +4490,7 @@ pub fn determine_inherited_purity(parent: (ast::purity, ast::node_id),
 // Here, the supertraits are the transitive closure of the supertrait
 // relation on the supertraits from each bounded trait's constraint
 // list.
+#[cfg(stage0)]
 pub fn each_bound_trait_and_supertraits(tcx: ctxt,
                                         bounds: &ParamBounds,
                                         f: &fn(@TraitRef) -> bool) {
@@ -4322,6 +4529,61 @@ pub fn each_bound_trait_and_supertraits(tcx: ctxt,
             i += 1;
         }
     }
+}
+// Iterate over a type parameter's bounded traits and any supertraits
+// of those traits, ignoring kinds.
+// Here, the supertraits are the transitive closure of the supertrait
+// relation on the supertraits from each bounded trait's constraint
+// list.
+#[cfg(not(stage0))]
+pub fn each_bound_trait_and_supertraits(tcx: ctxt,
+                                        bounds: param_bounds,
+                                        f: &fn(&TraitRef) -> bool) -> bool {
+    for bounds.each |bound| {
+        let bound_trait_ref = match *bound {
+            ty::bound_trait(bound_t) => bound_t,
+
+            ty::bound_copy | ty::bound_owned |
+            ty::bound_const | ty::bound_durable => {
+                loop; // skip non-trait bounds
+            }
+        };
+
+        let mut supertrait_set = HashMap::new();
+        let mut trait_refs = ~[];
+        let mut i = 0;
+
+        // Seed the worklist with the trait from the bound
+        supertrait_set.insert(bound_trait_ref.def_id, ());
+        trait_refs.push(bound_trait_ref);
+
+        // Add the given trait ty to the hash map
+        while i < trait_refs.len() {
+            debug!("each_bound_trait_and_supertraits(i=%?, trait_ref=%s)",
+                   i, trait_refs[i].repr(tcx));
+
+            if !f(trait_refs[i]) {
+                return false;
+            }
+
+            // Add supertraits to supertrait_set
+            let supertrait_refs = trait_ref_supertraits(tcx, trait_refs[i]);
+            for supertrait_refs.each |&supertrait_ref| {
+                debug!("each_bound_trait_and_supertraits(supertrait_ref=%s)",
+                       supertrait_ref.repr(tcx));
+
+                let d_id = supertrait_ref.def_id;
+                if !supertrait_set.contains_key(&d_id) {
+                    // FIXME(#5527) Could have same trait multiple times
+                    supertrait_set.insert(d_id, ());
+                    trait_refs.push(supertrait_ref);
+                }
+            }
+
+            i += 1;
+        }
+    }
+    return true;
 }
 
 pub fn count_traits_and_supertraits(tcx: ctxt,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -828,11 +828,20 @@ pub impl FnCtxt {
         }
     }
 
+    #[cfg(stage0)]
     fn opt_node_ty_substs(&self, id: ast::node_id,
                           f: &fn(&ty::substs) -> bool) {
         match self.inh.node_type_substs.find(&id) {
             Some(s) => { f(s); }
             None => ()
+        }
+    }
+    #[cfg(not(stage0))]
+    fn opt_node_ty_substs(&self, id: ast::node_id,
+                          f: &fn(&ty::substs) -> bool) -> bool {
+        match self.inh.node_type_substs.find(&id) {
+            Some(s) => f(s),
+            None => true
         }
     }
 

--- a/src/librustc/util/enum_set.rs
+++ b/src/librustc/util/enum_set.rs
@@ -49,6 +49,7 @@ pub impl<E:CLike> EnumSet<E> {
         (self.bits & bit(e)) != 0
     }
 
+    #[cfg(stage0)]
     fn each(&self, f: &fn(E) -> bool) {
         let mut bits = self.bits;
         let mut index = 0;
@@ -62,6 +63,22 @@ pub impl<E:CLike> EnumSet<E> {
             index += 1;
             bits >>= 1;
         }
+    }
+    #[cfg(not(stage0))]
+    fn each(&self, f: &fn(E) -> bool) -> bool {
+        let mut bits = self.bits;
+        let mut index = 0;
+        while bits != 0 {
+            if (bits & 1) != 0 {
+                let e = CLike::from_uint(index);
+                if !f(e) {
+                    return false;
+                }
+            }
+            index += 1;
+            bits >>= 1;
+        }
+        return true;
     }
 }
 

--- a/src/librustpkg/workspace.rs
+++ b/src/librustpkg/workspace.rs
@@ -14,7 +14,7 @@ use path_util::{rust_path, workspace_contains_package_id};
 use util::PkgId;
 use core::path::Path;
 
-pub fn pkg_parent_workspaces(pkgid: PkgId, action: &fn(&Path) -> bool) {
+pub fn pkg_parent_workspaces(pkgid: PkgId, action: &fn(&Path) -> bool) -> bool {
     // Using the RUST_PATH, find workspaces that contain
     // this package ID
     let workspaces = rust_path().filtered(|ws|
@@ -31,4 +31,5 @@ pub fn pkg_parent_workspaces(pkgid: PkgId, action: &fn(&Path) -> bool) {
             break;
         }
     }
+    return true;
 }

--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -143,6 +143,7 @@ pub impl BigBitv {
     }
 
     #[inline(always)]
+    #[cfg(stage0)]
     fn each_storage(&mut self, op: &fn(v: &mut uint) -> bool) {
         for uint::range(0, self.storage.len()) |i| {
             let mut w = self.storage[i];
@@ -150,7 +151,12 @@ pub impl BigBitv {
             self.storage[i] = w;
             if !b { break; }
         }
-     }
+    }
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn each_storage(&mut self, op: &fn(v: &mut uint) -> bool) -> bool {
+        uint::range(0, self.storage.len(), |i| op(&mut self.storage[i]))
+    }
 
     #[inline(always)]
     fn invert(&mut self) { for self.each_storage |w| { *w = !*w } }
@@ -193,6 +199,7 @@ pub impl BigBitv {
     }
 
     #[inline(always)]
+    #[cfg(stage0)]
     fn equals(&self, b: &BigBitv, nbits: uint) -> bool {
         let len = b.storage.len();
         for uint::iterate(0, len) |i| {
@@ -201,6 +208,19 @@ pub impl BigBitv {
                 return false;
             }
         }
+    }
+
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn equals(&self, b: &BigBitv, nbits: uint) -> bool {
+        let len = b.storage.len();
+        for uint::iterate(0, len) |i| {
+            let mask = big_mask(nbits, i);
+            if mask & self.storage[i] != mask & b.storage[i] {
+                return false;
+            }
+        }
+        return true;
     }
 
 }
@@ -387,12 +407,23 @@ pub impl Bitv {
     }
 
     #[inline(always)]
+    #[cfg(stage0)]
     fn each(&self, f: &fn(bool) -> bool) {
         let mut i = 0;
         while i < self.nbits {
             if !f(self.get(i)) { break; }
             i += 1;
         }
+    }
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn each(&self, f: &fn(bool) -> bool) -> bool {
+        let mut i = 0;
+        while i < self.nbits {
+            if !f(self.get(i)) { return false; }
+            i += 1;
+        }
+        return true;
     }
 
     /// Returns true if all bits are 0
@@ -488,12 +519,17 @@ pub impl Bitv {
         true
     }
 
+    #[cfg(stage0)]
     fn ones(&self, f: &fn(uint) -> bool) {
         for uint::range(0, self.nbits) |i| {
             if self.get(i) {
                 if !f(i) { break }
             }
         }
+    }
+    #[cfg(not(stage0))]
+    fn ones(&self, f: &fn(uint) -> bool) -> bool {
+        uint::range(0, self.nbits, |i| !self.get(i) || f(i))
     }
 
 }
@@ -661,18 +697,21 @@ pub impl BitvSet {
     }
 }
 
+#[cfg(not(stage0))]
 impl BaseIter<uint> for BitvSet {
     fn size_hint(&self) -> Option<uint> { Some(self.len()) }
 
-    fn each(&self, blk: &fn(v: &uint) -> bool) {
+    fn each(&self, blk: &fn(v: &uint) -> bool) -> bool {
         for self.bitv.storage.eachi |i, &w| {
             if !iterate_bits(i * uint::bits, w, |b| blk(&b)) {
-                return;
+                return false;
             }
         }
+        return true;
     }
 }
 
+#[cfg(not(stage0))]
 impl cmp::Eq for BitvSet {
     fn eq(&self, other: &BitvSet) -> bool {
         if self.size != other.size {
@@ -706,6 +745,7 @@ impl Mutable for BitvSet {
     }
 }
 
+#[cfg(not(stage0))]
 impl Set<uint> for BitvSet {
     fn contains(&self, value: &uint) -> bool {
         *value < self.bitv.storage.len() * uint::bits && self.bitv.get(*value)
@@ -773,64 +813,55 @@ impl Set<uint> for BitvSet {
         other.is_subset(self)
     }
 
-    fn difference(&self, other: &BitvSet, f: &fn(&uint) -> bool) {
+    fn difference(&self, other: &BitvSet, f: &fn(&uint) -> bool) -> bool {
         for self.each_common(other) |i, w1, w2| {
             if !iterate_bits(i, w1 & !w2, |b| f(&b)) {
-                return;
+                return false;
             }
         }
         /* everything we have that they don't also shows up */
         self.each_outlier(other, |mine, i, w|
             !mine || iterate_bits(i, w, |b| f(&b))
-        );
+        )
     }
 
     fn symmetric_difference(&self, other: &BitvSet,
-                                 f: &fn(&uint) -> bool) {
+                            f: &fn(&uint) -> bool) -> bool {
         for self.each_common(other) |i, w1, w2| {
             if !iterate_bits(i, w1 ^ w2, |b| f(&b)) {
-                return;
+                return false;
             }
         }
-        self.each_outlier(other, |_, i, w|
-            iterate_bits(i, w, |b| f(&b))
-        );
+        self.each_outlier(other, |_, i, w| iterate_bits(i, w, |b| f(&b)))
     }
 
-    fn intersection(&self, other: &BitvSet, f: &fn(&uint) -> bool) {
-        for self.each_common(other) |i, w1, w2| {
-            if !iterate_bits(i, w1 & w2, |b| f(&b)) {
-                return;
-            }
-        }
+    fn intersection(&self, other: &BitvSet, f: &fn(&uint) -> bool) -> bool {
+        self.each_common(other, |i, w1, w2| iterate_bits(i, w1 & w2, |b| f(&b)))
     }
 
-    fn union(&self, other: &BitvSet, f: &fn(&uint) -> bool) {
+    fn union(&self, other: &BitvSet, f: &fn(&uint) -> bool) -> bool {
         for self.each_common(other) |i, w1, w2| {
             if !iterate_bits(i, w1 | w2, |b| f(&b)) {
-                return;
+                return false;
             }
         }
-        self.each_outlier(other, |_, i, w|
-            iterate_bits(i, w, |b| f(&b))
-        );
+        self.each_outlier(other, |_, i, w| iterate_bits(i, w, |b| f(&b)))
     }
 }
 
+#[cfg(not(stage0))]
 priv impl BitvSet {
     /// Visits each of the words that the two bit vectors (self and other)
     /// both have in common. The three yielded arguments are (bit location,
     /// w1, w2) where the bit location is the number of bits offset so far,
     /// and w1/w2 are the words coming from the two vectors self, other.
     fn each_common(&self, other: &BitvSet,
-                        f: &fn(uint, uint, uint) -> bool) {
+                   f: &fn(uint, uint, uint) -> bool) -> bool {
         let min = uint::min(self.bitv.storage.len(),
                             other.bitv.storage.len());
-        for self.bitv.storage.slice(0, min).eachi |i, &w| {
-            if !f(i * uint::bits, w, other.bitv.storage[i]) {
-                return;
-            }
-        }
+        self.bitv.storage.slice(0, min).eachi(|i, &w| {
+            f(i * uint::bits, w, other.bitv.storage[i])
+        })
     }
 
     /// Visits each word in self or other that extends beyond the other. This
@@ -841,7 +872,7 @@ priv impl BitvSet {
     /// is true if the word comes from 'self', and false if it comes from
     /// 'other'.
     fn each_outlier(&self, other: &BitvSet,
-                         f: &fn(bool, uint, uint) -> bool) {
+                    f: &fn(bool, uint, uint) -> bool) -> bool {
         let len1 = self.bitv.storage.len();
         let len2 = other.bitv.storage.len();
         let min = uint::min(len1, len2);
@@ -849,14 +880,15 @@ priv impl BitvSet {
         /* only one of these loops will execute and that's the point */
         for self.bitv.storage.slice(min, len1).eachi |i, &w| {
             if !f(true, (i + min) * uint::bits, w) {
-                return;
+                return false;
             }
         }
         for other.bitv.storage.slice(min, len2).eachi |i, &w| {
             if !f(false, (i + min) * uint::bits, w) {
-                return;
+                return false;
             }
         }
+        return true;
     }
 }
 

--- a/src/libstd/deque.rs
+++ b/src/libstd/deque.rs
@@ -63,15 +63,25 @@ pub impl<T> Deque<T> {
     }
 
     /// Iterate over the elements in the deque
+    #[cfg(stage0)]
     fn each(&self, f: &fn(&T) -> bool) {
+        self.eachi(|_i, e| f(e))
+    }
+    /// Iterate over the elements in the deque
+    #[cfg(not(stage0))]
+    fn each(&self, f: &fn(&T) -> bool) -> bool {
         self.eachi(|_i, e| f(e))
     }
 
     /// Iterate over the elements in the deque by index
+    #[cfg(stage0)]
     fn eachi(&self, f: &fn(uint, &T) -> bool) {
-        for uint::range(0, self.nelts) |i| {
-            if !f(i, self.get(i as int)) { return; }
-        }
+        uint::range(0, self.nelts, |i| f(i, self.get(i as int)))
+    }
+    /// Iterate over the elements in the deque by index
+    #[cfg(not(stage0))]
+    fn eachi(&self, f: &fn(uint, &T) -> bool) -> bool {
+        uint::range(0, self.nelts, |i| f(i, self.get(i as int)))
     }
 
     /// Remove and return the first element in the deque

--- a/src/libstd/dlist.rs
+++ b/src/libstd/dlist.rs
@@ -492,12 +492,13 @@ pub impl<T:Copy> DList<T> {
 
 impl<T> BaseIter<T> for @mut DList<T> {
     /**
-    * Iterates through the current contents.
-    *
-    * Attempts to access this dlist during iteration are allowed (to
-    * allow for e.g. breadth-first search with in-place enqueues), but
-    * removing the current node is forbidden.
-    */
+     * Iterates through the current contents.
+     *
+     * Attempts to access this dlist during iteration are allowed (to
+     * allow for e.g. breadth-first search with in-place enqueues), but
+     * removing the current node is forbidden.
+     */
+    #[cfg(stage0)]
     fn each(&self, f: &fn(v: &T) -> bool) {
         let mut link = self.peek_n();
         while link.is_some() {
@@ -524,6 +525,42 @@ impl<T> BaseIter<T> for @mut DList<T> {
             }
             link = nobe.next_link();
         }
+    }
+    /**
+     * Iterates through the current contents.
+     *
+     * Attempts to access this dlist during iteration are allowed (to
+     * allow for e.g. breadth-first search with in-place enqueues), but
+     * removing the current node is forbidden.
+     */
+    #[cfg(not(stage0))]
+    fn each(&self, f: &fn(v: &T) -> bool) -> bool {
+        let mut link = self.peek_n();
+        while link.is_some() {
+            let nobe = link.get();
+            assert!(nobe.linked);
+
+            {
+                let frozen_nobe = &*nobe;
+                if !f(&frozen_nobe.data) { return false; }
+            }
+
+            // Check (weakly) that the user didn't do a remove.
+            if self.size == 0 {
+                fail!("The dlist became empty during iteration??")
+            }
+            if !nobe.linked ||
+                (!((nobe.prev.is_some()
+                    || managed::mut_ptr_eq(self.hd.expect(~"headless dlist?"),
+                                           nobe))
+                   && (nobe.next.is_some()
+                    || managed::mut_ptr_eq(self.tl.expect(~"tailless dlist?"),
+                                           nobe)))) {
+                fail!("Removing a dlist node during iteration is forbidden!")
+            }
+            link = nobe.next_link();
+        }
+        return true;
     }
 
     #[inline(always)]

--- a/src/libstd/dlist.rs
+++ b/src/libstd/dlist.rs
@@ -393,6 +393,7 @@ pub impl<T> DList<T> {
     }
 
     /// Iterate over nodes.
+    #[cfg(stage0)]
     fn each_node(@mut self, f: &fn(@mut DListNode<T>) -> bool) {
         let mut link = self.peek_n();
         while link.is_some() {
@@ -400,6 +401,17 @@ pub impl<T> DList<T> {
             if !f(nobe) { break; }
             link = nobe.next_link();
         }
+    }
+    /// Iterate over nodes.
+    #[cfg(not(stage0))]
+    fn each_node(@mut self, f: &fn(@mut DListNode<T>) -> bool) -> bool {
+        let mut link = self.peek_n();
+        while link.is_some() {
+            let nobe = link.get();
+            if !f(nobe) { return false; }
+            link = nobe.next_link();
+        }
+        return true;
     }
 
     /// Check data structure integrity. O(n).

--- a/src/libstd/ebml.rs
+++ b/src/libstd/ebml.rs
@@ -199,6 +199,7 @@ pub mod reader {
         }
     }
 
+    #[cfg(stage0)]
     pub fn docs(d: Doc, it: &fn(uint, Doc) -> bool) {
         let mut pos = d.start;
         while pos < d.end {
@@ -211,7 +212,22 @@ pub mod reader {
             }
         }
     }
+    #[cfg(not(stage0))]
+    pub fn docs(d: Doc, it: &fn(uint, Doc) -> bool) -> bool {
+        let mut pos = d.start;
+        while pos < d.end {
+            let elt_tag = vuint_at(*d.data, pos);
+            let elt_size = vuint_at(*d.data, elt_tag.next);
+            pos = elt_size.next + elt_size.val;
+            let doc = Doc { data: d.data, start: elt_size.next, end: pos };
+            if !it(elt_tag.val, doc) {
+                return false;
+            }
+        }
+        return true;
+    }
 
+    #[cfg(stage0)]
     pub fn tagged_docs(d: Doc, tg: uint, it: &fn(Doc) -> bool) {
         let mut pos = d.start;
         while pos < d.end {
@@ -226,6 +242,23 @@ pub mod reader {
                 }
             }
         }
+    }
+    #[cfg(not(stage0))]
+    pub fn tagged_docs(d: Doc, tg: uint, it: &fn(Doc) -> bool) -> bool {
+        let mut pos = d.start;
+        while pos < d.end {
+            let elt_tag = vuint_at(*d.data, pos);
+            let elt_size = vuint_at(*d.data, elt_tag.next);
+            pos = elt_size.next + elt_size.val;
+            if elt_tag.val == tg {
+                let doc = Doc { data: d.data, start: elt_size.next,
+                                end: pos };
+                if !it(doc) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     pub fn doc_data(d: Doc) -> ~[u8] {

--- a/src/libstd/fileinput.rs
+++ b/src/libstd/fileinput.rs
@@ -256,9 +256,20 @@ impl FileInput {
     (line numbers and file names, see documentation for
     `FileInputState`). Otherwise identical to `lines_each`.
     */
+    #[cfg(stage0)]
     pub fn each_line_state(&self,
                             f: &fn(&str, FileInputState) -> bool) {
          self.each_line(|line| f(line, copy self.fi.state));
+    }
+    /**
+    Apply `f` to each line successively, along with some state
+    (line numbers and file names, see documentation for
+    `FileInputState`). Otherwise identical to `lines_each`.
+    */
+    #[cfg(not(stage0))]
+    pub fn each_line_state(&self,
+                            f: &fn(&str, FileInputState) -> bool) -> bool {
+         self.each_line(|line| f(line, copy self.fi.state))
     }
 
 
@@ -367,9 +378,21 @@ reading from `stdin`).
 
 Fails when attempting to read from a file that can't be opened.
 */
+#[cfg(stage0)]
 pub fn input(f: &fn(&str) -> bool) {
     let mut i = FileInput::from_args();
     i.each_line(f);
+}
+/**
+Iterate directly over the command line arguments (no arguments implies
+reading from `stdin`).
+
+Fails when attempting to read from a file that can't be opened.
+*/
+#[cfg(not(stage0))]
+pub fn input(f: &fn(&str) -> bool) -> bool {
+    let mut i = FileInput::from_args();
+    i.each_line(f)
 }
 
 /**
@@ -379,9 +402,22 @@ provided at each call.
 
 Fails when attempting to read from a file that can't be opened.
 */
+#[cfg(stage0)]
 pub fn input_state(f: &fn(&str, FileInputState) -> bool) {
     let mut i = FileInput::from_args();
     i.each_line_state(f);
+}
+/**
+Iterate directly over the command line arguments (no arguments
+implies reading from `stdin`) with the current state of the iteration
+provided at each call.
+
+Fails when attempting to read from a file that can't be opened.
+*/
+#[cfg(not(stage0))]
+pub fn input_state(f: &fn(&str, FileInputState) -> bool) -> bool {
+    let mut i = FileInput::from_args();
+    i.each_line_state(f)
 }
 
 /**
@@ -389,9 +425,20 @@ Iterate over a vector of files (an empty vector implies just `stdin`).
 
 Fails when attempting to read from a file that can't be opened.
 */
+#[cfg(stage0)]
 pub fn input_vec(files: ~[Option<Path>], f: &fn(&str) -> bool) {
     let mut i = FileInput::from_vec(files);
     i.each_line(f);
+}
+/**
+Iterate over a vector of files (an empty vector implies just `stdin`).
+
+Fails when attempting to read from a file that can't be opened.
+*/
+#[cfg(not(stage0))]
+pub fn input_vec(files: ~[Option<Path>], f: &fn(&str) -> bool) -> bool {
+    let mut i = FileInput::from_vec(files);
+    i.each_line(f)
 }
 
 /**
@@ -400,10 +447,23 @@ with the current state of the iteration provided at each call.
 
 Fails when attempting to read from a file that can't be opened.
 */
+#[cfg(stage0)]
 pub fn input_vec_state(files: ~[Option<Path>],
                        f: &fn(&str, FileInputState) -> bool) {
     let mut i = FileInput::from_vec(files);
     i.each_line_state(f);
+}
+/**
+Iterate over a vector of files (an empty vector implies just `stdin`)
+with the current state of the iteration provided at each call.
+
+Fails when attempting to read from a file that can't be opened.
+*/
+#[cfg(not(stage0))]
+pub fn input_vec_state(files: ~[Option<Path>],
+                       f: &fn(&str, FileInputState) -> bool) -> bool {
+    let mut i = FileInput::from_vec(files);
+    i.each_line_state(f)
 }
 
 #[cfg(test)]

--- a/src/libstd/list.rs
+++ b/src/libstd/list.rs
@@ -140,6 +140,7 @@ pub fn iter<T>(l: @List<T>, f: &fn(&T)) {
 }
 
 /// Iterate over a list
+#[cfg(stage0)]
 pub fn each<T>(l: @List<T>, f: &fn(&T) -> bool) {
     let mut cur = l;
     loop {
@@ -152,9 +153,24 @@ pub fn each<T>(l: @List<T>, f: &fn(&T) -> bool) {
         }
     }
 }
+/// Iterate over a list
+#[cfg(not(stage0))]
+pub fn each<T>(l: @List<T>, f: &fn(&T) -> bool) -> bool {
+    let mut cur = l;
+    loop {
+        cur = match *cur {
+          Cons(ref hd, tl) => {
+            if !f(hd) { return false; }
+            tl
+          }
+          Nil => { return true; }
+        }
+    }
+}
 
 impl<T> MutList<T> {
     /// Iterate over a mutable list
+    #[cfg(stage0)]
     pub fn each(@mut self, f: &fn(&mut T) -> bool) {
         let mut cur = self;
         loop {
@@ -169,6 +185,24 @@ impl<T> MutList<T> {
                 MutNil => break
             }
         }
+    }
+    /// Iterate over a mutable list
+    #[cfg(not(stage0))]
+    pub fn each(@mut self, f: &fn(&mut T) -> bool) -> bool {
+        let mut cur = self;
+        loop {
+            let borrowed = &mut *cur;
+            cur = match *borrowed {
+                MutCons(ref mut hd, tl) => {
+                    if !f(hd) {
+                        return false;
+                    }
+                    tl
+                }
+                MutNil => break
+            }
+        }
+        return true;
     }
 }
 

--- a/src/libstd/net_url.rs
+++ b/src/libstd/net_url.rs
@@ -703,8 +703,15 @@ impl ToStr for Url {
     }
 }
 
+#[cfg(stage0)]
 impl IterBytes for Url {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        self.to_str().iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl IterBytes for Url {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         self.to_str().iter_bytes(lsb0, f)
     }
 }

--- a/src/libstd/priority_queue.rs
+++ b/src/libstd/priority_queue.rs
@@ -28,7 +28,14 @@ impl<T:Ord> BaseIter<T> for PriorityQueue<T> {
     /// Visit all values in the underlying vector.
     ///
     /// The values are **not** visited in order.
+    #[cfg(stage0)]
     fn each(&self, f: &fn(&T) -> bool) { self.data.each(f) }
+    /// Visit all values in the underlying vector.
+    ///
+    /// The values are **not** visited in order.
+    #[cfg(not(stage0))]
+    fn each(&self, f: &fn(&T) -> bool) -> bool { self.data.each(f) }
+
     fn size_hint(&self) -> Option<uint> { self.data.size_hint() }
 }
 

--- a/src/libstd/smallintmap.rs
+++ b/src/libstd/smallintmap.rs
@@ -51,6 +51,7 @@ impl<V> Map<uint, V> for SmallIntMap<V> {
     }
 
     /// Visit all key-value pairs in order
+    #[cfg(stage0)]
     fn each<'a>(&'a self, it: &fn(&uint, &'a V) -> bool) {
         for uint::range(0, self.v.len()) |i| {
             match self.v[i] {
@@ -60,24 +61,61 @@ impl<V> Map<uint, V> for SmallIntMap<V> {
         }
     }
 
+    /// Visit all key-value pairs in order
+    #[cfg(not(stage0))]
+    fn each<'a>(&'a self, it: &fn(&uint, &'a V) -> bool) -> bool {
+        for uint::range(0, self.v.len()) |i| {
+            match self.v[i] {
+              Some(ref elt) => if !it(&i, elt) { return false; },
+              None => ()
+            }
+        }
+        return true;
+    }
+
     /// Visit all keys in order
+    #[cfg(stage0)]
     fn each_key(&self, blk: &fn(key: &uint) -> bool) {
+        self.each(|k, _| blk(k))
+    }
+    #[cfg(not(stage0))]
+    /// Visit all keys in order
+    fn each_key(&self, blk: &fn(key: &uint) -> bool) -> bool {
         self.each(|k, _| blk(k))
     }
 
     /// Visit all values in order
+    #[cfg(stage0)]
     fn each_value<'a>(&'a self, blk: &fn(value: &'a V) -> bool) {
         self.each(|_, v| blk(v))
     }
 
+    /// Visit all values in order
+    #[cfg(not(stage0))]
+    fn each_value<'a>(&'a self, blk: &fn(value: &'a V) -> bool) -> bool {
+        self.each(|_, v| blk(v))
+    }
+
     /// Iterate over the map and mutate the contained values
+    #[cfg(stage0)]
     fn mutate_values(&mut self, it: &fn(&uint, &mut V) -> bool) {
         for uint::range(0, self.v.len()) |i| {
             match self.v[i] {
-              Some(ref mut elt) => if !it(&i, elt) { break },
+              Some(ref mut elt) => if !it(&i, elt) { return; },
               None => ()
             }
         }
+    }
+    /// Iterate over the map and mutate the contained values
+    #[cfg(not(stage0))]
+    fn mutate_values(&mut self, it: &fn(&uint, &mut V) -> bool) -> bool {
+        for uint::range(0, self.v.len()) |i| {
+            match self.v[i] {
+              Some(ref mut elt) => if !it(&i, elt) { return false; },
+              None => ()
+            }
+        }
+        return true;
     }
 
     /// Return a reference to the value corresponding to the key
@@ -149,6 +187,7 @@ pub impl<V> SmallIntMap<V> {
     fn new() -> SmallIntMap<V> { SmallIntMap{v: ~[]} }
 
     /// Visit all key-value pairs in reverse order
+    #[cfg(stage0)]
     fn each_reverse<'a>(&'a self, it: &fn(uint, &'a V) -> bool) {
         for uint::range_rev(self.v.len(), 0) |i| {
             match self.v[i - 1] {
@@ -156,6 +195,18 @@ pub impl<V> SmallIntMap<V> {
               None => ()
             }
         }
+    }
+
+    /// Visit all key-value pairs in reverse order
+    #[cfg(not(stage0))]
+    fn each_reverse<'a>(&'a self, it: &fn(uint, &'a V) -> bool) -> bool {
+        for uint::range_rev(self.v.len(), 0) |i| {
+            match self.v[i - 1] {
+              Some(ref elt) => if !it(i - 1, elt) { return false; },
+              None => ()
+            }
+        }
+        return true;
     }
 
     fn get<'a>(&'a self, key: &uint) -> &'a V {

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -674,7 +674,7 @@ impl<T: TotalOrd> Set<T> for TreeSet<T> {
                 a = x.next();
             }
         }
-        return a.each(|&x| f(x)) && y.advance(f);
+        return b.each(|&x| f(x)) && y.advance(f);
     }
 }
 
@@ -1326,7 +1326,7 @@ mod test_set {
     }
 
     fn check(a: &[int], b: &[int], expected: &[int],
-             f: &fn(&TreeSet<int>, &TreeSet<int>, f: &fn(&int) -> bool)) {
+             f: &fn(&TreeSet<int>, &TreeSet<int>, f: &fn(&int) -> bool) -> bool) {
         let mut set_a = TreeSet::new();
         let mut set_b = TreeSet::new();
 

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -105,23 +105,47 @@ impl<K: TotalOrd, V> Map<K, V> for TreeMap<K, V> {
     }
 
     /// Visit all key-value pairs in order
+    #[cfg(stage0)]
     fn each<'a>(&'a self, f: &fn(&'a K, &'a V) -> bool) {
+        each(&self.root, f);
+    }
+    /// Visit all key-value pairs in order
+    #[cfg(not(stage0))]
+    fn each<'a>(&'a self, f: &fn(&'a K, &'a V) -> bool) -> bool {
         each(&self.root, f)
     }
 
     /// Visit all keys in order
+    #[cfg(stage0)]
     fn each_key(&self, f: &fn(&K) -> bool) {
+        self.each(|k, _| f(k))
+    }
+    /// Visit all keys in order
+    #[cfg(not(stage0))]
+    fn each_key(&self, f: &fn(&K) -> bool) -> bool {
         self.each(|k, _| f(k))
     }
 
     /// Visit all values in order
+    #[cfg(stage0)]
     fn each_value<'a>(&'a self, f: &fn(&'a V) -> bool) {
+        self.each(|_, v| f(v))
+    }
+    /// Visit all values in order
+    #[cfg(not(stage0))]
+    fn each_value<'a>(&'a self, f: &fn(&'a V) -> bool) -> bool {
         self.each(|_, v| f(v))
     }
 
     /// Iterate over the map and mutate the contained values
+    #[cfg(stage0)]
     fn mutate_values(&mut self, f: &fn(&K, &mut V) -> bool) {
         mutate_values(&mut self.root, f);
+    }
+    /// Iterate over the map and mutate the contained values
+    #[cfg(not(stage0))]
+    fn mutate_values(&mut self, f: &fn(&K, &mut V) -> bool) -> bool {
+        mutate_values(&mut self.root, f)
     }
 
     /// Return a reference to the value corresponding to the key
@@ -177,6 +201,7 @@ impl<K: TotalOrd, V> Map<K, V> for TreeMap<K, V> {
     }
 }
 
+#[cfg(stage0)]
 pub impl<K: TotalOrd, V> TreeMap<K, V> {
     /// Create an empty TreeMap
     fn new() -> TreeMap<K, V> { TreeMap{root: None, length: 0} }
@@ -193,6 +218,32 @@ pub impl<K: TotalOrd, V> TreeMap<K, V> {
 
     /// Visit all values in reverse order
     fn each_value_reverse(&self, f: &fn(&V) -> bool) {
+        self.each_reverse(|_, v| f(v))
+    }
+
+    /// Get a lazy iterator over the key-value pairs in the map.
+    /// Requires that it be frozen (immutable).
+    fn iter<'a>(&'a self) -> TreeMapIterator<'a, K, V> {
+        TreeMapIterator{stack: ~[], node: &self.root}
+    }
+}
+#[cfg(not(stage0))]
+pub impl<K: TotalOrd, V> TreeMap<K, V> {
+    /// Create an empty TreeMap
+    fn new() -> TreeMap<K, V> { TreeMap{root: None, length: 0} }
+
+    /// Visit all key-value pairs in reverse order
+    fn each_reverse<'a>(&'a self, f: &fn(&'a K, &'a V) -> bool) -> bool {
+        each_reverse(&self.root, f)
+    }
+
+    /// Visit all keys in reverse order
+    fn each_key_reverse(&self, f: &fn(&K) -> bool) -> bool {
+        self.each_reverse(|k, _| f(k))
+    }
+
+    /// Visit all values in reverse order
+    fn each_value_reverse(&self, f: &fn(&V) -> bool) -> bool {
         self.each_reverse(|_, v| f(v))
     }
 
@@ -246,15 +297,27 @@ pub struct TreeSet<T> {
 impl<T: TotalOrd> BaseIter<T> for TreeSet<T> {
     /// Visit all values in order
     #[inline(always)]
+    #[cfg(stage0)]
     fn each(&self, f: &fn(&T) -> bool) { self.map.each_key(f) }
+    /// Visit all values in order
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn each(&self, f: &fn(&T) -> bool) -> bool { self.map.each_key(f) }
     #[inline(always)]
     fn size_hint(&self) -> Option<uint> { Some(self.len()) }
 }
 
 impl<T: TotalOrd> ReverseIter<T> for TreeSet<T> {
     /// Visit all values in reverse order
+    #[cfg(stage0)]
     #[inline(always)]
     fn each_reverse(&self, f: &fn(&T) -> bool) {
+        self.map.each_key_reverse(f)
+    }
+    /// Visit all values in reverse order
+    #[cfg(not(stage0))]
+    #[inline(always)]
+    fn each_reverse(&self, f: &fn(&T) -> bool) -> bool {
         self.map.each_key_reverse(f)
     }
 }
@@ -361,6 +424,7 @@ impl<T: TotalOrd> Set<T> for TreeSet<T> {
     }
 
     /// Visit the values (in-order) representing the difference
+    #[cfg(stage0)]
     fn difference(&self, other: &TreeSet<T>, f: &fn(&T) -> bool) {
         let mut x = self.iter();
         let mut y = other.iter();
@@ -389,8 +453,38 @@ impl<T: TotalOrd> Set<T> for TreeSet<T> {
             }
         }
     }
+    /// Visit the values (in-order) representing the difference
+    #[cfg(not(stage0))]
+    fn difference(&self, other: &TreeSet<T>, f: &fn(&T) -> bool) -> bool {
+        let mut x = self.iter();
+        let mut y = other.iter();
+
+        let mut a = x.next();
+        let mut b = y.next();
+
+        while a.is_some() {
+            if b.is_none() {
+                return f(a.unwrap()) && x.advance(f);
+            }
+
+            let a1 = a.unwrap();
+            let b1 = b.unwrap();
+
+            let cmp = a1.cmp(b1);
+
+            if cmp == Less {
+                if !f(a1) { return false; }
+                a = x.next();
+            } else {
+                if cmp == Equal { a = x.next() }
+                b = y.next();
+            }
+        }
+        return true;
+    }
 
     /// Visit the values (in-order) representing the symmetric difference
+    #[cfg(stage0)]
     fn symmetric_difference(&self, other: &TreeSet<T>,
                                  f: &fn(&T) -> bool) {
         let mut x = self.iter();
@@ -427,8 +521,43 @@ impl<T: TotalOrd> Set<T> for TreeSet<T> {
             if f(b1) { y.next() } else { None }
         }
     }
+    /// Visit the values (in-order) representing the symmetric difference
+    #[cfg(not(stage0))]
+    fn symmetric_difference(&self, other: &TreeSet<T>,
+                            f: &fn(&T) -> bool) -> bool {
+        let mut x = self.iter();
+        let mut y = other.iter();
+
+        let mut a = x.next();
+        let mut b = y.next();
+
+        while a.is_some() {
+            if b.is_none() {
+                return f(a.unwrap()) && x.advance(f);
+            }
+
+            let a1 = a.unwrap();
+            let b1 = b.unwrap();
+
+            let cmp = a1.cmp(b1);
+
+            if cmp == Less {
+                if !f(a1) { return false; }
+                a = x.next();
+            } else {
+                if cmp == Greater {
+                    if !f(b1) { return false; }
+                } else {
+                    a = x.next();
+                }
+                b = y.next();
+            }
+        }
+        return b.each(|&x| f(x)) && y.advance(f);
+    }
 
     /// Visit the values (in-order) representing the intersection
+    #[cfg(stage0)]
     fn intersection(&self, other: &TreeSet<T>, f: &fn(&T) -> bool) {
         let mut x = self.iter();
         let mut y = other.iter();
@@ -452,8 +581,35 @@ impl<T: TotalOrd> Set<T> for TreeSet<T> {
             }
         }
     }
+    /// Visit the values (in-order) representing the intersection
+    #[cfg(not(stage0))]
+    fn intersection(&self, other: &TreeSet<T>, f: &fn(&T) -> bool) -> bool {
+        let mut x = self.iter();
+        let mut y = other.iter();
+
+        let mut a = x.next();
+        let mut b = y.next();
+
+        while a.is_some() && b.is_some() {
+            let a1 = a.unwrap();
+            let b1 = b.unwrap();
+
+            let cmp = a1.cmp(b1);
+
+            if cmp == Less {
+                a = x.next();
+            } else {
+                if cmp == Equal {
+                    if !f(a1) { return false }
+                }
+                b = y.next();
+            }
+        }
+        return true;
+    }
 
     /// Visit the values (in-order) representing the union
+    #[cfg(stage0)]
     fn union(&self, other: &TreeSet<T>, f: &fn(&T) -> bool) {
         let mut x = self.iter();
         let mut y = other.iter();
@@ -487,6 +643,38 @@ impl<T: TotalOrd> Set<T> for TreeSet<T> {
         do b.while_some |b1| {
             if f(b1) { y.next() } else { None }
         }
+    }
+    /// Visit the values (in-order) representing the union
+    #[cfg(not(stage0))]
+    fn union(&self, other: &TreeSet<T>, f: &fn(&T) -> bool) -> bool {
+        let mut x = self.iter();
+        let mut y = other.iter();
+
+        let mut a = x.next();
+        let mut b = y.next();
+
+        while a.is_some() {
+            if b.is_none() {
+                return f(a.unwrap()) && x.advance(f);
+            }
+
+            let a1 = a.unwrap();
+            let b1 = b.unwrap();
+
+            let cmp = a1.cmp(b1);
+
+            if cmp == Greater {
+                if !f(b1) { return false; }
+                b = y.next();
+            } else {
+                if !f(a1) { return false; }
+                if cmp == Equal {
+                    b = y.next();
+                }
+                a = x.next();
+            }
+        }
+        return a.each(|&x| f(x)) && y.advance(f);
     }
 }
 
@@ -525,20 +713,28 @@ pub impl<K: TotalOrd, V> TreeNode<K, V> {
     }
 }
 
+#[cfg(stage0)]
+fn each<'r, K: TotalOrd, V>(_: &'r Option<~TreeNode<K, V>>,
+                            _: &fn(&'r K, &'r V) -> bool) -> bool {
+    fail!(~"don't use me in stage0!")
+}
+#[cfg(not(stage0))]
 fn each<'r, K: TotalOrd, V>(node: &'r Option<~TreeNode<K, V>>,
-                            f: &fn(&'r K, &'r V) -> bool) {
-    for node.each |x| {
-        each(&x.left, f);
-        if f(&x.key, &x.value) { each(&x.right, f) }
-    }
+                            f: &fn(&'r K, &'r V) -> bool) -> bool {
+    node.each(|x| each(&x.left, f) && f(&x.key, &x.value) &&
+                  each(&x.right, f))
 }
 
+#[cfg(stage0)]
+fn each_reverse<'r, K: TotalOrd, V>(_: &'r Option<~TreeNode<K, V>>,
+                                    _: &fn(&'r K, &'r V) -> bool) -> bool {
+    fail!(~"don't use me in stage0!")
+}
+#[cfg(not(stage0))]
 fn each_reverse<'r, K: TotalOrd, V>(node: &'r Option<~TreeNode<K, V>>,
-                                    f: &fn(&'r K, &'r V) -> bool) {
-    for node.each |x| {
-        each_reverse(&x.right, f);
-        if f(&x.key, &x.value) { each_reverse(&x.left, f) }
-    }
+                                    f: &fn(&'r K, &'r V) -> bool) -> bool {
+    node.each(|x| each_reverse(&x.right, f) && f(&x.key, &x.value) &&
+                  each_reverse(&x.left, f))
 }
 
 fn mutate_values<'r, K: TotalOrd, V>(node: &'r mut Option<~TreeNode<K, V>>,

--- a/src/libstd/workcache.rs
+++ b/src/libstd/workcache.rs
@@ -99,6 +99,7 @@ struct WorkKey {
     name: ~str
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for WorkKey {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
@@ -106,6 +107,13 @@ impl to_bytes::IterBytes for WorkKey {
         self.kind.iter_bytes(lsb0, |bytes| {flag = f(bytes); flag});
         if !flag { return; }
         self.name.iter_bytes(lsb0, f);
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for WorkKey {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        self.kind.iter_bytes(lsb0, f) && self.name.iter_bytes(lsb0, f)
     }
 }
 

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -81,6 +81,7 @@ static AbiDatas: &'static [AbiData] = &[
     AbiData {abi: RustIntrinsic, name: "rust-intrinsic", abi_arch: RustArch},
 ];
 
+#[cfg(stage0)]
 fn each_abi(op: &fn(abi: Abi) -> bool) {
     /*!
      *
@@ -92,6 +93,15 @@ fn each_abi(op: &fn(abi: Abi) -> bool) {
             return;
         }
     }
+}
+#[cfg(not(stage0))]
+fn each_abi(op: &fn(abi: Abi) -> bool) -> bool {
+    /*!
+     *
+     * Iterates through each of the defined ABIs.
+     */
+
+    AbiDatas.each(|abi_data| op(abi_data.abi))
 }
 
 pub fn lookup(name: &str) -> Option<Abi> {
@@ -189,6 +199,7 @@ pub impl AbiSet {
         self.bits |= (1 << abi.index());
     }
 
+    #[cfg(stage0)]
     fn each(&self, op: &fn(abi: Abi) -> bool) {
         for each_abi |abi| {
             if self.contains(abi) {
@@ -197,6 +208,10 @@ pub impl AbiSet {
                 }
             }
         }
+    }
+    #[cfg(not(stage0))]
+    fn each(&self, op: &fn(abi: Abi) -> bool) -> bool {
+        each_abi(|abi| !self.contains(abi) || op(abi))
     }
 
     fn is_empty(&self) -> bool {
@@ -252,14 +267,28 @@ pub impl AbiSet {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for Abi {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.index().iter_bytes(lsb0, f)
     }
 }
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for Abi {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        self.index().iter_bytes(lsb0, f)
+    }
+}
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for AbiSet {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        self.bits.iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for AbiSet {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         self.bits.iter_bytes(lsb0, f)
     }
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -97,8 +97,15 @@ impl<D:Decoder> Decodable<D> for ident {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for ident {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        self.repr.iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for ident {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         self.repr.iter_bytes(lsb0, f)
     }
 }
@@ -284,6 +291,7 @@ pub enum binding_mode {
     bind_infer
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for binding_mode {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         match *self {
@@ -294,6 +302,18 @@ impl to_bytes::IterBytes for binding_mode {
 
           bind_infer =>
           2u8.iter_bytes(lsb0, f),
+        }
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for binding_mode {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        match *self {
+          bind_by_copy => 0u8.iter_bytes(lsb0, f),
+
+          bind_by_ref(ref m) => to_bytes::iter_bytes_2(&1u8, m, lsb0, f),
+
+          bind_infer => 2u8.iter_bytes(lsb0, f),
         }
     }
 }
@@ -330,8 +350,15 @@ pub enum pat_ {
 #[deriving(Eq)]
 pub enum mutability { m_mutbl, m_imm, m_const, }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for mutability {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        (*self as u8).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for mutability {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -345,8 +372,15 @@ pub enum Sigil {
     ManagedSigil
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for Sigil {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        (*self as uint).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for Sigil {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (*self as uint).iter_bytes(lsb0, f)
     }
 }
@@ -744,8 +778,15 @@ impl ToStr for int_ty {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for int_ty {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        (*self as u8).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for int_ty {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -761,8 +802,15 @@ impl ToStr for uint_ty {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for uint_ty {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        (*self as u8).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for uint_ty {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -778,8 +826,15 @@ impl ToStr for float_ty {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for float_ty {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        (*self as u8).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for float_ty {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -823,9 +878,16 @@ impl ToStr for Onceness {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for Onceness {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as uint).iter_bytes(lsb0, f);
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for Onceness {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        (*self as uint).iter_bytes(lsb0, f)
     }
 }
 
@@ -874,9 +936,16 @@ pub enum ty_ {
     ty_infer,
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for Ty {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.span.lo, &self.span.hi, lsb0, f);
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for Ty {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        to_bytes::iter_bytes_2(&self.span.lo, &self.span.hi, lsb0, f)
     }
 }
 
@@ -941,8 +1010,15 @@ impl ToStr for purity {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for purity {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        (*self as u8).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for purity {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }
@@ -956,8 +1032,15 @@ pub enum ret_style {
     return_val, // everything else
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for ret_style {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        (*self as u8).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for ret_style {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (*self as u8).iter_bytes(lsb0, f)
     }
 }

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -191,10 +191,19 @@ pub fn is_call_expr(e: @expr) -> bool {
 }
 
 // This makes def_id hashable
+#[cfg(stage0)]
 impl to_bytes::IterBytes for def_id {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         to_bytes::iter_bytes_2(&self.crate, &self.node, lsb0, f);
+    }
+}
+// This makes def_id hashable
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for def_id {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        to_bytes::iter_bytes_2(&self.crate, &self.node, lsb0, f)
     }
 }
 

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -65,8 +65,15 @@ impl Sub<BytePos, BytePos> for BytePos {
     }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for BytePos {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        (**self).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for BytePos {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (**self).iter_bytes(lsb0, f)
     }
 }
@@ -83,8 +90,15 @@ impl cmp::Ord for CharPos {
     fn gt(&self, other: &CharPos) -> bool { **self > **other }
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for CharPos {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
+        (**self).iter_bytes(lsb0, f)
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for CharPos {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (**self).iter_bytes(lsb0, f)
     }
 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -195,18 +195,8 @@ pub fn expand_item(extsbox: @mut SyntaxEnv,
 }
 
 // does this attribute list contain "macro_escape" ?
-pub fn contains_macro_escape (attrs: &[ast::attribute]) -> bool{
-    let mut accum = false;
-    do attrs.each |attr| {
-        let mname = attr::get_attr_name(attr);
-        if (mname == @~"macro_escape") {
-            accum = true;
-            false
-        } else {
-            true
-        }
-    }
-    accum
+pub fn contains_macro_escape (attrs: &[ast::attribute]) -> bool {
+    attrs.any(|attr| "macro_escape" == *attr::get_attr_name(attr))
 }
 
 // this macro disables (one layer of) macro

--- a/src/libsyntax/ext/pipes/proto.rs
+++ b/src/libsyntax/ext/pipes/proto.rs
@@ -100,6 +100,7 @@ pub impl state_ {
 
     /// Iterate over the states that can be reached in one message
     /// from this state.
+    #[cfg(stage0)]
     fn reachable(&self, f: &fn(state) -> bool) {
         for self.messages.each |m| {
             match *m {
@@ -110,6 +111,21 @@ pub impl state_ {
               _ => ()
             }
         }
+    }
+    /// Iterate over the states that can be reached in one message
+    /// from this state.
+    #[cfg(not(stage0))]
+    fn reachable(&self, f: &fn(state) -> bool) -> bool {
+        for self.messages.each |m| {
+            match *m {
+              message(_, _, _, _, Some(next_state { state: ref id, _ })) => {
+                let state = self.proto.get_state((*id));
+                if !f(state) { return false; }
+              }
+              _ => ()
+            }
+        }
+        return true;
     }
 }
 

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -132,9 +132,17 @@ impl<A:Eq> Eq for OptVec<A> {
 }
 
 impl<A> BaseIter<A> for OptVec<A> {
+    #[cfg(stage0)]
     fn each(&self, blk: &fn(v: &A) -> bool) {
         match *self {
             Empty => {}
+            Vec(ref v) => v.each(blk)
+        }
+    }
+    #[cfg(not(stage0))]
+    fn each(&self, blk: &fn(v: &A) -> bool) -> bool {
+        match *self {
+            Empty => true,
             Vec(ref v) => v.each(blk)
         }
     }
@@ -146,7 +154,13 @@ impl<A> BaseIter<A> for OptVec<A> {
 
 impl<A> old_iter::ExtendedIter<A> for OptVec<A> {
     #[inline(always)]
+    #[cfg(stage0)]
     fn eachi(&self, blk: &fn(v: uint, v: &A) -> bool) {
+        old_iter::eachi(self, blk)
+    }
+    #[inline(always)]
+    #[cfg(not(stage0))]
+    fn eachi(&self, blk: &fn(v: uint, v: &A) -> bool) -> bool {
         old_iter::eachi(self, blk)
     }
     #[inline(always)]

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -62,10 +62,18 @@ pub enum ObsoleteSyntax {
     ObsoleteFixedLengthVectorType,
 }
 
+#[cfg(stage0)]
 impl to_bytes::IterBytes for ObsoleteSyntax {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (*self as uint).iter_bytes(lsb0, f);
+    }
+}
+#[cfg(not(stage0))]
+impl to_bytes::IterBytes for ObsoleteSyntax {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        (*self as uint).iter_bytes(lsb0, f)
     }
 }
 

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -355,9 +355,16 @@ impl<'self> Equiv<@~str> for StringRef<'self> {
     fn equiv(&self, other: &@~str) -> bool { str::eq_slice(**self, **other) }
 }
 
+#[cfg(stage0)]
 impl<'self> to_bytes::IterBytes for StringRef<'self> {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (**self).iter_bytes(lsb0, f);
+    }
+}
+#[cfg(not(stage0))]
+impl<'self> to_bytes::IterBytes for StringRef<'self> {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        (**self).iter_bytes(lsb0, f)
     }
 }
 

--- a/src/test/bench/graph500-bfs.rs
+++ b/src/test/bench/graph500-bfs.rs
@@ -10,8 +10,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[allow(deprecated_mode)];
-
 /*!
 
 An implementation of the Graph500 Breadth First Search problem in Rust.
@@ -23,7 +21,7 @@ use std::arc;
 use std::time;
 use std::deque::Deque;
 use std::par;
-use core::hashmap::{HashMap, HashSet};
+use core::hashmap::HashSet;
 use core::int::abs;
 use core::rand::RngUtil;
 
@@ -83,14 +81,13 @@ fn make_graph(N: uint, edges: ~[(node_id, node_id)]) -> graph {
         HashSet::new()
     };
 
-    do vec::each(edges) |e| {
+    for vec::each(edges) |e| {
         match *e {
             (i, j) => {
                 graph[i].insert(j);
                 graph[j].insert(i);
             }
         }
-        true
     }
 
     do vec::map_consume(graph) |mut v| {

--- a/src/test/compile-fail/bad-for-loop.rs
+++ b/src/test/compile-fail/bad-for-loop.rs
@@ -11,4 +11,5 @@
 fn main() {
     fn baz(_x: &fn(y: int) -> int) {}
     for baz |_e| { } //~ ERROR A `for` loop iterator should expect a closure that returns `bool`
+                     //~^ ERROR expected `for` closure to return `bool`
 }

--- a/src/test/compile-fail/borrowck-lend-flow-loop.rs
+++ b/src/test/compile-fail/borrowck-lend-flow-loop.rs
@@ -17,7 +17,7 @@
 fn borrow(_v: &int) {}
 fn borrow_mut(_v: &mut int) {}
 fn cond() -> bool { fail!() }
-fn for_func(_f: &fn() -> bool) { fail!() }
+fn for_func(_f: &fn() -> bool) -> bool { fail!() }
 fn produce<T>() -> T { fail!(); }
 
 fn inc(v: &mut ~int) {

--- a/src/test/compile-fail/issue-2817-2.rs
+++ b/src/test/compile-fail/issue-2817-2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn not_bool(f: &fn(int) -> ~str) {}
+fn not_bool(f: &fn(int) -> ~str) -> bool {}
 
 fn main() {
     for uint::range(0, 100000) |_i| { //~ ERROR A for-loop body must return (), but

--- a/src/test/compile-fail/issue-2817.rs
+++ b/src/test/compile-fail/issue-2817.rs
@@ -16,10 +16,10 @@ fn uuid_random() -> uint { fail!(); }
 
 fn main() {
     do uint::range(0, 100000) |_i| { //~ ERROR Do-block body must return bool, but
-    }
+    };
     // should get a more general message if the callback
     // doesn't return nil
     do uint::range(0, 100000) |_i| { //~ ERROR mismatched types
         ~"str"
-    }
+    };
 }

--- a/src/test/compile-fail/issue-3651-2.rs
+++ b/src/test/compile-fail/issue-3651-2.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    do 5.times {} //~ ERROR Do-block body must return bool, but returns () here. Perhaps
+    do 5.times {}; //~ ERROR Do-block body must return bool, but returns () here. Perhaps
 }

--- a/src/test/compile-fail/issue-3651.rs
+++ b/src/test/compile-fail/issue-3651.rs
@@ -10,4 +10,5 @@
 
 fn main() {
     for task::spawn { return true; } //~ ERROR A `for` loop iterator should expect a closure that
+                                     //~^ ERROR expected `for` closure to return `bool`
 }

--- a/src/test/compile-fail/private-method.rs
+++ b/src/test/compile-fail/private-method.rs
@@ -18,7 +18,7 @@ mod kitties {
     }
 
     pub impl cat {
-        priv fn nap(&self) { uint::range(1u, 10000u, |_i| false)}
+        priv fn nap(&self) { uint::range(1u, 10000u, |_i| false); }
     }
 
     pub fn cat(in_x : uint, in_y : int) -> cat {

--- a/src/test/run-pass/assignability-trait.rs
+++ b/src/test/run-pass/assignability-trait.rs
@@ -13,22 +13,18 @@
 // it.
 
 trait iterable<A> {
-    fn iterate(&self, blk: &fn(x: &A) -> bool);
+    fn iterate(&self, blk: &fn(x: &A) -> bool) -> bool;
 }
 
 impl<'self,A> iterable<A> for &'self [A] {
-    fn iterate(&self, f: &fn(x: &A) -> bool) {
-        for vec::each(*self) |e| {
-            if !f(e) { break; }
-        }
+    fn iterate(&self, f: &fn(x: &A) -> bool) -> bool {
+        vec::each(*self, f)
     }
 }
 
 impl<A> iterable<A> for ~[A] {
-    fn iterate(&self, f: &fn(x: &A) -> bool) {
-        for vec::each(*self) |e| {
-            if !f(e) { break; }
-        }
+    fn iterate(&self, f: &fn(x: &A) -> bool) -> bool {
+        vec::each(*self, f)
     }
 }
 

--- a/src/test/run-pass/borrowck-mut-uniq.rs
+++ b/src/test/run-pass/borrowck-mut-uniq.rs
@@ -18,7 +18,7 @@ fn add_int(x: &mut Ints, v: int) {
     x.values <-> values;
 }
 
-fn iter_ints(x: &Ints, f: &fn(x: &int) -> bool) {
+fn iter_ints(x: &Ints, f: &fn(x: &int) -> bool) -> bool {
     let l = x.values.len();
     uint::range(0, l, |i| f(&x.values[i]))
 }

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -59,25 +59,26 @@ impl<T> Mutable for cat<T> {
 }
 
 impl<T> Map<int, T> for cat<T> {
-    fn each<'a>(&'a self, f: &fn(&int, &'a T) -> bool) {
+    fn each<'a>(&'a self, f: &fn(&int, &'a T) -> bool) -> bool {
         let mut n = int::abs(self.meows);
         while n > 0 {
-            if !f(&n, &self.name) { break; }
+            if !f(&n, &self.name) { return false; }
             n -= 1;
         }
+        return true;
     }
 
     fn contains_key(&self, k: &int) -> bool { *k <= self.meows }
 
-    fn each_key(&self, f: &fn(v: &int) -> bool) {
-        for self.each |k, _| { if !f(k) { break; } loop;};
+    fn each_key(&self, f: &fn(v: &int) -> bool) -> bool {
+        self.each(|k, _| f(k))
     }
 
-    fn each_value<'a>(&'a self, f: &fn(v: &'a T) -> bool) {
-        for self.each |_, v| { if !f(v) { break; } loop;};
+    fn each_value<'a>(&'a self, f: &fn(v: &'a T) -> bool) -> bool {
+        self.each(|_, v| f(v))
     }
 
-    fn mutate_values(&mut self, _f: &fn(&int, &mut T) -> bool) {
+    fn mutate_values(&mut self, _f: &fn(&int, &mut T) -> bool) -> bool {
         fail!(~"nope")
     }
 

--- a/src/test/run-pass/do-for-empty-args.rs
+++ b/src/test/run-pass/do-for-empty-args.rs
@@ -11,14 +11,15 @@
 // no-reformat
 // Testing various forms of `do` and `for` with empty arg lists
 
-fn f(f: &fn() -> bool) {
+fn f(f: &fn() -> bool) -> bool {
+    true
 }
 
 pub fn main() {
-    do f() || { true }
-    do f() { true }
-    do f || { true }
-    do f { true }
+    do f() || { true };
+    do f() { true };
+    do f || { true };
+    do f { true };
     for f() || { }
     for f() { }
     for f || { }

--- a/src/test/run-pass/do-for-no-args.rs
+++ b/src/test/run-pass/do-for-no-args.rs
@@ -10,7 +10,7 @@
 
 // Testing that we can drop the || in for/do exprs
 
-fn f(f: @fn() -> bool) { }
+fn f(f: @fn() -> bool) -> bool { true }
 
 fn d(f: @fn()) { }
 

--- a/src/test/run-pass/ret-break-cont-in-block.rs
+++ b/src/test/run-pass/ret-break-cont-in-block.rs
@@ -12,12 +12,13 @@
 
 use core::cmp::Eq;
 
-fn iter<T>(v: ~[T], it: &fn(&T) -> bool) {
+fn iter<T>(v: ~[T], it: &fn(&T) -> bool) -> bool {
     let mut i = 0u, l = v.len();
     while i < l {
-        if !it(&v[i]) { break; }
+        if !it(&v[i]) { return false; }
         i += 1u;
     }
+    return true;
 }
 
 fn find_pos<T:Eq + Copy + Clone>(n: T, h: ~[T]) -> Option<uint> {


### PR DESCRIPTION
Closes #6183.

The first commit changes the compiler's method of treating a `for` loop, and all the remaining commits are just dealing with the fallout.

The biggest fallout was the `IterBytes` trait, although it's really a whole lot nicer now because all of the `iter_bytes_XX` methods are just and-ed together. Sadly there was a huge amount of stuff that's `cfg(stage0)` gated, but whoever lands the next snapshot is going to have a lot of fun deleting all this code!
