### PR TITLE
Removing '&const' usage and cleaning up the ast

### DIFF
--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -436,8 +436,8 @@ impl<T:Freeze + Send> RWARC<T> {
 // lock it. This wraps the unsafety, with the justification that the 'lock'
 // field is never overwritten; only 'failed' and 'data'.
 #[doc(hidden)]
-fn borrow_rwlock<T:Freeze + Send>(state: *const RWARCInner<T>) -> *RWlock {
-    unsafe { cast::transmute(&const (*state).lock) }
+fn borrow_rwlock<T:Freeze + Send>(state: *mut RWARCInner<T>) -> *RWlock {
+    unsafe { cast::transmute(&(*state).lock) }
 }
 
 /// The "write permission" token used for RWARC.write_downgrade().

--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -705,8 +705,8 @@ impl cmp::Eq for BitvSet {
 }
 
 impl Container for BitvSet {
-    fn len(&const self) -> uint { self.size }
-    fn is_empty(&const self) -> bool { self.size == 0 }
+    fn len(&self) -> uint { self.size }
+    fn is_empty(&self) -> bool { self.size == 0 }
 }
 
 impl Mutable for BitvSet {

--- a/src/libextra/deque.rs
+++ b/src/libextra/deque.rs
@@ -28,10 +28,10 @@ pub struct Deque<T> {
 
 impl<T> Container for Deque<T> {
     /// Return the number of elements in the deque
-    fn len(&const self) -> uint { self.nelts }
+    fn len(&self) -> uint { self.nelts }
 
     /// Return true if the deque contains no elements
-    fn is_empty(&const self) -> bool { self.len() == 0 }
+    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl<T> Mutable for Deque<T> {

--- a/src/libextra/flate.rs
+++ b/src/libextra/flate.rs
@@ -44,8 +44,8 @@ static lz_fast : c_int = 0x1;   // LZ with only one probe
 static lz_norm : c_int = 0x80;  // LZ with 128 probes, "normal"
 static lz_best : c_int = 0xfff; // LZ with 4095 probes, "best"
 
-pub fn deflate_bytes(bytes: &const [u8]) -> ~[u8] {
-    do vec::as_const_buf(bytes) |b, len| {
+pub fn deflate_bytes(bytes: &[u8]) -> ~[u8] {
+    do vec::as_imm_buf(bytes) |b, len| {
         unsafe {
             let mut outsz : size_t = 0;
             let res =
@@ -62,8 +62,8 @@ pub fn deflate_bytes(bytes: &const [u8]) -> ~[u8] {
     }
 }
 
-pub fn inflate_bytes(bytes: &const [u8]) -> ~[u8] {
-    do vec::as_const_buf(bytes) |b, len| {
+pub fn inflate_bytes(bytes: &[u8]) -> ~[u8] {
+    do vec::as_imm_buf(bytes) |b, len| {
         unsafe {
             let mut outsz : size_t = 0;
             let res =

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -87,10 +87,10 @@ impl<K: Ord + TotalOrd, V> Ord for TreeMap<K, V> {
 
 impl<K: TotalOrd, V> Container for TreeMap<K, V> {
     /// Return the number of elements in the map
-    fn len(&const self) -> uint { self.length }
+    fn len(&self) -> uint { self.length }
 
     /// Return true if the map contains no elements
-    fn is_empty(&const self) -> bool { self.root.is_none() }
+    fn is_empty(&self) -> bool { self.root.is_none() }
 }
 
 impl<K: TotalOrd, V> Mutable for TreeMap<K, V> {
@@ -265,11 +265,11 @@ impl<T: Ord + TotalOrd> Ord for TreeSet<T> {
 impl<T: TotalOrd> Container for TreeSet<T> {
     /// Return the number of elements in the set
     #[inline]
-    fn len(&const self) -> uint { self.map.len() }
+    fn len(&self) -> uint { self.map.len() }
 
     /// Return true if the set contains no elements
     #[inline]
-    fn is_empty(&const self) -> bool { self.map.is_empty() }
+    fn is_empty(&self) -> bool { self.map.is_empty() }
 }
 
 impl<T: TotalOrd> Mutable for TreeSet<T> {

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -786,7 +786,7 @@ fn get_explicit_self(item: ebml::Doc) -> ast::explicit_self_ {
         's' => { return ast::sty_static; }
         'v' => { return ast::sty_value; }
         '@' => { return ast::sty_box(get_mutability(string[1])); }
-        '~' => { return ast::sty_uniq(get_mutability(string[1])); }
+        '~' => { return ast::sty_uniq; }
         '&' => {
             // FIXME(#4846) expl. region
             return ast::sty_region(None, get_mutability(string[1]));

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -630,9 +630,8 @@ fn encode_explicit_self(ebml_w: &mut writer::Encoder, explicit_self: ast::explic
             ebml_w.writer.write(&[ '@' as u8 ]);
             encode_mutability(ebml_w, m);
         }
-        sty_uniq(m) => {
+        sty_uniq => {
             ebml_w.writer.write(&[ '~' as u8 ]);
-            encode_mutability(ebml_w, m);
         }
     }
 

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -92,7 +92,7 @@ pub fn check_expr(sess: Session,
     if is_const {
         match e.node {
           expr_unary(_, deref, _) => { }
-          expr_unary(_, box(_), _) | expr_unary(_, uniq(_), _) => {
+          expr_unary(_, box(_), _) | expr_unary(_, uniq, _) => {
             sess.span_err(e.span,
                           "disallowed operator in constant expression");
             return;

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -152,122 +152,122 @@ impl LanguageItems {
 
     // FIXME #4621: Method macros sure would be nice here.
 
-    pub fn freeze_trait(&const self) -> def_id {
+    pub fn freeze_trait(&self) -> def_id {
         self.items[FreezeTraitLangItem as uint].get()
     }
-    pub fn copy_trait(&const self) -> def_id {
+    pub fn copy_trait(&self) -> def_id {
         self.items[CopyTraitLangItem as uint].get()
     }
-    pub fn send_trait(&const self) -> def_id {
+    pub fn send_trait(&self) -> def_id {
         self.items[SendTraitLangItem as uint].get()
     }
-    pub fn sized_trait(&const self) -> def_id {
+    pub fn sized_trait(&self) -> def_id {
         self.items[SizedTraitLangItem as uint].get()
     }
 
-    pub fn drop_trait(&const self) -> def_id {
+    pub fn drop_trait(&self) -> def_id {
         self.items[DropTraitLangItem as uint].get()
     }
 
-    pub fn add_trait(&const self) -> def_id {
+    pub fn add_trait(&self) -> def_id {
         self.items[AddTraitLangItem as uint].get()
     }
-    pub fn sub_trait(&const self) -> def_id {
+    pub fn sub_trait(&self) -> def_id {
         self.items[SubTraitLangItem as uint].get()
     }
-    pub fn mul_trait(&const self) -> def_id {
+    pub fn mul_trait(&self) -> def_id {
         self.items[MulTraitLangItem as uint].get()
     }
-    pub fn div_trait(&const self) -> def_id {
+    pub fn div_trait(&self) -> def_id {
         self.items[DivTraitLangItem as uint].get()
     }
-    pub fn rem_trait(&const self) -> def_id {
+    pub fn rem_trait(&self) -> def_id {
         self.items[RemTraitLangItem as uint].get()
     }
-    pub fn neg_trait(&const self) -> def_id {
+    pub fn neg_trait(&self) -> def_id {
         self.items[NegTraitLangItem as uint].get()
     }
-    pub fn not_trait(&const self) -> def_id {
+    pub fn not_trait(&self) -> def_id {
         self.items[NotTraitLangItem as uint].get()
     }
-    pub fn bitxor_trait(&const self) -> def_id {
+    pub fn bitxor_trait(&self) -> def_id {
         self.items[BitXorTraitLangItem as uint].get()
     }
-    pub fn bitand_trait(&const self) -> def_id {
+    pub fn bitand_trait(&self) -> def_id {
         self.items[BitAndTraitLangItem as uint].get()
     }
-    pub fn bitor_trait(&const self) -> def_id {
+    pub fn bitor_trait(&self) -> def_id {
         self.items[BitOrTraitLangItem as uint].get()
     }
-    pub fn shl_trait(&const self) -> def_id {
+    pub fn shl_trait(&self) -> def_id {
         self.items[ShlTraitLangItem as uint].get()
     }
-    pub fn shr_trait(&const self) -> def_id {
+    pub fn shr_trait(&self) -> def_id {
         self.items[ShrTraitLangItem as uint].get()
     }
-    pub fn index_trait(&const self) -> def_id {
+    pub fn index_trait(&self) -> def_id {
         self.items[IndexTraitLangItem as uint].get()
     }
 
-    pub fn eq_trait(&const self) -> def_id {
+    pub fn eq_trait(&self) -> def_id {
         self.items[EqTraitLangItem as uint].get()
     }
-    pub fn ord_trait(&const self) -> def_id {
+    pub fn ord_trait(&self) -> def_id {
         self.items[OrdTraitLangItem as uint].get()
     }
 
-    pub fn str_eq_fn(&const self) -> def_id {
+    pub fn str_eq_fn(&self) -> def_id {
         self.items[StrEqFnLangItem as uint].get()
     }
-    pub fn uniq_str_eq_fn(&const self) -> def_id {
+    pub fn uniq_str_eq_fn(&self) -> def_id {
         self.items[UniqStrEqFnLangItem as uint].get()
     }
-    pub fn annihilate_fn(&const self) -> def_id {
+    pub fn annihilate_fn(&self) -> def_id {
         self.items[AnnihilateFnLangItem as uint].get()
     }
-    pub fn log_type_fn(&const self) -> def_id {
+    pub fn log_type_fn(&self) -> def_id {
         self.items[LogTypeFnLangItem as uint].get()
     }
-    pub fn fail_fn(&const self) -> def_id {
+    pub fn fail_fn(&self) -> def_id {
         self.items[FailFnLangItem as uint].get()
     }
-    pub fn fail_bounds_check_fn(&const self) -> def_id {
+    pub fn fail_bounds_check_fn(&self) -> def_id {
         self.items[FailBoundsCheckFnLangItem as uint].get()
     }
-    pub fn exchange_malloc_fn(&const self) -> def_id {
+    pub fn exchange_malloc_fn(&self) -> def_id {
         self.items[ExchangeMallocFnLangItem as uint].get()
     }
-    pub fn exchange_free_fn(&const self) -> def_id {
+    pub fn exchange_free_fn(&self) -> def_id {
         self.items[ExchangeFreeFnLangItem as uint].get()
     }
-    pub fn malloc_fn(&const self) -> def_id {
+    pub fn malloc_fn(&self) -> def_id {
         self.items[MallocFnLangItem as uint].get()
     }
-    pub fn free_fn(&const self) -> def_id {
+    pub fn free_fn(&self) -> def_id {
         self.items[FreeFnLangItem as uint].get()
     }
-    pub fn borrow_as_imm_fn(&const self) -> def_id {
+    pub fn borrow_as_imm_fn(&self) -> def_id {
         self.items[BorrowAsImmFnLangItem as uint].get()
     }
-    pub fn borrow_as_mut_fn(&const self) -> def_id {
+    pub fn borrow_as_mut_fn(&self) -> def_id {
         self.items[BorrowAsMutFnLangItem as uint].get()
     }
-    pub fn return_to_mut_fn(&const self) -> def_id {
+    pub fn return_to_mut_fn(&self) -> def_id {
         self.items[ReturnToMutFnLangItem as uint].get()
     }
-    pub fn check_not_borrowed_fn(&const self) -> def_id {
+    pub fn check_not_borrowed_fn(&self) -> def_id {
         self.items[CheckNotBorrowedFnLangItem as uint].get()
     }
-    pub fn strdup_uniq_fn(&const self) -> def_id {
+    pub fn strdup_uniq_fn(&self) -> def_id {
         self.items[StrDupUniqFnLangItem as uint].get()
     }
-    pub fn record_borrow_fn(&const self) -> def_id {
+    pub fn record_borrow_fn(&self) -> def_id {
         self.items[RecordBorrowFnLangItem as uint].get()
     }
-    pub fn unrecord_borrow_fn(&const self) -> def_id {
+    pub fn unrecord_borrow_fn(&self) -> def_id {
         self.items[UnrecordBorrowFnLangItem as uint].get()
     }
-    pub fn start_fn(&const self) -> def_id {
+    pub fn start_fn(&self) -> def_id {
         self.items[StartFnLangItem as uint].get()
     }
     pub fn ty_desc(&const self) -> def_id {

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -368,7 +368,7 @@ fn visit_fn(fk: &visit::fn_kind,
     match *fk {
         fk_method(_, _, method) => {
             match method.explicit_self.node {
-                sty_value | sty_region(*) | sty_box(_) | sty_uniq(_) => {
+                sty_value | sty_region(*) | sty_box(_) | sty_uniq => {
                     fn_maps.add_variable(Arg(method.self_id,
                                              special_idents::self_));
                 }

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -340,7 +340,7 @@ fn const_expr_unadjusted(cx: @mut CrateContext, e: &ast::expr) -> ValueRef {
             let is_float = ty::type_is_fp(ty);
             return match u {
               ast::box(_)  |
-              ast::uniq(_) |
+              ast::uniq |
               ast::deref  => {
                 let (dv, _dt) = const_deref(cx, te, ty, true);
                 dv

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1314,7 +1314,7 @@ fn trans_unary_datum(bcx: block,
             trans_boxed_expr(bcx, un_ty, sub_expr, sub_ty,
                              heap_managed)
         }
-        ast::uniq(_) => {
+        ast::uniq => {
             let heap  = heap_for_unique(bcx, un_ty);
             trans_boxed_expr(bcx, un_ty, sub_expr, sub_ty, heap)
         }

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -532,7 +532,7 @@ pub fn trans_trait_callee(bcx: block,
     let llpair = match explicit_self {
         ast::sty_region(*) => Load(bcx, llpair),
         ast::sty_static | ast::sty_value |
-        ast::sty_box(_) | ast::sty_uniq(_) => llpair
+        ast::sty_box(_) | ast::sty_uniq => llpair
     };
 
     let callee_ty = node_id_type(bcx, callee_id);
@@ -622,7 +622,7 @@ pub fn trans_trait_callee_from_llval(bcx: block,
 
             self_mode = ty::ByRef;
         }
-        ast::sty_uniq(_) => {
+        ast::sty_uniq => {
             // Pass the unique pointer.
             match store {
                 ty::UniqTraitStore => llself = llbox,

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -278,7 +278,7 @@ pub fn mark_for_method_call(cx: &Context, e_id: node_id, callee_id: node_id) {
 pub fn mark_for_expr(cx: &Context, e: &expr) {
     match e.node {
       expr_vstore(_, _) | expr_vec(_, _) | expr_struct(*) | expr_tup(_) |
-      expr_unary(_, box(_), _) | expr_unary(_, uniq(_), _) |
+      expr_unary(_, box(_), _) | expr_unary(_, uniq, _) |
       expr_binary(_, add, _, _) | expr_copy(_) | expr_repeat(*) => {
         node_type_needs(cx, use_repr, e.id);
       }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3696,14 +3696,14 @@ pub enum DtorKind {
 }
 
 impl DtorKind {
-    pub fn is_not_present(&const self) -> bool {
+    pub fn is_not_present(&self) -> bool {
         match *self {
             NoDtor => true,
             _ => false
         }
     }
 
-    pub fn is_present(&const self) -> bool {
+    pub fn is_present(&self) -> bool {
         !self.is_not_present()
     }
 

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -662,10 +662,10 @@ fn ty_of_method_or_bare_fn<AC:AstConv,RS:region_scope + Copy + 'static>(
                                 ty::mt {ty: self_info.untransformed_self_ty,
                                         mutbl: mutability}))
             }
-            ast::sty_uniq(mutability) => {
+            ast::sty_uniq => {
                 Some(ty::mk_uniq(this.tcx(),
                                  ty::mt {ty: self_info.untransformed_self_ty,
-                                         mutbl: mutability}))
+                                         mutbl: ast::m_imm}))
             }
         }
     }

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1123,11 +1123,11 @@ impl<'self> LookupContext<'self> {
                 }
             }
 
-            sty_uniq(m) => {
+            sty_uniq => {
                 debug!("(is relevant?) explicit self is a unique pointer");
                 match ty::get(rcvr_ty).sty {
                     ty::ty_uniq(mt) => {
-                        mutability_matches(mt.mutbl, m) &&
+                        mutability_matches(mt.mutbl, ast::m_imm) &&
                         self.fcx.can_mk_subty(mt.ty, candidate.rcvr_ty).is_ok()
                     }
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2301,7 +2301,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
       ast::expr_unary(callee_id, unop, oprnd) => {
         let exp_inner = do unpack_expected(fcx, expected) |sty| {
             match unop {
-              ast::box(_) | ast::uniq(_) => match *sty {
+              ast::box(_) | ast::uniq => match *sty {
                 ty::ty_box(ref mt) | ty::ty_uniq(ref mt) => Some(mt.ty),
                 _ => None
               },
@@ -2318,9 +2318,10 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                     oprnd_t = ty::mk_box(tcx,
                                          ty::mt {ty: oprnd_t, mutbl: mutbl});
                 }
-                ast::uniq(mutbl) => {
+                ast::uniq => {
                     oprnd_t = ty::mk_uniq(tcx,
-                                          ty::mt {ty: oprnd_t, mutbl: mutbl});
+                                          ty::mt {ty: oprnd_t,
+                                                  mutbl: ast::m_imm});
                 }
                 ast::deref => {
                     let sty = structure_of(fcx, expr.span, oprnd_t);

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -64,7 +64,7 @@ pub struct VtableContext {
 }
 
 impl VtableContext {
-    pub fn tcx(&const self) -> ty::ctxt { self.ccx.tcx }
+    pub fn tcx(&self) -> ty::ctxt { self.ccx.tcx }
 }
 
 fn has_trait_bounds(type_param_defs: &[ty::TypeParameterDef]) -> bool {

--- a/src/libstd/at_vec.rs
+++ b/src/libstd/at_vec.rs
@@ -108,7 +108,7 @@ pub fn build_sized_opt<A>(size: Option<uint>,
 /// Iterates over the `rhs` vector, copying each element and appending it to the
 /// `lhs`. Afterwards, the `lhs` is then returned for use again.
 #[inline]
-pub fn append<T:Copy>(lhs: @[T], rhs: &const [T]) -> @[T] {
+pub fn append<T:Copy>(lhs: @[T], rhs: &[T]) -> @[T] {
     do build_sized(lhs.len() + rhs.len()) |push| {
         for lhs.iter().advance |x| { push(copy *x); }
         for uint::range(0, rhs.len()) |i| { push(copy rhs[i]); }
@@ -180,9 +180,9 @@ pub mod traits {
     use kinds::Copy;
     use ops::Add;
 
-    impl<'self,T:Copy> Add<&'self const [T],@[T]> for @[T] {
+    impl<'self,T:Copy> Add<&'self [T],@[T]> for @[T] {
         #[inline]
-        fn add(&self, rhs: & &'self const [T]) -> @[T] {
+        fn add(&self, rhs: & &'self [T]) -> @[T] {
             append(*self, (*rhs))
         }
     }

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -282,10 +282,10 @@ impl<K:Hash + Eq,V> HashMap<K, V> {
 
 impl<K:Hash + Eq,V> Container for HashMap<K, V> {
     /// Return the number of elements in the map
-    fn len(&const self) -> uint { self.size }
+    fn len(&self) -> uint { self.size }
 
     /// Return true if the map contains no elements
-    fn is_empty(&const self) -> bool { self.len() == 0 }
+    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl<K:Hash + Eq,V> Mutable for HashMap<K, V> {
@@ -623,10 +623,10 @@ impl<T:Hash + Eq> Eq for HashSet<T> {
 
 impl<T:Hash + Eq> Container for HashSet<T> {
     /// Return the number of elements in the set
-    fn len(&const self) -> uint { self.map.len() }
+    fn len(&self) -> uint { self.map.len() }
 
     /// Return true if the set contains no elements
-    fn is_empty(&const self) -> bool { self.map.is_empty() }
+    fn is_empty(&self) -> bool { self.map.is_empty() }
 }
 
 impl<T:Hash + Eq> Mutable for HashSet<T> {

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -1152,7 +1152,7 @@ impl<W:Writer,C> Writer for Wrapper<W, C> {
 impl Writer for *libc::FILE {
     fn write(&self, v: &[u8]) {
         unsafe {
-            do vec::as_const_buf(v) |vbuf, len| {
+            do vec::as_imm_buf(v) |vbuf, len| {
                 let nout = libc::fwrite(vbuf as *c_void,
                                         1,
                                         len as size_t,
@@ -1203,9 +1203,9 @@ impl Writer for fd_t {
     fn write(&self, v: &[u8]) {
         unsafe {
             let mut count = 0u;
-            do vec::as_const_buf(v) |vbuf, len| {
+            do vec::as_imm_buf(v) |vbuf, len| {
                 while count < len {
-                    let vb = ptr::const_offset(vbuf, count) as *c_void;
+                    let vb = ptr::offset(vbuf, count) as *c_void;
                     let nout = libc::write(*self, vb, len as size_t);
                     if nout < 0 as ssize_t {
                         error!("error writing buffer");

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -121,13 +121,13 @@ impl<T> Option<T> {
 
     /// Returns true if the option equals `none`
     #[inline]
-    pub fn is_none(&const self) -> bool {
+    pub fn is_none(&self) -> bool {
         match *self { None => true, Some(_) => false }
     }
 
     /// Returns true if the option contains some value
     #[inline]
-    pub fn is_some(&const self) -> bool { !self.is_none() }
+    pub fn is_some(&self) -> bool { !self.is_none() }
 
     /// Update an optional value by optionally running its content through a
     /// function that returns an option.

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -232,9 +232,9 @@ pub unsafe fn array_each<T>(arr: **T, cb: &fn(*T)) {
 
 #[allow(missing_doc)]
 pub trait RawPtr<T> {
-    fn is_null(&const self) -> bool;
-    fn is_not_null(&const self) -> bool;
-    unsafe fn to_option(&const self) -> Option<&T>;
+    fn is_null(&self) -> bool;
+    fn is_not_null(&self) -> bool;
+    unsafe fn to_option(&self) -> Option<&T>;
     fn offset(&self, count: uint) -> Self;
 }
 
@@ -242,11 +242,11 @@ pub trait RawPtr<T> {
 impl<T> RawPtr<T> for *T {
     /// Returns true if the pointer is equal to the null pointer.
     #[inline]
-    fn is_null(&const self) -> bool { is_null(*self) }
+    fn is_null(&self) -> bool { is_null(*self) }
 
     /// Returns true if the pointer is not equal to the null pointer.
     #[inline]
-    fn is_not_null(&const self) -> bool { is_not_null(*self) }
+    fn is_not_null(&self) -> bool { is_not_null(*self) }
 
     ///
     /// Returns `None` if the pointer is null, or else returns the value wrapped
@@ -259,7 +259,7 @@ impl<T> RawPtr<T> for *T {
     /// be pointing to invalid memory.
     ///
     #[inline]
-    unsafe fn to_option(&const self) -> Option<&T> {
+    unsafe fn to_option(&self) -> Option<&T> {
         if self.is_null() { None } else {
             Some(cast::transmute(*self))
         }
@@ -274,11 +274,11 @@ impl<T> RawPtr<T> for *T {
 impl<T> RawPtr<T> for *mut T {
     /// Returns true if the pointer is equal to the null pointer.
     #[inline]
-    fn is_null(&const self) -> bool { is_null(*self) }
+    fn is_null(&self) -> bool { is_null(*self) }
 
     /// Returns true if the pointer is not equal to the null pointer.
     #[inline]
-    fn is_not_null(&const self) -> bool { is_not_null(*self) }
+    fn is_not_null(&self) -> bool { is_not_null(*self) }
 
     ///
     /// Returns `None` if the pointer is null, or else returns the value wrapped
@@ -291,7 +291,7 @@ impl<T> RawPtr<T> for *mut T {
     /// be pointing to invalid memory.
     ///
     #[inline]
-    unsafe fn to_option(&const self) -> Option<&T> {
+    unsafe fn to_option(&self) -> Option<&T> {
         if self.is_null() { None } else {
             Some(cast::transmute(*self))
         }

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -569,7 +569,7 @@ Section: Misc
 */
 
 /// Determines if a vector of bytes contains valid UTF-8
-pub fn is_utf8(v: &const [u8]) -> bool {
+pub fn is_utf8(v: &[u8]) -> bool {
     let mut i = 0u;
     let total = v.len();
     while i < total {
@@ -815,7 +815,7 @@ pub mod raw {
     }
 
     /// Create a Rust string from a *u8 buffer of the given length
-    pub unsafe fn from_buf_len(buf: *const u8, len: uint) -> ~str {
+    pub unsafe fn from_buf_len(buf: *u8, len: uint) -> ~str {
         let mut v: ~[u8] = vec::with_capacity(len + 1);
         vec::as_mut_buf(v, |vbuf, _len| {
             ptr::copy_memory(vbuf, buf as *u8, len)
@@ -838,8 +838,8 @@ pub mod raw {
     }
 
     /// Converts a vector of bytes to a new owned string.
-    pub unsafe fn from_bytes(v: &const [u8]) -> ~str {
-        do vec::as_const_buf(v) |buf, len| {
+    pub unsafe fn from_bytes(v: &[u8]) -> ~str {
+        do vec::as_imm_buf(v) |buf, len| {
             from_buf_len(buf, len)
         }
     }

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -129,7 +129,7 @@ type TaskGroupInner<'self> = &'self mut Option<TaskGroupData>;
 
 // A taskgroup is 'dead' when nothing can cause it to fail; only members can.
 fn taskgroup_is_dead(tg: &TaskGroupData) -> bool {
-    (&const tg.members).is_empty()
+    tg.members.is_empty()
 }
 
 // A list-like structure by which taskgroups keep track of all ancestor groups

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -35,11 +35,11 @@ pub struct TrieMap<T> {
 impl<T> Container for TrieMap<T> {
     /// Return the number of elements in the map
     #[inline]
-    fn len(&const self) -> uint { self.length }
+    fn len(&self) -> uint { self.length }
 
     /// Return true if the map contains no elements
     #[inline]
-    fn is_empty(&const self) -> bool { self.len() == 0 }
+    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl<T> Mutable for TrieMap<T> {
@@ -179,11 +179,11 @@ pub struct TrieSet {
 impl Container for TrieSet {
     /// Return the number of elements in the set
     #[inline]
-    fn len(&const self) -> uint { self.map.len() }
+    fn len(&self) -> uint { self.map.len() }
 
     /// Return true if the set contains no elements
     #[inline]
-    fn is_empty(&const self) -> bool { self.map.is_empty() }
+    fn is_empty(&self) -> bool { self.map.is_empty() }
 }
 
 impl Mutable for TrieSet {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -333,7 +333,7 @@ pub enum binop {
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub enum unop {
     box(mutability),
-    uniq(mutability),
+    uniq,
     deref,
     not,
     neg
@@ -805,7 +805,7 @@ pub enum explicit_self_ {
     sty_value,                                 // `self`
     sty_region(Option<@Lifetime>, mutability), // `&'lt self`
     sty_box(mutability),                       // `@self`
-    sty_uniq(mutability)                       // `~self`
+    sty_uniq                                   // `~self`
 }
 
 pub type explicit_self = spanned<explicit_self_>;

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -135,7 +135,7 @@ pub fn is_shift_binop(b: binop) -> bool {
 pub fn unop_to_str(op: unop) -> ~str {
     match op {
       box(mt) => if mt == m_mutbl { ~"@mut " } else { ~"@" },
-      uniq(mt) => if mt == m_mutbl { ~"~mut " } else { ~"~" },
+      uniq => ~"~",
       deref => ~"*",
       not => ~"!",
       neg => ~"-"

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -248,7 +248,7 @@ pub fn get_explicit_self(cx: @ExtCtxt, span: span, self_ptr: &Option<PtrTy>)
             let self_ty = respan(
                 span,
                 match *ptr {
-                    Send => ast::sty_uniq(ast::m_imm),
+                    Send => ast::sty_uniq,
                     Managed(mutbl) => ast::sty_box(mutbl),
                     Borrowed(ref lt, mutbl) => {
                         let lt = lt.map(|s| @cx.lifetime(span,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1653,6 +1653,7 @@ pub fn print_explicit_self(s: @ps, explicit_self: ast::explicit_self_) -> bool {
     match explicit_self {
         ast::sty_static => { return false; }
         ast::sty_value => { word(s.s, "self"); }
+        ast::sty_uniq => { word(s.s, "~self"); }
         ast::sty_region(lt, m) => {
             word(s.s, "&");
             print_opt_lifetime(s, lt);
@@ -1661,9 +1662,6 @@ pub fn print_explicit_self(s: @ps, explicit_self: ast::explicit_self_) -> bool {
         }
         ast::sty_box(m) => {
             word(s.s, "@"); print_mutability(s, m); word(s.s, "self");
-        }
-        ast::sty_uniq(m) => {
-            word(s.s, "~"); print_mutability(s, m); word(s.s, "self");
         }
     }
     return true;


### PR DESCRIPTION
This removes usage of `&const` throughout the standard libraries/compiler, and it removes some extraneous fields in the AST now that unique boxes always inherit their mutability.
