### PR TITLE
Remove unnecessary allocations

### DIFF
--- a/src/libextra/ebml.rs
+++ b/src/libextra/ebml.rs
@@ -93,6 +93,14 @@ pub mod reader {
         pub fn get(&self, tag: uint) -> Doc {
             get_doc(*self, tag)
         }
+
+        pub fn as_str_slice<'a>(&'a self) -> &'a str {
+            str::from_bytes_slice(self.data.slice(self.start, self.end))
+        }
+
+        pub fn as_str(&self) -> ~str {
+            self.as_str_slice().to_owned()
+        }
     }
 
     struct Res {
@@ -239,15 +247,10 @@ pub mod reader {
         return true;
     }
 
-    pub fn doc_data(d: Doc) -> ~[u8] {
-        vec::slice::<u8>(*d.data, d.start, d.end).to_vec()
-    }
-
     pub fn with_doc_data<T>(d: Doc, f: &fn(x: &[u8]) -> T) -> T {
         f(vec::slice(*d.data, d.start, d.end))
     }
 
-    pub fn doc_as_str(d: Doc) -> ~str { str::from_bytes(doc_data(d)) }
 
     pub fn doc_as_u8(d: Doc) -> u8 {
         assert_eq!(d.end, d.start + 1u);
@@ -294,7 +297,7 @@ pub mod reader {
 
                 if r_tag == (EsLabel as uint) {
                     self.pos = r_doc.end;
-                    let str = doc_as_str(r_doc);
+                    let str = r_doc.as_str_slice();
                     if lbl != str {
                         fail!("Expected label %s but found %s", lbl, str);
                     }
@@ -415,7 +418,9 @@ pub mod reader {
         fn read_char(&mut self) -> char {
             doc_as_u32(self.next_doc(EsChar)) as char
         }
-        fn read_str(&mut self) -> ~str { doc_as_str(self.next_doc(EsStr)) }
+        fn read_str(&mut self) -> ~str {
+            self.next_doc(EsStr).as_str()
+        }
 
         // Compound types:
         fn read_enum<T>(&mut self,

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -174,7 +174,7 @@ fn item_symbol(item: ebml::Doc) -> ~str {
 
 fn item_parent_item(d: ebml::Doc) -> Option<ast::def_id> {
     for reader::tagged_docs(d, tag_items_data_parent_item) |did| {
-        return Some(reader::with_doc_data(did, |d| parse_def_id(d)));
+        return Some(reader::with_doc_data(did, parse_def_id));
     }
     None
 }
@@ -195,8 +195,7 @@ fn item_reqd_and_translated_parent_item(cnum: ast::crate_num,
 
 fn item_def_id(d: ebml::Doc, cdata: cmd) -> ast::def_id {
     let tagdoc = reader::get_doc(d, tag_def_id);
-    return translate_def_id(cdata, reader::with_doc_data(tagdoc,
-                                                    |d| parse_def_id(d)));
+    return translate_def_id(cdata, reader::with_doc_data(tagdoc, parse_def_id));
 }
 
 fn each_reexport(d: ebml::Doc, f: &fn(ebml::Doc) -> bool) -> bool {
@@ -282,7 +281,7 @@ fn enum_variant_ids(item: ebml::Doc, cdata: cmd) -> ~[ast::def_id] {
     let mut ids: ~[ast::def_id] = ~[];
     let v = tag_items_data_item_variant;
     for reader::tagged_docs(item, v) |p| {
-        let ext = reader::with_doc_data(p, |d| parse_def_id(d));
+        let ext = reader::with_doc_data(p, parse_def_id);
         ids.push(ast::def_id { crate: cdata.cnum, node: ext.node });
     };
     return ids;
@@ -424,7 +423,7 @@ pub fn get_impl_method(intr: @ident_interner, cdata: cmd, id: ast::node_id,
     let mut found = None;
     for reader::tagged_docs(find_item(id, items), tag_item_impl_method)
         |mid| {
-            let m_did = reader::with_doc_data(mid, |d| parse_def_id(d));
+            let m_did = reader::with_doc_data(mid, parse_def_id);
             if item_name(intr, find_item(m_did.node, items)) == name {
                 found = Some(translate_def_id(cdata, m_did));
             }
@@ -662,7 +661,7 @@ fn item_impl_methods(intr: @ident_interner, cdata: cmd, item: ebml::Doc,
                      base_tps: uint) -> ~[@resolve::MethodInfo] {
     let mut rslt = ~[];
     for reader::tagged_docs(item, tag_item_impl_method) |doc| {
-        let m_did = reader::with_doc_data(doc, |d| parse_def_id(d));
+        let m_did = reader::with_doc_data(doc, parse_def_id);
         let mth_item = lookup_item(m_did.node, cdata.data);
         let explicit_self = get_explicit_self(mth_item);
         rslt.push(@resolve::MethodInfo {
@@ -684,7 +683,7 @@ pub fn get_impls_for_mod(intr: @ident_interner,
     let mod_item = lookup_item(m_id, data);
     let mut result = ~[];
     for reader::tagged_docs(mod_item, tag_mod_impl) |doc| {
-        let did = reader::with_doc_data(doc, |d| parse_def_id(d));
+        let did = reader::with_doc_data(doc, parse_def_id);
         let local_did = translate_def_id(cdata, did);
         debug!("(get impls for mod) getting did %? for '%?'",
                local_did, name);

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -62,17 +62,17 @@ pub struct PState {
     tcx: ty::ctxt
 }
 
-fn peek(st: @mut PState) -> char {
+fn peek(st: &PState) -> char {
     st.data[st.pos] as char
 }
 
-fn next(st: @mut PState) -> char {
+fn next(st: &mut PState) -> char {
     let ch = st.data[st.pos] as char;
     st.pos = st.pos + 1u;
     return ch;
 }
 
-fn next_byte(st: @mut PState) -> u8 {
+fn next_byte(st: &mut PState) -> u8 {
     let b = st.data[st.pos];
     st.pos = st.pos + 1u;
     return b;
@@ -92,20 +92,20 @@ fn scan<R>(st: &mut PState, is_last: &fn(char) -> bool,
     return op(st.data.slice(start_pos, end_pos));
 }
 
-pub fn parse_ident(st: @mut PState, last: char) -> ast::ident {
+pub fn parse_ident(st: &mut PState, last: char) -> ast::ident {
     fn is_last(b: char, c: char) -> bool { return c == b; }
     return parse_ident_(st, |a| is_last(last, a) );
 }
 
-fn parse_ident_(st: @mut PState, is_last: @fn(char) -> bool) ->
+fn parse_ident_(st: &mut PState, is_last: @fn(char) -> bool) ->
    ast::ident {
     let rslt = scan(st, is_last, str::from_bytes);
     return st.tcx.sess.ident_of(rslt);
 }
 
 pub fn parse_state_from_data(data: @~[u8], crate_num: int,
-                             pos: uint, tcx: ty::ctxt) -> @mut PState {
-    @mut PState {
+                             pos: uint, tcx: ty::ctxt) -> PState {
+    PState {
         data: data,
         crate: crate_num,
         pos: pos,
@@ -115,23 +115,23 @@ pub fn parse_state_from_data(data: @~[u8], crate_num: int,
 
 pub fn parse_ty_data(data: @~[u8], crate_num: int, pos: uint, tcx: ty::ctxt,
                      conv: conv_did) -> ty::t {
-    let st = parse_state_from_data(data, crate_num, pos, tcx);
-    parse_ty(st, conv)
+    let mut st = parse_state_from_data(data, crate_num, pos, tcx);
+    parse_ty(&mut st, conv)
 }
 
 pub fn parse_bare_fn_ty_data(data: @~[u8], crate_num: int, pos: uint, tcx: ty::ctxt,
                              conv: conv_did) -> ty::BareFnTy {
-    let st = parse_state_from_data(data, crate_num, pos, tcx);
-    parse_bare_fn_ty(st, conv)
+    let mut st = parse_state_from_data(data, crate_num, pos, tcx);
+    parse_bare_fn_ty(&mut st, conv)
 }
 
 pub fn parse_trait_ref_data(data: @~[u8], crate_num: int, pos: uint, tcx: ty::ctxt,
                             conv: conv_did) -> ty::TraitRef {
-    let st = parse_state_from_data(data, crate_num, pos, tcx);
-    parse_trait_ref(st, conv)
+    let mut st = parse_state_from_data(data, crate_num, pos, tcx);
+    parse_trait_ref(&mut st, conv)
 }
 
-fn parse_path(st: @mut PState) -> @ast::Path {
+fn parse_path(st: &mut PState) -> @ast::Path {
     let mut idents: ~[ast::ident] = ~[];
     fn is_last(c: char) -> bool { return c == '(' || c == ':'; }
     idents.push(parse_ident_(st, is_last));
@@ -151,7 +151,7 @@ fn parse_path(st: @mut PState) -> @ast::Path {
     };
 }
 
-fn parse_sigil(st: @mut PState) -> ast::Sigil {
+fn parse_sigil(st: &mut PState) -> ast::Sigil {
     match next(st) {
         '@' => ast::ManagedSigil,
         '~' => ast::OwnedSigil,
@@ -160,7 +160,7 @@ fn parse_sigil(st: @mut PState) -> ast::Sigil {
     }
 }
 
-fn parse_vstore(st: @mut PState) -> ty::vstore {
+fn parse_vstore(st: &mut PState) -> ty::vstore {
     assert_eq!(next(st), '/');
 
     let c = peek(st);
@@ -178,7 +178,7 @@ fn parse_vstore(st: @mut PState) -> ty::vstore {
     }
 }
 
-fn parse_trait_store(st: @mut PState) -> ty::TraitStore {
+fn parse_trait_store(st: &mut PState) -> ty::TraitStore {
     match next(st) {
         '~' => ty::UniqTraitStore,
         '@' => ty::BoxTraitStore,
@@ -187,10 +187,10 @@ fn parse_trait_store(st: @mut PState) -> ty::TraitStore {
     }
 }
 
-fn parse_substs(st: @mut PState, conv: conv_did) -> ty::substs {
-    let self_r = parse_opt(st, || parse_region(st) );
+fn parse_substs(st: &mut PState, conv: conv_did) -> ty::substs {
+    let self_r = parse_opt(st, |st| parse_region(st) );
 
-    let self_ty = parse_opt(st, || parse_ty(st, conv) );
+    let self_ty = parse_opt(st, |st| parse_ty(st, conv) );
 
     assert_eq!(next(st), '[');
     let mut params: ~[ty::t] = ~[];
@@ -204,7 +204,7 @@ fn parse_substs(st: @mut PState, conv: conv_did) -> ty::substs {
     };
 }
 
-fn parse_bound_region(st: @mut PState) -> ty::bound_region {
+fn parse_bound_region(st: &mut PState) -> ty::bound_region {
     match next(st) {
       's' => ty::br_self,
       'a' => {
@@ -222,7 +222,7 @@ fn parse_bound_region(st: @mut PState) -> ty::bound_region {
     }
 }
 
-fn parse_region(st: @mut PState) -> ty::Region {
+fn parse_region(st: &mut PState) -> ty::Region {
     match next(st) {
       'b' => {
         ty::re_bound(parse_bound_region(st))
@@ -251,15 +251,15 @@ fn parse_region(st: @mut PState) -> ty::Region {
     }
 }
 
-fn parse_opt<T>(st: @mut PState, f: &fn() -> T) -> Option<T> {
+fn parse_opt<T>(st: &mut PState, f: &fn(&mut PState) -> T) -> Option<T> {
     match next(st) {
       'n' => None,
-      's' => Some(f()),
+      's' => Some(f(st)),
       _ => fail!("parse_opt: bad input")
     }
 }
 
-fn parse_str(st: @mut PState, term: char) -> ~str {
+fn parse_str(st: &mut PState, term: char) -> ~str {
     let mut result = ~"";
     while peek(st) != term {
         result += str::from_byte(next_byte(st));
@@ -268,13 +268,13 @@ fn parse_str(st: @mut PState, term: char) -> ~str {
     return result;
 }
 
-fn parse_trait_ref(st: @mut PState, conv: conv_did) -> ty::TraitRef {
+fn parse_trait_ref(st: &mut PState, conv: conv_did) -> ty::TraitRef {
     let def = parse_def(st, NominalType, conv);
     let substs = parse_substs(st, conv);
     ty::TraitRef {def_id: def, substs: substs}
 }
 
-fn parse_ty(st: @mut PState, conv: conv_did) -> ty::t {
+fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
     match next(st) {
       'n' => return ty::mk_nil(),
       'z' => return ty::mk_bot(),
@@ -370,8 +370,8 @@ fn parse_ty(st: @mut PState, conv: conv_did) -> ty::t {
         match st.tcx.rcache.find(&key) {
           Some(&tt) => return tt,
           None => {
-            let ps = @mut PState {pos: pos ,.. copy *st};
-            let tt = parse_ty(ps, conv);
+            let mut ps = PState {pos: pos ,.. copy *st};
+            let tt = parse_ty(&mut ps, conv);
             st.tcx.rcache.insert(key, tt);
             return tt;
           }
@@ -394,7 +394,7 @@ fn parse_ty(st: @mut PState, conv: conv_did) -> ty::t {
     }
 }
 
-fn parse_mutability(st: @mut PState) -> ast::mutability {
+fn parse_mutability(st: &mut PState) -> ast::mutability {
     match peek(st) {
       'm' => { next(st); ast::m_mutbl }
       '?' => { next(st); ast::m_const }
@@ -402,20 +402,17 @@ fn parse_mutability(st: @mut PState) -> ast::mutability {
     }
 }
 
-fn parse_mt(st: @mut PState, conv: conv_did) -> ty::mt {
+fn parse_mt(st: &mut PState, conv: conv_did) -> ty::mt {
     let m = parse_mutability(st);
     ty::mt { ty: parse_ty(st, conv), mutbl: m }
 }
 
-fn parse_def(st: @mut PState, source: DefIdSource,
+fn parse_def(st: &mut PState, source: DefIdSource,
              conv: conv_did) -> ast::def_id {
-    let mut def = ~[];
-    while peek(st) != '|' { def.push(next_byte(st)); }
-    st.pos = st.pos + 1u;
-    return conv(source, parse_def_id(def));
+    return conv(source, scan(st, |c| { c == '|' }, parse_def_id));
 }
 
-fn parse_uint(st: @mut PState) -> uint {
+fn parse_uint(st: &mut PState) -> uint {
     let mut n = 0;
     loop {
         let cur = peek(st);
@@ -426,7 +423,7 @@ fn parse_uint(st: @mut PState) -> uint {
     };
 }
 
-fn parse_hex(st: @mut PState) -> uint {
+fn parse_hex(st: &mut PState) -> uint {
     let mut n = 0u;
     loop {
         let cur = peek(st);
@@ -449,7 +446,7 @@ fn parse_purity(c: char) -> purity {
     }
 }
 
-fn parse_abi_set(st: @mut PState) -> AbiSet {
+fn parse_abi_set(st: &mut PState) -> AbiSet {
     assert_eq!(next(st), '[');
     let mut abis = AbiSet::empty();
     while peek(st) != ']' {
@@ -470,7 +467,7 @@ fn parse_onceness(c: char) -> ast::Onceness {
     }
 }
 
-fn parse_closure_ty(st: @mut PState, conv: conv_did) -> ty::ClosureTy {
+fn parse_closure_ty(st: &mut PState, conv: conv_did) -> ty::ClosureTy {
     let sigil = parse_sigil(st);
     let purity = parse_purity(next(st));
     let onceness = parse_onceness(next(st));
@@ -487,7 +484,7 @@ fn parse_closure_ty(st: @mut PState, conv: conv_did) -> ty::ClosureTy {
     }
 }
 
-fn parse_bare_fn_ty(st: @mut PState, conv: conv_did) -> ty::BareFnTy {
+fn parse_bare_fn_ty(st: &mut PState, conv: conv_did) -> ty::BareFnTy {
     let purity = parse_purity(next(st));
     let abi = parse_abi_set(st);
     let sig = parse_sig(st, conv);
@@ -498,7 +495,7 @@ fn parse_bare_fn_ty(st: @mut PState, conv: conv_did) -> ty::BareFnTy {
     }
 }
 
-fn parse_sig(st: @mut PState, conv: conv_did) -> ty::FnSig {
+fn parse_sig(st: &mut PState, conv: conv_did) -> ty::FnSig {
     assert_eq!(next(st), '[');
     let mut inputs = ~[];
     while peek(st) != ']' {
@@ -541,16 +538,16 @@ pub fn parse_type_param_def_data(data: @~[u8], start: uint,
                                  crate_num: int, tcx: ty::ctxt,
                                  conv: conv_did) -> ty::TypeParameterDef
 {
-    let st = parse_state_from_data(data, crate_num, start, tcx);
-    parse_type_param_def(st, conv)
+    let mut st = parse_state_from_data(data, crate_num, start, tcx);
+    parse_type_param_def(&mut st, conv)
 }
 
-fn parse_type_param_def(st: @mut PState, conv: conv_did) -> ty::TypeParameterDef {
+fn parse_type_param_def(st: &mut PState, conv: conv_did) -> ty::TypeParameterDef {
     ty::TypeParameterDef {def_id: parse_def(st, NominalType, conv),
                           bounds: @parse_bounds(st, conv)}
 }
 
-fn parse_bounds(st: @mut PState, conv: conv_did) -> ty::ParamBounds {
+fn parse_bounds(st: &mut PState, conv: conv_did) -> ty::ParamBounds {
     let mut param_bounds = ty::ParamBounds {
         builtin_bounds: ty::EmptyBuiltinBounds(),
         trait_bounds: ~[]

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -55,8 +55,8 @@ pub enum DefIdSource {
 type conv_did<'self> =
     &'self fn(source: DefIdSource, ast::def_id) -> ast::def_id;
 
-pub struct PState {
-    data: @~[u8],
+pub struct PState<'self> {
+    data: &'self [u8],
     crate: int,
     pos: uint,
     tcx: ty::ctxt
@@ -103,8 +103,8 @@ fn parse_ident_(st: &mut PState, is_last: @fn(char) -> bool) ->
     return st.tcx.sess.ident_of(rslt);
 }
 
-pub fn parse_state_from_data(data: @~[u8], crate_num: int,
-                             pos: uint, tcx: ty::ctxt) -> PState {
+pub fn parse_state_from_data<'a>(data: &'a [u8], crate_num: int,
+                             pos: uint, tcx: ty::ctxt) -> PState<'a> {
     PState {
         data: data,
         crate: crate_num,
@@ -113,19 +113,19 @@ pub fn parse_state_from_data(data: @~[u8], crate_num: int,
     }
 }
 
-pub fn parse_ty_data(data: @~[u8], crate_num: int, pos: uint, tcx: ty::ctxt,
+pub fn parse_ty_data(data: &[u8], crate_num: int, pos: uint, tcx: ty::ctxt,
                      conv: conv_did) -> ty::t {
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_ty(&mut st, conv)
 }
 
-pub fn parse_bare_fn_ty_data(data: @~[u8], crate_num: int, pos: uint, tcx: ty::ctxt,
+pub fn parse_bare_fn_ty_data(data: &[u8], crate_num: int, pos: uint, tcx: ty::ctxt,
                              conv: conv_did) -> ty::BareFnTy {
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_bare_fn_ty(&mut st, conv)
 }
 
-pub fn parse_trait_ref_data(data: @~[u8], crate_num: int, pos: uint, tcx: ty::ctxt,
+pub fn parse_trait_ref_data(data: &[u8], crate_num: int, pos: uint, tcx: ty::ctxt,
                             conv: conv_did) -> ty::TraitRef {
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_trait_ref(&mut st, conv)
@@ -534,7 +534,7 @@ pub fn parse_def_id(buf: &[u8]) -> ast::def_id {
     ast::def_id { crate: crate_num, node: def_num }
 }
 
-pub fn parse_type_param_def_data(data: @~[u8], start: uint,
+pub fn parse_type_param_def_data(data: &[u8], start: uint,
                                  crate_num: int, tcx: ty::ctxt,
                                  conv: conv_did) -> ty::TypeParameterDef
 {

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -964,7 +964,7 @@ impl ebml_decoder_decoder_helpers for reader::Decoder {
 
         return do self.read_opaque |this, doc| {
             let ty = tydecode::parse_ty_data(
-                doc.data,
+                *doc.data,
                 xcx.dcx.cdata.cnum,
                 doc.start,
                 xcx.dcx.tcx,
@@ -994,7 +994,7 @@ impl ebml_decoder_decoder_helpers for reader::Decoder {
                            -> ty::TypeParameterDef {
         do self.read_opaque |this, doc| {
             tydecode::parse_type_param_def_data(
-                doc.data,
+                *doc.data,
                 doc.start,
                 xcx.dcx.cdata.cnum,
                 xcx.dcx.tcx,

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -434,12 +434,12 @@ pub fn super_fn_sigs<C:Combine>(
 pub fn super_tys<C:Combine>(
     this: &C, a: ty::t, b: ty::t) -> cres<ty::t> {
     let tcx = this.infcx().tcx;
-    return match (/*bad*/copy ty::get(a).sty, /*bad*/copy ty::get(b).sty) {
+    return match (&ty::get(a).sty, &ty::get(b).sty) {
       // The "subtype" ought to be handling cases involving bot or var:
-      (ty::ty_bot, _) |
-      (_, ty::ty_bot) |
-      (ty::ty_infer(TyVar(_)), _) |
-      (_, ty::ty_infer(TyVar(_))) => {
+      (&ty::ty_bot, _) |
+      (_, &ty::ty_bot) |
+      (&ty::ty_infer(TyVar(_)), _) |
+      (_, &ty::ty_infer(TyVar(_))) => {
         tcx.sess.bug(
             fmt!("%s: bot and var types should have been handled (%s,%s)",
                  this.tag(),
@@ -448,46 +448,46 @@ pub fn super_tys<C:Combine>(
       }
 
         // Relate integral variables to other types
-        (ty::ty_infer(IntVar(a_id)), ty::ty_infer(IntVar(b_id))) => {
+        (&ty::ty_infer(IntVar(a_id)), &ty::ty_infer(IntVar(b_id))) => {
             if_ok!(this.infcx().simple_vars(this.a_is_expected(),
                                             a_id, b_id));
             Ok(a)
         }
-        (ty::ty_infer(IntVar(v_id)), ty::ty_int(v)) => {
+        (&ty::ty_infer(IntVar(v_id)), &ty::ty_int(v)) => {
             unify_integral_variable(this, this.a_is_expected(),
                                     v_id, IntType(v))
         }
-        (ty::ty_int(v), ty::ty_infer(IntVar(v_id))) => {
+        (&ty::ty_int(v), &ty::ty_infer(IntVar(v_id))) => {
             unify_integral_variable(this, !this.a_is_expected(),
                                     v_id, IntType(v))
         }
-        (ty::ty_infer(IntVar(v_id)), ty::ty_uint(v)) => {
+        (&ty::ty_infer(IntVar(v_id)), &ty::ty_uint(v)) => {
             unify_integral_variable(this, this.a_is_expected(),
                                     v_id, UintType(v))
         }
-        (ty::ty_uint(v), ty::ty_infer(IntVar(v_id))) => {
+        (&ty::ty_uint(v), &ty::ty_infer(IntVar(v_id))) => {
             unify_integral_variable(this, !this.a_is_expected(),
                                     v_id, UintType(v))
         }
 
         // Relate floating-point variables to other types
-        (ty::ty_infer(FloatVar(a_id)), ty::ty_infer(FloatVar(b_id))) => {
+        (&ty::ty_infer(FloatVar(a_id)), &ty::ty_infer(FloatVar(b_id))) => {
             if_ok!(this.infcx().simple_vars(this.a_is_expected(),
                                             a_id, b_id));
             Ok(a)
         }
-        (ty::ty_infer(FloatVar(v_id)), ty::ty_float(v)) => {
+        (&ty::ty_infer(FloatVar(v_id)), &ty::ty_float(v)) => {
             unify_float_variable(this, this.a_is_expected(), v_id, v)
         }
-        (ty::ty_float(v), ty::ty_infer(FloatVar(v_id))) => {
+        (&ty::ty_float(v), &ty::ty_infer(FloatVar(v_id))) => {
             unify_float_variable(this, !this.a_is_expected(), v_id, v)
         }
 
-      (ty::ty_nil, _) |
-      (ty::ty_bool, _) |
-      (ty::ty_int(_), _) |
-      (ty::ty_uint(_), _) |
-      (ty::ty_float(_), _) => {
+      (&ty::ty_nil, _) |
+      (&ty::ty_bool, _) |
+      (&ty::ty_int(_), _) |
+      (&ty::ty_uint(_), _) |
+      (&ty::ty_float(_), _) => {
         if ty::get(a).sty == ty::get(b).sty {
             Ok(a)
         } else {
@@ -495,12 +495,12 @@ pub fn super_tys<C:Combine>(
         }
       }
 
-      (ty::ty_param(ref a_p), ty::ty_param(ref b_p)) if a_p.idx == b_p.idx => {
+      (&ty::ty_param(ref a_p), &ty::ty_param(ref b_p)) if a_p.idx == b_p.idx => {
         Ok(a)
       }
 
-      (ty::ty_enum(a_id, ref a_substs),
-       ty::ty_enum(b_id, ref b_substs))
+      (&ty::ty_enum(a_id, ref a_substs),
+       &ty::ty_enum(b_id, ref b_substs))
       if a_id == b_id => {
           let type_def = ty::lookup_item_type(tcx, a_id);
           do this.substs(&type_def.generics, a_substs, b_substs).chain |substs| {
@@ -508,8 +508,8 @@ pub fn super_tys<C:Combine>(
           }
       }
 
-      (ty::ty_trait(a_id, ref a_substs, a_store, a_mutbl),
-       ty::ty_trait(b_id, ref b_substs, b_store, b_mutbl))
+      (&ty::ty_trait(a_id, ref a_substs, a_store, a_mutbl),
+       &ty::ty_trait(b_id, ref b_substs, b_store, b_mutbl))
       if a_id == b_id && a_mutbl == b_mutbl => {
           let trait_def = ty::lookup_trait_def(tcx, a_id);
           do this.substs(&trait_def.generics, a_substs, b_substs).chain |substs| {
@@ -519,7 +519,7 @@ pub fn super_tys<C:Combine>(
           }
       }
 
-      (ty::ty_struct(a_id, ref a_substs), ty::ty_struct(b_id, ref b_substs))
+      (&ty::ty_struct(a_id, ref a_substs), &ty::ty_struct(b_id, ref b_substs))
       if a_id == b_id => {
           let type_def = ty::lookup_item_type(tcx, a_id);
           do this.substs(&type_def.generics, a_substs, b_substs).chain |substs| {
@@ -527,31 +527,31 @@ pub fn super_tys<C:Combine>(
           }
       }
 
-      (ty::ty_box(ref a_mt), ty::ty_box(ref b_mt)) => {
+      (&ty::ty_box(ref a_mt), &ty::ty_box(ref b_mt)) => {
         do this.mts(a_mt, b_mt).chain |mt| {
             Ok(ty::mk_box(tcx, mt))
         }
       }
 
-      (ty::ty_uniq(ref a_mt), ty::ty_uniq(ref b_mt)) => {
+      (&ty::ty_uniq(ref a_mt), &ty::ty_uniq(ref b_mt)) => {
         do this.mts(a_mt, b_mt).chain |mt| {
             Ok(ty::mk_uniq(tcx, mt))
         }
       }
 
-      (ty::ty_ptr(ref a_mt), ty::ty_ptr(ref b_mt)) => {
+      (&ty::ty_ptr(ref a_mt), &ty::ty_ptr(ref b_mt)) => {
         do this.mts(a_mt, b_mt).chain |mt| {
             Ok(ty::mk_ptr(tcx, mt))
         }
       }
 
-      (ty::ty_rptr(a_r, ref a_mt), ty::ty_rptr(b_r, ref b_mt)) => {
+      (&ty::ty_rptr(a_r, ref a_mt), &ty::ty_rptr(b_r, ref b_mt)) => {
           let r = if_ok!(this.contraregions(a_r, b_r));
           let mt = if_ok!(this.mts(a_mt, b_mt));
           Ok(ty::mk_rptr(tcx, r, mt))
       }
 
-      (ty::ty_evec(ref a_mt, vs_a), ty::ty_evec(ref b_mt, vs_b)) => {
+      (&ty::ty_evec(ref a_mt, vs_a), &ty::ty_evec(ref b_mt, vs_b)) => {
         do this.mts(a_mt, b_mt).chain |mt| {
             do this.vstores(ty::terr_vec, vs_a, vs_b).chain |vs| {
                 Ok(ty::mk_evec(tcx, mt, vs))
@@ -559,13 +559,13 @@ pub fn super_tys<C:Combine>(
         }
       }
 
-      (ty::ty_estr(vs_a), ty::ty_estr(vs_b)) => {
+      (&ty::ty_estr(vs_a), &ty::ty_estr(vs_b)) => {
         do this.vstores(ty::terr_str, vs_a, vs_b).chain |vs| {
             Ok(ty::mk_estr(tcx,vs))
         }
       }
 
-      (ty::ty_tup(ref as_), ty::ty_tup(ref bs)) => {
+      (&ty::ty_tup(ref as_), &ty::ty_tup(ref bs)) => {
         if as_.len() == bs.len() {
             map_vec2(*as_, *bs, |a, b| this.tys(*a, *b) )
                 .chain(|ts| Ok(ty::mk_tup(tcx, ts)) )
@@ -575,13 +575,13 @@ pub fn super_tys<C:Combine>(
         }
       }
 
-      (ty::ty_bare_fn(ref a_fty), ty::ty_bare_fn(ref b_fty)) => {
+      (&ty::ty_bare_fn(ref a_fty), &ty::ty_bare_fn(ref b_fty)) => {
         do this.bare_fn_tys(a_fty, b_fty).chain |fty| {
             Ok(ty::mk_bare_fn(tcx, fty))
         }
       }
 
-      (ty::ty_closure(ref a_fty), ty::ty_closure(ref b_fty)) => {
+      (&ty::ty_closure(ref a_fty), &ty::ty_closure(ref b_fty)) => {
         do this.closure_tys(a_fty, b_fty).chain |fty| {
             Ok(ty::mk_closure(tcx, fty))
         }

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -347,7 +347,7 @@ pub fn gather_comments_and_literals(span_diagnostic:
         }
 
 
-        let bstart = rdr.pos;
+        let bstart = rdr.last_pos;
         rdr.next_token();
         //discard, and look ahead; we're working with internal state
         let TokenAndSpan {tok: tok, sp: sp} = rdr.peek();

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -13,7 +13,7 @@ use core::prelude::*;
 use ast;
 use codemap::{BytePos, CharPos, CodeMap, Pos};
 use diagnostic;
-use parse::lexer::{is_whitespace, get_str_from, reader};
+use parse::lexer::{is_whitespace, with_str_from, reader};
 use parse::lexer::{StringReader, bump, is_eof, nextch, TokenAndSpan};
 use parse::lexer::{is_line_non_doc_comment, is_block_non_doc_comment};
 use parse::lexer;
@@ -352,9 +352,10 @@ pub fn gather_comments_and_literals(span_diagnostic:
         //discard, and look ahead; we're working with internal state
         let TokenAndSpan {tok: tok, sp: sp} = rdr.peek();
         if token::is_lit(&tok) {
-            let s = get_str_from(rdr, bstart);
-            debug!("tok lit: %s", s);
-            literals.push(lit {lit: s, pos: sp.lo});
+            do with_str_from(rdr, bstart) |s| {
+                debug!("tok lit: %s", s);
+                literals.push(lit {lit: s.to_owned(), pos: sp.lo});
+            }
         } else {
             debug!("tok: %s", token::to_str(get_ident_interner(), &tok));
         }

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -165,9 +165,10 @@ fn byte_offset(rdr: &StringReader, pos: BytePos) -> BytePos {
     (pos - rdr.filemap.start_pos)
 }
 
-pub fn get_str_from(rdr: @mut StringReader, start: BytePos) -> ~str {
-    return str::slice(*rdr.src, start.to_uint(),
-                      byte_offset(rdr, rdr.last_pos).to_uint()).to_owned();
+pub fn with_str_from<T>(rdr: @mut StringReader, start: BytePos, f: &fn(s: &str) -> T) -> T {
+    f(rdr.src.slice(
+            byte_offset(rdr, start).to_uint(),
+            byte_offset(rdr, rdr.last_pos).to_uint()))
 }
 
 // EFFECT: advance the StringReader by one character. If a newline is
@@ -259,18 +260,24 @@ fn consume_any_line_comment(rdr: @mut StringReader)
             bump(rdr);
             // line comments starting with "///" or "//!" are doc-comments
             if rdr.curr == '/' || rdr.curr == '!' {
-                let start_bpos = rdr.pos - BytePos(2u);
-                let mut acc = ~"//";
+                let start_bpos = rdr.pos - BytePos(3u);
                 while rdr.curr != '\n' && !is_eof(rdr) {
-                    str::push_char(&mut acc, rdr.curr);
                     bump(rdr);
                 }
-                // but comments with only more "/"s are not
-                if !is_line_non_doc_comment(acc) {
-                    return Some(TokenAndSpan{
-                        tok: token::DOC_COMMENT(str_to_ident(acc)),
-                        sp: codemap::mk_sp(start_bpos, rdr.pos)
-                    });
+                let ret = do with_str_from(rdr, start_bpos) |string| {
+                    // but comments with only more "/"s are not
+                    if !is_line_non_doc_comment(string) {
+                        Some(TokenAndSpan{
+                            tok: token::DOC_COMMENT(str_to_ident(string)),
+                            sp: codemap::mk_sp(start_bpos, rdr.pos)
+                        })
+                    } else {
+                        None
+                    }
+                };
+
+                if ret.is_some() {
+                    return ret;
                 }
             } else {
                 while rdr.curr != '\n' && !is_eof(rdr) { bump(rdr); }
@@ -306,25 +313,26 @@ pub fn is_block_non_doc_comment(s: &str) -> bool {
 fn consume_block_comment(rdr: @mut StringReader)
                       -> Option<TokenAndSpan> {
     // block comments starting with "/**" or "/*!" are doc-comments
-    if rdr.curr == '*' || rdr.curr == '!' {
-        let start_bpos = rdr.pos - BytePos(2u);
-        let mut acc = ~"/*";
+    let res = if rdr.curr == '*' || rdr.curr == '!' {
+        let start_bpos = rdr.pos - BytePos(3u);
         while !(rdr.curr == '*' && nextch(rdr) == '/') && !is_eof(rdr) {
-            str::push_char(&mut acc, rdr.curr);
             bump(rdr);
         }
         if is_eof(rdr) {
             rdr.fatal(~"unterminated block doc-comment");
         } else {
-            acc += "*/";
             bump(rdr);
             bump(rdr);
-            // but comments with only "*"s between two "/"s are not
-            if !is_block_non_doc_comment(acc) {
-                return Some(TokenAndSpan{
-                    tok: token::DOC_COMMENT(str_to_ident(acc)),
-                    sp: codemap::mk_sp(start_bpos, rdr.pos)
-                });
+            do with_str_from(rdr, start_bpos) |string| {
+                // but comments with only "*"s between two "/"s are not
+                if !is_block_non_doc_comment(string) {
+                    Some(TokenAndSpan{
+                         tok: token::DOC_COMMENT(str_to_ident(string)),
+                         sp: codemap::mk_sp(start_bpos, rdr.pos)
+                         })
+                } else {
+                    None
+                }
             }
         }
     } else {
@@ -338,10 +346,11 @@ fn consume_block_comment(rdr: @mut StringReader)
                 bump(rdr);
             }
         }
-    }
+        None
+    };
     // restart whitespace munch.
 
-    return consume_whitespace_and_comments(rdr);
+   if res.is_some() { res } else { consume_whitespace_and_comments(rdr) }
 }
 
 fn scan_exponent(rdr: @mut StringReader) -> Option<~str> {
@@ -540,17 +549,21 @@ fn ident_continue(c: char) -> bool {
 fn next_token_inner(rdr: @mut StringReader) -> token::Token {
     let mut c = rdr.curr;
     if ident_start(c) {
-        let start = byte_offset(rdr, rdr.last_pos);
+        let start = rdr.last_pos;
         while ident_continue(rdr.curr) {
             bump(rdr);
         }
-        let string = get_str_from(rdr, start);
 
-        if "_" == string { return token::UNDERSCORE; }
-        let is_mod_name = rdr.curr == ':' && nextch(rdr) == ':';
+        return do with_str_from(rdr, start) |string| {
+            if string == "_" {
+                token::UNDERSCORE
+            } else {
+                let is_mod_name = rdr.curr == ':' && nextch(rdr) == ':';
 
-        // FIXME: perform NFKC normalization here. (Issue #2253)
-        return token::IDENT(str_to_ident(string), is_mod_name);
+                // FIXME: perform NFKC normalization here. (Issue #2253)
+                token::IDENT(str_to_ident(string), is_mod_name)
+            }
+        }
     }
     if is_dec_digit(c) {
         return scan_number(c, rdr);
@@ -648,19 +661,19 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
       '\'' => {
         // Either a character constant 'a' OR a lifetime name 'abc
         bump(rdr);
+        let start = rdr.last_pos;
         let mut c2 = rdr.curr;
         bump(rdr);
 
         // If the character is an ident start not followed by another single
         // quote, then this is a lifetime name:
         if ident_start(c2) && rdr.curr != '\'' {
-            let mut lifetime_name = ~"";
-            lifetime_name.push_char(c2);
             while ident_continue(rdr.curr) {
-                lifetime_name.push_char(rdr.curr);
                 bump(rdr);
             }
-            return token::LIFETIME(str_to_ident(lifetime_name));
+            return do with_str_from(rdr, start) |lifetime_name| {
+                token::LIFETIME(str_to_ident(lifetime_name))
+            }
         }
 
         // Otherwise it is a character constant:
@@ -691,12 +704,13 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
       }
       '"' => {
         let mut accum_str = ~"";
-        let n = byte_offset(rdr, rdr.last_pos);
+        let n = rdr.last_pos;
         bump(rdr);
         while rdr.curr != '"' {
             if is_eof(rdr) {
-                rdr.fatal(fmt!("unterminated double quote string: %s",
-                               get_str_from(rdr, n)));
+                do with_str_from(rdr, n) |s| {
+                    rdr.fatal(fmt!("unterminated double quote string: %s", s));
+                }
             }
 
             let ch = rdr.curr;


### PR DESCRIPTION
This removes some unnecessary allocations in the lexer, the typechecker and the metadata decoder. Reduces the time spent in the parsing and typechecking passes by about 10% for me.
