### PR TITLE
Remove visit_struct_method

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -940,10 +940,6 @@ fn lint_unused_mut() -> visit::vt<@mut Context> {
             visit_fn_decl(cx, &tm.decl);
             visit::visit_ty_method(tm, (cx, vt));
         },
-        visit_struct_method: |sm, (cx, vt)| {
-            visit_fn_decl(cx, &sm.decl);
-            visit::visit_struct_method(sm, (cx, vt));
-        },
         visit_trait_method: |tm, (cx, vt)| {
             match *tm {
                 ast::required(ref tm) => visit_fn_decl(cx, &tm.decl),
@@ -1023,14 +1019,6 @@ fn lint_missing_doc() -> visit::vt<@mut Context> {
     }
 
     visit::mk_vt(@visit::Visitor {
-        visit_struct_method: |m, (cx, vt)| {
-            if m.vis == ast::public {
-                check_attrs(cx, m.attrs, m.span,
-                            "missing documentation for a method");
-            }
-            visit::visit_struct_method(m, (cx, vt));
-        },
-
         visit_ty_method: |m, (cx, vt)| {
             // All ty_method objects are linted about because they're part of a
             // trait (no visibility)

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -90,7 +90,6 @@ pub struct Visitor<E> {
     visit_trait_method: @fn(&trait_method, (E, vt<E>)),
     visit_struct_def: @fn(@struct_def, ident, &Generics, node_id, (E, vt<E>)),
     visit_struct_field: @fn(@struct_field, (E, vt<E>)),
-    visit_struct_method: @fn(@method, (E, vt<E>))
 }
 
 pub type visitor<E> = @Visitor<E>;
@@ -116,7 +115,6 @@ pub fn default_visitor<E: Copy>() -> visitor<E> {
         visit_trait_method: |a,b|visit_trait_method::<E>(a, b),
         visit_struct_def: |a,b,c,d,e|visit_struct_def::<E>(a, b, c, d, e),
         visit_struct_field: |a,b|visit_struct_field::<E>(a, b),
-        visit_struct_method: |a,b|visit_struct_method::<E>(a, b)
     };
 }
 
@@ -412,10 +410,6 @@ pub fn visit_struct_def<E: Copy>(
 
 pub fn visit_struct_field<E: Copy>(sf: &struct_field, (e, v): (E, vt<E>)) {
     (v.visit_ty)(sf.node.ty, (e, v));
-}
-
-pub fn visit_struct_method<E: Copy>(m: &method, (e, v): (E, vt<E>)) {
-    visit_method_helper(m, (e, v));
 }
 
 pub fn visit_block<E: Copy>(b: &blk, (e, v): (E, vt<E>)) {
@@ -729,10 +723,6 @@ pub fn mk_simple_visitor(v: simple_visitor) -> vt<()> {
         f(sf);
         visit_struct_field(sf, (e, v));
     }
-    fn v_struct_method(f: @fn(@method), m: @method, (e, v): ((), vt<()>)) {
-        f(m);
-        visit_struct_method(m, (e, v));
-    }
     return mk_vt(@Visitor {
         visit_mod: |a,b,c,d|v_mod(v.visit_mod, a, b, c, d),
         visit_view_item: |a,b| v_view_item(v.visit_view_item, a, b),
@@ -760,7 +750,5 @@ pub fn mk_simple_visitor(v: simple_visitor) -> vt<()> {
             v_struct_def(v.visit_struct_def, a, b, c, d, e),
         visit_struct_field: |a,b|
             v_struct_field(v.visit_struct_field, a, b),
-        visit_struct_method: |a,b|
-            v_struct_method(v.visit_struct_method, a, b)
     });
 }


### PR DESCRIPTION
This was introduced in 3038968 and missed in 0046ed9 when class-related codes were removed.
