### PR TITLE
Fix comment indenting properly for Vim files.

### DIFF
--- a/src/etc/vim/ftplugin/rust.vim
+++ b/src/etc/vim/ftplugin/rust.vim
@@ -1,14 +1,25 @@
 " Vim syntax file
 " Language:     Rust
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
-" Last Change:  2013 Jul 6
+" Last Change:  2013 Jul 10
 
 if exists("b:did_ftplugin")
 	finish
 endif
 let b:did_ftplugin = 1
 
-setlocal comments=s1:/*,mb:*,ex:*/,:///,://!,://
+" The rust source code at present seems to typically omit a leader on /*!
+" comments, so we'll use that as our default, but make it easy to switch.
+" This does not affect indentation at all (I tested it with and without
+" leader), merely whether a leader is inserted by default or not.
+if exists("g:rust_bang_comment_leader") && g:rust_bang_comment_leader == 1
+	" Why is the `,s0:/*,mb:\ ,ex:*/` there, you ask? I don't understand why,
+	" but without it, */ gets indented one space even if there were no
+	" leaders. I'm fairly sure that's a Vim bug.
+	setlocal comments=s1:/*,mb:*,ex:*/,s0:/*,mb:\ ,ex:*/,:///,://!,://
+else
+	setlocal comments=s0:/*!,m:\ ,ex:*/,s1:/*,mb:*,ex:*/,:///,://!,://
+endif
 setlocal commentstring=//%s
 setlocal formatoptions-=t formatoptions+=croqnlj
 

--- a/src/etc/vim/indent/rust.vim
+++ b/src/etc/vim/indent/rust.vim
@@ -10,7 +10,7 @@ endif
 let b:did_indent = 1
 
 setlocal cindent
-setlocal cinoptions=L0,(0,Ws,JN
+setlocal cinoptions=L0,(0,Ws,JN,j1
 setlocal cinkeys=0{,0},!^F,o,O,0[,0]
 " Don't think cinwords will actually do anything at all... never mind
 setlocal cinwords=do,for,if,else,while,loop,impl,mod,unsafe,trait,struct,enum,fn,extern

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -117,9 +117,9 @@ syn match     rustFloat       display "\<[0-9][0-9_]*\.[0-9_]\+\%([eE][+-]\=[0-9
 syn match     rustLifetime    display "\'\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"
 syn match   rustCharacter   "'\([^'\\]\|\\\(['nrt\\\"]\|x\x\{2}\|u\x\{4}\|U\x\{8}\)\)'"
 
-syn region    rustComment     start="/\*" end="\*/" contains=rustTodo
+syn region    rustCommentML   start="/\*" end="\*/" contains=rustTodo
 syn region    rustComment     start="//" skip="\\$" end="$" contains=rustTodo keepend
-syn region    rustCommentDoc  start="/\*\%(!\|\*/\@!\)" end="\*/" contains=rustTodo
+syn region    rustCommentMLDoc start="/\*\%(!\|\*/\@!\)" end="\*/" contains=rustTodo
 syn region    rustCommentDoc  start="//[/!]" skip="\\$" end="$" contains=rustTodo keepend
 
 syn keyword rustTodo contained TODO FIXME XXX NB NOTE
@@ -151,7 +151,9 @@ hi def link rustModPath       Include
 hi def link rustModPathSep    Delimiter
 hi def link rustFuncName      Function
 hi def link rustFuncCall      Function
+hi def link rustCommentMLDoc  rustCommentDoc
 hi def link rustCommentDoc    SpecialComment
+hi def link rustCommentML     rustComment
 hi def link rustComment       Comment
 hi def link rustAssert        PreCondit
 hi def link rustFail          PreCondit


### PR DESCRIPTION
Indentation now works correctly on subsequent lines of a multi-line
comment, whether there are leaders (`*`) or not. (Formerly it was
incorrectly doing a two-space indent if there was no leader.)

By default, this no longer puts a `*` leader on `/*!` comments, as
that appears to be the current convention in the Rust source code, but
that can easily be re-enabled if desired:

```
let g:rust_bang_comment_leader = 1
```

---

Also a little fix which gets inline closures correct.

Was highlighting thus:

``` rust
a::b::c(|x| {
        here;
        we;
        go;
        });
```

Will now highlight thus, as it should:

``` rust
a::b::c(|x| {
    here;
    we;
    go;
});
```
