### PR TITLE
rustc: Leak the LLVM module and context. #3552

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -392,8 +392,12 @@ pub mod write {
                 }
                 // Clean up and return
 
-                llvm::LLVMDisposeModule(llmod);
-                llvm::LLVMContextDispose(llcx);
+                // Save some time by not destroying the LLVM module
+                if !sess.opts.leak_llvm {
+                    llvm::LLVMDisposeModule(llmod);
+                    llvm::LLVMContextDispose(llcx);
+                }
+
                 if sess.time_llvm_passes() {
                     llvm::LLVMRustPrintPassTimings();
                 }
@@ -413,8 +417,12 @@ pub mod write {
                 }
             }
 
-            llvm::LLVMDisposeModule(llmod);
-            llvm::LLVMContextDispose(llcx);
+            // Save some time by not destroying the LLVM module
+            if !sess.opts.leak_llvm {
+                llvm::LLVMDisposeModule(llmod);
+                llvm::LLVMContextDispose(llcx);
+            }
+
             if sess.time_llvm_passes() { llvm::LLVMRustPrintPassTimings(); }
         }
     }

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -762,7 +762,8 @@ pub fn build_session_options(binary: @str,
         parse_only: parse_only,
         no_trans: no_trans,
         debugging_opts: debugging_opts,
-        android_cross_path: android_cross_path
+        android_cross_path: android_cross_path,
+        leak_llvm: true
     };
     return sopts;
 }

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -166,6 +166,9 @@ pub struct options {
     no_trans: bool,
     debugging_opts: uint,
     android_cross_path: Option<~str>,
+    // Destroying the LLVM module takes significant time. Standalone rustc
+    // will just leak it to save precious seconds.
+    leak_llvm: bool
 }
 
 pub struct crate_metadata {
@@ -350,6 +353,7 @@ pub fn basic_options() -> @options {
         no_trans: false,
         debugging_opts: 0u,
         android_cross_path: None,
+        leak_llvm: false
     }
 }
 


### PR DESCRIPTION
During normal batch operation, rustc will not bother to dispose of the LLVM module and context in order to save some time.

```
before

time: 9.696 s   translation
time: 37.966 s  LLVM passes
time: 0.302 s   linking

real    1m4.415s
user    1m3.528s
sys     0m0.788s

after

time: 9.759 s   translation
time: 35.625 s  LLVM passes
time: 0.308 s   linking

real    1m3.528s
user    1m2.468s
sys     0m0.968s
```
