### PR TITLE
mark glue functions with unnamed_addr

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1903,6 +1903,10 @@ pub mod llvm {
                                     Constraints: *c_char, SideEffects: Bool,
                                     AlignStack: Bool, Dialect: c_uint)
                                  -> ValueRef;
+
+        #[fast_ffi]
+        pub unsafe fn LLVMSetUnnamedAddr(Global: ValueRef, value: Bool);
+
     }
 }
 
@@ -1911,14 +1915,22 @@ pub fn SetInstructionCallConv(Instr: ValueRef, CC: CallConv) {
         llvm::LLVMSetInstructionCallConv(Instr, CC as c_uint);
     }
 }
+
 pub fn SetFunctionCallConv(Fn: ValueRef, CC: CallConv) {
     unsafe {
         llvm::LLVMSetFunctionCallConv(Fn, CC as c_uint);
     }
 }
+
 pub fn SetLinkage(Global: ValueRef, Link: Linkage) {
     unsafe {
         llvm::LLVMSetLinkage(Global, Link as c_uint);
+    }
+}
+
+pub fn set_unnamed_addr(global: ValueRef, value: bool) {
+    unsafe {
+        llvm::LLVMSetUnnamedAddr(global, value as Bool)
     }
 }
 
@@ -1927,11 +1939,13 @@ pub fn ConstICmp(Pred: IntPredicate, V1: ValueRef, V2: ValueRef) -> ValueRef {
         llvm::LLVMConstICmp(Pred as c_ushort, V1, V2)
     }
 }
+
 pub fn ConstFCmp(Pred: RealPredicate, V1: ValueRef, V2: ValueRef) -> ValueRef {
     unsafe {
         llvm::LLVMConstFCmp(Pred as c_ushort, V1, V2)
     }
 }
+
 /* Memory-managed object interface to type handles. */
 
 pub struct TypeNames {

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -717,7 +717,12 @@ pub fn declare_generic_glue(ccx: @CrateContext, t: ty::t, llfnty: TypeRef,
     note_unique_llvm_symbol(ccx, fn_nm);
     let llfn = decl_cdecl_fn(ccx.llmod, *fn_nm, llfnty);
     set_glue_inlining(llfn, t);
-    return llfn;
+
+    // glue functions aren't visible to user code, so function pointer addresses are never
+    // semantically relevant - we can inform LLVM and allow it to merge the functions
+    lib::llvm::set_unnamed_addr(llfn, true);
+
+    llfn
 }
 
 pub fn make_generic_glue_inner(ccx: @CrateContext,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -603,3 +603,8 @@ extern "C" LLVMValueRef LLVMInlineAsm(LLVMTypeRef Ty,
                                Constraints, HasSideEffects,
                                IsAlignStack, (InlineAsm::AsmDialect) Dialect));
 }
+
+extern "C" void LLVMSetUnnamedAddr(LLVMValueRef Global, LLVMBool value) {
+    GlobalValue *GV = unwrap<GlobalValue>(Global);
+    GV->setUnnamedAddr(value);
+}


### PR DESCRIPTION
This doesn't do anything with our current LLVM passes, but it's easy to do, and with `-mergefunc` enabled it no longer has to output stubs to maintain addresses for each glue function.
