### PR TITLE
mark unique pointer parameters as noalias

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1704,6 +1704,9 @@ pub fn create_llargs_for_fn_args(cx: fn_ctxt,
                         llvm::LLVMAddAttribute(llarg, lib::llvm::NoAliasAttribute as c_uint);
                     }
                 }
+                ast::ty_uniq(_) => {
+                    llvm::LLVMAddAttribute(llarg, lib::llvm::NoAliasAttribute as c_uint);
+                }
                 _ => {}
             }
 


### PR DESCRIPTION
The compiler guarantees that there are no other references to a unique pointer when it's passed by-value to a function.

The existence of the header and annihilator don't matter since it's not relevant to the call:

> For a call to the parent function, dependencies between memory references from before or after the call and from those during the call are “irrelevant” to the noalias keyword for the arguments and return value used in that call.

@graydon's tracing garbage collector stores the metadata outside of the boxes, so that won't be a problem. I'm unsure if updating the header while inside a function where it's marked as `noalias` would be a problem anyway since you never actually read or write to the header.

@nikomatsakis: r?
