### PR TITLE
Adapted `trans::common::{block, fn_ctxt, scope_info}` to new naming convention.

### DIFF
--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -25,7 +25,7 @@ use std::str;
 use syntax::ast;
 
 // Take an inline assembly expression and splat it out via LLVM
-pub fn trans_inline_asm(bcx: block, ia: &ast::inline_asm) -> block {
+pub fn trans_inline_asm(bcx: @mut Block, ia: &ast::inline_asm) -> @mut Block {
 
     let mut bcx = bcx;
     let mut constraints = ~[];

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -23,17 +23,17 @@ use middle::trans::type_::Type;
 use std::cast;
 use std::libc::{c_uint, c_ulonglong, c_char};
 
-pub fn terminate(cx: block, _: &str) {
+pub fn terminate(cx: @mut Block, _: &str) {
     cx.terminated = true;
 }
 
-pub fn check_not_terminated(cx: block) {
+pub fn check_not_terminated(cx: @mut Block) {
     if cx.terminated {
         fail!("already terminated!");
     }
 }
 
-pub fn B(cx: block) -> Builder {
+pub fn B(cx: @mut Block) -> Builder {
     let b = cx.fcx.ccx.builder();
     b.position_at_end(cx.llbb);
     b
@@ -47,35 +47,35 @@ pub fn B(cx: block) -> Builder {
 // for (fail/break/return statements, call to diverging functions, etc), and
 // further instructions to the block should simply be ignored.
 
-pub fn RetVoid(cx: block) {
+pub fn RetVoid(cx: @mut Block) {
     if cx.unreachable { return; }
     check_not_terminated(cx);
     terminate(cx, "RetVoid");
     B(cx).ret_void();
 }
 
-pub fn Ret(cx: block, V: ValueRef) {
+pub fn Ret(cx: @mut Block, V: ValueRef) {
     if cx.unreachable { return; }
     check_not_terminated(cx);
     terminate(cx, "Ret");
     B(cx).ret(V);
 }
 
-pub fn AggregateRet(cx: block, RetVals: &[ValueRef]) {
+pub fn AggregateRet(cx: @mut Block, RetVals: &[ValueRef]) {
     if cx.unreachable { return; }
     check_not_terminated(cx);
     terminate(cx, "AggregateRet");
     B(cx).aggregate_ret(RetVals);
 }
 
-pub fn Br(cx: block, Dest: BasicBlockRef) {
+pub fn Br(cx: @mut Block, Dest: BasicBlockRef) {
     if cx.unreachable { return; }
     check_not_terminated(cx);
     terminate(cx, "Br");
     B(cx).br(Dest);
 }
 
-pub fn CondBr(cx: block, If: ValueRef, Then: BasicBlockRef,
+pub fn CondBr(cx: @mut Block, If: ValueRef, Then: BasicBlockRef,
               Else: BasicBlockRef) {
     if cx.unreachable { return; }
     check_not_terminated(cx);
@@ -83,7 +83,7 @@ pub fn CondBr(cx: block, If: ValueRef, Then: BasicBlockRef,
     B(cx).cond_br(If, Then, Else);
 }
 
-pub fn Switch(cx: block, V: ValueRef, Else: BasicBlockRef, NumCases: uint)
+pub fn Switch(cx: @mut Block, V: ValueRef, Else: BasicBlockRef, NumCases: uint)
     -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     check_not_terminated(cx);
@@ -98,14 +98,14 @@ pub fn AddCase(S: ValueRef, OnVal: ValueRef, Dest: BasicBlockRef) {
     }
 }
 
-pub fn IndirectBr(cx: block, Addr: ValueRef, NumDests: uint) {
+pub fn IndirectBr(cx: @mut Block, Addr: ValueRef, NumDests: uint) {
     if cx.unreachable { return; }
     check_not_terminated(cx);
     terminate(cx, "IndirectBr");
     B(cx).indirect_br(Addr, NumDests);
 }
 
-pub fn Invoke(cx: block,
+pub fn Invoke(cx: @mut Block,
               Fn: ValueRef,
               Args: &[ValueRef],
               Then: BasicBlockRef,
@@ -122,7 +122,7 @@ pub fn Invoke(cx: block,
     B(cx).invoke(Fn, Args, Then, Catch)
 }
 
-pub fn FastInvoke(cx: block, Fn: ValueRef, Args: &[ValueRef],
+pub fn FastInvoke(cx: @mut Block, Fn: ValueRef, Args: &[ValueRef],
                   Then: BasicBlockRef, Catch: BasicBlockRef) {
     if cx.unreachable { return; }
     check_not_terminated(cx);
@@ -130,7 +130,7 @@ pub fn FastInvoke(cx: block, Fn: ValueRef, Args: &[ValueRef],
     B(cx).fast_invoke(Fn, Args, Then, Catch);
 }
 
-pub fn Unreachable(cx: block) {
+pub fn Unreachable(cx: @mut Block) {
     if cx.unreachable { return; }
     cx.unreachable = true;
     if !cx.terminated {
@@ -145,177 +145,177 @@ pub fn _Undef(val: ValueRef) -> ValueRef {
 }
 
 /* Arithmetic */
-pub fn Add(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Add(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).add(LHS, RHS)
 }
 
-pub fn NSWAdd(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NSWAdd(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nswadd(LHS, RHS)
 }
 
-pub fn NUWAdd(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NUWAdd(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nuwadd(LHS, RHS)
 }
 
-pub fn FAdd(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn FAdd(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).fadd(LHS, RHS)
 }
 
-pub fn Sub(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Sub(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).sub(LHS, RHS)
 }
 
-pub fn NSWSub(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NSWSub(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nswsub(LHS, RHS)
 }
 
-pub fn NUWSub(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NUWSub(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nuwsub(LHS, RHS)
 }
 
-pub fn FSub(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn FSub(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).fsub(LHS, RHS)
 }
 
-pub fn Mul(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Mul(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).mul(LHS, RHS)
 }
 
-pub fn NSWMul(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NSWMul(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nswmul(LHS, RHS)
 }
 
-pub fn NUWMul(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NUWMul(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nuwmul(LHS, RHS)
 }
 
-pub fn FMul(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn FMul(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).fmul(LHS, RHS)
 }
 
-pub fn UDiv(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn UDiv(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).udiv(LHS, RHS)
 }
 
-pub fn SDiv(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn SDiv(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).sdiv(LHS, RHS)
 }
 
-pub fn ExactSDiv(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn ExactSDiv(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).exactsdiv(LHS, RHS)
 }
 
-pub fn FDiv(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn FDiv(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).fdiv(LHS, RHS)
 }
 
-pub fn URem(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn URem(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).urem(LHS, RHS)
 }
 
-pub fn SRem(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn SRem(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).srem(LHS, RHS)
 }
 
-pub fn FRem(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn FRem(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).frem(LHS, RHS)
 }
 
-pub fn Shl(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Shl(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).shl(LHS, RHS)
 }
 
-pub fn LShr(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn LShr(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).lshr(LHS, RHS)
 }
 
-pub fn AShr(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn AShr(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).ashr(LHS, RHS)
 }
 
-pub fn And(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn And(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).and(LHS, RHS)
 }
 
-pub fn Or(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Or(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).or(LHS, RHS)
 }
 
-pub fn Xor(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Xor(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).xor(LHS, RHS)
 }
 
-pub fn BinOp(cx: block, Op: Opcode, LHS: ValueRef, RHS: ValueRef)
+pub fn BinOp(cx: @mut Block, Op: Opcode, LHS: ValueRef, RHS: ValueRef)
           -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).binop(Op, LHS, RHS)
 }
 
-pub fn Neg(cx: block, V: ValueRef) -> ValueRef {
+pub fn Neg(cx: @mut Block, V: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     B(cx).neg(V)
 }
 
-pub fn NSWNeg(cx: block, V: ValueRef) -> ValueRef {
+pub fn NSWNeg(cx: @mut Block, V: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     B(cx).nswneg(V)
 }
 
-pub fn NUWNeg(cx: block, V: ValueRef) -> ValueRef {
+pub fn NUWNeg(cx: @mut Block, V: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     B(cx).nuwneg(V)
 }
-pub fn FNeg(cx: block, V: ValueRef) -> ValueRef {
+pub fn FNeg(cx: @mut Block, V: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     B(cx).fneg(V)
 }
 
-pub fn Not(cx: block, V: ValueRef) -> ValueRef {
+pub fn Not(cx: @mut Block, V: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     B(cx).not(V)
 }
 
 /* Memory */
-pub fn Malloc(cx: block, Ty: Type) -> ValueRef {
+pub fn Malloc(cx: @mut Block, Ty: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
         B(cx).malloc(Ty)
     }
 }
 
-pub fn ArrayMalloc(cx: block, Ty: Type, Val: ValueRef) -> ValueRef {
+pub fn ArrayMalloc(cx: @mut Block, Ty: Type, Val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
         B(cx).array_malloc(Ty, Val)
     }
 }
 
-pub fn Alloca(cx: block, Ty: Type, name: &str) -> ValueRef {
+pub fn Alloca(cx: @mut Block, Ty: Type, name: &str) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Ty.ptr_to().to_ref()); }
         let b = cx.fcx.ccx.builder();
@@ -324,7 +324,7 @@ pub fn Alloca(cx: block, Ty: Type, name: &str) -> ValueRef {
     }
 }
 
-pub fn ArrayAlloca(cx: block, Ty: Type, Val: ValueRef) -> ValueRef {
+pub fn ArrayAlloca(cx: @mut Block, Ty: Type, Val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Ty.ptr_to().to_ref()); }
         let b = cx.fcx.ccx.builder();
@@ -333,12 +333,12 @@ pub fn ArrayAlloca(cx: block, Ty: Type, Val: ValueRef) -> ValueRef {
     }
 }
 
-pub fn Free(cx: block, PointerVal: ValueRef) {
+pub fn Free(cx: @mut Block, PointerVal: ValueRef) {
     if cx.unreachable { return; }
     B(cx).free(PointerVal)
 }
 
-pub fn Load(cx: block, PointerVal: ValueRef) -> ValueRef {
+pub fn Load(cx: @mut Block, PointerVal: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         if cx.unreachable {
@@ -354,7 +354,7 @@ pub fn Load(cx: block, PointerVal: ValueRef) -> ValueRef {
     }
 }
 
-pub fn AtomicLoad(cx: block, PointerVal: ValueRef, order: AtomicOrdering) -> ValueRef {
+pub fn AtomicLoad(cx: @mut Block, PointerVal: ValueRef, order: AtomicOrdering) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         if cx.unreachable {
@@ -365,7 +365,7 @@ pub fn AtomicLoad(cx: block, PointerVal: ValueRef, order: AtomicOrdering) -> Val
 }
 
 
-pub fn LoadRangeAssert(cx: block, PointerVal: ValueRef, lo: c_ulonglong,
+pub fn LoadRangeAssert(cx: @mut Block, PointerVal: ValueRef, lo: c_ulonglong,
                        hi: c_ulonglong, signed: lib::llvm::Bool) -> ValueRef {
     if cx.unreachable {
         let ccx = cx.fcx.ccx;
@@ -383,17 +383,17 @@ pub fn LoadRangeAssert(cx: block, PointerVal: ValueRef, lo: c_ulonglong,
     }
 }
 
-pub fn Store(cx: block, Val: ValueRef, Ptr: ValueRef) {
+pub fn Store(cx: @mut Block, Val: ValueRef, Ptr: ValueRef) {
     if cx.unreachable { return; }
     B(cx).store(Val, Ptr)
 }
 
-pub fn AtomicStore(cx: block, Val: ValueRef, Ptr: ValueRef, order: AtomicOrdering) {
+pub fn AtomicStore(cx: @mut Block, Val: ValueRef, Ptr: ValueRef, order: AtomicOrdering) {
     if cx.unreachable { return; }
     B(cx).atomic_store(Val, Ptr, order)
 }
 
-pub fn GEP(cx: block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
+pub fn GEP(cx: @mut Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
         B(cx).gep(Pointer, Indices)
@@ -403,35 +403,35 @@ pub fn GEP(cx: block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
 // Simple wrapper around GEP that takes an array of ints and wraps them
 // in C_i32()
 #[inline]
-pub fn GEPi(cx: block, base: ValueRef, ixs: &[uint]) -> ValueRef {
+pub fn GEPi(cx: @mut Block, base: ValueRef, ixs: &[uint]) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
         B(cx).gepi(base, ixs)
     }
 }
 
-pub fn InBoundsGEP(cx: block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
+pub fn InBoundsGEP(cx: @mut Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
         B(cx).inbounds_gep(Pointer, Indices)
     }
 }
 
-pub fn StructGEP(cx: block, Pointer: ValueRef, Idx: uint) -> ValueRef {
+pub fn StructGEP(cx: @mut Block, Pointer: ValueRef, Idx: uint) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
         B(cx).struct_gep(Pointer, Idx)
     }
 }
 
-pub fn GlobalString(cx: block, _Str: *c_char) -> ValueRef {
+pub fn GlobalString(cx: @mut Block, _Str: *c_char) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
         B(cx).global_string(_Str)
     }
 }
 
-pub fn GlobalStringPtr(cx: block, _Str: *c_char) -> ValueRef {
+pub fn GlobalStringPtr(cx: @mut Block, _Str: *c_char) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
         B(cx).global_string_ptr(_Str)
@@ -439,112 +439,112 @@ pub fn GlobalStringPtr(cx: block, _Str: *c_char) -> ValueRef {
 }
 
 /* Casts */
-pub fn Trunc(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn Trunc(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).trunc(Val, DestTy)
     }
 }
 
-pub fn ZExt(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn ZExt(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).zext(Val, DestTy)
     }
 }
 
-pub fn SExt(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn SExt(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).sext(Val, DestTy)
     }
 }
 
-pub fn FPToUI(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPToUI(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).fptoui(Val, DestTy)
     }
 }
 
-pub fn FPToSI(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPToSI(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).fptosi(Val, DestTy)
     }
 }
 
-pub fn UIToFP(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn UIToFP(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).uitofp(Val, DestTy)
     }
 }
 
-pub fn SIToFP(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn SIToFP(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).sitofp(Val, DestTy)
     }
 }
 
-pub fn FPTrunc(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPTrunc(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).fptrunc(Val, DestTy)
     }
 }
 
-pub fn FPExt(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPExt(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).fpext(Val, DestTy)
     }
 }
 
-pub fn PtrToInt(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn PtrToInt(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).ptrtoint(Val, DestTy)
     }
 }
 
-pub fn IntToPtr(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn IntToPtr(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).inttoptr(Val, DestTy)
     }
 }
 
-pub fn BitCast(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn BitCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).bitcast(Val, DestTy)
     }
 }
 
-pub fn ZExtOrBitCast(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn ZExtOrBitCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).zext_or_bitcast(Val, DestTy)
     }
 }
 
-pub fn SExtOrBitCast(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn SExtOrBitCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).sext_or_bitcast(Val, DestTy)
     }
 }
 
-pub fn TruncOrBitCast(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn TruncOrBitCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).trunc_or_bitcast(Val, DestTy)
     }
 }
 
-pub fn Cast(cx: block, Op: Opcode, Val: ValueRef, DestTy: Type, _: *u8)
+pub fn Cast(cx: @mut Block, Op: Opcode, Val: ValueRef, DestTy: Type, _: *u8)
      -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
@@ -552,21 +552,21 @@ pub fn Cast(cx: block, Op: Opcode, Val: ValueRef, DestTy: Type, _: *u8)
     }
 }
 
-pub fn PointerCast(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn PointerCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).pointercast(Val, DestTy)
     }
 }
 
-pub fn IntCast(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn IntCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).intcast(Val, DestTy)
     }
 }
 
-pub fn FPCast(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).fpcast(Val, DestTy)
@@ -575,7 +575,7 @@ pub fn FPCast(cx: block, Val: ValueRef, DestTy: Type) -> ValueRef {
 
 
 /* Comparisons */
-pub fn ICmp(cx: block, Op: IntPredicate, LHS: ValueRef, RHS: ValueRef)
+pub fn ICmp(cx: @mut Block, Op: IntPredicate, LHS: ValueRef, RHS: ValueRef)
      -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
@@ -583,7 +583,7 @@ pub fn ICmp(cx: block, Op: IntPredicate, LHS: ValueRef, RHS: ValueRef)
     }
 }
 
-pub fn FCmp(cx: block, Op: RealPredicate, LHS: ValueRef, RHS: ValueRef)
+pub fn FCmp(cx: @mut Block, Op: RealPredicate, LHS: ValueRef, RHS: ValueRef)
      -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
@@ -592,14 +592,14 @@ pub fn FCmp(cx: block, Op: RealPredicate, LHS: ValueRef, RHS: ValueRef)
 }
 
 /* Miscellaneous instructions */
-pub fn EmptyPhi(cx: block, Ty: Type) -> ValueRef {
+pub fn EmptyPhi(cx: @mut Block, Ty: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Ty.to_ref()); }
         B(cx).empty_phi(Ty)
     }
 }
 
-pub fn Phi(cx: block, Ty: Type, vals: &[ValueRef], bbs: &[BasicBlockRef]) -> ValueRef {
+pub fn Phi(cx: @mut Block, Ty: Type, vals: &[ValueRef], bbs: &[BasicBlockRef]) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Ty.to_ref()); }
         B(cx).phi(Ty, vals, bbs)
@@ -615,7 +615,7 @@ pub fn AddIncomingToPhi(phi: ValueRef, val: ValueRef, bb: BasicBlockRef) {
     }
 }
 
-pub fn _UndefReturn(cx: block, Fn: ValueRef) -> ValueRef {
+pub fn _UndefReturn(cx: @mut Block, Fn: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         let ty = val_ty(Fn);
@@ -629,57 +629,57 @@ pub fn _UndefReturn(cx: block, Fn: ValueRef) -> ValueRef {
     }
 }
 
-pub fn add_span_comment(cx: block, sp: span, text: &str) {
+pub fn add_span_comment(cx: @mut Block, sp: span, text: &str) {
     B(cx).add_span_comment(sp, text)
 }
 
-pub fn add_comment(cx: block, text: &str) {
+pub fn add_comment(cx: @mut Block, text: &str) {
     B(cx).add_comment(text)
 }
 
-pub fn InlineAsmCall(cx: block, asm: *c_char, cons: *c_char,
+pub fn InlineAsmCall(cx: @mut Block, asm: *c_char, cons: *c_char,
                      inputs: &[ValueRef], output: Type,
                      volatile: bool, alignstack: bool,
                      dia: AsmDialect) -> ValueRef {
     B(cx).inline_asm_call(asm, cons, inputs, output, volatile, alignstack, dia)
 }
 
-pub fn Call(cx: block, Fn: ValueRef, Args: &[ValueRef]) -> ValueRef {
+pub fn Call(cx: @mut Block, Fn: ValueRef, Args: &[ValueRef]) -> ValueRef {
     if cx.unreachable { return _UndefReturn(cx, Fn); }
     B(cx).call(Fn, Args)
 }
 
-pub fn FastCall(cx: block, Fn: ValueRef, Args: &[ValueRef]) -> ValueRef {
+pub fn FastCall(cx: @mut Block, Fn: ValueRef, Args: &[ValueRef]) -> ValueRef {
     if cx.unreachable { return _UndefReturn(cx, Fn); }
     B(cx).call(Fn, Args)
 }
 
-pub fn CallWithConv(cx: block, Fn: ValueRef, Args: &[ValueRef],
+pub fn CallWithConv(cx: @mut Block, Fn: ValueRef, Args: &[ValueRef],
                     Conv: CallConv) -> ValueRef {
     if cx.unreachable { return _UndefReturn(cx, Fn); }
     B(cx).call_with_conv(Fn, Args, Conv)
 }
 
-pub fn Select(cx: block, If: ValueRef, Then: ValueRef, Else: ValueRef) -> ValueRef {
+pub fn Select(cx: @mut Block, If: ValueRef, Then: ValueRef, Else: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(Then); }
     B(cx).select(If, Then, Else)
 }
 
-pub fn VAArg(cx: block, list: ValueRef, Ty: Type) -> ValueRef {
+pub fn VAArg(cx: @mut Block, list: ValueRef, Ty: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Ty.to_ref()); }
         B(cx).va_arg(list, Ty)
     }
 }
 
-pub fn ExtractElement(cx: block, VecVal: ValueRef, Index: ValueRef) -> ValueRef {
+pub fn ExtractElement(cx: @mut Block, VecVal: ValueRef, Index: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
         B(cx).extract_element(VecVal, Index)
     }
 }
 
-pub fn InsertElement(cx: block, VecVal: ValueRef, EltVal: ValueRef,
+pub fn InsertElement(cx: @mut Block, VecVal: ValueRef, EltVal: ValueRef,
                      Index: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
@@ -687,7 +687,7 @@ pub fn InsertElement(cx: block, VecVal: ValueRef, EltVal: ValueRef,
     }
 }
 
-pub fn ShuffleVector(cx: block, V1: ValueRef, V2: ValueRef,
+pub fn ShuffleVector(cx: @mut Block, V1: ValueRef, V2: ValueRef,
                      Mask: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
@@ -695,40 +695,40 @@ pub fn ShuffleVector(cx: block, V1: ValueRef, V2: ValueRef,
     }
 }
 
-pub fn VectorSplat(cx: block, NumElts: uint, EltVal: ValueRef) -> ValueRef {
+pub fn VectorSplat(cx: @mut Block, NumElts: uint, EltVal: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
         B(cx).vector_splat(NumElts, EltVal)
     }
 }
 
-pub fn ExtractValue(cx: block, AggVal: ValueRef, Index: uint) -> ValueRef {
+pub fn ExtractValue(cx: @mut Block, AggVal: ValueRef, Index: uint) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
         B(cx).extract_value(AggVal, Index)
     }
 }
 
-pub fn InsertValue(cx: block, AggVal: ValueRef, EltVal: ValueRef, Index: uint) {
+pub fn InsertValue(cx: @mut Block, AggVal: ValueRef, EltVal: ValueRef, Index: uint) {
     if cx.unreachable { return; }
     B(cx).insert_value(AggVal, EltVal, Index)
 }
 
-pub fn IsNull(cx: block, Val: ValueRef) -> ValueRef {
+pub fn IsNull(cx: @mut Block, Val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
         B(cx).is_null(Val)
     }
 }
 
-pub fn IsNotNull(cx: block, Val: ValueRef) -> ValueRef {
+pub fn IsNotNull(cx: @mut Block, Val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
         B(cx).is_not_null(Val)
     }
 }
 
-pub fn PtrDiff(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn PtrDiff(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         if cx.unreachable { return llvm::LLVMGetUndef(ccx.int_type.to_ref()); }
@@ -736,35 +736,35 @@ pub fn PtrDiff(cx: block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     }
 }
 
-pub fn Trap(cx: block) {
+pub fn Trap(cx: @mut Block) {
     if cx.unreachable { return; }
     B(cx).trap();
 }
 
-pub fn LandingPad(cx: block, Ty: Type, PersFn: ValueRef,
+pub fn LandingPad(cx: @mut Block, Ty: Type, PersFn: ValueRef,
                   NumClauses: uint) -> ValueRef {
     check_not_terminated(cx);
     assert!(!cx.unreachable);
     B(cx).landing_pad(Ty, PersFn, NumClauses)
 }
 
-pub fn SetCleanup(cx: block, LandingPad: ValueRef) {
+pub fn SetCleanup(cx: @mut Block, LandingPad: ValueRef) {
     B(cx).set_cleanup(LandingPad)
 }
 
-pub fn Resume(cx: block, Exn: ValueRef) -> ValueRef {
+pub fn Resume(cx: @mut Block, Exn: ValueRef) -> ValueRef {
     check_not_terminated(cx);
     terminate(cx, "Resume");
     B(cx).resume(Exn)
 }
 
 // Atomic Operations
-pub fn AtomicCmpXchg(cx: block, dst: ValueRef,
+pub fn AtomicCmpXchg(cx: @mut Block, dst: ValueRef,
                      cmp: ValueRef, src: ValueRef,
                      order: AtomicOrdering) -> ValueRef {
     B(cx).atomic_cmpxchg(dst, cmp, src, order)
 }
-pub fn AtomicRMW(cx: block, op: AtomicBinOp,
+pub fn AtomicRMW(cx: @mut Block, op: AtomicBinOp,
                  dst: ValueRef, src: ValueRef,
                  order: AtomicOrdering) -> ValueRef {
     B(cx).atomic_rmw(op, dst, src, order)

--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -56,7 +56,7 @@ impl FnType {
         return llfn;
     }
 
-    pub fn build_shim_args(&self, bcx: block, arg_tys: &[Type], llargbundle: ValueRef)
+    pub fn build_shim_args(&self, bcx: @mut Block, arg_tys: &[Type], llargbundle: ValueRef)
                            -> ~[ValueRef] {
         let mut atys: &[LLVMType] = self.arg_tys;
         let mut attrs: &[option::Option<Attribute>] = self.attrs;
@@ -90,7 +90,7 @@ impl FnType {
         return llargvals;
     }
 
-    pub fn build_shim_ret(&self, bcx: block, arg_tys: &[Type], ret_def: bool,
+    pub fn build_shim_ret(&self, bcx: @mut Block, arg_tys: &[Type], ret_def: bool,
                           llargbundle: ValueRef, llretval: ValueRef) {
         for self.attrs.iter().enumerate().advance |(i, a)| {
             match *a {
@@ -120,7 +120,7 @@ impl FnType {
         };
     }
 
-    pub fn build_wrap_args(&self, bcx: block, ret_ty: Type,
+    pub fn build_wrap_args(&self, bcx: @mut Block, ret_ty: Type,
                            llwrapfn: ValueRef, llargbundle: ValueRef) {
         let mut atys: &[LLVMType] = self.arg_tys;
         let mut attrs: &[option::Option<Attribute>] = self.attrs;
@@ -156,7 +156,7 @@ impl FnType {
         store_inbounds(bcx, llretptr, llargbundle, [0u, n]);
     }
 
-    pub fn build_wrap_ret(&self, bcx: block, arg_tys: &[Type], llargbundle: ValueRef) {
+    pub fn build_wrap_ret(&self, bcx: @mut Block, arg_tys: &[Type], llargbundle: ValueRef) {
         if self.ret_ty.ty.kind() == Void {
             return;
         }

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -156,7 +156,7 @@ pub fn mk_closure_tys(tcx: ty::ctxt,
     return cdata_ty;
 }
 
-fn heap_for_unique_closure(bcx: block, t: ty::t) -> heap {
+fn heap_for_unique_closure(bcx: @mut Block, t: ty::t) -> heap {
     if ty::type_contents(bcx.tcx(), t).contains_managed() {
         heap_managed_unique
     } else {
@@ -164,7 +164,7 @@ fn heap_for_unique_closure(bcx: block, t: ty::t) -> heap {
     }
 }
 
-pub fn allocate_cbox(bcx: block, sigil: ast::Sigil, cdata_ty: ty::t)
+pub fn allocate_cbox(bcx: @mut Block, sigil: ast::Sigil, cdata_ty: ty::t)
                   -> Result {
     let _icx = push_ctxt("closure::allocate_cbox");
     let ccx = bcx.ccx();
@@ -189,14 +189,14 @@ pub fn allocate_cbox(bcx: block, sigil: ast::Sigil, cdata_ty: ty::t)
 pub struct ClosureResult {
     llbox: ValueRef, // llvalue of ptr to closure
     cdata_ty: ty::t, // type of the closure data
-    bcx: block       // final bcx
+    bcx: @mut Block       // final bcx
 }
 
 // Given a block context and a list of tydescs and values to bind
 // construct a closure out of them. If copying is true, it is a
 // heap allocated closure that copies the upvars into environment.
 // Otherwise, it is stack allocated and copies pointers to the upvars.
-pub fn store_environment(bcx: block,
+pub fn store_environment(bcx: @mut Block,
                          bound_values: ~[EnvValue],
                          sigil: ast::Sigil) -> ClosureResult {
     let _icx = push_ctxt("closure::store_environment");
@@ -257,7 +257,7 @@ pub fn store_environment(bcx: block,
 
 // Given a context and a list of upvars, build a closure. This just
 // collects the upvars and packages them up for store_environment.
-pub fn build_closure(bcx0: block,
+pub fn build_closure(bcx0: @mut Block,
                      cap_vars: &[moves::CaptureVar],
                      sigil: ast::Sigil,
                      include_ret_handle: Option<ValueRef>) -> ClosureResult {
@@ -318,7 +318,7 @@ pub fn build_closure(bcx0: block,
 // Given an enclosing block context, a new function context, a closure type,
 // and a list of upvars, generate code to load and populate the environment
 // with the upvars and type descriptors.
-pub fn load_environment(fcx: fn_ctxt,
+pub fn load_environment(fcx: @mut FunctionContext,
                         cdata_ty: ty::t,
                         cap_vars: &[moves::CaptureVar],
                         load_ret_handle: bool,
@@ -355,14 +355,14 @@ pub fn load_environment(fcx: fn_ctxt,
     }
 }
 
-pub fn trans_expr_fn(bcx: block,
+pub fn trans_expr_fn(bcx: @mut Block,
                      sigil: ast::Sigil,
                      decl: &ast::fn_decl,
                      body: &ast::Block,
                      outer_id: ast::node_id,
                      user_id: ast::node_id,
                      is_loop_body: Option<Option<ValueRef>>,
-                     dest: expr::Dest) -> block {
+                     dest: expr::Dest) -> @mut Block {
     /*!
      *
      * Translates the body of a closure expression.
@@ -455,10 +455,10 @@ pub fn trans_expr_fn(bcx: block,
 }
 
 pub fn make_closure_glue(
-        cx: block,
+        cx: @mut Block,
         v: ValueRef,
         t: ty::t,
-        glue_fn: &fn(block, v: ValueRef, t: ty::t) -> block) -> block {
+        glue_fn: &fn(@mut Block, v: ValueRef, t: ty::t) -> @mut Block) -> @mut Block {
     let _icx = push_ctxt("closure::make_closure_glue");
     let bcx = cx;
     let tcx = cx.tcx();
@@ -478,10 +478,10 @@ pub fn make_closure_glue(
 }
 
 pub fn make_opaque_cbox_take_glue(
-    bcx: block,
+    bcx: @mut Block,
     sigil: ast::Sigil,
     cboxptr: ValueRef)     // ptr to ptr to the opaque closure
-    -> block {
+    -> @mut Block {
     // Easy cases:
     let _icx = push_ctxt("closure::make_opaque_cbox_take_glue");
     match sigil {
@@ -499,10 +499,10 @@ pub fn make_opaque_cbox_take_glue(
 }
 
 pub fn make_opaque_cbox_drop_glue(
-    bcx: block,
+    bcx: @mut Block,
     sigil: ast::Sigil,
     cboxptr: ValueRef)     // ptr to the opaque closure
-    -> block {
+    -> @mut Block {
     let _icx = push_ctxt("closure::make_opaque_cbox_drop_glue");
     match sigil {
         ast::BorrowedSigil => bcx,
@@ -520,10 +520,10 @@ pub fn make_opaque_cbox_drop_glue(
 }
 
 pub fn make_opaque_cbox_free_glue(
-    bcx: block,
+    bcx: @mut Block,
     sigil: ast::Sigil,
     cbox: ValueRef)     // ptr to ptr to the opaque closure
-    -> block {
+    -> @mut Block {
     let _icx = push_ctxt("closure::make_opaque_cbox_free_glue");
     match sigil {
         ast::BorrowedSigil => {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -134,7 +134,7 @@ pub fn finalize(cx: @mut CrateContext) {
 ///
 /// Adds the created metadata nodes directly to the crate's IR.
 /// The return value should be ignored if called from outside of the debuginfo module.
-pub fn create_local_var_metadata(bcx: block, local: @ast::Local) -> DIVariable {
+pub fn create_local_var_metadata(bcx: @mut Block, local: @ast::Local) -> DIVariable {
     let cx = bcx.ccx();
 
     let ident = match local.pat.node {
@@ -198,7 +198,7 @@ pub fn create_local_var_metadata(bcx: block, local: @ast::Local) -> DIVariable {
 ///
 /// Adds the created metadata nodes directly to the crate's IR.
 /// The return value should be ignored if called from outside of the debuginfo module.
-pub fn create_argument_metadata(bcx: block, arg: &ast::arg, span: span) -> Option<DIVariable> {
+pub fn create_argument_metadata(bcx: @mut Block, arg: &ast::arg, span: span) -> Option<DIVariable> {
     debug!("create_argument_metadata");
     if true {
         // XXX create_argument_metadata disabled for now because "node_id_type(bcx, arg.id)" below
@@ -260,7 +260,7 @@ pub fn create_argument_metadata(bcx: block, arg: &ast::arg, span: span) -> Optio
 /// Sets the current debug location at the beginning of the span
 ///
 /// Maps to a call to llvm::LLVMSetCurrentDebugLocation(...)
-pub fn update_source_pos(bcx: block, span: span) {
+pub fn update_source_pos(bcx: @mut Block, span: span) {
     if !bcx.sess().opts.debuginfo || (*span.lo == 0 && *span.hi == 0) {
         return;
     }
@@ -273,9 +273,8 @@ pub fn update_source_pos(bcx: block, span: span) {
 ///
 /// Adds the created metadata nodes directly to the crate's IR.
 /// The return value should be ignored if called from outside of the debuginfo module.
-pub fn create_function_metadata(fcx: fn_ctxt) -> DISubprogram {
+pub fn create_function_metadata(fcx: &FunctionContext) -> DISubprogram {
     let cx = fcx.ccx;
-    let fcx = &mut *fcx;
     let span = fcx.span.get();
 
     let fnitem = cx.tcx.items.get_copy(&fcx.id);
@@ -445,7 +444,7 @@ fn file_metadata(cx: &mut CrateContext, full_path: &str) -> DIFile {
 }
 
 /// Get or create the lexical block metadata node for the given LLVM basic block.
-fn lexical_block_metadata(bcx: block) -> DILexicalBlock {
+fn lexical_block_metadata(bcx: @mut Block) -> DILexicalBlock {
     let cx = bcx.ccx();
     let mut bcx = bcx;
 

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -175,13 +175,13 @@ impl Dest {
     }
 }
 
-fn drop_and_cancel_clean(bcx: block, dat: Datum) -> block {
+fn drop_and_cancel_clean(bcx: @mut Block, dat: Datum) -> @mut Block {
     let bcx = dat.drop_val(bcx);
     dat.cancel_clean(bcx);
     return bcx;
 }
 
-pub fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
+pub fn trans_to_datum(bcx: @mut Block, expr: @ast::expr) -> DatumBlock {
     debug!("trans_to_datum(expr=%s)", bcx.expr_to_str(expr));
 
     let mut bcx = bcx;
@@ -231,11 +231,11 @@ pub fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
     debug!("after adjustments, datum=%s", datum.to_str(bcx.ccx()));
     return DatumBlock {bcx: bcx, datum: datum};
 
-    fn auto_ref(bcx: block, datum: Datum) -> DatumBlock {
+    fn auto_ref(bcx: @mut Block, datum: Datum) -> DatumBlock {
         DatumBlock {bcx: bcx, datum: datum.to_rptr(bcx)}
     }
 
-    fn auto_borrow_fn(bcx: block,
+    fn auto_borrow_fn(bcx: @mut Block,
                       adjusted_ty: ty::t,
                       datum: Datum) -> DatumBlock {
         // Currently, all closure types are represented precisely the
@@ -246,7 +246,7 @@ pub fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
                                   mode: datum.mode}}
     }
 
-    fn auto_slice(bcx: block,
+    fn auto_slice(bcx: @mut Block,
                   autoderefs: uint,
                   expr: &ast::expr,
                   datum: Datum) -> DatumBlock {
@@ -274,7 +274,7 @@ pub fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
         DatumBlock {bcx: bcx, datum: scratch}
     }
 
-    fn add_env(bcx: block, expr: &ast::expr, datum: Datum) -> DatumBlock {
+    fn add_env(bcx: @mut Block, expr: &ast::expr, datum: Datum) -> DatumBlock {
         // This is not the most efficient thing possible; since closures
         // are two words it'd be better if this were compiled in
         // 'dest' mode, but I can't find a nice way to structure the
@@ -293,7 +293,7 @@ pub fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
         DatumBlock {bcx: bcx, datum: scratch}
     }
 
-    fn auto_slice_and_ref(bcx: block,
+    fn auto_slice_and_ref(bcx: @mut Block,
                           autoderefs: uint,
                           expr: &ast::expr,
                           datum: Datum) -> DatumBlock {
@@ -302,7 +302,7 @@ pub fn trans_to_datum(bcx: block, expr: @ast::expr) -> DatumBlock {
     }
 }
 
-pub fn trans_into(bcx: block, expr: @ast::expr, dest: Dest) -> block {
+pub fn trans_into(bcx: @mut Block, expr: @ast::expr, dest: Dest) -> @mut Block {
     if bcx.tcx().adjustments.contains_key(&expr.id) {
         // use trans_to_datum, which is mildly less efficient but
         // which will perform the adjustments:
@@ -360,7 +360,7 @@ pub fn trans_into(bcx: block, expr: @ast::expr, dest: Dest) -> block {
     };
 }
 
-fn trans_lvalue(bcx: block, expr: @ast::expr) -> DatumBlock {
+fn trans_lvalue(bcx: @mut Block, expr: @ast::expr) -> DatumBlock {
     /*!
      *
      * Translates an lvalue expression, always yielding a by-ref
@@ -379,7 +379,7 @@ fn trans_lvalue(bcx: block, expr: @ast::expr) -> DatumBlock {
     };
 }
 
-fn trans_to_datum_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
+fn trans_to_datum_unadjusted(bcx: @mut Block, expr: @ast::expr) -> DatumBlock {
     /*!
      * Translates an expression into a datum.  If this expression
      * is an rvalue, this will result in a temporary value being
@@ -439,13 +439,13 @@ fn trans_to_datum_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
         }
     }
 
-    fn nil(bcx: block, ty: ty::t) -> DatumBlock {
+    fn nil(bcx: @mut Block, ty: ty::t) -> DatumBlock {
         let datum = immediate_rvalue(C_nil(), ty);
         DatumBlock {bcx: bcx, datum: datum}
     }
 }
 
-fn trans_rvalue_datum_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
+fn trans_rvalue_datum_unadjusted(bcx: @mut Block, expr: @ast::expr) -> DatumBlock {
     let _icx = push_ctxt("trans_rvalue_datum_unadjusted");
 
     trace_span!(bcx, expr.span, shorten(bcx.expr_to_str(expr)));
@@ -495,7 +495,7 @@ fn trans_rvalue_datum_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
     }
 }
 
-fn trans_rvalue_stmt_unadjusted(bcx: block, expr: @ast::expr) -> block {
+fn trans_rvalue_stmt_unadjusted(bcx: @mut Block, expr: @ast::expr) -> @mut Block {
     let mut bcx = bcx;
     let _icx = push_ctxt("trans_rvalue_stmt");
 
@@ -551,8 +551,8 @@ fn trans_rvalue_stmt_unadjusted(bcx: block, expr: @ast::expr) -> block {
     };
 }
 
-fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
-                               dest: Dest) -> block {
+fn trans_rvalue_dps_unadjusted(bcx: @mut Block, expr: @ast::expr,
+                               dest: Dest) -> @mut Block {
     let _icx = push_ctxt("trans_rvalue_dps_unadjusted");
     let tcx = bcx.tcx();
 
@@ -697,8 +697,8 @@ fn trans_rvalue_dps_unadjusted(bcx: block, expr: @ast::expr,
     }
 }
 
-fn trans_def_dps_unadjusted(bcx: block, ref_expr: &ast::expr,
-                            def: ast::def, dest: Dest) -> block {
+fn trans_def_dps_unadjusted(bcx: @mut Block, ref_expr: &ast::expr,
+                            def: ast::def, dest: Dest) -> @mut Block {
     let _icx = push_ctxt("trans_def_dps_unadjusted");
     let ccx = bcx.ccx();
 
@@ -743,7 +743,7 @@ fn trans_def_dps_unadjusted(bcx: block, ref_expr: &ast::expr,
     }
 }
 
-fn trans_def_datum_unadjusted(bcx: block,
+fn trans_def_datum_unadjusted(bcx: @mut Block,
                               ref_expr: &ast::expr,
                               def: ast::def) -> DatumBlock
 {
@@ -767,7 +767,7 @@ fn trans_def_datum_unadjusted(bcx: block,
         }
     }
 
-    fn fn_data_to_datum(bcx: block,
+    fn fn_data_to_datum(bcx: @mut Block,
                         ref_expr: &ast::expr,
                         def_id: ast::def_id,
                         fn_data: callee::FnData) -> DatumBlock {
@@ -802,7 +802,7 @@ fn trans_def_datum_unadjusted(bcx: block,
     }
 }
 
-fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
+fn trans_lvalue_unadjusted(bcx: @mut Block, expr: @ast::expr) -> DatumBlock {
     /*!
      *
      * Translates an lvalue expression, always yielding a by-ref
@@ -841,7 +841,7 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
         }
     };
 
-    fn trans_rec_field(bcx: block,
+    fn trans_rec_field(bcx: @mut Block,
                        base: @ast::expr,
                        field: ast::ident) -> DatumBlock {
         //! Translates `base.field`.
@@ -864,7 +864,7 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
         }
     }
 
-    fn trans_index(bcx: block,
+    fn trans_index(bcx: @mut Block,
                    index_expr: &ast::expr,
                    base: @ast::expr,
                    idx: @ast::expr) -> DatumBlock {
@@ -928,7 +928,7 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
         };
     }
 
-    fn trans_def_lvalue(bcx: block,
+    fn trans_def_lvalue(bcx: @mut Block,
                         ref_expr: &ast::expr,
                         def: ast::def)
         -> DatumBlock
@@ -950,7 +950,7 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
                     }
                 }
 
-                fn get_val(bcx: block, did: ast::def_id, const_ty: ty::t)
+                fn get_val(bcx: @mut Block, did: ast::def_id, const_ty: ty::t)
                            -> ValueRef {
                     // For external constants, we don't inline.
                     if did.crate == ast::local_crate {
@@ -1004,7 +1004,7 @@ fn trans_lvalue_unadjusted(bcx: block, expr: @ast::expr) -> DatumBlock {
     }
 }
 
-pub fn trans_local_var(bcx: block, def: ast::def) -> Datum {
+pub fn trans_local_var(bcx: @mut Block, def: ast::def) -> Datum {
     let _icx = push_ctxt("trans_local_var");
 
     return match def {
@@ -1056,7 +1056,7 @@ pub fn trans_local_var(bcx: block, def: ast::def) -> Datum {
         }
     };
 
-    fn take_local(bcx: block,
+    fn take_local(bcx: @mut Block,
                   table: &HashMap<ast::node_id, ValueRef>,
                   nid: ast::node_id) -> Datum {
         let v = match table.find(&nid) {
@@ -1123,12 +1123,12 @@ pub fn with_field_tys<R>(tcx: ty::ctxt,
     }
 }
 
-fn trans_rec_or_struct(bcx: block,
+fn trans_rec_or_struct(bcx: @mut Block,
                        fields: &[ast::Field],
                        base: Option<@ast::expr>,
                        expr_span: codemap::span,
                        id: ast::node_id,
-                       dest: Dest) -> block
+                       dest: Dest) -> @mut Block
 {
     let _icx = push_ctxt("trans_rec");
     let bcx = bcx;
@@ -1200,10 +1200,10 @@ struct StructBaseInfo {
  * - `optbase` contains information on the base struct (if any) from
  * which remaining fields are copied; see comments on `StructBaseInfo`.
  */
-fn trans_adt(bcx: block, repr: &adt::Repr, discr: int,
+fn trans_adt(bcx: @mut Block, repr: &adt::Repr, discr: int,
              fields: &[(uint, @ast::expr)],
              optbase: Option<StructBaseInfo>,
-             dest: Dest) -> block {
+             dest: Dest) -> @mut Block {
     let _icx = push_ctxt("trans_adt");
     let mut bcx = bcx;
     let addr = match dest {
@@ -1248,7 +1248,7 @@ fn trans_adt(bcx: block, repr: &adt::Repr, discr: int,
 }
 
 
-fn trans_immediate_lit(bcx: block, expr: @ast::expr,
+fn trans_immediate_lit(bcx: @mut Block, expr: @ast::expr,
                        lit: ast::lit) -> DatumBlock {
     // must not be a string constant, that is a RvalueDpsExpr
     let _icx = push_ctxt("trans_immediate_lit");
@@ -1256,7 +1256,7 @@ fn trans_immediate_lit(bcx: block, expr: @ast::expr,
     immediate_rvalue_bcx(bcx, consts::const_lit(bcx.ccx(), expr, lit), ty)
 }
 
-fn trans_unary_datum(bcx: block,
+fn trans_unary_datum(bcx: @mut Block,
                      un_expr: &ast::expr,
                      op: ast::unop,
                      sub_expr: @ast::expr) -> DatumBlock {
@@ -1316,7 +1316,7 @@ fn trans_unary_datum(bcx: block,
         }
     };
 
-    fn trans_boxed_expr(bcx: block,
+    fn trans_boxed_expr(bcx: @mut Block,
                         box_ty: ty::t,
                         contents: @ast::expr,
                         contents_ty: ty::t,
@@ -1342,7 +1342,7 @@ fn trans_unary_datum(bcx: block,
     }
 }
 
-fn trans_addr_of(bcx: block, expr: &ast::expr,
+fn trans_addr_of(bcx: @mut Block, expr: &ast::expr,
                  subexpr: @ast::expr) -> DatumBlock {
     let _icx = push_ctxt("trans_addr_of");
     let mut bcx = bcx;
@@ -1353,7 +1353,7 @@ fn trans_addr_of(bcx: block, expr: &ast::expr,
 
 // Important to get types for both lhs and rhs, because one might be _|_
 // and the other not.
-fn trans_eager_binop(bcx: block,
+fn trans_eager_binop(bcx: @mut Block,
                      binop_expr: &ast::expr,
                      binop_ty: ty::t,
                      op: ast::binop,
@@ -1456,7 +1456,7 @@ fn trans_eager_binop(bcx: block,
 // refinement types would obviate the need for this
 enum lazy_binop_ty { lazy_and, lazy_or }
 
-fn trans_lazy_binop(bcx: block,
+fn trans_lazy_binop(bcx: @mut Block,
                     binop_expr: &ast::expr,
                     op: lazy_binop_ty,
                     a: @ast::expr,
@@ -1501,7 +1501,7 @@ fn trans_lazy_binop(bcx: block,
     return immediate_rvalue_bcx(join, phi, binop_ty);
 }
 
-fn trans_binary(bcx: block,
+fn trans_binary(bcx: @mut Block,
                 binop_expr: &ast::expr,
                 op: ast::binop,
                 lhs: @ast::expr,
@@ -1527,14 +1527,14 @@ fn trans_binary(bcx: block,
     }
 }
 
-fn trans_overloaded_op(bcx: block,
+fn trans_overloaded_op(bcx: @mut Block,
                        expr: &ast::expr,
                        callee_id: ast::node_id,
                        rcvr: @ast::expr,
                        args: ~[@ast::expr],
                        ret_ty: ty::t,
                        dest: Dest)
-                       -> block {
+                       -> @mut Block {
     let origin = bcx.ccx().maps.method_map.get_copy(&expr.id);
     let fty = node_id_type(bcx, callee_id);
     callee::trans_call_inner(bcx,
@@ -1552,7 +1552,7 @@ fn trans_overloaded_op(bcx: block,
                              DoAutorefArg).bcx
 }
 
-fn int_cast(bcx: block, lldsttype: Type, llsrctype: Type,
+fn int_cast(bcx: @mut Block, lldsttype: Type, llsrctype: Type,
             llsrc: ValueRef, signed: bool) -> ValueRef {
     let _icx = push_ctxt("int_cast");
     unsafe {
@@ -1570,7 +1570,7 @@ fn int_cast(bcx: block, lldsttype: Type, llsrctype: Type,
     }
 }
 
-fn float_cast(bcx: block, lldsttype: Type, llsrctype: Type,
+fn float_cast(bcx: @mut Block, lldsttype: Type, llsrctype: Type,
               llsrc: ValueRef) -> ValueRef {
     let _icx = push_ctxt("float_cast");
     let srcsz = llsrctype.float_width();
@@ -1604,7 +1604,7 @@ pub fn cast_type_kind(t: ty::t) -> cast_kind {
     }
 }
 
-fn trans_imm_cast(bcx: block, expr: @ast::expr,
+fn trans_imm_cast(bcx: @mut Block, expr: @ast::expr,
                   id: ast::node_id) -> DatumBlock {
     let _icx = push_ctxt("trans_cast");
     let ccx = bcx.ccx();
@@ -1666,12 +1666,12 @@ fn trans_imm_cast(bcx: block, expr: @ast::expr,
     return immediate_rvalue_bcx(bcx, newval, t_out);
 }
 
-fn trans_assign_op(bcx: block,
+fn trans_assign_op(bcx: @mut Block,
                    expr: @ast::expr,
                    callee_id: ast::node_id,
                    op: ast::binop,
                    dst: @ast::expr,
-                   src: @ast::expr) -> block
+                   src: @ast::expr) -> @mut Block
 {
     let _icx = push_ctxt("trans_assign_op");
     let mut bcx = bcx;

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -128,11 +128,11 @@ fn shim_types(ccx: @mut CrateContext, id: ast::node_id) -> ShimTypes {
 }
 
 type shim_arg_builder<'self> =
-    &'self fn(bcx: block, tys: &ShimTypes,
+    &'self fn(bcx: @mut Block, tys: &ShimTypes,
               llargbundle: ValueRef) -> ~[ValueRef];
 
 type shim_ret_builder<'self> =
-    &'self fn(bcx: block, tys: &ShimTypes,
+    &'self fn(bcx: @mut Block, tys: &ShimTypes,
               llargbundle: ValueRef,
               llretval: ValueRef);
 
@@ -171,12 +171,12 @@ fn build_shim_fn_(ccx: @mut CrateContext,
     return llshimfn;
 }
 
-type wrap_arg_builder<'self> = &'self fn(bcx: block,
+type wrap_arg_builder<'self> = &'self fn(bcx: @mut Block,
                                          tys: &ShimTypes,
                                          llwrapfn: ValueRef,
                                          llargbundle: ValueRef);
 
-type wrap_ret_builder<'self> = &'self fn(bcx: block,
+type wrap_ret_builder<'self> = &'self fn(bcx: @mut Block,
                                          tys: &ShimTypes,
                                          llargbundle: ValueRef);
 
@@ -369,13 +369,13 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
 
         let _icx = push_ctxt("foreign::build_shim_fn");
 
-        fn build_args(bcx: block, tys: &ShimTypes, llargbundle: ValueRef)
+        fn build_args(bcx: @mut Block, tys: &ShimTypes, llargbundle: ValueRef)
                    -> ~[ValueRef] {
             let _icx = push_ctxt("foreign::shim::build_args");
             tys.fn_ty.build_shim_args(bcx, tys.llsig.llarg_tys, llargbundle)
         }
 
-        fn build_ret(bcx: block,
+        fn build_ret(bcx: @mut Block,
                      tys: &ShimTypes,
                      llargbundle: ValueRef,
                      llretval: ValueRef) {
@@ -491,7 +491,7 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
                        build_args,
                        build_ret);
 
-        fn build_args(bcx: block,
+        fn build_args(bcx: @mut Block,
                       tys: &ShimTypes,
                       llwrapfn: ValueRef,
                       llargbundle: ValueRef) {
@@ -517,7 +517,7 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
             }
         }
 
-        fn build_ret(bcx: block,
+        fn build_ret(bcx: @mut Block,
                      shim_types: &ShimTypes,
                      llargbundle: ValueRef) {
             let _icx = push_ctxt("foreign::wrap::build_ret");
@@ -539,7 +539,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
                        ref_id: Option<ast::node_id>) {
     debug!("trans_intrinsic(item.ident=%s)", ccx.sess.str_of(item.ident));
 
-    fn simple_llvm_intrinsic(bcx: block, name: &'static str, num_args: uint) {
+    fn simple_llvm_intrinsic(bcx: @mut Block, name: &'static str, num_args: uint) {
         assert!(num_args <= 4);
         let mut args = [0 as ValueRef, ..4];
         let first_real_arg = bcx.fcx.arg_pos(0u);
@@ -550,7 +550,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
         Ret(bcx, Call(bcx, llfn, args.slice(0, num_args)));
     }
 
-    fn memcpy_intrinsic(bcx: block, name: &'static str, tp_ty: ty::t, sizebits: u8) {
+    fn memcpy_intrinsic(bcx: @mut Block, name: &'static str, tp_ty: ty::t, sizebits: u8) {
         let ccx = bcx.ccx();
         let lltp_ty = type_of::type_of(ccx, tp_ty);
         let align = C_i32(machine::llalign_of_min(ccx, lltp_ty) as i32);
@@ -571,7 +571,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
         RetVoid(bcx);
     }
 
-    fn memset_intrinsic(bcx: block, name: &'static str, tp_ty: ty::t, sizebits: u8) {
+    fn memset_intrinsic(bcx: @mut Block, name: &'static str, tp_ty: ty::t, sizebits: u8) {
         let ccx = bcx.ccx();
         let lltp_ty = type_of::type_of(ccx, tp_ty);
         let align = C_i32(machine::llalign_of_min(ccx, lltp_ty) as i32);
@@ -592,7 +592,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
         RetVoid(bcx);
     }
 
-    fn count_zeros_intrinsic(bcx: block, name: &'static str) {
+    fn count_zeros_intrinsic(bcx: @mut Block, name: &'static str) {
         let x = get_param(bcx.fcx.llfn, bcx.fcx.arg_pos(0u));
         let y = C_i1(false);
         let llfn = bcx.ccx().intrinsics.get_copy(&name);
@@ -1020,7 +1020,7 @@ pub fn trans_foreign_fn(ccx: @mut CrateContext,
 
         let _icx = push_ctxt("foreign::foreign::build_shim_fn");
 
-        fn build_args(bcx: block, tys: &ShimTypes, llargbundle: ValueRef)
+        fn build_args(bcx: @mut Block, tys: &ShimTypes, llargbundle: ValueRef)
                       -> ~[ValueRef] {
             let _icx = push_ctxt("foreign::extern::shim::build_args");
             let ccx = bcx.ccx();
@@ -1050,7 +1050,7 @@ pub fn trans_foreign_fn(ccx: @mut CrateContext,
             return llargvals;
         }
 
-        fn build_ret(bcx: block,
+        fn build_ret(bcx: @mut Block,
                      shim_types: &ShimTypes,
                      llargbundle: ValueRef,
                      llretval: ValueRef) {
@@ -1107,7 +1107,7 @@ pub fn trans_foreign_fn(ccx: @mut CrateContext,
                        build_args,
                        build_ret);
 
-        fn build_args(bcx: block,
+        fn build_args(bcx: @mut Block,
                       tys: &ShimTypes,
                       llwrapfn: ValueRef,
                       llargbundle: ValueRef) {
@@ -1118,7 +1118,7 @@ pub fn trans_foreign_fn(ccx: @mut CrateContext,
                                       llargbundle);
         }
 
-        fn build_ret(bcx: block, tys: &ShimTypes, llargbundle: ValueRef) {
+        fn build_ret(bcx: @mut Block, tys: &ShimTypes, llargbundle: ValueRef) {
             let _icx = push_ctxt("foreign::foreign::wrap::build_ret");
             tys.fn_ty.build_wrap_ret(bcx, tys.llsig.llarg_tys, llargbundle);
         }

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -42,7 +42,7 @@ use std::libc::c_uint;
 use std::str;
 use syntax::ast;
 
-pub fn trans_free(cx: block, v: ValueRef) -> block {
+pub fn trans_free(cx: @mut Block, v: ValueRef) -> @mut Block {
     let _icx = push_ctxt("trans_free");
     callee::trans_lang_call(cx,
         langcall(cx, None, "", FreeFnLangItem),
@@ -50,7 +50,7 @@ pub fn trans_free(cx: block, v: ValueRef) -> block {
         Some(expr::Ignore)).bcx
 }
 
-pub fn trans_exchange_free(cx: block, v: ValueRef) -> block {
+pub fn trans_exchange_free(cx: @mut Block, v: ValueRef) -> @mut Block {
     let _icx = push_ctxt("trans_exchange_free");
     callee::trans_lang_call(cx,
         langcall(cx, None, "", ExchangeFreeFnLangItem),
@@ -58,7 +58,7 @@ pub fn trans_exchange_free(cx: block, v: ValueRef) -> block {
         Some(expr::Ignore)).bcx
 }
 
-pub fn take_ty(cx: block, v: ValueRef, t: ty::t) -> block {
+pub fn take_ty(cx: @mut Block, v: ValueRef, t: ty::t) -> @mut Block {
     // NB: v is an *alias* of type t here, not a direct value.
     let _icx = push_ctxt("take_ty");
     if ty::type_needs_drop(cx.tcx(), t) {
@@ -67,7 +67,7 @@ pub fn take_ty(cx: block, v: ValueRef, t: ty::t) -> block {
     return cx;
 }
 
-pub fn drop_ty(cx: block, v: ValueRef, t: ty::t) -> block {
+pub fn drop_ty(cx: @mut Block, v: ValueRef, t: ty::t) -> @mut Block {
     // NB: v is an *alias* of type t here, not a direct value.
     let _icx = push_ctxt("drop_ty");
     if ty::type_needs_drop(cx.tcx(), t) {
@@ -76,7 +76,7 @@ pub fn drop_ty(cx: block, v: ValueRef, t: ty::t) -> block {
     return cx;
 }
 
-pub fn drop_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
+pub fn drop_ty_immediate(bcx: @mut Block, v: ValueRef, t: ty::t) -> @mut Block {
     let _icx = push_ctxt("drop_ty_immediate");
     match ty::get(t).sty {
         ty::ty_uniq(_)
@@ -93,7 +93,7 @@ pub fn drop_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
     }
 }
 
-pub fn free_ty(cx: block, v: ValueRef, t: ty::t) -> block {
+pub fn free_ty(cx: @mut Block, v: ValueRef, t: ty::t) -> @mut Block {
     // NB: v is an *alias* of type t here, not a direct value.
     let _icx = push_ctxt("free_ty");
     if ty::type_needs_drop(cx.tcx(), t) {
@@ -102,7 +102,7 @@ pub fn free_ty(cx: block, v: ValueRef, t: ty::t) -> block {
     return cx;
 }
 
-pub fn free_ty_immediate(bcx: block, v: ValueRef, t: ty::t) -> block {
+pub fn free_ty_immediate(bcx: @mut Block, v: ValueRef, t: ty::t) -> @mut Block {
     let _icx = push_ctxt("free_ty_immediate");
     match ty::get(t).sty {
       ty::ty_uniq(_) |
@@ -273,7 +273,7 @@ pub fn lazily_emit_tydesc_glue(ccx: @mut CrateContext,
 }
 
 // See [Note-arg-mode]
-pub fn call_tydesc_glue_full(bcx: block,
+pub fn call_tydesc_glue_full(bcx: @mut Block,
                              v: ValueRef,
                              tydesc: ValueRef,
                              field: uint,
@@ -334,15 +334,15 @@ pub fn call_tydesc_glue_full(bcx: block,
 }
 
 // See [Note-arg-mode]
-pub fn call_tydesc_glue(cx: block, v: ValueRef, t: ty::t, field: uint)
-    -> block {
+pub fn call_tydesc_glue(cx: @mut Block, v: ValueRef, t: ty::t, field: uint)
+    -> @mut Block {
     let _icx = push_ctxt("call_tydesc_glue");
     let ti = get_tydesc(cx.ccx(), t);
     call_tydesc_glue_full(cx, v, ti.tydesc, field, Some(ti));
     return cx;
 }
 
-pub fn make_visit_glue(bcx: block, v: ValueRef, t: ty::t) -> block {
+pub fn make_visit_glue(bcx: @mut Block, v: ValueRef, t: ty::t) -> @mut Block {
     let _icx = push_ctxt("make_visit_glue");
     do with_scope(bcx, None, "visitor cleanup") |bcx| {
         let mut bcx = bcx;
@@ -360,7 +360,7 @@ pub fn make_visit_glue(bcx: block, v: ValueRef, t: ty::t) -> block {
     }
 }
 
-pub fn make_free_glue(bcx: block, v: ValueRef, t: ty::t) -> block {
+pub fn make_free_glue(bcx: @mut Block, v: ValueRef, t: ty::t) -> @mut Block {
     // NB: v0 is an *alias* of type t here, not a direct value.
     let _icx = push_ctxt("make_free_glue");
     match ty::get(t).sty {
@@ -397,8 +397,8 @@ pub fn make_free_glue(bcx: block, v: ValueRef, t: ty::t) -> block {
     }
 }
 
-pub fn trans_struct_drop_flag(bcx: block, t: ty::t, v0: ValueRef, dtor_did: ast::def_id,
-                              class_did: ast::def_id, substs: &ty::substs) -> block {
+pub fn trans_struct_drop_flag(bcx: @mut Block, t: ty::t, v0: ValueRef, dtor_did: ast::def_id,
+                              class_did: ast::def_id, substs: &ty::substs) -> @mut Block {
     let repr = adt::represent_type(bcx.ccx(), t);
     let drop_flag = adt::trans_drop_flag_ptr(bcx, repr, v0);
     do with_cond(bcx, IsNotNull(bcx, Load(bcx, drop_flag))) |cx| {
@@ -435,8 +435,8 @@ pub fn trans_struct_drop_flag(bcx: block, t: ty::t, v0: ValueRef, dtor_did: ast:
     }
 }
 
-pub fn trans_struct_drop(mut bcx: block, t: ty::t, v0: ValueRef, dtor_did: ast::def_id,
-                         class_did: ast::def_id, substs: &ty::substs) -> block {
+pub fn trans_struct_drop(mut bcx: @mut Block, t: ty::t, v0: ValueRef, dtor_did: ast::def_id,
+                         class_did: ast::def_id, substs: &ty::substs) -> @mut Block {
     let repr = adt::represent_type(bcx.ccx(), t);
 
     // Find and call the actual destructor
@@ -468,7 +468,7 @@ pub fn trans_struct_drop(mut bcx: block, t: ty::t, v0: ValueRef, dtor_did: ast::
     bcx
 }
 
-pub fn make_drop_glue(bcx: block, v0: ValueRef, t: ty::t) -> block {
+pub fn make_drop_glue(bcx: @mut Block, v0: ValueRef, t: ty::t) -> @mut Block {
     // NB: v0 is an *alias* of type t here, not a direct value.
     let _icx = push_ctxt("make_drop_glue");
     let ccx = bcx.ccx();
@@ -539,10 +539,10 @@ pub fn make_drop_glue(bcx: block, v0: ValueRef, t: ty::t) -> block {
 }
 
 // box_ptr_ptr is optional, it is constructed if not supplied.
-pub fn decr_refcnt_maybe_free(bcx: block, box_ptr: ValueRef,
+pub fn decr_refcnt_maybe_free(bcx: @mut Block, box_ptr: ValueRef,
                               box_ptr_ptr: Option<ValueRef>,
                               t: ty::t)
-                           -> block {
+                           -> @mut Block {
     let _icx = push_ctxt("decr_refcnt_maybe_free");
     let ccx = bcx.ccx();
 
@@ -566,7 +566,7 @@ pub fn decr_refcnt_maybe_free(bcx: block, box_ptr: ValueRef,
 }
 
 
-pub fn make_take_glue(bcx: block, v: ValueRef, t: ty::t) -> block {
+pub fn make_take_glue(bcx: @mut Block, v: ValueRef, t: ty::t) -> @mut Block {
     let _icx = push_ctxt("make_take_glue");
     // NB: v is a *pointer* to type t here, not a direct value.
     match ty::get(t).sty {
@@ -630,7 +630,7 @@ pub fn make_take_glue(bcx: block, v: ValueRef, t: ty::t) -> block {
     }
 }
 
-pub fn incr_refcnt_of_boxed(cx: block, box_ptr: ValueRef) {
+pub fn incr_refcnt_of_boxed(cx: @mut Block, box_ptr: ValueRef) {
     let _icx = push_ctxt("incr_refcnt_of_boxed");
     let ccx = cx.ccx();
     let rc_ptr = GEPi(cx, box_ptr, [0u, abi::box_field_refcnt]);
@@ -677,7 +677,7 @@ pub fn declare_tydesc(ccx: &mut CrateContext, t: ty::t) -> @mut tydesc_info {
     return inf;
 }
 
-pub type glue_helper<'self> = &'self fn(block, ValueRef, ty::t) -> block;
+pub type glue_helper<'self> = &'self fn(@mut Block, ValueRef, ty::t) -> @mut Block;
 
 pub fn declare_generic_glue(ccx: &mut CrateContext, t: ty::t, llfnty: Type,
                             name: &str) -> ValueRef {

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -124,7 +124,7 @@ pub fn trans_method(ccx: @mut CrateContext,
              []);
 }
 
-pub fn trans_self_arg(bcx: block,
+pub fn trans_self_arg(bcx: @mut Block,
                       base: @ast::expr,
                       temp_cleanups: &mut ~[ValueRef],
                       mentry: typeck::method_map_entry) -> Result {
@@ -141,7 +141,7 @@ pub fn trans_self_arg(bcx: block,
                    DontAutorefArg)
 }
 
-pub fn trans_method_callee(bcx: block,
+pub fn trans_method_callee(bcx: @mut Block,
                            callee_id: ast::node_id,
                            this: @ast::expr,
                            mentry: typeck::method_map_entry)
@@ -251,7 +251,7 @@ pub fn trans_method_callee(bcx: block,
     }
 }
 
-pub fn trans_static_method_callee(bcx: block,
+pub fn trans_static_method_callee(bcx: @mut Block,
                                   method_id: ast::def_id,
                                   trait_id: ast::def_id,
                                   callee_id: ast::node_id)
@@ -348,7 +348,7 @@ pub fn method_with_name(ccx: &mut CrateContext,
     meth.def_id
 }
 
-pub fn trans_monomorphized_callee(bcx: block,
+pub fn trans_monomorphized_callee(bcx: @mut Block,
                                   callee_id: ast::node_id,
                                   base: @ast::expr,
                                   mentry: typeck::method_map_entry,
@@ -409,7 +409,7 @@ pub fn trans_monomorphized_callee(bcx: block,
 
 }
 
-pub fn combine_impl_and_methods_tps(bcx: block,
+pub fn combine_impl_and_methods_tps(bcx: @mut Block,
                                     mth_did: ast::def_id,
                                     callee_id: ast::node_id,
                                     rcvr_substs: &[ty::t],
@@ -459,7 +459,7 @@ pub fn combine_impl_and_methods_tps(bcx: block,
 }
 
 
-pub fn trans_trait_callee(bcx: block,
+pub fn trans_trait_callee(bcx: @mut Block,
                           callee_id: ast::node_id,
                           n_method: uint,
                           self_expr: @ast::expr,
@@ -496,7 +496,7 @@ pub fn trans_trait_callee(bcx: block,
                                   explicit_self)
 }
 
-pub fn trans_trait_callee_from_llval(bcx: block,
+pub fn trans_trait_callee_from_llval(bcx: @mut Block,
                                      callee_ty: ty::t,
                                      n_method: uint,
                                      llpair: ValueRef,
@@ -628,7 +628,7 @@ pub fn vtable_id(ccx: @mut CrateContext,
 
 /// Creates a returns a dynamic vtable for the given type and vtable origin.
 /// This is used only for objects.
-pub fn get_vtable(bcx: block,
+pub fn get_vtable(bcx: @mut Block,
                   self_ty: ty::t,
                   origin: typeck::vtable_origin)
                   -> ValueRef {
@@ -672,7 +672,7 @@ pub fn make_vtable(ccx: &mut CrateContext,
 }
 
 /// Generates a dynamic vtable for objects.
-pub fn make_impl_vtable(bcx: block,
+pub fn make_impl_vtable(bcx: @mut Block,
                         impl_id: ast::def_id,
                         self_ty: ty::t,
                         substs: &[ty::t],
@@ -716,12 +716,12 @@ pub fn make_impl_vtable(bcx: block,
     make_vtable(ccx, tydesc, methods)
 }
 
-pub fn trans_trait_cast(bcx: block,
+pub fn trans_trait_cast(bcx: @mut Block,
                         val: @ast::expr,
                         id: ast::node_id,
                         dest: expr::Dest,
                         _store: ty::TraitStore)
-                     -> block {
+                     -> @mut Block {
     let mut bcx = bcx;
     let _icx = push_ctxt("impl::trans_cast");
 

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -37,9 +37,9 @@ use middle::trans::type_::Type;
 pub struct Reflector {
     visitor_val: ValueRef,
     visitor_methods: @~[@ty::Method],
-    final_bcx: block,
+    final_bcx: @mut Block,
     tydesc_ty: Type,
-    bcx: block
+    bcx: @mut Block
 }
 
 impl Reflector {
@@ -374,11 +374,11 @@ impl Reflector {
 }
 
 // Emit a sequence of calls to visit_ty::visit_foo
-pub fn emit_calls_to_trait_visit_ty(bcx: block,
+pub fn emit_calls_to_trait_visit_ty(bcx: @mut Block,
                                     t: ty::t,
                                     visitor_val: ValueRef,
                                     visitor_trait_id: def_id)
-                                 -> block {
+                                 -> @mut Block {
     let final = sub_block(bcx, "final");
     let tydesc_ty = ty::get_tydesc_ty(bcx.ccx().tcx).unwrap();
     let tydesc_ty = type_of(bcx.ccx(), tydesc_ty);

--- a/src/librustc/middle/trans/uniq.rs
+++ b/src/librustc/middle/trans/uniq.rs
@@ -17,8 +17,8 @@ use middle::trans::datum::immediate_rvalue;
 use middle::trans::glue;
 use middle::ty;
 
-pub fn make_free_glue(bcx: block, vptrptr: ValueRef, box_ty: ty::t)
-    -> block {
+pub fn make_free_glue(bcx: @mut Block, vptrptr: ValueRef, box_ty: ty::t)
+    -> @mut Block {
     let _icx = push_ctxt("uniq::make_free_glue");
     let box_datum = immediate_rvalue(Load(bcx, vptrptr), box_ty);
 

--- a/src/librustc/middle/trans/write_guard.rs
+++ b/src/librustc/middle/trans/write_guard.rs
@@ -34,10 +34,10 @@ use syntax::ast;
 use middle::trans::type_::Type;
 
 pub fn root_and_write_guard(datum: &Datum,
-                            mut bcx: block,
+                            mut bcx: @mut Block,
                             span: span,
                             expr_id: ast::node_id,
-                            derefs: uint) -> block {
+                            derefs: uint) -> @mut Block {
     let key = root_map_key { id: expr_id, derefs: derefs };
     debug!("write_guard::root_and_write_guard(key=%?)", key);
 
@@ -60,12 +60,12 @@ pub fn root_and_write_guard(datum: &Datum,
     }
 }
 
-pub fn return_to_mut(mut bcx: block,
+pub fn return_to_mut(mut bcx: @mut Block,
                      root_key: root_map_key,
                      frozen_val_ref: ValueRef,
                      bits_val_ref: ValueRef,
                      filename_val: ValueRef,
-                     line_val: ValueRef) -> block {
+                     line_val: ValueRef) -> @mut Block {
     debug!("write_guard::return_to_mut(root_key=%?, %s, %s, %s)",
            root_key,
            bcx.to_str(),
@@ -102,10 +102,10 @@ pub fn return_to_mut(mut bcx: block,
 }
 
 fn root(datum: &Datum,
-        mut bcx: block,
+        mut bcx: @mut Block,
         span: span,
         root_key: root_map_key,
-        root_info: RootInfo) -> block {
+        root_info: RootInfo) -> @mut Block {
     //! In some cases, borrowck will decide that an @T/@[]/@str
     //! value must be rooted for the program to be safe.  In that
     //! case, we will call this function, which will stash a copy
@@ -182,8 +182,8 @@ fn root(datum: &Datum,
 }
 
 fn perform_write_guard(datum: &Datum,
-                       bcx: block,
-                       span: span) -> block {
+                       bcx: @mut Block,
+                       span: span) -> @mut Block {
     debug!("perform_write_guard");
 
     let llval = datum.to_value_llval(bcx);


### PR DESCRIPTION
The following types are renamed:

``` rust
block_ => Block
block => @mut Block

fn_ctx_ => FunctionContext
fn_ctx => @mut FunctionContext

scope_info => ScopeInfo
```

I also tried to convert instances of `@mut` to `&mut` or `&` but a lot of them are blocked by issue #6268, so I left it for some time later.
