### PR TITLE
remove headers from unique vectors/strings

### DIFF
--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -63,34 +63,33 @@ pub enum LangItem {
     FailFnLangItem,                    // 24
     FailBoundsCheckFnLangItem,         // 25
     ExchangeMallocFnLangItem,          // 26
-    VectorExchangeMallocFnLangItem,    // 27
-    ClosureExchangeMallocFnLangItem,   // 28
-    ExchangeFreeFnLangItem,            // 29
-    MallocFnLangItem,                  // 30
-    FreeFnLangItem,                    // 31
-    BorrowAsImmFnLangItem,             // 32
-    BorrowAsMutFnLangItem,             // 33
-    ReturnToMutFnLangItem,             // 34
-    CheckNotBorrowedFnLangItem,        // 35
-    StrDupUniqFnLangItem,              // 36
-    RecordBorrowFnLangItem,            // 37
-    UnrecordBorrowFnLangItem,          // 38
+    ClosureExchangeMallocFnLangItem,   // 27
+    ExchangeFreeFnLangItem,            // 28
+    MallocFnLangItem,                  // 29
+    FreeFnLangItem,                    // 30
+    BorrowAsImmFnLangItem,             // 31
+    BorrowAsMutFnLangItem,             // 32
+    ReturnToMutFnLangItem,             // 33
+    CheckNotBorrowedFnLangItem,        // 34
+    StrDupUniqFnLangItem,              // 35
+    RecordBorrowFnLangItem,            // 36
+    UnrecordBorrowFnLangItem,          // 37
 
-    StartFnLangItem,                   // 39
+    StartFnLangItem,                   // 38
 
-    TyDescStructLangItem,              // 40
-    TyVisitorTraitLangItem,            // 41
-    OpaqueStructLangItem,              // 42
+    TyDescStructLangItem,              // 39
+    TyVisitorTraitLangItem,            // 40
+    OpaqueStructLangItem,              // 41
 }
 
 pub struct LanguageItems {
-    items: [Option<def_id>, ..43]
+    items: [Option<def_id>, ..42]
 }
 
 impl LanguageItems {
     pub fn new() -> LanguageItems {
         LanguageItems {
-            items: [ None, ..43 ]
+            items: [ None, ..42 ]
         }
     }
 
@@ -130,24 +129,23 @@ impl LanguageItems {
             24 => "fail_",
             25 => "fail_bounds_check",
             26 => "exchange_malloc",
-            27 => "vector_exchange_malloc",
-            28 => "closure_exchange_malloc",
-            29 => "exchange_free",
-            30 => "malloc",
-            31 => "free",
-            32 => "borrow_as_imm",
-            33 => "borrow_as_mut",
-            34 => "return_to_mut",
-            35 => "check_not_borrowed",
-            36 => "strdup_uniq",
-            37 => "record_borrow",
-            38 => "unrecord_borrow",
+            27 => "closure_exchange_malloc",
+            28 => "exchange_free",
+            29 => "malloc",
+            30 => "free",
+            31 => "borrow_as_imm",
+            32 => "borrow_as_mut",
+            33 => "return_to_mut",
+            34 => "check_not_borrowed",
+            35 => "strdup_uniq",
+            36 => "record_borrow",
+            37 => "unrecord_borrow",
 
-            39 => "start",
+            38 => "start",
 
-            40 => "ty_desc",
-            41 => "ty_visitor",
-            42 => "opaque",
+            39 => "ty_desc",
+            40 => "ty_visitor",
+            41 => "opaque",
 
             _ => "???"
         }
@@ -239,9 +237,6 @@ impl LanguageItems {
     }
     pub fn exchange_malloc_fn(&self) -> def_id {
         self.items[ExchangeMallocFnLangItem as uint].get()
-    }
-    pub fn vector_exchange_malloc_fn(&self) -> def_id {
-        self.items[VectorExchangeMallocFnLangItem as uint].get()
     }
     pub fn closure_exchange_malloc_fn(&self) -> def_id {
         self.items[ClosureExchangeMallocFnLangItem as uint].get()
@@ -336,7 +331,6 @@ impl<'self> LanguageItemCollector<'self> {
         item_refs.insert(@"fail_bounds_check",
                          FailBoundsCheckFnLangItem as uint);
         item_refs.insert(@"exchange_malloc", ExchangeMallocFnLangItem as uint);
-        item_refs.insert(@"vector_exchange_malloc", VectorExchangeMallocFnLangItem as uint);
         item_refs.insert(@"closure_exchange_malloc", ClosureExchangeMallocFnLangItem as uint);
         item_refs.insert(@"exchange_free", ExchangeFreeFnLangItem as uint);
         item_refs.insert(@"malloc", MallocFnLangItem as uint);

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -294,25 +294,6 @@ pub fn malloc_raw_dyn(bcx: block,
             [size],
             None);
         rslt(r.bcx, PointerCast(r.bcx, r.val, llty_value.ptr_to()))
-    } else if heap == heap_exchange_vector {
-        // Grab the TypeRef type of box_ptr_ty.
-        let element_type = match ty::get(t).sty {
-            ty::ty_unboxed_vec(e) => e,
-            _ => fail!("not a vector body")
-        };
-        let box_ptr_ty = ty::mk_evec(bcx.tcx(), element_type, ty::vstore_uniq);
-        let llty = type_of(ccx, box_ptr_ty);
-
-        let llty_value = type_of::type_of(ccx, t);
-        let llalign = llalign_of_min(ccx, llty_value);
-
-        // Allocate space:
-        let r = callee::trans_lang_call(
-            bcx,
-            bcx.tcx().lang_items.vector_exchange_malloc_fn(),
-            [C_i32(llalign as i32), size],
-            None);
-        rslt(r.bcx, PointerCast(r.bcx, r.val, llty))
     } else {
         // we treat ~fn, @fn and @[] as @ here, which isn't ideal
         let (mk_fn, langcall) = match heap {
@@ -322,7 +303,7 @@ pub fn malloc_raw_dyn(bcx: block,
             heap_exchange_closure => {
                 (ty::mk_imm_box, bcx.tcx().lang_items.closure_exchange_malloc_fn())
             }
-            _ => fail!("heap_exchange/heap_exchange_vector already handled")
+            _ => fail!("heap_exchange already handled")
         };
 
         // Grab the TypeRef type of box_ptr_ty.

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -283,7 +283,6 @@ pub enum heap {
     heap_managed,
     heap_managed_unique,
     heap_exchange,
-    heap_exchange_vector,
     heap_exchange_closure
 }
 
@@ -405,7 +404,7 @@ pub fn add_clean_free(cx: block, ptr: ValueRef, heap: heap) {
         let f: @fn(block) -> block = |a| glue::trans_free(a, ptr);
         f
       }
-      heap_exchange | heap_exchange_vector | heap_exchange_closure => {
+      heap_exchange | heap_exchange_closure => {
         let f: @fn(block) -> block = |a| glue::trans_exchange_free(a, ptr);
         f
       }

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -460,7 +460,7 @@ fn trans_rvalue_datum_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
                                                       expr, contents);
         }
         ast::expr_vstore(contents, ast::expr_vstore_uniq) => {
-            let heap = tvec::heap_for_unique_vector(bcx, expr_ty(bcx, contents));
+            let heap = heap_for_unique(bcx, expr_ty(bcx, contents));
             return tvec::trans_uniq_or_managed_vstore(bcx, heap,
                                                       expr, contents);
         }

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -397,9 +397,7 @@ pub fn make_free_glue(bcx: block, v: ValueRef, t: ty::t) -> block {
       ty::ty_uniq(*) => {
         uniq::make_free_glue(bcx, v, t)
       }
-      ty::ty_evec(_, ty::vstore_uniq) | ty::ty_estr(ty::vstore_uniq) => {
-        tvec::make_uniq_free_glue(bcx, v, t)
-      }
+      ty::ty_evec(_, ty::vstore_uniq) | ty::ty_estr(ty::vstore_uniq) |
       ty::ty_evec(_, ty::vstore_box) | ty::ty_estr(ty::vstore_box) => {
         make_free_glue(bcx, v, tvec::expand_boxed_vec_ty(bcx.tcx(), t))
       }

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -122,9 +122,9 @@ impl Reflector {
                      bracket_name: &str,
                      extra: &[ValueRef],
                      inner: &fn(&mut Reflector)) {
-        self.visit(~"enter_" + bracket_name, extra);
+        self.visit("enter_" + bracket_name, extra);
         inner(self);
-        self.visit(~"leave_" + bracket_name, extra);
+        self.visit("leave_" + bracket_name, extra);
     }
 
     pub fn vstore_name_and_extra(&mut self,
@@ -183,7 +183,11 @@ impl Reflector {
           ty::ty_evec(ref mt, vst) => {
               let (name, extra) = self.vstore_name_and_extra(t, vst);
               let extra = extra + self.c_mt(mt);
-              self.visit(~"evec_" + name, extra)
+              if "uniq" == name && ty::type_contents(bcx.tcx(), t).contains_managed() {
+                  self.visit("evec_uniq_managed", extra)
+              } else {
+                  self.visit(~"evec_" + name, extra)
+              }
           }
           ty::ty_box(ref mt) => {
               let extra = self.c_mt(mt);

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -183,7 +183,7 @@ pub fn type_of(cx: &mut CrateContext, t: ty::t) -> Type {
       ty::ty_uint(t) => Type::uint_from_ty(cx, t),
       ty::ty_float(t) => Type::float_from_ty(cx, t),
       ty::ty_estr(ty::vstore_uniq) => {
-        Type::unique(cx, &Type::vec(cx.sess.targ_cfg.arch, &Type::i8())).ptr_to()
+        Type::vec(cx.sess.targ_cfg.arch, &Type::i8()).ptr_to()
       }
       ty::ty_enum(did, ref substs) => {
         // Only create the named struct, but don't fill it in. We
@@ -217,7 +217,11 @@ pub fn type_of(cx: &mut CrateContext, t: ty::t) -> Type {
       ty::ty_evec(ref mt, ty::vstore_uniq) => {
           let ty = type_of(cx, mt.ty);
           let ty = Type::vec(cx.sess.targ_cfg.arch, &ty);
-          Type::unique(cx, &ty).ptr_to()
+          if ty::type_contents(cx.tcx, mt.ty).contains_managed() {
+              Type::unique(cx, &ty).ptr_to()
+          } else {
+              ty.ptr_to()
+          }
       }
       ty::ty_unboxed_vec(ref mt) => {
           let ty = type_of(cx, mt.ty);

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -297,6 +297,14 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
+    #[cfg(not(stage0))]
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
+        self.align_to::<~[@u8]>();
+        if ! self.inner.visit_evec_uniq_managed(mtbl, inner) { return false; }
+        self.bump_past::<~[@u8]>();
+        true
+    }
+
     fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<&'static [u8]>();
         if ! self.inner.visit_evec_slice(mtbl, inner) { return false; }

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -353,6 +353,14 @@ impl TyVisitor for ReprVisitor {
     }
 
     fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<&UnboxedVecRepr> |b| {
+            self.writer.write_char('~');
+            self.write_unboxed_vec_repr(mtbl, *b, inner);
+        }
+    }
+
+    #[cfg(not(stage0))]
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
         do self.get::<&VecRepr> |b| {
             self.writer.write_char('~');
             self.write_unboxed_vec_repr(mtbl, &b.unboxed, inner);

--- a/src/libstd/rt/global_heap.rs
+++ b/src/libstd/rt/global_heap.rs
@@ -84,14 +84,6 @@ pub unsafe fn exchange_malloc(size: uintptr_t) -> *c_char {
     malloc_raw(size as uint) as *c_char
 }
 
-#[cfg(not(test))]
-#[lang="vector_exchange_malloc"]
-#[inline]
-pub unsafe fn vector_exchange_malloc(align: u32, size: uintptr_t) -> *c_char {
-    let total_size = get_box_size(size as uint, align as uint);
-    malloc_raw(total_size as uint) as *c_char
-}
-
 // FIXME: #7496
 #[cfg(not(test))]
 #[lang="closure_exchange_malloc"]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1003,11 +1003,24 @@ pub mod raw {
 
     /// Sets the length of the string and adds the null terminator
     #[inline]
+    #[cfg(stage0)]
     pub unsafe fn set_len(v: &mut ~str, new_len: uint) {
         let v: **mut vec::raw::VecRepr = cast::transmute(v);
         let repr: *mut vec::raw::VecRepr = *v;
         (*repr).unboxed.fill = new_len + 1u;
         let null = ptr::mut_offset(cast::transmute(&((*repr).unboxed.data)),
+                                   new_len);
+        *null = 0u8;
+    }
+
+    /// Sets the length of the string and adds the null terminator
+    #[inline]
+    #[cfg(not(stage0))]
+    pub unsafe fn set_len(v: &mut ~str, new_len: uint) {
+        let v: **mut vec::UnboxedVecRepr = cast::transmute(v);
+        let repr: *mut vec::UnboxedVecRepr = *v;
+        (*repr).fill = new_len + 1u;
+        let null = ptr::mut_offset(cast::transmute(&((*repr).data)),
                                    new_len);
         *null = 0u8;
     }
@@ -2027,7 +2040,7 @@ impl NullTerminatedStr for @str {
      */
     #[inline]
     fn as_bytes_with_null<'a>(&'a self) -> &'a [u8] {
-        let ptr: &'a ~[u8] = unsafe { ::cast::transmute(self) };
+        let ptr: &'a @[u8] = unsafe { ::cast::transmute(self) };
         let slice: &'a [u8] = *ptr;
         slice
     }

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -99,6 +99,7 @@ pub trait TyVisitor {
     fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool;
     fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool;
     fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool;
     fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool;
     fn visit_evec_fixed(&self, n: uint, sz: uint, align: uint,
                         mtbl: uint, inner: *TyDesc) -> bool;

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -390,9 +390,9 @@ void tm_to_rust_tm(tm* in_tm, rust_tm* out_tm, int32_t gmtoff,
     if (zone != NULL) {
         size_t size = strlen(zone);
         reserve_vec_exact(&out_tm->tm_zone, size + 1);
-        memcpy(out_tm->tm_zone->body.data, zone, size);
-        out_tm->tm_zone->body.fill = size + 1;
-        out_tm->tm_zone->body.data[size] = '\0';
+        memcpy(out_tm->tm_zone->data, zone, size);
+        out_tm->tm_zone->fill = size + 1;
+        out_tm->tm_zone->data[size] = '\0';
     }
 }
 

--- a/src/rt/rust_util.h
+++ b/src/rt/rust_util.h
@@ -57,17 +57,17 @@ vec_data(rust_vec *v) {
     return reinterpret_cast<T*>(v->data);
 }
 
-inline void reserve_vec_exact(rust_vec_box** vpp,
+inline void reserve_vec_exact(rust_vec** vpp,
                               size_t size) {
-    if (size > (*vpp)->body.alloc) {
+    if (size > (*vpp)->alloc) {
         rust_exchange_alloc exchange_alloc;
-        *vpp = (rust_vec_box*)exchange_alloc
-            .realloc(*vpp, size + sizeof(rust_vec_box));
-        (*vpp)->body.alloc = size;
+        *vpp = (rust_vec*)exchange_alloc
+            .realloc(*vpp, size + sizeof(rust_vec));
+        (*vpp)->alloc = size;
     }
 }
 
-typedef rust_vec_box rust_str;
+typedef rust_vec rust_str;
 
 inline size_t get_box_size(size_t body_size, size_t body_align) {
     size_t header_size = sizeof(rust_opaque_box);

--- a/src/test/run-pass/reflect-visit-data.rs
+++ b/src/test/run-pass/reflect-visit-data.rs
@@ -284,6 +284,13 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
+        self.align_to::<~[@u8]>();
+        if ! self.inner.visit_evec_uniq_managed(mtbl, inner) { return false; }
+        self.bump_past::<~[@u8]>();
+        true
+    }
+
     fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<&'static [u8]>();
         if ! self.inner.visit_evec_slice(mtbl, inner) { return false; }
@@ -567,6 +574,7 @@ impl TyVisitor for my_visitor {
     fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_evec_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_evec_uniq(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_uniq_managed(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_evec_slice(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_evec_fixed(&self, _n: uint, _sz: uint, _align: uint,
                         _mtbl: uint, _inner: *TyDesc) -> bool { true }

--- a/src/test/run-pass/reflect-visit-type.rs
+++ b/src/test/run-pass/reflect-visit-type.rs
@@ -85,6 +85,14 @@ impl TyVisitor for MyVisitor {
         self.types.push(~"]");
         true
     }
+    fn visit_evec_uniq_managed(&self, _mtbl: uint, inner: *TyDesc) -> bool {
+        self.types.push(~"[");
+        unsafe {
+            visit_tydesc(inner, (@*self) as @TyVisitor);
+        }
+        self.types.push(~"]");
+        true
+    }
     fn visit_evec_slice(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_evec_fixed(&self, _n: uint, _sz: uint, _align: uint,
                         _mtbl: uint, _inner: *TyDesc) -> bool { true }


### PR DESCRIPTION
Note that the headers are still on `~[T]` when `T` is managed. This is continued from #7605, which removed all the code relying on the headers and removed them from `~T` for non-managed `T`.
