### PR TITLE
rustpkg: Make rustpkg commands work without a package ID

### DIFF
--- a/src/librustpkg/installed_packages.rs
+++ b/src/librustpkg/installed_packages.rs
@@ -18,11 +18,18 @@ pub fn list_installed_packages(f: &fn(&PkgId) -> bool) -> bool  {
     for workspaces.iter().advance |p| {
         let binfiles = os::list_dir(&p.push("bin"));
         for binfiles.iter().advance() |exec| {
-            f(&PkgId::new(*exec, p));
+            let exec_path = Path(*exec).filestem();
+            do exec_path.iter().advance |s| {
+                f(&PkgId::new(*s, p))
+            };
         }
         let libfiles = os::list_dir(&p.push("lib"));
         for libfiles.iter().advance() |lib| {
-            f(&PkgId::new(*lib, p));
+            debug!("Full name: %s", *lib);
+            let lib_path = Path(*lib).filestem();
+            do lib_path.iter().advance |s| {
+                f(&PkgId::new(*s, p))
+            };
         }
     }
     true

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -54,11 +54,17 @@ pub fn rust_path() -> ~[Path] {
     };
     let cwd = os::getcwd();
     // now add in default entries
-    env_rust_path.push(cwd.push(".rust"));
     env_rust_path.push(cwd.clone());
     do cwd.each_parent() |p| { push_if_exists(&mut env_rust_path, p) };
     let h = os::homedir();
-    for h.iter().advance |h| { push_if_exists(&mut env_rust_path, h); }
+    // Avoid adding duplicates
+    // could still add dups if someone puts one of these in the RUST_PATH
+    // manually, though...
+    for h.iter().advance |hdir| {
+        if !(cwd.is_ancestor_of(hdir) || hdir.is_ancestor_of(&cwd)) {
+            push_if_exists(&mut env_rust_path, hdir);
+        }
+    }
     env_rust_path
 }
 

--- a/src/librustpkg/usage.rs
+++ b/src/librustpkg/usage.rs
@@ -23,10 +23,11 @@ Options:
 }
 
 pub fn build() {
-    io::println("rustpkg [options..] build
+    io::println("rustpkg [options..] build [package-ID]
 
-Build all targets described in the package script in the current
-directory.
+Build the given package ID if specified. With no package ID argument,
+build the package in the current directory. In that case, the current
+directory must be a direct child of an `src` directory in a workspace.
 
 Options:
     -c, --cfg      Pass a cfg flag to the package script");

--- a/src/librustpkg/workspace.rs
+++ b/src/librustpkg/workspace.rs
@@ -10,9 +10,10 @@
 
 // rustpkg utilities having to do with workspaces
 
+use std::os;
+use std::path::Path;
 use path_util::{rust_path, workspace_contains_package_id};
 use package_id::PkgId;
-use std::path::Path;
 
 pub fn each_pkg_parent_workspace(pkgid: &PkgId, action: &fn(&Path) -> bool) -> bool {
     // Using the RUST_PATH, find workspaces that contain
@@ -37,4 +38,25 @@ pub fn pkg_parent_workspaces(pkgid: &PkgId) -> ~[Path] {
     rust_path().consume_iter()
         .filter(|ws| workspace_contains_package_id(pkgid, ws))
         .collect()
+}
+
+pub fn in_workspace(complain: &fn()) -> bool {
+    let dir_part = os::getcwd().pop().components.clone();
+    if  *(dir_part.last()) != ~"src" {
+        complain();
+        false
+    }
+    else {
+        true
+    }
+}
+
+/// Construct a workspace and package-ID name based on the current directory.
+/// This gets used when rustpkg gets invoked without a package-ID argument.
+pub fn cwd_to_workspace() -> (Path, PkgId) {
+    let cwd = os::getcwd();
+    let ws = cwd.pop().pop();
+    let cwd_ = cwd.clone();
+    let pkgid = cwd_.components.last().to_str();
+    (ws, PkgId::new(pkgid, &cwd))
 }


### PR DESCRIPTION
r? @brson `rustpkg build`, if executed in a package source directory inside
a workspace, will now build that package. By "inside a workspace"
I mean that the parent directory has to be called `src`, and rustpkg
will create a `build` directory in .. if there isn't already one.

Same goes for `rustpkg install` and `rustpkg clean`.

For the time being, `rustpkg build` (etc.) will still error out if
you run it inside a directory whose parent isn't called `src`.
I'm not sure whether or not it's desirable to have it do something
in a non-workspace directory.
