### PR TITLE
librustc: Correct #[always_inline] -> #[inline(always)]

### DIFF
--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -574,7 +574,7 @@ fn padding(size: u64) -> ValueRef {
 }
 
 // XXX this utility routine should be somewhere more general
-#[always_inline]
+#[inline(always)]
 fn roundup(x: u64, a: u64) -> u64 { ((x + (a - 1)) / a) * a }
 
 /// Get the discriminant of a constant value.  (Not currently used.)

--- a/src/rt/rust_globals.h
+++ b/src/rt/rust_globals.h
@@ -20,7 +20,7 @@
 #endif
 
 #if defined(__GNUC__)
-#define ALWAYS_INLINE __attribute((always_inline)) INLINE
+#define ALWAYS_INLINE __attribute__((always_inline)) INLINE
 #elif defined(_MSC_VER)
 #define ALWAYS_INLINE __forceinline
 #else


### PR DESCRIPTION
#6446
