### PR TITLE
Cleanup warnings

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1480,7 +1480,6 @@ This code creates a closure that adds a given string to its argument,
 returns it from a function, and then calls it:
 
 ~~~~
-# extern mod std;
 fn mk_appender(suffix: ~str) -> @fn(~str) -> ~str {
     // The compiler knows that we intend this closure to be of type @fn
     return |s| s + suffix;
@@ -2292,7 +2291,7 @@ let nonsense = mycircle.radius() * mycircle.area();
 
 ## Deriving implementations for traits
 
-A small number of traits in `std` and `std` can have implementations
+A small number of traits in `std` and `extra` can have implementations
 that can be automatically derived. These instances are specified by
 placing the `deriving` attribute on a data type declaration. For
 example, the following will mean that `Circle` has an implementation
@@ -2541,9 +2540,9 @@ as well as an inscrutable string of alphanumerics. These are both
 part of Rust's library versioning scheme. The alphanumerics are
 a hash representing the crate metadata.
 
-## The std library
+## The standard library
 
-The Rust std library provides runtime features required by the language,
+The Rust standard library provides runtime features required by the language,
 including the task scheduler and memory allocators, as well as library
 support for Rust built-in types, platform abstractions, and other commonly
 used features.
@@ -2559,7 +2558,7 @@ I/O abstractions ([`io`]), [containers] like [`hashmap`],
 common traits ([`kinds`], [`ops`], [`cmp`], [`num`],
 [`to_str`], [`clone`]), and complete bindings to the C standard library ([`libc`]).
 
-### Core injection and the Rust prelude
+### Standard Library injection and the Rust prelude
 
 `std` is imported at the topmost level of every crate by default, as
 if the first line of each crate was
@@ -2571,7 +2570,7 @@ with the `std::` path prefix, as in `use std::vec`, `use std::task::spawn`,
 etc.
 
 Additionally, `std` contains a `prelude` module that reexports many of the
-most common std modules, types and traits. The contents of the prelude are
+most common standard modules, types and traits. The contents of the prelude are
 imported into every *module* by default.  Implicitly, all modules behave as if
 they contained the following prologue:
 

--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -50,20 +50,20 @@ pub fn main() {
 
 pub fn parse_config(args: ~[~str]) -> config {
     let opts =
-        ~[getopts::reqopt(~"compile-lib-path"),
-          getopts::reqopt(~"run-lib-path"),
-          getopts::reqopt(~"rustc-path"), getopts::reqopt(~"src-base"),
-          getopts::reqopt(~"build-base"), getopts::reqopt(~"aux-base"),
-          getopts::reqopt(~"stage-id"),
-          getopts::reqopt(~"mode"), getopts::optflag(~"ignored"),
-          getopts::optopt(~"runtool"), getopts::optopt(~"rustcflags"),
-          getopts::optflag(~"verbose"),
-          getopts::optopt(~"logfile"),
-          getopts::optflag(~"jit"),
-          getopts::optflag(~"newrt"),
-          getopts::optopt(~"target"),
-          getopts::optopt(~"adb-path"),
-          getopts::optopt(~"adb-test-dir")
+        ~[getopts::reqopt("compile-lib-path"),
+          getopts::reqopt("run-lib-path"),
+          getopts::reqopt("rustc-path"), getopts::reqopt("src-base"),
+          getopts::reqopt("build-base"), getopts::reqopt("aux-base"),
+          getopts::reqopt("stage-id"),
+          getopts::reqopt("mode"), getopts::optflag("ignored"),
+          getopts::optopt("runtool"), getopts::optopt("rustcflags"),
+          getopts::optflag("verbose"),
+          getopts::optopt("logfile"),
+          getopts::optflag("jit"),
+          getopts::optflag("newrt"),
+          getopts::optopt("target"),
+          getopts::optopt("adb-path"),
+          getopts::optopt("adb-test-dir")
          ];
 
     assert!(!args.is_empty());
@@ -74,43 +74,43 @@ pub fn parse_config(args: ~[~str]) -> config {
           Err(f) => fail!(getopts::fail_str(f))
         };
 
-    fn opt_path(m: &getopts::Matches, nm: ~str) -> Path {
+    fn opt_path(m: &getopts::Matches, nm: &str) -> Path {
         Path(getopts::opt_str(m, nm))
     }
 
     config {
-        compile_lib_path: getopts::opt_str(matches, ~"compile-lib-path"),
-        run_lib_path: getopts::opt_str(matches, ~"run-lib-path"),
-        rustc_path: opt_path(matches, ~"rustc-path"),
-        src_base: opt_path(matches, ~"src-base"),
-        build_base: opt_path(matches, ~"build-base"),
-        aux_base: opt_path(matches, ~"aux-base"),
-        stage_id: getopts::opt_str(matches, ~"stage-id"),
-        mode: str_mode(getopts::opt_str(matches, ~"mode")),
-        run_ignored: getopts::opt_present(matches, ~"ignored"),
+        compile_lib_path: getopts::opt_str(matches, "compile-lib-path"),
+        run_lib_path: getopts::opt_str(matches, "run-lib-path"),
+        rustc_path: opt_path(matches, "rustc-path"),
+        src_base: opt_path(matches, "src-base"),
+        build_base: opt_path(matches, "build-base"),
+        aux_base: opt_path(matches, "aux-base"),
+        stage_id: getopts::opt_str(matches, "stage-id"),
+        mode: str_mode(getopts::opt_str(matches, "mode")),
+        run_ignored: getopts::opt_present(matches, "ignored"),
         filter:
              if vec::len(matches.free) > 0u {
                  option::Some(copy matches.free[0])
              } else { option::None },
-        logfile: getopts::opt_maybe_str(matches, ~"logfile").map(|s| Path(*s)),
-        runtool: getopts::opt_maybe_str(matches, ~"runtool"),
-        rustcflags: getopts::opt_maybe_str(matches, ~"rustcflags"),
-        jit: getopts::opt_present(matches, ~"jit"),
-        newrt: getopts::opt_present(matches, ~"newrt"),
-        target: opt_str2(getopts::opt_maybe_str(matches, ~"target")).to_str(),
-        adb_path: opt_str2(getopts::opt_maybe_str(matches, ~"adb-path")).to_str(),
+        logfile: getopts::opt_maybe_str(matches, "logfile").map(|s| Path(*s)),
+        runtool: getopts::opt_maybe_str(matches, "runtool"),
+        rustcflags: getopts::opt_maybe_str(matches, "rustcflags"),
+        jit: getopts::opt_present(matches, "jit"),
+        newrt: getopts::opt_present(matches, "newrt"),
+        target: opt_str2(getopts::opt_maybe_str(matches, "target")).to_str(),
+        adb_path: opt_str2(getopts::opt_maybe_str(matches, "adb-path")).to_str(),
         adb_test_dir:
-            opt_str2(getopts::opt_maybe_str(matches, ~"adb-test-dir")).to_str(),
+            opt_str2(getopts::opt_maybe_str(matches, "adb-test-dir")).to_str(),
         adb_device_status:
-            if (opt_str2(getopts::opt_maybe_str(matches, ~"target")) ==
+            if (opt_str2(getopts::opt_maybe_str(matches, "target")) ==
                 ~"arm-linux-androideabi") {
-                if (opt_str2(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
+                if (opt_str2(getopts::opt_maybe_str(matches, "adb-test-dir")) !=
                     ~"(none)" &&
-                    opt_str2(getopts::opt_maybe_str(matches, ~"adb-test-dir")) !=
+                    opt_str2(getopts::opt_maybe_str(matches, "adb-test-dir")) !=
                     ~"") { true }
                 else { false }
             } else { false },
-        verbose: getopts::opt_present(matches, ~"verbose")
+        verbose: getopts::opt_present(matches, "verbose")
     }
 }
 

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -87,10 +87,10 @@ pub fn load_props(testfile: &Path) -> TestProps {
 
 pub fn is_test_ignored(config: &config, testfile: &Path) -> bool {
     for iter_header(testfile) |ln| {
-        if parse_name_directive(ln, ~"xfail-test") { return true; }
+        if parse_name_directive(ln, "xfail-test") { return true; }
         if parse_name_directive(ln, xfail_target()) { return true; }
         if config.mode == common::mode_pretty &&
-           parse_name_directive(ln, ~"xfail-pretty") { return true; }
+           parse_name_directive(ln, "xfail-pretty") { return true; }
     };
     return false;
 
@@ -107,8 +107,7 @@ fn iter_header(testfile: &Path, it: &fn(~str) -> bool) -> bool {
         // Assume that any directives will be found before the first
         // module or function. This doesn't seem to be an optimization
         // with a warm page cache. Maybe with a cold one.
-        if str::starts_with(ln, ~"fn")
-            || str::starts_with(ln, ~"mod") {
+        if str::starts_with(ln, "fn") || str::starts_with(ln, "mod") {
             return false;
         } else { if !(it(ln)) { return false; } }
     }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -25,7 +25,7 @@ use util::logv;
 pub fn run(config: config, testfile: ~str) {
     if config.verbose {
         // We're going to be dumping a lot of info. Start on a new line.
-        io::stdout().write_str(~"\n\n");
+        io::stdout().write_str("\n\n");
     }
     let testfile = Path(testfile);
     debug!("running %s", testfile.to_str());
@@ -231,7 +231,7 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
     // do not optimize debuginfo tests
     let mut config = match config.rustcflags {
         Some(ref flags) => config {
-            rustcflags: Some(str::replace(*flags, ~"-O", ~"")),
+            rustcflags: Some(str::replace(*flags, "-O", "")),
             .. copy *config
         },
         None => copy *config
@@ -249,19 +249,19 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
     // write debugger script
     let script_str = str::append(cmds, "\nquit\n");
     debug!("script_str = %s", script_str);
-    dump_output_file(config, testfile, script_str, ~"debugger.script");
+    dump_output_file(config, testfile, script_str, "debugger.script");
 
     // run debugger script with gdb
     #[cfg(windows)]
     fn debugger() -> ~str { ~"gdb.exe" }
     #[cfg(unix)]
     fn debugger() -> ~str { ~"gdb" }
-    let debugger_script = make_out_name(config, testfile, ~"debugger.script");
+    let debugger_script = make_out_name(config, testfile, "debugger.script");
     let debugger_opts = ~[~"-quiet", ~"-batch", ~"-nx",
                           ~"-command=" + debugger_script.to_str(),
                           make_exe_name(config, testfile).to_str()];
     let ProcArgs = ProcArgs {prog: debugger(), args: debugger_opts};
-    ProcRes = compose_and_run(config, testfile, ProcArgs, ~[], ~"", None);
+    ProcRes = compose_and_run(config, testfile, ProcArgs, ~[], "", None);
     if ProcRes.status != 0 {
         fatal(~"gdb failed to execute");
     }
@@ -368,7 +368,7 @@ fn check_expected_errors(expected_errors: ~[errors::ExpectedError],
         }
 
         // ignore this msg which gets printed at the end
-        if str::contains(line, ~"aborting due to") {
+        if str::contains(line, "aborting due to") {
             was_expected = true;
         }
 
@@ -643,7 +643,7 @@ fn program_output(config: &config, testfile: &Path, lib_path: &str, prog: ~str,
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "freebsd")]
 fn make_cmdline(_libpath: &str, prog: &str, args: &[~str]) -> ~str {
-    fmt!("%s %s", prog, str::connect(args, ~" "))
+    fmt!("%s %s", prog, str::connect(args, " "))
 }
 
 #[cfg(target_os = "win32")]
@@ -668,7 +668,7 @@ fn dump_output_file(config: &config, testfile: &Path,
                     out: &str, extension: &str) {
     let outfile = make_out_name(config, testfile, extension);
     let writer =
-        io::file_writer(&outfile, ~[io::Create, io::Truncate]).get();
+        io::file_writer(&outfile, [io::Create, io::Truncate]).get();
     writer.write_str(out);
 }
 
@@ -692,8 +692,8 @@ fn output_base_name(config: &config, testfile: &Path) -> Path {
 
 fn maybe_dump_to_stdout(config: &config, out: &str, err: &str) {
     if config.verbose {
-        let sep1 = fmt!("------%s------------------------------", ~"stdout");
-        let sep2 = fmt!("------%s------------------------------", ~"stderr");
+        let sep1 = fmt!("------%s------------------------------", "stdout");
+        let sep2 = fmt!("------%s------------------------------", "stderr");
         let sep3 = ~"------------------------------------------";
         io::stdout().write_line(sep1);
         io::stdout().write_line(out);
@@ -781,10 +781,10 @@ fn _arm_exec_compiled_test(config: &config, props: &TestProps,
     newargs_err.push(newcmd_err);
 
     let procsrv::Result{ out: out_out, err: _out_err, status: out_status } =
-            procsrv::run(~"", config.adb_path, newargs_out, ~[(~"",~"")],
+            procsrv::run("", config.adb_path, newargs_out, ~[(~"",~"")],
                          Some(~""));
     let procsrv::Result{ out: err_out, err: _err_err, status: _err_status } =
-            procsrv::run(~"", config.adb_path, newargs_err, ~[(~"",~"")],
+            procsrv::run("", config.adb_path, newargs_err, ~[(~"",~"")],
                          Some(~""));
 
     dump_output(config, testfile, out_out, err_out);
@@ -818,8 +818,8 @@ fn _arm_push_aux_shared_library(config: &config, testfile: &Path) {
 
         if (file.filetype() == Some(~".so")) {
 
-            let copy_result = procsrv::run(~"", config.adb_path,
-                ~[~"push", file.to_str(), copy config.adb_test_dir],
+            let copy_result = procsrv::run("", config.adb_path,
+                [~"push", file.to_str(), copy config.adb_test_dir],
                 ~[(~"",~"")], Some(~""));
 
             if config.verbose {

--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -12,10 +12,6 @@
 
 use core::prelude::*;
 
-use core::old_iter;
-use core::str;
-use core::vec;
-
 pub trait ToBase64 {
     fn to_base64(&self) -> ~str;
 }
@@ -242,12 +238,12 @@ mod tests {
 
     #[test]
     fn test_from_base64() {
-        assert_eq!((~"").from_base64(), str::to_bytes(~""));
-        assert!((~"Zg==").from_base64() == str::to_bytes(~"f"));
-        assert_eq!((~"Zm8=").from_base64(), str::to_bytes(~"fo"));
-        assert_eq!((~"Zm9v").from_base64(), str::to_bytes(~"foo"));
-        assert!((~"Zm9vYg==").from_base64() == str::to_bytes(~"foob"));
-        assert_eq!((~"Zm9vYmE=").from_base64(), str::to_bytes(~"fooba"))
-        assert_eq!((~"Zm9vYmFy").from_base64(), str::to_bytes(~"foobar"));
+        assert_eq!((~"").from_base64(), str::to_bytes(""));
+        assert!((~"Zg==").from_base64() == str::to_bytes("f"));
+        assert_eq!((~"Zm8=").from_base64(), str::to_bytes("fo"));
+        assert_eq!((~"Zm9v").from_base64(), str::to_bytes("foo"));
+        assert!((~"Zm9vYg==").from_base64() == str::to_bytes("foob"));
+        assert_eq!((~"Zm9vYmE=").from_base64(), str::to_bytes("fooba"))
+        assert_eq!((~"Zm9vYmFy").from_base64(), str::to_bytes("foobar"));
     }
 }

--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -10,8 +10,6 @@
 
 use core::prelude::*;
 
-use core::vec::from_elem;
-
 struct SmallBitv {
     /// only the lowest nbits of this value are used. the rest is undefined.
     bits: uint
@@ -257,7 +255,7 @@ pub impl Bitv {
             let nelems = nbits/uint::bits +
                          if nbits % uint::bits == 0 {0} else {1};
             let elem = if init {!0} else {0};
-            let s = from_elem(nelems, elem);
+            let s = vec::from_elem(nelems, elem);
             Big(~BigBitv::new(s))
         };
         Bitv {rep: rep, nbits: nbits}
@@ -502,7 +500,7 @@ impl Clone for Bitv {
             Bitv{nbits: self.nbits, rep: Small(~SmallBitv{bits: b.bits})}
           }
           Big(ref b) => {
-            let mut st = from_elem(self.nbits / uint::bits + 1, 0);
+            let mut st = vec::from_elem(self.nbits / uint::bits + 1, 0);
             let len = st.len();
             for uint::range(0, len) |i| { st[i] = b.storage[i]; };
             Bitv{nbits: self.nbits, rep: Big(~BigBitv{storage: st})}
@@ -872,17 +870,14 @@ mod tests {
 
     #[test]
     fn test_0_elements() {
-        let mut act;
-        let exp;
-        act = Bitv::new(0u, false);
-        exp = vec::from_elem::<uint>(0u, 0u);
+        let act = Bitv::new(0u, false);
+        let exp = vec::from_elem::<uint>(0u, 0u);
         assert!(act.eq_vec(exp));
     }
 
     #[test]
     fn test_1_element() {
-        let mut act;
-        act = Bitv::new(1u, false);
+        let mut act = Bitv::new(1u, false);
         assert!(act.eq_vec(~[0u]));
         act = Bitv::new(1u, true);
         assert!(act.eq_vec(~[1u]));
@@ -1488,7 +1483,7 @@ mod tests {
     #[bench]
     fn bench_bitv_big_union(b: &mut BenchHarness) {
         let mut b1 = Bitv::new(bench_bits, false);
-        let mut b2 = Bitv::new(bench_bits, false);
+        let b2 = Bitv::new(bench_bits, false);
         do b.iter {
             b1.union(&b2);
         }

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -540,13 +540,13 @@ mod tests {
 
     #[test]
     fn test_dlist_concat() {
-        let a = from_vec(~[1,2]);
-        let b = from_vec(~[3,4]);
-        let c = from_vec(~[5,6]);
-        let d = from_vec(~[7,8]);
-        let ab = from_vec(~[a,b]);
-        let cd = from_vec(~[c,d]);
-        let abcd = concat(concat(from_vec(~[ab,cd])));
+        let a = from_vec([1,2]);
+        let b = from_vec([3,4]);
+        let c = from_vec([5,6]);
+        let d = from_vec([7,8]);
+        let ab = from_vec([a,b]);
+        let cd = from_vec([c,d]);
+        let abcd = concat(concat(from_vec([ab,cd])));
         abcd.assert_consistent(); assert_eq!(abcd.len(), 8);
         abcd.assert_consistent(); assert_eq!(abcd.pop().get(), 1);
         abcd.assert_consistent(); assert_eq!(abcd.pop().get(), 2);
@@ -560,8 +560,8 @@ mod tests {
     }
     #[test]
     fn test_dlist_append() {
-        let a = from_vec(~[1,2,3]);
-        let b = from_vec(~[4,5,6]);
+        let a = from_vec([1,2,3]);
+        let b = from_vec([4,5,6]);
         a.append(b);
         assert_eq!(a.len(), 6);
         assert_eq!(b.len(), 0);
@@ -576,7 +576,7 @@ mod tests {
     }
     #[test]
     fn test_dlist_append_empty() {
-        let a = from_vec(~[1,2,3]);
+        let a = from_vec([1,2,3]);
         let b = DList::<int>();
         a.append(b);
         assert_eq!(a.len(), 3);
@@ -590,7 +590,7 @@ mod tests {
     #[test]
     fn test_dlist_append_to_empty() {
         let a = DList::<int>();
-        let b = from_vec(~[4,5,6]);
+        let b = from_vec([4,5,6]);
         a.append(b);
         assert_eq!(a.len(), 3);
         assert_eq!(b.len(), 0);
@@ -626,8 +626,8 @@ mod tests {
     }
     #[test]
     fn test_dlist_prepend() {
-        let a = from_vec(~[1,2,3]);
-        let b = from_vec(~[4,5,6]);
+        let a = from_vec([1,2,3]);
+        let b = from_vec([4,5,6]);
         b.prepend(a);
         assert_eq!(a.len(), 0);
         assert_eq!(b.len(), 6);
@@ -642,7 +642,7 @@ mod tests {
     }
     #[test]
     fn test_dlist_reverse() {
-        let a = from_vec(~[5,4,3,2,1]);
+        let a = from_vec([5,4,3,2,1]);
         a.reverse();
         assert_eq!(a.len(), 5);
         a.assert_consistent(); assert_eq!(a.pop().get(), 1);
@@ -661,7 +661,7 @@ mod tests {
     }
     #[test]
     fn test_dlist_each_node() {
-        let a = from_vec(~[1,2,4,5]);
+        let a = from_vec([1,2,4,5]);
         for a.each_node |nobe| {
             if nobe.data > 3 {
                 a.insert_before(3, nobe);
@@ -678,7 +678,7 @@ mod tests {
     }
     #[test]
     fn test_dlist_clear() {
-        let a = from_vec(~[5,4,3,2,1]);
+        let a = from_vec([5,4,3,2,1]);
         a.clear();
         assert_eq!(a.len(), 0);
         a.assert_consistent();
@@ -686,20 +686,20 @@ mod tests {
     #[test]
     fn test_dlist_is_empty() {
         let empty = DList::<int>();
-        let full1 = from_vec(~[1,2,3]);
+        let full1 = from_vec([1,2,3]);
         assert!(empty.is_empty());
         assert!(!full1.is_empty());
     }
     #[test]
     fn test_dlist_head_tail() {
-        let l = from_vec(~[1,2,3]);
+        let l = from_vec([1,2,3]);
         assert_eq!(l.head(), 1);
         assert_eq!(l.tail(), 3);
         assert_eq!(l.len(), 3);
     }
     #[test]
     fn test_dlist_pop() {
-        let l = from_vec(~[1,2,3]);
+        let l = from_vec([1,2,3]);
         assert_eq!(l.pop().get(), 1);
         assert_eq!(l.tail(), 3);
         assert_eq!(l.head(), 2);
@@ -712,7 +712,7 @@ mod tests {
     }
     #[test]
     fn test_dlist_pop_tail() {
-        let l = from_vec(~[1,2,3]);
+        let l = from_vec([1,2,3]);
         assert_eq!(l.pop_tail().get(), 3);
         assert_eq!(l.tail(), 2);
         assert_eq!(l.head(), 1);
@@ -758,7 +758,7 @@ mod tests {
     }
     #[test]
     fn test_dlist_break_early() {
-        let l = from_vec(~[1,2,3,4,5]);
+        let l = from_vec([1,2,3,4,5]);
         let mut x = 0;
         for l.each |i| {
             x += 1;

--- a/src/libextra/fileinput.rs
+++ b/src/libextra/fileinput.rs
@@ -96,8 +96,6 @@ total line count).
 
 use core::prelude::*;
 
-use core::io::ReaderUtil;
-
 /**
 A summary of the internal state of a `FileInput` object. `line_num`
 and `line_num_file` represent the number of lines read in total and in
@@ -407,7 +405,6 @@ pub fn input_vec_state(files: ~[Option<Path>],
 mod test {
     use core::prelude::*;
 
-    use core::io::WriterUtil;
     use super::{FileInput, pathify, input_vec, input_vec_state};
 
     fn make_file(path : &Path, contents: &[~str]) {
@@ -441,7 +438,7 @@ mod test {
 
         // 3 files containing 0\n, 1\n, and 2\n respectively
         for filenames.eachi |i, &filename| {
-            make_file(filename.get_ref(), ~[fmt!("%u", i)]);
+            make_file(filename.get_ref(), [fmt!("%u", i)]);
         }
 
         let fi = FileInput::from_vec(copy filenames);
@@ -471,7 +468,7 @@ mod test {
 
         // 3 files containing 1\n, 2\n, and 3\n respectively
         for filenames.eachi |i, &filename| {
-            make_file(filename.get_ref(), ~[fmt!("%u", i)]);
+            make_file(filename.get_ref(), [fmt!("%u", i)]);
         }
 
         let fi = FileInput::from_vec(filenames);
@@ -533,9 +530,9 @@ mod test {
             3,
             |i| fmt!("tmp/lib-fileinput-test-empty-files-%u.tmp", i)),true);
 
-        make_file(filenames[0].get_ref(), ~[~"1", ~"2"]);
-        make_file(filenames[1].get_ref(), ~[]);
-        make_file(filenames[2].get_ref(), ~[~"3", ~"4"]);
+        make_file(filenames[0].get_ref(), [~"1", ~"2"]);
+        make_file(filenames[1].get_ref(), []);
+        make_file(filenames[2].get_ref(), [~"3", ~"4"]);
 
         let mut count = 0;
         for input_vec_state(copy filenames) |line, state| {
@@ -580,7 +577,7 @@ mod test {
             make_file(&filename.get(), contents);
         }
 
-        let mut in = FileInput::from_vec(filenames);
+        let in = FileInput::from_vec(filenames);
 
         // read once from 0
         assert_eq!(in.read_line(), ~"0 1");

--- a/src/libextra/flate.rs
+++ b/src/libextra/flate.rs
@@ -16,12 +16,8 @@ Simple compression
 
 use core::prelude::*;
 
-use core::libc::{c_void, size_t, c_int};
 use core::libc;
-use core::vec;
-
-#[cfg(test)] use core::rand;
-#[cfg(test)] use core::rand::RngUtil;
+use core::libc::{c_void, size_t, c_int};
 
 pub mod rustrt {
     use core::libc::{c_int, c_void, size_t};
@@ -83,27 +79,34 @@ pub fn inflate_bytes(bytes: &const [u8]) -> ~[u8] {
     }
 }
 
-#[test]
-#[allow(non_implicitly_copyable_typarams)]
-fn test_flate_round_trip() {
-    let mut r = rand::rng();
-    let mut words = ~[];
-    for 20.times {
-        let range = r.gen_uint_range(1, 10);
-        words.push(r.gen_bytes(range));
-    }
-    for 20.times {
-        let mut in = ~[];
-        for 2000.times {
-            in.push_all(r.choose(words));
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::rand;
+    use core::rand::RngUtil;
+
+    #[test]
+    #[allow(non_implicitly_copyable_typarams)]
+    fn test_flate_round_trip() {
+        let mut r = rand::rng();
+        let mut words = ~[];
+        for 20.times {
+            let range = r.gen_uint_range(1, 10);
+            words.push(r.gen_bytes(range));
         }
-        debug!("de/inflate of %u bytes of random word-sequences",
-               in.len());
-        let cmp = deflate_bytes(in);
-        let out = inflate_bytes(cmp);
-        debug!("%u bytes deflated to %u (%.1f%% size)",
-               in.len(), cmp.len(),
-               100.0 * ((cmp.len() as float) / (in.len() as float)));
-        assert_eq!(in, out);
+        for 20.times {
+            let mut in = ~[];
+            for 2000.times {
+                in.push_all(r.choose(words));
+            }
+            debug!("de/inflate of %u bytes of random word-sequences",
+                   in.len());
+            let cmp = deflate_bytes(in);
+            let out = inflate_bytes(cmp);
+            debug!("%u bytes deflated to %u (%.1f%% size)",
+                   in.len(), cmp.len(),
+                   100.0 * ((cmp.len() as float) / (in.len() as float)));
+            assert_eq!(in, out);
+        }
     }
 }

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -681,12 +681,12 @@ mod tests {
     #[test]
     fn test_reqopt_long() {
         let args = ~[~"--test=20"];
-        let opts = ~[reqopt(~"test")];
+        let opts = ~[reqopt("test")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert!((opt_present(m, ~"test")));
-            assert_eq!(opt_str(m, ~"test"), ~"20");
+            assert!((opt_present(m, "test")));
+            assert_eq!(opt_str(m, "test"), ~"20");
           }
           _ => { fail!("test_reqopt_long failed"); }
         }
@@ -695,7 +695,7 @@ mod tests {
     #[test]
     fn test_reqopt_long_missing() {
         let args = ~[~"blah"];
-        let opts = ~[reqopt(~"test")];
+        let opts = ~[reqopt("test")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, OptionMissing_),
@@ -706,7 +706,7 @@ mod tests {
     #[test]
     fn test_reqopt_long_no_arg() {
         let args = ~[~"--test"];
-        let opts = ~[reqopt(~"test")];
+        let opts = ~[reqopt("test")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, ArgumentMissing_),
@@ -717,7 +717,7 @@ mod tests {
     #[test]
     fn test_reqopt_long_multi() {
         let args = ~[~"--test=20", ~"--test=30"];
-        let opts = ~[reqopt(~"test")];
+        let opts = ~[reqopt("test")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, OptionDuplicated_),
@@ -728,12 +728,12 @@ mod tests {
     #[test]
     fn test_reqopt_short() {
         let args = ~[~"-t", ~"20"];
-        let opts = ~[reqopt(~"t")];
+        let opts = ~[reqopt("t")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert!((opt_present(m, ~"t")));
-            assert_eq!(opt_str(m, ~"t"), ~"20");
+            assert!((opt_present(m, "t")));
+            assert_eq!(opt_str(m, "t"), ~"20");
           }
           _ => fail!()
         }
@@ -742,7 +742,7 @@ mod tests {
     #[test]
     fn test_reqopt_short_missing() {
         let args = ~[~"blah"];
-        let opts = ~[reqopt(~"t")];
+        let opts = ~[reqopt("t")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, OptionMissing_),
@@ -753,7 +753,7 @@ mod tests {
     #[test]
     fn test_reqopt_short_no_arg() {
         let args = ~[~"-t"];
-        let opts = ~[reqopt(~"t")];
+        let opts = ~[reqopt("t")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, ArgumentMissing_),
@@ -764,7 +764,7 @@ mod tests {
     #[test]
     fn test_reqopt_short_multi() {
         let args = ~[~"-t", ~"20", ~"-t", ~"30"];
-        let opts = ~[reqopt(~"t")];
+        let opts = ~[reqopt("t")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, OptionDuplicated_),
@@ -777,12 +777,12 @@ mod tests {
     #[test]
     fn test_optopt_long() {
         let args = ~[~"--test=20"];
-        let opts = ~[optopt(~"test")];
+        let opts = ~[optopt("test")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert!((opt_present(m, ~"test")));
-            assert_eq!(opt_str(m, ~"test"), ~"20");
+            assert!((opt_present(m, "test")));
+            assert_eq!(opt_str(m, "test"), ~"20");
           }
           _ => fail!()
         }
@@ -791,10 +791,10 @@ mod tests {
     #[test]
     fn test_optopt_long_missing() {
         let args = ~[~"blah"];
-        let opts = ~[optopt(~"test")];
+        let opts = ~[optopt("test")];
         let rs = getopts(args, opts);
         match rs {
-          Ok(ref m) => assert!(!opt_present(m, ~"test")),
+          Ok(ref m) => assert!(!opt_present(m, "test")),
           _ => fail!()
         }
     }
@@ -802,7 +802,7 @@ mod tests {
     #[test]
     fn test_optopt_long_no_arg() {
         let args = ~[~"--test"];
-        let opts = ~[optopt(~"test")];
+        let opts = ~[optopt("test")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, ArgumentMissing_),
@@ -813,7 +813,7 @@ mod tests {
     #[test]
     fn test_optopt_long_multi() {
         let args = ~[~"--test=20", ~"--test=30"];
-        let opts = ~[optopt(~"test")];
+        let opts = ~[optopt("test")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, OptionDuplicated_),
@@ -824,12 +824,12 @@ mod tests {
     #[test]
     fn test_optopt_short() {
         let args = ~[~"-t", ~"20"];
-        let opts = ~[optopt(~"t")];
+        let opts = ~[optopt("t")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert!((opt_present(m, ~"t")));
-            assert_eq!(opt_str(m, ~"t"), ~"20");
+            assert!((opt_present(m, "t")));
+            assert_eq!(opt_str(m, "t"), ~"20");
           }
           _ => fail!()
         }
@@ -838,10 +838,10 @@ mod tests {
     #[test]
     fn test_optopt_short_missing() {
         let args = ~[~"blah"];
-        let opts = ~[optopt(~"t")];
+        let opts = ~[optopt("t")];
         let rs = getopts(args, opts);
         match rs {
-          Ok(ref m) => assert!(!opt_present(m, ~"t")),
+          Ok(ref m) => assert!(!opt_present(m, "t")),
           _ => fail!()
         }
     }
@@ -849,7 +849,7 @@ mod tests {
     #[test]
     fn test_optopt_short_no_arg() {
         let args = ~[~"-t"];
-        let opts = ~[optopt(~"t")];
+        let opts = ~[optopt("t")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, ArgumentMissing_),
@@ -860,7 +860,7 @@ mod tests {
     #[test]
     fn test_optopt_short_multi() {
         let args = ~[~"-t", ~"20", ~"-t", ~"30"];
-        let opts = ~[optopt(~"t")];
+        let opts = ~[optopt("t")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, OptionDuplicated_),
@@ -873,10 +873,10 @@ mod tests {
     #[test]
     fn test_optflag_long() {
         let args = ~[~"--test"];
-        let opts = ~[optflag(~"test")];
+        let opts = ~[optflag("test")];
         let rs = getopts(args, opts);
         match rs {
-          Ok(ref m) => assert!(opt_present(m, ~"test")),
+          Ok(ref m) => assert!(opt_present(m, "test")),
           _ => fail!()
         }
     }
@@ -884,10 +884,10 @@ mod tests {
     #[test]
     fn test_optflag_long_missing() {
         let args = ~[~"blah"];
-        let opts = ~[optflag(~"test")];
+        let opts = ~[optflag("test")];
         let rs = getopts(args, opts);
         match rs {
-          Ok(ref m) => assert!(!opt_present(m, ~"test")),
+          Ok(ref m) => assert!(!opt_present(m, "test")),
           _ => fail!()
         }
     }
@@ -895,7 +895,7 @@ mod tests {
     #[test]
     fn test_optflag_long_arg() {
         let args = ~[~"--test=20"];
-        let opts = ~[optflag(~"test")];
+        let opts = ~[optflag("test")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => {
@@ -909,7 +909,7 @@ mod tests {
     #[test]
     fn test_optflag_long_multi() {
         let args = ~[~"--test", ~"--test"];
-        let opts = ~[optflag(~"test")];
+        let opts = ~[optflag("test")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, OptionDuplicated_),
@@ -920,10 +920,10 @@ mod tests {
     #[test]
     fn test_optflag_short() {
         let args = ~[~"-t"];
-        let opts = ~[optflag(~"t")];
+        let opts = ~[optflag("t")];
         let rs = getopts(args, opts);
         match rs {
-          Ok(ref m) => assert!(opt_present(m, ~"t")),
+          Ok(ref m) => assert!(opt_present(m, "t")),
           _ => fail!()
         }
     }
@@ -931,10 +931,10 @@ mod tests {
     #[test]
     fn test_optflag_short_missing() {
         let args = ~[~"blah"];
-        let opts = ~[optflag(~"t")];
+        let opts = ~[optflag("t")];
         let rs = getopts(args, opts);
         match rs {
-          Ok(ref m) => assert!(!opt_present(m, ~"t")),
+          Ok(ref m) => assert!(!opt_present(m, "t")),
           _ => fail!()
         }
     }
@@ -942,7 +942,7 @@ mod tests {
     #[test]
     fn test_optflag_short_arg() {
         let args = ~[~"-t", ~"20"];
-        let opts = ~[optflag(~"t")];
+        let opts = ~[optflag("t")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
@@ -957,7 +957,7 @@ mod tests {
     #[test]
     fn test_optflag_short_multi() {
         let args = ~[~"-t", ~"-t"];
-        let opts = ~[optflag(~"t")];
+        let opts = ~[optflag("t")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, OptionDuplicated_),
@@ -969,11 +969,11 @@ mod tests {
     #[test]
     fn test_optflagmulti_short1() {
         let args = ~[~"-v"];
-        let opts = ~[optflagmulti(~"v")];
+        let opts = ~[optflagmulti("v")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert_eq!(opt_count(m, ~"v"), 1);
+            assert_eq!(opt_count(m, "v"), 1);
           }
           _ => fail!()
         }
@@ -982,11 +982,11 @@ mod tests {
     #[test]
     fn test_optflagmulti_short2a() {
         let args = ~[~"-v", ~"-v"];
-        let opts = ~[optflagmulti(~"v")];
+        let opts = ~[optflagmulti("v")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert_eq!(opt_count(m, ~"v"), 2);
+            assert_eq!(opt_count(m, "v"), 2);
           }
           _ => fail!()
         }
@@ -995,11 +995,11 @@ mod tests {
     #[test]
     fn test_optflagmulti_short2b() {
         let args = ~[~"-vv"];
-        let opts = ~[optflagmulti(~"v")];
+        let opts = ~[optflagmulti("v")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert_eq!(opt_count(m, ~"v"), 2);
+            assert_eq!(opt_count(m, "v"), 2);
           }
           _ => fail!()
         }
@@ -1008,11 +1008,11 @@ mod tests {
     #[test]
     fn test_optflagmulti_long1() {
         let args = ~[~"--verbose"];
-        let opts = ~[optflagmulti(~"verbose")];
+        let opts = ~[optflagmulti("verbose")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert_eq!(opt_count(m, ~"verbose"), 1);
+            assert_eq!(opt_count(m, "verbose"), 1);
           }
           _ => fail!()
         }
@@ -1021,11 +1021,11 @@ mod tests {
     #[test]
     fn test_optflagmulti_long2() {
         let args = ~[~"--verbose", ~"--verbose"];
-        let opts = ~[optflagmulti(~"verbose")];
+        let opts = ~[optflagmulti("verbose")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert_eq!(opt_count(m, ~"verbose"), 2);
+            assert_eq!(opt_count(m, "verbose"), 2);
           }
           _ => fail!()
         }
@@ -1035,12 +1035,12 @@ mod tests {
     #[test]
     fn test_optmulti_long() {
         let args = ~[~"--test=20"];
-        let opts = ~[optmulti(~"test")];
+        let opts = ~[optmulti("test")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert!((opt_present(m, ~"test")));
-            assert_eq!(opt_str(m, ~"test"), ~"20");
+            assert!((opt_present(m, "test")));
+            assert_eq!(opt_str(m, "test"), ~"20");
           }
           _ => fail!()
         }
@@ -1049,10 +1049,10 @@ mod tests {
     #[test]
     fn test_optmulti_long_missing() {
         let args = ~[~"blah"];
-        let opts = ~[optmulti(~"test")];
+        let opts = ~[optmulti("test")];
         let rs = getopts(args, opts);
         match rs {
-          Ok(ref m) => assert!(!opt_present(m, ~"test")),
+          Ok(ref m) => assert!(!opt_present(m, "test")),
           _ => fail!()
         }
     }
@@ -1060,7 +1060,7 @@ mod tests {
     #[test]
     fn test_optmulti_long_no_arg() {
         let args = ~[~"--test"];
-        let opts = ~[optmulti(~"test")];
+        let opts = ~[optmulti("test")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, ArgumentMissing_),
@@ -1071,13 +1071,13 @@ mod tests {
     #[test]
     fn test_optmulti_long_multi() {
         let args = ~[~"--test=20", ~"--test=30"];
-        let opts = ~[optmulti(~"test")];
+        let opts = ~[optmulti("test")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-              assert!(opt_present(m, ~"test"));
-              assert_eq!(opt_str(m, ~"test"), ~"20");
-              let pair = opt_strs(m, ~"test");
+              assert!(opt_present(m, "test"));
+              assert_eq!(opt_str(m, "test"), ~"20");
+              let pair = opt_strs(m, "test");
               assert!(pair[0] == ~"20");
               assert!(pair[1] == ~"30");
           }
@@ -1088,12 +1088,12 @@ mod tests {
     #[test]
     fn test_optmulti_short() {
         let args = ~[~"-t", ~"20"];
-        let opts = ~[optmulti(~"t")];
+        let opts = ~[optmulti("t")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert!((opt_present(m, ~"t")));
-            assert_eq!(opt_str(m, ~"t"), ~"20");
+            assert!((opt_present(m, "t")));
+            assert_eq!(opt_str(m, "t"), ~"20");
           }
           _ => fail!()
         }
@@ -1102,10 +1102,10 @@ mod tests {
     #[test]
     fn test_optmulti_short_missing() {
         let args = ~[~"blah"];
-        let opts = ~[optmulti(~"t")];
+        let opts = ~[optmulti("t")];
         let rs = getopts(args, opts);
         match rs {
-          Ok(ref m) => assert!(!opt_present(m, ~"t")),
+          Ok(ref m) => assert!(!opt_present(m, "t")),
           _ => fail!()
         }
     }
@@ -1113,7 +1113,7 @@ mod tests {
     #[test]
     fn test_optmulti_short_no_arg() {
         let args = ~[~"-t"];
-        let opts = ~[optmulti(~"t")];
+        let opts = ~[optmulti("t")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, ArgumentMissing_),
@@ -1124,13 +1124,13 @@ mod tests {
     #[test]
     fn test_optmulti_short_multi() {
         let args = ~[~"-t", ~"20", ~"-t", ~"30"];
-        let opts = ~[optmulti(~"t")];
+        let opts = ~[optmulti("t")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
-            assert!((opt_present(m, ~"t")));
-            assert_eq!(opt_str(m, ~"t"), ~"20");
-            let pair = opt_strs(m, ~"t");
+            assert!((opt_present(m, "t")));
+            assert_eq!(opt_str(m, "t"), ~"20");
+            let pair = opt_strs(m, "t");
             assert!(pair[0] == ~"20");
             assert!(pair[1] == ~"30");
           }
@@ -1141,7 +1141,7 @@ mod tests {
     #[test]
     fn test_unrecognized_option_long() {
         let args = ~[~"--untest"];
-        let opts = ~[optmulti(~"t")];
+        let opts = ~[optmulti("t")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, UnrecognizedOption_),
@@ -1152,7 +1152,7 @@ mod tests {
     #[test]
     fn test_unrecognized_option_short() {
         let args = ~[~"-t"];
-        let opts = ~[optmulti(~"test")];
+        let opts = ~[optmulti("test")];
         let rs = getopts(args, opts);
         match rs {
           Err(copy f) => check_fail_type(f, UnrecognizedOption_),
@@ -1167,26 +1167,26 @@ mod tests {
               ~"--flag", ~"--long=30", ~"-f", ~"-m", ~"40",
               ~"-m", ~"50", ~"-n", ~"-A B", ~"-n", ~"-60 70"];
         let opts =
-            ~[optopt(~"s"), optflag(~"flag"), reqopt(~"long"),
-             optflag(~"f"), optmulti(~"m"), optmulti(~"n"),
-             optopt(~"notpresent")];
+            ~[optopt("s"), optflag("flag"), reqopt("long"),
+             optflag("f"), optmulti("m"), optmulti("n"),
+             optopt("notpresent")];
         let rs = getopts(args, opts);
         match rs {
           Ok(ref m) => {
             assert!(m.free[0] == ~"prog");
             assert!(m.free[1] == ~"free1");
-            assert_eq!(opt_str(m, ~"s"), ~"20");
+            assert_eq!(opt_str(m, "s"), ~"20");
             assert!(m.free[2] == ~"free2");
-            assert!((opt_present(m, ~"flag")));
-            assert_eq!(opt_str(m, ~"long"), ~"30");
-            assert!((opt_present(m, ~"f")));
-            let pair = opt_strs(m, ~"m");
+            assert!((opt_present(m, "flag")));
+            assert_eq!(opt_str(m, "long"), ~"30");
+            assert!((opt_present(m, "f")));
+            let pair = opt_strs(m, "m");
             assert!(pair[0] == ~"40");
             assert!(pair[1] == ~"50");
-            let pair = opt_strs(m, ~"n");
+            let pair = opt_strs(m, "n");
             assert!(pair[0] == ~"-A B");
             assert!(pair[1] == ~"-60 70");
-            assert!((!opt_present(m, ~"notpresent")));
+            assert!((!opt_present(m, "notpresent")));
           }
           _ => fail!()
         }
@@ -1195,43 +1195,43 @@ mod tests {
     #[test]
     fn test_multi() {
         let args = ~[~"-e", ~"foo", ~"--encrypt", ~"foo"];
-        let opts = ~[optopt(~"e"), optopt(~"encrypt"), optopt(~"f")];
+        let opts = ~[optopt("e"), optopt("encrypt"), optopt("f")];
         let matches = &match getopts(args, opts) {
           result::Ok(m) => m,
           result::Err(_) => fail!()
         };
-        assert!(opts_present(matches, ~[~"e"]));
-        assert!(opts_present(matches, ~[~"encrypt"]));
-        assert!(opts_present(matches, ~[~"encrypt", ~"e"]));
-        assert!(opts_present(matches, ~[~"e", ~"encrypt"]));
-        assert!(!opts_present(matches, ~[~"f"]));
-        assert!(!opts_present(matches, ~[~"thing"]));
-        assert!(!opts_present(matches, ~[]));
+        assert!(opts_present(matches, [~"e"]));
+        assert!(opts_present(matches, [~"encrypt"]));
+        assert!(opts_present(matches, [~"encrypt", ~"e"]));
+        assert!(opts_present(matches, [~"e", ~"encrypt"]));
+        assert!(!opts_present(matches, [~"f"]));
+        assert!(!opts_present(matches, [~"thing"]));
+        assert!(!opts_present(matches, []));
 
-        assert_eq!(opts_str(matches, ~[~"e"]), ~"foo");
-        assert_eq!(opts_str(matches, ~[~"encrypt"]), ~"foo");
-        assert_eq!(opts_str(matches, ~[~"e", ~"encrypt"]), ~"foo");
-        assert_eq!(opts_str(matches, ~[~"encrypt", ~"e"]), ~"foo");
+        assert_eq!(opts_str(matches, [~"e"]), ~"foo");
+        assert_eq!(opts_str(matches, [~"encrypt"]), ~"foo");
+        assert_eq!(opts_str(matches, [~"e", ~"encrypt"]), ~"foo");
+        assert_eq!(opts_str(matches, [~"encrypt", ~"e"]), ~"foo");
     }
 
     #[test]
     fn test_nospace() {
         let args = ~[~"-Lfoo", ~"-M."];
-        let opts = ~[optmulti(~"L"), optmulti(~"M")];
+        let opts = ~[optmulti("L"), optmulti("M")];
         let matches = &match getopts(args, opts) {
           result::Ok(m) => m,
           result::Err(_) => fail!()
         };
-        assert!(opts_present(matches, ~[~"L"]));
-        assert_eq!(opts_str(matches, ~[~"L"]), ~"foo");
-        assert!(opts_present(matches, ~[~"M"]));
-        assert_eq!(opts_str(matches, ~[~"M"]), ~".");
+        assert!(opts_present(matches, [~"L"]));
+        assert_eq!(opts_str(matches, [~"L"]), ~"foo");
+        assert!(opts_present(matches, [~"M"]));
+        assert_eq!(opts_str(matches, [~"M"]), ~".");
 
     }
 
     #[test]
     fn test_groups_reqopt() {
-        let opt = groups::reqopt(~"b", ~"banana", ~"some bananas", ~"VAL");
+        let opt = groups::reqopt("b", "banana", "some bananas", "VAL");
         assert!(opt == OptGroup { short_name: ~"b",
                         long_name: ~"banana",
                         hint: ~"VAL",
@@ -1242,7 +1242,7 @@ mod tests {
 
     #[test]
     fn test_groups_optopt() {
-        let opt = groups::optopt(~"a", ~"apple", ~"some apples", ~"VAL");
+        let opt = groups::optopt("a", "apple", "some apples", "VAL");
         assert!(opt == OptGroup { short_name: ~"a",
                         long_name: ~"apple",
                         hint: ~"VAL",
@@ -1253,7 +1253,7 @@ mod tests {
 
     #[test]
     fn test_groups_optflag() {
-        let opt = groups::optflag(~"k", ~"kiwi", ~"some kiwis");
+        let opt = groups::optflag("k", "kiwi", "some kiwis");
         assert!(opt == OptGroup { short_name: ~"k",
                         long_name: ~"kiwi",
                         hint: ~"",
@@ -1264,8 +1264,7 @@ mod tests {
 
     #[test]
     fn test_groups_optflagopt() {
-        let opt = groups::optflagopt(~"p", ~"pineapple",
-                                       ~"some pineapples", ~"VAL");
+        let opt = groups::optflagopt("p", "pineapple", "some pineapples", "VAL");
         assert!(opt == OptGroup { short_name: ~"p",
                         long_name: ~"pineapple",
                         hint: ~"VAL",
@@ -1276,8 +1275,7 @@ mod tests {
 
     #[test]
     fn test_groups_optmulti() {
-        let opt = groups::optmulti(~"l", ~"lime",
-                                     ~"some limes", ~"VAL");
+        let opt = groups::optmulti("l", "lime", "some limes", "VAL");
         assert!(opt == OptGroup { short_name: ~"l",
                         long_name: ~"lime",
                         hint: ~"VAL",
@@ -1288,9 +1286,8 @@ mod tests {
 
     #[test]
     fn test_groups_long_to_short() {
-        let short = ~[reqopt(~"b"), reqopt(~"banana")];
-        let verbose = groups::reqopt(~"b", ~"banana",
-                                       ~"some bananas", ~"VAL");
+        let short = ~[reqopt("b"), reqopt("banana")];
+        let verbose = groups::reqopt("b", "banana", "some bananas", "VAL");
 
         assert_eq!(groups::long_to_short(&verbose), short);
     }
@@ -1298,19 +1295,19 @@ mod tests {
     #[test]
     fn test_groups_getopts() {
         let short = ~[
-            reqopt(~"b"), reqopt(~"banana"),
-            optopt(~"a"), optopt(~"apple"),
-            optflag(~"k"), optflagopt(~"kiwi"),
-            optflagopt(~"p"),
-            optmulti(~"l")
+            reqopt("b"), reqopt("banana"),
+            optopt("a"), optopt("apple"),
+            optflag("k"), optflagopt("kiwi"),
+            optflagopt("p"),
+            optmulti("l")
         ];
 
         let verbose = ~[
-            groups::reqopt(~"b", ~"banana", ~"Desc", ~"VAL"),
-            groups::optopt(~"a", ~"apple", ~"Desc", ~"VAL"),
-            groups::optflag(~"k", ~"kiwi", ~"Desc"),
-            groups::optflagopt(~"p", ~"", ~"Desc", ~"VAL"),
-            groups::optmulti(~"l", ~"", ~"Desc", ~"VAL"),
+            groups::reqopt("b", "banana", "Desc", "VAL"),
+            groups::optopt("a", "apple", "Desc", "VAL"),
+            groups::optflag("k", "kiwi", "Desc"),
+            groups::optflagopt("p", "", "Desc", "VAL"),
+            groups::optmulti("l", "", "Desc", "VAL"),
         ];
 
         let sample_args = ~[~"-k", ~"15", ~"--apple", ~"1", ~"k",
@@ -1324,12 +1321,12 @@ mod tests {
     #[test]
     fn test_groups_usage() {
         let optgroups = ~[
-            groups::reqopt(~"b", ~"banana", ~"Desc", ~"VAL"),
-            groups::optopt(~"a", ~"012345678901234567890123456789",
-                             ~"Desc", ~"VAL"),
-            groups::optflag(~"k", ~"kiwi", ~"Desc"),
-            groups::optflagopt(~"p", ~"", ~"Desc", ~"VAL"),
-            groups::optmulti(~"l", ~"", ~"Desc", ~"VAL"),
+            groups::reqopt("b", "banana", "Desc", "VAL"),
+            groups::optopt("a", "012345678901234567890123456789",
+                             "Desc", "VAL"),
+            groups::optflag("k", "kiwi", "Desc"),
+            groups::optflagopt("p", "", "Desc", "VAL"),
+            groups::optmulti("l", "", "Desc", "VAL"),
         ];
 
         let expected =
@@ -1345,7 +1342,7 @@ Options:
 
 ";
 
-        let generated_usage = groups::usage(~"Usage: fruits", optgroups);
+        let generated_usage = groups::usage("Usage: fruits", optgroups);
 
         debug!("expected: <<%s>>", expected);
         debug!("generated: <<%s>>", generated_usage);
@@ -1358,10 +1355,10 @@ Options:
         // lines wrap after 78: or rather descriptions wrap after 54
 
         let optgroups = ~[
-           groups::optflag(~"k", ~"kiwi",
-           ~"This is a long description which won't be wrapped..+.."), // 54
-           groups::optflag(~"a", ~"apple",
-           ~"This is a long description which _will_ be wrapped..+.."), // 55
+            groups::optflag("k", "kiwi",
+                "This is a long description which won't be wrapped..+.."), // 54
+            groups::optflag("a", "apple",
+                "This is a long description which _will_ be wrapped..+.."), // 55
         ];
 
         let expected =
@@ -1374,7 +1371,7 @@ Options:
 
 ";
 
-        let usage = groups::usage(~"Usage: fruits", optgroups);
+        let usage = groups::usage("Usage: fruits", optgroups);
 
         debug!("expected: <<%s>>", expected);
         debug!("generated: <<%s>>", usage);

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -1444,15 +1444,15 @@ mod tests {
 
     #[test]
     fn test_write_object() {
-        assert_eq!(to_str(&mk_object(~[])), ~"{}");
-        assert_eq!(to_pretty_str(&mk_object(~[])), ~"{}");
+        assert_eq!(to_str(&mk_object([])), ~"{}");
+        assert_eq!(to_pretty_str(&mk_object([])), ~"{}");
 
         assert_eq!(
-            to_str(&mk_object(~[(~"a", Boolean(true))])),
+            to_str(&mk_object([(~"a", Boolean(true))])),
             ~"{\"a\":true}"
         );
         assert_eq!(
-            to_pretty_str(&mk_object(~[(~"a", Boolean(true))])),
+            to_pretty_str(&mk_object([(~"a", Boolean(true))])),
             ~"\
             {\n  \
                 \"a\": true\n\
@@ -1460,10 +1460,10 @@ mod tests {
         );
 
         assert_eq!(
-            to_str(&mk_object(~[
+            to_str(&mk_object([
                 (~"b", List(~[
-                    mk_object(~[(~"c", String(~"\x0c\r"))]),
-                    mk_object(~[(~"d", String(~""))])
+                    mk_object([(~"c", String(~"\x0c\r"))]),
+                    mk_object([(~"d", String(~""))])
                 ]))
             ])),
             ~"{\
@@ -1474,10 +1474,10 @@ mod tests {
             }"
         );
         assert_eq!(
-            to_pretty_str(&mk_object(~[
+            to_pretty_str(&mk_object([
                 (~"b", List(~[
-                    mk_object(~[(~"c", String(~"\x0c\r"))]),
-                    mk_object(~[(~"d", String(~""))])
+                    mk_object([(~"c", String(~"\x0c\r"))]),
+                    mk_object([(~"d", String(~""))])
                 ]))
             ])),
             ~"\
@@ -1493,11 +1493,11 @@ mod tests {
             }"
         );
 
-        let a = mk_object(~[
+        let a = mk_object([
             (~"a", Boolean(true)),
             (~"b", List(~[
-                mk_object(~[(~"c", String(~"\x0c\r"))]),
-                mk_object(~[(~"d", String(~""))])
+                mk_object([(~"c", String(~"\x0c\r"))]),
+                mk_object([(~"d", String(~""))])
             ]))
         ]);
 
@@ -1582,299 +1582,299 @@ mod tests {
 
     #[test]
     fn test_trailing_characters() {
-        assert_eq!(from_str(~"nulla"),
+        assert_eq!(from_str("nulla"),
             Err(Error {line: 1u, col: 5u, msg: @~"trailing characters"}));
-        assert_eq!(from_str(~"truea"),
+        assert_eq!(from_str("truea"),
             Err(Error {line: 1u, col: 5u, msg: @~"trailing characters"}));
-        assert_eq!(from_str(~"falsea"),
+        assert_eq!(from_str("falsea"),
             Err(Error {line: 1u, col: 6u, msg: @~"trailing characters"}));
-        assert_eq!(from_str(~"1a"),
+        assert_eq!(from_str("1a"),
             Err(Error {line: 1u, col: 2u, msg: @~"trailing characters"}));
-        assert_eq!(from_str(~"[]a"),
+        assert_eq!(from_str("[]a"),
             Err(Error {line: 1u, col: 3u, msg: @~"trailing characters"}));
-        assert_eq!(from_str(~"{}a"),
+        assert_eq!(from_str("{}a"),
             Err(Error {line: 1u, col: 3u, msg: @~"trailing characters"}));
     }
 
     #[test]
     fn test_read_identifiers() {
-        assert_eq!(from_str(~"n"),
+        assert_eq!(from_str("n"),
             Err(Error {line: 1u, col: 2u, msg: @~"invalid syntax"}));
-        assert_eq!(from_str(~"nul"),
+        assert_eq!(from_str("nul"),
             Err(Error {line: 1u, col: 4u, msg: @~"invalid syntax"}));
 
-        assert_eq!(from_str(~"t"),
+        assert_eq!(from_str("t"),
             Err(Error {line: 1u, col: 2u, msg: @~"invalid syntax"}));
-        assert_eq!(from_str(~"truz"),
+        assert_eq!(from_str("truz"),
             Err(Error {line: 1u, col: 4u, msg: @~"invalid syntax"}));
 
-        assert_eq!(from_str(~"f"),
+        assert_eq!(from_str("f"),
             Err(Error {line: 1u, col: 2u, msg: @~"invalid syntax"}));
-        assert_eq!(from_str(~"faz"),
+        assert_eq!(from_str("faz"),
             Err(Error {line: 1u, col: 3u, msg: @~"invalid syntax"}));
 
-        assert_eq!(from_str(~"null"), Ok(Null));
-        assert_eq!(from_str(~"true"), Ok(Boolean(true)));
-        assert_eq!(from_str(~"false"), Ok(Boolean(false)));
-        assert_eq!(from_str(~" null "), Ok(Null));
-        assert_eq!(from_str(~" true "), Ok(Boolean(true)));
-        assert_eq!(from_str(~" false "), Ok(Boolean(false)));
+        assert_eq!(from_str("null"), Ok(Null));
+        assert_eq!(from_str("true"), Ok(Boolean(true)));
+        assert_eq!(from_str("false"), Ok(Boolean(false)));
+        assert_eq!(from_str(" null "), Ok(Null));
+        assert_eq!(from_str(" true "), Ok(Boolean(true)));
+        assert_eq!(from_str(" false "), Ok(Boolean(false)));
     }
 
     #[test]
     fn test_decode_identifiers() {
-        let mut decoder = Decoder(from_str(~"null").unwrap());
+        let mut decoder = Decoder(from_str("null").unwrap());
         let v: () = Decodable::decode(&mut decoder);
         assert_eq!(v, ());
 
-        let mut decoder = Decoder(from_str(~"true").unwrap());
+        let mut decoder = Decoder(from_str("true").unwrap());
         let v: bool = Decodable::decode(&mut decoder);
         assert_eq!(v, true);
 
-        let mut decoder = Decoder(from_str(~"false").unwrap());
+        let mut decoder = Decoder(from_str("false").unwrap());
         let v: bool = Decodable::decode(&mut decoder);
         assert_eq!(v, false);
     }
 
     #[test]
     fn test_read_number() {
-        assert_eq!(from_str(~"+"),
+        assert_eq!(from_str("+"),
             Err(Error {line: 1u, col: 1u, msg: @~"invalid syntax"}));
-        assert_eq!(from_str(~"."),
+        assert_eq!(from_str("."),
             Err(Error {line: 1u, col: 1u, msg: @~"invalid syntax"}));
 
-        assert_eq!(from_str(~"-"),
+        assert_eq!(from_str("-"),
             Err(Error {line: 1u, col: 2u, msg: @~"invalid number"}));
-        assert_eq!(from_str(~"00"),
+        assert_eq!(from_str("00"),
             Err(Error {line: 1u, col: 2u, msg: @~"invalid number"}));
-        assert_eq!(from_str(~"1."),
+        assert_eq!(from_str("1."),
             Err(Error {line: 1u, col: 3u, msg: @~"invalid number"}));
-        assert_eq!(from_str(~"1e"),
+        assert_eq!(from_str("1e"),
             Err(Error {line: 1u, col: 3u, msg: @~"invalid number"}));
-        assert_eq!(from_str(~"1e+"),
+        assert_eq!(from_str("1e+"),
             Err(Error {line: 1u, col: 4u, msg: @~"invalid number"}));
 
-        assert_eq!(from_str(~"3"), Ok(Number(3f)));
-        assert_eq!(from_str(~"3.1"), Ok(Number(3.1f)));
-        assert_eq!(from_str(~"-1.2"), Ok(Number(-1.2f)));
-        assert_eq!(from_str(~"0.4"), Ok(Number(0.4f)));
-        assert_eq!(from_str(~"0.4e5"), Ok(Number(0.4e5f)));
-        assert_eq!(from_str(~"0.4e+15"), Ok(Number(0.4e15f)));
-        assert_eq!(from_str(~"0.4e-01"), Ok(Number(0.4e-01f)));
-        assert_eq!(from_str(~" 3 "), Ok(Number(3f)));
+        assert_eq!(from_str("3"), Ok(Number(3f)));
+        assert_eq!(from_str("3.1"), Ok(Number(3.1f)));
+        assert_eq!(from_str("-1.2"), Ok(Number(-1.2f)));
+        assert_eq!(from_str("0.4"), Ok(Number(0.4f)));
+        assert_eq!(from_str("0.4e5"), Ok(Number(0.4e5f)));
+        assert_eq!(from_str("0.4e+15"), Ok(Number(0.4e15f)));
+        assert_eq!(from_str("0.4e-01"), Ok(Number(0.4e-01f)));
+        assert_eq!(from_str(" 3 "), Ok(Number(3f)));
     }
 
     #[test]
     fn test_decode_numbers() {
-        let mut decoder = Decoder(from_str(~"3").unwrap());
+        let mut decoder = Decoder(from_str("3").unwrap());
         let v: float = Decodable::decode(&mut decoder);
         assert_eq!(v, 3f);
 
-        let mut decoder = Decoder(from_str(~"3.1").unwrap());
+        let mut decoder = Decoder(from_str("3.1").unwrap());
         let v: float = Decodable::decode(&mut decoder);
         assert_eq!(v, 3.1f);
 
-        let mut decoder = Decoder(from_str(~"-1.2").unwrap());
+        let mut decoder = Decoder(from_str("-1.2").unwrap());
         let v: float = Decodable::decode(&mut decoder);
         assert_eq!(v, -1.2f);
 
-        let mut decoder = Decoder(from_str(~"0.4").unwrap());
+        let mut decoder = Decoder(from_str("0.4").unwrap());
         let v: float = Decodable::decode(&mut decoder);
         assert_eq!(v, 0.4f);
 
-        let mut decoder = Decoder(from_str(~"0.4e5").unwrap());
+        let mut decoder = Decoder(from_str("0.4e5").unwrap());
         let v: float = Decodable::decode(&mut decoder);
         assert_eq!(v, 0.4e5f);
 
-        let mut decoder = Decoder(from_str(~"0.4e15").unwrap());
+        let mut decoder = Decoder(from_str("0.4e15").unwrap());
         let v: float = Decodable::decode(&mut decoder);
         assert_eq!(v, 0.4e15f);
 
-        let mut decoder = Decoder(from_str(~"0.4e-01").unwrap());
+        let mut decoder = Decoder(from_str("0.4e-01").unwrap());
         let v: float = Decodable::decode(&mut decoder);
         assert_eq!(v, 0.4e-01f);
     }
 
     #[test]
     fn test_read_str() {
-        assert_eq!(from_str(~"\""),
+        assert_eq!(from_str("\""),
             Err(Error {line: 1u, col: 2u, msg: @~"EOF while parsing string"
         }));
-        assert_eq!(from_str(~"\"lol"),
+        assert_eq!(from_str("\"lol"),
             Err(Error {line: 1u, col: 5u, msg: @~"EOF while parsing string"
         }));
 
-        assert_eq!(from_str(~"\"\""), Ok(String(~"")));
-        assert_eq!(from_str(~"\"foo\""), Ok(String(~"foo")));
-        assert_eq!(from_str(~"\"\\\"\""), Ok(String(~"\"")));
-        assert_eq!(from_str(~"\"\\b\""), Ok(String(~"\x08")));
-        assert_eq!(from_str(~"\"\\n\""), Ok(String(~"\n")));
-        assert_eq!(from_str(~"\"\\r\""), Ok(String(~"\r")));
-        assert_eq!(from_str(~"\"\\t\""), Ok(String(~"\t")));
-        assert_eq!(from_str(~" \"foo\" "), Ok(String(~"foo")));
-        assert_eq!(from_str(~"\"\\u12ab\""), Ok(String(~"\u12ab")));
-        assert_eq!(from_str(~"\"\\uAB12\""), Ok(String(~"\uAB12")));
+        assert_eq!(from_str("\"\""), Ok(String(~"")));
+        assert_eq!(from_str("\"foo\""), Ok(String(~"foo")));
+        assert_eq!(from_str("\"\\\"\""), Ok(String(~"\"")));
+        assert_eq!(from_str("\"\\b\""), Ok(String(~"\x08")));
+        assert_eq!(from_str("\"\\n\""), Ok(String(~"\n")));
+        assert_eq!(from_str("\"\\r\""), Ok(String(~"\r")));
+        assert_eq!(from_str("\"\\t\""), Ok(String(~"\t")));
+        assert_eq!(from_str(" \"foo\" "), Ok(String(~"foo")));
+        assert_eq!(from_str("\"\\u12ab\""), Ok(String(~"\u12ab")));
+        assert_eq!(from_str("\"\\uAB12\""), Ok(String(~"\uAB12")));
     }
 
     #[test]
     fn test_decode_str() {
-        let mut decoder = Decoder(from_str(~"\"\"").unwrap());
+        let mut decoder = Decoder(from_str("\"\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"");
 
-        let mut decoder = Decoder(from_str(~"\"foo\"").unwrap());
+        let mut decoder = Decoder(from_str("\"foo\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"foo");
 
-        let mut decoder = Decoder(from_str(~"\"\\\"\"").unwrap());
+        let mut decoder = Decoder(from_str("\"\\\"\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\"");
 
-        let mut decoder = Decoder(from_str(~"\"\\b\"").unwrap());
+        let mut decoder = Decoder(from_str("\"\\b\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\x08");
 
-        let mut decoder = Decoder(from_str(~"\"\\n\"").unwrap());
+        let mut decoder = Decoder(from_str("\"\\n\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\n");
 
-        let mut decoder = Decoder(from_str(~"\"\\r\"").unwrap());
+        let mut decoder = Decoder(from_str("\"\\r\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\r");
 
-        let mut decoder = Decoder(from_str(~"\"\\t\"").unwrap());
+        let mut decoder = Decoder(from_str("\"\\t\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\t");
 
-        let mut decoder = Decoder(from_str(~"\"\\u12ab\"").unwrap());
+        let mut decoder = Decoder(from_str("\"\\u12ab\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\u12ab");
 
-        let mut decoder = Decoder(from_str(~"\"\\uAB12\"").unwrap());
+        let mut decoder = Decoder(from_str("\"\\uAB12\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\uAB12");
     }
 
     #[test]
     fn test_read_list() {
-        assert_eq!(from_str(~"["),
+        assert_eq!(from_str("["),
             Err(Error {line: 1u, col: 2u, msg: @~"EOF while parsing value"}));
-        assert_eq!(from_str(~"[1"),
+        assert_eq!(from_str("[1"),
             Err(Error {line: 1u, col: 3u, msg: @~"EOF while parsing list"}));
-        assert_eq!(from_str(~"[1,"),
+        assert_eq!(from_str("[1,"),
             Err(Error {line: 1u, col: 4u, msg: @~"EOF while parsing value"}));
-        assert_eq!(from_str(~"[1,]"),
+        assert_eq!(from_str("[1,]"),
             Err(Error {line: 1u, col: 4u, msg: @~"invalid syntax"}));
-        assert_eq!(from_str(~"[6 7]"),
+        assert_eq!(from_str("[6 7]"),
             Err(Error {line: 1u, col: 4u, msg: @~"expected `,` or `]`"}));
 
-        assert_eq!(from_str(~"[]"), Ok(List(~[])));
-        assert_eq!(from_str(~"[ ]"), Ok(List(~[])));
-        assert_eq!(from_str(~"[true]"), Ok(List(~[Boolean(true)])));
-        assert_eq!(from_str(~"[ false ]"), Ok(List(~[Boolean(false)])));
-        assert_eq!(from_str(~"[null]"), Ok(List(~[Null])));
-        assert_eq!(from_str(~"[3, 1]"),
+        assert_eq!(from_str("[]"), Ok(List(~[])));
+        assert_eq!(from_str("[ ]"), Ok(List(~[])));
+        assert_eq!(from_str("[true]"), Ok(List(~[Boolean(true)])));
+        assert_eq!(from_str("[ false ]"), Ok(List(~[Boolean(false)])));
+        assert_eq!(from_str("[null]"), Ok(List(~[Null])));
+        assert_eq!(from_str("[3, 1]"),
                      Ok(List(~[Number(3f), Number(1f)])));
-        assert_eq!(from_str(~"\n[3, 2]\n"),
+        assert_eq!(from_str("\n[3, 2]\n"),
                      Ok(List(~[Number(3f), Number(2f)])));
-        assert_eq!(from_str(~"[2, [4, 1]]"),
+        assert_eq!(from_str("[2, [4, 1]]"),
                Ok(List(~[Number(2f), List(~[Number(4f), Number(1f)])])));
     }
 
     #[test]
     fn test_decode_list() {
-        let mut decoder = Decoder(from_str(~"[]").unwrap());
+        let mut decoder = Decoder(from_str("[]").unwrap());
         let v: ~[()] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[]);
 
-        let mut decoder = Decoder(from_str(~"[null]").unwrap());
+        let mut decoder = Decoder(from_str("[null]").unwrap());
         let v: ~[()] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[()]);
 
-        let mut decoder = Decoder(from_str(~"[true]").unwrap());
+        let mut decoder = Decoder(from_str("[true]").unwrap());
         let v: ~[bool] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[true]);
 
-        let mut decoder = Decoder(from_str(~"[true]").unwrap());
+        let mut decoder = Decoder(from_str("[true]").unwrap());
         let v: ~[bool] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[true]);
 
-        let mut decoder = Decoder(from_str(~"[3, 1]").unwrap());
+        let mut decoder = Decoder(from_str("[3, 1]").unwrap());
         let v: ~[int] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[3, 1]);
 
-        let mut decoder = Decoder(from_str(~"[[3], [1, 2]]").unwrap());
+        let mut decoder = Decoder(from_str("[[3], [1, 2]]").unwrap());
         let v: ~[~[uint]] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[~[3], ~[1, 2]]);
     }
 
     #[test]
     fn test_read_object() {
-        assert_eq!(from_str(~"{"),
+        assert_eq!(from_str("{"),
             Err(Error {
                 line: 1u,
                 col: 2u,
                 msg: @~"EOF while parsing object"}));
-        assert_eq!(from_str(~"{ "),
+        assert_eq!(from_str("{ "),
             Err(Error {
                 line: 1u,
                 col: 3u,
                 msg: @~"EOF while parsing object"}));
-        assert_eq!(from_str(~"{1"),
+        assert_eq!(from_str("{1"),
             Err(Error {
                 line: 1u,
                 col: 2u,
                 msg: @~"key must be a string"}));
-        assert_eq!(from_str(~"{ \"a\""),
+        assert_eq!(from_str("{ \"a\""),
             Err(Error {
                 line: 1u,
                 col: 6u,
                 msg: @~"EOF while parsing object"}));
-        assert_eq!(from_str(~"{\"a\""),
+        assert_eq!(from_str("{\"a\""),
             Err(Error {
                 line: 1u,
                 col: 5u,
                 msg: @~"EOF while parsing object"}));
-        assert_eq!(from_str(~"{\"a\" "),
+        assert_eq!(from_str("{\"a\" "),
             Err(Error {
                 line: 1u,
                 col: 6u,
                 msg: @~"EOF while parsing object"}));
 
-        assert_eq!(from_str(~"{\"a\" 1"),
+        assert_eq!(from_str("{\"a\" 1"),
             Err(Error {line: 1u, col: 6u, msg: @~"expected `:`"}));
-        assert_eq!(from_str(~"{\"a\":"),
+        assert_eq!(from_str("{\"a\":"),
             Err(Error {line: 1u, col: 6u, msg: @~"EOF while parsing value"}));
-        assert_eq!(from_str(~"{\"a\":1"),
+        assert_eq!(from_str("{\"a\":1"),
             Err(Error {
                 line: 1u,
                 col: 7u,
                 msg: @~"EOF while parsing object"}));
-        assert_eq!(from_str(~"{\"a\":1 1"),
+        assert_eq!(from_str("{\"a\":1 1"),
             Err(Error {line: 1u, col: 8u, msg: @~"expected `,` or `}`"}));
-        assert_eq!(from_str(~"{\"a\":1,"),
+        assert_eq!(from_str("{\"a\":1,"),
             Err(Error {
                 line: 1u,
                 col: 8u,
                 msg: @~"EOF while parsing object"}));
 
-        assert_eq!(result::unwrap(from_str(~"{}")), mk_object(~[]));
-        assert_eq!(result::unwrap(from_str(~"{\"a\": 3}")),
-                  mk_object(~[(~"a", Number(3.0f))]));
+        assert_eq!(result::unwrap(from_str("{}")), mk_object([]));
+        assert_eq!(result::unwrap(from_str("{\"a\": 3}")),
+                  mk_object([(~"a", Number(3.0f))]));
 
         assert_eq!(result::unwrap(from_str(
-                ~"{ \"a\": null, \"b\" : true }")),
-                  mk_object(~[
+                      "{ \"a\": null, \"b\" : true }")),
+                  mk_object([
                       (~"a", Null),
                       (~"b", Boolean(true))]));
         assert_eq!(result::unwrap(
-                      from_str(~"\n{ \"a\": null, \"b\" : true }\n")),
-                  mk_object(~[
+                      from_str("\n{ \"a\": null, \"b\" : true }\n")),
+                  mk_object([
                       (~"a", Null),
                       (~"b", Boolean(true))]));
         assert_eq!(result::unwrap(from_str(
-                ~"{\"a\" : 1.0 ,\"b\": [ true ]}")),
-                  mk_object(~[
+                      "{\"a\" : 1.0 ,\"b\": [ true ]}")),
+                  mk_object([
                       (~"a", Number(1.0)),
                       (~"b", List(~[Boolean(true)]))
                   ]));
@@ -1887,13 +1887,13 @@ mod tests {
                               ~"{ \"c\": {\"d\": null} } " +
                           ~"]" +
                       ~"}")),
-                  mk_object(~[
+                  mk_object([
                       (~"a", Number(1.0f)),
                       (~"b", List(~[
                           Boolean(true),
                           String(~"foo\nbar"),
-                          mk_object(~[
-                              (~"c", mk_object(~[(~"d", Null)]))
+                          mk_object([
+                              (~"c", mk_object([(~"d", Null)]))
                           ])
                       ]))
                   ]));
@@ -1920,23 +1920,23 @@ mod tests {
 
     #[test]
     fn test_decode_option() {
-        let mut decoder = Decoder(from_str(~"null").unwrap());
+        let mut decoder = Decoder(from_str("null").unwrap());
         let value: Option<~str> = Decodable::decode(&mut decoder);
         assert_eq!(value, None);
 
-        let mut decoder = Decoder(from_str(~"\"jodhpurs\"").unwrap());
+        let mut decoder = Decoder(from_str("\"jodhpurs\"").unwrap());
         let value: Option<~str> = Decodable::decode(&mut decoder);
         assert_eq!(value, Some(~"jodhpurs"));
     }
 
     #[test]
     fn test_decode_enum() {
-        let mut decoder = Decoder(from_str(~"\"Dog\"").unwrap());
+        let mut decoder = Decoder(from_str("\"Dog\"").unwrap());
         let value: Animal = Decodable::decode(&mut decoder);
         assert_eq!(value, Dog);
 
         let mut decoder =
-            Decoder(from_str(~"[\"Frog\",\"Henry\",349]").unwrap());
+            Decoder(from_str("[\"Frog\",\"Henry\",349]").unwrap());
         let value: Animal = Decodable::decode(&mut decoder);
         assert_eq!(value, Frog(~"Henry", 349));
     }
@@ -1953,7 +1953,7 @@ mod tests {
 
     #[test]
     fn test_multiline_errors() {
-        assert_eq!(from_str(~"{\n  \"foo\":\n \"bar\""),
+        assert_eq!(from_str("{\n  \"foo\":\n \"bar\""),
             Err(Error {
                 line: 3u,
                 col: 8u,

--- a/src/libextra/list.rs
+++ b/src/libextra/list.rs
@@ -184,9 +184,9 @@ mod tests {
 
     #[test]
     fn test_is_empty() {
-        let empty : @list::List<int> = from_vec(~[]);
-        let full1 = from_vec(~[1]);
-        let full2 = from_vec(~['r', 'u']);
+        let empty : @list::List<int> = from_vec([]);
+        let full1 = from_vec([1]);
+        let full2 = from_vec(['r', 'u']);
 
         assert!(is_empty(empty));
         assert!(!is_empty(full1));
@@ -195,7 +195,7 @@ mod tests {
 
     #[test]
     fn test_from_vec() {
-        let l = from_vec(~[0, 1, 2]);
+        let l = from_vec([0, 1, 2]);
 
         assert_eq!(head(l), 0);
 
@@ -208,14 +208,14 @@ mod tests {
 
     #[test]
     fn test_from_vec_empty() {
-        let empty : @list::List<int> = from_vec(~[]);
+        let empty : @list::List<int> = from_vec([]);
         assert_eq!(empty, @list::Nil::<int>);
     }
 
     #[test]
     fn test_foldl() {
         fn add(a: &uint, b: &int) -> uint { return *a + (*b as uint); }
-        let l = from_vec(~[0, 1, 2, 3, 4]);
+        let l = from_vec([0, 1, 2, 3, 4]);
         let empty = @list::Nil::<int>;
         assert_eq!(list::foldl(0u, l, add), 10u);
         assert_eq!(list::foldl(0u, empty, add), 0u);
@@ -226,21 +226,21 @@ mod tests {
         fn sub(a: &int, b: &int) -> int {
             *a - *b
         }
-        let l = from_vec(~[1, 2, 3, 4]);
+        let l = from_vec([1, 2, 3, 4]);
         assert_eq!(list::foldl(0, l, sub), -10);
     }
 
     #[test]
     fn test_find_success() {
         fn match_(i: &int) -> bool { return *i == 2; }
-        let l = from_vec(~[0, 1, 2]);
+        let l = from_vec([0, 1, 2]);
         assert_eq!(list::find(l, match_), option::Some(2));
     }
 
     #[test]
     fn test_find_fail() {
         fn match_(_i: &int) -> bool { return false; }
-        let l = from_vec(~[0, 1, 2]);
+        let l = from_vec([0, 1, 2]);
         let empty = @list::Nil::<int>;
         assert_eq!(list::find(l, match_), option::None::<int>);
         assert_eq!(list::find(empty, match_), option::None::<int>);
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn test_has() {
-        let l = from_vec(~[5, 8, 6]);
+        let l = from_vec([5, 8, 6]);
         let empty = @list::Nil::<int>;
         assert!((list::has(l, 5)));
         assert!((!list::has(l, 7)));
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_len() {
-        let l = from_vec(~[0, 1, 2]);
+        let l = from_vec([0, 1, 2]);
         let empty = @list::Nil::<int>;
         assert_eq!(list::len(l), 3u);
         assert_eq!(list::len(empty), 0u);
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_append() {
-        assert!(from_vec(~[1,2,3,4])
-            == list::append(list::from_vec(~[1,2]), list::from_vec(~[3,4])));
+        assert!(from_vec([1,2,3,4])
+            == list::append(list::from_vec([1,2]), list::from_vec([3,4])));
     }
 }

--- a/src/libextra/md4.rs
+++ b/src/libextra/md4.rs
@@ -127,17 +127,17 @@ pub fn md4_text(msg: &str) -> ~str { md4_str(str::to_bytes(msg)) }
 
 #[test]
 fn test_md4() {
-    assert_eq!(md4_text(~""), ~"31d6cfe0d16ae931b73c59d7e0c089c0");
-    assert_eq!(md4_text(~"a"), ~"bde52cb31de33e46245e05fbdbd6fb24");
-    assert_eq!(md4_text(~"abc"), ~"a448017aaf21d8525fc10ae87aa6729d");
-    assert!(md4_text(~"message digest") ==
+    assert_eq!(md4_text(""), ~"31d6cfe0d16ae931b73c59d7e0c089c0");
+    assert_eq!(md4_text("a"), ~"bde52cb31de33e46245e05fbdbd6fb24");
+    assert_eq!(md4_text("abc"), ~"a448017aaf21d8525fc10ae87aa6729d");
+    assert!(md4_text("message digest") ==
         ~"d9130a8164549fe818874806e1c7014b");
-    assert!(md4_text(~"abcdefghijklmnopqrstuvwxyz") ==
+    assert!(md4_text("abcdefghijklmnopqrstuvwxyz") ==
         ~"d79e1c308aa5bbcdeea8ed63df412da9");
     assert!(md4_text(
-        ~"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\
         0123456789") == ~"043f8582f241db351ce627e153e7f0e4");
-    assert!(md4_text(~"1234567890123456789012345678901234567890123456789\
+    assert!(md4_text("1234567890123456789012345678901234567890123456789\
                      0123456789012345678901234567890") ==
         ~"e33b4ddc9c38f2199c3e7b164fcc0536");
 }

--- a/src/libextra/net_ip.rs
+++ b/src/libextra/net_ip.rs
@@ -393,7 +393,7 @@ mod test {
     }
     #[test]
     fn test_ip_ipv4_bad_parse() {
-        match v4::try_parse_addr(~"b4df00d") {
+        match v4::try_parse_addr("b4df00d") {
           result::Err(ref err_info) => {
             debug!("got error as expected %?", err_info);
             assert!(true);
@@ -406,7 +406,7 @@ mod test {
     #[test]
     #[ignore(target_os="win32")]
     fn test_ip_ipv6_bad_parse() {
-        match v6::try_parse_addr(~"::,~2234k;") {
+        match v6::try_parse_addr("::,~2234k;") {
           result::Err(ref err_info) => {
             debug!("got error as expected %?", err_info);
             assert!(true);

--- a/src/libextra/net_tcp.rs
+++ b/src/libextra/net_tcp.rs
@@ -1630,7 +1630,7 @@ mod test {
         assert_eq!(net::ip::get_port(&sock.get_peer_addr()), 8887);
 
         // Fulfill the protocol the test server expects
-        let resp_bytes = str::to_bytes(~"ping");
+        let resp_bytes = str::to_bytes("ping");
         tcp_write_single(&sock, resp_bytes);
         debug!("message sent");
         sock.read(0u);

--- a/src/libextra/net_url.rs
+++ b/src/libextra/net_url.rs
@@ -716,11 +716,11 @@ impl IterBytes for Url {
 
 #[test]
 fn test_split_char_first() {
-    let (u,v) = split_char_first(~"hello, sweet world", ',');
+    let (u,v) = split_char_first("hello, sweet world", ',');
     assert_eq!(u, ~"hello");
     assert_eq!(v, ~" sweet world");
 
-    let (u,v) = split_char_first(~"hello sweet world", ',');
+    let (u,v) = split_char_first("hello sweet world", ',');
     assert_eq!(u, ~"hello sweet world");
     assert_eq!(v, ~"");
 }
@@ -774,9 +774,9 @@ fn test_get_authority() {
         "//2001:0db8:85a3:0042:0000:8a2e:0370:7334:8000:00").is_err());
 
     // these parse as empty, because they don't start with '//'
-    let (_, h, _, _) = get_authority(~"user:pass@rust-lang").unwrap();
+    let (_, h, _, _) = get_authority("user:pass@rust-lang").unwrap();
     assert_eq!(h, ~"");
-    let (_, h, _, _) = get_authority(~"rust-lang.org").unwrap();
+    let (_, h, _, _) = get_authority("rust-lang.org").unwrap();
     assert_eq!(h, ~"");
 }
 
@@ -788,12 +788,12 @@ fn test_get_path() {
     let (p, r) = get_path("test@email.com#fragment", false).unwrap();
     assert_eq!(p, ~"test@email.com");
     assert_eq!(r, ~"#fragment");
-    let (p, r) = get_path(~"/gen/:addr=?q=v", false).unwrap();
+    let (p, r) = get_path("/gen/:addr=?q=v", false).unwrap();
     assert_eq!(p, ~"/gen/:addr=");
     assert_eq!(r, ~"?q=v");
 
     //failure cases
-    assert!(get_path(~"something?q", true).is_err());
+    assert!(get_path("something?q", true).is_err());
 }
 
 #[cfg(test)]
@@ -1058,7 +1058,7 @@ mod tests {
         // FIXME #4449: Commented out because this causes an ICE, but only
         // on FreeBSD
         /*
-        assert_eq!(decode_form_urlencoded(~[]).len(), 0);
+        assert_eq!(decode_form_urlencoded([]).len(), 0);
 
         let s = str::to_bytes("a=1&foo+bar=abc&foo+bar=12+%3D+34");
         let form = decode_form_urlencoded(s);

--- a/src/libextra/num/bigint.rs
+++ b/src/libextra/num/bigint.rs
@@ -1156,12 +1156,12 @@ mod biguint_tests {
         fn check(slice: &[BigDigit], data: &[BigDigit]) {
             assert!(data == BigUint::from_slice(slice).data);
         }
-        check(~[1], ~[1]);
-        check(~[0, 0, 0], ~[]);
-        check(~[1, 2, 0, 0], ~[1, 2]);
-        check(~[0, 0, 1, 2], ~[0, 0, 1, 2]);
-        check(~[0, 0, 1, 2, 0, 0], ~[0, 0, 1, 2]);
-        check(~[-1], ~[-1]);
+        check([1], [1]);
+        check([0, 0, 0], []);
+        check([1, 2, 0, 0], [1, 2]);
+        check([0, 0, 1, 2], [0, 0, 1, 2]);
+        check([0, 0, 1, 2, 0, 0], [0, 0, 1, 2]);
+        check([-1], [-1]);
     }
 
     #[test]
@@ -1579,9 +1579,9 @@ mod biguint_tests {
             }
         }
 
-        assert_eq!(FromStrRadix::from_str_radix::<BigUint>(~"Z", 10), None);
-        assert_eq!(FromStrRadix::from_str_radix::<BigUint>(~"_", 2), None);
-        assert_eq!(FromStrRadix::from_str_radix::<BigUint>(~"-1", 10), None);
+        assert_eq!(FromStrRadix::from_str_radix::<BigUint>("Z", 10), None);
+        assert_eq!(FromStrRadix::from_str_radix::<BigUint>("_", 2), None);
+        assert_eq!(FromStrRadix::from_str_radix::<BigUint>("-1", 10), None);
     }
 
     #[test]

--- a/src/libextra/priority_queue.rs
+++ b/src/libextra/priority_queue.rs
@@ -14,7 +14,6 @@ use core::prelude::*;
 
 use core::old_iter::BaseIter;
 use core::unstable::intrinsics::{move_val_init, init};
-use core::unstable::intrinsics::uninit;
 use core::util::{replace, swap};
 
 pub struct PriorityQueue<T> {

--- a/src/libextra/sha1.rs
+++ b/src/libextra/sha1.rs
@@ -295,7 +295,7 @@ mod tests {
             let mut i = 0;
             let mut rs = ~"";
             while i < 100000 {
-                str::push_str(&mut rs, ~"aaaaaaaaaa");
+                rs.push_str("aaaaaaaaaa");
                 i += 1;
             }
             return rs;

--- a/src/libextra/sort.rs
+++ b/src/libextra/sort.rs
@@ -895,7 +895,7 @@ mod tests {
     #[test]
     fn test_merge_sort_mutable() {
         pub fn le(a: &int, b: &int) -> bool { *a <= *b }
-        let mut v1 = ~[3, 2, 1];
+        let v1 = ~[3, 2, 1];
         let v2 = merge_sort(v1, le);
         assert_eq!(v2, ~[1, 2, 3]);
     }

--- a/src/libextra/std.rc
+++ b/src/libextra/std.rc
@@ -27,7 +27,6 @@ not required in or otherwise suitable for the core library.
 #[crate_type = "lib"];
 
 #[deny(non_camel_case_types)];
-#[allow(unnecessary_allocation)];
 
 #[no_core];
 #[no_std];

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -394,8 +394,8 @@ fn should_sort_failures_before_printing_them() {
         print_failures(st);
     };
 
-    let apos = str::find_str(s, ~"a").get();
-    let bpos = str::find_str(s, ~"b").get();
+    let apos = str::find_str(s, "a").get();
+    let bpos = str::find_str(s, "b").get();
     assert!(apos < bpos);
 }
 

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -899,7 +899,7 @@ mod tests {
     }
 
     fn test_at_utc() {
-        os::setenv(~"TZ", ~"America/Los_Angeles");
+        os::setenv("TZ", "America/Los_Angeles");
         tzset();
 
         let time = ::time::Timespec::new(1234567890, 54321);
@@ -920,7 +920,7 @@ mod tests {
     }
 
     fn test_at() {
-        os::setenv(~"TZ", ~"America/Los_Angeles");
+        os::setenv("TZ", "America/Los_Angeles");
         tzset();
 
         let time = ::time::Timespec::new(1234567890, 54321);
@@ -948,7 +948,7 @@ mod tests {
     }
 
     fn test_to_timespec() {
-        os::setenv(~"TZ", ~"America/Los_Angeles");
+        os::setenv("TZ", "America/Los_Angeles");
         tzset();
 
         let time = ::time::Timespec::new(1234567890, 54321);
@@ -959,7 +959,7 @@ mod tests {
     }
 
     fn test_conversions() {
-        os::setenv(~"TZ", ~"America/Los_Angeles");
+        os::setenv("TZ", "America/Los_Angeles");
         tzset();
 
         let time = ::time::Timespec::new(1234567890, 54321);
@@ -975,10 +975,10 @@ mod tests {
     }
 
     fn test_strptime() {
-        os::setenv(~"TZ", ~"America/Los_Angeles");
+        os::setenv("TZ", "America/Los_Angeles");
         tzset();
 
-        match strptime(~"", ~"") {
+        match strptime("", "") {
           Ok(ref tm) => {
             assert!(tm.tm_sec == 0_i32);
             assert!(tm.tm_min == 0_i32);
@@ -995,12 +995,12 @@ mod tests {
           Err(_) => ()
         }
 
-        let format = ~"%a %b %e %T %Y";
-        assert_eq!(strptime(~"", format), Err(~"Invalid time"));
-        assert!(strptime(~"Fri Feb 13 15:31:30", format)
+        let format = "%a %b %e %T %Y";
+        assert_eq!(strptime("", format), Err(~"Invalid time"));
+        assert!(strptime("Fri Feb 13 15:31:30", format)
             == Err(~"Invalid time"));
 
-        match strptime(~"Fri Feb 13 15:31:30 2009", format) {
+        match strptime("Fri Feb 13 15:31:30 2009", format) {
           Err(copy e) => fail!(e),
           Ok(ref tm) => {
             assert!(tm.tm_sec == 30_i32);
@@ -1034,7 +1034,7 @@ mod tests {
             ~"Friday",
             ~"Saturday"
         ].each |day| {
-            assert!(test(*day, ~"%A"));
+            assert!(test(*day, "%A"));
         }
 
         for [
@@ -1046,7 +1046,7 @@ mod tests {
             ~"Fri",
             ~"Sat"
         ].each |day| {
-            assert!(test(*day, ~"%a"));
+            assert!(test(*day, "%a"));
         }
 
         for [
@@ -1063,7 +1063,7 @@ mod tests {
             ~"November",
             ~"December"
         ].each |day| {
-            assert!(test(*day, ~"%B"));
+            assert!(test(*day, "%B"));
         }
 
         for [
@@ -1080,60 +1080,60 @@ mod tests {
             ~"Nov",
             ~"Dec"
         ].each |day| {
-            assert!(test(*day, ~"%b"));
+            assert!(test(*day, "%b"));
         }
 
-        assert!(test(~"19", ~"%C"));
-        assert!(test(~"Fri Feb 13 23:31:30 2009", ~"%c"));
-        assert!(test(~"02/13/09", ~"%D"));
-        assert!(test(~"03", ~"%d"));
-        assert!(test(~"13", ~"%d"));
-        assert!(test(~" 3", ~"%e"));
-        assert!(test(~"13", ~"%e"));
-        assert!(test(~"2009-02-13", ~"%F"));
-        assert!(test(~"03", ~"%H"));
-        assert!(test(~"13", ~"%H"));
-        assert!(test(~"03", ~"%I")); // FIXME (#2350): flesh out
-        assert!(test(~"11", ~"%I")); // FIXME (#2350): flesh out
-        assert!(test(~"044", ~"%j"));
-        assert!(test(~" 3", ~"%k"));
-        assert!(test(~"13", ~"%k"));
-        assert!(test(~" 1", ~"%l"));
-        assert!(test(~"11", ~"%l"));
-        assert!(test(~"03", ~"%M"));
-        assert!(test(~"13", ~"%M"));
-        assert!(test(~"\n", ~"%n"));
-        assert!(test(~"am", ~"%P"));
-        assert!(test(~"pm", ~"%P"));
-        assert!(test(~"AM", ~"%p"));
-        assert!(test(~"PM", ~"%p"));
-        assert!(test(~"23:31", ~"%R"));
-        assert!(test(~"11:31:30 AM", ~"%r"));
-        assert!(test(~"11:31:30 PM", ~"%r"));
-        assert!(test(~"03", ~"%S"));
-        assert!(test(~"13", ~"%S"));
-        assert!(test(~"15:31:30", ~"%T"));
-        assert!(test(~"\t", ~"%t"));
-        assert!(test(~"1", ~"%u"));
-        assert!(test(~"7", ~"%u"));
-        assert!(test(~"13-Feb-2009", ~"%v"));
-        assert!(test(~"0", ~"%w"));
-        assert!(test(~"6", ~"%w"));
-        assert!(test(~"2009", ~"%Y"));
-        assert!(test(~"09", ~"%y"));
-        assert!(result::unwrap(strptime(~"UTC", ~"%Z")).tm_zone ==
+        assert!(test("19", "%C"));
+        assert!(test("Fri Feb 13 23:31:30 2009", "%c"));
+        assert!(test("02/13/09", "%D"));
+        assert!(test("03", "%d"));
+        assert!(test("13", "%d"));
+        assert!(test(" 3", "%e"));
+        assert!(test("13", "%e"));
+        assert!(test("2009-02-13", "%F"));
+        assert!(test("03", "%H"));
+        assert!(test("13", "%H"));
+        assert!(test("03", "%I")); // FIXME (#2350): flesh out
+        assert!(test("11", "%I")); // FIXME (#2350): flesh out
+        assert!(test("044", "%j"));
+        assert!(test(" 3", "%k"));
+        assert!(test("13", "%k"));
+        assert!(test(" 1", "%l"));
+        assert!(test("11", "%l"));
+        assert!(test("03", "%M"));
+        assert!(test("13", "%M"));
+        assert!(test("\n", "%n"));
+        assert!(test("am", "%P"));
+        assert!(test("pm", "%P"));
+        assert!(test("AM", "%p"));
+        assert!(test("PM", "%p"));
+        assert!(test("23:31", "%R"));
+        assert!(test("11:31:30 AM", "%r"));
+        assert!(test("11:31:30 PM", "%r"));
+        assert!(test("03", "%S"));
+        assert!(test("13", "%S"));
+        assert!(test("15:31:30", "%T"));
+        assert!(test("\t", "%t"));
+        assert!(test("1", "%u"));
+        assert!(test("7", "%u"));
+        assert!(test("13-Feb-2009", "%v"));
+        assert!(test("0", "%w"));
+        assert!(test("6", "%w"));
+        assert!(test("2009", "%Y"));
+        assert!(test("09", "%y"));
+        assert!(result::unwrap(strptime("UTC", "%Z")).tm_zone ==
             ~"UTC");
-        assert!(result::unwrap(strptime(~"PST", ~"%Z")).tm_zone ==
+        assert!(result::unwrap(strptime("PST", "%Z")).tm_zone ==
             ~"");
-        assert!(result::unwrap(strptime(~"-0000", ~"%z")).tm_gmtoff ==
+        assert!(result::unwrap(strptime("-0000", "%z")).tm_gmtoff ==
             0);
-        assert!(result::unwrap(strptime(~"-0800", ~"%z")).tm_gmtoff ==
+        assert!(result::unwrap(strptime("-0800", "%z")).tm_gmtoff ==
             0);
-        assert!(test(~"%", ~"%%"));
+        assert!(test("%", "%%"));
     }
 
     fn test_ctime() {
-        os::setenv(~"TZ", ~"America/Los_Angeles");
+        os::setenv("TZ", "America/Los_Angeles");
         tzset();
 
         let time = ::time::Timespec::new(1234567890, 54321);
@@ -1147,60 +1147,60 @@ mod tests {
     }
 
     fn test_strftime() {
-        os::setenv(~"TZ", ~"America/Los_Angeles");
+        os::setenv("TZ", "America/Los_Angeles");
         tzset();
 
         let time = ::time::Timespec::new(1234567890, 54321);
         let utc = at_utc(time);
         let local = at(time);
 
-        assert_eq!(local.strftime(~""), ~"");
-        assert_eq!(local.strftime(~"%A"), ~"Friday");
-        assert_eq!(local.strftime(~"%a"), ~"Fri");
-        assert_eq!(local.strftime(~"%B"), ~"February");
-        assert_eq!(local.strftime(~"%b"), ~"Feb");
-        assert_eq!(local.strftime(~"%C"), ~"20");
-        assert_eq!(local.strftime(~"%c"), ~"Fri Feb 13 15:31:30 2009");
-        assert_eq!(local.strftime(~"%D"), ~"02/13/09");
-        assert_eq!(local.strftime(~"%d"), ~"13");
-        assert_eq!(local.strftime(~"%e"), ~"13");
-        assert_eq!(local.strftime(~"%F"), ~"2009-02-13");
+        assert_eq!(local.strftime(""), ~"");
+        assert_eq!(local.strftime("%A"), ~"Friday");
+        assert_eq!(local.strftime("%a"), ~"Fri");
+        assert_eq!(local.strftime("%B"), ~"February");
+        assert_eq!(local.strftime("%b"), ~"Feb");
+        assert_eq!(local.strftime("%C"), ~"20");
+        assert_eq!(local.strftime("%c"), ~"Fri Feb 13 15:31:30 2009");
+        assert_eq!(local.strftime("%D"), ~"02/13/09");
+        assert_eq!(local.strftime("%d"), ~"13");
+        assert_eq!(local.strftime("%e"), ~"13");
+        assert_eq!(local.strftime("%F"), ~"2009-02-13");
         // assert!(local.strftime("%G") == "2009");
         // assert!(local.strftime("%g") == "09");
-        assert_eq!(local.strftime(~"%H"), ~"15");
-        assert_eq!(local.strftime(~"%I"), ~"03");
-        assert_eq!(local.strftime(~"%j"), ~"044");
-        assert_eq!(local.strftime(~"%k"), ~"15");
-        assert_eq!(local.strftime(~"%l"), ~" 3");
-        assert_eq!(local.strftime(~"%M"), ~"31");
-        assert_eq!(local.strftime(~"%m"), ~"02");
-        assert_eq!(local.strftime(~"%n"), ~"\n");
-        assert_eq!(local.strftime(~"%P"), ~"pm");
-        assert_eq!(local.strftime(~"%p"), ~"PM");
-        assert_eq!(local.strftime(~"%R"), ~"15:31");
-        assert_eq!(local.strftime(~"%r"), ~"03:31:30 PM");
-        assert_eq!(local.strftime(~"%S"), ~"30");
-        assert_eq!(local.strftime(~"%s"), ~"1234567890");
-        assert_eq!(local.strftime(~"%T"), ~"15:31:30");
-        assert_eq!(local.strftime(~"%t"), ~"\t");
+        assert_eq!(local.strftime("%H"), ~"15");
+        assert_eq!(local.strftime("%I"), ~"03");
+        assert_eq!(local.strftime("%j"), ~"044");
+        assert_eq!(local.strftime("%k"), ~"15");
+        assert_eq!(local.strftime("%l"), ~" 3");
+        assert_eq!(local.strftime("%M"), ~"31");
+        assert_eq!(local.strftime("%m"), ~"02");
+        assert_eq!(local.strftime("%n"), ~"\n");
+        assert_eq!(local.strftime("%P"), ~"pm");
+        assert_eq!(local.strftime("%p"), ~"PM");
+        assert_eq!(local.strftime("%R"), ~"15:31");
+        assert_eq!(local.strftime("%r"), ~"03:31:30 PM");
+        assert_eq!(local.strftime("%S"), ~"30");
+        assert_eq!(local.strftime("%s"), ~"1234567890");
+        assert_eq!(local.strftime("%T"), ~"15:31:30");
+        assert_eq!(local.strftime("%t"), ~"\t");
         // assert!(local.strftime("%U") == "06");
-        assert_eq!(local.strftime(~"%u"), ~"5");
+        assert_eq!(local.strftime("%u"), ~"5");
         // assert!(local.strftime("%V") == "07");
-        assert_eq!(local.strftime(~"%v"), ~"13-Feb-2009");
+        assert_eq!(local.strftime("%v"), ~"13-Feb-2009");
         // assert!(local.strftime("%W") == "06");
-        assert_eq!(local.strftime(~"%w"), ~"5");
+        assert_eq!(local.strftime("%w"), ~"5");
         // handle "%X"
         // handle "%x"
-        assert_eq!(local.strftime(~"%Y"), ~"2009");
-        assert_eq!(local.strftime(~"%y"), ~"09");
+        assert_eq!(local.strftime("%Y"), ~"2009");
+        assert_eq!(local.strftime("%y"), ~"09");
 
         // FIXME (#2350): We should probably standardize on the timezone
         // abbreviation.
-        let zone = local.strftime(~"%Z");
+        let zone = local.strftime("%Z");
         assert!(zone == ~"PST" || zone == ~"Pacific Standard Time");
 
-        assert_eq!(local.strftime(~"%z"), ~"-0800");
-        assert_eq!(local.strftime(~"%%"), ~"%");
+        assert_eq!(local.strftime("%z"), ~"-0800");
+        assert_eq!(local.strftime("%%"), ~"%");
 
         // FIXME (#2350): We should probably standardize on the timezone
         // abbreviation.

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -759,10 +759,10 @@ mod test_treemap {
     fn u8_map() {
         let mut m = TreeMap::new();
 
-        let k1 = str::to_bytes(~"foo");
-        let k2 = str::to_bytes(~"bar");
-        let v1 = str::to_bytes(~"baz");
-        let v2 = str::to_bytes(~"foobar");
+        let k1 = str::to_bytes("foo");
+        let k2 = str::to_bytes("bar");
+        let v1 = str::to_bytes("baz");
+        let v2 = str::to_bytes("foobar");
 
         m.insert(copy k1, copy v1);
         m.insert(copy k2, copy v2);

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -211,8 +211,8 @@ mod test {
 
     #[test]
     fn test_rpaths_to_flags() {
-        let flags = rpaths_to_flags(~[Path("path1"),
-                                      Path("path2")]);
+        let flags = rpaths_to_flags([Path("path1"),
+                                     Path("path2")]);
         assert_eq!(flags, ~[~"-Wl,-rpath,path1", ~"-Wl,-rpath,path2"]);
     }
 
@@ -243,10 +243,10 @@ mod test {
 
     #[test]
     fn test_minimize2() {
-        let res = minimize_rpaths(~[Path("1a"), Path("2"), Path("2"),
-                                    Path("1a"), Path("4a"),Path("1a"),
-                                    Path("2"), Path("3"), Path("4a"),
-                                    Path("3")]);
+        let res = minimize_rpaths([Path("1a"), Path("2"), Path("2"),
+                                   Path("1a"), Path("4a"),Path("1a"),
+                                   Path("2"), Path("3"), Path("4a"),
+                                   Path("3")]);
         assert_eq!(res, ~[Path("1a"), Path("2"), Path("4a"), Path("3")]);
     }
 

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -30,7 +30,7 @@ use core::io;
 use core::os;
 use core::str;
 use core::vec;
-use extra::getopts::groups::{optopt, optmulti, optflag, optflagopt, getopts};
+use extra::getopts::groups::{optopt, optmulti, optflag, optflagopt};
 use extra::getopts::{opt_present};
 use extra::getopts;
 use syntax::ast;
@@ -942,7 +942,7 @@ mod test {
             @~"rustc", matches, diagnostic::emit);
         let sess = build_session(sessopts, diagnostic::emit);
         let cfg = build_configuration(sess, @~"whatever", &str_input(~""));
-        assert!((attr::contains_name(cfg, ~"test")));
+        assert!((attr::contains_name(cfg, "test")));
     }
 
     // When the user supplies --test and --cfg test, don't implicitly add
@@ -950,7 +950,7 @@ mod test {
     #[test]
     fn test_switch_implies_cfg_test_unless_cfg_test() {
         let matches =
-            &match getopts(~[~"--test", ~"--cfg=test"], optgroups()) {
+            &match getopts([~"--test", ~"--cfg=test"], optgroups()) {
               Ok(copy m) => m,
               Err(copy f) => {
                 fail!("test_switch_implies_cfg_test_unless_cfg_test: %s", getopts::fail_str(f));
@@ -960,7 +960,7 @@ mod test {
             @~"rustc", matches, diagnostic::emit);
         let sess = build_session(sessopts, diagnostic::emit);
         let cfg = build_configuration(sess, @~"whatever", &str_input(~""));
-        let test_items = attr::find_meta_items_by_name(cfg, ~"test");
+        let test_items = attr::find_meta_items_by_name(cfg, "test");
         assert_eq!(test_items.len(), 1u);
     }
 }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -10,7 +10,6 @@
 
 use core::prelude::*;
 
-use driver::session::Session;
 use driver::session;
 use middle::ty;
 use middle::pat_util;

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -535,7 +535,7 @@ pub impl NameBindings {
                        parent_link: ParentLink,
                        def_id: Option<def_id>,
                        kind: ModuleKind,
-                       sp: span) {
+                       _sp: span) {
         match self.type_def {
             None => {
                 let module = @mut Module(parent_link, def_id, kind);
@@ -2586,8 +2586,8 @@ pub impl Resolver {
                                         (ImportSearch, ImplModuleKind) => {
                                             self.session.span_err(
                                                 span,
-                                                ~"cannot import from a trait \
-                                                  or type implementation");
+                                                "cannot import from a trait \
+                                                 or type implementation");
                                             return Failed;
                                         }
                                         (_, _) => search_module = module_def,

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1367,13 +1367,21 @@ pub type mono_id = @mono_id_;
 impl to_bytes::IterBytes for mono_param_id {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         match *self {
-            mono_precise(t, ref mids) =>
-                to_bytes::iter_bytes_3(&0u8, &ty::type_id(t), mids, lsb0, f),
+            mono_precise(t, ref mids) => {
+                0u8.iter_bytes(lsb0, f) &&
+                ty::type_id(t).iter_bytes(lsb0, f) &&
+                mids.iter_bytes(lsb0, f)
+            }
 
             mono_any => 1u8.iter_bytes(lsb0, f),
 
-            mono_repr(ref a, ref b, ref c, ref d) =>
-                to_bytes::iter_bytes_5(&2u8, a, b, c, d, lsb0, f)
+            mono_repr(ref a, ref b, ref c, ref d) => {
+                2u8.iter_bytes(lsb0, f) &&
+                a.iter_bytes(lsb0, f) &&
+                b.iter_bytes(lsb0, f) &&
+                c.iter_bytes(lsb0, f) &&
+                d.iter_bytes(lsb0, f)
+            }
         }
     }
 }
@@ -1386,7 +1394,7 @@ impl to_bytes::IterBytes for MonoDataClass {
 
 impl to_bytes::IterBytes for mono_id_ {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_2(&self.def, &self.params, lsb0, f)
+        self.def.iter_bytes(lsb0, f) && self.params.iter_bytes(lsb0, f)
     }
 }
 

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -873,7 +873,7 @@ pub fn trans_trait_cast(bcx: block,
                         val: @ast::expr,
                         id: ast::node_id,
                         dest: expr::Dest,
-                        store: ty::TraitStore)
+                        _store: ty::TraitStore)
                      -> block {
     let mut bcx = bcx;
     let _icx = bcx.insn_ctxt("impl::trans_cast");

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -145,7 +145,7 @@ pub impl Reflector {
     }
 
     fn leaf(&mut self, name: ~str) {
-        self.visit(name, ~[]);
+        self.visit(name, []);
     }
 
     // Entrypoint

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -137,7 +137,9 @@ type creader_cache = @mut HashMap<creader_cache_key, t>;
 
 impl to_bytes::IterBytes for creader_cache_key {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_3(&self.cnum, &self.pos, &self.len, lsb0, f)
+        self.cnum.iter_bytes(lsb0, f) &&
+        self.pos.iter_bytes(lsb0, f) &&
+        self.len.iter_bytes(lsb0, f)
     }
 }
 
@@ -392,14 +394,19 @@ pub struct FnSig {
 
 impl to_bytes::IterBytes for BareFnTy {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_3(&self.purity, &self.abis, &self.sig, lsb0, f)
+        self.purity.iter_bytes(lsb0, f) &&
+        self.abis.iter_bytes(lsb0, f) &&
+        self.sig.iter_bytes(lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for ClosureTy {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_5(&self.purity, &self.sigil, &self.onceness,
-                               &self.region, &self.sig, lsb0, f)
+        self.purity.iter_bytes(lsb0, f) &&
+        self.sigil.iter_bytes(lsb0, f) &&
+        self.onceness.iter_bytes(lsb0, f) &&
+        self.region.iter_bytes(lsb0, f) &&
+        self.sig.iter_bytes(lsb0, f)
     }
 }
 
@@ -717,9 +724,15 @@ pub enum InferTy {
 impl to_bytes::IterBytes for InferTy {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         match *self {
-          TyVar(ref tv) => to_bytes::iter_bytes_2(&0u8, tv, lsb0, f),
-          IntVar(ref iv) => to_bytes::iter_bytes_2(&1u8, iv, lsb0, f),
-          FloatVar(ref fv) => to_bytes::iter_bytes_2(&2u8, fv, lsb0, f),
+            TyVar(ref tv) => {
+                0u8.iter_bytes(lsb0, f) && tv.iter_bytes(lsb0, f)
+            }
+            IntVar(ref iv) => {
+                1u8.iter_bytes(lsb0, f) && iv.iter_bytes(lsb0, f)
+            }
+            FloatVar(ref fv) => {
+                2u8.iter_bytes(lsb0, f) && fv.iter_bytes(lsb0, f)
+            }
         }
     }
 }
@@ -733,8 +746,12 @@ pub enum InferRegion {
 impl to_bytes::IterBytes for InferRegion {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         match *self {
-            ReVar(ref rv) => to_bytes::iter_bytes_2(&0u8, rv, lsb0, f),
-            ReSkolemized(ref v, _) => to_bytes::iter_bytes_2(&1u8, v, lsb0, f)
+            ReVar(ref rv) => {
+                0u8.iter_bytes(lsb0, f) && rv.iter_bytes(lsb0, f)
+            }
+            ReSkolemized(ref v, _) => {
+                1u8.iter_bytes(lsb0, f) && v.iter_bytes(lsb0, f)
+            }
         }
     }
 }
@@ -2626,119 +2643,115 @@ impl cmp::TotalEq for bound_region {
 impl to_bytes::IterBytes for vstore {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         match *self {
-          vstore_fixed(ref u) =>
-          to_bytes::iter_bytes_2(&0u8, u, lsb0, f),
+            vstore_fixed(ref u) => {
+                0u8.iter_bytes(lsb0, f) && u.iter_bytes(lsb0, f)
+            }
+            vstore_uniq => 1u8.iter_bytes(lsb0, f),
+            vstore_box => 2u8.iter_bytes(lsb0, f),
 
-          vstore_uniq => 1u8.iter_bytes(lsb0, f),
-          vstore_box => 2u8.iter_bytes(lsb0, f),
-
-          vstore_slice(ref r) =>
-          to_bytes::iter_bytes_2(&3u8, r, lsb0, f),
+            vstore_slice(ref r) => {
+                3u8.iter_bytes(lsb0, f) && r.iter_bytes(lsb0, f)
+            }
         }
     }
 }
 
 impl to_bytes::IterBytes for substs {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-          to_bytes::iter_bytes_3(&self.self_r,
-                                 &self.self_ty,
-                                 &self.tps, lsb0, f)
+        self.self_r.iter_bytes(lsb0, f) &&
+        self.self_ty.iter_bytes(lsb0, f) &&
+        self.tps.iter_bytes(lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for mt {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-          to_bytes::iter_bytes_2(&self.ty,
-                                 &self.mutbl, lsb0, f)
+        self.ty.iter_bytes(lsb0, f) && self.mutbl.iter_bytes(lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for field {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-          to_bytes::iter_bytes_2(&self.ident,
-                                 &self.mt, lsb0, f)
+        self.ident.iter_bytes(lsb0, f) && self.mt.iter_bytes(lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for FnSig {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_2(&self.inputs,
-                               &self.output,
-                               lsb0, f)
+        self.inputs.iter_bytes(lsb0, f) && self.output.iter_bytes(lsb0, f)
     }
 }
 
 impl to_bytes::IterBytes for sty {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         match *self {
-          ty_nil => 0u8.iter_bytes(lsb0, f),
-          ty_bool => 1u8.iter_bytes(lsb0, f),
+            ty_nil => 0u8.iter_bytes(lsb0, f),
+            ty_bool => 1u8.iter_bytes(lsb0, f),
 
-          ty_int(ref t) =>
-          to_bytes::iter_bytes_2(&2u8, t, lsb0, f),
+            ty_int(ref t) => 2u8.iter_bytes(lsb0, f) && t.iter_bytes(lsb0, f),
 
-          ty_uint(ref t) =>
-          to_bytes::iter_bytes_2(&3u8, t, lsb0, f),
+            ty_uint(ref t) => 3u8.iter_bytes(lsb0, f) && t.iter_bytes(lsb0, f),
 
-          ty_float(ref t) =>
-          to_bytes::iter_bytes_2(&4u8, t, lsb0, f),
+            ty_float(ref t) => 4u8.iter_bytes(lsb0, f) && t.iter_bytes(lsb0, f),
 
-          ty_estr(ref v) =>
-          to_bytes::iter_bytes_2(&5u8, v, lsb0, f),
+            ty_estr(ref v) => 5u8.iter_bytes(lsb0, f) && v.iter_bytes(lsb0, f),
 
-          ty_enum(ref did, ref substs) =>
-          to_bytes::iter_bytes_3(&6u8, did, substs, lsb0, f),
+            ty_enum(ref did, ref substs) => {
+                6u8.iter_bytes(lsb0, f) &&
+                did.iter_bytes(lsb0, f) &&
+                substs.iter_bytes(lsb0, f)
+            }
 
-          ty_box(ref mt) =>
-          to_bytes::iter_bytes_2(&7u8, mt, lsb0, f),
+            ty_box(ref mt) => 7u8.iter_bytes(lsb0, f) && mt.iter_bytes(lsb0, f),
 
-          ty_evec(ref mt, ref v) =>
-          to_bytes::iter_bytes_3(&8u8, mt, v, lsb0, f),
+            ty_evec(ref mt, ref v) => {
+                8u8.iter_bytes(lsb0, f) &&
+                mt.iter_bytes(lsb0, f) &&
+                v.iter_bytes(lsb0, f)
+            }
 
-          ty_unboxed_vec(ref mt) =>
-          to_bytes::iter_bytes_2(&9u8, mt, lsb0, f),
+            ty_unboxed_vec(ref mt) => 9u8.iter_bytes(lsb0, f) && mt.iter_bytes(lsb0, f),
 
-          ty_tup(ref ts) =>
-          to_bytes::iter_bytes_2(&10u8, ts, lsb0, f),
+            ty_tup(ref ts) => 10u8.iter_bytes(lsb0, f) && ts.iter_bytes(lsb0, f),
 
-          ty_bare_fn(ref ft) =>
-          to_bytes::iter_bytes_2(&12u8, ft, lsb0, f),
+            ty_bare_fn(ref ft) => 12u8.iter_bytes(lsb0, f) && ft.iter_bytes(lsb0, f),
 
-          ty_self(ref did) => to_bytes::iter_bytes_2(&13u8, did, lsb0, f),
+            ty_self(ref did) => 13u8.iter_bytes(lsb0, f) && did.iter_bytes(lsb0, f),
 
-          ty_infer(ref v) =>
-          to_bytes::iter_bytes_2(&14u8, v, lsb0, f),
+            ty_infer(ref v) => 14u8.iter_bytes(lsb0, f) && v.iter_bytes(lsb0, f),
 
-          ty_param(ref p) =>
-          to_bytes::iter_bytes_2(&15u8, p, lsb0, f),
+            ty_param(ref p) => 15u8.iter_bytes(lsb0, f) && p.iter_bytes(lsb0, f),
 
-          ty_type => 16u8.iter_bytes(lsb0, f),
-          ty_bot => 17u8.iter_bytes(lsb0, f),
+            ty_type => 16u8.iter_bytes(lsb0, f),
+            ty_bot => 17u8.iter_bytes(lsb0, f),
 
-          ty_ptr(ref mt) =>
-          to_bytes::iter_bytes_2(&18u8, mt, lsb0, f),
+            ty_ptr(ref mt) => 18u8.iter_bytes(lsb0, f) && mt.iter_bytes(lsb0, f),
 
-          ty_uniq(ref mt) =>
-          to_bytes::iter_bytes_2(&19u8, mt, lsb0, f),
+            ty_uniq(ref mt) => 19u8.iter_bytes(lsb0, f) && mt.iter_bytes(lsb0, f),
 
-          ty_trait(ref did, ref substs, ref v, ref mutbl) =>
-          to_bytes::iter_bytes_5(&20u8, did, substs, v, mutbl, lsb0, f),
+            ty_trait(ref did, ref substs, ref v, ref mutbl) => {
+                20u8.iter_bytes(lsb0, f) &&
+                did.iter_bytes(lsb0, f) &&
+                substs.iter_bytes(lsb0, f) &&
+                v.iter_bytes(lsb0, f) &&
+                mutbl.iter_bytes(lsb0, f)
+            }
 
-          ty_opaque_closure_ptr(ref ck) =>
-          to_bytes::iter_bytes_2(&21u8, ck, lsb0, f),
+            ty_opaque_closure_ptr(ref ck) => 21u8.iter_bytes(lsb0, f) && ck.iter_bytes(lsb0, f),
 
-          ty_opaque_box => 22u8.iter_bytes(lsb0, f),
+            ty_opaque_box => 22u8.iter_bytes(lsb0, f),
 
-          ty_struct(ref did, ref substs) =>
-          to_bytes::iter_bytes_3(&23u8, did, substs, lsb0, f),
+            ty_struct(ref did, ref substs) => {
+                23u8.iter_bytes(lsb0, f) && did.iter_bytes(lsb0, f) && substs.iter_bytes(lsb0, f)
+            }
 
-          ty_rptr(ref r, ref mt) =>
-          to_bytes::iter_bytes_3(&24u8, r, mt, lsb0, f),
+            ty_rptr(ref r, ref mt) => {
+                24u8.iter_bytes(lsb0, f) && r.iter_bytes(lsb0, f) && mt.iter_bytes(lsb0, f)
+            }
 
-          ty_err => 25u8.iter_bytes(lsb0, f),
+            ty_err => 25u8.iter_bytes(lsb0, f),
 
-          ty_closure(ref ct) =>
-          to_bytes::iter_bytes_2(&26u8, ct, lsb0, f),
+            ty_closure(ref ct) => 26u8.iter_bytes(lsb0, f) && ct.iter_bytes(lsb0, f),
         }
     }
 }

--- a/src/librustc/middle/typeck/infer/region_inference.rs
+++ b/src/librustc/middle/typeck/infer/region_inference.rs
@@ -564,14 +564,23 @@ enum Constraint {
 impl to_bytes::IterBytes for Constraint {
    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         match *self {
-          ConstrainVarSubVar(ref v0, ref v1) =>
-          to_bytes::iter_bytes_3(&0u8, v0, v1, lsb0, f),
+            ConstrainVarSubVar(ref v0, ref v1) => {
+                0u8.iter_bytes(lsb0, f) &&
+                v0.iter_bytes(lsb0, f) &&
+                v1.iter_bytes(lsb0, f)
+            }
 
-          ConstrainRegSubVar(ref ra, ref va) =>
-          to_bytes::iter_bytes_3(&1u8, ra, va, lsb0, f),
+            ConstrainRegSubVar(ref ra, ref va) => {
+                1u8.iter_bytes(lsb0, f) &&
+                ra.iter_bytes(lsb0, f) &&
+                va.iter_bytes(lsb0, f)
+            }
 
-          ConstrainVarSubReg(ref va, ref ra) =>
-          to_bytes::iter_bytes_3(&2u8, va, ra, lsb0, f)
+            ConstrainVarSubReg(ref va, ref ra) => {
+                2u8.iter_bytes(lsb0, f) &&
+                va.iter_bytes(lsb0, f) &&
+                ra.iter_bytes(lsb0, f)
+            }
         }
     }
 }

--- a/src/librustc/util/enum_set.rs
+++ b/src/librustc/util/enum_set.rs
@@ -10,8 +10,6 @@
 
 use core::prelude::*;
 
-use core;
-
 #[deriving(Eq, IterBytes)]
 pub struct EnumSet<E> {
     // We must maintain the invariant that no bits are set

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -278,26 +278,26 @@ mod test {
 
     #[test]
     fn should_error_with_no_crates() {
-        let config = parse_config(~[~"rustdoc"]);
+        let config = parse_config([~"rustdoc"]);
         assert!(config.get_err() == ~"no crates specified");
     }
 
     #[test]
     fn should_error_with_multiple_crates() {
         let config =
-            parse_config(~[~"rustdoc", ~"crate1.rc", ~"crate2.rc"]);
+            parse_config([~"rustdoc", ~"crate1.rc", ~"crate2.rc"]);
         assert!(config.get_err() == ~"multiple crates specified");
     }
 
     #[test]
     fn should_set_output_dir_to_cwd_if_not_provided() {
-        let config = parse_config(~[~"rustdoc", ~"crate.rc"]);
+        let config = parse_config([~"rustdoc", ~"crate.rc"]);
         assert!(config.get().output_dir == Path("."));
     }
 
     #[test]
     fn should_set_output_dir_if_provided() {
-        let config = parse_config(~[
+        let config = parse_config([
             ~"rustdoc", ~"crate.rc", ~"--output-dir", ~"snuggles"
         ]);
         assert!(config.get().output_dir == Path("snuggles"));
@@ -305,13 +305,13 @@ mod test {
 
     #[test]
     fn should_set_output_format_to_pandoc_html_if_not_provided() {
-        let config = parse_config(~[~"rustdoc", ~"crate.rc"]);
+        let config = parse_config([~"rustdoc", ~"crate.rc"]);
         assert!(config.get().output_format == PandocHtml);
     }
 
     #[test]
     fn should_set_output_format_to_markdown_if_requested() {
-        let config = parse_config(~[
+        let config = parse_config([
             ~"rustdoc", ~"crate.rc", ~"--output-format", ~"markdown"
         ]);
         assert!(config.get().output_format == Markdown);
@@ -319,7 +319,7 @@ mod test {
 
     #[test]
     fn should_set_output_format_to_pandoc_html_if_requested() {
-        let config = parse_config(~[
+        let config = parse_config([
             ~"rustdoc", ~"crate.rc", ~"--output-format", ~"html"
         ]);
         assert!(config.get().output_format == PandocHtml);
@@ -327,7 +327,7 @@ mod test {
 
     #[test]
     fn should_error_on_bogus_format() {
-        let config = parse_config(~[
+        let config = parse_config([
             ~"rustdoc", ~"crate.rc", ~"--output-format", ~"bogus"
         ]);
         assert!(config.get_err() == ~"unknown output format 'bogus'");
@@ -335,13 +335,13 @@ mod test {
 
     #[test]
     fn should_set_output_style_to_doc_per_mod_by_default() {
-        let config = parse_config(~[~"rustdoc", ~"crate.rc"]);
+        let config = parse_config([~"rustdoc", ~"crate.rc"]);
         assert!(config.get().output_style == DocPerMod);
     }
 
     #[test]
     fn should_set_output_style_to_one_doc_if_requested() {
-        let config = parse_config(~[
+        let config = parse_config([
             ~"rustdoc", ~"crate.rc", ~"--output-style", ~"doc-per-crate"
         ]);
         assert!(config.get().output_style == DocPerCrate);
@@ -349,7 +349,7 @@ mod test {
 
     #[test]
     fn should_set_output_style_to_doc_per_mod_if_requested() {
-        let config = parse_config(~[
+        let config = parse_config([
             ~"rustdoc", ~"crate.rc", ~"--output-style", ~"doc-per-mod"
         ]);
         assert!(config.get().output_style == DocPerMod);
@@ -357,7 +357,7 @@ mod test {
 
     #[test]
     fn should_error_on_bogus_output_style() {
-        let config = parse_config(~[
+        let config = parse_config([
             ~"rustdoc", ~"crate.rc", ~"--output-style", ~"bogus"
         ]);
         assert!(config.get_err() == ~"unknown output style 'bogus'");
@@ -365,7 +365,7 @@ mod test {
 
     #[test]
     fn should_set_pandoc_command_if_requested() {
-        let config = parse_config(~[
+        let config = parse_config([
             ~"rustdoc", ~"crate.rc", ~"--pandoc-cmd", ~"panda-bear-doc"
         ]);
         assert!(config.get().pandoc_cmd == Some(~"panda-bear-doc"));
@@ -373,7 +373,7 @@ mod test {
 
     #[test]
     fn should_set_pandoc_command_when_using_pandoc() {
-        let config = parse_config(~[~"rustdoc", ~"crate.rc"]);
+        let config = parse_config([~"rustdoc", ~"crate.rc"]);
         assert!(config.get().pandoc_cmd == Some(~"pandoc"));
     }
 }

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -220,13 +220,13 @@ mod test {
 
     #[test]
     fn test_paragraphs_1() {
-        let paras = paragraphs(~"1\n\n2");
+        let paras = paragraphs("1\n\n2");
         assert_eq!(paras, ~[~"1", ~"2"]);
     }
 
     #[test]
     fn test_paragraphs_2() {
-        let paras = paragraphs(~"\n\n1\n1\n\n2\n\n");
+        let paras = paragraphs("\n\n1\n1\n\n2\n\n");
         assert_eq!(paras, ~[~"1\n1", ~"2"]);
     }
 

--- a/src/librustdoc/extract.rs
+++ b/src/librustdoc/extract.rs
@@ -16,9 +16,7 @@ use astsrv;
 use doc::ItemUtils;
 use doc;
 
-use core::local_data::local_data_get;
 use syntax::ast;
-use syntax;
 use syntax::parse::token::{ident_interner};
 use syntax::parse::token;
 

--- a/src/librustdoc/markdown_index_pass.rs
+++ b/src/librustdoc/markdown_index_pass.rs
@@ -193,21 +193,21 @@ mod test {
 
     #[test]
     fn should_remove_punctuation_from_headers() {
-        assert!(pandoc_header_id(~"impl foo of bar<A>") ==
+        assert!(pandoc_header_id("impl foo of bar<A>") ==
                 ~"impl-foo-of-bara");
-        assert!(pandoc_header_id(~"impl of num::num for int")
+        assert!(pandoc_header_id("impl of num::num for int")
                 == ~"impl-of-numnum-for-int");
-        assert!(pandoc_header_id(~"impl of num::num for int/&")
+        assert!(pandoc_header_id("impl of num::num for int/&")
                 == ~"impl-of-numnum-for-int");
-        assert!(pandoc_header_id(~"impl of num::num for ^int")
+        assert!(pandoc_header_id("impl of num::num for ^int")
                 == ~"impl-of-numnum-for-int");
-        assert!(pandoc_header_id(~"impl for & condvar")
+        assert!(pandoc_header_id("impl for & condvar")
                 == ~"impl-for-condvar");
-        assert!(pandoc_header_id(~"impl of Select<T, U> for (Left, Right)")
+        assert!(pandoc_header_id("impl of Select<T, U> for (Left, Right)")
                 == ~"impl-of-selectt-u-for-left-right");
-        assert!(pandoc_header_id(~"impl of Condition<'self, T, U>")
+        assert!(pandoc_header_id("impl of Condition<'self, T, U>")
                 == ~"impl-of-conditionself-t-u");
-        assert!(pandoc_header_id(~"impl of Condition<T: Copy + Clone>")
+        assert!(pandoc_header_id("impl of Condition<T: Copy + Clone>")
                 == ~"impl-of-conditiont-copy-clone");
     }
 

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -587,13 +587,13 @@ mod test {
     #[test]
     fn write_markdown_should_write_mod_headers() {
         let markdown = render(~"mod moo { }");
-        assert!(str::contains(markdown, ~"# Module `moo`"));
+        assert!(str::contains(markdown, "# Module `moo`"));
     }
 
     #[test]
     fn should_leave_blank_line_after_header() {
         let markdown = render(~"mod morp { }");
-        assert!(str::contains(markdown, ~"Module `morp`\n\n"));
+        assert!(str::contains(markdown, "Module `morp`\n\n"));
     }
 
     #[test]
@@ -613,10 +613,10 @@ mod test {
               fn d() { }"
         );
 
-        let idx_a = str::find_str(markdown, ~"# Module `a`").get();
-        let idx_b = str::find_str(markdown, ~"## Function `b`").get();
-        let idx_c = str::find_str(markdown, ~"# Module `c`").get();
-        let idx_d = str::find_str(markdown, ~"## Function `d`").get();
+        let idx_a = str::find_str(markdown, "# Module `a`").get();
+        let idx_b = str::find_str(markdown, "## Function `b`").get();
+        let idx_c = str::find_str(markdown, "# Module `c`").get();
+        let idx_d = str::find_str(markdown, "## Function `d`").get();
 
         assert!(idx_b < idx_d);
         assert!(idx_d < idx_a);
@@ -649,7 +649,7 @@ mod test {
             let (page, markdown) = po.recv();
             match page {
                 doc::CratePage(_) => {
-                    assert!(str::contains(markdown, ~"% Crate core"));
+                    assert!(str::contains(markdown, "% Crate core"));
                 }
                 doc::ItemPage(_) => {
                     assert!(str::contains(markdown, ~"% Module a"));
@@ -661,7 +661,7 @@ mod test {
     #[test]
     fn should_write_full_path_to_mod() {
         let markdown = render(~"mod a { mod b { mod c { } } }");
-        assert!(str::contains(markdown, ~"# Module `a::b::c`"));
+        assert!(str::contains(markdown, "# Module `a::b::c`"));
     }
 
     #[test]
@@ -672,13 +672,13 @@ mod test {
               Body\"]\
               mod a {
 }");
-        assert!(str::contains(markdown, ~"#### Header\n\nBody\n\n"));
+        assert!(str::contains(markdown, "#### Header\n\nBody\n\n"));
     }
 
     #[test]
     fn should_write_crate_description() {
         let markdown = render(~"#[doc = \"this is the crate\"];");
-        assert!(str::contains(markdown, ~"this is the crate"));
+        assert!(str::contains(markdown, "this is the crate"));
     }
 
 
@@ -687,21 +687,21 @@ mod test {
         let markdown = render(~"mod a { } mod b { }");
         assert!(str::contains(
             markdown,
-            ~"\n\n* [Module `a`](#module-a)\n\
-              * [Module `b`](#module-b)\n\n"
+            "\n\n* [Module `a`](#module-a)\n\
+             * [Module `b`](#module-b)\n\n"
         ));
     }
 
     #[test]
     fn should_write_index_brief() {
         let markdown = render(~"#[doc = \"test\"] mod a { }");
-        assert!(str::contains(markdown, ~"(#module-a) - test\n"));
+        assert!(str::contains(markdown, "(#module-a) - test\n"));
     }
 
     #[test]
     fn should_not_write_index_if_no_entries() {
         let markdown = render(~"");
-        assert!(!str::contains(markdown, ~"\n\n\n"));
+        assert!(!str::contains(markdown, "\n\n\n"));
     }
 
     #[test]
@@ -709,7 +709,7 @@ mod test {
         let markdown = render(~"extern { fn a(); }");
         assert!(str::contains(
             markdown,
-            ~"\n\n* [Function `a`](#function-a)\n\n"
+            "\n\n* [Function `a`](#function-a)\n\n"
         ));
     }
 
@@ -717,32 +717,32 @@ mod test {
     fn should_write_foreign_fns() {
         let markdown = render(
             ~"extern { #[doc = \"test\"] fn a(); }");
-        assert!(str::contains(markdown, ~"test"));
+        assert!(str::contains(markdown, "test"));
     }
 
     #[test]
     fn should_write_foreign_fn_headers() {
         let markdown = render(
             ~"extern { #[doc = \"test\"] fn a(); }");
-        assert!(str::contains(markdown, ~"## Function `a`"));
+        assert!(str::contains(markdown, "## Function `a`"));
     }
 
     #[test]
     fn write_markdown_should_write_function_header() {
         let markdown = render(~"fn func() { }");
-        assert!(str::contains(markdown, ~"## Function `func`"));
+        assert!(str::contains(markdown, "## Function `func`"));
     }
 
     #[test]
     fn should_write_the_function_signature() {
         let markdown = render(~"#[doc = \"f\"] fn a() { }");
-        assert!(str::contains(markdown, ~"\n    fn a()\n"));
+        assert!(str::contains(markdown, "\n    fn a()\n"));
     }
 
     #[test]
     fn should_insert_blank_line_after_fn_signature() {
         let markdown = render(~"#[doc = \"f\"] fn a() { }");
-        assert!(str::contains(markdown, ~"fn a()\n\n"));
+        assert!(str::contains(markdown, "fn a()\n\n"));
     }
 
     #[test]
@@ -763,19 +763,19 @@ mod test {
             ]
         };
         let markdown = write_markdown_str(doc);
-        assert!(str::contains(markdown, ~"    line 1\n    line 2"));
+        assert!(str::contains(markdown, "    line 1\n    line 2"));
     }
 
     #[test]
     fn should_leave_blank_line_between_fn_header_and_sig() {
         let markdown = render(~"fn a() { }");
-        assert!(str::contains(markdown, ~"Function `a`\n\n    fn a()"));
+        assert!(str::contains(markdown, "Function `a`\n\n    fn a()"));
     }
 
     #[test]
     fn should_write_const_header() {
         let markdown = render(~"static a: bool = true;");
-        assert!(str::contains(markdown, ~"## Const `a`\n\n"));
+        assert!(str::contains(markdown, "## Const `a`\n\n"));
     }
 
     #[test]
@@ -783,20 +783,19 @@ mod test {
         let markdown = render(
             ~"#[doc = \"b\"]\
               static a: bool = true;");
-        assert!(str::contains(markdown, ~"\n\nb\n\n"));
+        assert!(str::contains(markdown, "\n\nb\n\n"));
     }
 
     #[test]
     fn should_write_enum_header() {
         let markdown = render(~"enum a { b }");
-        assert!(str::contains(markdown, ~"## Enum `a`\n\n"));
+        assert!(str::contains(markdown, "## Enum `a`\n\n"));
     }
 
     #[test]
     fn should_write_enum_description() {
-        let markdown = render(
-            ~"#[doc = \"b\"] enum a { b }");
-        assert!(str::contains(markdown, ~"\n\nb\n\n"));
+        let markdown = render(~"#[doc = \"b\"] enum a { b }");
+        assert!(str::contains(markdown, "\n\nb\n\n"));
     }
 
     #[test]
@@ -807,9 +806,9 @@ mod test {
               #[doc = \"test\"] c }");
         assert!(str::contains(
             markdown,
-            ~"\n\n#### Variants\n\
-              \n* `b` - test\
-              \n* `c` - test\n\n"));
+            "\n\n#### Variants\n\
+             \n* `b` - test\
+             \n* `c` - test\n\n"));
     }
 
     #[test]
@@ -817,9 +816,9 @@ mod test {
         let markdown = render(~"enum a { b, c }");
         assert!(str::contains(
             markdown,
-            ~"\n\n#### Variants\n\
-              \n* `b`\
-              \n* `c`\n\n"));
+            "\n\n#### Variants\n\
+             \n* `b`\
+             \n* `c`\n\n"));
     }
 
     #[test]
@@ -827,100 +826,97 @@ mod test {
         let markdown = render(~"enum a { b(int), #[doc = \"a\"] c(int) }");
         assert!(str::contains(
             markdown,
-            ~"\n\n#### Variants\n\
-              \n* `b(int)`\
-              \n* `c(int)` - a\n\n"));
+            "\n\n#### Variants\n\
+             \n* `b(int)`\
+             \n* `c(int)` - a\n\n"));
     }
 
     #[test]
     fn should_write_trait_header() {
         let markdown = render(~"trait i { fn a(); }");
-        assert!(str::contains(markdown, ~"## Trait `i`"));
+        assert!(str::contains(markdown, "## Trait `i`"));
     }
 
     #[test]
     fn should_write_trait_desc() {
-        let markdown = render(
-            ~"#[doc = \"desc\"] trait i { fn a(); }");
-        assert!(str::contains(markdown, ~"desc"));
+        let markdown = render(~"#[doc = \"desc\"] trait i { fn a(); }");
+        assert!(str::contains(markdown, "desc"));
     }
 
     #[test]
     fn should_write_trait_method_header() {
-        let markdown = render(
-            ~"trait i { fn a(); }");
-        assert!(str::contains(markdown, ~"### Method `a`"));
+        let markdown = render(~"trait i { fn a(); }");
+        assert!(str::contains(markdown, "### Method `a`"));
     }
 
     #[test]
     fn should_write_trait_method_signature() {
-        let markdown = render(
-            ~"trait i { fn a(&self); }");
-        assert!(str::contains(markdown, ~"\n    fn a(&self)"));
+        let markdown = render(~"trait i { fn a(&self); }");
+        assert!(str::contains(markdown, "\n    fn a(&self)"));
     }
 
     #[test]
     fn should_write_impl_header() {
         let markdown = render(~"impl int { fn a() { } }");
-        assert!(str::contains(markdown, ~"## Implementation for `int`"));
+        assert!(str::contains(markdown, "## Implementation for `int`"));
     }
 
     #[test]
     fn should_write_impl_header_with_bounds() {
         let markdown = render(~"impl <T> int<T> { }");
-        assert!(str::contains(markdown, ~"## Implementation for `int<T>` where `<T>`"));
+        assert!(str::contains(markdown, "## Implementation for `int<T>` where `<T>`"));
     }
 
     #[test]
     fn should_write_impl_header_with_trait() {
         let markdown = render(~"impl j for int { fn a() { } }");
         assert!(str::contains(markdown,
-                              ~"## Implementation of `j` for `int`"));
+                              "## Implementation of `j` for `int`"));
     }
 
     #[test]
     fn should_write_impl_desc() {
         let markdown = render(
             ~"#[doc = \"desc\"] impl int { fn a() { } }");
-        assert!(str::contains(markdown, ~"desc"));
+        assert!(str::contains(markdown, "desc"));
     }
 
     #[test]
     fn should_write_impl_method_header() {
         let markdown = render(
             ~"impl int { fn a() { } }");
-        assert!(str::contains(markdown, ~"### Method `a`"));
+        assert!(str::contains(markdown, "### Method `a`"));
     }
 
     #[test]
     fn should_write_impl_method_signature() {
         let markdown = render(
             ~"impl int { fn a(&mut self) { } }");
-        assert!(str::contains(markdown, ~"\n    fn a(&mut self)"));
+        assert!(str::contains(markdown, "\n    fn a(&mut self)"));
     }
 
     #[test]
     fn should_write_type_header() {
         let markdown = render(~"type t = int;");
-        assert!(str::contains(markdown, ~"## Type `t`"));
+        assert!(str::contains(markdown, "## Type `t`"));
     }
 
     #[test]
     fn should_write_type_desc() {
         let markdown = render(
             ~"#[doc = \"desc\"] type t = int;");
-        assert!(str::contains(markdown, ~"\n\ndesc\n\n"));
+        assert!(str::contains(markdown, "\n\ndesc\n\n"));
     }
 
     #[test]
     fn should_write_type_signature() {
         let markdown = render(~"type t = int;");
-        assert!(str::contains(markdown, ~"\n\n    type t = int\n\n"));
+        assert!(str::contains(markdown, "\n\n    type t = int\n\n"));
     }
 
     #[test]
     fn should_put_struct_header() {
         let markdown = render(~"struct S { field: () }");
-        assert!(str::contains(markdown, ~"## Struct `S`\n\n"));
+        assert!(str::contains(markdown, "## Struct `S`\n\n"));
     }
 }

--- a/src/librustdoc/sectionalize_pass.rs
+++ b/src/librustdoc/sectionalize_pass.rs
@@ -188,7 +188,7 @@ mod test {
 }");
         assert!(str::contains(
             doc.cratemod().mods()[0].item.sections[0].header,
-            ~"Header"));
+            "Header"));
     }
 
     #[test]
@@ -201,7 +201,7 @@ mod test {
 }");
         assert!(str::contains(
             doc.cratemod().mods()[0].item.sections[0].body,
-            ~"Body"));
+            "Body"));
     }
 
     #[test]
@@ -226,10 +226,10 @@ mod test {
 }");
         assert!(!str::contains(
             doc.cratemod().mods()[0].desc().get(),
-            ~"Header"));
+            "Header"));
         assert!(!str::contains(
             doc.cratemod().mods()[0].desc().get(),
-            ~"Body"));
+            "Body"));
     }
 
     #[test]

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -80,7 +80,7 @@ fn record(mut repl: Repl, blk: &ast::blk, intr: @token::ident_interner) -> Repl 
         let new_view_items = do with_pp(intr) |pp, writer| {
             for blk.node.view_items.each |view_item| {
                 pprust::print_view_item(pp, *view_item);
-                writer.write_line(~"");
+                writer.write_line("");
             }
         };
 
@@ -94,7 +94,7 @@ fn record(mut repl: Repl, blk: &ast::blk, intr: @token::ident_interner) -> Repl 
                 match stmt.node {
                     ast::stmt_decl(*) | ast::stmt_mac(*) => {
                         pprust::print_stmt(pp, *stmt);
-                        writer.write_line(~"");
+                        writer.write_line("");
                     }
                     ast::stmt_expr(expr, _) | ast::stmt_semi(expr, _) => {
                         match expr.node {
@@ -415,7 +415,7 @@ pub fn main() {
             Some(line) => {
                 if line.is_empty() {
                     if istty {
-                        io::println(~"()");
+                        io::println("()");
                     }
                     loop;
                 }

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -12,7 +12,6 @@
 
 use context::Ctx;
 use core::hashmap::HashMap;
-use core::path::Path;
 use core::prelude::*;
 use std::tempfile::mkdtemp;
 use util::{PkgId, default_version};

--- a/src/libstd/cast.rs
+++ b/src/libstd/cast.rs
@@ -11,7 +11,6 @@
 //! Unsafe casting functions
 
 use sys;
-use unstable;
 use unstable::intrinsics;
 
 /// Casts the value at `src` to U. The two types must have the same length.

--- a/src/libstd/hash.rs
+++ b/src/libstd/hash.rs
@@ -488,7 +488,7 @@ mod tests {
             assert!(f == i && f == v);
 
             buf += ~[t as u8];
-            stream_inc.input(~[t as u8]);
+            stream_inc.input([t as u8]);
 
             t += 1;
         }

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -1839,7 +1839,7 @@ mod tests {
         {
             let out: @io::Writer =
                 result::get(
-                    &io::file_writer(tmpfile, ~[io::Create, io::Truncate]));
+                    &io::file_writer(tmpfile, [io::Create, io::Truncate]));
             out.write_str(frood);
         }
         let inp: @io::Reader = result::get(&io::file_reader(tmpfile));
@@ -1850,7 +1850,7 @@ mod tests {
 
     #[test]
     fn test_readchars_empty() {
-        do io::with_str_reader(~"") |inp| {
+        do io::with_str_reader("") |inp| {
             let res : ~[char] = inp.read_chars(128);
             assert_eq!(res.len(), 0);
         }
@@ -1858,7 +1858,7 @@ mod tests {
 
     #[test]
     fn test_read_line_utf8() {
-        do io::with_str_reader(~"生锈的汤匙切肉汤hello生锈的汤匙切肉汤") |inp| {
+        do io::with_str_reader("生锈的汤匙切肉汤hello生锈的汤匙切肉汤") |inp| {
             let line = inp.read_line();
             assert_eq!(line, ~"生锈的汤匙切肉汤hello生锈的汤匙切肉汤");
         }
@@ -1866,15 +1866,15 @@ mod tests {
 
     #[test]
     fn test_read_lines() {
-        do io::with_str_reader(~"a\nb\nc\n") |inp| {
+        do io::with_str_reader("a\nb\nc\n") |inp| {
             assert_eq!(inp.read_lines(), ~[~"a", ~"b", ~"c"]);
         }
 
-        do io::with_str_reader(~"a\nb\nc") |inp| {
+        do io::with_str_reader("a\nb\nc") |inp| {
             assert_eq!(inp.read_lines(), ~[~"a", ~"b", ~"c"]);
         }
 
-        do io::with_str_reader(~"") |inp| {
+        do io::with_str_reader("") |inp| {
             assert!(inp.read_lines().is_empty());
         }
     }
@@ -1909,7 +1909,7 @@ mod tests {
 
     #[test]
     fn test_readchar() {
-        do io::with_str_reader(~"生") |inp| {
+        do io::with_str_reader("生") |inp| {
             let res : char = inp.read_char();
             assert_eq!(res as int, 29983);
         }
@@ -1917,7 +1917,7 @@ mod tests {
 
     #[test]
     fn test_readchar_empty() {
-        do io::with_str_reader(~"") |inp| {
+        do io::with_str_reader("") |inp| {
             let res : char = inp.read_char();
             assert_eq!(res as int, -1);
         }
@@ -1966,7 +1966,7 @@ mod tests {
 
     #[test]
     fn file_writer_bad_name() {
-        match io::file_writer(&Path("?/?"), ~[]) {
+        match io::file_writer(&Path("?/?"), []) {
           result::Err(copy e) => {
             assert!(str::starts_with(e, "error opening"));
           }
@@ -1987,15 +1987,15 @@ mod tests {
     #[test]
     fn bytes_buffer_overwrite() {
         let wr = BytesWriter();
-        wr.write(~[0u8, 1u8, 2u8, 3u8]);
+        wr.write([0u8, 1u8, 2u8, 3u8]);
         assert!(*wr.bytes == ~[0u8, 1u8, 2u8, 3u8]);
         wr.seek(-2, SeekCur);
-        wr.write(~[4u8, 5u8, 6u8, 7u8]);
+        wr.write([4u8, 5u8, 6u8, 7u8]);
         assert!(*wr.bytes == ~[0u8, 1u8, 4u8, 5u8, 6u8, 7u8]);
         wr.seek(-2, SeekEnd);
-        wr.write(~[8u8]);
+        wr.write([8u8]);
         wr.seek(1, SeekSet);
-        wr.write(~[9u8]);
+        wr.write([9u8]);
         assert!(*wr.bytes == ~[0u8, 9u8, 4u8, 5u8, 8u8, 7u8]);
     }
 
@@ -2085,7 +2085,7 @@ mod tests {
         }
     }
 
-#[test]
+    #[test]
     fn test_read_write_f32() {
         let path = Path("tmp/lib-io-test-read-write-f32.tmp");
         let f:f32 = 8.1250;

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -951,7 +951,6 @@ impl num::FromStrRadix for f32 {
 mod tests {
     use f32::*;
     use num::*;
-    use super::*;
     use prelude::*;
 
     #[test]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -993,7 +993,6 @@ impl num::FromStrRadix for f64 {
 mod tests {
     use f64::*;
     use num::*;
-    use super::*;
     use prelude::*;
 
     #[test]

--- a/src/libstd/num/float.rs
+++ b/src/libstd/num/float.rs
@@ -1251,101 +1251,101 @@ mod tests {
 
     #[test]
     pub fn test_from_str() {
-        assert_eq!(from_str(~"3"), Some(3.));
-        assert_eq!(from_str(~"3.14"), Some(3.14));
-        assert_eq!(from_str(~"+3.14"), Some(3.14));
-        assert_eq!(from_str(~"-3.14"), Some(-3.14));
-        assert_eq!(from_str(~"2.5E10"), Some(25000000000.));
-        assert_eq!(from_str(~"2.5e10"), Some(25000000000.));
-        assert_eq!(from_str(~"25000000000.E-10"), Some(2.5));
-        assert_eq!(from_str(~"."), Some(0.));
-        assert_eq!(from_str(~".e1"), Some(0.));
-        assert_eq!(from_str(~".e-1"), Some(0.));
-        assert_eq!(from_str(~"5."), Some(5.));
-        assert_eq!(from_str(~".5"), Some(0.5));
-        assert_eq!(from_str(~"0.5"), Some(0.5));
-        assert_eq!(from_str(~"-.5"), Some(-0.5));
-        assert_eq!(from_str(~"-5"), Some(-5.));
-        assert_eq!(from_str(~"inf"), Some(infinity));
-        assert_eq!(from_str(~"+inf"), Some(infinity));
-        assert_eq!(from_str(~"-inf"), Some(neg_infinity));
+        assert_eq!(from_str("3"), Some(3.));
+        assert_eq!(from_str("3.14"), Some(3.14));
+        assert_eq!(from_str("+3.14"), Some(3.14));
+        assert_eq!(from_str("-3.14"), Some(-3.14));
+        assert_eq!(from_str("2.5E10"), Some(25000000000.));
+        assert_eq!(from_str("2.5e10"), Some(25000000000.));
+        assert_eq!(from_str("25000000000.E-10"), Some(2.5));
+        assert_eq!(from_str("."), Some(0.));
+        assert_eq!(from_str(".e1"), Some(0.));
+        assert_eq!(from_str(".e-1"), Some(0.));
+        assert_eq!(from_str("5."), Some(5.));
+        assert_eq!(from_str(".5"), Some(0.5));
+        assert_eq!(from_str("0.5"), Some(0.5));
+        assert_eq!(from_str("-.5"), Some(-0.5));
+        assert_eq!(from_str("-5"), Some(-5.));
+        assert_eq!(from_str("inf"), Some(infinity));
+        assert_eq!(from_str("+inf"), Some(infinity));
+        assert_eq!(from_str("-inf"), Some(neg_infinity));
         // note: NaN != NaN, hence this slightly complex test
-        match from_str(~"NaN") {
+        match from_str("NaN") {
             Some(f) => assert!(f.is_NaN()),
             None => fail!()
         }
         // note: -0 == 0, hence these slightly more complex tests
-        match from_str(~"-0") {
+        match from_str("-0") {
             Some(v) if v.is_zero() => assert!(v.is_negative()),
             _ => fail!()
         }
-        match from_str(~"0") {
+        match from_str("0") {
             Some(v) if v.is_zero() => assert!(v.is_positive()),
             _ => fail!()
         }
 
-        assert!(from_str(~"").is_none());
-        assert!(from_str(~"x").is_none());
-        assert!(from_str(~" ").is_none());
-        assert!(from_str(~"   ").is_none());
-        assert!(from_str(~"e").is_none());
-        assert!(from_str(~"E").is_none());
-        assert!(from_str(~"E1").is_none());
-        assert!(from_str(~"1e1e1").is_none());
-        assert!(from_str(~"1e1.1").is_none());
-        assert!(from_str(~"1e1-1").is_none());
+        assert!(from_str("").is_none());
+        assert!(from_str("x").is_none());
+        assert!(from_str(" ").is_none());
+        assert!(from_str("   ").is_none());
+        assert!(from_str("e").is_none());
+        assert!(from_str("E").is_none());
+        assert!(from_str("E1").is_none());
+        assert!(from_str("1e1e1").is_none());
+        assert!(from_str("1e1.1").is_none());
+        assert!(from_str("1e1-1").is_none());
     }
 
     #[test]
     pub fn test_from_str_hex() {
-        assert_eq!(from_str_hex(~"a4"), Some(164.));
-        assert_eq!(from_str_hex(~"a4.fe"), Some(164.9921875));
-        assert_eq!(from_str_hex(~"-a4.fe"), Some(-164.9921875));
-        assert_eq!(from_str_hex(~"+a4.fe"), Some(164.9921875));
-        assert_eq!(from_str_hex(~"ff0P4"), Some(0xff00 as float));
-        assert_eq!(from_str_hex(~"ff0p4"), Some(0xff00 as float));
-        assert_eq!(from_str_hex(~"ff0p-4"), Some(0xff as float));
-        assert_eq!(from_str_hex(~"."), Some(0.));
-        assert_eq!(from_str_hex(~".p1"), Some(0.));
-        assert_eq!(from_str_hex(~".p-1"), Some(0.));
-        assert_eq!(from_str_hex(~"f."), Some(15.));
-        assert_eq!(from_str_hex(~".f"), Some(0.9375));
-        assert_eq!(from_str_hex(~"0.f"), Some(0.9375));
-        assert_eq!(from_str_hex(~"-.f"), Some(-0.9375));
-        assert_eq!(from_str_hex(~"-f"), Some(-15.));
-        assert_eq!(from_str_hex(~"inf"), Some(infinity));
-        assert_eq!(from_str_hex(~"+inf"), Some(infinity));
-        assert_eq!(from_str_hex(~"-inf"), Some(neg_infinity));
+        assert_eq!(from_str_hex("a4"), Some(164.));
+        assert_eq!(from_str_hex("a4.fe"), Some(164.9921875));
+        assert_eq!(from_str_hex("-a4.fe"), Some(-164.9921875));
+        assert_eq!(from_str_hex("+a4.fe"), Some(164.9921875));
+        assert_eq!(from_str_hex("ff0P4"), Some(0xff00 as float));
+        assert_eq!(from_str_hex("ff0p4"), Some(0xff00 as float));
+        assert_eq!(from_str_hex("ff0p-4"), Some(0xff as float));
+        assert_eq!(from_str_hex("."), Some(0.));
+        assert_eq!(from_str_hex(".p1"), Some(0.));
+        assert_eq!(from_str_hex(".p-1"), Some(0.));
+        assert_eq!(from_str_hex("f."), Some(15.));
+        assert_eq!(from_str_hex(".f"), Some(0.9375));
+        assert_eq!(from_str_hex("0.f"), Some(0.9375));
+        assert_eq!(from_str_hex("-.f"), Some(-0.9375));
+        assert_eq!(from_str_hex("-f"), Some(-15.));
+        assert_eq!(from_str_hex("inf"), Some(infinity));
+        assert_eq!(from_str_hex("+inf"), Some(infinity));
+        assert_eq!(from_str_hex("-inf"), Some(neg_infinity));
         // note: NaN != NaN, hence this slightly complex test
-        match from_str_hex(~"NaN") {
+        match from_str_hex("NaN") {
             Some(f) => assert!(f.is_NaN()),
             None => fail!()
         }
         // note: -0 == 0, hence these slightly more complex tests
-        match from_str_hex(~"-0") {
+        match from_str_hex("-0") {
             Some(v) if v.is_zero() => assert!(v.is_negative()),
             _ => fail!()
         }
-        match from_str_hex(~"0") {
+        match from_str_hex("0") {
             Some(v) if v.is_zero() => assert!(v.is_positive()),
             _ => fail!()
         }
-        assert_eq!(from_str_hex(~"e"), Some(14.));
-        assert_eq!(from_str_hex(~"E"), Some(14.));
-        assert_eq!(from_str_hex(~"E1"), Some(225.));
-        assert_eq!(from_str_hex(~"1e1e1"), Some(123361.));
-        assert_eq!(from_str_hex(~"1e1.1"), Some(481.0625));
+        assert_eq!(from_str_hex("e"), Some(14.));
+        assert_eq!(from_str_hex("E"), Some(14.));
+        assert_eq!(from_str_hex("E1"), Some(225.));
+        assert_eq!(from_str_hex("1e1e1"), Some(123361.));
+        assert_eq!(from_str_hex("1e1.1"), Some(481.0625));
 
-        assert!(from_str_hex(~"").is_none());
-        assert!(from_str_hex(~"x").is_none());
-        assert!(from_str_hex(~" ").is_none());
-        assert!(from_str_hex(~"   ").is_none());
-        assert!(from_str_hex(~"p").is_none());
-        assert!(from_str_hex(~"P").is_none());
-        assert!(from_str_hex(~"P1").is_none());
-        assert!(from_str_hex(~"1p1p1").is_none());
-        assert!(from_str_hex(~"1p1.1").is_none());
-        assert!(from_str_hex(~"1p1-1").is_none());
+        assert!(from_str_hex("").is_none());
+        assert!(from_str_hex("x").is_none());
+        assert!(from_str_hex(" ").is_none());
+        assert!(from_str_hex("   ").is_none());
+        assert!(from_str_hex("p").is_none());
+        assert!(from_str_hex("P").is_none());
+        assert!(from_str_hex("P1").is_none());
+        assert!(from_str_hex("1p1p1").is_none());
+        assert!(from_str_hex("1p1.1").is_none());
+        assert!(from_str_hex("1p1-1").is_none());
     }
 
     #[test]
@@ -1375,8 +1375,8 @@ mod tests {
 
     #[test]
     pub fn test_from_str_radix() {
-        assert_eq!(from_str_radix(~"10", 36u), Some(36.));
-        assert_eq!(from_str_radix(~"1000.001", 2u), Some(8.125));
+        assert_eq!(from_str_radix("10", 36u), Some(36.));
+        assert_eq!(from_str_radix("1000.001", 2u), Some(8.125));
     }
 
     #[test]

--- a/src/libstd/num/int-template.rs
+++ b/src/libstd/num/int-template.rs
@@ -755,45 +755,45 @@ mod tests {
 
     #[test]
     fn test_from_str() {
-        assert_eq!(from_str(~"0"), Some(0 as T));
-        assert_eq!(from_str(~"3"), Some(3 as T));
-        assert_eq!(from_str(~"10"), Some(10 as T));
-        assert_eq!(i32::from_str(~"123456789"), Some(123456789 as i32));
-        assert_eq!(from_str(~"00100"), Some(100 as T));
+        assert_eq!(from_str("0"), Some(0 as T));
+        assert_eq!(from_str("3"), Some(3 as T));
+        assert_eq!(from_str("10"), Some(10 as T));
+        assert_eq!(i32::from_str("123456789"), Some(123456789 as i32));
+        assert_eq!(from_str("00100"), Some(100 as T));
 
-        assert_eq!(from_str(~"-1"), Some(-1 as T));
-        assert_eq!(from_str(~"-3"), Some(-3 as T));
-        assert_eq!(from_str(~"-10"), Some(-10 as T));
-        assert_eq!(i32::from_str(~"-123456789"), Some(-123456789 as i32));
-        assert_eq!(from_str(~"-00100"), Some(-100 as T));
+        assert_eq!(from_str("-1"), Some(-1 as T));
+        assert_eq!(from_str("-3"), Some(-3 as T));
+        assert_eq!(from_str("-10"), Some(-10 as T));
+        assert_eq!(i32::from_str("-123456789"), Some(-123456789 as i32));
+        assert_eq!(from_str("-00100"), Some(-100 as T));
 
-        assert!(from_str(~" ").is_none());
-        assert!(from_str(~"x").is_none());
+        assert!(from_str(" ").is_none());
+        assert!(from_str("x").is_none());
     }
 
     #[test]
     fn test_parse_bytes() {
         use str::to_bytes;
-        assert_eq!(parse_bytes(to_bytes(~"123"), 10u), Some(123 as T));
-        assert_eq!(parse_bytes(to_bytes(~"1001"), 2u), Some(9 as T));
-        assert_eq!(parse_bytes(to_bytes(~"123"), 8u), Some(83 as T));
-        assert_eq!(i32::parse_bytes(to_bytes(~"123"), 16u), Some(291 as i32));
-        assert_eq!(i32::parse_bytes(to_bytes(~"ffff"), 16u), Some(65535 as i32));
-        assert_eq!(i32::parse_bytes(to_bytes(~"FFFF"), 16u), Some(65535 as i32));
-        assert_eq!(parse_bytes(to_bytes(~"z"), 36u), Some(35 as T));
-        assert_eq!(parse_bytes(to_bytes(~"Z"), 36u), Some(35 as T));
+        assert_eq!(parse_bytes(to_bytes("123"), 10u), Some(123 as T));
+        assert_eq!(parse_bytes(to_bytes("1001"), 2u), Some(9 as T));
+        assert_eq!(parse_bytes(to_bytes("123"), 8u), Some(83 as T));
+        assert_eq!(i32::parse_bytes(to_bytes("123"), 16u), Some(291 as i32));
+        assert_eq!(i32::parse_bytes(to_bytes("ffff"), 16u), Some(65535 as i32));
+        assert_eq!(i32::parse_bytes(to_bytes("FFFF"), 16u), Some(65535 as i32));
+        assert_eq!(parse_bytes(to_bytes("z"), 36u), Some(35 as T));
+        assert_eq!(parse_bytes(to_bytes("Z"), 36u), Some(35 as T));
 
-        assert_eq!(parse_bytes(to_bytes(~"-123"), 10u), Some(-123 as T));
-        assert_eq!(parse_bytes(to_bytes(~"-1001"), 2u), Some(-9 as T));
-        assert_eq!(parse_bytes(to_bytes(~"-123"), 8u), Some(-83 as T));
-        assert_eq!(i32::parse_bytes(to_bytes(~"-123"), 16u), Some(-291 as i32));
-        assert_eq!(i32::parse_bytes(to_bytes(~"-ffff"), 16u), Some(-65535 as i32));
-        assert_eq!(i32::parse_bytes(to_bytes(~"-FFFF"), 16u), Some(-65535 as i32));
-        assert_eq!(parse_bytes(to_bytes(~"-z"), 36u), Some(-35 as T));
-        assert_eq!(parse_bytes(to_bytes(~"-Z"), 36u), Some(-35 as T));
+        assert_eq!(parse_bytes(to_bytes("-123"), 10u), Some(-123 as T));
+        assert_eq!(parse_bytes(to_bytes("-1001"), 2u), Some(-9 as T));
+        assert_eq!(parse_bytes(to_bytes("-123"), 8u), Some(-83 as T));
+        assert_eq!(i32::parse_bytes(to_bytes("-123"), 16u), Some(-291 as i32));
+        assert_eq!(i32::parse_bytes(to_bytes("-ffff"), 16u), Some(-65535 as i32));
+        assert_eq!(i32::parse_bytes(to_bytes("-FFFF"), 16u), Some(-65535 as i32));
+        assert_eq!(parse_bytes(to_bytes("-z"), 36u), Some(-35 as T));
+        assert_eq!(parse_bytes(to_bytes("-Z"), 36u), Some(-35 as T));
 
-        assert!(parse_bytes(to_bytes(~"Z"), 35u).is_none());
-        assert!(parse_bytes(to_bytes(~"-9"), 2u).is_none());
+        assert!(parse_bytes(to_bytes("Z"), 35u).is_none());
+        assert!(parse_bytes(to_bytes("-9"), 2u).is_none());
     }
 
     #[test]
@@ -836,36 +836,36 @@ mod tests {
     #[test]
     fn test_int_from_str_overflow() {
         let mut i8_val: i8 = 127_i8;
-        assert_eq!(i8::from_str(~"127"), Some(i8_val));
-        assert!(i8::from_str(~"128").is_none());
+        assert_eq!(i8::from_str("127"), Some(i8_val));
+        assert!(i8::from_str("128").is_none());
 
         i8_val += 1 as i8;
-        assert_eq!(i8::from_str(~"-128"), Some(i8_val));
-        assert!(i8::from_str(~"-129").is_none());
+        assert_eq!(i8::from_str("-128"), Some(i8_val));
+        assert!(i8::from_str("-129").is_none());
 
         let mut i16_val: i16 = 32_767_i16;
-        assert_eq!(i16::from_str(~"32767"), Some(i16_val));
-        assert!(i16::from_str(~"32768").is_none());
+        assert_eq!(i16::from_str("32767"), Some(i16_val));
+        assert!(i16::from_str("32768").is_none());
 
         i16_val += 1 as i16;
-        assert_eq!(i16::from_str(~"-32768"), Some(i16_val));
-        assert!(i16::from_str(~"-32769").is_none());
+        assert_eq!(i16::from_str("-32768"), Some(i16_val));
+        assert!(i16::from_str("-32769").is_none());
 
         let mut i32_val: i32 = 2_147_483_647_i32;
-        assert_eq!(i32::from_str(~"2147483647"), Some(i32_val));
-        assert!(i32::from_str(~"2147483648").is_none());
+        assert_eq!(i32::from_str("2147483647"), Some(i32_val));
+        assert!(i32::from_str("2147483648").is_none());
 
         i32_val += 1 as i32;
-        assert_eq!(i32::from_str(~"-2147483648"), Some(i32_val));
-        assert!(i32::from_str(~"-2147483649").is_none());
+        assert_eq!(i32::from_str("-2147483648"), Some(i32_val));
+        assert!(i32::from_str("-2147483649").is_none());
 
         let mut i64_val: i64 = 9_223_372_036_854_775_807_i64;
-        assert_eq!(i64::from_str(~"9223372036854775807"), Some(i64_val));
-        assert!(i64::from_str(~"9223372036854775808").is_none());
+        assert_eq!(i64::from_str("9223372036854775807"), Some(i64_val));
+        assert!(i64::from_str("9223372036854775808").is_none());
 
         i64_val += 1 as i64;
-        assert_eq!(i64::from_str(~"-9223372036854775808"), Some(i64_val));
-        assert!(i64::from_str(~"-9223372036854775809").is_none());
+        assert_eq!(i64::from_str("-9223372036854775808"), Some(i64_val));
+        assert!(i64::from_str("-9223372036854775809").is_none());
     }
 
     #[test]

--- a/src/libstd/num/uint-template.rs
+++ b/src/libstd/num/uint-template.rs
@@ -472,29 +472,29 @@ mod tests {
 
     #[test]
     pub fn test_from_str() {
-        assert_eq!(from_str(~"0"), Some(0u as T));
-        assert_eq!(from_str(~"3"), Some(3u as T));
-        assert_eq!(from_str(~"10"), Some(10u as T));
-        assert_eq!(u32::from_str(~"123456789"), Some(123456789 as u32));
-        assert_eq!(from_str(~"00100"), Some(100u as T));
+        assert_eq!(from_str("0"), Some(0u as T));
+        assert_eq!(from_str("3"), Some(3u as T));
+        assert_eq!(from_str("10"), Some(10u as T));
+        assert_eq!(u32::from_str("123456789"), Some(123456789 as u32));
+        assert_eq!(from_str("00100"), Some(100u as T));
 
-        assert!(from_str(~"").is_none());
-        assert!(from_str(~" ").is_none());
-        assert!(from_str(~"x").is_none());
+        assert!(from_str("").is_none());
+        assert!(from_str(" ").is_none());
+        assert!(from_str("x").is_none());
     }
 
     #[test]
     pub fn test_parse_bytes() {
         use str::to_bytes;
-        assert_eq!(parse_bytes(to_bytes(~"123"), 10u), Some(123u as T));
-        assert_eq!(parse_bytes(to_bytes(~"1001"), 2u), Some(9u as T));
-        assert_eq!(parse_bytes(to_bytes(~"123"), 8u), Some(83u as T));
-        assert_eq!(u16::parse_bytes(to_bytes(~"123"), 16u), Some(291u as u16));
-        assert_eq!(u16::parse_bytes(to_bytes(~"ffff"), 16u), Some(65535u as u16));
-        assert_eq!(parse_bytes(to_bytes(~"z"), 36u), Some(35u as T));
+        assert_eq!(parse_bytes(to_bytes("123"), 10u), Some(123u as T));
+        assert_eq!(parse_bytes(to_bytes("1001"), 2u), Some(9u as T));
+        assert_eq!(parse_bytes(to_bytes("123"), 8u), Some(83u as T));
+        assert_eq!(u16::parse_bytes(to_bytes("123"), 16u), Some(291u as u16));
+        assert_eq!(u16::parse_bytes(to_bytes("ffff"), 16u), Some(65535u as u16));
+        assert_eq!(parse_bytes(to_bytes("z"), 36u), Some(35u as T));
 
-        assert!(parse_bytes(to_bytes(~"Z"), 10u).is_none());
-        assert!(parse_bytes(to_bytes(~"_"), 2u).is_none());
+        assert!(parse_bytes(to_bytes("Z"), 10u).is_none());
+        assert!(parse_bytes(to_bytes("_"), 2u).is_none());
     }
 
     #[test]
@@ -527,36 +527,36 @@ mod tests {
     #[test]
     fn test_uint_from_str_overflow() {
         let mut u8_val: u8 = 255_u8;
-        assert_eq!(u8::from_str(~"255"), Some(u8_val));
-        assert!(u8::from_str(~"256").is_none());
+        assert_eq!(u8::from_str("255"), Some(u8_val));
+        assert!(u8::from_str("256").is_none());
 
         u8_val += 1 as u8;
-        assert_eq!(u8::from_str(~"0"), Some(u8_val));
-        assert!(u8::from_str(~"-1").is_none());
+        assert_eq!(u8::from_str("0"), Some(u8_val));
+        assert!(u8::from_str("-1").is_none());
 
         let mut u16_val: u16 = 65_535_u16;
-        assert_eq!(u16::from_str(~"65535"), Some(u16_val));
-        assert!(u16::from_str(~"65536").is_none());
+        assert_eq!(u16::from_str("65535"), Some(u16_val));
+        assert!(u16::from_str("65536").is_none());
 
         u16_val += 1 as u16;
-        assert_eq!(u16::from_str(~"0"), Some(u16_val));
-        assert!(u16::from_str(~"-1").is_none());
+        assert_eq!(u16::from_str("0"), Some(u16_val));
+        assert!(u16::from_str("-1").is_none());
 
         let mut u32_val: u32 = 4_294_967_295_u32;
-        assert_eq!(u32::from_str(~"4294967295"), Some(u32_val));
-        assert!(u32::from_str(~"4294967296").is_none());
+        assert_eq!(u32::from_str("4294967295"), Some(u32_val));
+        assert!(u32::from_str("4294967296").is_none());
 
         u32_val += 1 as u32;
-        assert_eq!(u32::from_str(~"0"), Some(u32_val));
-        assert!(u32::from_str(~"-1").is_none());
+        assert_eq!(u32::from_str("0"), Some(u32_val));
+        assert!(u32::from_str("-1").is_none());
 
         let mut u64_val: u64 = 18_446_744_073_709_551_615_u64;
-        assert_eq!(u64::from_str(~"18446744073709551615"), Some(u64_val));
-        assert!(u64::from_str(~"18446744073709551616").is_none());
+        assert_eq!(u64::from_str("18446744073709551615"), Some(u64_val));
+        assert!(u64::from_str("18446744073709551616").is_none());
 
         u64_val += 1 as u64;
-        assert_eq!(u64::from_str(~"0"), Some(u64_val));
-        assert!(u64::from_str(~"-1").is_none());
+        assert_eq!(u64::from_str("0"), Some(u64_val));
+        assert!(u64::from_str("-1").is_none());
     }
 
     #[test]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1444,14 +1444,14 @@ mod tests {
     #[test]
     fn test_setenv() {
         let n = make_rand_name();
-        setenv(n, ~"VALUE");
+        setenv(n, "VALUE");
         assert_eq!(getenv(n), option::Some(~"VALUE"));
     }
 
     #[test]
     fn test_unsetenv() {
         let n = make_rand_name();
-        setenv(n, ~"VALUE");
+        setenv(n, "VALUE");
         unsetenv(n);
         assert_eq!(getenv(n), option::None);
     }
@@ -1461,10 +1461,10 @@ mod tests {
     #[ignore]
     fn test_setenv_overwrite() {
         let n = make_rand_name();
-        setenv(n, ~"1");
-        setenv(n, ~"2");
+        setenv(n, "1");
+        setenv(n, "2");
         assert_eq!(getenv(n), option::Some(~"2"));
-        setenv(n, ~"");
+        setenv(n, "");
         assert_eq!(getenv(n), option::Some(~""));
     }
 
@@ -1515,7 +1515,7 @@ mod tests {
         let n = make_rand_name();
 
         let mut e = env();
-        setenv(n, ~"VALUE");
+        setenv(n, "VALUE");
         assert!(!vec::contains(e, &(copy n, ~"VALUE")));
 
         e = env();
@@ -1526,7 +1526,7 @@ mod tests {
     fn test() {
         assert!((!Path("test-path").is_absolute));
 
-        debug!(~"Current working directory: " + getcwd().to_str());
+        debug!("Current working directory: %s", getcwd().to_str());
 
         debug!(make_absolute(&Path("test-path")));
         debug!(make_absolute(&Path("/usr/bin")));
@@ -1535,43 +1535,43 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn homedir() {
-        let oldhome = getenv(~"HOME");
+        let oldhome = getenv("HOME");
 
-        setenv(~"HOME", ~"/home/MountainView");
+        setenv("HOME", "/home/MountainView");
         assert_eq!(os::homedir(), Some(Path("/home/MountainView")));
 
-        setenv(~"HOME", ~"");
+        setenv("HOME", "");
         assert!(os::homedir().is_none());
 
-        for oldhome.each |s| { setenv(~"HOME", *s) }
+        for oldhome.each |s| { setenv("HOME", *s) }
     }
 
     #[test]
     #[cfg(windows)]
     fn homedir() {
 
-        let oldhome = getenv(~"HOME");
-        let olduserprofile = getenv(~"USERPROFILE");
+        let oldhome = getenv("HOME");
+        let olduserprofile = getenv("USERPROFILE");
 
-        setenv(~"HOME", ~"");
-        setenv(~"USERPROFILE", ~"");
+        setenv("HOME", "");
+        setenv("USERPROFILE", "");
 
         assert!(os::homedir().is_none());
 
-        setenv(~"HOME", ~"/home/MountainView");
+        setenv("HOME", "/home/MountainView");
         assert_eq!(os::homedir(), Some(Path("/home/MountainView")));
 
-        setenv(~"HOME", ~"");
+        setenv("HOME", "");
 
-        setenv(~"USERPROFILE", ~"/home/MountainView");
+        setenv("USERPROFILE", "/home/MountainView");
         assert_eq!(os::homedir(), Some(Path("/home/MountainView")));
 
-        setenv(~"HOME", ~"/home/MountainView");
-        setenv(~"USERPROFILE", ~"/home/PaloAlto");
+        setenv("HOME", "/home/MountainView");
+        setenv("USERPROFILE", "/home/PaloAlto");
         assert_eq!(os::homedir(), Some(Path("/home/MountainView")));
 
-        oldhome.each(|s| {setenv(~"HOME", *s);true});
-        olduserprofile.each(|s| {setenv(~"USERPROFILE", *s);true});
+        oldhome.each(|s| { setenv("HOME", *s); true });
+        olduserprofile.each(|s| { setenv("USERPROFILE", *s); true });
     }
 
     #[test]
@@ -1646,7 +1646,7 @@ mod tests {
             fail!("%s doesn't exist", in.to_str());
           }
           assert!((rs));
-          let rslt = run::run_program(~"diff", ~[in.to_str(), out.to_str()]);
+          let rslt = run::run_program("diff", [in.to_str(), out.to_str()]);
           assert_eq!(rslt, 0);
           assert_eq!(out.get_mode(), in_mode);
           assert!((remove_file(&in)));

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -988,10 +988,10 @@ mod tests {
     #[test]
     fn test_choose_weighted() {
         let mut r = rng();
-        assert!(r.choose_weighted(~[
+        assert!(r.choose_weighted([
             Weighted { weight: 1u, item: 42 },
         ]) == 42);
-        assert!(r.choose_weighted(~[
+        assert!(r.choose_weighted([
             Weighted { weight: 0u, item: 42 },
             Weighted { weight: 1u, item: 43 },
         ]) == 43);
@@ -1000,10 +1000,10 @@ mod tests {
     #[test]
     fn test_choose_weighted_option() {
         let mut r = rng();
-        assert!(r.choose_weighted_option(~[
+        assert!(r.choose_weighted_option([
             Weighted { weight: 1u, item: 42 },
         ]) == Some(42));
-        assert!(r.choose_weighted_option(~[
+        assert!(r.choose_weighted_option([
             Weighted { weight: 0u, item: 42 },
             Weighted { weight: 1u, item: 43 },
         ]) == Some(43));
@@ -1015,8 +1015,8 @@ mod tests {
     fn test_weighted_vec() {
         let mut r = rng();
         let empty: ~[int] = ~[];
-        assert_eq!(r.weighted_vec(~[]), empty);
-        assert!(r.weighted_vec(~[
+        assert_eq!(r.weighted_vec([]), empty);
+        assert!(r.weighted_vec([
             Weighted { weight: 0u, item: 3u },
             Weighted { weight: 1u, item: 2u },
             Weighted { weight: 2u, item: 1u },
@@ -1027,15 +1027,15 @@ mod tests {
     fn test_shuffle() {
         let mut r = rng();
         let empty: ~[int] = ~[];
-        assert_eq!(r.shuffle(~[]), empty);
-        assert_eq!(r.shuffle(~[1, 1, 1]), ~[1, 1, 1]);
+        assert_eq!(r.shuffle([]), empty);
+        assert_eq!(r.shuffle([1, 1, 1]), ~[1, 1, 1]);
     }
 
     #[test]
     fn test_task_rng() {
         let mut r = task_rng();
         r.gen::<int>();
-        assert_eq!(r.shuffle(~[1, 1, 1]), ~[1, 1, 1]);
+        assert_eq!(r.shuffle([1, 1, 1]), ~[1, 1, 1]);
         assert_eq!(r.gen_uint_range(0u, 1u), 0u);
     }
 

--- a/src/libstd/rt/comm.rs
+++ b/src/libstd/rt/comm.rs
@@ -474,7 +474,7 @@ mod test {
     #[test]
     fn oneshot_single_thread_peek_open() {
         do run_in_newsched_task {
-            let (port, chan) = oneshot::<int>();
+            let (port, _) = oneshot::<int>();
             assert!(!port.peek());
         }
     }

--- a/src/libstd/rt/io/extensions.rs
+++ b/src/libstd/rt/io/extensions.rs
@@ -587,12 +587,10 @@ fn extend_sign(val: u64, nbytes: uint) -> i64 {
 
 #[cfg(test)]
 mod test {
-    use super::{ReaderUtil, ReaderByteConversions, WriterByteConversions};
-    use u64;
-    use i32;
+    use super::ReaderUtil;
     use option::{Some, None};
     use cell::Cell;
-    use rt::io::mem::{MemReader, MemWriter};
+    use rt::io::mem::MemReader;
     use rt::io::mock::MockReader;
     use rt::io::{read_error, placeholder_error};
 

--- a/src/libstd/rt/local.rs
+++ b/src/libstd/rt/local.rs
@@ -33,7 +33,7 @@ impl Local for Scheduler {
 }
 
 impl Local for Task {
-    fn put(value: ~Task) { abort!("unimpl") }
+    fn put(_value: ~Task) { abort!("unimpl") }
     fn take() -> ~Task { abort!("unimpl") }
     fn exists() -> bool { abort!("unimpl") }
     fn borrow(f: &fn(&mut Task)) {
@@ -71,10 +71,10 @@ impl Local for Task {
 
 // XXX: This formulation won't work once ~IoFactoryObject is a real trait pointer
 impl Local for IoFactoryObject {
-    fn put(value: ~IoFactoryObject) { abort!("unimpl") }
+    fn put(_value: ~IoFactoryObject) { abort!("unimpl") }
     fn take() -> ~IoFactoryObject { abort!("unimpl") }
     fn exists() -> bool { abort!("unimpl") }
-    fn borrow(f: &fn(&mut IoFactoryObject)) { abort!("unimpl") }
+    fn borrow(_f: &fn(&mut IoFactoryObject)) { abort!("unimpl") }
     unsafe fn unsafe_borrow() -> *mut IoFactoryObject {
         let sched = Local::unsafe_borrow::<Scheduler>();
         let io: *mut IoFactoryObject = (*sched).event_loop.io().unwrap();

--- a/src/libstd/rt/sched.rs
+++ b/src/libstd/rt/sched.rs
@@ -20,7 +20,6 @@ use super::context::Context;
 use super::task::Task;
 use rt::local_ptr;
 use rt::local::Local;
-use rt::rtio::IoFactoryObject;
 
 /// The Scheduler is responsible for coordinating execution of Coroutines
 /// on a single thread. When the scheduler is running it is owned by

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -16,7 +16,6 @@
 use prelude::*;
 use libc::{c_void, uintptr_t};
 use cast::transmute;
-use super::sched::Scheduler;
 use rt::local::Local;
 use super::local_heap::LocalHeap;
 use rt::logging::StdErrLogger;

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -2794,31 +2794,31 @@ mod tests {
 
     #[test]
     fn test_len() {
-        assert_eq!(len(~""), 0u);
-        assert_eq!(len(~"hello world"), 11u);
-        assert_eq!(len(~"\x63"), 1u);
-        assert_eq!(len(~"\xa2"), 2u);
-        assert_eq!(len(~"\u03c0"), 2u);
-        assert_eq!(len(~"\u2620"), 3u);
-        assert_eq!(len(~"\U0001d11e"), 4u);
+        assert_eq!(len(""), 0u);
+        assert_eq!(len("hello world"), 11u);
+        assert_eq!(len("\x63"), 1u);
+        assert_eq!(len("\xa2"), 2u);
+        assert_eq!(len("\u03c0"), 2u);
+        assert_eq!(len("\u2620"), 3u);
+        assert_eq!(len("\U0001d11e"), 4u);
 
-        assert_eq!(char_len(~""), 0u);
-        assert_eq!(char_len(~"hello world"), 11u);
-        assert_eq!(char_len(~"\x63"), 1u);
-        assert_eq!(char_len(~"\xa2"), 1u);
-        assert_eq!(char_len(~"\u03c0"), 1u);
-        assert_eq!(char_len(~"\u2620"), 1u);
-        assert_eq!(char_len(~"\U0001d11e"), 1u);
-        assert_eq!(char_len(~"ประเทศไทย中华Việt Nam"), 19u);
+        assert_eq!(char_len(""), 0u);
+        assert_eq!(char_len("hello world"), 11u);
+        assert_eq!(char_len("\x63"), 1u);
+        assert_eq!(char_len("\xa2"), 1u);
+        assert_eq!(char_len("\u03c0"), 1u);
+        assert_eq!(char_len("\u2620"), 1u);
+        assert_eq!(char_len("\U0001d11e"), 1u);
+        assert_eq!(char_len("ประเทศไทย中华Việt Nam"), 19u);
     }
 
     #[test]
     fn test_rfind_char() {
-        assert_eq!(rfind_char(~"hello", 'l'), Some(3u));
-        assert_eq!(rfind_char(~"hello", 'o'), Some(4u));
-        assert_eq!(rfind_char(~"hello", 'h'), Some(0u));
-        assert!(rfind_char(~"hello", 'z').is_none());
-        assert_eq!(rfind_char(~"ประเทศไทย中华Việt Nam", '华'), Some(30u));
+        assert_eq!(rfind_char("hello", 'l'), Some(3u));
+        assert_eq!(rfind_char("hello", 'o'), Some(4u));
+        assert_eq!(rfind_char("hello", 'h'), Some(0u));
+        assert!(rfind_char("hello", 'z').is_none());
+        assert_eq!(rfind_char("ประเทศไทย中华Việt Nam", '华'), Some(30u));
     }
 
     #[test]
@@ -2848,66 +2848,66 @@ mod tests {
     #[test]
     fn test_split_char() {
         fn t(s: &str, c: char, u: &[~str]) {
-            debug!(~"split_byte: " + s);
+            debug!("split_byte: %?", s);
             let mut v = ~[];
             for each_split_char(s, c) |s| { v.push(s.to_owned()) }
             debug!("split_byte to: %?", v);
             assert!(vec::all2(v, u, |a,b| a == b));
         }
-        t(~"abc.hello.there", '.', ~[~"abc", ~"hello", ~"there"]);
-        t(~".hello.there", '.', ~[~"", ~"hello", ~"there"]);
-        t(~"...hello.there.", '.', ~[~"", ~"", ~"", ~"hello", ~"there", ~""]);
+        t("abc.hello.there", '.', [~"abc", ~"hello", ~"there"]);
+        t(".hello.there", '.', [~"", ~"hello", ~"there"]);
+        t("...hello.there.", '.', [~"", ~"", ~"", ~"hello", ~"there", ~""]);
 
-        t(~"", 'z', ~[~""]);
-        t(~"z", 'z', ~[~"",~""]);
-        t(~"ok", 'z', ~[~"ok"]);
+        t("", 'z', [~""]);
+        t("z", 'z', [~"",~""]);
+        t("ok", 'z', [~"ok"]);
     }
 
     #[test]
     fn test_split_char_2() {
         fn t(s: &str, c: char, u: &[~str]) {
-            debug!(~"split_byte: " + s);
+            debug!("split_byte: %?", s);
             let mut v = ~[];
             for each_split_char(s, c) |s| { v.push(s.to_owned()) }
             debug!("split_byte to: %?", v);
             assert!(vec::all2(v, u, |a,b| a == b));
         }
-        let data = ~"ประเทศไทย中华Việt Nam";
-        t(data, 'V', ~[~"ประเทศไทย中华", ~"iệt Nam"]);
-        t(data, 'ท', ~[~"ประเ", ~"ศไ", ~"ย中华Việt Nam"]);
+        let data = "ประเทศไทย中华Việt Nam";
+        t(data, 'V', [~"ประเทศไทย中华", ~"iệt Nam"]);
+        t(data, 'ท', [~"ประเ", ~"ศไ", ~"ย中华Việt Nam"]);
     }
 
     #[test]
     fn test_splitn_char() {
         fn t(s: &str, c: char, n: uint, u: &[~str]) {
-            debug!(~"splitn_byte: " + s);
+            debug!("splitn_byte: %?", s);
             let mut v = ~[];
             for each_splitn_char(s, c, n) |s| { v.push(s.to_owned()) }
             debug!("split_byte to: %?", v);
             debug!("comparing vs. %?", u);
             assert!(vec::all2(v, u, |a,b| a == b));
         }
-        t(~"abc.hello.there", '.', 0u, ~[~"abc.hello.there"]);
-        t(~"abc.hello.there", '.', 1u, ~[~"abc", ~"hello.there"]);
-        t(~"abc.hello.there", '.', 2u, ~[~"abc", ~"hello", ~"there"]);
-        t(~"abc.hello.there", '.', 3u, ~[~"abc", ~"hello", ~"there"]);
-        t(~".hello.there", '.', 0u, ~[~".hello.there"]);
-        t(~".hello.there", '.', 1u, ~[~"", ~"hello.there"]);
-        t(~"...hello.there.", '.', 3u, ~[~"", ~"", ~"", ~"hello.there."]);
-        t(~"...hello.there.", '.', 5u, ~[~"", ~"", ~"", ~"hello", ~"there", ~""]);
+        t("abc.hello.there", '.', 0u, [~"abc.hello.there"]);
+        t("abc.hello.there", '.', 1u, [~"abc", ~"hello.there"]);
+        t("abc.hello.there", '.', 2u, [~"abc", ~"hello", ~"there"]);
+        t("abc.hello.there", '.', 3u, [~"abc", ~"hello", ~"there"]);
+        t(".hello.there", '.', 0u, [~".hello.there"]);
+        t(".hello.there", '.', 1u, [~"", ~"hello.there"]);
+        t("...hello.there.", '.', 3u, [~"", ~"", ~"", ~"hello.there."]);
+        t("...hello.there.", '.', 5u, [~"", ~"", ~"", ~"hello", ~"there", ~""]);
 
-        t(~"", 'z', 5u, ~[~""]);
-        t(~"z", 'z', 5u, ~[~"",~""]);
-        t(~"ok", 'z', 5u, ~[~"ok"]);
-        t(~"z", 'z', 0u, ~[~"z"]);
-        t(~"w.x.y", '.', 0u, ~[~"w.x.y"]);
-        t(~"w.x.y", '.', 1u, ~[~"w",~"x.y"]);
+        t("", 'z', 5u, [~""]);
+        t("z", 'z', 5u, [~"",~""]);
+        t("ok", 'z', 5u, [~"ok"]);
+        t("z", 'z', 0u, [~"z"]);
+        t("w.x.y", '.', 0u, [~"w.x.y"]);
+        t("w.x.y", '.', 1u, [~"w",~"x.y"]);
     }
 
     #[test]
-    fn test_splitn_char_2 () {
+    fn test_splitn_char_2() {
         fn t(s: &str, c: char, n: uint, u: &[~str]) {
-            debug!(~"splitn_byte: " + s);
+            debug!("splitn_byte: %?", s);
             let mut v = ~[];
             for each_splitn_char(s, c, n) |s| { v.push(s.to_owned()) }
             debug!("split_byte to: %?", v);
@@ -2915,60 +2915,59 @@ mod tests {
             assert!(vec::all2(v, u, |a,b| a == b));
         }
 
-        t(~"ประเทศไทย中华Việt Nam", '华', 1u, ~[~"ประเทศไทย中", ~"Việt Nam"]);
-        t(~"zzXXXzYYYzWWWz", 'z', 3u, ~[~"", ~"", ~"XXX", ~"YYYzWWWz"]);
-        t(~"z", 'z', 5u, ~[~"",~""]);
-        t(~"", 'z', 5u, ~[~""]);
-        t(~"ok", 'z', 5u, ~[~"ok"]);
+        t("ประเทศไทย中华Việt Nam", '华', 1u, [~"ประเทศไทย中", ~"Việt Nam"]);
+        t("zzXXXzYYYzWWWz", 'z', 3u, [~"", ~"", ~"XXX", ~"YYYzWWWz"]);
+        t("z", 'z', 5u, [~"",~""]);
+        t("", 'z', 5u, [~""]);
+        t("ok", 'z', 5u, [~"ok"]);
     }
-
 
     #[test]
     fn test_splitn_char_3() {
         fn t(s: &str, c: char, n: uint, u: &[~str]) {
-            debug!(~"splitn_byte: " + s);
+            debug!("splitn_byte: %?", s);
             let mut v = ~[];
             for each_splitn_char(s, c, n) |s| { v.push(s.to_owned()) }
             debug!("split_byte to: %?", v);
             debug!("comparing vs. %?", u);
             assert!(vec::all2(v, u, |a,b| a == b));
         }
-        let data = ~"ประเทศไทย中华Việt Nam";
-        t(data, 'V', 1u, ~[~"ประเทศไทย中华", ~"iệt Nam"]);
-        t(data, 'ท', 1u, ~[~"ประเ", ~"ศไทย中华Việt Nam"]);
+        let data = "ประเทศไทย中华Việt Nam";
+        t(data, 'V', 1u, [~"ประเทศไทย中华", ~"iệt Nam"]);
+        t(data, 'ท', 1u, [~"ประเ", ~"ศไทย中华Việt Nam"]);
     }
 
     #[test]
     fn test_split_char_no_trailing() {
         fn t(s: &str, c: char, u: &[~str]) {
-            debug!(~"split_byte: " + s);
+            debug!("split_byte: %?", s);
             let mut v = ~[];
             for each_split_char_no_trailing(s, c) |s| { v.push(s.to_owned()) }
             debug!("split_byte to: %?", v);
             assert!(vec::all2(v, u, |a,b| a == b));
         }
-        t(~"abc.hello.there", '.', ~[~"abc", ~"hello", ~"there"]);
-        t(~".hello.there", '.', ~[~"", ~"hello", ~"there"]);
-        t(~"...hello.there.", '.', ~[~"", ~"", ~"", ~"hello", ~"there"]);
+        t("abc.hello.there", '.', [~"abc", ~"hello", ~"there"]);
+        t(".hello.there", '.', [~"", ~"hello", ~"there"]);
+        t("...hello.there.", '.', [~"", ~"", ~"", ~"hello", ~"there"]);
 
-        t(~"...hello.there.", '.', ~[~"", ~"", ~"", ~"hello", ~"there"]);
-        t(~"", 'z', ~[]);
-        t(~"z", 'z', ~[~""]);
-        t(~"ok", 'z', ~[~"ok"]);
+        t("...hello.there.", '.', [~"", ~"", ~"", ~"hello", ~"there"]);
+        t("", 'z', []);
+        t("z", 'z', [~""]);
+        t("ok", 'z', [~"ok"]);
     }
 
     #[test]
     fn test_split_char_no_trailing_2() {
         fn t(s: &str, c: char, u: &[~str]) {
-            debug!(~"split_byte: " + s);
+            debug!("split_byte: %?", s);
             let mut v = ~[];
             for each_split_char_no_trailing(s, c) |s| { v.push(s.to_owned()) }
             debug!("split_byte to: %?", v);
             assert!(vec::all2(v, u, |a,b| a == b));
         }
-        let data = ~"ประเทศไทย中华Việt Nam";
-        t(data, 'V', ~[~"ประเทศไทย中华", ~"iệt Nam"]);
-        t(data, 'ท', ~[~"ประเ", ~"ศไ", ~"ย中华Việt Nam"]);
+        let data = "ประเทศไทย中华Việt Nam";
+        t(data, 'V', [~"ประเทศไทย中华", ~"iệt Nam"]);
+        t(data, 'ท', [~"ประเ", ~"ศไ", ~"ย中华Việt Nam"]);
     }
 
     #[test]
@@ -2978,20 +2977,20 @@ mod tests {
             for each_split_str(s, sep) |s| { v.push(s.to_owned()) }
             assert!(vec::all2(v, u, |a,b| a == b));
         }
-        t(~"--1233345--", ~"12345", ~[~"--1233345--"]);
-        t(~"abc::hello::there", ~"::", ~[~"abc", ~"hello", ~"there"]);
-        t(~"::hello::there", ~"::", ~[~"", ~"hello", ~"there"]);
-        t(~"hello::there::", ~"::", ~[~"hello", ~"there", ~""]);
-        t(~"::hello::there::", ~"::", ~[~"", ~"hello", ~"there", ~""]);
-        t(~"ประเทศไทย中华Việt Nam", ~"中华", ~[~"ประเทศไทย", ~"Việt Nam"]);
-        t(~"zzXXXzzYYYzz", ~"zz", ~[~"", ~"XXX", ~"YYY", ~""]);
-        t(~"zzXXXzYYYz", ~"XXX", ~[~"zz", ~"zYYYz"]);
-        t(~".XXX.YYY.", ~".", ~[~"", ~"XXX", ~"YYY", ~""]);
-        t(~"", ~".", ~[~""]);
-        t(~"zz", ~"zz", ~[~"",~""]);
-        t(~"ok", ~"z", ~[~"ok"]);
-        t(~"zzz", ~"zz", ~[~"",~"z"]);
-        t(~"zzzzz", ~"zz", ~[~"",~"",~"z"]);
+        t("--1233345--", "12345", [~"--1233345--"]);
+        t("abc::hello::there", "::", [~"abc", ~"hello", ~"there"]);
+        t("::hello::there", "::", [~"", ~"hello", ~"there"]);
+        t("hello::there::", "::", [~"hello", ~"there", ~""]);
+        t("::hello::there::", "::", [~"", ~"hello", ~"there", ~""]);
+        t("ประเทศไทย中华Việt Nam", "中华", [~"ประเทศไทย", ~"Việt Nam"]);
+        t("zzXXXzzYYYzz", "zz", [~"", ~"XXX", ~"YYY", ~""]);
+        t("zzXXXzYYYz", "XXX", [~"zz", ~"zYYYz"]);
+        t(".XXX.YYY.", ".", [~"", ~"XXX", ~"YYY", ~""]);
+        t("", ".", [~""]);
+        t("zz", "zz", [~"",~""]);
+        t("ok", "z", [~"ok"]);
+        t("zzz", "zz", [~"",~"z"]);
+        t("zzzzz", "zz", [~"",~"",~"z"]);
     }
 
 
@@ -3003,12 +3002,12 @@ mod tests {
             assert!(vec::all2(v, u, |a,b| a == b));
         }
 
-        t(~"ประเทศไทย中华Việt Nam", |cc| cc == '华', ~[~"ประเทศไทย中", ~"Việt Nam"]);
-        t(~"zzXXXzYYYz", char::is_lowercase, ~[~"", ~"", ~"XXX", ~"YYY", ~""]);
-        t(~"zzXXXzYYYz", char::is_uppercase, ~[~"zz", ~"", ~"", ~"z", ~"", ~"", ~"z"]);
-        t(~"z", |cc| cc == 'z', ~[~"",~""]);
-        t(~"", |cc| cc == 'z', ~[~""]);
-        t(~"ok", |cc| cc == 'z', ~[~"ok"]);
+        t("ประเทศไทย中华Việt Nam", |cc| cc == '华', [~"ประเทศไทย中", ~"Việt Nam"]);
+        t("zzXXXzYYYz", char::is_lowercase, [~"", ~"", ~"XXX", ~"YYY", ~""]);
+        t("zzXXXzYYYz", char::is_uppercase, [~"zz", ~"", ~"", ~"z", ~"", ~"", ~"z"]);
+        t("z", |cc| cc == 'z', [~"",~""]);
+        t("", |cc| cc == 'z', [~""]);
+        t("ok", |cc| cc == 'z', [~"ok"]);
     }
 
     #[test]
@@ -3019,18 +3018,18 @@ mod tests {
             assert!(vec::all2(v, u, |a,b| a == b));
         }
 
-        t(~"ประเทศไทย中华Việt Nam", |cc| cc == '华', ~[~"ประเทศไทย中", ~"Việt Nam"]);
-        t(~"zzXXXzYYYz", char::is_lowercase, ~[~"", ~"", ~"XXX", ~"YYY"]);
-        t(~"zzXXXzYYYz", char::is_uppercase, ~[~"zz", ~"", ~"", ~"z", ~"", ~"", ~"z"]);
-        t(~"z", |cc| cc == 'z', ~[~""]);
-        t(~"", |cc| cc == 'z', ~[]);
-        t(~"ok", |cc| cc == 'z', ~[~"ok"]);
+        t("ประเทศไทย中华Việt Nam", |cc| cc == '华', [~"ประเทศไทย中", ~"Việt Nam"]);
+        t("zzXXXzYYYz", char::is_lowercase, [~"", ~"", ~"XXX", ~"YYY"]);
+        t("zzXXXzYYYz", char::is_uppercase, [~"zz", ~"", ~"", ~"z", ~"", ~"", ~"z"]);
+        t("z", |cc| cc == 'z', [~""]);
+        t("", |cc| cc == 'z', []);
+        t("ok", |cc| cc == 'z', [~"ok"]);
     }
 
     #[test]
     fn test_lines() {
-        let lf = ~"\nMary had a little lamb\nLittle lamb\n";
-        let crlf = ~"\r\nMary had a little lamb\r\nLittle lamb\r\n";
+        let lf = "\nMary had a little lamb\nLittle lamb\n";
+        let crlf = "\r\nMary had a little lamb\r\nLittle lamb\r\n";
 
         fn t(s: &str, f: &fn(&str, &fn(&str) -> bool) -> bool, u: &[~str]) {
             let mut v = ~[];
@@ -3038,30 +3037,30 @@ mod tests {
             assert!(vec::all2(v, u, |a,b| a == b));
         }
 
-        t(lf, each_line ,~[~"", ~"Mary had a little lamb", ~"Little lamb"]);
-        t(lf, each_line_any, ~[~"", ~"Mary had a little lamb", ~"Little lamb"]);
-        t(crlf, each_line, ~[~"\r", ~"Mary had a little lamb\r", ~"Little lamb\r"]);
-        t(crlf, each_line_any, ~[~"", ~"Mary had a little lamb", ~"Little lamb"]);
-        t(~"", each_line, ~[]);
-        t(~"", each_line_any, ~[]);
-        t(~"\n", each_line, ~[~""]);
-        t(~"\n", each_line_any, ~[~""]);
-        t(~"banana", each_line, ~[~"banana"]);
-        t(~"banana", each_line_any, ~[~"banana"]);
+        t(lf, each_line, [~"", ~"Mary had a little lamb", ~"Little lamb"]);
+        t(lf, each_line_any, [~"", ~"Mary had a little lamb", ~"Little lamb"]);
+        t(crlf, each_line, [~"\r", ~"Mary had a little lamb\r", ~"Little lamb\r"]);
+        t(crlf, each_line_any, [~"", ~"Mary had a little lamb", ~"Little lamb"]);
+        t("", each_line, []);
+        t("", each_line_any, []);
+        t("\n", each_line, [~""]);
+        t("\n", each_line_any, [~""]);
+        t("banana", each_line, [~"banana"]);
+        t("banana", each_line_any, [~"banana"]);
     }
 
     #[test]
-    fn test_words () {
+    fn test_words() {
         fn t(s: &str, f: &fn(&str, &fn(&str) -> bool) -> bool, u: &[~str]) {
             let mut v = ~[];
             for f(s) |s| { v.push(s.to_owned()) }
             assert!(vec::all2(v, u, |a,b| a == b));
         }
-        let data = ~"\nMary had a little lamb\nLittle lamb\n";
+        let data = "\nMary had a little lamb\nLittle lamb\n";
 
-        t(data, each_word, ~[~"Mary",~"had",~"a",~"little",~"lamb",~"Little",~"lamb"]);
-        t(~"ok", each_word, ~[~"ok"]);
-        t(~"", each_word, ~[]);
+        t(data, each_word, [~"Mary",~"had",~"a",~"little",~"lamb",~"Little",~"lamb"]);
+        t("ok", each_word, [~"ok"]);
+        t("", each_word, []);
     }
 
     #[test]
@@ -3071,53 +3070,53 @@ mod tests {
             for each_split_within(s, i) |s| { v.push(s.to_owned()) }
             assert!(vec::all2(v, u, |a,b| a == b));
         }
-        t(~"", 0, ~[]);
-        t(~"", 15, ~[]);
-        t(~"hello", 15, ~[~"hello"]);
-        t(~"\nMary had a little lamb\nLittle lamb\n", 15,
-            ~[~"Mary had a", ~"little lamb", ~"Little lamb"]);
+        t("", 0, []);
+        t("", 15, []);
+        t("hello", 15, [~"hello"]);
+        t("\nMary had a little lamb\nLittle lamb\n", 15,
+            [~"Mary had a", ~"little lamb", ~"Little lamb"]);
     }
 
     #[test]
     fn test_find_str() {
         // byte positions
-        assert!(find_str(~"banana", ~"apple pie").is_none());
-        assert_eq!(find_str(~"", ~""), Some(0u));
+        assert!(find_str("banana", "apple pie").is_none());
+        assert_eq!(find_str("", ""), Some(0u));
 
-        let data = ~"ประเทศไทย中华Việt Nam";
-        assert_eq!(find_str(data, ~""), Some(0u));
-        assert_eq!(find_str(data, ~"ประเ"), Some( 0u));
-        assert_eq!(find_str(data, ~"ะเ"), Some( 6u));
-        assert_eq!(find_str(data, ~"中华"), Some(27u));
-        assert!(find_str(data, ~"ไท华").is_none());
+        let data = "ประเทศไทย中华Việt Nam";
+        assert_eq!(find_str(data, ""), Some(0u));
+        assert_eq!(find_str(data, "ประเ"), Some( 0u));
+        assert_eq!(find_str(data, "ะเ"), Some( 6u));
+        assert_eq!(find_str(data, "中华"), Some(27u));
+        assert!(find_str(data, "ไท华").is_none());
     }
 
     #[test]
     fn test_find_str_between() {
         // byte positions
-        assert_eq!(find_str_between(~"", ~"", 0u, 0u), Some(0u));
+        assert_eq!(find_str_between("", "", 0u, 0u), Some(0u));
 
-        let data = ~"abcabc";
-        assert_eq!(find_str_between(data, ~"ab", 0u, 6u), Some(0u));
-        assert_eq!(find_str_between(data, ~"ab", 2u, 6u), Some(3u));
-        assert!(find_str_between(data, ~"ab", 2u, 4u).is_none());
+        let data = "abcabc";
+        assert_eq!(find_str_between(data, "ab", 0u, 6u), Some(0u));
+        assert_eq!(find_str_between(data, "ab", 2u, 6u), Some(3u));
+        assert!(find_str_between(data, "ab", 2u, 4u).is_none());
 
         let mut data = ~"ประเทศไทย中华Việt Nam";
         data = data + data;
-        assert_eq!(find_str_between(data, ~"", 0u, 43u), Some(0u));
-        assert_eq!(find_str_between(data, ~"", 6u, 43u), Some(6u));
+        assert_eq!(find_str_between(data, "", 0u, 43u), Some(0u));
+        assert_eq!(find_str_between(data, "", 6u, 43u), Some(6u));
 
-        assert_eq!(find_str_between(data, ~"ประ", 0u, 43u), Some( 0u));
-        assert_eq!(find_str_between(data, ~"ทศไ", 0u, 43u), Some(12u));
-        assert_eq!(find_str_between(data, ~"ย中", 0u, 43u), Some(24u));
-        assert_eq!(find_str_between(data, ~"iệt", 0u, 43u), Some(34u));
-        assert_eq!(find_str_between(data, ~"Nam", 0u, 43u), Some(40u));
+        assert_eq!(find_str_between(data, "ประ", 0u, 43u), Some( 0u));
+        assert_eq!(find_str_between(data, "ทศไ", 0u, 43u), Some(12u));
+        assert_eq!(find_str_between(data, "ย中", 0u, 43u), Some(24u));
+        assert_eq!(find_str_between(data, "iệt", 0u, 43u), Some(34u));
+        assert_eq!(find_str_between(data, "Nam", 0u, 43u), Some(40u));
 
-        assert_eq!(find_str_between(data, ~"ประ", 43u, 86u), Some(43u));
-        assert_eq!(find_str_between(data, ~"ทศไ", 43u, 86u), Some(55u));
-        assert_eq!(find_str_between(data, ~"ย中", 43u, 86u), Some(67u));
-        assert_eq!(find_str_between(data, ~"iệt", 43u, 86u), Some(77u));
-        assert_eq!(find_str_between(data, ~"Nam", 43u, 86u), Some(83u));
+        assert_eq!(find_str_between(data, "ประ", 43u, 86u), Some(43u));
+        assert_eq!(find_str_between(data, "ทศไ", 43u, 86u), Some(55u));
+        assert_eq!(find_str_between(data, "ย中", 43u, 86u), Some(67u));
+        assert_eq!(find_str_between(data, "iệt", 43u, 86u), Some(77u));
+        assert_eq!(find_str_between(data, "Nam", 43u, 86u), Some(83u));
     }
 
     #[test]
@@ -3135,10 +3134,10 @@ mod tests {
         fn t(v: &[~str], s: &str) {
             assert_eq!(concat(v), s.to_str());
         }
-        t(~[~"you", ~"know", ~"I'm", ~"no", ~"good"], ~"youknowI'mnogood");
-        let v: ~[~str] = ~[];
-        t(v, ~"");
-        t(~[~"hi"], ~"hi");
+        t([~"you", ~"know", ~"I'm", ~"no", ~"good"], "youknowI'mnogood");
+        let v: &[~str] = [];
+        t(v, "");
+        t([~"hi"], "hi");
     }
 
     #[test]
@@ -3146,11 +3145,11 @@ mod tests {
         fn t(v: &[~str], sep: &str, s: &str) {
             assert_eq!(connect(v, sep), s.to_str());
         }
-        t(~[~"you", ~"know", ~"I'm", ~"no", ~"good"],
-          ~" ", ~"you know I'm no good");
-        let v: ~[~str] = ~[];
-        t(v, ~" ", ~"");
-        t(~[~"hi"], ~" ", ~"hi");
+        t([~"you", ~"know", ~"I'm", ~"no", ~"good"],
+          " ", "you know I'm no good");
+        let v: &[~str] = ~[];
+        t(v, " ", "");
+        t([~"hi"], " ", "hi");
     }
 
     #[test]
@@ -3166,11 +3165,11 @@ mod tests {
 
     #[test]
     fn test_repeat() {
-        assert_eq!(repeat(~"x", 4), ~"xxxx");
-        assert_eq!(repeat(~"hi", 4), ~"hihihihi");
-        assert_eq!(repeat(~"ไท华", 3), ~"ไท华ไท华ไท华");
-        assert_eq!(repeat(~"", 4), ~"");
-        assert_eq!(repeat(~"hi", 0), ~"");
+        assert_eq!(repeat("x", 4), ~"xxxx");
+        assert_eq!(repeat("hi", 4), ~"hihihihi");
+        assert_eq!(repeat("ไท华", 3), ~"ไท华ไท华ไท华");
+        assert_eq!(repeat("", 4), ~"");
+        assert_eq!(repeat("hi", 0), ~"");
     }
 
     #[test]
@@ -3197,38 +3196,38 @@ mod tests {
 
     #[test]
     fn test_starts_with() {
-        assert!((starts_with(~"", ~"")));
-        assert!((starts_with(~"abc", ~"")));
-        assert!((starts_with(~"abc", ~"a")));
-        assert!((!starts_with(~"a", ~"abc")));
-        assert!((!starts_with(~"", ~"abc")));
+        assert!((starts_with("", "")));
+        assert!((starts_with("abc", "")));
+        assert!((starts_with("abc", "a")));
+        assert!((!starts_with("a", "abc")));
+        assert!((!starts_with("", "abc")));
     }
 
     #[test]
     fn test_ends_with() {
-        assert!((ends_with(~"", ~"")));
-        assert!((ends_with(~"abc", ~"")));
-        assert!((ends_with(~"abc", ~"c")));
-        assert!((!ends_with(~"a", ~"abc")));
-        assert!((!ends_with(~"", ~"abc")));
+        assert!((ends_with("", "")));
+        assert!((ends_with("abc", "")));
+        assert!((ends_with("abc", "c")));
+        assert!((!ends_with("a", "abc")));
+        assert!((!ends_with("", "abc")));
     }
 
     #[test]
     fn test_is_empty() {
-        assert!((is_empty(~"")));
-        assert!((!is_empty(~"a")));
+        assert!((is_empty("")));
+        assert!((!is_empty("a")));
     }
 
     #[test]
     fn test_replace() {
-        let a = ~"a";
-        assert_eq!(replace(~"", a, ~"b"), ~"");
-        assert_eq!(replace(~"a", a, ~"b"), ~"b");
-        assert_eq!(replace(~"ab", a, ~"b"), ~"bb");
-        let test = ~"test";
-        assert!(replace(~" test test ", test, ~"toast") ==
+        let a = "a";
+        assert_eq!(replace("", a, "b"), ~"");
+        assert_eq!(replace("a", a, "b"), ~"b");
+        assert_eq!(replace("ab", a, "b"), ~"bb");
+        let test = "test";
+        assert!(replace(" test test ", test, "toast") ==
             ~" toast toast ");
-        assert_eq!(replace(~" test test ", test, ~""), ~"   ");
+        assert_eq!(replace(" test test ", test, ""), ~"   ");
     }
 
     #[test]
@@ -3338,32 +3337,26 @@ mod tests {
 
     #[test]
     fn test_trim_left_chars() {
-        assert!(trim_left_chars(" *** foo *** ", ~[]) ==
-                     " *** foo *** ");
-        assert!(trim_left_chars(" *** foo *** ", ~['*', ' ']) ==
-                     "foo *** ");
-        assert_eq!(trim_left_chars(" ***  *** ", ~['*', ' ']), "");
-        assert!(trim_left_chars("foo *** ", ~['*', ' ']) ==
-                     "foo *** ");
+        assert!(trim_left_chars(" *** foo *** ", []) == " *** foo *** ");
+        assert!(trim_left_chars(" *** foo *** ", ['*', ' ']) == "foo *** ");
+        assert_eq!(trim_left_chars(" ***  *** ", ['*', ' ']), "");
+        assert!(trim_left_chars("foo *** ", ['*', ' ']) == "foo *** ");
     }
 
     #[test]
     fn test_trim_right_chars() {
-        assert!(trim_right_chars(" *** foo *** ", ~[]) ==
-                     " *** foo *** ");
-        assert!(trim_right_chars(" *** foo *** ", ~['*', ' ']) ==
-                     " *** foo");
-        assert_eq!(trim_right_chars(" ***  *** ", ~['*', ' ']), "");
-        assert!(trim_right_chars(" *** foo", ~['*', ' ']) ==
-                     " *** foo");
+        assert!(trim_right_chars(" *** foo *** ", []) == " *** foo *** ");
+        assert!(trim_right_chars(" *** foo *** ", ['*', ' ']) == " *** foo");
+        assert_eq!(trim_right_chars(" ***  *** ", ['*', ' ']), "");
+        assert!(trim_right_chars(" *** foo", ['*', ' ']) == " *** foo");
     }
 
     #[test]
     fn test_trim_chars() {
-        assert_eq!(trim_chars(" *** foo *** ", ~[]), " *** foo *** ");
-        assert_eq!(trim_chars(" *** foo *** ", ~['*', ' ']), "foo");
-        assert_eq!(trim_chars(" ***  *** ", ~['*', ' ']), "");
-        assert_eq!(trim_chars("foo", ~['*', ' ']), "foo");
+        assert_eq!(trim_chars(" *** foo *** ", []), " *** foo *** ");
+        assert_eq!(trim_chars(" *** foo *** ", ['*', ' ']), "foo");
+        assert_eq!(trim_chars(" ***  *** ", ['*', ' ']), "");
+        assert_eq!(trim_chars("foo", ['*', ' ']), "foo");
     }
 
     #[test]
@@ -3398,11 +3391,11 @@ mod tests {
 
     #[test]
     fn test_is_whitespace() {
-        assert!((is_whitespace(~"")));
-        assert!((is_whitespace(~" ")));
-        assert!((is_whitespace(~"\u2009"))); // Thin space
-        assert!((is_whitespace(~"  \n\t   ")));
-        assert!((!is_whitespace(~"   _   ")));
+        assert!(is_whitespace(""));
+        assert!(is_whitespace(" "));
+        assert!(is_whitespace("\u2009")); // Thin space
+        assert!(is_whitespace("  \n\t   "));
+        assert!(!is_whitespace("   _   "));
     }
 
     #[test]
@@ -3543,7 +3536,7 @@ mod tests {
 
     #[test]
     fn test_as_buf() {
-        let a = ~"Abcdefg";
+        let a = "Abcdefg";
         let b = as_buf(a, |buf, _l| {
             assert_eq!(unsafe { *buf }, 65u8);
             100
@@ -3553,7 +3546,7 @@ mod tests {
 
     #[test]
     fn test_as_buf_small() {
-        let a = ~"A";
+        let a = "A";
         let b = as_buf(a, |buf, _l| {
             assert_eq!(unsafe { *buf }, 65u8);
             100
@@ -3631,32 +3624,32 @@ mod tests {
 
     #[test]
     fn test_contains() {
-        assert!(contains(~"abcde", ~"bcd"));
-        assert!(contains(~"abcde", ~"abcd"));
-        assert!(contains(~"abcde", ~"bcde"));
-        assert!(contains(~"abcde", ~""));
-        assert!(contains(~"", ~""));
-        assert!(!contains(~"abcde", ~"def"));
-        assert!(!contains(~"", ~"a"));
+        assert!(contains("abcde", "bcd"));
+        assert!(contains("abcde", "abcd"));
+        assert!(contains("abcde", "bcde"));
+        assert!(contains("abcde", ""));
+        assert!(contains("", ""));
+        assert!(!contains("abcde", "def"));
+        assert!(!contains("", "a"));
 
         let data = ~"ประเทศไทย中华Việt Nam";
-        assert!(contains(data, ~"ประเ"));
-        assert!(contains(data, ~"ะเ"));
-        assert!(contains(data, ~"中华"));
-        assert!(!contains(data, ~"ไท华"));
+        assert!(contains(data, "ประเ"));
+        assert!(contains(data, "ะเ"));
+        assert!(contains(data, "中华"));
+        assert!(!contains(data, "ไท华"));
     }
 
     #[test]
     fn test_contains_char() {
-        assert!(contains_char(~"abc", 'b'));
-        assert!(contains_char(~"a", 'a'));
-        assert!(!contains_char(~"abc", 'd'));
-        assert!(!contains_char(~"", 'a'));
+        assert!(contains_char("abc", 'b'));
+        assert!(contains_char("a", 'a'));
+        assert!(!contains_char("abc", 'd'));
+        assert!(!contains_char("", 'a'));
     }
 
     #[test]
     fn test_split_char_each() {
-        let data = ~"\nMary had a little lamb\nLittle lamb\n";
+        let data = "\nMary had a little lamb\nLittle lamb\n";
 
         let mut ii = 0;
 
@@ -3674,7 +3667,7 @@ mod tests {
 
     #[test]
     fn test_splitn_char_each() {
-        let data = ~"\nMary had a little lamb\nLittle lamb\n";
+        let data = "\nMary had a little lamb\nLittle lamb\n";
 
         let mut ii = 0;
 
@@ -3691,7 +3684,7 @@ mod tests {
 
     #[test]
     fn test_words_each() {
-        let data = ~"\nMary had a little lamb\nLittle lamb\n";
+        let data = "\nMary had a little lamb\nLittle lamb\n";
 
         let mut ii = 0;
 
@@ -3706,12 +3699,12 @@ mod tests {
             ii += 1;
         }
 
-        each_word(~"", |_x| fail!()); // should not fail
+        each_word("", |_x| fail!()); // should not fail
     }
 
     #[test]
     fn test_lines_each () {
-        let lf = ~"\nMary had a little lamb\nLittle lamb\n";
+        let lf = "\nMary had a little lamb\nLittle lamb\n";
 
         let mut ii = 0;
 
@@ -3728,26 +3721,26 @@ mod tests {
 
     #[test]
     fn test_map() {
-        assert_eq!(~"", map(~"", |c| unsafe {libc::toupper(c as c_char)} as char));
-        assert_eq!(~"YMCA", map(~"ymca", |c| unsafe {libc::toupper(c as c_char)} as char));
+        assert_eq!(~"", map("", |c| unsafe {libc::toupper(c as c_char)} as char));
+        assert_eq!(~"YMCA", map("ymca", |c| unsafe {libc::toupper(c as c_char)} as char));
     }
 
     #[test]
     fn test_all() {
-        assert_eq!(true, all(~"", char::is_uppercase));
-        assert_eq!(false, all(~"ymca", char::is_uppercase));
-        assert_eq!(true, all(~"YMCA", char::is_uppercase));
-        assert_eq!(false, all(~"yMCA", char::is_uppercase));
-        assert_eq!(false, all(~"YMCy", char::is_uppercase));
+        assert_eq!(true, all("", char::is_uppercase));
+        assert_eq!(false, all("ymca", char::is_uppercase));
+        assert_eq!(true, all("YMCA", char::is_uppercase));
+        assert_eq!(false, all("yMCA", char::is_uppercase));
+        assert_eq!(false, all("YMCy", char::is_uppercase));
     }
 
     #[test]
     fn test_any() {
-        assert_eq!(false, any(~"", char::is_uppercase));
-        assert_eq!(false, any(~"ymca", char::is_uppercase));
-        assert_eq!(true, any(~"YMCA", char::is_uppercase));
-        assert_eq!(true, any(~"yMCA", char::is_uppercase));
-        assert_eq!(true, any(~"Ymcy", char::is_uppercase));
+        assert_eq!(false, any("", char::is_uppercase));
+        assert_eq!(false, any("ymca", char::is_uppercase));
+        assert_eq!(true, any("YMCA", char::is_uppercase));
+        assert_eq!(true, any("yMCA", char::is_uppercase));
+        assert_eq!(true, any("Ymcy", char::is_uppercase));
     }
 
     #[test]
@@ -3761,41 +3754,41 @@ mod tests {
     #[test]
     fn test_utf16() {
         let pairs =
-            ~[(~"𐍅𐌿𐌻𐍆𐌹𐌻𐌰\n",
+            [(~"𐍅𐌿𐌻𐍆𐌹𐌻𐌰\n",
               ~[0xd800_u16, 0xdf45_u16, 0xd800_u16, 0xdf3f_u16,
-               0xd800_u16, 0xdf3b_u16, 0xd800_u16, 0xdf46_u16,
-               0xd800_u16, 0xdf39_u16, 0xd800_u16, 0xdf3b_u16,
-               0xd800_u16, 0xdf30_u16, 0x000a_u16]),
+                0xd800_u16, 0xdf3b_u16, 0xd800_u16, 0xdf46_u16,
+                0xd800_u16, 0xdf39_u16, 0xd800_u16, 0xdf3b_u16,
+                0xd800_u16, 0xdf30_u16, 0x000a_u16]),
 
              (~"𐐒𐑉𐐮𐑀𐐲𐑋 𐐏𐐲𐑍\n",
               ~[0xd801_u16, 0xdc12_u16, 0xd801_u16,
-               0xdc49_u16, 0xd801_u16, 0xdc2e_u16, 0xd801_u16,
-               0xdc40_u16, 0xd801_u16, 0xdc32_u16, 0xd801_u16,
-               0xdc4b_u16, 0x0020_u16, 0xd801_u16, 0xdc0f_u16,
-               0xd801_u16, 0xdc32_u16, 0xd801_u16, 0xdc4d_u16,
-               0x000a_u16]),
+                0xdc49_u16, 0xd801_u16, 0xdc2e_u16, 0xd801_u16,
+                0xdc40_u16, 0xd801_u16, 0xdc32_u16, 0xd801_u16,
+                0xdc4b_u16, 0x0020_u16, 0xd801_u16, 0xdc0f_u16,
+                0xd801_u16, 0xdc32_u16, 0xd801_u16, 0xdc4d_u16,
+                0x000a_u16]),
 
              (~"𐌀𐌖𐌋𐌄𐌑𐌉·𐌌𐌄𐌕𐌄𐌋𐌉𐌑\n",
               ~[0xd800_u16, 0xdf00_u16, 0xd800_u16, 0xdf16_u16,
-               0xd800_u16, 0xdf0b_u16, 0xd800_u16, 0xdf04_u16,
-               0xd800_u16, 0xdf11_u16, 0xd800_u16, 0xdf09_u16,
-               0x00b7_u16, 0xd800_u16, 0xdf0c_u16, 0xd800_u16,
-               0xdf04_u16, 0xd800_u16, 0xdf15_u16, 0xd800_u16,
-               0xdf04_u16, 0xd800_u16, 0xdf0b_u16, 0xd800_u16,
-               0xdf09_u16, 0xd800_u16, 0xdf11_u16, 0x000a_u16 ]),
+                0xd800_u16, 0xdf0b_u16, 0xd800_u16, 0xdf04_u16,
+                0xd800_u16, 0xdf11_u16, 0xd800_u16, 0xdf09_u16,
+                0x00b7_u16, 0xd800_u16, 0xdf0c_u16, 0xd800_u16,
+                0xdf04_u16, 0xd800_u16, 0xdf15_u16, 0xd800_u16,
+                0xdf04_u16, 0xd800_u16, 0xdf0b_u16, 0xd800_u16,
+                0xdf09_u16, 0xd800_u16, 0xdf11_u16, 0x000a_u16 ]),
 
              (~"𐒋𐒘𐒈𐒑𐒛𐒒 𐒕𐒓 𐒈𐒚𐒍 𐒏𐒜𐒒𐒖𐒆 𐒕𐒆\n",
               ~[0xd801_u16, 0xdc8b_u16, 0xd801_u16, 0xdc98_u16,
-               0xd801_u16, 0xdc88_u16, 0xd801_u16, 0xdc91_u16,
-               0xd801_u16, 0xdc9b_u16, 0xd801_u16, 0xdc92_u16,
-               0x0020_u16, 0xd801_u16, 0xdc95_u16, 0xd801_u16,
-               0xdc93_u16, 0x0020_u16, 0xd801_u16, 0xdc88_u16,
-               0xd801_u16, 0xdc9a_u16, 0xd801_u16, 0xdc8d_u16,
-               0x0020_u16, 0xd801_u16, 0xdc8f_u16, 0xd801_u16,
-               0xdc9c_u16, 0xd801_u16, 0xdc92_u16, 0xd801_u16,
-               0xdc96_u16, 0xd801_u16, 0xdc86_u16, 0x0020_u16,
-               0xd801_u16, 0xdc95_u16, 0xd801_u16, 0xdc86_u16,
-               0x000a_u16 ]) ];
+                0xd801_u16, 0xdc88_u16, 0xd801_u16, 0xdc91_u16,
+                0xd801_u16, 0xdc9b_u16, 0xd801_u16, 0xdc92_u16,
+                0x0020_u16, 0xd801_u16, 0xdc95_u16, 0xd801_u16,
+                0xdc93_u16, 0x0020_u16, 0xd801_u16, 0xdc88_u16,
+                0xd801_u16, 0xdc9a_u16, 0xd801_u16, 0xdc8d_u16,
+                0x0020_u16, 0xd801_u16, 0xdc8f_u16, 0xd801_u16,
+                0xdc9c_u16, 0xd801_u16, 0xdc92_u16, 0xd801_u16,
+                0xdc96_u16, 0xd801_u16, 0xdc86_u16, 0x0020_u16,
+                0xd801_u16, 0xdc95_u16, 0xd801_u16, 0xdc86_u16,
+                0x000a_u16 ]) ];
 
         for pairs.each |p| {
             let (s, u) = copy *p;
@@ -3972,35 +3965,35 @@ mod tests {
 
     #[test]
     fn test_escape_unicode() {
-        assert_eq!(escape_unicode(~"abc"), ~"\\x61\\x62\\x63");
-        assert_eq!(escape_unicode(~"a c"), ~"\\x61\\x20\\x63");
-        assert_eq!(escape_unicode(~"\r\n\t"), ~"\\x0d\\x0a\\x09");
-        assert_eq!(escape_unicode(~"'\"\\"), ~"\\x27\\x22\\x5c");
-        assert!(escape_unicode(~"\x00\x01\xfe\xff") ==
+        assert_eq!(escape_unicode("abc"), ~"\\x61\\x62\\x63");
+        assert_eq!(escape_unicode("a c"), ~"\\x61\\x20\\x63");
+        assert_eq!(escape_unicode("\r\n\t"), ~"\\x0d\\x0a\\x09");
+        assert_eq!(escape_unicode("'\"\\"), ~"\\x27\\x22\\x5c");
+        assert!(escape_unicode("\x00\x01\xfe\xff") ==
                      ~"\\x00\\x01\\xfe\\xff");
-        assert_eq!(escape_unicode(~"\u0100\uffff"), ~"\\u0100\\uffff");
-        assert!(escape_unicode(~"\U00010000\U0010ffff") ==
+        assert_eq!(escape_unicode("\u0100\uffff"), ~"\\u0100\\uffff");
+        assert!(escape_unicode("\U00010000\U0010ffff") ==
             ~"\\U00010000\\U0010ffff");
-        assert_eq!(escape_unicode(~"ab\ufb00"), ~"\\x61\\x62\\ufb00");
-        assert_eq!(escape_unicode(~"\U0001d4ea\r"), ~"\\U0001d4ea\\x0d");
+        assert_eq!(escape_unicode("ab\ufb00"), ~"\\x61\\x62\\ufb00");
+        assert_eq!(escape_unicode("\U0001d4ea\r"), ~"\\U0001d4ea\\x0d");
     }
 
     #[test]
     fn test_escape_default() {
-        assert_eq!(escape_default(~"abc"), ~"abc");
-        assert_eq!(escape_default(~"a c"), ~"a c");
-        assert_eq!(escape_default(~"\r\n\t"), ~"\\r\\n\\t");
-        assert_eq!(escape_default(~"'\"\\"), ~"\\'\\\"\\\\");
-        assert_eq!(escape_default(~"\u0100\uffff"), ~"\\u0100\\uffff");
-        assert!(escape_default(~"\U00010000\U0010ffff") ==
+        assert_eq!(escape_default("abc"), ~"abc");
+        assert_eq!(escape_default("a c"), ~"a c");
+        assert_eq!(escape_default("\r\n\t"), ~"\\r\\n\\t");
+        assert_eq!(escape_default("'\"\\"), ~"\\'\\\"\\\\");
+        assert_eq!(escape_default("\u0100\uffff"), ~"\\u0100\\uffff");
+        assert!(escape_default("\U00010000\U0010ffff") ==
             ~"\\U00010000\\U0010ffff");
-        assert_eq!(escape_default(~"ab\ufb00"), ~"ab\\ufb00");
-        assert_eq!(escape_default(~"\U0001d4ea\r"), ~"\\U0001d4ea\\r");
+        assert_eq!(escape_default("ab\ufb00"), ~"ab\\ufb00");
+        assert_eq!(escape_default("\U0001d4ea\r"), ~"\\U0001d4ea\\r");
     }
 
     #[test]
     fn test_to_managed() {
-        assert_eq!((~"abc").to_managed(), @"abc");
+        assert_eq!("abc".to_managed(), @"abc");
         assert_eq!(slice("abcdef", 1, 5).to_managed(), @"bcde");
     }
 

--- a/src/libstd/str/ascii.rs
+++ b/src/libstd/str/ascii.rs
@@ -228,8 +228,8 @@ mod tests {
         assert_eq!('`'.to_ascii().to_upper().to_char(), '`');
         assert_eq!('{'.to_ascii().to_upper().to_char(), '{');
 
-        assert!(str::all(~"banana", |c| c.is_ascii()));
-        assert!(! str::all(~"ประเทศไทย中华Việt Nam", |c| c.is_ascii()));
+        assert!(str::all("banana", |c| c.is_ascii()));
+        assert!(! str::all("ประเทศไทย中华Việt Nam", |c| c.is_ascii()));
     }
 
     #[test]

--- a/src/libstd/to_bytes.rs
+++ b/src/libstd/to_bytes.rs
@@ -236,42 +236,6 @@ impl<A:IterBytes> IterBytes for @[A] {
     }
 }
 
-// NOTE: remove all of these after a snapshot, the new for-loop iteration
-//       protocol makes these unnecessary.
-
-#[inline(always)]
-pub fn iter_bytes_2<A:IterBytes,B:IterBytes>(a: &A, b: &B,
-                                             lsb0: bool, z: Cb) -> bool {
-    a.iter_bytes(lsb0, z) && b.iter_bytes(lsb0, z)
-}
-
-pub fn iter_bytes_3<A: IterBytes,
-                    B: IterBytes,
-                    C: IterBytes>(a: &A, b: &B, c: &C, lsb0: bool, z: Cb) -> bool {
-    a.iter_bytes(lsb0, z) && b.iter_bytes(lsb0, z) && c.iter_bytes(lsb0, z)
-}
-
-pub fn iter_bytes_4<A: IterBytes,
-                B: IterBytes,
-                C: IterBytes,
-                D: IterBytes>(a: &A, b: &B, c: &C,
-                              d: &D,
-                              lsb0: bool, z: Cb) -> bool {
-    a.iter_bytes(lsb0, z) && b.iter_bytes(lsb0, z) && c.iter_bytes(lsb0, z) &&
-        d.iter_bytes(lsb0, z)
-}
-
-pub fn iter_bytes_5<A: IterBytes,
-                B: IterBytes,
-                C: IterBytes,
-                D: IterBytes,
-                E: IterBytes>(a: &A, b: &B, c: &C,
-                              d: &D, e: &E,
-                              lsb0: bool, z: Cb) -> bool {
-    a.iter_bytes(lsb0, z) && b.iter_bytes(lsb0, z) && c.iter_bytes(lsb0, z) &&
-        d.iter_bytes(lsb0, z) && e.iter_bytes(lsb0, z)
-}
-
 impl<'self> IterBytes for &'self str {
     #[inline(always)]
     fn iter_bytes(&self, _lsb0: bool, f: Cb) -> bool {

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2962,8 +2962,8 @@ mod tests {
 
     #[test]
     fn test_is_empty() {
-        assert!(is_empty::<int>(~[]));
-        assert!(!is_empty(~[0]));
+        assert!(is_empty::<int>([]));
+        assert!(!is_empty([0]));
     }
 
     #[test]
@@ -3445,7 +3445,7 @@ mod tests {
 
     #[test]
     fn test_each_empty() {
-        for each::<int>(~[]) |_v| {
+        for each::<int>([]) |_v| {
             fail!(); // should never be executed
         }
     }
@@ -3453,7 +3453,7 @@ mod tests {
     #[test]
     fn test_each_nonempty() {
         let mut i = 0;
-        for each(~[1, 2, 3]) |v| {
+        for each([1, 2, 3]) |v| {
             i += *v;
         }
         assert_eq!(i, 6);
@@ -3462,7 +3462,7 @@ mod tests {
     #[test]
     fn test_eachi() {
         let mut i = 0;
-        for eachi(~[1, 2, 3]) |j, v| {
+        for eachi([1, 2, 3]) |j, v| {
             if i == 0 { assert!(*v == 1); }
             assert_eq!(j + 1u, *v as uint);
             i += *v;
@@ -3481,7 +3481,7 @@ mod tests {
     #[test]
     fn test_each_reverse_nonempty() {
         let mut i = 0;
-        for each_reverse(~[1, 2, 3]) |v| {
+        for each_reverse([1, 2, 3]) |v| {
             if i == 0 { assert!(*v == 3); }
             i += *v
         }
@@ -3491,7 +3491,7 @@ mod tests {
     #[test]
     fn test_eachi_reverse() {
         let mut i = 0;
-        for eachi_reverse(~[0, 1, 2]) |j, v| {
+        for eachi_reverse([0, 1, 2]) |j, v| {
             if i == 0 { assert!(*v == 2); }
             assert_eq!(j, *v as uint);
             i += *v;
@@ -3512,48 +3512,48 @@ mod tests {
         let mut results: ~[~[int]];
 
         results = ~[];
-        for each_permutation(~[]) |v| { results.push(to_owned(v)); }
+        for each_permutation([]) |v| { results.push(to_owned(v)); }
         assert_eq!(results, ~[~[]]);
 
         results = ~[];
-        for each_permutation(~[7]) |v| { results.push(to_owned(v)); }
+        for each_permutation([7]) |v| { results.push(to_owned(v)); }
         assert_eq!(results, ~[~[7]]);
 
         results = ~[];
-        for each_permutation(~[1,1]) |v| { results.push(to_owned(v)); }
+        for each_permutation([1,1]) |v| { results.push(to_owned(v)); }
         assert_eq!(results, ~[~[1,1],~[1,1]]);
 
         results = ~[];
-        for each_permutation(~[5,2,0]) |v| { results.push(to_owned(v)); }
+        for each_permutation([5,2,0]) |v| { results.push(to_owned(v)); }
         assert!(results ==
             ~[~[5,2,0],~[5,0,2],~[2,5,0],~[2,0,5],~[0,5,2],~[0,2,5]]);
     }
 
     #[test]
     fn test_any_and_all() {
-        assert!(any(~[1u, 2u, 3u], is_three));
-        assert!(!any(~[0u, 1u, 2u], is_three));
-        assert!(any(~[1u, 2u, 3u, 4u, 5u], is_three));
-        assert!(!any(~[1u, 2u, 4u, 5u, 6u], is_three));
+        assert!(any([1u, 2u, 3u], is_three));
+        assert!(!any([0u, 1u, 2u], is_three));
+        assert!(any([1u, 2u, 3u, 4u, 5u], is_three));
+        assert!(!any([1u, 2u, 4u, 5u, 6u], is_three));
 
-        assert!(all(~[3u, 3u, 3u], is_three));
-        assert!(!all(~[3u, 3u, 2u], is_three));
-        assert!(all(~[3u, 3u, 3u, 3u, 3u], is_three));
-        assert!(!all(~[3u, 3u, 0u, 1u, 2u], is_three));
+        assert!(all([3u, 3u, 3u], is_three));
+        assert!(!all([3u, 3u, 2u], is_three));
+        assert!(all([3u, 3u, 3u, 3u, 3u], is_three));
+        assert!(!all([3u, 3u, 0u, 1u, 2u], is_three));
     }
 
     #[test]
     fn test_any2_and_all2() {
 
-        assert!(any2(~[2u, 4u, 6u], ~[2u, 4u, 6u], is_equal));
-        assert!(any2(~[1u, 2u, 3u], ~[4u, 5u, 3u], is_equal));
-        assert!(!any2(~[1u, 2u, 3u], ~[4u, 5u, 6u], is_equal));
-        assert!(any2(~[2u, 4u, 6u], ~[2u, 4u], is_equal));
+        assert!(any2([2u, 4u, 6u], [2u, 4u, 6u], is_equal));
+        assert!(any2([1u, 2u, 3u], [4u, 5u, 3u], is_equal));
+        assert!(!any2([1u, 2u, 3u], [4u, 5u, 6u], is_equal));
+        assert!(any2([2u, 4u, 6u], [2u, 4u], is_equal));
 
-        assert!(all2(~[2u, 4u, 6u], ~[2u, 4u, 6u], is_equal));
-        assert!(!all2(~[1u, 2u, 3u], ~[4u, 5u, 3u], is_equal));
-        assert!(!all2(~[1u, 2u, 3u], ~[4u, 5u, 6u], is_equal));
-        assert!(!all2(~[2u, 4u, 6u], ~[2u, 4u], is_equal));
+        assert!(all2([2u, 4u, 6u], [2u, 4u, 6u], is_equal));
+        assert!(!all2([1u, 2u, 3u], [4u, 5u, 3u], is_equal));
+        assert!(!all2([1u, 2u, 3u], [4u, 5u, 6u], is_equal));
+        assert!(!all2([2u, 4u, 6u], [2u, 4u], is_equal));
     }
 
     #[test]
@@ -3576,7 +3576,7 @@ mod tests {
 
     #[test]
     fn test_position_elem() {
-        assert!(position_elem(~[], &1).is_none());
+        assert!(position_elem([], &1).is_none());
 
         let v1 = ~[1, 2, 3, 3, 2, 5];
         assert_eq!(position_elem(v1, &1), Some(0u));
@@ -3590,7 +3590,7 @@ mod tests {
         fn less_than_three(i: &int) -> bool { *i < 3 }
         fn is_eighteen(i: &int) -> bool { *i == 18 }
 
-        assert!(position(~[], less_than_three).is_none());
+        assert!(position([], less_than_three).is_none());
 
         let v1 = ~[5, 4, 3, 2, 1];
         assert_eq!(position(v1, less_than_three), Some(3u));
@@ -3599,7 +3599,7 @@ mod tests {
 
     #[test]
     fn test_position_between() {
-        assert!(position_between(~[], 0u, 0u, f).is_none());
+        assert!(position_between([], 0u, 0u, f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
         let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
@@ -3627,7 +3627,7 @@ mod tests {
 
     #[test]
     fn test_find() {
-        assert!(find(~[], f).is_none());
+        assert!(find([], f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
         fn g(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'd' }
@@ -3639,7 +3639,7 @@ mod tests {
 
     #[test]
     fn test_find_between() {
-        assert!(find_between(~[], 0u, 0u, f).is_none());
+        assert!(find_between([], 0u, 0u, f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
         let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
@@ -3667,7 +3667,7 @@ mod tests {
 
     #[test]
     fn test_rposition() {
-        assert!(find(~[], f).is_none());
+        assert!(find([], f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
         fn g(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'd' }
@@ -3679,7 +3679,7 @@ mod tests {
 
     #[test]
     fn test_rposition_between() {
-        assert!(rposition_between(~[], 0u, 0u, f).is_none());
+        assert!(rposition_between([], 0u, 0u, f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
         let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
@@ -3707,7 +3707,7 @@ mod tests {
 
     #[test]
     fn test_rfind() {
-        assert!(rfind(~[], f).is_none());
+        assert!(rfind([], f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
         fn g(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'd' }
@@ -3719,7 +3719,7 @@ mod tests {
 
     #[test]
     fn test_rfind_between() {
-        assert!(rfind_between(~[], 0u, 0u, f).is_none());
+        assert!(rfind_between([], 0u, 0u, f).is_none());
 
         fn f(xy: &(int, char)) -> bool { let (_x, y) = *xy; y == 'b' }
         let v = ~[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'b')];
@@ -3798,14 +3798,14 @@ mod tests {
         reverse(v);
         assert_eq!(v[0], 20);
         assert_eq!(v[1], 10);
-        let v2 = reversed::<int>(~[10, 20]);
+        let v2 = reversed::<int>([10, 20]);
         assert_eq!(v2[0], 20);
         assert_eq!(v2[1], 10);
         v[0] = 30;
         assert_eq!(v2[0], 20);
         // Make sure they work with 0-length vectors too.
 
-        let v4 = reversed::<int>(~[]);
+        let v4 = reversed::<int>([]);
         assert_eq!(v4, ~[]);
         let mut v3: ~[int] = ~[];
         reverse::<int>(v3);
@@ -3813,7 +3813,7 @@ mod tests {
 
     #[test]
     fn reversed_mut() {
-        let v2 = reversed::<int>(~[10, 20]);
+        let v2 = reversed::<int>([10, 20]);
         assert_eq!(v2[0], 20);
         assert_eq!(v2[1], 10);
     }
@@ -3822,22 +3822,22 @@ mod tests {
     fn test_split() {
         fn f(x: &int) -> bool { *x == 3 }
 
-        assert_eq!(split(~[], f), ~[]);
-        assert_eq!(split(~[1, 2], f), ~[~[1, 2]]);
-        assert_eq!(split(~[3, 1, 2], f), ~[~[], ~[1, 2]]);
-        assert_eq!(split(~[1, 2, 3], f), ~[~[1, 2], ~[]]);
-        assert_eq!(split(~[1, 2, 3, 4, 3, 5], f), ~[~[1, 2], ~[4], ~[5]]);
+        assert_eq!(split([], f), ~[]);
+        assert_eq!(split([1, 2], f), ~[~[1, 2]]);
+        assert_eq!(split([3, 1, 2], f), ~[~[], ~[1, 2]]);
+        assert_eq!(split([1, 2, 3], f), ~[~[1, 2], ~[]]);
+        assert_eq!(split([1, 2, 3, 4, 3, 5], f), ~[~[1, 2], ~[4], ~[5]]);
     }
 
     #[test]
     fn test_splitn() {
         fn f(x: &int) -> bool { *x == 3 }
 
-        assert_eq!(splitn(~[], 1u, f), ~[]);
-        assert_eq!(splitn(~[1, 2], 1u, f), ~[~[1, 2]]);
-        assert_eq!(splitn(~[3, 1, 2], 1u, f), ~[~[], ~[1, 2]]);
-        assert_eq!(splitn(~[1, 2, 3], 1u, f), ~[~[1, 2], ~[]]);
-        assert!(splitn(~[1, 2, 3, 4, 3, 5], 1u, f) ==
+        assert_eq!(splitn([], 1u, f), ~[]);
+        assert_eq!(splitn([1, 2], 1u, f), ~[~[1, 2]]);
+        assert_eq!(splitn([3, 1, 2], 1u, f), ~[~[], ~[1, 2]]);
+        assert_eq!(splitn([1, 2, 3], 1u, f), ~[~[1, 2], ~[]]);
+        assert!(splitn([1, 2, 3, 4, 3, 5], 1u, f) ==
                       ~[~[1, 2], ~[4, 3, 5]]);
     }
 
@@ -3845,10 +3845,10 @@ mod tests {
     fn test_rsplit() {
         fn f(x: &int) -> bool { *x == 3 }
 
-        assert_eq!(rsplit(~[], f), ~[]);
-        assert_eq!(rsplit(~[1, 2], f), ~[~[1, 2]]);
-        assert_eq!(rsplit(~[1, 2, 3], f), ~[~[1, 2], ~[]]);
-        assert!(rsplit(~[1, 2, 3, 4, 3, 5], f) ==
+        assert_eq!(rsplit([], f), ~[]);
+        assert_eq!(rsplit([1, 2], f), ~[~[1, 2]]);
+        assert_eq!(rsplit([1, 2, 3], f), ~[~[1, 2], ~[]]);
+        assert!(rsplit([1, 2, 3, 4, 3, 5], f) ==
             ~[~[1, 2], ~[4], ~[5]]);
     }
 
@@ -3856,53 +3856,46 @@ mod tests {
     fn test_rsplitn() {
         fn f(x: &int) -> bool { *x == 3 }
 
-        assert_eq!(rsplitn(~[], 1u, f), ~[]);
-        assert_eq!(rsplitn(~[1, 2], 1u, f), ~[~[1, 2]]);
-        assert_eq!(rsplitn(~[1, 2, 3], 1u, f), ~[~[1, 2], ~[]]);
-        assert!(rsplitn(~[1, 2, 3, 4, 3, 5], 1u, f) ==
-                       ~[~[1, 2, 3, 4], ~[5]]);
+        assert_eq!(rsplitn([], 1u, f), ~[]);
+        assert_eq!(rsplitn([1, 2], 1u, f), ~[~[1, 2]]);
+        assert_eq!(rsplitn([1, 2, 3], 1u, f), ~[~[1, 2], ~[]]);
+        assert_eq!(rsplitn([1, 2, 3, 4, 3, 5], 1u, f), ~[~[1, 2, 3, 4], ~[5]]);
     }
 
     #[test]
     fn test_partition() {
         // FIXME (#4355 maybe): using v.partition here crashes
         assert_eq!(partition(~[], |x: &int| *x < 3), (~[], ~[]));
-        assert!(partition(~[1, 2, 3], |x: &int| *x < 4) ==
-            (~[1, 2, 3], ~[]));
-        assert!(partition(~[1, 2, 3], |x: &int| *x < 2) ==
-            (~[1], ~[2, 3]));
-        assert!(partition(~[1, 2, 3], |x: &int| *x < 0) ==
-            (~[], ~[1, 2, 3]));
+        assert_eq!(partition(~[1, 2, 3], |x: &int| *x < 4), (~[1, 2, 3], ~[]));
+        assert_eq!(partition(~[1, 2, 3], |x: &int| *x < 2), (~[1], ~[2, 3]));
+        assert_eq!(partition(~[1, 2, 3], |x: &int| *x < 0), (~[], ~[1, 2, 3]));
     }
 
     #[test]
     fn test_partitioned() {
-        assert_eq!((~[]).partitioned(|x: &int| *x < 3), (~[], ~[]))
-        assert!((~[1, 2, 3]).partitioned(|x: &int| *x < 4) ==
-                     (~[1, 2, 3], ~[]));
-        assert!((~[1, 2, 3]).partitioned(|x: &int| *x < 2) ==
-                     (~[1], ~[2, 3]));
-        assert!((~[1, 2, 3]).partitioned(|x: &int| *x < 0) ==
-                     (~[], ~[1, 2, 3]));
+        assert_eq!(([]).partitioned(|x: &int| *x < 3), (~[], ~[]))
+        assert_eq!(([1, 2, 3]).partitioned(|x: &int| *x < 4), (~[1, 2, 3], ~[]));
+        assert_eq!(([1, 2, 3]).partitioned(|x: &int| *x < 2), (~[1], ~[2, 3]));
+        assert_eq!(([1, 2, 3]).partitioned(|x: &int| *x < 0), (~[], ~[1, 2, 3]));
     }
 
     #[test]
     fn test_concat() {
-        assert_eq!(concat(~[~[1], ~[2,3]]), ~[1, 2, 3]);
+        assert_eq!(concat([~[1], ~[2,3]]), ~[1, 2, 3]);
     }
 
     #[test]
     fn test_connect() {
-        assert_eq!(connect(~[], &0), ~[]);
-        assert_eq!(connect(~[~[1], ~[2, 3]], &0), ~[1, 0, 2, 3]);
-        assert_eq!(connect(~[~[1], ~[2], ~[3]], &0), ~[1, 0, 2, 0, 3]);
+        assert_eq!(connect([], &0), ~[]);
+        assert_eq!(connect([~[1], ~[2, 3]], &0), ~[1, 0, 2, 3]);
+        assert_eq!(connect([~[1], ~[2], ~[3]], &0), ~[1, 0, 2, 0, 3]);
     }
 
     #[test]
     fn test_windowed () {
         fn t(n: uint, expected: &[&[int]]) {
             let mut i = 0;
-            for windowed(n, ~[1,2,3,4,5,6]) |v| {
+            for windowed(n, [1,2,3,4,5,6]) |v| {
                 assert_eq!(v, expected[i]);
                 i += 1;
             }
@@ -3920,7 +3913,7 @@ mod tests {
     #[should_fail]
     #[ignore(cfg(windows))]
     fn test_windowed_() {
-        for windowed (0u, ~[1u,2u,3u,4u,5u,6u]) |_v| {}
+        for windowed (0u, [1u,2u,3u,4u,5u,6u]) |_v| {}
     }
 
     #[test]

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -112,7 +112,9 @@ pub struct Lifetime {
 
 impl to_bytes::IterBytes for Lifetime {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_3(&self.id, &self.span, &self.ident, lsb0, f)
+        self.id.iter_bytes(lsb0, f) &&
+        self.span.iter_bytes(lsb0, f) &&
+        self.ident.iter_bytes(lsb0, f)
     }
 }
 
@@ -266,7 +268,9 @@ impl to_bytes::IterBytes for binding_mode {
         match *self {
           bind_by_copy => 0u8.iter_bytes(lsb0, f),
 
-          bind_by_ref(ref m) => to_bytes::iter_bytes_2(&1u8, m, lsb0, f),
+          bind_by_ref(ref m) => {
+              1u8.iter_bytes(lsb0, f) && m.iter_bytes(lsb0, f)
+          }
 
           bind_infer => 2u8.iter_bytes(lsb0, f),
         }
@@ -788,7 +792,7 @@ pub enum ty_ {
 
 impl to_bytes::IterBytes for Ty {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_2(&self.span.lo, &self.span.hi, lsb0, f)
+        self.span.lo.iter_bytes(lsb0, f) && self.span.hi.iter_bytes(lsb0, f)
     }
 }
 
@@ -876,9 +880,15 @@ impl to_bytes::IterBytes for explicit_self_ {
         match *self {
             sty_static => 0u8.iter_bytes(lsb0, f),
             sty_value => 1u8.iter_bytes(lsb0, f),
-            sty_region(ref lft, ref mutbl) => to_bytes::iter_bytes_3(&2u8, &lft, mutbl, lsb0, f),
-            sty_box(ref mutbl) => to_bytes::iter_bytes_2(&3u8, mutbl, lsb0, f),
-            sty_uniq(ref mutbl) => to_bytes::iter_bytes_2(&4u8, mutbl, lsb0, f),
+            sty_region(ref lft, ref mutbl) => {
+                2u8.iter_bytes(lsb0, f) && lft.iter_bytes(lsb0, f) && mutbl.iter_bytes(lsb0, f)
+            }
+            sty_box(ref mutbl) => {
+                3u8.iter_bytes(lsb0, f) && mutbl.iter_bytes(lsb0, f)
+            }
+            sty_uniq(ref mutbl) => {
+                4u8.iter_bytes(lsb0, f) && mutbl.iter_bytes(lsb0, f)
+            }
         }
     }
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -17,9 +17,8 @@ use abi::AbiSet;
 use opt_vec::OptVec;
 use parse::token::get_ident_interner;
 
-use core::cast;
 use core::hashmap::HashMap;
-use core::option::{Option};
+use core::option::Option;
 use core::to_bytes::IterBytes;
 use core::to_bytes;
 use core::to_str::ToStr;

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -197,7 +197,7 @@ pub fn is_call_expr(e: @expr) -> bool {
 impl to_bytes::IterBytes for def_id {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_2(&self.crate, &self.node, lsb0, f)
+        self.crate.iter_bytes(lsb0, f) && self.node.iter_bytes(lsb0, f)
     }
 }
 

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -140,7 +140,9 @@ impl<D:Decoder> Decodable<D> for span {
 
 impl to_bytes::IterBytes for span {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_3(&self.lo, &self.hi, &self.expn_info, lsb0, f)
+        self.lo.iter_bytes(lsb0, f) &&
+        self.hi.iter_bytes(lsb0, f) &&
+        self.expn_info.iter_bytes(lsb0, f)
     }
 }
 
@@ -193,7 +195,7 @@ pub struct NameAndSpan {name: ~str, span: Option<span>}
 
 impl to_bytes::IterBytes for NameAndSpan {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_2(&self.name, &self.span, lsb0, f)
+        self.name.iter_bytes(lsb0, f) && self.span.iter_bytes(lsb0, f)
     }
 }
 
@@ -204,7 +206,7 @@ pub struct CallInfo {
 
 impl to_bytes::IterBytes for CallInfo {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
-        to_bytes::iter_bytes_2(&self.call_site, &self.callee, lsb0, f)
+        self.call_site.iter_bytes(lsb0, f) && self.callee.iter_bytes(lsb0, f)
     }
 }
 
@@ -216,7 +218,9 @@ pub enum ExpnInfo {
 impl to_bytes::IterBytes for ExpnInfo {
     fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
         match *self {
-            ExpandedFrom(ref call_info) => to_bytes::iter_bytes_2(&0u8, call_info, lsb0, f)
+            ExpandedFrom(ref call_info) => {
+                0u8.iter_bytes(lsb0, f) && call_info.iter_bytes(lsb0, f)
+            }
         }
     }
 }

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -15,11 +15,9 @@
 
 use core::prelude::*;
 
-use abi::AbiSet;
 use ast::ident;
 use ast;
 use codemap::span;
-// use ext::quote::rt::*;
 
 // Transitional reexports so qquote can find the paths it is looking for
 mod syntax {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2752,7 +2752,7 @@ pub impl Parser {
             match *self.token {
                 token::SEMI => {
                     if !vec::is_empty(attributes_box) {
-                        self.span_err(*self.last_span,~"expected item after attributes");
+                        self.span_err(*self.last_span, "expected item after attributes");
                         attributes_box = ~[];
                     }
                     self.bump(); // empty
@@ -2823,7 +2823,7 @@ pub impl Parser {
         }
 
         if !vec::is_empty(attributes_box) {
-            self.span_err(*self.last_span,~"expected item after attributes");
+            self.span_err(*self.last_span, "expected item after attributes");
         }
 
         let hi = self.span.hi;
@@ -3742,7 +3742,7 @@ pub impl Parser {
         } = self.parse_foreign_items(first_item_attrs, true);
         if (! attrs_remaining.is_empty()) {
             self.span_err(*self.last_span,
-                          ~"expected item after attributes");
+                          "expected item after attributes");
         }
         assert!(*self.token == token::RBRACE);
         ast::foreign_mod {


### PR DESCRIPTION
Simple patch series to fix up all the warnings a rustc compile is giving at the moment. It also fixes a NOTE in `to_bytes.rs` to remove the `to_bytes::iter_bytes_<N>` functions.
