### PR TITLE
libsyntax: fix infinite loop when recursively including modules

### DIFF
--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -44,6 +44,8 @@ pub struct ParseSess {
     cm: @codemap::CodeMap, // better be the same as the one in the reader!
     next_id: node_id,
     span_diagnostic: @span_handler, // better be the same as the one in the reader!
+    /// Used to determine and report recursive mod inclusions
+    included_mod_stack: ~[Path],
 }
 
 pub fn new_parse_sess(demitter: Option<Emitter>) -> @mut ParseSess {
@@ -52,6 +54,7 @@ pub fn new_parse_sess(demitter: Option<Emitter>) -> @mut ParseSess {
         cm: cm,
         next_id: 1,
         span_diagnostic: mk_span_handler(mk_handler(demitter), cm),
+        included_mod_stack: ~[],
     }
 }
 
@@ -62,6 +65,7 @@ pub fn new_parse_sess_special_handler(sh: @span_handler,
         cm: cm,
         next_id: 1,
         span_diagnostic: sh,
+        included_mod_stack: ~[],
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -264,7 +264,6 @@ pub struct Parser {
     obsolete_set: @mut HashSet<ObsoleteSyntax>,
     /// Used to determine the path to externally loaded source files
     mod_path_stack: @mut ~[@str],
-
 }
 
 #[unsafe_destructor]
@@ -3834,7 +3833,7 @@ impl Parser {
         (id, item_static(ty, m, e), None)
     }
 
-    // parse a mod { ...}  item
+    // parse a `mod <foo> { ... }` or `mod <foo>;` item
     fn parse_item_mod(&self, outer_attrs: ~[ast::attribute]) -> item_info {
         let id_span = *self.span;
         let id = self.parse_ident();
@@ -3907,6 +3906,23 @@ impl Parser {
             prefix.push_many(path.components)
         };
         let full_path = full_path.normalize();
+
+        let maybe_i = do self.sess.included_mod_stack.iter().position_ |&p| { p == full_path };
+        match maybe_i {
+            Some(i) => {
+                let stack = &self.sess.included_mod_stack;
+                let mut err = ~"circular modules: ";
+                for stack.slice(i, stack.len()).iter().advance |p| {
+                    err.push_str(p.to_str());
+                    err.push_str(" -> ");
+                }
+                err.push_str(full_path.to_str());
+                self.span_fatal(id_sp, err);
+            }
+            None => ()
+        }
+        self.sess.included_mod_stack.push(full_path.clone());
+
         let p0 =
             new_sub_parser_from_file(self.sess, copy self.cfg,
                                      &full_path, id_sp);
@@ -3914,6 +3930,7 @@ impl Parser {
         let mod_attrs = vec::append(outer_attrs, inner);
         let first_item_outer_attrs = next;
         let m0 = p0.parse_mod_items(token::EOF, first_item_outer_attrs);
+        self.sess.included_mod_stack.pop();
         return (ast::item_mod(m0), mod_attrs);
 
         fn cdir_path_opt(default: @str, attrs: ~[ast::attribute]) -> @str {

--- a/src/test/compile-fail/circular_modules_hello.rs
+++ b/src/test/compile-fail/circular_modules_hello.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-test: this is an auxiliary file for circular-modules-main.rs
+
+mod circular_modules_main;
+
+pub fn say_hello() {
+  println(circular_modules_main::hi_str());
+}

--- a/src/test/compile-fail/circular_modules_main.rs
+++ b/src/test/compile-fail/circular_modules_main.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+mod circular_modules_hello; //~ERROR: circular modules
+
+pub fn hi_str() -> ~str {
+  ~"Hi!"
+}
+
+fn main() {
+    circular_modules_hello::say_hello();
+}


### PR DESCRIPTION
Fixes #7276
