### PR TITLE
rustpkg: Implement URL-like package IDs

### DIFF
--- a/src/librustpkg/conditions.rs
+++ b/src/librustpkg/conditions.rs
@@ -28,3 +28,7 @@ condition! {
 condition! {
     missing_pkg_files: (super::PkgId) -> ();
 }
+
+condition! {
+    bad_pkg_id: (super::Path, ~str) -> ::util::PkgId;
+}

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -10,12 +10,10 @@
 
 // rustpkg utilities having to do with paths and directories
 
-use util::PkgId;
+pub use util::{PkgId, RemotePath, LocalPath};
 use core::libc::consts::os::posix88::{S_IRUSR, S_IWUSR, S_IXUSR};
 use core::os::mkdir_recursive;
-
-#[deriving(Eq)]
-pub enum OutputType { Main, Lib, Bench, Test }
+pub use util::{normalize, OutputType, Main, Lib, Bench, Test};
 
 /// Returns the value of RUST_PATH, as a list
 /// of Paths. In general this should be read from the
@@ -31,32 +29,14 @@ pub static u_rwx: i32 = (S_IRUSR | S_IWUSR | S_IXUSR) as i32;
 /// succeeded.
 pub fn make_dir_rwx(p: &Path) -> bool { os::make_dir(p, u_rwx) }
 
-/// Replace all occurrences of '-' in the stem part of path with '_'
-/// This is because we treat rust-foo-bar-quux and rust_foo_bar_quux
-/// as the same name
-pub fn normalize(p: ~Path) -> ~Path {
-    match p.filestem() {
-        None => p,
-        Some(st) => {
-            let replaced = str::replace(st, "-", "_");
-            if replaced != st {
-                ~p.with_filestem(replaced)
-            }
-            else {
-                p
-            }
-        }
-    }
-}
-
 // n.b. So far this only handles local workspaces
 // n.b. The next three functions ignore the package version right
 // now. Should fix that.
 
 /// True if there's a directory in <workspace> with
 /// pkgid's short name
-pub fn workspace_contains_package_id(pkgid: &PkgId, workspace: &Path) -> bool {
-    let pkgpath = workspace.push("src").push(pkgid.path.to_str());
+pub fn workspace_contains_package_id(pkgid: PkgId, workspace: &Path) -> bool {
+    let pkgpath = workspace.push("src").push(pkgid.local_path.to_str());
     os::path_is_dir(&pkgpath)
 }
 
@@ -64,34 +44,58 @@ pub fn workspace_contains_package_id(pkgid: &PkgId, workspace: &Path) -> bool {
 /// Doesn't check that it exists.
 pub fn pkgid_src_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
     let result = workspace.push("src");
-    result.push(pkgid.path.to_str())
+    result.push(pkgid.local_path.to_str())
 }
 
 /// Figure out what the executable name for <pkgid> in <workspace>'s build
 /// directory is, and if the file exists, return it.
 pub fn built_executable_in_workspace(pkgid: &PkgId, workspace: &Path) -> Option<Path> {
     let mut result = workspace.push("build");
-    result = result.push_rel(&pkgid.path);
     // should use a target-specific subdirectory
-    result = mk_output_path(Main, fmt!("%s-%s", pkgid.path.to_str(), pkgid.version.to_str()),
-                                       result);
+    result = mk_output_path(Main, pkgid, &result);
     debug!("built_executable_in_workspace: checking whether %s exists",
            result.to_str());
     if os::path_exists(&result) {
         Some(result)
     }
     else {
+        // This is not an error, but it's worth logging it
+        error!(fmt!("built_executable_in_workspace: %s does not exist", result.to_str()));
+        None
+    }
+}
+
+/// Figure out what the test name for <pkgid> in <workspace>'s build
+/// directory is, and if the file exists, return it.
+pub fn built_test_in_workspace(pkgid: PkgId, workspace: &Path) -> Option<Path> {
+    output_in_workspace(pkgid, workspace, Test)
+}
+
+/// Figure out what the test name for <pkgid> in <workspace>'s build
+/// directory is, and if the file exists, return it.
+pub fn built_bench_in_workspace(pkgid: PkgId, workspace: &Path) -> Option<Path> {
+    output_in_workspace(pkgid, workspace, Bench)
+}
+
+fn output_in_workspace(pkgid: PkgId, workspace: &Path, what: OutputType) -> Option<Path> {
+    let mut result = workspace.push("build");
+    // should use a target-specific subdirectory
+    result = mk_output_path(what, pkgid, &result);
+    debug!("output_in_workspace: checking whether %s exists",
+           result.to_str());
+    if os::path_exists(&result) {
+        Some(result)
+    }
+    else {
+        error!(fmt!("output_in_workspace: %s does not exist", result.to_str()));
         None
     }
 }
 
 /// Figure out what the library name for <pkgid> in <workspace>'s build
 /// directory is, and if the file exists, return it.
-pub fn built_library_in_workspace(pkgid: &PkgId, workspace: &Path) -> Option<Path> {
-    let mut result = workspace.push("build");
-    result = result.push_rel(&pkgid.path);
-    // should use a target-specific subdirectory
-    result = mk_output_path(Lib, pkgid.path.to_str(), result);
+pub fn built_library_in_workspace(pkgid: PkgId, workspace: &Path) -> Option<Path> {
+    let result = mk_output_path(Lib, pkgid, &workspace.push("build"));
     debug!("built_library_in_workspace: checking whether %s exists",
            result.to_str());
 
@@ -100,8 +104,7 @@ pub fn built_library_in_workspace(pkgid: &PkgId, workspace: &Path) -> Option<Pat
     let dir_contents = os::list_dir(&result.pop());
     debug!("dir has %? entries", dir_contents.len());
 
-    // n.b. This code assumes the pkgid's path only has one element
-    let lib_prefix = fmt!("%s%s", os::consts::DLL_PREFIX, pkgid.path.to_str());
+    let lib_prefix = fmt!("%s%s", os::consts::DLL_PREFIX, pkgid.short_name);
     let lib_filetype = fmt!("%s%s", pkgid.version.to_str(), os::consts::DLL_SUFFIX);
 
     debug!("lib_prefix = %s and lib_filetype = %s", lib_prefix, lib_filetype);
@@ -173,13 +176,15 @@ pub fn target_library_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
 
 /// Returns the test executable that would be installed for <pkgid>
 /// in <workspace>
-pub fn target_test_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
+/// note that we *don't* install test executables, so this is just for unit testing
+pub fn target_test_in_workspace(pkgid: PkgId, workspace: &Path) -> Path {
     target_file_in_workspace(pkgid, workspace, Test)
 }
 
 /// Returns the bench executable that would be installed for <pkgid>
 /// in <workspace>
-pub fn target_bench_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
+/// note that we *don't* install bench executables, so this is just for unit testing
+pub fn target_bench_in_workspace(pkgid: PkgId, workspace: &Path) -> Path {
     target_file_in_workspace(pkgid, workspace, Bench)
 }
 
@@ -188,17 +193,14 @@ fn target_file_in_workspace(pkgid: &PkgId, workspace: &Path,
     use conditions::bad_path::cond;
 
     let (subdir, create_dir) = match what {
-        Main => ("bin", true), Lib => ("lib", true), Test | Bench => ("build", false)
+        Lib => "lib", Main | Test | Bench => "bin"
     };
     let result = workspace.push(subdir);
-    if create_dir {
-        if !os::path_exists(&result) && !mkdir_recursive(&result, u_rwx) {
-            cond.raise((copy result,
-                        fmt!("I couldn't create the %s dir", subdir)));
-        }
+    debug!("target_file_in_workspace: %s %?", result.to_str(), create_dir);
+    if !os::path_exists(&result) && !mkdir_recursive(&result, u_rwx) {
+        cond.raise((result, fmt!("I couldn't create the %s dir", subdir)));
     }
-    mk_output_path(what, pkgid.path.to_str(), result)
-
+    mk_output_path(what, pkgid, &result)
 }
 
 /// Return the directory for <pkgid>'s build artifacts in <workspace>.
@@ -209,7 +211,7 @@ pub fn build_pkg_id_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
     let mut result = workspace.push("build");
     // n.b. Should actually use a target-specific
     // subdirectory of build/
-    result = result.push(normalize(~copy pkgid.path).to_str());
+    result = result.push_rel(&*pkgid.local_path);
     if os::path_exists(&result) || os::mkdir_recursive(&result, u_rwx) {
         result
     }
@@ -220,8 +222,15 @@ pub fn build_pkg_id_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
 
 /// Return the output file for a given directory name,
 /// given whether we're building a library and whether we're building tests
-pub fn mk_output_path(what: OutputType, short_name: ~str, dir: Path) -> Path {
-    match what {
+pub fn mk_output_path(what: OutputType, pkg_id: PkgId, workspace: &Path) -> Path {
+    let short_name = pkg_id.short_name_with_version();
+    // Not local_path.dir_path()! For package foo/bar/blat/, we want
+    // the executable blat-0.5 to live under blat/
+    let dir = workspace.push_rel(&*pkg_id.local_path);
+    debug!("mk_output_path: short_name = %s, path = %s",
+           short_name, dir.to_str());
+    let output_path = match what {
+        // this code is duplicated from elsewhere; fix this
         Lib => dir.push(os::dll_filename(short_name)),
         _ => dir.push(fmt!("%s%s%s", short_name,
                            match what {
@@ -230,5 +239,7 @@ pub fn mk_output_path(what: OutputType, short_name: ~str, dir: Path) -> Path {
                                _     => ""
                            }
                            os::EXE_SUFFIX))
-    }
+    };
+    debug!("mk_output_path: returning %s", output_path.to_str());
+    output_path
 }

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -157,27 +157,6 @@ impl<'self> PkgScript<'self> {
 impl Ctx {
 
     fn run(&self, cmd: ~str, args: ~[~str]) {
-        let root = util::root();
-
-        util::need_dir(&root);
-        util::need_dir(&root.push(~"work"));
-        util::need_dir(&root.push(~"lib"));
-        util::need_dir(&root.push(~"bin"));
-        util::need_dir(&root.push(~"tmp"));
-
-        fn sep_name_vers(in: ~str) -> (Option<~str>, Option<~str>) {
-            let mut name = None;
-            let mut vers = None;
-
-            for str::each_split_char(in, '@') |s| {
-                if      name.is_none() { name = Some(s.to_owned()); }
-                else if vers.is_none() { vers = Some(s.to_owned()); }
-                else                   { break;               }
-            }
-
-            (name, vers)
-        }
-
         match cmd {
             ~"build" => {
                 if args.len() < 1 {
@@ -227,9 +206,7 @@ impl Ctx {
                     return usage::uninstall();
                 }
 
-                let (name, vers) = sep_name_vers(copy args[0]);
-
-                self.prefer(name.get(), vers);
+                self.prefer(args[0], None);
             }
             ~"test" => {
                 self.test();
@@ -239,20 +216,16 @@ impl Ctx {
                     return usage::uninstall();
                 }
 
-                let (name, vers) = sep_name_vers(copy args[0]);
-
-                self.uninstall(name.get(), vers);
+                self.uninstall(args[0], None);
             }
             ~"unprefer" => {
                 if args.len() < 1 {
                     return usage::uninstall();
                 }
 
-                let (name, vers) = sep_name_vers(copy args[0]);
-
-                self.unprefer(name.get(), vers);
+                self.unprefer(args[0], None);
             }
-            _ => fail!("reached an unhandled command")
+            _ => fail!(fmt!("I don't know the command `%s`", cmd))
         }
     }
 
@@ -267,7 +240,7 @@ impl Ctx {
         debug!("Destination dir = %s", build_dir.to_str());
 
         // Create the package source
-        let mut src = PkgSrc::new(workspace, &build_dir, &pkgid);
+        let mut src = PkgSrc::new(workspace, &build_dir, pkgid);
         debug!("Package src = %?", src);
 
         // Is there custom build logic? If so, use it
@@ -305,7 +278,6 @@ impl Ctx {
             // Build it!
             src.build(&build_dir, cfgs, self.sysroot_opt);
         }
-
     }
 
     fn clean(&self, workspace: &Path, id: &PkgId)  {
@@ -317,7 +289,7 @@ impl Ctx {
         util::note(fmt!("Cleaning package %s (removing directory %s)",
                         id.to_str(), dir.to_str()));
         if os::path_exists(&dir) {
-            util::remove_dir_r(&dir);
+            os::remove_dir_recursive(&dir);
             util::note(fmt!("Removed directory %s", dir.to_str()));
         }
 
@@ -353,19 +325,19 @@ impl Ctx {
             debug!("Copying: %s -> %s", exec.to_str(), target_exec.to_str());
             if !(os::mkdir_recursive(&target_exec.dir_path(), u_rwx) &&
                  os::copy_file(exec, &target_exec)) {
-                cond.raise((*exec, target_exec));
+                cond.raise((copy *exec, copy target_exec));
             }
         }
         for maybe_library.each |lib| {
             debug!("Copying: %s -> %s", lib.to_str(), target_lib.to_str());
             if !(os::mkdir_recursive(&target_lib.dir_path(), u_rwx) &&
                  os::copy_file(lib, &target_lib)) {
-                cond.raise((*lib, target_lib));
+                cond.raise((copy *lib, copy target_lib));
             }
         }
     }
 
-    fn prefer(&self, _id: ~str, _vers: Option<~str>)  {
+    fn prefer(&self, _id: &str, _vers: Option<~str>)  {
         fail!(~"prefer not yet implemented");
     }
 
@@ -374,14 +346,15 @@ impl Ctx {
         fail!("test not yet implemented");
     }
 
-    fn uninstall(&self, _id: ~str, _vers: Option<~str>)  {
+    fn uninstall(&self, _id: &str, _vers: Option<~str>)  {
         fail!("uninstall not yet implemented");
     }
 
-    fn unprefer(&self, _id: ~str, _vers: Option<~str>)  {
+    fn unprefer(&self, _id: &str, _vers: Option<~str>)  {
         fail!("unprefer not yet implemented");
     }
 }
+
 
 pub fn main() {
     io::println("WARNING: The Rust package manager is experimental and may be unstable");
@@ -443,32 +416,6 @@ pub struct Crate {
     cfgs: ~[~str]
 }
 
-pub struct Listener {
-    cmds: ~[~str],
-    cb: ~fn()
-}
-
-pub fn run(listeners: ~[Listener]) {
-    let rcmd = copy os::args()[2];
-    let mut found = false;
-
-    for listeners.each |listener| {
-        for listener.cmds.each |&cmd| {
-            if cmd == rcmd {
-                (listener.cb)();
-
-                found = true;
-
-                break;
-            }
-        }
-    }
-
-    if !found {
-        os::set_exit_status(42);
-    }
-}
-
 pub impl Crate {
 
     fn new(p: &Path) -> Crate {
@@ -527,10 +474,6 @@ pub fn src_dir() -> Path {
     os::getcwd()
 }
 
-condition! {
-    bad_pkg_id: (super::Path, ~str) -> ::util::PkgId;
-}
-
 // An enumeration of the unpacked source of a package workspace.
 // This contains a list of files found in the source workspace.
 pub struct PkgSrc {
@@ -576,7 +519,7 @@ impl PkgSrc {
 
         if !os::path_exists(&dir) {
             if !self.fetch_git() {
-                cond.raise((self.id, ~"supplied path for package dir does not \
+                cond.raise((copy self.id, ~"supplied path for package dir does not \
                     exist, and couldn't interpret it as a URL fragment"));
             }
         }
@@ -598,12 +541,12 @@ impl PkgSrc {
         let mut local = self.root.push("src");
         local = local.push(self.id.to_str());
         // Git can't clone into a non-empty directory
-        util::remove_dir_r(&local);
+        os::remove_dir_recursive(&local);
 
         let url = fmt!("https://%s", self.id.remote_path.to_str());
         util::note(fmt!("git clone %s %s", url, local.to_str()));
 
-        if run::program_output(~"git", ~[~"clone", url, local.to_str()]).status != 0 {
+        if run::program_output(~"git", ~[~"clone", copy url, local.to_str()]).status != 0 {
             util::note(fmt!("fetching %s failed: can't clone repository", url));
             return false;
         }
@@ -733,3 +676,4 @@ impl PkgSrc {
         self.build_crates(maybe_sysroot, dst_dir, &dir, self.benchs, cfgs, Bench);
     }
 }
+

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -30,12 +30,10 @@ use rustc::metadata::filesearch;
 use std::{getopts};
 use syntax::{ast, diagnostic};
 use util::*;
-use path_util::normalize;
-use path_util::{build_pkg_id_in_workspace, pkgid_src_in_workspace};
+use path_util::{build_pkg_id_in_workspace, pkgid_src_in_workspace, u_rwx};
 use path_util::{built_executable_in_workspace, built_library_in_workspace};
 use path_util::{target_executable_in_workspace, target_library_in_workspace};
 use workspace::pkg_parent_workspaces;
-use rustc::driver::session::{lib_crate, bin_crate, crate_type};
 use context::Ctx;
 
 mod conditions;
@@ -269,7 +267,7 @@ impl Ctx {
         debug!("Destination dir = %s", build_dir.to_str());
 
         // Create the package source
-        let mut src = PkgSrc::new(&workspace.push("src"), &build_dir, pkgid);
+        let mut src = PkgSrc::new(workspace, &build_dir, &pkgid);
         debug!("Package src = %?", src);
 
         // Is there custom build logic? If so, use it
@@ -337,6 +335,8 @@ impl Ctx {
         // Should use RUST_PATH in the future.
         // Also should use workcache to not build if not necessary.
         self.build(workspace, id);
+        debug!("install: workspace = %s, id = %s", workspace.to_str(),
+               id.to_str());
 
         // Now copy stuff into the install dirs
         let maybe_executable = built_executable_in_workspace(id, workspace);
@@ -344,104 +344,29 @@ impl Ctx {
         let target_exec = target_executable_in_workspace(id, workspace);
         let target_lib = target_library_in_workspace(id, workspace);
 
+        debug!("target_exec = %s target_lib = %s \
+                maybe_executable = %? maybe_library = %?",
+               target_exec.to_str(), target_lib.to_str(),
+               maybe_executable, maybe_library);
+
         for maybe_executable.each |exec| {
             debug!("Copying: %s -> %s", exec.to_str(), target_exec.to_str());
-            if !os::copy_file(exec, &target_exec) {
-                cond.raise((copy *exec, copy target_exec));
+            if !(os::mkdir_recursive(&target_exec.dir_path(), u_rwx) &&
+                 os::copy_file(exec, &target_exec)) {
+                cond.raise((*exec, target_exec));
             }
         }
         for maybe_library.each |lib| {
             debug!("Copying: %s -> %s", lib.to_str(), target_lib.to_str());
-            if !os::copy_file(lib, &target_lib) {
-                cond.raise((copy *lib, copy target_lib));
+            if !(os::mkdir_recursive(&target_lib.dir_path(), u_rwx) &&
+                 os::copy_file(lib, &target_lib)) {
+                cond.raise((*lib, target_lib));
             }
         }
     }
 
-    fn fetch(&self, _dir: &Path, _url: ~str, _target: Option<~str>)  {
-        // stub
-        fail!("fetch not yet implemented");
-    }
-
-    fn fetch_curl(&self, dir: &Path, url: ~str)  {
-        util::note(fmt!("fetching from %s using curl", url));
-
-        let tar = dir.dir_path().push(&dir.file_path().to_str() + ~".tar");
-
-        if run::program_output(~"curl", ~[~"-f", ~"-s",
-                                          ~"-o", tar.to_str(),
-                                          url]).status != 0 {
-            util::error(~"fetching failed: downloading using curl failed");
-
-            fail!();
-        }
-
-        if run::program_output(~"tar", ~[~"-x", ~"--strip-components=1",
-                                         ~"-C", dir.to_str(), ~"-f",
-                                         tar.to_str()]).status != 0 {
-            util::error(~"fetching failed: extracting using tar failed" +
-                        ~"(is it a valid tar archive?)");
-
-           fail!();
-        }
-    }
-
-    fn fetch_git(&self, dir: &Path, url: ~str, mut target: Option<~str>)  {
-        util::note(fmt!("fetching from %s using git", url));
-
-        // Git can't clone into a non-empty directory
-        util::remove_dir_r(dir);
-
-        if run::program_output(~"git", ~[~"clone", url,
-                                         dir.to_str()]).status != 0 {
-            util::error(~"fetching failed: can't clone repository");
-            fail!();
-        }
-
-        if !target.is_none() {
-            let mut success = true;
-
-            do util::temp_change_dir(dir) {
-                success = run::program_output(~"git",
-                                              ~[~"checkout",
-                                                target.swap_unwrap()]).status != 0
-            }
-
-            if !success {
-                util::error(~"fetching failed: can't checkout target");
-                fail!();
-            }
-        }
-    }
-
-    fn prefer(&self, id: ~str, vers: Option<~str>)  {
-        let package = match util::get_pkg(id, vers) {
-            result::Ok(package) => package,
-            result::Err(err) => {
-                util::error(err);
-                fail!(); // Condition?
-            }
-        };
-        let name = package.id.path.to_str(); // ???
-
-        util::note(fmt!("preferring %s v%s", name, package.id.version.to_str()));
-
-        let bin_dir = util::root().push(~"bin");
-
-        for package.bins.each |&bin| {
-            let path = Path(bin);
-            let mut name = None;
-            for str::each_split_char(path.file_path().to_str(), '-') |s| {
-                name = Some(s.to_owned());
-                break;
-            }
-            let out = bin_dir.push(name.unwrap());
-
-            util::link_exe(&path, &out);
-            util::note(fmt!("linked %s", out.to_str()));
-        }
-
-        util::note(fmt!("preferred %s v%s", name, package.id.version.to_str()));
+    fn prefer(&self, _id: ~str, _vers: Option<~str>)  {
+        fail!(~"prefer not yet implemented");
     }
 
     fn test(&self)  {
@@ -641,17 +566,19 @@ impl PkgSrc {
     fn check_dir(&self) -> Path {
         use conditions::nonexistent_package::cond;
 
-        debug!("Pushing onto root: %s | %s", self.id.path.to_str(),
+        debug!("Pushing onto root: %s | %s", self.id.to_str(),
                self.root.to_str());
 
-        let dir = self.root.push_rel(&self.id.path).normalize();
+        let mut dir = self.root.push("src");
+        dir = dir.push(self.id.to_str()); // ?? Should this use the version number?
 
         debug!("Checking dir: %s", dir.to_str());
 
-        // tjc: Rather than erroring out, need to try downloading the
-        // contents of the path to a local directory (#5679)
         if !os::path_exists(&dir) {
-            cond.raise((copy self.id, ~"missing package dir"));
+            if !self.fetch_git() {
+                cond.raise((self.id, ~"supplied path for package dir does not \
+                    exist, and couldn't interpret it as a URL fragment"));
+            }
         }
 
         if !os::path_is_dir(&dir) {
@@ -661,6 +588,28 @@ impl PkgSrc {
 
         dir
     }
+
+    /// Try interpreting self's package id as a remote package, and try
+    /// fetching it and caching it in a local directory. If that didn't
+    /// work, return false.
+    /// (right now we only support git)
+    fn fetch_git(&self) -> bool {
+
+        let mut local = self.root.push("src");
+        local = local.push(self.id.to_str());
+        // Git can't clone into a non-empty directory
+        util::remove_dir_r(&local);
+
+        let url = fmt!("https://%s", self.id.remote_path.to_str());
+        util::note(fmt!("git clone %s %s", url, local.to_str()));
+
+        if run::program_output(~"git", ~[~"clone", url, local.to_str()]).status != 0 {
+            util::note(fmt!("fetching %s failed: can't clone repository", url));
+            return false;
+        }
+        true
+    }
+
 
     // If a file named "pkg.rs" in the current directory exists,
     // return the path for it. Otherwise, None
@@ -680,7 +629,7 @@ impl PkgSrc {
     /// Requires that dashes in p have already been normalized to
     /// underscores
     fn stem_matches(&self, p: &Path) -> bool {
-        let self_id = normalize(~copy self.id.path).filestem();
+        let self_id = self.id.local_path.filestem();
         if self_id == p.filestem() {
             return true;
         }
@@ -715,7 +664,7 @@ impl PkgSrc {
 
         let dir = self.check_dir();
         let prefix = dir.components.len();
-        debug!("Matching against %?", self.id.path.filestem());
+        debug!("Matching against %?", self.id.local_path.filestem());
         for os::walk_dir(&dir) |pth| {
             match pth.filename() {
                 Some(~"lib.rs") => push_crate(&mut self.libs,
@@ -752,8 +701,7 @@ impl PkgSrc {
                     src_dir: &Path,
                     crates: &[Crate],
                     cfgs: &[~str],
-                    test: bool, crate_type: crate_type) {
-
+                    what: OutputType) {
         for crates.each |&crate| {
             let path = &src_dir.push_rel(&crate.file).normalize();
             util::note(fmt!("build_crates: compiling %s", path.to_str()));
@@ -763,7 +711,7 @@ impl PkgSrc {
                                      dst_dir,
                                      crate.flags,
                                      crate.cfgs + cfgs,
-                                     false, test, crate_type);
+                                     false, what);
             if !result {
                 build_err::cond.raise(fmt!("build failure on %s",
                                            path.to_str()));
@@ -776,12 +724,12 @@ impl PkgSrc {
     fn build(&self, dst_dir: &Path, cfgs: ~[~str], maybe_sysroot: Option<@Path>) {
         let dir = self.check_dir();
         debug!("Building libs");
-        self.build_crates(maybe_sysroot, dst_dir, &dir, self.libs, cfgs, false, lib_crate);
+        self.build_crates(maybe_sysroot, dst_dir, &dir, self.libs, cfgs, Lib);
         debug!("Building mains");
-        self.build_crates(maybe_sysroot, dst_dir, &dir, self.mains, cfgs, false, bin_crate);
+        self.build_crates(maybe_sysroot, dst_dir, &dir, self.mains, cfgs, Main);
         debug!("Building tests");
-        self.build_crates(maybe_sysroot, dst_dir, &dir, self.tests, cfgs, true, bin_crate);
+        self.build_crates(maybe_sysroot, dst_dir, &dir, self.tests, cfgs, Test);
         debug!("Building benches");
-        self.build_crates(maybe_sysroot, dst_dir, &dir, self.benchs, cfgs, true, bin_crate);
+        self.build_crates(maybe_sysroot, dst_dir, &dir, self.benchs, cfgs, Bench);
     }
 }

--- a/src/librustpkg/workspace.rs
+++ b/src/librustpkg/workspace.rs
@@ -21,9 +21,10 @@ pub fn pkg_parent_workspaces(pkgid: &PkgId, action: &fn(&Path) -> bool) -> bool 
         workspace_contains_package_id(pkgid, ws));
     if workspaces.is_empty() {
         // tjc: make this a condition
-        fail!("Package %s not found in any of the following workspaces: %s",
-              pkgid.path.to_str(),
-              rust_path().to_str());
+        fail!("Package %s not found in any of \
+                    the following workspaces: %s",
+                   pkgid.remote_path.to_str(),
+                   rust_path().to_str());
     }
     for workspaces.each |ws| {
         if action(ws) {


### PR DESCRIPTION
r? @brson This patch implements package IDs like
github.com/catamorphism/test-pkg.

To support such package IDs, I changed the PkgId struct to contain
a LocalPath and a RemotePath field, where the RemotePath reflects
the actual URL and the LocalPath reflects the file name of the cached
copy. Right now, the only difference is that the local path doesn't
contain dashes, but this will change when we implement #6407.

Also, PkgIds now have a short_name field -- though the short name
can be derived from the LocalPath, I thought it was cleaner not to
call option::get() wantonly.
