### PR TITLE
Remove pub from core::{unicode,cmath,stackwalk,rt}

### DIFF
--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -16,7 +16,7 @@ use option::{None, Option, Some};
 use str;
 use u32;
 use uint;
-use unicode;
+use unicode::{derived_property, general_category};
 
 #[cfg(notest)] use cmp::Eq;
 
@@ -53,10 +53,9 @@ use unicode;
     Cn  Unassigned  a reserved unassigned code point or a noncharacter
 */
 
-pub use is_alphabetic = unicode::derived_property::Alphabetic;
-pub use is_XID_start = unicode::derived_property::XID_Start;
-pub use is_XID_continue = unicode::derived_property::XID_Continue;
-
+pub fn is_alphabetic(c: char) -> bool   { derived_property::Alphabetic(c) }
+pub fn is_XID_start(c: char) -> bool    { derived_property::XID_Start(c) }
+pub fn is_XID_continue(c: char) -> bool { derived_property::XID_Continue(c) }
 
 /**
  * Indicates whether a character is in lower case, defined
@@ -64,7 +63,7 @@ pub use is_XID_continue = unicode::derived_property::XID_Continue;
  */
 #[inline(always)]
 pub fn is_lowercase(c: char) -> bool {
-    return unicode::general_category::Ll(c);
+    return general_category::Ll(c);
 }
 
 /**
@@ -73,7 +72,7 @@ pub fn is_lowercase(c: char) -> bool {
  */
 #[inline(always)]
 pub fn is_uppercase(c: char) -> bool {
-    return unicode::general_category::Lu(c);
+    return general_category::Lu(c);
 }
 
 /**
@@ -84,9 +83,9 @@ pub fn is_uppercase(c: char) -> bool {
 #[inline(always)]
 pub fn is_whitespace(c: char) -> bool {
     return ('\x09' <= c && c <= '\x0d')
-        || unicode::general_category::Zs(c)
-        || unicode::general_category::Zl(c)
-        || unicode::general_category::Zp(c);
+        || general_category::Zs(c)
+        || general_category::Zl(c)
+        || general_category::Zp(c);
 }
 
 /**
@@ -96,18 +95,18 @@ pub fn is_whitespace(c: char) -> bool {
  */
 #[inline(always)]
 pub fn is_alphanumeric(c: char) -> bool {
-    return unicode::derived_property::Alphabetic(c) ||
-        unicode::general_category::Nd(c) ||
-        unicode::general_category::Nl(c) ||
-        unicode::general_category::No(c);
+    return derived_property::Alphabetic(c) ||
+        general_category::Nd(c) ||
+        general_category::Nl(c) ||
+        general_category::No(c);
 }
 
 /// Indicates whether the character is numeric (Nd, Nl, or No)
 #[inline(always)]
 pub fn is_digit(c: char) -> bool {
-    return unicode::general_category::Nd(c) ||
-        unicode::general_category::Nl(c) ||
-        unicode::general_category::No(c);
+    return general_category::Nd(c) ||
+        general_category::Nl(c) ||
+        general_category::No(c);
 }
 
 /**

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -247,12 +247,12 @@ pub mod unstable;
 
 /* For internal use, not exported */
 
-pub mod unicode;
+mod unicode;
 #[path = "num/cmath.rs"]
-pub mod cmath;
-pub mod stackwalk;
+mod cmath;
+mod stackwalk;
 #[path = "rt/mod.rs"]
-pub mod rt;
+mod rt;
 
 // A curious inner-module that's not exported that contains the binding
 // 'core' so that macro-expanded references to core::error and such

--- a/src/libcore/gc.rs
+++ b/src/libcore/gc.rs
@@ -44,7 +44,7 @@ use libc::{size_t, uintptr_t};
 use option::{None, Option, Some};
 use ptr;
 use hashmap::HashSet;
-use stackwalk;
+use stackwalk::walk_stack;
 use sys;
 
 pub use stackwalk::Word;
@@ -230,7 +230,7 @@ unsafe fn walk_gc_roots(mem: Memory, sentinel: **Word, visitor: Visitor) {
     // frame is marked by a sentinel, which is a box pointer stored on
     // the stack.
     let mut reached_sentinel = ptr::is_null(sentinel);
-    for stackwalk::walk_stack |frame| {
+    for walk_stack |frame| {
         let pc = last_ret;
         let Segment {segment: next_segment, boundary: boundary} =
             find_segment_for_frame(frame.fp, segment);


### PR DESCRIPTION
I just removed `pub mod` from `core.rc` and then got everything to compile again. One thing I'm worried about is an import like this:

``` rust
use a;
use a::b;

mod a {
  pub type b = int;
}
mod b {
  use a;    // bad
  use a::b; // good
}
```

I'm not sure if `use a::b` being valid is a bug or intended behavior (same question about `use a`). If it's intended behavior, then I got around these modules not being public by only importing the specific members that are necessary. Otherwise that probably needs an open issue.
