### PR TITLE
Removed drop from the keyword list in the docs

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -207,7 +207,7 @@ The keywords are the following strings:
 as
 break
 copy
-do drop
+do
 else enum extern
 false fn for
 if impl


### PR DESCRIPTION
Drop is no longer a keyword, removed it from the intro docs.
