### PR TITLE
Upgrade terminfo

### DIFF
--- a/src/libextra/term.rs
+++ b/src/libextra/term.rs
@@ -20,7 +20,7 @@ use core::os;
 use terminfo::*;
 use terminfo::searcher::open;
 use terminfo::parser::compiled::parse;
-use terminfo::parm::{expand, Number};
+use terminfo::parm::{expand, Number, Variables};
 
 // FIXME (#2807): Windows support.
 
@@ -84,7 +84,7 @@ impl Terminal {
     pub fn fg(&self, color: u8) {
         if self.color_supported {
             let s = expand(*self.ti.strings.find_equiv(&("setaf")).unwrap(),
-                           [Number(color as int)], [], []);
+                           [Number(color as int)], &mut Variables::new());
             if s.is_ok() {
                 self.out.write(s.get());
             } else {
@@ -95,7 +95,7 @@ impl Terminal {
     pub fn bg(&self, color: u8) {
         if self.color_supported {
             let s = expand(*self.ti.strings.find_equiv(&("setab")).unwrap(),
-                           [Number(color as int)], [], []);
+                           [Number(color as int)], &mut Variables::new());
             if s.is_ok() {
                 self.out.write(s.get());
             } else {
@@ -105,7 +105,7 @@ impl Terminal {
     }
     pub fn reset(&self) {
         if self.color_supported {
-            let s = expand(*self.ti.strings.find_equiv(&("op")).unwrap(), [], [], []);
+            let s = expand(*self.ti.strings.find_equiv(&("op")).unwrap(), [], &mut Variables::new());
             if s.is_ok() {
                 self.out.write(s.get());
             } else {

--- a/src/libextra/term.rs
+++ b/src/libextra/term.rs
@@ -105,7 +105,8 @@ impl Terminal {
     }
     pub fn reset(&self) {
         if self.color_supported {
-            let s = expand(*self.ti.strings.find_equiv(&("op")).unwrap(), [], &mut Variables::new());
+            let mut vars = Variables::new();
+            let s = expand(*self.ti.strings.find_equiv(&("op")).unwrap(), [], &mut vars);
             if s.is_ok() {
                 self.out.write(s.get());
             } else {

--- a/src/libextra/terminfo/parm.rs
+++ b/src/libextra/terminfo/parm.rs
@@ -68,7 +68,6 @@ pub fn expand(cap: &[u8], params: &mut [Param], sta: &mut [Param], dyn: &mut [Pa
 
     while i < cap.len() {
         cur = cap[i] as char;
-        debug!("current char: %c", cur);
         let mut old_state = state;
         match state {
             Nothing => {
@@ -134,33 +133,19 @@ pub fn expand(cap: &[u8], params: &mut [Param], sta: &mut [Param], dyn: &mut [Pa
                         (_, _) => return Err(~"non-numbers on stack with |")
                     },
                     'A' => match (stack.pop(), stack.pop()) {
-                        (Number(x), Number(y)) => {
-                            if x == 1 && y == 1 {
-                                stack.push(Number(1));
-                            } else {
-                                stack.push(Number(0));
-                            }
-                        },
-                        (_, _) => return Err(~"non-numbers on stack with logical and")
+                        (Number(0), Number(_)) => stack.push(Number(0)),
+                        (Number(_), Number(0)) => stack.push(Number(0)),
+                        (Number(_), Number(_)) => stack.push(Number(1)),
+                        _ => return Err(~"non-numbers on stack with logical and")
                     },
                     'O' => match (stack.pop(), stack.pop()) {
-                        (Number(x), Number(y)) => {
-                            if x == 1 && y == 1 {
-                                stack.push(Number(1));
-                            } else {
-                                stack.push(Number(0));
-                            }
-                        },
-                        (_, _) => return Err(~"non-numbers on stack with logical or")
+                        (Number(0), Number(0)) => stack.push(Number(0)),
+                        (Number(_), Number(_)) => stack.push(Number(1)),
+                        _ => return Err(~"non-numbers on stack with logical or")
                     },
                     '!' => match stack.pop() {
-                        Number(x) => {
-                            if x == 1 {
-                                stack.push(Number(0))
-                            } else {
-                                stack.push(Number(1))
-                            }
-                        },
+                        Number(0) => stack.push(Number(1)),
+                        Number(_) => stack.push(Number(0)),
                         _ => return Err(~"non-number on stack with logical not")
                     },
                     '~' => match stack.pop() {
@@ -168,9 +153,9 @@ pub fn expand(cap: &[u8], params: &mut [Param], sta: &mut [Param], dyn: &mut [Pa
                         _         => return Err(~"non-number on stack with %~")
                     },
                     'i' => match (copy params[0], copy params[1]) {
-                        (Number(x), Number(y)) => {
-                            params[0] = Number(x + 1);
-                            params[1] = Number(y + 1);
+                        (Number(ref mut x), Number(ref mut y)) => {
+                            *x += 1;
+                            *y += 1;
                         },
                         (_, _) => return Err(~"first two params not numbers with %i")
                     },

--- a/src/libextra/terminfo/parm.rs
+++ b/src/libextra/terminfo/parm.rs
@@ -176,19 +176,22 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     } else { return Err(~"stack is empty") },
                     '=' => if stack.len() > 1 {
                         match (stack.pop(), stack.pop()) {
-                            (Number(y), Number(x)) => stack.push(Number(if x == y { 1 } else { 0 })),
+                            (Number(y), Number(x)) => stack.push(Number(if x == y { 1 }
+                                                                        else { 0 })),
                             _ => return Err(~"non-numbers on stack with =")
                         }
                     } else { return Err(~"stack is empty") },
                     '>' => if stack.len() > 1 {
                         match (stack.pop(), stack.pop()) {
-                            (Number(y), Number(x)) => stack.push(Number(if x > y { 1 } else { 0 })),
+                            (Number(y), Number(x)) => stack.push(Number(if x > y { 1 }
+                                                                        else { 0 })),
                             _ => return Err(~"non-numbers on stack with >")
                         }
                     } else { return Err(~"stack is empty") },
                     '<' => if stack.len() > 1 {
                         match (stack.pop(), stack.pop()) {
-                            (Number(y), Number(x)) => stack.push(Number(if x < y { 1 } else { 0 })),
+                            (Number(y), Number(x)) => stack.push(Number(if x < y { 1 }
+                                                                        else { 0 })),
                             _ => return Err(~"non-numbers on stack with <")
                         }
                     } else { return Err(~"stack is empty") },
@@ -353,12 +356,14 @@ mod test {
     #[test]
     fn test_basic_setabf() {
         let s = bytes!("\\E[48;5;%p1%dm");
-        assert_eq!(expand(s, [Number(1)], &mut Variables::new()).unwrap(), bytes!("\\E[48;5;1m").to_owned());
+        assert_eq!(expand(s, [Number(1)], &mut Variables::new()).unwrap(),
+                   bytes!("\\E[48;5;1m").to_owned());
     }
 
     #[test]
     fn test_multiple_int_constants() {
-        assert_eq!(expand(bytes!("%{1}%{2}%d%d"), [], &mut Variables::new()).unwrap(), bytes!("21").to_owned());
+        assert_eq!(expand(bytes!("%{1}%{2}%d%d"), [], &mut Variables::new()).unwrap(),
+                   bytes!("21").to_owned());
     }
 
     #[test]


### PR DESCRIPTION
Implement conditional support in terminfo, along with a few other related operators.

Fix implementation of non-commutative arithmetic operators.

Remove all known cases of task failure from `terminfo::parm::expand`, and change the method signature.

Fix some other miscellaneous issues.
