### PR TITLE
fix incorrect region code based on the old 'self

### DIFF
--- a/doc/tutorial-ffi.md
+++ b/doc/tutorial-ffi.md
@@ -157,7 +157,7 @@ pub struct Unique<T> {
     priv ptr: *mut T
 }
 
-pub impl<'self, T: Owned> Unique<T> {
+pub impl<T: Owned> Unique<T> {
     fn new(value: T) -> Unique<T> {
         unsafe {
             let ptr = malloc(core::sys::size_of::<T>() as size_t) as *mut T;
@@ -168,14 +168,14 @@ pub impl<'self, T: Owned> Unique<T> {
         }
     }
 
-    // the 'self lifetime results in the same semantics as `&*x` with ~T
-    fn borrow(&self) -> &'self T {
-        unsafe { cast::transmute(self.ptr) }
+    // the 'r lifetime results in the same semantics as `&*x` with ~T
+    fn borrow<'r>(&'r self) -> &'r T {
+        unsafe { cast::copy_lifetime(self, &*self.ptr) }
     }
 
-    // the 'self lifetime results in the same semantics as `&mut *x` with ~T
-    fn borrow_mut(&mut self) -> &'self mut T {
-        unsafe { cast::transmute(self.ptr) }
+    // the 'r lifetime results in the same semantics as `&mut *x` with ~T
+    fn borrow_mut<'r>(&'r mut self) -> &'r mut T {
+        unsafe { cast::copy_mut_lifetime(self, &mut *self.ptr) }
     }
 }
 

--- a/src/libcore/cast.rs
+++ b/src/libcore/cast.rs
@@ -110,6 +110,12 @@ pub unsafe fn copy_lifetime<'a,S,T>(_ptr: &'a S, ptr: &T) -> &'a T {
 
 /// Transforms lifetime of the second pointer to match the first.
 #[inline(always)]
+pub unsafe fn copy_mut_lifetime<'a,S,T>(_ptr: &'a mut S, ptr: &mut T) -> &'a mut T {
+    transmute_mut_region(ptr)
+}
+
+/// Transforms lifetime of the second pointer to match the first.
+#[inline(always)]
 pub unsafe fn copy_lifetime_vec<'a,S,T>(_ptr: &'a [S], ptr: &T) -> &'a T {
     transmute_region(ptr)
 }


### PR DESCRIPTION
also removes unnecessary casts from the RcMut implementation
