### PR TITLE
stop using an absolute rpath

### DIFF
--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -77,10 +77,6 @@ fn get_rpaths(os: session::os,
     // crates they depend on.
     let rel_rpaths = get_rpaths_relative_to_output(os, output, libs);
 
-    // Make backup absolute paths to the libraries. Binaries can
-    // be moved as long as the crates they link against don't move.
-    let abs_rpaths = get_absolute_rpaths(libs);
-
     // And a final backup rpath to the global library location.
     let fallback_rpaths = ~[get_install_prefix_rpath(target_triple)];
 
@@ -92,11 +88,9 @@ fn get_rpaths(os: session::os,
     }
 
     log_rpaths("relative", rel_rpaths);
-    log_rpaths("absolute", abs_rpaths);
     log_rpaths("fallback", fallback_rpaths);
 
     let mut rpaths = rel_rpaths;
-    rpaths.push_all(abs_rpaths);
     rpaths.push_all(fallback_rpaths);
 
     // Remove duplicates
@@ -166,14 +160,6 @@ pub fn get_relative_to(abs1: &Path, abs2: &Path) -> Path {
     }
 }
 
-fn get_absolute_rpaths(libs: &[Path]) -> ~[Path] {
-    vec::map(libs, |a| get_absolute_rpath(a) )
-}
-
-pub fn get_absolute_rpath(lib: &Path) -> Path {
-    os::make_absolute(lib).dir_path()
-}
-
 #[cfg(stage0)]
 pub fn get_install_prefix_rpath(target_triple: &str) -> Path {
     let install_prefix = env!("CFG_PREFIX");
@@ -220,7 +206,7 @@ mod test {
     // these redundant #[cfg(test)] blocks can be removed
     #[cfg(test)]
     #[cfg(test)]
-    use back::rpath::{get_absolute_rpath, get_install_prefix_rpath};
+    use back::rpath::{get_install_prefix_rpath};
     use back::rpath::{get_relative_to, get_rpath_relative_to_output};
     use back::rpath::{minimize_rpaths, rpaths_to_flags};
     use driver::session;
@@ -363,15 +349,5 @@ mod test {
                                                &Path("bin/rustc"),
                                                &Path("lib/libstd.so"));
         assert_eq!(res.to_str(), ~"@executable_path/../lib");
-    }
-
-    #[test]
-    fn test_get_absolute_rpath() {
-        let res = get_absolute_rpath(&Path("lib/libstd.so"));
-        debug!("test_get_absolute_rpath: %s vs. %s",
-               res.to_str(),
-               os::make_absolute(&Path("lib")).to_str());
-
-        assert_eq!(res, os::make_absolute(&Path("lib")));
     }
 }


### PR DESCRIPTION
This is a bad default, because the binaries will point at an absolute
path regardless of where they are moved. This opens up a security issue
for packages, because they will attempt to load libraries from a path
that's often owned by a regular user.

Every Rust binary is currently flagged by Debian, Fedora and Arch lint
checkers as having dangerous rpaths. They don't meet the requirements to
be placed in the repositories without manually stripping this from each
binary.

The relative rpath is still enough to keep the binaries working until
they are moved relative to the crates they're linked against.

http://wiki.debian.org/RpathIssue
https://fedoraproject.org/wiki/Packaging:Guidelines#Beware_of_Rpath
