### PR TITLE
Update version number to 0.7-pre.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -139,7 +139,7 @@ endif
 
 # version-string calculation
 CFG_GIT_DIR := $(CFG_SRC_DIR).git
-CFG_RELEASE = 0.6
+CFG_RELEASE = 0.7-pre
 CFG_VERSION = $(CFG_RELEASE)
 
 ifneq ($(wildcard $(CFG_GIT)),)


### PR DESCRIPTION
There's a reason we didn't update this after 0.6 but I don't know
what it is. Let's see what breaks.
