### PR TITLE
Added to_str() method for HashMap and HashSet

### DIFF
--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -15,7 +15,9 @@ The `ToStr` trait for converting to strings
 */
 
 use str;
+use str::OwnedStr;
 use hashmap::HashMap;
+use hashmap::HashSet;
 use container::Map;
 use hash::Hash;
 use cmp::Eq;
@@ -59,13 +61,13 @@ impl<A:ToStr+Hash+Eq, B:ToStr+Hash+Eq> ToStr for HashMap<A, B> {
                 first = false;
             }
             else {
-                str::push_str(&mut acc, ~", ");
+                acc.push_str(", ");
             }
-            str::push_str(&mut acc, key.to_str());
-            str::push_str(&mut acc, ~" : ");
-            str::push_str(&mut acc, value.to_str());
+            acc.push_str(key.to_str());
+            acc.push_str(": ");
+            acc.push_str(value.to_str());
         }
-        str::push_char(&mut acc, '}');
+        acc.push_char('}');
         acc
     }
 }
@@ -82,6 +84,7 @@ impl<A:ToStr,B:ToStr> ToStr for (A, B) {
         }
     }
 }
+
 impl<A:ToStr,B:ToStr,C:ToStr> ToStr for (A, B, C) {
     #[inline(always)]
     fn to_str(&self) -> ~str {
@@ -185,7 +188,7 @@ mod tests {
 
         let table_str = table.to_str();
 
-        assert!(table_str == ~"{1 : 2, 3 : 4}" || table_str == ~"{3 : 4, 1 : 2}");
+        assert!(table_str == ~"{1: 2, 3: 4}" || table_str == ~"{3: 4, 1: 2}");
         assert!(empty.to_str() == ~"{}");
     }
 }

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -178,6 +178,7 @@ impl<A:ToStr> ToStr for @[A] {
 #[allow(non_implicitly_copyable_typarams)]
 mod tests {
     use hashmap::HashMap;
+    use hashmap::HashSet;
     #[test]
     fn test_simple_types() {
         assert!(1i.to_str() == ~"1");
@@ -224,8 +225,8 @@ mod tests {
 
     #[test]
     fn test_hashset() {
-        let mut set: HashSet<int, int> = HashSet::new();
-        let empty_set: HashSet<int, int> = HashSet::new();
+        let mut set: HashSet<int> = HashSet::new();
+        let empty_set: HashSet<int> = HashSet::new();
 
         set.insert(1);
         set.insert(2);
@@ -233,6 +234,6 @@ mod tests {
         let set_str = set.to_str();
 
         assert!(set_str == ~"{1, 2}" || set_str == ~"{2, 1}");
-        assert!(empty.to_str() == ~"{}");
+        assert!(empty_set.to_str() == ~"{}");
     }
 }

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -175,15 +175,17 @@ mod tests {
                ~"[[], [1], [1, 1]]");
     }
 
-    // #[test]
-    // fn test_hashmap() {
-    //     let mut table: HashMap<int, int> = HashMap::new();
-    //     let mut empty: HashMap<int, int> = HashMap::new();
+    #[test]
+    fn test_hashmap() {
+        let mut table: HashMap<int, int> = HashMap::new();
+        let empty: HashMap<int, int> = HashMap::new();
 
-    //     table.insert(3, 4);
-    //     table.insert(1, 2);
+        table.insert(3, 4);
+        table.insert(1, 2);
 
-    //     assert!(table.to_str() == ~"{1 : 2, 3 : 4}");
-    //     assert!(empty.to_str() == ~"{}");
-    //}
+        let table_str = table.to_str();
+
+        assert!(table_str == ~"{1 : 2, 3 : 4}" || table_str == ~"{3 : 4, 1 : 2}");
+        assert!(empty.to_str() == ~"{}");
+    }
 }

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -144,6 +144,7 @@ impl<A:ToStr> ToStr for @[A] {
 #[cfg(test)]
 #[allow(non_implicitly_copyable_typarams)]
 mod tests {
+    use hashmap::HashMap;
     #[test]
     fn test_simple_types() {
         assert!(1i.to_str() == ~"1");
@@ -174,15 +175,15 @@ mod tests {
                ~"[[], [1], [1, 1]]");
     }
 
-    #[test]
-    fn test_hashmap() {
-        let mut table: HashMap<int, int> = HashMap::new();
-        let mut empty: HashMap<int, int> = HashMap::new();
+    // #[test]
+    // fn test_hashmap() {
+    //     let mut table: HashMap<int, int> = HashMap::new();
+    //     let mut empty: HashMap<int, int> = HashMap::new();
 
-        table.insert(3, 4);
-        table.insert(1, 2);
+    //     table.insert(3, 4);
+    //     table.insert(1, 2);
 
-        assert!(table.to_str() == ~"{1 : 2, 3 : 4}");
-        assert!(empty.to_str() == ~"{}");
-    }
+    //     assert!(table.to_str() == ~"{1 : 2, 3 : 4}");
+    //     assert!(empty.to_str() == ~"{}");
+    //}
 }

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -15,6 +15,10 @@ The `ToStr` trait for converting to strings
 */
 
 use str;
+use hashmap::HashMap;
+use container::Map;
+use hash::Hash;
+use cmp::Eq;
 
 pub trait ToStr {
     fn to_str(&self) -> ~str;
@@ -43,6 +47,26 @@ impl<A:ToStr> ToStr for (A,) {
                 ~"(" + a.to_str() + ~", " + ~")"
             }
         }
+    }
+}
+
+impl<A:ToStr+Hash+Eq, B:ToStr+Hash+Eq> ToStr for HashMap<A, B> {
+    #[inline(always)]
+    fn to_str(&self) -> ~str {
+        let mut acc = ~"{", first = true;
+        for self.each |key, value| {
+            if first {
+                first = false;
+            }
+            else {
+                str::push_str(&mut acc, ~", ");
+            }
+            str::push_str(&mut acc, key.to_str());
+            str::push_str(&mut acc, ~" : ");
+            str::push_str(&mut acc, value.to_str());
+        }
+        str::push_char(&mut acc, '}');
+        acc
     }
 }
 
@@ -148,5 +172,17 @@ mod tests {
         assert!((~[1, 2, 3]).to_str() == ~"[1, 2, 3]");
         assert!((~[~[], ~[1], ~[1, 1]]).to_str() ==
                ~"[[], [1], [1, 1]]");
+    }
+
+    #[test]
+    fn test_hashmap() {
+        let mut table: HashMap<int, int> = HashMap::new();
+        let mut empty: HashMap<int, int> = HashMap::new();
+
+        table.insert(3, 4);
+        table.insert(1, 2);
+
+        assert!(table.to_str() == ~"{1 : 2, 3 : 4}");
+        assert!(empty.to_str() == ~"{}");
     }
 }

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -14,7 +14,6 @@ The `ToStr` trait for converting to strings
 
 */
 
-use str;
 use str::OwnedStr;
 use hashmap::HashMap;
 use hashmap::HashSet;
@@ -179,6 +178,7 @@ impl<A:ToStr> ToStr for @[A] {
 mod tests {
     use hashmap::HashMap;
     use hashmap::HashSet;
+    use container::Set;
     #[test]
     fn test_simple_types() {
         assert!(1i.to_str() == ~"1");

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -72,6 +72,24 @@ impl<A:ToStr+Hash+Eq, B:ToStr+Hash+Eq> ToStr for HashMap<A, B> {
     }
 }
 
+impl<A:ToStr+Hash+Eq> ToStr for HashSet<A> {
+    #[inline(always)]
+    fn to_str(&self) -> ~str {
+    let mut acc = ~"{", first = true;
+    for self.each |element| {
+        if first {
+            first = false;
+        }
+        else {
+            acc.push_str(", ");
+        }
+        acc.push_str(element.to_str());
+    }
+    acc.push_char('}');
+    acc
+    }
+}
+
 impl<A:ToStr,B:ToStr> ToStr for (A, B) {
     #[inline(always)]
     fn to_str(&self) -> ~str {

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -209,4 +209,18 @@ mod tests {
         assert!(table_str == ~"{1: 2, 3: 4}" || table_str == ~"{3: 4, 1: 2}");
         assert!(empty.to_str() == ~"{}");
     }
+
+    #[test]
+    fn test_hashset() {
+        let mut set: HashSet<int, int> = HashSet::new();
+        let empty_set: HashSet<int, int> = HashSet::new();
+
+        set.insert(1);
+        set.insert(2);
+
+        let set_str = set.to_str();
+
+        assert!(set_str == ~"{1, 2}" || set_str == ~"{2, 1}");
+        assert!(empty.to_str() == ~"{}");
+    }
 }

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -125,11 +125,15 @@ impl<'self,A:ToStr> ToStr for &'self [A] {
     fn to_str(&self) -> ~str {
         let mut acc = ~"[", first = true;
         for self.each |elt| {
-            if first { first = false; }
-            else { str::push_str(&mut acc, ~", "); }
-            str::push_str(&mut acc, elt.to_str());
+            if first {
+                first = false;
+            }
+            else {
+                acc.push_str(", ");
+            }
+            acc.push_str(elt.to_str());
         }
-        str::push_char(&mut acc, ']');
+        acc.push_char(']');
         acc
     }
 }
@@ -139,11 +143,15 @@ impl<A:ToStr> ToStr for ~[A] {
     fn to_str(&self) -> ~str {
         let mut acc = ~"[", first = true;
         for self.each |elt| {
-            if first { first = false; }
-            else { str::push_str(&mut acc, ~", "); }
-            str::push_str(&mut acc, elt.to_str());
+            if first {
+                first = false;
+            }
+            else {
+                acc.push_str(", ");
+            }
+            acc.push_str(elt.to_str());
         }
-        str::push_char(&mut acc, ']');
+        acc.push_char(']');
         acc
     }
 }
@@ -153,11 +161,15 @@ impl<A:ToStr> ToStr for @[A] {
     fn to_str(&self) -> ~str {
         let mut acc = ~"[", first = true;
         for self.each |elt| {
-            if first { first = false; }
-            else { str::push_str(&mut acc, ~", "); }
-            str::push_str(&mut acc, elt.to_str());
+            if first {
+                first = false;
+            }
+            else {
+                acc.push_str(", ");
+            }
+            acc.push_str(elt.to_str());
         }
-        str::push_char(&mut acc, ']');
+        acc.push_char(']');
         acc
     }
 }


### PR DESCRIPTION
Implemented to_str() for HashMap and HashSet
Added tests.
Minor formatting and stylistic cleanups.
