### PR TITLE
Add an identifier to TypeParameterDefs and use it to pretty print type parameters

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -543,7 +543,8 @@ pub fn parse_type_param_def_data(data: &[u8], start: uint,
 }
 
 fn parse_type_param_def(st: &mut PState, conv: conv_did) -> ty::TypeParameterDef {
-    ty::TypeParameterDef {def_id: parse_def(st, NominalType, |x,y| conv(x,y)),
+    ty::TypeParameterDef {ident: parse_ident(st, ':'),
+                          def_id: parse_def(st, NominalType, |x,y| conv(x,y)),
                           bounds: @parse_bounds(st, |x,y| conv(x,y))}
 }
 

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -416,6 +416,8 @@ fn enc_bounds(w: @io::Writer, cx: @ctxt, bs: &ty::ParamBounds) {
 }
 
 pub fn enc_type_param_def(w: @io::Writer, cx: @ctxt, v: &ty::TypeParameterDef) {
+    w.write_str(cx.tcx.sess.str_of(v.ident));
+    w.write_char(':');
     w.write_str((cx.ds)(v.def_id));
     w.write_char('|');
     enc_bounds(w, cx, v.bounds);

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -130,6 +130,7 @@ impl Subst for ty::ParamBounds {
 impl Subst for ty::TypeParameterDef {
     fn subst(&self, tcx: ty::ctxt, substs: &ty::substs) -> ty::TypeParameterDef {
         ty::TypeParameterDef {
+            ident: self.ident,
             def_id: self.def_id,
             bounds: self.bounds.subst(tcx, substs)
         }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -794,6 +794,7 @@ impl ToStr for IntVarValue {
 }
 
 pub struct TypeParameterDef {
+    ident: ast::ident,
     def_id: ast::def_id,
     bounds: @ParamBounds
 }

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -59,6 +59,7 @@ use syntax::print::pprust::{path_to_str, explicit_self_to_str};
 use syntax::visit;
 use syntax::opt_vec::OptVec;
 use syntax::opt_vec;
+use syntax::parse::token::special_idents;
 
 pub fn collect_item_types(ccx: @mut CrateCtxt, crate: &ast::crate) {
     fn collect_intrinsic_type(ccx: &CrateCtxt,
@@ -318,6 +319,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
         let self_trait_def = get_trait_def(ccx, local_def(trait_id));
         let self_trait_ref = self_trait_def.trait_ref.subst(tcx, &substs);
         new_type_param_defs.push(ty::TypeParameterDef {
+            ident: special_idents::self_,
             def_id: dummy_defid,
             bounds: @ty::ParamBounds {
                 builtin_bounds: ty::EmptyBuiltinBounds(),
@@ -1151,6 +1153,7 @@ pub fn ty_generics(ccx: &CrateCtxt,
                     let bounds = @compute_bounds(ccx, rp, generics,
                                                  param_ty, &param.bounds);
                     let def = ty::TypeParameterDef {
+                        ident: param.ident,
                         def_id: local_def(param.id),
                         bounds: bounds
                     };

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -435,16 +435,17 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_infer(infer_ty) => infer_ty.to_str(),
       ty_err => ~"[type error]",
       ty_param(param_ty {idx: id, def_id: did}) => {
-          let mut parm = (('T' as uint) + id) as char;
-          if (parm as uint) > ('Z' as uint) {
-              parm = (parm as uint - 26) as char;
-          }
-
-          if cx.sess.verbose() {
-              fmt!("%c:%?", parm, did)
-          } else {
-              fmt!("%c", parm)
-          }
+          let param_def = cx.ty_param_defs.find(&did.node);
+          let ident = match param_def {
+              Some(def) => {
+                  cx.sess.str_of(def.ident).to_owned()
+              }
+              None => {
+                  // This should not happen...
+                  fmt!("BUG[%?]", id)
+              }
+          };
+          if !cx.sess.verbose() { ident } else { fmt!("%s:%?", ident, did) }
       }
       ty_self(*) => ~"Self",
       ty_enum(did, ref substs) | ty_struct(did, ref substs) => {

--- a/src/test/compile-fail/type-parameter-names.rs
+++ b/src/test/compile-fail/type-parameter-names.rs
@@ -1,0 +1,6 @@
+// Test that we print out the names of type parameters correctly in
+// our error messages.
+
+fn foo<Foo, Bar>(x: Foo) -> Bar { x } //~ ERROR expected `Bar` but found `Foo`
+
+fn main() {}


### PR DESCRIPTION
Fixes #2951
