### PR TITLE
Lexer: Fix offset handling in get_str_from()

### DIFF
--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -347,7 +347,7 @@ pub fn gather_comments_and_literals(span_diagnostic:
         }
 
 
-        let bstart = rdr.pos;
+        let bstart = rdr.last_pos;
         rdr.next_token();
         //discard, and look ahead; we're working with internal state
         let TokenAndSpan {tok: tok, sp: sp} = rdr.peek();


### PR DESCRIPTION
As the comment said, the subtraction is bogus for multibyte characters.
Fortunately, we can just use last_pos instead of pos to get the correct
position without any subtraction hackery.
