### PR TITLE
std: get std::path tests to work again

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -947,6 +947,7 @@ pub mod windows {
 mod tests {
     use option::{None, Some};
     use path::{PosixPath, WindowsPath, windows};
+    use str;
 
     #[test]
     fn test_double_slash_collapsing() {


### PR DESCRIPTION
The patch reversion in 7755018074a7802e47ae61f69f5e2b5364a12eb8 left out a `use std` in `std::path`, which is causing those tests to fail.
