### PR TITLE
Nits in tuple to_str implementation

### DIFF
--- a/src/libstd/to_str.rs
+++ b/src/libstd/to_str.rs
@@ -91,7 +91,7 @@ impl<A:ToStr+Hash+Eq> ToStr for HashSet<A> {
 impl<A:ToStr,B:ToStr> ToStr for (A, B) {
     #[inline(always)]
     fn to_str(&self) -> ~str {
-        // FIXME(#4760): this causes an llvm assertion
+        // FIXME(#4653): this causes an llvm assertion
         //let &(ref a, ref b) = self;
         match *self {
             (ref a, ref b) => {
@@ -104,7 +104,7 @@ impl<A:ToStr,B:ToStr> ToStr for (A, B) {
 impl<A:ToStr,B:ToStr,C:ToStr> ToStr for (A, B, C) {
     #[inline(always)]
     fn to_str(&self) -> ~str {
-        // FIXME(#4760): this causes an llvm assertion
+        // FIXME(#4653): this causes an llvm assertion
         //let &(ref a, ref b, ref c) = self;
         match *self {
             (ref a, ref b, ref c) => {

--- a/src/libstd/to_str.rs
+++ b/src/libstd/to_str.rs
@@ -44,7 +44,7 @@ impl<A:ToStr> ToStr for (A,) {
     fn to_str(&self) -> ~str {
         match *self {
             (ref a,) => {
-                ~"(" + a.to_str() + ",)"
+                fmt!("(%s,)", (*a).to_str())
             }
         }
     }
@@ -95,7 +95,7 @@ impl<A:ToStr,B:ToStr> ToStr for (A, B) {
         //let &(ref a, ref b) = self;
         match *self {
             (ref a, ref b) => {
-                ~"(" + a.to_str() + ", " + b.to_str() + ")"
+                fmt!("(%s, %s)", (*a).to_str(), (*b).to_str())
             }
         }
     }


### PR DESCRIPTION
[1/2] fixes a couple of comments.
[2/2] uses fmt! instead of hand-concatenating strings in a couple of places.

No functional changes.
