### PR TITLE
Revert "De-share ast::Ty"

### DIFF
--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -98,10 +98,10 @@ fn fold_foreign_mod(
 fn fold_item_underscore(cx: @Context, item: &ast::item_,
                         fld: @fold::ast_fold) -> ast::item_ {
     let item = match *item {
-        ast::item_impl(ref a, ref b, ref c, ref methods) => {
+        ast::item_impl(ref a, ref b, c, ref methods) => {
             let methods = methods.iter().filter(|m| method_in_cfg(cx, **m))
                 .transform(|x| *x).collect();
-            ast::item_impl(/*bad*/ copy *a, /*bad*/ copy *b, /*bad*/ copy *c, methods)
+            ast::item_impl(/*bad*/ copy *a, /*bad*/ copy *b, c, methods)
         }
         ast::item_trait(ref a, ref b, ref methods) => {
             let methods = methods.iter().filter(|m| trait_method_in_cfg(cx, *m) )

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1003,7 +1003,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
                                         index);
         }
       }
-      item_impl(ref generics, ref opt_trait, ref ty, ref methods) => {
+      item_impl(ref generics, ref opt_trait, ty, ref methods) => {
         add_to_index();
         ebml_w.start_tag(tag_items_data_item);
         encode_def_id(ebml_w, local_def(item.id));

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -117,7 +117,7 @@ fn check_item(item: @item, (cx, visitor): (Context, visit::vt<Context>)) {
     // If this is a destructor, check kinds.
     if !attrs_contains_name(item.attrs, "unsafe_destructor") {
         match item.node {
-            item_impl(_, Some(ref trait_ref), ref self_type, _) => {
+            item_impl(_, Some(ref trait_ref), self_type, _) => {
                 match cx.tcx.def_map.find(&trait_ref.ref_id) {
                     None => cx.tcx.sess.bug("trait ref not in def map!"),
                     Some(&trait_def) => {
@@ -321,7 +321,7 @@ pub fn check_expr(e: @expr, (cx, v): (Context, visit::vt<Context>)) {
     visit::visit_expr(e, (cx, v));
 }
 
-fn check_ty(aty: &Ty, (cx, v): (Context, visit::vt<Context>)) {
+fn check_ty(aty: @Ty, (cx, v): (Context, visit::vt<Context>)) {
     match aty.node {
       ty_path(_, _, id) => {
           let r = cx.tcx.node_type_substs.find(&id);

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -747,9 +747,9 @@ fn check_item_ctypes(cx: &Context, it: &ast::item) {
 
     fn check_foreign_fn(cx: &Context, decl: &ast::fn_decl) {
         for decl.inputs.iter().advance |in| {
-            check_ty(cx, &in.ty);
+            check_ty(cx, in.ty);
         }
-        check_ty(cx, &decl.output)
+        check_ty(cx, decl.output)
     }
 
     match it.node {
@@ -759,7 +759,7 @@ fn check_item_ctypes(cx: &Context, it: &ast::item) {
                 ast::foreign_item_fn(ref decl, _, _) => {
                     check_foreign_fn(cx, decl);
                 }
-                ast::foreign_item_static(ref t, _) => { check_ty(cx, t); }
+                ast::foreign_item_static(t, _) => { check_ty(cx, t); }
             }
         }
       }

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -713,10 +713,10 @@ fn determine_rp_in_fn(fk: &visit::fn_kind,
     do cx.with(cx.item_id, false) {
         do cx.with_ambient_variance(rv_contravariant) {
             for decl.inputs.iter().advance |a| {
-                (visitor.visit_ty)(&a.ty, (cx, visitor));
+                (visitor.visit_ty)(a.ty, (cx, visitor));
             }
         }
-        (visitor.visit_ty)(&decl.output, (cx, visitor));
+        (visitor.visit_ty)(decl.output, (cx, visitor));
         let generics = visit::generics_of_fn(fk);
         (visitor.visit_generics)(&generics, (cx, visitor));
         (visitor.visit_block)(body, (cx, visitor));
@@ -731,7 +731,7 @@ fn determine_rp_in_ty_method(ty_m: &ast::ty_method,
     }
 }
 
-fn determine_rp_in_ty(ty: &ast::Ty,
+fn determine_rp_in_ty(ty: @ast::Ty,
                       (cx, visitor): (@mut DetermineRpCtxt,
                                       visit::vt<@mut DetermineRpCtxt>)) {
     // we are only interested in types that will require an item to
@@ -815,8 +815,8 @@ fn determine_rp_in_ty(ty: &ast::Ty,
     }
 
     match ty.node {
-      ast::ty_box(ref mt) | ast::ty_uniq(ref mt) | ast::ty_vec(ref mt) |
-      ast::ty_rptr(_, ref mt) | ast::ty_ptr(ref mt) => {
+      ast::ty_box(mt) | ast::ty_uniq(mt) | ast::ty_vec(mt) |
+      ast::ty_rptr(_, mt) | ast::ty_ptr(mt) => {
         visit_mt(mt, (cx, visitor));
       }
 
@@ -824,7 +824,7 @@ fn determine_rp_in_ty(ty: &ast::Ty,
         // type parameters are---for now, anyway---always invariant
         do cx.with_ambient_variance(rv_invariant) {
             for path.types.iter().advance |tp| {
-                (visitor.visit_ty)(tp, (cx, visitor));
+                (visitor.visit_ty)(*tp, (cx, visitor));
             }
         }
       }
@@ -837,10 +837,10 @@ fn determine_rp_in_ty(ty: &ast::Ty,
             // parameters are contravariant
             do cx.with_ambient_variance(rv_contravariant) {
                 for decl.inputs.iter().advance |a| {
-                    (visitor.visit_ty)(&a.ty, (cx, visitor));
+                    (visitor.visit_ty)(a.ty, (cx, visitor));
                 }
             }
-            (visitor.visit_ty)(&decl.output, (cx, visitor));
+            (visitor.visit_ty)(decl.output, (cx, visitor));
         }
       }
 
@@ -849,7 +849,7 @@ fn determine_rp_in_ty(ty: &ast::Ty,
       }
     }
 
-    fn visit_mt(mt: &ast::mt,
+    fn visit_mt(mt: ast::mt,
                 (cx, visitor): (@mut DetermineRpCtxt,
                                 visit::vt<@mut DetermineRpCtxt>)) {
         // mutability is invariant

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1233,7 +1233,7 @@ impl Resolver {
                 visit_item(item, (new_parent, visitor));
             }
 
-            item_impl(_, None, ref ty, ref methods) => {
+            item_impl(_, None, ty, ref methods) => {
                 // If this implements an anonymous trait, then add all the
                 // methods within to a new module, if the type was defined
                 // within this module.
@@ -1243,8 +1243,8 @@ impl Resolver {
                 // the same module that declared the type.
 
                 // Create the module and add all methods.
-                match ty {
-                    &Ty {
+                match *ty {
+                    Ty {
                         node: ty_path(ref path, _, _),
                         _
                     } if path.idents.len() == 1 => {
@@ -1313,7 +1313,7 @@ impl Resolver {
                 visit_item(item, (parent, visitor));
             }
 
-            item_impl(_, Some(_), _, _) => {
+            item_impl(_, Some(_), _ty, ref _methods) => {
                 visit_item(item, (parent, visitor));
             }
 
@@ -3534,7 +3534,7 @@ impl Resolver {
 
             item_impl(ref generics,
                       ref implemented_traits,
-                      ref self_type,
+                      self_type,
                       ref methods) => {
                 self.resolve_implementation(item.id,
                                             generics,
@@ -3585,10 +3585,10 @@ impl Resolver {
                                     visitor);
 
                                 for ty_m.decl.inputs.iter().advance |argument| {
-                                    self.resolve_type(&argument.ty, visitor);
+                                    self.resolve_type(argument.ty, visitor);
                                 }
 
-                                self.resolve_type(&ty_m.decl.output, visitor);
+                                self.resolve_type(ty_m.decl.output, visitor);
                             }
                           }
                           provided(m) => {
@@ -3778,12 +3778,12 @@ impl Resolver {
                                              None,
                                              visitor);
 
-                        self.resolve_type(&argument.ty, visitor);
+                        self.resolve_type(argument.ty, visitor);
 
                         debug!("(resolving function) recorded argument");
                     }
 
-                    self.resolve_type(&declaration.output, visitor);
+                    self.resolve_type(declaration.output, visitor);
                 }
             }
 
@@ -3878,7 +3878,7 @@ impl Resolver {
 
             // Resolve fields.
             for fields.iter().advance |field| {
-                self.resolve_type(&field.node.ty, visitor);
+                self.resolve_type(field.node.ty, visitor);
             }
         }
     }
@@ -3914,7 +3914,7 @@ impl Resolver {
                                   id: node_id,
                                   generics: &Generics,
                                   opt_trait_reference: &Option<trait_ref>,
-                                  self_type: &Ty,
+                                  self_type: @Ty,
                                   methods: &[@method],
                                   visitor: ResolveVisitor) {
         // If applicable, create a rib for the type parameters.
@@ -4001,7 +4001,7 @@ impl Resolver {
         let mutability = if local.node.is_mutbl {Mutable} else {Immutable};
 
         // Resolve the type.
-        self.resolve_type(&local.node.ty, visitor);
+        self.resolve_type(local.node.ty, visitor);
 
         // Resolve the initializer, if necessary.
         match local.node.init {
@@ -4112,7 +4112,7 @@ impl Resolver {
         debug!("(resolving block) leaving block");
     }
 
-    pub fn resolve_type(@mut self, ty: &Ty, visitor: ResolveVisitor) {
+    pub fn resolve_type(@mut self, ty: @Ty, visitor: ResolveVisitor) {
         match ty.node {
             // Like path expressions, the interpretation of path types depends
             // on whether the path has multiple elements in it or not.
@@ -4334,7 +4334,7 @@ impl Resolver {
 
                     // Check the types in the path pattern.
                     for path.types.iter().advance |ty| {
-                        self.resolve_type(ty, visitor);
+                        self.resolve_type(*ty, visitor);
                     }
                 }
 
@@ -4367,7 +4367,7 @@ impl Resolver {
 
                     // Check the types in the path pattern.
                     for path.types.iter().advance |ty| {
-                        self.resolve_type(ty, visitor);
+                        self.resolve_type(*ty, visitor);
                     }
                 }
 
@@ -4396,7 +4396,7 @@ impl Resolver {
 
                     // Check the types in the path pattern.
                     for path.types.iter().advance |ty| {
-                        self.resolve_type(ty, visitor);
+                        self.resolve_type(*ty, visitor);
                     }
                 }
 
@@ -4491,7 +4491,7 @@ impl Resolver {
                         -> Option<def> {
         // First, resolve the types.
         for path.types.iter().advance |ty| {
-            self.resolve_type(ty, visitor);
+            self.resolve_type(*ty, visitor);
         }
 
         if path.global {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1811,7 +1811,7 @@ pub fn copy_args_to_allocas(fcx: fn_ctxt,
         fcx.llargs.insert(arg_id, llarg);
 
         if fcx.ccx.sess.opts.extra_debuginfo && fcx_has_nonzero_span(fcx) {
-            debuginfo::create_arg(bcx, &args[arg_n], args[arg_n].ty.span);
+            debuginfo::create_arg(bcx, args[arg_n], args[arg_n].ty.span);
         }
     }
 
@@ -1979,7 +1979,7 @@ pub fn trans_enum_variant(ccx: @mut CrateContext,
     let fn_args = do args.map |varg| {
         ast::arg {
             is_mutbl: false,
-            ty: copy varg.ty,
+            ty: varg.ty,
             pat: ast_util::ident_to_pat(
                 ccx.tcx.sess.next_node_id(),
                 codemap::dummy_sp(),
@@ -2053,7 +2053,7 @@ pub fn trans_tuple_struct(ccx: @mut CrateContext,
     let fn_args = do fields.map |field| {
         ast::arg {
             is_mutbl: false,
-            ty: copy field.node.ty,
+            ty: field.node.ty,
             pat: ast_util::ident_to_pat(ccx.tcx.sess.next_node_id(),
                                         codemap::dummy_sp(),
                                         special_idents::arg),

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -182,7 +182,7 @@ pub fn create_local_var(bcx: block, local: @ast::local) -> DIVariable {
 ///
 /// Adds the created metadata nodes directly to the crate's IR.
 /// The return value should be ignored if called from outside of the debuginfo module.
-pub fn create_arg(bcx: block, arg: &ast::arg, span: span) -> Option<DIVariable> {
+pub fn create_arg(bcx: block, arg: ast::arg, span: span) -> Option<DIVariable> {
     debug!("create_arg");
     if true {
         // XXX create_arg disabled for now because "node_id_type(bcx, arg.id)" below blows
@@ -259,25 +259,23 @@ pub fn create_function(fcx: fn_ctxt) -> DISubprogram {
     let fcx = &mut *fcx;
     let span = fcx.span.get();
 
-    let fnitem = cx.tcx.items.get_copy(&fcx.id);
-    let (ident, ret_ty, id) = match fnitem {
-      ast_map::node_item(ref item, _) => {
+    let (ident, ret_ty, id) = match cx.tcx.items.get_copy(&fcx.id) {
+      ast_map::node_item(item, _) => {
         match item.node {
-          ast::item_fn(ast::fn_decl { output: ref ty, _}, _, _, _, _) => {
-            (item.ident, ty, item.id)
+          ast::item_fn(ref decl, _, _, _, _) => {
+            (item.ident, decl.output, item.id)
           }
           _ => fcx.ccx.sess.span_bug(item.span, "create_function: item bound to non-function")
         }
       }
-      ast_map::node_method(@ast::method { decl: ast::fn_decl { output: ref ty, _ },
-                           id: id, ident: ident, _}, _, _) => {
-          (ident, ty, id)
+      ast_map::node_method(method, _, _) => {
+          (method.ident, method.decl.output, method.id)
       }
-      ast_map::node_expr(ref expr) => {
+      ast_map::node_expr(expr) => {
         match expr.node {
           ast::expr_fn_block(ref decl, _) => {
             let name = gensym_name("fn");
-            (name, &decl.output, expr.id)
+            (name, decl.output, expr.id)
           }
           _ => fcx.ccx.sess.span_bug(expr.span,
                   "create_function: expected an expr_fn_block here")

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -179,7 +179,7 @@ fn ast_path_substs<AC:AstConv,RS:region_scope + Copy + 'static>(
             fmt!("wrong number of type arguments: expected %u but found %u",
                  decl_generics.type_param_defs.len(), path.types.len()));
     }
-    let tps = path.types.map(|a_t| ast_ty_to_ty(this, rscope, a_t));
+    let tps = path.types.map(|a_t| ast_ty_to_ty(this, rscope, *a_t));
 
     substs {self_r:self_r, self_ty:self_ty, tps:tps}
 }
@@ -377,7 +377,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + 'static>(
                    |tmt| ty::mk_rptr(tcx, r, tmt))
       }
       ast::ty_tup(ref fields) => {
-        let flds = fields.map(|t| ast_ty_to_ty(this, rscope, t));
+        let flds = fields.map(|t| ast_ty_to_ty(this, rscope, *t));
         ty::mk_tup(tcx, flds)
       }
       ast::ty_bare_fn(ref bf) => {
@@ -525,13 +525,13 @@ pub fn ty_of_arg<AC:AstConv,
                  RS:region_scope + Copy + 'static>(
                  this: &AC,
                  rscope: &RS,
-                 a: &ast::arg,
+                 a: ast::arg,
                  expected_ty: Option<ty::t>)
                  -> ty::t {
     match a.ty.node {
         ast::ty_infer if expected_ty.is_some() => expected_ty.get(),
         ast::ty_infer => this.ty_infer(a.ty.span),
-        _ => ast_ty_to_ty(this, rscope, &a.ty),
+        _ => ast_ty_to_ty(this, rscope, a.ty),
     }
 }
 
@@ -621,11 +621,11 @@ fn ty_of_method_or_bare_fn<AC:AstConv,RS:region_scope + Copy + 'static>(
         transform_self_ty(this, &rb, self_info)
     });
 
-    let input_tys = decl.inputs.map(|a| ty_of_arg(this, &rb, a, None));
+    let input_tys = decl.inputs.map(|a| ty_of_arg(this, &rb, *a, None));
 
     let output_ty = match decl.output.node {
         ast::ty_infer => this.ty_infer(decl.output.span),
-        _ => ast_ty_to_ty(this, &rb, &decl.output)
+        _ => ast_ty_to_ty(this, &rb, decl.output)
     };
 
     return (opt_transformed_self_ty,
@@ -724,14 +724,14 @@ pub fn ty_of_closure<AC:AstConv,RS:region_scope + Copy + 'static>(
             // were supplied
             if i < e.inputs.len() {Some(e.inputs[i])} else {None}
         };
-        ty_of_arg(this, &rb, a, expected_arg_ty)
+        ty_of_arg(this, &rb, *a, expected_arg_ty)
     }.collect();
 
     let expected_ret_ty = expected_sig.map(|e| e.output);
     let output_ty = match decl.output.node {
         ast::ty_infer if expected_ret_ty.is_some() => expected_ret_ty.get(),
         ast::ty_infer => this.ty_infer(decl.output.span),
-        _ => ast_ty_to_ty(this, &rb, &decl.output)
+        _ => ast_ty_to_ty(this, &rb, decl.output)
     };
 
     ty::ClosureTy {

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -638,7 +638,7 @@ impl CoherenceChecker {
                         // Then visit the module items.
                         visit_mod(module_, item.span, item.id, ((), visitor));
                     }
-                    item_impl(_, None, ref ast_ty, _) => {
+                    item_impl(_, None, ast_ty, _) => {
                         if !self.ast_type_is_defined_in_local_crate(ast_ty) {
                             // This is an error.
                             let session = self.crate_context.tcx.sess;
@@ -725,7 +725,7 @@ impl CoherenceChecker {
     /// For coherence, when we have `impl Type`, we need to guarantee that
     /// `Type` is "local" to the crate. For our purposes, this means that it
     /// must precisely name some nominal type defined in this crate.
-    pub fn ast_type_is_defined_in_local_crate(&self, original_type: &ast::Ty)
+    pub fn ast_type_is_defined_in_local_crate(&self, original_type: @ast::Ty)
                                               -> bool {
         match original_type.node {
             ty_path(_, _, path_id) => {

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -148,7 +148,7 @@ pub fn get_enum_variant_types(ccx: &CrateCtxt,
         match variant.node.kind {
             ast::tuple_variant_kind(ref args) if args.len() > 0 => {
                 let rs = type_rscope(region_parameterization);
-                let input_tys = args.map(|va| ccx.to_ty(&rs, &va.ty));
+                let input_tys = args.map(|va| ccx.to_ty(&rs, va.ty));
                 result_ty = Some(ty::mk_ctor_fn(tcx, input_tys, enum_ty));
             }
 
@@ -684,7 +684,7 @@ pub fn convert_field(ccx: &CrateCtxt,
                      generics: &ast::Generics) {
     let region_parameterization =
         RegionParameterization::from_variance_and_generics(rp, generics);
-    let tt = ccx.to_ty(&type_rscope(region_parameterization), &v.node.ty);
+    let tt = ccx.to_ty(&type_rscope(region_parameterization), v.node.ty);
     write_ty_to_tcx(ccx.tcx, v.node.id, tt);
     /* add the field to the tcache */
     ccx.tcx.tcache.insert(local_def(v.node.id),
@@ -813,7 +813,7 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::item) {
                                generics,
                                rp);
       }
-      ast::item_impl(ref generics, ref opt_trait_ref, ref selfty, ref ms) => {
+      ast::item_impl(ref generics, ref opt_trait_ref, selfty, ref ms) => {
         let i_ty_generics = ty_generics(ccx, rp, generics, 0);
         let region_parameterization =
             RegionParameterization::from_variance_and_generics(rp, generics);
@@ -1031,7 +1031,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::item)
     }
     let rp = tcx.region_paramd_items.find(&it.id).map_consume(|x| *x);
     match it.node {
-      ast::item_static(ref t, _, _) => {
+      ast::item_static(t, _, _) => {
         let typ = ccx.to_ty(&empty_rscope, t);
         let tpt = no_params(typ);
         tcx.tcache.insert(local_def(it.id), tpt);
@@ -1060,7 +1060,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::item)
         ccx.tcx.tcache.insert(local_def(it.id), tpt);
         return tpt;
       }
-      ast::item_ty(ref t, ref generics) => {
+      ast::item_ty(t, ref generics) => {
         match tcx.tcache.find(&local_def(it.id)) {
           Some(&tpt) => return tpt,
           None => { }
@@ -1124,7 +1124,7 @@ pub fn ty_of_foreign_item(ccx: &CrateCtxt,
                                   generics,
                                   abis)
         }
-        ast::foreign_item_static(ref t, _) => {
+        ast::foreign_item_static(t, _) => {
             ty::ty_param_bounds_and_ty {
                 generics: ty::Generics {
                     type_param_defs: @~[],
@@ -1215,8 +1215,8 @@ pub fn ty_of_foreign_fn_decl(ccx: &CrateCtxt,
     let ty_generics = ty_generics(ccx, None, ast_generics, 0);
     let region_param_names = RegionParamNames::from_generics(ast_generics);
     let rb = in_binding_rscope(&empty_rscope, region_param_names);
-    let input_tys = decl.inputs.map(|a| ty_of_arg(ccx, &rb, a, None) );
-    let output_ty = ast_ty_to_ty(ccx, &rb, &decl.output);
+    let input_tys = decl.inputs.map(|a| ty_of_arg(ccx, &rb, *a, None) );
+    let output_ty = ast_ty_to_ty(ccx, &rb, decl.output);
 
     let t_fn = ty::mk_bare_fn(
         ccx.tcx,

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -94,7 +94,7 @@ fn fold_const(
             do astsrv::exec(srv) |ctxt| {
                 match ctxt.ast_map.get_copy(&doc.id()) {
                     ast_map::node_item(@ast::item {
-                        node: ast::item_static(ref ty, _, _), _
+                        node: ast::item_static(@ref ty, _, _), _
                     }, _) => {
                         pprust::ty_to_str(ty, extract::interner())
                     }
@@ -245,7 +245,7 @@ fn fold_impl(
         do astsrv::exec(srv) |ctxt| {
             match ctxt.ast_map.get_copy(&doc.id()) {
                 ast_map::node_item(@ast::item {
-                    node: ast::item_impl(ref generics, ref opt_trait_type, ref self_ty, _), _
+                    node: ast::item_impl(ref generics, ref opt_trait_type, @ref self_ty, _), _
                 }, _) => {
                     let bounds = pprust::generics_to_str(generics, extract::interner());
                     let bounds = if bounds.is_empty() { None } else { Some(bounds) };
@@ -285,7 +285,7 @@ fn fold_type(
                 match ctxt.ast_map.get_copy(&doc.id()) {
                     ast_map::node_item(@ast::item {
                         ident: ident,
-                        node: ast::item_ty(ref ty, ref params), _
+                        node: ast::item_ty(@ref ty, ref params), _
                     }, _) => {
                         Some(fmt!(
                             "type %s%s = %s",

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -110,7 +110,7 @@ pub struct Path {
     global: bool,
     idents: ~[ident],
     rp: Option<Lifetime>,
-    types: ~[Ty],
+    types: ~[@Ty],
 }
 
 pub type crate_num = int;
@@ -361,7 +361,7 @@ pub enum stmt_ {
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub struct local_ {
     is_mutbl: bool,
-    ty: Ty,
+    ty: @Ty,
     pat: @pat,
     init: Option<@expr>,
     id: node_id,
@@ -429,12 +429,12 @@ pub enum expr_ {
     expr_vstore(@expr, expr_vstore),
     expr_vec(~[@expr], mutability),
     expr_call(@expr, ~[@expr], CallSugar),
-    expr_method_call(node_id, @expr, ident, ~[Ty], ~[@expr], CallSugar),
+    expr_method_call(node_id, @expr, ident, ~[@Ty], ~[@expr], CallSugar),
     expr_tup(~[@expr]),
     expr_binary(node_id, binop, @expr, @expr),
     expr_unary(node_id, unop, @expr),
     expr_lit(@lit),
-    expr_cast(@expr, Ty),
+    expr_cast(@expr, @Ty),
     expr_if(@expr, blk, Option<@expr>),
     expr_while(@expr, blk),
     /* Conditionless loop (can be exited with break, cont, or ret)
@@ -454,7 +454,7 @@ pub enum expr_ {
     expr_copy(@expr),
     expr_assign(@expr, @expr),
     expr_assign_op(node_id, binop, @expr, @expr),
-    expr_field(@expr, ident, ~[Ty]),
+    expr_field(@expr, ident, ~[@Ty]),
     expr_index(node_id, @expr, @expr),
     expr_path(Path),
 
@@ -604,7 +604,7 @@ pub enum lit_ {
 // type structure in middle/ty.rs as well.
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub struct mt {
-    ty: ~Ty,
+    ty: @Ty,
     mutbl: mutability,
 }
 
@@ -733,7 +733,7 @@ pub enum ty_ {
     ty_rptr(Option<Lifetime>, mt),
     ty_closure(@TyClosure),
     ty_bare_fn(@TyBareFn),
-    ty_tup(~[Ty]),
+    ty_tup(~[@Ty]),
     ty_path(Path, Option<OptVec<TyParamBound>>, node_id), // for #7264; see above
     ty_mac(mac),
     // ty_infer means the type should be inferred instead of it having been
@@ -762,7 +762,7 @@ pub struct inline_asm {
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub struct arg {
     is_mutbl: bool,
-    ty: Ty,
+    ty: @Ty,
     pat: @pat,
     id: node_id,
 }
@@ -770,7 +770,7 @@ pub struct arg {
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub struct fn_decl {
     inputs: ~[arg],
-    output: Ty,
+    output: @Ty,
     cf: ret_style,
 }
 
@@ -845,7 +845,7 @@ pub struct foreign_mod {
 
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub struct variant_arg {
-    ty: Ty,
+    ty: @Ty,
     id: node_id,
 }
 
@@ -959,7 +959,7 @@ impl visibility {
 pub struct struct_field_ {
     kind: struct_field_kind,
     id: node_id,
-    ty: Ty,
+    ty: @Ty,
     attrs: ~[attribute],
 }
 
@@ -995,17 +995,17 @@ pub struct item {
 
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub enum item_ {
-    item_static(Ty, mutability, @expr),
+    item_static(@Ty, mutability, @expr),
     item_fn(fn_decl, purity, AbiSet, Generics, blk),
     item_mod(_mod),
     item_foreign_mod(foreign_mod),
-    item_ty(Ty, Generics),
+    item_ty(@Ty, Generics),
     item_enum(enum_def, Generics),
     item_struct(@struct_def, Generics),
     item_trait(Generics, ~[trait_ref], ~[trait_method]),
     item_impl(Generics,
               Option<trait_ref>, // (optional) trait this impl implements
-              Ty, // self
+              @Ty, // self
               ~[@method]),
     // a macro invocation (which includes macro definition)
     item_mac(mac),
@@ -1024,7 +1024,7 @@ pub struct foreign_item {
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub enum foreign_item_ {
     foreign_item_fn(fn_decl, purity, Generics),
-    foreign_item_static(Ty, /* is_mutbl */ bool),
+    foreign_item_static(@Ty, /* is_mutbl */ bool),
 }
 
 // The data we save and restore about an inlined item or method.  This is not

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -39,30 +39,31 @@ pub trait AstBuilder {
                 global: bool,
                 idents: ~[ast::ident],
                 rp: Option<ast::Lifetime>,
-                types: ~[ast::Ty])
+                types: ~[@ast::Ty])
         -> ast::Path;
 
     // types
-    fn ty_mt(&self, ty: ast::Ty, mutbl: ast::mutability) -> ast::mt;
+    fn ty_mt(&self, ty: @ast::Ty, mutbl: ast::mutability) -> ast::mt;
 
-    fn ty(&self, span: span, ty: ast::ty_) -> ast::Ty;
-    fn ty_path(&self, ast::Path, Option<OptVec<ast::TyParamBound>>) -> ast::Ty;
-    fn ty_ident(&self, span: span, idents: ast::ident) -> ast::Ty;
+    fn ty(&self, span: span, ty: ast::ty_) -> @ast::Ty;
+    fn ty_path(&self, ast::Path, Option<OptVec<ast::TyParamBound>>) -> @ast::Ty;
+    fn ty_ident(&self, span: span, idents: ast::ident) -> @ast::Ty;
 
     fn ty_rptr(&self, span: span,
-               ty: ast::Ty,
+               ty: @ast::Ty,
                lifetime: Option<ast::Lifetime>,
-               mutbl: ast::mutability) -> ast::Ty;
-    fn ty_uniq(&self, span: span, ty: ast::Ty) -> ast::Ty;
-    fn ty_box(&self, span: span, ty: ast::Ty, mutbl: ast::mutability) -> ast::Ty;
+               mutbl: ast::mutability)
+        -> @ast::Ty;
+    fn ty_uniq(&self, span: span, ty: @ast::Ty) -> @ast::Ty;
+    fn ty_box(&self, span: span, ty: @ast::Ty, mutbl: ast::mutability) -> @ast::Ty;
 
-    fn ty_option(&self, ty: ast::Ty) -> ast::Ty;
-    fn ty_infer(&self, sp: span) -> ast::Ty;
-    fn ty_nil(&self) -> ast::Ty;
+    fn ty_option(&self, ty: @ast::Ty) -> @ast::Ty;
+    fn ty_infer(&self, sp: span) -> @ast::Ty;
+    fn ty_nil(&self) -> @ast::Ty;
 
-    fn ty_vars(&self, ty_params: &OptVec<ast::TyParam>) -> ~[ast::Ty];
-    fn ty_vars_global(&self, ty_params: &OptVec<ast::TyParam>) -> ~[ast::Ty];
-    fn ty_field_imm(&self, span: span, name: ident, ty: ast::Ty) -> ast::ty_field;
+    fn ty_vars(&self, ty_params: &OptVec<ast::TyParam>) -> ~[@ast::Ty];
+    fn ty_vars_global(&self, ty_params: &OptVec<ast::TyParam>) -> ~[@ast::Ty];
+    fn ty_field_imm(&self, span: span, name: ident, ty: @ast::Ty) -> ast::ty_field;
     fn strip_bounds(&self, bounds: &Generics) -> Generics;
 
     fn typaram(&self, id: ast::ident, bounds: OptVec<ast::TyParamBound>) -> ast::TyParam;
@@ -166,25 +167,25 @@ pub trait AstBuilder {
     fn item(&self, span: span,
             name: ident, attrs: ~[ast::attribute], node: ast::item_) -> @ast::item;
 
-    fn arg(&self, span: span, name: ident, ty: ast::Ty) -> ast::arg;
+    fn arg(&self, span: span, name: ident, ty: @ast::Ty) -> ast::arg;
     // XXX unused self
-    fn fn_decl(&self, inputs: ~[ast::arg], output: ast::Ty) -> ast::fn_decl;
+    fn fn_decl(&self, inputs: ~[ast::arg], output: @ast::Ty) -> ast::fn_decl;
 
     fn item_fn_poly(&self,
                     span: span,
                     name: ident,
                     inputs: ~[ast::arg],
-                    output: ast::Ty,
+                    output: @ast::Ty,
                     generics: Generics,
                     body: ast::blk) -> @ast::item;
     fn item_fn(&self,
                span: span,
                name: ident,
                inputs: ~[ast::arg],
-               output: ast::Ty,
+               output: @ast::Ty,
                body: ast::blk) -> @ast::item;
 
-    fn variant(&self, span: span, name: ident, tys: ~[ast::Ty]) -> ast::variant;
+    fn variant(&self, span: span, name: ident, tys: ~[@ast::Ty]) -> ast::variant;
     fn item_enum_poly(&self,
                       span: span,
                       name: ident,
@@ -206,9 +207,9 @@ pub trait AstBuilder {
     fn item_ty_poly(&self,
                     span: span,
                     name: ident,
-                    ty: ast::Ty,
+                    ty: @ast::Ty,
                     generics: Generics) -> @ast::item;
-    fn item_ty(&self, span: span, name: ident, ty: ast::Ty) -> @ast::item;
+    fn item_ty(&self, span: span, name: ident, ty: @ast::Ty) -> @ast::item;
 
     fn attribute(&self, sp: span, mi: @ast::meta_item) -> ast::attribute;
 
@@ -238,7 +239,7 @@ impl AstBuilder for @ExtCtxt {
                 global: bool,
                 idents: ~[ast::ident],
                 rp: Option<ast::Lifetime>,
-                types: ~[ast::Ty])
+                types: ~[@ast::Ty])
         -> ast::Path {
         ast::Path {
             span: sp,
@@ -249,15 +250,15 @@ impl AstBuilder for @ExtCtxt {
         }
     }
 
-    fn ty_mt(&self, ty: ast::Ty, mutbl: ast::mutability) -> ast::mt {
+    fn ty_mt(&self, ty: @ast::Ty, mutbl: ast::mutability) -> ast::mt {
         ast::mt {
-            ty: ~ty,
+            ty: ty,
             mutbl: mutbl
         }
     }
 
-    fn ty(&self, span: span, ty: ast::ty_) -> ast::Ty {
-        ast::Ty {
+    fn ty(&self, span: span, ty: ast::ty_) -> @ast::Ty {
+        @ast::Ty {
             id: self.next_id(),
             span: span,
             node: ty
@@ -265,7 +266,7 @@ impl AstBuilder for @ExtCtxt {
     }
 
     fn ty_path(&self, path: ast::Path, bounds: Option<OptVec<ast::TyParamBound>>)
-              -> ast::Ty {
+              -> @ast::Ty {
         self.ty(path.span,
                 ast::ty_path(path, bounds, self.next_id()))
     }
@@ -273,28 +274,28 @@ impl AstBuilder for @ExtCtxt {
     // Might need to take bounds as an argument in the future, if you ever want
     // to generate a bounded existential trait type.
     fn ty_ident(&self, span: span, ident: ast::ident)
-        -> ast::Ty {
+        -> @ast::Ty {
         self.ty_path(self.path_ident(span, ident), None)
     }
 
     fn ty_rptr(&self,
                span: span,
-               ty: ast::Ty,
+               ty: @ast::Ty,
                lifetime: Option<ast::Lifetime>,
                mutbl: ast::mutability)
-        -> ast::Ty {
+        -> @ast::Ty {
         self.ty(span,
                 ast::ty_rptr(lifetime, self.ty_mt(ty, mutbl)))
     }
-    fn ty_uniq(&self, span: span, ty: ast::Ty) -> ast::Ty {
+    fn ty_uniq(&self, span: span, ty: @ast::Ty) -> @ast::Ty {
         self.ty(span, ast::ty_uniq(self.ty_mt(ty, ast::m_imm)))
     }
     fn ty_box(&self, span: span,
-                 ty: ast::Ty, mutbl: ast::mutability) -> ast::Ty {
+                 ty: @ast::Ty, mutbl: ast::mutability) -> @ast::Ty {
         self.ty(span, ast::ty_box(self.ty_mt(ty, mutbl)))
     }
 
-    fn ty_option(&self, ty: ast::Ty) -> ast::Ty {
+    fn ty_option(&self, ty: @ast::Ty) -> @ast::Ty {
         self.ty_path(
             self.path_all(dummy_sp(),
                           true,
@@ -307,20 +308,20 @@ impl AstBuilder for @ExtCtxt {
                           ~[ ty ]), None)
     }
 
-    fn ty_field_imm(&self, span: span, name: ident, ty: ast::Ty) -> ast::ty_field {
+    fn ty_field_imm(&self, span: span, name: ident, ty: @ast::Ty) -> ast::ty_field {
         respan(span,
                ast::ty_field_ {
                    ident: name,
-                   mt: ast::mt { ty: ~ty, mutbl: ast::m_imm },
+                   mt: ast::mt { ty: ty, mutbl: ast::m_imm },
                })
     }
 
-    fn ty_infer(&self, span: span) -> ast::Ty {
+    fn ty_infer(&self, span: span) -> @ast::Ty {
         self.ty(span, ast::ty_infer)
     }
 
-    fn ty_nil(&self) -> ast::Ty {
-        ast::Ty {
+    fn ty_nil(&self) -> @ast::Ty {
+        @ast::Ty {
             id: self.next_id(),
             node: ast::ty_nil,
             span: dummy_sp(),
@@ -334,12 +335,12 @@ impl AstBuilder for @ExtCtxt {
     // these are strange, and probably shouldn't be used outside of
     // pipes. Specifically, the global version possible generates
     // incorrect code.
-    fn ty_vars(&self, ty_params: &OptVec<ast::TyParam>) -> ~[ast::Ty] {
+    fn ty_vars(&self, ty_params: &OptVec<ast::TyParam>) -> ~[@ast::Ty] {
         opt_vec::take_vec(
             ty_params.map(|p| self.ty_ident(dummy_sp(), p.ident)))
     }
 
-    fn ty_vars_global(&self, ty_params: &OptVec<ast::TyParam>) -> ~[ast::Ty] {
+    fn ty_vars_global(&self, ty_params: &OptVec<ast::TyParam>) -> ~[@ast::Ty] {
         opt_vec::take_vec(
             ty_params.map(|p| self.ty_path(
                 self.path_global(dummy_sp(), ~[p.ident]), None)))
@@ -641,7 +642,7 @@ impl AstBuilder for @ExtCtxt {
         self.lambda1(span, self.blk(span, stmts, None), ident)
     }
 
-    fn arg(&self, span: span, ident: ast::ident, ty: ast::Ty) -> ast::arg {
+    fn arg(&self, span: span, ident: ast::ident, ty: @ast::Ty) -> ast::arg {
         let arg_pat = self.pat_ident(span, ident);
         ast::arg {
             is_mutbl: false,
@@ -652,7 +653,7 @@ impl AstBuilder for @ExtCtxt {
     }
 
     // XXX unused self
-    fn fn_decl(&self, inputs: ~[ast::arg], output: ast::Ty) -> ast::fn_decl {
+    fn fn_decl(&self, inputs: ~[ast::arg], output: @ast::Ty) -> ast::fn_decl {
         ast::fn_decl {
             inputs: inputs,
             output: output,
@@ -676,7 +677,7 @@ impl AstBuilder for @ExtCtxt {
                     span: span,
                     name: ident,
                     inputs: ~[ast::arg],
-                    output: ast::Ty,
+                    output: @ast::Ty,
                     generics: Generics,
                     body: ast::blk) -> @ast::item {
         self.item(span,
@@ -693,7 +694,7 @@ impl AstBuilder for @ExtCtxt {
                span: span,
                name: ident,
                inputs: ~[ast::arg],
-               output: ast::Ty,
+               output: @ast::Ty,
                body: ast::blk
               ) -> @ast::item {
         self.item_fn_poly(
@@ -705,10 +706,10 @@ impl AstBuilder for @ExtCtxt {
             body)
     }
 
-    fn variant(&self, span: span, name: ident, tys: ~[ast::Ty]) -> ast::variant {
-        let args = tys.consume_iter().transform(|ty| {
-            ast::variant_arg { ty: ty, id: self.next_id() }
-        }).collect();
+    fn variant(&self, span: span, name: ident, tys: ~[@ast::Ty]) -> ast::variant {
+        let args = do tys.map |ty| {
+            ast::variant_arg { ty: *ty, id: self.next_id() }
+        };
 
         respan(span,
                ast::variant_ {
@@ -772,12 +773,12 @@ impl AstBuilder for @ExtCtxt {
         )
     }
 
-    fn item_ty_poly(&self, span: span, name: ident, ty: ast::Ty,
+    fn item_ty_poly(&self, span: span, name: ident, ty: @ast::Ty,
                     generics: Generics) -> @ast::item {
         self.item(span, name, ~[], ast::item_ty(ty, generics))
     }
 
-    fn item_ty(&self, span: span, name: ident, ty: ast::Ty) -> @ast::item {
+    fn item_ty(&self, span: span, name: ident, ty: @ast::Ty) -> @ast::item {
         self.item_ty_poly(span, name, ty, ast_util::empty_generics())
     }
 

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -456,7 +456,7 @@ impl<'self> MethodDef<'self> {
     }
 
     fn get_ret_ty(&self, cx: @ExtCtxt, span: span,
-                     generics: &Generics, type_ident: ident) -> ast::Ty {
+                     generics: &Generics, type_ident: ident) -> @ast::Ty {
         self.ret_ty.to_ty(cx, span, type_ident, generics)
     }
 
@@ -466,7 +466,7 @@ impl<'self> MethodDef<'self> {
 
     fn split_self_nonself_args(&self, cx: @ExtCtxt, span: span,
                              type_ident: ident, generics: &Generics)
-        -> (ast::explicit_self, ~[@expr], ~[@expr], ~[(ident, ast::Ty)]) {
+        -> (ast::explicit_self, ~[@expr], ~[@expr], ~[(ident, @ast::Ty)]) {
 
         let mut self_args = ~[];
         let mut nonself_args = ~[];
@@ -514,7 +514,7 @@ impl<'self> MethodDef<'self> {
                      type_ident: ident,
                      generics: &Generics,
                      explicit_self: ast::explicit_self,
-                     arg_types: ~[(ident, ast::Ty)],
+                     arg_types: ~[(ident, @ast::Ty)],
                      body: @expr) -> @ast::method {
         // create the generics that aren't for Self
         let fn_generics = self.generics.to_generics(cx, span, type_ident, generics);

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -61,7 +61,7 @@ impl<'self> Path<'self> {
                  span: span,
                  self_ty: ident,
                  self_generics: &Generics)
-                 -> ast::Ty {
+                 -> @ast::Ty {
         cx.ty_path(self.to_path(cx, span, self_ty, self_generics), None)
     }
     pub fn to_path(&self,
@@ -122,7 +122,7 @@ impl<'self> Ty<'self> {
                  span: span,
                  self_ty: ident,
                  self_generics: &Generics)
-                 -> ast::Ty {
+                 -> @ast::Ty {
         match *self {
             Ptr(ref ty, ref ptr) => {
                 let raw_ty = ty.to_ty(cx, span, self_ty, self_generics);

--- a/src/libsyntax/ext/pipes/ast_builder.rs
+++ b/src/libsyntax/ext/pipes/ast_builder.rs
@@ -42,19 +42,19 @@ pub fn path_global(ids: ~[ident], span: span) -> ast::Path {
 }
 
 pub trait append_types {
-    fn add_ty(&self, ty: ast::Ty) -> ast::Path;
-    fn add_tys(&self, tys: ~[ast::Ty]) -> ast::Path;
+    fn add_ty(&self, ty: @ast::Ty) -> ast::Path;
+    fn add_tys(&self, tys: ~[@ast::Ty]) -> ast::Path;
 }
 
 impl append_types for ast::Path {
-    fn add_ty(&self, ty: ast::Ty) -> ast::Path {
+    fn add_ty(&self, ty: @ast::Ty) -> ast::Path {
         ast::Path {
             types: vec::append_one(copy self.types, ty),
             .. copy *self
         }
     }
 
-    fn add_tys(&self, tys: ~[ast::Ty]) -> ast::Path {
+    fn add_tys(&self, tys: ~[@ast::Ty]) -> ast::Path {
         ast::Path {
             types: vec::append(copy self.types, tys),
             .. copy *self

--- a/src/libsyntax/ext/pipes/check.rs
+++ b/src/libsyntax/ext/pipes/check.rs
@@ -49,7 +49,7 @@ impl proto::visitor<(), (), ()> for @ExtCtxt {
         }
     }
 
-    fn visit_message(&self, name: @str, _span: span, _tys: &[ast::Ty],
+    fn visit_message(&self, name: @str, _span: span, _tys: &[@ast::Ty],
                      this: state, next: Option<next_state>) {
         match next {
           Some(ref next_state) => {

--- a/src/libsyntax/ext/pipes/pipec.rs
+++ b/src/libsyntax/ext/pipes/pipec.rs
@@ -25,7 +25,7 @@ use std::vec;
 
 pub trait gen_send {
     fn gen_send(&mut self, cx: @ExtCtxt, try: bool) -> @ast::item;
-    fn to_ty(&mut self, cx: @ExtCtxt) -> ast::Ty;
+    fn to_ty(&mut self, cx: @ExtCtxt) -> @ast::Ty;
 }
 
 pub trait to_type_decls {
@@ -37,7 +37,7 @@ pub trait to_type_decls {
 pub trait gen_init {
     fn gen_init(&self, cx: @ExtCtxt) -> @ast::item;
     fn compile(&self, cx: @ExtCtxt) -> @ast::item;
-    fn buffer_ty_path(&self, cx: @ExtCtxt) -> ast::Ty;
+    fn buffer_ty_path(&self, cx: @ExtCtxt) -> @ast::Ty;
     fn gen_buffer_type(&self, cx: @ExtCtxt) -> @ast::item;
     fn gen_buffer_init(&self, ext_cx: @ExtCtxt) -> @ast::expr;
     fn gen_init_bounded(&self, ext_cx: @ExtCtxt) -> @ast::expr;
@@ -56,7 +56,7 @@ impl gen_send for message {
                 next.generics.ty_params.len());
             let arg_names = vec::from_fn(tys.len(), |i| cx.ident_of("x_"+i.to_str()));
             let args_ast: ~[ast::arg] = arg_names.iter().zip(tys.iter())
-                .transform(|(n, t)| cx.arg(span, copy *n, copy *t)).collect();
+                .transform(|(n, t)| cx.arg(span, *n, *t)).collect();
 
             let pipe_ty = cx.ty_path(
                 path(~[this.data_name()], span)
@@ -137,7 +137,7 @@ impl gen_send for message {
                 let arg_names = vec::from_fn(tys.len(), |i| "x_" + i.to_str());
 
                 let args_ast: ~[ast::arg] = arg_names.iter().zip(tys.iter())
-                    .transform(|(&n, t)| cx.arg(span, cx.ident_of(n), copy *t)).collect();
+                    .transform(|(n, t)| cx.arg(span, cx.ident_of(*n), *t)).collect();
 
                 let args_ast = vec::append(
                     ~[cx.arg(span,
@@ -189,7 +189,7 @@ impl gen_send for message {
           }
         }
 
-    fn to_ty(&mut self, cx: @ExtCtxt) -> ast::Ty {
+    fn to_ty(&mut self, cx: @ExtCtxt) -> @ast::Ty {
         cx.ty_path(path(~[cx.ident_of(self.name())], self.span())
           .add_tys(cx.ty_vars(&self.get_generics().ty_params)), None)
     }
@@ -369,7 +369,7 @@ impl gen_init for protocol {
         })
     }
 
-    fn buffer_ty_path(&self, cx: @ExtCtxt) -> ast::Ty {
+    fn buffer_ty_path(&self, cx: @ExtCtxt) -> @ast::Ty {
         let mut params: OptVec<ast::TyParam> = opt_vec::Empty;
         for self.states.iter().advance |s| {
             for s.generics.ty_params.iter().advance |tp| {

--- a/src/libsyntax/ext/pipes/proto.rs
+++ b/src/libsyntax/ext/pipes/proto.rs
@@ -37,11 +37,11 @@ impl direction {
 
 pub struct next_state {
     state: @str,
-    tys: ~[ast::Ty],
+    tys: ~[@ast::Ty],
 }
 
 // name, span, data, current state, next state
-pub struct message(@str, span, ~[ast::Ty], state, Option<next_state>);
+pub struct message(@str, span, ~[@ast::Ty], state, Option<next_state>);
 
 impl message {
     pub fn name(&mut self) -> @str {
@@ -81,7 +81,7 @@ impl state_ {
     pub fn add_message(@self,
                        name: @str,
                        span: span,
-                       data: ~[ast::Ty],
+                       data: ~[@ast::Ty],
                        next: Option<next_state>) {
         self.messages.push(message(name, span, data, self,
                                    next));
@@ -96,7 +96,7 @@ impl state_ {
     }
 
     /// Returns the type that is used for the messages.
-    pub fn to_ty(&self, cx: @ExtCtxt) -> ast::Ty {
+    pub fn to_ty(&self, cx: @ExtCtxt) -> @ast::Ty {
         cx.ty_path
             (path(~[cx.ident_of(self.name)],self.span).add_tys(
                 cx.ty_vars(&self.generics.ty_params)), None)
@@ -206,7 +206,7 @@ impl protocol_ {
 pub trait visitor<Tproto, Tstate, Tmessage> {
     fn visit_proto(&self, proto: protocol, st: &[Tstate]) -> Tproto;
     fn visit_state(&self, state: state, m: &[Tmessage]) -> Tstate;
-    fn visit_message(&self, name: @str, spane: span, tys: &[ast::Ty],
+    fn visit_message(&self, name: @str, spane: span, tys: &[@ast::Ty],
                      this: state, next: Option<next_state>) -> Tmessage;
 }
 

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -88,13 +88,13 @@ pub mod rt {
         }
     }
 
-    impl ToSource for ast::Ty {
+    impl ToSource for @ast::Ty {
         fn to_source(&self) -> @str {
-            pprust::ty_to_str(self, get_ident_interner()).to_managed()
+            pprust::ty_to_str(*self, get_ident_interner()).to_managed()
         }
     }
 
-    impl<'self> ToSource for &'self [ast::Ty] {
+    impl<'self> ToSource for &'self [@ast::Ty] {
         fn to_source(&self) -> @str {
             self.map(|i| i.to_source()).connect(", ").to_managed()
         }
@@ -216,13 +216,13 @@ pub mod rt {
         }
     }
 
-    impl ToTokens for ast::Ty {
+    impl ToTokens for @ast::Ty {
         fn to_tokens(&self, cx: @ExtCtxt) -> ~[token_tree] {
             cx.parse_tts(self.to_source())
         }
     }
 
-    impl<'self> ToTokens for &'self [ast::Ty] {
+    impl<'self> ToTokens for &'self [@ast::Ty] {
         fn to_tokens(&self, cx: @ExtCtxt) -> ~[token_tree] {
             cx.parse_tts(self.to_source())
         }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -486,7 +486,7 @@ mod test {
         assert_eq!(parser.parse_arg_general(true),
                    ast::arg{
                        is_mutbl: false,
-                       ty: ast::Ty{id:3, // fixme
+                       ty: @ast::Ty{id:3, // fixme
                                     node: ast::ty_path(ast::Path{
                                         span:sp(4,4), // this is bizarre...
                                         // check this in the original parser?
@@ -523,7 +523,7 @@ mod test {
                             node: ast::item_fn(ast::fn_decl{
                                 inputs: ~[ast::arg{
                                     is_mutbl: false,
-                                    ty: ast::Ty{id:3, // fixme
+                                    ty: @ast::Ty{id:3, // fixme
                                                 node: ast::ty_path(ast::Path{
                                         span:sp(10,13),
                                         global:false,
@@ -546,7 +546,7 @@ mod test {
                                                   span: sp(6,7)},
                                     id: 4 // fixme
                                 }],
-                                output: ast::Ty{id:5, // fixme
+                                output: @ast::Ty{id:5, // fixme
                                                  node: ast::ty_nil,
                                                  span:sp(15,15)}, // not sure
                                 cf: ast::return_val

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -823,7 +823,7 @@ impl Parser {
     // parse a possibly mutable type
     pub fn parse_mt(&self) -> mt {
         let mutbl = self.parse_mutability();
-        let t = ~self.parse_ty(false);
+        let t = self.parse_ty(false);
         mt { ty: t, mutbl: mutbl }
     }
 
@@ -834,7 +834,7 @@ impl Parser {
         let mutbl = self.parse_mutability();
         let id = self.parse_ident();
         self.expect(&token::COLON);
-        let ty = ~self.parse_ty(false);
+        let ty = self.parse_ty(false);
         spanned(
             lo,
             ty.span.hi,
@@ -846,13 +846,13 @@ impl Parser {
     }
 
     // parse optional return type [ -> TY ] in function decl
-    pub fn parse_ret_ty(&self) -> (ret_style, Ty) {
+    pub fn parse_ret_ty(&self) -> (ret_style, @Ty) {
         return if self.eat(&token::RARROW) {
             let lo = self.span.lo;
             if self.eat(&token::NOT) {
                 (
                     noreturn,
-                    Ty {
+                    @Ty {
                         id: self.get_id(),
                         node: ty_bot,
                         span: mk_sp(lo, self.last_span.hi)
@@ -865,7 +865,7 @@ impl Parser {
             let pos = self.span.lo;
             (
                 return_val,
-                Ty {
+                @Ty {
                     id: self.get_id(),
                     node: ty_nil,
                     span: mk_sp(pos, pos),
@@ -877,7 +877,7 @@ impl Parser {
     // parse a type.
     // Useless second parameter for compatibility with quasiquote macros.
     // Bleh!
-    pub fn parse_ty(&self, _: bool) -> Ty {
+    pub fn parse_ty(&self, _: bool) -> @Ty {
         maybe_whole!(self, nt_ty);
 
         let lo = self.span.lo;
@@ -974,7 +974,7 @@ impl Parser {
         };
 
         let sp = mk_sp(lo, self.last_span.hi);
-        Ty {id: self.get_id(), node: t, span: sp}
+        @Ty {id: self.get_id(), node: t, span: sp}
     }
 
     // parse the type following a @ or a ~
@@ -1115,7 +1115,7 @@ impl Parser {
         let t = if self.eat(&token::COLON) {
             self.parse_ty(false)
         } else {
-            Ty {
+            @Ty {
                 id: self.get_id(),
                 node: ty_infer,
                 span: mk_sp(self.span.lo, self.span.hi),
@@ -1462,7 +1462,7 @@ impl Parser {
     pub fn mk_method_call(&self,
                       rcvr: @expr,
                       ident: ident,
-                      tps: ~[Ty],
+                      tps: ~[@Ty],
                       args: ~[@expr],
                       sugar: CallSugar) -> ast::expr_ {
         expr_method_call(self.get_id(), rcvr, ident, tps, args, sugar)
@@ -1472,7 +1472,7 @@ impl Parser {
         expr_index(self.get_id(), expr, idx)
     }
 
-    pub fn mk_field(&self, expr: @expr, ident: ident, tys: ~[Ty]) -> ast::expr_ {
+    pub fn mk_field(&self, expr: @expr, ident: ident, tys: ~[@Ty]) -> ast::expr_ {
         expr_field(expr, ident, tys)
     }
 
@@ -2214,7 +2214,7 @@ impl Parser {
                     // No argument list - `do foo {`
                       ast::fn_decl {
                           inputs: ~[],
-                          output: Ty {
+                          output: @Ty {
                               id: self.get_id(),
                               node: ty_infer,
                               span: *self.span
@@ -2825,7 +2825,7 @@ impl Parser {
             self.obsolete(*self.span, ObsoleteMutWithMultipleBindings)
         }
 
-        let mut ty = Ty {
+        let mut ty = @Ty {
             id: self.get_id(),
             node: ty_infer,
             span: mk_sp(lo, lo),
@@ -3234,7 +3234,7 @@ impl Parser {
 
     // parse a generic use site
     fn parse_generic_values(
-        &self) -> (OptVec<ast::Lifetime>, ~[Ty])
+        &self) -> (OptVec<ast::Lifetime>, ~[@Ty])
     {
         if !self.eat(&token::LT) {
             (opt_vec::Empty, ~[])
@@ -3244,7 +3244,7 @@ impl Parser {
     }
 
     fn parse_generic_values_after_lt(
-        &self) -> (OptVec<ast::Lifetime>, ~[Ty])
+        &self) -> (OptVec<ast::Lifetime>, ~[@Ty])
     {
         let lifetimes = self.parse_lifetimes();
         let result = self.parse_seq_to_gt(
@@ -3454,7 +3454,7 @@ impl Parser {
         let output = if self.eat(&token::RARROW) {
             self.parse_ty(false)
         } else {
-            Ty { id: self.get_id(), node: ty_infer, span: *self.span }
+            @Ty { id: self.get_id(), node: ty_infer, span: *self.span }
         };
 
         ast::fn_decl {
@@ -4172,9 +4172,9 @@ impl Parser {
                     seq_sep_trailing_disallowed(token::COMMA),
                     |p| p.parse_ty(false)
                 );
-                for arg_tys.consume_iter().advance |ty| {
+                for arg_tys.iter().advance |ty| {
                     args.push(ast::variant_arg {
-                        ty: ty,
+                        ty: *ty,
                         id: self.get_id(),
                     });
                 }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -104,7 +104,7 @@ pub enum nonterminal {
     nt_stmt(@ast::stmt),
     nt_pat( @ast::pat),
     nt_expr(@ast::expr),
-    nt_ty(   ast::Ty),
+    nt_ty(  @ast::Ty),
     nt_ident(ast::ident, bool),
     nt_path( ast::Path),
     nt_tt(  @ast::token_tree), //needs @ed to break a circularity

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -398,7 +398,7 @@ pub fn print_type(s: @ps, ty: &ast::Ty) {
       }
       ast::ty_tup(ref elts) => {
         popen(s);
-        commasep(s, inconsistent, *elts, print_type);
+        commasep(s, inconsistent, *elts, |p, &t| print_type(p, t));
         if elts.len() == 1 {
             word(s.s, ",");
         }
@@ -454,7 +454,7 @@ pub fn print_foreign_item(s: @ps, item: &ast::foreign_item) {
         word(s.s, ";");
         end(s); // end the outer fn box
       }
-      ast::foreign_item_static(ref t, m) => {
+      ast::foreign_item_static(t, m) => {
         head(s, "static");
         if m {
             word_space(s, "mut");
@@ -476,7 +476,7 @@ pub fn print_item(s: @ps, item: &ast::item) {
     let ann_node = node_item(s, item);
     (s.ann.pre)(ann_node);
     match item.node {
-      ast::item_static(ref ty, m, expr) => {
+      ast::item_static(ty, m, expr) => {
         head(s, visibility_qualified(item.vis, "static"));
         if m == ast::m_mutbl {
             word_space(s, "mut");
@@ -530,7 +530,7 @@ pub fn print_item(s: @ps, item: &ast::item) {
         print_foreign_mod(s, nmod, item.attrs);
         bclose(s, item.span);
       }
-      ast::item_ty(ref ty, ref params) => {
+      ast::item_ty(ty, ref params) => {
         ibox(s, indent_unit);
         ibox(s, 0u);
         word_nbsp(s, visibility_qualified(item.vis, "type"));
@@ -559,7 +559,7 @@ pub fn print_item(s: @ps, item: &ast::item) {
           print_struct(s, struct_def, generics, item.ident, item.span);
       }
 
-      ast::item_impl(ref generics, ref opt_trait, ref ty, ref methods) => {
+      ast::item_impl(ref generics, ref opt_trait, ty, ref methods) => {
         head(s, visibility_qualified(item.vis, "impl"));
         if generics.is_parameterized() {
             print_generics(s, generics);
@@ -694,7 +694,7 @@ pub fn print_struct(s: @ps,
                     ast::named_field(*) => fail!("unexpected named field"),
                     ast::unnamed_field => {
                         maybe_print_comment(s, field.span.lo);
-                        print_type(s, &field.node.ty);
+                        print_type(s, field.node.ty);
                     }
                 }
             }
@@ -718,7 +718,7 @@ pub fn print_struct(s: @ps,
                     print_visibility(s, visibility);
                     print_ident(s, ident);
                     word_nbsp(s, ":");
-                    print_type(s, &field.node.ty);
+                    print_type(s, field.node.ty);
                     word(s.s, ",");
                 }
             }
@@ -777,7 +777,7 @@ pub fn print_variant(s: @ps, v: &ast::variant) {
             if !args.is_empty() {
                 popen(s);
                 fn print_variant_arg(s: @ps, arg: &ast::variant_arg) {
-                    print_type(s, &arg.ty);
+                    print_type(s, arg.ty);
                 }
                 commasep(s, consistent, *args, print_variant_arg);
                 pclose(s);
@@ -1172,7 +1172,7 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
         print_ident(s, ident);
         if tys.len() > 0u {
             word(s.s, "::<");
-            commasep(s, inconsistent, *tys, print_type);
+            commasep(s, inconsistent, *tys, |p, &e| print_type(p, e));
             word(s.s, ">");
         }
         print_call_post(s, sugar, &blk, &mut base_args);
@@ -1198,7 +1198,7 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
         print_expr(s, expr);
       }
       ast::expr_lit(lit) => print_literal(s, lit),
-      ast::expr_cast(expr, ref ty) => {
+      ast::expr_cast(expr, ty) => {
         print_expr(s, expr);
         space(s.s);
         word_space(s, "as");
@@ -1348,7 +1348,7 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
         print_ident(s, id);
         if tys.len() > 0u {
             word(s.s, "::<");
-            commasep(s, inconsistent, *tys, print_type);
+            commasep(s, inconsistent, *tys, |p, &e| print_type(p, e));
             word(s.s, ">");
         }
       }
@@ -1437,7 +1437,7 @@ pub fn print_local_decl(s: @ps, loc: &ast::local) {
     print_irrefutable_pat(s, loc.node.pat);
     match loc.node.ty.node {
       ast::ty_infer => (),
-      _ => { word_space(s, ":"); print_type(s, &loc.node.ty); }
+      _ => { word_space(s, ":"); print_type(s, loc.node.ty); }
     }
 }
 
@@ -1510,7 +1510,7 @@ fn print_path_(s: @ps, path: &ast::Path, colons_before_params: bool,
                 }
             }
 
-            commasep(s, inconsistent, path.types, print_type);
+            commasep(s, inconsistent, path.types, |p, &e| print_type(p, e));
 
             word(s.s, ">");
         }
@@ -1693,7 +1693,7 @@ pub fn print_fn_args(s: @ps, decl: &ast::fn_decl,
 
     for decl.inputs.iter().advance |arg| {
         if first { first = false; } else { word_space(s, ","); }
-        print_arg(s, arg);
+        print_arg(s, *arg);
     }
 
     end(s);
@@ -1711,7 +1711,7 @@ pub fn print_fn_args_and_ret(s: @ps, decl: &ast::fn_decl,
         _ => {
             space_if_not_bol(s);
             word_space(s, "->");
-            print_type(s, &decl.output);
+            print_type(s, decl.output);
         }
     }
 }
@@ -1726,7 +1726,7 @@ pub fn print_fn_block_args(s: @ps, decl: &ast::fn_decl) {
         _ => {
             space_if_not_bol(s);
             word_space(s, "->");
-            print_type(s, &decl.output);
+            print_type(s, decl.output);
         }
     }
 
@@ -1882,7 +1882,7 @@ pub fn print_mt(s: @ps, mt: &ast::mt) {
     print_type(s, mt.ty);
 }
 
-pub fn print_arg(s: @ps, input: &ast::arg) {
+pub fn print_arg(s: @ps, input: ast::arg) {
     ibox(s, indent_unit);
     if input.is_mutbl {
         word_space(s, "mut");
@@ -1902,7 +1902,7 @@ pub fn print_arg(s: @ps, input: &ast::arg) {
                 space(s.s);
             }
         }
-        print_type(s, &input.ty);
+        print_type(s, input.ty);
       }
     }
     end(s);
@@ -1944,7 +1944,7 @@ pub fn print_ty_fn(s: @ps,
     }
     for decl.inputs.iter().advance |arg| {
         if first { first = false; } else { word_space(s, ","); }
-        print_arg(s, arg);
+        print_arg(s, *arg);
     }
     end(s);
     pclose(s);
@@ -1958,7 +1958,7 @@ pub fn print_ty_fn(s: @ps,
             ibox(s, indent_unit);
             word_space(s, "->");
             if decl.cf == ast::noreturn { word_nbsp(s, "!"); }
-            else { print_type(s, &decl.output); }
+            else { print_type(s, decl.output); }
             end(s);
         }
     }
@@ -2272,7 +2272,7 @@ mod test {
 
         let decl = ast::fn_decl {
             inputs: ~[],
-            output: ast::Ty {id: 0,
+            output: @ast::Ty {id: 0,
                               node: ast::ty_nil,
                               span: codemap::dummy_sp()},
             cf: ast::return_val

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -83,7 +83,7 @@ pub struct Visitor<E> {
     visit_decl: @fn(@decl, (E, vt<E>)),
     visit_expr: @fn(@expr, (E, vt<E>)),
     visit_expr_post: @fn(@expr, (E, vt<E>)),
-    visit_ty: @fn(&Ty, (E, vt<E>)),
+    visit_ty: @fn(@Ty, (E, vt<E>)),
     visit_generics: @fn(&Generics, (E, vt<E>)),
     visit_fn: @fn(&fn_kind, &fn_decl, &blk, span, node_id, (E, vt<E>)),
     visit_ty_method: @fn(&ty_method, (E, vt<E>)),
@@ -131,7 +131,7 @@ pub fn visit_view_item<E>(_vi: &view_item, (_e, _v): (E, vt<E>)) { }
 
 pub fn visit_local<E: Copy>(loc: &local, (e, v): (E, vt<E>)) {
     (v.visit_pat)(loc.node.pat, (copy e, v));
-    (v.visit_ty)(&loc.node.ty, (copy e, v));
+    (v.visit_ty)(loc.node.ty, (copy e, v));
     match loc.node.init {
       None => (),
       Some(ex) => (v.visit_expr)(ex, (e, v))
@@ -144,7 +144,7 @@ fn visit_trait_ref<E: Copy>(tref: &ast::trait_ref, (e, v): (E, vt<E>)) {
 
 pub fn visit_item<E: Copy>(i: &item, (e, v): (E, vt<E>)) {
     match i.node {
-        item_static(ref t, _, ex) => {
+        item_static(t, _, ex) => {
             (v.visit_ty)(t, (copy e, v));
             (v.visit_expr)(ex, (copy e, v));
         }
@@ -169,7 +169,7 @@ pub fn visit_item<E: Copy>(i: &item, (e, v): (E, vt<E>)) {
             for nm.view_items.iter().advance |vi| { (v.visit_view_item)(vi, (copy e, v)); }
             for nm.items.iter().advance |ni| { (v.visit_foreign_item)(*ni, (copy e, v)); }
         }
-        item_ty(ref t, ref tps) => {
+        item_ty(t, ref tps) => {
             (v.visit_ty)(t, (copy e, v));
             (v.visit_generics)(tps, (e, v));
         }
@@ -181,7 +181,7 @@ pub fn visit_item<E: Copy>(i: &item, (e, v): (E, vt<E>)) {
                 (e, v)
             );
         }
-        item_impl(ref tps, ref traits, ref ty, ref methods) => {
+        item_impl(ref tps, ref traits, ty, ref methods) => {
             (v.visit_generics)(tps, (copy e, v));
             for traits.iter().advance |p| {
                 visit_trait_ref(p, (copy e, v));
@@ -213,7 +213,7 @@ pub fn visit_enum_def<E: Copy>(enum_definition: &ast::enum_def,
         match vr.node.kind {
             tuple_variant_kind(ref variant_args) => {
                 for variant_args.iter().advance |va| {
-                    (v.visit_ty)(&va.ty, (copy e, v));
+                    (v.visit_ty)(va.ty, (copy e, v));
                 }
             }
             struct_variant_kind(struct_def) => {
@@ -232,25 +232,25 @@ pub fn skip_ty<E>(_t: &Ty, (_e,_v): (E, vt<E>)) {}
 
 pub fn visit_ty<E: Copy>(t: &Ty, (e, v): (E, vt<E>)) {
     match t.node {
-        ty_box(ref mt) | ty_uniq(ref mt) |
-        ty_vec(ref mt) | ty_ptr(ref mt) | ty_rptr(_, ref mt) => {
+        ty_box(mt) | ty_uniq(mt) |
+        ty_vec(mt) | ty_ptr(mt) | ty_rptr(_, mt) => {
             (v.visit_ty)(mt.ty, (e, v));
         },
         ty_tup(ref ts) => {
             for ts.iter().advance |tt| {
-                (v.visit_ty)(tt, (copy e, v));
+                (v.visit_ty)(*tt, (copy e, v));
             }
         },
         ty_closure(ref f) => {
-            for f.decl.inputs.iter().advance |a| { (v.visit_ty)(&a.ty, (copy e, v)); }
-            (v.visit_ty)(&f.decl.output, (copy e, v));
+            for f.decl.inputs.iter().advance |a| { (v.visit_ty)(a.ty, (copy e, v)); }
+            (v.visit_ty)(f.decl.output, (copy e, v));
             do f.bounds.map |bounds| {
                 visit_ty_param_bounds(bounds, (copy e, v));
             };
         },
         ty_bare_fn(ref f) => {
-            for f.decl.inputs.iter().advance |a| { (v.visit_ty)(&a.ty, (copy e, v)); }
-            (v.visit_ty)(&f.decl.output, (e, v));
+            for f.decl.inputs.iter().advance |a| { (v.visit_ty)(a.ty, (copy e, v)); }
+            (v.visit_ty)(f.decl.output, (e, v));
         },
         ty_path(ref p, ref bounds, _) => {
             visit_path(p, (copy e, v));
@@ -267,7 +267,7 @@ pub fn visit_ty<E: Copy>(t: &Ty, (e, v): (E, vt<E>)) {
 }
 
 pub fn visit_path<E: Copy>(p: &Path, (e, v): (E, vt<E>)) {
-    for p.types.iter().advance |tp| { (v.visit_ty)(tp, (copy e, v)); }
+    for p.types.iter().advance |tp| { (v.visit_ty)(*tp, (copy e, v)); }
 }
 
 pub fn visit_pat<E: Copy>(p: &pat, (e, v): (E, vt<E>)) {
@@ -326,7 +326,7 @@ pub fn visit_foreign_item<E: Copy>(ni: &foreign_item, (e, v): (E, vt<E>)) {
             visit_fn_decl(fd, (copy e, v));
             (v.visit_generics)(generics, (e, v));
         }
-        foreign_item_static(ref t, _) => {
+        foreign_item_static(t, _) => {
             (v.visit_ty)(t, (e, v));
         }
     }
@@ -351,9 +351,9 @@ pub fn visit_generics<E: Copy>(generics: &Generics, (e, v): (E, vt<E>)) {
 pub fn visit_fn_decl<E: Copy>(fd: &fn_decl, (e, v): (E, vt<E>)) {
     for fd.inputs.iter().advance |a| {
         (v.visit_pat)(a.pat, (copy e, v));
-        (v.visit_ty)(&a.ty, (copy e, v));
+        (v.visit_ty)(a.ty, (copy e, v));
     }
-    (v.visit_ty)(&fd.output, (e, v));
+    (v.visit_ty)(fd.output, (e, v));
 }
 
 // Note: there is no visit_method() method in the visitor, instead override
@@ -384,9 +384,9 @@ pub fn visit_fn<E: Copy>(fk: &fn_kind, decl: &fn_decl, body: &blk, _sp: span,
 }
 
 pub fn visit_ty_method<E: Copy>(m: &ty_method, (e, v): (E, vt<E>)) {
-    for m.decl.inputs.iter().advance |a| { (v.visit_ty)(&a.ty, (copy e, v)); }
+    for m.decl.inputs.iter().advance |a| { (v.visit_ty)(a.ty, (copy e, v)); }
     (v.visit_generics)(&m.generics, (copy e, v));
-    (v.visit_ty)(&m.decl.output, (e, v));
+    (v.visit_ty)(m.decl.output, (e, v));
 }
 
 pub fn visit_trait_method<E: Copy>(m: &trait_method, (e, v): (E, vt<E>)) {
@@ -409,7 +409,7 @@ pub fn visit_struct_def<E: Copy>(
 }
 
 pub fn visit_struct_field<E: Copy>(sf: &struct_field, (e, v): (E, vt<E>)) {
-    (v.visit_ty)(&sf.node.ty, (e, v));
+    (v.visit_ty)(sf.node.ty, (e, v));
 }
 
 pub fn visit_block<E: Copy>(b: &blk, (e, v): (E, vt<E>)) {
@@ -475,7 +475,7 @@ pub fn visit_expr<E: Copy>(ex: @expr, (e, v): (E, vt<E>)) {
         expr_method_call(_, callee, _, ref tys, ref args, _) => {
             visit_exprs(*args, (copy e, v));
             for tys.iter().advance |tp| {
-                (v.visit_ty)(tp, (copy e, v));
+                (v.visit_ty)(*tp, (copy e, v));
             }
             (v.visit_expr)(callee, (copy e, v));
         }
@@ -486,7 +486,7 @@ pub fn visit_expr<E: Copy>(ex: @expr, (e, v): (E, vt<E>)) {
         expr_addr_of(_, x) | expr_unary(_, _, x) |
         expr_loop_body(x) | expr_do_body(x) => (v.visit_expr)(x, (copy e, v)),
         expr_lit(_) => (),
-        expr_cast(x, ref t) => {
+        expr_cast(x, t) => {
             (v.visit_expr)(x, (copy e, v));
             (v.visit_ty)(t, (copy e, v));
         }
@@ -527,7 +527,7 @@ pub fn visit_expr<E: Copy>(ex: @expr, (e, v): (E, vt<E>)) {
         expr_field(x, _, ref tys) => {
             (v.visit_expr)(x, (copy e, v));
             for tys.iter().advance |tp| {
-                (v.visit_ty)(tp, (copy e, v));
+                (v.visit_ty)(*tp, (copy e, v));
             }
         }
         expr_index(_, a, b) => {
@@ -579,7 +579,7 @@ pub struct SimpleVisitor {
     visit_decl: @fn(@decl),
     visit_expr: @fn(@expr),
     visit_expr_post: @fn(@expr),
-    visit_ty: @fn(&Ty),
+    visit_ty: @fn(@Ty),
     visit_generics: @fn(&Generics),
     visit_fn: @fn(&fn_kind, &fn_decl, &blk, span, node_id),
     visit_ty_method: @fn(&ty_method),
@@ -591,7 +591,7 @@ pub struct SimpleVisitor {
 
 pub type simple_visitor = @SimpleVisitor;
 
-pub fn simple_ignore_ty(_t: &Ty) {}
+pub fn simple_ignore_ty(_t: @Ty) {}
 
 pub fn default_simple_visitor() -> @SimpleVisitor {
     @SimpleVisitor {
@@ -672,7 +672,7 @@ pub fn mk_simple_visitor(v: simple_visitor) -> vt<()> {
     fn v_expr_post(f: @fn(@expr), ex: @expr, (_e, _v): ((), vt<()>)) {
         f(ex);
     }
-    fn v_ty(f: @fn(&Ty), ty: &Ty, (e, v): ((), vt<()>)) {
+    fn v_ty(f: @fn(@Ty), ty: @Ty, (e, v): ((), vt<()>)) {
         f(ty);
         visit_ty(ty, (e, v));
     }
@@ -717,7 +717,7 @@ pub fn mk_simple_visitor(v: simple_visitor) -> vt<()> {
         f(fk, decl, body, sp, id);
         visit_fn(fk, decl, body, sp, id, (e, v));
     }
-    let visit_ty: @fn(&Ty, ((), vt<()>)) =
+    let visit_ty: @fn(@Ty, ((), vt<()>)) =
         |a,b| v_ty(v.visit_ty, a, b);
     fn v_struct_field(f: @fn(@struct_field), sf: @struct_field, (e, v): ((), vt<()>)) {
         f(sf);


### PR DESCRIPTION
Revert the removal of the `@` from `Ty` as I think it caused the memory regression seen here in #7615. The graph posted on that PR is from before this change.

Since `Ty` is a recursive type, I think that the change from `@` to `~` meant that a copy that would previously stop at the `@` continued. It seems to me that during syntax folding, the data was being kept around somehow, causing the bloat.

This reverts commit 47eca2113c5c55a4ffbb8c11a38c8ca7a79a1d72.
