### PR TITLE
libsyntax: Remove `extern mod foo { ... }` from the language.

### DIFF
--- a/doc/tutorial-ffi.md
+++ b/doc/tutorial-ffi.md
@@ -235,7 +235,8 @@ convention to use:
 ~~~~
 #[cfg(target_os = "win32")]
 #[abi = "stdcall"]
-extern mod kernel32 {
+#[link_name = "kernel32"]
+extern {
     fn SetEnvironmentVariableA(n: *u8, v: *u8) -> int;
 }
 ~~~~

--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -197,10 +197,10 @@ pub fn env() -> ~[(~str,~str)] {
         }
         #[cfg(unix)]
         unsafe fn get_env_pairs() -> ~[~str] {
-            extern mod rustrt {
+            extern {
                 unsafe fn rust_env_pairs() -> **libc::c_char;
             }
-            let environ = rustrt::rust_env_pairs();
+            let environ = rust_env_pairs();
             if (environ as uint == 0) {
                 fail!(fmt!("os::env() failure getting env string from OS: %s",
                            os::last_os_error()));
@@ -677,9 +677,8 @@ pub fn list_dir(p: &Path) -> ~[~str] {
         unsafe fn get_list(p: &Path) -> ~[~str] {
             use libc::{dirent_t};
             use libc::{opendir, readdir, closedir};
-            extern mod rustrt {
-                unsafe fn rust_list_dir_val(ptr: *dirent_t)
-                    -> *libc::c_char;
+            extern {
+                unsafe fn rust_list_dir_val(ptr: *dirent_t) -> *libc::c_char;
             }
             let input = p.to_str();
             let mut strings = ~[];
@@ -690,10 +689,8 @@ pub fn list_dir(p: &Path) -> ~[~str] {
         debug!("os::list_dir -- opendir() SUCCESS");
                 let mut entry_ptr = readdir(dir_ptr);
                 while (entry_ptr as uint != 0) {
-                    strings.push(
-                        str::raw::from_c_str(
-                            rustrt::rust_list_dir_val(
-                                entry_ptr)));
+                    strings.push(str::raw::from_c_str(rust_list_dir_val(
+                        entry_ptr)));
                     entry_ptr = readdir(dir_ptr);
                 }
                 closedir(dir_ptr);
@@ -721,7 +718,7 @@ pub fn list_dir(p: &Path) -> ~[~str] {
             };
             use unstable::exchange_alloc::{malloc_raw, free_raw};
             #[nolink]
-            extern mod rustrt {
+            extern {
                 unsafe fn rust_list_dir_wfd_size() -> libc::size_t;
                 unsafe fn rust_list_dir_wfd_fp_buf(wfd: *libc::c_void)
                     -> *u16;
@@ -729,8 +726,7 @@ pub fn list_dir(p: &Path) -> ~[~str] {
             fn star(p: &Path) -> Path { p.push("*") }
             do as_utf16_p(star(p).to_str()) |path_ptr| {
                 let mut strings = ~[];
-                let wfd_ptr = malloc_raw(
-                    rustrt::rust_list_dir_wfd_size() as uint);
+                let wfd_ptr = malloc_raw(rust_list_dir_wfd_size() as uint);
                 let find_handle =
                     FindFirstFileW(
                         path_ptr,
@@ -738,8 +734,7 @@ pub fn list_dir(p: &Path) -> ~[~str] {
                 if find_handle as int != INVALID_HANDLE_VALUE {
                     let mut more_files = 1 as libc::c_int;
                     while more_files != 0 {
-                        let fp_buf = rustrt::rust_list_dir_wfd_fp_buf(
-                            wfd_ptr);
+                        let fp_buf = rust_list_dir_wfd_fp_buf(wfd_ptr);
                         if fp_buf as uint == 0 {
                             fail!(~"os::list_dir() failure:"+
                                   ~" got null ptr from wfd");

--- a/src/libstd/priority_queue.rs
+++ b/src/libstd/priority_queue.rs
@@ -13,7 +13,7 @@
 use core::old_iter::BaseIter;
 
 #[abi = "rust-intrinsic"]
-extern "rust-intrinsic" mod rusti {
+extern "rust-intrinsic" {
     fn move_val_init<T>(dst: &mut T, src: T);
     fn init<T>() -> T;
 }
@@ -139,15 +139,15 @@ pub impl <T:Ord> PriorityQueue<T> {
             while pos > start {
                 let parent = (pos - 1) >> 1;
                 if new > self.data[parent] {
-                    let mut x = rusti::init();
+                    let mut x = init();
                     x <-> self.data[parent];
-                    rusti::move_val_init(&mut self.data[pos], x);
+                    move_val_init(&mut self.data[pos], x);
                     pos = parent;
                     loop
                 }
                 break
             }
-            rusti::move_val_init(&mut self.data[pos], new);
+            move_val_init(&mut self.data[pos], new);
         }
     }
 
@@ -162,14 +162,14 @@ pub impl <T:Ord> PriorityQueue<T> {
                 if right < end && !(self.data[child] > self.data[right]) {
                     child = right;
                 }
-                let mut x = rusti::init();
+                let mut x = init();
                 x <-> self.data[child];
-                rusti::move_val_init(&mut self.data[pos], x);
+                move_val_init(&mut self.data[pos], x);
                 pos = child;
                 child = 2 * pos + 1;
             }
 
-            rusti::move_val_init(&mut self.data[pos], new);
+            move_val_init(&mut self.data[pos], new);
             self.siftup(start, pos);
         }
     }

--- a/src/libstd/rc.rs
+++ b/src/libstd/rc.rs
@@ -95,7 +95,7 @@ mod test_rc {
 }
 
 #[abi = "rust-intrinsic"]
-extern "rust-intrinsic" mod rusti {
+extern "rust-intrinsic" {
     fn init<T>() -> T;
 }
 
@@ -159,7 +159,7 @@ impl<T: Owned> Drop for RcMut<T> {
         unsafe {
             (*self.ptr).count -= 1;
             if (*self.ptr).count == 0 {
-                let mut x = rusti::init();
+                let mut x = init();
                 x <-> *self.ptr;
                 free(self.ptr as *c_void)
             }

--- a/src/libstd/uv_ll.rs
+++ b/src/libstd/uv_ll.rs
@@ -730,8 +730,7 @@ pub mod uv_ll_struct_stubgen {
 }
 
 #[nolink]
-extern mod rustrt {
-
+extern {
     // libuv public API
     unsafe fn rust_uv_loop_new() -> *libc::c_void;
     unsafe fn rust_uv_loop_delete(lp: *libc::c_void);
@@ -884,49 +883,49 @@ extern mod rustrt {
 }
 
 pub unsafe fn loop_new() -> *libc::c_void {
-    return rustrt::rust_uv_loop_new();
+    return rust_uv_loop_new();
 }
 
 pub unsafe fn loop_delete(loop_handle: *libc::c_void) {
-    rustrt::rust_uv_loop_delete(loop_handle);
+    rust_uv_loop_delete(loop_handle);
 }
 
 pub unsafe fn run(loop_handle: *libc::c_void) {
-    rustrt::rust_uv_run(loop_handle);
+    rust_uv_run(loop_handle);
 }
 
 pub unsafe fn close<T>(handle: *T, cb: *u8) {
-    rustrt::rust_uv_close(handle as *libc::c_void, cb);
+    rust_uv_close(handle as *libc::c_void, cb);
 }
 
 pub unsafe fn walk(loop_handle: *libc::c_void, cb: *u8, arg: *libc::c_void) {
-    rustrt::rust_uv_walk(loop_handle, cb, arg);
+    rust_uv_walk(loop_handle, cb, arg);
 }
 
 pub unsafe fn idle_new() -> *uv_idle_t {
-    rustrt::rust_uv_idle_new()
+    rust_uv_idle_new()
 }
 
 pub unsafe fn idle_delete(handle: *uv_idle_t) {
-    rustrt::rust_uv_idle_delete(handle)
+    rust_uv_idle_delete(handle)
 }
 
 pub unsafe fn idle_init(loop_handle: *uv_loop_t,
                         handle: *uv_idle_t) -> libc::c_int {
-    rustrt::rust_uv_idle_init(loop_handle, handle)
+    rust_uv_idle_init(loop_handle, handle)
 }
 
 pub unsafe fn idle_start(handle: *uv_idle_t, cb: uv_idle_cb) -> libc::c_int {
-    rustrt::rust_uv_idle_start(handle, cb)
+    rust_uv_idle_start(handle, cb)
 }
 
 pub unsafe fn idle_stop(handle: *uv_idle_t) -> libc::c_int {
-    rustrt::rust_uv_idle_stop(handle)
+    rust_uv_idle_stop(handle)
 }
 
 pub unsafe fn tcp_init(loop_handle: *libc::c_void, handle: *uv_tcp_t)
     -> libc::c_int {
-    return rustrt::rust_uv_tcp_init(loop_handle, handle);
+    return rust_uv_tcp_init(loop_handle, handle);
 }
 // FIXME ref #2064
 pub unsafe fn tcp_connect(connect_ptr: *uv_connect_t,
@@ -934,7 +933,7 @@ pub unsafe fn tcp_connect(connect_ptr: *uv_connect_t,
                       addr_ptr: *sockaddr_in,
                       after_connect_cb: *u8)
 -> libc::c_int {
-    return rustrt::rust_uv_tcp_connect(connect_ptr, tcp_handle_ptr,
+    return rust_uv_tcp_connect(connect_ptr, tcp_handle_ptr,
                                     after_connect_cb, addr_ptr);
 }
 // FIXME ref #2064
@@ -943,40 +942,40 @@ pub unsafe fn tcp_connect6(connect_ptr: *uv_connect_t,
                       addr_ptr: *sockaddr_in6,
                       after_connect_cb: *u8)
 -> libc::c_int {
-    return rustrt::rust_uv_tcp_connect6(connect_ptr, tcp_handle_ptr,
+    return rust_uv_tcp_connect6(connect_ptr, tcp_handle_ptr,
                                     after_connect_cb, addr_ptr);
 }
 // FIXME ref #2064
 pub unsafe fn tcp_bind(tcp_server_ptr: *uv_tcp_t,
                    addr_ptr: *sockaddr_in) -> libc::c_int {
-    return rustrt::rust_uv_tcp_bind(tcp_server_ptr,
+    return rust_uv_tcp_bind(tcp_server_ptr,
                                  addr_ptr);
 }
 // FIXME ref #2064
 pub unsafe fn tcp_bind6(tcp_server_ptr: *uv_tcp_t,
                    addr_ptr: *sockaddr_in6) -> libc::c_int {
-    return rustrt::rust_uv_tcp_bind6(tcp_server_ptr,
+    return rust_uv_tcp_bind6(tcp_server_ptr,
                                  addr_ptr);
 }
 
 pub unsafe fn tcp_getpeername(tcp_handle_ptr: *uv_tcp_t,
                               name: *sockaddr_in) -> libc::c_int {
-    return rustrt::rust_uv_tcp_getpeername(tcp_handle_ptr, name);
+    return rust_uv_tcp_getpeername(tcp_handle_ptr, name);
 }
 
 pub unsafe fn tcp_getpeername6(tcp_handle_ptr: *uv_tcp_t,
                                name: *sockaddr_in6) ->libc::c_int {
-    return rustrt::rust_uv_tcp_getpeername6(tcp_handle_ptr, name);
+    return rust_uv_tcp_getpeername6(tcp_handle_ptr, name);
 }
 
 pub unsafe fn listen<T>(stream: *T, backlog: libc::c_int,
                  cb: *u8) -> libc::c_int {
-    return rustrt::rust_uv_listen(stream as *libc::c_void, backlog, cb);
+    return rust_uv_listen(stream as *libc::c_void, backlog, cb);
 }
 
 pub unsafe fn accept(server: *libc::c_void, client: *libc::c_void)
     -> libc::c_int {
-    return rustrt::rust_uv_accept(server as *libc::c_void,
+    return rust_uv_accept(server as *libc::c_void,
                                client as *libc::c_void);
 }
 
@@ -984,57 +983,57 @@ pub unsafe fn write<T>(req: *uv_write_t, stream: *T,
          buf_in: *~[uv_buf_t], cb: *u8) -> libc::c_int {
     let buf_ptr = vec::raw::to_ptr(*buf_in);
     let buf_cnt = vec::len(*buf_in) as i32;
-    return rustrt::rust_uv_write(req as *libc::c_void,
+    return rust_uv_write(req as *libc::c_void,
                               stream as *libc::c_void,
                               buf_ptr, buf_cnt, cb);
 }
 pub unsafe fn read_start(stream: *uv_stream_t, on_alloc: *u8,
                      on_read: *u8) -> libc::c_int {
-    return rustrt::rust_uv_read_start(stream as *libc::c_void,
+    return rust_uv_read_start(stream as *libc::c_void,
                                    on_alloc, on_read);
 }
 
 pub unsafe fn read_stop(stream: *uv_stream_t) -> libc::c_int {
-    return rustrt::rust_uv_read_stop(stream as *libc::c_void);
+    return rust_uv_read_stop(stream as *libc::c_void);
 }
 
 pub unsafe fn last_error(loop_handle: *libc::c_void) -> uv_err_t {
-    return rustrt::rust_uv_last_error(loop_handle);
+    return rust_uv_last_error(loop_handle);
 }
 
 pub unsafe fn strerror(err: *uv_err_t) -> *libc::c_char {
-    return rustrt::rust_uv_strerror(err);
+    return rust_uv_strerror(err);
 }
 pub unsafe fn err_name(err: *uv_err_t) -> *libc::c_char {
-    return rustrt::rust_uv_err_name(err);
+    return rust_uv_err_name(err);
 }
 
 pub unsafe fn async_init(loop_handle: *libc::c_void,
                      async_handle: *uv_async_t,
                      cb: *u8) -> libc::c_int {
-    return rustrt::rust_uv_async_init(loop_handle,
+    return rust_uv_async_init(loop_handle,
                                    async_handle,
                                    cb);
 }
 
 pub unsafe fn async_send(async_handle: *uv_async_t) {
-    return rustrt::rust_uv_async_send(async_handle);
+    return rust_uv_async_send(async_handle);
 }
 pub unsafe fn buf_init(input: *u8, len: uint) -> uv_buf_t {
     let out_buf = uv_buf_t { base: ptr::null(), len: 0 as libc::size_t };
     let out_buf_ptr: *uv_buf_t = &out_buf;
-    rustrt::rust_uv_buf_init(out_buf_ptr, input, len as size_t);
+    rust_uv_buf_init(out_buf_ptr, input, len as size_t);
     return out_buf;
 }
 pub unsafe fn ip4_addr(ip: &str, port: int) -> sockaddr_in {
     do str::as_c_str(ip) |ip_buf| {
-        rustrt::rust_uv_ip4_addr(ip_buf as *u8,
+        rust_uv_ip4_addr(ip_buf as *u8,
                                  port as libc::c_int)
     }
 }
 pub unsafe fn ip6_addr(ip: &str, port: int) -> sockaddr_in6 {
     do str::as_c_str(ip) |ip_buf| {
-        rustrt::rust_uv_ip6_addr(ip_buf as *u8,
+        rust_uv_ip6_addr(ip_buf as *u8,
                                  port as libc::c_int)
     }
 }
@@ -1043,7 +1042,7 @@ pub unsafe fn ip4_name(src: &sockaddr_in) -> ~str {
     let dst: ~[u8] = ~[0u8,0u8,0u8,0u8,0u8,0u8,0u8,0u8,
                      0u8,0u8,0u8,0u8,0u8,0u8,0u8,0u8];
     do vec::as_imm_buf(dst) |dst_buf, size| {
-        rustrt::rust_uv_ip4_name(to_unsafe_ptr(src),
+        rust_uv_ip4_name(to_unsafe_ptr(src),
                                  dst_buf, size as libc::size_t);
         // seems that checking the result of uv_ip4_name
         // doesn't work too well..
@@ -1064,7 +1063,7 @@ pub unsafe fn ip6_name(src: &sockaddr_in6) -> ~str {
                        0u8,0u8,0u8,0u8,0u8,0u8];
     do vec::as_imm_buf(dst) |dst_buf, size| {
         let src_unsafe_ptr = to_unsafe_ptr(src);
-        let result = rustrt::rust_uv_ip6_name(src_unsafe_ptr,
+        let result = rust_uv_ip6_name(src_unsafe_ptr,
                                               dst_buf, size as libc::size_t);
         match result {
           0i32 => str::raw::from_buf(dst_buf),
@@ -1073,23 +1072,23 @@ pub unsafe fn ip6_name(src: &sockaddr_in6) -> ~str {
     }
 }
 pub unsafe fn ip4_port(src: &sockaddr_in) -> uint {
-    rustrt::rust_uv_ip4_port(to_unsafe_ptr(src)) as uint
+    rust_uv_ip4_port(to_unsafe_ptr(src)) as uint
 }
 pub unsafe fn ip6_port(src: &sockaddr_in6) -> uint {
-    rustrt::rust_uv_ip6_port(to_unsafe_ptr(src)) as uint
+    rust_uv_ip6_port(to_unsafe_ptr(src)) as uint
 }
 
 pub unsafe fn timer_init(loop_ptr: *libc::c_void,
                      timer_ptr: *uv_timer_t) -> libc::c_int {
-    return rustrt::rust_uv_timer_init(loop_ptr, timer_ptr);
+    return rust_uv_timer_init(loop_ptr, timer_ptr);
 }
 pub unsafe fn timer_start(timer_ptr: *uv_timer_t, cb: *u8, timeout: uint,
                       repeat: uint) -> libc::c_int {
-    return rustrt::rust_uv_timer_start(timer_ptr, cb, timeout as libc::c_uint,
+    return rust_uv_timer_start(timer_ptr, cb, timeout as libc::c_uint,
                                     repeat as libc::c_uint);
 }
 pub unsafe fn timer_stop(timer_ptr: *uv_timer_t) -> libc::c_int {
-    return rustrt::rust_uv_timer_stop(timer_ptr);
+    return rust_uv_timer_stop(timer_ptr);
 }
 pub unsafe fn getaddrinfo(loop_ptr: *libc::c_void,
                            handle: *uv_getaddrinfo_t,
@@ -1097,7 +1096,7 @@ pub unsafe fn getaddrinfo(loop_ptr: *libc::c_void,
                            node_name_ptr: *u8,
                            service_name_ptr: *u8,
                            hints: *addrinfo) -> libc::c_int {
-    rustrt::rust_uv_getaddrinfo(loop_ptr,
+    rust_uv_getaddrinfo(loop_ptr,
                            handle,
                            cb,
                            node_name_ptr,
@@ -1105,7 +1104,7 @@ pub unsafe fn getaddrinfo(loop_ptr: *libc::c_void,
                            hints)
 }
 pub unsafe fn freeaddrinfo(res: *addrinfo) {
-    rustrt::rust_uv_freeaddrinfo(res);
+    rust_uv_freeaddrinfo(res);
 }
 
 // libuv struct initializers
@@ -1131,53 +1130,53 @@ pub fn getaddrinfo_t() -> uv_getaddrinfo_t {
 // data access helpers
 pub unsafe fn get_loop_for_uv_handle<T>(handle: *T)
     -> *libc::c_void {
-    return rustrt::rust_uv_get_loop_for_uv_handle(handle as *libc::c_void);
+    return rust_uv_get_loop_for_uv_handle(handle as *libc::c_void);
 }
 pub unsafe fn get_stream_handle_from_connect_req(connect: *uv_connect_t)
     -> *uv_stream_t {
-    return rustrt::rust_uv_get_stream_handle_from_connect_req(
+    return rust_uv_get_stream_handle_from_connect_req(
         connect);
 }
 pub unsafe fn get_stream_handle_from_write_req(
     write_req: *uv_write_t)
     -> *uv_stream_t {
-    return rustrt::rust_uv_get_stream_handle_from_write_req(
+    return rust_uv_get_stream_handle_from_write_req(
         write_req);
 }
 pub unsafe fn get_data_for_uv_loop(loop_ptr: *libc::c_void) -> *libc::c_void {
-    rustrt::rust_uv_get_data_for_uv_loop(loop_ptr)
+    rust_uv_get_data_for_uv_loop(loop_ptr)
 }
 pub unsafe fn set_data_for_uv_loop(loop_ptr: *libc::c_void,
                                    data: *libc::c_void) {
-    rustrt::rust_uv_set_data_for_uv_loop(loop_ptr, data);
+    rust_uv_set_data_for_uv_loop(loop_ptr, data);
 }
 pub unsafe fn get_data_for_uv_handle<T>(handle: *T) -> *libc::c_void {
-    return rustrt::rust_uv_get_data_for_uv_handle(handle as *libc::c_void);
+    return rust_uv_get_data_for_uv_handle(handle as *libc::c_void);
 }
 pub unsafe fn set_data_for_uv_handle<T, U>(handle: *T, data: *U) {
-    rustrt::rust_uv_set_data_for_uv_handle(handle as *libc::c_void,
+    rust_uv_set_data_for_uv_handle(handle as *libc::c_void,
                                            data as *libc::c_void);
 }
 pub unsafe fn get_data_for_req<T>(req: *T) -> *libc::c_void {
-    return rustrt::rust_uv_get_data_for_req(req as *libc::c_void);
+    return rust_uv_get_data_for_req(req as *libc::c_void);
 }
 pub unsafe fn set_data_for_req<T, U>(req: *T,
                     data: *U) {
-    rustrt::rust_uv_set_data_for_req(req as *libc::c_void,
+    rust_uv_set_data_for_req(req as *libc::c_void,
                                      data as *libc::c_void);
 }
 pub unsafe fn get_base_from_buf(buf: uv_buf_t) -> *u8 {
-    return rustrt::rust_uv_get_base_from_buf(buf);
+    return rust_uv_get_base_from_buf(buf);
 }
 pub unsafe fn get_len_from_buf(buf: uv_buf_t) -> libc::size_t {
-    return rustrt::rust_uv_get_len_from_buf(buf);
+    return rust_uv_get_len_from_buf(buf);
 }
 pub unsafe fn malloc_buf_base_of(suggested_size: libc::size_t)
     -> *u8 {
-    return rustrt::rust_uv_malloc_buf_base_of(suggested_size);
+    return rust_uv_malloc_buf_base_of(suggested_size);
 }
 pub unsafe fn free_base_of_buf(buf: uv_buf_t) {
-    rustrt::rust_uv_free_base_of_buf(buf);
+    rust_uv_free_base_of_buf(buf);
 }
 
 pub unsafe fn get_last_err_info(uv_loop: *libc::c_void) -> ~str {
@@ -1203,22 +1202,22 @@ pub struct uv_err_data {
 }
 
 pub unsafe fn is_ipv4_addrinfo(input: *addrinfo) -> bool {
-    rustrt::rust_uv_is_ipv4_addrinfo(input)
+    rust_uv_is_ipv4_addrinfo(input)
 }
 pub unsafe fn is_ipv6_addrinfo(input: *addrinfo) -> bool {
-    rustrt::rust_uv_is_ipv6_addrinfo(input)
+    rust_uv_is_ipv6_addrinfo(input)
 }
 pub unsafe fn get_INADDR_NONE() -> u32 {
-    rustrt::rust_uv_helper_get_INADDR_NONE()
+    rust_uv_helper_get_INADDR_NONE()
 }
 pub unsafe fn get_next_addrinfo(input: *addrinfo) -> *addrinfo {
-    rustrt::rust_uv_get_next_addrinfo(input)
+    rust_uv_get_next_addrinfo(input)
 }
 pub unsafe fn addrinfo_as_sockaddr_in(input: *addrinfo) -> *sockaddr_in {
-    rustrt::rust_uv_addrinfo_as_sockaddr_in(input)
+    rust_uv_addrinfo_as_sockaddr_in(input)
 }
 pub unsafe fn addrinfo_as_sockaddr_in6(input: *addrinfo) -> *sockaddr_in6 {
-    rustrt::rust_uv_addrinfo_as_sockaddr_in6(input)
+    rust_uv_addrinfo_as_sockaddr_in6(input)
 }
 
 #[cfg(test)]
@@ -1792,7 +1791,7 @@ mod test {
         unsafe {
             struct_size_check_common::<uv_tcp_t>(
                 ~"uv_tcp_t",
-                super::rustrt::rust_uv_helper_uv_tcp_t_size()
+                super::rust_uv_helper_uv_tcp_t_size()
             );
         }
     }
@@ -1801,7 +1800,7 @@ mod test {
         unsafe {
             struct_size_check_common::<uv_connect_t>(
                 ~"uv_connect_t",
-                super::rustrt::rust_uv_helper_uv_connect_t_size()
+                super::rust_uv_helper_uv_connect_t_size()
             );
         }
     }
@@ -1810,7 +1809,7 @@ mod test {
         unsafe {
             struct_size_check_common::<uv_buf_t>(
                 ~"uv_buf_t",
-                super::rustrt::rust_uv_helper_uv_buf_t_size()
+                super::rust_uv_helper_uv_buf_t_size()
             );
         }
     }
@@ -1819,7 +1818,7 @@ mod test {
         unsafe {
             struct_size_check_common::<uv_write_t>(
                 ~"uv_write_t",
-                super::rustrt::rust_uv_helper_uv_write_t_size()
+                super::rust_uv_helper_uv_write_t_size()
             );
         }
     }
@@ -1829,7 +1828,7 @@ mod test {
         unsafe {
             struct_size_check_common::<sockaddr_in>(
                 ~"sockaddr_in",
-                super::rustrt::rust_uv_helper_sockaddr_in_size()
+                super::rust_uv_helper_sockaddr_in_size()
             );
         }
     }
@@ -1837,7 +1836,7 @@ mod test {
     fn test_uv_ll_struct_size_sockaddr_in6() {
         unsafe {
             let foreign_handle_size =
-                super::rustrt::rust_uv_helper_sockaddr_in6_size();
+                super::rust_uv_helper_sockaddr_in6_size();
             let rust_handle_size = sys::size_of::<sockaddr_in6>();
             let output = fmt!("sockaddr_in6 -- foreign: %u rust: %u",
                               foreign_handle_size as uint, rust_handle_size);
@@ -1856,7 +1855,7 @@ mod test {
     fn test_uv_ll_struct_size_addr_in() {
         unsafe {
             let foreign_handle_size =
-                super::rustrt::rust_uv_helper_addr_in_size();
+                super::rust_uv_helper_addr_in_size();
             let rust_handle_size = sys::size_of::<addr_in>();
             let output = fmt!("addr_in -- foreign: %u rust: %u",
                               foreign_handle_size as uint, rust_handle_size);
@@ -1872,7 +1871,7 @@ mod test {
         unsafe {
             struct_size_check_common::<uv_async_t>(
                 ~"uv_async_t",
-                super::rustrt::rust_uv_helper_uv_async_t_size()
+                super::rust_uv_helper_uv_async_t_size()
             );
         }
     }
@@ -1882,7 +1881,7 @@ mod test {
         unsafe {
             struct_size_check_common::<uv_timer_t>(
                 ~"uv_timer_t",
-                super::rustrt::rust_uv_helper_uv_timer_t_size()
+                super::rust_uv_helper_uv_timer_t_size()
             );
         }
     }
@@ -1893,7 +1892,7 @@ mod test {
         unsafe {
             struct_size_check_common::<uv_getaddrinfo_t>(
                 ~"uv_getaddrinfo_t",
-                super::rustrt::rust_uv_helper_uv_getaddrinfo_t_size()
+                super::rust_uv_helper_uv_getaddrinfo_t_size()
             );
         }
     }
@@ -1904,7 +1903,7 @@ mod test {
         unsafe {
             struct_size_check_common::<uv_timer_t>(
                 ~"addrinfo",
-                super::rustrt::rust_uv_helper_uv_timer_t_size()
+                super::rust_uv_helper_uv_timer_t_size()
             );
         }
     }

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -60,6 +60,7 @@ pub enum ObsoleteSyntax {
     ObsoleteStaticMethod,
     ObsoleteConstItem,
     ObsoleteFixedLengthVectorType,
+    ObsoleteNamedExternModule,
 }
 
 impl to_bytes::IterBytes for ObsoleteSyntax {
@@ -211,6 +212,11 @@ pub impl Parser {
             ObsoleteFixedLengthVectorType => (
                 "fixed-length vector notation",
                 "instead of `[T * N]`, write `[T, ..N]`"
+            ),
+            ObsoleteNamedExternModule => (
+                "named external module",
+                "instead of `extern mod foo { ... }`, write `mod foo { \
+                 extern { ... } }`"
             ),
         };
 

--- a/src/test/compile-fail/unused-unsafe.rs
+++ b/src/test/compile-fail/unused-unsafe.rs
@@ -12,8 +12,10 @@
 
 #[deny(unused_unsafe)];
 
-extern mod foo {
-    fn bar();
+mod foo {
+    pub extern {
+        pub fn bar();
+    }
 }
 
 fn callback<T>(_f: &fn() -> T) -> T { fail!() }


### PR DESCRIPTION
r? @catamorphism
