### PR TITLE
std::dynamic_lib: start fixing windows implementation

### DIFF
--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -18,11 +18,6 @@ use task;
 
 pub mod at_exit;
 
-// Currently only works for *NIXes
-#[cfg(target_os = "linux")]
-#[cfg(target_os = "android")]
-#[cfg(target_os = "macos")]
-#[cfg(target_os = "freebsd")]
 pub mod dynamic_lib;
 
 pub mod global;


### PR DESCRIPTION
The code compiles and runs under windows now, but I couldn't look up any
symbol from the current executable (dlopen(NULL)), and calling looked
up external function handles doesn't seem to work correctly under windows.

This the beginning of a fix for #7095.
