### PR TITLE
Enable large stacks on 64-bit architectures

### DIFF
--- a/src/rt/rust_env.cpp
+++ b/src/rt/rust_env.cpp
@@ -27,6 +27,9 @@
 #define RUST_DEBUG_MEM "RUST_DEBUG_MEM"
 #define RUST_DEBUG_BORROW "RUST_DEBUG_BORROW"
 
+#define DEFAULT_RUST_MIN_STACK_32 0x300
+#define DEFAULT_RUST_MIN_STACK_64 0x400000
+
 static lock_and_signal env_lock;
 
 extern "C" CDECL void
@@ -99,8 +102,10 @@ get_min_stk_size() {
     if(minsz) {
         return strtol(minsz, NULL, 0);
     }
-    else {
-        return 0x300;
+    else if (sizeof(size_t) > 4) {
+        return DEFAULT_RUST_MIN_STACK_64;
+    } else {
+        return DEFAULT_RUST_MIN_STACK_32;
     }
 }
 


### PR DESCRIPTION
Just to get the ball rolling, this patch sets stacks to 4 MB on >32-bit architectures.
