### PR TITLE
librustc: back::link::sanitize support escape_utf8

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -660,9 +660,9 @@ pub fn sanitize(s: &str) -> ~str {
             | '_' => result.push_char(c),
 
             _ => {
-                if c > 'z' && char::is_XID_continue(c) {
-                    result.push_char(c);
-                }
+                let tstr = char::escape_unicode(c);
+                result.push_char('$');
+                result.push_str(tstr.slice_from(1));
             }
         }
     }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -660,7 +660,8 @@ pub fn sanitize(s: &str) -> ~str {
             | '_' => result.push_char(c),
 
             _ => {
-                let tstr = char::escape_unicode(c);
+                let mut tstr = ~"";
+                do char::escape_unicode(c) |c| { tstr.push_char(c); }
                 result.push_char('$');
                 result.push_str(tstr.slice_from(1));
             }


### PR DESCRIPTION
back::link::sanitize support escape_utf8
fix #7486
