### PR TITLE
Fix #3225: Check for old Rust libraries when building and installing.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -235,6 +235,33 @@ LIBRUST_DSYM_GLOB_$(1) :=$(call CFG_LIB_DSYM_GLOB_$(1),rust)
 
 endef
 
+# $(1) is the path for directory to match against
+# $(2) is the glob to use in the match
+# $(3) is filename (usually the target being created) to filter out from match
+#      (i.e. filename is not out-of-date artifact from prior Rust version/build)
+# The glob denoted by $(2) often is constructed with a space character prefix,
+# which is why we cannot just do `ls` on $(1)/$(2).
+define CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT
+  $(Q)( cd $(1) && ( ls $(2) 2>/dev/null || true ) | grep -v $(3) > /dev/null && echo "Warning: there are previous" '$(2)' "libraries:" || true )
+  $(Q)( cd $(1) && ( ls $(2) 2>/dev/null || true ) | grep -v $(3) || true )
+endef
+
+# Same interface as above, but deletes rather than just listing the files.
+define REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT
+  $(Q)( cd $(1) && ( ls $(2) 2>/dev/null || true ) | grep -v $(3) > /dev/null && echo "Warning: removing previous" '$(2)' "libraries:" || true )
+  $(Q)( cd $(1) && ( ls $(2) 2>/dev/null || true ) | grep -v $(3) | xargs rm -v )
+endef
+
+ifdef VERBOSE
+define LIST_ALL_OLD_GLOB_MATCHES_EXCEPT
+  @echo "Info: now are following matches for" '$(2)' "libraries:"
+  @( cd $(1) && ( ls $(2) 2>/dev/null || true ) | grep -v $(3) || true )
+endef
+else
+define LIST_ALL_OLD_GLOB_MATCHES_EXCEPT
+endef
+endif
+
 $(foreach target,$(CFG_TARGET_TRIPLES),\
   $(eval $(call DEF_LIBS,$(target))))
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -239,19 +239,25 @@ endef
 # $(2) is the glob to use in the match
 # $(3) is filename (usually the target being created) to filter out from match
 #      (i.e. filename is not out-of-date artifact from prior Rust version/build)
-# The glob denoted by $(2) often is constructed with a space character prefix,
-# which is why we cannot just do `ls` on $(1)/$(2).
+#
+# Note that a common bug is to accidentally construct the glob denoted
+# by $(2) with a space character prefix, which invalidates the
+# construction $(1)$(2).
 define CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT
-  $(Q)( cd $(1) && ( ls $(2) 2>/dev/null || true ) | grep -v $(3) > /dev/null && echo "Warning: there are previous" '$(2)' "libraries:" || true )
-  $(Q)( cd $(1) && ( ls $(2) 2>/dev/null || true ) | grep -v $(3) || true )
+  $(Q)MATCHES="$(filter-out %$(3),$(wildcard $(1)/$(2)))"; if [ -n "$$MATCHES" ] ; then echo "Warning: there are previous" \'$(2)\' "libraries:" $$MATCHES; fi
 endef
 
 # Same interface as above, but deletes rather than just listing the files.
 define REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT
-  $(Q)( cd $(1) && ( ls $(2) 2>/dev/null || true ) | grep -v $(3) > /dev/null && echo "Warning: removing previous" '$(2)' "libraries:" || true )
-  $(Q)( cd $(1) && ( ls $(2) 2>/dev/null || true ) | grep -v $(3) | xargs rm -v )
+  $(Q)MATCHES="$(filter-out %$(3),$(wildcard $(1)/$(2)))"; if [ -n "$$MATCHES" ] ; then echo "Warning: removing previous" \'$(2)\' "libraries:" $$MATCHES; rm -v $$MATCHES ; fi
 endef
 
+# We use a different strategy for LIST_ALL_OLD_GLOB_MATCHES_EXCEPT
+# than in the macros above because it needs the result of running the
+# `ls` command after other rules in the command list have run; the
+# macro-expander for $(wildcard ...) would deliver its results too
+# soon. (This is in contrast to the macros above, which are meant to
+# be run at the outset of a command list in a rule.)
 ifdef VERBOSE
 define LIST_ALL_OLD_GLOB_MATCHES_EXCEPT
   @echo "Info: now are following matches for" '$(2)' "libraries:"

--- a/mk/host.mk
+++ b/mk/host.mk
@@ -45,10 +45,12 @@ $$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4)): \
 	| $$(HLIB$(2)_H_$(4))/
 
 	@$$(call E, cp: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$< $$@
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTC_GLOB_$(4)) \
 		$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTC_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(4)), `basename $$@`)
 
 $$(HLIB$(2)_H_$(4))/$(CFG_LIBSYNTAX_$(4)): \
 	$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBSYNTAX_$(4)) \
@@ -58,10 +60,12 @@ $$(HLIB$(2)_H_$(4))/$(CFG_LIBSYNTAX_$(4)): \
 	$$(HEXTRALIB_DEFAULT$(2)_H_$(4)) \
 	| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBSYNTAX_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$< $$@
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBSYNTAX_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBSYNTAX_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBSYNTAX_GLOB_$(4)), `basename $$@`)
 
 $$(HLIB$(2)_H_$(4))/$(CFG_RUNTIME_$(4)): \
 	$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_RUNTIME_$(4)) \
@@ -74,6 +78,7 @@ $$(HLIB$(2)_H_$(4))/$(CFG_STDLIB_$(4)): \
 	$$(HLIB$(2)_H_$(4))/$(CFG_RUNTIME_$(4)) \
 	| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(STDLIB_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$< $$@
 # Subtle: We do not let the shell expand $(STDLIB_DSYM_GLOB) directly rather
 # we use Make's $$(wildcard) facility. The reason is that, on mac, when using
@@ -85,6 +90,7 @@ $$(HLIB$(2)_H_$(4))/$(CFG_STDLIB_$(4)): \
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(STDLIB_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(STDLIB_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(STDLIB_GLOB_$(4)), `basename $$@`)
 
 $$(HLIB$(2)_H_$(4))/$(CFG_EXTRALIB_$(4)): \
 	$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4)) \
@@ -92,10 +98,12 @@ $$(HLIB$(2)_H_$(4))/$(CFG_EXTRALIB_$(4)): \
 	$$(HLIB$(2)_H_$(4))/$(CFG_RUNTIME_$(4)) \
 	| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$< $$@
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(EXTRALIB_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(EXTRALIB_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
 
 $$(HLIB$(2)_H_$(4))/libstd.rlib: \
 	$$(TLIB$(1)_T_$(4)_H_$(3))/libstd.rlib \

--- a/mk/host.mk
+++ b/mk/host.mk
@@ -45,12 +45,12 @@ $$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4)): \
 	| $$(HLIB$(2)_H_$(4))/
 
 	@$$(call E, cp: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTC_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$< $$@
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTC_GLOB_$(4)) \
 		$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTC_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTC_GLOB_$(4)),$$(notdir $$@))
 
 $$(HLIB$(2)_H_$(4))/$(CFG_LIBSYNTAX_$(4)): \
 	$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBSYNTAX_$(4)) \
@@ -60,12 +60,12 @@ $$(HLIB$(2)_H_$(4))/$(CFG_LIBSYNTAX_$(4)): \
 	$$(HEXTRALIB_DEFAULT$(2)_H_$(4)) \
 	| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBSYNTAX_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBSYNTAX_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$< $$@
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBSYNTAX_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBSYNTAX_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBSYNTAX_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBSYNTAX_GLOB_$(4)),$$(notdir $$@))
 
 $$(HLIB$(2)_H_$(4))/$(CFG_RUNTIME_$(4)): \
 	$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_RUNTIME_$(4)) \
@@ -78,7 +78,7 @@ $$(HLIB$(2)_H_$(4))/$(CFG_STDLIB_$(4)): \
 	$$(HLIB$(2)_H_$(4))/$(CFG_RUNTIME_$(4)) \
 	| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(STDLIB_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(STDLIB_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$< $$@
 # Subtle: We do not let the shell expand $(STDLIB_DSYM_GLOB) directly rather
 # we use Make's $$(wildcard) facility. The reason is that, on mac, when using
@@ -90,7 +90,7 @@ $$(HLIB$(2)_H_$(4))/$(CFG_STDLIB_$(4)): \
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(STDLIB_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(STDLIB_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(STDLIB_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(STDLIB_GLOB_$(4)),$$(notdir $$@))
 
 $$(HLIB$(2)_H_$(4))/$(CFG_EXTRALIB_$(4)): \
 	$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4)) \
@@ -98,12 +98,12 @@ $$(HLIB$(2)_H_$(4))/$(CFG_EXTRALIB_$(4)): \
 	$$(HLIB$(2)_H_$(4))/$(CFG_RUNTIME_$(4)) \
 	| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(EXTRALIB_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$< $$@
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(EXTRALIB_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(EXTRALIB_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(EXTRALIB_GLOB_$(4)),$$(notdir $$@))
 
 $$(HLIB$(2)_H_$(4))/libstd.rlib: \
 	$$(TLIB$(1)_T_$(4)_H_$(3))/libstd.rlib \

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -16,12 +16,20 @@
 # destination directory as arg 2, and filename/libname-glob as arg 3
 ifdef VERBOSE
  INSTALL = install -m755 $(1)/$(3) $(2)/$(3)
- INSTALL_LIB = install -m644 `ls -drt1 $(1)/$(3) | tail -1` $(2)/
+ DO_INSTALL_LIB = install -m644 `ls -drt1 $(1)/$(3) | tail -1` $(2)/
 else
  INSTALL = $(Q)$(call E, install: $(2)/$(3)) && install -m755 $(1)/$(3) $(2)/$(3)
- INSTALL_LIB = $(Q)$(call E, install_lib: $(2)/$(3)) &&                    \
+ DO_INSTALL_LIB = $(Q)$(call E, install_lib: $(2)/$(3)) &&                    \
 	       install -m644 `ls -drt1 $(1)/$(3) | tail -1` $(2)/
 endif
+
+# $(1) is the source dirctory
+# $(2) is the destination directory
+# $(3) is the filename/libname-glob
+define INSTALL_LIB
+  LIB_NAME=`ls -drt1 $(1)/$(3) | tail -1 | xargs basename` ; ( ls -drt1 $(2)/$(3) 2>/dev/null || true ) | grep -v $$LIB_NAME >/dev/null 2>&1 && echo "Warning, one or more libraries matching Rust library '$(3)'" && echo "  (other than '$$LIB_NAME' itself) already present" && echo "  at destination $(2):" && ( ls -drt1 $(2)/$(3) 2>/dev/null || true ) | grep -v $$LIB_NAME || true
+  $(call DO_INSTALL_LIB,$(1),$(2),$(3))
+endef
 
 # The stage we install from
 ISTAGE = 2

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -38,18 +38,18 @@ endif
 # Target-specific $(LIB_DESTIN_DIR) is the destination directory
 # $(1) is the filename/libname-glob
 define INSTALL_LIB
-  $(if $(filter-out 1,$(words $(wildcard $(LIB_SOURCE_DIR)/$(1)))),      \
-       $(error Aborting install because more than one library matching   \
-               $(1) is present in build tree $(LIB_SOURCE_DIR):          \
+  $(if $(filter-out 1,$(words $(wildcard $(LIB_SOURCE_DIR)/$(1)))),        \
+       $(error Aborting install because more than one library matching     \
+               $(1) is present in build tree $(LIB_SOURCE_DIR):            \
                $(wildcard $(LIB_SOURCE_DIR)/$(1))))
-  $(Q)LIB_NAME=$(notdir $(lastword $(wildcard $(LIB_SOURCE_DIR)/$(1)))); \
-  MATCHES=$(filter-out %$(notdir $(lastword $(wildcard $(LIB_SOURCE_DIR)/$(1)))),\
-                        $(wildcard $(LIB_DESTIN_DIR)/$(1)));             \
-  if [ -n "$$MATCHES" ]; then                                            \
-    echo "Warning, one or libraries matching Rust library '$(1)'" &&     \
-    echo "  (other than '$$LIB_NAME' itself) already present"     &&     \
-    echo "  at destination $(LIB_DESTIN_DIR):"                    &&     \
-    echo $$MATCHES ;                                                     \
+  $(Q)LIB_NAME="$(notdir $(lastword $(wildcard $(LIB_SOURCE_DIR)/$(1))))"; \
+  MATCHES="$(filter-out %$(notdir $(lastword $(wildcard $(LIB_SOURCE_DIR)/$(1)))),\
+                        $(wildcard $(LIB_DESTIN_DIR)/$(1)))";              \
+  if [ -n "$$MATCHES" ]; then                                              \
+    echo "Warning, one or libraries matching Rust library '$(1)'" &&       \
+    echo "  (other than '$$LIB_NAME' itself) already present"     &&       \
+    echo "  at destination $(LIB_DESTIN_DIR):"                    &&       \
+    echo $$MATCHES ;                                                       \
   fi
   $(call DO_INSTALL_LIB,$(1))
 endef

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -12,23 +12,46 @@
 # For consistency it might be desirable for stageN to be an exact
 # mirror of the installation directory structure.
 
-# Installation macro. Call with source directory as arg 1,
-# destination directory as arg 2, and filename/libname-glob as arg 3
-ifdef VERBOSE
- INSTALL = install -m755 $(1)/$(3) $(2)/$(3)
- DO_INSTALL_LIB = install -m644 `ls -drt1 $(1)/$(3) | tail -1` $(2)/
-else
- INSTALL = $(Q)$(call E, install: $(2)/$(3)) && install -m755 $(1)/$(3) $(2)/$(3)
- DO_INSTALL_LIB = $(Q)$(call E, install_lib: $(2)/$(3)) &&                    \
-	       install -m644 `ls -drt1 $(1)/$(3) | tail -1` $(2)/
-endif
-
+# Installation macros.
+# For INSTALL,
 # $(1) is the source dirctory
 # $(2) is the destination directory
 # $(3) is the filename/libname-glob
+ifdef VERBOSE
+ INSTALL = install -m755 $(1)/$(3) $(2)/$(3)
+else
+ INSTALL = $(Q)$(call E, install: $(2)/$(3)) && install -m755 $(1)/$(3) $(2)/$(3)
+endif
+
+# For INSTALL_LIB,
+# Target-specific $(LIB_SOURCE_DIR) is the source directory
+# Target-specific $(LIB_DESTIN_DIR) is the destination directory
+# $(1) is the filename/libname-glob
+ifdef VERBOSE
+ DO_INSTALL_LIB = install -m644 `ls -drt1 $(LIB_SOURCE_DIR)/$(1) | tail -1` $(LIB_DESTIN_DIR)/
+else
+ DO_INSTALL_LIB = $(Q)$(call E, install_lib: $(LIB_DESTIN_DIR)/$(1)) &&                    \
+	       install -m644 `ls -drt1 $(LIB_SOURCE_DIR)/$(1) | tail -1` $(LIB_DESTIN_DIR)/
+endif
+
+# Target-specific $(LIB_SOURCE_DIR) is the source directory
+# Target-specific $(LIB_DESTIN_DIR) is the destination directory
+# $(1) is the filename/libname-glob
 define INSTALL_LIB
-  LIB_NAME=`ls -drt1 $(1)/$(3) | tail -1 | xargs basename` ; ( ls -drt1 $(2)/$(3) 2>/dev/null || true ) | grep -v $$LIB_NAME >/dev/null 2>&1 && echo "Warning, one or more libraries matching Rust library '$(3)'" && echo "  (other than '$$LIB_NAME' itself) already present" && echo "  at destination $(2):" && ( ls -drt1 $(2)/$(3) 2>/dev/null || true ) | grep -v $$LIB_NAME || true
-  $(call DO_INSTALL_LIB,$(1),$(2),$(3))
+  $(if $(filter-out 1,$(words $(wildcard $(LIB_SOURCE_DIR)/$(1)))),      \
+       $(error Aborting install because more than one library matching   \
+               $(1) is present in build tree $(LIB_SOURCE_DIR):          \
+               $(wildcard $(LIB_SOURCE_DIR)/$(1))))
+  $(Q)LIB_NAME=$(notdir $(lastword $(wildcard $(LIB_SOURCE_DIR)/$(1)))); \
+  MATCHES=$(filter-out %$(notdir $(lastword $(wildcard $(LIB_SOURCE_DIR)/$(1)))),\
+                        $(wildcard $(LIB_DESTIN_DIR)/$(1)));             \
+  if [ -n "$$MATCHES" ]; then                                            \
+    echo "Warning, one or libraries matching Rust library '$(1)'" &&     \
+    echo "  (other than '$$LIB_NAME' itself) already present"     &&     \
+    echo "  at destination $(LIB_DESTIN_DIR):"                    &&     \
+    echo $$MATCHES ;                                                     \
+  fi
+  $(call DO_INSTALL_LIB,$(1))
 endef
 
 # The stage we install from
@@ -57,38 +80,32 @@ $(foreach target,$(CFG_TARGET_TRIPLES), \
  $(eval $(call INSTALL_PREPARE_N,$(target),$(CFG_BUILD_TRIPLE))))
 
 define INSTALL_TARGET_N
+install-target-$(1)-host-$(2): LIB_SOURCE_DIR=$$(TL$(1)$(2))
+install-target-$(1)-host-$(2): LIB_DESTIN_DIR=$$(PTL$(1)$(2))
 install-target-$(1)-host-$(2): $$(TSREQ$$(ISTAGE)_T_$(1)_H_$(2)) $$(SREQ$$(ISTAGE)_T_$(1)_H_$(2))
 	$$(Q)mkdir -p $$(PTL$(1)$(2))
-	$$(Q)$$(call INSTALL_LIB,$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(CFG_RUNTIME_$(1)))
-	$$(Q)$$(call INSTALL_LIB, \
-		$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(STDLIB_GLOB_$(1)))
-	$$(Q)$$(call INSTALL_LIB, \
-		$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(EXTRALIB_GLOB_$(1)))
-	$$(Q)$$(call INSTALL_LIB,$$(TL$(1)$(2)),$$(PTL$(1)$(2)),libmorestack.a)
+	$$(Q)$$(call INSTALL_LIB,$$(CFG_RUNTIME_$(1)))
+	$$(Q)$$(call INSTALL_LIB,$$(STDLIB_GLOB_$(1)))
+	$$(Q)$$(call INSTALL_LIB,$$(EXTRALIB_GLOB_$(1)))
+	$$(Q)$$(call INSTALL_LIB,libmorestack.a)
 
 endef
 
 define INSTALL_HOST_N
+install-target-$(1)-host-$(2): LIB_SOURCE_DIR=$$(TL$(1)$(2))
+install-target-$(1)-host-$(2): LIB_DESTIN_DIR=$$(PTL$(1)$(2))
 install-target-$(1)-host-$(2): $$(CSREQ$$(ISTAGE)_T_$(1)_H_$(2))
 	$$(Q)mkdir -p $$(PTL$(1)$(2))
-	$$(Q)$$(call INSTALL_LIB,$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(CFG_RUNTIME_$(1)))
-	$$(Q)$$(call INSTALL_LIB, \
-		$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(STDLIB_GLOB_$(1)))
-	$$(Q)$$(call INSTALL_LIB, \
-		$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(EXTRALIB_GLOB_$(1)))
-	$$(Q)$$(call INSTALL_LIB, \
-		$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(LIBRUSTC_GLOB_$(1)))
-	$$(Q)$$(call INSTALL_LIB, \
-		$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(LIBSYNTAX_GLOB_$(1)))
-	$$(Q)$$(call INSTALL_LIB, \
-		$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(LIBRUSTPKG_GLOB_$(1)))
-	$$(Q)$$(call INSTALL_LIB, \
-		$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(LIBRUSTDOC_GLOB_$(1)))
-	$$(Q)$$(call INSTALL_LIB, \
-		$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(LIBRUSTI_GLOB_$(1)))
-	$$(Q)$$(call INSTALL_LIB, \
-		$$(TL$(1)$(2)),$$(PTL$(1)$(2)),$$(LIBRUST_GLOB_$(1)))
-	$$(Q)$$(call INSTALL_LIB,$$(TL$(1)$(2)),$$(PTL$(1)$(2)),libmorestack.a)
+	$$(Q)$$(call INSTALL_LIB,$$(CFG_RUNTIME_$(1)))
+	$$(Q)$$(call INSTALL_LIB,$$(STDLIB_GLOB_$(1)))
+	$$(Q)$$(call INSTALL_LIB,$$(EXTRALIB_GLOB_$(1)))
+	$$(Q)$$(call INSTALL_LIB,$$(LIBRUSTC_GLOB_$(1)))
+	$$(Q)$$(call INSTALL_LIB,$$(LIBSYNTAX_GLOB_$(1)))
+	$$(Q)$$(call INSTALL_LIB,$$(LIBRUSTPKG_GLOB_$(1)))
+	$$(Q)$$(call INSTALL_LIB,$$(LIBRUSTDOC_GLOB_$(1)))
+	$$(Q)$$(call INSTALL_LIB,$$(LIBRUSTI_GLOB_$(1)))
+	$$(Q)$$(call INSTALL_LIB,$$(LIBRUST_GLOB_$(1)))
+	$$(Q)$$(call INSTALL_LIB,libmorestack.a)
 
 endef
 
@@ -112,6 +129,8 @@ PHB = $(PREFIX_BIN)
 # Shorthand for the prefix bin directory
 PHL = $(PREFIX_LIB)
 
+install-host: LIB_SOURCE_DIR=$(HL)
+install-host: LIB_DESTIN_DIR=$(PHL)
 install-host: $(CSREQ$(ISTAGE)_T_$(CFG_BUILD_TRIPLE)_H_$(CFG_BUILD_TRIPLE))
 	$(Q)mkdir -p $(PREFIX_BIN)
 	$(Q)mkdir -p $(PREFIX_LIB)
@@ -121,14 +140,14 @@ install-host: $(CSREQ$(ISTAGE)_T_$(CFG_BUILD_TRIPLE)_H_$(CFG_BUILD_TRIPLE))
 	$(Q)$(call INSTALL,$(HB2),$(PHB),rustdoc$(X_$(CFG_BUILD_TRIPLE)))
 	$(Q)$(call INSTALL,$(HB2),$(PHB),rusti$(X_$(CFG_BUILD_TRIPLE)))
 	$(Q)$(call INSTALL,$(HB2),$(PHB),rust$(X_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(HL),$(PHL),$(STDLIB_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(HL),$(PHL),$(EXTRALIB_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(HL),$(PHL),$(LIBRUSTC_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(HL),$(PHL),$(LIBSYNTAX_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(HL),$(PHL),$(LIBRUSTI_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(HL),$(PHL),$(LIBRUST_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(HL),$(PHL),$(LIBRUSTPKG_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(HL),$(PHL),$(LIBRUSTDOC_GLOB_$(CFG_BUILD_TRIPLE)))
+	$(Q)$(call INSTALL_LIB,$(STDLIB_GLOB_$(CFG_BUILD_TRIPLE)))
+	$(Q)$(call INSTALL_LIB,$(EXTRALIB_GLOB_$(CFG_BUILD_TRIPLE)))
+	$(Q)$(call INSTALL_LIB,$(LIBRUSTC_GLOB_$(CFG_BUILD_TRIPLE)))
+	$(Q)$(call INSTALL_LIB,$(LIBSYNTAX_GLOB_$(CFG_BUILD_TRIPLE)))
+	$(Q)$(call INSTALL_LIB,$(LIBRUSTI_GLOB_$(CFG_BUILD_TRIPLE)))
+	$(Q)$(call INSTALL_LIB,$(LIBRUST_GLOB_$(CFG_BUILD_TRIPLE)))
+	$(Q)$(call INSTALL_LIB,$(LIBRUSTPKG_GLOB_$(CFG_BUILD_TRIPLE)))
+	$(Q)$(call INSTALL_LIB,$(LIBRUSTDOC_GLOB_$(CFG_BUILD_TRIPLE)))
 	$(Q)$(call INSTALL,$(HL),$(PHL),$(CFG_RUNTIME_$(CFG_BUILD_TRIPLE)))
 	$(Q)$(call INSTALL,$(HL),$(PHL),$(CFG_RUSTLLVM_$(CFG_BUILD_TRIPLE)))
 	$(Q)$(call INSTALL,$(S)/man, \

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -81,25 +81,25 @@ $$(HLIB0_H_$(1))/$(CFG_STDLIB_$(1)): \
 		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_STDLIB_$(1)) \
 		| $(HLIB0_H_$(1))/
 	@$$(call E, cp: $$@)
-	$$(call CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
+	$$(call CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(EXTRALIB_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$(TLIB$(2)_T_$(1)_H_$(3))/$(STDLIB_GLOB_$(1)) $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(EXTRALIB_GLOB_$(4)),$$(notdir $$@))
 
 $$(HLIB0_H_$(1))/$(CFG_EXTRALIB_$(1)): \
 		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_EXTRALIB_$(1)) \
 		| $(HLIB0_H_$(1))/
 	@$$(call E, cp: $$@)
-	$$(call CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
+	$$(call CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(EXTRALIB_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$(TLIB$(2)_T_$(1)_H_$(3))/$(EXTRALIB_GLOB_$(1)) $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(EXTRALIB_GLOB_$(4)),$$(notdir $$@))
 
 $$(HLIB0_H_$(1))/$(CFG_LIBRUSTC_$(1)): \
 		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_LIBRUSTC_$(1)) \
 		| $(HLIB0_H_$(1))/
 	@$$(call E, cp: $$@)
-	$$(call CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(4)), `basename $$@`)
+	$$(call CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTC_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$(TLIB$(2)_T_$(1)_H_$(3))/$(LIBRUSTC_GLOB_$(1)) $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTC_GLOB_$(4)),$$(notdir $$@))
 
 $$(HLIB0_H_$(1))/$(CFG_RUSTLLVM_$(1)): \
 		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_RUSTLLVM_$(1)) \

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -1,10 +1,16 @@
 # Extract the snapshot host compiler
 
+$(HBIN0_H_$(CFG_BUILD_TRIPLE))/:
+	mkdir -p $@
 
+$(HLIB0_H_$(CFG_BUILD_TRIPLE))/:
+	mkdir -p $@
 
 $(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)):		\
 		$(S)src/snapshots.txt					\
-		$(S)src/etc/get-snapshot.py $(MKFILE_DEPS)
+		$(S)src/etc/get-snapshot.py $(MKFILE_DEPS)		\
+		| $(HBIN0_H_$(CFG_BUILD_TRIPLE))/
+
 	@$(call E, fetch: $@)
 #   Note: the variable "SNAPSHOT_FILE" is generally not set, and so
 #   we generally only pass one argument to this script.
@@ -22,23 +28,28 @@ endif
 # Host libs will be extracted by the above rule
 
 $(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_RUNTIME_$(CFG_BUILD_TRIPLE)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE))
+		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)) \
+		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
 	$(Q)touch $@
 
 $(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_STDLIB_$(CFG_BUILD_TRIPLE)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE))
+		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)) \
+		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
 	$(Q)touch $@
 
 $(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_EXTRALIB_$(CFG_BUILD_TRIPLE)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE))
+		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)) \
+		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
 	$(Q)touch $@
 
 $(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_LIBRUSTC_$(CFG_BUILD_TRIPLE)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE))
+		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)) \
+		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
 	$(Q)touch $@
 
 $(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_RUSTLLVM_$(CFG_BUILD_TRIPLE)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE))
+		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)) \
+		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
 	$(Q)touch $@
 
 # For other targets, let the host build the target:
@@ -48,33 +59,51 @@ define BOOTSTRAP_STAGE0
   # $(2) stage to bootstrap from
   # $(3) target to bootstrap from
 
-$$(HBIN0_H_$(1))/rustc$$(X_$(1)):								\
-		$$(TBIN$(2)_T_$(1)_H_$(3))/rustc$$(X_$(1))
+$(HBIN0_H_$(1))/:
+	mkdir -p $@
+
+$(HLIB0_H_$(1))/:
+	mkdir -p $@
+
+$$(HBIN0_H_$(1))/rustc$$(X_$(1)): \
+		$$(TBIN$(2)_T_$(1)_H_$(3))/rustc$$(X_$(1)) \
+		| $(HBIN0_H_$(1))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
 $$(HLIB0_H_$(1))/$(CFG_RUNTIME_$(1)): \
-		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_RUNTIME_$(1))
+		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_RUNTIME_$(1)) \
+		| $(HLIB0_H_$(1))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
 $$(HLIB0_H_$(1))/$(CFG_STDLIB_$(1)): \
-		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_STDLIB_$(1))
+		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_STDLIB_$(1)) \
+		| $(HLIB0_H_$(1))/
 	@$$(call E, cp: $$@)
+	$$(call CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$(TLIB$(2)_T_$(1)_H_$(3))/$(STDLIB_GLOB_$(1)) $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
 
 $$(HLIB0_H_$(1))/$(CFG_EXTRALIB_$(1)): \
-		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_EXTRALIB_$(1))
+		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_EXTRALIB_$(1)) \
+		| $(HLIB0_H_$(1))/
 	@$$(call E, cp: $$@)
+	$$(call CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$(TLIB$(2)_T_$(1)_H_$(3))/$(EXTRALIB_GLOB_$(1)) $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(4)), `basename $$@`)
 
 $$(HLIB0_H_$(1))/$(CFG_LIBRUSTC_$(1)): \
-		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_LIBRUSTC_$(1))
+		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_LIBRUSTC_$(1)) \
+		| $(HLIB0_H_$(1))/
 	@$$(call E, cp: $$@)
+	$$(call CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$(TLIB$(2)_T_$(1)_H_$(3))/$(LIBRUSTC_GLOB_$(1)) $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(4)), `basename $$@`)
 
 $$(HLIB0_H_$(1))/$(CFG_RUSTLLVM_$(1)): \
-		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_RUSTLLVM_$(1))
+		$$(TLIB$(2)_T_$(1)_H_$(3))/$(CFG_RUSTLLVM_$(1)) \
+		| $(HLIB0_H_$(1))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -48,9 +48,9 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_STDLIB_$(2)): \
 		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(STDLIB_GLOB_$(2)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(STDLIB_GLOB_$(2)),$$(notdir $$@))
 	$$(STAGE$(1)_T_$(2)_H_$(3)) $$(WFLAGS_ST$(1)) -o $$@ $$< && touch $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(STDLIB_GLOB_$(2)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(STDLIB_GLOB_$(2)),$$(notdir $$@))
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_EXTRALIB_$(2)): \
 		$$(EXTRALIB_CRATE) $$(EXTRALIB_INPUTS) \
@@ -58,9 +58,9 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_EXTRALIB_$(2)): \
 		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(2)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(EXTRALIB_GLOB_$(2)),$$(notdir $$@))
 	$$(STAGE$(1)_T_$(2)_H_$(3)) $$(WFLAGS_ST$(1)) -o $$@ $$< && touch $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(2)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(EXTRALIB_GLOB_$(2)),$$(notdir $$@))
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBSYNTAX_$(3)): \
                 $$(LIBSYNTAX_CRATE) $$(LIBSYNTAX_INPUTS) \
@@ -69,9 +69,9 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBSYNTAX_$(3)): \
 		$$(TEXTRALIB_DEFAULT$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBSYNTAX_GLOB_$(2)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBSYNTAX_GLOB_$(2)),$$(notdir $$@))
 	$$(STAGE$(1)_T_$(2)_H_$(3)) $(BORROWCK) -o $$@ $$< && touch $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBSYNTAX_GLOB_$(2)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBSYNTAX_GLOB_$(2)),$$(notdir $$@))
 
 # Only build the compiler for host triples
 ifneq ($$(findstring $(2),$$(CFG_HOST_TRIPLES)),)
@@ -89,9 +89,9 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBRUSTC_$(3)):		\
                 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_RUSTLLVM_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(2)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTC_GLOB_$(2)),$$(notdir $$@))
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< && touch $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(2)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTC_GLOB_$(2)),$$(notdir $$@))
 
 $$(TBIN$(1)_T_$(2)_H_$(3))/rustc$$(X_$(3)):			\
 		$$(DRIVER_CRATE)				\

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -48,7 +48,9 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_STDLIB_$(2)): \
 		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(STDLIB_GLOB_$(2)), `basename $$@`)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) $$(WFLAGS_ST$(1)) -o $$@ $$< && touch $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(STDLIB_GLOB_$(2)), `basename $$@`)
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_EXTRALIB_$(2)): \
 		$$(EXTRALIB_CRATE) $$(EXTRALIB_INPUTS) \
@@ -56,7 +58,9 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_EXTRALIB_$(2)): \
 		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(2)), `basename $$@`)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) $$(WFLAGS_ST$(1)) -o $$@ $$< && touch $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(EXTRALIB_GLOB_$(2)), `basename $$@`)
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBSYNTAX_$(3)): \
                 $$(LIBSYNTAX_CRATE) $$(LIBSYNTAX_INPUTS) \
@@ -65,7 +69,9 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBSYNTAX_$(3)): \
 		$$(TEXTRALIB_DEFAULT$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBSYNTAX_GLOB_$(2)), `basename $$@`)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) $(BORROWCK) -o $$@ $$< && touch $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBSYNTAX_GLOB_$(2)), `basename $$@`)
 
 # Only build the compiler for host triples
 ifneq ($$(findstring $(2),$$(CFG_HOST_TRIPLES)),)
@@ -83,7 +89,9 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBRUSTC_$(3)):		\
                 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_RUSTLLVM_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(2)), `basename $$@`)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< && touch $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTC_GLOB_$(2)), `basename $$@`)
 
 $$(TBIN$(1)_T_$(2)_H_$(3))/rustc$$(X_$(3)):			\
 		$$(DRIVER_CRATE)				\

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -37,72 +37,89 @@ define TOOLS_STAGE_N_TARGET
 
 $$(TBIN$(1)_T_$(4)_H_$(3))/compiletest$$(X_$(4)):			\
 		$$(COMPILETEST_CRATE) $$(COMPILETEST_INPUTS)	\
-		$$(TSREQ$(1)_T_$(4)_H_$(3))						\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))      \
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))
+		$$(TSREQ$(1)_T_$(4)_H_$(3))			\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))	\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
+		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) -o $$@ $$<
 
 $$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTPKG_$(4)):		\
-		$$(RUSTPKG_LIB) $$(RUSTPKG_INPUTS)		    \
-		$$(TSREQ$(1)_T_$(4)_H_$(3))					\
+		$$(RUSTPKG_LIB) $$(RUSTPKG_INPUTS)		\
+		$$(TSREQ$(1)_T_$(4)_H_$(3))			\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))	\
+		| $$(TLIB$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTPKG_GLOB_$(4)), `basename $$@`)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) $$(WFLAGS_ST$(1)) -o $$@ $$< && touch $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTPKG_GLOB_$(4)), `basename $$@`)
 
 $$(TBIN$(1)_T_$(4)_H_$(3))/rustpkg$$(X_$(4)):				\
-		$$(DRIVER_CRATE) 							\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTPKG_$(4))
+		$$(DRIVER_CRATE)					\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTPKG_$(4))	\
+		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) --cfg rustpkg -o $$@ $$<
 
 $$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTDOC_$(4)):		\
-		$$(RUSTDOC_LIB) $$(RUSTDOC_INPUTS)			\
-		$$(TSREQ$(1)_T_$(4)_H_$(3))					\
+		$$(RUSTDOC_LIB) $$(RUSTDOC_INPUTS)		\
+		$$(TSREQ$(1)_T_$(4)_H_$(3))			\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))	\
+		| $$(TLIB$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTDOC_GLOB_$(4)), `basename $$@`)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) -o $$@ $$< && touch $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTDOC_GLOB_$(4)), `basename $$@`)
 
-$$(TBIN$(1)_T_$(4)_H_$(3))/rustdoc$$(X_$(4)):			\
-		$$(DRIVER_CRATE) 							\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTDOC_$(4))
+$$(TBIN$(1)_T_$(4)_H_$(3))/rustdoc$$(X_$(4)):				\
+		$$(DRIVER_CRATE)					\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTDOC_$(4))	\
+		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) --cfg rustdoc -o $$@ $$<
 
 $$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTI_$(4)):		\
 		$$(RUSTI_LIB) $$(RUSTI_INPUTS)			\
-		$$(TSREQ$(1)_T_$(4)_H_$(3))					\
+		$$(TSREQ$(1)_T_$(4)_H_$(3))			\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))	\
+		| $$(TLIB$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTI_GLOB_$(4)), `basename $$@`)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) -o $$@ $$< && touch $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTI_GLOB_$(4)), `basename $$@`)
 
 $$(TBIN$(1)_T_$(4)_H_$(3))/rusti$$(X_$(4)):			\
-		$$(DRIVER_CRATE) 							\
-		$$(TLIB$(1)_T_$(4)_H_$(4))/$(CFG_LIBRUSTI_$(4))
+		$$(DRIVER_CRATE)				\
+		$$(TLIB$(1)_T_$(4)_H_$(4))/$(CFG_LIBRUSTI_$(4)) \
+		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) --cfg rusti -o $$@ $$<
 
-$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUST_$(4)):		\
-		$$(RUST_LIB) $$(RUST_INPUTS)			\
-		$$(TSREQ$(1)_T_$(4)_H_$(3))					\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))	\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
+$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUST_$(4)):				\
+		$$(RUST_LIB) $$(RUST_INPUTS)				\
+		$$(TSREQ$(1)_T_$(4)_H_$(3))				\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))		\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))		\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTPKG_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTI_$(4))		\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTDOC_$(4))	\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))		\
+		| $$(TLIB$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUST_GLOB_$(4)), `basename $$@`)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) -o $$@ $$< && touch $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUST_GLOB_$(4)), `basename $$@`)
 
 $$(TBIN$(1)_T_$(4)_H_$(3))/rust$$(X_$(4)):			\
-		$$(DRIVER_CRATE) 							\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUST_$(4))
+		$$(DRIVER_CRATE)				\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUST_$(4))	\
+		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) --cfg rust -o $$@ $$<
 
@@ -112,7 +129,8 @@ define TOOLS_STAGE_N_HOST
 
 $$(HBIN$(2)_H_$(4))/compiletest$$(X_$(4)):				\
 		$$(TBIN$(1)_T_$(4)_H_$(3))/compiletest$$(X_$(4))	\
-		$$(HSREQ$(2)_H_$(4))
+		$$(HSREQ$(2)_H_$(4))	\
+		| $$(HBIN$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
@@ -120,9 +138,12 @@ $$(HBIN$(2)_H_$(4))/compiletest$$(X_$(4)):				\
 $$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTPKG_$(4)):				\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTPKG_$(4))	\
 		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))		\
-		$$(HSREQ$(2)_H_$(4))
+		$$(HSREQ$(2)_H_$(4))					\
+		| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTPKG_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$< $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTPKG_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTPKG_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTPKG_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
@@ -130,16 +151,20 @@ $$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTPKG_$(4)):				\
 $$(HBIN$(2)_H_$(4))/rustpkg$$(X_$(4)):				\
 		$$(TBIN$(1)_T_$(4)_H_$(3))/rustpkg$$(X_$(4))	\
 		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTPKG_$(4))	\
-		$$(HSREQ$(2)_H_$(4))
+		$$(HSREQ$(2)_H_$(4))				\
+			| $$(HBIN$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
-$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTDOC_$(4)):					\
+$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTDOC_$(4)):				\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTDOC_$(4))	\
-		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))			\
-		$$(HSREQ$(2)_H_$(4))
+		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))		\
+		$$(HSREQ$(2)_H_$(4))					\
+		| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTDOC_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$< $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTDOC_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTDOC_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTDOC_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
@@ -147,16 +172,20 @@ $$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTDOC_$(4)):					\
 $$(HBIN$(2)_H_$(4))/rustdoc$$(X_$(4)):				\
 		$$(TBIN$(1)_T_$(4)_H_$(3))/rustdoc$$(X_$(4))	\
 		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTDOC_$(4))	\
-		$$(HSREQ$(2)_H_$(4))
+		$$(HSREQ$(2)_H_$(4))				\
+		| $$(HBIN$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
-$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTI_$(4)):					\
+$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTI_$(4)):			\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTI_$(4))	\
-		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))			\
-		$$(HSREQ$(2)_H_$(4))
+		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))	\
+		$$(HSREQ$(2)_H_$(4))				\
+		| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTI_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$< $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTI_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTI_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTI_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
@@ -164,24 +193,29 @@ $$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTI_$(4)):					\
 $$(HBIN$(2)_H_$(4))/rusti$$(X_$(4)):				\
 		$$(TBIN$(1)_T_$(4)_H_$(3))/rusti$$(X_$(4))	\
 		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTI_$(4))	\
-		$$(HSREQ$(2)_H_$(4))
+		$$(HSREQ$(2)_H_$(4))				\
+		| $$(HBIN$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
-$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUST_$(4)):					\
+$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUST_$(4)):			\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUST_$(4))	\
-		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))			\
-		$$(HSREQ$(2)_H_$(4))
+		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))	\
+		$$(HSREQ$(2)_H_$(4))				\
+		| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUST_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp $$< $$@
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUST_GLOB_$(4)), `basename $$@`)
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUST_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUST_DSYM_GLOB)_$(4)) \
 	        $$(HLIB$(2)_H_$(4))
 
 $$(HBIN$(2)_H_$(4))/rust$$(X_$(4)):				\
 		$$(TBIN$(1)_T_$(4)_H_$(3))/rust$$(X_$(4))	\
-		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUST_$(4))	\
-		$$(HSREQ$(2)_H_$(4))
+		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUST_$(4))		\
+		$$(HSREQ$(2)_H_$(4))				\
+		| $$(HBIN$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -37,88 +37,88 @@ define TOOLS_STAGE_N_TARGET
 
 $$(TBIN$(1)_T_$(4)_H_$(3))/compiletest$$(X_$(4)):			\
 		$$(COMPILETEST_CRATE) $$(COMPILETEST_INPUTS)	\
-		$$(TSREQ$(1)_T_$(4)_H_$(3))			\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))	\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
+		$$(TSREQ$(1)_T_$(4)_H_$(3))						\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))      \
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))    \
 		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) -o $$@ $$<
 
 $$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTPKG_$(4)):		\
-		$$(RUSTPKG_LIB) $$(RUSTPKG_INPUTS)		\
-		$$(TSREQ$(1)_T_$(4)_H_$(3))			\
+		$$(RUSTPKG_LIB) $$(RUSTPKG_INPUTS)		    \
+		$$(TSREQ$(1)_T_$(4)_H_$(3))					\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))	\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4)) \
 		| $$(TLIB$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTPKG_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTPKG_GLOB_$(4)),$$(notdir $$@))
 	$$(STAGE$(1)_T_$(4)_H_$(3)) $$(WFLAGS_ST$(1)) -o $$@ $$< && touch $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTPKG_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTPKG_GLOB_$(4)),$$(notdir $$@))
 
 $$(TBIN$(1)_T_$(4)_H_$(3))/rustpkg$$(X_$(4)):				\
-		$$(DRIVER_CRATE)					\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTPKG_$(4))	\
+		$$(DRIVER_CRATE) 							\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTPKG_$(4)) \
 		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) --cfg rustpkg -o $$@ $$<
 
 $$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTDOC_$(4)):		\
-		$$(RUSTDOC_LIB) $$(RUSTDOC_INPUTS)		\
-		$$(TSREQ$(1)_T_$(4)_H_$(3))			\
+		$$(RUSTDOC_LIB) $$(RUSTDOC_INPUTS)			\
+		$$(TSREQ$(1)_T_$(4)_H_$(3))					\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))	\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4)) \
 		| $$(TLIB$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTDOC_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTDOC_GLOB_$(4)),$$(notdir $$@))
 	$$(STAGE$(1)_T_$(4)_H_$(3)) -o $$@ $$< && touch $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTDOC_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTDOC_GLOB_$(4)),$$(notdir $$@))
 
-$$(TBIN$(1)_T_$(4)_H_$(3))/rustdoc$$(X_$(4)):				\
-		$$(DRIVER_CRATE)					\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTDOC_$(4))	\
+$$(TBIN$(1)_T_$(4)_H_$(3))/rustdoc$$(X_$(4)):			\
+		$$(DRIVER_CRATE) 							\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTDOC_$(4))			\
 		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) --cfg rustdoc -o $$@ $$<
 
 $$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTI_$(4)):		\
 		$$(RUSTI_LIB) $$(RUSTI_INPUTS)			\
-		$$(TSREQ$(1)_T_$(4)_H_$(3))			\
+		$$(TSREQ$(1)_T_$(4)_H_$(3))					\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))	\
 		| $$(TLIB$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTI_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTI_GLOB_$(4)),$$(notdir $$@))
 	$$(STAGE$(1)_T_$(4)_H_$(3)) -o $$@ $$< && touch $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTI_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTI_GLOB_$(4)),$$(notdir $$@))
 
 $$(TBIN$(1)_T_$(4)_H_$(3))/rusti$$(X_$(4)):			\
-		$$(DRIVER_CRATE)				\
+		$$(DRIVER_CRATE) 							\
 		$$(TLIB$(1)_T_$(4)_H_$(4))/$(CFG_LIBRUSTI_$(4)) \
 		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) --cfg rusti -o $$@ $$<
 
-$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUST_$(4)):				\
-		$$(RUST_LIB) $$(RUST_INPUTS)				\
-		$$(TSREQ$(1)_T_$(4)_H_$(3))				\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))		\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))		\
+$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUST_$(4)):		\
+		$$(RUST_LIB) $$(RUST_INPUTS)			\
+		$$(TSREQ$(1)_T_$(4)_H_$(3))					\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_STDLIB_$(4))	\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_EXTRALIB_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTPKG_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTI_$(4))		\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTDOC_$(4))	\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTC_$(4))		\
 		| $$(TLIB$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUST_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUST_GLOB_$(4)),$$(notdir $$@))
 	$$(STAGE$(1)_T_$(4)_H_$(3)) -o $$@ $$< && touch $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUST_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUST_GLOB_$(4)),$$(notdir $$@))
 
 $$(TBIN$(1)_T_$(4)_H_$(3))/rust$$(X_$(4)):			\
-		$$(DRIVER_CRATE)				\
-		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUST_$(4))	\
+		$$(DRIVER_CRATE) 							\
+		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUST_$(4)) \
 		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(4)_H_$(3)) --cfg rust -o $$@ $$<
@@ -129,7 +129,7 @@ define TOOLS_STAGE_N_HOST
 
 $$(HBIN$(2)_H_$(4))/compiletest$$(X_$(4)):				\
 		$$(TBIN$(1)_T_$(4)_H_$(3))/compiletest$$(X_$(4))	\
-		$$(HSREQ$(2)_H_$(4))	\
+		$$(HSREQ$(2)_H_$(4))					\
 		| $$(HBIN$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
@@ -141,9 +141,9 @@ $$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTPKG_$(4)):				\
 		$$(HSREQ$(2)_H_$(4))					\
 		| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTPKG_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTPKG_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$< $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTPKG_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTPKG_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTPKG_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTPKG_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
@@ -152,19 +152,19 @@ $$(HBIN$(2)_H_$(4))/rustpkg$$(X_$(4)):				\
 		$$(TBIN$(1)_T_$(4)_H_$(3))/rustpkg$$(X_$(4))	\
 		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTPKG_$(4))	\
 		$$(HSREQ$(2)_H_$(4))				\
-			| $$(HBIN$(2)_H_$(4))/
+		| $$(HBIN$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
-$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTDOC_$(4)):				\
+$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTDOC_$(4)):					\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTDOC_$(4))	\
-		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))		\
-		$$(HSREQ$(2)_H_$(4))					\
+		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))			\
+		$$(HSREQ$(2)_H_$(4)) \
 		| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTDOC_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTDOC_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$< $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTDOC_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTDOC_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTDOC_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTDOC_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
@@ -177,15 +177,15 @@ $$(HBIN$(2)_H_$(4))/rustdoc$$(X_$(4)):				\
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
-$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTI_$(4)):			\
+$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTI_$(4)):					\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUSTI_$(4))	\
-		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))	\
-		$$(HSREQ$(2)_H_$(4))				\
+		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))			\
+		$$(HSREQ$(2)_H_$(4)) \
 		| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTI_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTI_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$< $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUSTI_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUSTI_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTI_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUSTI_DSYM_GLOB_$(4))) \
 	        $$(HLIB$(2)_H_$(4))
@@ -198,22 +198,22 @@ $$(HBIN$(2)_H_$(4))/rusti$$(X_$(4)):				\
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
-$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUST_$(4)):			\
+$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUST_$(4)):					\
 		$$(TLIB$(1)_T_$(4)_H_$(3))/$(CFG_LIBRUST_$(4))	\
 		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUSTC_$(4))	\
 		$$(HSREQ$(2)_H_$(4))				\
 		| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$@)
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUST_GLOB_$(4)), `basename $$@`)
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUST_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp $$< $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT, `dirname $$@`, $(LIBRUST_GLOB_$(4)), `basename $$@`)
+	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBRUST_GLOB_$(4)),$$(notdir $$@))
 	$$(Q)cp -R $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUST_GLOB_$(4)) \
 		$$(wildcard $$(TLIB$(1)_T_$(4)_H_$(3))/$(LIBRUST_DSYM_GLOB)_$(4)) \
 	        $$(HLIB$(2)_H_$(4))
 
 $$(HBIN$(2)_H_$(4))/rust$$(X_$(4)):				\
 		$$(TBIN$(1)_T_$(4)_H_$(3))/rust$$(X_$(4))	\
-		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUST_$(4))		\
+		$$(HLIB$(2)_H_$(4))/$(CFG_LIBRUST_$(4))	\
 		$$(HSREQ$(2)_H_$(4))				\
 		| $$(HBIN$(2)_H_$(4))/
 	@$$(call E, cp: $$@)

--- a/src/etc/get-snapshot.py
+++ b/src/etc/get-snapshot.py
@@ -8,9 +8,20 @@ def unpack_snapshot(triple, dl_path):
   print("opening snapshot " + dl_path)
   tar = tarfile.open(dl_path)
   kernel = get_kernel(triple)
+
+  stagep = os.path.join(triple, "stage0")
+
+  # Remove files from prior unpackings, since snapshot rustc may not
+  # be able to disambiguate between multiple candidate libraries.
+  # (Leave dirs in place since extracting step still needs them.)
+  for root, _, files in os.walk(stagep):
+    for f in files:
+      print("removing " + os.path.join(root, f))
+      os.unlink(os.path.join(root, f))
+
   for p in tar.getnames():
     name = p.replace("rust-stage0/", "", 1);
-    stagep = os.path.join(triple, "stage0")
+
     fp = os.path.join(stagep, name)
     print("extracting " + p)
     tar.extract(p, download_unpack_base)


### PR DESCRIPTION
When building Rust libraries (e.g. librustc, libstd, etc), checks for
and verbosely removes previous build products before invoking rustc.
(Also, when Make variable VERBOSE is defined, it will list all of the
libraries matching the object library's glob after the rustc
invocation has completed.)

When installing Rust libraries, checks for previous libraries in
target install directory, but does not remove them.

The thinking behind these two different modes of operation is that the
installation target, unlike the build tree, is not under the control
of this infrastructure and it is not up to this Makefile to decide if
the previous libraries should be removed.

Fixes #3225 (at least in terms of mitigating the multiple library
problem by proactively warning the user about it.)
