### PR TITLE
rustc: map node ids through a table that ensures bitset indexes in dataflow are dense

### DIFF
--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -82,7 +82,7 @@ impl<'self> CheckLoanCtxt<'self> {
         //! are issued for future scopes and thus they may have been
         //! *issued* but not yet be in effect.
 
-        for self.dfcx_loans.each_bit_on_entry(scope_id) |loan_index| {
+        for self.dfcx_loans.each_bit_on_entry_frozen(scope_id) |loan_index| {
             let loan = &self.all_loans[loan_index];
             if !op(loan) {
                 return false;
@@ -134,7 +134,7 @@ impl<'self> CheckLoanCtxt<'self> {
         //! we encounter `scope_id`.
 
         let mut result = ~[];
-        for self.dfcx_loans.each_gen_bit(scope_id) |loan_index| {
+        for self.dfcx_loans.each_gen_bit_frozen(scope_id) |loan_index| {
             result.push(loan_index);
         }
         return result;

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -504,7 +504,7 @@ impl FlowedMoveData {
 
         let opt_loan_path_index = self.move_data.existing_move_path(loan_path);
 
-        for self.dfcx_moves.each_bit_on_entry(id) |index| {
+        for self.dfcx_moves.each_bit_on_entry_frozen(id) |index| {
             let move = &self.move_data.moves[index];
             let moved_path = move.path;
             if base_indices.contains(&moved_path) {
@@ -560,7 +560,7 @@ impl FlowedMoveData {
             }
         };
 
-        for self.dfcx_assign.each_bit_on_entry(id) |index| {
+        for self.dfcx_assign.each_bit_on_entry_frozen(id) |index| {
             let assignment = &self.move_data.var_assignments[index];
             if assignment.path == loan_path_index && !f(assignment) {
                 return false;


### PR DESCRIPTION
I'm pretty sure this got adequately reviewed by a combination of @nikomatsakis and @graydon so I'm rubber stamping it because I really want this in (it makes it much less likely for me to swap, allowing me to get more work done).
