### PR TITLE
Fix issue #6141: leaking ~fn

### DIFF
--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -548,11 +548,9 @@ pub impl Datum {
     }
 
     fn to_rptr(&self, bcx: block) -> Datum {
-        //!
-        //
-        // Returns a new datum of region-pointer type containing the
-        // the same ptr as this datum (after converting to by-ref
-        // using `to_ref_llval()`).
+        //! Returns a new datum of region-pointer type containing the
+        //! the same ptr as this datum (after converting to by-ref
+        //! using `to_ref_llval()`).
 
         // Convert to ref, yielding lltype *T.  Then create a Rust
         // type &'static T (which translates to *T).  Construct new

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2893,20 +2893,20 @@ pub fn expr_ty_adjusted(cx: ctxt, expr: @ast::expr) -> t {
      */
 
     let unadjusted_ty = expr_ty(cx, expr);
-    adjust_ty(cx, expr.span, unadjusted_ty, cx.adjustments.find(&expr.id))
+    adjust_ty(cx, expr.span, unadjusted_ty, cx.adjustments.find_copy(&expr.id))
 }
 
 pub fn adjust_ty(cx: ctxt,
                  span: span,
                  unadjusted_ty: ty::t,
-                 adjustment: Option<&@AutoAdjustment>) -> ty::t
+                 adjustment: Option<@AutoAdjustment>) -> ty::t
 {
     /*! See `expr_ty_adjusted` */
 
     return match adjustment {
         None => unadjusted_ty,
 
-        Some(&@AutoAddEnv(r, s)) => {
+        Some(@AutoAddEnv(r, s)) => {
             match ty::get(unadjusted_ty).sty {
                 ty::ty_bare_fn(ref b) => {
                     ty::mk_closure(
@@ -2924,7 +2924,7 @@ pub fn adjust_ty(cx: ctxt,
             }
         }
 
-        Some(&@AutoDerefRef(ref adj)) => {
+        Some(@AutoDerefRef(ref adj)) => {
             let mut adjusted_ty = unadjusted_ty;
 
             for uint::range(0, adj.autoderefs) |i| {

--- a/src/rt/rust_task.cpp
+++ b/src/rt/rust_task.cpp
@@ -76,15 +76,8 @@ rust_task::delete_this()
     assert(ref_count == 0); // ||
     //   (ref_count == 1 && this == sched->root_task));
 
-    if (borrow_list) {
-        // NOTE should free borrow_list from within rust code!
-        // If there is a pointer in there, it is a ~[BorrowRecord] pointer,
-        // which are currently allocated with LIBC malloc/free. But this is
-        // not really the right way to do this, we should be freeing this
-        // pointer from Rust code.
-        free(borrow_list);
-        borrow_list = NULL;
-    }
+    // The borrow list should be freed in the task annihilator
+    assert(!borrow_list);
 
     sched_loop->release_task(this);
 }

--- a/src/test/run-pass/issue-6141-leaking-owned-fn.rs
+++ b/src/test/run-pass/issue-6141-leaking-owned-fn.rs
@@ -1,0 +1,8 @@
+fn run(f: &fn()) {
+    f()
+}
+
+fn main() {
+    let f: ~fn() = || ();
+    run(f);
+}


### PR DESCRIPTION
When autoborrowing a fn in trans, adjust the type of the datum to be `&fn`.

Fixes #6141.

r? @brson
