### PR TITLE
Fix #6805: add --enable-ccache configure option

### DIFF
--- a/configure
+++ b/configure
@@ -376,6 +376,7 @@ opt fast-make 0 "use .gitmodules as timestamp for submodule deps"
 opt manage-submodules 1 "let the build manage the git submodules"
 opt mingw-cross 0 "cross-compile for win32 using mingw"
 opt clang 0 "prefer clang to gcc for building the runtime"
+opt ccache 0 "invoke gcc/clang via ccache to reuse object files between builds"
 opt local-rust 0 "use an installed rustc rather than downloading a snapshot"
 opt pax-flags 0 "apply PaX flags to rustc binaries (required for GRSecurity/PaX-patched kernels)"
 valopt prefix "/usr/local" "set installation prefix"
@@ -421,6 +422,7 @@ else
 fi
 
 probe CFG_CLANG            clang++
+probe CFG_CCACHE           ccache
 probe CFG_GCC              gcc
 probe CFG_LD               ld
 probe CFG_VALGRIND         valgrind
@@ -569,6 +571,16 @@ then
     esac
 else
     CFG_C_COMPILER="gcc"
+fi
+
+if [ ! -z "$CFG_ENABLE_CCACHE" ]
+then
+    if [ -z "$CFG_CCACHE" ]
+    then
+        err "ccache requested but not found"
+    fi
+
+    CFG_C_COMPILER="ccache $CFG_C_COMPILER"
 fi
 
 # a little post-processing of various config values
@@ -825,20 +837,35 @@ do
                    --enable-bindings=none --disable-threads \
                    --disable-pthreads"
 
-        if [ "$CFG_C_COMPILER" = "clang" ]
-        then
+        case "$CFG_C_COMPILER" in
+            ("ccache clang")
+            LLVM_CXX_32="ccache clang++ -m32 -Qunused-arguments"
+            LLVM_CC_32="ccache clang -m32 -Qunused-arguments"
+
+            LLVM_CXX_64="ccache clang++ -Qunused-arguments"
+            LLVM_CC_64="ccache clang -Qunused-arguments"
+            ;;
+            ("clang")
             LLVM_CXX_32="clang++ -m32"
             LLVM_CC_32="clang -m32"
 
             LLVM_CXX_64="clang++"
             LLVM_CC_64="clang"
-        else
+            ;;
+            ("ccache gcc")
+            LLVM_CXX_32="ccache g++ -m32"
+            LLVM_CC_32="ccache gcc -m32"
+
+            LLVM_CXX_64="ccache g++"
+            LLVM_CC_64="ccache gcc"
+            ;;
+            ("gcc")
             LLVM_CXX_32="g++ -m32"
             LLVM_CC_32="gcc -m32"
 
             LLVM_CXX_64="g++"
             LLVM_CC_64="gcc"
-        fi
+        esac
 
         LLVM_CFLAGS_32="-m32"
         LLVM_CXXFLAGS_32="-m32"
@@ -933,6 +960,14 @@ if [ ! -z "$CFG_ENABLE_PAX_FLAGS" ]
 then
     putvar CFG_ENABLE_PAX_FLAGS
     putvar CFG_PAXCTL
+fi
+
+# Avoid spurious warnings from clang by feeding it original source on
+# ccache-miss rather than preprocessed input.
+if [ ! -z "$CFG_ENABLE_CCACHE" ] && [ ! -z "$CFG_ENABLE_CLANG" ]
+then
+    CFG_CCACHE_CPP2=1
+    putvar CFG_CCACHE_CPP2
 fi
 
 if [ ! -z $BAD_PANDOC ]

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -106,7 +106,32 @@ ifeq ($(CFG_C_COMPILER),gcc)
     CPP=gcc
   endif
 else
+ifeq ($(CFG_C_COMPILER),ccache clang)
+  # The -Qunused-arguments sidesteps spurious warnings from clang
+  ifeq ($(origin CC),default)
+    CC=ccache clang -Qunused-arguments
+  endif
+  ifeq ($(origin CXX),default)
+    CXX=ccache clang++ -Qunused-arguments
+  endif
+  ifeq ($(origin CPP),default)
+    CPP=ccache clang -Qunused-arguments
+  endif
+else
+ifeq ($(CFG_C_COMPILER),ccache gcc)
+  ifeq ($(origin CC),default)
+    CC=ccache gcc
+  endif
+  ifeq ($(origin CXX),default)
+    CXX=ccache g++
+  endif
+  ifeq ($(origin CPP),default)
+    CPP=ccache gcc
+  endif
+else
   CFG_ERR := $(error please try on a system with gcc or clang)
+endif
+endif
 endif
 endif
 
@@ -366,6 +391,10 @@ CFG_LDPATH_x86_64-unknown-freebsd :=
 CFG_RUN_x86_64-unknown-freebsd=$(2)
 CFG_RUN_TARG_x86_64-unknown-freebsd=$(call CFG_RUN_x86_64-unknown-freebsd,,$(2))
 
+ifeq ($(CFG_CCACHE_CPP2),1)
+  CCACHE_CPP2=1
+  export CCACHE_CPP
+endif
 
 define CFG_MAKE_TOOLCHAIN
   CFG_COMPILE_C_$(1) = $$(CC_$(1))  \


### PR DESCRIPTION
Fix #6805: add --enable-ccache configure option to prefix compiler invocations with `ccache` to attempt to reuse common results, e.g. for LLVM (re)builds.

The information at developer [Note-ccache](../../wiki/Note-ccache) and at [ccache and clang concerns](http://petereisentraut.blogspot.fr/2011/09/ccache-and-clang-part-2.html) were what drove my introduction of the `-Qunused-arguments` and `CCACHE_CPP2` options.  (Though I did confirm first-hand that at least the first really is necessary.)

Yes, one certainly can re-route how `gcc` and `clang` are resolved in one's PATH and use that as a way to invoke `ccache`.  But I personally do not want to introduce that change to my own PATH, and this seems like a small enough change that it does not hurt to add it, at least for now.  (I don't know what form it would take when we move over to `rustpkg`.)
