### PR TITLE
filtered for Option type

### DIFF
--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -159,6 +159,15 @@ impl<T> Option<T> {
         }
     }
 
+    /// Filters an optional value using given function.
+    #[inline(always)]
+    pub fn filtered<'a>(self, f: &fn(t: &'a T) -> bool) -> Option<T> {
+        match self {
+            Some(x) => if(f(&x)) {Some(x)} else {None},
+            None => None
+        }
+    }
+
     /// Maps a `some` value from one type to another by reference
     #[inline(always)]
     pub fn map<'a, U>(&self, f: &fn(&'a T) -> U) -> Option<U> {
@@ -458,4 +467,12 @@ fn test_get_or_zero() {
     assert_eq!(some_stuff.get_or_zero(), 42);
     let no_stuff: Option<int> = None;
     assert_eq!(no_stuff.get_or_zero(), 0);
+}
+
+#[test]
+fn test_filtered() {
+    let some_stuff = Some(42);
+    let modified_stuff = some_stuff.filtered(|&x| {x < 10});
+    assert_eq!(some_stuff.get(), 42);
+    assert!(modified_stuff.is_none());
 }


### PR DESCRIPTION
This commit adds filtered method for Option type. It is not exactly necessary (chain method can be used instead), however I believe that this approach using extra filtered method is more convinient.
