### PR TITLE
mk: fix clean-llvm for cross-compile

### DIFF
--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -20,7 +20,7 @@ CLEAN_STAGE_RULES =								\
     clean$(stage)_T_$(target)_H_$(host))))
 
 CLEAN_LLVM_RULES = 								\
- $(foreach target, $(CFG_TARGET_TRIPLES),		\
+ $(foreach target, $(CFG_HOST_TRIPLES),		\
   clean-llvm$(target))
 
 .PHONY: clean clean-all clean-misc clean-llvm


### PR DESCRIPTION
fix clean-llvm in mk/clean.mk for cross-compile

after #7442 landed, below error produced while android cross-compile

```
make[1]: *** No rule to make target `clean-llvmarm-linux-androideabi', needed by `clean-llvm'.  Stop.
make[1]: Leaving directory `/home/yichoi/rust_latest/build'
make: *** [rustllvm/llvm-auto-clean-stamp] Error 2
```
