### PR TITLE
Disallow negative counts in repeat expressions

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4315,23 +4315,30 @@ pub fn normalize_ty(cx: ctxt, t: t) -> t {
 pub fn eval_repeat_count(tcx: ctxt, count_expr: @ast::expr) -> uint {
     match const_eval::eval_const_expr_partial(tcx, count_expr) {
       Ok(ref const_val) => match *const_val {
-        const_eval::const_int(count) => return count as uint,
+        const_eval::const_int(count) => if count < 0 {
+            tcx.sess.span_err(count_expr.span,
+                              "expected positive integer for \
+                               repeat count but found negative integer");
+            return 0;
+        } else {
+            return count as uint
+        },
         const_eval::const_uint(count) => return count as uint,
         const_eval::const_float(count) => {
             tcx.sess.span_err(count_expr.span,
-                              "expected signed or unsigned integer for \
+                              "expected positive integer for \
                                repeat count but found float");
             return count as uint;
         }
         const_eval::const_str(_) => {
             tcx.sess.span_err(count_expr.span,
-                              "expected signed or unsigned integer for \
+                              "expected positive integer for \
                                repeat count but found string");
             return 0;
         }
         const_eval::const_bool(_) => {
             tcx.sess.span_err(count_expr.span,
-                              "expected signed or unsigned integer for \
+                              "expected positive integer for \
                                repeat count but found boolean");
             return 0;
         }

--- a/src/test/compile-fail/issue-6977.rs
+++ b/src/test/compile-fail/issue-6977.rs
@@ -1,0 +1,7 @@
+//xfail-test
+
+// Trying to create a fixed-length vector with a negative size
+
+fn main() {
+      let _x = [0,..-1];
+}


### PR DESCRIPTION
This fixes #6977. Negative counts don't make sense anyway.
