### PR TITLE
Use @str instead of @~str in the compiler.

### DIFF
--- a/src/libfuzzer/fuzzer.rc
+++ b/src/libfuzzer/fuzzer.rc
@@ -345,13 +345,13 @@ pub fn check_variants_T<T:Copy>(crate: @ast::crate,
                                             intr,
                                             span_handler,
                                             crate2,
-                                            fname.to_str(),
+                                            fname.to_managed(),
                                             rdr,
                                             a,
                                             pprust::no_ann(),
                                             false)
                     };
-                    @string
+                    string.to_managed()
                 };
                 match cx.mode {
                     tm_converge => check_roundtrip_convergence(str3, 1),
@@ -361,9 +361,9 @@ pub fn check_variants_T<T:Copy>(crate: @ast::crate,
                                               thing_label,
                                               i,
                                               j);
-                        let safe_to_run = !(content_is_dangerous_to_run(*str3)
+                        let safe_to_run = !(content_is_dangerous_to_run(str3)
                                             || has_raw_pointers(crate2));
-                        check_whole_compiler(*str3,
+                        check_whole_compiler(str3,
                                              &Path(file_label),
                                              safe_to_run);
                     }
@@ -502,15 +502,15 @@ pub fn check_compiling(filename: &Path) -> happiness {
 }
 
 
-pub fn parse_and_print(code: @~str) -> ~str {
+pub fn parse_and_print(code: @str) -> @str {
     let filename = Path("tmp.rs");
     let sess = parse::new_parse_sess(option::None);
-    write_file(&filename, *code);
-    let crate = parse::parse_crate_from_source_str(filename.to_str(),
+    write_file(&filename, code);
+    let crate = parse::parse_crate_from_source_str(filename.to_str().to_managed(),
                                                    code,
                                                    ~[],
                                                    sess);
-    do io::with_str_reader(*code) |rdr| {
+    do io::with_str_reader(code) |rdr| {
         let filename = filename.to_str();
         do as_str |a| {
             pprust::print_crate(sess.cm,
@@ -518,12 +518,12 @@ pub fn parse_and_print(code: @~str) -> ~str {
                                 token::mk_fake_ident_interner(),
                                 copy sess.span_diagnostic,
                                 crate,
-                                filename.to_str(),
+                                filename.to_managed(),
                                 rdr,
                                 a,
                                 pprust::no_ann(),
                                 false)
-        }
+        }.to_managed()
     }
 }
 
@@ -598,15 +598,15 @@ pub fn file_might_not_converge(filename: &Path) -> bool {
     return false;
 }
 
-pub fn check_roundtrip_convergence(code: @~str, maxIters: uint) {
+pub fn check_roundtrip_convergence(code: @str, maxIters: uint) {
     let mut i = 0u;
     let mut newv = code;
     let mut oldv = code;
 
     while i < maxIters {
         oldv = newv;
-        if content_might_not_converge(*oldv) { return; }
-        newv = @parse_and_print(oldv);
+        if content_might_not_converge(oldv) { return; }
+        newv = parse_and_print(oldv);
         if oldv == newv { break; }
         i += 1u;
     }
@@ -615,8 +615,8 @@ pub fn check_roundtrip_convergence(code: @~str, maxIters: uint) {
         error!("Converged after %u iterations", i);
     } else {
         error!("Did not converge after %u iterations!", i);
-        write_file(&Path("round-trip-a.rs"), *oldv);
-        write_file(&Path("round-trip-b.rs"), *newv);
+        write_file(&Path("round-trip-a.rs"), oldv);
+        write_file(&Path("round-trip-b.rs"), newv);
         run::process_status("diff", [~"-w", ~"-u", ~"round-trip-a.rs", ~"round-trip-b.rs"]);
         fail!("Mismatch");
     }
@@ -626,8 +626,8 @@ pub fn check_convergence(files: &[Path]) {
     error!("pp convergence tests: %u files", files.len());
     for files.each |file| {
         if !file_might_not_converge(file) {
-            let s = @result::get(&io::read_whole_file_str(file));
-            if !content_might_not_converge(*s) {
+            let s = result::get(&io::read_whole_file_str(file)).to_managed();
+            if !content_might_not_converge(s) {
                 error!("pp converge: %s", file.to_str());
                 // Change from 7u to 2u once
                 // https://github.com/mozilla/rust/issues/850 is fixed
@@ -646,14 +646,14 @@ pub fn check_variants(files: &[Path], cx: Context) {
             loop;
         }
 
-        let s = @result::get(&io::read_whole_file_str(file));
-        if contains(*s, "#") {
+        let s = result::get(&io::read_whole_file_str(file)).to_managed();
+        if s.contains_char('#') {
             loop; // Macros are confusing
         }
-        if cx.mode == tm_converge && content_might_not_converge(*s) {
+        if cx.mode == tm_converge && content_might_not_converge(s) {
             loop;
         }
-        if cx.mode == tm_run && content_is_dangerous_to_compile(*s) {
+        if cx.mode == tm_run && content_is_dangerous_to_compile(s) {
             loop;
         }
 
@@ -661,11 +661,11 @@ pub fn check_variants(files: &[Path], cx: Context) {
 
         error!("check_variants: %?", file_str);
         let sess = parse::new_parse_sess(None);
-        let crate = parse::parse_crate_from_source_str(file_str.to_str(),
+        let crate = parse::parse_crate_from_source_str(file_str.to_managed(),
                                                        s,
                                                        ~[],
                                                        sess);
-        io::with_str_reader(*s, |rdr| {
+        io::with_str_reader(s, |rdr| {
             let file_str = file_str.to_str();
             error!("%s",
                    as_str(|a| {
@@ -675,7 +675,7 @@ pub fn check_variants(files: &[Path], cx: Context) {
                         token::mk_fake_ident_interner(),
                         copy sess.span_diagnostic,
                         crate,
-                        file_str.to_str(),
+                        file_str.to_managed(),
                         rdr,
                         a,
                         pprust::no_ann(),

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -493,16 +493,16 @@ pub fn build_link_meta(sess: Session,
         let linkage_metas = attr::find_linkage_metas(c.node.attrs);
         attr::require_unique_names(sess.diagnostic(), linkage_metas);
         for linkage_metas.each |meta| {
-            if *attr::get_meta_item_name(*meta) == ~"name" {
+            if "name" == attr::get_meta_item_name(*meta) {
                 match attr::get_meta_item_value_str(*meta) {
                   // Changing attr would avoid the need for the copy
                   // here
-                  Some(v) => { name = Some(v.to_managed()); }
+                  Some(v) => { name = Some(v); }
                   None => cmh_items.push(*meta)
                 }
-            } else if *attr::get_meta_item_name(*meta) == ~"vers" {
+            } else if "vers" == attr::get_meta_item_name(*meta) {
                 match attr::get_meta_item_value_str(*meta) {
-                  Some(v) => { vers = Some(v.to_managed()); }
+                  Some(v) => { vers = Some(v); }
                   None => cmh_items.push(*meta)
                 }
             } else { cmh_items.push(*meta); }
@@ -518,7 +518,7 @@ pub fn build_link_meta(sess: Session,
     // This calculates CMH as defined above
     fn crate_meta_extras_hash(symbol_hasher: &mut hash::State,
                               cmh_items: ~[@ast::meta_item],
-                              dep_hashes: ~[~str]) -> @str {
+                              dep_hashes: ~[@str]) -> @str {
         fn len_and_str(s: &str) -> ~str {
             fmt!("%u_%s", s.len(), s)
         }
@@ -532,14 +532,14 @@ pub fn build_link_meta(sess: Session,
         fn hash(symbol_hasher: &mut hash::State, m: &@ast::meta_item) {
             match m.node {
               ast::meta_name_value(key, value) => {
-                write_string(symbol_hasher, len_and_str(*key));
+                write_string(symbol_hasher, len_and_str(key));
                 write_string(symbol_hasher, len_and_str_lit(value));
               }
               ast::meta_word(name) => {
-                write_string(symbol_hasher, len_and_str(*name));
+                write_string(symbol_hasher, len_and_str(name));
               }
               ast::meta_list(name, ref mis) => {
-                write_string(symbol_hasher, len_and_str(*name));
+                write_string(symbol_hasher, len_and_str(name));
                 for mis.each |m_| {
                     hash(symbol_hasher, m_);
                 }
@@ -706,7 +706,7 @@ pub fn mangle(sess: Session, ss: path) -> ~str {
 
     for ss.each |s| {
         match *s { path_name(s) | path_mod(s) => {
-          let sani = sanitize(*sess.str_of(s));
+          let sani = sanitize(sess.str_of(s));
           n += fmt!("%u%s", sani.len(), sani);
         } }
     }
@@ -912,7 +912,7 @@ pub fn link_args(sess: Session,
     }
 
     let ula = cstore::get_used_link_args(cstore);
-    for ula.each |arg| { args.push(/*bad*/copy *arg); }
+    for ula.each |arg| { args.push(arg.to_owned()); }
 
     // Add all the link args for external crates.
     do cstore::iter_crate_data(cstore) |crate_num, _| {

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -150,7 +150,7 @@ pub struct options {
     // will be added to the crate AST node.  This should not be used for
     // anything except building the full crate config prior to parsing.
     cfg: ast::crate_cfg,
-    binary: @~str,
+    binary: @str,
     test: bool,
     parse_only: bool,
     no_trans: bool,
@@ -295,7 +295,7 @@ impl Session_ {
     }
 
     // pointless function, now...
-    pub fn str_of(@self, id: ast::ident) -> @~str {
+    pub fn str_of(@self, id: ast::ident) -> @str {
         token::ident_to_str(&id)
     }
 
@@ -331,7 +331,7 @@ pub fn basic_options() -> @options {
         target_triple: host_triple(),
         target_feature: ~"",
         cfg: ~[],
-        binary: @~"rustc",
+        binary: @"rustc",
         test: false,
         parse_only: false,
         no_trans: false,
@@ -361,7 +361,7 @@ pub fn building_library(req_crate_type: crate_type,
             match syntax::attr::first_attr_value_str_by_name(
                 crate.node.attrs,
                 "crate_type") {
-              Some(@~"lib") => true,
+              Some(s) if "lib" == s => true,
               _ => false
             }
         }
@@ -389,22 +389,22 @@ mod test {
     use syntax::ast;
     use syntax::codemap;
 
-    fn make_crate_type_attr(t: ~str) -> ast::attribute {
+    fn make_crate_type_attr(t: @str) -> ast::attribute {
         codemap::respan(codemap::dummy_sp(), ast::attribute_ {
             style: ast::attr_outer,
             value: @codemap::respan(codemap::dummy_sp(),
                 ast::meta_name_value(
-                    @~"crate_type",
+                    @"crate_type",
                     codemap::respan(codemap::dummy_sp(),
-                                     ast::lit_str(@t)))),
+                                     ast::lit_str(t)))),
             is_sugared_doc: false
         })
     }
 
     fn make_crate(with_bin: bool, with_lib: bool) -> @ast::crate {
         let mut attrs = ~[];
-        if with_bin { attrs += [make_crate_type_attr(~"bin")]; }
-        if with_lib { attrs += [make_crate_type_attr(~"lib")]; }
+        if with_bin { attrs += [make_crate_type_attr(@"bin")]; }
+        if with_lib { attrs += [make_crate_type_attr(@"lib")]; }
         @codemap::respan(codemap::dummy_sp(), ast::crate_ {
             module: ast::_mod { view_items: ~[], items: ~[] },
             attrs: attrs,

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -202,7 +202,7 @@ pub fn metas_in_cfg(cfg: ast::crate_cfg,
     cfg_metas.any(|cfg_meta| {
         cfg_meta.all(|cfg_mi| {
             match cfg_mi.node {
-                ast::meta_list(s, ref it) if *s == ~"not"
+                ast::meta_list(s, ref it) if "not" == s
                     => it.all(|mi| !attr::contains(cfg, *mi)),
                 _ => attr::contains(cfg, *cfg_mi)
             }

--- a/src/librustc/front/intrinsic_inject.rs
+++ b/src/librustc/front/intrinsic_inject.rs
@@ -17,9 +17,9 @@ use syntax::ast;
 use syntax::codemap::spanned;
 
 pub fn inject_intrinsic(sess: Session, crate: @ast::crate) -> @ast::crate {
-    let intrinsic_module = @(include_str!("intrinsic.rs").to_owned());
+    let intrinsic_module = include_str!("intrinsic.rs").to_managed();
 
-    let item = parse::parse_item_from_source_str(~"<intrinsic>",
+    let item = parse::parse_item_from_source_str(@"<intrinsic>",
                                                  intrinsic_module,
                                                  /*bad*/copy sess.opts.cfg,
                                                  ~[],

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -49,8 +49,8 @@ fn inject_libstd_ref(sess: Session, crate: @ast::crate) -> @ast::crate {
                     spanned(ast::attribute_ {
                         style: ast::attr_inner,
                         value: @spanned(ast::meta_name_value(
-                            @~"vers",
-                            spanned(ast::lit_str(@STD_VERSION.to_str()))
+                            @"vers",
+                            spanned(ast::lit_str(STD_VERSION.to_managed()))
                         )),
                         is_sugared_doc: false
                     })

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -52,7 +52,7 @@ pub fn modify_for_testing(sess: session::Session,
     // configuration, either with the '--test' or '--cfg test'
     // command line options.
     let should_test = attr::contains(crate.node.config,
-                                     attr::mk_word_item(@~"test"));
+                                     attr::mk_word_item(@"test"));
 
     if should_test {
         generate_test_harness(sess, crate)
@@ -76,7 +76,7 @@ fn generate_test_harness(sess: session::Session,
     ext_cx.bt_push(ExpandedFrom(CallInfo {
         call_site: dummy_sp(),
         callee: NameAndSpan {
-            name: ~"test",
+            name: @"test",
             span: None
         }
     }));
@@ -111,7 +111,7 @@ fn fold_mod(cx: @mut TestCtxt,
     fn nomain(cx: @mut TestCtxt, item: @ast::item) -> @ast::item {
         if !*cx.sess.building_library {
             @ast::item{attrs: item.attrs.filtered(|attr| {
-                               *attr::get_attr_name(attr) != ~"main"
+                               "main" != attr::get_attr_name(attr)
                            }),.. copy *item}
         } else { item }
     }
@@ -272,9 +272,9 @@ mod __test {
 */
 
 fn mk_std(cx: &TestCtxt) -> @ast::view_item {
-    let vers = ast::lit_str(@~"0.7-pre");
+    let vers = ast::lit_str(@"0.7-pre");
     let vers = nospan(vers);
-    let mi = ast::meta_name_value(@~"vers", vers);
+    let mi = ast::meta_name_value(@"vers", vers);
     let mi = nospan(mi);
     let id_std = cx.sess.ident_of("extra");
     let vi = if is_std(cx) {
@@ -321,7 +321,7 @@ fn mk_test_module(cx: &TestCtxt) -> @ast::item {
 
     // This attribute tells resolve to let us call unexported functions
     let resolve_unexported_attr =
-        attr::mk_attr(attr::mk_word_item(@~"!resolve_unexported"));
+        attr::mk_attr(attr::mk_word_item(@"!resolve_unexported"));
 
     let item = ast::item {
         ident: cx.sess.ident_of("__test"),
@@ -376,7 +376,7 @@ fn is_std(cx: &TestCtxt) -> bool {
     let is_std = {
         let items = attr::find_linkage_metas(cx.crate.node.attrs);
         match attr::last_meta_item_value_str_by_name(items, "name") {
-          Some(@~"extra") => true,
+          Some(s) if "extra" == s => true,
           _ => false
         }
     };
@@ -413,7 +413,7 @@ fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: &Test) -> @ast::expr {
     debug!("encoding %s", ast_util::path_name_i(path));
 
     let name_lit: ast::lit =
-        nospan(ast::lit_str(@ast_util::path_name_i(path)));
+        nospan(ast::lit_str(ast_util::path_name_i(path).to_managed()));
 
     let name_expr = @ast::expr {
           id: cx.sess.next_node_id(),

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -74,7 +74,7 @@ pub fn get_item_path(tcx: ty::ctxt, def: ast::def_id) -> ast_map::path {
     // FIXME #1920: This path is not always correct if the crate is not linked
     // into the root namespace.
     vec::append(~[ast_map::path_mod(tcx.sess.ident_of(
-        *cdata.name))], path)
+        cdata.name))], path)
 }
 
 pub enum found_ast {

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -48,7 +48,7 @@ pub struct Context {
     span: span,
     ident: ast::ident,
     metas: ~[@ast::meta_item],
-    hash: @~str,
+    hash: @str,
     os: os,
     is_static: bool,
     intr: @ident_interner
@@ -60,7 +60,7 @@ pub fn load_library_crate(cx: &Context) -> (~str, @~[u8]) {
       None => {
         cx.diag.span_fatal(
             cx.span, fmt!("can't find crate for `%s`",
-                          *token::ident_to_str(&cx.ident)));
+                          token::ident_to_str(&cx.ident)));
       }
     }
 }
@@ -89,7 +89,7 @@ fn find_library_crate_aux(
     filesearch: @filesearch::FileSearch
 ) -> Option<(~str, @~[u8])> {
     let crate_name = crate_name_from_metas(cx.metas);
-    let prefix: ~str = prefix + *crate_name + "-";
+    let prefix: ~str = prefix + crate_name + "-";
     let suffix: ~str = /*bad*/copy suffix;
 
     let mut matches = ~[];
@@ -128,7 +128,7 @@ fn find_library_crate_aux(
         Some(/*bad*/copy matches[0])
     } else {
         cx.diag.span_err(
-            cx.span, fmt!("multiple matching crates for `%s`", *crate_name));
+            cx.span, fmt!("multiple matching crates for `%s`", crate_name));
         cx.diag.handler().note("candidates:");
         for matches.each |&(ident, data)| {
             cx.diag.handler().note(fmt!("path: %s", ident));
@@ -140,7 +140,7 @@ fn find_library_crate_aux(
     }
 }
 
-pub fn crate_name_from_metas(metas: &[@ast::meta_item]) -> @~str {
+pub fn crate_name_from_metas(metas: &[@ast::meta_item]) -> @str {
     let name_items = attr::find_meta_items_by_name(metas, "name");
     match name_items.last_opt() {
         Some(i) => {
@@ -166,7 +166,7 @@ pub fn note_linkage_attrs(intr: @ident_interner,
 
 fn crate_matches(crate_data: @~[u8],
                  metas: &[@ast::meta_item],
-                 hash: @~str) -> bool {
+                 hash: @str) -> bool {
     let attrs = decoder::get_crate_attributes(crate_data);
     let linkage_metas = attr::find_linkage_metas(attrs);
     if !hash.is_empty() {

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -88,7 +88,7 @@ pub fn encode_inlined_item(ecx: @e::EncodeContext,
                            maps: Maps) {
     debug!("> Encoding inlined item: %s::%s (%u)",
            ast_map::path_to_str(path, token::get_ident_interner()),
-           *ecx.tcx.sess.str_of(ii.ident()),
+           ecx.tcx.sess.str_of(ii.ident()),
            ebml_w.writer.tell());
 
     let id_range = ast_util::compute_id_range_for_inlined_item(&ii);
@@ -101,7 +101,7 @@ pub fn encode_inlined_item(ecx: @e::EncodeContext,
 
     debug!("< Encoded inlined fn: %s::%s (%u)",
            ast_map::path_to_str(path, token::get_ident_interner()),
-           *ecx.tcx.sess.str_of(ii.ident()),
+           ecx.tcx.sess.str_of(ii.ident()),
            ebml_w.writer.tell());
 }
 
@@ -131,10 +131,10 @@ pub fn decode_inlined_item(cdata: @cstore::crate_metadata,
         };
         let raw_ii = decode_ast(ast_doc);
         let ii = renumber_ast(xcx, raw_ii);
-        debug!("Fn named: %s", *tcx.sess.str_of(ii.ident()));
+        debug!("Fn named: %s", tcx.sess.str_of(ii.ident()));
         debug!("< Decoded inlined fn: %s::%s",
                ast_map::path_to_str(path, token::get_ident_interner()),
-               *tcx.sess.str_of(ii.ident()));
+               tcx.sess.str_of(ii.ident()));
         ast_map::map_decoded_item(tcx.sess.diagnostic(),
                                   dcx.tcx.items, path, &ii);
         decode_side_tables(xcx, ast_doc);

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -711,7 +711,7 @@ impl BorrowckCtxt {
             LpVar(id) => {
                 match self.tcx.items.find(&id) {
                     Some(&ast_map::node_local(ref ident)) => {
-                        out.push_str(*token::ident_to_str(ident));
+                        out.push_str(token::ident_to_str(ident));
                     }
                     r => {
                         self.tcx.sess.bug(
@@ -726,7 +726,7 @@ impl BorrowckCtxt {
                 match fname {
                     mc::NamedField(ref fname) => {
                         out.push_char('.');
-                        out.push_str(*token::ident_to_str(fname));
+                        out.push_str(token::ident_to_str(fname));
                     }
                     mc::PositionalField(idx) => {
                         out.push_char('#'); // invent a notation here

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -144,8 +144,8 @@ pub fn check_exhaustive(cx: @MatchCheckCtxt, sp: span, pats: ~[@pat]) {
             match ty::get(ty).sty {
                 ty::ty_bool => {
                     match (*ctor) {
-                        val(const_bool(true)) => Some(@~"true"),
-                        val(const_bool(false)) => Some(@~"false"),
+                        val(const_bool(true)) => Some(@"true"),
+                        val(const_bool(false)) => Some(@"false"),
                         _ => None
                     }
                 }
@@ -165,7 +165,7 @@ pub fn check_exhaustive(cx: @MatchCheckCtxt, sp: span, pats: ~[@pat]) {
                 }
                 ty::ty_unboxed_vec(*) | ty::ty_evec(*) => {
                     match *ctor {
-                        vec(n) => Some(@fmt!("vectors of length %u", n)),
+                        vec(n) => Some(fmt!("vectors of length %u", n).to_managed()),
                         _ => None
                     }
                 }
@@ -174,7 +174,7 @@ pub fn check_exhaustive(cx: @MatchCheckCtxt, sp: span, pats: ~[@pat]) {
         }
     };
     let msg = ~"non-exhaustive patterns" + match ext {
-        Some(ref s) => ~": " + **s + " not covered",
+        Some(ref s) => fmt!(": %s not covered",  *s),
         None => ~""
     };
     cx.tcx.sess.span_err(sp, msg);

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -236,14 +236,14 @@ pub enum const_val {
     const_float(f64),
     const_int(i64),
     const_uint(u64),
-    const_str(~str),
+    const_str(@str),
     const_bool(bool)
 }
 
 pub fn eval_const_expr(tcx: middle::ty::ctxt, e: @expr) -> const_val {
     match eval_const_expr_partial(tcx, e) {
-        Ok(ref r) => (/*bad*/copy *r),
-        Err(ref s) => tcx.sess.span_fatal(e.span, *s)
+        Ok(r) => r,
+        Err(s) => tcx.sess.span_fatal(e.span, s)
     }
 }
 
@@ -409,13 +409,13 @@ pub fn eval_const_expr_partial(tcx: middle::ty::ctxt, e: @expr)
 
 pub fn lit_to_const(lit: @lit) -> const_val {
     match lit.node {
-      lit_str(s) => const_str(/*bad*/copy *s),
+      lit_str(s) => const_str(s),
       lit_int(n, _) => const_int(n),
       lit_uint(n, _) => const_uint(n),
       lit_int_unsuffixed(n) => const_int(n),
-      lit_float(n, _) => const_float(float::from_str(*n).get() as f64),
+      lit_float(n, _) => const_float(float::from_str(n).get() as f64),
       lit_float_unsuffixed(n) =>
-        const_float(float::from_str(*n).get() as f64),
+        const_float(float::from_str(n).get() as f64),
       lit_nil => const_int(0i64),
       lit_bool(b) => const_bool(b)
     }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -269,50 +269,50 @@ fn LanguageItemCollector(crate: @crate,
                       -> LanguageItemCollector {
     let mut item_refs = HashMap::new();
 
-    item_refs.insert(@~"const", ConstTraitLangItem as uint);
-    item_refs.insert(@~"copy", CopyTraitLangItem as uint);
-    item_refs.insert(@~"owned", OwnedTraitLangItem as uint);
-    item_refs.insert(@~"sized", SizedTraitLangItem as uint);
+    item_refs.insert(@"const", ConstTraitLangItem as uint);
+    item_refs.insert(@"copy", CopyTraitLangItem as uint);
+    item_refs.insert(@"owned", OwnedTraitLangItem as uint);
+    item_refs.insert(@"sized", SizedTraitLangItem as uint);
 
-    item_refs.insert(@~"drop", DropTraitLangItem as uint);
+    item_refs.insert(@"drop", DropTraitLangItem as uint);
 
-    item_refs.insert(@~"add", AddTraitLangItem as uint);
-    item_refs.insert(@~"sub", SubTraitLangItem as uint);
-    item_refs.insert(@~"mul", MulTraitLangItem as uint);
-    item_refs.insert(@~"div", DivTraitLangItem as uint);
-    item_refs.insert(@~"rem", RemTraitLangItem as uint);
-    item_refs.insert(@~"neg", NegTraitLangItem as uint);
-    item_refs.insert(@~"not", NotTraitLangItem as uint);
-    item_refs.insert(@~"bitxor", BitXorTraitLangItem as uint);
-    item_refs.insert(@~"bitand", BitAndTraitLangItem as uint);
-    item_refs.insert(@~"bitor", BitOrTraitLangItem as uint);
-    item_refs.insert(@~"shl", ShlTraitLangItem as uint);
-    item_refs.insert(@~"shr", ShrTraitLangItem as uint);
-    item_refs.insert(@~"index", IndexTraitLangItem as uint);
+    item_refs.insert(@"add", AddTraitLangItem as uint);
+    item_refs.insert(@"sub", SubTraitLangItem as uint);
+    item_refs.insert(@"mul", MulTraitLangItem as uint);
+    item_refs.insert(@"div", DivTraitLangItem as uint);
+    item_refs.insert(@"rem", RemTraitLangItem as uint);
+    item_refs.insert(@"neg", NegTraitLangItem as uint);
+    item_refs.insert(@"not", NotTraitLangItem as uint);
+    item_refs.insert(@"bitxor", BitXorTraitLangItem as uint);
+    item_refs.insert(@"bitand", BitAndTraitLangItem as uint);
+    item_refs.insert(@"bitor", BitOrTraitLangItem as uint);
+    item_refs.insert(@"shl", ShlTraitLangItem as uint);
+    item_refs.insert(@"shr", ShrTraitLangItem as uint);
+    item_refs.insert(@"index", IndexTraitLangItem as uint);
 
-    item_refs.insert(@~"eq", EqTraitLangItem as uint);
-    item_refs.insert(@~"ord", OrdTraitLangItem as uint);
+    item_refs.insert(@"eq", EqTraitLangItem as uint);
+    item_refs.insert(@"ord", OrdTraitLangItem as uint);
 
-    item_refs.insert(@~"str_eq", StrEqFnLangItem as uint);
-    item_refs.insert(@~"uniq_str_eq", UniqStrEqFnLangItem as uint);
-    item_refs.insert(@~"annihilate", AnnihilateFnLangItem as uint);
-    item_refs.insert(@~"log_type", LogTypeFnLangItem as uint);
-    item_refs.insert(@~"fail_", FailFnLangItem as uint);
-    item_refs.insert(@~"fail_bounds_check",
+    item_refs.insert(@"str_eq", StrEqFnLangItem as uint);
+    item_refs.insert(@"uniq_str_eq", UniqStrEqFnLangItem as uint);
+    item_refs.insert(@"annihilate", AnnihilateFnLangItem as uint);
+    item_refs.insert(@"log_type", LogTypeFnLangItem as uint);
+    item_refs.insert(@"fail_", FailFnLangItem as uint);
+    item_refs.insert(@"fail_bounds_check",
                      FailBoundsCheckFnLangItem as uint);
-    item_refs.insert(@~"exchange_malloc", ExchangeMallocFnLangItem as uint);
-    item_refs.insert(@~"exchange_free", ExchangeFreeFnLangItem as uint);
-    item_refs.insert(@~"malloc", MallocFnLangItem as uint);
-    item_refs.insert(@~"free", FreeFnLangItem as uint);
-    item_refs.insert(@~"borrow_as_imm", BorrowAsImmFnLangItem as uint);
-    item_refs.insert(@~"borrow_as_mut", BorrowAsMutFnLangItem as uint);
-    item_refs.insert(@~"return_to_mut", ReturnToMutFnLangItem as uint);
-    item_refs.insert(@~"check_not_borrowed",
+    item_refs.insert(@"exchange_malloc", ExchangeMallocFnLangItem as uint);
+    item_refs.insert(@"exchange_free", ExchangeFreeFnLangItem as uint);
+    item_refs.insert(@"malloc", MallocFnLangItem as uint);
+    item_refs.insert(@"free", FreeFnLangItem as uint);
+    item_refs.insert(@"borrow_as_imm", BorrowAsImmFnLangItem as uint);
+    item_refs.insert(@"borrow_as_mut", BorrowAsMutFnLangItem as uint);
+    item_refs.insert(@"return_to_mut", ReturnToMutFnLangItem as uint);
+    item_refs.insert(@"check_not_borrowed",
                      CheckNotBorrowedFnLangItem as uint);
-    item_refs.insert(@~"strdup_uniq", StrDupUniqFnLangItem as uint);
-    item_refs.insert(@~"record_borrow", RecordBorrowFnLangItem as uint);
-    item_refs.insert(@~"unrecord_borrow", UnrecordBorrowFnLangItem as uint);
-    item_refs.insert(@~"start", StartFnLangItem as uint);
+    item_refs.insert(@"strdup_uniq", StrDupUniqFnLangItem as uint);
+    item_refs.insert(@"record_borrow", RecordBorrowFnLangItem as uint);
+    item_refs.insert(@"unrecord_borrow", UnrecordBorrowFnLangItem as uint);
+    item_refs.insert(@"start", StartFnLangItem as uint);
 
     LanguageItemCollector {
         crate: crate,
@@ -328,7 +328,7 @@ struct LanguageItemCollector {
     crate: @crate,
     session: Session,
 
-    item_refs: HashMap<@~str, uint>,
+    item_refs: HashMap<@str, uint>,
 }
 
 impl LanguageItemCollector {
@@ -366,9 +366,9 @@ impl LanguageItemCollector {
 
     pub fn match_and_collect_item(&mut self,
                                   item_def_id: def_id,
-                                  key: @~str,
-                                  value: @~str) {
-        if *key != ~"lang" {
+                                  key: @str,
+                                  value: @str) {
+        if "lang" != key {
             return;    // Didn't match.
         }
 
@@ -419,7 +419,7 @@ impl LanguageItemCollector {
         for self.item_refs.each |&key, &item_ref| {
             match self.items.items[item_ref] {
                 None => {
-                    self.session.err(fmt!("no item found for `%s`", *key));
+                    self.session.err(fmt!("no item found for `%s`", key));
                 }
                 Some(_) => {
                     // OK.

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -310,12 +310,12 @@ impl IrMaps {
         }
     }
 
-    pub fn variable_name(&mut self, var: Variable) -> @~str {
+    pub fn variable_name(&mut self, var: Variable) -> @str {
         match self.var_kinds[*var] {
             Local(LocalInfo { ident: nm, _ }) | Arg(_, nm) => {
                 self.tcx.sess.str_of(nm)
             },
-            ImplicitRet => @~"<implicit-ret>"
+            ImplicitRet => @"<implicit-ret>"
         }
     }
 
@@ -1578,12 +1578,12 @@ impl Liveness {
           FreeVarNode(span) => {
             self.tcx.sess.span_err(
                 span,
-                fmt!("capture of %s: `%s`", msg, *name));
+                fmt!("capture of %s: `%s`", msg, name));
           }
           ExprNode(span) => {
             self.tcx.sess.span_err(
                 span,
-                fmt!("use of %s: `%s`", msg, *name));
+                fmt!("use of %s: `%s`", msg, name));
           }
           ExitNode | VarDefNode(_) => {
             self.tcx.sess.span_bug(
@@ -1593,7 +1593,7 @@ impl Liveness {
         }
     }
 
-    pub fn should_warn(&self, var: Variable) -> Option<@~str> {
+    pub fn should_warn(&self, var: Variable) -> Option<@str> {
         let name = self.ir.variable_name(var);
         if name[0] == ('_' as u8) { None } else { Some(name) }
     }
@@ -1638,10 +1638,10 @@ impl Liveness {
                 if is_assigned {
                     self.tcx.sess.add_lint(unused_variable, id, sp,
                         fmt!("variable `%s` is assigned to, \
-                                  but never used", **name));
+                                  but never used", *name));
                 } else {
                     self.tcx.sess.add_lint(unused_variable, id, sp,
-                        fmt!("unused variable: `%s`", **name));
+                        fmt!("unused variable: `%s`", *name));
                 }
             }
             true
@@ -1659,7 +1659,7 @@ impl Liveness {
             let r = self.should_warn(var);
             for r.iter().advance |name| {
                 self.tcx.sess.add_lint(dead_assignment, id, sp,
-                    fmt!("value assigned to `%s` is never read", **name));
+                    fmt!("value assigned to `%s` is never read", *name));
             }
         }
     }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1201,7 +1201,7 @@ pub fn ptr_sigil(ptr: ptr_kind) -> ~str {
 impl Repr for InteriorKind {
     fn repr(&self, tcx: ty::ctxt) -> ~str {
         match *self {
-            InteriorField(NamedField(fld)) => copy *tcx.sess.str_of(fld),
+            InteriorField(NamedField(fld)) => tcx.sess.str_of(fld).to_owned(),
             InteriorField(PositionalField(i)) => fmt!("#%?", i),
             InteriorElement(_) => ~"[]",
         }

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -235,7 +235,7 @@ pub fn check_crate<'mm>(tcx: ty::ctxt,
             if field.ident != ident { loop; }
             if field.vis == private {
                 tcx.sess.span_err(span, fmt!("field `%s` is private",
-                                             *token::ident_to_str(&ident)));
+                                             token::ident_to_str(&ident)));
             }
             break;
         }
@@ -255,7 +255,7 @@ pub fn check_crate<'mm>(tcx: ty::ctxt,
                      !privileged_items.contains(&(container_id.node))) {
                 tcx.sess.span_err(span,
                                   fmt!("method `%s` is private",
-                                       *token::ident_to_str(name)));
+                                       token::ident_to_str(name)));
             }
         } else {
             let visibility =
@@ -263,7 +263,7 @@ pub fn check_crate<'mm>(tcx: ty::ctxt,
             if visibility != public {
                 tcx.sess.span_err(span,
                                   fmt!("method `%s` is private",
-                                       *token::ident_to_str(name)));
+                                       token::ident_to_str(name)));
             }
         }
     };
@@ -283,13 +283,13 @@ pub fn check_crate<'mm>(tcx: ty::ctxt,
                             !privileged_items.contains(&def_id.node) {
                         tcx.sess.span_err(span,
                                           fmt!("function `%s` is private",
-                                               *token::ident_to_str(path.idents.last())));
+                                               token::ident_to_str(path.idents.last())));
                     }
                 } else if csearch::get_item_visibility(tcx.sess.cstore,
                                                        def_id) != public {
                     tcx.sess.span_err(span,
                                       fmt!("function `%s` is private",
-                                           *token::ident_to_str(path.idents.last())));
+                                           token::ident_to_str(path.idents.last())));
                 }
             }
             _ => {}
@@ -328,7 +328,7 @@ pub fn check_crate<'mm>(tcx: ty::ctxt,
                                              .contains(&(trait_id.node)) => {
                                             tcx.sess.span_err(span,
                                                               fmt!("method `%s` is private",
-                                                                   *token::ident_to_str(&method
+                                                                   token::ident_to_str(&method
                                                                                         .ident)));
                                         }
                                         provided(_) | required(_) => {

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -84,7 +84,7 @@ pub type TraitMap = HashMap<node_id,@mut ~[def_id]>;
 pub type ExportMap2 = @mut HashMap<node_id, ~[Export2]>;
 
 pub struct Export2 {
-    name: @~str,        // The name of the target.
+    name: @str,        // The name of the target.
     def_id: def_id,     // The definition of the target.
     reexport: bool,     // Whether this is a reexport.
 }
@@ -1035,14 +1035,14 @@ impl Resolver {
                     self.session.span_err(sp,
                         fmt!("duplicate definition of %s `%s`",
                              namespace_to_str(ns),
-                             *self.session.str_of(name)));
+                             self.session.str_of(name)));
                     {
                         let r = child.span_for_namespace(ns);
                         for r.iter().advance |sp| {
                             self.session.span_note(*sp,
                                  fmt!("first definition of %s %s here:",
                                       namespace_to_str(ns),
-                                      *self.session.str_of(name)));
+                                      self.session.str_of(name)));
                         }
                     }
                 }
@@ -1695,7 +1695,7 @@ impl Resolver {
                   debug!("(building reduced graph for \
                           external crate) ... adding \
                           trait method '%s'",
-                         *self.session.str_of(method_name));
+                         self.session.str_of(method_name));
 
                   // Add it to the trait info if not static.
                   if explicit_self != sty_static {
@@ -1824,7 +1824,7 @@ impl Resolver {
                                              visibility,
                                              &mut modules,
                                              child_name_bindings,
-                                             *self.session.str_of(
+                                             self.session.str_of(
                                                  final_ident),
                                              final_ident,
                                              new_parent);
@@ -1843,7 +1843,7 @@ impl Resolver {
                                     debug!("(building reduced graph for \
                                             external crate) processing \
                                             static methods for type name %s",
-                                            *self.session.str_of(
+                                            self.session.str_of(
                                                 final_ident));
 
                                     let (child_name_bindings, new_parent) =
@@ -1894,7 +1894,7 @@ impl Resolver {
                                         debug!("(building reduced graph for \
                                                  external crate) creating \
                                                  static method '%s'",
-                                               *self.session.str_of(ident));
+                                               self.session.str_of(ident));
 
                                         let (method_name_bindings, _) =
                                             self.add_child(
@@ -1945,7 +1945,7 @@ impl Resolver {
                         directive: privacy %? %s::%s",
                        privacy,
                        self.idents_to_str(directive.module_path),
-                       *self.session.str_of(target));
+                       self.session.str_of(target));
 
                 match module_.import_resolutions.find(&target) {
                     Some(&resolution) => {
@@ -2054,7 +2054,7 @@ impl Resolver {
                 Failed => {
                     // We presumably emitted an error. Continue.
                     let msg = fmt!("failed to resolve import `%s`",
-                                   *self.import_path_to_str(
+                                   self.import_path_to_str(
                                        import_directive.module_path,
                                        *import_directive.subclass));
                     self.session.span_err(import_directive.span, msg);
@@ -2077,30 +2077,30 @@ impl Resolver {
         let mut result = ~"";
         for idents.each |ident| {
             if first { first = false; } else { result += "::" };
-            result += *self.session.str_of(*ident);
+            result += self.session.str_of(*ident);
         };
         return result;
     }
 
     pub fn import_directive_subclass_to_str(@mut self,
                                             subclass: ImportDirectiveSubclass)
-                                            -> @~str {
+                                            -> @str {
         match subclass {
             SingleImport(_target, source) => self.session.str_of(source),
-            GlobImport => @~"*"
+            GlobImport => @"*"
         }
     }
 
     pub fn import_path_to_str(@mut self,
                               idents: &[ident],
                               subclass: ImportDirectiveSubclass)
-                              -> @~str {
+                              -> @str {
         if idents.is_empty() {
             self.import_directive_subclass_to_str(subclass)
         } else {
-            @fmt!("%s::%s",
-                 self.idents_to_str(idents),
-                 *self.import_directive_subclass_to_str(subclass))
+            (fmt!("%s::%s",
+                  self.idents_to_str(idents),
+                  self.import_directive_subclass_to_str(subclass))).to_managed()
         }
     }
 
@@ -2221,9 +2221,9 @@ impl Resolver {
                                  -> ResolveResult<()> {
         debug!("(resolving single import) resolving `%s` = `%s::%s` from \
                 `%s`",
-               *self.session.str_of(target),
+               self.session.str_of(target),
                self.module_to_str(containing_module),
-               *self.session.str_of(source),
+               self.session.str_of(source),
                self.module_to_str(module_));
 
         // We need to resolve both namespaces for this to succeed.
@@ -2427,12 +2427,12 @@ impl Resolver {
         let span = directive.span;
         if resolve_fail {
             self.session.span_err(span, fmt!("unresolved import: there is no `%s` in `%s`",
-                                             *self.session.str_of(source),
+                                             self.session.str_of(source),
                                              self.module_to_str(containing_module)));
             return Failed;
         } else if priv_fail {
             self.session.span_err(span, fmt!("unresolved import: found `%s` in `%s` but it is \
-                                             private", *self.session.str_of(source),
+                                             private", self.session.str_of(source),
                                              self.module_to_str(containing_module)));
             return Failed;
         }
@@ -2535,7 +2535,7 @@ impl Resolver {
 
             debug!("(resolving glob import) writing resolution `%s` in `%s` \
                     to `%s`, privacy=%?",
-                   *self.session.str_of(ident),
+                   self.session.str_of(ident),
                    self.module_to_str(containing_module),
                    self.module_to_str(module_),
                    copy dest_import_resolution.privacy);
@@ -2604,17 +2604,17 @@ impl Resolver {
                                               fmt!("unresolved import. maybe \
                                                     a missing `extern mod \
                                                     %s`?",
-                                                    *segment_name));
+                                                    segment_name));
                         return Failed;
                     }
                     self.session.span_err(span, fmt!("unresolved import: could not find `%s` in \
-                                                     `%s`.", *segment_name, module_name));
+                                                     `%s`.", segment_name, module_name));
                     return Failed;
                 }
                 Indeterminate => {
                     debug!("(resolving module path for import) module \
                             resolution is indeterminate: %s",
-                            *self.session.str_of(name));
+                            self.session.str_of(name));
                     return Indeterminate;
                 }
                 Success(target) => {
@@ -2628,7 +2628,7 @@ impl Resolver {
                                     self.session.span_err(span,
                                                           fmt!("not a \
                                                                 module `%s`",
-                                                               *self.session.
+                                                               self.session.
                                                                    str_of(
                                                                     name)));
                                     return Failed;
@@ -2656,7 +2656,7 @@ impl Resolver {
                             // There are no type bindings at all.
                             self.session.span_err(span,
                                                   fmt!("not a module `%s`",
-                                                       *self.session.str_of(
+                                                       self.session.str_of(
                                                             name)));
                             return Failed;
                         }
@@ -2783,7 +2783,7 @@ impl Resolver {
                                          -> ResolveResult<Target> {
         debug!("(resolving item in lexical scope) resolving `%s` in \
                 namespace %? in `%s`",
-               *self.session.str_of(name),
+               self.session.str_of(name),
                namespace,
                self.module_to_str(module_));
 
@@ -2997,11 +2997,11 @@ impl Resolver {
         // top of the crate otherwise.
         let mut containing_module;
         let mut i;
-        if *token::ident_to_str(&module_path[0]) == ~"self" {
+        if "self" == token::ident_to_str(&module_path[0]) {
             containing_module =
                 self.get_nearest_normal_module_parent_or_self(module_);
             i = 1;
-        } else if *token::ident_to_str(&module_path[0]) == ~"super" {
+        } else if "super" == token::ident_to_str(&module_path[0]) {
             containing_module =
                 self.get_nearest_normal_module_parent_or_self(module_);
             i = 0;  // We'll handle `super` below.
@@ -3011,7 +3011,7 @@ impl Resolver {
 
         // Now loop through all the `super`s we find.
         while i < module_path.len() &&
-                *token::ident_to_str(&module_path[i]) == ~"super" {
+                "super" == token::ident_to_str(&module_path[i]) {
             debug!("(resolving module prefix) resolving `super` at %s",
                    self.module_to_str(containing_module));
             match self.get_nearest_normal_module_parent(containing_module) {
@@ -3039,7 +3039,7 @@ impl Resolver {
                                   name_search_type: NameSearchType)
                                   -> ResolveResult<Target> {
         debug!("(resolving name in module) resolving `%s` in `%s`",
-               *self.session.str_of(name),
+               self.session.str_of(name),
                self.module_to_str(module_));
 
         // First, check the direct children of the module.
@@ -3112,7 +3112,7 @@ impl Resolver {
 
         // We're out of luck.
         debug!("(resolving name in module) failed to resolve `%s`",
-               *self.session.str_of(name));
+               self.session.str_of(name));
         return Failed;
     }
 
@@ -3230,7 +3230,7 @@ impl Resolver {
             (Some(d), Some(Public)) => {
                 debug!("(computing exports) YES: %s '%s' => %?",
                        if reexport { ~"reexport" } else { ~"export"},
-                       *self.session.str_of(ident),
+                       self.session.str_of(ident),
                        def_id_of_def(d));
                 exports2.push(Export2 {
                     reexport: reexport,
@@ -3252,7 +3252,7 @@ impl Resolver {
                                   module_: @mut Module) {
         for module_.children.each |ident, namebindings| {
             debug!("(computing exports) maybe export '%s'",
-                   *self.session.str_of(*ident));
+                   self.session.str_of(*ident));
             self.add_exports_of_namebindings(&mut *exports2,
                                              *ident,
                                              *namebindings,
@@ -3268,14 +3268,14 @@ impl Resolver {
         for module_.import_resolutions.each |ident, importresolution| {
             if importresolution.privacy != Public {
                 debug!("(computing exports) not reexporting private `%s`",
-                       *self.session.str_of(*ident));
+                       self.session.str_of(*ident));
                 loop;
             }
             for [ TypeNS, ValueNS ].each |ns| {
                 match importresolution.target_for_namespace(*ns) {
                     Some(target) => {
                         debug!("(computing exports) maybe reexport '%s'",
-                               *self.session.str_of(*ident));
+                               self.session.str_of(*ident));
                         self.add_exports_of_namebindings(&mut *exports2,
                                                          *ident,
                                                          target.bindings,
@@ -3318,7 +3318,7 @@ impl Resolver {
                 match orig_module.children.find(&name) {
                     None => {
                         debug!("!!! (with scope) didn't find `%s` in `%s`",
-                               *self.session.str_of(name),
+                               self.session.str_of(name),
                                self.module_to_str(orig_module));
                     }
                     Some(name_bindings) => {
@@ -3326,7 +3326,7 @@ impl Resolver {
                             None => {
                                 debug!("!!! (with scope) didn't find module \
                                         for `%s` in `%s`",
-                                       *self.session.str_of(name),
+                                       self.session.str_of(name),
                                        self.module_to_str(orig_module));
                             }
                             Some(module_) => {
@@ -3503,7 +3503,7 @@ impl Resolver {
 
     pub fn resolve_item(@mut self, item: @item, visitor: ResolveVisitor) {
         debug!("(resolving item) resolving %s",
-               *self.session.str_of(item.ident));
+               self.session.str_of(item.ident));
 
         // Items with the !resolve_unexported attribute are X-ray contexts.
         // This is used to allow the test runner to run unexported tests.
@@ -4044,7 +4044,7 @@ impl Resolver {
                         p.span,
                         fmt!("variable `%s` from pattern #1 is \
                                   not bound in pattern #%u",
-                             *self.session.str_of(key), i + 1));
+                             self.session.str_of(key), i + 1));
                   }
                   Some(binding_i) => {
                     if binding_0.binding_mode != binding_i.binding_mode {
@@ -4052,7 +4052,7 @@ impl Resolver {
                             binding_i.span,
                             fmt!("variable `%s` is bound with different \
                                       mode in pattern #%u than in pattern #1",
-                                 *self.session.str_of(key), i + 1));
+                                 self.session.str_of(key), i + 1));
                     }
                   }
                 }
@@ -4064,7 +4064,7 @@ impl Resolver {
                         binding.span,
                         fmt!("variable `%s` from pattern #%u is \
                                   not bound in pattern #1",
-                             *self.session.str_of(key), i + 1));
+                             self.session.str_of(key), i + 1));
                 }
             }
         }
@@ -4148,7 +4148,7 @@ impl Resolver {
                             Some(def) => {
                                 debug!("(resolving type) resolved `%s` to \
                                         type %?",
-                                       *self.session.str_of(
+                                       self.session.str_of(
                                             *path.idents.last()),
                                        def);
                                 result_def = Some(def);
@@ -4224,7 +4224,7 @@ impl Resolver {
                                 if mode == RefutableMode => {
                             debug!("(resolving pattern) resolving `%s` to \
                                     struct or enum variant",
-                                    *self.session.str_of(ident));
+                                    self.session.str_of(ident));
 
                             self.enforce_default_binding_mode(
                                 pattern,
@@ -4238,13 +4238,13 @@ impl Resolver {
                                                         shadows an enum \
                                                         variant or unit-like \
                                                         struct in scope",
-                                                        *self.session
+                                                        self.session
                                                             .str_of(ident)));
                         }
                         FoundConst(def) if mode == RefutableMode => {
                             debug!("(resolving pattern) resolving `%s` to \
                                     constant",
-                                    *self.session.str_of(ident));
+                                    self.session.str_of(ident));
 
                             self.enforce_default_binding_mode(
                                 pattern,
@@ -4259,7 +4259,7 @@ impl Resolver {
                         }
                         BareIdentifierPatternUnresolved => {
                             debug!("(resolving pattern) binding `%s`",
-                                   *self.session.str_of(ident));
+                                   self.session.str_of(ident));
 
                             let is_mutable = mutability == Mutable;
 
@@ -4350,7 +4350,7 @@ impl Resolver {
                             self.session.span_err(
                                 path.span,
                                 fmt!("`%s` is not an enum variant or constant",
-                                     *self.session.str_of(
+                                     self.session.str_of(
                                          *path.idents.last())));
                         }
                         None => {
@@ -4378,7 +4378,7 @@ impl Resolver {
                             self.session.span_err(
                                 path.span,
                                 fmt!("`%s` is not an enum variant, struct or const",
-                                     *self.session.str_of(
+                                     self.session.str_of(
                                          *path.idents.last())));
                         }
                         None => {
@@ -4753,7 +4753,7 @@ impl Resolver {
             Some(dl_def(def)) => {
                 debug!("(resolving path in local ribs) resolved `%s` to \
                         local: %?",
-                       *self.session.str_of(ident),
+                       self.session.str_of(ident),
                        def);
                 return Some(def);
             }
@@ -4811,7 +4811,7 @@ impl Resolver {
                     Some(def) => {
                         debug!("(resolving item path in lexical scope) \
                                 resolved `%s` to item",
-                               *self.session.str_of(ident));
+                               self.session.str_of(ident));
                         return Some(def);
                     }
                 }
@@ -4828,17 +4828,17 @@ impl Resolver {
     pub fn find_best_match_for_name(@mut self,
                                     name: &str,
                                     max_distance: uint)
-                                    -> Option<~str> {
+                                    -> Option<@str> {
         let this = &mut *self;
 
-        let mut maybes: ~[~str] = ~[];
+        let mut maybes: ~[@str] = ~[];
         let mut values: ~[uint] = ~[];
 
         let mut j = this.value_ribs.len();
         while j != 0 {
             j -= 1;
             for this.value_ribs[j].bindings.each_key |&k| {
-                vec::push(&mut maybes, copy *this.session.str_of(k));
+                vec::push(&mut maybes, this.session.str_of(k));
                 vec::push(&mut values, uint::max_value);
             }
         }
@@ -4857,7 +4857,7 @@ impl Resolver {
             values[smallest] != uint::max_value &&
             values[smallest] < name.len() + 2 &&
             values[smallest] <= max_distance &&
-            maybes[smallest] != name.to_owned() {
+            name != maybes[smallest] {
 
             Some(vec::swap_remove(&mut maybes, smallest))
 
@@ -4882,7 +4882,7 @@ impl Resolver {
                         match field.node.kind {
                           unnamed_field => {},
                           named_field(ident, _) => {
-                              if str::eq_slice(*this.session.str_of(ident),
+                              if str::eq_slice(this.session.str_of(ident),
                                                name) {
                                 return true
                               }
@@ -5007,7 +5007,7 @@ impl Resolver {
                         self.session.span_err(expr.span,
                                               fmt!("use of undeclared label \
                                                    `%s`",
-                                                   *self.session.str_of(
+                                                   self.session.str_of(
                                                        label))),
                     Some(dl_def(def @ def_label(_))) => {
                         self.record_def(expr.id, def)
@@ -5122,7 +5122,7 @@ impl Resolver {
     pub fn search_for_traits_containing_method(@mut self, name: ident)
                                                -> ~[def_id] {
         debug!("(searching for traits containing method) looking for '%s'",
-               *self.session.str_of(name));
+               self.session.str_of(name));
 
 
         let mut found_traits = ~[];
@@ -5227,7 +5227,7 @@ impl Resolver {
         debug!("(adding trait info) found trait %d:%d for method '%s'",
                trait_def_id.crate,
                trait_def_id.node,
-               *self.session.str_of(name));
+               self.session.str_of(name));
         found_traits.push(trait_def_id);
     }
 
@@ -5346,7 +5346,7 @@ impl Resolver {
 
         debug!("Children:");
         for module_.children.each_key |&name| {
-            debug!("* %s", *self.session.str_of(name));
+            debug!("* %s", self.session.str_of(name));
         }
 
         debug!("Import resolutions:");
@@ -5369,7 +5369,7 @@ impl Resolver {
                 }
             }
 
-            debug!("* %s:%s%s", *self.session.str_of(*name),
+            debug!("* %s:%s%s", self.session.str_of(*name),
                    value_repr, type_repr);
         }
     }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1239,10 +1239,10 @@ impl Resolver {
                             if *old_sp != span {
                                 self.session.span_err(span,
                                                       fmt!("duplicate definition of method `%s`",
-                                                           *self.session.str_of(ident)));
+                                                           self.session.str_of(ident)));
                                 self.session.span_note(*old_sp,
                                                        fmt!("first definition of method `%s` here",
-                                                            *self.session.str_of(ident)));
+                                                            self.session.str_of(ident)));
                             }
                         }
                     }
@@ -1376,10 +1376,10 @@ impl Resolver {
                             if *old_sp != ty_m.span {
                                 self.session.span_err(ty_m.span,
                                                       fmt!("duplicate definition of method `%s`",
-                                                           *self.session.str_of(ident)));
+                                                           self.session.str_of(ident)));
                                 self.session.span_note(*old_sp,
                                                        fmt!("first definition of method `%s` here",
-                                                            *self.session.str_of(ident)));
+                                                            self.session.str_of(ident)));
                             }
                         }
                     }

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1699,7 +1699,7 @@ pub fn trans_match_inner(scope_cx: block,
             // Special case for empty types
             let fail_cx = @mut None;
             let f: mk_fail = || mk_fail(scope_cx, discr_expr.span,
-                            @~"scrutinizing value that can't exist", fail_cx);
+                            @"scrutinizing value that can't exist", fail_cx);
             Some(f)
         } else {
             None
@@ -1731,7 +1731,7 @@ pub fn trans_match_inner(scope_cx: block,
     bcx = controlflow::join_blocks(scope_cx, arm_cxs);
     return bcx;
 
-    fn mk_fail(bcx: block, sp: span, msg: @~str,
+    fn mk_fail(bcx: block, sp: span, msg: @str,
                finished: @mut Option<BasicBlockRef>) -> BasicBlockRef {
         match *finished { Some(bb) => return bb, _ => () }
         let fail_cx = sub_block(bcx, "case_fallthrough");

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -33,7 +33,7 @@ pub fn trans_inline_asm(bcx: block, ia: &ast::inline_asm) -> block {
 
     // Prepare the output operands
     let outputs = do ia.outputs.map |&(c, out)| {
-        constraints.push(copy *c);
+        constraints.push(c);
 
         aoutputs.push(unpack_result!(bcx, {
             callee::trans_arg_expr(bcx,
@@ -69,7 +69,7 @@ pub fn trans_inline_asm(bcx: block, ia: &ast::inline_asm) -> block {
 
     // Now the input operands
     let inputs = do ia.inputs.map |&(c, in)| {
-        constraints.push(copy *c);
+        constraints.push(c);
 
         unpack_result!(bcx, {
             callee::trans_arg_expr(bcx,
@@ -90,14 +90,14 @@ pub fn trans_inline_asm(bcx: block, ia: &ast::inline_asm) -> block {
     let mut constraints = constraints.connect(",");
 
     let mut clobbers = getClobbers();
-    if *ia.clobbers != ~"" && clobbers != ~"" {
-        clobbers = *ia.clobbers + "," + clobbers;
+    if !ia.clobbers.is_empty() && !clobbers.is_empty() {
+        clobbers = fmt!("%s,%s", ia.clobbers, clobbers);
     } else {
-        clobbers += *ia.clobbers;
+        clobbers += ia.clobbers;
     };
 
     // Add the clobbers to our constraints list
-    if clobbers != ~"" && constraints != ~"" {
+    if !clobbers.is_empty() && !constraints.is_empty() {
         constraints += ",";
         constraints += clobbers;
     } else {
@@ -122,7 +122,7 @@ pub fn trans_inline_asm(bcx: block, ia: &ast::inline_asm) -> block {
         ast::asm_intel => lib::llvm::AD_Intel
     };
 
-    let r = do str::as_c_str(*ia.asm) |a| {
+    let r = do str::as_c_str(ia.asm) |a| {
         do str::as_c_str(constraints) |c| {
             InlineAsmCall(bcx, a, c, inputs, output, ia.volatile, ia.alignstack, dialect)
         }

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -54,12 +54,12 @@ pub fn const_lit(cx: @CrateContext, e: @ast::expr, lit: ast::lit)
                         ty_to_str(cx.tcx, lit_int_ty)))
         }
       }
-      ast::lit_float(fs, t) => C_floating(/*bad*/copy *fs, T_float_ty(cx, t)),
+      ast::lit_float(fs, t) => C_floating(fs, T_float_ty(cx, t)),
       ast::lit_float_unsuffixed(fs) => {
         let lit_float_ty = ty::node_id_to_type(cx.tcx, e.id);
         match ty::get(lit_float_ty).sty {
           ty::ty_float(t) => {
-            C_floating(/*bad*/copy *fs, T_float_ty(cx, t))
+            C_floating(fs, T_float_ty(cx, t))
           }
           _ => {
             cx.sess.span_bug(lit.span,

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -348,13 +348,13 @@ pub fn trans_fail_expr(bcx: block,
                     ppaux::ty_to_str(tcx, arg_datum.ty));
             }
         }
-        _ => trans_fail(bcx, sp_opt, @~"explicit failure")
+        _ => trans_fail(bcx, sp_opt, @"explicit failure")
     }
 }
 
 pub fn trans_fail(bcx: block,
                   sp_opt: Option<span>,
-                  fail_str: @~str)
+                  fail_str: @str)
                -> block {
     let _icx = bcx.insn_ctxt("trans_fail");
     let V_fail_str = C_cstr(bcx.ccx(), fail_str);
@@ -371,11 +371,11 @@ fn trans_fail_value(bcx: block,
       Some(sp) => {
         let sess = bcx.sess();
         let loc = sess.parse_sess.cm.lookup_char_pos(sp.lo);
-        (C_cstr(bcx.ccx(), @/*bad*/ copy loc.file.name),
+        (C_cstr(bcx.ccx(), loc.file.name),
          loc.line as int)
       }
       None => {
-        (C_cstr(bcx.ccx(), @~"<runtime>"), 0)
+        (C_cstr(bcx.ccx(), @"<runtime>"), 0)
       }
     };
     let V_str = PointerCast(bcx, V_fail_str, T_ptr(T_i8()));

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -452,7 +452,7 @@ fn trans_to_datum_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
 fn trans_rvalue_datum_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
     let _icx = bcx.insn_ctxt("trans_rvalue_datum_unadjusted");
 
-    trace_span!(bcx, expr.span, @shorten(bcx.expr_to_str(expr)));
+    trace_span!(bcx, expr.span, shorten(bcx.expr_to_str(expr)));
 
     match expr.node {
         ast::expr_path(_) | ast::expr_self => {
@@ -507,7 +507,7 @@ fn trans_rvalue_stmt_unadjusted(bcx: block, expr: @ast::expr) -> block {
         return bcx;
     }
 
-    trace_span!(bcx, expr.span, @shorten(bcx.expr_to_str(expr)));
+    trace_span!(bcx, expr.span, shorten(bcx.expr_to_str(expr)));
 
     match expr.node {
         ast::expr_break(label_opt) => {
@@ -560,7 +560,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
     let _icx = bcx.insn_ctxt("trans_rvalue_dps_unadjusted");
     let tcx = bcx.tcx();
 
-    trace_span!(bcx, expr.span, @shorten(bcx.expr_to_str(expr)));
+    trace_span!(bcx, expr.span, shorten(bcx.expr_to_str(expr)));
 
     match expr.node {
         ast::expr_paren(e) => {
@@ -821,7 +821,7 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
     debug!("trans_lvalue(expr=%s)", bcx.expr_to_str(expr));
     let _indenter = indenter();
 
-    trace_span!(bcx, expr.span, @shorten(bcx.expr_to_str(expr)));
+    trace_span!(bcx, expr.span, shorten(bcx.expr_to_str(expr)));
 
     return match expr.node {
         ast::expr_paren(e) => {
@@ -1703,6 +1703,6 @@ fn trans_assign_op(bcx: block,
     return result_datum.copy_to_datum(bcx, DROP_EXISTING, dst_datum);
 }
 
-fn shorten(x: ~str) -> ~str {
-    if x.char_len() > 60 { x.slice_chars(0, 60).to_owned() } else { x }
+fn shorten(x: &str) -> @str {
+    (if x.char_len() > 60 {x.slice_chars(0, 60)} else {x}).to_managed()
 }

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -686,10 +686,10 @@ pub fn declare_tydesc(ccx: @CrateContext, t: ty::t) -> @mut tydesc_info {
     let llsize = llsize_of(ccx, llty);
     let llalign = llalign_of(ccx, llty);
     let addrspace = declare_tydesc_addrspace(ccx, t);
-    let name = @mangle_internal_name_by_type_and_seq(ccx, t, "tydesc");
+    let name = mangle_internal_name_by_type_and_seq(ccx, t, "tydesc").to_managed();
     note_unique_llvm_symbol(ccx, name);
-    debug!("+++ declare_tydesc %s %s", ppaux::ty_to_str(ccx.tcx, t), *name);
-    let gvar = str::as_c_str(*name, |buf| {
+    debug!("+++ declare_tydesc %s %s", ppaux::ty_to_str(ccx.tcx, t), name);
+    let gvar = str::as_c_str(name, |buf| {
         unsafe {
             llvm::LLVMAddGlobal(ccx.llmod, ccx.tydesc_type, buf)
         }
@@ -715,10 +715,10 @@ pub fn declare_generic_glue(ccx: @CrateContext, t: ty::t, llfnty: TypeRef,
                             name: ~str) -> ValueRef {
     let _icx = ccx.insn_ctxt("declare_generic_glue");
     let name = name;
-    let fn_nm = @mangle_internal_name_by_type_and_seq(ccx, t, (~"glue_" + name));
-    debug!("%s is for type %s", *fn_nm, ppaux::ty_to_str(ccx.tcx, t));
+    let fn_nm = mangle_internal_name_by_type_and_seq(ccx, t, (~"glue_" + name)).to_managed();
+    debug!("%s is for type %s", fn_nm, ppaux::ty_to_str(ccx.tcx, t));
     note_unique_llvm_symbol(ccx, fn_nm);
-    let llfn = decl_cdecl_fn(ccx.llmod, *fn_nm, llfnty);
+    let llfn = decl_cdecl_fn(ccx.llmod, fn_nm, llfnty);
     set_glue_inlining(llfn, t);
     return llfn;
 }

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -139,7 +139,7 @@ pub fn static_size_of_enum(cx: @CrateContext, t: ty::t) -> uint {
                 });
 
                 debug!("static_size_of_enum: variant %s type %s",
-                       *cx.tcx.sess.str_of(variant.name),
+                       cx.tcx.sess.str_of(variant.name),
                        ty_str(cx.tn, T_struct(lltypes, false)));
 
                 let this_size = llsize_of_real(cx, T_struct(lltypes, false));

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -339,7 +339,7 @@ pub fn trans_static_method_callee(bcx: block,
         }
     };
     debug!("trans_static_method_callee: method_id=%?, callee_id=%?, \
-            name=%s", method_id, callee_id, *ccx.sess.str_of(mname));
+            name=%s", method_id, callee_id, ccx.sess.str_of(mname));
 
     let vtbls = resolve_vtables_in_fn_ctxt(
         bcx.fcx, ccx.maps.vtable_map.get_copy(&callee_id));
@@ -791,7 +791,7 @@ pub fn make_vtable(ccx: @CrateContext,
 
         let tbl = C_struct(components);
         let vtable = ccx.sess.str_of((ccx.names)("vtable"));
-        let vt_gvar = do str::as_c_str(*vtable) |buf| {
+        let vt_gvar = do str::as_c_str(vtable) |buf| {
             llvm::LLVMAddGlobal(ccx.llmod, val_ty(tbl), buf)
         };
         llvm::LLVMSetInitializer(vt_gvar, tbl);
@@ -827,16 +827,15 @@ pub fn make_impl_vtable(bcx: block,
                                 ty::mk_bare_fn(tcx, copy im.fty));
         if im.generics.has_type_params() || ty::type_has_self(fty) {
             debug!("(making impl vtable) method has self or type params: %s",
-                   *tcx.sess.str_of(im.ident));
+                   tcx.sess.str_of(im.ident));
             C_null(T_ptr(T_nil()))
         } else {
             debug!("(making impl vtable) adding method to vtable: %s",
-                   *tcx.sess.str_of(im.ident));
+                   tcx.sess.str_of(im.ident));
             let m_id = method_with_name_or_default(ccx, impl_id, im.ident);
 
             trans_fn_ref_with_vtables(bcx, m_id, 0,
                                       substs, Some(vtables)).llfn
-
         }
     };
 

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -164,7 +164,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
     ccx.monomorphizing.insert(fn_id, depth + 1);
 
     let pt = vec::append(/*bad*/copy *pt,
-                         [path_name((ccx.names)(*ccx.sess.str_of(name)))]);
+                         [path_name((ccx.names)(ccx.sess.str_of(name)))]);
     let s = mangle_exported_name(ccx, /*bad*/copy pt, mono_ty);
 
     let mk_lldecl = || {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -50,7 +50,7 @@ impl Reflector {
         C_int(self.bcx.ccx(), i)
     }
 
-    pub fn c_slice(&mut self, s: @~str) -> ValueRef {
+    pub fn c_slice(&mut self, s: @str) -> ValueRef {
         // We're careful to not use first class aggregates here because that
         // will kick us off fast isel. (Issue #4352.)
         let bcx = self.bcx;

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -250,7 +250,7 @@ pub fn trans_slice_vstore(bcx: block,
 
 pub fn trans_lit_str(bcx: block,
                      lit_expr: @ast::expr,
-                     str_lit: @~str,
+                     str_lit: @str,
                      dest: Dest)
                   -> block {
     //!

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -118,43 +118,43 @@ pub fn type_uses_for(ccx: @CrateContext, fn_id: def_id, n_tps: uint)
                                  _,
                                  _) => {
         if abi.is_intrinsic() {
-            let flags = match *cx.ccx.sess.str_of(i.ident) {
-                ~"size_of"  | ~"pref_align_of" | ~"min_align_of" |
-                ~"uninit"   | ~"init" | ~"transmute" | ~"move_val" |
-                ~"move_val_init" => use_repr,
+            let flags = match cx.ccx.sess.str_of(i.ident).as_slice() {
+                "size_of"  | "pref_align_of" | "min_align_of" |
+                "uninit"   | "init" | "transmute" | "move_val" |
+                "move_val_init" => use_repr,
 
-                ~"get_tydesc" | ~"needs_drop" => use_tydesc,
+                "get_tydesc" | "needs_drop" => use_tydesc,
 
-                ~"atomic_cxchg"    | ~"atomic_cxchg_acq"|
-                ~"atomic_cxchg_rel"| ~"atomic_load"     |
-                ~"atomic_load_acq" | ~"atomic_store"    |
-                ~"atomic_store_rel"| ~"atomic_xchg"     |
-                ~"atomic_xadd"     | ~"atomic_xsub"     |
-                ~"atomic_xchg_acq" | ~"atomic_xadd_acq" |
-                ~"atomic_xsub_acq" | ~"atomic_xchg_rel" |
-                ~"atomic_xadd_rel" | ~"atomic_xsub_rel" => 0,
+                "atomic_cxchg"    | "atomic_cxchg_acq"|
+                "atomic_cxchg_rel"| "atomic_load"     |
+                "atomic_load_acq" | "atomic_store"    |
+                "atomic_store_rel"| "atomic_xchg"     |
+                "atomic_xadd"     | "atomic_xsub"     |
+                "atomic_xchg_acq" | "atomic_xadd_acq" |
+                "atomic_xsub_acq" | "atomic_xchg_rel" |
+                "atomic_xadd_rel" | "atomic_xsub_rel" => 0,
 
-                ~"visit_tydesc"  | ~"forget" | ~"frame_address" |
-                ~"morestack_addr" => 0,
+                "visit_tydesc"  | "forget" | "frame_address" |
+                "morestack_addr" => 0,
 
-                ~"memcpy32" | ~"memcpy64" | ~"memmove32" | ~"memmove64" |
-                ~"memset32" | ~"memset64" => use_repr,
+                "memcpy32" | "memcpy64" | "memmove32" | "memmove64" |
+                "memset32" | "memset64" => use_repr,
 
-                ~"sqrtf32" | ~"sqrtf64" | ~"powif32" | ~"powif64" |
-                ~"sinf32"  | ~"sinf64"  | ~"cosf32"  | ~"cosf64"  |
-                ~"powf32"  | ~"powf64"  | ~"expf32"  | ~"expf64"  |
-                ~"exp2f32" | ~"exp2f64" | ~"logf32"  | ~"logf64"  |
-                ~"log10f32"| ~"log10f64"| ~"log2f32" | ~"log2f64" |
-                ~"fmaf32"  | ~"fmaf64"  | ~"fabsf32" | ~"fabsf64" |
-                ~"floorf32"| ~"floorf64"| ~"ceilf32" | ~"ceilf64" |
-                ~"truncf32"| ~"truncf64" => 0,
+                "sqrtf32" | "sqrtf64" | "powif32" | "powif64" |
+                "sinf32"  | "sinf64"  | "cosf32"  | "cosf64"  |
+                "powf32"  | "powf64"  | "expf32"  | "expf64"  |
+                "exp2f32" | "exp2f64" | "logf32"  | "logf64"  |
+                "log10f32"| "log10f64"| "log2f32" | "log2f64" |
+                "fmaf32"  | "fmaf64"  | "fabsf32" | "fabsf64" |
+                "floorf32"| "floorf64"| "ceilf32" | "ceilf64" |
+                "truncf32"| "truncf64" => 0,
 
-                ~"ctpop8" | ~"ctpop16" | ~"ctpop32" | ~"ctpop64" => 0,
+                "ctpop8" | "ctpop16" | "ctpop32" | "ctpop64" => 0,
 
-                ~"ctlz8" | ~"ctlz16" | ~"ctlz32" | ~"ctlz64" => 0,
-                ~"cttz8" | ~"cttz16" | ~"cttz32" | ~"cttz64" => 0,
+                "ctlz8" | "ctlz16" | "ctlz32" | "ctlz64" => 0,
+                "cttz8" | "cttz16" | "cttz32" | "cttz64" => 0,
 
-                ~"bswap16" | ~"bswap32" | ~"bswap64" => 0,
+                "bswap16" | "bswap32" | "bswap64" => 0,
 
                 // would be cool to make these an enum instead of strings!
                 _ => fail!("unknown intrinsic in type_use")

--- a/src/librustc/middle/trans/write_guard.rs
+++ b/src/librustc/middle/trans/write_guard.rs
@@ -117,8 +117,8 @@ fn root(datum: &Datum,
     if bcx.sess().trace() {
         trans_trace(
             bcx, None,
-            @fmt!("preserving until end of scope %d",
-                  root_info.scope));
+            (fmt!("preserving until end of scope %d",
+                  root_info.scope)).to_managed());
     }
 
     // First, root the datum. Note that we must zero this value,

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -281,7 +281,7 @@ struct ctxt_ {
     tcache: type_cache,
     rcache: creader_cache,
     ccache: constness_cache,
-    short_names_cache: @mut HashMap<t, @~str>,
+    short_names_cache: @mut HashMap<t, @str>,
     needs_unwind_cleanup_cache: @mut HashMap<t, bool>,
     tc_cache: @mut HashMap<uint, TypeContents>,
     ast_ty_to_ty_cache: @mut HashMap<node_id, ast_ty_to_ty_cache_entry>,
@@ -3366,7 +3366,7 @@ pub fn field_idx_strict(tcx: ty::ctxt, id: ast::ident, fields: &[field])
     for fields.each |f| { if f.ident == id { return i; } i += 1u; }
     tcx.sess.bug(fmt!(
         "No field named `%s` found in the list of fields `%?`",
-        *tcx.sess.str_of(id),
+        tcx.sess.str_of(id),
         fields.map(|f| tcx.sess.str_of(f.ident))));
 }
 
@@ -3514,8 +3514,8 @@ pub fn type_err_to_str(cx: ctxt, err: &type_err) -> ~str {
         terr_record_fields(values) => {
             fmt!("expected a record with field `%s` but found one with field \
                   `%s`",
-                 *cx.sess.str_of(values.expected),
-                 *cx.sess.str_of(values.found))
+                 cx.sess.str_of(values.expected),
+                 cx.sess.str_of(values.found))
         }
         terr_arg_count => ~"incorrect number of function parameters",
         terr_regions_does_not_outlive(*) => {
@@ -3549,7 +3549,7 @@ pub fn type_err_to_str(cx: ctxt, err: &type_err) -> ~str {
                  trait_store_to_str(cx, (*values).found))
         }
         terr_in_field(err, fname) => {
-            fmt!("in field `%s`, %s", *cx.sess.str_of(fname),
+            fmt!("in field `%s`, %s", cx.sess.str_of(fname),
                  type_err_to_str(cx, err))
         }
         terr_sorts(values) => {

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -297,7 +297,7 @@ pub fn check_struct_pat_fields(pcx: &pat_ctxt,
                 tcx.sess.span_err(span,
                                   fmt!("struct `%s` does not have a field
                                         named `%s`", name,
-                                       *tcx.sess.str_of(field.ident)));
+                                       tcx.sess.str_of(field.ident)));
             }
         }
     }
@@ -310,7 +310,7 @@ pub fn check_struct_pat_fields(pcx: &pat_ctxt,
             }
             tcx.sess.span_err(span,
                               fmt!("pattern does not mention field `%s`",
-                                   *tcx.sess.str_of(field.ident)));
+                                   tcx.sess.str_of(field.ident)));
         }
     }
 }

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -251,7 +251,7 @@ impl CoherenceChecker {
         if associated_traits.len() == 0 {
             debug!("(checking implementation) no associated traits for item \
                     '%s'",
-                   *self.crate_context.tcx.sess.str_of(item.ident));
+                   self.crate_context.tcx.sess.str_of(item.ident));
 
             match get_base_type_def_id(self.inference_context,
                                        item.span,
@@ -278,7 +278,7 @@ impl CoherenceChecker {
                     associated_trait.ref_id);
             debug!("(checking implementation) adding impl for trait '%s', item '%s'",
                    trait_ref.repr(self.crate_context.tcx),
-                   *self.crate_context.tcx.sess.str_of(item.ident));
+                   self.crate_context.tcx.sess.str_of(item.ident));
 
             self.instantiate_default_methods(item.id, trait_ref);
 
@@ -401,7 +401,7 @@ impl CoherenceChecker {
                     // method to that entry.
                     debug!("(checking implementation) adding method `%s` \
                             to entry for existing trait",
-                            *self.crate_context.tcx.sess.str_of(
+                            self.crate_context.tcx.sess.str_of(
                                 provided_method_info.method_info.ident));
                     mis.push(provided_method_info);
                 }
@@ -409,7 +409,7 @@ impl CoherenceChecker {
                     // If the trait doesn't have an entry yet, create one.
                     debug!("(checking implementation) creating new entry \
                             for method `%s`",
-                            *self.crate_context.tcx.sess.str_of(
+                            self.crate_context.tcx.sess.str_of(
                                 provided_method_info.method_info.ident));
                     pmm.insert(local_def(impl_id),
                                @mut ~[provided_method_info]);
@@ -742,7 +742,7 @@ impl CoherenceChecker {
 
             tcx.sess.span_err(trait_ref_span,
                               fmt!("missing method `%s`",
-                                   *tcx.sess.str_of(method.ident)));
+                                   tcx.sess.str_of(method.ident)));
         }
     }
 
@@ -794,7 +794,7 @@ impl CoherenceChecker {
             for all_provided_methods.each |provided_method| {
                 debug!(
                     "(creating impl) adding provided method `%s` to impl",
-                    *sess.str_of(provided_method.method_info.ident));
+                    sess.str_of(provided_method.method_info.ident));
                 vec::push(all_methods, provided_method.method_info);
             }
         }
@@ -909,7 +909,7 @@ impl CoherenceChecker {
                         session.bug(fmt!(
                             "no base type for external impl \
                              with no trait: %s (type %s)!",
-                             *session.str_of(implementation.ident),
+                             session.str_of(implementation.ident),
                              ty_to_str(self.crate_context.tcx,self_type.ty)));
                     }
                     Some(_) => {

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -471,7 +471,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
                 cm.span,
                 fmt!("method `%s` has a `%s` declaration in the impl, \
                       but not in the trait",
-                     *tcx.sess.str_of(trait_m.ident),
+                     tcx.sess.str_of(trait_m.ident),
                      explicit_self_to_str(impl_m.explicit_self, tcx.sess.intr())));
             return;
         }
@@ -480,7 +480,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
                 cm.span,
                 fmt!("method `%s` has a `%s` declaration in the trait, \
                       but not in the impl",
-                     *tcx.sess.str_of(trait_m.ident),
+                     tcx.sess.str_of(trait_m.ident),
                      explicit_self_to_str(trait_m.explicit_self, tcx.sess.intr())));
             return;
         }
@@ -496,7 +496,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
             cm.span,
             fmt!("method `%s` has %u type %s, but its trait \
                   declaration has %u type %s",
-                 *tcx.sess.str_of(trait_m.ident),
+                 tcx.sess.str_of(trait_m.ident),
                  num_impl_m_type_params,
                  pluralize(num_impl_m_type_params, ~"parameter"),
                  num_trait_m_type_params,
@@ -509,7 +509,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
             cm.span,
             fmt!("method `%s` has %u parameter%s \
                   but the trait has %u",
-                 *tcx.sess.str_of(trait_m.ident),
+                 tcx.sess.str_of(trait_m.ident),
                  impl_m.fty.sig.inputs.len(),
                  if impl_m.fty.sig.inputs.len() == 1 { "" } else { "s" },
                  trait_m.fty.sig.inputs.len()));
@@ -533,7 +533,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
                      which is not required by \
                      the corresponding type parameter \
                      in the trait declaration",
-                    *tcx.sess.str_of(trait_m.ident),
+                    tcx.sess.str_of(trait_m.ident),
                     i,
                     extra_bounds.user_string(tcx)));
            return;
@@ -551,7 +551,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
                       type parameter %u has %u trait %s, but the \
                       corresponding type parameter in \
                       the trait declaration has %u trait %s",
-                     *tcx.sess.str_of(trait_m.ident),
+                     tcx.sess.str_of(trait_m.ident),
                      i, impl_param_def.bounds.trait_bounds.len(),
                      pluralize(impl_param_def.bounds.trait_bounds.len(),
                                ~"bound"),
@@ -652,7 +652,7 @@ pub fn compare_impl_method(tcx: ty::ctxt,
             tcx.sess.span_err(
                 cm.span,
                 fmt!("method `%s` has an incompatible type: %s",
-                     *tcx.sess.str_of(trait_m.ident),
+                     tcx.sess.str_of(trait_m.ident),
                      ty::type_err_to_str(tcx, terr)));
             ty::note_and_explain_type_err(tcx, terr);
         }
@@ -700,7 +700,7 @@ pub fn check_methods_against_trait(ccx: &CrateCtxt,
                 tcx.sess.span_err(
                     impl_m.span,
                     fmt!("method `%s` is not a member of trait `%s`",
-                         *tcx.sess.str_of(impl_m.mty.ident),
+                         tcx.sess.str_of(impl_m.mty.ident),
                          path_to_str(a_trait_ty.path, tcx.sess.intr())));
             }
         }
@@ -829,7 +829,7 @@ pub fn convert(ccx: &CrateCtxt, it: @ast::item) {
     let tcx = ccx.tcx;
     let rp = tcx.region_paramd_items.find(&it.id).map_consume(|x| *x);
     debug!("convert: item %s with id %d rp %?",
-           *tcx.sess.str_of(it.ident), it.id, rp);
+           tcx.sess.str_of(it.ident), it.id, rp);
     match it.node {
       // These don't define types.
       ast::item_foreign_mod(_) | ast::item_mod(_) => {}
@@ -1084,7 +1084,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: @ast::item)
             ty: ty::mk_bare_fn(ccx.tcx, tofd)
         };
         debug!("type of %s (id %d) is %s",
-               *tcx.sess.str_of(it.ident),
+               tcx.sess.str_of(it.ident),
                it.id,
                ppaux::ty_to_str(tcx, tpt.ty));
         ccx.tcx.tcache.insert(local_def(it.id), tpt);

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -236,9 +236,9 @@ pub fn run_compiler(args: &~[~str], demitter: diagnostic::Emitter) {
     ::core::logging::console_off();
 
     let mut args = /*bad*/copy *args;
-    let binary = @args.shift();
+    let binary = args.shift().to_managed();
 
-    if args.is_empty() { usage(*binary); return; }
+    if args.is_empty() { usage(binary); return; }
 
     let matches =
         &match getopts::groups::getopts(args, optgroups()) {
@@ -249,7 +249,7 @@ pub fn run_compiler(args: &~[~str], demitter: diagnostic::Emitter) {
         };
 
     if opt_present(matches, "h") || opt_present(matches, "help") {
-        usage(*binary);
+        usage(binary);
         return;
     }
 
@@ -276,16 +276,16 @@ pub fn run_compiler(args: &~[~str], demitter: diagnostic::Emitter) {
     }
 
     if opt_present(matches, "v") || opt_present(matches, "version") {
-        version(*binary);
+        version(binary);
         return;
     }
     let input = match matches.free.len() {
       0u => early_error(demitter, ~"no input filename given"),
       1u => {
-        let ifile = /*bad*/copy matches.free[0];
-        if ifile == ~"-" {
+        let ifile = matches.free[0].as_slice();
+        if "-" == ifile {
             let src = str::from_bytes(io::stdin().read_whole_stream());
-            str_input(src)
+            str_input(src.to_managed())
         } else {
             file_input(Path(ifile))
         }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -159,7 +159,7 @@ pub fn bound_region_to_str_space(cx: ctxt,
     if cx.sess.verbose() { return fmt!("%s%? ", prefix, br); }
 
     match br {
-      br_named(id)         => fmt!("%s'%s ", prefix, *cx.sess.str_of(id)),
+      br_named(id)         => fmt!("%s'%s ", prefix, cx.sess.str_of(id)),
       br_self              => fmt!("%s'self ", prefix),
       br_anon(_)           => prefix.to_str(),
       br_fresh(_)          => prefix.to_str(),
@@ -323,7 +323,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
         match ident {
           Some(i) => {
               s.push_char(' ');
-              s.push_str(*cx.sess.str_of(i));
+              s.push_str(cx.sess.str_of(i));
           }
           _ => { }
         }
@@ -389,7 +389,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
                        &m.fty.sig) + ";"
     }
     fn field_to_str(cx: ctxt, f: field) -> ~str {
-        return *cx.sess.str_of(f.ident) + ": " + mt_to_str(cx, &f.mt);
+        return fmt!("%s: %s", cx.sess.str_of(f.ident), mt_to_str(cx, &f.mt));
     }
 
     // if there is an id, print that instead of the structural type:
@@ -656,7 +656,7 @@ impl Repr for ty::Method {
 
 impl Repr for ast::ident {
     fn repr(&self, _tcx: ctxt) -> ~str {
-        copy *token::ident_to_str(self)
+        token::ident_to_str(self).to_owned()
     }
 }
 

--- a/src/librustdoc/astsrv.rs
+++ b/src/librustdoc/astsrv.rs
@@ -41,7 +41,7 @@ pub struct Ctxt {
 
 type SrvOwner<'self,T> = &'self fn(srv: Srv) -> T;
 pub type CtxtHandler<T> = ~fn(ctxt: Ctxt) -> T;
-type Parser = ~fn(Session, s: ~str) -> @ast::crate;
+type Parser = ~fn(Session, s: @str) -> @ast::crate;
 
 enum Msg {
     HandleRequest(~fn(Ctxt)),
@@ -68,7 +68,7 @@ fn run<T>(owner: SrvOwner<T>, source: ~str, parse: Parser) -> T {
     let source = Cell::new(source);
     let parse = Cell::new(parse);
     do task::spawn {
-        act(&po, source.take(), parse.take());
+        act(&po, source.take().to_managed(), parse.take());
     }
 
     let srv_ = Srv {
@@ -80,12 +80,12 @@ fn run<T>(owner: SrvOwner<T>, source: ~str, parse: Parser) -> T {
     res
 }
 
-fn act(po: &Port<Msg>, source: ~str, parse: Parser) {
+fn act(po: &Port<Msg>, source: @str, parse: Parser) {
     let sess = build_session();
 
     let ctxt = build_ctxt(
         sess,
-        parse(sess, copy source)
+        parse(sess, source)
     );
 
     let mut keep_going = true;

--- a/src/librustdoc/attr_parser.rs
+++ b/src/librustdoc/attr_parser.rs
@@ -41,13 +41,13 @@ pub fn parse_crate(attrs: ~[ast::attribute]) -> CrateAttrs {
     let name = attr::last_meta_item_value_str_by_name(link_metas, "name");
 
     CrateAttrs {
-        name: name.map(|s| copy **s)
+        name: name.map(|s| s.to_owned())
     }
 }
 
 pub fn parse_desc(attrs: ~[ast::attribute]) -> Option<~str> {
     let doc_strs = do doc_metas(attrs).filter_mapped |meta| {
-        attr::get_meta_item_value_str(*meta).map(|s| copy **s)
+        attr::get_meta_item_value_str(*meta).map(|s| s.to_owned())
     };
     if doc_strs.is_empty() {
         None

--- a/src/librustdoc/attr_parser.rs
+++ b/src/librustdoc/attr_parser.rs
@@ -75,13 +75,13 @@ mod test {
     use syntax;
     use super::{parse_hidden, parse_crate, parse_desc};
 
-    fn parse_attributes(source: ~str) -> ~[ast::attribute] {
+    fn parse_attributes(source: @str) -> ~[ast::attribute] {
         use syntax::parse;
         use syntax::parse::attr::parser_attr;
 
         let parse_sess = syntax::parse::new_parse_sess(None);
         let parser = parse::new_parser_from_source_str(
-            parse_sess, ~[], ~"-", @source);
+            parse_sess, ~[], @"-", source);
 
         parser.parse_outer_attributes()
     }
@@ -89,7 +89,7 @@ mod test {
 
     #[test]
     fn should_extract_crate_name_from_link_attribute() {
-        let source = ~"#[link(name = \"snuggles\")]";
+        let source = @"#[link(name = \"snuggles\")]";
         let attrs = parse_attributes(source);
         let attrs = parse_crate(attrs);
         assert!(attrs.name == Some(~"snuggles"));
@@ -97,7 +97,7 @@ mod test {
 
     #[test]
     fn should_not_extract_crate_name_if_no_link_attribute() {
-        let source = ~"";
+        let source = @"";
         let attrs = parse_attributes(source);
         let attrs = parse_crate(attrs);
         assert!(attrs.name == None);
@@ -105,7 +105,7 @@ mod test {
 
     #[test]
     fn should_not_extract_crate_name_if_no_name_value_in_link_attribute() {
-        let source = ~"#[link(whatever)]";
+        let source = @"#[link(whatever)]";
         let attrs = parse_attributes(source);
         let attrs = parse_crate(attrs);
         assert!(attrs.name == None);
@@ -113,7 +113,7 @@ mod test {
 
     #[test]
     fn parse_desc_should_handle_undocumented_mods() {
-        let source = ~"";
+        let source = @"";
         let attrs = parse_attributes(source);
         let attrs = parse_desc(attrs);
         assert!(attrs == None);
@@ -121,7 +121,7 @@ mod test {
 
     #[test]
     fn parse_desc_should_parse_simple_doc_attributes() {
-        let source = ~"#[doc = \"basic\"]";
+        let source = @"#[doc = \"basic\"]";
         let attrs = parse_attributes(source);
         let attrs = parse_desc(attrs);
         assert!(attrs == Some(~"basic"));
@@ -129,28 +129,28 @@ mod test {
 
     #[test]
     fn should_parse_hidden_attribute() {
-        let source = ~"#[doc(hidden)]";
+        let source = @"#[doc(hidden)]";
         let attrs = parse_attributes(source);
         assert!(parse_hidden(attrs) == true);
     }
 
     #[test]
     fn should_parse_hidden_attribute_with_other_docs() {
-        let source = ~"#[doc = \"foo\"] #[doc(hidden)] #[doc = \"foo\"]";
+        let source = @"#[doc = \"foo\"] #[doc(hidden)] #[doc = \"foo\"]";
         let attrs = parse_attributes(source);
         assert!(parse_hidden(attrs) == true);
     }
 
     #[test]
     fn should_not_parse_non_hidden_attribute() {
-        let source = ~"#[doc = \"\"]";
+        let source = @"#[doc = \"\"]";
         let attrs = parse_attributes(source);
         assert!(parse_hidden(attrs) == false);
     }
 
     #[test]
     fn should_concatenate_multiple_doc_comments() {
-        let source = ~"/// foo\n/// bar";
+        let source = @"/// foo\n/// bar";
         let desc = parse_desc(parse_attributes(source));
         assert!(desc == Some(~"foo\nbar"));
     }

--- a/src/librustdoc/extract.rs
+++ b/src/librustdoc/extract.rs
@@ -25,7 +25,7 @@ use syntax::parse::token;
 // thread-local data
 // Hack-Becomes-Feature: using thread-local-state everywhere...
 pub fn to_str(id: ast::ident) -> ~str {
-    return copy *ident_to_str(&id);
+    /* bad */ ident_to_str(&id).to_owned()
 }
 
 // get rid of this pointless function:

--- a/src/librustdoc/extract.rs
+++ b/src/librustdoc/extract.rs
@@ -287,21 +287,21 @@ mod test {
 
     use core::vec;
 
-    fn mk_doc(source: ~str) -> doc::Doc {
+    fn mk_doc(source: @str) -> doc::Doc {
         let ast = parse::from_str(source);
         extract(ast, ~"")
     }
 
     #[test]
     fn extract_empty_crate() {
-        let doc = mk_doc(~"");
+        let doc = mk_doc(@"");
         assert!(doc.cratemod().mods().is_empty());
         assert!(doc.cratemod().fns().is_empty());
     }
 
     #[test]
     fn extract_mods() {
-        let doc = mk_doc(~"mod a { mod b { } mod c { } }");
+        let doc = mk_doc(@"mod a { mod b { } mod c { } }");
         assert!(doc.cratemod().mods()[0].name() == ~"a");
         assert!(doc.cratemod().mods()[0].mods()[0].name() == ~"b");
         assert!(doc.cratemod().mods()[0].mods()[1].name() == ~"c");
@@ -309,27 +309,27 @@ mod test {
 
     #[test]
     fn extract_fns_from_foreign_mods() {
-        let doc = mk_doc(~"extern { fn a(); }");
+        let doc = mk_doc(@"extern { fn a(); }");
         assert!(doc.cratemod().nmods()[0].fns[0].name() == ~"a");
     }
 
     #[test]
     fn extract_mods_deep() {
-        let doc = mk_doc(~"mod a { mod b { mod c { } } }");
+        let doc = mk_doc(@"mod a { mod b { mod c { } } }");
         assert!(doc.cratemod().mods()[0].mods()[0].mods()[0].name() ==
             ~"c");
     }
 
     #[test]
     fn extract_should_set_mod_ast_id() {
-        let doc = mk_doc(~"mod a { }");
+        let doc = mk_doc(@"mod a { }");
         assert!(doc.cratemod().mods()[0].id() != 0);
     }
 
     #[test]
     fn extract_fns() {
         let doc = mk_doc(
-            ~"fn a() { } \
+            @"fn a() { } \
               mod b { fn c() {
              } }");
         assert!(doc.cratemod().fns()[0].name() == ~"a");
@@ -338,13 +338,13 @@ mod test {
 
     #[test]
     fn extract_should_set_fn_ast_id() {
-        let doc = mk_doc(~"fn a() { }");
+        let doc = mk_doc(@"fn a() { }");
         assert!(doc.cratemod().fns()[0].id() != 0);
     }
 
     #[test]
     fn extract_should_use_default_crate_name() {
-        let source = ~"";
+        let source = @"";
         let ast = parse::from_str(source);
         let doc = extract(ast, ~"burp");
         assert!(doc.cratemod().name() == ~"burp");
@@ -361,57 +361,57 @@ mod test {
 
     #[test]
     fn should_extract_const_name_and_id() {
-        let doc = mk_doc(~"static a: int = 0;");
+        let doc = mk_doc(@"static a: int = 0;");
         assert!(doc.cratemod().consts()[0].id() != 0);
         assert!(doc.cratemod().consts()[0].name() == ~"a");
     }
 
     #[test]
     fn should_extract_enums() {
-        let doc = mk_doc(~"enum e { v }");
+        let doc = mk_doc(@"enum e { v }");
         assert!(doc.cratemod().enums()[0].id() != 0);
         assert!(doc.cratemod().enums()[0].name() == ~"e");
     }
 
     #[test]
     fn should_extract_enum_variants() {
-        let doc = mk_doc(~"enum e { v }");
+        let doc = mk_doc(@"enum e { v }");
         assert!(doc.cratemod().enums()[0].variants[0].name == ~"v");
     }
 
     #[test]
     fn should_extract_traits() {
-        let doc = mk_doc(~"trait i { fn f(); }");
+        let doc = mk_doc(@"trait i { fn f(); }");
         assert!(doc.cratemod().traits()[0].name() == ~"i");
     }
 
     #[test]
     fn should_extract_trait_methods() {
-        let doc = mk_doc(~"trait i { fn f(); }");
+        let doc = mk_doc(@"trait i { fn f(); }");
         assert!(doc.cratemod().traits()[0].methods[0].name == ~"f");
     }
 
     #[test]
     fn should_extract_impl_methods() {
-        let doc = mk_doc(~"impl int { fn f() { } }");
+        let doc = mk_doc(@"impl int { fn f() { } }");
         assert!(doc.cratemod().impls()[0].methods[0].name == ~"f");
     }
 
     #[test]
     fn should_extract_tys() {
-        let doc = mk_doc(~"type a = int;");
+        let doc = mk_doc(@"type a = int;");
         assert!(doc.cratemod().types()[0].name() == ~"a");
     }
 
     #[test]
     fn should_extract_structs() {
-        let doc = mk_doc(~"struct Foo { field: () }");
+        let doc = mk_doc(@"struct Foo { field: () }");
         assert!(doc.cratemod().structs()[0].name() == ~"Foo");
     }
 
     #[test]
     fn should_extract_struct_fields() {
-        let doc = mk_doc(~"struct Foo { field: () }");
+        let doc = mk_doc(@"struct Foo { field: () }");
         assert!(doc.cratemod().structs()[0].fields[0] == ~"field");
     }
 }

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -368,7 +368,7 @@ pub fn default_seq_fold_struct<T>(
 
 #[test]
 fn default_fold_should_produce_same_doc() {
-    let source = ~"mod a { fn b() { } mod c { fn d() { } } }";
+    let source = @"mod a { fn b() { } mod c { fn d() { } } }";
     let ast = parse::from_str(source);
     let doc = extract::extract(ast, ~"");
     let fld = default_seq_fold(());
@@ -378,7 +378,7 @@ fn default_fold_should_produce_same_doc() {
 
 #[test]
 fn default_fold_should_produce_same_consts() {
-    let source = ~"static a: int = 0;";
+    let source = @"static a: int = 0;";
     let ast = parse::from_str(source);
     let doc = extract::extract(ast, ~"");
     let fld = default_seq_fold(());
@@ -388,7 +388,7 @@ fn default_fold_should_produce_same_consts() {
 
 #[test]
 fn default_fold_should_produce_same_enums() {
-    let source = ~"enum a { b }";
+    let source = @"enum a { b }";
     let ast = parse::from_str(source);
     let doc = extract::extract(ast, ~"");
     let fld = default_seq_fold(());
@@ -398,7 +398,7 @@ fn default_fold_should_produce_same_enums() {
 
 #[test]
 fn default_parallel_fold_should_produce_same_doc() {
-    let source = ~"mod a { fn b() { } mod c { fn d() { } } }";
+    let source = @"mod a { fn b() { } mod c { fn d() { } } }";
     let ast = parse::from_str(source);
     let doc = extract::extract(ast, ~"");
     let fld = default_par_fold(());

--- a/src/librustdoc/parse.rs
+++ b/src/librustdoc/parse.rs
@@ -23,9 +23,9 @@ pub fn from_file(file: &Path) -> @ast::crate {
         file, ~[], parse::new_parse_sess(None))
 }
 
-pub fn from_str(source: ~str) -> @ast::crate {
+pub fn from_str(source: @str) -> @ast::crate {
     parse::parse_crate_from_source_str(
-        ~"-", @source, ~[], parse::new_parse_sess(None))
+        @"-", source, ~[], parse::new_parse_sess(None))
 }
 
 pub fn from_file_sess(sess: session::Session, file: &Path) -> @ast::crate {
@@ -33,11 +33,11 @@ pub fn from_file_sess(sess: session::Session, file: &Path) -> @ast::crate {
         file, cfg(sess, file_input(copy *file)), sess.parse_sess)
 }
 
-pub fn from_str_sess(sess: session::Session, source: ~str) -> @ast::crate {
+pub fn from_str_sess(sess: session::Session, source: @str) -> @ast::crate {
     parse::parse_crate_from_source_str(
-        ~"-", @copy source, cfg(sess, str_input(source)), sess.parse_sess)
+        @"-", source, cfg(sess, str_input(source)), sess.parse_sess)
 }
 
 fn cfg(sess: session::Session, input: driver::input) -> ast::crate_cfg {
-    driver::build_configuration(sess, @~"rustdoc", &input)
+    driver::build_configuration(sess, @"rustdoc", &input)
 }

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -117,7 +117,7 @@ fn record(mut repl: Repl, blk: &ast::blk, intr: @token::ident_interner) -> Repl 
 
 /// Run an input string in a Repl, returning the new Repl.
 fn run(repl: Repl, input: ~str) -> Repl {
-    let binary = @copy repl.binary;
+    let binary = repl.binary.to_managed();
     let options = @session::options {
         crate_type: session::unknown_crate,
         binary: binary,
@@ -130,7 +130,7 @@ fn run(repl: Repl, input: ~str) -> Repl {
     let head = include_str!("wrapper.rs").to_owned();
     let foot = fmt!("fn main() {\n%s\n%s\n\nprint({\n%s\n})\n}",
                     repl.view_items, repl.stmts, input);
-    let wrapped = driver::str_input(head + foot);
+    let wrapped = driver::str_input((head + foot).to_managed());
 
     debug!("inputting %s", head + foot);
 
@@ -186,7 +186,7 @@ fn run(repl: Repl, input: ~str) -> Repl {
 fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
     match do task::try {
         let src_path = Path(src_filename);
-        let binary = @copy binary;
+        let binary = binary.to_managed();
         let options = @session::options {
             binary: binary,
             addl_lib_search_paths: @mut ~[os::getcwd()],

--- a/src/librustpkg/rustpkg.rc
+++ b/src/librustpkg/rustpkg.rc
@@ -100,7 +100,7 @@ impl<'self> PkgScript<'self> {
     /// a PkgScript that we can then execute
     fn parse<'a>(script: Path, workspace: &Path, id: &'a PkgId) -> PkgScript<'a> {
         // Get the executable name that was invoked
-        let binary = @copy os::args()[0];
+        let binary = os::args()[0].to_managed();
         // Build the rustc session data structures to pass
         // to the compiler
         let options = @session::options {
@@ -145,7 +145,7 @@ impl<'self> PkgScript<'self> {
                 let root = r.pop().pop().pop().pop(); // :-\
                 debug!("Root is %s, calling compile_rest", root.to_str());
                 let exe = self.build_dir.push(~"pkg" + util::exe_suffix());
-                let binary = @copy os::args()[0];
+                let binary = os::args()[0].to_managed();
                 util::compile_crate_from_input(&self.input,
                                                &self.build_dir,
                                                sess,

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -22,7 +22,7 @@ use iterator::IteratorUtil;
 use libc;
 use option::{None, Option, Some};
 use str;
-use str::{StrSlice, StrVector};
+use str::{Str, StrSlice, StrVector};
 use to_str::ToStr;
 use ascii::{AsciiCast, AsciiStr};
 use old_iter::BaseIter;
@@ -102,7 +102,7 @@ pub trait GenericPath {
     fn push_rel(&self, (&Self)) -> Self;
     /// Returns a new Path consisting of the path given by the given vector
     /// of strings, relative to `self`.
-    fn push_many(&self, (&[~str])) -> Self;
+    fn push_many<S: Str>(&self, (&[S])) -> Self;
     /// Identical to `dir_path` except in the case where `self` has only one
     /// component. In this case, `pop` returns the empty path.
     fn pop(&self) -> Self;
@@ -566,10 +566,10 @@ impl GenericPath for PosixPath {
         false
     }
 
-    fn push_many(&self, cs: &[~str]) -> PosixPath {
+    fn push_many<S: Str>(&self, cs: &[S]) -> PosixPath {
         let mut v = copy self.components;
         for cs.each |e| {
-            for e.split_iter(windows::is_sep).advance |s| {
+            for e.as_slice().split_iter(windows::is_sep).advance |s| {
                 if !s.is_empty() {
                     v.push(s.to_owned())
                 }
@@ -823,10 +823,10 @@ impl GenericPath for WindowsPath {
         }
     }
 
-    fn push_many(&self, cs: &[~str]) -> WindowsPath {
+    fn push_many<S: Str>(&self, cs: &[S]) -> WindowsPath {
         let mut v = copy self.components;
         for cs.each |e| {
-            for e.split_iter(windows::is_sep).advance |s| {
+            for e.as_slice().split_iter(windows::is_sep).advance |s| {
                 if !s.is_empty() {
                     v.push(s.to_owned())
                 }

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -64,7 +64,7 @@ pub use path::PosixPath;
 pub use path::WindowsPath;
 pub use ptr::RawPtr;
 pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr};
-pub use str::{StrVector, StrSlice, OwnedStr, StrUtil, NullTerminatedStr};
+pub use str::{Str, StrVector, StrSlice, OwnedStr, StrUtil, NullTerminatedStr};
 pub use from_str::{FromStr};
 pub use to_bytes::IterBytes;
 pub use to_str::{ToStr, ToStrConsume};

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -729,10 +729,22 @@ impl Ord for @str {
 }
 
 #[cfg(not(test))]
-impl<'self> Equiv<~str> for &'self str {
+impl<'self, S: Str> Equiv<S> for &'self str {
     #[inline(always)]
-    fn equiv(&self, other: &~str) -> bool { eq_slice(*self, *other) }
+    fn equiv(&self, other: &S) -> bool { eq_slice(*self, other.as_slice()) }
 }
+#[cfg(not(test))]
+impl<'self, S: Str> Equiv<S> for @str {
+    #[inline(always)]
+    fn equiv(&self, other: &S) -> bool { eq_slice(*self, other.as_slice()) }
+}
+
+#[cfg(not(test))]
+impl<'self, S: Str> Equiv<S> for ~str {
+    #[inline(always)]
+    fn equiv(&self, other: &S) -> bool { eq_slice(*self, other.as_slice()) }
+}
+
 
 /*
 Section: Iterating through strings

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -84,7 +84,7 @@ pub type Mrk = uint;
 
 impl<S:Encoder> Encodable<S> for ident {
     fn encode(&self, s: &mut S) {
-        s.emit_str(*interner_get(self.name));
+        s.emit_str(interner_get(self.name));
     }
 }
 
@@ -228,9 +228,9 @@ pub type meta_item = spanned<meta_item_>;
 
 #[deriving(Eq, Encodable, Decodable)]
 pub enum meta_item_ {
-    meta_word(@~str),
-    meta_list(@~str, ~[@meta_item]),
-    meta_name_value(@~str, lit),
+    meta_word(@str),
+    meta_list(@str, ~[@meta_item]),
+    meta_name_value(@str, lit),
 }
 
 pub type blk = spanned<blk_>;
@@ -634,12 +634,12 @@ pub type lit = spanned<lit_>;
 
 #[deriving(Eq, Encodable, Decodable)]
 pub enum lit_ {
-    lit_str(@~str),
+    lit_str(@str),
     lit_int(i64, int_ty),
     lit_uint(u64, uint_ty),
     lit_int_unsuffixed(i64),
-    lit_float(@~str, float_ty),
-    lit_float_unsuffixed(@~str),
+    lit_float(@str, float_ty),
+    lit_float_unsuffixed(@str),
     lit_nil,
     lit_bool(bool),
 }
@@ -819,10 +819,10 @@ pub enum asm_dialect {
 
 #[deriving(Eq, Encodable, Decodable)]
 pub struct inline_asm {
-    asm: @~str,
-    clobbers: @~str,
-    inputs: ~[(@~str, @expr)],
-    outputs: ~[(@~str, @expr)],
+    asm: @str,
+    clobbers: @str,
+    inputs: ~[(@str, @expr)],
+    outputs: ~[(@str, @expr)],
     volatile: bool,
     alignstack: bool,
     dialect: asm_dialect

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -58,8 +58,8 @@ pub fn path_to_str_with_sep(p: &[path_elt], sep: &str, itr: @ident_interner)
                          -> ~str {
     let strs = do p.map |e| {
         match *e {
-          path_mod(s) => copy *itr.get(s.name),
-          path_name(s) => copy *itr.get(s.name)
+          path_mod(s) => itr.get(s.name),
+          path_name(s) => itr.get(s.name)
         }
     };
     strs.connect(sep)
@@ -68,9 +68,9 @@ pub fn path_to_str_with_sep(p: &[path_elt], sep: &str, itr: @ident_interner)
 pub fn path_ident_to_str(p: &path, i: ident, itr: @ident_interner) -> ~str {
     if p.is_empty() {
         //FIXME /* FIXME (#2543) */ copy *i
-        copy *itr.get(i.name)
+        itr.get(i.name).to_owned()
     } else {
-        fmt!("%s::%s", path_to_str(*p, itr), *itr.get(i.name))
+        fmt!("%s::%s", path_to_str(*p, itr), itr.get(i.name))
     }
 }
 
@@ -80,8 +80,8 @@ pub fn path_to_str(p: &[path_elt], itr: @ident_interner) -> ~str {
 
 pub fn path_elt_to_str(pe: path_elt, itr: @ident_interner) -> ~str {
     match pe {
-        path_mod(s) => copy *itr.get(s.name),
-        path_name(s) => copy *itr.get(s.name)
+        path_mod(s) => itr.get(s.name).to_owned(),
+        path_name(s) => itr.get(s.name).to_owned()
     }
 }
 
@@ -359,16 +359,16 @@ pub fn node_id_to_str(map: map, id: node_id, itr: @ident_interner) -> ~str {
       }
       Some(&node_method(m, _, path)) => {
         fmt!("method %s in %s (id=%?)",
-             *itr.get(m.ident.name), path_to_str(*path, itr), id)
+             itr.get(m.ident.name), path_to_str(*path, itr), id)
       }
       Some(&node_trait_method(ref tm, _, path)) => {
         let m = ast_util::trait_method_to_ty_method(&**tm);
         fmt!("method %s in %s (id=%?)",
-             *itr.get(m.ident.name), path_to_str(*path, itr), id)
+             itr.get(m.ident.name), path_to_str(*path, itr), id)
       }
       Some(&node_variant(ref variant, _, path)) => {
         fmt!("variant %s in %s (id=%?)",
-             *itr.get(variant.node.name.name), path_to_str(*path, itr), id)
+             itr.get(variant.node.name.name), path_to_str(*path, itr), id)
       }
       Some(&node_expr(expr)) => {
         fmt!("expr %s (id=%?)", pprust::expr_to_str(expr, itr), id)
@@ -384,7 +384,7 @@ pub fn node_id_to_str(map: map, id: node_id, itr: @ident_interner) -> ~str {
         fmt!("arg (id=%?)", id)
       }
       Some(&node_local(ident)) => {
-        fmt!("local (id=%?, name=%s)", id, *itr.get(ident.name))
+        fmt!("local (id=%?, name=%s)", id, itr.get(ident.name))
       }
       Some(&node_block(_)) => {
         fmt!("block")

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -28,7 +28,7 @@ use core::iterator::IteratorUtil;
 
 pub fn path_name_i(idents: &[ident]) -> ~str {
     // FIXME: Bad copies (#2543 -- same for everything else that says "bad")
-    idents.map(|i| copy *token::interner_get(i.name)).connect("::")
+    idents.map(|i| token::interner_get(i.name)).connect("::")
 }
 
 pub fn path_to_ident(p: @Path) -> ident { copy *p.idents.last() }
@@ -815,7 +815,7 @@ mod test {
         assert_eq!(copy s,~[14]);
     }
 
-    // convert a list of uints to an @~[ident]
+    // convert a list of uints to an @[ident]
     // (ignores the interner completely)
     fn uints_to_idents (uints: &~[uint]) -> @~[ident] {
         @uints.map(|u|{ ident {name:*u, ctxt: empty_ctxt} })

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -306,8 +306,8 @@ fn highlight_lines(cm: @codemap::CodeMap,
 
 fn print_macro_backtrace(cm: @codemap::CodeMap, sp: span) {
     for sp.expn_info.iter().advance |ei| {
-        let ss = ei.callee.span.map_default(@~"", |span| @cm.span_to_str(*span));
-        print_diagnostic(*ss, note,
+        let ss = ei.callee.span.map_default(~"", |span| cm.span_to_str(*span));
+        print_diagnostic(ss, note,
                          fmt!("in expansion of %s!", ei.callee.name));
         let ss = cm.span_to_str(ei.call_site);
         print_diagnostic(ss, note, "expansion site");

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -45,7 +45,7 @@ pub fn expand_asm(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
                                        cx.cfg(),
                                        tts.to_owned());
 
-    let mut asm = ~"";
+    let mut asm = @"";
     let mut outputs = ~[];
     let mut inputs = ~[];
     let mut cons = ~"";
@@ -113,7 +113,7 @@ pub fn expand_asm(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
                         p.eat(&token::COMMA);
                     }
 
-                    let clob = ~"~{" + *p.parse_str() + "}";
+                    let clob = fmt!("~{%s}", p.parse_str());
                     clobs.push(clob);
                 }
 
@@ -122,11 +122,11 @@ pub fn expand_asm(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
             Options => {
                 let option = p.parse_str();
 
-                if "volatile" == *option {
+                if "volatile" == option {
                     volatile = true;
-                } else if "alignstack" == *option {
+                } else if "alignstack" == option {
                     alignstack = true;
-                } else if "intel" == *option {
+                } else if "intel" == option {
                     dialect = ast::asm_intel;
                 }
 
@@ -176,8 +176,8 @@ pub fn expand_asm(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
     MRExpr(@ast::expr {
         id: cx.next_id(),
         node: ast::expr_inline_asm(ast::inline_asm {
-            asm: @asm,
-            clobbers: @cons,
+            asm: asm,
+            clobbers: cons.to_managed(),
             inputs: inputs,
             outputs: outputs,
             volatile: volatile,

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -33,7 +33,7 @@ use core::hashmap::HashMap;
 // ast::mac_invoc_tt.
 
 pub struct MacroDef {
-    name: ~str,
+    name: @str,
     ext: SyntaxExtension
 }
 
@@ -308,18 +308,18 @@ impl ExtCtxt {
     pub fn set_trace_macros(&self, x: bool) {
         *self.trace_mac = x
     }
-    pub fn str_of(&self, id: ast::ident) -> ~str {
-        copy *ident_to_str(&id)
+    pub fn str_of(&self, id: ast::ident) -> @str {
+        ident_to_str(&id)
     }
     pub fn ident_of(&self, st: &str) -> ast::ident {
         str_to_ident(st)
     }
 }
 
-pub fn expr_to_str(cx: @ExtCtxt, expr: @ast::expr, err_msg: ~str) -> ~str {
+pub fn expr_to_str(cx: @ExtCtxt, expr: @ast::expr, err_msg: ~str) -> @str {
     match expr.node {
       ast::expr_lit(l) => match l.node {
-        ast::lit_str(s) => copy *s,
+        ast::lit_str(s) => s,
         _ => cx.span_fatal(l.span, err_msg)
       },
       _ => cx.span_fatal(expr.span, err_msg)
@@ -350,7 +350,7 @@ pub fn check_zero_tts(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree],
 pub fn get_single_str_from_tts(cx: @ExtCtxt,
                                sp: span,
                                tts: &[ast::token_tree],
-                               name: &str) -> ~str {
+                               name: &str) -> @str {
     if tts.len() != 1 {
         cx.span_fatal(sp, fmt!("%s takes 1 argument.", name));
     }
@@ -538,25 +538,25 @@ mod test {
 
     #[test] fn testenv () {
         let mut a = HashMap::new();
-        a.insert (@~"abc",@15);
+        a.insert (@"abc",@15);
         let m = MapChain::new(~a);
-        m.insert (@~"def",@16);
-        // FIXME: #4492 (ICE)  assert_eq!(m.find(&@~"abc"),Some(@15));
-        //  ....               assert_eq!(m.find(&@~"def"),Some(@16));
-        assert_eq!(*(m.find(&@~"abc").get()),15);
-        assert_eq!(*(m.find(&@~"def").get()),16);
+        m.insert (@"def",@16);
+        // FIXME: #4492 (ICE)  assert_eq!(m.find(&@"abc"),Some(@15));
+        //  ....               assert_eq!(m.find(&@"def"),Some(@16));
+        assert_eq!(*(m.find(&@"abc").get()),15);
+        assert_eq!(*(m.find(&@"def").get()),16);
         let n = m.push_frame();
         // old bindings are still present:
-        assert_eq!(*(n.find(&@~"abc").get()),15);
-        assert_eq!(*(n.find(&@~"def").get()),16);
-        n.insert (@~"def",@17);
+        assert_eq!(*(n.find(&@"abc").get()),15);
+        assert_eq!(*(n.find(&@"def").get()),16);
+        n.insert (@"def",@17);
         // n shows the new binding
-        assert_eq!(*(n.find(&@~"abc").get()),15);
-        assert_eq!(*(n.find(&@~"def").get()),17);
+        assert_eq!(*(n.find(&@"abc").get()),15);
+        assert_eq!(*(n.find(&@"def").get()),17);
         // ... but m still has the old ones
-        // FIXME: #4492: assert_eq!(m.find(&@~"abc"),Some(@15));
-        // FIXME: #4492: assert_eq!(m.find(&@~"def"),Some(@16));
-        assert_eq!(*(m.find(&@~"abc").get()),15);
-        assert_eq!(*(m.find(&@~"def").get()),16);
+        // FIXME: #4492: assert_eq!(m.find(&@"abc"),Some(@15));
+        // FIXME: #4492: assert_eq!(m.find(&@"def"),Some(@16));
+        assert_eq!(*(m.find(&@"abc").get()),15);
+        assert_eq!(*(m.find(&@"def").get()),16);
     }
 }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -126,8 +126,8 @@ pub trait AstBuilder {
     fn expr_vec(&self, sp: span, exprs: ~[@ast::expr]) -> @ast::expr;
     fn expr_vec_uniq(&self, sp: span, exprs: ~[@ast::expr]) -> @ast::expr;
     fn expr_vec_slice(&self, sp: span, exprs: ~[@ast::expr]) -> @ast::expr;
-    fn expr_str(&self, sp: span, s: ~str) -> @ast::expr;
-    fn expr_str_uniq(&self, sp: span, s: ~str) -> @ast::expr;
+    fn expr_str(&self, sp: span, s: @str) -> @ast::expr;
+    fn expr_str_uniq(&self, sp: span, s: @str) -> @ast::expr;
 
     fn expr_unreachable(&self, span: span) -> @ast::expr;
 
@@ -215,9 +215,9 @@ pub trait AstBuilder {
 
     fn attribute(&self, sp: span, mi: @ast::meta_item) -> ast::attribute;
 
-    fn meta_word(&self, sp: span, w: ~str) -> @ast::meta_item;
-    fn meta_list(&self, sp: span, name: ~str, mis: ~[@ast::meta_item]) -> @ast::meta_item;
-    fn meta_name_value(&self, sp: span, name: ~str, value: ast::lit_) -> @ast::meta_item;
+    fn meta_word(&self, sp: span, w: @str) -> @ast::meta_item;
+    fn meta_list(&self, sp: span, name: @str, mis: ~[@ast::meta_item]) -> @ast::meta_item;
+    fn meta_name_value(&self, sp: span, name: @str, value: ast::lit_) -> @ast::meta_item;
 
     fn view_use(&self, sp: span,
                 vis: ast::visibility, vp: ~[@ast::view_path]) -> @ast::view_item;
@@ -521,10 +521,10 @@ impl AstBuilder for @ExtCtxt {
     fn expr_vec_slice(&self, sp: span, exprs: ~[@ast::expr]) -> @ast::expr {
         self.expr_vstore(sp, self.expr_vec(sp, exprs), ast::expr_vstore_slice)
     }
-    fn expr_str(&self, sp: span, s: ~str) -> @ast::expr {
-        self.expr_lit(sp, ast::lit_str(@s))
+    fn expr_str(&self, sp: span, s: @str) -> @ast::expr {
+        self.expr_lit(sp, ast::lit_str(s))
     }
-    fn expr_str_uniq(&self, sp: span, s: ~str) -> @ast::expr {
+    fn expr_str_uniq(&self, sp: span, s: @str) -> @ast::expr {
         self.expr_vstore(sp, self.expr_str(sp, s), ast::expr_vstore_uniq)
     }
 
@@ -540,8 +540,8 @@ impl AstBuilder for @ExtCtxt {
                 self.ident_of("fail_with"),
             ],
             ~[
-                self.expr_str(span, ~"internal error: entered unreachable code"),
-                self.expr_str(span, copy loc.file.name),
+                self.expr_str(span, @"internal error: entered unreachable code"),
+                self.expr_str(span, loc.file.name),
                 self.expr_uint(span, loc.line),
             ])
     }
@@ -791,14 +791,14 @@ impl AstBuilder for @ExtCtxt {
                })
     }
 
-    fn meta_word(&self, sp: span, w: ~str) -> @ast::meta_item {
-        @respan(sp, ast::meta_word(@w))
+    fn meta_word(&self, sp: span, w: @str) -> @ast::meta_item {
+        @respan(sp, ast::meta_word(w))
     }
-    fn meta_list(&self, sp: span, name: ~str, mis: ~[@ast::meta_item]) -> @ast::meta_item {
-        @respan(sp, ast::meta_list(@name, mis))
+    fn meta_list(&self, sp: span, name: @str, mis: ~[@ast::meta_item]) -> @ast::meta_item {
+        @respan(sp, ast::meta_list(name, mis))
     }
-    fn meta_name_value(&self, sp: span, name: ~str, value: ast::lit_) -> @ast::meta_item {
-        @respan(sp, ast::meta_name_value(@name, respan(sp, value)))
+    fn meta_name_value(&self, sp: span, name: @str, value: ast::lit_) -> @ast::meta_item {
+        @respan(sp, ast::meta_name_value(name, respan(sp, value)))
     }
 
     fn view_use(&self, sp: span,

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -72,7 +72,7 @@ fn decodable_substructure(cx: @ExtCtxt, span: span,
             };
             let read_struct_field = cx.ident_of("read_struct_field");
 
-            let getarg = |name: ~str, field: uint| {
+            let getarg = |name: @str, field: uint| {
                 cx.expr_method_call(span, blkdecoder, read_struct_field,
                                     ~[cx.expr_str(span, name),
                                       cx.expr_uint(span, field),
@@ -86,7 +86,7 @@ fn decodable_substructure(cx: @ExtCtxt, span: span,
                     } else {
                         let mut fields = vec::with_capacity(n);
                         for uint::range(0, n) |i| {
-                            fields.push(getarg(fmt!("_field%u", i), i));
+                            fields.push(getarg(fmt!("_field%u", i).to_managed(), i));
                         }
                         cx.expr_call_ident(span, substr.type_ident, fields)
                     }

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -127,7 +127,7 @@ fn encodable_substructure(cx: @ExtCtxt, span: span,
             for fields.eachi |i, f| {
                 let (name, val) = match *f {
                     (Some(id), e, _) => (cx.str_of(id), e),
-                    (None, e, _) => (fmt!("_field%u", i), e)
+                    (None, e, _) => (fmt!("_field%u", i).to_managed(), e)
                 };
                 let enc = cx.expr_method_call(span, val, encode, ~[blkencoder]);
                 let lambda = cx.lambda_expr_1(span, enc, blkarg);

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -364,7 +364,7 @@ impl<'self> TraitDef<'self> {
         let doc_attr = cx.attribute(
             span,
             cx.meta_name_value(span,
-                               ~"doc", ast::lit_str(@~"Automatically derived.")));
+                               @"doc", ast::lit_str(@"Automatically derived.")));
         cx.item(
             span,
             ::parse::token::special_idents::clownshoes_extensions,

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -82,23 +82,23 @@ pub fn expand_meta_deriving(cx: @ExtCtxt,
                     meta_word(tname) => {
                         macro_rules! expand(($func:path) => ($func(cx, titem.span,
                                                                    titem, in_items)));
-                        match *tname {
-                            ~"Clone" => expand!(clone::expand_deriving_clone),
-                            ~"DeepClone" => expand!(clone::expand_deriving_deep_clone),
+                        match tname.as_slice() {
+                            "Clone" => expand!(clone::expand_deriving_clone),
+                            "DeepClone" => expand!(clone::expand_deriving_deep_clone),
 
-                            ~"IterBytes" => expand!(iter_bytes::expand_deriving_iter_bytes),
+                            "IterBytes" => expand!(iter_bytes::expand_deriving_iter_bytes),
 
-                            ~"Encodable" => expand!(encodable::expand_deriving_encodable),
-                            ~"Decodable" => expand!(decodable::expand_deriving_decodable),
+                            "Encodable" => expand!(encodable::expand_deriving_encodable),
+                            "Decodable" => expand!(decodable::expand_deriving_decodable),
 
-                            ~"Eq" => expand!(eq::expand_deriving_eq),
-                            ~"TotalEq" => expand!(totaleq::expand_deriving_totaleq),
-                            ~"Ord" => expand!(ord::expand_deriving_ord),
-                            ~"TotalOrd" => expand!(totalord::expand_deriving_totalord),
+                            "Eq" => expand!(eq::expand_deriving_eq),
+                            "TotalEq" => expand!(totaleq::expand_deriving_totaleq),
+                            "Ord" => expand!(ord::expand_deriving_ord),
+                            "TotalOrd" => expand!(totalord::expand_deriving_totalord),
 
-                            ~"Rand" => expand!(rand::expand_deriving_rand),
+                            "Rand" => expand!(rand::expand_deriving_rand),
 
-                            ~"ToStr" => expand!(to_str::expand_deriving_to_str),
+                            "ToStr" => expand!(to_str::expand_deriving_to_str),
 
                             ref tname => {
                                 cx.span_err(titem.span, fmt!("unknown \

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -33,8 +33,8 @@ pub fn expand_syntax_ext(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
     // Option<str> rather than just an maybe-empty string.
 
     let e = match os::getenv(var) {
-      None => cx.expr_str(sp, ~""),
-      Some(ref s) => cx.expr_str(sp, copy *s)
+      None => cx.expr_str(sp, @""),
+      Some(s) => cx.expr_str(sp, s.to_managed())
     };
     MRExpr(e)
 }

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -274,12 +274,13 @@ fn pieces_to_expr(cx: @ExtCtxt, sp: span,
                    then there's no need for it to be mutable */
                 if i == 0 {
                     stms.push(cx.stmt_let(fmt_sp, npieces > 1,
-                                          ident, cx.expr_str_uniq(fmt_sp, s)));
+                                          ident, cx.expr_str_uniq(fmt_sp, s.to_managed())));
                 } else {
                     // we call the push_str function because the
                     // bootstrap doesnt't seem to work if we call the
                     // method.
-                    let args = ~[cx.expr_mut_addr_of(fmt_sp, buf()), cx.expr_str(fmt_sp, s)];
+                    let args = ~[cx.expr_mut_addr_of(fmt_sp, buf()),
+                                 cx.expr_str(fmt_sp, s.to_managed())];
                     let call = cx.expr_call_global(fmt_sp,
                                                    ~[core_ident,
                                                      str_ident,
@@ -303,7 +304,7 @@ fn pieces_to_expr(cx: @ExtCtxt, sp: span,
                    must be initialized as an empty string */
                 if i == 0 {
                     stms.push(cx.stmt_let(fmt_sp, true, ident,
-                                          cx.expr_str_uniq(fmt_sp, ~"")));
+                                          cx.expr_str_uniq(fmt_sp, @"")));
                 }
                 stms.push(cx.stmt_expr(make_new_conv(cx, fmt_sp, conv,
                                                      args[n], buf())));

--- a/src/libsyntax/ext/pipes/check.rs
+++ b/src/libsyntax/ext/pipes/check.rs
@@ -51,7 +51,7 @@ impl proto::visitor<(), (), ()> for @ExtCtxt {
         }
     }
 
-    fn visit_message(&self, name: ~str, _span: span, _tys: &[@ast::Ty],
+    fn visit_message(&self, name: @str, _span: span, _tys: &[@ast::Ty],
                      this: state, next: Option<next_state>) {
         match next {
           Some(ref next_state) => {

--- a/src/libsyntax/ext/pipes/parse_proto.rs
+++ b/src/libsyntax/ext/pipes/parse_proto.rs
@@ -20,13 +20,13 @@ use parse::token;
 use parse::token::{interner_get};
 
 pub trait proto_parser {
-    fn parse_proto(&self, id: ~str) -> protocol;
+    fn parse_proto(&self, id: @str) -> protocol;
     fn parse_state(&self, proto: protocol);
     fn parse_message(&self, state: state);
 }
 
 impl proto_parser for parser::Parser {
-    fn parse_proto(&self, id: ~str) -> protocol {
+    fn parse_proto(&self, id: @str) -> protocol {
         let proto = protocol(id, *self.span);
 
         self.parse_seq_to_before_end(
@@ -43,7 +43,7 @@ impl proto_parser for parser::Parser {
 
     fn parse_state(&self, proto: protocol) {
         let id = self.parse_ident();
-        let name = copy *interner_get(id.name);
+        let name = interner_get(id.name);
 
         self.expect(&token::COLON);
         let dir = match copy *self.token {
@@ -51,9 +51,9 @@ impl proto_parser for parser::Parser {
             _ => fail!()
         };
         self.bump();
-        let dir = match dir {
-          @~"send" => send,
-          @~"recv" => recv,
+        let dir = match dir.as_slice() {
+          "send" => send,
+          "recv" => recv,
           _ => fail!()
         };
 
@@ -78,7 +78,7 @@ impl proto_parser for parser::Parser {
     }
 
     fn parse_message(&self, state: state) {
-        let mname = copy *interner_get(self.parse_ident().name);
+        let mname = interner_get(self.parse_ident().name);
 
         let args = if *self.token == token::LPAREN {
             self.parse_unspanned_seq(
@@ -97,7 +97,7 @@ impl proto_parser for parser::Parser {
 
         let next = match *self.token {
           token::IDENT(_, _) => {
-            let name = copy *interner_get(self.parse_ident().name);
+            let name = interner_get(self.parse_ident().name);
             let ntys = if *self.token == token::LT {
                 self.parse_unspanned_seq(
                     &token::LT,

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -101,7 +101,7 @@ impl gen_send for message {
                          name,
                          vec::append_one(
                              arg_names.map(|x| cx.str_of(*x)),
-                             ~"s").connect(", "));
+                             @"s").connect(", "));
 
             if !try {
                 body += fmt!("::std::pipes::send(pipe, message);\n");
@@ -114,7 +114,7 @@ impl gen_send for message {
                               } else { ::std::pipes::rt::make_none() } }");
             }
 
-            let body = cx.parse_expr(body);
+            let body = cx.parse_expr(body.to_managed());
 
             let mut rty = cx.ty_path(path(~[next.data_name()],
                                           span)
@@ -123,7 +123,7 @@ impl gen_send for message {
                 rty = cx.ty_option(rty);
             }
 
-            let name = cx.ident_of(if try { ~"try_" + name } else { name } );
+            let name = if try {cx.ident_of(~"try_" + name)} else {cx.ident_of(name)};
 
             cx.item_fn_poly(dummy_sp(),
                             name,
@@ -173,12 +173,12 @@ impl gen_send for message {
                                   } }");
                 }
 
-                let body = cx.parse_expr(body);
+                let body = cx.parse_expr(body.to_managed());
 
-                let name = if try { ~"try_" + name } else { name };
+                let name = if try {cx.ident_of(~"try_" + name)} else {cx.ident_of(name)};
 
                 cx.item_fn_poly(dummy_sp(),
-                                cx.ident_of(name),
+                                name,
                                 args_ast,
                                 if try {
                                     cx.ty_option(cx.ty_nil())
@@ -326,7 +326,7 @@ impl gen_init for protocol {
                            start_state.generics.to_source(),
                            start_state.to_ty(cx).to_source(),
                            start_state.to_ty(cx).to_source(),
-                           body.to_source()))
+                           body.to_source()).to_managed())
     }
 
     fn gen_buffer_init(&self, ext_cx: @ExtCtxt) -> @ast::expr {
@@ -358,10 +358,10 @@ impl gen_init for protocol {
                 self.states.map_to_vec(
                     |s| ext_cx.parse_stmt(
                         fmt!("data.%s.set_buffer(buffer)",
-                             s.name))),
+                             s.name).to_managed())),
                 Some(ext_cx.parse_expr(fmt!(
                     "::std::ptr::to_mut_unsafe_ptr(&mut (data.%s))",
-                    self.states[0].name)))));
+                    self.states[0].name).to_managed()))));
 
         quote_expr!({
             let buffer = $buffer;
@@ -459,9 +459,9 @@ impl gen_init for protocol {
         let allows = cx.attribute(
             copy self.span,
             cx.meta_list(copy self.span,
-                         ~"allow",
-                         ~[cx.meta_word(copy self.span, ~"non_camel_case_types"),
-                           cx.meta_word(copy self.span, ~"unused_mut")]));
+                         @"allow",
+                         ~[cx.meta_word(copy self.span, @"non_camel_case_types"),
+                           cx.meta_word(copy self.span, @"unused_mut")]));
         cx.item_mod(copy self.span, cx.ident_of(copy self.name),
                     ~[allows], ~[], items)
     }

--- a/src/libsyntax/ext/pipes/proto.rs
+++ b/src/libsyntax/ext/pipes/proto.rs
@@ -38,17 +38,17 @@ impl direction {
 }
 
 pub struct next_state {
-    state: ~str,
+    state: @str,
     tys: ~[@ast::Ty],
 }
 
 // name, span, data, current state, next state
-pub struct message(~str, span, ~[@ast::Ty], state, Option<next_state>);
+pub struct message(@str, span, ~[@ast::Ty], state, Option<next_state>);
 
 impl message {
-    pub fn name(&mut self) -> ~str {
+    pub fn name(&mut self) -> @str {
         match *self {
-          message(ref id, _, _, _, _) => copy *id
+          message(id, _, _, _, _) => id
         }
     }
 
@@ -70,7 +70,7 @@ pub type state = @state_;
 
 pub struct state_ {
     id: uint,
-    name: ~str,
+    name: @str,
     ident: ast::ident,
     span: span,
     dir: direction,
@@ -81,7 +81,7 @@ pub struct state_ {
 
 impl state_ {
     pub fn add_message(@self,
-                       name: ~str,
+                       name: @str,
                        span: span,
                        data: ~[@ast::Ty],
                        next: Option<next_state>) {
@@ -122,11 +122,11 @@ impl state_ {
 
 pub type protocol = @mut protocol_;
 
-pub fn protocol(name: ~str, span: span) -> protocol {
+pub fn protocol(name: @str, span: span) -> protocol {
     @mut protocol_(name, span)
 }
 
-pub fn protocol_(name: ~str, span: span) -> protocol_ {
+pub fn protocol_(name: @str, span: span) -> protocol_ {
     protocol_ {
         name: name,
         span: span,
@@ -136,7 +136,7 @@ pub fn protocol_(name: ~str, span: span) -> protocol_ {
 }
 
 pub struct protocol_ {
-    name: ~str,
+    name: @str,
     span: span,
     states: @mut ~[state],
 
@@ -181,7 +181,7 @@ impl protocol_ {
 
 impl protocol_ {
     pub fn add_state_poly(@mut self,
-                          name: ~str,
+                          name: @str,
                           ident: ast::ident,
                           dir: direction,
                           generics: ast::Generics)
@@ -208,7 +208,7 @@ impl protocol_ {
 pub trait visitor<Tproto, Tstate, Tmessage> {
     fn visit_proto(&self, proto: protocol, st: &[Tstate]) -> Tproto;
     fn visit_state(&self, state: state, m: &[Tmessage]) -> Tstate;
-    fn visit_message(&self, name: ~str, spane: span, tys: &[@ast::Ty],
+    fn visit_message(&self, name: @str, spane: span, tys: &[@ast::Ty],
                      this: state, next: Option<next_state>) -> Tmessage;
 }
 

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -43,8 +43,6 @@ pub mod rt {
     pub use parse::new_parser_from_tts;
     pub use codemap::{BytePos, span, dummy_spanned};
 
-    use print::pprust::{item_to_str, ty_to_str};
-
     pub trait ToTokens {
         pub fn to_tokens(&self, _cx: @ExtCtxt) -> ~[token_tree];
     }
@@ -71,132 +69,132 @@ pub mod rt {
 
     pub trait ToSource {
         // Takes a thing and generates a string containing rust code for it.
-        pub fn to_source(&self) -> ~str;
+        pub fn to_source(&self) -> @str;
     }
 
     impl ToSource for ast::ident {
-        fn to_source(&self) -> ~str {
-            copy *ident_to_str(self)
+        fn to_source(&self) -> @str {
+            ident_to_str(self)
         }
     }
 
     impl ToSource for @ast::item {
-        fn to_source(&self) -> ~str {
-            item_to_str(*self, get_ident_interner())
+        fn to_source(&self) -> @str {
+            pprust::item_to_str(*self, get_ident_interner()).to_managed()
         }
     }
 
     impl<'self> ToSource for &'self [@ast::item] {
-        fn to_source(&self) -> ~str {
-            self.map(|i| i.to_source()).connect("\n\n")
+        fn to_source(&self) -> @str {
+            self.map(|i| i.to_source()).connect("\n\n").to_managed()
         }
     }
 
     impl ToSource for @ast::Ty {
-        fn to_source(&self) -> ~str {
-            ty_to_str(*self, get_ident_interner())
+        fn to_source(&self) -> @str {
+            pprust::ty_to_str(*self, get_ident_interner()).to_managed()
         }
     }
 
     impl<'self> ToSource for &'self [@ast::Ty] {
-        fn to_source(&self) -> ~str {
-            self.map(|i| i.to_source()).connect(", ")
+        fn to_source(&self) -> @str {
+            self.map(|i| i.to_source()).connect(", ").to_managed()
         }
     }
 
     impl ToSource for Generics {
-        fn to_source(&self) -> ~str {
-            pprust::generics_to_str(self, get_ident_interner())
+        fn to_source(&self) -> @str {
+            pprust::generics_to_str(self, get_ident_interner()).to_managed()
         }
     }
 
     impl ToSource for @ast::expr {
-        fn to_source(&self) -> ~str {
-            pprust::expr_to_str(*self, get_ident_interner())
+        fn to_source(&self) -> @str {
+            pprust::expr_to_str(*self, get_ident_interner()).to_managed()
         }
     }
 
     impl ToSource for ast::blk {
-        fn to_source(&self) -> ~str {
-            pprust::block_to_str(self, get_ident_interner())
+        fn to_source(&self) -> @str {
+            pprust::block_to_str(self, get_ident_interner()).to_managed()
         }
     }
 
     impl<'self> ToSource for &'self str {
-        fn to_source(&self) -> ~str {
-            let lit = dummy_spanned(ast::lit_str(@self.to_owned()));
-            pprust::lit_to_str(@lit)
+        fn to_source(&self) -> @str {
+            let lit = dummy_spanned(ast::lit_str(self.to_managed()));
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
     impl ToSource for int {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> @str {
             let lit = dummy_spanned(ast::lit_int(*self as i64, ast::ty_i));
-            pprust::lit_to_str(@lit)
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
     impl ToSource for i8 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> @str {
             let lit = dummy_spanned(ast::lit_int(*self as i64, ast::ty_i8));
-            pprust::lit_to_str(@lit)
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
     impl ToSource for i16 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> @str {
             let lit = dummy_spanned(ast::lit_int(*self as i64, ast::ty_i16));
-            pprust::lit_to_str(@lit)
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
 
     impl ToSource for i32 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> @str {
             let lit = dummy_spanned(ast::lit_int(*self as i64, ast::ty_i32));
-            pprust::lit_to_str(@lit)
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
     impl ToSource for i64 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> @str {
             let lit = dummy_spanned(ast::lit_int(*self as i64, ast::ty_i64));
-            pprust::lit_to_str(@lit)
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
     impl ToSource for uint {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> @str {
             let lit = dummy_spanned(ast::lit_uint(*self as u64, ast::ty_u));
-            pprust::lit_to_str(@lit)
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
     impl ToSource for u8 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> @str {
             let lit = dummy_spanned(ast::lit_uint(*self as u64, ast::ty_u8));
-            pprust::lit_to_str(@lit)
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
     impl ToSource for u16 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> @str {
             let lit = dummy_spanned(ast::lit_uint(*self as u64, ast::ty_u16));
-            pprust::lit_to_str(@lit)
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
     impl ToSource for u32 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> @str {
             let lit = dummy_spanned(ast::lit_uint(*self as u64, ast::ty_u32));
-            pprust::lit_to_str(@lit)
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
     impl ToSource for u64 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> @str {
             let lit = dummy_spanned(ast::lit_uint(*self as u64, ast::ty_u64));
-            pprust::lit_to_str(@lit)
+            pprust::lit_to_str(@lit).to_managed()
         }
     }
 
@@ -317,18 +315,18 @@ pub mod rt {
     }
 
     pub trait ExtParseUtils {
-        fn parse_item(&self, s: ~str) -> @ast::item;
-        fn parse_expr(&self, s: ~str) -> @ast::expr;
-        fn parse_stmt(&self, s: ~str) -> @ast::stmt;
-        fn parse_tts(&self, s: ~str) -> ~[ast::token_tree];
+        fn parse_item(&self, s: @str) -> @ast::item;
+        fn parse_expr(&self, s: @str) -> @ast::expr;
+        fn parse_stmt(&self, s: @str) -> @ast::stmt;
+        fn parse_tts(&self, s: @str) -> ~[ast::token_tree];
     }
 
     impl ExtParseUtils for ExtCtxt {
 
-        fn parse_item(&self, s: ~str) -> @ast::item {
+        fn parse_item(&self, s: @str) -> @ast::item {
             let res = parse::parse_item_from_source_str(
-                ~"<quote expansion>",
-                @(copy s),
+                @"<quote expansion>",
+                s,
                 self.cfg(),
                 ~[],
                 self.parse_sess());
@@ -341,27 +339,27 @@ pub mod rt {
             }
         }
 
-        fn parse_stmt(&self, s: ~str) -> @ast::stmt {
+        fn parse_stmt(&self, s: @str) -> @ast::stmt {
             parse::parse_stmt_from_source_str(
-                ~"<quote expansion>",
-                @(copy s),
+                @"<quote expansion>",
+                s,
                 self.cfg(),
                 ~[],
                 self.parse_sess())
         }
 
-        fn parse_expr(&self, s: ~str) -> @ast::expr {
+        fn parse_expr(&self, s: @str) -> @ast::expr {
             parse::parse_expr_from_source_str(
-                ~"<quote expansion>",
-                @(copy s),
+                @"<quote expansion>",
+                s,
                 self.cfg(),
                 self.parse_sess())
         }
 
-        fn parse_tts(&self, s: ~str) -> ~[ast::token_tree] {
+        fn parse_tts(&self, s: @str) -> ~[ast::token_tree] {
             parse::parse_tts_from_source_str(
-                ~"<quote expansion>",
-                @(copy s),
+                @"<quote expansion>",
+                s,
                 self.cfg(),
                 self.parse_sess())
         }

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -205,7 +205,7 @@ pub fn nameize(p_s: @mut ParseSess, ms: &[matcher], res: &[@named_match])
           } => {
             if ret_val.contains_key(bind_name) {
                 p_s.span_diagnostic.span_fatal(sp, ~"Duplicated bind name: "+
-                                               *ident_to_str(bind_name))
+                                               ident_to_str(bind_name))
             }
             ret_val.insert(*bind_name, res[idx]);
           }
@@ -373,8 +373,8 @@ pub fn parse(
                 let nts = bb_eis.map(|ei| {
                     match ei.elts[ei.idx].node {
                       match_nonterminal(ref bind,ref name,_) => {
-                        fmt!("%s ('%s')", *ident_to_str(name),
-                             *ident_to_str(bind))
+                        fmt!("%s ('%s')", ident_to_str(name),
+                             ident_to_str(bind))
                       }
                       _ => fail!()
                     } }).connect(" or ");
@@ -398,7 +398,7 @@ pub fn parse(
                 match ei.elts[ei.idx].node {
                   match_nonterminal(_, ref name, idx) => {
                     ei.matches[idx].push(@matched_nonterminal(
-                        parse_nt(&rust_parser, *ident_to_str(name))));
+                        parse_nt(&rust_parser, ident_to_str(name))));
                     ei.idx += 1u;
                   }
                   _ => fail!()

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -148,7 +148,7 @@ pub fn add_new_extension(cx: @ExtCtxt,
         |cx, sp, arg| generic_extension(cx, sp, name, arg, *lhses, *rhses);
 
     return MRDef(MacroDef{
-        name: copy *ident_to_str(&name),
+        name: ident_to_str(&name),
         ext: NormalTT(base::SyntaxExpanderTT{expander: exp, span: Some(sp)})
     });
 }

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -121,7 +121,7 @@ fn lookup_cur_matched(r: &mut TtReader, name: ident) -> @named_match {
         Some(s) => lookup_cur_matched_by_matched(r, s),
         None => {
             r.sp_diag.span_fatal(r.cur_span, fmt!("unknown macro variable `%s`",
-                                                  *ident_to_str(&name)));
+                                                  ident_to_str(&name)));
         }
     }
 }
@@ -139,8 +139,8 @@ fn lockstep_iter_size(t: &token_tree, r: &mut TtReader) -> lis {
             lis_contradiction(_) => copy rhs,
             lis_constraint(r_len, _) if l_len == r_len => copy lhs,
             lis_constraint(r_len, ref r_id) => {
-                let l_n = copy *ident_to_str(l_id);
-                let r_n = copy *ident_to_str(r_id);
+                let l_n = ident_to_str(l_id);
+                let r_n = ident_to_str(r_id);
                 lis_contradiction(fmt!("Inconsistent lockstep iteration: \
                                        '%s' has %u items, but '%s' has %u",
                                         l_n, l_len, r_n, r_len))
@@ -290,7 +290,7 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
                 r.sp_diag.span_fatal(
                     copy r.cur_span, /* blame the macro writer */
                     fmt!("variable '%s' is still repeating at this depth",
-                         *ident_to_str(&ident)));
+                         ident_to_str(&ident)));
               }
             }
           }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -990,7 +990,7 @@ mod test {
     // make sure idents get transformed everywhere
     #[test] fn ident_transformation () {
         let zz_fold = fun_to_ident_folder(to_zz());
-        let ast = string_to_crate(@~"#[a] mod b {fn c (d : e, f : g) {h!(i,j,k);l;m}}");
+        let ast = string_to_crate(@"#[a] mod b {fn c (d : e, f : g) {h!(i,j,k);l;m}}");
         assert_pred!(matches_codepattern,
                      "matches_codepattern",
                      pprust::to_str(zz_fold.fold_crate(ast),fake_print_crate,
@@ -1001,7 +1001,7 @@ mod test {
     // even inside macro defs....
     #[test] fn ident_transformation_in_defs () {
         let zz_fold = fun_to_ident_folder(to_zz());
-        let ast = string_to_crate(@~"macro_rules! a {(b $c:expr $(d $e:token)f+
+        let ast = string_to_crate(@"macro_rules! a {(b $c:expr $(d $e:token)f+
 => (g $(d $d $e)+))} ");
         assert_pred!(matches_codepattern,
                      "matches_codepattern",

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -46,7 +46,7 @@ impl parser_attr for Parser {
               }
               token::DOC_COMMENT(s) => {
                 let attr = ::attr::mk_sugared_doc_attr(
-                    copy *self.id_to_str(s),
+                    self.id_to_str(s),
                     self.span.lo,
                     self.span.hi
                 );
@@ -119,7 +119,7 @@ impl parser_attr for Parser {
               }
               token::DOC_COMMENT(s) => {
                 let attr = ::attr::mk_sugared_doc_attr(
-                    copy *self.id_to_str(s),
+                    self.id_to_str(s),
                     self.span.lo,
                     self.span.hi
                 );

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -320,10 +320,10 @@ pub struct lit {
 // probably not a good thing.
 pub fn gather_comments_and_literals(span_diagnostic:
                                     @diagnostic::span_handler,
-                                    path: ~str,
+                                    path: @str,
                                     srdr: @io::Reader)
                                  -> (~[cmnt], ~[lit]) {
-    let src = @str::from_bytes(srdr.read_whole_stream());
+    let src = str::from_bytes(srdr.read_whole_stream()).to_managed();
     let cm = CodeMap::new();
     let filemap = cm.new_filemap(path, src);
     let rdr = lexer::new_low_level_string_reader(span_diagnostic, filemap);

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -158,7 +158,7 @@ impl Parser {
             self.fatal(
                 fmt!(
                     "expected `%s`, found `%s`",
-                    *self.id_to_str(kw.to_ident()),
+                    self.id_to_str(kw.to_ident()),
                     self.this_token_to_str()
                 )
             );

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -40,7 +40,7 @@ pub struct TokenAndSpan {tok: token::Token, sp: span}
 
 pub struct StringReader {
     span_diagnostic: @span_handler,
-    src: @~str,
+    src: @str,
     // The absolute offset within the codemap of the next character to read
     pos: BytePos,
     // The absolute offset within the codemap of the last character read(curr)
@@ -176,7 +176,7 @@ pub fn with_str_from<T>(rdr: @mut StringReader, start: BytePos, f: &fn(s: &str) 
 pub fn bump(rdr: &mut StringReader) {
     rdr.last_pos = rdr.pos;
     let current_byte_offset = byte_offset(rdr, rdr.pos).to_uint();
-    if current_byte_offset < (*rdr.src).len() {
+    if current_byte_offset < (rdr.src).len() {
         assert!(rdr.curr != -1 as char);
         let last_char = rdr.curr;
         let next = rdr.src.char_range_at(current_byte_offset);
@@ -202,7 +202,7 @@ pub fn is_eof(rdr: @mut StringReader) -> bool {
 }
 pub fn nextch(rdr: @mut StringReader) -> char {
     let offset = byte_offset(rdr, rdr.pos).to_uint();
-    if offset < (*rdr.src).len() {
+    if offset < (rdr.src).len() {
         return rdr.src.char_at(offset);
     } else { return -1 as char; }
 }
@@ -801,9 +801,9 @@ mod test {
     }
 
     // open a string reader for the given string
-    fn setup(teststr: ~str) -> Env {
+    fn setup(teststr: @str) -> Env {
         let cm = CodeMap::new();
-        let fm = cm.new_filemap(~"zebra.rs", @teststr);
+        let fm = cm.new_filemap(@"zebra.rs", teststr);
         let span_handler =
             diagnostic::mk_span_handler(diagnostic::mk_handler(None),@cm);
         Env {
@@ -813,7 +813,7 @@ mod test {
 
     #[test] fn t1 () {
         let Env {string_reader} =
-            setup(~"/* my source file */ \
+            setup(@"/* my source file */ \
                     fn main() { io::println(~\"zebra\"); }\n");
         let id = str_to_ident("fn");
         let tok1 = string_reader.next_token();
@@ -849,14 +849,14 @@ mod test {
     }
 
     #[test] fn doublecolonparsing () {
-        let env = setup (~"a b");
+        let env = setup (@"a b");
         check_tokenization (env,
                            ~[mk_ident("a",false),
                              mk_ident("b",false)]);
     }
 
     #[test] fn dcparsing_2 () {
-        let env = setup (~"a::b");
+        let env = setup (@"a::b");
         check_tokenization (env,
                            ~[mk_ident("a",true),
                              token::MOD_SEP,
@@ -864,7 +864,7 @@ mod test {
     }
 
     #[test] fn dcparsing_3 () {
-        let env = setup (~"a ::b");
+        let env = setup (@"a ::b");
         check_tokenization (env,
                            ~[mk_ident("a",false),
                              token::MOD_SEP,
@@ -872,7 +872,7 @@ mod test {
     }
 
     #[test] fn dcparsing_4 () {
-        let env = setup (~"a:: b");
+        let env = setup (@"a:: b");
         check_tokenization (env,
                            ~[mk_ident("a",true),
                              token::MOD_SEP,
@@ -880,28 +880,28 @@ mod test {
     }
 
     #[test] fn character_a() {
-        let env = setup(~"'a'");
+        let env = setup(@"'a'");
         let TokenAndSpan {tok, sp: _} =
             env.string_reader.next_token();
         assert_eq!(tok,token::LIT_INT('a' as i64, ast::ty_char));
     }
 
     #[test] fn character_space() {
-        let env = setup(~"' '");
+        let env = setup(@"' '");
         let TokenAndSpan {tok, sp: _} =
             env.string_reader.next_token();
         assert_eq!(tok, token::LIT_INT(' ' as i64, ast::ty_char));
     }
 
     #[test] fn character_escaped() {
-        let env = setup(~"'\n'");
+        let env = setup(@"'\n'");
         let TokenAndSpan {tok, sp: _} =
             env.string_reader.next_token();
         assert_eq!(tok, token::LIT_INT('\n' as i64, ast::ty_char));
     }
 
     #[test] fn lifetime_name() {
-        let env = setup(~"'abc");
+        let env = setup(@"'abc");
         let TokenAndSpan {tok, sp: _} =
             env.string_reader.next_token();
         let id = token::str_to_ident("abc");

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -82,38 +82,38 @@ pub fn parse_crate_from_file(
 }
 
 pub fn parse_crate_from_source_str(
-    name: ~str,
-    source: @~str,
+    name: @str,
+    source: @str,
     cfg: ast::crate_cfg,
     sess: @mut ParseSess
 ) -> @ast::crate {
     let p = new_parser_from_source_str(
         sess,
         /*bad*/ copy cfg,
-        /*bad*/ copy name,
+        name,
         source
     );
     maybe_aborted(p.parse_crate_mod(),p)
 }
 
 pub fn parse_expr_from_source_str(
-    name: ~str,
-    source: @~str,
+    name: @str,
+    source: @str,
     cfg: ast::crate_cfg,
     sess: @mut ParseSess
 ) -> @ast::expr {
     let p = new_parser_from_source_str(
         sess,
         cfg,
-        /*bad*/ copy name,
+        name,
         source
     );
     maybe_aborted(p.parse_expr(), p)
 }
 
 pub fn parse_item_from_source_str(
-    name: ~str,
-    source: @~str,
+    name: @str,
+    source: @str,
     cfg: ast::crate_cfg,
     attrs: ~[ast::attribute],
     sess: @mut ParseSess
@@ -121,30 +121,30 @@ pub fn parse_item_from_source_str(
     let p = new_parser_from_source_str(
         sess,
         cfg,
-        /*bad*/ copy name,
+        name,
         source
     );
     maybe_aborted(p.parse_item(attrs),p)
 }
 
 pub fn parse_meta_from_source_str(
-    name: ~str,
-    source: @~str,
+    name: @str,
+    source: @str,
     cfg: ast::crate_cfg,
     sess: @mut ParseSess
 ) -> @ast::meta_item {
     let p = new_parser_from_source_str(
         sess,
         cfg,
-        /*bad*/ copy name,
+        name,
         source
     );
     maybe_aborted(p.parse_meta_item(),p)
 }
 
 pub fn parse_stmt_from_source_str(
-    name: ~str,
-    source: @~str,
+    name: @str,
+    source: @str,
     cfg: ast::crate_cfg,
     attrs: ~[ast::attribute],
     sess: @mut ParseSess
@@ -152,22 +152,22 @@ pub fn parse_stmt_from_source_str(
     let p = new_parser_from_source_str(
         sess,
         cfg,
-        /*bad*/ copy name,
+        name,
         source
     );
     maybe_aborted(p.parse_stmt(attrs),p)
 }
 
 pub fn parse_tts_from_source_str(
-    name: ~str,
-    source: @~str,
+    name: @str,
+    source: @str,
     cfg: ast::crate_cfg,
     sess: @mut ParseSess
 ) -> ~[ast::token_tree] {
     let p = new_parser_from_source_str(
         sess,
         cfg,
-        /*bad*/ copy name,
+        name,
         source
     );
     *p.quote_depth += 1u;
@@ -182,8 +182,8 @@ pub fn parse_tts_from_source_str(
 // result.
 pub fn parse_from_source_str<T>(
     f: &fn(&Parser) -> T,
-    name: ~str, ss: codemap::FileSubstr,
-    source: @~str,
+    name: @str, ss: codemap::FileSubstr,
+    source: @str,
     cfg: ast::crate_cfg,
     sess: @mut ParseSess
 ) -> T {
@@ -213,8 +213,8 @@ pub fn next_node_id(sess: @mut ParseSess) -> node_id {
 // Create a new parser from a source string
 pub fn new_parser_from_source_str(sess: @mut ParseSess,
                                   cfg: ast::crate_cfg,
-                                  name: ~str,
-                                  source: @~str)
+                                  name: @str,
+                                  source: @str)
                                -> Parser {
     filemap_to_parser(sess,string_to_filemap(sess,source,name),cfg)
 }
@@ -223,9 +223,9 @@ pub fn new_parser_from_source_str(sess: @mut ParseSess,
 // is specified as a substring of another file.
 pub fn new_parser_from_source_substr(sess: @mut ParseSess,
                                   cfg: ast::crate_cfg,
-                                  name: ~str,
+                                  name: @str,
                                   ss: codemap::FileSubstr,
-                                  source: @~str)
+                                  source: @str)
                                -> Parser {
     filemap_to_parser(sess,substring_to_filemap(sess,source,name,ss),cfg)
 }
@@ -275,7 +275,7 @@ pub fn new_parser_from_tts(sess: @mut ParseSess,
 pub fn file_to_filemap(sess: @mut ParseSess, path: &Path, spanopt: Option<span>)
     -> @FileMap {
     match io::read_whole_file_str(path) {
-        Ok(src) => string_to_filemap(sess, @src, path.to_str()),
+        Ok(src) => string_to_filemap(sess, src.to_managed(), path.to_str().to_managed()),
         Err(e) => {
             match spanopt {
                 Some(span) => sess.span_diagnostic.span_fatal(span, e),
@@ -287,14 +287,14 @@ pub fn file_to_filemap(sess: @mut ParseSess, path: &Path, spanopt: Option<span>)
 
 // given a session and a string, add the string to
 // the session's codemap and return the new filemap
-pub fn string_to_filemap(sess: @mut ParseSess, source: @~str, path: ~str)
+pub fn string_to_filemap(sess: @mut ParseSess, source: @str, path: @str)
     -> @FileMap {
     sess.cm.new_filemap(path, source)
 }
 
 // given a session and a string and a path and a FileSubStr, add
 // the string to the CodeMap and return the new FileMap
-pub fn substring_to_filemap(sess: @mut ParseSess, source: @~str, path: ~str,
+pub fn substring_to_filemap(sess: @mut ParseSess, source: @str, path: @str,
                            filesubstr: FileSubstr) -> @FileMap {
     sess.cm.new_filemap_w_substr(path,filesubstr,source)
 }
@@ -349,7 +349,7 @@ mod test {
     use util::parser_testing::{string_to_stmt, strs_to_idents};
 
     // map a string to tts, return the tt without its parsesess
-    fn string_to_tts_only(source_str : @~str) -> ~[ast::token_tree] {
+    fn string_to_tts_only(source_str : @str) -> ~[ast::token_tree] {
         let (tts,_ps) = string_to_tts_and_sess(source_str);
         tts
     }
@@ -368,7 +368,7 @@ mod test {
     }
 
     #[test] fn path_exprs_1 () {
-        assert_eq!(string_to_expr(@~"a"),
+        assert_eq!(string_to_expr(@"a"),
                    @ast::expr{id:1,
                               node:ast::expr_path(@ast::Path {span:sp(0,1),
                                                               global:false,
@@ -379,7 +379,7 @@ mod test {
     }
 
     #[test] fn path_exprs_2 () {
-        assert_eq!(string_to_expr(@~"::a::b"),
+        assert_eq!(string_to_expr(@"::a::b"),
                    @ast::expr{id:1,
                                node:ast::expr_path(
                                    @ast::Path {span:sp(0,6),
@@ -394,11 +394,11 @@ mod test {
     // marked as `#[should_fail]`.
     /*#[should_fail]
     #[test] fn bad_path_expr_1() {
-        string_to_expr(@~"::abc::def::return");
+        string_to_expr(@"::abc::def::return");
     }*/
 
     #[test] fn string_to_tts_1 () {
-        let (tts,_ps) = string_to_tts_and_sess(@~"fn a (b : int) { b; }");
+        let (tts,_ps) = string_to_tts_and_sess(@"fn a (b : int) { b; }");
         assert_eq!(to_json_str(@tts),
                    ~"[\
                 [\"tt_tok\",null,[\"IDENT\",\"fn\",false]],\
@@ -427,7 +427,7 @@ mod test {
     }
 
     #[test] fn ret_expr() {
-        assert_eq!(string_to_expr(@~"return d"),
+        assert_eq!(string_to_expr(@"return d"),
                    @ast::expr{id:2,
                               node:ast::expr_ret(
                                   Some(@ast::expr{id:1,
@@ -443,7 +443,7 @@ mod test {
     }
 
     #[test] fn parse_stmt_1 () {
-        assert_eq!(string_to_stmt(@~"b;"),
+        assert_eq!(string_to_stmt(@"b;"),
                    @spanned{
                        node: ast::stmt_expr(@ast::expr{
                            id: 1,
@@ -465,7 +465,7 @@ mod test {
     }
 
     #[test] fn parse_ident_pat () {
-        let parser = string_to_parser(@~"b");
+        let parser = string_to_parser(@"b");
         assert_eq!(parser.parse_pat(),
                    @ast::pat{id:1, // fixme
                              node: ast::pat_ident(ast::bind_infer,
@@ -482,7 +482,7 @@ mod test {
     }
 
     #[test] fn parse_arg () {
-        let parser = string_to_parser(@~"b : int");
+        let parser = string_to_parser(@"b : int");
         assert_eq!(parser.parse_arg_general(true),
                    ast::arg{
                        is_mutbl: false,
@@ -515,7 +515,7 @@ mod test {
     #[test] fn parse_fundecl () {
         // this test depends on the intern order of "fn" and "int", and on the
         // assignment order of the node_ids.
-        assert_eq!(string_to_item(@~"fn a (b : int) { b; }"),
+        assert_eq!(string_to_item(@"fn a (b : int) { b; }"),
                   Some(
                       @ast::item{ident:str_to_ident("a"),
                             attrs:~[],
@@ -585,12 +585,12 @@ mod test {
 
     #[test] fn parse_exprs () {
         // just make sure that they parse....
-        string_to_expr(@~"3 + 4");
-        string_to_expr(@~"a::z.froob(b,@(987+3))");
+        string_to_expr(@"3 + 4");
+        string_to_expr(@"a::z.froob(b,@(987+3))");
     }
 
     #[test] fn attrs_fix_bug () {
-        string_to_item(@~"pub fn mk_file_writer(path: &Path, flags: &[FileFlag])
+        string_to_item(@"pub fn mk_file_writer(path: &Path, flags: &[FileFlag])
                    -> Result<@Writer, ~str> {
     #[cfg(windows)]
     fn wb() -> c_int {

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -259,7 +259,7 @@ impl Parser {
                                    -> bool {
         match *token {
             token::IDENT(sid, _) => {
-                str::eq_slice(*self.id_to_str(sid), ident)
+                str::eq_slice(self.id_to_str(sid), ident)
             }
             _ => false
         }

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -80,7 +80,7 @@ pub struct begin_t {
 }
 
 pub enum token {
-    STRING(@~str, int),
+    STRING(@str, int),
     BREAK(break_t),
     BEGIN(begin_t),
     END,
@@ -107,7 +107,7 @@ impl token {
 
 pub fn tok_str(t: token) -> ~str {
     match t {
-        STRING(s, len) => return fmt!("STR(%s,%d)", *s, len),
+        STRING(s, len) => return fmt!("STR(%s,%d)", s, len),
         BREAK(_) => return ~"BREAK",
         BEGIN(_) => return ~"BEGIN",
         END => return ~"END",
@@ -335,11 +335,11 @@ impl Printer {
           STRING(s, len) => {
             if self.scan_stack_empty {
                 debug!("pp STRING('%s')/print ~[%u,%u]",
-                       *s, self.left, self.right);
+                       s, self.left, self.right);
                 self.print(t, len);
             } else {
                 debug!("pp STRING('%s')/buffer ~[%u,%u]",
-                       *s, self.left, self.right);
+                       s, self.left, self.right);
                 self.advance_right();
                 self.token[self.right] = t;
                 self.size[self.right] = len;
@@ -534,11 +534,11 @@ impl Printer {
             }
           }
           STRING(s, len) => {
-            debug!("print STRING(%s)", *s);
+            debug!("print STRING(%s)", s);
             assert_eq!(L, len);
             // assert!(L <= space);
             self.space -= len;
-            self.print_str(*s);
+            self.print_str(s);
           }
           EOF => {
             // EOF should never get here.
@@ -572,15 +572,15 @@ pub fn end(p: @mut Printer) { p.pretty_print(END); }
 pub fn eof(p: @mut Printer) { p.pretty_print(EOF); }
 
 pub fn word(p: @mut Printer, wrd: &str) {
-    p.pretty_print(STRING(@/*bad*/ wrd.to_owned(), wrd.len() as int));
+    p.pretty_print(STRING(/* bad */ wrd.to_managed(), wrd.len() as int));
 }
 
 pub fn huge_word(p: @mut Printer, wrd: &str) {
-    p.pretty_print(STRING(@/*bad*/ wrd.to_owned(), size_infinity));
+    p.pretty_print(STRING(/* bad */ wrd.to_managed(), size_infinity));
 }
 
 pub fn zero_word(p: @mut Printer, wrd: &str) {
-    p.pretty_print(STRING(@/*bad*/ wrd.to_owned(), 0));
+    p.pretty_print(STRING(/* bad */ wrd.to_managed(), 0));
 }
 
 pub fn spaces(p: @mut Printer, n: uint) { break_offset(p, n, 0); }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -111,14 +111,14 @@ pub fn print_crate(cm: @CodeMap,
                    intr: @ident_interner,
                    span_diagnostic: @diagnostic::span_handler,
                    crate: @ast::crate,
-                   filename: ~str,
+                   filename: @str,
                    in: @io::Reader,
                    out: @io::Writer,
                    ann: pp_ann,
                    is_expanded: bool) {
     let (cmnts, lits) = comments::gather_comments_and_literals(
         span_diagnostic,
-        copy filename,
+        filename,
         in
     );
     let s = @ps {
@@ -860,7 +860,7 @@ pub fn print_attribute(s: @ps, attr: ast::attribute) {
     if attr.node.is_sugared_doc {
         let meta = attr::attr_meta(attr);
         let comment = attr::get_meta_item_value_str(meta).get();
-        word(s.s, *comment);
+        word(s.s, comment);
     } else {
         word(s.s, "#[");
         print_meta_item(s, attr.node.value);
@@ -1400,10 +1400,10 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
             word(s.s, "asm!");
         }
         popen(s);
-        print_string(s, *a.asm);
+        print_string(s, a.asm);
         word_space(s, ":");
         for a.outputs.each |&(co, o)| {
-            print_string(s, *co);
+            print_string(s, co);
             popen(s);
             print_expr(s, o);
             pclose(s);
@@ -1411,14 +1411,14 @@ pub fn print_expr(s: @ps, expr: @ast::expr) {
         }
         word_space(s, ":");
         for a.inputs.each |&(co, o)| {
-            print_string(s, *co);
+            print_string(s, co);
             popen(s);
             print_expr(s, o);
             pclose(s);
             word_space(s, ",");
         }
         word_space(s, ":");
-        print_string(s, *a.clobbers);
+        print_string(s, a.clobbers);
         pclose(s);
       }
       ast::expr_mac(ref m) => print_mac(s, m),
@@ -1474,7 +1474,7 @@ pub fn print_decl(s: @ps, decl: @ast::decl) {
 }
 
 pub fn print_ident(s: @ps, ident: ast::ident) {
-    word(s.s, *ident_to_str(&ident));
+    word(s.s, ident_to_str(&ident));
 }
 
 pub fn print_for_decl(s: @ps, loc: @ast::local, coll: @ast::expr) {
@@ -1776,14 +1776,14 @@ pub fn print_generics(s: @ps, generics: &ast::Generics) {
 pub fn print_meta_item(s: @ps, item: @ast::meta_item) {
     ibox(s, indent_unit);
     match item.node {
-      ast::meta_word(name) => word(s.s, *name),
+      ast::meta_word(name) => word(s.s, name),
       ast::meta_name_value(name, value) => {
-        word_space(s, *name);
+        word_space(s, name);
         word_space(s, "=");
         print_literal(s, @value);
       }
       ast::meta_list(name, ref items) => {
-        word(s.s, *name);
+        word(s.s, name);
         popen(s);
         commasep(
             s,
@@ -1995,7 +1995,7 @@ pub fn print_literal(s: @ps, lit: @ast::lit) {
       _ => ()
     }
     match lit.node {
-      ast::lit_str(st) => print_string(s, *st),
+      ast::lit_str(st) => print_string(s, st),
       ast::lit_int(ch, ast::ty_char) => {
         word(s.s, ~"'" + char::escape_default(ch as char) + "'");
       }
@@ -2023,9 +2023,9 @@ pub fn print_literal(s: @ps, lit: @ast::lit) {
         }
       }
       ast::lit_float(f, t) => {
-        word(s.s, *f + ast_util::float_ty_to_str(t));
+        word(s.s, f.to_owned() + ast_util::float_ty_to_str(t));
       }
-      ast::lit_float_unsuffixed(f) => word(s.s, *f),
+      ast::lit_float_unsuffixed(f) => word(s.s, f),
       ast::lit_nil => word(s.s, "()"),
       ast::lit_bool(val) => {
         if val { word(s.s, "true"); } else { word(s.s, "false"); }
@@ -2101,7 +2101,7 @@ pub fn print_comment(s: @ps, cmnt: &comments::cmnt) {
         // We need to do at least one, possibly two hardbreaks.
         let is_semi =
             match s.s.last_token() {
-              pp::STRING(s, _) => *s == ~";",
+              pp::STRING(s, _) => ";" == s,
               _ => false
             };
         if is_semi || is_begin(s) || is_end(s) { hardbreak(s.s); }

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -19,7 +19,6 @@ use core::prelude::*;
 
 use core::cmp::Equiv;
 use core::hashmap::HashMap;
-use syntax::parse::token::StringRef;
 
 pub struct Interner<T> {
     priv map: @mut HashMap<T, uint>,
@@ -80,8 +79,8 @@ impl<T:Eq + IterBytes + Hash + Const + Copy> Interner<T> {
 // A StrInterner differs from Interner<String> in that it accepts
 // borrowed pointers rather than @ ones, resulting in less allocation.
 pub struct StrInterner {
-    priv map: @mut HashMap<@~str, uint>,
-    priv vect: @mut ~[@~str],
+    priv map: @mut HashMap<@str, uint>,
+    priv vect: @mut ~[@str],
 }
 
 // when traits can extend traits, we should extend index<uint,T> to get []
@@ -95,37 +94,38 @@ impl StrInterner {
 
     pub fn prefill(init: &[&str]) -> StrInterner {
         let rv = StrInterner::new();
-        for init.each() |v| { rv.intern(*v); }
+        for init.each |&v| { rv.intern(v); }
         rv
     }
 
     pub fn intern(&self, val: &str) -> uint {
-        match self.map.find_equiv(&StringRef(val)) {
+        match self.map.find_equiv(&val) {
             Some(&idx) => return idx,
             None => (),
         }
 
         let new_idx = self.len();
-        self.map.insert(@val.to_owned(), new_idx);
-        self.vect.push(@val.to_owned());
+        let val = val.to_managed();
+        self.map.insert(val, new_idx);
+        self.vect.push(val);
         new_idx
     }
 
     pub fn gensym(&self, val: &str) -> uint {
         let new_idx = self.len();
         // leave out of .map to avoid colliding
-        self.vect.push(@val.to_owned());
+        self.vect.push(val.to_managed());
         new_idx
     }
 
     // this isn't "pure" in the traditional sense, because it can go from
     // failing to returning a value as items are interned. But for typestate,
     // where we first check a pred and then rely on it, ceasing to fail is ok.
-    pub fn get(&self, idx: uint) -> @~str { self.vect[idx] }
+    pub fn get(&self, idx: uint) -> @str { self.vect[idx] }
 
     pub fn len(&self) -> uint { let vect = &*self.vect; vect.len() }
 
-    pub fn find_equiv<Q:Hash + IterBytes + Equiv<@~str>>(&self, val: &Q)
+    pub fn find_equiv<Q:Hash + IterBytes + Equiv<@str>>(&self, val: &Q)
                                                          -> Option<uint> {
         match self.map.find_equiv(val) {
             Some(v) => Some(*v),
@@ -140,41 +140,41 @@ mod tests {
     #[test]
     #[should_fail]
     fn i1 () {
-        let i : Interner<@~str> = Interner::new();
+        let i : Interner<@str> = Interner::new();
         i.get(13);
     }
 
     #[test]
     fn i2 () {
-        let i : Interner<@~str> = Interner::new();
+        let i : Interner<@str> = Interner::new();
         // first one is zero:
-        assert_eq!(i.intern (@~"dog"), 0);
+        assert_eq!(i.intern (@"dog"), 0);
         // re-use gets the same entry:
-        assert_eq!(i.intern (@~"dog"), 0);
+        assert_eq!(i.intern (@"dog"), 0);
         // different string gets a different #:
-        assert_eq!(i.intern (@~"cat"), 1);
-        assert_eq!(i.intern (@~"cat"), 1);
+        assert_eq!(i.intern (@"cat"), 1);
+        assert_eq!(i.intern (@"cat"), 1);
         // dog is still at zero
-        assert_eq!(i.intern (@~"dog"), 0);
+        assert_eq!(i.intern (@"dog"), 0);
         // gensym gets 3
-        assert_eq!(i.gensym (@~"zebra" ), 2);
+        assert_eq!(i.gensym (@"zebra" ), 2);
         // gensym of same string gets new number :
-        assert_eq!(i.gensym (@~"zebra" ), 3);
+        assert_eq!(i.gensym (@"zebra" ), 3);
         // gensym of *existing* string gets new number:
-        assert_eq!(i.gensym (@~"dog"), 4);
-        assert_eq!(i.get(0), @~"dog");
-        assert_eq!(i.get(1), @~"cat");
-        assert_eq!(i.get(2), @~"zebra");
-        assert_eq!(i.get(3), @~"zebra");
-        assert_eq!(i.get(4), @~"dog");
+        assert_eq!(i.gensym (@"dog"), 4);
+        assert_eq!(i.get(0), @"dog");
+        assert_eq!(i.get(1), @"cat");
+        assert_eq!(i.get(2), @"zebra");
+        assert_eq!(i.get(3), @"zebra");
+        assert_eq!(i.get(4), @"dog");
     }
 
     #[test]
     fn i3 () {
-        let i : Interner<@~str> = Interner::prefill([@~"Alan",@~"Bob",@~"Carol"]);
-        assert_eq!(i.get(0), @~"Alan");
-        assert_eq!(i.get(1), @~"Bob");
-        assert_eq!(i.get(2), @~"Carol");
-        assert_eq!(i.intern(@~"Bob"), 1);
+        let i : Interner<@str> = Interner::prefill([@"Alan",@"Bob",@"Carol"]);
+        assert_eq!(i.get(0), @"Alan");
+        assert_eq!(i.get(1), @"Bob");
+        assert_eq!(i.get(2), @"Carol");
+        assert_eq!(i.intern(@"Bob"), 1);
     }
 }

--- a/src/libsyntax/util/parser_testing.rs
+++ b/src/libsyntax/util/parser_testing.rs
@@ -18,50 +18,50 @@ use parse::token;
 
 // map a string to tts, using a made-up filename: return both the token_trees
 // and the ParseSess
-pub fn string_to_tts_and_sess (source_str : @~str) -> (~[ast::token_tree],@mut ParseSess) {
+pub fn string_to_tts_and_sess (source_str : @str) -> (~[ast::token_tree],@mut ParseSess) {
     let ps = new_parse_sess(None);
-    (filemap_to_tts(ps,string_to_filemap(ps,source_str,~"bogofile")),ps)
+    (filemap_to_tts(ps,string_to_filemap(ps,source_str,@"bogofile")),ps)
 }
 
-pub fn string_to_parser_and_sess(source_str: @~str) -> (Parser,@mut ParseSess) {
+pub fn string_to_parser_and_sess(source_str: @str) -> (Parser,@mut ParseSess) {
     let ps = new_parse_sess(None);
-    (new_parser_from_source_str(ps,~[],~"bogofile",source_str),ps)
+    (new_parser_from_source_str(ps,~[],@"bogofile",source_str),ps)
 }
 
 // map string to parser (via tts)
-pub fn string_to_parser(source_str: @~str) -> Parser {
+pub fn string_to_parser(source_str: @str) -> Parser {
     let (p,_) = string_to_parser_and_sess(source_str);
     p
 }
 
-pub fn string_to_crate (source_str : @~str) -> @ast::crate {
+pub fn string_to_crate (source_str : @str) -> @ast::crate {
     string_to_parser(source_str).parse_crate_mod()
 }
 
 // parse a string, return an expr
-pub fn string_to_expr (source_str : @~str) -> @ast::expr {
+pub fn string_to_expr (source_str : @str) -> @ast::expr {
     string_to_parser(source_str).parse_expr()
 }
 
 // parse a string, return an item
-pub fn string_to_item (source_str : @~str) -> Option<@ast::item> {
+pub fn string_to_item (source_str : @str) -> Option<@ast::item> {
     string_to_parser(source_str).parse_item(~[])
 }
 
 // parse a string, return an item and the ParseSess
-pub fn string_to_item_and_sess (source_str : @~str) -> (Option<@ast::item>,@mut ParseSess) {
+pub fn string_to_item_and_sess (source_str : @str) -> (Option<@ast::item>,@mut ParseSess) {
     let (p,ps) = string_to_parser_and_sess(source_str);
     (p.parse_item(~[]),ps)
 }
 
 // parse a string, return a stmt
-pub fn string_to_stmt(source_str : @~str) -> @ast::stmt {
+pub fn string_to_stmt(source_str : @str) -> @ast::stmt {
     string_to_parser(source_str).parse_stmt(~[])
 }
 
 // parse a string, return a pat. Uses "irrefutable"... which doesn't
 // (currently) affect parsing.
-pub fn string_to_pat(source_str : @~str) -> @ast::pat {
+pub fn string_to_pat(source_str : @str) -> @ast::pat {
     string_to_parser(source_str).parse_pat()
 }
 


### PR DESCRIPTION
Fixes #5048.

I'm sure this reduces memory usage, but I can't get cgroups to work properly to actually measure memory. (It doesn't appear to offer much speed improvement, but I'm fairly sure it's not slower.)

This is quite huge, so it'd be nice to get a resolution soon.
