### PR TITLE
Add a lint mode for unnecessary allocations

### DIFF
--- a/src/libcore/os.rs
+++ b/src/libcore/os.rs
@@ -509,7 +509,7 @@ pub fn self_exe_path() -> Option<Path> {
  * Otherwise, homedir returns option::none.
  */
 pub fn homedir() -> Option<Path> {
-    return match getenv(~"HOME") {
+    return match getenv("HOME") {
         Some(ref p) => if !str::is_empty(*p) {
           Some(Path(*p))
         } else {

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1808,7 +1808,7 @@ pub fn to_utf16(s: &str) -> ~[u16] {
             ch -= 0x1_0000_u32;
             let w1 = 0xD800_u16 | ((ch >> 10) as u16);
             let w2 = 0xDC00_u16 | ((ch as u16) & 0x3FF_u16);
-            u.push_all(~[w1, w2])
+            u.push_all([w1, w2])
         }
     }
     u

--- a/src/libcore/unstable/extfmt.rs
+++ b/src/libcore/unstable/extfmt.rs
@@ -178,7 +178,7 @@ pub mod ct {
                 i += 1;
 
                 if i >= lim {
-                    err(~"unterminated conversion at end of string");
+                    err("unterminated conversion at end of string");
                 } else if s[i] == '%' as u8 {
                     push_slice(&mut pieces, s, h, i);
                     i += 1;
@@ -309,7 +309,7 @@ pub mod ct {
 
     pub fn parse_type(s: &str, i: uint, lim: uint, err: ErrorFn) ->
         Parsed<Ty> {
-        if i >= lim { err(~"missing type in conversion"); }
+        if i >= lim { err("missing type in conversion"); }
 
         // FIXME (#2249): Do we really want two signed types here?
         // How important is it to be printf compatible?

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -387,8 +387,8 @@ pub mod write {
                 fmt!("%s/bin/arm-linux-androideabi-gcc", path)
             }
             &None => {
-                sess.fatal(~"need Android NDK path for building \
-                             (--android-cross-path)")
+                sess.fatal("need Android NDK path for building \
+                            (--android-cross-path)")
             }
         };
         let mut cc_args = ~[];
@@ -403,7 +403,7 @@ pub mod write {
             sess.err(fmt!("building with `%s` failed with code %d",
                         cc_prog, prog.status));
             sess.note(fmt!("%s arguments: %s",
-                        cc_prog, str::connect(cc_args, ~" ")));
+                        cc_prog, str::connect(cc_args, " ")));
             sess.note(prog.err + prog.out);
             sess.abort_if_errors();
         }
@@ -566,7 +566,7 @@ pub fn build_link_meta(sess: Session,
                                   || fmt!("output file name `%s` doesn't\
                                            appear to have a stem",
                                           output.to_str())).to_managed();
-                warn_missing(sess, ~"name", name);
+                warn_missing(sess, "name", name);
                 name
               }
             };
@@ -577,7 +577,7 @@ pub fn build_link_meta(sess: Session,
               Some(v) => v,
               None => {
                 let vers = @"0.0";
-                warn_missing(sess, ~"vers", vers);
+                warn_missing(sess, "vers", vers);
                 vers
               }
             };
@@ -618,9 +618,9 @@ pub fn symbol_hash(tcx: ty::ctxt,
 
     symbol_hasher.reset();
     write_string(symbol_hasher, link_meta.name);
-    write_string(symbol_hasher, ~"-");
+    write_string(symbol_hasher, "-");
     write_string(symbol_hasher, link_meta.extras_hash);
-    write_string(symbol_hasher, ~"-");
+    write_string(symbol_hasher, "-");
     write_string(symbol_hasher, encoder::encoded_ty(tcx, t));
     let mut hash = truncated_hash_result(symbol_hasher);
     // Prefix with _ so that it never blends into adjacent digits
@@ -770,8 +770,8 @@ pub fn link_binary(sess: Session,
                         fmt!("%s/bin/arm-linux-androideabi-gcc", path)
                     }
                     &None => {
-                        sess.fatal(~"need Android NDK path for linking \
-                                     (--android-cross-path)")
+                        sess.fatal("need Android NDK path for linking \
+                                    (--android-cross-path)")
                     }
                 }
             } else if sess.targ_cfg.os == session::os_win32 {
@@ -798,21 +798,21 @@ pub fn link_binary(sess: Session,
 
     debug!("output: %s", output.to_str());
     let cc_args = link_args(sess, obj_filename, out_filename, lm);
-    debug!("%s link args: %s", cc_prog, str::connect(cc_args, ~" "));
+    debug!("%s link args: %s", cc_prog, str::connect(cc_args, " "));
     // We run 'cc' here
     let prog = run::program_output(cc_prog, cc_args);
     if 0 != prog.status {
         sess.err(fmt!("linking with `%s` failed with code %d",
                       cc_prog, prog.status));
         sess.note(fmt!("%s arguments: %s",
-                       cc_prog, str::connect(cc_args, ~" ")));
+                       cc_prog, str::connect(cc_args, " ")));
         sess.note(prog.err + prog.out);
         sess.abort_if_errors();
     }
 
     // Clean up on Darwin
     if sess.targ_cfg.os == session::os_macos {
-        run::run_program(~"dsymutil", ~[output.to_str()]);
+        run::run_program("dsymutil", [output.to_str()]);
     }
 
     // Remove the temporary object file if we aren't saving temps
@@ -920,7 +920,7 @@ pub fn link_args(sess: Session,
     // On linux librt and libdl are an indirect dependencies via rustrt,
     // and binutils 2.22+ won't add them automatically
     if sess.targ_cfg.os == session::os_linux {
-        args.push_all(~[~"-lrt", ~"-ldl"]);
+        args.push_all([~"-lrt", ~"-ldl"]);
 
         // LLVM implements the `frem` instruction as a call to `fmod`,
         // which lives in libm. Similar to above, on some linuxes we
@@ -928,19 +928,18 @@ pub fn link_args(sess: Session,
         args.push(~"-lm");
     }
     else if sess.targ_cfg.os == session::os_android {
-        args.push_all(~[~"-ldl", ~"-llog",  ~"-lsupc++",
-                           ~"-lgnustl_shared"]);
+        args.push_all([~"-ldl", ~"-llog",  ~"-lsupc++", ~"-lgnustl_shared"]);
         args.push(~"-lm");
     }
 
     if sess.targ_cfg.os == session::os_freebsd {
-        args.push_all(~[~"-pthread", ~"-lrt",
-                        ~"-L/usr/local/lib", ~"-lexecinfo",
-                        ~"-L/usr/local/lib/gcc46",
-                        ~"-L/usr/local/lib/gcc44", ~"-lstdc++",
-                        ~"-Wl,-z,origin",
-                        ~"-Wl,-rpath,/usr/local/lib/gcc46",
-                        ~"-Wl,-rpath,/usr/local/lib/gcc44"]);
+        args.push_all([~"-pthread", ~"-lrt",
+                       ~"-L/usr/local/lib", ~"-lexecinfo",
+                       ~"-L/usr/local/lib/gcc46",
+                       ~"-L/usr/local/lib/gcc44", ~"-lstdc++",
+                       ~"-Wl,-z,origin",
+                       ~"-Wl,-rpath,/usr/local/lib/gcc46",
+                       ~"-Wl,-rpath,/usr/local/lib/gcc44"]);
     }
 
     // OS X 10.6 introduced 'compact unwind info', which is produced by the

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -86,9 +86,9 @@ fn get_rpaths(os: session::os,
         }
     }
 
-    log_rpaths(~"relative", rel_rpaths);
-    log_rpaths(~"absolute", abs_rpaths);
-    log_rpaths(~"fallback", fallback_rpaths);
+    log_rpaths("relative", rel_rpaths);
+    log_rpaths("absolute", abs_rpaths);
+    log_rpaths("fallback", fallback_rpaths);
 
     let mut rpaths = rel_rpaths;
     rpaths.push_all(abs_rpaths);

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -332,7 +332,7 @@ pub fn building_library(req_crate_type: crate_type,
         } else {
             match syntax::attr::first_attr_value_str_by_name(
                 crate.node.attrs,
-                ~"crate_type") {
+                "crate_type") {
               Some(@~"lib") => true,
               _ => false
             }

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -175,7 +175,7 @@ fn in_cfg(cfg: ast::crate_cfg, attrs: ~[ast::attribute]) -> bool {
 pub fn metas_in_cfg(cfg: ast::crate_cfg,
                     metas: ~[@ast::meta_item]) -> bool {
     // The "cfg" attributes on the item
-    let cfg_metas = attr::find_meta_items_by_name(metas, ~"cfg");
+    let cfg_metas = attr::find_meta_items_by_name(metas, "cfg");
 
     // Pull the inner meta_items from the #[cfg(meta_item, ...)]  attributes,
     // so we can match against them. This is the list of configurations for

--- a/src/librustc/front/core_inject.rs
+++ b/src/librustc/front/core_inject.rs
@@ -28,7 +28,7 @@ pub fn maybe_inject_libcore_ref(sess: Session,
 }
 
 fn use_core(crate: @ast::crate) -> bool {
-    !attr::attrs_contains_name(crate.node.attrs, ~"no_core")
+    !attr::attrs_contains_name(crate.node.attrs, "no_core")
 }
 
 fn inject_libcore_ref(sess: Session,

--- a/src/librustc/front/intrinsic_inject.rs
+++ b/src/librustc/front/intrinsic_inject.rs
@@ -25,7 +25,7 @@ pub fn inject_intrinsic(sess: Session, crate: @ast::crate) -> @ast::crate {
         match item {
           Some(i) => i,
           None => {
-            sess.fatal(~"no item found in intrinsic module");
+            sess.fatal("no item found in intrinsic module");
           }
         };
 

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -93,8 +93,8 @@ fn strip_test_functions(crate: @ast::crate) -> @ast::crate {
     // When not compiling with --test we should not compile the
     // #[test] functions
     do config::strip_items(crate) |attrs| {
-        !attr::contains_name(attr::attr_metas(attrs), ~"test") &&
-        !attr::contains_name(attr::attr_metas(attrs), ~"bench")
+        !attr::contains_name(attr::attr_metas(attrs), "test") &&
+        !attr::contains_name(attr::attr_metas(attrs), "bench")
     }
 }
 
@@ -148,7 +148,7 @@ fn fold_item(cx: @mut TestCtxt, i: @ast::item, fld: @fold::ast_fold)
             let sess = cx.sess;
             sess.span_fatal(
                 i.span,
-                ~"unsafe functions cannot be used for tests");
+                "unsafe functions cannot be used for tests");
           }
           _ => {
             debug!("this is a test function");
@@ -172,7 +172,7 @@ fn fold_item(cx: @mut TestCtxt, i: @ast::item, fld: @fold::ast_fold)
 
 fn is_test_fn(cx: @mut TestCtxt, i: @ast::item) -> bool {
     let has_test_attr = !attr::find_attrs_by_name(i.attrs,
-                                                  ~"test").is_empty();
+                                                  "test").is_empty();
 
     fn has_test_signature(i: @ast::item) -> bool {
         match &i.node {
@@ -193,7 +193,7 @@ fn is_test_fn(cx: @mut TestCtxt, i: @ast::item) -> bool {
         let sess = cx.sess;
         sess.span_err(
             i.span,
-            ~"functions used as tests must have signature fn() -> ()."
+            "functions used as tests must have signature fn() -> ()."
         );
     }
     return has_test_attr && has_test_signature(i);
@@ -201,7 +201,7 @@ fn is_test_fn(cx: @mut TestCtxt, i: @ast::item) -> bool {
 
 fn is_bench_fn(i: @ast::item) -> bool {
     let has_bench_attr =
-        vec::len(attr::find_attrs_by_name(i.attrs, ~"bench")) > 0u;
+        vec::len(attr::find_attrs_by_name(i.attrs, "bench")) > 0u;
 
     fn has_test_signature(i: @ast::item) -> bool {
         match i.node {
@@ -239,7 +239,7 @@ fn is_ignored(cx: @mut TestCtxt, i: @ast::item) -> bool {
 }
 
 fn should_fail(i: @ast::item) -> bool {
-    vec::len(attr::find_attrs_by_name(i.attrs, ~"should_fail")) > 0u
+    vec::len(attr::find_attrs_by_name(i.attrs, "should_fail")) > 0u
 }
 
 fn add_test_module(cx: &TestCtxt, m: &ast::_mod) -> ast::_mod {
@@ -373,7 +373,7 @@ fn mk_tests(cx: &TestCtxt) -> @ast::item {
 fn is_std(cx: &TestCtxt) -> bool {
     let is_std = {
         let items = attr::find_linkage_metas(cx.crate.node.attrs);
-        match attr::last_meta_item_value_str_by_name(items, ~"name") {
+        match attr::last_meta_item_value_str_by_name(items, "name") {
           Some(@~"std") => true,
           _ => false
         }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -99,7 +99,7 @@ fn warn_if_multiple_versions(e: @mut Env,
             diag.handler().warn(
                 fmt!("using multiple versions of crate `%s`", *name));
             for matches.each |match_| {
-                diag.span_note(match_.span, ~"used here");
+                diag.span_note(match_.span, "used here");
                 let attrs = ~[
                     attr::mk_attr(attr::mk_list_item(
                         @~"link", /*bad*/copy *match_.metas))
@@ -164,7 +164,7 @@ fn visit_item(e: @mut Env, i: @ast::item) {
             ast::named => {
                 let foreign_name =
                     match attr::first_attr_value_str_by_name(i.attrs,
-                                                            ~"link_name") {
+                                                             "link_name") {
                         Some(nn) => {
                             if *nn == ~"" {
                                 e.diag.span_fatal(
@@ -176,7 +176,7 @@ fn visit_item(e: @mut Env, i: @ast::item) {
                         }
                         None => e.intr.get(i.ident)
                     };
-                if attr::find_attrs_by_name(i.attrs, ~"nolink").is_empty() {
+                if attr::find_attrs_by_name(i.attrs, "nolink").is_empty() {
                     already_added =
                         !cstore::add_used_library(cstore, foreign_name);
                 }
@@ -272,7 +272,7 @@ fn resolve_crate(e: @mut Env,
 
         let cname =
             match attr::last_meta_item_value_str_by_name(load_ctxt.metas,
-                                                         ~"name") {
+                                                         "name") {
                 Some(v) => v,
                 None => e.intr.get(ident),
             };

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -186,7 +186,7 @@ fn translated_parent_item_opt(cnum: ast::crate_num, d: ebml::Doc) ->
 
 fn item_reqd_and_translated_parent_item(cnum: ast::crate_num,
                                         d: ebml::Doc) -> ast::def_id {
-    let trait_did = item_parent_item(d).expect(~"item without parent");
+    let trait_did = item_parent_item(d).expect("item without parent");
     ast::def_id { crate: cnum, node: trait_did.node }
 }
 
@@ -785,8 +785,8 @@ pub fn get_provided_trait_methods(intr: @ident_interner, cdata: cmd,
         let fty = match ty::get(ty).sty {
             ty::ty_bare_fn(ref f) => copy *f,
             _ => {
-                tcx.diag.handler().bug(~"get_provided_trait_methods(): id \
-                                         has non-function type");
+                tcx.diag.handler().bug("get_provided_trait_methods(): id \
+                                        has non-function type");
             }
         };
 
@@ -1064,7 +1064,7 @@ fn list_crate_attributes(intr: @ident_interner, md: ebml::Doc, hash: &str,
         out.write_str(fmt!("%s\n", pprust::attribute_to_str(*attr, intr)));
     }
 
-    out.write_str(~"\n\n");
+    out.write_str("\n\n");
 }
 
 pub fn get_crate_attributes(data: @~[u8]) -> ~[ast::attribute] {
@@ -1097,7 +1097,7 @@ pub fn get_crate_deps(intr: @ident_interner, data: @~[u8]) -> ~[crate_dep] {
 }
 
 fn list_crate_deps(intr: @ident_interner, data: @~[u8], out: @io::Writer) {
-    out.write_str(~"=External Dependencies=\n");
+    out.write_str("=External Dependencies=\n");
 
     for get_crate_deps(intr, data).each |dep| {
         out.write_str(
@@ -1105,7 +1105,7 @@ fn list_crate_deps(intr: @ident_interner, data: @~[u8], out: @io::Writer) {
                  dep.cnum, *intr.get(dep.name), *dep.hash, *dep.vers));
     }
 
-    out.write_str(~"\n");
+    out.write_str("\n");
 }
 
 pub fn get_crate_hash(data: @~[u8]) -> @~str {
@@ -1118,7 +1118,7 @@ pub fn get_crate_vers(data: @~[u8]) -> @~str {
     let attrs = decoder::get_crate_attributes(data);
     let linkage_attrs = attr::find_linkage_metas(attrs);
 
-    match attr::last_meta_item_value_str_by_name(linkage_attrs, ~"vers") {
+    match attr::last_meta_item_value_str_by_name(linkage_attrs, "vers") {
         Some(ver) => ver,
         None => @~"0.0"
     }

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -846,7 +846,7 @@ fn encode_info_for_item(ecx: @EncodeContext,
                 struct_def.fields[0].node.kind == ast::unnamed_field {
             let ctor_id = match struct_def.ctor_id {
                 Some(ctor_id) => ctor_id,
-                None => ecx.tcx.sess.bug(~"struct def didn't have ctor id"),
+                None => ecx.tcx.sess.bug("struct def didn't have ctor id"),
             };
 
             encode_info_for_struct_ctor(ecx,
@@ -1067,7 +1067,7 @@ fn encode_info_for_items(ecx: @EncodeContext,
     ebml_w.start_tag(tag_items_data);
     index.push(entry { val: crate_node_id, pos: ebml_w.writer.tell() });
     encode_info_for_mod(ecx, ebml_w, &crate.node.module,
-                        crate_node_id, ~[],
+                        crate_node_id, [],
                         syntax::parse::token::special_idents::invalid);
     visit::visit_crate(crate, (), visit::mk_vt(@visit::Visitor {
         visit_expr: |_e, _cx, _v| { },
@@ -1235,8 +1235,8 @@ fn synthesize_crate_attrs(ecx: @EncodeContext,
 
         let other_items =
             {
-                let tmp = attr::remove_meta_items_by_name(items, ~"name");
-                attr::remove_meta_items_by_name(tmp, ~"vers")
+                let tmp = attr::remove_meta_items_by_name(items, "name");
+                attr::remove_meta_items_by_name(tmp, "vers")
             };
 
         let meta_items = vec::append(~[name_item, vers_item], other_items);

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -127,7 +127,7 @@ pub fn get_rustpkg_sysroot() -> Result<Path, ~str> {
 }
 
 pub fn get_rustpkg_root() -> Result<Path, ~str> {
-    match os::getenv(~"RUSTPKG_ROOT") {
+    match os::getenv("RUSTPKG_ROOT") {
         Some(ref _p) => result::Ok(Path((*_p))),
         None => match os::homedir() {
           Some(ref _q) => result::Ok((*_q).push(".rustpkg")),
@@ -181,5 +181,5 @@ pub fn libdir() -> ~str {
    if str::is_empty(libdir) {
       fail!("rustc compiled without CFG_LIBDIR environment variable");
    }
-   libdir
+   libdir.to_owned()
 }

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -120,7 +120,7 @@ fn find_library_crate_aux(
     } else {
         cx.diag.span_err(
             cx.span, fmt!("multiple matching crates for `%s`", *crate_name));
-        cx.diag.handler().note(~"candidates:");
+        cx.diag.handler().note("candidates:");
         for matches.each |&(ident, data)| {
             cx.diag.handler().note(fmt!("path: %s", ident));
             let attrs = decoder::get_crate_attributes(data);
@@ -132,7 +132,7 @@ fn find_library_crate_aux(
 }
 
 pub fn crate_name_from_metas(metas: &[@ast::meta_item]) -> @~str {
-    let name_items = attr::find_meta_items_by_name(metas, ~"name");
+    let name_items = attr::find_meta_items_by_name(metas, "name");
     match name_items.last_opt() {
         Some(i) => {
             match attr::get_meta_item_value_str(*i) {

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -155,7 +155,7 @@ fn enc_region(w: @io::Writer, cx: @ctxt, r: ty::Region) {
       }
       ty::re_infer(_) => {
         // these should not crop up after typeck
-        cx.diag.handler().bug(~"Cannot encode region variables");
+        cx.diag.handler().bug("Cannot encode region variables");
       }
     }
 }
@@ -301,7 +301,7 @@ fn enc_sty(w: @io::Writer, cx: @ctxt, st: ty::sty) {
         enc_bare_fn_ty(w, cx, f);
       }
       ty::ty_infer(_) => {
-        cx.diag.handler().bug(~"Cannot encode inference variable types");
+        cx.diag.handler().bug("Cannot encode inference variable types");
       }
       ty::ty_param(param_ty {idx: id, def_id: did}) => {
         w.write_char('p');
@@ -321,15 +321,15 @@ fn enc_sty(w: @io::Writer, cx: @ctxt, st: ty::sty) {
       }
       ty::ty_opaque_box => w.write_char('B'),
       ty::ty_struct(def, ref substs) => {
-          debug!("~~~~ %s", ~"a[");
+          debug!("~~~~ %s", "a[");
           w.write_str(&"a[");
           let s = (cx.ds)(def);
           debug!("~~~~ %s", s);
           w.write_str(s);
-          debug!("~~~~ %s", ~"|");
+          debug!("~~~~ %s", "|");
           w.write_char('|');
           enc_substs(w, cx, substs);
-          debug!("~~~~ %s", ~"]");
+          debug!("~~~~ %s", "]");
           w.write_char(']');
       }
       ty::ty_err => fail!("Shouldn't encode error type")

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -614,10 +614,10 @@ fn encode_vtable_res(ecx: @e::EncodeContext,
 fn encode_vtable_origin(ecx: @e::EncodeContext,
                         ebml_w: &mut writer::Encoder,
                         vtable_origin: &typeck::vtable_origin) {
-    do ebml_w.emit_enum(~"vtable_origin") |ebml_w| {
+    do ebml_w.emit_enum("vtable_origin") |ebml_w| {
         match *vtable_origin {
           typeck::vtable_static(def_id, ref tys, vtable_res) => {
-            do ebml_w.emit_enum_variant(~"vtable_static", 0u, 3u) |ebml_w| {
+            do ebml_w.emit_enum_variant("vtable_static", 0u, 3u) |ebml_w| {
                 do ebml_w.emit_enum_variant_arg(0u) |ebml_w| {
                     ebml_w.emit_def_id(def_id)
                 }
@@ -630,7 +630,7 @@ fn encode_vtable_origin(ecx: @e::EncodeContext,
             }
           }
           typeck::vtable_param(pn, bn) => {
-            do ebml_w.emit_enum_variant(~"vtable_param", 1u, 2u) |ebml_w| {
+            do ebml_w.emit_enum_variant("vtable_param", 1u, 2u) |ebml_w| {
                 do ebml_w.emit_enum_variant_arg(0u) |ebml_w| {
                     ebml_w.emit_uint(pn);
                 }
@@ -756,20 +756,20 @@ impl ebml_writer_helpers for writer::Encoder {
                  ecx: @e::EncodeContext,
                  tpbt: ty::ty_param_bounds_and_ty) {
         do self.emit_struct("ty_param_bounds_and_ty", 2) |this| {
-            do this.emit_struct_field(~"generics", 0) |this| {
+            do this.emit_struct_field("generics", 0) |this| {
                 do this.emit_struct("Generics", 2) |this| {
-                    do this.emit_struct_field(~"type_param_defs", 0) |this| {
+                    do this.emit_struct_field("type_param_defs", 0) |this| {
                         do this.emit_from_vec(*tpbt.generics.type_param_defs)
                                 |this, type_param_def| {
                             this.emit_type_param_def(ecx, type_param_def);
                         }
                     }
-                    do this.emit_struct_field(~"region_param", 1) |this| {
+                    do this.emit_struct_field("region_param", 1) |this| {
                         tpbt.generics.region_param.encode(this);
                     }
                 }
             }
-            do this.emit_struct_field(~"ty", 1) |this| {
+            do this.emit_struct_field("ty", 1) |this| {
                 this.emit_ty(ecx, tpbt.ty);
             }
         }

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -718,7 +718,7 @@ fn check_loans_in_expr<'a>(expr: @ast::expr,
                         None,
                         expr.callee_id,
                         expr.span,
-                        ~[rval]);
+                        [rval]);
       }
       ast::expr_unary(*) | ast::expr_index(*)
       if this.bccx.method_map.contains_key(&expr.id) => {
@@ -726,7 +726,7 @@ fn check_loans_in_expr<'a>(expr: @ast::expr,
                         None,
                         expr.callee_id,
                         expr.span,
-                        ~[]);
+                        []);
       }
       _ => { }
     }

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -79,7 +79,7 @@ pub fn check_crate(
     visit::visit_crate(crate, bccx, v);
 
     if tcx.sess.borrowck_stats() {
-        io::println(~"--- borrowck stats ---");
+        io::println("--- borrowck stats ---");
         io::println(fmt!("paths requiring guarantees: %u",
                         bccx.stats.guaranteed_paths));
         io::println(fmt!("paths requiring loans     : %s",
@@ -556,27 +556,27 @@ pub impl BorrowckCtxt {
             err_out_of_root_scope(super_scope, sub_scope) => {
                 note_and_explain_region(
                     self.tcx,
-                    ~"managed value would have to be rooted for ",
+                    "managed value would have to be rooted for ",
                     sub_scope,
-                    ~"...");
+                    "...");
                 note_and_explain_region(
                     self.tcx,
-                    ~"...but can only be rooted for ",
+                    "...but can only be rooted for ",
                     super_scope,
-                    ~"");
+                    "");
             }
 
             err_out_of_scope(super_scope, sub_scope) => {
                 note_and_explain_region(
                     self.tcx,
-                    ~"borrowed pointer must be valid for ",
+                    "borrowed pointer must be valid for ",
                     sub_scope,
-                    ~"...");
+                    "...");
                 note_and_explain_region(
                     self.tcx,
-                    ~"...but borrowed value is only valid for ",
+                    "...but borrowed value is only valid for ",
                     super_scope,
-                    ~"");
+                    "");
           }
         }
     }

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -129,7 +129,7 @@ pub fn raw_pat(p: @pat) -> @pat {
 
 pub fn check_exhaustive(cx: @MatchCheckCtxt, sp: span, pats: ~[@pat]) {
     assert!((!pats.is_empty()));
-    let ext = match is_useful(cx, &pats.map(|p| ~[*p]), ~[wild()]) {
+    let ext = match is_useful(cx, &pats.map(|p| ~[*p]), [wild()]) {
         not_useful => {
             // This is good, wildcard pattern isn't reachable
             return;

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -357,7 +357,7 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
             }
 
             ast::stmt_mac(*) => {
-                self.tcx().sess.span_bug(stmt.span, ~"unexpanded macro");
+                self.tcx().sess.span_bug(stmt.span, "unexpanded macro");
             }
         }
     }
@@ -724,7 +724,7 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
             }
 
             ast::expr_mac(*) => {
-                self.tcx().sess.span_bug(expr.span, ~"unexpanded macro");
+                self.tcx().sess.span_bug(expr.span, "unexpanded macro");
             }
         }
 

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -78,7 +78,7 @@ fn find_item(item: @item, ctxt: @mut EntryContext, visitor: EntryVisitor) {
                             } else {
                                 ctxt.session.span_err(
                                     item.span,
-                                    ~"multiple 'main' functions");
+                                    "multiple 'main' functions");
                             }
                         } else {
                             // This isn't main
@@ -89,23 +89,23 @@ fn find_item(item: @item, ctxt: @mut EntryContext, visitor: EntryVisitor) {
                 }
             }
 
-            if attrs_contains_name(item.attrs, ~"main") {
+            if attrs_contains_name(item.attrs, "main") {
                 if ctxt.attr_main_fn.is_none() {
                     ctxt.attr_main_fn = Some((item.id, item.span));
                 } else {
                     ctxt.session.span_err(
                         item.span,
-                        ~"multiple 'main' functions");
+                        "multiple 'main' functions");
                 }
             }
 
-            if attrs_contains_name(item.attrs, ~"start") {
+            if attrs_contains_name(item.attrs, "start") {
                 if ctxt.start_fn.is_none() {
                     ctxt.start_fn = Some((item.id, item.span));
                 } else {
                     ctxt.session.span_err(
                         item.span,
-                        ~"multiple 'start' functions");
+                        "multiple 'start' functions");
                 }
             }
         }
@@ -129,15 +129,15 @@ fn configure_main(ctxt: @mut EntryContext) {
     } else {
         if !*this.session.building_library {
             // No main function
-            this.session.err(~"main function not found");
+            this.session.err("main function not found");
             if !this.non_main_fns.is_empty() {
                 // There were some functions named 'main' though. Try to give the user a hint.
-                this.session.note(~"the main function must be defined at the crate level \
-                                    but you have one or more functions named 'main' that are not \
-                                    defined at the crate level. Either move the definition or \
-                                    attach the `#[main]` attribute to override this behavior.");
+                this.session.note("the main function must be defined at the crate level \
+                                   but you have one or more functions named 'main' that are not \
+                                   defined at the crate level. Either move the definition or \
+                                   attach the `#[main]` attribute to override this behavior.");
                 for this.non_main_fns.each |&(_, span)| {
-                    this.session.span_note(span, ~"here is a function named 'main'");
+                    this.session.span_note(span, "here is a function named 'main'");
                 }
             }
             this.session.abort_if_errors();

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -122,7 +122,7 @@ fn check_item(item: @item, cx: Context, visitor: visit::vt<Context>) {
         match item.node {
             item_impl(_, Some(trait_ref), self_type, _) => {
                 match cx.tcx.def_map.find(&trait_ref.ref_id) {
-                    None => cx.tcx.sess.bug(~"trait ref not in def map!"),
+                    None => cx.tcx.sess.bug("trait ref not in def map!"),
                     Some(&trait_def) => {
                         let trait_def_id = ast_util::def_id_of_def(trait_def);
                         if cx.tcx.lang_items.drop_trait() == trait_def_id {
@@ -270,7 +270,7 @@ pub fn check_expr(e: @expr, cx: Context, v: visit::vt<Context>) {
             // Even though the callee_id may have been the id with
             // node_type_substs, e.id is correct here.
             ty::method_call_type_param_defs(cx.tcx, cx.method_map, e.id).expect(
-                ~"non path/method call expr has type substs??")
+                "non path/method call expr has type substs??")
           }
         };
         if ts.len() != type_param_defs.len() {

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -79,6 +79,7 @@ pub enum lint {
     unused_variable,
     dead_assignment,
     unused_mut,
+    unnecessary_allocation,
 }
 
 pub fn level_to_str(lv: level) -> &'static str {
@@ -240,6 +241,13 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
      LintSpec {
         lint: unused_mut,
         desc: "detect mut variables which don't need to be mutable",
+        default: warn
+    }),
+
+    ("unnecessary_allocation",
+     LintSpec {
+        lint: unnecessary_allocation,
+        desc: "detects unnecessary allocations that can be eliminated",
         default: warn
     }),
 ];
@@ -881,6 +889,67 @@ fn lint_session(cx: @mut Context) -> visit::vt<()> {
     })
 }
 
+fn lint_unnecessary_allocations(cx: @mut Context) -> visit::vt<()> {
+    // If the expression `e` has an allocated type, but `t` dictates that it's
+    // something like a slice (doesn't need allocation), emit a warning with the
+    // specified span.
+    //
+    // Currently, this only applies to string and vector literals with sigils in
+    // front. Those can have the sigil removed to get a borrowed pointer
+    // automatically.
+    fn check(cx: @mut Context, e: @ast::expr, t: ty::t) {
+        match e.node {
+            ast::expr_vstore(e2, ast::expr_vstore_uniq) |
+            ast::expr_vstore(e2, ast::expr_vstore_box) => {
+                match e2.node {
+                    ast::expr_lit(@codemap::spanned{
+                            node: ast::lit_str(*), _}) |
+                    ast::expr_vec(*) => {}
+                    _ => return
+                }
+            }
+
+            _ => return
+        }
+
+        match ty::get(t).sty {
+            ty::ty_estr(ty::vstore_slice(*)) |
+            ty::ty_evec(_, ty::vstore_slice(*)) => {
+                cx.span_lint(unnecessary_allocation,
+                             e.span, "unnecessary allocation, the sigil can be \
+                                      removed");
+            }
+
+            _ => ()
+        }
+    }
+
+    let visit_expr: @fn(@ast::expr) = |e| {
+        match e.node {
+            ast::expr_call(c, ref args, _) => {
+                let t = ty::node_id_to_type(cx.tcx, c.id);
+                let s = ty::ty_fn_sig(t);
+                for vec::each2(*args, s.inputs) |e, t| {
+                    check(cx, *e, *t);
+                }
+            }
+            ast::expr_method_call(_, _, _, ref args, _) => {
+                let t = ty::node_id_to_type(cx.tcx, e.callee_id);
+                let s = ty::ty_fn_sig(t);
+                for vec::each2(*args, s.inputs) |e, t| {
+                    check(cx, *e, *t);
+                }
+            }
+            _ => {}
+        }
+    };
+
+    visit::mk_simple_visitor(@visit::SimpleVisitor {
+        visit_expr: visit_expr,
+        .. *visit::default_simple_visitor()
+    })
+}
+
 pub fn check_crate(tcx: ty::ctxt, crate: @ast::crate) {
     let cx = @mut Context {
         dict: @get_lint_dict(),
@@ -908,6 +977,7 @@ pub fn check_crate(tcx: ty::ctxt, crate: @ast::crate) {
     cx.add_lint(lint_unused_unsafe(cx));
     cx.add_lint(lint_unused_mut(cx));
     cx.add_lint(lint_session(cx));
+    cx.add_lint(lint_unnecessary_allocations(cx));
 
     // type inference doesn't like this being declared below, we need to tell it
     // what the type of this first function is...

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -439,7 +439,7 @@ pub fn each_lint(sess: session::Session,
             let metas = match meta.node {
                 ast::meta_list(_, ref metas) => metas,
                 _ => {
-                    sess.span_err(meta.span, ~"malformed lint attribute");
+                    sess.span_err(meta.span, "malformed lint attribute");
                     loop;
                 }
             };
@@ -451,7 +451,7 @@ pub fn each_lint(sess: session::Session,
                         }
                     }
                     _ => {
-                        sess.span_err(meta.span, ~"malformed lint attribute");
+                        sess.span_err(meta.span, "malformed lint attribute");
                     }
                 }
             }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -726,7 +726,7 @@ pub impl Liveness {
         for uint::range(0, self.ir.num_vars) |var_idx| {
             let idx = node_base_idx + var_idx;
             if test(idx).is_valid() {
-                wr.write_str(~" ");
+                wr.write_str(" ");
                 wr.write_str(Variable(var_idx).to_str());
             }
         }
@@ -750,7 +750,7 @@ pub impl Liveness {
                     loop_scope.len()
                 };
                 if len == 0 {
-                    self.tcx.sess.span_bug(sp, ~"break outside loop");
+                    self.tcx.sess.span_bug(sp, "break outside loop");
                 } else {
                     // FIXME(#5275): this shouldn't have to be a method...
                     self.last_loop_scope()
@@ -766,18 +766,18 @@ pub impl Liveness {
 
     fn ln_str(&self, ln: LiveNode) -> ~str {
         do io::with_str_writer |wr| {
-            wr.write_str(~"[ln(");
+            wr.write_str("[ln(");
             wr.write_uint(*ln);
-            wr.write_str(~") of kind ");
+            wr.write_str(") of kind ");
             wr.write_str(fmt!("%?", copy self.ir.lnks[*ln]));
-            wr.write_str(~" reads");
+            wr.write_str(" reads");
             self.write_vars(wr, ln, |idx| self.users[idx].reader );
-            wr.write_str(~"  writes");
+            wr.write_str("  writes");
             self.write_vars(wr, ln, |idx| self.users[idx].writer );
-            wr.write_str(~" ");
-            wr.write_str(~" precedes ");
+            wr.write_str(" ");
+            wr.write_str(" precedes ");
             wr.write_str((copy self.successors[*ln]).to_str());
-            wr.write_str(~"]");
+            wr.write_str("]");
         }
     }
 
@@ -1195,7 +1195,7 @@ pub impl Liveness {
           expr_log(l, r) |
           expr_index(l, r) |
           expr_binary(_, l, r) => {
-            self.propagate_through_exprs(~[l, r], succ)
+            self.propagate_through_exprs([l, r], succ)
           }
 
           expr_addr_of(_, e) |

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -400,7 +400,7 @@ pub fn check_crate(tcx: ty::ctxt,
             // Do not check privacy inside items with the resolve_unexported
             // attribute. This is used for the test runner.
             if !attr::contains_name(attr::attr_metas(/*bad*/copy item.attrs),
-                                    ~"!resolve_unexported") {
+                                    "!resolve_unexported") {
                 visit::visit_item(item, method_map, visitor);
             }
         },

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -381,7 +381,7 @@ pub fn resolve_stmt(stmt: @ast::stmt, cx: Context, visitor: visit::vt<Context>) 
             let expr_cx = Context {parent: Some(stmt_id), ..cx};
             visit::visit_stmt(stmt, expr_cx, visitor);
         }
-        ast::stmt_mac(*) => cx.sess.bug(~"unexpanded macro")
+        ast::stmt_mac(*) => cx.sess.bug("unexpanded macro")
     }
 }
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2584,7 +2584,7 @@ pub impl Resolver {
                         match result {
                             Failed => {
                                 self.session.span_err(span,
-                                                      ~"unresolved name");
+                                                      "unresolved name");
                                 return Failed;
                             }
                             Indeterminate => {
@@ -2966,7 +2966,7 @@ pub impl Resolver {
         if index != import_count {
             let sn = self.session.codemap.span_to_snippet(imports[index].span);
             if str::contains(sn, "::") {
-                self.session.span_err(imports[index].span, ~"unresolved import");
+                self.session.span_err(imports[index].span, "unresolved import");
             } else {
                 let err = fmt!("unresolved import (maybe you meant `%s::*`?)",
                                sn.slice(0, sn.len() - 1)); // -1 to adjust for semicolon
@@ -3249,14 +3249,14 @@ pub impl Resolver {
 
                         self.session.span_err(
                             span,
-                            ~"attempted dynamic environment-capture");
+                            "attempted dynamic environment-capture");
                     } else {
                         // This was an attempt to use a type parameter outside
                         // its scope.
 
                         self.session.span_err(span,
-                                              ~"attempt to use a type \
-                                               argument out of scope");
+                                              "attempt to use a type \
+                                              argument out of scope");
                     }
 
                     return None;
@@ -3271,14 +3271,14 @@ pub impl Resolver {
 
                         self.session.span_err(
                             span,
-                            ~"attempted dynamic environment-capture");
+                            "attempted dynamic environment-capture");
                     } else {
                         // This was an attempt to use a type parameter outside
                         // its scope.
 
                         self.session.span_err(span,
-                                              ~"attempt to use a type \
-                                               argument out of scope");
+                                              "attempt to use a type \
+                                              argument out of scope");
                     }
 
                     return None;
@@ -3286,8 +3286,8 @@ pub impl Resolver {
                 ConstantItemRibKind => {
                     // Still doesn't deal with upvars
                     self.session.span_err(span,
-                                          ~"attempt to use a non-constant \
-                                            value in a constant");
+                                          "attempt to use a non-constant \
+                                           value in a constant");
 
                 }
             }
@@ -3352,7 +3352,7 @@ pub impl Resolver {
         // This is used to allow the test runner to run unexported tests.
         let orig_xray_flag = self.xray_context;
         if contains_name(attr_metas(item.attrs),
-                         ~"!resolve_unexported") {
+                         "!resolve_unexported") {
             self.xray_context = Xray;
         }
 
@@ -3424,8 +3424,8 @@ pub impl Resolver {
                                                 visitor) {
                             None =>
                                 self.session.span_err(trt.path.span,
-                                                      ~"attempt to derive a \
-                                                       nonexistent trait"),
+                                                      "attempt to derive a \
+                                                      nonexistent trait"),
                             Some(def) => {
                                 // Write a mapping from the trait ID to the
                                 // definition of the trait into the definition
@@ -3699,8 +3699,8 @@ pub impl Resolver {
         match self.resolve_path(trait_reference.path, TypeNS, true, visitor) {
             None => {
                 self.session.span_err(trait_reference.path.span,
-                                      ~"attempt to implement an \
-                                        unknown trait");
+                                      "attempt to implement an \
+                                       unknown trait");
             }
             Some(def) => {
                 self.record_def(trait_reference.ref_id, def);
@@ -4094,8 +4094,8 @@ pub impl Resolver {
                         }
                         FoundConst(_) => {
                             self.session.span_err(pattern.span,
-                                                  ~"only refutable patterns \
-                                                    allowed here");
+                                                  "only refutable patterns \
+                                                   allowed here");
                         }
                         BareIdentifierPatternUnresolved => {
                             debug!("(resolving pattern) binding `%s`",
@@ -4195,7 +4195,7 @@ pub impl Resolver {
                         }
                         None => {
                             self.session.span_err(path.span,
-                                                  ~"unresolved enum variant");
+                                                  "unresolved enum variant");
                         }
                     }
 
@@ -4223,8 +4223,8 @@ pub impl Resolver {
                         }
                         None => {
                             self.session.span_err(path.span,
-                                                  ~"unresolved enum variant, \
-                                                    struct or const");
+                                                  "unresolved enum variant, \
+                                                   struct or const");
                         }
                     }
 
@@ -4598,8 +4598,8 @@ pub impl Resolver {
                         Some(dl_def(def)) => return Some(def),
                         _ => {
                             self.session.span_bug(span,
-                                                  ~"self wasn't mapped to a \
-                                                    def?!")
+                                                  "self wasn't mapped to a \
+                                                   def?!")
                         }
                     }
                 }
@@ -4829,8 +4829,8 @@ pub impl Resolver {
                     }
                     Some(_) => {
                         self.session.span_bug(expr.span,
-                                              ~"label wasn't mapped to a \
-                                                label def!")
+                                              "label wasn't mapped to a \
+                                               label def!")
                     }
                 }
             }
@@ -4839,8 +4839,8 @@ pub impl Resolver {
                 match self.resolve_self_value_in_local_ribs(expr.span) {
                     None => {
                         self.session.span_err(expr.span,
-                                              ~"`self` is not allowed in \
-                                                this context")
+                                              "`self` is not allowed in \
+                                               this context")
                     }
                     Some(def) => self.record_def(expr.id, def),
                 }

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -296,7 +296,7 @@ pub fn variant_opt(bcx: block, pat_id: ast::node_id)
             return lit(UnitLikeStructLit(pat_id));
         }
         _ => {
-            ccx.sess.bug(~"non-variant or struct in variant_opt()");
+            ccx.sess.bug("non-variant or struct in variant_opt()");
         }
     }
 }
@@ -891,10 +891,10 @@ pub fn extract_vec_elems(bcx: block,
 
     let mut elems = do vec::from_fn(elem_count) |i| {
         match slice {
-            None => GEPi(bcx, base, ~[i]),
-            Some(n) if i < n => GEPi(bcx, base, ~[i]),
+            None => GEPi(bcx, base, [i]),
+            Some(n) if i < n => GEPi(bcx, base, [i]),
             Some(n) if i > n => {
-                InBoundsGEP(bcx, base, ~[
+                InBoundsGEP(bcx, base, [
                     Sub(bcx, count,
                         C_int(bcx.ccx(), (elem_count - i) as int))])
             }
@@ -1089,11 +1089,8 @@ pub fn compare_values(cx: block,
             let scratch_rhs = alloca(cx, val_ty(rhs));
             Store(cx, rhs, scratch_rhs);
             let did = cx.tcx().lang_items.uniq_str_eq_fn();
-            let bcx = callee::trans_lang_call(cx, did,
-                                                        ~[scratch_lhs,
-                                                          scratch_rhs],
-                                                        expr::SaveIn(
-                                                         scratch_result.val));
+            let bcx = callee::trans_lang_call(cx, did, [scratch_lhs, scratch_rhs],
+                                              expr::SaveIn(scratch_result.val));
             let result = scratch_result.to_result(bcx);
             Result {
                 bcx: result.bcx,
@@ -1103,10 +1100,8 @@ pub fn compare_values(cx: block,
         ty::ty_estr(_) => {
             let scratch_result = scratch_datum(cx, ty::mk_bool(), false);
             let did = cx.tcx().lang_items.str_eq_fn();
-            let bcx = callee::trans_lang_call(cx, did,
-                                                        ~[lhs, rhs],
-                                                        expr::SaveIn(
-                                                         scratch_result.val));
+            let bcx = callee::trans_lang_call(cx, did, [lhs, rhs],
+                                              expr::SaveIn(scratch_result.val));
             let result = scratch_result.to_result(bcx);
             Result {
                 bcx: result.bcx,
@@ -1114,7 +1109,7 @@ pub fn compare_values(cx: block,
             }
         }
         _ => {
-            cx.tcx().sess.bug(~"only scalars and strings supported in \
+            cx.tcx().sess.bug("only scalars and strings supported in \
                                 compare_values");
         }
     }
@@ -1343,7 +1338,7 @@ pub fn compile_submatch(bcx: block,
         let tup_repr = adt::represent_type(bcx.ccx(), tup_ty);
         let n_tup_elts = match ty::get(tup_ty).sty {
           ty::ty_tup(ref elts) => elts.len(),
-          _ => ccx.sess.bug(~"non-tuple type in tuple pattern")
+          _ => ccx.sess.bug("non-tuple type in tuple pattern")
         };
         let tup_vals = do vec::from_fn(n_tup_elts) |i| {
             adt::trans_field_ptr(bcx, tup_repr, val, 0, i)
@@ -1362,7 +1357,7 @@ pub fn compile_submatch(bcx: block,
                     ty::lookup_struct_fields(tcx, struct_id).len();
             }
             _ => {
-                ccx.sess.bug(~"non-struct type in tuple struct pattern");
+                ccx.sess.bug("non-struct type in tuple struct pattern");
             }
         }
 
@@ -1478,8 +1473,8 @@ pub fn compile_submatch(bcx: block,
                       }
                       _ => {
                           bcx.sess().bug(
-                              ~"in compile_submatch, expected \
-                                trans_opt to return a single_result")
+                              "in compile_submatch, expected \
+                               trans_opt to return a single_result")
                       }
                   }
               }
@@ -1689,7 +1684,7 @@ pub fn trans_match_inner(scope_cx: block,
         }
     };
     let lldiscr = discr_datum.to_ref_llval(bcx);
-    compile_submatch(bcx, matches, ~[lldiscr], chk);
+    compile_submatch(bcx, matches, [lldiscr], chk);
 
     let mut arm_cxs = ~[];
     for arm_datas.each |arm_data| {

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -158,7 +158,7 @@ fn represent_type_uncached(cx: @CrateContext, t: ty::t) -> Repr {
 
             if cases.len() == 0 {
                 // Uninhabitable; represent as unit
-                return Univariant(mk_struct(cx, ~[], false), false);
+                return Univariant(mk_struct(cx, [], false), false);
             }
 
             if cases.all(|c| c.tys.len() == 0) {
@@ -206,7 +206,7 @@ fn represent_type_uncached(cx: @CrateContext, t: ty::t) -> Repr {
             let discr = ~[ty::mk_int()];
             return General(cases.map(|c| mk_struct(cx, discr + c.tys, false)))
         }
-        _ => cx.sess.bug(~"adt::represent_type called on non-ADT type")
+        _ => cx.sess.bug("adt::represent_type called on non-ADT type")
     }
 }
 
@@ -353,7 +353,7 @@ pub fn trans_case(bcx: block, r: &Repr, discr: int) -> _match::opt_result {
             _match::single_result(rslt(bcx, C_int(bcx.ccx(), discr)))
         }
         Univariant(*) => {
-            bcx.ccx().sess.bug(~"no cases for univariants or structs")
+            bcx.ccx().sess.bug("no cases for univariants or structs")
         }
         General(*) => {
             _match::single_result(rslt(bcx, C_int(bcx.ccx(), discr)))
@@ -423,7 +423,7 @@ pub fn trans_field_ptr(bcx: block, r: &Repr, val: ValueRef, discr: int,
     // someday), it will need to return a possibly-new bcx as well.
     match *r {
         CEnum(*) => {
-            bcx.ccx().sess.bug(~"element access in C-like enum")
+            bcx.ccx().sess.bug("element access in C-like enum")
         }
         Univariant(ref st, _dtor) => {
             assert_eq!(discr, 0);
@@ -468,8 +468,7 @@ fn struct_field_ptr(bcx: block, st: &Struct, val: ValueRef, ix: uint,
 pub fn trans_drop_flag_ptr(bcx: block, r: &Repr, val: ValueRef) -> ValueRef {
     match *r {
         Univariant(ref st, true) => GEPi(bcx, val, [0, st.fields.len() - 1]),
-        _ => bcx.ccx().sess.bug(~"tried to get drop flag of non-droppable \
-                                  type")
+        _ => bcx.ccx().sess.bug("tried to get drop flag of non-droppable type")
     }
 }
 
@@ -600,7 +599,7 @@ pub fn const_get_discrim(ccx: @CrateContext, r: &Repr, val: ValueRef)
 pub fn const_get_field(ccx: @CrateContext, r: &Repr, val: ValueRef,
                        _discr: int, ix: uint) -> ValueRef {
     match *r {
-        CEnum(*) => ccx.sess.bug(~"element access in C-like enum const"),
+        CEnum(*) => ccx.sess.bug("element access in C-like enum const"),
         Univariant(*) => const_struct_field(ccx, val, ix),
         General(*) => const_struct_field(ccx, val, ix + 1),
         NullablePointer{ _ } => const_struct_field(ccx, val, ix)

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -235,7 +235,7 @@ pub fn umin(cx: block, a: ValueRef, b: ValueRef) -> ValueRef {
 pub fn ptr_offs(bcx: block, base: ValueRef, sz: ValueRef) -> ValueRef {
     let _icx = bcx.insn_ctxt("ptr_offs");
     let raw = PointerCast(bcx, base, T_ptr(T_i8()));
-    InBoundsGEP(bcx, raw, ~[sz])
+    InBoundsGEP(bcx, raw, [sz])
 }
 
 // Increment a pointer by a given amount and then cast it to be a pointer
@@ -296,7 +296,7 @@ pub fn malloc_raw_dyn(bcx: block,
     let bcx = callee::trans_lang_call(
         bcx,
         langcall,
-        ~[tydesc, size],
+        [tydesc, size],
         expr::SaveIn(rval));
     let r = rslt(bcx, PointerCast(bcx, Load(bcx, rval), llty));
     maybe_set_managed_unique_rc(r.bcx, r.val, heap);
@@ -314,7 +314,7 @@ pub fn malloc_raw_dyn(bcx: block,
 pub fn non_gc_box_cast(bcx: block, val: ValueRef) -> ValueRef {
     unsafe {
         debug!("non_gc_box_cast");
-        add_comment(bcx, ~"non_gc_box_cast");
+        add_comment(bcx, "non_gc_box_cast");
         assert!(llvm::LLVMGetPointerAddressSpace(val_ty(val)) ==
                      gc_box_addrspace || bcx.unreachable);
         let non_gc_t = T_ptr(llvm::LLVMGetElementType(val_ty(val)));
@@ -563,8 +563,8 @@ pub fn compare_scalar_types(cx: block,
         }
         _ => {
             // Should never get here, because t is scalar.
-            cx.sess().bug(~"non-scalar type passed to \
-                            compare_scalar_types")
+            cx.sess().bug("non-scalar type passed to \
+                           compare_scalar_types")
         }
     }
 }
@@ -579,8 +579,8 @@ pub fn compare_scalar_values(cx: block,
                           -> ValueRef {
     let _icx = cx.insn_ctxt("compare_scalar_values");
     fn die(cx: block) -> ! {
-        cx.tcx().sess.bug(~"compare_scalar_values: must be a\
-          comparison operator");
+        cx.tcx().sess.bug("compare_scalar_values: must be a\
+                           comparison operator");
     }
     match nt {
       nil_type => {
@@ -720,18 +720,18 @@ pub fn iter_structural_ty(cx: block, av: ValueRef, t: ty::t,
                           _match::single_result(r) => {
                               AddCase(llswitch, r.val, variant_cx.llbb)
                           }
-                          _ => ccx.sess.unimpl(~"value from adt::trans_case \
-                                                 in iter_structural_ty")
+                          _ => ccx.sess.unimpl("value from adt::trans_case \
+                                                in iter_structural_ty")
                       }
                       Br(variant_cx, next_cx.llbb);
                   }
                   cx = next_cx;
               }
-              _ => ccx.sess.unimpl(~"value from adt::trans_switch \
-                                     in iter_structural_ty")
+              _ => ccx.sess.unimpl("value from adt::trans_switch \
+                                    in iter_structural_ty")
           }
       }
-      _ => cx.sess().unimpl(~"type in iter_structural_ty")
+      _ => cx.sess().unimpl("type in iter_structural_ty")
     }
     return cx;
 }
@@ -959,7 +959,7 @@ pub fn get_landing_pad(bcx: block) -> BasicBlockRef {
     // The landing pad return type (the type being propagated). Not sure what
     // this represents but it's determined by the personality function and
     // this is what the EH proposal example uses.
-    let llretty = T_struct(~[T_ptr(T_i8()), T_i32()], false);
+    let llretty = T_struct([T_ptr(T_i8()), T_i32()], false);
     // The exception handling personality function. This is the C++
     // personality function __gxx_personality_v0, wrapped in our naming
     // convention.
@@ -972,7 +972,7 @@ pub fn get_landing_pad(bcx: block) -> BasicBlockRef {
     // Because we may have unwound across a stack boundary, we must call into
     // the runtime to figure out which stack segment we are on and place the
     // stack limit back into the TLS.
-    Call(pad_bcx, bcx.ccx().upcalls.reset_stack_limit, ~[]);
+    Call(pad_bcx, bcx.ccx().upcalls.reset_stack_limit, []);
 
     // We store the retval in a function-central alloca, so that calls to
     // Resume can find it.
@@ -1159,7 +1159,7 @@ pub fn trans_stmt(cx: block, s: &ast::stmt) -> block {
                 ast::decl_item(i) => trans_item(*cx.fcx.ccx, i)
             }
         }
-        ast::stmt_mac(*) => cx.tcx().sess.bug(~"unexpanded macro")
+        ast::stmt_mac(*) => cx.tcx().sess.bug("unexpanded macro")
     }
 
     return bcx;
@@ -1462,7 +1462,7 @@ pub fn call_memcpy(cx: block, dst: ValueRef, src: ValueRef,
     let size = IntCast(cx, n_bytes, ccx.int_type);
     let align = C_i32(1i32);
     let volatile = C_i1(false);
-    Call(cx, memcpy, ~[dst_ptr, src_ptr, size, align, volatile]);
+    Call(cx, memcpy, [dst_ptr, src_ptr, size, align, volatile]);
 }
 
 pub fn memcpy_ty(bcx: block, dst: ValueRef, src: ValueRef, t: ty::t) {
@@ -1509,7 +1509,7 @@ pub fn memzero(cx: block, llptr: ValueRef, llty: TypeRef) {
     let size = IntCast(cx, machine::llsize_of(ccx, llty), ccx.int_type);
     let align = C_i32(1i32);
     let volatile = C_i1(false);
-    Call(cx, llintrinsicfn, ~[llptr, llzeroval, size, align, volatile]);
+    Call(cx, llintrinsicfn, [llptr, llzeroval, size, align, volatile]);
 }
 
 pub fn alloc_ty(bcx: block, t: ty::t) -> ValueRef {
@@ -1559,9 +1559,9 @@ pub struct BasicBlocks {
 pub fn mk_standard_basic_blocks(llfn: ValueRef) -> BasicBlocks {
     unsafe {
         BasicBlocks {
-            sa: str::as_c_str(~"static_allocas",
+            sa: str::as_c_str("static_allocas",
                            |buf| llvm::LLVMAppendBasicBlock(llfn, buf)),
-            rt: str::as_c_str(~"return",
+            rt: str::as_c_str("return",
                            |buf| llvm::LLVMAppendBasicBlock(llfn, buf))
         }
     }
@@ -2057,8 +2057,7 @@ pub fn trans_tuple_struct(ccx: @CrateContext,
         let llarg = match fcx.llargs.get_copy(&field.node.id) {
             local_mem(x) => x,
             _ => {
-                ccx.tcx.sess.bug(~"trans_tuple_struct: llarg wasn't \
-                                   local_mem")
+                ccx.tcx.sess.bug("trans_tuple_struct: llarg wasn't local_mem")
             }
         };
         let arg_ty = arg_tys[i];
@@ -2105,7 +2104,7 @@ pub fn trans_item(ccx: @CrateContext, item: &ast::item) {
             let llfndecl = get_item_val(ccx, item.id);
             foreign::trans_foreign_fn(ccx,
                                       vec::append(/*bad*/copy *path,
-                                                  ~[path_name(item.ident)]),
+                                                  [path_name(item.ident)]),
                                       decl,
                                       body,
                                       llfndecl,
@@ -2113,7 +2112,7 @@ pub fn trans_item(ccx: @CrateContext, item: &ast::item) {
         } else if !generics.is_type_parameterized() {
             let llfndecl = get_item_val(ccx, item.id);
             trans_fn(ccx,
-                     vec::append(/*bad*/copy *path, ~[path_name(item.ident)]),
+                     vec::append(/*bad*/copy *path, [path_name(item.ident)]),
                      decl,
                      body,
                      llfndecl,
@@ -2263,8 +2262,8 @@ pub fn create_entry_wrapper(ccx: @CrateContext,
 
     fn create_main(ccx: @CrateContext, main_llfn: ValueRef) -> ValueRef {
         let nt = ty::mk_nil();
-        let llfty = type_of_fn(ccx, ~[], nt);
-        let llfdecl = decl_fn(ccx.llmod, ~"_rust_main",
+        let llfty = type_of_fn(ccx, [], nt);
+        let llfdecl = decl_fn(ccx.llmod, "_rust_main",
                               lib::llvm::CCallConv, llfty);
 
         let fcx = new_fn_ctxt(ccx, ~[], llfdecl, nt, None);
@@ -2287,11 +2286,11 @@ pub fn create_entry_wrapper(ccx: @CrateContext,
     fn create_entry_fn(ccx: @CrateContext,
                        rust_main: ValueRef,
                        use_start_lang_item: bool) {
-        let llfty = T_fn(~[ccx.int_type, T_ptr(T_ptr(T_i8()))], ccx.int_type);
+        let llfty = T_fn([ccx.int_type, T_ptr(T_ptr(T_i8()))], ccx.int_type);
 
         // FIXME #4404 android JNI hacks
         let llfn = if *ccx.sess.building_library {
-            decl_cdecl_fn(ccx.llmod, ~"amain", llfty)
+            decl_cdecl_fn(ccx.llmod, "amain", llfty)
         } else {
             let main_name = match ccx.sess.targ_cfg.os {
                 session::os_win32 => ~"WinMain@16",
@@ -2299,7 +2298,7 @@ pub fn create_entry_wrapper(ccx: @CrateContext,
             };
             decl_cdecl_fn(ccx.llmod, main_name, llfty)
         };
-        let llbb = str::as_c_str(~"top", |buf| {
+        let llbb = str::as_c_str("top", |buf| {
             unsafe {
                 llvm::LLVMAppendBasicBlock(llfn, buf)
             }
@@ -2310,7 +2309,7 @@ pub fn create_entry_wrapper(ccx: @CrateContext,
 
             let start_def_id = ccx.tcx.lang_items.start_fn();
             if start_def_id.crate == ast::local_crate {
-                ccx.sess.bug(~"start lang item is never in the local crate")
+                ccx.sess.bug("start lang item is never in the local crate")
             } else {
                 let start_fn_type = csearch::get_type(ccx.tcx,
                                                       start_def_id).ty;
@@ -2328,8 +2327,8 @@ pub fn create_entry_wrapper(ccx: @CrateContext,
             let (start_fn, args) = if use_start_lang_item {
                 let start_def_id = ccx.tcx.lang_items.start_fn();
                 let start_fn = if start_def_id.crate == ast::local_crate {
-                    ccx.sess.bug(~"start lang item is never in the local \
-                                   crate")
+                    ccx.sess.bug("start lang item is never in the local \
+                                  crate")
                 } else {
                     let start_fn_type = csearch::get_type(ccx.tcx,
                             start_def_id).ty;
@@ -2391,7 +2390,7 @@ pub fn item_path(ccx: @CrateContext, i: @ast::item) -> path {
             // separate map for paths?
         _ => fail!("item_path")
     };
-    vec::append(/*bad*/copy *base, ~[path_name(i.ident)])
+    vec::append(/*bad*/copy *base, [path_name(i.ident)])
 }
 
 pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
@@ -2404,7 +2403,7 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
         let val = match tcx.items.get_copy(&id) {
           ast_map::node_item(i, pth) => {
             let my_path = vec::append(/*bad*/copy *pth,
-                                      ~[path_name(i.ident)]);
+                                      [path_name(i.ident)]);
             match i.node {
               ast::item_const(_, expr) => {
                 let typ = ty::node_id_to_type(tcx, i.id);
@@ -2442,8 +2441,8 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
             debug!("get_item_val(): processing a node_trait_method");
             match *trait_method {
               ast::required(_) => {
-                ccx.sess.bug(~"unexpected variant: required trait method in \
-                               get_item_val()");
+                ccx.sess.bug("unexpected variant: required trait method in \
+                              get_item_val()");
               }
               ast::provided(m) => {
                 exprt = true;
@@ -2461,7 +2460,7 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
                 ast::foreign_item_fn(*) => {
                     register_fn(ccx, ni.span,
                                 vec::append(/*bad*/copy *pth,
-                                            ~[path_name(ni.ident)]),
+                                            [path_name(ni.ident)]),
                                 ni.id,
                                 ni.attrs)
                 }
@@ -2486,8 +2485,8 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
                 ast::tuple_variant_kind(ref args) => {
                     assert!(args.len() != 0u);
                     let pth = vec::append(/*bad*/copy *pth,
-                                          ~[path_name(enm.ident),
-                                            path_name((*v).node.name)]);
+                                          [path_name(enm.ident),
+                                           path_name((*v).node.name)]);
                     llfn = match enm.node {
                       ast::item_enum(_, _) => {
                         register_fn(ccx, (*v).span, pth, id, enm.attrs)
@@ -2507,8 +2506,8 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
             // Only register the constructor if this is a tuple-like struct.
             match struct_def.ctor_id {
                 None => {
-                    tcx.sess.bug(~"attempt to register a constructor of \
-                                       a non-tuple-like struct")
+                    tcx.sess.bug("attempt to register a constructor of \
+                                  a non-tuple-like struct")
                 }
                 Some(ctor_id) => {
                     let llfn = register_fn(ccx,
@@ -2541,7 +2540,7 @@ pub fn register_method(ccx: @CrateContext,
                        pth: @ast_map::path,
                        m: @ast::method) -> ValueRef {
     let mty = ty::node_id_to_type(ccx.tcx, id);
-    let pth = vec::append(/*bad*/copy *pth, ~[path_name((ccx.names)("meth")),
+    let pth = vec::append(/*bad*/copy *pth, [path_name((ccx.names)("meth")),
                                   path_name(m.ident)]);
     let llfn = register_fn_full(ccx, m.span, pth, id, m.attrs, mty);
     set_inline_hint_if_appr(m.attrs, llfn);
@@ -2559,7 +2558,7 @@ pub fn trans_constant(ccx: @CrateContext, it: @ast::item) {
         let mut i = 0;
         let path = item_path(ccx, it);
         for (*enum_definition).variants.each |variant| {
-            let p = vec::append(/*bad*/copy path, ~[
+            let p = vec::append(/*bad*/copy path, [
                 path_name(variant.node.name),
                 path_name(special_idents::descrim)
             ]);
@@ -2617,126 +2616,126 @@ pub fn declare_intrinsics(llmod: ModuleRef) -> HashMap<~str, ValueRef> {
     let T_trap_args: ~[TypeRef] = ~[];
     let T_frameaddress_args: ~[TypeRef] = ~[T_i32()];
     let gcroot =
-        decl_cdecl_fn(llmod, ~"llvm.gcroot",
-                      T_fn(~[T_ptr(T_ptr(T_i8())), T_ptr(T_i8())],
+        decl_cdecl_fn(llmod, "llvm.gcroot",
+                      T_fn([T_ptr(T_ptr(T_i8())), T_ptr(T_i8())],
                            T_void()));
     let gcread =
-        decl_cdecl_fn(llmod, ~"llvm.gcread",
-                      T_fn(~[T_ptr(T_i8()), T_ptr(T_ptr(T_i8()))],
+        decl_cdecl_fn(llmod, "llvm.gcread",
+                      T_fn([T_ptr(T_i8()), T_ptr(T_ptr(T_i8()))],
                            T_void()));
     let memcpy32 =
-        decl_cdecl_fn(llmod, ~"llvm.memcpy.p0i8.p0i8.i32",
+        decl_cdecl_fn(llmod, "llvm.memcpy.p0i8.p0i8.i32",
                       T_fn(copy T_memcpy32_args, T_void()));
     let memcpy64 =
-        decl_cdecl_fn(llmod, ~"llvm.memcpy.p0i8.p0i8.i64",
+        decl_cdecl_fn(llmod, "llvm.memcpy.p0i8.p0i8.i64",
                       T_fn(copy T_memcpy64_args, T_void()));
     let memmove32 =
-        decl_cdecl_fn(llmod, ~"llvm.memmove.p0i8.p0i8.i32",
+        decl_cdecl_fn(llmod, "llvm.memmove.p0i8.p0i8.i32",
                       T_fn(T_memcpy32_args, T_void()));
     let memmove64 =
-        decl_cdecl_fn(llmod, ~"llvm.memmove.p0i8.p0i8.i64",
+        decl_cdecl_fn(llmod, "llvm.memmove.p0i8.p0i8.i64",
                       T_fn(T_memcpy64_args, T_void()));
     let memset32 =
-        decl_cdecl_fn(llmod, ~"llvm.memset.p0i8.i32",
+        decl_cdecl_fn(llmod, "llvm.memset.p0i8.i32",
                       T_fn(T_memset32_args, T_void()));
     let memset64 =
-        decl_cdecl_fn(llmod, ~"llvm.memset.p0i8.i64",
+        decl_cdecl_fn(llmod, "llvm.memset.p0i8.i64",
                       T_fn(T_memset64_args, T_void()));
-    let trap = decl_cdecl_fn(llmod, ~"llvm.trap", T_fn(T_trap_args,
+    let trap = decl_cdecl_fn(llmod, "llvm.trap", T_fn(T_trap_args,
                                                       T_void()));
-    let frameaddress = decl_cdecl_fn(llmod, ~"llvm.frameaddress",
+    let frameaddress = decl_cdecl_fn(llmod, "llvm.frameaddress",
                                      T_fn(T_frameaddress_args,
                                           T_ptr(T_i8())));
-    let sqrtf32 = decl_cdecl_fn(llmod, ~"llvm.sqrt.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let sqrtf64 = decl_cdecl_fn(llmod, ~"llvm.sqrt.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let powif32 = decl_cdecl_fn(llmod, ~"llvm.powi.f32",
-                                T_fn(~[T_f32(), T_i32()], T_f32()));
-    let powif64 = decl_cdecl_fn(llmod, ~"llvm.powi.f64",
-                                T_fn(~[T_f64(), T_i32()], T_f64()));
-    let sinf32 = decl_cdecl_fn(llmod, ~"llvm.sin.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let sinf64 = decl_cdecl_fn(llmod, ~"llvm.sin.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let cosf32 = decl_cdecl_fn(llmod, ~"llvm.cos.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let cosf64 = decl_cdecl_fn(llmod, ~"llvm.cos.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let powf32 = decl_cdecl_fn(llmod, ~"llvm.pow.f32",
-                                T_fn(~[T_f32(), T_f32()], T_f32()));
-    let powf64 = decl_cdecl_fn(llmod, ~"llvm.pow.f64",
-                                T_fn(~[T_f64(), T_f64()], T_f64()));
-    let expf32 = decl_cdecl_fn(llmod, ~"llvm.exp.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let expf64 = decl_cdecl_fn(llmod, ~"llvm.exp.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let exp2f32 = decl_cdecl_fn(llmod, ~"llvm.exp2.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let exp2f64 = decl_cdecl_fn(llmod, ~"llvm.exp2.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let logf32 = decl_cdecl_fn(llmod, ~"llvm.log.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let logf64 = decl_cdecl_fn(llmod, ~"llvm.log.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let log10f32 = decl_cdecl_fn(llmod, ~"llvm.log10.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let log10f64 = decl_cdecl_fn(llmod, ~"llvm.log10.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let log2f32 = decl_cdecl_fn(llmod, ~"llvm.log2.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let log2f64 = decl_cdecl_fn(llmod, ~"llvm.log2.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let fmaf32 = decl_cdecl_fn(llmod, ~"llvm.fma.f32",
-                                T_fn(~[T_f32(), T_f32(), T_f32()], T_f32()));
-    let fmaf64 = decl_cdecl_fn(llmod, ~"llvm.fma.f64",
-                                T_fn(~[T_f64(), T_f64(), T_f64()], T_f64()));
-    let fabsf32 = decl_cdecl_fn(llmod, ~"llvm.fabs.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let fabsf64 = decl_cdecl_fn(llmod, ~"llvm.fabs.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let floorf32 = decl_cdecl_fn(llmod, ~"llvm.floor.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let floorf64 = decl_cdecl_fn(llmod, ~"llvm.floor.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let ceilf32 = decl_cdecl_fn(llmod, ~"llvm.ceil.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let ceilf64 = decl_cdecl_fn(llmod, ~"llvm.ceil.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let truncf32 = decl_cdecl_fn(llmod, ~"llvm.trunc.f32",
-                                T_fn(~[T_f32()], T_f32()));
-    let truncf64 = decl_cdecl_fn(llmod, ~"llvm.trunc.f64",
-                                T_fn(~[T_f64()], T_f64()));
-    let ctpop8 = decl_cdecl_fn(llmod, ~"llvm.ctpop.i8",
-                                T_fn(~[T_i8()], T_i8()));
-    let ctpop16 = decl_cdecl_fn(llmod, ~"llvm.ctpop.i16",
-                                T_fn(~[T_i16()], T_i16()));
-    let ctpop32 = decl_cdecl_fn(llmod, ~"llvm.ctpop.i32",
-                                T_fn(~[T_i32()], T_i32()));
-    let ctpop64 = decl_cdecl_fn(llmod, ~"llvm.ctpop.i64",
-                                T_fn(~[T_i64()], T_i64()));
-    let ctlz8 = decl_cdecl_fn(llmod, ~"llvm.ctlz.i8",
-                                T_fn(~[T_i8(), T_i1()], T_i8()));
-    let ctlz16 = decl_cdecl_fn(llmod, ~"llvm.ctlz.i16",
-                                T_fn(~[T_i16(), T_i1()], T_i16()));
-    let ctlz32 = decl_cdecl_fn(llmod, ~"llvm.ctlz.i32",
-                                T_fn(~[T_i32(), T_i1()], T_i32()));
-    let ctlz64 = decl_cdecl_fn(llmod, ~"llvm.ctlz.i64",
-                                T_fn(~[T_i64(), T_i1()], T_i64()));
-    let cttz8 = decl_cdecl_fn(llmod, ~"llvm.cttz.i8",
-                                T_fn(~[T_i8(), T_i1()], T_i8()));
-    let cttz16 = decl_cdecl_fn(llmod, ~"llvm.cttz.i16",
-                                T_fn(~[T_i16(), T_i1()], T_i16()));
-    let cttz32 = decl_cdecl_fn(llmod, ~"llvm.cttz.i32",
-                                T_fn(~[T_i32(), T_i1()], T_i32()));
-    let cttz64 = decl_cdecl_fn(llmod, ~"llvm.cttz.i64",
-                                T_fn(~[T_i64(), T_i1()], T_i64()));
-    let bswap16 = decl_cdecl_fn(llmod, ~"llvm.bswap.i16",
-                                T_fn(~[T_i16()], T_i16()));
-    let bswap32 = decl_cdecl_fn(llmod, ~"llvm.bswap.i32",
-                                T_fn(~[T_i32()], T_i32()));
-    let bswap64 = decl_cdecl_fn(llmod, ~"llvm.bswap.i64",
-                                T_fn(~[T_i64()], T_i64()));
+    let sqrtf32 = decl_cdecl_fn(llmod, "llvm.sqrt.f32",
+                                T_fn([T_f32()], T_f32()));
+    let sqrtf64 = decl_cdecl_fn(llmod, "llvm.sqrt.f64",
+                                T_fn([T_f64()], T_f64()));
+    let powif32 = decl_cdecl_fn(llmod, "llvm.powi.f32",
+                                T_fn([T_f32(), T_i32()], T_f32()));
+    let powif64 = decl_cdecl_fn(llmod, "llvm.powi.f64",
+                                T_fn([T_f64(), T_i32()], T_f64()));
+    let sinf32 = decl_cdecl_fn(llmod, "llvm.sin.f32",
+                                T_fn([T_f32()], T_f32()));
+    let sinf64 = decl_cdecl_fn(llmod, "llvm.sin.f64",
+                                T_fn([T_f64()], T_f64()));
+    let cosf32 = decl_cdecl_fn(llmod, "llvm.cos.f32",
+                                T_fn([T_f32()], T_f32()));
+    let cosf64 = decl_cdecl_fn(llmod, "llvm.cos.f64",
+                                T_fn([T_f64()], T_f64()));
+    let powf32 = decl_cdecl_fn(llmod, "llvm.pow.f32",
+                                T_fn([T_f32(), T_f32()], T_f32()));
+    let powf64 = decl_cdecl_fn(llmod, "llvm.pow.f64",
+                                T_fn([T_f64(), T_f64()], T_f64()));
+    let expf32 = decl_cdecl_fn(llmod, "llvm.exp.f32",
+                                T_fn([T_f32()], T_f32()));
+    let expf64 = decl_cdecl_fn(llmod, "llvm.exp.f64",
+                                T_fn([T_f64()], T_f64()));
+    let exp2f32 = decl_cdecl_fn(llmod, "llvm.exp2.f32",
+                                T_fn([T_f32()], T_f32()));
+    let exp2f64 = decl_cdecl_fn(llmod, "llvm.exp2.f64",
+                                T_fn([T_f64()], T_f64()));
+    let logf32 = decl_cdecl_fn(llmod, "llvm.log.f32",
+                                T_fn([T_f32()], T_f32()));
+    let logf64 = decl_cdecl_fn(llmod, "llvm.log.f64",
+                                T_fn([T_f64()], T_f64()));
+    let log10f32 = decl_cdecl_fn(llmod, "llvm.log10.f32",
+                                T_fn([T_f32()], T_f32()));
+    let log10f64 = decl_cdecl_fn(llmod, "llvm.log10.f64",
+                                T_fn([T_f64()], T_f64()));
+    let log2f32 = decl_cdecl_fn(llmod, "llvm.log2.f32",
+                                T_fn([T_f32()], T_f32()));
+    let log2f64 = decl_cdecl_fn(llmod, "llvm.log2.f64",
+                                T_fn([T_f64()], T_f64()));
+    let fmaf32 = decl_cdecl_fn(llmod, "llvm.fma.f32",
+                                T_fn([T_f32(), T_f32(), T_f32()], T_f32()));
+    let fmaf64 = decl_cdecl_fn(llmod, "llvm.fma.f64",
+                                T_fn([T_f64(), T_f64(), T_f64()], T_f64()));
+    let fabsf32 = decl_cdecl_fn(llmod, "llvm.fabs.f32",
+                                T_fn([T_f32()], T_f32()));
+    let fabsf64 = decl_cdecl_fn(llmod, "llvm.fabs.f64",
+                                T_fn([T_f64()], T_f64()));
+    let floorf32 = decl_cdecl_fn(llmod, "llvm.floor.f32",
+                                T_fn([T_f32()], T_f32()));
+    let floorf64 = decl_cdecl_fn(llmod, "llvm.floor.f64",
+                                T_fn([T_f64()], T_f64()));
+    let ceilf32 = decl_cdecl_fn(llmod, "llvm.ceil.f32",
+                                T_fn([T_f32()], T_f32()));
+    let ceilf64 = decl_cdecl_fn(llmod, "llvm.ceil.f64",
+                                T_fn([T_f64()], T_f64()));
+    let truncf32 = decl_cdecl_fn(llmod, "llvm.trunc.f32",
+                                T_fn([T_f32()], T_f32()));
+    let truncf64 = decl_cdecl_fn(llmod, "llvm.trunc.f64",
+                                T_fn([T_f64()], T_f64()));
+    let ctpop8 = decl_cdecl_fn(llmod, "llvm.ctpop.i8",
+                                T_fn([T_i8()], T_i8()));
+    let ctpop16 = decl_cdecl_fn(llmod, "llvm.ctpop.i16",
+                                T_fn([T_i16()], T_i16()));
+    let ctpop32 = decl_cdecl_fn(llmod, "llvm.ctpop.i32",
+                                T_fn([T_i32()], T_i32()));
+    let ctpop64 = decl_cdecl_fn(llmod, "llvm.ctpop.i64",
+                                T_fn([T_i64()], T_i64()));
+    let ctlz8 = decl_cdecl_fn(llmod, "llvm.ctlz.i8",
+                                T_fn([T_i8(), T_i1()], T_i8()));
+    let ctlz16 = decl_cdecl_fn(llmod, "llvm.ctlz.i16",
+                                T_fn([T_i16(), T_i1()], T_i16()));
+    let ctlz32 = decl_cdecl_fn(llmod, "llvm.ctlz.i32",
+                                T_fn([T_i32(), T_i1()], T_i32()));
+    let ctlz64 = decl_cdecl_fn(llmod, "llvm.ctlz.i64",
+                                T_fn([T_i64(), T_i1()], T_i64()));
+    let cttz8 = decl_cdecl_fn(llmod, "llvm.cttz.i8",
+                                T_fn([T_i8(), T_i1()], T_i8()));
+    let cttz16 = decl_cdecl_fn(llmod, "llvm.cttz.i16",
+                                T_fn([T_i16(), T_i1()], T_i16()));
+    let cttz32 = decl_cdecl_fn(llmod, "llvm.cttz.i32",
+                                T_fn([T_i32(), T_i1()], T_i32()));
+    let cttz64 = decl_cdecl_fn(llmod, "llvm.cttz.i64",
+                                T_fn([T_i64(), T_i1()], T_i64()));
+    let bswap16 = decl_cdecl_fn(llmod, "llvm.bswap.i16",
+                                T_fn([T_i16()], T_i16()));
+    let bswap32 = decl_cdecl_fn(llmod, "llvm.bswap.i32",
+                                T_fn([T_i32()], T_i32()));
+    let bswap64 = decl_cdecl_fn(llmod, "llvm.bswap.i64",
+                                T_fn([T_i64()], T_i64()));
 
     let mut intrinsics = HashMap::new();
     intrinsics.insert(~"llvm.gcroot", gcroot);
@@ -2801,12 +2800,11 @@ pub fn declare_intrinsics(llmod: ModuleRef) -> HashMap<~str, ValueRef> {
 pub fn declare_dbg_intrinsics(llmod: ModuleRef,
                               intrinsics: &mut HashMap<~str, ValueRef>) {
     let declare =
-        decl_cdecl_fn(llmod, ~"llvm.dbg.declare",
-                      T_fn(~[T_metadata(), T_metadata()], T_void()));
+        decl_cdecl_fn(llmod, "llvm.dbg.declare",
+                      T_fn([T_metadata(), T_metadata()], T_void()));
     let value =
-        decl_cdecl_fn(llmod, ~"llvm.dbg.value",
-                      T_fn(~[T_metadata(), T_i64(), T_metadata()],
-                           T_void()));
+        decl_cdecl_fn(llmod, "llvm.dbg.value",
+                      T_fn([T_metadata(), T_i64(), T_metadata()], T_void()));
     intrinsics.insert(~"llvm.dbg.declare", declare);
     intrinsics.insert(~"llvm.dbg.value", value);
 }
@@ -2815,7 +2813,7 @@ pub fn trap(bcx: block) {
     let v: ~[ValueRef] = ~[];
     match bcx.ccx().intrinsics.find(&~"llvm.trap") {
       Some(&x) => { Call(bcx, x, v); },
-      _ => bcx.sess().bug(~"unbound llvm.trap in trap")
+      _ => bcx.sess().bug("unbound llvm.trap in trap")
     }
 }
 
@@ -2838,9 +2836,9 @@ pub fn decl_gc_metadata(ccx: @CrateContext, llmod_id: &str) {
 }
 
 pub fn create_module_map(ccx: @CrateContext) -> ValueRef {
-    let elttype = T_struct(~[ccx.int_type, ccx.int_type], false);
+    let elttype = T_struct([ccx.int_type, ccx.int_type], false);
     let maptype = T_array(elttype, ccx.module_data.len() + 1);
-    let map = str::as_c_str(~"_rust_mod_map", |buf| {
+    let map = str::as_c_str("_rust_mod_map", |buf| {
         unsafe {
             llvm::LLVMAddGlobal(ccx.llmod, maptype, buf)
         }
@@ -2848,11 +2846,11 @@ pub fn create_module_map(ccx: @CrateContext) -> ValueRef {
     lib::llvm::SetLinkage(map, lib::llvm::InternalLinkage);
     let mut elts: ~[ValueRef] = ~[];
     for ccx.module_data.each |key, &val| {
-        let elt = C_struct(~[p2i(ccx, C_cstr(ccx, @/*bad*/ copy *key)),
+        let elt = C_struct([p2i(ccx, C_cstr(ccx, @/*bad*/ copy *key)),
                             p2i(ccx, val)]);
         elts.push(elt);
     }
-    let term = C_struct(~[C_int(ccx, 0), C_int(ccx, 0)]);
+    let term = C_struct([C_int(ccx, 0), C_int(ccx, 0)]);
     elts.push(term);
     unsafe {
         llvm::LLVMSetInitializer(map, C_array(elttype, elts));
@@ -2876,7 +2874,7 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
     };
     let sym_name = ~"_rust_crate_map_" + mapname;
     let arrtype = T_array(int_type, n_subcrates as uint);
-    let maptype = T_struct(~[T_i32(), T_ptr(T_i8()), int_type, arrtype], false);
+    let maptype = T_struct([T_i32(), T_ptr(T_i8()), int_type, arrtype], false);
     let map = str::as_c_str(sym_name, |buf| {
         unsafe {
             llvm::LLVMAddGlobal(llmod, maptype, buf)
@@ -2919,11 +2917,11 @@ pub fn fill_crate_map(ccx: @CrateContext, map: ValueRef) {
 
     unsafe {
         llvm::LLVMSetInitializer(map, C_struct(
-            ~[C_i32(1),
-              lib::llvm::llvm::LLVMConstPointerCast(llannihilatefn,
-                                                    T_ptr(T_i8())),
-              p2i(ccx, create_module_map(ccx)),
-              C_array(ccx.int_type, subcrates)]));
+            [C_i32(1),
+             lib::llvm::llvm::LLVMConstPointerCast(llannihilatefn,
+                                                   T_ptr(T_i8())),
+             p2i(ccx, create_module_map(ccx)),
+             C_array(ccx.int_type, subcrates)]));
     }
 }
 
@@ -2950,8 +2948,8 @@ pub fn write_metadata(cx: @CrateContext, crate: &ast::crate) {
     if !*cx.sess.building_library { return; }
     let encode_parms = crate_ctxt_to_encode_parms(cx);
     let llmeta = C_bytes(encoder::encode_metadata(encode_parms, crate));
-    let llconst = C_struct(~[llmeta]);
-    let mut llglobal = str::as_c_str(~"rust_metadata", |buf| {
+    let llconst = C_struct([llmeta]);
+    let mut llglobal = str::as_c_str("rust_metadata", |buf| {
         unsafe {
             llvm::LLVMAddGlobal(cx.llmod, val_ty(llconst), buf)
         }
@@ -2965,11 +2963,11 @@ pub fn write_metadata(cx: @CrateContext, crate: &ast::crate) {
 
         let t_ptr_i8 = T_ptr(T_i8());
         llglobal = llvm::LLVMConstBitCast(llglobal, t_ptr_i8);
-        let llvm_used = str::as_c_str(~"llvm.used", |buf| {
+        let llvm_used = str::as_c_str("llvm.used", |buf| {
             llvm::LLVMAddGlobal(cx.llmod, T_array(t_ptr_i8, 1u), buf)
         });
         lib::llvm::SetLinkage(llvm_used, lib::llvm::AppendingLinkage);
-        llvm::LLVMSetInitializer(llvm_used, C_array(t_ptr_i8, ~[llglobal]));
+        llvm::LLVMSetInitializer(llvm_used, C_array(t_ptr_i8, [llglobal]));
     }
 }
 
@@ -3122,7 +3120,7 @@ pub fn trans_crate(sess: session::Session,
         // Translate the metadata.
         write_metadata(ccx, crate);
         if ccx.sess.trans_stats() {
-            io::println(~"--- trans stats ---");
+            io::println("--- trans stats ---");
             io::println(fmt!("n_static_tydescs: %u",
                              ccx.stats.n_static_tydescs));
             io::println(fmt!("n_glues_created: %u",

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -189,7 +189,7 @@ pub fn Invoke(cx: block,
            val_str(cx.ccx().tn, Fn),
            str::connect(vec::map(Args, |a| val_str(cx.ccx().tn,
                                                    *a).to_owned()),
-                        ~", "));
+                        ", "));
     unsafe {
         count_insn(cx, "invoke");
         llvm::LLVMBuildInvoke(B(cx),
@@ -862,7 +862,7 @@ pub fn _UndefReturn(cx: block, Fn: ValueRef) -> ValueRef {
         let ty = val_ty(Fn);
         let retty = if llvm::LLVMGetTypeKind(ty) == lib::llvm::Integer {
             llvm::LLVMGetReturnType(ty) } else { ccx.int_type };
-            count_insn(cx, ~"");
+            count_insn(cx, "");
         return llvm::LLVMGetUndef(retty);
     }
 }
@@ -880,17 +880,17 @@ pub fn add_comment(bcx: block, text: &str) {
     unsafe {
         let ccx = bcx.ccx();
         if ccx.sess.asm_comments() {
-            let sanitized = str::replace(text, ~"$", ~"");
+            let sanitized = str::replace(text, "$", "");
             let comment_text = ~"# " +
-                str::replace(sanitized, ~"\n", ~"\n\t# ");
+                str::replace(sanitized, "\n", "\n\t# ");
             let asm = str::as_c_str(comment_text, |c| {
-                str::as_c_str(~"", |e| {
-                    count_insn(bcx, ~"inlineasm");
-                    llvm::LLVMConstInlineAsm(T_fn(~[], T_void()), c, e,
+                str::as_c_str("", |e| {
+                    count_insn(bcx, "inlineasm");
+                    llvm::LLVMConstInlineAsm(T_fn([], T_void()), c, e,
                                              False, False)
                 })
             });
-            Call(bcx, asm, ~[]);
+            Call(bcx, asm, []);
         }
     }
 }
@@ -1062,7 +1062,7 @@ pub fn Trap(cx: block) {
         let BB: BasicBlockRef = llvm::LLVMGetInsertBlock(b);
         let FN: ValueRef = llvm::LLVMGetBasicBlockParent(BB);
         let M: ModuleRef = llvm::LLVMGetGlobalParent(FN);
-        let T: ValueRef = str::as_c_str(~"llvm.trap", |buf| {
+        let T: ValueRef = str::as_c_str("llvm.trap", |buf| {
             llvm::LLVMGetNamedFunction(M, buf)
         });
         assert!((T as int != 0));

--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -177,7 +177,7 @@ pub impl FnType {
             }
         }
 
-        let llretval = load_inbounds(bcx, llargbundle, ~[ 0, arg_tys.len() ]);
+        let llretval = load_inbounds(bcx, llargbundle, [ 0, arg_tys.len() ]);
         let llretval = if self.ret_ty.cast {
             let retptr = BitCast(bcx, llretval, T_ptr(self.ret_ty.ty));
             Load(bcx, retptr)

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -379,7 +379,7 @@ pub fn trans_lang_call(bcx: block,
                                 trans_fn_ref_with_vtables_to_callee(bcx,
                                                                     did,
                                                                     0,
-                                                                    ~[],
+                                                                    [],
                                                                     None)
                              },
                              ArgVals(args),
@@ -717,8 +717,7 @@ pub fn trans_arg_expr(bcx: block,
                 }
                 _ => {
                     bcx.sess().impossible_case(
-                        arg_expr.span, ~"ret_flag with non-loop-\
-                                         body expr");
+                        arg_expr.span, "ret_flag with non-loop-body expr");
                 }
             }
         }

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -317,7 +317,7 @@ pub fn load_environment(fcx: fn_ctxt,
         Some(ll) => ll,
         None => {
             let ll =
-                str::as_c_str(~"load_env",
+                str::as_c_str("load_env",
                               |buf|
                               unsafe {
                                 llvm::LLVMAppendBasicBlock(fcx.llfn, buf)
@@ -516,7 +516,7 @@ pub fn make_opaque_cbox_take_glue(
         let bcx = callee::trans_lang_call(
             bcx,
             bcx.tcx().lang_items.exchange_malloc_fn(),
-            ~[opaque_tydesc, sz],
+            [opaque_tydesc, sz],
             expr::SaveIn(rval));
         let cbox_out = PointerCast(bcx, Load(bcx, rval), llopaquecboxty);
         call_memcpy(bcx, cbox_out, cbox_in, sz);
@@ -589,7 +589,7 @@ pub fn make_opaque_cbox_free_glue(
             ast::ManagedSigil => glue::trans_free(bcx, cbox),
             ast::OwnedSigil => glue::trans_exchange_free(bcx, cbox),
             ast::BorrowedSigil => {
-                bcx.sess().bug(~"impossible")
+                bcx.sess().bug("impossible")
             }
         }
     }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -781,7 +781,7 @@ pub fn T_void() -> TypeRef {
 }
 
 pub fn T_nil() -> TypeRef {
-    return T_struct(~[], false)
+    return T_struct([], false)
 }
 
 pub fn T_metadata() -> TypeRef { unsafe { return llvm::LLVMMetadataType(); } }
@@ -864,7 +864,7 @@ pub fn T_fn(inputs: &[TypeRef], output: TypeRef) -> TypeRef {
 }
 
 pub fn T_fn_pair(cx: @CrateContext, tfn: TypeRef) -> TypeRef {
-    return T_struct(~[T_ptr(tfn), T_opaque_cbox_ptr(cx)], false);
+    return T_struct([T_ptr(tfn), T_opaque_cbox_ptr(cx)], false);
 }
 
 pub fn T_ptr(t: TypeRef) -> TypeRef {
@@ -903,7 +903,7 @@ pub fn set_struct_body(t: TypeRef, elts: &[TypeRef], packed: bool) {
     }
 }
 
-pub fn T_empty_struct() -> TypeRef { return T_struct(~[], false); }
+pub fn T_empty_struct() -> TypeRef { return T_struct([], false); }
 
 // A vtable is, in reality, a vtable pointer followed by zero or more pointers
 // to tydescs and other vtables that it closes over. But the types and number
@@ -912,7 +912,7 @@ pub fn T_empty_struct() -> TypeRef { return T_struct(~[], false); }
 pub fn T_vtable() -> TypeRef { T_array(T_ptr(T_i8()), 1u) }
 
 pub fn T_task(targ_cfg: @session::config) -> TypeRef {
-    let t = T_named_struct(~"task");
+    let t = T_named_struct("task");
 
     // Refcount
     // Delegate pointer
@@ -960,11 +960,11 @@ pub fn T_generic_glue_fn(cx: @CrateContext) -> TypeRef {
 }
 
 pub fn T_tydesc(targ_cfg: @session::config) -> TypeRef {
-    let tydesc = T_named_struct(~"tydesc");
+    let tydesc = T_named_struct("tydesc");
     let tydescpp = T_ptr(T_ptr(tydesc));
     let pvoid = T_ptr(T_i8());
     let glue_fn_ty =
-        T_ptr(T_fn(~[T_ptr(T_nil()), T_ptr(T_nil()), tydescpp,
+        T_ptr(T_fn([T_ptr(T_nil()), T_ptr(T_nil()), tydescpp,
                     pvoid], T_void()));
 
     let int_type = T_int(targ_cfg);
@@ -990,9 +990,9 @@ pub fn T_vector(t: TypeRef, n: uint) -> TypeRef {
 
 // Interior vector.
 pub fn T_vec2(targ_cfg: @session::config, t: TypeRef) -> TypeRef {
-    return T_struct(~[T_int(targ_cfg), // fill
-                      T_int(targ_cfg), // alloc
-                      T_array(t, 0u)], // elements
+    return T_struct([T_int(targ_cfg), // fill
+                     T_int(targ_cfg), // alloc
+                     T_array(t, 0u)], // elements
                     false);
 }
 
@@ -1028,7 +1028,7 @@ pub fn T_box_header(cx: @CrateContext) -> TypeRef {
 }
 
 pub fn T_box(cx: @CrateContext, t: TypeRef) -> TypeRef {
-    return T_struct(vec::append(T_box_header_fields(cx), ~[t]), false);
+    return T_struct(vec::append(T_box_header_fields(cx), [t]), false);
 }
 
 pub fn T_box_ptr(t: TypeRef) -> TypeRef {
@@ -1046,7 +1046,7 @@ pub fn T_opaque_box_ptr(cx: @CrateContext) -> TypeRef {
 }
 
 pub fn T_unique(cx: @CrateContext, t: TypeRef) -> TypeRef {
-    return T_struct(vec::append(T_box_header_fields(cx), ~[t]), false);
+    return T_struct(vec::append(T_box_header_fields(cx), [t]), false);
 }
 
 pub fn T_unique_ptr(t: TypeRef) -> TypeRef {
@@ -1056,12 +1056,12 @@ pub fn T_unique_ptr(t: TypeRef) -> TypeRef {
 }
 
 pub fn T_port(cx: @CrateContext, _t: TypeRef) -> TypeRef {
-    return T_struct(~[cx.int_type], false); // Refcount
+    return T_struct([cx.int_type], false); // Refcount
 
 }
 
 pub fn T_chan(cx: @CrateContext, _t: TypeRef) -> TypeRef {
-    return T_struct(~[cx.int_type], false); // Refcount
+    return T_struct([cx.int_type], false); // Refcount
 
 }
 
@@ -1085,16 +1085,16 @@ pub fn T_captured_tydescs(cx: @CrateContext, n: uint) -> TypeRef {
 pub fn T_opaque_trait(cx: @CrateContext, store: ty::TraitStore) -> TypeRef {
     match store {
         ty::BoxTraitStore => {
-            T_struct(~[T_ptr(cx.tydesc_type), T_opaque_box_ptr(cx)], false)
+            T_struct([T_ptr(cx.tydesc_type), T_opaque_box_ptr(cx)], false)
         }
         ty::UniqTraitStore => {
-            T_struct(~[T_ptr(cx.tydesc_type),
-                       T_unique_ptr(T_unique(cx, T_i8())),
-                       T_ptr(cx.tydesc_type)],
+            T_struct([T_ptr(cx.tydesc_type),
+                      T_unique_ptr(T_unique(cx, T_i8())),
+                      T_ptr(cx.tydesc_type)],
                      false)
         }
         ty::RegionTraitStore(_) => {
-            T_struct(~[T_ptr(cx.tydesc_type), T_ptr(T_i8())], false)
+            T_struct([T_ptr(cx.tydesc_type), T_ptr(T_i8())], false)
         }
     }
 }
@@ -1130,7 +1130,7 @@ pub fn C_floating(s: &str, t: TypeRef) -> ValueRef {
 }
 
 pub fn C_nil() -> ValueRef {
-    return C_struct(~[]);
+    return C_struct([]);
 }
 
 pub fn C_bool(b: bool) -> ValueRef {
@@ -1193,7 +1193,7 @@ pub fn C_estr_slice(cx: @CrateContext, s: @~str) -> ValueRef {
     unsafe {
         let len = s.len();
         let cs = llvm::LLVMConstPointerCast(C_cstr(cx, s), T_ptr(T_i8()));
-        C_struct(~[cs, C_uint(cx, len + 1u /* +1 for null */)])
+        C_struct([cs, C_uint(cx, len + 1u /* +1 for null */)])
     }
 }
 

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -165,7 +165,7 @@ pub fn get_const_val(cx: @CrateContext, def_id: ast::def_id) -> ValueRef {
             }, _) => {
                 trans_const(cx, subexpr, def_id.node);
             }
-            _ => cx.tcx.sess.bug(~"expected a const to be an item")
+            _ => cx.tcx.sess.bug("expected a const to be an item")
         }
     }
     cx.const_values.get_copy(&def_id.node)
@@ -177,7 +177,7 @@ pub fn const_expr(cx: @CrateContext, e: @ast::expr) -> ValueRef {
     match cx.tcx.adjustments.find(&e.id) {
         None => { }
         Some(&@ty::AutoAddEnv(ty::re_static, ast::BorrowedSigil)) => {
-            llconst = C_struct(~[llconst, C_null(T_opaque_box_ptr(cx))])
+            llconst = C_struct([llconst, C_null(T_opaque_box_ptr(cx))])
         }
         Some(&@ty::AutoAddEnv(ref r, ref s)) => {
             cx.sess.span_bug(e.span, fmt!("unexpected static function: \
@@ -213,7 +213,7 @@ pub fn const_expr(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                                                           val_ty(llconst));
                             assert_eq!(abi::slice_elt_base, 0);
                             assert_eq!(abi::slice_elt_len, 1);
-                            llconst = C_struct(~[llptr, size]);
+                            llconst = C_struct([llptr, size]);
                         }
                         _ => {
                             cx.sess.span_bug(e.span,
@@ -450,8 +450,8 @@ fn const_expr_unadjusted(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                         llvm::LLVMConstIntCast(iv, llty, s)
                     }
                     expr::cast_float => llvm::LLVMConstUIToFP(iv, llty),
-                    _ => cx.sess.bug(~"enum cast destination is not \
-                                       integral or float")
+                    _ => cx.sess.bug("enum cast destination is not \
+                                      integral or float")
                 }
               }
               (expr::cast_pointer, expr::cast_pointer) => {
@@ -462,7 +462,7 @@ fn const_expr_unadjusted(cx: @CrateContext, e: @ast::expr) -> ValueRef {
               }
               _ => {
                 cx.sess.impossible_case(e.span,
-                                        ~"bad combination of types for cast")
+                                        "bad combination of types for cast")
               }
             }
           }
@@ -512,7 +512,7 @@ fn const_expr_unadjusted(cx: @CrateContext, e: @ast::expr) -> ValueRef {
                 llvm::LLVMSetGlobalConstant(gv, True);
                 SetLinkage(gv, PrivateLinkage);
                 let p = const_ptrcast(cx, gv, llunitty);
-                C_struct(~[p, sz])
+                C_struct([p, sz])
               }
               _ => cx.sess.span_bug(e.span, "bad const-slice expr")
             }

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -93,14 +93,14 @@ pub fn trans_if(bcx: block,
             trans_block(else_bcx_in, blk, dest)
           }
           // would be nice to have a constraint on ifs
-          _ => bcx.tcx().sess.bug(~"strange alternative in if")
+          _ => bcx.tcx().sess.bug("strange alternative in if")
         }
       }
       _ => else_bcx_in
     };
     let else_bcx_out = trans_block_cleanups(else_bcx_out,
                                             block_cleanups(else_bcx_in));
-    return join_blocks(bcx, ~[then_bcx_out, else_bcx_out]);
+    return join_blocks(bcx, [then_bcx_out, else_bcx_out]);
 
 }
 
@@ -228,7 +228,7 @@ pub fn trans_log(log_ex: @ast::expr,
             let val = val_datum.to_ref_llval(bcx);
             let did = bcx.tcx().lang_items.log_type_fn();
             let bcx = callee::trans_lang_call_with_type_params(
-                bcx, did, ~[level, val], ~[val_datum.ty], expr::Ignore);
+                bcx, did, [level, val], [val_datum.ty], expr::Ignore);
             bcx
         }
     }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -217,7 +217,7 @@ fn create_compile_unit(cx: @CrateContext) -> @Metadata<CompileUnitMetadata> {
                          llstr(env!("CFG_VERSION")),
                          lli1(true), // deprecated: main compile unit
                          lli1(cx.sess.opts.optimize != session::No),
-                         llstr(~""), // flags (???)
+                         llstr(""), // flags (???)
                          lli32(0) // runtime version (???)
                         ];
     let unit_node = llmdnode(unit_metadata);
@@ -368,7 +368,7 @@ fn create_basic_type(cx: @CrateContext, t: ty::t, span: span)
             ast::ty_f32 => (~"f32", DW_ATE_float),
             ast::ty_f64 => (~"f64", DW_ATE_float)
         },
-        _ => cx.sess.bug(~"debuginfo::create_basic_type - t is invalid type")
+        _ => cx.sess.bug("debuginfo::create_basic_type - t is invalid type")
     };
 
     let fname = filename_from_span(cx, span);
@@ -522,7 +522,7 @@ fn create_tuple(cx: @CrateContext, t: ty::t, elements: &[ty::t], span: span)
     for elements.each |element| {
         let ty_md = create_ty(cx, *element, span);
         let (size, align) = size_and_align_of(cx, *element);
-        add_member(scx, ~"", line_from_span(cx.sess.codemap, span) as int,
+        add_member(scx, "", line_from_span(cx.sess.codemap, span) as int,
                    size as int, align as int, ty_md.node);
     }
     let mdval = @Metadata {
@@ -539,7 +539,7 @@ fn voidptr() -> (ValueRef, int, int) {
     let null = ptr::null();
     let size = sys::size_of::<ValueRef>() as int;
     let align = sys::min_align_of::<ValueRef>() as int;
-    let vp = create_derived_type(PointerTypeTag, null, ~"", 0,
+    let vp = create_derived_type(PointerTypeTag, null, "", 0,
                                  size, align, 0, null);
     return (vp, size, align);
 }
@@ -561,16 +561,16 @@ fn create_boxed_type(cx: @CrateContext, contents: ty::t,
     let refcount_type = create_basic_type(cx, int_t, span);
     let name = ty_to_str(cx.tcx, contents);
     let scx = create_structure(file_node, @fmt!("box<%s>", name), 0);
-    add_member(scx, ~"refcnt", 0, sys::size_of::<uint>() as int,
+    add_member(scx, "refcnt", 0, sys::size_of::<uint>() as int,
                sys::min_align_of::<uint>() as int, refcount_type.node);
     // the tydesc and other pointers should be irrelevant to the
     // debugger, so treat them as void* types
     let (vp, vpsize, vpalign) = voidptr();
-    add_member(scx, ~"tydesc", 0, vpsize, vpalign, vp);
-    add_member(scx, ~"prev", 0, vpsize, vpalign, vp);
-    add_member(scx, ~"next", 0, vpsize, vpalign, vp);
+    add_member(scx, "tydesc", 0, vpsize, vpalign, vp);
+    add_member(scx, "prev", 0, vpsize, vpalign, vp);
+    add_member(scx, "next", 0, vpsize, vpalign, vp);
     let (size, align) = size_and_align_of(cx, contents);
-    add_member(scx, ~"boxed", 0, size, align, boxed.node);
+    add_member(scx, "boxed", 0, size, align, boxed.node);
     let llnode = finish_structure(scx);
     let mdval = @Metadata {
         node: llnode,
@@ -619,7 +619,7 @@ fn create_fixed_vec(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t,
     let fname = filename_from_span(cx, span);
     let file_node = create_file(cx, fname);
     let (size, align) = size_and_align_of(cx, elem_t);
-    let subrange = llmdnode(~[lltag(SubrangeTag), lli64(0), lli64(len - 1)]);
+    let subrange = llmdnode([lltag(SubrangeTag), lli64(0), lli64(len - 1)]);
     let name = fmt!("[%s]", ty_to_str(cx.tcx, elem_t));
     let array = create_composite_type(ArrayTypeTag, name, file_node.node, 0,
                                       size * len, align, 0, Some(t_md.node),
@@ -641,18 +641,18 @@ fn create_boxed_vec(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t,
     let vec_scx = create_structure(file_node,
                                @/*bad*/ copy ty_to_str(cx.tcx, vec_t), 0);
     let size_t_type = create_basic_type(cx, ty::mk_uint(), vec_ty_span);
-    add_member(vec_scx, ~"fill", 0, sys::size_of::<libc::size_t>() as int,
+    add_member(vec_scx, "fill", 0, sys::size_of::<libc::size_t>() as int,
                sys::min_align_of::<libc::size_t>() as int, size_t_type.node);
-    add_member(vec_scx, ~"alloc", 0, sys::size_of::<libc::size_t>() as int,
+    add_member(vec_scx, "alloc", 0, sys::size_of::<libc::size_t>() as int,
                sys::min_align_of::<libc::size_t>() as int, size_t_type.node);
-    let subrange = llmdnode(~[lltag(SubrangeTag), lli64(0), lli64(0)]);
+    let subrange = llmdnode([lltag(SubrangeTag), lli64(0), lli64(0)]);
     let (arr_size, arr_align) = size_and_align_of(cx, elem_t);
     let name = fmt!("[%s]", ty_to_str(cx.tcx, elem_t));
     let data_ptr = create_composite_type(ArrayTypeTag, name, file_node.node, 0,
                                          arr_size, arr_align, 0,
                                          Some(elem_ty_md.node),
                                          Some(~[subrange]));
-    add_member(vec_scx, ~"data", 0, 0, // clang says the size should be 0
+    add_member(vec_scx, "data", 0, 0, // clang says the size should be 0
                sys::min_align_of::<u8>() as int, data_ptr);
     let llnode = finish_structure(vec_scx);
     let vec_md = @Metadata {
@@ -665,15 +665,15 @@ fn create_boxed_vec(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t,
     let box_scx = create_structure(file_node, @fmt!("box<%s>", name), 0);
     let int_t = ty::mk_int();
     let refcount_type = create_basic_type(cx, int_t, vec_ty_span);
-    add_member(box_scx, ~"refcnt", 0, sys::size_of::<uint>() as int,
+    add_member(box_scx, "refcnt", 0, sys::size_of::<uint>() as int,
                sys::min_align_of::<uint>() as int, refcount_type.node);
     let (vp, vpsize, vpalign) = voidptr();
-    add_member(box_scx, ~"tydesc", 0, vpsize, vpalign, vp);
-    add_member(box_scx, ~"prev", 0, vpsize, vpalign, vp);
-    add_member(box_scx, ~"next", 0, vpsize, vpalign, vp);
+    add_member(box_scx, "tydesc", 0, vpsize, vpalign, vp);
+    add_member(box_scx, "prev", 0, vpsize, vpalign, vp);
+    add_member(box_scx, "next", 0, vpsize, vpalign, vp);
     let size = 2 * sys::size_of::<int>() as int;
     let align = sys::min_align_of::<int>() as int;
-    add_member(box_scx, ~"boxed", 0, size, align, vec_md.node);
+    add_member(box_scx, "boxed", 0, size, align, vec_md.node);
     let llnode = finish_structure(box_scx);
     let mdval = @Metadata {
         node: llnode,
@@ -693,8 +693,8 @@ fn create_vec_slice(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t, span: span)
     let elem_ptr = create_pointer_type(cx, elem_t, span, elem_ty_md);
     let scx = create_structure(file_node, @ty_to_str(cx.tcx, vec_t), 0);
     let (_, ptr_size, ptr_align) = voidptr();
-    add_member(scx, ~"vec", 0, ptr_size, ptr_align, elem_ptr.node);
-    add_member(scx, ~"length", 0, sys::size_of::<uint>() as int,
+    add_member(scx, "vec", 0, ptr_size, ptr_align, elem_ptr.node);
+    add_member(scx, "length", 0, sys::size_of::<uint>() as int,
                sys::min_align_of::<uint>() as int, uint_type.node);
     let llnode = finish_structure(scx);
     let mdval = @Metadata {
@@ -715,7 +715,7 @@ fn create_fn_ty(cx: @CrateContext, fn_ty: ty::t, inputs: ~[ty::t], output: ty::t
     let output_ptr_md = create_pointer_type(cx, output, span, output_md);
     let inputs_vals = do inputs.map |arg| { create_ty(cx, *arg, span).node };
     let members = ~[output_ptr_md.node, vp] + inputs_vals;
-    let llnode = create_composite_type(SubroutineTag, ~"", file_node.node,
+    let llnode = create_composite_type(SubroutineTag, "", file_node.node,
                                        0, 0, 0, 0, None, Some(members));
     let mdval = @Metadata {
         node: llnode,
@@ -802,7 +802,7 @@ fn create_ty(cx: @CrateContext, t: ty::t, span: span)
         ty::ty_tup(ref elements) => {
             create_tuple(cx, t, *elements, span)
         },
-        _ => cx.sess.bug(~"debuginfo: unexpected type in create_ty")
+        _ => cx.sess.bug("debuginfo: unexpected type in create_ty")
     }
 }
 
@@ -869,7 +869,7 @@ pub fn create_local_var(bcx: block, local: @ast::local)
         }
       }
     };
-    let declargs = ~[llmdnode(~[llptr]), mdnode];
+    let declargs = ~[llmdnode([llptr]), mdnode];
     trans::build::Call(bcx, *cx.intrinsics.get(&~"llvm.dbg.declare"),
                        declargs);
     return mdval;
@@ -918,7 +918,7 @@ pub fn create_arg(bcx: block, arg: ast::arg, sp: span)
             let llptr = match fcx.llargs.get_copy(&arg.id) {
               local_mem(v) | local_imm(v) => v,
             };
-            let declargs = ~[llmdnode(~[llptr]), mdnode];
+            let declargs = ~[llmdnode([llptr]), mdnode];
             trans::build::Call(bcx,
                                *cx.intrinsics.get(&~"llvm.dbg.declare"),
                                declargs);
@@ -1003,7 +1003,7 @@ pub fn create_function(fcx: fn_ctxt) -> @Metadata<SubProgramMetadata> {
     } else {
         llnull()
     };
-    let sub_node = create_composite_type(SubroutineTag, ~"", file_node, 0, 0,
+    let sub_node = create_composite_type(SubroutineTag, "", file_node, 0, 0,
                                          0, 0, option::None,
                                          option::Some(~[ty_node]));
 
@@ -1013,7 +1013,7 @@ pub fn create_function(fcx: fn_ctxt) -> @Metadata<SubProgramMetadata> {
                        llstr(*cx.sess.str_of(ident)),
                         //XXX fully-qualified C++ name:
                        llstr(*cx.sess.str_of(ident)),
-                       llstr(~""), //XXX MIPS name?????
+                       llstr(""), //XXX MIPS name?????
                        file_node,
                        lli32(loc.line as int),
                        sub_node,

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -885,9 +885,9 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
         };
 
         let vt = tvec::vec_types(bcx, base_datum.ty);
-        base::maybe_name_value(bcx.ccx(), vt.llunit_size, ~"unit_sz");
+        base::maybe_name_value(bcx.ccx(), vt.llunit_size, "unit_sz");
         let scaled_ix = Mul(bcx, ix_val, vt.llunit_size);
-        base::maybe_name_value(bcx.ccx(), scaled_ix, ~"scaled_ix");
+        base::maybe_name_value(bcx.ccx(), scaled_ix, "scaled_ix");
 
         let mut (bcx, base, len) =
             base_datum.get_vec_base_and_len(bcx, index_expr.span,
@@ -907,7 +907,7 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
             controlflow::trans_fail_bounds_check(bcx, index_expr.span,
                                                  ix_val, unscaled_len)
         };
-        let elt = InBoundsGEP(bcx, base, ~[ix_val]);
+        let elt = InBoundsGEP(bcx, base, [ix_val]);
         let elt = PointerCast(bcx, elt, T_ptr(vt.llunit_ty));
         return DatumBlock {
             bcx: bcx,
@@ -1110,8 +1110,8 @@ pub fn with_field_tys<R>(tcx: ty::ctxt,
                                struct_fields(tcx, variant_id, substs))
                         }
                         _ => {
-                            tcx.sess.bug(~"resolve didn't map this expr to a \
-                                           variant ID")
+                            tcx.sess.bug("resolve didn't map this expr to a \
+                                          variant ID")
                         }
                     }
                 }
@@ -1168,7 +1168,7 @@ fn trans_rec_or_struct(bcx: block,
             }
             None => {
                 if need_base.any(|b| *b) {
-                    tcx.sess.span_bug(expr_span, ~"missing fields and no base expr")
+                    tcx.sess.span_bug(expr_span, "missing fields and no base expr")
                 }
                 None
             }
@@ -1313,9 +1313,9 @@ fn trans_unary_datum(bcx: block,
             trans_boxed_expr(bcx, un_ty, sub_expr, sub_ty, heap)
         }
         ast::deref => {
-            bcx.sess().bug(~"deref expressions should have been \
-                             translated using trans_lvalue(), not \
-                             trans_unary_datum()")
+            bcx.sess().bug("deref expressions should have been \
+                            translated using trans_lvalue(), not \
+                            trans_unary_datum()")
         }
     };
 
@@ -1482,8 +1482,8 @@ fn trans_lazy_binop(bcx: block,
     }
 
     Br(past_rhs, join.llbb);
-    let phi = Phi(join, T_bool(), ~[lhs, rhs], ~[past_lhs.llbb,
-                                                 past_rhs.llbb]);
+    let phi = Phi(join, T_bool(), [lhs, rhs], [past_lhs.llbb,
+                                               past_rhs.llbb]);
 
     return immediate_rvalue_bcx(join, phi, binop_ty);
 }
@@ -1644,10 +1644,10 @@ fn trans_imm_cast(bcx: block, expr: @ast::expr,
                                               val_ty(lldiscrim_a),
                                               lldiscrim_a, true),
                     cast_float => SIToFP(bcx, lldiscrim_a, ll_t_out),
-                    _ => ccx.sess.bug(~"translating unsupported cast.")
+                    _ => ccx.sess.bug("translating unsupported cast.")
                 }
             }
-            _ => ccx.sess.bug(~"translating unsupported cast.")
+            _ => ccx.sess.bug("translating unsupported cast.")
         };
     return immediate_rvalue_bcx(bcx, newval, t_out);
 }

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -42,7 +42,7 @@ pub fn trans_free(cx: block, v: ValueRef) -> block {
     callee::trans_lang_call(
         cx,
         cx.tcx().lang_items.free_fn(),
-        ~[PointerCast(cx, v, T_ptr(T_i8()))],
+        [PointerCast(cx, v, T_ptr(T_i8()))],
         expr::Ignore)
 }
 
@@ -51,7 +51,7 @@ pub fn trans_exchange_free(cx: block, v: ValueRef) -> block {
     callee::trans_lang_call(
         cx,
         cx.tcx().lang_items.exchange_free_fn(),
-        ~[PointerCast(cx, v, T_ptr(T_i8()))],
+        [PointerCast(cx, v, T_ptr(T_i8()))],
         expr::Ignore)
 }
 
@@ -100,7 +100,7 @@ pub fn drop_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
       ty::ty_estr(ty::vstore_box) => {
         decr_refcnt_maybe_free(bcx, v, t)
       }
-      _ => bcx.tcx().sess.bug(~"drop_ty_immediate: non-box ty")
+      _ => bcx.tcx().sess.bug("drop_ty_immediate: non-box ty")
     }
 }
 
@@ -147,7 +147,7 @@ pub fn free_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
         Store(bcx, v, vp);
         free_ty(bcx, vp, t)
       }
-      _ => bcx.tcx().sess.bug(~"free_ty_immediate: non-box ty")
+      _ => bcx.tcx().sess.bug("free_ty_immediate: non-box ty")
     }
 }
 
@@ -269,7 +269,7 @@ pub fn lazily_emit_tydesc_glue(ccx: @CrateContext,
                    ppaux::ty_to_str(ccx.tcx, ti.ty));
             let glue_fn = declare_generic_glue(ccx, ti.ty, llfnty, ~"take");
             ti.take_glue = Some(glue_fn);
-            make_generic_glue(ccx, ti.ty, glue_fn, make_take_glue, ~"take");
+            make_generic_glue(ccx, ti.ty, glue_fn, make_take_glue, "take");
             debug!("--- lazily_emit_tydesc_glue TAKE %s",
                    ppaux::ty_to_str(ccx.tcx, ti.ty));
           }
@@ -282,7 +282,7 @@ pub fn lazily_emit_tydesc_glue(ccx: @CrateContext,
                    ppaux::ty_to_str(ccx.tcx, ti.ty));
             let glue_fn = declare_generic_glue(ccx, ti.ty, llfnty, ~"drop");
             ti.drop_glue = Some(glue_fn);
-            make_generic_glue(ccx, ti.ty, glue_fn, make_drop_glue, ~"drop");
+            make_generic_glue(ccx, ti.ty, glue_fn, make_drop_glue, "drop");
             debug!("--- lazily_emit_tydesc_glue DROP %s",
                    ppaux::ty_to_str(ccx.tcx, ti.ty));
           }
@@ -295,7 +295,7 @@ pub fn lazily_emit_tydesc_glue(ccx: @CrateContext,
                    ppaux::ty_to_str(ccx.tcx, ti.ty));
             let glue_fn = declare_generic_glue(ccx, ti.ty, llfnty, ~"free");
             ti.free_glue = Some(glue_fn);
-            make_generic_glue(ccx, ti.ty, glue_fn, make_free_glue, ~"free");
+            make_generic_glue(ccx, ti.ty, glue_fn, make_free_glue, "free");
             debug!("--- lazily_emit_tydesc_glue FREE %s",
                    ppaux::ty_to_str(ccx.tcx, ti.ty));
           }
@@ -308,7 +308,7 @@ pub fn lazily_emit_tydesc_glue(ccx: @CrateContext,
                    ppaux::ty_to_str(ccx.tcx, ti.ty));
             let glue_fn = declare_generic_glue(ccx, ti.ty, llfnty, ~"visit");
             ti.visit_glue = Some(glue_fn);
-            make_generic_glue(ccx, ti.ty, glue_fn, make_visit_glue, ~"visit");
+            make_generic_glue(ccx, ti.ty, glue_fn, make_visit_glue, "visit");
             debug!("--- lazily_emit_tydesc_glue VISIT %s",
                    ppaux::ty_to_str(ccx.tcx, ti.ty));
           }
@@ -379,8 +379,8 @@ pub fn call_tydesc_glue_full(bcx: block,
         }
     };
 
-    Call(bcx, llfn, ~[C_null(T_ptr(T_nil())), C_null(T_ptr(T_nil())),
-                      C_null(T_ptr(T_ptr(bcx.ccx().tydesc_type))), llrawptr]);
+    Call(bcx, llfn, [C_null(T_ptr(T_nil())), C_null(T_ptr(T_nil())),
+                     C_null(T_ptr(T_ptr(bcx.ccx().tydesc_type))), llrawptr]);
 }
 
 // See [Note-arg-mode]
@@ -394,7 +394,7 @@ pub fn call_tydesc_glue(cx: block, v: ValueRef, t: ty::t, field: uint)
 
 pub fn make_visit_glue(bcx: block, v: ValueRef, t: ty::t) {
     let _icx = bcx.insn_ctxt("make_visit_glue");
-    let bcx = do with_scope(bcx, None, ~"visitor cleanup") |bcx| {
+    let bcx = do with_scope(bcx, None, "visitor cleanup") |bcx| {
         let mut bcx = bcx;
         let (visitor_trait, object_ty) = ty::visitor_object_ty(bcx.tcx());
         let v = PointerCast(bcx, v, T_ptr(type_of::type_of(bcx.ccx(), object_ty)));
@@ -820,14 +820,14 @@ pub fn emit_tydescs(ccx: @CrateContext) {
 
         let tydesc =
             C_named_struct(ccx.tydesc_type,
-                           ~[ti.size, // size
-                             ti.align, // align
-                             take_glue, // take_glue
-                             drop_glue, // drop_glue
-                             free_glue, // free_glue
-                             visit_glue, // visit_glue
-                             shape, // shape
-                             shape_tables]); // shape_tables
+                           [ti.size, // size
+                            ti.align, // align
+                            take_glue, // take_glue
+                            drop_glue, // drop_glue
+                            free_glue, // free_glue
+                            visit_glue, // visit_glue
+                            shape, // shape
+                            shape_tables]); // shape_tables
 
         unsafe {
             let gvar = ti.tydesc;

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -77,14 +77,14 @@ pub fn maybe_instantiate_inline(ccx: @CrateContext, fn_id: ast::def_id,
                   ccx.external.insert(there.id, Some(here.id.node));
               }
             }
-            _ => ccx.sess.bug(~"maybe_instantiate_inline: item has a \
-                  non-enum parent")
+            _ => ccx.sess.bug("maybe_instantiate_inline: item has a \
+                               non-enum parent")
           }
           if translate { trans_item(ccx, item); }
           local_def(my_id)
         }
         csearch::found_parent(_, _) => {
-            ccx.sess.bug(~"maybe_get_item_ast returned a found_parent \
+            ccx.sess.bug("maybe_get_item_ast returned a found_parent \
              with a non-item parent");
         }
         csearch::found(ast::ii_method(impl_did, mth)) => {
@@ -98,7 +98,7 @@ pub fn maybe_instantiate_inline(ccx: @CrateContext, fn_id: ast::def_id,
               let llfn = get_item_val(ccx, mth.id);
               let path = vec::append(
                   ty::item_path(ccx.tcx, impl_did),
-                  ~[path_name(mth.ident)]);
+                  [path_name(mth.ident)]);
               let self_kind = match mth.explicit_self.node {
                   ast::sty_static => no_self,
                   _ => {

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -150,6 +150,6 @@ pub fn static_size_of_enum(cx: @CrateContext, t: ty::t) -> uint {
             cx.enum_sizes.insert(t, max_size);
             return max_size;
         }
-        _ => cx.sess.bug(~"static_size_of_enum called on non-enum")
+        _ => cx.sess.bug("static_size_of_enum called on non-enum")
     }
 }

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -213,8 +213,8 @@ pub fn trans_method_callee(bcx: block,
             // Make sure to fail with a readable error message if
             // there's some internal error here
             if !(method_index < supertrait_method_def_ids.len()) {
-                tcx.sess.bug(~"trans_method_callee: supertrait method \
-                               index is out of bounds");
+                tcx.sess.bug("trans_method_callee: supertrait method \
+                              index is out of bounds");
             }
             // Get the method name using the method index in the origin
             let method_name =
@@ -657,11 +657,11 @@ pub fn trans_trait_callee_from_llval(bcx: block,
     let self_mode;
     match explicit_self {
         ast::sty_static => {
-            bcx.tcx().sess.bug(~"shouldn't see static method here");
+            bcx.tcx().sess.bug("shouldn't see static method here");
         }
         ast::sty_value => {
-            bcx.tcx().sess.bug(~"methods with by-value self should not be \
-                               called on objects");
+            bcx.tcx().sess.bug("methods with by-value self should not be \
+                                called on objects");
         }
         ast::sty_region(*) => {
             // As before, we need to pass a pointer to a pointer to the
@@ -691,7 +691,7 @@ pub fn trans_trait_callee_from_llval(bcx: block,
             // Pass a pointer to the box.
             match store {
                 ty::BoxTraitStore => llself = llbox,
-                _ => bcx.tcx().sess.bug(~"@self receiver with non-@Trait")
+                _ => bcx.tcx().sess.bug("@self receiver with non-@Trait")
             }
 
             let llscratch = alloca(bcx, val_ty(llself));
@@ -704,7 +704,7 @@ pub fn trans_trait_callee_from_llval(bcx: block,
             // Pass the unique pointer.
             match store {
                 ty::UniqTraitStore => llself = llbox,
-                _ => bcx.tcx().sess.bug(~"~self receiver with non-~Trait")
+                _ => bcx.tcx().sess.bug("~self receiver with non-~Trait")
             }
 
             let llscratch = alloca(bcx, val_ty(llself));

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -120,23 +120,23 @@ pub fn monomorphic_fn(ccx: @CrateContext,
         (pt, m.ident, m.span)
       }
       ast_map::node_trait_method(@ast::required(_), _, _) => {
-        ccx.tcx.sess.bug(~"Can't monomorphize a required trait method")
+        ccx.tcx.sess.bug("Can't monomorphize a required trait method")
       }
       ast_map::node_expr(*) => {
-        ccx.tcx.sess.bug(~"Can't monomorphize an expr")
+        ccx.tcx.sess.bug("Can't monomorphize an expr")
       }
       ast_map::node_stmt(*) => {
-        ccx.tcx.sess.bug(~"Can't monomorphize a stmt")
+        ccx.tcx.sess.bug("Can't monomorphize a stmt")
       }
-      ast_map::node_arg(*) => ccx.tcx.sess.bug(~"Can't monomorphize an arg"),
+      ast_map::node_arg(*) => ccx.tcx.sess.bug("Can't monomorphize an arg"),
       ast_map::node_block(*) => {
-          ccx.tcx.sess.bug(~"Can't monomorphize a block")
+          ccx.tcx.sess.bug("Can't monomorphize a block")
       }
       ast_map::node_local(*) => {
-          ccx.tcx.sess.bug(~"Can't monomorphize a local")
+          ccx.tcx.sess.bug("Can't monomorphize a local")
       }
       ast_map::node_callee_scope(*) => {
-          ccx.tcx.sess.bug(~"Can't monomorphize a callee-scope")
+          ccx.tcx.sess.bug("Can't monomorphize a callee-scope")
       }
       ast_map::node_struct_ctor(_, i, pt) => (pt, i.ident, i.span)
     };
@@ -169,8 +169,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
     ccx.monomorphizing.insert(fn_id, depth + 1);
 
     let pt = vec::append(/*bad*/copy *pt,
-                         ~[path_name((ccx.names)(
-                             *ccx.sess.str_of(name)))]);
+                         [path_name((ccx.names)(*ccx.sess.str_of(name)))]);
     let s = mangle_exported_name(ccx, /*bad*/copy pt, mono_ty);
 
     let mk_lldecl = || {
@@ -206,7 +205,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
         d
       }
       ast_map::node_item(*) => {
-          ccx.tcx.sess.bug(~"Can't monomorphize this kind of item")
+          ccx.tcx.sess.bug("Can't monomorphize this kind of item")
       }
       ast_map::node_foreign_item(i, _, _, _) => {
           let d = mk_lldecl();
@@ -225,7 +224,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
                                    this_tv.disr_val, psubsts, d);
             }
             ast::struct_variant_kind(_) =>
-                ccx.tcx.sess.bug(~"can't monomorphize struct variants"),
+                ccx.tcx.sess.bug("can't monomorphize struct variants"),
         }
         d
       }
@@ -257,8 +256,8 @@ pub fn monomorphic_fn(ccx: @CrateContext,
         set_inline_hint(d);
         base::trans_tuple_struct(ccx,
                                  /*bad*/copy struct_def.fields,
-                                 struct_def.ctor_id.expect(~"ast-mapped tuple struct \
-                                                             didn't have a ctor id"),
+                                 struct_def.ctor_id.expect("ast-mapped tuple struct \
+                                                            didn't have a ctor id"),
                                  psubsts,
                                  d);
         d

--- a/src/librustc/middle/trans/reachable.rs
+++ b/src/librustc/middle/trans/reachable.rs
@@ -212,8 +212,8 @@ fn traverse_inline_body(cx: @mut ctx, body: &blk) {
               }
               Some(_) => {}
               None => {
-                cx.tcx.sess.span_bug(e.span, ~"expr_method_call not in \
-                                               method map");
+                cx.tcx.sess.span_bug(e.span, "expr_method_call not in \
+                                              method map");
               }
             }
           }

--- a/src/librustc/middle/trans/shape.rs
+++ b/src/librustc/middle/trans/shape.rs
@@ -48,8 +48,8 @@ pub fn mk_global(ccx: @CrateContext,
 
 pub fn mk_ctxt(llmod: ModuleRef) -> Ctxt {
     unsafe {
-        let llshapetablesty = trans::common::T_named_struct(~"shapes");
-        let _llshapetables = str::as_c_str(~"shapes", |buf| {
+        let llshapetablesty = trans::common::T_named_struct("shapes");
+        let _llshapetables = str::as_c_str("shapes", |buf| {
             llvm::LLVMAddGlobal(llmod, llshapetablesty, buf)
         });
 

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -45,8 +45,8 @@ pub fn expand_boxed_vec_ty(tcx: ty::ctxt, t: ty::t) -> ty::t {
       ty::ty_estr(ty::vstore_box) | ty::ty_evec(_, ty::vstore_box) => {
         ty::mk_imm_box(tcx, unboxed_vec_ty)
       }
-      _ => tcx.sess.bug(~"non boxed-vec type \
-                          in tvec::expand_boxed_vec_ty")
+      _ => tcx.sess.bug("non boxed-vec type \
+                         in tvec::expand_boxed_vec_ty")
     }
 }
 
@@ -74,7 +74,7 @@ pub fn pointer_add(bcx: block, ptr: ValueRef, bytes: ValueRef) -> ValueRef {
     let _icx = bcx.insn_ctxt("tvec::pointer_add");
     let old_ty = val_ty(ptr);
     let bptr = PointerCast(bcx, ptr, T_ptr(T_i8()));
-    return PointerCast(bcx, InBoundsGEP(bcx, bptr, ~[bytes]), old_ty);
+    return PointerCast(bcx, InBoundsGEP(bcx, bptr, [bytes]), old_ty);
 }
 
 pub fn alloc_raw(bcx: block, unit_ty: ty::t,
@@ -313,7 +313,7 @@ pub fn trans_uniq_or_managed_vstore(bcx: block,
                     let bcx = callee::trans_lang_call(
                         bcx,
                         bcx.tcx().lang_items.strdup_uniq_fn(),
-                        ~[ llptrval, llsizeval ],
+                        [ llptrval, llsizeval ],
                         expr::SaveIn(lldestval.to_ref_llval(bcx)));
                     return DatumBlock {
                         bcx: bcx,
@@ -564,7 +564,7 @@ pub fn iter_vec_raw(bcx: block, data_ptr: ValueRef, vec_ty: ty::t,
     let header_bcx = base::sub_block(bcx, "iter_vec_loop_header");
     Br(bcx, header_bcx.llbb);
     let data_ptr =
-        Phi(header_bcx, val_ty(data_ptr), ~[data_ptr], ~[bcx.llbb]);
+        Phi(header_bcx, val_ty(data_ptr), [data_ptr], [bcx.llbb]);
     let not_yet_at_end =
         ICmp(header_bcx, lib::llvm::IntULT, data_ptr, data_end_ptr);
     let body_bcx = base::sub_block(header_bcx, "iter_vec_loop_body");
@@ -572,7 +572,7 @@ pub fn iter_vec_raw(bcx: block, data_ptr: ValueRef, vec_ty: ty::t,
     CondBr(header_bcx, not_yet_at_end, body_bcx.llbb, next_bcx.llbb);
     let body_bcx = f(body_bcx, data_ptr, unit_ty);
     AddIncomingToPhi(data_ptr, InBoundsGEP(body_bcx, data_ptr,
-                                           ~[C_int(bcx.ccx(), 1)]),
+                                           [C_int(bcx.ccx(), 1)]),
                      body_bcx.llbb);
     Br(body_bcx, header_bcx.llbb);
     return next_bcx;

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -70,7 +70,7 @@ pub fn type_of_fn_from_ty(cx: @CrateContext, fty: ty::t) -> TypeRef {
         ty::ty_closure(ref f) => type_of_fn(cx, f.sig.inputs, f.sig.output),
         ty::ty_bare_fn(ref f) => type_of_fn(cx, f.sig.inputs, f.sig.output),
         _ => {
-            cx.sess.bug(~"type_of_fn_from_ty given non-closure, non-bare-fn")
+            cx.sess.bug("type_of_fn_from_ty given non-closure, non-bare-fn")
         }
     }
 }
@@ -90,7 +90,7 @@ pub fn type_of_non_gc_box(cx: @CrateContext, t: ty::t) -> TypeRef {
             T_ptr(T_unique(cx, type_of(cx, mt.ty)))
           }
           _ => {
-            cx.sess.bug(~"non-box in type_of_non_gc_box");
+            cx.sess.bug("non-box in type_of_non_gc_box");
           }
         }
     }
@@ -135,11 +135,11 @@ pub fn sizing_type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
 
         ty::ty_estr(ty::vstore_slice(*)) |
         ty::ty_evec(_, ty::vstore_slice(*)) => {
-            T_struct(~[T_ptr(T_i8()), T_ptr(T_i8())], false)
+            T_struct([T_ptr(T_i8()), T_ptr(T_i8())], false)
         }
 
         ty::ty_bare_fn(*) => T_ptr(T_i8()),
-        ty::ty_closure(*) => T_struct(~[T_ptr(T_i8()), T_ptr(T_i8())], false),
+        ty::ty_closure(*) => T_struct([T_ptr(T_i8()), T_ptr(T_i8())], false),
         ty::ty_trait(_, _, store, _) => T_opaque_trait(cx, store),
 
         ty::ty_estr(ty::vstore_fixed(size)) => T_array(T_i8(), size),
@@ -239,15 +239,11 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
       ty::ty_rptr(_, ref mt) => T_ptr(type_of(cx, mt.ty)),
 
       ty::ty_evec(ref mt, ty::vstore_slice(_)) => {
-        T_struct(~[T_ptr(type_of(cx, mt.ty)),
-                   T_uint_ty(cx, ast::ty_u)],
-                 false)
+        T_struct([T_ptr(type_of(cx, mt.ty)), T_uint_ty(cx, ast::ty_u)], false)
       }
 
       ty::ty_estr(ty::vstore_slice(_)) => {
-        T_struct(~[T_ptr(T_i8()),
-                   T_uint_ty(cx, ast::ty_u)],
-                 false)
+        T_struct([T_ptr(T_i8()), T_uint_ty(cx, ast::ty_u)], false)
       }
 
       ty::ty_estr(ty::vstore_fixed(n)) => {
@@ -282,10 +278,10 @@ pub fn type_of(cx: @CrateContext, t: ty::t) -> TypeRef {
                                         substs.tps))
         }
       }
-      ty::ty_self(*) => cx.tcx.sess.unimpl(~"type_of: ty_self"),
-      ty::ty_infer(*) => cx.tcx.sess.bug(~"type_of with ty_infer"),
-      ty::ty_param(*) => cx.tcx.sess.bug(~"type_of with ty_param"),
-      ty::ty_err(*) => cx.tcx.sess.bug(~"type_of with ty_err")
+      ty::ty_self(*) => cx.tcx.sess.unimpl("type_of: ty_self"),
+      ty::ty_infer(*) => cx.tcx.sess.bug("type_of with ty_infer"),
+      ty::ty_param(*) => cx.tcx.sess.bug("type_of with ty_param"),
+      ty::ty_err(*) => cx.tcx.sess.bug("type_of with ty_err")
     };
 
     cx.lltypes.insert(t, llty);
@@ -336,8 +332,8 @@ pub fn llvm_type_name(cx: @CrateContext,
 }
 
 pub fn type_of_dtor(ccx: @CrateContext, self_ty: ty::t) -> TypeRef {
-    T_fn(~[T_ptr(T_i8()),                   // output pointer
-           T_ptr(type_of(ccx, self_ty))],   // self arg
+    T_fn([T_ptr(T_i8()),                   // output pointer
+          T_ptr(type_of(ccx, self_ty))],   // self arg
          T_nil())
 }
 
@@ -351,6 +347,5 @@ pub fn type_of_rooted(ccx: @CrateContext, t: ty::t) -> TypeRef {
 pub fn type_of_glue_fn(ccx: @CrateContext, t: ty::t) -> TypeRef {
     let tydescpp = T_ptr(T_ptr(ccx.tydesc_type));
     let llty = T_ptr(type_of(ccx, t));
-    return T_fn(~[T_ptr(T_nil()), T_ptr(T_nil()), tydescpp, llty],
-                T_nil());
+    return T_fn([T_ptr(T_nil()), T_ptr(T_nil()), tydescpp, llty], T_nil());
 }

--- a/src/librustc/middle/trans/write_guard.rs
+++ b/src/librustc/middle/trans/write_guard.rs
@@ -78,7 +78,7 @@ pub fn return_to_mut(mut bcx: block,
         bcx = callee::trans_lang_call(
             bcx,
             bcx.tcx().lang_items.unrecord_borrow_fn(),
-            ~[
+            [
                 box_ptr,
                 bits_val,
                 filename_val,
@@ -90,7 +90,7 @@ pub fn return_to_mut(mut bcx: block,
     callee::trans_lang_call(
         bcx,
         bcx.tcx().lang_items.return_to_mut_fn(),
-        ~[
+        [
             box_ptr,
             bits_val,
             filename_val,
@@ -153,7 +153,7 @@ fn root(datum: &Datum,
             bcx = callee::trans_lang_call(
                 bcx,
                 freeze_did,
-                ~[
+                [
                     box_ptr,
                     filename,
                     line
@@ -164,7 +164,7 @@ fn root(datum: &Datum,
                 bcx = callee::trans_lang_call(
                     bcx,
                     bcx.tcx().lang_items.record_borrow_fn(),
-                    ~[
+                    [
                         box_ptr,
                         Load(bcx, scratch_bits.val),
                         filename,
@@ -193,8 +193,6 @@ fn perform_write_guard(datum: &Datum,
     callee::trans_lang_call(
         bcx,
         bcx.tcx().lang_items.check_not_borrowed_fn(),
-        ~[PointerCast(bcx, llval, T_ptr(T_i8())),
-          filename,
-          line],
+        [PointerCast(bcx, llval, T_ptr(T_i8())), filename, line],
         expr::Ignore)
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1481,7 +1481,7 @@ pub fn subst_tps(cx: ctxt, tps: &[t], self_ty_opt: Option<t>, typ: t) -> t {
         ty_param(p) => tps[p.idx],
         ty_self(_) => {
             match self_ty_opt {
-                None => cx.sess.bug(~"ty_self unexpected here"),
+                None => cx.sess.bug("ty_self unexpected here"),
                 Some(self_ty) => {
                     subst_tps(cx, tps, self_ty_opt, self_ty)
                 }
@@ -1582,8 +1582,7 @@ pub fn sequence_element_type(cx: ctxt, ty: t) -> t {
     match get(ty).sty {
       ty_estr(_) => return mk_mach_uint(ast::ty_u8),
       ty_evec(mt, _) | ty_unboxed_vec(mt) => return mt.ty,
-      _ => cx.sess.bug(
-          ~"sequence_element_type called on non-sequence value"),
+      _ => cx.sess.bug("sequence_element_type called on non-sequence value"),
     }
 }
 
@@ -2133,7 +2132,7 @@ pub fn type_contents(cx: ctxt, ty: t) -> TypeContents {
             ty_type => TC_NONE,
 
             ty_err => {
-                cx.sess.bug(~"Asked to compute contents of fictitious type");
+                cx.sess.bug("Asked to compute contents of fictitious type");
             }
         };
 
@@ -2471,7 +2470,7 @@ pub fn type_is_pod(cx: ctxt, ty: t) -> bool {
       }
 
       ty_infer(*) | ty_self(*) | ty_err => {
-        cx.sess.bug(~"non concrete type in type_is_pod");
+        cx.sess.bug("non concrete type in type_is_pod");
       }
     }
 
@@ -3519,29 +3518,29 @@ pub fn type_err_to_str(cx: ctxt, err: &type_err) -> ~str {
 pub fn note_and_explain_type_err(cx: ctxt, err: &type_err) {
     match *err {
         terr_regions_does_not_outlive(subregion, superregion) => {
-            note_and_explain_region(cx, ~"", subregion, ~"...");
-            note_and_explain_region(cx, ~"...does not necessarily outlive ",
-                                    superregion, ~"");
+            note_and_explain_region(cx, "", subregion, "...");
+            note_and_explain_region(cx, "...does not necessarily outlive ",
+                                    superregion, "");
         }
         terr_regions_not_same(region1, region2) => {
-            note_and_explain_region(cx, ~"", region1, ~"...");
-            note_and_explain_region(cx, ~"...is not the same lifetime as ",
-                                    region2, ~"");
+            note_and_explain_region(cx, "", region1, "...");
+            note_and_explain_region(cx, "...is not the same lifetime as ",
+                                    region2, "");
         }
         terr_regions_no_overlap(region1, region2) => {
-            note_and_explain_region(cx, ~"", region1, ~"...");
-            note_and_explain_region(cx, ~"...does not overlap ",
-                                    region2, ~"");
+            note_and_explain_region(cx, "", region1, "...");
+            note_and_explain_region(cx, "...does not overlap ",
+                                    region2, "");
         }
         terr_regions_insufficiently_polymorphic(_, conc_region) => {
             note_and_explain_region(cx,
-                                    ~"concrete lifetime that was found is ",
-                                    conc_region, ~"");
+                                    "concrete lifetime that was found is ",
+                                    conc_region, "");
         }
         terr_regions_overly_polymorphic(_, conc_region) => {
             note_and_explain_region(cx,
-                                    ~"expected concrete lifetime is ",
-                                    conc_region, ~"");
+                                    "expected concrete lifetime is ",
+                                    conc_region, "");
         }
         _ => {}
     }
@@ -3691,7 +3690,7 @@ pub fn ty_to_def_id(ty: t) -> Option<ast::def_id> {
 fn struct_ctor_id(cx: ctxt, struct_did: ast::def_id) -> Option<ast::def_id> {
     if struct_did.crate != ast::local_crate {
         // XXX: Cross-crate functionality.
-        cx.sess.unimpl(~"constructor ID of cross-crate tuple structs");
+        cx.sess.unimpl("constructor ID of cross-crate tuple structs");
     }
 
     match cx.items.find(&struct_did.node) {
@@ -3701,10 +3700,10 @@ fn struct_ctor_id(cx: ctxt, struct_did: ast::def_id) -> Option<ast::def_id> {
                     struct_def.ctor_id.map(|ctor_id|
                         ast_util::local_def(*ctor_id))
                 }
-                _ => cx.sess.bug(~"called struct_ctor_id on non-struct")
+                _ => cx.sess.bug("called struct_ctor_id on non-struct")
             }
         }
-        _ => cx.sess.bug(~"called struct_ctor_id on non-struct")
+        _ => cx.sess.bug("called struct_ctor_id on non-struct")
     }
 }
 
@@ -3869,7 +3868,7 @@ pub fn enum_variants(cx: ctxt, id: ast::def_id) -> @~[VariantInfo] {
                             disr_val = match const_eval::eval_const_expr(cx,
                                                                          ex) {
                               const_eval::const_int(val) => val as int,
-                              _ => cx.sess.bug(~"tag_variants: bad disr expr")
+                              _ => cx.sess.bug("tag_variants: bad disr expr")
                             }
                           }
                           _ => disr_val += 1
@@ -3888,7 +3887,7 @@ pub fn enum_variants(cx: ctxt, id: ast::def_id) -> @~[VariantInfo] {
                 }
             })
           }
-          _ => cx.sess.bug(~"tag_variants: id not bound to an enum")
+          _ => cx.sess.bug("tag_variants: id not bound to an enum")
         }
     };
     cx.enum_var_cache.insert(id, result);
@@ -3908,7 +3907,7 @@ pub fn enum_variant_with_id(cx: ctxt,
         if variant.id == variant_id { return variant; }
         i += 1;
     }
-    cx.sess.bug(~"enum_variant_with_id(): no variant exists with that ID");
+    cx.sess.bug("enum_variant_with_id(): no variant exists with that ID");
 }
 
 
@@ -4003,7 +4002,7 @@ pub fn lookup_struct_fields(cx: ctxt, did: ast::def_id) -> ~[field_ty] {
             ast::item_struct(struct_def, _) => {
                struct_field_tys(struct_def.fields)
             }
-            _ => cx.sess.bug(~"struct ID bound to non-struct")
+            _ => cx.sess.bug("struct ID bound to non-struct")
          }
        }
        Some(&ast_map::node_variant(ref variant, _, _)) => {
@@ -4012,8 +4011,8 @@ pub fn lookup_struct_fields(cx: ctxt, did: ast::def_id) -> ~[field_ty] {
               struct_field_tys(struct_def.fields)
             }
             _ => {
-              cx.sess.bug(~"struct ID bound to enum variant that isn't \
-                            struct-like")
+              cx.sess.bug("struct ID bound to enum variant that isn't \
+                           struct-like")
             }
           }
        }
@@ -4037,7 +4036,7 @@ pub fn lookup_struct_field(cx: ctxt,
     match vec::find(lookup_struct_fields(cx, parent),
                  |f| f.id.node == field_id.node) {
         Some(t) => t,
-        None => cx.sess.bug(~"struct ID not found in parent's fields")
+        None => cx.sess.bug("struct ID not found in parent's fields")
     }
 }
 
@@ -4338,11 +4337,11 @@ pub fn get_impl_id(tcx: ctxt, trait_id: def_id, self_ty: t) -> def_id {
             None => // try autoderef!
                 match deref(tcx, self_ty, false) {
                     Some(some_ty) => get_impl_id(tcx, trait_id, some_ty.ty),
-                    None => tcx.sess.bug(~"get_impl_id: no impl of trait for \
-                                           this type")
+                    None => tcx.sess.bug("get_impl_id: no impl of trait for \
+                                          this type")
             }
         },
-        None => tcx.sess.bug(~"get_impl_id: trait isn't in trait_impls")
+        None => tcx.sess.bug("get_impl_id: trait isn't in trait_impls")
     }
 }
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1462,7 +1462,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                        )
                      -> ty::t {
         match method::lookup(fcx, op_ex, self_ex,
-                             op_ex.callee_id, opname, self_t, ~[],
+                             op_ex.callee_id, opname, self_t, [],
                              deref_args, CheckTraitsOnly, autoderef_receiver) {
             Some(ref origin) => {
                 let method_ty = fcx.node_ty(op_ex.callee_id);
@@ -1876,7 +1876,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                                        } else {
                                            "s"
                                        },
-                                       str::connect(missing_fields, ~", ")));
+                                       str::connect(missing_fields, ", ")));
              }
         }
 
@@ -2111,7 +2111,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                     }
                     None => fcx.tcx().sess.impossible_case(
                         expr.span,
-                        ~"loop body must have an expected type")
+                        "loop body must have an expected type")
                 }
             }
         };
@@ -2397,7 +2397,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
           }
           fcx.write_nil(id);
       }
-      ast::expr_mac(_) => tcx.sess.bug(~"unexpanded macro"),
+      ast::expr_mac(_) => tcx.sess.bug("unexpanded macro"),
       ast::expr_break(_) => { fcx.write_bot(id); }
       ast::expr_again(_) => { fcx.write_bot(id); }
       ast::expr_ret(expr_opt) => {
@@ -2551,7 +2551,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                 None => {
                     fcx.tcx().sess.impossible_case(
                         expr.span,
-                        ~"do body must have expected type")
+                        "do body must have expected type")
                 }
             }
         };
@@ -2911,7 +2911,7 @@ pub fn check_stmt(fcx: @mut FnCtxt, stmt: @ast::stmt)  {
         saw_bot |= ty::type_is_bot(expr_ty);
         saw_err |= ty::type_is_error(expr_ty);
       }
-      ast::stmt_mac(*) => fcx.ccx.tcx.sess.bug(~"unexpanded macro")
+      ast::stmt_mac(*) => fcx.ccx.tcx.sess.bug("unexpanded macro")
     }
     if saw_bot {
         fcx.write_bot(node_id);

--- a/src/librustc/middle/typeck/infer/region_inference.rs
+++ b/src/librustc/middle/typeck/infer/region_inference.rs
@@ -1642,9 +1642,9 @@ pub impl RegionVarBindings {
 
                     note_and_explain_region(
                         self.tcx,
-                        ~"first, the lifetime must be contained by ",
+                        "first, the lifetime must be contained by ",
                         upper_bound_1.region,
-                        ~"...");
+                        "...");
 
                     self.tcx.sess.span_note(
                         upper_bound_1.span,
@@ -1652,9 +1652,9 @@ pub impl RegionVarBindings {
 
                     note_and_explain_region(
                         self.tcx,
-                        ~"but, the lifetime must also be contained by ",
+                        "but, the lifetime must also be contained by ",
                         upper_bound_2.region,
-                        ~"...");
+                        "...");
 
                     self.tcx.sess.span_note(
                         upper_bound_2.span,

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -382,9 +382,9 @@ fn check_for_entry_fn(ccx: @mut CrateCtxt) {
           Some((id, sp)) => match *tcx.sess.entry_type {
               Some(session::EntryMain) => check_main_fn_ty(ccx, id, sp),
               Some(session::EntryStart) => check_start_fn_ty(ccx, id, sp),
-              None => tcx.sess.bug(~"entry function without a type")
+              None => tcx.sess.bug("entry function without a type")
           },
-          None => tcx.sess.bug(~"type checking without entry function")
+          None => tcx.sess.bug("type checking without entry function")
         }
     }
 }

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -137,7 +137,7 @@ pub mod lib {
 pub fn version(argv0: &str) {
     let mut vers = ~"unknown version";
     let env_vers = env!("CFG_VERSION");
-    if env_vers.len() != 0 { vers = env_vers; }
+    if env_vers.len() != 0 { vers = env_vers.to_owned(); }
     io::println(fmt!("%s %s", argv0, vers));
     io::println(fmt!("host: %s", host_triple()));
 }
@@ -168,11 +168,11 @@ Available lint options:
     }
     io::println(fmt!("\nAvailable lint checks:\n"));
     io::println(fmt!("    %s  %7.7s  %s",
-                     padded(max_key, ~"name"), ~"default", ~"meaning"));
+                     padded(max_key, "name"), "default", "meaning"));
     io::println(fmt!("    %s  %7.7s  %s\n",
-                     padded(max_key, ~"----"), ~"-------", ~"-------"));
+                     padded(max_key, "----"), "-------", "-------"));
     for lint_dict.each |k, v| {
-        let k = str::replace(*k, ~"_", ~"-");
+        let k = str::replace(*k, "_", "-");
         io::println(fmt!("    %s  %7.7s  %s",
                          padded(max_key, k),
                          match v.default {
@@ -183,7 +183,7 @@ Available lint options:
                          },
                          v.desc));
     }
-    io::println(~"");
+    io::println("");
 }
 
 pub fn describe_debug_flags() {
@@ -211,24 +211,24 @@ pub fn run_compiler(args: &~[~str], demitter: diagnostic::Emitter) {
           }
         };
 
-    if opt_present(matches, ~"h") || opt_present(matches, ~"help") {
+    if opt_present(matches, "h") || opt_present(matches, "help") {
         usage(*binary);
         return;
     }
 
-    let lint_flags = vec::append(getopts::opt_strs(matches, ~"W"),
-                                 getopts::opt_strs(matches, ~"warn"));
+    let lint_flags = vec::append(getopts::opt_strs(matches, "W"),
+                                 getopts::opt_strs(matches, "warn"));
     if lint_flags.contains(&~"help") {
         describe_warnings();
         return;
     }
 
-    if getopts::opt_strs(matches, ~"Z").contains(&~"help") {
+    if getopts::opt_strs(matches, "Z").contains(&~"help") {
         describe_debug_flags();
         return;
     }
 
-    if opt_present(matches, ~"v") || opt_present(matches, ~"version") {
+    if opt_present(matches, "v") || opt_present(matches, "version") {
         version(*binary);
         return;
     }
@@ -248,12 +248,12 @@ pub fn run_compiler(args: &~[~str], demitter: diagnostic::Emitter) {
 
     let sopts = build_session_options(binary, matches, demitter);
     let sess = build_session(sopts, demitter);
-    let odir = getopts::opt_maybe_str(matches, ~"out-dir");
+    let odir = getopts::opt_maybe_str(matches, "out-dir");
     let odir = odir.map(|o| Path(*o));
-    let ofile = getopts::opt_maybe_str(matches, ~"o");
+    let ofile = getopts::opt_maybe_str(matches, "o");
     let ofile = ofile.map(|o| Path(*o));
     let cfg = build_configuration(sess, binary, &input);
-    let pretty = getopts::opt_default(matches, ~"pretty", "normal").map(
+    let pretty = getopts::opt_default(matches, "pretty", "normal").map(
                     |a| parse_pretty(sess, *a));
     match pretty {
       Some::<pp_mode>(ppm) => {
@@ -262,7 +262,7 @@ pub fn run_compiler(args: &~[~str], demitter: diagnostic::Emitter) {
       }
       None::<pp_mode> => {/* continue */ }
     }
-    let ls = opt_present(matches, ~"ls");
+    let ls = opt_present(matches, "ls");
     if ls {
         match input {
           file_input(ref ifile) => {
@@ -334,7 +334,7 @@ pub fn monitor(f: ~fn(diagnostic::Emitter)) {
             if p.recv() == done {
                 diagnostic::emit(
                     None,
-                    diagnostic::ice_msg(~"unexpected failure"),
+                    diagnostic::ice_msg("unexpected failure"),
                     diagnostic::error);
 
                 for [

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -409,13 +409,13 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_uniq(ref tm) => ~"~" + mt_to_str(cx, tm),
       ty_ptr(ref tm) => ~"*" + mt_to_str(cx, tm),
       ty_rptr(r, ref tm) => {
-        region_to_str_space(cx, ~"&", r) + mt_to_str(cx, tm)
+        region_to_str_space(cx, "&", r) + mt_to_str(cx, tm)
       }
       ty_unboxed_vec(ref tm) => { ~"unboxed_vec<" + mt_to_str(cx, tm) + ~">" }
       ty_type => ~"type",
       ty_tup(ref elems) => {
         let strs = elems.map(|elem| ty_to_str(cx, *elem));
-        ~"(" + str::connect(strs, ~",") + ~")"
+        ~"(" + str::connect(strs, ",") + ~")"
       }
       ty_closure(ref f) => {
           closure_to_str(cx, f)
@@ -428,11 +428,11 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_param(param_ty {idx: id, def_id: did}) => {
           if cx.sess.verbose() {
               fmt!("'%s:%?",
-                   str::from_bytes(~[('a' as u8) + (id as u8)]),
+                   str::from_bytes([('a' as u8) + (id as u8)]),
                    did)
           } else {
               fmt!("'%s",
-                   str::from_bytes(~[('a' as u8) + (id as u8)]))
+                   str::from_bytes([('a' as u8) + (id as u8)]))
           }
       }
       ty_self(*) => ~"Self",
@@ -450,7 +450,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_evec(ref mt, vs) => {
         vstore_ty_to_str(cx, mt, vs)
       }
-      ty_estr(vs) => fmt!("%s%s", vstore_to_str(cx, vs), ~"str"),
+      ty_estr(vs) => fmt!("%s%s", vstore_to_str(cx, vs), "str"),
       ty_opaque_box => ~"@?",
       ty_opaque_closure_ptr(ast::BorrowedSigil) => ~"closure&",
       ty_opaque_closure_ptr(ast::ManagedSigil) => ~"closure@",

--- a/src/libstd/dlist.rs
+++ b/src/libstd/dlist.rs
@@ -136,10 +136,10 @@ priv impl<T> DList<T> {
         }
         if !nobe.linked { fail!("That node isn't linked to any dlist.") }
         if !((nobe.prev.is_some()
-              || managed::mut_ptr_eq(self.hd.expect(~"headless dlist?"),
+              || managed::mut_ptr_eq(self.hd.expect("headless dlist?"),
                                  nobe)) &&
              (nobe.next.is_some()
-              || managed::mut_ptr_eq(self.tl.expect(~"tailless dlist?"),
+              || managed::mut_ptr_eq(self.tl.expect("tailless dlist?"),
                                  nobe))) {
             fail!("That node isn't on this dlist.")
         }
@@ -514,10 +514,10 @@ impl<T> BaseIter<T> for @mut DList<T> {
             }
             if !nobe.linked ||
                 (!((nobe.prev.is_some()
-                    || managed::mut_ptr_eq(self.hd.expect(~"headless dlist?"),
+                    || managed::mut_ptr_eq(self.hd.expect("headless dlist?"),
                                            nobe))
                    && (nobe.next.is_some()
-                    || managed::mut_ptr_eq(self.tl.expect(~"tailless dlist?"),
+                    || managed::mut_ptr_eq(self.tl.expect("tailless dlist?"),
                                            nobe)))) {
                 fail!("Removing a dlist node during iteration is forbidden!")
             }

--- a/src/libstd/getopts.rs
+++ b/src/libstd/getopts.rs
@@ -587,7 +587,7 @@ pub mod groups {
      */
     pub fn usage(brief: &str, opts: &[OptGroup]) -> ~str {
 
-        let desc_sep = ~"\n" + str::repeat(~" ", 24);
+        let desc_sep = ~"\n" + str::repeat(" ", 24);
 
         let rows = vec::map(opts, |optref| {
             let OptGroup{short_name: short_name,
@@ -597,7 +597,7 @@ pub mod groups {
                          hasarg: hasarg,
                          _} = copy *optref;
 
-            let mut row = str::repeat(~" ", 4);
+            let mut row = str::repeat(" ", 4);
 
             // short option
             row += match short_name.len() {
@@ -623,7 +623,7 @@ pub mod groups {
             // here we just need to indent the start of the description
             let rowlen = row.len();
             row += if rowlen < 24 {
-                str::repeat(~" ", 24 - rowlen)
+                str::repeat(" ", 24 - rowlen)
             } else {
                 copy desc_sep
             };
@@ -650,7 +650,7 @@ pub mod groups {
 
         return str::to_owned(brief)    +
                ~"\n\nOptions:\n"         +
-               str::connect(rows, ~"\n") +
+               str::connect(rows, "\n") +
                ~"\n\n";
     }
 } // end groups module

--- a/src/libstd/json.rs
+++ b/src/libstd/json.rs
@@ -524,9 +524,9 @@ priv impl Parser {
         if self.eof() { return self.error(~"EOF while parsing value"); }
 
         match self.ch {
-          'n' => self.parse_ident(~"ull", Null),
-          't' => self.parse_ident(~"rue", Boolean(true)),
-          'f' => self.parse_ident(~"alse", Boolean(false)),
+          'n' => self.parse_ident("ull", Null),
+          't' => self.parse_ident("rue", Boolean(true)),
+          'f' => self.parse_ident("alse", Boolean(false)),
           '0' .. '9' | '-' => self.parse_number(),
           '"' =>
             match self.parse_str() {

--- a/src/libstd/md4.rs
+++ b/src/libstd/md4.rs
@@ -26,7 +26,7 @@ pub fn md4(msg: &[u8]) -> Quad {
     let orig_len: u64 = (msg.len() * 8u) as u64;
 
     // pad message
-    let mut msg = vec::append(vec::to_owned(msg), ~[0x80u8]);
+    let mut msg = vec::append(vec::to_owned(msg), [0x80u8]);
     let mut bitlen = orig_len + 8u64;
     while (bitlen + 64u64) % 512u64 > 0u64 {
         msg.push(0u8);

--- a/src/libstd/net_url.rs
+++ b/src/libstd/net_url.rs
@@ -350,7 +350,7 @@ pub fn query_to_str(query: &Query) -> ~str {
             }
         }
     }
-    return str::connect(strvec, ~"&");
+    return str::connect(strvec, "&");
 }
 
 // returns the scheme and the rest of the url, or a parsing error
@@ -390,7 +390,7 @@ enum Input {
 // returns userinfo, host, port, and unparsed part, or an error
 fn get_authority(rawurl: &str) ->
     Result<(Option<UserInfo>, ~str, Option<~str>, ~str), ~str> {
-    if !str::starts_with(rawurl, ~"//") {
+    if !str::starts_with(rawurl, "//") {
         // there is no authority.
         return Ok((None, ~"", None, rawurl.to_str()));
     }
@@ -575,7 +575,7 @@ fn get_path(rawurl: &str, authority: bool) ->
     }
 
     if authority {
-        if end != 0 && !str::starts_with(rawurl, ~"/") {
+        if end != 0 && !str::starts_with(rawurl, "/") {
             return Err(~"Non-empty path must begin with\
                                '/' in presence of authority.");
         }
@@ -588,8 +588,8 @@ fn get_path(rawurl: &str, authority: bool) ->
 // returns the parsed query and the fragment, if present
 fn get_query_fragment(rawurl: &str) ->
     Result<(Query, Option<~str>), ~str> {
-    if !str::starts_with(rawurl, ~"?") {
-        if str::starts_with(rawurl, ~"#") {
+    if !str::starts_with(rawurl, "?") {
+        if str::starts_with(rawurl, "#") {
             let f = decode_component(str::slice(rawurl,
                                                 1,
                                                 str::len(rawurl)).to_owned());

--- a/src/libstd/rope.rs
+++ b/src/libstd/rope.rs
@@ -106,7 +106,7 @@ Section: Adding things to a rope
  * * this function executes in near-constant time
  */
 pub fn append_char(rope: Rope, char: char) -> Rope {
-    return append_str(rope, @str::from_chars(~[char]));
+    return append_str(rope, @str::from_chars([char]));
 }
 
 /**
@@ -127,7 +127,7 @@ pub fn append_str(rope: Rope, str: @~str) -> Rope {
  * * this function executes in near-constant time
  */
 pub fn prepend_char(rope: Rope, char: char) -> Rope {
-    return prepend_str(rope, @str::from_chars(~[char]));
+    return prepend_str(rope, @str::from_chars([char]));
 }
 
 /**

--- a/src/libstd/sha1.rs
+++ b/src/libstd/sha1.rs
@@ -177,7 +177,7 @@ pub fn sha1() -> @Sha1 {
             let b = (hpart >> 16u32 & 0xFFu32) as u8;
             let c = (hpart >> 8u32 & 0xFFu32) as u8;
             let d = (hpart & 0xFFu32) as u8;
-            rs = vec::append(copy rs, ~[a, b, c, d]);
+            rs = vec::append(copy rs, [a, b, c, d]);
         }
         return rs;
     }

--- a/src/libstd/term.rs
+++ b/src/libstd/term.rs
@@ -35,19 +35,19 @@ pub static color_bright_magenta: u8 = 13u8;
 pub static color_bright_cyan: u8 = 14u8;
 pub static color_bright_white: u8 = 15u8;
 
-pub fn esc(writer: @io::Writer) { writer.write(~[0x1bu8, '[' as u8]); }
+pub fn esc(writer: @io::Writer) { writer.write([0x1bu8, '[' as u8]); }
 
 /// Reset the foreground and background colors to default
 pub fn reset(writer: @io::Writer) {
     esc(writer);
-    writer.write(~['0' as u8, 'm' as u8]);
+    writer.write(['0' as u8, 'm' as u8]);
 }
 
 /// Returns true if the terminal supports color
 pub fn color_supported() -> bool {
     let supported_terms = ~[~"xterm-color", ~"xterm",
                            ~"screen-bce", ~"xterm-256color"];
-    return match os::getenv(~"TERM") {
+    return match os::getenv("TERM") {
           option::Some(ref env) => {
             for supported_terms.each |term| {
                 if *term == *env { return true; }
@@ -62,8 +62,8 @@ pub fn set_color(writer: @io::Writer, first_char: u8, color: u8) {
     assert!((color < 16u8));
     esc(writer);
     let mut color = color;
-    if color >= 8u8 { writer.write(~['1' as u8, ';' as u8]); color -= 8u8; }
-    writer.write(~[first_char, ('0' as u8) + color, 'm' as u8]);
+    if color >= 8u8 { writer.write(['1' as u8, ';' as u8]); color -= 8u8; }
+    writer.write([first_char, ('0' as u8) + color, 'm' as u8]);
 }
 
 /// Set the foreground color

--- a/src/libstd/test.rs
+++ b/src/libstd/test.rs
@@ -131,12 +131,12 @@ type OptRes = Either<TestOpts, ~str>;
 // Parses command line arguments into test options
 pub fn parse_opts(args: &[~str]) -> OptRes {
     let args_ = vec::tail(args);
-    let opts = ~[getopts::optflag(~"ignored"),
-                 getopts::optflag(~"test"),
-                 getopts::optflag(~"bench"),
-                 getopts::optopt(~"save"),
-                 getopts::optopt(~"diff"),
-                 getopts::optopt(~"logfile")];
+    let opts = ~[getopts::optflag("ignored"),
+                 getopts::optflag("test"),
+                 getopts::optflag("bench"),
+                 getopts::optopt("save"),
+                 getopts::optopt("diff"),
+                 getopts::optopt("logfile")];
     let matches =
         match getopts::getopts(args_, opts) {
           Ok(m) => m,
@@ -148,19 +148,19 @@ pub fn parse_opts(args: &[~str]) -> OptRes {
             option::Some(copy (matches).free[0])
         } else { option::None };
 
-    let run_ignored = getopts::opt_present(&matches, ~"ignored");
+    let run_ignored = getopts::opt_present(&matches, "ignored");
 
-    let logfile = getopts::opt_maybe_str(&matches, ~"logfile");
+    let logfile = getopts::opt_maybe_str(&matches, "logfile");
     let logfile = logfile.map(|s| Path(*s));
 
-    let run_benchmarks = getopts::opt_present(&matches, ~"bench");
+    let run_benchmarks = getopts::opt_present(&matches, "bench");
     let run_tests = ! run_benchmarks ||
-        getopts::opt_present(&matches, ~"test");
+        getopts::opt_present(&matches, "test");
 
-    let save_results = getopts::opt_maybe_str(&matches, ~"save");
+    let save_results = getopts::opt_maybe_str(&matches, "save");
     let save_results = save_results.map(|s| Path(*s));
 
-    let compare_results = getopts::opt_maybe_str(&matches, ~"diff");
+    let compare_results = getopts::opt_maybe_str(&matches, "diff");
     let compare_results = compare_results.map(|s| Path(*s));
 
     let test_opts = TestOpts {
@@ -220,18 +220,18 @@ pub fn run_tests_console(opts: &TestOpts,
               TrOk => {
                 st.passed += 1;
                 write_ok(st.out, st.use_color);
-                st.out.write_line(~"");
+                st.out.write_line("");
               }
               TrFailed => {
                 st.failed += 1;
                 write_failed(st.out, st.use_color);
-                st.out.write_line(~"");
+                st.out.write_line("");
                 st.failures.push(test);
               }
               TrIgnored => {
                 st.ignored += 1;
                 write_ignored(st.out, st.use_color);
-                st.out.write_line(~"");
+                st.out.write_line("");
               }
               TrBench(bs) => {
                 st.benchmarked += 1u;
@@ -246,8 +246,8 @@ pub fn run_tests_console(opts: &TestOpts,
 
     let log_out = match opts.logfile {
         Some(ref path) => match io::file_writer(path,
-                                                ~[io::Create,
-                                                  io::Truncate]) {
+                                                [io::Create,
+                                                 io::Truncate]) {
           result::Ok(w) => Some(w),
           result::Err(ref s) => {
               fail!("can't open output file: %s", *s)
@@ -318,19 +318,19 @@ pub fn run_tests_console(opts: &TestOpts,
     }
 
     fn write_ok(out: @io::Writer, use_color: bool) {
-        write_pretty(out, ~"ok", term::color_green, use_color);
+        write_pretty(out, "ok", term::color_green, use_color);
     }
 
     fn write_failed(out: @io::Writer, use_color: bool) {
-        write_pretty(out, ~"FAILED", term::color_red, use_color);
+        write_pretty(out, "FAILED", term::color_red, use_color);
     }
 
     fn write_ignored(out: @io::Writer, use_color: bool) {
-        write_pretty(out, ~"ignored", term::color_yellow, use_color);
+        write_pretty(out, "ignored", term::color_yellow, use_color);
     }
 
     fn write_bench(out: @io::Writer, use_color: bool) {
-        write_pretty(out, ~"bench", term::color_cyan, use_color);
+        write_pretty(out, "bench", term::color_cyan, use_color);
     }
 
     fn write_pretty(out: @io::Writer,
@@ -348,7 +348,7 @@ pub fn run_tests_console(opts: &TestOpts,
 }
 
 fn print_failures(st: &ConsoleTestState) {
-    st.out.write_line(~"\nfailures:");
+    st.out.write_line("\nfailures:");
     let mut failures = ~[];
     for uint::range(0, vec::uniq_len(&const st.failures)) |i| {
         let name = copy st.failures[i].name;

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -199,7 +199,7 @@ pub impl Tm {
      * Return a string of the current time in the form
      * "Thu Jan  1 00:00:00 1970".
      */
-    fn ctime(&self) -> ~str { self.strftime(~"%c") }
+    fn ctime(&self) -> ~str { self.strftime("%c") }
 
     /// Formats the time according to the format string.
     fn strftime(&self, format: &str) -> ~str {
@@ -214,9 +214,9 @@ pub impl Tm {
      */
     fn rfc822(&self) -> ~str {
         if self.tm_gmtoff == 0_i32 {
-            self.strftime(~"%a, %d %b %Y %T GMT")
+            self.strftime("%a, %d %b %Y %T GMT")
         } else {
-            self.strftime(~"%a, %d %b %Y %T %Z")
+            self.strftime("%a, %d %b %Y %T %Z")
         }
     }
 
@@ -227,7 +227,7 @@ pub impl Tm {
      * utc:   "Thu, 22 Mar 2012 14:53:18 -0000"
      */
     fn rfc822z(&self) -> ~str {
-        self.strftime(~"%a, %d %b %Y %T %z")
+        self.strftime("%a, %d %b %Y %T %z")
     }
 
     /**
@@ -238,9 +238,9 @@ pub impl Tm {
      */
     fn rfc3339(&self) -> ~str {
         if self.tm_gmtoff == 0_i32 {
-            self.strftime(~"%Y-%m-%dT%H:%M:%SZ")
+            self.strftime("%Y-%m-%dT%H:%M:%SZ")
         } else {
-            let s = self.strftime(~"%Y-%m-%dT%H:%M:%S");
+            let s = self.strftime("%Y-%m-%dT%H:%M:%S");
             let sign = if self.tm_gmtoff > 0_i32 { '+' } else { '-' };
             let mut m = i32::abs(self.tm_gmtoff) / 60_i32;
             let h = m / 60_i32;
@@ -326,7 +326,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
     fn parse_type(s: &str, pos: uint, ch: char, tm: &mut Tm)
       -> Result<uint, ~str> {
         match ch {
-          'A' => match match_strs(s, pos, ~[
+          'A' => match match_strs(s, pos, [
               (~"Sunday", 0_i32),
               (~"Monday", 1_i32),
               (~"Tuesday", 2_i32),
@@ -338,7 +338,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             Some(item) => { let (v, pos) = item; tm.tm_wday = v; Ok(pos) }
             None => Err(~"Invalid day")
           },
-          'a' => match match_strs(s, pos, ~[
+          'a' => match match_strs(s, pos, [
               (~"Sun", 0_i32),
               (~"Mon", 1_i32),
               (~"Tue", 2_i32),
@@ -350,7 +350,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             Some(item) => { let (v, pos) = item; tm.tm_wday = v; Ok(pos) }
             None => Err(~"Invalid day")
           },
-          'B' => match match_strs(s, pos, ~[
+          'B' => match match_strs(s, pos, [
               (~"January", 0_i32),
               (~"February", 1_i32),
               (~"March", 2_i32),
@@ -367,7 +367,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             Some(item) => { let (v, pos) = item; tm.tm_mon = v; Ok(pos) }
             None => Err(~"Invalid month")
           },
-          'b' | 'h' => match match_strs(s, pos, ~[
+          'b' | 'h' => match match_strs(s, pos, [
               (~"Jan", 0_i32),
               (~"Feb", 1_i32),
               (~"Mar", 2_i32),
@@ -488,13 +488,13 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
           }
           'n' => parse_char(s, pos, '\n'),
           'P' => match match_strs(s, pos,
-                                  ~[(~"am", 0_i32), (~"pm", 12_i32)]) {
+                                  [(~"am", 0_i32), (~"pm", 12_i32)]) {
 
             Some(item) => { let (v, pos) = item; tm.tm_hour += v; Ok(pos) }
             None => Err(~"Invalid hour")
           },
           'p' => match match_strs(s, pos,
-                                  ~[(~"AM", 0_i32), (~"PM", 12_i32)]) {
+                                  [(~"AM", 0_i32), (~"PM", 12_i32)]) {
 
             Some(item) => { let (v, pos) = item; tm.tm_hour += v; Ok(pos) }
             None => Err(~"Invalid hour")
@@ -579,7 +579,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             }
           }
           'Z' => {
-            if match_str(s, pos, ~"UTC") || match_str(s, pos, ~"GMT") {
+            if match_str(s, pos, "UTC") || match_str(s, pos, "GMT") {
                 tm.tm_gmtoff = 0_i32;
                 tm.tm_zone = ~"UTC";
                 Ok(pos + 3u)

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -107,7 +107,7 @@ pub struct Ctx {
 pub type vt = visit::vt<@mut Ctx>;
 
 pub fn extend(cx: @mut Ctx, elt: ident) -> @path {
-    @(vec::append(copy cx.path, ~[path_name(elt)]))
+    @(vec::append(copy cx.path, [path_name(elt)]))
 }
 
 pub fn mk_ast_map_visitor() -> vt {

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -21,7 +21,7 @@ use core::to_bytes;
 
 pub fn path_name_i(idents: &[ident], intr: @token::ident_interner) -> ~str {
     // FIXME: Bad copies (#2543 -- same for everything else that says "bad")
-    str::connect(idents.map(|i| copy *intr.get(*i)), ~"::")
+    str::connect(idents.map(|i| copy *intr.get(*i)), "::")
 }
 
 

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -291,7 +291,7 @@ pub fn remove_meta_items_by_name(items: ~[@ast::meta_item], name: &str) ->
  * linkage
  */
 pub fn find_linkage_metas(attrs: &[ast::attribute]) -> ~[@ast::meta_item] {
-    do find_attrs_by_name(attrs, ~"link").flat_map |attr| {
+    do find_attrs_by_name(attrs, "link").flat_map |attr| {
         match attr.node.value.node {
             ast::meta_list(_, ref items) => /* FIXME (#2543) */ copy *items,
             _ => ~[]
@@ -314,9 +314,9 @@ pub fn find_inline_attr(attrs: &[ast::attribute]) -> inline_attr {
         match attr.node.value.node {
           ast::meta_word(@~"inline") => ia_hint,
           ast::meta_list(@~"inline", ref items) => {
-            if !find_meta_items_by_name(*items, ~"always").is_empty() {
+            if !find_meta_items_by_name(*items, "always").is_empty() {
                 ia_always
-            } else if !find_meta_items_by_name(*items, ~"never").is_empty() {
+            } else if !find_meta_items_by_name(*items, "never").is_empty() {
                 ia_never
             } else {
                 ia_hint

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -218,7 +218,7 @@ pub fn emit(cmsp: Option<(@codemap::CodeMap, span)>, msg: &str, lvl: level) {
         print_macro_backtrace(cm, sp);
       }
       None => {
-        print_diagnostic(~"", lvl, msg);
+        print_diagnostic("", lvl, msg);
       }
     }
 }
@@ -296,7 +296,7 @@ fn print_macro_backtrace(cm: @codemap::CodeMap, sp: span) {
         print_diagnostic(*ss, note,
                          fmt!("in expansion of %s!", ei.callee.name));
         let ss = cm.span_to_str(ei.call_site);
-        print_diagnostic(ss, note, ~"expansion site");
+        print_diagnostic(ss, note, "expansion site");
         print_macro_backtrace(cm, ei.call_site);
     }
 }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -250,7 +250,7 @@ pub fn mk_ctxt(parse_sess: @mut parse::ParseSess, cfg: ast::crate_cfg)
         fn call_site(&self) -> span {
             match *self.backtrace {
                 Some(@ExpandedFrom(CallInfo {call_site: cs, _})) => cs,
-                None => self.bug(~"missing top span")
+                None => self.bug("missing top span")
             }
         }
         fn print_backtrace(&self) { }
@@ -276,7 +276,7 @@ pub fn mk_ctxt(parse_sess: @mut parse::ParseSess, cfg: ast::crate_cfg)
               })) => {
                 *self.backtrace = prev
               }
-              _ => self.bug(~"tried to pop without a push")
+              _ => self.bug("tried to pop without a push")
             }
         }
         fn span_fatal(&self, sp: span, msg: &str) -> ! {

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -21,15 +21,13 @@ pub fn expand_syntax_ext(cx: @ext_ctxt, sp: span, tts: &[ast::token_tree])
         if i & 1 == 1 {
             match *e {
                 ast::tt_tok(_, token::COMMA) => (),
-                _ => cx.span_fatal(sp, ~"concat_idents! \
-                                         expecting comma.")
+                _ => cx.span_fatal(sp, "concat_idents! expecting comma.")
             }
         } else {
             match *e {
                 ast::tt_tok(_, token::IDENT(ident,_)) =>
                 res_str += cx.str_of(ident),
-                _ => cx.span_fatal(sp, ~"concat_idents! \
-                                         requires ident args.")
+                _ => cx.span_fatal(sp, "concat_idents! requires ident args.")
             }
         }
     }

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -291,7 +291,7 @@ fn expand_deriving_decodable_struct_method(
             unnamed_field => {
                 cx.span_unimpl(
                     span,
-                    ~"unnamed fields with `deriving(Decodable)`"
+                    "unnamed fields with `deriving(Decodable)`"
                 );
             }
         }

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -321,7 +321,7 @@ fn expand_deriving_encodable_struct_method(
             unnamed_field => {
                 cx.span_unimpl(
                     span,
-                    ~"unnamed fields with `deriving(Encodable)`"
+                    "unnamed fields with `deriving(Encodable)`"
                 );
             }
         }

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -539,8 +539,8 @@ impl<'self> MethodDef<'self> {
                     (opt_id, field, other_fields)
                 }
             }
-            [] => { cx.span_bug(span, ~"No self arguments to non-static \
-                                        method in generic `deriving`") }
+            [] => { cx.span_bug(span, "No self arguments to non-static \
+                                       method in generic `deriving`") }
         };
 
         // body of the inner most destructuring match
@@ -658,8 +658,8 @@ impl<'self> MethodDef<'self> {
             // we've matched against all arguments, so make the final
             // expression at the bottom of the match tree
             if matches_so_far.len() == 0 {
-                cx.span_bug(span, ~"no self match on an enum in generic \
-                                    `deriving`");
+                cx.span_bug(span, "no self match on an enum in generic \
+                                   `deriving`");
             }
             // we currently have a vec of vecs, where each
             // subvec is the fields of one of the arguments,
@@ -718,8 +718,8 @@ impl<'self> MethodDef<'self> {
                 // make a matching-variant match, and a _ match.
                 let index = match matching {
                     Some(i) => i,
-                    None => cx.span_bug(span, ~"Non-matching variants when required to \
-                                                be matching in generic `deriving`")
+                    None => cx.span_bug(span, "Non-matching variants when required to \
+                                               be matching in generic `deriving`")
                 };
 
                 // matching-variant match

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -67,11 +67,11 @@ pub fn expand_meta_deriving(cx: @ext_ctxt,
 
     match mitem.node {
         meta_name_value(_, ref l) => {
-            cx.span_err(l.span, ~"unexpected value in `deriving`");
+            cx.span_err(l.span, "unexpected value in `deriving`");
             in_items
         }
         meta_word(_) | meta_list(_, []) => {
-            cx.span_warn(mitem.span, ~"empty trait list in `deriving`");
+            cx.span_warn(mitem.span, "empty trait list in `deriving`");
             in_items
         }
         meta_list(_, ref titems) => {

--- a/src/libsyntax/ext/deriving/to_str.rs
+++ b/src/libsyntax/ext/deriving/to_str.rs
@@ -49,6 +49,6 @@ fn to_str_substructure(cx: @ext_ctxt, span: span, substr: &Substructure) -> @exp
                                     cx.ident_of("log_str")],
                                   ~[self_addr])
         }
-        _ => cx.span_bug(span, ~"Invalid number of arguments in `deriving(ToStr)`")
+        _ => cx.span_bug(span, "Invalid number of arguments in `deriving(ToStr)`")
     }
 }

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -167,8 +167,8 @@ pub impl Ty {
             Literal(ref p) => {
                 p.to_path(cx, span, self_ty, self_generics)
             }
-            Ptr(*) => { cx.span_bug(span, ~"Pointer in a path in generic `deriving`") }
-            Tuple(*) => { cx.span_bug(span, ~"Tuple in a path in generic `deriving`") }
+            Ptr(*) => { cx.span_bug(span, "Pointer in a path in generic `deriving`") }
+            Tuple(*) => { cx.span_bug(span, "Tuple in a path in generic `deriving`") }
         }
     }
 }

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -18,7 +18,7 @@ use ast;
 use codemap::span;
 use ext::base::*;
 use ext::base;
-use ext::build::mk_uniq_str;
+use ext::build::mk_base_str;
 
 pub fn expand_syntax_ext(cx: @ext_ctxt, sp: span, tts: &[ast::token_tree])
     -> base::MacResult {
@@ -29,8 +29,8 @@ pub fn expand_syntax_ext(cx: @ext_ctxt, sp: span, tts: &[ast::token_tree])
     // Option<str> rather than just an maybe-empty string.
 
     let e = match os::getenv(var) {
-      None => mk_uniq_str(cx, sp, ~""),
-      Some(ref s) => mk_uniq_str(cx, sp, copy *s)
+      None => mk_base_str(cx, sp, ~""),
+      Some(ref s) => mk_base_str(cx, sp, copy *s)
     };
     MRExpr(e)
 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -234,7 +234,7 @@ pub fn expand_item_mac(extsbox: @mut SyntaxEnv,
         item_mac(codemap::spanned { node: mac_invoc_tt(pth, ref tts), _}) => {
             (pth, copy *tts)
         }
-        _ => cx.span_bug(it.span, ~"invalid item macro invocation")
+        _ => cx.span_bug(it.span, "invalid item macro invocation")
     };
 
     let extname = cx.parse_sess().interner.get(pth.idents[0]);
@@ -377,8 +377,7 @@ pub fn expand_block(extsbox: @mut SyntaxEnv,
             // see note below about treatment of exts table
             with_exts_frame!(extsbox,orig(blk,sp,fld))
         },
-        _ => cx.span_bug(sp,
-                         ~"expected ScopeMacros binding for \" block\"")
+        _ => cx.span_bug(sp, "expected ScopeMacros binding for \" block\"")
     }
 }
 
@@ -628,7 +627,7 @@ pub fn expand_crate(parse_sess: @mut parse::ParseSess,
                                               attrs,
                                               parse_sess) {
         Some(item) => item,
-        None => cx.bug(~"expected core macros to parse correctly")
+        None => cx.bug("expected core macros to parse correctly")
     };
     // This is run for its side-effects on the expander env,
     // as it registers all the core macros as expanders.

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -88,7 +88,7 @@ fn pieces_to_expr(cx: @ext_ctxt, sp: span,
                 let count_is_args = ~[count_lit];
                 return mk_call_global(cx, sp, count_is_path, count_is_args);
               }
-              _ => cx.span_unimpl(sp, ~"unimplemented fmt! conversion")
+              _ => cx.span_unimpl(sp, "unimplemented fmt! conversion")
             }
         }
         fn make_ty(cx: @ext_ctxt, sp: span, t: Ty) -> @ast::expr {

--- a/src/libsyntax/ext/pipes/liveness.rs
+++ b/src/libsyntax/ext/pipes/liveness.rs
@@ -85,7 +85,7 @@ pub fn analyze(proto: @mut protocol_, _cx: @ext_ctxt) {
     }
 
     if self_live.len() > 0 {
-        let states = str::connect(self_live.map(|s| copy s.name), ~" ");
+        let states = str::connect(self_live.map(|s| copy s.name), " ");
 
         debug!("protocol %s is unbounded due to loops involving: %s",
                copy proto.name, states);

--- a/src/libsyntax/ext/pipes/parse_proto.rs
+++ b/src/libsyntax/ext/pipes/parse_proto.rs
@@ -114,7 +114,7 @@ impl proto_parser for parser::Parser {
             self.bump();
             None
           }
-          _ => self.fatal(~"invalid next state")
+          _ => self.fatal("invalid next state")
         };
 
         state.add_message(mname, *self.span, args, next);

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -96,7 +96,7 @@ impl gen_send for message {
                          name,
                          str::connect(vec::append_one(
                            arg_names.map(|x| cx.str_of(*x)),
-                             ~"s"), ~", "));
+                             ~"s"), ", "));
 
             if !try {
                 body += fmt!("::core::pipes::send(pipe, message);\n");
@@ -148,7 +148,7 @@ impl gen_send for message {
                 }
                 else {
                     ~"(" + str::connect(arg_names.map(|x| copy *x),
-                                        ~", ") + ~")"
+                                        ", ") + ~")"
                 };
 
                 let mut body = ~"{ ";

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -86,7 +86,7 @@ pub mod rt {
 
     impl<'self> ToSource for &'self [@ast::item] {
         fn to_source(&self, cx: @ext_ctxt) -> ~str {
-            str::connect(self.map(|i| i.to_source(cx)), ~"\n\n")
+            str::connect(self.map(|i| i.to_source(cx)), "\n\n")
         }
     }
 
@@ -98,7 +98,7 @@ pub mod rt {
 
     impl<'self> ToSource for &'self [@ast::Ty] {
         fn to_source(&self, cx: @ext_ctxt) -> ~str {
-            str::connect(self.map(|i| i.to_source(cx)), ~", ")
+            str::connect(self.map(|i| i.to_source(cx)), ", ")
         }
     }
 
@@ -421,7 +421,7 @@ fn id_ext(cx: @ext_ctxt, str: &str) -> ast::ident {
 
 // Lift an ident to the expr that evaluates to that ident.
 fn mk_ident(cx: @ext_ctxt, sp: span, ident: ast::ident) -> @ast::expr {
-    let e_str = build::mk_uniq_str(cx, sp, cx.str_of(ident));
+    let e_str = build::mk_base_str(cx, sp, cx.str_of(ident));
     build::mk_method_call(cx, sp,
                           build::mk_path(cx, sp, ids_ext(cx, ~[~"ext_cx"])),
                           id_ext(cx, "ident_of"),

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -67,7 +67,7 @@ pub fn expand_mod(cx: @ext_ctxt, sp: span, tts: &[ast::token_tree])
     base::check_zero_tts(cx, sp, tts, "module_path!");
     base::MRExpr(mk_base_str(cx, sp,
                               str::connect(cx.mod_path().map(
-                                  |x| cx.str_of(*x)), ~"::")))
+                                  |x| cx.str_of(*x)), "::")))
 }
 
 // include! : parse the given file as an expr

--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -39,7 +39,7 @@ pub fn expand_trace_macros(cx: @ext_ctxt,
     } else if rust_parser.is_keyword("false") {
         cx.set_trace_macros(false);
     } else {
-        cx.span_fatal(sp, ~"trace_macros! only accepts `true` or `false`")
+        cx.span_fatal(sp, "trace_macros! only accepts `true` or `false`")
     }
 
     rust_parser.bump();

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -371,7 +371,7 @@ pub fn parse(
                              *sess.interner.get(bind))
                       }
                       _ => fail!()
-                    } }), ~" or ");
+                    } }), " or ");
                 return error(sp, fmt!(
                     "Local ambiguity: multiple parsing options: \
                      built-in NTs %s or %u other options.",
@@ -413,7 +413,7 @@ pub fn parse_nt(p: &Parser, name: &str) -> nonterminal {
     match name {
       "item" => match p.parse_item(~[]) {
         Some(i) => token::nt_item(i),
-        None => p.fatal(~"expected an item keyword")
+        None => p.fatal("expected an item keyword")
       },
       "block" => token::nt_block(p.parse_block()),
       "stmt" => token::nt_stmt(p.parse_stmt(~[])),

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -64,12 +64,12 @@ pub fn add_new_extension(cx: @ext_ctxt,
     // Extract the arguments:
     let lhses = match *argument_map.get(&lhs_nm) {
         @matched_seq(ref s, _) => /* FIXME (#2543) */ @copy *s,
-        _ => cx.span_bug(sp, ~"wrong-structured lhs")
+        _ => cx.span_bug(sp, "wrong-structured lhs")
     };
 
     let rhses = match *argument_map.get(&rhs_nm) {
       @matched_seq(ref s, _) => /* FIXME (#2543) */ @copy *s,
-      _ => cx.span_bug(sp, ~"wrong-structured rhs")
+      _ => cx.span_bug(sp, "wrong-structured rhs")
     };
 
     // Given `lhses` and `rhses`, this is the new macro we create
@@ -114,10 +114,10 @@ pub fn add_new_extension(cx: @ext_ctxt,
                                     (*tts).slice(1u,(*tts).len()-1u).to_owned()
                                 }
                                 _ => cx.span_fatal(
-                                    sp, ~"macro rhs must be delimited")
+                                    sp, "macro rhs must be delimited")
                             }
                         },
-                        _ => cx.span_bug(sp, ~"bad thing in rhs")
+                        _ => cx.span_bug(sp, "bad thing in rhs")
                     };
                     // rhs has holes ( `$id` and `$(...)` that need filled)
                     let trncbr = new_tt_reader(s_d, itr, Some(named_matches),
@@ -139,7 +139,7 @@ pub fn add_new_extension(cx: @ext_ctxt,
                   error(sp, ref msg) => cx.span_fatal(sp, (*msg))
                 }
               }
-              _ => cx.bug(~"non-matcher found in parsed lhses")
+              _ => cx.bug("non-matcher found in parsed lhses")
             }
         }
         cx.span_fatal(best_fail_spot, best_fail_msg);

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -234,9 +234,9 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
               lis_unconstrained => {
                 r.sp_diag.span_fatal(
                     sp, /* blame macro writer */
-                      ~"attempted to repeat an expression \
-                        containing no syntax \
-                        variables matched as repeating at this depth");
+                      "attempted to repeat an expression \
+                       containing no syntax \
+                       variables matched as repeating at this depth");
                   }
                   lis_contradiction(ref msg) => {
                       /* FIXME #2887 blame macro invoker instead*/
@@ -247,8 +247,8 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
                       if !zerok {
                         r.sp_diag.span_fatal(sp, /* FIXME #2887 blame invoker
                         */
-                                             ~"this must repeat at least \
-                                               once");
+                                             "this must repeat at least \
+                                              once");
                           }
 
                     r.stack.idx += 1u;

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -51,7 +51,7 @@ impl parser_attr for Parser {
                     self.span.hi
                 );
                 if attr.node.style != ast::attr_outer {
-                  self.fatal(~"expected outer comment");
+                  self.fatal("expected outer comment");
                 }
                 attrs += ~[attr];
                 self.bump();

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -33,15 +33,15 @@ pub struct cmnt {
 }
 
 pub fn is_doc_comment(s: &str) -> bool {
-    (s.starts_with(~"///") && !is_line_non_doc_comment(s)) ||
-    s.starts_with(~"//!") ||
-    (s.starts_with(~"/**") && !is_block_non_doc_comment(s)) ||
-    s.starts_with(~"/*!")
+    (s.starts_with("///") && !is_line_non_doc_comment(s)) ||
+    s.starts_with("//!") ||
+    (s.starts_with("/**") && !is_block_non_doc_comment(s)) ||
+    s.starts_with("/*!")
 }
 
 pub fn doc_comment_style(comment: &str) -> ast::attr_style {
     assert!(is_doc_comment(comment));
-    if comment.starts_with(~"//!") || comment.starts_with(~"/*!") {
+    if comment.starts_with("//!") || comment.starts_with("/*!") {
         ast::attr_inner
     } else {
         ast::attr_outer
@@ -92,14 +92,14 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         };
     }
 
-    if comment.starts_with(~"//") {
+    if comment.starts_with("//") {
         // FIXME #5475:
         // return comment.slice(3u, comment.len()).trim().to_owned();
         let r = comment.slice(3u, comment.len()); return r.trim().to_owned();
 
     }
 
-    if comment.starts_with(~"/*") {
+    if comment.starts_with("/*") {
         let mut lines = ~[];
         for str::each_line_any(comment.slice(3u, comment.len() - 2u)) |line| {
             lines.push(line.to_owned())
@@ -108,7 +108,7 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         let lines = block_trim(lines, ~"\t ", None);
         let lines = block_trim(lines, ~"*", Some(1u));
         let lines = block_trim(lines, ~"\t ", None);
-        return str::connect(lines, ~"\n");
+        return str::connect(lines, "\n");
     }
 
     fail!("not a doc-comment: %s", comment);

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -104,9 +104,7 @@ pub impl Parser {
                 i
             }
             token::INTERPOLATED(token::nt_ident(*)) => {
-                self.bug(
-                    ~"ident interpolation not converted to real token"
-                );
+                self.bug("ident interpolation not converted to real token");
             }
             _ => {
                 self.fatal(

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -354,7 +354,7 @@ pub impl Parser {
     fn get_lifetime(&self, tok: &token::Token) -> ast::ident {
         match *tok {
             token::LIFETIME(ref ident) => copy *ident,
-            _ => self.bug(~"not a lifetime"),
+            _ => self.bug("not a lifetime"),
         }
     }
 
@@ -434,7 +434,7 @@ pub impl Parser {
         });
 
         fn parse_onceness(this: &Parser) -> Onceness {
-            if this.eat_keyword(~"once") {
+            if this.eat_keyword("once") {
                 Once
             } else {
                 Many
@@ -1354,7 +1354,7 @@ pub impl Parser {
                 self.bump();
                 match *self.token {
                     token::LPAREN | token::LBRACE => {}
-                    _ => self.fatal(~"expected open delimiter")
+                    _ => self.fatal("expected open delimiter")
                 };
 
                 let ket = token::flip_delimiter(&*self.token);
@@ -1520,7 +1520,7 @@ pub impl Parser {
                 self.bump();
                 (Some(sep), zerok)
             } else {
-                self.fatal(~"expected `*` or `+`");
+                self.fatal("expected `*` or `+`");
             }
         }
     }
@@ -1587,7 +1587,7 @@ pub impl Parser {
 
         match *self.token {
             token::EOF => {
-                self.fatal(~"file ended with unbalanced delimiters");
+                self.fatal("file ended with unbalanced delimiters");
             }
             token::LPAREN | token::LBRACE | token::LBRACKET => {
                 let close_delim = token::flip_delimiter(&*self.token);
@@ -1602,7 +1602,7 @@ pub impl Parser {
                                 |p| p.parse_token_tree()
                             ),
                             // the close delimiter:
-                            ~[parse_any_tt_tok(self)]
+                            [parse_any_tt_tok(self)]
                         )
                     )
                 )
@@ -1635,7 +1635,7 @@ pub impl Parser {
                     token::flip_delimiter(self.token)
                 )
             }
-            _ => self.fatal(~"expected open delimiter")
+            _ => self.fatal("expected open delimiter")
         }
     }
 
@@ -1678,7 +1678,7 @@ pub impl Parser {
                     token::RPAREN
                 );
                 if ms.len() == 0u {
-                    self.fatal(~"repetition body must be nonempty");
+                    self.fatal("repetition body must be nonempty");
                 }
                 let (sep, zerok) = self.parse_sep_and_zerok();
                 match_seq(ms, sep, zerok, name_idx_lo, *name_idx)
@@ -1996,7 +1996,7 @@ pub impl Parser {
                 let block = self.parse_lambda_block_expr();
                 let last_arg = self.mk_expr(block.span.lo, block.span.hi,
                                             ctor(block));
-                let args = vec::append(args, ~[last_arg]);
+                let args = vec::append(args, [last_arg]);
                 self.mk_expr(lo.lo, block.span.hi, expr_call(f, args, sugar))
             }
             expr_method_call(f, i, /*bad*/ copy tps,
@@ -2004,7 +2004,7 @@ pub impl Parser {
                 let block = self.parse_lambda_block_expr();
                 let last_arg = self.mk_expr(block.span.lo, block.span.hi,
                                             ctor(block));
-                let args = vec::append(args, ~[last_arg]);
+                let args = vec::append(args, [last_arg]);
                 self.mk_expr(lo.lo, block.span.hi,
                              expr_method_call(f, i, tps, args, sugar))
             }
@@ -2575,7 +2575,7 @@ pub impl Parser {
             // XXX: Remove after snapshot.
         }
         if !is_plain_ident(&*self.token) {
-            self.fatal(~"expected ident");
+            self.fatal("expected ident");
         }
         let name = self.parse_ident();
         self.expect(&token::COLON);
@@ -2597,7 +2597,7 @@ pub impl Parser {
             // If we have attributes then we should have an item
             if !current_attrs.is_empty() {
                 p.span_err(*p.last_span,
-                           ~"expected item after attributes");
+                           "expected item after attributes");
             }
         }
 
@@ -2664,7 +2664,7 @@ pub impl Parser {
                                     "view items must be declared at the top of the block");
                 }
                 iovi_foreign_item(_) => {
-                    self.fatal(~"foreign items are not allowed here");
+                    self.fatal("foreign items are not allowed here");
                 }
                 iovi_none() => { /* fallthrough */ }
             }
@@ -3528,7 +3528,7 @@ pub impl Parser {
 
         if first && attrs_remaining_len > 0u {
             // We parsed attributes for the first item but didn't find it
-            self.span_err(*self.last_span,~"expected item after attributes");
+            self.span_err(*self.last_span, "expected item after attributes");
         }
 
         ast::_mod { view_items: view_items, items: items }
@@ -3583,7 +3583,7 @@ pub impl Parser {
                 let (main_mod, new_mod) =
                     match (main_mod_item, new_mod_item) {
                     (item_mod(m), item_mod(n)) => (m, n),
-                    _ => self.bug(~"parsed mod item should be mod")
+                    _ => self.bug("parsed mod item should be mod")
                 };
                 let merged_mod = ast::_mod {
                     view_items: main_mod.view_items + new_mod.view_items,
@@ -3600,7 +3600,7 @@ pub impl Parser {
     fn push_mod_path(&self, id: ident, attrs: ~[ast::attribute]) {
         let default_path = self.sess.interner.get(id);
         let file_path = match ::attr::first_attr_value_str_by_name(
-            attrs, ~"path") {
+            attrs, "path") {
 
             Some(d) => copy *d,
             None => copy *default_path
@@ -3623,7 +3623,7 @@ pub impl Parser {
         let mod_path = Path(".").push_many(*mod_path_stack);
         let default_path = *self.sess.interner.get(id) + ~".rs";
         let file_path = match ::attr::first_attr_value_str_by_name(
-            outer_attrs, ~"path") {
+            outer_attrs, "path") {
             Some(d) => {
                 let path = Path(copy *d);
                 if !path.is_absolute {
@@ -3660,7 +3660,7 @@ pub impl Parser {
         return (ast::item_mod(m0), mod_attrs);
 
         fn cdir_path_opt(default: ~str, attrs: ~[ast::attribute]) -> ~str {
-            match ::attr::first_attr_value_str_by_name(attrs, ~"path") {
+            match ::attr::first_attr_value_str_by_name(attrs, "path") {
                 Some(d) => copy *d,
                 None => default
             }
@@ -3915,7 +3915,7 @@ pub impl Parser {
         }
         self.expect(&token::RBRACE);
         if (have_disr && !all_nullary) {
-            self.fatal(~"discriminator values can only be used with a c-like \
+            self.fatal("discriminator values can only be used with a c-like \
                         enum");
         }
 
@@ -4209,7 +4209,7 @@ pub impl Parser {
                     || self.look_ahead(2) == token::LBRACE) {
             // MACRO INVOCATION ITEM
             if attrs.len() > 0 {
-                self.fatal(~"attrs on macros are not yet supported");
+                self.fatal("attrs on macros are not yet supported");
             }
 
             // item macro.
@@ -4235,7 +4235,7 @@ pub impl Parser {
                         |p| p.parse_token_tree()
                     )
                 }
-                _ => self.fatal(~"expected open delimiter")
+                _ => self.fatal("expected open delimiter")
             };
             // single-variant-enum... :
             let m = ast::mac_invoc_tt(pth, tts);
@@ -4262,9 +4262,9 @@ pub impl Parser {
             iovi_none =>
                 None,
             iovi_view_item(_) =>
-                self.fatal(~"view items are not allowed here"),
+                self.fatal("view items are not allowed here"),
             iovi_foreign_item(_) =>
-                self.fatal(~"foreign items are not allowed here"),
+                self.fatal("foreign items are not allowed here"),
             iovi_item(item) =>
                 Some(item)
         }
@@ -4404,7 +4404,7 @@ pub impl Parser {
             let metadata = self.parse_optional_meta();
             view_item_extern_mod(ident, metadata, self.get_id())
         } else {
-            self.bug(~"expected view item");
+            self.bug("expected view item");
         };
         self.expect(&token::SEMI);
         @ast::view_item { node: node,
@@ -4551,7 +4551,7 @@ pub impl Parser {
                 self.bump();
                 self.id_to_str(s)
             }
-            _ =>  self.fatal(~"expected string literal")
+            _ =>  self.fatal("expected string literal")
         }
     }
 }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -173,14 +173,14 @@ pub fn to_str(in: @ident_interner, t: &Token) -> ~str {
       LIT_INT_UNSUFFIXED(i) => { i.to_str() }
       LIT_FLOAT(s, t) => {
         let mut body = copy *in.get(s);
-        if body.ends_with(~".") {
+        if body.ends_with(".") {
             body = body + ~"0";  // `10.f` is not a float literal
         }
         body + ast_util::float_ty_to_str(t)
       }
       LIT_FLOAT_UNSUFFIXED(s) => {
         let mut body = copy *in.get(s);
-        if body.ends_with(~".") {
+        if body.ends_with(".") {
             body = body + ~"0";  // `10.f` is not a float literal
         }
         body

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -437,7 +437,7 @@ pub impl Printer {
     }
     fn print_newline(&mut self, amount: int) {
         debug!("NEWLINE %d", amount);
-        (*self.out).write_str(~"\n");
+        (*self.out).write_str("\n");
         self.pending_indentation = 0;
         self.indent(amount);
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -227,17 +227,17 @@ pub fn box(s: @ps, u: uint, b: pp::breaks) {
     pp::box(s.s, u, b);
 }
 
-pub fn nbsp(s: @ps) { word(s.s, ~" "); }
+pub fn nbsp(s: @ps) { word(s.s, " "); }
 
 pub fn word_nbsp(s: @ps, w: &str) { word(s.s, w); nbsp(s); }
 
 pub fn word_space(s: @ps, w: &str) { word(s.s, w); space(s.s); }
 
-pub fn popen(s: @ps) { word(s.s, ~"("); }
+pub fn popen(s: @ps) { word(s.s, "("); }
 
-pub fn pclose(s: @ps) { word(s.s, ~")"); }
+pub fn pclose(s: @ps) { word(s.s, ")"); }
 
-pub fn head(s: @ps, w: ~str) {
+pub fn head(s: @ps, w: &str) {
     // outer-box is consistent
     cbox(s, indent_unit);
     // head-box is inconsistent
@@ -249,7 +249,7 @@ pub fn head(s: @ps, w: ~str) {
 }
 
 pub fn bopen(s: @ps) {
-    word(s.s, ~"{");
+    word(s.s, "{");
     end(s); // close the head-box
 }
 
@@ -260,7 +260,7 @@ pub fn bclose_maybe_open (s: @ps, span: codemap::span, indented: uint,
                           close_box: bool) {
     maybe_print_comment(s, span.hi);
     break_offset_if_not_bol(s, 1u, -(indented as int));
-    word(s.s, ~"}");
+    word(s.s, "}");
     if close_box {
         end(s); // close the outer-box
     }
@@ -304,18 +304,18 @@ pub fn break_offset_if_not_bol(s: @ps, n: uint, off: int) {
 // Synthesizes a comment that was not textually present in the original source
 // file.
 pub fn synth_comment(s: @ps, text: ~str) {
-    word(s.s, ~"/*");
+    word(s.s, "/*");
     space(s.s);
     word(s.s, text);
     space(s.s);
-    word(s.s, ~"*/");
+    word(s.s, "*/");
 }
 
 pub fn commasep<IN: Copy>(s: @ps, b: breaks, elts: &[IN], op: &fn(@ps, IN)) {
     box(s, 0u, b);
     let mut first = true;
     for elts.each |elt| {
-        if first { first = false; } else { word_space(s, ~","); }
+        if first { first = false; } else { word_space(s, ","); }
         op(s, *elt);
     }
     end(s);
@@ -332,7 +332,7 @@ pub fn commasep_cmnt<IN: Copy>(s: @ps, b: breaks, elts: &[IN], op: &fn(@ps, IN),
         op(s, *elt);
         i += 1u;
         if i < len {
-            word(s.s, ~",");
+            word(s.s, ",");
             maybe_print_trailing_comment(s, get_span(*elt),
                                          Some(get_span(elts[i]).hi));
             space_if_not_bol(s);
@@ -374,23 +374,23 @@ pub fn print_type(s: @ps, ty: @ast::Ty) {
     maybe_print_comment(s, ty.span.lo);
     ibox(s, 0u);
     match ty.node {
-      ast::ty_nil => word(s.s, ~"()"),
-      ast::ty_bot => word(s.s, ~"!"),
-      ast::ty_box(ref mt) => { word(s.s, ~"@"); print_mt(s, mt); }
-      ast::ty_uniq(ref mt) => { word(s.s, ~"~"); print_mt(s, mt); }
+      ast::ty_nil => word(s.s, "()"),
+      ast::ty_bot => word(s.s, "!"),
+      ast::ty_box(ref mt) => { word(s.s, "@"); print_mt(s, mt); }
+      ast::ty_uniq(ref mt) => { word(s.s, "~"); print_mt(s, mt); }
       ast::ty_vec(ref mt) => {
-        word(s.s, ~"[");
+        word(s.s, "[");
         match mt.mutbl {
-          ast::m_mutbl => word_space(s, ~"mut"),
-          ast::m_const => word_space(s, ~"const"),
+          ast::m_mutbl => word_space(s, "mut"),
+          ast::m_const => word_space(s, "const"),
           ast::m_imm => ()
         }
         print_type(s, mt.ty);
-        word(s.s, ~"]");
+        word(s.s, "]");
       }
-      ast::ty_ptr(ref mt) => { word(s.s, ~"*"); print_mt(s, mt); }
+      ast::ty_ptr(ref mt) => { word(s.s, "*"); print_mt(s, mt); }
       ast::ty_rptr(lifetime, ref mt) => {
-          word(s.s, ~"&");
+          word(s.s, "&");
           print_opt_lifetime(s, lifetime);
           print_mt(s, mt);
       }
@@ -398,7 +398,7 @@ pub fn print_type(s: @ps, ty: @ast::Ty) {
         popen(s);
         commasep(s, inconsistent, *elts, print_type);
         if elts.len() == 1 {
-            word(s.s, ~",");
+            word(s.s, ",");
         }
         pclose(s);
       }
@@ -418,16 +418,16 @@ pub fn print_type(s: @ps, ty: @ast::Ty) {
       }
       ast::ty_path(path, _) => print_path(s, path, false),
       ast::ty_fixed_length_vec(ref mt, v) => {
-        word(s.s, ~"[");
+        word(s.s, "[");
         match mt.mutbl {
-            ast::m_mutbl => word_space(s, ~"mut"),
-            ast::m_const => word_space(s, ~"const"),
+            ast::m_mutbl => word_space(s, "mut"),
+            ast::m_const => word_space(s, "const"),
             ast::m_imm => ()
         }
         print_type(s, mt.ty);
-        word(s.s, ~", ..");
+        word(s.s, ", ..");
         print_expr(s, v);
-        word(s.s, ~"]");
+        word(s.s, "]");
       }
       ast::ty_mac(_) => {
           fail!("print_type doesn't know how to print a ty_mac");
@@ -449,15 +449,15 @@ pub fn print_foreign_item(s: @ps, item: @ast::foreign_item) {
         print_fn(s, decl, Some(purity), AbiSet::Rust(), item.ident, generics, None,
                  ast::inherited);
         end(s); // end head-ibox
-        word(s.s, ~";");
+        word(s.s, ";");
         end(s); // end the outer fn box
       }
       ast::foreign_item_const(t) => {
-        head(s, ~"static");
+        head(s, "static");
         print_ident(s, item.ident);
-        word_space(s, ~":");
+        word_space(s, ":");
         print_type(s, t);
-        word(s.s, ~";");
+        word(s.s, ";");
         end(s); // end the head-ibox
         end(s); // end the outer cbox
       }
@@ -474,14 +474,14 @@ pub fn print_item(s: @ps, item: @ast::item) {
       ast::item_const(ty, expr) => {
         head(s, visibility_qualified(item.vis, ~"static"));
         print_ident(s, item.ident);
-        word_space(s, ~":");
+        word_space(s, ":");
         print_type(s, ty);
         space(s.s);
         end(s); // end the head-ibox
 
-        word_space(s, ~"=");
+        word_space(s, "=");
         print_expr(s, expr);
-        word(s.s, ~";");
+        word(s.s, ";");
         end(s); // end the outer cbox
 
       }
@@ -496,7 +496,7 @@ pub fn print_item(s: @ps, item: @ast::item) {
             None,
             item.vis
         );
-        word(s.s, ~" ");
+        word(s.s, " ");
         print_block_with_attrs(s, body, item.attrs);
       }
       ast::item_mod(ref _mod) => {
@@ -512,7 +512,7 @@ pub fn print_item(s: @ps, item: @ast::item) {
         word_nbsp(s, nmod.abis.to_str());
         match nmod.sort {
             ast::named => {
-                word_nbsp(s, ~"mod");
+                word_nbsp(s, "mod");
                 print_ident(s, item.ident);
                 nbsp(s);
             }
@@ -531,9 +531,9 @@ pub fn print_item(s: @ps, item: @ast::item) {
         end(s); // end the inner ibox
 
         space(s.s);
-        word_space(s, ~"=");
+        word_space(s, "=");
         print_type(s, ty);
-        word(s.s, ~";");
+        word(s.s, ";");
         end(s); // end the outer ibox
       }
       ast::item_enum(ref enum_definition, ref params) => {
@@ -562,7 +562,7 @@ pub fn print_item(s: @ps, item: @ast::item) {
             Some(t) => {
                 print_trait_ref(s, t);
                 space(s.s);
-                word_space(s, ~"for");
+                word_space(s, "for");
             }
             None => ()
         };
@@ -571,7 +571,7 @@ pub fn print_item(s: @ps, item: @ast::item) {
         space(s.s);
 
         if methods.len() == 0 {
-            word(s.s, ~";");
+            word(s.s, ";");
         } else {
             bopen(s);
             for methods.each |meth| {
@@ -585,16 +585,16 @@ pub fn print_item(s: @ps, item: @ast::item) {
         print_ident(s, item.ident);
         print_generics(s, generics);
         if traits.len() != 0u {
-            word(s.s, ~":");
+            word(s.s, ":");
             for traits.eachi |i, trait_| {
                 nbsp(s);
                 if i != 0 {
-                    word_space(s, ~"+");
+                    word_space(s, "+");
                 }
                 print_path(s, trait_.path, false);
             }
         }
-        word(s.s, ~" ");
+        word(s.s, " ");
         bopen(s);
         for methods.each |meth| {
             print_trait_method(s, meth);
@@ -605,7 +605,7 @@ pub fn print_item(s: @ps, item: @ast::item) {
                                    _}) => {
         print_visibility(s, item.vis);
         print_path(s, pth, false);
-        word(s.s, ~"! ");
+        word(s.s, "! ");
         print_ident(s, item.ident);
         cbox(s, indent_unit);
         popen(s);
@@ -641,7 +641,7 @@ pub fn print_variants(s: @ps,
         print_outer_attributes(s, v.node.attrs);
         ibox(s, indent_unit);
         print_variant(s, v);
-        word(s.s, ~",");
+        word(s.s, ",");
         end(s);
         maybe_print_trailing_comment(s, v.span, None);
     }
@@ -692,7 +692,7 @@ pub fn print_struct(s: @ps,
             }
             pclose(s);
         }
-        word(s.s, ~";");
+        word(s.s, ";");
         end(s);
         end(s); // close the outer-box
     } else {
@@ -709,9 +709,9 @@ pub fn print_struct(s: @ps,
                     print_outer_attributes(s, field.node.attrs);
                     print_visibility(s, visibility);
                     print_ident(s, ident);
-                    word_nbsp(s, ~":");
+                    word_nbsp(s, ":");
                     print_type(s, field.node.ty);
-                    word(s.s, ~",");
+                    word(s.s, ",");
                 }
             }
         }
@@ -734,17 +734,17 @@ pub fn print_tt(s: @ps, tt: &ast::token_tree) {
           word(s.s, parse::token::to_str(s.intr, tk));
       }
       ast::tt_seq(_, ref tts, ref sep, zerok) => {
-        word(s.s, ~"$(");
+        word(s.s, "$(");
         for (*tts).each() |tt_elt| { print_tt(s, tt_elt); }
-        word(s.s, ~")");
+        word(s.s, ")");
         match (*sep) {
           Some(ref tk) => word(s.s, parse::token::to_str(s.intr, tk)),
           None => ()
         }
-        word(s.s, if zerok { ~"*" } else { ~"+" });
+        word(s.s, if zerok { "*" } else { "+" });
       }
       ast::tt_nonterminal(_, name) => {
-        word(s.s, ~"$");
+        word(s.s, "$");
         print_ident(s, name);
       }
     }
@@ -776,7 +776,7 @@ pub fn print_variant(s: @ps, v: &ast::variant) {
             }
         }
         ast::struct_variant_kind(struct_def) => {
-            head(s, ~"");
+            head(s, "");
             let generics = ast_util::empty_generics();
             print_struct(s, struct_def, &generics, v.node.name, v.span);
         }
@@ -784,7 +784,7 @@ pub fn print_variant(s: @ps, v: &ast::variant) {
     match v.node.disr_expr {
       Some(d) => {
         space(s.s);
-        word_space(s, ~"=");
+        word_space(s, "=");
         print_expr(s, d);
       }
       _ => ()
@@ -798,7 +798,7 @@ pub fn print_ty_method(s: @ps, m: &ast::ty_method) {
     print_ty_fn(s, None, None, None, m.purity, ast::Many,
                 &m.decl, Some(m.ident), Some(&m.generics),
                 Some(/*bad*/ copy m.explicit_self.node));
-    word(s.s, ~";");
+    word(s.s, ";");
 }
 
 pub fn print_trait_method(s: @ps, m: &ast::trait_method) {
@@ -815,7 +815,7 @@ pub fn print_method(s: @ps, meth: @ast::method) {
     print_fn(s, &meth.decl, Some(meth.purity), AbiSet::Rust(),
              meth.ident, &meth.generics, Some(meth.explicit_self.node),
              meth.vis);
-    word(s.s, ~" ");
+    word(s.s, " ");
     print_block_with_attrs(s, &meth.body, meth.attrs);
 }
 
@@ -837,7 +837,7 @@ pub fn print_inner_attributes(s: @ps, attrs: &[ast::attribute]) {
           ast::attr_inner => {
             print_attribute(s, *attr);
             if !attr.node.is_sugared_doc {
-                word(s.s, ~";");
+                word(s.s, ";");
             }
             count += 1;
           }
@@ -855,9 +855,9 @@ pub fn print_attribute(s: @ps, attr: ast::attribute) {
         let comment = attr::get_meta_item_value_str(meta).get();
         word(s.s, *comment);
     } else {
-        word(s.s, ~"#[");
+        word(s.s, "#[");
         print_meta_item(s, attr.node.value);
-        word(s.s, ~"]");
+        word(s.s, "]");
     }
 }
 
@@ -875,15 +875,15 @@ pub fn print_stmt(s: @ps, st: &ast::stmt) {
       ast::stmt_semi(expr, _) => {
         space_if_not_bol(s);
         print_expr(s, expr);
-        word(s.s, ~";");
+        word(s.s, ";");
       }
       ast::stmt_mac(ref mac, semi) => {
         space_if_not_bol(s);
         print_mac(s, mac);
-        if semi { word(s.s, ~";"); }
+        if semi { word(s.s, ";"); }
       }
     }
-    if parse::classify::stmt_ends_with_semi(st) { word(s.s, ~";"); }
+    if parse::classify::stmt_ends_with_semi(st) { word(s.s, ";"); }
     maybe_print_trailing_comment(s, st.span, None);
 }
 
@@ -925,7 +925,7 @@ pub fn print_possibly_embedded_block_(s: @ps,
                                       attrs: &[ast::attribute],
                                       close_box: bool) {
     match blk.node.rules {
-      ast::unsafe_blk => word_space(s, ~"unsafe"),
+      ast::unsafe_blk => word_space(s, "unsafe"),
       ast::default_blk => ()
     }
     maybe_print_comment(s, blk.span.lo);
@@ -956,8 +956,8 @@ pub fn print_possibly_embedded_block_(s: @ps,
 
 pub fn print_if(s: @ps, test: @ast::expr, blk: &ast::blk,
                 elseopt: Option<@ast::expr>, chk: bool) {
-    head(s, ~"if");
-    if chk { word_nbsp(s, ~"check"); }
+    head(s, "if");
+    if chk { word_nbsp(s, "check"); }
     print_expr(s, test);
     space(s.s);
     print_block(s, blk);
@@ -969,7 +969,7 @@ pub fn print_if(s: @ps, test: @ast::expr, blk: &ast::blk,
               ast::expr_if(i, ref t, e) => {
                 cbox(s, indent_unit - 1u);
                 ibox(s, 0u);
-                word(s.s, ~" else if ");
+                word(s.s, " else if ");
                 print_expr(s, i);
                 space(s.s);
                 print_block(s, t);
@@ -979,7 +979,7 @@ pub fn print_if(s: @ps, test: @ast::expr, blk: &ast::blk,
               ast::expr_block(ref b) => {
                 cbox(s, indent_unit - 1u);
                 ibox(s, 0u);
-                word(s.s, ~" else ");
+                word(s.s, " else ");
                 print_block(s, b);
               }
               // BLEAH, constraints would be great here
@@ -998,7 +998,7 @@ pub fn print_mac(s: @ps, m: &ast::mac) {
     match m.node {
       ast::mac_invoc_tt(pth, ref tts) => {
         print_path(s, pth, false);
-        word(s.s, ~"!");
+        word(s.s, "!");
         popen(s);
         print_tts(s, *tts);
         pclose(s);
@@ -1009,11 +1009,11 @@ pub fn print_mac(s: @ps, m: &ast::mac) {
 pub fn print_vstore(s: @ps, t: ast::vstore) {
     match t {
         ast::vstore_fixed(Some(i)) => word(s.s, fmt!("%u", i)),
-        ast::vstore_fixed(None) => word(s.s, ~"_"),
-        ast::vstore_uniq => word(s.s, ~"~"),
-        ast::vstore_box => word(s.s, ~"@"),
+        ast::vstore_fixed(None) => word(s.s, "_"),
+        ast::vstore_uniq => word(s.s, "~"),
+        ast::vstore_box => word(s.s, "@"),
         ast::vstore_slice(r) => {
-            word(s.s, ~"&");
+            word(s.s, "&");
             print_opt_lifetime(s, r);
         }
     }
@@ -1021,16 +1021,16 @@ pub fn print_vstore(s: @ps, t: ast::vstore) {
 
 pub fn print_expr_vstore(s: @ps, t: ast::expr_vstore) {
     match t {
-      ast::expr_vstore_uniq => word(s.s, ~"~"),
-      ast::expr_vstore_box => word(s.s, ~"@"),
+      ast::expr_vstore_uniq => word(s.s, "~"),
+      ast::expr_vstore_box => word(s.s, "@"),
       ast::expr_vstore_mut_box => {
-        word(s.s, ~"@");
-        word(s.s, ~"mut");
+        word(s.s, "@");
+        word(s.s, "mut");
       }
-      ast::expr_vstore_slice => word(s.s, ~"&"),
+      ast::expr_vstore_slice => word(s.s, "&"),
       ast::expr_vstore_mut_slice => {
-        word(s.s, ~"&");
-        word(s.s, ~"mut");
+        word(s.s, "&");
+        word(s.s, "mut");
       }
     }
 }
@@ -1041,11 +1041,11 @@ pub fn print_call_pre(s: @ps,
                    -> Option<@ast::expr> {
     match sugar {
         ast::DoSugar => {
-            head(s, ~"do");
+            head(s, "do");
             Some(base_args.pop())
         }
         ast::ForSugar => {
-            head(s, ~"for");
+            head(s, "for");
             Some(base_args.pop())
         }
         ast::NoSugar => None
@@ -1082,9 +1082,9 @@ pub fn print_call_post(s: @ps,
 pub fn print_expr(s: @ps, expr: @ast::expr) {
     fn print_field(s: @ps, field: ast::field) {
         ibox(s, indent_unit);
-        if field.node.mutbl == ast::m_mutbl { word_nbsp(s, ~"mut"); }
+        if field.node.mutbl == ast::m_mutbl { word_nbsp(s, "mut"); }
         print_ident(s, field.node.ident);
-        word_space(s, ~":");
+        word_space(s, ":");
         print_expr(s, field.node.expr);
         end(s);
     }
@@ -1101,53 +1101,53 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
         },
       ast::expr_vec(ref exprs, mutbl) => {
         ibox(s, indent_unit);
-        word(s.s, ~"[");
+        word(s.s, "[");
         if mutbl == ast::m_mutbl {
-            word(s.s, ~"mut");
+            word(s.s, "mut");
             if exprs.len() > 0u { nbsp(s); }
         }
         commasep_exprs(s, inconsistent, *exprs);
-        word(s.s, ~"]");
+        word(s.s, "]");
         end(s);
       }
 
       ast::expr_repeat(element, count, mutbl) => {
         ibox(s, indent_unit);
-        word(s.s, ~"[");
+        word(s.s, "[");
         if mutbl == ast::m_mutbl {
-            word(s.s, ~"mut");
+            word(s.s, "mut");
             nbsp(s);
         }
         print_expr(s, element);
-        word(s.s, ~",");
-        word(s.s, ~"..");
+        word(s.s, ",");
+        word(s.s, "..");
         print_expr(s, count);
-        word(s.s, ~"]");
+        word(s.s, "]");
         end(s);
       }
 
       ast::expr_struct(path, ref fields, wth) => {
         print_path(s, path, true);
-        word(s.s, ~"{");
+        word(s.s, "{");
         commasep_cmnt(s, consistent, (*fields), print_field, get_span);
         match wth {
             Some(expr) => {
                 ibox(s, indent_unit);
-                word(s.s, ~",");
+                word(s.s, ",");
                 space(s.s);
-                word(s.s, ~"..");
+                word(s.s, "..");
                 print_expr(s, expr);
                 end(s);
             }
-            _ => (word(s.s, ~","))
+            _ => (word(s.s, ","))
         }
-        word(s.s, ~"}");
+        word(s.s, "}");
       }
       ast::expr_tup(ref exprs) => {
         popen(s);
         commasep_exprs(s, inconsistent, *exprs);
         if exprs.len() == 1 {
-            word(s.s, ~",");
+            word(s.s, ",");
         }
         pclose(s);
       }
@@ -1161,12 +1161,12 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
         let mut base_args = copy *args;
         let blk = print_call_pre(s, sugar, &mut base_args);
         print_expr(s, func);
-        word(s.s, ~".");
+        word(s.s, ".");
         print_ident(s, ident);
         if tys.len() > 0u {
-            word(s.s, ~"::<");
+            word(s.s, "::<");
             commasep(s, inconsistent, *tys, print_type);
-            word(s.s, ~">");
+            word(s.s, ">");
         }
         print_call_post(s, sugar, &blk, &mut base_args);
       }
@@ -1181,7 +1181,7 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
         print_expr(s, expr);
       }
       ast::expr_addr_of(m, expr) => {
-        word(s.s, ~"&");
+        word(s.s, "&");
         print_mutability(s, m);
         // Avoid `& &e` => `&&e`.
         match (m, &expr.node) {
@@ -1194,32 +1194,32 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
       ast::expr_cast(expr, ty) => {
         print_expr(s, expr);
         space(s.s);
-        word_space(s, ~"as");
+        word_space(s, "as");
         print_type(s, ty);
       }
       ast::expr_if(test, ref blk, elseopt) => {
         print_if(s, test, blk, elseopt, false);
       }
       ast::expr_while(test, ref blk) => {
-        head(s, ~"while");
+        head(s, "while");
         print_expr(s, test);
         space(s.s);
         print_block(s, blk);
       }
       ast::expr_loop(ref blk, opt_ident) => {
         for opt_ident.each |ident| {
-            word(s.s, ~"'");
+            word(s.s, "'");
             print_ident(s, *ident);
-            word_space(s, ~":");
+            word_space(s, ":");
         }
-        head(s, ~"loop");
+        head(s, "loop");
         space(s.s);
         print_block(s, blk);
       }
       ast::expr_match(expr, ref arms) => {
         cbox(s, indent_unit);
         ibox(s, 4);
-        word_nbsp(s, ~"match");
+        word_nbsp(s, "match");
         print_expr(s, expr);
         space(s.s);
         bopen(s);
@@ -1232,19 +1232,19 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
             for arm.pats.each |p| {
                 if first {
                     first = false;
-                } else { space(s.s); word_space(s, ~"|"); }
+                } else { space(s.s); word_space(s, "|"); }
                 print_refutable_pat(s, *p);
             }
             space(s.s);
             match arm.guard {
               Some(e) => {
-                word_space(s, ~"if");
+                word_space(s, "if");
                 print_expr(s, e);
                 space(s.s);
               }
               None => ()
             }
-            word_space(s, ~"=>");
+            word_space(s, "=>");
 
             // Extract the expression from the extra block the parser adds
             // in the case of foo => expr
@@ -1268,7 +1268,7 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
                         }
                         if !expr_is_simple_block(expr)
                             && i < len - 1 {
-                            word(s.s, ~",");
+                            word(s.s, ",");
                         }
                         end(s); // close enclosing cbox
                     }
@@ -1321,97 +1321,97 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
         ibox(s, 0u);
         print_block(s, blk);
       }
-      ast::expr_copy(e) => { word_space(s, ~"copy"); print_expr(s, e); }
+      ast::expr_copy(e) => { word_space(s, "copy"); print_expr(s, e); }
       ast::expr_assign(lhs, rhs) => {
         print_expr(s, lhs);
         space(s.s);
-        word_space(s, ~"=");
+        word_space(s, "=");
         print_expr(s, rhs);
       }
       ast::expr_assign_op(op, lhs, rhs) => {
         print_expr(s, lhs);
         space(s.s);
         word(s.s, ast_util::binop_to_str(op));
-        word_space(s, ~"=");
+        word_space(s, "=");
         print_expr(s, rhs);
       }
       ast::expr_field(expr, id, ref tys) => {
         print_expr(s, expr);
-        word(s.s, ~".");
+        word(s.s, ".");
         print_ident(s, id);
         if tys.len() > 0u {
-            word(s.s, ~"::<");
+            word(s.s, "::<");
             commasep(s, inconsistent, *tys, print_type);
-            word(s.s, ~">");
+            word(s.s, ">");
         }
       }
       ast::expr_index(expr, index) => {
         print_expr(s, expr);
-        word(s.s, ~"[");
+        word(s.s, "[");
         print_expr(s, index);
-        word(s.s, ~"]");
+        word(s.s, "]");
       }
       ast::expr_path(path) => print_path(s, path, true),
-      ast::expr_self => word(s.s, ~"self"),
+      ast::expr_self => word(s.s, "self"),
       ast::expr_break(opt_ident) => {
-        word(s.s, ~"break");
+        word(s.s, "break");
         space(s.s);
         for opt_ident.each |ident| {
-            word(s.s, ~"'");
+            word(s.s, "'");
             print_ident(s, *ident);
             space(s.s);
         }
       }
       ast::expr_again(opt_ident) => {
-        word(s.s, ~"loop");
+        word(s.s, "loop");
         space(s.s);
         for opt_ident.each |ident| {
-            word(s.s, ~"'");
+            word(s.s, "'");
             print_ident(s, *ident);
             space(s.s)
         }
       }
       ast::expr_ret(result) => {
-        word(s.s, ~"return");
+        word(s.s, "return");
         match result {
-          Some(expr) => { word(s.s, ~" "); print_expr(s, expr); }
+          Some(expr) => { word(s.s, " "); print_expr(s, expr); }
           _ => ()
         }
       }
       ast::expr_log(lexp, expr) => {
-        word(s.s, ~"__log");
+        word(s.s, "__log");
         popen(s);
         print_expr(s, lexp);
-        word(s.s, ~",");
+        word(s.s, ",");
         space_if_not_bol(s);
         print_expr(s, expr);
         pclose(s);
       }
       ast::expr_inline_asm(ref a) => {
         if a.volatile {
-            word(s.s, ~"__volatile__ asm!");
+            word(s.s, "__volatile__ asm!");
         } else {
-            word(s.s, ~"asm!");
+            word(s.s, "asm!");
         }
         popen(s);
         print_string(s, *a.asm);
-        word_space(s, ~":");
+        word_space(s, ":");
         for a.outputs.each |&(co, o)| {
             print_string(s, *co);
             popen(s);
             print_expr(s, o);
             pclose(s);
-            word_space(s, ~",");
+            word_space(s, ",");
         }
-        word_space(s, ~":");
+        word_space(s, ":");
         for a.inputs.each |&(co, o)| {
             print_string(s, *co);
             popen(s);
             print_expr(s, o);
             pclose(s);
-            word_space(s, ~",");
+            word_space(s, ",");
         }
-        word_space(s, ~":");
+        word_space(s, ":");
         print_string(s, *a.clobbers);
         pclose(s);
       }
@@ -1430,7 +1430,7 @@ pub fn print_local_decl(s: @ps, loc: @ast::local) {
     print_irrefutable_pat(s, loc.node.pat);
     match loc.node.ty.node {
       ast::ty_infer => (),
-      _ => { word_space(s, ~":"); print_type(s, loc.node.ty); }
+      _ => { word_space(s, ":"); print_type(s, loc.node.ty); }
     }
 }
 
@@ -1440,12 +1440,12 @@ pub fn print_decl(s: @ps, decl: @ast::decl) {
       ast::decl_local(ref locs) => {
         space_if_not_bol(s);
         ibox(s, indent_unit);
-        word_nbsp(s, ~"let");
+        word_nbsp(s, "let");
 
         // if any are mut, all are mut
         if locs.any(|l| l.node.is_mutbl) {
             assert!(locs.all(|l| l.node.is_mutbl));
-            word_nbsp(s, ~"mut");
+            word_nbsp(s, "mut");
         }
 
         fn print_local(s: @ps, loc: @ast::local) {
@@ -1455,7 +1455,7 @@ pub fn print_decl(s: @ps, decl: @ast::decl) {
             match loc.node.init {
               Some(init) => {
                 nbsp(s);
-                word_space(s, ~"=");
+                word_space(s, "=");
                 print_expr(s, init);
               }
               _ => ()
@@ -1475,34 +1475,34 @@ pub fn print_ident(s: @ps, ident: ast::ident) {
 pub fn print_for_decl(s: @ps, loc: @ast::local, coll: @ast::expr) {
     print_local_decl(s, loc);
     space(s.s);
-    word_space(s, ~"in");
+    word_space(s, "in");
     print_expr(s, coll);
 }
 
 pub fn print_path(s: @ps, path: @ast::Path, colons_before_params: bool) {
     maybe_print_comment(s, path.span.lo);
-    if path.global { word(s.s, ~"::"); }
+    if path.global { word(s.s, "::"); }
     let mut first = true;
     for path.idents.each |id| {
-        if first { first = false; } else { word(s.s, ~"::"); }
+        if first { first = false; } else { word(s.s, "::"); }
         print_ident(s, *id);
     }
     if path.rp.is_some() || !path.types.is_empty() {
-        if colons_before_params { word(s.s, ~"::"); }
+        if colons_before_params { word(s.s, "::"); }
 
         if path.rp.is_some() || !path.types.is_empty() {
-            word(s.s, ~"<");
+            word(s.s, "<");
 
             for path.rp.each |r| {
                 print_lifetime(s, *r);
                 if !path.types.is_empty() {
-                    word_space(s, ~",");
+                    word_space(s, ",");
                 }
             }
 
             commasep(s, inconsistent, path.types, print_type);
 
-            word(s.s, ~">");
+            word(s.s, ">");
         }
     }
 }
@@ -1522,16 +1522,16 @@ pub fn print_pat(s: @ps, pat: @ast::pat, refutable: bool) {
     /* Pat isn't normalized, but the beauty of it
      is that it doesn't matter */
     match pat.node {
-      ast::pat_wild => word(s.s, ~"_"),
+      ast::pat_wild => word(s.s, "_"),
       ast::pat_ident(binding_mode, path, sub) => {
           if refutable {
               match binding_mode {
                   ast::bind_by_ref(mutbl) => {
-                      word_nbsp(s, ~"ref");
+                      word_nbsp(s, "ref");
                       print_mutability(s, mutbl);
                   }
                   ast::bind_by_copy => {
-                      word_nbsp(s, ~"copy");
+                      word_nbsp(s, "copy");
                   }
                   ast::bind_infer => {}
               }
@@ -1539,7 +1539,7 @@ pub fn print_pat(s: @ps, pat: @ast::pat, refutable: bool) {
           print_path(s, path, true);
           match sub {
               Some(p) => {
-                  word(s.s, ~"@");
+                  word(s.s, "@");
                   print_pat(s, p, refutable);
               }
               None => ()
@@ -1548,7 +1548,7 @@ pub fn print_pat(s: @ps, pat: @ast::pat, refutable: bool) {
       ast::pat_enum(path, ref args_) => {
         print_path(s, path, true);
         match *args_ {
-          None => word(s.s, ~"(*)"),
+          None => word(s.s, "(*)"),
           Some(ref args) => {
             if !args.is_empty() {
               popen(s);
@@ -1561,11 +1561,11 @@ pub fn print_pat(s: @ps, pat: @ast::pat, refutable: bool) {
       }
       ast::pat_struct(path, ref fields, etc) => {
         print_path(s, path, true);
-        word(s.s, ~"{");
+        word(s.s, "{");
         fn print_field(s: @ps, f: ast::field_pat, refutable: bool) {
             cbox(s, indent_unit);
             print_ident(s, f.ident);
-            word_space(s, ~":");
+            word_space(s, ":");
             print_pat(s, f.pat, refutable);
             end(s);
         }
@@ -1574,53 +1574,53 @@ pub fn print_pat(s: @ps, pat: @ast::pat, refutable: bool) {
                       |s, f| print_field(s,f,refutable),
                       get_span);
         if etc {
-            if fields.len() != 0u { word_space(s, ~","); }
-            word(s.s, ~"_");
+            if fields.len() != 0u { word_space(s, ","); }
+            word(s.s, "_");
         }
-        word(s.s, ~"}");
+        word(s.s, "}");
       }
       ast::pat_tup(ref elts) => {
         popen(s);
         commasep(s, inconsistent, *elts, |s, p| print_pat(s, p, refutable));
         if elts.len() == 1 {
-            word(s.s, ~",");
+            word(s.s, ",");
         }
         pclose(s);
       }
       ast::pat_box(inner) => {
-          word(s.s, ~"@");
+          word(s.s, "@");
           print_pat(s, inner, refutable);
       }
       ast::pat_uniq(inner) => {
-          word(s.s, ~"~");
+          word(s.s, "~");
           print_pat(s, inner, refutable);
       }
       ast::pat_region(inner) => {
-          word(s.s, ~"&");
+          word(s.s, "&");
           print_pat(s, inner, refutable);
       }
       ast::pat_lit(e) => print_expr(s, e),
       ast::pat_range(begin, end) => {
         print_expr(s, begin);
         space(s.s);
-        word(s.s, ~"..");
+        word(s.s, "..");
         print_expr(s, end);
       }
       ast::pat_vec(ref before, slice, ref after) => {
-        word(s.s, ~"[");
+        word(s.s, "[");
         do commasep(s, inconsistent, *before) |s, p| {
             print_pat(s, p, refutable);
         }
         for slice.each |&p| {
-            if !before.is_empty() { word_space(s, ~","); }
-            word(s.s, ~"..");
+            if !before.is_empty() { word_space(s, ","); }
+            word(s.s, "..");
             print_pat(s, p, refutable);
-            if !after.is_empty() { word_space(s, ~","); }
+            if !after.is_empty() { word_space(s, ","); }
         }
         do commasep(s, inconsistent, *after) |s, p| {
             print_pat(s, p, refutable);
         }
-        word(s.s, ~"]");
+        word(s.s, "]");
       }
     }
     (s.ann.post)(ann_node);
@@ -1634,18 +1634,18 @@ pub fn explicit_self_to_str(explicit_self: ast::explicit_self_, intr: @ident_int
 pub fn print_explicit_self(s: @ps, explicit_self: ast::explicit_self_) -> bool {
     match explicit_self {
         ast::sty_static => { return false; }
-        ast::sty_value => { word(s.s, ~"self"); }
+        ast::sty_value => { word(s.s, "self"); }
         ast::sty_region(lt, m) => {
-            word(s.s, ~"&");
+            word(s.s, "&");
             print_opt_lifetime(s, lt);
             print_mutability(s, m);
-            word(s.s, ~"self");
+            word(s.s, "self");
         }
         ast::sty_box(m) => {
-            word(s.s, ~"@"); print_mutability(s, m); word(s.s, ~"self");
+            word(s.s, "@"); print_mutability(s, m); word(s.s, "self");
         }
         ast::sty_uniq(m) => {
-            word(s.s, ~"~"); print_mutability(s, m); word(s.s, ~"self");
+            word(s.s, "~"); print_mutability(s, m); word(s.s, "self");
         }
     }
     return true;
@@ -1659,7 +1659,7 @@ pub fn print_fn(s: @ps,
                 generics: &ast::Generics,
                 opt_explicit_self: Option<ast::explicit_self_>,
                 vis: ast::visibility) {
-    head(s, ~"");
+    head(s, "");
     print_fn_header_info(s, opt_explicit_self, purity, abis, ast::Many, None, vis);
     nbsp(s);
     print_ident(s, name);
@@ -1678,7 +1678,7 @@ pub fn print_fn_args(s: @ps, decl: &ast::fn_decl,
     }
 
     for decl.inputs.each |arg| {
-        if first { first = false; } else { word_space(s, ~","); }
+        if first { first = false; } else { word_space(s, ","); }
         print_arg(s, *arg);
     }
 
@@ -1696,22 +1696,22 @@ pub fn print_fn_args_and_ret(s: @ps, decl: &ast::fn_decl,
         ast::ty_nil => {}
         _ => {
             space_if_not_bol(s);
-            word_space(s, ~"->");
+            word_space(s, "->");
             print_type(s, decl.output);
         }
     }
 }
 
 pub fn print_fn_block_args(s: @ps, decl: &ast::fn_decl) {
-    word(s.s, ~"|");
+    word(s.s, "|");
     print_fn_args(s, decl, None);
-    word(s.s, ~"|");
+    word(s.s, "|");
 
     match decl.output.node {
         ast::ty_infer => {}
         _ => {
             space_if_not_bol(s);
-            word_space(s, ~"->");
+            word_space(s, "->");
             print_type(s, decl.output);
         }
     }
@@ -1721,33 +1721,33 @@ pub fn print_fn_block_args(s: @ps, decl: &ast::fn_decl) {
 
 pub fn print_bounds(s: @ps, bounds: @OptVec<ast::TyParamBound>) {
     if !bounds.is_empty() {
-        word(s.s, ~":");
+        word(s.s, ":");
         let mut first = true;
         for bounds.each |bound| {
             nbsp(s);
             if first {
                 first = false;
             } else {
-                word_space(s, ~"+");
+                word_space(s, "+");
             }
 
             match *bound {
                 TraitTyParamBound(tref) => print_trait_ref(s, tref),
-                RegionTyParamBound => word(s.s, ~"'static"),
+                RegionTyParamBound => word(s.s, "'static"),
             }
         }
     }
 }
 
 pub fn print_lifetime(s: @ps, lifetime: &ast::Lifetime) {
-    word(s.s, ~"'");
+    word(s.s, "'");
     print_ident(s, lifetime.ident);
 }
 
 pub fn print_generics(s: @ps, generics: &ast::Generics) {
     let total = generics.lifetimes.len() + generics.ty_params.len();
     if total > 0 {
-        word(s.s, ~"<");
+        word(s.s, "<");
         fn print_item(s: @ps, generics: &ast::Generics, idx: uint) {
             if idx < generics.lifetimes.len() {
                 let lifetime = generics.lifetimes.get(idx);
@@ -1767,7 +1767,7 @@ pub fn print_generics(s: @ps, generics: &ast::Generics) {
 
         commasep(s, inconsistent, ints,
                  |s, i| print_item(s, generics, i));
-        word(s.s, ~">");
+        word(s.s, ">");
     }
 }
 
@@ -1777,7 +1777,7 @@ pub fn print_meta_item(s: @ps, item: @ast::meta_item) {
       ast::meta_word(name) => word(s.s, *name),
       ast::meta_name_value(name, value) => {
         word_space(s, *name);
-        word_space(s, ~"=");
+        word_space(s, "=");
         print_literal(s, @value);
       }
       ast::meta_list(name, ref items) => {
@@ -1801,23 +1801,23 @@ pub fn print_view_path(s: @ps, vp: @ast::view_path) {
         if path.idents[path.idents.len()-1u] != ident {
             print_ident(s, ident);
             space(s.s);
-            word_space(s, ~"=");
+            word_space(s, "=");
         }
         print_path(s, path, false);
       }
 
       ast::view_path_glob(path, _) => {
         print_path(s, path, false);
-        word(s.s, ~"::*");
+        word(s.s, "::*");
       }
 
       ast::view_path_list(path, ref idents, _) => {
         print_path(s, path, false);
-        word(s.s, ~"::{");
+        word(s.s, "::{");
         do commasep(s, inconsistent, (*idents)) |s, w| {
             print_ident(s, w.node.name);
         }
-        word(s.s, ~"}");
+        word(s.s, "}");
       }
     }
 }
@@ -1833,7 +1833,7 @@ pub fn print_view_item(s: @ps, item: @ast::view_item) {
     print_visibility(s, item.vis);
     match item.node {
         ast::view_item_extern_mod(id, ref mta, _) => {
-            head(s, ~"extern mod");
+            head(s, "extern mod");
             print_ident(s, id);
             if !mta.is_empty() {
                 popen(s);
@@ -1843,19 +1843,19 @@ pub fn print_view_item(s: @ps, item: @ast::view_item) {
         }
 
         ast::view_item_use(ref vps) => {
-            head(s, ~"use");
+            head(s, "use");
             print_view_paths(s, *vps);
         }
     }
-    word(s.s, ~";");
+    word(s.s, ";");
     end(s); // end inner head-block
     end(s); // end outer head-block
 }
 
 pub fn print_mutability(s: @ps, mutbl: ast::mutability) {
     match mutbl {
-      ast::m_mutbl => word_nbsp(s, ~"mut"),
-      ast::m_const => word_nbsp(s, ~"const"),
+      ast::m_mutbl => word_nbsp(s, "mut"),
+      ast::m_const => word_nbsp(s, "const"),
       ast::m_imm => {/* nothing */ }
     }
 }
@@ -1868,7 +1868,7 @@ pub fn print_mt(s: @ps, mt: &ast::mt) {
 pub fn print_arg(s: @ps, input: ast::arg) {
     ibox(s, indent_unit);
     if input.is_mutbl {
-        word_space(s, ~"mut");
+        word_space(s, "mut");
     }
     match input.ty.node {
       ast::ty_infer => print_irrefutable_pat(s, input.pat),
@@ -1881,7 +1881,7 @@ pub fn print_arg(s: @ps, input: ast::arg) {
             }
             _ => {
                 print_irrefutable_pat(s, input.pat);
-                word(s.s, ~":");
+                word(s.s, ":");
                 space(s.s);
             }
         }
@@ -1910,8 +1910,8 @@ pub fn print_ty_fn(s: @ps,
     print_opt_lifetime(s, opt_region);
     print_purity(s, purity);
     print_onceness(s, onceness);
-    word(s.s, ~"fn");
-    match id { Some(id) => { word(s.s, ~" "); print_ident(s, id); } _ => () }
+    word(s.s, "fn");
+    match id { Some(id) => { word(s.s, " "); print_ident(s, id); } _ => () }
     match generics { Some(g) => print_generics(s, g), _ => () }
     zerobreak(s.s);
 
@@ -1924,7 +1924,7 @@ pub fn print_ty_fn(s: @ps,
         first = !print_explicit_self(s, *explicit_self);
     }
     for decl.inputs.each |arg| {
-        if first { first = false; } else { word_space(s, ~","); }
+        if first { first = false; } else { word_space(s, ","); }
         print_arg(s, *arg);
     }
     end(s);
@@ -1937,8 +1937,8 @@ pub fn print_ty_fn(s: @ps,
         _ => {
             space_if_not_bol(s);
             ibox(s, indent_unit);
-            word_space(s, ~"->");
-            if decl.cf == ast::noreturn { word_nbsp(s, ~"!"); }
+            word_space(s, "->");
+            if decl.cf == ast::noreturn { word_nbsp(s, "!"); }
             else { print_type(s, decl.output); }
             end(s);
         }
@@ -2024,9 +2024,9 @@ pub fn print_literal(s: @ps, lit: @ast::lit) {
         word(s.s, *f + ast_util::float_ty_to_str(t));
       }
       ast::lit_float_unsuffixed(f) => word(s.s, *f),
-      ast::lit_nil => word(s.s, ~"()"),
+      ast::lit_nil => word(s.s, "()"),
       ast::lit_bool(val) => {
-        if val { word(s.s, ~"true"); } else { word(s.s, ~"false"); }
+        if val { word(s.s, "true"); } else { word(s.s, "false"); }
       }
     }
 }
@@ -2082,7 +2082,7 @@ pub fn print_comment(s: @ps, cmnt: &comments::cmnt) {
         }
       }
       comments::trailing => {
-        word(s.s, ~" ");
+        word(s.s, " ");
         if cmnt.lines.len() == 1u {
             word(s.s, cmnt.lines[0]);
             hardbreak(s.s);
@@ -2109,9 +2109,9 @@ pub fn print_comment(s: @ps, cmnt: &comments::cmnt) {
 }
 
 pub fn print_string(s: @ps, st: &str) {
-    word(s.s, ~"\"");
+    word(s.s, "\"");
     word(s.s, str::escape_default(st));
-    word(s.s, ~"\"");
+    word(s.s, "\"");
 }
 
 pub fn to_str<T: Copy>(t: T, f: @fn(@ps, T), intr: @ident_interner) -> ~str {
@@ -2146,7 +2146,7 @@ pub fn print_opt_purity(s: @ps, opt_purity: Option<ast::purity>) {
 pub fn print_extern_opt_abis(s: @ps, opt_abis: Option<AbiSet>) {
     match opt_abis {
         Some(abis) => {
-            word_nbsp(s, ~"extern");
+            word_nbsp(s, "extern");
             word_nbsp(s, abis.to_str());
         }
         None => {}
@@ -2155,9 +2155,9 @@ pub fn print_extern_opt_abis(s: @ps, opt_abis: Option<AbiSet>) {
 
 pub fn print_opt_sigil(s: @ps, opt_sigil: Option<ast::Sigil>) {
     match opt_sigil {
-        Some(ast::BorrowedSigil) => { word(s.s, ~"&"); }
-        Some(ast::OwnedSigil) => { word(s.s, ~"~"); }
-        Some(ast::ManagedSigil) => { word(s.s, ~"@"); }
+        Some(ast::BorrowedSigil) => { word(s.s, "&"); }
+        Some(ast::OwnedSigil) => { word(s.s, "~"); }
+        Some(ast::ManagedSigil) => { word(s.s, "@"); }
         None => {}
     };
 }
@@ -2172,7 +2172,7 @@ pub fn print_fn_header_info(s: @ps,
     word(s.s, visibility_qualified(vis, ~""));
 
     if abis != AbiSet::Rust() {
-        word_nbsp(s, ~"extern");
+        word_nbsp(s, "extern");
         word_nbsp(s, abis.to_str());
 
         if opt_purity != Some(ast::extern_fn) {
@@ -2183,7 +2183,7 @@ pub fn print_fn_header_info(s: @ps,
     }
 
     print_onceness(s, onceness);
-    word(s.s, ~"fn");
+    word(s.s, "fn");
     print_opt_sigil(s, opt_sigil);
 }
 
@@ -2219,7 +2219,7 @@ pub fn print_purity(s: @ps, p: ast::purity) {
 
 pub fn print_onceness(s: @ps, o: ast::Onceness) {
     match o {
-        ast::Once => { word_nbsp(s, ~"once"); }
+        ast::Once => { word_nbsp(s, "once"); }
         ast::Many => {}
     }
 }

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -55,8 +55,8 @@ fn main() {
     cal(foo::Point{x:3, y:9});
     let a = 3;
     ignore(a);
-    io::stdout().write_str(~"a");
-    let _a = do map(~[2]) |&x| {
+    io::stdout().write_str("a");
+    let _a = do map([2]) |&x| {
       x + 2
     };
 }


### PR DESCRIPTION
This adds a lint mode for detecting unnecessary allocations on the heap. This isn't super fancy, currently it only has two rules
1. For a function's arguments, if you allocate a `[~|@]str` literal, when the type of the argument is a `&str`, emit a warning.
2. For the same case, emit warnings for boxed vectors when slices are required.

After adding the lint, I rampaged through the libraries and removed all the unnecessary allocations I could find.
