### PR TITLE
librustc: Don't require `pub extern` to make extern functions visible

### DIFF
--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -200,7 +200,7 @@ pub fn check_crate(tcx: ty::ctxt,
         f = |item_id| {
             match tcx.items.find(&item_id) {
                 Some(&node_item(item, _)) => item.vis != public,
-                Some(&node_foreign_item(_, _, vis, _)) => vis != public,
+                Some(&node_foreign_item(*)) => false,
                 Some(&node_method(method, impl_did, _)) => {
                     match method.vis {
                         private => true,

--- a/src/test/run-pass/pub-extern-privacy.rs
+++ b/src/test/run-pass/pub-extern-privacy.rs
@@ -1,0 +1,14 @@
+use std::cast::transmute;
+
+mod a {
+    extern {
+        pub fn free(x: *u8);
+    }
+}
+
+fn main() {
+    unsafe {
+        a::free(transmute(0));
+    }
+}
+


### PR DESCRIPTION
r? @brson
