### PR TITLE
Update the version ordering algorithm to semver 2.0.0.

### DIFF
--- a/src/libextra/semver.rs
+++ b/src/libextra/semver.rs
@@ -318,6 +318,8 @@ fn test_parse() {
 fn test_eq() {
     assert_eq!(parse("1.2.3"), parse("1.2.3"));
     assert_eq!(parse("1.2.3-alpha1"), parse("1.2.3-alpha1"));
+    assert_eq!(parse("1.2.3+build.42"), parse("1.2.3+build.42"));
+    assert_eq!(parse("1.2.3-alpha1+42"), parse("1.2.3-alpha1+42"));
 }
 
 #[test]
@@ -326,6 +328,7 @@ fn test_ne() {
     assert!(parse("0.0.0")       != parse("0.1.0"));
     assert!(parse("0.0.0")       != parse("1.0.0"));
     assert!(parse("1.2.3-alpha") != parse("1.2.3-beta"));
+    assert!(parse("1.2.3+23")    != parse("1.2.3+42"));
 }
 
 #[test]
@@ -336,6 +339,7 @@ fn test_lt() {
     assert!(parse("1.2.3-alpha1") < parse("1.2.3"));
     assert!(parse("1.2.3-alpha1") < parse("1.2.3-alpha2"));
     assert!(!(parse("1.2.3-alpha2") < parse("1.2.3-alpha2")));
+    assert!(!(parse("1.2.3+23")     < parse("1.2.3+42")));
 }
 
 #[test]
@@ -345,6 +349,7 @@ fn test_le() {
     assert!(parse("1.2.0")        <= parse("1.2.3-alpha2"));
     assert!(parse("1.2.3-alpha1") <= parse("1.2.3-alpha2"));
     assert!(parse("1.2.3-alpha2") <= parse("1.2.3-alpha2"));
+    assert!(parse("1.2.3+23")     <= parse("1.2.3+42"));
 }
 
 #[test]
@@ -355,6 +360,7 @@ fn test_gt() {
     assert!(parse("1.2.3-alpha2") > parse("1.2.3-alpha1"));
     assert!(parse("1.2.3")        > parse("1.2.3-alpha2"));
     assert!(!(parse("1.2.3-alpha2") > parse("1.2.3-alpha2")));
+    assert!(!(parse("1.2.3+23")     > parse("1.2.3+42")));
 }
 
 #[test]
@@ -364,6 +370,7 @@ fn test_ge() {
     assert!(parse("1.2.3-alpha2") >= parse("1.2.0"));
     assert!(parse("1.2.3-alpha2") >= parse("1.2.3-alpha1"));
     assert!(parse("1.2.3-alpha2") >= parse("1.2.3-alpha2"));
+    assert!(parse("1.2.3+23")     >= parse("1.2.3+42"));
 }
 
 #[test]

--- a/src/libextra/semver.rs
+++ b/src/libextra/semver.rs
@@ -113,13 +113,7 @@ impl cmp::Ord for Version {
                  (0, _) => false,
                  (_, 0) => true,
                  (_, _) => self.pre < other.pre
-             })) ||
-
-            (self.major == other.major &&
-             self.minor == other.minor &&
-             self.patch == other.patch &&
-             self.pre == other.pre &&
-             self.build < other.build)
+             }))
     }
 
     #[inline]
@@ -377,15 +371,12 @@ fn test_spec_order() {
 
     let vs = ["1.0.0-alpha",
               "1.0.0-alpha.1",
+              "1.0.0-alpha.beta",
+              "1.0.0-beta",
               "1.0.0-beta.2",
               "1.0.0-beta.11",
               "1.0.0-rc.1",
-              "1.0.0-rc.1+build.1",
-              "1.0.0",
-              "1.0.0+0.3.7",
-              "1.3.7+build",
-              "1.3.7+build.2.b8f12d7",
-              "1.3.7+build.11.e0f985a"];
+              "1.0.0"];
     let mut i = 1;
     while i < vs.len() {
         let a = parse(vs[i-1]).get();


### PR DESCRIPTION
The Ord impl of Version refered to the algorithm in release candidate versions of semver. [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html) says, "Build metadata SHOULD be ignored when determining version precedence."

Note that Version's `le` is not "less than or equal to" now, since `lt` ignores build metadata. I think the new ordering algorithm satisfies strict weak ordering which C++ STL requires, instead of strict total ordering.

BTW, is `a || b || ... || x`-style code better or idiomatic in Rust than `if a { return true; } if b { return true; } ... if x { return true; } return false;`-style one?
