### PR TITLE
Added method to unpoison poisoned RWARCs

### DIFF
--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -48,6 +48,7 @@ use core::cast;
 use core::unstable::sync::UnsafeAtomicRcBox;
 use core::task;
 use core::borrow;
+use core::util;
 
 /// As sync::condvar, a mechanism for unlock-and-descheduling and signaling.
 pub struct Condvar<'self> {
@@ -328,6 +329,28 @@ impl<T:Const + Owned> RWARC<T> {
                 check_poison(false, (*state).failed);
                 let _z = PoisonOnFail(&mut (*state).failed);
                 blk(&mut (*state).data)
+            }
+        }
+    }
+
+    /// As write(), but unpoisons poisoned ARCs.
+    #[inline]
+    pub fn unpoison<U>(&self, blk: &fn() -> (T, U)) -> U {
+        unsafe {
+            let state = self.x.get();
+            do (*borrow_rwlock(state)).write {
+                let _z = PoisonOnFail(&mut (*state).failed);
+
+                let mut (writevalue, result) = blk();
+
+                util::swap(&mut (*state).data, &mut writevalue);
+                if (*state).failed {
+                    // Might be uninitialized so is unsafe to destroy
+                    cast::forget(writevalue)
+                }
+                (*state).failed = false;
+
+                result
             }
         }
     }
@@ -733,6 +756,24 @@ mod tests {
         p.recv();
         do arc.read |num| {
             assert_eq!(*num, 10);
+        }
+    }
+    #[test]
+    fn test_rw_arc_unpoison() {
+        let arc = RWARC(0);
+
+        // Poison the arc
+        let arc_clone = arc.clone();
+        do task::spawn_unlinked {
+            do arc_clone.write |_| {
+                fail!()
+            }
+        }
+
+        do arc.unpoison { (0, ()) }
+
+        do arc.read |_| {
+            // Should succeed at reading the now unpoisoned value
         }
     }
     #[test]


### PR DESCRIPTION
This is mostly a prototype for future changes. I assume more
complicated methods like unpoison_with_condvar may need to be added
but the whole complicated mess of varying types of writes, and reads
need to be refactored, and turned into a cleaner, and better interface
anyways. Personally, I need this operation to implement functions for
the library of concurrent data structures I am working on but this
operation may be of interest to others.

A rustic style for cleaning up the interface is unclear to me at the
moment but a possible example in Haskell might be to use a monad, and
have write simply be a consequence of the logically more primitive
read, and unpoison operations. This monadic approach in Haskell might
look like the following:

```
atomicIncrement var = atomically $ do
     x <- read var
     var $= x + 1
```
