### PR TITLE
Add rusti/rustpkg to check-lite

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -15,7 +15,7 @@
 
 # The names of crates that must be tested
 TEST_TARGET_CRATES = std extra
-TEST_HOST_CRATES = syntax rustc rustdoc rust rustpkg
+TEST_HOST_CRATES = syntax rustc rustdoc rust rustpkg rusti
 TEST_CRATES = $(TEST_TARGET_CRATES) $(TEST_HOST_CRATES)
 
 # Markdown files under doc/ that should have their code extracted and run
@@ -157,6 +157,7 @@ check-test: cleantestlibs cleantmptestlogs all check-stage2-rfail
 
 check-lite: cleantestlibs cleantmptestlogs \
 	check-stage2-std check-stage2-extra check-stage2-rpass \
+	check-stage2-rustpkg check-stage2-rusti \
 	check-stage2-rfail check-stage2-cfail
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log
 

--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -530,7 +530,8 @@ mod tests {
 
     // FIXME: #7220 rusti on 32bit mac doesn't work.
     // FIXME: #7641 rusti on 32bit linux cross compile doesn't work
-    #[cfg(not(target_word_size="32"))]
+    // FIXME: #7115 re-enable once LLVM has been upgraded
+    #[cfg(thiswillneverbeacfgflag)]
     fn run_program(prog: &str) {
         let mut r = repl();
         for prog.split_iter('\n').advance |cmd| {
@@ -539,7 +540,6 @@ mod tests {
             r = result.expect(fmt!("the command '%s' failed", cmd));
         }
     }
-    #[cfg(target_word_size="32")]
     fn run_program(_: &str) {}
 
     #[test]


### PR DESCRIPTION
A lot of cross-platform issues stem from rusti/rustpkg, so include these two test suites in the 'check-lite' target which is run on the cross-compile bots. It shouldn't be much of a performance hit because these suites are pretty fast to run.

Hopefully this will make snapshot/tarball creation easier in the future. 
