### PR TITLE
mv the raw pointer {swap,replace}_ptr to std::ptr + some cleanup

### DIFF
--- a/doc/tutorial-ffi.md
+++ b/doc/tutorial-ffi.md
@@ -153,7 +153,6 @@ use std::cast;
 use std::libc::{c_void, size_t, malloc, free};
 use std::ptr;
 use std::unstable::intrinsics;
-use std::util;
 
 // a wrapper around the handle returned by the foreign code
 pub struct Unique<T> {
@@ -186,7 +185,7 @@ pub impl<T: Owned> Unique<T> {
 impl<T: Owned> Drop for Unique<T> {
     fn finalize(&self) {
         unsafe {
-            let mut x = intrinsics::init(); // dummy value to swap in
+            let x = intrinsics::init(); // dummy value to swap in
             // moving the object out is needed to call the destructor
             ptr::replace_ptr(self.ptr, x);
             free(self.ptr as *c_void)

--- a/doc/tutorial-ffi.md
+++ b/doc/tutorial-ffi.md
@@ -188,7 +188,7 @@ impl<T: Owned> Drop for Unique<T> {
         unsafe {
             let mut x = intrinsics::init(); // dummy value to swap in
             // moving the object out is needed to call the destructor
-            util::replace_ptr(self.ptr, x);
+            ptr::replace_ptr(self.ptr, x);
             free(self.ptr as *c_void)
         }
     }

--- a/src/libextra/rc.rs
+++ b/src/libextra/rc.rs
@@ -28,7 +28,6 @@ use core::libc::{c_void, size_t, malloc, free};
 use core::ptr;
 use core::sys;
 use core::unstable::intrinsics;
-use core::util;
 
 struct RcBox<T> {
     value: T,
@@ -73,7 +72,7 @@ impl<T> Drop for Rc<T> {
         unsafe {
             (*self.ptr).count -= 1;
             if (*self.ptr).count == 0 {
-                util::replace_ptr(self.ptr, intrinsics::uninit());
+                ptr::replace_ptr(self.ptr, intrinsics::uninit());
                 free(self.ptr as *c_void)
             }
         }
@@ -223,7 +222,7 @@ impl<T> Drop for RcMut<T> {
         unsafe {
             (*self.ptr).count -= 1;
             if (*self.ptr).count == 0 {
-                util::replace_ptr(self.ptr, uninit());
+                ptr::replace_ptr(self.ptr, uninit());
                 free(self.ptr as *c_void)
             }
         }

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -72,11 +72,11 @@ pub unsafe fn position<T>(buf: *T, f: &fn(&T) -> bool) -> uint {
 
 /// Create an unsafe null pointer
 #[inline(always)]
-pub fn null<T>() -> *T { unsafe { cast::transmute(0u) } }
+pub fn null<T>() -> *T { 0 as *T }
 
 /// Create an unsafe mutable null pointer
 #[inline(always)]
-pub fn mut_null<T>() -> *mut T { unsafe { cast::transmute(0u) } }
+pub fn mut_null<T>() -> *mut T { 0 as *mut T }
 
 /// Returns true if the pointer is equal to the null pointer.
 #[inline(always)]
@@ -237,48 +237,28 @@ pub unsafe fn replace_ptr<T>(dest: *mut T, mut src: T) -> T {
     src
 }
 
-/**
-  Transform a region pointer - &T - to an unsafe pointer - *T.
-  This is safe, but is implemented with an unsafe block due to
-  transmute.
-*/
+/// Transform a region pointer - &T - to an unsafe pointer - *T.
 #[inline(always)]
 pub fn to_unsafe_ptr<T>(thing: &T) -> *T {
-    unsafe { cast::transmute(thing) }
+    thing as *T
 }
 
-/**
-  Transform a const region pointer - &const T - to a const unsafe pointer -
-  *const T. This is safe, but is implemented with an unsafe block due to
-  transmute.
-*/
+/// Transform a const region pointer - &const T - to a const unsafe pointer - *const T.
 #[inline(always)]
 pub fn to_const_unsafe_ptr<T>(thing: &const T) -> *const T {
-    unsafe { cast::transmute(thing) }
+    thing as *const T
 }
 
-/**
-  Transform a mutable region pointer - &mut T - to a mutable unsafe pointer -
-  *mut T. This is safe, but is implemented with an unsafe block due to
-  transmute.
-*/
+/// Transform a mutable region pointer - &mut T - to a mutable unsafe pointer - *mut T.
 #[inline(always)]
 pub fn to_mut_unsafe_ptr<T>(thing: &mut T) -> *mut T {
-    unsafe { cast::transmute(thing) }
+    thing as *mut T
 }
 
-/**
-  Cast a region pointer - &T - to a uint.
-  This is safe, but is implemented with an unsafe block due to
-  transmute.
-
-  (I couldn't think of a cutesy name for this one.)
-*/
+/// Cast a region pointer - &T - to a uint.
 #[inline(always)]
 pub fn to_uint<T>(thing: &T) -> uint {
-    unsafe {
-        cast::transmute(thing)
-    }
+    thing as *T as uint
 }
 
 /// Determine if two borrowed pointers point to the same thing.
@@ -404,14 +384,10 @@ impl<T> Ptr<T> for *mut T {
 impl<T> Eq for *const T {
     #[inline(always)]
     fn eq(&self, other: &*const T) -> bool {
-        unsafe {
-            let a: uint = cast::transmute(*self);
-            let b: uint = cast::transmute(*other);
-            return a == b;
-        }
+        (*self as uint) == (*other as uint)
     }
     #[inline(always)]
-    fn ne(&self, other: &*const T) -> bool { !(*self).eq(other) }
+    fn ne(&self, other: &*const T) -> bool { !self.eq(other) }
 }
 
 // Comparison for pointers
@@ -419,35 +395,19 @@ impl<T> Eq for *const T {
 impl<T> Ord for *const T {
     #[inline(always)]
     fn lt(&self, other: &*const T) -> bool {
-        unsafe {
-            let a: uint = cast::transmute(*self);
-            let b: uint = cast::transmute(*other);
-            return a < b;
-        }
+        (*self as uint) < (*other as uint)
     }
     #[inline(always)]
     fn le(&self, other: &*const T) -> bool {
-        unsafe {
-            let a: uint = cast::transmute(*self);
-            let b: uint = cast::transmute(*other);
-            return a <= b;
-        }
+        (*self as uint) <= (*other as uint)
     }
     #[inline(always)]
     fn ge(&self, other: &*const T) -> bool {
-        unsafe {
-            let a: uint = cast::transmute(*self);
-            let b: uint = cast::transmute(*other);
-            return a >= b;
-        }
+        (*self as uint) >= (*other as uint)
     }
     #[inline(always)]
     fn gt(&self, other: &*const T) -> bool {
-        unsafe {
-            let a: uint = cast::transmute(*self);
-            let b: uint = cast::transmute(*other);
-            return a > b;
-        }
+        (*self as uint) > (*other as uint)
     }
 }
 
@@ -456,11 +416,11 @@ impl<T> Ord for *const T {
 impl<'self,T:Eq> Eq for &'self T {
     #[inline(always)]
     fn eq(&self, other: & &'self T) -> bool {
-        return *(*self) == *(*other);
+        *(*self) == *(*other)
     }
     #[inline(always)]
     fn ne(&self, other: & &'self T) -> bool {
-        return *(*self) != *(*other);
+        *(*self) != *(*other)
     }
 }
 

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -65,42 +65,12 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
 }
 
 /**
- * Swap the values at two mutable locations of the same type, without
- * deinitialising or copying either one.
- */
-#[inline]
-pub unsafe fn swap_ptr<T>(x: *mut T, y: *mut T) {
-    // Give ourselves some scratch space to work with
-    let mut tmp: T = intrinsics::uninit();
-    let t: *mut T = &mut tmp;
-
-    // Perform the swap
-    ptr::copy_memory(t, x, 1);
-    ptr::copy_memory(x, y, 1);
-    ptr::copy_memory(y, t, 1);
-
-    // y and t now point to the same thing, but we need to completely forget `tmp`
-    // because it's no longer relevant.
-    cast::forget(tmp);
-}
-
-/**
  * Replace the value at a mutable location with a new one, returning the old
  * value, without deinitialising or copying either one.
  */
 #[inline(always)]
 pub fn replace<T>(dest: &mut T, mut src: T) -> T {
     swap(dest, &mut src);
-    src
-}
-
-/**
- * Replace the value at a mutable location with a new one, returning the old
- * value, without deinitialising or copying either one.
- */
-#[inline(always)]
-pub unsafe fn replace_ptr<T>(dest: *mut T, mut src: T) -> T {
-    swap_ptr(dest, ptr::to_mut_unsafe_ptr(&mut src));
     src
 }
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -506,7 +506,7 @@ pub fn shift<T>(v: &mut ~[T]) -> T {
         let vp = raw::to_mut_ptr(*v);
         let vp = ptr::mut_offset(vp, next_ln - 1);
 
-        util::replace_ptr(vp, work_elt)
+        ptr::replace_ptr(vp, work_elt)
     }
 }
 
@@ -570,7 +570,7 @@ pub fn consume<T>(mut v: ~[T], f: &fn(uint, v: T)) {
                 // elements during unwinding
                 let x = intrinsics::init();
                 let p = ptr::mut_offset(p, i);
-                f(i, util::replace_ptr(p, x));
+                f(i, ptr::replace_ptr(p, x));
             }
         }
 
@@ -597,7 +597,7 @@ pub fn consume_reverse<T>(mut v: ~[T], f: &fn(uint, v: T)) {
                 // elements during unwinding
                 let x = intrinsics::init();
                 let p = ptr::mut_offset(p, i);
-                f(i, util::replace_ptr(p, x));
+                f(i, ptr::replace_ptr(p, x));
             }
         }
 
@@ -613,7 +613,7 @@ pub fn pop<T>(v: &mut ~[T]) -> T {
     }
     let valptr = ptr::to_mut_unsafe_ptr(&mut v[ln - 1u]);
     unsafe {
-        let val = util::replace_ptr(valptr, intrinsics::init());
+        let val = ptr::replace_ptr(valptr, intrinsics::init());
         raw::set_len(v, ln - 1u);
         val
     }
@@ -707,8 +707,8 @@ pub fn push_all_move<T>(v: &mut ~[T], mut rhs: ~[T]) {
     unsafe {
         do as_mut_buf(rhs) |p, len| {
             for uint::range(0, len) |i| {
-                let x = util::replace_ptr(ptr::mut_offset(p, i),
-                                          intrinsics::uninit());
+                let x = ptr::replace_ptr(ptr::mut_offset(p, i),
+                                         intrinsics::uninit());
                 push(&mut *v, x);
             }
         }
@@ -723,7 +723,7 @@ pub fn truncate<T>(v: &mut ~[T], newlen: uint) {
         unsafe {
             // This loop is optimized out for non-drop types.
             for uint::range(newlen, oldlen) |i| {
-                util::replace_ptr(ptr::mut_offset(p, i), intrinsics::uninit());
+                ptr::replace_ptr(ptr::mut_offset(p, i), intrinsics::uninit());
             }
         }
     }
@@ -747,14 +747,14 @@ pub fn dedup<T:Eq>(v: &mut ~[T]) {
                 // last_written < next_to_read < ln
                 if *ptr::mut_offset(p, next_to_read) ==
                     *ptr::mut_offset(p, last_written) {
-                    util::replace_ptr(ptr::mut_offset(p, next_to_read),
-                                      intrinsics::uninit());
+                    ptr::replace_ptr(ptr::mut_offset(p, next_to_read),
+                                     intrinsics::uninit());
                 } else {
                     last_written += 1;
                     // last_written <= next_to_read < ln
                     if next_to_read != last_written {
-                        util::swap_ptr(ptr::mut_offset(p, last_written),
-                                       ptr::mut_offset(p, next_to_read));
+                        ptr::swap_ptr(ptr::mut_offset(p, last_written),
+                                      ptr::mut_offset(p, next_to_read));
                     }
                 }
                 // last_written <= next_to_read < ln
@@ -1398,7 +1398,7 @@ pub fn swap<T>(v: &mut [T], a: uint, b: uint) {
         // them to their raw pointers to do the swap
         let pa: *mut T = ptr::to_mut_unsafe_ptr(&mut v[a]);
         let pb: *mut T = ptr::to_mut_unsafe_ptr(&mut v[b]);
-        util::swap_ptr(pa, pb);
+        ptr::swap_ptr(pa, pb);
     }
 }
 

--- a/src/test/run-pass/swap-overlapping.rs
+++ b/src/test/run-pass/swap-overlapping.rs
@@ -26,8 +26,8 @@ pub fn main() {
 
 fn do_swap(test: &mut TestDescAndFn) {
     unsafe {
-        util::swap_ptr(ptr::to_mut_unsafe_ptr(test),
-                       ptr::to_mut_unsafe_ptr(test));
+        ptr::swap_ptr(ptr::to_mut_unsafe_ptr(test),
+                      ptr::to_mut_unsafe_ptr(test));
     }
 }
 


### PR DESCRIPTION
I don't like the `util` module in general, and `ptr` is a much better place for these.
