### PR TITLE
Makefile.in: simplify logic for CFG_VER_HASH

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -146,8 +146,7 @@ ifneq ($(wildcard $(CFG_GIT)),)
 ifneq ($(wildcard $(CFG_GIT_DIR)),)
     CFG_VERSION += $(shell git --git-dir=$(CFG_GIT_DIR) log -1 \
                      --pretty=format:'(%h %ci)')
-    CFG_VER_HASH = $(shell git --git-dir=$(CFG_GIT_DIR) log -1 \
-                     --pretty=format:'%H')
+    CFG_VER_HASH = $(shell git --git-dir=$(CFG_GIT_DIR) rev-parse HEAD)
 endif
 endif
 


### PR DESCRIPTION
git log -1 --pretty=format:'%H' is a very convoluted way of saying git
rev-parse HEAD.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
