### PR TITLE
Faster check for ascii-space

### DIFF
--- a/src/libstd/char.rs
+++ b/src/libstd/char.rs
@@ -82,7 +82,8 @@ pub fn is_uppercase(c: char) -> bool { general_category::Lu(c) }
 ///
 #[inline]
 pub fn is_whitespace(c: char) -> bool {
-    ('\x09' <= c && c <= '\x0d')
+    c == ' '
+        || ('\x09' <= c && c <= '\x0d')
         || general_category::Zs(c)
         || general_category::Zl(c)
         || general_category::Zp(c)


### PR DESCRIPTION
Since ' ' is by far one of the most common characters, it is worthwhile
to put it first, and short-circuit the rest of the function.

On the same JSON benchmark, as the json_perf improvement, reading example.json
10 times from https://code.google.com/p/rapidjson/wiki/Performance.

Before: 2.66s
After json perf: 0.16s
After json perf and ascii-space: 0.11s
