### PR TITLE
Replace all uses of rust-intrinsic ABI with calls to unstable::intrinsic...

### DIFF
--- a/src/libcore/cast.rs
+++ b/src/libcore/cast.rs
@@ -12,26 +12,17 @@
 
 use sys;
 use unstable;
-
-pub mod rusti {
-    #[abi = "rust-intrinsic"]
-    #[link_name = "rusti"]
-    pub extern "rust-intrinsic" {
-        fn forget<T>(x: T);
-
-        fn transmute<T,U>(e: T) -> U;
-    }
-}
+use unstable::intrinsics;
 
 /// Casts the value at `src` to U. The two types must have the same length.
 pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
-    let mut dest: U = unstable::intrinsics::init();
+    let mut dest: U = intrinsics::init();
     {
-        let dest_ptr: *mut u8 = rusti::transmute(&mut dest);
-        let src_ptr: *u8 = rusti::transmute(src);
-        unstable::intrinsics::memmove64(dest_ptr,
-                                        src_ptr,
-                                        sys::size_of::<U>() as u64);
+        let dest_ptr: *mut u8 = transmute(&mut dest);
+        let src_ptr: *u8 = transmute(src);
+        intrinsics::memmove64(dest_ptr,
+                              src_ptr,
+                              sys::size_of::<U>() as u64);
     }
     dest
 }
@@ -45,7 +36,7 @@ pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
  * reinterpret_cast on pointer types.
  */
 #[inline(always)]
-pub unsafe fn forget<T>(thing: T) { rusti::forget(thing); }
+pub unsafe fn forget<T>(thing: T) { intrinsics::forget(thing); }
 
 /**
  * Force-increment the reference count on a shared box. If used
@@ -65,7 +56,7 @@ pub unsafe fn bump_box_refcount<T>(t: @T) { forget(t); }
  */
 #[inline(always)]
 pub unsafe fn transmute<L, G>(thing: L) -> G {
-    rusti::transmute(thing)
+    intrinsics::transmute(thing)
 }
 
 /// Coerce an immutable reference to be mutable.

--- a/src/libcore/stackwalk.rs
+++ b/src/libcore/stackwalk.rs
@@ -11,6 +11,7 @@
 #[doc(hidden)]; // FIXME #3538
 
 use cast::transmute;
+use unstable::intrinsics;
 
 pub type Word = uint;
 
@@ -75,13 +76,6 @@ fn test_simple_deep() {
 
 fn frame_address(f: &fn(x: *u8)) {
     unsafe {
-        rusti::frame_address(f)
-    }
-}
-
-pub mod rusti {
-    #[abi = "rust-intrinsic"]
-    pub extern "rust-intrinsic" {
-        pub fn frame_address(f: &once fn(x: *u8));
+        intrinsics::frame_address(f)
     }
 }

--- a/src/libcore/sys.rs
+++ b/src/libcore/sys.rs
@@ -19,6 +19,7 @@ use libc;
 use libc::{c_void, c_char, size_t};
 use repr;
 use str;
+use unstable::intrinsics;
 
 pub type FreeGlue<'self> = &'self fn(*TypeDesc, *c_void);
 
@@ -36,16 +37,6 @@ pub struct TypeDesc {
 pub struct Closure {
     code: *(),
     env: *(),
-}
-
-pub mod rusti {
-    #[abi = "rust-intrinsic"]
-    pub extern "rust-intrinsic" {
-        fn get_tydesc<T>() -> *();
-        fn size_of<T>() -> uint;
-        fn pref_align_of<T>() -> uint;
-        fn min_align_of<T>() -> uint;
-    }
 }
 
 pub mod rustrt {
@@ -81,7 +72,7 @@ pub fn shape_le<T:Ord>(x1: &T, x2: &T) -> bool {
  */
 #[inline(always)]
 pub fn get_type_desc<T>() -> *TypeDesc {
-    unsafe { rusti::get_tydesc::<T>() as *TypeDesc }
+    unsafe { intrinsics::get_tydesc::<T>() as *TypeDesc }
 }
 
 /// Returns a pointer to a type descriptor.
@@ -93,7 +84,7 @@ pub fn get_type_desc_val<T>(_val: &T) -> *TypeDesc {
 /// Returns the size of a type
 #[inline(always)]
 pub fn size_of<T>() -> uint {
-    unsafe { rusti::size_of::<T>() }
+    unsafe { intrinsics::size_of::<T>() }
 }
 
 /// Returns the size of the type that `_val` points to
@@ -128,7 +119,7 @@ pub fn nonzero_size_of_val<T>(_val: &T) -> uint {
  */
 #[inline(always)]
 pub fn min_align_of<T>() -> uint {
-    unsafe { rusti::min_align_of::<T>() }
+    unsafe { intrinsics::min_align_of::<T>() }
 }
 
 /// Returns the ABI-required minimum alignment of the type of the value that
@@ -141,7 +132,7 @@ pub fn min_align_of_val<T>(_val: &T) -> uint {
 /// Returns the preferred alignment of a type
 #[inline(always)]
 pub fn pref_align_of<T>() -> uint {
-    unsafe { rusti::pref_align_of::<T>() }
+    unsafe { intrinsics::pref_align_of::<T>() }
 }
 
 /// Returns the preferred alignment of the type of the value that

--- a/src/libcore/unstable/intrinsics.rs
+++ b/src/libcore/unstable/intrinsics.rs
@@ -114,6 +114,7 @@ pub extern "rust-intrinsic" {
     /// `forget` is unsafe because the caller is responsible for
     /// ensuring the argument is deallocated already.
     pub unsafe fn forget<T>(_: T) -> ();
+    pub fn transmute<T,U>(e: T) -> U;
 
     /// Returns `true` if a type requires drop glue.
     pub fn needs_drop<T>() -> bool;
@@ -121,8 +122,8 @@ pub extern "rust-intrinsic" {
     // XXX: intrinsic uses legacy modes and has reference to TyDesc
     // and TyVisitor which are in librustc
     //fn visit_tydesc(++td: *TyDesc, &&tv: TyVisitor) -> ();
-    // XXX: intrinsic uses legacy modes
-    //fn frame_address(f: &once fn(*u8));
+
+    pub fn frame_address(f: &once fn(*u8));
 
     /// Get the address of the `__morestack` stack growth function.
     pub fn morestack_addr() -> *();

--- a/src/libstd/arena.rs
+++ b/src/libstd/arena.rs
@@ -43,14 +43,7 @@ use core::sys::TypeDesc;
 use core::sys;
 use core::uint;
 use core::vec;
-
-pub mod rusti {
-    #[abi = "rust-intrinsic"]
-    pub extern "rust-intrinsic" {
-        fn move_val_init<T>(dst: &mut T, src: T);
-        fn needs_drop<T>() -> bool;
-    }
-}
+use core::unstable::intrinsics;
 
 pub mod rustrt {
     use core::libc::size_t;
@@ -208,7 +201,7 @@ pub impl Arena {
             let tydesc = sys::get_type_desc::<T>();
             let ptr = self.alloc_pod_inner((*tydesc).size, (*tydesc).align);
             let ptr: *mut T = transmute(ptr);
-            rusti::move_val_init(&mut (*ptr), op());
+            intrinsics::move_val_init(&mut (*ptr), op());
             return transmute(ptr);
         }
     }
@@ -261,7 +254,7 @@ pub impl Arena {
             // has *not* been initialized yet.
             *ty_ptr = transmute(tydesc);
             // Actually initialize it
-            rusti::move_val_init(&mut(*ptr), op());
+            intrinsics::move_val_init(&mut(*ptr), op());
             // Now that we are done, update the tydesc to indicate that
             // the object is there.
             *ty_ptr = bitpack_tydesc_ptr(tydesc, true);
@@ -276,7 +269,7 @@ pub impl Arena {
         unsafe {
             // XXX: Borrow check
             let this = transmute_mut_region(self);
-            if !rusti::needs_drop::<T>() {
+            if !intrinsics::needs_drop::<T>() {
                 return this.alloc_pod(op);
             }
             // XXX: Borrow check

--- a/src/libstd/priority_queue.rs
+++ b/src/libstd/priority_queue.rs
@@ -11,8 +11,9 @@
 //! A priority queue implemented with a binary heap
 
 use core::old_iter::BaseIter;
+use core::unstable::intrinsics::{move_val_init, init};
+use core::unstable::intrinsics::uninit;
 use core::util::{replace, swap};
-use core::unstable::intrinsics::{init, move_val_init};
 
 pub struct PriorityQueue<T> {
     priv data: ~[T],


### PR DESCRIPTION
...s
