### PR TITLE
Add BuiltinBounds to closure type: parse and handle subtyping,

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -470,12 +470,14 @@ fn parse_closure_ty(st: @mut PState, conv: conv_did) -> ty::ClosureTy {
     let purity = parse_purity(next(st));
     let onceness = parse_onceness(next(st));
     let region = parse_region(st);
+    let bounds = parse_bounds(st, conv);
     let sig = parse_sig(st, conv);
     ty::ClosureTy {
         purity: purity,
         sigil: sigil,
         onceness: onceness,
         region: region,
+        bounds: bounds.builtin_bounds,
         sig: sig
     }
 }
@@ -540,10 +542,10 @@ pub fn parse_type_param_def_data(data: @~[u8], start: uint,
 
 fn parse_type_param_def(st: @mut PState, conv: conv_did) -> ty::TypeParameterDef {
     ty::TypeParameterDef {def_id: parse_def(st, NominalType, conv),
-                          bounds: parse_bounds(st, conv)}
+                          bounds: @parse_bounds(st, conv)}
 }
 
-fn parse_bounds(st: @mut PState, conv: conv_did) -> @ty::ParamBounds {
+fn parse_bounds(st: @mut PState, conv: conv_did) -> ty::ParamBounds {
     let mut param_bounds = ty::ParamBounds {
         builtin_bounds: ty::EmptyBuiltinBounds(),
         trait_bounds: ~[]
@@ -566,7 +568,7 @@ fn parse_bounds(st: @mut PState, conv: conv_did) -> @ty::ParamBounds {
                 param_bounds.trait_bounds.push(@parse_trait_ref(st, conv));
             }
             '.' => {
-                return @param_bounds;
+                return param_bounds;
             }
             _ => {
                 fail!("parse_bounds: bad bounds")

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -380,6 +380,9 @@ fn enc_closure_ty(w: @io::Writer, cx: @ctxt, ft: &ty::ClosureTy) {
     enc_purity(w, ft.purity);
     enc_onceness(w, ft.onceness);
     enc_region(w, cx, ft.region);
+    let bounds = ty::ParamBounds {builtin_bounds: ft.bounds,
+                                  trait_bounds: ~[]};
+    enc_bounds(w, cx, &bounds);
     enc_fn_sig(w, cx, &ft.sig);
 }
 
@@ -392,7 +395,7 @@ fn enc_fn_sig(w: @io::Writer, cx: @ctxt, fsig: &ty::FnSig) {
     enc_ty(w, cx, fsig.output);
 }
 
-fn enc_bounds(w: @io::Writer, cx: @ctxt, bs: @ty::ParamBounds) {
+fn enc_bounds(w: @io::Writer, cx: @ctxt, bs: &ty::ParamBounds) {
     for bs.builtin_bounds.each |bound| {
         match bound {
             ty::BoundOwned => w.write_char('S'),

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -818,6 +818,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
                 sigil: ast::BorrowedSigil,
                 onceness: ast::Many,
                 region: ty::re_bound(ty::br_anon(0)),
+                bounds: ty::EmptyBuiltinBounds(),
                 sig: FnSig {
                     bound_lifetime_names: opt_vec::Empty,
                     inputs: ~[ star_u8 ],

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -330,6 +330,7 @@ pub fn normalize_for_monomorphization(tcx: ty::ctxt,
                 sigil: sigil,
                 onceness: ast::Many,
                 region: ty::re_static,
+                bounds: ty::EmptyBuiltinBounds(),
                 sig: ty::FnSig {bound_lifetime_names: opt_vec::Empty,
                                 inputs: ~[],
                                 output: ty::mk_nil()}})

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -1207,25 +1207,21 @@ pub fn ty_generics(ccx: &CrateCtxt,
             builtin_bounds: ty::EmptyBuiltinBounds(),
             trait_bounds: ~[]
         };
-        for ast_bounds.each |b| {
-            match b {
-                &TraitTyParamBound(b) => {
-                    let li = &ccx.tcx.lang_items;
+        for ast_bounds.each |ast_bound| {
+            match *ast_bound {
+                TraitTyParamBound(b) => {
                     let ty = ty::mk_param(ccx.tcx, param_ty.idx, param_ty.def_id);
                     let trait_ref = instantiate_trait_ref(ccx, b, rp, generics, ty);
-                    if trait_ref.def_id == li.owned_trait() {
-                        param_bounds.builtin_bounds.add(ty::BoundOwned);
-                    } else if trait_ref.def_id == li.copy_trait() {
-                        param_bounds.builtin_bounds.add(ty::BoundCopy);
-                    } else if trait_ref.def_id == li.const_trait() {
-                        param_bounds.builtin_bounds.add(ty::BoundConst);
-                    } else {
+                    if !astconv::try_add_builtin_trait(
+                        ccx.tcx, trait_ref.def_id,
+                        &mut param_bounds.builtin_bounds)
+                    {
                         // Must be a user-defined trait
                         param_bounds.trait_bounds.push(trait_ref);
                     }
                 }
 
-                &RegionTyParamBound => {
+                RegionTyParamBound => {
                     param_bounds.builtin_bounds.add(ty::BoundStatic);
                 }
             }

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -56,6 +56,7 @@
 
 use middle::ty::{FloatVar, FnSig, IntVar, TyVar};
 use middle::ty::{IntType, UintType, substs};
+use middle::ty::{BuiltinBounds};
 use middle::ty;
 use middle::typeck::infer::glb::Glb;
 use middle::typeck::infer::lub::Lub;
@@ -100,6 +101,7 @@ pub trait Combine {
     fn purities(&self, a: purity, b: purity) -> cres<purity>;
     fn abis(&self, a: AbiSet, b: AbiSet) -> cres<AbiSet>;
     fn oncenesses(&self, a: Onceness, b: Onceness) -> cres<Onceness>;
+    fn bounds(&self, a: BuiltinBounds, b: BuiltinBounds) -> cres<BuiltinBounds>;
     fn contraregions(&self, a: ty::Region, b: ty::Region)
                   -> cres<ty::Region>;
     fn regions(&self, a: ty::Region, b: ty::Region) -> cres<ty::Region>;
@@ -372,11 +374,13 @@ pub fn super_closure_tys<C:Combine>(
     let r = if_ok!(this.contraregions(a_f.region, b_f.region));
     let purity = if_ok!(this.purities(a_f.purity, b_f.purity));
     let onceness = if_ok!(this.oncenesses(a_f.onceness, b_f.onceness));
+    let bounds = if_ok!(this.bounds(a_f.bounds, b_f.bounds));
     let sig = if_ok!(this.fn_sigs(&a_f.sig, &b_f.sig));
     Ok(ty::ClosureTy {purity: purity,
                       sigil: p,
                       onceness: onceness,
                       region: r,
+                      bounds: bounds,
                       sig: sig})
 }
 

--- a/src/librustc/middle/typeck/infer/glb.rs
+++ b/src/librustc/middle/typeck/infer/glb.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use middle::ty::{BuiltinBounds};
 use middle::ty::RegionVid;
 use middle::ty;
 use middle::typeck::infer::combine::*;
@@ -112,6 +113,12 @@ impl Combine for Glb {
             (Many, _) | (_, Many) => Ok(Many),
             (Once, Once) => Ok(Once)
         }
+    }
+
+    fn bounds(&self, a: BuiltinBounds, b: BuiltinBounds) -> cres<BuiltinBounds> {
+        // More bounds is a subtype of fewer bounds, so
+        // the GLB (mutual subtype) is the union.
+        Ok(a.union(b))
     }
 
     fn regions(&self, a: ty::Region, b: ty::Region) -> cres<ty::Region> {

--- a/src/librustc/middle/typeck/infer/lub.rs
+++ b/src/librustc/middle/typeck/infer/lub.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use middle::ty::{BuiltinBounds};
 use middle::ty::RegionVid;
 use middle::ty;
 use middle::typeck::infer::combine::*;
@@ -98,6 +99,12 @@ impl Combine for Lub {
             (Once, _) | (_, Once) => Ok(Once),
             (Many, Many) => Ok(Many)
         }
+    }
+
+    fn bounds(&self, a: BuiltinBounds, b: BuiltinBounds) -> cres<BuiltinBounds> {
+        // More bounds is a subtype of fewer bounds, so
+        // the LUB (mutual supertype) is the intersection.
+        Ok(a.intersection(b))
     }
 
     fn contraregions(&self, a: ty::Region, b: ty::Region)

--- a/src/librustc/util/enum_set.rs
+++ b/src/librustc/util/enum_set.rs
@@ -12,7 +12,9 @@ use core;
 
 #[deriving(Eq, IterBytes)]
 pub struct EnumSet<E> {
-    bits: uint
+    // We must maintain the invariant that no bits are set
+    // for which no variant exists
+    priv bits: uint
 }
 
 pub trait CLike {
@@ -37,8 +39,16 @@ pub impl<E:CLike> EnumSet<E> {
         (self.bits & e.bits) != 0
     }
 
+    fn intersection(&self, e: EnumSet<E>) -> EnumSet<E> {
+        EnumSet {bits: self.bits & e.bits}
+    }
+
     fn contains(&self, e: EnumSet<E>) -> bool {
         (self.bits & e.bits) == e.bits
+    }
+
+    fn union(&self, e: EnumSet<E>) -> EnumSet<E> {
+        EnumSet {bits: self.bits | e.bits}
     }
 
     fn add(&mut self, e: E) {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -828,7 +828,8 @@ pub struct TyClosure {
     lifetimes: OptVec<Lifetime>,
     purity: purity,
     onceness: Onceness,
-    decl: fn_decl
+    decl: fn_decl,
+    bounds: OptVec<TyParamBound>
 }
 
 #[deriving(Eq, Encodable, Decodable)]

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -589,6 +589,7 @@ pub fn noop_fold_ty(t: &ty_, fld: @ast_fold) -> ty_ {
                 purity: f.purity,
                 region: f.region,
                 onceness: f.onceness,
+                bounds: f.bounds.map(|x| fold_ty_param_bound(x, fld)),
                 decl: fold_fn_decl(&f.decl, fld),
                 lifetimes: copy f.lifetimes,
             })

--- a/src/test/compile-fail/closure-bounds-not-builtin.rs
+++ b/src/test/compile-fail/closure-bounds-not-builtin.rs
@@ -1,0 +1,8 @@
+
+trait Foo {}
+
+fn take(f: &fn:Foo()) {
+    //~^ ERROR only the builtin traits can be used as closure or object bounds
+}
+
+fn main() {}

--- a/src/test/compile-fail/closure-bounds-subtype.rs
+++ b/src/test/compile-fail/closure-bounds-subtype.rs
@@ -1,0 +1,34 @@
+fn take_any(_: &fn()) {
+}
+
+fn take_copyable(_: &fn:Copy()) {
+}
+
+fn take_copyable_owned(_: &fn:Copy+Owned()) {
+}
+
+fn give_any(f: &fn()) {
+    take_any(f);
+    take_copyable(f); //~ ERROR expected bounds `Copy` but found no bounds
+    take_copyable_owned(f); //~ ERROR expected bounds `Copy+Owned` but found no bounds
+}
+
+fn give_copyable(f: &fn:Copy()) {
+    take_any(f);
+    take_copyable(f);
+    take_copyable_owned(f); //~ ERROR expected bounds `Copy+Owned` but found bounds `Copy`
+}
+
+fn give_owned(f: &fn:Owned()) {
+    take_any(f);
+    take_copyable(f); //~ ERROR expected bounds `Copy` but found bounds `Owned`
+    take_copyable_owned(f); //~ ERROR expected bounds `Copy+Owned` but found bounds `Owned`
+}
+
+fn give_copyable_owned(f: &fn:Copy+Owned()) {
+    take_any(f);
+    take_copyable(f);
+    take_copyable_owned(f);
+}
+
+fn main() {}


### PR DESCRIPTION
Add BuiltinBounds to closure type: parse and handle subtyping,
but do not integrate with kindck etc (requires a snapshot first)

r? @brson
