### PR TITLE
rt: glob, globfree dummy function for android

### DIFF
--- a/src/rt/rust_android_dummy.cpp
+++ b/src/rt/rust_android_dummy.cpp
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#ifdef __ANDROID__
+
 #include "rust_android_dummy.h"
 #include <math.h>
 #include <errno.h>
-
-#ifdef __ANDROID__
 
 int backtrace(void **array, int size) { return 0; }
 
@@ -59,7 +59,18 @@ extern "C" void srand()
 extern "C" void atof()
 {
 }
+
 extern "C" void tgammaf()
 {
 }
+
+extern "C" int glob(const char *pattern, int flags, int (*errfunc) (const char *epath, int eerrno), glob_t *pglob)
+{
+    return 0;
+}
+
+extern "C" void globfree(glob_t *pglob)
+{
+}
+
 #endif

--- a/src/rt/rust_android_dummy.cpp
+++ b/src/rt/rust_android_dummy.cpp
@@ -64,7 +64,10 @@ extern "C" void tgammaf()
 {
 }
 
-extern "C" int glob(const char *pattern, int flags, int (*errfunc) (const char *epath, int eerrno), glob_t *pglob)
+extern "C" int glob(const char *pattern,
+                    int flags,
+                    int (*errfunc) (const char *epath, int eerrno),
+                    glob_t *pglob)
 {
     return 0;
 }

--- a/src/rt/rust_android_dummy.h
+++ b/src/rt/rust_android_dummy.h
@@ -11,5 +11,28 @@ char **backtrace_symbols (void *__const *__array, int __size);
 
 void backtrace_symbols_fd (void *__const *__array, int __size, int __fd);
 
+#include <sys/types.h>
+
+struct stat;
+typedef struct {
+    size_t gl_pathc;    /* Count of total paths so far. */
+    size_t gl_matchc;   /* Count of paths matching pattern. */
+    size_t gl_offs;     /* Reserved at beginning of gl_pathv. */
+    int gl_flags;       /* Copy of flags parameter to glob. */
+    char **gl_pathv;    /* List of paths matching pattern. */
+                /* Copy of errfunc parameter to glob. */
+    int (*gl_errfunc)(const char *, int);
+
+    /*
+     * Alternate filesystem access methods for glob; replacement
+     * versions of closedir(3), readdir(3), opendir(3), stat(2)
+     * and lstat(2).
+     */
+    void (*gl_closedir)(void *);
+    struct dirent *(*gl_readdir)(void *);
+    void *(*gl_opendir)(const char *);
+    int (*gl_lstat)(const char *, struct stat *);
+} glob_t;
+
 #endif
 


### PR DESCRIPTION
transitional patch to resolve compile/link failure on android

after #6161 landed, I've encountered below errors since android does not support glob in libc.

/opt/ndk_standalone/bin/../lib/gcc/arm-linux-androideabi/4.6/../../../../arm-linux-androideabi/bin/ld: /home/yichoi/rust_work/build/x86_64-unknown-linux-gnu/stage1/lib/rustc/arm-linux-androideabi/lib/libcore-c3ca5d77d81b46c1-0.7-pre.so: error: undefined reference to 'glob'

/opt/ndk_standalone/bin/../lib/gcc/arm-linux-androideabi/4.6/../../../../arm-linux-androideabi/bin/ld: /home/yichoi/rust_work/build/x86_64-unknown-linux-gnu/stage1/lib/rustc/arm-linux-androideabi/lib/libcore-c3ca5d77d81b46c1-0.7-pre.so: error: undefined reference to 'globfre

Since android does not have `glob.h`, `glob_t` definition comes from
https://groups.google.com/forum/?fromgroups=#!topic/android-ndk/vSH6MWPD0Vk
#6100 should be resolved.
