### PR TITLE
Include static methods on traits in reexports.

### DIFF
--- a/src/test/auxiliary/mod_trait_with_static_methods_lib.rs
+++ b/src/test/auxiliary/mod_trait_with_static_methods_lib.rs
@@ -1,0 +1,22 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub use sub_foo::Foo;
+
+pub mod sub_foo {
+    pub trait Foo {
+        pub fn foo() -> Self;
+    }
+
+    impl Foo for int {
+        pub fn foo() -> int { 42 }
+    }
+}
+

--- a/src/test/run-pass/trait_with_static_methods_cross_crate.rs
+++ b/src/test/run-pass/trait_with_static_methods_cross_crate.rs
@@ -1,0 +1,19 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:mod_trait_with_static_methods_lib.rs
+extern mod mod_trait_with_static_methods_lib;
+
+use mod_trait_with_static_methods_lib::Foo;
+
+pub fn main() {
+    assert!(42 == Foo::foo());
+}


### PR DESCRIPTION
This fixes the issue described in #4202.

From what I understood of the code, when we reexport a trait in a submodule using e.g. "pub use foo::SomeTrait", we were not previously making an effort to reexport the static methods on that trait.

I'm new to the Rust code base (and the Rust language itself) so my approach may not be kosher, but this patch works by changing the encoder to include the static methods associated with traits.

I couldn't see any tests for this area of the code, so I didn't really have any examples to go by. If tests are needed, I'm happy to work through that if I can get some assistance to do so.
