### PR TITLE
syntax: correct the Rand::rand call to select enum variants in #[deriving(Rand)].

### DIFF
--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -78,13 +78,13 @@ fn rand_substructure(cx: @ExtCtxt, span: span, substr: &Substructure) -> @expr {
 
             let variant_count = cx.expr_uint(span, variants.len());
 
-            // need to specify the u32-ness of the random number
-            let u32_ty = cx.ty_ident(span, cx.ident_of("u32"));
+            // need to specify the uint-ness of the random number
+            let uint_ty = cx.ty_ident(span, cx.ident_of("uint"));
             let r_ty = cx.ty_ident(span, cx.ident_of("R"));
-            let rand_name = cx.path_all(span, true, copy rand_ident, None, ~[ u32_ty, r_ty ]);
+            let rand_name = cx.path_all(span, true, copy rand_ident, None, ~[ uint_ty, r_ty ]);
             let rand_name = cx.expr_path(rand_name);
 
-            // ::std::rand::Rand::rand::<u32>(rng)
+            // ::std::rand::Rand::rand::<uint>(rng)
             let rv_call = cx.expr_call(span,
                                        rand_name,
                                        ~[ rng[0].duplicate(cx) ]);

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -78,19 +78,20 @@ fn rand_substructure(cx: @ExtCtxt, span: span, substr: &Substructure) -> @expr {
 
             let variant_count = cx.expr_uint(span, variants.len());
 
-            // need to specify the uint-ness of the random number
-            let u32_ty = cx.ty_ident(span, cx.ident_of("uint"));
+            // need to specify the u32-ness of the random number
+            let u32_ty = cx.ty_ident(span, cx.ident_of("u32"));
             let r_ty = cx.ty_ident(span, cx.ident_of("R"));
-            let rand_name = cx.path_all(span, false, copy rand_ident, None, ~[ u32_ty, r_ty ]);
+            let rand_name = cx.path_all(span, true, copy rand_ident, None, ~[ u32_ty, r_ty ]);
             let rand_name = cx.expr_path(rand_name);
 
+            // ::std::rand::Rand::rand::<u32>(rng)
             let rv_call = cx.expr_call(span,
                                        rand_name,
                                        ~[ rng[0].duplicate(cx) ]);
 
             // rand() % variants.len()
             let rand_variant = cx.expr_binary(span, ast::rem,
-                                                rv_call, variant_count);
+                                              rv_call, variant_count);
 
             let mut arms = do variants.mapi |i, id_sum| {
                 let i_expr = cx.expr_uint(span, i);

--- a/src/test/run-pass/deriving-global.rs
+++ b/src/test/run-pass/deriving-global.rs
@@ -1,3 +1,5 @@
+// xfail-test #7103 `extern mod` does not work on windows
+
 // Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/test/run-pass/deriving-global.rs
+++ b/src/test/run-pass/deriving-global.rs
@@ -1,0 +1,39 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern mod extra; // {En,De}codable
+mod submod {
+    // if any of these are implemented without global calls for any
+    // function calls, then being in a submodule will (correctly)
+    // cause errors about unrecognised module `std` (or `extra`)
+    #[deriving(Eq, Ord, TotalEq, TotalOrd,
+               IterBytes,
+               Clone, DeepClone,
+               ToStr, Rand,
+               Encodable, Decodable)]
+    enum A { A1(uint), A2(int) }
+
+    #[deriving(Eq, Ord, TotalEq, TotalOrd,
+               IterBytes,
+               Clone, DeepClone,
+               ToStr, Rand,
+               Encodable, Decodable)]
+    struct B { x: uint, y: int }
+
+    #[deriving(Eq, Ord, TotalEq, TotalOrd,
+               IterBytes,
+               Clone, DeepClone,
+               ToStr, Rand,
+               Encodable, Decodable)]
+    struct C(uint, int);
+
+}
+
+fn main() {}


### PR DESCRIPTION
Previously, this was not a global call, and so when `#[deriving(Rand)]`
was in any module other than the top-level one, it failed (unless there
was a `use std;` in scope).

Also, fix a minor inconsistency between uints and u32s for this piece
of code.
