### PR TITLE
rt: fix jemalloc android cross-compile for mac

### DIFF
--- a/src/rt/jemalloc/Makefile.in
+++ b/src/rt/jemalloc/Makefile.in
@@ -9,6 +9,7 @@ vpath % .
 SHELL := /bin/sh
 
 CC := @CC@
+AR := @AR@
 
 # Configuration parameters.
 DESTDIR =

--- a/src/rt/jemalloc/configure
+++ b/src/rt/jemalloc/configure
@@ -4453,7 +4453,7 @@ PIC_CFLAGS='-fPIC -DPIC'
 CTARGET='-o $@'
 LDTARGET='-o $@'
 EXTRA_LDFLAGS=
-MKLIB='ar crus $@'
+MKLIB='$(AR) crus $@'
 CC_MM=1
 
 default_munmap="1"


### PR DESCRIPTION
while cross-compiling, ar in cross toolchains are required. 
linux is not sensitive so could not see errors.
