### PR TITLE
Fixes for shootout benchmarks

### DIFF
--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -41,7 +41,9 @@ fn bottom_up_tree<'r>(arena: &'r mut arena::Arena, item: int, depth: int)
 }
 
 fn main() {
-    let args = os::args();
+    use std::os;
+    use std::int;
+    let args = std::os::args();
     let args = if os::getenv(~"RUST_BENCH").is_some() {
         ~[~"", ~"17"]
     } else if args.len() <= 1u {
@@ -63,7 +65,7 @@ fn main() {
     let stretch_depth = max_depth + 1;
     let stretch_tree = bottom_up_tree(&mut stretch_arena, 0, stretch_depth);
 
-    io::println(fmt!("stretch tree of depth %d\t check: %d",
+    println(fmt!("stretch tree of depth %d\t check: %d",
                           stretch_depth,
                           item_check(stretch_tree)));
 
@@ -81,12 +83,12 @@ fn main() {
             chk += item_check(temp_tree);
             i += 1;
         }
-        io::println(fmt!("%d\t trees of depth %d\t check: %d",
+        println(fmt!("%d\t trees of depth %d\t check: %d",
                          iterations * 2, depth,
                          chk));
         depth += 2;
     }
-    io::println(fmt!("long lived trees of depth %d\t check: %d",
+    println(fmt!("long lived tree of depth %d\t check: %d",
                      max_depth,
                      item_check(long_lived_tree)));
 }

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -85,7 +85,7 @@ fn show_number(nn: uint) -> ~str {
         out = show_digit(dig) + " " + out;
     }
 
-    return out;
+    return ~" " + out;
 }
 
 fn transform(aa: color, bb: color) -> color {

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,18 +19,14 @@ extern mod extra;
 
 use std::int;
 use std::io;
-use std::option;
 use std::os;
 use std::rand::Rng;
 use std::rand;
 use std::result;
 use std::str;
 use std::uint;
-use std::vec;
 
 static LINE_LENGTH: uint = 60u;
-
-//fn LINE_LENGTH() -> uint { return 60u; }
 
 struct MyRandom {
     last: u32
@@ -95,17 +91,15 @@ fn make_repeat_fasta(wr: @io::Writer, id: ~str, desc: ~str, s: ~str, n: int) {
     wr.write_line(~">" + id + " " + desc);
     let mut op = str::with_capacity( LINE_LENGTH );
     let sl = s.len();
-    unsafe {
-        for uint::range(0u, n as uint) |i| {
-            if (op.len() >= LINE_LENGTH) {
-                wr.write_line( op );
-                op = str::with_capacity( LINE_LENGTH );
-            }
-            op.push_char( s[i % sl] as char );
+    for uint::range(0u, n as uint) |i| {
+        if (op.len() >= LINE_LENGTH) {
+            wr.write_line( op );
+            op = str::with_capacity( LINE_LENGTH );
         }
-        if op.len() > 0 {
-            wr.write_line(op)
-        }
+        op.push_char( s[i % sl] as char );
+    }
+    if op.len() > 0 {
+        wr.write_line(op)
     }
 }
 
@@ -115,7 +109,7 @@ fn acid(ch: char, prob: u32) -> AminoAcids {
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv(~"RUST_BENCH").is_some() {
+    let args = if os::getenv("RUST_BENCH").is_some() {
         // alioth tests k-nucleotide with this data at 25,000,000
         ~[~"", ~"5000000"]
     } else if args.len() <= 1u {
@@ -124,9 +118,9 @@ fn main() {
         args
     };
 
-    let writer = if os::getenv(~"RUST_BENCH").is_some() {
+    let writer = if os::getenv("RUST_BENCH").is_some() {
         result::get(&io::file_writer(&Path("./shootout-fasta.data"),
-                                    ~[io::Truncate, io::Create]))
+                                    [io::Truncate, io::Create]))
     } else {
         io::stdout()
     };

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -28,7 +28,9 @@ use std::str;
 use std::uint;
 use std::vec;
 
-fn LINE_LENGTH() -> uint { return 60u; }
+static LINE_LENGTH: uint = 60u;
+
+//fn LINE_LENGTH() -> uint { return 60u; }
 
 struct MyRandom {
     last: u32
@@ -81,7 +83,7 @@ fn make_random_fasta(wr: @io::Writer,
     for uint::range(0u, n as uint) |_i| {
         op.push_char(select_random(myrandom_next(rng, 100u32),
                                               copy genelist));
-        if op.len() >= LINE_LENGTH() {
+        if op.len() >= LINE_LENGTH {
             wr.write_line(op);
             op = ~"";
         }
@@ -90,18 +92,20 @@ fn make_random_fasta(wr: @io::Writer,
 }
 
 fn make_repeat_fasta(wr: @io::Writer, id: ~str, desc: ~str, s: ~str, n: int) {
+    wr.write_line(~">" + id + " " + desc);
+    let mut op = str::with_capacity( LINE_LENGTH );
+    let sl = s.len();
     unsafe {
-        wr.write_line(~">" + id + " " + desc);
-        let mut op: ~str = ~"";
-        let sl: uint = s.len();
         for uint::range(0u, n as uint) |i| {
-            str::raw::push_byte(&mut op, s[i % sl]);
-            if op.len() >= LINE_LENGTH() {
-                wr.write_line(op);
-                op = ~"";
+            if (op.len() >= LINE_LENGTH) {
+                wr.write_line( op );
+                op = str::with_capacity( LINE_LENGTH );
             }
+            op.push_char( s[i % sl] as char );
         }
-        if op.len() > 0u { wr.write_line(op); }
+        if op.len() > 0 {
+            wr.write_line(op)
+        }
     }
 }
 

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -1,3 +1,13 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use std::f64;
 use std::from_str::FromStr;
 use std::os;


### PR DESCRIPTION
This PR fixes a few problems with the benchmark, mentioned in #2913. Since I do not have a 4GB RAM machine (I run rust on a puny 2GB RAM VM) I can't test binarytrees with N=20. If it works we can close #2913.

Fixes: 1) binarytrees prints "long lived trees of depth" instead of "long lived tree of depth"
Fixes: 2) chameneosredux -- the whitespace printed by show_number should be the same as printed by show_color
Already fixed: 3) spectralnorm prints an extra \n
Fixes: 4) threadring prints an extra \n
Fixes: 5) fasta -- strangely, output stops half-way through line 169 -- with another 8166 lines still to do.
Could not test: 6) the latest binarytrees fails with input N=20 on a 4GB machine.

r?
