### PR TITLE
Add `as_c_str` method on strings

### DIFF
--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -45,7 +45,7 @@ pub use path::PosixPath;
 pub use path::WindowsPath;
 pub use ptr::Ptr;
 pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr};
-pub use str::{StrSlice, OwnedStr};
+pub use str::{StrSlice, OwnedStr, StrUtil};
 pub use from_str::{FromStr};
 pub use to_bytes::IterBytes;
 pub use to_str::{ToStr, ToStrConsume};


### PR DESCRIPTION
Formerly this was a free function rather than a method. I've left it in place for now, although redefined it so that it just calls the method.
