### PR TITLE
fix arm stack alignment

### DIFF
--- a/src/libcore/rt/context.rs
+++ b/src/libcore/rt/context.rs
@@ -165,7 +165,9 @@ fn new_regs() -> ~Registers { ~([0, .. 32]) }
 
 #[cfg(target_arch = "arm")]
 fn initialize_call_frame(regs: &mut Registers, fptr: *c_void, arg: *c_void, sp: *mut uint) {
-    let sp = mut_offset(sp, -1);
+    let sp = align_down(sp);
+    // sp of arm eabi is 8-byte aligned
+    let sp = mut_offset(sp, -2);
 
     // The final return address. 0 indicates the bottom of the stack
     unsafe { *sp = 0; }

--- a/src/rt/arch/arm/context.cpp
+++ b/src/rt/arch/arm/context.cpp
@@ -26,9 +26,11 @@ void context::call(void *f, void *arg, void *stack)
 
   // set up the stack
   uint32_t *sp = ( uint32_t *)stack;
-  //sp = align_down(sp);
+  sp = align_down(sp);
   // The final return address. 0 indicates the bottom of the stack
-  *--sp = 0;
+  // sp of arm eabi is 8-byte aligned
+  sp -= 2;
+  *sp = 0;
 
   regs.data[0] = ( uint32_t )arg; // r0
   regs.data[13] = ( uint32_t )sp; //#52 sp, r13


### PR DESCRIPTION
This fixes segmentation fault of new rt tests.
For example

```
use core::rt::test::*;
use core::rt::comm::*;
use core::cell::Cell;

fn main() {
    do run_in_newsched_task {
        let (port, chan) = oneshot::<~int>();
        let port_cell = Cell(port);
        do spawntask_immediately {
            assert!(port_cell.take().recv() == ~10);
        }
        chan.send(~10);
    }
}
```
