### PR TITLE
Un-ignore rusti/rustpkg tests on x86

### DIFF
--- a/mk/target.mk
+++ b/mk/target.mk
@@ -8,6 +8,11 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+# This is the compile-time target-triple for the compiler. For the compiler at
+# runtime, this should be considered the host-triple. More explanation for why
+# this exists can be found on issue #2400
+export CFG_COMPILER_TRIPLE
+
 # TARGET_STAGE_N template: This defines how target artifacts are built
 # for all stage/target architecture combinations. The arguments:
 # $(1) is the stage
@@ -62,6 +67,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_RUSTLLVM_$(3)): \
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
+$$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBRUSTC_$(3)): CFG_COMPILER_TRIPLE = $(2)
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBRUSTC_$(3)):		\
 		$$(COMPILER_CRATE) $$(COMPILER_INPUTS)		\
                 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBSYNTAX_$(3)) \

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -307,6 +307,7 @@ $(3)/stage$(1)/test/syntaxtest-$(2)$$(X_$(2)):			\
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
 
+$(3)/stage$(1)/test/rustctest-$(2)$$(X_$(2)): CFG_COMPILER_TRIPLE = $(2)
 $(3)/stage$(1)/test/rustctest-$(2)$$(X_$(2)):					\
 		$$(COMPILER_CRATE) $$(COMPILER_INPUTS) \
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_RUSTLLVM_$(2)) \

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -516,15 +516,15 @@ pub fn host_triple() -> ~str {
     // idea of the host triple is the same as for the set of libraries we've
     // actually built.  We can't just take LLVM's host triple because they
     // normalize all ix86 architectures to i386.
-
-    // FIXME (#2400): Instead of grabbing the host triple we really should
-    // be grabbing (at compile time) the target triple that this rustc is
-    // built with and calling that (at runtime) the host triple.
-    let ht = env!("CFG_BUILD_TRIPLE");
+    //
+    // Instead of grabbing the host triple (for the current host), we grab (at
+    // compile time) the target triple that this rustc is built with and
+    // calling that (at runtime) the host triple.
+    let ht = env!("CFG_COMPILER_TRIPLE");
     return if ht != ~"" {
             ht
         } else {
-            fail!("rustc built without CFG_BUILD_TRIPLE")
+            fail!("rustc built without CFG_COMPILER_TRIPLE")
         };
 }
 
@@ -534,15 +534,15 @@ pub fn host_triple() -> ~str {
     // idea of the host triple is the same as for the set of libraries we've
     // actually built.  We can't just take LLVM's host triple because they
     // normalize all ix86 architectures to i386.
-
-    // FIXME (#2400): Instead of grabbing the host triple we really should
-    // be grabbing (at compile time) the target triple that this rustc is
-    // built with and calling that (at runtime) the host triple.
-    let ht = env!("CFG_BUILD_TRIPLE");
+    //
+    // Instead of grabbing the host triple (for the current host), we grab (at
+    // compile time) the target triple that this rustc is built with and
+    // calling that (at runtime) the host triple.
+    let ht = env!("CFG_COMPILER_TRIPLE");
     return if ht != "" {
             ht.to_owned()
         } else {
-            fail!("rustc built without CFG_BUILD_TRIPLE")
+            fail!("rustc built without CFG_COMPILER_TRIPLE")
         };
 }
 

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -453,8 +453,9 @@ mod tests {
         }
     }
 
-    #[test] #[ignore]
+    #[test]
     fn run_all() {
+        // FIXME(#6511):
         // By default, unit tests are run in parallel. Rusti, on the other hand,
         // does not enjoy doing this. I suspect that it is because the LLVM
         // bindings are not thread-safe (when running parallel tests, some tests
@@ -467,7 +468,7 @@ mod tests {
         run_cmds([""]);
 
         debug!("regression test for #5937");
-        run_cmds(["use core;", ""]);
+        run_cmds(["use std;", ""]);
 
         debug!("regression test for #5784");
         run_cmds(["let a = 1;"]);

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -93,9 +93,7 @@ fn test_sysroot() -> Path {
     self_path.pop()
 }
 
-// Ignored on i686 -- see #6517
 #[test]
-#[ignore(cfg(target_arch = "x86"))]
 fn test_make_dir_rwx() {
     let temp = &os::tmpdir();
     let dir = temp.push(~"quux");
@@ -109,7 +107,6 @@ fn test_make_dir_rwx() {
 }
 
 #[test]
-#[ignore(cfg(target_arch = "x86"))]
 fn test_install_valid() {
     let sysroot = test_sysroot();
     debug!("sysroot = %s", sysroot.to_str());
@@ -135,7 +132,6 @@ fn test_install_valid() {
 }
 
 #[test]
-#[ignore(cfg(target_arch = "x86"))]
 fn test_install_invalid() {
     use conditions::nonexistent_package::cond;
     use cond1 = conditions::missing_pkg_files::cond;
@@ -158,7 +154,6 @@ fn test_install_invalid() {
 }
 
 #[test]
-#[ignore(cfg(target_arch = "x86"))]
 fn test_install_url() {
     let workspace = mkdtemp(&os::tmpdir(), "test").expect("couldn't create temp dir");
     let sysroot = test_sysroot();


### PR DESCRIPTION
Most of the relevant information can be found in the commit messages.

r? @brson - I just wanted to make sure the make changes aren't completely bogus

This would close #2400, #6517, and #6489 (although a run through incoming-full on linux would have to confirm the latter two)
