### PR TITLE
Add -v/--version support to rust binary

### DIFF
--- a/src/librust/rust.rs
+++ b/src/librust/rust.rs
@@ -238,6 +238,12 @@ fn usage() {
 
 pub fn main() {
     let os_args = os::args();
+
+    if (os_args.len() > 1 && (os_args[1] == ~"-v" || os_args[1] == ~"--version")) {
+        rustc::version(os_args[0]);
+        unsafe { exit(0); }
+    }
+
     let args = os_args.tail();
 
     if !args.is_empty() {


### PR DESCRIPTION
I assume this might not be accepted as is because it's not really using the full blown optgroups and whatnot but it's all I managed to get done so far and it still solves a frustrating issue I hit so I'll take my chances.
