### PR TITLE
Trans refactor part 1

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -18,7 +18,7 @@ use lib::llvm::ModuleRef;
 use lib;
 use metadata::common::LinkMeta;
 use metadata::{encoder, csearch, cstore};
-use middle::trans::common::CrateContext;
+use middle::trans::context::CrateContext;
 use middle::ty;
 use util::ppaux;
 

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -622,11 +622,11 @@ pub fn symbol_hash(tcx: ty::ctxt,
     hash.to_managed()
 }
 
-pub fn get_symbol_hash(ccx: @CrateContext, t: ty::t) -> @str {
+pub fn get_symbol_hash(ccx: &mut CrateContext, t: ty::t) -> @str {
     match ccx.type_hashcodes.find(&t) {
       Some(&h) => h,
       None => {
-        let hash = symbol_hash(ccx.tcx, ccx.symbol_hasher, t, ccx.link_meta);
+        let hash = symbol_hash(ccx.tcx, &mut ccx.symbol_hasher, t, ccx.link_meta);
         ccx.type_hashcodes.insert(t, hash);
         hash
       }
@@ -705,7 +705,7 @@ pub fn exported_name(sess: Session,
             path_name(sess.ident_of(vers))));
 }
 
-pub fn mangle_exported_name(ccx: @CrateContext,
+pub fn mangle_exported_name(ccx: &mut CrateContext,
                             path: path,
                             t: ty::t) -> ~str {
     let hash = get_symbol_hash(ccx, t);
@@ -714,7 +714,7 @@ pub fn mangle_exported_name(ccx: @CrateContext,
                          ccx.link_meta.vers);
 }
 
-pub fn mangle_internal_name_by_type_only(ccx: @CrateContext,
+pub fn mangle_internal_name_by_type_only(ccx: &mut CrateContext,
                                          t: ty::t,
                                          name: &str) -> ~str {
     let s = ppaux::ty_to_short_str(ccx.tcx, t);
@@ -725,7 +725,7 @@ pub fn mangle_internal_name_by_type_only(ccx: @CrateContext,
           path_name(ccx.sess.ident_of(hash))]);
 }
 
-pub fn mangle_internal_name_by_type_and_seq(ccx: @CrateContext,
+pub fn mangle_internal_name_by_type_and_seq(ccx: &mut CrateContext,
                                          t: ty::t,
                                          name: &str) -> ~str {
     let s = ppaux::ty_to_str(ccx.tcx, t);
@@ -736,18 +736,18 @@ pub fn mangle_internal_name_by_type_and_seq(ccx: @CrateContext,
           path_name((ccx.names)(name))]);
 }
 
-pub fn mangle_internal_name_by_path_and_seq(ccx: @CrateContext,
+pub fn mangle_internal_name_by_path_and_seq(ccx: &mut CrateContext,
                                             path: path,
                                             flav: &str) -> ~str {
     return mangle(ccx.sess,
                   vec::append_one(path, path_name((ccx.names)(flav))));
 }
 
-pub fn mangle_internal_name_by_path(ccx: @CrateContext, path: path) -> ~str {
+pub fn mangle_internal_name_by_path(ccx: &mut CrateContext, path: path) -> ~str {
     return mangle(ccx.sess, path);
 }
 
-pub fn mangle_internal_name_by_seq(ccx: @CrateContext, flav: &str) -> ~str {
+pub fn mangle_internal_name_by_seq(ccx: &mut CrateContext, flav: &str) -> ~str {
     return fmt!("%s_%u", flav, (ccx.names)(flav).name);
 }
 

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1314,7 +1314,7 @@ pub fn compile_submatch(bcx: block,
 
     let vals_left = vec::append(vec::slice(vals, 0u, col).to_vec(),
                                 vec::slice(vals, col + 1u, vals.len()));
-    let ccx = *bcx.fcx.ccx;
+    let ccx = bcx.fcx.ccx;
     let mut pat_id = 0;
     let mut pat_span = dummy_sp();
     for m.each |br| {
@@ -1755,7 +1755,7 @@ pub fn bind_irrefutable_pat(bcx: block,
                             binding_mode: IrrefutablePatternBindingMode)
                          -> block {
     let _icx = bcx.insn_ctxt("match::bind_irrefutable_pat");
-    let ccx = *bcx.fcx.ccx;
+    let ccx = bcx.fcx.ccx;
     let mut bcx = bcx;
 
     // Necessary since bind_irrefutable_pat is called outside trans_match

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -3114,20 +3114,10 @@ pub fn trans_crate(sess: session::Session,
             io::println(fmt!("%-7u %s", v, k));
         }
     }
-    return (llmod, link_meta);
+    let llcx = ccx.llcx;
+    let link_meta = ccx.link_meta;
+    let llmod = ccx.llmod;
+
+    return (llcx, llmod, link_meta);
 }
 
-fn task_local_llcx_key(_v: @ContextRef) {}
-
-pub fn task_llcx() -> ContextRef {
-    let opt = unsafe { local_data::local_data_get(task_local_llcx_key) };
-    *opt.expect("task-local LLVMContextRef wasn't ever set!")
-}
-
-unsafe fn set_task_llcx(c: ContextRef) {
-    local_data::local_data_set(task_local_llcx_key, @c);
-}
-
-unsafe fn unset_task_llcx() {
-    local_data::local_data_pop(task_local_llcx_key);
-}

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -88,7 +88,7 @@ use syntax::abi::{X86, X86_64, Arm, Mips};
 pub use middle::trans::context::task_llcx;
 
 pub struct icx_popper {
-    ccx: @CrateContext,
+    ccx: @mut CrateContext,
 }
 
 #[unsafe_destructor]
@@ -100,7 +100,7 @@ impl Drop for icx_popper {
     }
 }
 
-pub fn icx_popper(ccx: @CrateContext) -> icx_popper {
+pub fn icx_popper(ccx: @mut CrateContext) -> icx_popper {
     icx_popper {
         ccx: ccx
     }
@@ -110,7 +110,7 @@ pub trait get_insn_ctxt {
     fn insn_ctxt(&self, s: &str) -> icx_popper;
 }
 
-impl get_insn_ctxt for @CrateContext {
+impl get_insn_ctxt for @mut CrateContext {
     fn insn_ctxt(&self, s: &str) -> icx_popper {
         debug!("new insn_ctxt: %s", s);
         if self.sess.count_llvm_insns() {
@@ -139,7 +139,7 @@ fn fcx_has_nonzero_span(fcx: fn_ctxt) -> bool {
     }
 }
 
-pub fn log_fn_time(ccx: @CrateContext, name: ~str, start: time::Timespec,
+pub fn log_fn_time(ccx: @mut CrateContext, name: ~str, start: time::Timespec,
                    end: time::Timespec) {
     let elapsed = 1000 * ((end.sec - start.sec) as int) +
         ((end.nsec as int) - (start.nsec as int)) / 1000000;
@@ -175,7 +175,7 @@ pub fn decl_internal_cdecl_fn(llmod: ModuleRef, name: ~str, llty: TypeRef) ->
     return llfn;
 }
 
-pub fn get_extern_fn(externs: ExternMap,
+pub fn get_extern_fn(externs: &mut ExternMap,
                      llmod: ModuleRef,
                      name: @str,
                      cc: lib::llvm::CallConv,
@@ -189,7 +189,7 @@ pub fn get_extern_fn(externs: ExternMap,
     return f;
 }
 
-pub fn get_extern_const(externs: ExternMap, llmod: ModuleRef,
+pub fn get_extern_const(externs: &mut ExternMap, llmod: ModuleRef,
                         name: @str, ty: TypeRef) -> ValueRef {
     match externs.find(&name) {
         Some(n) => return copy *n,
@@ -204,11 +204,11 @@ pub fn get_extern_const(externs: ExternMap, llmod: ModuleRef,
     }
 }
 
-    fn get_simple_extern_fn(cx: block,
-                            externs: ExternMap,
-                            llmod: ModuleRef,
-                            name: @str,
-                            n_args: int) -> ValueRef {
+fn get_simple_extern_fn(cx: block,
+                        externs: &mut ExternMap,
+                        llmod: ModuleRef,
+                        name: @str,
+                        n_args: int) -> ValueRef {
     let _icx = cx.insn_ctxt("get_simple_extern_fn");
     let ccx = cx.fcx.ccx;
     let inputs = vec::from_elem(n_args as uint, ccx.int_type);
@@ -217,7 +217,7 @@ pub fn get_extern_const(externs: ExternMap, llmod: ModuleRef,
     return get_extern_fn(externs, llmod, name, lib::llvm::CCallConv, t);
 }
 
-pub fn trans_foreign_call(cx: block, externs: ExternMap,
+pub fn trans_foreign_call(cx: block, externs: &mut ExternMap,
                           llmod: ModuleRef, name: @str, args: &[ValueRef]) ->
    ValueRef {
     let _icx = cx.insn_ctxt("trans_foreign_call");
@@ -269,7 +269,9 @@ pub fn opaque_box_body(bcx: block,
                        boxptr: ValueRef) -> ValueRef {
     let _icx = bcx.insn_ctxt("opaque_box_body");
     let ccx = bcx.ccx();
-    let boxptr = PointerCast(bcx, boxptr, T_ptr(T_box(ccx, type_of(ccx, body_t))));
+    let ty = type_of(ccx, body_t);
+    let ty = T_box(ccx, ty);
+    let boxptr = PointerCast(bcx, boxptr, T_ptr(ty));
     GEPi(bcx, boxptr, [0u, abi::box_field_body])
 }
 
@@ -335,7 +337,9 @@ pub fn non_gc_box_cast(bcx: block, val: ValueRef) -> ValueRef {
 // enough space for a box of that type.  This includes a rust_opaque_box
 // header.
 pub fn malloc_raw(bcx: block, t: ty::t, heap: heap) -> Result {
-    malloc_raw_dyn(bcx, t, heap, llsize_of(bcx.ccx(), type_of(bcx.ccx(), t)))
+    let ty = type_of(bcx.ccx(), t);
+    let size = llsize_of(bcx.ccx(), ty);
+    malloc_raw_dyn(bcx, t, heap, size)
 }
 
 pub struct MallocResult {
@@ -358,8 +362,8 @@ pub fn malloc_general_dyn(bcx: block, t: ty::t, heap: heap, size: ValueRef)
 
 pub fn malloc_general(bcx: block, t: ty::t, heap: heap)
     -> MallocResult {
-    malloc_general_dyn(bcx, t, heap,
-                       llsize_of(bcx.ccx(), type_of(bcx.ccx(), t)))
+        let ty = type_of(bcx.ccx(), t);
+    malloc_general_dyn(bcx, t, heap, llsize_of(bcx.ccx(), ty))
 }
 pub fn malloc_boxed(bcx: block, t: ty::t)
     -> MallocResult {
@@ -381,7 +385,8 @@ pub fn maybe_set_managed_unique_rc(bcx: block, bx: ValueRef, heap: heap) {
         // such as a ~(@foo) or such. These need to have their refcount forced
         // to -2 so the annihilator ignores them.
         let rc = GEPi(bcx, bx, [0u, abi::box_field_refcnt]);
-        Store(bcx, C_int(bcx.ccx(), -2), rc);
+        let rc_val = C_int(bcx.ccx(), -2);
+        Store(bcx, rc_val, rc);
     }
 }
 
@@ -392,11 +397,11 @@ pub fn malloc_unique(bcx: block, t: ty::t)
 
 // Type descriptor and type glue stuff
 
-pub fn get_tydesc_simple(ccx: @CrateContext, t: ty::t) -> ValueRef {
+pub fn get_tydesc_simple(ccx: &mut CrateContext, t: ty::t) -> ValueRef {
     get_tydesc(ccx, t).tydesc
 }
 
-pub fn get_tydesc(ccx: @CrateContext, t: ty::t) -> @mut tydesc_info {
+pub fn get_tydesc(ccx: &mut CrateContext, t: ty::t) -> @mut tydesc_info {
     match ccx.tydescs.find(&t) {
         Some(&inf) => {
             return inf;
@@ -485,7 +490,7 @@ pub fn set_glue_inlining(f: ValueRef, t: ty::t) {
 
 // Double-check that we never ask LLVM to declare the same symbol twice. It
 // silently mangles such symbols, breaking our linkage model.
-pub fn note_unique_llvm_symbol(ccx: @CrateContext, sym: @str) {
+pub fn note_unique_llvm_symbol(ccx: &mut CrateContext, sym: @str) {
     if ccx.all_llvm_symbols.contains(&sym) {
         ccx.sess.bug(~"duplicate LLVM symbol: " + sym);
     }
@@ -493,7 +498,7 @@ pub fn note_unique_llvm_symbol(ccx: @CrateContext, sym: @str) {
 }
 
 
-pub fn get_res_dtor(ccx: @CrateContext,
+pub fn get_res_dtor(ccx: @mut CrateContext,
                     did: ast::def_id,
                     parent_id: ast::def_id,
                     substs: &[ty::t])
@@ -527,7 +532,7 @@ pub fn get_res_dtor(ccx: @CrateContext,
                                      ty::lookup_item_type(tcx, parent_id).ty);
         let llty = type_of_dtor(ccx, class_ty);
         let name = name.to_managed(); // :-(
-        get_extern_fn(ccx.externs,
+        get_extern_fn(&mut ccx.externs,
                       ccx.llmod,
                       name,
                       lib::llvm::CCallConv,
@@ -536,7 +541,7 @@ pub fn get_res_dtor(ccx: @CrateContext,
 }
 
 // Structural comparison: a rather involved form of glue.
-pub fn maybe_name_value(cx: @CrateContext, v: ValueRef, s: &str) {
+pub fn maybe_name_value(cx: &CrateContext, v: ValueRef, s: &str) {
     if cx.sess.opts.save_temps {
         let _: () = str::as_c_str(s, |buf| {
             unsafe {
@@ -818,18 +823,18 @@ pub fn null_env_ptr(bcx: block) -> ValueRef {
     C_null(T_opaque_box_ptr(bcx.ccx()))
 }
 
-pub fn trans_external_path(ccx: @CrateContext, did: ast::def_id, t: ty::t)
+pub fn trans_external_path(ccx: &mut CrateContext, did: ast::def_id, t: ty::t)
     -> ValueRef {
     let name = csearch::get_symbol(ccx.sess.cstore, did).to_managed(); // Sad
     match ty::get(t).sty {
       ty::ty_bare_fn(_) | ty::ty_closure(_) => {
         let llty = type_of_fn_from_ty(ccx, t);
-        return get_extern_fn(ccx.externs, ccx.llmod, name,
+        return get_extern_fn(&mut ccx.externs, ccx.llmod, name,
                              lib::llvm::CCallConv, llty);
       }
       _ => {
         let llty = type_of(ccx, t);
-        return get_extern_const(ccx.externs, ccx.llmod, name, llty);
+        return get_extern_const(&mut ccx.externs, ccx.llmod, name, llty);
       }
     };
 }
@@ -1166,7 +1171,7 @@ pub fn trans_stmt(cx: block, s: &ast::stmt) -> block {
                         debuginfo::create_local_var(bcx, *local);
                     }
                 }
-                ast::decl_item(i) => trans_item(*cx.fcx.ccx, i)
+                ast::decl_item(i) => trans_item(cx.fcx.ccx, i)
             }
         }
         ast::stmt_mac(*) => cx.tcx().sess.bug("unexpanded macro")
@@ -1456,7 +1461,7 @@ pub fn call_memcpy(cx: block, dst: ValueRef, src: ValueRef, n_bytes: ValueRef, a
         X86 | Arm | Mips => "llvm.memcpy.p0i8.p0i8.i32",
         X86_64 => "llvm.memcpy.p0i8.p0i8.i64"
     };
-    let memcpy = *ccx.intrinsics.get(&key);
+    let memcpy = ccx.intrinsics.get_copy(&key);
     let src_ptr = PointerCast(cx, src, T_ptr(T_i8()));
     let dst_ptr = PointerCast(cx, dst, T_ptr(T_i8()));
     let size = IntCast(cx, n_bytes, ccx.int_type);
@@ -1500,7 +1505,7 @@ pub fn memzero(cx: block, llptr: ValueRef, llty: TypeRef) {
         X86_64 => "llvm.memset.p0i8.i64"
     };
 
-    let llintrinsicfn = *ccx.intrinsics.get(&intrinsic_key);
+    let llintrinsicfn = ccx.intrinsics.get_copy(&intrinsic_key);
     let llptr = PointerCast(cx, llptr, T_ptr(T_i8()));
     let llzeroval = C_u8(0);
     let size = IntCast(cx, machine::llsize_of(ccx, llty), ccx.int_type);
@@ -1572,7 +1577,7 @@ pub fn make_return_pointer(fcx: fn_ctxt, output_type: ty::t) -> ValueRef {
         if !ty::type_is_immediate(output_type) {
             llvm::LLVMGetParam(fcx.llfn, 0)
         } else {
-            let lloutputtype = type_of::type_of(*fcx.ccx, output_type);
+            let lloutputtype = type_of::type_of(fcx.ccx, output_type);
             alloca(raw_block(fcx, false, fcx.llstaticallocas), lloutputtype)
         }
     }
@@ -1584,7 +1589,7 @@ pub fn make_return_pointer(fcx: fn_ctxt, output_type: ty::t) -> ValueRef {
 //  - create_llargs_for_fn_args.
 //  - new_fn_ctxt
 //  - trans_args
-pub fn new_fn_ctxt_w_id(ccx: @CrateContext,
+pub fn new_fn_ctxt_w_id(ccx: @mut CrateContext,
                         path: path,
                         llfndecl: ValueRef,
                         id: ast::node_id,
@@ -1632,7 +1637,7 @@ pub fn new_fn_ctxt_w_id(ccx: @CrateContext,
           param_substs: param_substs,
           span: sp,
           path: path,
-          ccx: @ccx
+          ccx: ccx
     };
     fcx.llenv = unsafe {
           llvm::LLVMGetParam(llfndecl, fcx.env_arg_pos() as c_uint)
@@ -1641,7 +1646,7 @@ pub fn new_fn_ctxt_w_id(ccx: @CrateContext,
     fcx
 }
 
-pub fn new_fn_ctxt(ccx: @CrateContext,
+pub fn new_fn_ctxt(ccx: @mut CrateContext,
                    path: path,
                    llfndecl: ValueRef,
                    output_type: ty::t,
@@ -1817,7 +1822,7 @@ pub enum self_arg { impl_self(ty::t), impl_owned_self(ty::t), no_self, }
 // trans_closure: Builds an LLVM function out of a source function.
 // If the function closes over its environment a closure will be
 // returned.
-pub fn trans_closure(ccx: @CrateContext,
+pub fn trans_closure(ccx: @mut CrateContext,
                      path: path,
                      decl: &ast::fn_decl,
                      body: &ast::blk,
@@ -1861,7 +1866,7 @@ pub fn trans_closure(ccx: @CrateContext,
                 llvm::LLVMSetGC(fcx.llfn, strategy);
             }
         }
-        *ccx.uses_gc = true;
+        ccx.uses_gc = true;
     }
 
     // Create the first basic block in the function and keep a handle on it to
@@ -1898,7 +1903,7 @@ pub fn trans_closure(ccx: @CrateContext,
 
 // trans_fn: creates an LLVM function corresponding to a source language
 // function.
-pub fn trans_fn(ccx: @CrateContext,
+pub fn trans_fn(ccx: @mut CrateContext,
                 path: path,
                 decl: &ast::fn_decl,
                 body: &ast::blk,
@@ -1942,7 +1947,7 @@ pub fn trans_fn(ccx: @CrateContext,
     }
 }
 
-pub fn trans_enum_variant(ccx: @CrateContext,
+pub fn trans_enum_variant(ccx: @mut CrateContext,
                           enum_id: ast::node_id,
                           variant: &ast::variant,
                           args: &[ast::variant_arg],
@@ -2018,7 +2023,7 @@ pub fn trans_enum_variant(ccx: @CrateContext,
 
 // NB: In theory this should be merged with the function above. But the AST
 // structures are completely different, so very little code would be shared.
-pub fn trans_tuple_struct(ccx: @CrateContext,
+pub fn trans_tuple_struct(ccx: @mut CrateContext,
                           fields: &[@ast::struct_field],
                           ctor_id: ast::node_id,
                           param_substs: Option<@param_substs>,
@@ -2085,7 +2090,7 @@ pub fn trans_tuple_struct(ccx: @CrateContext,
     finish_fn(fcx, lltop);
 }
 
-pub fn trans_enum_def(ccx: @CrateContext, enum_definition: &ast::enum_def,
+pub fn trans_enum_def(ccx: @mut CrateContext, enum_definition: &ast::enum_def,
                       id: ast::node_id, vi: @~[ty::VariantInfo],
                       i: &mut uint) {
     for enum_definition.variants.each |variant| {
@@ -2108,7 +2113,7 @@ pub fn trans_enum_def(ccx: @CrateContext, enum_definition: &ast::enum_def,
     }
 }
 
-pub fn trans_item(ccx: @CrateContext, item: &ast::item) {
+pub fn trans_item(ccx: @mut CrateContext, item: &ast::item) {
     let _icx = ccx.insn_ctxt("trans_item");
     let path = match ccx.tcx.items.get_copy(&item.id) {
         ast_map::node_item(_, p) => p,
@@ -2196,7 +2201,7 @@ pub fn trans_item(ccx: @CrateContext, item: &ast::item) {
     }
 }
 
-pub fn trans_struct_def(ccx: @CrateContext, struct_def: @ast::struct_def) {
+pub fn trans_struct_def(ccx: @mut CrateContext, struct_def: @ast::struct_def) {
     // If this is a tuple-like struct, translate the constructor.
     match struct_def.ctor_id {
         // We only need to translate a constructor if there are fields;
@@ -2215,14 +2220,14 @@ pub fn trans_struct_def(ccx: @CrateContext, struct_def: @ast::struct_def) {
 // separate modules in the compiled program.  That's because modules exist
 // only as a convenience for humans working with the code, to organize names
 // and control visibility.
-pub fn trans_mod(ccx: @CrateContext, m: &ast::_mod) {
+pub fn trans_mod(ccx: @mut CrateContext, m: &ast::_mod) {
     let _icx = ccx.insn_ctxt("trans_mod");
     for m.items.each |item| {
         trans_item(ccx, *item);
     }
 }
 
-pub fn register_fn(ccx: @CrateContext,
+pub fn register_fn(ccx: @mut CrateContext,
                    sp: span,
                    path: path,
                    node_id: ast::node_id,
@@ -2232,7 +2237,7 @@ pub fn register_fn(ccx: @CrateContext,
     register_fn_full(ccx, sp, path, node_id, attrs, t)
 }
 
-pub fn register_fn_full(ccx: @CrateContext,
+pub fn register_fn_full(ccx: @mut CrateContext,
                         sp: span,
                         path: path,
                         node_id: ast::node_id,
@@ -2244,7 +2249,7 @@ pub fn register_fn_full(ccx: @CrateContext,
                        lib::llvm::CCallConv, llfty)
 }
 
-pub fn register_fn_fuller(ccx: @CrateContext,
+pub fn register_fn_fuller(ccx: @mut CrateContext,
                           sp: span,
                           path: path,
                           node_id: ast::node_id,
@@ -2286,7 +2291,7 @@ pub fn is_entry_fn(sess: &Session, node_id: ast::node_id) -> bool {
 
 // Create a _rust_main(args: ~[str]) function which will be called from the
 // runtime rust_start function
-pub fn create_entry_wrapper(ccx: @CrateContext,
+pub fn create_entry_wrapper(ccx: @mut CrateContext,
                            _sp: span, main_llfn: ValueRef) {
     let et = ccx.sess.entry_type.unwrap();
     if et == session::EntryMain {
@@ -2296,7 +2301,7 @@ pub fn create_entry_wrapper(ccx: @CrateContext,
         create_entry_fn(ccx, main_llfn, false);
     }
 
-    fn create_main(ccx: @CrateContext, main_llfn: ValueRef) -> ValueRef {
+    fn create_main(ccx: @mut CrateContext, main_llfn: ValueRef) -> ValueRef {
         let nt = ty::mk_nil();
 
         let llfty = type_of_fn(ccx, [], nt);
@@ -2326,7 +2331,7 @@ pub fn create_entry_wrapper(ccx: @CrateContext,
         return llfdecl;
     }
 
-    fn create_entry_fn(ccx: @CrateContext,
+    fn create_entry_fn(ccx: @mut CrateContext,
                        rust_main: ValueRef,
                        use_start_lang_item: bool) {
         let llfty = T_fn([ccx.int_type, T_ptr(T_ptr(T_i8()))], ccx.int_type);
@@ -2420,7 +2425,7 @@ pub fn fill_fn_pair(bcx: block, pair: ValueRef, llfn: ValueRef,
     Store(bcx, llenvblobptr, env_cell);
 }
 
-pub fn item_path(ccx: @CrateContext, i: @ast::item) -> path {
+pub fn item_path(ccx: &CrateContext, i: @ast::item) -> path {
     let base = match ccx.tcx.items.get_copy(&i.id) {
         ast_map::node_item(_, p) => p,
             // separate map for paths?
@@ -2429,20 +2434,21 @@ pub fn item_path(ccx: @CrateContext, i: @ast::item) -> path {
     vec::append(/*bad*/copy *base, [path_name(i.ident)])
 }
 
-pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
+pub fn get_item_val(ccx: @mut CrateContext, id: ast::node_id) -> ValueRef {
     debug!("get_item_val(id=`%?`)", id);
-    let tcx = ccx.tcx;
-    match ccx.item_vals.find(&id) {
-      Some(&v) => v,
+    let val = ccx.item_vals.find_copy(&id);
+    match val {
+      Some(v) => v,
       None => {
         let mut exprt = false;
-        let val = match tcx.items.get_copy(&id) {
+        let item = ccx.tcx.items.get_copy(&id);
+        let val = match item {
           ast_map::node_item(i, pth) => {
             let my_path = vec::append(/*bad*/copy *pth,
                                       [path_name(i.ident)]);
             match i.node {
               ast::item_const(_, expr) => {
-                let typ = ty::node_id_to_type(tcx, i.id);
+                let typ = ty::node_id_to_type(ccx.tcx, i.id);
                 let s = mangle_exported_name(ccx, my_path, typ);
                 // We need the translated value here, because for enums the
                 // LLVM type is not fully determined by the Rust type.
@@ -2501,13 +2507,12 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
                                 ni.attrs)
                 }
                 ast::foreign_item_const(*) => {
-                    let typ = ty::node_id_to_type(tcx, ni.id);
+                    let typ = ty::node_id_to_type(ccx.tcx, ni.id);
                     let ident = token::ident_to_str(&ni.ident);
                     let g = do str::as_c_str(ident) |buf| {
                         unsafe {
-                            llvm::LLVMAddGlobal(ccx.llmod,
-                                                type_of(ccx, typ),
-                                                buf)
+                            let ty = type_of(ccx, typ);
+                            llvm::LLVMAddGlobal(ccx.llmod, ty, buf)
                         }
                     };
                     g
@@ -2542,7 +2547,7 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
             // Only register the constructor if this is a tuple-like struct.
             match struct_def.ctor_id {
                 None => {
-                    tcx.sess.bug("attempt to register a constructor of \
+                    ccx.tcx.sess.bug("attempt to register a constructor of \
                                   a non-tuple-like struct")
                 }
                 Some(ctor_id) => {
@@ -2571,7 +2576,7 @@ pub fn get_item_val(ccx: @CrateContext, id: ast::node_id) -> ValueRef {
     }
 }
 
-pub fn register_method(ccx: @CrateContext,
+pub fn register_method(ccx: @mut CrateContext,
                        id: ast::node_id,
                        pth: @ast_map::path,
                        m: @ast::method) -> ValueRef {
@@ -2584,7 +2589,7 @@ pub fn register_method(ccx: @CrateContext,
 }
 
 // The constant translation pass.
-pub fn trans_constant(ccx: @CrateContext, it: @ast::item) {
+pub fn trans_constant(ccx: @mut CrateContext, it: @ast::item) {
     let _icx = ccx.insn_ctxt("trans_constant");
     match it.node {
       ast::item_enum(ref enum_definition, _) => {
@@ -2620,7 +2625,7 @@ pub fn trans_constant(ccx: @CrateContext, it: @ast::item) {
     }
 }
 
-pub fn trans_constants(ccx: @CrateContext, crate: &ast::crate) {
+pub fn trans_constants(ccx: @mut CrateContext, crate: &ast::crate) {
     visit::visit_crate(
         crate, ((),
         visit::mk_simple_visitor(@visit::SimpleVisitor {
@@ -2634,7 +2639,7 @@ pub fn vp2i(cx: block, v: ValueRef) -> ValueRef {
     return PtrToInt(cx, v, ccx.int_type);
 }
 
-pub fn p2i(ccx: @CrateContext, v: ValueRef) -> ValueRef {
+pub fn p2i(ccx: &CrateContext, v: ValueRef) -> ValueRef {
     unsafe {
         return llvm::LLVMConstPtrToInt(v, ccx.int_type);
     }
@@ -2853,8 +2858,8 @@ pub fn trap(bcx: block) {
     }
 }
 
-pub fn decl_gc_metadata(ccx: @CrateContext, llmod_id: &str) {
-    if !ccx.sess.opts.gc || !*ccx.uses_gc {
+pub fn decl_gc_metadata(ccx: &mut CrateContext, llmod_id: &str) {
+    if !ccx.sess.opts.gc || !ccx.uses_gc {
         return;
     }
 
@@ -2871,7 +2876,7 @@ pub fn decl_gc_metadata(ccx: @CrateContext, llmod_id: &str) {
     }
 }
 
-pub fn create_module_map(ccx: @CrateContext) -> ValueRef {
+pub fn create_module_map(ccx: &mut CrateContext) -> ValueRef {
     let elttype = T_struct([ccx.int_type, ccx.int_type], false);
     let maptype = T_array(elttype, ccx.module_data.len() + 1);
     let map = str::as_c_str("_rust_mod_map", |buf| {
@@ -2881,9 +2886,21 @@ pub fn create_module_map(ccx: @CrateContext) -> ValueRef {
     });
     lib::llvm::SetLinkage(map, lib::llvm::InternalLinkage);
     let mut elts: ~[ValueRef] = ~[];
-    for ccx.module_data.each |key, &val| {
-        let elt = C_struct([p2i(ccx, C_cstr(ccx, /* bad */key.to_managed())),
-                            p2i(ccx, val)]);
+
+    // This is not ideal, but the borrow checker doesn't
+    // like the multiple borrows. At least, it doesn't
+    // like them on the current snapshot. (2013-06-14)
+    let mut keys = ~[];
+    for ccx.module_data.each_key |k| {
+        keys.push(k.to_managed());
+    }
+
+    for keys.each |key| {
+        let val = *ccx.module_data.find_equiv(key).get();
+        let s_const = C_cstr(ccx, *key);
+        let s_ptr = p2i(ccx, s_const);
+        let v_ptr = p2i(ccx, val);
+        let elt = C_struct([s_ptr, v_ptr]);
         elts.push(elt);
     }
     let term = C_struct([C_int(ccx, 0), C_int(ccx, 0)]);
@@ -2919,7 +2936,7 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
     return map;
 }
 
-pub fn fill_crate_map(ccx: @CrateContext, map: ValueRef) {
+pub fn fill_crate_map(ccx: @mut CrateContext, map: ValueRef) {
     let mut subcrates: ~[ValueRef] = ~[];
     let mut i = 1;
     let cstore = ccx.sess.cstore;
@@ -2952,37 +2969,44 @@ pub fn fill_crate_map(ccx: @CrateContext, map: ValueRef) {
     }
 
     unsafe {
+        let mod_map = create_module_map(ccx);
         llvm::LLVMSetInitializer(map, C_struct(
             [C_i32(1),
              lib::llvm::llvm::LLVMConstPointerCast(llannihilatefn,
                                                    T_ptr(T_i8())),
-             p2i(ccx, create_module_map(ccx)),
+             p2i(ccx, mod_map),
              C_array(ccx.int_type, subcrates)]));
     }
 }
 
-pub fn crate_ctxt_to_encode_parms(cx: @CrateContext)
-    -> encoder::EncodeParams {
+pub fn crate_ctxt_to_encode_parms<'r>(cx: &'r CrateContext, ie: encoder::encode_inlined_item<'r>)
+    -> encoder::EncodeParams<'r> {
+
+        let diag = cx.sess.diagnostic();
+        let item_symbols = &cx.item_symbols;
+        let discrim_symbols = &cx.discrim_symbols;
+        let link_meta = &cx.link_meta;
+        encoder::EncodeParams {
+            diag: diag,
+            tcx: cx.tcx,
+            reachable: cx.reachable,
+            reexports2: cx.exp_map2,
+            item_symbols: item_symbols,
+            discrim_symbols: discrim_symbols,
+            link_meta: link_meta,
+            cstore: cx.sess.cstore,
+            encode_inlined_item: ie
+        }
+}
+
+pub fn write_metadata(cx: &mut CrateContext, crate: &ast::crate) {
+    if !*cx.sess.building_library { return; }
+
     let encode_inlined_item: encoder::encode_inlined_item =
         |ecx, ebml_w, path, ii|
         astencode::encode_inlined_item(ecx, ebml_w, path, ii, cx.maps);
 
-    encoder::EncodeParams {
-        diag: cx.sess.diagnostic(),
-        tcx: cx.tcx,
-        reachable: cx.reachable,
-        reexports2: cx.exp_map2,
-        item_symbols: cx.item_symbols,
-        discrim_symbols: cx.discrim_symbols,
-        link_meta: /*bad*/copy cx.link_meta,
-        cstore: cx.sess.cstore,
-        encode_inlined_item: encode_inlined_item
-    }
-}
-
-pub fn write_metadata(cx: @CrateContext, crate: &ast::crate) {
-    if !*cx.sess.building_library { return; }
-    let encode_parms = crate_ctxt_to_encode_parms(cx);
+    let encode_parms = crate_ctxt_to_encode_parms(cx, encode_inlined_item);
     let llmeta = C_bytes(encoder::encode_metadata(encode_parms, crate));
     let llconst = C_struct([llmeta]);
     let mut llglobal = str::as_c_str("rust_metadata", |buf| {
@@ -3008,7 +3032,7 @@ pub fn write_metadata(cx: @CrateContext, crate: &ast::crate) {
 }
 
 // Writes the current ABI version into the crate.
-pub fn write_abi_version(ccx: @CrateContext) {
+pub fn write_abi_version(ccx: &mut CrateContext) {
     mk_global(ccx, ~"rust_abi_version", C_uint(ccx, abi::abi_version),
                      false);
 }
@@ -3020,8 +3044,8 @@ pub fn trans_crate(sess: session::Session,
                    emap2: resolve::ExportMap2,
                    maps: astencode::Maps) -> (ContextRef, ModuleRef, LinkMeta) {
 
-    let symbol_hasher = @mut hash::default_state();
-    let link_meta = link::build_link_meta(sess, crate, output, symbol_hasher);
+    let mut symbol_hasher = hash::default_state();
+    let link_meta = link::build_link_meta(sess, crate, output, &mut symbol_hasher);
     let reachable = reachable::find_reachable(
         &crate.node.module,
         emap2,
@@ -3038,7 +3062,14 @@ pub fn trans_crate(sess: session::Session,
     // such as a function name in the module.
     // 1. http://llvm.org/bugs/show_bug.cgi?id=11479
     let llmod_id = link_meta.name.to_owned() + ".rc";
-    let ccx = @CrateContext::new(sess, llmod_id, tcx, emap2, maps,
+
+    // FIXME(#6511): get LLVM building with --enable-threads so this
+    //               function can be called
+    // if !llvm::LLVMRustStartMultithreading() {
+    //     sess.bug("couldn't enable multi-threaded LLVM");
+    // }
+
+    let ccx = @mut CrateContext::new(sess, llmod_id, tcx, emap2, maps,
                                  symbol_hasher, link_meta, reachable);
     // FIXME(#6511): get LLVM building with --enable-threads so this
     //               function can be called

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -46,8 +46,8 @@ pub fn B(cx: block) -> BuilderRef {
 pub fn count_insn(cx: block, category: &str) {
     if cx.ccx().sess.count_llvm_insns() {
 
-        let h = cx.ccx().stats.llvm_insns;
-        let v = &*cx.ccx().stats.llvm_insn_ctxt;
+        let h = &mut cx.ccx().stats.llvm_insns;
+        let v : &[~str] = cx.ccx().stats.llvm_insn_ctxt;
 
         // Build version of path with cycles removed.
 
@@ -547,7 +547,7 @@ pub fn AtomicLoad(cx: block, PointerVal: ValueRef, order: AtomicOrdering) -> Val
             return llvm::LLVMGetUndef(ccx.int_type);
         }
         count_insn(cx, "load.atomic");
-        let align = llalign_of_min(*ccx, ccx.int_type);
+        let align = llalign_of_min(ccx, ccx.int_type);
         return llvm::LLVMBuildAtomicLoad(B(cx), PointerVal, noname(), order, align as c_uint);
     }
 }

--- a/src/librustc/middle/trans/cabi_mips.rs
+++ b/src/librustc/middle/trans/cabi_mips.rs
@@ -18,7 +18,7 @@ use lib::llvm::{llvm, TypeRef, Integer, Pointer, Float, Double};
 use lib::llvm::{Struct, Array, Attribute};
 use lib::llvm::{StructRetAttribute};
 use lib::llvm::True;
-use middle::trans::base::task_llcx;
+use middle::trans::context::task_llcx;
 use middle::trans::common::*;
 use middle::trans::cabi::*;
 

--- a/src/librustc/middle/trans/cabi_x86.rs
+++ b/src/librustc/middle/trans/cabi_x86.rs
@@ -18,7 +18,7 @@ use super::common::*;
 use super::machine::*;
 
 struct X86_ABIInfo {
-    ccx: @CrateContext
+    ccx: @mut CrateContext
 }
 
 impl ABIInfo for X86_ABIInfo {
@@ -71,7 +71,7 @@ impl ABIInfo for X86_ABIInfo {
     }
 }
 
-pub fn abi_info(ccx: @CrateContext) -> @ABIInfo {
+pub fn abi_info(ccx: @mut CrateContext) -> @ABIInfo {
     return @X86_ABIInfo {
         ccx: ccx
     } as @ABIInfo;

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -129,7 +129,7 @@ impl EnvAction {
 }
 
 impl EnvValue {
-    pub fn to_str(&self, ccx: @CrateContext) -> ~str {
+    pub fn to_str(&self, ccx: &CrateContext) -> ~str {
         fmt!("%s(%s)", self.action.to_str(), self.datum.to_str(ccx))
     }
 }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -124,9 +124,9 @@ pub struct Stats {
     n_monos: uint,
     n_inlines: uint,
     n_closures: uint,
-    llvm_insn_ctxt: @mut ~[~str],
-    llvm_insns: @mut HashMap<~str, uint>,
-    fn_times: @mut ~[(~str, int)] // (ident, time)
+    llvm_insn_ctxt: ~[~str],
+    llvm_insns: HashMap<~str, uint>,
+    fn_times: ~[(~str, int)] // (ident, time)
 }
 
 pub struct BuilderRef_res {
@@ -147,7 +147,7 @@ pub fn BuilderRef_res(B: BuilderRef) -> BuilderRef_res {
     }
 }
 
-pub type ExternMap = @mut HashMap<@str, ValueRef>;
+pub type ExternMap = HashMap<@str, ValueRef>;
 
 // Types used for llself.
 pub struct ValSelfData {
@@ -266,7 +266,7 @@ pub struct fn_ctxt_ {
     path: path,
 
     // This function's enclosing crate context.
-    ccx: @@CrateContext
+    ccx: @mut CrateContext
 }
 
 impl fn_ctxt_ {
@@ -295,9 +295,9 @@ impl fn_ctxt_ {
 
 pub type fn_ctxt = @mut fn_ctxt_;
 
-pub fn warn_not_to_commit(ccx: @CrateContext, msg: &str) {
-    if !*ccx.do_not_commit_warning_issued {
-        *ccx.do_not_commit_warning_issued = true;
+pub fn warn_not_to_commit(ccx: &mut CrateContext, msg: &str) {
+    if !ccx.do_not_commit_warning_issued {
+        ccx.do_not_commit_warning_issued = true;
         ccx.sess.warn(msg.to_str() + " -- do not commit like this!");
     }
 }
@@ -659,7 +659,7 @@ pub fn block_parent(cx: block) -> block {
 // Accessors
 
 impl block_ {
-    pub fn ccx(@mut self) -> @CrateContext { *self.fcx.ccx }
+    pub fn ccx(@mut self) -> @mut CrateContext { self.fcx.ccx }
     pub fn tcx(@mut self) -> ty::ctxt { self.fcx.ccx.tcx }
     pub fn sess(@mut self) -> Session { self.fcx.ccx.sess }
 
@@ -754,7 +754,7 @@ pub fn T_f64() -> TypeRef {
 
 pub fn T_bool() -> TypeRef { return T_i8(); }
 
-pub fn T_int(targ_cfg: @session::config) -> TypeRef {
+pub fn T_int(targ_cfg: &session::config) -> TypeRef {
     return match targ_cfg.arch {
         X86 => T_i32(),
         X86_64 => T_i64(),
@@ -763,7 +763,7 @@ pub fn T_int(targ_cfg: @session::config) -> TypeRef {
     };
 }
 
-pub fn T_int_ty(cx: @CrateContext, t: ast::int_ty) -> TypeRef {
+pub fn T_int_ty(cx: &CrateContext, t: ast::int_ty) -> TypeRef {
     match t {
       ast::ty_i => cx.int_type,
       ast::ty_char => T_char(),
@@ -774,7 +774,7 @@ pub fn T_int_ty(cx: @CrateContext, t: ast::int_ty) -> TypeRef {
     }
 }
 
-pub fn T_uint_ty(cx: @CrateContext, t: ast::uint_ty) -> TypeRef {
+pub fn T_uint_ty(cx: &CrateContext, t: ast::uint_ty) -> TypeRef {
     match t {
       ast::ty_u => cx.int_type,
       ast::ty_u8 => T_i8(),
@@ -784,7 +784,7 @@ pub fn T_uint_ty(cx: @CrateContext, t: ast::uint_ty) -> TypeRef {
     }
 }
 
-pub fn T_float_ty(cx: @CrateContext, t: ast::float_ty) -> TypeRef {
+pub fn T_float_ty(cx: &CrateContext, t: ast::float_ty) -> TypeRef {
     match t {
       ast::ty_f => cx.float_type,
       ast::ty_f32 => T_f32(),
@@ -792,7 +792,7 @@ pub fn T_float_ty(cx: @CrateContext, t: ast::float_ty) -> TypeRef {
     }
 }
 
-pub fn T_float(targ_cfg: @session::config) -> TypeRef {
+pub fn T_float(targ_cfg: &session::config) -> TypeRef {
     return match targ_cfg.arch {
         X86 => T_f64(),
         X86_64 => T_f64(),
@@ -803,7 +803,7 @@ pub fn T_float(targ_cfg: @session::config) -> TypeRef {
 
 pub fn T_char() -> TypeRef { return T_i32(); }
 
-pub fn T_size_t(targ_cfg: @session::config) -> TypeRef {
+pub fn T_size_t(targ_cfg: &session::config) -> TypeRef {
     return T_int(targ_cfg);
 }
 
@@ -815,7 +815,7 @@ pub fn T_fn(inputs: &[TypeRef], output: TypeRef) -> TypeRef {
     }
 }
 
-pub fn T_fn_pair(cx: @CrateContext, tfn: TypeRef) -> TypeRef {
+pub fn T_fn_pair(cx: &CrateContext, tfn: TypeRef) -> TypeRef {
     return T_struct([T_ptr(tfn), T_opaque_cbox_ptr(cx)], false);
 }
 
@@ -865,7 +865,7 @@ pub fn T_empty_struct() -> TypeRef { return T_struct([], false); }
 // they are described by this opaque type.
 pub fn T_vtable() -> TypeRef { T_array(T_ptr(T_i8()), 1u) }
 
-pub fn T_tydesc_field(cx: @CrateContext, field: uint) -> TypeRef {
+pub fn T_tydesc_field(cx: &CrateContext, field: uint) -> TypeRef {
     // Bit of a kludge: pick the fn typeref out of the tydesc..
 
     unsafe {
@@ -878,7 +878,7 @@ pub fn T_tydesc_field(cx: @CrateContext, field: uint) -> TypeRef {
     }
 }
 
-pub fn T_generic_glue_fn(cx: @CrateContext) -> TypeRef {
+pub fn T_generic_glue_fn(cx: &mut CrateContext) -> TypeRef {
     let s = @"glue_fn";
     match name_has_type(cx.tn, s) {
       Some(t) => return t,
@@ -918,14 +918,14 @@ pub fn T_vector(t: TypeRef, n: uint) -> TypeRef {
 }
 
 // Interior vector.
-pub fn T_vec2(targ_cfg: @session::config, t: TypeRef) -> TypeRef {
+pub fn T_vec2(targ_cfg: &session::config, t: TypeRef) -> TypeRef {
     return T_struct([T_int(targ_cfg), // fill
                      T_int(targ_cfg), // alloc
                      T_array(t, 0u)], // elements
                     false);
 }
 
-pub fn T_vec(ccx: @CrateContext, t: TypeRef) -> TypeRef {
+pub fn T_vec(ccx: &CrateContext, t: TypeRef) -> TypeRef {
     return T_vec2(ccx.sess.targ_cfg, t);
 }
 
@@ -947,16 +947,16 @@ pub fn tuplify_box_ty(tcx: ty::ctxt, t: ty::t) -> ty::t {
                          t]);
 }
 
-pub fn T_box_header_fields(cx: @CrateContext) -> ~[TypeRef] {
+pub fn T_box_header_fields(cx: &CrateContext) -> ~[TypeRef] {
     let ptr = T_ptr(T_i8());
     return ~[cx.int_type, T_ptr(cx.tydesc_type), ptr, ptr];
 }
 
-pub fn T_box_header(cx: @CrateContext) -> TypeRef {
+pub fn T_box_header(cx: &CrateContext) -> TypeRef {
     return T_struct(T_box_header_fields(cx), false);
 }
 
-pub fn T_box(cx: @CrateContext, t: TypeRef) -> TypeRef {
+pub fn T_box(cx: &CrateContext, t: TypeRef) -> TypeRef {
     return T_struct(vec::append(T_box_header_fields(cx), [t]), false);
 }
 
@@ -966,15 +966,15 @@ pub fn T_box_ptr(t: TypeRef) -> TypeRef {
     }
 }
 
-pub fn T_opaque_box(cx: @CrateContext) -> TypeRef {
+pub fn T_opaque_box(cx: &CrateContext) -> TypeRef {
     return T_box(cx, T_i8());
 }
 
-pub fn T_opaque_box_ptr(cx: @CrateContext) -> TypeRef {
+pub fn T_opaque_box_ptr(cx: &CrateContext) -> TypeRef {
     return T_box_ptr(T_opaque_box(cx));
 }
 
-pub fn T_unique(cx: @CrateContext, t: TypeRef) -> TypeRef {
+pub fn T_unique(cx: &CrateContext, t: TypeRef) -> TypeRef {
     return T_struct(vec::append(T_box_header_fields(cx), [t]), false);
 }
 
@@ -984,32 +984,32 @@ pub fn T_unique_ptr(t: TypeRef) -> TypeRef {
     }
 }
 
-pub fn T_port(cx: @CrateContext, _t: TypeRef) -> TypeRef {
+pub fn T_port(cx: &CrateContext, _t: TypeRef) -> TypeRef {
     return T_struct([cx.int_type], false); // Refcount
 
 }
 
-pub fn T_chan(cx: @CrateContext, _t: TypeRef) -> TypeRef {
+pub fn T_chan(cx: &CrateContext, _t: TypeRef) -> TypeRef {
     return T_struct([cx.int_type], false); // Refcount
 
 }
 
 
-pub fn T_opaque_cbox_ptr(cx: @CrateContext) -> TypeRef {
+pub fn T_opaque_cbox_ptr(cx: &CrateContext) -> TypeRef {
     // closures look like boxes (even when they are ~fn or &fn)
     // see trans_closure.rs
     return T_opaque_box_ptr(cx);
 }
 
-pub fn T_enum_discrim(cx: @CrateContext) -> TypeRef {
+pub fn T_enum_discrim(cx: &CrateContext) -> TypeRef {
     return cx.int_type;
 }
 
-pub fn T_captured_tydescs(cx: @CrateContext, n: uint) -> TypeRef {
+pub fn T_captured_tydescs(cx: &CrateContext, n: uint) -> TypeRef {
     return T_struct(vec::from_elem::<TypeRef>(n, T_ptr(cx.tydesc_type)), false);
 }
 
-pub fn T_opaque_trait(cx: @CrateContext, store: ty::TraitStore) -> TypeRef {
+pub fn T_opaque_trait(cx: &CrateContext, store: ty::TraitStore) -> TypeRef {
     match store {
         ty::BoxTraitStore => {
             T_struct([T_ptr(cx.tydesc_type), T_opaque_box_ptr(cx)], false)
@@ -1075,11 +1075,11 @@ pub fn C_i64(i: i64) -> ValueRef {
     return C_integral(T_i64(), i as u64, True);
 }
 
-pub fn C_int(cx: @CrateContext, i: int) -> ValueRef {
+pub fn C_int(cx: &CrateContext, i: int) -> ValueRef {
     return C_integral(cx.int_type, i as u64, True);
 }
 
-pub fn C_uint(cx: @CrateContext, i: uint) -> ValueRef {
+pub fn C_uint(cx: &CrateContext, i: uint) -> ValueRef {
     return C_integral(cx.int_type, i as u64, False);
 }
 
@@ -1090,7 +1090,7 @@ pub fn C_u8(i: uint) -> ValueRef {
 
 // This is a 'c-like' raw string, which differs from
 // our boxed-and-length-annotated strings.
-pub fn C_cstr(cx: @CrateContext, s: @str) -> ValueRef {
+pub fn C_cstr(cx: &mut CrateContext, s: @str) -> ValueRef {
     unsafe {
         match cx.const_cstr_cache.find(&s) {
             Some(&llval) => return llval,
@@ -1116,7 +1116,7 @@ pub fn C_cstr(cx: @CrateContext, s: @str) -> ValueRef {
 
 // NB: Do not use `do_spill_noroot` to make this into a constant string, or
 // you will be kicked off fast isel. See issue #4352 for an example of this.
-pub fn C_estr_slice(cx: @CrateContext, s: @str) -> ValueRef {
+pub fn C_estr_slice(cx: &mut CrateContext, s: @str) -> ValueRef {
     unsafe {
         let len = s.len();
         let cs = llvm::LLVMConstPointerCast(C_cstr(cx, s), T_ptr(T_i8()));
@@ -1194,7 +1194,7 @@ pub fn C_bytes_plus_null(bytes: &[u8]) -> ValueRef {
     }
 }
 
-pub fn C_shape(ccx: @CrateContext, bytes: ~[u8]) -> ValueRef {
+pub fn C_shape(ccx: &CrateContext, bytes: ~[u8]) -> ValueRef {
     unsafe {
         let llshape = C_bytes_plus_null(bytes);
         let name = fmt!("shape%u", (ccx.names)("shape").name);
@@ -1214,7 +1214,7 @@ pub fn get_param(fndecl: ValueRef, param: uint) -> ValueRef {
     }
 }
 
-pub fn const_get_elt(cx: @CrateContext, v: ValueRef, us: &[c_uint])
+pub fn const_get_elt(cx: &CrateContext, v: ValueRef, us: &[c_uint])
                   -> ValueRef {
     unsafe {
         let r = do vec::as_imm_buf(us) |p, len| {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -55,6 +55,8 @@ use syntax::parse::token;
 use syntax::{ast, ast_map};
 use syntax::abi::{X86, X86_64, Arm, Mips};
 
+pub use middle::trans::context::CrateContext;
+
 // NOTE: this thunk is totally pointless now that we're not passing
 // interners around...
 pub type namegen = @fn(s: &str) -> ident;
@@ -155,86 +157,6 @@ pub fn BuilderRef_res(B: BuilderRef) -> BuilderRef_res {
 }
 
 pub type ExternMap = @mut HashMap<@str, ValueRef>;
-
-// Crate context.  Every crate we compile has one of these.
-pub struct CrateContext {
-     sess: session::Session,
-     llmod: ModuleRef,
-     llcx: ContextRef,
-     td: TargetData,
-     tn: @TypeNames,
-     externs: ExternMap,
-     intrinsics: HashMap<&'static str, ValueRef>,
-     item_vals: @mut HashMap<ast::node_id, ValueRef>,
-     exp_map2: resolve::ExportMap2,
-     reachable: reachable::map,
-     item_symbols: @mut HashMap<ast::node_id, ~str>,
-     link_meta: LinkMeta,
-     enum_sizes: @mut HashMap<ty::t, uint>,
-     discrims: @mut HashMap<ast::def_id, ValueRef>,
-     discrim_symbols: @mut HashMap<ast::node_id, @str>,
-     tydescs: @mut HashMap<ty::t, @mut tydesc_info>,
-     // Set when running emit_tydescs to enforce that no more tydescs are
-     // created.
-     finished_tydescs: @mut bool,
-     // Track mapping of external ids to local items imported for inlining
-     external: @mut HashMap<ast::def_id, Option<ast::node_id>>,
-     // Cache instances of monomorphized functions
-     monomorphized: @mut HashMap<mono_id, ValueRef>,
-     monomorphizing: @mut HashMap<ast::def_id, uint>,
-     // Cache computed type parameter uses (see type_use.rs)
-     type_use_cache: @mut HashMap<ast::def_id, @~[type_use::type_uses]>,
-     // Cache generated vtables
-     vtables: @mut HashMap<mono_id, ValueRef>,
-     // Cache of constant strings,
-     const_cstr_cache: @mut HashMap<@str, ValueRef>,
-
-     // Reverse-direction for const ptrs cast from globals.
-     // Key is an int, cast from a ValueRef holding a *T,
-     // Val is a ValueRef holding a *[T].
-     //
-     // Needed because LLVM loses pointer->pointee association
-     // when we ptrcast, and we have to ptrcast during translation
-     // of a [T] const because we form a slice, a [*T,int] pair, not
-     // a pointer to an LLVM array type.
-     const_globals: @mut HashMap<int, ValueRef>,
-
-     // Cache of emitted const values
-     const_values: @mut HashMap<ast::node_id, ValueRef>,
-
-     // Cache of external const values
-     extern_const_values: @mut HashMap<ast::def_id, ValueRef>,
-
-     impl_method_cache: @mut HashMap<(ast::def_id, ast::ident), ast::def_id>,
-
-     module_data: @mut HashMap<~str, ValueRef>,
-     lltypes: @mut HashMap<ty::t, TypeRef>,
-     llsizingtypes: @mut HashMap<ty::t, TypeRef>,
-     adt_reprs: @mut HashMap<ty::t, @adt::Repr>,
-     names: namegen,
-     next_addrspace: addrspace_gen,
-     symbol_hasher: @mut hash::State,
-     type_hashcodes: @mut HashMap<ty::t, @str>,
-     type_short_names: @mut HashMap<ty::t, ~str>,
-     all_llvm_symbols: @mut HashSet<@str>,
-     tcx: ty::ctxt,
-     maps: astencode::Maps,
-     stats: @mut Stats,
-     upcalls: @upcall::Upcalls,
-     tydesc_type: TypeRef,
-     int_type: TypeRef,
-     float_type: TypeRef,
-     opaque_vec_type: TypeRef,
-     builder: BuilderRef_res,
-     shape_cx: shape::Ctxt,
-     crate_map: ValueRef,
-     // Set when at least one function uses GC. Needed so that
-     // decl_gc_metadata knows whether to link to the module metadata, which
-     // is not emitted by LLVM's GC pass when no functions use GC.
-     uses_gc: @mut bool,
-     dbg_cx: Option<debuginfo::DebugContext>,
-     do_not_commit_warning_issued: @mut bool
-}
 
 // Types used for llself.
 pub struct ValSelfData {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -12,26 +12,18 @@
 
 use core::prelude::*;
 
-use back::{abi, upcall};
+use back::{abi};
 use driver::session;
 use driver::session::Session;
-use lib::llvm::{ModuleRef, ValueRef, TypeRef, BasicBlockRef, BuilderRef};
-use lib::llvm::{ContextRef, True, False, Bool};
-use lib::llvm::{llvm, TargetData, TypeNames, associate_type, name_has_type};
+use lib::llvm::{ValueRef, TypeRef, BasicBlockRef, BuilderRef};
+use lib::llvm::{True, False, Bool};
+use lib::llvm::{llvm, TypeNames, associate_type, name_has_type};
 use lib;
-use metadata::common::LinkMeta;
-use middle::astencode;
-use middle::resolve;
-use middle::trans::adt;
 use middle::trans::base;
 use middle::trans::build;
 use middle::trans::datum;
-use middle::trans::debuginfo;
 use middle::trans::glue;
-use middle::trans::reachable;
-use middle::trans::shape;
 use middle::trans::type_of;
-use middle::trans::type_use;
 use middle::trans::write_guard;
 use middle::ty::substs;
 use middle::ty;
@@ -41,8 +33,7 @@ use util::ppaux::{Repr};
 
 use core::cast::transmute;
 use core::cast;
-use core::hash;
-use core::hashmap::{HashMap, HashSet};
+use core::hashmap::{HashMap};
 use core::libc::{c_uint, c_longlong, c_ulonglong};
 use core::str;
 use core::to_bytes;

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -1,49 +1,35 @@
 use core::prelude::*;
 
-use back::{abi, upcall};
+use back::{upcall};
 use driver::session;
-use driver::session::Session;
-use lib::llvm::{ModuleRef, ValueRef, TypeRef, BasicBlockRef, BuilderRef};
-use lib::llvm::{ContextRef, True, False, Bool};
-use lib::llvm::{llvm, TargetData, TypeNames, associate_type, name_has_type};
+use lib::llvm::{ContextRef, ModuleRef, ValueRef, TypeRef};
+use lib::llvm::{llvm, TargetData, TypeNames};
+use lib::llvm::{mk_target_data, mk_type_names};
 use lib;
 use metadata::common::LinkMeta;
 use middle::astencode;
 use middle::resolve;
 use middle::trans::adt;
 use middle::trans::base;
-use middle::trans::build;
-use middle::trans::datum;
 use middle::trans::debuginfo;
-use middle::trans::glue;
 use middle::trans::reachable;
 use middle::trans::shape;
-use middle::trans::type_of;
 use middle::trans::type_use;
-use middle::trans::write_guard;
-use middle::ty::substs;
 use middle::ty;
-use middle::typeck;
-use middle::borrowck::root_map_key;
 
-use core::cast::transmute;
-use core::cast;
 use core::hash;
 use core::hashmap::{HashMap, HashSet};
-use core::libc::{c_uint, c_longlong, c_ulonglong};
 use core::str;
-use core::to_bytes;
-use core::vec::raw::to_ptr;
-use core::vec;
-use syntax::ast::ident;
-use syntax::ast_map::{path, path_elt};
-use syntax::codemap::span;
-use syntax::parse::token;
-use syntax::{ast, ast_map};
-use syntax::abi::{X86, X86_64, Arm, Mips};
+use core::local_data;
+use syntax::ast;
 
 use middle::trans::common::{ExternMap,tydesc_info,BuilderRef_res,Stats,namegen,addrspace_gen};
-use middle::trans::common::{mono_id};
+use middle::trans::common::{mono_id,T_int,T_float,T_tydesc,T_opaque_vec};
+use middle::trans::common::{new_namegen,new_addrspace_gen};
+
+use middle::trans::base::{decl_crate_map};
+
+use middle::trans::shape::{mk_ctxt};
 
 pub struct CrateContext {
      sess: session::Session,
@@ -121,3 +107,131 @@ pub struct CrateContext {
      dbg_cx: Option<debuginfo::DebugContext>,
      do_not_commit_warning_issued: @mut bool
 }
+
+impl CrateContext {
+    pub fn new(sess: session::Session, name: &str, tcx: ty::ctxt,
+               emap2: resolve::ExportMap2, maps: astencode::Maps,
+               symbol_hasher: @mut hash::State, link_meta: LinkMeta,
+               reachable: reachable::map) -> CrateContext {
+        unsafe {
+            let llcx = llvm::LLVMContextCreate();
+            set_task_llcx(llcx);
+            let llmod = str::as_c_str(name, |buf| {
+                llvm::LLVMModuleCreateWithNameInContext(buf, llcx)
+            });
+            let data_layout: &str = sess.targ_cfg.target_strs.data_layout;
+            let targ_triple: &str = sess.targ_cfg.target_strs.target_triple;
+            str::as_c_str(data_layout, |buf| llvm::LLVMSetDataLayout(llmod, buf));
+            str::as_c_str(targ_triple, |buf| llvm::LLVMSetTarget(llmod, buf));
+            let targ_cfg = sess.targ_cfg;
+            let td = mk_target_data(sess.targ_cfg.target_strs.data_layout);
+            let tn = mk_type_names();
+            let mut intrinsics = base::declare_intrinsics(llmod);
+            if sess.opts.extra_debuginfo {
+                base::declare_dbg_intrinsics(llmod, &mut intrinsics);
+            }
+            let int_type = T_int(targ_cfg);
+            let float_type = T_float(targ_cfg);
+            let tydesc_type = T_tydesc(targ_cfg);
+            lib::llvm::associate_type(tn, @"tydesc", tydesc_type);
+            let crate_map = decl_crate_map(sess, link_meta, llmod);
+            let dbg_cx = if sess.opts.debuginfo {
+                Some(debuginfo::mk_ctxt(name.to_owned()))
+            } else {
+                None
+            };
+
+            CrateContext {
+                  sess: sess,
+                  llmod: llmod,
+                  llcx: llcx,
+                  td: td,
+                  tn: tn,
+                  externs: @mut HashMap::new(),
+                  intrinsics: intrinsics,
+                  item_vals: @mut HashMap::new(),
+                  exp_map2: emap2,
+                  reachable: reachable,
+                  item_symbols: @mut HashMap::new(),
+                  link_meta: link_meta,
+                  enum_sizes: @mut HashMap::new(),
+                  discrims: @mut HashMap::new(),
+                  discrim_symbols: @mut HashMap::new(),
+                  tydescs: @mut HashMap::new(),
+                  finished_tydescs: @mut false,
+                  external: @mut HashMap::new(),
+                  monomorphized: @mut HashMap::new(),
+                  monomorphizing: @mut HashMap::new(),
+                  type_use_cache: @mut HashMap::new(),
+                  vtables: @mut HashMap::new(),
+                  const_cstr_cache: @mut HashMap::new(),
+                  const_globals: @mut HashMap::new(),
+                  const_values: @mut HashMap::new(),
+                  extern_const_values: @mut HashMap::new(),
+                  module_data: @mut HashMap::new(),
+                  lltypes: @mut HashMap::new(),
+                  llsizingtypes: @mut HashMap::new(),
+                  adt_reprs: @mut HashMap::new(),
+                  names: new_namegen(),
+                  next_addrspace: new_addrspace_gen(),
+                  symbol_hasher: symbol_hasher,
+                  type_hashcodes: @mut HashMap::new(),
+                  type_short_names: @mut HashMap::new(),
+                  all_llvm_symbols: @mut HashSet::new(),
+                  tcx: tcx,
+                  maps: maps,
+                  stats: @mut Stats {
+                    n_static_tydescs: 0u,
+                    n_glues_created: 0u,
+                    n_null_glues: 0u,
+                    n_real_glues: 0u,
+                    n_fns: 0u,
+                    n_monos: 0u,
+                    n_inlines: 0u,
+                    n_closures: 0u,
+                    llvm_insn_ctxt: @mut ~[],
+                    llvm_insns: @mut HashMap::new(),
+                    fn_times: @mut ~[]
+                  },
+                  upcalls: upcall::declare_upcalls(targ_cfg, llmod),
+                  tydesc_type: tydesc_type,
+                  int_type: int_type,
+                  float_type: float_type,
+                  opaque_vec_type: T_opaque_vec(targ_cfg),
+                  builder: BuilderRef_res(unsafe {
+                      llvm::LLVMCreateBuilderInContext(llcx)
+                  }),
+                  shape_cx: mk_ctxt(llmod),
+                  crate_map: crate_map,
+                  uses_gc: @mut false,
+                  dbg_cx: dbg_cx,
+                  do_not_commit_warning_issued: @mut false
+            }
+        }
+    }
+}
+
+#[unsafe_destructor]
+impl Drop for CrateContext {
+    fn finalize(&self) {
+        unsafe {
+            unset_task_llcx();
+        }
+    }
+}
+
+fn task_local_llcx_key(_v: @ContextRef) {}
+
+pub fn task_llcx() -> ContextRef {
+    let opt = unsafe { local_data::local_data_get(task_local_llcx_key) };
+    *opt.expect("task-local LLVMContextRef wasn't ever set!")
+}
+
+unsafe fn set_task_llcx(c: ContextRef) {
+    local_data::local_data_set(task_local_llcx_key, @c);
+}
+
+unsafe fn unset_task_llcx() {
+    local_data::local_data_pop(task_local_llcx_key);
+}
+

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -1,0 +1,123 @@
+use core::prelude::*;
+
+use back::{abi, upcall};
+use driver::session;
+use driver::session::Session;
+use lib::llvm::{ModuleRef, ValueRef, TypeRef, BasicBlockRef, BuilderRef};
+use lib::llvm::{ContextRef, True, False, Bool};
+use lib::llvm::{llvm, TargetData, TypeNames, associate_type, name_has_type};
+use lib;
+use metadata::common::LinkMeta;
+use middle::astencode;
+use middle::resolve;
+use middle::trans::adt;
+use middle::trans::base;
+use middle::trans::build;
+use middle::trans::datum;
+use middle::trans::debuginfo;
+use middle::trans::glue;
+use middle::trans::reachable;
+use middle::trans::shape;
+use middle::trans::type_of;
+use middle::trans::type_use;
+use middle::trans::write_guard;
+use middle::ty::substs;
+use middle::ty;
+use middle::typeck;
+use middle::borrowck::root_map_key;
+
+use core::cast::transmute;
+use core::cast;
+use core::hash;
+use core::hashmap::{HashMap, HashSet};
+use core::libc::{c_uint, c_longlong, c_ulonglong};
+use core::str;
+use core::to_bytes;
+use core::vec::raw::to_ptr;
+use core::vec;
+use syntax::ast::ident;
+use syntax::ast_map::{path, path_elt};
+use syntax::codemap::span;
+use syntax::parse::token;
+use syntax::{ast, ast_map};
+use syntax::abi::{X86, X86_64, Arm, Mips};
+
+use middle::trans::common::{ExternMap,tydesc_info,BuilderRef_res,Stats,namegen,addrspace_gen};
+use middle::trans::common::{mono_id};
+
+pub struct CrateContext {
+     sess: session::Session,
+     llmod: ModuleRef,
+     llcx: ContextRef,
+     td: TargetData,
+     tn: @TypeNames,
+     externs: ExternMap,
+     intrinsics: HashMap<&'static str, ValueRef>,
+     item_vals: @mut HashMap<ast::node_id, ValueRef>,
+     exp_map2: resolve::ExportMap2,
+     reachable: reachable::map,
+     item_symbols: @mut HashMap<ast::node_id, ~str>,
+     link_meta: LinkMeta,
+     enum_sizes: @mut HashMap<ty::t, uint>,
+     discrims: @mut HashMap<ast::def_id, ValueRef>,
+     discrim_symbols: @mut HashMap<ast::node_id, @str>,
+     tydescs: @mut HashMap<ty::t, @mut tydesc_info>,
+     // Set when running emit_tydescs to enforce that no more tydescs are
+     // created.
+     finished_tydescs: @mut bool,
+     // Track mapping of external ids to local items imported for inlining
+     external: @mut HashMap<ast::def_id, Option<ast::node_id>>,
+     // Cache instances of monomorphized functions
+     monomorphized: @mut HashMap<mono_id, ValueRef>,
+     monomorphizing: @mut HashMap<ast::def_id, uint>,
+     // Cache computed type parameter uses (see type_use.rs)
+     type_use_cache: @mut HashMap<ast::def_id, @~[type_use::type_uses]>,
+     // Cache generated vtables
+     vtables: @mut HashMap<mono_id, ValueRef>,
+     // Cache of constant strings,
+     const_cstr_cache: @mut HashMap<@str, ValueRef>,
+
+     // Reverse-direction for const ptrs cast from globals.
+     // Key is an int, cast from a ValueRef holding a *T,
+     // Val is a ValueRef holding a *[T].
+     //
+     // Needed because LLVM loses pointer->pointee association
+     // when we ptrcast, and we have to ptrcast during translation
+     // of a [T] const because we form a slice, a [*T,int] pair, not
+     // a pointer to an LLVM array type.
+     const_globals: @mut HashMap<int, ValueRef>,
+
+     // Cache of emitted const values
+     const_values: @mut HashMap<ast::node_id, ValueRef>,
+
+     // Cache of external const values
+     extern_const_values: @mut HashMap<ast::def_id, ValueRef>,
+
+     module_data: @mut HashMap<~str, ValueRef>,
+     lltypes: @mut HashMap<ty::t, TypeRef>,
+     llsizingtypes: @mut HashMap<ty::t, TypeRef>,
+     adt_reprs: @mut HashMap<ty::t, @adt::Repr>,
+     names: namegen,
+     next_addrspace: addrspace_gen,
+     symbol_hasher: @mut hash::State,
+     type_hashcodes: @mut HashMap<ty::t, @str>,
+     type_short_names: @mut HashMap<ty::t, ~str>,
+     all_llvm_symbols: @mut HashSet<@str>,
+     tcx: ty::ctxt,
+     maps: astencode::Maps,
+     stats: @mut Stats,
+     upcalls: @upcall::Upcalls,
+     tydesc_type: TypeRef,
+     int_type: TypeRef,
+     float_type: TypeRef,
+     opaque_vec_type: TypeRef,
+     builder: BuilderRef_res,
+     shape_cx: shape::Ctxt,
+     crate_map: ValueRef,
+     // Set when at least one function uses GC. Needed so that
+     // decl_gc_metadata knows whether to link to the module metadata, which
+     // is not emitted by LLVM's GC pass when no functions use GC.
+     uses_gc: @mut bool,
+     dbg_cx: Option<debuginfo::DebugContext>,
+     do_not_commit_warning_issued: @mut bool
+}

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -89,6 +89,8 @@ pub struct CrateContext {
      // Cache of external const values
      extern_const_values: HashMap<ast::def_id, ValueRef>,
 
+     impl_method_cache: HashMap<(ast::def_id, ast::ident), ast::def_id>,
+
      module_data: HashMap<~str, ValueRef>,
      lltypes: HashMap<ty::t, TypeRef>,
      llsizingtypes: HashMap<ty::t, TypeRef>,
@@ -178,6 +180,7 @@ impl CrateContext {
                   const_globals: HashMap::new(),
                   const_values: HashMap::new(),
                   extern_const_values: HashMap::new(),
+                  impl_method_cache: HashMap::new(),
                   module_data: HashMap::new(),
                   lltypes: HashMap::new(),
                   llsizingtypes: HashMap::new(),
@@ -244,4 +247,3 @@ unsafe fn set_task_llcx(c: ContextRef) {
 unsafe fn unset_task_llcx() {
     local_data::local_data_pop(task_local_llcx_key);
 }
-

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -844,7 +844,7 @@ impl DatumBlock {
         rslt(self.bcx, self.datum.to_appropriate_llval(self.bcx))
     }
 
-    pub fn ccx(&self) -> @CrateContext {
+    pub fn ccx(&self) -> @mut CrateContext {
         self.bcx.ccx()
     }
 

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -13,7 +13,7 @@ use core::prelude::*;
 use driver::session;
 use lib::llvm::ValueRef;
 use lib::llvm::llvm;
-use middle::trans::base::task_llcx;
+use middle::trans::context::task_llcx;
 use middle::trans::common::*;
 use middle::trans::machine;
 use middle::trans::type_of;

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -96,7 +96,7 @@ fn llnull() -> ValueRef {
     }
 }
 
-fn add_named_metadata(cx: @CrateContext, name: ~str, val: ValueRef) {
+fn add_named_metadata(cx: &CrateContext, name: ~str, val: ValueRef) {
     str::as_c_str(name, |sbuf| {
         unsafe {
             llvm::LLVMAddNamedMetadataOperand(cx.llmod, sbuf, val)
@@ -208,7 +208,7 @@ fn cached_metadata<T:Copy>(cache: metadata_cache,
     return option::None;
 }
 
-fn create_compile_unit(cx: @CrateContext) -> @Metadata<CompileUnitMetadata> {
+fn create_compile_unit(cx: &mut CrateContext) -> @Metadata<CompileUnitMetadata> {
     let cache = get_cache(cx);
     let crate_name = /*bad*/copy (/*bad*/copy cx.dbg_cx).get().crate_file;
     let tg = CompileUnitTag;
@@ -244,8 +244,8 @@ fn create_compile_unit(cx: @CrateContext) -> @Metadata<CompileUnitMetadata> {
     return mdval;
 }
 
-fn get_cache(cx: @CrateContext) -> metadata_cache {
-    (/*bad*/copy cx.dbg_cx).get().llmetadata
+fn get_cache(cx: &CrateContext) -> metadata_cache {
+    cx.dbg_cx.get_ref().llmetadata
 }
 
 fn get_file_path_and_dir(work_dir: &str, full_path: &str) -> (~str, ~str) {
@@ -257,7 +257,7 @@ fn get_file_path_and_dir(work_dir: &str, full_path: &str) -> (~str, ~str) {
     }, work_dir.to_owned())
 }
 
-fn create_file(cx: @CrateContext, full_path: ~str)
+fn create_file(cx: &mut CrateContext, full_path: ~str)
     -> @Metadata<FileMetadata> {
     let cache = get_cache(cx);;
     let tg = FileDescriptorTag;
@@ -290,9 +290,8 @@ fn line_from_span(cm: @codemap::CodeMap, sp: span) -> uint {
     cm.lookup_char_pos(sp.lo).line
 }
 
-fn create_block(cx: block) -> @Metadata<BlockMetadata> {
+fn create_block(mut cx: block) -> @Metadata<BlockMetadata> {
     let cache = get_cache(cx.ccx());
-    let mut cx = cx;
     while cx.node_info.is_none() {
         match cx.parent {
           Some(b) => cx = b,
@@ -340,13 +339,13 @@ fn create_block(cx: block) -> @Metadata<BlockMetadata> {
     return mdval;
 }
 
-fn size_and_align_of(cx: @CrateContext, t: ty::t) -> (int, int) {
+fn size_and_align_of(cx: &mut CrateContext, t: ty::t) -> (int, int) {
     let llty = type_of::type_of(cx, t);
     (machine::llsize_of_real(cx, llty) as int,
      machine::llalign_of_pref(cx, llty) as int)
 }
 
-fn create_basic_type(cx: @CrateContext, t: ty::t, span: span)
+fn create_basic_type(cx: &mut CrateContext, t: ty::t, span: span)
     -> @Metadata<TyDescMetadata> {
     let cache = get_cache(cx);
     let tg = BasicTypeDescriptorTag;
@@ -408,7 +407,7 @@ fn create_basic_type(cx: @CrateContext, t: ty::t, span: span)
     return mdval;
 }
 
-fn create_pointer_type(cx: @CrateContext, t: ty::t, span: span,
+fn create_pointer_type(cx: &mut CrateContext, t: ty::t, span: span,
                        pointee: @Metadata<TyDescMetadata>)
     -> @Metadata<TyDescMetadata> {
     let tg = PointerTypeTag;
@@ -498,7 +497,7 @@ fn add_member(cx: @mut StructCtxt,
     cx.total_size += size * 8;
 }
 
-fn create_struct(cx: @CrateContext, t: ty::t, fields: ~[ty::field],
+fn create_struct(cx: &mut CrateContext, t: ty::t, fields: ~[ty::field],
                  span: span) -> @Metadata<TyDescMetadata> {
     let fname = filename_from_span(cx, span);
     let file_node = create_file(cx, fname.to_owned());
@@ -521,7 +520,7 @@ fn create_struct(cx: @CrateContext, t: ty::t, fields: ~[ty::field],
     return mdval;
 }
 
-fn create_tuple(cx: @CrateContext, t: ty::t, elements: &[ty::t], span: span)
+fn create_tuple(cx: &mut CrateContext, t: ty::t, elements: &[ty::t], span: span)
     -> @Metadata<TyDescMetadata> {
     let fname = filename_from_span(cx, span);
     let file_node = create_file(cx, fname.to_owned());
@@ -555,7 +554,7 @@ fn voidptr() -> (ValueRef, int, int) {
     return (vp, size, align);
 }
 
-fn create_boxed_type(cx: @CrateContext, contents: ty::t,
+fn create_boxed_type(cx: &mut CrateContext, contents: ty::t,
                      span: span, boxed: @Metadata<TyDescMetadata>)
     -> @Metadata<TyDescMetadata> {
     //let tg = StructureTypeTag;
@@ -624,7 +623,7 @@ fn create_composite_type(type_tag: int, name: &str, file: ValueRef,
     return llmdnode(lldata);
 }
 
-fn create_fixed_vec(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t,
+fn create_fixed_vec(cx: &mut CrateContext, vec_t: ty::t, elem_t: ty::t,
                     len: int, span: span) -> @Metadata<TyDescMetadata> {
     let t_md = create_ty(cx, elem_t, span);
     let fname = filename_from_span(cx, span);
@@ -643,7 +642,7 @@ fn create_fixed_vec(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t,
     }
 }
 
-fn create_boxed_vec(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t,
+fn create_boxed_vec(cx: &mut CrateContext, vec_t: ty::t, elem_t: ty::t,
                     vec_ty_span: codemap::span)
     -> @Metadata<TyDescMetadata> {
     let fname = filename_from_span(cx, vec_ty_span);
@@ -695,7 +694,7 @@ fn create_boxed_vec(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t,
     return mdval;
 }
 
-fn create_vec_slice(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t, span: span)
+fn create_vec_slice(cx: &mut CrateContext, vec_t: ty::t, elem_t: ty::t, span: span)
     -> @Metadata<TyDescMetadata> {
     let fname = filename_from_span(cx, span);
     let file_node = create_file(cx, fname.to_owned());
@@ -717,7 +716,7 @@ fn create_vec_slice(cx: @CrateContext, vec_t: ty::t, elem_t: ty::t, span: span)
     return mdval;
 }
 
-fn create_fn_ty(cx: @CrateContext, fn_ty: ty::t, inputs: ~[ty::t], output: ty::t,
+fn create_fn_ty(cx: &mut CrateContext, fn_ty: ty::t, inputs: ~[ty::t], output: ty::t,
                 span: span) -> @Metadata<TyDescMetadata> {
     let fname = filename_from_span(cx, span);
     let file_node = create_file(cx, fname.to_owned());
@@ -737,7 +736,7 @@ fn create_fn_ty(cx: @CrateContext, fn_ty: ty::t, inputs: ~[ty::t], output: ty::t
     return mdval;
 }
 
-fn create_ty(cx: @CrateContext, t: ty::t, span: span)
+fn create_ty(cx: &mut CrateContext, t: ty::t, span: span)
     -> @Metadata<TyDescMetadata> {
     debug!("create_ty: %?", ty::get(t));
     /*let cache = get_cache(cx);
@@ -817,7 +816,7 @@ fn create_ty(cx: @CrateContext, t: ty::t, span: span)
     }
 }
 
-fn filename_from_span(cx: @CrateContext, sp: codemap::span) -> @str {
+fn filename_from_span(cx: &CrateContext, sp: codemap::span) -> @str {
     cx.sess.codemap.lookup_char_pos(sp.lo).file.name
 }
 
@@ -878,7 +877,7 @@ pub fn create_local_var(bcx: block, local: @ast::local)
         }
     };
     let declargs = ~[llmdnode([llptr]), mdnode];
-    trans::build::Call(bcx, *cx.intrinsics.get(&("llvm.dbg.declare")),
+    trans::build::Call(bcx, cx.intrinsics.get_copy(&("llvm.dbg.declare")),
                        declargs);
     return mdval;
 }
@@ -886,7 +885,7 @@ pub fn create_local_var(bcx: block, local: @ast::local)
 pub fn create_arg(bcx: block, arg: ast::arg, sp: span)
     -> Option<@Metadata<ArgumentMetadata>> {
     let fcx = bcx.fcx;
-    let cx = *fcx.ccx;
+    let cx = fcx.ccx;
     let cache = get_cache(cx);
     let tg = ArgVariableTag;
     match cached_metadata::<@Metadata<ArgumentMetadata>>(
@@ -927,7 +926,7 @@ pub fn create_arg(bcx: block, arg: ast::arg, sp: span)
             let llptr = fcx.llargs.get_copy(&arg.id);
             let declargs = ~[llmdnode([llptr]), mdnode];
             trans::build::Call(bcx,
-                               *cx.intrinsics.get(&("llvm.dbg.declare")),
+                               cx.intrinsics.get_copy(&("llvm.dbg.declare")),
                                declargs);
             return Some(mdval);
         }
@@ -955,8 +954,7 @@ pub fn update_source_pos(cx: block, s: span) {
 }
 
 pub fn create_function(fcx: fn_ctxt) -> @Metadata<SubProgramMetadata> {
-    let cx = *fcx.ccx;
-    let dbg_cx = (/*bad*/copy cx.dbg_cx).get();
+    let mut cx = fcx.ccx;
 
     debug!("~~");
 
@@ -980,6 +978,7 @@ pub fn create_function(fcx: fn_ctxt) -> @Metadata<SubProgramMetadata> {
       ast_map::node_expr(expr) => {
         match expr.node {
           ast::expr_fn_block(ref decl, _) => {
+            let dbg_cx = cx.dbg_cx.get_ref();
             ((dbg_cx.names)("fn"), decl.output, expr.id)
           }
           _ => fcx.ccx.sess.span_bug(expr.span,

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -27,7 +27,7 @@ use syntax::ast_util::local_def;
 // `translate` will be true if this function is allowed to translate the
 // item and false otherwise. Currently, this parameter is set to false when
 // translating default methods.
-pub fn maybe_instantiate_inline(ccx: @CrateContext, fn_id: ast::def_id,
+pub fn maybe_instantiate_inline(ccx: @mut CrateContext, fn_id: ast::def_id,
                                 translate: bool)
     -> ast::def_id {
     let _icx = ccx.insn_ctxt("maybe_instantiate_inline");

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -22,7 +22,7 @@ use util::ppaux::ty_to_str;
 // compute sizeof / alignof
 
 // Returns the number of bytes clobbered by a Store to this type.
-pub fn llsize_of_store(cx: @CrateContext, t: TypeRef) -> uint {
+pub fn llsize_of_store(cx: &CrateContext, t: TypeRef) -> uint {
     unsafe {
         return llvm::LLVMStoreSizeOfType(cx.td.lltd, t) as uint;
     }
@@ -30,7 +30,7 @@ pub fn llsize_of_store(cx: @CrateContext, t: TypeRef) -> uint {
 
 // Returns the number of bytes between successive elements of type T in an
 // array of T. This is the "ABI" size. It includes any ABI-mandated padding.
-pub fn llsize_of_alloc(cx: @CrateContext, t: TypeRef) -> uint {
+pub fn llsize_of_alloc(cx: &CrateContext, t: TypeRef) -> uint {
     unsafe {
         return llvm::LLVMABISizeOfType(cx.td.lltd, t) as uint;
     }
@@ -44,7 +44,7 @@ pub fn llsize_of_alloc(cx: @CrateContext, t: TypeRef) -> uint {
 // that LLVM *does* distinguish between e.g. a 1-bit value and an 8-bit value
 // at the codegen level! In general you should prefer `llbitsize_of_real`
 // below.
-pub fn llsize_of_real(cx: @CrateContext, t: TypeRef) -> uint {
+pub fn llsize_of_real(cx: &CrateContext, t: TypeRef) -> uint {
     unsafe {
         let nbits = llvm::LLVMSizeOfTypeInBits(cx.td.lltd, t) as uint;
         if nbits & 7u != 0u {
@@ -57,14 +57,14 @@ pub fn llsize_of_real(cx: @CrateContext, t: TypeRef) -> uint {
 }
 
 /// Returns the "real" size of the type in bits.
-pub fn llbitsize_of_real(cx: @CrateContext, t: TypeRef) -> uint {
+pub fn llbitsize_of_real(cx: &CrateContext, t: TypeRef) -> uint {
     unsafe {
         llvm::LLVMSizeOfTypeInBits(cx.td.lltd, t) as uint
     }
 }
 
 /// Returns the size of the type as an LLVM constant integer value.
-pub fn llsize_of(cx: @CrateContext, t: TypeRef) -> ValueRef {
+pub fn llsize_of(cx: &CrateContext, t: TypeRef) -> ValueRef {
     // Once upon a time, this called LLVMSizeOf, which does a
     // getelementptr(1) on a null pointer and casts to an int, in
     // order to obtain the type size as a value without requiring the
@@ -78,7 +78,7 @@ pub fn llsize_of(cx: @CrateContext, t: TypeRef) -> ValueRef {
 // Returns the "default" size of t (see above), or 1 if the size would
 // be zero.  This is important for things like vectors that expect
 // space to be consumed.
-pub fn nonzero_llsize_of(cx: @CrateContext, t: TypeRef) -> ValueRef {
+pub fn nonzero_llsize_of(cx: &CrateContext, t: TypeRef) -> ValueRef {
     if llbitsize_of_real(cx, t) == 0 {
         unsafe { llvm::LLVMConstInt(cx.int_type, 1, False) }
     } else {
@@ -90,7 +90,7 @@ pub fn nonzero_llsize_of(cx: @CrateContext, t: TypeRef) -> ValueRef {
 // The preferred alignment may be larger than the alignment used when
 // packing the type into structs. This will be used for things like
 // allocations inside a stack frame, which LLVM has a free hand in.
-pub fn llalign_of_pref(cx: @CrateContext, t: TypeRef) -> uint {
+pub fn llalign_of_pref(cx: &CrateContext, t: TypeRef) -> uint {
     unsafe {
         return llvm::LLVMPreferredAlignmentOfType(cx.td.lltd, t) as uint;
     }
@@ -99,7 +99,7 @@ pub fn llalign_of_pref(cx: @CrateContext, t: TypeRef) -> uint {
 // Returns the minimum alignment of a type required by the platform.
 // This is the alignment that will be used for struct fields, arrays,
 // and similar ABI-mandated things.
-pub fn llalign_of_min(cx: @CrateContext, t: TypeRef) -> uint {
+pub fn llalign_of_min(cx: &CrateContext, t: TypeRef) -> uint {
     unsafe {
         return llvm::LLVMABIAlignmentOfType(cx.td.lltd, t) as uint;
     }
@@ -108,7 +108,7 @@ pub fn llalign_of_min(cx: @CrateContext, t: TypeRef) -> uint {
 // Returns the "default" alignment of t, which is calculated by casting
 // null to a record containing a single-bit followed by a t value, then
 // doing gep(0,1) to get at the trailing (and presumably padded) t cell.
-pub fn llalign_of(cx: @CrateContext, t: TypeRef) -> ValueRef {
+pub fn llalign_of(cx: &CrateContext, t: TypeRef) -> ValueRef {
     unsafe {
         return llvm::LLVMConstIntCast(
             llvm::LLVMAlignOf(t), cx.int_type, False);
@@ -116,7 +116,7 @@ pub fn llalign_of(cx: @CrateContext, t: TypeRef) -> ValueRef {
 }
 
 // Computes the size of the data part of an enum.
-pub fn static_size_of_enum(cx: @CrateContext, t: ty::t) -> uint {
+pub fn static_size_of_enum(cx: &mut CrateContext, t: ty::t) -> uint {
     if cx.enum_sizes.contains_key(&t) {
         return cx.enum_sizes.get_copy(&t);
     }

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -42,7 +42,7 @@ for non-monomorphized methods only.  Other methods will
 be generated once they are invoked with specific type parameters,
 see `trans::base::lval_static_fn()` or `trans::base::monomorphic_fn()`.
 */
-pub fn trans_impl(ccx: @CrateContext,
+pub fn trans_impl(ccx: @mut CrateContext,
                   path: path,
                   name: ast::ident,
                   methods: &[@ast::method],
@@ -102,7 +102,7 @@ Translates a (possibly monomorphized) method body.
 - `llfn`: the LLVM ValueRef for the method
 - `impl_id`: the node ID of the impl this method is inside
 */
-pub fn trans_method(ccx: @CrateContext,
+pub fn trans_method(ccx: @mut CrateContext,
                     path: path,
                     method: &ast::method,
                     param_substs: Option<@param_substs>,
@@ -378,7 +378,7 @@ pub fn method_from_methods(ms: &[@ast::method], name: ast::ident)
     ms.find(|m| m.ident == name).map(|m| ast_util::local_def(m.id))
 }
 
-pub fn method_with_name_or_default(ccx: @CrateContext,
+pub fn method_with_name_or_default(ccx: @mut CrateContext,
                                    impl_id: ast::def_id,
                                    name: ast::ident) -> ast::def_id {
     *do ccx.impl_method_cache.find_or_insert_with((impl_id, name)) |_| {
@@ -415,7 +415,7 @@ pub fn method_with_name_or_default(ccx: @CrateContext,
     }
 }
 
-pub fn method_ty_param_count(ccx: @CrateContext, m_id: ast::def_id,
+pub fn method_ty_param_count(ccx: &CrateContext, m_id: ast::def_id,
                              i_id: ast::def_id) -> uint {
     debug!("method_ty_param_count: m_id: %?, i_id: %?", m_id, i_id);
     if m_id.crate == ast::local_crate {
@@ -734,7 +734,7 @@ pub fn trans_trait_callee_from_llval(bcx: block,
     };
 }
 
-pub fn vtable_id(ccx: @CrateContext,
+pub fn vtable_id(ccx: @mut CrateContext,
                  origin: &typeck::vtable_origin)
               -> mono_id {
     match origin {
@@ -778,7 +778,7 @@ pub fn get_vtable(bcx: block,
 }
 
 /// Helper function to declare and initialize the vtable.
-pub fn make_vtable(ccx: @CrateContext,
+pub fn make_vtable(ccx: @mut CrateContext,
                    tydesc: @mut tydesc_info,
                    ptrs: &[ValueRef])
                    -> ValueRef {

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -381,36 +381,44 @@ pub fn method_from_methods(ms: &[@ast::method], name: ast::ident)
 pub fn method_with_name_or_default(ccx: @mut CrateContext,
                                    impl_id: ast::def_id,
                                    name: ast::ident) -> ast::def_id {
-    *do ccx.impl_method_cache.find_or_insert_with((impl_id, name)) |_| {
-        if impl_id.crate == ast::local_crate {
-            match ccx.tcx.items.get_copy(&impl_id.node) {
-                ast_map::node_item(@ast::item {
-                                   node: ast::item_impl(_, _, _, ref ms), _
-                                   }, _) => {
-                    let did = method_from_methods(*ms, name);
-                    if did.is_some() {
-                        did.get()
-                    } else {
-                        // Look for a default method
-                        let pmm = ccx.tcx.provided_methods;
-                        match pmm.find(&impl_id) {
-                            Some(pmis) => {
-                                for pmis.each |pmi| {
-                                    if pmi.method_info.ident == name {
-                                        debug!("pmi.method_info.did = %?", pmi.method_info.did);
-                                        return pmi.method_info.did;
+    let imp = ccx.impl_method_cache.find_copy(&(impl_id, name));
+    match imp {
+        Some(m) => m,
+        None => {
+            let imp = if impl_id.crate == ast::local_crate {
+                match ccx.tcx.items.get_copy(&impl_id.node) {
+                    ast_map::node_item(@ast::item {
+                                       node: ast::item_impl(_, _, _, ref ms), _
+                                       }, _) => {
+                        let did = method_from_methods(*ms, name);
+                        if did.is_some() {
+                            did.get()
+                        } else {
+                            // Look for a default method
+                            let pmm = ccx.tcx.provided_methods;
+                            match pmm.find(&impl_id) {
+                                Some(pmis) => {
+                                    for pmis.each |pmi| {
+                                        if pmi.method_info.ident == name {
+                                            debug!("pmi.method_info.did = %?", pmi.method_info.did);
+                                            return pmi.method_info.did;
+                                        }
                                     }
+                                    fail!()
                                 }
-                                fail!()
+                                None => fail!()
                             }
-                            None => fail!()
                         }
                     }
+                    _ => fail!("method_with_name")
                 }
-                _ => fail!("method_with_name")
-            }
-        } else {
-            csearch::get_impl_method(ccx.sess.cstore, impl_id, name)
+            } else {
+                csearch::get_impl_method(ccx.sess.cstore, impl_id, name)
+            };
+
+            ccx.impl_method_cache.insert((impl_id, name), imp);
+
+            imp
         }
     }
 }

--- a/src/librustc/middle/trans/mod.rs
+++ b/src/librustc/middle/trans/mod.rs
@@ -1,0 +1,43 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub mod macros;
+pub mod inline;
+pub mod monomorphize;
+pub mod controlflow;
+pub mod glue;
+pub mod datum;
+pub mod write_guard;
+pub mod callee;
+pub mod expr;
+pub mod common;
+pub mod consts;
+pub mod type_of;
+pub mod build;
+pub mod base;
+pub mod _match;
+pub mod uniq;
+pub mod closure;
+pub mod tvec;
+pub mod meth;
+pub mod cabi;
+pub mod cabi_x86;
+pub mod cabi_x86_64;
+pub mod cabi_arm;
+pub mod cabi_mips;
+pub mod foreign;
+pub mod reflect;
+pub mod shape;
+pub mod debuginfo;
+pub mod type_use;
+pub mod reachable;
+pub mod machine;
+pub mod adt;
+pub mod asm;

--- a/src/librustc/middle/trans/mod.rs
+++ b/src/librustc/middle/trans/mod.rs
@@ -18,6 +18,7 @@ pub mod write_guard;
 pub mod callee;
 pub mod expr;
 pub mod common;
+pub mod context;
 pub mod consts;
 pub mod type_of;
 pub mod build;

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -40,7 +40,7 @@ use syntax::ast_util::local_def;
 use syntax::opt_vec;
 use syntax::abi::AbiSet;
 
-pub fn monomorphic_fn(ccx: @CrateContext,
+pub fn monomorphic_fn(ccx: @mut CrateContext,
                       fn_id: ast::def_id,
                       real_substs: &ty::substs,
                       vtables: Option<typeck::vtable_res>,
@@ -329,7 +329,7 @@ pub fn normalize_for_monomorphization(tcx: ty::ctxt,
     }
 }
 
-pub fn make_mono_id(ccx: @CrateContext,
+pub fn make_mono_id(ccx: @mut CrateContext,
                     item: ast::def_id,
                     substs: &[ty::t],
                     vtables: Option<typeck::vtable_res>,

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -151,8 +151,7 @@ impl Reflector {
     // Entrypoint
     pub fn visit_ty(&mut self, t: ty::t) {
         let bcx = self.bcx;
-        debug!("reflect::visit_ty %s",
-               ty_to_str(bcx.ccx().tcx, t));
+        debug!("reflect::visit_ty %s", ty_to_str(bcx.ccx().tcx, t));
 
         match ty::get(t).sty {
           ty::ty_bot => self.leaf(~"bot"),
@@ -312,16 +311,17 @@ impl Reflector {
                 + self.c_size_and_align(t);
             do self.bracketed(~"enum", enum_args) |this| {
                 for variants.eachi |i, v| {
+                    let name = ccx.sess.str_of(v.name);
                     let variant_args = ~[this.c_uint(i),
                                          this.c_int(v.disr_val),
                                          this.c_uint(v.args.len()),
-                                         this.c_slice(ccx.sess.str_of(v.name))];
+                                         this.c_slice(name)];
                     do this.bracketed(~"enum_variant", variant_args) |this| {
                         for v.args.eachi |j, a| {
                             let bcx = this.bcx;
                             let null = C_null(llptrty);
-                            let offset = p2i(ccx, adt::trans_field_ptr(bcx, repr, null,
-                                                                       v.disr_val, j));
+                            let ptr = adt::trans_field_ptr(bcx, repr, null, v.disr_val, j);
+                            let offset = p2i(ccx, ptr);
                             let field_args = ~[this.c_uint(j),
                                                offset,
                                                this.c_tydesc(*a)];

--- a/src/librustc/middle/trans/shape.rs
+++ b/src/librustc/middle/trans/shape.rs
@@ -25,8 +25,8 @@ pub struct Ctxt {
     pad2: u32
 }
 
-pub fn mk_global(ccx: @CrateContext,
-                 name: ~str,
+pub fn mk_global(ccx: &CrateContext,
+                 name: &str,
                  llval: ValueRef,
                  internal: bool)
               -> ValueRef {

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -151,7 +151,7 @@ pub struct VecTypes {
 }
 
 impl VecTypes {
-    pub fn to_str(&self, ccx: @CrateContext) -> ~str {
+    pub fn to_str(&self, ccx: &CrateContext) -> ~str {
         fmt!("VecTypes {vec_ty=%s, unit_ty=%s, llunit_ty=%s, llunit_size=%s}",
              ty_to_str(ccx.tcx, self.vec_ty),
              ty_to_str(ccx.tcx, self.unit_ty),

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -51,11 +51,11 @@ pub static use_repr: uint = 1;   /* Dependency on size/alignment/mode and
 pub static use_tydesc: uint = 2; /* Takes the tydesc, or compares */
 
 pub struct Context {
-    ccx: @CrateContext,
+    ccx: @mut CrateContext,
     uses: @mut ~[type_uses]
 }
 
-pub fn type_uses_for(ccx: @CrateContext, fn_id: def_id, n_tps: uint)
+pub fn type_uses_for(ccx: @mut CrateContext, fn_id: def_id, n_tps: uint)
     -> @~[type_uses] {
     match ccx.type_use_cache.find(&fn_id) {
       Some(uses) => return *uses,

--- a/src/librustc/rustc.rc
+++ b/src/librustc/rustc.rc
@@ -61,41 +61,8 @@ use syntax::codemap;
 use syntax::diagnostic;
 
 pub mod middle {
-    pub mod trans {
-        pub mod macros;
-        pub mod inline;
-        pub mod monomorphize;
-        pub mod controlflow;
-        pub mod glue;
-        pub mod datum;
-        pub mod write_guard;
-        pub mod callee;
-        pub mod expr;
-        pub mod common;
-        pub mod consts;
-        pub mod type_of;
-        pub mod build;
-        pub mod base;
-        pub mod _match;
-        pub mod uniq;
-        pub mod closure;
-        pub mod tvec;
-        pub mod meth;
-        pub mod cabi;
-        pub mod cabi_x86;
-        pub mod cabi_x86_64;
-        pub mod cabi_arm;
-        pub mod cabi_mips;
-        pub mod foreign;
-        pub mod reflect;
-        pub mod shape;
-        pub mod debuginfo;
-        pub mod type_use;
-        pub mod reachable;
-        pub mod machine;
-        pub mod adt;
-        pub mod asm;
-    }
+    #[path = "trans/mod.rs"]
+    pub mod trans;
     pub mod ty;
     pub mod subst;
     pub mod resolve;


### PR DESCRIPTION
This removes all of the explicit `@mut` fields from `CrateContext`. There are still a few that are managed, but no longer do we have `@mut bool` in the structure.

Most of the changes are changing `@CrateContext` to `@mut CrateContext`, though I did change as many as I could get away with to `&CrateContext` and `&mut CrateContext`. The biggest thing preventing me from changing to `&[mut]` in most places was the instruction counter thing. In two cases, where I got a static borrow error and a dynamic borrow error, I opted to remove the count call there as it was literally the only thing preventing me from switching to `&mut CrateContext` parameters in both cases.

Other things to note:
- the EncoderContext uses borrowed pointers with lifetimes, since it can, though that required me to work around the limitation of not being able to move a structure with borrowed pointers into a heap closure. I changed as much as I could to stack closures, but unfortunately I hit the AST visitor and changing that is somewhat outside the scope of this PR. Instead (and there is a comment to this effect) I choose to unsafely get the structure into the heap, this is because I know the lifetimes involved are safe, even though the compiler can't prove it.
- Many of the changes are workarounds because of the borrow checker, either dynamically freezing it for too long, or inferring too large a scope. This is mostly just from nested function calls where each borrow is considered to last for the entire statement. Other cases are where `CrateContext` was borrowed in a `match` causing it to be borrowed for the entire length of the match, even though that wasn't wanted (or needed).
- I haven't yet tested to see if this changes compilation times in any way. I doubt there will be much of an impact however, as the only major improvements are less indirection and fewer refcount bumps.
- This lays the foundations to remove many more heap allocations in trans as many cases can be changed to use lifetimes instead.
# 

This change includes some other, minor refactorings, as I am planning a series, however I don't want to submit them all at once as it will be hell to continually rebase.
