### PR TITLE
Reform rational

### DIFF
--- a/src/libstd/num/bigint.rs
+++ b/src/libstd/num/bigint.rs
@@ -144,6 +144,8 @@ impl FromStr for BigUint {
     }
 }
 
+impl Num for BigUint {}
+
 impl Shl<uint, BigUint> for BigUint {
     #[inline(always)]
     fn shl(&self, rhs: &uint) -> BigUint {
@@ -787,6 +789,8 @@ impl FromStr for BigInt {
         FromStrRadix::from_str_radix(s, 10)
     }
 }
+
+impl Num for BigInt {}
 
 impl Shl<uint, BigInt> for BigInt {
     #[inline(always)]

--- a/src/libstd/num/bigint.rs
+++ b/src/libstd/num/bigint.rs
@@ -17,7 +17,7 @@ A BigInt is a combination of BigUint and Sign.
 */
 
 use core::cmp::{Eq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater};
-use core::num::{IntConvertible, Zero, One, ToStrRadix, FromStrRadix};
+use core::num::{IntConvertible, Zero, One, ToStrRadix, FromStrRadix, Orderable};
 
 /**
 A BigDigit is a BigUint's composing element.
@@ -145,6 +145,24 @@ impl FromStr for BigUint {
 }
 
 impl Num for BigUint {}
+
+impl Orderable for BigUint {
+    #[inline(always)]
+    fn min(&self, other: &BigUint) -> BigUint {
+        if self < other { self.clone() } else { other.clone() }
+    }
+
+    #[inline(always)]
+    fn max(&self, other: &BigUint) -> BigUint {
+        if self > other { self.clone() } else { other.clone() }
+    }
+
+    #[inline(always)]
+    fn clamp(&self, mn: &BigUint, mx: &BigUint) -> BigUint {
+        if self > mx { mx.clone() } else
+        if self < mn { mn.clone() } else { self.clone() }
+    }
+}
 
 impl Shl<uint, BigUint> for BigUint {
     #[inline(always)]
@@ -791,6 +809,24 @@ impl FromStr for BigInt {
 }
 
 impl Num for BigInt {}
+
+impl Orderable for BigInt {
+    #[inline(always)]
+    fn min(&self, other: &BigInt) -> BigInt {
+        if self < other { self.clone() } else { other.clone() }
+    }
+
+    #[inline(always)]
+    fn max(&self, other: &BigInt) -> BigInt {
+        if self > other { self.clone() } else { other.clone() }
+    }
+
+    #[inline(always)]
+    fn clamp(&self, mn: &BigInt, mx: &BigInt) -> BigInt {
+        if self > mx { mx.clone() } else
+        if self < mn { mn.clone() } else { self.clone() }
+    }
+}
 
 impl Shl<uint, BigInt> for BigInt {
     #[inline(always)]

--- a/src/libstd/num/rational.rs
+++ b/src/libstd/num/rational.rs
@@ -283,7 +283,7 @@ impl<T: FromStrRadix + Clone + Integer + Ord>
 #[cfg(test)]
 mod test {
     use super::*;
-    use core::num::{Zero,One,FromStrRadix};
+    use core::num::{Zero,One,FromStrRadix,IntConvertible};
     use core::from_str::FromStr;
 
     pub static _0 : Rational = Ratio { numer: 0, denom: 1};
@@ -293,6 +293,12 @@ mod test {
     pub static _3_2: Rational = Ratio { numer: 3, denom: 2};
     pub static _neg1_2: Rational =  Ratio { numer: -1, denom: 2};
 
+    pub fn to_big(n: Rational) -> BigRational {
+        Ratio::new(
+            IntConvertible::from_int(n.numer),
+            IntConvertible::from_int(n.denom)
+        )
+    }
 
     #[test]
     fn test_test_constants() {
@@ -340,45 +346,75 @@ mod test {
 
         #[test]
         fn test_add() {
-            assert_eq!(_1 + _1_2, _3_2);
-            assert_eq!(_1 + _1, _2);
-            assert_eq!(_1_2 + _3_2, _2);
-            assert_eq!(_1_2 + _neg1_2, _0);
+            fn test(a: Rational, b: Rational, c: Rational) {
+                assert_eq!(a + b, c);
+                assert_eq!(to_big(a) + to_big(b), to_big(c));
+            }
+
+            test(_1, _1_2, _3_2);
+            test(_1, _1, _2);
+            test(_1_2, _3_2, _2);
+            test(_1_2, _neg1_2, _0);
         }
 
         #[test]
         fn test_sub() {
-            assert_eq!(_1 - _1_2, _1_2);
-            assert_eq!(_3_2 - _1_2, _1);
-            assert_eq!(_1 - _neg1_2, _3_2);
+            fn test(a: Rational, b: Rational, c: Rational) {
+                assert_eq!(a - b, c);
+                assert_eq!(to_big(a) - to_big(b), to_big(c))
+            }
+
+            test(_1, _1_2, _1_2);
+            test(_3_2, _1_2, _1);
+            test(_1, _neg1_2, _3_2);
         }
 
         #[test]
         fn test_mul() {
-            assert_eq!(_1 * _1_2, _1_2);
-            assert_eq!(_1_2 * _3_2, Ratio::new(3,4));
-            assert_eq!(_1_2 * _neg1_2, Ratio::new(-1, 4));
+            fn test(a: Rational, b: Rational, c: Rational) {
+                assert_eq!(a * b, c);
+                assert_eq!(to_big(a) * to_big(b), to_big(c))
+            }
+
+            test(_1, _1_2, _1_2);
+            test(_1_2, _3_2, Ratio::new(3,4));
+            test(_1_2, _neg1_2, Ratio::new(-1, 4));
         }
 
         #[test]
         fn test_div() {
-            assert_eq!(_1 / _1_2, _2);
-            assert_eq!(_3_2 / _1_2, _1 + _2);
-            assert_eq!(_1 / _neg1_2, _neg1_2 + _neg1_2 + _neg1_2 + _neg1_2);
+            fn test(a: Rational, b: Rational, c: Rational) {
+                assert_eq!(a / b, c);
+                assert_eq!(to_big(a) / to_big(b), to_big(c))
+            }
+
+            test(_1, _1_2, _2);
+            test(_3_2, _1_2, _1 + _2);
+            test(_1, _neg1_2, _neg1_2 + _neg1_2 + _neg1_2 + _neg1_2);
         }
 
         #[test]
         fn test_rem() {
-            assert_eq!(_3_2 % _1, _1_2);
-            assert_eq!(_2 % _neg1_2, _0);
-            assert_eq!(_1_2 % _2,  _1_2);
+            fn test(a: Rational, b: Rational, c: Rational) {
+                assert_eq!(a % b, c);
+                assert_eq!(to_big(a) % to_big(b), to_big(c))
+            }
+
+            test(_3_2, _1, _1_2);
+            test(_2, _neg1_2, _0);
+            test(_1_2, _2,  _1_2);
         }
 
         #[test]
         fn test_neg() {
-            assert_eq!(-_0, _0);
-            assert_eq!(-_1_2, _neg1_2);
-            assert_eq!(-(-_1), _1);
+            fn test(a: Rational, b: Rational) {
+                assert_eq!(-a, b);
+                assert_eq!(-to_big(a), to_big(b))
+            }
+
+            test(_0, _0);
+            test(_1_2, _neg1_2);
+            test(-_1, _1);
         }
         #[test]
         fn test_zero() {


### PR DESCRIPTION
`std::ratio` module contains `BigRational` type, but the type is not usable by following reasons.
- `Ratio::new` requires `T: Copy + Num + Ord`, but `BigInt` is not implicitly copyable, because it contains unique vector.
- `BigInt` is not implements `Num`

So, I rewrite `Ratio` as follows.
- `Ratio` requires `T: Clone + Integer + Ord`.
  - `Copy` -> `Clone`: to be able to use `BigRational`
  - `Num` -> `Integer`: It is incorrect that a rational number constructed by two non-integer numbers.
- `BigInt` implements `Num` and `Orderable` which are required by `Integer` bound
