### PR TITLE
fix for #6279 (Windows uv build is busted)

### DIFF
--- a/mk/host.mk
+++ b/mk/host.mk
@@ -130,8 +130,10 @@ $$(HLIB$(2)_H_$(4))/$(CFG_RUSTLLVM_$(4)): \
 $$(HBIN$(2)_H_$(4))/:
 	mkdir -p $$@
 
+ifneq ($(CFG_LIBDIR),bin)
 $$(HLIB$(2)_H_$(4))/:
 	mkdir -p $$@
+endif
 
 endef
 

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -163,8 +163,6 @@ endif
 ifdef CFG_WINDOWSY_$(1)
 $$(LIBUV_LIB_$(1)): $$(LIBUV_DEPS)
 	$$(Q)$$(MAKE) -C $$(S)src/libuv/ \
-		CFLAGS="$$(CFG_GCCISH_CFLAGS)" \
-		LDFLAGS="$$(CFG_GCCISH_LINK_FLAGS)" \
 		builddir_name="$$(CFG_BUILD_DIR)/rt/$(1)/libuv" \
 		OS=mingw \
 		V=$$(VERBOSE)

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -86,8 +86,10 @@ endif
 $$(TBIN$(1)_T_$(2)_H_$(3))/:
 	mkdir -p $$@
 
+ifneq ($(CFG_LIBDIR),bin)
 $$(TLIB$(1)_T_$(2)_H_$(3))/:
 	mkdir -p $$@
+endif
 
 endef
 


### PR DESCRIPTION
fix for #6279 #6253

mk: rt.mk regression patch for mingw32 after #6176

currently do not pass optimization option just make it works only

mk: target.mk host.mk fix for duplicated rules of mingw32 after #6235

It can be simply fixed with CFG_LIB check whether bin or lib however considering multiple target triples with linux and windows, CFG_LIB needs to configurable #5223 and #5577
