### PR TITLE
Provide an actual error when expanding macros to foreign items

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4492,9 +4492,9 @@ impl Parser {
                     self.span_err(view_item.span,
                                   "`use` and `extern mod` declarations must precede items");
                 }
-                iovi_item(_) => {
+                iovi_item(item) => {
                     // FIXME #5668: this will occur for a macro invocation:
-                    fail!();
+                    self.span_fatal(item.span, "macros cannot expand to foreign items");
                 }
                 iovi_foreign_item(foreign_item) => {
                     foreign_items.push(foreign_item);


### PR DESCRIPTION
I encountered this. A straight fail is not useful and most people aren't going to happily spelunk in `parser.rs`
