### PR TITLE
Remove useless namegen thunk

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -19,6 +19,7 @@ use lib;
 use metadata::common::LinkMeta;
 use metadata::{encoder, csearch, cstore};
 use middle::trans::context::CrateContext;
+use middle::trans::common::gensym_name;
 use middle::ty;
 use util::ppaux;
 
@@ -37,6 +38,7 @@ use syntax::ast;
 use syntax::ast_map::{path, path_mod, path_name};
 use syntax::attr;
 use syntax::print::pprust;
+use syntax::parse::token;
 
 #[deriving(Eq)]
 pub enum output_type {
@@ -731,22 +733,22 @@ pub fn mangle_internal_name_by_type_and_seq(ccx: &mut CrateContext,
     return mangle(ccx.sess,
         ~[path_name(ccx.sess.ident_of(s)),
           path_name(ccx.sess.ident_of(hash)),
-          path_name((ccx.names)(name))]);
+          path_name(gensym_name(name))]);
 }
 
 pub fn mangle_internal_name_by_path_and_seq(ccx: &mut CrateContext,
-                                            path: path,
+                                            mut path: path,
                                             flav: &str) -> ~str {
-    mangle(ccx.sess,
-           vec::append_one(path, path_name((ccx.names)(flav))))
+    path.push(path_name(gensym_name(flav)));
+    mangle(ccx.sess, path)
 }
 
 pub fn mangle_internal_name_by_path(ccx: &mut CrateContext, path: path) -> ~str {
     mangle(ccx.sess, path)
 }
 
-pub fn mangle_internal_name_by_seq(ccx: &mut CrateContext, flav: &str) -> ~str {
-    fmt!("%s_%u", flav, (ccx.names)(flav).name)
+pub fn mangle_internal_name_by_seq(_ccx: &mut CrateContext, flav: &str) -> ~str {
+    return fmt!("%s_%u", flav, token::gensym(flav));
 }
 
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1129,15 +1129,10 @@ pub fn new_block(cx: fn_ctxt, parent: Option<block>, kind: block_kind,
                  is_lpad: bool, name: &str, opt_node_info: Option<NodeInfo>)
     -> block {
 
-    let s = if cx.ccx.sess.opts.save_temps || cx.ccx.sess.opts.debuginfo {
-        (cx.ccx.names)(name)
-    } else {
-        special_idents::invalid
-    };
     unsafe {
-        let llbb = str::as_c_str(cx.ccx.sess.str_of(s), |buf| {
+        let llbb = do name.as_c_str |buf| {
             llvm::LLVMAppendBasicBlockInContext(cx.ccx.llcx, cx.llfn, buf)
-        });
+        };
         let bcx = mk_block(llbb,
                            parent,
                            kind,
@@ -1145,8 +1140,11 @@ pub fn new_block(cx: fn_ctxt, parent: Option<block>, kind: block_kind,
                            opt_node_info,
                            cx);
         for parent.iter().advance |cx| {
-            if cx.unreachable { Unreachable(bcx); }
-        };
+            if cx.unreachable {
+                Unreachable(bcx);
+                break;
+            }
+        }
         bcx
     }
 }
@@ -2532,12 +2530,15 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::node_id) -> ValueRef {
 
 pub fn register_method(ccx: @mut CrateContext,
                        id: ast::node_id,
-                       pth: @ast_map::path,
+                       path: @ast_map::path,
                        m: @ast::method) -> ValueRef {
     let mty = ty::node_id_to_type(ccx.tcx, id);
-    let pth = vec::append(/*bad*/copy *pth, [path_name((ccx.names)("meth")),
-                                  path_name(m.ident)]);
-    let llfn = register_fn_full(ccx, m.span, pth, id, m.attrs, mty);
+
+    let mut path = /*bad*/ copy *path;
+    path.push(path_name(gensym_name("meth")));
+    path.push(path_name(m.ident));
+
+    let llfn = register_fn_full(ccx, m.span, path, id, m.attrs, mty);
     set_inline_hint_if_appr(m.attrs, llfn);
     llfn
 }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -45,14 +45,8 @@ use syntax::{ast, ast_map};
 
 pub use middle::trans::context::CrateContext;
 
-// NOTE: this thunk is totally pointless now that we're not passing
-// interners around...
-pub type namegen = @fn(s: &str) -> ident;
-pub fn new_namegen() -> namegen {
-    let f: @fn(s: &str) -> ident = |prefix| {
-        token::str_to_ident(fmt!("%s_%u", prefix, token::gensym(prefix)))
-    };
-    f
+pub fn gensym_name(name: &str) -> ident {
+    token::str_to_ident(fmt!("%s_%u", name, token::gensym(name)))
 }
 
 pub struct tydesc_info {
@@ -819,8 +813,9 @@ pub fn C_bytes(bytes: &[u8]) -> ValueRef {
 
 pub fn C_bytes_plus_null(bytes: &[u8]) -> ValueRef {
     unsafe {
-        let ptr = cast::transmute(vec::raw::to_ptr(bytes));
-        return llvm::LLVMConstStringInContext(base::task_llcx(), ptr, bytes.len() as c_uint,False);
+        return llvm::LLVMConstStringInContext(base::task_llcx(),
+            cast::transmute(vec::raw::to_ptr(bytes)),
+            bytes.len() as c_uint, False);
     }
 }
 

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -34,8 +34,7 @@ use core::local_data;
 use extra::time;
 use syntax::ast;
 
-use middle::trans::common::{ExternMap,tydesc_info,BuilderRef_res,Stats,namegen};
-use middle::trans::common::{mono_id,new_namegen};
+use middle::trans::common::{mono_id,ExternMap,tydesc_info,BuilderRef_res,Stats};
 
 use middle::trans::base::{decl_crate_map};
 
@@ -93,7 +92,6 @@ pub struct CrateContext {
      lltypes: HashMap<ty::t, Type>,
      llsizingtypes: HashMap<ty::t, Type>,
      adt_reprs: HashMap<ty::t, @adt::Repr>,
-     names: namegen,
      symbol_hasher: hash::State,
      type_hashcodes: HashMap<ty::t, @str>,
      type_short_names: HashMap<ty::t, ~str>,
@@ -194,7 +192,6 @@ impl CrateContext {
                   lltypes: HashMap::new(),
                   llsizingtypes: HashMap::new(),
                   adt_reprs: HashMap::new(),
-                  names: new_namegen(),
                   symbol_hasher: symbol_hasher,
                   type_hashcodes: HashMap::new(),
                   type_short_names: HashMap::new(),

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -28,15 +28,15 @@ use middle::trans::type_of::*;
 use middle::ty;
 use middle::typeck;
 use util::common::indenter;
-use util::ppaux::Repr;
+use util::ppaux::{Repr, ty_to_str};
 
 use middle::trans::type_::Type;
 
-use core::str;
 use core::vec;
 use syntax::ast_map::{path, path_mod, path_name};
 use syntax::ast_util;
 use syntax::{ast, ast_map};
+use syntax::parse::token;
 
 /**
 The main "translation" pass for methods.  Generates code
@@ -753,9 +753,10 @@ pub fn make_vtable(ccx: &mut CrateContext,
             components.push(ptr)
         }
 
+        let name = fmt!("%s_vtable_%u", ty_to_str(ccx.tcx, tydesc.ty), token::gensym("vtable"));
+
         let tbl = C_struct(components);
-        let vtable = ccx.sess.str_of((ccx.names)("vtable"));
-        let vt_gvar = do str::as_c_str(vtable) |buf| {
+        let vt_gvar = do name.as_c_str |buf| {
             llvm::LLVMAddGlobal(ccx.llmod, val_ty(tbl).to_ref(), buf)
         };
         llvm::LLVMSetInitializer(vt_gvar, tbl);

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -161,8 +161,9 @@ pub fn monomorphic_fn(ccx: @mut CrateContext,
     }
     ccx.monomorphizing.insert(fn_id, depth + 1);
 
-    let pt = vec::append(/*bad*/copy *pt,
-                         [path_name((ccx.names)(ccx.sess.str_of(name)))]);
+    let elt = path_name(gensym_name(ccx.sess.str_of(name)));
+    let mut pt = /* bad */copy (*pt);
+    pt.push(elt);
     let s = mangle_exported_name(ccx, /*bad*/copy pt, mono_ty);
 
     let mk_lldecl = || {


### PR DESCRIPTION
This removes the `namegen` thunk that was in `common.rs`. I also take the opportunity to refactor a few uses where we had a `str -> ident -> str` chain that seemed somewhat redundant to me.

Also cleans up some warnings that made their way in already.
