### PR TITLE
Improve IR codegen

### DIFF
--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -179,16 +179,18 @@ impl FnType {
             }
         }
 
-        let llretval = load_inbounds(bcx, llargbundle, [ 0, arg_tys.len() ]);
-        let llretval = if self.ret_ty.cast {
-            let retptr = BitCast(bcx, llretval, T_ptr(self.ret_ty.ty));
-            Load(bcx, retptr)
-        } else {
-            Load(bcx, llretval)
-        };
-        let llretptr = BitCast(bcx,
-                               bcx.fcx.llretptr.get(),
-                               T_ptr(self.ret_ty.ty));
-        Store(bcx, llretval, llretptr);
+        if bcx.fcx.llretptr.is_some() {
+            let llretval = load_inbounds(bcx, llargbundle, [ 0, arg_tys.len() ]);
+            let llretval = if self.ret_ty.cast {
+                let retptr = BitCast(bcx, llretval, T_ptr(self.ret_ty.ty));
+                Load(bcx, retptr)
+            } else {
+                Load(bcx, llretval)
+            };
+            let llretptr = BitCast(bcx,
+                                   bcx.fcx.llretptr.get(),
+                                   T_ptr(self.ret_ty.ty));
+            Store(bcx, llretval, llretptr);
+        }
     }
 }

--- a/src/librustc/middle/trans/cabi_x86.rs
+++ b/src/librustc/middle/trans/cabi_x86.rs
@@ -60,6 +60,11 @@ impl ABIInfo for X86_ABIInfo {
                 cast: false,
                 ty: T_void(),
             };
+        } else if !ret_def {
+            ret_ty = LLVMType {
+                cast: false,
+                ty: T_void()
+            };
         }
 
         return FnType {

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -826,24 +826,33 @@ pub fn trans_arg_expr(bcx: block,
                         val = arg_datum.to_ref_llval(bcx);
                     }
                     ty::ByCopy => {
-                        debug!("by copy arg with type %s, storing to scratch",
-                               bcx.ty_to_str(arg_datum.ty));
-                        let scratch = scratch_datum(bcx, arg_datum.ty, false);
+                        if ty::type_needs_drop(bcx.tcx(), arg_datum.ty) ||
+                                arg_datum.appropriate_mode().is_by_ref() {
+                            debug!("by copy arg with type %s, storing to scratch",
+                                   bcx.ty_to_str(arg_datum.ty));
+                            let scratch = scratch_datum(bcx, arg_datum.ty, false);
 
-                        arg_datum.store_to_datum(bcx,
-                                                 arg_expr.id,
-                                                 INIT,
-                                                 scratch);
+                            arg_datum.store_to_datum(bcx,
+                                                     arg_expr.id,
+                                                     INIT,
+                                                     scratch);
 
-                        // Technically, ownership of val passes to the callee.
-                        // However, we must cleanup should we fail before the
-                        // callee is actually invoked.
-                        scratch.add_clean(bcx);
-                        temp_cleanups.push(scratch.val);
+                            // Technically, ownership of val passes to the callee.
+                            // However, we must cleanup should we fail before the
+                            // callee is actually invoked.
+                            scratch.add_clean(bcx);
+                            temp_cleanups.push(scratch.val);
 
-                        match arg_datum.appropriate_mode() {
-                            ByValue => val = Load(bcx, scratch.val),
-                            ByRef(_) => val = scratch.val,
+                            match scratch.appropriate_mode() {
+                                ByValue => val = Load(bcx, scratch.val),
+                                ByRef(_) => val = scratch.val,
+                            }
+                        } else {
+                            debug!("by copy arg with type %s");
+                            match arg_datum.mode {
+                                ByRef(_) => val = Load(bcx, arg_datum.val),
+                                ByValue => val = arg_datum.val,
+                            }
                         }
                     }
                 }

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -297,7 +297,10 @@ pub fn build_closure(bcx0: block,
         // the right thing):
         let ret_true = match bcx.fcx.loop_ret {
             Some((_, retptr)) => retptr,
-            None => bcx.fcx.llretptr.get()
+            None => match bcx.fcx.llretptr {
+                None => C_null(T_ptr(T_nil())),
+                Some(retptr) => retptr,
+            }
         };
         let ret_casted = PointerCast(bcx, ret_true, T_ptr(T_nil()));
         let ret_datum = Datum {val: ret_casted, ty: ty::mk_nil(),

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -55,7 +55,7 @@ pub fn type_of_fn(cx: &mut CrateContext, inputs: &[ty::t], output: ty::t)
         atys.push_all(type_of_explicit_args(cx, inputs));
 
         // Use the output as the actual return value if it's immediate.
-        if output_is_immediate {
+        if output_is_immediate && !ty::type_is_nil(output) {
             T_fn(atys, lloutputtype)
         } else {
             T_fn(atys, llvm::LLVMVoidTypeInContext(cx.llcx))
@@ -352,7 +352,7 @@ pub fn llvm_type_name(cx: &CrateContext,
 }
 
 pub fn type_of_dtor(ccx: &mut CrateContext, self_ty: ty::t) -> TypeRef {
-    T_fn([T_ptr(type_of(ccx, self_ty))] /* self */, T_nil())
+    T_fn([T_ptr(type_of(ccx, self_ty))] /* self */, T_void())
 }
 
 pub fn type_of_rooted(ccx: &mut CrateContext, t: ty::t) -> TypeRef {
@@ -364,5 +364,5 @@ pub fn type_of_rooted(ccx: &mut CrateContext, t: ty::t) -> TypeRef {
 
 pub fn type_of_glue_fn(ccx: &CrateContext) -> TypeRef {
     let tydescpp = T_ptr(T_ptr(ccx.tydesc_type));
-    return T_fn([T_ptr(T_nil()), tydescpp, T_ptr(T_i8())], T_nil());
+    return T_fn([T_ptr(T_nil()), tydescpp, T_ptr(T_i8())], T_void());
 }


### PR DESCRIPTION
The changes in these commits improve the IR codegen by removing unnecessary copies for certain function call arguments and stopping to allocate return values for functions returning nil. They reduce compile times by about 10% in total.
