### PR TITLE
rustc: implement a `#[no_implicit_prelude]` attribute.

### DIFF
--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -159,8 +159,8 @@ impl<V> SmallIntMap<V> {
     /// Visit all key-value pairs in reverse order
     pub fn each_reverse<'a>(&'a self, it: &fn(uint, &'a V) -> bool) -> bool {
         for uint::range_rev(self.v.len(), 0) |i| {
-            match self.v[i - 1] {
-              Some(ref elt) => if !it(i - 1, elt) { return false; },
+            match self.v[i] {
+              Some(ref elt) => if !it(i, elt) { return false; },
               None => ()
             }
         }

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -309,7 +309,7 @@ pub fn check_expr(e: @expr, (cx, v): (Context, visit::vt<Context>)) {
                        "explicit copy requires a copyable argument");
         }
         expr_repeat(element, count_expr, _) => {
-            let count = ty::eval_repeat_count(cx.tcx, count_expr);
+            let count = ty::eval_repeat_count(&cx.tcx, count_expr);
             if count > 1 {
                 let element_ty = ty::expr_ty(cx.tcx, element);
                 check_copy(cx, element_ty, element.span,

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -417,7 +417,7 @@ pub fn write_content(bcx: block,
                     return expr::trans_into(bcx, element, Ignore);
                 }
                 SaveIn(lldest) => {
-                    let count = ty::eval_repeat_count(bcx.tcx(), count_expr);
+                    let count = ty::eval_repeat_count(&bcx.tcx(), count_expr);
                     if count == 0 {
                         return bcx;
                     }
@@ -509,7 +509,7 @@ pub fn elements_required(bcx: block, content_expr: &ast::expr) -> uint {
         },
         ast::expr_vec(ref es, _) => es.len(),
         ast::expr_repeat(_, count_expr, _) => {
-            ty::eval_repeat_count(bcx.tcx(), count_expr)
+            ty::eval_repeat_count(&bcx.tcx(), count_expr)
         }
         _ => bcx.tcx().sess.span_bug(content_expr.span,
                                      "Unexpected evec content")

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -479,7 +479,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Copy + 'static>(
         }
       }
       ast::ty_fixed_length_vec(ref a_mt, e) => {
-        match const_eval::eval_const_expr_partial(tcx, e) {
+        match const_eval::eval_const_expr_partial(&tcx, e) {
           Ok(ref r) => {
             match *r {
               const_eval::const_int(i) =>

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -29,28 +29,38 @@ pub static bytes : uint = ($bits / 8);
 pub static min_value: $T = (-1 as $T) << (bits - 1);
 pub static max_value: $T = min_value - 1 as $T;
 
-///
-/// Iterate over the range [`lo`..`hi`)
-///
-/// # Arguments
-///
-/// * `lo` - lower bound, inclusive
-/// * `hi` - higher bound, exclusive
-///
-/// # Examples
-/// ~~~
-/// let mut sum = 0;
-/// for int::range(1, 5) |i| {
-///     sum += i;
-/// }
-/// assert!(sum == 10);
-/// ~~~
-///
+enum Range { Closed, HalfOpen }
+
 #[inline]
-pub fn range_step(start: $T, stop: $T, step: $T, it: &fn($T) -> bool) -> bool {
+///
+/// Iterate through a range with a given step value.
+///
+/// Let `term` denote the closed interval `[stop-step,stop]` if `r` is Closed;
+/// otherwise `term` denotes the half-open interval `[stop-step,stop)`.
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// `x_j == start + step*j`, and `x_n` lies in the interval `term`.
+///
+/// If no such nonnegative integer `n` exists, then the iteration range
+/// is empty.
+///
+fn range_step_core(start: $T, stop: $T, step: $T, r: Range, it: &fn($T) -> bool) -> bool {
     let mut i = start;
     if step == 0 {
         fail!(~"range_step called with step == 0");
+    } else if step == (1 as $T) { // elide bounds check to tighten loop
+        while i < stop {
+            if !it(i) { return false; }
+            // no need for overflow check;
+            // cannot have i + 1 > max_value because i < stop <= max_value
+            i += (1 as $T);
+        }
+    } else if step == (-1 as $T) { // elide bounds check to tighten loop
+        while i > stop {
+            if !it(i) { return false; }
+            // no need for underflow check;
+            // cannot have i - 1 < min_value because i > stop >= min_value
+            i -= (1 as $T);
+        }
     } else if step > 0 { // ascending
         while i < stop {
             if !it(i) { return false; }
@@ -66,8 +76,54 @@ pub fn range_step(start: $T, stop: $T, step: $T, it: &fn($T) -> bool) -> bool {
             i += step;
         }
     }
-    return true;
+    match r {
+        HalfOpen => return true,
+        Closed => return (i != stop || it(i))
+    }
 }
+
+#[inline]
+///
+/// Iterate through the range [`start`..`stop`) with a given step value.
+///
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// * `x_i == start + step*i`, and
+/// * `n` is the greatest nonnegative integer such that `x_n < stop`
+///
+/// (If no such `n` exists, then the iteration range is empty.)
+///
+/// # Arguments
+///
+/// * `start` - lower bound, inclusive
+/// * `stop` - higher bound, exclusive
+///
+/// # Examples
+/// ~~~
+/// let mut sum = 0;
+/// for int::range(1, 5) |i| {
+///     sum += i;
+/// }
+/// assert!(sum == 10);
+/// ~~~
+///
+pub fn range_step(start: $T, stop: $T, step: $T, it: &fn($T) -> bool) -> bool {
+    range_step_core(start, stop, step, HalfOpen, it)
+}
+
+#[inline]
+///
+/// Iterate through a range with a given step value.
+///
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// `x_i == start + step*i` and `x_n <= last < step + x_n`.
+///
+/// (If no such nonnegative integer `n` exists, then the iteration
+///  range is empty.)
+///
+pub fn range_step_inclusive(start: $T, last: $T, step: $T, it: &fn($T) -> bool) -> bool {
+    range_step_core(start, last, step, Closed, it)
+}
+
 
 #[inline]
 /// Iterate over the range [`lo`..`hi`)

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -132,9 +132,10 @@ pub fn range(lo: $T, hi: $T, it: &fn($T) -> bool) -> bool {
 }
 
 #[inline]
-/// Iterate over the range [`hi`..`lo`)
+/// Iterate over the range (`hi`..`lo`]
 pub fn range_rev(hi: $T, lo: $T, it: &fn($T) -> bool) -> bool {
-    range_step(hi, lo, -1 as $T, it)
+    if hi == min_value { return true; }
+    range_step_inclusive(hi-1, lo, -1 as $T, it)
 }
 
 impl Num for $T {}
@@ -897,7 +898,7 @@ mod tests {
         for range(0,3) |i| {
             l.push(i);
         }
-        for range_rev(13,10) |i| {
+        for range_rev(14,11) |i| {
             l.push(i);
         }
         for range_step(20,26,2) |i| {

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -132,9 +132,10 @@ pub fn range(lo: $T, hi: $T, it: &fn($T) -> bool) -> bool {
 }
 
 #[inline]
-/// Iterate over the range [`hi`..`lo`)
+/// Iterate over the range (`hi`..`lo`]
 pub fn range_rev(hi: $T, lo: $T, it: &fn($T) -> bool) -> bool {
-    range_step(hi, lo, -1 as $T_SIGNED, it)
+    if hi == min_value { return true; }
+    range_step_inclusive(hi-1, lo, -1 as $T_SIGNED, it)
 }
 
 impl Num for $T {}
@@ -662,7 +663,7 @@ mod tests {
         for range(0,3) |i| {
             l.push(i);
         }
-        for range_rev(13,10) |i| {
+        for range_rev(14,11) |i| {
             l.push(i);
         }
         for range_step(20,26,2) |i| {

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -30,32 +30,46 @@ pub static bytes : uint = ($bits / 8);
 pub static min_value: $T = 0 as $T;
 pub static max_value: $T = 0 as $T - 1 as $T;
 
+enum Range { Closed, HalfOpen }
+
 #[inline]
-/**
- * Iterate through a range with a given step value.
- *
- * # Examples
- * ~~~ {.rust}
- * let nums = [1,2,3,4,5,6,7];
- *
- * for uint::range_step(0, nums.len() - 1, 2) |i| {
- *     println(fmt!("%d & %d", nums[i], nums[i+1]));
- * }
- * ~~~
- */
-pub fn range_step(start: $T, stop: $T, step: $T_SIGNED, it: &fn($T) -> bool) -> bool {
+///
+/// Iterate through a range with a given step value.
+///
+/// Let `term` denote the closed interval `[stop-step,stop]` if `r` is Closed;
+/// otherwise `term` denotes the half-open interval `[stop-step,stop)`.
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// `x_j == start + step*j`, and `x_n` lies in the interval `term`.
+///
+/// If no such nonnegative integer `n` exists, then the iteration range
+/// is empty.
+///
+fn range_step_core(start: $T, stop: $T, step: $T_SIGNED, r: Range, it: &fn($T) -> bool) -> bool {
     let mut i = start;
     if step == 0 {
         fail!("range_step called with step == 0");
-    }
-    if step >= 0 {
+    } else if step == (1 as $T_SIGNED) { // elide bounds check to tighten loop
+        while i < stop {
+            if !it(i) { return false; }
+            // no need for overflow check;
+            // cannot have i + 1 > max_value because i < stop <= max_value
+            i += (1 as $T);
+        }
+    } else if step == (-1 as $T_SIGNED) { // elide bounds check to tighten loop
+        while i > stop {
+            if !it(i) { return false; }
+            // no need for underflow check;
+            // cannot have i - 1 < min_value because i > stop >= min_value
+            i -= (1 as $T);
+        }
+    } else if step > 0 { // ascending
         while i < stop {
             if !it(i) { return false; }
             // avoiding overflow. break if i + step > max_value
             if i > max_value - (step as $T) { return true; }
             i += step as $T;
         }
-    } else {
+    } else { // descending
         while i > stop {
             if !it(i) { return false; }
             // avoiding underflow. break if i + step < min_value
@@ -63,7 +77,52 @@ pub fn range_step(start: $T, stop: $T, step: $T_SIGNED, it: &fn($T) -> bool) -> 
             i -= -step as $T;
         }
     }
-    return true;
+    match r {
+        HalfOpen => return true,
+        Closed => return (i != stop || it(i))
+    }
+}
+
+#[inline]
+///
+/// Iterate through the range [`start`..`stop`) with a given step value.
+///
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// - `x_i == start + step*i`, and
+/// - `n` is the greatest nonnegative integer such that `x_n < stop`
+///
+/// (If no such `n` exists, then the iteration range is empty.)
+///
+/// # Arguments
+///
+/// * `start` - lower bound, inclusive
+/// * `stop` - higher bound, exclusive
+///
+/// # Examples
+/// ~~~ {.rust}
+/// let nums = [1,2,3,4,5,6,7];
+///
+/// for uint::range_step(0, nums.len() - 1, 2) |i| {
+///     println(fmt!("%d & %d", nums[i], nums[i+1]));
+/// }
+/// ~~~
+///
+pub fn range_step(start: $T, stop: $T, step: $T_SIGNED, it: &fn($T) -> bool) -> bool {
+    range_step_core(start, stop, step, HalfOpen, it)
+}
+
+#[inline]
+///
+/// Iterate through a range with a given step value.
+///
+/// Iterates through the range `[x_0, x_1, ..., x_n]` where
+/// `x_i == start + step*i` and `x_n <= last < step + x_n`.
+///
+/// (If no such nonnegative integer `n` exists, then the iteration
+///  range is empty.)
+///
+pub fn range_step_inclusive(start: $T, last: $T, step: $T_SIGNED, it: &fn($T) -> bool) -> bool {
+    range_step_core(start, last, step, Closed, it)
 }
 
 #[inline]

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -669,7 +669,7 @@ fn spawn_process_os(prog: &str, args: &[~str],
             fail!("failure in dup3(err_fd, 2): %s", os::last_os_error());
         }
         // close all other fds
-        for int::range_rev(getdtablesize() as int - 1, 2) |fd| {
+        for int::range_rev(getdtablesize() as int, 3) |fd| {
             close(fd as c_int);
         }
 

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -462,7 +462,7 @@ mod tests {
             m.insert(x, x / 2);
         }
 
-        let mut n = uint::max_value - 9999;
+        let mut n = uint::max_value - 10000;
         for m.each |k, v| {
             if n == uint::max_value - 5000 { break }
             assert!(n < uint::max_value - 5000);
@@ -499,7 +499,7 @@ mod tests {
             m.insert(x, x / 2);
         }
 
-        let mut n = uint::max_value;
+        let mut n = uint::max_value - 1;
         for m.each_reverse |k, v| {
             if n == uint::max_value - 5000 { break }
             assert!(n > uint::max_value - 5000);

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -261,7 +261,7 @@ impl<T> TrieNode<T> {
 
     fn each_reverse<'a>(&'a self, f: &fn(&uint, &'a T) -> bool) -> bool {
         for uint::range_rev(self.children.len(), 0) |idx| {
-            match self.children[idx - 1] {
+            match self.children[idx] {
                 Internal(ref x) => if !x.each_reverse(|i,t| f(i,t)) { return false },
                 External(k, ref v) => if !f(&k, v) { return false },
                 Nothing => ()

--- a/src/test/compile-fail/no-implicit-prelude-nested.rs
+++ b/src/test/compile-fail/no-implicit-prelude-nested.rs
@@ -1,0 +1,68 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that things from the prelude aren't in scope. Use many of them
+// so that renaming some things won't magically make this test fail
+// for the wrong reason (e.g. if `Add` changes to `Addition`, and
+// `no_implicit_prelude` stops working, then the `impl Add` will still
+// fail with the same error message).
+
+#[no_implicit_prelude]
+mod foo {
+    mod baz {
+        struct Test;
+        impl Add for Test {} //~ ERROR: attempt to implement a nonexistent trait
+        impl Clone for Test {} //~ ERROR: attempt to implement a nonexistent trait
+        impl Iterator for Test {} //~ ERROR: attempt to implement a nonexistent trait
+        impl ToStr for Test {} //~ ERROR: attempt to implement a nonexistent trait
+        impl Writer for Test {} //~ ERROR: attempt to implement a nonexistent trait
+
+        fn foo() {
+            print("foo"); //~ ERROR: unresolved name
+            println("bar"); //~ ERROR: unresolved name
+        }
+    }
+
+    struct Test;
+    impl Add for Test {} //~ ERROR: attempt to implement a nonexistent trait
+    impl Clone for Test {} //~ ERROR: attempt to implement a nonexistent trait
+    impl Iterator for Test {} //~ ERROR: attempt to implement a nonexistent trait
+    impl ToStr for Test {} //~ ERROR: attempt to implement a nonexistent trait
+    impl Writer for Test {} //~ ERROR: attempt to implement a nonexistent trait
+
+    fn foo() {
+        print("foo"); //~ ERROR: unresolved name
+        println("bar"); //~ ERROR: unresolved name
+    }
+}
+
+fn qux() {
+    #[no_implicit_prelude]
+    mod qux_inner {
+        struct Test;
+        impl Add for Test {} //~ ERROR: attempt to implement a nonexistent trait
+        impl Clone for Test {} //~ ERROR: attempt to implement a nonexistent trait
+        impl Iterator for Test {} //~ ERROR: attempt to implement a nonexistent trait
+        impl ToStr for Test {} //~ ERROR: attempt to implement a nonexistent trait
+        impl Writer for Test {} //~ ERROR: attempt to implement a nonexistent trait
+
+        fn foo() {
+            print("foo"); //~ ERROR: unresolved name
+            println("bar"); //~ ERROR: unresolved name
+        }
+    }
+}
+
+
+fn main() {
+    // these should work fine
+    print("foo");
+    println("bar");
+}

--- a/src/test/compile-fail/no-implicit-prelude.rs
+++ b/src/test/compile-fail/no-implicit-prelude.rs
@@ -1,0 +1,29 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[no_implicit_prelude];
+
+// Test that things from the prelude aren't in scope. Use many of them
+// so that renaming some things won't magically make this test fail
+// for the wrong reason (e.g. if `Add` changes to `Addition`, and
+// `no_implicit_prelude` stops working, then the `impl Add` will still
+// fail with the same error message).
+
+struct Test;
+impl Add for Test {} //~ ERROR: attempt to implement a nonexistent trait
+impl Clone for Test {} //~ ERROR: attempt to implement a nonexistent trait
+impl Iterator for Test {} //~ ERROR: attempt to implement a nonexistent trait
+impl ToStr for Test {} //~ ERROR: attempt to implement a nonexistent trait
+impl Writer for Test {} //~ ERROR: attempt to implement a nonexistent trait
+
+fn main() {
+    print("foo"); //~ ERROR: unresolved name
+    println("bar"); //~ ERROR: unresolved name
+}

--- a/src/test/run-pass/enum-vec-initializer.rs
+++ b/src/test/run-pass/enum-vec-initializer.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Flopsy {
+    Bunny = 2
+}
+
+static BAR:uint = Bunny as uint;
+static BAR2:uint = BAR;
+
+fn main() {
+    let v = [0, .. Bunny as uint];
+    let v = [0, .. BAR];
+    let v = [0, .. BAR2];
+    static BAR3:uint = BAR2;
+    let v = [0, .. BAR3];
+}

--- a/src/test/run-pass/num-range-rev.rs
+++ b/src/test/run-pass/num-range-rev.rs
@@ -40,13 +40,13 @@ pub fn main() {
     // int and uint have same result for
     //   Sum{100 > i >= 2} == (Sum{1 <= i <= 99} - 1) == n*(n+1)/2 - 1 for n=99
     let mut sum = 0u;
-    for uint_range_rev(99, 1) |i| {
+    for uint_range_rev(100, 2) |i| {
         sum += i;
     }
     assert_eq!(sum, 4949);
 
     let mut sum = 0i;
-    for int_range_rev(99, 1) |i| {
+    for int_range_rev(100, 2) |i| {
         sum += i;
     }
     assert_eq!(sum, 4949);
@@ -55,17 +55,17 @@ pub fn main() {
     // elements are visited in correct order
     let primes = [2,3,5,7,11];
     let mut prod = 1i;
-    for uint_range_rev(4, 0) |i| {
+    for uint_range_rev(5, 0) |i| {
         println(fmt!("uint 4 downto 0: %u", i));
         prod *= int::pow(primes[i], i);
     }
-    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3);
+    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3*1);
     let mut prod = 1i;
-    for int_range_rev(4, 0) |i| {
+    for int_range_rev(5, 0) |i| {
         println(fmt!("int 4 downto 0: %d", i));
         prod *= int::pow(primes[i], i as uint);
     }
-    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3);
+    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3*1);
 
 
     // range and range_rev are symmetric.
@@ -74,7 +74,7 @@ pub fn main() {
         sum_up += i;
     }
     let mut sum_down = 0u;
-    for uint_range_rev(29, 9) |i| {
+    for uint_range_rev(30, 10) |i| {
         sum_down += i;
     }
     assert_eq!(sum_up, sum_down);
@@ -84,7 +84,7 @@ pub fn main() {
         sum_up += i;
     }
     let mut sum_down = 0;
-    for int_range_rev(9, -21) |i| {
+    for int_range_rev(10, -20) |i| {
         sum_down += i;
     }
     assert_eq!(sum_up, sum_down);
@@ -96,7 +96,7 @@ pub fn main() {
     }
 
     for uint_range_rev(0, 1) |_| {
-        // fail!("range should be empty when start-1 underflows");
+        fail!("range should be empty when start-1 underflows");
     }
 
     // range iterations do not wrap/underflow

--- a/src/test/run-pass/num-range-rev.rs
+++ b/src/test/run-pass/num-range-rev.rs
@@ -1,0 +1,114 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::int;
+use std::uint;
+
+fn uint_range(lo: uint, hi: uint, it: &fn(uint) -> bool) -> bool {
+    uint::range(lo, hi, it)
+}
+
+fn int_range(lo: int,  hi: int, it: &fn(int) -> bool) -> bool {
+    int::range(lo, hi, it)
+}
+
+fn uint_range_rev(hi: uint, lo: uint, it: &fn(uint) -> bool) -> bool {
+    uint::range_rev(hi, lo, it)
+}
+
+fn int_range_rev(hi: int,  lo: int, it: &fn(int) -> bool) -> bool {
+    int::range_rev(hi, lo, it)
+}
+
+fn int_range_step(a: int, b: int, step: int, it: &fn(int) -> bool) -> bool {
+    int::range_step(a, b, step, it)
+}
+
+fn uint_range_step(a: uint, b: uint, step: int, it: &fn(uint) -> bool) -> bool {
+    uint::range_step(a, b, step, it)
+}
+
+
+pub fn main() {
+    // int and uint have same result for
+    //   Sum{100 > i >= 2} == (Sum{1 <= i <= 99} - 1) == n*(n+1)/2 - 1 for n=99
+    let mut sum = 0u;
+    for uint_range_rev(99, 1) |i| {
+        sum += i;
+    }
+    assert_eq!(sum, 4949);
+
+    let mut sum = 0i;
+    for int_range_rev(99, 1) |i| {
+        sum += i;
+    }
+    assert_eq!(sum, 4949);
+
+
+    // elements are visited in correct order
+    let primes = [2,3,5,7,11];
+    let mut prod = 1i;
+    for uint_range_rev(4, 0) |i| {
+        println(fmt!("uint 4 downto 0: %u", i));
+        prod *= int::pow(primes[i], i);
+    }
+    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3);
+    let mut prod = 1i;
+    for int_range_rev(4, 0) |i| {
+        println(fmt!("int 4 downto 0: %d", i));
+        prod *= int::pow(primes[i], i as uint);
+    }
+    assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3);
+
+
+    // range and range_rev are symmetric.
+    let mut sum_up = 0u;
+    for uint_range(10, 30) |i| {
+        sum_up += i;
+    }
+    let mut sum_down = 0u;
+    for uint_range_rev(29, 9) |i| {
+        sum_down += i;
+    }
+    assert_eq!(sum_up, sum_down);
+
+    let mut sum_up = 0;
+    for int_range(-20, 10) |i| {
+        sum_up += i;
+    }
+    let mut sum_down = 0;
+    for int_range_rev(9, -21) |i| {
+        sum_down += i;
+    }
+    assert_eq!(sum_up, sum_down);
+
+
+    // empty ranges
+    for int_range_rev(10, 10) |_| {
+        fail!("range should be empty when start == stop");
+    }
+
+    for uint_range_rev(0, 1) |_| {
+        // fail!("range should be empty when start-1 underflows");
+    }
+
+    // range iterations do not wrap/underflow
+    let mut uflo_loop_visited = ~[];
+    for int_range_step(int::min_value+15, int::min_value, -4) |x| {
+        uflo_loop_visited.push(x - int::min_value);
+    }
+    assert_eq!(uflo_loop_visited, ~[15, 11, 7, 3]);
+
+    let mut uflo_loop_visited = ~[];
+    for uint_range_step(uint::min_value+15, uint::min_value, -4) |x| {
+        uflo_loop_visited.push(x - uint::min_value);
+    }
+    assert_eq!(uflo_loop_visited, ~[15, 11, 7, 3]);
+}

--- a/src/test/run-pass/num-range.rs
+++ b/src/test/run-pass/num-range.rs
@@ -1,0 +1,119 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::int;
+use std::uint;
+
+fn uint_range(lo: uint, hi: uint, it: &fn(uint) -> bool) -> bool {
+    uint::range(lo, hi, it)
+}
+
+fn int_range(lo: int, hi: int, it: &fn(int) -> bool) -> bool {
+    int::range(lo, hi, it)
+}
+
+fn int_range_step(a: int, b: int, step: int, it: &fn(int) -> bool) -> bool {
+    int::range_step(a, b, step, it)
+}
+
+fn uint_range_step(a: uint, b: uint, s: int, it: &fn(uint) -> bool) -> bool {
+    uint::range_step(a, b, s, it)
+}
+
+pub fn main() {
+    println(fmt!("num-range start"));
+    // int and uint have same result for
+    //   Sum{2 <= i < 100} == (Sum{1 <= i <= 99} - 1) == n*(n+1)/2 - 1 for n=99
+    let mut sum = 0u;
+    for uint_range(2, 100) |i| {
+        sum += i;
+    }
+    assert_eq!(sum, 4949);
+
+    let mut sum = 0i;
+    for int_range(2, 100) |i| {
+        sum += i;
+    }
+    assert_eq!(sum, 4949);
+
+
+    // elements are visited in correct order
+    let primes = [2,3,5,7];
+    let mut prod = 1i;
+    for uint_range(0, 4) |i| {
+        prod *= int::pow(primes[i], i);
+    }
+    assert_eq!(prod, 1*3*5*5*7*7*7);
+    let mut prod = 1i;
+    for int_range(0, 4) |i| {
+        prod *= int::pow(primes[i], i as uint);
+    }
+    assert_eq!(prod, 1*3*5*5*7*7*7);
+
+
+    // empty ranges
+    for int_range(10, 10) |_| {
+        fail!("range should be empty when start == stop");
+    }
+
+    for uint_range(10, 10) |_| {
+        fail!("range should be empty when start == stop");
+    }
+
+
+    // range iterations do not wrap/overflow
+    let mut oflo_loop_visited = ~[];
+    for uint_range_step(uint::max_value-15, uint::max_value, 4) |x| {
+        oflo_loop_visited.push(uint::max_value - x);
+    }
+    assert_eq!(oflo_loop_visited, ~[15, 11, 7, 3]);
+
+    let mut oflo_loop_visited = ~[];
+    for int_range_step(int::max_value-15, int::max_value, 4) |x| {
+        oflo_loop_visited.push(int::max_value - x);
+    }
+    assert_eq!(oflo_loop_visited, ~[15, 11, 7, 3]);
+
+
+    // range_step never passes nor visits the stop element
+    for int_range_step(0, 21, 3) |x| {
+        assert!(x < 21);
+    }
+
+    // range_step_inclusive will never pass stop element, and may skip it.
+    let mut saw21 = false;
+    for uint::range_step_inclusive(0, 21, 4) |x| {
+        assert!(x <= 21);
+        if x == 21 { saw21 = true; }
+    }
+    assert!(!saw21);
+    let mut saw21 = false;
+    for int::range_step_inclusive(0, 21, 4) |x| {
+        assert!(x <= 21);
+        if x == 21 { saw21 = true; }
+    }
+    assert!(!saw21);
+
+    // range_step_inclusive will never pass stop element, but may visit it.
+    let mut saw21 = false;
+    for uint::range_step_inclusive(0, 21, 3) |x| {
+        assert!(x <= 21);
+        println(fmt!("saw: %u", x));
+        if x == 21 { saw21 = true; }
+    }
+    assert!(saw21);
+    let mut saw21 = false;
+    for int::range_step_inclusive(0, 21, 3) |x| {
+        assert!(x <= 21);
+        if x == 21 { saw21 = true; }
+    }
+    assert!(saw21);
+
+}


### PR DESCRIPTION
It disables the insertion of `use std::prelude::*;` into the top of
all the modules below the item on which it is placed (including that
item itself).

(Similar to GHC's `-XNoImplicitPrelude`.)
