### PR TITLE
Implement static_assert attribute

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1426,6 +1426,7 @@ names are effectively reserved. Some significant attributes include:
 by the compiler can be found via `rustc -W help`.
 * The `deriving` attribute, for automatically generating
   implementations of certain traits.
+* The `static_assert` attribute, for asserting that a static bool is true at compiletime
 
 Other attributes may be added or removed during development of the language.
 

--- a/src/test/compile-fail/static-assert.rs
+++ b/src/test/compile-fail/static-assert.rs
@@ -1,0 +1,5 @@
+#[static_assert]
+static a: bool = false; //~ ERROR static assertion failed
+
+fn main() {
+}

--- a/src/test/compile-fail/static-assert2.rs
+++ b/src/test/compile-fail/static-assert2.rs
@@ -1,0 +1,4 @@
+#[static_assert]
+static e: bool = 1 == 2; //~ ERROR static assertion failed
+
+fn main() {}

--- a/src/test/run-pass/static-assert.rs
+++ b/src/test/run-pass/static-assert.rs
@@ -1,0 +1,14 @@
+#[static_assert]
+static b: bool = true;
+
+#[static_assert]
+static c: bool = 1 == 1;
+
+#[static_assert]
+static d: bool = 1 != 2;
+
+#[static_assert]
+static f: bool = (4/2) == 2;
+
+fn main() {
+}


### PR DESCRIPTION
This verifies that a static item evaluates to true, at compile time.
