### PR TITLE
Make all lang_items optional

### DIFF
--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -122,7 +122,7 @@ fn check_item(item: @item, (cx, visitor): (Context, visit::vt<Context>)) {
                     None => cx.tcx.sess.bug("trait ref not in def map!"),
                     Some(&trait_def) => {
                         let trait_def_id = ast_util::def_id_of_def(trait_def);
-                        if cx.tcx.lang_items.drop_trait() == trait_def_id {
+                        if cx.tcx.lang_items.drop_trait() == Some(trait_def_id) {
                             // Yes, it's a destructor.
                             match self_type.node {
                                 ty_path(_, ref bounds, path_node_id) => {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -153,135 +153,143 @@ impl LanguageItems {
 
     // FIXME #4621: Method macros sure would be nice here.
 
-    pub fn freeze_trait(&self) -> def_id {
-        self.items[FreezeTraitLangItem as uint].get()
-    }
-    pub fn copy_trait(&self) -> def_id {
-        self.items[CopyTraitLangItem as uint].get()
-    }
-    pub fn send_trait(&self) -> def_id {
-        self.items[SendTraitLangItem as uint].get()
-    }
-    pub fn sized_trait(&self) -> def_id {
-        self.items[SizedTraitLangItem as uint].get()
+    pub fn require(&self, it: LangItem) -> Result<def_id, ~str> {
+        match self.items[it as uint] {
+            Some(id) => Ok(id),
+            None => Err(fmt!("requires `%s` lang_item",
+                             LanguageItems::item_name(it as uint)))
+        }
     }
 
-    pub fn drop_trait(&self) -> def_id {
-        self.items[DropTraitLangItem as uint].get()
+    pub fn freeze_trait(&self) -> Option<def_id> {
+        self.items[FreezeTraitLangItem as uint]
+    }
+    pub fn copy_trait(&self) -> Option<def_id> {
+        self.items[CopyTraitLangItem as uint]
+    }
+    pub fn send_trait(&self) -> Option<def_id> {
+        self.items[SendTraitLangItem as uint]
+    }
+    pub fn sized_trait(&self) -> Option<def_id> {
+        self.items[SizedTraitLangItem as uint]
     }
 
-    pub fn add_trait(&self) -> def_id {
-        self.items[AddTraitLangItem as uint].get()
-    }
-    pub fn sub_trait(&self) -> def_id {
-        self.items[SubTraitLangItem as uint].get()
-    }
-    pub fn mul_trait(&self) -> def_id {
-        self.items[MulTraitLangItem as uint].get()
-    }
-    pub fn div_trait(&self) -> def_id {
-        self.items[DivTraitLangItem as uint].get()
-    }
-    pub fn rem_trait(&self) -> def_id {
-        self.items[RemTraitLangItem as uint].get()
-    }
-    pub fn neg_trait(&self) -> def_id {
-        self.items[NegTraitLangItem as uint].get()
-    }
-    pub fn not_trait(&self) -> def_id {
-        self.items[NotTraitLangItem as uint].get()
-    }
-    pub fn bitxor_trait(&self) -> def_id {
-        self.items[BitXorTraitLangItem as uint].get()
-    }
-    pub fn bitand_trait(&self) -> def_id {
-        self.items[BitAndTraitLangItem as uint].get()
-    }
-    pub fn bitor_trait(&self) -> def_id {
-        self.items[BitOrTraitLangItem as uint].get()
-    }
-    pub fn shl_trait(&self) -> def_id {
-        self.items[ShlTraitLangItem as uint].get()
-    }
-    pub fn shr_trait(&self) -> def_id {
-        self.items[ShrTraitLangItem as uint].get()
-    }
-    pub fn index_trait(&self) -> def_id {
-        self.items[IndexTraitLangItem as uint].get()
+    pub fn drop_trait(&self) -> Option<def_id> {
+        self.items[DropTraitLangItem as uint]
     }
 
-    pub fn eq_trait(&self) -> def_id {
-        self.items[EqTraitLangItem as uint].get()
+    pub fn add_trait(&self) -> Option<def_id> {
+        self.items[AddTraitLangItem as uint]
     }
-    pub fn ord_trait(&self) -> def_id {
-        self.items[OrdTraitLangItem as uint].get()
+    pub fn sub_trait(&self) -> Option<def_id> {
+        self.items[SubTraitLangItem as uint]
+    }
+    pub fn mul_trait(&self) -> Option<def_id> {
+        self.items[MulTraitLangItem as uint]
+    }
+    pub fn div_trait(&self) -> Option<def_id> {
+        self.items[DivTraitLangItem as uint]
+    }
+    pub fn rem_trait(&self) -> Option<def_id> {
+        self.items[RemTraitLangItem as uint]
+    }
+    pub fn neg_trait(&self) -> Option<def_id> {
+        self.items[NegTraitLangItem as uint]
+    }
+    pub fn not_trait(&self) -> Option<def_id> {
+        self.items[NotTraitLangItem as uint]
+    }
+    pub fn bitxor_trait(&self) -> Option<def_id> {
+        self.items[BitXorTraitLangItem as uint]
+    }
+    pub fn bitand_trait(&self) -> Option<def_id> {
+        self.items[BitAndTraitLangItem as uint]
+    }
+    pub fn bitor_trait(&self) -> Option<def_id> {
+        self.items[BitOrTraitLangItem as uint]
+    }
+    pub fn shl_trait(&self) -> Option<def_id> {
+        self.items[ShlTraitLangItem as uint]
+    }
+    pub fn shr_trait(&self) -> Option<def_id> {
+        self.items[ShrTraitLangItem as uint]
+    }
+    pub fn index_trait(&self) -> Option<def_id> {
+        self.items[IndexTraitLangItem as uint]
     }
 
-    pub fn str_eq_fn(&self) -> def_id {
-        self.items[StrEqFnLangItem as uint].get()
+    pub fn eq_trait(&self) -> Option<def_id> {
+        self.items[EqTraitLangItem as uint]
     }
-    pub fn uniq_str_eq_fn(&self) -> def_id {
-        self.items[UniqStrEqFnLangItem as uint].get()
+    pub fn ord_trait(&self) -> Option<def_id> {
+        self.items[OrdTraitLangItem as uint]
     }
-    pub fn annihilate_fn(&self) -> def_id {
-        self.items[AnnihilateFnLangItem as uint].get()
+
+    pub fn str_eq_fn(&self) -> Option<def_id> {
+        self.items[StrEqFnLangItem as uint]
     }
-    pub fn log_type_fn(&self) -> def_id {
-        self.items[LogTypeFnLangItem as uint].get()
+    pub fn uniq_str_eq_fn(&self) -> Option<def_id> {
+        self.items[UniqStrEqFnLangItem as uint]
     }
-    pub fn fail_fn(&self) -> def_id {
-        self.items[FailFnLangItem as uint].get()
+    pub fn annihilate_fn(&self) -> Option<def_id> {
+        self.items[AnnihilateFnLangItem as uint]
     }
-    pub fn fail_bounds_check_fn(&self) -> def_id {
-        self.items[FailBoundsCheckFnLangItem as uint].get()
+    pub fn log_type_fn(&self) -> Option<def_id> {
+        self.items[LogTypeFnLangItem as uint]
     }
-    pub fn exchange_malloc_fn(&self) -> def_id {
-        self.items[ExchangeMallocFnLangItem as uint].get()
+    pub fn fail_fn(&self) -> Option<def_id> {
+        self.items[FailFnLangItem as uint]
     }
-    pub fn closure_exchange_malloc_fn(&self) -> def_id {
-        self.items[ClosureExchangeMallocFnLangItem as uint].get()
+    pub fn fail_bounds_check_fn(&self) -> Option<def_id> {
+        self.items[FailBoundsCheckFnLangItem as uint]
     }
-    pub fn exchange_free_fn(&self) -> def_id {
-        self.items[ExchangeFreeFnLangItem as uint].get()
+    pub fn exchange_malloc_fn(&self) -> Option<def_id> {
+        self.items[ExchangeMallocFnLangItem as uint]
     }
-    pub fn malloc_fn(&self) -> def_id {
-        self.items[MallocFnLangItem as uint].get()
+    pub fn closure_exchange_malloc_fn(&self) -> Option<def_id> {
+        self.items[ClosureExchangeMallocFnLangItem as uint]
     }
-    pub fn free_fn(&self) -> def_id {
-        self.items[FreeFnLangItem as uint].get()
+    pub fn exchange_free_fn(&self) -> Option<def_id> {
+        self.items[ExchangeFreeFnLangItem as uint]
     }
-    pub fn borrow_as_imm_fn(&self) -> def_id {
-        self.items[BorrowAsImmFnLangItem as uint].get()
+    pub fn malloc_fn(&self) -> Option<def_id> {
+        self.items[MallocFnLangItem as uint]
     }
-    pub fn borrow_as_mut_fn(&self) -> def_id {
-        self.items[BorrowAsMutFnLangItem as uint].get()
+    pub fn free_fn(&self) -> Option<def_id> {
+        self.items[FreeFnLangItem as uint]
     }
-    pub fn return_to_mut_fn(&self) -> def_id {
-        self.items[ReturnToMutFnLangItem as uint].get()
+    pub fn borrow_as_imm_fn(&self) -> Option<def_id> {
+        self.items[BorrowAsImmFnLangItem as uint]
     }
-    pub fn check_not_borrowed_fn(&self) -> def_id {
-        self.items[CheckNotBorrowedFnLangItem as uint].get()
+    pub fn borrow_as_mut_fn(&self) -> Option<def_id> {
+        self.items[BorrowAsMutFnLangItem as uint]
     }
-    pub fn strdup_uniq_fn(&self) -> def_id {
-        self.items[StrDupUniqFnLangItem as uint].get()
+    pub fn return_to_mut_fn(&self) -> Option<def_id> {
+        self.items[ReturnToMutFnLangItem as uint]
     }
-    pub fn record_borrow_fn(&self) -> def_id {
-        self.items[RecordBorrowFnLangItem as uint].get()
+    pub fn check_not_borrowed_fn(&self) -> Option<def_id> {
+        self.items[CheckNotBorrowedFnLangItem as uint]
     }
-    pub fn unrecord_borrow_fn(&self) -> def_id {
-        self.items[UnrecordBorrowFnLangItem as uint].get()
+    pub fn strdup_uniq_fn(&self) -> Option<def_id> {
+        self.items[StrDupUniqFnLangItem as uint]
     }
-    pub fn start_fn(&self) -> def_id {
-        self.items[StartFnLangItem as uint].get()
+    pub fn record_borrow_fn(&self) -> Option<def_id> {
+        self.items[RecordBorrowFnLangItem as uint]
     }
-    pub fn ty_desc(&const self) -> def_id {
-        self.items[TyDescStructLangItem as uint].get()
+    pub fn unrecord_borrow_fn(&self) -> Option<def_id> {
+        self.items[UnrecordBorrowFnLangItem as uint]
     }
-    pub fn ty_visitor(&const self) -> def_id {
-        self.items[TyVisitorTraitLangItem as uint].get()
+    pub fn start_fn(&self) -> Option<def_id> {
+        self.items[StartFnLangItem as uint]
     }
-    pub fn opaque(&const self) -> def_id {
-        self.items[OpaqueStructLangItem as uint].get()
+    pub fn ty_desc(&self) -> Option<def_id> {
+        self.items[TyDescStructLangItem as uint]
+    }
+    pub fn ty_visitor(&self) -> Option<def_id> {
+        self.items[TyVisitorTraitLangItem as uint]
+    }
+    pub fn opaque(&self) -> Option<def_id> {
+        self.items[OpaqueStructLangItem as uint]
     }
 }
 
@@ -439,23 +447,9 @@ impl<'self> LanguageItemCollector<'self> {
         }
     }
 
-    pub fn check_completeness(&self) {
-        for self.item_refs.iter().advance |(&key, &item_ref)| {
-            match self.items.items[item_ref] {
-                None => {
-                    self.session.err(fmt!("no item found for `%s`", key));
-                }
-                Some(_) => {
-                    // OK.
-                }
-            }
-        }
-    }
-
     pub fn collect(&mut self) {
         self.collect_local_language_items();
         self.collect_external_language_items();
-        self.check_completeness();
     }
 }
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -5268,8 +5268,13 @@ impl Resolver {
 
     pub fn add_fixed_trait_for_expr(@mut self,
                                     expr_id: node_id,
-                                    trait_id: def_id) {
-        self.trait_map.insert(expr_id, @mut ~[trait_id]);
+                                    trait_id: Option<def_id>) {
+        match trait_id {
+            Some(trait_id) => {
+                self.trait_map.insert(expr_id, @mut ~[trait_id]);
+            }
+            None => {}
+        }
     }
 
     pub fn record_def(@mut self, node_id: node_id, def: def) {

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -152,6 +152,7 @@ use back::abi;
 use lib::llvm::{llvm, ValueRef, BasicBlockRef};
 use middle::const_eval;
 use middle::borrowck::root_map_key;
+use middle::lang_items::{UniqStrEqFnLangItem, StrEqFnLangItem};
 use middle::pat_util::*;
 use middle::resolve::DefMap;
 use middle::trans::adt;
@@ -1099,7 +1100,9 @@ pub fn compare_values(cx: block,
             Store(cx, lhs, scratch_lhs);
             let scratch_rhs = alloca(cx, val_ty(rhs), "__rhs");
             Store(cx, rhs, scratch_rhs);
-            let did = cx.tcx().lang_items.uniq_str_eq_fn();
+            let did = langcall(cx, None,
+                               fmt!("comparison of `%s`", cx.ty_to_str(rhs_t)),
+                               UniqStrEqFnLangItem);
             let result = callee::trans_lang_call(cx, did, [scratch_lhs, scratch_rhs], None);
             Result {
                 bcx: result.bcx,
@@ -1107,7 +1110,9 @@ pub fn compare_values(cx: block,
             }
         }
         ty::ty_estr(_) => {
-            let did = cx.tcx().lang_items.str_eq_fn();
+            let did = langcall(cx, None,
+                               fmt!("comparison of `%s`", cx.ty_to_str(rhs_t)),
+                               StrEqFnLangItem);
             let result = callee::trans_lang_call(cx, did, [lhs, rhs], None);
             Result {
                 bcx: result.bcx,

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -17,6 +17,7 @@ use lib::llvm::{ValueRef, BasicBlockRef, BuilderRef};
 use lib::llvm::{True, False, Bool};
 use lib::llvm::{llvm};
 use lib;
+use middle::lang_items::LangItem;
 use middle::trans::base;
 use middle::trans::build;
 use middle::trans::datum;
@@ -1125,4 +1126,18 @@ pub fn filename_and_line_num_from_span(bcx: block,
 // Casts a Rust bool value to an i1.
 pub fn bool_to_i1(bcx: block, llval: ValueRef) -> ValueRef {
     build::ICmp(bcx, lib::llvm::IntNE, llval, C_bool(false))
+}
+
+pub fn langcall(bcx: block, span: Option<span>, msg: &str,
+                li: LangItem) -> ast::def_id {
+    match bcx.tcx().lang_items.require(li) {
+        Ok(id) => id,
+        Err(s) => {
+            let msg = fmt!("%s %s", msg, s);
+            match span {
+                Some(span) => { bcx.tcx().sess.span_fatal(span, msg); }
+                None => { bcx.tcx().sess.fatal(msg); }
+            }
+        }
+    }
 }

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -18,6 +18,7 @@ use back::link::*;
 use driver::session;
 use lib;
 use lib::llvm::{llvm, ValueRef, True};
+use middle::lang_items::{FreeFnLangItem, ExchangeFreeFnLangItem};
 use middle::trans::adt;
 use middle::trans::base::*;
 use middle::trans::callee;
@@ -44,7 +45,7 @@ use syntax::ast;
 pub fn trans_free(cx: block, v: ValueRef) -> block {
     let _icx = push_ctxt("trans_free");
     callee::trans_lang_call(cx,
-        cx.tcx().lang_items.free_fn(),
+        langcall(cx, None, "", FreeFnLangItem),
         [PointerCast(cx, v, Type::i8p())],
         Some(expr::Ignore)).bcx
 }
@@ -52,7 +53,7 @@ pub fn trans_free(cx: block, v: ValueRef) -> block {
 pub fn trans_exchange_free(cx: block, v: ValueRef) -> block {
     let _icx = push_ctxt("trans_exchange_free");
     callee::trans_lang_call(cx,
-        cx.tcx().lang_items.exchange_free_fn(),
+        langcall(cx, None, "", ExchangeFreeFnLangItem),
         [PointerCast(cx, v, Type::i8p())],
         Some(expr::Ignore)).bcx
 }
@@ -365,7 +366,12 @@ pub fn make_visit_glue(bcx: block, v: ValueRef, t: ty::t) -> block {
     let _icx = push_ctxt("make_visit_glue");
     do with_scope(bcx, None, "visitor cleanup") |bcx| {
         let mut bcx = bcx;
-        let (visitor_trait, object_ty) = ty::visitor_object_ty(bcx.tcx());
+        let (visitor_trait, object_ty) = match ty::visitor_object_ty(bcx.tcx()){
+            Ok(pair) => pair,
+            Err(s) => {
+                bcx.tcx().sess.fatal(s);
+            }
+        };
         let v = PointerCast(bcx, v, type_of::type_of(bcx.ccx(), object_ty).ptr_to());
         bcx = reflect::emit_calls_to_trait_visit_ty(bcx, t, v, visitor_trait.def_id);
         // The visitor is a boxed object and needs to be dropped

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -279,7 +279,7 @@ impl Reflector {
             let repr = adt::represent_type(bcx.ccx(), t);
             let variants = ty::substd_enum_variants(ccx.tcx, did, substs);
             let llptrty = type_of(ccx, t).ptr_to();
-            let opaquety = ty::get_opaque_ty(ccx.tcx);
+            let opaquety = ty::get_opaque_ty(ccx.tcx).unwrap();
             let opaqueptrty = ty::mk_ptr(ccx.tcx, ty::mt { ty: opaquety, mutbl: ast::m_imm });
 
             let make_get_disr = || {
@@ -380,7 +380,7 @@ pub fn emit_calls_to_trait_visit_ty(bcx: block,
                                     visitor_trait_id: def_id)
                                  -> block {
     let final = sub_block(bcx, "final");
-    let tydesc_ty = ty::get_tydesc_ty(bcx.ccx().tcx);
+    let tydesc_ty = ty::get_tydesc_ty(bcx.ccx().tcx).unwrap();
     let tydesc_ty = type_of(bcx.ccx(), tydesc_ty);
     let mut r = Reflector {
         visitor_val: visitor_val,

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -13,6 +13,8 @@ use driver::session;
 use metadata::csearch;
 use metadata;
 use middle::const_eval;
+use middle::lang_items::{TyDescStructLangItem, TyVisitorTraitLangItem};
+use middle::lang_items::OpaqueStructLangItem;
 use middle::freevars;
 use middle::resolve::{Impl, MethodInfo};
 use middle::resolve;
@@ -4358,29 +4360,34 @@ pub fn get_impl_id(tcx: ctxt, trait_id: def_id, self_ty: t) -> def_id {
     }
 }
 
-pub fn get_tydesc_ty(tcx: ctxt) -> t {
-    let tydesc_lang_item = tcx.lang_items.ty_desc();
-    tcx.intrinsic_defs.find_copy(&tydesc_lang_item)
-        .expect("Failed to resolve TyDesc")
+pub fn get_tydesc_ty(tcx: ctxt) -> Result<t, ~str> {
+    do tcx.lang_items.require(TyDescStructLangItem).map |tydesc_lang_item| {
+        tcx.intrinsic_defs.find_copy(tydesc_lang_item)
+            .expect("Failed to resolve TyDesc")
+    }
 }
 
-pub fn get_opaque_ty(tcx: ctxt) -> t {
-    let opaque_lang_item = tcx.lang_items.opaque();
-    tcx.intrinsic_defs.find_copy(&opaque_lang_item)
-        .expect("Failed to resolve Opaque")
+pub fn get_opaque_ty(tcx: ctxt) -> Result<t, ~str> {
+    do tcx.lang_items.require(OpaqueStructLangItem).map |opaque_lang_item| {
+        tcx.intrinsic_defs.find_copy(opaque_lang_item)
+            .expect("Failed to resolve Opaque")
+    }
 }
 
-pub fn visitor_object_ty(tcx: ctxt) -> (@TraitRef, t) {
+pub fn visitor_object_ty(tcx: ctxt) -> Result<(@TraitRef, t), ~str> {
+    let trait_lang_item = match tcx.lang_items.require(TyVisitorTraitLangItem) {
+        Ok(id) => id,
+        Err(s) => { return Err(s); }
+    };
     let substs = substs {
         self_r: None,
         self_ty: None,
         tps: ~[]
     };
-    let trait_lang_item = tcx.lang_items.ty_visitor();
     let trait_ref = @TraitRef { def_id: trait_lang_item, substs: substs };
     let mut static_trait_bound = EmptyBuiltinBounds();
     static_trait_bound.add(BoundStatic);
-    (trait_ref,
-     mk_trait(tcx, trait_ref.def_id, copy trait_ref.substs,
-              BoxTraitStore, ast::m_imm, static_trait_bound))
+    Ok((trait_ref,
+        mk_trait(tcx, trait_ref.def_id, copy trait_ref.substs,
+                 BoxTraitStore, ast::m_imm, static_trait_bound)))
 }

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -811,16 +811,16 @@ pub fn try_add_builtin_trait(tcx: ty::ctxt,
     //! is a builtin trait.
 
     let li = &tcx.lang_items;
-    if trait_def_id == li.send_trait() {
+    if Some(trait_def_id) == li.send_trait() {
         builtin_bounds.add(ty::BoundSend);
         true
-    } else if trait_def_id == li.copy_trait() {
+    } else if Some(trait_def_id) == li.copy_trait() {
         builtin_bounds.add(ty::BoundCopy);
         true
-    } else if trait_def_id == li.freeze_trait() {
+    } else if Some(trait_def_id) == li.freeze_trait() {
         builtin_bounds.add(ty::BoundFreeze);
         true
-    } else if trait_def_id == li.sized_trait() {
+    } else if Some(trait_def_id) == li.sized_trait() {
         builtin_bounds.add(ty::BoundSized);
         true
     } else {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3541,7 +3541,10 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             }
 
             "get_tydesc" => {
-              let tydesc_ty = ty::get_tydesc_ty(ccx.tcx);
+              let tydesc_ty = match ty::get_tydesc_ty(ccx.tcx) {
+                  Ok(t) => t,
+                  Err(s) => { tcx.sess.span_fatal(it.span, s); }
+              };
               let td_ptr = ty::mk_ptr(ccx.tcx, ty::mt {
                   ty: tydesc_ty,
                   mutbl: ast::m_imm
@@ -3549,8 +3552,15 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
               (1u, ~[], td_ptr)
             }
             "visit_tydesc" => {
-              let tydesc_ty = ty::get_tydesc_ty(ccx.tcx);
-              let (_, visitor_object_ty) = ty::visitor_object_ty(tcx);
+              let tydesc_ty = match ty::get_tydesc_ty(ccx.tcx) {
+                  Ok(t) => t,
+                  Err(s) => { tcx.sess.span_fatal(it.span, s); }
+              };
+              let visitor_object_ty = match ty::visitor_object_ty(tcx) {
+                  Ok((_, vot)) => vot,
+                  Err(s) => { tcx.sess.span_fatal(it.span, s); }
+              };
+
               let td_ptr = ty::mk_ptr(ccx.tcx, ty::mt {
                   ty: tydesc_ty,
                   mutbl: ast::m_imm

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -960,7 +960,9 @@ impl CoherenceChecker {
     pub fn populate_destructor_table(&self) {
         let coherence_info = &self.crate_context.coherence_info;
         let tcx = self.crate_context.tcx;
-        let drop_trait = tcx.lang_items.drop_trait();
+        let drop_trait = match tcx.lang_items.drop_trait() {
+            Some(id) => id, None => { return }
+        };
         let impls_opt = coherence_info.extension_methods.find(&drop_trait);
 
         let impls;

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -69,8 +69,12 @@ pub fn collect_item_types(ccx: @mut CrateCtxt, crate: &ast::crate) {
         ccx.tcx.intrinsic_defs.insert(lang_item, ty);
     }
 
-    collect_intrinsic_type(ccx, ccx.tcx.lang_items.ty_desc());
-    collect_intrinsic_type(ccx, ccx.tcx.lang_items.opaque());
+    match ccx.tcx.lang_items.ty_desc() {
+        Some(id) => { collect_intrinsic_type(ccx, id); } None => {}
+    }
+    match ccx.tcx.lang_items.opaque() {
+        Some(id) => { collect_intrinsic_type(ccx, id); } None => {}
+    }
 
     visit::visit_crate(
         crate, ((),

--- a/src/test/run-pass/smallest-hello-world.rs
+++ b/src/test/run-pass/smallest-hello-world.rs
@@ -1,0 +1,41 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast - windows doesn't like this
+
+// Smallest hello world with no runtime
+
+#[no_std];
+
+// This is an unfortunate thing to have to do on linux :(
+#[cfg(target_os = "linux")]
+#[doc(hidden)]
+pub mod linkhack {
+    #[link_args="-lrustrt -lrt"]
+    extern {}
+}
+
+extern {
+    fn puts(s: *u8);
+}
+
+extern "rust-intrinsic" {
+    fn transmute<T, U>(t: T) -> U;
+}
+
+#[start]
+fn main(_: int, _: **u8, _: *u8) -> int {
+    unsafe {
+        let (ptr, _): (*u8, uint) = transmute("Hello!");
+        puts(ptr);
+    }
+    return 0;
+}
+


### PR DESCRIPTION
Whenever a lang_item is required, some relevant message is displayed, often with
a span of what triggered the usage of the lang item.

Now "hello word" is as small as:

``` rust
#[no_std];

extern {
    fn puts(s: *u8);
}

extern "rust-intrinsic" {
    fn transmute<T, U>(t: T) -> U;
}

#[start]
fn main(_: int, _: **u8, _: *u8) -> int {
    unsafe {
        let (ptr, _): (*u8, uint) = transmute("Hello!");
        puts(ptr);
    }
    return 0;
}
```
