### PR TITLE
Smarter warning in extra::term::Terminal.reset()

### DIFF
--- a/src/libextra/term.rs
+++ b/src/libextra/term.rs
@@ -120,13 +120,15 @@ impl Terminal {
     pub fn reset(&self) {
         let mut vars = Variables::new();
         let s = do self.ti.strings.find_equiv(&("op"))
-                       .map_consume_default(Err(~"can't find op")) |&op| {
+                       .map_consume_default(Err(~"can't find terminfo capability `op`")) |&op| {
                            expand(op, [], &mut vars)
                        };
         if s.is_ok() {
             self.out.write(s.unwrap());
-        } else {
+        } else if self.num_colors > 0 {
             warn!("%s", s.unwrap_err());
+        } else {
+            debug!("%s", s.unwrap_err());
         }
     }
 


### PR DESCRIPTION
Don't spew a warn!() in reset() if num_colors is 0, because
non-color-supporting terminals are legit. Use debug!() there instead.
Continue spewing warn!() if we believe the terminal to support colors.

Use a better warning when the `op` capability can't be found.

r? @cmr
