### PR TITLE
Adds conditional byteswapping intrinsics

### DIFF
--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -238,3 +238,17 @@ pub extern "rust-intrinsic" {
     pub fn bswap32(x: i32) -> i32;
     pub fn bswap64(x: i64) -> i64;
 }
+
+#[cfg(target_endian = "little")] pub fn to_le16(x: i16) -> i16 { x }
+#[cfg(target_endian = "big")]    pub fn to_le16(x: i16) -> i16 { unsafe { bswap16(x) } }
+#[cfg(target_endian = "little")] pub fn to_le32(x: i32) -> i32 { x }
+#[cfg(target_endian = "big")]    pub fn to_le32(x: i32) -> i32 { unsafe { bswap32(x) } }
+#[cfg(target_endian = "little")] pub fn to_le64(x: i64) -> i64 { x }
+#[cfg(target_endian = "big")]    pub fn to_le64(x: i64) -> i64 { unsafe { bswap64(x) } }
+
+#[cfg(target_endian = "little")] pub fn to_be16(x: i16) -> i16 { unsafe { bswap16(x) } }
+#[cfg(target_endian = "big")]    pub fn to_be16(x: i16) -> i16 { x }
+#[cfg(target_endian = "little")] pub fn to_be32(x: i32) -> i32 { unsafe { bswap32(x) } }
+#[cfg(target_endian = "big")]    pub fn to_be32(x: i32) -> i32 { x }
+#[cfg(target_endian = "little")] pub fn to_be64(x: i64) -> i64 { unsafe { bswap64(x) } }
+#[cfg(target_endian = "big")]    pub fn to_be64(x: i64) -> i64 { x }


### PR DESCRIPTION
They simply byte-swap an integer to a specific endian, like the hton\* functions in C.

These intrinsics are synthesized, so maybe they should be in another file. But since they are just a single line of code each, based on the bswap intrinsics and aren't really intended for public consumption I thought they would fit in the intrinsics file.

The next step working on this could be to expose a trait / generic function for byteswapping.
