### PR TITLE
Fix inlining of glue code

### DIFF
--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -341,8 +341,7 @@ pub fn type_of_rooted(ccx: @CrateContext, t: ty::t) -> TypeRef {
     return T_root(type_of(ccx, t), addrspace);
 }
 
-pub fn type_of_glue_fn(ccx: @CrateContext, t: ty::t) -> TypeRef {
+pub fn type_of_glue_fn(ccx: @CrateContext) -> TypeRef {
     let tydescpp = T_ptr(T_ptr(ccx.tydesc_type));
-    let llty = T_ptr(type_of(ccx, t));
-    return T_fn([T_ptr(T_nil()), tydescpp, llty], T_nil());
+    return T_fn([T_ptr(T_nil()), tydescpp, T_ptr(T_i8())], T_nil());
 }


### PR DESCRIPTION
Currently, when calling glue functions, we cast the function to match
the argument type. This interacts very badly with LLVM and breaks
inlining of the glue code.

It's more efficient to use a unified function type for the glue
functions and always cast the function argument instead of the function.

The resulting code for rustc is about 13% faster (measured up to and
including the "trans" pass) and the resulting librustc is about 5%
smaller.
