### PR TITLE
Start making rusti usable again

### DIFF
--- a/configure
+++ b/configure
@@ -695,6 +695,9 @@ do
             # host lib dir
             make_dir $h/stage$i/$CFG_LIBDIR
 
+            # host test dir
+            make_dir $h/stage$i/test
+
             # target bin dir
             make_dir $h/stage$i/$CFG_LIBDIR/rustc/$t/bin
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -289,50 +289,50 @@ else
 STDTESTDEP_$(1)_$(2)_$(3) =
 endif
 
-$(3)/test/coretest.stage$(1)-$(2)$$(X_$(2)):			\
+$(3)/stage$(1)/test/coretest-$(2)$$(X_$(2)):			\
 		$$(CORELIB_CRATE) $$(CORELIB_INPUTS)	\
 		$$(STDTESTDEP_$(1)_$(2)_$(3))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
 
-$(3)/test/stdtest.stage$(1)-$(2)$$(X_$(2)):			\
+$(3)/stage$(1)/test/stdtest-$(2)$$(X_$(2)):			\
 		$$(STDLIB_CRATE) $$(STDLIB_INPUTS)	\
 		$$(STDTESTDEP_$(1)_$(2)_$(3))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
 
-$(3)/test/syntaxtest.stage$(1)-$(2)$$(X_$(2)):			\
+$(3)/stage$(1)/test/syntaxtest-$(2)$$(X_$(2)):			\
 		$$(LIBSYNTAX_CRATE) $$(LIBSYNTAX_INPUTS)	\
 		$$(STDTESTDEP_$(1)_$(2)_$(3))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
 
-$(3)/test/rustctest.stage$(1)-$(2)$$(X_$(2)):					\
+$(3)/stage$(1)/test/rustctest-$(2)$$(X_$(2)):					\
 		$$(COMPILER_CRATE) $$(COMPILER_INPUTS) \
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_RUSTLLVM_$(2)) \
                 $$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBSYNTAX_$(2))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
 
-$(3)/test/rustpkgtest.stage$(1)-$(2)$$(X_$(2)):					\
+$(3)/stage$(1)/test/rustpkgtest-$(2)$$(X_$(2)):					\
 		$$(RUSTPKG_LIB) $$(RUSTPKG_INPUTS)		\
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTC_$(2))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
 
-$(3)/test/rustitest.stage$(1)-$(2)$$(X_$(2)):					\
+$(3)/stage$(1)/test/rustitest-$(2)$$(X_$(2)):					\
 		$$(RUSTI_LIB) $$(RUSTI_INPUTS)		\
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTC_$(2))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
 
-$(3)/test/rusttest.stage$(1)-$(2)$$(X_$(2)):					\
+$(3)/stage$(1)/test/rusttest-$(2)$$(X_$(2)):					\
 		$$(RUST_LIB) $$(RUST_INPUTS)		\
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTC_$(2))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
 
-$(3)/test/rustdoctest.stage$(1)-$(2)$$(X_$(2)):					\
+$(3)/stage$(1)/test/rustdoctest-$(2)$$(X_$(2)):					\
 		$$(RUSTDOC_LIB) $$(RUSTDOC_INPUTS)		\
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTC_$(2))
 	@$$(call E, compile_and_link: $$@)
@@ -349,7 +349,7 @@ define DEF_TEST_CRATE_RULES
 check-stage$(1)-T-$(2)-H-$(3)-$(4)-exec: $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4))
 
 $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
-		$(3)/test/$(4)test.stage$(1)-$(2)$$(X_$(2))
+		$(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2))
 	@$$(call E, run: $$<)
 	$$(Q)$$(call CFG_RUN_TEST_$(2),$$<,$(2),$(3)) $$(TESTARGS)	\
 	--logfile $$(call TEST_LOG_FILE,$(1),$(2),$(3),$(4)) \
@@ -360,7 +360,7 @@ define DEF_TEST_CRATE_RULES_arm-linux-androideabi
 check-stage$(1)-T-$(2)-H-$(3)-$(4)-exec: $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4))
 
 $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
-		$(3)/test/$(4)test.stage$(1)-$(2)$$(X_$(2))
+		$(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2))
 	@$$(call E, run: $$< via adb)
 	@$(CFG_ADB) push $$< $(CFG_ADB_TEST_DIR)
 	@$(CFG_ADB) shell LD_LIBRARY_PATH=$(CFG_ADB_TEST_DIR) \
@@ -385,7 +385,7 @@ define DEF_TEST_CRATE_RULES_null
 check-stage$(1)-T-$(2)-H-$(3)-$(4)-exec: $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4))
 
 $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
-		$(3)/test/$(4)test.stage$(1)-$(2)$$(X_$(2))
+		$(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2))
 	@$$(call E, run: skipped $$< )
 	@touch $$@
 endef

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -437,21 +437,13 @@ mod tests {
         }
     }
 
-    fn super_simple() {
+    fn run_cmds(cmds: &[&str]) {
         let mut r = repl();
-        let result = run_line(&mut r, io::stdin(), io::stdout(), ~"", false);
-        result.expect("empty input shouldn't fail in rusti");
-    }
-
-    fn use_does_not_crash() {
-        // Regression tests for #5937
-        let mut r = repl();
-        let result = run_line(&mut r, io::stdin(), io::stdout(),
-                              ~"use core::util::with;", false);
-        r = result.expect("use statements should't fail in rusti");
-        let result = run_line(&mut r, io::stdin(), io::stdout(),
-                              ~"", false);
-        result.expect("something should be able to happen after a use statement");
+        for cmds.each |&cmd| {
+            let result = run_line(&mut r, io::stdin(), io::stdout(),
+                                  cmd.to_owned(), false);
+            r = result.expect(fmt!("the command '%s' failed", cmd));
+        }
     }
 
     #[test]
@@ -464,8 +456,17 @@ mod tests {
         //
         // To get some interesting output, run with RUST_LOG=rusti::tests
 
-        debug!("super_simple");       super_simple();
-        debug!("use_does_not_crash"); use_does_not_crash();
+        debug!("hopefully this runs");
+        run_cmds([""]);
 
+        debug!("regression test for #5937");
+        run_cmds(["use core;", ""]);
+
+        debug!("regression test for #5784");
+        run_cmds(["let a = 1;"]);
+
+        debug!("regression test for #5803");
+        run_cmds(["spawn( || println(\"Please don't segfault\") );",
+                  "do spawn { println(\"Please?\"); }"]);
     }
 }

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -122,7 +122,7 @@ fn run(repl: Repl, input: ~str) -> Repl {
 
     debug!("building driver input");
     let head = include_str!("wrapper.rs").to_owned();
-    let foot = fmt!("%s\nfn main() {\n%s\n\nprint({\n%s\n})\n}",
+    let foot = fmt!("fn main() {\n%s\n%s\n\nprint({\n%s\n})\n}",
                     repl.view_items, repl.stmts, input);
     let wrapped = driver::str_input(head + foot);
 
@@ -444,6 +444,7 @@ mod tests {
     }
 
     fn use_does_not_crash() {
+        // Regression tests for #5937
         let mut r = repl();
         let result = run_line(&mut r, io::stdin(), io::stdout(),
                               ~"use core::util::with;", false);

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -35,7 +35,7 @@ use std::rl;
  * A structure shared across REPL instances for storing history
  * such as statements and view items. I wish the AST was sendable.
  */
-struct Repl {
+pub struct Repl {
     prompt: ~str,
     binary: ~str,
     running: bool,
@@ -328,8 +328,8 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
 
 /// Executes a line of input, which may either be rust code or a
 /// :command. Returns a new Repl if it has changed.
-fn run_line(repl: &mut Repl, in: @io::Reader, out: @io::Writer, line: ~str,
-            use_rl: bool)
+pub fn run_line(repl: &mut Repl, in: @io::Reader, out: @io::Writer, line: ~str,
+                use_rl: bool)
     -> Option<Repl> {
     if line.starts_with(":") {
         let full = line.substr(1, line.len() - 1);
@@ -419,5 +419,52 @@ pub fn main() {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repl() -> Repl {
+        Repl {
+            prompt: ~"rusti> ",
+            binary: ~"rusti",
+            running: true,
+            view_items: ~"",
+            lib_search_paths: ~[],
+            stmts: ~""
+        }
+    }
+
+    fn super_simple() {
+        let mut r = repl();
+        let result = run_line(&mut r, io::stdin(), io::stdout(), ~"", false);
+        result.expect("empty input shouldn't fail in rusti");
+    }
+
+    fn use_does_not_crash() {
+        let mut r = repl();
+        let result = run_line(&mut r, io::stdin(), io::stdout(),
+                              ~"use core::util::with;", false);
+        r = result.expect("use statements should't fail in rusti");
+        let result = run_line(&mut r, io::stdin(), io::stdout(),
+                              ~"", false);
+        result.expect("something should be able to happen after a use statement");
+    }
+
+    #[test]
+    fn run_all() {
+        // By default, unit tests are run in parallel. Rusti, on the other hand,
+        // does not enjoy doing this. I suspect that it is because the LLVM
+        // bindings are not thread-safe (when running parallel tests, some tests
+        // were triggering assertions in LLVM (or segfaults). Hence, this
+        // function exists to run everything serially (sadface).
+        //
+        // To get some interesting output, run with RUST_LOG=rusti::tests
+
+        debug!("super_simple");       super_simple();
+        debug!("use_does_not_crash"); use_does_not_crash();
+
     }
 }

--- a/src/librusti/wrapper.rs
+++ b/src/librusti/wrapper.rs
@@ -18,8 +18,8 @@
 #[allow(unrecognized_lint)];
 #[allow(unused_imports)];
 #[allow(while_true)];
-#[allow(dead_assignment)];
 #[allow(unused_variable)];
+#[allow(dead_assignment)];
 #[allow(unused_unsafe)];
 #[allow(unused_mut)];
 

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -79,10 +79,10 @@ fn is_rwx(p: &Path) -> bool {
 
 fn test_sysroot() -> Path {
     // Totally gross hack but it's just for test cases.
-    // Infer the sysroot from the exe name and tack "stage2"
-    // onto it. (Did I mention it was a gross hack?)
+    // Infer the sysroot from the exe name and pray that it's right.
+    // (Did I mention it was a gross hack?)
     let self_path = os::self_exe_path().expect("Couldn't get self_exe path");
-    self_path.pop().push("stage2")
+    self_path.pop()
 }
 
 #[test]


### PR DESCRIPTION
These few commits address a few existing issues:
- #5469 - adding regression tests for `rusti`. This adds unit tests to the `rusti.rc` file (which needed some reorganization of the Makefile, see the first commit message). These are super-simple right now, and sadly can't test the output of the tests. I worked for a bit on making a compiletest version of the rusti tests, but I ended up hitting something which blocked me, although I've forgotten it by this point.
- #5937 - regression test added, and it's fixed
- #5803 - just doesn't appear to happen any more
- #5784 - it's no longer broken, and it no longer spits out warnings about unused variables.

I also did some investigation into #5774, and you may want to read the comment I left on the bug. The gist of the situation is that C++ exceptions across JIT code don't look like they're working, even though they [should be working](https://github.com/mozilla/rust/blob/3aa1122ec25d15a2a73a295f8298ad9c38b09a10/src/rustllvm/RustWrapper.cpp#L387). If anyone has any insight on this, that would be awesome!
