### PR TITLE
syntax highlight code examples in docstrings

### DIFF
--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -17,7 +17,7 @@
  * In this example, a large vector of floats is shared between several tasks.
  * With simple pipes, without ARC, a copy would have to be made for each task.
  *
- * ~~~
+ * ~~~ {.rust}
  * extern mod std;
  * use std::arc;
  * let numbers=vec::from_fn(100, |ind| (ind as float)*rand::random());
@@ -370,7 +370,10 @@ pub impl<T:Const + Owned> RWARC<T> {
      * See sync::rwlock.write_downgrade(). The RWWriteMode token must be used
      * to obtain the &mut T, and can be transformed into a RWReadMode token by
      * calling downgrade(), after which a &T can be obtained instead.
-     * ~~~
+     *
+     * # Example
+     *
+     * ~~~ {.rust}
      * do arc.write_downgrade |write_mode| {
      *     do (&write_mode).write_cond |state, condvar| {
      *         ... exclusive access with mutable state ...

--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -28,9 +28,9 @@ impl<'self> ToBase64 for &'self [u8] {
     /**
      * Turn a vector of `u8` bytes into a base64 string.
      *
-     * *Example*:
+     * # Example
      *
-     * ~~~~
+     * ~~~ {.rust}
      * extern mod std;
      * use std::base64::ToBase64;
      *
@@ -38,7 +38,7 @@ impl<'self> ToBase64 for &'self [u8] {
      *     let str = [52,32].to_base64();
      *     println(fmt!("%s", str));
      * }
-     * ~~~~
+     * ~~~
      */
     fn to_base64(&self) -> ~str {
         let mut s = ~"";
@@ -91,9 +91,9 @@ impl<'self> ToBase64 for &'self str {
      * Convert any string (literal, `@`, `&`, or `~`) to base64 encoding.
      *
      *
-     * *Example*:
+     * # Example
      *
-     * ~~~~
+     * ~~~ {.rust}
      * extern mod std;
      * use std::base64::ToBase64;
      *
@@ -101,7 +101,7 @@ impl<'self> ToBase64 for &'self str {
      *     let str = "Hello, World".to_base64();
      *     println(fmt!("%s",str));
      * }
-     * ~~~~
+     * ~~~
      *
      */
     fn to_base64(&self) -> ~str {
@@ -118,9 +118,9 @@ impl FromBase64 for ~[u8] {
      * Convert base64 `u8` vector into u8 byte values.
      * Every 4 encoded characters is converted into 3 octets, modulo padding.
      *
-     * *Example*:
+     * # Example
      *
-     * ~~~~
+     * ~~~ {.rust}
      * extern mod std;
      * use std::base64::ToBase64;
      * use std::base64::FromBase64;
@@ -131,7 +131,7 @@ impl FromBase64 for ~[u8] {
      *     let bytes = str.from_base64();
      *     println(fmt!("%?",bytes));
      * }
-     * ~~~~
+     * ~~~
      */
     fn from_base64(&self) -> ~[u8] {
         if self.len() % 4u != 0u { fail!("invalid base64 length"); }
@@ -196,11 +196,11 @@ impl FromBase64 for ~str {
      * You can use the `from_bytes` function in `core::str`
      * to turn a `[u8]` into a string with characters corresponding to those values.
      *
-     * *Example*:
+     * # Example
      *
      * This converts a string literal to base64 and back.
      *
-     * ~~~~
+     * ~~~ {.rust}
      * extern mod std;
      * use std::base64::ToBase64;
      * use std::base64::FromBase64;
@@ -214,7 +214,7 @@ impl FromBase64 for ~str {
      *     let result_str = str::from_bytes(bytes);
      *     println(fmt!("%s",result_str));
      * }
-     * ~~~~
+     * ~~~
      */
     fn from_base64(&self) -> ~[u8] {
         str::to_bytes(*self).from_base64()

--- a/src/libextra/flatpipes.rs
+++ b/src/libextra/flatpipes.rs
@@ -25,7 +25,7 @@ ports and channels.
 
 This example sends boxed integers across tasks using serialization.
 
-~~~
+~~~ {.rust}
 let (port, chan) = serial::pipe_stream();
 
 do task::spawn || {

--- a/src/libextra/future.rs
+++ b/src/libextra/future.rs
@@ -14,7 +14,7 @@
  *
  * # Example
  *
- * ~~~
+ * ~~~ {.rust}
  * # fn fib(n: uint) -> uint {42};
  * # fn make_a_sandwich() {};
  * let mut delayed_fib = std::future::spawn (|| fib(5000) );

--- a/src/libextra/net_tcp.rs
+++ b/src/libextra/net_tcp.rs
@@ -466,7 +466,7 @@ fn read_future(sock: &TcpSocket, timeout_msecs: uint)
  * Here, the `new_conn` is used in conjunction with `accept` from within
  * a task spawned by the `new_connect_cb` passed into `listen`
  *
- * ~~~~~~~~~~~
+ * ~~~ {.rust}
  * do net::tcp::listen(remote_ip, remote_port, backlog, iotask,
  *     // this callback is ran once after the connection is successfully
  *     // set up
@@ -497,7 +497,7 @@ fn read_future(sock: &TcpSocket, timeout_msecs: uint)
  *       None => ()
  *     }
  * };
- * ~~~~~~~~~~~
+ * ~~~
  *
  * # Arguments
  *

--- a/src/libextra/sync.rs
+++ b/src/libextra/sync.rs
@@ -545,7 +545,10 @@ pub impl RWlock {
      * the meantime (such as unlocking and then re-locking as a reader would
      * do). The block takes a "write mode token" argument, which can be
      * transformed into a "read mode token" by calling downgrade(). Example:
-     * ~~~
+     *
+     * # Example
+     *
+     * ~~~ {.rust}
      * do lock.write_downgrade |write_mode| {
      *     do (&write_mode).write_cond |condvar| {
      *         ... exclusive access ...

--- a/src/libstd/bool.rs
+++ b/src/libstd/bool.rs
@@ -43,10 +43,13 @@ use from_str::FromStr;
 * Negation of a boolean value.
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::not(true)
 * false
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::not(false)
 * true
 * ~~~
@@ -57,10 +60,13 @@ pub fn not(v: bool) -> bool { !v }
 * Conjunction of two boolean values.
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::and(true, false)
 * false
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::and(true, true)
 * true
 * ~~~
@@ -71,10 +77,13 @@ pub fn and(a: bool, b: bool) -> bool { a && b }
 * Disjunction of two boolean values.
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::or(true, false)
 * true
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::or(false, false)
 * false
 * ~~~
@@ -87,10 +96,13 @@ pub fn or(a: bool, b: bool) -> bool { a || b }
 * 'exclusive or' is identical to `or(and(a, not(b)), and(not(a), b))`.
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::xor(true, false)
 * true
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::xor(true, true)
 * false
 * ~~~
@@ -105,10 +117,12 @@ pub fn xor(a: bool, b: bool) -> bool { (a && !b) || (!a && b) }
 * 'if a then b' is equivalent to `!a || b`.
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::implies(true, true)
 * true
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::implies(true, false)
 * false
 * ~~~
@@ -121,10 +135,13 @@ pub fn implies(a: bool, b: bool) -> bool { !a || b }
 * Two booleans are equal if they have the same value.
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::eq(false, true)
 * false
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::eq(false, false)
 * true
 * ~~~
@@ -137,10 +154,13 @@ pub fn eq(a: bool, b: bool) -> bool { a == b }
 * Two booleans are not equal if they have different values.
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::ne(false, true)
 * true
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::ne(false, false)
 * false
 * ~~~
@@ -151,10 +171,13 @@ pub fn ne(a: bool, b: bool) -> bool { a != b }
 * Is a given boolean value true?
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::is_true(true)
 * true
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::is_true(false)
 * false
 * ~~~
@@ -165,10 +188,13 @@ pub fn is_true(v: bool) -> bool { v }
 * Is a given boolean value false?
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::is_false(false)
 * true
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::is_false(true)
 * false
 * ~~~
@@ -181,13 +207,18 @@ pub fn is_false(v: bool) -> bool { !v }
 * Yields an `Option<bool>`, because `str` may or may not actually be parseable.
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> FromStr::from_str::<bool>("true")
 * Some(true)
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> FromStr::from_str::<bool>("false")
 * Some(false)
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> FromStr::from_str::<bool>("not even a boolean")
 * None
 * ~~~
@@ -206,10 +237,13 @@ impl FromStr for bool {
 * Convert a `bool` to a `str`.
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::to_str(true)
 * "true"
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::to_str(false)
 * "false"
 * ~~~
@@ -237,10 +271,13 @@ pub fn all_values(blk: &fn(v: bool)) {
 * Convert a `bool` to a `u8`.
 *
 * # Examples
-* ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::to_bit(true)
 * 1
 * ~~~
+*
+* ~~~ {.rust}
 * rusti> std::bool::to_bit(false)
 * 0
 * ~~~

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -1009,8 +1009,9 @@ pub fn FILE_reader(f: *libc::FILE, cleanup: bool) -> @Reader {
 /**
 * Gives a `Reader` that allows you to read values from standard input.
 *
-* # Examples
-* ~~~
+* # Example
+*
+* ~~~ {.rust}
 * let stdin = core::io::stdin();
 * let line = stdin.read_line();
 * core::io::print(line);
@@ -1572,8 +1573,9 @@ pub fn buffered_file_writer(path: &Path) -> Result<@Writer, ~str> {
 /**
 * Gives a `Writer` which allows you to write to the standard output.
 *
-* # Examples
-* ~~~
+* # Example
+*
+* ~~~ {.rust}
 * let stdout = core::io::stdout();
 * stdout.write_str("hello\n");
 * ~~~
@@ -1583,8 +1585,9 @@ pub fn stdout() -> @Writer { fd_writer(libc::STDOUT_FILENO as c_int, false) }
 /**
 * Gives a `Writer` which allows you to write to standard error.
 *
-* # Examples
-* ~~~
+* # Example
+*
+* ~~~ {.rust}
 * let stderr = core::io::stderr();
 * stderr.write_str("hello\n");
 * ~~~
@@ -1597,8 +1600,9 @@ pub fn stderr() -> @Writer { fd_writer(libc::STDERR_FILENO as c_int, false) }
 * This string will not have an implicit newline at the end. If you want
 * an implicit newline, please see `println`.
 *
-* # Examples
-* ~~~
+* # Example
+*
+* ~~~ {.rust}
 * // print is imported into the prelude, and so is always available.
 * print("hello");
 * ~~~
@@ -1612,8 +1616,9 @@ pub fn print(s: &str) {
 *
 * If you do not want an implicit newline, please see `print`.
 *
-* # Examples
-* ~~~
+* # Example
+*
+* ~~~ {.rust}
 * // println is imported into the prelude, and so is always available.
 * println("hello");
 * ~~~

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -16,14 +16,14 @@ An internal iterator takes `fn(...) -> bool` as a parameter, with returning `fal
 breaking out of iteration. The adaptors in the module work with any such iterator, not just ones
 tied to specific traits. For example:
 
-~~~~
+~~~ {.rust}
 println(iter::to_vec(|f| uint::range(0, 20, f)).to_str());
-~~~~
+~~~
 
 An external iterator object implementing the interface in the `iterator` module can be used as an
 internal iterator by calling the `advance` method. For example:
 
-~~~~
+~~~ {.rust}
 use core::iterator::*;
 
 let xs = [0u, 1, 2, 3, 4, 5];
@@ -32,7 +32,7 @@ let mut it = xs.iter().chain(ys.iter());
 for it.advance |&x: &uint| {
     println(x.to_str());
 }
-~~~~
+~~~
 
 Internal iterators provide a subset of the functionality of an external iterator. It's not possible
 to interleave them to implement algorithms like `zip`, `union` and `merge`. However, they're often
@@ -55,7 +55,7 @@ pub trait Times {
  *
  * # Example:
  *
- * ~~~
+ * ~~~ {.rust}
  * let xs = ~[1, 2, 3];
  * let ys = do iter::to_vec |f| { xs.each(|x| f(*x)) };
  * assert_eq!(xs, ys);
@@ -73,11 +73,11 @@ pub fn to_vec<T>(iter: &fn(f: &fn(T) -> bool) -> bool) -> ~[T] {
  *
  * Example:
  *
- * ~~~~
+ * ~~~ {.rust}
  * let xs = ~[1u, 2, 3, 4, 5];
  * assert!(any(|&x: &uint| x > 2, |f| xs.each(f)));
  * assert!(!any(|&x: &uint| x > 5, |f| xs.each(f)));
- * ~~~~
+ * ~~~
  */
 #[inline(always)]
 pub fn any<T>(predicate: &fn(T) -> bool,
@@ -95,10 +95,10 @@ pub fn any<T>(predicate: &fn(T) -> bool,
  *
  * # Example:
  *
- * ~~~~
+ * ~~~ {.rust}
  * assert!(all(|&x: &uint| x < 6, |f| uint::range(1, 6, f)));
  * assert!(!all(|&x: &uint| x < 5, |f| uint::range(1, 6, f)));
- * ~~~~
+ * ~~~
  */
 #[inline(always)]
 pub fn all<T>(predicate: &fn(T) -> bool,
@@ -113,10 +113,10 @@ pub fn all<T>(predicate: &fn(T) -> bool,
  *
  * # Example:
  *
- * ~~~~
+ * ~~~ {.rust}
  * let xs = ~[1u, 2, 3, 4, 5, 6];
  * assert_eq!(*find(|& &x: & &uint| x > 3, |f| xs.each(f)).unwrap(), 4);
- * ~~~~
+ * ~~~
  */
 #[inline(always)]
 pub fn find<T>(predicate: &fn(&T) -> bool,
@@ -134,10 +134,10 @@ pub fn find<T>(predicate: &fn(&T) -> bool,
  *
  * # Example:
  *
- * ~~~~
+ * ~~~ {.rust}
  * let xs = ~[8, 2, 3, 1, -5, 9, 11, 15];
  * assert_eq!(max(|f| xs.each(f)).unwrap(), &15);
- * ~~~~
+ * ~~~
  */
 #[inline]
 pub fn max<T: Ord>(iter: &fn(f: &fn(T) -> bool) -> bool) -> Option<T> {
@@ -160,10 +160,10 @@ pub fn max<T: Ord>(iter: &fn(f: &fn(T) -> bool) -> bool) -> Option<T> {
  *
  * # Example:
  *
- * ~~~~
+ * ~~~ {.rust}
  * let xs = ~[8, 2, 3, 1, -5, 9, 11, 15];
  * assert_eq!(max(|f| xs.each(f)).unwrap(), &-5);
- * ~~~~
+ * ~~~
  */
 #[inline]
 pub fn min<T: Ord>(iter: &fn(f: &fn(T) -> bool) -> bool) -> Option<T> {
@@ -186,9 +186,9 @@ pub fn min<T: Ord>(iter: &fn(f: &fn(T) -> bool) -> bool) -> Option<T> {
  *
  * # Example:
  *
- * ~~~~
+ * ~~~ {.rust}
  * assert_eq!(fold(0i, |f| int::range(1, 5, f), |a, x| *a += x), 10);
- * ~~~~
+ * ~~~
  */
 #[inline]
 pub fn fold<T, U>(start: T, iter: &fn(f: &fn(U) -> bool) -> bool, f: &fn(&mut T, U)) -> T {
@@ -207,11 +207,11 @@ pub fn fold<T, U>(start: T, iter: &fn(f: &fn(U) -> bool) -> bool, f: &fn(&mut T,
  *
  * # Example:
  *
- * ~~~~
+ * ~~~ {.rust}
  * fn product<T: One + Mul<T, T>>(iter: &fn(f: &fn(&T) -> bool) -> bool) -> T {
  *     fold_ref(One::one::<T>(), iter, |a, x| *a = a.mul(x))
  * }
- * ~~~~
+ * ~~~
  */
 #[inline]
 pub fn fold_ref<T, U>(start: T, iter: &fn(f: &fn(&U) -> bool) -> bool, f: &fn(&mut T, &U)) -> T {
@@ -227,10 +227,10 @@ pub fn fold_ref<T, U>(start: T, iter: &fn(f: &fn(&U) -> bool) -> bool, f: &fn(&m
  *
  * # Example:
  *
- * ~~~~
+ * ~~~ {.rust}
  * let xs: ~[int] = ~[1, 2, 3, 4];
  * assert_eq!(do sum |f| { xs.each(f) }, 10);
- * ~~~~
+ * ~~~
  */
 #[inline(always)]
 pub fn sum<T: Zero + Add<T, T>>(iter: &fn(f: &fn(&T) -> bool) -> bool) -> T {
@@ -242,10 +242,10 @@ pub fn sum<T: Zero + Add<T, T>>(iter: &fn(f: &fn(&T) -> bool) -> bool) -> T {
  *
  * # Example:
  *
- * ~~~~
+ * ~~~ {.rust}
  * let xs: ~[int] = ~[1, 2, 3, 4];
  * assert_eq!(do product |f| { xs.each(f) }, 24);
- * ~~~~
+ * ~~~
  */
 #[inline(always)]
 pub fn product<T: One + Mul<T, T>>(iter: &fn(f: &fn(&T) -> bool) -> bool) -> T {

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -364,7 +364,7 @@ impl Round for f32 {
     ///
     /// The fractional part of the number, satisfying:
     ///
-    /// ~~~
+    /// ~~~ {.rust}
     /// assert!(x == trunc(x) + fract(x))
     /// ~~~
     ///

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -376,7 +376,7 @@ impl Round for f64 {
     ///
     /// The fractional part of the number, satisfying:
     ///
-    /// ~~~
+    /// ~~~ {.rust}
     /// assert!(x == trunc(x) + fract(x))
     /// ~~~
     ///

--- a/src/libstd/num/float.rs
+++ b/src/libstd/num/float.rs
@@ -454,7 +454,7 @@ impl Round for float {
     ///
     /// The fractional part of the number, satisfying:
     ///
-    /// ~~~
+    /// ~~~ {.rust}
     /// assert!(x == trunc(x) + fract(x))
     /// ~~~
     ///

--- a/src/libstd/pipes.rs
+++ b/src/libstd/pipes.rs
@@ -16,7 +16,7 @@ the other can receive messages. The set of legal messages and which
 directions they can flow at any given point are determined by a
 protocol. Below is an example protocol.
 
-~~~
+~~~ {.rust}
 proto! pingpong (
     ping: send {
         ping -> pong
@@ -785,20 +785,20 @@ or `right` if the second endpoint receives something. In each case,
 the result includes the other endpoint as well so it can be used
 again. Below is an example of using `select2`.
 
-~~~
+~~~ {.rust}
 match select2(a, b) {
-  left((none, b)) {
-    // endpoint a was closed.
-  }
-  right((a, none)) {
-    // endpoint b was closed.
-  }
-  left((Some(_), b)) {
-    // endpoint a received a message
-  }
-  right(a, Some(_)) {
-    // endpoint b received a message.
-  }
+    left((none, b)) {
+        // endpoint a was closed.
+    }
+    right((a, none)) {
+        // endpoint b was closed.
+    }
+    left((Some(_), b)) {
+        // endpoint a received a message
+    }
+    right(a, Some(_)) {
+        // endpoint b received a message.
+    }
 }
 ~~~
 

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -20,7 +20,8 @@ See the `distributions` submodule for sampling random numbers from
 distributions like normal and exponential.
 
 # Examples
-~~~
+
+~~~ {.rust}
 use core::rand::RngUtil;
 
 fn main() {
@@ -31,7 +32,7 @@ fn main() {
 }
 ~~~
 
-~~~
+~~~ {.rust}
 fn main () {
     let tuple_ptr = rand::random::<~(f64, char)>();
     println(fmt!("%?", tuple_ptr))
@@ -276,9 +277,9 @@ pub trait RngUtil {
     /**
      * Return a bool with a 1 in n chance of true
      *
-     * *Example*
+     * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      *
      * use core::rand::RngUtil;
      *
@@ -292,9 +293,9 @@ pub trait RngUtil {
     /**
      * Return a random string of the specified length composed of A-Z,a-z,0-9
      *
-     * *Example*
+     * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      *
      * use core::rand::RngUtil;
      *
@@ -308,9 +309,9 @@ pub trait RngUtil {
     /**
      * Return a random byte string of the specified length
      *
-     * *Example*
+     * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      *
      * use core::rand::RngUtil;
      *
@@ -324,9 +325,9 @@ pub trait RngUtil {
     /**
      * Choose an item randomly, failing if values is empty
      *
-     * *Example*
+     * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      *
      * use core::rand::RngUtil;
      *
@@ -343,9 +344,9 @@ pub trait RngUtil {
      * Choose an item respecting the relative weights, failing if the sum of
      * the weights is 0
      *
-     * *Example*
+     * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      *
      * use core::rand::RngUtil;
      *
@@ -363,9 +364,9 @@ pub trait RngUtil {
      * Choose Some(item) respecting the relative weights, returning none if
      * the sum of the weights is 0
      *
-     * *Example*
+     * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      *
      * use core::rand::RngUtil;
      *
@@ -384,9 +385,9 @@ pub trait RngUtil {
      * Return a vec containing copies of the items, in order, where
      * the weight of the item determines how many copies there are
      *
-     * *Example*
+     * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      *
      * use core::rand::RngUtil;
      *
@@ -403,9 +404,9 @@ pub trait RngUtil {
     /**
      * Shuffle a vec
      *
-     * *Example*
+     * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      *
      * use core::rand::RngUtil;
      *
@@ -419,9 +420,9 @@ pub trait RngUtil {
     /**
      * Shuffle a mutable vec in place
      *
-     * *Example*
+     * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      *
      * use core::rand::RngUtil;
      *

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -726,7 +726,7 @@ fn iter_between_matches<'a,'b>(s: &'a str,
  *
  * # Example
  *
- * ~~~
+ * ~~~ {.rust}
  * let mut v = ~[];
  * for each_split_str(".XXX.YYY.", ".") |subs| { v.push(subs); }
  * assert!(v == ["", "XXX", "YYY", ""]);
@@ -1923,7 +1923,7 @@ pub fn is_char_boundary(s: &str, index: uint) -> bool {
  *
  * # Example
  *
- * ~~~
+ * ~~~ {.rust}
  * let s = "中华Việt Nam";
  * let i = 0u;
  * while i < str::len(s) {
@@ -2109,7 +2109,7 @@ static tag_six_b: uint = 252u;
  *
  * # Example
  *
- * ~~~
+ * ~~~ {.rust}
  * let i = str::as_bytes("Hello World") { |bytes| bytes.len() };
  * ~~~
  */
@@ -2145,7 +2145,7 @@ pub fn as_bytes_slice<'a>(s: &'a str) -> &'a [u8] {
  *
  * # Example
  *
- * ~~~
+ * ~~~ {.rust}
  * let s = str::as_c_str("PATH", { |path| libc::getenv(path) });
  * ~~~
  */
@@ -2184,7 +2184,7 @@ pub fn as_buf<T>(s: &str, f: &fn(*u8, uint) -> T) -> T {
  *
  * # Example
  *
- * ~~~
+ * ~~~ {.rust}
  * let string = "a\nb\nc";
  * let mut lines = ~[];
  * for each_line(string) |line| { lines.push(line) }

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -138,7 +138,7 @@ terminate normally, but instead directly return from a function.
 
 # Example
 
-~~~
+~~~ {.rust}
 fn choose_weighted_item(v: &[Item]) -> Item {
     assert!(!v.is_empty());
     let mut so_far = 0u;

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -977,7 +977,7 @@ pub fn connect<T:Copy>(v: &[~[T]], sep: &T) -> ~[T] {
  *
  * Sum all values in the vector [1, 2, 3]:
  *
- * ~~~
+ * ~~~ {.rust}
  * vec::foldl(0, [1, 2, 3], |a, b| a + *b);
  * ~~~
  *
@@ -1009,7 +1009,7 @@ pub fn foldl<'a, T, U>(z: T, v: &'a [U], p: &fn(t: T, u: &'a U) -> T) -> T {
  *
  * Sum all values in the vector [1, 2, 3]:
  *
- * ~~~
+ * ~~~ {.rust}
  * vec::foldr([1, 2, 3], 0, |a, b| a + *b);
  * ~~~
  *
@@ -1376,10 +1376,8 @@ pub fn reverse<T>(v: &mut [T]) {
  *
  * Assume a mutable vector `v` contains `[1,2,3,4,5]`. After the call:
  *
- * ~~~
- *
+ * ~~~ {.rust}
  * reverse_part(v, 1, 4);
- *
  * ~~~
  *
  * `v` now contains `[1,4,3,2,5]`.
@@ -1416,14 +1414,15 @@ pub fn reversed<T:Copy>(v: &const [T]) -> ~[T] {
  * * continue iterating, false to break.
  *
  * # Examples
- * ~~~
+ *
+ * ~~~ {.rust}
  * [1,2,3].each(|&i| {
  *     io::println(int::str(i));
  *     true
  * });
  * ~~~
  *
- * ~~~
+ * ~~~ {.rust}
  * [1,2,3,4,5].each(|&i| {
  *     if i < 4 {
  *         io::println(int::str(i));
@@ -1438,7 +1437,7 @@ pub fn reversed<T:Copy>(v: &const [T]) -> ~[T] {
  * You probably will want to use each with a `for`/`do` expression, depending
  * on your iteration needs:
  *
- * ~~~
+ * ~~~ {.rust}
  * for [1,2,3].each |&i| {
  *     io::println(int::str(i));
  * }
@@ -1700,7 +1699,7 @@ pub fn each_permutation<T:Copy>(values: &[T], fun: &fn(perm : &[T]) -> bool) -> 
  *
  * Print the adjacent pairs of a vector (i.e. `[1,2]`, `[2,3]`, `[3,4]`)
  *
- * ~~~
+ * ~~~ {.rust}
  * for windowed(2, &[1,2,3,4]) |v| {
  *     io::println(fmt!("%?", v));
  * }


### PR DESCRIPTION
This works with pandoc linked against highlighting-kate >= 0.5.3.8. It seems to just be a no-op with earlier versions, because I successfully ran this through `try`.

This also fixes some consistency issues (like making `Example`/`Examples` always a header and always using three tildes).
