### PR TITLE
Minor doc updates to reflect #[deriving(Zero)], and small release notes adjustments.

### DIFF
--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -7,8 +7,9 @@ Version 0.7 (July 2013)
       * `use mod` is no longer valid.
       * `fail!` and `assert!` accept `~str`, `&'static str` or `fmt!`-style
         argument list.
-      * `Encodable`, `Decodable`, `TotalOrd`, `TotalEq`, `DeepClone` can all
-        be automatically derived with `#[deriving(...)]`.
+      * `Encodable`, `Decodable`, `Ord`, `TotalOrd`, `TotalEq`, `DeepClone`,
+        `Rand`, `Zero` and `ToStr` can all be automatically derived with
+        `#[deriving(...)]`.
       * The `Durable` trait is replaced with the `'static` bounds.
       * At long last, 'argument modes' no longer exist.
       * The `bytes!` macro returns a vector of bytes for string, u8, char,
@@ -52,8 +53,8 @@ Version 0.7 (July 2013)
         `(0, 1, 2).n2()` or `(0, 1, 2).n2_ref()`.
       * std: many types implement `Clone` - tuples, @, @mut. TODO
       * std: `path` type renamed to `Path`.
-      * std: Many standalone functions removed in favor of methods in
-        `vec`, `str`. In the future methods will also work as functions.
+      * std: Many standalone functions removed in favor of methods and iterators
+        in `vec`, `str`. In the future methods will also work as functions.
       * std: `reinterpret_cast` removed. Used `transmute`.
       * std: ascii string handling in `std::ascii`.
       * std: `Rand` is implemented for ~/@.
@@ -65,7 +66,7 @@ Version 0.7 (July 2013)
       * std: `FuzzyEq` renamed to `ApproxEq`.
       * std: `Map` now defines `pop` and `swap` methods.
       * extra: `flate` module moved from `std` to `extra`.
-      * extra: `FileInput` implements `std::io::Reader`.
+      * extra: `fileinput` module for iterating over a series of files.
       * extra: `Complex` number type and `complex` module.
       * extra: `Rational` number type and `rational` module.
       * extra: `BigInt`, `BigUint` implement numeric and comparison traits.

--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1561,6 +1561,7 @@ Supported traits for `deriving` are:
 * `Clone` and `DeepClone`, to perform (deep) copies.
 * `IterBytes`, to iterate over the bytes in a data type.
 * `Rand`, to create a random instance of a data type.
+* `Zero`, to create an zero (or empty) instance of a data type.
 * `ToStr`, to convert to a string. For a type with this instance,
   `obj.to_str()` has the same output as `fmt!("%?", obj)`.
 

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2319,7 +2319,7 @@ enum ABC { A, B, C }
 
 The full list of derivable traits is `Eq`, `TotalEq`, `Ord`,
 `TotalOrd`, `Encodable` `Decodable`, `Clone`, `DeepClone`,
-`IterBytes`, `Rand` and `ToStr`.
+`IterBytes`, `Rand`, `Zero`, and `ToStr`.
 
 # Modules and crates
 


### PR DESCRIPTION
The `extra::fileinput` module landed just after 0.6 was released, and there are many
more derivable traits.
