### PR TITLE
Move `extra::net_*` to `extra::net::*` properly.

### DIFF
--- a/src/libextra/extra.rs
+++ b/src/libextra/extra.rs
@@ -40,10 +40,8 @@ pub mod uv_ll;
 
 // General io and system-services modules
 
+#[path = "net/mod.rs"]
 pub mod net;
-pub mod net_ip;
-pub mod net_tcp;
-pub mod net_url;
 
 // libuv modules
 pub mod uv;

--- a/src/libextra/net/ip.rs
+++ b/src/libextra/net/ip.rs
@@ -22,20 +22,20 @@ use std::str;
 use iotask = uv::iotask::IoTask;
 use interact = uv::iotask::interact;
 
-use sockaddr_in = super::super::uv_ll::sockaddr_in;
-use sockaddr_in6 = super::super::uv_ll::sockaddr_in6;
-use addrinfo = super::super::uv_ll::addrinfo;
-use uv_getaddrinfo_t = super::super::uv_ll::uv_getaddrinfo_t;
-use uv_ip4_name = super::super::uv_ll::ip4_name;
-use uv_ip4_port = super::super::uv_ll::ip4_port;
-use uv_ip6_name = super::super::uv_ll::ip6_name;
-use uv_ip6_port = super::super::uv_ll::ip6_port;
-use uv_getaddrinfo = super::super::uv_ll::getaddrinfo;
-use uv_freeaddrinfo = super::super::uv_ll::freeaddrinfo;
-use create_uv_getaddrinfo_t = super::super::uv_ll::getaddrinfo_t;
-use set_data_for_req = super::super::uv_ll::set_data_for_req;
-use get_data_for_req = super::super::uv_ll::get_data_for_req;
-use ll = super::super::uv_ll;
+use sockaddr_in = uv_ll::sockaddr_in;
+use sockaddr_in6 = uv_ll::sockaddr_in6;
+use addrinfo = uv_ll::addrinfo;
+use uv_getaddrinfo_t = uv_ll::uv_getaddrinfo_t;
+use uv_ip4_name = uv_ll::ip4_name;
+use uv_ip4_port = uv_ll::ip4_port;
+use uv_ip6_name = uv_ll::ip6_name;
+use uv_ip6_port = uv_ll::ip6_port;
+use uv_getaddrinfo = uv_ll::getaddrinfo;
+use uv_freeaddrinfo = uv_ll::freeaddrinfo;
+use create_uv_getaddrinfo_t = uv_ll::getaddrinfo_t;
+use set_data_for_req = uv_ll::set_data_for_req;
+use get_data_for_req = uv_ll::get_data_for_req;
+use ll = uv_ll;
 
 /// An IP address
 pub enum IpAddr {

--- a/src/libextra/net/ip.rs
+++ b/src/libextra/net/ip.rs
@@ -22,20 +22,20 @@ use std::str;
 use iotask = uv::iotask::IoTask;
 use interact = uv::iotask::interact;
 
-use sockaddr_in = super::uv_ll::sockaddr_in;
-use sockaddr_in6 = super::uv_ll::sockaddr_in6;
-use addrinfo = super::uv_ll::addrinfo;
-use uv_getaddrinfo_t = super::uv_ll::uv_getaddrinfo_t;
-use uv_ip4_name = super::uv_ll::ip4_name;
-use uv_ip4_port = super::uv_ll::ip4_port;
-use uv_ip6_name = super::uv_ll::ip6_name;
-use uv_ip6_port = super::uv_ll::ip6_port;
-use uv_getaddrinfo = super::uv_ll::getaddrinfo;
-use uv_freeaddrinfo = super::uv_ll::freeaddrinfo;
-use create_uv_getaddrinfo_t = super::uv_ll::getaddrinfo_t;
-use set_data_for_req = super::uv_ll::set_data_for_req;
-use get_data_for_req = super::uv_ll::get_data_for_req;
-use ll = super::uv_ll;
+use sockaddr_in = super::super::uv_ll::sockaddr_in;
+use sockaddr_in6 = super::super::uv_ll::sockaddr_in6;
+use addrinfo = super::super::uv_ll::addrinfo;
+use uv_getaddrinfo_t = super::super::uv_ll::uv_getaddrinfo_t;
+use uv_ip4_name = super::super::uv_ll::ip4_name;
+use uv_ip4_port = super::super::uv_ll::ip4_port;
+use uv_ip6_name = super::super::uv_ll::ip6_name;
+use uv_ip6_port = super::super::uv_ll::ip6_port;
+use uv_getaddrinfo = super::super::uv_ll::getaddrinfo;
+use uv_freeaddrinfo = super::super::uv_ll::freeaddrinfo;
+use create_uv_getaddrinfo_t = super::super::uv_ll::getaddrinfo_t;
+use set_data_for_req = super::super::uv_ll::set_data_for_req;
+use get_data_for_req = super::super::uv_ll::get_data_for_req;
+use ll = super::super::uv_ll;
 
 /// An IP address
 pub enum IpAddr {
@@ -363,9 +363,9 @@ extern fn get_addr_cb(handle: *uv_getaddrinfo_t,
 #[cfg(test)]
 mod test {
 
-    use net_ip::*;
-    use net_ip::v4;
-    use net_ip::v6;
+    use net::ip::*;
+    use net::ip::v4;
+    use net::ip::v6;
     use uv;
 
     use std::result;

--- a/src/libextra/net/mod.rs
+++ b/src/libextra/net/mod.rs
@@ -13,13 +13,13 @@ Top-level module for network-related functionality.
 
 Basically, including this module gives you:
 
-* `net_tcp`
-* `net_ip`
-* `net_url`
+* `tcp`
+* `ip`
+* `url`
 
 See each of those three modules for documentation on what they do.
 */
 
-pub use tcp = net_tcp;
-pub use ip = net_ip;
-pub use url = net_url;
+pub mod tcp;
+pub mod ip;
+pub mod url;

--- a/src/libextra/net/tcp.rs
+++ b/src/libextra/net/tcp.rs
@@ -16,7 +16,7 @@
 
 use future;
 use future_spawn = future::spawn;
-use ip = net_ip;
+use ip = net::ip;
 use uv;
 use uv::iotask;
 use uv::iotask::IoTask;

--- a/src/libextra/net/url.rs
+++ b/src/libextra/net/url.rs
@@ -800,7 +800,7 @@ fn test_get_path() {
 #[cfg(test)]
 mod tests {
 
-    use net_url::*;
+    use net::url::*;
 
     use std::hashmap::HashMap;
 


### PR DESCRIPTION
Where \* = tcp, ip, url.

Formerly, extra::net::\* were aliases of extra::net__, but were the
recommended path to use. Thus, the documentation talked of the `net__`
modules while everything else was written expecting`net::*`.

This moves the actual modules so that `extra::net::*` is the actual
location of the modules.

This will naturally break any code which used `extra::net_*` directly.
They should be altered to use `extra::net::*` (which has been the
documented way of doing things for some time).

This ensures that there is one, and only one, obvious way of doing
things.
