### PR TITLE
std::rt: Don't overcommit rt test threads. #7772

### DIFF
--- a/src/libstd/rt/test.rs
+++ b/src/libstd/rt/test.rs
@@ -72,10 +72,7 @@ pub fn run_in_mt_newsched_task(f: ~fn()) {
         let nthreads = match os::getenv("RUST_TEST_THREADS") {
             Some(nstr) => FromStr::from_str(nstr).get(),
             None => {
-                // Using more threads than cores in test code
-                // to force the OS to preempt them frequently.
-                // Assuming that this help stress test concurrent types.
-                util::num_cpus() * 2
+                util::num_cpus()
             }
         };
 


### PR DESCRIPTION
Uses more fds than are available by default on OS X.
