### PR TITLE
Switch expected and actual in assert_eq!

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -467,7 +467,7 @@ pub fn core_macros() -> ~str {
     )
 
     macro_rules! assert_eq (
-        ($given:expr , $expected:expr) => (
+        ($expected:expr , $given:expr) => (
             {
                 let given_val = $given;
                 let expected_val = $expected;
@@ -480,7 +480,7 @@ pub fn core_macros() -> ~str {
     )
 
     macro_rules! assert_approx_eq (
-        ($given:expr , $expected:expr) => (
+        ($expected:expr , $given:expr) => (
             {
                 use std::cmp::ApproxEq;
 
@@ -496,7 +496,7 @@ pub fn core_macros() -> ~str {
                 }
             }
         );
-        ($given:expr , $expected:expr , $epsilon:expr) => (
+        ($expected:expr , $given:expr , $epsilon:expr) => (
             {
                 use std::cmp::ApproxEq;
 


### PR DESCRIPTION
The original XUnit was expected, actual, but we had actual, expected.
http://junit.sourceforge.net/javadoc/org/junit/Assert.html#assertEquals%28double,%20double%29

With the new formatting, this doesn't matter as much, but it's nice to be
consistent with previous frameworks, and if we change the output such
that it does matter, better to be ready.
