### PR TITLE
Bitv improvements

### DIFF
--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -568,6 +568,7 @@ pub struct BitvIterator<'self> {
 }
 
 impl<'self> Iterator<bool> for BitvIterator<'self> {
+    #[inline]
     fn next(&mut self) -> Option<bool> {
         if self.next_idx < self.bitv.nbits {
             let idx = self.next_idx;
@@ -866,6 +867,7 @@ pub struct BitvSetIterator<'self> {
 }
 
 impl<'self> Iterator<uint> for BitvSetIterator<'self> {
+    #[inline]
     fn next(&mut self) -> Option<uint> {
         while self.next_idx < self.set.capacity() {
             let idx = self.next_idx;
@@ -1564,6 +1566,40 @@ mod tests {
         let b2 = Bitv::new(BENCH_BITS, false);
         do b.iter {
             b1.union(&b2);
+        }
+    }
+
+    #[bench]
+    fn bench_btv_small_iter(b: &mut BenchHarness) {
+        let bitv = Bitv::new(uint::bits, false);
+        do b.iter {
+            let mut sum = 0;
+            for bitv.iter().advance |pres| {
+                sum += pres as uint;
+            }
+        }
+    }
+
+    #[bench]
+    fn bench_bitv_big_iter(b: &mut BenchHarness) {
+        let bitv = Bitv::new(BENCH_BITS, false);
+        do b.iter {
+            let mut sum = 0;
+            for bitv.iter().advance |pres| {
+                sum += pres as uint;
+            }
+        }
+    }
+
+    #[bench]
+    fn bench_bitvset_iter(b: &mut BenchHarness) {
+        let bitv = BitvSet::from_bitv(from_fn(BENCH_BITS,
+                                              |idx| {idx % 3 == 0}));
+        do b.iter {
+            let mut sum = 0;
+            for bitv.iter().advance |idx| {
+                sum += idx;
+            }
         }
     }
 }

--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -1266,6 +1266,25 @@ mod tests {
     }
 
     #[test]
+    fn test_bitv_iterator() {
+        let bools = [true, false, true, true];
+        let bitv = from_bools(bools);
+
+        for bitv.iter().zip(bools.iter()).advance |(act, &ex)| {
+            assert_eq!(ex, act);
+        }
+    }
+
+    #[test]
+    fn test_bitv_set_iterator() {
+        let bools = [true, false, true, true];
+        let bitv = BitvSet::from_bitv(from_bools(bools));
+
+        let idxs: ~[uint] = bitv.iter().collect();
+        assert_eq!(idxs, ~[0, 2, 3]);
+    }
+
+    #[test]
     fn test_small_difference() {
         let mut b1 = Bitv::new(3, false);
         let mut b2 = Bitv::new(3, false);

--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -215,7 +215,7 @@ impl BigBitv {
 }
 
 #[deriving(Clone)]
-enum BitvVariant { Big(~BigBitv), Small(~SmallBitv) }
+enum BitvVariant { Big(BigBitv), Small(SmallBitv) }
 
 enum Op {Union, Intersect, Assign, Difference}
 
@@ -241,20 +241,20 @@ impl Bitv {
         match self.rep {
           Small(ref mut s) => match other.rep {
             Small(ref s1) => match op {
-              Union      => s.union(*s1,      self.nbits),
-              Intersect  => s.intersect(*s1,  self.nbits),
-              Assign     => s.become(*s1,     self.nbits),
-              Difference => s.difference(*s1, self.nbits)
+              Union      => s.union(s1,      self.nbits),
+              Intersect  => s.intersect(s1,  self.nbits),
+              Assign     => s.become(s1,     self.nbits),
+              Difference => s.difference(s1, self.nbits)
             },
             Big(_) => die()
           },
           Big(ref mut s) => match other.rep {
             Small(_) => die(),
             Big(ref s1) => match op {
-              Union      => s.union(*s1,      self.nbits),
-              Intersect  => s.intersect(*s1,  self.nbits),
-              Assign     => s.become(*s1,     self.nbits),
-              Difference => s.difference(*s1, self.nbits)
+              Union      => s.union(s1,      self.nbits),
+              Intersect  => s.intersect(s1,  self.nbits),
+              Assign     => s.become(s1,     self.nbits),
+              Difference => s.difference(s1, self.nbits)
             }
           }
         }
@@ -265,14 +265,14 @@ impl Bitv {
 impl Bitv {
     pub fn new(nbits: uint, init: bool) -> Bitv {
         let rep = if nbits <= uint::bits {
-            Small(~SmallBitv::new(if init {!0} else {0}))
+            Small(SmallBitv::new(if init {!0} else {0}))
         }
         else {
             let nelems = nbits/uint::bits +
                          if nbits % uint::bits == 0 {0} else {1};
             let elem = if init {!0u} else {0u};
             let s = vec::from_elem(nelems, elem);
-            Big(~BigBitv::new(s))
+            Big(BigBitv::new(s))
         };
         Bitv {rep: rep, nbits: nbits}
     }
@@ -341,11 +341,11 @@ impl Bitv {
       if self.nbits != v1.nbits { return false; }
       match self.rep {
         Small(ref b) => match v1.rep {
-          Small(ref b1) => b.equals(*b1, self.nbits),
+          Small(ref b1) => b.equals(b1, self.nbits),
           _ => false
         },
         Big(ref s) => match v1.rep {
-          Big(ref s1) => s.equals(*s1, self.nbits),
+          Big(ref s1) => s.equals(s1, self.nbits),
           Small(_) => return false
         }
       }
@@ -614,8 +614,8 @@ impl BitvSet {
         }
         let Bitv{rep, _} = bitv;
         match rep {
-            Big(~b) => BitvSet{ size: size, bitv: b },
-            Small(~SmallBitv{bits}) =>
+            Big(b) => BitvSet{ size: size, bitv: b },
+            Small(SmallBitv{bits}) =>
                 BitvSet{ size: size, bitv: BigBitv{ storage: ~[bits] } },
         }
     }
@@ -628,7 +628,7 @@ impl BitvSet {
     pub fn unwrap(self) -> Bitv {
         let cap = self.capacity();
         let BitvSet{bitv, _} = self;
-        return Bitv{ nbits:cap, rep: Big(~bitv) };
+        return Bitv{ nbits:cap, rep: Big(bitv) };
     }
 
     #[inline]


### PR DESCRIPTION
Switched Bitv and BitvSet to external iterators. They still use some internal iterators internally (ha).

Derived clone for all Bitv types.

Removed indirection in BitvVariant. It previously held a unique pointer to the appropriate Bitv struct, even though those structs are the size of a pointer themselves. BitvVariant is the same size (16 bytes) as it was previously.
