### PR TITLE
Created utility uninhabited type

### DIFF
--- a/src/libcore/util.rs
+++ b/src/libcore/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -73,6 +73,20 @@ impl Drop for NonCopyable {
 }
 
 pub fn NonCopyable() -> NonCopyable { NonCopyable { i: () } }
+
+
+/// A type with no inhabitants
+pub enum Void { }
+
+pub impl Void {
+    /// A utility function for ignoring this uninhabited type
+    fn uninhabited(&self) -> ! {
+        match *self {
+            // Nothing to match on
+        }
+    }
+}
+
 
 /**
 A utility function for indicating unreachable code. It will fail if


### PR DESCRIPTION
In this commit I added a useful utility type, named Void, that encapsulates the
doable but annoying job of creating an uninhabited type. As well, a function on
that type, named absurd, was created which is useful for ignoring the result of
matching on that type. No unit tests were created because it is not possible to
create an instance of this type to test the usage of.

This type is useful because it is like NonCopyable in that it can be used to
create a type with special characteristics without special bloat. For instance,
instead of typing pub struct PhantomType { priv contents : () } for each void
type one may want to use one can simply type pub struct PhantomType (Void);.
This type make such special cases much easier to write.
