### PR TITLE
vim file improvements

### DIFF
--- a/src/etc/vim/after/ftplugin/rust.vim
+++ b/src/etc/vim/after/ftplugin/rust.vim
@@ -1,5 +1,5 @@
 "Highlight the 100th text column
 "Feature became available in v7.3
 if version >= 703
-    set colorcolumn=100
+    setlocal colorcolumn=100
 endif

--- a/src/etc/vim/after/syntax/rust.vim
+++ b/src/etc/vim/after/syntax/rust.vim
@@ -1,4 +1,4 @@
-if exists('g:no_rust_conceal') || !has('conceal') || &enc != 'utf-8'
+if !exists('g:rust_conceal') || !has('conceal') || &enc != 'utf-8'
 	finish
 endif
 

--- a/src/etc/vim/indent/rust.vim
+++ b/src/etc/vim/indent/rust.vim
@@ -5,4 +5,7 @@ if exists("b:did_indent")
 endif
 
 let b:did_indent = 1
-setlocal smartindent
+
+setlocal cindent
+setlocal cinoptions=L0,(0,Ws,JN
+setlocal cinkeys=0{,0},!^F,o,O

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -29,7 +29,7 @@ syn match     rustIdentifier  contains=rustIdentifierPrime "\%([^[:cntrl:][:spac
 syn match     rustFuncName    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
 
 " Reserved words
-syn keyword   rustKeyword     m32 m64 m128 f80 f16 f128 be
+"syn keyword   rustKeyword     m32 m64 m128 f80 f16 f128 be " These are obsolete
 
 syn keyword   rustType        int uint float char bool u8 u16 u32 u64 f32
 syn keyword   rustType        f64 i8 i16 i32 i64 str Self


### PR DESCRIPTION
`colorcolumn` is now set with `setlocal`, so it doesn't infect the entire session.

`conceal` support is now opt-in, not opt-out. I haven't found anybody that likes it or cares either way.

The indent file now uses `cindent` with appropriate `cinoptions` and `cinkeys`. Auto-indenting an entire file mostly gets the right thing now, with structs and enums not being affects like before. Defaults to the hanging indent style, unless the first argument is on a new line.

There were some keywords in the syntax file that I've never seen (and have been used as identifiers in some tests) so they have been commented out.
