### PR TITLE
Remove colorcolumn setting from Vim runtime files

### DIFF
--- a/src/etc/vim/after/ftplugin/rust.vim
+++ b/src/etc/vim/after/ftplugin/rust.vim
@@ -1,5 +1,0 @@
-"Highlight the 100th text column
-"Feature became available in v7.3
-if version >= 703
-    setlocal colorcolumn=100
-endif


### PR DESCRIPTION
I think settings like this should be left up to the user.
