### PR TITLE
Fix warnings in tests

### DIFF
--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -893,9 +893,9 @@ mod tests {
     #[test]
     fn test_1_element() {
         let mut act = Bitv::new(1u, false);
-        assert!(act.eq_vec(~[false]));
+        assert!(act.eq_vec([false]));
         act = Bitv::new(1u, true);
-        assert!(act.eq_vec(~[true]));
+        assert!(act.eq_vec([true]));
     }
 
     #[test]
@@ -913,11 +913,11 @@ mod tests {
 
         act = Bitv::new(10u, false);
         assert!((act.eq_vec(
-                    ~[false, false, false, false, false, false, false, false, false, false])));
+                    [false, false, false, false, false, false, false, false, false, false])));
         // all 1
 
         act = Bitv::new(10u, true);
-        assert!((act.eq_vec(~[true, true, true, true, true, true, true, true, true, true])));
+        assert!((act.eq_vec([true, true, true, true, true, true, true, true, true, true])));
         // mixed
 
         act = Bitv::new(10u, false);
@@ -926,7 +926,7 @@ mod tests {
         act.set(2u, true);
         act.set(3u, true);
         act.set(4u, true);
-        assert!((act.eq_vec(~[true, true, true, true, true, false, false, false, false, false])));
+        assert!((act.eq_vec([true, true, true, true, true, false, false, false, false, false])));
         // mixed
 
         act = Bitv::new(10u, false);
@@ -935,7 +935,7 @@ mod tests {
         act.set(7u, true);
         act.set(8u, true);
         act.set(9u, true);
-        assert!((act.eq_vec(~[false, false, false, false, false, true, true, true, true, true])));
+        assert!((act.eq_vec([false, false, false, false, false, true, true, true, true, true])));
         // mixed
 
         act = Bitv::new(10u, false);
@@ -943,7 +943,7 @@ mod tests {
         act.set(3u, true);
         act.set(6u, true);
         act.set(9u, true);
-        assert!((act.eq_vec(~[true, false, false, true, false, false, true, false, false, true])));
+        assert!((act.eq_vec([true, false, false, true, false, false, true, false, false, true])));
     }
 
     #[test]
@@ -953,14 +953,14 @@ mod tests {
 
         act = Bitv::new(31u, false);
         assert!(act.eq_vec(
-                ~[false, false, false, false, false, false, false, false, false, false, false,
+                [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false]));
         // all 1
 
         act = Bitv::new(31u, true);
         assert!(act.eq_vec(
-                ~[true, true, true, true, true, true, true, true, true, true, true, true, true,
+                [true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true]));
         // mixed
@@ -975,7 +975,7 @@ mod tests {
         act.set(6u, true);
         act.set(7u, true);
         assert!(act.eq_vec(
-                ~[true, true, true, true, true, true, true, true, false, false, false, false, false,
+                [true, true, true, true, true, true, true, true, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false]));
         // mixed
@@ -990,7 +990,7 @@ mod tests {
         act.set(22u, true);
         act.set(23u, true);
         assert!(act.eq_vec(
-                ~[false, false, false, false, false, false, false, false, false, false, false,
+                [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, true, true, true, true, true, true, true, true,
                 false, false, false, false, false, false, false]));
         // mixed
@@ -1004,7 +1004,7 @@ mod tests {
         act.set(29u, true);
         act.set(30u, true);
         assert!(act.eq_vec(
-                ~[false, false, false, false, false, false, false, false, false, false, false,
+                [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, true, true, true, true, true, true, true]));
         // mixed
@@ -1014,7 +1014,7 @@ mod tests {
         act.set(17u, true);
         act.set(30u, true);
         assert!(act.eq_vec(
-                ~[false, false, false, true, false, false, false, false, false, false, false, false,
+                [false, false, false, true, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, true, false, false, false, false, false, false,
                 false, false, false, false, false, false, true]));
     }
@@ -1026,14 +1026,14 @@ mod tests {
 
         act = Bitv::new(32u, false);
         assert!(act.eq_vec(
-                ~[false, false, false, false, false, false, false, false, false, false, false,
+                [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false]));
         // all 1
 
         act = Bitv::new(32u, true);
         assert!(act.eq_vec(
-                ~[true, true, true, true, true, true, true, true, true, true, true, true, true,
+                [true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true]));
         // mixed
@@ -1048,7 +1048,7 @@ mod tests {
         act.set(6u, true);
         act.set(7u, true);
         assert!(act.eq_vec(
-                ~[true, true, true, true, true, true, true, true, false, false, false, false, false,
+                [true, true, true, true, true, true, true, true, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false]));
         // mixed
@@ -1063,7 +1063,7 @@ mod tests {
         act.set(22u, true);
         act.set(23u, true);
         assert!(act.eq_vec(
-                ~[false, false, false, false, false, false, false, false, false, false, false,
+                [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, true, true, true, true, true, true, true, true,
                 false, false, false, false, false, false, false, false]));
         // mixed
@@ -1078,7 +1078,7 @@ mod tests {
         act.set(30u, true);
         act.set(31u, true);
         assert!(act.eq_vec(
-                ~[false, false, false, false, false, false, false, false, false, false, false,
+                [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, true, true, true, true, true, true, true, true]));
         // mixed
@@ -1089,7 +1089,7 @@ mod tests {
         act.set(30u, true);
         act.set(31u, true);
         assert!(act.eq_vec(
-                ~[false, false, false, true, false, false, false, false, false, false, false, false,
+                [false, false, false, true, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, true, false, false, false, false, false, false,
                 false, false, false, false, false, false, true, true]));
     }
@@ -1101,14 +1101,14 @@ mod tests {
 
         act = Bitv::new(33u, false);
         assert!(act.eq_vec(
-                ~[false, false, false, false, false, false, false, false, false, false, false,
+                [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false]));
         // all 1
 
         act = Bitv::new(33u, true);
         assert!(act.eq_vec(
-                ~[true, true, true, true, true, true, true, true, true, true, true, true, true,
+                [true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true, true]));
         // mixed
@@ -1123,7 +1123,7 @@ mod tests {
         act.set(6u, true);
         act.set(7u, true);
         assert!(act.eq_vec(
-                ~[true, true, true, true, true, true, true, true, false, false, false, false, false,
+                [true, true, true, true, true, true, true, true, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false]));
         // mixed
@@ -1138,7 +1138,7 @@ mod tests {
         act.set(22u, true);
         act.set(23u, true);
         assert!(act.eq_vec(
-                ~[false, false, false, false, false, false, false, false, false, false, false,
+                [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, true, true, true, true, true, true, true, true,
                 false, false, false, false, false, false, false, false, false]));
         // mixed
@@ -1153,7 +1153,7 @@ mod tests {
         act.set(30u, true);
         act.set(31u, true);
         assert!(act.eq_vec(
-                ~[false, false, false, false, false, false, false, false, false, false, false,
+                [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, true, true, true, true, true, true, true, true, false]));
         // mixed
@@ -1165,7 +1165,7 @@ mod tests {
         act.set(31u, true);
         act.set(32u, true);
         assert!(act.eq_vec(
-                ~[false, false, false, true, false, false, false, false, false, false, false, false,
+                [false, false, false, true, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, true, false, false, false, false, false, false,
                 false, false, false, false, false, false, true, true, true]));
     }

--- a/src/libextra/sort.rs
+++ b/src/libextra/sort.rs
@@ -792,7 +792,6 @@ mod test_qsort {
 
     use sort::*;
 
-    use std::int;
     use std::vec;
 
     fn check_sort(v1: &mut [int], v2: &mut [int]) {

--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -546,7 +546,6 @@ pub fn main() {
 #[cfg(test)]
 mod tests {
     use std::io;
-    use std::iterator::IteratorUtil;
     use program::Program;
     use super::*;
 

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -863,7 +863,7 @@ pub type SetAlgebraIter<'self, T> =
 
 #[cfg(test)]
 mod test_map {
-    use container::{Container, Map, Set};
+    use container::{Container, Map};
     use option::{None, Some};
     use super::*;
     use uint;
@@ -1104,7 +1104,7 @@ mod test_map {
 #[cfg(test)]
 mod test_set {
     use super::*;
-    use container::{Container, Map, Set};
+    use container::Container;
     use vec::ImmutableEqVector;
     use uint;
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1742,7 +1742,6 @@ mod tests {
     use rand;
     use run;
     use str::StrSlice;
-    use vec;
     use vec::CopyableVector;
     use libc::consts::os::posix88::{S_IRUSR, S_IWUSR, S_IXUSR};
 

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -16,8 +16,9 @@ use option::{Option, Some, None};
 use sys;
 use unstable::intrinsics;
 use util::swap;
-use ops::{Add,Sub};
-use num::Int;
+
+#[cfg(not(test))] use ops::{Add,Sub};
+#[cfg(not(test))] use num::Int;
 
 #[cfg(not(test))] use cmp::{Eq, Ord};
 use uint;
@@ -592,7 +593,7 @@ pub mod ptr_tests {
             }
 
             let mut xs_mut = xs.clone();
-            let mut m_start = to_mut_ptr(xs_mut);
+            let m_start = to_mut_ptr(xs_mut);
             let mut m_ptr = m_start + 9u32;
 
             while m_ptr >= m_start {

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -1078,7 +1078,6 @@ mod tests {
         // This is to verify that the implementation of the ISAAC rng is
         // correct (i.e. matches the output of the upstream implementation,
         // which is in the runtime)
-        use vec;
         use libc::size_t;
 
         #[abi = "cdecl"]

--- a/src/libstd/to_str.rs
+++ b/src/libstd/to_str.rs
@@ -181,7 +181,7 @@ impl<A:ToStr> ToStr for @[A] {
 mod tests {
     use hashmap::HashMap;
     use hashmap::HashSet;
-    use container::{Set, Map, MutableSet, MutableMap};
+    use container::{MutableSet, MutableMap};
     #[test]
     fn test_simple_types() {
         assert_eq!(1i.to_str(), ~"1");

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -16,7 +16,7 @@ use cast::transmute;
 use cast;
 use clone::Clone;
 use container::{Container, Mutable};
-use cmp::{Eq, TotalEq, TotalOrd, Ordering, Less, Equal, Greater};
+use cmp::{Eq, TotalOrd, Ordering, Less, Equal, Greater};
 use cmp;
 use iterator::*;
 use libc::c_void;


### PR DESCRIPTION
Fix warnings that only show up when compiling the tests for libstd, libextra and one in librusti. Only trivial changes.
