### PR TITLE
libc: omit memcpy, memmove and memset

### DIFF
--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -159,8 +159,8 @@ pub use libc::funcs::c95::stdlib::{free, getenv, labs, malloc, rand};
 pub use libc::funcs::c95::stdlib::{realloc, srand, strtod, strtol};
 pub use libc::funcs::c95::stdlib::{strtoul, system};
 
-pub use libc::funcs::c95::string::{memchr, memcmp, memcpy, memmove};
-pub use libc::funcs::c95::string::{memset, strcat, strchr, strcmp};
+pub use libc::funcs::c95::string::{memchr, memcmp};
+pub use libc::funcs::c95::string::{strcat, strchr, strcmp};
 pub use libc::funcs::c95::string::{strcoll, strcpy, strcspn, strerror};
 pub use libc::funcs::c95::string::{strlen, strncat, strncmp, strncpy};
 pub use libc::funcs::c95::string::{strpbrk, strrchr, strspn, strstr};
@@ -1452,16 +1452,10 @@ pub mod funcs {
                                -> size_t;
                 unsafe fn wcslen(buf: *wchar_t) -> size_t;
 
+                // Omitted: memcpy, memmove, memset (provided by LLVM)
+
                 // These are fine to execute on the Rust stack. They must be,
                 // in fact, because LLVM generates calls to them!
-                #[rust_stack]
-                #[inline(always)]
-                unsafe fn memcpy(s: *c_void, ct: *c_void, n: size_t)
-                              -> *c_void;
-                #[rust_stack]
-                #[inline(always)]
-                unsafe fn memmove(s: *c_void, ct: *c_void, n: size_t)
-                               -> *c_void;
                 #[rust_stack]
                 #[inline(always)]
                 unsafe fn memcmp(cx: *c_void, ct: *c_void, n: size_t)
@@ -1469,9 +1463,6 @@ pub mod funcs {
                 #[rust_stack]
                 #[inline(always)]
                 unsafe fn memchr(cx: *c_void, c: c_int, n: size_t) -> *c_void;
-                #[rust_stack]
-                #[inline(always)]
-                unsafe fn memset(s: *c_void, c: c_int, n: size_t) -> *c_void;
             }
         }
     }

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -20,22 +20,6 @@ use unstable::intrinsics;
 #[cfg(not(test))] use cmp::{Eq, Ord};
 use uint;
 
-#[cfg(stage0)]
-pub mod libc_ {
-    use libc::c_void;
-    use libc;
-
-    #[nolink]
-    #[abi = "cdecl"]
-    pub extern {
-        #[rust_stack]
-        unsafe fn memset(dest: *mut c_void,
-                         c: libc::c_int,
-                         len: libc::size_t)
-                      -> *c_void;
-    }
-}
-
 /// Calculate the offset from a pointer
 #[inline(always)]
 pub fn offset<T>(ptr: *T, count: uint) -> *T {
@@ -176,13 +160,6 @@ pub unsafe fn copy_nonoverlapping_memory<T>(dst: *mut T, src: *const T, count: u
 pub unsafe fn copy_nonoverlapping_memory<T>(dst: *mut T, src: *const T, count: uint) {
     use unstable::intrinsics::memcpy64;
     memcpy64(dst, src as *T, count as u64);
-}
-
-#[inline(always)]
-#[cfg(stage0)]
-pub unsafe fn set_memory<T>(dst: *mut T, c: int, count: uint) {
-    let n = count * sys::size_of::<T>();
-    libc_::memset(dst as *mut c_void, c as libc::c_int, n as size_t);
 }
 
 /**
@@ -601,6 +578,7 @@ pub mod ptr_tests {
     }
 
     #[test]
+    #[cfg(not(stage0))]
     fn test_set_memory() {
         let mut xs = [0u8, ..20];
         let ptr = vec::raw::to_mut_ptr(xs);


### PR DESCRIPTION
LLVM provides these functions as intrinsics, and will generate calls to
libc when appropriate. They are exposed in the `ptr` module as
`copy_nonoverlapping_memory`, `copy_memory` and `set_memory`.

@graydon: r?
