### PR TITLE
Add #[no_drop_flag] attribute

### DIFF
--- a/src/libextra/rc.rs
+++ b/src/libextra/rc.rs
@@ -70,10 +70,12 @@ impl<T> Rc<T> {
 impl<T> Drop for Rc<T> {
     fn finalize(&self) {
         unsafe {
-            (*self.ptr).count -= 1;
-            if (*self.ptr).count == 0 {
-                ptr::replace_ptr(self.ptr, intrinsics::uninit());
-                free(self.ptr as *c_void)
+            if self.ptr.is_not_null() {
+                (*self.ptr).count -= 1;
+                if (*self.ptr).count == 0 {
+                    ptr::replace_ptr(self.ptr, intrinsics::uninit());
+                    free(self.ptr as *c_void)
+                }
             }
         }
     }
@@ -220,10 +222,12 @@ impl<T> RcMut<T> {
 impl<T> Drop for RcMut<T> {
     fn finalize(&self) {
         unsafe {
-            (*self.ptr).count -= 1;
-            if (*self.ptr).count == 0 {
-                ptr::replace_ptr(self.ptr, uninit());
-                free(self.ptr as *c_void)
+            if self.ptr.is_not_null() {
+                (*self.ptr).count -= 1;
+                if (*self.ptr).count == 0 {
+                    ptr::replace_ptr(self.ptr, uninit());
+                    free(self.ptr as *c_void)
+                }
             }
         }
     }

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -135,7 +135,7 @@ fn represent_type_uncached(cx: &mut CrateContext, t: ty::t) -> Repr {
                 ty::lookup_field_type(cx.tcx, def_id, field.id, substs)
             };
             let packed = ty::lookup_packed(cx.tcx, def_id);
-            let dtor = ty::ty_dtor(cx.tcx, def_id).is_present();
+            let dtor = ty::ty_dtor(cx.tcx, def_id).has_drop_flag();
             let ftys =
                 if dtor { ftys + [ty::mk_bool()] } else { ftys };
             return Univariant(mk_struct(cx, ftys, packed), dtor)

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3855,7 +3855,7 @@ pub fn item_path_str(cx: ctxt, id: ast::def_id) -> ~str {
 
 pub enum DtorKind {
     NoDtor,
-    TraitDtor(def_id)
+    TraitDtor(def_id, bool)
 }
 
 impl DtorKind {
@@ -3869,13 +3869,24 @@ impl DtorKind {
     pub fn is_present(&const self) -> bool {
         !self.is_not_present()
     }
+
+    pub fn has_drop_flag(&self) -> bool {
+        match self {
+            &NoDtor => false,
+            &TraitDtor(_, flag) => flag
+        }
+    }
 }
 
 /* If struct_id names a struct with a dtor, return Some(the dtor's id).
    Otherwise return none. */
 pub fn ty_dtor(cx: ctxt, struct_id: def_id) -> DtorKind {
     match cx.destructor_for_type.find(&struct_id) {
-        Some(&method_def_id) => TraitDtor(method_def_id),
+        Some(&method_def_id) => {
+            let flag = has_attr(cx, struct_id, "no_drop_flag");
+
+            TraitDtor(method_def_id, flag)
+        }
         None => NoDtor,
     }
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3883,7 +3883,7 @@ impl DtorKind {
 pub fn ty_dtor(cx: ctxt, struct_id: def_id) -> DtorKind {
     match cx.destructor_for_type.find(&struct_id) {
         Some(&method_def_id) => {
-            let flag = has_attr(cx, struct_id, "no_drop_flag");
+            let flag = !has_attr(cx, struct_id, "no_drop_flag");
 
             TraitDtor(method_def_id, flag)
         }

--- a/src/libstd/unstable/atomics.rs
+++ b/src/libstd/unstable/atomics.rs
@@ -62,6 +62,7 @@ pub struct AtomicPtr<T> {
 /**
  * An owned atomic pointer. Ensures that only a single reference to the data is held at any time.
  */
+#[no_drop_flag]
 pub struct AtomicOption<T> {
     priv p: *mut c_void
 }

--- a/src/test/run-pass/attr-no-drop-flag-size.rs
+++ b/src/test/run-pass/attr-no-drop-flag-size.rs
@@ -1,0 +1,25 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::sys::size_of;
+
+#[no_drop_flag]
+struct Test<T> {
+    a: T
+}
+
+#[unsafe_destructor]
+impl<T> Drop for Test<T> {
+    fn finalize(&self) { }
+}
+
+fn main() {
+    assert_eq!(size_of::<int>(), size_of::<Test<int>>());
+}


### PR DESCRIPTION
This adds a `#[no_drop_flag]` attribute. This attribute tells the compiler to omit the drop flag from the struct, if it has a destructor. When the destructor is run, instead of setting the drop flag, it instead zeroes-out the struct. This means the destructor can run multiple times and therefore it is up to the developer to use it safely.

The primary usage case for this is smart-pointer types like `Rc<T>` as the extra flag caused the struct to be 1 word larger because of alignment.

This closes #7271 and #7138
