### PR TITLE
Overhaul `to_str_common` and `char::escape_*`

### DIFF
--- a/src/libextra/terminfo/parm.rs
+++ b/src/libextra/terminfo/parm.rs
@@ -11,7 +11,7 @@
 //! Parameterized string expansion
 
 use std::{char, vec, util};
-use std::num::strconv::{SignNone,SignNeg,SignAll,DigAll,to_str_bytes_common};
+use std::num::strconv::{SignNone,SignNeg,SignAll,int_to_str_bytes_common};
 use std::iterator::IteratorUtil;
 
 #[deriving(Eq)]
@@ -469,14 +469,20 @@ priv fn format(val: Param, op: FormatOp, flags: Flags) -> Result<~[u8],~str> {
                         FormatHex|FormatHEX => 16,
                         FormatString => util::unreachable()
                     };
-                    let (s,_) = match op {
+                    let mut s = ~[];
+                    match op {
                         FormatDigit => {
                             let sign = if flags.sign { SignAll } else { SignNeg };
-                            to_str_bytes_common(&d, radix, false, sign, DigAll)
+                            do int_to_str_bytes_common(d, radix, sign) |c| {
+                                s.push(c);
+                            }
                         }
-                        _ => to_str_bytes_common(&(d as uint), radix, false, SignNone, DigAll)
+                        _ => {
+                            do int_to_str_bytes_common(d as uint, radix, SignNone) |c| {
+                                s.push(c);
+                            }
+                        }
                     };
-                    let mut s = s;
                     if flags.precision > s.len() {
                         let mut s_ = vec::with_capacity(flags.precision);
                         let n = flags.precision - s.len();

--- a/src/libstd/char.rs
+++ b/src/libstd/char.rs
@@ -10,8 +10,8 @@
 
 //! Utilities for manipulating the char type
 
-use container::Container;
 use option::{None, Option, Some};
+use int;
 use str::StrSlice;
 use unicode::{derived_property, general_category};
 

--- a/src/libstd/char.rs
+++ b/src/libstd/char.rs
@@ -12,11 +12,10 @@
 
 use container::Container;
 use option::{None, Option, Some};
-use str;
-use str::{StrSlice, OwnedStr};
-use u32;
-use uint;
+use str::StrSlice;
 use unicode::{derived_property, general_category};
+
+#[cfg(test)] use str::OwnedStr;
 
 #[cfg(not(test))] use cmp::{Eq, Ord};
 #[cfg(not(test))] use num::Zero;
@@ -202,21 +201,21 @@ pub fn from_digit(num: uint, radix: uint) -> Option<char> {
 /// - chars in [0x100,0xffff] get 4-digit escapes: `\\uNNNN`
 /// - chars above 0x10000 get 8-digit escapes: `\\UNNNNNNNN`
 ///
-pub fn escape_unicode(c: char) -> ~str {
-    let s = u32::to_str_radix(c as u32, 16u);
-    let (c, pad) = cond!(
-        (c <= '\xff')   { ('x', 2u) }
-        (c <= '\uffff') { ('u', 4u) }
-        _               { ('U', 8u) }
+pub fn escape_unicode(c: char, f: &fn(char)) {
+    // avoid calling str::to_str_radix because we don't really need to allocate
+    // here.
+    f('\\');
+    let pad = cond!(
+        (c <= '\xff')   { f('x'); 2 }
+        (c <= '\uffff') { f('u'); 4 }
+        _               { f('U'); 8 }
     );
-    assert!(s.len() <= pad);
-    let mut out = ~"\\";
-    out.push_str(str::from_char(c));
-    for uint::range(s.len(), pad) |_| {
-        out.push_str("0");
+    for int::range_step(4 * (pad - 1), -1, -4) |offset| {
+        match ((c as u32) >> offset) & 0xf {
+            i @ 0 .. 9 => { f('0' + i as char); }
+            i => { f('a' + (i - 10) as char); }
+        }
     }
-    out.push_str(s);
-    out
 }
 
 ///
@@ -231,16 +230,16 @@ pub fn escape_unicode(c: char) -> ~str {
 /// - Any other chars in the range [0x20,0x7e] are not escaped.
 /// - Any other chars are given hex unicode escapes; see `escape_unicode`.
 ///
-pub fn escape_default(c: char) -> ~str {
+pub fn escape_default(c: char, f: &fn(char)) {
     match c {
-        '\t' => ~"\\t",
-        '\r' => ~"\\r",
-        '\n' => ~"\\n",
-        '\\' => ~"\\\\",
-        '\'' => ~"\\'",
-        '"'  => ~"\\\"",
-        '\x20' .. '\x7e' => str::from_char(c),
-        _ => c.escape_unicode(),
+        '\t' => { f('\\'); f('t'); }
+        '\r' => { f('\\'); f('r'); }
+        '\n' => { f('\\'); f('n'); }
+        '\\' => { f('\\'); f('\\'); }
+        '\'' => { f('\\'); f('\''); }
+        '"'  => { f('\\'); f('"'); }
+        '\x20' .. '\x7e' => { f(c); }
+        _ => c.escape_unicode(f),
     }
 }
 
@@ -274,8 +273,8 @@ pub trait Char {
     fn is_digit_radix(&self, radix: uint) -> bool;
     fn to_digit(&self, radix: uint) -> Option<uint>;
     fn from_digit(num: uint, radix: uint) -> Option<char>;
-    fn escape_unicode(&self) -> ~str;
-    fn escape_default(&self) -> ~str;
+    fn escape_unicode(&self, f: &fn(char));
+    fn escape_default(&self, f: &fn(char));
     fn len_utf8_bytes(&self) -> uint;
 }
 
@@ -302,9 +301,9 @@ impl Char for char {
 
     fn from_digit(num: uint, radix: uint) -> Option<char> { from_digit(num, radix) }
 
-    fn escape_unicode(&self) -> ~str { escape_unicode(*self) }
+    fn escape_unicode(&self, f: &fn(char)) { escape_unicode(*self, f) }
 
-    fn escape_default(&self) -> ~str { escape_default(*self) }
+    fn escape_default(&self, f: &fn(char)) { escape_default(*self, f) }
 
     fn len_utf8_bytes(&self) -> uint { len_utf8_bytes(*self) }
 }
@@ -392,27 +391,37 @@ fn test_is_digit() {
 
 #[test]
 fn test_escape_default() {
-    assert_eq!('\n'.escape_default(), ~"\\n");
-    assert_eq!('\r'.escape_default(), ~"\\r");
-    assert_eq!('\''.escape_default(), ~"\\'");
-    assert_eq!('"'.escape_default(), ~"\\\"");
-    assert_eq!(' '.escape_default(), ~" ");
-    assert_eq!('a'.escape_default(), ~"a");
-    assert_eq!('~'.escape_default(), ~"~");
-    assert_eq!('\x00'.escape_default(), ~"\\x00");
-    assert_eq!('\x1f'.escape_default(), ~"\\x1f");
-    assert_eq!('\x7f'.escape_default(), ~"\\x7f");
-    assert_eq!('\xff'.escape_default(), ~"\\xff");
-    assert_eq!('\u011b'.escape_default(), ~"\\u011b");
-    assert_eq!('\U0001d4b6'.escape_default(), ~"\\U0001d4b6");
+    fn string(c: char) -> ~str {
+        let mut result = ~"";
+        do escape_default(c) |c| { result.push_char(c); }
+        return result;
+    }
+    assert_eq!(string('\n'), ~"\\n");
+    assert_eq!(string('\r'), ~"\\r");
+    assert_eq!(string('\''), ~"\\'");
+    assert_eq!(string('"'), ~"\\\"");
+    assert_eq!(string(' '), ~" ");
+    assert_eq!(string('a'), ~"a");
+    assert_eq!(string('~'), ~"~");
+    assert_eq!(string('\x00'), ~"\\x00");
+    assert_eq!(string('\x1f'), ~"\\x1f");
+    assert_eq!(string('\x7f'), ~"\\x7f");
+    assert_eq!(string('\xff'), ~"\\xff");
+    assert_eq!(string('\u011b'), ~"\\u011b");
+    assert_eq!(string('\U0001d4b6'), ~"\\U0001d4b6");
 }
 
 #[test]
 fn test_escape_unicode() {
-    assert_eq!('\x00'.escape_unicode(), ~"\\x00");
-    assert_eq!('\n'.escape_unicode(), ~"\\x0a");
-    assert_eq!(' '.escape_unicode(), ~"\\x20");
-    assert_eq!('a'.escape_unicode(), ~"\\x61");
-    assert_eq!('\u011b'.escape_unicode(), ~"\\u011b");
-    assert_eq!('\U0001d4b6'.escape_unicode(), ~"\\U0001d4b6");
+    fn string(c: char) -> ~str {
+        let mut result = ~"";
+        do escape_unicode(c) |c| { result.push_char(c); }
+        return result;
+    }
+    assert_eq!(string('\x00'), ~"\\x00");
+    assert_eq!(string('\n'), ~"\\x0a");
+    assert_eq!(string(' '), ~"\\x20");
+    assert_eq!(string('a'), ~"\\x61");
+    assert_eq!(string('\u011b'), ~"\\u011b");
+    assert_eq!(string('\U0001d4b6'), ~"\\U0001d4b6");
 }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -754,8 +754,8 @@ impl Float for f32 {
 ///
 #[inline]
 pub fn to_str(num: f32) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 10u, true, strconv::SignNeg, strconv::DigAll);
+    let (r, _) = strconv::float_to_str_common(
+        num, 10u, true, strconv::SignNeg, strconv::DigAll);
     r
 }
 
@@ -768,8 +768,8 @@ pub fn to_str(num: f32) -> ~str {
 ///
 #[inline]
 pub fn to_str_hex(num: f32) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 16u, true, strconv::SignNeg, strconv::DigAll);
+    let (r, _) = strconv::float_to_str_common(
+        num, 16u, true, strconv::SignNeg, strconv::DigAll);
     r
 }
 
@@ -789,8 +789,8 @@ pub fn to_str_hex(num: f32) -> ~str {
 ///
 #[inline]
 pub fn to_str_radix(num: f32, rdx: uint) -> ~str {
-    let (r, special) = strconv::to_str_common(
-        &num, rdx, true, strconv::SignNeg, strconv::DigAll);
+    let (r, special) = strconv::float_to_str_common(
+        num, rdx, true, strconv::SignNeg, strconv::DigAll);
     if special { fail!("number has a special value, \
                       try to_str_radix_special() if those are expected") }
     r
@@ -807,7 +807,7 @@ pub fn to_str_radix(num: f32, rdx: uint) -> ~str {
 ///
 #[inline]
 pub fn to_str_radix_special(num: f32, rdx: uint) -> (~str, bool) {
-    strconv::to_str_common(&num, rdx, true,
+    strconv::float_to_str_common(num, rdx, true,
                            strconv::SignNeg, strconv::DigAll)
 }
 
@@ -822,8 +822,8 @@ pub fn to_str_radix_special(num: f32, rdx: uint) -> (~str, bool) {
 ///
 #[inline]
 pub fn to_str_exact(num: f32, dig: uint) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 10u, true, strconv::SignNeg, strconv::DigExact(dig));
+    let (r, _) = strconv::float_to_str_common(
+        num, 10u, true, strconv::SignNeg, strconv::DigExact(dig));
     r
 }
 
@@ -838,8 +838,8 @@ pub fn to_str_exact(num: f32, dig: uint) -> ~str {
 ///
 #[inline]
 pub fn to_str_digits(num: f32, dig: uint) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 10u, true, strconv::SignNeg, strconv::DigMax(dig));
+    let (r, _) = strconv::float_to_str_common(
+        num, 10u, true, strconv::SignNeg, strconv::DigMax(dig));
     r
 }
 

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -796,8 +796,8 @@ impl Float for f64 {
 ///
 #[inline]
 pub fn to_str(num: f64) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 10u, true, strconv::SignNeg, strconv::DigAll);
+    let (r, _) = strconv::float_to_str_common(
+        num, 10u, true, strconv::SignNeg, strconv::DigAll);
     r
 }
 
@@ -810,8 +810,8 @@ pub fn to_str(num: f64) -> ~str {
 ///
 #[inline]
 pub fn to_str_hex(num: f64) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 16u, true, strconv::SignNeg, strconv::DigAll);
+    let (r, _) = strconv::float_to_str_common(
+        num, 16u, true, strconv::SignNeg, strconv::DigAll);
     r
 }
 
@@ -831,8 +831,8 @@ pub fn to_str_hex(num: f64) -> ~str {
 ///
 #[inline]
 pub fn to_str_radix(num: f64, rdx: uint) -> ~str {
-    let (r, special) = strconv::to_str_common(
-        &num, rdx, true, strconv::SignNeg, strconv::DigAll);
+    let (r, special) = strconv::float_to_str_common(
+        num, rdx, true, strconv::SignNeg, strconv::DigAll);
     if special { fail!("number has a special value, \
                       try to_str_radix_special() if those are expected") }
     r
@@ -849,7 +849,7 @@ pub fn to_str_radix(num: f64, rdx: uint) -> ~str {
 ///
 #[inline]
 pub fn to_str_radix_special(num: f64, rdx: uint) -> (~str, bool) {
-    strconv::to_str_common(&num, rdx, true,
+    strconv::float_to_str_common(num, rdx, true,
                            strconv::SignNeg, strconv::DigAll)
 }
 
@@ -864,8 +864,8 @@ pub fn to_str_radix_special(num: f64, rdx: uint) -> (~str, bool) {
 ///
 #[inline]
 pub fn to_str_exact(num: f64, dig: uint) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 10u, true, strconv::SignNeg, strconv::DigExact(dig));
+    let (r, _) = strconv::float_to_str_common(
+        num, 10u, true, strconv::SignNeg, strconv::DigExact(dig));
     r
 }
 
@@ -880,8 +880,8 @@ pub fn to_str_exact(num: f64, dig: uint) -> ~str {
 ///
 #[inline]
 pub fn to_str_digits(num: f64, dig: uint) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 10u, true, strconv::SignNeg, strconv::DigMax(dig));
+    let (r, _) = strconv::float_to_str_common(
+        num, 10u, true, strconv::SignNeg, strconv::DigMax(dig));
     r
 }
 

--- a/src/libstd/num/float.rs
+++ b/src/libstd/num/float.rs
@@ -101,8 +101,8 @@ pub mod consts {
 ///
 #[inline]
 pub fn to_str(num: float) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 10u, true, strconv::SignNeg, strconv::DigAll);
+    let (r, _) = strconv::float_to_str_common(
+        num, 10u, true, strconv::SignNeg, strconv::DigAll);
     r
 }
 
@@ -115,8 +115,8 @@ pub fn to_str(num: float) -> ~str {
 ///
 #[inline]
 pub fn to_str_hex(num: float) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 16u, true, strconv::SignNeg, strconv::DigAll);
+    let (r, _) = strconv::float_to_str_common(
+        num, 16u, true, strconv::SignNeg, strconv::DigAll);
     r
 }
 
@@ -136,8 +136,8 @@ pub fn to_str_hex(num: float) -> ~str {
 ///
 #[inline]
 pub fn to_str_radix(num: float, radix: uint) -> ~str {
-    let (r, special) = strconv::to_str_common(
-        &num, radix, true, strconv::SignNeg, strconv::DigAll);
+    let (r, special) = strconv::float_to_str_common(
+        num, radix, true, strconv::SignNeg, strconv::DigAll);
     if special { fail!("number has a special value, \
                          try to_str_radix_special() if those are expected") }
     r
@@ -154,7 +154,7 @@ pub fn to_str_radix(num: float, radix: uint) -> ~str {
 ///
 #[inline]
 pub fn to_str_radix_special(num: float, radix: uint) -> (~str, bool) {
-    strconv::to_str_common(&num, radix, true,
+    strconv::float_to_str_common(num, radix, true,
                            strconv::SignNeg, strconv::DigAll)
 }
 
@@ -169,8 +169,8 @@ pub fn to_str_radix_special(num: float, radix: uint) -> (~str, bool) {
 ///
 #[inline]
 pub fn to_str_exact(num: float, digits: uint) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 10u, true, strconv::SignNeg, strconv::DigExact(digits));
+    let (r, _) = strconv::float_to_str_common(
+        num, 10u, true, strconv::SignNeg, strconv::DigExact(digits));
     r
 }
 
@@ -185,8 +185,8 @@ pub fn to_str_exact(num: float, digits: uint) -> ~str {
 ///
 #[inline]
 pub fn to_str_digits(num: float, digits: uint) -> ~str {
-    let (r, _) = strconv::to_str_common(
-        &num, 10u, true, strconv::SignNeg, strconv::DigMax(digits));
+    let (r, _) = strconv::float_to_str_common(
+        num, 10u, true, strconv::SignNeg, strconv::DigMax(digits));
     r
 }
 

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -18,6 +18,7 @@ use num::BitCount;
 use num::{ToStrRadix, FromStrRadix};
 use num::{Zero, One, strconv};
 use prelude::*;
+use str;
 
 pub use cmp::{min, max};
 
@@ -356,25 +357,33 @@ impl FromStrRadix for $T {
 /// Convert to a string as a byte slice in a given base.
 #[inline]
 pub fn to_str_bytes<U>(n: $T, radix: uint, f: &fn(v: &[u8]) -> U) -> U {
-    let (buf, _) = strconv::to_str_bytes_common(&n, radix, false,
-                            strconv::SignNeg, strconv::DigAll);
-    f(buf)
+    // The radix can be as low as 2, so we need at least 64 characters for a
+    // base 2 number.
+    let mut buf = [0u8, ..64];
+    let mut cur = 0;
+    do strconv::int_to_str_bytes_common(n, radix, strconv::SignNone) |i| {
+        buf[cur] = i;
+        cur += 1;
+    }
+    f(buf.slice(0, cur))
 }
 
 /// Convert to a string in base 10.
 #[inline]
 pub fn to_str(num: $T) -> ~str {
-    let (buf, _) = strconv::to_str_common(&num, 10u, false,
-                            strconv::SignNeg, strconv::DigAll);
-    buf
+    to_str_radix(num, 10u)
 }
 
 /// Convert to a string in a given base.
 #[inline]
 pub fn to_str_radix(num: $T, radix: uint) -> ~str {
-    let (buf, _) = strconv::to_str_common(&num, radix, false,
-                            strconv::SignNeg, strconv::DigAll);
-    buf
+    let mut buf = ~[];
+    do strconv::int_to_str_bytes_common(num, radix, strconv::SignNone) |i| {
+        buf.push(i);
+    }
+    // We know we generated valid utf-8, so we don't need to go through that
+    // check.
+    unsafe { str::raw::from_bytes_owned(buf) }
 }
 
 impl ToStr for $T {

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -81,65 +81,35 @@ impl Repr for bool {
     }
 }
 
-impl Repr for int {
-    fn write_repr(&self, writer: @Writer) { writer.write_int(*self); }
-}
-impl Repr for i8 {
-    fn write_repr(&self, writer: @Writer) { writer.write_int(*self as int); }
-}
-impl Repr for i16 {
-    fn write_repr(&self, writer: @Writer) { writer.write_int(*self as int); }
-}
-impl Repr for i32 {
-    fn write_repr(&self, writer: @Writer) { writer.write_int(*self as int); }
-}
-impl Repr for i64 {
-    // FIXME #4424: This can lose precision.
-    fn write_repr(&self, writer: @Writer) { writer.write_int(*self as int); }
-}
-
-impl Repr for uint {
-    fn write_repr(&self, writer: @Writer) { writer.write_uint(*self); }
-}
-impl Repr for u8 {
+macro_rules! int_repr(($ty:ident) => (impl Repr for $ty {
     fn write_repr(&self, writer: @Writer) {
-        writer.write_uint(*self as uint);
+        do ::$ty::to_str_bytes(*self, 10u) |bits| {
+            writer.write(bits);
+        }
     }
-}
-impl Repr for u16 {
-    fn write_repr(&self, writer: @Writer) {
-        writer.write_uint(*self as uint);
-    }
-}
-impl Repr for u32 {
-    fn write_repr(&self, writer: @Writer) {
-        writer.write_uint(*self as uint);
-    }
-}
-impl Repr for u64 {
-    // FIXME #4424: This can lose precision.
-    fn write_repr(&self, writer: @Writer) {
-        writer.write_uint(*self as uint);
-    }
-}
+}))
 
-impl Repr for float {
-    // FIXME #4423: This mallocs.
-    fn write_repr(&self, writer: @Writer) { writer.write_str(self.to_str()); }
-}
-impl Repr for f32 {
-    // FIXME #4423 This mallocs.
-    fn write_repr(&self, writer: @Writer) { writer.write_str(self.to_str()); }
-}
-impl Repr for f64 {
-    // FIXME #4423: This mallocs.
-    fn write_repr(&self, writer: @Writer) { writer.write_str(self.to_str()); }
-}
+int_repr!(int)
+int_repr!(i8)
+int_repr!(i16)
+int_repr!(i32)
+int_repr!(i64)
+int_repr!(uint)
+int_repr!(u8)
+int_repr!(u16)
+int_repr!(u32)
+int_repr!(u64)
 
-impl Repr for char {
-    fn write_repr(&self, writer: @Writer) { writer.write_char(*self); }
-}
+macro_rules! num_repr(($ty:ident) => (impl Repr for $ty {
+    fn write_repr(&self, writer: @Writer) {
+        let s = self.to_str();
+        writer.write(s.as_bytes());
+    }
+}))
 
+num_repr!(float)
+num_repr!(f32)
+num_repr!(f64)
 
 // New implementation using reflect::MovePtr
 

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -57,9 +57,9 @@ impl EscapedCharWriter for @Writer {
             '"' => self.write_str("\\\""),
             '\x20'..'\x7e' => self.write_char(ch),
             _ => {
-                // FIXME #4423: This is inefficient because it requires a
-                // malloc.
-                self.write_str(char::escape_unicode(ch))
+                do char::escape_unicode(ch) |c| {
+                    self.write_char(c);
+                }
             }
         }
     }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -16,7 +16,6 @@ use util::interner::StrInterner;
 use util::interner;
 
 use std::cast;
-use std::char;
 use std::cmp::Equiv;
 use std::local_data;
 use std::rand;
@@ -166,7 +165,12 @@ pub fn to_str(in: @ident_interner, t: &Token) -> ~str {
 
       /* Literals */
       LIT_INT(c, ast::ty_char) => {
-        ~"'" + char::escape_default(c as char) + "'"
+          let mut res = ~"'";
+          do (c as char).escape_default |c| {
+              res.push_char(c);
+          }
+          res.push_char('\'');
+          res
       }
       LIT_INT(i, t) => {
           i.to_str() + ast_util::int_ty_to_str(t)

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -27,7 +27,6 @@ use print::pp::{breaks, consistent, inconsistent, eof};
 use print::pp;
 use print::pprust;
 
-use std::char;
 use std::io;
 use std::u64;
 use std::uint;
@@ -2016,7 +2015,12 @@ pub fn print_literal(s: @ps, lit: @ast::lit) {
     match lit.node {
       ast::lit_str(st) => print_string(s, st),
       ast::lit_int(ch, ast::ty_char) => {
-        word(s.s, ~"'" + char::escape_default(ch as char) + "'");
+          let mut res = ~"'";
+          do (ch as char).escape_default |c| {
+              res.push_char(c);
+          }
+          res.push_char('\'');
+          word(s.s, res);
       }
       ast::lit_int(i, t) => {
         if i < 0_i64 {


### PR DESCRIPTION
This stems from trying to perform as few allocations as possible throughout the standard libraries.

This specializes the `ToStr` implementation for floats/ints separately because it's known that ints will have a maximum length (whereas floats could be very very large).

I also removed a `FIXME` to remove a malloc from the `to_str()` of floats in `repr.rs` because I think that this should be addressed elsewhere. I think that we may not be able to avoid it easily because floats can have such large representations, but regardless this should be a problem with the implementation of `float_to_str_bytes_common` now and not in the `Repr` module.
