### PR TITLE
Refactor representation of bounds to separate out BuiltinBounds into its own type. 

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -555,18 +555,34 @@ fn parse_type_param_def(st: @mut PState, conv: conv_did) -> ty::TypeParameterDef
                           bounds: parse_bounds(st, conv)}
 }
 
-fn parse_bounds(st: @mut PState, conv: conv_did) -> @~[ty::param_bound] {
-    let mut bounds = ~[];
+fn parse_bounds(st: @mut PState, conv: conv_did) -> @ty::ParamBounds {
+    let mut param_bounds = ty::ParamBounds {
+        builtin_bounds: ty::EmptyBuiltinBounds(),
+        trait_bounds: ~[]
+    };
     loop {
-        bounds.push(match next(st) {
-          'S' => ty::bound_owned,
-          'C' => ty::bound_copy,
-          'K' => ty::bound_const,
-          'O' => ty::bound_durable,
-          'I' => ty::bound_trait(@parse_trait_ref(st, conv)),
-          '.' => break,
-          _ => fail!(~"parse_bounds: bad bounds")
-        });
+        match next(st) {
+            'S' => {
+                param_bounds.builtin_bounds.add(ty::BoundOwned);
+            }
+            'C' => {
+                param_bounds.builtin_bounds.add(ty::BoundCopy);
+            }
+            'K' => {
+                param_bounds.builtin_bounds.add(ty::BoundConst);
+            }
+            'O' => {
+                param_bounds.builtin_bounds.add(ty::BoundStatic);
+            }
+            'I' => {
+                param_bounds.trait_bounds.push(@parse_trait_ref(st, conv));
+            }
+            '.' => {
+                return @param_bounds;
+            }
+            _ => {
+                fail!(~"parse_bounds: bad bounds")
+            }
+        }
     }
-    @bounds
 }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -396,19 +396,21 @@ fn enc_fn_sig(w: @io::Writer, cx: @ctxt, fsig: &ty::FnSig) {
     enc_ty(w, cx, fsig.output);
 }
 
-fn enc_bounds(w: @io::Writer, cx: @ctxt, bs: @~[ty::param_bound]) {
-    for (*bs).each |bound| {
-        match *bound {
-          ty::bound_owned => w.write_char('S'),
-          ty::bound_copy => w.write_char('C'),
-          ty::bound_const => w.write_char('K'),
-          ty::bound_durable => w.write_char('O'),
-          ty::bound_trait(tp) => {
-              w.write_char('I');
-              enc_trait_ref(w, cx, tp);
-          }
+fn enc_bounds(w: @io::Writer, cx: @ctxt, bs: @ty::ParamBounds) {
+    for bs.builtin_bounds.each |bound| {
+        match bound {
+            ty::BoundOwned => w.write_char('S'),
+            ty::BoundCopy => w.write_char('C'),
+            ty::BoundConst => w.write_char('K'),
+            ty::BoundStatic => w.write_char('O'),
         }
     }
+
+    for bs.trait_bounds.each |&tp| {
+        w.write_char('I');
+        enc_trait_ref(w, cx, tp);
+    }
+
     w.write_char('.');
 }
 

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -78,9 +78,11 @@ impl<T:Subst> Subst for ~[T] {
     }
 }
 
-impl<T:Subst> Subst for @~[T] {
-    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> @~[T] {
-        @(**self).subst(tcx, substs)
+impl<T:Subst> Subst for @T {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> @T {
+        match self {
+            &@ref t => @t.subst(tcx, substs)
+        }
     }
 }
 
@@ -115,19 +117,11 @@ impl Subst for ty::BareFnTy {
     }
 }
 
-impl Subst for ty::param_bound {
-    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::param_bound {
-        match self {
-            &ty::bound_copy |
-            &ty::bound_durable |
-            &ty::bound_owned |
-            &ty::bound_const => {
-                *self
-            }
-
-            &ty::bound_trait(tref) => {
-                ty::bound_trait(@tref.subst(tcx, substs))
-            }
+impl Subst for ty::ParamBounds {
+    fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::ParamBounds {
+        ty::ParamBounds {
+            builtin_bounds: self.builtin_bounds,
+            trait_bounds: self.trait_bounds.subst(tcx, substs)
         }
     }
 }

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -348,14 +348,9 @@ pub fn make_mono_id(ccx: @CrateContext,
         let mut i = 0;
         vec::map_zip(*item_ty.generics.type_param_defs, substs, |type_param_def, subst| {
             let mut v = ~[];
-            for type_param_def.bounds.each |bound| {
-                match *bound {
-                  ty::bound_trait(_) => {
-                    v.push(meth::vtable_id(ccx, /*bad*/copy vts[i]));
-                    i += 1;
-                  }
-                  _ => ()
-                }
+            for type_param_def.bounds.trait_bounds.each |_bound| {
+                v.push(meth::vtable_id(ccx, /*bad*/copy vts[i]));
+                i += 1;
             }
             (*subst, if !v.is_empty() { Some(v) } else { None })
         })

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -67,8 +67,7 @@ pub impl VtableContext {
 
 fn has_trait_bounds(type_param_defs: &[ty::TypeParameterDef]) -> bool {
     type_param_defs.any(
-        |type_param_def| type_param_def.bounds.any(
-            |bound| match bound { &ty::bound_trait(*) => true, _ => false }))
+        |type_param_def| !type_param_def.bounds.trait_bounds.is_empty())
 }
 
 fn lookup_vtables(vcx: &VtableContext,
@@ -99,7 +98,7 @@ fn lookup_vtables(vcx: &VtableContext,
 
             // Substitute the values of the type parameters that may
             // appear in the bound.
-            let trait_ref = trait_ref.subst(tcx, substs);
+            let trait_ref = (*trait_ref).subst(tcx, substs);
 
             debug!("after subst: %s", trait_ref.repr(tcx));
 
@@ -339,7 +338,8 @@ fn lookup_vtable(vcx: &VtableContext,
                                    vcx.infcx.trait_ref_to_str(trait_ref),
                                    vcx.infcx.trait_ref_to_str(of_trait_ref));
 
-                            let of_trait_ref = of_trait_ref.subst(tcx, &substs);
+                            let of_trait_ref =
+                                (*of_trait_ref).subst(tcx, &substs);
                             relate_trait_refs(
                                 vcx, location_info,
                                 &of_trait_ref, trait_ref);
@@ -458,7 +458,7 @@ fn connect_trait_tps(vcx: &VtableContext,
 
     // XXX: This should work for multiple traits.
     let impl_trait_ref = ty::impl_trait_refs(tcx, impl_did)[0];
-    let impl_trait_ref = impl_trait_ref.subst(tcx, impl_substs);
+    let impl_trait_ref = (*impl_trait_ref).subst(tcx, impl_substs);
     relate_trait_refs(vcx, location_info, &impl_trait_ref, trait_ref);
 }
 

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -131,6 +131,7 @@ pub mod driver;
 pub mod util {
     pub mod common;
     pub mod ppaux;
+    pub mod enum_set;
 }
 
 pub mod lib {

--- a/src/librustc/util/enum_set.rs
+++ b/src/librustc/util/enum_set.rs
@@ -45,10 +45,6 @@ pub impl<E:CLike> EnumSet<E> {
         self.bits |= bit(e);
     }
 
-    fn plus(&self, e: E) -> EnumSet<E> {
-        EnumSet {bits: self.bits | bit(e)}
-    }
-
     fn contains_elem(&self, e: E) -> bool {
         (self.bits & bit(e)) != 0
     }
@@ -84,5 +80,154 @@ impl<E:CLike> core::BitOr<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
 impl<E:CLike> core::BitAnd<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
     fn bitand(&self, e: &EnumSet<E>) -> EnumSet<E> {
         EnumSet {bits: self.bits & e.bits}
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core;
+    use core::iter;
+    use util::enum_set::*;
+
+    #[deriving(Eq)]
+    enum Foo {
+        A, B, C
+    }
+
+    impl CLike for Foo {
+        pub fn to_uint(&self) -> uint {
+            *self as uint
+        }
+
+        pub fn from_uint(v: uint) -> Foo {
+            unsafe { cast::transmute(v) }
+        }
+    }
+
+    #[test]
+    fn test_empty() {
+        let e: EnumSet<Foo> = EnumSet::empty();
+        assert!(e.is_empty());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // intersect
+
+    #[test]
+    fn test_two_empties_do_not_intersect() {
+        let e1: EnumSet<Foo> = EnumSet::empty();
+        let e2: EnumSet<Foo> = EnumSet::empty();
+        assert!(!e1.intersects(e2));
+    }
+
+    #[test]
+    fn test_empty_does_not_intersect_with_full() {
+        let e1: EnumSet<Foo> = EnumSet::empty();
+
+        let mut e2: EnumSet<Foo> = EnumSet::empty();
+        e2.add(A);
+        e2.add(B);
+        e2.add(C);
+
+        assert!(!e1.intersects(e2));
+    }
+
+    #[test]
+    fn test_disjoint_intersects() {
+        let mut e1: EnumSet<Foo> = EnumSet::empty();
+        e1.add(A);
+
+        let mut e2: EnumSet<Foo> = EnumSet::empty();
+        e2.add(B);
+
+        assert!(!e1.intersects(e2));
+    }
+
+    #[test]
+    fn test_overlapping_intersects() {
+        let mut e1: EnumSet<Foo> = EnumSet::empty();
+        e1.add(A);
+
+        let mut e2: EnumSet<Foo> = EnumSet::empty();
+        e2.add(A);
+        e2.add(B);
+
+        assert!(e1.intersects(e2));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // contains and contains_elem
+
+    #[test]
+    fn test_contains() {
+        let mut e1: EnumSet<Foo> = EnumSet::empty();
+        e1.add(A);
+
+        let mut e2: EnumSet<Foo> = EnumSet::empty();
+        e2.add(A);
+        e2.add(B);
+
+        assert!(!e1.contains(e2));
+        assert!(e2.contains(e1));
+    }
+
+    #[test]
+    fn test_contains_elem() {
+        let mut e1: EnumSet<Foo> = EnumSet::empty();
+        e1.add(A);
+        assert!(e1.contains_elem(A));
+        assert!(!e1.contains_elem(B));
+        assert!(!e1.contains_elem(C));
+
+        e1.add(A);
+        e1.add(B);
+        assert!(e1.contains_elem(A));
+        assert!(e1.contains_elem(B));
+        assert!(!e1.contains_elem(C));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // each
+
+    #[test]
+    fn test_each() {
+        let mut e1: EnumSet<Foo> = EnumSet::empty();
+
+        assert_eq!(~[], iter::to_vec(|f| e1.each(f)))
+
+        e1.add(A);
+        assert_eq!(~[A], iter::to_vec(|f| e1.each(f)))
+
+        e1.add(C);
+        assert_eq!(~[A,C], iter::to_vec(|f| e1.each(f)))
+
+        e1.add(C);
+        assert_eq!(~[A,C], iter::to_vec(|f| e1.each(f)))
+
+        e1.add(B);
+        assert_eq!(~[A,B,C], iter::to_vec(|f| e1.each(f)))
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // operators
+
+    #[test]
+    fn test_operators() {
+        let mut e1: EnumSet<Foo> = EnumSet::empty();
+        e1.add(A);
+        e1.add(C);
+
+        let mut e2: EnumSet<Foo> = EnumSet::empty();
+        e2.add(B);
+        e2.add(C);
+
+        let e_union = e1 | e2;
+        assert_eq!(~[A,B,C], iter::to_vec(|f| e_union.each(f)))
+
+        let e_intersection = e1 & e2;
+        assert_eq!(~[C], iter::to_vec(|f| e_intersection.each(f)))
+
+        let e_subtract = e1 - e2;
+        assert_eq!(~[A], iter::to_vec(|f| e_subtract.each(f)))
     }
 }

--- a/src/librustc/util/enum_set.rs
+++ b/src/librustc/util/enum_set.rs
@@ -1,0 +1,88 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core;
+
+#[deriving(Eq, IterBytes)]
+pub struct EnumSet<E> {
+    bits: uint
+}
+
+pub trait CLike {
+    pub fn to_uint(&self) -> uint;
+    pub fn from_uint(uint) -> Self;
+}
+
+fn bit<E:CLike>(e: E) -> uint {
+    1 << e.to_uint()
+}
+
+pub impl<E:CLike> EnumSet<E> {
+    fn empty() -> EnumSet<E> {
+        EnumSet {bits: 0}
+    }
+
+    fn is_empty(&self) -> bool {
+        self.bits == 0
+    }
+
+    fn intersects(&self, e: EnumSet<E>) -> bool {
+        (self.bits & e.bits) != 0
+    }
+
+    fn contains(&self, e: EnumSet<E>) -> bool {
+        (self.bits & e.bits) == e.bits
+    }
+
+    fn add(&mut self, e: E) {
+        self.bits |= bit(e);
+    }
+
+    fn plus(&self, e: E) -> EnumSet<E> {
+        EnumSet {bits: self.bits | bit(e)}
+    }
+
+    fn contains_elem(&self, e: E) -> bool {
+        (self.bits & bit(e)) != 0
+    }
+
+    fn each(&self, f: &fn(E) -> bool) {
+        let mut bits = self.bits;
+        let mut index = 0;
+        while bits != 0 {
+            if (bits & 1) != 0 {
+                let e = CLike::from_uint(index);
+                if !f(e) {
+                    return;
+                }
+            }
+            index += 1;
+            bits >>= 1;
+        }
+    }
+}
+
+impl<E:CLike> core::Sub<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
+    fn sub(&self, e: &EnumSet<E>) -> EnumSet<E> {
+        EnumSet {bits: self.bits & !e.bits}
+    }
+}
+
+impl<E:CLike> core::BitOr<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
+    fn bitor(&self, e: &EnumSet<E>) -> EnumSet<E> {
+        EnumSet {bits: self.bits | e.bits}
+    }
+}
+
+impl<E:CLike> core::BitAnd<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
+    fn bitand(&self, e: &EnumSet<E>) -> EnumSet<E> {
+        EnumSet {bits: self.bits & e.bits}
+    }
+}

--- a/src/test/compile-fail/issue-2611-4.rs
+++ b/src/test/compile-fail/issue-2611-4.rs
@@ -20,7 +20,7 @@ struct E {
 }
 
 impl A for E {
-  fn b<F:Copy + Const,G>(_x: F) -> F { fail!() } //~ ERROR in method `b`, type parameter 0 has 2 bounds, but
+  fn b<F:Copy + Const,G>(_x: F) -> F { fail!() } //~ ERROR type parameter 0 requires `Const`
 }
 
 fn main() {}

--- a/src/test/run-pass/issue-2611-3.rs
+++ b/src/test/run-pass/issue-2611-3.rs
@@ -8,11 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Tests that impl methods are matched to traits exactly:
-// we might be tempted to think matching is contravariant, but if
-// we let an impl method can have more permissive bounds than the trait
-// method it's implementing, the return type might be less specific than
-// needed. Just punt and make it invariant.
+// Tests that impls are allowed to have looser, more permissive bounds
+// than the traits require.
 
 trait A {
   fn b<C:Copy + Const,D>(x: C) -> C;


### PR DESCRIPTION
Use a bitset to represent built-in bounds. There are several places in the language where only builtin bounds (aka kinds) will be accepted, e.g. on closures, destructor type parameters perhaps, and on trait types.

r? @brson
