### PR TITLE
Remove re-exports from libcore/core.rc

### DIFF
--- a/src/libcore/at_vec.rs
+++ b/src/libcore/at_vec.rs
@@ -11,8 +11,10 @@
 //! Managed vectors
 
 use cast::transmute;
+use container::Container;
 use kinds::Copy;
 use old_iter;
+use old_iter::BaseIter;
 use option::Option;
 use sys;
 use uint;

--- a/src/libcore/comm.rs
+++ b/src/libcore/comm.rs
@@ -13,12 +13,13 @@ Message passing
 */
 
 use cast::{transmute, transmute_mut};
+use container::Container;
 use either::{Either, Left, Right};
 use kinds::Owned;
 use option::{Option, Some, None};
 use uint;
-use unstable;
 use vec;
+use vec::OwnedVector;
 use util::replace;
 use unstable::sync::{Exclusive, exclusive};
 
@@ -577,7 +578,7 @@ impl<T:Owned,
 #[cfg(test)]
 mod test {
     use either::Right;
-    use super::{Chan, Port, oneshot, recv_one, stream};
+    use super::{Chan, Port, oneshot, stream};
 
     #[test]
     fn test_select2() {

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -68,48 +68,6 @@ they contained the following prologue:
 #[cfg(test)] pub use ops = realcore::ops;
 #[cfg(test)] pub use cmp = realcore::cmp;
 
-/* Reexported core operators */
-
-pub use kinds::{Const, Copy, Owned};
-pub use ops::{Drop};
-pub use ops::{Add, Sub, Mul, Div, Rem, Neg, Not};
-pub use ops::{BitAnd, BitOr, BitXor};
-pub use ops::{Shl, Shr, Index};
-
-
-/* Reexported types and traits */
-
-pub use option::{Option, Some, None};
-pub use result::{Result, Ok, Err};
-
-pub use path::Path;
-pub use path::GenericPath;
-pub use path::WindowsPath;
-pub use path::PosixPath;
-
-pub use tuple::{CopyableTuple, ImmutableTuple, ExtendedTupleOps};
-pub use str::{StrSlice};
-pub use container::{Container, Mutable};
-pub use vec::{CopyableVector, ImmutableVector};
-pub use vec::{ImmutableEqVector, ImmutableCopyableVector};
-pub use vec::{OwnedVector, OwnedCopyableVector, MutableVector};
-pub use old_iter::{BaseIter, ExtendedIter, EqIter, CopyableIter};
-pub use old_iter::{CopyableOrderedIter, CopyableNonstrictIter};
-pub use old_iter::{ExtendedMutableIter};
-pub use iter::Times;
-
-pub use num::{Num, NumCast};
-pub use num::{Orderable, Signed, Unsigned, Round};
-pub use num::{Algebraic, Trigonometric, Exponential, Hyperbolic};
-pub use num::{Integer, Fractional, Real, RealExt};
-pub use num::{Bitwise, BitCount, Bounded};
-pub use num::{Primitive, Int, Float};
-
-pub use ptr::Ptr;
-pub use from_str::FromStr;
-pub use to_str::ToStr;
-pub use clone::Clone;
-
 // On Linux, link to the runtime with -lrt.
 #[cfg(target_os = "linux")]
 #[doc(hidden)]

--- a/src/libcore/either.rs
+++ b/src/libcore/either.rs
@@ -10,11 +10,14 @@
 
 //! A type that represents one of two alternatives
 
+use container::Container;
 use cmp::Eq;
 use kinds::Copy;
+use old_iter::BaseIter;
 use result::Result;
 use result;
 use vec;
+use vec::OwnedVector;
 
 /// The either type
 #[deriving(Clone, Eq)]

--- a/src/libcore/hash.rs
+++ b/src/libcore/hash.rs
@@ -21,6 +21,8 @@
 
 #[cfg(stage0)]
 use cast;
+use container::Container;
+use old_iter::BaseIter;
 use rt::io::Writer;
 use to_bytes::IterBytes;
 use uint;

--- a/src/libcore/io.rs
+++ b/src/libcore/io.rs
@@ -16,6 +16,7 @@ Basic input/output
 
 use result::Result;
 
+use container::Container;
 use int;
 use libc;
 use libc::{c_int, c_long, c_void, size_t, ssize_t};
@@ -24,11 +25,15 @@ use os;
 use cast;
 use path::Path;
 use ops::Drop;
+use old_iter::{BaseIter, CopyableIter};
 use ptr;
 use result;
 use str;
+use str::StrSlice;
+use to_str::ToStr;
 use uint;
 use vec;
+use vec::{OwnedVector, OwnedCopyableVector};
 
 #[allow(non_camel_case_types)] // not sure what to do about this
 pub type fd_t = c_int;

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -42,6 +42,7 @@ much easier to implement.
 
 #[cfg(not(stage0))] use cmp::Ord;
 #[cfg(not(stage0))] use option::{Option, Some, None};
+#[cfg(not(stage0))] use vec::OwnedVector;
 
 #[cfg(stage0)]
 pub trait Times {

--- a/src/libcore/logging.rs
+++ b/src/libcore/logging.rs
@@ -45,6 +45,7 @@ pub fn console_off() {
 #[cfg(not(test))]
 #[lang="log_type"]
 pub fn log_type<T>(level: u32, object: &T) {
+    use container::Container;
     use cast::transmute;
     use io;
     use libc;

--- a/src/libcore/num/strconv.rs
+++ b/src/libcore/num/strconv.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use container::Container;
 use core::cmp::{Ord, Eq};
 use ops::{Add, Sub, Mul, Div, Rem, Neg};
 use option::{None, Option, Some};
@@ -15,6 +16,8 @@ use char;
 use str;
 use kinds::Copy;
 use vec;
+use vec::{CopyableVector, ImmutableVector};
+use vec::OwnedVector;
 use num::{NumCast, Zero, One, cast, pow_with_uint};
 use f64;
 

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -48,6 +48,7 @@ use util;
 use num::Zero;
 use old_iter::{BaseIter, MutableIter, ExtendedIter};
 use old_iter;
+use str::StrSlice;
 
 #[cfg(test)] use str;
 

--- a/src/libcore/path.rs
+++ b/src/libcore/path.rs
@@ -14,12 +14,16 @@ Cross-platform file path handling
 
 */
 
+use container::Container;
 use cmp::Eq;
 use libc;
 use option::{None, Option, Some};
 use str;
+use str::StrSlice;
 use to_str::ToStr;
 use ascii::{AsciiCast, AsciiStr};
+use old_iter::BaseIter;
+use vec::OwnedVector;
 
 #[cfg(windows)]
 pub use Path = self::WindowsPath;

--- a/src/libcore/pipes.rs
+++ b/src/libcore/pipes.rs
@@ -82,6 +82,7 @@ bounded and unbounded protocols allows for less code duplication.
 
 */
 
+use container::Container;
 use cast::{forget, transmute, transmute_copy};
 use either::{Either, Left, Right};
 use kinds::Owned;
@@ -91,8 +92,10 @@ use option::{None, Option, Some};
 use unstable::finally::Finally;
 use unstable::intrinsics;
 use ptr;
+use ptr::Ptr;
 use task;
 use vec;
+use vec::OwnedVector;
 use util::replace;
 
 static SPIN_COUNT: uint = 0;

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -353,7 +353,7 @@ pub mod ptr_tests {
             assert!((p.fst == 50));
             assert!((p.snd == 60));
 
-            let mut v0 = ~[32000u16, 32001u16, 32002u16];
+            let v0 = ~[32000u16, 32001u16, 32002u16];
             let mut v1 = ~[0u16, 0u16, 0u16];
 
             copy_memory(mut_offset(vec::raw::to_mut_ptr(v1), 1u),

--- a/src/libcore/repr.rs
+++ b/src/libcore/repr.rs
@@ -25,10 +25,11 @@ use managed;
 use ptr;
 use reflect;
 use reflect::{MovePtr, align};
+use str::StrSlice;
 use to_str::ToStr;
-use vec::UnboxedVecRepr;
 use vec::raw::{VecRepr, SliceRepr};
 use vec;
+use vec::{OwnedVector, UnboxedVecRepr};
 
 #[cfg(test)] use io;
 

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -17,7 +17,9 @@ use either;
 use either::Either;
 use kinds::Copy;
 use option::{None, Option, Some};
+use old_iter::BaseIter;
 use vec;
+use vec::OwnedVector;
 
 /// The result type
 #[deriving(Clone, Eq)]

--- a/src/libcore/rt/mod.rs
+++ b/src/libcore/rt/mod.rs
@@ -13,6 +13,7 @@
 #[doc(hidden)];
 
 use libc::c_char;
+use ptr::Ptr;
 
 #[path = "sched/mod.rs"]
 mod sched;

--- a/src/libcore/rt/stack.rs
+++ b/src/libcore/rt/stack.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use container::Container;
+use ptr::Ptr;
 use vec;
 
 pub struct StackSegment {

--- a/src/libcore/rt/test.rs
+++ b/src/libcore/rt/test.rs
@@ -77,7 +77,7 @@ pub fn spawntask_try(f: ~fn()) -> Result<(), ()> {
 
     // Switch to the scheduler
     let f = Cell(Cell(f));
-    let mut sched = local_sched::take();
+    let sched = local_sched::take();
     do sched.deschedule_running_task_and_then() |old_task| {
         let old_task = Cell(old_task);
         let f = f.take();

--- a/src/libcore/rt/uv/mod.rs
+++ b/src/libcore/rt/uv/mod.rs
@@ -34,11 +34,13 @@ via `close` and `delete` methods.
 
 */
 
+use container::Container;
 use option::*;
 use str::raw::from_c_str;
 use to_str::ToStr;
 use vec;
 use ptr;
+use ptr::Ptr;
 use libc::{c_void, c_int, size_t, malloc, free};
 use cast::transmute;
 use ptr::null;

--- a/src/libcore/rt/uv/net.rs
+++ b/src/libcore/rt/uv/net.rs
@@ -388,7 +388,7 @@ fn listen() {
             assert!(status.is_none());
             let mut server_stream_watcher = server_stream_watcher;
             let mut loop_ = loop_;
-            let mut client_tcp_watcher = TcpWatcher::new(&mut loop_);
+            let client_tcp_watcher = TcpWatcher::new(&mut loop_);
             let mut client_tcp_watcher = client_tcp_watcher.as_stream();
             server_stream_watcher.accept(client_tcp_watcher);
             let count_cell = Cell(0);

--- a/src/libcore/rt/uvio.rs
+++ b/src/libcore/rt/uvio.rs
@@ -15,10 +15,12 @@ use super::io::net::ip::IpAddr;
 use super::uv::*;
 use super::rtio::*;
 use ops::Drop;
+use old_iter::CopyableIter;
 use cell::{Cell, empty_cell};
 use cast::transmute;
 use super::sched::{Scheduler, local_sched};
 
+#[cfg(test)] use container::Container;
 #[cfg(test)] use uint;
 #[cfg(test)] use unstable::run_in_bare_thread;
 #[cfg(test)] use super::test::*;
@@ -426,7 +428,7 @@ fn test_read_read_read() {
                 let io = local_sched::unsafe_borrow_io();
                 let mut listener = io.bind(addr).unwrap();
                 let mut stream = listener.listen().unwrap();
-                let mut buf = [1, .. 2048];
+                let buf = [1, .. 2048];
                 let mut total_bytes_written = 0;
                 while total_bytes_written < MAX {
                     stream.write(buf);

--- a/src/libcore/rt/work_queue.rs
+++ b/src/libcore/rt/work_queue.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use container::Container;
 use option::*;
+use vec::OwnedVector;
 
 pub struct WorkQueue<T> {
     priv queue: ~[T]

--- a/src/libcore/run.rs
+++ b/src/libcore/run.rs
@@ -778,7 +778,6 @@ pub fn waitpid(pid: pid_t) -> int {
 
 #[cfg(test)]
 mod tests {
-    use libc;
     use option::None;
     use os;
     use run::{readclose, writeclose};

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -23,14 +23,19 @@ use cast;
 use char;
 use clone::Clone;
 use cmp::{TotalOrd, Ordering, Less, Equal, Greater};
+use container::Container;
+use iter::Times;
+use iterator::Iterator;
 use libc;
 use option::{None, Option, Some};
-use iterator::Iterator;
+use old_iter::{BaseIter, EqIter};
 use ptr;
+use ptr::Ptr;
 use str;
+use to_str::ToStr;
 use uint;
 use vec;
-use to_str::ToStr;
+use vec::{OwnedVector, OwnedCopyableVector};
 
 #[cfg(not(test))] use cmp::{Eq, Ord, Equiv, TotalEq};
 
@@ -3133,13 +3138,16 @@ impl<'self> Iterator<char> for StrCharIterator<'self> {
 
 #[cfg(test)]
 mod tests {
+    use container::Container;
     use char;
     use option::Some;
     use libc::c_char;
     use libc;
+    use old_iter::BaseIter;
     use ptr;
     use str::*;
     use vec;
+    use vec::ImmutableVector;
     use cmp::{TotalOrd, Less, Equal, Greater};
 
     #[test]

--- a/src/libcore/str/ascii.rs
+++ b/src/libcore/str/ascii.rs
@@ -12,7 +12,10 @@
 
 use to_str::{ToStr,ToStrConsume};
 use str;
+use str::StrSlice;
 use cast;
+use old_iter::BaseIter;
+use vec::{CopyableVector, ImmutableVector, OwnedVector};
 
 /// Datatype to hold one ascii character. It is 8 bit long.
 #[deriving(Clone, Eq)]

--- a/src/libcore/task/mod.rs
+++ b/src/libcore/task/mod.rs
@@ -772,7 +772,7 @@ fn test_add_wrapper() {
     do b0.add_wrapper |body| {
         let ch = Cell(ch.take());
         let result: ~fn() = || {
-            let mut ch = ch.take();
+            let ch = ch.take();
             body();
             ch.send(());
         };

--- a/src/libcore/task/spawn.rs
+++ b/src/libcore/task/spawn.rs
@@ -78,7 +78,6 @@ use cell::Cell;
 use container::Map;
 use comm::{Chan, GenericChan};
 use prelude::*;
-use unstable;
 use ptr;
 use hashmap::HashSet;
 use task::local_data_priv::{local_get, local_set, OldHandle};

--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -17,6 +17,7 @@ The `ToBytes` and `IterBytes` traits
 use io;
 use io::Writer;
 use option::{None, Option, Some};
+use old_iter::BaseIter;
 use str;
 
 pub type Cb<'self> = &'self fn(buf: &[u8]) -> bool;

--- a/src/libcore/to_str.rs
+++ b/src/libcore/to_str.rs
@@ -20,6 +20,7 @@ use hashmap::HashSet;
 use container::Map;
 use hash::Hash;
 use cmp::Eq;
+use old_iter::BaseIter;
 
 pub trait ToStr {
     fn to_str(&self) -> ~str;

--- a/src/libcore/unstable/global.rs
+++ b/src/libcore/unstable/global.rs
@@ -255,11 +255,7 @@ fn test_modify() {
     unsafe {
         do global_data_modify(key) |v| {
             match v {
-                None => {
-                    unsafe {
-                        Some(~UnsafeAtomicRcBox::new(10))
-                    }
-                }
+                None => { Some(~UnsafeAtomicRcBox::new(10)) }
                 _ => fail!()
             }
         }
@@ -277,11 +273,7 @@ fn test_modify() {
 
         do global_data_modify(key) |v| {
             match v {
-                None => {
-                    unsafe {
-                        Some(~UnsafeAtomicRcBox::new(10))
-                    }
-                }
+                None => { Some(~UnsafeAtomicRcBox::new(10)) }
                 _ => fail!()
             }
         }

--- a/src/libcore/unstable/weak_task.rs
+++ b/src/libcore/unstable/weak_task.rs
@@ -191,7 +191,7 @@ fn test_select_stream_and_oneshot() {
     use comm::select2i;
     use either::{Left, Right};
 
-    let mut (port, chan) = stream();
+    let (port, chan) = stream();
     let port = Cell(port);
     let (waitport, waitchan) = stream();
     do spawn {

--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -22,9 +22,11 @@ use old_iter;
 use iterator::Iterator;
 use kinds::Copy;
 use libc;
+use old_iter::{BaseIter, CopyableIter};
 use option::{None, Option, Some};
 use ptr::to_unsafe_ptr;
 use ptr;
+use ptr::Ptr;
 use sys;
 use uint;
 use unstable::intrinsics;
@@ -3565,7 +3567,7 @@ mod tests {
         fn sub(a: int, b: &int) -> int {
             a - *b
         }
-        let mut v = ~[1, 2, 3, 4];
+        let v = ~[1, 2, 3, 4];
         let sum = foldl(0, v, sub);
         assert!(sum == -10);
     }
@@ -3575,7 +3577,7 @@ mod tests {
         fn sub(a: &int, b: int) -> int {
             *a - b
         }
-        let mut v = ~[1, 2, 3, 4];
+        let v = ~[1, 2, 3, 4];
         let sum = foldr(v, 0, sub);
         assert!(sum == -2);
     }
@@ -3739,7 +3741,7 @@ mod tests {
         assert!(position_between(~[], 0u, 0u, f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
-        let mut v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
+        let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
 
         assert!(position_between(v, 0u, 0u, f).is_none());
         assert!(position_between(v, 0u, 1u, f).is_none());
@@ -3768,7 +3770,7 @@ mod tests {
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
         fn g(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'd' }
-        let mut v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
+        let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
 
         assert!(find(v, f) == Some((1, 'b')));
         assert!(find(v, g).is_none());
@@ -3779,7 +3781,7 @@ mod tests {
         assert!(find_between(~[], 0u, 0u, f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
-        let mut v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
+        let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
 
         assert!(find_between(v, 0u, 0u, f).is_none());
         assert!(find_between(v, 0u, 1u, f).is_none());
@@ -3808,7 +3810,7 @@ mod tests {
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
         fn g(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'd' }
-        let mut v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
+        let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
 
         assert!(position(v, f) == Some(1u));
         assert!(position(v, g).is_none());
@@ -3819,7 +3821,7 @@ mod tests {
         assert!(rposition_between(~[], 0u, 0u, f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
-        let mut v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
+        let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
 
         assert!(rposition_between(v, 0u, 0u, f).is_none());
         assert!(rposition_between(v, 0u, 1u, f).is_none());
@@ -3848,7 +3850,7 @@ mod tests {
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
         fn g(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'd' }
-        let mut v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
+        let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
 
         assert!(rfind(v, f) == Some((3, 'b')));
         assert!(rfind(v, g).is_none());
@@ -3859,7 +3861,7 @@ mod tests {
         assert!(rfind_between(~[], 0u, 0u, f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
-        let mut v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
+        let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
 
         assert!(rfind_between(v, 0u, 0u, f).is_none());
         assert!(rfind_between(v, 0u, 1u, f).is_none());
@@ -4328,7 +4330,7 @@ mod tests {
     #[ignore(windows)]
     #[should_fail]
     fn test_map_fail() {
-        let mut v = [(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
+        let v = [(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
         let mut i = 0;
         do map(v) |_elt| {
             if i == 2 {

--- a/src/librustc/util/enum_set.rs
+++ b/src/librustc/util/enum_set.rs
@@ -82,19 +82,19 @@ pub impl<E:CLike> EnumSet<E> {
     }
 }
 
-impl<E:CLike> core::Sub<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
+impl<E:CLike> Sub<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
     fn sub(&self, e: &EnumSet<E>) -> EnumSet<E> {
         EnumSet {bits: self.bits & !e.bits}
     }
 }
 
-impl<E:CLike> core::BitOr<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
+impl<E:CLike> BitOr<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
     fn bitor(&self, e: &EnumSet<E>) -> EnumSet<E> {
         EnumSet {bits: self.bits | e.bits}
     }
 }
 
-impl<E:CLike> core::BitAnd<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
+impl<E:CLike> BitAnd<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
     fn bitand(&self, e: &EnumSet<E>) -> EnumSet<E> {
         EnumSet {bits: self.bits & e.bits}
     }

--- a/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
+++ b/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
@@ -15,7 +15,7 @@
 
 extern mod core;
 
-fn last<T>(v: ~[&T]) -> core::Option<T> {
+fn last<T>(v: ~[&T]) -> core::option::Option<T> {
     fail!();
 }
 


### PR DESCRIPTION
Also fix up all the fallout elsewhere throughout core. It's really nice being
able to have the prelude.

I'm not quite sure how resolution works with traits, but it seems to me like the public imports at the top-level of the core crate were leaking into the sub-crates, but that could also be working as intended. Regardless, things compile without the re-exports now.
