### PR TITLE
Fix #7013 by treating owned closures and traits as non-Const

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1940,7 +1940,7 @@ pub impl TypeContents {
     }
 
     fn nonconst(_cx: ctxt) -> TypeContents {
-        TC_MUTABLE
+        TC_MUTABLE + TC_OWNED_CLOSURE
     }
 
     fn moves_by_default(&self, cx: ctxt) -> bool {

--- a/src/test/compile-fail/owned-trait-not-const.rs
+++ b/src/test/compile-fail/owned-trait-not-const.rs
@@ -1,0 +1,23 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern mod std;
+
+pub trait Foo
+{
+}
+
+fn c<T: Const>(_: T) {}
+
+fn test(a: ~Foo) {
+    c(a); //~ ERROR instantiating a type parameter with an incompatible type `~Foo`, which does not fulfill `Const`
+}
+
+fn main() { }


### PR DESCRIPTION
Fix #7013: the idea is that they can include arbitrary types, which may not be Const.

I'm not totally sure this is conceptually correct and catches all cases, please check.
