### PR TITLE
Add Iterator util methods/traits

### DIFF
--- a/src/libcore/iterator.rs
+++ b/src/libcore/iterator.rs
@@ -53,6 +53,8 @@ pub trait IteratorUtil<A> {
     fn last(&mut self) -> A;
     fn fold<B>(&mut self, start: B, f: &fn(B, A) -> B) -> B;
     fn count(&mut self) -> uint;
+    fn all(&mut self, f: &fn(&A) -> bool) -> bool;
+    fn any(&mut self, f: &fn(&A) -> bool) -> bool;
 }
 
 /// Iterator adaptors provided for every `Iterator` implementation. The adaptor objects are also
@@ -204,6 +206,18 @@ impl<A, T: Iterator<A>> IteratorUtil<A> for T {
     /// Count the number of an iterator elemenrs
     #[inline(always)]
     fn count(&mut self) -> uint { self.fold(0, |cnt, _x| cnt + 1) }
+
+    #[inline(always)]
+    fn all(&mut self, f: &fn(&A) -> bool) -> bool {
+        for self.advance |x| { if !f(&x) { return false; } }
+        return true;
+    }
+
+    #[inline(always)]
+    fn any(&mut self, f: &fn(&A) -> bool) -> bool {
+        for self.advance |x| { if f(&x) { return true; } }
+        return false;
+    }
 }
 
 pub trait AdditiveIterator<A> {
@@ -754,4 +768,21 @@ mod tests {
         assert_eq!(v.slice(0, 0).iter().transform(|&x| x).min(), None);
     }
 
+    #[test]
+    fn test_all() {
+        let v = ~&[1, 2, 3, 4, 5];
+        assert!(v.iter().all(|&x| *x < 10));
+        assert!(!v.iter().all(|&x| x.is_even()));
+        assert!(!v.iter().all(|&x| *x > 100));
+        assert!(v.slice(0, 0).iter().all(|_| fail!()));
+    }
+
+    #[test]
+    fn test_any() {
+        let v = ~&[1, 2, 3, 4, 5];
+        assert!(v.iter().any(|&x| *x < 10));
+        assert!(v.iter().any(|&x| x.is_even()));
+        assert!(!v.iter().any(|&x| *x > 100));
+        assert!(!v.slice(0, 0).iter().any(|_| fail!()));
+    }
 }

--- a/src/libcore/iterator.rs
+++ b/src/libcore/iterator.rs
@@ -45,6 +45,7 @@ pub trait IteratorUtil<A> {
     fn advance(&mut self, f: &fn(A) -> bool);
     #[cfg(not(stage0))]
     fn advance(&mut self, f: &fn(A) -> bool) -> bool;
+    fn to_vec(self) -> ~[A];
 }
 
 /// Iterator adaptors provided for every `Iterator` implementation. The adaptor objects are also
@@ -130,6 +131,14 @@ impl<A, T: Iterator<A>> IteratorUtil<A> for T {
                 None => { return true; }
             }
         }
+    }
+
+    #[inline(always)]
+    fn to_vec(self) -> ~[A] {
+        let mut v = ~[];
+        let mut it = self;
+        for it.advance() |x| { v.push(x); }
+        return v;
     }
 }
 

--- a/src/libcore/iterator.rs
+++ b/src/libcore/iterator.rs
@@ -50,6 +50,8 @@ pub trait IteratorUtil<A> {
     fn nth(&mut self, n: uint) -> A;
     fn first(&mut self) -> A;
     fn last(&mut self) -> A;
+    fn fold<B>(&mut self, start: B, f: &fn(B, A) -> B) -> B;
+    fn count(&mut self) -> uint;
 }
 
 /// Iterator adaptors provided for every `Iterator` implementation. The adaptor objects are also
@@ -184,6 +186,23 @@ impl<A, T: Iterator<A>> IteratorUtil<A> for T {
         for self.advance |e| { elm = e; }
         return elm;
     }
+
+    /// Reduce an iterator to an accumulated value
+    #[inline]
+    fn fold<B>(&mut self, init: B, f: &fn(B, A) -> B) -> B {
+        let mut accum = init;
+        loop {
+            match self.next() {
+                Some(x) => { accum = f(accum, x); }
+                None    => { break; }
+            }
+        }
+        return accum;
+    }
+
+    /// Count the number of an iterator elemenrs
+    #[inline(always)]
+    fn count(&mut self) -> uint { self.fold(0, |cnt, _x| cnt + 1) }
 }
 
 pub struct ChainIterator<T, U> {
@@ -647,5 +666,13 @@ mod tests {
     fn test_iterator_last_fail() {
         let v: &[uint] = &[];
         v.iter().last();
+    }
+
+    #[test]
+    fn test_iterator_count() {
+        let v = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        assert_eq!(v.slice(0, 4).iter().count(), 4);
+        assert_eq!(v.slice(0, 10).iter().count(), 10);
+        assert_eq!(v.slice(0, 0).iter().count(), 0);
     }
 }


### PR DESCRIPTION
This pull request adds following methods and traits.

``` rust
pub trait IteratorUtil {
(snip)
    fn filter_map<'r,  B>(self, f: &'r fn(A) -> Option<B>) -> FilterMapIterator<'r, A, B, Self>;
(snip)
    fn to_vec(self) -> ~[A];
    fn nth(&mut self, n: uint) -> A;
    fn first(&mut self) -> A;
    fn last(&mut self) -> A;
    fn fold<B>(&mut self, start: B, f: &fn(B, A) -> B) -> B;
    fn count(&mut self) -> uint;
    fn all(&mut self, f: &fn(&A) -> bool) -> bool;
    fn any(&mut self, f: &fn(&A) -> bool) -> bool;
}

pub trait AdditiveIterator<A> {
    fn sum(&mut self) -> A;
}

pub trait MultiplicativeIterator<A> {
    fn product(&mut self) -> A;
}

pub trait OrdIterator<A> {
    fn max(&mut self) -> Option<A>;
    fn min(&mut self) -> Option<A>;
}
```
