### PR TITLE
Bring compiletest/rustpkg/driver up to date on std vs core

### DIFF
--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -50,7 +50,7 @@ $$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTPKG_$(4)):		\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))
 	@$$(call E, compile_and_link: $$@)
-	$$(STAGE$(1)_T_$(4)_H_$(3)) -o $$@ $$< && touch $$@
+	$$(STAGE$(1)_T_$(4)_H_$(3)) $$(WFLAGS_ST$(1)) -o $$@ $$< && touch $$@
 
 $$(TBIN$(1)_T_$(4)_H_$(3))/rustpkg$$(X_$(4)):				\
 		$$(DRIVER_CRATE) 							\

--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 #[deriving(Eq)]
 pub enum mode {
     mode_compile_fail,

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -11,20 +11,15 @@
 #[crate_type = "bin"];
 
 #[allow(non_camel_case_types)];
+#[allow(unrecognized_lint)]; // NOTE: remove after snapshot
+#[deny(warnings)];
 
-#[no_core]; // XXX: Remove after snapshot
-#[no_std];
+extern mod extra;
 
-extern mod core(name = "std", vers = "0.7");
-extern mod extra(name = "extra", vers = "0.7");
-
-use core::prelude::*;
-use core::*;
+use std::os;
 
 use extra::getopts;
 use extra::test;
-
-use core::result::{Ok, Err};
 
 use common::config;
 use common::mode_run_pass;
@@ -41,13 +36,6 @@ pub mod header;
 pub mod runtest;
 pub mod common;
 pub mod errors;
-
-mod std {
-    pub use core::cmp;
-    pub use core::str;
-    pub use core::sys;
-    pub use core::unstable;
-}
 
 pub fn main() {
     let args = os::args();
@@ -98,8 +86,8 @@ pub fn parse_config(args: ~[~str]) -> config {
         run_ignored: getopts::opt_present(matches, "ignored"),
         filter:
              if !matches.free.is_empty() {
-                 option::Some(copy matches.free[0])
-             } else { option::None },
+                 Some(copy matches.free[0])
+             } else { None },
         logfile: getopts::opt_maybe_str(matches, "logfile").map(|s| Path(*s)),
         runtool: getopts::opt_maybe_str(matches, "runtool"),
         rustcflags: getopts::opt_maybe_str(matches, "rustcflags"),
@@ -148,8 +136,8 @@ pub fn log_config(config: &config) {
 
 pub fn opt_str<'a>(maybestr: &'a Option<~str>) -> &'a str {
     match *maybestr {
-        option::None => "(none)",
-        option::Some(ref s) => {
+        None => "(none)",
+        Some(ref s) => {
             let s: &'a str = *s;
             s
         }
@@ -161,7 +149,7 @@ pub fn opt_str2(maybestr: Option<~str>) -> ~str {
 }
 
 pub fn str_opt(maybestr: ~str) -> Option<~str> {
-    if maybestr != ~"(none)" { option::Some(maybestr) } else { option::None }
+    if maybestr != ~"(none)" { Some(maybestr) } else { None }
 }
 
 pub fn str_mode(s: ~str) -> mode {
@@ -199,8 +187,8 @@ pub fn test_opts(config: &config) -> test::TestOpts {
         logfile: copy config.logfile,
         run_tests: true,
         run_benchmarks: false,
-        save_results: option::None,
-        compare_results: option::None
+        save_results: None,
+        compare_results: None
     }
 }
 
@@ -268,7 +256,7 @@ pub fn make_test_name(config: &config, testfile: &Path) -> test::TestName {
 }
 
 pub fn make_test_closure(config: &config, testfile: &Path) -> test::TestFn {
-    use core::cell::Cell;
+    use std::cell::Cell;
     let config = Cell::new(copy *config);
     let testfile = Cell::new(testfile.to_str());
     test::DynTestFn(|| { runtest::run(config.take(), testfile.take()) })

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -8,9 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
-use core::io;
+use std::io;
 
 pub struct ExpectedError { line: uint, kind: ~str, msg: ~str }
 

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use common::config;
 use common;
 
-use core::io;
-use core::os;
+use std::io;
+use std::os;
 
 pub struct TestProps {
     // Lines that should be expected, in order, on standard out

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -8,11 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
-use core::os;
-use core::run;
-use core::str;
+use std::os;
+use std::run;
+use std::str;
 
 #[cfg(target_os = "win32")]
 fn target_env(lib_path: &str, prog: &str) -> ~[(~str,~str)] {

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use common::mode_run_pass;
 use common::mode_run_fail;
 use common::mode_compile_fail;
@@ -22,10 +20,10 @@ use procsrv;
 use util;
 use util::logv;
 
-use core::io;
-use core::os;
-use core::uint;
-use core::vec;
+use std::io;
+use std::os;
+use std::uint;
+use std::vec;
 
 pub fn run(config: config, testfile: ~str) {
     if config.verbose {

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -8,12 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::prelude::*;
-
 use common::config;
 
-use core::io;
-use core::os::getenv;
+use std::io;
+use std::os::getenv;
 
 pub fn make_new_path(path: &str) -> ~str {
 

--- a/src/driver/driver.rs
+++ b/src/driver/driver.rs
@@ -8,11 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[no_core];
-#[no_std];
-
-extern mod core(name = "std", vers = "0.7");
-
 #[cfg(rustpkg)]
 extern mod this(name = "rustpkg");
 

--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -667,8 +667,10 @@ mod tests {
             fn f() {}
             f()
         ");
+    }
 
-        debug!("simultaneous definitions + expressions are allowed");
+    #[test]
+    fn simultaneous_definition_and_expression() {
         run_program("
             let a = 3; a as u8
         ");

--- a/src/librustpkg/api.rs
+++ b/src/librustpkg/api.rs
@@ -14,10 +14,8 @@ use package_id::*;
 use package_source::*;
 use version::Version;
 
-use std::option::*;
 use std::os;
 use std::hashmap::*;
-use std::path::*;
 
 /// Convenience functions intended for calling from pkg.rs
 

--- a/src/librustpkg/messages.rs
+++ b/src/librustpkg/messages.rs
@@ -10,7 +10,6 @@
 
 use extra::term;
 use std::io;
-use std::result::*;
 
 pub fn note(msg: &str) {
     pretty_message(msg, "note: ", term::color::GREEN, io::stdout())

--- a/src/librustpkg/package_source.rs
+++ b/src/librustpkg/package_source.rs
@@ -11,7 +11,6 @@
 use target::*;
 use package_id::PkgId;
 use std::path::Path;
-use std::option::*;
 use std::{os, run, str};
 use context::*;
 use crate::Crate;

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{libc, os, result, str};
+use std::{os, result};
 use rustc::driver::{driver, session};
 use rustc::metadata::filesearch;
 use extra::getopts::groups::getopts;
@@ -379,6 +379,7 @@ pub fn link_exe(_src: &Path, _dest: &Path) -> bool {
 #[cfg(target_os = "freebsd")]
 #[cfg(target_os = "macos")]
 pub fn link_exe(src: &Path, dest: &Path) -> bool {
+    use std::{libc, str};
     unsafe {
         do str::as_c_str(src.to_str()) |src_buf| {
             do str::as_c_str(dest.to_str()) |dest_buf| {


### PR DESCRIPTION
Also marks them with `#[deny(warnings)]` (I think they're both only ever really built past stage1)
