### PR TITLE
Fix typos in comments, debug statements

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -764,7 +764,7 @@ fn _arm_exec_compiled_test(config: config, props: TestProps,
     logv(config, fmt!("executing (%s) %s", config.target, cmdline));
 
     // adb shell dose not forward stdout and stderr of internal result
-    // to stdout and stderr seperately but to stdout only
+    // to stdout and stderr separately but to stdout only
     let mut newargs_out = ~[];
     let mut newargs_err = ~[];
     let subargs = args.args;

--- a/src/libcore/at_vec.rs
+++ b/src/libcore/at_vec.rs
@@ -52,7 +52,7 @@ pub fn capacity<T>(v: @[T]) -> uint {
  * # Arguments
  *
  * * size - An initial size of the vector to reserve
- * * builder - A function that will construct the vector. It recieves
+ * * builder - A function that will construct the vector. It receives
  *             as an argument a function that will push an element
  *             onto the vector being constructed.
  */
@@ -70,7 +70,7 @@ pub fn build_sized<A>(size: uint, builder: &fn(push: &fn(v: A))) -> @[A] {
  *
  * # Arguments
  *
- * * builder - A function that will construct the vector. It recieves
+ * * builder - A function that will construct the vector. It receives
  *             as an argument a function that will push an element
  *             onto the vector being constructed.
  */
@@ -87,7 +87,7 @@ pub fn build<A>(builder: &fn(push: &fn(v: A))) -> @[A] {
  * # Arguments
  *
  * * size - An option, maybe containing initial size of the vector to reserve
- * * builder - A function that will construct the vector. It recieves
+ * * builder - A function that will construct the vector. It receives
  *             as an argument a function that will push an element
  *             onto the vector being constructed.
  */

--- a/src/libcore/rt/io/extensions.rs
+++ b/src/libcore/rt/io/extensions.rs
@@ -11,7 +11,7 @@
 //! Utility mixins that apply to all Readers and Writers
 
 // XXX: Not sure how this should be structured
-// XXX: Iteration should probably be considered seperately
+// XXX: Iteration should probably be considered separately
 
 pub trait ReaderUtil {
 

--- a/src/libcore/task/local_data_priv.rs
+++ b/src/libcore/task/local_data_priv.rs
@@ -133,7 +133,7 @@ unsafe fn get_newsched_local_map(local: *mut LocalStorage) -> TaskLocalMap {
 
 unsafe fn key_to_key_value<T: 'static>(key: LocalDataKey<T>) -> *libc::c_void {
     // Keys are closures, which are (fnptr,envptr) pairs. Use fnptr.
-    // Use reintepret_cast -- transmute would leak (forget) the closure.
+    // Use reinterpret_cast -- transmute would leak (forget) the closure.
     let pair: (*libc::c_void, *libc::c_void) = cast::transmute_copy(&key);
     pair.first()
 }

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -219,7 +219,7 @@ pub fn build<A>(builder: &fn(push: &fn(v: A))) -> ~[A] {
  * # Arguments
  *
  * * size - An option, maybe containing initial size of the vector to reserve
- * * builder - A function that will construct the vector. It recieves
+ * * builder - A function that will construct the vector. It receives
  *             as an argument a function that will push an element
  *             onto the vector being constructed.
  */

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -87,7 +87,7 @@ pub fn nonzero_llsize_of(cx: @CrateContext, t: TypeRef) -> ValueRef {
 }
 
 // Returns the preferred alignment of the given type for the current target.
-// The preffered alignment may be larger than the alignment used when
+// The preferred alignment may be larger than the alignment used when
 // packing the type into structs. This will be used for things like
 // allocations inside a stack frame, which LLVM has a free hand in.
 pub fn llalign_of_pref(cx: @CrateContext, t: TypeRef) -> uint {
@@ -96,7 +96,7 @@ pub fn llalign_of_pref(cx: @CrateContext, t: TypeRef) -> uint {
     }
 }
 
-// Returns the minimum alignment of a type required by the plattform.
+// Returns the minimum alignment of a type required by the platform.
 // This is the alignment that will be used for struct fields, arrays,
 // and similar ABI-mandated things.
 pub fn llalign_of_min(cx: @CrateContext, t: TypeRef) -> uint {

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -31,7 +31,7 @@ use syntax::print::pprust::expr_to_str;
 use syntax::visit;
 
 // vtable resolution looks for places where trait bounds are
-// subsituted in and figures out which vtable is used. There is some
+// substituted in and figures out which vtable is used. There is some
 // extra complication thrown in to support early "opportunistic"
 // vtable resolution. This is a hacky mechanism that is invoked while
 // typechecking function calls (after typechecking non-closure

--- a/src/libstd/arena.rs
+++ b/src/libstd/arena.rs
@@ -20,7 +20,7 @@
 // calling the destructors on them.
 // One subtle point that needs to be addressed is how to handle
 // failures while running the user provided initializer function. It
-// is important to not run the destructor on uninitalized objects, but
+// is important to not run the destructor on uninitialized objects, but
 // how to detect them is somewhat subtle. Since alloc() can be invoked
 // recursively, it is not sufficient to simply exclude the most recent
 // object. To solve this without requiring extra space, we use the low

--- a/src/libstd/flatpipes.rs
+++ b/src/libstd/flatpipes.rs
@@ -15,7 +15,7 @@ or transformed to and from, byte vectors.
 
 The `FlatPort` and `FlatChan` types implement the generic channel and
 port interface for arbitrary types and transport strategies. It can
-particularly be used to send and recieve serializable types over I/O
+particularly be used to send and receive serializable types over I/O
 streams.
 
 `FlatPort` and `FlatChan` implement the same comm traits as pipe-based
@@ -55,7 +55,7 @@ use core::sys::size_of;
 use core::vec;
 
 /**
-A FlatPort, consisting of a `BytePort` that recieves byte vectors,
+A FlatPort, consisting of a `BytePort` that receives byte vectors,
 and an `Unflattener` that converts the bytes to a value.
 
 Create using the constructors in the `serial` and `pod` modules.
@@ -819,7 +819,7 @@ mod test {
             }
         }
 
-        // Reciever task
+        // Receiver task
         do task::spawn || {
             // Wait for a connection
             let (conn, res_chan) = accept_port.recv();
@@ -838,7 +838,7 @@ mod test {
 
             for int::range(0, 10) |i| {
                 let j = port.recv();
-                debug!("receieved %?", j);
+                debug!("received %?", j);
                 assert!(i == j);
             }
 

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -623,7 +623,7 @@ pub mod groups {
                 desc_sep
             };
 
-            // Normalize desc to contain words seperated by one space character
+            // Normalize desc to contain words separated by one space character
             let mut desc_normalized_whitespace = ~"";
             for str::each_word(desc) |word| {
                 desc_normalized_whitespace.push_str(word);

--- a/src/libstd/net_ip.rs
+++ b/src/libstd/net_ip.rs
@@ -420,7 +420,7 @@ mod test {
         if result::is_err(&ga_result) {
             fail!(~"got err result from net::ip::get_addr();")
         }
-        // note really sure how to realiably test/assert
+        // note really sure how to reliably test/assert
         // this.. mostly just wanting to see it work, atm.
         let results = result::unwrap(ga_result);
         debug!("test_get_addr: Number of results for %s: %?",

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -565,7 +565,7 @@ pub mod node {
      *
      * # Fields
      *
-     * * byte_offset = The number of bytes skippen in `content`
+     * * byte_offset = The number of bytes skipped in `content`
      * * byte_len - The number of bytes of `content` to use
      * * char_len - The number of chars in the leaf.
      * * content - Contents of the leaf.

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -32,7 +32,7 @@ pub mod rustrt {
 }
 
 // The name of a test. By convention this follows the rules for rust
-// paths; i.e. it should be a series of identifiers seperated by double
+// paths; i.e. it should be a series of identifiers separated by double
 // colons. This way if some test runner wants to arrange the tests
 // hierarchically it may.
 

--- a/src/libstd/uv_global_loop.rs
+++ b/src/libstd/uv_global_loop.rs
@@ -222,6 +222,6 @@ mod test {
             exit_po.recv();
         };
         debug!(~"test_stress_gl_uv_global_loop_high_level_global_timer"+
-            ~" exiting sucessfully!");
+            ~" exiting successfully!");
     }
 }

--- a/src/libstd/uv_iotask.rs
+++ b/src/libstd/uv_iotask.rs
@@ -243,7 +243,7 @@ fn impl_uv_iotask_async(iotask: &IoTask) {
     exit_po.recv();
 }
 
-// this fn documents the bear minimum neccesary to roll your own
+// this fn documents the bear minimum necessary to roll your own
 // high_level_loop
 #[cfg(test)]
 fn spawn_test_loop(exit_ch: ~Chan<()>) -> IoTask {

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -269,7 +269,7 @@ pub struct sockaddr_in {
 }
 
 // unix size: 28 .. FIXME #1645
-// stuck with 32 becuse of rust padding structs?
+// stuck with 32 because of rust padding structs?
 #[cfg(target_arch="x86_64")]
 pub struct sockaddr_in6 {
     a0: *u8, a1: *u8,
@@ -286,7 +286,7 @@ pub struct sockaddr_in6 {
 }
 
 // unix size: 28 .. FIXME #1645
-// stuck with 32 becuse of rust padding structs?
+// stuck with 32 because of rust padding structs?
 pub type addr_in = addr_in_impl::addr_in;
 #[cfg(unix)]
 pub mod addr_in_impl {
@@ -1376,7 +1376,7 @@ mod test {
             let tcp_init_result = tcp_init(test_loop as *libc::c_void,
                                            tcp_handle_ptr);
             if (tcp_init_result == 0) {
-                debug!(~"sucessful tcp_init_result");
+                debug!(~"successful tcp_init_result");
 
                 debug!(~"building addr...");
                 let addr = ip4_addr(ip, port);

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -697,7 +697,7 @@ fn expand_tts(cx: @ext_ctxt,
     // compiler (which we don't really want to do) and, in any case, only
     // pushed the problem a very small step further back: an error
     // resulting from a parse of the resulting quote is still attributed to
-    // the site the string literal occured, which was in a source file
+    // the site the string literal occurred, which was in a source file
     // _other_ than the one the user has control over. For example, an
     // error in a quote from the protocol compiler, invoked in user code
     // using proto! for example, will be attributed to the pipec.rs file in

--- a/src/rt/rust_log.cpp
+++ b/src/rt/rust_log.cpp
@@ -24,7 +24,7 @@
  */
 static lock_and_signal _log_lock;
 /**
- * Indicates whether we are outputing to the console.
+ * Indicates whether we are outputting to the console.
  * Protected by _log_lock;
  */
 static bool _log_to_console = true;

--- a/src/rt/rust_signal.h
+++ b/src/rt/rust_signal.h
@@ -11,7 +11,7 @@
 #ifndef RUST_SIGNAL_H
 #define RUST_SIGNAL_H
 
-// Just an abstrict class that reperesents something that can be signalled
+// Just an abstract class that represents something that can be signalled
 class rust_signal {
 public:
     virtual void signal() = 0;

--- a/src/test/compile-fail/borrowck-lend-flow-match.rs
+++ b/src/test/compile-fail/borrowck-lend-flow-match.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-pretty -- comments are infaithfully preserved
+// xfail-pretty -- comments are unfaithfully preserved
 
 #[allow(unused_variable)];
 #[allow(dead_assignment)];

--- a/src/test/compile-fail/borrowck-pat-reassign-binding.rs
+++ b/src/test/compile-fail/borrowck-pat-reassign-binding.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-pretty -- comments are infaithfully preserved
+// xfail-pretty -- comments are unfaithfully preserved
 
 fn main() {
     let mut x: Option<int> = None;

--- a/src/test/compile-fail/issue-1448-2.rs
+++ b/src/test/compile-fail/issue-1448-2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Regresion test for issue #1448 and #1386
+// Regression test for issue #1448 and #1386
 
 fn main() {
     debug!("%u", 10i); //~ ERROR mismatched types

--- a/src/test/compile-fail/issue-4935.rs
+++ b/src/test/compile-fail/issue-4935.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Regresion test for issue #4935
+// Regression test for issue #4935
 
 fn foo(a: uint) {}
 fn main() { foo(5, 6) } //~ ERROR this function takes 1 parameter but 2 parameters were supplied

--- a/src/test/run-fail/too-much-recursion-unwinding.rs
+++ b/src/test/run-fail/too-much-recursion-unwinding.rs
@@ -11,7 +11,7 @@
 // xfail-test leaks
 // error-pattern:ran out of stack
 
-// Test that the task fails after hiting the recursion limit
+// Test that the task fails after hitting the recursion limit
 // during unwinding
 
 fn recurse() {

--- a/src/test/run-pass/extern-pass-TwoU64s.rs
+++ b/src/test/run-pass/extern-pass-TwoU64s.rs
@@ -13,7 +13,7 @@
 
 // xfail-fast This works standalone on windows but not with check-fast.
 // possibly because there is another test that uses this extern fn but gives it
-// a diferent signature
+// a different signature
 
 #[deriving(Eq)]
 struct TwoU64s {

--- a/src/test/run-pass/issue-2989.rs
+++ b/src/test/run-pass/issue-2989.rs
@@ -21,7 +21,7 @@ impl methods for () {
 }
 
 // the position of this function is significant! - if it comes before methods
-// then it works, if it comes after it then it doesnt!
+// then it works, if it comes after it then it doesn't!
 fn to_bools(bitv: Storage) -> ~[bool] {
     vec::from_fn(8, |i| {
         let w = i / 64;

--- a/src/test/run-pass/while-cont.rs
+++ b/src/test/run-pass/while-cont.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Issue #825: Should recheck the loop contition after continuing
+// Issue #825: Should recheck the loop condition after continuing
 pub fn main() {
     let mut i = 1;
     while i > 0 {


### PR DESCRIPTION
Hi there,

Really enjoying Rust. Noticed a few typos so I searched around for a few more--here's some fixes.

Ran `make check` and got `summary of 24 test runs: 4868 passed; 0 failed; 330 ignored`.

Thanks!

Sean
