### PR TITLE
Avoid unnecessary basic blocks for allocas, return and else

### DIFF
--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -704,7 +704,7 @@ pub fn trans_call_inner(in_cx: block,
                         Store(bcx, C_bool(false), bcx.fcx.llretptr.get());
                     }
                 }
-                base::cleanup_and_leave(bcx, None, Some(bcx.fcx.llreturn));
+                base::cleanup_and_leave(bcx, None, Some(bcx.fcx.get_llreturn()));
                 Unreachable(bcx);
                 bcx
             }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -178,7 +178,7 @@ pub struct fn_ctxt_ {
     // the function, due to LLVM's quirks.
     // A block for all the function's static allocas, so that LLVM
     // will coalesce them into a single alloca call.
-    llstaticallocas: BasicBlockRef,
+    llstaticallocas: Option<BasicBlockRef>,
     // A block containing code that copies incoming arguments to space
     // already allocated by code in one of the llallocas blocks.
     // (LLVM requires that arguments be copied to local allocas before
@@ -249,6 +249,14 @@ impl fn_ctxt_ {
         } else {
             0u
         }
+    }
+
+    pub fn get_llstaticallocas(&mut self) -> BasicBlockRef {
+        if self.llstaticallocas.is_none() {
+            self.llstaticallocas = Some(base::mk_staticallocas_basic_block(self.llfn));
+        }
+
+        self.llstaticallocas.get()
     }
 
     pub fn get_llreturn(&mut self) -> BasicBlockRef {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -184,7 +184,7 @@ pub struct fn_ctxt_ {
     // (LLVM requires that arguments be copied to local allocas before
     // allowing most any operation to be performed on them.)
     llloadenv: Option<BasicBlockRef>,
-    llreturn: BasicBlockRef,
+    llreturn: Option<BasicBlockRef>,
     // The 'self' value currently in use in this function, if there
     // is one.
     //
@@ -251,6 +251,13 @@ impl fn_ctxt_ {
         }
     }
 
+    pub fn get_llreturn(&mut self) -> BasicBlockRef {
+        if self.llreturn.is_none() {
+            self.llreturn = Some(base::mk_return_basic_block(self.llfn));
+        }
+
+        self.llreturn.get()
+    }
 }
 
 pub type fn_ctxt = @mut fn_ctxt_;

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -279,7 +279,7 @@ pub fn trans_break_cont(bcx: block,
                         // This is a return from a loop body block
                         None => {
                             Store(bcx, C_bool(!to_end), bcx.fcx.llretptr.get());
-                            cleanup_and_leave(bcx, None, Some(bcx.fcx.llreturn));
+                            cleanup_and_leave(bcx, None, Some(bcx.fcx.get_llreturn()));
                             Unreachable(bcx);
                             return bcx;
                         }
@@ -328,7 +328,7 @@ pub fn trans_ret(bcx: block, e: Option<@ast::expr>) -> block {
       }
       _ => ()
     }
-    cleanup_and_leave(bcx, None, Some(bcx.fcx.llreturn));
+    cleanup_and_leave(bcx, None, Some(bcx.fcx.get_llreturn()));
     Unreachable(bcx);
     return bcx;
 }

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -67,13 +67,8 @@ pub fn trans_if(bcx: block,
         expr::trans_to_datum(bcx, cond).to_result();
 
     let then_bcx_in = scope_block(bcx, thn.info(), "then");
-    let else_bcx_in = scope_block(bcx, els.info(), "else");
 
     let cond_val = bool_to_i1(bcx, cond_val);
-    CondBr(bcx, cond_val, then_bcx_in.llbb, else_bcx_in.llbb);
-
-    debug!("then_bcx_in=%s, else_bcx_in=%s",
-           then_bcx_in.to_str(), else_bcx_in.to_str());
 
     let then_bcx_out = trans_block(then_bcx_in, thn, dest);
     let then_bcx_out = trans_block_cleanups(then_bcx_out,
@@ -83,9 +78,10 @@ pub fn trans_if(bcx: block,
     // because trans_expr will create another scope block
     // context for the block, but we've already got the
     // 'else' context
-    let else_bcx_out = match els {
+    let (else_bcx_in, next_bcx) = match els {
       Some(elexpr) => {
-        match elexpr.node {
+        let else_bcx_in = scope_block(bcx, els.info(), "else");
+        let else_bcx_out = match elexpr.node {
           ast::expr_if(_, _, _) => {
             let elseif_blk = ast_util::block_from_expr(elexpr);
             trans_block(else_bcx_in, &elseif_blk, dest)
@@ -95,14 +91,25 @@ pub fn trans_if(bcx: block,
           }
           // would be nice to have a constraint on ifs
           _ => bcx.tcx().sess.bug("strange alternative in if")
-        }
-      }
-      _ => else_bcx_in
-    };
-    let else_bcx_out = trans_block_cleanups(else_bcx_out,
-                                            block_cleanups(else_bcx_in));
-    return join_blocks(bcx, [then_bcx_out, else_bcx_out]);
+        };
+        let else_bcx_out = trans_block_cleanups(else_bcx_out,
+                                                block_cleanups(else_bcx_in));
 
+        (else_bcx_in, join_blocks(bcx, [then_bcx_out, else_bcx_out]))
+      }
+      _ => {
+          let next_bcx = sub_block(bcx, "next");
+          Br(then_bcx_out, next_bcx.llbb);
+
+          (next_bcx, next_bcx)
+      }
+    };
+
+    debug!("then_bcx_in=%s, else_bcx_in=%s",
+           then_bcx_in.to_str(), else_bcx_in.to_str());
+
+    CondBr(bcx, cond_val, then_bcx_in.llbb, else_bcx_in.llbb);
+    next_bcx
 }
 
 pub fn join_blocks(parent_bcx: block, in_cxs: &[block]) -> block {

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -164,7 +164,10 @@ fn build_shim_fn_(ccx: @mut CrateContext,
     // follow the normal Rust calling conventions.
     tie_up_header_blocks(fcx, lltop);
 
-    let ret_cx = raw_block(fcx, false, fcx.llreturn);
+    let ret_cx = match fcx.llreturn {
+        Some(llreturn) => raw_block(fcx, false, llreturn),
+        None => bcx
+    };
     RetVoid(ret_cx);
 
     return llshimfn;
@@ -217,7 +220,10 @@ fn build_wrap_fn_(ccx: @mut CrateContext,
     tie_up_header_blocks(fcx, lltop);
 
     // Then return according to the C ABI.
-    let return_context = raw_block(fcx, false, fcx.llreturn);
+    let return_context = match fcx.llreturn {
+        Some(llreturn) => raw_block(fcx, false, llreturn),
+        None => bcx
+    };
 
     let llfunctiontype = val_ty(llwrapfn);
     let llfunctiontype = llfunctiontype.element_type();
@@ -388,7 +394,6 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
                                      tys.ret_def,
                                      llargbundle,
                                      llretval);
-            build_return(bcx);
         }
 
         let lname = link_name(ccx, foreign_item);
@@ -438,8 +443,7 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
         if !ty::type_is_nil(ret_ty) && !ty::type_is_bot(ret_ty) {
             Store(bcx, retval, fcx.llretptr.get());
         }
-        build_return(bcx);
-        finish_fn(fcx, lltop);
+        finish_fn(fcx, lltop, bcx);
     }
 
     // FIXME (#2535): this is very shaky and probably gets ABIs wrong all
@@ -467,8 +471,7 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
         if !ty::type_is_nil(ret_ty) && !ty::type_is_bot(ret_ty) {
             Store(bcx, retval, fcx.llretptr.get());
         }
-        build_return(bcx);
-        finish_fn(fcx, lltop);
+        finish_fn(fcx, lltop, bcx);
     }
 
     fn build_wrap_fn(ccx: @mut CrateContext,
@@ -534,7 +537,6 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
                 let llretptr = load_inbounds(bcx, llargbundle, [0, arg_count]);
                 Store(bcx, Load(bcx, llretptr), retptr);
             }
-            build_return(bcx);
         }
     }
 }
@@ -629,8 +631,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
             }
         }
 
-        build_return(bcx);
-        finish_fn(fcx, lltop);
+        finish_fn(fcx, lltop, bcx);
 
         return;
     }
@@ -1124,8 +1125,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
             ccx.sess.span_bug(item.span, "unknown intrinsic");
         }
     }
-    build_return(bcx);
-    finish_fn(fcx, lltop);
+    finish_fn(fcx, lltop, bcx);
 }
 
 /**
@@ -1257,8 +1257,6 @@ pub fn trans_foreign_fn(ccx: @mut CrateContext,
                 // NB: The return pointer in the Rust ABI function is wired
                 // directly into the return slot in the shim struct.
             }
-
-            build_return(bcx);
         }
 
         let shim_name = link::mangle_internal_name_by_path(
@@ -1314,7 +1312,6 @@ pub fn trans_foreign_fn(ccx: @mut CrateContext,
         fn build_ret(bcx: block, tys: &ShimTypes, llargbundle: ValueRef) {
             let _icx = push_ctxt("foreign::foreign::wrap::build_ret");
             tys.fn_ty.build_wrap_ret(bcx, tys.llsig.llarg_tys, llargbundle);
-            build_return(bcx);
         }
     }
 

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -197,7 +197,7 @@ fn build_wrap_fn_(ccx: @mut CrateContext,
     // the C ABI.
     if needs_c_return && !ty::type_is_immediate(ccx.tcx, tys.fn_sig.output) {
         let lloutputtype = type_of::type_of(fcx.ccx, tys.fn_sig.output);
-        fcx.llretptr = Some(alloca(raw_block(fcx, false, fcx.llstaticallocas),
+        fcx.llretptr = Some(alloca(raw_block(fcx, false, fcx.get_llstaticallocas()),
                                    lloutputtype,
                                    ""));
     }

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -299,12 +299,15 @@ impl Reflector {
                     //
                     llvm::LLVMGetParam(llfdecl, fcx.arg_pos(0u) as c_uint)
                 };
-                let bcx = top_scope_block(fcx, None);
+                let mut bcx = top_scope_block(fcx, None);
                 let arg = BitCast(bcx, arg, llptrty);
                 let ret = adt::trans_get_discr(bcx, repr, arg);
                 Store(bcx, ret, fcx.llretptr.get());
-                cleanup_and_Br(bcx, bcx, fcx.llreturn);
-                finish_fn(fcx, bcx.llbb);
+                match fcx.llreturn {
+                    Some(llreturn) => cleanup_and_Br(bcx, bcx, llreturn),
+                    None => bcx = cleanup_block(bcx, Some(bcx.llbb))
+                };
+                finish_fn(fcx, bcx.llbb, bcx);
                 llfdecl
             };
 


### PR DESCRIPTION
These commits remove a bunch of empty or otherwise unnecessary blocks, reducing the size of the pre-optimization IR and improving its readability. `librustc.ll` created with `--passes ""` shrinks by about 120k lines which equals about 5% of the total size.
