### PR TITLE
disable bb-vectorize pass

### DIFF
--- a/src/librustc/back/passes.rs
+++ b/src/librustc/back/passes.rs
@@ -134,7 +134,6 @@ pub fn create_standard_passes(level:OptLevel) -> ~[~str] {
     passes.push(~"correlated-propagation");
     passes.push(~"dse");
 
-    passes.push(~"bb-vectorize");
     passes.push(~"instcombine");
     passes.push(~"early-cse");
 


### PR DESCRIPTION
It's currently very experimental and generates slow, bloated code along with taking a long time to run.
