### PR TITLE
Replaces the free-standing functions in f32, &c.

### DIFF
--- a/src/libextra/arena.rs
+++ b/src/libextra/arena.rs
@@ -49,6 +49,8 @@ use core::uint;
 use core::vec;
 use core::unstable::intrinsics;
 
+use core::num;
+
 pub mod rustrt {
     use core::libc::size_t;
     use core::sys::TypeDesc;
@@ -171,7 +173,7 @@ impl Arena {
     fn alloc_pod_grow(&mut self, n_bytes: uint, align: uint) -> *u8 {
         // Allocate a new chunk.
         let chunk_size = at_vec::capacity(self.pod_head.data);
-        let new_min_chunk_size = uint::max(n_bytes, chunk_size);
+        let new_min_chunk_size = num::max(n_bytes, chunk_size);
         self.chunks = @mut MutCons(copy self.pod_head, self.chunks);
         self.pod_head =
             chunk(uint::next_power_of_two(new_min_chunk_size + 1u), true);
@@ -215,7 +217,7 @@ impl Arena {
                          -> (*u8, *u8) {
         // Allocate a new chunk.
         let chunk_size = at_vec::capacity(self.head.data);
-        let new_min_chunk_size = uint::max(n_bytes, chunk_size);
+        let new_min_chunk_size = num::max(n_bytes, chunk_size);
         self.chunks = @mut MutCons(copy self.head, self.chunks);
         self.head =
             chunk(uint::next_power_of_two(new_min_chunk_size + 1u), false);

--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -13,6 +13,7 @@
 use core::prelude::*;
 
 use core::cmp;
+use core::num;
 use core::ops;
 use core::uint;
 use core::vec;
@@ -725,7 +726,7 @@ impl Set<uint> for BitvSet {
         }
         let nbits = self.capacity();
         if value >= nbits {
-            let newsize = uint::max(value, nbits * 2) / uint::bits + 1;
+            let newsize = num::max(value, nbits * 2) / uint::bits + 1;
             assert!(newsize > self.bitv.storage.len());
             self.bitv.storage.grow(newsize, &0);
         }
@@ -824,7 +825,7 @@ impl BitvSet {
     /// and w1/w2 are the words coming from the two vectors self, other.
     fn each_common(&self, other: &BitvSet,
                    f: &fn(uint, uint, uint) -> bool) -> bool {
-        let min = uint::min(self.bitv.storage.len(),
+        let min = num::min(self.bitv.storage.len(),
                             other.bitv.storage.len());
         self.bitv.storage.slice(0, min).eachi(|i, &w| {
             f(i * uint::bits, w, other.bitv.storage[i])
@@ -842,7 +843,7 @@ impl BitvSet {
                     f: &fn(bool, uint, uint) -> bool) -> bool {
         let len1 = self.bitv.storage.len();
         let len2 = other.bitv.storage.len();
-        let min = uint::min(len1, len2);
+        let min = num::min(len1, len2);
 
         /* only one of these loops will execute and that's the point */
         for self.bitv.storage.slice(min, len1).eachi |i, &w| {

--- a/src/libextra/net_tcp.rs
+++ b/src/libextra/net_tcp.rs
@@ -26,10 +26,10 @@ use core::io;
 use core::libc::size_t;
 use core::libc;
 use core::comm::{stream, Port, SharedChan};
+use core::num;
 use core::ptr;
 use core::result::{Result};
 use core::result;
-use core::uint;
 use core::vec;
 
 pub mod rustrt {
@@ -884,7 +884,7 @@ impl io::Reader for TcpSocketBuf {
           let needed = len - count;
             if nbuffered > 0 {
                 unsafe {
-                    let ncopy = uint::min(nbuffered, needed);
+                    let ncopy = num::min(nbuffered, needed);
                     let dst = ptr::mut_offset(
                         vec::raw::to_mut_ptr(buf), count);
                     let src = ptr::offset(

--- a/src/libextra/num/bigint.rs
+++ b/src/libextra/num/bigint.rs
@@ -22,7 +22,7 @@ use core::prelude::*;
 use core::iterator::IteratorUtil;
 use core::cmp::{Eq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater};
 use core::int;
-use core::num::{IntConvertible, Zero, One, ToStrRadix, FromStrRadix, Orderable};
+use core::num::{IntConvertible, Zero, One, ToStrRadix, FromStrRadix, Orderable, min, max};
 use core::str;
 use core::uint;
 use core::vec;
@@ -205,7 +205,7 @@ impl Unsigned for BigUint {}
 impl Add<BigUint, BigUint> for BigUint {
 
     fn add(&self, other: &BigUint) -> BigUint {
-        let new_len = uint::max(self.data.len(), other.data.len());
+        let new_len = max(self.data.len(), other.data.len());
 
         let mut carry = 0;
         let sum = do vec::from_fn(new_len) |i| {
@@ -225,7 +225,7 @@ impl Add<BigUint, BigUint> for BigUint {
 impl Sub<BigUint, BigUint> for BigUint {
 
     fn sub(&self, other: &BigUint) -> BigUint {
-        let new_len = uint::max(self.data.len(), other.data.len());
+        let new_len = max(self.data.len(), other.data.len());
 
         let mut borrow = 0;
         let diff = do vec::from_fn(new_len) |i| {
@@ -261,7 +261,7 @@ impl Mul<BigUint, BigUint> for BigUint {
         // = a1*b1 * base^2 +
         //   (a1*b1 + a0*b0 - (a1-b0)*(b1-a0)) * base +
         //   a0*b0
-        let half_len = uint::max(s_len, o_len) / 2;
+        let half_len = max(s_len, o_len) / 2;
         let (sHi, sLo) = cut_at(self,  half_len);
         let (oHi, oLo) = cut_at(other, half_len);
 
@@ -298,7 +298,7 @@ impl Mul<BigUint, BigUint> for BigUint {
 
 
         fn cut_at(a: &BigUint, n: uint) -> (BigUint, BigUint) {
-            let mid = uint::min(a.data.len(), n);
+            let mid = min(a.data.len(), n);
             return (BigUint::from_slice(vec::slice(a.data, mid,
                                                    a.data.len())),
                     BigUint::from_slice(vec::slice(a.data, 0, mid)));
@@ -482,7 +482,7 @@ impl Integer for BigUint {
 impl IntConvertible for BigUint {
 
     fn to_int(&self) -> int {
-        uint::min(self.to_uint(), int::max_value as uint) as int
+        min(self.to_uint(), int::max_value as uint) as int
     }
 
 
@@ -578,7 +578,7 @@ impl BigUint {
         let mut n: BigUint      = Zero::zero();
         let mut power: BigUint  = One::one();
         loop {
-            let start = uint::max(end, unit_len) - unit_len;
+            let start = max(end, unit_len) - unit_len;
             match uint::parse_bytes(vec::slice(buf, start, end), radix) {
                 // FIXME(#6102): Assignment operator for BigInt causes ICE
                 // Some(d) => n += BigUint::from_uint(d) * power,
@@ -1053,9 +1053,9 @@ impl IntConvertible for BigInt {
 
     fn to_int(&self) -> int {
         match self.sign {
-            Plus  => uint::min(self.to_uint(), int::max_value as uint) as int,
+            Plus  => min(self.to_uint(), int::max_value as uint) as int,
             Zero  => 0,
-            Minus => uint::min((-self).to_uint(),
+            Minus => min((-self).to_uint(),
                                (int::max_value as uint) + 1) as int
         }
     }

--- a/src/libextra/par.rs
+++ b/src/libextra/par.rs
@@ -12,9 +12,9 @@ use core::prelude::*;
 
 use core::iterator::IteratorUtil;
 use core::cast;
+use core::num;
 use core::ptr;
 use core::sys;
-use core::uint;
 use core::vec;
 use future_spawn = future::spawn;
 
@@ -46,7 +46,7 @@ fn map_slices<A:Copy + Owned,B:Copy + Owned>(
         ~[f()(0u, xs)]
     }
     else {
-        let num_tasks = uint::min(max_tasks, len / min_granularity);
+        let num_tasks = num::min(max_tasks, len / min_granularity);
 
         let items_per_task = len / num_tasks;
 
@@ -54,7 +54,7 @@ fn map_slices<A:Copy + Owned,B:Copy + Owned>(
         let mut base = 0u;
         info!("spawning tasks");
         while base < len {
-            let end = uint::min(len, base + items_per_task);
+            let end = num::min(len, base + items_per_task);
             do vec::as_imm_buf(xs) |p, _len| {
                 let f = f();
                 let base = base;

--- a/src/libextra/rope.rs
+++ b/src/libextra/rope.rs
@@ -567,6 +567,7 @@ pub mod node {
     use core::str;
     use core::uint;
     use core::vec;
+    use core::num;
 
     /// Implementation of type `rope`
     pub enum Root {
@@ -1045,7 +1046,7 @@ pub mod node {
             right: right,
             char_len: char_len(left) + char_len(right),
             byte_len: byte_len(left) + byte_len(right),
-            height: uint::max(height(left), height(right)) + 1u,
+            height: num::max(height(left), height(right)) + 1u,
         })
     }
 

--- a/src/libextra/sort.rs
+++ b/src/libextra/sort.rs
@@ -842,7 +842,7 @@ mod test_qsort {
 
         let expected = ~[1, 2, 3];
 
-        do quick_sort(names) |x, y| { int::le(*x, *y) };
+        do quick_sort(names) |x, y| { *x < *y };
 
         let immut_names = names;
 

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -14,7 +14,6 @@ use core::prelude::*;
 
 use core::iterator::*;
 use core::vec;
-use core::f64;
 use core::cmp;
 use core::num;
 use sort;
@@ -82,7 +81,7 @@ impl<'self> Stats for &'self [f64] {
     }
 
     fn std_dev(self) -> f64 {
-        f64::sqrt(self.var())
+        num::sqrt(self.var())
     }
 
     fn std_dev_pct(self) -> f64 {

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -699,8 +699,7 @@ pub mod bench {
                     n = 1_000_000_000 / self.ns_per_iter();
                 }
 
-                n = u64::max(u64::min(n+n/2, 100*last), last+1);
-                n = round_up(n);
+                n = round_up((n + n/2).clamp(&(last + 1), &(100 * last)));
                 self.bench_n(n, f);
             }
         }

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -12,9 +12,9 @@
 
 use core::prelude::*;
 
-use core::i32;
 use core::int;
 use core::io;
+use core::num;
 use core::str;
 use core::iterator::IteratorUtil;
 
@@ -251,7 +251,7 @@ impl Tm {
         } else {
             let s = self.strftime("%Y-%m-%dT%H:%M:%S");
             let sign = if self.tm_gmtoff > 0_i32 { '+' } else { '-' };
-            let mut m = i32::abs(self.tm_gmtoff) / 60_i32;
+            let mut m = num::abs(self.tm_gmtoff) / 60_i32;
             let h = m / 60_i32;
             m -= h * 60_i32;
             s + fmt!("%c%02d:%02d", sign, h as int, m as int)
@@ -834,7 +834,7 @@ priv fn do_strftime(format: &str, tm: &Tm) -> ~str {
           'Z' => copy tm.tm_zone,
           'z' => {
             let sign = if tm.tm_gmtoff > 0_i32 { '+' } else { '-' };
-            let mut m = i32::abs(tm.tm_gmtoff) / 60_i32;
+            let mut m = num::abs(tm.tm_gmtoff) / 60_i32;
             let h = m / 60_i32;
             m -= h * 60_i32;
             fmt!("%c%02d%02d", sign, h as int, m as int)

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -15,7 +15,7 @@
 use core::prelude::*;
 
 use core::iterator::*;
-use core::uint;
+use core::num;
 use core::util::{swap, replace};
 
 // This is implemented as an AA tree, which is a simplified variation of
@@ -65,7 +65,7 @@ fn lt<K: Ord + TotalOrd, V>(a: &TreeMap<K, V>,
     let mut y = b.iter();
 
     let (a_len, b_len) = (a.len(), b.len());
-    for uint::min(a_len, b_len).times {
+    for num::min(a_len, b_len).times {
         let (key_a,_) = x.next().unwrap();
         let (key_b,_) = y.next().unwrap();
         if *key_a < *key_b { return true; }

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -15,6 +15,7 @@ use metadata::cstore;
 use metadata::filesearch;
 
 use core::hashmap::HashSet;
+use core::num;
 use core::os;
 use core::uint;
 use core::util;
@@ -147,7 +148,7 @@ pub fn get_relative_to(abs1: &Path, abs2: &Path) -> Path {
     assert!(len1 > 0);
     assert!(len2 > 0);
 
-    let max_common_path = uint::min(len1, len2) - 1;
+    let max_common_path = num::min(len1, len2) - 1;
     let mut start_idx = 0;
     while start_idx < max_common_path
         && split1[start_idx] == split2[start_idx] {

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -26,11 +26,11 @@ use syntax::{ast, attr};
 
 use core::cast;
 use core::io;
+use core::num;
 use core::option;
 use core::os::consts::{macos, freebsd, linux, android, win32};
 use core::ptr;
 use core::str;
-use core::uint;
 use core::vec;
 use extra::flate;
 
@@ -215,7 +215,7 @@ fn get_metadata_section(os: os,
                     let vlen = encoder::metadata_encoding_version.len();
                     debug!("checking %u bytes of metadata-version stamp",
                            vlen);
-                    let minsz = uint::min(vlen, csz);
+                    let minsz = num::min(vlen, csz);
                     let mut version_ok = false;
                     do vec::raw::buf_as_slice(cvbuf, minsz) |buf0| {
                         version_ok = (buf0 ==

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -20,6 +20,7 @@ use middle::moves;
 use util::ppaux::ty_to_str;
 
 use core::iterator::IteratorUtil;
+use core::num;
 use core::uint;
 use core::vec;
 use extra::sort;
@@ -246,7 +247,7 @@ pub fn is_useful(cx: @MatchCheckCtxt, m: &matrix, v: &[@pat]) -> useful {
                 let max_len = do m.rev_iter().fold(0) |max_len, r| {
                   match r[0].node {
                     pat_vec(ref before, _, ref after) => {
-                      uint::max(before.len() + after.len(), max_len)
+                      num::max(before.len() + after.len(), max_len)
                     }
                     _ => max_len
                   }

--- a/src/librustc/middle/trans/cabi_arm.rs
+++ b/src/librustc/middle/trans/cabi_arm.rs
@@ -19,7 +19,7 @@ use middle::trans::common::{T_array, T_ptr, T_void};
 
 use core::iterator::IteratorUtil;
 use core::option::{Option, None, Some};
-use core::uint;
+use core::num;
 
 fn align_up_to(off: uint, a: uint) -> uint {
     return (off + a - 1u) / a * a;
@@ -44,7 +44,7 @@ fn ty_align(ty: TypeRef) -> uint {
                     1
                 } else {
                     let str_tys = struct_tys(ty);
-                    str_tys.iter().fold(1, |a, t| uint::max(a, ty_align(*t)))
+                    str_tys.iter().fold(1, |a, t| num::max(a, ty_align(*t)))
                 }
             }
             Array => {

--- a/src/librustc/middle/trans/cabi_mips.rs
+++ b/src/librustc/middle/trans/cabi_mips.rs
@@ -12,8 +12,8 @@ use core::prelude::*;
 
 use core::iterator::IteratorUtil;
 use core::libc::c_uint;
+use core::num;
 use core::ptr;
-use core::uint;
 use core::vec;
 use lib::llvm::{llvm, TypeRef, Integer, Pointer, Float, Double};
 use lib::llvm::{Struct, Array, Attribute};
@@ -57,7 +57,7 @@ fn ty_align(ty: TypeRef) -> uint {
                 1
               } else {
                 let str_tys = struct_tys(ty);
-                str_tys.iter().fold(1, |a, t| uint::max(a, ty_align(*t)))
+                str_tys.iter().fold(1, |a, t| num::max(a, ty_align(*t)))
               }
             }
             Array => {
@@ -113,7 +113,7 @@ fn classify_arg_ty(ty: TypeRef,
     let size = ty_size(ty) * 8;
     let mut align = ty_align(ty);
 
-    align = uint::min(uint::max(align, 4), 8);
+    align = align.clamp(&4, &8);
     *offset = align_up_to(*offset, align);
     *offset += align_up_to(size, align * 8) / 8;
 

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -21,6 +21,7 @@ use middle::trans::cabi::*;
 
 use core::iterator::IteratorUtil;
 use core::libc::c_uint;
+use core::num;
 use core::option;
 use core::option::Option;
 use core::uint;
@@ -82,7 +83,7 @@ fn classify_ty(ty: TypeRef) -> ~[x86_64_reg_class] {
                     1
                   } else {
                     let str_tys = struct_tys(ty);
-                    str_tys.iter().fold(1, |a, t| uint::max(a, ty_align(*t)))
+                    str_tys.iter().fold(1, |a, t| num::max(a, ty_align(*t)))
                   }
                 }
                 Array => {

--- a/src/librustdoc/unindent_pass.rs
+++ b/src/librustdoc/unindent_pass.rs
@@ -22,6 +22,7 @@ middle of a line, and each of the following lines is indented.
 use core::prelude::*;
 
 use core::iterator::IteratorUtil;
+use core::num;
 use core::str;
 use core::uint;
 use pass::Pass;
@@ -73,7 +74,7 @@ fn unindent(s: &str) -> ~str {
                     false
                 }
             };
-            uint::min(min_indent, spaces)
+            num::min(min_indent, spaces)
         }
     };
 

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -18,6 +18,7 @@
 use container::{Container, Mutable, Map, Set};
 use cmp::{Eq, Equiv};
 use hash::Hash;
+use num;
 use old_iter::BaseIter;
 use old_iter;
 use option::{None, Option, Some};
@@ -74,7 +75,7 @@ pub fn linear_map_with_capacity<K:Eq + Hash,V>(
 fn linear_map_with_capacity_and_keys<K:Eq + Hash,V>(
     k0: u64, k1: u64,
     initial_capacity: uint) -> HashMap<K, V> {
-    let cap = uint::max(INITIAL_CAPACITY, initial_capacity);
+    let cap = num::max(INITIAL_CAPACITY, initial_capacity);
     HashMap {
         k0: k0, k1: k1,
         resize_at: resize_at(cap),

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -56,6 +56,7 @@ use libc::consts::os::posix88::*;
 use os;
 use cast;
 use path::Path;
+use num;
 use ops::Drop;
 use old_iter::{BaseIter, CopyableIter};
 use ptr;
@@ -1049,7 +1050,7 @@ pub struct BytesReader<'self> {
 
 impl<'self> Reader for BytesReader<'self> {
     fn read(&self, bytes: &mut [u8], len: uint) -> uint {
-        let count = uint::min(len, self.bytes.len() - *self.pos);
+        let count = num::min(len, self.bytes.len() - *self.pos);
 
         let view = vec::slice(self.bytes, *self.pos, self.bytes.len());
         vec::bytes::copy_memory(bytes, view, count);
@@ -1650,7 +1651,7 @@ impl Writer for BytesWriter {
         let v_len = v.len();
 
         let bytes = &mut *self.bytes;
-        let count = uint::max(bytes.len(), *self.pos + v_len);
+        let count = num::max(bytes.len(), *self.pos + v_len);
         vec::reserve(bytes, count);
 
         unsafe {

--- a/src/libstd/num/float.rs
+++ b/src/libstd/num/float.rs
@@ -22,21 +22,11 @@
 
 #[allow(missing_doc)];
 
-use f64;
-use libc::c_int;
 use num::{Zero, One, strconv};
 use num::FPCategory;
 use num;
 use prelude::*;
 use to_str;
-
-pub use f64::{add, sub, mul, div, rem, lt, le, eq, ne, ge, gt};
-pub use f64::{acos, asin, atan2, cbrt, ceil, copysign, cosh, floor};
-pub use f64::{erf, erfc, exp, exp_m1, exp2, abs_sub};
-pub use f64::{mul_add, fmax, fmin, next_after, frexp, hypot, ldexp};
-pub use f64::{lgamma, ln, log_radix, ln_1p, log10, log2, ilog_radix};
-pub use f64::{modf, pow, powi, round, sinh, tanh, tgamma, trunc};
-pub use f64::{j0, j1, jn, y0, y1, yn};
 
 pub static NaN: float = 0.0/0.0;
 
@@ -341,31 +331,6 @@ pub fn pow_with_uint(base: uint, pow: uint) -> float {
     return total;
 }
 
-#[inline(always)]
-pub fn abs(x: float) -> float {
-    f64::abs(x as f64) as float
-}
-#[inline(always)]
-pub fn sqrt(x: float) -> float {
-    f64::sqrt(x as f64) as float
-}
-#[inline(always)]
-pub fn atan(x: float) -> float {
-    f64::atan(x as f64) as float
-}
-#[inline(always)]
-pub fn sin(x: float) -> float {
-    f64::sin(x as f64) as float
-}
-#[inline(always)]
-pub fn cos(x: float) -> float {
-    f64::cos(x as f64) as float
-}
-#[inline(always)]
-pub fn tan(x: float) -> float {
-    f64::tan(x as f64) as float
-}
-
 impl Num for float {}
 
 #[cfg(not(test))]
@@ -442,19 +407,19 @@ impl One for float {
 impl Round for float {
     /// Round half-way cases toward `neg_infinity`
     #[inline(always)]
-    fn floor(&self) -> float { floor(*self as f64) as float }
+    fn floor(&self) -> float { (*self as f64).floor() as float }
 
     /// Round half-way cases toward `infinity`
     #[inline(always)]
-    fn ceil(&self) -> float { ceil(*self as f64) as float }
+    fn ceil(&self) -> float { (*self as f64).ceil() as float }
 
     /// Round half-way cases away from `0.0`
     #[inline(always)]
-    fn round(&self) -> float { round(*self as f64) as float }
+    fn round(&self) -> float { (*self as f64).round() as float }
 
     /// The integer part of the number (rounds towards `0.0`)
     #[inline(always)]
-    fn trunc(&self) -> float { trunc(*self as f64) as float }
+    fn trunc(&self) -> float { (*self as f64).trunc() as float }
 
     ///
     /// The fractional part of the number, satisfying:
@@ -726,31 +691,30 @@ impl Real for float {
 impl RealExt for float {
     #[inline(always)]
     fn lgamma(&self) -> (int, float) {
-        let mut sign = 0;
-        let result = lgamma(*self as f64, &mut sign);
-        (sign as int, result as float)
+        let (sign, value) = (*self as f64).lgamma();
+        (sign, value as float)
     }
 
     #[inline(always)]
-    fn tgamma(&self) -> float { tgamma(*self as f64) as float }
+    fn tgamma(&self) -> float { (*self as f64).tgamma() as float }
 
     #[inline(always)]
-    fn j0(&self) -> float { j0(*self as f64) as float }
+    fn j0(&self) -> float { (*self as f64).j0() as float }
 
     #[inline(always)]
-    fn j1(&self) -> float { j1(*self as f64) as float }
+    fn j1(&self) -> float { (*self as f64).j1() as float }
 
     #[inline(always)]
-    fn jn(&self, n: int) -> float { jn(n as c_int, *self as f64) as float }
+    fn jn(&self, n: int) -> float { (*self as f64).jn(n) as float }
 
     #[inline(always)]
-    fn y0(&self) -> float { y0(*self as f64) as float }
+    fn y0(&self) -> float { (*self as f64).y0() as float }
 
     #[inline(always)]
-    fn y1(&self) -> float { y1(*self as f64) as float }
+    fn y1(&self) -> float { (*self as f64).y1() as float }
 
     #[inline(always)]
-    fn yn(&self, n: int) -> float { yn(n as c_int, *self as f64) as float }
+    fn yn(&self, n: int) -> float { (*self as f64).yn(n) as float }
 }
 
 #[cfg(not(test))]
@@ -791,7 +755,7 @@ impl Neg<float> for float {
 impl Signed for float {
     /// Computes the absolute value. Returns `NaN` if the number is `NaN`.
     #[inline(always)]
-    fn abs(&self) -> float { abs(*self) }
+    fn abs(&self) -> float { (*self).abs() as float }
 
     ///
     /// The positive difference of two numbers. Returns `0.0` if the number is less than or
@@ -811,7 +775,7 @@ impl Signed for float {
     ///
     #[inline(always)]
     fn signum(&self) -> float {
-        if self.is_NaN() { NaN } else { f64::copysign(1.0, *self as f64) as float }
+        (*self as f64).signum() as float
     }
 
     /// Returns `true` if the number is positive, including `+0.0` and `infinity`
@@ -938,13 +902,13 @@ impl Float for float {
     ///
     #[inline(always)]
     fn mul_add(&self, a: float, b: float) -> float {
-        mul_add(*self as f64, a as f64, b as f64) as float
+        (*self as f64).mul_add(a as f64, b as f64) as float
     }
 
     /// Returns the next representable floating-point value in the direction of `other`
     #[inline(always)]
     fn next_after(&self, other: float) -> float {
-        next_after(*self as f64, other as f64) as float
+        (*self as f64).next_after(other as f64) as float
     }
 }
 

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -26,62 +26,6 @@ pub static bytes : uint = ($bits / 8);
 pub static min_value: $T = (-1 as $T) << (bits - 1);
 pub static max_value: $T = min_value - 1 as $T;
 
-/// Calculates the sum of two numbers
-#[inline(always)]
-pub fn add(x: $T, y: $T) -> $T { x + y }
-/// Subtracts the second number from the first
-#[inline(always)]
-pub fn sub(x: $T, y: $T) -> $T { x - y }
-/// Multiplies two numbers together
-#[inline(always)]
-pub fn mul(x: $T, y: $T) -> $T { x * y }
-/// Divides the first argument by the second argument (using integer division)
-/// Divides the first argument by the second argument (using integer division)
-#[inline(always)]
-pub fn div(x: $T, y: $T) -> $T { x / y }
-
-///
-/// Returns the remainder of y / x.
-///
-/// # Examples
-/// ~~~
-/// assert!(int::rem(5 / 2) == 1);
-/// ~~~
-///
-/// When faced with negative numbers, the result copies the sign of the
-/// dividend.
-///
-/// ~~~
-/// assert!(int::rem(2 / -3) ==  2);
-/// ~~~
-///
-/// ~~~
-/// assert!(int::rem(-2 / 3) ==  -2);
-/// ~~~
-///
-///
-#[inline(always)]
-pub fn rem(x: $T, y: $T) -> $T { x % y }
-
-/// Returns true iff `x < y`
-#[inline(always)]
-pub fn lt(x: $T, y: $T) -> bool { x < y }
-/// Returns true iff `x <= y`
-#[inline(always)]
-pub fn le(x: $T, y: $T) -> bool { x <= y }
-/// Returns true iff `x == y`
-#[inline(always)]
-pub fn eq(x: $T, y: $T) -> bool { x == y }
-/// Returns true iff `x != y`
-#[inline(always)]
-pub fn ne(x: $T, y: $T) -> bool { x != y }
-/// Returns true iff `x >= y`
-#[inline(always)]
-pub fn ge(x: $T, y: $T) -> bool { x >= y }
-/// Returns true iff `x > y`
-#[inline(always)]
-pub fn gt(x: $T, y: $T) -> bool { x > y }
-
 ///
 /// Iterate over the range [`lo`..`hi`)
 ///

--- a/src/libstd/num/num.rs
+++ b/src/libstd/num/num.rs
@@ -46,6 +46,9 @@ pub trait Orderable: Ord {
     fn clamp(&self, mn: &Self, mx: &Self) -> Self;
 }
 
+#[inline(always)] pub fn min<T: Orderable>(a: T, b: T) -> T { a.min(&b) }
+#[inline(always)] pub fn max<T: Orderable>(a: T, b: T) -> T { a.max(&b) }
+
 pub trait Zero {
     fn zero() -> Self;      // FIXME (#5527): This should be an associated constant
     fn is_zero(&self) -> bool;
@@ -65,12 +68,9 @@ pub trait Signed: Num
     fn is_negative(&self) -> bool;
 }
 
-pub trait Unsigned: Num {}
+#[inline(always)] pub fn abs<T: Signed>(value: T) -> T { value.abs() }
 
-// This should be moved into the default implementation for Signed::abs
-pub fn abs<T:Ord + Zero + Neg<T>>(v: T) -> T {
-    if v < Zero::zero() { v.neg() } else { v }
-}
+pub trait Unsigned: Num {}
 
 pub trait Integer: Num
                  + Orderable
@@ -113,6 +113,8 @@ pub trait Algebraic {
     fn hypot(&self, other: &Self) -> Self;
 }
 
+#[inline(always)] pub fn sqrt<T: Algebraic>(value: T) -> T { value.sqrt() }
+
 pub trait Trigonometric {
     fn sin(&self) -> Self;
     fn cos(&self) -> Self;
@@ -124,6 +126,16 @@ pub trait Trigonometric {
     fn sin_cos(&self) -> (Self, Self);
 }
 
+#[inline(always)] pub fn sin<T: Trigonometric>(value: T) -> T { value.sin() }
+#[inline(always)] pub fn cos<T: Trigonometric>(value: T) -> T { value.cos() }
+#[inline(always)] pub fn tan<T: Trigonometric>(value: T) -> T { value.tan() }
+
+#[inline(always)] pub fn asin<T: Trigonometric>(value: T) -> T { value.asin() }
+#[inline(always)] pub fn acos<T: Trigonometric>(value: T) -> T { value.acos() }
+#[inline(always)] pub fn atan<T: Trigonometric>(value: T) -> T { value.atan() }
+
+#[inline(always)] pub fn atan2<T: Trigonometric>(x: T, y: T) -> T { x.atan2(&y) }
+
 pub trait Exponential {
     fn exp(&self) -> Self;
     fn exp2(&self) -> Self;
@@ -133,6 +145,14 @@ pub trait Exponential {
     fn log10(&self) -> Self;
 }
 
+#[inline(always)] pub fn exp<T: Exponential>(value: T) -> T { value.exp() }
+#[inline(always)] pub fn exp2<T: Exponential>(value: T) -> T { value.exp2() }
+
+#[inline(always)] pub fn ln<T: Exponential>(value: T) -> T { value.ln() }
+#[inline(always)] pub fn log<T: Exponential>(value: T, base: T) -> T { value.log(&base) }
+#[inline(always)] pub fn log2<T: Exponential>(value: T) -> T { value.log2() }
+#[inline(always)] pub fn log10<T: Exponential>(value: T) -> T { value.log10() }
+
 pub trait Hyperbolic: Exponential {
     fn sinh(&self) -> Self;
     fn cosh(&self) -> Self;
@@ -141,6 +161,14 @@ pub trait Hyperbolic: Exponential {
     fn acosh(&self) -> Self;
     fn atanh(&self) -> Self;
 }
+
+#[inline(always)] pub fn sinh<T: Hyperbolic>(value: T) -> T { value.sinh() }
+#[inline(always)] pub fn cosh<T: Hyperbolic>(value: T) -> T { value.cosh() }
+#[inline(always)] pub fn tanh<T: Hyperbolic>(value: T) -> T { value.tanh() }
+
+#[inline(always)] pub fn asinh<T: Hyperbolic>(value: T) -> T { value.asinh() }
+#[inline(always)] pub fn acosh<T: Hyperbolic>(value: T) -> T { value.acosh() }
+#[inline(always)] pub fn atanh<T: Hyperbolic>(value: T) -> T { value.atanh() }
 
 ///
 /// Defines constants and methods common to real numbers

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -21,7 +21,6 @@ use vec;
 use vec::{CopyableVector, ImmutableVector};
 use vec::OwnedVector;
 use num::{NumCast, Zero, One, cast, pow_with_uint};
-use f64;
 
 pub enum ExponentFormat {
     ExpNone,
@@ -93,8 +92,8 @@ macro_rules! impl_NumStrConv_Floating (($t:ty) => (
 
         #[inline(always)]
         fn round_to_zero(&self) -> $t {
-            ( if *self < 0.0 { f64::ceil(*self as f64)  }
-              else           { f64::floor(*self as f64) }
+            ( if *self < 0.0 { (*self as f64).ceil()  }
+              else           { (*self as f64).floor() }
             ) as $t
         }
 

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -27,42 +27,6 @@ pub static bytes : uint = ($bits / 8);
 pub static min_value: $T = 0 as $T;
 pub static max_value: $T = 0 as $T - 1 as $T;
 
-/// Calculates the sum of two numbers
-#[inline(always)]
-pub fn add(x: $T, y: $T) -> $T { x + y }
-/// Subtracts the second number from the first
-#[inline(always)]
-pub fn sub(x: $T, y: $T) -> $T { x - y }
-/// Multiplies two numbers together
-#[inline(always)]
-pub fn mul(x: $T, y: $T) -> $T { x * y }
-/// Divides the first argument by the second argument (using integer division)
-#[inline(always)]
-pub fn div(x: $T, y: $T) -> $T { x / y }
-/// Calculates the integer remainder when x is divided by y (equivalent to the
-/// '%' operator)
-#[inline(always)]
-pub fn rem(x: $T, y: $T) -> $T { x % y }
-
-/// Returns true iff `x < y`
-#[inline(always)]
-pub fn lt(x: $T, y: $T) -> bool { x < y }
-/// Returns true iff `x <= y`
-#[inline(always)]
-pub fn le(x: $T, y: $T) -> bool { x <= y }
-/// Returns true iff `x == y`
-#[inline(always)]
-pub fn eq(x: $T, y: $T) -> bool { x == y }
-/// Returns true iff `x != y`
-#[inline(always)]
-pub fn ne(x: $T, y: $T) -> bool { x != y }
-/// Returns true iff `x >= y`
-#[inline(always)]
-pub fn ge(x: $T, y: $T) -> bool { x >= y }
-/// Returns true iff `x > y`
-#[inline(always)]
-pub fn gt(x: $T, y: $T) -> bool { x > y }
-
 #[inline(always)]
 /**
  * Iterate through a range with a given step value.

--- a/src/libstd/rand/distributions.rs
+++ b/src/libstd/rand/distributions.rs
@@ -20,7 +20,6 @@
 // Generating Random Variables"], but more robust. If one wanted, one
 // could implement VIZIGNOR the ZIGNOR paper for more speed.
 
-use f64;
 use rand::{Rng,Rand};
 
 mod ziggurat_tables;
@@ -39,7 +38,7 @@ fn ziggurat<R:Rng>(rng: &mut R,
         let i: uint = rng.gen::<uint>() & 0xff;
         let x = u * X[i];
 
-        let test_x = if center_u {f64::abs(x)} else {x};
+        let test_x = if center_u { x.abs() } else {x};
 
         // algebraically equivalent to |u| < X[i+1]/X[i] (or u < X[i+1]/X[i])
         if test_x < X[i + 1] {
@@ -79,7 +78,7 @@ impl Rand for StandardNormal {
     fn rand<R:Rng>(rng: &mut R) -> StandardNormal {
         #[inline(always)]
         fn pdf(x: f64) -> f64 {
-            f64::exp((-x*x/2.0) as f64) as f64
+            ((-x*x/2.0) as f64).exp()
         }
         #[inline(always)]
         fn zero_case<R:Rng>(rng: &mut R, u: f64) -> f64 {
@@ -89,14 +88,15 @@ impl Rand for StandardNormal {
             // do-while, so the condition should be true on the first
             // run, they get overwritten anyway (0 < 1, so these are
             // good).
-            let mut (x, y) = (1.0, 0.0);
+            let mut (x, y) = (1.0f64, 0.0f64);
 
             // XXX infinities?
             while -2.0*y < x * x {
-                x = f64::ln(rng.gen()) / ziggurat_tables::ZIG_NORM_R;
-                y = f64::ln(rng.gen());
+                x = rng.gen::<f64>().ln() / ziggurat_tables::ZIG_NORM_R;
+                y = rng.gen::<f64>().ln();
             }
-            if u < 0.0 {x-ziggurat_tables::ZIG_NORM_R} else {ziggurat_tables::ZIG_NORM_R-x}
+
+            if u < 0.0 {x - ziggurat_tables::ZIG_NORM_R} else {ziggurat_tables::ZIG_NORM_R - x}
         }
 
         StandardNormal(ziggurat(
@@ -127,17 +127,15 @@ impl Rand for StandardNormal {
 /// ~~~
 pub struct Exp1(f64);
 
-// This could be done via `-f64::ln(rng.gen::<f64>())` but that is slower.
+// This could be done via `-rng.gen::<f64>().ln()` but that is slower.
 impl Rand for Exp1 {
     #[inline]
     fn rand<R:Rng>(rng: &mut R) -> Exp1 {
         #[inline(always)]
-        fn pdf(x: f64) -> f64 {
-            f64::exp(-x)
-        }
+        fn pdf(x: f64) -> f64 { (-x).exp() }
         #[inline(always)]
         fn zero_case<R:Rng>(rng: &mut R, _u: f64) -> f64 {
-            ziggurat_tables::ZIG_EXP_R - f64::ln(rng.gen())
+            ziggurat_tables::ZIG_EXP_R - rng.gen::<f64>().ln()
         }
 
         Exp1(ziggurat(rng, false,

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -28,6 +28,7 @@ use container::Container;
 use iter::Times;
 use iterator::{Iterator, IteratorUtil, FilterIterator};
 use libc;
+use num;
 use option::{None, Option, Some};
 use old_iter::{BaseIter, EqIter};
 use ptr;
@@ -789,7 +790,7 @@ pub fn eq(a: &~str, b: &~str) -> bool {
 
 #[inline]
 fn cmp(a: &str, b: &str) -> Ordering {
-    let low = uint::min(a.len(), b.len());
+    let low = num::min(a.len(), b.len());
 
     for uint::range(0, low) |idx| {
         match a[idx].cmp(&b[idx]) {
@@ -824,7 +825,7 @@ impl TotalOrd for @str {
 #[inline]
 fn lt(a: &str, b: &str) -> bool {
     let (a_len, b_len) = (a.len(), b.len());
-    let end = uint::min(a_len, b_len);
+    let end = num::min(a_len, b_len);
 
     let mut i = 0;
     while i < end {

--- a/src/libstd/unstable/extfmt.rs
+++ b/src/libstd/unstable/extfmt.rs
@@ -476,6 +476,7 @@ pub mod rt {
     use str;
     use sys;
     use int;
+    use num;
     use uint;
     use vec;
     use option::{Some, None, Option};
@@ -501,7 +502,7 @@ pub mod rt {
     pub fn conv_int(cv: Conv, i: int, buf: &mut ~str) {
         let radix = 10;
         let prec = get_int_precision(cv);
-        let s : ~str = uint_to_str_prec(int::abs(i) as uint, radix, prec);
+        let s : ~str = uint_to_str_prec(num::abs(i) as uint, radix, prec);
 
         let head = if i >= 0 {
             if have_flag(cv.flags, flag_sign_always) {

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -23,6 +23,7 @@ use iterator::{Iterator, IteratorUtil};
 use iter::FromIter;
 use kinds::Copy;
 use libc;
+use num;
 use old_iter::CopyableIter;
 use option::{None, Option, Some};
 use ptr::to_unsafe_ptr;
@@ -1665,7 +1666,7 @@ impl<'self,T:Eq> Equiv<~[T]> for &'self [T] {
 // Lexicographical comparison
 
 fn cmp<T: TotalOrd>(a: &[T], b: &[T]) -> Ordering {
-    let low = uint::min(a.len(), b.len());
+    let low = num::min(a.len(), b.len());
 
     for uint::range(0, low) |idx| {
         match a[idx].cmp(&b[idx]) {
@@ -1698,7 +1699,7 @@ impl<T: TotalOrd> TotalOrd for @[T] {
 
 fn lt<T:Ord>(a: &[T], b: &[T]) -> bool {
     let (a_len, b_len) = (a.len(), b.len());
-    let end = uint::min(a_len, b_len);
+    let end = num::min(a_len, b_len);
 
     let mut i = 0;
     while i < end {
@@ -2399,7 +2400,7 @@ pub mod raw {
 /// Operations on `[u8]`
 pub mod bytes {
     use libc;
-    use uint;
+    use num;
     use vec::raw;
     use vec;
 
@@ -2407,7 +2408,7 @@ pub mod bytes {
     pub fn memcmp(a: &~[u8], b: &~[u8]) -> int {
         let a_len = a.len();
         let b_len = b.len();
-        let n = uint::min(a_len, b_len) as libc::size_t;
+        let n = num::min(a_len, b_len) as libc::size_t;
         let r = unsafe {
             libc::memcmp(raw::to_ptr(*a) as *libc::c_void,
                          raw::to_ptr(*b) as *libc::c_void, n) as int

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -22,6 +22,7 @@ use visit;
 
 use core::hashmap::HashMap;
 use core::int;
+use core::num;
 use core::option;
 use core::to_bytes;
 
@@ -387,8 +388,8 @@ impl id_range {
     }
 
     pub fn add(&mut self, id: node_id) {
-        self.min = int::min(self.min, id);
-        self.max = int::max(self.max, id + 1);
+        self.min = num::min(self.min, id);
+        self.max = num::max(self.max, id + 1);
     }
 }
 

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -22,6 +22,7 @@ use parse::token::{get_ident_interner};
 
 use core::iterator::IteratorUtil;
 use core::io;
+use core::num;
 use core::str;
 use core::uint;
 
@@ -213,7 +214,7 @@ fn trim_whitespace_prefix_and_push_line(lines: &mut ~[~str],
     let len = s.len();
     // FIXME #3961: Doing bytewise comparison and slicing with CharPos
     let col = col.to_uint();
-    let s1 = if all_whitespace(s, 0, uint::min(len, col)) {
+    let s1 = if all_whitespace(s, 0, num::min(len, col)) {
         if col < len {
             s.slice(col, len).to_owned()
         } else {  ~"" }

--- a/src/test/run-pass/class-impl-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-parameterized-trait.rs
@@ -12,6 +12,8 @@
 // xfail-fast
 
 extern mod extra;
+
+use std::num;
 use extra::oldmap::*;
 
 class cat : map<int, bool> {
@@ -58,7 +60,7 @@ class cat : map<int, bool> {
   fn find(&&k:int) -> Option<bool> { Some(self.get(k)) }
   fn remove(&&k:int) -> Option<bool> { self.meows -= k; Some(true) }
   fn each(f: &fn(&&int, &&bool) -> bool) {
-    let mut n = int::abs(self.meows);
+    let mut n = num::abs(self.meows);
     while n > 0 {
         if !f(n, true) { break; }
         n -= 1;

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -12,7 +12,7 @@
 
 use std::cmp;
 use std::container::{Container, Mutable, Map};
-use std::int;
+use std::num;
 use std::old_iter::BaseIter;
 use std::uint;
 
@@ -63,7 +63,7 @@ impl<T> Mutable for cat<T> {
 
 impl<T> Map<int, T> for cat<T> {
     fn each<'a>(&'a self, f: &fn(&int, &'a T) -> bool) -> bool {
-        let mut n = int::abs(self.meows);
+        let mut n = num::abs(self.meows);
         while n > 0 {
             if !f(&n, &self.name) { return false; }
             n -= 1;

--- a/src/test/run-pass/core-export-f64-sqrt.rs
+++ b/src/test/run-pass/core-export-f64-sqrt.rs
@@ -10,12 +10,12 @@
 
 // Regression test that f64 exports things properly
 
-use std::f64;
+use std::num;
 use std::float;
 
 pub fn main() {
 
     let digits: uint = 10 as uint;
 
-    println(float::to_str_digits(f64::sqrt(42.0f64) as float, digits));
+    println(float::to_str_digits(num::sqrt(42.0f64) as float, digits));
 }

--- a/src/test/run-pass/trait-inheritance-self-in-supertype.rs
+++ b/src/test/run-pass/trait-inheritance-self-in-supertype.rs
@@ -1,7 +1,6 @@
 // Test for issue #4183: use of Self in supertraits.
 
-use std::f32;
-use std::f64;
+use std::num;
 
 pub static FUZZY_EPSILON: float = 0.1;
 
@@ -20,7 +19,7 @@ impl FuzzyEq<f32> for f32 {
     }
 
     fn fuzzy_eq_eps(&self, other: &f32, epsilon: &f32) -> bool {
-        f32::abs(*self - *other) < *epsilon
+        num::abs(*self - *other) < *epsilon
     }
 }
 
@@ -34,7 +33,7 @@ impl FuzzyEq<f64> for f64 {
     }
 
     fn fuzzy_eq_eps(&self, other: &f64, epsilon: &f64) -> bool {
-        f64::abs(*self - *other) < *epsilon
+        num::abs(*self - *other) < *epsilon
     }
 }
 

--- a/src/test/run-pass/utf8_idents.rs
+++ b/src/test/run-pass/utf8_idents.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::float;
+use std::num;
 
 pub fn main() {
     let ε = 0.00001;
     let Π = 3.14;
     let लंच = Π * Π + 1.54;
-    assert!(float::abs((लंच - 1.54) - (Π * Π)) < ε);
+    assert!(num::abs((लंच - 1.54) - (Π * Π)) < ε);
     assert_eq!(საჭმელად_გემრიელი_სადილი(), 0);
 }
 


### PR DESCRIPTION
The free-standing functions in f32, f64, i8, i16, i32, i64, u8, u16,
u32, u64, float, int, and uint are replaced with generic functions in
num instead.

This means that instead of having to know everywhere what the type is, like

```
f64::sin(x)
```

You can simply write code that uses the type-generic versions in num instead, this works for all types that implement the corresponding trait in num.

```
num::sin(x)
```

Note 1: If you were previously using any of those functions, just replace them
with the corresponding function with the same name in num.

Note 2: If you were using a function that corresponds to an operator, use the
operator instead.
