### PR TITLE
rustc compiler config for Vim

### DIFF
--- a/src/etc/vim/compiler/rustc.vim
+++ b/src/etc/vim/compiler/rustc.vim
@@ -1,0 +1,33 @@
+" Vim compiler file
+" Compiler:         Rust Compiler
+" Maintainer:       Chris Morgan <me@chrismorgan.info>
+" Latest Revision:  2013 Jul 12
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "rustc"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+if exists(":CompilerSet") != 2
+	command -nargs=* CompilerSet setlocal <args>
+endif
+
+if exists("g:rustc_makeprg_no_percent") && g:rustc_makeprg_no_percent == 1
+	CompilerSet makeprg=rustc
+else
+	CompilerSet makeprg=rustc\ \%
+endif
+
+CompilerSet errorformat=
+			\%f:%l:%c:\ %t%*[^:]:\ %m,
+			\%f:%l:%c:\ %*\\d:%*\\d\ %t%*[^:]:\ %m,
+			\%-G%f:%l\ %s,
+			\%-G%*[\ ]^,
+			\%-G%*[\ ]^%*[~],
+			\%-G%*[\ ]...
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
Note that this is not actually _used_ by default; it is a matter of
configuration still, because you might want to:
- Compile all .rs files with `rustc %` (where each can be built itself)
- Compile all .rs files with `rustc some-file.rs` (where you are editing
  part of a crate)
- Compile with a different tool, such as `make`. (In this case you might
  put a `~/.vim/after/compiler/rustc.vim` to match such cases, set
  makeprg and extend errorformat as appropriate. That should probably go
  in a different compiler mode, e.g. make-rustc.)

To try using it, `:compiler rustc`. Then, `:make` on a file you would
run `rustc` on will work its magic, invoking rustc. To automate this,
you could have something like `autocmd FileType rust compiler rustc` in
your Vim config.
