### PR TITLE
Remove unnecessary 'use' forms

### DIFF
--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -13,7 +13,6 @@ use core::prelude::*;
 use core::cmp;
 use core::ops;
 use core::uint;
-use core::vec::from_elem;
 use core::vec;
 
 struct SmallBitv {

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -24,13 +24,11 @@ use term;
 use core::comm::{stream, SharedChan};
 use core::either;
 use core::io;
-use core::num;
 use core::option;
 use core::result;
 use core::str;
 use core::task;
 use core::to_str::ToStr;
-use core::u64;
 use core::uint;
 use core::vec;
 

--- a/src/libextra/uv_global_loop.rs
+++ b/src/libextra/uv_global_loop.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -16,9 +16,7 @@ use iotask = uv_iotask;
 use uv_iotask::{IoTask, spawn_iotask};
 
 use core::comm::Chan;
-use core::libc;
 use core::option::{Some, None};
-use core::str;
 use core::task::task;
 use core::unstable::global::{global_data_clone_create, global_data_clone};
 use core::unstable::weak_task::weaken_task;

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -106,9 +106,7 @@ pub mod jit {
     use metadata::cstore;
 
     use core::cast;
-    use core::char;
     use core::libc::c_int;
-    use core::os;
     use core::ptr;
     use core::str;
 

--- a/src/librustc/back/passes.rs
+++ b/src/librustc/back/passes.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,7 +12,7 @@ use core::prelude::*;
 use core::str;
 use core::io;
 
-use driver::session::{OptLevel, No, Less, Default, Aggressive};
+use driver::session::{OptLevel, No, Less, Aggressive};
 use driver::session::{Session};
 use lib::llvm::{PassRef, ModuleRef,PassManagerRef,TargetDataRef};
 use lib::llvm::llvm;

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -34,7 +34,6 @@ use middle::ty;
 use middle::ty::FnSig;
 use util::ppaux::ty_to_str;
 
-use core::str;
 use core::uint;
 use core::vec;
 use syntax::codemap::span;

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,7 +19,6 @@ use back::link::*;
 use driver::session;
 use lib;
 use lib::llvm::{llvm, ValueRef, TypeRef, True};
-use lib::llvm::type_to_str;
 use middle::trans::adt;
 use middle::trans::base::*;
 use middle::trans::callee;

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -37,7 +37,6 @@ use core::to_bytes;
 use core::u32;
 use core::uint;
 use core::vec;
-use extra::smallintmap::SmallIntMap;
 use syntax::ast::*;
 use syntax::ast_util::is_local;
 use syntax::ast_util;

--- a/src/librustdoc/astsrv.rs
+++ b/src/librustdoc/astsrv.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -24,7 +24,6 @@ use parse;
 use core::cell::Cell;
 use core::comm::{stream, SharedChan, Port};
 use core::task;
-use core::vec;
 use rustc::driver::driver;
 use rustc::driver::session::Session;
 use rustc::driver::session::{basic_options, options};
@@ -32,6 +31,8 @@ use rustc::front;
 use syntax::ast;
 use syntax::ast_map;
 use syntax;
+
+#[cfg(test)] use core::vec;
 
 pub struct Ctxt {
     ast: @ast::crate,

--- a/src/librustdoc/extract.rs
+++ b/src/librustdoc/extract.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -16,7 +16,6 @@ use astsrv;
 use doc::ItemUtils;
 use doc;
 
-use core::local_data::local_data_get;
 use core::vec;
 use syntax::ast;
 use syntax::parse::token::{ident_interner};

--- a/src/librustdoc/markdown_writer.rs
+++ b/src/librustdoc/markdown_writer.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -17,8 +17,6 @@ use doc;
 use core::comm::*;
 use core::comm;
 use core::io;
-use core::libc;
-use core::os;
 use core::result;
 use core::run;
 use core::str;

--- a/src/librustdoc/unindent_pass.rs
+++ b/src/librustdoc/unindent_pass.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -22,7 +22,6 @@ middle of a line, and each of the following lines is indented.
 use core::prelude::*;
 
 use core::str;
-use core::task;
 use core::uint;
 use core::vec;
 use pass::Pass;

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,7 +11,6 @@
 //! A mutable, nullable memory location
 
 use cast::transmute_mut;
-use cmp;
 use prelude::*;
 use util::replace;
 

--- a/src/libstd/iterator.rs
+++ b/src/libstd/iterator.rs
@@ -20,7 +20,6 @@ implementing the `Iterator` trait.
 use cmp;
 use iter;
 use num::{Zero, One};
-use num;
 use prelude::*;
 
 /// An interface for dealing with "external iterators". These types of iterators

--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -29,7 +29,8 @@ magic.
 use prelude::*;
 
 use task::local_data_priv::{local_get, local_pop, local_modify, local_set, Handle};
-use task;
+
+#[cfg(test)] use task;
 
 /**
  * Indexes a task-local data slot. The function's code pointer is used for

--- a/src/libstd/rand/distributions.rs
+++ b/src/libstd/rand/distributions.rs
@@ -21,7 +21,6 @@
 // could implement VIZIGNOR the ZIGNOR paper for more speed.
 
 use f64;
-use prelude::*;
 use rand::{Rng,Rand};
 
 mod ziggurat_tables;

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -20,7 +20,6 @@ use prelude::*;
 use rt::local::Local;
 use rt::logging::StdErrLogger;
 use super::local_heap::LocalHeap;
-use super::sched::Scheduler;
 
 pub struct Task {
     heap: LocalHeap,

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -37,22 +37,22 @@
 
 use prelude::*;
 
-use cast;
 use cell::Cell;
 use cmp::Eq;
 use comm::{stream, Chan, GenericChan, GenericPort, Port};
-use comm;
-use ptr;
 use result::Result;
 use result;
 use rt::{context, OldTaskContext};
 use task::rt::{task_id, sched_id};
-use task;
 use unstable::finally::Finally;
 use util::replace;
 use util;
 
+#[cfg(test)] use cast;
 #[cfg(test)] use comm::SharedChan;
+#[cfg(test)] use comm;
+#[cfg(test)] use ptr;
+#[cfg(test)] use task;
 
 mod local_data_priv;
 pub mod rt;

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -79,7 +79,6 @@ use cast;
 use cell::Cell;
 use container::Map;
 use comm::{Chan, GenericChan};
-use comm;
 use ptr;
 use hashmap::HashSet;
 use task::local_data_priv::{local_get, local_set, OldHandle};
@@ -89,13 +88,14 @@ use task::{Failure, ManualThreads, PlatformThread, SchedOpts, SingleThreaded};
 use task::{Success, TaskOpts, TaskResult, ThreadPerCore, ThreadPerTask};
 use task::{ExistingScheduler, SchedulerHandle};
 use task::unkillable;
-use task;
 use uint;
 use util;
 use unstable::sync::{Exclusive, exclusive};
 use rt::local::Local;
 
 #[cfg(test)] use task::default_task_opts;
+#[cfg(test)] use comm;
+#[cfg(test)] use task;
 
 macro_rules! move_it (
     { $x:expr } => ( unsafe { let y = *ptr::to_unsafe_ptr(&($x)); y } )

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -10,8 +10,6 @@
 
 //! An ordered map and set for integer keys implemented as a radix trie
 
-use local_data;
-use os;
 use prelude::*;
 use uint;
 use util::{swap, replace};

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -14,7 +14,6 @@ use comm::{GenericChan, GenericPort};
 use comm;
 use libc;
 use prelude::*;
-use ptr;
 use task;
 
 pub mod at_exit;

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -11,7 +11,6 @@
 //! Miscellaneous helpers for common patterns.
 
 use cast;
-use local_data;
 use ptr;
 use prelude::*;
 use unstable::intrinsics;

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,7 +19,6 @@ use ast::ident;
 use ast;
 use codemap::span;
 
-use core::str;
 use core::vec;
 
 // Transitional reexports so qquote can find the paths it is looking for

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -92,7 +92,6 @@ use parse::{new_sub_parser_from_file, next_node_id, ParseSess};
 use opt_vec;
 use opt_vec::OptVec;
 
-use core::char;
 use core::either::Either;
 use core::either;
 use core::hashmap::HashSet;

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,11 +19,9 @@ use util::interner;
 use core::cast;
 use core::char;
 use core::cmp::Equiv;
-use core::hashmap::HashSet;
 use core::local_data;
 use core::str;
 use core::to_bytes;
-use core::vec;
 
 #[deriving(Encodable, Decodable, Eq)]
 pub enum binop {


### PR DESCRIPTION
Fix a laundry list of warnings involving unused imports that glutted
up compilation output.  There are more, but there seems to be some
false positives (where 'remedy' appears to break the build), but this
particular set of fixes seems safe.
