### PR TITLE
Add a lint to detect unnecessarily qualified names

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -71,6 +71,7 @@ use syntax::{ast, visit, ast_util};
 pub enum lint {
     ctypes,
     unused_imports,
+    unnecessary_qualification,
     while_true,
     path_statement,
     implicit_copies,
@@ -146,6 +147,13 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
         lint: unused_imports,
         desc: "imports that are never used",
         default: warn
+     }),
+
+    ("unnecessary_qualification",
+     LintSpec {
+        lint: unnecessary_qualification,
+        desc: "detects unnecessarily qualified names",
+        default: allow
      }),
 
     ("while_true",
@@ -557,11 +565,7 @@ fn item_stopping_visitor<E: Copy>(outer: visit::vt<E>) -> visit::vt<E> {
                 _ => (outer.visit_fn)(fk, fd, b, s, id, (e, v))
             }
         },
-    .. **(ty_stopping_visitor(outer))})
-}
-
-fn ty_stopping_visitor<E>(v: visit::vt<E>) -> visit::vt<E> {
-    visit::mk_vt(@visit::Visitor {visit_ty: |_t, (_e, _v)| { },.. **v})
+    .. **outer})
 }
 
 fn lint_while_true() -> visit::vt<@mut Context> {

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -462,6 +462,7 @@ pub fn id_visitor<T: Copy>(vfn: @fn(node_id, T)) -> visit::vt<T> {
         },
 
         visit_ty: |ty, (t, vt)| {
+            vfn(ty.id, copy t);
             match ty.node {
               ty_path(_, _, id) => vfn(id, copy t),
               _ => { /* fall through */ }

--- a/src/test/compile-fail/lint-qualification.rs
+++ b/src/test/compile-fail/lint-qualification.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deny(unnecessary_qualification)];
+
+mod foo {
+    pub fn bar() {}
+}
+
+fn main() {
+    use foo::bar;
+    foo::bar(); //~ ERROR: unnecessary qualification
+}


### PR DESCRIPTION
Fix #2551.

Lint is off by default because I didn't bother to fix all of std and extra.
