### PR TITLE
Correctly track the source of imports with the same name

### DIFF
--- a/src/libcore/vec.rs
+++ b/src/libcore/vec.rs
@@ -22,7 +22,7 @@ use old_iter;
 use iterator::Iterator;
 use kinds::Copy;
 use libc;
-use old_iter::{BaseIter, CopyableIter};
+use old_iter::CopyableIter;
 use option::{None, Option, Some};
 use ptr::to_unsafe_ptr;
 use ptr;

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1818,6 +1818,10 @@ pub impl Resolver {
                         debug!("(building import directive) bumping \
                                 reference");
                         resolution.outstanding_references += 1;
+
+                        // the source of this name is different now
+                        resolution.privacy = privacy;
+                        resolution.id = id;
                     }
                     None => {
                         debug!("(building import directive) creating new");

--- a/src/test/compile-fail/lint-unused-import-tricky-names.rs
+++ b/src/test/compile-fail/lint-unused-import-tricky-names.rs
@@ -1,0 +1,29 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deny(unused_imports)];
+
+// Regression test for issue #6633
+
+use foo::name::name; //~ ERROR: unused import
+use foo::name;
+
+pub mod foo {
+    pub mod name {
+        pub type a = int;
+        pub mod name {
+            pub type a = float;
+        }
+    }
+}
+
+fn bar() -> name::a { 1 }
+
+fn main(){}


### PR DESCRIPTION
Resolves #6633 and removes an unnecessary import in libcore
