### PR TITLE
Add a `mut_split()` method for dividing one `&mut [T]` into two

### DIFF
--- a/src/libstd/cast.rs
+++ b/src/libstd/cast.rs
@@ -14,7 +14,6 @@ use sys;
 use unstable::intrinsics;
 
 /// Casts the value at `src` to U. The two types must have the same length.
-/// Casts the value at `src` to U. The two types must have the same length.
 #[cfg(target_word_size = "32")]
 #[inline]
 pub unsafe fn transmute_copy<T, U>(src: &T) -> U {


### PR DESCRIPTION
I don't think we have this yet. This makes `&mut [T]` much more flexible.

r? @strcat (or whomever)
