### PR TITLE
Remove vecs_implicitly_copyable

### DIFF
--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -10,9 +10,7 @@
 
 #[crate_type = "bin"];
 
-#[allow(vecs_implicitly_copyable)];
 #[allow(non_camel_case_types)];
-#[allow(deprecated_pattern)];
 
 extern mod std(vers = "0.7-pre");
 
@@ -43,8 +41,8 @@ pub mod errors;
 pub fn main() {
     let args = os::args();
     let config = parse_config(args);
-    log_config(config);
-    run_tests(config);
+    log_config(&config);
+    run_tests(&config);
 }
 
 pub fn parse_config(args: ~[~str]) -> config {
@@ -89,22 +87,23 @@ pub fn parse_config(args: ~[~str]) -> config {
         run_ignored: getopts::opt_present(matches, ~"ignored"),
         filter:
              if vec::len(matches.free) > 0u {
-                 option::Some(matches.free[0])
+                 option::Some(copy matches.free[0])
              } else { option::None },
         logfile: getopts::opt_maybe_str(matches, ~"logfile").map(|s| Path(*s)),
         runtool: getopts::opt_maybe_str(matches, ~"runtool"),
         rustcflags: getopts::opt_maybe_str(matches, ~"rustcflags"),
         jit: getopts::opt_present(matches, ~"jit"),
         newrt: getopts::opt_present(matches, ~"newrt"),
-        target: opt_str(getopts::opt_maybe_str(matches, ~"target")),
-        adb_path: opt_str(getopts::opt_maybe_str(matches, ~"adb-path")),
-        adb_test_dir: opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")),
+        target: opt_str2(getopts::opt_maybe_str(matches, ~"target")).to_str(),
+        adb_path: opt_str2(getopts::opt_maybe_str(matches, ~"adb-path")).to_str(),
+        adb_test_dir:
+            opt_str2(getopts::opt_maybe_str(matches, ~"adb-test-dir")).to_str(),
         adb_device_status:
-            if (opt_str(getopts::opt_maybe_str(matches, ~"target")) ==
+            if (opt_str2(getopts::opt_maybe_str(matches, ~"target")) ==
                 ~"arm-linux-androideabi") {
-                if (opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
+                if (opt_str2(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
                     ~"(none)" &&
-                    opt_str(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
+                    opt_str2(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
                     ~"") { true }
                 else { false }
             } else { false },
@@ -112,7 +111,7 @@ pub fn parse_config(args: ~[~str]) -> config {
     }
 }
 
-pub fn log_config(config: config) {
+pub fn log_config(config: &config) {
     let c = config;
     logv(c, fmt!("configuration:"));
     logv(c, fmt!("compile_lib_path: %s", config.compile_lib_path));
@@ -123,9 +122,9 @@ pub fn log_config(config: config) {
     logv(c, fmt!("stage_id: %s", config.stage_id));
     logv(c, fmt!("mode: %s", mode_str(config.mode)));
     logv(c, fmt!("run_ignored: %b", config.run_ignored));
-    logv(c, fmt!("filter: %s", opt_str(config.filter)));
-    logv(c, fmt!("runtool: %s", opt_str(config.runtool)));
-    logv(c, fmt!("rustcflags: %s", opt_str(config.rustcflags)));
+    logv(c, fmt!("filter: %s", opt_str(&config.filter)));
+    logv(c, fmt!("runtool: %s", opt_str(&config.runtool)));
+    logv(c, fmt!("rustcflags: %s", opt_str(&config.rustcflags)));
     logv(c, fmt!("jit: %b", config.jit));
     logv(c, fmt!("newrt: %b", config.newrt));
     logv(c, fmt!("target: %s", config.target));
@@ -136,8 +135,18 @@ pub fn log_config(config: config) {
     logv(c, fmt!("\n"));
 }
 
-pub fn opt_str(maybestr: Option<~str>) -> ~str {
-    match maybestr { option::Some(s) => s, option::None => ~"(none)" }
+pub fn opt_str<'a>(maybestr: &'a Option<~str>) -> &'a str {
+    match *maybestr {
+        option::None => "(none)",
+        option::Some(ref s) => {
+            let s: &'a str = *s;
+            s
+        }
+    }
+}
+
+pub fn opt_str2(maybestr: Option<~str>) -> ~str {
+    match maybestr { None => ~"(none)", Some(s) => { s } }
 }
 
 pub fn str_opt(maybestr: ~str) -> Option<~str> {
@@ -165,16 +174,16 @@ pub fn mode_str(mode: mode) -> ~str {
     }
 }
 
-pub fn run_tests(config: config) {
+pub fn run_tests(config: &config) {
     let opts = test_opts(config);
     let tests = make_tests(config);
     let res = test::run_tests_console(&opts, tests);
     if !res { fail!("Some tests failed"); }
 }
 
-pub fn test_opts(config: config) -> test::TestOpts {
+pub fn test_opts(config: &config) -> test::TestOpts {
     test::TestOpts {
-        filter: config.filter,
+        filter: copy config.filter,
         run_ignored: config.run_ignored,
         logfile: copy config.logfile,
         run_tests: true,
@@ -184,7 +193,7 @@ pub fn test_opts(config: config) -> test::TestOpts {
     }
 }
 
-pub fn make_tests(config: config) -> ~[test::TestDescAndFn] {
+pub fn make_tests(config: &config) -> ~[test::TestDescAndFn] {
     debug!("making tests from %s",
            config.src_base.to_str());
     let mut tests = ~[];
@@ -198,7 +207,7 @@ pub fn make_tests(config: config) -> ~[test::TestDescAndFn] {
     tests
 }
 
-pub fn is_test(config: config, testfile: &Path) -> bool {
+pub fn is_test(config: &config, testfile: &Path) -> bool {
     // Pretty-printer does not work with .rc files yet
     let valid_extensions =
         match config.mode {
@@ -221,7 +230,7 @@ pub fn is_test(config: config, testfile: &Path) -> bool {
     return valid;
 }
 
-pub fn make_test(config: config, testfile: &Path) -> test::TestDescAndFn {
+pub fn make_test(config: &config, testfile: &Path) -> test::TestDescAndFn {
     test::TestDescAndFn {
         desc: test::TestDesc {
             name: make_test_name(config, testfile),
@@ -232,13 +241,15 @@ pub fn make_test(config: config, testfile: &Path) -> test::TestDescAndFn {
     }
 }
 
-pub fn make_test_name(config: config, testfile: &Path) -> test::TestName {
+pub fn make_test_name(config: &config, testfile: &Path) -> test::TestName {
     test::DynTestName(fmt!("[%s] %s",
                            mode_str(config.mode),
                            testfile.to_str()))
 }
 
-pub fn make_test_closure(config: config, testfile: &Path) -> test::TestFn {
-    let testfile = testfile.to_str();
-    test::DynTestFn(|| runtest::run(config, testfile))
+pub fn make_test_closure(config: &config, testfile: &Path) -> test::TestFn {
+    use core::cell::Cell;
+    let config = Cell(copy *config);
+    let testfile = Cell(testfile.to_str());
+    test::DynTestFn(|| { runtest::run(config.take(), testfile.take()) })
 }

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -14,7 +14,7 @@ use core::run::spawn_process;
 use core::run;
 
 #[cfg(target_os = "win32")]
-fn target_env(lib_path: ~str, prog: ~str) -> ~[(~str,~str)] {
+fn target_env(lib_path: &str, prog: &str) -> ~[(~str,~str)] {
 
     let mut env = os::env();
 
@@ -27,7 +27,7 @@ fn target_env(lib_path: ~str, prog: ~str) -> ~[(~str,~str)] {
         if k == ~"PATH" { (~"PATH", v + ~";" + lib_path + ~";" + aux_path) }
         else { (k,v) }
     };
-    if str::ends_with(prog, ~"rustc.exe") {
+    if str::ends_with(prog, "rustc.exe") {
         env.push((~"RUST_THREADS", ~"1"));
     }
     return env;
@@ -36,16 +36,16 @@ fn target_env(lib_path: ~str, prog: ~str) -> ~[(~str,~str)] {
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "freebsd")]
-fn target_env(_lib_path: ~str, _prog: ~str) -> ~[(~str,~str)] {
+fn target_env(_lib_path: &str, _prog: &str) -> ~[(~str,~str)] {
     ~[]
 }
 
-struct Result {status: int, out: ~str, err: ~str}
+pub struct Result {status: int, out: ~str, err: ~str}
 
 // FIXME (#2659): This code is duplicated in core::run::program_output
-pub fn run(lib_path: ~str,
-           prog: ~str,
-           args: ~[~str],
+pub fn run(lib_path: &str,
+           prog: &str,
+           args: &[~str],
            env: ~[(~str, ~str)],
            input: Option<~str>) -> Result {
     let pipe_in = os::pipe();

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -30,40 +30,40 @@ pub fn run(config: config, testfile: ~str) {
     let props = load_props(&testfile);
     debug!("loaded props");
     match config.mode {
-      mode_compile_fail => run_cfail_test(config, props, &testfile),
-      mode_run_fail => run_rfail_test(config, props, &testfile),
-      mode_run_pass => run_rpass_test(config, props, &testfile),
-      mode_pretty => run_pretty_test(config, props, &testfile),
-      mode_debug_info => run_debuginfo_test(config, props, &testfile)
+      mode_compile_fail => run_cfail_test(&config, &props, &testfile),
+      mode_run_fail => run_rfail_test(&config, &props, &testfile),
+      mode_run_pass => run_rpass_test(&config, &props, &testfile),
+      mode_pretty => run_pretty_test(&config, &props, &testfile),
+      mode_debug_info => run_debuginfo_test(&config, &props, &testfile)
     }
 }
 
-fn run_cfail_test(config: config, props: TestProps, testfile: &Path) {
+fn run_cfail_test(config: &config, props: &TestProps, testfile: &Path) {
     let ProcRes = compile_test(config, props, testfile);
 
     if ProcRes.status == 0 {
-        fatal_ProcRes(~"compile-fail test compiled successfully!", ProcRes);
+        fatal_ProcRes(~"compile-fail test compiled successfully!", &ProcRes);
     }
 
-    check_correct_failure_status(ProcRes);
+    check_correct_failure_status(&ProcRes);
 
     let expected_errors = errors::load_errors(testfile);
     if !expected_errors.is_empty() {
         if !props.error_patterns.is_empty() {
             fatal(~"both error pattern and expected errors specified");
         }
-        check_expected_errors(expected_errors, testfile, ProcRes);
+        check_expected_errors(expected_errors, testfile, &ProcRes);
     } else {
-        check_error_patterns(props, testfile, ProcRes);
+        check_error_patterns(props, testfile, &ProcRes);
     }
 }
 
-fn run_rfail_test(config: config, props: TestProps, testfile: &Path) {
+fn run_rfail_test(config: &config, props: &TestProps, testfile: &Path) {
     let ProcRes = if !config.jit {
         let ProcRes = compile_test(config, props, testfile);
 
         if ProcRes.status != 0 {
-            fatal_ProcRes(~"compilation failed!", ProcRes);
+            fatal_ProcRes(~"compilation failed!", &ProcRes);
         }
 
         exec_compiled_test(config, props, testfile)
@@ -74,26 +74,26 @@ fn run_rfail_test(config: config, props: TestProps, testfile: &Path) {
     // The value our Makefile configures valgrind to return on failure
     static valgrind_err: int = 100;
     if ProcRes.status == valgrind_err {
-        fatal_ProcRes(~"run-fail test isn't valgrind-clean!", ProcRes);
+        fatal_ProcRes(~"run-fail test isn't valgrind-clean!", &ProcRes);
     }
 
     match config.target {
 
         ~"arm-linux-androideabi" => {
             if (config.adb_device_status) {
-                check_correct_failure_status(ProcRes);
-                check_error_patterns(props, testfile, ProcRes);
+                check_correct_failure_status(&ProcRes);
+                check_error_patterns(props, testfile, &ProcRes);
             }
         }
 
         _=> {
-            check_correct_failure_status(ProcRes);
-            check_error_patterns(props, testfile, ProcRes);
+            check_correct_failure_status(&ProcRes);
+            check_error_patterns(props, testfile, &ProcRes);
         }
     }
 }
 
-fn check_correct_failure_status(ProcRes: ProcRes) {
+fn check_correct_failure_status(ProcRes: &ProcRes) {
     // The value the rust runtime returns on failure
     static rust_err: int = 101;
     if ProcRes.status != rust_err {
@@ -104,27 +104,27 @@ fn check_correct_failure_status(ProcRes: ProcRes) {
     }
 }
 
-fn run_rpass_test(config: config, props: TestProps, testfile: &Path) {
+fn run_rpass_test(config: &config, props: &TestProps, testfile: &Path) {
     if !config.jit {
         let mut ProcRes = compile_test(config, props, testfile);
 
         if ProcRes.status != 0 {
-            fatal_ProcRes(~"compilation failed!", ProcRes);
+            fatal_ProcRes(~"compilation failed!", &ProcRes);
         }
 
         ProcRes = exec_compiled_test(config, props, testfile);
 
         if ProcRes.status != 0 {
-            fatal_ProcRes(~"test run failed!", ProcRes);
+            fatal_ProcRes(~"test run failed!", &ProcRes);
         }
     } else {
         let ProcRes = jit_test(config, props, testfile);
 
-        if ProcRes.status != 0 { fatal_ProcRes(~"jit failed!", ProcRes); }
+        if ProcRes.status != 0 { fatal_ProcRes(~"jit failed!", &ProcRes); }
     }
 }
 
-fn run_pretty_test(config: config, props: TestProps, testfile: &Path) {
+fn run_pretty_test(config: &config, props: &TestProps, testfile: &Path) {
     if props.pp_exact.is_some() {
         logv(config, ~"testing for exact pretty-printing");
     } else { logv(config, ~"testing for converging pretty-printing"); }
@@ -137,32 +137,33 @@ fn run_pretty_test(config: config, props: TestProps, testfile: &Path) {
     let mut round = 0;
     while round < rounds {
         logv(config, fmt!("pretty-printing round %d", round));
-        let ProcRes = print_source(config, testfile, srcs[round]);
+        let ProcRes = print_source(config, testfile, copy srcs[round]);
 
         if ProcRes.status != 0 {
             fatal_ProcRes(fmt!("pretty-printing failed in round %d", round),
-                          ProcRes);
+                          &ProcRes);
         }
 
-        srcs.push(ProcRes.stdout);
+        let ProcRes{ stdout, _ } = ProcRes;
+        srcs.push(stdout);
         round += 1;
     }
 
     let mut expected =
         match props.pp_exact {
-          Some(file) => {
-            let filepath = testfile.dir_path().push_rel(&file);
+          Some(ref file) => {
+            let filepath = testfile.dir_path().push_rel(file);
             io::read_whole_file_str(&filepath).get()
           }
-          None => { srcs[vec::len(srcs) - 2u] }
+          None => { copy srcs[srcs.len() - 2u] }
         };
-    let mut actual = srcs[vec::len(srcs) - 1u];
+    let mut actual = copy srcs[srcs.len() - 1u];
 
     if props.pp_exact.is_some() {
         // Now we have to care about line endings
         let cr = ~"\r";
-        actual = str::replace(actual, cr, ~"");
-        expected = str::replace(expected, cr, ~"");
+        actual = str::replace(actual, cr, "");
+        expected = str::replace(expected, cr, "");
     }
 
     compare_source(expected, actual);
@@ -171,23 +172,22 @@ fn run_pretty_test(config: config, props: TestProps, testfile: &Path) {
     let ProcRes = typecheck_source(config, props, testfile, actual);
 
     if ProcRes.status != 0 {
-        fatal_ProcRes(~"pretty-printed source does not typecheck", ProcRes);
+        fatal_ProcRes(~"pretty-printed source does not typecheck", &ProcRes);
     }
 
     return;
 
-    fn print_source(config: config, testfile: &Path, src: ~str) -> ProcRes {
+    fn print_source(config: &config, testfile: &Path, src: ~str) -> ProcRes {
         compose_and_run(config, testfile, make_pp_args(config, testfile),
                         ~[], config.compile_lib_path, Some(src))
     }
 
-    fn make_pp_args(config: config, _testfile: &Path) -> ProcArgs {
-        let prog = config.rustc_path;
+    fn make_pp_args(config: &config, _testfile: &Path) -> ProcArgs {
         let args = ~[~"-", ~"--pretty", ~"normal"];
-        return ProcArgs {prog: prog.to_str(), args: args};
+        return ProcArgs {prog: config.rustc_path.to_str(), args: args};
     }
 
-    fn compare_source(expected: ~str, actual: ~str) {
+    fn compare_source(expected: &str, actual: &str) {
         if expected != actual {
             error(~"pretty-printed source does not match expected source");
             let msg =
@@ -207,46 +207,45 @@ actual:\n\
         }
     }
 
-    fn typecheck_source(config: config, props: TestProps,
+    fn typecheck_source(config: &config, props: &TestProps,
                         testfile: &Path, src: ~str) -> ProcRes {
-        compose_and_run_compiler(
-            config, props, testfile,
-            make_typecheck_args(config, props, testfile),
-            Some(src))
+        let args = make_typecheck_args(config, props, testfile);
+        compose_and_run_compiler(config, props, testfile, args, Some(src))
     }
 
-    fn make_typecheck_args(config: config, props: TestProps, testfile: &Path) -> ProcArgs {
-        let prog = config.rustc_path;
+    fn make_typecheck_args(config: &config, props: &TestProps, testfile: &Path) -> ProcArgs {
         let mut args = ~[~"-",
                          ~"--no-trans", ~"--lib",
                          ~"-L", config.build_base.to_str(),
                          ~"-L",
                          aux_output_dir_name(config, testfile).to_str()];
-        args += split_maybe_args(config.rustcflags);
-        args += split_maybe_args(props.compile_flags);
-        return ProcArgs {prog: prog.to_str(), args: args};
+        args += split_maybe_args(&config.rustcflags);
+        args += split_maybe_args(&props.compile_flags);
+        return ProcArgs {prog: config.rustc_path.to_str(), args: args};
     }
 }
 
-fn run_debuginfo_test(config: config, props: TestProps, testfile: &Path) {
+fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
     // do not optimize debuginfo tests
-    let config = match config.rustcflags {
-        Some(flags) => config {
-            rustcflags: Some(str::replace(flags, ~"-O", ~"")),
-            .. config
+    let mut config = match config.rustcflags {
+        Some(ref flags) => config {
+            rustcflags: Some(str::replace(*flags, ~"-O", ~"")),
+            .. copy *config
         },
-        None => config
+        None => copy *config
     };
+    let config = &mut config;
+    let cmds = str::connect(props.debugger_cmds, "\n");
+    let check_lines = copy props.check_lines;
 
     // compile test file (it shoud have 'compile-flags:-g' in the header)
     let mut ProcRes = compile_test(config, props, testfile);
     if ProcRes.status != 0 {
-        fatal_ProcRes(~"compilation failed!", ProcRes);
+        fatal_ProcRes(~"compilation failed!", &ProcRes);
     }
 
     // write debugger script
-    let script_str = str::append(str::connect(props.debugger_cmds, "\n"),
-                                 ~"\nquit\n");
+    let script_str = str::append(cmds, "\nquit\n");
     debug!("script_str = %s", script_str);
     dump_output_file(config, testfile, script_str, ~"debugger.script");
 
@@ -265,13 +264,13 @@ fn run_debuginfo_test(config: config, props: TestProps, testfile: &Path) {
         fatal(~"gdb failed to execute");
     }
 
-    let num_check_lines = vec::len(props.check_lines);
+    let num_check_lines = vec::len(check_lines);
     if num_check_lines > 0 {
         // check if each line in props.check_lines appears in the
         // output (in order)
         let mut i = 0u;
         for str::each_line(ProcRes.stdout) |line| {
-            if props.check_lines[i].trim() == line.trim() {
+            if check_lines[i].trim() == line.trim() {
                 i += 1u;
             }
             if i == num_check_lines {
@@ -281,14 +280,14 @@ fn run_debuginfo_test(config: config, props: TestProps, testfile: &Path) {
         }
         if i != num_check_lines {
             fatal_ProcRes(fmt!("line not found in debugger output: %s"
-                               props.check_lines[i]), ProcRes);
+                               check_lines[i]), &ProcRes);
         }
     }
 }
 
-fn check_error_patterns(props: TestProps,
+fn check_error_patterns(props: &TestProps,
                         testfile: &Path,
-                        ProcRes: ProcRes) {
+                        ProcRes: &ProcRes) {
     if vec::is_empty(props.error_patterns) {
         fatal(~"no error pattern specified in " + testfile.to_str());
     }
@@ -298,18 +297,18 @@ fn check_error_patterns(props: TestProps,
     }
 
     let mut next_err_idx = 0u;
-    let mut next_err_pat = props.error_patterns[next_err_idx];
+    let mut next_err_pat = &props.error_patterns[next_err_idx];
     let mut done = false;
     for str::each_line(ProcRes.stderr) |line| {
-        if str::contains(line, next_err_pat) {
-            debug!("found error pattern %s", next_err_pat);
+        if str::contains(line, *next_err_pat) {
+            debug!("found error pattern %s", *next_err_pat);
             next_err_idx += 1u;
             if next_err_idx == vec::len(props.error_patterns) {
                 debug!("found all error patterns");
                 done = true;
                 break;
             }
-            next_err_pat = props.error_patterns[next_err_idx];
+            next_err_pat = &props.error_patterns[next_err_idx];
         }
     }
     if done { return; }
@@ -330,7 +329,7 @@ fn check_error_patterns(props: TestProps,
 
 fn check_expected_errors(expected_errors: ~[errors::ExpectedError],
                          testfile: &Path,
-                         ProcRes: ProcRes) {
+                         ProcRes: &ProcRes) {
 
     // true if we found the error in question
     let mut found_flags = vec::from_elem(
@@ -380,14 +379,14 @@ fn check_expected_errors(expected_errors: ~[errors::ExpectedError],
 
     for uint::range(0u, vec::len(found_flags)) |i| {
         if !found_flags[i] {
-            let ee = expected_errors[i];
+            let ee = &expected_errors[i];
             fatal_ProcRes(fmt!("expected %s on line %u not found: %s",
                                ee.kind, ee.line, ee.msg), ProcRes);
         }
     }
 }
 
-fn is_compiler_error_or_warning(line: ~str) -> bool {
+fn is_compiler_error_or_warning(line: &str) -> bool {
     let mut i = 0u;
     return
         scan_until_char(line, ':', &mut i) &&
@@ -401,11 +400,11 @@ fn is_compiler_error_or_warning(line: ~str) -> bool {
         scan_char(line, ':', &mut i) &&
         scan_integer(line, &mut i) &&
         scan_char(line, ' ', &mut i) &&
-        (scan_string(line, ~"error", &mut i) ||
-         scan_string(line, ~"warning", &mut i));
+        (scan_string(line, "error", &mut i) ||
+         scan_string(line, "warning", &mut i));
 }
 
-fn scan_until_char(haystack: ~str, needle: char, idx: &mut uint) -> bool {
+fn scan_until_char(haystack: &str, needle: char, idx: &mut uint) -> bool {
     if *idx >= haystack.len() {
         return false;
     }
@@ -417,7 +416,7 @@ fn scan_until_char(haystack: ~str, needle: char, idx: &mut uint) -> bool {
     return true;
 }
 
-fn scan_char(haystack: ~str, needle: char, idx: &mut uint) -> bool {
+fn scan_char(haystack: &str, needle: char, idx: &mut uint) -> bool {
     if *idx >= haystack.len() {
         return false;
     }
@@ -429,7 +428,7 @@ fn scan_char(haystack: ~str, needle: char, idx: &mut uint) -> bool {
     return true;
 }
 
-fn scan_integer(haystack: ~str, idx: &mut uint) -> bool {
+fn scan_integer(haystack: &str, idx: &mut uint) -> bool {
     let mut i = *idx;
     while i < haystack.len() {
         let range = str::char_range_at(haystack, i);
@@ -445,7 +444,7 @@ fn scan_integer(haystack: ~str, idx: &mut uint) -> bool {
     return true;
 }
 
-fn scan_string(haystack: ~str, needle: ~str, idx: &mut uint) -> bool {
+fn scan_string(haystack: &str, needle: &str, idx: &mut uint) -> bool {
     let mut haystack_i = *idx;
     let mut needle_i = 0u;
     while needle_i < needle.len() {
@@ -466,34 +465,29 @@ struct ProcArgs {prog: ~str, args: ~[~str]}
 
 struct ProcRes {status: int, stdout: ~str, stderr: ~str, cmdline: ~str}
 
-fn compile_test(config: config, props: TestProps,
+fn compile_test(config: &config, props: &TestProps,
                 testfile: &Path) -> ProcRes {
     compile_test_(config, props, testfile, [])
 }
 
-fn jit_test(config: config, props: TestProps, testfile: &Path) -> ProcRes {
+fn jit_test(config: &config, props: &TestProps, testfile: &Path) -> ProcRes {
     compile_test_(config, props, testfile, [~"--jit"])
 }
 
-fn compile_test_(config: config, props: TestProps,
+fn compile_test_(config: &config, props: &TestProps,
                  testfile: &Path, extra_args: &[~str]) -> ProcRes {
     let link_args = ~[~"-L", aux_output_dir_name(config, testfile).to_str()];
-    compose_and_run_compiler(
-        config, props, testfile,
-        make_compile_args(config, props, link_args + extra_args,
-                          make_exe_name, testfile),
-        None)
+    let args = make_compile_args(config, props, link_args + extra_args,
+                                 make_exe_name, testfile);
+    compose_and_run_compiler(config, props, testfile, args, None)
 }
 
-fn exec_compiled_test(config: config, props: TestProps,
+fn exec_compiled_test(config: &config, props: &TestProps,
                       testfile: &Path) -> ProcRes {
 
     // If testing the new runtime then set the RUST_NEWRT env var
-    let env = if config.newrt {
-        props.exec_env + ~[(~"RUST_NEWRT", ~"1")]
-    } else {
-        props.exec_env
-    };
+    let env = copy props.exec_env;
+    let env = if config.newrt { env + &[(~"RUST_NEWRT", ~"1")] } else { env };
 
     match config.target {
 
@@ -515,8 +509,8 @@ fn exec_compiled_test(config: config, props: TestProps,
 }
 
 fn compose_and_run_compiler(
-    config: config,
-    props: TestProps,
+    config: &config,
+    props: &TestProps,
     testfile: &Path,
     args: ProcArgs,
     input: Option<~str>) -> ProcRes {
@@ -539,7 +533,7 @@ fn compose_and_run_compiler(
             fatal_ProcRes(
                 fmt!("auxiliary build of %s failed to compile: ",
                      abs_ab.to_str()),
-                auxres);
+                &auxres);
         }
 
         match config.target {
@@ -565,74 +559,66 @@ fn ensure_dir(path: &Path) {
     }
 }
 
-fn compose_and_run(config: config, testfile: &Path,
-                   ProcArgs: ProcArgs,
+fn compose_and_run(config: &config, testfile: &Path,
+                   ProcArgs{ args, prog }: ProcArgs,
                    procenv: ~[(~str, ~str)],
-                   lib_path: ~str,
+                   lib_path: &str,
                    input: Option<~str>) -> ProcRes {
     return program_output(config, testfile, lib_path,
-                       ProcArgs.prog, ProcArgs.args, procenv, input);
+                          prog, args, procenv, input);
 }
 
-fn make_compile_args(config: config, props: TestProps, extras: ~[~str],
-                     xform: &fn(config, (&Path)) -> Path,
+fn make_compile_args(config: &config, props: &TestProps, extras: ~[~str],
+                     xform: &fn(&config, (&Path)) -> Path,
                      testfile: &Path) -> ProcArgs {
-    let prog = config.rustc_path;
     let mut args = ~[testfile.to_str(),
                      ~"-o", xform(config, testfile).to_str(),
                      ~"-L", config.build_base.to_str()]
         + extras;
-    args += split_maybe_args(config.rustcflags);
-    args += split_maybe_args(props.compile_flags);
-    return ProcArgs {prog: prog.to_str(), args: args};
+    args += split_maybe_args(&config.rustcflags);
+    args += split_maybe_args(&props.compile_flags);
+    return ProcArgs {prog: config.rustc_path.to_str(), args: args};
 }
 
-fn make_lib_name(config: config, auxfile: &Path, testfile: &Path) -> Path {
+fn make_lib_name(config: &config, auxfile: &Path, testfile: &Path) -> Path {
     // what we return here is not particularly important, as it
     // happens; rustc ignores everything except for the directory.
     let auxname = output_testname(auxfile);
     aux_output_dir_name(config, testfile).push_rel(&auxname)
 }
 
-fn make_exe_name(config: config, testfile: &Path) -> Path {
+fn make_exe_name(config: &config, testfile: &Path) -> Path {
     Path(output_base_name(config, testfile).to_str() +
             str::to_owned(os::EXE_SUFFIX))
 }
 
-fn make_run_args(config: config, _props: TestProps, testfile: &Path) ->
+fn make_run_args(config: &config, _props: &TestProps, testfile: &Path) ->
    ProcArgs {
-    let toolargs = {
-            // If we've got another tool to run under (valgrind),
-            // then split apart its command
-            let runtool =
-                match config.runtool {
-                  Some(s) => Some(s),
-                  None => None
-                };
-            split_maybe_args(runtool)
-        };
+    // If we've got another tool to run under (valgrind),
+    // then split apart its command
+    let toolargs = split_maybe_args(&config.runtool);
 
-    let args = toolargs + ~[make_exe_name(config, testfile).to_str()];
-    return ProcArgs {prog: args[0],
-                     args: vec::slice(args, 1, args.len()).to_vec()};
+    let mut args = toolargs + ~[make_exe_name(config, testfile).to_str()];
+    let prog = args.shift();
+    return ProcArgs {prog: prog, args: args};
 }
 
-fn split_maybe_args(argstr: Option<~str>) -> ~[~str] {
+fn split_maybe_args(argstr: &Option<~str>) -> ~[~str] {
     fn rm_whitespace(v: ~[~str]) -> ~[~str] {
         v.filtered(|s| !str::is_whitespace(*s))
     }
 
-    match argstr {
-        Some(s) => {
+    match *argstr {
+        Some(ref s) => {
             let mut ss = ~[];
-            for str::each_split_char(s, ' ') |s| { ss.push(s.to_owned()) }
+            for str::each_split_char(*s, ' ') |s| { ss.push(s.to_owned()) }
             rm_whitespace(ss)
         }
         None => ~[]
     }
 }
 
-fn program_output(config: config, testfile: &Path, lib_path: ~str, prog: ~str,
+fn program_output(config: &config, testfile: &Path, lib_path: &str, prog: ~str,
                   args: ~[~str], env: ~[(~str, ~str)],
                   input: Option<~str>) -> ProcRes {
     let cmdline =
@@ -641,11 +627,12 @@ fn program_output(config: config, testfile: &Path, lib_path: ~str, prog: ~str,
             logv(config, fmt!("executing %s", cmdline));
             cmdline
         };
-    let res = procsrv::run(lib_path, prog, args, env, input);
-    dump_output(config, testfile, res.out, res.err);
-    return ProcRes {status: res.status,
-         stdout: res.out,
-         stderr: res.err,
+    let procsrv::Result{ out, err, status } =
+            procsrv::run(lib_path, prog, args, env, input);
+    dump_output(config, testfile, out, err);
+    return ProcRes {status: status,
+         stdout: out,
+         stderr: err,
          cmdline: cmdline};
 }
 
@@ -653,41 +640,41 @@ fn program_output(config: config, testfile: &Path, lib_path: ~str, prog: ~str,
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "freebsd")]
-fn make_cmdline(_libpath: ~str, prog: ~str, args: ~[~str]) -> ~str {
+fn make_cmdline(_libpath: &str, prog: &str, args: &[~str]) -> ~str {
     fmt!("%s %s", prog, str::connect(args, ~" "))
 }
 
 #[cfg(target_os = "win32")]
-fn make_cmdline(libpath: ~str, prog: ~str, args: ~[~str]) -> ~str {
+fn make_cmdline(libpath: &str, prog: &str, args: &[~str]) -> ~str {
     fmt!("%s %s %s", lib_path_cmd_prefix(libpath), prog,
          str::connect(args, ~" "))
 }
 
 // Build the LD_LIBRARY_PATH variable as it would be seen on the command line
 // for diagnostic purposes
-fn lib_path_cmd_prefix(path: ~str) -> ~str {
+fn lib_path_cmd_prefix(path: &str) -> ~str {
     fmt!("%s=\"%s\"", util::lib_path_env_var(), util::make_new_path(path))
 }
 
-fn dump_output(config: config, testfile: &Path, out: ~str, err: ~str) {
-    dump_output_file(config, testfile, out, ~"out");
-    dump_output_file(config, testfile, err, ~"err");
+fn dump_output(config: &config, testfile: &Path, out: &str, err: &str) {
+    dump_output_file(config, testfile, out, "out");
+    dump_output_file(config, testfile, err, "err");
     maybe_dump_to_stdout(config, out, err);
 }
 
-fn dump_output_file(config: config, testfile: &Path,
-                    out: ~str, extension: ~str) {
+fn dump_output_file(config: &config, testfile: &Path,
+                    out: &str, extension: &str) {
     let outfile = make_out_name(config, testfile, extension);
     let writer =
         io::file_writer(&outfile, ~[io::Create, io::Truncate]).get();
     writer.write_str(out);
 }
 
-fn make_out_name(config: config, testfile: &Path, extension: ~str) -> Path {
+fn make_out_name(config: &config, testfile: &Path, extension: &str) -> Path {
     output_base_name(config, testfile).with_filetype(extension)
 }
 
-fn aux_output_dir_name(config: config, testfile: &Path) -> Path {
+fn aux_output_dir_name(config: &config, testfile: &Path) -> Path {
     output_base_name(config, testfile).with_filetype("libaux")
 }
 
@@ -695,13 +682,13 @@ fn output_testname(testfile: &Path) -> Path {
     Path(testfile.filestem().get())
 }
 
-fn output_base_name(config: config, testfile: &Path) -> Path {
+fn output_base_name(config: &config, testfile: &Path) -> Path {
     config.build_base
         .push_rel(&output_testname(testfile))
         .with_filetype(config.stage_id)
 }
 
-fn maybe_dump_to_stdout(config: config, out: ~str, err: ~str) {
+fn maybe_dump_to_stdout(config: &config, out: &str, err: &str) {
     if config.verbose {
         let sep1 = fmt!("------%s------------------------------", ~"stdout");
         let sep2 = fmt!("------%s------------------------------", ~"stderr");
@@ -718,7 +705,7 @@ fn error(err: ~str) { io::stdout().write_line(fmt!("\nerror: %s", err)); }
 
 fn fatal(err: ~str) -> ! { error(err); fail!(); }
 
-fn fatal_ProcRes(err: ~str, ProcRes: ProcRes) -> ! {
+fn fatal_ProcRes(err: ~str, ProcRes: &ProcRes) -> ! {
     let msg =
         fmt!("\n\
 error: %s\n\
@@ -737,21 +724,20 @@ stderr:\n\
     fail!();
 }
 
-fn _arm_exec_compiled_test(config: config, props: TestProps,
+fn _arm_exec_compiled_test(config: &config, props: &TestProps,
                       testfile: &Path) -> ProcRes {
 
     let args = make_run_args(config, props, testfile);
-    let cmdline = make_cmdline(~"", args.prog, args.args);
+    let cmdline = make_cmdline("", args.prog, args.args);
 
     // get bare program string
     let mut tvec = ~[];
-    let tstr = args.prog;
-    for str::each_split_char(tstr, '/') |ts| { tvec.push(ts.to_owned()) }
+    for str::each_split_char(args.prog, '/') |ts| { tvec.push(ts.to_owned()) }
     let prog_short = tvec.pop();
 
     // copy to target
-    let copy_result = procsrv::run(~"", config.adb_path,
-        ~[~"push", args.prog, config.adb_test_dir],
+    let copy_result = procsrv::run("", config.adb_path,
+        [~"push", copy args.prog, copy config.adb_test_dir],
         ~[(~"",~"")], Some(~""));
 
     if config.verbose {
@@ -767,7 +753,6 @@ fn _arm_exec_compiled_test(config: config, props: TestProps,
     // to stdout and stderr separately but to stdout only
     let mut newargs_out = ~[];
     let mut newargs_err = ~[];
-    let subargs = args.args;
     newargs_out.push(~"shell");
     newargs_err.push(~"shell");
 
@@ -780,7 +765,7 @@ fn _arm_exec_compiled_test(config: config, props: TestProps,
     newcmd_err.push_str(fmt!("LD_LIBRARY_PATH=%s %s/%s",
         config.adb_test_dir, config.adb_test_dir, prog_short));
 
-    for vec::each(subargs) |tv| {
+    for args.args.each |tv| {
         newcmd_out.push_str(" ");
         newcmd_err.push_str(" ");
         newcmd_out.push_str(tv.to_owned());
@@ -793,26 +778,28 @@ fn _arm_exec_compiled_test(config: config, props: TestProps,
     newargs_out.push(newcmd_out);
     newargs_err.push(newcmd_err);
 
-    let exe_result_out = procsrv::run(~"", config.adb_path,
-        newargs_out, ~[(~"",~"")], Some(~""));
-    let exe_result_err = procsrv::run(~"", config.adb_path,
-        newargs_err, ~[(~"",~"")], Some(~""));
+    let procsrv::Result{ out: out_out, err: _out_err, status: out_status } =
+            procsrv::run(~"", config.adb_path, newargs_out, ~[(~"",~"")],
+                         Some(~""));
+    let procsrv::Result{ out: err_out, err: _err_err, status: _err_status } =
+            procsrv::run(~"", config.adb_path, newargs_err, ~[(~"",~"")],
+                         Some(~""));
 
-    dump_output(config, testfile, exe_result_out.out, exe_result_err.out);
+    dump_output(config, testfile, out_out, err_out);
 
-    match exe_result_err.out {
-        ~"" => ProcRes {status: exe_result_out.status, stdout: exe_result_out.out,
-            stderr: exe_result_err.out, cmdline: cmdline },
-        _   => ProcRes {status: 101, stdout: exe_result_out.out,
-            stderr: exe_result_err.out, cmdline: cmdline }
+    match err_out {
+        ~"" => ProcRes {status: out_status, stdout: out_out,
+            stderr: err_out, cmdline: cmdline },
+        _   => ProcRes {status: 101, stdout: out_out,
+            stderr: err_out, cmdline: cmdline }
     }
 }
 
-fn _dummy_exec_compiled_test(config: config, props: TestProps,
+fn _dummy_exec_compiled_test(config: &config, props: &TestProps,
                       testfile: &Path) -> ProcRes {
 
     let args = make_run_args(config, props, testfile);
-    let cmdline = make_cmdline(~"", args.prog, args.args);
+    let cmdline = make_cmdline("", args.prog, args.args);
 
     match config.mode {
         mode_run_fail => ProcRes {status: 101, stdout: ~"",
@@ -822,7 +809,7 @@ fn _dummy_exec_compiled_test(config: config, props: TestProps,
     }
 }
 
-fn _arm_push_aux_shared_library(config: config, testfile: &Path) {
+fn _arm_push_aux_shared_library(config: &config, testfile: &Path) {
     let tstr = aux_output_dir_name(config, testfile).to_str();
 
     for os::list_dir_path(&Path(tstr)).each |file| {
@@ -830,7 +817,7 @@ fn _arm_push_aux_shared_library(config: config, testfile: &Path) {
         if (file.filetype() == Some(~".so")) {
 
             let copy_result = procsrv::run(~"", config.adb_path,
-                ~[~"push", file.to_str(), config.adb_test_dir],
+                ~[~"push", file.to_str(), copy config.adb_test_dir],
                 ~[(~"",~"")], Some(~""));
 
             if config.verbose {

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -12,7 +12,7 @@ use common::config;
 
 use core::os::getenv;
 
-pub fn make_new_path(path: ~str) -> ~str {
+pub fn make_new_path(path: &str) -> ~str {
 
     // Windows just uses PATH as the library search path, so we have to
     // maintain the current value while adding our own
@@ -20,7 +20,7 @@ pub fn make_new_path(path: ~str) -> ~str {
       Some(curr) => {
         fmt!("%s%s%s", path, path_div(), curr)
       }
-      None => path
+      None => path.to_str()
     }
 }
 
@@ -42,7 +42,7 @@ pub fn path_div() -> ~str { ~":" }
 #[cfg(target_os = "win32")]
 pub fn path_div() -> ~str { ~";" }
 
-pub fn logv(config: config, s: ~str) {
+pub fn logv(config: &config, s: ~str) {
     debug!("%s", s);
     if config.verbose { io::println(s); }
 }

--- a/src/etc/extract-tests.py
+++ b/src/etc/extract-tests.py
@@ -60,7 +60,6 @@ while cur < len(lines):
             if not re.search(r"\bextern mod std\b", block):
                 block = "extern mod std;\n" + block
             block = """#[ forbid(ctypes) ];
-#[ forbid(deprecated_mode) ];
 #[ forbid(deprecated_pattern) ];
 #[ forbid(implicit_copies) ];
 #[ forbid(non_implicitly_copyable_typarams) ];
@@ -68,12 +67,9 @@ while cur < len(lines):
 #[ forbid(type_limits) ];
 #[ forbid(unrecognized_lint) ];
 #[ forbid(unused_imports) ];
-#[ forbid(vecs_implicitly_copyable) ];
 #[ forbid(while_true) ];
 
-#[ warn(deprecated_self) ];
-#[ warn(non_camel_case_types) ];
-#[ warn(structural_records) ];\n
+#[ warn(non_camel_case_types) ];\n
 """ + block
             if xfail:
                 block = "// xfail-test\n" + block

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -134,7 +134,7 @@ pub fn stash_expr_if(c: @fn(@ast::expr, test_mode)->bool,
                      e: @ast::expr,
                      tm: test_mode) {
     if c(e, tm) {
-        *es += ~[e];
+        *es = *es + ~[e];
     } else {
         /* now my indices are wrong :( */
     }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -51,7 +51,6 @@ pub enum lint {
     implicit_copies,
     unrecognized_lint,
     non_implicitly_copyable_typarams,
-    vecs_implicitly_copyable,
     deprecated_pattern,
     non_camel_case_types,
     type_limits,
@@ -129,14 +128,6 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
      LintSpec {
         lint: non_implicitly_copyable_typarams,
         desc: "passing non implicitly copyable types as copy type params",
-        default: warn
-     }),
-
-    ("vecs_implicitly_copyable",
-     LintSpec {
-        lint: vecs_implicitly_copyable,
-        desc: "make vecs and strs not implicitly copyable \
-              (only checked at top level)",
         default: warn
      }),
 

--- a/src/librustc/util/enum_set.rs
+++ b/src/librustc/util/enum_set.rs
@@ -102,7 +102,6 @@ impl<E:CLike> BitAnd<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
 
 #[cfg(test)]
 mod test {
-    use core;
     use core::iter;
     use util::enum_set::*;
 

--- a/src/librustdoc/attr_pass.rs
+++ b/src/librustdoc/attr_pass.rs
@@ -103,7 +103,7 @@ fn parse_item_attrs<T:Owned>(
     id: doc::AstId,
     parse_attrs: ~fn(a: ~[ast::attribute]) -> T) -> T {
     do astsrv::exec(srv) |ctxt| {
-        let attrs = match *ctxt.ast_map.get(&id) {
+        let attrs = match ctxt.ast_map.get_copy(&id) {
             ast_map::node_item(item, _) => copy item.attrs,
             ast_map::node_foreign_item(item, _, _, _) => copy item.attrs,
             _ => fail!("parse_item_attrs: not an item")
@@ -127,7 +127,7 @@ fn fold_enum(
             let desc = {
                 let variant = copy variant;
                 do astsrv::exec(srv.clone()) |ctxt| {
-                    match *ctxt.ast_map.get(&doc_id) {
+                    match ctxt.ast_map.get_copy(&doc_id) {
                         ast_map::node_item(@ast::item {
                             node: ast::item_enum(ref enum_definition, _), _
                         }, _) => {
@@ -177,7 +177,7 @@ fn merge_method_attrs(
 
     // Create an assoc list from method name to attributes
     let attrs: ~[(~str, Option<~str>)] = do astsrv::exec(srv) |ctxt| {
-        match *ctxt.ast_map.get(&item_id) {
+        match ctxt.ast_map.get_copy(&item_id) {
             ast_map::node_item(@ast::item {
                 node: ast::item_trait(_, _, ref methods), _
             }, _) => {

--- a/src/librustdoc/prune_hidden_pass.rs
+++ b/src/librustdoc/prune_hidden_pass.rs
@@ -53,7 +53,7 @@ fn is_hidden(srv: astsrv::Srv, doc: doc::ItemDoc) -> bool {
 
     let id = doc.id;
     do astsrv::exec(srv) |ctxt| {
-        let attrs = match *ctxt.ast_map.get(&id) {
+        let attrs = match ctxt.ast_map.get_copy(&id) {
           ast_map::node_item(item, _) => copy item.attrs,
           _ => ~[]
         };

--- a/src/librustdoc/prune_private_pass.rs
+++ b/src/librustdoc/prune_private_pass.rs
@@ -55,7 +55,7 @@ fn fold_impl(
     let doc = fold::default_seq_fold_impl(fold, doc);
 
     do astsrv::exec(fold.ctxt.clone()) |ctxt| {
-        match *ctxt.ast_map.get(&doc.item.id) {
+        match ctxt.ast_map.get_copy(&doc.item.id) {
             ast_map::node_item(item, _) => {
                 match item.node {
                     ast::item_impl(_, None, _, ref methods) => {
@@ -134,7 +134,7 @@ fn is_visible(srv: astsrv::Srv, doc: doc::ItemDoc) -> bool {
     let id = doc.id;
 
     do astsrv::exec(srv) |ctxt| {
-        match *ctxt.ast_map.get(&id) {
+        match ctxt.ast_map.get_copy(&id) {
             ast_map::node_item(item, _) => {
                 match &item.node {
                     &ast::item_impl(*) => {

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -63,7 +63,7 @@ fn fold_fn(
 
 fn get_fn_sig(srv: astsrv::Srv, fn_id: doc::AstId) -> Option<~str> {
     do astsrv::exec(srv) |ctxt| {
-        match *ctxt.ast_map.get(&fn_id) {
+        match ctxt.ast_map.get_copy(&fn_id) {
             ast_map::node_item(@ast::item {
                 ident: ident,
                 node: ast::item_fn(ref decl, purity, _, ref tys, _), _
@@ -90,7 +90,7 @@ fn fold_const(
         sig: Some({
             let doc = copy doc;
             do astsrv::exec(srv) |ctxt| {
-                match *ctxt.ast_map.get(&doc.id()) {
+                match ctxt.ast_map.get_copy(&doc.id()) {
                     ast_map::node_item(@ast::item {
                         node: ast::item_const(ty, _), _
                     }, _) => {
@@ -115,7 +115,7 @@ fn fold_enum(
             let sig = {
                 let variant = copy *variant;
                 do astsrv::exec(srv.clone()) |ctxt| {
-                    match *ctxt.ast_map.get(&doc_id) {
+                    match ctxt.ast_map.get_copy(&doc_id) {
                         ast_map::node_item(@ast::item {
                             node: ast::item_enum(ref enum_definition, _), _
                         }, _) => {
@@ -170,7 +170,7 @@ fn get_method_sig(
     method_name: ~str
 ) -> Option<~str> {
     do astsrv::exec(srv) |ctxt| {
-        match *ctxt.ast_map.get(&item_id) {
+        match ctxt.ast_map.get_copy(&item_id) {
             ast_map::node_item(@ast::item {
                 node: ast::item_trait(_, _, ref methods), _
             }, _) => {
@@ -241,7 +241,7 @@ fn fold_impl(
     let (bounds, trait_types, self_ty) = {
         let doc = copy doc;
         do astsrv::exec(srv) |ctxt| {
-            match *ctxt.ast_map.get(&doc.id()) {
+            match ctxt.ast_map.get_copy(&doc.id()) {
                 ast_map::node_item(@ast::item {
                     node: ast::item_impl(ref generics, opt_trait_type, self_ty, _), _
                 }, _) => {
@@ -280,7 +280,7 @@ fn fold_type(
         sig: {
             let doc = copy doc;
             do astsrv::exec(srv) |ctxt| {
-                match *ctxt.ast_map.get(&doc.id()) {
+                match ctxt.ast_map.get_copy(&doc.id()) {
                     ast_map::node_item(@ast::item {
                         ident: ident,
                         node: ast::item_ty(ty, ref params), _
@@ -312,7 +312,7 @@ fn fold_struct(
         sig: {
             let doc = copy doc;
             do astsrv::exec(srv) |ctxt| {
-                match *ctxt.ast_map.get(&doc.id()) {
+                match ctxt.ast_map.get_copy(&doc.id()) {
                     ast_map::node_item(item, _) => {
                         let item = strip_struct_extra_stuff(item);
                         Some(pprust::item_to_str(item,

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -125,7 +125,7 @@ fn fold_enum(
                             }.get();
 
                             pprust::variant_to_str(
-                                ast_variant, extract::interner())
+                                &ast_variant, extract::interner())
                         }
                         _ => fail!("enum variant not bound to an enum item")
                     }

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -18,14 +18,12 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-#[allow(vecs_implicitly_copyable,
-        non_implicitly_copyable_typarams)];
-
 extern mod std(vers = "0.7-pre");
 extern mod rustc(vers = "0.7-pre");
 extern mod syntax(vers = "0.7-pre");
 
 use core::*;
+use core::cell::Cell;
 use rustc::driver::{driver, session};
 use syntax::{ast, diagnostic};
 use syntax::ast_util::*;
@@ -71,8 +69,8 @@ fn with_pp(intr: @token::ident_interner,
  * because it has to parse the statements and view_items on each
  * input.
  */
-fn record(repl: Repl, blk: @ast::blk, intr: @token::ident_interner) -> Repl {
-    let view_items = if blk.node.view_items.len() > 0 {
+fn record(mut repl: Repl, blk: &ast::blk, intr: @token::ident_interner) -> Repl {
+    if blk.node.view_items.len() > 0 {
         let new_view_items = do with_pp(intr) |pp, writer| {
             for blk.node.view_items.each |view_item| {
                 pprust::print_view_item(pp, *view_item);
@@ -82,9 +80,9 @@ fn record(repl: Repl, blk: @ast::blk, intr: @token::ident_interner) -> Repl {
 
         debug!("new view items %s", new_view_items);
 
-        repl.view_items + "\n" + new_view_items
-    } else { repl.view_items };
-    let stmts = if blk.node.stmts.len() > 0 {
+        repl.view_items = repl.view_items + "\n" + new_view_items
+    }
+    if blk.node.stmts.len() > 0 {
         let new_stmts = do with_pp(intr) |pp, writer| {
             for blk.node.stmts.each |stmt| {
                 match stmt.node {
@@ -105,24 +103,21 @@ fn record(repl: Repl, blk: @ast::blk, intr: @token::ident_interner) -> Repl {
 
         debug!("new stmts %s", new_stmts);
 
-        repl.stmts + "\n" + new_stmts
-    } else { repl.stmts };
-
-    Repl{
-        view_items: view_items,
-        stmts: stmts,
-        .. repl
+        repl.stmts = repl.stmts + "\n" + new_stmts
     }
+
+    return repl;
 }
 
 /// Run an input string in a Repl, returning the new Repl.
 fn run(repl: Repl, input: ~str) -> Repl {
+    let binary = @copy repl.binary;
     let options = @session::options {
         crate_type: session::unknown_crate,
-        binary: @repl.binary,
+        binary: binary,
         addl_lib_search_paths: repl.lib_search_paths.map(|p| Path(*p)),
         jit: true,
-        .. *session::basic_options()
+        .. copy *session::basic_options()
     };
 
     debug!("building driver input");
@@ -138,7 +133,7 @@ fn run(repl: Repl, input: ~str) -> Repl {
 
     debug!("building driver configuration");
     let cfg = driver::build_configuration(sess,
-                                          @repl.binary,
+                                          binary,
                                           &wrapped);
 
     let outputs = driver::build_output_filenames(&wrapped, &None, &None, sess);
@@ -151,7 +146,7 @@ fn run(repl: Repl, input: ~str) -> Repl {
 
     for crate.node.module.items.each |item| {
         match item.node {
-            ast::item_fn(_, _, _, _, blk) => {
+            ast::item_fn(_, _, _, _, ref blk) => {
                 if item.ident == sess.ident_of("main") {
                     opt = blk.node.expr;
                 }
@@ -160,10 +155,11 @@ fn run(repl: Repl, input: ~str) -> Repl {
         }
     }
 
-    let blk = match opt.get().node {
-        ast::expr_call(_, exprs, _) => {
+    let e = opt.unwrap();
+    let blk = match e.node {
+        ast::expr_call(_, ref exprs, _) => {
             match exprs[0].node {
-                ast::expr_block(blk) => @blk,
+                ast::expr_block(ref blk) => blk,
                 _ => fail!()
             }
         }
@@ -182,15 +178,16 @@ fn run(repl: Repl, input: ~str) -> Repl {
 fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
     match do task::try {
         let src_path = Path(src_filename);
+        let binary = @copy binary;
         let options = @session::options {
-            binary: @binary,
+            binary: binary,
             addl_lib_search_paths: ~[os::getcwd()],
-            .. *session::basic_options()
+            .. copy *session::basic_options()
         };
-        let input = driver::file_input(src_path);
+        let input = driver::file_input(copy src_path);
         let sess = driver::build_session(options, diagnostic::emit);
         *sess.building_library = true;
-        let cfg = driver::build_configuration(sess, @binary, &input);
+        let cfg = driver::build_configuration(sess, binary, &input);
         let outputs = driver::build_output_filenames(
             &input, &None, &None, sess);
         // If the library already exists and is newer than the source
@@ -233,7 +230,7 @@ fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
 
 /// Tries to get a line from rl after outputting a prompt. Returns
 /// None if no input was read (e.g. EOF was reached).
-fn get_line(use_rl: bool, prompt: ~str) -> Option<~str> {
+fn get_line(use_rl: bool, prompt: &str) -> Option<~str> {
     if use_rl {
         let result = unsafe { rl::read(prompt) };
 
@@ -280,11 +277,11 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
             for args.each |arg| {
                 let (crate, filename) =
                     if arg.ends_with(".rs") || arg.ends_with(".rc") {
-                    (arg.substr(0, arg.len() - 3).to_owned(), *arg)
+                    (arg.substr(0, arg.len() - 3).to_owned(), copy *arg)
                 } else {
-                    (*arg, arg + ~".rs")
+                    (copy *arg, arg + ".rs")
                 };
-                match compile_crate(filename, repl.binary) {
+                match compile_crate(filename, copy repl.binary) {
                     Some(_) => loaded_crates.push(crate),
                     None => { }
                 }
@@ -311,7 +308,7 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
             let mut multiline_cmd = ~"";
             let mut end_multiline = false;
             while (!end_multiline) {
-                match get_line(use_rl, ~"rusti| ") {
+                match get_line(use_rl, "rusti| ") {
                     None => fail!("unterminated multiline command :{ .. :}"),
                     Some(line) => {
                         if str::trim(line) == ~":}" {
@@ -334,14 +331,14 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
 fn run_line(repl: &mut Repl, in: @io::Reader, out: @io::Writer, line: ~str,
             use_rl: bool)
     -> Option<Repl> {
-    if line.starts_with(~":") {
+    if line.starts_with(":") {
         let full = line.substr(1, line.len() - 1);
         let mut split = ~[];
         for str::each_word(full) |word| { split.push(word.to_owned()) }
         let len = split.len();
 
         if len > 0 {
-            let cmd = split[0];
+            let cmd = copy split[0];
 
             if !cmd.is_empty() {
                 let args = if len > 1 {
@@ -361,9 +358,10 @@ fn run_line(repl: &mut Repl, in: @io::Reader, out: @io::Writer, line: ~str,
         }
     }
 
-    let r = *repl;
+    let line = Cell(line);
+    let r = Cell(copy *repl);
     let result = do task::try {
-        run(r, line)
+        run(r.take(), line.take())
     };
 
     if result.is_ok() {
@@ -378,7 +376,7 @@ pub fn main() {
     let out = io::stdout();
     let mut repl = Repl {
         prompt: ~"rusti> ",
-        binary: args[0],
+        binary: copy args[0],
         running: true,
         view_items: ~"",
         lib_search_paths: ~[],

--- a/src/librusti/wrapper.rs
+++ b/src/librusti/wrapper.rs
@@ -13,13 +13,15 @@
 #[allow(implicit_copies)];
 #[allow(managed_heap_memory)];
 #[allow(non_camel_case_types)];
-#[allow(non_implicitly_copyable_typarams)];
 #[allow(owned_heap_memory)];
 #[allow(path_statement)];
 #[allow(unrecognized_lint)];
 #[allow(unused_imports)];
-#[allow(vecs_implicitly_copyable)];
 #[allow(while_true)];
+#[allow(dead_assignment)];
+#[allow(unused_variable)];
+#[allow(unused_unsafe)];
+#[allow(unused_mut)];
 
 extern mod std;
 

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -55,21 +55,21 @@ pub fn normalize(p: ~Path) -> ~Path {
 
 /// True if there's a directory in <workspace> with
 /// pkgid's short name
-pub fn workspace_contains_package_id(pkgid: PkgId, workspace: &Path) -> bool {
+pub fn workspace_contains_package_id(pkgid: &PkgId, workspace: &Path) -> bool {
     let pkgpath = workspace.push("src").push(pkgid.path.to_str());
     os::path_is_dir(&pkgpath)
 }
 
 /// Return the directory for <pkgid>'s source files in <workspace>.
 /// Doesn't check that it exists.
-pub fn pkgid_src_in_workspace(pkgid: PkgId, workspace: &Path) -> Path {
+pub fn pkgid_src_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
     let result = workspace.push("src");
     result.push(pkgid.path.to_str())
 }
 
 /// Figure out what the executable name for <pkgid> in <workspace>'s build
 /// directory is, and if the file exists, return it.
-pub fn built_executable_in_workspace(pkgid: PkgId, workspace: &Path) -> Option<Path> {
+pub fn built_executable_in_workspace(pkgid: &PkgId, workspace: &Path) -> Option<Path> {
     let mut result = workspace.push("build");
     result = result.push_rel(&pkgid.path);
     // should use a target-specific subdirectory
@@ -87,7 +87,7 @@ pub fn built_executable_in_workspace(pkgid: PkgId, workspace: &Path) -> Option<P
 
 /// Figure out what the library name for <pkgid> in <workspace>'s build
 /// directory is, and if the file exists, return it.
-pub fn built_library_in_workspace(pkgid: PkgId, workspace: &Path) -> Option<Path> {
+pub fn built_library_in_workspace(pkgid: &PkgId, workspace: &Path) -> Option<Path> {
     let mut result = workspace.push("build");
     result = result.push_rel(&pkgid.path);
     // should use a target-specific subdirectory
@@ -159,7 +159,7 @@ pub fn built_library_in_workspace(pkgid: PkgId, workspace: &Path) -> Option<Path
 /// Returns the executable that would be installed for <pkgid>
 /// in <workspace>
 /// As a side effect, creates the bin-dir if it doesn't exist
-pub fn target_executable_in_workspace(pkgid: PkgId, workspace: &Path) -> Path {
+pub fn target_executable_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
     target_file_in_workspace(pkgid, workspace, Main)
 }
 
@@ -167,23 +167,23 @@ pub fn target_executable_in_workspace(pkgid: PkgId, workspace: &Path) -> Path {
 /// Returns the executable that would be installed for <pkgid>
 /// in <workspace>
 /// As a side effect, creates the bin-dir if it doesn't exist
-pub fn target_library_in_workspace(pkgid: PkgId, workspace: &Path) -> Path {
+pub fn target_library_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
     target_file_in_workspace(pkgid, workspace, Lib)
 }
 
 /// Returns the test executable that would be installed for <pkgid>
 /// in <workspace>
-pub fn target_test_in_workspace(pkgid: PkgId, workspace: &Path) -> Path {
+pub fn target_test_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
     target_file_in_workspace(pkgid, workspace, Test)
 }
 
 /// Returns the bench executable that would be installed for <pkgid>
 /// in <workspace>
-pub fn target_bench_in_workspace(pkgid: PkgId, workspace: &Path) -> Path {
+pub fn target_bench_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
     target_file_in_workspace(pkgid, workspace, Bench)
 }
 
-fn target_file_in_workspace(pkgid: PkgId, workspace: &Path,
+fn target_file_in_workspace(pkgid: &PkgId, workspace: &Path,
                             what: OutputType) -> Path {
     use conditions::bad_path::cond;
 
@@ -193,7 +193,8 @@ fn target_file_in_workspace(pkgid: PkgId, workspace: &Path,
     let result = workspace.push(subdir);
     if create_dir {
         if !os::path_exists(&result) && !mkdir_recursive(&result, u_rwx) {
-            cond.raise((result, fmt!("I couldn't create the %s dir", subdir)));
+            cond.raise((copy result,
+                        fmt!("I couldn't create the %s dir", subdir)));
         }
     }
     mk_output_path(what, pkgid.path.to_str(), result)
@@ -202,13 +203,13 @@ fn target_file_in_workspace(pkgid: PkgId, workspace: &Path,
 
 /// Return the directory for <pkgid>'s build artifacts in <workspace>.
 /// Creates it if it doesn't exist.
-pub fn build_pkg_id_in_workspace(pkgid: PkgId, workspace: &Path) -> Path {
+pub fn build_pkg_id_in_workspace(pkgid: &PkgId, workspace: &Path) -> Path {
     use conditions::bad_path::cond;
 
     let mut result = workspace.push("build");
     // n.b. Should actually use a target-specific
     // subdirectory of build/
-    result = result.push(normalize(~pkgid.path).to_str());
+    result = result.push(normalize(~copy pkgid.path).to_str());
     if os::path_exists(&result) || os::mkdir_recursive(&result, u_rwx) {
         result
     }

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -17,8 +17,6 @@
 
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
-#[allow(vecs_implicitly_copyable,
-        non_implicitly_copyable_typarams)];
 
 extern mod std(vers = "0.7-pre");
 extern mod rustc(vers = "0.7-pre");
@@ -52,9 +50,9 @@ pub mod usage;
 /// A PkgScript represents user-supplied custom logic for
 /// special build hooks. This only exists for packages with
 /// an explicit package script.
-struct PkgScript {
+struct PkgScript<'self> {
     /// Uniquely identifies this package
-    id: PkgId,
+    id: &'self PkgId,
     // Used to have this field:    deps: ~[(~str, Option<~str>)]
     // but I think it shouldn't be stored here
     /// The contents of the package script: either a file path,
@@ -71,24 +69,24 @@ struct PkgScript {
     build_dir: Path
 }
 
-impl PkgScript {
+impl<'self> PkgScript<'self> {
     /// Given the path name for a package script
     /// and a package ID, parse the package script into
     /// a PkgScript that we can then execute
-    fn parse(script: Path, workspace: &Path, id: PkgId) -> PkgScript {
+    fn parse<'a>(script: Path, workspace: &Path, id: &'a PkgId) -> PkgScript<'a> {
         // Get the executable name that was invoked
-        let binary = os::args()[0];
+        let binary = @copy os::args()[0];
         // Build the rustc session data structures to pass
         // to the compiler
         let options = @session::options {
-            binary: @binary,
+            binary: binary,
             crate_type: session::bin_crate,
-            .. *session::basic_options()
+            .. copy *session::basic_options()
         };
         let input = driver::file_input(script);
         let sess = driver::build_session(options, diagnostic::emit);
-        let cfg = driver::build_configuration(sess, @binary, &input);
-        let (crate, _) = driver::compile_upto(sess, cfg, &input,
+        let cfg = driver::build_configuration(sess, binary, &input);
+        let (crate, _) = driver::compile_upto(sess, copy cfg, &input,
                                               driver::cu_parse, None);
         let work_dir = build_pkg_id_in_workspace(id, workspace);
 
@@ -123,10 +121,10 @@ impl PkgScript {
                 let root = r.pop().pop().pop().pop(); // :-\
                 debug!("Root is %s, calling compile_rest", root.to_str());
                 let exe = self.build_dir.push(~"pkg" + util::exe_suffix());
-                util::compile_crate_from_input(self.input, self.id,
-                                               Some(self.build_dir),
+                util::compile_crate_from_input(&self.input, self.id,
+                                               Some(copy self.build_dir),
                                                sess, Some(crate),
-                                               exe, os::args()[0],
+                                               &exe, @copy os::args()[0],
                                                driver::cu_everything);
                 debug!("Running program: %s %s %s", exe.to_str(), root.to_str(), what);
                 let status = run::run_program(exe.to_str(), ~[root.to_str(), what]);
@@ -188,9 +186,9 @@ impl Ctx {
                 }
                 // The package id is presumed to be the first command-line
                 // argument
-                let pkgid = PkgId::new(args[0]);
-                for pkg_parent_workspaces(pkgid) |workspace| {
-                    self.build(workspace, pkgid);
+                let pkgid = PkgId::new(copy args[0]);
+                for pkg_parent_workspaces(&pkgid) |workspace| {
+                    self.build(workspace, &pkgid);
                 }
             }
             ~"clean" => {
@@ -199,16 +197,16 @@ impl Ctx {
                 }
                 // The package id is presumed to be the first command-line
                 // argument
-                let pkgid = PkgId::new(args[0]);
+                let pkgid = PkgId::new(copy args[0]);
                 let cwd = os::getcwd();
-                self.clean(&cwd, pkgid); // tjc: should use workspace, not cwd
+                self.clean(&cwd, &pkgid); // tjc: should use workspace, not cwd
             }
             ~"do" => {
                 if args.len() < 2 {
                     return usage::do_cmd();
                 }
 
-                self.do_cmd(args[0], args[1]);
+                self.do_cmd(copy args[0], copy args[1]);
             }
             ~"info" => {
                 self.info();
@@ -221,8 +219,8 @@ impl Ctx {
                 // The package id is presumed to be the first command-line
                 // argument
                 let pkgid = PkgId::new(args[0]);
-                for pkg_parent_workspaces(pkgid) |workspace| {
-                    self.install(workspace, pkgid);
+                for pkg_parent_workspaces(&pkgid) |workspace| {
+                    self.install(workspace, &pkgid);
                 }
             }
             ~"prefer" => {
@@ -230,7 +228,7 @@ impl Ctx {
                     return usage::uninstall();
                 }
 
-                let (name, vers) = sep_name_vers(args[0]);
+                let (name, vers) = sep_name_vers(copy args[0]);
 
                 self.prefer(name.get(), vers);
             }
@@ -242,7 +240,7 @@ impl Ctx {
                     return usage::uninstall();
                 }
 
-                let (name, vers) = sep_name_vers(args[0]);
+                let (name, vers) = sep_name_vers(copy args[0]);
 
                 self.uninstall(name.get(), vers);
             }
@@ -251,7 +249,7 @@ impl Ctx {
                     return usage::uninstall();
                 }
 
-                let (name, vers) = sep_name_vers(args[0]);
+                let (name, vers) = sep_name_vers(copy args[0]);
 
                 self.unprefer(name.get(), vers);
             }
@@ -259,18 +257,18 @@ impl Ctx {
         }
     }
 
-    fn do_cmd(&self, _cmd: ~str, _pkgname: ~str)  {
+    fn do_cmd(&self, _cmd: &str, _pkgname: &str)  {
         // stub
         fail!("`do` not yet implemented");
     }
 
-    fn build(&self, workspace: &Path, pkgid: PkgId) {
+    fn build(&self, workspace: &Path, pkgid: &PkgId) {
         let src_dir   = pkgid_src_in_workspace(pkgid, workspace);
         let build_dir = build_pkg_id_in_workspace(pkgid, workspace);
         debug!("Destination dir = %s", build_dir.to_str());
 
         // Create the package source
-        let mut src = PkgSrc::new(&workspace.push("src"), &build_dir, &pkgid);
+        let mut src = PkgSrc::new(&workspace.push("src"), &build_dir, pkgid);
         debug!("Package src = %?", src);
 
         // Is there custom build logic? If so, use it
@@ -311,7 +309,7 @@ impl Ctx {
 
     }
 
-    fn clean(&self, workspace: &Path, id: PkgId)  {
+    fn clean(&self, workspace: &Path, id: &PkgId)  {
         // Could also support a custom build hook in the pkg
         // script for cleaning files rustpkg doesn't know about.
         // Do something reasonable for now
@@ -332,7 +330,7 @@ impl Ctx {
         fail!("info not yet implemented");
     }
 
-    fn install(&self, workspace: &Path, id: PkgId)  {
+    fn install(&self, workspace: &Path, id: &PkgId)  {
         use conditions::copy_failed::cond;
 
         // Should use RUST_PATH in the future.
@@ -348,13 +346,13 @@ impl Ctx {
         for maybe_executable.each |exec| {
             debug!("Copying: %s -> %s", exec.to_str(), target_exec.to_str());
             if !os::copy_file(exec, &target_exec) {
-                cond.raise((*exec, target_exec));
+                cond.raise((copy *exec, copy target_exec));
             }
         }
         for maybe_library.each |lib| {
             debug!("Copying: %s -> %s", lib.to_str(), target_lib.to_str());
             if !os::copy_file(lib, &target_lib) {
-                cond.raise((*lib, target_lib));
+                cond.raise((copy *lib, copy target_lib));
             }
         }
     }
@@ -387,7 +385,7 @@ impl Ctx {
         }
     }
 
-    fn fetch_git(&self, dir: &Path, url: ~str, target: Option<~str>)  {
+    fn fetch_git(&self, dir: &Path, url: ~str, mut target: Option<~str>)  {
         util::note(fmt!("fetching from %s using git", url));
 
         // Git can't clone into a non-empty directory
@@ -405,7 +403,7 @@ impl Ctx {
             do util::temp_change_dir(dir) {
                 success = run::program_output(~"git",
                                               ~[~"checkout",
-                                                target.get()]).status != 0
+                                                target.swap_unwrap()]).status != 0
             }
 
             if !success {
@@ -525,7 +523,7 @@ pub struct Listener {
 }
 
 pub fn run(listeners: ~[Listener]) {
-    let rcmd = os::args()[2];
+    let rcmd = copy os::args()[2];
     let mut found = false;
 
     for listeners.each |listener| {
@@ -652,12 +650,12 @@ impl PkgSrc {
         // tjc: Rather than erroring out, need to try downloading the
         // contents of the path to a local directory (#5679)
         if !os::path_exists(&dir) {
-            cond.raise((self.id, ~"missing package dir"));
+            cond.raise((copy self.id, ~"missing package dir"));
         }
 
         if !os::path_is_dir(&dir) {
-            cond.raise((self.id, ~"supplied path for package dir is a \
-                                   non-directory"));
+            cond.raise((copy self.id, ~"supplied path for package dir is a \
+                                        non-directory"));
         }
 
         dir
@@ -681,7 +679,7 @@ impl PkgSrc {
     /// Requires that dashes in p have already been normalized to
     /// underscores
     fn stem_matches(&self, p: &Path) -> bool {
-        let self_id = normalize(~self.id.path).filestem();
+        let self_id = normalize(~copy self.id.path).filestem();
         if self_id == p.filestem() {
             return true;
         }
@@ -737,7 +735,7 @@ impl PkgSrc {
             util::note(~"Couldn't infer any crates to build.\n\
                          Try naming a crate `main.rs`, `lib.rs`, \
                          `test.rs`, or `bench.rs`.");
-            cond.raise(self.id);
+            cond.raise(copy self.id);
         }
 
         debug!("found %u libs, %u mains, %u tests, %u benchs",
@@ -752,7 +750,7 @@ impl PkgSrc {
                     dst_dir: &Path,
                     src_dir: &Path,
                     crates: &[Crate],
-                    cfgs: ~[~str],
+                    cfgs: &[~str],
                     test: bool, crate_type: crate_type) {
 
         for crates.each |&crate| {
@@ -760,7 +758,7 @@ impl PkgSrc {
             util::note(fmt!("build_crates: compiling %s", path.to_str()));
             util::note(fmt!("build_crates: destination dir is %s", dst_dir.to_str()));
 
-            let result = util::compile_crate(maybe_sysroot, self.id, path,
+            let result = util::compile_crate(maybe_sysroot, &self.id, path,
                                      dst_dir,
                                      crate.flags,
                                      crate.cfgs + cfgs,

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -41,6 +41,7 @@ use context::Ctx;
 mod conditions;
 mod context;
 mod path_util;
+#[cfg(test)]
 mod tests;
 mod util;
 mod workspace;

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -77,7 +77,6 @@ fn is_rwx(p: &Path) -> bool {
     }
 }
 
-#[cfg(test)]
 fn test_sysroot() -> Path {
     // Totally gross hack but it's just for test cases.
     // Infer the sysroot from the exe name and tack "stage2"
@@ -107,19 +106,19 @@ fn test_install_valid() {
     let temp_pkg_id = fake_pkg();
     let temp_workspace = mk_temp_workspace(&temp_pkg_id.path);
     // should have test, bench, lib, and main
-    ctxt.install(&temp_workspace, temp_pkg_id);
+    ctxt.install(&temp_workspace, &temp_pkg_id);
     // Check that all files exist
-    let exec = target_executable_in_workspace(temp_pkg_id, &temp_workspace);
+    let exec = target_executable_in_workspace(&temp_pkg_id, &temp_workspace);
     debug!("exec = %s", exec.to_str());
     assert!(os::path_exists(&exec));
     assert!(is_rwx(&exec));
-    let lib = target_library_in_workspace(temp_pkg_id, &temp_workspace);
+    let lib = target_library_in_workspace(&temp_pkg_id, &temp_workspace);
     debug!("lib = %s", lib.to_str());
     assert!(os::path_exists(&lib));
     assert!(is_rwx(&lib));
     // And that the test and bench executables aren't installed
-    assert!(!os::path_exists(&target_test_in_workspace(temp_pkg_id, &temp_workspace)));
-    let bench = target_bench_in_workspace(temp_pkg_id, &temp_workspace);
+    assert!(!os::path_exists(&target_test_in_workspace(&temp_pkg_id, &temp_workspace)));
+    let bench = target_bench_in_workspace(&temp_pkg_id, &temp_workspace);
     debug!("bench = %s", bench.to_str());
     assert!(!os::path_exists(&bench));
 }
@@ -140,7 +139,7 @@ fn test_install_invalid() {
         do cond.trap(|_| {
             error_occurred = true;
         }).in {
-            ctxt.install(&temp_workspace, pkgid);
+            ctxt.install(&temp_workspace, &pkgid);
         }
     }
     assert!(error_occurred && error1_occurred);
@@ -155,19 +154,19 @@ fn test_install_url() {
     let temp_pkg_id = remote_pkg();
     let temp_workspace = mk_temp_workspace(&temp_pkg_id.path);
     // should have test, bench, lib, and main
-    ctxt.install(&temp_workspace, temp_pkg_id);
+    ctxt.install(&temp_workspace, &temp_pkg_id);
     // Check that all files exist
-    let exec = target_executable_in_workspace(temp_pkg_id, &temp_workspace);
+    let exec = target_executable_in_workspace(&temp_pkg_id, &temp_workspace);
     debug!("exec = %s", exec.to_str());
     assert!(os::path_exists(&exec));
     assert!(is_rwx(&exec));
-    let lib = target_library_in_workspace(temp_pkg_id, &temp_workspace);
+    let lib = target_library_in_workspace(&temp_pkg_id, &temp_workspace);
     debug!("lib = %s", lib.to_str());
     assert!(os::path_exists(&lib));
     assert!(is_rwx(&lib));
     // And that the test and bench executables aren't installed
-    assert!(!os::path_exists(&target_test_in_workspace(temp_pkg_id, &temp_workspace)));
-    let bench = target_bench_in_workspace(temp_pkg_id, &temp_workspace);
+    assert!(!os::path_exists(&target_test_in_workspace(&temp_pkg_id, &temp_workspace)));
+    let bench = target_bench_in_workspace(&temp_pkg_id, &temp_workspace);
     debug!("bench = %s", bench.to_str());
     assert!(!os::path_exists(&bench));
 }

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -23,7 +23,7 @@ use syntax::codemap::{dummy_sp, spanned, dummy_spanned};
 use syntax::ext::base::{mk_ctxt, ext_ctxt};
 use syntax::ext::build;
 use syntax::{ast, attr, codemap, diagnostic, fold};
-use syntax::ast::{meta_name_value, meta_list, attribute, crate_};
+use syntax::ast::{meta_name_value, meta_list, attribute};
 use syntax::attr::{mk_attr};
 use rustc::back::link::output_type_exe;
 use rustc::driver::session::{lib_crate, unknown_crate, crate_type};

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -28,6 +28,11 @@ use syntax::attr::{mk_attr};
 use rustc::back::link::output_type_exe;
 use rustc::driver::session::{lib_crate, unknown_crate, crate_type};
 
+static Commands: &'static [&'static str] =
+    &["build", "clean", "do", "info", "install", "prefer", "test", "uninstall",
+      "unprefer"];
+
+
 pub type ExitCode = int; // For now
 
 /// A version is either an exact revision,
@@ -41,28 +46,28 @@ impl Ord for Version {
     fn lt(&self, other: &Version) -> bool {
         match (self, other) {
             (&ExactRevision(f1), &ExactRevision(f2)) => f1 < f2,
-            (&SemVersion(v1), &SemVersion(v2)) => v1 < v2,
+            (&SemVersion(ref v1), &SemVersion(ref v2)) => v1 < v2,
             _ => false // incomparable, really
         }
     }
     fn le(&self, other: &Version) -> bool {
         match (self, other) {
             (&ExactRevision(f1), &ExactRevision(f2)) => f1 <= f2,
-            (&SemVersion(v1), &SemVersion(v2)) => v1 <= v2,
+            (&SemVersion(ref v1), &SemVersion(ref v2)) => v1 <= v2,
             _ => false // incomparable, really
         }
     }
     fn ge(&self, other: &Version) -> bool {
         match (self, other) {
             (&ExactRevision(f1), &ExactRevision(f2)) => f1 > f2,
-            (&SemVersion(v1), &SemVersion(v2)) => v1 > v2,
+            (&SemVersion(ref v1), &SemVersion(ref v2)) => v1 > v2,
             _ => false // incomparable, really
         }
     }
     fn gt(&self, other: &Version) -> bool {
         match (self, other) {
             (&ExactRevision(f1), &ExactRevision(f2)) => f1 >= f2,
-            (&SemVersion(v1), &SemVersion(v2)) => v1 >= v2,
+            (&SemVersion(ref v1), &SemVersion(ref v2)) => v1 >= v2,
             _ => false // incomparable, really
         }
     }
@@ -72,8 +77,8 @@ impl Ord for Version {
 impl ToStr for Version {
     fn to_str(&self) -> ~str {
         match *self {
-            ExactRevision(n) => n.to_str(),
-            SemVersion(v) => v.to_str()
+            ExactRevision(ref n) => n.to_str(),
+            SemVersion(ref v) => v.to_str()
         }
     }
 }
@@ -147,11 +152,8 @@ pub fn root() -> Path {
     }
 }
 
-pub fn is_cmd(cmd: ~str) -> bool {
-    let cmds = &[~"build", ~"clean", ~"do", ~"info", ~"install", ~"prefer",
-                 ~"test", ~"uninstall", ~"unprefer"];
-
-    vec::contains(cmds, &cmd)
+pub fn is_cmd(cmd: &str) -> bool {
+    Commands.any(|&c| c == cmd)
 }
 
 pub fn parse_name(id: ~str) -> result::Result<~str, ~str> {
@@ -220,7 +222,7 @@ fn fold_item(ctx: @mut ReadyCtx,
 
         for attrs.each |attr| {
             match attr.node.value.node {
-                ast::meta_list(_, mis) => {
+                ast::meta_list(_, ref mis) => {
                     for mis.each |mi| {
                         match mi.node {
                             ast::meta_word(cmd) => cmds.push(copy *cmd),
@@ -266,15 +268,14 @@ fn add_pkg_module(ctx: @mut ReadyCtx, m: ast::_mod) -> ast::_mod {
 }
 
 fn mk_listener_vec(ctx: @mut ReadyCtx) -> @ast::expr {
-    let fns = ctx.fns;
-    let descs = do fns.map |listener| {
-        mk_listener_rec(ctx, *listener)
+    let descs = do ctx.fns.map |listener| {
+        mk_listener_rec(ctx, listener)
     };
     let ext_cx = ctx.ext_cx;
     build::mk_slice_vec_e(ext_cx, dummy_sp(), descs)
 }
 
-fn mk_listener_rec(ctx: @mut ReadyCtx, listener: ListenerFn) -> @ast::expr {
+fn mk_listener_rec(ctx: @mut ReadyCtx, listener: &ListenerFn) -> @ast::expr {
     let span = listener.span;
     let cmds = do listener.cmds.map |&cmd| {
         let ext_cx = ctx.ext_cx;
@@ -437,11 +438,11 @@ pub fn add_pkg(pkg: &Pkg) -> bool {
 
 // FIXME (#4432): Use workcache to only compile when needed
 pub fn compile_input(sysroot: Option<@Path>,
-                     pkg_id: PkgId,
+                     pkg_id: &PkgId,
                      in_file: &Path,
                      out_dir: &Path,
-                     flags: ~[~str],
-                     cfgs: ~[~str],
+                     flags: &[~str],
+                     cfgs: &[~str],
                      opt: bool,
                      test: bool,
                      crate_type: session::crate_type) -> bool {
@@ -456,7 +457,7 @@ pub fn compile_input(sysroot: Option<@Path>,
     // tjc: by default, use the package ID name as the link name
     // not sure if we should support anything else
 
-    let binary = os::args()[0];
+    let binary = @copy os::args()[0];
     let building_library = match crate_type {
         lib_crate | unknown_crate => true,
         _ => false
@@ -485,32 +486,27 @@ pub fn compile_input(sysroot: Option<@Path>,
                           + flags
                           + cfgs.flat_map(|&c| { ~[~"--cfg", c] }),
                           driver::optgroups()).get();
-    let options = @session::options {
+    let mut options = session::options {
         crate_type: crate_type,
         optimize: if opt { session::Aggressive } else { session::No },
         test: test,
         maybe_sysroot: sysroot,
         addl_lib_search_paths: ~[copy *out_dir],
-        .. *driver::build_session_options(@binary, &matches, diagnostic::emit)
-    };
-    let mut crate_cfg = options.cfg;
-
-    for cfgs.each |&cfg| {
-        crate_cfg.push(attr::mk_word_item(@cfg));
-    }
-
-    let options = @session::options {
-        cfg: vec::append(options.cfg, crate_cfg),
         // output_type should be conditional
         output_type: output_type_exe, // Use this to get a library? That's weird
-        .. *options
+        .. copy *driver::build_session_options(binary, &matches, diagnostic::emit)
     };
-    let sess = driver::build_session(options, diagnostic::emit);
+
+    for cfgs.each |&cfg| {
+        options.cfg.push(attr::mk_word_item(@cfg));
+    }
+
+    let sess = driver::build_session(@options, diagnostic::emit);
 
     debug!("calling compile_crate_from_input, out_dir = %s,
            building_library = %?", out_dir.to_str(), sess.building_library);
-    let _ = compile_crate_from_input(input, pkg_id, Some(*out_dir), sess, None,
-                                     out_file, binary,
+    let _ = compile_crate_from_input(&input, pkg_id, Some(copy *out_dir), sess,
+                                     None, &out_file, binary,
                                      driver::cu_everything);
     true
 }
@@ -520,18 +516,19 @@ pub fn compile_input(sysroot: Option<@Path>,
 // If crate_opt is present, then finish compilation. If it's None, then
 // call compile_upto and return the crate
 // also, too many arguments
-pub fn compile_crate_from_input(input: driver::input,
-                                pkg_id: PkgId,
+pub fn compile_crate_from_input(input: &driver::input,
+                                pkg_id: &PkgId,
                                 build_dir_opt: Option<Path>,
                                 sess: session::Session,
                                 crate_opt: Option<@ast::crate>,
-                                out_file: Path,
-                                binary: ~str,
+                                out_file: &Path,
+                                binary: @~str,
                                 what: driver::compile_upto) -> @ast::crate {
     debug!("Calling build_output_filenames with %? and %s", build_dir_opt, out_file.to_str());
-    let outputs = driver::build_output_filenames(&input, &build_dir_opt, &Some(out_file), sess);
+    let outputs = driver::build_output_filenames(input, &build_dir_opt,
+                                                 &Some(copy *out_file), sess);
     debug!("Outputs are %? and output type = %?", outputs, sess.opts.output_type);
-    let cfg = driver::build_configuration(sess, @binary, &input);
+    let cfg = driver::build_configuration(sess, binary, input);
     match crate_opt {
         Some(c) => {
             debug!("Calling compile_rest, outputs = %?", outputs);
@@ -541,7 +538,7 @@ pub fn compile_crate_from_input(input: driver::input,
         }
         None => {
             debug!("Calling compile_upto, outputs = %?", outputs);
-            let (crate, _) = driver::compile_upto(sess, cfg, &input,
+            let (crate, _) = driver::compile_upto(sess, copy cfg, input,
                                                   driver::cu_parse, Some(outputs));
 
             debug!("About to inject link_meta info...");
@@ -552,7 +549,8 @@ pub fn compile_crate_from_input(input: driver::input,
             debug!("How many attrs? %?", attr::find_linkage_metas(crate.node.attrs).len());
 
             if attr::find_linkage_metas(crate.node.attrs).is_empty() {
-                crate_to_use = add_attrs(*crate, ~[mk_attr(@dummy_spanned(meta_list(@~"link",
+                crate_to_use = add_attrs(copy *crate,
+                    ~[mk_attr(@dummy_spanned(meta_list(@~"link",
                                                   // change PkgId to have a <shortname> field?
                     ~[@dummy_spanned(meta_name_value(@~"name",
                                                     mk_string_lit(@pkg_id.path.filestem().get()))),
@@ -578,20 +576,16 @@ pub fn exe_suffix() -> ~str { ~"" }
 
 /// Returns a copy of crate `c` with attributes `attrs` added to its
 /// attributes
-fn add_attrs(c: ast::crate, new_attrs: ~[attribute]) -> @ast::crate {
-    @spanned {
-        node: crate_ {
-            attrs: c.node.attrs + new_attrs, ..c.node
-        },
-        span: c.span
-    }
+fn add_attrs(mut c: ast::crate, new_attrs: ~[attribute]) -> @ast::crate {
+    c.node.attrs += new_attrs;
+    @c
 }
 
 // Called by build_crates
 // FIXME (#4432): Use workcache to only compile when needed
-pub fn compile_crate(sysroot: Option<@Path>, pkg_id: PkgId,
+pub fn compile_crate(sysroot: Option<@Path>, pkg_id: &PkgId,
                      crate: &Path, dir: &Path,
-                     flags: ~[~str], cfgs: ~[~str], opt: bool,
+                     flags: &[~str], cfgs: &[~str], opt: bool,
                      test: bool, crate_type: crate_type) -> bool {
     debug!("compile_crate: crate=%s, dir=%s", crate.to_str(), dir.to_str());
     debug!("compile_crate: short_name = %s, flags =...", pkg_id.to_str());

--- a/src/librustpkg/workspace.rs
+++ b/src/librustpkg/workspace.rs
@@ -14,7 +14,7 @@ use path_util::{rust_path, workspace_contains_package_id};
 use util::PkgId;
 use core::path::Path;
 
-pub fn pkg_parent_workspaces(pkgid: PkgId, action: &fn(&Path) -> bool) -> bool {
+pub fn pkg_parent_workspaces(pkgid: &PkgId, action: &fn(&Path) -> bool) -> bool {
     // Using the RUST_PATH, find workspaces that contain
     // this package ID
     let workspaces = rust_path().filtered(|ws|

--- a/src/libstd/rl.rs
+++ b/src/libstd/rl.rs
@@ -28,7 +28,7 @@ pub mod rustrt {
 }
 
 /// Add a line to history
-pub unsafe fn add_history(line: ~str) -> bool {
+pub unsafe fn add_history(line: &str) -> bool {
     do str::as_c_str(line) |buf| {
         rustrt::linenoiseHistoryAdd(buf) == 1 as c_int
     }
@@ -40,21 +40,21 @@ pub unsafe fn set_history_max_len(len: int) -> bool {
 }
 
 /// Save line history to a file
-pub unsafe fn save_history(file: ~str) -> bool {
+pub unsafe fn save_history(file: &str) -> bool {
     do str::as_c_str(file) |buf| {
         rustrt::linenoiseHistorySave(buf) == 1 as c_int
     }
 }
 
 /// Load line history from a file
-pub unsafe fn load_history(file: ~str) -> bool {
+pub unsafe fn load_history(file: &str) -> bool {
     do str::as_c_str(file) |buf| {
         rustrt::linenoiseHistoryLoad(buf) == 1 as c_int
     }
 }
 
 /// Print out a prompt and then wait for input and return it
-pub unsafe fn read(prompt: ~str) -> Option<~str> {
+pub unsafe fn read(prompt: &str) -> Option<~str> {
     do str::as_c_str(prompt) |buf| {
         let line = rustrt::linenoise(buf);
 

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -60,12 +60,12 @@ pub fn path_to_str_with_sep(p: &[path_elt], sep: ~str, itr: @ident_interner)
     str::connect(strs, sep)
 }
 
-pub fn path_ident_to_str(p: path, i: ident, itr: @ident_interner) -> ~str {
-    if vec::is_empty(p) {
+pub fn path_ident_to_str(p: &path, i: ident, itr: @ident_interner) -> ~str {
+    if vec::is_empty(*p) {
         //FIXME /* FIXME (#2543) */ copy *i
         copy *itr.get(i)
     } else {
-        fmt!("%s::%s", path_to_str(p, itr), *itr.get(i))
+        fmt!("%s::%s", path_to_str(*p, itr), *itr.get(i))
     }
 }
 
@@ -338,7 +338,7 @@ pub fn node_id_to_str(map: map, id: node_id, itr: @ident_interner) -> ~str {
         fmt!("unknown node (id=%d)", id)
       }
       Some(&node_item(item, path)) => {
-        let path_str = path_ident_to_str(*path, item.ident, itr);
+        let path_str = path_ident_to_str(path, item.ident, itr);
         let item_str = match item.node {
           item_const(*) => ~"const",
           item_fn(*) => ~"fn",
@@ -355,7 +355,7 @@ pub fn node_id_to_str(map: map, id: node_id, itr: @ident_interner) -> ~str {
       }
       Some(&node_foreign_item(item, abi, _, path)) => {
         fmt!("foreign item %s with abi %? (id=%?)",
-             path_ident_to_str(*path, item.ident, itr), abi, id)
+             path_ident_to_str(path, item.ident, itr), abi, id)
       }
       Some(&node_method(m, _, path)) => {
         fmt!("method %s in %s (id=%?)",

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -679,19 +679,19 @@ mod test {
     #[test] fn xorpush_test () {
         let mut s = ~[];
         xorPush(&mut s,14);
-        assert_eq!(s,~[14]);
+        assert_eq!(copy s,~[14]);
         xorPush(&mut s,14);
-        assert_eq!(s,~[]);
+        assert_eq!(copy s,~[]);
         xorPush(&mut s,14);
-        assert_eq!(s,~[14]);
+        assert_eq!(copy s,~[14]);
         xorPush(&mut s,15);
-        assert_eq!(s,~[14,15]);
+        assert_eq!(copy s,~[14,15]);
         xorPush (&mut s,16);
-        assert_eq! (s,~[14,15,16]);
+        assert_eq!(copy s,~[14,15,16]);
         xorPush (&mut s,16);
-        assert_eq! (s,~[14,15]);
+        assert_eq!(copy s,~[14,15]);
         xorPush (&mut s,15);
-        assert_eq! (s,~[14]);
+        assert_eq!(copy s,~[14]);
     }
 
     // convert a list of uints to an @~[ident]
@@ -746,7 +746,7 @@ mod test {
         let mut t = mk_sctable();
 
         let test_sc = ~[M(3),R(id(101,0),14),M(9)];
-        assert_eq!(unfold_test_sc(test_sc,empty_ctxt,&mut t),3);
+        assert_eq!(unfold_test_sc(copy test_sc,empty_ctxt,&mut t),3);
         assert_eq!(t[1],Mark(9,0));
         assert_eq!(t[2],Rename(id(101,0),14,1));
         assert_eq!(t[3],Mark(3,2));

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -184,7 +184,7 @@ fn diagnosticcolor(lvl: level) -> u8 {
     }
 }
 
-fn print_diagnostic(topic: ~str, lvl: level, msg: &str) {
+fn print_diagnostic(topic: &str, lvl: level, msg: &str) {
     let use_color = term::color_supported() &&
         io::stderr().get_type() == io::Screen;
     if !topic.is_empty() {

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -119,13 +119,13 @@ pub fn expand_asm(cx: @ext_ctxt, sp: span, tts: &[ast::token_tree])
                 cons = str::connect(clobs, ",");
             }
             Options => {
-                let option = *p.parse_str();
+                let option = p.parse_str();
 
-                if option == ~"volatile" {
+                if "volatile" == *option {
                     volatile = true;
-                } else if option == ~"alignstack" {
+                } else if "alignstack" == *option {
                     alignstack = true;
-                } else if option == ~"intel" {
+                } else if "intel" == *option {
                     dialect = ast::asm_intel;
                 }
 

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -836,7 +836,7 @@ fn mk_struct_deser_impl(
     cx: @ext_ctxt,
     span: span,
     ident: ast::ident,
-    fields: ~[@ast::struct_field],
+    fields: &[@ast::struct_field],
     generics: &ast::Generics
 ) -> @ast::item {
     let fields = do mk_struct_fields(fields).mapi |idx, field| {
@@ -1120,7 +1120,7 @@ fn mk_enum_deser_body(
     ext_cx: @ext_ctxt,
     span: span,
     name: ast::ident,
-    variants: ~[ast::variant]
+    variants: &[ast::variant]
 ) -> @ast::expr {
     let expr_arm_names = build::mk_base_vec_e(
         ext_cx,

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -509,7 +509,7 @@ pub fn mk_unreachable(cx: @ext_ctxt, span: span) -> @ast::expr {
         ],
         ~[
             mk_base_str(cx, span, ~"internal error: entered unreachable code"),
-            mk_base_str(cx, span, loc.file.name),
+            mk_base_str(cx, span, copy loc.file.name),
             mk_uint(cx, span, loc.line),
         ]
     )

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -60,11 +60,11 @@ fn cs_clone(cx: @ext_ctxt, span: span,
         build::mk_method_call(cx, span, field, clone_ident, ~[]);
 
     match *substr.fields {
-        Struct(af) => {
+        Struct(ref af) => {
             ctor_ident = ~[ substr.type_ident ];
             all_fields = af;
         }
-        EnumMatching(_, variant, af) => {
+        EnumMatching(_, variant, ref af) => {
             ctor_ident = ~[ variant.node.name ];
             all_fields = af;
         },
@@ -72,7 +72,7 @@ fn cs_clone(cx: @ext_ctxt, span: span,
         StaticEnum(*) | StaticStruct(*) => cx.span_bug(span, "Static method in `deriving(Clone)`")
     }
 
-    match all_fields {
+    match *all_fields {
         [(None, _, _), .. _] => {
             // enum-like
             let subcalls = all_fields.map(|&(_, self_f, _)| subcall(self_f));

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -65,8 +65,6 @@ fn cs_ord(less: bool, equal: bool,
     let false_blk_expr = build::mk_block(cx, span,
                                          ~[], ~[],
                                          Some(build::mk_bool(cx, span, false)));
-    let true_blk = build::mk_simple_block(cx, span,
-                                          build::mk_bool(cx, span, true));
     let base = build::mk_bool(cx, span, equal);
 
     cs_fold(
@@ -108,6 +106,8 @@ fn cs_ord(less: bool, equal: bool,
 
             let cmp = build::mk_method_call(cx, span,
                                             self_f, binop, other_fs.to_owned());
+            let true_blk = build::mk_simple_block(cx, span,
+                                                  build::mk_bool(cx, span, true));
             let if_ = expr_if(cmp, true_blk, Some(elseif));
 
             build::mk_expr(cx, span, if_)

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -55,15 +55,16 @@ pub fn ordering_const(cx: @ext_ctxt, span: span, cnst: Ordering) -> @expr {
 
 pub fn cs_cmp(cx: @ext_ctxt, span: span,
               substr: &Substructure) -> @expr {
-    let lexical_ord = ~[cx.ident_of("core"),
-                        cx.ident_of("cmp"),
-                        cx.ident_of("lexical_ordering")];
 
     cs_same_method_fold(
         // foldr (possibly) nests the matches in lexical_ordering better
         false,
         |cx, span, old, new| {
-            build::mk_call_global(cx, span, lexical_ord, ~[old, new])
+            build::mk_call_global(cx, span,
+                                  ~[cx.ident_of("core"),
+                                    cx.ident_of("cmp"),
+                                    cx.ident_of("lexical_ordering")],
+                                  ~[old, new])
         },
         ordering_const(cx, span, Equal),
         |cx, span, list, _| {

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -59,7 +59,7 @@ pub fn expand_meta_deriving(cx: @ext_ctxt,
     use ast::{meta_list, meta_name_value, meta_word};
 
     match mitem.node {
-        meta_name_value(_, l) => {
+        meta_name_value(_, ref l) => {
             cx.span_err(l.span, ~"unexpected value in `deriving`");
             in_items
         }
@@ -67,7 +67,7 @@ pub fn expand_meta_deriving(cx: @ext_ctxt,
             cx.span_warn(mitem.span, ~"empty trait list in `deriving`");
             in_items
         }
-        meta_list(_, titems) => {
+        meta_list(_, ref titems) => {
             do titems.foldr(in_items) |&titem, in_items| {
                 match titem.node {
                     meta_name_value(tname, _) |
@@ -92,9 +92,9 @@ pub fn expand_meta_deriving(cx: @ext_ctxt,
 
                             ~"ToStr" => expand!(to_str::expand_deriving_to_str),
 
-                            tname => {
+                            ref tname => {
                                 cx.span_err(titem.span, fmt!("unknown \
-                                    `deriving` trait: `%s`", tname));
+                                    `deriving` trait: `%s`", *tname));
                                 in_items
                             }
                         }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -662,12 +662,11 @@ mod test {
     #[test] fn fail_exists_test () {
         let src = ~"fn main() { fail!(\"something appropriately gloomy\");}";
         let sess = parse::new_parse_sess(None);
-        let cfg = ~[];
         let crate_ast = parse::parse_crate_from_source_str(
             ~"<test>",
             @src,
-            cfg,sess);
-        expand_crate(sess,cfg,crate_ast);
+            ~[],sess);
+        expand_crate(sess,~[],crate_ast);
     }
 
     // these following tests are quite fragile, in that they don't test what
@@ -679,13 +678,12 @@ mod test {
         let src = ~"fn bogus() {macro_rules! z (() => (3+4))}\
                     fn inty() -> int { z!() }";
         let sess = parse::new_parse_sess(None);
-        let cfg = ~[];
         let crate_ast = parse::parse_crate_from_source_str(
             ~"<test>",
             @src,
-            cfg,sess);
+            ~[],sess);
         // should fail:
-        expand_crate(sess,cfg,crate_ast);
+        expand_crate(sess,~[],crate_ast);
     }
 
     // make sure that macros can leave scope for modules
@@ -694,13 +692,12 @@ mod test {
         let src = ~"mod foo {macro_rules! z (() => (3+4))}\
                     fn inty() -> int { z!() }";
         let sess = parse::new_parse_sess(None);
-        let cfg = ~[];
         let crate_ast = parse::parse_crate_from_source_str(
             ~"<test>",
             @src,
-            cfg,sess);
+            ~[],sess);
         // should fail:
-        expand_crate(sess,cfg,crate_ast);
+        expand_crate(sess,~[],crate_ast);
     }
 
     // macro_escape modules shouldn't cause macros to leave scope
@@ -708,13 +705,12 @@ mod test {
         let src = ~"#[macro_escape] mod foo {macro_rules! z (() => (3+4))}\
                     fn inty() -> int { z!() }";
         let sess = parse::new_parse_sess(None);
-        let cfg = ~[];
         let crate_ast = parse::parse_crate_from_source_str(
             ~"<test>",
             @src,
-            cfg,sess);
+            ~[], sess);
         // should fail:
-        expand_crate(sess,cfg,crate_ast);
+        expand_crate(sess,~[],crate_ast);
     }
 
     #[test] fn core_macros_must_parse () {

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -62,7 +62,7 @@ fn pieces_to_expr(cx: @ext_ctxt, sp: span,
     // which tells the RT::conv* functions how to perform the conversion
 
     fn make_rt_conv_expr(cx: @ext_ctxt, sp: span, cnv: &Conv) -> @ast::expr {
-        fn make_flags(cx: @ext_ctxt, sp: span, flags: ~[Flag]) -> @ast::expr {
+        fn make_flags(cx: @ext_ctxt, sp: span, flags: &[Flag]) -> @ast::expr {
             let mut tmp_expr = make_rt_path_expr(cx, sp, "flag_none");
             for flags.each |f| {
                 let fstr = match *f {

--- a/src/libsyntax/ext/pipes/proto.rs
+++ b/src/libsyntax/ext/pipes/proto.rs
@@ -154,14 +154,14 @@ pub struct protocol_ {
 
 pub impl protocol_ {
     /// Get a state.
-    fn get_state(&self, name: ~str) -> state {
-        self.states.find(|i| i.name == name).get()
+    fn get_state(&self, name: &str) -> state {
+        self.states.find(|i| name == i.name).get()
     }
 
     fn get_state_by_id(&self, id: uint) -> state { self.states[id] }
 
-    fn has_state(&self, name: ~str) -> bool {
-        self.states.find(|i| i.name == name).is_some()
+    fn has_state(&self, name: &str) -> bool {
+        self.states.find(|i| name == i.name).is_some()
     }
 
     fn filename(&self) -> ~str {

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -452,9 +452,9 @@ fn mk_binop(cx: @ext_ctxt, sp: span, bop: token::binop) -> @ast::expr {
                    ids_ext(cx, ~[name.to_owned()]))
 }
 
-fn mk_token(cx: @ext_ctxt, sp: span, tok: token::Token) -> @ast::expr {
+fn mk_token(cx: @ext_ctxt, sp: span, tok: &token::Token) -> @ast::expr {
 
-    match tok {
+    match *tok {
         BINOP(binop) => {
             return build::mk_call(cx, sp,
                                   ids_ext(cx, ~[~"BINOP"]),
@@ -561,7 +561,7 @@ fn mk_token(cx: @ext_ctxt, sp: span, tok: token::Token) -> @ast::expr {
         _ => ()
     }
 
-    let name = match tok {
+    let name = match *tok {
         EQ => "EQ",
         LT => "LT",
         LE => "LE",
@@ -612,7 +612,7 @@ fn mk_tt(cx: @ext_ctxt, sp: span, tt: &ast::token_tree)
             let e_tok =
                 build::mk_call(cx, sp,
                                ids_ext(cx, ~[~"tt_tok"]),
-                               ~[e_sp, mk_token(cx, sp, *tok)]);
+                               ~[e_sp, mk_token(cx, sp, tok)]);
             let e_push =
                 build::mk_method_call(cx, sp,
                                       build::mk_path(cx, sp, ids_ext(cx, ~[~"tt"])),

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -63,19 +63,19 @@ pub fn add_new_extension(cx: @ext_ctxt,
 
     // Extract the arguments:
     let lhses = match *argument_map.get(&lhs_nm) {
-        @matched_seq(ref s, _) => /* FIXME (#2543) */ copy *s,
+        @matched_seq(ref s, _) => /* FIXME (#2543) */ @copy *s,
         _ => cx.span_bug(sp, ~"wrong-structured lhs")
     };
 
     let rhses = match *argument_map.get(&rhs_nm) {
-      @matched_seq(ref s, _) => /* FIXME (#2543) */ copy *s,
+      @matched_seq(ref s, _) => /* FIXME (#2543) */ @copy *s,
       _ => cx.span_bug(sp, ~"wrong-structured rhs")
     };
 
     // Given `lhses` and `rhses`, this is the new macro we create
     fn generic_extension(cx: @ext_ctxt, sp: span, name: ident,
                          arg: &[ast::token_tree],
-                         lhses: ~[@named_match], rhses: ~[@named_match])
+                         lhses: &[@named_match], rhses: &[@named_match])
     -> MacResult {
 
         if cx.trace_macros() {
@@ -93,7 +93,7 @@ pub fn add_new_extension(cx: @ext_ctxt,
         let s_d = cx.parse_sess().span_diagnostic;
         let itr = cx.parse_sess().interner;
 
-        for lhses.eachi() |i, lhs| { // try each arm's matchers
+        for lhses.eachi |i, lhs| { // try each arm's matchers
             match *lhs {
               @matched_nonterminal(nt_matchers(ref mtcs)) => {
                 // `none` is because we're not interpolating
@@ -103,7 +103,7 @@ pub fn add_new_extension(cx: @ext_ctxt,
                     None,
                     vec::to_owned(arg)
                 ) as @reader;
-                match parse(cx.parse_sess(), cx.cfg(), arg_rdr, (*mtcs)) {
+                match parse(cx.parse_sess(), cx.cfg(), arg_rdr, *mtcs) {
                   success(named_matches) => {
                     let rhs = match rhses[i] {
                         // okay, what's your transcriber?
@@ -146,7 +146,7 @@ pub fn add_new_extension(cx: @ext_ctxt,
     }
 
     let exp: @fn(@ext_ctxt, span, &[ast::token_tree]) -> MacResult =
-        |cx, sp, arg| generic_extension(cx, sp, name, arg, lhses, rhses);
+        |cx, sp, arg| generic_extension(cx, sp, name, arg, *lhses, *rhses);
 
     return MRDef(MacroDef{
         name: copy *cx.parse_sess().interner.get(name),

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -192,7 +192,7 @@ fn read_line_comments(rdr: @mut StringReader, code_to_the_left: bool,
 
 // FIXME #3961: This is not the right way to convert string byte
 // offsets to characters.
-fn all_whitespace(s: ~str, begin: uint, end: uint) -> bool {
+fn all_whitespace(s: &str, begin: uint, end: uint) -> bool {
     let mut i: uint = begin;
     while i != end {
         if !is_whitespace(s[i] as char) { return false; } i += 1u;

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -351,15 +351,14 @@ mod test {
     use core::option::None;
     use core::int;
     use core::num::NumCast;
-    use core::path::Path;
-    use codemap::{dummy_sp, CodeMap, span, BytePos, spanned};
+    use codemap::{CodeMap, span, BytePos, spanned};
     use opt_vec;
     use ast;
     use abi;
     use ast_util::mk_ident;
     use parse::parser::Parser;
-    use parse::token::{ident_interner, mk_ident_interner, mk_fresh_ident_interner};
-    use diagnostic::{span_handler, mk_span_handler, mk_handler, Emitter};
+    use parse::token::{ident_interner, mk_fresh_ident_interner};
+    use diagnostic::{mk_span_handler, mk_handler};
 
     // add known names to interner for testing
     fn mk_testing_interner() -> @ident_interner {
@@ -408,7 +407,7 @@ mod test {
 
     // map a string to tts, return the tt without its parsesess
     fn string_to_tts_only(source_str : @~str) -> ~[ast::token_tree] {
-        let (tts,ps) = string_to_tts_t(source_str);
+        let (tts,_ps) = string_to_tts_t(source_str);
         tts
     }
 
@@ -483,7 +482,7 @@ mod test {
     }*/
 
     #[test] fn string_to_tts_1 () {
-        let (tts,ps) = string_to_tts_t(@~"fn a (b : int) { b; }");
+        let (tts,_ps) = string_to_tts_t(@~"fn a (b : int) { b; }");
         assert_eq!(to_json_str(@tts),
                    ~"[\
                 [\"tt_tok\",null,[\"IDENT\",\"fn\",false]],\
@@ -548,7 +547,7 @@ mod test {
     }
 
     fn parser_done(p: Parser){
-        assert_eq!(*p.token,token::EOF);
+        assert_eq!(copy *p.token,token::EOF);
     }
 
     #[test] fn parse_ident_pat () {

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -253,9 +253,9 @@ pub impl Parser {
         }
     }
 
-    fn token_is_obsolete_ident(&self, ident: &str, token: Token) -> bool {
-        match token {
-            token::IDENT(copy sid, _) => {
+    fn token_is_obsolete_ident(&self, ident: &str, token: &Token) -> bool {
+        match *token {
+            token::IDENT(sid, _) => {
                 str::eq_slice(*self.id_to_str(sid), ident)
             }
             _ => false
@@ -263,7 +263,7 @@ pub impl Parser {
     }
 
     fn is_obsolete_ident(&self, ident: &str) -> bool {
-        self.token_is_obsolete_ident(ident, *self.token)
+        self.token_is_obsolete_ident(ident, self.token)
     }
 
     fn eat_obsolete_ident(&self, ident: &str) -> bool {
@@ -289,7 +289,7 @@ pub impl Parser {
     fn try_parse_obsolete_with(&self) -> bool {
         if *self.token == token::COMMA
             && self.token_is_obsolete_ident("with",
-                                            self.look_ahead(1u)) {
+                                            &self.look_ahead(1u)) {
             self.bump();
         }
         if self.eat_obsolete_ident("with") {
@@ -301,13 +301,13 @@ pub impl Parser {
         }
     }
 
-    fn try_parse_obsolete_priv_section(&self, attrs: ~[attribute]) -> bool {
+    fn try_parse_obsolete_priv_section(&self, attrs: &[attribute]) -> bool {
         if self.is_keyword(&~"priv") && self.look_ahead(1) == token::LBRACE {
             self.obsolete(copy *self.span, ObsoletePrivSection);
             self.eat_keyword(&~"priv");
             self.bump();
             while *self.token != token::RBRACE {
-                self.parse_single_struct_field(ast::private, attrs);
+                self.parse_single_struct_field(ast::private, attrs.to_owned());
             }
             self.bump();
             true

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2388,7 +2388,7 @@ pub impl Parser {
                 // preceded by unary-minus) or identifiers.
                 let val = self.parse_literal_maybe_minus();
                 if self.eat(&token::DOTDOT) {
-                    let end = if is_ident_or_path(&tok) {
+                    let end = if is_ident_or_path(tok) {
                         let path = self.parse_path_with_tps(true);
                         let hi = self.span.hi;
                         self.mk_expr(lo, hi, expr_path(path))

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -708,7 +708,7 @@ pub impl Parser {
             self.obsolete(*self.last_span, ObsoleteBareFnType);
             result
         } else if *self.token == token::MOD_SEP
-            || is_ident_or_path(&*self.token) {
+            || is_ident_or_path(self.token) {
             // NAMED TYPE
             let path = self.parse_path_with_tps(false);
             ty_path(path, self.get_id())
@@ -1556,9 +1556,12 @@ pub impl Parser {
                         |p| p.parse_token_tree()
                     );
                     let (s, z) = p.parse_sep_and_zerok();
+                    let seq = match seq {
+                        spanned { node, _ } => node,
+                    };
                     tt_seq(
-                        mk_sp(sp.lo ,p.span.hi),
-                        seq.node,
+                        mk_sp(sp.lo, p.span.hi),
+                        seq,
                         s,
                         z
                     )
@@ -1624,9 +1627,9 @@ pub impl Parser {
             token::LBRACE | token::LPAREN | token::LBRACKET => {
                 self.parse_matcher_subseq(
                     name_idx,
-                    *self.token,
+                    copy *self.token,
                     // tjc: not sure why we need a copy
-                    token::flip_delimiter(&*self.token)
+                    token::flip_delimiter(self.token)
                 )
             }
             _ => self.fatal(~"expected open delimiter")
@@ -1986,14 +1989,15 @@ pub impl Parser {
         // them as the lambda arguments
         let e = self.parse_expr_res(RESTRICT_NO_BAR_OR_DOUBLEBAR_OP);
         match e.node {
-            expr_call(f, args, NoSugar) => {
+            expr_call(f, /*bad*/ copy args, NoSugar) => {
                 let block = self.parse_lambda_block_expr();
                 let last_arg = self.mk_expr(block.span.lo, block.span.hi,
                                             ctor(block));
                 let args = vec::append(args, ~[last_arg]);
                 self.mk_expr(lo.lo, block.span.hi, expr_call(f, args, sugar))
             }
-            expr_method_call(f, i, tps, args, NoSugar) => {
+            expr_method_call(f, i, /*bad*/ copy tps,
+                             /*bad*/ copy args, NoSugar) => {
                 let block = self.parse_lambda_block_expr();
                 let last_arg = self.mk_expr(block.span.lo, block.span.hi,
                                             ctor(block));
@@ -2001,7 +2005,7 @@ pub impl Parser {
                 self.mk_expr(lo.lo, block.span.hi,
                              expr_method_call(f, i, tps, args, sugar))
             }
-            expr_field(f, i, tps) => {
+            expr_field(f, i, /*bad*/ copy tps) => {
                 let block = self.parse_lambda_block_expr();
                 let last_arg = self.mk_expr(block.span.lo, block.span.hi,
                                             ctor(block));
@@ -2259,7 +2263,7 @@ pub impl Parser {
         let lo = self.span.lo;
         let mut hi = self.span.hi;
         let pat;
-        match *self.token {
+        match /*bad*/ copy *self.token {
             // parse _
           token::UNDERSCORE => { self.bump(); pat = pat_wild; }
             // parse @pat
@@ -2373,8 +2377,8 @@ pub impl Parser {
             self.expect(&token::RBRACKET);
             pat = ast::pat_vec(before, slice, after);
           }
-          tok => {
-            if !is_ident_or_path(&tok)
+          ref tok => {
+            if !is_ident_or_path(tok)
                 || self.is_keyword(&~"true")
                 || self.is_keyword(&~"false")
             {
@@ -2897,7 +2901,7 @@ pub impl Parser {
                 loop;
             }
 
-            if is_ident_or_path(&*self.token) {
+            if is_ident_or_path(self.token) {
                 self.obsolete(*self.span,
                               ObsoleteTraitBoundSeparator);
             }
@@ -3531,6 +3535,7 @@ pub impl Parser {
     fn parse_item_mod(&self, outer_attrs: ~[ast::attribute]) -> item_info {
         let id_span = *self.span;
         let id = self.parse_ident();
+        let merge = ::attr::first_attr_value_str_by_name(outer_attrs, "merge");
         let info_ = if *self.token == token::SEMI {
             self.bump();
             // This mod is in an external file. Let's go get it!
@@ -3550,7 +3555,7 @@ pub impl Parser {
         // (int-template, iter-trait). If there's a 'merge' attribute
         // on the mod, then we'll go and suck in another file and merge
         // its contents
-        match ::attr::first_attr_value_str_by_name(outer_attrs, ~"merge") {
+        match merge {
             Some(path) => {
                 let prefix = Path(
                     self.sess.cm.span_to_filename(*self.span));
@@ -3636,10 +3641,7 @@ pub impl Parser {
             new_sub_parser_from_file(self.sess, copy self.cfg,
                                      &full_path, id_sp);
         let (inner, next) = p0.parse_inner_attrs_and_next();
-        let mod_attrs = vec::append(
-            /*bad*/ copy outer_attrs,
-            inner
-        );
+        let mod_attrs = vec::append(outer_attrs, inner);
         let first_item_outer_attrs = next;
         let m0 = p0.parse_mod_items(token::EOF, first_item_outer_attrs);
         return (ast::item_mod(m0), mod_attrs);
@@ -4105,7 +4107,8 @@ pub impl Parser {
         }
         if self.eat_keyword(&~"mod") {
             // MODULE ITEM
-            let (ident, item_, extra_attrs) = self.parse_item_mod(attrs);
+            let (ident, item_, extra_attrs) =
+                self.parse_item_mod(/*bad*/ copy attrs);
             return iovi_item(self.mk_item(lo, self.last_span.hi, ident, item_,
                                           visibility,
                                           maybe_append(attrs, extra_attrs)));

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -457,9 +457,9 @@ pub impl Printer {
             }
         }
     }
-    fn print_str(&mut self, s: ~str) {
+    fn print_str(&mut self, s: &str) {
         while self.pending_indentation > 0 {
-            (*self.out).write_str(~" ");
+            (*self.out).write_str(" ");
             self.pending_indentation -= 1;
         }
         (*self.out).write_str(s);
@@ -562,16 +562,16 @@ pub fn end(p: @mut Printer) { p.pretty_print(END); }
 
 pub fn eof(p: @mut Printer) { p.pretty_print(EOF); }
 
-pub fn word(p: @mut Printer, wrd: ~str) {
-    p.pretty_print(STRING(@/*bad*/ copy wrd, wrd.len() as int));
+pub fn word(p: @mut Printer, wrd: &str) {
+    p.pretty_print(STRING(@/*bad*/ wrd.to_owned(), wrd.len() as int));
 }
 
-pub fn huge_word(p: @mut Printer, wrd: ~str) {
-    p.pretty_print(STRING(@/*bad*/ copy wrd, size_infinity));
+pub fn huge_word(p: @mut Printer, wrd: &str) {
+    p.pretty_print(STRING(@/*bad*/ wrd.to_owned(), size_infinity));
 }
 
-pub fn zero_word(p: @mut Printer, wrd: ~str) {
-    p.pretty_print(STRING(@/*bad*/ copy wrd, 0));
+pub fn zero_word(p: @mut Printer, wrd: &str) {
+    p.pretty_print(STRING(@/*bad*/ wrd.to_owned(), 0));
 }
 
 pub fn spaces(p: @mut Printer, n: uint) { break_offset(p, n, 0); }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -156,7 +156,7 @@ pub fn lifetime_to_str(e: &ast::Lifetime, intr: @ident_interner) -> ~str {
 }
 
 pub fn tt_to_str(tt: ast::token_tree, intr: @ident_interner) -> ~str {
-    to_str(tt, print_tt, intr)
+    to_str(&tt, print_tt, intr)
 }
 
 pub fn tts_to_str(tts: &[ast::token_tree], intr: @ident_interner) -> ~str {
@@ -213,7 +213,7 @@ pub fn attribute_to_str(attr: ast::attribute, intr: @ident_interner) -> ~str {
     to_str(attr, print_attribute, intr)
 }
 
-pub fn variant_to_str(var: ast::variant, intr: @ident_interner) -> ~str {
+pub fn variant_to_str(var: &ast::variant, intr: @ident_interner) -> ~str {
     to_str(var, print_variant, intr)
 }
 
@@ -229,9 +229,9 @@ pub fn box(s: @ps, u: uint, b: pp::breaks) {
 
 pub fn nbsp(s: @ps) { word(s.s, ~" "); }
 
-pub fn word_nbsp(s: @ps, w: ~str) { word(s.s, w); nbsp(s); }
+pub fn word_nbsp(s: @ps, w: &str) { word(s.s, w); nbsp(s); }
 
-pub fn word_space(s: @ps, w: ~str) { word(s.s, w); space(s.s); }
+pub fn word_space(s: @ps, w: &str) { word(s.s, w); space(s.s); }
 
 pub fn popen(s: @ps) { word(s.s, ~"("); }
 
@@ -346,7 +346,7 @@ pub fn commasep_exprs(s: @ps, b: breaks, exprs: &[@ast::expr]) {
     commasep_cmnt(s, b, exprs, print_expr, expr_span);
 }
 
-pub fn print_mod(s: @ps, _mod: &ast::_mod, attrs: ~[ast::attribute]) {
+pub fn print_mod(s: @ps, _mod: &ast::_mod, attrs: &[ast::attribute]) {
     print_inner_attributes(s, attrs);
     for _mod.view_items.each |vitem| {
         print_view_item(s, *vitem);
@@ -355,7 +355,7 @@ pub fn print_mod(s: @ps, _mod: &ast::_mod, attrs: ~[ast::attribute]) {
 }
 
 pub fn print_foreign_mod(s: @ps, nmod: &ast::foreign_mod,
-                         attrs: ~[ast::attribute]) {
+                         attrs: &[ast::attribute]) {
     print_inner_attributes(s, attrs);
     for nmod.view_items.each |vitem| {
         print_view_item(s, *vitem);
@@ -539,7 +539,7 @@ pub fn print_item(s: @ps, item: @ast::item) {
       ast::item_enum(ref enum_definition, ref params) => {
         print_enum_def(
             s,
-            *enum_definition,
+            enum_definition,
             params,
             item.ident,
             item.span,
@@ -621,7 +621,7 @@ fn print_trait_ref(s: @ps, t: &ast::trait_ref) {
     print_path(s, t.path, false);
 }
 
-pub fn print_enum_def(s: @ps, enum_definition: ast::enum_def,
+pub fn print_enum_def(s: @ps, enum_definition: &ast::enum_def,
                       generics: &ast::Generics, ident: ast::ident,
                       span: codemap::span, visibility: ast::visibility) {
     head(s, visibility_qualified(visibility, ~"enum"));
@@ -632,7 +632,7 @@ pub fn print_enum_def(s: @ps, enum_definition: ast::enum_def,
 }
 
 pub fn print_variants(s: @ps,
-                      variants: ~[ast::variant],
+                      variants: &[ast::variant],
                       span: codemap::span) {
     bopen(s);
     for variants.each |v| {
@@ -640,7 +640,7 @@ pub fn print_variants(s: @ps,
         maybe_print_comment(s, v.span.lo);
         print_outer_attributes(s, v.node.attrs);
         ibox(s, indent_unit);
-        print_variant(s, *v);
+        print_variant(s, v);
         word(s.s, ~",");
         end(s);
         maybe_print_trailing_comment(s, v.span, None);
@@ -727,15 +727,15 @@ pub fn print_struct(s: @ps,
 /// appropriate macro, transcribe back into the grammar we just parsed from,
 /// and then pretty-print the resulting AST nodes (so, e.g., we print
 /// expression arguments as expressions). It can be done! I think.
-pub fn print_tt(s: @ps, tt: ast::token_tree) {
-    match tt {
+pub fn print_tt(s: @ps, tt: &ast::token_tree) {
+    match *tt {
       ast::tt_delim(ref tts) => print_tts(s, *tts),
       ast::tt_tok(_, ref tk) => {
           word(s.s, parse::token::to_str(s.intr, tk));
       }
       ast::tt_seq(_, ref tts, ref sep, zerok) => {
         word(s.s, ~"$(");
-        for (*tts).each() |tt_elt| { print_tt(s, *tt_elt); }
+        for (*tts).each() |tt_elt| { print_tt(s, tt_elt); }
         word(s.s, ~")");
         match (*sep) {
           Some(ref tk) => word(s.s, parse::token::to_str(s.intr, tk)),
@@ -756,12 +756,12 @@ pub fn print_tts(s: @ps, tts: &[ast::token_tree]) {
         if i != 0 {
             space(s.s);
         }
-        print_tt(s, *tt);
+        print_tt(s, tt);
     }
     end(s);
 }
 
-pub fn print_variant(s: @ps, v: ast::variant) {
+pub fn print_variant(s: @ps, v: &ast::variant) {
     print_visibility(s, v.node.vis);
     match v.node.kind {
         ast::tuple_variant_kind(ref args) => {
@@ -819,7 +819,7 @@ pub fn print_method(s: @ps, meth: @ast::method) {
     print_block_with_attrs(s, &meth.body, meth.attrs);
 }
 
-pub fn print_outer_attributes(s: @ps, attrs: ~[ast::attribute]) {
+pub fn print_outer_attributes(s: @ps, attrs: &[ast::attribute]) {
     let mut count = 0;
     for attrs.each |attr| {
         match attr.node.style {
@@ -830,7 +830,7 @@ pub fn print_outer_attributes(s: @ps, attrs: ~[ast::attribute]) {
     if count > 0 { hardbreak_if_not_bol(s); }
 }
 
-pub fn print_inner_attributes(s: @ps, attrs: ~[ast::attribute]) {
+pub fn print_inner_attributes(s: @ps, attrs: &[ast::attribute]) {
     let mut count = 0;
     for attrs.each |attr| {
         match attr.node.style {
@@ -879,7 +879,7 @@ pub fn print_stmt(s: @ps, st: &ast::stmt) {
       }
       ast::stmt_mac(ref mac, semi) => {
         space_if_not_bol(s);
-        print_mac(s, (*mac));
+        print_mac(s, mac);
         if semi { word(s.s, ~";"); }
       }
     }
@@ -892,18 +892,18 @@ pub fn print_block(s: @ps, blk: &ast::blk) {
 }
 
 pub fn print_block_unclosed(s: @ps, blk: &ast::blk) {
-    print_possibly_embedded_block_(s, blk, block_normal, indent_unit, ~[],
+    print_possibly_embedded_block_(s, blk, block_normal, indent_unit, &[],
                                  false);
 }
 
 pub fn print_block_unclosed_indent(s: @ps, blk: &ast::blk, indented: uint) {
-    print_possibly_embedded_block_(s, blk, block_normal, indented, ~[],
+    print_possibly_embedded_block_(s, blk, block_normal, indented, &[],
                                    false);
 }
 
 pub fn print_block_with_attrs(s: @ps,
                               blk: &ast::blk,
-                              attrs: ~[ast::attribute]) {
+                              attrs: &[ast::attribute]) {
     print_possibly_embedded_block_(s, blk, block_normal, indent_unit, attrs,
                                   true);
 }
@@ -915,14 +915,14 @@ pub fn print_possibly_embedded_block(s: @ps,
                                      embedded: embed_type,
                                      indented: uint) {
     print_possibly_embedded_block_(
-        s, blk, embedded, indented, ~[], true);
+        s, blk, embedded, indented, &[], true);
 }
 
 pub fn print_possibly_embedded_block_(s: @ps,
                                       blk: &ast::blk,
                                       embedded: embed_type,
                                       indented: uint,
-                                      attrs: ~[ast::attribute],
+                                      attrs: &[ast::attribute],
                                       close_box: bool) {
     match blk.node.rules {
       ast::unsafe_blk => word_space(s, ~"unsafe"),
@@ -994,7 +994,7 @@ pub fn print_if(s: @ps, test: @ast::expr, blk: &ast::blk,
     do_else(s, elseopt);
 }
 
-pub fn print_mac(s: @ps, m: ast::mac) {
+pub fn print_mac(s: @ps, m: &ast::mac) {
     match m.node {
       ast::mac_invoc_tt(pth, ref tts) => {
         print_path(s, pth, false);
@@ -1387,7 +1387,7 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
         print_expr(s, expr);
         pclose(s);
       }
-      ast::expr_inline_asm(a) => {
+      ast::expr_inline_asm(ref a) => {
         if a.volatile {
             word(s.s, ~"__volatile__ asm!");
         } else {
@@ -1415,7 +1415,7 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
         print_string(s, *a.clobbers);
         pclose(s);
       }
-      ast::expr_mac(ref m) => print_mac(s, (*m)),
+      ast::expr_mac(ref m) => print_mac(s, m),
       ast::expr_paren(e) => {
           popen(s);
           print_expr(s, e);
@@ -1559,7 +1559,7 @@ pub fn print_pat(s: @ps, pat: @ast::pat, refutable: bool) {
           }
         }
       }
-      ast::pat_struct(path, fields, etc) => {
+      ast::pat_struct(path, ref fields, etc) => {
         print_path(s, path, true);
         word(s.s, ~"{");
         fn print_field(s: @ps, f: ast::field_pat, refutable: bool) {
@@ -1570,18 +1570,18 @@ pub fn print_pat(s: @ps, pat: @ast::pat, refutable: bool) {
             end(s);
         }
         fn get_span(f: ast::field_pat) -> codemap::span { return f.pat.span; }
-        commasep_cmnt(s, consistent, fields,
+        commasep_cmnt(s, consistent, *fields,
                       |s, f| print_field(s,f,refutable),
                       get_span);
         if etc {
-            if vec::len(fields) != 0u { word_space(s, ~","); }
+            if fields.len() != 0u { word_space(s, ~","); }
             word(s.s, ~"_");
         }
         word(s.s, ~"}");
       }
-      ast::pat_tup(elts) => {
+      ast::pat_tup(ref elts) => {
         popen(s);
-        commasep(s, inconsistent, elts, |s, p| print_pat(s, p, refutable));
+        commasep(s, inconsistent, *elts, |s, p| print_pat(s, p, refutable));
         if elts.len() == 1 {
             word(s.s, ~",");
         }
@@ -1606,9 +1606,9 @@ pub fn print_pat(s: @ps, pat: @ast::pat, refutable: bool) {
         word(s.s, ~"..");
         print_expr(s, end);
       }
-      ast::pat_vec(before, slice, after) => {
+      ast::pat_vec(ref before, slice, ref after) => {
         word(s.s, ~"[");
-        do commasep(s, inconsistent, before) |s, p| {
+        do commasep(s, inconsistent, *before) |s, p| {
             print_pat(s, p, refutable);
         }
         for slice.each |&p| {
@@ -1617,7 +1617,7 @@ pub fn print_pat(s: @ps, pat: @ast::pat, refutable: bool) {
             print_pat(s, p, refutable);
             if !after.is_empty() { word_space(s, ~","); }
         }
-        do commasep(s, inconsistent, after) |s, p| {
+        do commasep(s, inconsistent, *after) |s, p| {
             print_pat(s, p, refutable);
         }
         word(s.s, ~"]");
@@ -1832,12 +1832,12 @@ pub fn print_view_item(s: @ps, item: @ast::view_item) {
     print_outer_attributes(s, item.attrs);
     print_visibility(s, item.vis);
     match item.node {
-        ast::view_item_extern_mod(id, mta, _) => {
+        ast::view_item_extern_mod(id, ref mta, _) => {
             head(s, ~"extern mod");
             print_ident(s, id);
             if !mta.is_empty() {
                 popen(s);
-                commasep(s, consistent, mta, print_meta_item);
+                commasep(s, consistent, *mta, print_meta_item);
                 pclose(s);
             }
         }
@@ -1960,7 +1960,7 @@ pub fn maybe_print_trailing_comment(s: @ps, span: codemap::span,
         match next_pos { None => (), Some(p) => next = p }
         if span.hi < (*cmnt).pos && (*cmnt).pos < next &&
                span_line.line == comment_line.line {
-            print_comment(s, (*cmnt));
+            print_comment(s, cmnt);
             s.cur_cmnt_and_lit.cur_cmnt += 1u;
         }
       }
@@ -1975,7 +1975,7 @@ pub fn print_remaining_comments(s: @ps) {
     loop {
         match next_comment(s) {
           Some(ref cmnt) => {
-            print_comment(s, (*cmnt));
+            print_comment(s, cmnt);
             s.cur_cmnt_and_lit.cur_cmnt += 1u;
           }
           _ => break
@@ -2055,7 +2055,7 @@ pub fn maybe_print_comment(s: @ps, pos: BytePos) {
         match next_comment(s) {
           Some(ref cmnt) => {
             if (*cmnt).pos < pos {
-                print_comment(s, (*cmnt));
+                print_comment(s, cmnt);
                 s.cur_cmnt_and_lit.cur_cmnt += 1u;
             } else { break; }
           }
@@ -2064,7 +2064,7 @@ pub fn maybe_print_comment(s: @ps, pos: BytePos) {
     }
 }
 
-pub fn print_comment(s: @ps, cmnt: comments::cmnt) {
+pub fn print_comment(s: @ps, cmnt: &comments::cmnt) {
     match cmnt.style {
       comments::mixed => {
         assert!((vec::len(cmnt.lines) == 1u));
@@ -2274,7 +2274,7 @@ mod test {
             vis: ast::public,
         });
 
-        let varstr = variant_to_str(var,mock_interner);
+        let varstr = variant_to_str(&var,mock_interner);
         assert_eq!(&varstr,&~"pub principal_skinner");
     }
 }

--- a/src/libsyntax/syntax.rc
+++ b/src/libsyntax/syntax.rc
@@ -20,7 +20,6 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-#[allow(vecs_implicitly_copyable)];
 #[allow(non_camel_case_types)];
 #[deny(deprecated_pattern)];
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -179,7 +179,7 @@ pub fn visit_item<E: Copy>(i: @item, e: E, v: vt<E>) {
         item_enum(ref enum_definition, ref tps) => {
             (v.visit_generics)(tps, e, v);
             visit_enum_def(
-                *enum_definition,
+                enum_definition,
                 tps,
                 e,
                 v
@@ -206,11 +206,11 @@ pub fn visit_item<E: Copy>(i: @item, e: E, v: vt<E>) {
                 (v.visit_trait_method)(m, e, v);
             }
         }
-        item_mac(ref m) => visit_mac((*m), e, v)
+        item_mac(ref m) => visit_mac(m, e, v)
     }
 }
 
-pub fn visit_enum_def<E: Copy>(enum_definition: ast::enum_def,
+pub fn visit_enum_def<E: Copy>(enum_definition: &ast::enum_def,
                                tps: &Generics,
                                e: E,
                                v: vt<E>) {
@@ -422,7 +422,7 @@ pub fn visit_stmt<E>(s: @stmt, e: E, v: vt<E>) {
       stmt_decl(d, _) => (v.visit_decl)(d, e, v),
       stmt_expr(ex, _) => (v.visit_expr)(ex, e, v),
       stmt_semi(ex, _) => (v.visit_expr)(ex, e, v),
-      stmt_mac(ref mac, _) => visit_mac((*mac), e, v)
+      stmt_mac(ref mac, _) => visit_mac(mac, e, v)
     }
 }
 
@@ -445,7 +445,7 @@ pub fn visit_exprs<E: Copy>(exprs: &[@expr], e: E, v: vt<E>) {
     for exprs.each |ex| { (v.visit_expr)(*ex, e, v); }
 }
 
-pub fn visit_mac<E>(_m: mac, _e: E, _v: vt<E>) {
+pub fn visit_mac<E>(_m: &mac, _e: E, _v: vt<E>) {
     /* no user-serviceable parts inside */
 }
 
@@ -537,7 +537,7 @@ pub fn visit_expr<E: Copy>(ex: @expr, e: E, v: vt<E>) {
             (v.visit_expr)(lv, e, v);
             (v.visit_expr)(x, e, v);
         }
-        expr_mac(ref mac) => visit_mac((*mac), e, v),
+        expr_mac(ref mac) => visit_mac(mac, e, v),
         expr_paren(x) => (v.visit_expr)(x, e, v),
         expr_inline_asm(ref a) => {
             for a.inputs.each |&(_, in)| {


### PR DESCRIPTION
This closes #5204 and #6421.

This also removes the `vecs_implicitly_copyable` lint (although now reading #6421, this may not be desired?). If we want to leave it in, it at least removes it from the compiler.
