### PR TITLE
Added --format to rustc

### DIFF
--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -1138,6 +1138,9 @@ mod tests {
         assert!(result::unwrap(strptime("-0800", "%z")).tm_gmtoff ==
             0);
         assert!(test("%", "%%"));
+
+        // Test for #7256
+        assert_eq!(strptime("360", "%Y-%m-%d"), Err(~"Invalid year"))
     }
 
     fn test_ctime() {

--- a/src/librust/rust.rc
+++ b/src/librust/rust.rc
@@ -118,6 +118,13 @@ static commands: &'static [Command<'static>] = &[
         usage_line: "run a rust interpreter",
         usage_full: UsgStr("\nUsage:\trusti"),
     },
+    Command{cmd: "format",
+              action: Call(format_source_code),
+              usage_line: "Formats and overwrites the specified files",
+              usage_full:
+                  UsgStr("usage: \"rust format file1.rs file2.rs\" aborts on error. Do 
+                          \"rust format --force file1.rs file2.rs\" if you want to contiue 
+                          formating even if an error is thrown")},
     Command{
         cmd: "help",
         action: Call(cmd_help),
@@ -129,6 +136,48 @@ static commands: &'static [Command<'static>] = &[
         )
     }
 ];
+pub fn format_source_code(args: &[~str]) -> ValidUsage {
+    let mut args = args.to_owned();
+
+    // true if all specified files are formatable
+    fn check_for_error(args: &[~str]) -> bool {
+        for args.iter().advance |p| {
+            let source_code =
+                core::run::process_output("rustc", &[copy *p, ~"--pretty"]);
+            if (source_code.output.is_empty()) { return false; }
+        }
+        true
+    }
+
+    fn write_output(args: &[~str]) {
+
+        
+        // If we have a writer in our result then we write the source code to it.
+        for args.iter().advance |path| {
+            let source_code =
+                core::run::process_output("rustc", &[copy *path, ~"--pretty"]);
+            let path = core::path::Path(*path);
+            // We overwrite the input file.
+            let writer_result = io::buffered_file_writer(&path);
+            match writer_result {
+                core::result::Ok(writer) => writer.write(source_code.output),
+                core::result::Err(u) => ()
+            };
+        }
+    }
+
+    // rust format --force file1 file2
+    if (*args.head() == ~"--force") {
+        args.shift();
+        write_output(args);
+        // rust format file1 file2 --format_source_code
+    } else if (*args.last() == ~"--force") {
+        args.pop();
+        write_output(args);
+
+    } else if (check_for_error(args)) { write_output(args); } else { return Invalid }
+    Valid(0)
+}
 
 fn rustc_help() {
     rustc::usage(copy os::args()[0])

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1415,24 +1415,26 @@ impl Resolver {
                                            (ReducedGraphParent,
                                             vt<ReducedGraphParent>)) {
         let ident = variant.node.name;
-        let (child, _) = self.add_child(ident, parent, ForbidDuplicateValues,
-                                        variant.span);
 
-        let privacy;
-        match variant.node.vis {
-            public => privacy = Public,
-            private => privacy = Private,
-            inherited => privacy = parent_privacy
-        }
+        let privacy =
+            match variant.node.vis {
+                public    => Public,
+                private   => Private,
+                inherited => parent_privacy
+            };
 
         match variant.node.kind {
             tuple_variant_kind(_) => {
+                let (child, _) = self.add_child(ident, parent, ForbidDuplicateValues,
+                                                variant.span);
                 child.define_value(privacy,
                                    def_variant(item_id,
                                                local_def(variant.node.id)),
                                    variant.span);
             }
             struct_variant_kind(_) => {
+                let (child, _) = self.add_child(ident, parent, ForbidDuplicateTypesAndValues,
+                                                variant.span);
                 child.define_type(privacy,
                                   def_variant(item_id,
                                               local_def(variant.node.id)),

--- a/src/test/compile-fail/dup-struct-enum-struct-variant.rs
+++ b/src/test/compile-fail/dup-struct-enum-struct-variant.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Foo { C { a: int, b: int } }
+struct C { a: int, b: int }         //~ ERROR error: duplicate definition of type `C`
+
+struct A { x: int }
+enum Bar { A { x: int } }           //~ ERROR error: duplicate definition of type `A`
+
+fn main() {}


### PR DESCRIPTION
Usage: rustc filename.rs --format
It formats the the specified file with --pretty normal.

There are two problems with this PR.

1.) I am using "process_output" instead of hooking me up in pretty_print directly. I didn't want to step on someones toes.

2.) Pretty print doesn't do a partial format. This mean that the source file doesn't get formated if the source code contains syntax errors.

I am currently using this with sublime. Every time I press ctrl+s it automatically saves and formats my current file.
