### PR TITLE
Highlight rustc's warning/errors in bright-white, similar to Clang

### DIFF
--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -213,7 +213,7 @@ fn print_diagnostic(topic: &str, lvl: level, msg: &str) {
     }
 
     print_maybe_colored(fmt!("%s: ", diagnosticstr(lvl)), diagnosticcolor(lvl));
-    stderr.write_str(fmt!("%s\n", msg));
+    print_maybe_colored(fmt!("%s\n", msg), term::color::BRIGHT_WHITE);
 }
 
 pub fn collect(messages: @mut ~[~str])


### PR DESCRIPTION
Currently on Mac OS X this is shown rather in light-gray though. Maybe a bug in term.rs?
Ping @cmr
