### PR TITLE
Removing internal iterators, part 3

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -802,20 +802,15 @@ Use declarations support a number of convenient shortcuts:
 An example of `use` declarations:
 
 ~~~~
-use std::float::sin;
-use std::str::{from_chars, contains};
+use std::float::{sin, pow};
 use std::option::Some;
 
 fn main() {
-    // Equivalent to 'info!(std::float::sin(1.0));'
-    info!(sin(1.0));
+    // Equivalent to 'info!(std::float::pow(std::float::sin(1.0), 2.0));'
+    info!(pow(sin(1.0), 2.0));
 
     // Equivalent to 'info!(std::option::Some(1.0));'
     info!(Some(1.0));
-
-    // Equivalent to
-    // 'info!(std::str::contains(std::str::from_chars(&['f','o','o']), "oo"));'
-    info!(contains(from_chars(&['f','o','o']), "oo"));
 }
 ~~~~
 

--- a/doc/rust.md
+++ b/doc/rust.md
@@ -802,15 +802,15 @@ Use declarations support a number of convenient shortcuts:
 An example of `use` declarations:
 
 ~~~~
-use std::float::{sin, pow};
-use std::option::Some;
+use std::float::sin;
+use std::option::{Some, None};
 
 fn main() {
-    // Equivalent to 'info!(std::float::pow(std::float::sin(1.0), 2.0));'
-    info!(pow(sin(1.0), 2.0));
+    // Equivalent to 'info!(std::float::sin(1.0));'
+    info!(sin(1.0));
 
-    // Equivalent to 'info!(std::option::Some(1.0));'
-    info!(Some(1.0));
+    // Equivalent to 'info!(~[std::option::Some(1.0), std::option::None]);'
+    info!(~[Some(1.0), None]);
 }
 ~~~~
 

--- a/doc/rust.md
+++ b/doc/rust.md
@@ -803,7 +803,7 @@ An example of `use` declarations:
 
 ~~~~
 use std::float::sin;
-use std::str::{slice, contains};
+use std::str::{from_chars, contains};
 use std::option::Some;
 
 fn main() {
@@ -814,8 +814,8 @@ fn main() {
     info!(Some(1.0));
 
     // Equivalent to
-    // 'info!(std::str::contains(std::str::slice("foo", 0, 1), "oo"));'
-    info!(contains(slice("foo", 0, 1), "oo"));
+    // 'info!(std::str::contains(std::str::from_chars(&['f','o','o']), "oo"));'
+    info!(contains(from_chars(&['f','o','o']), "oo"));
 }
 ~~~~
 

--- a/src/compiletest/compiletest.rc
+++ b/src/compiletest/compiletest.rc
@@ -231,11 +231,11 @@ pub fn is_test(config: &config, testfile: &Path) -> bool {
     let mut valid = false;
 
     for valid_extensions.each |ext| {
-        if str::ends_with(name, *ext) { valid = true; }
+        if name.ends_with(*ext) { valid = true; }
     }
 
     for invalid_prefixes.each |pre| {
-        if str::starts_with(name, *pre) { valid = false; }
+        if name.starts_with(*pre) { valid = false; }
     }
 
     return valid;

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -11,7 +11,6 @@
 use core::prelude::*;
 
 use core::io;
-use core::str;
 
 pub struct ExpectedError { line: uint, kind: ~str, msg: ~str }
 

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -31,7 +31,7 @@ pub fn load_errors(testfile: &Path) -> ~[ExpectedError] {
 fn parse_expected(line_num: uint, line: ~str) -> ~[ExpectedError] {
     let error_tag = ~"//~";
     let mut idx;
-    match str::find_str(line, error_tag) {
+    match line.find_str(error_tag) {
       None => return ~[],
       Some(nn) => { idx = (nn as uint) + error_tag.len(); }
     }

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -33,13 +33,13 @@ fn parse_expected(line_num: uint, line: ~str) -> ~[ExpectedError] {
     let mut idx;
     match str::find_str(line, error_tag) {
       None => return ~[],
-      Some(nn) => { idx = (nn as uint) + str::len(error_tag); }
+      Some(nn) => { idx = (nn as uint) + error_tag.len(); }
     }
 
     // "//~^^^ kind msg" denotes a message expected
     // three lines above current line:
     let mut adjust_line = 0u;
-    let len = str::len(line);
+    let len = line.len();
     while idx < len && line[idx] == ('^' as u8) {
         adjust_line += 1u;
         idx += 1u;
@@ -52,12 +52,12 @@ fn parse_expected(line_num: uint, line: ~str) -> ~[ExpectedError] {
 
     // FIXME: #4318 Instead of to_ascii and to_str_ascii, could use
     // to_ascii_consume and to_str_consume to not do a unnecessary copy.
-    let kind = str::slice(line, start_kind, idx);
+    let kind = line.slice(start_kind, idx);
     let kind = kind.to_ascii().to_lower().to_str_ascii();
 
     // Extract msg:
     while idx < len && line[idx] == (' ' as u8) { idx += 1u; }
-    let msg = str::slice(line, idx, len).to_owned();
+    let msg = line.slice(idx, len).to_owned();
 
     debug!("line=%u kind=%s msg=%s", line_num - adjust_line, kind, msg);
 

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -177,8 +177,8 @@ fn parse_name_value_directive(line: &str,
     let keycolon = directive + ":";
     match str::find_str(line, keycolon) {
         Some(colon) => {
-            let value = str::slice(line, colon + str::len(keycolon),
-                                   str::len(line)).to_owned();
+            let value = line.slice(colon + keycolon.len(),
+                                   line.len()).to_owned();
             debug!("%s: %s", directive,  value);
             Some(value)
         }

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -13,6 +13,7 @@ use core::prelude::*;
 use common::config;
 use common;
 
+use core::iterator::IteratorUtil;
 use core::io;
 use core::os;
 use core::str;

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -112,7 +112,7 @@ fn iter_header(testfile: &Path, it: &fn(~str) -> bool) -> bool {
         // Assume that any directives will be found before the first
         // module or function. This doesn't seem to be an optimization
         // with a warm page cache. Maybe with a cold one.
-        if str::starts_with(ln, "fn") || str::starts_with(ln, "mod") {
+        if ln.starts_with("fn") || ln.starts_with("mod") {
             return false;
         } else { if !(it(ln)) { return false; } }
     }

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -175,7 +175,7 @@ fn parse_name_directive(line: &str, directive: &str) -> bool {
 fn parse_name_value_directive(line: &str,
                               directive: ~str) -> Option<~str> {
     let keycolon = directive + ":";
-    match str::find_str(line, keycolon) {
+    match line.find_str(keycolon) {
         Some(colon) => {
             let value = line.slice(colon + keycolon.len(),
                                    line.len()).to_owned();

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -16,7 +16,6 @@ use common;
 use core::iterator::IteratorUtil;
 use core::io;
 use core::os;
-use core::str;
 
 pub struct TestProps {
     // Lines that should be expected, in order, on standard out

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -141,8 +141,8 @@ fn parse_check_line(line: &str) -> Option<~str> {
 fn parse_exec_env(line: &str) -> Option<(~str, ~str)> {
     do parse_name_value_directive(line, ~"exec-env").map |nv| {
         // nv is either FOO or FOO=BAR
-        let mut strs = ~[];
-        for str::each_splitn_char(*nv, '=', 1u) |s| { strs.push(s.to_owned()); }
+        let mut strs: ~[~str] = nv.splitn_iter('=', 1).transform(|s| s.to_owned()).collect();
+
         match strs.len() {
           1u => (strs.pop(), ~""),
           2u => {

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -169,7 +169,7 @@ fn parse_pp_exact(line: &str, testfile: &Path) -> Option<Path> {
 }
 
 fn parse_name_directive(line: &str, directive: &str) -> bool {
-    str::contains(line, directive)
+    line.contains(directive)
 }
 
 fn parse_name_value_directive(line: &str,

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -28,7 +28,7 @@ fn target_env(lib_path: &str, prog: &str) -> ~[(~str,~str)] {
         if k == ~"PATH" { (~"PATH", v + ";" + lib_path + ";" + aux_path) }
         else { (k,v) }
     };
-    if str::ends_with(prog, "rustc.exe") {
+    if prog.ends_with("rustc.exe") {
         env.push((~"RUST_THREADS", ~"1"));
     }
     return env;

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -309,7 +309,7 @@ fn check_error_patterns(props: &TestProps,
     let mut next_err_pat = &props.error_patterns[next_err_idx];
     let mut done = false;
     for ProcRes.stderr.line_iter().advance |line| {
-        if str::contains(line, *next_err_pat) {
+        if line.contains(*next_err_pat) {
             debug!("found error pattern %s", *next_err_pat);
             next_err_idx += 1u;
             if next_err_idx == props.error_patterns.len() {
@@ -365,8 +365,8 @@ fn check_expected_errors(expected_errors: ~[errors::ExpectedError],
                 debug!("prefix=%s ee.kind=%s ee.msg=%s line=%s",
                        prefixes[i], ee.kind, ee.msg, line);
                 if (str::starts_with(line, prefixes[i]) &&
-                    str::contains(line, ee.kind) &&
-                    str::contains(line, ee.msg)) {
+                    line.contains(ee.kind) &&
+                    line.contains(ee.msg)) {
                     found_flags[i] = true;
                     was_expected = true;
                     break;
@@ -375,7 +375,7 @@ fn check_expected_errors(expected_errors: ~[errors::ExpectedError],
         }
 
         // ignore this msg which gets printed at the end
-        if str::contains(line, "aborting due to") {
+        if line.contains("aborting due to") {
             was_expected = true;
         }
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -429,7 +429,7 @@ fn scan_char(haystack: &str, needle: char, idx: &mut uint) -> bool {
     if *idx >= haystack.len() {
         return false;
     }
-    let range = str::char_range_at(haystack, *idx);
+    let range = haystack.char_range_at(*idx);
     if range.ch != needle {
         return false;
     }
@@ -440,7 +440,7 @@ fn scan_char(haystack: &str, needle: char, idx: &mut uint) -> bool {
 fn scan_integer(haystack: &str, idx: &mut uint) -> bool {
     let mut i = *idx;
     while i < haystack.len() {
-        let range = str::char_range_at(haystack, i);
+        let range = haystack.char_range_at(i);
         if range.ch < '0' || '9' < range.ch {
             break;
         }
@@ -460,7 +460,7 @@ fn scan_string(haystack: &str, needle: &str, idx: &mut uint) -> bool {
         if haystack_i >= haystack.len() {
             return false;
         }
-        let range = str::char_range_at(haystack, haystack_i);
+        let range = haystack.char_range_at(haystack_i);
         haystack_i = range.next;
         if !scan_char(needle, range.ch, &mut needle_i) {
             return false;

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -244,7 +244,7 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
         None => copy *config
     };
     let config = &mut config;
-    let cmds = str::connect(props.debugger_cmds, "\n");
+    let cmds = props.debugger_cmds.connect("\n");
     let check_lines = copy props.check_lines;
 
     // compile test file (it shoud have 'compile-flags:-g' in the header)
@@ -645,13 +645,13 @@ fn program_output(config: &config, testfile: &Path, lib_path: &str, prog: ~str,
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "freebsd")]
 fn make_cmdline(_libpath: &str, prog: &str, args: &[~str]) -> ~str {
-    fmt!("%s %s", prog, str::connect(args, " "))
+    fmt!("%s %s", prog, args.connect(" "))
 }
 
 #[cfg(target_os = "win32")]
 fn make_cmdline(libpath: &str, prog: &str, args: &[~str]) -> ~str {
     fmt!("%s %s %s", lib_path_cmd_prefix(libpath), prog,
-         str::connect(args, " "))
+         args.connect(" "))
 }
 
 // Build the LD_LIBRARY_PATH variable as it would be seen on the command line

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -417,7 +417,7 @@ fn scan_until_char(haystack: &str, needle: char, idx: &mut uint) -> bool {
     if *idx >= haystack.len() {
         return false;
     }
-    let opt = str::find_char_from(haystack, needle, *idx);
+    let opt = haystack.slice_from(*idx).find(needle);
     if opt.is_none() {
         return false;
     }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -364,7 +364,7 @@ fn check_expected_errors(expected_errors: ~[errors::ExpectedError],
             if !found_flags[i] {
                 debug!("prefix=%s ee.kind=%s ee.msg=%s line=%s",
                        prefixes[i], ee.kind, ee.msg, line);
-                if (str::starts_with(line, prefixes[i]) &&
+                if (line.starts_with(prefixes[i]) &&
                     line.contains(ee.kind) &&
                     line.contains(ee.msg)) {
                     found_flags[i] = true;

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -735,7 +735,7 @@ fn _arm_exec_compiled_test(config: &config, props: &TestProps,
     let cmdline = make_cmdline("", args.prog, args.args);
 
     // get bare program string
-    let tvec: ~[~str] = args.prog.split_iter('/').transform(|ts| ts.to_owned()).collect();
+    let mut tvec: ~[~str] = args.prog.split_iter('/').transform(|ts| ts.to_owned()).collect();
     let prog_short = tvec.pop();
 
     // copy to target

--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -46,7 +46,6 @@ use sync::{Mutex, mutex_with_condvars, RWlock, rwlock_with_condvars};
 
 use core::cast;
 use core::unstable::sync::UnsafeAtomicRcBox;
-use core::ptr;
 use core::task;
 use core::borrow;
 

--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -49,7 +49,7 @@ impl<'self> ToBase64 for &'self [u8] {
     fn to_base64(&self) -> ~str {
         let mut s = ~"";
         let len = self.len();
-        str::reserve(&mut s, ((len + 3u) / 4u) * 3u);
+        s.reserve(((len + 3u) / 4u) * 3u);
 
         let mut i = 0u;
 
@@ -59,10 +59,10 @@ impl<'self> ToBase64 for &'self [u8] {
                     (self[i + 2u] as uint);
 
             // This 24-bit number gets separated into four 6-bit numbers.
-            str::push_char(&mut s, CHARS[(n >> 18u) & 63u]);
-            str::push_char(&mut s, CHARS[(n >> 12u) & 63u]);
-            str::push_char(&mut s, CHARS[(n >> 6u) & 63u]);
-            str::push_char(&mut s, CHARS[n & 63u]);
+            s.push_char(CHARS[(n >> 18u) & 63u]);
+            s.push_char(CHARS[(n >> 12u) & 63u]);
+            s.push_char(CHARS[(n >> 6u) & 63u]);
+            s.push_char(CHARS[n & 63u]);
 
             i += 3u;
         }
@@ -73,18 +73,18 @@ impl<'self> ToBase64 for &'self [u8] {
           0 => (),
           1 => {
             let n = (self[i] as uint) << 16u;
-            str::push_char(&mut s, CHARS[(n >> 18u) & 63u]);
-            str::push_char(&mut s, CHARS[(n >> 12u) & 63u]);
-            str::push_char(&mut s, '=');
-            str::push_char(&mut s, '=');
+            s.push_char(CHARS[(n >> 18u) & 63u]);
+            s.push_char(CHARS[(n >> 12u) & 63u]);
+            s.push_char('=');
+            s.push_char('=');
           }
           2 => {
             let n = (self[i] as uint) << 16u |
                 (self[i + 1u] as uint) << 8u;
-            str::push_char(&mut s, CHARS[(n >> 18u) & 63u]);
-            str::push_char(&mut s, CHARS[(n >> 12u) & 63u]);
-            str::push_char(&mut s, CHARS[(n >> 6u) & 63u]);
-            str::push_char(&mut s, '=');
+            s.push_char(CHARS[(n >> 18u) & 63u]);
+            s.push_char(CHARS[(n >> 12u) & 63u]);
+            s.push_char(CHARS[(n >> 6u) & 63u]);
+            s.push_char('=');
           }
           _ => fail!("Algebra is broken, please alert the math police")
         }

--- a/src/libextra/fileinput.rs
+++ b/src/libextra/fileinput.rs
@@ -416,7 +416,6 @@ mod test {
 
     use core::iterator::IteratorUtil;
     use core::io;
-    use core::str;
     use core::uint;
     use core::vec;
 
@@ -527,9 +526,7 @@ mod test {
         }
 
         for input_vec_state(filenames) |line, state| {
-            let nums = do vec::build |p| {
-                for str::each_split_char(line, ' ') |s| { p(s.to_owned()); }
-            };
+            let nums: ~[&str] = line.split_iter(' ').collect();
             let file_num = uint::from_str(nums[0]).get();
             let line_num = uint::from_str(nums[1]).get();
             assert_eq!(line_num, state.line_num_file);

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -247,7 +247,7 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
             let mut names;
             let mut i_arg = None;
             if cur[1] == '-' as u8 {
-                let tail = str::slice(cur, 2, curlen);
+                let tail = cur.slice(2, curlen);
                 let tail_eq: ~[&str] = tail.split_iter('=').collect();
                 if tail_eq.len() <= 1 {
                     names = ~[Long(tail.to_owned())];

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -112,7 +112,7 @@ pub struct Opt {
 
 fn mkname(nm: &str) -> Name {
   if nm.len() == 1u {
-      Short(str::char_at(nm, 0u))
+      Short(nm.char_at(0u))
   } else {
       Long(nm.to_owned())
   }
@@ -261,7 +261,7 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
                 let mut last_valid_opt_id = None;
                 names = ~[];
                 while j < curlen {
-                    let range = str::char_range_at(cur, j);
+                    let range = cur.char_range_at(j);
                     let opt = Short(range.ch);
 
                     /* In a series of potential options (eg. -aheJ), if we
@@ -565,11 +565,11 @@ pub mod groups {
                            hasarg: hasarg,
                            occur: occur}],
 
-           (1,0) => ~[Opt {name: Short(str::char_at(short_name, 0)),
+           (1,0) => ~[Opt {name: Short(short_name.char_at(0)),
                            hasarg: hasarg,
                            occur: occur}],
 
-           (1,_) => ~[Opt {name: Short(str::char_at(short_name, 0)),
+           (1,_) => ~[Opt {name: Short(short_name.char_at(0)),
                            hasarg: hasarg,
                            occur:  occur},
                       Opt {name:   Long((long_name)),

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -82,6 +82,7 @@
 
 use core::prelude::*;
 
+use core::iterator::IteratorUtil;
 use core::cmp::Eq;
 use core::result::{Err, Ok};
 use core::result;
@@ -247,14 +248,13 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
             let mut i_arg = None;
             if cur[1] == '-' as u8 {
                 let tail = str::slice(cur, 2, curlen);
-                let mut tail_eq = ~[];
-                for str::each_splitn_char(tail, '=', 1) |s| { tail_eq.push(s.to_owned()) }
+                let tail_eq: ~[&str] = tail.split_iter('=').collect();
                 if tail_eq.len() <= 1 {
                     names = ~[Long(tail.to_owned())];
                 } else {
                     names =
-                        ~[Long(copy tail_eq[0])];
-                    i_arg = Some(copy tail_eq[1]);
+                        ~[Long(tail_eq[0].to_owned())];
+                    i_arg = Some(tail_eq[1].to_owned());
                 }
             } else {
                 let mut j = 1;
@@ -635,7 +635,7 @@ pub mod groups {
 
             // Normalize desc to contain words separated by one space character
             let mut desc_normalized_whitespace = ~"";
-            for str::each_word(desc) |word| {
+            for desc.word_iter().advance |word| {
                 desc_normalized_whitespace.push_str(word);
                 desc_normalized_whitespace.push_char(' ');
             }

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -648,14 +648,14 @@ pub mod groups {
 
             // FIXME: #5516
             // wrapped description
-            row += str::connect(desc_rows, desc_sep);
+            row += desc_rows.connect(desc_sep);
 
             row
         });
 
         return str::to_owned(brief) +
                "\n\nOptions:\n" +
-               str::connect(rows, "\n") +
+               rows.connect("\n") +
                "\n\n";
     }
 } // end groups module

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -79,7 +79,7 @@ fn escape_str(s: &str) -> ~str {
 
 fn spaces(n: uint) -> ~str {
     let mut ss = ~"";
-    for n.times { str::push_str(&mut ss, " "); }
+    for n.times { ss.push_str(" "); }
     return ss;
 }
 
@@ -712,14 +712,14 @@ impl Parser {
 
             if (escape) {
                 match self.ch {
-                  '"' => str::push_char(&mut res, '"'),
-                  '\\' => str::push_char(&mut res, '\\'),
-                  '/' => str::push_char(&mut res, '/'),
-                  'b' => str::push_char(&mut res, '\x08'),
-                  'f' => str::push_char(&mut res, '\x0c'),
-                  'n' => str::push_char(&mut res, '\n'),
-                  'r' => str::push_char(&mut res, '\r'),
-                  't' => str::push_char(&mut res, '\t'),
+                  '"' => res.push_char('"'),
+                  '\\' => res.push_char('\\'),
+                  '/' => res.push_char('/'),
+                  'b' => res.push_char('\x08'),
+                  'f' => res.push_char('\x0c'),
+                  'n' => res.push_char('\n'),
+                  'r' => res.push_char('\r'),
+                  't' => res.push_char('\t'),
                   'u' => {
                       // Parse \u1234.
                       let mut i = 0u;
@@ -748,7 +748,7 @@ impl Parser {
                             ~"invalid \\u escape (not four digits)");
                       }
 
-                      str::push_char(&mut res, n as char);
+                      res.push_char(n as char);
                   }
                   _ => return self.error(~"invalid escape")
                 }
@@ -760,7 +760,7 @@ impl Parser {
                     self.bump();
                     return Ok(res);
                 }
-                str::push_char(&mut res, self.ch);
+                res.push_char(self.ch);
             }
         }
 

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -567,7 +567,7 @@ impl Parser {
     }
 
     fn parse_ident(&mut self, ident: &str, value: Json) -> Result<Json, Error> {
-        if str::all(ident, |c| c == self.next_char()) {
+        if ident.iter().all(|c| c == self.next_char()) {
             self.bump();
             Ok(value)
         } else {

--- a/src/libextra/net_ip.rs
+++ b/src/libextra/net_ip.rs
@@ -14,6 +14,7 @@
 
 use core::prelude::*;
 
+use core::iterator::IteratorUtil;
 use core::libc;
 use core::comm::{stream, SharedChan};
 use core::ptr;
@@ -158,9 +159,7 @@ pub mod v4 {
 
     use core::cast::transmute;
     use core::result;
-    use core::str;
     use core::uint;
-    use core::vec;
 
     /**
      * Convert a str to `ip_addr`
@@ -199,14 +198,12 @@ pub mod v4 {
         }
     }
     pub fn parse_to_ipv4_rep(ip: &str) -> result::Result<Ipv4Rep, ~str> {
-        let mut parts = ~[];
-        for str::each_split_char(ip, '.') |s| { parts.push(s.to_owned()) }
-        let parts = vec::map(parts, |s| {
-            match uint::from_str(*s) {
-              Some(n) if n <= 255 => n,
-              _ => 256
+        let parts: ~[uint] = ip.split_iter('.').transform(|s| {
+            match uint::from_str(s) {
+                Some(n) if n <= 255 => n,
+                _ => 256
             }
-        });
+        }).collect();
         if parts.len() != 4 {
             Err(fmt!("'%s' doesn't have 4 parts", ip))
         } else if parts.contains(&256) {

--- a/src/libextra/net_tcp.rs
+++ b/src/libextra/net_tcp.rs
@@ -1597,8 +1597,8 @@ mod test {
                        expected_req, actual_req);
         debug!("RESP: expected: '%s' actual: '%s'",
                        expected_resp, actual_resp);
-        assert!(str::contains(actual_req, expected_req));
-        assert!(str::contains(actual_resp, expected_resp));
+        assert!(actual_req.contains(expected_req));
+        assert!(actual_resp.contains(expected_resp));
     }
     pub fn impl_gl_tcp_ipv4_get_peer_addr() {
         let hl_loop = &uv::global_loop::get();
@@ -1765,8 +1765,8 @@ mod test {
                        expected_req, actual_req);
         debug!("RESP: expected: '%s' actual: '%s'",
                        expected_resp, actual_resp);
-        assert!(str::contains(actual_req, expected_req));
-        assert!(str::contains(actual_resp, expected_resp));
+        assert!(actual_req.contains(expected_req));
+        assert!(actual_resp.contains(expected_resp));
     }
 
     pub fn impl_tcp_socket_impl_reader_handles_eof() {

--- a/src/libextra/net_tcp.rs
+++ b/src/libextra/net_tcp.rs
@@ -1809,7 +1809,7 @@ mod test {
     }
 
     fn buf_write<W:io::Writer>(w: &W, val: &str) {
-        debug!("BUF_WRITE: val len %?", str::len(val));
+        debug!("BUF_WRITE: val len %?", val.len());
         do str::byte_slice(val) |b_slice| {
             debug!("BUF_WRITE: b_slice len %?",
                             b_slice.len());

--- a/src/libextra/net_url.rs
+++ b/src/libextra/net_url.rs
@@ -81,7 +81,7 @@ fn encode_inner(s: &str, full_url: bool) -> ~str {
               'a' .. 'z' |
               '0' .. '9' |
               '-' | '.' | '_' | '~' => {
-                str::push_char(&mut out, ch);
+                out.push_char(ch);
               }
               _ => {
                   if full_url {
@@ -92,7 +92,7 @@ fn encode_inner(s: &str, full_url: bool) -> ~str {
                       // sub-delims:
                       '!' | '$' | '&' | '"' | '(' | ')' | '*' |
                       '+' | ',' | ';' | '=' => {
-                        str::push_char(&mut out, ch);
+                        out.push_char(ch);
                       }
 
                       _ => out += fmt!("%%%X", ch as uint)
@@ -148,18 +148,18 @@ fn decode_inner(s: &str, full_url: bool) -> ~str {
                       // sub-delims:
                       '!' | '$' | '&' | '"' | '(' | ')' | '*' |
                       '+' | ',' | ';' | '=' => {
-                        str::push_char(&mut out, '%');
-                        str::push_char(&mut out, bytes[0u] as char);
-                        str::push_char(&mut out, bytes[1u] as char);
+                        out.push_char('%');
+                        out.push_char(bytes[0u] as char);
+                        out.push_char(bytes[1u] as char);
                       }
 
-                      ch => str::push_char(&mut out, ch)
+                      ch => out.push_char(ch)
                     }
                 } else {
-                      str::push_char(&mut out, ch);
+                      out.push_char(ch);
                 }
               }
-              ch => str::push_char(&mut out, ch)
+              ch => out.push_char(ch)
             }
         }
 
@@ -191,9 +191,9 @@ fn encode_plus(s: &str) -> ~str {
             let ch = rdr.read_byte() as char;
             match ch {
               'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '.' | '-' => {
-                str::push_char(&mut out, ch);
+                out.push_char(ch);
               }
-              ' ' => str::push_char(&mut out, '+'),
+              ' ' => out.push_char('+'),
               _ => out += fmt!("%%%X", ch as uint)
             }
         }
@@ -216,7 +216,7 @@ pub fn encode_form_urlencoded(m: &HashMap<~str, ~[~str]>) -> ~str {
             if first {
                 first = false;
             } else {
-                str::push_char(&mut out, '&');
+                out.push_char('&');
                 first = false;
             }
 
@@ -267,9 +267,9 @@ pub fn decode_form_urlencoded(s: &[u8]) -> HashMap<~str, ~[~str]> {
                     };
 
                     if parsing_key {
-                        str::push_char(&mut key, ch)
+                        key.push_char(ch)
                     } else {
-                        str::push_char(&mut value, ch)
+                        value.push_char(ch)
                     }
                 }
             }

--- a/src/libextra/net_url.rs
+++ b/src/libextra/net_url.rs
@@ -354,7 +354,7 @@ pub fn query_to_str(query: &Query) -> ~str {
             }
         }
     }
-    return str::connect(strvec, "&");
+    return strvec.connect("&");
 }
 
 // returns the scheme and the rest of the url, or a parsing error

--- a/src/libextra/net_url.rs
+++ b/src/libextra/net_url.rs
@@ -394,7 +394,7 @@ enum Input {
 // returns userinfo, host, port, and unparsed part, or an error
 fn get_authority(rawurl: &str) ->
     Result<(Option<UserInfo>, ~str, Option<~str>, ~str), ~str> {
-    if !str::starts_with(rawurl, "//") {
+    if !raw_url.starts_with("//") {
         // there is no authority.
         return Ok((None, ~"", None, rawurl.to_str()));
     }
@@ -579,7 +579,7 @@ fn get_path(rawurl: &str, authority: bool) ->
     }
 
     if authority {
-        if end != 0 && !str::starts_with(rawurl, "/") {
+        if end != 0 && !rawurl.starts_with("/") {
             return Err(~"Non-empty path must begin with\
                                '/' in presence of authority.");
         }
@@ -592,8 +592,8 @@ fn get_path(rawurl: &str, authority: bool) ->
 // returns the parsed query and the fragment, if present
 fn get_query_fragment(rawurl: &str) ->
     Result<(Query, Option<~str>), ~str> {
-    if !str::starts_with(rawurl, "?") {
-        if str::starts_with(rawurl, "#") {
+    if !rawurl.starts_with("?") {
+        if rawurl.starts_with("#") {
             let f = decode_component(rawurl.slice(
                                                 1,
                                                 rawurl.len()));

--- a/src/libextra/net_url.rs
+++ b/src/libextra/net_url.rs
@@ -19,7 +19,6 @@ use core::cmp::Eq;
 use core::io::{Reader, ReaderUtil};
 use core::io;
 use core::hashmap::HashMap;
-use core::str;
 use core::to_bytes;
 use core::uint;
 
@@ -394,7 +393,7 @@ enum Input {
 // returns userinfo, host, port, and unparsed part, or an error
 fn get_authority(rawurl: &str) ->
     Result<(Option<UserInfo>, ~str, Option<~str>, ~str), ~str> {
-    if !raw_url.starts_with("//") {
+    if !rawurl.starts_with("//") {
         // there is no authority.
         return Ok((None, ~"", None, rawurl.to_str()));
     }

--- a/src/libextra/net_url.rs
+++ b/src/libextra/net_url.rs
@@ -334,7 +334,7 @@ fn userinfo_to_str(userinfo: &UserInfo) -> ~str {
 fn query_from_str(rawquery: &str) -> Query {
     let mut query: Query = ~[];
     if str::len(rawquery) != 0 {
-        for str::each_split_char(rawquery, '&') |p| {
+        for rawquery.split_iter('&').advance |p| {
             let (k, v) = split_char_first(p, '=');
             query.push((decode_component(k), decode_component(v)));
         };

--- a/src/libextra/num/bigint.rs
+++ b/src/libextra/num/bigint.rs
@@ -524,7 +524,7 @@ impl ToStrRadix for BigUint {
                 let s = uint::to_str_radix(*n as uint, radix);
                 str::from_chars(vec::from_elem(l - s.len(), '0')) + s
             }));
-            str::trim_left_chars(s, ['0']).to_owned()
+            s.trim_left_chars(['0']).to_owned()
         }
     }
 }

--- a/src/libextra/num/bigint.rs
+++ b/src/libextra/num/bigint.rs
@@ -520,10 +520,10 @@ impl ToStrRadix for BigUint {
 
         fn fill_concat(v: &[BigDigit], radix: uint, l: uint) -> ~str {
             if v.is_empty() { return ~"0" }
-            let s = str::concat(vec::reversed(v).map(|n| {
+            let s = vec::reversed(v).map(|n| {
                 let s = uint::to_str_radix(*n as uint, radix);
                 str::from_chars(vec::from_elem(l - s.len(), '0')) + s
-            }));
+            }).concat();
             s.trim_left_chars(['0']).to_owned()
         }
     }

--- a/src/libextra/num/rational.rs
+++ b/src/libextra/num/rational.rs
@@ -12,11 +12,10 @@
 
 use core::prelude::*;
 
+use core::iterator::IteratorUtil;
 use core::cmp;
 use core::from_str::FromStr;
 use core::num::{Zero,One,ToStrRadix,FromStrRadix,Round};
-use core::str;
-use core::vec;
 use super::bigint::BigInt;
 
 /// Represents the ratio between 2 numbers.
@@ -252,11 +251,7 @@ impl<T: FromStr + Clone + Integer + Ord>
     FromStr for Ratio<T> {
     /// Parses `numer/denom`.
     fn from_str(s: &str) -> Option<Ratio<T>> {
-        let split = vec::build(|push| {
-            for str::each_splitn_char(s, '/', 1) |s| {
-                push(s.to_owned());
-            }
-        });
+        let split: ~[&str] = s.splitn_iter('/', 1).collect();
         if split.len() < 2 { return None; }
         do FromStr::from_str::<T>(split[0]).chain |a| {
             do FromStr::from_str::<T>(split[1]).chain |b| {
@@ -269,11 +264,7 @@ impl<T: FromStrRadix + Clone + Integer + Ord>
     FromStrRadix for Ratio<T> {
     /// Parses `numer/denom` where the numbers are in base `radix`.
     fn from_str_radix(s: &str, radix: uint) -> Option<Ratio<T>> {
-        let split = vec::build(|push| {
-            for str::each_splitn_char(s, '/', 1) |s| {
-                push(s.to_owned());
-            }
-        });
+        let split: ~[&str] = s.splitn_iter('/', 1).collect();
         if split.len() < 2 { None }
         else {
             do FromStrRadix::from_str_radix::<T>(split[0], radix).chain |a| {

--- a/src/libextra/rope.rs
+++ b/src/libextra/rope.rs
@@ -38,7 +38,6 @@
 use core::prelude::*;
 
 use core::iterator::IteratorUtil;
-use core::str;
 use core::uint;
 use core::vec;
 

--- a/src/libextra/rope.rs
+++ b/src/libextra/rope.rs
@@ -1289,9 +1289,7 @@ mod tests {
             fn aux(str: &mut ~str, node: @node::Node) {
                 match (*node) {
                     node::Leaf(x) => {
-                        str::push_str(
-                            str,
-                            x.content.slice(x.byte_offset, x.byte_offset + x.byte_len));
+                        str.push_str(x.content.slice(x.byte_offset, x.byte_offset + x.byte_len));
                     }
                     node::Concat(ref x) => {
                         aux(str, x.left);

--- a/src/libextra/rope.rs
+++ b/src/libextra/rope.rs
@@ -83,9 +83,9 @@ pub fn of_str(str: @~str) -> Rope {
  *
  * # Return value
  *
- * A rope representing the same string as `str::substr(str, byte_offset,
- * byte_len)`.  Depending on `byte_len`, this rope may be empty, flat or
- * complex.
+ * A rope representing the same string as `str.substr(byte_offset,
+ * byte_len)`.  Depending on `byte_len`, this rope may be empty, flat
+ * or complex.
  *
  * # Performance note
  *

--- a/src/libextra/rope.rs
+++ b/src/libextra/rope.rs
@@ -37,6 +37,7 @@
 
 use core::prelude::*;
 
+use core::iterator::IteratorUtil;
 use core::str;
 use core::uint;
 use core::vec;
@@ -1079,9 +1080,7 @@ pub mod node {
 
     pub fn loop_chars(node: @Node, it: &fn(c: char) -> bool) -> bool {
         return loop_leaves(node,|leaf| {
-            str::all_between(*leaf.content,
-                             leaf.byte_offset,
-                             leaf.byte_len, it)
+            leaf.content.slice(leaf.byte_offset, leaf.byte_len).iter().all(it)
         });
     }
 

--- a/src/libextra/rope.rs
+++ b/src/libextra/rope.rs
@@ -40,6 +40,7 @@ use core::prelude::*;
 use core::iterator::IteratorUtil;
 use core::uint;
 use core::vec;
+use core::str;
 
 /// The type of ropes.
 pub type Rope = node::Root;
@@ -1186,8 +1187,6 @@ pub mod node {
 
     pub mod char_iterator {
         use core::prelude::*;
-
-        use core::str;
 
         use rope::node::{Leaf, Node};
         use rope::node::leaf_iterator;

--- a/src/libextra/rope.rs
+++ b/src/libextra/rope.rs
@@ -1132,7 +1132,7 @@ pub mod node {
     pub fn char_at(mut node: @Node, mut pos: uint) -> char {
         loop {
             match *node {
-              Leaf(x) => return str::char_at(*x.content, pos),
+              Leaf(x) => return x.content.char_at(pos),
               Concat(Concat {left, right, _}) => {
                 let left_len = char_len(left);
                 node = if left_len > pos { left }
@@ -1257,8 +1257,7 @@ pub mod node {
                     return None
                 } else {
                     let range =
-                        str::char_range_at(*aleaf.content,
-                                     (*it).leaf_byte_pos + aleaf.byte_offset);
+                        aleaf.content.char_range_at((*it).leaf_byte_pos + aleaf.byte_offset);
                     let ch = range.ch;
                     let next = range.next;
                     (*it).leaf_byte_pos = next - aleaf.byte_offset;
@@ -1345,7 +1344,7 @@ mod tests {
                     equal = false;
                 } break; }
               Some(c) => {
-                let range = str::char_range_at(*sample, string_iter);
+                let range = sample.char_range_at(string_iter);
                 string_iter = range.next;
                 if range.ch != c { equal = false; break; }
               }

--- a/src/libextra/rope.rs
+++ b/src/libextra/rope.rs
@@ -71,7 +71,7 @@ pub fn empty() -> Rope {
  * * the function runs in linear time.
  */
 pub fn of_str(str: @~str) -> Rope {
-    return of_substr(str, 0u, str::len(*str));
+    return of_substr(str, 0u, str.len());
 }
 
 /**
@@ -98,7 +98,7 @@ pub fn of_str(str: @~str) -> Rope {
  */
 pub fn of_substr(str: @~str, byte_offset: uint, byte_len: uint) -> Rope {
     if byte_len == 0u { return node::Empty; }
-    if byte_offset + byte_len  > str::len(*str) { fail!(); }
+    if byte_offset + byte_len  > str.len() { fail!(); }
     return node::Content(node::of_substr(str, byte_offset, byte_len));
 }
 
@@ -657,7 +657,7 @@ pub mod node {
      * the length of `str`.
      */
     pub fn of_str(str: @~str) -> @Node {
-        return of_substr(str, 0u, str::len(*str));
+        return of_substr(str, 0u, str.len());
     }
 
     /**
@@ -705,7 +705,7 @@ pub mod node {
      */
     pub fn of_substr_unsafer(str: @~str, byte_start: uint, byte_len: uint,
                              char_len: uint) -> @Node {
-        assert!((byte_start + byte_len <= str::len(*str)));
+        assert!((byte_start + byte_len <= str.len()));
         let candidate = @Leaf(Leaf {
             byte_offset: byte_start,
             byte_len: byte_len,
@@ -1292,9 +1292,7 @@ mod tests {
                     node::Leaf(x) => {
                         str::push_str(
                             str,
-                            str::slice(
-                                *x.content, x.byte_offset,
-                                x.byte_offset + x.byte_len));
+                            x.content.slice(x.byte_offset, x.byte_offset + x.byte_len));
                     }
                     node::Concat(ref x) => {
                         aux(str, x.left);
@@ -1340,7 +1338,7 @@ mod tests {
         assert!(rope_to_string(r) == *sample);
 
         let mut string_iter = 0u;
-        let string_len = str::len(*sample);
+        let string_len = sample.len();
         let mut rope_iter = iterator::char::start(r);
         let mut equal = true;
         while equal {

--- a/src/libextra/semver.rs
+++ b/src/libextra/semver.rs
@@ -149,7 +149,7 @@ fn take_nonempty_prefix(rdr: @io::Reader,
     let mut buf = ~"";
     let mut ch = ch;
     while pred(ch) {
-        str::push_char(&mut buf, ch);
+        buf.push_char(ch);
         ch = rdr.read_char();
     }
     if buf.is_empty() {

--- a/src/libextra/semver.rs
+++ b/src/libextra/semver.rs
@@ -14,6 +14,7 @@
 
 use core::prelude::*;
 
+use core::iterator::IteratorUtil;
 use core::char;
 use core::cmp;
 use core::io::{ReaderUtil};
@@ -168,7 +169,7 @@ fn take_num(rdr: @io::Reader, ch: char) -> (uint, char) {
 
 fn take_ident(rdr: @io::Reader, ch: char) -> (Identifier, char) {
     let (s,ch) = take_nonempty_prefix(rdr, ch, char::is_alphanumeric);
-    if s.all(char::is_digit) {
+    if s.iter().all(char::is_digit) {
         match uint::from_str(s) {
             None => { bad_parse::cond.raise(()); (Numeric(0), ch) },
             Some(i) => (Numeric(i), ch)

--- a/src/libextra/semver.rs
+++ b/src/libextra/semver.rs
@@ -81,12 +81,12 @@ impl ToStr for Version {
         let s = if self.pre.is_empty() {
             s
         } else {
-            s + "-" + str::connect(self.pre.map(|i| i.to_str()), ".")
+            s + "-" + self.pre.map(|i| i.to_str()).connect(".")
         };
         if self.build.is_empty() {
             s
         } else {
-            s + "+" + str::connect(self.build.map(|i| i.to_str()), ".")
+            s + "+" + self.build.map(|i| i.to_str()).connect(".")
         }
     }
 }

--- a/src/libextra/semver.rs
+++ b/src/libextra/semver.rs
@@ -20,7 +20,6 @@ use core::cmp;
 use core::io::{ReaderUtil};
 use core::io;
 use core::option::{Option, Some, None};
-use core::str;
 use core::to_str::ToStr;
 use core::uint;
 

--- a/src/libextra/sha1.rs
+++ b/src/libextra/sha1.rs
@@ -281,7 +281,6 @@ pub fn sha1() -> @Sha1 {
 mod tests {
     use sha1;
 
-    use core::str;
     use core::vec;
 
     #[test]
@@ -396,7 +395,7 @@ mod tests {
 
         // Test that it works when accepting the message in pieces
         for tests.each |t| {
-            let len = str::len(t.input);
+            let len = t.input.len();
             let mut left = len;
             while left > 0u {
                 let take = (left + 1u) / 2u;

--- a/src/libextra/tempfile.rs
+++ b/src/libextra/tempfile.rs
@@ -42,7 +42,7 @@ mod tests {
     fn test_mkdtemp() {
         let p = mkdtemp(&Path("."), "foobar").unwrap();
         os::remove_dir(&p);
-        assert!(str::ends_with(p.to_str(), "foobar"));
+        assert!(p.to_str().ends_with("foobar"));
     }
 
     // Ideally these would be in core::os but then core would need

--- a/src/libextra/terminfo/parser/compiled.rs
+++ b/src/libextra/terminfo/parser/compiled.rs
@@ -14,6 +14,7 @@ use core::prelude::*;
 
 use core::{vec, int, str};
 use core::io::Reader;
+use core::iterator::IteratorUtil;
 use core::hashmap::HashMap;
 use super::super::TermInfo;
 
@@ -212,11 +213,8 @@ pub fn parse(file: @Reader, longnames: bool) -> Result<~TermInfo, ~str> {
         return Err(~"incompatible file: more string offsets than expected");
     }
 
-    let mut term_names: ~[~str] = vec::with_capacity(2);
     let names_str = str::from_bytes(file.read_bytes(names_bytes as uint - 1)); // don't read NUL
-    for names_str.each_split_char('|') |s| {
-        term_names.push(s.to_owned());
-    }
+    let term_names: ~[~str] = names_str.split_iter('|').transform(|s| s.to_owned()).collect();
 
     file.read_byte(); // consume NUL
 

--- a/src/libextra/terminfo/searcher.rs
+++ b/src/libextra/terminfo/searcher.rs
@@ -12,9 +12,10 @@
 /// Does not support hashed database, only filesystem!
 
 use core::prelude::*;
-use core::{os, str};
+use core::{os};
 use core::os::getenv;
 use core::io::{file_reader, Reader};
+use core::iterator::IteratorUtil;
 use path = core::path::Path;
 
 /// Return path to database entry for `term`
@@ -36,7 +37,7 @@ pub fn get_dbpath_for_term(term: &str) -> Option<~path> {
                 dirs_to_search.push(homedir.unwrap().push(".terminfo")); // ncurses compatability
             }
             match getenv("TERMINFO_DIRS") {
-                Some(dirs) => for str::each_split_char(dirs, ':') |i| {
+                Some(dirs) => for dirs.split_iter(':').advance |i| {
                     if i == "" {
                         dirs_to_search.push(path("/usr/share/terminfo"));
                     } else {

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -407,8 +407,8 @@ fn should_sort_failures_before_printing_them() {
         print_failures(st);
     };
 
-    let apos = str::find_str(s, "a").get();
-    let bpos = str::find_str(s, "b").get();
+    let apos = s.find_str("a").get();
+    let bpos = s.find_str("b").get();
     assert!(apos < bpos);
 }
 

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -514,7 +514,7 @@ pub fn filter_tests(
 
         fn filter_fn(test: TestDescAndFn, filter_str: &str) ->
             Option<TestDescAndFn> {
-            if str::contains(test.desc.name.to_str(), filter_str) {
+            if test.desc.name.to_str().contains(filter_str) {
                 return option::Some(test);
             } else { return option::None; }
         }

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -279,7 +279,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             match strs[i] { // can't use let due to stage0 bugs
                 (ref needle, value) => {
                     if match_str(ss, pos, *needle) {
-                        return Some((value, pos + str::len(*needle)));
+                        return Some((value, pos + needle.len()));
                     }
                 }
             }
@@ -598,7 +598,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
                 // It's odd, but to maintain compatibility with c's
                 // strptime we ignore the timezone.
                 let mut pos = pos;
-                let len = str::len(s);
+                let len = s.len();
                 while pos < len {
                     let range = str::char_range_at(s, pos);
                     pos = range.next;
@@ -651,7 +651,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             tm_nsec: 0_i32,
         };
         let mut pos = 0u;
-        let len = str::len(s);
+        let len = s.len();
         let mut result = Err(~"Invalid time");
 
         while !rdr.eof() && pos < len {

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -851,7 +851,7 @@ priv fn do_strftime(format: &str, tm: &Tm) -> ~str {
         while !rdr.eof() {
             match rdr.read_char() {
                 '%' => buf += parse_type(rdr.read_char(), tm),
-                ch => str::push_char(&mut buf, ch)
+                ch => buf.push_char(ch)
             }
         }
     }

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -296,7 +296,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
 
         let mut i = 0u;
         while i < digits {
-            let range = str::char_range_at(ss, pos);
+            let range = ss.char_range_at(pos);
             pos = range.next;
 
             match range.ch {
@@ -323,7 +323,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
     }
 
     fn parse_char(s: &str, pos: uint, c: char) -> Result<uint, ~str> {
-        let range = str::char_range_at(s, pos);
+        let range = s.char_range_at(pos);
 
         if c == range.ch {
             Ok(range.next)
@@ -600,7 +600,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
                 let mut pos = pos;
                 let len = s.len();
                 while pos < len {
-                    let range = str::char_range_at(s, pos);
+                    let range = s.char_range_at(pos);
                     pos = range.next;
                     if range.ch == ' ' { break; }
                 }
@@ -609,7 +609,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
             }
           }
           'z' => {
-            let range = str::char_range_at(s, pos);
+            let range = s.char_range_at(pos);
 
             if range.ch == '+' || range.ch == '-' {
                 match match_digits(s, range.next, 4u, false) {
@@ -655,7 +655,7 @@ priv fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
         let mut result = Err(~"Invalid time");
 
         while !rdr.eof() && pos < len {
-            let range = str::char_range_at(s, pos);
+            let range = s.char_range_at(pos);
             let ch = range.ch;
             let next = range.next;
 

--- a/src/libextra/uv_ll.rs
+++ b/src/libextra/uv_ll.rs
@@ -1480,7 +1480,7 @@ mod test {
 
                 let server_kill_msg = copy (*client_data).server_kill_msg;
                 let write_req = (*client_data).server_write_req;
-                if str::contains(request_str, server_kill_msg) {
+                if request_str.contains(server_kill_msg) {
                     debug!(~"SERVER: client req contains kill_msg!");
                     debug!(~"SERVER: sending response to client");
                     read_stop(client_stream_ptr);
@@ -1753,8 +1753,8 @@ mod test {
         let msg_from_client = server_port.recv();
         let msg_from_server = client_port.recv();
 
-        assert!(str::contains(msg_from_client, kill_server_msg));
-        assert!(str::contains(msg_from_server, server_resp_msg));
+        assert!(msg_from_client.contains(kill_server_msg));
+        assert!(msg_from_server.contains(server_resp_msg));
     }
 
     // FIXME don't run on fbsd or linux 32 bit(#2064)

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -57,7 +57,7 @@ pub fn write_file(filename: &Path, content: &str) {
 }
 
 pub fn contains(haystack: &str, needle: &str) -> bool {
-    str::contains(haystack, needle)
+    haystack.contains(needle)
 }
 
 pub fn find_rust_files(files: &mut ~[Path], path: &Path) {

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -376,7 +376,7 @@ pub fn check_variants_T<T:Copy>(crate: @ast::crate,
 
 pub fn last_part(filename: ~str) -> ~str {
     let ix = str::rfind_char(filename, '/').get();
-    str::slice(filename, ix + 1u, str::len(filename) - 3u).to_owned()
+    filename.slice(ix + 1u, filename.len() - 3u).to_owned()
 }
 
 pub enum happiness {
@@ -434,7 +434,7 @@ pub fn check_running(exe_filename: &Path) -> happiness {
         "/Users/jruderman/scripts/timed_run_rust_program.py",
         [exe_filename.to_str()]);
     let comb = str::from_bytes(p.output) + "\n" + str::from_bytes(p.error);
-    if str::len(comb) > 1u {
+    if comb.len() > 1u {
         error!("comb comb comb: %?", comb);
     }
 
@@ -712,4 +712,3 @@ pub mod core {
     pub use std::cmp;
     pub use std::sys;
 }
-

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -375,7 +375,7 @@ pub fn check_variants_T<T:Copy>(crate: @ast::crate,
 }
 
 pub fn last_part(filename: ~str) -> ~str {
-    let ix = str::rfind_char(filename, '/').get();
+    let ix = filename.rfind('/').get();
     filename.slice(ix + 1u, filename.len() - 3u).to_owned()
 }
 

--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -37,7 +37,6 @@ use std::result;
 use std::run;
 use std::str;
 use std::uint;
-use std::vec;
 
 use syntax::diagnostic;
 use syntax::parse::token::ident_interner;

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -394,7 +394,7 @@ pub mod write {
             sess.err(fmt!("building with `%s` failed with code %d",
                         cc_prog, prog.status));
             sess.note(fmt!("%s arguments: %s",
-                        cc_prog, str::connect(cc_args, " ")));
+                        cc_prog, cc_args.connect(" ")));
             sess.note(str::from_bytes(prog.error + prog.output));
             sess.abort_if_errors();
         }
@@ -809,14 +809,14 @@ pub fn link_binary(sess: Session,
 
     debug!("output: %s", output.to_str());
     let cc_args = link_args(sess, obj_filename, out_filename, lm);
-    debug!("%s link args: %s", cc_prog, str::connect(cc_args, " "));
+    debug!("%s link args: %s", cc_prog, cc_args.connect(" "));
     // We run 'cc' here
     let prog = run::process_output(cc_prog, cc_args);
     if 0 != prog.status {
         sess.err(fmt!("linking with `%s` failed with code %d",
                       cc_prog, prog.status));
         sess.note(fmt!("%s arguments: %s",
-                       cc_prog, str::connect(cc_args, " ")));
+                       cc_prog, cc_args.connect(" ")));
         sess.note(str::from_bytes(prog.error + prog.output));
         sess.abort_if_errors();
     }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -686,7 +686,7 @@ pub fn mangle(sess: Session, ss: path) -> ~str {
     for ss.each |s| {
         match *s { path_name(s) | path_mod(s) => {
           let sani = sanitize(*sess.str_of(s));
-          n += fmt!("%u%s", str::len(sani), sani);
+          n += fmt!("%u%s", sani.len(), sani);
         } }
     }
     n += "E"; // End name-sequence.

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -240,7 +240,7 @@ mod test {
         debug!("test_prefix_path: %s vs. %s",
                res.to_str(),
                d.to_str());
-        assert!(str::ends_with(res.to_str(), d.to_str()));
+        assert!(res.to_str().ends_with(d.to_str()));
     }
 
     #[test]

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -465,33 +465,33 @@ pub fn pretty_print_input(sess: Session, cfg: ast::crate_cfg, input: &input,
 }
 
 pub fn get_os(triple: &str) -> Option<session::os> {
-    if str::contains(triple, "win32") ||
-               str::contains(triple, "mingw32") {
+    if triple.contains("win32") ||
+               triple.contains("mingw32") {
             Some(session::os_win32)
-        } else if str::contains(triple, "darwin") {
+        } else if triple.contains("darwin") {
             Some(session::os_macos)
-        } else if str::contains(triple, "android") {
+        } else if triple.contains("android") {
             Some(session::os_android)
-        } else if str::contains(triple, "linux") {
+        } else if triple.contains("linux") {
             Some(session::os_linux)
-        } else if str::contains(triple, "freebsd") {
+        } else if triple.contains("freebsd") {
             Some(session::os_freebsd)
         } else { None }
 }
 
 pub fn get_arch(triple: &str) -> Option<abi::Architecture> {
-    if str::contains(triple, "i386") ||
-        str::contains(triple, "i486") ||
-               str::contains(triple, "i586") ||
-               str::contains(triple, "i686") ||
-               str::contains(triple, "i786") {
+    if triple.contains("i386") ||
+        triple.contains("i486") ||
+               triple.contains("i586") ||
+               triple.contains("i686") ||
+               triple.contains("i786") {
             Some(abi::X86)
-        } else if str::contains(triple, "x86_64") {
+        } else if triple.contains("x86_64") {
             Some(abi::X86_64)
-        } else if str::contains(triple, "arm") ||
-                      str::contains(triple, "xscale") {
+        } else if triple.contains("arm") ||
+                      triple.contains("xscale") {
             Some(abi::Arm)
-        } else if str::contains(triple, "mips") {
+        } else if triple.contains("mips") {
             Some(abi::Mips)
         } else { None }
 }

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -328,8 +328,8 @@ pub fn compile_rest(sess: Session,
 
     let outputs = outputs.get_ref();
     if (sess.opts.debugging_opts & session::print_link_args) != 0 {
-        io::println(str::connect(link::link_args(sess,
-            &outputs.obj_filename, &outputs.out_filename, link_meta), " "));
+        io::println(link::link_args(sess, &outputs.obj_filename,
+                                    &outputs.out_filename, link_meta).connect(" "));
     }
 
     // NB: Android hack

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -24,6 +24,7 @@ use middle;
 use util::common::time;
 use util::ppaux;
 
+use core::iterator::IteratorUtil;
 use core::hashmap::HashMap;
 use core::int;
 use core::io;
@@ -684,11 +685,7 @@ pub fn build_session_options(binary: @~str,
     let addl_lib_search_paths = getopts::opt_strs(matches, "L").map(|s| Path(*s));
     let linker = getopts::opt_maybe_str(matches, "linker");
     let linker_args = getopts::opt_strs(matches, "link-args").flat_map( |a| {
-        let mut args = ~[];
-        for str::each_split_char(*a, ' ') |arg| {
-            args.push(str::to_owned(arg));
-        }
-        args
+        a.split_iter(' ').transform(|arg| arg.to_owned()).collect()
     });
 
     let cfg = parse_cfgspecs(getopts::opt_strs(matches, "cfg"), demitter);
@@ -699,12 +696,9 @@ pub fn build_session_options(binary: @~str,
     let custom_passes = match getopts::opt_maybe_str(matches, "passes") {
         None => ~[],
         Some(s) => {
-            let mut o = ~[];
-            for s.each_split(|c| c == ' ' || c == ',') |s| {
-                let s = s.trim().to_owned();
-                o.push(s);
-            }
-            o
+            s.split_iter(|c: char| c == ' ' || c == ',').transform(|s| {
+                s.trim().to_owned()
+            }).collect()
         }
     };
 

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -17,6 +17,7 @@ use core::prelude::*;
 use metadata::cstore;
 use metadata::decoder;
 
+use core::iterator::IteratorUtil;
 use core::hashmap::HashMap;
 use core::vec;
 use extra;
@@ -114,7 +115,7 @@ pub fn get_used_libraries(cstore: &CStore) -> ~[~str] {
 }
 
 pub fn add_used_link_args(cstore: &mut CStore, args: &str) {
-    for args.each_split_char(' ') |s| {
+    for args.split_iter(' ').advance |s| {
         cstore.used_link_args.push(s.to_owned());
     }
 }

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -186,7 +186,7 @@ fn get_rustpkg_lib_path_nearest() -> Result<Path, ~str> {
 // On Unix should be "lib", on windows "bin"
 pub fn libdir() -> ~str {
    let libdir = env!("CFG_LIBDIR");
-   if str::is_empty(libdir) {
+   if libdir.is_empty() {
       fail!("rustc compiled without CFG_LIBDIR environment variable");
    }
    libdir.to_owned()

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -26,7 +26,6 @@ use middle;
 use util::ppaux::ty_to_str;
 
 use core::at_vec;
-use core::str;
 use core::uint;
 use extra::ebml::reader;
 use extra::ebml;

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -980,7 +980,7 @@ impl ebml_decoder_decoder_helpers for reader::Decoder {
         fn type_string(doc: ebml::Doc) -> ~str {
             let mut str = ~"";
             for uint::range(doc.start, doc.end) |i| {
-                str::push_char(&mut str, doc.data[i] as char);
+                str.push_char(doc.data[i] as char);
             }
             str
         }

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -25,7 +25,6 @@ use core::hashmap::{HashSet, HashMap};
 use core::io;
 use core::ops::{BitOr, BitAnd};
 use core::result::{Result};
-use core::str;
 use syntax::ast;
 use syntax::ast_map;
 use syntax::visit;

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -694,9 +694,9 @@ impl BorrowckCtxt {
                                                  out: &mut ~str) {
         match *loan_path {
             LpExtend(_, _, LpDeref) => {
-                str::push_char(out, '(');
+                out.push_char('(');
                 self.append_loan_path_to_str(loan_path, out);
-                str::push_char(out, ')');
+                out.push_char(')');
             }
             LpExtend(_, _, LpInterior(_)) |
             LpVar(_) => {
@@ -712,7 +712,7 @@ impl BorrowckCtxt {
             LpVar(id) => {
                 match self.tcx.items.find(&id) {
                     Some(&ast_map::node_local(ref ident)) => {
-                        str::push_str(out, *token::ident_to_str(ident));
+                        out.push_str(*token::ident_to_str(ident));
                     }
                     r => {
                         self.tcx.sess.bug(
@@ -726,23 +726,23 @@ impl BorrowckCtxt {
                 self.append_loan_path_to_str_from_interior(lp_base, out);
                 match fname {
                     mc::NamedField(ref fname) => {
-                        str::push_char(out, '.');
-                        str::push_str(out, *token::ident_to_str(fname));
+                        out.push_char('.');
+                        out.push_str(*token::ident_to_str(fname));
                     }
                     mc::PositionalField(idx) => {
-                        str::push_char(out, '#'); // invent a notation here
-                        str::push_str(out, idx.to_str());
+                        out.push_char('#'); // invent a notation here
+                        out.push_str(idx.to_str());
                     }
                 }
             }
 
             LpExtend(lp_base, _, LpInterior(mc::InteriorElement(_))) => {
                 self.append_loan_path_to_str_from_interior(lp_base, out);
-                str::push_str(out, "[]");
+                out.push_str("[]");
             }
 
             LpExtend(lp_base, _, LpDeref) => {
-                str::push_char(out, '*');
+                out.push_char('*');
                 self.append_loan_path_to_str(lp_base, out);
             }
         }

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -947,13 +947,13 @@ fn bits_to_str(words: &[uint]) -> ~str {
     for words.each |&word| {
         let mut v = word;
         for uint::range(0, uint::bytes) |_| {
-            str::push_char(&mut result, sep);
-            str::push_str(&mut result, fmt!("%02x", v & 0xFF));
+            result.push_char(sep);
+            result.push_str(fmt!("%02x", v & 0xFF));
             v >>= 8;
             sep = '-';
         }
     }
-    str::push_char(&mut result, ']');
+    result.push_char(']');
     return result;
 }
 

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -21,7 +21,6 @@ use core::prelude::*;
 use core::iterator::IteratorUtil;
 use core::cast;
 use core::io;
-use core::str;
 use core::uint;
 use core::vec;
 use syntax::ast;

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -17,7 +17,6 @@ use middle::resolve;
 use middle::ty;
 
 use core::hashmap::HashMap;
-use core::vec;
 use syntax::codemap::span;
 use syntax::{ast, ast_util, visit};
 

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -849,14 +849,14 @@ fn check_item_non_camel_case_types(cx: &Context, it: @ast::item) {
 
     fn ident_without_trailing_underscores<'r>(ident: &'r str) -> &'r str {
         match str::rfind(ident, |c| c != '_') {
-            Some(idx) => str::slice(ident, 0, idx + 1),
+            Some(idx) => ident.slice(0, idx + 1),
             None => ident, // all underscores
         }
     }
 
     fn ident_without_leading_underscores<'r>(ident: &'r str) -> &'r str {
         match str::find(ident, |c| c != '_') {
-            Some(idx) => str::slice(ident, idx, ident.len()),
+            Some(idx) => ident.slice(idx, ident.len()),
             None => ident // all underscores
         }
     }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -841,24 +841,9 @@ fn check_item_non_camel_case_types(cx: &Context, it: @ast::item) {
     fn is_camel_case(cx: ty::ctxt, ident: ast::ident) -> bool {
         let ident = cx.sess.str_of(ident);
         assert!(!ident.is_empty());
-        let ident = ident_without_trailing_underscores(*ident);
-        let ident = ident_without_leading_underscores(ident);
+        let ident = ident.trim_chars(&['_']);
         char::is_uppercase(str::char_at(ident, 0)) &&
             !ident.contains_char('_')
-    }
-
-    fn ident_without_trailing_underscores<'r>(ident: &'r str) -> &'r str {
-        match str::rfind(ident, |c| c != '_') {
-            Some(idx) => ident.slice(0, idx + 1),
-            None => ident, // all underscores
-        }
-    }
-
-    fn ident_without_leading_underscores<'r>(ident: &'r str) -> &'r str {
-        match str::find(ident, |c| c != '_') {
-            Some(idx) => ident.slice(idx, ident.len()),
-            None => ident // all underscores
-        }
     }
 
     fn check_case(cx: &Context, ident: ast::ident, span: span) {

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -842,7 +842,7 @@ fn check_item_non_camel_case_types(cx: &Context, it: @ast::item) {
         let ident = cx.sess.str_of(ident);
         assert!(!ident.is_empty());
         let ident = ident.trim_chars(&['_']);
-        char::is_uppercase(str::char_at(ident, 0)) &&
+        char::is_uppercase(ident.char_at(0)) &&
             !ident.contains_char('_')
     }
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -40,7 +40,7 @@ use syntax::visit::{visit_foreign_item, visit_item};
 use syntax::visit::{visit_mod, visit_ty, vt};
 use syntax::opt_vec::OptVec;
 
-use core::str::each_split_str;
+use core::iterator::IteratorUtil;
 use core::str;
 use core::uint;
 use core::vec;
@@ -1737,8 +1737,7 @@ impl Resolver {
                         entry: %s (%?)",
                     path_string, def_like);
 
-            let mut pieces = ~[];
-            for each_split_str(path_string, "::") |s| { pieces.push(s.to_owned()) }
+            let mut pieces: ~[&str] = path_string.split_str_iter("::").collect();
             let final_ident_str = pieces.pop();
             let final_ident = self.session.ident_of(final_ident_str);
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2681,7 +2681,7 @@ impl Resolver {
         match module_prefix_result {
             Failed => {
                 let mpath = self.idents_to_str(module_path);
-                match str::rfind(self.idents_to_str(module_path), |c| { c == ':' }) {
+                match self.idents_to_str(module_path).rfind(':') {
                     Some(idx) => {
                         self.session.span_err(span, fmt!("unresolved import: could not find `%s` \
                                                          in `%s`", str::substr(mpath, idx,

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -3099,7 +3099,7 @@ impl Resolver {
         let import_count = imports.len();
         if index != import_count {
             let sn = self.session.codemap.span_to_snippet(imports[index].span);
-            if str::contains(sn, "::") {
+            if sn.contains("::") {
                 self.session.span_err(imports[index].span, "unresolved import");
             } else {
                 let err = fmt!("unresolved import (maybe you meant `%s::*`?)",

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2684,11 +2684,11 @@ impl Resolver {
                 match self.idents_to_str(module_path).rfind(':') {
                     Some(idx) => {
                         self.session.span_err(span, fmt!("unresolved import: could not find `%s` \
-                                                         in `%s`", str::substr(mpath, idx,
-                                                                               mpath.len() - idx),
+                                                         in `%s`", mpath.substr(idx,
+                                                                                mpath.len() - idx),
                                                          // idx - 1 to account for the extra
                                                          // colon
-                                                         str::substr(mpath, 0, idx - 1)));
+                                                         mpath.substr(0, idx - 1)));
                     },
                     None => (),
                 };

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2575,7 +2575,7 @@ impl Resolver {
                     if "???" == module_name {
                         let span = span {
                             lo: span.lo,
-                            hi: span.lo + BytePos(str::len(*segment_name)),
+                            hi: span.lo + BytePos(segment_name.len()),
                             expn_info: span.expn_info,
                         };
                         self.session.span_err(span,
@@ -4830,7 +4830,7 @@ impl Resolver {
 
         if values.len() > 0 &&
             values[smallest] != uint::max_value &&
-            values[smallest] < str::len(name) + 2 &&
+            values[smallest] < name.len() + 2 &&
             values[smallest] <= max_distance &&
             maybes[smallest] != name.to_owned() {
 

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -87,7 +87,7 @@ pub fn trans_inline_asm(bcx: block, ia: &ast::inline_asm) -> block {
         revoke_clean(bcx, *c);
     }
 
-    let mut constraints = str::connect(constraints, ",");
+    let mut constraints = constraints.connect(",");
 
     let mut clobbers = getClobbers();
     if *ia.clobbers != ~"" && clobbers != ~"" {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1995,7 +1995,7 @@ pub fn trans_enum_variant(ccx: @CrateContext,
 
     debug!("trans_enum_variant: name=%s tps=%s repr=%? enum_ty=%s",
            unsafe { str::raw::from_c_str(llvm::LLVMGetValueName(llfndecl)) },
-           ~"[" + ty_param_substs.map(|&t| ty_to_str(ccx.tcx.connect(t)), ", ") + "]",
+           ~"[" + ty_param_substs.map(|&t| ty_to_str(ccx.tcx, t)).connect(", ") + "]",
            repr, ty_to_str(ccx.tcx, enum_ty));
 
     adt::trans_start_init(bcx, repr, fcx.llretptr.get(), disr);

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1995,7 +1995,7 @@ pub fn trans_enum_variant(ccx: @CrateContext,
 
     debug!("trans_enum_variant: name=%s tps=%s repr=%? enum_ty=%s",
            unsafe { str::raw::from_c_str(llvm::LLVMGetValueName(llfndecl)) },
-           ~"[" + str::connect(ty_param_substs.map(|&t| ty_to_str(ccx.tcx, t)), ", ") + "]",
+           ~"[" + ty_param_substs.map(|&t| ty_to_str(ccx.tcx.connect(t)), ", ") + "]",
            repr, ty_to_str(ccx.tcx, enum_ty));
 
     adt::trans_start_init(bcx, repr, fcx.llretptr.get(), disr);

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -192,9 +192,7 @@ pub fn Invoke(cx: block,
     terminate(cx, "Invoke");
     debug!("Invoke(%s with arguments (%s))",
            val_str(cx.ccx().tn, Fn),
-           vec::map(Args.connect(|a| val_str(cx.ccx().tn,
-                                                   *a).to_owned()),
-                        ", "));
+           Args.map(|a| val_str(cx.ccx().tn, *a).to_owned()).connect(", "));
     unsafe {
         count_insn(cx, "invoke");
         llvm::LLVMBuildInvoke(B(cx),

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -192,7 +192,7 @@ pub fn Invoke(cx: block,
     terminate(cx, "Invoke");
     debug!("Invoke(%s with arguments (%s))",
            val_str(cx.ccx().tn, Fn),
-           str::connect(vec::map(Args, |a| val_str(cx.ccx().tn,
+           vec::map(Args.connect(|a| val_str(cx.ccx().tn,
                                                    *a).to_owned()),
                         ", "));
     unsafe {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1483,7 +1483,7 @@ pub fn node_id_type_params(bcx: block, id: ast::node_id) -> ~[ty::t] {
     if !params.all(|t| !ty::type_needs_infer(*t)) {
         bcx.sess().bug(
             fmt!("Type parameters for node %d include inference types: %s",
-                 id, str::connect(params.map(|t| bcx.ty_to_str(*t)), ",")));
+                 id, params.map(|t| bcx.ty_to_str(*t)).connect(",")));
     }
 
     match bcx.fcx.param_substs {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1221,7 +1221,7 @@ pub fn C_estr_slice(cx: @CrateContext, s: @~str) -> ValueRef {
 pub fn C_postr(s: &str) -> ValueRef {
     unsafe {
         return do str::as_c_str(s) |buf| {
-            llvm::LLVMConstString(buf, str::len(s) as c_uint, False)
+            llvm::LLVMConstString(buf, s.len() as c_uint, False)
         };
     }
 }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -44,7 +44,6 @@ use core::cast;
 use core::hash;
 use core::hashmap::{HashMap, HashSet};
 use core::libc::{c_uint, c_longlong, c_ulonglong};
-use core::ptr;
 use core::str;
 use core::to_bytes;
 use core::vec::raw::to_ptr;

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -245,8 +245,8 @@ fn get_cache(cx: @CrateContext) -> metadata_cache {
 
 fn get_file_path_and_dir(work_dir: &str, full_path: &str) -> (~str, ~str) {
     (if str::starts_with(full_path, work_dir) {
-        str::slice(full_path, str::len(work_dir) + 1u,
-                   str::len(full_path)).to_owned()
+        full_path.slice(work_dir.len() + 1u,
+                   full_path.len()).to_owned()
     } else {
         full_path.to_owned()
     }, work_dir.to_owned())

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -244,7 +244,7 @@ fn get_cache(cx: @CrateContext) -> metadata_cache {
 }
 
 fn get_file_path_and_dir(work_dir: &str, full_path: &str) -> (~str, ~str) {
-    (if str::starts_with(full_path, work_dir) {
+    (if full_path.starts_with(work_dir) {
         full_path.slice(work_dir.len() + 1u,
                    full_path.len()).to_owned()
     } else {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1879,7 +1879,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                                        } else {
                                            "s"
                                        },
-                                       str::connect(missing_fields, ", ")));
+                                       missing_fields.connect(", ")));
              }
         }
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -115,7 +115,6 @@ use core::iterator::IteratorUtil;
 use core::cast::transmute;
 use core::hashmap::HashMap;
 use core::result;
-use core::str;
 use core::util::replace;
 use core::vec;
 use extra::list::Nil;

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -100,7 +100,7 @@ impl Env {
         return match search_mod(self, &self.crate.node.module, 0, names) {
             Some(id) => id,
             None => {
-                fail!("No item found: `%s`", str::connect(names, "::"));
+                fail!("No item found: `%s`", names.connect("::"));
             }
         };
 

--- a/src/librustc/middle/typeck/infer/to_str.rs
+++ b/src/librustc/middle/typeck/infer/to_str.rs
@@ -18,7 +18,6 @@ use middle::typeck::infer::InferCtxt;
 use middle::typeck::infer::unify::{Redirect, Root, VarValue};
 use util::ppaux::{mt_to_str, ty_to_str, trait_ref_to_str};
 
-use core::str;
 use core::uint;
 use syntax::ast;
 

--- a/src/librustc/middle/typeck/infer/to_str.rs
+++ b/src/librustc/middle/typeck/infer/to_str.rs
@@ -35,7 +35,7 @@ impl InferStr for ty::t {
 impl InferStr for FnSig {
     fn inf_str(&self, cx: &InferCtxt) -> ~str {
         fmt!("(%s) -> %s",
-             str::connect(self.inputs.map(|a| a.inf_str(cx)), ", "),
+             self.inputs.map(|a| a.inf_str(cx)).connect(", "),
              self.output.inf_str(cx))
     }
 }

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -16,7 +16,6 @@ use syntax::visit;
 
 use core::hashmap::HashSet;
 use core::io;
-use core::str;
 use extra;
 
 pub fn time<T>(do_it: bool, what: ~str, thunk: &fn() -> T) -> T {

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -111,7 +111,7 @@ pub fn local_rhs_span(l: @ast::local, def: span) -> span {
 
 pub fn pluralize(n: uint, s: ~str) -> ~str {
     if n == 1 { s }
-    else { str::concat([s, ~"s"]) }
+    else { fmt!("%ss", s) }
 }
 
 // A set of node IDs (used to keep track of which node IDs are for statements)

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -281,7 +281,7 @@ pub fn vstore_ty_to_str(cx: ctxt, mt: &mt, vs: ty::vstore) -> ~str {
 
 pub fn tys_to_str(cx: ctxt, ts: &[t]) -> ~str {
     let tstrs = ts.map(|t| ty_to_str(cx, *t));
-    fmt!("(%s)", str::connect(tstrs, ", "))
+    fmt!("(%s)", tstrs.connect(", "))
 }
 
 pub fn fn_sig_to_str(cx: ctxt, typ: &ty::FnSig) -> ~str {
@@ -369,7 +369,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
     fn push_sig_to_str(cx: ctxt, s: &mut ~str, sig: &ty::FnSig) {
         s.push_char('(');
         let strs = sig.inputs.map(|a| fn_input_to_str(cx, *a));
-        s.push_str(str::connect(strs, ", "));
+        s.push_str(strs.connect(", "));
         s.push_char(')');
         if ty::get(sig.output).sty != ty_nil {
             s.push_str(" -> ");
@@ -420,7 +420,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_type => ~"type",
       ty_tup(ref elems) => {
         let strs = elems.map(|elem| ty_to_str(cx, *elem));
-        ~"(" + str::connect(strs, ",") + ")"
+        ~"(" + strs.connect(",") + ")"
       }
       ty_closure(ref f) => {
           closure_to_str(cx, f)
@@ -477,7 +477,7 @@ pub fn parameterized(cx: ctxt,
 
     if tps.len() > 0u {
         let strs = vec::map(tps, |t| ty_to_str(cx, *t));
-        fmt!("%s%s<%s>", base, r_str, str::connect(strs, ","))
+        fmt!("%s%s<%s>", base, r_str, strs.connect(","))
     } else {
         fmt!("%s%s", base, r_str)
     }
@@ -515,7 +515,7 @@ impl<T:Repr> Repr for ~T {
 */
 
 fn repr_vec<T:Repr>(tcx: ctxt, v: &[T]) -> ~str {
-    fmt!("[%s]", str::connect(v.map(|t| t.repr(tcx)), ","))
+    fmt!("[%s]", v.map(|t| t.repr(tcx)).connect(","))
 }
 
 impl<'self, T:Repr> Repr for &'self [T] {
@@ -569,7 +569,7 @@ impl Repr for ty::ParamBounds {
         for self.trait_bounds.each |t| {
             res.push(t.repr(tcx));
         }
-        str::connect(res, "+")
+        res.connect("+")
     }
 }
 
@@ -787,7 +787,7 @@ impl UserString for ty::BuiltinBounds {
             for self.each |bb| {
                 result.push(bb.user_string(tcx));
             }
-            str::connect(result, "+")
+            result.connect("+")
         }
     }
 }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -485,7 +485,7 @@ pub fn parameterized(cx: ctxt,
 
 pub fn ty_to_short_str(cx: ctxt, typ: t) -> ~str {
     let mut s = encoder::encoded_ty(cx, typ);
-    if str::len(s) >= 32u { s = str::slice(s, 0u, 32u).to_owned(); }
+    if s.len() >= 32u { s = s.slice(0u, 32u).to_owned(); }
     return s;
 }
 

--- a/src/librustdoc/attr_parser.rs
+++ b/src/librustdoc/attr_parser.rs
@@ -53,7 +53,7 @@ pub fn parse_desc(attrs: ~[ast::attribute]) -> Option<~str> {
     if doc_strs.is_empty() {
         None
     } else {
-        Some(str::connect(doc_strs, "\n"))
+        Some(doc_strs.connect("\n"))
     }
 }
 

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -94,7 +94,7 @@ fn parse_desc(desc: ~str) -> Option<~str> {
 
     match first_sentence(copy desc) {
       Some(first_sentence) => {
-        if str::len(first_sentence) <= max_brief_len {
+        if first_sentence.len() <= max_brief_len {
             Some(first_sentence)
         } else {
             None
@@ -133,7 +133,7 @@ fn first_sentence_(s: &str) -> ~str {
     };
     match idx {
         Some(idx) if idx > 2u => {
-            str::to_owned(str::slice(s, 0, idx - 1))
+            str::to_owned(s.slice(0, idx - 1))
         }
         _ => {
             if str::ends_with(s, ".") {
@@ -165,7 +165,7 @@ pub fn paragraphs(s: &str) -> ~[~str] {
 
             whitespace_lines = 0;
 
-            accum = if str::is_empty(accum) {
+            accum = if accum.is_empty() {
                 copy *line
             } else {
                 accum + "\n" + *line

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -118,19 +118,17 @@ fn first_sentence_(s: &str) -> ~str {
     let mut dotcount = 0;
     // The index of the character following a single dot. This allows
     // Things like [0..1) to appear in the brief description
-    let idx = do str::find(s) |ch| {
+    let idx = s.find(|ch: char| {
         if ch == '.' {
             dotcount += 1;
             false
+        } else if dotcount == 1 {
+            true
         } else {
-            if dotcount == 1 {
-                true
-            } else {
-                dotcount = 0;
-                false
-            }
+            dotcount = 0;
+            false
         }
-    };
+    });
     match idx {
         Some(idx) if idx > 2u => {
             str::to_owned(s.slice(0, idx - 1))

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -151,7 +151,7 @@ pub fn paragraphs(s: &str) -> ~[~str] {
     let paras = do lines.iter().fold(~[]) |paras, line| {
         let mut res = paras;
 
-        if str::is_whitespace(*line) {
+        if line.is_whitespace() {
             whitespace_lines += 1;
         } else {
             if whitespace_lines > 0 {

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -134,7 +134,7 @@ fn first_sentence_(s: &str) -> ~str {
             str::to_owned(s.slice(0, idx - 1))
         }
         _ => {
-            if str::ends_with(s, ".") {
+            if s.ends_with(".") {
                 str::to_owned(s)
             } else {
                 str::to_owned(s)

--- a/src/librustdoc/markdown_index_pass.rs
+++ b/src/librustdoc/markdown_index_pass.rs
@@ -152,7 +152,7 @@ pub fn pandoc_header_id(header: &str) -> ~str {
         // Collapse sequences of whitespace to a single dash
         // XXX: Hacky implementation here that only covers
         // one or two spaces.
-        let s = str::trim(s);
+        let s = s.trim();
         let s = str::replace(s, "  ", "-");
         let s = str::replace(s, " ", "-");
         return s;

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -607,13 +607,13 @@ mod test {
     #[test]
     fn write_markdown_should_write_mod_headers() {
         let markdown = render(~"mod moo { }");
-        assert!(str::contains(markdown, "# Module `moo`"));
+        assert!(markdown.contains("# Module `moo`"));
     }
 
     #[test]
     fn should_leave_blank_line_after_header() {
         let markdown = render(~"mod morp { }");
-        assert!(str::contains(markdown, "Module `morp`\n\n"));
+        assert!(markdown.contains("Module `morp`\n\n"));
     }
 
     #[test]
@@ -669,10 +669,10 @@ mod test {
             let (page, markdown) = po.recv();
             match page {
                 doc::CratePage(_) => {
-                    assert!(str::contains(markdown, "% Crate core"));
+                    assert!(markdown.contains("% Crate core"));
                 }
                 doc::ItemPage(_) => {
-                    assert!(str::contains(markdown, "% Module a"));
+                    assert!(markdown.contains("% Module a"));
                 }
             }
         }
@@ -681,7 +681,7 @@ mod test {
     #[test]
     fn should_write_full_path_to_mod() {
         let markdown = render(~"mod a { mod b { mod c { } } }");
-        assert!(str::contains(markdown, "# Module `a::b::c`"));
+        assert!(markdown.contains("# Module `a::b::c`"));
     }
 
     #[test]
@@ -692,21 +692,20 @@ mod test {
               Body\"]\
               mod a {
 }");
-        assert!(str::contains(markdown, "#### Header\n\nBody\n\n"));
+        assert!(markdown.contains("#### Header\n\nBody\n\n"));
     }
 
     #[test]
     fn should_write_crate_description() {
         let markdown = render(~"#[doc = \"this is the crate\"];");
-        assert!(str::contains(markdown, "this is the crate"));
+        assert!(markdown.contains("this is the crate"));
     }
 
 
     #[test]
     fn should_write_index() {
         let markdown = render(~"mod a { } mod b { }");
-        assert!(str::contains(
-            markdown,
+        assert!(markdown.contains(
             "\n\n* [Module `a`](#module-a)\n\
              * [Module `b`](#module-b)\n\n"
         ));
@@ -715,20 +714,19 @@ mod test {
     #[test]
     fn should_write_index_brief() {
         let markdown = render(~"#[doc = \"test\"] mod a { }");
-        assert!(str::contains(markdown, "(#module-a) - test\n"));
+        assert!(markdown.contains("(#module-a) - test\n"));
     }
 
     #[test]
     fn should_not_write_index_if_no_entries() {
         let markdown = render(~"");
-        assert!(!str::contains(markdown, "\n\n\n"));
+        assert!(!markdown.contains("\n\n\n"));
     }
 
     #[test]
     fn should_write_index_for_foreign_mods() {
         let markdown = render(~"extern { fn a(); }");
-        assert!(str::contains(
-            markdown,
+        assert!(markdown.contains(
             "\n\n* [Function `a`](#function-a)\n\n"
         ));
     }
@@ -737,32 +735,32 @@ mod test {
     fn should_write_foreign_fns() {
         let markdown = render(
             ~"extern { #[doc = \"test\"] fn a(); }");
-        assert!(str::contains(markdown, "test"));
+        assert!(markdown.contains("test"));
     }
 
     #[test]
     fn should_write_foreign_fn_headers() {
         let markdown = render(
             ~"extern { #[doc = \"test\"] fn a(); }");
-        assert!(str::contains(markdown, "## Function `a`"));
+        assert!(markdown.contains("## Function `a`"));
     }
 
     #[test]
     fn write_markdown_should_write_function_header() {
         let markdown = render(~"fn func() { }");
-        assert!(str::contains(markdown, "## Function `func`"));
+        assert!(markdown.contains("## Function `func`"));
     }
 
     #[test]
     fn should_write_the_function_signature() {
         let markdown = render(~"#[doc = \"f\"] fn a() { }");
-        assert!(str::contains(markdown, "\n    fn a()\n"));
+        assert!(markdown.contains("\n    fn a()\n"));
     }
 
     #[test]
     fn should_insert_blank_line_after_fn_signature() {
         let markdown = render(~"#[doc = \"f\"] fn a() { }");
-        assert!(str::contains(markdown, "fn a()\n\n"));
+        assert!(markdown.contains("fn a()\n\n"));
     }
 
     #[test]
@@ -783,19 +781,19 @@ mod test {
             ]
         };
         let markdown = write_markdown_str(doc);
-        assert!(str::contains(markdown, "    line 1\n    line 2"));
+        assert!(markdown.contains("    line 1\n    line 2"));
     }
 
     #[test]
     fn should_leave_blank_line_between_fn_header_and_sig() {
         let markdown = render(~"fn a() { }");
-        assert!(str::contains(markdown, "Function `a`\n\n    fn a()"));
+        assert!(markdown.contains("Function `a`\n\n    fn a()"));
     }
 
     #[test]
     fn should_write_const_header() {
         let markdown = render(~"static a: bool = true;");
-        assert!(str::contains(markdown, "## Const `a`\n\n"));
+        assert!(markdown.contains("## Const `a`\n\n"));
     }
 
     #[test]
@@ -803,19 +801,19 @@ mod test {
         let markdown = render(
             ~"#[doc = \"b\"]\
               static a: bool = true;");
-        assert!(str::contains(markdown, "\n\nb\n\n"));
+        assert!(markdown.contains("\n\nb\n\n"));
     }
 
     #[test]
     fn should_write_enum_header() {
         let markdown = render(~"enum a { b }");
-        assert!(str::contains(markdown, "## Enum `a`\n\n"));
+        assert!(markdown.contains("## Enum `a`\n\n"));
     }
 
     #[test]
     fn should_write_enum_description() {
         let markdown = render(~"#[doc = \"b\"] enum a { b }");
-        assert!(str::contains(markdown, "\n\nb\n\n"));
+        assert!(markdown.contains("\n\nb\n\n"));
     }
 
     #[test]
@@ -824,8 +822,7 @@ mod test {
             ~"enum a { \
               #[doc = \"test\"] b, \
               #[doc = \"test\"] c }");
-        assert!(str::contains(
-            markdown,
+        assert!(markdown.contains(
             "\n\n#### Variants\n\
              \n\
              \n* `b` - test\
@@ -836,8 +833,7 @@ mod test {
     #[test]
     fn should_write_variant_list_without_descs() {
         let markdown = render(~"enum a { b, c }");
-        assert!(str::contains(
-            markdown,
+        assert!(markdown.contains(
             "\n\n#### Variants\n\
              \n\
              \n* `b`\
@@ -849,8 +845,7 @@ mod test {
     fn should_write_variant_list_with_indent() {
         let markdown = render(
             ~"enum a { #[doc = \"line 1\\n\\nline 2\"] b, c }");
-        assert!(str::contains(
-            markdown,
+        assert!(markdown.contains(
             "\n\n#### Variants\n\
              \n\
              \n* `b` - line 1\
@@ -863,8 +858,7 @@ mod test {
     #[test]
     fn should_write_variant_list_with_signatures() {
         let markdown = render(~"enum a { b(int), #[doc = \"a\"] c(int) }");
-        assert!(str::contains(
-            markdown,
+        assert!(markdown.contains(
             "\n\n#### Variants\n\
              \n\
              \n* `b(int)`\
@@ -875,43 +869,43 @@ mod test {
     #[test]
     fn should_write_trait_header() {
         let markdown = render(~"trait i { fn a(); }");
-        assert!(str::contains(markdown, "## Trait `i`"));
+        assert!(markdown.contains("## Trait `i`"));
     }
 
     #[test]
     fn should_write_trait_desc() {
         let markdown = render(~"#[doc = \"desc\"] trait i { fn a(); }");
-        assert!(str::contains(markdown, "desc"));
+        assert!(markdown.contains("desc"));
     }
 
     #[test]
     fn should_write_trait_method_header() {
         let markdown = render(~"trait i { fn a(); }");
-        assert!(str::contains(markdown, "### Method `a`"));
+        assert!(markdown.contains("### Method `a`"));
     }
 
     #[test]
     fn should_write_trait_method_signature() {
         let markdown = render(~"trait i { fn a(&self); }");
-        assert!(str::contains(markdown, "\n    fn a(&self)"));
+        assert!(markdown.contains("\n    fn a(&self)"));
     }
 
     #[test]
     fn should_write_impl_header() {
         let markdown = render(~"impl int { fn a() { } }");
-        assert!(str::contains(markdown, "## Implementation for `int`"));
+        assert!(markdown.contains("## Implementation for `int`"));
     }
 
     #[test]
     fn should_write_impl_header_with_bounds() {
         let markdown = render(~"impl <T> int<T> { }");
-        assert!(str::contains(markdown, "## Implementation for `int<T>` where `<T>`"));
+        assert!(markdown.contains("## Implementation for `int<T>` where `<T>`"));
     }
 
     #[test]
     fn should_write_impl_header_with_trait() {
         let markdown = render(~"impl j for int { fn a() { } }");
-        assert!(str::contains(markdown,
+        assert!(markdown.contains(
                               "## Implementation of `j` for `int`"));
     }
 
@@ -919,45 +913,45 @@ mod test {
     fn should_write_impl_desc() {
         let markdown = render(
             ~"#[doc = \"desc\"] impl int { fn a() { } }");
-        assert!(str::contains(markdown, "desc"));
+        assert!(markdown.contains("desc"));
     }
 
     #[test]
     fn should_write_impl_method_header() {
         let markdown = render(
             ~"impl int { fn a() { } }");
-        assert!(str::contains(markdown, "### Method `a`"));
+        assert!(markdown.contains("### Method `a`"));
     }
 
     #[test]
     fn should_write_impl_method_signature() {
         let markdown = render(
             ~"impl int { fn a(&mut self) { } }");
-        assert!(str::contains(markdown, "\n    fn a(&mut self)"));
+        assert!(markdown.contains("\n    fn a(&mut self)"));
     }
 
     #[test]
     fn should_write_type_header() {
         let markdown = render(~"type t = int;");
-        assert!(str::contains(markdown, "## Type `t`"));
+        assert!(markdown.contains("## Type `t`"));
     }
 
     #[test]
     fn should_write_type_desc() {
         let markdown = render(
             ~"#[doc = \"desc\"] type t = int;");
-        assert!(str::contains(markdown, "\n\ndesc\n\n"));
+        assert!(markdown.contains("\n\ndesc\n\n"));
     }
 
     #[test]
     fn should_write_type_signature() {
         let markdown = render(~"type t = int;");
-        assert!(str::contains(markdown, "\n\n    type t = int\n\n"));
+        assert!(markdown.contains("\n\n    type t = int\n\n"));
     }
 
     #[test]
     fn should_put_struct_header() {
         let markdown = render(~"struct S { field: () }");
-        assert!(str::contains(markdown, "## Struct `S`\n\n"));
+        assert!(markdown.contains("## Struct `S`\n\n"));
     }
 }

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -173,7 +173,7 @@ pub fn header_kind(doc: doc::ItemTag) -> ~str {
 }
 
 pub fn header_name(doc: doc::ItemTag) -> ~str {
-    let fullpath = str::connect(doc.path() + [doc.name()], "::");
+    let fullpath = (doc.path() + [doc.name()]).connect("::");
     match &doc {
         &doc::ModTag(_) if doc.id() != syntax::ast::crate_node_id => {
             fullpath
@@ -414,7 +414,7 @@ fn code_block_indent(s: ~str) -> ~str {
     for str::each_line_any(s) |line| {
         indented.push(fmt!("    %s", line));
     }
-    str::connect(indented, "\n")
+    indented.connect("\n")
 }
 
 fn write_const(
@@ -476,7 +476,7 @@ fn list_item_indent(item: &str) -> ~str {
     // separate markdown elements within `*` lists must be indented by four
     // spaces, or they will escape the list context. indenting everything
     // seems fine though.
-    str::connect_slices(indented, "\n    ")
+    indented.connect("\n    ")
 }
 
 fn write_trait(ctxt: &Ctxt, doc: doc::TraitDoc) {

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -633,10 +633,10 @@ mod test {
               fn d() { }"
         );
 
-        let idx_a = str::find_str(markdown, "# Module `a`").get();
-        let idx_b = str::find_str(markdown, "## Function `b`").get();
-        let idx_c = str::find_str(markdown, "# Module `c`").get();
-        let idx_d = str::find_str(markdown, "## Function `d`").get();
+        let idx_a = markdown.find_str("# Module `a`").get();
+        let idx_b = markdown.find_str("## Function `b`").get();
+        let idx_c = markdown.find_str("# Module `c`").get();
+        let idx_d = markdown.find_str("## Function `d`").get();
 
         assert!(idx_b < idx_d);
         assert!(idx_d < idx_a);

--- a/src/librustdoc/markdown_writer.rs
+++ b/src/librustdoc/markdown_writer.rs
@@ -107,7 +107,7 @@ fn pandoc_writer(
         use core::io::WriterUtil;
 
         debug!("pandoc cmd: %s", pandoc_cmd);
-        debug!("pandoc args: %s", str::connect(pandoc_args, " "));
+        debug!("pandoc args: %s", pandoc_args.connect(" "));
 
         let mut proc = run::Process::new(pandoc_cmd, pandoc_args, run::ProcessOptions::new());
 
@@ -164,7 +164,7 @@ pub fn make_filename(
             }
           }
           doc::ItemPage(doc) => {
-            str::connect(doc.path() + [doc.name()], "_")
+            (doc.path() + [doc.name()]).connect("_")
           }
         }
     };

--- a/src/librustdoc/sectionalize_pass.rs
+++ b/src/librustdoc/sectionalize_pass.rs
@@ -191,9 +191,7 @@ mod test {
               Body\"]\
               mod a {
 }");
-        assert!(str::contains(
-            doc.cratemod().mods()[0].item.sections[0].header,
-            "Header"));
+        assert!(doc.cratemod().mods()[0].item.sections[0].header.contains("Header"));
     }
 
     #[test]
@@ -204,9 +202,7 @@ mod test {
               Body\"]\
               mod a {
 }");
-        assert!(str::contains(
-            doc.cratemod().mods()[0].item.sections[0].body,
-            "Body"));
+        assert!(doc.cratemod().mods()[0].item.sections[0].body.contains("Body"));
     }
 
     #[test]
@@ -229,12 +225,8 @@ mod test {
               Body\"]\
               mod a {
 }");
-        assert!(!str::contains(
-            doc.cratemod().mods()[0].desc().get(),
-            "Header"));
-        assert!(!str::contains(
-            doc.cratemod().mods()[0].desc().get(),
-            "Body"));
+        assert!(!doc.cratemod().mods()[0].desc().get().contains("Header"));
+        assert!(!doc.cratemod().mods()[0].desc().get().contains("Body"));
     }
 
     #[test]

--- a/src/librustdoc/sectionalize_pass.rs
+++ b/src/librustdoc/sectionalize_pass.rs
@@ -153,7 +153,7 @@ fn sectionalize(desc: Option<~str>) -> (Option<~str>, ~[doc::Section]) {
 }
 
 fn parse_header(line: ~str) -> Option<~str> {
-    if str::starts_with(line, "# ") {
+    if line.starts_with("# ") {
         Some(line.slice(2u, line.len()).to_owned())
     } else {
         None

--- a/src/librustdoc/sectionalize_pass.rs
+++ b/src/librustdoc/sectionalize_pass.rs
@@ -154,7 +154,7 @@ fn sectionalize(desc: Option<~str>) -> (Option<~str>, ~[doc::Section]) {
 
 fn parse_header(line: ~str) -> Option<~str> {
     if str::starts_with(line, "# ") {
-        Some(str::slice(line, 2u, str::len(line)).to_owned())
+        Some(line.slice(2u, line.len()).to_owned())
     } else {
         None
     }

--- a/src/librustdoc/text_pass.rs
+++ b/src/librustdoc/text_pass.rs
@@ -157,7 +157,7 @@ mod test {
             let doc = (attr_pass::mk_pass().f)(srv.clone(), doc);
             let doc = (desc_to_brief_pass::mk_pass().f)(srv.clone(), doc);
             let doc = (sectionalize_pass::mk_pass().f)(srv.clone(), doc);
-            (mk_pass(~"", |s| str::trim(s).to_owned() ).f)(srv.clone(), doc)
+            (mk_pass(~"", |s| s.trim().to_owned() ).f)(srv.clone(), doc)
         }
     }
 

--- a/src/librustdoc/unindent_pass.rs
+++ b/src/librustdoc/unindent_pass.rs
@@ -83,8 +83,8 @@ fn unindent(s: &str) -> ~str {
             if str::is_whitespace(*line) {
                 copy *line
             } else {
-                assert!(str::len(*line) >= min_indent);
-                str::slice(*line, min_indent, str::len(*line)).to_owned()
+                assert!(line.len() >= min_indent);
+                line.slice(min_indent, line.len()).to_owned()
             }
         };
         str::connect(unindented, "\n")

--- a/src/librustdoc/unindent_pass.rs
+++ b/src/librustdoc/unindent_pass.rs
@@ -63,7 +63,7 @@ fn unindent(s: &str) -> ~str {
         } else {
             saw_first_line = true;
             let mut spaces = 0;
-            do str::all(*line) |char| {
+            do line.iter().all |char| {
                 // Only comparing against space because I wouldn't
                 // know what to do with mixed whitespace chars
                 if char == ' ' {

--- a/src/librustdoc/unindent_pass.rs
+++ b/src/librustdoc/unindent_pass.rs
@@ -87,7 +87,7 @@ fn unindent(s: &str) -> ~str {
                 line.slice(min_indent, line.len()).to_owned()
             }
         };
-        str::connect(unindented, "\n")
+        unindented.connect("\n")
     } else {
         s.to_str()
     }

--- a/src/librustdoc/unindent_pass.rs
+++ b/src/librustdoc/unindent_pass.rs
@@ -46,7 +46,7 @@ fn unindent(s: &str) -> ~str {
         let ignore_previous_indents =
             saw_first_line &&
             !saw_second_line &&
-            !str::is_whitespace(*line);
+            !line.is_whitespace();
 
         let min_indent = if ignore_previous_indents {
             uint::max_value
@@ -58,7 +58,7 @@ fn unindent(s: &str) -> ~str {
             saw_second_line = true;
         }
 
-        if str::is_whitespace(*line) {
+        if line.is_whitespace() {
             min_indent
         } else {
             saw_first_line = true;
@@ -80,7 +80,7 @@ fn unindent(s: &str) -> ~str {
     if !lines.is_empty() {
         let unindented = ~[lines.head().trim().to_owned()]
             + do lines.tail().map |line| {
-            if str::is_whitespace(*line) {
+            if line.is_whitespace() {
                 copy *line
             } else {
                 assert!(line.len() >= min_indent);

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -318,7 +318,7 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
                 match get_line(use_rl, "rusti| ") {
                     None => fail!("unterminated multiline command :{ .. :}"),
                     Some(line) => {
-                        if str::trim(line) == ":}" {
+                        if line.trim() == ":}" {
                             end_multiline = true;
                         } else {
                             multiline_cmd += line + "\n";

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -308,7 +308,7 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
                 println("no crates loaded");
             } else {
                 println(fmt!("crates loaded: %s",
-                                 str::connect(loaded_crates, ", ")));
+                                 loaded_crates.connect(", ")));
             }
         }
         ~"{" => {

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -339,9 +339,11 @@ pub fn run_line(repl: &mut Repl, in: @io::Reader, out: @io::Writer, line: ~str,
                 use_rl: bool)
     -> Option<Repl> {
     if line.starts_with(":") {
+        // FIXME #5898: conflicts with Cell.take(), so can't be at the top level
+        use core::iterator::IteratorUtil;
+
         let full = line.substr(1, line.len() - 1);
-        let mut split = ~[];
-        for str::each_word(full) |word| { split.push(word.to_owned()) }
+        let split: ~[~str] = full.word_iter().transform(|s| s.to_owned()).collect();
         let len = split.len();
 
         if len > 0 {

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -17,6 +17,7 @@ pub use target::{OutputType, Main, Lib, Test, Bench, Target, Build, Install};
 use core::libc::consts::os::posix88::{S_IRUSR, S_IWUSR, S_IXUSR};
 use core::os::mkdir_recursive;
 use core::os;
+use core::iterator::IteratorUtil;
 
 /// Returns the value of RUST_PATH, as a list
 /// of Paths. In general this should be read from the
@@ -166,7 +167,7 @@ fn library_in_workspace(full_name: &str, short_name: &str, where: Target,
         let f_name = match p_path.filename() {
             Some(s) => s, None => loop
         };
-        for f_name.each_split_char('-') |piece| {
+        for f_name.split_iter('-').advance |piece| {
             debug!("a piece = %s", piece);
             if which == 0 && piece != lib_prefix {
                 break;

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -29,6 +29,7 @@ extern mod syntax;
 
 use core::prelude::*;
 use core::*;
+use core::iterator::IteratorUtil;
 pub use core::path::Path;
 use core::hashmap::HashMap;
 use rustc::driver::{driver, session};
@@ -161,10 +162,8 @@ impl<'self> PkgScript<'self> {
                            exe.to_str(), root.to_str(), "configs");
                     let output = run::process_output(exe.to_str(), [root.to_str(), ~"configs"]);
                     // Run the configs() function to get the configs
-                    let mut cfgs = ~[];
-                    for str::each_word(str::from_bytes(output.output)) |w| {
-                        cfgs.push(w.to_owned());
-                    }
+                    let cfgs = str::from_bytes_slice(output.output).word_iter()
+                        .transform(|w| w.to_owned()).collect();
                     (cfgs, output.status)
                 }
             }

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -207,8 +207,8 @@ pub fn compile_input(ctxt: &Ctx,
 
     let binary = @(copy os::args()[0]);
 
-    debug!("flags: %s", str::connect(flags, " "));
-    debug!("cfgs: %s", str::connect(cfgs, " "));
+    debug!("flags: %s", flags.connect(" "));
+    debug!("cfgs: %s", cfgs.connect(" "));
     debug!("compile_input's sysroot = %?", ctxt.sysroot_opt);
 
     let crate_type = match what {

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -15,6 +15,7 @@ extern mod std;
 
 use extra::semver;
 use core::prelude::*;
+use core::iterator::IteratorUtil;
 use core::{char, os, result, run, str};
 use package_path::RemotePath;
 use extra::tempfile::mkdtemp;
@@ -112,7 +113,7 @@ pub fn try_getting_version(remote_path: &RemotePath) -> Option<Version> {
                                             ~"tag", ~"-l"]);
             let output_text = str::from_bytes(outp.output);
             debug!("Full output: ( %s ) [%?]", output_text, outp.status);
-            for output_text.each_split_char('\n') |l| {
+            for output_text.line_iter().advance |l| {
                 debug!("A line of output: %s", l);
                 if !l.is_whitespace() {
                     output = Some(l);
@@ -162,11 +163,8 @@ fn try_parsing_version(s: &str) -> Option<Version> {
 
 /// Just an approximation
 fn is_url_like(p: &RemotePath) -> bool {
-    let mut n = 0;
-    for p.to_str().each_split_char('/') |_| {
-        n += 1;
-    }
-    n > 2
+    let str = p.to_str();
+    str.split_iter('/').count() > 2
 }
 
 /// If s is of the form foo#bar, where bar is a valid version

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -175,7 +175,7 @@ pub fn split_version<'a>(s: &'a str) -> Option<(&'a str, Version)> {
     if { let mut i: uint = 0; for str::to_chars(s).each |&c| { if c == '#' { i += 1; } }; i > 1 } {
         return None;
     }
-    match str::rfind_char(s, '#') {
+    match s.rfind('#') {
         Some(i) => {
             debug!("in %s, i = %?", s, i);
             let path = s.slice(0, i);

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -143,8 +143,7 @@ fn try_parsing_version(s: &str) -> Option<Version> {
     let s = s.trim();
     debug!("Attempting to parse: %s", s);
     let mut parse_state = Start;
-    // I gave up on using external iterators (tjc)
-    for str::to_chars(s).each() |&c| {
+    for s.iter().advance |&c| {
         if char::is_digit(c) {
             parse_state = SawDigit;
         }
@@ -172,7 +171,7 @@ fn is_url_like(p: &RemotePath) -> bool {
 /// Otherwise, return None.
 pub fn split_version<'a>(s: &'a str) -> Option<(&'a str, Version)> {
     // reject strings with multiple '#'s
-    if { let mut i: uint = 0; for str::to_chars(s).each |&c| { if c == '#' { i += 1; } }; i > 1 } {
+    if s.splitn_iter('#', 2).count() > 1 {
         return None;
     }
     match s.rfind('#') {

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -143,7 +143,7 @@ fn try_parsing_version(s: &str) -> Option<Version> {
     let s = s.trim();
     debug!("Attempting to parse: %s", s);
     let mut parse_state = Start;
-    for s.iter().advance |&c| {
+    for s.iter().advance |c| {
         if char::is_digit(c) {
             parse_state = SawDigit;
         }
@@ -171,7 +171,7 @@ fn is_url_like(p: &RemotePath) -> bool {
 /// Otherwise, return None.
 pub fn split_version<'a>(s: &'a str) -> Option<(&'a str, Version)> {
     // reject strings with multiple '#'s
-    if s.splitn_iter('#', 2).count() > 1 {
+    if s.splitn_iter('#', 2).count() > 2 {
         return None;
     }
     match s.rfind('#') {

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -1836,7 +1836,6 @@ mod tests {
     use io;
     use path::Path;
     use result;
-    use str;
     use u64;
     use vec;
 

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -1979,7 +1979,7 @@ mod tests {
     fn file_writer_bad_name() {
         match io::file_writer(&Path("?/?"), []) {
           result::Err(e) => {
-            assert!(str::starts_with(e, "error opening"));
+            assert!(e.starts_with("error opening"));
           }
           result::Ok(_) => fail!()
         }
@@ -1989,7 +1989,7 @@ mod tests {
     fn buffered_file_writer_bad_name() {
         match io::buffered_file_writer(&Path("?/?")) {
           result::Err(e) => {
-            assert!(str::starts_with(e, "error opening"));
+            assert!(e.starts_with("error opening"));
           }
           result::Ok(_) => fail!()
         }

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -748,7 +748,7 @@ impl<T:Reader> ReaderUtil for T {
             if self.eof() && line.is_empty() { break; }
 
             // trim the \n, so that each_line is consistent with read_line
-            let n = str::len(line);
+            let n = line.len();
             if line[n-1] == '\n' as u8 {
                 unsafe { str::raw::set_len(&mut line, n-1); }
             }

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -672,7 +672,7 @@ impl<T:Reader> ReaderUtil for T {
                     val <<= 6;
                     val += (next & 63) as uint;
                 }
-                // See str::char_at
+                // See str::StrSlice::char_at
                 val += ((b0 << ((w + 1) as u8)) as uint)
                     << (w - 1) * 6 - w - 1u;
                 chars.push(val as char);

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -30,6 +30,7 @@
 
 use cast;
 use io;
+use iterator::IteratorUtil;
 use libc;
 use libc::{c_char, c_void, c_int, size_t};
 use libc::{mode_t, FILE};
@@ -224,12 +225,11 @@ pub fn env() -> ~[(~str,~str)] {
         fn env_convert(input: ~[~str]) -> ~[(~str, ~str)] {
             let mut pairs = ~[];
             for input.each |p| {
-                let mut vs = ~[];
-                for str::each_splitn_char(*p, '=', 1) |s| { vs.push(s.to_owned()) }
+                let vs: ~[&str] = p.splitn_iter('=', 1).collect();
                 debug!("splitting: len: %u",
                     vs.len());
                 assert_eq!(vs.len(), 2);
-                pairs.push((copy vs[0], copy vs[1]));
+                pairs.push((vs[0].to_owned(), vs[1].to_owned()));
             }
             pairs
         }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -525,7 +525,7 @@ pub fn self_exe_path() -> Option<Path> {
  */
 pub fn homedir() -> Option<Path> {
     return match getenv("HOME") {
-        Some(ref p) => if !str::is_empty(*p) {
+        Some(ref p) => if !p.is_empty() {
           Some(Path(*p))
         } else {
           secondary()
@@ -541,7 +541,7 @@ pub fn homedir() -> Option<Path> {
     #[cfg(windows)]
     fn secondary() -> Option<Path> {
         do getenv(~"USERPROFILE").chain |p| {
-            if !str::is_empty(p) {
+            if !p.is_empty() {
                 Some(Path(p))
             } else {
                 None
@@ -566,7 +566,7 @@ pub fn tmpdir() -> Path {
     fn getenv_nonempty(v: &str) -> Option<Path> {
         match getenv(v) {
             Some(x) =>
-                if str::is_empty(x) {
+                if x.is_empty() {
                     None
                 } else {
                     Some(Path(x))
@@ -1449,6 +1449,7 @@ mod tests {
     use rand;
     use run;
     use str;
+    use str::StrSlice;
     use vec;
     use libc::consts::os::posix88::{S_IRUSR, S_IWUSR, S_IXUSR};
 
@@ -1606,7 +1607,7 @@ mod tests {
 
     #[test]
     fn tmpdir() {
-        assert!(!str::is_empty(os::tmpdir().to_str()));
+        assert!(!os::tmpdir().to_str().is_empty());
     }
 
     // Issue #712
@@ -1671,7 +1672,7 @@ mod tests {
         unsafe {
           let tempdir = getcwd(); // would like to use $TMPDIR,
                                   // doesn't seem to work on Linux
-          assert!((str::len(tempdir.to_str()) > 0u));
+          assert!((tempdir.to_str().len() > 0u));
           let in = tempdir.push("in.txt");
           let out = tempdir.push("out.txt");
 
@@ -1686,7 +1687,7 @@ mod tests {
           let mut buf = str::to_bytes(s) + [0 as u8];
           do vec::as_mut_buf(buf) |b, _len| {
               assert!((libc::fwrite(b as *c_void, 1u as size_t,
-                                   (str::len(s) + 1u) as size_t, ostream)
+                                   (s.len() + 1u) as size_t, ostream)
                       == buf.len() as size_t))
           }
           assert_eq!(libc::fclose(ostream), (0u as c_int));

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -18,6 +18,7 @@ Cross-platform file path handling
 
 use container::Container;
 use cmp::Eq;
+use iterator::IteratorUtil;
 use libc;
 use option::{None, Option, Some};
 use str;
@@ -449,10 +450,9 @@ impl ToStr for PosixPath {
 // PosixPath and WindowsPath, most of their methods are common.
 impl GenericPath for PosixPath {
     fn from_str(s: &str) -> PosixPath {
-        let mut components = ~[];
-        for str::each_split_nonempty(s, |c| c == '/') |s| {
-            components.push(s.to_owned())
-        }
+        let components = s.split_iter('/')
+            .filter_map(|s| if s.is_empty() {None} else {Some(s.to_owned())})
+            .collect();
         let is_absolute = (s.len() != 0 && s[0] == '/' as u8);
         PosixPath {
             is_absolute: is_absolute,
@@ -508,7 +508,7 @@ impl GenericPath for PosixPath {
     }
 
     fn with_filename(&self, f: &str) -> PosixPath {
-        assert!(! str::any(f, |c| windows::is_sep(c as u8)));
+        assert!(! str::any(f, |c| windows::is_sep(c)));
         self.dir_path().push(f)
     }
 
@@ -569,11 +569,11 @@ impl GenericPath for PosixPath {
     fn push_many(&self, cs: &[~str]) -> PosixPath {
         let mut v = copy self.components;
         for cs.each |e| {
-            let mut ss = ~[];
-            for str::each_split_nonempty(*e, |c| windows::is_sep(c as u8)) |s| {
-                ss.push(s.to_owned())
+            for e.split_iter(windows::is_sep).advance |s| {
+                if !s.is_empty() {
+                    v.push(s.to_owned())
+                }
             }
-            v.push_all_move(ss);
         }
         PosixPath {
             is_absolute: self.is_absolute,
@@ -583,11 +583,11 @@ impl GenericPath for PosixPath {
 
     fn push(&self, s: &str) -> PosixPath {
         let mut v = copy self.components;
-        let mut ss = ~[];
-        for str::each_split_nonempty(s, |c| windows::is_sep(c as u8)) |s| {
-            ss.push(s.to_owned())
+        for s.split_iter(windows::is_sep).advance |s| {
+            if !s.is_empty() {
+                v.push(s.to_owned())
+            }
         }
-        v.push_all_move(ss);
         PosixPath { components: v, ..copy *self }
     }
 
@@ -661,11 +661,11 @@ impl GenericPath for WindowsPath {
             }
         }
 
-        let mut components = ~[];
-        for str::each_split_nonempty(rest, |c| windows::is_sep(c as u8)) |s| {
-            components.push(s.to_owned())
-        }
-        let is_absolute = (rest.len() != 0 && windows::is_sep(rest[0]));
+        let components = rest.split_iter(windows::is_sep)
+            .filter_map(|s| if s.is_empty() {None} else {Some(s.to_owned())})
+            .collect();
+
+        let is_absolute = (rest.len() != 0 && windows::is_sep(rest[0] as char));
         WindowsPath {
             host: host,
             device: device,
@@ -722,7 +722,7 @@ impl GenericPath for WindowsPath {
     }
 
     fn with_filename(&self, f: &str) -> WindowsPath {
-        assert!(! str::any(f, |c| windows::is_sep(c as u8)));
+        assert!(! str::any(f, |c| windows::is_sep(c)));
         self.dir_path().push(f)
     }
 
@@ -826,11 +826,11 @@ impl GenericPath for WindowsPath {
     fn push_many(&self, cs: &[~str]) -> WindowsPath {
         let mut v = copy self.components;
         for cs.each |e| {
-            let mut ss = ~[];
-            for str::each_split_nonempty(*e, |c| windows::is_sep(c as u8)) |s| {
-                ss.push(s.to_owned())
+            for e.split_iter(windows::is_sep).advance |s| {
+                if !s.is_empty() {
+                    v.push(s.to_owned())
+                }
             }
-            v.push_all_move(ss);
         }
         // tedious, but as-is, we can't use ..self
         WindowsPath {
@@ -843,11 +843,11 @@ impl GenericPath for WindowsPath {
 
     fn push(&self, s: &str) -> WindowsPath {
         let mut v = copy self.components;
-        let mut ss = ~[];
-        for str::each_split_nonempty(s, |c| windows::is_sep(c as u8)) |s| {
-            ss.push(s.to_owned())
+        for s.split_iter(windows::is_sep).advance |s| {
+            if !s.is_empty() {
+                v.push(s.to_owned())
+            }
         }
-        v.push_all_move(ss);
         WindowsPath { components: v, ..copy *self }
     }
 
@@ -905,8 +905,8 @@ pub mod windows {
     use option::{None, Option, Some};
 
     #[inline(always)]
-    pub fn is_sep(u: u8) -> bool {
-        u == '/' as u8 || u == '\\' as u8
+    pub fn is_sep(u: char) -> bool {
+        u == '/' || u == '\\'
     }
 
     pub fn extract_unc_prefix(s: &str) -> Option<(~str,~str)> {
@@ -915,7 +915,7 @@ pub mod windows {
             s[0] == s[1]) {
             let mut i = 2;
             while i < s.len() {
-                if is_sep(s[i]) {
+                if is_sep(s[i] as char) {
                     let pre = s.slice(2, i).to_owned();
                     let rest = s.slice(i, s.len()).to_owned();
                     return Some((pre, rest));

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -479,8 +479,8 @@ impl GenericPath for PosixPath {
         match self.filename() {
             None => None,
             Some(ref f) => {
-                match str::rfind_char(*f, '.') {
-                    Some(p) => Some(f.slice(0, p).to_owned()),
+                match f.rfind('.') {
+                    Some(p) => Some(f.slice_to(p).to_owned()),
                     None => Some(copy *f),
                 }
             }
@@ -491,8 +491,8 @@ impl GenericPath for PosixPath {
         match self.filename() {
             None => None,
             Some(ref f) => {
-                match str::rfind_char(*f, '.') {
-                    Some(p) if p < f.len() => Some(f.slice(p, f.len()).to_owned()),
+                match f.rfind('.') {
+                    Some(p) if p < f.len() => Some(f.slice_from(p).to_owned()),
                     _ => None,
                 }
             }
@@ -693,8 +693,8 @@ impl GenericPath for WindowsPath {
         match self.filename() {
             None => None,
             Some(ref f) => {
-                match str::rfind_char(*f, '.') {
-                    Some(p) => Some(f.slice(0, p).to_owned()),
+                match f.rfind('.') {
+                    Some(p) => Some(f.slice_to(p).to_owned()),
                     None => Some(copy *f),
                 }
             }
@@ -705,8 +705,8 @@ impl GenericPath for WindowsPath {
         match self.filename() {
           None => None,
           Some(ref f) => {
-            match str::rfind_char(*f, '.') {
-                Some(p) if p < f.len() => Some(f.slice(p, f.len()).to_owned()),
+            match f.rfind('.') {
+                Some(p) if p < f.len() => Some(f.slice_from(p).to_owned()),
                 _ => None,
             }
           }

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -508,7 +508,7 @@ impl GenericPath for PosixPath {
     }
 
     fn with_filename(&self, f: &str) -> PosixPath {
-        assert!(! str::any(f, |c| windows::is_sep(c)));
+        assert!(! f.iter().all(windows::is_sep));
         self.dir_path().push(f)
     }
 
@@ -722,7 +722,7 @@ impl GenericPath for WindowsPath {
     }
 
     fn with_filename(&self, f: &str) -> WindowsPath {
-        assert!(! str::any(f, |c| windows::is_sep(c)));
+        assert!(! f.iter().all(windows::is_sep));
         self.dir_path().push(f)
     }
 

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -22,7 +22,7 @@ use iterator::IteratorUtil;
 use libc;
 use option::{None, Option, Some};
 use str;
-use str::StrSlice;
+use str::{StrSlice, StrVector};
 use to_str::ToStr;
 use ascii::{AsciiCast, AsciiStr};
 use old_iter::BaseIter;
@@ -442,7 +442,7 @@ impl ToStr for PosixPath {
         if self.is_absolute {
             s += "/";
         }
-        s + str::connect(self.components, "/")
+        s + self.components.connect("/")
     }
 }
 
@@ -629,7 +629,7 @@ impl ToStr for WindowsPath {
         if self.is_absolute {
             s += "\\";
         }
-        s + str::connect(self.components, "\\")
+        s + self.components.connect("\\")
     }
 }
 

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -12,6 +12,7 @@
 
 #[allow(missing_doc)];
 
+use iterator::IteratorUtil;
 use cast;
 use comm::{stream, SharedChan, GenericChan, GenericPort};
 use int;

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -588,7 +588,7 @@ pub fn make_command_line(prog: &str, args: &[~str]) -> ~str {
     return cmd;
 
     fn append_arg(cmd: &mut ~str, arg: &str) {
-        let quote = arg.any(|c| c == ' ' || c == '\t');
+        let quote = arg.iter().any(|c| c == ' ' || c == '\t');
         if quote {
             cmd.push_char('"');
         }

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -432,16 +432,6 @@ pub fn byte_slice_no_callback<'a>(s: &'a str) -> &'a [u8] {
     }
 }
 
-/**
- * Take a substring of another.
- *
- * Returns a slice pointing at `n` characters starting from byte offset
- * `begin`.
- */
-pub fn substr<'a>(s: &'a str, begin: uint, n: uint) -> &'a str {
-    s.slice(begin, begin + count_bytes(s, begin, n))
-}
-
 /// Something that can be used to compare against a character
 pub trait CharEq {
     /// Determine if the splitter should split at the given character
@@ -1854,7 +1844,7 @@ impl<'self> StrSlice<'self> for &'self str {
      */
     #[inline]
     fn substr(&self, begin: uint, n: uint) -> &'self str {
-        substr(*self, begin, n)
+        s.slice(begin, begin + count_bytes(s, begin, n))
     }
     /// Escape each char in `s` with char::escape_default.
     #[inline]
@@ -2516,11 +2506,11 @@ mod tests {
     #[test]
     fn test_substr() {
         fn t(a: &str, b: &str, start: int) {
-            assert_eq!(substr(a, start as uint, b.len()), b);
+            assert_eq!(a.substr(start as uint, b.len()), b);
         }
         t("hello", "llo", 2);
         t("hello", "el", 1);
-        assert_eq!("ะเทศไท", substr("ประเทศไทย中华Việt Nam", 6u, 6u));
+        assert_eq!("ะเทศไท", "ประเทศไทย中华Việt Nam".substr(6u, 6u));
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1800,7 +1800,7 @@ impl<'self> StrSlice<'self> for &'self str {
      */
     #[inline]
     fn substr(&self, begin: uint, n: uint) -> &'self str {
-        s.slice(begin, begin + count_bytes(s, begin, n))
+        self.slice(begin, begin + count_bytes(*self, begin, n))
     }
     /// Escape each char in `s` with char::escape_default.
     #[inline]
@@ -2318,7 +2318,6 @@ impl<'self> Iterator<u8> for StrBytesRevIterator<'self> {
 mod tests {
     use iterator::IteratorUtil;
     use container::Container;
-    use char;
     use option::Some;
     use libc::c_char;
     use libc;
@@ -3024,14 +3023,6 @@ mod tests {
     fn test_map() {
         assert_eq!(~"", map("", |c| unsafe {libc::toupper(c as c_char)} as char));
         assert_eq!(~"YMCA", map("ymca", |c| unsafe {libc::toupper(c as c_char)} as char));
-    }
-
-    #[test]
-    fn test_chars() {
-        let ss = ~"ศไทย中华Việt Nam";
-        assert!(~['ศ','ไ','ท','ย','中','华','V','i','ệ','t',' ','N','a',
-                       'm']
-            == to_chars(ss));
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1168,30 +1168,6 @@ fn match_at<'a,'b>(haystack: &'a str, needle: &'b str, at: uint) -> bool {
 
 
 /**
- * Returns true if one string contains another
- *
- * # Arguments
- *
- * * haystack - The string to look in
- * * needle - The string to look for
- */
-pub fn contains<'a,'b>(haystack: &'a str, needle: &'b str) -> bool {
-    haystack.find_str(needle).is_some()
-}
-
-/**
- * Returns true if a string contains a char.
- *
- * # Arguments
- *
- * * haystack - The string to look in
- * * needle - The char to look for
- */
-pub fn contains_char(haystack: &str, needle: char) -> bool {
-    haystack.find(needle).is_some()
-}
-
-/**
  * Returns true if one string starts with another
  *
  * # Arguments
@@ -2019,15 +1995,27 @@ pub trait StrSlice<'self> {
 
 /// Extension methods for strings
 impl<'self> StrSlice<'self> for &'self str {
-    /// Returns true if one string contains another
+    /**
+     * Returns true if one string contains another
+     *
+     * # Arguments
+     *
+     * * needle - The string to look for
+     */
     #[inline]
     fn contains<'a>(&self, needle: &'a str) -> bool {
-        contains(*self, needle)
+        self.find_str(needle).is_some()
     }
-    /// Returns true if a string contains a char
+    /**
+     * Returns true if a string contains a char.
+     *
+     * # Arguments
+     *
+     * * needle - The char to look for
+     */
     #[inline]
     fn contains_char(&self, needle: char) -> bool {
-        contains_char(*self, needle)
+        self.find(needle).is_some()
     }
 
     #[inline]
@@ -3060,19 +3048,19 @@ mod tests {
 
     #[test]
     fn test_contains() {
-        assert!(contains("abcde", "bcd"));
-        assert!(contains("abcde", "abcd"));
-        assert!(contains("abcde", "bcde"));
-        assert!(contains("abcde", ""));
-        assert!(contains("", ""));
-        assert!(!contains("abcde", "def"));
-        assert!(!contains("", "a"));
+        assert!("abcde".contains("bcd"));
+        assert!("abcde".contains("abcd"));
+        assert!("abcde".contains("bcde"));
+        assert!("abcde".contains(""));
+        assert!("".contains(""));
+        assert!(!"abcde".contains("def"));
+        assert!(!"".contains("a"));
 
         let data = ~"ประเทศไทย中华Việt Nam";
-        assert!(contains(data, "ประเ"));
-        assert!(contains(data, "ะเ"));
-        assert!(contains(data, "中华"));
-        assert!(!contains(data, "ไท华"));
+        assert!(data.contains("ประเ"));
+        assert!(data.contains("ะเ"));
+        assert!(data.contains("中华"));
+        assert!(!data.contains("ไท华"));
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -432,11 +432,6 @@ pub fn byte_slice_no_callback<'a>(s: &'a str) -> &'a [u8] {
     }
 }
 
-/// Convert a string to a unique vector of characters
-pub fn to_chars(s: &str) -> ~[char] {
-    s.iter().collect()
-}
-
 /**
  * Take a substring of another.
  *

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1175,22 +1175,6 @@ impl<'self> Equiv<~str> for &'self str {
 Section: Iterating through strings
 */
 
-/**
- * Return true if a predicate matches all characters or if the string
- * contains no characters
- */
-pub fn all(s: &str, it: &fn(char) -> bool) -> bool {
-    all_between(s, 0u, len(s), it)
-}
-
-/**
- * Return true if a predicate matches any character (and false if it
- * matches none or there are no characters)
- */
-pub fn any(ss: &str, pred: &fn(char) -> bool) -> bool {
-    !all(ss, |cc| !pred(cc))
-}
-
 /// Apply a function to each character
 pub fn map(ss: &str, ff: &fn(char) -> char) -> ~str {
     let mut result = ~"";
@@ -1675,7 +1659,7 @@ pub fn is_empty(s: &str) -> bool { len(s) == 0u }
  * Whitespace characters are determined by `char::is_whitespace`
  */
 pub fn is_whitespace(s: &str) -> bool {
-    return all(s, char::is_whitespace);
+    s.iter().all(char::is_whitespace)
 }
 
 /**
@@ -1684,7 +1668,7 @@ pub fn is_whitespace(s: &str) -> bool {
  * Alphanumeric characters are determined by `char::is_alphanumeric`
  */
 fn is_alphanumeric(s: &str) -> bool {
-    return all(s, char::is_alphanumeric);
+    s.iter().all(char::is_alphanumeric)
 }
 
 /// Returns the string length/size in bytes not counting the null terminator
@@ -2467,8 +2451,6 @@ pub mod traits {}
 
 #[allow(missing_doc)]
 pub trait StrSlice<'self> {
-    fn all(&self, it: &fn(char) -> bool) -> bool;
-    fn any(&self, it: &fn(char) -> bool) -> bool;
     fn contains<'a>(&self, needle: &'a str) -> bool;
     fn contains_char(&self, needle: char) -> bool;
     fn iter(&self) -> StrCharIterator<'self>;
@@ -2514,18 +2496,6 @@ pub trait StrSlice<'self> {
 
 /// Extension methods for strings
 impl<'self> StrSlice<'self> for &'self str {
-    /**
-     * Return true if a predicate matches all characters or if the string
-     * contains no characters
-     */
-    #[inline]
-    fn all(&self, it: &fn(char) -> bool) -> bool { all(*self, it) }
-    /**
-     * Return true if a predicate matches any character (and false if it
-     * matches none or there are no characters)
-     */
-    #[inline]
-    fn any(&self, it: &fn(char) -> bool) -> bool { any(*self, it) }
     /// Returns true if one string contains another
     #[inline]
     fn contains<'a>(&self, needle: &'a str) -> bool {
@@ -3520,24 +3490,6 @@ mod tests {
     fn test_map() {
         assert_eq!(~"", map("", |c| unsafe {libc::toupper(c as c_char)} as char));
         assert_eq!(~"YMCA", map("ymca", |c| unsafe {libc::toupper(c as c_char)} as char));
-    }
-
-    #[test]
-    fn test_all() {
-        assert_eq!(true, all("", char::is_uppercase));
-        assert_eq!(false, all("ymca", char::is_uppercase));
-        assert_eq!(true, all("YMCA", char::is_uppercase));
-        assert_eq!(false, all("yMCA", char::is_uppercase));
-        assert_eq!(false, all("YMCy", char::is_uppercase));
-    }
-
-    #[test]
-    fn test_any() {
-        assert_eq!(false, any("", char::is_uppercase));
-        assert_eq!(false, any("ymca", char::is_uppercase));
-        assert_eq!(true, any("YMCA", char::is_uppercase));
-        assert_eq!(true, any("yMCA", char::is_uppercase));
-        assert_eq!(true, any("Ymcy", char::is_uppercase));
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -170,18 +170,6 @@ pub fn append(lhs: ~str, rhs: &str) -> ~str {
     v
 }
 
-/// Concatenate a vector of strings
-pub fn concat(v: &[~str]) -> ~str { v.concat() }
-
-/// Concatenate a vector of strings
-pub fn concat_slices(v: &[&str]) -> ~str { v.concat() }
-
-/// Concatenate a vector of strings, placing a given separator between each
-pub fn connect(v: &[~str], sep: &str) -> ~str { v.connect(sep) }
-
-/// Concatenate a vector of strings, placing a given separator between each
-pub fn connect_slices(v: &[&str], sep: &str) -> ~str { v.connect(sep) }
-
 #[allow(missing_doc)]
 pub trait StrVector {
     pub fn concat(&self) -> ~str;
@@ -2495,7 +2483,6 @@ mod tests {
     #[test]
     fn test_concat() {
         fn t(v: &[~str], s: &str) {
-            assert_eq!(concat(v), s.to_str());
             assert_eq!(v.concat(), s.to_str());
         }
         t([~"you", ~"know", ~"I'm", ~"no", ~"good"], "youknowI'mnogood");
@@ -2507,7 +2494,6 @@ mod tests {
     #[test]
     fn test_connect() {
         fn t(v: &[~str], sep: &str, s: &str) {
-            assert_eq!(connect(v, sep), s.to_str());
             assert_eq!(v.connect(sep), s.to_str());
         }
         t([~"you", ~"know", ~"I'm", ~"no", ~"good"],
@@ -2520,7 +2506,6 @@ mod tests {
     #[test]
     fn test_concat_slices() {
         fn t(v: &[&str], s: &str) {
-            assert_eq!(concat_slices(v), s.to_str());
             assert_eq!(v.concat(), s.to_str());
         }
         t(["you", "know", "I'm", "no", "good"], "youknowI'mnogood");
@@ -2532,7 +2517,6 @@ mod tests {
     #[test]
     fn test_connect_slices() {
         fn t(v: &[&str], sep: &str, s: &str) {
-            assert_eq!(connect_slices(v, sep), s.to_str());
             assert_eq!(v.connect(sep), s.to_str());
         }
         t(["you", "know", "I'm", "no", "good"],
@@ -3306,7 +3290,6 @@ mod tests {
         let lines: ~[&str] = data.line_iter().collect();
         assert_eq!(lines, ~["", "Märy häd ä little lämb", "", "Little lämb"]);
     }
-
 
     #[test]
     fn test_split_str_iterator() {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -32,7 +32,6 @@ use option::{None, Option, Some};
 use old_iter::{BaseIter, EqIter};
 use ptr;
 use ptr::RawPtr;
-use str;
 use to_str::ToStr;
 use uint;
 use vec;

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -981,24 +981,6 @@ fn match_at<'a,'b>(haystack: &'a str, needle: &'b str, at: uint) -> bool {
 Section: String properties
 */
 
-/**
- * Returns true if the string contains only whitespace
- *
- * Whitespace characters are determined by `char::is_whitespace`
- */
-pub fn is_whitespace(s: &str) -> bool {
-    s.iter().all(char::is_whitespace)
-}
-
-/**
- * Returns true if the string contains only alphanumerics
- *
- * Alphanumeric characters are determined by `char::is_alphanumeric`
- */
-fn is_alphanumeric(s: &str) -> bool {
-    s.iter().all(char::is_alphanumeric)
-}
-
 /// Returns the number of characters that a string holds
 #[inline(always)]
 pub fn char_len(s: &str) -> uint { count_chars(s, 0u, s.len()) }
@@ -1749,14 +1731,14 @@ impl<'self> StrSlice<'self> for &'self str {
      * Whitespace characters are determined by `char::is_whitespace`
      */
     #[inline]
-    fn is_whitespace(&self) -> bool { is_whitespace(*self) }
+    fn is_whitespace(&self) -> bool { self.iter().all(char::is_whitespace) }
     /**
      * Returns true if the string contains only alphanumerics
      *
      * Alphanumeric characters are determined by `char::is_alphanumeric`
      */
     #[inline]
-    fn is_alphanumeric(&self) -> bool { is_alphanumeric(*self) }
+    fn is_alphanumeric(&self) -> bool { self.iter().all(char::is_alphanumeric) }
     /// Returns the size in bytes not counting the null terminator
     #[inline(always)]
     fn len(&self) -> uint {
@@ -2773,11 +2755,11 @@ mod tests {
 
     #[test]
     fn test_is_whitespace() {
-        assert!(is_whitespace(""));
-        assert!(is_whitespace(" "));
-        assert!(is_whitespace("\u2009")); // Thin space
-        assert!(is_whitespace("  \n\t   "));
-        assert!(!is_whitespace("   _   "));
+        assert!("".is_whitespace());
+        assert!(" ".is_whitespace());
+        assert!("\u2009".is_whitespace()); // Thin space
+        assert!("  \n\t   ".is_whitespace());
+        assert!(!"   _   ".is_whitespace());
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1623,66 +1623,6 @@ pub fn char_at_reverse(s: &str, i: uint) -> char {
     char_range_at_reverse(s, i).ch
 }
 
-/**
- * Loop through a substring, char by char
- *
- * # Safety note
- *
- * * This function does not check whether the substring is valid.
- * * This function fails if `start` or `end` do not
- *   represent valid positions inside `s`
- *
- * # Arguments
- *
- * * s - A string to traverse. It may be empty.
- * * start - The byte offset at which to start in the string.
- * * end - The end of the range to traverse
- * * it - A block to execute with each consecutive character of `s`.
- *        Return `true` to continue, `false` to stop.
- *
- * # Return value
- *
- * `true` If execution proceeded correctly, `false` if it was interrupted,
- * that is if `it` returned `false` at any point.
- */
-pub fn all_between(s: &str, start: uint, end: uint,
-                    it: &fn(char) -> bool) -> bool {
-    assert!(is_char_boundary(s, start));
-    let mut i = start;
-    while i < end {
-        let CharRange {ch, next} = char_range_at(s, i);
-        if !it(ch) { return false; }
-        i = next;
-    }
-    return true;
-}
-
-/**
- * Loop through a substring, char by char
- *
- * # Safety note
- *
- * * This function does not check whether the substring is valid.
- * * This function fails if `start` or `end` do not
- *   represent valid positions inside `s`
- *
- * # Arguments
- *
- * * s - A string to traverse. It may be empty.
- * * start - The byte offset at which to start in the string.
- * * end - The end of the range to traverse
- * * it - A block to execute with each consecutive character of `s`.
- *        Return `true` to continue, `false` to stop.
- *
- * # Return value
- *
- * `true` if `it` returns `true` for any character
- */
-pub fn any_between(s: &str, start: uint, end: uint,
-                    it: &fn(char) -> bool) -> bool {
-    !all_between(s, start, end, |c| !it(c))
-}
-
 // UTF-8 tags and ranges
 static tag_cont_u8: u8 = 128u8;
 static tag_cont: uint = 128u;

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1194,8 +1194,8 @@ pub fn with_capacity(capacity: uint) -> ~str {
  * The number of Unicode characters in `s` between the given indices.
  */
 pub fn count_chars(s: &str, start: uint, end: uint) -> uint {
-    assert!(is_char_boundary(s, start));
-    assert!(is_char_boundary(s, end));
+    assert!(s.is_char_boundary(start));
+    assert!(s.is_char_boundary(end));
     let mut (i, len) = (start, 0u);
     while i < end {
         let next = s.char_range_at(i).next;
@@ -1208,7 +1208,7 @@ pub fn count_chars(s: &str, start: uint, end: uint) -> uint {
 /// Counts the number of bytes taken by the first `n` chars in `s`
 /// starting from `start`.
 pub fn count_bytes<'b>(s: &'b str, start: uint, n: uint) -> uint {
-    assert!(is_char_boundary(s, start));
+    assert!(s.is_char_boundary(start));
     let mut (end, cnt) = (start, n);
     let l = s.len();
     while cnt > 0u {
@@ -1658,7 +1658,7 @@ pub trait StrSlice<'self> {
     fn trim_right_chars(&self, chars_to_trim: &[char]) -> &'self str;
     fn to_owned(&self) -> ~str;
     fn to_managed(&self) -> @str;
-    fn is_char_boundary(s: &str, index: uint) -> bool;
+    fn is_char_boundary(&self, index: uint) -> bool;
     fn char_range_at(&self, start: uint) -> CharRange;
     fn char_at(&self, i: uint) -> char;
     fn char_range_at_reverse(&self, start: uint) -> CharRange;
@@ -1800,8 +1800,8 @@ impl<'self> StrSlice<'self> for &'self str {
      */
     #[inline]
     fn slice(&self, begin: uint, end: uint) -> &'self str {
-        assert!(is_char_boundary(*self, begin));
-        assert!(is_char_boundary(*self, end));
+        assert!(self.is_char_boundary(begin));
+        assert!(self.is_char_boundary(end));
         unsafe { raw::slice_bytes(*self, begin, end) }
     }
     #[inline]
@@ -2284,7 +2284,7 @@ impl<'self> Iterator<char> for StrCharIterator<'self> {
     #[inline]
     fn next(&mut self) -> Option<char> {
         if self.index < self.string.len() {
-            let CharRange {ch, next} = char_range_at(self.string, self.index);
+            let CharRange {ch, next} = self.string.char_range_at(self.index);
             self.index = next;
             Some(ch)
         } else {
@@ -2303,7 +2303,7 @@ impl<'self> Iterator<char> for StrCharRevIterator<'self> {
     #[inline]
     fn next(&mut self) -> Option<char> {
         if self.index > 0 {
-            let CharRange {ch, next} = char_range_at_reverse(self.string, self.index);
+            let CharRange {ch, next} = self.string.char_range_at_reverse(self.index);
             self.index = next;
             Some(ch)
         } else {
@@ -2461,7 +2461,7 @@ mod tests {
 
         let data = "abcabc";
         assert_eq!(data.slice(0u, 6u).find_str("ab"), Some(0u));
-        assert_eq!(data.slice(2u, 6u).find_str("ab"), Some(3u));
+        assert_eq!(data.slice(2u, 6u).find_str("ab"), Some(3u - 2u));
         assert!(data.slice(2u, 4u).find_str("ab").is_none());
 
         let mut data = ~"ประเทศไทย中华Việt Nam";
@@ -3042,10 +3042,10 @@ mod tests {
 
     #[test]
     fn test_contains_char() {
-        assert!(contains_char("abc", 'b'));
-        assert!(contains_char("a", 'a'));
-        assert!(!contains_char("abc", 'd'));
-        assert!(!contains_char("", 'a'));
+        assert!("abc".contains_char('b'));
+        assert!("a".contains_char('a'));
+        assert!(!"abc".contains_char('d'));
+        assert!(!"".contains_char('a'));
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -977,36 +977,6 @@ fn match_at<'a,'b>(haystack: &'a str, needle: &'b str, at: uint) -> bool {
 }
 
 
-/**
- * Returns true if one string starts with another
- *
- * # Arguments
- *
- * * haystack - The string to look in
- * * needle - The string to look for
- */
-pub fn starts_with<'a,'b>(haystack: &'a str, needle: &'b str) -> bool {
-    let (haystack_len, needle_len) = (haystack.len(), needle.len());
-    if needle_len == 0u { true }
-    else if needle_len > haystack_len { false }
-    else { match_at(haystack, needle, 0u) }
-}
-
-/**
- * Returns true if one string ends with another
- *
- * # Arguments
- *
- * * haystack - The string to look in
- * * needle - The string to look for
- */
-pub fn ends_with<'a,'b>(haystack: &'a str, needle: &'b str) -> bool {
-    let (haystack_len, needle_len) = (haystack.len(), needle.len());
-    if needle_len == 0u { true }
-    else if needle_len > haystack_len { false }
-    else { match_at(haystack, needle, haystack_len - needle_len) }
-}
-
 /*
 Section: String properties
 */
@@ -1600,7 +1570,7 @@ pub trait StrSlice<'self> {
     fn slice(&self, begin: uint, end: uint) -> &'self str;
     fn slice_from(&self, begin: uint) -> &'self str;
     fn slice_to(&self, end: uint) -> &'self str;
-    fn starts_with<'a>(&self, needle: &'a str) -> bool;
+    fn starts_with(&self, needle: &str) -> bool;
     fn substr(&self, begin: uint, n: uint) -> &'self str;
     fn escape_default(&self) -> ~str;
     fn escape_unicode(&self) -> ~str;
@@ -1770,12 +1740,6 @@ impl<'self> StrSlice<'self> for &'self str {
         self.split_iter(char::is_whitespace).filter(|s| !s.is_empty())
     }
 
-
-    /// Returns true if one string ends with another
-    #[inline]
-    fn ends_with(&self, needle: &str) -> bool {
-        ends_with(*self, needle)
-    }
     /// Returns true if the string has length 0
     #[inline]
     fn is_empty(&self) -> bool { self.len() == 0 }
@@ -1831,11 +1795,21 @@ impl<'self> StrSlice<'self> for &'self str {
     fn slice_to(&self, end: uint) -> &'self str {
         self.slice(0, end)
     }
-    /// Checks if `needle` is a prefix of the string.
-    #[inline]
+    /// Returns true if `needle` is a prefix of the string.
     fn starts_with<'a>(&self, needle: &'a str) -> bool {
-        starts_with(*self, needle)
+        let (self_len, needle_len) = (self.len(), needle.len());
+        if needle_len == 0u { true }
+        else if needle_len > self_len { false }
+        else { match_at(*self, needle, 0u) }
     }
+    /// Returns true if `needle` is a suffix of the string.
+    pub fn ends_with(&self, needle: &str) -> bool {
+        let (self_len, needle_len) = (self.len(), needle.len());
+        if needle_len == 0u { true }
+        else if needle_len > self_len { false }
+        else { match_at(*self, needle, self_len - needle_len) }
+    }
+
     /**
      * Take a substring of another.
      *
@@ -2591,20 +2565,20 @@ mod tests {
 
     #[test]
     fn test_starts_with() {
-        assert!((starts_with("", "")));
-        assert!((starts_with("abc", "")));
-        assert!((starts_with("abc", "a")));
-        assert!((!starts_with("a", "abc")));
-        assert!((!starts_with("", "abc")));
+        assert!(("".starts_with("")));
+        assert!(("abc".starts_with("")));
+        assert!(("abc".starts_with("a")));
+        assert!((!"a".starts_with("abc")));
+        assert!((!"".starts_with("abc")));
     }
 
     #[test]
     fn test_ends_with() {
-        assert!((ends_with("", "")));
-        assert!((ends_with("abc", "")));
-        assert!((ends_with("abc", "c")));
-        assert!((!ends_with("a", "abc")));
-        assert!((!ends_with("", "abc")));
+        assert!(("".ends_with("")));
+        assert!(("abc".ends_with("")));
+        assert!(("abc".ends_with("c")));
+        assert!((!"a".ends_with("abc")));
+        assert!((!"".ends_with("abc")));
     }
 
     #[test]

--- a/src/libstd/str/ascii.rs
+++ b/src/libstd/str/ascii.rs
@@ -202,7 +202,6 @@ impl ToStrConsume for ~[Ascii] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use str;
 
     macro_rules! v2ascii (
         ( [$($e:expr),*]) => ( [$(Ascii{chr:$e}),*]);

--- a/src/libstd/str/ascii.rs
+++ b/src/libstd/str/ascii.rs
@@ -226,8 +226,8 @@ mod tests {
         assert_eq!('`'.to_ascii().to_upper().to_char(), '`');
         assert_eq!('{'.to_ascii().to_upper().to_char(), '{');
 
-        assert!(str::all("banana", |c| c.is_ascii()));
-        assert!(! str::all("ประเทศไทย中华Việt Nam", |c| c.is_ascii()));
+        assert!("banana".iter().all(|c| c.is_ascii()));
+        assert!(!"ประเทศไทย中华Việt Nam".iter().all(|c| c.is_ascii()));
     }
 
     #[test]

--- a/src/libstd/unstable/extfmt.rs
+++ b/src/libstd/unstable/extfmt.rs
@@ -547,7 +547,7 @@ pub mod rt {
         let unpadded = match cv.precision {
           CountImplied => s,
           CountIs(max) => if (max as uint) < str::char_len(s) {
-            str::slice(s, 0, max as uint)
+            s.slice(0, max as uint)
           } else {
             s
           }

--- a/src/libstd/unstable/lang.rs
+++ b/src/libstd/unstable/lang.rs
@@ -136,10 +136,10 @@ unsafe fn fail_borrowed(box: *mut BoxRepr, file: *c_char, line: size_t) {
             let mut sep = " at ";
             for borrow_list.rev_iter().advance |entry| {
                 if entry.box == box {
-                    str::push_str(&mut msg, sep);
+                    msg.push_str(sep);
                     let filename = str::raw::from_c_str(entry.file);
-                    str::push_str(&mut msg, filename);
-                    str::push_str(&mut msg, fmt!(":%u", entry.line as uint));
+                    msg.push_str(filename);
+                    msg.push_str(fmt!(":%u", entry.line as uint));
                     sep = " and at ";
                 }
             }

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -10,7 +10,6 @@
 
 use core::prelude::*;
 
-use core::str;
 use core::to_bytes;
 
 #[deriving(Eq)]
@@ -267,7 +266,7 @@ impl ToStr for AbiSet {
         for self.each |abi| {
             strs.push(abi.data().name);
         }
-        fmt!("\"%s\"", str::connect_slices(strs, " "))
+        fmt!("\"%s\"", strs.connect(" "))
     }
 }
 

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -24,7 +24,6 @@ use syntax::parse::token::special_idents;
 
 use core::cmp;
 use core::hashmap::HashMap;
-use core::str;
 use core::vec;
 
 pub enum path_elt {

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -62,7 +62,7 @@ pub fn path_to_str_with_sep(p: &[path_elt], sep: &str, itr: @ident_interner)
           path_name(s) => copy *itr.get(s.name)
         }
     };
-    str::connect(strs, sep)
+    strs.connect(sep)
 }
 
 pub fn path_ident_to_str(p: &path, i: ident, itr: @ident_interner) -> ~str {

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -23,7 +23,6 @@ use visit;
 use core::hashmap::HashMap;
 use core::int;
 use core::option;
-use core::str;
 use core::to_bytes;
 
 pub fn path_name_i(idents: &[ident]) -> ~str {

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -28,7 +28,7 @@ use core::to_bytes;
 
 pub fn path_name_i(idents: &[ident]) -> ~str {
     // FIXME: Bad copies (#2543 -- same for everything else that says "bad")
-    str::connect(idents.map(|i| copy *token::interner_get(i.name)), "::")
+    idents.map(|i| copy *token::interner_get(i.name)).connect("::")
 }
 
 pub fn path_to_ident(p: @Path) -> ident { copy *p.idents.last() }

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -24,7 +24,6 @@ source code snippets, etc.
 use core::prelude::*;
 
 use core::cmp;
-use core::str;
 use core::to_bytes;
 use core::uint;
 use extra::serialize::{Encodable, Decodable, Encoder, Decoder};
@@ -288,11 +287,11 @@ impl FileMap {
     pub fn get_line(&self, line: int) -> ~str {
         let begin: BytePos = self.lines[line] - self.start_pos;
         let begin = begin.to_uint();
-        let end = match str::find_char_from(*self.src, '\n', begin) {
-            Some(e) => e,
-            None => self.src.len()
-        };
-        self.src.slice(begin, end).to_owned()
+        let slice = self.src.slice_from(begin);
+        match slice.find('\n') {
+            Some(e) => slice.slice_to(e).to_owned(),
+            None => slice.to_owned()
+        }
     }
 
     pub fn record_multibyte_char(&self, pos: BytePos, bytes: uint) {

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -290,9 +290,9 @@ impl FileMap {
         let begin = begin.to_uint();
         let end = match str::find_char_from(*self.src, '\n', begin) {
             Some(e) => e,
-            None => str::len(*self.src)
+            None => self.src.len()
         };
-        str::slice(*self.src, begin, end).to_owned()
+        self.src.slice(begin, end).to_owned()
     }
 
     pub fn record_multibyte_char(&self, pos: BytePos, bytes: uint) {
@@ -418,7 +418,7 @@ impl CodeMap {
         let begin = self.lookup_byte_offset(sp.lo);
         let end = self.lookup_byte_offset(sp.hi);
         assert_eq!(begin.fm.start_pos, end.fm.start_pos);
-        return str::slice(*begin.fm.src,
+        return begin.fm.src.slice(
                           begin.pos.to_uint(), end.pos.to_uint()).to_owned();
     }
 

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -14,7 +14,6 @@ use codemap::{Pos, span};
 use codemap;
 
 use core::io;
-use core::str;
 use core::uint;
 use core::vec;
 use extra::term;
@@ -259,7 +258,7 @@ fn highlight_lines(cm: @codemap::CodeMap,
     if elided {
         let last_line = display_lines[display_lines.len() - 1u];
         let s = fmt!("%s:%u ", fm.name, last_line + 1u);
-        let mut indent = str::len(s);
+        let mut indent = s.len();
         let mut out = ~"";
         while indent > 0u { out += " "; indent -= 1u; }
         out += "...\n";
@@ -277,11 +276,11 @@ fn highlight_lines(cm: @codemap::CodeMap,
         while num > 0u { num /= 10u; digits += 1u; }
 
         // indent past |name:## | and the 0-offset column location
-        let left = str::len(fm.name) + digits + lo.col.to_uint() + 3u;
+        let left = fm.name.len() + digits + lo.col.to_uint() + 3u;
         let mut s = ~"";
         // Skip is the number of characters we need to skip because they are
         // part of the 'filename:line ' part of the previous line.
-        let skip = str::len(fm.name) + digits + 3u;
+        let skip = fm.name.len() + digits + 3u;
         for skip.times() {
             s += " ";
         }

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -21,7 +21,6 @@ use ext::base::*;
 use parse;
 use parse::token;
 
-use core::str;
 use core::vec;
 
 enum State {

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -120,7 +120,7 @@ pub fn expand_asm(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
                     clobs.push(clob);
                 }
 
-                cons = str::connect(clobs, ",");
+                cons = clobs.connect(",");
             }
             Options => {
                 let option = p.parse_str();

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -276,6 +276,9 @@ fn pieces_to_expr(cx: @ExtCtxt, sp: span,
                     stms.push(cx.stmt_let(fmt_sp, npieces > 1,
                                           ident, cx.expr_str_uniq(fmt_sp, s)));
                 } else {
+                    // we call the push_str function because the
+                    // bootstrap doesnt't seem to work if we call the
+                    // method.
                     let args = ~[cx.expr_mut_addr_of(fmt_sp, buf()), cx.expr_str(fmt_sp, s)];
                     let call = cx.expr_call_global(fmt_sp,
                                                    ~[core_ident,

--- a/src/libsyntax/ext/pipes/liveness.rs
+++ b/src/libsyntax/ext/pipes/liveness.rs
@@ -88,7 +88,7 @@ pub fn analyze(proto: @mut protocol_, _cx: @ExtCtxt) {
     }
 
     if self_live.len() > 0 {
-        let states = str::connect(self_live.map(|s| copy s.name), " ");
+        let states = self_live.map(|s| copy s.name).connect(" ");
 
         debug!("protocol %s is unbounded due to loops involving: %s",
                copy proto.name, states);

--- a/src/libsyntax/ext/pipes/liveness.rs
+++ b/src/libsyntax/ext/pipes/liveness.rs
@@ -42,7 +42,6 @@ use core::prelude::*;
 use ext::base::ExtCtxt;
 use ext::pipes::proto::{protocol_};
 
-use core::str;
 use extra::bitv::Bitv;
 
 pub fn analyze(proto: @mut protocol_, _cx: @ExtCtxt) {

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -24,7 +24,6 @@ use opt_vec;
 use opt_vec::OptVec;
 
 use core::iterator::IteratorUtil;
-use core::str;
 use core::vec;
 
 pub trait gen_send {
@@ -100,9 +99,9 @@ impl gen_send for message {
             }
             body += fmt!("let message = %s(%s);\n",
                          name,
-                         str::connect(vec::append_one(
-                           arg_names.map(|x| cx.str_of(*x)),
-                             ~"s"), ", "));
+                         vec::append_one(
+                             arg_names.map(|x| cx.str_of(*x)),
+                             ~"s").connect(", "));
 
             if !try {
                 body += fmt!("::std::pipes::send(pipe, message);\n");
@@ -155,8 +154,7 @@ impl gen_send for message {
                     ~""
                 }
                 else {
-                    ~"(" + str::connect(arg_names.map(|x| copy *x),
-                                        ", ") + ")"
+                    ~"(" + arg_names.map(|x| copy *x).connect(", ") + ")"
                 };
 
                 let mut body = ~"{ ";

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -92,7 +92,7 @@ pub mod rt {
 
     impl<'self> ToSource for &'self [@ast::item] {
         fn to_source(&self) -> ~str {
-            str::connect(self.map(|i| i.to_source()), "\n\n")
+            self.map(|i| i.to_source()).connect("\n\n")
         }
     }
 
@@ -104,7 +104,7 @@ pub mod rt {
 
     impl<'self> ToSource for &'self [@ast::Ty] {
         fn to_source(&self) -> ~str {
-            str::connect(self.map(|i| i.to_source()), ", ")
+            self.map(|i| i.to_source()).connect(", ")
         }
     }
 

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -23,7 +23,6 @@ use print::pprust;
 
 use core::io;
 use core::result;
-use core::str;
 use core::vec;
 
 // These macros all relate to the file system; they either return
@@ -74,8 +73,7 @@ pub fn expand_mod(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
     -> base::MacResult {
     base::check_zero_tts(cx, sp, tts, "module_path!");
     base::MRExpr(cx.expr_str(sp,
-                              str::connect(cx.mod_path().map(
-                                  |x| cx.str_of(*x)), "::")))
+                             cx.mod_path().map(|x| cx.str_of(*x)).connect("::")))
 }
 
 // include! : parse the given file as an expr

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -24,7 +24,6 @@ use parse::token;
 
 use core::iterator::IteratorUtil;
 use core::hashmap::HashMap;
-use core::str;
 use core::uint;
 use core::vec;
 
@@ -371,14 +370,14 @@ pub fn parse(
         } else {
             if (bb_eis.len() > 0u && next_eis.len() > 0u)
                 || bb_eis.len() > 1u {
-                let nts = vec::map(bb_eis.connect(|ei| {
+                let nts = bb_eis.map(|ei| {
                     match ei.elts[ei.idx].node {
                       match_nonterminal(ref bind,ref name,_) => {
                         fmt!("%s ('%s')", *ident_to_str(name),
                              *ident_to_str(bind))
                       }
                       _ => fail!()
-                    } }), " or ");
+                    } }).connect(" or ");
                 return error(sp, fmt!(
                     "Local ambiguity: multiple parsing options: \
                      built-in NTs %s or %u other options.",

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -371,7 +371,7 @@ pub fn parse(
         } else {
             if (bb_eis.len() > 0u && next_eis.len() > 0u)
                 || bb_eis.len() > 1u {
-                let nts = str::connect(vec::map(bb_eis, |ei| {
+                let nts = vec::map(bb_eis.connect(|ei| {
                     match ei.elts[ei.idx].node {
                       match_nonterminal(ref bind,ref name,_) => {
                         fmt!("%s ('%s')", *ident_to_str(name),

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -116,7 +116,7 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         let lines = block_trim(lines, ~"\t ", None);
         let lines = block_trim(lines, ~"*", Some(1u));
         let lines = block_trim(lines, ~"\t ", None);
-        return str::connect(lines, "\n");
+        return lines.connect("\n");
     }
 
     fail!("not a doc-comment: %s", comment);

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -215,7 +215,7 @@ fn trim_whitespace_prefix_and_push_line(lines: &mut ~[~str],
     let col = col.to_uint();
     let s1 = if all_whitespace(s, 0, uint::min(len, col)) {
         if col < len {
-            str::slice(s, col, len).to_owned()
+            s.slice(col, len).to_owned()
         } else {  ~"" }
     } else { s };
     debug!("pushing line: %s", s1);
@@ -277,7 +277,7 @@ fn read_block_comment(rdr: @mut StringReader,
                 }
             }
         }
-        if str::len(curr_line) != 0 {
+        if curr_line.len() != 0 {
             trim_whitespace_prefix_and_push_line(&mut lines, curr_line, col);
         }
     }

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -125,7 +125,7 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
 fn read_to_eol(rdr: @mut StringReader) -> ~str {
     let mut val = ~"";
     while rdr.curr != '\n' && !is_eof(rdr) {
-        str::push_char(&mut val, rdr.curr);
+        val.push_char(rdr.curr);
         bump(rdr);
     }
     if rdr.curr == '\n' { bump(rdr); }
@@ -237,7 +237,7 @@ fn read_block_comment(rdr: @mut StringReader,
     // doc-comments are not really comments, they are attributes
     if rdr.curr == '*' || rdr.curr == '!' {
         while !(rdr.curr == '*' && nextch(rdr) == '/') && !is_eof(rdr) {
-            str::push_char(&mut curr_line, rdr.curr);
+            curr_line.push_char(rdr.curr);
             bump(rdr);
         }
         if !is_eof(rdr) {
@@ -261,7 +261,7 @@ fn read_block_comment(rdr: @mut StringReader,
                 curr_line = ~"";
                 bump(rdr);
             } else {
-                str::push_char(&mut curr_line, rdr.curr);
+                curr_line.push_char(rdr.curr);
                 if rdr.curr == '/' && nextch(rdr) == '*' {
                     bump(rdr);
                     bump(rdr);

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -307,7 +307,7 @@ fn consume_any_line_comment(rdr: @mut StringReader)
 
 pub fn is_block_non_doc_comment(s: &str) -> bool {
     assert!(s.len() >= 1u);
-    str::all_between(s, 1u, s.len() - 1u, |ch| ch == '*')
+    s.slice(1u, s.len() - 1u).iter().all(|ch| ch == '*')
 }
 
 // might return a sugared-doc-attr

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -22,7 +22,6 @@ use parse::token::{str_to_ident};
 use core::iterator::IteratorUtil;
 use core::char;
 use core::either;
-use core::str;
 use core::u64;
 
 pub use ext::tt::transcribe::{TtReader, new_tt_reader};
@@ -548,7 +547,7 @@ fn ident_continue(c: char) -> bool {
 // EFFECT: advances the input past that token
 // EFFECT: updates the interner
 fn next_token_inner(rdr: @mut StringReader) -> token::Token {
-    let mut c = rdr.curr;
+    let c = rdr.curr;
     if ident_start(c) {
         let start = rdr.last_pos;
         while ident_continue(rdr.curr) {

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -358,11 +358,11 @@ fn scan_exponent(rdr: @mut StringReader) -> Option<~str> {
     let mut c = rdr.curr;
     let mut rslt = ~"";
     if c == 'e' || c == 'E' {
-        str::push_char(&mut rslt, c);
+        rslt.push_char(c);
         bump(rdr);
         c = rdr.curr;
         if c == '-' || c == '+' {
-            str::push_char(&mut rslt, c);
+            rslt.push_char(c);
             bump(rdr);
         }
         let exponent = scan_digits(rdr, 10u);
@@ -379,7 +379,7 @@ fn scan_digits(rdr: @mut StringReader, radix: uint) -> ~str {
         if c == '_' { bump(rdr); loop; }
         match char::to_digit(c, radix) {
           Some(_) => {
-            str::push_char(&mut rslt, c);
+            rslt.push_char(c);
             bump(rdr);
           }
           _ => return rslt
@@ -721,31 +721,28 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
                 let escaped = rdr.curr;
                 bump(rdr);
                 match escaped {
-                  'n' => str::push_char(&mut accum_str, '\n'),
-                  'r' => str::push_char(&mut accum_str, '\r'),
-                  't' => str::push_char(&mut accum_str, '\t'),
-                  '\\' => str::push_char(&mut accum_str, '\\'),
-                  '\'' => str::push_char(&mut accum_str, '\''),
-                  '"' => str::push_char(&mut accum_str, '"'),
+                  'n' => accum_str.push_char('\n'),
+                  'r' => accum_str.push_char('\r'),
+                  't' => accum_str.push_char('\t'),
+                  '\\' => accum_str.push_char('\\'),
+                  '\'' => accum_str.push_char('\''),
+                  '"' => accum_str.push_char('"'),
                   '\n' => consume_whitespace(rdr),
                   'x' => {
-                    str::push_char(&mut accum_str,
-                                   scan_numeric_escape(rdr, 2u));
+                    accum_str.push_char(scan_numeric_escape(rdr, 2u));
                   }
                   'u' => {
-                    str::push_char(&mut accum_str,
-                                   scan_numeric_escape(rdr, 4u));
+                    accum_str.push_char(scan_numeric_escape(rdr, 4u));
                   }
                   'U' => {
-                    str::push_char(&mut accum_str,
-                                   scan_numeric_escape(rdr, 8u));
+                    accum_str.push_char(scan_numeric_escape(rdr, 8u));
                   }
                   c2 => {
                     rdr.fatal(fmt!("unknown string escape: %d", c2 as int));
                   }
                 }
               }
-              _ => str::push_char(&mut accum_str, ch)
+              _ => accum_str.push_char(ch)
             }
         }
         bump(rdr);

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -180,7 +180,7 @@ pub fn bump(rdr: &mut StringReader) {
     if current_byte_offset < (*rdr.src).len() {
         assert!(rdr.curr != -1 as char);
         let last_char = rdr.curr;
-        let next = str::char_range_at(*rdr.src, current_byte_offset);
+        let next = rdr.src.char_range_at(current_byte_offset);
         let byte_offset_diff = next.next - current_byte_offset;
         rdr.pos = rdr.pos + BytePos(byte_offset_diff);
         rdr.curr = next.ch;
@@ -204,7 +204,7 @@ pub fn is_eof(rdr: @mut StringReader) -> bool {
 pub fn nextch(rdr: @mut StringReader) -> char {
     let offset = byte_offset(rdr, rdr.pos).to_uint();
     if offset < (*rdr.src).len() {
-        return str::char_at(*rdr.src, offset);
+        return rdr.src.char_at(offset);
     } else { return -1 as char; }
 }
 

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -366,7 +366,7 @@ fn scan_exponent(rdr: @mut StringReader) -> Option<~str> {
             bump(rdr);
         }
         let exponent = scan_digits(rdr, 10u);
-        if str::len(exponent) > 0u {
+        if exponent.len() > 0u {
             return Some(rslt + exponent);
         } else { rdr.fatal(~"scan_exponent: bad fp literal"); }
     } else { return None::<~str>; }
@@ -434,7 +434,7 @@ fn scan_number(c: char, rdr: @mut StringReader) -> token::Token {
             tp = if signed { either::Left(ast::ty_i64) }
                       else { either::Right(ast::ty_u64) };
         }
-        if str::len(num_str) == 0u {
+        if num_str.len() == 0u {
             rdr.fatal(~"no valid digits found for number");
         }
         let parsed = match u64::from_str_radix(num_str, base as uint) {
@@ -499,7 +499,7 @@ fn scan_number(c: char, rdr: @mut StringReader) -> token::Token {
         }
         return token::LIT_FLOAT_UNSUFFIXED(str_to_ident(num_str));
     } else {
-        if str::len(num_str) == 0u {
+        if num_str.len() == 0u {
             rdr.fatal(~"no valid digits found for number");
         }
         let parsed = match u64::from_str_radix(num_str, base as uint) {

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -19,6 +19,7 @@ use ext::tt::transcribe::{dup_tt_reader};
 use parse::token;
 use parse::token::{str_to_ident};
 
+use core::iterator::IteratorUtil;
 use core::char;
 use core::either;
 use core::str;
@@ -245,7 +246,7 @@ fn consume_whitespace_and_comments(rdr: @mut StringReader)
 
 pub fn is_line_non_doc_comment(s: &str) -> bool {
     let s = s.trim_right();
-    s.len() > 3 && s.all(|ch| ch == '/')
+    s.len() > 3 && s.iter().all(|ch| ch == '/')
 }
 
 // PRECONDITION: rdr.curr is not whitespace

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -92,6 +92,7 @@ use parse::{new_sub_parser_from_file, next_node_id, ParseSess};
 use opt_vec;
 use opt_vec::OptVec;
 
+use core::iterator::IteratorUtil;
 use core::either::Either;
 use core::either;
 use core::hashmap::HashSet;
@@ -3981,17 +3982,15 @@ impl Parser {
             token::LIT_STR(s) => {
                 self.bump();
                 let the_string = ident_to_str(&s);
-                let mut words = ~[];
-                for str::each_word(*the_string) |s| { words.push(s) }
                 let mut abis = AbiSet::empty();
-                for words.each |word| {
-                    match abi::lookup(*word) {
+                for the_string.word_iter().advance |word| {
+                    match abi::lookup(word) {
                         Some(abi) => {
                             if abis.contains(abi) {
                                 self.span_err(
                                     *self.span,
                                     fmt!("ABI `%s` appears twice",
-                                         *word));
+                                         word));
                             } else {
                                 abis.add(abi);
                             }
@@ -4006,7 +4005,7 @@ impl Parser {
                                      str::connect_slices(
                                          abi::all_names(),
                                          ", "),
-                                     *word));
+                                     word));
                         }
                     }
                 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4002,9 +4002,7 @@ impl Parser {
                                 fmt!("illegal ABI: \
                                       expected one of [%s], \
                                       found `%s`",
-                                     str::connect_slices(
-                                         abi::all_names(),
-                                         ", "),
+                                     abi::all_names().connect(", "),
                                      word));
                         }
                     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -249,7 +249,7 @@ pub fn head(s: @ps, w: &str) {
     // outer-box is consistent
     cbox(s, indent_unit);
     // head-box is inconsistent
-    ibox(s, str::len(w) + 1);
+    ibox(s, w.len() + 1);
     // keyword that starts the head
     if !w.is_empty() {
         word_nbsp(s, w);

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -34,7 +34,6 @@ use core::io;
 use core::str;
 use core::u64;
 use core::uint;
-use core::vec;
 
 // The @ps is stored here to prevent recursive type.
 pub enum ann_node<'self> {

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -81,27 +81,27 @@ fn make_random_fasta(wr: @io::Writer,
     for uint::range(0u, n as uint) |_i| {
         str::push_char(&mut op, select_random(myrandom_next(rng, 100u32),
                                               copy genelist));
-        if str::len(op) >= LINE_LENGTH() {
+        if op.len() >= LINE_LENGTH() {
             wr.write_line(op);
             op = ~"";
         }
     }
-    if str::len(op) > 0u { wr.write_line(op); }
+    if op.len() > 0u { wr.write_line(op); }
 }
 
 fn make_repeat_fasta(wr: @io::Writer, id: ~str, desc: ~str, s: ~str, n: int) {
     unsafe {
         wr.write_line(~">" + id + " " + desc);
         let mut op: ~str = ~"";
-        let sl: uint = str::len(s);
+        let sl: uint = s.len();
         for uint::range(0u, n as uint) |i| {
             str::raw::push_byte(&mut op, s[i % sl]);
-            if str::len(op) >= LINE_LENGTH() {
+            if op.len() >= LINE_LENGTH() {
                 wr.write_line(op);
                 op = ~"";
             }
         }
-        if str::len(op) > 0u { wr.write_line(op); }
+        if op.len() > 0u { wr.write_line(op); }
     }
 }
 

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -79,7 +79,7 @@ fn make_random_fasta(wr: @io::Writer,
     };
     let mut op: ~str = ~"";
     for uint::range(0u, n as uint) |_i| {
-        str::push_char(&mut op, select_random(myrandom_next(rng, 100u32),
+        op.push_char(select_random(myrandom_next(rng, 100u32),
                                               copy genelist));
         if op.len() >= LINE_LENGTH() {
             wr.write_line(op);

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -191,7 +191,7 @@ fn main() {
    while !rdr.eof() {
       let line: ~str = rdr.read_line();
 
-      if str::len(line) == 0u { loop; }
+      if line.len() == 0u { loop; }
 
       match (line[0] as char, proc_mode) {
 

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -197,7 +197,7 @@ fn main() {
 
          // start processing if this is the one
          ('>', false) => {
-            match str::find_str_from(line, ~"THREE", 1u) {
+            match line.slice_from(1).find_str(~"THREE") {
                option::Some(_) => { proc_mode = true; }
                option::None    => { }
             }

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -14,6 +14,7 @@ extern mod extra;
 
 use std::io::{ReaderUtil, WriterUtil};
 use std::io;
+use std::iterator::IteratorUtil;
 use std::os;
 use std::str;
 use std::u8;
@@ -73,8 +74,8 @@ impl Sudoku {
         let mut g = vec::from_fn(10u, { |_i| ~[0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8] });
         while !reader.eof() {
             let line = reader.read_line();
-            let mut comps = ~[];
-            for str::each_split_char(line.trim(), ',') |s| { comps.push(s.to_owned()) }
+            let comps: ~[&str] = line.trim().split_iter(',').collect();
+
             if comps.len() == 3u {
                 let row     = uint::from_str(comps[0]).get() as u8;
                 let col     = uint::from_str(comps[1]).get() as u8;

--- a/src/test/compile-fail/die-not-static.rs
+++ b/src/test/compile-fail/die-not-static.rs
@@ -2,7 +2,7 @@ use std::str;
 
 fn main() {
     let v = ~"test";
-    let sslice = str::slice(v, 0, v.len());
+    let sslice = v.slice(0, v.len());
     //~^ ERROR borrowed value does not live long enough
     fail!(sslice);
 }

--- a/src/test/run-fail/task-spawn-barefn.rs
+++ b/src/test/run-fail/task-spawn-barefn.rs
@@ -20,5 +20,5 @@ fn main() {
 }
 
 fn startfn() {
-    assert!(str::is_empty(~"Ensure that the child task runs by failing"));
+    assert!("Ensure that the child task runs by failing".is_empty());
 }

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -120,7 +120,7 @@ impl ToStr for AsciiArt {
         let lines = do self.lines.map |line| {str::from_chars(*line)};
 
         // Concatenate the lines together using a new-line.
-        str::connect(lines, "\n")
+        lines.connect("\n")
     }
 }
 

--- a/src/test/run-pass/issue-4241.rs
+++ b/src/test/run-pass/issue-4241.rs
@@ -98,8 +98,8 @@ priv fn cmd_to_str(cmd: ~[~str]) -> ~str {
   res.push_str(cmd.len().to_str());
   res.push_str("\r\n");
     for cmd.each |s| {
-    res.push_str(str::concat(~[~"$", s.len().to_str(), ~"\r\n",
-                                          copy *s, ~"\r\n"]));
+    res.push_str([~"$", s.len().to_str(), ~"\r\n",
+                  copy *s, ~"\r\n"].concat()));
     }
   res
 }

--- a/src/test/run-pass/issue-4241.rs
+++ b/src/test/run-pass/issue-4241.rs
@@ -95,10 +95,10 @@ priv fn parse_response(io: @io::Reader) -> Result {
 
 priv fn cmd_to_str(cmd: ~[~str]) -> ~str {
   let mut res = ~"*";
-  str::push_str(&mut res, cmd.len().to_str());
-  str::push_str(&mut res, "\r\n");
+  res.push_str(cmd.len().to_str());
+  res.push_str("\r\n");
     for cmd.each |s| {
-    str::push_str(&mut res, str::concat(~[~"$", s.len().to_str(), ~"\r\n",
+    res.push_str(str::concat(~[~"$", s.len().to_str(), ~"\r\n",
                                           copy *s, ~"\r\n"]));
     }
   res

--- a/src/test/run-pass/move-out-of-field.rs
+++ b/src/test/run-pass/move-out-of-field.rs
@@ -6,7 +6,7 @@ struct StringBuffer {
 
 impl StringBuffer {
     pub fn append(&mut self, v: &str) {
-        str::push_str(&mut self.s, v);
+        self.s.push_str(v);
     }
 }
 

--- a/src/test/run-pass/option-ext.rs
+++ b/src/test/run-pass/option-ext.rs
@@ -12,7 +12,7 @@ use std::str;
 
 pub fn main() {
     let thing = ~"{{ f }}";
-    let f = str::find_str(thing, ~"{{");
+    let f = thing.find_str(~"{{");
 
     if f.is_none() {
         println(~"None!");

--- a/src/test/run-pass/string-self-append.rs
+++ b/src/test/run-pass/string-self-append.rs
@@ -18,8 +18,8 @@ pub fn main() {
     let mut i = 20;
     let mut expected_len = 1u;
     while i > 0 {
-        error!(str::len(a));
-        assert_eq!(str::len(a), expected_len);
+        error!(a.len());
+        assert_eq!(a.len(), expected_len);
         a = a + a; // FIXME(#3387)---can't write a += a
         i -= 1;
         expected_len *= 2u;

--- a/src/test/run-pass/trait-to-str.rs
+++ b/src/test/run-pass/trait-to-str.rs
@@ -14,7 +14,8 @@
 
 extern mod std;
 
-use std::{str, int, vec};
+use std::str::StrVector;
+use std::{int, vec};
 
 trait to_str {
     fn to_str(&self) -> ~str;
@@ -26,7 +27,7 @@ impl to_str for int {
 
 impl<T:to_str> to_str for ~[T] {
     fn to_str(&self) -> ~str {
-        ~"[" + self.map(|e| e.to_str()).connect(", ") + "]"
+        ~"[" + vec::map(*self, |e| e.to_str()).connect(", ") + "]"
     }
 }
 

--- a/src/test/run-pass/trait-to-str.rs
+++ b/src/test/run-pass/trait-to-str.rs
@@ -26,7 +26,7 @@ impl to_str for int {
 
 impl<T:to_str> to_str for ~[T] {
     fn to_str(&self) -> ~str {
-        ~"[" + str::connect(vec::map(*self, |e| e.to_str() ), ", ") + "]"
+        ~"[" + self.map(|e| e.to_str()).connect(", ") + "]"
     }
 }
 

--- a/src/test/run-pass/utf8_chars.rs
+++ b/src/test/run-pass/utf8_chars.rs
@@ -10,6 +10,7 @@
 
 extern mod extra;
 
+use std::iterator::IteratorUtil;
 use std::str;
 use std::vec;
 
@@ -17,11 +18,12 @@ pub fn main() {
     // Chars of 1, 2, 3, and 4 bytes
     let chs: ~[char] = ~['e', 'é', '€', 0x10000 as char];
     let s: ~str = str::from_chars(chs);
+    let schs: ~[char] = s.iter().collect();
 
     assert!(s.len() == 10u);
     assert!(str::char_len(s) == 4u);
-    assert!(str::to_chars(s).len() == 4u);
-    assert!(str::from_chars(str::to_chars(s)) == s);
+    assert!(schs.len() == 4u);
+    assert!(str::from_chars(schs) == s);
     assert!(s.char_at(0u) == 'e');
     assert!(s.char_at(1u) == 'é');
 

--- a/src/test/run-pass/utf8_chars.rs
+++ b/src/test/run-pass/utf8_chars.rs
@@ -22,8 +22,8 @@ pub fn main() {
     assert!(str::char_len(s) == 4u);
     assert!(str::to_chars(s).len() == 4u);
     assert!(str::from_chars(str::to_chars(s)) == s);
-    assert!(str::char_at(s, 0u) == 'e');
-    assert!(str::char_at(s, 1u) == 'é');
+    assert!(s.char_at(0u) == 'e');
+    assert!(s.char_at(1u) == 'é');
 
     assert!((str::is_utf8(str::to_bytes(s))));
     assert!((!str::is_utf8(~[0x80_u8])));

--- a/src/test/run-pass/utf8_chars.rs
+++ b/src/test/run-pass/utf8_chars.rs
@@ -18,7 +18,7 @@ pub fn main() {
     let chs: ~[char] = ~['e', 'é', '€', 0x10000 as char];
     let s: ~str = str::from_chars(chs);
 
-    assert!(str::len(s) == 10u);
+    assert!(s.len() == 10u);
     assert!(str::char_len(s) == 4u);
     assert!(str::to_chars(s).len() == 4u);
     assert!(str::from_chars(str::to_chars(s)) == s);

--- a/src/test/run-pass/utf8_chars.rs
+++ b/src/test/run-pass/utf8_chars.rs
@@ -33,7 +33,7 @@ pub fn main() {
     let mut stack = ~"a×c€";
     assert_eq!(str::pop_char(&mut stack), '€');
     assert_eq!(str::pop_char(&mut stack), 'c');
-    str::push_char(&mut stack, 'u');
+    stack.push_char('u');
     assert!(stack == ~"a×u");
     assert_eq!(str::shift_char(&mut stack), 'a');
     assert_eq!(str::shift_char(&mut stack), '×');


### PR DESCRIPTION
Continuation of #7015, and #6995.

Rewrites the character-based `each_split` functions in `str` to use an iterator, removes a few redundant methods, and replaces all uses of `len`, `is_empty` and `slice` functions with the methods (and deletes the the functions).

Update: Ok, this has turned into a major makeover for `str`, turning a lot of functions into methods, and removing redundant ones. Each commit is essentially a single such change.

(Unscientific benchmarks suggest that the external `split_iter` is approximately 10% faster than the internal one. I'm not quite sure why this would be true.)

(@thestinger is probably interested in this.)
