### PR TITLE
Add IterBytes impls for float/f32/f64. This allows creating HashMaps with floats as keys.

### DIFF
--- a/src/libstd/hash.rs
+++ b/src/libstd/hash.rs
@@ -558,4 +558,15 @@ mod tests {
             val & !(0xff << (byte * 8))
         }
     }
+
+    #[test]
+    fn test_float_hashes_differ() {
+        assert!(0.0.hash() != 1.0.hash());
+        assert!(1.0.hash() != (-1.0).hash());
+    }
+
+    #[test]
+    fn test_float_hashes_of_zero() {
+        assert_eq!(0.0.hash(), (-0.0).hash());
+    }
 }

--- a/src/libstd/to_bytes.rs
+++ b/src/libstd/to_bytes.rs
@@ -14,6 +14,7 @@ The `ToBytes` and `IterBytes` traits
 
 */
 
+use cast;
 use io;
 use io::Writer;
 use option::{None, Option, Some};
@@ -187,6 +188,35 @@ impl IterBytes for int {
     #[inline(always)]
     fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
         (*self as uint).iter_bytes(lsb0, f)
+    }
+}
+
+impl IterBytes for float {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        (*self as f64).iter_bytes(lsb0, f)
+    }
+}
+
+impl IterBytes for f32 {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        let i: u32 = unsafe {
+            // 0.0 == -0.0 so they should also have the same hashcode
+            cast::transmute(if *self == -0.0 { 0.0 } else { *self })
+        };
+        i.iter_bytes(lsb0, f)
+    }
+}
+
+impl IterBytes for f64 {
+    #[inline(always)]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        let i: u64 = unsafe {
+            // 0.0 == -0.0 so they should also have the same hashcode
+            cast::transmute(if *self == -0.0 { 0.0 } else { *self })
+        };
+        i.iter_bytes(lsb0, f)
     }
 }
 


### PR DESCRIPTION
It can sometimes be useful to have maps/sets of floating point values.

Doing arithmetic with floats and then using them as keys is, of course, not a good idea.
