### PR TITLE
Better error message for certain classes of unresolved imports

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2487,7 +2487,7 @@ pub impl Resolver {
                     if module_name == ~"???" {
                         self.session.span_err(span {lo: span.lo, hi: span.lo +
                                               BytePos(str::len(*segment_name)), expn_info:
-                                              span.expn_info}, fmt!("unresolved import.  maybe \
+                                              span.expn_info}, fmt!("unresolved import. maybe \
                                                                     a missing 'extern mod %s'?",
                                                                     *segment_name));
                         return Failed;

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2487,8 +2487,8 @@ pub impl Resolver {
                     if module_name == ~"???" {
                         self.session.span_err(span {lo: span.lo, hi: span.lo +
                                               BytePos(str::len(*segment_name)), expn_info:
-                                              span.expn_info}, fmt!("unresolved import.  perhaps \
-                                                                    you forgot an 'extern mod %s'?",
+                                              span.expn_info}, fmt!("unresolved import.  maybe \
+                                                                    a missing 'extern mod %s'?",
                                                                     *segment_name));
                         return Failed;
                     }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -64,7 +64,7 @@ use syntax::attr::{attr_metas, contains_name, attrs_contains_name};
 use syntax::parse::token::ident_interner;
 use syntax::parse::token::special_idents;
 use syntax::print::pprust::path_to_str;
-use syntax::codemap::{span, dummy_sp};
+use syntax::codemap::{span, dummy_sp, BytePos};
 use syntax::visit::{default_visitor, mk_vt, Visitor, visit_block};
 use syntax::visit::{visit_crate, visit_expr, visit_expr_opt};
 use syntax::visit::{visit_foreign_item, visit_item};
@@ -2482,6 +2482,16 @@ pub impl Resolver {
                                               TypeNS,
                                               name_search_type) {
                 Failed => {
+                    let segment_name = self.session.str_of(name);
+                    let module_name = self.module_to_str(search_module);
+                    if module_name == ~"???" {
+                        self.session.span_err(span {lo: span.lo, hi: span.lo +
+                                              BytePos(str::len(*segment_name)), expn_info:
+                                              span.expn_info}, fmt!("unresolved import.  perhaps \
+                                                                    you forgot an 'extern mod %s'?",
+                                                                    *segment_name));
+                        return Failed;
+                    }
                     self.session.span_err(span, ~"unresolved name");
                     return Failed;
                 }

--- a/src/test/compile-fail/issue-1697.rs
+++ b/src/test/compile-fail/issue-1697.rs
@@ -10,7 +10,7 @@
 
 // Testing that we don't fail abnormally after hitting the errors
 
-use unresolved::*; //~ ERROR unresolved name
+use unresolved::*; //~ ERROR unresolved import. maybe a missing
 //~^ ERROR failed to resolve import
 
 fn main() {

--- a/src/test/compile-fail/unresolved-import.rs
+++ b/src/test/compile-fail/unresolved-import.rs
@@ -1,0 +1,12 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use foo::bar; //~ ERROR unresolved import. maybe a missing
+              //~^ ERROR failed to resolve import


### PR DESCRIPTION
This improves error reporting for the following class of imports:

``` rust
use foo::bar;
```

Where foo, the topmost module, is unresolved. It now results in:

``` text
/tmp/foo.rs:1:4: 1:7 error: unresolved import.  perhapsyou forgot an 'extern mod foo'?
/tmp/foo.rs:1 use foo::bar;
                  ^~~
/tmp/foo.rs:1:4: 1:12 error: failed to resolve import: foo::bar
/tmp/foo.rs:1 use foo::bar;
                  ^~~~~~~~
error: failed to resolve imports
error: aborting due to 3 previous errors
```

This is the first of a series of changes I plan on making to unresolved name error messages.
