### PR TITLE
PR #7637 followup: no need to print the set of removed files twice.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -249,7 +249,7 @@ endef
 
 # Same interface as above, but deletes rather than just listing the files.
 define REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT
-  $(Q)MATCHES="$(filter-out %$(3),$(wildcard $(1)/$(2)))"; if [ -n "$$MATCHES" ] ; then echo "Warning: removing previous" \'$(2)\' "libraries:" $$MATCHES; rm -v $$MATCHES ; fi
+  $(Q)MATCHES="$(filter-out %$(3),$(wildcard $(1)/$(2)))"; if [ -n "$$MATCHES" ] ; then echo "Warning: removing previous" \'$(2)\' "libraries:" $$MATCHES; rm $$MATCHES ; fi
 endef
 
 # We use a different strategy for LIST_ALL_OLD_GLOB_MATCHES_EXCEPT


### PR DESCRIPTION
trivial r? for anyone who agrees with me.  :)

Given the choice between
1. printing the set of files once on a single line,
2. printing the set of files one per line, or 
3. printing the set twice, once in each manner,

I originally chose (3.) since it seemed safest to be loud about this.  But now that I've used it for a bit, I think (1.) would suffice.
