### PR TITLE
hashmap: Remove .consume() methods

### DIFF
--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -1086,9 +1086,8 @@ impl serialize::Decoder for Decoder {
         debug!("read_map()");
         let len = match self.stack.pop() {
             Object(obj) => {
-                let mut obj = obj;
                 let len = obj.len();
-                do obj.consume |key, value| {
+                for obj.consume().advance |(key, value)| {
                     self.stack.push(value);
                     self.stack.push(String(key));
                 }

--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -154,7 +154,7 @@ Available lint options:
 "));
 
     let lint_dict = lint::get_lint_dict();
-    let mut lint_dict = lint_dict.consume_iter()
+    let mut lint_dict = lint_dict.consume()
                                  .transform(|(k, v)| (v, k))
                                  .collect::<~[(lint::LintSpec, &'static str)]>();
     lint_dict.qsort();

--- a/src/librusti/program.rs
+++ b/src/librusti/program.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use std::cast;
+use std::util;
 use std::hashmap::HashMap;
 use std::local_data;
 
@@ -165,7 +166,8 @@ impl Program {
             None => {}
         }
 
-        do self.newvars.consume |name, var| {
+        let newvars = util::replace(&mut self.newvars, HashMap::new());
+        for newvars.consume().advance |(name, var)| {
             self.local_vars.insert(name, var);
         }
 
@@ -230,7 +232,8 @@ impl Program {
     /// it updates this cache with the new values of each local variable.
     pub fn consume_cache(&mut self) {
         let map = local_data::pop(tls_key).expect("tls is empty");
-        do map.consume |name, value| {
+        let cons_map = util::replace(map, HashMap::new());
+        for cons_map.consume().advance |(name, value)| {
             match self.local_vars.find_mut(&name) {
                 Some(v) => { v.data = (*value).clone(); }
                 None => { fail!("unknown variable %s", name) }
@@ -341,7 +344,8 @@ impl Program {
         }
 
         // I'm not an @ pointer, so this has to be done outside.
-        do newvars.consume |k, v| {
+        let cons_newvars = util::replace(newvars, HashMap::new());
+        for cons_newvars.consume().advance |(k, v)| {
             self.newvars.insert(k, v);
         }
 

--- a/src/libstd/unstable/weak_task.rs
+++ b/src/libstd/unstable/weak_task.rs
@@ -122,7 +122,7 @@ fn run_weak_task_service(port: Port<ServiceMsg>) {
         }
     }
 
-    do shutdown_map.consume |_, shutdown_chan| {
+    for shutdown_map.consume().advance |(_, shutdown_chan)| {
         // Weak task may have already exited
         shutdown_chan.send(());
     }

--- a/src/test/bench/graph500-bfs.rs
+++ b/src/test/bench/graph500-bfs.rs
@@ -96,9 +96,9 @@ fn make_graph(N: uint, edges: ~[(node_id, node_id)]) -> graph {
         }
     }
 
-    do graph.consume_iter().transform |mut v| {
+    do graph.consume_iter().transform |v| {
         let mut vec = ~[];
-        do v.consume |i| {
+        for v.consume().advance |i| {
             vec.push(i);
         }
         vec
@@ -119,7 +119,7 @@ fn gen_search_keys(graph: &[~[node_id]], n: uint) -> ~[node_id] {
         }
     }
     let mut vec = ~[];
-    do keys.consume |i| {
+    for keys.consume().advance |i| {
         vec.push(i);
     }
     return vec;


### PR DESCRIPTION
Updated all users of HashMap, HashSet ::consume() to use
.consume_iter().

Since .consume_iter() takes the map or set by value, it needs awkward
extra code to in librusti's use of @mut HashMap, where the map value can
not be directly moved out.

Addresses issue #7719
