### PR TITLE
ptr: split out borrowed pointer utilities

### DIFF
--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -48,6 +48,7 @@ use core::cast;
 use core::unstable::sync::UnsafeAtomicRcBox;
 use core::ptr;
 use core::task;
+use core::borrow;
 
 /// As sync::condvar, a mechanism for unlock-and-descheduling and signaling.
 pub struct Condvar<'self> {
@@ -425,7 +426,7 @@ impl<T:Const + Owned> RWARC<T> {
             // of this cast is removing the mutability.)
             let new_data = cast::transmute_immut(data);
             // Downgrade ensured the token belonged to us. Just a sanity check.
-            assert!(ptr::ref_eq(&(*state).data, new_data));
+            assert!(borrow::ref_eq(&(*state).data, new_data));
             // Produce new token
             RWReadMode {
                 data: new_data,

--- a/src/libextra/sync.rs
+++ b/src/libextra/sync.rs
@@ -17,6 +17,7 @@
 
 use core::prelude::*;
 
+use core::borrow;
 use core::comm;
 use core::ptr;
 use core::task;
@@ -589,7 +590,7 @@ impl RWlock {
     /// To be called inside of the write_downgrade block.
     pub fn downgrade<'a>(&self, token: RWlockWriteMode<'a>)
                          -> RWlockReadMode<'a> {
-        if !ptr::ref_eq(self, token.lock) {
+        if !borrow::ref_eq(self, token.lock) {
             fail!("Can't downgrade() with a different rwlock's write_mode!");
         }
         unsafe {

--- a/src/libstd/borrow.rs
+++ b/src/libstd/borrow.rs
@@ -1,0 +1,60 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Borrowed pointer utilities
+
+#[cfg(not(test))]
+use prelude::*;
+
+/// Cast a region pointer - &T - to a uint.
+#[inline(always)]
+pub fn to_uint<T>(thing: &T) -> uint {
+    thing as *T as uint
+}
+
+/// Determine if two borrowed pointers point to the same thing.
+#[inline(always)]
+pub fn ref_eq<'a, 'b, T>(thing: &'a T, other: &'b T) -> bool {
+    to_uint(thing) == to_uint(other)
+}
+
+// Equality for region pointers
+#[cfg(not(test))]
+impl<'self, T: Eq> Eq for &'self T {
+    #[inline(always)]
+    fn eq(&self, other: & &'self T) -> bool {
+        *(*self) == *(*other)
+    }
+    #[inline(always)]
+    fn ne(&self, other: & &'self T) -> bool {
+        *(*self) != *(*other)
+    }
+}
+
+// Comparison for region pointers
+#[cfg(not(test))]
+impl<'self, T: Ord> Ord for &'self T {
+    #[inline(always)]
+    fn lt(&self, other: & &'self T) -> bool {
+        *(*self) < *(*other)
+    }
+    #[inline(always)]
+    fn le(&self, other: & &'self T) -> bool {
+        *(*self) <= *(*other)
+    }
+    #[inline(always)]
+    fn ge(&self, other: & &'self T) -> bool {
+        *(*self) >= *(*other)
+    }
+    #[inline(always)]
+    fn gt(&self, other: & &'self T) -> bool {
+        *(*self) > *(*other)
+    }
+}

--- a/src/libstd/core.rc
+++ b/src/libstd/core.rc
@@ -125,6 +125,7 @@ pub mod ascii;
 pub mod ptr;
 pub mod owned;
 pub mod managed;
+pub mod borrow;
 
 
 /* Core language traits */

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -255,18 +255,6 @@ pub fn to_mut_unsafe_ptr<T>(thing: &mut T) -> *mut T {
     thing as *mut T
 }
 
-/// Cast a region pointer - &T - to a uint.
-#[inline(always)]
-pub fn to_uint<T>(thing: &T) -> uint {
-    thing as *T as uint
-}
-
-/// Determine if two borrowed pointers point to the same thing.
-#[inline(always)]
-pub fn ref_eq<'a,'b,T>(thing: &'a T, other: &'b T) -> bool {
-    to_uint(thing) == to_uint(other)
-}
-
 /**
   Given a **T (pointer to an array of pointers),
   iterate through each *T, up to the provided `len`,
@@ -408,40 +396,6 @@ impl<T> Ord for *const T {
     #[inline(always)]
     fn gt(&self, other: &*const T) -> bool {
         (*self as uint) > (*other as uint)
-    }
-}
-
-// Equality for region pointers
-#[cfg(not(test))]
-impl<'self,T:Eq> Eq for &'self T {
-    #[inline(always)]
-    fn eq(&self, other: & &'self T) -> bool {
-        *(*self) == *(*other)
-    }
-    #[inline(always)]
-    fn ne(&self, other: & &'self T) -> bool {
-        *(*self) != *(*other)
-    }
-}
-
-// Comparison for region pointers
-#[cfg(not(test))]
-impl<'self,T:Ord> Ord for &'self T {
-    #[inline(always)]
-    fn lt(&self, other: & &'self T) -> bool {
-        *(*self) < *(*other)
-    }
-    #[inline(always)]
-    fn le(&self, other: & &'self T) -> bool {
-        *(*self) <= *(*other)
-    }
-    #[inline(always)]
-    fn ge(&self, other: & &'self T) -> bool {
-        *(*self) >= *(*other)
-    }
-    #[inline(always)]
-    fn gt(&self, other: & &'self T) -> bool {
-        *(*self) > *(*other)
     }
 }
 

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -13,6 +13,7 @@
 //! local storage, and logging. Even a 'freestanding' Rust would likely want
 //! to implement this.
 
+use borrow;
 use cast::transmute;
 use libc::{c_void, uintptr_t};
 use ptr;
@@ -64,7 +65,7 @@ impl Task {
         // This is just an assertion that `run` was called unsafely
         // and this instance of Task is still accessible.
         do Local::borrow::<Task> |task| {
-            assert!(ptr::ref_eq(task, self));
+            assert!(borrow::ref_eq(task, self));
         }
 
         match self.unwinder {
@@ -89,7 +90,7 @@ impl Task {
         // This is just an assertion that `destroy` was called unsafely
         // and this instance of Task is still accessible.
         do Local::borrow::<Task> |task| {
-            assert!(ptr::ref_eq(task, self));
+            assert!(borrow::ref_eq(task, self));
         }
         match self.storage {
             LocalStorage(ptr, Some(ref dtor)) => {

--- a/src/test/run-pass/borrowck-borrow-from-expr-block.rs
+++ b/src/test/run-pass/borrowck-borrow-from-expr-block.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::borrow;
 use std::ptr;
 
 fn borrow(x: &int, f: &fn(x: &int)) {
@@ -17,7 +18,7 @@ fn borrow(x: &int, f: &fn(x: &int)) {
 fn test1(x: @~int) {
     do borrow(&*(*x).clone()) |p| {
         let x_a = ptr::to_unsafe_ptr(&**x);
-        assert!((x_a as uint) != ptr::to_uint(p));
+        assert!((x_a as uint) != borrow::to_uint(p));
         assert_eq!(unsafe{*x_a}, *p);
     }
 }

--- a/src/test/run-pass/cast-region-to-uint.rs
+++ b/src/test/run-pass/cast-region-to-uint.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ptr;
+use std::borrow;
 
 pub fn main() {
     let x = 3;
-    debug!("&x=%x", ptr::to_uint(&x));
+    debug!("&x=%x", borrow::to_uint(&x));
 }


### PR DESCRIPTION
The ptr module is intended to be for raw pointers.

Closes #3111
