### PR TITLE
rustpkg: Silence extra output from rustpkg tests

### DIFF
--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -144,10 +144,10 @@ fn command_line_test(args: &[~str], cwd: &Path) -> ProcessOutput {
                                                            err_fd: None
                                                           });
     let output = prog.finish_with_output();
-    io::println(fmt!("Output from command %s with args %? was %s {%s}[%?]",
+    debug!("Output from command %s with args %? was %s {%s}[%?]",
                     cmd, args, str::from_bytes(output.output),
                    str::from_bytes(output.error),
-                   output.status));
+                   output.status);
 /*
 By the way, rustpkg *won't* return a nonzero exit code if it fails --
 see #4547

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -187,7 +187,7 @@ pub fn compile_input(ctxt: &Ctx,
         Lib => lib_crate,
         Test | Bench | Main => bin_crate
     };
-    let matches = getopts(~[~"-Z", ~"time-passes"]
+    let matches = getopts(debug_flags()
                           + match what {
                               Lib => ~[~"--lib"],
                               // --test compiles both #[test] and #[bench] fns
@@ -415,3 +415,7 @@ mod test {
     }
 
 }
+
+// tjc: cheesy
+fn debug_flags() -> ~[~str] { ~[] }
+// static debug_flags: ~[~str] = ~[~"-Z", ~"time-passes"];


### PR DESCRIPTION
Closes #7250
