### PR TITLE
rt: Remove rust_call_nullary_fn

### DIFF
--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -830,13 +830,6 @@ rust_get_rt_env() {
     return task->kernel->env;
 }
 
-typedef void *(*nullary_fn)();
-
-extern "C" CDECL void
-rust_call_nullary_fn(nullary_fn f) {
-    f();
-}
-
 #ifndef _WIN32
 pthread_key_t sched_key;
 #else

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -222,7 +222,6 @@ rust_uv_ip4_addrp
 rust_uv_ip6_addrp
 rust_uv_free_ip4_addr
 rust_uv_free_ip6_addr
-rust_call_nullary_fn
 rust_initialize_global_state
 rust_dbg_next_port
 rust_new_memory_region


### PR DESCRIPTION
There's no need to delegate to C to call the Rust main function.
