### PR TITLE
Switch json parsing to read_chars for performance

### DIFF
--- a/src/libstd/char.rs
+++ b/src/libstd/char.rs
@@ -82,7 +82,8 @@ pub fn is_uppercase(c: char) -> bool { general_category::Lu(c) }
 ///
 #[inline]
 pub fn is_whitespace(c: char) -> bool {
-    ('\x09' <= c && c <= '\x0d')
+    c == ' '
+        || ('\x09' <= c && c <= '\x0d')
         || general_category::Zs(c)
         || general_category::Zl(c)
         || general_category::Zp(c)


### PR DESCRIPTION
Avoids the overhead of read_char for every character.

Benchmark reading example.json 10 times from
https://code.google.com/p/rapidjson/wiki/Performance

Before: 2.55s
After:  0.16s

Regression testing is already done by isrustfastyet.
