### PR TITLE
Deny common lints by default for lib{std,extra}

### DIFF
--- a/mk/target.mk
+++ b/mk/target.mk
@@ -13,6 +13,15 @@
 # this exists can be found on issue #2400
 export CFG_COMPILER_TRIPLE
 
+# The standard libraries should be held up to a higher standard than any old
+# code, make sure that these common warnings are denied by default. These can
+# be overridden during development temporarily. For stage0, we allow all these
+# to suppress warnings which may be bugs in stage0 (should be fixed in stage1+)
+# NOTE: add "-A warnings" after snapshot to WFLAGS_ST0
+WFLAGS_ST0 = -A unrecognized-lint
+WFLAGS_ST1 = -D warnings
+WFLAGS_ST2 = -D warnings
+
 # TARGET_STAGE_N template: This defines how target artifacts are built
 # for all stage/target architecture combinations. The arguments:
 # $(1) is the stage
@@ -39,7 +48,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_STDLIB_$(2)): \
 		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
-	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< && touch $$@
+	$$(STAGE$(1)_T_$(2)_H_$(3)) $$(WFLAGS_ST$(1)) -o $$@ $$< && touch $$@
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_EXTRALIB_$(2)): \
 		$$(EXTRALIB_CRATE) $$(EXTRALIB_INPUTS) \
@@ -47,7 +56,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_EXTRALIB_$(2)): \
 		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
-	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< && touch $$@
+	$$(STAGE$(1)_T_$(2)_H_$(3)) $$(WFLAGS_ST$(1)) -o $$@ $$< && touch $$@
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBSYNTAX_$(3)): \
                 $$(LIBSYNTAX_CRATE) $$(LIBSYNTAX_INPUTS) \

--- a/src/libextra/term.rs
+++ b/src/libextra/term.rs
@@ -15,12 +15,12 @@
 use core::prelude::*;
 
 use core::io;
-use core::os;
 
-use terminfo::*;
-use terminfo::searcher::open;
-use terminfo::parser::compiled::parse;
-use terminfo::parm::{expand, Number, Variables};
+#[cfg(not(target_os = "win32"))] use core::os;
+#[cfg(not(target_os = "win32"))] use terminfo::*;
+#[cfg(not(target_os = "win32"))] use terminfo::searcher::open;
+#[cfg(not(target_os = "win32"))] use terminfo::parser::compiled::parse;
+#[cfg(not(target_os = "win32"))] use terminfo::parm::{expand, Number, Variables};
 
 // FIXME (#2807): Windows support.
 
@@ -122,10 +122,10 @@ impl Terminal {
         return Ok(Terminal {out: out, color_supported: false});
     }
 
-    pub fn fg(&self, color: u8) {
+    pub fn fg(&self, _color: u8) {
     }
 
-    pub fn bg(&self, color: u8) {
+    pub fn bg(&self, _color: u8) {
     }
 
     pub fn reset(&self) {

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -568,7 +568,7 @@ pub mod types {
     pub mod os {
         pub mod common {
             pub mod posix01 {
-                use libc::types::os::arch::c95::{c_int, c_short};
+                use libc::types::os::arch::c95::c_short;
                 use libc::types::os::arch::extra::{int64, time64_t};
                 use libc::types::os::arch::posix88::{dev_t, ino_t};
                 use libc::types::os::arch::posix88::mode_t;

--- a/src/libstd/rt/thread_local_storage.rs
+++ b/src/libstd/rt/thread_local_storage.rs
@@ -60,13 +60,13 @@ pub type Key = DWORD;
 #[cfg(windows)]
 pub unsafe fn create(key: &mut Key) {
     static TLS_OUT_OF_INDEXES: DWORD = 0xFFFFFFFF;
-    *key = unsafe { TlsAlloc() };
+    *key = TlsAlloc();
     assert!(*key != TLS_OUT_OF_INDEXES);
 }
 
 #[cfg(windows)]
 pub unsafe fn set(key: Key, value: *mut c_void) {
-    unsafe { assert!(0 != TlsSetValue(key, value)) }
+    assert!(0 != TlsSetValue(key, value))
 }
 
 #[cfg(windows)]

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -12,11 +12,10 @@
 
 #[allow(missing_doc)];
 
-use iterator::IteratorUtil;
 use cast;
 use comm::{stream, SharedChan, GenericChan, GenericPort};
-use int;
 use io;
+use iterator::IteratorUtil;
 use libc::{pid_t, c_void, c_int};
 use libc;
 use option::{Some, None};
@@ -465,7 +464,6 @@ fn spawn_process_os(prog: &str, args: &[~str],
     use libc::funcs::extra::msvcrt::get_osfhandle;
 
     use sys;
-    use uint;
 
     unsafe {
 
@@ -638,6 +636,7 @@ fn spawn_process_os(prog: &str, args: &[~str],
 
     use libc::funcs::posix88::unistd::{fork, dup2, close, chdir, execvp};
     use libc::funcs::bsd44::getdtablesize;
+    use int;
 
     mod rustrt {
         use libc::c_void;

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -91,7 +91,7 @@ use uint;
 use util;
 use unstable::sync::{Exclusive, exclusive};
 use rt::local::Local;
-use iterator::{IteratorUtil};
+use iterator::IteratorUtil;
 
 #[cfg(test)] use task::default_task_opts;
 #[cfg(test)] use comm;

--- a/src/libstd/to_str.rs
+++ b/src/libstd/to_str.rs
@@ -17,8 +17,8 @@ The `ToStr` trait for converting to strings
 use str::OwnedStr;
 use hashmap::HashMap;
 use hashmap::HashSet;
-use iterator::IteratorUtil;
 use hash::Hash;
+use iterator::IteratorUtil;
 use cmp::Eq;
 use vec::ImmutableVector;
 
@@ -177,7 +177,7 @@ impl<A:ToStr> ToStr for @[A] {
 mod tests {
     use hashmap::HashMap;
     use hashmap::HashSet;
-    use container::{Set,Map};
+    use container::{Set, Map};
     #[test]
     fn test_simple_types() {
         assert_eq!(1i.to_str(), ~"1");

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -164,7 +164,6 @@ mod dl {
     use libc;
     use path;
     use ptr;
-    use str;
     use task;
     use result::*;
 
@@ -175,7 +174,7 @@ mod dl {
     }
 
     pub unsafe fn open_internal() -> *libc::c_void {
-        let mut handle = ptr::null();
+        let handle = ptr::null();
         GetModuleHandleExW(0 as libc::DWORD, ptr::null(), &handle as **libc::c_void);
         handle
     }


### PR DESCRIPTION
Reopening of #7031, Closes #6963

I imagine though that this will bounce in bors once or twice... Because attributes can't be cfg(stage0)'d off, there's temporarily a lot of new stage0/stage1+ code.
