### PR TITLE
add android dummy functions for mman related

### DIFF
--- a/src/rt/rust_android_dummy.cpp
+++ b/src/rt/rust_android_dummy.cpp
@@ -83,4 +83,29 @@ extern "C" int pthread_atfork(void (*prefork)(void),
     return 0;
 }
 
+extern "C" int mlockall(int flags)
+{
+    return 0;
+}
+
+extern "C" int munlockall(void)
+{
+    return 0;
+}
+
+extern "C" int shm_open(const char *name, int oflag, mode_t mode)
+{
+    return 0;
+}
+
+extern "C" int shm_unlink(const char *name)
+{
+    return 0;
+}
+
+extern "C" int posix_madvise(void *addr, size_t len, int advice)
+{
+    return 0;
+}
+
 #endif


### PR DESCRIPTION
add android dummy functions which does not exist in boinic.

after #7257, some mman related functions are needed for android.
