### PR TITLE
Remove unused variable

### DIFF
--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -40,7 +40,6 @@ static path_entry_separator: &'static str = ":";
 /// DIR/.rust for any DIR that's the current working directory
 /// or an ancestor of it
 pub fn rust_path() -> ~[Path] {
-    let env_path: ~str = os::getenv("RUST_PATH").get_or_default(~"");
     let mut env_rust_path: ~[Path] = match os::getenv("RUST_PATH") {
         Some(env_path) => {
             let env_path_components: ~[&str] =


### PR DESCRIPTION
The compiler reported that as a warning while building, and from looking at it quickly it seems to be indeed unused and overwritten two lines below. I hope I'm not missing something obvious though.
