### PR TITLE
Permit C-style enums in vector repeat length expressions (N.B. values only, not type signatures)

### DIFF
--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -309,7 +309,7 @@ pub fn check_expr(e: @expr, (cx, v): (Context, visit::vt<Context>)) {
                        "explicit copy requires a copyable argument");
         }
         expr_repeat(element, count_expr, _) => {
-            let count = ty::eval_repeat_count(cx.tcx, count_expr);
+            let count = ty::eval_repeat_count(&cx.tcx, count_expr);
             if count > 1 {
                 let element_ty = ty::expr_ty(cx.tcx, element);
                 check_copy(cx, element_ty, element.span,

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -417,7 +417,7 @@ pub fn write_content(bcx: block,
                     return expr::trans_into(bcx, element, Ignore);
                 }
                 SaveIn(lldest) => {
-                    let count = ty::eval_repeat_count(bcx.tcx(), count_expr);
+                    let count = ty::eval_repeat_count(&bcx.tcx(), count_expr);
                     if count == 0 {
                         return bcx;
                     }
@@ -509,7 +509,7 @@ pub fn elements_required(bcx: block, content_expr: &ast::expr) -> uint {
         },
         ast::expr_vec(ref es, _) => es.len(),
         ast::expr_repeat(_, count_expr, _) => {
-            ty::eval_repeat_count(bcx.tcx(), count_expr)
+            ty::eval_repeat_count(&bcx.tcx(), count_expr)
         }
         _ => bcx.tcx().sess.span_bug(content_expr.span,
                                      "Unexpected evec content")

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -479,7 +479,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + 'static>(
         }
       }
       ast::ty_fixed_length_vec(ref a_mt, e) => {
-        match const_eval::eval_const_expr_partial(tcx, e) {
+        match const_eval::eval_const_expr_partial(&tcx, e) {
           Ok(ref r) => {
             match *r {
               const_eval::const_int(i) =>

--- a/src/test/run-pass/enum-vec-initializer.rs
+++ b/src/test/run-pass/enum-vec-initializer.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Flopsy {
+    Bunny = 2
+}
+
+static BAR:uint = Bunny as uint;
+static BAR2:uint = BAR;
+
+fn main() {
+    let v = [0, .. Bunny as uint];
+    let v = [0, .. BAR];
+    let v = [0, .. BAR2];
+    static BAR3:uint = BAR2;
+    let v = [0, .. BAR3];
+}


### PR DESCRIPTION
Allowing them in type signatures is a significant amount of extra work, unfortunately. This also doesn't apply to static values, which takes a different code path.
