### PR TITLE
Remove many shared pointers

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -349,7 +349,7 @@ pub fn expect<T:Copy>(sess: Session,
 }
 
 pub fn building_library(req_crate_type: crate_type,
-                        crate: @ast::crate,
+                        crate: &ast::crate,
                         testing: bool) -> bool {
     match req_crate_type {
       bin_crate => false,

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -24,11 +24,11 @@ struct Context {
 // any items that do not belong in the current configuration
 pub fn strip_unconfigured_items(crate: @ast::crate) -> @ast::crate {
     do strip_items(crate) |attrs| {
-        in_cfg(/*bad*/copy crate.node.config, attrs)
+        in_cfg(crate.node.config, attrs)
     }
 }
 
-pub fn strip_items(crate: @ast::crate, in_cfg: in_cfg_pred)
+pub fn strip_items(crate: &ast::crate, in_cfg: in_cfg_pred)
     -> @ast::crate {
 
     let ctxt = @Context { in_cfg: in_cfg };
@@ -44,8 +44,7 @@ pub fn strip_items(crate: @ast::crate, in_cfg: in_cfg_pred)
           .. *fold::default_ast_fold()};
 
     let fold = fold::make_fold(precursor);
-    let res = @fold.fold_crate(&*crate);
-    return res;
+    @fold.fold_crate(crate)
 }
 
 fn filter_item(cx: @Context, item: @ast::item) ->
@@ -183,12 +182,12 @@ fn trait_method_in_cfg(cx: @Context, meth: &ast::trait_method) -> bool {
 
 // Determine if an item should be translated in the current crate
 // configuration based on the item's attributes
-fn in_cfg(cfg: ast::crate_cfg, attrs: ~[ast::attribute]) -> bool {
+fn in_cfg(cfg: &[@ast::meta_item], attrs: &[ast::attribute]) -> bool {
     metas_in_cfg(cfg, attr::attr_metas(attrs))
 }
 
-pub fn metas_in_cfg(cfg: ast::crate_cfg,
-                    metas: ~[@ast::meta_item]) -> bool {
+pub fn metas_in_cfg(cfg: &[@ast::meta_item],
+                    metas: &[@ast::meta_item]) -> bool {
     // The "cfg" attributes on the item
     let cfg_metas = attr::find_meta_items_by_name(metas, "cfg");
 

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -30,11 +30,11 @@ pub fn maybe_inject_libstd_ref(sess: Session, crate: @ast::crate)
     }
 }
 
-fn use_std(crate: @ast::crate) -> bool {
+fn use_std(crate: &ast::crate) -> bool {
     !attr::attrs_contains_name(crate.node.attrs, "no_std")
 }
 
-fn inject_libstd_ref(sess: Session, crate: @ast::crate) -> @ast::crate {
+fn inject_libstd_ref(sess: Session, crate: &ast::crate) -> @ast::crate {
     fn spanned<T:Copy>(x: T) -> codemap::spanned<T> {
         codemap::spanned { node: x, span: dummy_sp() }
     }

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -92,7 +92,7 @@ fn generate_test_harness(sess: session::Session,
     return res;
 }
 
-fn strip_test_functions(crate: @ast::crate) -> @ast::crate {
+fn strip_test_functions(crate: &ast::crate) -> @ast::crate {
     // When not compiling with --test we should not compile the
     // #[test] functions
     do config::strip_items(crate) |attrs| {

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -58,7 +58,7 @@ pub fn check_crate(
     moves_map: moves::MovesMap,
     moved_variables_set: moves::MovedVariablesSet,
     capture_map: moves::CaptureMap,
-    crate: @ast::crate) -> (root_map, write_guard_map)
+    crate: &ast::crate) -> (root_map, write_guard_map)
 {
     let bccx = @BorrowckCtxt {
         tcx: tcx,
@@ -507,7 +507,7 @@ impl BorrowckCtxt {
     pub fn report_use_of_moved_value(&self,
                                      use_span: span,
                                      use_kind: MovedValueUseKind,
-                                     lp: @LoanPath,
+                                     lp: &LoanPath,
                                      move: &move_data::Move,
                                      moved_lp: @LoanPath) {
         let verb = match use_kind {
@@ -570,7 +570,7 @@ impl BorrowckCtxt {
 
     pub fn report_reassigned_immutable_variable(&self,
                                                 span: span,
-                                                lp: @LoanPath,
+                                                lp: &LoanPath,
                                                 assign:
                                                 &move_data::Assignment) {
         self.tcx.sess.span_err(

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -21,7 +21,7 @@ use syntax::codemap;
 use syntax::{visit, ast_util, ast_map};
 
 pub fn check_crate(sess: Session,
-                   crate: @crate,
+                   crate: &crate,
                    ast_map: ast_map::map,
                    def_map: resolve::DefMap,
                    method_map: typeck::method_map,

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -19,7 +19,7 @@ pub struct Context {
     can_ret: bool
 }
 
-pub fn check_crate(tcx: ty::ctxt, crate: @crate) {
+pub fn check_crate(tcx: ty::ctxt, crate: &crate) {
     visit::visit_crate(crate,
                        (Context { in_loop: false, can_ret: true },
                        visit::mk_vt(@visit::Visitor {

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -36,7 +36,7 @@ pub struct MatchCheckCtxt {
 pub fn check_crate(tcx: ty::ctxt,
                    method_map: method_map,
                    moves_map: moves::MovesMap,
-                   crate: @crate) {
+                   crate: &crate) {
     let cx = @MatchCheckCtxt {tcx: tcx,
                               method_map: method_map,
                               moves_map: moves_map};
@@ -50,7 +50,7 @@ pub fn check_crate(tcx: ty::ctxt,
     tcx.sess.abort_if_errors();
 }
 
-pub fn expr_is_non_moving_lvalue(cx: @MatchCheckCtxt, expr: @expr) -> bool {
+pub fn expr_is_non_moving_lvalue(cx: &MatchCheckCtxt, expr: &expr) -> bool {
     if !ty::expr_is_lval(cx.tcx, cx.method_map, expr) {
         return false;
     }
@@ -108,7 +108,7 @@ pub fn check_expr(cx: @MatchCheckCtxt, ex: @expr, (s, v): ((), visit::vt<()>)) {
 }
 
 // Check for unreachable patterns
-pub fn check_arms(cx: @MatchCheckCtxt, arms: &[arm]) {
+pub fn check_arms(cx: &MatchCheckCtxt, arms: &[arm]) {
     let mut seen = ~[];
     for arms.iter().advance |arm| {
         for arm.pats.iter().advance |pat| {
@@ -131,7 +131,7 @@ pub fn raw_pat(p: @pat) -> @pat {
     }
 }
 
-pub fn check_exhaustive(cx: @MatchCheckCtxt, sp: span, pats: ~[@pat]) {
+pub fn check_exhaustive(cx: &MatchCheckCtxt, sp: span, pats: ~[@pat]) {
     assert!((!pats.is_empty()));
     let ext = match is_useful(cx, &pats.map(|p| ~[*p]), [wild()]) {
         not_useful => {
@@ -205,7 +205,7 @@ pub enum ctor {
 
 // Note: is_useful doesn't work on empty types, as the paper notes.
 // So it assumes that v is non-empty.
-pub fn is_useful(cx: @MatchCheckCtxt, m: &matrix, v: &[@pat]) -> useful {
+pub fn is_useful(cx: &MatchCheckCtxt, m: &matrix, v: &[@pat]) -> useful {
     if m.len() == 0u { return useful_; }
     if m[0].len() == 0u { return not_useful; }
     let real_pat = match m.iter().find_(|r| r[0].id != 0) {
@@ -281,7 +281,7 @@ pub fn is_useful(cx: @MatchCheckCtxt, m: &matrix, v: &[@pat]) -> useful {
     }
 }
 
-pub fn is_useful_specialized(cx: @MatchCheckCtxt,
+pub fn is_useful_specialized(cx: &MatchCheckCtxt,
                              m: &matrix,
                              v: &[@pat],
                              ctor: ctor,
@@ -297,7 +297,7 @@ pub fn is_useful_specialized(cx: @MatchCheckCtxt,
     }
 }
 
-pub fn pat_ctor_id(cx: @MatchCheckCtxt, p: @pat) -> Option<ctor> {
+pub fn pat_ctor_id(cx: &MatchCheckCtxt, p: @pat) -> Option<ctor> {
     let pat = raw_pat(p);
     match pat.node {
       pat_wild => { None }
@@ -333,7 +333,7 @@ pub fn pat_ctor_id(cx: @MatchCheckCtxt, p: @pat) -> Option<ctor> {
     }
 }
 
-pub fn is_wild(cx: @MatchCheckCtxt, p: @pat) -> bool {
+pub fn is_wild(cx: &MatchCheckCtxt, p: @pat) -> bool {
     let pat = raw_pat(p);
     match pat.node {
       pat_wild => { true }
@@ -347,7 +347,7 @@ pub fn is_wild(cx: @MatchCheckCtxt, p: @pat) -> bool {
     }
 }
 
-pub fn missing_ctor(cx: @MatchCheckCtxt,
+pub fn missing_ctor(cx: &MatchCheckCtxt,
                     m: &matrix,
                     left_ty: ty::t)
                  -> Option<ctor> {
@@ -449,7 +449,7 @@ pub fn missing_ctor(cx: @MatchCheckCtxt,
     }
 }
 
-pub fn ctor_arity(cx: @MatchCheckCtxt, ctor: &ctor, ty: ty::t) -> uint {
+pub fn ctor_arity(cx: &MatchCheckCtxt, ctor: &ctor, ty: ty::t) -> uint {
     match ty::get(ty).sty {
       ty::ty_tup(ref fs) => fs.len(),
       ty::ty_box(_) | ty::ty_uniq(_) | ty::ty_rptr(*) => 1u,
@@ -476,7 +476,7 @@ pub fn wild() -> @pat {
     @pat {id: 0, node: pat_wild, span: dummy_sp()}
 }
 
-pub fn specialize(cx: @MatchCheckCtxt,
+pub fn specialize(cx: &MatchCheckCtxt,
                   r: &[@pat],
                   ctor_id: &ctor,
                   arity: uint,
@@ -743,12 +743,12 @@ pub fn specialize(cx: @MatchCheckCtxt,
     }
 }
 
-pub fn default(cx: @MatchCheckCtxt, r: &[@pat]) -> Option<~[@pat]> {
+pub fn default(cx: &MatchCheckCtxt, r: &[@pat]) -> Option<~[@pat]> {
     if is_wild(cx, r[0]) { Some(vec::to_owned(r.tail())) }
     else { None }
 }
 
-pub fn check_local(cx: @MatchCheckCtxt,
+pub fn check_local(cx: &MatchCheckCtxt,
                    loc: @local,
                    (s, v): ((),
                             visit::vt<()>)) {
@@ -766,7 +766,7 @@ pub fn check_local(cx: @MatchCheckCtxt,
     check_legality_of_move_bindings(cx, is_lvalue, false, [ loc.node.pat ]);
 }
 
-pub fn check_fn(cx: @MatchCheckCtxt,
+pub fn check_fn(cx: &MatchCheckCtxt,
                 kind: &visit::fn_kind,
                 decl: &fn_decl,
                 body: &blk,
@@ -783,7 +783,7 @@ pub fn check_fn(cx: @MatchCheckCtxt,
     }
 }
 
-pub fn is_refutable(cx: @MatchCheckCtxt, pat: &pat) -> bool {
+pub fn is_refutable(cx: &MatchCheckCtxt, pat: &pat) -> bool {
     match cx.tcx.def_map.find(&pat.id) {
       Some(&def_variant(enum_id, _)) => {
         if ty::enum_variants(cx.tcx, enum_id).len() != 1u {
@@ -821,7 +821,7 @@ pub fn is_refutable(cx: @MatchCheckCtxt, pat: &pat) -> bool {
 
 // Legality of move bindings checking
 
-pub fn check_legality_of_move_bindings(cx: @MatchCheckCtxt,
+pub fn check_legality_of_move_bindings(cx: &MatchCheckCtxt,
                                        is_lvalue: bool,
                                        has_guard: bool,
                                        pats: &[@pat]) {

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -75,7 +75,7 @@ pub fn join_all(cs: &[constness]) -> constness {
     cs.iter().fold(integral_const, |a, b| join(a, *b))
 }
 
-pub fn classify(e: @expr,
+pub fn classify(e: &expr,
                 tcx: ty::ctxt)
              -> constness {
     let did = ast_util::local_def(e.id);
@@ -164,7 +164,7 @@ pub fn classify(e: @expr,
     }
 }
 
-pub fn lookup_const(tcx: ty::ctxt, e: @expr) -> Option<@expr> {
+pub fn lookup_const(tcx: ty::ctxt, e: &expr) -> Option<@expr> {
     match tcx.def_map.find(&e.id) {
         Some(&ast::def_static(def_id, false)) => lookup_const_by_id(tcx, def_id),
         _ => None
@@ -203,7 +203,7 @@ pub fn lookup_const_by_id(tcx: ty::ctxt,
     }
 }
 
-pub fn lookup_constness(tcx: ty::ctxt, e: @expr) -> constness {
+pub fn lookup_constness(tcx: ty::ctxt, e: &expr) -> constness {
     match lookup_const(tcx, e) {
         Some(rhs) => {
             let ty = ty::expr_ty(tcx, rhs);
@@ -217,7 +217,7 @@ pub fn lookup_constness(tcx: ty::ctxt, e: @expr) -> constness {
     }
 }
 
-pub fn process_crate(crate: @ast::crate,
+pub fn process_crate(crate: &ast::crate,
                      tcx: ty::ctxt) {
     let v = visit::mk_simple_visitor(@visit::SimpleVisitor {
         visit_expr_post: |e| { classify(e, tcx); },
@@ -239,14 +239,14 @@ pub enum const_val {
     const_bool(bool)
 }
 
-pub fn eval_const_expr(tcx: middle::ty::ctxt, e: @expr) -> const_val {
+pub fn eval_const_expr(tcx: middle::ty::ctxt, e: &expr) -> const_val {
     match eval_const_expr_partial(tcx, e) {
         Ok(r) => r,
         Err(s) => tcx.sess.span_fatal(e.span, s)
     }
 }
 
-pub fn eval_const_expr_partial(tcx: middle::ty::ctxt, e: @expr)
+pub fn eval_const_expr_partial(tcx: middle::ty::ctxt, e: &expr)
                             -> Result<const_val, ~str> {
     use middle::ty;
     fn fromb(b: bool) -> Result<const_val, ~str> { Ok(const_int(b as i64)) }
@@ -406,7 +406,7 @@ pub fn eval_const_expr_partial(tcx: middle::ty::ctxt, e: @expr)
     }
 }
 
-pub fn lit_to_const(lit: @lit) -> const_val {
+pub fn lit_to_const(lit: &lit) -> const_val {
     match lit.node {
       lit_str(s) => const_str(s),
       lit_int(n, _) => const_int(n),
@@ -434,14 +434,14 @@ pub fn compare_const_vals(a: &const_val, b: &const_val) -> Option<int> {
     }
 }
 
-pub fn compare_lit_exprs(tcx: middle::ty::ctxt, a: @expr, b: @expr) -> Option<int> {
+pub fn compare_lit_exprs(tcx: middle::ty::ctxt, a: &expr, b: &expr) -> Option<int> {
     compare_const_vals(&eval_const_expr(tcx, a), &eval_const_expr(tcx, b))
 }
 
-pub fn lit_expr_eq(tcx: middle::ty::ctxt, a: @expr, b: @expr) -> Option<bool> {
+pub fn lit_expr_eq(tcx: middle::ty::ctxt, a: &expr, b: &expr) -> Option<bool> {
     compare_lit_exprs(tcx, a, b).map(|&val| val == 0)
 }
 
-pub fn lit_eq(a: @lit, b: @lit) -> Option<bool> {
+pub fn lit_eq(a: &lit, b: &lit) -> Option<bool> {
     compare_const_vals(&lit_to_const(a), &lit_to_const(b)).map(|&val| val == 0)
 }

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -47,7 +47,7 @@ fn type_is_unsafe_function(ty: ty::t) -> bool {
 
 pub fn check_crate(tcx: ty::ctxt,
                    method_map: method_map,
-                   crate: @ast::crate) {
+                   crate: &ast::crate) {
     let context = @mut Context {
         method_map: method_map,
         unsafe_context: SafeContext,

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -41,7 +41,7 @@ struct EntryContext {
 
 type EntryVisitor = vt<@mut EntryContext>;
 
-pub fn find_entry_point(session: Session, crate: @crate, ast_map: ast_map::map) {
+pub fn find_entry_point(session: Session, crate: &crate, ast_map: ast_map::map) {
 
     // FIXME #4404 android JNI hacks
     if *session.building_library &&

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -88,7 +88,7 @@ fn collect_freevars(def_map: resolve::DefMap, blk: &ast::blk)
 // efficient as it fully recomputes the free variables at every
 // node of interest rather than building up the free variables in
 // one pass. This could be improved upon if it turns out to matter.
-pub fn annotate_freevars(def_map: resolve::DefMap, crate: @ast::crate) ->
+pub fn annotate_freevars(def_map: resolve::DefMap, crate: &ast::crate) ->
    freevar_map {
     let freevars = @mut HashMap::new();
 

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -17,7 +17,6 @@ use middle::typeck;
 use util::ppaux::{Repr, ty_to_str};
 use util::ppaux::UserString;
 
-use core::vec;
 use syntax::ast::*;
 use syntax::attr::attrs_contains_name;
 use syntax::codemap::span;
@@ -63,7 +62,7 @@ pub struct Context {
 
 pub fn check_crate(tcx: ty::ctxt,
                    method_map: typeck::method_map,
-                   crate: @crate) {
+                   crate: &crate) {
     let ctx = Context {
         tcx: tcx,
         method_map: method_map,
@@ -163,7 +162,7 @@ fn check_item(item: @item, (cx, visitor): (Context, visit::vt<Context>)) {
 // closure.
 fn with_appropriate_checker(cx: Context, id: node_id,
                             b: &fn(checker: &fn(Context, @freevar_entry))) {
-    fn check_for_uniq(cx: Context, fv: @freevar_entry, bounds: ty::BuiltinBounds) {
+    fn check_for_uniq(cx: Context, fv: &freevar_entry, bounds: ty::BuiltinBounds) {
         // all captured data must be owned, regardless of whether it is
         // moved in or copied in.
         let id = ast_util::def_id_of_def(fv.def).node;
@@ -175,7 +174,7 @@ fn with_appropriate_checker(cx: Context, id: node_id,
         check_freevar_bounds(cx, fv.span, var_t, bounds);
     }
 
-    fn check_for_box(cx: Context, fv: @freevar_entry, bounds: ty::BuiltinBounds) {
+    fn check_for_box(cx: Context, fv: &freevar_entry, bounds: ty::BuiltinBounds) {
         // all captured data must be owned
         let id = ast_util::def_id_of_def(fv.def).node;
         let var_t = ty::node_id_to_type(cx.tcx, id);
@@ -186,7 +185,7 @@ fn with_appropriate_checker(cx: Context, id: node_id,
         check_freevar_bounds(cx, fv.span, var_t, bounds);
     }
 
-    fn check_for_block(cx: Context, fv: @freevar_entry, bounds: ty::BuiltinBounds) {
+    fn check_for_block(cx: Context, fv: &freevar_entry, bounds: ty::BuiltinBounds) {
         let id = ast_util::def_id_of_def(fv.def).node;
         let var_t = ty::node_id_to_type(cx.tcx, id);
         check_freevar_bounds(cx, fv.span, var_t, bounds);
@@ -496,8 +495,8 @@ pub fn check_durable(tcx: ty::ctxt, ty: ty::t, sp: span) -> bool {
 /// FIXME(#5723)---This code should probably move into regionck.
 pub fn check_cast_for_escaping_regions(
     cx: Context,
-    source: @expr,
-    target: @expr)
+    source: &expr,
+    target: &expr)
 {
     // Determine what type we are casting to; if it is not an trait, then no
     // worries.

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -281,80 +281,79 @@ impl LanguageItems {
     }
 }
 
-fn LanguageItemCollector(crate: @crate,
-                         session: Session)
-                      -> LanguageItemCollector {
-    let mut item_refs = HashMap::new();
-
-    item_refs.insert(@"const", ConstTraitLangItem as uint);
-    item_refs.insert(@"copy", CopyTraitLangItem as uint);
-    item_refs.insert(@"owned", OwnedTraitLangItem as uint);
-    item_refs.insert(@"sized", SizedTraitLangItem as uint);
-
-    item_refs.insert(@"drop", DropTraitLangItem as uint);
-
-    item_refs.insert(@"add", AddTraitLangItem as uint);
-    item_refs.insert(@"sub", SubTraitLangItem as uint);
-    item_refs.insert(@"mul", MulTraitLangItem as uint);
-    item_refs.insert(@"div", DivTraitLangItem as uint);
-    item_refs.insert(@"rem", RemTraitLangItem as uint);
-    item_refs.insert(@"neg", NegTraitLangItem as uint);
-    item_refs.insert(@"not", NotTraitLangItem as uint);
-    item_refs.insert(@"bitxor", BitXorTraitLangItem as uint);
-    item_refs.insert(@"bitand", BitAndTraitLangItem as uint);
-    item_refs.insert(@"bitor", BitOrTraitLangItem as uint);
-    item_refs.insert(@"shl", ShlTraitLangItem as uint);
-    item_refs.insert(@"shr", ShrTraitLangItem as uint);
-    item_refs.insert(@"index", IndexTraitLangItem as uint);
-
-    item_refs.insert(@"eq", EqTraitLangItem as uint);
-    item_refs.insert(@"ord", OrdTraitLangItem as uint);
-
-    item_refs.insert(@"str_eq", StrEqFnLangItem as uint);
-    item_refs.insert(@"uniq_str_eq", UniqStrEqFnLangItem as uint);
-    item_refs.insert(@"annihilate", AnnihilateFnLangItem as uint);
-    item_refs.insert(@"log_type", LogTypeFnLangItem as uint);
-    item_refs.insert(@"fail_", FailFnLangItem as uint);
-    item_refs.insert(@"fail_bounds_check",
-                     FailBoundsCheckFnLangItem as uint);
-    item_refs.insert(@"exchange_malloc", ExchangeMallocFnLangItem as uint);
-    item_refs.insert(@"exchange_free", ExchangeFreeFnLangItem as uint);
-    item_refs.insert(@"malloc", MallocFnLangItem as uint);
-    item_refs.insert(@"free", FreeFnLangItem as uint);
-    item_refs.insert(@"borrow_as_imm", BorrowAsImmFnLangItem as uint);
-    item_refs.insert(@"borrow_as_mut", BorrowAsMutFnLangItem as uint);
-    item_refs.insert(@"return_to_mut", ReturnToMutFnLangItem as uint);
-    item_refs.insert(@"check_not_borrowed",
-                     CheckNotBorrowedFnLangItem as uint);
-    item_refs.insert(@"strdup_uniq", StrDupUniqFnLangItem as uint);
-    item_refs.insert(@"record_borrow", RecordBorrowFnLangItem as uint);
-    item_refs.insert(@"unrecord_borrow", UnrecordBorrowFnLangItem as uint);
-    item_refs.insert(@"start", StartFnLangItem as uint);
-    item_refs.insert(@"ty_desc", TyDescStructLangItem as uint);
-    item_refs.insert(@"ty_visitor", TyVisitorTraitLangItem as uint);
-    item_refs.insert(@"opaque", OpaqueStructLangItem as uint);
-
-    LanguageItemCollector {
-        crate: crate,
-        session: session,
-        items: LanguageItems::new(),
-        item_refs: item_refs
-    }
-}
-
-struct LanguageItemCollector {
+struct LanguageItemCollector<'self> {
     items: LanguageItems,
 
-    crate: @crate,
+    crate: &'self crate,
     session: Session,
 
     item_refs: HashMap<@str, uint>,
 }
 
-impl LanguageItemCollector {
+impl<'self> LanguageItemCollector<'self> {
+
+    pub fn new<'a>(crate: &'a crate, session: Session) -> LanguageItemCollector<'a> {
+        let mut item_refs = HashMap::new();
+
+        item_refs.insert(@"const", ConstTraitLangItem as uint);
+        item_refs.insert(@"copy", CopyTraitLangItem as uint);
+        item_refs.insert(@"owned", OwnedTraitLangItem as uint);
+        item_refs.insert(@"sized", SizedTraitLangItem as uint);
+
+        item_refs.insert(@"drop", DropTraitLangItem as uint);
+
+        item_refs.insert(@"add", AddTraitLangItem as uint);
+        item_refs.insert(@"sub", SubTraitLangItem as uint);
+        item_refs.insert(@"mul", MulTraitLangItem as uint);
+        item_refs.insert(@"div", DivTraitLangItem as uint);
+        item_refs.insert(@"rem", RemTraitLangItem as uint);
+        item_refs.insert(@"neg", NegTraitLangItem as uint);
+        item_refs.insert(@"not", NotTraitLangItem as uint);
+        item_refs.insert(@"bitxor", BitXorTraitLangItem as uint);
+        item_refs.insert(@"bitand", BitAndTraitLangItem as uint);
+        item_refs.insert(@"bitor", BitOrTraitLangItem as uint);
+        item_refs.insert(@"shl", ShlTraitLangItem as uint);
+        item_refs.insert(@"shr", ShrTraitLangItem as uint);
+        item_refs.insert(@"index", IndexTraitLangItem as uint);
+
+        item_refs.insert(@"eq", EqTraitLangItem as uint);
+        item_refs.insert(@"ord", OrdTraitLangItem as uint);
+
+        item_refs.insert(@"str_eq", StrEqFnLangItem as uint);
+        item_refs.insert(@"uniq_str_eq", UniqStrEqFnLangItem as uint);
+        item_refs.insert(@"annihilate", AnnihilateFnLangItem as uint);
+        item_refs.insert(@"log_type", LogTypeFnLangItem as uint);
+        item_refs.insert(@"fail_", FailFnLangItem as uint);
+        item_refs.insert(@"fail_bounds_check",
+                         FailBoundsCheckFnLangItem as uint);
+        item_refs.insert(@"exchange_malloc", ExchangeMallocFnLangItem as uint);
+        item_refs.insert(@"exchange_free", ExchangeFreeFnLangItem as uint);
+        item_refs.insert(@"malloc", MallocFnLangItem as uint);
+        item_refs.insert(@"free", FreeFnLangItem as uint);
+        item_refs.insert(@"borrow_as_imm", BorrowAsImmFnLangItem as uint);
+        item_refs.insert(@"borrow_as_mut", BorrowAsMutFnLangItem as uint);
+        item_refs.insert(@"return_to_mut", ReturnToMutFnLangItem as uint);
+        item_refs.insert(@"check_not_borrowed",
+                         CheckNotBorrowedFnLangItem as uint);
+        item_refs.insert(@"strdup_uniq", StrDupUniqFnLangItem as uint);
+        item_refs.insert(@"record_borrow", RecordBorrowFnLangItem as uint);
+        item_refs.insert(@"unrecord_borrow", UnrecordBorrowFnLangItem as uint);
+        item_refs.insert(@"start", StartFnLangItem as uint);
+        item_refs.insert(@"ty_desc", TyDescStructLangItem as uint);
+        item_refs.insert(@"ty_visitor", TyVisitorTraitLangItem as uint);
+        item_refs.insert(@"opaque", OpaqueStructLangItem as uint);
+
+        LanguageItemCollector {
+            crate: crate,
+            session: session,
+            items: LanguageItems::new(),
+            item_refs: item_refs
+        }
+    }
+
     pub fn match_and_collect_meta_item(&mut self,
                                        item_def_id: def_id,
-                                       meta_item: @meta_item) {
+                                       meta_item: &meta_item) {
         match meta_item.node {
             meta_name_value(key, literal) => {
                 match literal.node {
@@ -386,7 +385,7 @@ impl LanguageItemCollector {
 
     pub fn match_and_collect_item(&mut self,
                                   item_def_id: def_id,
-                                  key: @str,
+                                  key: &str,
                                   value: @str) {
         if "lang" != key {
             return;    // Didn't match.
@@ -455,10 +454,10 @@ impl LanguageItemCollector {
     }
 }
 
-pub fn collect_language_items(crate: @crate,
+pub fn collect_language_items(crate: &crate,
                               session: Session)
                            -> LanguageItems {
-    let mut collector = LanguageItemCollector(crate, session);
+    let mut collector = LanguageItemCollector::new(crate, session);
     collector.collect();
     let LanguageItemCollector { items, _ } = collector;
     session.abort_if_errors();

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -701,7 +701,7 @@ fn lint_type_limits() -> visit::vt<@mut Context> {
     })
 }
 
-fn check_item_default_methods(cx: &Context, item: @ast::item) {
+fn check_item_default_methods(cx: &Context, item: &ast::item) {
     match item.node {
         ast::item_trait(_, _, ref methods) => {
             for methods.iter().advance |method| {
@@ -718,8 +718,8 @@ fn check_item_default_methods(cx: &Context, item: @ast::item) {
     }
 }
 
-fn check_item_ctypes(cx: &Context, it: @ast::item) {
-    fn check_ty(cx: &Context, ty: @ast::Ty) {
+fn check_item_ctypes(cx: &Context, it: &ast::item) {
+    fn check_ty(cx: &Context, ty: &ast::Ty) {
         match ty.node {
             ast::ty_path(_, _, id) => {
                 match cx.tcx.def_map.get_copy(&id) {
@@ -797,7 +797,7 @@ fn check_type(cx: &Context, span: span, ty: ty::t) {
     }
 }
 
-fn check_item_heap(cx: &Context, it: @ast::item) {
+fn check_item_heap(cx: &Context, it: &ast::item) {
     match it.node {
       ast::item_fn(*) |
       ast::item_ty(*) |
@@ -851,7 +851,7 @@ fn lint_path_statement() -> visit::vt<@mut Context> {
     })
 }
 
-fn check_item_non_camel_case_types(cx: &Context, it: @ast::item) {
+fn check_item_non_camel_case_types(cx: &Context, it: &ast::item) {
     fn is_camel_case(cx: ty::ctxt, ident: ast::ident) -> bool {
         let ident = cx.sess.str_of(ident);
         assert!(!ident.is_empty());
@@ -973,7 +973,7 @@ fn lint_session() -> visit::vt<@mut Context> {
 fn lint_unnecessary_allocations() -> visit::vt<@mut Context> {
     // Warn if string and vector literals with sigils are immediately borrowed.
     // Those can have the sigil removed.
-    fn check(cx: &Context, e: @ast::expr) {
+    fn check(cx: &Context, e: &ast::expr) {
         match e.node {
             ast::expr_vstore(e2, ast::expr_vstore_uniq) |
             ast::expr_vstore(e2, ast::expr_vstore_box) => {

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -150,7 +150,7 @@ fn live_node_kind_to_str(lnk: LiveNodeKind, cx: ty::ctxt) -> ~str {
 pub fn check_crate(tcx: ty::ctxt,
                    method_map: typeck::method_map,
                    capture_map: moves::CaptureMap,
-                   crate: @crate) {
+                   crate: &crate) {
     let visitor = visit::mk_vt(@visit::Visitor {
         visit_fn: visit_fn,
         visit_local: visit_local,
@@ -322,7 +322,7 @@ impl IrMaps {
         self.capture_info_map.insert(node_id, @cs);
     }
 
-    pub fn captures(&mut self, expr: @expr) -> @~[CaptureInfo] {
+    pub fn captures(&mut self, expr: &expr) -> @~[CaptureInfo] {
         match self.capture_info_map.find(&expr.id) {
           Some(&caps) => caps,
           None => {
@@ -596,7 +596,7 @@ impl Liveness {
         }
     }
 
-    pub fn variable_from_path(&self, expr: @expr) -> Option<Variable> {
+    pub fn variable_from_path(&self, expr: &expr) -> Option<Variable> {
         match expr.node {
           expr_path(_) => {
             let def = self.tcx.def_map.get_copy(&expr.id);
@@ -923,7 +923,7 @@ impl Liveness {
         }
     }
 
-    pub fn propagate_through_stmt(&self, stmt: @stmt, succ: LiveNode)
+    pub fn propagate_through_stmt(&self, stmt: &stmt, succ: LiveNode)
                                   -> LiveNode {
         match stmt.node {
           stmt_decl(decl, _) => {
@@ -940,7 +940,7 @@ impl Liveness {
         }
     }
 
-    pub fn propagate_through_decl(&self, decl: @decl, succ: LiveNode)
+    pub fn propagate_through_decl(&self, decl: &decl, succ: LiveNode)
                                   -> LiveNode {
         match decl.node {
             decl_local(ref local) => {
@@ -950,7 +950,7 @@ impl Liveness {
         }
     }
 
-    pub fn propagate_through_local(&self, local: @local, succ: LiveNode)
+    pub fn propagate_through_local(&self, local: &local, succ: LiveNode)
                                    -> LiveNode {
         // Note: we mark the variable as defined regardless of whether
         // there is an initializer.  Initially I had thought to only mark
@@ -1293,7 +1293,7 @@ impl Liveness {
     }
 
     // see comment on propagate_through_lvalue()
-    pub fn write_lvalue(&self, expr: @expr, succ: LiveNode, acc: uint)
+    pub fn write_lvalue(&self, expr: &expr, succ: LiveNode, acc: uint)
                         -> LiveNode {
         match expr.node {
           expr_path(_) => self.access_path(expr, succ, acc),
@@ -1306,7 +1306,7 @@ impl Liveness {
         }
     }
 
-    pub fn access_path(&self, expr: @expr, succ: LiveNode, acc: uint)
+    pub fn access_path(&self, expr: &expr, succ: LiveNode, acc: uint)
                        -> LiveNode {
         let def = self.tcx.def_map.get_copy(&expr.id);
         match moves::moved_variable_node_id_from_def(def) {
@@ -1324,7 +1324,7 @@ impl Liveness {
     }
 
     pub fn propagate_through_loop(&self,
-                                  expr: @expr,
+                                  expr: &expr,
                                   cond: Option<@expr>,
                                   body: &blk,
                                   succ: LiveNode)

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -190,7 +190,7 @@ enum UseMode {
 
 pub fn compute_moves(tcx: ty::ctxt,
                      method_map: method_map,
-                     crate: @crate) -> MoveMaps
+                     crate: &crate) -> MoveMaps
 {
     let visitor = visit::mk_vt(@visit::Visitor {
         visit_expr: compute_modes_for_expr,
@@ -521,7 +521,7 @@ impl VisitContext {
     }
 
     pub fn use_overloaded_operator(&self,
-                                   expr: @expr,
+                                   expr: &expr,
                                    receiver_expr: @expr,
                                    arg_exprs: &[@expr],
                                    visitor: vt<VisitContext>)

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -29,7 +29,7 @@ pub fn pat_id_map(dm: resolve::DefMap, pat: @pat) -> PatIdMap {
     map
 }
 
-pub fn pat_is_variant_or_struct(dm: resolve::DefMap, pat: @pat) -> bool {
+pub fn pat_is_variant_or_struct(dm: resolve::DefMap, pat: &pat) -> bool {
     match pat.node {
         pat_enum(_, _) | pat_ident(_, _, None) | pat_struct(*) => {
             match dm.find(&pat.id) {

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -40,7 +40,7 @@ use syntax::visit;
 
 pub fn check_crate<'mm>(tcx: ty::ctxt,
                    method_map: &'mm method_map,
-                   crate: @ast::crate) {
+                   crate: &ast::crate) {
     let privileged_items = @mut ~[];
 
     // Adds an item to its scope.

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -406,8 +406,6 @@ pub fn expand_nested_bindings<'r>(bcx: block,
     }
 }
 
-pub type enter_pat<'self> = &'self fn(@ast::pat) -> Option<~[@ast::pat]>;
-
 pub fn assert_is_binding_or_wild(bcx: block, p: @ast::pat) {
     if !pat_is_binding_or_wild(bcx.tcx().def_map, p) {
         bcx.sess().span_bug(
@@ -416,6 +414,8 @@ pub fn assert_is_binding_or_wild(bcx: block, p: @ast::pat) {
                  pat_to_str(p, bcx.sess().intr())));
     }
 }
+
+pub type enter_pat<'self> = &'self fn(@ast::pat) -> Option<~[@ast::pat]>;
 
 pub fn enter_match<'r>(bcx: block,
                        dm: DefMap,
@@ -1048,7 +1048,7 @@ pub fn any_tuple_struct_pat(bcx: block, m: &[@Match], col: uint) -> bool {
 pub type mk_fail = @fn() -> BasicBlockRef;
 
 pub fn pick_col(m: &[@Match]) -> uint {
-    fn score(p: @ast::pat) -> uint {
+    fn score(p: &ast::pat) -> uint {
         match p.node {
           ast::pat_lit(_) | ast::pat_enum(_, _) | ast::pat_range(_, _) => 1u,
           ast::pat_ident(_, _, Some(p)) => score(p),
@@ -1609,7 +1609,7 @@ pub fn compile_submatch(bcx: block,
 }
 
 pub fn trans_match(bcx: block,
-                   match_expr: @ast::expr,
+                   match_expr: &ast::expr,
                    discr_expr: @ast::expr,
                    arms: ~[ast::arm],
                    dest: Dest) -> block {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -160,7 +160,7 @@ pub fn decl_cdecl_fn(llmod: ModuleRef, name: &str, ty: Type) -> ValueRef {
 
 // Only use this if you are going to actually define the function. It's
 // not valid to simply declare a function as internal.
-pub fn decl_internal_cdecl_fn(llmod: ModuleRef, name: ~str, ty: Type) -> ValueRef {
+pub fn decl_internal_cdecl_fn(llmod: ModuleRef, name: &str, ty: Type) -> ValueRef {
     let llfn = decl_cdecl_fn(llmod, name, ty);
     lib::llvm::SetLinkage(llfn, lib::llvm::InternalLinkage);
     return llfn;
@@ -592,8 +592,7 @@ pub fn compare_scalar_values(cx: block,
     }
 }
 
-pub type val_pair_fn = @fn(block, ValueRef, ValueRef) -> block;
-pub type val_and_ty_fn = @fn(block, ValueRef, ty::t) -> block;
+pub type val_and_ty_fn<'self> = &'self fn(block, ValueRef, ty::t) -> block;
 
 pub fn load_inbounds(cx: block, p: ValueRef, idxs: &[uint]) -> ValueRef {
     return Load(cx, GEPi(cx, p, idxs));
@@ -1032,13 +1031,13 @@ pub fn build_return(bcx: block) {
     Br(bcx, bcx.fcx.llreturn);
 }
 
-pub fn ignore_lhs(_bcx: block, local: @ast::local) -> bool {
+pub fn ignore_lhs(_bcx: block, local: &ast::local) -> bool {
     match local.node.pat.node {
         ast::pat_wild => true, _ => false
     }
 }
 
-pub fn init_local(bcx: block, local: @ast::local) -> block {
+pub fn init_local(bcx: block, local: &ast::local) -> block {
 
     debug!("init_local(bcx=%s, local.id=%?)",
            bcx.to_str(), local.node.id);
@@ -1378,7 +1377,7 @@ pub fn block_locals(b: &ast::blk, it: &fn(@ast::local)) {
     }
 }
 
-pub fn alloc_local(cx: block, local: @ast::local) -> block {
+pub fn alloc_local(cx: block, local: &ast::local) -> block {
     let _icx = push_ctxt("alloc_local");
     let t = node_id_type(cx, local.node.id);
     let simple_name = match local.node.pat.node {
@@ -2379,7 +2378,7 @@ pub fn fill_fn_pair(bcx: block, pair: ValueRef, llfn: ValueRef,
     Store(bcx, llenvblobptr, env_cell);
 }
 
-pub fn item_path(ccx: &CrateContext, i: @ast::item) -> path {
+pub fn item_path(ccx: &CrateContext, i: &ast::item) -> path {
     let base = match ccx.tcx.items.get_copy(&i.id) {
         ast_map::node_item(_, p) => p,
             // separate map for paths?
@@ -2544,7 +2543,7 @@ pub fn register_method(ccx: @mut CrateContext,
 }
 
 // The constant translation pass.
-pub fn trans_constant(ccx: @mut CrateContext, it: @ast::item) {
+pub fn trans_constant(ccx: &mut CrateContext, it: @ast::item) {
     let _icx = push_ctxt("trans_constant");
     match it.node {
       ast::item_enum(ref enum_definition, _) => {
@@ -2894,7 +2893,7 @@ pub fn write_abi_version(ccx: &mut CrateContext) {
 }
 
 pub fn trans_crate(sess: session::Session,
-                   crate: @ast::crate,
+                   crate: &ast::crate,
                    tcx: ty::ctxt,
                    output: &Path,
                    emap2: resolve::ExportMap2,

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -468,7 +468,7 @@ pub fn make_closure_glue(
         cx: block,
         v: ValueRef,
         t: ty::t,
-        glue_fn: @fn(block, v: ValueRef, t: ty::t) -> block) -> block {
+        glue_fn: &fn(block, v: ValueRef, t: ty::t) -> block) -> block {
     let _icx = push_ctxt("closure::make_closure_glue");
     let bcx = cx;
     let tcx = cx.tcx();

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -411,7 +411,6 @@ pub fn add_clean_free(cx: block, ptr: ValueRef, heap: heap) {
 // drop glue checks whether it is zero.
 pub fn revoke_clean(cx: block, val: ValueRef) {
     do in_scope_cx(cx) |scope_info| {
-        let scope_info = &mut *scope_info; // FIXME(#5074) workaround borrowck
         let cleanup_pos = scope_info.cleanups.iter().position_(
             |cu| match *cu {
                 clean_temp(v, _, _) if v == val => true,
@@ -473,7 +472,7 @@ pub trait get_node_info {
     fn info(&self) -> Option<NodeInfo>;
 }
 
-impl get_node_info for @ast::expr {
+impl get_node_info for ast::expr {
     fn info(&self) -> Option<NodeInfo> {
         Some(NodeInfo {id: self.id,
                        callee_id: self.get_callee_id(),
@@ -573,7 +572,7 @@ pub fn val_ty(v: ValueRef) -> Type {
     }
 }
 
-pub fn in_scope_cx(cx: block, f: &fn(si: @mut scope_info)) {
+pub fn in_scope_cx(cx: block, f: &fn(si: &mut scope_info)) {
     let mut cur = cx;
     loop {
         match cur.kind {
@@ -612,11 +611,11 @@ impl block_ {
         e.repr(self.tcx())
     }
 
-    pub fn expr_is_lval(&self, e: @ast::expr) -> bool {
+    pub fn expr_is_lval(&self, e: &ast::expr) -> bool {
         ty::expr_is_lval(self.tcx(), self.ccx().maps.method_map, e)
     }
 
-    pub fn expr_kind(&self, e: @ast::expr) -> ty::ExprKind {
+    pub fn expr_kind(&self, e: &ast::expr) -> ty::ExprKind {
         ty::expr_kind(self.tcx(), self.ccx().maps.method_map, e)
     }
 
@@ -995,11 +994,11 @@ pub fn node_id_type(bcx: block, id: ast::node_id) -> ty::t {
     monomorphize_type(bcx, t)
 }
 
-pub fn expr_ty(bcx: block, ex: @ast::expr) -> ty::t {
+pub fn expr_ty(bcx: block, ex: &ast::expr) -> ty::t {
     node_id_type(bcx, ex.id)
 }
 
-pub fn expr_ty_adjusted(bcx: block, ex: @ast::expr) -> ty::t {
+pub fn expr_ty_adjusted(bcx: block, ex: &ast::expr) -> ty::t {
     let tcx = bcx.tcx();
     let t = ty::expr_ty_adjusted(tcx, ex);
     monomorphize_type(bcx, t)

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -35,7 +35,7 @@ use core::libc::c_uint;
 use core::str;
 use syntax::{ast, ast_util, ast_map};
 
-pub fn const_lit(cx: @mut CrateContext, e: @ast::expr, lit: ast::lit)
+pub fn const_lit(cx: &mut CrateContext, e: &ast::expr, lit: ast::lit)
     -> ValueRef {
     let _icx = push_ctxt("trans_lit");
     match lit.node {
@@ -82,7 +82,7 @@ pub fn const_ptrcast(cx: &mut CrateContext, a: ValueRef, t: Type) -> ValueRef {
     }
 }
 
-pub fn const_vec(cx: @mut CrateContext, e: @ast::expr, es: &[@ast::expr])
+pub fn const_vec(cx: @mut CrateContext, e: &ast::expr, es: &[@ast::expr])
     -> (ValueRef, ValueRef, Type) {
     unsafe {
         let vec_ty = ty::expr_ty(cx.tcx, e);
@@ -101,7 +101,7 @@ pub fn const_vec(cx: @mut CrateContext, e: @ast::expr, es: &[@ast::expr])
     }
 }
 
-fn const_addr_of(cx: @mut CrateContext, cv: ValueRef) -> ValueRef {
+fn const_addr_of(cx: &mut CrateContext, cv: ValueRef) -> ValueRef {
     unsafe {
         let gv = do "const".as_c_str |name| {
             llvm::LLVMAddGlobal(cx.llmod, val_ty(cv).to_ref(), name)
@@ -113,7 +113,7 @@ fn const_addr_of(cx: @mut CrateContext, cv: ValueRef) -> ValueRef {
     }
 }
 
-fn const_deref_ptr(cx: @mut CrateContext, v: ValueRef) -> ValueRef {
+fn const_deref_ptr(cx: &mut CrateContext, v: ValueRef) -> ValueRef {
     let v = match cx.const_globals.find(&(v as int)) {
         Some(&v) => v,
         None => v
@@ -124,13 +124,13 @@ fn const_deref_ptr(cx: @mut CrateContext, v: ValueRef) -> ValueRef {
     }
 }
 
-fn const_deref_newtype(cx: @mut CrateContext, v: ValueRef, t: ty::t)
+fn const_deref_newtype(cx: &mut CrateContext, v: ValueRef, t: ty::t)
     -> ValueRef {
     let repr = adt::represent_type(cx, t);
     adt::const_get_field(cx, repr, v, 0, 0)
 }
 
-fn const_deref(cx: @mut CrateContext, v: ValueRef, t: ty::t, explicit: bool)
+fn const_deref(cx: &mut CrateContext, v: ValueRef, t: ty::t, explicit: bool)
     -> (ValueRef, ty::t) {
     match ty::deref(cx.tcx, t, explicit) {
         Some(ref mt) => {
@@ -247,7 +247,7 @@ pub fn const_expr(cx: @mut CrateContext, e: @ast::expr) -> ValueRef {
     llconst
 }
 
-fn const_expr_unadjusted(cx: @mut CrateContext, e: @ast::expr) -> ValueRef {
+fn const_expr_unadjusted(cx: @mut CrateContext, e: &ast::expr) -> ValueRef {
     unsafe {
         let _icx = push_ctxt("const_expr");
         return match e.node {
@@ -393,7 +393,8 @@ fn const_expr_unadjusted(cx: @mut CrateContext, e: @ast::expr) -> ValueRef {
                           let llunitty = type_of::type_of(cx, unit_ty);
                           let unit_sz = machine::llsize_of(cx, llunitty);
 
-                          (const_deref_ptr(cx, const_get_elt(cx, bv, [0])),
+                          let e1 = const_get_elt(cx, bv, [0]);
+                          (const_deref_ptr(cx, e1),
                            llvm::LLVMConstUDiv(const_get_elt(cx, bv, [1]),
                                                unit_sz))
                       },

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -178,7 +178,7 @@ pub fn trans_loop(bcx:block,
     return next_bcx;
 }
 
-pub fn trans_log(log_ex: @ast::expr,
+pub fn trans_log(log_ex: &ast::expr,
                  lvl: @ast::expr,
                  bcx: block,
                  e: @ast::expr) -> block {

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -723,7 +723,7 @@ impl Datum {
     }
 
     /// expr: The deref expression.
-    pub fn deref(&self, bcx: block, expr: @ast::expr, derefs: uint)
+    pub fn deref(&self, bcx: block, expr: &ast::expr, derefs: uint)
                  -> DatumBlock {
         match self.try_deref(bcx, expr.span, expr.id, derefs, false) {
             (Some(lvres), bcx) => DatumBlock { bcx: bcx, datum: lvres },

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -254,7 +254,7 @@ pub fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
 
     fn auto_slice(bcx: block,
                   autoderefs: uint,
-                  expr: @ast::expr,
+                  expr: &ast::expr,
                   datum: Datum) -> DatumBlock {
         // This is not the most efficient thing possible; since slices
         // are two words it'd be better if this were compiled in
@@ -280,7 +280,7 @@ pub fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
         DatumBlock {bcx: bcx, datum: scratch}
     }
 
-    fn add_env(bcx: block, expr: @ast::expr, datum: Datum) -> DatumBlock {
+    fn add_env(bcx: block, expr: &ast::expr, datum: Datum) -> DatumBlock {
         // This is not the most efficient thing possible; since closures
         // are two words it'd be better if this were compiled in
         // 'dest' mode, but I can't find a nice way to structure the
@@ -301,7 +301,7 @@ pub fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
 
     fn auto_slice_and_ref(bcx: block,
                           autoderefs: uint,
-                          expr: @ast::expr,
+                          expr: &ast::expr,
                           datum: Datum) -> DatumBlock {
         let DatumBlock { bcx, datum } = auto_slice(bcx, autoderefs, expr, datum);
         auto_ref(bcx, datum)
@@ -705,7 +705,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
     }
 }
 
-fn trans_def_dps_unadjusted(bcx: block, ref_expr: @ast::expr,
+fn trans_def_dps_unadjusted(bcx: block, ref_expr: &ast::expr,
                             def: ast::def, dest: Dest) -> block {
     let _icx = push_ctxt("trans_def_dps_unadjusted");
     let ccx = bcx.ccx();
@@ -752,7 +752,7 @@ fn trans_def_dps_unadjusted(bcx: block, ref_expr: @ast::expr,
 }
 
 fn trans_def_datum_unadjusted(bcx: block,
-                              ref_expr: @ast::expr,
+                              ref_expr: &ast::expr,
                               def: ast::def) -> DatumBlock
 {
     let _icx = push_ctxt("trans_def_datum_unadjusted");
@@ -776,7 +776,7 @@ fn trans_def_datum_unadjusted(bcx: block,
     }
 
     fn fn_data_to_datum(bcx: block,
-                        ref_expr: @ast::expr,
+                        ref_expr: &ast::expr,
                         def_id: ast::def_id,
                         fn_data: callee::FnData) -> DatumBlock {
         /*!
@@ -873,7 +873,7 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
     }
 
     fn trans_index(bcx: block,
-                   index_expr: @ast::expr,
+                   index_expr: &ast::expr,
                    base: @ast::expr,
                    idx: @ast::expr) -> DatumBlock {
         //! Translates `base[idx]`.
@@ -936,7 +936,7 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
     }
 
     fn trans_def_lvalue(bcx: block,
-                        ref_expr: @ast::expr,
+                        ref_expr: &ast::expr,
                         def: ast::def)
         -> DatumBlock
     {
@@ -1263,7 +1263,7 @@ fn trans_immediate_lit(bcx: block, expr: @ast::expr,
 }
 
 fn trans_unary_datum(bcx: block,
-                     un_expr: @ast::expr,
+                     un_expr: &ast::expr,
                      op: ast::unop,
                      sub_expr: @ast::expr) -> DatumBlock {
     let _icx = push_ctxt("trans_unary_datum");
@@ -1337,7 +1337,7 @@ fn trans_unary_datum(bcx: block,
     }
 }
 
-fn trans_addr_of(bcx: block, expr: @ast::expr,
+fn trans_addr_of(bcx: block, expr: &ast::expr,
                  subexpr: @ast::expr) -> DatumBlock {
     let _icx = push_ctxt("trans_addr_of");
     let mut bcx = bcx;
@@ -1349,7 +1349,7 @@ fn trans_addr_of(bcx: block, expr: @ast::expr,
 // Important to get types for both lhs and rhs, because one might be _|_
 // and the other not.
 fn trans_eager_binop(bcx: block,
-                     binop_expr: @ast::expr,
+                     binop_expr: &ast::expr,
                      binop_ty: ty::t,
                      op: ast::binop,
                      lhs_datum: &Datum,
@@ -1447,7 +1447,7 @@ fn trans_eager_binop(bcx: block,
 enum lazy_binop_ty { lazy_and, lazy_or }
 
 fn trans_lazy_binop(bcx: block,
-                    binop_expr: @ast::expr,
+                    binop_expr: &ast::expr,
                     op: lazy_binop_ty,
                     a: @ast::expr,
                     b: @ast::expr) -> DatumBlock {
@@ -1492,7 +1492,7 @@ fn trans_lazy_binop(bcx: block,
 }
 
 fn trans_binary(bcx: block,
-                binop_expr: @ast::expr,
+                binop_expr: &ast::expr,
                 op: ast::binop,
                 lhs: @ast::expr,
                 rhs: @ast::expr) -> DatumBlock
@@ -1518,7 +1518,7 @@ fn trans_binary(bcx: block,
 }
 
 fn trans_overloaded_op(bcx: block,
-                       expr: @ast::expr,
+                       expr: &ast::expr,
                        callee_id: ast::node_id,
                        rcvr: @ast::expr,
                        args: ~[@ast::expr],

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -55,7 +55,7 @@ fn abi_info(ccx: @mut CrateContext) -> @cabi::ABIInfo {
     }
 }
 
-pub fn link_name(ccx: &CrateContext, i: @ast::foreign_item) -> @str {
+pub fn link_name(ccx: &CrateContext, i: &ast::foreign_item) -> @str {
      match attr::first_attr_value_str_by_name(i.attrs, "link_name") {
         None => ccx.sess.str_of(i.ident),
         Some(ln) => ln,
@@ -89,7 +89,7 @@ struct LlvmSignature {
     sret: bool,
 }
 
-fn foreign_signature(ccx: @mut CrateContext, fn_sig: &ty::FnSig)
+fn foreign_signature(ccx: &mut CrateContext, fn_sig: &ty::FnSig)
                      -> LlvmSignature {
     /*!
      * The ForeignSignature is the LLVM types of the arguments/return type
@@ -138,7 +138,7 @@ type shim_ret_builder<'self> =
               llretval: ValueRef);
 
 fn build_shim_fn_(ccx: @mut CrateContext,
-                  shim_name: ~str,
+                  shim_name: &str,
                   llbasefn: ValueRef,
                   tys: &ShimTypes,
                   cc: lib::llvm::CallConv,
@@ -357,7 +357,7 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
     }
 
     fn build_shim_fn(ccx: @mut CrateContext,
-                     foreign_item: @ast::foreign_item,
+                     foreign_item: &ast::foreign_item,
                      tys: &ShimTypes,
                      cc: lib::llvm::CallConv)
                   -> ValueRef {
@@ -419,7 +419,7 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
     // over the place
     fn build_direct_fn(ccx: @mut CrateContext,
                        decl: ValueRef,
-                       item: @ast::foreign_item,
+                       item: &ast::foreign_item,
                        tys: &ShimTypes,
                        cc: lib::llvm::CallConv) {
         debug!("build_direct_fn(%s)", link_name(ccx, item));
@@ -446,7 +446,7 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
     // over the place
     fn build_fast_ffi_fn(ccx: @mut CrateContext,
                          decl: ValueRef,
-                         item: @ast::foreign_item,
+                         item: &ast::foreign_item,
                          tys: &ShimTypes,
                          cc: lib::llvm::CallConv) {
         debug!("build_fast_ffi_fn(%s)", link_name(ccx, item));
@@ -541,7 +541,7 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
 
 pub fn trans_intrinsic(ccx: @mut CrateContext,
                        decl: ValueRef,
-                       item: @ast::foreign_item,
+                       item: &ast::foreign_item,
                        path: ast_map::path,
                        substs: @param_substs,
                        attributes: &[ast::attribute],

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -357,7 +357,7 @@ pub fn method_from_methods(ms: &[@ast::method], name: ast::ident)
     ms.iter().find_(|m| m.ident == name).map(|m| ast_util::local_def(m.id))
 }
 
-pub fn method_with_name_or_default(ccx: @mut CrateContext,
+pub fn method_with_name_or_default(ccx: &mut CrateContext,
                                    impl_id: ast::def_id,
                                    name: ast::ident) -> ast::def_id {
     let imp = ccx.impl_method_cache.find_copy(&(impl_id, name));
@@ -742,8 +742,8 @@ pub fn get_vtable(bcx: block,
 }
 
 /// Helper function to declare and initialize the vtable.
-pub fn make_vtable(ccx: @mut CrateContext,
-                   tydesc: @mut tydesc_info,
+pub fn make_vtable(ccx: &mut CrateContext,
+                   tydesc: &tydesc_info,
                    ptrs: &[ValueRef])
                    -> ValueRef {
     unsafe {
@@ -770,7 +770,7 @@ pub fn make_vtable(ccx: @mut CrateContext,
 pub fn make_impl_vtable(bcx: block,
                         impl_id: ast::def_id,
                         self_ty: ty::t,
-                        substs: ~[ty::t],
+                        substs: &[ty::t],
                         vtables: typeck::vtable_res)
                         -> ValueRef {
     let ccx = bcx.ccx();

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -86,7 +86,7 @@ impl Reflector {
           self.c_tydesc(mt.ty)]
     }
 
-    pub fn visit(&mut self, ty_name: ~str, args: &[ValueRef]) {
+    pub fn visit(&mut self, ty_name: &str, args: &[ValueRef]) {
         let tcx = self.bcx.tcx();
         let mth_idx = ty::method_idx(
             tcx.sess.ident_of(~"visit_" + ty_name),
@@ -122,7 +122,7 @@ impl Reflector {
     }
 
     pub fn bracketed(&mut self,
-                     bracket_name: ~str,
+                     bracket_name: &str,
                      extra: &[ValueRef],
                      inner: &fn(&mut Reflector)) {
         self.visit(~"enter_" + bracket_name, extra);
@@ -146,7 +146,7 @@ impl Reflector {
         }
     }
 
-    pub fn leaf(&mut self, name: ~str) {
+    pub fn leaf(&mut self, name: &str) {
         self.visit(name, []);
     }
 
@@ -156,27 +156,27 @@ impl Reflector {
         debug!("reflect::visit_ty %s", ty_to_str(bcx.ccx().tcx, t));
 
         match ty::get(t).sty {
-          ty::ty_bot => self.leaf(~"bot"),
-          ty::ty_nil => self.leaf(~"nil"),
-          ty::ty_bool => self.leaf(~"bool"),
-          ty::ty_int(ast::ty_i) => self.leaf(~"int"),
-          ty::ty_int(ast::ty_char) => self.leaf(~"char"),
-          ty::ty_int(ast::ty_i8) => self.leaf(~"i8"),
-          ty::ty_int(ast::ty_i16) => self.leaf(~"i16"),
-          ty::ty_int(ast::ty_i32) => self.leaf(~"i32"),
-          ty::ty_int(ast::ty_i64) => self.leaf(~"i64"),
-          ty::ty_uint(ast::ty_u) => self.leaf(~"uint"),
-          ty::ty_uint(ast::ty_u8) => self.leaf(~"u8"),
-          ty::ty_uint(ast::ty_u16) => self.leaf(~"u16"),
-          ty::ty_uint(ast::ty_u32) => self.leaf(~"u32"),
-          ty::ty_uint(ast::ty_u64) => self.leaf(~"u64"),
-          ty::ty_float(ast::ty_f) => self.leaf(~"float"),
-          ty::ty_float(ast::ty_f32) => self.leaf(~"f32"),
-          ty::ty_float(ast::ty_f64) => self.leaf(~"f64"),
+          ty::ty_bot => self.leaf("bot"),
+          ty::ty_nil => self.leaf("nil"),
+          ty::ty_bool => self.leaf("bool"),
+          ty::ty_int(ast::ty_i) => self.leaf("int"),
+          ty::ty_int(ast::ty_char) => self.leaf("char"),
+          ty::ty_int(ast::ty_i8) => self.leaf("i8"),
+          ty::ty_int(ast::ty_i16) => self.leaf("i16"),
+          ty::ty_int(ast::ty_i32) => self.leaf("i32"),
+          ty::ty_int(ast::ty_i64) => self.leaf("i64"),
+          ty::ty_uint(ast::ty_u) => self.leaf("uint"),
+          ty::ty_uint(ast::ty_u8) => self.leaf("u8"),
+          ty::ty_uint(ast::ty_u16) => self.leaf("u16"),
+          ty::ty_uint(ast::ty_u32) => self.leaf("u32"),
+          ty::ty_uint(ast::ty_u64) => self.leaf("u64"),
+          ty::ty_float(ast::ty_f) => self.leaf("float"),
+          ty::ty_float(ast::ty_f32) => self.leaf("f32"),
+          ty::ty_float(ast::ty_f64) => self.leaf("f64"),
 
           ty::ty_unboxed_vec(ref mt) => {
               let values = self.c_mt(mt);
-              self.visit(~"vec", values)
+              self.visit("vec", values)
           }
 
           ty::ty_estr(vst) => {
@@ -190,28 +190,28 @@ impl Reflector {
           }
           ty::ty_box(ref mt) => {
               let extra = self.c_mt(mt);
-              self.visit(~"box", extra)
+              self.visit("box", extra)
           }
           ty::ty_uniq(ref mt) => {
               let extra = self.c_mt(mt);
-              self.visit(~"uniq", extra)
+              self.visit("uniq", extra)
           }
           ty::ty_ptr(ref mt) => {
               let extra = self.c_mt(mt);
-              self.visit(~"ptr", extra)
+              self.visit("ptr", extra)
           }
           ty::ty_rptr(_, ref mt) => {
               let extra = self.c_mt(mt);
-              self.visit(~"rptr", extra)
+              self.visit("rptr", extra)
           }
 
           ty::ty_tup(ref tys) => {
               let extra = ~[self.c_uint(tys.len())]
                   + self.c_size_and_align(t);
-              do self.bracketed(~"tup", extra) |this| {
+              do self.bracketed("tup", extra) |this| {
                   for tys.iter().enumerate().advance |(i, t)| {
                       let extra = ~[this.c_uint(i), this.c_tydesc(*t)];
-                      this.visit(~"tup_field", extra);
+                      this.visit("tup_field", extra);
                   }
               }
           }
@@ -226,9 +226,9 @@ impl Reflector {
                           self.c_uint(sigilval),
                           self.c_uint(fty.sig.inputs.len()),
                           self.c_uint(retval)];
-            self.visit(~"enter_fn", extra);
+            self.visit("enter_fn", extra);
             self.visit_sig(retval, &fty.sig);
-            self.visit(~"leave_fn", extra);
+            self.visit("leave_fn", extra);
           }
 
           // FIXME (#2594): fetch constants out of intrinsic:: for the
@@ -241,9 +241,9 @@ impl Reflector {
                           self.c_uint(sigilval),
                           self.c_uint(fty.sig.inputs.len()),
                           self.c_uint(retval)];
-            self.visit(~"enter_fn", extra);
+            self.visit("enter_fn", extra);
             self.visit_sig(retval, &fty.sig);
-            self.visit(~"leave_fn", extra);
+            self.visit("leave_fn", extra);
           }
 
           ty::ty_struct(did, ref substs) => {
@@ -253,13 +253,13 @@ impl Reflector {
 
               let extra = ~[self.c_uint(fields.len())]
                   + self.c_size_and_align(t);
-              do self.bracketed(~"class", extra) |this| {
+              do self.bracketed("class", extra) |this| {
                   for fields.iter().enumerate().advance |(i, field)| {
                       let extra = ~[this.c_uint(i),
                                     this.c_slice(
                                         bcx.ccx().sess.str_of(field.ident))]
                           + this.c_mt(&field.mt);
-                      this.visit(~"class_field", extra);
+                      this.visit("class_field", extra);
                   }
               }
           }
@@ -309,14 +309,14 @@ impl Reflector {
 
             let enum_args = ~[self.c_uint(variants.len()), make_get_disr()]
                 + self.c_size_and_align(t);
-            do self.bracketed(~"enum", enum_args) |this| {
+            do self.bracketed("enum", enum_args) |this| {
                 for variants.iter().enumerate().advance |(i, v)| {
                     let name = ccx.sess.str_of(v.name);
                     let variant_args = ~[this.c_uint(i),
                                          this.c_int(v.disr_val),
                                          this.c_uint(v.args.len()),
                                          this.c_slice(name)];
-                    do this.bracketed(~"enum_variant", variant_args) |this| {
+                    do this.bracketed("enum_variant", variant_args) |this| {
                         for v.args.iter().enumerate().advance |(j, a)| {
                             let bcx = this.bcx;
                             let null = C_null(llptrty);
@@ -325,7 +325,7 @@ impl Reflector {
                             let field_args = ~[this.c_uint(j),
                                                offset,
                                                this.c_tydesc(*a)];
-                            this.visit(~"enum_variant_field", field_args);
+                            this.visit("enum_variant_field", field_args);
                         }
                     }
                 }
@@ -333,20 +333,20 @@ impl Reflector {
           }
 
           // Miscallaneous extra types
-          ty::ty_trait(_, _, _, _, _) => self.leaf(~"trait"),
-          ty::ty_infer(_) => self.leaf(~"infer"),
-          ty::ty_err => self.leaf(~"err"),
+          ty::ty_trait(_, _, _, _, _) => self.leaf("trait"),
+          ty::ty_infer(_) => self.leaf("infer"),
+          ty::ty_err => self.leaf("err"),
           ty::ty_param(ref p) => {
               let extra = ~[self.c_uint(p.idx)];
-              self.visit(~"param", extra)
+              self.visit("param", extra)
           }
-          ty::ty_self(*) => self.leaf(~"self"),
-          ty::ty_type => self.leaf(~"type"),
-          ty::ty_opaque_box => self.leaf(~"opaque_box"),
+          ty::ty_self(*) => self.leaf("self"),
+          ty::ty_type => self.leaf("type"),
+          ty::ty_opaque_box => self.leaf("opaque_box"),
           ty::ty_opaque_closure_ptr(ck) => {
               let ckval = ast_sigil_constant(ck);
               let extra = ~[self.c_uint(ckval)];
-              self.visit(~"closure_ptr", extra)
+              self.visit("closure_ptr", extra)
           }
         }
     }
@@ -357,11 +357,11 @@ impl Reflector {
             let extra = ~[self.c_uint(i),
                          self.c_uint(modeval),
                          self.c_tydesc(*arg)];
-            self.visit(~"fn_input", extra);
+            self.visit("fn_input", extra);
         }
         let extra = ~[self.c_uint(retval),
                       self.c_tydesc(sig.output)];
-        self.visit(~"fn_output", extra);
+        self.visit("fn_output", extra);
     }
 }
 

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -164,7 +164,7 @@ impl VecTypes {
 
 pub fn trans_fixed_vstore(bcx: block,
                           vstore_expr: @ast::expr,
-                          content_expr: @ast::expr,
+                          content_expr: &ast::expr,
                           dest: expr::Dest)
                        -> block {
     //!
@@ -286,7 +286,7 @@ pub fn trans_lit_str(bcx: block,
 
 
 pub fn trans_uniq_or_managed_vstore(bcx: block, heap: heap, vstore_expr: @ast::expr,
-                                    content_expr: @ast::expr) -> DatumBlock {
+                                    content_expr: &ast::expr) -> DatumBlock {
     //!
     //
     // @[...] or ~[...] (also @"..." or ~"...") allocate boxes in the
@@ -346,7 +346,7 @@ pub fn trans_uniq_or_managed_vstore(bcx: block, heap: heap, vstore_expr: @ast::e
 pub fn write_content(bcx: block,
                      vt: &VecTypes,
                      vstore_expr: @ast::expr,
-                     content_expr: @ast::expr,
+                     content_expr: &ast::expr,
                      dest: Dest)
                   -> block {
     let _icx = push_ctxt("tvec::write_content");
@@ -471,7 +471,7 @@ pub fn write_content(bcx: block,
     }
 }
 
-pub fn vec_types_from_expr(bcx: block, vec_expr: @ast::expr) -> VecTypes {
+pub fn vec_types_from_expr(bcx: block, vec_expr: &ast::expr) -> VecTypes {
     let vec_ty = node_id_type(bcx, vec_expr.id);
     vec_types(bcx, vec_ty)
 }
@@ -488,7 +488,7 @@ pub fn vec_types(bcx: block, vec_ty: ty::t) -> VecTypes {
               llunit_size: llunit_size}
 }
 
-pub fn elements_required(bcx: block, content_expr: @ast::expr) -> uint {
+pub fn elements_required(bcx: block, content_expr: &ast::expr) -> uint {
     //! Figure out the number of elements we need to store this content
 
     match content_expr.node {
@@ -541,8 +541,6 @@ pub fn get_base_and_len(bcx: block,
         }
     }
 }
-
-pub type val_and_ty_fn = @fn(block, ValueRef, ty::t) -> Result;
 
 pub type iter_vec_block<'self> = &'self fn(block, ValueRef, ty::t) -> block;
 

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -79,7 +79,7 @@ pub fn type_uses_for(ccx: @mut CrateContext, fn_id: def_id, n_tps: uint)
         ty::ty_bare_fn(ty::BareFnTy {sig: ref sig, _}) |
         ty::ty_closure(ty::ClosureTy {sig: ref sig, _}) => {
             for sig.inputs.iter().advance |arg| {
-                type_needs(cx, use_repr, *arg);
+                type_needs(&cx, use_repr, *arg);
             }
         }
         _ => ()
@@ -100,7 +100,7 @@ pub fn type_uses_for(ccx: @mut CrateContext, fn_id: def_id, n_tps: uint)
       ast_map::node_item(@ast::item { node: item_fn(_, _, _, _, ref body),
                                       _ }, _) |
       ast_map::node_method(@ast::method {body: ref body, _}, _, _) => {
-        handle_body(cx, body);
+        handle_body(&cx, body);
       }
       ast_map::node_trait_method(*) => {
         // This will be a static trait method. For now, we just assume
@@ -177,7 +177,7 @@ pub fn type_uses_for(ccx: @mut CrateContext, fn_id: def_id, n_tps: uint)
     uses
 }
 
-pub fn type_needs(cx: Context, use_: uint, ty: ty::t) {
+pub fn type_needs(cx: &Context, use_: uint, ty: ty::t) {
     // Optimization -- don't descend type if all params already have this use
     let len = {
         let uses = &*cx.uses;
@@ -191,7 +191,7 @@ pub fn type_needs(cx: Context, use_: uint, ty: ty::t) {
     }
 }
 
-pub fn type_needs_inner(cx: Context,
+pub fn type_needs_inner(cx: &Context,
                         use_: uint,
                         ty: ty::t,
                         enums_seen: @List<def_id>) {
@@ -233,11 +233,11 @@ pub fn type_needs_inner(cx: Context,
     }
 }
 
-pub fn node_type_needs(cx: Context, use_: uint, id: node_id) {
+pub fn node_type_needs(cx: &Context, use_: uint, id: node_id) {
     type_needs(cx, use_, ty::node_id_to_type(cx.ccx.tcx, id));
 }
 
-pub fn mark_for_method_call(cx: Context, e_id: node_id, callee_id: node_id) {
+pub fn mark_for_method_call(cx: &Context, e_id: node_id, callee_id: node_id) {
     let mut opt_static_did = None;
     {
         let r = cx.ccx.maps.method_map.find(&e_id);
@@ -275,7 +275,7 @@ pub fn mark_for_method_call(cx: Context, e_id: node_id, callee_id: node_id) {
     }
 }
 
-pub fn mark_for_expr(cx: Context, e: @expr) {
+pub fn mark_for_expr(cx: &Context, e: &expr) {
     match e.node {
       expr_vstore(_, _) | expr_vec(_, _) | expr_struct(*) | expr_tup(_) |
       expr_unary(_, box(_), _) | expr_unary(_, uniq(_), _) |
@@ -379,7 +379,7 @@ pub fn mark_for_expr(cx: Context, e: @expr) {
     }
 }
 
-pub fn handle_body(cx: Context, body: &blk) {
+pub fn handle_body(cx: &Context, body: &blk) {
     let v = visit::mk_vt(@visit::Visitor {
         visit_expr: |e, (cx, v)| {
             visit::visit_expr(e, (cx, v));

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3017,7 +3017,7 @@ pub fn block_ty(cx: ctxt, b: &ast::blk) -> t {
 
 // Returns the type of a pattern as a monotype. Like @expr_ty, this function
 // doesn't provide type parameter substitutions.
-pub fn pat_ty(cx: ctxt, pat: @ast::pat) -> t {
+pub fn pat_ty(cx: ctxt, pat: &ast::pat) -> t {
     return node_id_to_type(cx, pat.id);
 }
 
@@ -3033,11 +3033,11 @@ pub fn pat_ty(cx: ctxt, pat: @ast::pat) -> t {
 // ask for the type of "id" in "id(3)", it will return "fn(&int) -> int"
 // instead of "fn(t) -> T with T = int". If this isn't what you want, see
 // expr_ty_params_and_ty() below.
-pub fn expr_ty(cx: ctxt, expr: @ast::expr) -> t {
+pub fn expr_ty(cx: ctxt, expr: &ast::expr) -> t {
     return node_id_to_type(cx, expr.id);
 }
 
-pub fn expr_ty_adjusted(cx: ctxt, expr: @ast::expr) -> t {
+pub fn expr_ty_adjusted(cx: ctxt, expr: &ast::expr) -> t {
     /*!
      *
      * Returns the type of `expr`, considering any `AutoAdjustment`
@@ -3191,7 +3191,7 @@ pub struct ParamsTy {
 }
 
 pub fn expr_ty_params_and_ty(cx: ctxt,
-                             expr: @ast::expr)
+                             expr: &ast::expr)
                           -> ParamsTy {
     ParamsTy {
         params: node_id_to_type_params(cx, expr.id),
@@ -3199,7 +3199,7 @@ pub fn expr_ty_params_and_ty(cx: ctxt,
     }
 }
 
-pub fn expr_has_ty_params(cx: ctxt, expr: @ast::expr) -> bool {
+pub fn expr_has_ty_params(cx: ctxt, expr: &ast::expr) -> bool {
     return node_id_has_type_params(cx, expr.id);
 }
 
@@ -3235,7 +3235,7 @@ pub fn method_call_type_param_defs(
     }
 }
 
-pub fn resolve_expr(tcx: ctxt, expr: @ast::expr) -> ast::def {
+pub fn resolve_expr(tcx: ctxt, expr: &ast::expr) -> ast::def {
     match tcx.def_map.find(&expr.id) {
         Some(&def) => def,
         None => {
@@ -3247,7 +3247,7 @@ pub fn resolve_expr(tcx: ctxt, expr: @ast::expr) -> ast::def {
 
 pub fn expr_is_lval(tcx: ctxt,
                     method_map: typeck::method_map,
-                    e: @ast::expr) -> bool {
+                    e: &ast::expr) -> bool {
     match expr_kind(tcx, method_map, e) {
         LvalueExpr => true,
         RvalueDpsExpr | RvalueDatumExpr | RvalueStmtExpr => false
@@ -3268,7 +3268,7 @@ pub enum ExprKind {
 
 pub fn expr_kind(tcx: ctxt,
                  method_map: typeck::method_map,
-                 expr: @ast::expr) -> ExprKind {
+                 expr: &ast::expr) -> ExprKind {
     if method_map.contains_key(&expr.id) {
         // Overloaded operations are generally calls, and hence they are
         // generated via DPS.  However, assign_op (e.g., `x += y`) is an
@@ -3388,7 +3388,7 @@ pub fn expr_kind(tcx: ctxt,
     }
 }
 
-pub fn stmt_node_id(s: @ast::stmt) -> ast::node_id {
+pub fn stmt_node_id(s: &ast::stmt) -> ast::node_id {
     match s.node {
       ast::stmt_decl(_, id) | stmt_expr(_, id) | stmt_semi(_, id) => {
         return id;
@@ -4374,7 +4374,7 @@ pub fn normalize_ty(cx: ctxt, t: t) -> t {
 }
 
 // Returns the repeat count for a repeating vector expression.
-pub fn eval_repeat_count(tcx: ctxt, count_expr: @ast::expr) -> uint {
+pub fn eval_repeat_count(tcx: ctxt, count_expr: &ast::expr) -> uint {
     match const_eval::eval_const_expr_partial(tcx, count_expr) {
       Ok(ref const_val) => match *const_val {
         const_eval::const_int(count) => if count < 0 {

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -248,7 +248,7 @@ pub static NO_TPS: uint = 2;
 // internal notion of a type. `getter` is a function that returns the type
 // corresponding to a definition ID:
 pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + 'static>(
-    this: &AC, rscope: &RS, ast_ty: @ast::Ty) -> ty::t {
+    this: &AC, rscope: &RS, ast_ty: &ast::Ty) -> ty::t {
 
     fn ast_mt_to_mt<AC:AstConv, RS:region_scope + Copy + 'static>(
         this: &AC, rscope: &RS, mt: &ast::mt) -> ty::mt {

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -329,11 +329,9 @@ impl<'self> LookupContext<'self> {
         let opt_applicable_traits = trait_map.find(&self.expr.id);
         for opt_applicable_traits.iter().advance |applicable_traits| {
             for applicable_traits.iter().advance |trait_did| {
-                let coherence_info = self.fcx.ccx.coherence_info;
-
                 // Look for explicit implementations.
                 let opt_impl_infos =
-                    coherence_info.extension_methods.find(trait_did);
+                    self.fcx.ccx.coherence_info.extension_methods.find(trait_did);
                 for opt_impl_infos.iter().advance |impl_infos| {
                     for impl_infos.iter().advance |impl_info| {
                         self.push_candidates_from_impl(

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -284,7 +284,7 @@ pub fn blank_fn_ctxt(ccx: @mut CrateCtxt,
     }
 }
 
-pub fn check_item_types(ccx: @mut CrateCtxt, crate: @ast::crate) {
+pub fn check_item_types(ccx: @mut CrateCtxt, crate: &ast::crate) {
     let visit = visit::mk_simple_visitor(@visit::SimpleVisitor {
         visit_item: |a| check_item(ccx, a),
         .. *visit::default_simple_visitor()

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -197,7 +197,7 @@ pub struct CoherenceChecker {
 }
 
 impl CoherenceChecker {
-    pub fn check_coherence(self, crate: @crate) {
+    pub fn check_coherence(self, crate: &crate) {
         // Check implementations and traits. This populates the tables
         // containing the inherent methods and extension methods. It also
         // builds up the trait inheritance table.
@@ -455,7 +455,7 @@ impl CoherenceChecker {
     }
 
     pub fn check_implementation_coherence(&self) {
-        let coherence_info = self.crate_context.coherence_info;
+        let coherence_info = &self.crate_context.coherence_info;
         for coherence_info.extension_methods.each_key |&trait_id| {
             self.check_implementation_coherence_of(trait_id);
         }
@@ -514,7 +514,7 @@ impl CoherenceChecker {
     }
 
     pub fn iter_impls_of_trait(&self, trait_def_id: def_id, f: &fn(@Impl)) {
-        let coherence_info = self.crate_context.coherence_info;
+        let coherence_info = &self.crate_context.coherence_info;
         let extension_methods = &*coherence_info.extension_methods;
 
         match extension_methods.find(&trait_def_id) {
@@ -631,7 +631,7 @@ impl CoherenceChecker {
     }
 
     // Privileged scope checking
-    pub fn check_privileged_scopes(self, crate: @crate) {
+    pub fn check_privileged_scopes(self, crate: &crate) {
         visit_crate(crate, ((), mk_vt(@Visitor {
             visit_item: |item, (_context, visitor)| {
                 match item.node {
@@ -978,7 +978,7 @@ impl CoherenceChecker {
     //
 
     pub fn populate_destructor_table(&self) {
-        let coherence_info = self.crate_context.coherence_info;
+        let coherence_info = &self.crate_context.coherence_info;
         let tcx = self.crate_context.tcx;
         let drop_trait = tcx.lang_items.drop_trait();
         let impls_opt = coherence_info.extension_methods.find(&drop_trait);
@@ -1102,7 +1102,7 @@ fn subst_receiver_types_in_method_ty(tcx: ty::ctxt,
     )
 }
 
-pub fn check_coherence(crate_context: @mut CrateCtxt, crate: @crate) {
-    let coherence_checker = @CoherenceChecker(crate_context);
+pub fn check_coherence(crate_context: @mut CrateCtxt, crate: &crate) {
+    let coherence_checker = CoherenceChecker(crate_context);
     coherence_checker.check_coherence(crate);
 }

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -61,8 +61,8 @@ use syntax::visit;
 use syntax::opt_vec::OptVec;
 use syntax::opt_vec;
 
-pub fn collect_item_types(ccx: @mut CrateCtxt, crate: @ast::crate) {
-    fn collect_intrinsic_type(ccx: @mut CrateCtxt,
+pub fn collect_item_types(ccx: @mut CrateCtxt, crate: &ast::crate) {
+    fn collect_intrinsic_type(ccx: &CrateCtxt,
                               lang_item: ast::def_id) {
         let ty::ty_param_bounds_and_ty { ty: ty, _ } =
             ccx.get_item_ty(lang_item);
@@ -83,7 +83,7 @@ pub fn collect_item_types(ccx: @mut CrateCtxt, crate: @ast::crate) {
 
 impl CrateCtxt {
     fn to_ty<RS:region_scope + Copy + 'static>(
-        &self, rs: &RS, ast_ty: @ast::Ty) -> ty::t
+        &self, rs: &RS, ast_ty: &ast::Ty) -> ty::t
     {
         ast_ty_to_ty(self, rs, ast_ty)
     }
@@ -632,7 +632,7 @@ pub fn check_methods_against_trait(ccx: &CrateCtxt,
                                    generics: &ast::Generics,
                                    rp: Option<ty::region_variance>,
                                    selfty: ty::t,
-                                   a_trait_ty: @ast::trait_ref,
+                                   a_trait_ty: &ast::trait_ref,
                                    impl_ms: &[ConvertedMethod])
 {
     let tcx = ccx.tcx;
@@ -670,7 +670,7 @@ pub fn check_methods_against_trait(ccx: &CrateCtxt,
 pub fn convert_field(ccx: &CrateCtxt,
                      rp: Option<ty::region_variance>,
                      type_param_defs: @~[ty::TypeParameterDef],
-                     v: @ast::struct_field,
+                     v: &ast::struct_field,
                      generics: &ast::Generics) {
     let region_parameterization =
         RegionParameterization::from_variance_and_generics(rp, generics);
@@ -736,7 +736,7 @@ pub fn convert_methods(ccx: &CrateCtxt,
     });
 
     fn ty_of_method(ccx: &CrateCtxt,
-                    m: @ast::method,
+                    m: &ast::method,
                     rp: Option<ty::region_variance>,
                     untransformed_rcvr_ty: ty::t,
                     rcvr_generics: &ast::Generics,
@@ -785,7 +785,7 @@ pub fn ensure_no_ty_param_bounds(ccx: &CrateCtxt,
     }
 }
 
-pub fn convert(ccx: &CrateCtxt, it: @ast::item) {
+pub fn convert(ccx: &CrateCtxt, it: &ast::item) {
     let tcx = ccx.tcx;
     let rp = tcx.region_paramd_items.find(&it.id).map_consume(|x| *x);
     debug!("convert: item %s with id %d rp %?",
@@ -875,7 +875,7 @@ pub fn convert(ccx: &CrateCtxt, it: @ast::item) {
 
 pub fn convert_struct(ccx: &CrateCtxt,
                       rp: Option<ty::region_variance>,
-                      struct_def: @ast::struct_def,
+                      struct_def: &ast::struct_def,
                       generics: &ast::Generics,
                       tpt: ty::ty_param_bounds_and_ty,
                       id: ast::node_id) {
@@ -914,7 +914,7 @@ pub fn convert_struct(ccx: &CrateCtxt,
     }
 }
 
-pub fn convert_foreign(ccx: &CrateCtxt, i: @ast::foreign_item) {
+pub fn convert_foreign(ccx: &CrateCtxt, i: &ast::foreign_item) {
     // As above, this call populates the type table with the converted
     // type of the foreign item. We simply write it into the node type
     // table.
@@ -937,7 +937,7 @@ pub fn convert_foreign(ccx: &CrateCtxt, i: @ast::foreign_item) {
 }
 
 pub fn instantiate_trait_ref(ccx: &CrateCtxt,
-                             ast_trait_ref: @ast::trait_ref,
+                             ast_trait_ref: &ast::trait_ref,
                              rp: Option<ty::region_variance>,
                              generics: &ast::Generics,
                              self_ty: ty::t) -> @ty::TraitRef
@@ -983,7 +983,7 @@ fn get_trait_def(ccx: &CrateCtxt, trait_id: ast::def_id) -> @ty::TraitDef {
     }
 }
 
-pub fn trait_def_of_item(ccx: &CrateCtxt, it: @ast::item) -> @ty::TraitDef {
+pub fn trait_def_of_item(ccx: &CrateCtxt, it: &ast::item) -> @ty::TraitDef {
     let def_id = local_def(it.id);
     let tcx = ccx.tcx;
     match tcx.trait_defs.find(&def_id) {
@@ -1011,7 +1011,7 @@ pub fn trait_def_of_item(ccx: &CrateCtxt, it: @ast::item) -> @ty::TraitDef {
     }
 }
 
-pub fn ty_of_item(ccx: &CrateCtxt, it: @ast::item)
+pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::item)
                -> ty::ty_param_bounds_and_ty {
     let def_id = local_def(it.id);
     let tcx = ccx.tcx;
@@ -1103,7 +1103,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: @ast::item)
 }
 
 pub fn ty_of_foreign_item(ccx: &CrateCtxt,
-                          it: @ast::foreign_item,
+                          it: &ast::foreign_item,
                           abis: AbiSet) -> ty::ty_param_bounds_and_ty
 {
     match it.node {

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -182,7 +182,7 @@ pub struct CrateCtxt {
     trait_map: resolve::TraitMap,
     method_map: method_map,
     vtable_map: vtable_map,
-    coherence_info: @coherence::CoherenceInfo,
+    coherence_info: coherence::CoherenceInfo,
     tcx: ty::ctxt
 }
 
@@ -220,7 +220,7 @@ pub fn lookup_def_tcx(tcx: ty::ctxt, sp: span, id: ast::node_id) -> ast::def {
     }
 }
 
-pub fn lookup_def_ccx(ccx: @mut CrateCtxt, sp: span, id: ast::node_id)
+pub fn lookup_def_ccx(ccx: &CrateCtxt, sp: span, id: ast::node_id)
                    -> ast::def {
     lookup_def_tcx(ccx.tcx, sp, id)
 }
@@ -276,11 +276,11 @@ trait get_and_find_region {
 }
 
 impl get_and_find_region for isr_alist {
-    fn get(&self, br: ty::bound_region) -> ty::Region {
+    pub fn get(&self, br: ty::bound_region) -> ty::Region {
         self.find(br).get()
     }
 
-    fn find(&self, br: ty::bound_region) -> Option<ty::Region> {
+    pub fn find(&self, br: ty::bound_region) -> Option<ty::Region> {
         for list::each(*self) |isr| {
             let (isr_br, isr_r) = *isr;
             if isr_br == br { return Some(isr_r); }
@@ -289,7 +289,7 @@ impl get_and_find_region for isr_alist {
     }
 }
 
-fn check_main_fn_ty(ccx: @mut CrateCtxt,
+fn check_main_fn_ty(ccx: &CrateCtxt,
                     main_id: ast::node_id,
                     main_span: span) {
     let tcx = ccx.tcx;
@@ -330,7 +330,7 @@ fn check_main_fn_ty(ccx: @mut CrateCtxt,
     }
 }
 
-fn check_start_fn_ty(ccx: @mut CrateCtxt,
+fn check_start_fn_ty(ccx: &CrateCtxt,
                      start_id: ast::node_id,
                      start_span: span) {
     let tcx = ccx.tcx;
@@ -379,7 +379,7 @@ fn check_start_fn_ty(ccx: @mut CrateCtxt,
     }
 }
 
-fn check_for_entry_fn(ccx: @mut CrateCtxt) {
+fn check_for_entry_fn(ccx: &CrateCtxt) {
     let tcx = ccx.tcx;
     if !*tcx.sess.building_library {
         match *tcx.sess.entry_fn {
@@ -395,14 +395,14 @@ fn check_for_entry_fn(ccx: @mut CrateCtxt) {
 
 pub fn check_crate(tcx: ty::ctxt,
                    trait_map: resolve::TraitMap,
-                   crate: @ast::crate)
+                   crate: &ast::crate)
                 -> (method_map, vtable_map) {
     let time_passes = tcx.sess.time_passes();
     let ccx = @mut CrateCtxt {
         trait_map: trait_map,
         method_map: @mut HashMap::new(),
         vtable_map: @mut HashMap::new(),
-        coherence_info: @coherence::CoherenceInfo(),
+        coherence_info: coherence::CoherenceInfo(),
         tcx: tcx
     };
 

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -331,7 +331,7 @@ pub fn find_and_install_dependencies(ctxt: &Ctx,
     debug!("In find_and_install_dependencies...");
     let my_workspace = copy *workspace;
     let my_ctxt      = copy *ctxt;
-    for c.each_view_item() |vi: @ast::view_item| {
+    for c.each_view_item() |vi: &ast::view_item| {
         debug!("A view item!");
         match vi.node {
             // ignore metadata, I guess

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -124,7 +124,7 @@ pub fn mk_ast_map_visitor() -> vt {
     });
 }
 
-pub fn map_crate(diag: @span_handler, c: @crate) -> map {
+pub fn map_crate(diag: @span_handler, c: &crate) -> map {
     let cx = @mut Ctx {
         map: @mut HashMap::new(),
         path: ~[],

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -565,11 +565,11 @@ pub fn walk_pat(pat: @pat, it: &fn(@pat) -> bool) -> bool {
 }
 
 pub trait EachViewItem {
-    pub fn each_view_item(&self, f: @fn(@ast::view_item) -> bool) -> bool;
+    pub fn each_view_item(&self, f: @fn(&ast::view_item) -> bool) -> bool;
 }
 
 impl EachViewItem for ast::crate {
-    fn each_view_item(&self, f: @fn(@ast::view_item) -> bool) -> bool {
+    fn each_view_item(&self, f: @fn(&ast::view_item) -> bool) -> bool {
         let broke = @mut false;
         let vtor: visit::vt<()> = visit::mk_simple_visitor(@visit::SimpleVisitor {
             visit_view_item: |vi| { *broke = f(vi); }, ..*visit::default_simple_visitor()
@@ -579,7 +579,7 @@ impl EachViewItem for ast::crate {
     }
 }
 
-pub fn view_path_id(p: @view_path) -> node_id {
+pub fn view_path_id(p: &view_path) -> node_id {
     match p.node {
       view_path_simple(_, _, id) |
       view_path_glob(_, id) |

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::prelude::*;
-
 use ast::{meta_item, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -644,7 +644,7 @@ pub fn core_macros() -> @str {
 }
 
 pub fn expand_crate(parse_sess: @mut parse::ParseSess,
-                    cfg: ast::crate_cfg, c: @crate) -> @crate {
+                    cfg: ast::crate_cfg, c: &crate) -> @crate {
     // adding *another* layer of indirection here so that the block
     // visitor can swap out one exts table for another for the duration
     // of the block.  The cleaner alternative would be to thread the
@@ -695,7 +695,7 @@ pub fn expand_crate(parse_sess: @mut parse::ParseSess,
     // as it registers all the core macros as expanders.
     f.fold_item(cm);
 
-    @f.fold_crate(&*c)
+    @f.fold_crate(c)
 }
 
 // given a function from idents to idents, produce

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -39,7 +39,7 @@ pub enum fn_kind<'self> {
     // fn foo(&self)
     fk_method(ident, &'self Generics, &'self method),
 
-    // fn@(x, y) { ... }
+    // @fn(x, y) { ... }
     fk_anon(ast::Sigil),
 
     // |x, y| ...
@@ -129,9 +129,9 @@ pub fn visit_mod<E: Copy>(m: &_mod, _sp: span, _id: node_id, (e, v): (E, vt<E>))
     for m.items.iter().advance |i| { (v.visit_item)(*i, (copy e, v)); }
 }
 
-pub fn visit_view_item<E>(_vi: @view_item, (_e, _v): (E, vt<E>)) { }
+pub fn visit_view_item<E>(_vi: &view_item, (_e, _v): (E, vt<E>)) { }
 
-pub fn visit_local<E: Copy>(loc: @local, (e, v): (E, vt<E>)) {
+pub fn visit_local<E: Copy>(loc: &local, (e, v): (E, vt<E>)) {
     (v.visit_pat)(loc.node.pat, (copy e, v));
     (v.visit_ty)(loc.node.ty, (copy e, v));
     match loc.node.init {
@@ -140,11 +140,11 @@ pub fn visit_local<E: Copy>(loc: @local, (e, v): (E, vt<E>)) {
     }
 }
 
-fn visit_trait_ref<E: Copy>(tref: @ast::trait_ref, (e, v): (E, vt<E>)) {
+fn visit_trait_ref<E: Copy>(tref: &ast::trait_ref, (e, v): (E, vt<E>)) {
     visit_path(tref.path, (e, v));
 }
 
-pub fn visit_item<E: Copy>(i: @item, (e, v): (E, vt<E>)) {
+pub fn visit_item<E: Copy>(i: &item, (e, v): (E, vt<E>)) {
     match i.node {
         item_static(t, _, ex) => {
             (v.visit_ty)(t, (copy e, v));
@@ -230,9 +230,9 @@ pub fn visit_enum_def<E: Copy>(enum_definition: &ast::enum_def,
     }
 }
 
-pub fn skip_ty<E>(_t: @Ty, (_e,_v): (E, vt<E>)) {}
+pub fn skip_ty<E>(_t: &Ty, (_e,_v): (E, vt<E>)) {}
 
-pub fn visit_ty<E: Copy>(t: @Ty, (e, v): (E, vt<E>)) {
+pub fn visit_ty<E: Copy>(t: &Ty, (e, v): (E, vt<E>)) {
     match t.node {
         ty_box(mt) | ty_uniq(mt) |
         ty_vec(mt) | ty_ptr(mt) | ty_rptr(_, mt) => {
@@ -268,11 +268,11 @@ pub fn visit_ty<E: Copy>(t: @Ty, (e, v): (E, vt<E>)) {
     }
 }
 
-pub fn visit_path<E: Copy>(p: @Path, (e, v): (E, vt<E>)) {
+pub fn visit_path<E: Copy>(p: &Path, (e, v): (E, vt<E>)) {
     for p.types.iter().advance |tp| { (v.visit_ty)(*tp, (copy e, v)); }
 }
 
-pub fn visit_pat<E: Copy>(p: @pat, (e, v): (E, vt<E>)) {
+pub fn visit_pat<E: Copy>(p: &pat, (e, v): (E, vt<E>)) {
     match p.node {
         pat_enum(path, ref children) => {
             visit_path(path, (copy e, v));
@@ -322,7 +322,7 @@ pub fn visit_pat<E: Copy>(p: @pat, (e, v): (E, vt<E>)) {
     }
 }
 
-pub fn visit_foreign_item<E: Copy>(ni: @foreign_item, (e, v): (E, vt<E>)) {
+pub fn visit_foreign_item<E: Copy>(ni: &foreign_item, (e, v): (E, vt<E>)) {
     match ni.node {
         foreign_item_fn(ref fd, _, ref generics) => {
             visit_fn_decl(fd, (copy e, v));
@@ -410,11 +410,11 @@ pub fn visit_struct_def<E: Copy>(
     }
 }
 
-pub fn visit_struct_field<E: Copy>(sf: @struct_field, (e, v): (E, vt<E>)) {
+pub fn visit_struct_field<E: Copy>(sf: &struct_field, (e, v): (E, vt<E>)) {
     (v.visit_ty)(sf.node.ty, (e, v));
 }
 
-pub fn visit_struct_method<E: Copy>(m: @method, (e, v): (E, vt<E>)) {
+pub fn visit_struct_method<E: Copy>(m: &method, (e, v): (E, vt<E>)) {
     visit_method_helper(m, (e, v));
 }
 
@@ -428,7 +428,7 @@ pub fn visit_block<E: Copy>(b: &blk, (e, v): (E, vt<E>)) {
     visit_expr_opt(b.node.expr, (e, v));
 }
 
-pub fn visit_stmt<E>(s: @stmt, (e, v): (E, vt<E>)) {
+pub fn visit_stmt<E>(s: &stmt, (e, v): (E, vt<E>)) {
     match s.node {
       stmt_decl(d, _) => (v.visit_decl)(d, (e, v)),
       stmt_expr(ex, _) => (v.visit_expr)(ex, (e, v)),
@@ -437,7 +437,7 @@ pub fn visit_stmt<E>(s: @stmt, (e, v): (E, vt<E>)) {
     }
 }
 
-pub fn visit_decl<E: Copy>(d: @decl, (e, v): (E, vt<E>)) {
+pub fn visit_decl<E: Copy>(d: &decl, (e, v): (E, vt<E>)) {
     match d.node {
         decl_local(ref loc) => (v.visit_local)(*loc, (e, v)),
         decl_item(it) => (v.visit_item)(it, (e, v))


### PR DESCRIPTION
Mostly just low-haning fruit, i.e. function arguments that were @ even
though & would work just as well.

Reduces librustc.so size by 200k when compiling without -O, by 100k when
compiling with -O.
