### PR TITLE
io: handle fread() errors

### DIFF
--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -868,9 +868,19 @@ impl Reader for *libc::FILE {
                 assert!(buf_len >= len);
 
                 let count = libc::fread(buf_p as *mut c_void, 1u as size_t,
-                                        len as size_t, *self);
+                                        len as size_t, *self) as uint;
+                if count < len {
+                  match libc::ferror(*self) {
+                    0 => (),
+                    _ => {
+                      error!("error reading buffer");
+                      error!("%s", os::last_os_error());
+                      fail!();
+                    }
+                  }
+                }
 
-                count as uint
+                count
             }
         }
     }


### PR DESCRIPTION
When, occasionally, trying to read directory instead of file, `fread()`
returns `EISDIR` error. And, considering, absence of error handling,
`read_whole_stream()` just loops indefinitely.
