### PR TITLE
compiletest: Add #[no_core] to fix check-stage1.

### DIFF
--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -12,6 +12,7 @@
 
 #[allow(non_camel_case_types)];
 
+#[no_core]; // XXX: Remove after snapshot
 #[no_std];
 
 extern mod core(name = "std", vers = "0.7-pre");


### PR DESCRIPTION
Can be removed after a snapshot I believe.
