### PR TITLE
rustc: Don't generate code for unreachable expressions

### DIFF
--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -499,6 +499,10 @@ fn trans_rvalue_stmt_unadjusted(bcx: block, expr: @ast::expr) -> block {
     let mut bcx = bcx;
     let _icx = bcx.insn_ctxt("trans_rvalue_stmt");
 
+    if bcx.unreachable {
+        return bcx;
+    }
+
     trace_span!(bcx, expr.span, @shorten(bcx.expr_to_str(expr)));
 
     match expr.node {

--- a/src/test/run-pass/issue-5741.rs
+++ b/src/test/run-pass/issue-5741.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    return;
+    while io::stdin().read_line() != ~"quit" { };
+}


### PR DESCRIPTION
r? @nikomatsakis The way we deal with unreachable expressions in trans is pretty ad hoc,
but this at least doesn't make it worse, and eliminates the LLVM
assertion failure reported in #5741.
