### PR TITLE
Workcache fixes 1

### DIFF
--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -38,7 +38,6 @@ use std::task;
 use std::to_str::ToStr;
 use std::u64;
 use std::f64;
-use std::hashmap::HashMap;
 use std::os;
 
 
@@ -852,7 +851,7 @@ fn calc_result(desc: &TestDesc, task_succeeded: bool) -> TestResult {
 
 impl ToJson for Metric {
     fn to_json(&self) -> json::Json {
-        let mut map = ~HashMap::new();
+        let mut map = ~TreeMap::new();
         map.insert(~"value", json::Number(self.value as float));
         map.insert(~"noise", json::Number(self.noise as float));
         json::Object(map)

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -164,7 +164,7 @@ impl Logger {
 struct Context {
     db: RWARC<Database>,
     logger: @mut Logger,
-    cfg: @json::Object,
+    cfg: json::Object,
     freshness: TreeMap<~str,@fn(&str,&str)->bool>
 }
 
@@ -215,7 +215,7 @@ fn digest_file(path: &Path) -> ~str {
 }
 
 impl Context {
-    pub fn new(db: RWARC<Database>, lg: @mut Logger, cfg: @json::Object)
+    pub fn new(db: RWARC<Database>, lg: @mut Logger, cfg: json::Object)
                -> Context {
         Context {
             db: db,
@@ -361,7 +361,7 @@ fn test() {
                               db_cache: TreeMap::new(),
                               db_dirty: false });
     let lg = @mut Logger { a: () };
-    let cfg = @HashMap::new();
+    let cfg = HashMap::new();
     let cx = @Context::new(db, lg, cfg);
     let w:Work<~str> = do cx.prep("test1") |prep| {
         let pth = Path("foo.c");

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -21,7 +21,6 @@ use treemap::TreeMap;
 use std::cell::Cell;
 use std::comm::{PortOne, oneshot, send_one, recv_one};
 use std::either::{Either, Left, Right};
-use std::hashmap::HashMap;
 use std::io;
 use std::result;
 use std::run;
@@ -381,7 +380,7 @@ fn test() {
     }
 
     let cx = Context::new(RWARC(Database::new(Path("db.json"))),
-                          Logger::new(), HashMap::new());
+                          Logger::new(), TreeMap::new());
 
     let s = do cx.with_prep("test1") |prep| {
         prep.declare_input("file", pth.to_str(), digest_file(&pth));

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -179,7 +179,7 @@ struct Context {
     db: RWARC<Database>,
     logger: RWARC<Logger>,
     cfg: ARC<json::Object>,
-    freshness: ARC<TreeMap<~str,~fn(&str,&str)->bool>>
+    freshness: ARC<TreeMap<~str,extern fn(&str,&str)->bool>>
 }
 
 struct Prep<'self> {


### PR DESCRIPTION
This just redoes various parts of workcache to support context-cloning (eventually quite crudely, via ARCs), the absence of which was blocking rustpkg from being able to use it. Better versions of this are possible (notably removing the ARCs on everything except the database) but it ought to work well enough for now.
