### PR TITLE
Remove --quiet from git submodule operations

### DIFF
--- a/configure
+++ b/configure
@@ -749,18 +749,18 @@ then
     cd ${CFG_SRC_DIR}
 
     msg "git: submodule sync"
-    "${CFG_GIT}" submodule --quiet sync
+    "${CFG_GIT}" submodule sync
 
     msg "git: submodule update"
-    "${CFG_GIT}" submodule --quiet update --init
+    "${CFG_GIT}" submodule update --init
     need_ok "git failed"
 
     msg "git: submodule foreach sync"
-    "${CFG_GIT}" submodule --quiet foreach --recursive 'if test -e .gitmodules; then git submodule sync; fi'
+    "${CFG_GIT}" submodule foreach --recursive 'if test -e .gitmodules; then git submodule sync; fi'
     need_ok "git failed"
 
     msg "git: submodule foreach update"
-    "${CFG_GIT}" submodule --quiet update --init --recursive
+    "${CFG_GIT}" submodule update --init --recursive
     need_ok "git failed"
 
     # NB: this is just for the sake of getting the submodule SHA1 values
@@ -769,9 +769,9 @@ then
     "${CFG_GIT}" submodule status --recursive
 
     msg "git: submodule clobber"
-    "${CFG_GIT}" submodule --quiet foreach --recursive git clean -dxf
+    "${CFG_GIT}" submodule foreach --recursive git clean -dxf
     need_ok "git failed"
-    "${CFG_GIT}" submodule --quiet foreach --recursive git checkout .
+    "${CFG_GIT}" submodule foreach --recursive git checkout .
     need_ok "git failed"
 
     cd ${CFG_BUILD_DIR}


### PR DESCRIPTION
Closes #3816.

Without --quiet, git shows its own progress report of download. It's not really a progress bar, but it's a percentage and files incoming. This will help initial downloads of LLVM to not cause people to wonder why their configure script is hanging for hours.

r? @graydon
