### PR TITLE
Improve lifetimes on foldl/foldr and lift the Copy requirement

### DIFF
--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -991,7 +991,7 @@ pub fn connect<T:Copy>(v: &[~[T]], sep: &T) -> ~[T] {
  * ~~~
  *
  */
-pub fn foldl<T, U>(z: T, v: &[U], p: &fn(t: T, u: &U) -> T) -> T {
+pub fn foldl<'a, T, U>(z: T, v: &'a [U], p: &fn(t: T, u: &'a U) -> T) -> T {
     let mut accum = z;
     let mut i = 0;
     let l = v.len();
@@ -1023,12 +1023,13 @@ pub fn foldl<T, U>(z: T, v: &[U], p: &fn(t: T, u: &U) -> T) -> T {
  * ~~~
  *
  */
-pub fn foldr<T, U: Copy>(v: &[T], z: U, p: &fn(t: &T, u: U) -> U) -> U {
-    let mut accum = z;
-    for v.each_reverse |elt| {
-        accum = p(elt, accum);
+pub fn foldr<'a, T, U>(v: &'a [T], mut z: U, p: &fn(t: &'a T, u: U) -> U) -> U {
+    let mut i = v.len();
+    while i > 0 {
+        i -= 1;
+        z = p(&v[i], z);
     }
-    accum
+    return z;
 }
 
 /**
@@ -1851,7 +1852,7 @@ pub trait ImmutableVector<'self, T> {
     fn last_opt(&self) -> Option<&'self T>;
     fn each_reverse(&self, blk: &fn(&T) -> bool);
     fn eachi_reverse(&self, blk: &fn(uint, &T) -> bool);
-    fn foldr<U: Copy>(&self, z: U, p: &fn(t: &T, u: U) -> U) -> U;
+    fn foldr<'a, U>(&'a self, z: U, p: &fn(t: &'a T, u: U) -> U) -> U;
     fn map<U>(&self, f: &fn(t: &T) -> U) -> ~[U];
     fn mapi<U>(&self, f: &fn(uint, t: &T) -> U) -> ~[U];
     fn map_r<U>(&self, f: &fn(x: &T) -> U) -> ~[U];
@@ -1924,7 +1925,7 @@ impl<'self,T> ImmutableVector<'self, T> for &'self [T] {
 
     /// Reduce a vector from right to left
     #[inline]
-    fn foldr<U:Copy>(&self, z: U, p: &fn(t: &T, u: U) -> U) -> U {
+    fn foldr<'a, U>(&'a self, z: U, p: &fn(t: &'a T, u: U) -> U) -> U {
         foldr(*self, z, p)
     }
 


### PR DESCRIPTION
Closes #5311 and #4490.

This doesn't change `vec.foldl` because that's still part of `old_iter`, although I could change that as well if necessary.
