### PR TITLE
Use concrete types in glue functions

### DIFF
--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -187,20 +187,20 @@ impl Type {
             None => ()
         }
 
-        let ty = Type::glue_fn();
+        let ty = Type::glue_fn(Type::i8p());
         cx.tn.associate_type("glue_fn", &ty);
 
         return ty;
     }
 
-    pub fn glue_fn() -> Type {
-        Type::func([ Type::nil().ptr_to(), Type::i8p() ],
+    pub fn glue_fn(t: Type) -> Type {
+        Type::func([ Type::nil().ptr_to(), t ],
             &Type::void())
     }
 
     pub fn tydesc(arch: Architecture) -> Type {
         let mut tydesc = Type::named_struct("tydesc");
-        let glue_fn_ty = Type::glue_fn().ptr_to();
+        let glue_fn_ty = Type::glue_fn(Type::i8p()).ptr_to();
 
         let int_ty = Type::int(arch);
 


### PR DESCRIPTION
We used to have concrete types in glue functions, but the way we used
to implement that broke inlining of those functions. To fix that, we
converted all glue to just take an i8\* and always casted to that type.

The problem with the old implementation was that we made a wrong
assumption about the glue functions, taking it for granted that they
always take an i8*, because that's the function type expected by the
TyDesc fields. Therefore, we always ended up with some kind of cast.

But actually, we can initially have the glue with concrete types and
only cast the functions to the generic type once we actually emit the
TyDesc data.

That means that for glue calls that can be statically resolved, we don't
need any casts, unless the glue uses a simplified type. In that case we
cast the argument. And for glue calls that are resolved at runtime, we
cast the argument to i8*, because that's what the glue function in the
TyDesc expects.

Since most of out glue calls are static, this saves a lot of bitcasts.
The size of the unoptimized librustc.ll goes down by 240k lines.
