### PR TITLE
remove vecs_implicitly_copyable from libstd

### DIFF
--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -60,7 +60,6 @@ they contained the following prologue:
 // Don't link to core. We are core.
 #[no_core];
 
-#[warn(vecs_implicitly_copyable)];
 #[deny(non_camel_case_types)];
 #[allow(deprecated_mutable_fields)];
 

--- a/src/libstd/arc.rs
+++ b/src/libstd/arc.rs
@@ -499,7 +499,7 @@ mod tests {
 
             let arc_v = p.recv();
 
-            let v = *arc::get::<~[int]>(&arc_v);
+            let v = copy *arc::get::<~[int]>(&arc_v);
             assert!(v[3] == 4);
         };
 

--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -238,8 +238,8 @@ mod test {
 
     #[test]
     fn test_sendable_future() {
-        let expected = ~"schlorf";
-        let f = Cell(do spawn { copy expected });
+        let expected = "schlorf";
+        let f = Cell(do spawn { expected });
         do task::spawn {
             let mut f = f.take();
             let actual = f.get();

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -229,13 +229,13 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
     let l = args.len();
     let mut i = 0;
     while i < l {
-        let cur = args[i];
+        let cur = copy args[i];
         let curlen = cur.len();
         if !is_arg(cur) {
             free.push(cur);
         } else if cur == ~"--" {
             let mut j = i + 1;
-            while j < l { free.push(args[j]); j += 1; }
+            while j < l { free.push(copy args[j]); j += 1; }
             break;
         } else {
             let mut names;
@@ -248,8 +248,8 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
                     names = ~[Long(tail)];
                 } else {
                     names =
-                        ~[Long(tail_eq[0])];
-                    i_arg = Some(tail_eq[1]);
+                        ~[Long(copy tail_eq[0])];
+                    i_arg = Some(copy tail_eq[1]);
                 }
             } else {
                 let mut j = 1;
@@ -266,7 +266,7 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
                        interpreted correctly
                     */
 
-                    match find_opt(opts, opt) {
+                    match find_opt(opts, copy opt) {
                       Some(id) => last_valid_opt_id = Some(id),
                       None => {
                         let arg_follows =
@@ -292,7 +292,7 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
             let mut name_pos = 0;
             for names.each() |nm| {
                 name_pos += 1;
-                let optid = match find_opt(opts, *nm) {
+                let optid = match find_opt(opts, copy *nm) {
                   Some(id) => id,
                   None => return Err(UnrecognizedOption(name_str(nm)))
                 };
@@ -305,18 +305,18 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
                   }
                   Maybe => {
                     if !i_arg.is_none() {
-                        vals[optid].push(Val(i_arg.get()));
+                        vals[optid].push(Val((copy i_arg).get()));
                     } else if name_pos < names.len() ||
                                   i + 1 == l || is_arg(args[i + 1]) {
                         vals[optid].push(Given);
-                    } else { i += 1; vals[optid].push(Val(args[i])); }
+                    } else { i += 1; vals[optid].push(Val(copy args[i])); }
                   }
                   Yes => {
                     if !i_arg.is_none() {
-                        vals[optid].push(Val(i_arg.get()));
+                        vals[optid].push(Val((copy i_arg).get()));
                     } else if i + 1 == l {
                         return Err(ArgumentMissing(name_str(nm)));
-                    } else { i += 1; vals[optid].push(Val(args[i])); }
+                    } else { i += 1; vals[optid].push(Val(copy args[i])); }
                   }
                 }
             }
@@ -346,7 +346,7 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
 
 fn opt_vals(mm: &Matches, nm: &str) -> ~[Optval] {
     return match find_opt(mm.opts, mkname(nm)) {
-      Some(id) => mm.vals[id],
+      Some(id) => copy mm.vals[id],
       None => {
         error!("No option '%s' defined", nm);
         fail!()
@@ -354,7 +354,7 @@ fn opt_vals(mm: &Matches, nm: &str) -> ~[Optval] {
     };
 }
 
-fn opt_val(mm: &Matches, nm: &str) -> Optval { return opt_vals(mm, nm)[0]; }
+fn opt_val(mm: &Matches, nm: &str) -> Optval { copy opt_vals(mm, nm)[0] }
 
 /// Returns true if an option was matched
 pub fn opt_present(mm: &Matches, nm: &str) -> bool {
@@ -547,25 +547,29 @@ pub mod groups {
     // translate OptGroup into Opt
     // (both short and long names correspond to different Opts)
     pub fn long_to_short(lopt: &OptGroup) -> ~[Opt] {
-        match ((*lopt).short_name.len(),
-               (*lopt).long_name.len()) {
+        let OptGroup{short_name: short_name,
+                     long_name: long_name,
+                     hasarg: hasarg,
+                     occur: occur,
+                     _} = copy *lopt;
 
+        match (short_name.len(), long_name.len()) {
            (0,0) => fail!(~"this long-format option was given no name"),
 
-           (0,_) => ~[Opt {name:   Long(((*lopt).long_name)),
-                           hasarg: (*lopt).hasarg,
-                           occur:  (*lopt).occur}],
+           (0,_) => ~[Opt {name: Long((long_name)),
+                           hasarg: hasarg,
+                           occur: occur}],
 
-           (1,0) => ~[Opt {name: Short(str::char_at((*lopt).short_name, 0)),
-                           hasarg: (*lopt).hasarg,
-                           occur:  (*lopt).occur}],
+           (1,0) => ~[Opt {name: Short(str::char_at(short_name, 0)),
+                           hasarg: hasarg,
+                           occur: occur}],
 
-           (1,_) => ~[Opt {name: Short(str::char_at((*lopt).short_name, 0)),
-                           hasarg: (*lopt).hasarg,
-                           occur:  (*lopt).occur},
-                      Opt {name:   Long(((*lopt).long_name)),
-                           hasarg: (*lopt).hasarg,
-                           occur:  (*lopt).occur}],
+           (1,_) => ~[Opt {name: Short(str::char_at(short_name, 0)),
+                           hasarg: hasarg,
+                           occur:  occur},
+                      Opt {name:   Long((long_name)),
+                           hasarg: hasarg,
+                           occur:  occur}],
 
            (_,_) => fail!(~"something is wrong with the long-form opt")
         }
@@ -586,11 +590,12 @@ pub mod groups {
         let desc_sep = ~"\n" + str::repeat(~" ", 24);
 
         let rows = vec::map(opts, |optref| {
-            let short_name = (*optref).short_name;
-            let long_name = (*optref).long_name;
-            let hint = (*optref).hint;
-            let desc = (*optref).desc;
-            let hasarg = (*optref).hasarg;
+            let OptGroup{short_name: short_name,
+                         long_name: long_name,
+                         hint: hint,
+                         desc: desc,
+                         hasarg: hasarg,
+                         _} = copy *optref;
 
             let mut row = str::repeat(~" ", 4);
 
@@ -620,7 +625,7 @@ pub mod groups {
             row += if rowlen < 24 {
                 str::repeat(~" ", 24 - rowlen)
             } else {
-                desc_sep
+                copy desc_sep
             };
 
             // Normalize desc to contain words seperated by one space character
@@ -892,7 +897,7 @@ mod tests {
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => {
-            error!(fail_str(f));
+            error!(fail_str(copy f));
             check_fail_type(f, UnexpectedArgument_);
           }
           _ => fail!()

--- a/src/libstd/net_ip.rs
+++ b/src/libstd/net_ip.rs
@@ -175,7 +175,7 @@ pub mod v4 {
     pub fn parse_addr(ip: &str) -> IpAddr {
         match try_parse_addr(ip) {
           result::Ok(addr) => addr,
-          result::Err(ref err_data) => fail!(err_data.err_msg)
+          result::Err(ref err_data) => fail!(copy err_data.err_msg)
         }
     }
     // the simple, old style numberic representation of
@@ -272,7 +272,7 @@ pub mod v6 {
     pub fn parse_addr(ip: &str) -> IpAddr {
         match try_parse_addr(ip) {
           result::Ok(addr) => addr,
-          result::Err(copy err_data) => fail!(err_data.err_msg)
+          result::Err(copy err_data) => fail!(copy err_data.err_msg)
         }
     }
     pub fn try_parse_addr(ip: &str) -> result::Result<IpAddr,ParseAddrErr> {

--- a/src/libstd/num/bigint.rs
+++ b/src/libstd/num/bigint.rs
@@ -16,7 +16,6 @@ A BigUint is represented as an array of BigDigits.
 A BigInt is a combination of BigUint and Sign.
 */
 
-#[deny(vecs_implicitly_copyable)];
 #[deny(deprecated_mutable_fields)];
 
 use core::cmp::{Eq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater};

--- a/src/libstd/priority_queue.rs
+++ b/src/libstd/priority_queue.rs
@@ -270,8 +270,8 @@ mod tests {
     }
 
     fn check_to_vec(data: ~[int]) {
-        let heap = from_vec(data);
-        assert!(merge_sort(heap.to_vec(), le) == merge_sort(data, le));
+        let heap = from_vec(copy data);
+        assert!(merge_sort((copy heap).to_vec(), le) == merge_sort(data, le));
         assert!(heap.to_sorted_vec() == merge_sort(data, le));
     }
 

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -822,7 +822,7 @@ pub mod node {
                   None => break,
                   Some(x) => {
                     //FIXME (#2744): Replace with memcpy or something similar
-                    let local_buf: ~[u8] = cast::transmute(*x.content);
+                    let local_buf: ~[u8] = cast::transmute(copy *x.content);
                     let mut i = x.byte_offset;
                     while i < x.byte_len {
                         buf[offset] = local_buf[i];
@@ -1299,12 +1299,12 @@ mod tests {
         let buf = @ mut ~"1234567890";
         let mut i = 0;
         while i < 10 {
-            let a = *buf;
-            let b = *buf;
+            let a = copy *buf;
+            let b = copy *buf;
             *buf = a + b;
             i+=1;
         }
-        let sample = @*buf;
+        let sample = @copy *buf;
         let r      = of_str(sample);
         assert!(char_len(r) == str::char_len(*sample));
         assert!(rope_to_string(r) == *sample);
@@ -1335,12 +1335,12 @@ mod tests {
         let buf = @ mut ~"1234567890";
         let mut i = 0;
         while i < 10 {
-            let a = *buf;
-            let b = *buf;
+            let a = copy *buf;
+            let b = copy *buf;
             *buf = a + b;
             i+=1;
         }
-        let sample = @*buf;
+        let sample = @copy *buf;
         let r      = of_str(sample);
 
         let mut len = 0u;
@@ -1358,15 +1358,15 @@ mod tests {
     #[test]
     fn bal1() {
         let init = @~"1234567890";
-        let buf  = @mut * init;
+        let buf  = @mut copy *init;
         let mut i = 0;
         while i < 8 {
-            let a = *buf;
-            let b = *buf;
+            let a = copy *buf;
+            let b = copy *buf;
             *buf = a + b;
             i+=1;
         }
-        let sample = @*buf;
+        let sample = @copy *buf;
         let r1     = of_str(sample);
         let mut r2 = of_str(init);
         i = 0;

--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -177,7 +177,7 @@ pub fn sha1() -> @Sha1 {
             let b = (hpart >> 16u32 & 0xFFu32) as u8;
             let c = (hpart >> 8u32 & 0xFFu32) as u8;
             let d = (hpart & 0xFFu32) as u8;
-            rs = vec::append(rs, ~[a, b, c, d]);
+            rs = vec::append(copy rs, ~[a, b, c, d]);
         }
         return rs;
     }
@@ -381,7 +381,7 @@ mod tests {
         for vec::each(tests) |t| {
             sh.input_str(t.input);
             let out = sh.result();
-            check_vec_eq(t.output, out);
+            check_vec_eq(copy t.output, out);
 
             let out_str = sh.result_str();
             assert!((out_str.len() == 40));
@@ -402,7 +402,7 @@ mod tests {
                 left = left - take;
             }
             let out = sh.result();
-            check_vec_eq(t.output, out);
+            check_vec_eq(copy t.output, out);
 
             let out_str = sh.result_str();
             assert!((out_str.len() == 40));

--- a/src/libstd/std.rc
+++ b/src/libstd/std.rc
@@ -26,7 +26,6 @@ not required in or otherwise suitable for the core library.
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-#[allow(vecs_implicitly_copyable)];
 #[deny(non_camel_case_types)];
 
 // Allow mutable fields only in stage0.

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -42,9 +42,9 @@ pub enum TestName {
 }
 impl ToStr for TestName {
     fn to_str(&self) -> ~str {
-        match self {
-            &StaticTestName(s) => s.to_str(),
-            &DynTestName(s) => s.to_str()
+        match copy *self {
+            StaticTestName(s) => s.to_str(),
+            DynTestName(s) => s.to_str()
         }
     }
 }
@@ -145,7 +145,7 @@ pub fn parse_opts(args: &[~str]) -> OptRes {
 
     let filter =
         if vec::len(matches.free) > 0 {
-            option::Some(matches.free[0])
+            option::Some(copy (matches).free[0])
         } else { option::None };
 
     let run_ignored = getopts::opt_present(&matches, ~"ignored");
@@ -203,7 +203,7 @@ pub fn run_tests_console(opts: &TestOpts,
 
     fn callback(event: &TestEvent, st: &mut ConsoleTestState) {
         debug!("callback(event=%?)", event);
-        match *event {
+        match copy *event {
           TeFiltered(ref filtered_tests) => {
             st.total = filtered_tests.len();
             let noun = if st.total != 1 { ~"tests" } else { ~"test" };
@@ -213,7 +213,7 @@ pub fn run_tests_console(opts: &TestOpts,
               fmt!("test %s ... ", test.name.to_str())),
           TeResult(copy test, result) => {
             match st.log_out {
-                Some(f) => write_log(f, result, &test),
+                Some(f) => write_log(f, copy result, &test),
                 None => ()
             }
             match result {
@@ -412,7 +412,7 @@ fn run_tests(opts: &TestOpts,
              callback: @fn(e: TestEvent)) {
     let mut filtered_tests = filter_tests(opts, tests);
 
-    let filtered_descs = filtered_tests.map(|t| t.desc);
+    let filtered_descs = filtered_tests.map(|t| copy t.desc);
     callback(TeFiltered(filtered_descs));
 
     let (filtered_tests, filtered_benchs) =
@@ -442,7 +442,7 @@ fn run_tests(opts: &TestOpts,
                 // We are doing one test at a time so we can print the name
                 // of the test before we run it. Useful for debugging tests
                 // that hang forever.
-                callback(TeWait(test.desc));
+                callback(TeWait(copy test.desc));
             }
             run_test(!opts.run_tests, test, ch.clone());
             pending += 1;
@@ -450,7 +450,7 @@ fn run_tests(opts: &TestOpts,
 
         let (desc, result) = p.recv();
         if concurrency != 1 {
-            callback(TeWait(desc));
+            callback(TeWait(copy desc));
         }
         callback(TeResult(desc, result));
         pending -= 1;
@@ -565,7 +565,7 @@ pub fn run_test(force_ignore: bool,
             let task_result = result_future.unwrap().recv();
             let test_result = calc_result(&desc,
                                           task_result == task::Success);
-            monitor_ch.send((desc, test_result));
+            monitor_ch.send((copy desc, test_result));
         }
     }
 
@@ -850,7 +850,7 @@ mod tests {
           either::Left(copy o) => o,
           _ => fail!(~"Malformed arg in first_free_arg_should_be_a_filter")
         };
-        assert!(~"filter" == opts.filter.get());
+        assert!("filter" == (copy opts.filter).get());
     }
 
     #[test]
@@ -931,7 +931,7 @@ mod tests {
             for vec::each(names) |name| {
                 let test = TestDescAndFn {
                     desc: TestDesc {
-                        name: DynTestName(*name),
+                        name: DynTestName(copy *name),
                         ignore: false,
                         should_fail: false
                     },

--- a/src/libstd/timer.rs
+++ b/src/libstd/timer.rs
@@ -175,9 +175,9 @@ extern fn delayed_send_close_cb(handle: *uv::ll::uv_timer_t) {
 
 #[cfg(test)]
 mod test {
-
     use timer::*;
     use uv;
+    use core::cell::Cell;
     use core::rand::RngUtil;
     use core::pipes::{stream, SharedChan};
 
@@ -277,11 +277,11 @@ mod test {
 
         for old_iter::repeat(times as uint) {
             let mut rng = rand::rng();
-            let expected = rng.gen_str(16u);
+            let expected = Cell(rng.gen_str(16u));
             let (test_po, test_ch) = stream::<~str>();
             let hl_loop_clone = hl_loop.clone();
             do task::spawn() {
-                delayed_send(&hl_loop_clone, 50u, &test_ch, expected);
+                delayed_send(&hl_loop_clone, 50u, &test_ch, expected.take());
             };
 
             match recv_timeout(&hl_loop, 1u, &test_po) {

--- a/src/libstd/workcache.rs
+++ b/src/libstd/workcache.rs
@@ -339,7 +339,7 @@ impl TPrep for Prep {
                               &self.declared_inputs) &&
             self.all_fresh("discovered input", disc_in) &&
             self.all_fresh("discovered output", disc_out) => {
-                Work::new(@mut *self, Left(json_decode(*res)))
+                Work::new(@mut copy *self, Left(json_decode(*res)))
             }
 
             _ => {
@@ -358,7 +358,7 @@ impl TPrep for Prep {
                     let v = blk(&exe);
                     send_one(chan, (exe, v));
                 }
-                Work::new(@mut *self, Right(port))
+                Work::new(@mut copy *self, Right(port))
             }
         }
     }


### PR DESCRIPTION
I removed some of the copies, but most are just made explicit. The usage in `libcore` was already fixed, but the attribute was only set to warn (not removed).
