### PR TITLE
declare that "///" is still a doc comment, just not "////+" (fixes #5838)

### DIFF
--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -247,7 +247,8 @@ fn consume_whitespace_and_comments(rdr: @mut StringReader)
 }
 
 pub fn is_line_non_doc_comment(s: &str) -> bool {
-    s.trim_right().all(|ch| ch == '/')
+    let s = s.trim_right();
+    s.len() > 3 && s.all(|ch| ch == '/')
 }
 
 // PRECONDITION: rdr.curr is not whitespace
@@ -268,7 +269,7 @@ fn consume_any_line_comment(rdr: @mut StringReader)
                     str::push_char(&mut acc, rdr.curr);
                     bump(rdr);
                 }
-                // but comments with only "/"s are not
+                // but comments with only more "/"s are not
                 if !is_line_non_doc_comment(acc) {
                     return Some(TokenAndSpan{
                         tok: token::DOC_COMMENT(rdr.interner.intern(acc)),
@@ -890,5 +891,11 @@ mod test {
             env.string_reader.next_token();
         let id = env.interner.intern("abc");
         assert_eq!(tok, token::LIFETIME(id));
+    }
+
+    #[test] fn line_doc_comments() {
+        assert!(!is_line_non_doc_comment("///"));
+        assert!(!is_line_non_doc_comment("/// blah"));
+        assert!(is_line_non_doc_comment("////"));
     }
 }


### PR DESCRIPTION
There's currently a function in the lexer that rejects a line comment that is all slashes from being a doc comment. I think the intention was that you could draw boxes,

```
/////////////
// like so //
/////////////
```

Since a line doc comment split up over multiple paragraphs will have a "blank" line that is just /// between the paragraphs, that would get mistaken for a box segment, lexed as a regular comment, and go missing from the sequence of doc comment attributes before they were reassembled by rustdoc into markdown input.

I figure the best plan here is to just declare that a comment that is exactly `///` is a doc comment after all, and to only omit comments with four slashes or more, which is what this commit implements. Can't really draw boxes that narrow, anyway.
