### PR TITLE
Vim: Add a RustRun function to run the current buffer contents

### DIFF
--- a/src/etc/vim/ftplugin/rust.vim
+++ b/src/etc/vim/ftplugin/rust.vim
@@ -41,3 +41,15 @@ if exists("g:loaded_delimitMate")
 endif
 
 let b:undo_ftplugin = "setlocal formatoptions< comments< commentstring< includeexpr< suffixesadd< | if exists('b:rust_original_delimitMate_excluded_regions') | let b:delimitMate_excluded_regions = b:rust_original_delimitMate_excluded_regions | unlet b:rust_original_delimitMate_excluded_regions | elseif exists('b:delimitMate_excluded_regions') | unlet b:delimitMate_excluded_regions | endif"
+
+function! RustRun()
+	let l:bufno = bufnr('%')
+
+	new
+	set buftype=nofile bufhidden=delete nobuflisted
+	setlocal noswapfile
+
+	put =eval('getbufline(' . l:bufno . ', 1, 99999999999)')
+	0d
+	silent! %!rust run /dev/stdin
+endfunction


### PR DESCRIPTION
This allows to run the contents of a buffer through "rust run" and show
the results in a scratch buffer. Handy for things that are just a bit
too big to be done comfortably in rusti.

Refs #7747
