### PR TITLE
Step one for 'proper' pub condition: support pub keyword in form.

### DIFF
--- a/src/libcore/rt/io/mod.rs
+++ b/src/libcore/rt/io/mod.rs
@@ -337,7 +337,8 @@ pub enum IoErrorKind {
 // XXX: Can't put doc comments on macros
 // Raised by `I/O` operations on error.
 condition! {
-    io_error: super::IoError -> ();
+    // FIXME (#6009): uncomment `pub` after expansion support lands.
+    /*pub*/ io_error: super::IoError -> ();
 }
 
 pub trait Reader {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -485,8 +485,23 @@ pub fn core_macros() -> ~str {
 
     macro_rules! condition (
 
+        { pub $c:ident: $in:ty -> $out:ty; } => {
+
+            pub mod $c {
+                fn key(_x: @::core::condition::Handler<$in,$out>) { }
+
+                pub static cond :
+                    ::core::condition::Condition<'static,$in,$out> =
+                    ::core::condition::Condition {
+                        name: stringify!($c),
+                        key: key
+                    };
+            }
+        };
+
         { $c:ident: $in:ty -> $out:ty; } => {
 
+            // FIXME (#6009): remove mod's `pub` below once variant above lands.
             pub mod $c {
                 fn key(_x: @::core::condition::Handler<$in,$out>) { }
 


### PR DESCRIPTION
@brson: r?  [please ignore the other one that was accidentally based off master due to back-button-bugs in github.com]

My goal is to resolve the question of whether we want to encourage (by example) consistent use of pub to make identifiers publicly-accessible, even in syntax extensions. (If people don't want that, then we can just let this pull request die.)

This is part one of two. Part two, whose contents should be clear from the FIXME's in this commit, would land after this gets incorporated into a snapshot.

(The eventual goal is to address issue #6009 , which was implied by my choice of branch name, but not mentioned in the pull request, so github did not notice it.)
