### PR TITLE
Add inlining for iter_bytes for types used as hashmap keys

### DIFF
--- a/src/libcore/to_bytes.rs
+++ b/src/libcore/to_bytes.rs
@@ -458,6 +458,7 @@ pub fn iter_bytes_2<A:IterBytes,B:IterBytes>(a: &A, b: &B,
     b.iter_bytes(lsb0, |bytes| {flag = z(bytes); flag});
 }
 #[cfg(not(stage0))]
+#[inline(always)]
 pub fn iter_bytes_2<A:IterBytes,B:IterBytes>(a: &A, b: &B,
                                              lsb0: bool, z: Cb) -> bool {
     a.iter_bytes(lsb0, z) && b.iter_bytes(lsb0, z)

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -98,12 +98,14 @@ impl<D:Decoder> Decodable<D> for ident {
 
 #[cfg(stage0)]
 impl to_bytes::IterBytes for ident {
+    #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         self.repr.iter_bytes(lsb0, f)
     }
 }
 #[cfg(not(stage0))]
 impl to_bytes::IterBytes for ident {
+    #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         self.repr.iter_bytes(lsb0, f)
     }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -357,12 +357,14 @@ impl<'self> Equiv<@~str> for StringRef<'self> {
 
 #[cfg(stage0)]
 impl<'self> to_bytes::IterBytes for StringRef<'self> {
+    #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) {
         (**self).iter_bytes(lsb0, f);
     }
 }
 #[cfg(not(stage0))]
 impl<'self> to_bytes::IterBytes for StringRef<'self> {
+    #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         (**self).iter_bytes(lsb0, f)
     }


### PR DESCRIPTION
Not inlining these affects the hash table performance quite badly.
