### PR TITLE
.mailmap: tolerate different names, emails in shortlog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,12 @@
+#
+# This list is used by git-shortlog to aggregate contributions.  It is
+# necessary when either the author's full name is not always written
+# the same way, and/or the same author contributes from different
+# email addresses.
+#
+
+Elly Jones <elly@leptoquark.net>
+ILyoan <ilyoan@gmail.com>
+Junyoung Cho <june0.cho@samsung.com>
+Matthijs Hofstra <thiezz@gmail.com>
+Rob Arnold <robarnold@cs.cmu.edu>


### PR DESCRIPTION
Write a conservative .mailmap as an example for contributors to write
their preferred names/ email addresses to.  This patch makes no
assumptions about the same author using different email addresses, and
only collects cases where the full-name of the person is spelt
differently for the same email address.  Verify with:

  $ git shortlog -se | cut -f 2 | cut -d< -f 2 | sort | uniq -d

It only assumes that the author prefers the full-name that appears
dominantly, by number of contributions.

For the purposes of merging, a strictly alphabetical ordering is
advised.  See MAPPING AUTHORS section of git-shortlog(1) to understand
the format of this file.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
