### PR TITLE
core::vec is missing methods for mutable slices

### DIFF
--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2347,12 +2347,19 @@ impl<T:Eq> OwnedEqVector<T> for ~[T] {
     }
 }
 
-pub trait MutableVector<T> {
+pub trait MutableVector<'self, T> {
+    fn mut_slice(&mut self, start: uint, end: uint) -> &'self mut [T];
+
     unsafe fn unsafe_mut_ref(&self, index: uint) -> *mut T;
     unsafe fn unsafe_set(&self, index: uint, val: T);
 }
 
-impl<'self,T> MutableVector<T> for &'self mut [T] {
+impl<'self,T> MutableVector<'self, T> for &'self mut [T] {
+    #[inline]
+    fn mut_slice(&mut self, start: uint, end: uint) -> &'self mut [T] {
+        mut_slice(*self, start, end)
+    }
+
     #[inline(always)]
     unsafe fn unsafe_mut_ref(&self, index: uint) -> *mut T {
         let pair_ptr: &(*mut T, uint) = transmute(self);


### PR DESCRIPTION
Fix #5984. Also, I found a problem on type inference and left a comment.
