### PR TITLE
LLVM upgrades

### DIFF
--- a/configure
+++ b/configure
@@ -835,8 +835,7 @@ do
 
         # Disable unused LLVM features
         LLVM_OPTS="$LLVM_DBG_OPTS --disable-docs \
-                   --enable-bindings=none --disable-threads \
-                   --disable-pthreads"
+                   --enable-bindings=none"
 
         case "$CFG_C_COMPILER" in
             ("ccache clang")

--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -14,7 +14,9 @@ LLVM_DEPS := $(S)/.gitmodules
 else
 
 # This is just a rough approximation of LLVM deps
-LLVM_DEPS=$(call rwildcard,$(CFG_LLVM_SRC_DIR),*cpp *hpp)
+LLVM_DEPS_SRC=$(call rwildcard,$(CFG_LLVM_SRC_DIR)/lib,*cpp *hpp)
+LLVM_DEPS_INC=$(call rwildcard,$(CFG_LLVM_SRC_DIR)/include,*cpp *hpp)
+LLVM_DEPS=$(LLVM_DEPS_SRC) $(LLVM_DEPS_INC)
 endif
 
 define DEF_LLVM_RULES

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1547,7 +1547,8 @@ pub mod llvm {
                                          Op: AtomicBinOp,
                                          LHS: ValueRef,
                                          RHS: ValueRef,
-                                         Order: AtomicOrdering)
+                                         Order: AtomicOrdering,
+                                         SingleThreaded: Bool)
                                          -> ValueRef;
 
         /* Selected entries from the downcasts. */

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -60,35 +60,35 @@ pub enum Linkage {
 }
 
 pub enum Attribute {
-    ZExtAttribute = 1,
-    SExtAttribute = 2,
-    NoReturnAttribute = 4,
-    InRegAttribute = 8,
-    StructRetAttribute = 16,
-    NoUnwindAttribute = 32,
-    NoAliasAttribute = 64,
-    ByValAttribute = 128,
-    NestAttribute = 256,
-    ReadNoneAttribute = 512,
-    ReadOnlyAttribute = 1024,
-    NoInlineAttribute = 2048,
-    AlwaysInlineAttribute = 4096,
-    OptimizeForSizeAttribute = 8192,
-    StackProtectAttribute = 16384,
-    StackProtectReqAttribute = 32768,
-    // 31 << 16
-    AlignmentAttribute = 2031616,
-    NoCaptureAttribute = 2097152,
-    NoRedZoneAttribute = 4194304,
-    NoImplicitFloatAttribute = 8388608,
-    NakedAttribute = 16777216,
-    InlineHintAttribute = 33554432,
-    // 7 << 26
-    StackAttribute = 469762048,
-    ReturnsTwiceAttribute = 536870912,
-    // 1 << 30
-    UWTableAttribute = 1073741824,
-    NonLazyBindAttribute = 2147483648,
+    ZExtAttribute = 1 << 0,
+    SExtAttribute = 1 << 1,
+    NoReturnAttribute = 1 << 2,
+    InRegAttribute = 1 << 3,
+    StructRetAttribute = 1 << 4,
+    NoUnwindAttribute = 1 << 5,
+    NoAliasAttribute = 1 << 6,
+    ByValAttribute = 1 << 7,
+    NestAttribute = 1 << 8,
+    ReadNoneAttribute = 1 << 9,
+    ReadOnlyAttribute = 1 << 10,
+    NoInlineAttribute = 1 << 11,
+    AlwaysInlineAttribute = 1 << 12,
+    OptimizeForSizeAttribute = 1 << 13,
+    StackProtectAttribute = 1 << 14,
+    StackProtectReqAttribute = 1 << 15,
+    AlignmentAttribute = 31 << 16,
+    NoCaptureAttribute = 1 << 21,
+    NoRedZoneAttribute = 1 << 22,
+    NoImplicitFloatAttribute = 1 << 23,
+    NakedAttribute = 1 << 24,
+    InlineHintAttribute = 1 << 25,
+    StackAttribute = 7 << 26,
+    ReturnsTwiceAttribute = 1 << 29,
+    UWTableAttribute = 1 << 30,
+    NonLazyBindAttribute = 1 << 31,
+
+    // Not added to LLVM yet, so may need to stay updated if LLVM changes.
+    FixedStackSegment = 1 << 41,
 }
 
 // enum for the LLVM IntPredicate type
@@ -1915,6 +1915,15 @@ pub fn ConstICmp(Pred: IntPredicate, V1: ValueRef, V2: ValueRef) -> ValueRef {
 pub fn ConstFCmp(Pred: RealPredicate, V1: ValueRef, V2: ValueRef) -> ValueRef {
     unsafe {
         llvm::LLVMConstFCmp(Pred as c_ushort, V1, V2)
+    }
+}
+
+pub fn SetFunctionAttribute(Fn: ValueRef, attr: Attribute) {
+    unsafe {
+        let attr = attr as u64;
+        let lower = attr & 0xffffffff;
+        let upper = (attr >> 32) & 0xffffffff;
+        llvm::LLVMAddFunctionAttr(Fn, lower as c_uint, upper as c_uint);
     }
 }
 /* Memory-managed object interface to type handles. */

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -412,46 +412,25 @@ pub fn get_tydesc(ccx: @CrateContext, t: ty::t) -> @mut tydesc_info {
 }
 
 pub fn set_optimize_for_size(f: ValueRef) {
-    unsafe {
-        llvm::LLVMAddFunctionAttr(f,
-                                  lib::llvm::OptimizeForSizeAttribute
-                                    as c_uint,
-                                  0);
-    }
+    lib::llvm::SetFunctionAttribute(f, lib::llvm::OptimizeForSizeAttribute)
 }
 
 pub fn set_no_inline(f: ValueRef) {
-    unsafe {
-        llvm::LLVMAddFunctionAttr(f,
-                                  lib::llvm::NoInlineAttribute as c_uint,
-                                  0);
-    }
+    lib::llvm::SetFunctionAttribute(f, lib::llvm::NoInlineAttribute)
 }
 
 pub fn set_no_unwind(f: ValueRef) {
-    unsafe {
-        llvm::LLVMAddFunctionAttr(f,
-                                  lib::llvm::NoUnwindAttribute as c_uint,
-                                  0);
-    }
+    lib::llvm::SetFunctionAttribute(f, lib::llvm::NoUnwindAttribute)
 }
 
 // Tell LLVM to emit the information necessary to unwind the stack for the
 // function f.
 pub fn set_uwtable(f: ValueRef) {
-    unsafe {
-        llvm::LLVMAddFunctionAttr(f,
-                                  lib::llvm::UWTableAttribute as c_uint,
-                                  0);
-    }
+    lib::llvm::SetFunctionAttribute(f, lib::llvm::UWTableAttribute)
 }
 
 pub fn set_inline_hint(f: ValueRef) {
-    unsafe {
-        llvm::LLVMAddFunctionAttr(f,
-                                  lib::llvm::InlineHintAttribute as c_uint,
-                                  0);
-    }
+    lib::llvm::SetFunctionAttribute(f, lib::llvm::InlineHintAttribute)
 }
 
 pub fn set_inline_hint_if_appr(attrs: &[ast::attribute],
@@ -465,17 +444,11 @@ pub fn set_inline_hint_if_appr(attrs: &[ast::attribute],
 }
 
 pub fn set_always_inline(f: ValueRef) {
-    unsafe {
-        llvm::LLVMAddFunctionAttr(f,
-                                  lib::llvm::AlwaysInlineAttribute as c_uint,
-                                  0);
-    }
+    lib::llvm::SetFunctionAttribute(f, lib::llvm::AlwaysInlineAttribute)
 }
 
 pub fn set_fixed_stack_segment(f: ValueRef) {
-    unsafe {
-        llvm::LLVMAddFunctionAttr(f, 0, 1 << (39 - 32));
-    }
+    lib::llvm::SetFunctionAttribute(f, lib::llvm::FixedStackSegment)
 }
 
 pub fn set_glue_inlining(f: ValueRef, t: ty::t) {

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -1119,6 +1119,6 @@ pub fn AtomicRMW(cx: block, op: AtomicBinOp,
                  dst: ValueRef, src: ValueRef,
                  order: AtomicOrdering) -> ValueRef {
     unsafe {
-        llvm::LLVMBuildAtomicRMW(B(cx), op, dst, src, order)
+        llvm::LLVMBuildAtomicRMW(B(cx), op, dst, src, order, lib::llvm::False)
     }
 }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -113,6 +113,7 @@ public:
 
   virtual uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
                                        unsigned SectionID, bool isReadOnly);
+  bool finalizeMemory(std::string *ErrMsg) { return false; }
 
   virtual bool applyPermissions(std::string *Str);
 
@@ -342,7 +343,6 @@ LLVMRustBuildJIT(void* mem,
 
   std::string Err;
   TargetOptions Options;
-  Options.JITExceptionHandling = true;
   Options.JITEmitDebugInfo = true;
   Options.NoFramePointerElim = true;
   Options.EnableSegmentedStacks = EnableSegmentedStacks;
@@ -526,15 +526,6 @@ extern "C" LLVMValueRef LLVMBuildAtomicCmpXchg(LLVMBuilderRef B,
                                                AtomicOrdering order) {
     return wrap(unwrap(B)->CreateAtomicCmpXchg(unwrap(target), unwrap(old),
                                                unwrap(source), order));
-}
-extern "C" LLVMValueRef LLVMBuildAtomicRMW(LLVMBuilderRef B,
-                                           AtomicRMWInst::BinOp op,
-                                           LLVMValueRef target,
-                                           LLVMValueRef source,
-                                           AtomicOrdering order) {
-    return wrap(unwrap(B)->CreateAtomicRMW(op,
-                                           unwrap(target), unwrap(source),
-                                           order));
 }
 
 extern "C" void LLVMSetDebug(int Enabled) {

--- a/src/rustllvm/rustllvm.h
+++ b/src/rustllvm/rustllvm.h
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Linker.h"
 #include "llvm/PassManager.h"
 #include "llvm/IR/InlineAsm.h"


### PR DESCRIPTION
This includes some of @brson's patches, plus one of mine. A multithreaded-llvm is necessary for running `rusti` tests in parallel, and in general is a good idea for running `rustc` in parallel.
