### PR TITLE
Remove redundant import error

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1909,7 +1909,6 @@ pub impl Resolver {
             }
 
             if self.unresolved_imports == prev_unresolved_imports {
-                self.session.err(~"failed to resolve imports");
                 self.report_unresolved_imports(module_root);
                 break;
             }

--- a/src/test/compile-fail/issue-2937.rs
+++ b/src/test/compile-fail/issue-2937.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:failed to resolve imports
-use x = m::f;
+use x = m::f; //~ ERROR failed to resolve imports
 
 mod m {
 }

--- a/src/test/compile-fail/issue-2937.rs
+++ b/src/test/compile-fail/issue-2937.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use x = m::f; //~ ERROR failed to resolve imports
+use x = m::f; //~ ERROR failed to resolve import
 
 mod m {
 }


### PR DESCRIPTION
Every unresolved import is reported. An additional error message isn't useful
and obscures (imo) the real errors: I need to take it into account when
looking at the error count.
