### PR TITLE
Define _RUST_STAGEN when building rustrt.

### DIFF
--- a/configure
+++ b/configure
@@ -665,12 +665,16 @@ make_dir rt
 for t in $CFG_TARGET_TRIPLES
 do
   make_dir rt/$t
-  for i in                                          \
-    isaac linenoise sync test \
-    arch/i386 arch/x86_64 arch/arm arch/mips  \
-    libuv libuv/src/ares libuv/src/eio libuv/src/ev
+  for s in 0 1 2 3
   do
-    make_dir rt/$t/$i
+    make_dir rt/$t/stage$s
+    for i in                                          \
+      isaac linenoise sync test \
+      arch/i386 arch/x86_64 arch/arm arch/mips  \
+      libuv libuv/src/ares libuv/src/eio libuv/src/ev
+    do
+      make_dir rt/$t/stage$s/$i
+    done
   done
 done
 

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -18,13 +18,13 @@
 define TARGET_STAGE_N
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/libmorestack.a: \
-		rt/$(2)/arch/$$(HOST_$(2))/libmorestack.a \
+		rt/$(2)/stage$(1)/arch/$$(HOST_$(2))/libmorestack.a \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_RUNTIME_$(2)): \
-		rt/$(2)/$(CFG_RUNTIME_$(2)) \
+		rt/$(2)/stage$(1)/$(CFG_RUNTIME_$(2)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@


### PR DESCRIPTION
As discussed with @brson on IRC:

This lets us use #ifdefs to determine which stage of the build we happen
to be in, which is useful in the event we need to make changes to rustrt
that are incompatible with the code generated by a stage0 rustc.

Example of the _RUST_STAGEN flag in action here: https://gist.github.com/thomaslee/5641890

I'm not sure what tests for this change should look like, so please advise if I need to do some work around that.
