### PR TITLE
Implement scopes independent of LLVM basic blocks

### DIFF
--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -321,7 +321,7 @@ pub fn add_clean(bcx: block, val: ValueRef, t: ty::t) {
     debug!("add_clean(%s, %s, %s)", bcx.to_str(), bcx.val_to_str(val), t.repr(bcx.tcx()));
 
     let cleanup_type = cleanup_type(bcx.tcx(), t);
-    do in_scope_cx(bcx) |scope_info| {
+    do in_scope_cx(bcx, None) |scope_info| {
         scope_info.cleanups.push(clean(|a| glue::drop_ty(a, val, t), cleanup_type));
         grow_scope_clean(scope_info);
     }
@@ -333,25 +333,36 @@ pub fn add_clean_temp_immediate(cx: block, val: ValueRef, ty: ty::t) {
            cx.to_str(), cx.val_to_str(val),
            ty.repr(cx.tcx()));
     let cleanup_type = cleanup_type(cx.tcx(), ty);
-    do in_scope_cx(cx) |scope_info| {
+    do in_scope_cx(cx, None) |scope_info| {
         scope_info.cleanups.push(
             clean_temp(val, |a| glue::drop_ty_immediate(a, val, ty),
                        cleanup_type));
         grow_scope_clean(scope_info);
     }
 }
+
 pub fn add_clean_temp_mem(bcx: block, val: ValueRef, t: ty::t) {
+    add_clean_temp_mem_in_scope_(bcx, None, val, t);
+}
+
+pub fn add_clean_temp_mem_in_scope(bcx: block, scope_id: ast::node_id, val: ValueRef, t: ty::t) {
+    add_clean_temp_mem_in_scope_(bcx, Some(scope_id), val, t);
+}
+
+pub fn add_clean_temp_mem_in_scope_(bcx: block, scope_id: Option<ast::node_id>,
+                                    val: ValueRef, t: ty::t) {
     if !ty::type_needs_drop(bcx.tcx(), t) { return; }
     debug!("add_clean_temp_mem(%s, %s, %s)",
            bcx.to_str(), bcx.val_to_str(val),
            t.repr(bcx.tcx()));
     let cleanup_type = cleanup_type(bcx.tcx(), t);
-    do in_scope_cx(bcx) |scope_info| {
+    do in_scope_cx(bcx, scope_id) |scope_info| {
         scope_info.cleanups.push(clean_temp(val, |a| glue::drop_ty(a, val, t), cleanup_type));
         grow_scope_clean(scope_info);
     }
 }
 pub fn add_clean_return_to_mut(bcx: block,
+                               scope_id: ast::node_id,
                                root_key: root_map_key,
                                frozen_val_ref: ValueRef,
                                bits_val_ref: ValueRef,
@@ -369,7 +380,7 @@ pub fn add_clean_return_to_mut(bcx: block,
            bcx.to_str(),
            bcx.val_to_str(frozen_val_ref),
            bcx.val_to_str(bits_val_ref));
-    do in_scope_cx(bcx) |scope_info| {
+    do in_scope_cx(bcx, Some(scope_id)) |scope_info| {
         scope_info.cleanups.push(
             clean_temp(
                 frozen_val_ref,
@@ -390,7 +401,7 @@ pub fn add_clean_free(cx: block, ptr: ValueRef, heap: heap) {
         f
       }
     };
-    do in_scope_cx(cx) |scope_info| {
+    do in_scope_cx(cx, None) |scope_info| {
         scope_info.cleanups.push(clean_temp(ptr, free_fn,
                                       normal_exit_and_unwind));
         grow_scope_clean(scope_info);
@@ -402,7 +413,7 @@ pub fn add_clean_free(cx: block, ptr: ValueRef, heap: heap) {
 // this will be more involved. For now, we simply zero out the local, and the
 // drop glue checks whether it is zero.
 pub fn revoke_clean(cx: block, val: ValueRef) {
-    do in_scope_cx(cx) |scope_info| {
+    do in_scope_cx(cx, None) |scope_info| {
         let cleanup_pos = scope_info.cleanups.iter().position_(
             |cu| match *cu {
                 clean_temp(v, _, _) if v == val => true,
@@ -419,27 +430,14 @@ pub fn revoke_clean(cx: block, val: ValueRef) {
 }
 
 pub fn block_cleanups(bcx: block) -> ~[cleanup] {
-    match bcx.kind {
-       block_non_scope  => ~[],
-       block_scope(inf) => /*bad*/copy inf.cleanups
+    match bcx.scope {
+       None  => ~[],
+       Some(inf) => /*bad*/copy inf.cleanups
     }
 }
 
-pub enum block_kind {
-    // A scope at the end of which temporary values created inside of it are
-    // cleaned up. May correspond to an actual block in the language, but also
-    // to an implicit scope, for example, calls introduce an implicit scope in
-    // which the arguments are evaluated and cleaned up.
-    block_scope(@mut scope_info),
-
-    // A non-scope block is a basic block created as a translation artifact
-    // from translating code that expresses conditional logic rather than by
-    // explicit { ... } block structure in the source language.  It's called a
-    // non-scope block because it doesn't introduce a new variable scope.
-    block_non_scope,
-}
-
 pub struct scope_info {
+    parent: Option<@mut scope_info>,
     loop_break: Option<block>,
     loop_label: Option<ident>,
     // A list of functions that must be run at when leaving this
@@ -451,6 +449,8 @@ pub struct scope_info {
     cleanup_paths: ~[cleanup_path],
     // Unwinding landing pad. Also cleared when cleanups change.
     landing_pad: Option<BasicBlockRef>,
+    // info about the AST node this scope originated from, if any
+    node_info: Option<NodeInfo>,
 }
 
 impl scope_info {
@@ -506,8 +506,8 @@ pub struct block_ {
     terminated: bool,
     unreachable: bool,
     parent: Option<block>,
-    // The 'kind' of basic block this is.
-    kind: block_kind,
+    // The current scope within this basic block
+    scope: Option<@mut scope_info>,
     // Is this block part of a landing pad?
     is_lpad: bool,
     // info about the AST node this block originated from, if any
@@ -517,7 +517,7 @@ pub struct block_ {
     fcx: fn_ctxt
 }
 
-pub fn block_(llbb: BasicBlockRef, parent: Option<block>, kind: block_kind,
+pub fn block_(llbb: BasicBlockRef, parent: Option<block>,
               is_lpad: bool, node_info: Option<NodeInfo>, fcx: fn_ctxt)
     -> block_ {
 
@@ -526,7 +526,7 @@ pub fn block_(llbb: BasicBlockRef, parent: Option<block>, kind: block_kind,
         terminated: false,
         unreachable: false,
         parent: parent,
-        kind: kind,
+        scope: None,
         is_lpad: is_lpad,
         node_info: node_info,
         fcx: fcx
@@ -535,10 +535,10 @@ pub fn block_(llbb: BasicBlockRef, parent: Option<block>, kind: block_kind,
 
 pub type block = @mut block_;
 
-pub fn mk_block(llbb: BasicBlockRef, parent: Option<block>, kind: block_kind,
+pub fn mk_block(llbb: BasicBlockRef, parent: Option<block>,
             is_lpad: bool, node_info: Option<NodeInfo>, fcx: fn_ctxt)
     -> block {
-    @mut block_(llbb, parent, kind, is_lpad, node_info, fcx)
+    @mut block_(llbb, parent, is_lpad, node_info, fcx)
 }
 
 pub struct Result {
@@ -563,19 +563,33 @@ pub fn val_ty(v: ValueRef) -> Type {
     }
 }
 
-pub fn in_scope_cx(cx: block, f: &fn(si: &mut scope_info)) {
+pub fn in_scope_cx(cx: block, scope_id: Option<ast::node_id>, f: &fn(si: &mut scope_info)) {
     let mut cur = cx;
+    let mut cur_scope = cur.scope;
     loop {
-        match cur.kind {
-            block_scope(inf) => {
-                debug!("in_scope_cx: selected cur=%s (cx=%s)",
-                       cur.to_str(), cx.to_str());
-                f(inf);
-                return;
+        cur_scope = match cur_scope {
+            Some(inf) => match scope_id {
+                Some(wanted) => match inf.node_info {
+                    Some(NodeInfo { id: actual, _ }) if wanted == actual => {
+                        debug!("in_scope_cx: selected cur=%s (cx=%s)",
+                               cur.to_str(), cx.to_str());
+                        f(inf);
+                        return;
+                    },
+                    _ => inf.parent,
+                },
+                None => {
+                    debug!("in_scope_cx: selected cur=%s (cx=%s)",
+                           cur.to_str(), cx.to_str());
+                    f(inf);
+                    return;
+                }
+            },
+            None => {
+                cur = block_parent(cur);
+                cur.scope
             }
-            _ => ()
         }
-        cur = block_parent(cur);
     }
 }
 

--- a/src/librustc/middle/trans/write_guard.rs
+++ b/src/librustc/middle/trans/write_guard.rs
@@ -123,7 +123,7 @@ fn root(datum: &Datum,
     let scratch = scratch_datum(bcx, datum.ty, true);
     datum.copy_to_datum(bcx, INIT, scratch);
     let cleanup_bcx = find_bcx_for_scope(bcx, root_info.scope);
-    add_clean_temp_mem(cleanup_bcx, scratch.val, scratch.ty);
+    add_clean_temp_mem_in_scope(cleanup_bcx, root_info.scope, scratch.val, scratch.ty);
 
     // Now, consider also freezing it.
     match root_info.freeze {
@@ -168,7 +168,7 @@ fn root(datum: &Datum,
             }
 
             add_clean_return_to_mut(
-                cleanup_bcx, root_key, scratch.val, scratch_bits.val,
+                cleanup_bcx, root_info.scope, root_key, scratch.val, scratch_bits.val,
                 filename, line);
         }
     }


### PR DESCRIPTION
Currently, scopes are tied to LLVM basic blocks. For each scope, there
are two new basic blocks, which means two extra jumps in the unoptimized
IR. These blocks aren't actually required, but only used to act as the
boundary for cleanups.

By keeping track of the current scope within a single basic block, we
can avoid those extra blocks and jumps, shrinking the pre-optimization
IR quite considerably. For example, the IR for trans_intrinsic goes
from ~22k lines to ~16k lines, almost 30% less.

The impact on the build times of optimized builds is rather small (about
1%), but unoptimized builds are about 11% faster. The testsuite for
unoptimized builds runs between 15% (CPU time) and 7.5% (wallclock time on
my i7) faster.

Also, in some situations this helps LLVM to generate better code by
inlining functions that it previously considered to be too large.
Likely because of the pointless blocks/jumps that were still present at
the time the inlining pass runs.

Refs #7462
