### PR TITLE
std: remove the invalid NullTerminatedStr instance for &'static str.

### DIFF
--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1953,18 +1953,6 @@ impl NullTerminatedStr for @str {
         slice
     }
 }
-// static strings are the only slices guaranteed to a nul-terminator
-impl NullTerminatedStr for &'static str {
-    /**
-     * Work with the byte buffer of a string as a byte slice.
-     *
-     * The byte slice does include the null terminator.
-     */
-    #[inline]
-    fn as_bytes_with_null(&self) -> &'static [u8] {
-        unsafe { ::cast::transmute(*self) }
-    }
-}
 
 #[allow(missing_doc)]
 pub trait OwnedStr {
@@ -2924,10 +2912,6 @@ mod tests {
             184, 173, 229, 141, 142, 86, 105, 225, 187, 135, 116, 32, 78, 97,
             109, 0
         ];
-
-        assert_eq!("".as_bytes_with_null(), &[0]);
-        assert_eq!("abc".as_bytes_with_null(), &['a' as u8, 'b' as u8, 'c' as u8, 0]);
-        assert_eq!("ศไทย中华Việt Nam".as_bytes_with_null(), v);
 
         let s1 = @"";
         let s2 = @"abc";

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -93,7 +93,7 @@ impl RepeatFasta {
             let stdout = self.stdout;
             let alu_len = self.alu.len();
             let mut buf = vec::from_elem(alu_len + LINE_LEN, 0u8);
-            let alu: &[u8] = self.alu.as_bytes_with_null();
+            let alu: &[u8] = self.alu.as_bytes();
 
             copy_memory(buf, alu, alu_len);
             copy_memory(vec::mut_slice(buf, alu_len, buf.len()),

--- a/src/test/compile-fail/static-slice-not-null-terminated.rs
+++ b/src/test/compile-fail/static-slice-not-null-terminated.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let _ = (~"foo").as_bytes_with_null();
+    let _ = (@"foo").as_bytes_with_null();
+
+    // a plain static slice is null terminated, but such a slice can
+    // be sliced shorter (i.e. become non-null terminated) and still
+    // have the static lifetime
+    let foo: &'static str = "foo";
+    let _ = foo.as_bytes_with_null();
+     //~^ ERROR does not implement any method in scope named `as_bytes_with_null`
+}


### PR DESCRIPTION
A slice of a 'static str is still 'static, but doesn't necessarily
have the null terminator.
