### PR TITLE
rustc: Add inline(maybe), which only writes the AST to crate metadata.

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -719,7 +719,7 @@ fn purity_static_method_family(p: purity) -> char {
 fn should_inline(attrs: &[attribute]) -> bool {
     match attr::find_inline_attr(attrs) {
         attr::ia_none | attr::ia_never  => false,
-        attr::ia_hint | attr::ia_always => true
+        attr::ia_maybe | attr::ia_hint | attr::ia_always => true
     }
 }
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -452,7 +452,7 @@ pub fn set_inline_hint_if_appr(attrs: &[ast::attribute],
       attr::ia_hint => set_inline_hint(llfn),
       attr::ia_always => set_always_inline(llfn),
       attr::ia_never => set_no_inline(llfn),
-      attr::ia_none => { /* fallthrough */ }
+      attr::ia_maybe | attr::ia_none => { /* fallthrough */ }
     }
 }
 

--- a/src/librustc/middle/trans/reachable.rs
+++ b/src/librustc/middle/trans/reachable.rs
@@ -117,7 +117,7 @@ fn traverse_public_item(cx: @mut ctx, item: @item) {
       }
       item_fn(_, _, _, ref generics, ref blk) => {
         if generics.ty_params.len() > 0u ||
-           attr::find_inline_attr(item.attrs) != attr::ia_none {
+           attr::find_inline_attr(item.attrs) != attr::ia_none { // XXX why is this ia_none?
             traverse_inline_body(cx, blk);
         }
       }
@@ -125,7 +125,7 @@ fn traverse_public_item(cx: @mut ctx, item: @item) {
         for ms.each |m| {
             if generics.ty_params.len() > 0u ||
                 m.generics.ty_params.len() > 0u ||
-                attr::find_inline_attr(m.attrs) != attr::ia_none
+                attr::find_inline_attr(m.attrs) != attr::ia_none // XXX why is this ia_none?
             {
                 {
                     let cx = &mut *cx; // FIXME(#6269) reborrow @mut to &mut

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -304,6 +304,9 @@ pub fn find_linkage_metas(attrs: &[ast::attribute]) -> ~[@ast::meta_item] {
 #[deriving(Eq)]
 pub enum inline_attr {
     ia_none,
+    // just write the inlining info to crate metadata, don't hint
+    // LLVM, because that can be too forceful
+    ia_maybe,
     ia_hint,
     ia_always,
     ia_never,
@@ -316,7 +319,9 @@ pub fn find_inline_attr(attrs: &[ast::attribute]) -> inline_attr {
         match attr.node.value.node {
           ast::meta_word(@~"inline") => ia_hint,
           ast::meta_list(@~"inline", ref items) => {
-            if !find_meta_items_by_name(*items, "always").is_empty() {
+            if !find_meta_items_by_name(*items, "maybe").is_empty() {
+                ia_maybe
+            } else if !find_meta_items_by_name(*items, "always").is_empty() {
                 ia_always
             } else if !find_meta_items_by_name(*items, "never").is_empty() {
                 ia_never


### PR DESCRIPTION
This gives LLVM the data required to inline (i.e. writes the AST to the crate), but doesn't force it to, like `#[inline]` (which is actually just a hint, but is apparently very aggressive) or `#[inline(always)]`.

I'm not sure how to test, but given:

``` rust
// inline_maybe.rs
#[inline(maybe)]
pub fn foo() -> int { 1 }

// inline_maybe2.rs
extern mod inline_maybe;
use inline_maybe::foo;
fn main() {
    if foo() == 2 {
        print("hi");
    }
}
```

With a pre-`inline(maybe)` rustc the asm for `inline_maybe2.rs` contains:

``` asm
    callq   _ZN3foo15_8faebfb4af26143_00E@PLT
    cmpq    $1, %rax
    jne .LBB0_4
```

With this patch, the `foo` call is inlined and constant-folded away. (with `-O`.)

With a huge `foo` (that wouldn't be normally inlined, even within the same crate) with `inline(maybe)`, the actual call remains in `inline_maybe2`, i.e. it isn't inlined.

I'm not sure about two lines (my line comment), but I'm unsure who's most appropriate to consult/familiar with this code.
