### PR TITLE
Reexport static trait methods on traits in the same module.

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -388,6 +388,17 @@ fn encode_reexported_static_methods(ecx: @EncodeContext,
             match ecx.tcx.items.find(&exp.def_id.node) {
                 Some(&ast_map::node_item(item, path)) => {
                     let original_name = ecx.tcx.sess.str_of(item.ident);
+
+                    //
+                    // We don't need to reexport static methods on traits
+                    // declared in the same module as our `pub use ...` since
+                    // that's done when we encode the trait item.
+                    //
+                    // The only exception is when the reexport *changes* the
+                    // name e.g. `pub use Foo = self::Bar` -- we have
+                    // encoded metadata for static methods relative to Bar,
+                    // but not yet for Foo.
+                    //
                     if mod_path != *path || *exp.name != *original_name {
                         for methods.each |&m| {
                             if m.explicit_self == ast::sty_static {

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -386,8 +386,10 @@ fn encode_reexported_static_methods(ecx: @EncodeContext,
     match ecx.tcx.trait_methods_cache.find(&exp.def_id) {
         Some(methods) => {
             match ecx.tcx.items.find(&exp.def_id.node) {
-                Some(&ast_map::node_item(_, path)) => {
-                    if mod_path != *path {
+                Some(&ast_map::node_item(item, path)) => {
+                    let interner = ecx.tcx.sess.parse_sess.interner;
+                    let original_name = ecx.tcx.sess.str_of(item.ident);
+                    if mod_path != *path || *exp.name != *original_name {
                         for methods.each |&m| {
                             if m.explicit_self == ast::sty_static {
                                 encode_reexported_static_method(ecx,

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -387,7 +387,6 @@ fn encode_reexported_static_methods(ecx: @EncodeContext,
         Some(methods) => {
             match ecx.tcx.items.find(&exp.def_id.node) {
                 Some(&ast_map::node_item(item, path)) => {
-                    let interner = ecx.tcx.sess.parse_sess.interner;
                     let original_name = ecx.tcx.sess.str_of(item.ident);
                     if mod_path != *path || *exp.name != *original_name {
                         for methods.each |&m| {

--- a/src/test/auxiliary/mod_trait_with_static_methods_lib.rs
+++ b/src/test/auxiliary/mod_trait_with_static_methods_lib.rs
@@ -9,6 +9,15 @@
 // except according to those terms.
 
 pub use sub_foo::Foo;
+pub use Baz = self::Bar;
+
+pub trait Bar {
+    pub fn bar() -> Self;
+}
+
+impl Bar for int {
+    pub fn bar() -> int { 84 }
+}
 
 pub mod sub_foo {
     pub trait Foo {
@@ -18,4 +27,5 @@ pub mod sub_foo {
     impl Foo for int {
         pub fn foo() -> int { 42 }
     }
+
 }

--- a/src/test/run-pass/trait_with_static_methods_cross_crate.rs
+++ b/src/test/run-pass/trait_with_static_methods_cross_crate.rs
@@ -13,7 +13,9 @@
 extern mod mod_trait_with_static_methods_lib;
 
 use mod_trait_with_static_methods_lib::Foo;
+use mod_trait_with_static_methods_lib::Baz;
 
 pub fn main() {
     assert_eq!(42, Foo::foo());
+    assert_eq!(84, Baz::bar());
 }


### PR DESCRIPTION
My earlier fix for #4202 would not work correctly if the trait being exported was a top-level item relative to the module from which it was being exported. An example that would not work correctly with the original patch:

```
// foo.rs

pub use Foo = self::Bar;

pub trait Bar {
  pub fn bar() -> Self;
}

impl Bar for int {
  pub fn bar() -> int { 42 }
}

// bar.rs

fn main() {
  foo::Foo::bar()
}
```

This is now supported.

I believe this change will allow the GenericPath trait to be exported from core::path as Path in such a manner, which should allow #5389 to move forward.
