### PR TITLE
rustdoc: insert blank lines between consecutive doc comment blocks

### DIFF
--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -22,6 +22,15 @@ use parse::comments::{doc_comment_style, strip_doc_comment_decoration};
 use core::hashmap::HashSet;
 use extra;
 
+pub enum doc_style {
+    doc_block_outer,
+    doc_block_inner,
+    doc_line_outer,
+    doc_line_inner,
+    doc_attr_outer,
+    doc_attr_inner,
+}
+
 /* Constructors */
 
 pub fn mk_name_value_item_str(name: @~str, value: @~str)
@@ -73,14 +82,18 @@ pub fn attr_metas(attrs: &[ast::attribute]) -> ~[@ast::meta_item] {
     do attrs.map |a| { attr_meta(*a) }
 }
 
-pub fn desugar_doc_attr(attr: &ast::attribute) -> ast::attribute {
+pub fn desugar_doc_attr(attr: &ast::attribute) -> (ast::attribute, doc_style) {
     if attr.node.is_sugared_doc {
         let comment = get_meta_item_value_str(attr.node.value).get();
-        let meta = mk_name_value_item_str(@~"doc",
-                                     @strip_doc_comment_decoration(*comment));
-        mk_attr(meta)
+        let (content, style) = strip_doc_comment_decoration(*comment);
+        let meta = mk_name_value_item_str(@~"doc", @content);
+        (mk_attr(meta), style)
     } else {
-        *attr
+        let style = match attr.node.style {
+            ast::attr_inner => doc_attr_inner,
+            ast::attr_outer => doc_attr_outer,
+        };
+        (*attr, style)
     }
 }
 

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -11,6 +11,7 @@
 use core::prelude::*;
 
 use ast;
+use attr;
 use codemap::{BytePos, CharPos, CodeMap, Pos};
 use diagnostic;
 use parse::lexer::{is_whitespace, get_str_from, reader};
@@ -50,7 +51,7 @@ pub fn doc_comment_style(comment: &str) -> ast::attr_style {
     }
 }
 
-pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
+pub fn strip_doc_comment_decoration(comment: &str) -> (~str, attr::doc_style) {
 
     /// remove whitespace-only lines from the start/end of lines
     fn vertical_trim(lines: ~[~str]) -> ~[~str] {
@@ -94,10 +95,18 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         };
     }
 
+    assert!(comment.len() >= 3);
+
     if comment.starts_with("//") {
+        let style = if comment.char_at(2) == '!' {
+            attr::doc_line_inner
+        } else {
+            attr::doc_line_outer
+        };
         // FIXME #5475:
-        // return comment.slice(3u, comment.len()).trim().to_owned();
-        let r = comment.slice(3u, comment.len()); return r.trim().to_owned();
+        // return (comment.slice(3u, comment.len()).trim().to_owned(), style);
+        let r = comment.slice(3u, comment.len());
+        return (r.trim().to_owned(), style);
 
     }
 
@@ -110,7 +119,12 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         let lines = block_trim(lines, ~"\t ", None);
         let lines = block_trim(lines, ~"*", Some(1u));
         let lines = block_trim(lines, ~"\t ", None);
-        return str::connect(lines, "\n");
+        let style = if comment.char_at(2) == '!' {
+            attr::doc_block_inner
+        } else {
+            attr::doc_block_outer
+        };
+        return (str::connect(lines, "\n"), style);
     }
 
     fail!("not a doc-comment: %s", comment);


### PR DESCRIPTION
This is to prevent, for example,

```
/**
 * foo
 */

/// bar

mod m {
  //! baz
}
```

from being rendered into a single paragraph "foo bar baz" in the html.
