### PR TITLE
Use static string with fail!() and remove fail!(fmt!())

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -2386,9 +2386,9 @@ enum List<X> { Nil, Cons(X, @List<X>) }
 let x: List<int> = Cons(10, @Cons(11, @Nil));
 
 match x {
-    Cons(_, @Nil) => fail!(~"singleton list"),
+    Cons(_, @Nil) => fail!("singleton list"),
     Cons(*)       => return,
-    Nil           => fail!(~"empty list")
+    Nil           => fail!("empty list")
 }
 ~~~~
 

--- a/doc/tutorial-macros.md
+++ b/doc/tutorial-macros.md
@@ -223,7 +223,7 @@ match x {
                 // complicated stuff goes here
                 return result + val;
             },
-            _ => fail!(~"Didn't get good_2")
+            _ => fail!("Didn't get good_2")
         }
     }
     _ => return 0 // default value
@@ -265,7 +265,7 @@ macro_rules! biased_match (
 biased_match!((x)       ~ (good_1(g1, val)) else { return 0 };
               binds g1, val )
 biased_match!((g1.body) ~ (good_2(result) )
-                  else { fail!(~"Didn't get good_2") };
+                  else { fail!("Didn't get good_2") };
               binds result )
 // complicated stuff goes here
 return result + val;
@@ -366,7 +366,7 @@ macro_rules! biased_match (
 # fn f(x: t1) -> uint {
 biased_match!(
     (x)       ~ (good_1(g1, val)) else { return 0 };
-    (g1.body) ~ (good_2(result) ) else { fail!(~"Didn't get good_2") };
+    (g1.body) ~ (good_2(result) ) else { fail!("Didn't get good_2") };
     binds val, result )
 // complicated stuff goes here
 return result + val;

--- a/doc/tutorial-tasks.md
+++ b/doc/tutorial-tasks.md
@@ -325,7 +325,7 @@ let result: Result<int, ()> = do task::try {
     if some_condition() {
         calculate_result()
     } else {
-        fail!(~"oops!");
+        fail!("oops!");
     }
 };
 assert!(result.is_err());

--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -151,7 +151,7 @@ pub fn str_mode(s: ~str) -> mode {
       ~"run-pass" => mode_run_pass,
       ~"pretty" => mode_pretty,
       ~"debug-info" => mode_debug_info,
-      _ => fail!(~"invalid mode")
+      _ => fail!("invalid mode")
     }
 }
 
@@ -169,7 +169,7 @@ pub fn run_tests(config: config) {
     let opts = test_opts(config);
     let tests = make_tests(config);
     let res = test::run_tests_console(&opts, tests);
-    if !res { fail!(~"Some tests failed"); }
+    if !res { fail!("Some tests failed"); }
 }
 
 pub fn test_opts(config: config) -> test::TestOpts {

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -139,7 +139,7 @@ fn parse_exec_env(line: ~str) -> Option<(~str, ~str)> {
         match strs.len() {
           1u => (strs[0], ~""),
           2u => (strs[0], strs[1]),
-          n => fail!(fmt!("Expected 1 or 2 strings, not %u", n))
+          n => fail!("Expected 1 or 2 strings, not %u", n)
         }
     }
 }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -561,7 +561,7 @@ fn compose_and_run_compiler(
 fn ensure_dir(path: &Path) {
     if os::path_is_dir(path) { return; }
     if !os::make_dir(path, 0x1c0i32) {
-        fail!(fmt!("can't make dir %s", path.to_str()));
+        fail!("can't make dir %s", path.to_str());
     }
 }
 

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -46,7 +46,7 @@ pub impl<T> Cell<T> {
     fn take(&self) -> T {
         let this = unsafe { transmute_mut(self) };
         if this.is_empty() {
-            fail!(~"attempt to take an empty cell");
+            fail!("attempt to take an empty cell");
         }
 
         replace(&mut this.value, None).unwrap()
@@ -56,7 +56,7 @@ pub impl<T> Cell<T> {
     fn put_back(&self, value: T) {
         let this = unsafe { transmute_mut(self) };
         if !this.is_empty() {
-            fail!(~"attempt to put a value back into a full cell");
+            fail!("attempt to put a value back into a full cell");
         }
         this.value = Some(value);
     }

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -145,7 +145,7 @@ pub fn is_digit_radix(c: char, radix: uint) -> bool {
 #[inline]
 pub fn to_digit(c: char, radix: uint) -> Option<uint> {
     if radix > 36 {
-        fail!(fmt!("to_digit: radix %? is to high (maximum 36)", radix));
+        fail!("to_digit: radix %? is to high (maximum 36)", radix);
     }
     let val = match c {
       '0' .. '9' => c as uint - ('0' as uint),
@@ -168,7 +168,7 @@ pub fn to_digit(c: char, radix: uint) -> Option<uint> {
 #[inline]
 pub fn from_digit(num: uint, radix: uint) -> Option<char> {
     if radix > 36 {
-        fail!(fmt!("from_digit: radix %? is to high (maximum 36)", num));
+        fail!("from_digit: radix %? is to high (maximum 36)", num);
     }
     if num < radix {
         if num < 10 {
@@ -241,7 +241,7 @@ pub fn len_utf8_bytes(c: char) -> uint {
     else if code < max_two_b { 2u }
     else if code < max_three_b { 3u }
     else if code < max_four_b { 4u }
-    else { fail!(~"invalid character!") }
+    else { fail!("invalid character!") }
 }
 
 #[cfg(not(test))]

--- a/src/libcore/comm.rs
+++ b/src/libcore/comm.rs
@@ -210,7 +210,7 @@ impl<T: Owned> Peekable<T> for Port<T> {
             let mut endp = replace(self_endp, None);
             let peek = match endp {
                 Some(ref mut endp) => peek(endp),
-                None => fail!(~"peeking empty stream")
+                None => fail!("peeking empty stream")
             };
             *self_endp = endp;
             peek
@@ -222,7 +222,7 @@ impl<T: Owned> Selectable for Port<T> {
     fn header(&mut self) -> *mut PacketHeader {
             match self.endp {
                 Some(ref mut endp) => endp.header(),
-                None => fail!(~"peeking empty stream")
+                None => fail!("peeking empty stream")
             }
     }
 }
@@ -522,7 +522,7 @@ pub fn select2i<A:Selectable, B:Selectable>(a: &mut A, b: &mut B)
     match wait_many(endpoints) {
         0 => Left(()),
         1 => Right(()),
-        _ => fail!(~"wait returned unexpected index"),
+        _ => fail!("wait returned unexpected index"),
     }
 }
 

--- a/src/libcore/either.rs
+++ b/src/libcore/either.rs
@@ -135,7 +135,7 @@ pub fn unwrap_left<T,U>(eith: Either<T,U>) -> T {
 
     match eith {
         Left(x) => x,
-        Right(_) => fail!(~"either::unwrap_left Right")
+        Right(_) => fail!("either::unwrap_left Right")
     }
 }
 
@@ -145,7 +145,7 @@ pub fn unwrap_right<T,U>(eith: Either<T,U>) -> U {
 
     match eith {
         Right(x) => x,
-        Left(_) => fail!(~"either::unwrap_right Left")
+        Left(_) => fail!("either::unwrap_right Left")
     }
 }
 

--- a/src/libcore/hashmap.rs
+++ b/src/libcore/hashmap.rs
@@ -200,7 +200,7 @@ priv impl<K:Hash + Eq,V> HashMap<K, V> {
     fn value_for_bucket<'a>(&'a self, idx: uint) -> &'a V {
         match self.buckets[idx] {
             Some(ref bkt) => &bkt.value,
-            None => fail!(~"HashMap::find: internal logic error"),
+            None => fail!("HashMap::find: internal logic error"),
         }
     }
 
@@ -217,7 +217,7 @@ priv impl<K:Hash + Eq,V> HashMap<K, V> {
     /// True if there was no previous entry with that key
     fn insert_internal(&mut self, hash: uint, k: K, v: V) -> Option<V> {
         match self.bucket_for_key_with_hash(hash, &k) {
-            TableFull => { fail!(~"Internal logic error"); }
+            TableFull => { fail!("Internal logic error"); }
             FoundHole(idx) => {
                 debug!("insert fresh (%?->%?) at idx %?, hash %?",
                        k, v, idx, hash);
@@ -230,7 +230,7 @@ priv impl<K:Hash + Eq,V> HashMap<K, V> {
                 debug!("insert overwrite (%?->%?) at idx %?, hash %?",
                        k, v, idx, hash);
                 match self.buckets[idx] {
-                    None => { fail!(~"insert_internal: Internal logic error") }
+                    None => { fail!("insert_internal: Internal logic error") }
                     Some(ref mut b) => {
                         b.hash = hash;
                         b.key = k;
@@ -500,7 +500,7 @@ pub impl<K: Hash + Eq, V> HashMap<K, V> {
 
         let hash = k.hash_keyed(self.k0, self.k1) as uint;
         let idx = match self.bucket_for_key_with_hash(hash, &k) {
-            TableFull => fail!(~"Internal logic error"),
+            TableFull => fail!("Internal logic error"),
             FoundEntry(idx) => idx,
             FoundHole(idx) => {
                 self.buckets[idx] = Some(Bucket{hash: hash, key: k,
@@ -531,7 +531,7 @@ pub impl<K: Hash + Eq, V> HashMap<K, V> {
 
         let hash = k.hash_keyed(self.k0, self.k1) as uint;
         let idx = match self.bucket_for_key_with_hash(hash, &k) {
-            TableFull => fail!(~"Internal logic error"),
+            TableFull => fail!("Internal logic error"),
             FoundEntry(idx) => idx,
             FoundHole(idx) => {
                 self.buckets[idx] = Some(Bucket{hash: hash, key: k,
@@ -560,7 +560,7 @@ pub impl<K: Hash + Eq, V> HashMap<K, V> {
 
         let hash = k.hash_keyed(self.k0, self.k1) as uint;
         let idx = match self.bucket_for_key_with_hash(hash, &k) {
-            TableFull => fail!(~"Internal logic error"),
+            TableFull => fail!("Internal logic error"),
             FoundEntry(idx) => idx,
             FoundHole(idx) => {
                 let v = f(&k);
@@ -592,7 +592,7 @@ pub impl<K: Hash + Eq, V> HashMap<K, V> {
 
         let hash = k.hash_keyed(self.k0, self.k1) as uint;
         let idx = match self.bucket_for_key_with_hash(hash, &k) {
-            TableFull => fail!(~"Internal logic error"),
+            TableFull => fail!("Internal logic error"),
             FoundEntry(idx) => idx,
             FoundHole(idx) => {
                 let v = f(&k);
@@ -623,7 +623,7 @@ pub impl<K: Hash + Eq, V> HashMap<K, V> {
     fn get<'a>(&'a self, k: &K) -> &'a V {
         match self.find(k) {
             Some(v) => v,
-            None => fail!(fmt!("No entry found for key: %?", k)),
+            None => fail!("No entry found for key: %?", k),
         }
     }
 

--- a/src/libcore/local_data.rs
+++ b/src/libcore/local_data.rs
@@ -133,13 +133,13 @@ fn test_tls_modify() {
         local_data_modify(my_key, |data| {
             match data {
                 Some(@ref val) => fail!("unwelcome value: %s", *val),
-                None       => Some(@~"first data")
+                None           => Some(@~"first data")
             }
         });
         local_data_modify(my_key, |data| {
             match data {
                 Some(@~"first data") => Some(@~"next data"),
-                Some(@ref val)           => fail!("wrong value: %s", *val),
+                Some(@ref val)       => fail!("wrong value: %s", *val),
                 None                 => fail!("missing value")
             }
         });

--- a/src/libcore/local_data.rs
+++ b/src/libcore/local_data.rs
@@ -132,15 +132,15 @@ fn test_tls_modify() {
         fn my_key(_x: @~str) { }
         local_data_modify(my_key, |data| {
             match data {
-                Some(@ref val) => fail!(~"unwelcome value: " + *val),
+                Some(@ref val) => fail!("unwelcome value: %s", *val),
                 None       => Some(@~"first data")
             }
         });
         local_data_modify(my_key, |data| {
             match data {
                 Some(@~"first data") => Some(@~"next data"),
-                Some(@ref val)           => fail!(~"wrong value: " + *val),
-                None                 => fail!(~"missing value")
+                Some(@ref val)           => fail!("wrong value: %s", *val),
+                None                 => fail!("missing value")
             }
         });
         assert!(*(local_data_pop(my_key).get()) == ~"next data");

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -772,7 +772,7 @@ pub fn to_str_hex(num: f32) -> ~str {
 pub fn to_str_radix(num: f32, rdx: uint) -> ~str {
     let (r, special) = strconv::to_str_common(
         &num, rdx, true, strconv::SignNeg, strconv::DigAll);
-    if special { fail!(~"number has a special value, \
+    if special { fail!("number has a special value, \
                       try to_str_radix_special() if those are expected") }
     r
 }

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -814,7 +814,7 @@ pub fn to_str_hex(num: f64) -> ~str {
 pub fn to_str_radix(num: f64, rdx: uint) -> ~str {
     let (r, special) = strconv::to_str_common(
         &num, rdx, true, strconv::SignNeg, strconv::DigAll);
-    if special { fail!(~"number has a special value, \
+    if special { fail!("number has a special value, \
                       try to_str_radix_special() if those are expected") }
     r
 }

--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -133,7 +133,7 @@ pub fn to_str_hex(num: float) -> ~str {
 pub fn to_str_radix(num: float, radix: uint) -> ~str {
     let (r, special) = strconv::to_str_common(
         &num, radix, true, strconv::SignNeg, strconv::DigAll);
-    if special { fail!(~"number has a special value, \
+    if special { fail!("number has a special value, \
                          try to_str_radix_special() if those are expected") }
     r
 }

--- a/src/libcore/num/int-template.rs
+++ b/src/libcore/num/int-template.rs
@@ -89,7 +89,7 @@ pub fn gt(x: T, y: T) -> bool { x > y }
 pub fn _range_step(start: T, stop: T, step: T, it: &fn(T) -> bool) -> bool {
     let mut i = start;
     if step == 0 {
-        fail!(~"range_step called with step == 0");
+        fail!("range_step called with step == 0");
     } else if step > 0 { // ascending
         while i < stop {
             if !it(i) { return false; }
@@ -923,16 +923,16 @@ mod tests {
 
         // None of the `fail`s should execute.
         for range(10,0) |_i| {
-            fail!(~"unreachable");
+            fail!("unreachable");
         }
         for range_rev(0,10) |_i| {
-            fail!(~"unreachable");
+            fail!("unreachable");
         }
         for range_step(10,0,1) |_i| {
-            fail!(~"unreachable");
+            fail!("unreachable");
         }
         for range_step(0,10,-1) |_i| {
-            fail!(~"unreachable");
+            fail!("unreachable");
         }
     }
 

--- a/src/libcore/num/strconv.rs
+++ b/src/libcore/num/strconv.rs
@@ -178,11 +178,11 @@ pub fn to_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+NumStrConv+Copy+
         num: &T, radix: uint, negative_zero: bool,
         sign: SignFormat, digits: SignificantDigits) -> (~[u8], bool) {
     if (radix as int) < 2 {
-        fail!(fmt!("to_str_bytes_common: radix %? to low, \
-                   must lie in the range [2, 36]", radix));
+        fail!("to_str_bytes_common: radix %? to low, \
+                   must lie in the range [2, 36]", radix);
     } else if radix as int > 36 {
-        fail!(fmt!("to_str_bytes_common: radix %? to high, \
-                   must lie in the range [2, 36]", radix));
+        fail!("to_str_bytes_common: radix %? to high, \
+                   must lie in the range [2, 36]", radix);
     }
 
     let _0: T = Zero::zero();
@@ -444,20 +444,20 @@ pub fn from_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+Copy+Div<T,T>+
         ) -> Option<T> {
     match exponent {
         ExpDec if radix >= DIGIT_E_RADIX       // decimal exponent 'e'
-          => fail!(fmt!("from_str_bytes_common: radix %? incompatible with \
-                        use of 'e' as decimal exponent", radix)),
+          => fail!("from_str_bytes_common: radix %? incompatible with \
+                        use of 'e' as decimal exponent", radix),
         ExpBin if radix >= DIGIT_P_RADIX       // binary exponent 'p'
-          => fail!(fmt!("from_str_bytes_common: radix %? incompatible with \
-                        use of 'p' as binary exponent", radix)),
+          => fail!("from_str_bytes_common: radix %? incompatible with \
+                        use of 'p' as binary exponent", radix),
         _ if special && radix >= DIGIT_I_RADIX // first digit of 'inf'
-          => fail!(fmt!("from_str_bytes_common: radix %? incompatible with \
-                        special values 'inf' and 'NaN'", radix)),
+          => fail!("from_str_bytes_common: radix %? incompatible with \
+                        special values 'inf' and 'NaN'", radix),
         _ if (radix as int) < 2
-          => fail!(fmt!("from_str_bytes_common: radix %? to low, \
-                        must lie in the range [2, 36]", radix)),
+          => fail!("from_str_bytes_common: radix %? to low, \
+                        must lie in the range [2, 36]", radix),
         _ if (radix as int) > 36
-          => fail!(fmt!("from_str_bytes_common: radix %? to high, \
-                        must lie in the range [2, 36]", radix)),
+          => fail!("from_str_bytes_common: radix %? to high, \
+                        must lie in the range [2, 36]", radix),
         _ => ()
     }
 

--- a/src/libcore/num/strconv.rs
+++ b/src/libcore/num/strconv.rs
@@ -178,11 +178,9 @@ pub fn to_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+NumStrConv+Copy+
         num: &T, radix: uint, negative_zero: bool,
         sign: SignFormat, digits: SignificantDigits) -> (~[u8], bool) {
     if (radix as int) < 2 {
-        fail!("to_str_bytes_common: radix %? to low, \
-                   must lie in the range [2, 36]", radix);
+        fail!("to_str_bytes_common: radix %? to low, must lie in the range [2, 36]", radix);
     } else if radix as int > 36 {
-        fail!("to_str_bytes_common: radix %? to high, \
-                   must lie in the range [2, 36]", radix);
+        fail!("to_str_bytes_common: radix %? to high, must lie in the range [2, 36]", radix);
     }
 
     let _0: T = Zero::zero();
@@ -445,19 +443,19 @@ pub fn from_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+Copy+Div<T,T>+
     match exponent {
         ExpDec if radix >= DIGIT_E_RADIX       // decimal exponent 'e'
           => fail!("from_str_bytes_common: radix %? incompatible with \
-                        use of 'e' as decimal exponent", radix),
+                    use of 'e' as decimal exponent", radix),
         ExpBin if radix >= DIGIT_P_RADIX       // binary exponent 'p'
           => fail!("from_str_bytes_common: radix %? incompatible with \
-                        use of 'p' as binary exponent", radix),
+                    use of 'p' as binary exponent", radix),
         _ if special && radix >= DIGIT_I_RADIX // first digit of 'inf'
           => fail!("from_str_bytes_common: radix %? incompatible with \
-                        special values 'inf' and 'NaN'", radix),
+                    special values 'inf' and 'NaN'", radix),
         _ if (radix as int) < 2
           => fail!("from_str_bytes_common: radix %? to low, \
-                        must lie in the range [2, 36]", radix),
+                    must lie in the range [2, 36]", radix),
         _ if (radix as int) > 36
           => fail!("from_str_bytes_common: radix %? to high, \
-                        must lie in the range [2, 36]", radix),
+                    must lie in the range [2, 36]", radix),
         _ => ()
     }
 

--- a/src/libcore/num/uint-template.rs
+++ b/src/libcore/num/uint-template.rs
@@ -57,7 +57,7 @@ pub fn _range_step(start: T,
                    it: &fn(T) -> bool) -> bool {
     let mut i = start;
     if step == 0 {
-        fail!(~"range_step called with step == 0");
+        fail!("range_step called with step == 0");
     }
     if step >= 0 {
         while i < stop {
@@ -630,16 +630,16 @@ mod tests {
 
         // None of the `fail`s should execute.
         for range(0,0) |_i| {
-            fail!(~"unreachable");
+            fail!("unreachable");
         }
         for range_rev(0,0) |_i| {
-            fail!(~"unreachable");
+            fail!("unreachable");
         }
         for range_step(10,0,1) |_i| {
-            fail!(~"unreachable");
+            fail!("unreachable");
         }
         for range_step(0,1,-10) |_i| {
-            fail!(~"unreachable");
+            fail!("unreachable");
         }
     }
 

--- a/src/libcore/old_iter.rs
+++ b/src/libcore/old_iter.rs
@@ -269,7 +269,7 @@ pub fn min<A:Copy + Ord,IA:BaseIter<A>>(this: &IA) -> A {
         }
     } {
         Some(val) => val,
-        None => fail!(~"min called on empty iterator")
+        None => fail!("min called on empty iterator")
     }
 }
 
@@ -284,7 +284,7 @@ pub fn max<A:Copy + Ord,IA:BaseIter<A>>(this: &IA) -> A {
         }
     } {
         Some(val) => val,
-        None => fail!(~"max called on empty iterator")
+        None => fail!("max called on empty iterator")
     }
 }
 

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -265,7 +265,7 @@ pub impl<T> Option<T> {
     fn get_ref<'a>(&'a self) -> &'a T {
         match *self {
           Some(ref x) => x,
-          None => fail!(~"option::get_ref none")
+          None => fail!("option::get_ref none")
         }
     }
 
@@ -287,7 +287,7 @@ pub impl<T> Option<T> {
     fn get_mut_ref<'a>(&'a mut self) -> &'a mut T {
         match *self {
           Some(ref mut x) => x,
-          None => fail!(~"option::get_mut_ref none")
+          None => fail!("option::get_mut_ref none")
         }
     }
 
@@ -311,7 +311,7 @@ pub impl<T> Option<T> {
          */
         match self {
           Some(x) => x,
-          None => fail!(~"option::unwrap none")
+          None => fail!("option::unwrap none")
         }
     }
 
@@ -325,7 +325,7 @@ pub impl<T> Option<T> {
      */
     #[inline(always)]
     fn swap_unwrap(&mut self) -> T {
-        if self.is_none() { fail!(~"option::swap_unwrap none") }
+        if self.is_none() { fail!("option::swap_unwrap none") }
         util::replace(self, None).unwrap()
     }
 
@@ -365,7 +365,7 @@ pub impl<T:Copy> Option<T> {
     fn get(self) -> T {
         match self {
           Some(copy x) => return x,
-          None => fail!(~"option::get none")
+          None => fail!("option::get none")
         }
     }
 

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -178,8 +178,8 @@ pub fn env() -> ~[(~str,~str)] {
             };
             let ch = GetEnvironmentStringsA();
             if (ch as uint == 0) {
-                fail!(fmt!("os::env() failure getting env string from OS: %s",
-                           os::last_os_error()));
+                fail!("os::env() failure getting env string from OS: %s",
+                           os::last_os_error());
             }
             let mut curr_ptr: uint = ch as uint;
             let mut result = ~[];
@@ -201,8 +201,8 @@ pub fn env() -> ~[(~str,~str)] {
             }
             let environ = rust_env_pairs();
             if (environ as uint == 0) {
-                fail!(fmt!("os::env() failure getting env string from OS: %s",
-                           os::last_os_error()));
+                fail!("os::env() failure getting env string from OS: %s",
+                           os::last_os_error());
             }
             let mut result = ~[];
             ptr::array_each(environ, |e| {
@@ -744,8 +744,7 @@ pub fn list_dir(p: &Path) -> ~[~str] {
                     while more_files != 0 {
                         let fp_buf = rust_list_dir_wfd_fp_buf(wfd_ptr);
                         if fp_buf as uint == 0 {
-                            fail!(~"os::list_dir() failure:"+
-                                  ~" got null ptr from wfd");
+                            fail!("os::list_dir() failure: got null ptr from wfd");
                         }
                         else {
                             let fp_vec = vec::from_buf(
@@ -1062,7 +1061,7 @@ pub fn last_os_error() -> ~str {
             let err = strerror_r(errno() as c_int, &mut buf[0],
                                  TMPBUF_SZ as size_t);
             if err < 0 {
-                fail!(~"strerror_r failure");
+                fail!("strerror_r failure");
             }
 
             str::raw::from_c_str(&buf[0])
@@ -1100,7 +1099,7 @@ pub fn last_os_error() -> ~str {
                                      &mut buf[0], TMPBUF_SZ as DWORD,
                                      ptr::null());
             if res == 0 {
-                fail!(fmt!("[%?] FormatMessage failure", errno()));
+                fail!("[%?] FormatMessage failure", errno());
             }
 
             str::raw::from_c_str(&buf[0])
@@ -1304,7 +1303,7 @@ pub fn glob(pattern: &str) -> ~[Path] {
 /// Returns a vector of Path objects that match the given glob pattern
 #[cfg(target_os = "win32")]
 pub fn glob(pattern: &str) -> ~[Path] {
-    fail!(~"glob() is unimplemented on Windows")
+    fail!("glob() is unimplemented on Windows")
 }
 
 #[cfg(target_os = "macos")]
@@ -1638,7 +1637,7 @@ mod tests {
           let in_mode = in.get_mode();
           let rs = os::copy_file(&in, &out);
           if (!os::path_exists(&in)) {
-            fail!(fmt!("%s doesn't exist", in.to_str()));
+            fail!("%s doesn't exist", in.to_str());
           }
           assert!((rs));
           let rslt = run::run_program(~"diff", ~[in.to_str(), out.to_str()]);

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -178,8 +178,7 @@ pub fn env() -> ~[(~str,~str)] {
             };
             let ch = GetEnvironmentStringsA();
             if (ch as uint == 0) {
-                fail!("os::env() failure getting env string from OS: %s",
-                           os::last_os_error());
+                fail!("os::env() failure getting env string from OS: %s", os::last_os_error());
             }
             let mut curr_ptr: uint = ch as uint;
             let mut result = ~[];
@@ -201,8 +200,7 @@ pub fn env() -> ~[(~str,~str)] {
             }
             let environ = rust_env_pairs();
             if (environ as uint == 0) {
-                fail!("os::env() failure getting env string from OS: %s",
-                           os::last_os_error());
+                fail!("os::env() failure getting env string from OS: %s", os::last_os_error());
             }
             let mut result = ~[];
             ptr::array_each(environ, |e| {

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -281,7 +281,7 @@ fn wait_event(this: *rust_task) -> *libc::c_void {
 
         let killed = rustrt::task_wait_event(this, &mut event);
         if killed && !task::failing() {
-            fail!(~"killed")
+            fail!("killed")
         }
         event
     }
@@ -365,7 +365,7 @@ pub fn send<T,Tbuffer>(mut p: SendPacketBuffered<T,Tbuffer>,
             //unsafe { forget(p); }
             return true;
         }
-        Full => fail!(~"duplicate send"),
+        Full => fail!("duplicate send"),
         Blocked => {
             debug!("waking up task for %?", p_);
             let old_task = swap_task(&mut p.header.blocked_task, ptr::null());
@@ -478,7 +478,7 @@ fn try_recv_<T:Owned>(p: &mut Packet<T>) -> Option<T> {
             debug!("woke up, p.state = %?", copy p.header.state);
           }
           Blocked => if first {
-            fail!(~"blocking on already blocked packet")
+            fail!("blocking on already blocked packet")
           },
           Full => {
             let payload = replace(&mut p.payload, None);
@@ -514,7 +514,7 @@ pub fn peek<T:Owned,Tb:Owned>(p: &mut RecvPacketBuffered<T, Tb>) -> bool {
     unsafe {
         match (*p.header()).state {
             Empty | Terminated => false,
-            Blocked => fail!(~"peeking on blocked packet"),
+            Blocked => fail!("peeking on blocked packet"),
             Full => true
         }
     }
@@ -543,7 +543,7 @@ fn sender_terminate<T:Owned>(p: *mut Packet<T>) {
       }
       Full => {
         // This is impossible
-        fail!(~"you dun goofed")
+        fail!("you dun goofed")
       }
       Terminated => {
         assert!(p.header.blocked_task.is_null());
@@ -609,7 +609,7 @@ pub fn wait_many<T: Selectable>(pkts: &mut [T]) -> uint {
                     (*p).state = old;
                     break;
                 }
-                Blocked => fail!(~"blocking on blocked packet"),
+                Blocked => fail!("blocking on blocked packet"),
                 Empty => ()
             }
         }
@@ -704,7 +704,7 @@ pub impl<T,Tbuffer> SendPacketBuffered<T,Tbuffer> {
                 let header = ptr::to_mut_unsafe_ptr(&mut packet.header);
                 header
             },
-            None => fail!(~"packet already consumed")
+            None => fail!("packet already consumed")
         }
     }
 
@@ -758,7 +758,7 @@ impl<T:Owned,Tbuffer:Owned> Selectable for RecvPacketBuffered<T, Tbuffer> {
                 let header = ptr::to_mut_unsafe_ptr(&mut packet.header);
                 header
             },
-            None => fail!(~"packet already consumed")
+            None => fail!("packet already consumed")
         }
     }
 }
@@ -816,7 +816,7 @@ pub fn select2<A:Owned,Ab:Owned,B:Owned,Bb:Owned>(
     match i {
         0 => Left((try_recv(a), b)),
         1 => Right((a, try_recv(b))),
-        _ => fail!(~"select2 return an invalid packet")
+        _ => fail!("select2 return an invalid packet")
     }
 }
 
@@ -840,7 +840,7 @@ pub fn select2i<A:Selectable,B:Selectable>(a: &mut A, b: &mut B)
     match wait_many(endpoints) {
         0 => Left(()),
         1 => Right(()),
-        _ => fail!(~"wait returned unexpected index")
+        _ => fail!("wait returned unexpected index")
     }
 }
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -176,7 +176,7 @@ pub fn ref_eq<'a,'b,T>(thing: &'a T, other: &'b T) -> bool {
 pub unsafe fn array_each_with_len<T>(arr: **T, len: uint, cb: &fn(*T)) {
     debug!("array_each_with_len: before iterate");
     if (arr as uint == 0) {
-        fail!(~"ptr::array_each_with_len failure: arr input is null pointer");
+        fail!("ptr::array_each_with_len failure: arr input is null pointer");
     }
     //let start_ptr = *arr;
     uint::iterate(0, len, |e| {
@@ -198,7 +198,7 @@ pub unsafe fn array_each_with_len<T>(arr: **T, len: uint, cb: &fn(*T)) {
 */
 pub unsafe fn array_each<T>(arr: **T, cb: &fn(*T)) {
     if (arr as uint == 0) {
-        fail!(~"ptr::array_each_with_len failure: arr input is null pointer");
+        fail!("ptr::array_each_with_len failure: arr input is null pointer");
     }
     let len = buf_len(arr);
     debug!("array_each inferred len: %u",

--- a/src/libcore/repr.rs
+++ b/src/libcore/repr.rs
@@ -532,7 +532,7 @@ impl TyVisitor for ReprVisitor {
                         -> bool {
         let var_stk: &mut ~[VariantState] = self.var_stk;
         match var_stk.pop() {
-            SearchingFor(*) => fail!(~"enum value matched no variant"),
+            SearchingFor(*) => fail!("enum value matched no variant"),
             _ => true
         }
     }

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -42,7 +42,7 @@ pub fn get<T:Copy,U>(res: &Result<T, U>) -> T {
     match *res {
       Ok(copy t) => t,
       Err(ref the_err) =>
-        fail!(fmt!("get called on error result: %?", *the_err))
+        fail!("get called on error result: %?", *the_err)
     }
 }
 
@@ -58,7 +58,7 @@ pub fn get_ref<'a, T, U>(res: &'a Result<T, U>) -> &'a T {
     match *res {
         Ok(ref t) => t,
         Err(ref the_err) =>
-            fail!(fmt!("get_ref called on error result: %?", *the_err))
+            fail!("get_ref called on error result: %?", *the_err)
     }
 }
 
@@ -73,7 +73,7 @@ pub fn get_ref<'a, T, U>(res: &'a Result<T, U>) -> &'a T {
 pub fn get_err<T, U: Copy>(res: &Result<T, U>) -> U {
     match *res {
       Err(copy u) => u,
-      Ok(_) => fail!(~"get_err called on ok result")
+      Ok(_) => fail!("get_err called on ok result")
     }
 }
 
@@ -378,7 +378,7 @@ pub fn iter_vec2<S,T,U:Copy>(ss: &[S], ts: &[T],
 pub fn unwrap<T, U>(res: Result<T, U>) -> T {
     match res {
       Ok(t) => t,
-      Err(_) => fail!(~"unwrap called on an err result")
+      Err(_) => fail!("unwrap called on an err result")
     }
 }
 
@@ -387,7 +387,7 @@ pub fn unwrap<T, U>(res: Result<T, U>) -> T {
 pub fn unwrap_err<T, U>(res: Result<T, U>) -> U {
     match res {
       Err(u) => u,
-      Ok(_) => fail!(~"unwrap called on an ok result")
+      Ok(_) => fail!("unwrap called on an ok result")
     }
 }
 

--- a/src/libcore/rt/local_services.rs
+++ b/src/libcore/rt/local_services.rs
@@ -163,7 +163,7 @@ pub fn borrow_local_services(f: &fn(&mut LocalServices)) {
                 f(&mut task.local_services)
             }
             None => {
-                fail!(~"no local services for schedulers yet")
+                fail!("no local services for schedulers yet")
             }
         }
     }
@@ -177,7 +177,7 @@ pub unsafe fn unsafe_borrow_local_services() -> &mut LocalServices {
             transmute_mut_region(&mut task.local_services)
         }
         None => {
-            fail!(~"no local services for schedulers yet")
+            fail!("no local services for schedulers yet")
         }
     }
 }

--- a/src/libcore/rt/sched/mod.rs
+++ b/src/libcore/rt/sched/mod.rs
@@ -295,7 +295,7 @@ pub impl Scheduler {
             Some(DoNothing) => {
                 None
             }
-            None => fail!(fmt!("all context switches should have a cleanup job"))
+            None => fail!("all context switches should have a cleanup job")
         };
         // XXX: Pattern matching mutable pointers above doesn't work
         // because borrowck thinks the three patterns are conflicting

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -646,8 +646,7 @@ pub fn program_output(prog: &str, args: &[~str]) -> ProgramOutput {
                 errs = s;
             }
             (n, _) => {
-                fail!("program_output received an unexpected file \
-                           number: %u", n);
+                fail!("program_output received an unexpected file number: %u", n);
             }
         };
         count -= 1;

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -205,29 +205,29 @@ fn spawn_process_internal(prog: &str, args: &[~str],
 
         let orig_std_in = get_osfhandle(if in_fd > 0 { in_fd } else { 0 }) as HANDLE;
         if orig_std_in == INVALID_HANDLE_VALUE as HANDLE {
-            fail!(fmt!("failure in get_osfhandle: %s", os::last_os_error()));
+            fail!("failure in get_osfhandle: %s", os::last_os_error());
         }
         if DuplicateHandle(cur_proc, orig_std_in, cur_proc, &mut si.hStdInput,
                            0, TRUE, DUPLICATE_SAME_ACCESS) == FALSE {
-            fail!(fmt!("failure in DuplicateHandle: %s", os::last_os_error()));
+            fail!("failure in DuplicateHandle: %s", os::last_os_error());
         }
 
         let orig_std_out = get_osfhandle(if out_fd > 0 { out_fd } else { 1 }) as HANDLE;
         if orig_std_out == INVALID_HANDLE_VALUE as HANDLE {
-            fail!(fmt!("failure in get_osfhandle: %s", os::last_os_error()));
+            fail!("failure in get_osfhandle: %s", os::last_os_error());
         }
         if DuplicateHandle(cur_proc, orig_std_out, cur_proc, &mut si.hStdOutput,
                            0, TRUE, DUPLICATE_SAME_ACCESS) == FALSE {
-            fail!(fmt!("failure in DuplicateHandle: %s", os::last_os_error()));
+            fail!("failure in DuplicateHandle: %s", os::last_os_error());
         }
 
         let orig_std_err = get_osfhandle(if err_fd > 0 { err_fd } else { 2 }) as HANDLE;
         if orig_std_err as HANDLE == INVALID_HANDLE_VALUE as HANDLE {
-            fail!(fmt!("failure in get_osfhandle: %s", os::last_os_error()));
+            fail!("failure in get_osfhandle: %s", os::last_os_error());
         }
         if DuplicateHandle(cur_proc, orig_std_err, cur_proc, &mut si.hStdError,
                            0, TRUE, DUPLICATE_SAME_ACCESS) == FALSE {
-            fail!(fmt!("failure in DuplicateHandle: %s", os::last_os_error()));
+            fail!("failure in DuplicateHandle: %s", os::last_os_error());
         }
 
         let cmd = make_command_line(prog, args);
@@ -252,7 +252,7 @@ fn spawn_process_internal(prog: &str, args: &[~str],
         CloseHandle(si.hStdError);
 
         for create_err.each |msg| {
-            fail!(fmt!("failure in CreateProcess: %s", *msg));
+            fail!("failure in CreateProcess: %s", *msg);
         }
 
         // We close the thread handle because we don't care about keeping the thread id valid,
@@ -379,7 +379,7 @@ fn spawn_process_internal(prog: &str, args: &[~str],
 
         let pid = fork();
         if pid < 0 {
-            fail!(fmt!("failure in fork: %s", os::last_os_error()));
+            fail!("failure in fork: %s", os::last_os_error());
         } else if pid > 0 {
             return RunProgramResult {pid: pid, handle: ptr::null()};
         }
@@ -387,13 +387,13 @@ fn spawn_process_internal(prog: &str, args: &[~str],
         rustrt::rust_unset_sigprocmask();
 
         if in_fd > 0 && dup2(in_fd, 0) == -1 {
-            fail!(fmt!("failure in dup2(in_fd, 0): %s", os::last_os_error()));
+            fail!("failure in dup2(in_fd, 0): %s", os::last_os_error());
         }
         if out_fd > 0 && dup2(out_fd, 1) == -1 {
-            fail!(fmt!("failure in dup2(out_fd, 1): %s", os::last_os_error()));
+            fail!("failure in dup2(out_fd, 1): %s", os::last_os_error());
         }
         if err_fd > 0 && dup2(err_fd, 2) == -1 {
-            fail!(fmt!("failure in dup3(err_fd, 2): %s", os::last_os_error()));
+            fail!("failure in dup3(err_fd, 2): %s", os::last_os_error());
         }
         // close all other fds
         for int::range_rev(getdtablesize() as int - 1, 2) |fd| {
@@ -403,7 +403,7 @@ fn spawn_process_internal(prog: &str, args: &[~str],
         for dir.each |dir| {
             do str::as_c_str(*dir) |dirp| {
                 if chdir(dirp) == -1 {
-                    fail!(fmt!("failure in chdir: %s", os::last_os_error()));
+                    fail!("failure in chdir: %s", os::last_os_error());
                 }
             }
         }
@@ -415,7 +415,7 @@ fn spawn_process_internal(prog: &str, args: &[~str],
             do with_argv(prog, args) |argv| {
                 execvp(*argv, argv);
                 // execvp only returns if an error occurred
-                fail!(fmt!("failure in execvp: %s", os::last_os_error()));
+                fail!("failure in execvp: %s", os::last_os_error());
             }
         }
     }
@@ -646,8 +646,8 @@ pub fn program_output(prog: &str, args: &[~str]) -> ProgramOutput {
                 errs = s;
             }
             (n, _) => {
-                fail!(fmt!("program_output received an unexpected file \
-                           number: %u", n));
+                fail!("program_output received an unexpected file \
+                           number: %u", n);
             }
         };
         count -= 1;
@@ -713,14 +713,14 @@ pub fn waitpid(pid: pid_t) -> int {
 
             let proc = OpenProcess(SYNCHRONIZE | PROCESS_QUERY_INFORMATION, FALSE, pid as DWORD);
             if proc.is_null() {
-                fail!(fmt!("failure in OpenProcess: %s", os::last_os_error()));
+                fail!("failure in OpenProcess: %s", os::last_os_error());
             }
 
             loop {
                 let mut status = 0;
                 if GetExitCodeProcess(proc, &mut status) == FALSE {
                     CloseHandle(proc);
-                    fail!(fmt!("failure in GetExitCodeProcess: %s", os::last_os_error()));
+                    fail!("failure in GetExitCodeProcess: %s", os::last_os_error());
                 }
                 if status != STILL_ACTIVE {
                     CloseHandle(proc);
@@ -728,7 +728,7 @@ pub fn waitpid(pid: pid_t) -> int {
                 }
                 if WaitForSingleObject(proc, INFINITE) == WAIT_FAILED {
                     CloseHandle(proc);
-                    fail!(fmt!("failure in WaitForSingleObject: %s", os::last_os_error()));
+                    fail!("failure in WaitForSingleObject: %s", os::last_os_error());
                 }
             }
         }
@@ -765,7 +765,7 @@ pub fn waitpid(pid: pid_t) -> int {
 
         let mut status = 0 as c_int;
         if unsafe { waitpid(pid, &mut status, 0) } == -1 {
-            fail!(fmt!("failure in waitpid: %s", os::last_os_error()));
+            fail!("failure in waitpid: %s", os::last_os_error());
         }
 
         return if WIFEXITED(status) {

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1051,8 +1051,8 @@ pub fn _each_split_within<'a>(ss: &'a str,
 
             (B, Cr, UnderLim) => { B }
             (B, Cr, OverLim)  if (i - last_start + 1) > lim
-                              => fail!(fmt!("word starting with %? longer than limit!",
-                                            self::slice(ss, last_start, i + 1))),
+                              => fail!("word starting with %? longer than limit!",
+                                            self::slice(ss, last_start, i + 1)),
             (B, Cr, OverLim)  => { slice(); slice_start = last_start; B }
             (B, Ws, UnderLim) => { last_end = i; C }
             (B, Ws, OverLim)  => { last_end = i; slice(); A }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1052,7 +1052,7 @@ pub fn _each_split_within<'a>(ss: &'a str,
             (B, Cr, UnderLim) => { B }
             (B, Cr, OverLim)  if (i - last_start + 1) > lim
                               => fail!("word starting with %? longer than limit!",
-                                            self::slice(ss, last_start, i + 1)),
+                                       self::slice(ss, last_start, i + 1)),
             (B, Cr, OverLim)  => { slice(); slice_start = last_start; B }
             (B, Ws, UnderLim) => { last_end = i; C }
             (B, Ws, OverLim)  => { last_end = i; slice(); A }

--- a/src/libcore/task/mod.rs
+++ b/src/libcore/task/mod.rs
@@ -198,7 +198,7 @@ pub fn task() -> TaskBuilder {
 priv impl TaskBuilder {
     fn consume(&mut self) -> TaskBuilder {
         if self.consumed {
-            fail!(~"Cannot copy a task_builder"); // Fake move mode on self
+            fail!("Cannot copy a task_builder"); // Fake move mode on self
         }
         self.consumed = true;
         let gen_body = replace(&mut self.gen_body, None);
@@ -263,7 +263,7 @@ pub impl TaskBuilder {
         // sending out messages.
 
         if self.opts.notify_chan.is_some() {
-            fail!(~"Can't set multiple future_results for one task!");
+            fail!("Can't set multiple future_results for one task!");
         }
 
         // Construct the future and give it to the caller.
@@ -494,7 +494,7 @@ pub fn yield() {
         let task_ = rt::rust_get_task();
         let killed = rt::rust_task_yield(task_);
         if killed && !failing() {
-            fail!(~"killed");
+            fail!("killed");
         }
     }
 }

--- a/src/libcore/task/spawn.rs
+++ b/src/libcore/task/spawn.rs
@@ -569,10 +569,10 @@ pub fn spawn_raw(opts: TaskOpts, f: ~fn()) {
             spawn_raw_newsched(opts, f)
         }
         SchedulerContext => {
-            fail!(~"can't spawn from scheduler context")
+            fail!("can't spawn from scheduler context")
         }
         GlobalContext => {
-            fail!(~"can't spawn from global context")
+            fail!("can't spawn from global context")
         }
     }
 }
@@ -708,7 +708,7 @@ fn spawn_raw_oldsched(mut opts: TaskOpts, f: ~fn()) {
 
     fn new_task_in_sched(opts: SchedOpts) -> *rust_task {
         if opts.foreign_stack_size != None {
-            fail!(~"foreign_stack_size scheduler option unimplemented");
+            fail!("foreign_stack_size scheduler option unimplemented");
         }
 
         let num_threads = match opts.mode {
@@ -719,11 +719,11 @@ fn spawn_raw_oldsched(mut opts: TaskOpts, f: ~fn()) {
             SingleThreaded => 1u,
             ThreadPerCore => unsafe { rt::rust_num_threads() },
             ThreadPerTask => {
-                fail!(~"ThreadPerTask scheduling mode unimplemented")
+                fail!("ThreadPerTask scheduling mode unimplemented")
             }
             ManualThreads(threads) => {
                 if threads == 0u {
-                    fail!(~"can not create a scheduler with no threads");
+                    fail!("can not create a scheduler with no threads");
                 }
                 threads
             }

--- a/src/libcore/unstable/exchange_alloc.rs
+++ b/src/libcore/unstable/exchange_alloc.rs
@@ -46,7 +46,7 @@ stuff in exchange_alloc::malloc
 pub unsafe fn malloc_raw(size: uint) -> *c_void {
     let p = c_malloc(size as size_t);
     if p.is_null() {
-        fail!(~"Failure in malloc_raw: result ptr is null");
+        fail!("Failure in malloc_raw: result ptr is null");
     }
     p
 }

--- a/src/libcore/unstable/sync.rs
+++ b/src/libcore/unstable/sync.rs
@@ -198,8 +198,7 @@ pub impl<T:Owned> Exclusive<T> {
         let rec = self.x.get();
         do (*rec).lock.lock {
             if (*rec).failed {
-                fail!(
-                    ~"Poisoned exclusive - another task failed inside!");
+                fail!("Poisoned exclusive - another task failed inside!");
             }
             (*rec).failed = true;
             let result = f(&mut (*rec).data);

--- a/src/libcore/util.rs
+++ b/src/libcore/util.rs
@@ -171,7 +171,7 @@ fn choose_weighted_item(v: &[Item]) -> Item {
 
 */
 pub fn unreachable() -> ! {
-    fail!(~"internal error: entered unreachable code");
+    fail!("internal error: entered unreachable code");
 }
 
 #[cfg(test)]

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -237,7 +237,7 @@ pub fn build_sized_opt<A>(size: Option<uint>,
 
 /// Returns the first element of a vector
 pub fn head<'r,T>(v: &'r [T]) -> &'r T {
-    if v.len() == 0 { fail!(~"head: empty vector") }
+    if v.len() == 0 { fail!("head: empty vector") }
     &v[0]
 }
 
@@ -263,7 +263,7 @@ pub fn initn<'r,T>(v: &'r [T], n: uint) -> &'r [T] {
 
 /// Returns the last element of the slice `v`, failing if the slice is empty.
 pub fn last<'r,T>(v: &'r [T]) -> &'r T {
-    if v.len() == 0 { fail!(~"last: empty vector") }
+    if v.len() == 0 { fail!("last: empty vector") }
     &v[v.len() - 1]
 }
 
@@ -587,7 +587,7 @@ pub fn consume_reverse<T>(mut v: ~[T], f: &fn(uint, v: T)) {
 pub fn pop<T>(v: &mut ~[T]) -> T {
     let ln = v.len();
     if ln == 0 {
-        fail!(~"sorry, cannot vec::pop an empty vector")
+        fail!("sorry, cannot vec::pop an empty vector")
     }
     let valptr = ptr::to_mut_unsafe_ptr(&mut v[ln - 1u]);
     unsafe {
@@ -601,7 +601,7 @@ pub fn pop<T>(v: &mut ~[T]) -> T {
 pub fn pop<T>(v: &mut ~[T]) -> T {
     let ln = v.len();
     if ln == 0 {
-        fail!(~"sorry, cannot vec::pop an empty vector")
+        fail!("sorry, cannot vec::pop an empty vector")
     }
     let valptr = ptr::to_mut_unsafe_ptr(&mut v[ln - 1u]);
     unsafe {
@@ -620,7 +620,7 @@ pub fn pop<T>(v: &mut ~[T]) -> T {
 pub fn swap_remove<T>(v: &mut ~[T], index: uint) -> T {
     let ln = v.len();
     if index >= ln {
-        fail!(fmt!("vec::swap_remove - index %u >= length %u", index, ln));
+        fail!("vec::swap_remove - index %u >= length %u", index, ln);
     }
     if index < ln - 1 {
         swap(*v, index, ln - 1);

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -606,7 +606,7 @@ pub fn check_roundtrip_convergence(code: @~str, maxIters: uint) {
         run::run_program(~"diff",
                          ~[~"-w", ~"-u", ~"round-trip-a.rs",
                           ~"round-trip-b.rs"]);
-        fail!(~"Mismatch");
+        fail!("Mismatch");
     }
 }
 

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -173,7 +173,7 @@ pub fn get_install_prefix_rpath(target_triple: &str) -> Path {
     let install_prefix = env!("CFG_PREFIX");
 
     if install_prefix == ~"" {
-        fail!(~"rustc compiled without CFG_PREFIX environment variable");
+        fail!("rustc compiled without CFG_PREFIX environment variable");
     }
 
     let tlib = filesearch::relative_target_lib_path(target_triple);

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -523,7 +523,7 @@ pub fn host_triple() -> ~str {
     return if ht != ~"" {
             ht
         } else {
-            fail!(~"rustc built without CFG_BUILD_TRIPLE")
+            fail!("rustc built without CFG_BUILD_TRIPLE")
         };
 }
 
@@ -917,7 +917,7 @@ mod test {
         let matches =
             &match getopts(~[~"--test"], optgroups()) {
               Ok(copy m) => m,
-              Err(copy f) => fail!(~"test_switch_implies_cfg_test: " +
+              Err(copy f) => fail!("test_switch_implies_cfg_test: %s",
                              getopts::fail_str(f))
             };
         let sessopts = build_session_options(
@@ -935,7 +935,7 @@ mod test {
             &match getopts(~[~"--test", ~"--cfg=test"], optgroups()) {
               Ok(copy m) => m,
               Err(copy f) => {
-                fail!(~"test_switch_implies_cfg_test_unless_cfg_test: " +
+                fail!("test_switch_implies_cfg_test_unless_cfg_test: %s",
                     getopts::fail_str(f));
               }
             };

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -917,8 +917,7 @@ mod test {
         let matches =
             &match getopts(~[~"--test"], optgroups()) {
               Ok(copy m) => m,
-              Err(copy f) => fail!("test_switch_implies_cfg_test: %s",
-                             getopts::fail_str(f))
+              Err(copy f) => fail!("test_switch_implies_cfg_test: %s", getopts::fail_str(f))
             };
         let sessopts = build_session_options(
             @~"rustc", matches, diagnostic::emit);
@@ -935,8 +934,7 @@ mod test {
             &match getopts(~[~"--test", ~"--cfg=test"], optgroups()) {
               Ok(copy m) => m,
               Err(copy f) => {
-                fail!("test_switch_implies_cfg_test_unless_cfg_test: %s",
-                    getopts::fail_str(f));
+                fail!("test_switch_implies_cfg_test_unless_cfg_test: %s", getopts::fail_str(f));
               }
             };
         let sessopts = build_session_options(

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -2044,7 +2044,7 @@ pub fn float_width(llt: TypeRef) -> uint {
               2 => 64u,
               3 => 80u,
               4 | 5 => 128u,
-              _ => fail!(~"llvm_float_width called on a non-float type")
+              _ => fail!("llvm_float_width called on a non-float type")
             };
     }
 }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -87,7 +87,7 @@ fn find_item(item_id: int, items: ebml::Doc) -> ebml::Doc {
 fn lookup_item(item_id: int, data: @~[u8]) -> ebml::Doc {
     let items = reader::get_doc(reader::Doc(data), tag_items);
     match maybe_find_item(item_id, items) {
-       None => fail!(fmt!("lookup_item: id not found: %d", item_id)),
+       None => fail!("lookup_item: id not found: %d", item_id),
        Some(d) => d
     }
 }
@@ -139,7 +139,7 @@ fn item_family(item: ebml::Doc) -> Family {
       'g' => PublicField,
       'j' => PrivateField,
       'N' => InheritedField,
-       c => fail!(fmt!("unexpected family char: %c", c))
+       c => fail!("unexpected family char: %c", c)
     }
 }
 
@@ -151,7 +151,7 @@ fn item_visibility(item: ebml::Doc) -> ast::visibility {
                 'y' => ast::public,
                 'n' => ast::private,
                 'i' => ast::inherited,
-                _ => fail!(~"unknown visibility character")
+                _ => fail!("unknown visibility character")
             }
         }
     }
@@ -458,8 +458,8 @@ pub enum def_like {
 fn def_like_to_def(def_like: def_like) -> ast::def {
     match def_like {
         dl_def(def) => return def,
-        dl_impl(*) => fail!(~"found impl in def_like_to_def"),
-        dl_field => fail!(~"found field in def_like_to_def")
+        dl_impl(*) => fail!("found impl in def_like_to_def"),
+        dl_field => fail!("found field in def_like_to_def")
     }
 }
 
@@ -677,7 +677,7 @@ fn get_self_ty(item: ebml::Doc) -> ast::self_ty_ {
             'm' => { ast::m_mutbl }
             'c' => { ast::m_const }
             _ => {
-                fail!(fmt!("unknown mutability character: `%c`", ch as char))
+                fail!("unknown mutability character: `%c`", ch as char)
             }
         }
     }
@@ -696,7 +696,7 @@ fn get_self_ty(item: ebml::Doc) -> ast::self_ty_ {
             return ast::sty_region(None, get_mutability(string[1]));
         }
         _ => {
-            fail!(fmt!("unknown self type code: `%c`", self_ty_kind as char));
+            fail!("unknown self type code: `%c`", self_ty_kind as char);
         }
     }
 }
@@ -998,7 +998,7 @@ fn describe_def(items: ebml::Doc, id: ast::def_id) -> ~str {
     if id.crate != ast::local_crate { return ~"external"; }
     let it = match maybe_find_item(id.node, items) {
         Some(it) => it,
-        None => fail!(fmt!("describe_def: item not found %?", id))
+        None => fail!("describe_def: item not found %?", id)
     };
     return item_family_to_str(item_family(it));
 }
@@ -1189,7 +1189,7 @@ pub fn translate_def_id(cdata: cmd, did: ast::def_id) -> ast::def_id {
 
     match cdata.cnum_map.find(&did.crate) {
       option::Some(&n) => ast::def_id { crate: n, node: did.node },
-      option::None => fail!(~"didn't find a crate in the cnum_map")
+      option::None => fail!("didn't find a crate in the cnum_map")
     }
 }
 

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -696,7 +696,7 @@ fn purity_static_method_family(p: purity) -> char {
       unsafe_fn => 'U',
       pure_fn => 'P',
       impure_fn => 'F',
-      _ => fail!(~"extern fn can't be static")
+      _ => fail!("extern fn can't be static")
     }
 }
 
@@ -1009,7 +1009,7 @@ fn encode_info_for_item(ecx: @EncodeContext,
             ebml_w.end_tag();
         }
       }
-      item_mac(*) => fail!(~"item macros unimplemented")
+      item_mac(*) => fail!("item macros unimplemented")
     }
 }
 
@@ -1068,7 +1068,7 @@ fn encode_info_for_items(ecx: @EncodeContext,
                         let mut ebml_w = copy ebml_w;
                         encode_info_for_item(ecx, &mut ebml_w, i, index, *pt);
                     }
-                    _ => fail!(~"bad item")
+                    _ => fail!("bad item")
                 }
             }
         },
@@ -1087,7 +1087,7 @@ fn encode_info_for_items(ecx: @EncodeContext,
                                                      abi);
                     }
                     // case for separate item and foreign-item tables
-                    _ => fail!(~"bad foreign item")
+                    _ => fail!("bad foreign item")
                 }
             }
         },

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -139,7 +139,7 @@ fn make_target_lib_path(sysroot: &Path,
 fn get_or_default_sysroot() -> Path {
     match os::self_exe_path() {
       option::Some(ref p) => (*p).pop(),
-      option::None => fail!(~"can't determine value for sysroot")
+      option::None => fail!("can't determine value for sysroot")
     }
 }
 
@@ -207,7 +207,7 @@ fn get_rustpkg_lib_path_nearest() -> Result<Path, ~str> {
 pub fn libdir() -> ~str {
    let libdir = env!("CFG_LIBDIR");
    if str::is_empty(libdir) {
-      fail!(~"rustc compiled without CFG_LIBDIR environment variable");
+      fail!("rustc compiled without CFG_LIBDIR environment variable");
    }
    libdir
 }

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -142,7 +142,7 @@ pub fn crate_name_from_metas(metas: &[@ast::meta_item]) -> @~str {
                 _ => fail!()
             }
         }
-        None => fail!(~"expected to find the crate name")
+        None => fail!("expected to find the crate name")
     }
 }
 

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -219,7 +219,7 @@ fn parse_bound_region(st: @mut PState) -> ty::bound_region {
         assert!(next(st) == '|');
         ty::br_cap_avoid(id, @parse_bound_region(st))
       },
-      _ => fail!(~"parse_bound_region: bad input")
+      _ => fail!("parse_bound_region: bad input")
     }
 }
 
@@ -248,7 +248,7 @@ fn parse_region(st: @mut PState) -> ty::Region {
       'e' => {
         ty::re_static
       }
-      _ => fail!(~"parse_region: bad input")
+      _ => fail!("parse_region: bad input")
     }
 }
 
@@ -256,7 +256,7 @@ fn parse_opt<T>(st: @mut PState, f: &fn() -> T) -> Option<T> {
     match next(st) {
       'n' => None,
       's' => Some(f()),
-      _ => fail!(~"parse_opt: bad input")
+      _ => fail!("parse_opt: bad input")
     }
 }
 
@@ -295,7 +295,7 @@ fn parse_ty(st: @mut PState, conv: conv_did) -> ty::t {
           'D' => return ty::mk_mach_int(ast::ty_i64),
           'f' => return ty::mk_mach_float(ast::ty_f32),
           'F' => return ty::mk_mach_float(ast::ty_f64),
-          _ => fail!(~"parse_ty: bad numeric type")
+          _ => fail!("parse_ty: bad numeric type")
         }
       }
       'c' => return ty::mk_char(),
@@ -446,7 +446,7 @@ fn parse_purity(c: char) -> purity {
       'p' => pure_fn,
       'i' => impure_fn,
       'c' => extern_fn,
-      _ => fail!(~"parse_purity: bad purity")
+      _ => fail!("parse_purity: bad purity")
     }
 }
 
@@ -467,7 +467,7 @@ fn parse_onceness(c: char) -> ast::Onceness {
     match c {
         'o' => ast::Once,
         'm' => ast::Many,
-        _ => fail!(~"parse_onceness: bad onceness")
+        _ => fail!("parse_onceness: bad onceness")
     }
 }
 
@@ -531,13 +531,13 @@ pub fn parse_def_id(buf: &[u8]) -> ast::def_id {
 
     let crate_num = match uint::parse_bytes(crate_part, 10u) {
        Some(cn) => cn as int,
-       None => fail!(fmt!("internal error: parse_def_id: crate number \
-                               expected, but found %?", crate_part))
+       None => fail!("internal error: parse_def_id: crate number \
+                               expected, but found %?", crate_part)
     };
     let def_num = match uint::parse_bytes(def_part, 10u) {
        Some(dn) => dn as int,
-       None => fail!(fmt!("internal error: parse_def_id: id expected, but \
-                               found %?", def_part))
+       None => fail!("internal error: parse_def_id: id expected, but \
+                               found %?", def_part)
     };
     ast::def_id { crate: crate_num, node: def_num }
 }
@@ -581,7 +581,7 @@ fn parse_bounds(st: @mut PState, conv: conv_did) -> @ty::ParamBounds {
                 return @param_bounds;
             }
             _ => {
-                fail!(~"parse_bounds: bad bounds")
+                fail!("parse_bounds: bad bounds")
             }
         }
     }

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -531,13 +531,13 @@ pub fn parse_def_id(buf: &[u8]) -> ast::def_id {
 
     let crate_num = match uint::parse_bytes(crate_part, 10u) {
        Some(cn) => cn as int,
-       None => fail!("internal error: parse_def_id: crate number \
-                               expected, but found %?", crate_part)
+       None => fail!("internal error: parse_def_id: crate number expected, but found %?",
+                     crate_part)
     };
     let def_num = match uint::parse_bytes(def_part, 10u) {
        Some(dn) => dn as int,
-       None => fail!("internal error: parse_def_id: id expected, but \
-                               found %?", def_part)
+       None => fail!("internal error: parse_def_id: id expected, but found %?",
+                     def_part)
     };
     ast::def_id { crate: crate_num, node: def_num }
 }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -332,7 +332,7 @@ fn enc_sty(w: @io::Writer, cx: @ctxt, st: ty::sty) {
           debug!("~~~~ %s", ~"]");
           w.write_char(']');
       }
-      ty::ty_err => fail!(~"Shouldn't encode error type")
+      ty::ty_err => fail!("Shouldn't encode error type")
     }
 }
 

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -293,7 +293,7 @@ fn simplify_ast(ii: &ast::inlined_item) -> ast::inlined_item {
                                              span: _}, _) => true,
               ast::stmt_decl(@codemap::spanned { node: ast::decl_item(_),
                                              span: _}, _) => false,
-              ast::stmt_mac(*) => fail!(~"unexpanded macro in astencode")
+              ast::stmt_mac(*) => fail!("unexpanded macro in astencode")
             }
         };
         let blk_sans_items = ast::blk_ {
@@ -686,7 +686,7 @@ impl vtable_decoder_helpers for reader::Decoder {
                     )
                   }
                   // hard to avoid - user input
-                  _ => fail!(~"bad enum variant")
+                  _ => fail!("bad enum variant")
                 }
             }
         }

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -241,7 +241,7 @@ pub fn check_item_recursion(sess: Session,
                     ast_map::node_item(it, _) => {
                       (v.visit_item)(it, env, v);
                     }
-                    _ => fail!(~"const not bound to an item")
+                    _ => fail!("const not bound to an item")
                   }
                 }
               }

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -147,14 +147,14 @@ pub fn check_exhaustive(cx: @MatchCheckCtxt, sp: span, pats: ~[@pat]) {
                 ty::ty_enum(id, _) => {
                     let vid = match *ctor {
                         variant(id) => id,
-                        _ => fail!(~"check_exhaustive: non-variant ctor"),
+                        _ => fail!("check_exhaustive: non-variant ctor"),
                     };
                     let variants = ty::enum_variants(cx.tcx, id);
 
                     match variants.find(|v| v.id == vid) {
                         Some(v) => Some(cx.tcx.sess.str_of(v.name)),
                         None => {
-                            fail!(~"check_exhaustive: bad variant in ctor")
+                            fail!("check_exhaustive: bad variant in ctor")
                         }
                     }
                 }
@@ -382,7 +382,7 @@ pub fn missing_ctor(cx: @MatchCheckCtxt,
               None => (),
               Some(val(const_bool(true))) => true_found = true,
               Some(val(const_bool(false))) => false_found = true,
-              _ => fail!(~"impossible case")
+              _ => fail!("impossible case")
             }
         }
         if true_found && false_found { None }
@@ -449,10 +449,10 @@ pub fn ctor_arity(cx: @MatchCheckCtxt, ctor: &ctor, ty: ty::t) -> uint {
       ty::ty_box(_) | ty::ty_uniq(_) | ty::ty_rptr(*) => 1u,
       ty::ty_enum(eid, _) => {
           let id = match *ctor { variant(id) => id,
-          _ => fail!(~"impossible case") };
+          _ => fail!("impossible case") };
         match vec::find(*ty::enum_variants(cx.tcx, eid), |v| v.id == id ) {
             Some(v) => v.args.len(),
-            None => fail!(~"impossible case")
+            None => fail!("impossible case")
         }
       }
       ty::ty_struct(cid, _) => ty::lookup_struct_fields(cx.tcx, cid).len(),
@@ -504,7 +504,7 @@ pub fn specialize(cx: @MatchCheckCtxt,
                                     compare_const_vals(c_hi, &e_v) <= 0
                             }
                             single => true,
-                            _ => fail!(~"type error")
+                            _ => fail!("type error")
                         };
                         if match_ {
                             Some(vec::to_owned(r.tail()))
@@ -535,7 +535,7 @@ pub fn specialize(cx: @MatchCheckCtxt,
                                     compare_const_vals(c_hi, &e_v) <= 0
                             }
                             single => true,
-                            _ => fail!(~"type error")
+                            _ => fail!("type error")
                         };
                         if match_ {
                             Some(vec::to_owned(r.tail()))
@@ -625,7 +625,7 @@ pub fn specialize(cx: @MatchCheckCtxt,
                             compare_const_vals(c_hi, &e_v) <= 0
                     }
                     single => true,
-                    _ => fail!(~"type error")
+                    _ => fail!("type error")
                 };
                 if match_ { Some(vec::to_owned(r.tail())) } else { None }
             }
@@ -635,7 +635,7 @@ pub fn specialize(cx: @MatchCheckCtxt,
                     range(ref lo, ref hi) =>
                         ((/*bad*/copy *lo), (/*bad*/copy *hi)),
                     single => return Some(vec::to_owned(r.tail())),
-                    _ => fail!(~"type error")
+                    _ => fail!("type error")
                 };
                 let v_lo = eval_const_expr(cx.tcx, lo),
                 v_hi = eval_const_expr(cx.tcx, hi);

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -467,7 +467,7 @@ pub fn compare_const_vals(a: &const_val, b: &const_val) -> int {
             1
         }
     }
-    _ => fail!(~"compare_const_vals: ill-typed comparison")
+    _ => fail!("compare_const_vals: ill-typed comparison")
   }
 }
 

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -48,7 +48,7 @@ fn collect_freevars(def_map: resolve::DefMap, blk: &ast::blk)
               ast::expr_path(*) | ast::expr_self => {
                   let mut i = 0;
                   match def_map.find(&expr.id) {
-                    None => fail!(~"path not found"),
+                    None => fail!("path not found"),
                     Some(&df) => {
                       let mut def = df;
                       while i < depth {
@@ -111,7 +111,7 @@ pub fn annotate_freevars(def_map: resolve::DefMap, crate: @ast::crate) ->
 
 pub fn get_freevars(tcx: ty::ctxt, fid: ast::node_id) -> freevar_info {
     match tcx.freevars.find(&fid) {
-      None => fail!(~"get_freevars: "+int::to_str(fid)+~" has no freevars"),
+      None => fail!("get_freevars: %d has no freevars", fid),
       Some(&d) => return d
     }
 }

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -275,11 +275,11 @@ pub fn check_expr(e: @expr, cx: Context, v: visit::vt<Context>) {
         };
         if ts.len() != type_param_defs.len() {
             // Fail earlier to make debugging easier
-            fail!(fmt!("internal error: in kind::check_expr, length \
+            fail!("internal error: in kind::check_expr, length \
                        mismatch between actual and declared bounds: actual = \
                         %s, declared = %s",
                        ts.repr(cx.tcx),
-                       type_param_defs.repr(cx.tcx)));
+                       type_param_defs.repr(cx.tcx));
         }
         for vec::each2(**ts, *type_param_defs) |&ty, type_param_def| {
             check_bounds(cx, type_parameter_id, e.span, ty, type_param_def)

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -276,10 +276,10 @@ pub fn check_expr(e: @expr, cx: Context, v: visit::vt<Context>) {
         if ts.len() != type_param_defs.len() {
             // Fail earlier to make debugging easier
             fail!("internal error: in kind::check_expr, length \
-                       mismatch between actual and declared bounds: actual = \
-                        %s, declared = %s",
-                       ts.repr(cx.tcx),
-                       type_param_defs.repr(cx.tcx));
+                  mismatch between actual and declared bounds: actual = \
+                  %s, declared = %s",
+                  ts.repr(cx.tcx),
+                  type_param_defs.repr(cx.tcx));
         }
         for vec::each2(**ts, *type_param_defs) |&ty, type_param_def| {
             check_bounds(cx, type_parameter_id, e.span, ty, type_param_def)

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -127,7 +127,7 @@ pub impl RegionMaps {
 
         match self.scope_map.find(&id) {
             Some(&r) => r,
-            None => { fail!(fmt!("No enclosing scope for id %?", id)); }
+            None => { fail!("No enclosing scope for id %?", id); }
         }
     }
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -319,7 +319,7 @@ pub fn namespace_for_duplicate_checking_mode(mode: DuplicateCheckingMode)
         ForbidDuplicateModules | ForbidDuplicateTypes |
         ForbidDuplicateTypesAndValues => TypeNS,
         ForbidDuplicateValues => ValueNS,
-        OverwriteDuplicates => fail!(~"OverwriteDuplicates has no namespace")
+        OverwriteDuplicates => fail!("OverwriteDuplicates has no namespace")
     }
 }
 
@@ -605,7 +605,7 @@ pub impl NameBindings {
     fn get_module(@mut self) -> @mut Module {
         match self.get_module_if_available() {
             None => {
-                fail!(~"get_module called on a node with no module \
+                fail!("get_module called on a node with no module \
                        definition!")
             }
             Some(module_def) => module_def
@@ -1336,7 +1336,7 @@ pub impl Resolver {
             }
 
             item_mac(*) => {
-                fail!(~"item macros unimplemented")
+                fail!("item macros unimplemented")
             }
         }
     }
@@ -1577,7 +1577,7 @@ pub impl Resolver {
                     match existing_module.parent_link {
                       NoParentLink |
                       BlockParentLink(*) => {
-                        fail!(~"can't happen");
+                        fail!("can't happen");
                       }
                       ModuleParentLink(parent_module, ident) => {
                         let name_bindings = parent_module.children.get(
@@ -1647,7 +1647,7 @@ pub impl Resolver {
           def_prim_ty(*) | def_ty_param(*) | def_binding(*) |
           def_use(*) | def_upvar(*) | def_region(*) |
           def_typaram_binder(*) | def_label(*) | def_self_ty(*) => {
-            fail!(fmt!("didn't expect `%?`", def));
+            fail!("didn't expect `%?`", def);
           }
         }
     }
@@ -2269,7 +2269,7 @@ pub impl Resolver {
             }
             UnboundResult => { /* Continue. */ }
             UnknownResult => {
-                fail!(~"value result should be known at this point");
+                fail!("value result should be known at this point");
             }
         }
         match type_result {
@@ -2279,7 +2279,7 @@ pub impl Resolver {
             }
             UnboundResult => { /* Continue. */ }
             UnknownResult => {
-                fail!(~"type result should be known at this point");
+                fail!("type result should be known at this point");
             }
         }
 
@@ -3573,7 +3573,7 @@ pub impl Resolver {
             }
 
           item_mac(*) => {
-            fail!(~"item macros unimplemented")
+            fail!("item macros unimplemented")
           }
         }
 
@@ -4310,7 +4310,7 @@ pub impl Resolver {
             Success(target) => {
                 match target.bindings.value_def {
                     None => {
-                        fail!(~"resolved name in the value namespace to a \
+                        fail!("resolved name in the value namespace to a \
                               set of name bindings with no def?!");
                     }
                     Some(def) => {
@@ -4330,7 +4330,7 @@ pub impl Resolver {
             }
 
             Indeterminate => {
-                fail!(~"unexpected indeterminate result");
+                fail!("unexpected indeterminate result");
             }
 
             Failed => {
@@ -4501,7 +4501,7 @@ pub impl Resolver {
             }
 
             Indeterminate => {
-                fail!(~"indeterminate unexpected");
+                fail!("indeterminate unexpected");
             }
 
             Success(resulting_module) => {
@@ -4550,7 +4550,7 @@ pub impl Resolver {
             }
 
             Indeterminate => {
-                fail!(~"indeterminate unexpected");
+                fail!("indeterminate unexpected");
             }
 
             Success(resulting_module) => {
@@ -4660,7 +4660,7 @@ pub impl Resolver {
                 }
             }
             Indeterminate => {
-                fail!(~"unexpected indeterminate result");
+                fail!("unexpected indeterminate result");
             }
             Failed => {
                 return None;

--- a/src/librustc/middle/resolve_stage0.rs
+++ b/src/librustc/middle/resolve_stage0.rs
@@ -320,7 +320,7 @@ pub fn namespace_for_duplicate_checking_mode(mode: DuplicateCheckingMode)
         ForbidDuplicateModules | ForbidDuplicateTypes |
         ForbidDuplicateTypesAndValues => TypeNS,
         ForbidDuplicateValues => ValueNS,
-        OverwriteDuplicates => fail!(~"OverwriteDuplicates has no namespace")
+        OverwriteDuplicates => fail!("OverwriteDuplicates has no namespace")
     }
 }
 
@@ -606,7 +606,7 @@ pub impl NameBindings {
     fn get_module(@mut self) -> @mut Module {
         match self.get_module_if_available() {
             None => {
-                fail!(~"get_module called on a node with no module \
+                fail!("get_module called on a node with no module \
                        definition!")
             }
             Some(module_def) => module_def
@@ -1352,7 +1352,7 @@ pub impl Resolver {
             }
 
             item_mac(*) => {
-                fail!(~"item macros unimplemented")
+                fail!("item macros unimplemented")
             }
         }
     }
@@ -1593,7 +1593,7 @@ pub impl Resolver {
                     match existing_module.parent_link {
                       NoParentLink |
                       BlockParentLink(*) => {
-                        fail!(~"can't happen");
+                        fail!("can't happen");
                       }
                       ModuleParentLink(parent_module, ident) => {
                         let name_bindings = parent_module.children.get(
@@ -1663,7 +1663,7 @@ pub impl Resolver {
           def_prim_ty(*) | def_ty_param(*) | def_binding(*) |
           def_use(*) | def_upvar(*) | def_region(*) |
           def_typaram_binder(*) | def_label(*) | def_self_ty(*) => {
-            fail!(fmt!("didn't expect `%?`", def));
+            fail!("didn't expect `%?`", def);
           }
         }
     }
@@ -2286,7 +2286,7 @@ pub impl Resolver {
             }
             UnboundResult => { /* Continue. */ }
             UnknownResult => {
-                fail!(~"value result should be known at this point");
+                fail!("value result should be known at this point");
             }
         }
         match type_result {
@@ -2296,7 +2296,7 @@ pub impl Resolver {
             }
             UnboundResult => { /* Continue. */ }
             UnknownResult => {
-                fail!(~"type result should be known at this point");
+                fail!("type result should be known at this point");
             }
         }
 
@@ -3599,7 +3599,7 @@ pub impl Resolver {
             }
 
           item_mac(*) => {
-            fail!(~"item macros unimplemented")
+            fail!("item macros unimplemented")
           }
         }
 
@@ -4337,7 +4337,7 @@ pub impl Resolver {
             Success(target) => {
                 match target.bindings.value_def {
                     None => {
-                        fail!(~"resolved name in the value namespace to a \
+                        fail!("resolved name in the value namespace to a \
                               set of name bindings with no def?!");
                     }
                     Some(def) => {
@@ -4357,7 +4357,7 @@ pub impl Resolver {
             }
 
             Indeterminate => {
-                fail!(~"unexpected indeterminate result");
+                fail!("unexpected indeterminate result");
             }
 
             Failed => {
@@ -4528,7 +4528,7 @@ pub impl Resolver {
             }
 
             Indeterminate => {
-                fail!(~"indeterminate unexpected");
+                fail!("indeterminate unexpected");
             }
 
             Success(resulting_module) => {
@@ -4577,7 +4577,7 @@ pub impl Resolver {
             }
 
             Indeterminate => {
-                fail!(~"indeterminate unexpected");
+                fail!("indeterminate unexpected");
             }
 
             Success(resulting_module) => {
@@ -4687,7 +4687,7 @@ pub impl Resolver {
                 }
             }
             Indeterminate => {
-                fail!(~"unexpected indeterminate result");
+                fail!("unexpected indeterminate result");
             }
             Failed => {
                 return None;

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -205,7 +205,7 @@ pub fn opt_eq(tcx: ty::ctxt, a: &Opt, b: &Opt) -> bool {
                         a_expr = e.get();
                     }
                     UnitLikeStructLit(_) => {
-                        fail!(~"UnitLikeStructLit should have been handled \
+                        fail!("UnitLikeStructLit should have been handled \
                                above")
                     }
                 }
@@ -218,7 +218,7 @@ pub fn opt_eq(tcx: ty::ctxt, a: &Opt, b: &Opt) -> bool {
                         b_expr = e.get();
                     }
                     UnitLikeStructLit(_) => {
-                        fail!(~"UnitLikeStructLit should have been handled \
+                        fail!("UnitLikeStructLit should have been handled \
                                above")
                     }
                 }

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -47,7 +47,7 @@ pub fn trans_inline_asm(bcx: block, ia: &ast::inline_asm) -> block {
 
         let e = match out.node {
             ast::expr_addr_of(_, e) => e,
-            _ => fail!(~"Expression must be addr of")
+            _ => fail!("Expression must be addr of")
         };
 
         let outty = ty::arg {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1985,7 +1985,7 @@ pub fn trans_enum_variant(ccx: @CrateContext,
         // works. So we have to cast to the destination's view of the type.
         let llarg = match fcx.llargs.find(&va.id) {
             Some(&local_mem(x)) => x,
-            _ => fail!(~"trans_enum_variant: how do we know this works?"),
+            _ => fail!("trans_enum_variant: how do we know this works?"),
         };
         let arg_ty = arg_tys[i].ty;
         memcpy_ty(bcx, lldestptr, llarg, arg_ty);
@@ -2097,7 +2097,7 @@ pub fn trans_item(ccx: @CrateContext, item: &ast::item) {
     let path = match ccx.tcx.items.get_copy(&item.id) {
         ast_map::node_item(_, p) => p,
         // tjc: ?
-        _ => fail!(~"trans_item"),
+        _ => fail!("trans_item"),
     };
     match item.node {
       ast::item_fn(ref decl, purity, _abis, ref generics, ref body) => {
@@ -2390,7 +2390,7 @@ pub fn item_path(ccx: @CrateContext, i: @ast::item) -> path {
     let base = match ccx.tcx.items.get_copy(&i.id) {
         ast_map::node_item(_, p) => p,
             // separate map for paths?
-        _ => fail!(~"item_path")
+        _ => fail!("item_path")
     };
     vec::append(/*bad*/copy *base, ~[path_name(i.ident)])
 }
@@ -2436,7 +2436,7 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
                 set_inline_hint_if_appr(i.attrs, llfn);
                 llfn
               }
-              _ => fail!(~"get_item_val: weird result in table")
+              _ => fail!("get_item_val: weird result in table")
             }
           }
           ast_map::node_trait_method(trait_method, _, pth) => {
@@ -2493,11 +2493,11 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
                       ast::item_enum(_, _) => {
                         register_fn(ccx, (*v).span, pth, id, enm.attrs)
                       }
-                      _ => fail!(~"node_variant, shouldn't happen")
+                      _ => fail!("node_variant, shouldn't happen")
                     };
                 }
                 ast::struct_variant_kind(_) => {
-                    fail!(~"struct variant kind unexpected in get_item_val")
+                    fail!("struct variant kind unexpected in get_item_val")
                 }
             }
             set_inline_hint(llfn);

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -25,7 +25,7 @@ pub fn terminate(cx: block, _: &str) {
 
 pub fn check_not_terminated(cx: block) {
     if cx.terminated {
-        fail!(~"already terminated!");
+        fail!("already terminated!");
     }
 }
 

--- a/src/librustc/middle/trans/cabi_arm.rs
+++ b/src/librustc/middle/trans/cabi_arm.rs
@@ -52,7 +52,7 @@ fn ty_align(ty: TypeRef) -> uint {
                 let elt = llvm::LLVMGetElementType(ty);
                 ty_align(elt)
             }
-            _ => fail!(~"ty_align: unhandled type")
+            _ => fail!("ty_align: unhandled type")
         };
     }
 }
@@ -84,7 +84,7 @@ fn ty_size(ty: TypeRef) -> uint {
                 let eltsz = ty_size(elt);
                 len * eltsz
             }
-            _ => fail!(~"ty_size: unhandled type")
+            _ => fail!("ty_size: unhandled type")
         };
     }
 }

--- a/src/librustc/middle/trans/cabi_mips.rs
+++ b/src/librustc/middle/trans/cabi_mips.rs
@@ -60,7 +60,7 @@ fn ty_align(ty: TypeRef) -> uint {
                 let elt = llvm::LLVMGetElementType(ty);
                 ty_align(elt)
             }
-            _ => fail!(~"ty_size: unhandled type")
+            _ => fail!("ty_size: unhandled type")
         };
     }
 }
@@ -92,7 +92,7 @@ fn ty_size(ty: TypeRef) -> uint {
               let eltsz = ty_size(elt);
               len * eltsz
             }
-            _ => fail!(~"ty_size: unhandled type")
+            _ => fail!("ty_size: unhandled type")
         };
     }
 }

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -89,7 +89,7 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
                     let elt = llvm::LLVMGetElementType(ty);
                     ty_align(elt)
                 }
-                _ => fail!(~"ty_size: unhandled type")
+                _ => fail!("ty_size: unhandled type")
             };
         }
     }
@@ -121,7 +121,7 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
                   let eltsz = ty_size(elt);
                   len * eltsz
                 }
-                _ => fail!(~"ty_size: unhandled type")
+                _ => fail!("ty_size: unhandled type")
             };
         }
     }
@@ -214,7 +214,7 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
                         i += 1u;
                     }
                 }
-                _ => fail!(~"classify: unhandled type")
+                _ => fail!("classify: unhandled type")
             }
         }
     }
@@ -315,7 +315,7 @@ fn llreg_ty(cls: &[x86_64_reg_class]) -> TypeRef {
                 sse_ds_class => {
                     tys.push(T_f64());
                 }
-                _ => fail!(~"llregtype: unhandled class")
+                _ => fail!("llregtype: unhandled class")
             }
             i += 1u;
         }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -837,7 +837,7 @@ pub fn create_local_var(bcx: block, local: @ast::local)
     let name = match local.node.pat.node {
       ast::pat_ident(_, pth, _) => ast_util::path_to_ident(pth),
       // FIXME this should be handled (#2533)
-      _ => fail!(~"no single variable name for local")
+      _ => fail!("no single variable name for local")
     };
     let loc = cx.sess.codemap.lookup_char_pos(local.span.lo);
     let ty = node_id_type(bcx, local.node.id);

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -753,7 +753,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             if in_type_size != out_type_size {
                 let sp = match ccx.tcx.items.get_copy(&ref_id.get()) {
                     ast_map::node_expr(e) => e.span,
-                    _ => fail!(~"transmute has non-expr arg"),
+                    _ => fail!("transmute has non-expr arg"),
                 };
                 let pluralize = |n| if 1u == n { "" } else { "s" };
                 ccx.sess.span_fatal(sp,

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -257,7 +257,7 @@ pub fn trans_method_callee(bcx: block,
                                                trait_id, off, vtbl)
                 }
                 // how to get rid of this?
-                None => fail!(~"trans_method_callee: missing param_substs")
+                None => fail!("trans_method_callee: missing param_substs")
             }
         }
         typeck::method_trait(_, off, store) => {
@@ -269,7 +269,7 @@ pub fn trans_method_callee(bcx: block,
                                mentry.explicit_self)
         }
         typeck::method_self(*) | typeck::method_super(*) => {
-            fail!(~"method_self or method_super should have been handled \
+            fail!("method_self or method_super should have been handled \
                 above")
         }
     }
@@ -317,13 +317,13 @@ pub fn trans_static_method_callee(bcx: block,
             ast_map::node_trait_method(trait_method, _, _) => {
                 ast_util::trait_method_to_ty_method(trait_method).ident
             }
-            _ => fail!(~"callee is not a trait method")
+            _ => fail!("callee is not a trait method")
         }
     } else {
         let path = csearch::get_item_path(bcx.tcx(), method_id);
         match path[path.len()-1] {
             path_name(s) => { s }
-            path_mod(_) => { fail!(~"path doesn't have a name?") }
+            path_mod(_) => { fail!("path doesn't have a name?") }
         }
     };
     debug!("trans_static_method_callee: method_id=%?, callee_id=%?, \
@@ -354,7 +354,7 @@ pub fn trans_static_method_callee(bcx: block,
             FnData {llfn: PointerCast(bcx, lval, llty)}
         }
         _ => {
-            fail!(~"vtable_param left in monomorphized \
+            fail!("vtable_param left in monomorphized \
                    function's vtable substs");
         }
     }
@@ -375,7 +375,7 @@ pub fn method_with_name(ccx: @CrateContext, impl_id: ast::def_id,
             }, _) => {
             method_from_methods(*ms, name).get()
           }
-          _ => fail!(~"method_with_name")
+          _ => fail!("method_with_name")
         }
     } else {
         csearch::get_impl_method(ccx.sess.cstore, impl_id, name)
@@ -410,7 +410,7 @@ pub fn method_with_name_or_default(ccx: @CrateContext,
                   }
               }
           }
-          _ => fail!(~"method_with_name")
+          _ => fail!("method_with_name")
         }
     } else {
         csearch::get_impl_method(ccx.sess.cstore, impl_id, name)
@@ -436,7 +436,7 @@ pub fn method_ty_param_count(ccx: @CrateContext, m_id: ast::def_id,
                                             _, _)) => {
                 m.generics.ty_params.len()
             }
-            copy e => fail!(fmt!("method_ty_param_count %?", e))
+            copy e => fail!("method_ty_param_count %?", e)
         }
     } else {
         csearch::get_type_param_count(ccx.sess.cstore, m_id) -
@@ -495,8 +495,7 @@ pub fn trans_monomorphized_callee(bcx: block,
           }
       }
       typeck::vtable_param(*) => {
-          fail!(~"vtable_param left in monomorphized function's " +
-              "vtable substs");
+          fail!("vtable_param left in monomorphized function's vtable substs");
       }
     };
 
@@ -752,7 +751,7 @@ pub fn vtable_id(ccx: @CrateContext,
         }
 
         // can't this be checked at the callee?
-        _ => fail!(~"vtable_id")
+        _ => fail!("vtable_id")
     }
 }
 
@@ -767,7 +766,7 @@ pub fn get_vtable(ccx: @CrateContext,
         typeck::vtable_static(id, substs, sub_vtables) => {
             make_impl_vtable(ccx, id, substs, sub_vtables)
         }
-        _ => fail!(~"get_vtable: expected a static origin")
+        _ => fail!("get_vtable: expected a static origin")
       }
     }
 }

--- a/src/librustc/middle/trans/reachable.rs
+++ b/src/librustc/middle/trans/reachable.rs
@@ -147,7 +147,7 @@ fn traverse_public_item(cx: @mut ctx, item: @item) {
       }
       item_const(*) |
       item_enum(*) | item_trait(*) => (),
-      item_mac(*) => fail!(~"item macros unimplemented")
+      item_mac(*) => fail!("item macros unimplemented")
     }
 }
 

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -154,7 +154,7 @@ pub fn type_uses_for(ccx: @CrateContext, fn_id: def_id, n_tps: uint)
                 ~"bswap16" | ~"bswap32" | ~"bswap64" => 0,
 
                 // would be cool to make these an enum instead of strings!
-                _ => fail!(~"unknown intrinsic in type_use")
+                _ => fail!("unknown intrinsic in type_use")
             };
             for uint::range(0u, n_tps) |n| { cx.uses[n] |= flags;}
         }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1687,7 +1687,7 @@ pub fn simd_type(cx: ctxt, ty: t) -> t {
             let fields = lookup_struct_fields(cx, did);
             lookup_field_type(cx, did, fields[0].id, substs)
         }
-        _ => fail!(~"simd_type called on invalid type")
+        _ => fail!("simd_type called on invalid type")
     }
 }
 
@@ -1697,14 +1697,14 @@ pub fn simd_size(cx: ctxt, ty: t) -> uint {
             let fields = lookup_struct_fields(cx, did);
             fields.len()
         }
-        _ => fail!(~"simd_size called on invalid type")
+        _ => fail!("simd_size called on invalid type")
     }
 }
 
 pub fn get_element_type(ty: t, i: uint) -> t {
     match get(ty).sty {
       ty_tup(ref ts) => return ts[i],
-      _ => fail!(~"get_element_type called on invalid type")
+      _ => fail!("get_element_type called on invalid type")
     }
 }
 
@@ -3001,7 +3001,7 @@ pub fn ty_fn_sig(fty: t) -> FnSig {
         ty_bare_fn(ref f) => copy f.sig,
         ty_closure(ref f) => copy f.sig,
         ref s => {
-            fail!(fmt!("ty_fn_sig() called on non-fn type: %?", s))
+            fail!("ty_fn_sig() called on non-fn type: %?", s)
         }
     }
 }
@@ -3012,7 +3012,7 @@ pub fn ty_fn_args(fty: t) -> ~[arg] {
         ty_bare_fn(ref f) => copy f.sig.inputs,
         ty_closure(ref f) => copy f.sig.inputs,
         ref s => {
-            fail!(fmt!("ty_fn_args() called on non-fn type: %?", s))
+            fail!("ty_fn_args() called on non-fn type: %?", s)
         }
     }
 }
@@ -3021,8 +3021,7 @@ pub fn ty_closure_sigil(fty: t) -> Sigil {
     match get(fty).sty {
         ty_closure(ref f) => f.sigil,
         ref s => {
-            fail!(fmt!("ty_closure_sigil() called on non-closure type: %?",
-                       s))
+            fail!("ty_closure_sigil() called on non-closure type: %?", s)
         }
     }
 }
@@ -3032,7 +3031,7 @@ pub fn ty_fn_purity(fty: t) -> ast::purity {
         ty_bare_fn(ref f) => f.purity,
         ty_closure(ref f) => f.purity,
         ref s => {
-            fail!(fmt!("ty_fn_purity() called on non-fn type: %?", s))
+            fail!("ty_fn_purity() called on non-fn type: %?", s)
         }
     }
 }
@@ -3042,7 +3041,7 @@ pub fn ty_fn_ret(fty: t) -> t {
         ty_bare_fn(ref f) => f.sig.output,
         ty_closure(ref f) => f.sig.output,
         ref s => {
-            fail!(fmt!("ty_fn_ret() called on non-fn type: %?", s))
+            fail!("ty_fn_ret() called on non-fn type: %?", s)
         }
     }
 }
@@ -3059,7 +3058,7 @@ pub fn ty_vstore(ty: t) -> vstore {
     match get(ty).sty {
         ty_evec(_, vstore) => vstore,
         ty_estr(vstore) => vstore,
-        ref s => fail!(fmt!("ty_vstore() called on invalid sty: %?", s))
+        ref s => fail!("ty_vstore() called on invalid sty: %?", s)
     }
 }
 
@@ -3496,7 +3495,7 @@ pub fn stmt_node_id(s: @ast::stmt) -> ast::node_id {
       ast::stmt_decl(_, id) | stmt_expr(_, id) | stmt_semi(_, id) => {
         return id;
       }
-      ast::stmt_mac(*) => fail!(~"unexpanded macro in trans")
+      ast::stmt_mac(*) => fail!("unexpanded macro in trans")
     }
 }
 
@@ -3833,8 +3832,7 @@ fn lookup_locally_or_in_crate_store<V:Copy>(
     }
 
     if def_id.crate == ast::local_crate {
-        fail!(fmt!("No def'n found for %? in tcx.%s",
-                   def_id, descr));
+        fail!("No def'n found for %? in tcx.%s", def_id, descr);
     }
     let v = load_external();
     map.insert(def_id, v);
@@ -4095,7 +4093,7 @@ pub fn enum_variants(cx: ctxt, id: ast::def_id) -> @~[VariantInfo] {
                          }
                     }
                     ast::struct_variant_kind(_) => {
-                        fail!(~"struct variant kinds unimpl in enum_variants")
+                        fail!("struct variant kinds unimpl in enum_variants")
                     }
                 }
             })

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1244,7 +1244,7 @@ pub impl<'self> LookupContext<'self> {
         let span = if did.crate == ast::local_crate {
             match self.tcx().items.find(&did.node) {
               Some(&ast_map::node_method(m, _, _)) => m.span,
-              _ => fail!(fmt!("report_static_candidate: bad item %?", did))
+              _ => fail!("report_static_candidate: bad item %?", did)
             }
         } else {
             self.expr.span

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2147,8 +2147,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                                 inner_ty, fcx.expr_ty(loop_body));
             }
             ref n => {
-                fail!(fmt!(
-                    "check_loop_body expected expr_fn_block, not %?", n))
+                fail!("check_loop_body expected expr_fn_block, not %?", n)
             }
         }
 
@@ -2573,7 +2572,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
             demand::suptype(fcx, b.span, inner_ty, fcx.expr_ty(b));
           }
           // argh
-          _ => fail!(~"expected fn ty")
+          _ => fail!("expected fn ty")
         }
         fcx.write_ty(expr.id, fcx.node_ty(b.id));
       }

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -140,7 +140,7 @@ fn fixup_substs(vcx: &VtableContext, location_info: &LocationInfo,
     do fixup_ty(vcx, location_info, t, is_early).map |t_f| {
         match ty::get(*t_f).sty {
           ty::ty_trait(_, ref substs_f, _, _) => (/*bad*/copy *substs_f),
-          _ => fail!(~"t_f should be a trait")
+          _ => fail!("t_f should be a trait")
         }
     }
 }

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -142,7 +142,7 @@ pub fn get_base_type_def_id(inference_context: @mut InferCtxt,
                     return Some(def_id);
                 }
                 _ => {
-                    fail!(~"get_base_type() returned a type that wasn't an \
+                    fail!("get_base_type() returned a type that wasn't an \
                            enum, class, or trait");
                 }
             }

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -1137,7 +1137,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: @ast::item)
       }
       ast::item_impl(*) | ast::item_mod(_) |
       ast::item_foreign_mod(_) => fail!(),
-      ast::item_mac(*) => fail!(~"item macros unimplemented")
+      ast::item_mac(*) => fail!("item macros unimplemented")
     }
 }
 

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -154,16 +154,16 @@ pub impl Env {
     fn assert_subtype(&self, a: ty::t, b: ty::t) {
         if !self.is_subtype(a, b) {
             fail!("%s is not a subtype of %s, but it should be",
-                      self.ty_to_str(a),
-                      self.ty_to_str(b));
+                  self.ty_to_str(a),
+                  self.ty_to_str(b));
         }
     }
 
     fn assert_not_subtype(&self, a: ty::t, b: ty::t) {
         if self.is_subtype(a, b) {
             fail!("%s is a subtype of %s, but it shouldn't be",
-                      self.ty_to_str(a),
-                      self.ty_to_str(b));
+                  self.ty_to_str(a),
+                  self.ty_to_str(b));
         }
     }
 

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -100,7 +100,7 @@ pub impl Env {
         return match search_mod(self, &self.crate.node.module, 0, names) {
             Some(id) => id,
             None => {
-                fail!(fmt!("No item found: `%s`", str::connect(names, "::")));
+                fail!("No item found: `%s`", str::connect(names, "::"));
             }
         };
 
@@ -153,17 +153,17 @@ pub impl Env {
 
     fn assert_subtype(&self, a: ty::t, b: ty::t) {
         if !self.is_subtype(a, b) {
-            fail!(fmt!("%s is not a subtype of %s, but it should be",
+            fail!("%s is not a subtype of %s, but it should be",
                       self.ty_to_str(a),
-                      self.ty_to_str(b)));
+                      self.ty_to_str(b));
         }
     }
 
     fn assert_not_subtype(&self, a: ty::t, b: ty::t) {
         if self.is_subtype(a, b) {
-            fail!(fmt!("%s is a subtype of %s, but it shouldn't be",
+            fail!("%s is a subtype of %s, but it shouldn't be",
                       self.ty_to_str(a),
-                      self.ty_to_str(b)));
+                      self.ty_to_str(b));
         }
     }
 
@@ -240,7 +240,7 @@ pub impl Env {
     fn check_lub(&self, t1: ty::t, t2: ty::t, t_lub: ty::t) {
         match self.lub().tys(t1, t2) {
             Err(e) => {
-                fail!(fmt!("Unexpected error computing LUB: %?", e))
+                fail!("Unexpected error computing LUB: %?", e)
             }
             Ok(t) => {
                 self.assert_eq(t, t_lub);
@@ -262,7 +262,7 @@ pub impl Env {
                self.ty_to_str(t_glb));
         match self.glb().tys(t1, t2) {
             Err(e) => {
-                fail!(fmt!("Unexpected error computing LUB: %?", e))
+                fail!("Unexpected error computing LUB: %?", e)
             }
             Ok(t) => {
                 self.assert_eq(t, t_glb);
@@ -281,8 +281,7 @@ pub impl Env {
         match self.lub().tys(t1, t2) {
             Err(_) => {}
             Ok(t) => {
-                fail!(fmt!("Unexpected success computing LUB: %?",
-                          self.ty_to_str(t)))
+                fail!("Unexpected success computing LUB: %?", self.ty_to_str(t))
             }
         }
     }
@@ -292,8 +291,7 @@ pub impl Env {
         match self.glb().tys(t1, t2) {
             Err(_) => {}
             Ok(t) => {
-                fail!(fmt!("Unexpected success computing GLB: %?",
-                          self.ty_to_str(t)))
+                fail!("Unexpected success computing GLB: %?", self.ty_to_str(t))
             }
         }
     }

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -227,7 +227,7 @@ impl region_scope for type_rscope {
             None => {
                 // if the self region is used, region parameterization should
                 // have inferred that this type is RP
-                fail!(~"region parameterization should have inferred that \
+                fail!("region parameterization should have inferred that \
                         this type is RP");
             }
             Some(ref region_parameterization) => {

--- a/src/librustdoc/attr_pass.rs
+++ b/src/librustdoc/attr_pass.rs
@@ -140,9 +140,8 @@ fn fold_enum(
                                 copy ast_variant.node.attrs)
                         }
                         _ => {
-                            fail!("Enum variant %s has id that's \
-                                        not bound to an enum item",
-                                       variant.name)
+                            fail!("Enum variant %s has id that's not bound to an enum item",
+                                  variant.name)
                         }
                     }
                 }

--- a/src/librustdoc/attr_pass.rs
+++ b/src/librustdoc/attr_pass.rs
@@ -106,7 +106,7 @@ fn parse_item_attrs<T:Owned>(
         let attrs = match *ctxt.ast_map.get(&id) {
             ast_map::node_item(item, _) => copy item.attrs,
             ast_map::node_foreign_item(item, _, _, _) => copy item.attrs,
-            _ => fail!(~"parse_item_attrs: not an item")
+            _ => fail!("parse_item_attrs: not an item")
         };
         parse_attrs(attrs)
     }
@@ -140,9 +140,9 @@ fn fold_enum(
                                 copy ast_variant.node.attrs)
                         }
                         _ => {
-                            fail!(fmt!("Enum variant %s has id that's \
+                            fail!("Enum variant %s has id that's \
                                         not bound to an enum item",
-                                       variant.name))
+                                       variant.name)
                         }
                     }
                 }
@@ -202,7 +202,7 @@ fn merge_method_attrs(
                      attr_parser::parse_desc(copy method.attrs))
                 })
             }
-            _ => fail!(~"unexpected item")
+            _ => fail!("unexpected item")
         }
     };
 

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -401,7 +401,7 @@ fn write_sig(ctxt: &Ctxt, sig: Option<~str>) {
             ctxt.w.put_line(code_block_indent(sig));
             ctxt.w.put_line(~"");
         }
-        None => fail!(~"unimplemented")
+        None => fail!("unimplemented")
     }
 }
 

--- a/src/librustdoc/markdown_writer.rs
+++ b/src/librustdoc/markdown_writer.rs
@@ -135,7 +135,7 @@ fn pandoc_writer(
         if status != 0 {
             error!("pandoc-out: %s", stdout);
             error!("pandoc-err: %s", stderr);
-            fail!(~"pandoc failed");
+            fail!("pandoc failed");
         }
     }
 }

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -75,7 +75,7 @@ fn get_fn_sig(srv: astsrv::Srv, fn_id: doc::AstId) -> Option<~str> {
                 Some(pprust::fun_to_str(decl, purity, ident, None, tys,
                                         extract::interner()))
             }
-            _ => fail!(~"get_fn_sig: fn_id not bound to a fn item")
+            _ => fail!("get_fn_sig: fn_id not bound to a fn item")
         }
     }
 }
@@ -96,7 +96,7 @@ fn fold_const(
                     }, _) => {
                         pprust::ty_to_str(ty, extract::interner())
                     }
-                    _ => fail!(~"fold_const: id not bound to a const item")
+                    _ => fail!("fold_const: id not bound to a const item")
                 }
             }}),
         .. doc
@@ -127,7 +127,7 @@ fn fold_enum(
                             pprust::variant_to_str(
                                 ast_variant, extract::interner())
                         }
-                        _ => fail!(~"enum variant not bound to an enum item")
+                        _ => fail!("enum variant not bound to an enum item")
                     }
                 }
             };
@@ -204,7 +204,7 @@ fn get_method_sig(
                             }
                         }
                     }
-                    _ => fail!(~"method not found")
+                    _ => fail!("method not found")
                 }
             }
             ast_map::node_item(@ast::item {
@@ -223,10 +223,10 @@ fn get_method_sig(
                             extract::interner()
                         ))
                     }
-                    None => fail!(~"method not found")
+                    None => fail!("method not found")
                 }
             }
-            _ => fail!(~"get_method_sig: item ID not bound to trait or impl")
+            _ => fail!("get_method_sig: item ID not bound to trait or impl")
         }
     }
 }
@@ -255,7 +255,7 @@ fn fold_impl(
                      Some(pprust::ty_to_str(
                          self_ty, extract::interner())))
                 }
-                _ => fail!(~"expected impl")
+                _ => fail!("expected impl")
             }
         }
     };
@@ -294,7 +294,7 @@ fn fold_type(
                                               extract::interner())
                         ))
                     }
-                    _ => fail!(~"expected type")
+                    _ => fail!("expected type")
                 }
             }
         },
@@ -318,7 +318,7 @@ fn fold_struct(
                         Some(pprust::item_to_str(item,
                                                  extract::interner()))
                     }
-                    _ => fail!(~"not an item")
+                    _ => fail!("not an item")
                 }
             }
         },
@@ -333,7 +333,7 @@ fn fold_struct(
 fn strip_struct_extra_stuff(item: @ast::item) -> @ast::item {
     let node = match copy item.node {
         ast::item_struct(def, tys) => ast::item_struct(def, tys),
-        _ => fail!(~"not a struct")
+        _ => fail!("not a struct")
     };
 
     @ast::item {

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -312,7 +312,7 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
             let mut end_multiline = false;
             while (!end_multiline) {
                 match get_line(use_rl, ~"rusti| ") {
-                    None => fail!(~"unterminated multiline command :{ .. :}"),
+                    None => fail!("unterminated multiline command :{ .. :}"),
                     Some(line) => {
                         if str::trim(line) == ~":}" {
                             end_multiline = true;

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -146,8 +146,8 @@ impl PkgScript {
                 }
             }
             Err(e) => {
-                fail!(fmt!("Running package script, couldn't find rustpkg sysroot (%s)",
-                           e))
+                fail!("Running package script, couldn't find rustpkg sysroot (%s)",
+                           e)
             }
         }
     }
@@ -256,13 +256,13 @@ impl Ctx {
 
                 self.unprefer(name.get(), vers);
             }
-            _ => fail!(~"reached an unhandled command")
+            _ => fail!("reached an unhandled command")
         }
     }
 
     fn do_cmd(&self, _cmd: ~str, _pkgname: ~str)  {
         // stub
-        fail!(~"`do` not yet implemented");
+        fail!("`do` not yet implemented");
     }
 
     fn build(&self, workspace: &Path, pkgid: PkgId) {
@@ -289,7 +289,7 @@ impl Ctx {
                 let (cfgs, hook_result) = pscript.run_custom(~"post_build");
                 debug!("Command return code = %?", hook_result);
                 if hook_result != 0 {
-                    fail!(fmt!("Error running custom build command"))
+                    fail!("Error running custom build command")
                 }
                 custom = true;
                 // otherwise, the package script succeeded
@@ -330,7 +330,7 @@ impl Ctx {
 
     fn info(&self) {
         // stub
-        fail!(~"info not yet implemented");
+        fail!("info not yet implemented");
     }
 
     fn install(&self, workspace: &Path, id: PkgId)  {
@@ -362,7 +362,7 @@ impl Ctx {
 
     fn fetch(&self, _dir: &Path, _url: ~str, _target: Option<~str>)  {
         // stub
-        fail!(~"fetch not yet implemented");
+        fail!("fetch not yet implemented");
     }
 
     fn fetch_curl(&self, dir: &Path, url: ~str)  {
@@ -448,15 +448,15 @@ impl Ctx {
 
     fn test(&self)  {
         // stub
-        fail!(~"test not yet implemented");
+        fail!("test not yet implemented");
     }
 
     fn uninstall(&self, _id: ~str, _vers: Option<~str>)  {
-        fail!(~"uninstall not yet implemented");
+        fail!("uninstall not yet implemented");
     }
 
     fn unprefer(&self, _id: ~str, _vers: Option<~str>)  {
-        fail!(~"unprefer not yet implemented");
+        fail!("unprefer not yet implemented");
     }
 }
 

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -146,8 +146,7 @@ impl PkgScript {
                 }
             }
             Err(e) => {
-                fail!("Running package script, couldn't find rustpkg sysroot (%s)",
-                           e)
+                fail!("Running package script, couldn't find rustpkg sysroot (%s)", e)
             }
         }
     }

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -324,7 +324,7 @@ pub fn parse_vers(vers: ~str) -> result::Result<semver::Version, ~str> {
 
 pub fn need_dir(s: &Path) {
     if !os::path_is_dir(s) && !os::make_dir(s, 493_i32) {
-        fail!(fmt!("can't create dir: %s", s.to_str()));
+        fail!("can't create dir: %s", s.to_str());
     }
 }
 
@@ -421,12 +421,12 @@ pub fn wait_for_lock(path: &Path) {
 }
 
 pub fn load_pkgs() -> result::Result<~[json::Json], ~str> {
-    fail!(~"load_pkg not implemented");
+    fail!("load_pkg not implemented");
 }
 
 pub fn get_pkg(_id: ~str,
                _vers: Option<~str>) -> result::Result<Pkg, ~str> {
-    fail!(~"get_pkg not implemented");
+    fail!("get_pkg not implemented");
 }
 
 pub fn add_pkg(pkg: &Pkg) -> bool {

--- a/src/librustpkg/workspace.rs
+++ b/src/librustpkg/workspace.rs
@@ -21,10 +21,10 @@ pub fn pkg_parent_workspaces(pkgid: PkgId, action: &fn(&Path) -> bool) -> bool {
         workspace_contains_package_id(pkgid, ws));
     if workspaces.is_empty() {
         // tjc: make this a condition
-        fail!(fmt!("Package %s not found in any of \
+        fail!("Package %s not found in any of \
                     the following workspaces: %s",
                    pkgid.path.to_str(),
-                   rust_path().to_str()));
+                   rust_path().to_str());
     }
     for workspaces.each |ws| {
         if action(ws) {

--- a/src/librustpkg/workspace.rs
+++ b/src/librustpkg/workspace.rs
@@ -21,10 +21,9 @@ pub fn pkg_parent_workspaces(pkgid: PkgId, action: &fn(&Path) -> bool) -> bool {
         workspace_contains_package_id(pkgid, ws));
     if workspaces.is_empty() {
         // tjc: make this a condition
-        fail!("Package %s not found in any of \
-                    the following workspaces: %s",
-                   pkgid.path.to_str(),
-                   rust_path().to_str());
+        fail!("Package %s not found in any of the following workspaces: %s",
+              pkgid.path.to_str(),
+              rust_path().to_str());
     }
     for workspaces.each |ws| {
         if action(ws) {

--- a/src/libstd/arc.rs
+++ b/src/libstd/arc.rs
@@ -208,9 +208,9 @@ pub impl<T:Owned> MutexARC<T> {
 fn check_poison(is_mutex: bool, failed: bool) {
     if failed {
         if is_mutex {
-            fail!(~"Poisoned MutexARC - another task failed inside!");
+            fail!("Poisoned MutexARC - another task failed inside!");
         } else {
-            fail!(~"Poisoned rw_arc - another task failed inside!");
+            fail!("Poisoned rw_arc - another task failed inside!");
         }
     }
 }

--- a/src/libstd/base64.rs
+++ b/src/libstd/base64.rs
@@ -82,7 +82,7 @@ impl<'self> ToBase64 for &'self [u8] {
             str::push_char(&mut s, CHARS[(n >> 6u) & 63u]);
             str::push_char(&mut s, '=');
           }
-          _ => fail!(~"Algebra is broken, please alert the math police")
+          _ => fail!("Algebra is broken, please alert the math police")
         }
         s
     }
@@ -136,7 +136,7 @@ impl FromBase64 for ~[u8] {
      * ~~~~
      */
     fn from_base64(&self) -> ~[u8] {
-        if self.len() % 4u != 0u { fail!(~"invalid base64 length"); }
+        if self.len() % 4u != 0u { fail!("invalid base64 length"); }
 
         let len = self.len();
         let mut padding = 0u;
@@ -173,10 +173,10 @@ impl FromBase64 for ~[u8] {
                                 r.push(((n >> 10u) & 0xFFu) as u8);
                                 return copy r;
                             }
-                            _ => fail!(~"invalid base64 padding")
+                            _ => fail!("invalid base64 padding")
                         }
                     }
-                    _ => fail!(~"invalid base64 character")
+                    _ => fail!("invalid base64 character")
                 }
 
                 i += 1u;

--- a/src/libstd/bitv.rs
+++ b/src/libstd/bitv.rs
@@ -236,7 +236,7 @@ pub struct Bitv {
 }
 
 fn die() -> ! {
-    fail!(~"Tried to do operation on bit vectors with different sizes");
+    fail!("Tried to do operation on bit vectors with different sizes");
 }
 
 priv impl Bitv {
@@ -1308,7 +1308,7 @@ mod tests {
         let mut b = Bitv::new(14, true);
         b.clear();
         for b.ones |i| {
-            fail!(fmt!("found 1 at %?", i));
+            fail!("found 1 at %?", i);
         }
     }
 
@@ -1317,7 +1317,7 @@ mod tests {
         let mut b = Bitv::new(140, true);
         b.clear();
         for b.ones |i| {
-            fail!(fmt!("found 1 at %?", i));
+            fail!("found 1 at %?", i);
         }
     }
 

--- a/src/libstd/dlist.rs
+++ b/src/libstd/dlist.rs
@@ -40,18 +40,18 @@ priv impl<T> DListNode<T> {
         match self.next {
             Some(neighbour) => match neighbour.prev {
               Some(me) => if !managed::mut_ptr_eq(self, me) {
-                  fail!(~"Asymmetric next-link in dlist node.")
+                  fail!("Asymmetric next-link in dlist node.")
               },
-              None => fail!(~"One-way next-link in dlist node.")
+              None => fail!("One-way next-link in dlist node.")
             },
             None => ()
         }
         match self.prev {
             Some(neighbour) => match neighbour.next {
               Some(me) => if !managed::mut_ptr_eq(me, self) {
-                  fail!(~"Asymmetric prev-link in dlist node.")
+                  fail!("Asymmetric prev-link in dlist node.")
               },
-              None => fail!(~"One-way prev-link in dlist node.")
+              None => fail!("One-way prev-link in dlist node.")
             },
             None => ()
         }
@@ -68,7 +68,7 @@ pub impl<T> DListNode<T> {
     fn next_node(@mut self) -> @mut DListNode<T> {
         match self.next_link() {
             Some(nobe) => nobe,
-            None       => fail!(~"This dlist node has no next neighbour.")
+            None       => fail!("This dlist node has no next neighbour.")
         }
     }
     /// Get the previous node in the list, if there is one.
@@ -80,7 +80,7 @@ pub impl<T> DListNode<T> {
     fn prev_node(@mut self) -> @mut DListNode<T> {
         match self.prev_link() {
             Some(nobe) => nobe,
-            None       => fail!(~"This dlist node has no previous neighbour.")
+            None       => fail!("This dlist node has no previous neighbour.")
         }
     }
 }
@@ -132,21 +132,21 @@ priv impl<T> DList<T> {
         // These asserts could be stronger if we had node-root back-pointers,
         // but those wouldn't allow for O(1) append.
         if self.size == 0 {
-            fail!(~"This dlist is empty; that node can't be on it.")
+            fail!("This dlist is empty; that node can't be on it.")
         }
-        if !nobe.linked { fail!(~"That node isn't linked to any dlist.") }
+        if !nobe.linked { fail!("That node isn't linked to any dlist.") }
         if !((nobe.prev.is_some()
               || managed::mut_ptr_eq(self.hd.expect(~"headless dlist?"),
                                  nobe)) &&
              (nobe.next.is_some()
               || managed::mut_ptr_eq(self.tl.expect(~"tailless dlist?"),
                                  nobe))) {
-            fail!(~"That node isn't on this dlist.")
+            fail!("That node isn't on this dlist.")
         }
     }
     fn make_mine(&self, nobe: @mut DListNode<T>) {
         if nobe.prev.is_some() || nobe.next.is_some() || nobe.linked {
-            fail!(~"Cannot insert node that's already on a dlist!")
+            fail!("Cannot insert node that's already on a dlist!")
         }
         nobe.linked = true;
     }
@@ -318,16 +318,14 @@ pub impl<T> DList<T> {
     fn head_n(@mut self) -> @mut DListNode<T> {
         match self.hd {
             Some(nobe) => nobe,
-            None       => fail!(
-                ~"Attempted to get the head of an empty dlist.")
+            None       => fail!("Attempted to get the head of an empty dlist.")
         }
     }
     /// Get the node at the list's tail, failing if empty. O(1).
     fn tail_n(@mut self) -> @mut DListNode<T> {
         match self.tl {
             Some(nobe) => nobe,
-            None       => fail!(
-                ~"Attempted to get the tail of an empty dlist.")
+            None       => fail!("Attempted to get the tail of an empty dlist.")
         }
     }
 
@@ -340,7 +338,7 @@ pub impl<T> DList<T> {
      */
     fn append(@mut self, them: @mut DList<T>) {
         if managed::mut_ptr_eq(self, them) {
-            fail!(~"Cannot append a dlist to itself!")
+            fail!("Cannot append a dlist to itself!")
         }
         if them.len() > 0 {
             self.link(self.tl, them.hd);
@@ -357,7 +355,7 @@ pub impl<T> DList<T> {
      */
     fn prepend(@mut self, them: @mut DList<T>) {
         if managed::mut_ptr_eq(self, them) {
-            fail!(~"Cannot prepend a dlist to itself!")
+            fail!("Cannot prepend a dlist to itself!")
         }
         if them.len() > 0 {
             self.link(them.tl, self.hd);
@@ -524,7 +522,7 @@ impl<T> BaseIter<T> for @mut DList<T> {
 
             // Check (weakly) that the user didn't do a remove.
             if self.size == 0 {
-                fail!(~"The dlist became empty during iteration??")
+                fail!("The dlist became empty during iteration??")
             }
             if !nobe.linked ||
                 (!((nobe.prev.is_some()
@@ -533,7 +531,7 @@ impl<T> BaseIter<T> for @mut DList<T> {
                    && (nobe.next.is_some()
                     || managed::mut_ptr_eq(self.tl.expect(~"tailless dlist?"),
                                            nobe)))) {
-                fail!(~"Removing a dlist node during iteration is forbidden!")
+                fail!("Removing a dlist node during iteration is forbidden!")
             }
             link = nobe.next_link();
         }

--- a/src/libstd/ebml.rs
+++ b/src/libstd/ebml.rs
@@ -319,9 +319,7 @@ pub mod reader {
                     self.pos = r_doc.end;
                     let str = doc_as_str(r_doc);
                     if lbl != str {
-                        fail!("Expected label %s but found %s",
-                                   lbl,
-                                   str);
+                        fail!("Expected label %s but found %s", lbl, str);
                     }
                 }
             }
@@ -338,12 +336,11 @@ pub mod reader {
                    copy self.parent.start, copy self.parent.end,
                    copy self.pos, r_tag, r_doc.start, r_doc.end);
             if r_tag != (exp_tag as uint) {
-                fail!("expected EBML doc with tag %? but found tag %?",
-                          exp_tag, r_tag);
+                fail!("expected EBML doc with tag %? but found tag %?", exp_tag, r_tag);
             }
             if r_doc.end > self.parent.end {
-                fail!("invalid EBML, child extends to 0x%x, \
-                           parent to 0x%x", r_doc.end, self.parent.end);
+                fail!("invalid EBML, child extends to 0x%x, parent to 0x%x",
+                      r_doc.end, self.parent.end);
             }
             self.pos = r_doc.end;
             r_doc

--- a/src/libstd/ebml.rs
+++ b/src/libstd/ebml.rs
@@ -116,7 +116,7 @@ pub mod reader {
                         (data[start + 3u] as uint),
                     next: start + 4u};
         }
-        fail!(~"vint too big");
+        fail!("vint too big");
     }
 
     #[cfg(target_arch = "x86")]
@@ -319,9 +319,9 @@ pub mod reader {
                     self.pos = r_doc.end;
                     let str = doc_as_str(r_doc);
                     if lbl != str {
-                        fail!(fmt!("Expected label %s but found %s",
+                        fail!("Expected label %s but found %s",
                                    lbl,
-                                   str));
+                                   str);
                     }
                 }
             }
@@ -330,7 +330,7 @@ pub mod reader {
         fn next_doc(&mut self, exp_tag: EbmlEncoderTag) -> Doc {
             debug!(". next_doc(exp_tag=%?)", exp_tag);
             if self.pos >= self.parent.end {
-                fail!(~"no more documents in current node!");
+                fail!("no more documents in current node!");
             }
             let TaggedDoc { tag: r_tag, doc: r_doc } =
                 doc_at(self.parent.data, self.pos);
@@ -338,12 +338,12 @@ pub mod reader {
                    copy self.parent.start, copy self.parent.end,
                    copy self.pos, r_tag, r_doc.start, r_doc.end);
             if r_tag != (exp_tag as uint) {
-                fail!(fmt!("expected EBML doc with tag %? but found tag %?",
-                          exp_tag, r_tag));
+                fail!("expected EBML doc with tag %? but found tag %?",
+                          exp_tag, r_tag);
             }
             if r_doc.end > self.parent.end {
-                fail!(fmt!("invalid EBML, child extends to 0x%x, \
-                           parent to 0x%x", r_doc.end, self.parent.end));
+                fail!("invalid EBML, child extends to 0x%x, \
+                           parent to 0x%x", r_doc.end, self.parent.end);
             }
             self.pos = r_doc.end;
             r_doc
@@ -393,7 +393,7 @@ pub mod reader {
         fn read_uint(&mut self) -> uint {
             let v = doc_as_u64(self.next_doc(EsUint));
             if v > (::core::uint::max_value as u64) {
-                fail!(fmt!("uint %? too large for this architecture", v));
+                fail!("uint %? too large for this architecture", v);
             }
             v as uint
         }
@@ -414,7 +414,7 @@ pub mod reader {
             let v = doc_as_u64(self.next_doc(EsInt)) as i64;
             if v > (int::max_value as i64) || v < (int::min_value as i64) {
                 debug!("FIXME #6122: Removing this makes this function miscompile");
-                fail!(fmt!("int %? out of range for this architecture", v));
+                fail!("int %? out of range for this architecture", v);
             }
             v as int
         }
@@ -423,10 +423,10 @@ pub mod reader {
             doc_as_u8(self.next_doc(EsBool)) as bool
         }
 
-        fn read_f64(&mut self) -> f64 { fail!(~"read_f64()"); }
-        fn read_f32(&mut self) -> f32 { fail!(~"read_f32()"); }
-        fn read_float(&mut self) -> float { fail!(~"read_float()"); }
-        fn read_char(&mut self) -> char { fail!(~"read_char()"); }
+        fn read_f64(&mut self) -> f64 { fail!("read_f64()"); }
+        fn read_f32(&mut self) -> f32 { fail!("read_f32()"); }
+        fn read_float(&mut self) -> float { fail!("read_float()"); }
+        fn read_char(&mut self) -> char { fail!("read_char()"); }
         fn read_str(&mut self) -> ~str { doc_as_str(self.next_doc(EsStr)) }
 
         // Compound types:
@@ -602,7 +602,7 @@ pub mod reader {
 
         fn read_map<T>(&mut self, _: &fn(&mut Decoder, uint) -> T) -> T {
             debug!("read_map()");
-            fail!(~"read_map is unimplemented");
+            fail!("read_map is unimplemented");
         }
 
         fn read_map_elt_key<T>(&mut self,
@@ -610,7 +610,7 @@ pub mod reader {
                                _: &fn(&mut Decoder) -> T)
                                -> T {
             debug!("read_map_elt_key(idx=%u)", idx);
-            fail!(~"read_map_elt_val is unimplemented");
+            fail!("read_map_elt_val is unimplemented");
         }
 
         fn read_map_elt_val<T>(&mut self,
@@ -618,7 +618,7 @@ pub mod reader {
                                _: &fn(&mut Decoder) -> T)
                                -> T {
             debug!("read_map_elt_val(idx=%u)", idx);
-            fail!(~"read_map_elt_val is unimplemented");
+            fail!("read_map_elt_val is unimplemented");
         }
     }
 }
@@ -647,7 +647,7 @@ pub mod writer {
                             n as u8]),
             4u => w.write(&[0x10u8 | ((n >> 24_u) as u8), (n >> 16_u) as u8,
                             (n >> 8_u) as u8, n as u8]),
-            _ => fail!(fmt!("vint to write too big: %?", n))
+            _ => fail!("vint to write too big: %?", n)
         };
     }
 
@@ -656,7 +656,7 @@ pub mod writer {
         if n < 0x4000_u { write_sized_vuint(w, n, 2u); return; }
         if n < 0x200000_u { write_sized_vuint(w, n, 3u); return; }
         if n < 0x10000000_u { write_sized_vuint(w, n, 4u); return; }
-        fail!(fmt!("vint to write too big: %?", n));
+        fail!("vint to write too big: %?", n);
     }
 
     #[cfg(stage0)]
@@ -847,17 +847,17 @@ pub mod writer {
 
         // FIXME (#2742): implement these
         fn emit_f64(&mut self, _v: f64) {
-            fail!(~"Unimplemented: serializing an f64");
+            fail!("Unimplemented: serializing an f64");
         }
         fn emit_f32(&mut self, _v: f32) {
-            fail!(~"Unimplemented: serializing an f32");
+            fail!("Unimplemented: serializing an f32");
         }
         fn emit_float(&mut self, _v: float) {
-            fail!(~"Unimplemented: serializing a float");
+            fail!("Unimplemented: serializing a float");
         }
 
         fn emit_char(&mut self, _v: char) {
-            fail!(~"Unimplemented: serializing a char");
+            fail!("Unimplemented: serializing a char");
         }
 
         fn emit_str(&mut self, v: &str) {
@@ -954,15 +954,15 @@ pub mod writer {
         }
 
         fn emit_map(&mut self, _len: uint, _f: &fn(&mut Encoder)) {
-            fail!(~"emit_map is unimplemented");
+            fail!("emit_map is unimplemented");
         }
 
         fn emit_map_elt_key(&mut self, _idx: uint, _f: &fn(&mut Encoder)) {
-            fail!(~"emit_map_elt_key is unimplemented");
+            fail!("emit_map_elt_key is unimplemented");
         }
 
         fn emit_map_elt_val(&mut self, _idx: uint, _f: &fn(&mut Encoder)) {
-            fail!(~"emit_map_elt_val is unimplemented");
+            fail!("emit_map_elt_val is unimplemented");
         }
     }
 }

--- a/src/libstd/fileinput.rs
+++ b/src/libstd/fileinput.rs
@@ -598,7 +598,7 @@ mod test {
             let expected_path = match line {
                 "1" | "2" => copy filenames[0],
                 "3" | "4" => copy filenames[2],
-                _ => fail!(~"unexpected line")
+                _ => fail!("unexpected line")
             };
             assert_eq!(copy state.current_path, expected_path);
             count += 1;

--- a/src/libstd/flatpipes.rs
+++ b/src/libstd/flatpipes.rs
@@ -258,7 +258,7 @@ impl<T,U:Unflattener<T>,P:BytePort> GenericPort<T> for FlatPort<T, U, P> {
     fn recv(&self) -> T {
         match self.try_recv() {
             Some(val) => val,
-            None => fail!(~"port is closed")
+            None => fail!("port is closed")
         }
     }
     fn try_recv(&self) -> Option<T> {
@@ -294,7 +294,7 @@ impl<T,U:Unflattener<T>,P:BytePort> GenericPort<T> for FlatPort<T, U, P> {
             }
         }
         else {
-            fail!(~"flatpipe: unrecognized command");
+            fail!("flatpipe: unrecognized command");
         }
     }
 }
@@ -473,7 +473,7 @@ pub mod flatteners {
                 Ok(json) => {
                     json::Decoder(json)
                 }
-                Err(e) => fail!(fmt!("flatpipe: can't parse json: %?", e))
+                Err(e) => fail!("flatpipe: can't parse json: %?", e)
             }
         }
     }

--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -67,14 +67,14 @@ pub impl<A> Future<A> {
             {
                 match self.state {
                     Forced(ref mut v) => { return cast::transmute(v); }
-                    Evaluating => fail!(~"Recursive forcing of future!"),
+                    Evaluating => fail!("Recursive forcing of future!"),
                     Pending(_) => {}
                 }
             }
             {
                 let state = replace(&mut self.state, Evaluating);
                 match state {
-                    Forced(_) | Evaluating => fail!(~"Logic error."),
+                    Forced(_) | Evaluating => fail!("Logic error."),
                     Pending(f) => {
                         self.state = Forced(f());
                         cast::transmute(self.get_ref())

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -554,7 +554,7 @@ pub mod groups {
                      _} = copy *lopt;
 
         match (short_name.len(), long_name.len()) {
-           (0,0) => fail!(~"this long-format option was given no name"),
+           (0,0) => fail!("this long-format option was given no name"),
 
            (0,_) => ~[Opt {name: Long((long_name)),
                            hasarg: hasarg,
@@ -571,7 +571,7 @@ pub mod groups {
                            hasarg: hasarg,
                            occur:  occur}],
 
-           (_,_) => fail!(~"something is wrong with the long-form opt")
+           (_,_) => fail!("something is wrong with the long-form opt")
         }
     }
 
@@ -603,7 +603,7 @@ pub mod groups {
             row += match short_name.len() {
                 0 => ~"",
                 1 => ~"-" + short_name + " ",
-                _ => fail!(~"the short name should only be 1 ascii char long"),
+                _ => fail!("the short name should only be 1 ascii char long"),
             };
 
             // long option
@@ -686,7 +686,7 @@ mod tests {
             assert!((opt_present(m, ~"test")));
             assert!((opt_str(m, ~"test") == ~"20"));
           }
-          _ => { fail!(~"test_reqopt_long failed"); }
+          _ => { fail!("test_reqopt_long failed"); }
         }
     }
 

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -853,7 +853,7 @@ impl serialize::Decoder for Decoder {
         debug!("read_nil");
         match self.stack.pop() {
             Null => (),
-            value => fail!(fmt!("not a null: %?", value))
+            value => fail!("not a null: %?", value)
         }
     }
 
@@ -873,7 +873,7 @@ impl serialize::Decoder for Decoder {
         debug!("read_bool");
         match self.stack.pop() {
             Boolean(b) => b,
-            value => fail!(fmt!("not a boolean: %?", value))
+            value => fail!("not a boolean: %?", value)
         }
     }
 
@@ -883,14 +883,14 @@ impl serialize::Decoder for Decoder {
         debug!("read_float");
         match self.stack.pop() {
             Number(f) => f,
-            value => fail!(fmt!("not a number: %?", value))
+            value => fail!("not a number: %?", value)
         }
     }
 
     fn read_char(&mut self) -> char {
         let mut v = ~[];
         for str::each_char(self.read_str()) |c| { v.push(c) }
-        if v.len() != 1 { fail!(~"string must have one character") }
+        if v.len() != 1 { fail!("string must have one character") }
         v[0]
     }
 
@@ -898,7 +898,7 @@ impl serialize::Decoder for Decoder {
         debug!("read_str");
         match self.stack.pop() {
             String(s) => s,
-            json => fail!(fmt!("not a string: %?", json))
+            json => fail!("not a string: %?", json)
         }
     }
 
@@ -920,14 +920,14 @@ impl serialize::Decoder for Decoder {
                 }
                 match self.stack.pop() {
                     String(s) => s,
-                    value => fail!(fmt!("invalid variant name: %?", value)),
+                    value => fail!("invalid variant name: %?", value),
                 }
             }
-            ref json => fail!(fmt!("invalid variant: %?", *json)),
+            ref json => fail!("invalid variant: %?", *json),
         };
         let idx = match vec::position(names, |n| str::eq_slice(*n, name)) {
             Some(idx) => idx,
-            None => fail!(fmt!("Unknown variant name: %?", name)),
+            None => fail!("Unknown variant name: %?", name),
         };
         f(self, idx)
     }
@@ -979,7 +979,7 @@ impl serialize::Decoder for Decoder {
             Object(obj) => {
                 let mut obj = obj;
                 let value = match obj.pop(&name.to_owned()) {
-                    None => fail!(fmt!("no such field: %s", name)),
+                    None => fail!("no such field: %s", name),
                     Some(json) => {
                         self.stack.push(json);
                         f(self)
@@ -988,7 +988,7 @@ impl serialize::Decoder for Decoder {
                 self.stack.push(Object(obj));
                 value
             }
-            value => fail!(fmt!("not an object: %?", value))
+            value => fail!("not an object: %?", value)
         }
     }
 
@@ -1038,7 +1038,7 @@ impl serialize::Decoder for Decoder {
                 }
                 len
             }
-            _ => fail!(~"not a list"),
+            _ => fail!("not a list"),
         };
         f(self, len)
     }
@@ -1060,7 +1060,7 @@ impl serialize::Decoder for Decoder {
                 }
                 len
             }
-            json => fail!(fmt!("not an object: %?", json)),
+            json => fail!("not an object: %?", json),
         };
         f(self, len)
     }

--- a/src/libstd/list.rs
+++ b/src/libstd/list.rs
@@ -93,7 +93,7 @@ pub fn len<T>(ls: @List<T>) -> uint {
 pub fn tail<T:Copy>(ls: @List<T>) -> @List<T> {
     match *ls {
         Cons(_, tl) => return tl,
-        Nil => fail!(~"list empty")
+        Nil => fail!("list empty")
     }
 }
 
@@ -102,7 +102,7 @@ pub fn head<T:Copy>(ls: @List<T>) -> T {
     match *ls {
       Cons(copy hd, _) => hd,
       // makes me sad
-      _ => fail!(~"head invoked on empty list")
+      _ => fail!("head invoked on empty list")
     }
 }
 

--- a/src/libstd/net_ip.rs
+++ b/src/libstd/net_ip.rs
@@ -59,14 +59,14 @@ pub fn format_addr(ip: &IpAddr) -> ~str {
       Ipv4(ref addr) =>  unsafe {
         let result = uv_ip4_name(addr);
         if result == ~"" {
-            fail!(~"failed to convert inner sockaddr_in address to str")
+            fail!("failed to convert inner sockaddr_in address to str")
         }
         result
       },
       Ipv6(ref addr) => unsafe {
         let result = uv_ip6_name(addr);
         if result == ~"" {
-            fail!(~"failed to convert inner sockaddr_in address to str")
+            fail!("failed to convert inner sockaddr_in address to str")
         }
         result
       }
@@ -394,7 +394,7 @@ mod test {
             assert!(true);
           }
           result::Ok(ref addr) => {
-            fail!(fmt!("Expected failure, but got addr %?", addr));
+            fail!("Expected failure, but got addr %?", addr);
           }
         }
     }
@@ -407,7 +407,7 @@ mod test {
             assert!(true);
           }
           result::Ok(ref addr) => {
-            fail!(fmt!("Expected failure, but got addr %?", addr));
+            fail!("Expected failure, but got addr %?", addr);
           }
         }
     }
@@ -418,7 +418,7 @@ mod test {
         let iotask = &uv::global_loop::get();
         let ga_result = get_addr(localhost_name, iotask);
         if result::is_err(&ga_result) {
-            fail!(~"got err result from net::ip::get_addr();")
+            fail!("got err result from net::ip::get_addr();")
         }
         // note really sure how to reliably test/assert
         // this.. mostly just wanting to see it work, atm.

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -1687,7 +1687,7 @@ mod test {
             assert!(true);
           }
           _ => {
-            fail!("expected address_in_use listen error,\
+            fail!("expected address_in_use listen error, \
                    but got a different error varient. check logs.");
           }
         }
@@ -1706,7 +1706,7 @@ mod test {
             assert!(true);
           }
           _ => {
-            fail!("expected address_in_use listen error,\
+            fail!("expected address_in_use listen error, \
                    but got a different error varient. check logs.");
           }
         }

--- a/src/libstd/net_tcp.rs
+++ b/src/libstd/net_tcp.rs
@@ -1646,7 +1646,7 @@ mod test {
             hl_loop);
         match actual_resp_result.get_err() {
           ConnectionRefused => (),
-          _ => fail!(~"unknown error.. expected connection_refused")
+          _ => fail!("unknown error.. expected connection_refused")
         }
     }
     pub fn impl_gl_tcp_ipv4_server_address_in_use() {
@@ -1687,8 +1687,8 @@ mod test {
             assert!(true);
           }
           _ => {
-            fail!(~"expected address_in_use listen error,"+
-                ~"but got a different error varient. check logs.");
+            fail!("expected address_in_use listen error,\
+                   but got a different error varient. check logs.");
           }
         }
     }
@@ -1706,8 +1706,8 @@ mod test {
             assert!(true);
           }
           _ => {
-            fail!(~"expected address_in_use listen error,"+
-                      ~"but got a different error varient. check logs.");
+            fail!("expected address_in_use listen error,\
+                   but got a different error varient. check logs.");
           }
         }
     }
@@ -1888,14 +1888,13 @@ mod test {
         if result::is_err(&listen_result) {
             match result::get_err(&listen_result) {
               GenericListenErr(ref name, ref msg) => {
-                fail!(fmt!("SERVER: exited abnormally name %s msg %s",
-                                *name, *msg));
+                fail!("SERVER: exited abnormally name %s msg %s", *name, *msg);
               }
               AccessDenied => {
-                fail!(~"SERVER: exited abnormally, got access denied..");
+                fail!("SERVER: exited abnormally, got access denied..");
               }
               AddressInUse => {
-                fail!(~"SERVER: exited abnormally, got address in use...");
+                fail!("SERVER: exited abnormally, got address in use...");
               }
             }
         }
@@ -1914,15 +1913,14 @@ mod test {
                 debug!("establish_cb %?", kill_ch);
             },
             |new_conn, kill_ch| {
-                fail!(fmt!("SERVER: shouldn't be called.. %? %?",
-                           new_conn, kill_ch));
+                fail!("SERVER: shouldn't be called.. %? %?", new_conn, kill_ch);
         });
         // err check on listen_result
         if result::is_err(&listen_result) {
             result::get_err(&listen_result)
         }
         else {
-            fail!(~"SERVER: did not fail as expected")
+            fail!("SERVER: did not fail as expected")
         }
     }
 
@@ -1966,7 +1964,7 @@ mod test {
             debug!("tcp_write_single err name: %s msg: %s",
                 err_data.err_name, err_data.err_msg);
             // meh. torn on what to do here.
-            fail!(~"tcp_write_single failed");
+            fail!("tcp_write_single failed");
         }
     }
 }

--- a/src/libstd/num/rational.rs
+++ b/src/libstd/num/rational.rs
@@ -48,7 +48,7 @@ impl<T: Copy + Num + Ord>
     #[inline(always)]
     pub fn new(numer: T, denom: T) -> Ratio<T> {
         if denom == Zero::zero() {
-            fail!(~"denominator == 0");
+            fail!("denominator == 0");
         }
         let mut ret = Ratio::new_raw(numer, denom);
         ret.reduce();

--- a/src/libstd/sort.rs
+++ b/src/libstd/sort.rs
@@ -581,7 +581,7 @@ impl<T:Copy + Ord> MergeState<T> {
             shift_vec(array, dest, c2, len2);
             swap(&mut array[dest+len2], &mut tmp[c1]);
         } else if len1 == 0 {
-            fail!(~"Comparison violates its contract!");
+            fail!("Comparison violates its contract!");
         } else {
             assert!(len2 == 0);
             assert!(len1 > 1);
@@ -703,7 +703,7 @@ impl<T:Copy + Ord> MergeState<T> {
             shift_vec(array, dest+1, c1+1, len1);
             swap(&mut array[dest], &mut tmp[c2]);
         } else if len2 == 0 {
-            fail!(~"Comparison violates its contract!");
+            fail!("Comparison violates its contract!");
         } else {
             assert!(len1 == 0);
             assert!(len2 != 0);
@@ -949,7 +949,7 @@ mod test_tim_sort {
         fn lt(&self, other: &CVal) -> bool {
             let mut rng = rand::rng();
             if rng.gen::<float>() > 0.995 {
-                fail!(~"It's happening!!!");
+                fail!("It's happening!!!");
             }
             (*self).val < other.val
         }
@@ -1004,7 +1004,7 @@ mod test_tim_sort {
         };
 
         tim_sort(arr);
-        fail!(~"Guarantee the fail");
+        fail!("Guarantee the fail");
     }
 
     struct DVal { val: uint }
@@ -1065,7 +1065,7 @@ mod big_tests {
         fn isSorted<T:Ord>(arr: &[T]) {
             for uint::range(0, arr.len()-1) |i| {
                 if arr[i] > arr[i+1] {
-                    fail!(~"Array not sorted");
+                    fail!("Array not sorted");
                 }
             }
         }
@@ -1136,7 +1136,7 @@ mod big_tests {
         fn isSorted<T:Ord>(arr: &[@T]) {
             for uint::range(0, arr.len()-1) |i| {
                 if arr[i] > arr[i+1] {
-                    fail!(~"Array not sorted");
+                    fail!("Array not sorted");
                 }
             }
         }
@@ -1219,7 +1219,7 @@ mod big_tests {
                         local_data::local_data_set(self.key, @(y+1));
                     }
                 }
-                _ => fail!(~"Expected key to work"),
+                _ => fail!("Expected key to work"),
             }
         }
     }

--- a/src/libstd/sort_stage0.rs
+++ b/src/libstd/sort_stage0.rs
@@ -577,7 +577,7 @@ impl<T:Copy + Ord> MergeState<T> {
             copy_vec(array, dest, array, c2, len2);
             util::swap(&mut array[dest+len2], &mut tmp[c1]);
         } else if len1 == 0 {
-            fail!(~"Comparison violates its contract!");
+            fail!("Comparison violates its contract!");
         } else {
             assert!(len2 == 0);
             assert!(len1 > 1);
@@ -699,7 +699,7 @@ impl<T:Copy + Ord> MergeState<T> {
             copy_vec(array, dest+1, array, c1+1, len1);
             util::swap(&mut array[dest], &mut tmp[c2]);
         } else if len2 == 0 {
-            fail!(~"Comparison violates its contract!");
+            fail!("Comparison violates its contract!");
         } else {
             assert!(len1 == 0);
             assert!(len2 != 0);
@@ -941,7 +941,7 @@ mod test_tim_sort {
     impl Ord for CVal {
         fn lt(&self, other: &CVal) -> bool {
             let rng = rand::rng();
-            if rng.gen::<float>() > 0.995 { fail!(~"It's happening!!!"); }
+            if rng.gen::<float>() > 0.995 { fail!("It's happening!!!"); }
             (*self).val < other.val
         }
         fn le(&self, other: &CVal) -> bool { (*self).val <= other.val }
@@ -995,7 +995,7 @@ mod test_tim_sort {
         };
 
         tim_sort(arr);
-        fail!(~"Guarantee the fail");
+        fail!("Guarantee the fail");
     }
 
     struct DVal { val: uint }
@@ -1056,7 +1056,7 @@ mod big_tests {
         fn isSorted<T:Ord>(arr: &const [T]) {
             for uint::range(0, arr.len()-1) |i| {
                 if arr[i] > arr[i+1] {
-                    fail!(~"Array not sorted");
+                    fail!("Array not sorted");
                 }
             }
         }
@@ -1127,7 +1127,7 @@ mod big_tests {
         fn isSorted<T:Ord>(arr: &const [@T]) {
             for uint::range(0, arr.len()-1) |i| {
                 if arr[i] > arr[i+1] {
-                    fail!(~"Array not sorted");
+                    fail!("Array not sorted");
                 }
             }
         }
@@ -1210,7 +1210,7 @@ mod big_tests {
                         local_data::local_data_set(self.key, @(y+1));
                     }
                 }
-                _ => fail!(~"Expected key to work"),
+                _ => fail!("Expected key to work"),
             }
         }
     }

--- a/src/libstd/sync.rs
+++ b/src/libstd/sync.rs
@@ -329,11 +329,11 @@ fn check_cvar_bounds<U>(out_of_bounds: Option<uint>, id: uint, act: &str,
                         blk: &fn() -> U) -> U {
     match out_of_bounds {
         Some(0) =>
-            fail!(fmt!("%s with illegal ID %u - this lock has no condvars!",
-                      act, id)),
+            fail!("%s with illegal ID %u - this lock has no condvars!",
+                      act, id),
         Some(length) =>
-            fail!(fmt!("%s with illegal ID %u - ID must be less than %u",
-                      act, id, length)),
+            fail!("%s with illegal ID %u - ID must be less than %u",
+                      act, id, length),
         None => blk()
     }
 }
@@ -578,7 +578,7 @@ pub impl RWlock {
                      token: RWlockWriteMode<'a>)
                   -> RWlockReadMode<'a> {
         if !ptr::ref_eq(self, token.lock) {
-            fail!(~"Can't downgrade() with a different rwlock's write_mode!");
+            fail!("Can't downgrade() with a different rwlock's write_mode!");
         }
         unsafe {
             do task::unkillable {

--- a/src/libstd/sync.rs
+++ b/src/libstd/sync.rs
@@ -329,11 +329,9 @@ fn check_cvar_bounds<U>(out_of_bounds: Option<uint>, id: uint, act: &str,
                         blk: &fn() -> U) -> U {
     match out_of_bounds {
         Some(0) =>
-            fail!("%s with illegal ID %u - this lock has no condvars!",
-                      act, id),
+            fail!("%s with illegal ID %u - this lock has no condvars!", act, id),
         Some(length) =>
-            fail!("%s with illegal ID %u - ID must be less than %u",
-                      act, id, length),
+            fail!("%s with illegal ID %u - ID must be less than %u", act, id, length),
         None => blk()
     }
 }

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -89,7 +89,7 @@ pub fn test_main(args: &[~str], tests: ~[TestDescAndFn]) {
           either::Left(o) => o,
           either::Right(m) => fail!(m)
         };
-    if !run_tests_console(&opts, tests) { fail!(~"Some tests failed"); }
+    if !run_tests_console(&opts, tests) { fail!("Some tests failed"); }
 }
 
 // A variant optimized for invocation with a static test vector.
@@ -109,7 +109,7 @@ pub fn test_main_static(args: &[~str], tests: &[TestDescAndFn]) {
             TestDescAndFn { testfn: StaticBenchFn(f), desc: copy t.desc },
 
             _ => {
-                fail!(~"non-static tests passed to test::test_main_static");
+                fail!("non-static tests passed to test::test_main_static");
             }
         }
     };
@@ -250,7 +250,7 @@ pub fn run_tests_console(opts: &TestOpts,
                                                   io::Truncate]) {
           result::Ok(w) => Some(w),
           result::Err(ref s) => {
-              fail!(fmt!("can't open output file: %s", *s))
+              fail!("can't open output file: %s", *s)
           }
         },
         None => None
@@ -849,7 +849,7 @@ mod tests {
         let args = ~[~"progname", ~"filter"];
         let opts = match parse_opts(args) {
           either::Left(copy o) => o,
-          _ => fail!(~"Malformed arg in first_free_arg_should_be_a_filter")
+          _ => fail!("Malformed arg in first_free_arg_should_be_a_filter")
         };
         assert!("filter" == (copy opts.filter).get());
     }
@@ -859,7 +859,7 @@ mod tests {
         let args = ~[~"progname", ~"filter", ~"--ignored"];
         let opts = match parse_opts(args) {
           either::Left(copy o) => o,
-          _ => fail!(~"Malformed arg in parse_ignored_flag")
+          _ => fail!("Malformed arg in parse_ignored_flag")
         };
         assert!((opts.run_ignored));
     }

--- a/src/libstd/timer.rs
+++ b/src/libstd/timer.rs
@@ -63,13 +63,11 @@ pub fn delayed_send<T:Owned>(iotask: &IoTask,
                 } else {
                     let error_msg = uv::ll::get_last_err_info(
                         loop_ptr);
-                    fail!(~"timer::delayed_send() start failed: " +
-                        error_msg);
+                    fail!("timer::delayed_send() start failed: %s", error_msg);
                 }
             } else {
                 let error_msg = uv::ll::get_last_err_info(loop_ptr);
-                fail!(~"timer::delayed_send() init failed: " +
-                    error_msg);
+                fail!("timer::delayed_send() init failed: %s", error_msg);
             }
         }
     };
@@ -158,7 +156,7 @@ extern fn delayed_send_cb(handle: *uv::ll::uv_timer_t, status: libc::c_int) {
         } else {
             let loop_ptr = uv::ll::get_loop_for_uv_handle(handle);
             let error_msg = uv::ll::get_last_err_info(loop_ptr);
-            fail!(~"timer::sleep() init failed: "+error_msg);
+            fail!("timer::sleep() init failed: %s", error_msg);
         }
     }
 }

--- a/src/libstd/treemap.rs
+++ b/src/libstd/treemap.rs
@@ -716,7 +716,7 @@ pub impl<K: TotalOrd, V> TreeNode<K, V> {
 #[cfg(stage0)]
 fn each<'r, K: TotalOrd, V>(_: &'r Option<~TreeNode<K, V>>,
                             _: &fn(&'r K, &'r V) -> bool) -> bool {
-    fail!(~"don't use me in stage0!")
+    fail!("don't use me in stage0!")
 }
 #[cfg(not(stage0))]
 fn each<'r, K: TotalOrd, V>(node: &'r Option<~TreeNode<K, V>>,
@@ -728,7 +728,7 @@ fn each<'r, K: TotalOrd, V>(node: &'r Option<~TreeNode<K, V>>,
 #[cfg(stage0)]
 fn each_reverse<'r, K: TotalOrd, V>(_: &'r Option<~TreeNode<K, V>>,
                                     _: &fn(&'r K, &'r V) -> bool) -> bool {
-    fail!(~"don't use me in stage0!")
+    fail!("don't use me in stage0!")
 }
 #[cfg(not(stage0))]
 fn each_reverse<'r, K: TotalOrd, V>(node: &'r Option<~TreeNode<K, V>>,

--- a/src/libstd/uv_global_loop.rs
+++ b/src/libstd/uv_global_loop.rs
@@ -180,11 +180,11 @@ mod test {
                                                            simple_timer_cb,
                                                            1u, 0u);
                         if(start_status != 0i32) {
-                            fail!(~"failure on ll::timer_start()");
+                            fail!("failure on ll::timer_start()");
                         }
                     }
                     else {
-                        fail!(~"failure on ll::timer_init()");
+                        fail!("failure on ll::timer_init()");
                     }
                 }
             };

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -338,7 +338,7 @@ fn cannot_combine(n: Abi, m: Abi) {
                          (m == a && n == b));
         }
         None => {
-            fail!(~"Invalid match not detected");
+            fail!("Invalid match not detected");
         }
     }
 }
@@ -350,7 +350,7 @@ fn can_combine(n: Abi, m: Abi) {
     set.add(m);
     match set.check_valid() {
         Some((_, _)) => {
-            fail!(~"Valid match declared invalid");
+            fail!("Valid match declared invalid");
         }
         None => {}
     }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -74,7 +74,7 @@ impl<S:Encoder> Encodable<S> for ident {
         unsafe {
             let intr =
                 match local_data::local_data_get(interner_key!()) {
-                    None => fail!(~"encode: TLS interner not set up"),
+                    None => fail!("encode: TLS interner not set up"),
                     Some(intr) => intr
                 };
 
@@ -88,7 +88,7 @@ impl<D:Decoder> Decodable<D> for ident {
         let intr = match unsafe {
             local_data::local_data_get(interner_key!())
         } {
-            None => fail!(~"decode: TLS interner not set up"),
+            None => fail!("decode: TLS interner not set up"),
             Some(intr) => intr
         };
 

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -304,7 +304,7 @@ pub fn map_struct_def(
                     cx.map.insert(ctor_id,
                                   node_struct_ctor(struct_def, item, p));
                 }
-                _ => fail!(~"struct def parent wasn't an item")
+                _ => fail!("struct def parent wasn't an item")
             }
         }
     }

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -37,7 +37,7 @@ pub fn stmt_id(s: &stmt) -> node_id {
       stmt_decl(_, id) => id,
       stmt_expr(_, id) => id,
       stmt_semi(_, id) => id,
-      stmt_mac(*) => fail!(~"attempted to analyze unexpanded stmt")
+      stmt_mac(*) => fail!("attempted to analyze unexpanded stmt")
     }
 }
 

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -430,8 +430,8 @@ priv impl CodeMap {
             }
         }
         if (a >= len) {
-            fail!(fmt!("position %u does not resolve to a source location",
-                      pos.to_uint()))
+            fail!("position %u does not resolve to a source location",
+                      pos.to_uint())
         }
 
         return a;

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -430,8 +430,7 @@ priv impl CodeMap {
             }
         }
         if (a >= len) {
-            fail!("position %u does not resolve to a source location",
-                      pos.to_uint())
+            fail!("position %u does not resolve to a source location", pos.to_uint())
         }
 
         return a;

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -917,7 +917,7 @@ fn mk_struct_fields(fields: &[@ast::struct_field]) -> ~[field] {
     do fields.map |field| {
         let ident = match field.node.kind {
             ast::named_field(ident, _) => ident,
-            _ => fail!(~"[auto_encode] does not support unnamed fields")
+            _ => fail!("[auto_encode] does not support unnamed fields")
         };
 
         field {
@@ -1056,7 +1056,7 @@ fn mk_enum_ser_body(
                     /*bad*/ copy *args
                 ),
             ast::struct_variant_kind(*) =>
-                fail!(~"struct variants unimplemented"),
+                fail!("struct variants unimplemented"),
         }
     };
 
@@ -1151,7 +1151,7 @@ fn mk_enum_deser_body(
                 }
             },
             ast::struct_variant_kind(*) =>
-                fail!(~"struct variants unimplemented"),
+                fail!("struct variants unimplemented"),
         };
 
         let pat = @ast::pat {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -479,11 +479,11 @@ impl <K: Eq + Hash + IterBytes ,V: Copy> MapChain<K,V>{
     // names? I think not.
     // delaying implementing this....
     fn each_key (&self, _f: &fn (&K)->bool) {
-        fail!(~"unimplemented 2013-02-15T10:01");
+        fail!("unimplemented 2013-02-15T10:01");
     }
 
     fn each_value (&self, _f: &fn (&V) -> bool) {
-        fail!(~"unimplemented 2013-02-15T10:02");
+        fail!("unimplemented 2013-02-15T10:02");
     }
 
     // Returns a copy of the value that the name maps to.

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -468,7 +468,7 @@ pub fn core_macros() -> ~str {
                 let expected_val = $expected;
                 // check both directions of equality....
                 if !((given_val == expected_val) && (expected_val == given_val)) {
-                    fail!(fmt!(\"left: %? != right: %?\", given_val, expected_val));
+                    fail!(\"left: %? != right: %?\", given_val, expected_val);
                 }
             }
         )
@@ -660,7 +660,7 @@ mod test {
 
     // make sure that fail! is present
     #[test] fn fail_exists_test () {
-        let src = ~"fn main() { fail!(~\"something appropriately gloomy\");}";
+        let src = ~"fn main() { fail!(\"something appropriately gloomy\");}";
         let sess = parse::new_parse_sess(None);
         let cfg = ~[];
         let crate_ast = parse::parse_crate_from_source_str(
@@ -733,7 +733,7 @@ mod test {
             cfg,~[make_dummy_attr (@~"macro_escape")],sess);
         match item_ast {
             Some(_) => (), // success
-            None => fail!(~"expected this to parse")
+            None => fail!("expected this to parse")
         }
     }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -468,7 +468,7 @@ pub fn core_macros() -> ~str {
                 let expected_val = $expected;
                 // check both directions of equality....
                 if !((given_val == expected_val) && (expected_val == given_val)) {
-                    fail!(\"left: %? != right: %?\", given_val, expected_val);
+                    fail!(\"left: %? does not equal right: %?\", given_val, expected_val);
                 }
             }
         )

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -556,7 +556,7 @@ fn mk_token(cx: @ext_ctxt, sp: span, tok: token::Token) -> @ast::expr {
                                   ~[mk_ident(cx, sp, ident)]);
         }
 
-        INTERPOLATED(_) => fail!(~"quote! with interpolated token"),
+        INTERPOLATED(_) => fail!("quote! with interpolated token"),
 
         _ => ()
     }
@@ -623,7 +623,7 @@ fn mk_tt(cx: @ext_ctxt, sp: span, tt: &ast::token_tree)
         }
 
         ast::tt_delim(ref tts) => mk_tts(cx, sp, *tts),
-        ast::tt_seq(*) => fail!(~"tt_seq in quote!"),
+        ast::tt_seq(*) => fail!("tt_seq in quote!"),
 
         ast::tt_nonterminal(sp, ident) => {
 

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -63,7 +63,7 @@ impl<T> OptVec<T> {
 
     fn get<'a>(&'a self, i: uint) -> &'a T {
         match *self {
-            Empty => fail!(fmt!("Invalid index %u", i)),
+            Empty => fail!("Invalid index %u", i),
             Vec(ref v) => &v[i]
         }
     }

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -111,7 +111,7 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         return str::connect(lines, ~"\n");
     }
 
-    fail!(~"not a doc-comment: " + comment);
+    fail!("not a doc-comment: %s", comment);
 }
 
 fn read_to_eol(rdr: @mut StringReader) -> ~str {

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -211,7 +211,7 @@ pub fn to_str(in: @ident_interner, t: &Token) -> ~str {
                       nt_block(*) => ~"block",
                       nt_stmt(*) => ~"statement",
                       nt_pat(*) => ~"pattern",
-                      nt_expr(*) => fail!(~"should have been handled above"),
+                      nt_expr(*) => fail!("should have been handled above"),
                       nt_ty(*) => ~"type",
                       nt_ident(*) => ~"identifier",
                       nt_path(*) => ~"path",

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2237,7 +2237,7 @@ mod test {
 
     fn string_check<T:Eq> (given : &T, expected: &T) {
         if !(given == expected) {
-            fail!("given %?, expected %?",given,expected);
+            fail!("given %?, expected %?", given, expected);
         }
     }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -430,10 +430,10 @@ pub fn print_type(s: @ps, ty: @ast::Ty) {
         word(s.s, ~"]");
       }
       ast::ty_mac(_) => {
-          fail!(~"print_type doesn't know how to print a ty_mac");
+          fail!("print_type doesn't know how to print a ty_mac");
       }
       ast::ty_infer => {
-          fail!(~"print_type shouldn't see a ty_infer");
+          fail!("print_type shouldn't see a ty_infer");
       }
 
     }
@@ -683,7 +683,7 @@ pub fn print_struct(s: @ps,
             popen(s);
             do commasep(s, inconsistent, struct_def.fields) |s, field| {
                 match field.node.kind {
-                    ast::named_field(*) => fail!(~"unexpected named field"),
+                    ast::named_field(*) => fail!("unexpected named field"),
                     ast::unnamed_field => {
                         maybe_print_comment(s, field.span.lo);
                         print_type(s, field.node.ty);
@@ -702,7 +702,7 @@ pub fn print_struct(s: @ps,
 
         for struct_def.fields.each |field| {
             match field.node.kind {
-                ast::unnamed_field => fail!(~"unexpected unnamed field"),
+                ast::unnamed_field => fail!("unexpected unnamed field"),
                 ast::named_field(ident, visibility) => {
                     hardbreak_if_not_bol(s);
                     maybe_print_comment(s, field.span.lo);
@@ -984,7 +984,7 @@ pub fn print_if(s: @ps, test: @ast::expr, blk: &ast::blk,
               }
               // BLEAH, constraints would be great here
               _ => {
-                  fail!(~"print_if saw if with weird alternative");
+                  fail!("print_if saw if with weird alternative");
               }
             }
           }
@@ -2237,7 +2237,7 @@ mod test {
 
     fn string_check<T:Eq> (given : &T, expected: &T) {
         if !(given == expected) {
-            fail!(fmt!("given %?, expected %?",given,expected));
+            fail!("given %?, expected %?",given,expected);
         }
     }
 

--- a/src/test/auxiliary/static-methods-crate.rs
+++ b/src/test/auxiliary/static-methods-crate.rs
@@ -36,6 +36,6 @@ impl read for bool {
 pub fn read<T:read + Copy>(s: ~str) -> T {
     match read::readMaybe(s) {
       Some(x) => x,
-      _ => fail!(~"read failed!")
+      _ => fail!("read failed!")
     }
 }

--- a/src/test/bench/graph500-bfs.rs
+++ b/src/test/bench/graph500-bfs.rs
@@ -217,7 +217,7 @@ fn bfs2(graph: graph, key: node_id) -> bfs_result {
         match *c {
           white => { -1i64 }
           black(parent) => { parent }
-          _ => { fail!(~"Found remaining gray nodes in BFS") }
+          _ => { fail!("Found remaining gray nodes in BFS") }
         }
     }
 }
@@ -305,7 +305,7 @@ fn pbfs(graph: &arc::ARC<graph>, key: node_id) -> bfs_result {
             match *c {
                 white => { -1i64 }
                 black(parent) => { parent }
-                _ => { fail!(~"Found remaining gray nodes in BFS") }
+                _ => { fail!("Found remaining gray nodes in BFS") }
             }
         };
         result

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -61,7 +61,7 @@ fn show_digit(nn: uint) -> ~str {
         7 => {~"seven"}
         8 => {~"eight"}
         9 => {~"nine"}
-        _ => {fail!(~"expected digits from 0 to 9...")}
+        _ => {fail!("expected digits from 0 to 9...")}
     }
 }
 

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -76,7 +76,7 @@ pub impl Sudoku {
                 g[row][col] = uint::from_str(comps[2]).get() as u8;
             }
             else {
-                fail!(~"Invalid sudoku file");
+                fail!("Invalid sudoku file");
             }
         }
         return Sudoku::new(g)
@@ -112,7 +112,7 @@ pub impl Sudoku {
                 ptr = ptr + 1u;
             } else {
                 // no: redo this field aft recoloring pred; unless there is none
-                if ptr == 0u { fail!(~"No solution found for this sudoku"); }
+                if ptr == 0u { fail!("No solution found for this sudoku"); }
                 ptr = ptr - 1u;
             }
         }

--- a/src/test/bench/task-perf-jargon-metal-smoke.rs
+++ b/src/test/bench/task-perf-jargon-metal-smoke.rs
@@ -50,6 +50,6 @@ fn main() {
     let (p,c) = comm::stream();
     child_generation(uint::from_str(args[1]).get(), c);
     if p.try_recv().is_none() {
-        fail!(~"it happened when we slumbered");
+        fail!("it happened when we slumbered");
     }
 }

--- a/src/test/compile-fail/borrowck-vec-pattern-element-loan.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-element-loan.rs
@@ -2,7 +2,7 @@ fn a() -> &[int] {
     let vec = [1, 2, 3, 4];
     let tail = match vec {
         [_, ..tail] => tail, //~ ERROR does not live long enough
-        _ => fail!(~"a")
+        _ => fail!("a")
     };
     tail
 }
@@ -11,7 +11,7 @@ fn b() -> &[int] {
     let vec = [1, 2, 3, 4];
     let init = match vec {
         [..init, _] => init, //~ ERROR does not live long enough
-        _ => fail!(~"b")
+        _ => fail!("b")
     };
     init
 }
@@ -20,7 +20,7 @@ fn c() -> &[int] {
     let vec = [1, 2, 3, 4];
     let slice = match vec {
         [_, ..slice, _] => slice, //~ ERROR does not live long enough
-        _ => fail!(~"c")
+        _ => fail!("c")
     };
     slice
 }

--- a/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
@@ -4,7 +4,7 @@ fn a() {
         [~ref _a] => {
             vec[0] = ~4; //~ ERROR cannot assign to `vec[]` because it is borrowed
         }
-        _ => fail!(~"foo")
+        _ => fail!("foo")
     }
 }
 

--- a/src/test/compile-fail/borrowck-vec-pattern-tail-element-loan.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-tail-element-loan.rs
@@ -2,7 +2,7 @@ fn a() -> &int {
     let vec = [1, 2, 3, 4];
     let tail = match vec {
         [_a, ..tail] => &tail[0], //~ ERROR borrowed value does not live long enough
-        _ => fail!(~"foo")
+        _ => fail!("foo")
     };
     tail
 }

--- a/src/test/compile-fail/issue-3601.rs
+++ b/src/test/compile-fail/issue-3601.rs
@@ -37,6 +37,6 @@ fn main() {
         ~Element(ed) => match ed.kind { //~ ERROR non-exhaustive patterns
             ~HTMLImageElement(ref d) if d.image.is_some() => { true }
         },
-        _ => fail!(~"WAT") //~ ERROR unreachable pattern
+        _ => fail!("WAT") //~ ERROR unreachable pattern
     };
 }

--- a/src/test/compile-fail/non-exhaustive-match-nested.rs
+++ b/src/test/compile-fail/non-exhaustive-match-nested.rs
@@ -16,7 +16,7 @@ enum u { c, d }
 fn main() {
   let x = a(c);
   match x {
-      a(d) => { fail!(~"hello"); }
-      b => { fail!(~"goodbye"); }
+      a(d) => { fail!("hello"); }
+      b => { fail!("goodbye"); }
     }
 }

--- a/src/test/run-fail/alt-disc-bot.rs
+++ b/src/test/run-fail/alt-disc-bot.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 // error-pattern:quux
-fn f() -> ! { fail!(~"quux") }
+fn f() -> ! { fail!("quux") }
 fn g() -> int { match f() { true => { 1 } false => { 0 } } }
 fn main() { g(); }

--- a/src/test/run-fail/alt-wildcards.rs
+++ b/src/test/run-fail/alt-wildcards.rs
@@ -11,9 +11,9 @@
 // error-pattern:squirrelcupcake
 fn cmp() -> int {
     match (option::Some('a'), option::None::<char>) {
-        (option::Some(_), _) => { fail!(~"squirrelcupcake"); }
+        (option::Some(_), _) => { fail!("squirrelcupcake"); }
         (_, option::Some(_)) => { fail!(); }
-        _                    => { fail!(~"wat"); }
+        _                    => { fail!("wat"); }
     }
 }
 

--- a/src/test/run-fail/args-fail.rs
+++ b/src/test/run-fail/args-fail.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 // error-pattern:meep
-fn f(a: int, b: int, c: @int) { fail!(~"moop"); }
+fn f(a: int, b: int, c: @int) { fail!("moop"); }
 
-fn main() { f(1, fail!(~"meep"), @42); }
+fn main() { f(1, fail!("meep"), @42); }

--- a/src/test/run-fail/assert-eq-macro-fail.rs
+++ b/src/test/run-fail/assert-eq-macro-fail.rs
@@ -1,4 +1,4 @@
-// error-pattern:left: 14 != right: 15
+// error-pattern:left: 14 does not equal right: 15
 
 #[deriving(Eq)]
 struct Point { x : int }

--- a/src/test/run-fail/binop-fail-2.rs
+++ b/src/test/run-fail/binop-fail-2.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 // error-pattern:quux
-fn my_err(s: ~str) -> ! { error!(s); fail!(~"quux"); }
+fn my_err(s: ~str) -> ! { error!(s); fail!("quux"); }
 fn main() { 3u == my_err(~"bye"); }

--- a/src/test/run-fail/binop-fail.rs
+++ b/src/test/run-fail/binop-fail.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 // error-pattern:quux
-fn my_err(s: ~str) -> ! { error!(s); fail!(~"quux"); }
+fn my_err(s: ~str) -> ! { error!(s); fail!("quux"); }
 fn main() { 3u == my_err(~"bye"); }

--- a/src/test/run-fail/bug-811.rs
+++ b/src/test/run-fail/bug-811.rs
@@ -21,4 +21,4 @@ struct chan_t<T> {
 
 fn send<T:Owned>(ch: chan_t<T>, data: T) { fail!(); }
 
-fn main() { fail!(~"quux"); }
+fn main() { fail!("quux"); }

--- a/src/test/run-fail/die-macro-expr.rs
+++ b/src/test/run-fail/die-macro-expr.rs
@@ -1,5 +1,5 @@
 // error-pattern:test
 
 fn main() {
-    let i: int = fail!(~"test");
+    let i: int = fail!("test");
 }

--- a/src/test/run-fail/die-macro-pure.rs
+++ b/src/test/run-fail/die-macro-pure.rs
@@ -1,7 +1,7 @@
 // error-pattern:test
 
 fn f() {
-    fail!(~"test");
+    fail!("test");
 }
 
 fn main() {

--- a/src/test/run-fail/die-macro.rs
+++ b/src/test/run-fail/die-macro.rs
@@ -1,5 +1,5 @@
 // error-pattern:test
 
 fn main() {
-    fail!(~"test");
+    fail!("test");
 }

--- a/src/test/run-fail/doublefail.rs
+++ b/src/test/run-fail/doublefail.rs
@@ -10,6 +10,6 @@
 
 //error-pattern:One
 fn main() {
-    fail!(~"One");
-    fail!(~"Two");
+    fail!("One");
+    fail!("Two");
 }

--- a/src/test/run-fail/explicit-fail-msg.rs
+++ b/src/test/run-fail/explicit-fail-msg.rs
@@ -10,5 +10,5 @@
 
 // error-pattern:wooooo
 fn main() {
-    let mut a = 1; if 1 == 1 { a = 2; } fail!(~"woooo" + ~"o");
+    let mut a = 1; if 1 == 1 { a = 2; } fail!(~"woooo" + "o");
 }

--- a/src/test/run-fail/fail-arg.rs
+++ b/src/test/run-fail/fail-arg.rs
@@ -11,4 +11,4 @@
 // error-pattern:woe
 fn f(a: int) { debug!(a); }
 
-fn main() { f(fail!(~"woe")); }
+fn main() { f(fail!("woe")); }

--- a/src/test/run-fail/fail-macro-owned.rs
+++ b/src/test/run-fail/fail-macro-owned.rs
@@ -11,5 +11,5 @@
 // error-pattern:task failed at 'test-fail-owned'
 
 fn main() {
-    fail!(~"test-fail-owned");
+    fail!("test-fail-owned");
 }

--- a/src/test/run-fail/fail-main.rs
+++ b/src/test/run-fail/fail-main.rs
@@ -10,4 +10,4 @@
 
 // error-pattern:moop
 extern mod std;
-fn main() { fail!(~"moop"); }
+fn main() { fail!("moop"); }

--- a/src/test/run-fail/fail-parens.rs
+++ b/src/test/run-fail/fail-parens.rs
@@ -13,7 +13,7 @@
 // error-pattern:oops
 
 fn bigfail() {
-    while (fail!(~"oops")) { if (fail!()) {
+    while (fail!("oops")) { if (fail!()) {
         match (fail!()) { () => {
         }
                      }

--- a/src/test/run-fail/for-each-loop-fail.rs
+++ b/src/test/run-fail/for-each-loop-fail.rs
@@ -10,4 +10,4 @@
 
 // error-pattern:moop
 extern mod std;
-fn main() { for uint::range(0u, 10u) |_i| { fail!(~"moop"); } }
+fn main() { for uint::range(0u, 10u) |_i| { fail!("moop"); } }

--- a/src/test/run-fail/if-check-fail.rs
+++ b/src/test/run-fail/if-check-fail.rs
@@ -19,7 +19,7 @@ fn foo(x: uint) {
     if even(x) {
         debug!(x);
     } else {
-        fail!(~"Number is odd");
+        fail!("Number is odd");
     }
 }
 

--- a/src/test/run-fail/if-cond-bot.rs
+++ b/src/test/run-fail/if-cond-bot.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 // error-pattern:quux
-fn my_err(s: ~str) -> ! { error!(s); fail!(~"quux"); }
+fn my_err(s: ~str) -> ! { error!(s); fail!("quux"); }
 fn main() { if my_err(~"bye") { } }

--- a/src/test/run-fail/issue-3029.rs
+++ b/src/test/run-fail/issue-3029.rs
@@ -11,7 +11,7 @@
 // error-pattern:so long
 fn main() {
     let x = ~[], y = ~[3];
-    fail!(~"so long");
+    fail!("so long");
     x += y;
     ~"good" + ~"bye";
 }

--- a/src/test/run-fail/issue-948.rs
+++ b/src/test/run-fail/issue-948.rs
@@ -14,5 +14,5 @@ struct Point { x: int, y: int }
 
 fn main() {
     let origin = Point {x: 0, y: 0};
-    let f: Point = Point {x: (fail!(~"beep boop")),.. origin};
+    let f: Point = Point {x: (fail!("beep boop")),.. origin};
 }

--- a/src/test/run-fail/linked-failure3.rs
+++ b/src/test/run-fail/linked-failure3.rs
@@ -12,7 +12,7 @@
 
 // error-pattern:fail
 
-fn grandchild() { fail!(~"grandchild dies"); }
+fn grandchild() { fail!("grandchild dies"); }
 
 fn child() {
     let (p, _c) = comm::stream::<int>();

--- a/src/test/run-fail/rhs-type.rs
+++ b/src/test/run-fail/rhs-type.rs
@@ -14,4 +14,4 @@
 
 struct T { t: ~str }
 
-fn main() { let pth = fail!(~"bye"); let rs: T = T {t: pth}; }
+fn main() { let pth = fail!("bye"); let rs: T = T {t: pth}; }

--- a/src/test/run-fail/rt-log-trunc.rs
+++ b/src/test/run-fail/rt-log-trunc.rs
@@ -12,7 +12,7 @@
 // error-pattern:[...]
 
 fn main() {
-    fail!(~"\
+    fail!("\
           aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
           aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
           aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\

--- a/src/test/run-fail/run-unexported-tests.rs
+++ b/src/test/run-fail/run-unexported-tests.rs
@@ -17,5 +17,5 @@ mod m {
     pub fn exported() { }
 
     #[test]
-    fn unexported() { fail!(~"runned an unexported test"); }
+    fn unexported() { fail!("runned an unexported test"); }
 }

--- a/src/test/run-fail/task-comm-recv-block.rs
+++ b/src/test/run-fail/task-comm-recv-block.rs
@@ -12,7 +12,7 @@
 
 fn goodfail() {
     task::yield();
-    fail!(~"goodfail");
+    fail!("goodfail");
 }
 
 fn main() {
@@ -21,5 +21,5 @@ fn main() {
     // We shouldn't be able to get past this recv since there's no
     // message available
     let i: int = po.recv();
-    fail!(~"badfail");
+    fail!("badfail");
 }

--- a/src/test/run-fail/unwind-alt.rs
+++ b/src/test/run-fail/unwind-alt.rs
@@ -15,7 +15,7 @@ fn test_box() {
 }
 fn test_str() {
   let res = match false { true => { ~"happy" },
-     _ => fail!(~"non-exhaustive match failure") };
+     _ => fail!("non-exhaustive match failure") };
   assert!(res == ~"happy");
 }
 fn main() {

--- a/src/test/run-fail/unwind-lambda.rs
+++ b/src/test/run-fail/unwind-lambda.rs
@@ -22,7 +22,7 @@ fn main() {
         let cheese = copy cheese;
         let f: &fn() = || {
             let chew = mush + cheese;
-            fail!(~"so yummy")
+            fail!("so yummy")
         };
         f();
     });

--- a/src/test/run-fail/unwind-resource-fail.rs
+++ b/src/test/run-fail/unwind-resource-fail.rs
@@ -15,7 +15,7 @@ struct r {
 }
 
 impl Drop for r {
-    fn finalize(&self) { fail!(~"squirrel") }
+    fn finalize(&self) { fail!("squirrel") }
 }
 
 fn r(i: int) -> r { r { i: i } }

--- a/src/test/run-fail/unwind-resource-fail2.rs
+++ b/src/test/run-fail/unwind-resource-fail2.rs
@@ -16,7 +16,7 @@ struct r {
 }
 
 impl Drop for r {
-    fn finalize(&self) { fail!(~"wombat") }
+    fn finalize(&self) { fail!("wombat") }
 }
 
 fn r(i: int) -> r { r { i: i } }

--- a/src/test/run-fail/unwind-resource-fail3.rs
+++ b/src/test/run-fail/unwind-resource-fail3.rs
@@ -20,7 +20,7 @@ fn faily_box(i: @int) -> faily_box { faily_box { i: i } }
 #[unsafe_destructor]
 impl Drop for faily_box {
     fn finalize(&self) {
-        fail!(~"quux");
+        fail!("quux");
     }
 }
 

--- a/src/test/run-fail/while-body-fails.rs
+++ b/src/test/run-fail/while-body-fails.rs
@@ -9,4 +9,4 @@
 // except according to those terms.
 
 // error-pattern:quux
-fn main() { let x: int = { while true { fail!(~"quux"); } ; 8 } ; }
+fn main() { let x: int = { while true { fail!("quux"); } ; 8 } ; }

--- a/src/test/run-fail/while-fail.rs
+++ b/src/test/run-fail/while-fail.rs
@@ -10,5 +10,5 @@
 
 // error-pattern:giraffe
 fn main() {
-    fail!({ while true { fail!(~"giraffe")}; "clandestine" });
+    fail!({ while true { fail!("giraffe") }; "clandestine" });
 }

--- a/src/test/run-fail/while-fail.rs
+++ b/src/test/run-fail/while-fail.rs
@@ -10,5 +10,5 @@
 
 // error-pattern:giraffe
 fn main() {
-    fail!({ while true { fail!(~"giraffe")}; ~"clandestine" });
+    fail!({ while true { fail!(~"giraffe")}; "clandestine" });
 }

--- a/src/test/run-fail/zip-different-lengths.rs
+++ b/src/test/run-fail/zip-different-lengths.rs
@@ -37,5 +37,5 @@ fn main() {
 
     assert!(same_length(chars, ints));
     let ps = zip(chars, ints);
-    fail!(~"the impossible happened");
+    fail!("the impossible happened");
 }

--- a/src/test/run-pass/alt-pattern-lit.rs
+++ b/src/test/run-pass/alt-pattern-lit.rs
@@ -14,7 +14,7 @@ fn altlit(f: int) -> int {
     match f {
       10 => { debug!("case 10"); return 20; }
       11 => { debug!("case 11"); return 22; }
-      _  => fail!(~"the impossible happened")
+      _  => fail!("the impossible happened")
     }
 }
 

--- a/src/test/run-pass/alt-range.rs
+++ b/src/test/run-pass/alt-range.rs
@@ -11,31 +11,31 @@
 pub fn main() {
     match 5u {
       1u..5u => {}
-      _ => fail!(~"should match range"),
+      _ => fail!("should match range"),
     }
     match 5u {
-      6u..7u => fail!(~"shouldn't match range"),
+      6u..7u => fail!("shouldn't match range"),
       _ => {}
     }
     match 5u {
-      1u => fail!(~"should match non-first range"),
+      1u => fail!("should match non-first range"),
       2u..6u => {}
-      _ => fail!(~"math is broken")
+      _ => fail!("math is broken")
     }
     match 'c' {
       'a'..'z' => {}
-      _ => fail!(~"should suppport char ranges")
+      _ => fail!("should suppport char ranges")
     }
     match -3 {
       -7..5 => {}
-      _ => fail!(~"should match signed range")
+      _ => fail!("should match signed range")
     }
     match 3.0 {
       1.0..5.0 => {}
-      _ => fail!(~"should match float range")
+      _ => fail!("should match float range")
     }
     match -1.5 {
       -3.6..3.6 => {}
-      _ => fail!(~"should match negative float range")
+      _ => fail!("should match negative float range")
     }
 }

--- a/src/test/run-pass/binary-minus-without-space.rs
+++ b/src/test/run-pass/binary-minus-without-space.rs
@@ -11,6 +11,6 @@
 // Check that issue #954 stays fixed
 
 pub fn main() {
-    match -1 { -1 => {}, _ => fail!(~"wat") }
+    match -1 { -1 => {}, _ => fail!("wat") }
     assert!(1-1 == 0);
 }

--- a/src/test/run-pass/block-arg.rs
+++ b/src/test/run-pass/block-arg.rs
@@ -35,14 +35,14 @@ pub fn main() {
         assert!(false);
     }
     match do vec::all(v) |e| { e.is_negative() } {
-        true => { fail!(~"incorrect answer."); }
+        true => { fail!("incorrect answer."); }
         false => { }
     }
     match 3 {
       _ if do vec::any(v) |e| { e.is_negative() } => {
       }
       _ => {
-        fail!(~"wrong answer.");
+        fail!("wrong answer.");
       }
     }
 

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -79,7 +79,7 @@ impl<T> Map<int, T> for cat<T> {
     }
 
     fn mutate_values(&mut self, _f: &fn(&int, &mut T) -> bool) -> bool {
-        fail!(~"nope")
+        fail!("nope")
     }
 
     fn insert(&mut self, k: int, _: T) -> bool {
@@ -114,7 +114,7 @@ pub impl<T> cat<T> {
     fn get<'a>(&'a self, k: &int) -> &'a T {
         match self.find(k) {
           Some(v) => { v }
-          None    => { fail!(~"epic fail"); }
+          None    => { fail!("epic fail"); }
         }
     }
 

--- a/src/test/run-pass/expr-alt-box.rs
+++ b/src/test/run-pass/expr-alt-box.rs
@@ -15,13 +15,13 @@
 
 // Tests for match as expressions resulting in boxed types
 fn test_box() {
-    let res = match true { true => { @100 } _ => fail!(~"wat") };
+    let res = match true { true => { @100 } _ => fail!("wat") };
     assert!((*res == 100));
 }
 
 fn test_str() {
     let res = match true { true => { ~"happy" },
-                         _ => fail!(~"not happy at all") };
+                         _ => fail!("not happy at all") };
     assert!((res == ~"happy"));
 }
 

--- a/src/test/run-pass/expr-alt-generic-box2.rs
+++ b/src/test/run-pass/expr-alt-generic-box2.rs
@@ -14,7 +14,7 @@
 type compare<T> = @fn(T, T) -> bool;
 
 fn test_generic<T:Copy>(expected: T, eq: compare<T>) {
-    let actual: T = match true { true => { expected }, _ => fail!(~"wat") };
+    let actual: T = match true { true => { expected }, _ => fail!("wat") };
     assert!((eq(expected, actual)));
 }
 

--- a/src/test/run-pass/expr-alt-generic-unique1.rs
+++ b/src/test/run-pass/expr-alt-generic-unique1.rs
@@ -16,7 +16,7 @@ type compare<T> = @fn(~T, ~T) -> bool;
 fn test_generic<T:Copy+Clone>(expected: ~T, eq: compare<T>) {
     let actual: ~T = match true {
         true => { expected.clone() },
-        _ => fail!(~"wat")
+        _ => fail!("wat")
     };
     assert!((eq(expected, actual)));
 }

--- a/src/test/run-pass/expr-alt-generic-unique2.rs
+++ b/src/test/run-pass/expr-alt-generic-unique2.rs
@@ -16,7 +16,7 @@ type compare<T> = @fn(T, T) -> bool;
 fn test_generic<T:Copy+Clone>(expected: T, eq: compare<T>) {
     let actual: T = match true {
         true => expected.clone(),
-        _ => fail!(~"wat")
+        _ => fail!("wat")
     };
     assert!((eq(expected, actual)));
 }

--- a/src/test/run-pass/expr-alt-generic.rs
+++ b/src/test/run-pass/expr-alt-generic.rs
@@ -14,7 +14,7 @@
 type compare<T> = @fn(T, T) -> bool;
 
 fn test_generic<T:Copy>(expected: T, eq: compare<T>) {
-  let actual: T = match true { true => { expected }, _ => fail!(~"wat") };
+  let actual: T = match true { true => { expected }, _ => fail!("wat") };
     assert!((eq(expected, actual)));
 }
 

--- a/src/test/run-pass/for-loop-fail.rs
+++ b/src/test/run-pass/for-loop-fail.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub fn main() { let x: ~[int] = ~[]; for x.each |_i| { fail!(~"moop"); } }
+pub fn main() { let x: ~[int] = ~[]; for x.each |_i| { fail!("moop"); } }

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -85,7 +85,7 @@ pub mod pipes {
             // The receiver will eventually clean this up.
             unsafe { forget(p); }
           }
-          full => { fail!(~"duplicate send") }
+          full => { fail!("duplicate send") }
           blocked => {
 
             // The receiver will eventually clean this up.
@@ -127,7 +127,7 @@ pub mod pipes {
           }
           full => {
             // This is impossible
-            fail!(~"you dun goofed")
+            fail!("you dun goofed")
           }
           terminated => {
             // I have to clean up, use drop_glue
@@ -144,7 +144,7 @@ pub mod pipes {
           }
           blocked => {
             // this shouldn't happen.
-            fail!(~"terminating a blocked packet")
+            fail!("terminating a blocked packet")
           }
           terminated | full => {
             // I have to clean up, use drop_glue
@@ -269,7 +269,7 @@ pub mod pingpong {
         pub fn do_pong(c: pong) -> (ping, ()) {
             let packet = ::pipes::recv(c);
             if packet.is_none() {
-                fail!(~"sender closed the connection")
+                fail!("sender closed the connection")
             }
             (pingpong::liberate_pong(packet.unwrap()), ())
         }
@@ -284,7 +284,7 @@ pub mod pingpong {
         pub fn do_ping(c: ping) -> (pong, ()) {
             let packet = ::pipes::recv(c);
             if packet.is_none() {
-                fail!(~"sender closed the connection")
+                fail!("sender closed the connection")
             }
             (pingpong::liberate_ping(packet.unwrap()), ())
         }

--- a/src/test/run-pass/nullable-pointer-iotareduction.rs
+++ b/src/test/run-pass/nullable-pointer-iotareduction.rs
@@ -28,7 +28,7 @@ impl<T> E<T> {
     }
     fn get_ref<'r>(&'r self) -> (int, &'r T) {
         match *self {
-            Nothing(*) => fail!(fmt!("E::get_ref(Nothing::<%s>)",  stringify!($T))),
+            Nothing(*) => fail!("E::get_ref(Nothing::<%s>)",  stringify!($T)),
             Thing(x, ref y) => (x, y)
         }
     }
@@ -57,8 +57,8 @@ macro_rules! check_fancy {
         let t_ = Thing::<$T>(23, $e);
         match t_.get_ref() {
             (23, $v) => { $chk }
-            _ => fail!(fmt!("Thing::<%s>(23, %s).get_ref() != (23, _)",
-                            stringify!($T), stringify!($e)))
+            _ => fail!("Thing::<%s>(23, %s).get_ref() != (23, _)",
+                            stringify!($T), stringify!($e))
         }
     }}
 }

--- a/src/test/run-pass/nullable-pointer-iotareduction.rs
+++ b/src/test/run-pass/nullable-pointer-iotareduction.rs
@@ -58,7 +58,7 @@ macro_rules! check_fancy {
         match t_.get_ref() {
             (23, $v) => { $chk }
             _ => fail!("Thing::<%s>(23, %s).get_ref() != (23, _)",
-                            stringify!($T), stringify!($e))
+                       stringify!($T), stringify!($e))
         }
     }}
 }

--- a/src/test/run-pass/option_addition.rs
+++ b/src/test/run-pass/option_addition.rs
@@ -20,7 +20,7 @@ pub fn main() {
 
     match nope {
         None => (),
-        Some(foo) => fail!(fmt!("expected None, but found %?", foo))
+        Some(foo) => fail!("expected None, but found %?", foo)
     }
     assert!(foo == somefoo.get());
     assert!(bar == somebar.get());

--- a/src/test/run-pass/overload-index-operator.rs
+++ b/src/test/run-pass/overload-index-operator.rs
@@ -35,7 +35,7 @@ impl<K:Eq,V:Copy> Index<K,V> for AssociationList<K,V> {
                 return copy pair.value;
             }
         }
-        fail!(fmt!("No value found for key: %?", index));
+        fail!("No value found for key: %?", index);
     }
 }
 

--- a/src/test/run-pass/pipe-bank-proto.rs
+++ b/src/test/run-pass/pipe-bank-proto.rs
@@ -74,7 +74,7 @@ fn client_follow(bank: bank::client::login) {
     let bank = client::login(bank, ~"theincredibleholk", ~"1234");
     let bank = switch(bank, follow! (
         ok -> connected { connected }
-        invalid -> _next { fail!(~"bank closed the connected") }
+        invalid -> _next { fail!("bank closed the connected") }
     ));
 
     let bank = client::deposit(bank, 100.00);
@@ -84,7 +84,7 @@ fn client_follow(bank: bank::client::login) {
             io::println(~"Yay! I got money!");
         }
         insufficient_funds -> _next {
-            fail!(~"someone stole my money")
+            fail!("someone stole my money")
         }
     ));
 }
@@ -97,8 +97,8 @@ fn bank_client(bank: bank::client::login) {
       Some(ok(connected)) => {
         move_it!(connected)
       }
-      Some(invalid(_)) => { fail!(~"login unsuccessful") }
-      None => { fail!(~"bank closed the connection") }
+      Some(invalid(_)) => { fail!("login unsuccessful") }
+      None => { fail!("bank closed the connection") }
     };
 
     let bank = client::deposit(bank, 100.00);
@@ -108,10 +108,10 @@ fn bank_client(bank: bank::client::login) {
         io::println(~"Yay! I got money!");
       }
       Some(insufficient_funds(_)) => {
-        fail!(~"someone stole my money")
+        fail!("someone stole my money")
       }
       None => {
-        fail!(~"bank closed the connection")
+        fail!("bank closed the connection")
       }
     }
 }

--- a/src/test/run-pass/region-return-interior-of-option.rs
+++ b/src/test/run-pass/region-return-interior-of-option.rs
@@ -11,7 +11,7 @@
 fn get<'r, T>(opt: &'r Option<T>) -> &'r T {
     match *opt {
       Some(ref v) => v,
-      None => fail!(~"none")
+      None => fail!("none")
     }
 }
 

--- a/src/test/run-pass/weird-exprs.rs
+++ b/src/test/run-pass/weird-exprs.rs
@@ -67,7 +67,7 @@ fn canttouchthis() -> uint {
 fn angrydome() {
     loop { if break { } }
     let mut i = 0;
-    loop { i += 1; if i == 1 { match (loop) { 1 => { }, _ => fail!(~"wat") } }
+    loop { i += 1; if i == 1 { match (loop) { 1 => { }, _ => fail!("wat") } }
       break; }
 }
 


### PR DESCRIPTION
fail!() used to require owned strings but can handle static strings
now. Also, it can pass its arguments to fmt!() on its own, no need for
the caller to call fmt!() itself.
