### PR TITLE
Deque: fix an assertion, speed up and big cleanup

### DIFF
--- a/src/libextra/deque.rs
+++ b/src/libextra/deque.rs
@@ -107,7 +107,7 @@ impl<T> Deque<T> {
         if self.lo == 0u {
             self.lo = self.elts.len() - 1u;
         } else { self.lo -= 1u; }
-        if self.lo == self.hi {
+        if self.nelts == self.elts.len() {
             self.elts = grow(self.nelts, oldlo, self.elts);
             self.lo = self.elts.len() - 1u;
             self.hi = self.nelts;

--- a/src/libextra/deque.rs
+++ b/src/libextra/deque.rs
@@ -14,7 +14,8 @@ use std::uint;
 use std::vec;
 use std::iterator::FromIterator;
 
-static INITIAL_CAPACITY: uint = 32u; // 2^5
+static INITIAL_CAPACITY: uint = 8u; // 2^3
+static MINIMUM_CAPACITY: uint = 2u;
 
 #[allow(missing_doc)]
 pub struct Deque<T> {
@@ -43,8 +44,13 @@ impl<T> Mutable for Deque<T> {
 impl<T> Deque<T> {
     /// Create an empty Deque
     pub fn new() -> Deque<T> {
+        Deque::with_capacity(INITIAL_CAPACITY)
+    }
+
+    /// Create an empty Deque with space for at least `n` elements.
+    pub fn with_capacity(n: uint) -> Deque<T> {
         Deque{nelts: 0, lo: 0,
-              elts: vec::from_fn(INITIAL_CAPACITY, |_| None)}
+              elts: vec::from_fn(uint::max(MINIMUM_CAPACITY, n), |_| None)}
     }
 
     /// Return a reference to the first element in the deque
@@ -525,6 +531,16 @@ mod tests {
             assert_eq!(*e, i + 2);
         }
 
+    }
+
+    #[test]
+    fn test_with_capacity() {
+        let mut d = Deque::with_capacity(0);
+        d.add_back(1);
+        assert_eq!(d.len(), 1);
+        let mut d = Deque::with_capacity(50);
+        d.add_back(1);
+        assert_eq!(d.len(), 1);
     }
 
     #[test]

--- a/src/libextra/deque.rs
+++ b/src/libextra/deque.rs
@@ -256,6 +256,7 @@ mod tests {
     use std::cmp::Eq;
     use std::kinds::Copy;
     use std::int;
+    use extra::test;
 
     #[test]
     fn test_simple() {
@@ -367,6 +368,61 @@ mod tests {
         assert_eq!(copy *deq.get(1), copy b);
         assert_eq!(copy *deq.get(2), copy c);
         assert_eq!(copy *deq.get(3), copy d);
+    }
+
+    #[test]
+    fn test_add_front_grow() {
+        let mut deq = Deque::new();
+        for int::range(0, 66) |i| {
+            deq.add_front(i);
+        }
+        assert_eq!(deq.len(), 66);
+
+        for int::range(0, 66) |i| {
+            assert_eq!(*deq.get(i), 65 - i);
+        }
+
+        let mut deq = Deque::new();
+        for int::range(0, 66) |i| {
+            deq.add_back(i);
+        }
+
+        for int::range(0, 66) |i| {
+            assert_eq!(*deq.get(i), i);
+        }
+    }
+
+    #[bench]
+    fn bench_new(b: &mut test::BenchHarness) {
+        do b.iter {
+            let _ = Deque::new::<u64>();
+        }
+    }
+
+    #[bench]
+    fn bench_add_back(b: &mut test::BenchHarness) {
+        let mut deq = Deque::new();
+        do b.iter {
+            deq.add_back(0);
+        }
+    }
+
+    #[bench]
+    fn bench_add_front(b: &mut test::BenchHarness) {
+        let mut deq = Deque::new();
+        do b.iter {
+            deq.add_front(0);
+        }
+    }
+
+    #[bench]
+    fn bench_grow(b: &mut test::BenchHarness) {
+        let mut deq = Deque::new();
+        do b.iter {
+            for 65.times {
+                deq.add_front(1);
+            }
+        }
     }
 
     #[deriving(Eq)]

--- a/src/libextra/deque.rs
+++ b/src/libextra/deque.rs
@@ -77,16 +77,6 @@ impl<T> Deque<T> {
         get(self.elts, idx)
     }
 
-    /// Iterate over the elements in the deque
-    pub fn each(&self, f: &fn(&T) -> bool) -> bool {
-        self.eachi(|_i, e| f(e))
-    }
-
-    /// Iterate over the elements in the deque by index
-    pub fn eachi(&self, f: &fn(uint, &T) -> bool) -> bool {
-        uint::range(0, self.nelts, |i| f(i, self.get(i as int)))
-    }
-
     /// Remove and return the first element in the deque
     ///
     /// Fails if the deque is empty
@@ -512,25 +502,6 @@ mod tests {
         let reccy3 = RecCy { x: 1, y: 777, t: Three(1, 2, 3) };
         let reccy4 = RecCy { x: 19, y: 252, t: Two(17, 42) };
         test_parameterized::<RecCy>(reccy1, reccy2, reccy3, reccy4);
-    }
-
-    #[test]
-    fn test_eachi() {
-        let mut deq = Deque::new();
-        deq.add_back(1);
-        deq.add_back(2);
-        deq.add_back(3);
-
-        for deq.eachi |i, e| {
-            assert_eq!(*e, i + 1);
-        }
-
-        deq.pop_front();
-
-        for deq.eachi |i, e| {
-            assert_eq!(*e, i + 2);
-        }
-
     }
 
     #[test]

--- a/src/libextra/deque.rs
+++ b/src/libextra/deque.rs
@@ -18,6 +18,7 @@ static INITIAL_CAPACITY: uint = 8u; // 2^3
 static MINIMUM_CAPACITY: uint = 2u;
 
 #[allow(missing_doc)]
+#[deriving(Clone)]
 pub struct Deque<T> {
     priv nelts: uint,
     priv lo: uint,
@@ -269,6 +270,16 @@ fn raw_index(lo: uint, len: uint, index: uint) -> uint {
         lo + index - len
     } else {
         lo + index
+    }
+}
+
+impl<A: Eq> Eq for Deque<A> {
+    fn eq(&self, other: &Deque<A>) -> bool {
+        self.nelts == other.nelts &&
+            self.iter().zip(other.iter()).all(|(a, b)| a.eq(b))
+    }
+    fn ne(&self, other: &Deque<A>) -> bool {
+        !self.eq(other)
     }
 }
 
@@ -630,5 +641,43 @@ mod tests {
             assert_eq!(2*i, x);
         }
         assert_eq!(deq.len(), 256);
+    }
+
+    #[test]
+    fn test_clone() {
+        let mut d = Deque::new();
+        d.add_front(17);
+        d.add_front(42);
+        d.add_back(137);
+        d.add_back(137);
+        assert_eq!(d.len(), 4u);
+        let mut e = d.clone();
+        assert_eq!(e.len(), 4u);
+        while !d.is_empty() {
+            assert_eq!(d.pop_back(), e.pop_back());
+        }
+        assert_eq!(d.len(), 0u);
+        assert_eq!(e.len(), 0u);
+    }
+
+    #[test]
+    fn test_eq() {
+        let mut d = Deque::new();
+        assert_eq!(&d, &Deque::with_capacity(0));
+        d.add_front(137);
+        d.add_front(17);
+        d.add_front(42);
+        d.add_back(137);
+        let mut e = Deque::with_capacity(0);
+        e.add_back(42);
+        e.add_back(17);
+        e.add_back(137);
+        e.add_back(137);
+        assert_eq!(&e, &d);
+        e.pop_back();
+        e.add_back(0);
+        assert!(e != d);
+        e.clear();
+        assert_eq!(e, Deque::new());
     }
 }

--- a/src/libextra/deque.rs
+++ b/src/libextra/deque.rs
@@ -273,7 +273,7 @@ mod tests {
     use super::*;
     use std::cmp::Eq;
     use std::kinds::Copy;
-    use std::int;
+    use std::{int, uint};
     use extra::test;
 
     #[test]
@@ -536,6 +536,8 @@ mod tests {
     #[test]
     fn test_iter() {
         let mut d = Deque::new();
+        assert_eq!(d.iter().next(), None);
+
         for int::range(0,5) |i| {
             d.add_back(i);
         }
@@ -550,6 +552,8 @@ mod tests {
     #[test]
     fn test_rev_iter() {
         let mut d = Deque::new();
+        assert_eq!(d.rev_iter().next(), None);
+
         for int::range(0,5) |i| {
             d.add_back(i);
         }
@@ -559,6 +563,52 @@ mod tests {
             d.add_front(i);
         }
         assert_eq!(d.rev_iter().collect::<~[&int]>(), ~[&4,&3,&2,&1,&0,&6,&7,&8]);
+    }
+
+    #[test]
+    fn test_mut_iter() {
+        let mut d = Deque::new();
+        assert!(d.mut_iter().next().is_none());
+
+        for uint::range(0,3) |i| {
+            d.add_front(i);
+        }
+
+        for d.mut_iter().enumerate().advance |(i, elt)| {
+            assert_eq!(*elt, 2 - i);
+            *elt = i;
+        }
+
+        {
+            let mut it = d.mut_iter();
+            assert_eq!(*it.next().unwrap(), 0);
+            assert_eq!(*it.next().unwrap(), 1);
+            assert_eq!(*it.next().unwrap(), 2);
+            assert!(it.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_mut_rev_iter() {
+        let mut d = Deque::new();
+        assert!(d.mut_rev_iter().next().is_none());
+
+        for uint::range(0,3) |i| {
+            d.add_front(i);
+        }
+
+        for d.mut_rev_iter().enumerate().advance |(i, elt)| {
+            assert_eq!(*elt, i);
+            *elt = i;
+        }
+
+        {
+            let mut it = d.mut_rev_iter();
+            assert_eq!(*it.next().unwrap(), 0);
+            assert_eq!(*it.next().unwrap(), 1);
+            assert_eq!(*it.next().unwrap(), 2);
+            assert!(it.next().is_none());
+        }
     }
 
     #[test]

--- a/src/libextra/serialize.rs
+++ b/src/libextra/serialize.rs
@@ -682,7 +682,7 @@ impl<
 > Encodable<S> for Deque<T> {
     fn encode(&self, s: &mut S) {
         do s.emit_seq(self.len()) |s| {
-            for self.eachi |i, e| {
+            for self.iter().enumerate().advance |(i, e)| {
                 s.emit_seq_elt(i, |s| e.encode(s));
             }
         }


### PR DESCRIPTION
Fix an assertion in grow when using add_front.

Speeds up grow (and the functions that use it) by a lot. We retain the vector instead of creating it anew for each grow. 

The struct field hi is removed since it is redundant, and all iterators are updated to use a representation closer to the Deque itself, it should make it work even if deque sizes are not powers of two.

Deque::with_capacity is also implemented, but .reserve() is not yet done.
