### PR TITLE
More str cleanup

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -24,7 +24,6 @@ use util::logv;
 
 use core::io;
 use core::os;
-use core::str;
 use core::uint;
 use core::vec;
 

--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -229,8 +229,6 @@ impl<'self> FromBase64 for &'self str {
 
 #[cfg(test)]
 mod tests {
-    use core::str;
-
     #[test]
     fn test_to_base64() {
         assert_eq!("".to_base64(), ~"");

--- a/src/libextra/rope.rs
+++ b/src/libextra/rope.rs
@@ -1271,7 +1271,6 @@ mod tests {
 
     use rope::*;
 
-    use core::str;
     use core::uint;
     use core::vec;
 

--- a/src/libextra/sha1.rs
+++ b/src/libextra/sha1.rs
@@ -24,7 +24,6 @@
 
 use core::prelude::*;
 
-use core::str;
 use core::uint;
 use core::vec;
 
@@ -278,8 +277,6 @@ pub fn sha1() -> @Sha1 {
 #[cfg(test)]
 mod tests {
     use sha1;
-
-    use core::vec;
 
     #[test]
     fn test() {

--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -294,11 +294,6 @@ mod tests {
 
     use super::SmallIntMap;
 
-    use core::local_data;
-    use core::rand;
-    use core::uint;
-    use core::vec;
-
     #[test]
     fn test_find_mut() {
         let mut m = SmallIntMap::new();

--- a/src/libextra/sort.rs
+++ b/src/libextra/sort.rs
@@ -751,7 +751,6 @@ fn shift_vec<T:Copy>(dest: &mut [T],
 mod test_qsort3 {
     use sort::*;
 
-    use core::vec;
 
     fn check_sort(v1: &mut [int], v2: &mut [int]) {
         let len = v1.len();
@@ -860,8 +859,6 @@ mod tests {
     use core::prelude::*;
 
     use sort::*;
-
-    use core::vec;
 
     fn check_sort(v1: &[int], v2: &[int]) {
         let len = v1.len();

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -12,7 +12,6 @@
 
 use core::prelude::*;
 
-use core::vec;
 use core::f64;
 use core::cmp;
 use core::num;

--- a/src/libextra/std.rc
+++ b/src/libextra/std.rc
@@ -37,6 +37,7 @@ not required in or otherwise suitable for the core library.
 
 extern mod core(name = "std", vers = "0.7-pre");
 
+#[cfg(stage0)]
 use core::{str, unstable};
 use core::str::{StrSlice, OwnedStr};
 

--- a/src/libextra/tempfile.rs
+++ b/src/libextra/tempfile.rs
@@ -36,7 +36,6 @@ mod tests {
     use tempfile::mkdtemp;
 
     use core::os;
-    use core::str;
 
     #[test]
     fn test_mkdtemp() {

--- a/src/libextra/terminfo/parser/compiled.rs
+++ b/src/libextra/terminfo/parser/compiled.rs
@@ -313,7 +313,6 @@ pub fn parse(file: @Reader, longnames: bool) -> Result<~TermInfo, ~str> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use p = core::path::Path;
 
     #[test]
     fn test_veclens() {

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -26,7 +26,6 @@ use core::either;
 use core::io;
 use core::option;
 use core::result;
-use core::str;
 use core::task;
 use core::to_str::ToStr;
 use core::uint;
@@ -542,7 +541,7 @@ pub fn filter_tests(
 
     // Sort the tests alphabetically
     fn lteq(t1: &TestDescAndFn, t2: &TestDescAndFn) -> bool {
-        str::le(t1.desc.name.to_str(), t2.desc.name.to_str())
+        t1.desc.name.to_str() < t2.desc.name.to_str()
     }
     sort::quick_sort(filtered, lteq);
 

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -710,7 +710,6 @@ mod test_treemap {
 
     use core::rand::RngUtil;
     use core::rand;
-    use core::str;
     use core::vec;
 
     #[test]

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -199,9 +199,6 @@ pub fn minimize_rpaths(rpaths: &[Path]) -> ~[Path] {
 mod test {
     use core::prelude::*;
 
-    use core::os;
-    use core::str;
-
     // FIXME(#2119): the outer attribute should be #[cfg(unix, test)], then
     // these redundant #[cfg(test)] blocks can be removed
     #[cfg(test)]

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -15,7 +15,6 @@ use cstore = metadata::cstore;
 use driver::session::Session;
 use e = metadata::encoder;
 use metadata::decoder;
-use metadata::encoder;
 use metadata::tydecode;
 use metadata::tydecode::{DefIdSource, NominalType, TypeWithId, TypeParameter};
 use metadata::tyencode;

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -4845,7 +4845,7 @@ impl Resolver {
         let mut smallest = 0;
         for maybes.eachi |i, &other| {
 
-            values[i] = str::levdistance(name, other);
+            values[i] = name.lev_distance(other);
 
             if values[i] <= values[smallest] {
                 smallest = i;

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -47,7 +47,6 @@
 use core::container::Map;
 use core::libc::c_ulonglong;
 use core::option::{Option, Some, None};
-use core::str;
 use core::vec;
 
 use lib::llvm::{ValueRef, TypeRef, True, IntEQ, IntNE};

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -71,7 +71,6 @@ use core::libc::c_uint;
 use core::str;
 use core::uint;
 use core::vec;
-use core::local_data;
 use extra::time;
 use syntax::ast::ident;
 use syntax::ast_map::{path, path_elt_to_str, path_name};
@@ -3120,4 +3119,3 @@ pub fn trans_crate(sess: session::Session,
 
     return (llcx, llmod, link_meta);
 }
-

--- a/src/librustdoc/astsrv.rs
+++ b/src/librustdoc/astsrv.rs
@@ -32,8 +32,6 @@ use syntax::ast;
 use syntax::ast_map;
 use syntax;
 
-#[cfg(test)] use core::vec;
-
 pub struct Ctxt {
     ast: @ast::crate,
     ast_map: ast_map::map

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -129,14 +129,12 @@ fn first_sentence_(s: &str) -> ~str {
         }
     });
     match idx {
-        Some(idx) if idx > 2u => {
-            str::to_owned(s.slice(0, idx - 1))
-        }
+        Some(idx) if idx > 2u => s.slice(0, idx - 1).to_owned(),
         _ => {
             if s.ends_with(".") {
-                str::to_owned(s)
+                s.to_owned()
             } else {
-                str::to_owned(s)
+                s.to_owned()
             }
         }
     }

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -143,11 +143,9 @@ fn first_sentence_(s: &str) -> ~str {
 }
 
 pub fn paragraphs(s: &str) -> ~[~str] {
-    let mut lines = ~[];
-    for str::each_line_any(s) |line| { lines.push(line.to_owned()); }
     let mut whitespace_lines = 0;
     let mut accum = ~"";
-    let paras = do lines.iter().fold(~[]) |paras, line| {
+    let paras = do s.any_line_iter().fold(~[]) |paras, line| {
         let mut res = paras;
 
         if line.is_whitespace() {
@@ -163,9 +161,9 @@ pub fn paragraphs(s: &str) -> ~[~str] {
             whitespace_lines = 0;
 
             accum = if accum.is_empty() {
-                copy *line
+                line.to_owned()
             } else {
-                accum + "\n" + *line
+                fmt!("%s\n%s", accum, line)
             }
         }
 

--- a/src/librustdoc/desc_to_brief_pass.rs
+++ b/src/librustdoc/desc_to_brief_pass.rs
@@ -24,7 +24,6 @@ use fold::Fold;
 use fold;
 use pass::Pass;
 
-use core::str;
 use core::util;
 
 pub fn mk_pass() -> Pass {

--- a/src/librustdoc/extract.rs
+++ b/src/librustdoc/extract.rs
@@ -285,8 +285,6 @@ mod test {
     use extract::{extract, from_srv};
     use parse;
 
-    use core::vec;
-
     fn mk_doc(source: @str) -> doc::Doc {
         let ast = parse::from_str(source);
         extract(ast, ~"")

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -22,6 +22,7 @@ use markdown_writer::WriterFactory;
 use pass::Pass;
 use sort_pass;
 
+use core::iterator::IteratorUtil;
 use core::cell::Cell;
 use core::str;
 use core::vec;
@@ -466,10 +467,7 @@ fn write_variant(ctxt: &Ctxt, doc: doc::VariantDoc) {
 }
 
 fn list_item_indent(item: &str) -> ~str {
-    let mut indented = ~[];
-    for str::each_line_any(item) |line| {
-        indented.push(line);
-    }
+    let indented = item.any_line_iter().collect::<~[&str]>();
 
     // separate markdown elements within `*` lists must be indented by four
     // spaces, or they will escape the list context. indenting everything

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -22,7 +22,6 @@ use markdown_writer::WriterFactory;
 use pass::Pass;
 use sort_pass;
 
-use core::iterator::IteratorUtil;
 use core::cell::Cell;
 use core::str;
 use core::vec;

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -537,8 +537,6 @@ mod test {
     use tystr_pass;
     use unindent_pass;
 
-    use core::str;
-
     fn render(source: ~str) -> ~str {
         let (srv, doc) = create_doc_srv(source);
         let markdown = write_markdown_str_srv(srv, doc);

--- a/src/librustdoc/page_pass.rs
+++ b/src/librustdoc/page_pass.rs
@@ -157,7 +157,6 @@ mod test {
     use doc;
     use extract;
     use page_pass::run;
-    use core::vec;
 
     fn mk_doc_(
         output_style: config::OutputStyle,

--- a/src/librustdoc/prune_hidden_pass.rs
+++ b/src/librustdoc/prune_hidden_pass.rs
@@ -77,8 +77,6 @@ mod test {
 
     #[test]
     fn should_prune_hidden_items() {
-        use core::vec;
-
         let doc = mk_doc(~"#[doc(hidden)] mod a { }");
         assert!(doc.cratemod().mods().is_empty())
     }

--- a/src/librustdoc/prune_private_pass.rs
+++ b/src/librustdoc/prune_private_pass.rs
@@ -162,7 +162,6 @@ mod test {
     use extract;
     use tystr_pass;
     use prune_private_pass::run;
-    use core::vec;
 
     fn mk_doc(source: ~str) -> doc::Doc {
         do astsrv::from_str(copy source) |srv| {

--- a/src/librustdoc/sectionalize_pass.rs
+++ b/src/librustdoc/sectionalize_pass.rs
@@ -19,7 +19,7 @@ use fold::Fold;
 use fold;
 use pass::Pass;
 
-use core::str;
+use core::iterator::IteratorUtil;
 
 pub fn mk_pass() -> Pass {
     Pass {
@@ -104,21 +104,19 @@ fn sectionalize(desc: Option<~str>) -> (Option<~str>, ~[doc::Section]) {
     if desc.is_none() {
         return (None, ~[]);
     }
-    let mut lines = ~[];
-    for str::each_line_any(*desc.get_ref()) |line| { lines.push(line.to_owned()); }
 
     let mut new_desc = None::<~str>;
     let mut current_section = None;
     let mut sections = ~[];
 
-    for lines.each |line| {
-        match parse_header(copy *line) {
+    for desc.get_ref().any_line_iter().advance |line| {
+        match parse_header(line) {
           Some(header) => {
             if current_section.is_some() {
-                sections += [copy *current_section.get_ref()];
+                sections.push(copy *current_section.get_ref());
             }
             current_section = Some(doc::Section {
-                header: header,
+                header: header.to_owned(),
                 body: ~""
             });
           }
@@ -126,17 +124,17 @@ fn sectionalize(desc: Option<~str>) -> (Option<~str>, ~[doc::Section]) {
             match copy current_section {
               Some(section) => {
                 current_section = Some(doc::Section {
-                    body: section.body + "\n" + *line,
+                    body: fmt!("%s\n%s", section.body, line),
                     .. section
                 });
               }
               None => {
                 new_desc = match copy new_desc {
                   Some(desc) => {
-                    Some(desc + "\n" + *line)
+                    Some(fmt!("%s\n%s", desc, line))
                   }
                   None => {
-                    Some(copy *line)
+                    Some(line.to_owned())
                   }
                 };
               }
@@ -146,15 +144,15 @@ fn sectionalize(desc: Option<~str>) -> (Option<~str>, ~[doc::Section]) {
     }
 
     if current_section.is_some() {
-        sections += [current_section.get()];
+        sections.push(current_section.unwrap());
     }
 
     (new_desc, sections)
 }
 
-fn parse_header(line: ~str) -> Option<~str> {
+fn parse_header<'a>(line: &'a str) -> Option<&'a str> {
     if line.starts_with("# ") {
-        Some(line.slice(2u, line.len()).to_owned())
+        Some(line.slice_from(2))
     } else {
         None
     }

--- a/src/librustdoc/sectionalize_pass.rs
+++ b/src/librustdoc/sectionalize_pass.rs
@@ -170,9 +170,6 @@ mod test {
     use extract;
     use sectionalize_pass::run;
 
-    use core::str;
-    use core::vec;
-
     fn mk_doc(source: ~str) -> doc::Doc {
         do astsrv::from_str(copy source) |srv| {
             let doc = extract::from_srv(srv.clone(), ~"");

--- a/src/librustdoc/text_pass.rs
+++ b/src/librustdoc/text_pass.rs
@@ -149,8 +149,6 @@ mod test {
     use sectionalize_pass;
     use text_pass::mk_pass;
 
-    use core::str;
-
     fn mk_doc(source: ~str) -> doc::Doc {
         do astsrv::from_str(copy source) |srv| {
             let doc = extract::from_srv(srv.clone(), ~"");

--- a/src/librusti/rusti.rc
+++ b/src/librusti/rusti.rc
@@ -370,7 +370,7 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
                     if arg.ends_with(".rs") || arg.ends_with(".rc") {
                     (arg.slice_to(arg.len() - 3).to_owned(), copy *arg)
                 } else {
-                    (copy *arg, arg + ".rs")
+                    (copy *arg, *arg + ".rs")
                 };
                 match compile_crate(filename, copy repl.binary) {
                     Some(_) => loaded_crates.push(crate),

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -144,7 +144,7 @@ pub mod win32 {
     }
 
     pub fn as_utf16_p<T>(s: &str, f: &fn(*u16) -> T) -> T {
-        let mut t = str::to_utf16(s);
+        let mut t = s.to_utf16();
         // Null terminate before passing on.
         t += [0u16];
         vec::as_imm_buf(t, |buf, _len| f(buf))

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -947,7 +947,6 @@ pub mod windows {
 mod tests {
     use option::{None, Some};
     use path::{PosixPath, WindowsPath, windows};
-    use str;
 
     #[test]
     fn test_double_slash_collapsing() {

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -515,7 +515,7 @@ impl GenericPath for PosixPath {
     fn with_filestem(&self, s: &str) -> PosixPath {
         match self.filetype() {
             None => self.with_filename(s),
-            Some(ref t) => self.with_filename(str::to_owned(s) + *t),
+            Some(ref t) => self.with_filename(s.to_owned() + *t),
         }
     }
 
@@ -657,7 +657,7 @@ impl GenericPath for WindowsPath {
             (None, None) => {
                 host = None;
                 device = None;
-                rest = str::to_owned(s);
+                rest = s.to_owned();
             }
         }
 
@@ -729,7 +729,7 @@ impl GenericPath for WindowsPath {
     fn with_filestem(&self, s: &str) -> WindowsPath {
         match self.filetype() {
             None => self.with_filename(s),
-            Some(ref t) => self.with_filename(str::to_owned(s) + *t),
+            Some(ref t) => self.with_filename(s.to_owned() + *t),
         }
     }
 
@@ -984,7 +984,7 @@ mod tests {
     fn test_posix_paths() {
         fn t(wp: &PosixPath, s: &str) {
             let ss = wp.to_str();
-            let sss = str::to_owned(s);
+            let sss = s.to_owned();
             if (ss != sss) {
                 debug!("got %s", ss);
                 debug!("expected %s", sss);
@@ -1042,7 +1042,7 @@ mod tests {
     fn test_normalize() {
         fn t(wp: &PosixPath, s: &str) {
             let ss = wp.to_str();
-            let sss = str::to_owned(s);
+            let sss = s.to_owned();
             if (ss != sss) {
                 debug!("got %s", ss);
                 debug!("expected %s", sss);
@@ -1105,7 +1105,7 @@ mod tests {
     fn test_windows_paths() {
         fn t(wp: &WindowsPath, s: &str) {
             let ss = wp.to_str();
-            let sss = str::to_owned(s);
+            let sss = s.to_owned();
             if (ss != sss) {
                 debug!("got %s", ss);
                 debug!("expected %s", sss);

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1432,7 +1432,7 @@ impl<'self> StrSlice<'self> for &'self str {
      *
      * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      * assert_eq!("11foo1bar11".trim_chars(&'1'), "foo1bar")
      * assert_eq!("12foo1bar12".trim_chars(& &['1', '2']), "foo1bar")
      * assert_eq!("123foo1bar123".trim_chars(&|c: char| c.is_digit()), "foo1bar")
@@ -1451,7 +1451,7 @@ impl<'self> StrSlice<'self> for &'self str {
      *
      * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      * assert_eq!("11foo1bar11".trim_left_chars(&'1'), "foo1bar11")
      * assert_eq!("12foo1bar12".trim_left_chars(& &['1', '2']), "foo1bar12")
      * assert_eq!("123foo1bar123".trim_left_chars(&|c: char| c.is_digit()), "foo1bar123")
@@ -1473,7 +1473,7 @@ impl<'self> StrSlice<'self> for &'self str {
      *
      * # Example
      *
-     * ~~~
+     * ~~~ {.rust}
      * assert_eq!("11foo1bar11".trim_right_chars(&'1'), "11foo1bar")
      * assert_eq!("12foo1bar12".trim_right_chars(& &['1', '2']), "12foo1bar")
      * assert_eq!("123foo1bar123".trim_right_chars(&|c: char| c.is_digit()), "123foo1bar")

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -23,7 +23,6 @@ use cast;
 use char;
 use char::Char;
 use clone::Clone;
-use cmp::{TotalOrd, Ordering, Less, Equal, Greater};
 use container::Container;
 use iter::Times;
 use iterator::{Iterator, IteratorUtil, FilterIterator, AdditiveIterator, MapIterator};
@@ -36,8 +35,6 @@ use to_str::ToStr;
 use uint;
 use vec;
 use vec::{OwnedVector, OwnedCopyableVector, ImmutableVector};
-
-#[cfg(not(test))] use cmp::{Eq, Ord, Equiv, TotalEq};
 
 /*
 Section: Conditions
@@ -530,165 +527,6 @@ pub fn eq(a: &~str, b: &~str) -> bool {
     eq_slice(*a, *b)
 }
 
-#[cfg(not(test))]
-impl<'self> TotalOrd for &'self str {
-    #[inline]
-    fn cmp(&self, other: & &'self str) -> Ordering {
-        for self.bytes_iter().zip(other.bytes_iter()).advance |(s_b, o_b)| {
-            match s_b.cmp(&o_b) {
-                Greater => return Greater,
-                Less => return Less,
-                Equal => ()
-            }
-        }
-
-        self.len().cmp(&other.len())
-    }
-}
-
-#[cfg(not(test))]
-impl TotalOrd for ~str {
-    #[inline]
-    fn cmp(&self, other: &~str) -> Ordering { self.as_slice().cmp(&other.as_slice()) }
-}
-
-#[cfg(not(test))]
-impl TotalOrd for @str {
-    #[inline]
-    fn cmp(&self, other: &@str) -> Ordering { self.as_slice().cmp(&other.as_slice()) }
-}
-
-/// Bytewise slice less than
-#[inline]
-fn lt(a: &str, b: &str) -> bool {
-    a.cmp(& b) == Less
-}
-
-/// Bytewise less than or equal
-#[inline]
-pub fn le(a: &str, b: &str) -> bool {
-    !lt(b, a)
-}
-
-/// Bytewise greater than or equal
-#[inline]
-fn ge(a: &str, b: &str) -> bool {
-    !lt(a, b)
-}
-
-/// Bytewise greater than
-#[inline]
-fn gt(a: &str, b: &str) -> bool {
-    !le(a, b)
-}
-
-#[cfg(not(test))]
-impl<'self> Eq for &'self str {
-    #[inline(always)]
-    fn eq(&self, other: & &'self str) -> bool {
-        eq_slice((*self), (*other))
-    }
-    #[inline(always)]
-    fn ne(&self, other: & &'self str) -> bool { !(*self).eq(other) }
-}
-
-#[cfg(not(test))]
-impl Eq for ~str {
-    #[inline(always)]
-    fn eq(&self, other: &~str) -> bool {
-        eq_slice((*self), (*other))
-    }
-    #[inline(always)]
-    fn ne(&self, other: &~str) -> bool { !(*self).eq(other) }
-}
-
-#[cfg(not(test))]
-impl Eq for @str {
-    #[inline(always)]
-    fn eq(&self, other: &@str) -> bool {
-        eq_slice((*self), (*other))
-    }
-    #[inline(always)]
-    fn ne(&self, other: &@str) -> bool { !(*self).eq(other) }
-}
-
-#[cfg(not(test))]
-impl<'self> TotalEq for &'self str {
-    #[inline(always)]
-    fn equals(&self, other: & &'self str) -> bool {
-        eq_slice((*self), (*other))
-    }
-}
-
-#[cfg(not(test))]
-impl TotalEq for ~str {
-    #[inline(always)]
-    fn equals(&self, other: &~str) -> bool {
-        eq_slice((*self), (*other))
-    }
-}
-
-#[cfg(not(test))]
-impl TotalEq for @str {
-    #[inline(always)]
-    fn equals(&self, other: &@str) -> bool {
-        eq_slice((*self), (*other))
-    }
-}
-
-#[cfg(not(test))]
-impl Ord for ~str {
-    #[inline(always)]
-    fn lt(&self, other: &~str) -> bool { lt((*self), (*other)) }
-    #[inline(always)]
-    fn le(&self, other: &~str) -> bool { le((*self), (*other)) }
-    #[inline(always)]
-    fn ge(&self, other: &~str) -> bool { ge((*self), (*other)) }
-    #[inline(always)]
-    fn gt(&self, other: &~str) -> bool { gt((*self), (*other)) }
-}
-
-#[cfg(not(test))]
-impl<'self> Ord for &'self str {
-    #[inline(always)]
-    fn lt(&self, other: & &'self str) -> bool { lt((*self), (*other)) }
-    #[inline(always)]
-    fn le(&self, other: & &'self str) -> bool { le((*self), (*other)) }
-    #[inline(always)]
-    fn ge(&self, other: & &'self str) -> bool { ge((*self), (*other)) }
-    #[inline(always)]
-    fn gt(&self, other: & &'self str) -> bool { gt((*self), (*other)) }
-}
-
-#[cfg(not(test))]
-impl Ord for @str {
-    #[inline(always)]
-    fn lt(&self, other: &@str) -> bool { lt((*self), (*other)) }
-    #[inline(always)]
-    fn le(&self, other: &@str) -> bool { le((*self), (*other)) }
-    #[inline(always)]
-    fn ge(&self, other: &@str) -> bool { ge((*self), (*other)) }
-    #[inline(always)]
-    fn gt(&self, other: &@str) -> bool { gt((*self), (*other)) }
-}
-
-#[cfg(not(test))]
-impl<'self, S: Str> Equiv<S> for &'self str {
-    #[inline(always)]
-    fn equiv(&self, other: &S) -> bool { eq_slice(*self, other.as_slice()) }
-}
-#[cfg(not(test))]
-impl<'self, S: Str> Equiv<S> for @str {
-    #[inline(always)]
-    fn equiv(&self, other: &S) -> bool { eq_slice(*self, other.as_slice()) }
-}
-
-#[cfg(not(test))]
-impl<'self, S: Str> Equiv<S> for ~str {
-    #[inline(always)]
-    fn equiv(&self, other: &S) -> bool { eq_slice(*self, other.as_slice()) }
-}
-
 /*
 Section: Searching
 */
@@ -1072,11 +910,135 @@ pub mod raw {
 #[cfg(not(test))]
 pub mod traits {
     use ops::Add;
+    use cmp::{TotalOrd, Ordering, Less, Equal, Greater, Eq, Ord, Equiv, TotalEq};
+    use super::{Str, eq_slice};
+
     impl<'self> Add<&'self str,~str> for ~str {
         #[inline(always)]
         fn add(&self, rhs: & &'self str) -> ~str {
             self.append((*rhs))
         }
+    }
+
+    impl<'self> TotalOrd for &'self str {
+        #[inline]
+        fn cmp(&self, other: & &'self str) -> Ordering {
+            for self.bytes_iter().zip(other.bytes_iter()).advance |(s_b, o_b)| {
+                match s_b.cmp(&o_b) {
+                    Greater => return Greater,
+                    Less => return Less,
+                    Equal => ()
+                }
+            }
+
+            self.len().cmp(&other.len())
+        }
+    }
+
+    impl TotalOrd for ~str {
+        #[inline]
+        fn cmp(&self, other: &~str) -> Ordering { self.as_slice().cmp(&other.as_slice()) }
+    }
+
+    impl TotalOrd for @str {
+        #[inline]
+        fn cmp(&self, other: &@str) -> Ordering { self.as_slice().cmp(&other.as_slice()) }
+    }
+
+    impl<'self> Eq for &'self str {
+        #[inline(always)]
+        fn eq(&self, other: & &'self str) -> bool {
+            eq_slice((*self), (*other))
+        }
+        #[inline(always)]
+        fn ne(&self, other: & &'self str) -> bool { !(*self).eq(other) }
+    }
+
+    impl Eq for ~str {
+        #[inline(always)]
+        fn eq(&self, other: &~str) -> bool {
+            eq_slice((*self), (*other))
+        }
+        #[inline(always)]
+        fn ne(&self, other: &~str) -> bool { !(*self).eq(other) }
+    }
+
+    impl Eq for @str {
+        #[inline(always)]
+        fn eq(&self, other: &@str) -> bool {
+            eq_slice((*self), (*other))
+        }
+        #[inline(always)]
+        fn ne(&self, other: &@str) -> bool { !(*self).eq(other) }
+    }
+
+    impl<'self> TotalEq for &'self str {
+        #[inline(always)]
+        fn equals(&self, other: & &'self str) -> bool {
+            eq_slice((*self), (*other))
+        }
+    }
+
+    impl TotalEq for ~str {
+        #[inline(always)]
+        fn equals(&self, other: &~str) -> bool {
+            eq_slice((*self), (*other))
+        }
+    }
+
+    impl TotalEq for @str {
+        #[inline(always)]
+        fn equals(&self, other: &@str) -> bool {
+            eq_slice((*self), (*other))
+        }
+    }
+
+    impl<'self> Ord for &'self str {
+        #[inline(always)]
+        fn lt(&self, other: & &'self str) -> bool { self.cmp(other) == Less }
+        #[inline(always)]
+        fn le(&self, other: & &'self str) -> bool { self.cmp(other) != Greater }
+        #[inline(always)]
+        fn ge(&self, other: & &'self str) -> bool { self.cmp(other) != Less }
+        #[inline(always)]
+        fn gt(&self, other: & &'self str) -> bool { self.cmp(other) == Greater }
+    }
+
+    impl Ord for ~str {
+        #[inline(always)]
+        fn lt(&self, other: &~str) -> bool { self.cmp(other) == Less }
+        #[inline(always)]
+        fn le(&self, other: &~str) -> bool { self.cmp(other) != Greater }
+        #[inline(always)]
+        fn ge(&self, other: &~str) -> bool { self.cmp(other) != Less }
+        #[inline(always)]
+        fn gt(&self, other: &~str) -> bool { self.cmp(other) == Greater }
+    }
+
+    impl Ord for @str {
+        #[inline(always)]
+        fn lt(&self, other: &@str) -> bool { self.cmp(other) == Less }
+        #[inline(always)]
+        fn le(&self, other: &@str) -> bool { self.cmp(other) != Greater }
+        #[inline(always)]
+        fn ge(&self, other: &@str) -> bool { self.cmp(other) != Less }
+        #[inline(always)]
+        fn gt(&self, other: &@str) -> bool { self.cmp(other) == Greater }
+    }
+
+    impl<'self, S: Str> Equiv<S> for &'self str {
+        #[inline(always)]
+        fn equiv(&self, other: &S) -> bool { eq_slice(*self, other.as_slice()) }
+    }
+
+    impl<'self, S: Str> Equiv<S> for @str {
+        #[inline(always)]
+        fn equiv(&self, other: &S) -> bool { eq_slice(*self, other.as_slice()) }
+    }
+
+    impl<'self, S: Str> Equiv<S> for ~str {
+        #[inline(always)]
+        fn equiv(&self, other: &S) -> bool { eq_slice(*self, other.as_slice()) }
     }
 }
 
@@ -2267,10 +2229,10 @@ mod tests {
 
     #[test]
     fn test_le() {
-        assert!((le(&"", &"")));
-        assert!((le(&"", &"foo")));
-        assert!((le(&"foo", &"foo")));
-        assert!((!eq(&~"foo", &~"bar")));
+        assert!("" <= "");
+        assert!("" <= "foo");
+        assert!("foo" <= "foo");
+        assert!("foo" != ~"bar");
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -913,10 +913,12 @@ pub mod traits {
     use cmp::{TotalOrd, Ordering, Less, Equal, Greater, Eq, Ord, Equiv, TotalEq};
     use super::{Str, eq_slice};
 
-    impl<'self> Add<&'self str,~str> for ~str {
+    impl<'self> Add<&'self str,~str> for &'self str {
         #[inline(always)]
         fn add(&self, rhs: & &'self str) -> ~str {
-            self.append((*rhs))
+            let mut ret = self.to_owned();
+            ret.push_str(*rhs);
+            ret
         }
     }
 
@@ -3135,6 +3137,24 @@ mod tests {
     #[test]
     fn test_char_range_at_reverse_underflow() {
         assert_eq!("abc".char_range_at_reverse(0).next, 0);
+    }
+
+    #[test]
+    fn test_add() {
+        macro_rules! t (
+            ($s1:expr, $s2:expr, $e:expr) => {
+                assert_eq!($s1 + $s2, $e);
+                assert_eq!($s1.to_owned() + $s2, $e);
+                assert_eq!($s1.to_managed() + $s2, $e);
+            }
+        );
+
+        t!("foo",  "bar", ~"foobar");
+        t!("foo", @"bar", ~"foobar");
+        t!("foo", ~"bar", ~"foobar");
+        t!("ศไทย中",  "华Việt Nam", ~"ศไทย中华Việt Nam");
+        t!("ศไทย中", @"华Việt Nam", ~"ศไทย中华Việt Nam");
+        t!("ศไทย中", ~"华Việt Nam", ~"ศไทย中华Việt Nam");
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -530,54 +530,38 @@ pub fn eq(a: &~str, b: &~str) -> bool {
     eq_slice(*a, *b)
 }
 
-#[inline]
-fn cmp(a: &str, b: &str) -> Ordering {
-    let low = uint::min(a.len(), b.len());
-
-    for uint::range(0, low) |idx| {
-        match a[idx].cmp(&b[idx]) {
-          Greater => return Greater,
-          Less => return Less,
-          Equal => ()
-        }
-    }
-
-    a.len().cmp(&b.len())
-}
-
 #[cfg(not(test))]
 impl<'self> TotalOrd for &'self str {
     #[inline]
-    fn cmp(&self, other: & &'self str) -> Ordering { cmp(*self, *other) }
+    fn cmp(&self, other: & &'self str) -> Ordering {
+        for self.bytes_iter().zip(other.bytes_iter()).advance |(s_b, o_b)| {
+            match s_b.cmp(&o_b) {
+                Greater => return Greater,
+                Less => return Less,
+                Equal => ()
+            }
+        }
+
+        self.len().cmp(&other.len())
+    }
 }
 
 #[cfg(not(test))]
 impl TotalOrd for ~str {
     #[inline]
-    fn cmp(&self, other: &~str) -> Ordering { cmp(*self, *other) }
+    fn cmp(&self, other: &~str) -> Ordering { self.as_slice().cmp(&other.as_slice()) }
 }
 
 #[cfg(not(test))]
 impl TotalOrd for @str {
     #[inline]
-    fn cmp(&self, other: &@str) -> Ordering { cmp(*self, *other) }
+    fn cmp(&self, other: &@str) -> Ordering { self.as_slice().cmp(&other.as_slice()) }
 }
 
 /// Bytewise slice less than
 #[inline]
 fn lt(a: &str, b: &str) -> bool {
-    let (a_len, b_len) = (a.len(), b.len());
-    let end = uint::min(a_len, b_len);
-
-    let mut i = 0;
-    while i < end {
-        let (c_a, c_b) = (a[i], b[i]);
-        if c_a < c_b { return true; }
-        if c_a > c_b { return false; }
-        i += 1;
-    }
-
-    return a_len < b_len;
+    a.cmp(& b) == Less
 }
 
 /// Bytewise less than or equal

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -39,8 +39,6 @@ pub mod rt {
     use parse;
     use print::pprust;
 
-    use core::str;
-
     pub use ast::*;
     pub use parse::token::*;
     pub use parse::new_parser_from_tts;

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -969,7 +969,7 @@ mod test {
     // change every identifier to "zz"
     pub fn to_zz() -> @fn(ast::ident)->ast::ident {
         let zz_id = token::str_to_ident("zz");
-        |id| {zz_id}
+        |_id| {zz_id}
     }
 
     // maybe add to expand.rs...

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -89,12 +89,11 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         }
 
         return do lines.map |line| {
-            let mut chars = ~[];
-            for line.iter().advance |c| { chars.push(c) }
+            let chars = line.iter().collect::<~[char]>();
             if i > chars.len() {
                 ~""
             } else {
-                str::from_chars(chars.slice(i, chars.len()).to_owned())
+                str::from_chars(chars.slice(i, chars.len()))
             }
         };
     }
@@ -103,14 +102,13 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         // FIXME #5475:
         // return comment.slice(3u, comment.len()).trim().to_owned();
         let r = comment.slice(3u, comment.len()); return r.trim().to_owned();
-
     }
 
     if comment.starts_with("/*") {
-        let mut lines = ~[];
-        for str::each_line_any(comment.slice(3u, comment.len() - 2u)) |line| {
-            lines.push(line.to_owned())
-        }
+        let lines = comment.slice(3u, comment.len() - 2u)
+            .any_line_iter()
+            .transform(|s| s.to_owned())
+            .collect::<~[~str]>();
         let lines = vertical_trim(lines);
         let lines = block_trim(lines, ~"\t ", None);
         let lines = block_trim(lines, ~"*", Some(1u));


### PR DESCRIPTION
Moves all the remaining functions that could reasonably be methods to be methods, except for some FFI ones (which I believe @erickt is working on, possibly) and `each_split_within`, since I'm not really sure the details of it (I believe @kimundi wrote the current implementation, so maybe he could convert it to an external iterator method on `StrSlice`, e.g. `word_wrap_iter(&self) -> WordWrapIterator<'self>`, where `WordWrapIterator` impls `Iterator<&'self str>`. It probably won't be too hard, since it's already a state machine.)

This also cleans up the comparison impls for the string types, except I'm not sure how the lang items `eq_str` and `eq_str_uniq` need to be handled, so they (`eq_slice` and `eq`) remain stand-alone functions.
