### PR TITLE
libsyntax cleanup episode 1

### DIFF
--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -8,9 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
-use core::to_bytes;
+use std::to_bytes;
 
 #[deriving(Eq)]
 pub enum Abi {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -10,18 +10,16 @@
 
 // The Rust abstract syntax tree.
 
-use core::prelude::*;
-
 use codemap::{span, spanned};
 use abi::AbiSet;
 use opt_vec::OptVec;
 use parse::token::{interner_get, str_to_ident};
 
-use core::hashmap::HashMap;
-use core::option::Option;
-use core::to_bytes::IterBytes;
-use core::to_bytes;
-use core::to_str::ToStr;
+use std::hashmap::HashMap;
+use std::option::Option;
+use std::to_bytes::IterBytes;
+use std::to_bytes;
+use std::to_str::ToStr;
 use extra::serialize::{Encodable, Decodable, Encoder, Decoder};
 
 

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use abi::AbiSet;
 use ast::*;
 use ast;
@@ -22,9 +20,9 @@ use print::pprust;
 use visit;
 use syntax::parse::token::special_idents;
 
-use core::cmp;
-use core::hashmap::HashMap;
-use core::vec;
+use std::cmp;
+use std::hashmap::HashMap;
+use std::vec;
 
 pub enum path_elt {
     path_mod(ident),

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -8,22 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast::*;
 use ast;
 use ast_util;
 use codemap::{span, spanned};
-use core::cast;
-use core::local_data;
 use opt_vec;
 use parse::token;
 use visit;
 
-use core::hashmap::HashMap;
-use core::int;
-use core::option;
-use core::to_bytes;
+use std::hashmap::HashMap;
+use std::int;
+use std::option;
+use std::to_bytes;
+use std::cast;
+use std::local_data;
 
 pub fn path_name_i(idents: &[ident]) -> ~str {
     // FIXME: Bad copies (#2543 -- same for everything else that says "bad")
@@ -793,7 +791,7 @@ pub fn getLast(arr: &~[Mrk]) -> uint {
 mod test {
     use ast::*;
     use super::*;
-    use core::io;
+    use std::io;
 
     #[test] fn xorpush_test () {
         let mut s = ~[];

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -10,7 +10,7 @@
 
 // Functions dealing with attributes and meta_items
 
-use core::prelude::*;
+extern mod extra;
 
 use ast;
 use codemap::{spanned, dummy_spanned};
@@ -19,10 +19,8 @@ use codemap::BytePos;
 use diagnostic::span_handler;
 use parse::comments::{doc_comment_style, strip_doc_comment_decoration};
 
-use core::hashmap::HashSet;
-use core::vec;
-use extra;
-
+use std::hashmap::HashSet;
+use std::vec;
 /* Constructors */
 
 pub fn mk_name_value_item_str(name: @str, value: @str)

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -10,7 +10,7 @@
 
 // Functions dealing with attributes and meta_items
 
-extern mod extra;
+use extra;
 
 use ast;
 use codemap::{spanned, dummy_spanned};

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -21,11 +21,9 @@ source code snippets, etc.
 
 */
 
-use core::prelude::*;
-
-use core::cmp;
-use core::to_bytes;
-use core::uint;
+use std::cmp;
+use std::to_bytes;
+use std::uint;
 use extra::serialize::{Encodable, Decodable, Encoder, Decoder};
 
 pub trait Pos {

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -8,14 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use codemap::{Pos, span};
 use codemap;
 
-use core::io;
-use core::uint;
-use core::vec;
+use std::io;
+use std::uint;
+use std::vec;
 use extra::term;
 
 pub type Emitter = @fn(cmsp: Option<(@codemap::CodeMap, span)>,

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -12,15 +12,14 @@
  * Inline assembly support.
  */
 
-use core::prelude::*;
-
-use core::vec;
 use ast;
 use codemap::span;
 use ext::base;
 use ext::base::*;
 use parse;
 use parse::token;
+
+use std::vec;
 
 enum State {
     Asm,

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
-use core::vec;
 use ast;
 use ast::Name;
 use codemap;
@@ -22,7 +19,8 @@ use parse;
 use parse::token;
 use parse::token::{ident_to_str, intern, str_to_ident};
 
-use core::hashmap::HashMap;
+use std::vec;
+use std::hashmap::HashMap;
 
 // new-style macro! tt code:
 //
@@ -535,7 +533,7 @@ fn satisfies_pred<K : Eq + Hash + IterBytes,V>(map : &mut HashMap<K,V>,
 #[cfg(test)]
 mod test {
     use super::MapChain;
-    use core::hashmap::HashMap;
+    use std::hashmap::HashMap;
 
     #[test] fn testenv () {
         let mut a = HashMap::new();

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use abi::AbiSet;
 use ast::ident;
 use ast;

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use codemap::span;
 use ext::base::*;

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast::{meta_item, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast::{meta_item, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use ast::{meta_item, item, expr};
 use codemap::span;

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
+use std::prelude::*;
 
 use ast::{meta_item, item, expr};
 use codemap::span;

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -8,14 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast::{meta_item, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
-use core::cmp::{Ordering, Equal, Less, Greater};
+use std::cmp::{Ordering, Equal, Less, Greater};
 
 pub fn expand_deriving_totalord(cx: @ExtCtxt,
                                 span: span,

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -13,9 +13,8 @@ The compiler code necessary for #[deriving(Decodable)]. See
 encodable.rs for more.
 */
 
-use core::prelude::*;
-use core::vec;
-use core::uint;
+use std::vec;
+use std::uint;
 
 use ast::{meta_item, item, expr, m_mutbl};
 use codemap::span;

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -75,8 +75,6 @@ would yield functions like:
     }
 */
 
-use core::prelude::*;
-
 use ast::{meta_item, item, expr, m_imm, m_mutbl};
 use codemap::span;
 use ext::base::ExtCtxt;

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -162,8 +162,6 @@ StaticEnum(<ast::enum_def of C>, ~[(<ident of C0>, Left(1)),
 
 */
 
-use core::prelude::*;
-
 use ast;
 use ast::{enum_def, expr, ident, Generics, struct_def};
 
@@ -172,8 +170,8 @@ use ext::build::AstBuilder;
 use codemap::{span,respan};
 use opt_vec;
 
-use core::uint;
-use core::vec;
+use std::uint;
+use std::vec;
 
 pub use self::ty::*;
 mod ty;
@@ -195,7 +193,7 @@ pub struct TraitDef<'self> {
 pub struct MethodDef<'self> {
     /// name of the method
     name: &'self str,
-    /// List of generics, e.g. `R: core::rand::Rng`
+    /// List of generics, e.g. `R: std::rand::Rng`
     generics: LifetimeBounds<'self>,
 
     /// Whether there is a self argument (outer Option) i.e. whether

--- a/src/libsyntax/ext/deriving/iter_bytes.rs
+++ b/src/libsyntax/ext/deriving/iter_bytes.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast::{meta_item, item, expr, and};
 use codemap::span;
 use ext::base::ExtCtxt;

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -18,8 +18,6 @@ library.
 
 */
 
-use core::prelude::*;
-
 use ast::{enum_def, ident, item, Generics, meta_item, struct_def};
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use ast::{meta_item, item, expr, ident};
 use codemap::span;
@@ -17,7 +15,7 @@ use ext::base::ExtCtxt;
 use ext::build::{AstBuilder, Duplicate};
 use ext::deriving::generic::*;
 
-use core::vec;
+use std::vec;
 
 pub fn expand_deriving_rand(cx: @ExtCtxt,
                             span: span,

--- a/src/libsyntax/ext/deriving/to_str.rs
+++ b/src/libsyntax/ext/deriving/to_str.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use ast::{meta_item, item, expr};
 use codemap::span;

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -13,8 +13,6 @@ A mini version of ast::Ty, which is easier to use, and features an
 explicit `Self` type to use when specifying impls to be derived.
 */
 
-use core::prelude::*;
-
 use ast;
 use ast::{expr,Generics,ident};
 use ext::base::ExtCtxt;
@@ -29,7 +27,7 @@ pub enum PtrTy<'self> {
     Borrowed(Option<&'self str>, ast::mutability), // &['lifetime] [mut]
 }
 
-/// A path, e.g. `::core::option::Option::<int>` (global). Has support
+/// A path, e.g. `::std::option::Option::<int>` (global). Has support
 /// for type parameters and a lifetime.
 pub struct Path<'self> {
     path: ~[&'self str],

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -8,15 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast::{meta_item, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-use core::vec;
+use std::vec;
 
 pub fn expand_deriving_zero(cx: @ExtCtxt,
                             span: span,

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -14,15 +14,13 @@
  * interface.
  */
 
-use core::prelude::*;
-
 use ast;
 use codemap::span;
 use ext::base::*;
 use ext::base;
 use ext::build::AstBuilder;
 
-use core::os;
+use std::os;
 
 pub fn expand_syntax_ext(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
     -> base::MacResult {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast::{blk_, attribute_, attr_outer, meta_word};
 use ast::{crate, expr_, expr_mac, mac_invoc_tt};
 use ast::{item_mac, stmt_, stmt_mac, stmt_expr, stmt_semi};
@@ -27,7 +25,7 @@ use parse::token::{ident_to_str, intern};
 use visit;
 use visit::Visitor;
 
-use core::vec;
+use std::vec;
 
 pub fn expand_expr(extsbox: @mut SyntaxEnv,
                    cx: @ExtCtxt,
@@ -757,8 +755,6 @@ mod test {
     use print::pprust;
     use util::parser_testing::{string_to_item, string_to_pat, strs_to_idents};
     use visit::{mk_vt};
-
-    use core::option::{None, Some};
 
     // make sure that fail! is present
     #[test] fn fail_exists_test () {

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -14,17 +14,15 @@
  * compiler syntax extension plugin interface.
  */
 
-use core::prelude::*;
-
 use ast;
 use codemap::span;
 use ext::base::*;
 use ext::base;
 use ext::build::AstBuilder;
 
-use core::option;
-use core::unstable::extfmt::ct::*;
-use core::vec;
+use std::option;
+use std::unstable::extfmt::ct::*;
+use std::vec;
 use parse::token::{str_to_ident};
 
 pub fn expand_syntax_ext(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
@@ -267,7 +265,7 @@ fn pieces_to_expr(cx: @ExtCtxt, sp: span,
     let mut stms = ~[];
 
     /* Translate each piece (portion of the fmt expression) by invoking the
-       corresponding function in core::unstable::extfmt. Each function takes a
+       corresponding function in std::unstable::extfmt. Each function takes a
        buffer to insert data into along with the data being formatted. */
     let npieces = pieces.len();
     do vec::consume(pieces) |i, pc| {

--- a/src/libsyntax/ext/log_syntax.rs
+++ b/src/libsyntax/ext/log_syntax.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
-use core::vec;
 use ast;
 use codemap;
 use ext::base::*;
@@ -18,7 +15,8 @@ use ext::base;
 use print;
 use parse::token::{get_ident_interner};
 
-use core::io;
+use std::vec;
+use std::io;
 
 pub fn expand_syntax_ext(cx: @ExtCtxt,
                          sp: codemap::span,

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -13,13 +13,11 @@
 // To start with, it will be use dummy spans, but it might someday do
 // something smarter.
 
-use core::prelude::*;
-
 use ast::ident;
 use ast;
 use codemap::span;
 
-use core::vec;
+use std::vec;
 
 // Transitional reexports so qquote can find the paths it is looking for
 mod syntax {

--- a/src/libsyntax/ext/pipes/check.rs
+++ b/src/libsyntax/ext/pipes/check.rs
@@ -29,8 +29,6 @@ that.
 
 */
 
-use core::prelude::*;
-
 use ast;
 use codemap::span;
 use ext::base::ExtCtxt;

--- a/src/libsyntax/ext/pipes/liveness.rs
+++ b/src/libsyntax/ext/pipes/liveness.rs
@@ -37,8 +37,6 @@ updating the states using rule (2) until there are no changes.
 
 */
 
-use core::prelude::*;
-
 use ext::base::ExtCtxt;
 use ext::pipes::proto::{protocol_};
 

--- a/src/libsyntax/ext/pipes/mod.rs
+++ b/src/libsyntax/ext/pipes/mod.rs
@@ -52,7 +52,6 @@ use ext::pipes::pipec::gen_init;
 use ext::pipes::proto::visit;
 use parse::lexer::{new_tt_reader, reader};
 use parse::parser::Parser;
-use core::option::None;
 
 pub mod ast_builder;
 pub mod parse_proto;

--- a/src/libsyntax/ext/pipes/parse_proto.rs
+++ b/src/libsyntax/ext/pipes/parse_proto.rs
@@ -10,8 +10,6 @@
 
 // Parsing pipes protocols from token trees.
 
-use core::prelude::*;
-
 use ast_util;
 use ext::pipes::proto::*;
 use parse::common::SeqSep;

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -10,8 +10,6 @@
 
 // A protocol compiler for Rust.
 
-use core::prelude::*;
-
 use ast;
 use codemap::{dummy_sp, spanned};
 use ext::base::ExtCtxt;
@@ -23,7 +21,7 @@ use ext::quote::rt::*;
 use opt_vec;
 use opt_vec::OptVec;
 
-use core::vec;
+use std::vec;
 
 pub trait gen_send {
     fn gen_send(&mut self, cx: @ExtCtxt, try: bool) -> @ast::item;

--- a/src/libsyntax/ext/pipes/proto.rs
+++ b/src/libsyntax/ext/pipes/proto.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use codemap::span;
 use ext::base::ExtCtxt;

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
-use core::vec;
 use ast;
 use codemap::{BytePos, Pos, span};
 use ext::base::ExtCtxt;
@@ -19,6 +16,8 @@ use ext::build::AstBuilder;
 use parse::token::*;
 use parse::token;
 use parse;
+
+use std::vec;
 
 /**
 *
@@ -32,8 +31,6 @@ use parse;
 */
 
 pub mod rt {
-    use core::prelude::*;
-
     use ast;
     use ext::base::ExtCtxt;
     use parse;

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use codemap;
 use codemap::{Pos, ExpandedFrom, span};
@@ -21,9 +19,9 @@ use parse;
 use parse::token::{get_ident_interner};
 use print::pprust;
 
-use core::io;
-use core::result;
-use core::vec;
+use std::io;
+use std::result;
+use std::vec;
 
 // These macros all relate to the file system; they either return
 // the column/row/filename of the expression, or they include

--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
-use core::vec;
 use ast;
 use codemap::span;
 use ext::base::ExtCtxt;
@@ -18,6 +15,8 @@ use ext::base;
 use parse::lexer::{new_tt_reader, reader};
 use parse::parser::Parser;
 use parse::token::keywords;
+
+use std::vec;
 
 pub fn expand_trace_macros(cx: @ExtCtxt,
                            sp: span,

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -10,8 +10,6 @@
 
 // Earley-like parser for macros.
 
-use core::prelude::*;
-
 use ast;
 use ast::{matcher, match_tok, match_seq, match_nonterminal, ident};
 use codemap::{BytePos, mk_sp};
@@ -22,9 +20,9 @@ use parse::parser::Parser;
 use parse::token::{Token, EOF, to_str, nonterminal, get_ident_interner, ident_to_str};
 use parse::token;
 
-use core::hashmap::HashMap;
-use core::uint;
-use core::vec;
+use std::hashmap::HashMap;
+use std::uint;
+use std::vec;
 
 /* This is an Earley-like parser, without support for in-grammar nonterminals,
 only by calling out to the main rust parser for named nonterminals (which it

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
-use core::vec;
 use ast::{ident, matcher_, matcher, match_tok, match_nonterminal, match_seq};
 use ast::{tt_delim};
 use ast;
@@ -26,7 +23,8 @@ use parse::token::{get_ident_interner, special_idents, gensym_ident, ident_to_st
 use parse::token::{FAT_ARROW, SEMI, nt_matchers, nt_tt};
 use print;
 
-use core::io;
+use std::vec;
+use std::io;
 
 pub fn add_new_extension(cx: @ExtCtxt,
                          sp: span,

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use ast::{token_tree, tt_delim, tt_tok, tt_seq, tt_nonterminal,ident};
 use codemap::{span, dummy_sp};
@@ -19,8 +17,8 @@ use parse::token::{EOF, INTERPOLATED, IDENT, Token, nt_ident};
 use parse::token::{ident_to_str};
 use parse::lexer::TokenAndSpan;
 
-use core::hashmap::HashMap;
-use core::option;
+use std::hashmap::HashMap;
+use std::option;
 
 ///an unzipping of `token_tree`s
 struct TtFrame {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -8,15 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast::*;
 use ast;
 use codemap::{span, spanned};
 use parse::token;
 use opt_vec::OptVec;
 
-use core::vec;
+use std::vec;
 
 pub trait ast_fold {
     fn fold_crate(@self, &crate) -> crate;
@@ -1011,5 +1009,4 @@ mod test {
                                     token::get_ident_interner()),
                      ~"zz!zz((zz$zz:zz$(zz $zz:zz)zz+=>(zz$(zz$zz$zz)+)))");
     }
-
 }

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -16,8 +16,7 @@
  * other useful things like `push()` and `len()`.
  */
 
-use core::prelude::*;
-use core::vec::VecIterator;
+use std::vec::VecIterator;
 
 #[deriving(Encodable, Decodable)]
 pub enum OptVec<T> {

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use codemap::{BytePos, CharPos, CodeMap, Pos};
 use diagnostic;
@@ -20,9 +18,9 @@ use parse::lexer;
 use parse::token;
 use parse::token::{get_ident_interner};
 
-use core::io;
-use core::str;
-use core::uint;
+use std::io;
+use std::str;
+use std::uint;
 
 #[deriving(Eq)]
 pub enum cmnt_style {

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use codemap::{BytePos, spanned};
 use parse::lexer::reader;

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use codemap::{BytePos, CharPos, CodeMap, Pos, span};
 use codemap;
@@ -19,9 +17,9 @@ use ext::tt::transcribe::{dup_tt_reader};
 use parse::token;
 use parse::token::{str_to_ident};
 
-use core::char;
-use core::either;
-use core::u64;
+use std::char;
+use std::either;
+use std::u64;
 
 pub use ext::tt::transcribe::{TtReader, new_tt_reader};
 
@@ -789,7 +787,6 @@ mod test {
 
     use ast;
     use codemap::{BytePos, CodeMap, span};
-    use core::option::None;
     use diagnostic;
     use parse::token;
     use parse::token::{str_to_ident};

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -20,10 +20,8 @@ use parse::attr::parser_attr;
 use parse::lexer::reader;
 use parse::parser::Parser;
 
-use core::io;
-use core::option::{None, Option, Some};
-use core::path::Path;
-use core::result::{Err, Ok};
+use std::io;
+use std::path::Path;
 
 pub mod lexer;
 pub mod parser;
@@ -335,9 +333,7 @@ mod test {
     use super::*;
     use extra::serialize::Encodable;
     use extra;
-    use core::io;
-    use core::option::Some;
-    use core::option::None;
+    use std::io;
     use codemap::{span, BytePos, spanned};
     use opt_vec;
     use ast;

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -17,8 +17,6 @@ Obsolete syntax that becomes too hard to parse can be
 removed.
 */
 
-use core::prelude::*;
-
 use ast::{expr, expr_lit, lit_nil, attribute};
 use ast;
 use codemap::{span, respan};
@@ -26,8 +24,8 @@ use parse::parser::Parser;
 use parse::token::{keywords, Token};
 use parse::token;
 
-use core::str;
-use core::to_bytes;
+use std::str;
+use std::to_bytes;
 
 /// The specific types of unsupported syntax
 #[deriving(Eq)]
@@ -127,7 +125,7 @@ impl Parser {
             ),
             ObsoleteSwap => (
                 "swap",
-                "Use core::util::{swap, replace} instead"
+                "Use std::util::{swap, replace} instead"
             ),
             ObsoleteUnsafeBlock => (
                 "non-standalone unsafe block",

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use abi;
 use abi::AbiSet;
 use ast::{Sigil, BorrowedSigil, ManagedSigil, OwnedSigil};
@@ -92,10 +90,10 @@ use parse::{new_sub_parser_from_file, next_node_id, ParseSess};
 use opt_vec;
 use opt_vec::OptVec;
 
-use core::either::Either;
-use core::either;
-use core::hashmap::HashSet;
-use core::vec;
+use std::either::Either;
+use std::either;
+use std::hashmap::HashSet;
+use std::vec;
 
 #[deriving(Eq)]
 enum restriction {

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use ast;
 use ast::Name;
 use ast_util;
@@ -17,12 +15,12 @@ use parse::token;
 use util::interner::StrInterner;
 use util::interner;
 
-use core::cast;
-use core::char;
-use core::cmp::Equiv;
-use core::local_data;
-use core::rand;
-use core::rand::RngUtil;
+use std::cast;
+use std::char;
+use std::cmp::Equiv;
+use std::local_data;
+use std::rand;
+use std::rand::RngUtil;
 
 #[deriving(Encodable, Decodable, Eq)]
 pub enum binop {

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -61,10 +61,8 @@
  * avoid combining it with other lines and making matters even worse.
  */
 
-use core::prelude::*;
-
-use core::io;
-use core::vec;
+use std::io;
+use std::vec;
 
 #[deriving(Eq)]
 pub enum breaks { consistent, inconsistent, }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use abi::AbiSet;
 use ast::{RegionTyParamBound, TraitTyParamBound, required, provided};
 use ast;
@@ -29,10 +27,10 @@ use print::pp::{breaks, consistent, inconsistent, eof};
 use print::pp;
 use print::pprust;
 
-use core::char;
-use core::io;
-use core::u64;
-use core::uint;
+use std::char;
+use std::io;
+use std::u64;
+use std::uint;
 
 // The @ps is stored here to prevent recursive type.
 pub enum ann_node<'self> {
@@ -2251,8 +2249,6 @@ mod test {
     use ast;
     use ast_util;
     use codemap;
-    use core::cmp::Eq;
-    use core::option::None;
     use parse::token;
 
     fn string_check<T:Eq> (given : &T, expected: &T) {

--- a/src/libsyntax/syntax.rs
+++ b/src/libsyntax/syntax.rs
@@ -23,16 +23,7 @@
 #[allow(non_camel_case_types)];
 #[deny(deprecated_pattern)];
 
-#[no_core];
-#[no_std];
-
-extern mod core(name = "std");
-extern mod extra(name = "extra");
-
-// For deriving(Encodable) purposes...
-extern mod std(name = "std");
-
-use core::prelude::*;
+extern mod extra;
 
 pub mod util {
     pub mod interner;

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -12,13 +12,8 @@
 // allows bidirectional lookup; i.e. given a value, one can easily find the
 // type, and vice versa.
 
-// allow the interner_key macro to escape this module:
-#[macro_escape];
-
-use core::prelude::*;
-
-use core::cmp::Equiv;
-use core::hashmap::HashMap;
+use std::cmp::Equiv;
+use std::hashmap::HashMap;
 
 pub struct Interner<T> {
     priv map: @mut HashMap<T, uint>,

--- a/src/libsyntax/util/parser_testing.rs
+++ b/src/libsyntax/util/parser_testing.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::option::{Option,None};
 use ast;
 use parse::{new_parse_sess};
 use parse::{ParseSess,string_to_filemap,filemap_to_tts};

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use abi::AbiSet;
 use ast::*;
 use ast;


### PR DESCRIPTION
Sets the stage for further cleanup (especially mass-slaughter of `@`)
