### PR TITLE
vec: fix documentation of vec::each

### DIFF
--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1351,16 +1351,19 @@ pub fn reversed<T:Copy>(v: &const [T]) -> ~[T] {
  * * continue iterating, false to break.
  *
  * # Examples
+ * (not using vec::each(), because it will be removed soon)
  *
  * ~~~ {.rust}
- * [1,2,3].each(|&i| {
+ * let v = [1,2,3];
+ * v.iter().advance(|&i| {
  *     io::println(int::str(i));
  *     true
  * });
  * ~~~
  *
  * ~~~ {.rust}
- * [1,2,3,4,5].each(|&i| {
+ * let v = [1,2,3,4,5];
+ * v.iter().advance(|&i| {
  *     if i < 4 {
  *         io::println(int::str(i));
  *         true
@@ -1375,7 +1378,8 @@ pub fn reversed<T:Copy>(v: &const [T]) -> ~[T] {
  * on your iteration needs:
  *
  * ~~~ {.rust}
- * for [1,2,3].each |&i| {
+ * let v = [1,2,3];
+ * v.iter().advance |&i| {
  *     io::println(int::str(i));
  * }
  * ~~~


### PR DESCRIPTION
5ec3aba (Improve documentation for each, 2012-12-27) incorrectly
documented vec::each by providing examples of old_iter::BaseIter usage
in the context of a vector.  Since d2e9912 (vec: remove BaseIter
implementation, 2013-06-21), those examples don't even work anymore.
Correct the examples.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
