### PR TITLE
fix mips stack alignment

### DIFF
--- a/src/libcore/rt/context.rs
+++ b/src/libcore/rt/context.rs
@@ -183,7 +183,9 @@ fn new_regs() -> ~Registers { ~([0, .. 32]) }
 
 #[cfg(target_arch = "mips")]
 fn initialize_call_frame(regs: &mut Registers, fptr: *c_void, arg: *c_void, sp: *mut uint) {
-    let sp = mut_offset(sp, -1);
+    let sp = align_down(sp);
+    // sp of mips o32 is 8-byte aligned
+    let sp = mut_offset(sp, -2);
 
     // The final return address. 0 indicates the bottom of the stack
     unsafe { *sp = 0; }

--- a/src/rt/arch/mips/context.cpp
+++ b/src/rt/arch/mips/context.cpp
@@ -34,9 +34,11 @@ void context::call(void *f, void *arg, void *stack)
 
   // set up the stack
   uint32_t *sp = (uint32_t *)stack;
-  //sp = align_down(sp);
+  sp = align_down(sp);
   // The final return address. 0 indicates the bottom of the stack
-  *--sp = 0;
+  // sp of mips o32 is 8-byte aligned
+  sp -= 2;
+  *sp = 0;
 
   regs.data[4] = (uint32_t)arg;
   regs.data[29] = (uint32_t)sp;


### PR DESCRIPTION
Results of libcore and libstd tests

```
failures:
    rand::tests::test_rng_seeded_custom_seed2
    time::tests::run_tests
    uv_ll::test::test_uv_ll_struct_size_addrinfo
    uv_ll::test::test_uv_ll_struct_size_uv_timer_t

segfaults:
    stackwalk::test_simple
    stackwalk::test_simple_deep
```
