### PR TITLE
Fix segfault when using local-rust-root

### DIFF
--- a/src/etc/local_stage0.sh
+++ b/src/etc/local_stage0.sh
@@ -43,7 +43,7 @@ fi
 
 cp ${PREFIX}/bin/rustc ${TARG_DIR}/stage0/bin/
 cp ${PREFIX}/lib/rustc/${TARG_DIR}/${LIBDIR}/* ${TARG_DIR}/stage0/${LIBDIR}/
+cp ${PREFIX}/lib/libextra*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/
 cp ${PREFIX}/lib/librust*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/
-cp ${PREFIX}/lib/libcore*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/
 cp ${PREFIX}/lib/libstd*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/
 cp ${PREFIX}/lib/libsyntax*${LIB_SUF} ${TARG_DIR}/stage0/${LIBDIR}/


### PR DESCRIPTION
This updates the script in src/etc/local_stage0.sh to copy the correct libraries
to stage0.
