### PR TITLE
Basic support for dynamically loading syntax extensions

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -187,6 +187,7 @@ pub fn compile_rest(sess: Session,
 
     crate = time(time_passes, ~"expansion", ||
         syntax::ext::expand::expand_crate(sess.parse_sess, copy cfg,
+                                          sess.opts.dynamic_syntax_extensions,
                                           crate));
 
     crate = time(time_passes, ~"configuration", ||
@@ -652,6 +653,7 @@ pub fn build_session_options(binary: @~str,
     let debuginfo = debugging_opts & session::debug_info != 0 ||
         extra_debuginfo;
     let statik = debugging_opts & session::statik != 0;
+    let dynamic_syntax_extensions = debugging_opts & session::dynamic_syntax_extensions != 0;
     let target =
         match target_opt {
             None => host_triple(),
@@ -700,7 +702,8 @@ pub fn build_session_options(binary: @~str,
         parse_only: parse_only,
         no_trans: no_trans,
         debugging_opts: debugging_opts,
-        android_cross_path: android_cross_path
+        android_cross_path: android_cross_path,
+        dynamic_syntax_extensions: dynamic_syntax_extensions
     };
     return sopts;
 }

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -69,6 +69,7 @@ pub static extra_debug_info: uint = 1 << 21;
 pub static statik: uint = 1 << 22;
 pub static print_link_args: uint = 1 << 23;
 pub static no_debug_borrows: uint = 1 << 24;
+pub static dynamic_syntax_extensions: uint = 1 << 25;
 
 pub fn debugging_opts_map() -> ~[(~str, ~str, uint)] {
     ~[(~"verbose", ~"in general, enable more debug printouts", verbose),
@@ -107,6 +108,9 @@ pub fn debugging_opts_map() -> ~[(~str, ~str, uint)] {
      (~"no-debug-borrows",
       ~"do not show where borrow checks fail",
       no_debug_borrows),
+     (~"dynamic-syntax-extensions",
+      ~"allow loading of syntax extensions via #[syntax_extension] (experimental)",
+      dynamic_syntax_extensions)
     ]
 }
 
@@ -148,6 +152,8 @@ pub struct options {
     no_trans: bool,
     debugging_opts: uint,
     android_cross_path: Option<~str>,
+    // whether syntax extensions can be loaded
+    dynamic_syntax_extensions: bool
 }
 
 pub struct crate_metadata {
@@ -318,6 +324,7 @@ pub fn basic_options() -> @options {
         no_trans: false,
         debugging_opts: 0u,
         android_cross_path: None,
+        dynamic_syntax_extensions: false
     }
 }
 

--- a/src/librustdoc/astsrv.rs
+++ b/src/librustdoc/astsrv.rs
@@ -115,7 +115,9 @@ fn build_ctxt(sess: Session,
 
     let ast = config::strip_unconfigured_items(ast);
     let ast = syntax::ext::expand::expand_crate(sess.parse_sess,
-                                                copy sess.opts.cfg, ast);
+                                                copy sess.opts.cfg,
+                                                false, // no dynamic syntax extensions
+                                                ast);
     let ast = front::test::modify_for_testing(sess, ast);
     let ast_map = ast_map::map_crate(sess.diagnostic(), ast);
 

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -1,0 +1,196 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/*!
+
+Dynamic libraries.
+
+Highly experimental, no guarantees if it works with non-Rust
+libraries, or anything other than libraries compiled with the exact
+Rust compiler that the program using this was compiled with.
+
+*/
+
+use str;
+use io;
+use cast;
+use option::{None, Option};
+use result::{Ok, Err, Result};
+use libc::{c_int, c_void};
+use ops::Drop;
+use ptr::Ptr;
+
+mod raw {
+    use libc::{c_char, c_int, c_void};
+
+    #[cfg(target_os = "linux")]
+    #[cfg(target_os = "android")]
+    #[cfg(target_os = "macos")]
+    #[cfg(target_os = "freebsd")]
+    pub enum RTLD {
+        LAZY = 1,
+        NOW = 2,
+        GLOBAL = 256,
+        LOCAL = 0
+    }
+
+    #[cfg(target_os = "linux")]
+    #[cfg(target_os = "android")]
+    #[cfg(target_os = "macos")]
+    #[cfg(target_os = "freebsd")]
+    pub extern {
+        fn dlopen(name: *c_char, mode: c_int) -> *c_void;
+        fn dlsym(handle: *c_void, name: *c_char) -> *c_void;
+        fn dlerror() -> *c_char;
+        fn dlclose(handle: *c_void);
+    }
+
+    #[cfg(target_os = "win32")]
+    pub extern {
+        fn LoadLibrary(name: *c_char);
+        fn GetProcAddress(handle: *c_void, name: *c_char) -> *c_void;
+        fn FreeLibrary(handle: *c_void);
+    }
+}
+
+/// An object representing a dynamic library
+pub struct DynamicLib {
+    priv handle: *c_void
+}
+
+/// An object representing a symbol from a dynamic library. A
+/// work-around for either extern fns becoming &extern fn (so that
+/// they can have a lifetime), or #5922.
+pub struct TaggedSymbol<'self, T> {
+    priv sym: T,
+    priv lifetime: Option<&'self ()>
+}
+
+impl DynamicLib {
+    /// Open a dynamic library.
+    #[cfg(target_os = "linux")]
+    #[cfg(target_os = "android")]
+    #[cfg(target_os = "macos")]
+    #[cfg(target_os = "freebsd")]
+    pub fn open(name: &str) -> Result<DynamicLib, ~str> {
+        let handle = do str::as_c_str(name) |n| {
+            unsafe { raw::dlopen(n, raw::NOW as c_int | raw::GLOBAL as c_int) }
+        };
+        if handle.is_not_null() {
+            Ok(DynamicLib { handle: handle })
+        } else {
+            Err(
+                unsafe {
+                    let error = raw::dlerror();
+                    if error.is_not_null() {
+                        str::raw::from_c_str(error)
+                    } else {
+                        ~"unknown error"
+                    }
+                })
+        }
+    }
+    /// Open a dynamic library.
+    #[cfg(target_os = "win32")]
+    pub fn open(name: &str) -> Result<DynamicLib, ~str> {
+        let handle = do str::as_c_str(name) |n| {
+            unsafe { raw::LoadLibrary(n) }
+        };
+        if handle.is_not_null() {
+            Ok(DynamicLib { handle: handle })
+        } else {
+            let err = unsafe { intrinsics::GetLastError() } as uint;
+            // XXX: make this message nice
+            Err(fmt!("`LoadLibrary` failed with code %u", err))
+        }
+    }
+
+    /// Retrieve a pointer to a symbol from the library. Note: this
+    /// operation has no way of knowing if the symbol actually has
+    /// type `T`, and so using the returned value can crash the
+    /// program, not just cause the task to fail.
+    #[cfg(target_os = "linux")]
+    #[cfg(target_os = "android")]
+    #[cfg(target_os = "macos")]
+    #[cfg(target_os = "freebsd")]
+    pub fn get_symbol<'r, T>(&'r self, name: &str) -> Result<TaggedSymbol<'r, T>, ~str> {
+        let sym = do str::as_c_str(name) |n| {
+            raw::dlsym(self.handle, n)
+        };
+        if sym.is_not_null() {
+            Ok(TaggedSymbol {
+                sym: cast::transmute(sym),
+                lifetime: None::<&'r ()>
+            })
+        } else {
+            let error = raw::dlerror();
+            if error.is_not_null() {
+                Err(str::raw::from_c_str(error))
+            } else {
+                Err(~"unknown error")
+            }
+        }
+    }
+
+    /// Retrieve a pointer to a symbol from the library. Note: this
+    /// operation has no way of knowing if the symbol actually has
+    /// type `T`, and so using the returned value can crash the
+    /// program, not just cause the task to fail.
+    #[cfg(target_os = "win32")]
+    pub unsafe fn get_symbol<'r, T>(&'r self, name: &str) -> Result<TaggedSymbol<'r, T>, ~str> {
+        let sym = do str::as_c_str(name) |n| {
+            raw::GetProcAddress(self.handle, n)
+        };
+        if sym.is_not_null() {
+            Ok(TaggedSymbol { sym: cast::transmute(sym),
+                             lifetime: None::<&'r ()> })
+        } else {
+            let err = unsafe { intrinsics::GetLastError() } as uint;
+            Err(fmt!("`GetProcAddress` failed with code %u", err))
+        }
+    }
+}
+
+#[unsafe_destructor]
+impl Drop for DynamicLib {
+    #[cfg(target_os = "linux")]
+    #[cfg(target_os = "android")]
+    #[cfg(target_os = "macos")]
+    #[cfg(target_os = "freebsd")]
+    fn finalize(&self) {
+        io::println("Dropping library");
+        if self.handle.is_not_null() {
+            unsafe { raw::dlclose(self.handle) }
+        }
+    }
+
+    #[cfg(target_os = "win32")]
+    fn finalize(&self) {
+        io::println("Dropping library");
+        if self.handle.is_not_null() {
+            unsafe { raw::FreeLibrary(self.handle) }
+        }
+    }
+}
+
+impl<'self, T> TaggedSymbol<'self, T> {
+    /// Get a reference to the (reference to the) symbol.
+    ///
+    /// WARNING: Using the returned value can lead to crashes, since
+    /// the symbol may not really have type `T`.
+    ///
+    /// WARNING: Storing the derefence of this pointer can lead to
+    /// crashes, if the library the symbol comes from has been dropped
+    /// before using the stored symbol (the compiler doesn't give any
+    /// indication that this is a problem).
+    pub unsafe fn get<'r>(&'r self) -> &'r T {
+        &'r self.sym
+    }
+}

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -15,6 +15,7 @@ use comm::{GenericChan, GenericPort};
 use prelude::*;
 use task;
 
+pub mod dynamic_lib;
 pub mod at_exit;
 pub mod global;
 pub mod finally;

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -113,17 +113,17 @@ pub enum Transformer {
     ScopeMacros(bool)
 }
 
+// utility function to simplify creating NormalTT syntax extensions
+pub fn builtin_normal_tt(f: SyntaxExpanderTTFun) -> @Transformer {
+    @SE(NormalTT(SyntaxExpanderTT{expander: f, span: None}))
+}
+// utility function to simplify creating IdentTT syntax extensions
+pub fn builtin_item_tt(f: SyntaxExpanderTTItemFun) -> @Transformer {
+    @SE(IdentTT(SyntaxExpanderTTItem{expander: f, span: None}))
+}
 // The base map of methods for expanding syntax extension
 // AST nodes into full ASTs
 pub fn syntax_expander_table() -> SyntaxEnv {
-    // utility function to simplify creating NormalTT syntax extensions
-    fn builtin_normal_tt(f: SyntaxExpanderTTFun) -> @Transformer {
-        @SE(NormalTT(SyntaxExpanderTT{expander: f, span: None}))
-    }
-    // utility function to simplify creating IdentTT syntax extensions
-    fn builtin_item_tt(f: SyntaxExpanderTTItemFun) -> @Transformer {
-        @SE(IdentTT(SyntaxExpanderTTItem{expander: f, span: None}))
-    }
     let mut syntax_expanders = HashMap::new();
     // NB identifier starts with space, and can't conflict with legal idents
     syntax_expanders.insert(@~" block",

--- a/src/libsyntax/ext/dynamic.rs
+++ b/src/libsyntax/ext/dynamic.rs
@@ -1,0 +1,127 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/*!
+Dynamically loading syntax extensions.
+
+Implementation of the #[syntax_extension="filename"] attribute, that
+allows an external Rust library to provide custom syntax
+extensions. This library should define public function called
+`register_syntax_extensions` (with #[no_mangle], to preserve the
+name), with type `fn (@ExtCtxt) -> ~[(@~str, @Transformer)]` (both
+`ExtCtxt` and `Transformer` are defined in `ext::base`). This function
+returns a vector of the new syntax extensions and their names.
+
+The `#[syntax_extension]` attribute current only works at the crate
+level, is highly experimental and requires the `-Z
+dynamic-syntax-extensions` flag.
+
+# Example
+
+## `my_ext.rs`
+~~~
+extern mod syntax;
+use syntax::ast;
+use syntax::parse;
+use syntax::codemap::span;
+use syntax::ext::base::{ExtCtxt, builtin_normal_tt, MacResult, MRExpr, Transformer};
+use syntax::ext::build::AstBuilder;
+
+#[no_mangle]
+pub fn register_syntax_extensions(_cx: @ExtCtxt) -> ~[(@~str, @Transformer)] {
+    ~[(@~"my_macro", builtin_normal_tt(my_macro))]
+}
+
+fn my_macro(cx: @ExtCtxt, sp: span, _tts: &[ast::token_tree]) -> MacResult {
+    MRExpr(cx.expr_str(sp, ~"hello world"))
+}
+~~~
+
+## `main.rs`
+Compiled with `-Z dynamic-syntax-extensions`
+~~~
+#[syntax_extension="libmy_ext-<hash>-<version>.so"]
+
+fn main() {
+    println(my_macro!())
+}
+~~~
+
+The exact file name of the library is required, and it needs to either
+be in a directory that the library loader will search in (e.g. in
+`LD_LIBRARY_PATH`), or be specified as a file path.
+
+*/
+
+use core::prelude::*;
+use core::unstable::dynamic_lib::DynamicLib;
+use ast;
+use attr;
+use codemap::span;
+use ext::base::{ExtCtxt, SyntaxEnv, Transformer};
+
+static REGISTER_FN: &'static str = "register_syntax_extensions";
+type RegisterFnType = extern fn(@ExtCtxt) -> ~[(@~str, @Transformer)];
+
+// the return value needs to be stored until all expansion has
+// happened, otherwise syntax extensions will be calling into a
+// library that has been closed, causing segfaults
+pub fn load_dynamic_crate(cx: @ExtCtxt, table: @mut SyntaxEnv, c: @ast::crate, enabled: bool)
+    -> ~[DynamicLib] {
+    do vec::build |push| {
+        for attr::find_attrs_by_name(c.node.attrs, "syntax_extension").each |attr| {
+            if !enabled {
+                cx.span_fatal(attr.span,
+                              "#[syntax_extension] is experimental and disabled by \
+                               default; use `-Z dynamic-syntax-extensions` to enable");
+            }
+
+            match attr::get_meta_item_value_str(attr::attr_meta(*attr)) {
+                Some(value) => {
+                    match load_dynamic(cx, *value, table) {
+                        Ok(lib) => push(lib),
+                        Err(err) => {
+                            cx.span_err(attr.span,
+                                        fmt!("could not load syntax extensions from `%s`: %s",
+                                             *value, err));
+                        }
+                    }
+                }
+                None => { cx.span_err(attr.span, "Expecting `syntax_extension=\"filename\"`") }
+            }
+        }
+    }
+}
+
+fn load_dynamic(cx: @ExtCtxt, name: &str, table: @mut SyntaxEnv) -> Result<DynamicLib, ~str> {
+    match DynamicLib::open(name) {
+        Ok(lib) => {
+            let mut error = None;
+            { // borrow checker complains about lib & sym without this block
+                let sym = lib.get_symbol::<RegisterFnType>(REGISTER_FN);
+                match sym {
+                    Ok(func) => {
+                        // should need unsafe { } (#3080)
+                        let syn_exts = (*func.get())(cx);
+                        for syn_exts.each |&(name, transformer)| {
+                            table.insert(name, transformer);
+                        }
+                    }
+                    Err(err) => { error = Some(err); }
+                }
+            }
+            match error {
+                None => Ok(lib),
+                Some(err) => Err(err)
+            }
+        }
+        Err(err) => Err(err)
+    }
+}

--- a/src/libsyntax/syntax.rc
+++ b/src/libsyntax/syntax.rc
@@ -72,6 +72,7 @@ pub mod ext {
     pub mod asm;
     pub mod base;
     pub mod expand;
+    pub mod dynamic;
 
     pub mod quote;
 


### PR DESCRIPTION
This adds a wrapper around `dlopen`/`dlsym` etc to `std::unstable`, with some effort to get the lifetimes of the symbols from the library to be restricted to the lifetime of the dynamic library (it requires #5922 to work properly). (This lifetime stuff is helpful rather than a safety guarantee, since callbacks into the library can be saved out of view of the compiler (as happens in the syntax extension code).)

(I'm quite uncertain about this part, since I've only occasionally used these functions on Linux, and never on any other platform.)

It also adds a `#[syntax_extension="library"]` attribute which will load the library (requires the full filename), and call `register_syntax_extensions` to retrieve a vec of new syntax extensions which are added to the macros that are expanded.

See [ext/dynamic.rs](https://github.com/mozilla/rust/pull/6735/files#L6R12) for a more detailed description.

I'm only been able to test on x86-64 Linux and it doesn't break anything there, but I'm not really sure how to write tests for this.

(This is definitely not ready for general use (I've hidden it behind a `-Z dynamic-syntax-extensions` flag), but makes experimenting with/modifiying syntax extensions much easier, since they can be copied out of libsyntax for experimentation and then don't require a full rebuild.)
