### PR TITLE
add a Clone impl for borrowed pointers

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -51,6 +51,12 @@ impl<T> Clone for @mut T {
     fn clone(&self) -> @mut T { *self }
 }
 
+impl<'self, T> Clone for &'self T {
+    /// Return a shallow copy of the borrowed pointer.
+    #[inline(always)]
+    fn clone(&self) -> &'self T { *self }
+}
+
 macro_rules! clone_impl(
     ($t:ty) => {
         impl Clone for $t {
@@ -101,4 +107,12 @@ fn test_managed_mut_clone() {
     assert!(a == b);
     *b = 10;
     assert!(a == b);
+}
+
+#[test]
+fn test_borrowed_clone() {
+    let x = 5i;
+    let y: &int = &x;
+    let z: &int = (&y).clone();
+    assert_eq!(*z, 5);
 }


### PR DESCRIPTION
somewhat annoying to actually call thanks to auto-deref, but it does let `deriving(Clone)` work
