### PR TITLE
pass correct flags to jemalloc for cross-compiling

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -211,7 +211,8 @@ $$(LIBUV_LIB_$(1)_$(2)): $$(LIBUV_DEPS)
 endif
 
 $$(JEMALLOC_LIB_$(1)_$(2)):
-	cd $$(CFG_BUILD_DIR)/rt/$(1)/stage$(2)/jemalloc; $(S)src/rt/jemalloc/configure --disable-experimental
+	cd $$(CFG_BUILD_DIR)/rt/$(1)/stage$(2)/jemalloc; $(S)src/rt/jemalloc/configure \
+		--disable-experimental --build=$(CFG_BUILD_TRIPLE) --host=$(1)
 	$$(Q)$$(MAKE) -C $$(CFG_BUILD_DIR)/rt/$(1)/stage$(2)/jemalloc
 
 # These could go in rt.mk or rustllvm.mk, they're needed for both.


### PR DESCRIPTION
It's still broken because `jemalloc`'s `configure` script doesn't work when the build triple doesn't match the target triple due to missing a way to get the page size. I'm not entirely sure how to pass a hardcoded value to autoconf/configure.

This at least gets it a bit further along.
