### PR TITLE
std::rt: Add start_on_main_thread function

### DIFF
--- a/src/test/run-pass/rt-start-main-thread.rs
+++ b/src/test/run-pass/rt-start-main-thread.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+
+#[start]
+fn start(argc: int, argv: **u8, crate_map: *u8) -> int {
+    do std::rt::start_on_main_thread(argc, argv, crate_map) {
+        info!("running on main thread");
+        do spawn {
+            info!("running on another thread");
+        }
+    }
+}


### PR DESCRIPTION
Applications that need to use the GUI can override start and set up the runtime using
this function.
