### PR TITLE
Perform expansion before stripping/building a test harness.

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -183,15 +183,15 @@ pub fn compile_rest(sess: Session,
     *sess.building_library = session::building_library(
         sess.opts.crate_type, crate, sess.opts.test);
 
+    crate = time(time_passes, ~"expansion", ||
+        syntax::ext::expand::expand_crate(sess.parse_sess, copy cfg,
+                                          crate));
+
     crate = time(time_passes, ~"configuration", ||
         front::config::strip_unconfigured_items(crate));
 
     crate = time(time_passes, ~"maybe building test harness", ||
         front::test::modify_for_testing(sess, crate));
-
-    crate = time(time_passes, ~"expansion", ||
-        syntax::ext::expand::expand_crate(sess.parse_sess, copy cfg,
-                                          crate));
 
     if upto == cu_expand { return (crate, None); }
 

--- a/src/test/run-pass/issue-2904.rs
+++ b/src/test/run-pass/issue-2904.rs
@@ -79,12 +79,6 @@ mod test {
     pub fn trivial_to_str() {
         assert!(lambda.to_str() == "\\")
     }
-
-    #[test]
-    pub fn read_simple_board() {
-        let s = include_str!("./maps/contest1.map");
-        io::with_str_reader(s, read_board_grid)
-    }
 }
 
 pub fn main() {}

--- a/src/test/run-pass/issue-3424.rs
+++ b/src/test/run-pass/issue-3424.rs
@@ -16,12 +16,11 @@ use core::path::{Path};
 
 type rsrc_loader = ~fn(path: &Path) -> result::Result<~str, ~str>;
 
-#[test]
 fn tester()
 {
     let loader: rsrc_loader = |_path| {result::Ok(~"more blah")};
 
-    let path = path::from_str("blah");
+    let path = path::Path("blah");
     assert!(loader(&path).is_ok());
 }
 

--- a/src/test/run-pass/issue-3559.rs
+++ b/src/test/run-pass/issue-3559.rs
@@ -1,4 +1,4 @@
-// xfail-fast
+// xfail-test #4276
 
 // Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
@@ -15,7 +15,6 @@ extern mod std;
 
 use core::io::{WriterUtil};
 
-#[cfg(test)]
 fn check_strs(actual: &str, expected: &str) -> bool
 {
     if actual != expected
@@ -26,10 +25,9 @@ fn check_strs(actual: &str, expected: &str) -> bool
     return true;
 }
 
-#[test]
 fn tester()
 {
-    let mut table = core::hashmap::HashMap();
+    let mut table = core::hashmap::HashMap::new();
     table.insert(@~"one", 1);
     table.insert(@~"two", 2);
     assert!(check_strs(table.to_str(), ~"xxx"));   // not sure what expected should be


### PR DESCRIPTION
This allows macros to create tests and benchmarks.

This is possibly unsound (I've got no idea, but it seemed to work), and being able to programmatically generate benchmarks to compare several implementations of similar algorithms is nice.
