### PR TITLE
core: Fail with a better error message when list_dir gets an empty path

### DIFF
--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -675,7 +675,7 @@ pub fn mkdir_recursive(p: &Path, mode: c_int) -> bool {
 /// Lists the contents of a directory
 #[allow(non_implicitly_copyable_typarams)]
 pub fn list_dir(p: &Path) -> ~[~str] {
-    if p.components.is_empty() {
+    if p.components.is_empty() && !p.is_absolute() {
         // Not sure what the right behavior is here, but this
         // prevents a bounds check failure later
         return ~[];
@@ -1606,6 +1606,20 @@ mod tests {
         let dirs = os::list_dir(&Path(""));
         assert!(dirs.is_empty());
     }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn list_dir_root() {
+        let dirs = os::list_dir(&Path("/"));
+        assert!(dirs.len() > 1);
+    }
+    #[test]
+    #[cfg(windows)]
+    fn list_dir_root() {
+        let dirs = os::list_dir(&Path("C:\\"));
+        assert!(dirs.len() > 1);
+    }
+
 
     #[test]
     fn path_is_dir() {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -675,6 +675,11 @@ pub fn mkdir_recursive(p: &Path, mode: c_int) -> bool {
 /// Lists the contents of a directory
 #[allow(non_implicitly_copyable_typarams)]
 pub fn list_dir(p: &Path) -> ~[~str] {
+    if p.components.is_empty() {
+        // Not sure what the right behavior is here, but this
+        // prevents a bounds check failure later
+        return ~[];
+    }
     unsafe {
         #[cfg(target_os = "linux")]
         #[cfg(target_os = "android")]
@@ -1594,6 +1599,12 @@ mod tests {
         for dirs.each |dir| {
             debug!(copy *dir);
         }
+    }
+
+    #[test]
+    fn list_dir_empty_path() {
+        let dirs = os::list_dir(&Path(""));
+        assert!(dirs.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
r? @brson (Yes, this did happen in real life...)
