### PR TITLE
Update doc references to new names for std, extra, and std::libc

### DIFF
--- a/src/README.txt
+++ b/src/README.txt
@@ -4,8 +4,8 @@ Source layout:
 
 librustc/          The self-hosted compiler
 
-libcore/           The core library (imported and linked by default)
-libstd/            The standard library (slightly more peripheral code)
+libstd/            The standard library (imported and linked by default)
+libextra/          The "extras" library (slightly more peripheral code)
 libsyntax/         The Rust parser and pretty-printer
 
 rt/                The runtime system

--- a/src/libextra/std.rc
+++ b/src/libextra/std.rc
@@ -10,19 +10,19 @@
 
 /*!
 
-The Rust standard library.
+The Rust "extras" library.
 
-The Rust standand library provides a number of useful features that are
-not required in or otherwise suitable for the core library.
+The Rust extras library (`extra`) provides a number of useful features that
+are not required in or otherwise suitable for the standard library (`std`).
 
 */
 
 #[link(name = "extra",
        vers = "0.7-pre",
        uuid = "122bed0b-c19b-4b82-b0b7-7ae8aead7297",
-       url = "https://github.com/mozilla/rust/tree/master/src/libstd")];
+       url = "https://github.com/mozilla/rust/tree/master/src/libextra")];
 
-#[comment = "The Rust standard library"];
+#[comment = "The Rust extras library"];
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
@@ -128,7 +128,7 @@ pub mod test;
 pub mod serialize;
 
 // A curious inner-module that's not exported that contains the binding
-// 'extra' so that macro-expanded references to std::serialize and such
+// 'extra' so that macro-expanded references to extra::serialize and such
 // can be resolved within libextra.
 #[doc(hidden)]
 pub mod std {

--- a/src/libextra/std.rc
+++ b/src/libextra/std.rc
@@ -10,10 +10,13 @@
 
 /*!
 
-The Rust "extras" library.
+Rust extras.
 
-The Rust extras library (`extra`) provides a number of useful features that
-are not required in or otherwise suitable for the standard library (`std`).
+The `extra` crate is a set of useful modules for a variety of
+purposes, including collections, numerics, I/O, serialization,
+and concurrency.
+
+Rust extras are part of the standard Rust distribution.
 
 */
 
@@ -22,7 +25,7 @@ are not required in or otherwise suitable for the standard library (`std`).
        uuid = "122bed0b-c19b-4b82-b0b7-7ae8aead7297",
        url = "https://github.com/mozilla/rust/tree/master/src/libextra")];
 
-#[comment = "The Rust extras library"];
+#[comment = "Rust extras"];
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 

--- a/src/libstd/core.rc
+++ b/src/libstd/core.rc
@@ -12,19 +12,20 @@
 
 # The Rust standard library
 
-The Rust standard library provides runtime features required by the language,
-including the task scheduler and memory allocators, as well as library
-support for Rust built-in types, platform abstractions, and other commonly
-used features.
+The Rust standard library is a group of interrelated modules defining
+the core language traits, operations on built-in data types, collections,
+platform abstractions, the task scheduler, runtime support for language
+features and other common functionality.
 
-`std` includes modules corresponding to each of the integer types, each of
-the floating point types, the `bool` type, tuples, characters, strings
-(`str`), vectors (`vec`), managed boxes (`managed`), owned boxes (`owned`),
-and unsafe and borrowed pointers (`ptr`).  Additionally, `std` provides
-pervasive types (`option` and `result`), task creation and communication
-primitives (`task`, `comm`), platform abstractions (`os` and `path`), basic
-I/O abstractions (`io`), common traits (`kinds`, `ops`, `cmp`, `num`,
-`to_str`), and complete bindings to the C standard library (`libc`).
+`std` includes modules corresponding to each of the integer types,
+each of the floating point types, the `bool` type, tuples, characters,
+strings (`str`), vectors (`vec`), managed boxes (`managed`), owned
+boxes (`owned`), and unsafe and borrowed pointers (`ptr`, `borrowed`).
+Additionally, `std` provides pervasive types (`option` and `result`),
+task creation and communication primitives (`task`, `comm`), platform
+abstractions (`os` and `path`), basic I/O abstractions (`io`), common
+traits (`kinds`, `ops`, `cmp`, `num`, `to_str`), and complete bindings
+to the C standard library (`libc`).
 
 # Standard library injection and the Rust prelude
 
@@ -38,7 +39,7 @@ with the `std::` path prefix, as in `use std::vec`, `use std::task::spawn`,
 etc.
 
 Additionally, `std` contains a `prelude` module that reexports many of the
-most common `std` modules, types and traits. The contents of the prelude are
+most common types, traits and functions. The contents of the prelude are
 imported into every *module* by default.  Implicitly, all modules behave as if
 they contained the following prologue:
 

--- a/src/libstd/core.rc
+++ b/src/libstd/core.rc
@@ -38,7 +38,7 @@ with the `std::` path prefix, as in `use std::vec`, `use std::task::spawn`,
 etc.
 
 Additionally, `std` contains a `prelude` module that reexports many of the
-most common std modules, types and traits. The contents of the prelude are
+most common `std` modules, types and traits. The contents of the prelude are
 imported into every *module* by default.  Implicitly, all modules behave as if
 they contained the following prologue:
 
@@ -66,7 +66,7 @@ they contained the following prologue:
 #[deny(non_camel_case_types)];
 #[deny(missing_doc)];
 
-// Make core testable by not duplicating lang items. See #2912
+// Make std testable by not duplicating lang items. See #2912
 #[cfg(test)] extern mod realstd(name = "std");
 #[cfg(test)] pub use kinds = realstd::kinds;
 #[cfg(test)] pub use ops = realstd::ops;

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -14,8 +14,8 @@
 * This module contains bindings to the C standard library,
 * organized into modules by their defining standard.
 * Additionally, it contains some assorted platform-specific definitions.
-* For convenience, most functions and types are reexported from `core::libc`,
-* so `pub use core::libc::*` will import the available
+* For convenience, most functions and types are reexported from `std::libc`,
+* so `pub use std::libc::*` will import the available
 * C bindings as appropriate for the target platform. The exact
 * set of functions available are platform specific.
 *


### PR DESCRIPTION
Was updating some code of mine to use the new `std`/`extra` library names, and noticed a place where docs for `std::libc` hadn't been updated. Then I updated some top-level docs for the new libraries' names, too.
