### PR TITLE
librustc: Don't allow newtype or unit-like structs to shadow other names in the value namespace.

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -294,18 +294,6 @@ pub enum DuplicateCheckingMode {
     OverwriteDuplicates
 }
 
-// Returns the namespace associated with the given duplicate checking mode,
-// or fails for OverwriteDuplicates. This is used for error messages.
-pub fn namespace_for_duplicate_checking_mode(mode: DuplicateCheckingMode)
-                                          -> Namespace {
-    match mode {
-        ForbidDuplicateModules | ForbidDuplicateTypes |
-        ForbidDuplicateTypesAndValues => TypeNS,
-        ForbidDuplicateValues => ValueNS,
-        OverwriteDuplicates => fail!("OverwriteDuplicates has no namespace")
-    }
-}
-
 /// One local scope.
 pub struct Rib {
     bindings: @mut HashMap<ident,def_like>,
@@ -1007,37 +995,43 @@ impl Resolver {
                 //   nothing.
 
                 let mut is_duplicate = false;
-                match duplicate_checking_mode {
+                let ns = match duplicate_checking_mode {
                     ForbidDuplicateModules => {
-                        is_duplicate =
-                            child.get_module_if_available().is_some();
+                        is_duplicate = child.get_module_if_available().is_some();
+                        Some(TypeNS)
                     }
                     ForbidDuplicateTypes => {
                         match child.def_for_namespace(TypeNS) {
                             Some(def_mod(_)) | None => {}
                             Some(_) => is_duplicate = true
                         }
+                        Some(TypeNS)
                     }
                     ForbidDuplicateValues => {
                         is_duplicate = child.defined_in_namespace(ValueNS);
+                        Some(ValueNS)
                     }
                     ForbidDuplicateTypesAndValues => {
+                        let mut n = None;
                         match child.def_for_namespace(TypeNS) {
                             Some(def_mod(_)) | None => {}
-                            Some(_) => is_duplicate = true
+                            Some(_) => {
+                                n = Some(TypeNS);
+                                is_duplicate = true;
+                            }
                         };
                         if child.defined_in_namespace(ValueNS) {
                             is_duplicate = true;
+                            n = Some(ValueNS);
                         }
+                        n
                     }
-                    OverwriteDuplicates => {}
-                }
-                if duplicate_checking_mode != OverwriteDuplicates &&
-                        is_duplicate {
+                    OverwriteDuplicates => None
+                };
+                if is_duplicate {
                     // Return an error here by looking up the namespace that
                     // had the duplicate.
-                    let ns = namespace_for_duplicate_checking_mode(
-                        duplicate_checking_mode);
+                    let ns = ns.unwrap();
                     self.session.span_err(sp,
                         fmt!("duplicate definition of %s `%s`",
                              namespace_to_str(ns),

--- a/src/test/compile-fail/issue-7044.rs
+++ b/src/test/compile-fail/issue-7044.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+static X: int = 0;
+struct X; //~ ERROR error: duplicate definition of value `X`
+
+fn main() {}


### PR DESCRIPTION
Fixes #7044.
