### PR TITLE
Fixes rusti crashes.

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -157,9 +157,9 @@ pub mod jit {
                     code: entry,
                     env: ptr::null()
                 };
-                let func: &fn(argv: ~[@~str]) = cast::transmute(closure);
+                let func: &fn() = cast::transmute(closure);
 
-                func(~[sess.opts.binary]);
+                func();
             }
         }
     }


### PR DESCRIPTION
Fixes #6378

Don't pass the binary name to the LLVMRustExecuteJIT closure, otherwise it will leak memory; the binary name doesn't seem to be needed, anyhow.
