### PR TITLE
Actually filter view_items in blocks

### DIFF
--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -136,8 +136,10 @@ fn fold_block(
 ) -> ast::blk_ {
     let filtered_stmts =
         b.stmts.filter_mapped(|a| filter_stmt(cx, *a));
+    let filtered_view_items =
+        b.view_items.filter_mapped(|a| filter_view_item(cx, *a));
     ast::blk_ {
-        view_items: /*bad*/copy b.view_items,
+        view_items: vec::map(filtered_view_items, |x| fld.fold_view_item(*x)),
         stmts: vec::map(filtered_stmts, |x| fld.fold_stmt(*x)),
         expr: b.expr.map(|x| fld.fold_expr(*x)),
         id: b.id,

--- a/src/test/run-pass/filter-block-view-items.rs
+++ b/src/test/run-pass/filter-block-view-items.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    // Make sure that this view item is filtered out because otherwise it would
+    // trigger a compilation error
+    #[cfg(not_present)] use foo = bar;
+}


### PR DESCRIPTION
Among other things, this suppresses a spurious unused import warning in the compiler right now.
