### PR TITLE
Use a specialized string interner to reduce the need for owned strings

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -698,8 +698,8 @@ pub fn exported_name(sess: Session,
                      vers: &str) -> ~str {
     return mangle(sess,
             vec::append_one(
-            vec::append_one(path, path_name(sess.ident_of(hash.to_owned()))),
-            path_name(sess.ident_of(vers.to_owned()))));
+            vec::append_one(path, path_name(sess.ident_of(hash))),
+            path_name(sess.ident_of(vers))));
 }
 
 pub fn mangle_exported_name(ccx: @CrateContext,
@@ -717,14 +717,14 @@ pub fn mangle_internal_name_by_type_only(ccx: @CrateContext,
     let s = ppaux::ty_to_short_str(ccx.tcx, t);
     let hash = get_symbol_hash(ccx, t);
     return mangle(ccx.sess,
-        ~[path_name(ccx.sess.ident_of(name.to_owned())),
+        ~[path_name(ccx.sess.ident_of(name)),
           path_name(ccx.sess.ident_of(s)),
-          path_name(ccx.sess.ident_of(hash.to_owned()))]);
+          path_name(ccx.sess.ident_of(hash))]);
 }
 
 pub fn mangle_internal_name_by_path_and_seq(ccx: @CrateContext,
                                             path: path,
-                                            flav: ~str) -> ~str {
+                                            flav: &str) -> ~str {
     return mangle(ccx.sess,
                   vec::append_one(path, path_name((ccx.names)(flav))));
 }
@@ -733,7 +733,7 @@ pub fn mangle_internal_name_by_path(ccx: @CrateContext, path: path) -> ~str {
     return mangle(ccx.sess, path);
 }
 
-pub fn mangle_internal_name_by_seq(ccx: @CrateContext, flav: ~str) -> ~str {
+pub fn mangle_internal_name_by_seq(ccx: @CrateContext, flav: &str) -> ~str {
     return fmt!("%s_%u", flav, (ccx.names)(flav).repr);
 }
 

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -284,8 +284,8 @@ pub impl Session_ {
     fn str_of(@self, id: ast::ident) -> @~str {
         self.parse_sess.interner.get(id)
     }
-    fn ident_of(@self, st: ~str) -> ast::ident {
-        self.parse_sess.interner.intern(@st)
+    fn ident_of(@self, st: &str) -> ast::ident {
+        self.parse_sess.interner.intern(st)
     }
     fn intr(@self) -> @syntax::parse::token::ident_interner {
         self.parse_sess.interner

--- a/src/librustc/front/core_inject.rs
+++ b/src/librustc/front/core_inject.rs
@@ -42,7 +42,7 @@ fn inject_libcore_ref(sess: Session,
             let n1 = sess.next_node_id();
             let vi1 = @ast::view_item {
                 node: ast::view_item_extern_mod(
-                        sess.ident_of(~"core"), ~[], n1),
+                        sess.ident_of("core"), ~[], n1),
                 attrs: ~[
                     spanned(ast::attribute_ {
                         style: ast::attr_inner,
@@ -78,8 +78,8 @@ fn inject_libcore_ref(sess: Session,
                 span: dummy_sp(),
                 global: false,
                 idents: ~[
-                    sess.ident_of(~"core"),
-                    sess.ident_of(~"prelude")
+                    sess.ident_of("core"),
+                    sess.ident_of("prelude")
                 ],
                 rp: None,
                 types: ~[]

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -274,7 +274,7 @@ fn mk_std(cx: &TestCtxt) -> @ast::view_item {
     let vers = nospan(vers);
     let mi = ast::meta_name_value(@~"vers", vers);
     let mi = nospan(mi);
-    let id_std = cx.sess.ident_of(~"std");
+    let id_std = cx.sess.ident_of("std");
     let vi = if is_std(cx) {
         ast::view_item_use(
             ~[@nospan(ast::view_path_simple(id_std,
@@ -322,7 +322,7 @@ fn mk_test_module(cx: &TestCtxt) -> @ast::item {
         attr::mk_attr(attr::mk_word_item(@~"!resolve_unexported"));
 
     let item = ast::item {
-        ident: cx.sess.ident_of(~"__test"),
+        ident: cx.sess.ident_of("__test"),
         attrs: ~[resolve_unexported_attr],
         id: cx.sess.next_node_id(),
         node: item_,

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -70,7 +70,7 @@ pub fn get_item_path(tcx: ty::ctxt, def: ast::def_id) -> ast_map::path {
     // FIXME #1920: This path is not always correct if the crate is not linked
     // into the root namespace.
     vec::append(~[ast_map::path_mod(tcx.sess.ident_of(
-        /*bad*/copy *cdata.name))], path)
+        *cdata.name))], path)
 }
 
 pub enum found_ast {

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -294,10 +294,10 @@ fn item_path(intr: @ident_interner, item_doc: ebml::Doc) -> ast_map::path {
     for reader::docs(path_doc) |tag, elt_doc| {
         if tag == tag_path_elt_mod {
             let str = reader::doc_as_str(elt_doc);
-            result.push(ast_map::path_mod(intr.intern(@str)));
+            result.push(ast_map::path_mod(intr.intern(str)));
         } else if tag == tag_path_elt_name {
             let str = reader::doc_as_str(elt_doc);
-            result.push(ast_map::path_name(intr.intern(@str)));
+            result.push(ast_map::path_name(intr.intern(str)));
         } else {
             // ignore tag_path_len element
         }
@@ -311,7 +311,7 @@ fn item_name(intr: @ident_interner, item: ebml::Doc) -> ast::ident {
     do reader::with_doc_data(name) |data| {
         let string = str::from_bytes_slice(data);
         match intr.find_equiv(&StringRef(string)) {
-            None => intr.intern(@(string.to_owned())),
+            None => intr.intern(string),
             Some(val) => val,
         }
     }
@@ -828,7 +828,7 @@ pub fn get_type_name_if_impl(intr: @ident_interner,
     }
 
     for reader::tagged_docs(item, tag_item_impl_type_basename) |doc| {
-        return Some(intr.intern(@str::from_bytes(reader::doc_data(doc))));
+        return Some(intr.intern(str::from_bytes(reader::doc_data(doc))));
     }
 
     return None;
@@ -1080,7 +1080,7 @@ pub fn get_crate_deps(intr: @ident_interner, data: @~[u8]) -> ~[crate_dep] {
     }
     for reader::tagged_docs(depsdoc, tag_crate_dep) |depdoc| {
         deps.push(crate_dep {cnum: crate_num,
-                  name: intr.intern(@docstr(depdoc, tag_crate_dep_name)),
+                  name: intr.intern(docstr(depdoc, tag_crate_dep_name)),
                   vers: @docstr(depdoc, tag_crate_dep_vers),
                   hash: @docstr(depdoc, tag_crate_dep_hash)});
         crate_num += 1;

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1163,7 +1163,7 @@ trait fake_ext_ctxt {
     fn cfg(&self) -> ast::crate_cfg;
     fn parse_sess(&self) -> @mut parse::ParseSess;
     fn call_site(&self) -> span;
-    fn ident_of(&self, st: ~str) -> ast::ident;
+    fn ident_of(&self, st: &str) -> ast::ident;
 }
 
 #[cfg(test)]
@@ -1180,8 +1180,8 @@ impl fake_ext_ctxt for fake_session {
             expn_info: None
         }
     }
-    fn ident_of(&self, st: ~str) -> ast::ident {
-        self.interner.intern(@st)
+    fn ident_of(&self, st: &str) -> ast::ident {
+        self.interner.intern(st)
     }
 }
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -708,7 +708,7 @@ pub struct PrimitiveTypeTable {
 }
 
 pub impl PrimitiveTypeTable {
-    fn intern(&mut self, intr: @ident_interner, string: @~str,
+    fn intern(&mut self, intr: @ident_interner, string: &str,
               primitive_type: prim_ty) {
         let ident = intr.intern(string);
         self.primitive_types.insert(ident, primitive_type);
@@ -720,22 +720,22 @@ pub fn PrimitiveTypeTable(intr: @ident_interner) -> PrimitiveTypeTable {
         primitive_types: HashMap::new()
     };
 
-    table.intern(intr, @~"bool",    ty_bool);
-    table.intern(intr, @~"char",    ty_int(ty_char));
-    table.intern(intr, @~"float",   ty_float(ty_f));
-    table.intern(intr, @~"f32",     ty_float(ty_f32));
-    table.intern(intr, @~"f64",     ty_float(ty_f64));
-    table.intern(intr, @~"int",     ty_int(ty_i));
-    table.intern(intr, @~"i8",      ty_int(ty_i8));
-    table.intern(intr, @~"i16",     ty_int(ty_i16));
-    table.intern(intr, @~"i32",     ty_int(ty_i32));
-    table.intern(intr, @~"i64",     ty_int(ty_i64));
-    table.intern(intr, @~"str",     ty_str);
-    table.intern(intr, @~"uint",    ty_uint(ty_u));
-    table.intern(intr, @~"u8",      ty_uint(ty_u8));
-    table.intern(intr, @~"u16",     ty_uint(ty_u16));
-    table.intern(intr, @~"u32",     ty_uint(ty_u32));
-    table.intern(intr, @~"u64",     ty_uint(ty_u64));
+    table.intern(intr, "bool",    ty_bool);
+    table.intern(intr, "char",    ty_int(ty_char));
+    table.intern(intr, "float",   ty_float(ty_f));
+    table.intern(intr, "f32",     ty_float(ty_f32));
+    table.intern(intr, "f64",     ty_float(ty_f64));
+    table.intern(intr, "int",     ty_int(ty_i));
+    table.intern(intr, "i8",      ty_int(ty_i8));
+    table.intern(intr, "i16",     ty_int(ty_i16));
+    table.intern(intr, "i32",     ty_int(ty_i32));
+    table.intern(intr, "i64",     ty_int(ty_i64));
+    table.intern(intr, "str",     ty_str);
+    table.intern(intr, "uint",    ty_uint(ty_u));
+    table.intern(intr, "u8",      ty_uint(ty_u8));
+    table.intern(intr, "u16",     ty_uint(ty_u16));
+    table.intern(intr, "u32",     ty_uint(ty_u32));
+    table.intern(intr, "u64",     ty_uint(ty_u64));
 
     return table;
 }
@@ -1675,7 +1675,7 @@ pub impl Resolver {
 
             let mut current_module = root;
             for pieces.each |ident_str| {
-                let ident = self.session.ident_of(/*bad*/copy *ident_str);
+                let ident = self.session.ident_of(*ident_str);
                 // Create or reuse a graph node for the child.
                 let (child_name_bindings, new_parent) =
                     self.add_child(ident,

--- a/src/librustc/middle/resolve_stage0.rs
+++ b/src/librustc/middle/resolve_stage0.rs
@@ -709,7 +709,7 @@ pub struct PrimitiveTypeTable {
 }
 
 pub impl PrimitiveTypeTable {
-    fn intern(&mut self, intr: @ident_interner, string: @~str,
+    fn intern(&mut self, intr: @ident_interner, string: &str,
               primitive_type: prim_ty) {
         let ident = intr.intern(string);
         self.primitive_types.insert(ident, primitive_type);
@@ -721,22 +721,22 @@ pub fn PrimitiveTypeTable(intr: @ident_interner) -> PrimitiveTypeTable {
         primitive_types: HashMap::new()
     };
 
-    table.intern(intr, @~"bool",    ty_bool);
-    table.intern(intr, @~"char",    ty_int(ty_char));
-    table.intern(intr, @~"float",   ty_float(ty_f));
-    table.intern(intr, @~"f32",     ty_float(ty_f32));
-    table.intern(intr, @~"f64",     ty_float(ty_f64));
-    table.intern(intr, @~"int",     ty_int(ty_i));
-    table.intern(intr, @~"i8",      ty_int(ty_i8));
-    table.intern(intr, @~"i16",     ty_int(ty_i16));
-    table.intern(intr, @~"i32",     ty_int(ty_i32));
-    table.intern(intr, @~"i64",     ty_int(ty_i64));
-    table.intern(intr, @~"str",     ty_str);
-    table.intern(intr, @~"uint",    ty_uint(ty_u));
-    table.intern(intr, @~"u8",      ty_uint(ty_u8));
-    table.intern(intr, @~"u16",     ty_uint(ty_u16));
-    table.intern(intr, @~"u32",     ty_uint(ty_u32));
-    table.intern(intr, @~"u64",     ty_uint(ty_u64));
+    table.intern(intr, "bool",    ty_bool);
+    table.intern(intr, "char",    ty_int(ty_char));
+    table.intern(intr, "float",   ty_float(ty_f));
+    table.intern(intr, "f32",     ty_float(ty_f32));
+    table.intern(intr, "f64",     ty_float(ty_f64));
+    table.intern(intr, "int",     ty_int(ty_i));
+    table.intern(intr, "i8",      ty_int(ty_i8));
+    table.intern(intr, "i16",     ty_int(ty_i16));
+    table.intern(intr, "i32",     ty_int(ty_i32));
+    table.intern(intr, "i64",     ty_int(ty_i64));
+    table.intern(intr, "str",     ty_str);
+    table.intern(intr, "uint",    ty_uint(ty_u));
+    table.intern(intr, "u8",      ty_uint(ty_u8));
+    table.intern(intr, "u16",     ty_uint(ty_u16));
+    table.intern(intr, "u32",     ty_uint(ty_u32));
+    table.intern(intr, "u64",     ty_uint(ty_u64));
 
     return table;
 }

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1222,7 +1222,7 @@ pub fn compile_guard(bcx: block,
 
     let val = unpack_result!(bcx, {
         do with_scope_result(bcx, guard_expr.info(),
-                             ~"guard") |bcx| {
+                             "guard") |bcx| {
             expr::trans_to_datum(bcx, guard_expr).to_result()
         }
     });
@@ -1446,7 +1446,7 @@ pub fn compile_submatch(bcx: block,
     }
     let else_cx = match kind {
         no_branch | single => bcx,
-        _ => sub_block(bcx, ~"match_else")
+        _ => sub_block(bcx, "match_else")
     };
     let sw = if kind == switch {
         Switch(bcx, test_val, else_cx.llbb, opts.len())
@@ -1464,7 +1464,7 @@ pub fn compile_submatch(bcx: block,
         i += 1u;
         let mut opt_cx = else_cx;
         if !exhaustive || i < len {
-            opt_cx = sub_block(bcx, ~"match_case");
+            opt_cx = sub_block(bcx, "match_case");
             match kind {
               single => Br(bcx, opt_cx.llbb),
               switch => {
@@ -1486,7 +1486,7 @@ pub fn compile_submatch(bcx: block,
                   let t = node_id_type(bcx, pat_id);
                   let Result {bcx: after_cx, val: matches} = {
                       do with_scope_result(bcx, None,
-                                           ~"compare_scope") |bcx| {
+                                           "compare_scope") |bcx| {
                           match trans_opt(bcx, opt) {
                               single_result(
                                   Result {bcx, val}) => {
@@ -1514,13 +1514,13 @@ pub fn compile_submatch(bcx: block,
                           }
                       }
                   };
-                  bcx = sub_block(after_cx, ~"compare_next");
+                  bcx = sub_block(after_cx, "compare_next");
                   CondBr(after_cx, matches, opt_cx.llbb, bcx.llbb);
               }
               compare_vec_len => {
                   let Result {bcx: after_cx, val: matches} = {
                       do with_scope_result(bcx, None,
-                                           ~"compare_vec_len_scope") |bcx| {
+                                           "compare_vec_len_scope") |bcx| {
                           match trans_opt(bcx, opt) {
                               single_result(
                                   Result {bcx, val}) => {
@@ -1552,7 +1552,7 @@ pub fn compile_submatch(bcx: block,
                           }
                       }
                   };
-                  bcx = sub_block(after_cx, ~"compare_vec_len_next");
+                  bcx = sub_block(after_cx, "compare_vec_len_next");
                   CondBr(after_cx, matches, opt_cx.llbb, bcx.llbb);
               }
               _ => ()
@@ -1610,7 +1610,7 @@ pub fn trans_match(bcx: block,
                    arms: ~[ast::arm],
                    dest: Dest) -> block {
     let _icx = bcx.insn_ctxt("match::trans_match");
-    do with_scope(bcx, match_expr.info(), ~"match") |bcx| {
+    do with_scope(bcx, match_expr.info(), "match") |bcx| {
         trans_match_inner(bcx, discr_expr, arms, dest)
     }
 }
@@ -1632,7 +1632,7 @@ pub fn trans_match_inner(scope_cx: block,
 
     let mut arm_datas = ~[], matches = ~[];
     for arms.each |arm| {
-        let body = scope_block(bcx, arm.body.info(), ~"case_body");
+        let body = scope_block(bcx, arm.body.info(), "case_body");
 
         // Create the bindings map, which is a mapping from each binding name
         // to an alloca() that will be the value for that local variable.
@@ -1716,7 +1716,7 @@ pub fn trans_match_inner(scope_cx: block,
     fn mk_fail(bcx: block, sp: span, msg: @~str,
                finished: @mut Option<BasicBlockRef>) -> BasicBlockRef {
         match *finished { Some(bb) => return bb, _ => () }
-        let fail_cx = sub_block(bcx, ~"case_fallthrough");
+        let fail_cx = sub_block(bcx, "case_fallthrough");
         controlflow::trans_fail(fail_cx, Some(sp), msg);
         *finished = Some(fail_cx.llbb);
         return fail_cx.llbb;

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -454,7 +454,7 @@ pub fn trans_call_inner(in_cx: block,
                         dest: expr::Dest,
                         autoref_arg: AutorefArg)
                         -> block {
-    do base::with_scope(in_cx, call_info, ~"call") |cx| {
+    do base::with_scope(in_cx, call_info, "call") |cx| {
         let ret_in_loop = match args {
           ArgExprs(args) => {
             args.len() > 0u && match vec::last(args).node {

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -400,7 +400,7 @@ pub fn trans_expr_fn(bcx: block,
     // XXX: Bad copy.
     let s = mangle_internal_name_by_path_and_seq(ccx,
                                                  copy sub_path,
-                                                 ~"expr_fn");
+                                                 "expr_fn");
     let llfn = decl_internal_cdecl_fn(ccx.llmod, s, llfnty);
 
     // Always mark inline if this is a loop body. This is important for

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -54,12 +54,12 @@ use syntax::parse::token::ident_interner;
 use syntax::{ast, ast_map};
 use syntax::abi::{X86, X86_64, Arm, Mips};
 
-pub type namegen = @fn(s: ~str) -> ident;
+pub type namegen = @fn(s: &str) -> ident;
 pub fn new_namegen(intr: @ident_interner) -> namegen {
-    let f: @fn(s: ~str) -> ident = |prefix| {
-        intr.gensym(@fmt!("%s_%u",
+    let f: @fn(s: &str) -> ident = |prefix| {
+        intr.gensym(fmt!("%s_%u",
                           prefix,
-                          intr.gensym(@prefix).repr))
+                          intr.gensym(prefix).repr))
     };
     f
 }
@@ -1177,7 +1177,7 @@ pub fn C_cstr(cx: @CrateContext, s: @~str) -> ValueRef {
             llvm::LLVMConstString(buf, s.len() as c_uint, False)
         };
         let g =
-            str::as_c_str(fmt!("str%u", (cx.names)(~"str").repr),
+            str::as_c_str(fmt!("str%u", (cx.names)("str").repr),
                         |buf| llvm::LLVMAddGlobal(cx.llmod, val_ty(sc), buf));
         llvm::LLVMSetInitializer(g, sc);
         llvm::LLVMSetGlobalConstant(g, True);
@@ -1269,7 +1269,7 @@ pub fn C_bytes_plus_null(bytes: &[u8]) -> ValueRef {
 pub fn C_shape(ccx: @CrateContext, bytes: ~[u8]) -> ValueRef {
     unsafe {
         let llshape = C_bytes_plus_null(bytes);
-        let name = fmt!("shape%u", (ccx.names)(~"shape").repr);
+        let name = fmt!("shape%u", (ccx.names)("shape").repr);
         let llglobal = str::as_c_str(name, |buf| {
             llvm::LLVMAddGlobal(ccx.llmod, val_ty(llshape), buf)
         });

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -517,7 +517,7 @@ fn create_tuple(cx: @CrateContext, t: ty::t, elements: &[ty::t], span: span)
     let scx = create_structure(file_node,
                                cx.sess.str_of(
                                    ((/*bad*/copy cx.dbg_cx).get().names)
-                                   (~"tuple")),
+                                   ("tuple")),
                                line_from_span(cx.sess.codemap, span) as int);
     for elements.each |element| {
         let ty_md = create_ty(cx, *element, span);
@@ -973,7 +973,7 @@ pub fn create_function(fcx: fn_ctxt) -> @Metadata<SubProgramMetadata> {
       ast_map::node_expr(expr) => {
         match expr.node {
           ast::expr_fn_block(ref decl, _) => {
-            ((dbg_cx.names)(~"fn"), decl.output, expr.id)
+            ((dbg_cx.names)("fn"), decl.output, expr.id)
           }
           _ => fcx.ccx.sess.span_bug(expr.span,
                   "create_function: expected an expr_fn_block here")

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -536,8 +536,8 @@ fn trans_rvalue_stmt_unadjusted(bcx: block, expr: @ast::expr) -> block {
                            src_datum_ref,
                            dst_datum_ref);
 
-            let swap_cx = base::sub_block(bcx, ~"swap");
-            let next_cx = base::sub_block(bcx, ~"next");
+            let swap_cx = base::sub_block(bcx, "swap");
+            let next_cx = base::sub_block(bcx, "next");
 
             CondBr(bcx, cmp, next_cx.llbb, swap_cx.llbb);
 
@@ -594,7 +594,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
         }
         ast::expr_block(ref blk) => {
             return do base::with_scope(bcx, blk.info(),
-                                       ~"block-expr body") |bcx| {
+                                       "block-expr body") |bcx| {
                 controlflow::trans_block(bcx, blk, dest)
             };
         }
@@ -1473,7 +1473,7 @@ fn trans_lazy_binop(bcx: block,
     let bcx = bcx;
 
     let Result {bcx: past_lhs, val: lhs} = {
-        do base::with_scope_result(bcx, a.info(), ~"lhs") |bcx| {
+        do base::with_scope_result(bcx, a.info(), "lhs") |bcx| {
             trans_to_datum(bcx, a).to_result()
         }
     };
@@ -1482,8 +1482,8 @@ fn trans_lazy_binop(bcx: block,
         return immediate_rvalue_bcx(past_lhs, lhs, binop_ty);
     }
 
-    let join = base::sub_block(bcx, ~"join");
-    let before_rhs = base::sub_block(bcx, ~"rhs");
+    let join = base::sub_block(bcx, "join");
+    let before_rhs = base::sub_block(bcx, "rhs");
 
     let lhs_i1 = bool_to_i1(past_lhs, lhs);
     match op {
@@ -1492,7 +1492,7 @@ fn trans_lazy_binop(bcx: block,
     }
 
     let Result {bcx: past_rhs, val: rhs} = {
-        do base::with_scope_result(before_rhs, b.info(), ~"rhs") |bcx| {
+        do base::with_scope_result(before_rhs, b.info(), "rhs") |bcx| {
             trans_to_datum(bcx, b).to_result()
         }
     };

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -671,9 +671,9 @@ pub fn declare_tydesc(ccx: @CrateContext, t: ty::t) -> @mut tydesc_info {
     let addrspace = declare_tydesc_addrspace(ccx, t);
     //XXX this triggers duplicate LLVM symbols
     let name = @(if false /*ccx.sess.opts.debuginfo*/ {
-        mangle_internal_name_by_type_only(ccx, t, ~"tydesc")
+        mangle_internal_name_by_type_only(ccx, t, "tydesc")
     } else {
-        mangle_internal_name_by_seq(ccx, ~"tydesc")
+        mangle_internal_name_by_seq(ccx, "tydesc")
     });
     note_unique_llvm_symbol(ccx, name);
     debug!("+++ declare_tydesc %s %s", ppaux::ty_to_str(ccx.tcx, t), *name);

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -775,7 +775,7 @@ pub fn make_vtable(ccx: @CrateContext, ptrs: ~[ValueRef]) -> ValueRef {
     unsafe {
         let _icx = ccx.insn_ctxt("impl::make_vtable");
         let tbl = C_struct(ptrs);
-        let vtable = ccx.sess.str_of((ccx.names)(~"vtable"));
+        let vtable = ccx.sess.str_of((ccx.names)("vtable"));
         let vt_gvar = do str::as_c_str(*vtable) |buf| {
             llvm::LLVMAddGlobal(ccx.llmod, val_ty(tbl), buf)
         };

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -171,7 +171,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
 
     let pt = vec::append(/*bad*/copy *pt,
                          ~[path_name((ccx.names)(
-                             copy *ccx.sess.str_of(name)))]);
+                             *ccx.sess.str_of(name)))]);
     let s = mangle_exported_name(ccx, /*bad*/copy pt, mono_ty);
 
     let mk_lldecl = || {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -114,7 +114,7 @@ pub impl Reflector {
             ArgVals(args), SaveIn(scratch.val), DontAutorefArg);
         let result = scratch.to_value_llval(bcx);
         let result = bool_to_i1(bcx, result);
-        let next_bcx = sub_block(bcx, ~"next");
+        let next_bcx = sub_block(bcx, "next");
         CondBr(bcx, result, next_bcx.llbb, self.final_bcx.llbb);
         self.bcx = next_bcx
     }
@@ -275,7 +275,7 @@ pub impl Reflector {
             let variants = ty::substd_enum_variants(ccx.tcx, did, substs);
             let llptrty = T_ptr(type_of(ccx, t));
             let (_, opaquety) =
-                ccx.tcx.intrinsic_defs.find_copy(&ccx.sess.ident_of(~"Opaque"))
+                ccx.tcx.intrinsic_defs.find_copy(&ccx.sess.ident_of("Opaque"))
                 .expect("Failed to resolve intrinsic::Opaque");
             let opaqueptrty = ty::mk_ptr(ccx.tcx, ty::mt { ty: opaquety, mutbl: ast::m_imm });
 
@@ -283,7 +283,7 @@ pub impl Reflector {
                 let sub_path = bcx.fcx.path + ~[path_name(special_idents::anon)];
                 let sym = mangle_internal_name_by_path_and_seq(ccx,
                                                                sub_path,
-                                                               ~"get_disr");
+                                                               "get_disr");
                 let args = [
                     ty::arg {
                         ty: opaqueptrty
@@ -373,7 +373,7 @@ pub fn emit_calls_to_trait_visit_ty(bcx: block,
                                     visitor_trait_id: def_id)
                                  -> block {
     use syntax::parse::token::special_idents::tydesc;
-    let final = sub_block(bcx, ~"final");
+    let final = sub_block(bcx, "final");
     assert!(bcx.ccx().tcx.intrinsic_defs.contains_key(&tydesc));
     let (_, tydesc_ty) = bcx.ccx().tcx.intrinsic_defs.get_copy(&tydesc);
     let tydesc_ty = type_of(bcx.ccx(), tydesc_ty);

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -421,11 +421,11 @@ pub fn write_content(bcx: block,
                         expr::trans_to_datum(bcx, element)
                     });
 
-                    let next_bcx = sub_block(bcx, ~"expr_repeat: while next");
-                    let loop_bcx = loop_scope_block(bcx, next_bcx, None, ~"expr_repeat", None);
-                    let cond_bcx = scope_block(loop_bcx, None, ~"expr_repeat: loop cond");
-                    let set_bcx = scope_block(loop_bcx, None, ~"expr_repeat: body: set");
-                    let inc_bcx = scope_block(loop_bcx, None, ~"expr_repeat: body: inc");
+                    let next_bcx = sub_block(bcx, "expr_repeat: while next");
+                    let loop_bcx = loop_scope_block(bcx, next_bcx, None, "expr_repeat", None);
+                    let cond_bcx = scope_block(loop_bcx, None, "expr_repeat: loop cond");
+                    let set_bcx = scope_block(loop_bcx, None, "expr_repeat: body: set");
+                    let inc_bcx = scope_block(loop_bcx, None, "expr_repeat: body: inc");
                     Br(bcx, loop_bcx.llbb);
 
                     let loop_counter = {
@@ -561,14 +561,14 @@ pub fn iter_vec_raw(bcx: block, data_ptr: ValueRef, vec_ty: ty::t,
     let data_end_ptr = pointer_add(bcx, data_ptr, fill);
 
     // Now perform the iteration.
-    let header_bcx = base::sub_block(bcx, ~"iter_vec_loop_header");
+    let header_bcx = base::sub_block(bcx, "iter_vec_loop_header");
     Br(bcx, header_bcx.llbb);
     let data_ptr =
         Phi(header_bcx, val_ty(data_ptr), ~[data_ptr], ~[bcx.llbb]);
     let not_yet_at_end =
         ICmp(header_bcx, lib::llvm::IntULT, data_ptr, data_end_ptr);
-    let body_bcx = base::sub_block(header_bcx, ~"iter_vec_loop_body");
-    let next_bcx = base::sub_block(header_bcx, ~"iter_vec_next");
+    let body_bcx = base::sub_block(header_bcx, "iter_vec_loop_body");
+    let next_bcx = base::sub_block(header_bcx, "iter_vec_next");
     CondBr(header_bcx, not_yet_at_end, body_bcx.llbb, next_bcx.llbb);
     let body_bcx = f(body_bcx, data_ptr, unit_ty);
     AddIncomingToPhi(data_ptr, InBoundsGEP(body_bcx, data_ptr,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1550,7 +1550,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                             lhs_resolved_t, None)
                 };
                 return lookup_op_method(fcx, ex, lhs_expr, lhs_resolved_t,
-                                       fcx.tcx().sess.ident_of(copy *name),
+                                       fcx.tcx().sess.ident_of(*name),
                                        ~[rhs], DoDerefArgs, DontAutoderefReceiver, if_op_unbound,
                                        expected_result);
             }
@@ -1574,8 +1574,8 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
     }
 
     fn check_user_unop(fcx: @mut FnCtxt,
-                       op_str: ~str,
-                       mname: ~str,
+                       op_str: &str,
+                       mname: &str,
                        ex: @ast::expr,
                        rhs_expr: @ast::expr,
                        rhs_t: ty::t,
@@ -2308,7 +2308,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                     if !(ty::type_is_integral(oprnd_t) ||
                          ty::get(oprnd_t).sty == ty::ty_bool) {
                         oprnd_t = check_user_unop(fcx,
-                            ~"!", ~"not", expr, oprnd, oprnd_t,
+                            "!", "not", expr, oprnd, oprnd_t,
                                                   expected);
                     }
                 }
@@ -2318,7 +2318,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                     if !(ty::type_is_integral(oprnd_t) ||
                          ty::type_is_fp(oprnd_t)) {
                         oprnd_t = check_user_unop(fcx,
-                            ~"-", ~"neg", expr, oprnd, oprnd_t, expected);
+                            "-", "neg", expr, oprnd, oprnd_t, expected);
                     }
                 }
             }
@@ -2783,7 +2783,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                       let resolved = structurally_resolved_type(fcx,
                                                                 expr.span,
                                                                 raw_base_t);
-                      let index_ident = tcx.sess.ident_of(~"index");
+                      let index_ident = tcx.sess.ident_of("index");
                       let error_message = || {
                         fcx.type_error_message(expr.span,
                                                |actual| {

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -156,7 +156,7 @@ fn run(repl: Repl, input: ~str) -> Repl {
     for crate.node.module.items.each |item| {
         match item.node {
             ast::item_fn(_, _, _, _, blk) => {
-                if item.ident == sess.ident_of(~"main") {
+                if item.ident == sess.ident_of("main") {
                     opt = blk.node.expr;
                 }
             }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -93,7 +93,7 @@ impl<D:Decoder> Decodable<D> for ident {
             Some(intr) => intr
         };
 
-        (*intr).intern(@d.read_str())
+        (*intr).intern(d.read_str())
     }
 }
 

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -244,7 +244,7 @@ trait ExtCtxtMethods {
     fn expr_blk(&self, expr: @ast::expr) -> ast::blk;
     fn expr_path(&self, span: span, strs: ~[ast::ident]) -> @ast::expr;
     fn expr_path_global(&self, span: span, strs: ~[ast::ident]) -> @ast::expr;
-    fn expr_var(&self, span: span, var: ~str) -> @ast::expr;
+    fn expr_var(&self, span: span, var: &str) -> @ast::expr;
     fn expr_field(&self, span: span, expr: @ast::expr, ident: ast::ident)
                   -> @ast::expr;
     fn expr_call(&self, span: span, expr: @ast::expr, args: ~[@ast::expr])
@@ -446,7 +446,7 @@ impl ExtCtxtMethods for @ext_ctxt {
         self.expr(span, ast::expr_path(self.path_global(span, strs)))
     }
 
-    fn expr_var(&self, span: span, var: ~str) -> @ast::expr {
+    fn expr_var(&self, span: span, var: &str) -> @ast::expr {
         self.expr_path(span, ~[self.ident_of(var)])
     }
 
@@ -583,13 +583,13 @@ fn mk_ser_impl(
     // Make a path to the std::serialize::Encodable typaram.
     let ty_param = cx.bind_path(
         span,
-        cx.ident_of(~"__S"),
+        cx.ident_of("__S"),
         cx.path_global(
             span,
             ~[
-                cx.ident_of(~"std"),
-                cx.ident_of(~"serialize"),
-                cx.ident_of(~"Encoder"),
+                cx.ident_of("std"),
+                cx.ident_of("serialize"),
+                cx.ident_of("Encoder"),
             ]
         ),
         @opt_vec::Empty
@@ -599,11 +599,11 @@ fn mk_ser_impl(
     let path = cx.path_tps_global(
         span,
         ~[
-            cx.ident_of(~"std"),
-            cx.ident_of(~"serialize"),
-            cx.ident_of(~"Encodable"),
+            cx.ident_of("std"),
+            cx.ident_of("serialize"),
+            cx.ident_of("Encodable"),
         ],
-        ~[cx.ty_path(span, ~[cx.ident_of(~"__S")], ~[])]
+        ~[cx.ty_path(span, ~[cx.ident_of("__S")], ~[])]
     );
 
     mk_impl(
@@ -627,13 +627,13 @@ fn mk_deser_impl(
     // Make a path to the std::serialize::Decodable typaram.
     let ty_param = cx.bind_path(
         span,
-        cx.ident_of(~"__D"),
+        cx.ident_of("__D"),
         cx.path_global(
             span,
             ~[
-                cx.ident_of(~"std"),
-                cx.ident_of(~"serialize"),
-                cx.ident_of(~"Decoder"),
+                cx.ident_of("std"),
+                cx.ident_of("serialize"),
+                cx.ident_of("Decoder"),
             ]
         ),
         @opt_vec::Empty
@@ -643,11 +643,11 @@ fn mk_deser_impl(
     let path = cx.path_tps_global(
         span,
         ~[
-            cx.ident_of(~"std"),
-            cx.ident_of(~"serialize"),
-            cx.ident_of(~"Decodable"),
+            cx.ident_of("std"),
+            cx.ident_of("serialize"),
+            cx.ident_of("Decodable"),
         ],
-        ~[cx.ty_path(span, ~[cx.ident_of(~"__D")], ~[])]
+        ~[cx.ty_path(span, ~[cx.ident_of("__D")], ~[])]
     );
 
     mk_impl(
@@ -671,7 +671,7 @@ fn mk_ser_method(
         node: ast::ty_rptr(
             None,
             ast::mt {
-                ty: cx.ty_path(span, ~[cx.ident_of(~"__S")], ~[]),
+                ty: cx.ty_path(span, ~[cx.ident_of("__S")], ~[]),
                 mutbl: ast::m_mutbl
             }
         ),
@@ -685,7 +685,7 @@ fn mk_ser_method(
             id: cx.next_id(),
             node: ast::pat_ident(
                 ast::bind_by_copy,
-                ast_util::ident_to_path(span, cx.ident_of(~"__s")),
+                ast_util::ident_to_path(span, cx.ident_of("__s")),
                 None),
             span: span,
         },
@@ -705,7 +705,7 @@ fn mk_ser_method(
     };
 
     @ast::method {
-        ident: cx.ident_of(~"encode"),
+        ident: cx.ident_of("encode"),
         attrs: ~[],
         generics: ast_util::empty_generics(),
         self_ty: codemap::spanned {
@@ -733,7 +733,7 @@ fn mk_deser_method(
         node: ast::ty_rptr(
             None,
             ast::mt {
-                ty: cx.ty_path(span, ~[cx.ident_of(~"__D")], ~[]),
+                ty: cx.ty_path(span, ~[cx.ident_of("__D")], ~[]),
                 mutbl: ast::m_mutbl
             }
         ),
@@ -749,7 +749,7 @@ fn mk_deser_method(
                 node: ast::pat_ident(ast::bind_by_copy,
                                      ast_util::ident_to_path(span,
                                                              cx.ident_of(
-                                                                ~"__d")),
+                                                                "__d")),
                                      None),
                 span: span,
             },
@@ -764,7 +764,7 @@ fn mk_deser_method(
     };
 
     @ast::method {
-        ident: cx.ident_of(~"decode"),
+        ident: cx.ident_of("decode"),
         attrs: ~[],
         generics: ast_util::empty_generics(),
         self_ty: codemap::spanned { node: ast::sty_static, span: span },
@@ -792,21 +792,21 @@ fn mk_struct_ser_impl(
                 span,
                 cx.expr_field(
                     span,
-                    cx.expr_var(span, ~"self"),
+                    cx.expr_var(span, "self"),
                     field.ident
                 ),
-                cx.ident_of(~"encode"),
-                ~[cx.expr_var(span, ~"__s")]
+                cx.ident_of("encode"),
+                ~[cx.expr_var(span, "__s")]
             ),
-            cx.ident_of(~"__s")
+            cx.ident_of("__s")
         );
 
         // ast for `__s.emit_struct_field($(name), $(idx), $(expr_lambda))`
         cx.stmt(
             cx.expr_method_call(
                 span,
-                cx.expr_var(span, ~"__s"),
-                cx.ident_of(~"emit_struct_field"),
+                cx.expr_var(span, "__s"),
+                cx.ident_of("emit_struct_field"),
                 ~[
                     cx.lit_str(span, @cx.str_of(field.ident)),
                     cx.lit_uint(span, idx),
@@ -819,12 +819,12 @@ fn mk_struct_ser_impl(
     // ast for `__s.emit_struct($(name), |__s| $(fields))`
     let ser_body = cx.expr_method_call(
         span,
-        cx.expr_var(span, ~"__s"),
-        cx.ident_of(~"emit_struct"),
+        cx.expr_var(span, "__s"),
+        cx.ident_of("emit_struct"),
         ~[
             cx.lit_str(span, @cx.str_of(ident)),
             cx.lit_uint(span, vec::len(fields)),
-            cx.lambda_stmts_1(span, fields, cx.ident_of(~"__s")),
+            cx.lambda_stmts_1(span, fields, cx.ident_of("__s")),
         ]
     );
 
@@ -845,22 +845,22 @@ fn mk_struct_deser_impl(
                 cx.expr_call(
                     span,
                     cx.expr_path_global(span, ~[
-                        cx.ident_of(~"std"),
-                        cx.ident_of(~"serialize"),
-                        cx.ident_of(~"Decodable"),
-                        cx.ident_of(~"decode"),
+                        cx.ident_of("std"),
+                        cx.ident_of("serialize"),
+                        cx.ident_of("Decodable"),
+                        cx.ident_of("decode"),
                     ]),
-                    ~[cx.expr_var(span, ~"__d")]
+                    ~[cx.expr_var(span, "__d")]
                 )
             ),
-            cx.ident_of(~"__d")
+            cx.ident_of("__d")
         );
 
         // ast for `__d.read_struct_field($(name), $(idx), $(expr_lambda))`
         let expr: @ast::expr = cx.expr_method_call(
             span,
-            cx.expr_var(span, ~"__d"),
-            cx.ident_of(~"read_struct_field"),
+            cx.expr_var(span, "__d"),
+            cx.ident_of("read_struct_field"),
             ~[
                 cx.lit_str(span, @cx.str_of(field.ident)),
                 cx.lit_uint(span, idx),
@@ -881,8 +881,8 @@ fn mk_struct_deser_impl(
     // ast for `read_struct($(name), |__d| $(fields))`
     let body = cx.expr_method_call(
         span,
-        cx.expr_var(span, ~"__d"),
-        cx.ident_of(~"read_struct"),
+        cx.expr_var(span, "__d"),
+        cx.ident_of("read_struct"),
         ~[
             cx.lit_str(span, @cx.str_of(ident)),
             cx.lit_uint(span, vec::len(fields)),
@@ -895,7 +895,7 @@ fn mk_struct_deser_impl(
                         None
                     )
                 ),
-                cx.ident_of(~"__d")
+                cx.ident_of("__d")
             ),
         ]
     );
@@ -997,8 +997,8 @@ fn ser_variant(
         // ast for `__s.emit_enum_variant_arg`
         let expr_emit = cx.expr_field(
             span,
-            cx.expr_var(span, ~"__s"),
-            cx.ident_of(~"emit_enum_variant_arg")
+            cx.expr_var(span, "__s"),
+            cx.ident_of("emit_enum_variant_arg")
         );
 
         // ast for `|__s| $(v).encode(__s)`
@@ -1006,10 +1006,10 @@ fn ser_variant(
             cx.expr_method_call(
                 span,
                  cx.expr_path(span, ~[names[a_idx]]),
-                 cx.ident_of(~"encode"),
-                ~[cx.expr_var(span, ~"__s")]
+                 cx.ident_of("encode"),
+                ~[cx.expr_var(span, "__s")]
             ),
-            cx.ident_of(~"__s")
+            cx.ident_of("__s")
         );
 
         // ast for `$(expr_emit)($(a_idx), $(expr_encode))`
@@ -1025,13 +1025,13 @@ fn ser_variant(
     // ast for `__s.emit_enum_variant($(name), $(idx), $(sz), $(lambda))`
     let body = cx.expr_method_call(
         span,
-        cx.expr_var(span, ~"__s"),
-        cx.ident_of(~"emit_enum_variant"),
+        cx.expr_var(span, "__s"),
+        cx.ident_of("emit_enum_variant"),
         ~[
             cx.lit_str(span, @cx.str_of(v_name)),
             cx.lit_uint(span, v_idx),
             cx.lit_uint(span, stmts.len()),
-            cx.lambda_stmts_1(span, stmts, cx.ident_of(~"__s")),
+            cx.lambda_stmts_1(span, stmts, cx.ident_of("__s")),
         ]
     );
 
@@ -1065,7 +1065,7 @@ fn mk_enum_ser_body(
         ast::expr_match(
             cx.expr(
                 span,
-                ast::expr_unary(ast::deref, cx.expr_var(span, ~"self"))
+                ast::expr_unary(ast::deref, cx.expr_var(span, "self"))
             ),
             arms
         )
@@ -1074,11 +1074,11 @@ fn mk_enum_ser_body(
     // ast for `__s.emit_enum($(name), || $(match_expr))`
     cx.expr_method_call(
         span,
-        cx.expr_var(span, ~"__s"),
-        cx.ident_of(~"emit_enum"),
+        cx.expr_var(span, "__s"),
+        cx.ident_of("emit_enum"),
         ~[
             cx.lit_str(span, @cx.str_of(name)),
-            cx.lambda_expr_1(match_expr, cx.ident_of(~"__s")),
+            cx.lambda_expr_1(match_expr, cx.ident_of("__s")),
         ]
     )
 }
@@ -1095,21 +1095,21 @@ fn mk_enum_deser_variant_nary(
             cx.expr_call(
                 span,
                 cx.expr_path_global(span, ~[
-                    cx.ident_of(~"std"),
-                    cx.ident_of(~"serialize"),
-                    cx.ident_of(~"Decodable"),
-                    cx.ident_of(~"decode"),
+                    cx.ident_of("std"),
+                    cx.ident_of("serialize"),
+                    cx.ident_of("Decodable"),
+                    cx.ident_of("decode"),
                 ]),
-                ~[cx.expr_var(span, ~"__d")]
+                ~[cx.expr_var(span, "__d")]
             ),
-            cx.ident_of(~"__d")
+            cx.ident_of("__d")
         );
 
         // ast for `__d.read_enum_variant_arg($(a_idx), $(expr_lambda))`
         cx.expr_method_call(
             span,
-            cx.expr_var(span, ~"__d"),
-            cx.ident_of(~"read_enum_variant_arg"),
+            cx.expr_var(span, "__d"),
+            cx.ident_of("read_enum_variant_arg"),
             ~[cx.lit_uint(span, idx), expr_lambda]
         )
     };
@@ -1205,7 +1205,7 @@ fn mk_enum_deser_body(
                             node: ast::pat_ident(
                                 ast::bind_by_copy,
                                 ast_util::ident_to_path(span,
-                                    ext_cx.ident_of(~"__d")),
+                                    ext_cx.ident_of("__d")),
                                 None),
                             span: span,
                         },
@@ -1223,7 +1223,7 @@ fn mk_enum_deser_body(
                             node: ast::pat_ident(
                                 ast::bind_by_copy,
                                 ast_util::ident_to_path(span,
-                                    ext_cx.ident_of(~"i")),
+                                    ext_cx.ident_of("i")),
                                 None),
                             span: span,
                         },
@@ -1240,7 +1240,7 @@ fn mk_enum_deser_body(
             ext_cx.expr_blk(
                 ext_cx.expr(
                     span,
-                    ast::expr_match(ext_cx.expr_var(span, ~"i"), arms)
+                    ast::expr_match(ext_cx.expr_var(span, "i"), arms)
                 )
             )
         )
@@ -1250,18 +1250,18 @@ fn mk_enum_deser_body(
     let expr_lambda = ext_cx.lambda_expr_1(
         ext_cx.expr_method_call(
             span,
-            ext_cx.expr_var(span, ~"__d"),
-            ext_cx.ident_of(~"read_enum_variant"),
+            ext_cx.expr_var(span, "__d"),
+            ext_cx.ident_of("read_enum_variant"),
             ~[expr_arm_names, expr_lambda]
         ),
-        ext_cx.ident_of(~"__d")
+        ext_cx.ident_of("__d")
     );
 
     // ast for `__d.read_enum($(e_name), $(expr_lambda))`
     ext_cx.expr_method_call(
         span,
-        ext_cx.expr_var(span, ~"__d"),
-        ext_cx.ident_of(~"read_enum"),
+        ext_cx.expr_var(span, "__d"),
+        ext_cx.ident_of("read_enum"),
         ~[
             ext_cx.lit_str(span, @ext_cx.str_of(name)),
             expr_lambda

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -232,7 +232,7 @@ pub trait ext_ctxt {
     fn set_trace_macros(&self, x: bool);
     /* for unhygienic identifier transformation */
     fn str_of(&self, id: ast::ident) -> ~str;
-    fn ident_of(&self, st: ~str) -> ast::ident;
+    fn ident_of(&self, st: &str) -> ast::ident;
 }
 
 pub fn mk_ctxt(parse_sess: @mut parse::ParseSess, cfg: ast::crate_cfg)
@@ -322,8 +322,8 @@ pub fn mk_ctxt(parse_sess: @mut parse::ParseSess, cfg: ast::crate_cfg)
         fn str_of(&self, id: ast::ident) -> ~str {
             copy *self.parse_sess.interner.get(id)
         }
-        fn ident_of(&self, st: ~str) -> ast::ident {
-            self.parse_sess.interner.intern(@/*bad*/ copy st)
+        fn ident_of(&self, st: &str) -> ast::ident {
+            self.parse_sess.interner.intern(st)
         }
     }
     let imp: @CtxtRepr = @CtxtRepr {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -502,10 +502,10 @@ pub fn mk_unreachable(cx: @ext_ctxt, span: span) -> @ast::expr {
         cx,
         span,
         ~[
-            cx.ident_of(~"core"),
-            cx.ident_of(~"sys"),
-            cx.ident_of(~"FailWithCause"),
-            cx.ident_of(~"fail_with"),
+            cx.ident_of("core"),
+            cx.ident_of("sys"),
+            cx.ident_of("FailWithCause"),
+            cx.ident_of("fail_with"),
         ],
         ~[
             mk_base_str(cx, span, ~"internal error: entered unreachable code"),

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -33,7 +33,7 @@ pub fn expand_syntax_ext(cx: @ext_ctxt, sp: span, tts: &[ast::token_tree])
             }
         }
     }
-    let res = cx.parse_sess().interner.intern(@res_str);
+    let res = cx.parse_sess().interner.intern(res_str);
 
     let e = @ast::expr {
         id: cx.next_id(),

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -58,9 +58,9 @@ fn cs_ord(less: bool, equal: bool,
           cx: @ext_ctxt, span: span,
           substr: &Substructure) -> @expr {
     let binop = if less {
-        cx.ident_of(~"lt")
+        cx.ident_of("lt")
     } else {
-        cx.ident_of(~"gt")
+        cx.ident_of("gt")
     };
     let false_blk_expr = build::mk_block(cx, span,
                                          ~[], ~[],
@@ -101,7 +101,7 @@ fn cs_ord(less: bool, equal: bool,
             }
 
             let cmp = build::mk_method_call(cx, span,
-                                            self_f, cx.ident_of(~"eq"), other_fs.to_owned());
+                                            self_f, cx.ident_of("eq"), other_fs.to_owned());
             let subexpr = build::mk_simple_block(cx, span, subexpr);
             let elseif = expr_if(cmp, subexpr, Some(false_blk_expr));
             let elseif = build::mk_expr(cx, span, elseif);

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -43,21 +43,21 @@ pub fn expand_deriving_totalord(cx: @ext_ctxt,
 
 pub fn ordering_const(cx: @ext_ctxt, span: span, cnst: Ordering) -> @expr {
     let cnst = match cnst {
-        Less => ~"Less",
-        Equal => ~"Equal",
-        Greater => ~"Greater"
+        Less => "Less",
+        Equal => "Equal",
+        Greater => "Greater"
     };
     build::mk_path_global(cx, span,
-                          ~[cx.ident_of(~"core"),
-                            cx.ident_of(~"cmp"),
+                          ~[cx.ident_of("core"),
+                            cx.ident_of("cmp"),
                             cx.ident_of(cnst)])
 }
 
 pub fn cs_cmp(cx: @ext_ctxt, span: span,
               substr: &Substructure) -> @expr {
-    let lexical_ord = ~[cx.ident_of(~"core"),
-                        cx.ident_of(~"cmp"),
-                        cx.ident_of(~"lexical_ordering")];
+    let lexical_ord = ~[cx.ident_of("core"),
+                        cx.ident_of("cmp"),
+                        cx.ident_of("lexical_ordering")];
 
     cs_same_method_fold(
         // foldr (possibly) nests the matches in lexical_ordering better

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -41,15 +41,15 @@ fn create_derived_decodable_impl(
 ) -> @item {
     let decoder_ty_param = build::mk_ty_param(
         cx,
-        cx.ident_of(~"__D"),
+        cx.ident_of("__D"),
         @opt_vec::with(
             build::mk_trait_ty_param_bound_global(
                 cx,
                 span,
                 ~[
-                    cx.ident_of(~"std"),
-                    cx.ident_of(~"serialize"),
-                    cx.ident_of(~"Decoder"),
+                    cx.ident_of("std"),
+                    cx.ident_of("serialize"),
+                    cx.ident_of("Decoder"),
                 ]
             )
         )
@@ -62,13 +62,13 @@ fn create_derived_decodable_impl(
     let trait_path = build::mk_raw_path_global_(
         span,
         ~[
-            cx.ident_of(~"std"),
-            cx.ident_of(~"serialize"),
-            cx.ident_of(~"Decodable")
+            cx.ident_of("std"),
+            cx.ident_of("serialize"),
+            cx.ident_of("Decodable")
         ],
         None,
         ~[
-            build::mk_simple_ty_path(cx, span, cx.ident_of(~"__D"))
+            build::mk_simple_ty_path(cx, span, cx.ident_of("__D"))
         ]
     );
     create_derived_impl(
@@ -96,11 +96,11 @@ fn create_decode_method(
     let d_arg_type = build::mk_ty_rptr(
         cx,
         span,
-        build::mk_simple_ty_path(cx, span, cx.ident_of(~"__D")),
+        build::mk_simple_ty_path(cx, span, cx.ident_of("__D")),
         None,
         ast::m_mutbl
     );
-    let d_ident = cx.ident_of(~"__d");
+    let d_ident = cx.ident_of("__d");
     let d_arg = build::mk_arg(cx, span, d_ident, d_arg_type);
 
     // Create the type of the return value.
@@ -120,7 +120,7 @@ fn create_decode_method(
 
     // Create the method.
     let self_ty = spanned { node: sty_static, span: span };
-    let method_ident = cx.ident_of(~"decode");
+    let method_ident = cx.ident_of("decode");
     @ast::method {
         ident: method_ident,
         attrs: ~[],
@@ -148,14 +148,14 @@ fn call_substructure_decode_method(
             cx,
             span,
             ~[
-                cx.ident_of(~"std"),
-                cx.ident_of(~"serialize"),
-                cx.ident_of(~"Decodable"),
-                cx.ident_of(~"decode"),
+                cx.ident_of("std"),
+                cx.ident_of("serialize"),
+                cx.ident_of("Decodable"),
+                cx.ident_of("decode"),
             ]
         ),
         ~[
-            build::mk_path(cx, span, ~[cx.ident_of(~"__d")])
+            build::mk_path(cx, span, ~[cx.ident_of("__d")])
         ]
     )
 }
@@ -223,14 +223,14 @@ fn create_read_struct_field(
 
     let d_arg = build::mk_arg(cx,
                               span,
-                              cx.ident_of(~"__d"),
+                              cx.ident_of("__d"),
                               build::mk_ty_infer(cx, span));
 
     let call_expr = build::mk_method_call(
         cx,
         span,
-        build::mk_path(cx, span, ~[cx.ident_of(~"__d")]),
-        cx.ident_of(~"read_struct_field"),
+        build::mk_path(cx, span, ~[cx.ident_of("__d")]),
+        cx.ident_of("read_struct_field"),
         ~[
             build::mk_base_str(cx, span, cx.str_of(ident)),
             build::mk_uint(cx, span, idx),
@@ -257,8 +257,8 @@ fn create_read_struct_arg(
     let call_expr = build::mk_method_call(
         cx,
         span,
-        build::mk_path(cx, span, ~[cx.ident_of(~"__d")]),
-        cx.ident_of(~"read_struct_arg"),
+        build::mk_path(cx, span, ~[cx.ident_of("__d")]),
+        cx.ident_of("read_struct_arg"),
         ~[
             build::mk_uint(cx, span, idx),
             build::mk_lambda_no_args(cx, span, decode_expr),
@@ -295,7 +295,7 @@ fn expand_deriving_decodable_struct_method(
 
     let d_arg = build::mk_arg(cx,
                               span,
-                              cx.ident_of(~"__d"),
+                              cx.ident_of("__d"),
                               build::mk_ty_infer(cx, span));
 
     let read_struct_expr = build::mk_method_call(
@@ -304,9 +304,9 @@ fn expand_deriving_decodable_struct_method(
         build::mk_path(
             cx,
             span,
-            ~[cx.ident_of(~"__d")]
+            ~[cx.ident_of("__d")]
         ),
-        cx.ident_of(~"read_struct"),
+        cx.ident_of("read_struct"),
         ~[
             build::mk_base_str(cx, span, cx.str_of(type_ident)),
             build::mk_uint(cx, span, fields.len()),
@@ -353,15 +353,15 @@ fn create_read_variant_arg(
 
             let d_arg = build::mk_arg(cx,
                                       span,
-                                      cx.ident_of(~"__d"),
+                                      cx.ident_of("__d"),
                                       build::mk_ty_infer(cx, span));
             let t_infer = build::mk_ty_infer(cx, span);
 
             let call_expr = build::mk_method_call(
                 cx,
                 span,
-                build::mk_path(cx, span, ~[cx.ident_of(~"__d")]),
-                cx.ident_of(~"read_enum_variant_arg"),
+                build::mk_path(cx, span, ~[cx.ident_of("__d")]),
+                cx.ident_of("read_enum_variant_arg"),
                 ~[
                     build::mk_uint(cx, span, j),
                     build::mk_lambda(cx,
@@ -416,8 +416,8 @@ fn create_read_enum_variant(
     build::mk_method_call(
         cx,
         span,
-        build::mk_path(cx, span, ~[cx.ident_of(~"__d")]),
-        cx.ident_of(~"read_enum_variant"),
+        build::mk_path(cx, span, ~[cx.ident_of("__d")]),
+        cx.ident_of("read_enum_variant"),
         ~[
             expr_arm_names,
             build::mk_lambda(
@@ -428,13 +428,13 @@ fn create_read_enum_variant(
                         build::mk_arg(
                             cx,
                             span,
-                            cx.ident_of(~"__d"),
+                            cx.ident_of("__d"),
                             build::mk_ty_infer(cx, span)
                         ),
                         build::mk_arg(
                             cx,
                             span,
-                            cx.ident_of(~"__i"),
+                            cx.ident_of("__i"),
                             build::mk_ty_infer(cx, span)
                         )
                     ],
@@ -444,7 +444,7 @@ fn create_read_enum_variant(
                     cx,
                     span,
                     ast::expr_match(
-                        build::mk_path(cx, span, ~[cx.ident_of(~"__i")]),
+                        build::mk_path(cx, span, ~[cx.ident_of("__i")]),
                         arms
                     )
                 )
@@ -468,15 +468,15 @@ fn expand_deriving_decodable_enum_method(
 
     let d_arg = build::mk_arg(cx,
                               span,
-                              cx.ident_of(~"__d"),
+                              cx.ident_of("__d"),
                               build::mk_ty_infer(cx, span));
 
     // Create the read_enum expression
     let read_enum_expr = build::mk_method_call(
         cx,
         span,
-        build::mk_path(cx, span, ~[cx.ident_of(~"__d")]),
-        cx.ident_of(~"read_enum"),
+        build::mk_path(cx, span, ~[cx.ident_of("__d")]),
+        cx.ident_of("read_enum"),
         ~[
             build::mk_base_str(cx, span, cx.str_of(type_ident)),
             build::mk_lambda(cx,

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -41,15 +41,15 @@ fn create_derived_encodable_impl(
 ) -> @item {
     let encoder_ty_param = build::mk_ty_param(
         cx,
-        cx.ident_of(~"__E"),
+        cx.ident_of("__E"),
         @opt_vec::with(
             build::mk_trait_ty_param_bound_global(
                 cx,
                 span,
                 ~[
-                    cx.ident_of(~"std"),
-                    cx.ident_of(~"serialize"),
-                    cx.ident_of(~"Encoder"),
+                    cx.ident_of("std"),
+                    cx.ident_of("serialize"),
+                    cx.ident_of("Encoder"),
                 ]
             )
         )
@@ -62,13 +62,13 @@ fn create_derived_encodable_impl(
     let trait_path = build::mk_raw_path_global_(
         span,
         ~[
-            cx.ident_of(~"std"),
-            cx.ident_of(~"serialize"),
-            cx.ident_of(~"Encodable")
+            cx.ident_of("std"),
+            cx.ident_of("serialize"),
+            cx.ident_of("Encodable")
         ],
         None,
         ~[
-            build::mk_simple_ty_path(cx, span, cx.ident_of(~"__E"))
+            build::mk_simple_ty_path(cx, span, cx.ident_of("__E"))
         ]
     );
     create_derived_impl(
@@ -94,11 +94,11 @@ fn create_encode_method(
     let e_arg_type = build::mk_ty_rptr(
         cx,
         span,
-        build::mk_simple_ty_path(cx, span, cx.ident_of(~"__E")),
+        build::mk_simple_ty_path(cx, span, cx.ident_of("__E")),
         None,
         ast::m_mutbl
     );
-    let e_arg = build::mk_arg(cx, span, cx.ident_of(~"__e"), e_arg_type);
+    let e_arg = build::mk_arg(cx, span, cx.ident_of("__e"), e_arg_type);
 
     // Create the type of the return value.
     let output_type = @ast::Ty { id: cx.next_id(), node: ty_nil, span: span };
@@ -112,7 +112,7 @@ fn create_encode_method(
 
     // Create the method.
     let self_ty = spanned { node: sty_region(None, m_imm), span: span };
-    let method_ident = cx.ident_of(~"encode");
+    let method_ident = cx.ident_of("encode");
     @ast::method {
         ident: method_ident,
         attrs: ~[],
@@ -134,11 +134,11 @@ fn call_substructure_encode_method(
     self_field: @expr
 ) -> @ast::expr {
     // Gather up the parameters we want to chain along.
-    let e_ident = cx.ident_of(~"__e");
+    let e_ident = cx.ident_of("__e");
     let e_expr = build::mk_path(cx, span, ~[e_ident]);
 
     // Call the substructure method.
-    let encode_ident = cx.ident_of(~"encode");
+    let encode_ident = cx.ident_of("encode");
     build::mk_method_call(
         cx,
         span,
@@ -204,7 +204,7 @@ fn expand_deriving_encodable_struct_method(
     type_ident: ident,
     struct_def: &struct_def
 ) -> @method {
-    let self_ident = cx.ident_of(~"self");
+    let self_ident = cx.ident_of("self");
 
     // Create the body of the method.
     let mut idx = 0;
@@ -227,7 +227,7 @@ fn expand_deriving_encodable_struct_method(
                     self_field
                 );
 
-                let e_ident = cx.ident_of(~"__e");
+                let e_ident = cx.ident_of("__e");
                 let e_arg = build::mk_arg(cx,
                                           span,
                                           e_ident,
@@ -243,8 +243,8 @@ fn expand_deriving_encodable_struct_method(
                 let call_expr = build::mk_method_call(
                     cx,
                     span,
-                    build::mk_path(cx, span, ~[cx.ident_of(~"__e")]),
-                    cx.ident_of(~"emit_struct_field"),
+                    build::mk_path(cx, span, ~[cx.ident_of("__e")]),
+                    cx.ident_of("emit_struct_field"),
                     ~[
                         build::mk_base_str(cx, span, cx.str_of(ident)),
                         build::mk_uint(cx, span, idx),
@@ -266,7 +266,7 @@ fn expand_deriving_encodable_struct_method(
 
     let e_arg = build::mk_arg(cx,
                               span,
-                              cx.ident_of(~"__e"),
+                              cx.ident_of("__e"),
                               build::mk_ty_infer(cx, span));
 
     let emit_struct_stmt = build::mk_method_call(
@@ -275,9 +275,9 @@ fn expand_deriving_encodable_struct_method(
         build::mk_path(
             cx,
             span,
-            ~[cx.ident_of(~"__e")]
+            ~[cx.ident_of("__e")]
         ),
-        cx.ident_of(~"emit_struct"),
+        cx.ident_of("emit_struct"),
         ~[
             build::mk_base_str(cx, span, cx.str_of(type_ident)),
             build::mk_uint(cx, span, statements.len()),
@@ -305,7 +305,7 @@ fn expand_deriving_encodable_enum_method(
     // Create the arms of the match in the method body.
     let arms = do enum_definition.variants.mapi |i, variant| {
         // Create the matching pattern.
-        let (pat, fields) = create_enum_variant_pattern(cx, span, variant, ~"__self", ast::m_imm);
+        let (pat, fields) = create_enum_variant_pattern(cx, span, variant, "__self", ast::m_imm);
 
         // Feed the discriminant to the encode function.
         let mut stmts = ~[];
@@ -317,7 +317,7 @@ fn expand_deriving_encodable_enum_method(
             // Call the substructure method.
             let expr = call_substructure_encode_method(cx, span, field);
 
-            let e_ident = cx.ident_of(~"__e");
+            let e_ident = cx.ident_of("__e");
             let e_arg = build::mk_arg(cx,
                                       span,
                                       e_ident,
@@ -333,8 +333,8 @@ fn expand_deriving_encodable_enum_method(
             let call_expr = build::mk_method_call(
                 cx,
                 span,
-                build::mk_path(cx, span, ~[cx.ident_of(~"__e")]),
-                cx.ident_of(~"emit_enum_variant_arg"),
+                build::mk_path(cx, span, ~[cx.ident_of("__e")]),
+                cx.ident_of("emit_enum_variant_arg"),
                 ~[
                     build::mk_uint(cx, span, j),
                     blk_expr,
@@ -347,13 +347,13 @@ fn expand_deriving_encodable_enum_method(
         // Create the pattern body.
         let e_arg = build::mk_arg(cx,
                                   span,
-                                  cx.ident_of(~"__e"),
+                                  cx.ident_of("__e"),
                                   build::mk_ty_infer(cx, span));
         let call_expr = build::mk_method_call(
             cx,
             span,
-            build::mk_path(cx, span, ~[cx.ident_of(~"__e")]),
-            cx.ident_of(~"emit_enum_variant"),
+            build::mk_path(cx, span, ~[cx.ident_of("__e")]),
+            cx.ident_of("emit_enum_variant"),
             ~[
                 build::mk_base_str(cx, span, cx.str_of(variant.node.name)),
                 build::mk_uint(cx, span, i),
@@ -377,7 +377,7 @@ fn expand_deriving_encodable_enum_method(
         }
     };
 
-    let e_ident = cx.ident_of(~"__e");
+    let e_ident = cx.ident_of("__e");
     let e_arg = build::mk_arg(cx,
                               span,
                               e_ident,
@@ -394,8 +394,8 @@ fn expand_deriving_encodable_enum_method(
     let call_expr = build::mk_method_call(
         cx,
         span,
-        build::mk_path(cx, span, ~[cx.ident_of(~"__e")]),
-        cx.ident_of(~"emit_enum"),
+        build::mk_path(cx, span, ~[cx.ident_of("__e")]),
+        cx.ident_of("emit_enum"),
         ~[
             build::mk_base_str(cx, span, cx.str_of(type_ident)),
             lambda_expr,

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -263,7 +263,7 @@ pub fn create_struct_pattern(cx: @ext_ctxt,
                              span: span,
                              struct_ident: ident,
                              struct_def: &struct_def,
-                             prefix: ~str,
+                             prefix: &str,
                              mutbl: ast::mutability)
     -> (@ast::pat, ~[(Option<ident>, @expr)]) {
     if struct_def.fields.is_empty() {
@@ -323,7 +323,7 @@ pub fn create_struct_pattern(cx: @ext_ctxt,
 pub fn create_enum_variant_pattern(cx: @ext_ctxt,
                                    span: span,
                                    variant: &ast::variant,
-                                   prefix: ~str,
+                                   prefix: &str,
                                    mutbl: ast::mutability)
     -> (@ast::pat, ~[(Option<ident>, @expr)]) {
 
@@ -371,7 +371,7 @@ pub fn expand_enum_or_struct_match(cx: @ext_ctxt,
                                span: span,
                                arms: ~[ ast::arm ])
                             -> @expr {
-    let self_ident = cx.ident_of(~"self");
+    let self_ident = cx.ident_of("self");
     let self_expr = build::mk_path(cx, span, ~[ self_ident ]);
     let self_expr = build::mk_unary(cx, span, ast::deref, self_expr);
     let self_match_expr = ast::expr_match(self_expr, arms);

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -53,10 +53,10 @@ fn rand_substructure(cx: @ext_ctxt, span: span, substr: &Substructure) -> @expr 
         _ => cx.bug("Incorrect number of arguments to `rand` in `deriving(Rand)`")
     };
     let rand_ident = ~[
-        cx.ident_of(~"core"),
-        cx.ident_of(~"rand"),
-        cx.ident_of(~"Rand"),
-        cx.ident_of(~"rand")
+        cx.ident_of("core"),
+        cx.ident_of("rand"),
+        cx.ident_of("Rand"),
+        cx.ident_of("rand")
     ];
     let rand_call = || {
         build::mk_call_global(cx,
@@ -77,8 +77,8 @@ fn rand_substructure(cx: @ext_ctxt, span: span, substr: &Substructure) -> @expr 
             let variant_count = build::mk_uint(cx, span, variants.len());
 
             // need to specify the uint-ness of the random number
-            let u32_ty = build::mk_ty_path(cx, span, ~[cx.ident_of(~"uint")]);
-            let r_ty = build::mk_ty_path(cx, span, ~[cx.ident_of(~"R")]);
+            let u32_ty = build::mk_ty_path(cx, span, ~[cx.ident_of("uint")]);
+            let r_ty = build::mk_ty_path(cx, span, ~[cx.ident_of("R")]);
             let rand_name = build::mk_raw_path_(span, copy rand_ident, None, ~[ u32_ty, r_ty ]);
             let rand_name = build::mk_path_raw(cx, span, rand_name);
 

--- a/src/libsyntax/ext/deriving/to_str.rs
+++ b/src/libsyntax/ext/deriving/to_str.rs
@@ -44,9 +44,9 @@ fn to_str_substructure(cx: @ext_ctxt, span: span, substr: &Substructure) -> @exp
         [self_obj] => {
             let self_addr = build::mk_addr_of(cx, span, self_obj);
             build::mk_call_global(cx, span,
-                                  ~[cx.ident_of(~"core"),
-                                    cx.ident_of(~"sys"),
-                                    cx.ident_of(~"log_str")],
+                                  ~[cx.ident_of("core"),
+                                    cx.ident_of("sys"),
+                                    cx.ident_of("log_str")],
                                   ~[self_addr])
         }
         _ => cx.span_bug(span, ~"Invalid number of arguments in `deriving(ToStr)`")

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -218,7 +218,7 @@ pub impl LifetimeBounds {
 
 pub fn get_explicit_self(cx: @ext_ctxt, span: span, self_ptr: Option<PtrTy>)
     -> (@expr, ast::self_ty) {
-    let self_path = build::mk_path(cx, span, ~[cx.ident_of(~"self")]);
+    let self_path = build::mk_path(cx, span, ~[cx.ident_of("self")]);
     match self_ptr {
         None => {
             (self_path, respan(span, ast::sty_value))

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -138,9 +138,9 @@ pub trait ext_ctxt_ast_builder {
 impl ext_ctxt_ast_builder for @ext_ctxt {
     fn ty_option(&self, ty: @ast::Ty) -> @ast::Ty {
         self.ty_path_ast_builder(path_global(~[
-            self.ident_of(~"core"),
-            self.ident_of(~"option"),
-            self.ident_of(~"Option")
+            self.ident_of("core"),
+            self.ident_of("option"),
+            self.ident_of("Option")
         ], dummy_sp()).add_ty(ty))
     }
 
@@ -360,12 +360,12 @@ impl ext_ctxt_ast_builder for @ext_ctxt {
         let vi = ast::view_item_use(~[
             @codemap::spanned {
                 node: ast::view_path_simple(
-                    self.ident_of(~"Owned"),
+                    self.ident_of("Owned"),
                     path(
                         ~[
-                            self.ident_of(~"core"),
-                            self.ident_of(~"kinds"),
-                            self.ident_of(~"Owned")
+                            self.ident_of("core"),
+                            self.ident_of("kinds"),
+                            self.ident_of("Owned")
                         ],
                         codemap::dummy_sp()
                     ),

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -58,7 +58,7 @@ impl gen_send for message {
                 path(~[this.data_name()], span)
                 .add_tys(cx.ty_vars_global(&this.generics.ty_params)));
             let args_ast = vec::append(
-                ~[cx.arg(cx.ident_of(~"pipe"),
+                ~[cx.arg(cx.ident_of("pipe"),
                               pipe_ty)],
                 args_ast);
 
@@ -136,7 +136,7 @@ impl gen_send for message {
                 };
 
                 let args_ast = vec::append(
-                    ~[cx.arg(cx.ident_of(~"pipe"),
+                    ~[cx.arg(cx.ident_of("pipe"),
                              cx.ty_path_ast_builder(
                                  path(~[this.data_name()], span)
                                  .add_tys(cx.ty_vars_global(
@@ -212,8 +212,8 @@ impl to_type_decls for state {
                 let next_name = cx.str_of(next.data_name());
 
                 let dir = match this.dir {
-                  send => ~"server",
-                  recv => ~"client"
+                  send => "server",
+                  recv => "client"
                 };
 
                 vec::append_one(tys,
@@ -265,12 +265,12 @@ impl to_type_decls for state {
                     self.data_name(),
                     self.span,
                     cx.ty_path_ast_builder(
-                        path_global(~[cx.ident_of(~"core"),
-                                      cx.ident_of(~"pipes"),
-                                      cx.ident_of(dir.to_str() + ~"Packet")],
+                        path_global(~[cx.ident_of("core"),
+                                      cx.ident_of("pipes"),
+                                      cx.ident_of(dir.to_str() + "Packet")],
                              dummy_sp())
                         .add_ty(cx.ty_path_ast_builder(
-                            path(~[cx.ident_of(~"super"),
+                            path(~[cx.ident_of("super"),
                                    self.data_name()],
                                  dummy_sp())
                             .add_tys(cx.ty_vars_global(
@@ -283,13 +283,13 @@ impl to_type_decls for state {
                     self.data_name(),
                     self.span,
                     cx.ty_path_ast_builder(
-                        path_global(~[cx.ident_of(~"core"),
-                                      cx.ident_of(~"pipes"),
+                        path_global(~[cx.ident_of("core"),
+                                      cx.ident_of("pipes"),
                                       cx.ident_of(dir.to_str()
-                                                  + ~"PacketBuffered")],
+                                                  + "PacketBuffered")],
                              dummy_sp())
                         .add_tys(~[cx.ty_path_ast_builder(
-                            path(~[cx.ident_of(~"super"),
+                            path(~[cx.ident_of("super"),
                                    self.data_name()],
                                         dummy_sp())
                             .add_tys(cx.ty_vars_global(
@@ -341,7 +341,7 @@ impl gen_init for protocol {
     }
 
     fn gen_buffer_init(&self, ext_cx: @ext_ctxt) -> @ast::expr {
-        ext_cx.struct_expr(path(~[ext_cx.ident_of(~"__Buffer")],
+        ext_cx.struct_expr(path(~[ext_cx.ident_of("__Buffer")],
                                 dummy_sp()),
                       self.states.map_to_vec(|s| {
             let fty = s.to_ty(ext_cx);
@@ -389,8 +389,8 @@ impl gen_init for protocol {
             }
         }
 
-        cx.ty_path_ast_builder(path(~[cx.ident_of(~"super"),
-                                      cx.ident_of(~"__Buffer")],
+        cx.ty_path_ast_builder(path(~[cx.ident_of("super"),
+                                      cx.ident_of("__Buffer")],
                                     copy self.span)
                                .add_tys(cx.ty_vars_global(&params)))
     }
@@ -427,7 +427,7 @@ impl gen_init for protocol {
         };
 
         cx.item_struct_poly(
-            cx.ident_of(~"__Buffer"),
+            cx.ident_of("__Buffer"),
             dummy_sp(),
             ast::struct_def {
                 fields: fields,
@@ -452,13 +452,13 @@ impl gen_init for protocol {
             items.push(self.gen_buffer_type(cx))
         }
 
-        items.push(cx.item_mod(cx.ident_of(~"client"),
+        items.push(cx.item_mod(cx.ident_of("client"),
                                copy self.span,
                                client_states));
-        items.push(cx.item_mod(cx.ident_of(~"server"),
+        items.push(cx.item_mod(cx.ident_of("server"),
                                copy self.span,
                                server_states));
 
-        cx.item_mod(cx.ident_of(self.name), copy self.span, items)
+        cx.item_mod(cx.ident_of(copy self.name), copy self.span, items)
     }
 }

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -377,14 +377,14 @@ pub fn expand_quote_tokens(cx: @ext_ctxt,
 pub fn expand_quote_expr(cx: @ext_ctxt,
                          sp: span,
                          tts: &[ast::token_tree]) -> base::MacResult {
-    base::MRExpr(expand_parse_call(cx, sp, ~"parse_expr", ~[], tts))
+    base::MRExpr(expand_parse_call(cx, sp, "parse_expr", ~[], tts))
 }
 
 pub fn expand_quote_item(cx: @ext_ctxt,
                          sp: span,
                          tts: &[ast::token_tree]) -> base::MacResult {
     let e_attrs = build::mk_uniq_vec_e(cx, sp, ~[]);
-    base::MRExpr(expand_parse_call(cx, sp, ~"parse_item",
+    base::MRExpr(expand_parse_call(cx, sp, "parse_item",
                                     ~[e_attrs], tts))
 }
 
@@ -392,7 +392,7 @@ pub fn expand_quote_pat(cx: @ext_ctxt,
                         sp: span,
                         tts: &[ast::token_tree]) -> base::MacResult {
     let e_refutable = build::mk_lit(cx, sp, ast::lit_bool(true));
-    base::MRExpr(expand_parse_call(cx, sp, ~"parse_pat",
+    base::MRExpr(expand_parse_call(cx, sp, "parse_pat",
                                     ~[e_refutable], tts))
 }
 
@@ -400,7 +400,7 @@ pub fn expand_quote_ty(cx: @ext_ctxt,
                        sp: span,
                        tts: &[ast::token_tree]) -> base::MacResult {
     let e_param_colons = build::mk_lit(cx, sp, ast::lit_bool(false));
-    base::MRExpr(expand_parse_call(cx, sp, ~"parse_ty",
+    base::MRExpr(expand_parse_call(cx, sp, "parse_ty",
                                     ~[e_param_colons], tts))
 }
 
@@ -408,16 +408,16 @@ pub fn expand_quote_stmt(cx: @ext_ctxt,
                          sp: span,
                          tts: &[ast::token_tree]) -> base::MacResult {
     let e_attrs = build::mk_uniq_vec_e(cx, sp, ~[]);
-    base::MRExpr(expand_parse_call(cx, sp, ~"parse_stmt",
+    base::MRExpr(expand_parse_call(cx, sp, "parse_stmt",
                                     ~[e_attrs], tts))
 }
 
 fn ids_ext(cx: @ext_ctxt, strs: ~[~str]) -> ~[ast::ident] {
-    strs.map(|str| cx.parse_sess().interner.intern(@copy *str))
+    strs.map(|str| cx.parse_sess().interner.intern(*str))
 }
 
-fn id_ext(cx: @ext_ctxt, str: ~str) -> ast::ident {
-    cx.parse_sess().interner.intern(@str)
+fn id_ext(cx: @ext_ctxt, str: &str) -> ast::ident {
+    cx.parse_sess().interner.intern(str)
 }
 
 // Lift an ident to the expr that evaluates to that ident.
@@ -425,7 +425,7 @@ fn mk_ident(cx: @ext_ctxt, sp: span, ident: ast::ident) -> @ast::expr {
     let e_str = build::mk_uniq_str(cx, sp, cx.str_of(ident));
     build::mk_method_call(cx, sp,
                           build::mk_path(cx, sp, ids_ext(cx, ~[~"ext_cx"])),
-                          id_ext(cx, ~"ident_of"),
+                          id_ext(cx, "ident_of"),
                           ~[e_str])
 }
 
@@ -616,7 +616,7 @@ fn mk_tt(cx: @ext_ctxt, sp: span, tt: &ast::token_tree)
             let e_push =
                 build::mk_method_call(cx, sp,
                                       build::mk_path(cx, sp, ids_ext(cx, ~[~"tt"])),
-                                      id_ext(cx, ~"push"),
+                                      id_ext(cx, "push"),
                                       ~[e_tok]);
             ~[build::mk_stmt(cx, sp, e_push)]
 
@@ -632,14 +632,14 @@ fn mk_tt(cx: @ext_ctxt, sp: span, tt: &ast::token_tree)
             let e_to_toks =
                 build::mk_method_call(cx, sp,
                                       build::mk_path(cx, sp, ~[ident]),
-                                      id_ext(cx, ~"to_tokens"),
+                                      id_ext(cx, "to_tokens"),
                                       ~[build::mk_path(cx, sp,
                                                        ids_ext(cx, ~[~"ext_cx"]))]);
 
             let e_push =
                 build::mk_method_call(cx, sp,
                                       build::mk_path(cx, sp, ids_ext(cx, ~[~"tt"])),
-                                      id_ext(cx, ~"push_all_move"),
+                                      id_ext(cx, "push_all_move"),
                                       ~[e_to_toks]);
 
             ~[build::mk_stmt(cx, sp, e_push)]
@@ -711,15 +711,15 @@ fn expand_tts(cx: @ext_ctxt,
 
     let e_sp = build::mk_method_call(cx, sp,
                                      build::mk_path(cx, sp, ids_ext(cx, ~[~"ext_cx"])),
-                                     id_ext(cx, ~"call_site"),
+                                     id_ext(cx, "call_site"),
                                      ~[]);
 
     let stmt_let_sp = build::mk_local(cx, sp, false,
-                                      id_ext(cx, ~"sp"),
+                                      id_ext(cx, "sp"),
                                       e_sp);
 
     let stmt_let_tt = build::mk_local(cx, sp, true,
-                                      id_ext(cx, ~"tt"),
+                                      id_ext(cx, "tt"),
                                       build::mk_uniq_vec_e(cx, sp, ~[]));
 
     build::mk_block(cx, sp, uses,
@@ -731,18 +731,18 @@ fn expand_tts(cx: @ext_ctxt,
 
 fn expand_parse_call(cx: @ext_ctxt,
                      sp: span,
-                     parse_method: ~str,
+                     parse_method: &str,
                      arg_exprs: ~[@ast::expr],
                      tts: &[ast::token_tree]) -> @ast::expr {
     let tts_expr = expand_tts(cx, sp, tts);
 
     let cfg_call = || build::mk_method_call(
         cx, sp, build::mk_path(cx, sp, ids_ext(cx, ~[~"ext_cx"])),
-        id_ext(cx, ~"cfg"), ~[]);
+        id_ext(cx, "cfg"), ~[]);
 
     let parse_sess_call = || build::mk_method_call(
         cx, sp, build::mk_path(cx, sp, ids_ext(cx, ~[~"ext_cx"])),
-        id_ext(cx, ~"parse_sess"), ~[]);
+        id_ext(cx, "parse_sess"), ~[]);
 
     let new_parser_call =
         build::mk_call_global(cx, sp,

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -36,8 +36,8 @@ pub fn add_new_extension(cx: @ext_ctxt,
         spanned { node: copy m, span: dummy_sp() }
     }
 
-    let lhs_nm =  cx.parse_sess().interner.gensym(@~"lhs");
-    let rhs_nm =  cx.parse_sess().interner.gensym(@~"rhs");
+    let lhs_nm =  cx.parse_sess().interner.gensym("lhs");
+    let rhs_nm =  cx.parse_sess().interner.gensym("rhs");
 
     // The grammar for macro_rules! is:
     // $( $lhs:mtcs => $rhs:tt );+

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -271,7 +271,7 @@ fn consume_any_line_comment(rdr: @mut StringReader)
                 // but comments with only "/"s are not
                 if !is_line_non_doc_comment(acc) {
                     return Some(TokenAndSpan{
-                        tok: token::DOC_COMMENT(rdr.interner.intern(@acc)),
+                        tok: token::DOC_COMMENT(rdr.interner.intern(acc)),
                         sp: codemap::mk_sp(start_bpos, rdr.pos)
                     });
                 }
@@ -325,7 +325,7 @@ fn consume_block_comment(rdr: @mut StringReader)
             // but comments with only "*"s between two "/"s are not
             if !is_block_non_doc_comment(acc) {
                 return Some(TokenAndSpan{
-                    tok: token::DOC_COMMENT(rdr.interner.intern(@acc)),
+                    tok: token::DOC_COMMENT(rdr.interner.intern(acc)),
                     sp: codemap::mk_sp(start_bpos, rdr.pos)
                 });
             }
@@ -467,12 +467,12 @@ fn scan_number(c: char, rdr: @mut StringReader) -> token::Token {
         if c == '3' && n == '2' {
             bump(rdr);
             bump(rdr);
-            return token::LIT_FLOAT(rdr.interner.intern(@num_str),
+            return token::LIT_FLOAT(rdr.interner.intern(num_str),
                                  ast::ty_f32);
         } else if c == '6' && n == '4' {
             bump(rdr);
             bump(rdr);
-            return token::LIT_FLOAT(rdr.interner.intern(@num_str),
+            return token::LIT_FLOAT(rdr.interner.intern(num_str),
                                  ast::ty_f64);
             /* FIXME (#2252): if this is out of range for either a
             32-bit or 64-bit float, it won't be noticed till the
@@ -484,9 +484,9 @@ fn scan_number(c: char, rdr: @mut StringReader) -> token::Token {
     }
     if is_float {
         if is_machine_float {
-            return token::LIT_FLOAT(rdr.interner.intern(@num_str), ast::ty_f);
+            return token::LIT_FLOAT(rdr.interner.intern(num_str), ast::ty_f);
         }
-        return token::LIT_FLOAT_UNSUFFIXED(rdr.interner.intern(@num_str));
+        return token::LIT_FLOAT_UNSUFFIXED(rdr.interner.intern(num_str));
     } else {
         if str::len(num_str) == 0u {
             rdr.fatal(~"no valid digits found for number");
@@ -548,7 +548,7 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
         let is_mod_name = c == ':' && nextch(rdr) == ':';
 
         // FIXME: perform NFKC normalization here. (Issue #2253)
-        return token::IDENT(rdr.interner.intern(@accum_str), is_mod_name);
+        return token::IDENT(rdr.interner.intern(accum_str), is_mod_name);
     }
     if is_dec_digit(c) {
         return scan_number(c, rdr);
@@ -658,7 +658,7 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
                 lifetime_name.push_char(rdr.curr);
                 bump(rdr);
             }
-            return token::LIFETIME(rdr.interner.intern(@lifetime_name));
+            return token::LIFETIME(rdr.interner.intern(lifetime_name));
         }
 
         // Otherwise it is a character constant:
@@ -731,7 +731,7 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
             }
         }
         bump(rdr);
-        return token::LIT_STR(rdr.interner.intern(@accum_str));
+        return token::LIT_STR(rdr.interner.intern(accum_str));
       }
       '-' => {
         if nextch(rdr) == '>' {
@@ -799,7 +799,7 @@ mod test {
         let Env {interner: ident_interner, string_reader} =
             setup(~"/* my source file */ \
                     fn main() { io::println(~\"zebra\"); }\n");
-        let id = ident_interner.intern(@~"fn");
+        let id = ident_interner.intern("fn");
         let tok1 = string_reader.next_token();
         let tok2 = TokenAndSpan{
             tok:token::IDENT(id, false),
@@ -810,7 +810,7 @@ mod test {
         // read another token:
         let tok3 = string_reader.next_token();
         let tok4 = TokenAndSpan{
-            tok:token::IDENT(ident_interner.intern (@~"main"), false),
+            tok:token::IDENT(ident_interner.intern("main"), false),
             sp:span {lo:BytePos(24),hi:BytePos(28),expn_info: None}};
         assert_eq!(tok3,tok4);
         // the lparen is already read:
@@ -828,39 +828,39 @@ mod test {
     }
 
     // make the identifier by looking up the string in the interner
-    fn mk_ident (env: Env, id: ~str, is_mod_name: bool) -> token::Token {
-        token::IDENT (env.interner.intern(@id),is_mod_name)
+    fn mk_ident (env: Env, id: &str, is_mod_name: bool) -> token::Token {
+        token::IDENT (env.interner.intern(id),is_mod_name)
     }
 
     #[test] fn doublecolonparsing () {
         let env = setup (~"a b");
         check_tokenization (env,
-                           ~[mk_ident (env,~"a",false),
-                             mk_ident (env,~"b",false)]);
+                           ~[mk_ident (env,"a",false),
+                             mk_ident (env,"b",false)]);
     }
 
     #[test] fn dcparsing_2 () {
         let env = setup (~"a::b");
         check_tokenization (env,
-                           ~[mk_ident (env,~"a",true),
+                           ~[mk_ident (env,"a",true),
                              token::MOD_SEP,
-                             mk_ident (env,~"b",false)]);
+                             mk_ident (env,"b",false)]);
     }
 
     #[test] fn dcparsing_3 () {
         let env = setup (~"a ::b");
         check_tokenization (env,
-                           ~[mk_ident (env,~"a",false),
+                           ~[mk_ident (env,"a",false),
                              token::MOD_SEP,
-                             mk_ident (env,~"b",false)]);
+                             mk_ident (env,"b",false)]);
     }
 
     #[test] fn dcparsing_4 () {
         let env = setup (~"a:: b");
         check_tokenization (env,
-                           ~[mk_ident (env,~"a",true),
+                           ~[mk_ident (env,"a",true),
                              token::MOD_SEP,
-                             mk_ident (env,~"b",false)]);
+                             mk_ident (env,"b",false)]);
     }
 
     #[test] fn character_a() {
@@ -888,7 +888,7 @@ mod test {
         let env = setup(~"'abc");
         let TokenAndSpan {tok, sp: _} =
             env.string_reader.next_token();
-        let id = env.interner.intern(@~"abc");
+        let id = env.interner.intern("abc");
         assert_eq!(tok, token::LIFETIME(id));
     }
 }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -375,13 +375,13 @@ mod test {
 
         assert!(i.len() < 100);
         for int::range(0,100-((i.len()).to_int())) |_dc| {
-            i.gensym(@~"dontcare");
+            i.gensym("dontcare");
         }
-        i.intern(@~"a");
-        i.intern(@~"b");
-        i.intern(@~"c");
-        i.intern(@~"d");
-        i.intern(@~"return");
+        i.intern("a");
+        i.intern("b");
+        i.intern("c");
+        i.intern("d");
+        i.intern("return");
         assert!(i.get(ast::ident{repr:101,ctxt:0}) == @~"b");
         i
     }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -11,7 +11,7 @@
 use ast;
 use ast_util;
 use parse::token;
-use util::interner::Interner;
+use util::interner::StrInterner;
 use util::interner;
 
 use core::cmp::Equiv;
@@ -390,14 +390,14 @@ pub fn token_to_binop(tok: Token) -> Option<ast::binop> {
 }
 
 pub struct ident_interner {
-    priv interner: Interner<@~str>,
+    priv interner: StrInterner,
 }
 
 pub impl ident_interner {
-    fn intern(&self, val: @~str) -> ast::ident {
+    fn intern(&self, val: &str) -> ast::ident {
         ast::ident { repr: self.interner.intern(val), ctxt: 0 }
     }
-    fn gensym(&self, val: @~str) -> ast::ident {
+    fn gensym(&self, val: &str) -> ast::ident {
         ast::ident { repr: self.interner.gensym(val), ctxt: 0 }
     }
     fn get(&self, idx: ast::ident) -> @~str {
@@ -421,45 +421,45 @@ pub fn mk_fresh_ident_interner() -> @ident_interner {
     // the indices here must correspond to the numbers in
     // special_idents.
     let init_vec = ~[
-        @~"_",                  // 0
-        @~"anon",               // 1
-        @~"",                   // 2
-        @~"unary",              // 3
-        @~"!",                  // 4
-        @~"[]",                 // 5
-        @~"unary-",             // 6
-        @~"__extensions__",     // 7
-        @~"self",               // 8
-        @~"item",               // 9
-        @~"block",              // 10
-        @~"stmt",               // 11
-        @~"pat",                // 12
-        @~"expr",               // 13
-        @~"ty",                 // 14
-        @~"ident",              // 15
-        @~"path",               // 16
-        @~"tt",                 // 17
-        @~"matchers",           // 18
-        @~"str",                // 19
-        @~"TyVisitor",          // 20
-        @~"arg",                // 21
-        @~"descrim",            // 22
-        @~"__rust_abi",         // 23
-        @~"__rust_stack_shim",  // 24
-        @~"TyDesc",             // 25
-        @~"main",               // 26
-        @~"<opaque>",           // 27
-        @~"blk",                // 28
-        @~"static",             // 29
-        @~"intrinsic",          // 30
-        @~"__foreign_mod__",    // 31
-        @~"__field__",          // 32
-        @~"C",                  // 33
-        @~"Self",               // 34
+        "_",                  // 0
+        "anon",               // 1
+        "",                   // 2
+        "unary",              // 3
+        "!",                  // 4
+        "[]",                 // 5
+        "unary-",             // 6
+        "__extensions__",     // 7
+        "self",               // 8
+        "item",               // 9
+        "block",              // 10
+        "stmt",               // 11
+        "pat",                // 12
+        "expr",               // 13
+        "ty",                 // 14
+        "ident",              // 15
+        "path",               // 16
+        "tt",                 // 17
+        "matchers",           // 18
+        "str",                // 19
+        "TyVisitor",          // 20
+        "arg",                // 21
+        "descrim",            // 22
+        "__rust_abi",         // 23
+        "__rust_stack_shim",  // 24
+        "TyDesc",             // 25
+        "main",               // 26
+        "<opaque>",           // 27
+        "blk",                // 28
+        "static",             // 29
+        "intrinsic",          // 30
+        "__foreign_mod__",    // 31
+        "__field__",          // 32
+        "C",                  // 33
+        "Self",               // 34
     ];
 
     let rv = @ident_interner {
-        interner: interner::Interner::prefill(init_vec)
+        interner: interner::StrInterner::prefill(init_vec)
     };
     unsafe {
         task::local_data::local_data_set(interner_key!(), @rv);
@@ -483,7 +483,7 @@ pub fn mk_ident_interner() -> @ident_interner {
 /* for when we don't care about the contents; doesn't interact with TLD or
    serialization */
 pub fn mk_fake_ident_interner() -> @ident_interner {
-    @ident_interner { interner: interner::Interner::new() }
+    @ident_interner { interner: interner::StrInterner::new() }
 }
 
 /**

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2249,7 +2249,7 @@ mod test {
     #[test]
     fn test_fun_to_str() {
         let mock_interner = parse::token::mk_fake_ident_interner();
-        let abba_ident = mock_interner.intern(@~"abba");
+        let abba_ident = mock_interner.intern("abba");
 
         let decl = ast::fn_decl {
             inputs: ~[],
@@ -2267,7 +2267,7 @@ mod test {
     #[test]
     fn test_variant_to_str() {
         let mock_interner = parse::token::mk_fake_ident_interner();
-        let ident = mock_interner.intern(@~"principal_skinner");
+        let ident = mock_interner.intern("principal_skinner");
 
         let var = codemap::respan(codemap::dummy_sp(), ast::variant_ {
             name: ident,

--- a/src/test/compile-fail/qquote-1.rs
+++ b/src/test/compile-fail/qquote-1.rs
@@ -26,7 +26,7 @@ trait fake_ext_ctxt {
     fn cfg() -> ast::crate_cfg;
     fn parse_sess() -> parse::parse_sess;
     fn call_site() -> span;
-    fn ident_of(st: ~str) -> ast::ident;
+    fn ident_of(st: &str) -> ast::ident;
 }
 
 type fake_session = parse::parse_sess;
@@ -41,8 +41,8 @@ impl fake_ext_ctxt for fake_session {
             expn_info: None
         }
     }
-    fn ident_of(st: ~str) -> ast::ident {
-        self.interner.intern(@st)
+    fn ident_of(st: &str) -> ast::ident {
+        self.interner.intern(st)
     }
 }
 

--- a/src/test/compile-fail/qquote-2.rs
+++ b/src/test/compile-fail/qquote-2.rs
@@ -25,7 +25,7 @@ trait fake_ext_ctxt {
     fn cfg() -> ast::crate_cfg;
     fn parse_sess() -> parse::parse_sess;
     fn call_site() -> span;
-    fn ident_of(st: ~str) -> ast::ident;
+    fn ident_of(st: &str) -> ast::ident;
 }
 
 type fake_session = parse::parse_sess;
@@ -40,8 +40,8 @@ impl fake_ext_ctxt for fake_session {
             expn_info: None
         }
     }
-    fn ident_of(st: ~str) -> ast::ident {
-        self.interner.intern(@st)
+    fn ident_of(st: &str) -> ast::ident {
+        self.interner.intern(st)
     }
 }
 

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -27,7 +27,7 @@ trait fake_ext_ctxt {
     fn cfg() -> ast::crate_cfg;
     fn parse_sess() -> parse::parse_sess;
     fn call_site() -> span;
-    fn ident_of(st: ~str) -> ast::ident;
+    fn ident_of(st: &str) -> ast::ident;
 }
 
 type fake_session = parse::parse_sess;
@@ -42,8 +42,8 @@ impl fake_ext_ctxt for fake_session {
             expn_info: None
         }
     }
-    fn ident_of(st: ~str) -> ast::ident {
-        self.interner.intern(@copy st)
+    fn ident_of(st: &str) -> ast::ident {
+        self.interner.intern(st)
     }
 }
 


### PR DESCRIPTION
&str can be turned into @~str on demand, using to_owned(), so for
strings, we can create a specialized interner that accepts &str for
intern() and find() but stores and returns @~str.
