### PR TITLE
Disallow 'extern' on main/start functions

### DIFF
--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -319,16 +319,19 @@ fn check_main_fn_ty(ccx: &CrateCtxt,
                 }
                 _ => ()
             }
-            let mut ok = ty::type_is_nil(fn_ty.sig.output);
-            let num_args = fn_ty.sig.inputs.len();
-            ok &= num_args == 0u;
-            if !ok {
-                tcx.sess.span_err(
-                    main_span,
-                    fmt!("Wrong type in main function: found `%s`, \
-                          expected `fn() -> ()`",
-                         ppaux::ty_to_str(tcx, main_t)));
-            }
+            let se_ty = ty::mk_bare_fn(tcx, ty::BareFnTy {
+                purity: ast::impure_fn,
+                abis: abi::AbiSet::Rust(),
+                sig: ty::FnSig {
+                    bound_lifetime_names: opt_vec::Empty,
+                    inputs: ~[],
+                    output: ty::mk_nil()
+                }
+            });
+
+            require_same_types(tcx, None, false, main_span, main_t, se_ty,
+                || fmt!("main function expects type: `%s`",
+                        ppaux::ty_to_str(ccx.tcx, se_ty)));
         }
         _ => {
             tcx.sess.span_bug(main_span,

--- a/src/test/compile-fail/bad-main.rs
+++ b/src/test/compile-fail/bad-main.rs
@@ -8,6 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:expected `fn()
-
-fn main(x: int) { }
+fn main(x: int) { } //~ ERROR: main function expects type

--- a/src/test/compile-fail/extern-main-fn.rs
+++ b/src/test/compile-fail/extern-main-fn.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() -> char {
-//~^ ERROR: main function expects type
-}
+extern fn main() {} //~ ERROR: main function expects type

--- a/src/test/compile-fail/main-wrong-type.rs
+++ b/src/test/compile-fail/main-wrong-type.rs
@@ -14,5 +14,5 @@ struct S {
 }
 
 fn main(foo: S) {
-//~^ ERROR Wrong type in main function: found `extern "Rust" fn(S)`
+//~^ ERROR: main function expects type
 }


### PR DESCRIPTION
Translation currently doesn't allow for this attribute to be present (not even `extern "Rust" fn`)

Closes #6451
