### PR TITLE
Kind-check closure freevars against destination builtin bounds.

### DIFF
--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -82,8 +82,6 @@ pub fn check_crate(tcx: ty::ctxt,
     tcx.sess.abort_if_errors();
 }
 
-type check_fn = @fn(Context, @freevar_entry);
-
 fn check_struct_safe_for_destructor(cx: Context,
                                     span: span,
                                     struct_did: def_id) {
@@ -163,30 +161,43 @@ fn check_item(item: @item, (cx, visitor): (Context, visit::vt<Context>)) {
 // Yields the appropriate function to check the kind of closed over
 // variables. `id` is the node_id for some expression that creates the
 // closure.
-fn with_appropriate_checker(cx: Context, id: node_id, b: &fn(check_fn)) {
-    fn check_for_uniq(cx: Context, fv: @freevar_entry) {
+fn with_appropriate_checker(cx: Context, id: node_id,
+                            b: &fn(checker: &fn(Context, @freevar_entry))) {
+    fn check_for_uniq(cx: Context, fv: @freevar_entry, bounds: ty::BuiltinBounds) {
         // all captured data must be owned, regardless of whether it is
         // moved in or copied in.
         let id = ast_util::def_id_of_def(fv.def).node;
         let var_t = ty::node_id_to_type(cx.tcx, id);
+
+        // FIXME(#3569): Once closure capabilities are restricted based on their
+        // incoming bounds, make this check conditional based on the bounds.
         if !check_owned(cx, var_t, fv.span) { return; }
 
         // check that only immutable variables are implicitly copied in
         check_imm_free_var(cx, fv.def, fv.span);
+
+        check_freevar_bounds(cx, fv.span, var_t, bounds);
     }
 
-    fn check_for_box(cx: Context, fv: @freevar_entry) {
+    fn check_for_box(cx: Context, fv: @freevar_entry, bounds: ty::BuiltinBounds) {
         // all captured data must be owned
         let id = ast_util::def_id_of_def(fv.def).node;
         let var_t = ty::node_id_to_type(cx.tcx, id);
+
+        // FIXME(#3569): Once closure capabilities are restricted based on their
+        // incoming bounds, make this check conditional based on the bounds.
         if !check_durable(cx.tcx, var_t, fv.span) { return; }
 
         // check that only immutable variables are implicitly copied in
         check_imm_free_var(cx, fv.def, fv.span);
+
+        check_freevar_bounds(cx, fv.span, var_t, bounds);
     }
 
-    fn check_for_block(_cx: Context, _fv: @freevar_entry) {
-        // no restrictions
+    fn check_for_block(cx: Context, fv: @freevar_entry, bounds: ty::BuiltinBounds) {
+        let id = ast_util::def_id_of_def(fv.def).node;
+        let var_t = ty::node_id_to_type(cx.tcx, id);
+        check_freevar_bounds(cx, fv.span, var_t, bounds);
     }
 
     fn check_for_bare(cx: Context, fv: @freevar_entry) {
@@ -197,14 +208,14 @@ fn with_appropriate_checker(cx: Context, id: node_id, b: &fn(check_fn)) {
 
     let fty = ty::node_id_to_type(cx.tcx, id);
     match ty::get(fty).sty {
-        ty::ty_closure(ty::ClosureTy {sigil: OwnedSigil, _}) => {
-            b(check_for_uniq)
+        ty::ty_closure(ty::ClosureTy {sigil: OwnedSigil, bounds: bounds, _}) => {
+            b(|cx, fv| check_for_uniq(cx, fv, bounds))
         }
-        ty::ty_closure(ty::ClosureTy {sigil: ManagedSigil, _}) => {
-            b(check_for_box)
+        ty::ty_closure(ty::ClosureTy {sigil: ManagedSigil, bounds: bounds, _}) => {
+            b(|cx, fv| check_for_box(cx, fv, bounds))
         }
-        ty::ty_closure(ty::ClosureTy {sigil: BorrowedSigil, _}) => {
-            b(check_for_block)
+        ty::ty_closure(ty::ClosureTy {sigil: BorrowedSigil, bounds: bounds, _}) => {
+            b(|cx, fv| check_for_block(cx, fv, bounds))
         }
         ty::ty_bare_fn(_) => {
             b(check_for_bare)
@@ -272,7 +283,7 @@ pub fn check_expr(e: @expr, (cx, v): (Context, visit::vt<Context>)) {
                       type_param_defs.repr(cx.tcx));
             }
             for ts.iter().zip(type_param_defs.iter()).advance |(&ty, type_param_def)| {
-                check_bounds(cx, type_parameter_id, e.span, ty, type_param_def)
+                check_typaram_bounds(cx, type_parameter_id, e.span, ty, type_param_def)
             }
         }
     }
@@ -315,7 +326,7 @@ fn check_ty(aty: @Ty, (cx, v): (Context, visit::vt<Context>)) {
               let type_param_defs =
                   ty::lookup_item_type(cx.tcx, did).generics.type_param_defs;
               for ts.iter().zip(type_param_defs.iter()).advance |(&ty, type_param_def)| {
-                  check_bounds(cx, aty.id, aty.span, ty, type_param_def)
+                  check_typaram_bounds(cx, aty.id, aty.span, ty, type_param_def)
               }
           }
       }
@@ -324,19 +335,26 @@ fn check_ty(aty: @Ty, (cx, v): (Context, visit::vt<Context>)) {
     visit::visit_ty(aty, (cx, v));
 }
 
-pub fn check_bounds(cx: Context,
+pub fn check_builtin_bounds(cx: Context, ty: ty::t, bounds: ty::BuiltinBounds)
+                           -> ty::BuiltinBounds // returns the missing bounds
+{
+    let kind = ty::type_contents(cx.tcx, ty);
+    let mut missing = ty::EmptyBuiltinBounds();
+    for bounds.each |bound| {
+        if !kind.meets_bound(cx.tcx, bound) {
+            missing.add(bound);
+        }
+    }
+    missing
+}
+
+pub fn check_typaram_bounds(cx: Context,
                     _type_parameter_id: node_id,
                     sp: span,
                     ty: ty::t,
                     type_param_def: &ty::TypeParameterDef)
 {
-    let kind = ty::type_contents(cx.tcx, ty);
-    let mut missing = ty::EmptyBuiltinBounds();
-    for type_param_def.bounds.builtin_bounds.each |bound| {
-        if !kind.meets_bound(cx.tcx, bound) {
-            missing.add(bound);
-        }
-    }
+    let missing = check_builtin_bounds(cx, ty, type_param_def.bounds.builtin_bounds);
     if !missing.is_empty() {
         cx.tcx.sess.span_err(
             sp,
@@ -344,6 +362,23 @@ pub fn check_bounds(cx: Context,
                   `%s`, which does not fulfill `%s`",
                  ty_to_str(cx.tcx, ty),
                  missing.user_string(cx.tcx)));
+    }
+}
+
+pub fn check_freevar_bounds(cx: Context, sp: span, ty: ty::t,
+                            bounds: ty::BuiltinBounds)
+{
+    let missing = check_builtin_bounds(cx, ty, bounds);
+    if !missing.is_empty() {
+        cx.tcx.sess.span_err(
+            sp,
+            fmt!("cannot capture variable of type `%s`, which does not fulfill \
+                  `%s`, in a bounded closure",
+                 ty_to_str(cx.tcx, ty), missing.user_string(cx.tcx)));
+        cx.tcx.sess.span_note(
+            sp,
+            fmt!("this closure's environment must satisfy `%s`",
+                 bounds.user_string(cx.tcx)));
     }
 }
 

--- a/src/test/compile-fail/closure-bounds-cant-promote-superkind-1.rs
+++ b/src/test/compile-fail/closure-bounds-cant-promote-superkind-1.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn bar(_blk: &fn:Copy()) {
+}
+
+fn foo(blk: &fn()) {
+    bar(blk); //~ ERROR expected bounds `Copy` but found no bounds
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/closure-bounds-cant-promote-superkind-2.rs
+++ b/src/test/compile-fail/closure-bounds-cant-promote-superkind-2.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn bar(_blk: &fn:Const+Owned()) {
+}
+
+fn foo(blk: &fn:Copy+Owned()) {
+    bar(blk); //~ ERROR expected bounds `Owned+Const` but found bounds `Copy+Owned`
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/closure-bounds-cant-promote-superkind-in-struct.rs
+++ b/src/test/compile-fail/closure-bounds-cant-promote-superkind-in-struct.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct X {
+    field: @fn:Copy(),
+}
+
+fn foo(blk: @fn()) -> X {
+    return X { field: blk }; //~ ERROR expected bounds `Copy` but found no bounds
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/closure-bounds-copy-cant-capture-noncopyable.rs
+++ b/src/test/compile-fail/closure-bounds-copy-cant-capture-noncopyable.rs
@@ -1,0 +1,24 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::comm;
+
+fn foo(blk: ~fn:Copy()) {
+    blk();
+}
+
+fn main() {
+    let (p,c) = comm::stream();
+    do foo { // shouldn't be legal
+        c.send(()); //~ ERROR cannot capture variable of type `std::comm::Chan<()>`, which does not fulfill `Copy`, in a bounded closure
+        //~^ NOTE this closure's environment must satisfy `Copy`
+    }
+    p.recv();
+}

--- a/src/test/compile-fail/closure-bounds-static-cant-capture-borrowed.rs
+++ b/src/test/compile-fail/closure-bounds-static-cant-capture-borrowed.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn bar(blk: &fn:'static()) {
+}
+
+fn foo(x: &()) {
+    do bar {
+        let _ = x; //~ ERROR cannot capture variable of type `&()`, which does not fulfill `'static`, in a bounded closure
+        //~^ NOTE this closure's environment must satisfy `'static`
+    }
+}
+
+fn main() {
+}

--- a/src/test/run-pass/closure-bounds-can-capture-chan.rs
+++ b/src/test/run-pass/closure-bounds-can-capture-chan.rs
@@ -1,0 +1,23 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::comm;
+
+fn foo(blk: ~fn:Owned()) {
+    blk();
+}
+
+fn main() {
+    let (p,c) = comm::stream();
+    do foo { // shouldn't be legal
+        c.send(());
+    }
+    p.recv();
+}

--- a/src/test/run-pass/closure-bounds-promote-subkind-1.rs
+++ b/src/test/run-pass/closure-bounds-promote-subkind-1.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn bar(_blk: &fn()) {
+}
+
+fn foo(blk: &fn:Copy()) {
+    bar(blk);
+}
+
+fn main() {
+}

--- a/src/test/run-pass/closure-bounds-promote-subkind-2.rs
+++ b/src/test/run-pass/closure-bounds-promote-subkind-2.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn bar(_blk: &fn:Const+Owned()) {
+}
+
+fn foo(blk: &fn:Const+Copy+Owned()) {
+    bar(blk);
+}
+
+fn main() {
+}

--- a/src/test/run-pass/closure-bounds-promote-subkind-in-struct.rs
+++ b/src/test/run-pass/closure-bounds-promote-subkind-in-struct.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct X {
+    field: @fn(),
+}
+
+fn foo(blk: @fn:Copy()) -> X {
+    return X { field: blk };
+}
+
+fn main() {
+}


### PR DESCRIPTION
r? @nikomatsakis

Things this doesn't check for:
- doesn't treat stack closure freevars as implicit borrows
- doesn't add more capabilities at closure usage sites
- doesn't restrict capabilities at same (i.e., still can copy stack closures that capture &mut)
- doesn't do trait bounds
