### PR TITLE
Generalized implementation of FromBase64

### DIFF
--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -113,7 +113,7 @@ pub trait FromBase64 {
     fn from_base64(&self) -> ~[u8];
 }
 
-impl FromBase64 for ~[u8] {
+impl<'self> FromBase64 for &'self [u8] {
     /**
      * Convert base64 `u8` vector into u8 byte values.
      * Every 4 encoded characters is converted into 3 octets, modulo padding.
@@ -188,7 +188,7 @@ impl FromBase64 for ~[u8] {
     }
 }
 
-impl FromBase64 for ~str {
+impl<'self> FromBase64 for &'self str {
     /**
      * Convert any base64 encoded string (literal, `@`, `&`, or `~`)
      * to the byte values it encodes.
@@ -227,23 +227,23 @@ mod tests {
 
     #[test]
     fn test_to_base64() {
-        assert_eq!((~"").to_base64(), ~"");
-        assert!((~"f").to_base64()      == ~"Zg==");
-        assert_eq!((~"fo").to_base64(), ~"Zm8=");
-        assert_eq!((~"foo").to_base64(), ~"Zm9v");
-        assert!((~"foob").to_base64()   == ~"Zm9vYg==");
-        assert_eq!((~"fooba").to_base64(), ~"Zm9vYmE=");
-        assert_eq!((~"foobar").to_base64(), ~"Zm9vYmFy");
+        assert_eq!("".to_base64(), ~"");
+        assert_eq!("f".to_base64(), ~"Zg==");
+        assert_eq!("fo".to_base64(), ~"Zm8=");
+        assert_eq!("foo".to_base64(), ~"Zm9v");
+        assert_eq!("foob".to_base64(), ~"Zm9vYg==");
+        assert_eq!("fooba".to_base64(), ~"Zm9vYmE=");
+        assert_eq!("foobar".to_base64(), ~"Zm9vYmFy");
     }
 
     #[test]
     fn test_from_base64() {
-        assert_eq!((~"").from_base64(), str::to_bytes(""));
-        assert!((~"Zg==").from_base64() == str::to_bytes("f"));
-        assert_eq!((~"Zm8=").from_base64(), str::to_bytes("fo"));
-        assert_eq!((~"Zm9v").from_base64(), str::to_bytes("foo"));
-        assert!((~"Zm9vYg==").from_base64() == str::to_bytes("foob"));
-        assert_eq!((~"Zm9vYmE=").from_base64(), str::to_bytes("fooba"))
-        assert_eq!((~"Zm9vYmFy").from_base64(), str::to_bytes("foobar"));
+        assert_eq!("".from_base64(), str::to_bytes(""));
+        assert_eq!("Zg==".from_base64(), str::to_bytes("f"));
+        assert_eq!("Zm8=".from_base64(), str::to_bytes("fo"));
+        assert_eq!("Zm9v".from_base64(), str::to_bytes("foo"));
+        assert_eq!("Zm9vYg==".from_base64(), str::to_bytes("foob"));
+        assert_eq!("Zm9vYmE=".from_base64(), str::to_bytes("fooba"))
+        assert_eq!("Zm9vYmFy".from_base64(), str::to_bytes("foobar"));
     }
 }


### PR DESCRIPTION
Previously, FromBase64 was only implemented on ~[u8] and ~str when
any pointer would do. The implementations of FromBase64 are now
consistent with the implementations of ToBase64.
