### PR TITLE
rustc: Give glue symbols meaningful names

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -721,6 +721,17 @@ pub fn mangle_internal_name_by_type_only(ccx: @CrateContext,
           path_name(ccx.sess.ident_of(hash))]);
 }
 
+pub fn mangle_internal_name_by_type_and_seq(ccx: @CrateContext,
+                                         t: ty::t,
+                                         name: &str) -> ~str {
+    let s = ppaux::ty_to_str(ccx.tcx, t);
+    let hash = get_symbol_hash(ccx, t);
+    return mangle(ccx.sess,
+        ~[path_name(ccx.sess.ident_of(s)),
+          path_name(ccx.sess.ident_of(hash)),
+          path_name((ccx.names)(name))]);
+}
+
 pub fn mangle_internal_name_by_path_and_seq(ccx: @CrateContext,
                                             path: path,
                                             flav: &str) -> ~str {

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -669,12 +669,7 @@ pub fn declare_tydesc(ccx: @CrateContext, t: ty::t) -> @mut tydesc_info {
     let llsize = llsize_of(ccx, llty);
     let llalign = llalign_of(ccx, llty);
     let addrspace = declare_tydesc_addrspace(ccx, t);
-    // FIXME #6574: this triggers duplicate LLVM symbols
-    let name = @(if false /*ccx.sess.opts.debuginfo*/ {
-        mangle_internal_name_by_type_only(ccx, t, "tydesc")
-    } else {
-        mangle_internal_name_by_seq(ccx, "tydesc")
-    });
+    let name = @mangle_internal_name_by_type_and_seq(ccx, t, "tydesc");
     note_unique_llvm_symbol(ccx, name);
     debug!("+++ declare_tydesc %s %s", ppaux::ty_to_str(ccx.tcx, t), *name);
     let gvar = str::as_c_str(*name, |buf| {
@@ -703,12 +698,7 @@ pub fn declare_generic_glue(ccx: @CrateContext, t: ty::t, llfnty: TypeRef,
                             name: ~str) -> ValueRef {
     let _icx = ccx.insn_ctxt("declare_generic_glue");
     let name = name;
-    // FIXME #6574 this triggers duplicate LLVM symbols
-    let fn_nm = @(if false /*ccx.sess.opts.debuginfo*/ {
-        mangle_internal_name_by_type_only(ccx, t, (~"glue_" + name))
-    } else {
-        mangle_internal_name_by_seq(ccx, (~"glue_" + name))
-    });
+    let fn_nm = @mangle_internal_name_by_type_and_seq(ccx, t, (~"glue_" + name));
     debug!("%s is for type %s", *fn_nm, ppaux::ty_to_str(ccx.tcx, t));
     note_unique_llvm_symbol(ccx, fn_nm);
     let llfn = decl_cdecl_fn(ccx.llmod, *fn_nm, llfnty);


### PR DESCRIPTION
Instead of `glue_drop1234` it's `Type::<hash>::glue_drop1234`

Haven't done any performance testing.
