### PR TITLE
Fix accidental enum bloat in the AST

### DIFF
--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -421,7 +421,7 @@ fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: &Test) -> @ast::expr {
           span: span
     };
 
-    let fn_path = path_node_global(path);
+    let fn_path = ~path_node_global(path);
 
     let fn_expr = @ast::expr {
         id: cx.sess.next_node_id(),

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1014,7 +1014,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_name(ecx, ebml_w, item.ident);
         encode_attributes(ebml_w, item.attrs);
         match ty.node {
-            ast::ty_path(ref path, ref bounds, _) if path.idents.len() == 1 => {
+            ast::ty_path(~ref path, ref bounds, _) if path.idents.len() == 1 => {
                 assert!(bounds.is_none());
                 encode_impl_type_basename(ecx, ebml_w,
                                           ast_util::path_to_ident(path));

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -449,7 +449,7 @@ pub fn check_crate<'mm>(tcx: ty::ctxt,
                         _ => {}
                     }
                 }
-                expr_path(ref path) => {
+                expr_path(~ref path) => {
                     check_path(expr.span, tcx.def_map.get_copy(&expr.id), path);
                 }
                 expr_struct(_, ref fields, _) => {

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -68,7 +68,7 @@ fn ty_method_might_be_inlined(ty_method: &ty_method) -> bool {
 // monomorphized or it was marked with `#[inline]`.
 fn trait_method_might_be_inlined(trait_method: &trait_method) -> bool {
     match *trait_method {
-        required(ref ty_method) => ty_method_might_be_inlined(ty_method),
+        required(~ref ty_method) => ty_method_might_be_inlined(ty_method),
         provided(_) => true
     }
 }

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -815,8 +815,8 @@ fn determine_rp_in_ty(ty: &ast::Ty,
     }
 
     match ty.node {
-      ast::ty_box(ref mt) | ast::ty_uniq(ref mt) | ast::ty_vec(ref mt) |
-      ast::ty_rptr(_, ref mt) | ast::ty_ptr(ref mt) => {
+      ast::ty_box(~ref mt) | ast::ty_uniq(~ref mt) | ast::ty_vec(~ref mt) |
+      ast::ty_rptr(_, ~ref mt) | ast::ty_ptr(~ref mt) => {
         visit_mt(mt, (cx, visitor));
       }
 
@@ -855,10 +855,10 @@ fn determine_rp_in_ty(ty: &ast::Ty,
         // mutability is invariant
         if mt.mutbl == ast::m_mutbl {
             do cx.with_ambient_variance(rv_invariant) {
-                (visitor.visit_ty)(mt.ty, (cx, visitor));
+                (visitor.visit_ty)(&mt.ty, (cx, visitor));
             }
         } else {
-            (visitor.visit_ty)(mt.ty, (cx, visitor));
+            (visitor.visit_ty)(&mt.ty, (cx, visitor));
         }
     }
 }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1245,7 +1245,7 @@ impl Resolver {
                 // Create the module and add all methods.
                 match ty {
                     &Ty {
-                        node: ty_path(ref path, _, _),
+                        node: ty_path(~ref path, _, _),
                         _
                     } if path.idents.len() == 1 => {
                         let name = path_to_ident(path);
@@ -3640,7 +3640,7 @@ impl Resolver {
                 }
             }
 
-            item_fn(ref fn_decl, _, _, ref generics, ref block) => {
+            item_fn(~ref fn_decl, _, _, ref generics, ref block) => {
                 self.resolve_function(OpaqueFunctionRibKind,
                                       Some(fn_decl),
                                       HasTypeParameters
@@ -3811,7 +3811,7 @@ impl Resolver {
                                         type_parameter_bound: &TyParamBound,
                                         visitor: ResolveVisitor) {
         match *type_parameter_bound {
-            TraitTyParamBound(ref tref) => {
+            TraitTyParamBound(~ref tref) => {
                 self.resolve_trait_reference(tref, visitor, TraitBoundingTypeParameter)
             }
             RegionTyParamBound => {}
@@ -4117,7 +4117,7 @@ impl Resolver {
             // Like path expressions, the interpretation of path types depends
             // on whether the path has multiple elements in it or not.
 
-            ty_path(ref path, ref bounds, path_id) => {
+            ty_path(~ref path, ref bounds, path_id) => {
                 // This is a path in the type namespace. Walk through scopes
                 // scopes looking for it.
                 let mut result_def = None;
@@ -4916,7 +4916,7 @@ impl Resolver {
             // The interpretation of paths depends on whether the path has
             // multiple elements in it or not.
 
-            expr_path(ref path) => {
+            expr_path(~ref path) => {
                 // This is a local path in the value namespace. Walk through
                 // scopes looking for it.
 
@@ -4976,7 +4976,7 @@ impl Resolver {
                 visit_expr(expr, ((), visitor));
             }
 
-            expr_fn_block(ref fn_decl, ref block) => {
+            expr_fn_block(~ref fn_decl, ref block) => {
                 self.resolve_function(FunctionRibKind(expr.id, block.node.id),
                                       Some(fn_decl),
                                       NoTypeParameters,
@@ -4985,7 +4985,7 @@ impl Resolver {
                                       visitor);
             }
 
-            expr_struct(ref path, _, _) => {
+            expr_struct(~ref path, _, _) => {
                 // Resolve the path to the structure it goes to.
                 match self.resolve_path(path, TypeNS, false, visitor) {
                     Some(def_ty(class_id)) | Some(def_struct(class_id))

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2130,7 +2130,7 @@ pub fn trans_item(ccx: @mut CrateContext, item: &ast::item) {
         _ => fail!("trans_item"),
     };
     match item.node {
-      ast::item_fn(ref decl, purity, _abis, ref generics, ref body) => {
+      ast::item_fn(~ref decl, purity, _abis, ref generics, ref body) => {
         if purity == ast::extern_fn  {
             let llfndecl = get_item_val(ccx, item.id);
             foreign::trans_foreign_fn(ccx,

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -825,7 +825,7 @@ pub fn trans_arg_expr(bcx: block,
             match arg_expr.node {
                 ast::expr_loop_body(
                     blk @ @ast::expr {
-                        node: ast::expr_fn_block(ref decl, ref body),
+                        node: ast::expr_fn_block(~ref decl, ref body),
                         _
                     }) => {
                     let scratch_ty = expr_ty(bcx, arg_expr);

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -263,7 +263,7 @@ pub fn create_function(fcx: fn_ctxt) -> DISubprogram {
     let (ident, ret_ty, id) = match fnitem {
       ast_map::node_item(ref item, _) => {
         match item.node {
-          ast::item_fn(ast::fn_decl { output: ref ty, _}, _, _, _, _) => {
+          ast::item_fn(~ast::fn_decl { output: ref ty, _}, _, _, _, _) => {
             (item.ident, ty, item.id)
           }
           _ => fcx.ccx.sess.span_bug(item.span, "create_function: item bound to non-function")

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -602,7 +602,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
         ast::expr_vec(*) | ast::expr_repeat(*) => {
             return tvec::trans_fixed_vstore(bcx, expr, expr, dest);
         }
-        ast::expr_fn_block(ref decl, ref body) => {
+        ast::expr_fn_block(~ref decl, ref body) => {
             let expr_ty = expr_ty(bcx, expr);
             let sigil = ty::ty_closure_sigil(expr_ty);
             debug!("translating fn_block %s with type %s",
@@ -616,7 +616,7 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
             let expr_ty = expr_ty(bcx, expr);
             let sigil = ty::ty_closure_sigil(expr_ty);
             match blk.node {
-                ast::expr_fn_block(ref decl, ref body) => {
+                ast::expr_fn_block(~ref decl, ref body) => {
                     return closure::trans_expr_fn(bcx,
                                                   sigil,
                                                   decl,

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -183,7 +183,7 @@ pub fn monomorphic_fn(ccx: @mut CrateContext,
 
     let lldecl = match map_node {
       ast_map::node_item(i@@ast::item {
-                node: ast::item_fn(ref decl, _, _, _, ref body),
+                node: ast::item_fn(~ref decl, _, _, _, ref body),
                 _
             }, _) => {
         let d = mk_lldecl();

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -595,7 +595,7 @@ pub fn check_item(ccx: @mut CrateCtxt, it: @ast::item) {
                             enum_definition.variants,
                             it.id);
       }
-      ast::item_fn(ref decl, _, _, _, ref body) => {
+      ast::item_fn(~ref decl, _, _, _, ref body) => {
         check_bare_fn(ccx, decl, body, it.id, None);
       }
       ast::item_impl(_, _, _, ref ms) => {
@@ -2171,7 +2171,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         };
 
         match loop_body.node {
-            ast::expr_fn_block(ref decl, ref body) => {
+            ast::expr_fn_block(~ref decl, ref body) => {
                 // If an error occurred, we pretend this isn't a for
                 // loop, so as to assign types to all nodes while also
                 // propagating ty_err throughout so as to suppress
@@ -2436,7 +2436,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         };
         fcx.write_ty(id, oprnd_t);
       }
-      ast::expr_path(ref pth) => {
+      ast::expr_path(~ref pth) => {
         let defn = lookup_def(fcx, pth.span, id);
 
         let tpt = ty_param_bounds_and_ty_for_def(fcx, expr.span, defn);
@@ -2546,7 +2546,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
       ast::expr_match(discrim, ref arms) => {
         _match::check_match(fcx, expr, discrim, *arms);
       }
-      ast::expr_fn_block(ref decl, ref body) => {
+      ast::expr_fn_block(~ref decl, ref body) => {
         check_expr_fn(fcx, expr, None,
                       decl, body, Vanilla, expected);
       }
@@ -2576,7 +2576,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
             }
         };
         match b.node {
-          ast::expr_fn_block(ref decl, ref body) => {
+          ast::expr_fn_block(~ref decl, ref body) => {
             check_expr_fn(fcx, b, None,
                           decl, body, DoBlock, Some(inner_ty));
             demand::suptype(fcx, b.span, inner_ty, fcx.expr_ty(b));
@@ -2621,7 +2621,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
             fcx.write_bot(id);
         }
       }
-      ast::expr_cast(e, ref t) => {
+      ast::expr_cast(e, ~ref t) => {
         check_expr(fcx, e);
         let t_1 = fcx.to_ty(t);
         let t_e = fcx.expr_ty(e);

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -1031,13 +1031,13 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::item)
     }
     let rp = tcx.region_paramd_items.find(&it.id).map_consume(|x| *x);
     match it.node {
-      ast::item_static(ref t, _, _) => {
+      ast::item_static(~ref t, _, _) => {
         let typ = ccx.to_ty(&empty_rscope, t);
         let tpt = no_params(typ);
         tcx.tcache.insert(local_def(it.id), tpt);
         return tpt;
       }
-      ast::item_fn(ref decl, purity, _, ref generics, _) => {
+      ast::item_fn(~ref decl, purity, _, ref generics, _) => {
         assert!(rp.is_none());
         let ty_generics = ty_generics(ccx, None, generics, 0);
         let tofd = astconv::ty_of_bare_fn(ccx,
@@ -1184,7 +1184,7 @@ pub fn ty_generics(ccx: &CrateCtxt,
         };
         for ast_bounds.iter().advance |ast_bound| {
             match *ast_bound {
-                TraitTyParamBound(ref b) => {
+                TraitTyParamBound(~ref b) => {
                     let ty = ty::mk_param(ccx.tcx, param_ty.idx, param_ty.def_id);
                     let trait_ref = instantiate_trait_ref(ccx, b, rp, generics, ty);
                     if !astconv::try_add_builtin_trait(

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -68,7 +68,7 @@ fn get_fn_sig(srv: astsrv::Srv, fn_id: doc::AstId) -> Option<~str> {
         match ctxt.ast_map.get_copy(&fn_id) {
             ast_map::node_item(@ast::item {
                 ident: ident,
-                node: ast::item_fn(ref decl, purity, _, ref tys, _), _
+                node: ast::item_fn(~ref decl, purity, _, ref tys, _), _
             }, _) |
             ast_map::node_foreign_item(@ast::foreign_item {
                 ident: ident,
@@ -94,7 +94,7 @@ fn fold_const(
             do astsrv::exec(srv) |ctxt| {
                 match ctxt.ast_map.get_copy(&doc.id()) {
                     ast_map::node_item(@ast::item {
-                        node: ast::item_static(ref ty, _, _), _
+                        node: ast::item_static(~ref ty, _, _), _
                     }, _) => {
                         pprust::ty_to_str(ty, extract::interner())
                     }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -132,7 +132,7 @@ pub static crate_node_id: node_id = 0;
 // the "special" built-in traits (see middle::lang_items) and
 // detects Copy, Send, Send, and Freeze.
 pub enum TyParamBound {
-    TraitTyParamBound(trait_ref),
+    TraitTyParamBound(~trait_ref),
     RegionTyParamBound
 }
 
@@ -434,7 +434,7 @@ pub enum expr_ {
     expr_binary(node_id, binop, @expr, @expr),
     expr_unary(node_id, unop, @expr),
     expr_lit(@lit),
-    expr_cast(@expr, Ty),
+    expr_cast(@expr, ~Ty),
     expr_if(@expr, blk, Option<@expr>),
     expr_while(@expr, blk),
     /* Conditionless loop (can be exited with break, cont, or ret)
@@ -442,7 +442,7 @@ pub enum expr_ {
        (implicit) condition is always true. */
     expr_loop(blk, Option<ident>),
     expr_match(@expr, ~[arm]),
-    expr_fn_block(fn_decl, blk),
+    expr_fn_block(~fn_decl, blk),
     // Inner expr is always an expr_fn_block. We need the wrapping node to
     // easily type this (a function returning nil on the inside but bool on
     // the outside).
@@ -456,7 +456,7 @@ pub enum expr_ {
     expr_assign_op(node_id, binop, @expr, @expr),
     expr_field(@expr, ident, ~[Ty]),
     expr_index(node_id, @expr, @expr),
-    expr_path(Path),
+    expr_path(~Path),
 
     /// The special identifier `self`.
     expr_self,
@@ -471,7 +471,7 @@ pub enum expr_ {
     expr_mac(mac),
 
     // A struct literal expression.
-    expr_struct(Path, ~[field], Option<@expr>),
+    expr_struct(~Path, ~[field], Option<@expr>),
 
     // A vector literal constructed from one repeated element.
     expr_repeat(@expr /* element */, @expr /* count */, mutability),
@@ -583,7 +583,7 @@ pub type mac = spanned<mac_>;
 
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub enum mac_ {
-    mac_invoc_tt(Path,~[token_tree]),   // new macro-invocation
+    mac_invoc_tt(~Path,~[token_tree]),   // new macro-invocation
 }
 
 pub type lit = spanned<lit_>;
@@ -604,7 +604,7 @@ pub enum lit_ {
 // type structure in middle/ty.rs as well.
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub struct mt {
-    ty: ~Ty,
+    ty: Ty,
     mutbl: mutability,
 }
 
@@ -633,7 +633,7 @@ pub struct ty_method {
 // implementation, just a signature) or provided (meaning it has a default
 // implementation).
 pub enum trait_method {
-    required(ty_method),
+    required(~ty_method),
     provided(@method),
 }
 
@@ -725,16 +725,16 @@ pub struct TyBareFn {
 pub enum ty_ {
     ty_nil,
     ty_bot, /* bottom type */
-    ty_box(mt),
-    ty_uniq(mt),
-    ty_vec(mt),
-    ty_fixed_length_vec(mt, @expr),
-    ty_ptr(mt),
-    ty_rptr(Option<Lifetime>, mt),
+    ty_box(~mt),
+    ty_uniq(~mt),
+    ty_vec(~mt),
+    ty_fixed_length_vec(~mt, @expr),
+    ty_ptr(~mt),
+    ty_rptr(Option<Lifetime>, ~mt),
     ty_closure(@TyClosure),
     ty_bare_fn(@TyBareFn),
     ty_tup(~[Ty]),
-    ty_path(Path, Option<OptVec<TyParamBound>>, node_id), // for #7264; see above
+    ty_path(~Path, Option<OptVec<TyParamBound>>, node_id), // for #7264; see above
     ty_mac(mac),
     // ty_infer means the type should be inferred instead of it having been
     // specified. This should only appear at the "top level" of a type and not
@@ -995,8 +995,8 @@ pub struct item {
 
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub enum item_ {
-    item_static(Ty, mutability, @expr),
-    item_fn(fn_decl, purity, AbiSet, Generics, blk),
+    item_static(~Ty, mutability, @expr),
+    item_fn(~fn_decl, purity, AbiSet, Generics, blk),
     item_mod(_mod),
     item_foreign_mod(foreign_mod),
     item_ty(Ty, Generics),

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -250,7 +250,7 @@ pub fn public_methods(ms: ~[@method]) -> ~[@method] {
 // a default, pull out the useful fields to make a ty_method
 pub fn trait_method_to_ty_method(method: &trait_method) -> ty_method {
     match *method {
-        required(ref m) => copy *m,
+        required(~ref m) => copy *m,
         provided(ref m) => {
             ty_method {
                 ident: m.ident,
@@ -272,7 +272,7 @@ pub fn split_trait_methods(trait_methods: &[trait_method])
     let mut provd = ~[];
     for trait_methods.iter().advance |trt_method| {
         match *trt_method {
-          required(ref tm) => reqd.push(copy *tm),
+          required(~ref tm) => reqd.push(copy *tm),
           provided(m) => provd.push(m)
         }
     };

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -251,7 +251,7 @@ impl AstBuilder for @ExtCtxt {
 
     fn ty_mt(&self, ty: ast::Ty, mutbl: ast::mutability) -> ast::mt {
         ast::mt {
-            ty: ~ty,
+            ty: ty,
             mutbl: mutbl
         }
     }
@@ -267,7 +267,7 @@ impl AstBuilder for @ExtCtxt {
     fn ty_path(&self, path: ast::Path, bounds: Option<OptVec<ast::TyParamBound>>)
               -> ast::Ty {
         self.ty(path.span,
-                ast::ty_path(path, bounds, self.next_id()))
+                ast::ty_path(~path, bounds, self.next_id()))
     }
 
     // Might need to take bounds as an argument in the future, if you ever want
@@ -284,14 +284,14 @@ impl AstBuilder for @ExtCtxt {
                mutbl: ast::mutability)
         -> ast::Ty {
         self.ty(span,
-                ast::ty_rptr(lifetime, self.ty_mt(ty, mutbl)))
+                ast::ty_rptr(lifetime, ~self.ty_mt(ty, mutbl)))
     }
     fn ty_uniq(&self, span: span, ty: ast::Ty) -> ast::Ty {
-        self.ty(span, ast::ty_uniq(self.ty_mt(ty, ast::m_imm)))
+        self.ty(span, ast::ty_uniq(~self.ty_mt(ty, ast::m_imm)))
     }
     fn ty_box(&self, span: span,
                  ty: ast::Ty, mutbl: ast::mutability) -> ast::Ty {
-        self.ty(span, ast::ty_box(self.ty_mt(ty, mutbl)))
+        self.ty(span, ast::ty_box(~self.ty_mt(ty, mutbl)))
     }
 
     fn ty_option(&self, ty: ast::Ty) -> ast::Ty {
@@ -311,7 +311,7 @@ impl AstBuilder for @ExtCtxt {
         respan(span,
                ast::ty_field_ {
                    ident: name,
-                   mt: ast::mt { ty: ~ty, mutbl: ast::m_imm },
+                   mt: ast::mt { ty: ty, mutbl: ast::m_imm },
                })
     }
 
@@ -363,7 +363,7 @@ impl AstBuilder for @ExtCtxt {
     }
 
     fn typarambound(&self, path: ast::Path) -> ast::TyParamBound {
-        ast::TraitTyParamBound(self.trait_ref(path))
+        ast::TraitTyParamBound(~self.trait_ref(path))
     }
 
     fn lifetime(&self, span: span, ident: ast::ident) -> ast::Lifetime {
@@ -419,7 +419,7 @@ impl AstBuilder for @ExtCtxt {
     }
 
     fn expr_path(&self, path: ast::Path) -> @ast::expr {
-        self.expr(path.span, ast::expr_path(path))
+        self.expr(path.span, ast::expr_path(~path))
     }
 
     fn expr_ident(&self, span: span, id: ast::ident) -> @ast::expr {
@@ -485,7 +485,7 @@ impl AstBuilder for @ExtCtxt {
         respan(span, ast::field_ { ident: name, expr: e })
     }
     fn expr_struct(&self, span: span, path: ast::Path, fields: ~[ast::field]) -> @ast::expr {
-        self.expr(span, ast::expr_struct(path, fields, None))
+        self.expr(span, ast::expr_struct(~path, fields, None))
     }
     fn expr_struct_ident(&self, span: span,
                          id: ast::ident, fields: ~[ast::field]) -> @ast::expr {
@@ -600,10 +600,10 @@ impl AstBuilder for @ExtCtxt {
     }
 
     fn lambda_fn_decl(&self, span: span, fn_decl: ast::fn_decl, blk: ast::blk) -> @ast::expr {
-        self.expr(span, ast::expr_fn_block(fn_decl, blk))
+        self.expr(span, ast::expr_fn_block(~fn_decl, blk))
     }
     fn lambda(&self, span: span, ids: ~[ast::ident], blk: ast::blk) -> @ast::expr {
-        let fn_decl = self.fn_decl(
+        let fn_decl = ~self.fn_decl(
             ids.map(|id| self.arg(span, *id, self.ty_infer(span))),
             self.ty_infer(span));
 
@@ -682,7 +682,7 @@ impl AstBuilder for @ExtCtxt {
         self.item(span,
                   name,
                   ~[],
-                  ast::item_fn(self.fn_decl(inputs, output),
+                  ast::item_fn(~self.fn_decl(inputs, output),
                                ast::impure_fn,
                                AbiSet::Rust(),
                                generics,

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -36,7 +36,7 @@ pub fn expand_syntax_ext(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
     let e = @ast::expr {
         id: cx.next_id(),
         node: ast::expr_path(
-            ast::Path {
+            ~ast::Path {
                  span: sp,
                  global: false,
                  idents: ~[res],

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -117,8 +117,8 @@ fn fold_arg_(a: arg, fld: @ast_fold) -> arg {
 fn fold_mac_(m: &mac, fld: @ast_fold) -> mac {
     spanned {
         node: match m.node {
-            mac_invoc_tt(ref p,ref tts) =>
-            mac_invoc_tt(fld.fold_path(p),
+            mac_invoc_tt(~ref p,ref tts) =>
+            mac_invoc_tt(~fld.fold_path(p),
                          fold_tts(*tts,fld))
         },
         span: fld.new_span(m.span)
@@ -162,7 +162,7 @@ pub fn fold_fn_decl(decl: &ast::fn_decl, fld: @ast_fold) -> ast::fn_decl {
 
 fn fold_ty_param_bound(tpb: &TyParamBound, fld: @ast_fold) -> TyParamBound {
     match *tpb {
-        TraitTyParamBound(ref ty) => TraitTyParamBound(fold_trait_ref(ty, fld)),
+        TraitTyParamBound(~ref ty) => TraitTyParamBound(~fold_trait_ref(ty, fld)),
         RegionTyParamBound => RegionTyParamBound
     }
 }
@@ -267,10 +267,10 @@ fn noop_fold_struct_field(sf: @struct_field, fld: @ast_fold)
 
 pub fn noop_fold_item_underscore(i: &item_, fld: @ast_fold) -> item_ {
     match *i {
-        item_static(ref t, m, e) => item_static(fld.fold_ty(t), m, fld.fold_expr(e)),
-        item_fn(ref decl, purity, abi, ref generics, ref body) => {
+        item_static(~ref t, m, e) => item_static(~fld.fold_ty(t), m, fld.fold_expr(e)),
+        item_fn(~ref decl, purity, abi, ref generics, ref body) => {
             item_fn(
-                fold_fn_decl(decl, fld),
+                ~fold_fn_decl(decl, fld),
                 purity,
                 abi,
                 fold_generics(generics, fld),
@@ -565,9 +565,9 @@ pub fn noop_fold_expr(e: &expr_, fld: @ast_fold) -> expr_ {
                 arms.map(|x| fld.fold_arm(x))
             )
         }
-        expr_fn_block(ref decl, ref body) => {
+        expr_fn_block(~ref decl, ref body) => {
             expr_fn_block(
-                fold_fn_decl(decl, fld),
+                ~fold_fn_decl(decl, fld),
                 fld.fold_block(body)
             )
         }
@@ -597,7 +597,7 @@ pub fn noop_fold_expr(e: &expr_, fld: @ast_fold) -> expr_ {
                 fld.fold_expr(er)
             )
         }
-        expr_path(ref pth) => expr_path(fld.fold_path(pth)),
+        expr_path(~ref pth) => expr_path(~fld.fold_path(pth)),
         expr_self => expr_self,
         expr_break(ref opt_ident) => {
             expr_break(opt_ident.map(|x| fld.fold_ident(*x)))
@@ -622,9 +622,9 @@ pub fn noop_fold_expr(e: &expr_, fld: @ast_fold) -> expr_ {
             })
         }
         expr_mac(ref mac) => expr_mac(fold_mac(mac)),
-        expr_struct(ref path, ref fields, maybe_expr) => {
+        expr_struct(~ref path, ref fields, maybe_expr) => {
             expr_struct(
-                fld.fold_path(path),
+                ~fld.fold_path(path),
                 fields.map(|x| fold_field(*x)),
                 maybe_expr.map(|x| fld.fold_expr(*x))
             )
@@ -637,7 +637,7 @@ pub fn noop_fold_ty(t: &ty_, fld: @ast_fold) -> ty_ {
     let fold_mac = |x| fold_mac_(x, fld);
     fn fold_mt(mt: &mt, fld: @ast_fold) -> mt {
         mt {
-            ty: ~fld.fold_ty(mt.ty),
+            ty: fld.fold_ty(&mt.ty),
             mutbl: mt.mutbl,
         }
     }
@@ -658,11 +658,11 @@ pub fn noop_fold_ty(t: &ty_, fld: @ast_fold) -> ty_ {
     }
     match *t {
         ty_nil | ty_bot | ty_infer => copy *t,
-        ty_box(ref mt) => ty_box(fold_mt(mt, fld)),
-        ty_uniq(ref mt) => ty_uniq(fold_mt(mt, fld)),
-        ty_vec(ref mt) => ty_vec(fold_mt(mt, fld)),
-        ty_ptr(ref mt) => ty_ptr(fold_mt(mt, fld)),
-        ty_rptr(region, ref mt) => ty_rptr(region, fold_mt(mt, fld)),
+        ty_box(~ref mt) => ty_box(~fold_mt(mt, fld)),
+        ty_uniq(~ref mt) => ty_uniq(~fold_mt(mt, fld)),
+        ty_vec(~ref mt) => ty_vec(~fold_mt(mt, fld)),
+        ty_ptr(~ref mt) => ty_ptr(~fold_mt(mt, fld)),
+        ty_rptr(region, ~ref mt) => ty_rptr(region, ~fold_mt(mt, fld)),
         ty_closure(ref f) => {
             ty_closure(@TyClosure {
                 sigil: f.sigil,
@@ -683,11 +683,11 @@ pub fn noop_fold_ty(t: &ty_, fld: @ast_fold) -> ty_ {
             })
         }
         ty_tup(ref tys) => ty_tup(tys.map(|ty| fld.fold_ty(ty))),
-        ty_path(ref path, ref bounds, id) =>
-            ty_path(fld.fold_path(path), fold_opt_bounds(bounds, fld), fld.new_id(id)),
-        ty_fixed_length_vec(ref mt, e) => {
+        ty_path(~ref path, ref bounds, id) =>
+            ty_path(~fld.fold_path(path), fold_opt_bounds(bounds, fld), fld.new_id(id)),
+        ty_fixed_length_vec(~ref mt, e) => {
             ty_fixed_length_vec(
-                fold_mt(mt, fld),
+                ~fold_mt(mt, fld),
                 fld.fold_expr(e)
             )
         }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -370,7 +370,7 @@ mod test {
     #[test] fn path_exprs_1 () {
         assert_eq!(string_to_expr(@"a"),
                    @ast::expr{id:1,
-                              node:ast::expr_path(ast::Path {span:sp(0,1),
+                              node:ast::expr_path(~ast::Path {span:sp(0,1),
                                                               global:false,
                                                               idents:~[str_to_ident("a")],
                                                               rp:None,
@@ -382,7 +382,7 @@ mod test {
         assert_eq!(string_to_expr(@"::a::b"),
                    @ast::expr{id:1,
                                node:ast::expr_path(
-                                    ast::Path {span:sp(0,6),
+                                    ~ast::Path {span:sp(0,6),
                                                global:true,
                                                idents:strs_to_idents(~["a","b"]),
                                                rp:None,
@@ -432,7 +432,7 @@ mod test {
                               node:ast::expr_ret(
                                   Some(@ast::expr{id:1,
                                                   node:ast::expr_path(
-                                                       ast::Path{span:sp(7,8),
+                                                       ~ast::Path{span:sp(7,8),
                                                                  global:false,
                                                                  idents:~[str_to_ident("d")],
                                                                  rp:None,
@@ -448,7 +448,7 @@ mod test {
                        node: ast::stmt_expr(@ast::expr{
                            id: 1,
                            node: ast::expr_path(
-                                ast::Path{
+                                ~ast::Path{
                                    span:sp(0,1),
                                    global:false,
                                    idents:~[str_to_ident("b")],
@@ -487,7 +487,7 @@ mod test {
                    ast::arg{
                        is_mutbl: false,
                        ty: ast::Ty{id:3, // fixme
-                                    node: ast::ty_path(ast::Path{
+                                    node: ast::ty_path(~ast::Path{
                                         span:sp(4,4), // this is bizarre...
                                         // check this in the original parser?
                                         global:false,
@@ -520,11 +520,11 @@ mod test {
                       @ast::item{ident:str_to_ident("a"),
                             attrs:~[],
                             id: 9, // fixme
-                            node: ast::item_fn(ast::fn_decl{
+                            node: ast::item_fn(~ast::fn_decl{
                                 inputs: ~[ast::arg{
                                     is_mutbl: false,
                                     ty: ast::Ty{id:3, // fixme
-                                                node: ast::ty_path(ast::Path{
+                                                node: ast::ty_path(~ast::Path{
                                         span:sp(10,13),
                                         global:false,
                                         idents:~[str_to_ident("int")],
@@ -565,7 +565,7 @@ mod test {
                                                 node: ast::stmt_semi(@ast::expr{
                                                     id: 6,
                                                     node: ast::expr_path(
-                                                          ast::Path{
+                                                          ~ast::Path{
                                                             span:sp(17,18),
                                                             global:false,
                                                             idents:~[str_to_ident("b")],

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -378,20 +378,20 @@ pub fn print_type(s: @ps, ty: &ast::Ty) {
     match ty.node {
       ast::ty_nil => word(s.s, "()"),
       ast::ty_bot => word(s.s, "!"),
-      ast::ty_box(ref mt) => { word(s.s, "@"); print_mt(s, mt); }
-      ast::ty_uniq(ref mt) => { word(s.s, "~"); print_mt(s, mt); }
-      ast::ty_vec(ref mt) => {
+      ast::ty_box(~ref mt) => { word(s.s, "@"); print_mt(s, mt); }
+      ast::ty_uniq(~ref mt) => { word(s.s, "~"); print_mt(s, mt); }
+      ast::ty_vec(~ref mt) => {
         word(s.s, "[");
         match mt.mutbl {
           ast::m_mutbl => word_space(s, "mut"),
           ast::m_const => word_space(s, "const"),
           ast::m_imm => ()
         }
-        print_type(s, mt.ty);
+        print_type(s, &mt.ty);
         word(s.s, "]");
       }
-      ast::ty_ptr(ref mt) => { word(s.s, "*"); print_mt(s, mt); }
-      ast::ty_rptr(ref lifetime, ref mt) => {
+      ast::ty_ptr(~ref mt) => { word(s.s, "*"); print_mt(s, mt); }
+      ast::ty_rptr(ref lifetime, ~ref mt) => {
           word(s.s, "&");
           print_opt_lifetime(s, lifetime);
           print_mt(s, mt);
@@ -418,15 +418,15 @@ pub fn print_type(s: @ps, ty: &ast::Ty) {
                       f.purity, f.onceness, &f.decl, None, &f.bounds,
                       Some(&generics), None);
       }
-      ast::ty_path(ref path, ref bounds, _) => print_bounded_path(s, path, bounds),
-      ast::ty_fixed_length_vec(ref mt, v) => {
+      ast::ty_path(~ref path, ref bounds, _) => print_bounded_path(s, path, bounds),
+      ast::ty_fixed_length_vec(~ref mt, v) => {
         word(s.s, "[");
         match mt.mutbl {
             ast::m_mutbl => word_space(s, "mut"),
             ast::m_const => word_space(s, "const"),
             ast::m_imm => ()
         }
-        print_type(s, mt.ty);
+        print_type(s, &mt.ty);
         word(s.s, ", ..");
         print_expr(s, v);
         word(s.s, "]");
@@ -476,7 +476,7 @@ pub fn print_item(s: @ps, item: &ast::item) {
     let ann_node = node_item(s, item);
     (s.ann.pre)(ann_node);
     match item.node {
-      ast::item_static(ref ty, m, expr) => {
+      ast::item_static(~ref ty, m, expr) => {
         head(s, visibility_qualified(item.vis, "static"));
         if m == ast::m_mutbl {
             word_space(s, "mut");
@@ -493,7 +493,7 @@ pub fn print_item(s: @ps, item: &ast::item) {
         end(s); // end the outer cbox
 
       }
-      ast::item_fn(ref decl, purity, abi, ref typarams, ref body) => {
+      ast::item_fn(~ref decl, purity, abi, ref typarams, ref body) => {
         print_fn(
             s,
             decl,
@@ -609,7 +609,7 @@ pub fn print_item(s: @ps, item: &ast::item) {
         }
         bclose(s, item.span);
       }
-      ast::item_mac(codemap::spanned { node: ast::mac_invoc_tt(ref pth, ref tts),
+      ast::item_mac(codemap::spanned { node: ast::mac_invoc_tt(~ref pth, ref tts),
                                    _}) => {
         print_visibility(s, item.vis);
         print_path(s, pth, false);
@@ -811,7 +811,7 @@ pub fn print_ty_method(s: @ps, m: &ast::ty_method) {
 
 pub fn print_trait_method(s: @ps, m: &ast::trait_method) {
     match *m {
-        required(ref ty_m) => print_ty_method(s, ty_m),
+        required(~ref ty_m) => print_ty_method(s, ty_m),
         provided(m) => print_method(s, m)
     }
 }
@@ -1004,7 +1004,7 @@ pub fn print_if(s: @ps, test: &ast::expr, blk: &ast::blk,
 
 pub fn print_mac(s: @ps, m: &ast::mac) {
     match m.node {
-      ast::mac_invoc_tt(ref pth, ref tts) => {
+      ast::mac_invoc_tt(~ref pth, ref tts) => {
         print_path(s, pth, false);
         word(s.s, "!");
         popen(s);
@@ -1133,7 +1133,7 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
         end(s);
       }
 
-      ast::expr_struct(ref path, ref fields, wth) => {
+      ast::expr_struct(~ref path, ref fields, wth) => {
         print_path(s, path, true);
         word(s.s, "{");
         commasep_cmnt(s, consistent, (*fields), print_field, get_span);
@@ -1198,7 +1198,7 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
         print_expr(s, expr);
       }
       ast::expr_lit(lit) => print_literal(s, lit),
-      ast::expr_cast(expr, ref ty) => {
+      ast::expr_cast(expr, ~ref ty) => {
         print_expr(s, expr);
         space(s.s);
         word_space(s, "as");
@@ -1288,7 +1288,7 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
         }
         bclose_(s, expr.span, indent_unit);
       }
-      ast::expr_fn_block(ref decl, ref body) => {
+      ast::expr_fn_block(~ref decl, ref body) => {
         // in do/for blocks we don't want to show an empty
         // argument list, but at this point we don't know which
         // we are inside.
@@ -1358,7 +1358,7 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
         print_expr(s, index);
         word(s.s, "]");
       }
-      ast::expr_path(ref path) => print_path(s, path, true),
+      ast::expr_path(~ref path) => print_path(s, path, true),
       ast::expr_self => word(s.s, "self"),
       ast::expr_break(opt_ident) => {
         word(s.s, "break");
@@ -1747,7 +1747,7 @@ pub fn print_bounds(s: @ps, bounds: &OptVec<ast::TyParamBound>,
             }
 
             match *bound {
-                TraitTyParamBound(ref tref) => print_trait_ref(s, tref),
+                TraitTyParamBound(~ref tref) => print_trait_ref(s, tref),
                 RegionTyParamBound => word(s.s, "'static"),
             }
         }
@@ -1879,7 +1879,7 @@ pub fn print_mutability(s: @ps, mutbl: ast::mutability) {
 
 pub fn print_mt(s: @ps, mt: &ast::mt) {
     print_mutability(s, mt.mutbl);
-    print_type(s, mt.ty);
+    print_type(s, &mt.ty);
 }
 
 pub fn print_arg(s: @ps, input: &ast::arg) {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -144,11 +144,11 @@ fn visit_trait_ref<E: Copy>(tref: &ast::trait_ref, (e, v): (E, vt<E>)) {
 
 pub fn visit_item<E: Copy>(i: &item, (e, v): (E, vt<E>)) {
     match i.node {
-        item_static(ref t, _, ex) => {
+        item_static(~ref t, _, ex) => {
             (v.visit_ty)(t, (copy e, v));
             (v.visit_expr)(ex, (copy e, v));
         }
-        item_fn(ref decl, purity, abi, ref generics, ref body) => {
+        item_fn(~ref decl, purity, abi, ref generics, ref body) => {
             (v.visit_fn)(
                 &fk_item_fn(
                     i.ident,
@@ -232,9 +232,9 @@ pub fn skip_ty<E>(_t: &Ty, (_e,_v): (E, vt<E>)) {}
 
 pub fn visit_ty<E: Copy>(t: &Ty, (e, v): (E, vt<E>)) {
     match t.node {
-        ty_box(ref mt) | ty_uniq(ref mt) |
-        ty_vec(ref mt) | ty_ptr(ref mt) | ty_rptr(_, ref mt) => {
-            (v.visit_ty)(mt.ty, (e, v));
+        ty_box(~ref mt) | ty_uniq(~ref mt) |
+        ty_vec(~ref mt) | ty_ptr(~ref mt) | ty_rptr(_, ~ref mt) => {
+            (v.visit_ty)(&mt.ty, (e, v));
         },
         ty_tup(ref ts) => {
             for ts.iter().advance |tt| {
@@ -252,14 +252,14 @@ pub fn visit_ty<E: Copy>(t: &Ty, (e, v): (E, vt<E>)) {
             for f.decl.inputs.iter().advance |a| { (v.visit_ty)(&a.ty, (copy e, v)); }
             (v.visit_ty)(&f.decl.output, (e, v));
         },
-        ty_path(ref p, ref bounds, _) => {
+        ty_path(~ref p, ref bounds, _) => {
             visit_path(p, (copy e, v));
             do bounds.map |bounds| {
                 visit_ty_param_bounds(bounds, (copy e, v));
             };
         },
-        ty_fixed_length_vec(ref mt, ex) => {
-            (v.visit_ty)(mt.ty, (copy e, v));
+        ty_fixed_length_vec(~ref mt, ex) => {
+            (v.visit_ty)(&mt.ty, (copy e, v));
             (v.visit_expr)(ex, (copy e, v));
         },
         ty_nil | ty_bot | ty_mac(_) | ty_infer => ()
@@ -336,7 +336,7 @@ pub fn visit_ty_param_bounds<E: Copy>(bounds: &OptVec<TyParamBound>,
                                       (e, v): (E, vt<E>)) {
     for bounds.iter().advance |bound| {
         match *bound {
-            TraitTyParamBound(ref ty) => visit_trait_ref(ty, (copy e, v)),
+            TraitTyParamBound(~ref ty) => visit_trait_ref(ty, (copy e, v)),
             RegionTyParamBound => {}
         }
     }
@@ -391,7 +391,7 @@ pub fn visit_ty_method<E: Copy>(m: &ty_method, (e, v): (E, vt<E>)) {
 
 pub fn visit_trait_method<E: Copy>(m: &trait_method, (e, v): (E, vt<E>)) {
     match *m {
-      required(ref ty_m) => (v.visit_ty_method)(ty_m, (e, v)),
+      required(~ref ty_m) => (v.visit_ty_method)(ty_m, (e, v)),
       provided(m) => visit_method_helper(m, (e, v))
     }
 }
@@ -458,7 +458,7 @@ pub fn visit_expr<E: Copy>(ex: @expr, (e, v): (E, vt<E>)) {
             (v.visit_expr)(element, (copy e, v));
             (v.visit_expr)(count, (copy e, v));
         }
-        expr_struct(ref p, ref flds, base) => {
+        expr_struct(~ref p, ref flds, base) => {
             visit_path(p, (copy e, v));
             for flds.iter().advance |f| {
                 (v.visit_expr)(f.node.expr, (copy e, v));
@@ -486,7 +486,7 @@ pub fn visit_expr<E: Copy>(ex: @expr, (e, v): (E, vt<E>)) {
         expr_addr_of(_, x) | expr_unary(_, _, x) |
         expr_loop_body(x) | expr_do_body(x) => (v.visit_expr)(x, (copy e, v)),
         expr_lit(_) => (),
-        expr_cast(x, ref t) => {
+        expr_cast(x, ~ref t) => {
             (v.visit_expr)(x, (copy e, v));
             (v.visit_ty)(t, (copy e, v));
         }
@@ -504,7 +504,7 @@ pub fn visit_expr<E: Copy>(ex: @expr, (e, v): (E, vt<E>)) {
             (v.visit_expr)(x, (copy e, v));
             for arms.iter().advance |a| { (v.visit_arm)(a, (copy e, v)); }
         }
-        expr_fn_block(ref decl, ref body) => {
+        expr_fn_block(~ref decl, ref body) => {
             (v.visit_fn)(
                 &fk_fn_block,
                 decl,
@@ -534,7 +534,7 @@ pub fn visit_expr<E: Copy>(ex: @expr, (e, v): (E, vt<E>)) {
             (v.visit_expr)(a, (copy e, v));
             (v.visit_expr)(b, (copy e, v));
         }
-        expr_path(ref p) => visit_path(p, (copy e, v)),
+        expr_path(~ref p) => visit_path(p, (copy e, v)),
         expr_self => (),
         expr_break(_) => (),
         expr_again(_) => (),


### PR DESCRIPTION
My previous changes caused some of the enum variants to grow quite large. This throws some `~` at it in order to keep the enum sizes down.

For comparison, the before/after of type sizes for this PR: https://gist.github.com/Aatch/5945776
