### PR TITLE
Rename #[no_drop_flag] to #[unsafe_no_drop_flag]

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3904,7 +3904,7 @@ impl DtorKind {
 pub fn ty_dtor(cx: ctxt, struct_id: def_id) -> DtorKind {
     match cx.destructor_for_type.find(&struct_id) {
         Some(&method_def_id) => {
-            let flag = !has_attr(cx, struct_id, "no_drop_flag");
+            let flag = !has_attr(cx, struct_id, "unsafe_no_drop_flag");
 
             TraitDtor(method_def_id, flag)
         }

--- a/src/libstd/unstable/atomics.rs
+++ b/src/libstd/unstable/atomics.rs
@@ -62,7 +62,7 @@ pub struct AtomicPtr<T> {
 /**
  * An owned atomic pointer. Ensures that only a single reference to the data is held at any time.
  */
-#[no_drop_flag]
+#[unsafe_no_drop_flag]
 pub struct AtomicOption<T> {
     priv p: *mut c_void
 }

--- a/src/test/run-pass/attr-no-drop-flag-size.rs
+++ b/src/test/run-pass/attr-no-drop-flag-size.rs
@@ -10,7 +10,7 @@
 
 use std::sys::size_of;
 
-#[no_drop_flag]
+#[unsafe_no_drop_flag]
 struct Test<T> {
     a: T
 }


### PR DESCRIPTION
This closes #7428.

cc @thestinger
