### PR TITLE
librustc: Bump the offset when translating const structs. Closes #6352.

### DIFF
--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -563,6 +563,7 @@ fn build_const_struct(ccx: @CrateContext, st: &Struct, vals: &[ValueRef])
             vals[i]
         };
         cfields.push(val);
+        offset += machine::llsize_of_alloc(ccx, llty) as u64
     }
 
     return cfields;

--- a/src/test/run-pass/const-struct-offsets.rs
+++ b/src/test/run-pass/const-struct-offsets.rs
@@ -1,0 +1,14 @@
+enum Foo {
+    IntVal(i32),
+    Int64Val(i64)
+}
+
+struct Bar {
+    i: i32,
+    v: Foo
+}
+
+static bar: Bar = Bar { i: 0, v: IntVal(0) };
+
+fn main() {}
+


### PR DESCRIPTION
r? @nikomatsakis 
