### PR TITLE
trans::glue: don't generate struct destructors in the free glue

### DIFF
--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -450,15 +450,6 @@ pub fn make_free_glue(bcx: block, v: ValueRef, t: ty::t) {
       ty::ty_opaque_closure_ptr(ck) => {
         closure::make_opaque_cbox_free_glue(bcx, ck, v)
       }
-      ty::ty_struct(did, ref substs) => {
-        // Call the dtor if there is one
-        match ty::ty_dtor(bcx.tcx(), did) {
-            ty::NoDtor => bcx,
-            ty::TraitDtor(ref dt_id) => {
-                trans_struct_drop(bcx, t, v, *dt_id, did, substs)
-            }
-        }
-      }
       _ => bcx
     };
     build_return(bcx);


### PR DESCRIPTION
The free glue shouldn't be called for structs, and the drop glue already
contains the destructor.
