### PR TITLE
std: Remove ThreadPerCore spawn mode. Unused

### DIFF
--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -106,8 +106,6 @@ pub enum SchedMode {
     /// All tasks run in the same OS thread
     SingleThreaded,
     /// Tasks are distributed among available CPUs
-    ThreadPerCore,
-    /// Each task runs in its own OS thread
     ThreadPerTask,
     /// Tasks are distributed among a fixed number of OS threads
     ManualThreads(uint),
@@ -1141,22 +1139,6 @@ fn test_child_doesnt_ref_parent() {
         }
     }
     task::spawn(child_no(0));
-}
-
-#[test]
-fn test_sched_thread_per_core() {
-    let (port, chan) = comm::stream();
-
-    do spawn_sched(ThreadPerCore) || {
-        unsafe {
-            let cores = rt::rust_num_threads();
-            let reported_threads = rt::rust_sched_threads();
-            assert_eq!(cores as uint, reported_threads as uint);
-            chan.send(());
-        }
-    }
-
-    port.recv();
 }
 
 #[test]

--- a/src/libstd/task/rt.rs
+++ b/src/libstd/task/rt.rs
@@ -38,7 +38,6 @@ pub extern {
     fn rust_new_sched(num_threads: libc::uintptr_t) -> sched_id;
     fn rust_sched_threads() -> libc::size_t;
     fn rust_sched_current_nonlazy_threads() -> libc::size_t;
-    fn rust_num_threads() -> libc::uintptr_t;
 
     fn get_task_id() -> task_id;
     #[rust_stack]

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -84,7 +84,7 @@ use task::local_data_priv::{local_get, local_set, OldHandle};
 use task::rt::rust_task;
 use task::rt;
 use task::{Failure, ManualThreads, PlatformThread, SchedOpts, SingleThreaded};
-use task::{Success, TaskOpts, TaskResult, ThreadPerCore, ThreadPerTask};
+use task::{Success, TaskOpts, TaskResult, ThreadPerTask};
 use task::{ExistingScheduler, SchedulerHandle};
 use task::unkillable;
 use uint;
@@ -745,7 +745,6 @@ fn spawn_raw_oldsched(mut opts: TaskOpts, f: ~fn()) {
             | ExistingScheduler(*)
             | PlatformThread => 0u, /* Won't be used */
             SingleThreaded => 1u,
-            ThreadPerCore => unsafe { rt::rust_num_threads() },
             ThreadPerTask => {
                 fail!("ThreadPerTask scheduling mode unimplemented")
             }

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -476,12 +476,6 @@ rust_get_sched_id() {
     return task->sched->get_id();
 }
 
-extern "C" CDECL uintptr_t
-rust_num_threads() {
-    rust_task *task = rust_get_current_task();
-    return task->kernel->env->num_sched_threads;
-}
-
 extern "C" CDECL int
 rust_get_argc() {
     rust_task *task = rust_get_current_task();

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -28,7 +28,6 @@ rust_get_argc
 rust_get_argv
 rust_new_sched
 rust_new_task_in_sched
-rust_num_threads
 rust_path_is_dir
 rust_path_exists
 rust_get_stdin


### PR DESCRIPTION
This doesn't make sense under the new scheduler.
