### PR TITLE
rename the Ptr trait to RawPtr

### DIFF
--- a/src/libstd/pipes.rs
+++ b/src/libstd/pipes.rs
@@ -94,7 +94,7 @@ use option::{None, Option, Some};
 use unstable::finally::Finally;
 use unstable::intrinsics;
 use ptr;
-use ptr::Ptr;
+use ptr::RawPtr;
 use task;
 use vec;
 use vec::OwnedVector;

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -43,7 +43,7 @@ pub use path::GenericPath;
 pub use path::Path;
 pub use path::PosixPath;
 pub use path::WindowsPath;
-pub use ptr::Ptr;
+pub use ptr::RawPtr;
 pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr};
 pub use str::{StrVector, StrSlice, OwnedStr, StrUtil};
 pub use from_str::{FromStr};

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -296,7 +296,7 @@ pub unsafe fn array_each<T>(arr: **T, cb: &fn(*T)) {
 }
 
 #[allow(missing_doc)]
-pub trait Ptr<T> {
+pub trait RawPtr<T> {
     fn is_null(&const self) -> bool;
     fn is_not_null(&const self) -> bool;
     unsafe fn to_option(&const self) -> Option<&T>;
@@ -304,7 +304,7 @@ pub trait Ptr<T> {
 }
 
 /// Extension methods for immutable pointers
-impl<T> Ptr<T> for *T {
+impl<T> RawPtr<T> for *T {
     /// Returns true if the pointer is equal to the null pointer.
     #[inline(always)]
     fn is_null(&const self) -> bool { is_null(*self) }
@@ -336,7 +336,7 @@ impl<T> Ptr<T> for *T {
 }
 
 /// Extension methods for mutable pointers
-impl<T> Ptr<T> for *mut T {
+impl<T> RawPtr<T> for *mut T {
     /// Returns true if the pointer is equal to the null pointer.
     #[inline(always)]
     fn is_null(&const self) -> bool { is_null(*self) }

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -56,7 +56,7 @@ Several modules in `core` are clients of `rt`:
 
 #[doc(hidden)];
 
-use ptr::Ptr;
+use ptr::RawPtr;
 
 /// The global (exchange) heap.
 pub mod global_heap;

--- a/src/libstd/rt/stack.rs
+++ b/src/libstd/rt/stack.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use container::Container;
-use ptr::Ptr;
+use ptr::RawPtr;
 use vec;
 use ops::Drop;
 use libc::{c_uint, uintptr_t};

--- a/src/libstd/rt/uv/mod.rs
+++ b/src/libstd/rt/uv/mod.rs
@@ -38,7 +38,7 @@ use container::Container;
 use option::*;
 use str::raw::from_c_str;
 use to_str::ToStr;
-use ptr::Ptr;
+use ptr::RawPtr;
 use libc;
 use vec;
 use ptr;

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -30,7 +30,7 @@ use libc;
 use option::{None, Option, Some};
 use old_iter::{BaseIter, EqIter};
 use ptr;
-use ptr::Ptr;
+use ptr::RawPtr;
 use str;
 use to_str::ToStr;
 use uint;

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -26,7 +26,7 @@ use old_iter::CopyableIter;
 use option::{None, Option, Some};
 use ptr::to_unsafe_ptr;
 use ptr;
-use ptr::Ptr;
+use ptr::RawPtr;
 use sys;
 use uint;
 use unstable::intrinsics;


### PR DESCRIPTION
Closes #6607

I went with `RawPtr` instead of `UnsafePtr` because not all of these operations are `unsafe`, so to me it makes more sense to refer to it as a "raw" (not wrapped/abstracted) pointer. If we decide on something else in #6608 it can be renamed again.
