### PR TITLE
vec::with_capacity: do one alloc for non-managed + ptr module improvements

### DIFF
--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -27,7 +27,7 @@ use option::{None, Option, Some};
 use ptr::to_unsafe_ptr;
 use ptr;
 use ptr::RawPtr;
-use rt::global_heap::realloc_raw;
+use rt::global_heap::{malloc_raw, realloc_raw};
 use sys;
 use sys::size_of;
 use uint;
@@ -101,10 +101,29 @@ pub fn to_owned<T:Copy>(t: &[T]) -> ~[T] {
 }
 
 /// Creates a new vector with a capacity of `capacity`
+#[cfg(stage0)]
 pub fn with_capacity<T>(capacity: uint) -> ~[T] {
     let mut vec = ~[];
     vec.reserve(capacity);
     vec
+}
+
+/// Creates a new vector with a capacity of `capacity`
+#[cfg(not(stage0))]
+pub fn with_capacity<T>(capacity: uint) -> ~[T] {
+    unsafe {
+        if contains_managed::<T>() {
+            let mut vec = ~[];
+            vec.reserve(capacity);
+            vec
+        } else {
+            let alloc = capacity * sys::nonzero_size_of::<T>();
+            let ptr = malloc_raw(alloc + size_of::<raw::VecRepr>()) as *mut raw::VecRepr;
+            (*ptr).unboxed.alloc = alloc;
+            (*ptr).unboxed.fill = 0;
+            cast::transmute(ptr)
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
f74250e r=huonw

``` rust
extern mod extra;

use std::vec;

#[bench]
fn bench_with_capacity(b: &mut extra::test::BenchHarness) {
    do b.iter {
        let _v: ~[u8] = vec::with_capacity(1024);
    }
}
```

Before:

`test bench_with_capacity ... bench: 293 ns/iter (+/- 0)`

After:

`test bench_with_capacity ... bench: 125 ns/iter (+/- 3)`
