### PR TITLE
Rename print!()/println!() to printf!()/printlnf!()

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -644,16 +644,22 @@ pub fn core_macros() -> @str {
         );
     )
 
-    macro_rules! print(
-        ($( $arg:expr),+) => ( {
-            print(fmt!($($arg),+));
-        } )
+    macro_rules! printf (
+        ($arg:expr) => (
+            print(fmt!(\"%?\", $arg))
+        );
+        ($( $arg:expr ),+) => (
+            print(fmt!($($arg),+))
+        )
     )
 
-    macro_rules! println(
-        ($( $arg:expr),+) => ( {
-            println(fmt!($($arg),+));
-        } )
+    macro_rules! printfln (
+        ($arg:expr) => (
+            println(fmt!(\"%?\", $arg))
+        );
+        ($( $arg:expr ),+) => (
+            println(fmt!($($arg),+))
+        )
     )
 }";
 }


### PR DESCRIPTION
The new names make it obvious that these generate formatted output.

Add a one-argument case that uses %? to format, just like the other
format-using macros (e.g. info!()).
