### PR TITLE
Do not strip leading whitespace when parsing doc comments.

### DIFF
--- a/src/librustdoc/attr_parser.rs
+++ b/src/librustdoc/attr_parser.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -152,6 +152,6 @@ mod test {
     fn should_concatenate_multiple_doc_comments() {
         let source = @"/// foo\n/// bar";
         let desc = parse_desc(parse_attributes(source));
-        assert!(desc == Some(~"foo\nbar"));
+        assert!(desc == Some(~" foo\n bar"));
     }
 }


### PR DESCRIPTION
This change prevents the indentation in code blocks inside the /// doc comments
from being eaten. The indentation that is the same across the consecutive doc
comments is removed by the uindent_pass in librustdoc.

The bug can be seen, e.g., here: http://static.rust-lang.org/doc/std/iterator.html#example-12

I also altered how the block comments are treated, for consistency. There isn't much testing done on the documentation output (I added a few tests of my own for the modified function), so I don't know if anything relied on the previous behavior. I checked a number of documentation files and observed either no change in output or changes that consistent of the above bug being fixed.
