### PR TITLE
Made ast::blk not use spanned<T> anymore.

### DIFF
--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -173,11 +173,11 @@ impl<T> Deque<T> for DList<T> {
                 let tail_own = match tail.prev.resolve() {
                     None => {
                         self.list_tail = Rawlink::none();
-                        self.list_head.swap_unwrap()
+                        self.list_head.take_unwrap()
                     },
                     Some(tail_prev) => {
                         self.list_tail = tail.prev;
-                        tail_prev.next.swap_unwrap()
+                        tail_prev.next.take_unwrap()
                     }
                 };
                 Some(tail_own.value)
@@ -465,7 +465,7 @@ impl<'self, A> ListInsertion<A> for MutDListIterator<'self, A> {
                     Some(prev) => prev,
                 };
                 let mut ins_node = ~Node{value: elt, next: None, prev: Rawlink::none()};
-                let node_own = prev_node.next.swap_unwrap();
+                let node_own = prev_node.next.take_unwrap();
                 ins_node.next = link_with_prev(node_own, Rawlink::some(ins_node));
                 prev_node.next = link_with_prev(ins_node, Rawlink::some(prev_node));
                 self.list.length += 1;

--- a/src/libextra/net/ip.rs
+++ b/src/libextra/net/ip.rs
@@ -116,7 +116,7 @@ pub fn get_addr(node: &str, iotask: &iotask)
     let (output_po, output_ch) = stream();
     let mut output_ch = Some(SharedChan::new(output_ch));
     do str::as_buf(node) |node_ptr, len| {
-        let output_ch = output_ch.swap_unwrap();
+        let output_ch = output_ch.take_unwrap();
         debug!("slice len %?", len);
         let handle = create_uv_getaddrinfo_t();
         let handle_ptr: *uv_getaddrinfo_t = &handle;

--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -159,8 +159,8 @@ impl<V> SmallIntMap<V> {
     /// Visit all key-value pairs in reverse order
     pub fn each_reverse<'a>(&'a self, it: &fn(uint, &'a V) -> bool) -> bool {
         for uint::range_rev(self.v.len(), 0) |i| {
-            match self.v[i - 1] {
-              Some(ref elt) => if !it(i - 1, elt) { return false; },
+            match self.v[i] {
+              Some(ref elt) => if !it(i, elt) { return false; },
               None => ()
             }
         }

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -552,7 +552,7 @@ fn mutate_values<'r, K: TotalOrd, V>(node: &'r mut Option<~TreeNode<K, V>>,
 // Remove left horizontal link by rotating right
 fn skew<K: TotalOrd, V>(node: &mut ~TreeNode<K, V>) {
     if node.left.map_default(false, |x| x.level == node.level) {
-        let mut save = node.left.swap_unwrap();
+        let mut save = node.left.take_unwrap();
         swap(&mut node.left, &mut save.right); // save.right now None
         swap(node, &mut save);
         node.right = Some(save);
@@ -564,7 +564,7 @@ fn skew<K: TotalOrd, V>(node: &mut ~TreeNode<K, V>) {
 fn split<K: TotalOrd, V>(node: &mut ~TreeNode<K, V>) {
     if node.right.map_default(false,
       |x| x.right.map_default(false, |y| y.level == node.level)) {
-        let mut save = node.right.swap_unwrap();
+        let mut save = node.right.take_unwrap();
         swap(&mut node.right, &mut save.left); // save.left now None
         save.level += 1;
         swap(node, &mut save);
@@ -643,7 +643,7 @@ fn remove<K: TotalOrd, V>(node: &mut Option<~TreeNode<K, V>>,
           Equal => {
             if save.left.is_some() {
                 if save.right.is_some() {
-                    let mut left = save.left.swap_unwrap();
+                    let mut left = save.left.take_unwrap();
                     if left.right.is_some() {
                         heir_swap(save, &mut left.right);
                     } else {
@@ -653,13 +653,13 @@ fn remove<K: TotalOrd, V>(node: &mut Option<~TreeNode<K, V>>,
                     save.left = Some(left);
                     (remove(&mut save.left, key), true)
                 } else {
-                    let new = save.left.swap_unwrap();
+                    let new = save.left.take_unwrap();
                     let ~TreeNode{value, _} = replace(save, new);
-                    *save = save.left.swap_unwrap();
+                    *save = save.left.take_unwrap();
                     (Some(value), true)
                 }
             } else if save.right.is_some() {
-                let new = save.right.swap_unwrap();
+                let new = save.right.take_unwrap();
                 let ~TreeNode{value, _} = replace(save, new);
                 (Some(value), true)
             } else {

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -422,7 +422,7 @@ pub fn pretty_print_input(sess: Session, cfg: ast::crate_cfg, input: &input,
           pprust::node_block(s, ref blk) => {
             pp::space(s.s);
             pprust::synth_comment(
-                s, ~"block " + int::to_str(blk.node.id));
+                s, ~"block " + int::to_str(blk.id));
           }
           pprust::node_expr(s, expr) => {
             pp::space(s.s);

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -33,7 +33,7 @@ pub fn strip_items(crate: &ast::crate, in_cfg: in_cfg_pred)
 
     let precursor = @fold::AstFoldFns {
           fold_mod: |a,b| fold_mod(ctxt, a, b),
-          fold_block: fold::wrap(|a,b| fold_block(ctxt, a, b) ),
+          fold_block: |a,b| fold_block(ctxt, a, b),
           fold_foreign_mod: |a,b| fold_foreign_mod(ctxt, a, b),
           fold_item_underscore: |a,b| {
             // Bad copy.
@@ -133,21 +133,22 @@ fn filter_stmt(cx: @Context, stmt: @ast::stmt) ->
 
 fn fold_block(
     cx: @Context,
-    b: &ast::blk_,
+    b: &ast::blk,
     fld: @fold::ast_fold
-) -> ast::blk_ {
+) -> ast::blk {
     let resulting_stmts = do b.stmts.iter().filter_map |a| {
         filter_stmt(cx, *a).chain(|stmt| fld.fold_stmt(stmt))
     }.collect();
     let filtered_view_items = do b.view_items.iter().filter_map |a| {
         filter_view_item(cx, a).map(|&x| fld.fold_view_item(x))
     }.collect();
-    ast::blk_ {
+    ast::blk {
         view_items: filtered_view_items,
         stmts: resulting_stmts,
         expr: b.expr.map(|x| fld.fold_expr(*x)),
         id: b.id,
         rules: b.rules,
+        span: b.span,
     }
 }
 

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -44,7 +44,7 @@ pub fn check_loans(bccx: @BorrowckCtxt,
                    move_data: move_data::FlowedMoveData,
                    all_loans: &[Loan],
                    body: &ast::blk) {
-    debug!("check_loans(body id=%?)", body.node.id);
+    debug!("check_loans(body id=%?)", body.id);
 
     let clcx = @mut CheckLoanCtxt {
         bccx: bccx,
@@ -751,5 +751,5 @@ fn check_loans_in_block<'a>(blk: &ast::blk,
                                          visit::vt<@mut CheckLoanCtxt<'a>>))
 {
     visit::visit_block(blk, (this, vt));
-    this.check_for_conflicting_loans(blk.node.id);
+    this.check_for_conflicting_loans(blk.id);
 }

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -80,8 +80,8 @@ pub fn gather_loans(bccx: @BorrowckCtxt,
         bccx: bccx,
         id_range: id_range::max(),
         all_loans: @mut ~[],
-        item_ub: body.node.id,
-        repeating_ids: ~[body.node.id],
+        item_ub: body.id,
+        repeating_ids: ~[body.id],
         move_data: @mut MoveData::new()
     };
     glcx.gather_fn_arg_patterns(decl, body);
@@ -123,9 +123,9 @@ fn gather_loans_in_fn(fk: &visit::fn_kind,
 
         // Visit closures as part of the containing item.
         &visit::fk_anon(*) | &visit::fk_fn_block(*) => {
-            this.push_repeating_id(body.node.id);
+            this.push_repeating_id(body.id);
             visit::visit_fn(fk, decl, body, sp, id, (this, v));
-            this.pop_repeating_id(body.node.id);
+            this.pop_repeating_id(body.id);
             this.gather_fn_arg_patterns(decl, body);
         }
     }
@@ -134,7 +134,7 @@ fn gather_loans_in_fn(fk: &visit::fn_kind,
 fn gather_loans_in_block(blk: &ast::blk,
                          (this, vt): (@mut GatherLoanCtxt,
                                       visit::vt<@mut GatherLoanCtxt>)) {
-    this.id_range.add(blk.node.id);
+    this.id_range.add(blk.id);
     visit::visit_block(blk, (this, vt));
 }
 
@@ -240,7 +240,7 @@ fn gather_loans_in_expr(ex: @ast::expr,
         let cmt = this.bccx.cat_expr(ex_v);
         for arms.iter().advance |arm| {
             for arm.pats.iter().advance |pat| {
-                this.gather_pat(cmt, *pat, Some((arm.body.node.id, ex.id)));
+                this.gather_pat(cmt, *pat, Some((arm.body.id, ex.id)));
             }
         }
         visit::visit_expr(ex, (this, vt));
@@ -268,16 +268,16 @@ fn gather_loans_in_expr(ex: @ast::expr,
           this.pop_repeating_id(cond.id);
 
           // during body, can only root for the body
-          this.push_repeating_id(body.node.id);
+          this.push_repeating_id(body.id);
           (vt.visit_block)(body, (this, vt));
-          this.pop_repeating_id(body.node.id);
+          this.pop_repeating_id(body.id);
       }
 
       // see explanation attached to the `root_ub` field:
       ast::expr_loop(ref body, _) => {
-          this.push_repeating_id(body.node.id);
+          this.push_repeating_id(body.id);
           visit::visit_expr(ex, (this, vt));
-          this.pop_repeating_id(body.node.id);
+          this.pop_repeating_id(body.id);
       }
 
       ast::expr_fn_block(*) => {
@@ -623,7 +623,7 @@ impl GatherLoanCtxt {
             let arg_cmt = mc_ctxt.cat_rvalue(
                 arg.id,
                 arg.pat.span,
-                body.node.id, // Arguments live only as long as the fn body.
+                body.id, // Arguments live only as long as the fn body.
                 arg_ty);
 
             self.gather_pat(arg_cmt, arg.pat, None);

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -53,13 +53,13 @@ pub fn construct(tcx: ty::ctxt,
 impl CFGBuilder {
     fn block(&mut self, blk: &ast::blk, pred: CFGIndex) -> CFGIndex {
         let mut stmts_exit = pred;
-        for blk.node.stmts.iter().advance |&stmt| {
+        for blk.stmts.iter().advance |&stmt| {
             stmts_exit = self.stmt(stmt, stmts_exit);
         }
 
-        let expr_exit = self.opt_expr(blk.node.expr, stmts_exit);
+        let expr_exit = self.opt_expr(blk.expr, stmts_exit);
 
-        self.add_node(blk.node.id, [expr_exit])
+        self.add_node(blk.id, [expr_exit])
     }
 
     fn stmt(&mut self, stmt: @ast::stmt, pred: CFGIndex) -> CFGIndex {

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -330,7 +330,7 @@ impl<O:DataFlowOperator+Copy+'static> DataFlowContext<O> {
         let pre: @fn(pprust::ann_node) = |node| {
             let (ps, id) = match node {
                 pprust::node_expr(ps, expr) => (ps, expr.id),
-                pprust::node_block(ps, blk) => (ps, blk.node.id),
+                pprust::node_block(ps, blk) => (ps, blk.id),
                 pprust::node_item(ps, _) => (ps, 0),
                 pprust::node_pat(ps, pat) => (ps, pat.id)
             };
@@ -383,18 +383,18 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
                   blk: &ast::blk,
                   in_out: &mut [uint],
                   loop_scopes: &mut ~[LoopScope]) {
-        debug!("DataFlowContext::walk_block(blk.node.id=%?, in_out=%s)",
-               blk.node.id, bits_to_str(reslice(in_out)));
+        debug!("DataFlowContext::walk_block(blk.id=%?, in_out=%s)",
+               blk.id, bits_to_str(reslice(in_out)));
 
-        self.merge_with_entry_set(blk.node.id, in_out);
+        self.merge_with_entry_set(blk.id, in_out);
 
-        for blk.node.stmts.iter().advance |&stmt| {
+        for blk.stmts.iter().advance |&stmt| {
             self.walk_stmt(stmt, in_out, loop_scopes);
         }
 
-        self.walk_opt_expr(blk.node.expr, in_out, loop_scopes);
+        self.walk_opt_expr(blk.expr, in_out, loop_scopes);
 
-        self.dfcx.apply_gen_kill(blk.node.id, in_out);
+        self.dfcx.apply_gen_kill(blk.id, in_out);
     }
 
     fn walk_stmt(&mut self,

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -99,9 +99,9 @@ pub fn check_crate(tcx: ty::ctxt,
 
         visit_block: |block, (_, visitor)| {
             let old_unsafe_context = context.unsafe_context;
-            if block.node.rules == unsafe_blk &&
+            if block.rules == unsafe_blk &&
                     context.unsafe_context == SafeContext {
-                context.unsafe_context = UnsafeBlock(block.node.id)
+                context.unsafe_context = UnsafeBlock(block.id)
             }
 
             visit::visit_block(block, ((), visitor));

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -309,7 +309,7 @@ pub fn check_expr(e: @expr, (cx, v): (Context, visit::vt<Context>)) {
                        "explicit copy requires a copyable argument");
         }
         expr_repeat(element, count_expr, _) => {
-            let count = ty::eval_repeat_count(cx.tcx, count_expr);
+            let count = ty::eval_repeat_count(&cx.tcx, count_expr);
             if count > 1 {
                 let element_ty = ty::expr_ty(cx.tcx, element);
                 check_copy(cx, element_ty, element.span,

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -916,8 +916,8 @@ fn lint_unused_unsafe() -> visit::vt<@mut Context> {
     visit::mk_vt(@visit::Visitor {
         visit_expr: |e, (cx, vt): (@mut Context, visit::vt<@mut Context>)| {
             match e.node {
-                ast::expr_block(ref blk) if blk.node.rules == ast::unsafe_blk => {
-                    if !cx.tcx.used_unsafe.contains(&blk.node.id) {
+                ast::expr_block(ref blk) if blk.rules == ast::unsafe_blk => {
+                    if !cx.tcx.used_unsafe.contains(&blk.id) {
                         cx.span_lint(unused_unsafe, blk.span,
                                      "unnecessary `unsafe` block");
                     }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -886,7 +886,7 @@ impl Liveness {
                       self.tcx.sess.intr()));
 
         let entry_ln: LiveNode =
-            self.with_loop_nodes(body.node.id, self.s.exit_ln, self.s.exit_ln,
+            self.with_loop_nodes(body.id, self.s.exit_ln, self.s.exit_ln,
               || { self.propagate_through_fn_block(decl, body) });
 
         // hack to skip the loop unless debug! is enabled:
@@ -895,7 +895,7 @@ impl Liveness {
                    for uint::range(0u, self.ir.num_live_nodes) |ln_idx| {
                        debug!("%s", self.ln_str(LiveNode(ln_idx)));
                    }
-                   body.node.id
+                   body.id
                },
                entry_ln.to_str());
 
@@ -907,7 +907,7 @@ impl Liveness {
         // the fallthrough exit is only for those cases where we do not
         // explicitly return:
         self.init_from_succ(self.s.fallthrough_ln, self.s.exit_ln);
-        if blk.node.expr.is_none() {
+        if blk.expr.is_none() {
             self.acc(self.s.fallthrough_ln, self.s.no_ret_var, ACC_READ)
         }
 
@@ -916,8 +916,8 @@ impl Liveness {
 
     pub fn propagate_through_block(&self, blk: &blk, succ: LiveNode)
                                    -> LiveNode {
-        let succ = self.propagate_through_opt_expr(blk.node.expr, succ);
-        do blk.node.stmts.rev_iter().fold(succ) |succ, stmt| {
+        let succ = self.propagate_through_opt_expr(blk.expr, succ);
+        do blk.stmts.rev_iter().fold(succ) |succ, stmt| {
             self.propagate_through_stmt(*stmt, succ)
         }
     }
@@ -1009,7 +1009,7 @@ impl Liveness {
               The next-node for a break is the successor of the entire
               loop. The next-node for a continue is the top of this loop.
               */
-              self.with_loop_nodes(blk.node.id, succ,
+              self.with_loop_nodes(blk.id, succ,
                   self.live_node(expr.id, expr.span), || {
 
                  // the construction of a closure itself is not important,

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -285,13 +285,13 @@ impl VisitContext {
          * meaning either copied or moved depending on its type.
          */
 
-        debug!("consume_block(blk.id=%?)", blk.node.id);
+        debug!("consume_block(blk.id=%?)", blk.id);
 
-        for blk.node.stmts.iter().advance |stmt| {
+        for blk.stmts.iter().advance |stmt| {
             (visitor.visit_stmt)(*stmt, (*self, visitor));
         }
 
-        for blk.node.expr.iter().advance |tail_expr| {
+        for blk.expr.iter().advance |tail_expr| {
             self.consume_expr(*tail_expr, visitor);
         }
     }

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -384,7 +384,7 @@ pub fn check_crate<'mm>(tcx: ty::ctxt,
         visit_block: |block, (method_map, visitor)| {
             // Gather up all the privileged items.
             let mut n_added = 0;
-            for block.node.stmts.iter().advance |stmt| {
+            for block.stmts.iter().advance |stmt| {
                 match stmt.node {
                     stmt_decl(decl, _) => {
                         match decl.node {

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -324,11 +324,11 @@ fn parent_to_expr(cx: Context, child_id: ast::node_id, sp: span) {
 
 fn resolve_block(blk: &ast::blk, (cx, visitor): (Context, visit::vt<Context>)) {
     // Record the parent of this block.
-    parent_to_expr(cx, blk.node.id, blk.span);
+    parent_to_expr(cx, blk.id, blk.span);
 
     // Descend.
-    let new_cx = Context {var_parent: Some(blk.node.id),
-                          parent: Some(blk.node.id),
+    let new_cx = Context {var_parent: Some(blk.id),
+                          parent: Some(blk.id),
                           ..cx};
     visit::visit_block(blk, (new_cx, visitor));
 }
@@ -420,20 +420,20 @@ fn resolve_fn(fk: &visit::fn_kind,
                               visit::vt<Context>)) {
     debug!("region::resolve_fn(id=%?, \
                                span=%?, \
-                               body.node.id=%?, \
+                               body.id=%?, \
                                cx.parent=%?)",
            id,
            cx.sess.codemap.span_to_str(sp),
-           body.node.id,
+           body.id,
            cx.parent);
 
     // The arguments and `self` are parented to the body of the fn.
-    let decl_cx = Context {parent: Some(body.node.id),
-                           var_parent: Some(body.node.id),
+    let decl_cx = Context {parent: Some(body.id),
+                           var_parent: Some(body.id),
                            ..cx};
     match *fk {
         visit::fk_method(_, _, method) => {
-            cx.region_maps.record_parent(method.self_id, body.node.id);
+            cx.region_maps.record_parent(method.self_id, body.id);
         }
         _ => {}
     }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1069,12 +1069,12 @@ impl Resolver {
 
     pub fn block_needs_anonymous_module(@mut self, block: &blk) -> bool {
         // If the block has view items, we need an anonymous module.
-        if block.node.view_items.len() > 0 {
+        if block.view_items.len() > 0 {
             return true;
         }
 
         // Check each statement.
-        for block.node.stmts.iter().advance |statement| {
+        for block.stmts.iter().advance |statement| {
             match statement.node {
                 stmt_decl(declaration, _) => {
                     match declaration.node {
@@ -1566,7 +1566,7 @@ impl Resolver {
                                           vt<ReducedGraphParent>)) {
         let new_parent;
         if self.block_needs_anonymous_module(block) {
-            let block_id = block.node.id;
+            let block_id = block.id;
 
             debug!("(building reduced graph for block) creating a new \
                     anonymous module for block %d",
@@ -4096,7 +4096,7 @@ impl Resolver {
 
         // Move down in the graph, if there's an anonymous module rooted here.
         let orig_module = self.current_module;
-        match self.current_module.anonymous_children.find(&block.node.id) {
+        match self.current_module.anonymous_children.find(&block.id) {
             None => { /* Nothing to do. */ }
             Some(&anonymous_module) => {
                 debug!("(resolving block) found anonymous module, moving \
@@ -4989,7 +4989,7 @@ impl Resolver {
             }
 
             expr_fn_block(ref fn_decl, ref block) => {
-                self.resolve_function(FunctionRibKind(expr.id, block.node.id),
+                self.resolve_function(FunctionRibKind(expr.id, block.id),
                                       Some(fn_decl),
                                       NoTypeParameters,
                                       block,

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1430,7 +1430,7 @@ pub fn with_scope_datumblock(bcx: block, opt_node_info: Option<NodeInfo>,
 }
 
 pub fn block_locals(b: &ast::blk, it: &fn(@ast::local)) {
-    for b.node.stmts.iter().advance |s| {
+    for b.stmts.iter().advance |s| {
         match s.node {
           ast::stmt_decl(d, _) => {
             match d.node {
@@ -1858,7 +1858,7 @@ pub fn trans_closure(ccx: @mut CrateContext,
     let bcx_top = top_scope_block(fcx, body.info());
     let mut bcx = bcx_top;
     let lltop = bcx.llbb;
-    let block_ty = node_id_type(bcx, body.node.id);
+    let block_ty = node_id_type(bcx, body.id);
 
     let arg_tys = ty::ty_fn_args(node_id_type(bcx, id));
     bcx = copy_args_to_allocas(fcx, bcx, decl.inputs, raw_llargs, arg_tys);
@@ -1869,7 +1869,7 @@ pub fn trans_closure(ccx: @mut CrateContext,
     // translation calls that don't have a return value (trans_crate,
     // trans_mod, trans_item, et cetera) and those that do
     // (trans_block, trans_expr, et cetera).
-    if body.node.expr.is_none() || ty::type_is_bot(block_ty) ||
+    if body.expr.is_none() || ty::type_is_bot(block_ty) ||
         ty::type_is_nil(block_ty)
     {
         bcx = controlflow::trans_block(bcx, body, expr::Ignore);
@@ -2132,7 +2132,7 @@ pub fn trans_item(ccx: @mut CrateContext, item: &ast::item) {
                      item.id,
                      item.attrs);
         } else {
-            for body.node.stmts.iter().advance |stmt| {
+            for body.stmts.iter().advance |stmt| {
                 match stmt.node {
                   ast::stmt_decl(@codemap::spanned { node: ast::decl_item(i),
                                                  _ }, _) => {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -481,7 +481,7 @@ impl get_node_info for ast::expr {
 
 impl get_node_info for ast::blk {
     fn info(&self) -> Option<NodeInfo> {
-        Some(NodeInfo {id: self.node.id,
+        Some(NodeInfo {id: self.id,
                        callee_id: None,
                        span: self.span})
     }

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -35,11 +35,11 @@ use syntax::codemap::span;
 pub fn trans_block(bcx: block, b: &ast::blk, dest: expr::Dest) -> block {
     let _icx = push_ctxt("trans_block");
     let mut bcx = bcx;
-    for b.node.stmts.iter().advance |s| {
+    for b.stmts.iter().advance |s| {
         debuginfo::update_source_pos(bcx, b.span);
         bcx = trans_stmt(bcx, *s);
     }
-    match b.node.expr {
+    match b.expr {
         Some(e) => {
             debuginfo::update_source_pos(bcx, e.span);
             bcx = expr::trans_into(bcx, e, dest);
@@ -58,7 +58,7 @@ pub fn trans_if(bcx: block,
             dest: expr::Dest)
          -> block {
     debug!("trans_if(bcx=%s, cond=%s, thn=%?, dest=%s)",
-           bcx.to_str(), bcx.expr_to_str(cond), thn.node.id,
+           bcx.to_str(), bcx.expr_to_str(cond), thn.id,
            dest.to_str(bcx.ccx()));
     let _indenter = indenter();
 

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -417,7 +417,7 @@ pub fn write_content(bcx: block,
                     return expr::trans_into(bcx, element, Ignore);
                 }
                 SaveIn(lldest) => {
-                    let count = ty::eval_repeat_count(bcx.tcx(), count_expr);
+                    let count = ty::eval_repeat_count(&bcx.tcx(), count_expr);
                     if count == 0 {
                         return bcx;
                     }
@@ -509,7 +509,7 @@ pub fn elements_required(bcx: block, content_expr: &ast::expr) -> uint {
         },
         ast::expr_vec(ref es, _) => es.len(),
         ast::expr_repeat(_, count_expr, _) => {
-            ty::eval_repeat_count(bcx.tcx(), count_expr)
+            ty::eval_repeat_count(&bcx.tcx(), count_expr)
         }
         _ => bcx.tcx().sess.span_bug(content_expr.span,
                                      "Unexpected evec content")

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -414,7 +414,7 @@ pub fn handle_body(cx: &Context, body: &blk) {
         },
         visit_block: |b, (cx, v)| {
             visit::visit_block(b, (cx, v));
-            for b.node.expr.iter().advance |e| {
+            for b.expr.iter().advance |e| {
                 node_type_needs(cx, use_repr, e.id);
             }
         },

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2840,7 +2840,7 @@ pub fn tys_in_fn_sig(sig: &FnSig) -> ~[t] {
 
 // Type accessors for AST nodes
 pub fn block_ty(cx: ctxt, b: &ast::blk) -> t {
-    return node_id_to_type(cx, b.node.id);
+    return node_id_to_type(cx, b.id);
 }
 
 

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -479,7 +479,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + 'static>(
         }
       }
       ast::ty_fixed_length_vec(ref a_mt, e) => {
-        match const_eval::eval_const_expr_partial(tcx, e) {
+        match const_eval::eval_const_expr_partial(&tcx, e) {
           Ok(ref r) => {
             match *r {
               const_eval::const_int(i) =>

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -72,14 +72,14 @@ pub fn check_match(fcx: @mut FnCtxt,
           None => ()
         }
         check_block(fcx, &arm.body);
-        let bty = fcx.node_ty(arm.body.node.id);
+        let bty = fcx.node_ty(arm.body.id);
         saw_err = saw_err || ty::type_is_error(bty);
         if guard_err {
-            fcx.write_error(arm.body.node.id);
+            fcx.write_error(arm.body.id);
             saw_err = true;
         }
         else if guard_bot {
-            fcx.write_bot(arm.body.node.id);
+            fcx.write_bot(arm.body.id);
         }
 
         result_ty =

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -155,7 +155,7 @@ pub fn regionck_expr(fcx: @mut FnCtxt, e: @ast::expr) {
 
 pub fn regionck_fn(fcx: @mut FnCtxt, blk: &ast::blk) {
     let rcx = @mut Rcx { fcx: fcx, errors_reported: 0,
-                         repeating_scope: blk.node.id };
+                         repeating_scope: blk.id };
     if fcx.err_count_since_creation() == 0 {
         // regionck assumes typeck succeeded
         let v = regionck_visitor();
@@ -188,7 +188,7 @@ fn visit_item(_item: @ast::item, (_rcx, _v): (@mut Rcx, rvt)) {
 }
 
 fn visit_block(b: &ast::blk, (rcx, v): (@mut Rcx, rvt)) {
-    rcx.fcx.tcx().region_maps.record_cleanup_scope(b.node.id);
+    rcx.fcx.tcx().region_maps.record_cleanup_scope(b.id);
     visit::visit_block(b, (rcx, v));
 }
 
@@ -287,11 +287,11 @@ fn visit_expr(expr: @ast::expr, (rcx, v): (@mut Rcx, rvt)) {
             }
         }
         ast::expr_loop(ref body, _) => {
-            tcx.region_maps.record_cleanup_scope(body.node.id);
+            tcx.region_maps.record_cleanup_scope(body.id);
         }
         ast::expr_while(cond, ref body) => {
             tcx.region_maps.record_cleanup_scope(cond.id);
-            tcx.region_maps.record_cleanup_scope(body.node.id);
+            tcx.region_maps.record_cleanup_scope(body.id);
         }
         _ => {}
     }
@@ -434,7 +434,7 @@ fn visit_expr(expr: @ast::expr, (rcx, v): (@mut Rcx, rvt)) {
         }
 
         ast::expr_loop(ref body, _) => {
-            let repeating_scope = rcx.set_repeating_scope(body.node.id);
+            let repeating_scope = rcx.set_repeating_scope(body.id);
             visit::visit_expr(expr, (rcx, v));
             rcx.set_repeating_scope(repeating_scope);
         }
@@ -443,7 +443,7 @@ fn visit_expr(expr: @ast::expr, (rcx, v): (@mut Rcx, rvt)) {
             let repeating_scope = rcx.set_repeating_scope(cond.id);
             (v.visit_expr)(cond, (rcx, v));
 
-            rcx.set_repeating_scope(body.node.id);
+            rcx.set_repeating_scope(body.id);
             (v.visit_block)(body, (rcx, v));
 
             rcx.set_repeating_scope(repeating_scope);
@@ -486,7 +486,7 @@ fn check_expr_fn_block(rcx: @mut Rcx,
                 _ => ()
             }
 
-            let repeating_scope = rcx.set_repeating_scope(body.node.id);
+            let repeating_scope = rcx.set_repeating_scope(body.id);
             visit::visit_expr(expr, (rcx, v));
             rcx.set_repeating_scope(repeating_scope);
         }

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -276,7 +276,7 @@ fn visit_block(b: &ast::blk, (wbcx, v): (@mut WbCtxt, wb_vt)) {
         return;
     }
 
-    resolve_type_vars_for_node(wbcx, b.span, b.node.id);
+    resolve_type_vars_for_node(wbcx, b.span, b.id);
     visit::visit_block(b, (wbcx, v));
 }
 

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -745,7 +745,7 @@ pub fn convert_methods(ccx: &CrateCtxt,
         write_ty_to_tcx(tcx, m.id, fty);
         tcx.methods.insert(mty.def_id, mty);
         ConvertedMethod {mty: mty, id: m.id,
-                         span: m.span, body_id: m.body.node.id}
+                         span: m.span, body_id: m.body.id}
     }).collect();
 
     fn ty_of_method(ccx: &CrateCtxt,

--- a/src/librusti/program.rs
+++ b/src/librusti/program.rs
@@ -346,7 +346,7 @@ impl Program {
         // helper functions to perform ast iteration
         fn each_user_local(blk: &ast::blk, f: &fn(@ast::local)) {
             do find_user_block(blk) |blk| {
-                for blk.node.stmts.iter().advance |stmt| {
+                for blk.stmts.iter().advance |stmt| {
                     match stmt.node {
                         ast::stmt_decl(d, _) => {
                             match d.node {
@@ -361,7 +361,7 @@ impl Program {
         }
 
         fn find_user_block(blk: &ast::blk, f: &fn(&ast::blk)) {
-            for blk.node.stmts.iter().advance |stmt| {
+            for blk.stmts.iter().advance |stmt| {
                 match stmt.node {
                     ast::stmt_semi(e, _) => {
                         match e.node {

--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -149,7 +149,7 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
     do find_main(crate, sess) |blk| {
         // Fish out all the view items, be sure to record 'extern mod' items
         // differently beause they must appear before all 'use' statements
-        for blk.node.view_items.iter().advance |vi| {
+        for blk.view_items.iter().advance |vi| {
             let s = do with_pp(intr) |pp, _| {
                 pprust::print_view_item(pp, vi);
             };
@@ -163,7 +163,7 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
 
         // Iterate through all of the block's statements, inserting them into
         // the correct portions of the program
-        for blk.node.stmts.iter().advance |stmt| {
+        for blk.stmts.iter().advance |stmt| {
             let s = do with_pp(intr) |pp, _| { pprust::print_stmt(pp, *stmt); };
             match stmt.node {
                 ast::stmt_decl(d, _) => {
@@ -203,7 +203,7 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
                 }
             }
         }
-        result = do blk.node.expr.map_consume |e| {
+        result = do blk.expr.map_consume |e| {
             do with_pp(intr) |pp, _| { pprust::print_expr(pp, e); }
         };
     }

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -29,28 +29,38 @@ pub static bytes : uint = ($bits / 8);
 pub static min_value: $T = (-1 as $T) << (bits - 1);
 pub static max_value: $T = min_value - 1 as $T;
 
-///
-/// Iterate over the range [`lo`..`hi`)
-///
-/// # Arguments
-///
-/// * `lo` - lower bound, inclusive
-/// * `hi` - higher bound, exclusive
-///
-/// # Examples
-/// ~~~
-/// let mut sum = 0;
-/// for int::range(1, 5) |i| {
-///     sum += i;
-/// }
-/// assert!(sum == 10);
-/// ~~~
-///
+enum Range { Closed, HalfOpen }
+
 #[inline]
-pub fn range_step(start: $T, stop: $T, step: $T, it: &fn($T) -> bool) -> bool {
+///
+/// Iterate through a range with a given step value.
+///
+/// Let `term` denote the closed interval `[stop-step,stop]` if `r` is Closed;
+/// otherwise `term` denotes the half-open interval `[stop-step,stop)`.
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// `x_j == start + step*j`, and `x_n` lies in the interval `term`.
+///
+/// If no such nonnegative integer `n` exists, then the iteration range
+/// is empty.
+///
+fn range_step_core(start: $T, stop: $T, step: $T, r: Range, it: &fn($T) -> bool) -> bool {
     let mut i = start;
     if step == 0 {
         fail!(~"range_step called with step == 0");
+    } else if step == (1 as $T) { // elide bounds check to tighten loop
+        while i < stop {
+            if !it(i) { return false; }
+            // no need for overflow check;
+            // cannot have i + 1 > max_value because i < stop <= max_value
+            i += (1 as $T);
+        }
+    } else if step == (-1 as $T) { // elide bounds check to tighten loop
+        while i > stop {
+            if !it(i) { return false; }
+            // no need for underflow check;
+            // cannot have i - 1 < min_value because i > stop >= min_value
+            i -= (1 as $T);
+        }
     } else if step > 0 { // ascending
         while i < stop {
             if !it(i) { return false; }
@@ -66,8 +76,54 @@ pub fn range_step(start: $T, stop: $T, step: $T, it: &fn($T) -> bool) -> bool {
             i += step;
         }
     }
-    return true;
+    match r {
+        HalfOpen => return true,
+        Closed => return (i != stop || it(i))
+    }
 }
+
+#[inline]
+///
+/// Iterate through the range [`start`..`stop`) with a given step value.
+///
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// * `x_i == start + step*i`, and
+/// * `n` is the greatest nonnegative integer such that `x_n < stop`
+///
+/// (If no such `n` exists, then the iteration range is empty.)
+///
+/// # Arguments
+///
+/// * `start` - lower bound, inclusive
+/// * `stop` - higher bound, exclusive
+///
+/// # Examples
+/// ~~~
+/// let mut sum = 0;
+/// for int::range(1, 5) |i| {
+///     sum += i;
+/// }
+/// assert!(sum == 10);
+/// ~~~
+///
+pub fn range_step(start: $T, stop: $T, step: $T, it: &fn($T) -> bool) -> bool {
+    range_step_core(start, stop, step, HalfOpen, it)
+}
+
+#[inline]
+///
+/// Iterate through a range with a given step value.
+///
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// `x_i == start + step*i` and `x_n <= last < step + x_n`.
+///
+/// (If no such nonnegative integer `n` exists, then the iteration
+///  range is empty.)
+///
+pub fn range_step_inclusive(start: $T, last: $T, step: $T, it: &fn($T) -> bool) -> bool {
+    range_step_core(start, last, step, Closed, it)
+}
+
 
 #[inline]
 /// Iterate over the range [`lo`..`hi`)

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -132,9 +132,10 @@ pub fn range(lo: $T, hi: $T, it: &fn($T) -> bool) -> bool {
 }
 
 #[inline]
-/// Iterate over the range [`hi`..`lo`)
+/// Iterate over the range (`hi`..`lo`]
 pub fn range_rev(hi: $T, lo: $T, it: &fn($T) -> bool) -> bool {
-    range_step(hi, lo, -1 as $T, it)
+    if hi == min_value { return true; }
+    range_step_inclusive(hi-1, lo, -1 as $T, it)
 }
 
 impl Num for $T {}
@@ -897,7 +898,7 @@ mod tests {
         for range(0,3) |i| {
             l.push(i);
         }
-        for range_rev(13,10) |i| {
+        for range_rev(14,11) |i| {
             l.push(i);
         }
         for range_step(20,26,2) |i| {

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -132,9 +132,10 @@ pub fn range(lo: $T, hi: $T, it: &fn($T) -> bool) -> bool {
 }
 
 #[inline]
-/// Iterate over the range [`hi`..`lo`)
+/// Iterate over the range (`hi`..`lo`]
 pub fn range_rev(hi: $T, lo: $T, it: &fn($T) -> bool) -> bool {
-    range_step(hi, lo, -1 as $T_SIGNED, it)
+    if hi == min_value { return true; }
+    range_step_inclusive(hi-1, lo, -1 as $T_SIGNED, it)
 }
 
 impl Num for $T {}
@@ -662,7 +663,7 @@ mod tests {
         for range(0,3) |i| {
             l.push(i);
         }
-        for range_rev(13,10) |i| {
+        for range_rev(14,11) |i| {
             l.push(i);
         }
         for range_step(20,26,2) |i| {

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -30,32 +30,46 @@ pub static bytes : uint = ($bits / 8);
 pub static min_value: $T = 0 as $T;
 pub static max_value: $T = 0 as $T - 1 as $T;
 
+enum Range { Closed, HalfOpen }
+
 #[inline]
-/**
- * Iterate through a range with a given step value.
- *
- * # Examples
- * ~~~ {.rust}
- * let nums = [1,2,3,4,5,6,7];
- *
- * for uint::range_step(0, nums.len() - 1, 2) |i| {
- *     println(fmt!("%d & %d", nums[i], nums[i+1]));
- * }
- * ~~~
- */
-pub fn range_step(start: $T, stop: $T, step: $T_SIGNED, it: &fn($T) -> bool) -> bool {
+///
+/// Iterate through a range with a given step value.
+///
+/// Let `term` denote the closed interval `[stop-step,stop]` if `r` is Closed;
+/// otherwise `term` denotes the half-open interval `[stop-step,stop)`.
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// `x_j == start + step*j`, and `x_n` lies in the interval `term`.
+///
+/// If no such nonnegative integer `n` exists, then the iteration range
+/// is empty.
+///
+fn range_step_core(start: $T, stop: $T, step: $T_SIGNED, r: Range, it: &fn($T) -> bool) -> bool {
     let mut i = start;
     if step == 0 {
         fail!("range_step called with step == 0");
-    }
-    if step >= 0 {
+    } else if step == (1 as $T_SIGNED) { // elide bounds check to tighten loop
+        while i < stop {
+            if !it(i) { return false; }
+            // no need for overflow check;
+            // cannot have i + 1 > max_value because i < stop <= max_value
+            i += (1 as $T);
+        }
+    } else if step == (-1 as $T_SIGNED) { // elide bounds check to tighten loop
+        while i > stop {
+            if !it(i) { return false; }
+            // no need for underflow check;
+            // cannot have i - 1 < min_value because i > stop >= min_value
+            i -= (1 as $T);
+        }
+    } else if step > 0 { // ascending
         while i < stop {
             if !it(i) { return false; }
             // avoiding overflow. break if i + step > max_value
             if i > max_value - (step as $T) { return true; }
             i += step as $T;
         }
-    } else {
+    } else { // descending
         while i > stop {
             if !it(i) { return false; }
             // avoiding underflow. break if i + step < min_value
@@ -63,7 +77,52 @@ pub fn range_step(start: $T, stop: $T, step: $T_SIGNED, it: &fn($T) -> bool) -> 
             i -= -step as $T;
         }
     }
-    return true;
+    match r {
+        HalfOpen => return true,
+        Closed => return (i != stop || it(i))
+    }
+}
+
+#[inline]
+///
+/// Iterate through the range [`start`..`stop`) with a given step value.
+///
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// - `x_i == start + step*i`, and
+/// - `n` is the greatest nonnegative integer such that `x_n < stop`
+///
+/// (If no such `n` exists, then the iteration range is empty.)
+///
+/// # Arguments
+///
+/// * `start` - lower bound, inclusive
+/// * `stop` - higher bound, exclusive
+///
+/// # Examples
+/// ~~~ {.rust}
+/// let nums = [1,2,3,4,5,6,7];
+///
+/// for uint::range_step(0, nums.len() - 1, 2) |i| {
+///     println(fmt!("%d & %d", nums[i], nums[i+1]));
+/// }
+/// ~~~
+///
+pub fn range_step(start: $T, stop: $T, step: $T_SIGNED, it: &fn($T) -> bool) -> bool {
+    range_step_core(start, stop, step, HalfOpen, it)
+}
+
+#[inline]
+///
+/// Iterate through a range with a given step value.
+///
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// `x_i == start + step*i` and `x_n <= last < step + x_n`.
+///
+/// (If no such nonnegative integer `n` exists, then the iteration
+///  range is empty.)
+///
+pub fn range_step_inclusive(start: $T, last: $T, step: $T_SIGNED, it: &fn($T) -> bool) -> bool {
+    range_step_core(start, last, step, Closed, it)
 }
 
 #[inline]

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -203,14 +203,14 @@ impl<T> Option<T> {
     /// Apply a function to the contained value or do nothing
     pub fn mutate(&mut self, f: &fn(T) -> T) {
         if self.is_some() {
-            *self = Some(f(self.swap_unwrap()));
+            *self = Some(f(self.take_unwrap()));
         }
     }
 
     /// Apply a function to the contained value or set it to a default
     pub fn mutate_default(&mut self, def: T, f: &fn(T) -> T) {
         if self.is_some() {
-            *self = Some(f(self.swap_unwrap()));
+            *self = Some(f(self.take_unwrap()));
         } else {
             *self = Some(def);
         }
@@ -293,8 +293,8 @@ impl<T> Option<T> {
      * Fails if the value equals `None`.
      */
     #[inline]
-    pub fn swap_unwrap(&mut self) -> T {
-        if self.is_none() { fail!("option::swap_unwrap none") }
+    pub fn take_unwrap(&mut self) -> T {
+        if self.is_none() { fail!("option::take_unwrap none") }
         util::replace(self, None).unwrap()
     }
 
@@ -460,7 +460,7 @@ fn test_option_dance() {
     let mut y = Some(5);
     let mut y2 = 0;
     for x.iter().advance |_x| {
-        y2 = y.swap_unwrap();
+        y2 = y.take_unwrap();
     }
     assert_eq!(y2, 5);
     assert!(y.is_none());
@@ -468,8 +468,8 @@ fn test_option_dance() {
 #[test] #[should_fail] #[ignore(cfg(windows))]
 fn test_option_too_much_dance() {
     let mut y = Some(util::NonCopyable);
-    let _y2 = y.swap_unwrap();
-    let _y3 = y.swap_unwrap();
+    let _y2 = y.take_unwrap();
+    let _y3 = y.take_unwrap();
 }
 
 #[test]

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -127,7 +127,7 @@ impl Task {
 
         // Wait for children. Possibly report the exit status.
         let local_success = !self.unwinder.unwinding;
-        let join_latch = self.join_latch.swap_unwrap();
+        let join_latch = self.join_latch.take_unwrap();
         match self.on_exit {
             Some(ref on_exit) => {
                 let success = join_latch.wait(local_success);

--- a/src/libstd/rt/tube.rs
+++ b/src/libstd/rt/tube.rs
@@ -53,7 +53,7 @@ impl<T> Tube<T> {
             if (*state).blocked_task.is_some() {
                 // There's a waiting task. Wake it up
                 rtdebug!("waking blocked tube");
-                let task = (*state).blocked_task.swap_unwrap();
+                let task = (*state).blocked_task.take_unwrap();
                 let sched = Local::take::<Scheduler>();
                 sched.resume_task_immediately(task);
             }

--- a/src/libstd/rt/uv/async.rs
+++ b/src/libstd/rt/uv/async.rs
@@ -62,7 +62,7 @@ impl AsyncWatcher {
             let mut watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
             {
                 let data = watcher.get_watcher_data();
-                data.close_cb.swap_unwrap()();
+                data.close_cb.take_unwrap()();
             }
             watcher.drop_watcher_data();
             unsafe { uvll::free_handle(handle as *c_void); }

--- a/src/libstd/rt/uv/idle.rs
+++ b/src/libstd/rt/uv/idle.rs
@@ -73,7 +73,7 @@ impl IdleWatcher {
                 let mut idle_watcher: IdleWatcher = NativeHandle::from_native_handle(handle);
                 {
                     let data = idle_watcher.get_watcher_data();
-                    data.close_cb.swap_unwrap()();
+                    data.close_cb.take_unwrap()();
                 }
                 idle_watcher.drop_watcher_data();
                 uvll::idle_delete(handle);

--- a/src/libstd/rt/uv/net.rs
+++ b/src/libstd/rt/uv/net.rs
@@ -209,7 +209,7 @@ impl StreamWatcher {
             let write_request: WriteRequest = NativeHandle::from_native_handle(req);
             let mut stream_watcher = write_request.stream();
             write_request.delete();
-            let cb = stream_watcher.get_watcher_data().write_cb.swap_unwrap();
+            let cb = stream_watcher.get_watcher_data().write_cb.take_unwrap();
             let status = status_to_maybe_uv_error(stream_watcher.native_handle(), status);
             cb(stream_watcher, status);
         }
@@ -233,7 +233,7 @@ impl StreamWatcher {
 
         extern fn close_cb(handle: *uvll::uv_stream_t) {
             let mut stream_watcher: StreamWatcher = NativeHandle::from_native_handle(handle);
-            stream_watcher.get_watcher_data().close_cb.swap_unwrap()();
+            stream_watcher.get_watcher_data().close_cb.take_unwrap()();
             stream_watcher.drop_watcher_data();
             unsafe { free_handle(handle as *c_void) }
         }
@@ -301,7 +301,7 @@ impl TcpWatcher {
                 let connect_request: ConnectRequest = NativeHandle::from_native_handle(req);
                 let mut stream_watcher = connect_request.stream();
                 connect_request.delete();
-                let cb = stream_watcher.get_watcher_data().connect_cb.swap_unwrap();
+                let cb = stream_watcher.get_watcher_data().connect_cb.take_unwrap();
                 let status = status_to_maybe_uv_error(stream_watcher.native_handle(), status);
                 cb(stream_watcher, status);
             }
@@ -438,7 +438,7 @@ impl UdpWatcher {
             let send_request: UdpSendRequest = NativeHandle::from_native_handle(req);
             let mut udp_watcher = send_request.handle();
             send_request.delete();
-            let cb = udp_watcher.get_watcher_data().udp_send_cb.swap_unwrap();
+            let cb = udp_watcher.get_watcher_data().udp_send_cb.take_unwrap();
             let status = status_to_maybe_uv_error(udp_watcher.native_handle(), status);
             cb(udp_watcher, status);
         }
@@ -456,7 +456,7 @@ impl UdpWatcher {
 
         extern fn close_cb(handle: *uvll::uv_udp_t) {
             let mut udp_watcher: UdpWatcher = NativeHandle::from_native_handle(handle);
-            udp_watcher.get_watcher_data().close_cb.swap_unwrap()();
+            udp_watcher.get_watcher_data().close_cb.take_unwrap()();
             udp_watcher.drop_watcher_data();
             unsafe { free_handle(handle as *c_void) }
         }

--- a/src/libstd/rt/uv/timer.rs
+++ b/src/libstd/rt/uv/timer.rs
@@ -70,7 +70,7 @@ impl TimerWatcher {
             let mut watcher: TimerWatcher = NativeHandle::from_native_handle(handle);
             {
                 let data = watcher.get_watcher_data();
-                data.close_cb.swap_unwrap()();
+                data.close_cb.take_unwrap()();
             }
             watcher.drop_watcher_data();
             unsafe {

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -669,7 +669,7 @@ fn spawn_process_os(prog: &str, args: &[~str],
             fail!("failure in dup3(err_fd, 2): %s", os::last_os_error());
         }
         // close all other fds
-        for int::range_rev(getdtablesize() as int - 1, 2) |fd| {
+        for int::range_rev(getdtablesize() as int, 3) |fd| {
             close(fd as c_int);
         }
 

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -302,7 +302,7 @@ fn each_ancestor(list:        &mut AncestorList,
         fn with_parent_tg<U>(parent_group: &mut Option<TaskGroupArc>,
                              blk: &fn(TaskGroupInner) -> U) -> U {
             // If this trips, more likely the problem is 'blk' failed inside.
-            let tmp_arc = parent_group.swap_unwrap();
+            let tmp_arc = parent_group.take_unwrap();
             let result = do access_group(&tmp_arc) |tg_opt| { blk(tg_opt) };
             *parent_group = Some(tmp_arc);
             result
@@ -609,7 +609,7 @@ fn spawn_raw_newsched(mut opts: TaskOpts, f: ~fn()) {
     };
 
     if opts.notify_chan.is_some() {
-        let notify_chan = opts.notify_chan.swap_unwrap();
+        let notify_chan = opts.notify_chan.take_unwrap();
         let notify_chan = Cell::new(notify_chan);
         let on_exit: ~fn(bool) = |success| {
             notify_chan.take().send(
@@ -647,7 +647,7 @@ fn spawn_raw_oldsched(mut opts: TaskOpts, f: ~fn()) {
             let notify_chan = if opts.notify_chan.is_none() {
                 None
             } else {
-                Some(opts.notify_chan.swap_unwrap())
+                Some(opts.notify_chan.take_unwrap())
             };
 
             let child_wrapper = make_child_wrapper(new_task, child_tg,

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -462,7 +462,7 @@ mod tests {
             m.insert(x, x / 2);
         }
 
-        let mut n = uint::max_value - 9999;
+        let mut n = uint::max_value - 10000;
         for m.each |k, v| {
             if n == uint::max_value - 5000 { break }
             assert!(n < uint::max_value - 5000);
@@ -499,7 +499,7 @@ mod tests {
             m.insert(x, x / 2);
         }
 
-        let mut n = uint::max_value;
+        let mut n = uint::max_value - 1;
         for m.each_reverse |k, v| {
             if n == uint::max_value - 5000 { break }
             assert!(n > uint::max_value - 5000);

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -261,7 +261,7 @@ impl<T> TrieNode<T> {
 
     fn each_reverse<'a>(&'a self, f: &fn(&uint, &'a T) -> bool) -> bool {
         for uint::range_rev(self.children.len(), 0) |idx| {
-            match self.children[idx - 1] {
+            match self.children[idx] {
                 Internal(ref x) => if !x.each_reverse(|i,t| f(i,t)) { return false },
                 External(k, ref v) => if !f(&k, v) { return false },
                 Nothing => ()

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -215,15 +215,16 @@ pub enum meta_item_ {
     meta_name_value(@str, lit),
 }
 
-pub type blk = spanned<blk_>;
+//pub type blk = spanned<blk_>;
 
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
-pub struct blk_ {
+pub struct blk {
     view_items: ~[view_item],
     stmts: ~[@stmt],
     expr: Option<@expr>,
     id: node_id,
     rules: blk_check_mode,
+    span: span,
 }
 
 #[deriving(Eq, Encodable, Decodable,IterBytes)]

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -190,7 +190,7 @@ pub fn map_fn(
 }
 
 pub fn map_block(b: &blk, (cx,v): (@mut Ctx, visit::vt<@mut Ctx>)) {
-    cx.map.insert(b.node.id, node_block(/* FIXME (#2543) */ copy *b));
+    cx.map.insert(b.id, node_block(/* FIXME (#2543) */ copy *b));
     visit::visit_block(b, (cx, v));
 }
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -11,7 +11,7 @@
 use ast::*;
 use ast;
 use ast_util;
-use codemap::{span, spanned};
+use codemap::{span, dummy_sp};
 use opt_vec;
 use parse::token;
 use visit;
@@ -194,21 +194,23 @@ pub fn is_call_expr(e: @expr) -> bool {
 }
 
 pub fn block_from_expr(e: @expr) -> blk {
-    let blk_ = default_block(~[], option::Some::<@expr>(e), e.id);
-    return spanned {node: blk_, span: e.span};
+    let mut blk = default_block(~[], option::Some::<@expr>(e), e.id);
+    blk.span = e.span;
+    return blk;
 }
 
 pub fn default_block(
     stmts1: ~[@stmt],
     expr1: Option<@expr>,
     id1: node_id
-) -> blk_ {
-    ast::blk_ {
+) -> blk {
+    ast::blk {
         view_items: ~[],
         stmts: stmts1,
         expr: expr1,
         id: id1,
         rules: default_blk,
+        span: dummy_sp(),
     }
 }
 
@@ -437,7 +439,7 @@ pub fn id_visitor<T: Copy>(vfn: @fn(node_id, T)) -> visit::vt<T> {
             visit::visit_local(l, (t, vt));
         },
         visit_block: |b, (t, vt)| {
-            vfn(b.node.id, copy t);
+            vfn(b.id, copy t);
             visit::visit_block(b, (t, vt));
         },
         visit_stmt: |s, (t, vt)| {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -400,14 +400,14 @@ impl AstBuilder for @ExtCtxt {
                view_items: ~[ast::view_item],
                stmts: ~[@ast::stmt],
                expr: Option<@ast::expr>) -> ast::blk {
-        respan(span,
-               ast::blk_ {
-                   view_items: view_items,
-                   stmts: stmts,
-                   expr: expr,
-                   id: self.next_id(),
-                   rules: ast::default_blk,
-               })
+           ast::blk {
+               view_items: view_items,
+               stmts: stmts,
+               expr: expr,
+               id: self.next_id(),
+               rules: ast::default_blk,
+               span: span,
+           }
     }
 
     fn expr(&self, span: span, node: ast::expr_) -> @ast::expr {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{blk_, crate, expr_, expr_mac, mac_invoc_tt};
+use ast::{blk, crate, expr_, expr_mac, mac_invoc_tt};
 use ast::{item_mac, stmt_, stmt_mac, stmt_expr, stmt_semi};
 use ast::{illegal_ctxt};
 use ast;
@@ -394,13 +394,12 @@ pub fn new_name_finder() -> @Visitor<@mut ~[ast::ident]> {
 
 pub fn expand_block(extsbox: @mut SyntaxEnv,
                     _cx: @ExtCtxt,
-                    blk: &blk_,
-                    sp: span,
+                    blk: &blk,
                     fld: @ast_fold,
-                    orig: @fn(&blk_, span, @ast_fold) -> (blk_, span))
-                 -> (blk_, span) {
+                    orig: @fn(&blk, @ast_fold) -> blk)
+                 -> blk {
     // see note below about treatment of exts table
-    with_exts_frame!(extsbox,false,orig(blk,sp,fld))
+    with_exts_frame!(extsbox,false,orig(blk,fld))
 }
 
 
@@ -736,8 +735,8 @@ pub fn expand_crate(parse_sess: @mut parse::ParseSess,
             expand_item(extsbox, cx, item, recur, afp.fold_item),
         fold_stmt: |stmt,span,recur|
             expand_stmt(extsbox, cx, stmt, span, recur, afp.fold_stmt),
-        fold_block: |blk,span,recur|
-            expand_block(extsbox, cx, blk, span, recur, afp.fold_block),
+        fold_block: |blk,recur|
+            expand_block(extsbox, cx, blk, recur, afp.fold_block),
         new_span: |a| new_span(cx, a),
         .. *afp};
     let f = make_fold(f_pre);

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -13,7 +13,6 @@
  */
 
 use ast;
-use codemap;
 
 // does this expression require a semicolon to be treated
 // as a statement? The negation of this: 'can this expression
@@ -40,8 +39,7 @@ pub fn expr_requires_semi_to_be_stmt(e: @ast::expr) -> bool {
 pub fn expr_is_simple_block(e: @ast::expr) -> bool {
     match e.node {
         ast::expr_block(
-            codemap::spanned {
-                node: ast::blk_ { rules: ast::default_blk, _ }, _ }
+            ast::blk { rules: ast::default_blk, _ }
         ) => true,
       _ => false
     }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -557,27 +557,26 @@ mod test {
                                         lifetimes: opt_vec::Empty,
                                         ty_params: opt_vec::Empty,
                                     },
-                                    spanned{
+                                    ast::blk {
+                                        view_items: ~[],
+                                        stmts: ~[@spanned{
+                                            node: ast::stmt_semi(@ast::expr{
+                                                id: 6,
+                                                node: ast::expr_path(
+                                                      ast::Path{
+                                                        span:sp(17,18),
+                                                        global:false,
+                                                        idents:~[str_to_ident("b")],
+                                                        rp:None,
+                                                        types: ~[]}),
+                                                span: sp(17,18)},
+                                                                 7), // fixme
+                                            span: sp(17,18)}],
+                                        expr: None,
+                                        id: 8, // fixme
+                                        rules: ast::default_blk, // no idea
                                         span: sp(15,21),
-                                        node: ast::blk_{
-                                            view_items: ~[],
-                                            stmts: ~[@spanned{
-                                                node: ast::stmt_semi(@ast::expr{
-                                                    id: 6,
-                                                    node: ast::expr_path(
-                                                          ast::Path{
-                                                            span:sp(17,18),
-                                                            global:false,
-                                                            idents:~[str_to_ident("b")],
-                                                            rp:None,
-                                                            types: ~[]}),
-                                                    span: sp(17,18)},
-                                                                     7), // fixme
-                                                span: sp(17,18)}],
-                                            expr: None,
-                                            id: 8, // fixme
-                                            rules: ast::default_blk // no idea
-                                        }}),
+                                    }),
                             vis: ast::inherited,
                             span: sp(0,21)}));
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2245,15 +2245,15 @@ impl Parser {
         let lo = self.last_span.lo;
         let decl = parse_decl();
         let body = parse_body();
-        let fakeblock = ast::blk_ {
+        let fakeblock = ast::blk {
             view_items: ~[],
             stmts: ~[],
             expr: Some(body),
             id: self.get_id(),
             rules: default_blk,
+            span: body.span,
         };
-        let fakeblock = spanned(body.span.lo, body.span.hi,
-                                fakeblock);
+
         return self.mk_expr(lo, body.span.hi,
                             expr_fn_block(decl, fakeblock));
     }
@@ -2402,14 +2402,12 @@ impl Parser {
                 self.eat(&token::COMMA);
             }
 
-            let blk = codemap::spanned {
-                node: ast::blk_ {
-                    view_items: ~[],
-                    stmts: ~[],
-                    expr: Some(expr),
-                    id: self.get_id(),
-                    rules: default_blk,
-                },
+            let blk = ast::blk {
+                view_items: ~[],
+                stmts: ~[],
+                expr: Some(expr),
+                id: self.get_id(),
+                rules: default_blk,
                 span: expr.span,
             };
 
@@ -3120,14 +3118,14 @@ impl Parser {
 
         let hi = self.span.hi;
         self.bump();
-        let bloc = ast::blk_ {
+        ast::blk {
             view_items: view_items,
             stmts: stmts,
             expr: expr,
             id: self.get_id(),
             rules: s,
-        };
-        spanned(lo, hi, bloc)
+            span: mk_sp(lo, hi),
+        }
     }
 
     fn parse_optional_purity(&self) -> ast::purity {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -932,7 +932,7 @@ pub fn print_possibly_embedded_block_(s: @ps,
                                       indented: uint,
                                       attrs: &[ast::attribute],
                                       close_box: bool) {
-    match blk.node.rules {
+    match blk.rules {
       ast::unsafe_blk => word_space(s, "unsafe"),
       ast::default_blk => ()
     }
@@ -946,11 +946,11 @@ pub fn print_possibly_embedded_block_(s: @ps,
 
     print_inner_attributes(s, attrs);
 
-    for blk.node.view_items.iter().advance |vi| { print_view_item(s, vi); }
-    for blk.node.stmts.iter().advance |st| {
+    for blk.view_items.iter().advance |vi| { print_view_item(s, vi); }
+    for blk.stmts.iter().advance |st| {
         print_stmt(s, *st);
     }
-    match blk.node.expr {
+    match blk.expr {
       Some(expr) => {
         space_if_not_bol(s);
         print_expr(s, expr);
@@ -1255,12 +1255,12 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
 
             // Extract the expression from the extra block the parser adds
             // in the case of foo => expr
-            if arm.body.node.view_items.is_empty() &&
-                arm.body.node.stmts.is_empty() &&
-                arm.body.node.rules == ast::default_blk &&
-                arm.body.node.expr.is_some()
+            if arm.body.view_items.is_empty() &&
+                arm.body.stmts.is_empty() &&
+                arm.body.rules == ast::default_blk &&
+                arm.body.expr.is_some()
             {
-                match arm.body.node.expr {
+                match arm.body.expr {
                     Some(expr) => {
                         match expr.node {
                             ast::expr_block(ref blk) => {
@@ -1297,16 +1297,16 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
         print_fn_block_args(s, decl);
         space(s.s);
         // }
-        assert!(body.node.stmts.is_empty());
-        assert!(body.node.expr.is_some());
+        assert!(body.stmts.is_empty());
+        assert!(body.expr.is_some());
         // we extract the block, so as not to create another set of boxes
-        match body.node.expr.get().node {
+        match body.expr.get().node {
             ast::expr_block(ref blk) => {
                 print_block_unclosed(s, blk);
             }
             _ => {
                 // this is a bare expression
-                print_expr(s, body.node.expr.get());
+                print_expr(s, body.expr.get());
                 end(s); // need to close a box
             }
         }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -413,13 +413,13 @@ pub fn visit_struct_field<E: Copy>(sf: &struct_field, (e, v): (E, vt<E>)) {
 }
 
 pub fn visit_block<E: Copy>(b: &blk, (e, v): (E, vt<E>)) {
-    for b.node.view_items.iter().advance |vi| {
+    for b.view_items.iter().advance |vi| {
         (v.visit_view_item)(vi, (copy e, v));
     }
-    for b.node.stmts.iter().advance |s| {
+    for b.stmts.iter().advance |s| {
         (v.visit_stmt)(*s, (copy e, v));
     }
-    visit_expr_opt(b.node.expr, (e, v));
+    visit_expr_opt(b.expr, (e, v));
 }
 
 pub fn visit_stmt<E>(s: &stmt, (e, v): (E, vt<E>)) {

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -60,8 +60,8 @@ fn thread_ring(i: uint, count: uint, num_chan: pipe, num_port: pipe) {
     // Send/Receive lots of messages.
     for uint::range(0u, count) |j| {
         //error!("task %?, iter %?", i, j);
-        let mut num_chan2 = num_chan.swap_unwrap();
-        let mut num_port2 = num_port.swap_unwrap();
+        let mut num_chan2 = num_chan.take_unwrap();
+        let mut num_port2 = num_port.take_unwrap();
         send(&num_chan2, i * j);
         num_chan = Some(num_chan2);
         let _n = recv(&num_port2);

--- a/src/test/bench/msgsend-ring-rw-arcs.rs
+++ b/src/test/bench/msgsend-ring-rw-arcs.rs
@@ -56,8 +56,8 @@ fn thread_ring(i: uint, count: uint, num_chan: pipe, num_port: pipe) {
     // Send/Receive lots of messages.
     for uint::range(0u, count) |j| {
         //error!("task %?, iter %?", i, j);
-        let mut num_chan2 = num_chan.swap_unwrap();
-        let mut num_port2 = num_port.swap_unwrap();
+        let mut num_chan2 = num_chan.take_unwrap();
+        let mut num_port2 = num_port.take_unwrap();
         send(&num_chan2, i * j);
         num_chan = Some(num_chan2);
         let _n = recv(&num_port2);

--- a/src/test/run-pass/enum-vec-initializer.rs
+++ b/src/test/run-pass/enum-vec-initializer.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Flopsy {
+    Bunny = 2
+}
+
+static BAR:uint = Bunny as uint;
+static BAR2:uint = BAR;
+
+fn main() {
+    let v = [0, .. Bunny as uint];
+    let v = [0, .. BAR];
+    let v = [0, .. BAR2];
+    static BAR3:uint = BAR2;
+    let v = [0, .. BAR3];
+}

--- a/src/test/run-pass/num-range-rev.rs
+++ b/src/test/run-pass/num-range-rev.rs
@@ -40,13 +40,13 @@ pub fn main() {
     // int and uint have same result for
     //   Sum{100 > i >= 2} == (Sum{1 <= i <= 99} - 1) == n*(n+1)/2 - 1 for n=99
     let mut sum = 0u;
-    for uint_range_rev(99, 1) |i| {
+    for uint_range_rev(100, 2) |i| {
         sum += i;
     }
     assert_eq!(sum, 4949);
 
     let mut sum = 0i;
-    for int_range_rev(99, 1) |i| {
+    for int_range_rev(100, 2) |i| {
         sum += i;
     }
     assert_eq!(sum, 4949);
@@ -55,17 +55,17 @@ pub fn main() {
     // elements are visited in correct order
     let primes = [2,3,5,7,11];
     let mut prod = 1i;
-    for uint_range_rev(4, 0) |i| {
+    for uint_range_rev(5, 0) |i| {
         println(fmt!("uint 4 downto 0: %u", i));
         prod *= int::pow(primes[i], i);
     }
-    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3);
+    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3*1);
     let mut prod = 1i;
-    for int_range_rev(4, 0) |i| {
+    for int_range_rev(5, 0) |i| {
         println(fmt!("int 4 downto 0: %d", i));
         prod *= int::pow(primes[i], i as uint);
     }
-    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3);
+    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3*1);
 
 
     // range and range_rev are symmetric.
@@ -74,7 +74,7 @@ pub fn main() {
         sum_up += i;
     }
     let mut sum_down = 0u;
-    for uint_range_rev(29, 9) |i| {
+    for uint_range_rev(30, 10) |i| {
         sum_down += i;
     }
     assert_eq!(sum_up, sum_down);
@@ -84,7 +84,7 @@ pub fn main() {
         sum_up += i;
     }
     let mut sum_down = 0;
-    for int_range_rev(9, -21) |i| {
+    for int_range_rev(10, -20) |i| {
         sum_down += i;
     }
     assert_eq!(sum_up, sum_down);
@@ -96,7 +96,7 @@ pub fn main() {
     }
 
     for uint_range_rev(0, 1) |_| {
-        // fail!("range should be empty when start-1 underflows");
+        fail!("range should be empty when start-1 underflows");
     }
 
     // range iterations do not wrap/underflow

--- a/src/test/run-pass/num-range-rev.rs
+++ b/src/test/run-pass/num-range-rev.rs
@@ -1,0 +1,114 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::int;
+use std::uint;
+
+fn uint_range(lo: uint, hi: uint, it: &fn(uint) -> bool) -> bool {
+    uint::range(lo, hi, it)
+}
+
+fn int_range(lo: int,  hi: int, it: &fn(int) -> bool) -> bool {
+    int::range(lo, hi, it)
+}
+
+fn uint_range_rev(hi: uint, lo: uint, it: &fn(uint) -> bool) -> bool {
+    uint::range_rev(hi, lo, it)
+}
+
+fn int_range_rev(hi: int,  lo: int, it: &fn(int) -> bool) -> bool {
+    int::range_rev(hi, lo, it)
+}
+
+fn int_range_step(a: int, b: int, step: int, it: &fn(int) -> bool) -> bool {
+    int::range_step(a, b, step, it)
+}
+
+fn uint_range_step(a: uint, b: uint, step: int, it: &fn(uint) -> bool) -> bool {
+    uint::range_step(a, b, step, it)
+}
+
+
+pub fn main() {
+    // int and uint have same result for
+    //   Sum{100 > i >= 2} == (Sum{1 <= i <= 99} - 1) == n*(n+1)/2 - 1 for n=99
+    let mut sum = 0u;
+    for uint_range_rev(99, 1) |i| {
+        sum += i;
+    }
+    assert_eq!(sum, 4949);
+
+    let mut sum = 0i;
+    for int_range_rev(99, 1) |i| {
+        sum += i;
+    }
+    assert_eq!(sum, 4949);
+
+
+    // elements are visited in correct order
+    let primes = [2,3,5,7,11];
+    let mut prod = 1i;
+    for uint_range_rev(4, 0) |i| {
+        println(fmt!("uint 4 downto 0: %u", i));
+        prod *= int::pow(primes[i], i);
+    }
+    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3);
+    let mut prod = 1i;
+    for int_range_rev(4, 0) |i| {
+        println(fmt!("int 4 downto 0: %d", i));
+        prod *= int::pow(primes[i], i as uint);
+    }
+    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3);
+
+
+    // range and range_rev are symmetric.
+    let mut sum_up = 0u;
+    for uint_range(10, 30) |i| {
+        sum_up += i;
+    }
+    let mut sum_down = 0u;
+    for uint_range_rev(29, 9) |i| {
+        sum_down += i;
+    }
+    assert_eq!(sum_up, sum_down);
+
+    let mut sum_up = 0;
+    for int_range(-20, 10) |i| {
+        sum_up += i;
+    }
+    let mut sum_down = 0;
+    for int_range_rev(9, -21) |i| {
+        sum_down += i;
+    }
+    assert_eq!(sum_up, sum_down);
+
+
+    // empty ranges
+    for int_range_rev(10, 10) |_| {
+        fail!("range should be empty when start == stop");
+    }
+
+    for uint_range_rev(0, 1) |_| {
+        // fail!("range should be empty when start-1 underflows");
+    }
+
+    // range iterations do not wrap/underflow
+    let mut uflo_loop_visited = ~[];
+    for int_range_step(int::min_value+15, int::min_value, -4) |x| {
+        uflo_loop_visited.push(x - int::min_value);
+    }
+    assert_eq!(uflo_loop_visited, ~[15, 11, 7, 3]);
+
+    let mut uflo_loop_visited = ~[];
+    for uint_range_step(uint::min_value+15, uint::min_value, -4) |x| {
+        uflo_loop_visited.push(x - uint::min_value);
+    }
+    assert_eq!(uflo_loop_visited, ~[15, 11, 7, 3]);
+}

--- a/src/test/run-pass/num-range.rs
+++ b/src/test/run-pass/num-range.rs
@@ -1,0 +1,119 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::int;
+use std::uint;
+
+fn uint_range(lo: uint, hi: uint, it: &fn(uint) -> bool) -> bool {
+    uint::range(lo, hi, it)
+}
+
+fn int_range(lo: int, hi: int, it: &fn(int) -> bool) -> bool {
+    int::range(lo, hi, it)
+}
+
+fn int_range_step(a: int, b: int, step: int, it: &fn(int) -> bool) -> bool {
+    int::range_step(a, b, step, it)
+}
+
+fn uint_range_step(a: uint, b: uint, s: int, it: &fn(uint) -> bool) -> bool {
+    uint::range_step(a, b, s, it)
+}
+
+pub fn main() {
+    println(fmt!("num-range start"));
+    // int and uint have same result for
+    //   Sum{2 <= i < 100} == (Sum{1 <= i <= 99} - 1) == n*(n+1)/2 - 1 for n=99
+    let mut sum = 0u;
+    for uint_range(2, 100) |i| {
+        sum += i;
+    }
+    assert_eq!(sum, 4949);
+
+    let mut sum = 0i;
+    for int_range(2, 100) |i| {
+        sum += i;
+    }
+    assert_eq!(sum, 4949);
+
+
+    // elements are visited in correct order
+    let primes = [2,3,5,7];
+    let mut prod = 1i;
+    for uint_range(0, 4) |i| {
+        prod *= int::pow(primes[i], i);
+    }
+    assert_eq!(prod, 1*3*5*5*7*7*7);
+    let mut prod = 1i;
+    for int_range(0, 4) |i| {
+        prod *= int::pow(primes[i], i as uint);
+    }
+    assert_eq!(prod, 1*3*5*5*7*7*7);
+
+
+    // empty ranges
+    for int_range(10, 10) |_| {
+        fail!("range should be empty when start == stop");
+    }
+
+    for uint_range(10, 10) |_| {
+        fail!("range should be empty when start == stop");
+    }
+
+
+    // range iterations do not wrap/overflow
+    let mut oflo_loop_visited = ~[];
+    for uint_range_step(uint::max_value-15, uint::max_value, 4) |x| {
+        oflo_loop_visited.push(uint::max_value - x);
+    }
+    assert_eq!(oflo_loop_visited, ~[15, 11, 7, 3]);
+
+    let mut oflo_loop_visited = ~[];
+    for int_range_step(int::max_value-15, int::max_value, 4) |x| {
+        oflo_loop_visited.push(int::max_value - x);
+    }
+    assert_eq!(oflo_loop_visited, ~[15, 11, 7, 3]);
+
+
+    // range_step never passes nor visits the stop element
+    for int_range_step(0, 21, 3) |x| {
+        assert!(x < 21);
+    }
+
+    // range_step_inclusive will never pass stop element, and may skip it.
+    let mut saw21 = false;
+    for uint::range_step_inclusive(0, 21, 4) |x| {
+        assert!(x <= 21);
+        if x == 21 { saw21 = true; }
+    }
+    assert!(!saw21);
+    let mut saw21 = false;
+    for int::range_step_inclusive(0, 21, 4) |x| {
+        assert!(x <= 21);
+        if x == 21 { saw21 = true; }
+    }
+    assert!(!saw21);
+
+    // range_step_inclusive will never pass stop element, but may visit it.
+    let mut saw21 = false;
+    for uint::range_step_inclusive(0, 21, 3) |x| {
+        assert!(x <= 21);
+        println(fmt!("saw: %u", x));
+        if x == 21 { saw21 = true; }
+    }
+    assert!(saw21);
+    let mut saw21 = false;
+    for int::range_step_inclusive(0, 21, 3) |x| {
+        assert!(x <= 21);
+        if x == 21 { saw21 = true; }
+    }
+    assert!(saw21);
+
+}


### PR DESCRIPTION
This is the first of a series of refactorings to get rid of the `codemap::spanned<T>` struct (see this thread for more information: https://mail.mozilla.org/pipermail/rust-dev/2013-July/004798.html).

The changes in this PR should not change any semantics, just rename `ast::blk_` to `ast::blk` and add a span field to it. 95% of the changes were of the form `block.node.id` -> `block.id`. Only some transformations in `libsyntax::fold` where not entirely trivial.
