### PR TITLE
Add pop() and swap() to the Map trait

### DIFF
--- a/src/libcore/container.rs
+++ b/src/libcore/container.rs
@@ -55,6 +55,14 @@ pub trait Map<K, V>: Mutable {
     /// Remove a key-value pair from the map. Return true if the key
     /// was present in the map, otherwise false.
     fn remove(&mut self, key: &K) -> bool;
+
+    /// Insert a key-value pair from the map. If the key already had a value
+    /// present in the map, that value is returned. Otherwise None is returned.
+    fn swap(&mut self, k: K, v: V) -> Option<V>;
+
+    /// Removes a key from the map, returning the value at the key if the key
+    /// was previously in the map.
+    fn pop(&mut self, k: &K) -> Option<V>;
 }
 
 pub trait Set<T>: Mutable {

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -103,6 +103,10 @@ impl<T> Map<int, T> for cat<T> {
             false
         }
     }
+
+    fn pop(&mut self, _k: &int) -> Option<T> { fail!() }
+
+    fn swap(&mut self, _k: int, _v: T) -> Option<T> { fail!() }
 }
 
 pub impl<T> cat<T> {


### PR DESCRIPTION
Closes #5392 and #5393

I implemented the pop/swap methods for TrieMap/TreeMap/SmallIntMap, and I also updated all of them such that pop isn't just a remove/insert, but rather it's all done in one operation.

One thing I did notice is that with default methods it'd be really nice to define `insert` and `remove` in terms of `pop` and `swap` (or vice versa, just to have them available).
