### PR TITLE
Allow linking against crates with #[no_std]

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1460,6 +1460,9 @@ fn encode_lang_items(ecx: &EncodeContext, ebml_w: &mut writer::Encoder) {
     ebml_w.start_tag(tag_lang_items);
 
     for ecx.tcx.lang_items.each_item |def_id, i| {
+        let def_id = match def_id {
+            Some(id) => id, None => { loop }
+        };
         if def_id.crate != local_crate {
             loop;
         }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -92,8 +92,8 @@ impl LanguageItems {
         }
     }
 
-    pub fn each_item(&self, f: &fn(def_id: def_id, i: uint) -> bool) -> bool {
-        self.items.iter().enumerate().advance(|(i, &item)| f(item.get(), i))
+    pub fn each_item(&self, f: &fn(Option<def_id>, uint) -> bool) -> bool {
+        self.items.iter().enumerate().advance(|(i, &item)| f(item, i))
     }
 
     pub fn item_name(index: uint) -> &'static str {

--- a/src/rt/rust_crate_map.h
+++ b/src/rt/rust_crate_map.h
@@ -68,7 +68,7 @@ public:
             return &reinterpret_cast<const cratemap_v0 *>(this)->
                 m_children[0];
         case 1:
-            return &m_children[1];
+            return &m_children[0];
         default: assert(false && "Unknown crate map version!");
             return NULL; // Appease -Werror=return-type
         }

--- a/src/test/auxiliary/no_std_crate.rs
+++ b/src/test/auxiliary/no_std_crate.rs
@@ -1,0 +1,3 @@
+#[no_std];
+
+pub fn foo() {}

--- a/src/test/run-pass/no-std-xcrate.rs
+++ b/src/test/run-pass/no-std-xcrate.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:no_std_crate.rs
+
+// This tests that crates which link to std can also be linked to crates with
+// #[no_std] that have no lang items.
+
+extern mod no_std_crate;
+
+fn main() {
+    no_std_crate::foo();
+}

--- a/src/test/run-pass/no-std-xcrate2.rs
+++ b/src/test/run-pass/no-std-xcrate2.rs
@@ -1,0 +1,33 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:no_std_crate.rs
+
+// This tests that libraries built with #[no_std] can be linked to crates with
+// #[no_std] and actually run.
+
+#[no_std];
+
+extern mod no_std_crate;
+
+// This is an unfortunate thing to have to do on linux :(
+#[cfg(target_os = "linux")]
+#[doc(hidden)]
+pub mod linkhack {
+    #[link_args="-lrustrt -lrt"]
+    extern {}
+}
+
+#[start]
+fn main(_: int, _: **u8, _: *u8) -> int {
+    no_std_crate::foo();
+    0
+}


### PR DESCRIPTION
Previously having optional lang_items caused an assertion failure at
compile-time, and then once that was fixed there was a segfault at runtime of
using a NULL crate-map (crates with no_std).

Now crates with/without `#[no_std]` (and also missing lang items) should work a bit better.

Closes #7852
