### PR TITLE
Implement sin_cos method for float, f64 and f32

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -414,6 +414,12 @@ impl Trigonometric for f32 {
 
     #[inline(always)]
     fn atan2(&self, other: f32) -> f32 { atan2(*self, other) }
+
+    /// Simultaneously computes the sine and cosine of the number
+    #[inline(always)]
+    fn sin_cos(&self) -> (f32, f32) {
+        (self.sin(), self.cos())
+    }
 }
 
 impl Exponential for f32 {

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -426,6 +426,12 @@ impl Trigonometric for f64 {
 
     #[inline(always)]
     fn atan2(&self, other: f64) -> f64 { atan2(*self, other) }
+
+    /// Simultaneously computes the sine and cosine of the number
+    #[inline(always)]
+    fn sin_cos(&self) -> (f64, f64) {
+        (self.sin(), self.cos())
+    }
 }
 
 impl Exponential for f64 {

--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -530,6 +530,14 @@ impl Trigonometric for float {
     fn atan2(&self, other: float) -> float {
         (*self as f64).atan2(other as f64) as float
     }
+
+    /// Simultaneously computes the sine and cosine of the number
+    #[inline(always)]
+    fn sin_cos(&self) -> (float, float) {
+        match (*self as f64).sin_cos() {
+            (s, c) => (s as float, c as float)
+        }
+    }
 }
 
 impl Exponential for float {

--- a/src/libcore/num/num.rs
+++ b/src/libcore/num/num.rs
@@ -118,6 +118,7 @@ pub trait Trigonometric {
     fn acos(&self) -> Self;
     fn atan(&self) -> Self;
     fn atan2(&self, other: Self) -> Self;
+    fn sin_cos(&self) -> (Self, Self);
 }
 
 pub trait Exponential {


### PR DESCRIPTION
As discussed on issue #4819. This is a naive implementation, trusting LLVM to do the relevant optimizations. In the future this could be implemented more efficiently, but it's a start.
