### PR TITLE
reduce the usage of explicit version markers

### DIFF
--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -12,7 +12,7 @@
 
 #[allow(non_camel_case_types)];
 
-extern mod std(vers = "0.7-pre");
+extern mod std;
 
 use core::*;
 

--- a/src/driver/driver.rs
+++ b/src/driver/driver.rs
@@ -9,21 +9,21 @@
 // except according to those terms.
 
 #[cfg(rustpkg)]
-extern mod this(name = "rustpkg", vers = "0.7-pre");
+extern mod this(name = "rustpkg");
 
 #[cfg(fuzzer)]
-extern mod this(name = "fuzzer", vers = "0.7-pre");
+extern mod this(name = "fuzzer");
 
 #[cfg(rustdoc)]
-extern mod this(name = "rustdoc", vers = "0.7-pre");
+extern mod this(name = "rustdoc");
 
 #[cfg(rusti)]
-extern mod this(name = "rusti", vers = "0.7-pre");
+extern mod this(name = "rusti");
 
 #[cfg(rust)]
-extern mod this(name = "rust", vers = "0.7-pre");
+extern mod this(name = "rust");
 
 #[cfg(rustc)]
-extern mod this(name = "rustc", vers = "0.7-pre");
+extern mod this(name = "rustc");
 
 fn main() { this::main() }

--- a/src/libcore/core.rc
+++ b/src/libcore/core.rc
@@ -63,7 +63,7 @@ they contained the following prologue:
 #[deny(non_camel_case_types)];
 
 // Make core testable by not duplicating lang items. See #2912
-#[cfg(test)] extern mod realcore(name = "core", vers = "0.7-pre");
+#[cfg(test)] extern mod realcore(name = "core");
 #[cfg(test)] pub use kinds = realcore::kinds;
 #[cfg(test)] pub use ops = realcore::ops;
 #[cfg(test)] pub use cmp = realcore::cmp;

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -20,8 +20,8 @@
 
 #[allow(non_camel_case_types)];
 
-extern mod std(vers = "0.7-pre");
-extern mod syntax(vers = "0.7-pre");
+extern mod std;
+extern mod syntax;
 
 use core::run;
 

--- a/src/librust/rust.rc
+++ b/src/librust/rust.rc
@@ -20,10 +20,10 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-extern mod rustpkg(vers = "0.7-pre");
-extern mod rustdoc(vers = "0.7-pre");
-extern mod rusti(vers = "0.7-pre");
-extern mod rustc(vers = "0.7-pre");
+extern mod rustpkg;
+extern mod rustdoc;
+extern mod rusti;
+extern mod rustc;
 
 use core::run;
 

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -21,9 +21,8 @@
 #[allow(non_camel_case_types)];
 #[deny(deprecated_pattern)];
 
-extern mod std(vers = "0.7-pre");
-extern mod syntax(vers = "0.7-pre");
-
+extern mod std;
+extern mod syntax;
 
 use driver::driver::{host_triple, optgroups, early_error};
 use driver::driver::{str_input, file_input, build_session_options};

--- a/src/librustdoc/rustdoc.rc
+++ b/src/librustdoc/rustdoc.rc
@@ -21,9 +21,9 @@
 
 #[allow(non_implicitly_copyable_typarams)];
 
-extern mod std(vers = "0.7-pre");
-extern mod rustc(vers = "0.7-pre");
-extern mod syntax(vers = "0.7-pre");
+extern mod std;
+extern mod rustc;
+extern mod syntax;
 
 use config::Config;
 use doc::Item;

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -18,9 +18,9 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-extern mod std(vers = "0.7-pre");
-extern mod rustc(vers = "0.7-pre");
-extern mod syntax(vers = "0.7-pre");
+extern mod std;
+extern mod rustc;
+extern mod syntax;
 
 use core::*;
 use core::cell::Cell;

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -18,9 +18,9 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-extern mod std(vers = "0.7-pre");
-extern mod rustc(vers = "0.7-pre");
-extern mod syntax(vers = "0.7-pre");
+extern mod std;
+extern mod rustc;
+extern mod syntax;
 
 use core::*;
 pub use core::path::Path;

--- a/src/libsyntax/syntax.rc
+++ b/src/libsyntax/syntax.rc
@@ -23,7 +23,7 @@
 #[allow(non_camel_case_types)];
 #[deny(deprecated_pattern)];
 
-extern mod std(vers = "0.7-pre");
+extern mod std;
 
 // allow the interner_key macro
 // to escape this module:


### PR DESCRIPTION
I don't see a reason to encode this information in all the `extern mod` statements, it's not a precise enough version to actually provide any sort of robustness.
