### PR TITLE
Mention parsing in docs

### DIFF
--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -14,7 +14,7 @@
 #[forbid(non_camel_case_types)];
 #[allow(missing_doc)];
 
-//! json serialization
+//! json parsing and serialization
 
 use std::iterator;
 use std::float;


### PR DESCRIPTION
Minor tweak, but I was confused when first digging into json.rs docs.

I think it's clearer to say the module provides parsing and serialization.
