### PR TITLE
rustc::middle::trans::reachable: remove some unneeded code

### DIFF
--- a/src/test/run-pass/borrowck-nested-calls.rs
+++ b/src/test/run-pass/borrowck-nested-calls.rs
@@ -24,7 +24,7 @@ impl Foo {
     }
 }
 
-fn main() {
+pub fn main() {
     let mut f = Foo {a: 22, b: 23};
     f.inc_a(f.next_b());
     assert_eq!(f.a, 22+23);

--- a/src/test/run-pass/borrowck-unary-move-2.rs
+++ b/src/test/run-pass/borrowck-unary-move-2.rs
@@ -26,7 +26,7 @@ fn noncopyable() -> noncopyable {
 
 struct wrapper(noncopyable);
 
-fn main() {
+pub fn main() {
     let x1 = wrapper(noncopyable());
     let _x2 = *x1;
 }

--- a/src/test/run-pass/borrowck-wg-autoderef-and-autoborrowvec-combined-issue-6272.rs
+++ b/src/test/run-pass/borrowck-wg-autoderef-and-autoborrowvec-combined-issue-6272.rs
@@ -27,7 +27,7 @@
 // run-fail/borrowck-wg-autoderef-and-autoborrowvec-combined-fail-issue-6272.rs
 
 
-fn main() {
+pub fn main() {
     let a = @mut [3i];
     let b = @mut [a];
     let c = @mut b;

--- a/src/test/run-pass/cast-mutable-trait.rs
+++ b/src/test/run-pass/cast-mutable-trait.rs
@@ -25,7 +25,7 @@ fn bar(t: @mut T) {
     t.foo();
 }
 
-fn main() {
+pub fn main() {
     let s = @mut S { unused: 0 };
     let s2 = s as @mut T;
     s2.foo();

--- a/src/test/run-pass/cfgs-on-items.rs
+++ b/src/test/run-pass/cfgs-on-items.rs
@@ -25,7 +25,7 @@ fn foo2() -> int { 2 }
 fn foo2() -> int { 3 }
 
 
-fn main() {
+pub fn main() {
     assert_eq!(1, foo1());
     assert_eq!(3, foo2());
 }

--- a/src/test/run-pass/cond-macro-no-default.rs
+++ b/src/test/run-pass/cond-macro-no-default.rs
@@ -16,7 +16,7 @@ fn clamp<T:Copy + Ord + Signed>(x: T, mn: T, mx: T) -> T {
     return x;
 }
 
-fn main() {
+pub fn main() {
     assert_eq!(clamp(1, 2, 4), 2);
     assert_eq!(clamp(8, 2, 4), 4);
     assert_eq!(clamp(3, 2, 4), 3);

--- a/src/test/run-pass/cond-macro.rs
+++ b/src/test/run-pass/cond-macro.rs
@@ -16,7 +16,7 @@ fn clamp<T:Copy + Ord + Signed>(x: T, mn: T, mx: T) -> T {
     )
 }
 
-fn main() {
+pub fn main() {
     assert_eq!(clamp(1, 2, 4), 2);
     assert_eq!(clamp(8, 2, 4), 4);
     assert_eq!(clamp(3, 2, 4), 3);

--- a/src/test/run-pass/const-binops.rs
+++ b/src/test/run-pass/const-binops.rs
@@ -56,7 +56,7 @@ static am: bool = 2 > 1;
 static an: bool = 2 > -2;
 static ao: bool = 1.0 > -2.0;
 
-fn main() {
+pub fn main() {
     assert_eq!(a, -1);
     assert_eq!(a2, 6);
     assert_approx_eq!(b, 5.7);

--- a/src/test/run-pass/const-cross-crate-const.rs
+++ b/src/test/run-pass/const-cross-crate-const.rs
@@ -16,7 +16,7 @@ static foo: &'static str = cci_const::foopy;
 static a: uint = cci_const::uint_val;
 static b: uint = cci_const::uint_expr + 5;
 
-fn main() {
+pub fn main() {
     assert_eq!(a, 12);
     let foo2 = a;
     assert_eq!(foo2, cci_const::uint_val);

--- a/src/test/run-pass/const-struct-offsets.rs
+++ b/src/test/run-pass/const-struct-offsets.rs
@@ -10,5 +10,5 @@ struct Bar {
 
 static bar: Bar = Bar { i: 0, v: IntVal(0) };
 
-fn main() {}
+pub fn main() {}
 

--- a/src/test/run-pass/cross-crate-const-pat.rs
+++ b/src/test/run-pass/cross-crate-const-pat.rs
@@ -13,7 +13,7 @@
 
 extern mod cci_const;
 
-fn main() {
+pub fn main() {
     let x = cci_const::uint_val;
     match x {
         cci_const::uint_val => {}

--- a/src/test/run-pass/cross-crate-newtype-struct-pat.rs
+++ b/src/test/run-pass/cross-crate-newtype-struct-pat.rs
@@ -13,7 +13,7 @@
 
 extern mod newtype_struct_xc;
 
-fn main() {
+pub fn main() {
     let x = newtype_struct_xc::Au(21);
     match x {
         newtype_struct_xc::Au(n) => assert_eq!(n, 21)

--- a/src/test/run-pass/deriving-clone-generic-enum.rs
+++ b/src/test/run-pass/deriving-clone-generic-enum.rs
@@ -15,7 +15,7 @@ enum E<T,U> {
     C
 }
 
-fn main() {
+pub fn main() {
     let _ = A::<int, int>(1i).clone();
     let _ = B(1i, 1.234).deep_clone();
 }

--- a/src/test/run-pass/deriving-clone-generic-tuple-struct.rs
+++ b/src/test/run-pass/deriving-clone-generic-tuple-struct.rs
@@ -11,6 +11,6 @@
 #[deriving(Clone, DeepClone)]
 struct S<T>(T, ());
 
-fn main() {
+pub fn main() {
     let _ = S(1i, ()).clone().deep_clone();
 }

--- a/src/test/run-pass/deriving-clone-struct.rs
+++ b/src/test/run-pass/deriving-clone-struct.rs
@@ -31,4 +31,4 @@ struct S {
     _nil: ()
 }
 
-fn main() {}
+pub fn main() {}

--- a/src/test/run-pass/deriving-rand.rs
+++ b/src/test/run-pass/deriving-rand.rs
@@ -30,7 +30,7 @@ enum D {
     D2 { x: (), y: () }
 }
 
-fn main() {
+pub fn main() {
     // check there's no segfaults
     for 20.times {
         rand::random::<A>();

--- a/src/test/run-pass/deriving-self-lifetime-totalord-totaleq.rs
+++ b/src/test/run-pass/deriving-self-lifetime-totalord-totaleq.rs
@@ -17,7 +17,7 @@ struct A<'self> {
     x: &'self int
 }
 
-fn main() {
+pub fn main() {
     let a = A { x: &1 }, b = A { x: &2 };
 
     assert!(a.equals(&a));

--- a/src/test/run-pass/deriving-self-lifetime.rs
+++ b/src/test/run-pass/deriving-self-lifetime.rs
@@ -13,7 +13,7 @@ struct A<'self> {
     x: &'self int
 }
 
-fn main() {
+pub fn main() {
     let a = A { x: &1 };
     let b = A { x: &2 };
 

--- a/src/test/run-pass/deriving-to-str.rs
+++ b/src/test/run-pass/deriving-to-str.rs
@@ -30,7 +30,7 @@ enum D {
     D2 { x: (), y: () }
 }
 
-fn main() {
+pub fn main() {
     macro_rules! t(
         ($ty:ty) => {{
             let x =rand::random::<$ty>();

--- a/src/test/run-pass/dupe-first-attr.rc
+++ b/src/test/run-pass/dupe-first-attr.rc
@@ -26,4 +26,4 @@ mod hello;
 #[cfg(target_os = "android")]
 mod hello;
 
-fn main() { }
+pub fn main() { }

--- a/src/test/run-pass/expr-repeat-vstore.rs
+++ b/src/test/run-pass/expr-repeat-vstore.rs
@@ -1,6 +1,6 @@
 use std::io::println;
 
-fn main() {
+pub fn main() {
     let v: ~[int] = ~[ 1, ..5 ];
     println(v[0].to_str());
     println(v[1].to_str());

--- a/src/test/run-pass/extern-mod-ordering-exe.rs
+++ b/src/test/run-pass/extern-mod-ordering-exe.rs
@@ -5,6 +5,6 @@ extern mod extern_mod_ordering_lib;
 
 use extern_mod_ordering_lib::extern_mod_ordering_lib;
 
-fn main() {
+pub fn main() {
     extern_mod_ordering_lib::f();
 }

--- a/src/test/run-pass/extern-mod-url.rs
+++ b/src/test/run-pass/extern-mod-url.rs
@@ -13,4 +13,4 @@
 // xfail-test
 extern mod test = "github.com/catamorphism/test-pkg";
 
-fn main() {}
+pub fn main() {}

--- a/src/test/run-pass/filter-block-view-items.rs
+++ b/src/test/run-pass/filter-block-view-items.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
+pub fn main() {
     // Make sure that this view item is filtered out because otherwise it would
     // trigger a compilation error
     #[cfg(not_present)] use foo = bar;

--- a/src/test/run-pass/issue-2611-3.rs
+++ b/src/test/run-pass/issue-2611-3.rs
@@ -23,4 +23,4 @@ impl A for E {
   fn b<F:Copy,G>(_x: F) -> F { fail!() } //~ ERROR in method `b`, type parameter 0 has 1 bound, but
 }
 
-fn main() {}
+pub fn main() {}

--- a/src/test/run-pass/issue-3290.rs
+++ b/src/test/run-pass/issue-3290.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // xfail-test
-fn main() {
+pub fn main() {
    let mut x = ~3;
    x = x;
    assert_eq!(*x, 3);

--- a/src/test/run-pass/issue-3796.rs
+++ b/src/test/run-pass/issue-3796.rs
@@ -10,7 +10,7 @@
 
 // xfail-test
 #[deny(dead_assignment)];
-fn main() {
+pub fn main() {
     let mut x = 1;
     let f: &fn() -> int = || { x + 20 };
     assert_eq!(f(), 21);

--- a/src/test/run-pass/issue-3907-2.rs
+++ b/src/test/run-pass/issue-3907-2.rs
@@ -22,7 +22,7 @@ impl Foo for S {
     fn bar() { }
 }
 
-fn main() {
+pub fn main() {
     let s = S {
         name: 0
     };

--- a/src/test/run-pass/issue-4241.rs
+++ b/src/test/run-pass/issue-4241.rs
@@ -123,5 +123,5 @@ fn query2(cmd: ~[~str]) -> Result {
 }
 
 
-fn main() {
+pub fn main() {
 }

--- a/src/test/run-pass/issue-4252.rs
+++ b/src/test/run-pass/issue-4252.rs
@@ -31,7 +31,7 @@ impl<T: X> Drop for Z<T> {
     }
 }
 
-fn main() {
+pub fn main() {
     let y = Y;
     let _z = Z{x: y};
 }

--- a/src/test/run-pass/issue-4325.rs
+++ b/src/test/run-pass/issue-4325.rs
@@ -22,4 +22,4 @@ impl<'self, T> Node<'self, T> {
   }
 }
 
-fn main() {}
+pub fn main() {}

--- a/src/test/run-pass/issue-4333.rs
+++ b/src/test/run-pass/issue-4333.rs
@@ -10,7 +10,7 @@
 
 use std::io;
 
-fn main() {
+pub fn main() {
     let stdout = &io::stdout() as &io::WriterUtil;
     stdout.write_line("Hello!");
 }

--- a/src/test/run-pass/issue-4735.rs
+++ b/src/test/run-pass/issue-4735.rs
@@ -21,7 +21,7 @@ impl Drop for NonCopyable {
     }
 }
 
-fn main() {
+pub fn main() {
     let t = ~0;
     let p = unsafe { transmute::<~int, *c_void>(t) };
     let z = NonCopyable(p);

--- a/src/test/run-pass/issue-5315.rs
+++ b/src/test/run-pass/issue-5315.rs
@@ -11,7 +11,7 @@
 // xfail-test
 struct A(bool);
 
-fn main() {
+pub fn main() {
     let f = A;
     f(true);
 }

--- a/src/test/run-pass/issue-5353.rs
+++ b/src/test/run-pass/issue-5353.rs
@@ -21,4 +21,4 @@ fn gl_err_str(err: u32) -> ~str
   }
 }
 
-fn main() {}
+pub fn main() {}

--- a/src/test/run-pass/issue-5517.rs
+++ b/src/test/run-pass/issue-5517.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
+pub fn main() {
     let box1 = @mut 42;
     let _x = *(&mut *box1) == 42 || *(&mut *box1) == 31337;
 }

--- a/src/test/run-pass/issue-5550.rs
+++ b/src/test/run-pass/issue-5550.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
+pub fn main() {
     let s: ~str = ~"foobar";
     let mut t: &str = s;
     t = t.slice(0, 3); // for master: str::view(t, 0, 3) maybe

--- a/src/test/run-pass/issue-5572.rs
+++ b/src/test/run-pass/issue-5572.rs
@@ -1,3 +1,3 @@
 fn foo<T: ::std::cmp::Eq>(t: T) { }
 
-fn main() { }
+pub fn main() { }

--- a/src/test/run-pass/issue-5741.rs
+++ b/src/test/run-pass/issue-5741.rs
@@ -10,7 +10,7 @@
 
 use std::io;
 
-fn main() {
+pub fn main() {
     return;
     while io::stdin().read_line() != ~"quit" { };
 }

--- a/src/test/run-pass/issue-6130.rs
+++ b/src/test/run-pass/issue-6130.rs
@@ -10,7 +10,7 @@
 
 #[deny(type_limits)];
 
-fn main() {
+pub fn main() {
     let i: uint = 0;
     assert!(i <= 0xFFFF_FFFF_u);
 

--- a/src/test/run-pass/issue-6141-leaking-owned-fn.rs
+++ b/src/test/run-pass/issue-6141-leaking-owned-fn.rs
@@ -2,7 +2,7 @@ fn run(f: &fn()) {
     f()
 }
 
-fn main() {
+pub fn main() {
     let f: ~fn() = || ();
     run(f);
 }

--- a/src/test/run-pass/issue-6341.rs
+++ b/src/test/run-pass/issue-6341.rs
@@ -15,4 +15,4 @@ impl Drop for A {
     fn finalize(&self) {}
 }
 
-fn main() {}
+pub fn main() {}

--- a/src/test/run-pass/issue-6344-let.rs
+++ b/src/test/run-pass/issue-6344-let.rs
@@ -14,7 +14,7 @@ impl Drop for A {
     fn finalize(&self) {}
 }
 
-fn main() {
+pub fn main() {
     let a = A { x: 0 };
 
     let A { x: ref x } = a;

--- a/src/test/run-pass/issue-6344-match.rs
+++ b/src/test/run-pass/issue-6344-match.rs
@@ -13,7 +13,7 @@ impl Drop for A {
     fn finalize(&self) {}
 }
 
-fn main() {
+pub fn main() {
     let a = A { x: 0 };
 
     match a {

--- a/src/test/run-pass/match-range-static.rs
+++ b/src/test/run-pass/match-range-static.rs
@@ -1,7 +1,7 @@
 static s: int = 1;
 static e: int = 42;
 
-fn main() {
+pub fn main() {
     match 7 {
         s..e => (),
         _ => (),

--- a/src/test/run-pass/match-vec-rvalue.rs
+++ b/src/test/run-pass/match-vec-rvalue.rs
@@ -1,6 +1,6 @@
 // Tests that matching rvalues with drops does not crash.
 
-fn main() {
+pub fn main() {
     match ~[1, 2, 3] {
         x => {
             assert_eq!(x.len(), 3);

--- a/src/test/run-pass/move-out-of-field.rs
+++ b/src/test/run-pass/move-out-of-field.rs
@@ -14,7 +14,7 @@ fn to_str(sb: StringBuffer) -> ~str {
     sb.s
 }
 
-fn main() {
+pub fn main() {
     let mut sb = StringBuffer {s: ~""};
     sb.append("Hello, ");
     sb.append("World!");

--- a/src/test/run-pass/multibyte.rs
+++ b/src/test/run-pass/multibyte.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 // Test that multibyte characters don't crash the compiler
-fn main() {
+pub fn main() {
     println("마이너스 사인이 없으면");
 }

--- a/src/test/run-pass/newtype-struct-drop-run.rs
+++ b/src/test/run-pass/newtype-struct-drop-run.rs
@@ -19,7 +19,7 @@ impl Drop for Foo {
     }
 }
 
-fn main() {
+pub fn main() {
     let y = @mut 32;
     {
         let x = Foo(y);

--- a/src/test/run-pass/packed-struct-borrow-element.rs
+++ b/src/test/run-pass/packed-struct-borrow-element.rs
@@ -14,7 +14,7 @@ struct Foo {
     baz: uint
 }
 
-fn main() {
+pub fn main() {
     let foo = Foo { bar: 1, baz: 2 };
     let brw = &foo.baz;
 

--- a/src/test/run-pass/packed-struct-generic-layout.rs
+++ b/src/test/run-pass/packed-struct-generic-layout.rs
@@ -17,7 +17,7 @@ struct S<T, S> {
     c: S
 }
 
-fn main() {
+pub fn main() {
     unsafe {
         let s = S { a: 0xff_ff_ff_ffu32, b: 1, c: 0xaa_aa_aa_aa as i32 };
         let transd : [u8, .. 9] = cast::transmute(s);

--- a/src/test/run-pass/packed-struct-generic-size.rs
+++ b/src/test/run-pass/packed-struct-generic-size.rs
@@ -17,7 +17,7 @@ struct S<T, S> {
     c: S
 }
 
-fn main() {
+pub fn main() {
     assert_eq!(sys::size_of::<S<u8, u8>>(), 3);
 
     assert_eq!(sys::size_of::<S<u64, u16>>(), 11);

--- a/src/test/run-pass/packed-struct-layout.rs
+++ b/src/test/run-pass/packed-struct-layout.rs
@@ -22,7 +22,7 @@ struct S5 {
     b: u32
 }
 
-fn main() {
+pub fn main() {
     unsafe {
         let s4 = S4 { a: 1, b: [2,3,4] };
         let transd : [u8, .. 4] = cast::transmute(s4);

--- a/src/test/run-pass/packed-struct-match.rs
+++ b/src/test/run-pass/packed-struct-match.rs
@@ -14,7 +14,7 @@ struct Foo {
     baz: uint
 }
 
-fn main() {
+pub fn main() {
     let foo = Foo { bar: 1, baz: 2 };
     match foo {
         Foo {bar, baz} => {

--- a/src/test/run-pass/packed-struct-size-xc.rs
+++ b/src/test/run-pass/packed-struct-size-xc.rs
@@ -5,6 +5,6 @@ extern mod packed;
 
 use std::sys;
 
-fn main() {
+pub fn main() {
     assert_eq!(sys::size_of::<packed::S>(), 5);
 }

--- a/src/test/run-pass/packed-struct-size.rs
+++ b/src/test/run-pass/packed-struct-size.rs
@@ -51,7 +51,7 @@ struct S7_Option {
 }
 
 
-fn main() {
+pub fn main() {
     assert_eq!(sys::size_of::<S4>(), 4);
     assert_eq!(sys::size_of::<S5>(), 5);
     assert_eq!(sys::size_of::<S13_str>(), 13 + sys::size_of::<~str>());

--- a/src/test/run-pass/packed-struct-vec.rs
+++ b/src/test/run-pass/packed-struct-vec.rs
@@ -18,7 +18,7 @@ struct Foo {
     baz: u64
 }
 
-fn main() {
+pub fn main() {
     let foos = [Foo { bar: 1, baz: 2 }, .. 10];
 
     assert_eq!(sys::size_of::<[Foo, .. 10]>(), 90);

--- a/src/test/run-pass/packed-tuple-struct-layout.rs
+++ b/src/test/run-pass/packed-tuple-struct-layout.rs
@@ -16,7 +16,7 @@ struct S4(u8,[u8, .. 3]);
 #[packed]
 struct S5(u8,u32);
 
-fn main() {
+pub fn main() {
     unsafe {
         let s4 = S4(1, [2,3,4]);
         let transd : [u8, .. 4] = cast::transmute(s4);

--- a/src/test/run-pass/packed-tuple-struct-size.rs
+++ b/src/test/run-pass/packed-tuple-struct-size.rs
@@ -30,7 +30,7 @@ struct S3_Foo(u8, u16, Foo);
 #[packed]
 struct S7_Option(f32, u8, u16, Option<@mut f64>);
 
-fn main() {
+pub fn main() {
     assert_eq!(sys::size_of::<S4>(), 4);
 
     assert_eq!(sys::size_of::<S5>(), 5);

--- a/src/test/run-pass/pub-extern-privacy.rs
+++ b/src/test/run-pass/pub-extern-privacy.rs
@@ -6,7 +6,7 @@ mod a {
     }
 }
 
-fn main() {
+pub fn main() {
     unsafe {
         a::free(transmute(0));
     }

--- a/src/test/run-pass/region-dependent-autofn.rs
+++ b/src/test/run-pass/region-dependent-autofn.rs
@@ -17,6 +17,6 @@ fn both<'r>(v: &'r fn()) -> &'r fn() {
     subslice(subslice(v))
 }
 
-fn main() {
+pub fn main() {
     both(main);
 }

--- a/src/test/run-pass/region-dependent-autoslice.rs
+++ b/src/test/run-pass/region-dependent-autoslice.rs
@@ -17,7 +17,7 @@ fn both<'r>(v: &'r [uint]) -> &'r [uint] {
     subslice1(subslice1(v))
 }
 
-fn main() {
+pub fn main() {
     let v = ~[1,2,3];
     both(v);
 }

--- a/src/test/run-pass/simd-type.rs
+++ b/src/test/run-pass/simd-type.rs
@@ -6,4 +6,4 @@ struct RGBA {
     a: f32
 }
 
-fn main() {}
+pub fn main() {}

--- a/src/test/run-pass/sized-borrowed-pointer.rs
+++ b/src/test/run-pass/sized-borrowed-pointer.rs
@@ -12,4 +12,4 @@
 
 fn bar<T: Sized>() { }
 fn foo<T>() { bar::<&T>() }
-fn main() { }
+pub fn main() { }

--- a/src/test/run-pass/sized-owned-pointer.rs
+++ b/src/test/run-pass/sized-owned-pointer.rs
@@ -12,4 +12,4 @@
 
 fn bar<T: Sized>() { }
 fn foo<T>() { bar::<~T>() }
-fn main() { }
+pub fn main() { }

--- a/src/test/run-pass/static-assert.rs
+++ b/src/test/run-pass/static-assert.rs
@@ -10,5 +10,5 @@ static d: bool = 1 != 2;
 #[static_assert]
 static f: bool = (4/2) == 2;
 
-fn main() {
+pub fn main() {
 }

--- a/src/test/run-pass/syntax-extension-bytes.rs
+++ b/src/test/run-pass/syntax-extension-bytes.rs
@@ -10,7 +10,7 @@
 
 static static_vec: &'static [u8] = bytes!("abc", 0xFF, '!');
 
-fn main() {
+pub fn main() {
     let vec = bytes!("abc");
     assert_eq!(vec, &[97_u8, 98_u8, 99_u8]);
 

--- a/src/test/run-pass/unconstrained-region.rs
+++ b/src/test/run-pass/unconstrained-region.rs
@@ -17,6 +17,6 @@ fn foo(blk: &fn(p: &'a fn() -> &'a fn())) {
         || { *statep = 1; }
     }
 }
-fn main() {
+pub fn main() {
     do foo |p| { p()() }
 }

--- a/src/test/run-pass/unit-like-struct-drop-run.rs
+++ b/src/test/run-pass/unit-like-struct-drop-run.rs
@@ -21,7 +21,7 @@ impl Drop for Foo {
     }
 }
 
-fn main() {
+pub fn main() {
     let x = do task::try {
         let _b = Foo;
     };


### PR DESCRIPTION
This was a remnant from the export list era.
