### PR TITLE
migrate to native types

### DIFF
--- a/doc/po/tutorial-ffi.md.pot
+++ b/doc/po/tutorial-ffi.md.pot
@@ -306,7 +306,7 @@ msgstr ""
 #. type: Plain text
 #: doc/tutorial-ffi.md:156
 msgid ""
-"~~~~ use std::cast; use std::libc::{c_void, size_t, malloc, free}; use std::"
+"~~~~ use std::cast; use std::libc::{size_t, malloc, free}; use std::"
 "ptr; use std::unstable::intrinsics;"
 msgstr ""
 
@@ -368,7 +368,7 @@ msgid ""
 "            let x = intrinsics::init(); // dummy value to swap in\n"
 "            // moving the object out is needed to call the destructor\n"
 "            ptr::replace_ptr(self.ptr, x);\n"
-"            free(self.ptr as *c_void)\n"
+"            free(self.ptr as *Void)\n"
 "        }\n"
 "    }\n"
 "}\n"

--- a/doc/tutorial-ffi.md
+++ b/doc/tutorial-ffi.md
@@ -150,7 +150,7 @@ wrapping `malloc` and `free`:
 
 ~~~~
 use std::cast;
-use std::libc::{c_void, size_t, malloc, free};
+use std::libc::{size_t, malloc, free};
 use std::ptr;
 use std::unstable::intrinsics;
 
@@ -188,7 +188,7 @@ impl<T: Send> Drop for Unique<T> {
             let x = intrinsics::init(); // dummy value to swap in
             // moving the object out is needed to call the destructor
             ptr::replace_ptr(self.ptr, x);
-            free(self.ptr as *c_void)
+            free(self.ptr as *Void)
         }
     }
 }

--- a/src/etc/gedit/share/gtksourceview-3.0/language-specs/rust.lang
+++ b/src/etc/gedit/share/gtksourceview-3.0/language-specs/rust.lang
@@ -94,7 +94,6 @@
     <context id="ctypes" style-ref="type">
 		<keyword>c_float</keyword>
 		<keyword>c_double</keyword>
-		<keyword>c_void</keyword>
 		<keyword>FILE</keyword>
 		<keyword>fpos_t</keyword>
 		<keyword>DIR</keyword>

--- a/src/etc/kate/rust.xml
+++ b/src/etc/kate/rust.xml
@@ -94,7 +94,6 @@
 	<list name="ctypes">
 		<item> c_float </item>
 		<item> c_double </item>
-		<item> c_void </item>
 		<item> FILE </item>
 		<item> fpos_t </item>
 		<item> DIR </item>

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -37,10 +37,10 @@ syn keyword   rustKeyword     be
 
 syn keyword   rustType        int uint float char bool u8 u16 u32 u64 f32
 syn keyword   rustType        f64 i8 i16 i32 i64 str Self
-syn keyword   rustType        Option Either
+syn keyword   rustType        Option Either Void
 
 " Types from libc
-syn keyword   rustType        c_float c_double c_void FILE fpos_t
+syn keyword   rustType        c_float c_double FILE fpos_t
 syn keyword   rustType        DIR dirent
 syn keyword   rustType        c_char c_schar c_uchar
 syn keyword   rustType        c_short c_ushort c_int c_uint c_long c_ulong

--- a/src/libextra/flate.rs
+++ b/src/libextra/flate.rs
@@ -16,26 +16,26 @@ Simple compression
 
 #[allow(missing_doc)];
 
-use std::libc::{c_void, size_t, c_int};
+use std::libc::{size_t, c_int};
 use std::libc;
 use std::vec;
 
 pub mod rustrt {
-    use std::libc::{c_int, c_void, size_t};
+    use std::libc::{c_int, size_t};
 
     #[link_name = "rustrt"]
     pub extern {
-        unsafe fn tdefl_compress_mem_to_heap(psrc_buf: *const c_void,
+        unsafe fn tdefl_compress_mem_to_heap(psrc_buf: *const Void,
                                              src_buf_len: size_t,
                                              pout_len: *mut size_t,
                                              flags: c_int)
-                                          -> *c_void;
+                                          -> *Void;
 
-        unsafe fn tinfl_decompress_mem_to_heap(psrc_buf: *const c_void,
+        unsafe fn tinfl_decompress_mem_to_heap(psrc_buf: *const Void,
                                                src_buf_len: size_t,
                                                pout_len: *mut size_t,
                                                flags: c_int)
-                                            -> *c_void;
+                                            -> *Void;
     }
 }
 
@@ -49,7 +49,7 @@ pub fn deflate_bytes(bytes: &[u8]) -> ~[u8] {
         unsafe {
             let mut outsz : size_t = 0;
             let res =
-                rustrt::tdefl_compress_mem_to_heap(b as *c_void,
+                rustrt::tdefl_compress_mem_to_heap(b as *Void,
                                                    len as size_t,
                                                    &mut outsz,
                                                    LZ_NORM);
@@ -67,7 +67,7 @@ pub fn inflate_bytes(bytes: &[u8]) -> ~[u8] {
         unsafe {
             let mut outsz : size_t = 0;
             let res =
-                rustrt::tinfl_decompress_mem_to_heap(b as *c_void,
+                rustrt::tinfl_decompress_mem_to_heap(b as *Void,
                                                      len as size_t,
                                                      &mut outsz,
                                                      0);

--- a/src/libextra/net/tcp.rs
+++ b/src/libextra/net/tcp.rs
@@ -37,8 +37,8 @@ pub mod rustrt {
     #[nolink]
     pub extern {
         unsafe fn rust_uv_current_kernel_malloc(size: libc::c_uint)
-                                             -> *libc::c_void;
-        unsafe fn rust_uv_current_kernel_free(mem: *libc::c_void);
+                                             -> *Void;
+        unsafe fn rust_uv_current_kernel_free(mem: *Void);
         unsafe fn rust_uv_helper_uv_tcp_t_size() -> libc::c_uint;
     }
 }
@@ -231,7 +231,7 @@ pub fn connect(input_ip: ip::IpAddr, port: uint,
                             uv::ll::set_data_for_uv_handle(
                                 stream_handle_ptr,
                                 socket_data_ptr as
-                                *libc::c_void);
+                                *Void);
                             // just so the connect_cb can send the
                             // outcome..
                             uv::ll::set_data_for_req(connect_req_ptr,
@@ -275,7 +275,7 @@ pub fn connect(input_ip: ip::IpAddr, port: uint,
                 debug!("tcp::connect - received failure on result_po");
                 // still have to free the malloc'd stream handle..
                 rustrt::rust_uv_current_kernel_free(stream_handle_ptr
-                                                    as *libc::c_void);
+                                                    as *Void);
                 let tcp_conn_err = match err_data.err_name {
                     ~"ECONNREFUSED" => ConnectionRefused,
                     _ => GenericConnectErr(copy err_data.err_name,
@@ -555,8 +555,8 @@ pub fn accept(new_conn: TcpNewConnection)
                         debug!("uv_tcp_init successful for \
                                      client stream");
                         match uv::ll::accept(
-                            server_handle_ptr as *libc::c_void,
-                            client_stream_handle_ptr as *libc::c_void) {
+                            server_handle_ptr as *Void,
+                            client_stream_handle_ptr as *Void) {
                             0i32 => {
                                 debug!("successfully accepted client \
                                         connection: \
@@ -567,7 +567,7 @@ pub fn accept(new_conn: TcpNewConnection)
                                 uv::ll::set_data_for_uv_handle(
                                     client_stream_handle_ptr,
                                     client_socket_data_ptr
-                                    as *libc::c_void);
+                                    as *Void);
                                 let ptr = uv::ll::get_data_for_uv_handle(
                                     client_stream_handle_ptr);
                                 debug!("ptrs: %x %x",
@@ -1021,7 +1021,7 @@ fn tear_down_socket_data(socket_data: @TcpSocketData) {
         //the line below will most likely crash
         //log(debug, fmt!("about to free socket_data at %?", socket_data));
         rustrt::rust_uv_current_kernel_free(stream_handle_ptr
-                                            as *libc::c_void);
+                                            as *Void);
         debug!("exiting dtor for tcp_socket");
     }
 }
@@ -1303,7 +1303,7 @@ extern fn on_tcp_read_cb(stream: *uv::ll::uv_stream_t,
     }
 }
 
-extern fn on_alloc_cb(handle: *libc::c_void,
+extern fn on_alloc_cb(handle: *Void,
                       suggested_size: size_t)
     -> uv::ll::uv_buf_t {
     unsafe {

--- a/src/libextra/rc.rs
+++ b/src/libextra/rc.rs
@@ -23,7 +23,7 @@ cycle cannot be created with `Rc<T>` because there is no way to modify it after 
 
 
 use std::cast;
-use std::libc::{c_void, size_t, malloc, free};
+use std::libc::{size_t, malloc, free};
 use std::ptr;
 use std::sys;
 use std::unstable::intrinsics;
@@ -74,7 +74,7 @@ impl<T> Drop for Rc<T> {
                 (*self.ptr).count -= 1;
                 if (*self.ptr).count == 0 {
                     ptr::read_ptr(self.ptr);
-                    free(self.ptr as *c_void)
+                    free(self.ptr as *Void)
                 }
             }
         }
@@ -229,7 +229,7 @@ impl<T> Drop for RcMut<T> {
                 (*self.ptr).count -= 1;
                 if (*self.ptr).count == 0 {
                     ptr::replace_ptr(self.ptr, uninit());
-                    free(self.ptr as *c_void)
+                    free(self.ptr as *Void)
                 }
             }
         }

--- a/src/libextra/timer.rs
+++ b/src/libextra/timer.rs
@@ -19,7 +19,6 @@ use std::cast::transmute;
 use std::cast;
 use std::comm::{stream, Chan, SharedChan, Port, select2i};
 use std::either;
-use std::libc::c_void;
 use std::libc;
 
 /**
@@ -54,10 +53,10 @@ pub fn delayed_send<T:Send>(iotask: &IoTask,
                     timer_ptr, delayed_send_cb, msecs, 0u);
                 if (start_result == 0i32) {
                     // Note: putting the channel into a ~
-                    // to cast to *c_void
+                    // to cast to *Void
                     let timer_done_ch_clone = ~timer_done_ch.clone();
                     let timer_done_ch_ptr = transmute::<
-                        ~SharedChan<()>, *c_void>(
+                        ~SharedChan<()>, *Void>(
                         timer_done_ch_clone);
                     uv::ll::set_data_for_uv_handle(
                         timer_ptr,
@@ -147,9 +146,9 @@ extern fn delayed_send_cb(handle: *uv::ll::uv_timer_t, status: libc::c_int) {
         debug!(
             "delayed_send_cb handle %? status %?", handle, status);
         // Faking a borrowed pointer to our ~SharedChan
-        let timer_done_ch_ptr: &*c_void = &uv::ll::get_data_for_uv_handle(
+        let timer_done_ch_ptr: &*Void = &uv::ll::get_data_for_uv_handle(
             handle);
-        let timer_done_ch_ptr = transmute::<&*c_void, &~SharedChan<()>>(
+        let timer_done_ch_ptr = transmute::<&*Void, &~SharedChan<()>>(
             timer_done_ch_ptr);
         let stop_result = uv::ll::timer_stop(handle);
         if (stop_result == 0i32) {
@@ -167,7 +166,7 @@ extern fn delayed_send_close_cb(handle: *uv::ll::uv_timer_t) {
     unsafe {
         debug!("delayed_send_close_cb handle %?", handle);
         let timer_done_ch_ptr = uv::ll::get_data_for_uv_handle(handle);
-        let timer_done_ch = transmute::<*c_void, ~SharedChan<()>>(
+        let timer_done_ch = transmute::<*Void, ~SharedChan<()>>(
             timer_done_ch_ptr);
         timer_done_ch.send(());
     }

--- a/src/libextra/uv_global_loop.rs
+++ b/src/libextra/uv_global_loop.rs
@@ -128,14 +128,13 @@ mod test {
     use std::libc;
     use std::task;
     use std::cast::transmute;
-    use std::libc::c_void;
     use std::comm::{stream, SharedChan, Chan};
 
     extern fn simple_timer_close_cb(timer_ptr: *ll::uv_timer_t) {
         unsafe {
             let exit_ch_ptr = ll::get_data_for_uv_handle(
-                timer_ptr as *libc::c_void);
-            let exit_ch = transmute::<*c_void, ~Chan<bool>>(exit_ch_ptr);
+                timer_ptr as *Void);
+            let exit_ch = transmute::<*Void, ~Chan<bool>>(exit_ch_ptr);
             exit_ch.send(true);
             debug!("EXIT_CH_PTR simple_timer_close_cb exit_ch_ptr: %?",
                      exit_ch_ptr);
@@ -160,7 +159,7 @@ mod test {
     fn impl_uv_hl_simple_timer(iotask: &IoTask) {
         unsafe {
             let (exit_po, exit_ch) = stream::<bool>();
-            let exit_ch_ptr: *libc::c_void = transmute(~exit_ch);
+            let exit_ch_ptr: *Void = transmute(~exit_ch);
             debug!("EXIT_CH_PTR newly created exit_ch_ptr: %?",
                             exit_ch_ptr);
             let timer_handle = ll::timer_t();
@@ -170,7 +169,7 @@ mod test {
                 let init_status = ll::timer_init(loop_ptr, timer_ptr);
                 if(init_status == 0i32) {
                     ll::set_data_for_uv_handle(
-                        timer_ptr as *libc::c_void,
+                        timer_ptr as *Void,
                         exit_ch_ptr);
                     let start_status = ll::timer_start(timer_ptr,
                                                        simple_timer_cb,

--- a/src/libextra/uv_ll.rs
+++ b/src/libextra/uv_ll.rs
@@ -824,8 +824,8 @@ extern {
     unsafe fn rust_uv_timer_start(
         timer_handle: *uv_timer_t,
         cb: *u8,
-        timeout: libc::uint64_t,
-        repeat: libc::uint64_t) -> libc::c_int;
+        timeout: u64,
+        repeat: u64) -> libc::c_int;
     unsafe fn rust_uv_timer_stop(handle: *uv_timer_t) -> libc::c_int;
 
     unsafe fn rust_uv_getaddrinfo(loop_ptr: *libc::c_void,
@@ -1089,8 +1089,8 @@ pub unsafe fn timer_init(loop_ptr: *libc::c_void,
 }
 pub unsafe fn timer_start(timer_ptr: *uv_timer_t, cb: *u8, timeout: uint,
                       repeat: uint) -> libc::c_int {
-    return rust_uv_timer_start(timer_ptr, cb, timeout as libc::uint64_t,
-                               repeat as libc::uint64_t);
+    return rust_uv_timer_start(timer_ptr, cb, timeout as u64,
+                               repeat as u64);
 }
 pub unsafe fn timer_stop(timer_ptr: *uv_timer_t) -> libc::c_int {
     return rust_uv_timer_stop(timer_ptr);

--- a/src/libextra/uv_ll.rs
+++ b/src/libextra/uv_ll.rs
@@ -34,16 +34,16 @@
 #[allow(missing_doc)];
 
 
-use std::libc::{c_void, size_t};
+use std::libc::size_t;
 use std::libc;
 use std::ptr::to_unsafe_ptr;
 use std::ptr;
 use std::str;
 use std::vec;
 
-pub type uv_handle_t = c_void;
-pub type uv_loop_t = c_void;
-pub type uv_idle_t = c_void;
+pub type uv_handle_t = Void;
+pub type uv_loop_t = Void;
+pub type uv_idle_t = Void;
 pub type uv_idle_cb = *u8;
 
 // libuv struct mappings
@@ -74,10 +74,10 @@ pub enum uv_handle_type {
 pub type handle_type = libc::c_uint;
 
 pub struct uv_handle_fields {
-   loop_handle: *libc::c_void,
+   loop_handle: *Void,
    type_: handle_type,
    close_cb: *u8,
-   data: *libc::c_void,
+   data: *Void,
 }
 
 // unix size: 8
@@ -737,12 +737,12 @@ pub mod uv_ll_struct_stubgen {
 #[nolink]
 extern {
     // libuv public API
-    unsafe fn rust_uv_loop_new() -> *libc::c_void;
-    unsafe fn rust_uv_loop_delete(lp: *libc::c_void);
-    unsafe fn rust_uv_run(loop_handle: *libc::c_void);
-    unsafe fn rust_uv_close(handle: *libc::c_void, cb: *u8);
-    unsafe fn rust_uv_walk(loop_handle: *libc::c_void, cb: *u8,
-                           arg: *libc::c_void);
+    unsafe fn rust_uv_loop_new() -> *Void;
+    unsafe fn rust_uv_loop_delete(lp: *Void);
+    unsafe fn rust_uv_run(loop_handle: *Void);
+    unsafe fn rust_uv_close(handle: *Void, cb: *u8);
+    unsafe fn rust_uv_walk(loop_handle: *Void, cb: *u8,
+                           arg: *Void);
 
     unsafe fn rust_uv_idle_new() -> *uv_idle_t;
     unsafe fn rust_uv_idle_delete(handle: *uv_idle_t);
@@ -753,16 +753,16 @@ extern {
     unsafe fn rust_uv_idle_stop(handle: *uv_idle_t) -> libc::c_int;
 
     unsafe fn rust_uv_async_send(handle: *uv_async_t);
-    unsafe fn rust_uv_async_init(loop_handle: *libc::c_void,
+    unsafe fn rust_uv_async_init(loop_handle: *Void,
                           async_handle: *uv_async_t,
                           cb: *u8) -> libc::c_int;
     unsafe fn rust_uv_tcp_init(
-        loop_handle: *libc::c_void,
+        loop_handle: *Void,
         handle_ptr: *uv_tcp_t) -> libc::c_int;
     // FIXME ref #2604 .. ?
     unsafe fn rust_uv_buf_init(out_buf: *uv_buf_t, base: *u8,
                         len: libc::size_t);
-    unsafe fn rust_uv_last_error(loop_handle: *libc::c_void) -> uv_err_t;
+    unsafe fn rust_uv_last_error(loop_handle: *Void) -> uv_err_t;
     // FIXME ref #2064
     unsafe fn rust_uv_strerror(err: *uv_err_t) -> *libc::c_char;
     // FIXME ref #2064
@@ -802,23 +802,23 @@ extern {
                                       name: *sockaddr_in) -> libc::c_int;
     unsafe fn rust_uv_tcp_getpeername6(tcp_handle_ptr: *uv_tcp_t,
                                        name: *sockaddr_in6) ->libc::c_int;
-    unsafe fn rust_uv_listen(stream: *libc::c_void,
+    unsafe fn rust_uv_listen(stream: *Void,
                              backlog: libc::c_int,
                              cb: *u8) -> libc::c_int;
-    unsafe fn rust_uv_accept(server: *libc::c_void, client: *libc::c_void)
+    unsafe fn rust_uv_accept(server: *Void, client: *Void)
                           -> libc::c_int;
-    unsafe fn rust_uv_write(req: *libc::c_void,
-                            stream: *libc::c_void,
+    unsafe fn rust_uv_write(req: *Void,
+                            stream: *Void,
                             buf_in: *uv_buf_t,
                             buf_cnt: libc::c_int,
                             cb: *u8)
         -> libc::c_int;
-    unsafe fn rust_uv_read_start(stream: *libc::c_void,
+    unsafe fn rust_uv_read_start(stream: *Void,
                                  on_alloc: *u8,
                                  on_read: *u8)
         -> libc::c_int;
-    unsafe fn rust_uv_read_stop(stream: *libc::c_void) -> libc::c_int;
-    unsafe fn rust_uv_timer_init(loop_handle: *libc::c_void,
+    unsafe fn rust_uv_read_stop(stream: *Void) -> libc::c_int;
+    unsafe fn rust_uv_timer_init(loop_handle: *Void,
                                  timer_handle: *uv_timer_t)
         -> libc::c_int;
     unsafe fn rust_uv_timer_start(
@@ -828,7 +828,7 @@ extern {
         repeat: u64) -> libc::c_int;
     unsafe fn rust_uv_timer_stop(handle: *uv_timer_t) -> libc::c_int;
 
-    unsafe fn rust_uv_getaddrinfo(loop_ptr: *libc::c_void,
+    unsafe fn rust_uv_getaddrinfo(loop_ptr: *Void,
                                   handle: *uv_getaddrinfo_t,
                                   cb: *u8,
                                   node_name_ptr: *u8,
@@ -855,20 +855,20 @@ extern {
     unsafe fn rust_uv_get_stream_handle_from_write_req(
         write_req: *uv_write_t)
         -> *uv_stream_t;
-    unsafe fn rust_uv_get_loop_for_uv_handle(handle: *libc::c_void)
-        -> *libc::c_void;
-    unsafe fn rust_uv_get_data_for_uv_loop(loop_ptr: *libc::c_void)
-        -> *libc::c_void;
-    unsafe fn rust_uv_set_data_for_uv_loop(loop_ptr: *libc::c_void,
-                                           data: *libc::c_void);
-    unsafe fn rust_uv_get_data_for_uv_handle(handle: *libc::c_void)
-        -> *libc::c_void;
-    unsafe fn rust_uv_set_data_for_uv_handle(handle: *libc::c_void,
-                                             data: *libc::c_void);
-    unsafe fn rust_uv_get_data_for_req(req: *libc::c_void)
-        -> *libc::c_void;
-    unsafe fn rust_uv_set_data_for_req(req: *libc::c_void,
-                                       data: *libc::c_void);
+    unsafe fn rust_uv_get_loop_for_uv_handle(handle: *Void)
+        -> *Void;
+    unsafe fn rust_uv_get_data_for_uv_loop(loop_ptr: *Void)
+        -> *Void;
+    unsafe fn rust_uv_set_data_for_uv_loop(loop_ptr: *Void,
+                                           data: *Void);
+    unsafe fn rust_uv_get_data_for_uv_handle(handle: *Void)
+        -> *Void;
+    unsafe fn rust_uv_set_data_for_uv_handle(handle: *Void,
+                                             data: *Void);
+    unsafe fn rust_uv_get_data_for_req(req: *Void)
+        -> *Void;
+    unsafe fn rust_uv_set_data_for_req(req: *Void,
+                                       data: *Void);
     unsafe fn rust_uv_get_base_from_buf(buf: uv_buf_t) -> *u8;
     unsafe fn rust_uv_get_len_from_buf(buf: uv_buf_t) -> libc::size_t;
 
@@ -887,23 +887,23 @@ extern {
     unsafe fn rust_uv_helper_addr_in_size() -> libc::c_uint;
 }
 
-pub unsafe fn loop_new() -> *libc::c_void {
+pub unsafe fn loop_new() -> *Void {
     return rust_uv_loop_new();
 }
 
-pub unsafe fn loop_delete(loop_handle: *libc::c_void) {
+pub unsafe fn loop_delete(loop_handle: *Void) {
     rust_uv_loop_delete(loop_handle);
 }
 
-pub unsafe fn run(loop_handle: *libc::c_void) {
+pub unsafe fn run(loop_handle: *Void) {
     rust_uv_run(loop_handle);
 }
 
 pub unsafe fn close<T>(handle: *T, cb: *u8) {
-    rust_uv_close(handle as *libc::c_void, cb);
+    rust_uv_close(handle as *Void, cb);
 }
 
-pub unsafe fn walk(loop_handle: *libc::c_void, cb: *u8, arg: *libc::c_void) {
+pub unsafe fn walk(loop_handle: *Void, cb: *u8, arg: *Void) {
     rust_uv_walk(loop_handle, cb, arg);
 }
 
@@ -928,7 +928,7 @@ pub unsafe fn idle_stop(handle: *uv_idle_t) -> libc::c_int {
     rust_uv_idle_stop(handle)
 }
 
-pub unsafe fn tcp_init(loop_handle: *libc::c_void, handle: *uv_tcp_t)
+pub unsafe fn tcp_init(loop_handle: *Void, handle: *uv_tcp_t)
     -> libc::c_int {
     return rust_uv_tcp_init(loop_handle, handle);
 }
@@ -975,34 +975,34 @@ pub unsafe fn tcp_getpeername6(tcp_handle_ptr: *uv_tcp_t,
 
 pub unsafe fn listen<T>(stream: *T, backlog: libc::c_int,
                  cb: *u8) -> libc::c_int {
-    return rust_uv_listen(stream as *libc::c_void, backlog, cb);
+    return rust_uv_listen(stream as *Void, backlog, cb);
 }
 
-pub unsafe fn accept(server: *libc::c_void, client: *libc::c_void)
+pub unsafe fn accept(server: *Void, client: *Void)
     -> libc::c_int {
-    return rust_uv_accept(server as *libc::c_void,
-                               client as *libc::c_void);
+    return rust_uv_accept(server as *Void,
+                               client as *Void);
 }
 
 pub unsafe fn write<T>(req: *uv_write_t, stream: *T,
          buf_in: *~[uv_buf_t], cb: *u8) -> libc::c_int {
     let buf_ptr = vec::raw::to_ptr(*buf_in);
     let buf_cnt = (*buf_in).len() as i32;
-    return rust_uv_write(req as *libc::c_void,
-                              stream as *libc::c_void,
+    return rust_uv_write(req as *Void,
+                              stream as *Void,
                               buf_ptr, buf_cnt, cb);
 }
 pub unsafe fn read_start(stream: *uv_stream_t, on_alloc: *u8,
                      on_read: *u8) -> libc::c_int {
-    return rust_uv_read_start(stream as *libc::c_void,
+    return rust_uv_read_start(stream as *Void,
                                    on_alloc, on_read);
 }
 
 pub unsafe fn read_stop(stream: *uv_stream_t) -> libc::c_int {
-    return rust_uv_read_stop(stream as *libc::c_void);
+    return rust_uv_read_stop(stream as *Void);
 }
 
-pub unsafe fn last_error(loop_handle: *libc::c_void) -> uv_err_t {
+pub unsafe fn last_error(loop_handle: *Void) -> uv_err_t {
     return rust_uv_last_error(loop_handle);
 }
 
@@ -1013,7 +1013,7 @@ pub unsafe fn err_name(err: *uv_err_t) -> *libc::c_char {
     return rust_uv_err_name(err);
 }
 
-pub unsafe fn async_init(loop_handle: *libc::c_void,
+pub unsafe fn async_init(loop_handle: *Void,
                      async_handle: *uv_async_t,
                      cb: *u8) -> libc::c_int {
     return rust_uv_async_init(loop_handle,
@@ -1083,7 +1083,7 @@ pub unsafe fn ip6_port(src: &sockaddr_in6) -> uint {
     rust_uv_ip6_port(to_unsafe_ptr(src)) as uint
 }
 
-pub unsafe fn timer_init(loop_ptr: *libc::c_void,
+pub unsafe fn timer_init(loop_ptr: *Void,
                      timer_ptr: *uv_timer_t) -> libc::c_int {
     return rust_uv_timer_init(loop_ptr, timer_ptr);
 }
@@ -1095,7 +1095,7 @@ pub unsafe fn timer_start(timer_ptr: *uv_timer_t, cb: *u8, timeout: uint,
 pub unsafe fn timer_stop(timer_ptr: *uv_timer_t) -> libc::c_int {
     return rust_uv_timer_stop(timer_ptr);
 }
-pub unsafe fn getaddrinfo(loop_ptr: *libc::c_void,
+pub unsafe fn getaddrinfo(loop_ptr: *Void,
                            handle: *uv_getaddrinfo_t,
                            cb: *u8,
                            node_name_ptr: *u8,
@@ -1134,8 +1134,8 @@ pub fn getaddrinfo_t() -> uv_getaddrinfo_t {
 
 // data access helpers
 pub unsafe fn get_loop_for_uv_handle<T>(handle: *T)
-    -> *libc::c_void {
-    return rust_uv_get_loop_for_uv_handle(handle as *libc::c_void);
+    -> *Void {
+    return rust_uv_get_loop_for_uv_handle(handle as *Void);
 }
 pub unsafe fn get_stream_handle_from_connect_req(connect: *uv_connect_t)
     -> *uv_stream_t {
@@ -1148,27 +1148,27 @@ pub unsafe fn get_stream_handle_from_write_req(
     return rust_uv_get_stream_handle_from_write_req(
         write_req);
 }
-pub unsafe fn get_data_for_uv_loop(loop_ptr: *libc::c_void) -> *libc::c_void {
+pub unsafe fn get_data_for_uv_loop(loop_ptr: *Void) -> *Void {
     rust_uv_get_data_for_uv_loop(loop_ptr)
 }
-pub unsafe fn set_data_for_uv_loop(loop_ptr: *libc::c_void,
-                                   data: *libc::c_void) {
+pub unsafe fn set_data_for_uv_loop(loop_ptr: *Void,
+                                   data: *Void) {
     rust_uv_set_data_for_uv_loop(loop_ptr, data);
 }
-pub unsafe fn get_data_for_uv_handle<T>(handle: *T) -> *libc::c_void {
-    return rust_uv_get_data_for_uv_handle(handle as *libc::c_void);
+pub unsafe fn get_data_for_uv_handle<T>(handle: *T) -> *Void {
+    return rust_uv_get_data_for_uv_handle(handle as *Void);
 }
 pub unsafe fn set_data_for_uv_handle<T, U>(handle: *T, data: *U) {
-    rust_uv_set_data_for_uv_handle(handle as *libc::c_void,
-                                           data as *libc::c_void);
+    rust_uv_set_data_for_uv_handle(handle as *Void,
+                                           data as *Void);
 }
-pub unsafe fn get_data_for_req<T>(req: *T) -> *libc::c_void {
-    return rust_uv_get_data_for_req(req as *libc::c_void);
+pub unsafe fn get_data_for_req<T>(req: *T) -> *Void {
+    return rust_uv_get_data_for_req(req as *Void);
 }
 pub unsafe fn set_data_for_req<T, U>(req: *T,
                     data: *U) {
-    rust_uv_set_data_for_req(req as *libc::c_void,
-                                     data as *libc::c_void);
+    rust_uv_set_data_for_req(req as *Void,
+                                     data as *Void);
 }
 pub unsafe fn get_base_from_buf(buf: uv_buf_t) -> *u8 {
     return rust_uv_get_base_from_buf(buf);
@@ -1184,7 +1184,7 @@ pub unsafe fn free_base_of_buf(buf: uv_buf_t) {
     rust_uv_free_base_of_buf(buf);
 }
 
-pub unsafe fn get_last_err_info(uv_loop: *libc::c_void) -> ~str {
+pub unsafe fn get_last_err_info(uv_loop: *Void) -> ~str {
     let err = last_error(uv_loop);
     let err_ptr: *uv_err_t = &err;
     let err_name = str::raw::from_c_str(err_name(err_ptr));
@@ -1193,7 +1193,7 @@ pub unsafe fn get_last_err_info(uv_loop: *libc::c_void) -> ~str {
                     err_name, err_msg);
 }
 
-pub unsafe fn get_last_err_data(uv_loop: *libc::c_void) -> uv_err_data {
+pub unsafe fn get_last_err_data(uv_loop: *Void) -> uv_err_data {
     let err = last_error(uv_loop);
     let err_ptr: *uv_err_t = &err;
     let err_name = str::raw::from_c_str(err_name(err_ptr));
@@ -1249,12 +1249,12 @@ mod test {
         read_chan: SharedChan<~str>,
     }
 
-    extern fn after_close_cb(handle: *libc::c_void) {
+    extern fn after_close_cb(handle: *Void) {
         debug!("after uv_close! handle ptr: %?",
                         handle);
     }
 
-    extern fn on_alloc_cb(handle: *libc::c_void,
+    extern fn on_alloc_cb(handle: *Void,
                          suggested_size: libc::size_t)
         -> uv_buf_t {
         unsafe {
@@ -1280,14 +1280,14 @@ mod test {
                 debug!("CLIENT read: data! nread: %d", nread);
                 read_stop(stream);
                 let client_data =
-                    get_data_for_uv_handle(stream as *libc::c_void)
+                    get_data_for_uv_handle(stream as *Void)
                       as *request_wrapper;
                 let buf_base = get_base_from_buf(buf);
                 let bytes = vec::from_buf(buf_base, nread as uint);
                 let read_chan = (*client_data).read_chan.clone();
                 let msg_from_server = str::from_bytes(bytes);
                 read_chan.send(msg_from_server);
-                close(stream as *libc::c_void, after_close_cb)
+                close(stream as *Void, after_close_cb)
             }
             else if (nread == -1) {
                 // err .. possibly EOF
@@ -1329,13 +1329,13 @@ mod test {
             if (status == 0i32) {
                 debug!(~"on_connect_cb: in status=0 if..");
                 let client_data = get_data_for_req(
-                    connect_req_ptr as *libc::c_void)
+                    connect_req_ptr as *Void)
                     as *request_wrapper;
                 let write_handle = (*client_data).write_req;
                 debug!("on_connect_cb: tcp: %d write_hdl: %d",
                                 stream as int, write_handle as int);
                 let write_result = write(write_handle,
-                                  stream as *libc::c_void,
+                                  stream as *Void,
                                   (*client_data).req_buf,
                                   on_write_complete_cb);
                 debug!("on_connect_cb: write() status: %d",
@@ -1343,7 +1343,7 @@ mod test {
             }
             else {
                 let test_loop = get_loop_for_uv_handle(
-                    stream as *libc::c_void);
+                    stream as *Void);
                 let err_msg = get_last_err_info(test_loop);
                 debug!(err_msg);
                 assert!(false);
@@ -1385,7 +1385,7 @@ mod test {
                 read_chan: client_chan
             };
 
-            let tcp_init_result = tcp_init(test_loop as *libc::c_void,
+            let tcp_init_result = tcp_init(test_loop as *Void,
                                            tcp_handle_ptr);
             if (tcp_init_result == 0) {
                 debug!(~"successful tcp_init_result");
@@ -1407,9 +1407,9 @@ mod test {
                 if (tcp_connect_result == 0) {
                     // not set the data on the connect_req
                     // until its initialized
-                    set_data_for_req(connect_req_ptr as *libc::c_void,
+                    set_data_for_req(connect_req_ptr as *Void,
                                      &client_data);
-                    set_data_for_uv_handle(tcp_handle_ptr as *libc::c_void,
+                    set_data_for_uv_handle(tcp_handle_ptr as *Void,
                                            &client_data);
                     debug!(~"before run tcp req loop");
                     run(test_loop);
@@ -1428,18 +1428,18 @@ mod test {
         }
     }
 
-    extern fn server_after_close_cb(handle: *libc::c_void) {
+    extern fn server_after_close_cb(handle: *Void) {
         debug!("SERVER server stream closed, should exit. h: %?",
                    handle);
     }
 
-    extern fn client_stream_after_close_cb(handle: *libc::c_void) {
+    extern fn client_stream_after_close_cb(handle: *Void) {
         unsafe {
             debug!(~"SERVER: closed client stream, now closing server stream");
             let client_data = get_data_for_uv_handle(
                 handle) as
                 *tcp_server_data;
-            close((*client_data).server as *libc::c_void,
+            close((*client_data).server as *Void,
                           server_after_close_cb);
         }
     }
@@ -1449,7 +1449,7 @@ mod test {
             let client_stream_ptr =
                 get_stream_handle_from_write_req(req);
             debug!(~"SERVER: resp sent... closing client stream");
-            close(client_stream_ptr as *libc::c_void,
+            close(client_stream_ptr as *Void,
                           client_stream_after_close_cb)
         }
     }
@@ -1474,7 +1474,7 @@ mod test {
                 let request_str = str::from_bytes(bytes);
 
                 let client_data = get_data_for_uv_handle(
-                    client_stream_ptr as *libc::c_void) as *tcp_server_data;
+                    client_stream_ptr as *Void) as *tcp_server_data;
 
                 let server_kill_msg = copy (*client_data).server_kill_msg;
                 let write_req = (*client_data).server_write_req;
@@ -1486,7 +1486,7 @@ mod test {
                     server_chan.send(request_str);
                     let write_result = write(
                         write_req,
-                        client_stream_ptr as *libc::c_void,
+                        client_stream_ptr as *Void,
                         (*client_data).server_resp_buf,
                         after_server_resp_write);
                     debug!("SERVER: resp write result: %d",
@@ -1495,7 +1495,7 @@ mod test {
                         debug!(~"bad result for server resp write()");
                         debug!(get_last_err_info(
                             get_loop_for_uv_handle(client_stream_ptr
-                                as *libc::c_void)));
+                                as *Void)));
                         assert!(false);
                     }
                 }
@@ -1523,7 +1523,7 @@ mod test {
         unsafe {
             debug!(~"client connecting!");
             let test_loop = get_loop_for_uv_handle(
-                                   server_stream_ptr as *libc::c_void);
+                                   server_stream_ptr as *Void);
             if status != 0i32 {
                 let err_msg = get_last_err_info(test_loop);
                 debug!("server_connect_cb: non-zero status: %?",
@@ -1531,19 +1531,19 @@ mod test {
                 return;
             }
             let server_data = get_data_for_uv_handle(
-                server_stream_ptr as *libc::c_void) as *tcp_server_data;
+                server_stream_ptr as *Void) as *tcp_server_data;
             let client_stream_ptr = (*server_data).client;
             let client_init_result = tcp_init(test_loop,
                                                       client_stream_ptr);
             set_data_for_uv_handle(
-                client_stream_ptr as *libc::c_void,
-                server_data as *libc::c_void);
+                client_stream_ptr as *Void,
+                server_data as *Void);
             if (client_init_result == 0i32) {
                 debug!(~"successfully initialized client stream");
                 let accept_result = accept(server_stream_ptr as
-                                                     *libc::c_void,
+                                                     *Void,
                                                    client_stream_ptr as
-                                                     *libc::c_void);
+                                                     *Void);
                 if (accept_result == 0i32) {
                     // start reading
                     let read_result = read_start(
@@ -1586,7 +1586,7 @@ mod test {
         continue_chan: SharedChan<bool>,
     }
 
-    extern fn async_close_cb(handle: *libc::c_void) {
+    extern fn async_close_cb(handle: *Void) {
         debug!("SERVER: closing async cb... h: %?",
                    handle);
     }
@@ -1599,11 +1599,11 @@ mod test {
             // can continue on to let the tcp client
             // do its thang
             let data = get_data_for_uv_handle(
-                async_handle as *libc::c_void) as *async_handle_data;
+                async_handle as *Void) as *async_handle_data;
             let continue_chan = (*data).continue_chan.clone();
             let should_continue = status == 0i32;
             continue_chan.send(should_continue);
-            close(async_handle as *libc::c_void, async_close_cb);
+            close(async_handle as *Void, async_close_cb);
         }
     }
 
@@ -1647,12 +1647,12 @@ mod test {
                 server_write_req: server_write_req_ptr
             };
             let server_data_ptr: *tcp_server_data = &server_data;
-            set_data_for_uv_handle(tcp_server_ptr as *libc::c_void,
-                                           server_data_ptr as *libc::c_void);
+            set_data_for_uv_handle(tcp_server_ptr as *Void,
+                                           server_data_ptr as *Void);
 
             // uv_tcp_init()
             let tcp_init_result = tcp_init(
-                test_loop as *libc::c_void, tcp_server_ptr);
+                test_loop as *Void, tcp_server_ptr);
             if (tcp_init_result == 0i32) {
                 let server_addr = ip4_addr(server_ip, server_port);
                 // FIXME ref #2064
@@ -1665,7 +1665,7 @@ mod test {
 
                     // uv_listen()
                     let listen_result = listen(tcp_server_ptr as
-                                                         *libc::c_void,
+                                                         *Void,
                                                        128i32,
                                                        server_connection_cb);
                     if (listen_result == 0i32) {
@@ -1676,8 +1676,8 @@ mod test {
                                            continue_async_cb);
                         if (async_result == 0i32) {
                             set_data_for_uv_handle(
-                                continue_async_handle_ptr as *libc::c_void,
-                                async_data_ptr as *libc::c_void);
+                                continue_async_handle_ptr as *Void,
+                                async_data_ptr as *Void);
                             async_send(continue_async_handle_ptr);
                             // uv_run()
                             run(test_loop);

--- a/src/libstd/cleanup.rs
+++ b/src/libstd/cleanup.rs
@@ -250,12 +250,12 @@ pub unsafe fn annihilate() {
 
 /// Bindings to the runtime
 pub mod rustrt {
-    use libc::c_void;
+    use util::Void;
 
     #[link_name = "rustrt"]
     pub extern {
         #[rust_stack]
         // FIXME (#4386): Unable to make following method private.
-        pub unsafe fn rust_get_task() -> *c_void;
+        pub unsafe fn rust_get_task() -> *Void;
     }
 }

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -51,7 +51,7 @@ use result::Result;
 use container::Container;
 use int;
 use libc;
-use libc::{c_int, c_long, c_void, size_t, ssize_t};
+use libc::{c_int, c_long, size_t, ssize_t};
 use libc::consts::os::posix88::*;
 use os;
 use cast;
@@ -64,6 +64,7 @@ use str;
 use str::StrSlice;
 use to_str::ToStr;
 use uint;
+use util::Void;
 use vec;
 use vec::{MutableVector, ImmutableVector, OwnedVector, OwnedCopyableVector, CopyableVector};
 
@@ -920,7 +921,7 @@ impl Reader for *libc::FILE {
             do bytes.as_mut_buf |buf_p, buf_len| {
                 assert!(buf_len >= len);
 
-                let count = libc::fread(buf_p as *mut c_void, 1u as size_t,
+                let count = libc::fread(buf_p as *mut Void, 1u as size_t,
                                         len as size_t, *self) as uint;
                 if count < len {
                   match libc::ferror(*self) {
@@ -1153,7 +1154,7 @@ impl Writer for *libc::FILE {
     fn write(&self, v: &[u8]) {
         unsafe {
             do v.as_imm_buf |vbuf, len| {
-                let nout = libc::fwrite(vbuf as *c_void,
+                let nout = libc::fwrite(vbuf as *Void,
                                         1,
                                         len as size_t,
                                         *self);
@@ -1205,7 +1206,7 @@ impl Writer for fd_t {
             let mut count = 0u;
             do v.as_imm_buf |vbuf, len| {
                 while count < len {
-                    let vb = ptr::offset(vbuf, count) as *c_void;
+                    let vb = ptr::offset(vbuf, count) as *Void;
                     let nout = libc::write(*self, vb, len as size_t);
                     if nout < 0 as ssize_t {
                         error!("error writing buffer");

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -123,7 +123,7 @@ pub use libc::funcs::extra::msvcrt::*;
 // you can write more-platform-agnostic code if you stick to just these
 // symbols.
 
-pub use libc::types::common::c95::{FILE, c_void, fpos_t};
+pub use libc::types::common::c95::{FILE, fpos_t};
 pub use libc::types::common::posix88::{DIR, dirent_t};
 pub use libc::types::os::arch::c95::{c_char, c_double, c_float, c_int};
 pub use libc::types::os::arch::c95::{c_long, c_short, c_uchar, c_ulong};
@@ -186,7 +186,7 @@ pub mod types {
     // Standard types that are opaque or common, so are not per-target.
     pub mod common {
         pub mod c95 {
-            pub enum c_void {}
+            // Omitted: `void`, exists as `util::Void`
             pub enum FILE {}
             pub enum fpos_t {}
         }
@@ -209,18 +209,18 @@ pub mod types {
     pub mod os {
         pub mod common {
             pub mod posix01 {
-                use libc::types::common::c95::{c_void};
+                use util::Void;
                 use libc::types::os::arch::c95::{c_char, size_t};
                 pub struct glob_t {
                     gl_pathc: size_t,
                     gl_pathv: **c_char,
                     gl_offs:  size_t,
 
-                    __unused1: *c_void,
-                    __unused2: *c_void,
-                    __unused3: *c_void,
-                    __unused4: *c_void,
-                    __unused5: *c_void,
+                    __unused1: *Void,
+                    __unused2: *Void,
+                    __unused3: *Void,
+                    __unused4: *Void,
+                    __unused5: *Void,
                 }
             }
         }
@@ -455,7 +455,7 @@ pub mod types {
     pub mod os {
         pub mod common {
             pub mod posix01 {
-                use libc::types::common::c95::{c_void};
+                use util::Void;
                 use libc::types::os::arch::c95::{c_char, c_int, size_t};
                 pub struct glob_t {
                     gl_pathc:  size_t,
@@ -464,13 +464,13 @@ pub mod types {
                     __unused2: c_int,
                     gl_pathv:  **c_char,
 
-                    __unused3: *c_void,
+                    __unused3: *Void,
 
-                    __unused4: *c_void,
-                    __unused5: *c_void,
-                    __unused6: *c_void,
-                    __unused7: *c_void,
-                    __unused8: *c_void,
+                    __unused4: *Void,
+                    __unused5: *Void,
+                    __unused6: *Void,
+                    __unused7: *Void,
+                    __unused8: *Void,
                 }
             }
         }
@@ -626,7 +626,7 @@ pub mod types {
             }
             pub mod extra {
                 use ptr;
-                use libc::types::common::c95::c_void;
+                use util::Void;
                 use libc::types::os::arch::c95::{c_char, c_int, c_uint, size_t};
                 use libc::types::os::arch::c95::{c_long, c_ulong};
                 use libc::types::os::arch::c95::{wchar_t};
@@ -657,8 +657,8 @@ pub mod types {
                 // Not really, but opaque to us.
                 pub type LPSECURITY_ATTRIBUTES = LPVOID;
 
-                pub type LPVOID = *mut c_void;
-                pub type LPCVOID = *c_void;
+                pub type LPVOID = *mut Void;
+                pub type LPCVOID = *Void;
                 pub type LPBYTE = *mut BYTE;
                 pub type LPWORD = *mut WORD;
                 pub type LPDWORD = *mut DWORD;
@@ -753,7 +753,7 @@ pub mod types {
     pub mod os {
         pub mod common {
             pub mod posix01 {
-                use libc::types::common::c95::{c_void};
+                use util::Void;
                 use libc::types::os::arch::c95::{c_char, c_int, size_t};
                 pub struct glob_t {
                     gl_pathc:  size_t,
@@ -762,13 +762,13 @@ pub mod types {
                     __unused2: c_int,
                     gl_pathv:  **c_char,
 
-                    __unused3: *c_void,
+                    __unused3: *Void,
 
-                    __unused4: *c_void,
-                    __unused5: *c_void,
-                    __unused6: *c_void,
-                    __unused7: *c_void,
-                    __unused8: *c_void,
+                    __unused4: *Void,
+                    __unused5: *Void,
+                    __unused6: *Void,
+                    __unused7: *Void,
+                    __unused8: *Void,
                 }
             }
         }
@@ -1136,7 +1136,7 @@ pub mod consts {
         #[cfg(target_arch = "arm")]
         pub mod posix88 {
             use libc::types::os::arch::c95::c_int;
-            use libc::types::common::c95::c_void;
+            use util::Void;
 
             pub static O_RDONLY : c_int = 0;
             pub static O_WRONLY : c_int = 1;
@@ -1192,7 +1192,7 @@ pub mod consts {
             pub static MAP_FIXED : c_int = 0x0010;
             pub static MAP_ANON : c_int = 0x0020;
 
-            pub static MAP_FAILED : *c_void = -1 as *c_void;
+            pub static MAP_FAILED : *Void = -1 as *Void;
 
             pub static MCL_CURRENT : c_int = 0x0001;
             pub static MCL_FUTURE : c_int = 0x0002;
@@ -1296,7 +1296,7 @@ pub mod consts {
         #[cfg(target_arch = "mips")]
         pub mod posix88 {
             use libc::types::os::arch::c95::c_int;
-            use libc::types::common::c95::c_void;
+            use util::Void;
 
             pub static O_RDONLY : c_int = 0;
             pub static O_WRONLY : c_int = 1;
@@ -1352,7 +1352,7 @@ pub mod consts {
             pub static MAP_FIXED : c_int = 0x0010;
             pub static MAP_ANON : c_int = 0x0020;
 
-            pub static MAP_FAILED : *c_void = -1 as *c_void;
+            pub static MAP_FAILED : *Void = -1 as *Void;
 
             pub static MCL_CURRENT : c_int = 0x0001;
             pub static MCL_FUTURE : c_int = 0x0002;
@@ -1596,7 +1596,7 @@ pub mod consts {
         pub mod c99 {
         }
         pub mod posix88 {
-            use libc::types::common::c95::c_void;
+            use util::Void;
             use libc::types::os::arch::c95::c_int;
 
             pub static O_RDONLY : c_int = 0;
@@ -1653,7 +1653,7 @@ pub mod consts {
             pub static MAP_FIXED : c_int = 0x0010;
             pub static MAP_ANON : c_int = 0x1000;
 
-            pub static MAP_FAILED : *c_void = -1 as *c_void;
+            pub static MAP_FAILED : *Void = -1 as *Void;
 
             pub static MCL_CURRENT : c_int = 0x0001;
             pub static MCL_FUTURE : c_int = 0x0002;
@@ -1935,7 +1935,7 @@ pub mod consts {
         pub mod c99 {
         }
         pub mod posix88 {
-            use libc::types::common::c95::c_void;
+            use util::Void;
             use libc::types::os::arch::c95::c_int;
 
             pub static O_RDONLY : c_int = 0;
@@ -1992,7 +1992,7 @@ pub mod consts {
             pub static MAP_FIXED : c_int = 0x0010;
             pub static MAP_ANON : c_int = 0x1000;
 
-            pub static MAP_FAILED : *c_void = -1 as *c_void;
+            pub static MAP_FAILED : *Void = -1 as *Void;
 
             pub static MCL_CURRENT : c_int = 0x0001;
             pub static MCL_FUTURE : c_int = 0x0002;
@@ -2293,7 +2293,8 @@ pub mod funcs {
         #[nolink]
         #[abi = "cdecl"]
         pub mod stdio {
-            use libc::types::common::c95::{FILE, c_void, fpos_t};
+            use util::Void;
+            use libc::types::common::c95::{FILE, fpos_t};
             use libc::types::os::arch::c95::{c_char, c_int, c_long, size_t};
 
             pub extern {
@@ -2326,10 +2327,10 @@ pub mod funcs {
                 unsafe fn puts(s: *c_char) -> c_int;
                 unsafe fn ungetc(c: c_int, stream: *FILE) -> c_int;
                 #[fast_ffi]
-                unsafe fn fread(ptr: *mut c_void, size: size_t,
+                unsafe fn fread(ptr: *mut Void, size: size_t,
                          nobj: size_t, stream: *FILE) -> size_t;
                 #[fast_ffi]
-                unsafe fn fwrite(ptr: *c_void, size: size_t,
+                unsafe fn fwrite(ptr: *Void, size: size_t,
                           nobj: size_t, stream: *FILE) -> size_t;
                 unsafe fn fseek(stream: *FILE, offset: c_long,
                          whence: c_int) -> c_int;
@@ -2346,7 +2347,7 @@ pub mod funcs {
         #[nolink]
         #[abi = "cdecl"]
         pub mod stdlib {
-            use libc::types::common::c95::c_void;
+            use util::Void;
             use libc::types::os::arch::c95::{c_char, c_double, c_int};
             use libc::types::os::arch::c95::{c_long, c_uint, c_ulong};
             use libc::types::os::arch::c95::{size_t};
@@ -2363,13 +2364,13 @@ pub mod funcs {
                 unsafe fn strtoul(s: *c_char, endp: **c_char, base: c_int)
                                -> c_ulong;
                 #[fast_ffi]
-                unsafe fn calloc(nobj: size_t, size: size_t) -> *c_void;
+                unsafe fn calloc(nobj: size_t, size: size_t) -> *Void;
                 #[fast_ffi]
-                unsafe fn malloc(size: size_t) -> *c_void;
+                unsafe fn malloc(size: size_t) -> *Void;
                 #[fast_ffi]
-                unsafe fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
+                unsafe fn realloc(p: *mut Void, size: size_t) -> *mut Void;
                 #[fast_ffi]
-                unsafe fn free(p: *c_void);
+                unsafe fn free(p: *Void);
                 unsafe fn abort() -> !;
                 unsafe fn exit(status: c_int) -> !;
                 // Omitted: atexit.
@@ -2384,7 +2385,7 @@ pub mod funcs {
         #[nolink]
         #[abi = "cdecl"]
         pub mod string {
-            use libc::types::common::c95::c_void;
+            use util::Void;
             use libc::types::os::arch::c95::{c_char, c_int, size_t};
             use libc::types::os::arch::c95::{wchar_t};
 
@@ -2418,11 +2419,11 @@ pub mod funcs {
                 // in fact, because LLVM generates calls to them!
                 #[rust_stack]
                 #[inline]
-                unsafe fn memcmp(cx: *c_void, ct: *c_void, n: size_t)
+                unsafe fn memcmp(cx: *Void, ct: *Void, n: size_t)
                               -> c_int;
                 #[rust_stack]
                 #[inline]
-                unsafe fn memchr(cx: *c_void, c: c_int, n: size_t) -> *c_void;
+                unsafe fn memchr(cx: *Void, c: c_int, n: size_t) -> *Void;
             }
         }
     }
@@ -2501,7 +2502,7 @@ pub mod funcs {
         #[nolink]
         #[abi = "cdecl"]
         pub mod unistd {
-            use libc::types::common::c95::c_void;
+            use util::Void;
             use libc::types::os::arch::c95::{c_int, c_uint, c_char,
                                              c_long, size_t};
             use libc::types::os::arch::c99::intptr_t;
@@ -2555,7 +2556,7 @@ pub mod funcs {
 
                 #[link_name = "_read"]
                 #[fast_ffi]
-                unsafe fn read(fd: c_int, buf: *mut c_void, count: c_uint)
+                unsafe fn read(fd: c_int, buf: *mut Void, count: c_uint)
                             -> c_int;
 
                 #[link_name = "_rmdir"]
@@ -2566,7 +2567,7 @@ pub mod funcs {
 
                 #[link_name = "_write"]
                 #[fast_ffi]
-                unsafe fn write(fd: c_int, buf: *c_void, count: c_uint)
+                unsafe fn write(fd: c_int, buf: *Void, count: c_uint)
                              -> c_int;
             }
         }
@@ -2678,7 +2679,7 @@ pub mod funcs {
         #[nolink]
         #[abi = "cdecl"]
         pub mod unistd {
-            use libc::types::common::c95::c_void;
+            use util::Void;
             use libc::types::os::arch::c95::{c_char, c_int, c_long, c_uint};
             use libc::types::os::arch::c95::{size_t};
             use libc::types::os::arch::posix88::{gid_t, off_t, pid_t};
@@ -2722,7 +2723,7 @@ pub mod funcs {
                 unsafe fn pause() -> c_int;
                 unsafe fn pipe(fds: *mut c_int) -> c_int;
                 #[fast_ffi]
-                unsafe fn read(fd: c_int, buf: *mut c_void,
+                unsafe fn read(fd: c_int, buf: *mut Void,
                         count: size_t) -> ssize_t;
                 unsafe fn rmdir(path: *c_char) -> c_int;
                 unsafe fn setgid(gid: gid_t) -> c_int;
@@ -2735,7 +2736,7 @@ pub mod funcs {
                 unsafe fn ttyname(fd: c_int) -> *c_char;
                 unsafe fn unlink(c: *c_char) -> c_int;
                 #[fast_ffi]
-                unsafe fn write(fd: c_int, buf: *c_void, count: size_t)
+                unsafe fn write(fd: c_int, buf: *Void, count: size_t)
                              -> ssize_t;
             }
         }
@@ -2754,28 +2755,28 @@ pub mod funcs {
         #[nolink]
         #[abi = "cdecl"]
         pub mod mman {
-            use libc::types::common::c95::{c_void};
+            use util::Void;
             use libc::types::os::arch::c95::{size_t, c_int, c_char};
             use libc::types::os::arch::posix88::{mode_t, off_t};
 
             pub extern {
-                unsafe fn mlock(addr: *c_void, len: size_t) -> c_int;
-                unsafe fn munlock(addr: *c_void, len: size_t) -> c_int;
+                unsafe fn mlock(addr: *Void, len: size_t) -> c_int;
+                unsafe fn munlock(addr: *Void, len: size_t) -> c_int;
                 unsafe fn mlockall(flags: c_int) -> c_int;
                 unsafe fn munlockall() -> c_int;
 
-                unsafe fn mmap(addr: *c_void,
+                unsafe fn mmap(addr: *Void,
                                len: size_t,
                                prot: c_int,
                                flags: c_int,
                                fd: c_int,
-                               offset: off_t) -> *mut c_void;
-                unsafe fn munmap(addr: *c_void, len: size_t) -> c_int;
+                               offset: off_t) -> *mut Void;
+                unsafe fn munmap(addr: *Void, len: size_t) -> c_int;
 
-                unsafe fn mprotect(addr: *c_void, len: size_t, prot: c_int)
+                unsafe fn mprotect(addr: *Void, len: size_t, prot: c_int)
                     -> c_int;
 
-                unsafe fn msync(addr: *c_void, len: size_t, flags: c_int)
+                unsafe fn msync(addr: *Void, len: size_t, flags: c_int)
                     -> c_int;
                 unsafe fn shm_open(name: *c_char, oflag: c_int, mode: mode_t)
                     -> c_int;
@@ -2849,13 +2850,13 @@ pub mod funcs {
         #[nolink]
         #[abi = "cdecl"]
         pub mod glob {
-            use libc::types::common::c95::{c_void};
+            use util::Void;
             use libc::types::os::arch::c95::{c_char, c_int};
             use libc::types::os::common::posix01::{glob_t};
 
             pub extern {
                 unsafe fn glob(pattern: *c_char, flags: c_int,
-                               errfunc: *c_void, // XXX callback
+                               errfunc: *Void, // XXX callback
                                pglob: *mut glob_t);
                 unsafe fn globfree(pglob: *mut glob_t);
             }
@@ -2864,11 +2865,11 @@ pub mod funcs {
         #[nolink]
         #[abi = "cdecl"]
         pub mod mman {
-            use libc::types::common::c95::{c_void};
+            use util::Void;
             use libc::types::os::arch::c95::{c_int, size_t};
 
             pub extern {
-                unsafe fn posix_madvise(addr: *c_void,
+                unsafe fn posix_madvise(addr: *Void,
                                         len: size_t,
                                         advice: c_int) -> c_int;
             }
@@ -2905,29 +2906,29 @@ pub mod funcs {
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "freebsd")]
     pub mod bsd44 {
-        use libc::types::common::c95::{c_void};
+        use util::Void;
         use libc::types::os::arch::c95::{c_char, c_uchar, c_int, c_uint,
                                          size_t};
 
         #[abi = "cdecl"]
         pub extern {
             unsafe fn sysctl(name: *c_int, namelen: c_uint,
-                      oldp: *mut c_void, oldlenp: *mut size_t,
-                      newp: *c_void, newlen: size_t) -> c_int;
+                      oldp: *mut Void, oldlenp: *mut size_t,
+                      newp: *Void, newlen: size_t) -> c_int;
 
             unsafe fn sysctlbyname(name: *c_char,
-                            oldp: *mut c_void, oldlenp: *mut size_t,
-                            newp: *c_void, newlen: size_t) -> c_int;
+                            oldp: *mut Void, oldlenp: *mut size_t,
+                            newp: *Void, newlen: size_t) -> c_int;
 
             unsafe fn sysctlnametomib(name: *c_char, mibp: *mut c_int,
                                sizep: *mut size_t) -> c_int;
 
             unsafe fn getdtablesize() -> c_int;
 
-            unsafe fn madvise(addr: *c_void, len: size_t, advice: c_int)
+            unsafe fn madvise(addr: *Void, len: size_t, advice: c_int)
                 -> c_int;
 
-            unsafe fn mincore(addr: *c_void, len: size_t, vec: *c_uchar)
+            unsafe fn mincore(addr: *Void, len: size_t, vec: *c_uchar)
                 -> c_int;
         }
     }
@@ -2936,17 +2937,17 @@ pub mod funcs {
     #[cfg(target_os = "linux")]
     #[cfg(target_os = "android")]
     pub mod bsd44 {
-        use libc::types::common::c95::{c_void};
+        use util::Void;
         use libc::types::os::arch::c95::{c_uchar, c_int, size_t};
 
         #[abi = "cdecl"]
         pub extern {
             unsafe fn getdtablesize() -> c_int;
 
-            unsafe fn madvise(addr: *c_void, len: size_t, advice: c_int)
+            unsafe fn madvise(addr: *Void, len: size_t, advice: c_int)
                 -> c_int;
 
-            unsafe fn mincore(addr: *c_void, len: size_t, vec: *c_uchar)
+            unsafe fn mincore(addr: *Void, len: size_t, vec: *c_uchar)
                 -> c_int;
         }
     }

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -191,14 +191,7 @@ pub mod types {
             pub enum fpos_t {}
         }
         pub mod c99 {
-            pub type int8_t = i8;
-            pub type int16_t = i16;
-            pub type int32_t = i32;
-            pub type int64_t = i64;
-            pub type uint8_t = u8;
-            pub type uint16_t = u16;
-            pub type uint32_t = u32;
-            pub type uint64_t = u64;
+            // Omitted: fixed-size integer types
         }
         pub mod posix88 {
             pub enum DIR {}
@@ -520,7 +513,6 @@ pub mod types {
                 pub type ssize_t = i64;
             }
             pub mod posix01 {
-                use libc::types::common::c99::{uint8_t, uint32_t, int32_t};
                 use libc::types::os::arch::c95::{c_long, time_t};
                 use libc::types::os::arch::posix88::{dev_t, gid_t, ino_t};
                 use libc::types::os::arch::posix88::{mode_t, off_t};
@@ -548,11 +540,11 @@ pub mod types {
                     st_blocks: blkcnt_t,
                     st_blksize: blksize_t,
                     st_flags: fflags_t,
-                    st_gen: uint32_t,
-                    st_lspare: int32_t,
+                    st_gen: u32,
+                    st_lspare: i32,
                     st_birthtime: time_t,
                     st_birthtime_nsec: c_long,
-                    __unused: [uint8_t, ..2],
+                    __unused: [u8, ..2],
                 }
             }
             pub mod posix08 {
@@ -569,7 +561,7 @@ pub mod types {
         pub mod common {
             pub mod posix01 {
                 use libc::types::os::arch::c95::c_short;
-                use libc::types::os::arch::extra::{int64, time64_t};
+                use libc::types::os::arch::extra::time64_t;
                 use libc::types::os::arch::posix88::{dev_t, ino_t};
                 use libc::types::os::arch::posix88::mode_t;
 
@@ -583,7 +575,7 @@ pub mod types {
                     st_uid: c_short,
                     st_gid: c_short,
                     st_rdev: dev_t,
-                    st_size: int64,
+                    st_size: i64,
                     st_atime: time64_t,
                     st_mtime: time64_t,
                     st_ctime: time64_t,
@@ -679,7 +671,6 @@ pub mod types {
                 pub type SIZE_T = size_t;
 
                 pub type time64_t = i64;
-                pub type int64 = i64;
 
                 pub struct STARTUPINFO {
                     cb: DWORD,
@@ -820,7 +811,6 @@ pub mod types {
                 pub type ssize_t = i32;
             }
             pub mod posix01 {
-                use libc::types::common::c99::{int32_t, int64_t, uint32_t};
                 use libc::types::os::arch::c95::{c_long, time_t};
                 use libc::types::os::arch::posix88::{dev_t, gid_t, ino_t,
                                                      mode_t, off_t, uid_t};
@@ -848,10 +838,10 @@ pub mod types {
                     st_size: off_t,
                     st_blocks: blkcnt_t,
                     st_blksize: blksize_t,
-                    st_flags: uint32_t,
-                    st_gen: uint32_t,
-                    st_lspare: int32_t,
-                    st_qspare: [int64_t, ..2],
+                    st_flags: u32,
+                    st_gen: u32,
+                    st_lspare: i32,
+                    st_qspare: [i64, ..2],
                 }
             }
             pub mod posix08 {
@@ -900,8 +890,6 @@ pub mod types {
                 pub type ssize_t = i64;
             }
             pub mod posix01 {
-                use libc::types::common::c99::{int32_t, int64_t};
-                use libc::types::common::c99::{uint32_t};
                 use libc::types::os::arch::c95::{c_long, time_t};
                 use libc::types::os::arch::posix88::{dev_t, gid_t, ino_t};
                 use libc::types::os::arch::posix88::{mode_t, off_t, uid_t};
@@ -929,10 +917,10 @@ pub mod types {
                     st_size: off_t,
                     st_blocks: blkcnt_t,
                     st_blksize: blksize_t,
-                    st_flags: uint32_t,
-                    st_gen: uint32_t,
-                    st_lspare: int32_t,
-                    st_qspare: [int64_t, ..2],
+                    st_flags: u32,
+                    st_gen: u32,
+                    st_lspare: i32,
+                    st_qspare: [i64, ..2],
                 }
             }
             pub mod posix08 {

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -28,26 +28,29 @@ Rust's prelude has three main parts:
 
 
 // Reexported core operators
-pub use either::{Either, Left, Right};
 pub use kinds::{Copy, Sized};
 pub use kinds::{Freeze, Send};
 pub use ops::{Add, Sub, Mul, Div, Rem, Neg, Not};
 pub use ops::{BitAnd, BitOr, BitXor};
 pub use ops::{Drop};
 pub use ops::{Shl, Shr, Index};
-pub use option::{Option, Some, None};
-pub use result::{Result, Ok, Err};
 
 // Reexported functions
 pub use io::{print, println};
 
-// Reexported types and traits
+// Reexported types and variants
+pub use either::{Either, Left, Right};
+pub use option::{Option, Some, None};
+pub use result::{Result, Ok, Err};
+pub use util::Void;
+
+// Reexported traits
 pub use clone::{Clone, DeepClone};
 pub use cmp::{Eq, ApproxEq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater, Equiv};
 pub use char::Char;
 pub use container::{Container, Mutable, Map, Set};
 pub use hash::Hash;
-pub use iter::{Times};
+pub use iter::Times;
 pub use iterator::{Iterator, IteratorUtil, OrdIterator};
 pub use num::{Num, NumCast};
 pub use num::{Orderable, Signed, Unsigned, Round};
@@ -62,7 +65,7 @@ pub use path::WindowsPath;
 pub use ptr::RawPtr;
 pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr, ToBytesConsume};
 pub use str::{Str, StrVector, StrSlice, OwnedStr, StrUtil, NullTerminatedStr};
-pub use from_str::{FromStr};
+pub use from_str::FromStr;
 pub use to_bytes::IterBytes;
 pub use to_str::{ToStr, ToStrConsume};
 pub use tuple::{CopyableTuple, ImmutableTuple, ExtendedTupleOps};

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -20,8 +20,8 @@ Runtime type reflection
 use intrinsic::{Opaque, TyDesc, TyVisitor};
 #[cfg(not(stage0))]
 use unstable::intrinsics::{Opaque, TyDesc, TyVisitor};
-use libc::c_void;
 use sys;
+use util::Void;
 use vec;
 
 /**
@@ -31,7 +31,7 @@ use vec;
  * then build a MovePtrAdaptor wrapped around your struct.
  */
 pub trait MovePtr {
-    fn move_ptr(&self, adjustment: &fn(*c_void) -> *c_void);
+    fn move_ptr(&self, adjustment: &fn(*Void) -> *Void);
     fn push_ptr(&self);
     fn pop_ptr(&self);
 }
@@ -54,14 +54,14 @@ impl<V:TyVisitor + MovePtr> MovePtrAdaptor<V> {
     #[inline]
     pub fn bump(&self, sz: uint) {
         do self.inner.move_ptr() |p| {
-            ((p as uint) + sz) as *c_void
+            ((p as uint) + sz) as *Void
         };
     }
 
     #[inline]
     pub fn align(&self, a: uint) {
         do self.inner.move_ptr() |p| {
-            align(p as uint, a) as *c_void
+            align(p as uint, a) as *Void
         };
     }
 

--- a/src/libstd/rt/context.rs
+++ b/src/libstd/rt/context.rs
@@ -10,9 +10,9 @@
 
 use option::*;
 use super::stack::StackSegment;
-use libc::c_void;
 use cast::{transmute, transmute_mut_unsafe,
            transmute_region, transmute_mut_region};
+use util::Void;
 
 // XXX: Registers is boxed so that it is 16-byte aligned, for storing
 // SSE regs.  It would be marginally better not to do this. In C++ we
@@ -45,8 +45,8 @@ impl Context {
         // The C-ABI function that is the task entry point
         extern fn task_start_wrapper(f: &~fn()) { (*f)() }
 
-        let fp: *c_void = task_start_wrapper as *c_void;
-        let argp: *c_void = unsafe { transmute::<&~fn(), *c_void>(&*start) };
+        let fp: *Void = task_start_wrapper as *Void;
+        let argp: *Void = unsafe { transmute::<&~fn(), *Void>(&*start) };
         let sp: *uint = stack.end();
         let sp: *mut uint = unsafe { transmute_mut_unsafe(sp) };
 
@@ -107,7 +107,7 @@ fn new_regs() -> ~Registers {
 }
 
 #[cfg(target_arch = "x86")]
-fn initialize_call_frame(regs: &mut Registers, fptr: *c_void, arg: *c_void, sp: *mut uint) {
+fn initialize_call_frame(regs: &mut Registers, fptr: *Void, arg: *Void, sp: *mut uint) {
 
     let sp = align_down(sp);
     let sp = mut_offset(sp, -4);
@@ -130,7 +130,7 @@ type Registers = [uint, ..22];
 fn new_regs() -> ~Registers { ~([0, .. 22]) }
 
 #[cfg(target_arch = "x86_64")]
-fn initialize_call_frame(regs: &mut Registers, fptr: *c_void, arg: *c_void, sp: *mut uint) {
+fn initialize_call_frame(regs: &mut Registers, fptr: *Void, arg: *Void, sp: *mut uint) {
 
     // Redefinitions from regs.h
     static RUSTRT_ARG0: uint = 3;
@@ -164,7 +164,7 @@ type Registers = [uint, ..32];
 fn new_regs() -> ~Registers { ~([0, .. 32]) }
 
 #[cfg(target_arch = "arm")]
-fn initialize_call_frame(regs: &mut Registers, fptr: *c_void, arg: *c_void, sp: *mut uint) {
+fn initialize_call_frame(regs: &mut Registers, fptr: *Void, arg: *Void, sp: *mut uint) {
     let sp = align_down(sp);
     // sp of arm eabi is 8-byte aligned
     let sp = mut_offset(sp, -2);
@@ -184,7 +184,7 @@ type Registers = [uint, ..32];
 fn new_regs() -> ~Registers { ~([0, .. 32]) }
 
 #[cfg(target_arch = "mips")]
-fn initialize_call_frame(regs: &mut Registers, fptr: *c_void, arg: *c_void, sp: *mut uint) {
+fn initialize_call_frame(regs: &mut Registers, fptr: *Void, arg: *Void, sp: *mut uint) {
     let sp = align_down(sp);
     // sp of mips o32 is 8-byte aligned
     let sp = mut_offset(sp, -2);

--- a/src/libstd/rt/global_heap.rs
+++ b/src/libstd/rt/global_heap.rs
@@ -8,10 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::{c_char, c_void, size_t, uintptr_t, free, malloc, realloc};
+use libc::{c_char, size_t, uintptr_t, free, malloc, realloc};
 use managed::raw::{BoxHeaderRepr, BoxRepr};
 use unstable::intrinsics::TyDesc;
 use sys::size_of;
+use util::Void;
 
 extern {
     #[rust_stack]
@@ -36,7 +37,7 @@ fn align_to(size: uint, align: uint) -> uint {
 
 /// A wrapper around libc::malloc, aborting on out-of-memory
 #[inline]
-pub unsafe fn malloc_raw(size: uint) -> *c_void {
+pub unsafe fn malloc_raw(size: uint) -> *Void {
     let p = malloc(size as size_t);
     if p.is_null() {
         // we need a non-allocating way to print an error here
@@ -47,7 +48,7 @@ pub unsafe fn malloc_raw(size: uint) -> *c_void {
 
 /// A wrapper around libc::realloc, aborting on out-of-memory
 #[inline]
-pub unsafe fn realloc_raw(ptr: *mut c_void, size: uint) -> *mut c_void {
+pub unsafe fn realloc_raw(ptr: *mut Void, size: uint) -> *mut Void {
     let p = realloc(ptr, size as size_t);
     if p.is_null() {
         // we need a non-allocating way to print an error here
@@ -117,5 +118,5 @@ pub unsafe fn closure_exchange_malloc(td: *c_char, size: uintptr_t) -> *c_char {
 #[lang="exchange_free"]
 #[inline]
 pub unsafe fn exchange_free(ptr: *c_char) {
-    free(ptr as *c_void);
+    free(ptr as *Void);
 }

--- a/src/libstd/rt/local_heap.rs
+++ b/src/libstd/rt/local_heap.rs
@@ -10,14 +10,15 @@
 
 //! The local, garbage collected heap
 
-use libc::{c_void, uintptr_t, size_t};
+use libc::{uintptr_t, size_t};
 use ops::Drop;
+use util::Void;
 
-type MemoryRegion = c_void;
-type BoxedRegion = c_void;
+type MemoryRegion = Void;
+type BoxedRegion = Void;
 
-pub type OpaqueBox = c_void;
-pub type TypeDesc = c_void;
+pub type OpaqueBox = Void;
+pub type TypeDesc = Void;
 
 pub struct LocalHeap {
     memory_region: *MemoryRegion,

--- a/src/libstd/rt/rc.rs
+++ b/src/libstd/rt/rc.rs
@@ -20,18 +20,18 @@
 
 use ops::Drop;
 use clone::Clone;
-use libc::c_void;
 use cast;
+use util::Void;
 
 pub struct RC<T> {
-    p: *c_void // ~(uint, T)
+    p: *Void // ~(uint, T)
 }
 
 impl<T> RC<T> {
     pub fn new(val: T) -> RC<T> {
         unsafe {
             let v = ~(1, val);
-            let p: *c_void = cast::transmute(v);
+            let p: *Void = cast::transmute(v);
             RC { p: p }
         }
     }

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -15,12 +15,13 @@
 
 use borrow;
 use cast::transmute;
-use libc::{c_void, uintptr_t};
+use libc::uintptr_t;
 use ptr;
 use prelude::*;
 use rt::local::Local;
 use rt::logging::StdErrLogger;
 use super::local_heap::LocalHeap;
+use util::Void;
 
 pub struct Task {
     heap: LocalHeap,
@@ -32,7 +33,7 @@ pub struct Task {
 }
 
 pub struct GarbageCollector;
-pub struct LocalStorage(*c_void, Option<~fn(*c_void)>);
+pub struct LocalStorage(*Void, Option<~fn(*Void)>);
 
 pub struct Unwinder {
     unwinding: bool,
@@ -122,7 +123,7 @@ impl Unwinder {
             assert!(token == 0 || token == UNWIND_TOKEN);
         }
 
-        extern fn try_fn(code: *c_void, env: *c_void) {
+        extern fn try_fn(code: *Void, env: *Void) {
             unsafe {
                 let closure: Closure = Closure {
                     code: transmute(code),
@@ -135,7 +136,7 @@ impl Unwinder {
 
         extern {
             #[rust_stack]
-            fn rust_try(f: *u8, code: *c_void, data: *c_void) -> uintptr_t;
+            fn rust_try(f: *u8, code: *Void, data: *Void) -> uintptr_t;
         }
     }
 

--- a/src/libstd/rt/thread.rs
+++ b/src/libstd/rt/thread.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc;
 use ops::Drop;
+use util::Void;
 
 #[allow(non_camel_case_types)] // runtime type
-type raw_thread = libc::c_void;
+type raw_thread = Void;
 
 pub struct Thread {
     main: ~fn(),

--- a/src/libstd/rt/thread_local_storage.rs
+++ b/src/libstd/rt/thread_local_storage.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_void;
 #[cfg(unix)]
 use libc::c_int;
 #[cfg(unix)]
 use ptr::null;
 #[cfg(windows)]
 use libc::types::os::arch::extra::{DWORD, LPVOID, BOOL};
+use util::Void;
 
 #[cfg(unix)]
 pub type Key = pthread_key_t;
@@ -25,12 +25,12 @@ pub unsafe fn create(key: &mut Key) {
 }
 
 #[cfg(unix)]
-pub unsafe fn set(key: Key, value: *mut c_void) {
+pub unsafe fn set(key: Key, value: *mut Void) {
     assert_eq!(0, pthread_setspecific(key, value));
 }
 
 #[cfg(unix)]
-pub unsafe fn get(key: Key) -> *mut c_void {
+pub unsafe fn get(key: Key) -> *mut Void {
     pthread_getspecific(key)
 }
 
@@ -49,9 +49,9 @@ extern {
     #[fast_ffi]
     fn pthread_key_create(key: *mut pthread_key_t, dtor: *u8) -> c_int;
     #[fast_ffi]
-    fn pthread_setspecific(key: pthread_key_t, value: *mut c_void) -> c_int;
+    fn pthread_setspecific(key: pthread_key_t, value: *mut Void) -> c_int;
     #[fast_ffi]
-    fn pthread_getspecific(key: pthread_key_t) -> *mut c_void;
+    fn pthread_getspecific(key: pthread_key_t) -> *mut Void;
 }
 
 #[cfg(windows)]
@@ -65,12 +65,12 @@ pub unsafe fn create(key: &mut Key) {
 }
 
 #[cfg(windows)]
-pub unsafe fn set(key: Key, value: *mut c_void) {
+pub unsafe fn set(key: Key, value: *mut Void) {
     assert!(0 != TlsSetValue(key, value))
 }
 
 #[cfg(windows)]
-pub unsafe fn get(key: Key) -> *mut c_void {
+pub unsafe fn get(key: Key) -> *mut Void {
     TlsGetValue(key)
 }
 

--- a/src/libstd/rt/uv/file.rs
+++ b/src/libstd/rt/uv/file.rs
@@ -10,7 +10,6 @@
 
 use prelude::*;
 use ptr::null;
-use libc::c_void;
 use rt::uv::{Request, NativeHandle, Loop, FsCallback};
 use rt::uv::uvll;
 use rt::uv::uvll::*;
@@ -28,7 +27,7 @@ impl FsRequest {
     }
 
     fn delete(self) {
-        unsafe { free_req(self.native_handle() as *c_void) }
+        unsafe { free_req(self.native_handle() as *Void) }
     }
 
     fn open(&mut self, _loop_: &Loop, _cb: FsCallback) {

--- a/src/libstd/rt/uv/mod.rs
+++ b/src/libstd/rt/uv/mod.rs
@@ -43,10 +43,11 @@ use vec;
 use vec::ImmutableVector;
 use ptr;
 use str;
-use libc::{c_void, c_int, size_t, malloc, free};
+use libc::{c_int, size_t, malloc, free};
 use cast::transmute;
 use ptr::null;
 use unstable::finally::Finally;
+use util::Void;
 
 use rt::io::IoError;
 
@@ -165,7 +166,7 @@ impl<H, W: Watcher + NativeHandle<*H>> WatcherInterop for W {
                 idle_cb: None,
                 timer_cb: None
             };
-            let data = transmute::<~WatcherData, *c_void>(data);
+            let data = transmute::<~WatcherData, *Void>(data);
             uvll::set_data_for_uv_handle(self.native_handle(), data);
         }
     }
@@ -173,7 +174,7 @@ impl<H, W: Watcher + NativeHandle<*H>> WatcherInterop for W {
     pub fn get_watcher_data<'r>(&'r mut self) -> &'r mut WatcherData {
         unsafe {
             let data = uvll::get_data_for_uv_handle(self.native_handle());
-            let data = transmute::<&*c_void, &mut ~WatcherData>(&data);
+            let data = transmute::<&*Void, &mut ~WatcherData>(&data);
             return &mut **data;
         }
     }
@@ -181,7 +182,7 @@ impl<H, W: Watcher + NativeHandle<*H>> WatcherInterop for W {
     pub fn drop_watcher_data(&mut self) {
         unsafe {
             let data = uvll::get_data_for_uv_handle(self.native_handle());
-            let _data = transmute::<*c_void, ~WatcherData>(data);
+            let _data = transmute::<*Void, ~WatcherData>(data);
             uvll::set_data_for_uv_handle(self.native_handle(), null::<()>());
         }
     }
@@ -313,7 +314,7 @@ pub fn vec_to_uv_buf(v: ~[u8]) -> Buf {
 pub fn vec_from_uv_buf(buf: Buf) -> Option<~[u8]> {
     if !(buf.len == 0 && buf.base.is_null()) {
         let v = unsafe { vec::from_buf(buf.base, buf.len as uint) };
-        unsafe { free(buf.base as *c_void) };
+        unsafe { free(buf.base as *Void) };
         return Some(v);
     } else {
         // No buffer

--- a/src/libstd/rt/uv/net.rs
+++ b/src/libstd/rt/uv/net.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use prelude::*;
-use libc::{size_t, ssize_t, c_int, c_void};
+use libc::{size_t, ssize_t, c_int};
 use rt::uv::uvll;
 use rt::uv::uvll::*;
 use rt::uv::{AllocCallback, ConnectionCallback, ReadCallback};
@@ -110,8 +110,8 @@ impl StreamWatcher {
     }
 
     pub fn accept(&mut self, stream: StreamWatcher) {
-        let self_handle = self.native_handle() as *c_void;
-        let stream_handle = stream.native_handle() as *c_void;
+        let self_handle = self.native_handle() as *Void;
+        let stream_handle = stream.native_handle() as *Void;
         unsafe {
             assert_eq!(0, uvll::accept(self_handle, stream_handle));
         }
@@ -134,7 +134,7 @@ impl StreamWatcher {
                 data.close_cb.swap_unwrap()();
             }
             stream_watcher.drop_watcher_data();
-            unsafe { free_handle(handle as *c_void) }
+            unsafe { free_handle(handle as *Void) }
         }
     }
 }
@@ -276,7 +276,7 @@ impl ConnectRequest {
     }
 
     fn delete(self) {
-        unsafe { free_req(self.native_handle() as *c_void) }
+        unsafe { free_req(self.native_handle() as *Void) }
     }
 }
 
@@ -312,7 +312,7 @@ impl WriteRequest {
     }
 
     pub fn delete(self) {
-        unsafe { free_req(self.native_handle() as *c_void) }
+        unsafe { free_req(self.native_handle() as *Void) }
     }
 }
 

--- a/src/libstd/rt/uv/timer.rs
+++ b/src/libstd/rt/uv/timer.rs
@@ -8,11 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::{c_void, c_int};
+use libc::c_int;
 use option::Some;
 use rt::uv::uvll;
 use rt::uv::{Watcher, Loop, NativeHandle, TimerCallback, NullCallback};
 use rt::uv::status_to_maybe_uv_error;
+use util::Void;
 
 pub struct TimerWatcher(*uvll::uv_timer_t);
 impl Watcher for TimerWatcher { }
@@ -74,7 +75,7 @@ impl TimerWatcher {
             }
             watcher.drop_watcher_data();
             unsafe {
-                uvll::free_handle(handle as *c_void);
+                uvll::free_handle(handle as *Void);
             }
         }
     }

--- a/src/libstd/rt/uv/uvll.rs
+++ b/src/libstd/rt/uv/uvll.rs
@@ -436,8 +436,8 @@ extern {
                           timer_handle: *uv_timer_t) -> c_int;
     fn rust_uv_timer_start(timer_handle: *uv_timer_t,
                            cb: *u8,
-                           timeout: libc::uint64_t,
-                           repeat: libc::uint64_t) -> c_int;
+                           timeout: u64,
+                           repeat: u64) -> c_int;
     fn rust_uv_timer_stop(handle: *uv_timer_t) -> c_int;
 
     fn rust_uv_malloc_buf_base_of(sug_size: size_t) -> *u8;

--- a/src/libstd/rt/uv/uvll.rs
+++ b/src/libstd/rt/uv/uvll.rs
@@ -29,12 +29,13 @@
 
 #[allow(non_camel_case_types)]; // C types
 
-use libc::{size_t, c_int, c_uint, c_void, c_char, uintptr_t};
+use libc::{size_t, c_int, c_uint, c_char, uintptr_t};
 use libc::{malloc, free};
 use libc;
 use prelude::*;
 use ptr;
 use str;
+use util::Void;
 use vec;
 
 pub static UNKNOWN: c_int = -1;
@@ -56,21 +57,21 @@ pub struct uv_buf_t {
     len: libc::size_t,
 }
 
-pub type uv_handle_t = c_void;
-pub type uv_loop_t = c_void;
-pub type uv_idle_t = c_void;
-pub type uv_tcp_t = c_void;
-pub type uv_connect_t = c_void;
-pub type uv_write_t = c_void;
-pub type uv_async_t = c_void;
-pub type uv_timer_t = c_void;
-pub type uv_stream_t = c_void;
-pub type uv_fs_t = c_void;
+pub type uv_handle_t = Void;
+pub type uv_loop_t = Void;
+pub type uv_idle_t = Void;
+pub type uv_tcp_t = Void;
+pub type uv_connect_t = Void;
+pub type uv_write_t = Void;
+pub type uv_async_t = Void;
+pub type uv_timer_t = Void;
+pub type uv_stream_t = Void;
+pub type uv_fs_t = Void;
 
 pub type uv_idle_cb = *u8;
 
-pub type sockaddr_in = c_void;
-pub type sockaddr_in6 = c_void;
+pub type sockaddr_in = Void;
+pub type sockaddr_in6 = Void;
 
 #[deriving(Eq)]
 pub enum uv_handle_type {
@@ -109,7 +110,7 @@ pub enum uv_req_type {
     UV_REQ_TYPE_MAX
 }
 
-pub unsafe fn malloc_handle(handle: uv_handle_type) -> *c_void {
+pub unsafe fn malloc_handle(handle: uv_handle_type) -> *Void {
     assert!(handle != UV_UNKNOWN_HANDLE && handle != UV_HANDLE_TYPE_MAX);
     let size = rust_uv_handle_size(handle as uint);
     let p = malloc(size);
@@ -117,11 +118,11 @@ pub unsafe fn malloc_handle(handle: uv_handle_type) -> *c_void {
     return p;
 }
 
-pub unsafe fn free_handle(v: *c_void) {
+pub unsafe fn free_handle(v: *Void) {
     free(v)
 }
 
-pub unsafe fn malloc_req(req: uv_req_type) -> *c_void {
+pub unsafe fn malloc_req(req: uv_req_type) -> *Void {
     assert!(req != UV_UNKNOWN_REQ && req != UV_REQ_TYPE_MAX);
     let size = rust_uv_req_size(req as uint);
     let p = malloc(size);
@@ -129,7 +130,7 @@ pub unsafe fn malloc_req(req: uv_req_type) -> *c_void {
     return p;
 }
 
-pub unsafe fn free_req(v: *c_void) {
+pub unsafe fn free_req(v: *Void) {
     free(v)
 }
 
@@ -147,23 +148,23 @@ fn request_sanity_check() {
     }
 }
 
-pub unsafe fn loop_new() -> *c_void {
+pub unsafe fn loop_new() -> *Void {
     return rust_uv_loop_new();
 }
 
-pub unsafe fn loop_delete(loop_handle: *c_void) {
+pub unsafe fn loop_delete(loop_handle: *Void) {
     rust_uv_loop_delete(loop_handle);
 }
 
-pub unsafe fn run(loop_handle: *c_void) {
+pub unsafe fn run(loop_handle: *Void) {
     rust_uv_run(loop_handle);
 }
 
 pub unsafe fn close<T>(handle: *T, cb: *u8) {
-    rust_uv_close(handle as *c_void, cb);
+    rust_uv_close(handle as *Void, cb);
 }
 
-pub unsafe fn walk(loop_handle: *c_void, cb: *u8, arg: *c_void) {
+pub unsafe fn walk(loop_handle: *Void, cb: *u8, arg: *Void) {
     rust_uv_walk(loop_handle, cb, arg);
 }
 
@@ -187,7 +188,7 @@ pub unsafe fn idle_stop(handle: *uv_idle_t) -> c_int {
     rust_uv_idle_stop(handle)
 }
 
-pub unsafe fn tcp_init(loop_handle: *c_void, handle: *uv_tcp_t) -> c_int {
+pub unsafe fn tcp_init(loop_handle: *Void, handle: *uv_tcp_t) -> c_int {
     return rust_uv_tcp_init(loop_handle, handle);
 }
 
@@ -225,27 +226,27 @@ pub unsafe fn tcp_getpeername6(tcp_handle_ptr: *uv_tcp_t, name: *sockaddr_in6) -
 }
 
 pub unsafe fn listen<T>(stream: *T, backlog: c_int, cb: *u8) -> c_int {
-    return rust_uv_listen(stream as *c_void, backlog, cb);
+    return rust_uv_listen(stream as *Void, backlog, cb);
 }
 
-pub unsafe fn accept(server: *c_void, client: *c_void) -> c_int {
-    return rust_uv_accept(server as *c_void, client as *c_void);
+pub unsafe fn accept(server: *Void, client: *Void) -> c_int {
+    return rust_uv_accept(server as *Void, client as *Void);
 }
 
 pub unsafe fn write<T>(req: *uv_write_t, stream: *T, buf_in: &[uv_buf_t], cb: *u8) -> c_int {
     let buf_ptr = vec::raw::to_ptr(buf_in);
     let buf_cnt = buf_in.len() as i32;
-    return rust_uv_write(req as *c_void, stream as *c_void, buf_ptr, buf_cnt, cb);
+    return rust_uv_write(req as *Void, stream as *Void, buf_ptr, buf_cnt, cb);
 }
 pub unsafe fn read_start(stream: *uv_stream_t, on_alloc: *u8, on_read: *u8) -> c_int {
-    return rust_uv_read_start(stream as *c_void, on_alloc, on_read);
+    return rust_uv_read_start(stream as *Void, on_alloc, on_read);
 }
 
 pub unsafe fn read_stop(stream: *uv_stream_t) -> c_int {
-    return rust_uv_read_stop(stream as *c_void);
+    return rust_uv_read_stop(stream as *Void);
 }
 
-pub unsafe fn last_error(loop_handle: *c_void) -> uv_err_t {
+pub unsafe fn last_error(loop_handle: *Void) -> uv_err_t {
     return rust_uv_last_error(loop_handle);
 }
 
@@ -256,7 +257,7 @@ pub unsafe fn err_name(err: *uv_err_t) -> *c_char {
     return rust_uv_err_name(err);
 }
 
-pub unsafe fn async_init(loop_handle: *c_void, async_handle: *uv_async_t, cb: *u8) -> c_int {
+pub unsafe fn async_init(loop_handle: *Void, async_handle: *uv_async_t, cb: *u8) -> c_int {
     return rust_uv_async_init(loop_handle, async_handle, cb);
 }
 
@@ -270,7 +271,7 @@ pub unsafe fn buf_init(input: *u8, len: uint) -> uv_buf_t {
     return out_buf;
 }
 
-pub unsafe fn timer_init(loop_ptr: *c_void, timer_ptr: *uv_timer_t) -> c_int {
+pub unsafe fn timer_init(loop_ptr: *Void, timer_ptr: *uv_timer_t) -> c_int {
     return rust_uv_timer_init(loop_ptr, timer_ptr);
 }
 pub unsafe fn timer_start(timer_ptr: *uv_timer_t, cb: *u8, timeout: u64,
@@ -301,8 +302,8 @@ pub unsafe fn free_ip6_addr(addr: *sockaddr_in6) {
 }
 
 // data access helpers
-pub unsafe fn get_loop_for_uv_handle<T>(handle: *T) -> *c_void {
-    return rust_uv_get_loop_for_uv_handle(handle as *c_void);
+pub unsafe fn get_loop_for_uv_handle<T>(handle: *T) -> *Void {
+    return rust_uv_get_loop_for_uv_handle(handle as *Void);
 }
 pub unsafe fn get_stream_handle_from_connect_req(connect: *uv_connect_t) -> *uv_stream_t {
     return rust_uv_get_stream_handle_from_connect_req(connect);
@@ -310,23 +311,23 @@ pub unsafe fn get_stream_handle_from_connect_req(connect: *uv_connect_t) -> *uv_
 pub unsafe fn get_stream_handle_from_write_req(write_req: *uv_write_t) -> *uv_stream_t {
     return rust_uv_get_stream_handle_from_write_req(write_req);
 }
-pub unsafe fn get_data_for_uv_loop(loop_ptr: *c_void) -> *c_void {
+pub unsafe fn get_data_for_uv_loop(loop_ptr: *Void) -> *Void {
     rust_uv_get_data_for_uv_loop(loop_ptr)
 }
-pub unsafe fn set_data_for_uv_loop(loop_ptr: *c_void, data: *c_void) {
+pub unsafe fn set_data_for_uv_loop(loop_ptr: *Void, data: *Void) {
     rust_uv_set_data_for_uv_loop(loop_ptr, data);
 }
-pub unsafe fn get_data_for_uv_handle<T>(handle: *T) -> *c_void {
-    return rust_uv_get_data_for_uv_handle(handle as *c_void);
+pub unsafe fn get_data_for_uv_handle<T>(handle: *T) -> *Void {
+    return rust_uv_get_data_for_uv_handle(handle as *Void);
 }
 pub unsafe fn set_data_for_uv_handle<T, U>(handle: *T, data: *U) {
-    rust_uv_set_data_for_uv_handle(handle as *c_void, data as *c_void);
+    rust_uv_set_data_for_uv_handle(handle as *Void, data as *Void);
 }
-pub unsafe fn get_data_for_req<T>(req: *T) -> *c_void {
-    return rust_uv_get_data_for_req(req as *c_void);
+pub unsafe fn get_data_for_req<T>(req: *T) -> *Void {
+    return rust_uv_get_data_for_req(req as *Void);
 }
 pub unsafe fn set_data_for_req<T, U>(req: *T, data: *U) {
-    rust_uv_set_data_for_req(req as *c_void, data as *c_void);
+    rust_uv_set_data_for_req(req as *Void, data as *Void);
 }
 pub unsafe fn get_base_from_buf(buf: uv_buf_t) -> *u8 {
     return rust_uv_get_base_from_buf(buf);
@@ -341,7 +342,7 @@ pub unsafe fn free_base_of_buf(buf: uv_buf_t) {
     rust_uv_free_base_of_buf(buf);
 }
 
-pub unsafe fn get_last_err_info(uv_loop: *c_void) -> ~str {
+pub unsafe fn get_last_err_info(uv_loop: *Void) -> ~str {
     let err = last_error(uv_loop);
     let err_ptr = ptr::to_unsafe_ptr(&err);
     let err_name = str::raw::from_c_str(err_name(err_ptr));
@@ -350,7 +351,7 @@ pub unsafe fn get_last_err_info(uv_loop: *c_void) -> ~str {
                     err_name, err_msg);
 }
 
-pub unsafe fn get_last_err_data(uv_loop: *c_void) -> uv_err_data {
+pub unsafe fn get_last_err_data(uv_loop: *Void) -> uv_err_data {
     let err = last_error(uv_loop);
     let err_ptr = ptr::to_unsafe_ptr(&err);
     let err_name = str::raw::from_c_str(err_name(err_ptr));
@@ -371,11 +372,11 @@ extern {
     fn rust_uv_req_type_max() -> uintptr_t;
 
     // libuv public API
-    fn rust_uv_loop_new() -> *c_void;
-    fn rust_uv_loop_delete(lp: *c_void);
-    fn rust_uv_run(loop_handle: *c_void);
-    fn rust_uv_close(handle: *c_void, cb: *u8);
-    fn rust_uv_walk(loop_handle: *c_void, cb: *u8, arg: *c_void);
+    fn rust_uv_loop_new() -> *Void;
+    fn rust_uv_loop_delete(lp: *Void);
+    fn rust_uv_run(loop_handle: *Void);
+    fn rust_uv_close(handle: *Void, cb: *u8);
+    fn rust_uv_walk(loop_handle: *Void, cb: *u8, arg: *Void);
 
     fn rust_uv_idle_new() -> *uv_idle_t;
     fn rust_uv_idle_delete(handle: *uv_idle_t);
@@ -384,13 +385,13 @@ extern {
     fn rust_uv_idle_stop(handle: *uv_idle_t) -> c_int;
 
     fn rust_uv_async_send(handle: *uv_async_t);
-    fn rust_uv_async_init(loop_handle: *c_void,
+    fn rust_uv_async_init(loop_handle: *Void,
                           async_handle: *uv_async_t,
                           cb: *u8) -> c_int;
-    fn rust_uv_tcp_init(loop_handle: *c_void, handle_ptr: *uv_tcp_t) -> c_int;
+    fn rust_uv_tcp_init(loop_handle: *Void, handle_ptr: *uv_tcp_t) -> c_int;
     // FIXME ref #2604 .. ?
     fn rust_uv_buf_init(out_buf: *uv_buf_t, base: *u8, len: size_t);
-    fn rust_uv_last_error(loop_handle: *c_void) -> uv_err_t;
+    fn rust_uv_last_error(loop_handle: *Void) -> uv_err_t;
     // FIXME ref #2064
     fn rust_uv_strerror(err: *uv_err_t) -> *c_char;
     // FIXME ref #2064
@@ -421,18 +422,18 @@ extern {
                                name: *sockaddr_in) -> c_int;
     fn rust_uv_tcp_getpeername6(tcp_handle_ptr: *uv_tcp_t,
                                 name: *sockaddr_in6) ->c_int;
-    fn rust_uv_listen(stream: *c_void, backlog: c_int, cb: *u8) -> c_int;
-    fn rust_uv_accept(server: *c_void, client: *c_void) -> c_int;
-    fn rust_uv_write(req: *c_void,
-                     stream: *c_void,
+    fn rust_uv_listen(stream: *Void, backlog: c_int, cb: *u8) -> c_int;
+    fn rust_uv_accept(server: *Void, client: *Void) -> c_int;
+    fn rust_uv_write(req: *Void,
+                     stream: *Void,
                      buf_in: *uv_buf_t,
                      buf_cnt: c_int,
                      cb: *u8) -> c_int;
-    fn rust_uv_read_start(stream: *c_void,
+    fn rust_uv_read_start(stream: *Void,
                           on_alloc: *u8,
                           on_read: *u8) -> c_int;
-    fn rust_uv_read_stop(stream: *c_void) -> c_int;
-    fn rust_uv_timer_init(loop_handle: *c_void,
+    fn rust_uv_read_stop(stream: *Void) -> c_int;
+    fn rust_uv_timer_init(loop_handle: *Void,
                           timer_handle: *uv_timer_t) -> c_int;
     fn rust_uv_timer_start(timer_handle: *uv_timer_t,
                            cb: *u8,
@@ -444,13 +445,13 @@ extern {
     fn rust_uv_free_base_of_buf(buf: uv_buf_t);
     fn rust_uv_get_stream_handle_from_connect_req(connect_req: *uv_connect_t) -> *uv_stream_t;
     fn rust_uv_get_stream_handle_from_write_req(write_req: *uv_write_t) -> *uv_stream_t;
-    fn rust_uv_get_loop_for_uv_handle(handle: *c_void) -> *c_void;
-    fn rust_uv_get_data_for_uv_loop(loop_ptr: *c_void) -> *c_void;
-    fn rust_uv_set_data_for_uv_loop(loop_ptr: *c_void, data: *c_void);
-    fn rust_uv_get_data_for_uv_handle(handle: *c_void) -> *c_void;
-    fn rust_uv_set_data_for_uv_handle(handle: *c_void, data: *c_void);
-    fn rust_uv_get_data_for_req(req: *c_void) -> *c_void;
-    fn rust_uv_set_data_for_req(req: *c_void, data: *c_void);
+    fn rust_uv_get_loop_for_uv_handle(handle: *Void) -> *Void;
+    fn rust_uv_get_data_for_uv_loop(loop_ptr: *Void) -> *Void;
+    fn rust_uv_set_data_for_uv_loop(loop_ptr: *Void, data: *Void);
+    fn rust_uv_get_data_for_uv_handle(handle: *Void) -> *Void;
+    fn rust_uv_set_data_for_uv_handle(handle: *Void, data: *Void);
+    fn rust_uv_get_data_for_req(req: *Void) -> *Void;
+    fn rust_uv_set_data_for_req(req: *Void, data: *Void);
     fn rust_uv_get_base_from_buf(buf: uv_buf_t) -> *u8;
     fn rust_uv_get_len_from_buf(buf: uv_buf_t) -> size_t;
 }

--- a/src/libstd/rt/uvll.rs
+++ b/src/libstd/rt/uvll.rs
@@ -29,7 +29,7 @@
 
 #[allow(non_camel_case_types)]; // C types
 
-use libc::{size_t, c_int, c_uint, c_void, c_char, uintptr_t};
+use libc::{size_t, c_int, c_uint, c_char, uintptr_t};
 use libc::{malloc, free};
 use prelude::*;
 
@@ -43,21 +43,21 @@ pub struct uv_buf_t {
     len: libc::size_t,
 }
 
-pub type uv_handle_t = c_void;
-pub type uv_loop_t = c_void;
-pub type uv_idle_t = c_void;
-pub type uv_tcp_t = c_void;
-pub type uv_connect_t = c_void;
-pub type uv_write_t = c_void;
-pub type uv_async_t = c_void;
-pub type uv_timer_t = c_void;
-pub type uv_stream_t = c_void;
-pub type uv_fs_t = c_void;
+pub type uv_handle_t = Void;
+pub type uv_loop_t = Void;
+pub type uv_idle_t = Void;
+pub type uv_tcp_t = Void;
+pub type uv_connect_t = Void;
+pub type uv_write_t = Void;
+pub type uv_async_t = Void;
+pub type uv_timer_t = Void;
+pub type uv_stream_t = Void;
+pub type uv_fs_t = Void;
 
 pub type uv_idle_cb = *u8;
 
-pub type sockaddr_in = c_void;
-pub type sockaddr_in6 = c_void;
+pub type sockaddr_in = Void;
+pub type sockaddr_in6 = Void;
 
 #[deriving(Eq)]
 pub enum uv_handle_type {
@@ -96,7 +96,7 @@ pub enum uv_req_type {
     UV_REQ_TYPE_MAX
 }
 
-pub unsafe fn malloc_handle(handle: uv_handle_type) -> *c_void {
+pub unsafe fn malloc_handle(handle: uv_handle_type) -> *Void {
     assert!(handle != UV_UNKNOWN_HANDLE && handle != UV_HANDLE_TYPE_MAX);
     let size = rust_uv_handle_size(handle as uint);
     let p = malloc(size);
@@ -104,11 +104,11 @@ pub unsafe fn malloc_handle(handle: uv_handle_type) -> *c_void {
     return p;
 }
 
-pub unsafe fn free_handle(v: *c_void) {
+pub unsafe fn free_handle(v: *Void) {
     free(v)
 }
 
-pub unsafe fn malloc_req(req: uv_req_type) -> *c_void {
+pub unsafe fn malloc_req(req: uv_req_type) -> *Void {
     assert!(req != UV_UNKNOWN_REQ && req != UV_REQ_TYPE_MAX);
     let size = rust_uv_req_size(req as uint);
     let p = malloc(size);
@@ -116,7 +116,7 @@ pub unsafe fn malloc_req(req: uv_req_type) -> *c_void {
     return p;
 }
 
-pub unsafe fn free_req(v: *c_void) {
+pub unsafe fn free_req(v: *Void) {
     free(v)
 }
 
@@ -134,23 +134,23 @@ fn request_sanity_check() {
     }
 }
 
-pub unsafe fn loop_new() -> *c_void {
+pub unsafe fn loop_new() -> *Void {
     return rust_uv_loop_new();
 }
 
-pub unsafe fn loop_delete(loop_handle: *c_void) {
+pub unsafe fn loop_delete(loop_handle: *Void) {
     rust_uv_loop_delete(loop_handle);
 }
 
-pub unsafe fn run(loop_handle: *c_void) {
+pub unsafe fn run(loop_handle: *Void) {
     rust_uv_run(loop_handle);
 }
 
 pub unsafe fn close<T>(handle: *T, cb: *u8) {
-    rust_uv_close(handle as *c_void, cb);
+    rust_uv_close(handle as *Void, cb);
 }
 
-pub unsafe fn walk(loop_handle: *c_void, cb: *u8, arg: *c_void) {
+pub unsafe fn walk(loop_handle: *Void, cb: *u8, arg: *Void) {
     rust_uv_walk(loop_handle, cb, arg);
 }
 
@@ -174,7 +174,7 @@ pub unsafe fn idle_stop(handle: *uv_idle_t) -> c_int {
     rust_uv_idle_stop(handle)
 }
 
-pub unsafe fn tcp_init(loop_handle: *c_void, handle: *uv_tcp_t) -> c_int {
+pub unsafe fn tcp_init(loop_handle: *Void, handle: *uv_tcp_t) -> c_int {
     return rust_uv_tcp_init(loop_handle, handle);
 }
 
@@ -212,27 +212,27 @@ pub unsafe fn tcp_getpeername6(tcp_handle_ptr: *uv_tcp_t, name: *sockaddr_in6) -
 }
 
 pub unsafe fn listen<T>(stream: *T, backlog: c_int, cb: *u8) -> c_int {
-    return rust_uv_listen(stream as *c_void, backlog, cb);
+    return rust_uv_listen(stream as *Void, backlog, cb);
 }
 
-pub unsafe fn accept(server: *c_void, client: *c_void) -> c_int {
-    return rust_uv_accept(server as *c_void, client as *c_void);
+pub unsafe fn accept(server: *Void, client: *Void) -> c_int {
+    return rust_uv_accept(server as *Void, client as *Void);
 }
 
 pub unsafe fn write<T>(req: *uv_write_t, stream: *T, buf_in: &[uv_buf_t], cb: *u8) -> c_int {
     let buf_ptr = vec::raw::to_ptr(buf_in);
     let buf_cnt = buf_in.len() as i32;
-    return rust_uv_write(req as *c_void, stream as *c_void, buf_ptr, buf_cnt, cb);
+    return rust_uv_write(req as *Void, stream as *Void, buf_ptr, buf_cnt, cb);
 }
 pub unsafe fn read_start(stream: *uv_stream_t, on_alloc: *u8, on_read: *u8) -> c_int {
-    return rust_uv_read_start(stream as *c_void, on_alloc, on_read);
+    return rust_uv_read_start(stream as *Void, on_alloc, on_read);
 }
 
 pub unsafe fn read_stop(stream: *uv_stream_t) -> c_int {
-    return rust_uv_read_stop(stream as *c_void);
+    return rust_uv_read_stop(stream as *Void);
 }
 
-pub unsafe fn last_error(loop_handle: *c_void) -> uv_err_t {
+pub unsafe fn last_error(loop_handle: *Void) -> uv_err_t {
     return rust_uv_last_error(loop_handle);
 }
 
@@ -243,7 +243,7 @@ pub unsafe fn err_name(err: *uv_err_t) -> *c_char {
     return rust_uv_err_name(err);
 }
 
-pub unsafe fn async_init(loop_handle: *c_void, async_handle: *uv_async_t, cb: *u8) -> c_int {
+pub unsafe fn async_init(loop_handle: *Void, async_handle: *uv_async_t, cb: *u8) -> c_int {
     return rust_uv_async_init(loop_handle, async_handle, cb);
 }
 
@@ -257,7 +257,7 @@ pub unsafe fn buf_init(input: *u8, len: uint) -> uv_buf_t {
     return out_buf;
 }
 
-pub unsafe fn timer_init(loop_ptr: *c_void, timer_ptr: *uv_timer_t) -> c_int {
+pub unsafe fn timer_init(loop_ptr: *Void, timer_ptr: *uv_timer_t) -> c_int {
     return rust_uv_timer_init(loop_ptr, timer_ptr);
 }
 pub unsafe fn timer_start(timer_ptr: *uv_timer_t, cb: *u8, timeout: uint,
@@ -288,8 +288,8 @@ pub unsafe fn free_ip6_addr(addr: *sockaddr_in6) {
 }
 
 // data access helpers
-pub unsafe fn get_loop_for_uv_handle<T>(handle: *T) -> *c_void {
-    return rust_uv_get_loop_for_uv_handle(handle as *c_void);
+pub unsafe fn get_loop_for_uv_handle<T>(handle: *T) -> *Void {
+    return rust_uv_get_loop_for_uv_handle(handle as *Void);
 }
 pub unsafe fn get_stream_handle_from_connect_req(connect: *uv_connect_t) -> *uv_stream_t {
     return rust_uv_get_stream_handle_from_connect_req(connect);
@@ -297,23 +297,23 @@ pub unsafe fn get_stream_handle_from_connect_req(connect: *uv_connect_t) -> *uv_
 pub unsafe fn get_stream_handle_from_write_req(write_req: *uv_write_t) -> *uv_stream_t {
     return rust_uv_get_stream_handle_from_write_req(write_req);
 }
-pub unsafe fn get_data_for_uv_loop(loop_ptr: *c_void) -> *c_void {
+pub unsafe fn get_data_for_uv_loop(loop_ptr: *Void) -> *Void {
     rust_uv_get_data_for_uv_loop(loop_ptr)
 }
-pub unsafe fn set_data_for_uv_loop(loop_ptr: *c_void, data: *c_void) {
+pub unsafe fn set_data_for_uv_loop(loop_ptr: *Void, data: *Void) {
     rust_uv_set_data_for_uv_loop(loop_ptr, data);
 }
-pub unsafe fn get_data_for_uv_handle<T>(handle: *T) -> *c_void {
-    return rust_uv_get_data_for_uv_handle(handle as *c_void);
+pub unsafe fn get_data_for_uv_handle<T>(handle: *T) -> *Void {
+    return rust_uv_get_data_for_uv_handle(handle as *Void);
 }
 pub unsafe fn set_data_for_uv_handle<T, U>(handle: *T, data: *U) {
-    rust_uv_set_data_for_uv_handle(handle as *c_void, data as *c_void);
+    rust_uv_set_data_for_uv_handle(handle as *Void, data as *Void);
 }
-pub unsafe fn get_data_for_req<T>(req: *T) -> *c_void {
-    return rust_uv_get_data_for_req(req as *c_void);
+pub unsafe fn get_data_for_req<T>(req: *T) -> *Void {
+    return rust_uv_get_data_for_req(req as *Void);
 }
 pub unsafe fn set_data_for_req<T, U>(req: *T, data: *U) {
-    rust_uv_set_data_for_req(req as *c_void, data as *c_void);
+    rust_uv_set_data_for_req(req as *Void, data as *Void);
 }
 pub unsafe fn get_base_from_buf(buf: uv_buf_t) -> *u8 {
     return rust_uv_get_base_from_buf(buf);
@@ -328,7 +328,7 @@ pub unsafe fn free_base_of_buf(buf: uv_buf_t) {
     rust_uv_free_base_of_buf(buf);
 }
 
-pub unsafe fn get_last_err_info(uv_loop: *c_void) -> ~str {
+pub unsafe fn get_last_err_info(uv_loop: *Void) -> ~str {
     let err = last_error(uv_loop);
     let err_ptr = ptr::to_unsafe_ptr(&err);
     let err_name = str::raw::from_c_str(err_name(err_ptr));
@@ -337,7 +337,7 @@ pub unsafe fn get_last_err_info(uv_loop: *c_void) -> ~str {
                     err_name, err_msg);
 }
 
-pub unsafe fn get_last_err_data(uv_loop: *c_void) -> uv_err_data {
+pub unsafe fn get_last_err_data(uv_loop: *Void) -> uv_err_data {
     let err = last_error(uv_loop);
     let err_ptr = ptr::to_unsafe_ptr(&err);
     let err_name = str::raw::from_c_str(err_name(err_ptr));
@@ -358,11 +358,11 @@ extern {
     fn rust_uv_req_type_max() -> uintptr_t;
 
     // libuv public API
-    fn rust_uv_loop_new() -> *c_void;
-    fn rust_uv_loop_delete(lp: *c_void);
-    fn rust_uv_run(loop_handle: *c_void);
-    fn rust_uv_close(handle: *c_void, cb: *u8);
-    fn rust_uv_walk(loop_handle: *c_void, cb: *u8, arg: *c_void);
+    fn rust_uv_loop_new() -> *Void;
+    fn rust_uv_loop_delete(lp: *Void);
+    fn rust_uv_run(loop_handle: *Void);
+    fn rust_uv_close(handle: *Void, cb: *u8);
+    fn rust_uv_walk(loop_handle: *Void, cb: *u8, arg: *Void);
 
     fn rust_uv_idle_new() -> *uv_idle_t;
     fn rust_uv_idle_delete(handle: *uv_idle_t);
@@ -371,13 +371,13 @@ extern {
     fn rust_uv_idle_stop(handle: *uv_idle_t) -> c_int;
 
     fn rust_uv_async_send(handle: *uv_async_t);
-    fn rust_uv_async_init(loop_handle: *c_void,
+    fn rust_uv_async_init(loop_handle: *Void,
                           async_handle: *uv_async_t,
                           cb: *u8) -> c_int;
-    fn rust_uv_tcp_init(loop_handle: *c_void, handle_ptr: *uv_tcp_t) -> c_int;
+    fn rust_uv_tcp_init(loop_handle: *Void, handle_ptr: *uv_tcp_t) -> c_int;
     // FIXME ref #2604 .. ?
     fn rust_uv_buf_init(out_buf: *uv_buf_t, base: *u8, len: size_t);
-    fn rust_uv_last_error(loop_handle: *c_void) -> uv_err_t;
+    fn rust_uv_last_error(loop_handle: *Void) -> uv_err_t;
     // FIXME ref #2064
     fn rust_uv_strerror(err: *uv_err_t) -> *c_char;
     // FIXME ref #2064
@@ -408,18 +408,18 @@ extern {
                                name: *sockaddr_in) -> c_int;
     fn rust_uv_tcp_getpeername6(tcp_handle_ptr: *uv_tcp_t,
                                 name: *sockaddr_in6) ->c_int;
-    fn rust_uv_listen(stream: *c_void, backlog: c_int, cb: *u8) -> c_int;
-    fn rust_uv_accept(server: *c_void, client: *c_void) -> c_int;
-    fn rust_uv_write(req: *c_void,
-                     stream: *c_void,
+    fn rust_uv_listen(stream: *Void, backlog: c_int, cb: *u8) -> c_int;
+    fn rust_uv_accept(server: *Void, client: *Void) -> c_int;
+    fn rust_uv_write(req: *Void,
+                     stream: *Void,
                      buf_in: *uv_buf_t,
                      buf_cnt: c_int,
                      cb: *u8) -> c_int;
-    fn rust_uv_read_start(stream: *c_void,
+    fn rust_uv_read_start(stream: *Void,
                           on_alloc: *u8,
                           on_read: *u8) -> c_int;
-    fn rust_uv_read_stop(stream: *c_void) -> c_int;
-    fn rust_uv_timer_init(loop_handle: *c_void,
+    fn rust_uv_read_stop(stream: *Void) -> c_int;
+    fn rust_uv_timer_init(loop_handle: *Void,
                           timer_handle: *uv_timer_t) -> c_int;
     fn rust_uv_timer_start(timer_handle: *uv_timer_t,
                            cb: *u8,
@@ -431,13 +431,13 @@ extern {
     fn rust_uv_free_base_of_buf(buf: uv_buf_t);
     fn rust_uv_get_stream_handle_from_connect_req(connect_req: *uv_connect_t) -> *uv_stream_t;
     fn rust_uv_get_stream_handle_from_write_req(write_req: *uv_write_t) -> *uv_stream_t;
-    fn rust_uv_get_loop_for_uv_handle(handle: *c_void) -> *c_void;
-    fn rust_uv_get_data_for_uv_loop(loop_ptr: *c_void) -> *c_void;
-    fn rust_uv_set_data_for_uv_loop(loop_ptr: *c_void, data: *c_void);
-    fn rust_uv_get_data_for_uv_handle(handle: *c_void) -> *c_void;
-    fn rust_uv_set_data_for_uv_handle(handle: *c_void, data: *c_void);
-    fn rust_uv_get_data_for_req(req: *c_void) -> *c_void;
-    fn rust_uv_set_data_for_req(req: *c_void, data: *c_void);
+    fn rust_uv_get_loop_for_uv_handle(handle: *Void) -> *Void;
+    fn rust_uv_get_data_for_uv_loop(loop_ptr: *Void) -> *Void;
+    fn rust_uv_set_data_for_uv_loop(loop_ptr: *Void, data: *Void);
+    fn rust_uv_get_data_for_uv_handle(handle: *Void) -> *Void;
+    fn rust_uv_set_data_for_uv_handle(handle: *Void, data: *Void);
+    fn rust_uv_get_data_for_req(req: *Void) -> *Void;
+    fn rust_uv_set_data_for_req(req: *Void, data: *Void);
     fn rust_uv_get_base_from_buf(buf: uv_buf_t) -> *u8;
     fn rust_uv_get_len_from_buf(buf: uv_buf_t) -> size_t;
 }

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -16,7 +16,7 @@ use cast;
 use comm::{stream, SharedChan, GenericChan, GenericPort};
 use io;
 use iterator::IteratorUtil;
-use libc::{pid_t, c_void, c_int};
+use libc::{pid_t, c_int};
 use libc;
 use option::{Some, None};
 use os;
@@ -24,6 +24,7 @@ use prelude::*;
 use ptr;
 use str;
 use task;
+use util::Void;
 use vec::ImmutableVector;
 
 /**
@@ -639,12 +640,12 @@ fn spawn_process_os(prog: &str, args: &[~str],
     use int;
 
     mod rustrt {
-        use libc::c_void;
+        use util::Void;
 
         #[abi = "cdecl"]
         pub extern {
             unsafe fn rust_unset_sigprocmask();
-            unsafe fn rust_set_environ(envp: *c_void);
+            unsafe fn rust_set_environ(envp: *Void);
         }
     }
 
@@ -707,7 +708,7 @@ fn with_argv<T>(prog: &str, args: &[~str],
 }
 
 #[cfg(unix)]
-fn with_envp<T>(env: Option<&[(~str, ~str)]>, cb: &fn(*c_void) -> T) -> T {
+fn with_envp<T>(env: Option<&[(~str, ~str)]>, cb: &fn(*Void) -> T) -> T {
     // On posixy systems we can pass a char** for envp, which is
     // a null-terminated array of "k=v\n" strings.
     match env {
@@ -737,7 +738,7 @@ fn with_envp<T>(env: Option<&[(~str, ~str)]>, cb: &fn(*c_void) -> T) -> T {
 }
 
 #[cfg(windows)]
-fn with_envp<T>(env: Option<&[(~str, ~str)]>, cb: &fn(*mut c_void) -> T) -> T {
+fn with_envp<T>(env: Option<&[(~str, ~str)]>, cb: &fn(*mut Void) -> T) -> T {
     // On win32 we pass an "environment block" which is not a char**, but
     // rather a concatenation of null-terminated k=v\0 sequences, with a final
     // \0 to terminate.

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -32,6 +32,7 @@ use ptr;
 use ptr::RawPtr;
 use to_str::ToStr;
 use uint;
+use util::Void;
 use vec;
 use vec::{OwnedVector, OwnedCopyableVector, ImmutableVector};
 
@@ -536,8 +537,8 @@ pub fn eq_slice(a: &str, b: &str) -> bool {
             if (alen != blen) { false }
             else {
                 unsafe {
-                    libc::memcmp(ap as *libc::c_void,
-                                 bp as *libc::c_void,
+                    libc::memcmp(ap as *Void,
+                                 bp as *Void,
                                  (alen - 1) as libc::size_t) == 0
                 }
             }
@@ -553,8 +554,8 @@ pub fn eq_slice(a: &str, b: &str) -> bool {
             if (alen != blen) { false }
             else {
                 unsafe {
-                    libc::memcmp(ap as *libc::c_void,
-                                 bp as *libc::c_void,
+                    libc::memcmp(ap as *Void,
+                                 bp as *Void,
                                  (alen - 1) as libc::size_t) == 0
                 }
             }

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -912,12 +912,12 @@ mod testrt {
 
     #[nolink]
     pub extern {
-        unsafe fn rust_dbg_lock_create() -> *libc::c_void;
-        unsafe fn rust_dbg_lock_destroy(lock: *libc::c_void);
-        unsafe fn rust_dbg_lock_lock(lock: *libc::c_void);
-        unsafe fn rust_dbg_lock_unlock(lock: *libc::c_void);
-        unsafe fn rust_dbg_lock_wait(lock: *libc::c_void);
-        unsafe fn rust_dbg_lock_signal(lock: *libc::c_void);
+        unsafe fn rust_dbg_lock_create() -> *Void;
+        unsafe fn rust_dbg_lock_destroy(lock: *Void);
+        unsafe fn rust_dbg_lock_lock(lock: *Void);
+        unsafe fn rust_dbg_lock_unlock(lock: *Void);
+        unsafe fn rust_dbg_lock_wait(lock: *Void);
+        unsafe fn rust_dbg_lock_signal(lock: *Void);
     }
 }
 

--- a/src/libstd/task/rt.rs
+++ b/src/libstd/task/rt.rs
@@ -17,6 +17,7 @@ The task interface to the runtime
 #[doc(hidden)];
 
 use libc;
+use util::Void;
 
 #[allow(non_camel_case_types)] // runtime type
 pub type sched_id = int;
@@ -26,9 +27,9 @@ pub type task_id = int;
 // These are both opaque runtime/compiler types that we don't know the
 // structure of and should only deal with via unsafe pointer
 #[allow(non_camel_case_types)] // runtime type
-pub type rust_task = libc::c_void;
+pub type rust_task = Void;
 #[allow(non_camel_case_types)] // runtime type
-pub type rust_closure = libc::c_void;
+pub type rust_closure = Void;
 
 pub extern {
     #[rust_stack]
@@ -63,9 +64,9 @@ pub extern {
     fn rust_task_kill_all(task: *rust_task);
 
     #[rust_stack]
-    fn rust_get_task_local_data(task: *rust_task) -> *libc::c_void;
+    fn rust_get_task_local_data(task: *rust_task) -> *Void;
     #[rust_stack]
-    fn rust_set_task_local_data(task: *rust_task, map: *libc::c_void);
+    fn rust_set_task_local_data(task: *rust_task, map: *Void);
     #[rust_stack]
     fn rust_task_local_data_atexit(task: *rust_task, cleanup_fn: *u8);
 }

--- a/src/libstd/unstable/at_exit.rs
+++ b/src/libstd/unstable/at_exit.rs
@@ -39,10 +39,10 @@ pub fn at_exit(f: ~fn()) {
 // pointer and due to FFI problems I am more comfortable making the
 // interface use a normal pointer
 mod rustrt {
-    use libc::c_void;
+    use util::Void;
 
     pub extern {
-        fn rust_register_exit_function(runner: *c_void, f: ~~fn());
+        fn rust_register_exit_function(runner: *Void, f: ~~fn());
     }
 }
 

--- a/src/libstd/unstable/atomics.rs
+++ b/src/libstd/unstable/atomics.rs
@@ -21,8 +21,8 @@
 use unstable::intrinsics;
 use cast;
 use option::{Option,Some,None};
-use libc::c_void;
 use ops::Drop;
+use util::Void;
 
 /**
  * A simple atomic flag, that can be set and cleared. The most basic atomic type.
@@ -64,7 +64,7 @@ pub struct AtomicPtr<T> {
  */
 #[unsafe_no_drop_flag]
 pub struct AtomicOption<T> {
-    priv p: *mut c_void
+    priv p: *mut Void
 }
 
 pub enum Ordering {

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -17,12 +17,12 @@ A simple wrapper over the platforms dynamic library facilities
 */
 use cast;
 use path;
-use libc;
 use ops::*;
 use option::*;
 use result::*;
+use util::Void;
 
-pub struct DynamicLibrary { priv handle: *libc::c_void }
+pub struct DynamicLibrary { priv handle: *Void }
 
 impl Drop for DynamicLibrary {
     fn drop(&self) {
@@ -107,14 +107,15 @@ mod dl {
     use str;
     use task;
     use result::*;
+    use util::Void;
 
-    pub unsafe fn open_external(filename: &path::Path) -> *libc::c_void {
+    pub unsafe fn open_external(filename: &path::Path) -> *Void {
         do filename.to_str().as_c_str |raw_name| {
             dlopen(raw_name, Lazy as libc::c_int)
         }
     }
 
-    pub unsafe fn open_internal() -> *libc::c_void {
+    pub unsafe fn open_internal() -> *Void {
         dlopen(ptr::null(), Lazy as libc::c_int)
     }
 
@@ -135,10 +136,10 @@ mod dl {
         }
     }
 
-    pub unsafe fn symbol(handle: *libc::c_void, symbol: *libc::c_char) -> *libc::c_void {
+    pub unsafe fn symbol(handle: *Void, symbol: *libc::c_char) -> *Void {
         dlsym(handle, symbol)
     }
-    pub unsafe fn close(handle: *libc::c_void) {
+    pub unsafe fn close(handle: *Void) {
         dlclose(handle); ()
     }
 
@@ -151,10 +152,10 @@ mod dl {
 
     #[link_name = "dl"]
     extern {
-        fn dlopen(filename: *libc::c_char, flag: libc::c_int) -> *libc::c_void;
+        fn dlopen(filename: *libc::c_char, flag: libc::c_int) -> *Void;
         fn dlerror() -> *libc::c_char;
-        fn dlsym(handle: *libc::c_void, symbol: *libc::c_char) -> *libc::c_void;
-        fn dlclose(handle: *libc::c_void) -> libc::c_int;
+        fn dlsym(handle: *Void, symbol: *libc::c_char) -> *Void;
+        fn dlclose(handle: *Void) -> libc::c_int;
     }
 }
 
@@ -167,15 +168,15 @@ mod dl {
     use task;
     use result::*;
 
-    pub unsafe fn open_external(filename: &path::Path) -> *libc::c_void {
+    pub unsafe fn open_external(filename: &path::Path) -> *Void {
         do os::win32::as_utf16_p(filename.to_str()) |raw_name| {
             LoadLibraryW(raw_name)
         }
     }
 
-    pub unsafe fn open_internal() -> *libc::c_void {
+    pub unsafe fn open_internal() -> *Void {
         let handle = ptr::null();
-        GetModuleHandleExW(0 as libc::DWORD, ptr::null(), &handle as **libc::c_void);
+        GetModuleHandleExW(0 as libc::DWORD, ptr::null(), &handle as **Void);
         handle
     }
 
@@ -195,20 +196,20 @@ mod dl {
             }
         }
     }
-    pub unsafe fn symbol(handle: *libc::c_void, symbol: *libc::c_char) -> *libc::c_void {
+    pub unsafe fn symbol(handle: *Void, symbol: *libc::c_char) -> *Void {
         GetProcAddress(handle, symbol)
     }
-    pub unsafe fn close(handle: *libc::c_void) {
+    pub unsafe fn close(handle: *Void) {
         FreeLibrary(handle); ()
     }
 
     #[link_name = "kernel32"]
     extern "stdcall" {
         fn SetLastError(error: u32);
-        fn LoadLibraryW(name: *u16) -> *libc::c_void;
+        fn LoadLibraryW(name: *u16) -> *Void;
         fn GetModuleHandleExW(dwFlags: libc::DWORD, name: *u16,
-                              handle: **libc::c_void) -> *libc::c_void;
-        fn GetProcAddress(handle: *libc::c_void, name: *libc::c_char) -> *libc::c_void;
-        fn FreeLibrary(handle: *libc::c_void);
+                              handle: **Void) -> *Void;
+        fn GetProcAddress(handle: *Void, name: *libc::c_char) -> *Void;
+        fn FreeLibrary(handle: *Void);
     }
 }

--- a/src/libstd/unstable/global.rs
+++ b/src/libstd/unstable/global.rs
@@ -28,7 +28,6 @@ avoid hitting the mutex.
 use cast::{transmute};
 use clone::Clone;
 use kinds::Send;
-use libc::{c_void};
 use option::{Option, Some, None};
 use ops::Drop;
 use unstable::sync::{Exclusive, exclusive};
@@ -36,6 +35,7 @@ use unstable::at_exit::at_exit;
 use unstable::intrinsics::atomic_cxchg;
 use hashmap::HashMap;
 use sys::Closure;
+use util::Void;
 
 #[cfg(test)] use unstable::sync::{UnsafeAtomicRcBox};
 #[cfg(test)] use task::spawn;
@@ -101,7 +101,7 @@ unsafe fn global_data_modify_<T:Send>(
         };
         match maybe_new_value {
             Some(value) => {
-                let data: *c_void = transmute(value);
+                let data: *Void = transmute(value);
                 let dtor: ~fn() = match maybe_dtor {
                     Some(dtor) => dtor,
                     None => {
@@ -143,7 +143,7 @@ pub unsafe fn global_data_clone<T:Send + Clone>(
 // destructor. Keys are pointers derived from the type of the
 // global value.  There is a single GlobalState instance per runtime.
 struct GlobalState {
-    map: HashMap<uint, (*c_void, ~fn())>
+    map: HashMap<uint, (*Void, ~fn())>
 }
 
 impl Drop for GlobalState {

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -12,7 +12,6 @@
 
 use comm::{GenericChan, GenericPort};
 use comm;
-use libc;
 use prelude::*;
 use task;
 
@@ -74,7 +73,7 @@ fn test_run_in_bare_thread_exchange() {
 }
 
 #[allow(non_camel_case_types)] // runtime type
-pub type raw_thread = libc::c_void;
+pub type raw_thread = Void;
 
 extern {
     fn rust_raw_thread_start(f: &(&fn())) -> *raw_thread;

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use cast;
-use libc;
 use option::*;
 use task;
 use task::atomically;
@@ -18,12 +17,13 @@ use unstable::intrinsics;
 use ops::Drop;
 use clone::Clone;
 use kinds::Send;
+use util::Void;
 
 /// An atomically reference counted pointer.
 ///
 /// Enforces no shared-memory safety.
 pub struct UnsafeAtomicRcBox<T> {
-    data: *mut libc::c_void,
+    data: *mut Void,
 }
 
 struct AtomicRcBoxData<T> {
@@ -95,7 +95,7 @@ impl<T> Drop for UnsafeAtomicRcBox<T>{
 /****************************************************************************/
 
 #[allow(non_camel_case_types)] // runtime type
-pub type rust_little_lock = *libc::c_void;
+pub type rust_little_lock = *Void;
 
 struct LittleLock {
     l: rust_little_lock,

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -11,8 +11,8 @@
 //! Miscellaneous helpers for common patterns.
 
 use cast;
+use ops::Drop;
 use ptr;
-use prelude::*;
 use unstable::intrinsics;
 
 /// The identity function.

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -21,7 +21,6 @@ use clone::Clone;
 use iterator::{FromIterator, Iterator, IteratorUtil};
 use kinds::Copy;
 use libc;
-use libc::c_void;
 use num::Zero;
 use option::{None, Option, Some};
 use ptr::to_unsafe_ptr;
@@ -38,6 +37,7 @@ use intrinsic::{get_tydesc, TyDesc};
 use unstable::intrinsics::{get_tydesc, contains_managed, TyDesc};
 use vec;
 use util;
+use util::Void;
 
 extern {
     #[fast_ffi]
@@ -1142,7 +1142,7 @@ impl<T> OwnedVector<T> for ~[T] {
                     vec_reserve_shared_actual(td, ptr as **raw::VecRepr, n as libc::size_t);
                 } else {
                     let alloc = n * sys::nonzero_size_of::<T>();
-                    *ptr = realloc_raw(*ptr as *mut c_void, alloc + size_of::<raw::VecRepr>())
+                    *ptr = realloc_raw(*ptr as *mut Void, alloc + size_of::<raw::VecRepr>())
                            as *mut raw::VecRepr;
                     (**ptr).unboxed.alloc = alloc;
                 }
@@ -1176,7 +1176,7 @@ impl<T> OwnedVector<T> for ~[T] {
                     if alloc / sys::nonzero_size_of::<T>() != n || size < alloc {
                         fail!("vector size is too large: %u", n);
                     }
-                    *ptr = realloc_raw(*ptr as *mut c_void, size)
+                    *ptr = realloc_raw(*ptr as *mut Void, size)
                            as *mut raw::VecRepr;
                     (**ptr).unboxed.alloc = alloc;
                 }
@@ -1968,6 +1968,7 @@ pub mod bytes {
     use vec::raw;
     use vec;
     use ptr;
+    use util::Void;
 
     /// A trait for operations on mutable operations on `[u8]`
     pub trait MutableByteVector {
@@ -1990,8 +1991,8 @@ pub mod bytes {
         let b_len = b.len();
         let n = uint::min(a_len, b_len) as libc::size_t;
         let r = unsafe {
-            libc::memcmp(raw::to_ptr(*a) as *libc::c_void,
-                         raw::to_ptr(*b) as *libc::c_void, n) as int
+            libc::memcmp(raw::to_ptr(*a) as *Void,
+                         raw::to_ptr(*b) as *Void, n) as int
         };
 
         if r != 0 { r } else {

--- a/src/test/bench/shootout-pidigits.rs
+++ b/src/test/bench/shootout-pidigits.rs
@@ -2,14 +2,14 @@
 
 use std::cast::transmute;
 use std::from_str::FromStr;
-use std::libc::{STDOUT_FILENO, c_char, c_int, c_uint, c_void, fdopen, fputc};
+use std::libc::{STDOUT_FILENO, c_char, c_int, c_uint, fdopen, fputc};
 use std::libc::{fputs};
 use std::ptr::null;
 
 struct mpz_t {
     _mp_alloc: c_int,
     _mp_size: c_int,
-    _mp_limb_t: *c_void,
+    _mp_limb_t: *Void,
 }
 
 impl mpz_t {

--- a/src/test/compile-fail/non-copyable-void.rs
+++ b/src/test/compile-fail/non-copyable-void.rs
@@ -12,7 +12,7 @@ use std::libc;
 
 fn main() {
     let x : *~[int] = &~[1,2,3];
-    let y : *libc::c_void = x as *libc::c_void;
+    let y : *Void = x as *Void;
     unsafe {
         let _z = copy *y;
         //~^ ERROR copying a value of non-copyable type

--- a/src/test/run-pass/const-cast.rs
+++ b/src/test/run-pass/const-cast.rs
@@ -13,11 +13,11 @@ use std::libc;
 extern fn foo() {}
 
 static x: *u8 = foo;
-static y: *libc::c_void = x as *libc::c_void;
+static y: *Void = x as *Void;
 static a: &'static int = &10;
 static b: *int = a as *int;
 
 pub fn main() {
-    assert_eq!(x as *libc::c_void, y);
+    assert_eq!(x as *Void, y);
     assert_eq!(a as *int, b);
 }

--- a/src/test/run-pass/issue-3656.rs
+++ b/src/test/run-pass/issue-3656.rs
@@ -18,7 +18,7 @@ use std::libc::*;
 struct KEYGEN {
     hash_algorithm: [c_uint, ..2],
     count: uint32_t,
-    salt: *c_void,
+    salt: *Void,
     salt_size: uint32_t,
 }
 

--- a/src/test/run-pass/issue-4735.rs
+++ b/src/test/run-pass/issue-4735.rs
@@ -10,19 +10,18 @@
 
 
 use std::cast::transmute;
-use std::libc::c_void;
 
-struct NonCopyable(*c_void);
+struct NonCopyable(*Void);
 
 impl Drop for NonCopyable {
     fn drop(&self) {
         let p = **self;
-        let v = unsafe { transmute::<*c_void, ~int>(p) };
+        let v = unsafe { transmute::<*Void, ~int>(p) };
     }
 }
 
 fn main() {
     let t = ~0;
-    let p = unsafe { transmute::<~int, *c_void>(t) };
+    let p = unsafe { transmute::<~int, *Void>(t) };
     let z = NonCopyable(p);
 }

--- a/src/test/run-pass/reflect-visit-data.rs
+++ b/src/test/run-pass/reflect-visit-data.rs
@@ -11,7 +11,6 @@
 // xfail-fast
 
 use std::int;
-use std::libc::c_void;
 use std::ptr;
 use std::sys;
 use std::vec::UnboxedVecRepr;
@@ -21,7 +20,7 @@ use std::unstable::intrinsics::{TyDesc, get_tydesc, visit_tydesc, TyVisitor, Opa
 
 /// Trait for visitor that wishes to reflect on data.
 trait movable_ptr {
-    fn move_ptr(&self, adjustment: &fn(*c_void) -> *c_void);
+    fn move_ptr(&self, adjustment: &fn(*Void) -> *Void);
 }
 
 /// Helper function for alignment calculation.
@@ -37,14 +36,14 @@ impl<V:TyVisitor + movable_ptr> ptr_visit_adaptor<V> {
     #[inline(always)]
     pub fn bump(&self, sz: uint) {
       do self.inner.move_ptr() |p| {
-            ((p as uint) + sz) as *c_void
+            ((p as uint) + sz) as *Void
       };
     }
 
     #[inline(always)]
     pub fn align(&self, a: uint) {
       do self.inner.move_ptr() |p| {
-            align(p as uint, a) as *c_void
+            align(p as uint, a) as *Void
       };
     }
 
@@ -486,8 +485,8 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
 struct my_visitor(@mut Stuff);
 
 struct Stuff {
-    ptr1: *c_void,
-    ptr2: *c_void,
+    ptr1: *Void,
+    ptr2: *Void,
     vals: ~[~str]
 }
 
@@ -511,7 +510,7 @@ impl my_visitor {
 struct Inner<V> { inner: V }
 
 impl movable_ptr for my_visitor {
-    fn move_ptr(&self, adjustment: &fn(*c_void) -> *c_void) {
+    fn move_ptr(&self, adjustment: &fn(*Void) -> *Void) {
         self.ptr1 = adjustment(self.ptr1);
         self.ptr2 = adjustment(self.ptr2);
     }
@@ -654,7 +653,7 @@ struct Triple { x: int, y: int, z: int }
 pub fn main() {
     unsafe {
         let r = (1,2,3,true,false, Triple {x:5,y:4,z:3}, (12,));
-        let p = ptr::to_unsafe_ptr(&r) as *c_void;
+        let p = ptr::to_unsafe_ptr(&r) as *Void;
         let u = my_visitor(@mut Stuff {ptr1: p,
                                        ptr2: p,
                                        vals: ~[]});

--- a/src/test/run-pass/rt-sched-1.rs
+++ b/src/test/run-pass/rt-sched-1.rs
@@ -15,10 +15,10 @@ use std::comm::*;
 use std::libc;
 
 pub type sched_id = int;
-pub type task_id = *libc::c_void;
+pub type task_id = *Void;
 
-pub type task = *libc::c_void;
-pub type closure = *libc::c_void;
+pub type task = *Void;
+pub type closure = *Void;
 
 mod rustrt {
     use super::{closure, sched_id, task, task_id};


### PR DESCRIPTION
This removes some redundant libc types where a native Rust type already exists.
