### PR TITLE
remove the unused exchange_malloc `align` parameter

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -291,13 +291,12 @@ pub fn malloc_raw_dyn(bcx: block,
 
     if heap == heap_exchange {
         let llty_value = type_of::type_of(ccx, t);
-        let llalign = llalign_of_min(ccx, llty_value);
 
         // Allocate space:
         let r = callee::trans_lang_call(
             bcx,
             bcx.tcx().lang_items.exchange_malloc_fn(),
-            [C_i32(llalign as i32), size],
+            [size],
             None);
         rslt(r.bcx, PointerCast(r.bcx, r.val, llty_value.ptr_to()))
     } else if heap == heap_exchange_vector {

--- a/src/libstd/rt/global_heap.rs
+++ b/src/libstd/rt/global_heap.rs
@@ -76,11 +76,11 @@ pub unsafe fn exchange_malloc(td: *c_char, size: uintptr_t) -> *c_char {
     box as *c_char
 }
 
-// FIXME #4942: Make these signatures agree with exchange_alloc's signatures
+/// The allocator for unique pointers without contained managed pointers.
 #[cfg(not(stage0), not(test))]
 #[lang="exchange_malloc"]
 #[inline]
-pub unsafe fn exchange_malloc(_align: u32, size: uintptr_t) -> *c_char {
+pub unsafe fn exchange_malloc(size: uintptr_t) -> *c_char {
     malloc_raw(size as uint) as *c_char
 }
 


### PR DESCRIPTION
`malloc` already returns memory correctly aligned for every possible
type in standard C, and that's enough for all types in Rust too
