### PR TITLE
Silence various warnings in bootstrap build.

### DIFF
--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -17,7 +17,6 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-#[allow(non_implicitly_copyable_typarams)];
 #[deny(deprecated_pattern)];
 
 extern mod extra;

--- a/src/librustdoc/path_pass.rs
+++ b/src/librustdoc/path_pass.rs
@@ -43,7 +43,6 @@ impl Clone for Ctxt {
     }
 }
 
-#[allow(non_implicitly_copyable_typarams)]
 fn run(srv: astsrv::Srv, doc: doc::Doc) -> doc::Doc {
     let ctxt = Ctxt {
         srv: srv,
@@ -66,7 +65,6 @@ fn fold_item(fold: &fold::Fold<Ctxt>, doc: doc::ItemDoc) -> doc::ItemDoc {
     }
 }
 
-#[allow(non_implicitly_copyable_typarams)]
 fn fold_mod(fold: &fold::Fold<Ctxt>, doc: doc::ModDoc) -> doc::ModDoc {
     let is_topmod = doc.id() == ast::crate_node_id;
 

--- a/src/librustdoc/rustdoc.rs
+++ b/src/librustdoc/rustdoc.rs
@@ -19,8 +19,6 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
-#[allow(non_implicitly_copyable_typarams)];
-
 extern mod extra;
 extern mod rustc;
 extern mod syntax;

--- a/src/librustdoc/sort_pass.rs
+++ b/src/librustdoc/sort_pass.rs
@@ -42,7 +42,6 @@ pub fn mk_pass(name: ~str, lteq: ItemLtEqOp) -> Pass {
     }
 }
 
-#[allow(non_implicitly_copyable_typarams)]
 fn run(
     _srv: astsrv::Srv,
     doc: doc::Doc,
@@ -55,7 +54,6 @@ fn run(
     (fold.fold_doc)(&fold, doc)
 }
 
-#[allow(non_implicitly_copyable_typarams)]
 fn fold_mod(
     fold: &fold::Fold<ItemLtEq>,
     doc: doc::ModDoc

--- a/src/librustdoc/text_pass.rs
+++ b/src/librustdoc/text_pass.rs
@@ -44,7 +44,6 @@ impl Clone for WrappedOp {
     }
 }
 
-#[allow(non_implicitly_copyable_typarams)]
 fn run(
     _srv: astsrv::Srv,
     doc: doc::Doc,

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -20,7 +20,6 @@ use print::pprust;
 use visit;
 use syntax::parse::token::special_idents;
 
-use std::cmp;
 use std::hashmap::HashMap;
 use std::vec;
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -16,8 +16,6 @@ use opt_vec;
 use parse::token;
 use visit;
 
-use std::cast::unsafe_copy;
-use std::cast;
 use std::hashmap::HashMap;
 use std::int;
 use std::local_data;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2713,7 +2713,6 @@ impl Parser {
           token::LBRACE => {
             self.bump();
             let (_, _) = self.parse_pat_fields();
-            hi = self.span.hi;
             self.bump();
             self.obsolete(*self.span, ObsoleteRecordPattern);
             pat = pat_wild;
@@ -2744,7 +2743,6 @@ impl Parser {
                     }
                 }
                 if fields.len() == 1 { self.expect(&token::COMMA); }
-                hi = self.span.hi;
                 self.expect(&token::RPAREN);
                 pat = pat_tup(fields);
             }
@@ -2760,7 +2758,6 @@ impl Parser {
             self.bump();
             let (before, slice, after) =
                 self.parse_pat_vec_elements();
-            hi = self.span.hi;
             self.expect(&token::RBRACKET);
             pat = ast::pat_vec(before, slice, after);
             hi = self.last_span.hi;
@@ -4654,7 +4651,7 @@ impl Parser {
 
     pub fn parse_item(&self, attrs: ~[attribute]) -> Option<@ast::item> {
         match self.parse_item_or_view_item(attrs, true) {
-            iovi_none(attrs) =>
+            iovi_none(_) =>
                 None,
             iovi_view_item(_) =>
                 self.fatal("view items are not allowed here"),
@@ -4824,7 +4821,6 @@ impl Parser {
         // First, parse view items.
         let mut view_items : ~[ast::view_item] = ~[];
         let mut items = ~[];
-        let mut done = false;
         // I think this code would probably read better as a single
         // loop with a mutable three-state-variable (for extern mods,
         // view items, and regular items) ... except that because


### PR DESCRIPTION
r? anyone

The only bit that I'm a little concerned about is whether there's some way the assignments to `hi` could somehow still be necessary; but I think that could only be the case if it had been `&const` borrowed (or whatever the hypothetical syntax is for that), and that's not going on in this file.
