### PR TITLE
Mark c_vec functions as unsafe again

### DIFF
--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -78,7 +78,7 @@ fn DtorRes(dtor: Option<@fn()>) -> DtorRes {
  * * base - A foreign pointer to a buffer
  * * len - The number of elements in the buffer
  */
-pub fn CVec<T>(base: *mut T, len: uint) -> CVec<T> {
+pub unsafe fn CVec<T>(base: *mut T, len: uint) -> CVec<T> {
     return CVec{
         base: base,
         len: len,
@@ -97,7 +97,7 @@ pub fn CVec<T>(base: *mut T, len: uint) -> CVec<T> {
  * * dtor - A function to run when the value is destructed, useful
  *          for freeing the buffer, etc.
  */
-pub fn c_vec_with_dtor<T>(base: *mut T, len: uint, dtor: @fn())
+pub unsafe fn c_vec_with_dtor<T>(base: *mut T, len: uint, dtor: @fn())
   -> CVec<T> {
     return CVec{
         base: base,
@@ -138,7 +138,7 @@ pub fn set<T:Copy>(t: CVec<T>, ofs: uint, v: T) {
 pub fn len<T>(t: CVec<T>) -> uint { t.len }
 
 /// Returns a pointer to the first element of the vector
-pub fn ptr<T>(t: CVec<T>) -> *mut T { t.base }
+pub unsafe fn ptr<T>(t: CVec<T>) -> *mut T { t.base }
 
 #[cfg(test)]
 mod tests {
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn test_and_I_mean_it() {
         let cv = malloc(16u as size_t);
-        let p = ptr(cv);
+        let p = unsafe { ptr(cv) };
 
         set(cv, 0u, 32u8);
         set(cv, 1u, 33u8);


### PR DESCRIPTION
As noted by @jwise [here](https://github.com/mozilla/rust/commit/52445129fdb4ee847332acbf516ced8f73b7990a#commitcomment-3172192), it's probably a good idea to keep these unsafe.

The lint check won't warn about these because it ignore `unsafe fn` declarations.
