### PR TITLE
Change the assert_eq message to be more verbose and pretty

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -531,7 +531,8 @@ pub fn core_macros() -> @str {
                 let expected_val = $expected;
                 // check both directions of equality....
                 if !((given_val == expected_val) && (expected_val == given_val)) {
-                    fail!(\"left: %? does not equal right: %?\", given_val, expected_val);
+                    fail!(\"assertion failed: `(left == right) && (right == \
+                    left)` (left: `%?`, right: `%?`)\", given_val, expected_val);
                 }
             }
         )

--- a/src/test/run-fail/assert-eq-macro-fail.rs
+++ b/src/test/run-fail/assert-eq-macro-fail.rs
@@ -1,4 +1,4 @@
-// error-pattern:left: 14 does not equal right: 15
+// error-pattern:assertion failed: `(left == right) && (right == left)` (left: `14`, right: `15`)
 
 #[deriving(Eq)]
 struct Point { x : int }


### PR DESCRIPTION
This changes it from 

```
left: true does not equal right: false
```

to

```
assertion failed: `(left == right) && (right == left)` (left: `true`, right: `false`)
```
