### PR TITLE
Rename Option swap_unwrap to take_unwrap. 

### DIFF
--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -173,11 +173,11 @@ impl<T> Deque<T> for DList<T> {
                 let tail_own = match tail.prev.resolve() {
                     None => {
                         self.list_tail = Rawlink::none();
-                        self.list_head.swap_unwrap()
+                        self.list_head.take_unwrap()
                     },
                     Some(tail_prev) => {
                         self.list_tail = tail.prev;
-                        tail_prev.next.swap_unwrap()
+                        tail_prev.next.take_unwrap()
                     }
                 };
                 Some(tail_own.value)
@@ -465,7 +465,7 @@ impl<'self, A> ListInsertion<A> for MutDListIterator<'self, A> {
                     Some(prev) => prev,
                 };
                 let mut ins_node = ~Node{value: elt, next: None, prev: Rawlink::none()};
-                let node_own = prev_node.next.swap_unwrap();
+                let node_own = prev_node.next.take_unwrap();
                 ins_node.next = link_with_prev(node_own, Rawlink::some(ins_node));
                 prev_node.next = link_with_prev(ins_node, Rawlink::some(prev_node));
                 self.list.length += 1;

--- a/src/libextra/net/ip.rs
+++ b/src/libextra/net/ip.rs
@@ -116,7 +116,7 @@ pub fn get_addr(node: &str, iotask: &iotask)
     let (output_po, output_ch) = stream();
     let mut output_ch = Some(SharedChan::new(output_ch));
     do str::as_buf(node) |node_ptr, len| {
-        let output_ch = output_ch.swap_unwrap();
+        let output_ch = output_ch.take_unwrap();
         debug!("slice len %?", len);
         let handle = create_uv_getaddrinfo_t();
         let handle_ptr: *uv_getaddrinfo_t = &handle;

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -552,7 +552,7 @@ fn mutate_values<'r, K: TotalOrd, V>(node: &'r mut Option<~TreeNode<K, V>>,
 // Remove left horizontal link by rotating right
 fn skew<K: TotalOrd, V>(node: &mut ~TreeNode<K, V>) {
     if node.left.map_default(false, |x| x.level == node.level) {
-        let mut save = node.left.swap_unwrap();
+        let mut save = node.left.take_unwrap();
         swap(&mut node.left, &mut save.right); // save.right now None
         swap(node, &mut save);
         node.right = Some(save);
@@ -564,7 +564,7 @@ fn skew<K: TotalOrd, V>(node: &mut ~TreeNode<K, V>) {
 fn split<K: TotalOrd, V>(node: &mut ~TreeNode<K, V>) {
     if node.right.map_default(false,
       |x| x.right.map_default(false, |y| y.level == node.level)) {
-        let mut save = node.right.swap_unwrap();
+        let mut save = node.right.take_unwrap();
         swap(&mut node.right, &mut save.left); // save.left now None
         save.level += 1;
         swap(node, &mut save);
@@ -643,7 +643,7 @@ fn remove<K: TotalOrd, V>(node: &mut Option<~TreeNode<K, V>>,
           Equal => {
             if save.left.is_some() {
                 if save.right.is_some() {
-                    let mut left = save.left.swap_unwrap();
+                    let mut left = save.left.take_unwrap();
                     if left.right.is_some() {
                         heir_swap(save, &mut left.right);
                     } else {
@@ -653,13 +653,13 @@ fn remove<K: TotalOrd, V>(node: &mut Option<~TreeNode<K, V>>,
                     save.left = Some(left);
                     (remove(&mut save.left, key), true)
                 } else {
-                    let new = save.left.swap_unwrap();
+                    let new = save.left.take_unwrap();
                     let ~TreeNode{value, _} = replace(save, new);
-                    *save = save.left.swap_unwrap();
+                    *save = save.left.take_unwrap();
                     (Some(value), true)
                 }
             } else if save.right.is_some() {
-                let new = save.right.swap_unwrap();
+                let new = save.right.take_unwrap();
                 let ~TreeNode{value, _} = replace(save, new);
                 (Some(value), true)
             } else {

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -203,14 +203,14 @@ impl<T> Option<T> {
     /// Apply a function to the contained value or do nothing
     pub fn mutate(&mut self, f: &fn(T) -> T) {
         if self.is_some() {
-            *self = Some(f(self.swap_unwrap()));
+            *self = Some(f(self.take_unwrap()));
         }
     }
 
     /// Apply a function to the contained value or set it to a default
     pub fn mutate_default(&mut self, def: T, f: &fn(T) -> T) {
         if self.is_some() {
-            *self = Some(f(self.swap_unwrap()));
+            *self = Some(f(self.take_unwrap()));
         } else {
             *self = Some(def);
         }
@@ -293,8 +293,8 @@ impl<T> Option<T> {
      * Fails if the value equals `None`.
      */
     #[inline]
-    pub fn swap_unwrap(&mut self) -> T {
-        if self.is_none() { fail!("option::swap_unwrap none") }
+    pub fn take_unwrap(&mut self) -> T {
+        if self.is_none() { fail!("option::take_unwrap none") }
         util::replace(self, None).unwrap()
     }
 
@@ -460,7 +460,7 @@ fn test_option_dance() {
     let mut y = Some(5);
     let mut y2 = 0;
     for x.iter().advance |_x| {
-        y2 = y.swap_unwrap();
+        y2 = y.take_unwrap();
     }
     assert_eq!(y2, 5);
     assert!(y.is_none());
@@ -468,8 +468,8 @@ fn test_option_dance() {
 #[test] #[should_fail] #[ignore(cfg(windows))]
 fn test_option_too_much_dance() {
     let mut y = Some(util::NonCopyable);
-    let _y2 = y.swap_unwrap();
-    let _y3 = y.swap_unwrap();
+    let _y2 = y.take_unwrap();
+    let _y3 = y.take_unwrap();
 }
 
 #[test]

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -127,7 +127,7 @@ impl Task {
 
         // Wait for children. Possibly report the exit status.
         let local_success = !self.unwinder.unwinding;
-        let join_latch = self.join_latch.swap_unwrap();
+        let join_latch = self.join_latch.take_unwrap();
         match self.on_exit {
             Some(ref on_exit) => {
                 let success = join_latch.wait(local_success);

--- a/src/libstd/rt/tube.rs
+++ b/src/libstd/rt/tube.rs
@@ -53,7 +53,7 @@ impl<T> Tube<T> {
             if (*state).blocked_task.is_some() {
                 // There's a waiting task. Wake it up
                 rtdebug!("waking blocked tube");
-                let task = (*state).blocked_task.swap_unwrap();
+                let task = (*state).blocked_task.take_unwrap();
                 let sched = Local::take::<Scheduler>();
                 sched.resume_task_immediately(task);
             }

--- a/src/libstd/rt/uv/async.rs
+++ b/src/libstd/rt/uv/async.rs
@@ -62,7 +62,7 @@ impl AsyncWatcher {
             let mut watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
             {
                 let data = watcher.get_watcher_data();
-                data.close_cb.swap_unwrap()();
+                data.close_cb.take_unwrap()();
             }
             watcher.drop_watcher_data();
             unsafe { uvll::free_handle(handle as *c_void); }

--- a/src/libstd/rt/uv/idle.rs
+++ b/src/libstd/rt/uv/idle.rs
@@ -73,7 +73,7 @@ impl IdleWatcher {
                 let mut idle_watcher: IdleWatcher = NativeHandle::from_native_handle(handle);
                 {
                     let data = idle_watcher.get_watcher_data();
-                    data.close_cb.swap_unwrap()();
+                    data.close_cb.take_unwrap()();
                 }
                 idle_watcher.drop_watcher_data();
                 uvll::idle_delete(handle);

--- a/src/libstd/rt/uv/net.rs
+++ b/src/libstd/rt/uv/net.rs
@@ -209,7 +209,7 @@ impl StreamWatcher {
             let write_request: WriteRequest = NativeHandle::from_native_handle(req);
             let mut stream_watcher = write_request.stream();
             write_request.delete();
-            let cb = stream_watcher.get_watcher_data().write_cb.swap_unwrap();
+            let cb = stream_watcher.get_watcher_data().write_cb.take_unwrap();
             let status = status_to_maybe_uv_error(stream_watcher.native_handle(), status);
             cb(stream_watcher, status);
         }
@@ -233,7 +233,7 @@ impl StreamWatcher {
 
         extern fn close_cb(handle: *uvll::uv_stream_t) {
             let mut stream_watcher: StreamWatcher = NativeHandle::from_native_handle(handle);
-            stream_watcher.get_watcher_data().close_cb.swap_unwrap()();
+            stream_watcher.get_watcher_data().close_cb.take_unwrap()();
             stream_watcher.drop_watcher_data();
             unsafe { free_handle(handle as *c_void) }
         }
@@ -301,7 +301,7 @@ impl TcpWatcher {
                 let connect_request: ConnectRequest = NativeHandle::from_native_handle(req);
                 let mut stream_watcher = connect_request.stream();
                 connect_request.delete();
-                let cb = stream_watcher.get_watcher_data().connect_cb.swap_unwrap();
+                let cb = stream_watcher.get_watcher_data().connect_cb.take_unwrap();
                 let status = status_to_maybe_uv_error(stream_watcher.native_handle(), status);
                 cb(stream_watcher, status);
             }
@@ -438,7 +438,7 @@ impl UdpWatcher {
             let send_request: UdpSendRequest = NativeHandle::from_native_handle(req);
             let mut udp_watcher = send_request.handle();
             send_request.delete();
-            let cb = udp_watcher.get_watcher_data().udp_send_cb.swap_unwrap();
+            let cb = udp_watcher.get_watcher_data().udp_send_cb.take_unwrap();
             let status = status_to_maybe_uv_error(udp_watcher.native_handle(), status);
             cb(udp_watcher, status);
         }
@@ -456,7 +456,7 @@ impl UdpWatcher {
 
         extern fn close_cb(handle: *uvll::uv_udp_t) {
             let mut udp_watcher: UdpWatcher = NativeHandle::from_native_handle(handle);
-            udp_watcher.get_watcher_data().close_cb.swap_unwrap()();
+            udp_watcher.get_watcher_data().close_cb.take_unwrap()();
             udp_watcher.drop_watcher_data();
             unsafe { free_handle(handle as *c_void) }
         }

--- a/src/libstd/rt/uv/timer.rs
+++ b/src/libstd/rt/uv/timer.rs
@@ -70,7 +70,7 @@ impl TimerWatcher {
             let mut watcher: TimerWatcher = NativeHandle::from_native_handle(handle);
             {
                 let data = watcher.get_watcher_data();
-                data.close_cb.swap_unwrap()();
+                data.close_cb.take_unwrap()();
             }
             watcher.drop_watcher_data();
             unsafe {

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -302,7 +302,7 @@ fn each_ancestor(list:        &mut AncestorList,
         fn with_parent_tg<U>(parent_group: &mut Option<TaskGroupArc>,
                              blk: &fn(TaskGroupInner) -> U) -> U {
             // If this trips, more likely the problem is 'blk' failed inside.
-            let tmp_arc = parent_group.swap_unwrap();
+            let tmp_arc = parent_group.take_unwrap();
             let result = do access_group(&tmp_arc) |tg_opt| { blk(tg_opt) };
             *parent_group = Some(tmp_arc);
             result
@@ -609,7 +609,7 @@ fn spawn_raw_newsched(mut opts: TaskOpts, f: ~fn()) {
     };
 
     if opts.notify_chan.is_some() {
-        let notify_chan = opts.notify_chan.swap_unwrap();
+        let notify_chan = opts.notify_chan.take_unwrap();
         let notify_chan = Cell::new(notify_chan);
         let on_exit: ~fn(bool) = |success| {
             notify_chan.take().send(
@@ -647,7 +647,7 @@ fn spawn_raw_oldsched(mut opts: TaskOpts, f: ~fn()) {
             let notify_chan = if opts.notify_chan.is_none() {
                 None
             } else {
-                Some(opts.notify_chan.swap_unwrap())
+                Some(opts.notify_chan.take_unwrap())
             };
 
             let child_wrapper = make_child_wrapper(new_task, child_tg,

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -60,8 +60,8 @@ fn thread_ring(i: uint, count: uint, num_chan: pipe, num_port: pipe) {
     // Send/Receive lots of messages.
     for uint::range(0u, count) |j| {
         //error!("task %?, iter %?", i, j);
-        let mut num_chan2 = num_chan.swap_unwrap();
-        let mut num_port2 = num_port.swap_unwrap();
+        let mut num_chan2 = num_chan.take_unwrap();
+        let mut num_port2 = num_port.take_unwrap();
         send(&num_chan2, i * j);
         num_chan = Some(num_chan2);
         let _n = recv(&num_port2);

--- a/src/test/bench/msgsend-ring-rw-arcs.rs
+++ b/src/test/bench/msgsend-ring-rw-arcs.rs
@@ -56,8 +56,8 @@ fn thread_ring(i: uint, count: uint, num_chan: pipe, num_port: pipe) {
     // Send/Receive lots of messages.
     for uint::range(0u, count) |j| {
         //error!("task %?, iter %?", i, j);
-        let mut num_chan2 = num_chan.swap_unwrap();
-        let mut num_port2 = num_port.swap_unwrap();
+        let mut num_chan2 = num_chan.take_unwrap();
+        let mut num_port2 = num_port.take_unwrap();
         send(&num_chan2, i * j);
         num_chan = Some(num_chan2);
         let _n = recv(&num_port2);


### PR DESCRIPTION
Fixes Issue #7764

Running `make check` I do get a failure:

```
test rt::io::extensions::test::push_bytes ... ok
rustest rt::comm::test::oneshot_single_thread_send_port_close ... t: task failed at 'Unhandled condition:
 read_error: {kind: OtherIoError, desc: "Placeholder error. You shouldn\'t be seeing this", detail: None}',
 /Users/shout/Projects/rust/src/libstd/condition.rs:50
/bin/sh: line 1: 35056 Abort trap: 6           x86_64-apple-darwin/stage2/test/stdtest-x86_64-apple-darwin --logfile
 tmp/check-stage2-T-x86_64-apple-darwin-H-x86_64-apple-darwin-std.log
make: *** [tmp/check-stage2-T-x86_64-apple-darwin-H-x86_64-apple-darwin-std.ok] Error 134
```
