### PR TITLE
mk: add mechanisms for triggering clean-llvm builds from commits

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -536,9 +536,18 @@ ALL_TARGET_RULES = $(foreach target,$(CFG_TARGET_TRIPLES), \
 	$(foreach host,$(CFG_HOST_TRIPLES), \
  all-target-$(target)-host-$(host)))
 
-all: $(ALL_TARGET_RULES) $(GENERATED) docs
+all: rustllvm/llvm-auto-clean-stamp \
+     $(ALL_TARGET_RULES) $(GENERATED) docs
 
 endif
+
+# This is used to independently force an LLVM clean rebuild
+# when we changed something not otherwise captured by builtin
+# dependencies. In these cases, commit a change that touches
+# the stamp in the source dir.
+rustllvm/llvm-auto-clean-stamp: $(S)src/rustllvm/llvm-auto-clean-trigger
+	$(Q)$(MAKE) clean-llvm
+	touch $@
 
 
 ######################################################################

--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -23,7 +23,7 @@ CLEAN_LLVM_RULES = 								\
  $(foreach target, $(CFG_TARGET_TRIPLES),		\
   clean-llvm$(target))
 
-.PHONY: clean clean-all clean-misc
+.PHONY: clean clean-all clean-misc clean-llvm
 
 clean-all: clean clean-llvm
 


### PR DESCRIPTION
This makes it possible for us to trigger the llvm-clean make-target by checking in a change that touches rustllvm/llvm-auto-clean-stamp. Most developers don't need to see or know about this, but when you push a change that "needs an LLVM rebuild", even if not otherwise obvious, this should give a mechanism to do it.
