### PR TITLE
rustc: Check for null before dropping ~objects. #5192

### DIFF
--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -546,20 +546,23 @@ pub fn make_drop_glue(bcx: block, v0: ValueRef, t: ty::t) {
         decr_refcnt_maybe_free(bcx, llbox, ty::mk_opaque_box(ccx.tcx))
       }
       ty::ty_trait(_, _, ty::UniqTraitStore, _) => {
-        let lluniquevalue = GEPi(bcx, v0, [0, abi::trt_field_box]);
-        let llvtable = Load(bcx, GEPi(bcx, v0, [0, abi::trt_field_vtable]));
+          let lluniquevalue = GEPi(bcx, v0, [0, abi::trt_field_box]);
+          // Only drop the value when it is non-null
+          do with_cond(bcx, IsNotNull(bcx, Load(bcx, lluniquevalue))) |bcx| {
+              let llvtable = Load(bcx, GEPi(bcx, v0, [0, abi::trt_field_vtable]));
 
-        // Cast the vtable to a pointer to a pointer to a tydesc.
-        let llvtable = PointerCast(bcx,
-                                   llvtable,
-                                   T_ptr(T_ptr(ccx.tydesc_type)));
-        let lltydesc = Load(bcx, llvtable);
-        call_tydesc_glue_full(bcx,
-                              lluniquevalue,
-                              lltydesc,
-                              abi::tydesc_field_free_glue,
-                              None);
-        bcx
+              // Cast the vtable to a pointer to a pointer to a tydesc.
+              let llvtable = PointerCast(bcx,
+                                         llvtable,
+                                         T_ptr(T_ptr(ccx.tydesc_type)));
+              let lltydesc = Load(bcx, llvtable);
+              call_tydesc_glue_full(bcx,
+                                    lluniquevalue,
+                                    lltydesc,
+                                    abi::tydesc_field_free_glue,
+                                    None);
+              bcx
+          }
       }
       ty::ty_opaque_closure_ptr(ck) => {
         closure::make_opaque_cbox_drop_glue(bcx, ck, v0)

--- a/src/test/run-pass/unique-object-move.rs
+++ b/src/test/run-pass/unique-object-move.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #5192
+
+pub trait EventLoop { }
+
+pub struct UvEventLoop {
+    uvio: int
+}
+
+impl EventLoop for UvEventLoop { }
+
+pub fn main() {
+    let loop_: ~EventLoop = ~UvEventLoop { uvio: 0 } as ~EventLoop;
+    let loop2_ = loop_;
+}


### PR DESCRIPTION
r? @catamorphism 

This could probably refactored to more closely mirror the code for `@objects`, but I'm not inclined to do so.
