### PR TITLE
Add RelativeEq trait

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -73,6 +73,13 @@ pub trait ApproxEq<Eps> {
     fn approx_eq_eps(&self, other: &Self, approx_epsilon: &Eps) -> bool;
 }
 
+/// Trait for testing relatively equality
+pub trait RelativeEq<Eps> {
+    fn relative_epsilon() -> Eps;
+    fn relative_eq(&self, other: &Self) -> bool;
+    fn relative_eq_eps(&self, other: &Self, relative_epsilon: &Eps) -> bool;
+}
+
 #[deriving(Clone, Eq)]
 pub enum Ordering { Less = -1, Equal = 0, Greater = 1 }
 

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -227,6 +227,22 @@ impl ApproxEq<f32> for f32 {
 }
 
 #[cfg(notest)]
+impl RelativeEq<f32> for f32 {
+    #[inline(always)]
+    fn relative_epsilon() -> f32 { 1.0e-6 }
+
+    #[inline(always)]
+    fn relative_eq(&self, other: &f32) -> bool {
+        self.relative_eq_eps(other, &RelativeEq::relative_epsilon::<f32, f32>())
+    }
+
+    #[inline(always)]
+    fn relative_eq_eps(&self, other: &f32, relative_epsilon: &f32) -> bool {
+        (*self - *other).abs() < fmax(self.abs(), other.abs()) * (*relative_epsilon)
+    }
+}
+
+#[cfg(notest)]
 impl Ord for f32 {
     #[inline(always)]
     fn lt(&self, other: &f32) -> bool { (*self) < (*other) }
@@ -988,6 +1004,15 @@ mod tests {
         assert!(1.000001f32.approx_eq_eps(&1f32, &1.0e-5));
         assert!(1.0000001f32.approx_eq_eps(&1f32, &1.0e-6));
         assert!(!1.0000001f32.approx_eq_eps(&1f32, &1.0e-7));
+    }
+
+    #[test]
+    fn test_relative_eq() {
+        assert!(1.0e8f32.relative_eq(&1.0e8f32));
+        assert!(0.9999999e8f32.relative_eq(&1.0e8f32));
+        assert!(1.00001e8f32.relative_eq_eps(&1.0e8f32, &1.0e-5));
+        assert!(1.000001e8f32.relative_eq_eps(&1.0e8f32, &1.0e-6));
+        assert!(!1.000001e8f32.relative_eq_eps(&1.0e8f32, &1.0e-7));
     }
 
     #[test]

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -250,6 +250,22 @@ impl ApproxEq<f64> for f64 {
 }
 
 #[cfg(notest)]
+impl RelativeEq<f64> for f64 {
+    #[inline(always)]
+    fn relative_epsilon() -> f64 { 1.0e-6 }
+
+    #[inline(always)]
+    fn relative_eq(&self, other: &f64) -> bool {
+        self.relative_eq_eps(other, &RelativeEq::relative_epsilon::<f64, f64>())
+    }
+
+    #[inline(always)]
+    fn relative_eq_eps(&self, other: &f64, relative_epsilon: &f64) -> bool {
+        (*self - *other).abs() < fmax(self.abs(), other.abs()) * (*relative_epsilon)
+    }
+}
+
+#[cfg(notest)]
 impl Ord for f64 {
     #[inline(always)]
     fn lt(&self, other: &f64) -> bool { (*self) < (*other) }
@@ -1035,6 +1051,15 @@ mod tests {
         assert!(1.000001f64.approx_eq_eps(&1f64, &1.0e-5));
         assert!(1.0000001f64.approx_eq_eps(&1f64, &1.0e-6));
         assert!(!1.0000001f64.approx_eq_eps(&1f64, &1.0e-7));
+    }
+
+    #[test]
+    fn test_relative_eq() {
+        assert!(1.0e8f64.relative_eq(&1.0e8f64));
+        assert!(0.9999999e8f64.relative_eq(&1.0e8f64));
+        assert!(1.00001e8f64.relative_eq_eps(&1.0e8f64, &1.0e-5));
+        assert!(1.000001e8f64.relative_eq_eps(&1.0e8f64, &1.0e-6));
+        assert!(!1.000001e8f64.relative_eq_eps(&1.0e8f64, &1.0e-7));
     }
 
     #[test]

--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -388,6 +388,23 @@ impl ApproxEq<float> for float {
 }
 
 #[cfg(notest)]
+impl RelativeEq<float> for float {
+    #[inline(always)]
+    fn relative_epsilon() -> float { 1.0e-6 }
+
+    #[inline(always)]
+    fn relative_eq(&self, other: &float) -> bool {
+        self.relative_eq_eps(other, &RelativeEq::relative_epsilon::<float, float>())
+    }
+
+    #[inline(always)]
+    fn relative_eq_eps(&self, other: &float, relative_epsilon: &float) -> bool {
+        (*self - *other).abs() <
+            fmax(self.abs() as f64, other.abs() as f64) as float * (*relative_epsilon)
+    }
+}
+
+#[cfg(notest)]
 impl Ord for float {
     #[inline(always)]
     fn lt(&self, other: &float) -> bool { (*self) < (*other) }
@@ -999,6 +1016,15 @@ mod tests {
         assert!(1.000001f.approx_eq_eps(&1f, &1.0e-5));
         assert!(1.0000001f.approx_eq_eps(&1f, &1.0e-6));
         assert!(!1.0000001f.approx_eq_eps(&1f, &1.0e-7));
+    }
+
+    #[test]
+    fn test_relative_eq() {
+        assert!(1.0e8f.relative_eq(&1.0e8f));
+        assert!(0.9999999e8f.relative_eq(&1.0e8f));
+        assert!(1.00001e8f.relative_eq_eps(&1.0e8f, &1.0e-5));
+        assert!(1.000001e8f.relative_eq_eps(&1.0e8f, &1.0e-6));
+        assert!(!1.000001e8f.relative_eq_eps(&1.0e8f, &1.0e-7));
     }
 
     #[test]

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 //! An interface for numeric types
-use cmp::{Eq, ApproxEq, Ord};
+use cmp::{Eq, ApproxEq, RelativeEq, Ord};
 use ops::{Add, Sub, Mul, Div, Rem, Neg};
 use ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
 use option::Option;
@@ -241,7 +241,8 @@ pub trait Int: Integer
 pub trait Float: Real
                + Signed
                + Primitive
-               + ApproxEq<Self> {
+               + ApproxEq<Self>
+               + RelativeEq<Self> {
     // FIXME (#5527): These should be associated constants
     fn NaN() -> Self;
     fn infinity() -> Self;

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -28,7 +28,8 @@ pub use io::{print, println};
 /* Reexported types and traits */
 
 pub use clone::Clone;
-pub use cmp::{Eq, ApproxEq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater, Equiv};
+pub use cmp::{Eq, ApproxEq, RelativeEq, Ord, TotalEq, TotalOrd, Ordering};
+pub use cmp::{Less, Equal, Greater, Equiv};
 pub use container::{Container, Mutable, Map, Set};
 pub use hash::Hash;
 pub use old_iter::{BaseIter, ReverseIter, MutableIter, ExtendedIter, EqIter};

--- a/src/test/run-pass/issue-5316.rs
+++ b/src/test/run-pass/issue-5316.rs
@@ -1,0 +1,19 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that merely having lifetime parameters is not
+// enough for trans to consider this as non-monomorphic,
+// which led to various assertions and failures in turn.
+
+pub fn main() {
+    let a = 1e20f32 * (1f32/11f32) * 3f32;
+    let b = 1e20f32 * (3f32/11f32);
+    assert!(a.relative_eq(&b)); 
+}

--- a/src/test/run-pass/trait-inheritance-num.rs
+++ b/src/test/run-pass/trait-inheritance-num.rs
@@ -17,7 +17,7 @@ use core::num::NumCast::from;
 
 pub trait NumExt: Num + NumCast + Eq + Ord {}
 
-pub trait FloatExt: NumExt + ApproxEq<Self> {}
+pub trait FloatExt: NumExt + ApproxEq<Self> + RelativeEq<Self> {}
 
 fn greater_than_one<T:NumExt>(n: &T) -> bool { *n > from(1) }
 fn greater_than_one_float<T:FloatExt>(n: &T) -> bool { *n > from(1) }

--- a/src/test/run-pass/trait-inheritance-num2.rs
+++ b/src/test/run-pass/trait-inheritance-num2.rs
@@ -93,7 +93,7 @@ impl IntegerExt for i64 {}
 impl IntegerExt for int {}
 
 
-pub trait FloatExt: NumExt + ApproxEq<Self> {}
+pub trait FloatExt: NumExt + ApproxEq<Self> + RelativeEq<Self> {}
 
 impl FloatExt for f32 {}
 impl FloatExt for f64 {}


### PR DESCRIPTION
Fix for #5316
Current Implementation of ApproxEq trait uses absolute error method, and this method is working well for small float point numbers but not suitable for large numbers. 
This patch provides RelativeEq trait and implementation of it uses relative error method that will be better for comparing big numbers.
