### PR TITLE
Fix take glue of owned trait objects

### DIFF
--- a/src/librustc/back/abi.rs
+++ b/src/librustc/back/abi.rs
@@ -57,12 +57,10 @@ pub static n_tydesc_fields: uint = 8u;
 pub static fn_field_code: uint = 0u;
 pub static fn_field_box: uint = 1u;
 
-// The three fields of a trait object/trait instance: vtable, box, and type
-// description.
+// The two fields of a trait object/trait instance: vtable and box.
+// The vtable contains the type descriptor as first element.
 pub static trt_field_vtable: uint = 0u;
 pub static trt_field_box: uint = 1u;
-// This field is only present in unique trait objects, so it comes last.
-pub static trt_field_tydesc: uint = 2u;
 
 pub static vec_elt_fill: uint = 0u;
 

--- a/src/test/run-pass/owned-trait-objects.rs
+++ b/src/test/run-pass/owned-trait-objects.rs
@@ -1,0 +1,37 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::uint::{range};
+
+trait FooTrait {
+    fn foo(&self) -> uint;
+}
+
+struct BarStruct {
+    x: uint
+}
+
+impl FooTrait for BarStruct {
+    fn foo(&self) -> uint {
+        self.x
+    }
+}
+
+pub fn main() {
+    let foos: ~[ ~FooTrait ] = ~[
+        ~BarStruct{ x: 0 } as ~FooTrait,
+        ~BarStruct{ x: 1 } as ~FooTrait,
+        ~BarStruct{ x: 2 } as ~FooTrait
+    ];
+
+    for range(0, foos.len()) |i| {
+        assert_eq!(i, foos[i].foo());
+    }
+}


### PR DESCRIPTION
This finishes the incomplete conversion of unique traits as two-word
allocations started in 211d038abc05c77785f72a31840016517cf218c2.

Fixes #5882, #6717, #7153, #7208.
