### PR TITLE
Use an enum for keywords and intern them to improve parser performance

### DIFF
--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -16,6 +16,7 @@ use ext::base::ExtCtxt;
 use ext::base;
 use parse::lexer::{new_tt_reader, reader};
 use parse::parser::Parser;
+use parse::token::keywords;
 
 pub fn expand_trace_macros(cx: @ExtCtxt,
                            sp: span,
@@ -36,9 +37,9 @@ pub fn expand_trace_macros(cx: @ExtCtxt,
         rdr.dup()
     );
 
-    if rust_parser.is_keyword("true") {
+    if rust_parser.is_keyword(keywords::True) {
         cx.set_trace_macros(true);
-    } else if rust_parser.is_keyword("false") {
+    } else if rust_parser.is_keyword(keywords::False) {
         cx.set_trace_macros(false);
     } else {
         cx.span_fatal(sp, "trace_macros! only accepts `true` or `false`")

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -14,6 +14,7 @@ use ast;
 use codemap::{BytePos, spanned};
 use parse::lexer::reader;
 use parse::parser::Parser;
+use parse::token::keywords;
 use parse::token;
 
 use opt_vec;
@@ -133,54 +134,15 @@ pub impl Parser {
         return if *self.token == *tok { self.bump(); true } else { false };
     }
 
-    // Storing keywords as interned idents instead of strings would be nifty.
-
-    // A sanity check that the word we are asking for is a known keyword
-    // NOTE: this could be done statically....
-    fn require_keyword(&self, word: &str) {
-        if !self.keywords.contains_equiv(&word) {
-            self.bug(fmt!("unknown keyword: %s", word));
-        }
+    fn is_keyword(&self, kw: keywords::Keyword) -> bool {
+        token::is_keyword(kw, self.token)
     }
 
-    // return true when this token represents the given string, and is not
-    // followed immediately by :: .
-    fn token_is_word(&self, word: &str, tok: &token::Token) -> bool {
-        match *tok {
-            token::IDENT(sid, false) => { word == *self.id_to_str(sid) }
-             _ => { false }
-        }
-    }
-
-    fn token_is_keyword(&self, word: &str, tok: &token::Token) -> bool {
-        self.require_keyword(word);
-        self.token_is_word(word, tok)
-    }
-
-    fn is_keyword(&self, word: &str) -> bool {
-        self.token_is_keyword(word, &copy *self.token)
-    }
-
-    fn id_is_any_keyword(&self, id: ast::ident) -> bool {
-        self.keywords.contains(self.id_to_str(id))
-    }
-
-    fn is_any_keyword(&self, tok: &token::Token) -> bool {
-        match *tok {
-          token::IDENT(sid, false) => {
-            self.keywords.contains(self.id_to_str(sid))
-          }
-          _ => false
-        }
-    }
-
-    // if the given word is not a keyword, signal an error.
     // if the next token is the given keyword, eat it and return
     // true. Otherwise, return false.
-    fn eat_keyword(&self, word: &str) -> bool {
-        self.require_keyword(word);
+    fn eat_keyword(&self, kw: keywords::Keyword) -> bool {
         let is_kw = match *self.token {
-            token::IDENT(sid, false) => word == *self.id_to_str(sid),
+            token::IDENT(sid, false) => kw.to_ident().repr == sid.repr,
             _ => false
         };
         if is_kw { self.bump() }
@@ -190,63 +152,30 @@ pub impl Parser {
     // if the given word is not a keyword, signal an error.
     // if the next token is not the given word, signal an error.
     // otherwise, eat it.
-    fn expect_keyword(&self, word: &str) {
-        self.require_keyword(word);
-        if !self.eat_keyword(word) {
+    fn expect_keyword(&self, kw: keywords::Keyword) {
+        if !self.eat_keyword(kw) {
             self.fatal(
                 fmt!(
                     "expected `%s`, found `%s`",
-                    word,
+                    *self.id_to_str(kw.to_ident()),
                     self.this_token_to_str()
                 )
             );
         }
     }
 
-    // return true if the given string is a strict keyword
-    fn is_strict_keyword(&self, word: &str) -> bool {
-        self.strict_keywords.contains_equiv(&word)
-    }
-
-    // signal an error if the current token is a strict keyword
-    fn check_strict_keywords(&self) {
-        match *self.token {
-            token::IDENT(_, false) => {
-                let w = token_to_str(self.reader, &copy *self.token);
-                self.check_strict_keywords_(w);
-            }
-            _ => ()
-        }
-    }
-
     // signal an error if the given string is a strict keyword
-    fn check_strict_keywords_(&self, w: &str) {
-        if self.is_strict_keyword(w) {
+    fn check_strict_keywords(&self) {
+        if token::is_strict_keyword(self.token) {
             self.span_err(*self.last_span,
-                          fmt!("found `%s` in ident position", w));
+                          fmt!("found `%s` in ident position", self.this_token_to_str()));
         }
-    }
-
-    // return true if this is a reserved keyword
-    fn is_reserved_keyword(&self, word: &str) -> bool {
-        self.reserved_keywords.contains_equiv(&word)
     }
 
     // signal an error if the current token is a reserved keyword
     fn check_reserved_keywords(&self) {
-        match *self.token {
-            token::IDENT(_, false) => {
-                let w = token_to_str(self.reader, &copy *self.token);
-                self.check_reserved_keywords_(w);
-            }
-            _ => ()
-        }
-    }
-
-    // signal an error if the given string is a reserved keyword
-    fn check_reserved_keywords_(&self, w: &str) {
-        if self.is_reserved_keyword(w) {
-            self.fatal(fmt!("`%s` is a reserved keyword", w));
+        if token::is_reserved_keyword(self.token) {
+            self.fatal(fmt!("`%s` is a reserved keyword", self.this_token_to_str()));
         }
     }
 

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -23,7 +23,7 @@ use ast::{expr, expr_lit, lit_nil, attribute};
 use ast;
 use codemap::{span, respan};
 use parse::parser::Parser;
-use parse::token::Token;
+use parse::token::{keywords, Token};
 use parse::token;
 
 use core::to_bytes;
@@ -295,9 +295,9 @@ pub impl Parser {
     }
 
     fn try_parse_obsolete_priv_section(&self, attrs: &[attribute]) -> bool {
-        if self.is_keyword("priv") && self.look_ahead(1) == token::LBRACE {
+        if self.is_keyword(keywords::Priv) && self.look_ahead(1) == token::LBRACE {
             self.obsolete(copy *self.span, ObsoletePrivSection);
-            self.eat_keyword("priv");
+            self.eat_keyword(keywords::Priv);
             self.bump();
             while *self.token != token::RBRACE {
                 self.parse_single_struct_field(ast::private, attrs.to_owned());

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -17,7 +17,6 @@ use util::interner::StrInterner;
 use util::interner;
 
 use core::cmp::Equiv;
-use core::hashmap::HashSet;
 use core::to_bytes;
 
 #[deriving(Encodable, Decodable, Eq)]
@@ -452,6 +451,45 @@ fn mk_fresh_ident_interner() -> @ident_interner {
         "__field__",          // 32
         "C",                  // 33
         "Self",               // 34
+
+        "as",                 // 35
+        "break",              // 36
+        "const",              // 37
+        "copy",               // 38
+        "do",                 // 39
+        "drop",               // 40
+        "else",               // 41
+        "enum",               // 42
+        "extern",             // 43
+        "false",              // 44
+        "fn",                 // 45
+        "for",                // 46
+        "if",                 // 47
+        "impl",               // 48
+        "let",                // 49
+        "__log",              // 50
+        "loop",               // 51
+        "match",              // 52
+        "mod",                // 53
+        "mut",                // 54
+        "once",               // 55
+        "priv",               // 56
+        "pub",                // 57
+        "pure",               // 58
+        "ref",                // 59
+        "return",             // 60
+        "static",             // 29 -- also a special ident
+        "self",               //  8 -- also a special ident
+        "struct",             // 61
+        "super",              // 62
+        "true",               // 63
+        "trait",              // 64
+        "type",               // 65
+        "unsafe",             // 66
+        "use",                // 67
+        "while",              // 68
+
+        "be",                 // 69
     ];
 
     @ident_interner {
@@ -495,61 +533,134 @@ pub fn intern(str : &str) -> ast::ident {
 /**
  * All the valid words that have meaning in the Rust language.
  *
- * Rust keywords are either 'temporary', 'strict' or 'reserved'.  Temporary
- * keywords are contextual and may be used as identifiers anywhere.  They are
- * expected to disappear from the grammar soon.  Strict keywords may not
+ * Rust keywords are either 'strict' or 'reserved'.  Strict keywords may not
  * appear as identifiers at all. Reserved keywords are not used anywhere in
  * the language and may not appear as identifiers.
  */
-pub fn keyword_table() -> HashSet<~str> {
-    let mut keywords = HashSet::new();
-    let mut strict = strict_keyword_table();
-    let mut reserved = reserved_keyword_table();
+pub mod keywords {
+    use ast::ident;
 
-    do strict.consume |word| {
-        keywords.insert(word);
-    }
-    do reserved.consume |word| {
-        keywords.insert(word);
+    pub enum Keyword {
+        // Strict keywords
+        As,
+        Break,
+        Const,
+        Copy,
+        Do,
+        Drop,
+        Else,
+        Enum,
+        Extern,
+        False,
+        Fn,
+        For,
+        If,
+        Impl,
+        Let,
+        __Log,
+        Loop,
+        Match,
+        Mod,
+        Mut,
+        Once,
+        Priv,
+        Pub,
+        Pure,
+        Ref,
+        Return,
+        Static,
+        Self,
+        Struct,
+        Super,
+        True,
+        Trait,
+        Type,
+        Unsafe,
+        Use,
+        While,
+
+        // Reserved keywords
+        Be,
     }
 
-    keywords
+    pub impl Keyword {
+        fn to_ident(&self) -> ident {
+            match *self {
+                As => ident { repr: 35, ctxt: 0 },
+                   Break => ident { repr: 36, ctxt: 0 },
+                   Const => ident { repr: 37, ctxt: 0 },
+                   Copy => ident { repr: 38, ctxt: 0 },
+                   Do => ident { repr: 39, ctxt: 0 },
+                   Drop => ident { repr: 40, ctxt: 0 },
+                   Else => ident { repr: 41, ctxt: 0 },
+                   Enum => ident { repr: 42, ctxt: 0 },
+                   Extern => ident { repr: 43, ctxt: 0 },
+                   False => ident { repr: 44, ctxt: 0 },
+                   Fn => ident { repr: 45, ctxt: 0 },
+                   For => ident { repr: 46, ctxt: 0 },
+                   If => ident { repr: 47, ctxt: 0 },
+                   Impl => ident { repr: 48, ctxt: 0 },
+                   Let => ident { repr: 49, ctxt: 0 },
+                   __Log => ident { repr: 50, ctxt: 0 },
+                   Loop => ident { repr: 51, ctxt: 0 },
+                   Match => ident { repr: 52, ctxt: 0 },
+                   Mod => ident { repr: 53, ctxt: 0 },
+                   Mut => ident { repr: 54, ctxt: 0 },
+                   Once => ident { repr: 55, ctxt: 0 },
+                   Priv => ident { repr: 56, ctxt: 0 },
+                   Pub => ident { repr: 57, ctxt: 0 },
+                   Pure => ident { repr: 58, ctxt: 0 },
+                   Ref => ident { repr: 59, ctxt: 0 },
+                   Return => ident { repr: 60, ctxt: 0 },
+                   Static => ident { repr: 29, ctxt: 0 },
+                   Self => ident { repr: 8, ctxt: 0 },
+                   Struct => ident { repr: 61, ctxt: 0 },
+                   Super => ident { repr: 62, ctxt: 0 },
+                   True => ident { repr: 63, ctxt: 0 },
+                   Trait => ident { repr: 64, ctxt: 0 },
+                   Type => ident { repr: 65, ctxt: 0 },
+                   Unsafe => ident { repr: 66, ctxt: 0 },
+                   Use => ident { repr: 67, ctxt: 0 },
+                   While => ident { repr: 68, ctxt: 0 },
+                   Be => ident { repr: 69, ctxt: 0 },
+            }
+        }
+    }
 }
 
-/// Full keywords. May not appear anywhere else.
-pub fn strict_keyword_table() -> HashSet<~str> {
-    let mut words = HashSet::new();
-    let keys = ~[
-        ~"as",
-        ~"break",
-        ~"const", ~"copy",
-        ~"do", ~"drop",
-        ~"else", ~"enum", ~"extern",
-        ~"false", ~"fn", ~"for",
-        ~"if", ~"impl",
-        ~"let", ~"__log", ~"loop",
-        ~"match", ~"mod", ~"mut",
-        ~"once",
-        ~"priv", ~"pub", ~"pure",
-        ~"ref", ~"return",
-        ~"static", ~"self", ~"struct", ~"super",
-        ~"true", ~"trait", ~"type",
-        ~"unsafe", ~"use",
-        ~"while"
-    ];
-    do vec::consume(keys) |_, w| {
-        words.insert(w);
+pub fn is_keyword(kw: keywords::Keyword, tok: &Token) -> bool {
+    match *tok {
+        token::IDENT(sid, false) => { kw.to_ident().repr == sid.repr }
+        _ => { false }
     }
-    return words;
 }
 
-pub fn reserved_keyword_table() -> HashSet<~str> {
-    let mut words = HashSet::new();
-    let keys = ~[
-        ~"be"
-    ];
-    do vec::consume(keys) |_, s| {
-        words.insert(s);
+pub fn is_any_keyword(tok: &Token) -> bool {
+    match *tok {
+        token::IDENT(sid, false) => match sid.repr {
+            8 | 29 | 35 .. 69 => true,
+            _ => false,
+        },
+        _ => false
     }
-    return words;
+}
+
+pub fn is_strict_keyword(tok: &Token) -> bool {
+    match *tok {
+        token::IDENT(sid, false) => match sid.repr {
+            8 | 29 | 35 .. 68 => true,
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+pub fn is_reserved_keyword(tok: &Token) -> bool {
+    match *tok {
+        token::IDENT(sid, false) => match sid.repr {
+            69 => true,
+            _ => false,
+        },
+        _ => false,
+    }
 }


### PR DESCRIPTION
Currently, keywords are stored in hashsets that are recreated for every
Parser instance, which is quite expensive since macro expansion creates
lots of them. Additionally, the parser functions that look for a keyword
currently accept a string and have a runtime check to validate that they
actually received a keyword.

By creating an enum for the keywords and inserting them into the
ident interner, we can avoid the creation of the hashsets and get static
checks for the keywords.

For libstd, this cuts the parse+expansion part from ~2.6s to ~1.6s.
