### PR TITLE
Rewrite TLS to require less usage of `@`

### DIFF
--- a/src/libextra/rl.rs
+++ b/src/libextra/rl.rs
@@ -72,11 +72,11 @@ fn complete_key(_v: @CompletionCb) {}
 
 /// Bind to the main completion callback
 pub unsafe fn complete(cb: CompletionCb) {
-    local_data::local_data_set(complete_key, @(cb));
+    local_data::set(complete_key, @(cb));
 
     extern fn callback(line: *c_char, completions: *()) {
         unsafe {
-            let cb = *local_data::local_data_get(complete_key)
+            let cb = *local_data::get(complete_key)
                 .get();
 
             do cb(str::raw::from_c_str(line)) |suggestion| {

--- a/src/libextra/rl.rs
+++ b/src/libextra/rl.rs
@@ -76,7 +76,7 @@ pub unsafe fn complete(cb: CompletionCb) {
 
     extern fn callback(line: *c_char, completions: *()) {
         unsafe {
-            let cb = *local_data::get(complete_key)
+            let cb = *local_data::get(complete_key, |k| k.map(|&k| *k))
                 .get();
 
             do cb(str::raw::from_c_str(line)) |suggestion| {

--- a/src/libextra/sort.rs
+++ b/src/libextra/sort.rs
@@ -1204,7 +1204,7 @@ mod big_tests {
     #[unsafe_destructor]
     impl<'self> Drop for LVal<'self> {
         fn drop(&self) {
-            let x = unsafe { local_data::get(self.key) };
+            let x = unsafe { local_data::get(self.key, |k| k.map(|&k| *k)) };
             match x {
                 Some(@y) => {
                     unsafe {

--- a/src/libextra/sort.rs
+++ b/src/libextra/sort.rs
@@ -1204,11 +1204,11 @@ mod big_tests {
     #[unsafe_destructor]
     impl<'self> Drop for LVal<'self> {
         fn drop(&self) {
-            let x = unsafe { local_data::local_data_get(self.key) };
+            let x = unsafe { local_data::get(self.key) };
             match x {
                 Some(@y) => {
                     unsafe {
-                        local_data::local_data_set(self.key, @(y+1));
+                        local_data::set(self.key, @(y+1));
                     }
                 }
                 _ => fail!("Expected key to work"),

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -92,7 +92,7 @@ fn task_local_insn_key(_v: @~[&'static str]) {}
 
 pub fn with_insn_ctxt(blk: &fn(&[&'static str])) {
     unsafe {
-        let opt = local_data::local_data_get(task_local_insn_key);
+        let opt = local_data::get(task_local_insn_key);
         if opt.is_some() {
             blk(*opt.unwrap());
         }
@@ -101,7 +101,7 @@ pub fn with_insn_ctxt(blk: &fn(&[&'static str])) {
 
 pub fn init_insn_ctxt() {
     unsafe {
-        local_data::local_data_set(task_local_insn_key, @~[]);
+        local_data::set(task_local_insn_key, @~[]);
     }
 }
 
@@ -111,7 +111,7 @@ pub struct _InsnCtxt { _x: () }
 impl Drop for _InsnCtxt {
     fn drop(&self) {
         unsafe {
-            do local_data::local_data_modify(task_local_insn_key) |c| {
+            do local_data::modify(task_local_insn_key) |c| {
                 do c.map_consume |ctx| {
                     let mut ctx = copy *ctx;
                     ctx.pop();
@@ -125,7 +125,7 @@ impl Drop for _InsnCtxt {
 pub fn push_ctxt(s: &'static str) -> _InsnCtxt {
     debug!("new InsnCtxt: %s", s);
     unsafe {
-        do local_data::local_data_modify(task_local_insn_key) |c| {
+        do local_data::modify(task_local_insn_key) |c| {
             do c.map_consume |ctx| {
                 let mut ctx = copy *ctx;
                 ctx.push(s);

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -92,7 +92,7 @@ fn task_local_insn_key(_v: @~[&'static str]) {}
 
 pub fn with_insn_ctxt(blk: &fn(&[&'static str])) {
     unsafe {
-        let opt = local_data::get(task_local_insn_key);
+        let opt = local_data::get(task_local_insn_key, |k| k.map(|&k| *k));
         if opt.is_some() {
             blk(*opt.unwrap());
         }

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -241,14 +241,14 @@ impl Drop for CrateContext {
 
 fn task_local_llcx_key(_v: @ContextRef) {}
 pub fn task_llcx() -> ContextRef {
-    let opt = unsafe { local_data::local_data_get(task_local_llcx_key) };
+    let opt = unsafe { local_data::get(task_local_llcx_key) };
     *opt.expect("task-local LLVMContextRef wasn't ever set!")
 }
 
 unsafe fn set_task_llcx(c: ContextRef) {
-    local_data::local_data_set(task_local_llcx_key, @c);
+    local_data::set(task_local_llcx_key, @c);
 }
 
 unsafe fn unset_task_llcx() {
-    local_data::local_data_pop(task_local_llcx_key);
+    local_data::pop(task_local_llcx_key);
 }

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -241,7 +241,7 @@ impl Drop for CrateContext {
 
 fn task_local_llcx_key(_v: @ContextRef) {}
 pub fn task_llcx() -> ContextRef {
-    let opt = unsafe { local_data::get(task_local_llcx_key) };
+    let opt = unsafe { local_data::get(task_local_llcx_key, |k| k.map(|&k| *k)) };
     *opt.expect("task-local LLVMContextRef wasn't ever set!")
 }
 

--- a/src/librusti/program.rs
+++ b/src/librusti/program.rs
@@ -144,7 +144,7 @@ impl Program {
                 let key = ::std::sys::Closure{ code: %? as *(),
                                                env: ::std::ptr::null() };
                 let key = ::std::cast::transmute(key);
-                *::std::local_data::get(key).unwrap()
+                *::std::local_data::get(key, |k| k.map(|&x| *x)).unwrap()
             };\n", key.code as uint));
 
         // Using this __tls_map handle, deserialize each variable binding that

--- a/src/librusti/program.rs
+++ b/src/librusti/program.rs
@@ -58,7 +58,7 @@ struct LocalVariable {
 }
 
 type LocalCache = @mut HashMap<~str, @~[u8]>;
-fn tls_key(_k: @LocalCache) {}
+fn tls_key(_k: LocalCache) {}
 
 impl Program {
     pub fn new() -> Program {
@@ -132,7 +132,7 @@ impl Program {
         ");
 
         let key: sys::Closure = unsafe {
-            let tls_key: &'static fn(@LocalCache) = tls_key;
+            let tls_key: &'static fn(LocalCache) = tls_key;
             cast::transmute(tls_key)
         };
         // First, get a handle to the tls map which stores all the local
@@ -144,7 +144,7 @@ impl Program {
                 let key = ::std::sys::Closure{ code: %? as *(),
                                                env: ::std::ptr::null() };
                 let key = ::std::cast::transmute(key);
-                *::std::local_data::get(key, |k| k.map(|&x| *x)).unwrap()
+                ::std::local_data::get(key, |k| k.map(|&x| *x)).unwrap()
             };\n", key.code as uint));
 
         // Using this __tls_map handle, deserialize each variable binding that
@@ -227,7 +227,7 @@ impl Program {
             map.insert(copy *name, @copy value.data);
         }
         unsafe {
-            local_data::set(tls_key, @map);
+            local_data::set(tls_key, map);
         }
     }
 

--- a/src/librusti/program.rs
+++ b/src/librusti/program.rs
@@ -144,7 +144,7 @@ impl Program {
                 let key = ::std::sys::Closure{ code: %? as *(),
                                                env: ::std::ptr::null() };
                 let key = ::std::cast::transmute(key);
-                *::std::local_data::local_data_get(key).unwrap()
+                *::std::local_data::get(key).unwrap()
             };\n", key.code as uint));
 
         // Using this __tls_map handle, deserialize each variable binding that
@@ -227,7 +227,7 @@ impl Program {
             map.insert(copy *name, @copy value.data);
         }
         unsafe {
-            local_data::local_data_set(tls_key, @map);
+            local_data::set(tls_key, @map);
         }
     }
 
@@ -236,7 +236,7 @@ impl Program {
     /// it updates this cache with the new values of each local variable.
     pub fn consume_cache(&mut self) {
         let map = unsafe {
-            local_data::local_data_pop(tls_key).expect("tls is empty")
+            local_data::pop(tls_key).expect("tls is empty")
         };
         do map.consume |name, value| {
             match self.local_vars.find_mut(&name) {

--- a/src/libstd/condition.rs
+++ b/src/libstd/condition.rs
@@ -32,7 +32,7 @@ impl<'self, T, U> Condition<'self, T, U> {
     pub fn trap(&'self self, h: &'self fn(T) -> U) -> Trap<'self, T, U> {
         unsafe {
             let p : *RustClosure = ::cast::transmute(&h);
-            let prev = local_data::get(self.key);
+            let prev = local_data::get(self.key, |k| k.map(|&x| *x));
             let h = @Handler { handle: *p, prev: prev };
             Trap { cond: self, handler: h }
         }

--- a/src/libstd/condition.rs
+++ b/src/libstd/condition.rs
@@ -26,7 +26,7 @@ pub struct Handler<T, U> {
 
 pub struct Condition<'self, T, U> {
     name: &'static str,
-    key: local_data::LocalDataKey<'self, Handler<T, U>>
+    key: local_data::LocalDataKey<'self, @Handler<T, U>>
 }
 
 impl<'self, T, U> Condition<'self, T, U> {

--- a/src/libstd/condition.rs
+++ b/src/libstd/condition.rs
@@ -12,7 +12,6 @@
 
 #[allow(missing_doc)];
 
-use local_data::{local_data_pop, local_data_set};
 use local_data;
 use prelude::*;
 
@@ -26,14 +25,14 @@ pub struct Handler<T, U> {
 
 pub struct Condition<'self, T, U> {
     name: &'static str,
-    key: local_data::LocalDataKey<'self, @Handler<T, U>>
+    key: local_data::Key<'self, @Handler<T, U>>
 }
 
 impl<'self, T, U> Condition<'self, T, U> {
     pub fn trap(&'self self, h: &'self fn(T) -> U) -> Trap<'self, T, U> {
         unsafe {
             let p : *RustClosure = ::cast::transmute(&h);
-            let prev = local_data::local_data_get(self.key);
+            let prev = local_data::get(self.key);
             let h = @Handler { handle: *p, prev: prev };
             Trap { cond: self, handler: h }
         }
@@ -46,7 +45,7 @@ impl<'self, T, U> Condition<'self, T, U> {
 
     pub fn raise_default(&self, t: T, default: &fn() -> U) -> U {
         unsafe {
-            match local_data_pop(self.key) {
+            match local_data::pop(self.key) {
                 None => {
                     debug!("Condition.raise: found no handler");
                     default()
@@ -55,12 +54,12 @@ impl<'self, T, U> Condition<'self, T, U> {
                     debug!("Condition.raise: found handler");
                     match handler.prev {
                         None => {}
-                        Some(hp) => local_data_set(self.key, hp)
+                        Some(hp) => local_data::set(self.key, hp)
                     }
                     let handle : &fn(T) -> U =
                         ::cast::transmute(handler.handle);
                     let u = handle(t);
-                    local_data_set(self.key, handler);
+                    local_data::set(self.key, handler);
                     u
                 }
             }
@@ -78,7 +77,7 @@ impl<'self, T, U> Trap<'self, T, U> {
         unsafe {
             let _g = Guard { cond: self.cond };
             debug!("Trap: pushing handler to TLS");
-            local_data_set(self.cond.key, self.handler);
+            local_data::set(self.cond.key, self.handler);
             inner()
         }
     }
@@ -93,12 +92,12 @@ impl<'self, T, U> Drop for Guard<'self, T, U> {
     fn drop(&self) {
         unsafe {
             debug!("Guard: popping handler from TLS");
-            let curr = local_data_pop(self.cond.key);
+            let curr = local_data::pop(self.cond.key);
             match curr {
                 None => {}
                 Some(h) => match h.prev {
                     None => {}
-                    Some(hp) => local_data_set(self.cond.key, hp)
+                    Some(hp) => local_data::set(self.cond.key, hp)
                 }
             }
         }

--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -12,14 +12,28 @@
 
 Task local data management
 
-Allows storing boxes with arbitrary types inside, to be accessed
-anywhere within a task, keyed by a pointer to a global finaliser
-function. Useful for dynamic variables, singletons, and interfacing
-with foreign code with bad callback interfaces.
+Allows storing boxes with arbitrary types inside, to be accessed anywhere within
+a task, keyed by a pointer to a global finaliser function. Useful for dynamic
+variables, singletons, and interfacing with foreign code with bad callback
+interfaces.
 
-To use, declare a monomorphic global function at the type to store,
-and use it as the 'key' when accessing. See the 'tls' tests below for
-examples.
+To use, declare a monomorphic (no type parameters) global function at the type
+to store, and use it as the 'key' when accessing.
+
+~~~{.rust}
+use std::local_data;
+
+fn key_int(_: @int) {}
+fn key_vector(_: @~[int]) {}
+
+unsafe {
+    local_data::set(key_int, @3);
+    assert!(local_data::get(key_int) == Some(@3));
+
+    local_data::set(key_vector, @~[3]);
+    assert!(local_data::get(key_vector).unwrap()[0] == 3);
+}
+~~~
 
 Casting 'Arcane Sight' reveals an overwhelming aura of Transmutation
 magic.
@@ -46,40 +60,37 @@ use task::local_data_priv::{local_get, local_pop, local_set, Handle};
  *
  * These two cases aside, the interface is safe.
  */
-pub type LocalDataKey<'self,T> = &'self fn:Copy(v: T);
+pub type Key<'self,T> = &'self fn:Copy(v: T);
 
 /**
  * Remove a task-local data value from the table, returning the
  * reference that was originally created to insert it.
  */
-pub unsafe fn local_data_pop<T: 'static>(key: LocalDataKey<T>) -> Option<T> {
+pub unsafe fn pop<T: 'static>(key: Key<T>) -> Option<T> {
     local_pop(Handle::new(), key)
 }
 /**
  * Retrieve a task-local data value. It will also be kept alive in the
  * table until explicitly removed.
  */
-pub unsafe fn local_data_get<T: 'static>(key: LocalDataKey<@T>) -> Option<@T> {
+pub unsafe fn get<T: 'static>(key: Key<@T>) -> Option<@T> {
     local_get(Handle::new(), key, |loc| loc.map(|&x| *x))
 }
 /**
  * Store a value in task-local data. If this key already has a value,
  * that value is overwritten (and its destructor is run).
  */
-pub unsafe fn local_data_set<T: 'static>(key: LocalDataKey<@T>, data: @T) {
+pub unsafe fn set<T: 'static>(key: Key<@T>, data: @T) {
     local_set(Handle::new(), key, data)
 }
 /**
  * Modify a task-local data value. If the function returns 'None', the
  * data is removed (and its reference dropped).
  */
-pub unsafe fn local_data_modify<T: 'static>(
-    key: LocalDataKey<@T>,
-    modify_fn: &fn(Option<@T>) -> Option<@T>) {
-
-    let cur = local_data_pop(key);
-    match modify_fn(cur) {
-        Some(next) => { local_data_set(key, next); }
+pub unsafe fn modify<T: 'static>(key: Key<@T>,
+                                 f: &fn(Option<@T>) -> Option<@T>) {
+    match f(pop(key)) {
+        Some(next) => { set(key, next); }
         None => {}
     }
 }
@@ -88,19 +99,19 @@ pub unsafe fn local_data_modify<T: 'static>(
 fn test_tls_multitask() {
     unsafe {
         fn my_key(_x: @~str) { }
-        local_data_set(my_key, @~"parent data");
+        set(my_key, @~"parent data");
         do task::spawn {
             // TLS shouldn't carry over.
-            assert!(local_data_get(my_key).is_none());
-            local_data_set(my_key, @~"child data");
-            assert!(*(local_data_get(my_key).get()) ==
+            assert!(get(my_key).is_none());
+            set(my_key, @~"child data");
+            assert!(*(get(my_key).get()) ==
                     ~"child data");
             // should be cleaned up for us
         }
         // Must work multiple times
-        assert!(*(local_data_get(my_key).get()) == ~"parent data");
-        assert!(*(local_data_get(my_key).get()) == ~"parent data");
-        assert!(*(local_data_get(my_key).get()) == ~"parent data");
+        assert!(*(get(my_key).get()) == ~"parent data");
+        assert!(*(get(my_key).get()) == ~"parent data");
+        assert!(*(get(my_key).get()) == ~"parent data");
     }
 }
 
@@ -108,9 +119,9 @@ fn test_tls_multitask() {
 fn test_tls_overwrite() {
     unsafe {
         fn my_key(_x: @~str) { }
-        local_data_set(my_key, @~"first data");
-        local_data_set(my_key, @~"next data"); // Shouldn't leak.
-        assert!(*(local_data_get(my_key).get()) == ~"next data");
+        set(my_key, @~"first data");
+        set(my_key, @~"next data"); // Shouldn't leak.
+        assert!(*(get(my_key).get()) == ~"next data");
     }
 }
 
@@ -118,10 +129,10 @@ fn test_tls_overwrite() {
 fn test_tls_pop() {
     unsafe {
         fn my_key(_x: @~str) { }
-        local_data_set(my_key, @~"weasel");
-        assert!(*(local_data_pop(my_key).get()) == ~"weasel");
+        set(my_key, @~"weasel");
+        assert!(*(pop(my_key).get()) == ~"weasel");
         // Pop must remove the data from the map.
-        assert!(local_data_pop(my_key).is_none());
+        assert!(pop(my_key).is_none());
     }
 }
 
@@ -129,20 +140,20 @@ fn test_tls_pop() {
 fn test_tls_modify() {
     unsafe {
         fn my_key(_x: @~str) { }
-        local_data_modify(my_key, |data| {
+        modify(my_key, |data| {
             match data {
                 Some(@ref val) => fail!("unwelcome value: %s", *val),
                 None           => Some(@~"first data")
             }
         });
-        local_data_modify(my_key, |data| {
+        modify(my_key, |data| {
             match data {
                 Some(@~"first data") => Some(@~"next data"),
                 Some(@ref val)       => fail!("wrong value: %s", *val),
                 None                 => fail!("missing value")
             }
         });
-        assert!(*(local_data_pop(my_key).get()) == ~"next data");
+        assert!(*(pop(my_key).get()) == ~"next data");
     }
 }
 
@@ -156,7 +167,7 @@ fn test_tls_crust_automorestack_memorial_bug() {
     // a stack smaller than 1 MB.
     fn my_key(_x: @~str) { }
     do task::spawn {
-        unsafe { local_data_set(my_key, @~"hax"); }
+        unsafe { set(my_key, @~"hax"); }
     }
 }
 
@@ -167,9 +178,9 @@ fn test_tls_multiple_types() {
     fn int_key(_x: @int) { }
     do task::spawn {
         unsafe {
-            local_data_set(str_key, @~"string data");
-            local_data_set(box_key, @@());
-            local_data_set(int_key, @42);
+            set(str_key, @~"string data");
+            set(box_key, @@());
+            set(int_key, @42);
         }
     }
 }
@@ -181,12 +192,12 @@ fn test_tls_overwrite_multiple_types() {
     fn int_key(_x: @int) { }
     do task::spawn {
         unsafe {
-            local_data_set(str_key, @~"string data");
-            local_data_set(int_key, @42);
+            set(str_key, @~"string data");
+            set(int_key, @42);
             // This could cause a segfault if overwriting-destruction is done
             // with the crazy polymorphic transmute rather than the provided
             // finaliser.
-            local_data_set(int_key, @31337);
+            set(int_key, @31337);
         }
     }
 }
@@ -199,17 +210,17 @@ fn test_tls_cleanup_on_failure() {
         fn str_key(_x: @~str) { }
         fn box_key(_x: @@()) { }
         fn int_key(_x: @int) { }
-        local_data_set(str_key, @~"parent data");
-        local_data_set(box_key, @@());
+        set(str_key, @~"parent data");
+        set(box_key, @@());
         do task::spawn {
             // spawn_linked
-            local_data_set(str_key, @~"string data");
-            local_data_set(box_key, @@());
-            local_data_set(int_key, @42);
+            set(str_key, @~"string data");
+            set(box_key, @@());
+            set(int_key, @42);
             fail!();
         }
         // Not quite nondeterministic.
-        local_data_set(int_key, @31337);
+        set(int_key, @31337);
         fail!();
     }
 }
@@ -219,6 +230,6 @@ fn test_static_pointer() {
     unsafe {
         fn key(_x: @&'static int) { }
         static VALUE: int = 0;
-        local_data_set(key, @&VALUE);
+        set(key, @&VALUE);
     }
 }

--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -28,7 +28,7 @@ magic.
 
 use prelude::*;
 
-use task::local_data_priv::{local_get, local_pop, local_modify, local_set, Handle};
+use task::local_data_priv::{local_get, local_pop, local_set, Handle};
 
 #[cfg(test)] use task;
 
@@ -83,7 +83,11 @@ pub unsafe fn local_data_modify<T: 'static>(
     key: LocalDataKey<T>,
     modify_fn: &fn(Option<@T>) -> Option<@T>) {
 
-    local_modify(Handle::new(), key, modify_fn)
+    let cur = local_data_pop(key);
+    match modify_fn(cur) {
+        Some(next) => { local_data_set(key, next); }
+        None => {}
+    }
 }
 
 #[test]

--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -273,3 +273,11 @@ fn test_static_pointer() {
         set(key, @&VALUE);
     }
 }
+
+#[test]
+fn test_owned() {
+    unsafe {
+        fn key(_x: ~int) { }
+        set(key, ~1);
+    }
+}

--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -170,7 +170,7 @@ fn test_tls_pop() {
     unsafe {
         fn my_key(_x: @~str) { }
         set(my_key, @~"weasel");
-        assert!(*(pop(my_key, |k| k.map(|&k| *k)).get()) == ~"weasel");
+        assert!(*(pop(my_key).get()) == ~"weasel");
         // Pop must remove the data from the map.
         assert!(pop(my_key).is_none());
     }

--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -46,33 +46,27 @@ use task::local_data_priv::{local_get, local_pop, local_set, Handle};
  *
  * These two cases aside, the interface is safe.
  */
-pub type LocalDataKey<'self,T> = &'self fn:Copy(v: @T);
+pub type LocalDataKey<'self,T> = &'self fn:Copy(v: T);
 
 /**
  * Remove a task-local data value from the table, returning the
  * reference that was originally created to insert it.
  */
-pub unsafe fn local_data_pop<T: 'static>(
-    key: LocalDataKey<T>) -> Option<@T> {
-
+pub unsafe fn local_data_pop<T: 'static>(key: LocalDataKey<T>) -> Option<T> {
     local_pop(Handle::new(), key)
 }
 /**
  * Retrieve a task-local data value. It will also be kept alive in the
  * table until explicitly removed.
  */
-pub unsafe fn local_data_get<T: 'static>(
-    key: LocalDataKey<T>) -> Option<@T> {
-
-    local_get(Handle::new(), key)
+pub unsafe fn local_data_get<T: 'static>(key: LocalDataKey<@T>) -> Option<@T> {
+    local_get(Handle::new(), key, |loc| loc.map(|&x| *x))
 }
 /**
  * Store a value in task-local data. If this key already has a value,
  * that value is overwritten (and its destructor is run).
  */
-pub unsafe fn local_data_set<T: 'static>(
-    key: LocalDataKey<T>, data: @T) {
-
+pub unsafe fn local_data_set<T: 'static>(key: LocalDataKey<@T>, data: @T) {
     local_set(Handle::new(), key, data)
 }
 /**
@@ -80,7 +74,7 @@ pub unsafe fn local_data_set<T: 'static>(
  * data is removed (and its reference dropped).
  */
 pub unsafe fn local_data_modify<T: 'static>(
-    key: LocalDataKey<T>,
+    key: LocalDataKey<@T>,
     modify_fn: &fn(Option<@T>) -> Option<@T>) {
 
     let cur = local_data_pop(key);

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1230,7 +1230,7 @@ fn overridden_arg_key(_v: @OverriddenArgs) {}
 /// `os::set_args` function.
 pub fn args() -> ~[~str] {
     unsafe {
-        match local_data::local_data_get(overridden_arg_key) {
+        match local_data::get(overridden_arg_key) {
             None => real_args(),
             Some(args) => copy args.val
         }
@@ -1243,7 +1243,7 @@ pub fn args() -> ~[~str] {
 pub fn set_args(new_args: ~[~str]) {
     unsafe {
         let overridden_args = @OverriddenArgs { val: copy new_args };
-        local_data::local_data_set(overridden_arg_key, overridden_args);
+        local_data::set(overridden_arg_key, overridden_args);
     }
 }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1230,7 +1230,7 @@ fn overridden_arg_key(_v: @OverriddenArgs) {}
 /// `os::set_args` function.
 pub fn args() -> ~[~str] {
     unsafe {
-        match local_data::get(overridden_arg_key) {
+        match local_data::get(overridden_arg_key, |k| k.map(|&k| *k)) {
             None => real_args(),
             Some(args) => copy args.val
         }

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -850,13 +850,13 @@ fn tls_rng_state(_v: @@mut IsaacRng) {}
 pub fn task_rng() -> @mut IsaacRng {
     let r : Option<@@mut IsaacRng>;
     unsafe {
-        r = local_data::local_data_get(tls_rng_state);
+        r = local_data::get(tls_rng_state);
     }
     match r {
         None => {
             unsafe {
                 let rng = @@mut IsaacRng::new_seeded(seed());
-                local_data::local_data_set(tls_rng_state, rng);
+                local_data::set(tls_rng_state, rng);
                 *rng
             }
         }

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -850,7 +850,7 @@ fn tls_rng_state(_v: @@mut IsaacRng) {}
 pub fn task_rng() -> @mut IsaacRng {
     let r : Option<@@mut IsaacRng>;
     unsafe {
-        r = local_data::get(tls_rng_state);
+        r = local_data::get(tls_rng_state, |k| k.map(|&k| *k));
     }
     match r {
         None => {

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -172,10 +172,10 @@ mod test {
             unsafe {
                 fn key(_x: @~str) { }
                 local_data::set(key, @~"data");
-                assert!(*local_data::get(key).get() == ~"data");
+                assert!(*local_data::get(key, |k| k.map(|&k| *k)).get() == ~"data");
                 fn key2(_x: @~str) { }
                 local_data::set(key2, @~"data");
-                assert!(*local_data::get(key2).get() == ~"data");
+                assert!(*local_data::get(key2, |k| k.map(|&k| *k)).get() == ~"data");
             }
         }
     }

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -167,15 +167,15 @@ mod test {
 
     #[test]
     fn tls() {
-        use local_data::*;
+        use local_data;
         do run_in_newsched_task() {
             unsafe {
                 fn key(_x: @~str) { }
-                local_data_set(key, @~"data");
-                assert!(*local_data_get(key).get() == ~"data");
+                local_data::set(key, @~"data");
+                assert!(*local_data::get(key).get() == ~"data");
                 fn key2(_x: @~str) { }
-                local_data_set(key2, @~"data");
-                assert!(*local_data_get(key2).get() == ~"data");
+                local_data::set(key2, @~"data");
+                assert!(*local_data::get(key2).get() == ~"data");
             }
         }
     }

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -32,7 +32,7 @@ pub struct Task {
 }
 
 pub struct GarbageCollector;
-pub struct LocalStorage(*c_void, Option<~fn(*c_void)>);
+pub struct LocalStorage(*c_void, Option<extern "Rust" fn(*c_void)>);
 
 pub struct Unwinder {
     unwinding: bool,

--- a/src/libstd/task/local_data_priv.rs
+++ b/src/libstd/task/local_data_priv.rs
@@ -12,7 +12,7 @@
 
 use cast;
 use libc;
-use local_data::LocalDataKey;
+use local_data;
 use managed::raw::BoxRepr;
 use prelude::*;
 use ptr;
@@ -131,7 +131,7 @@ unsafe fn get_local_map(handle: Handle) -> &mut TaskLocalMap {
     }
 }
 
-unsafe fn key_to_key_value<T: 'static>(key: LocalDataKey<T>) -> *libc::c_void {
+unsafe fn key_to_key_value<T: 'static>(key: local_data::Key<T>) -> *libc::c_void {
     let pair: sys::Closure = cast::transmute(key);
     return pair.code as *libc::c_void;
 }
@@ -155,7 +155,7 @@ unsafe fn transmute_back<'a, T>(data: &'a TLSValue) -> (*BoxRepr, &'a T) {
 }
 
 pub unsafe fn local_pop<T: 'static>(handle: Handle,
-                                    key: LocalDataKey<T>) -> Option<T> {
+                                    key: local_data::Key<T>) -> Option<T> {
     // If you've never seen horrendously unsafe code written in rust before,
     // just feel free to look a bit farther...
     let map = get_local_map(handle);
@@ -203,7 +203,7 @@ pub unsafe fn local_pop<T: 'static>(handle: Handle,
 }
 
 pub unsafe fn local_get<T: 'static, U>(handle: Handle,
-                                       key: LocalDataKey<T>,
+                                       key: local_data::Key<T>,
                                        f: &fn(Option<&T>) -> U) -> U {
     // This does in theory take multiple mutable loans on the tls map, but the
     // references returned are never removed because the map is only increasing
@@ -227,7 +227,7 @@ pub unsafe fn local_get<T: 'static, U>(handle: Handle,
 
 // FIXME(#7673): This shouldn't require '@', it should use '~'
 pub unsafe fn local_set<T: 'static>(handle: Handle,
-                                    key: LocalDataKey<@T>,
+                                    key: local_data::Key<@T>,
                                     data: @T) {
     let map = get_local_map(handle);
     let keyval = key_to_key_value(key);

--- a/src/libstd/task/local_data_priv_stage0.rs
+++ b/src/libstd/task/local_data_priv_stage0.rs
@@ -1,0 +1,229 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[allow(missing_doc)];
+
+use cast;
+use cmp::Eq;
+use libc;
+use local_data;
+use prelude::*;
+use sys;
+use task::rt;
+
+use super::rt::rust_task;
+use rt::task::{Task, LocalStorage};
+
+pub enum Handle {
+    OldHandle(*rust_task),
+    NewHandle(*mut LocalStorage)
+}
+
+impl Handle {
+    pub fn new() -> Handle {
+        use rt::{context, OldTaskContext};
+        use rt::local::Local;
+        unsafe {
+            match context() {
+                OldTaskContext => {
+                    OldHandle(rt::rust_get_task())
+                }
+                _ => {
+                    let task = Local::unsafe_borrow::<Task>();
+                    NewHandle(&mut (*task).storage)
+                }
+            }
+        }
+    }
+}
+
+pub trait LocalData { }
+impl<T: 'static> LocalData for @T { }
+
+impl Eq for @LocalData {
+    fn eq(&self, other: &@LocalData) -> bool {
+        unsafe {
+            let ptr_a: &(uint, uint) = cast::transmute(self);
+            let ptr_b: &(uint, uint) = cast::transmute(other);
+            return ptr_a == ptr_b;
+        }
+    }
+    fn ne(&self, other: &@LocalData) -> bool { !(*self).eq(other) }
+}
+
+// If TLS is used heavily in future, this could be made more efficient with a
+// proper map.
+type TaskLocalElement = (*libc::c_void, *libc::c_void, @LocalData);
+// Has to be a pointer at outermost layer; the foreign call returns void *.
+type TaskLocalMap = ~[Option<TaskLocalElement>];
+
+fn cleanup_task_local_map(map_ptr: *libc::c_void) {
+    unsafe {
+        assert!(!map_ptr.is_null());
+        // Get and keep the single reference that was created at the
+        // beginning.
+        let _map: TaskLocalMap = cast::transmute(map_ptr);
+        // All local_data will be destroyed along with the map.
+    }
+}
+
+// Gets the map from the runtime. Lazily initialises if not done so already.
+unsafe fn get_local_map(handle: Handle) -> &mut TaskLocalMap {
+    match handle {
+        OldHandle(task) => get_task_local_map(task),
+        NewHandle(local_storage) => get_newsched_local_map(local_storage)
+    }
+}
+
+unsafe fn get_task_local_map(task: *rust_task) -> &mut TaskLocalMap {
+
+    extern fn cleanup_task_local_map_extern_cb(map_ptr: *libc::c_void) {
+        cleanup_task_local_map(map_ptr);
+    }
+
+    // Relies on the runtime initialising the pointer to null.
+    // Note: the map is an owned pointer and is "owned" by TLS. It is moved
+    // into the tls slot for this task, and then mutable loans are taken from
+    // this slot to modify the map.
+    let map_ptr = rt::rust_get_task_local_data(task);
+    if (*map_ptr).is_null() {
+        // First time TLS is used, create a new map and set up the necessary
+        // TLS information for its safe destruction
+        let map: TaskLocalMap = ~[];
+        *map_ptr = cast::transmute(map);
+        rt::rust_task_local_data_atexit(task, cleanup_task_local_map_extern_cb);
+    }
+    return cast::transmute(map_ptr);
+}
+
+unsafe fn get_newsched_local_map(local: *mut LocalStorage) -> &mut TaskLocalMap {
+    // This is based on the same idea as the oldsched code above.
+    match &mut *local {
+        // If the at_exit function is already set, then we just need to take a
+        // loan out on the TLS map stored inside
+        &LocalStorage(ref mut map_ptr, Some(_)) => {
+            assert!(map_ptr.is_not_null());
+            return cast::transmute(map_ptr);
+        }
+        // If this is the first time we've accessed TLS, perform similar
+        // actions to the oldsched way of doing things.
+        &LocalStorage(ref mut map_ptr, ref mut at_exit) => {
+            assert!(map_ptr.is_null());
+            assert!(at_exit.is_none());
+            let map: TaskLocalMap = ~[];
+            *map_ptr = cast::transmute(map);
+            *at_exit = Some(cleanup_task_local_map);
+            return cast::transmute(map_ptr);
+        }
+    }
+}
+
+unsafe fn key_to_key_value<T: 'static>(key: local_data::Key<@T>) -> *libc::c_void {
+    let pair: sys::Closure = cast::transmute(key);
+    return pair.code as *libc::c_void;
+}
+
+// If returning Some(..), returns with @T with the map's reference. Careful!
+unsafe fn local_data_lookup<T: 'static>(
+    map: &mut TaskLocalMap, key: local_data::Key<@T>)
+    -> Option<(uint, *libc::c_void)> {
+
+    let key_value = key_to_key_value(key);
+    for map.iter().enumerate().advance |(i, entry)| {
+        match *entry {
+            Some((k, data, _)) if k == key_value => { return Some((i, data)); }
+            _ => {}
+        }
+    }
+    return None;
+}
+
+unsafe fn local_get_helper<T: 'static>(
+    handle: Handle, key: local_data::Key<@T>,
+    do_pop: bool) -> Option<@T> {
+
+    let map = get_local_map(handle);
+    // Interpreturn our findings from the map
+    do local_data_lookup(map, key).map |result| {
+        // A reference count magically appears on 'data' out of thin air. It
+        // was referenced in the local_data box, though, not here, so before
+        // overwriting the local_data_box we need to give an extra reference.
+        // We must also give an extra reference when not removing.
+        let (index, data_ptr) = *result;
+        let data: @T = cast::transmute(data_ptr);
+        cast::bump_box_refcount(data);
+        if do_pop {
+            map[index] = None;
+        }
+        data
+    }
+}
+
+
+pub unsafe fn local_pop<T: 'static>(
+    handle: Handle,
+    key: local_data::Key<@T>) -> Option<@T> {
+
+    local_get_helper(handle, key, true)
+}
+
+pub unsafe fn local_get<T: 'static, U>(
+    handle: Handle,
+    key: local_data::Key<@T>,
+    f: &fn(Option<&@T>) -> U) -> U {
+
+    match local_get_helper(handle, key, false) {
+        Some(ref x) => f(Some(x)),
+        None => f(None)
+    }
+}
+
+pub unsafe fn local_set<T: 'static>(
+    handle: Handle, key: local_data::Key<@T>, data: @T) {
+
+    let map = get_local_map(handle);
+    // Store key+data as *voids. Data is invisibly referenced once; key isn't.
+    let keyval = key_to_key_value(key);
+    // We keep the data in two forms: one as an unsafe pointer, so we can get
+    // it back by casting; another in an existential box, so the reference we
+    // own on it can be dropped when the box is destroyed. The unsafe pointer
+    // does not have a reference associated with it, so it may become invalid
+    // when the box is destroyed.
+    let data_ptr = *cast::transmute::<&@T, &*libc::c_void>(&data);
+    let data_box = @data as @LocalData;
+    // Construct new entry to store in the map.
+    let new_entry = Some((keyval, data_ptr, data_box));
+    // Find a place to put it.
+    match local_data_lookup(map, key) {
+        Some((index, _old_data_ptr)) => {
+            // Key already had a value set, _old_data_ptr, whose reference
+            // will get dropped when the local_data box is overwritten.
+            map[index] = new_entry;
+        }
+        None => {
+            // Find an empty slot. If not, grow the vector.
+            match map.iter().position(|x| x.is_none()) {
+                Some(empty_index) => { map[empty_index] = new_entry; }
+                None => { map.push(new_entry); }
+            }
+        }
+    }
+}
+
+pub unsafe fn local_modify<T: 'static>(
+    handle: Handle, key: local_data::Key<@T>,
+    modify_fn: &fn(Option<@T>) -> Option<@T>) {
+
+    // Could be more efficient by doing the lookup work, but this is easy.
+    let newdata = modify_fn(local_pop(handle, key));
+    if newdata.is_some() {
+        local_set(handle, key, newdata.unwrap());
+    }
+}

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -54,6 +54,10 @@ use util;
 #[cfg(test)] use ptr;
 #[cfg(test)] use task;
 
+#[cfg(stage0)]
+#[path="local_data_priv_stage0.rs"]
+mod local_data_priv;
+#[cfg(not(stage0))]
 mod local_data_priv;
 pub mod rt;
 pub mod spawn;

--- a/src/libstd/task/rt.rs
+++ b/src/libstd/task/rt.rs
@@ -63,9 +63,7 @@ pub extern {
     fn rust_task_kill_all(task: *rust_task);
 
     #[rust_stack]
-    fn rust_get_task_local_data(task: *rust_task) -> *libc::c_void;
-    #[rust_stack]
-    fn rust_set_task_local_data(task: *rust_task, map: *libc::c_void);
+    fn rust_get_task_local_data(task: *rust_task) -> *mut *libc::c_void;
     #[rust_stack]
     fn rust_task_local_data_atexit(task: *rust_task, cleanup_fn: *u8);
 }

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -477,26 +477,28 @@ fn gen_child_taskgroup(linked: bool, supervised: bool)
          * Step 1. Get spawner's taskgroup info.
          *##################################################################*/
         let spawner_group: @@mut TCB =
-            match local_get(OldHandle(spawner), taskgroup_key!()) {
-                None => {
-                    // Main task, doing first spawn ever. Lazily initialise
-                    // here.
-                    let mut members = new_taskset();
-                    taskset_insert(&mut members, spawner);
-                    let tasks = exclusive(Some(TaskGroupData {
-                        members: members,
-                        descendants: new_taskset(),
-                    }));
-                    // Main task/group has no ancestors, no notifier, etc.
-                    let group = @@mut TCB(spawner,
-                                          tasks,
-                                          AncestorList(None),
-                                          true,
-                                          None);
-                    local_set(OldHandle(spawner), taskgroup_key!(), group);
-                    group
+            do local_get(OldHandle(spawner), taskgroup_key!()) |group| {
+                match group {
+                    None => {
+                        // Main task, doing first spawn ever. Lazily initialise
+                        // here.
+                        let mut members = new_taskset();
+                        taskset_insert(&mut members, spawner);
+                        let tasks = exclusive(Some(TaskGroupData {
+                            members: members,
+                            descendants: new_taskset(),
+                        }));
+                        // Main task/group has no ancestors, no notifier, etc.
+                        let group = @@mut TCB(spawner,
+                                              tasks,
+                                              AncestorList(None),
+                                              true,
+                                              None);
+                        local_set(OldHandle(spawner), taskgroup_key!(), group);
+                        group
+                    }
+                    Some(&group) => group
                 }
-                Some(group) => group
             };
         let spawner_group: &mut TCB = *spawner_group;
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -698,7 +698,7 @@ pub fn get_sctable() -> @mut SCTable {
         let sctable_key = (cast::transmute::<(uint, uint),
                            &fn:Copy(v: @@mut SCTable)>(
                                (-4 as uint, 0u)));
-        match local_data::get(sctable_key) {
+        match local_data::get(sctable_key, |k| k.map(|&k| *k)) {
             None => {
                 let new_table = @@mut new_sctable_internal();
                 local_data::set(sctable_key,new_table);

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -698,10 +698,10 @@ pub fn get_sctable() -> @mut SCTable {
         let sctable_key = (cast::transmute::<(uint, uint),
                            &fn:Copy(v: @@mut SCTable)>(
                                (-4 as uint, 0u)));
-        match local_data::local_data_get(sctable_key) {
+        match local_data::get(sctable_key) {
             None => {
                 let new_table = @@mut new_sctable_internal();
-                local_data::local_data_set(sctable_key,new_table);
+                local_data::set(sctable_key,new_table);
                 *new_table
             },
             Some(intr) => *intr

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -490,7 +490,7 @@ pub fn get_ident_interner() -> @ident_interner {
             (cast::transmute::<(uint, uint),
              &fn:Copy(v: @@::parse::token::ident_interner)>(
                  (-3 as uint, 0u)));
-        match local_data::get(key) {
+        match local_data::get(key, |k| k.map(|&k| *k)) {
             Some(interner) => *interner,
             None => {
                 let interner = mk_fresh_ident_interner();

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -490,11 +490,11 @@ pub fn get_ident_interner() -> @ident_interner {
             (cast::transmute::<(uint, uint),
              &fn:Copy(v: @@::parse::token::ident_interner)>(
                  (-3 as uint, 0u)));
-        match local_data::local_data_get(key) {
+        match local_data::get(key) {
             Some(interner) => *interner,
             None => {
                 let interner = mk_fresh_ident_interner();
-                local_data::local_data_set(key, @interner);
+                local_data::set(key, @interner);
                 interner
             }
         }

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -672,14 +672,10 @@ rust_unlock_little_lock(lock_and_signal *lock) {
     lock->unlock();
 }
 
-// set/get/atexit task_local_data can run on the rust stack for speed.
-extern "C" void *
+// get/atexit task_local_data can run on the rust stack for speed.
+extern "C" void **
 rust_get_task_local_data(rust_task *task) {
-    return task->task_local_data;
-}
-extern "C" void
-rust_set_task_local_data(rust_task *task, void *data) {
-    task->task_local_data = data;
+    return &task->task_local_data;
 }
 extern "C" void
 rust_task_local_data_atexit(rust_task *task, void (*cleanup_fn)(void *data)) {

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -171,7 +171,6 @@ rust_destroy_little_lock
 rust_lock_little_lock
 rust_unlock_little_lock
 rust_get_task_local_data
-rust_set_task_local_data
 rust_task_local_data_atexit
 rust_task_ref
 rust_task_deref

--- a/src/test/compile-fail/core-tls-store-pointer.rs
+++ b/src/test/compile-fail/core-tls-store-pointer.rs
@@ -10,12 +10,12 @@
 
 // Testing that we can't store a borrowed pointer it task-local storage
 
-use std::local_data::*;
+use std::local_data;
 
 fn key(_x: @&int) { }
 
 fn main() {
     unsafe {
-        local_data_set(key, @&0); //~ ERROR does not fulfill `'static`
+        local_data::set(key, @&0); //~ ERROR does not fulfill `'static`
     }
 }


### PR DESCRIPTION
cc #6004 and #3273

This is a rewrite of TLS to get towards not requiring `@` when using task local storage. Most of the rewrite is straightforward, although there are two caveats:
1. Changing `local_set` to not require `@` is blocked on #7673
2. The code in `local_pop` is some of the most unsafe code I've written. A second set of eyes should definitely scrutinize it...

The public-facing interface currently hasn't changed, although it will have to change because `local_data::get` cannot return `Option<T>`, nor can it return `Option<&T>` (the lifetime isn't known). This will have to be changed to be given a closure which yield `&T` (or as an Option). I didn't do this part of the api rewrite in this pull request as I figured that it could wait until when `@` is fully removed.

This also doesn't deal with the issue of using something other than functions as keys, but I'm looking into using static slices (as mentioned in the issues).
