### PR TITLE
add #[non_owned] and #[mutable] attributes

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -19,6 +19,7 @@ A dynamic, mutable location.
 Similar to a mutable option type, but friendlier.
 */
 
+#[mutable]
 pub struct Cell<T> {
     priv value: Option<T>
 }

--- a/src/test/compile-fail/mutable-enum.rs
+++ b/src/test/compile-fail/mutable-enum.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[mutable]
+enum Foo { A }
+
+fn bar<T: Const>(_: T) {}
+
+fn main() {
+    let x = A;
+    bar(x); //~ ERROR instantiating a type parameter with an incompatible type `Foo`, which does not fulfill `Const`
+}

--- a/src/test/compile-fail/mutable-struct.rs
+++ b/src/test/compile-fail/mutable-struct.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[mutable]
+struct Foo { a: int }
+
+fn bar<T: Const>(_: T) {}
+
+fn main() {
+    let x = Foo { a: 5 };
+    bar(x); //~ ERROR instantiating a type parameter with an incompatible type `Foo`, which does not fulfill `Const`
+}

--- a/src/test/compile-fail/non_owned-enum.rs
+++ b/src/test/compile-fail/non_owned-enum.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[non_owned]
+enum Foo { A }
+
+fn bar<T: Owned>(_: T) {}
+
+fn main() {
+    let x = A;
+    bar(x); //~ ERROR instantiating a type parameter with an incompatible type `Foo`, which does not fulfill `Owned`
+}

--- a/src/test/compile-fail/non_owned-struct.rs
+++ b/src/test/compile-fail/non_owned-struct.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[non_owned]
+struct Foo { a: int }
+
+fn bar<T: Owned>(_: T) {}
+
+fn main() {
+    let x = Foo { a: 5 };
+    bar(x); //~ ERROR instantiating a type parameter with an incompatible type `Foo`, which does not fulfill `Owned`
+}


### PR DESCRIPTION
Also fixed the docstring on `TC_ONCE_CLOSURE` (was accidentally the same as `TC_MUTABLE`) and shifted the `TC_EMPTY_ENUM` bit left by one since whatever previously used that bit has been removed.
