### PR TITLE
Fix #7017, add test

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4043,7 +4043,7 @@ pub fn has_attr(tcx: ctxt, did: def_id, attr: &str) -> bool {
     } else {
         let mut ret = false;
         do csearch::get_item_attrs(tcx.cstore, did) |meta_items| {
-            ret = attr::contains_name(meta_items, attr);
+            ret = ret || attr::contains_name(meta_items, attr);
         }
         ret
     }

--- a/src/test/compile-fail/rcmut-not-const-and-not-owned.rs
+++ b/src/test/compile-fail/rcmut-not-const-and-not-owned.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern mod extra;
+
+fn o<T: Owned>(_: &T) {}
+fn c<T: Const>(_: &T) {}
+
+fn main() {
+    let x = extra::rc::rc_mut_from_owned(0);
+    o(&x); //~ ERROR instantiating a type parameter with an incompatible type `extra::rc::RcMut<int>`, which does not fulfill `Owned`
+    c(&x); //~ ERROR instantiating a type parameter with an incompatible type `extra::rc::RcMut<int>`, which does not fulfill `Const`
+}


### PR DESCRIPTION
Minimally fixes #7017, we were overwriting the result and thus ignoring attributes before the last.

csearch::get_item_attrs and decoder::get_item_attrs should probably also be changed to each_item_attrs using the for protocol, but that's just a minor performance/style issue.
