### PR TITLE
syntax: modernise attribute handling in syntax::attr.

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -369,7 +369,7 @@ pub fn building_library(req_crate_type: crate_type,
             match syntax::attr::first_attr_value_str_by_name(
                 crate.node.attrs,
                 "crate_type") {
-              Some(s) if "lib" == s => true,
+              Some(s) => "lib" == s,
               _ => false
             }
         }
@@ -395,18 +395,11 @@ mod test {
     use driver::session::{unknown_crate};
 
     use syntax::ast;
+    use syntax::attr;
     use syntax::codemap;
 
-    fn make_crate_type_attr(t: @str) -> ast::attribute {
-        codemap::respan(codemap::dummy_sp(), ast::attribute_ {
-            style: ast::attr_outer,
-            value: @codemap::respan(codemap::dummy_sp(),
-                ast::meta_name_value(
-                    @"crate_type",
-                    codemap::respan(codemap::dummy_sp(),
-                                     ast::lit_str(t)))),
-            is_sugared_doc: false
-        })
+    fn make_crate_type_attr(t: @str) -> ast::Attribute {
+        attr::mk_attr(attr::mk_name_value_item_str(@"crate_type", t))
     }
 
     fn make_crate(with_bin: bool, with_lib: bool) -> @ast::crate {

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -30,10 +30,10 @@ pub fn maybe_inject_libstd_ref(sess: Session, crate: @ast::crate)
 }
 
 fn use_std(crate: &ast::crate) -> bool {
-    !attr::attrs_contains_name(crate.node.attrs, "no_std")
+    !attr::contains_name(crate.node.attrs, "no_std")
 }
-fn no_prelude(attrs: &[ast::attribute]) -> bool {
-    attr::attrs_contains_name(attrs, "no_implicit_prelude")
+fn no_prelude(attrs: &[ast::Attribute]) -> bool {
+    attr::contains_name(attrs, "no_implicit_prelude")
 }
 
 fn inject_libstd_ref(sess: Session, crate: &ast::crate) -> @ast::crate {
@@ -48,14 +48,8 @@ fn inject_libstd_ref(sess: Session, crate: &ast::crate) -> @ast::crate {
                 node: ast::view_item_extern_mod(
                         sess.ident_of("std"), ~[], n1),
                 attrs: ~[
-                    spanned(ast::attribute_ {
-                        style: ast::attr_inner,
-                        value: @spanned(ast::meta_name_value(
-                            @"vers",
-                            spanned(ast::lit_str(STD_VERSION.to_managed()))
-                        )),
-                        is_sugared_doc: false
-                    })
+                    attr::mk_attr(
+                        attr::mk_name_value_item_str(@"vers", STD_VERSION.to_managed()))
                 ],
                 vis: ast::private,
                 span: dummy_sp()

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -151,7 +151,7 @@ pub fn get_static_methods_if_impl(cstore: @mut cstore::CStore,
 
 pub fn get_item_attrs(cstore: @mut cstore::CStore,
                       def_id: ast::def_id,
-                      f: &fn(~[@ast::meta_item])) {
+                      f: &fn(~[@ast::MetaItem])) {
     let cdata = cstore::get_crate_data(cstore, def_id.crate);
     decoder::get_item_attrs(cdata, def_id.node, f)
 }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -966,7 +966,7 @@ pub fn get_static_methods_if_impl(intr: @ident_interner,
 
 pub fn get_item_attrs(cdata: cmd,
                       node_id: ast::node_id,
-                      f: &fn(~[@ast::meta_item])) {
+                      f: &fn(~[@ast::MetaItem])) {
 
     let item = lookup_item(node_id, cdata.data);
     for reader::tagged_docs(item, tag_attributes) |attributes| {
@@ -1073,8 +1073,8 @@ fn item_family_to_str(fam: Family) -> ~str {
     }
 }
 
-fn get_meta_items(md: ebml::Doc) -> ~[@ast::meta_item] {
-    let mut items: ~[@ast::meta_item] = ~[];
+fn get_meta_items(md: ebml::Doc) -> ~[@ast::MetaItem] {
+    let mut items: ~[@ast::MetaItem] = ~[];
     for reader::tagged_docs(md, tag_meta_item_word) |meta_item_doc| {
         let nd = reader::get_doc(meta_item_doc, tag_meta_item_name);
         let n = nd.as_str_slice().to_managed();
@@ -1085,7 +1085,7 @@ fn get_meta_items(md: ebml::Doc) -> ~[@ast::meta_item] {
         let vd = reader::get_doc(meta_item_doc, tag_meta_item_value);
         let n = nd.as_str_slice().to_managed();
         let v = vd.as_str_slice().to_managed();
-        // FIXME (#623): Should be able to decode meta_name_value variants,
+        // FIXME (#623): Should be able to decode MetaNameValue variants,
         // but currently the encoder just drops them
         items.push(attr::mk_name_value_item_str(n, v));
     };
@@ -1098,8 +1098,8 @@ fn get_meta_items(md: ebml::Doc) -> ~[@ast::meta_item] {
     return items;
 }
 
-fn get_attributes(md: ebml::Doc) -> ~[ast::attribute] {
-    let mut attrs: ~[ast::attribute] = ~[];
+fn get_attributes(md: ebml::Doc) -> ~[ast::Attribute] {
+    let mut attrs: ~[ast::Attribute] = ~[];
     match reader::maybe_get_doc(md, tag_attributes) {
       option::Some(attrs_d) => {
         for reader::tagged_docs(attrs_d, tag_attribute) |attr_doc| {
@@ -1110,8 +1110,8 @@ fn get_attributes(md: ebml::Doc) -> ~[ast::attribute] {
             let meta_item = meta_items[0];
             attrs.push(
                 codemap::spanned {
-                    node: ast::attribute_ {
-                        style: ast::attr_outer,
+                    node: ast::Attribute_ {
+                        style: ast::AttrOuter,
                         value: meta_item,
                         is_sugared_doc: false,
                     },
@@ -1145,7 +1145,7 @@ fn list_crate_attributes(intr: @ident_interner, md: ebml::Doc, hash: &str,
     out.write_str("\n\n");
 }
 
-pub fn get_crate_attributes(data: @~[u8]) -> ~[ast::attribute] {
+pub fn get_crate_attributes(data: @~[u8]) -> ~[ast::Attribute] {
     return get_attributes(reader::Doc(data));
 }
 

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -36,6 +36,7 @@ use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_util::*;
 use syntax::attr;
+use syntax::attr::AttrMetaMethods;
 use syntax::diagnostic::span_handler;
 use syntax::opt_vec::OptVec;
 use syntax::opt_vec;
@@ -821,10 +822,11 @@ fn purity_static_method_family(p: purity) -> char {
 }
 
 
-fn should_inline(attrs: &[attribute]) -> bool {
-    match attr::find_inline_attr(attrs) {
-        attr::ia_none | attr::ia_never  => false,
-        attr::ia_hint | attr::ia_always => true
+fn should_inline(attrs: &[Attribute]) -> bool {
+    use syntax::attr::*;
+    match find_inline_attr(attrs) {
+        InlineNone | InlineNever  => false,
+        InlineHint | InlineAlways => true
     }
 }
 
@@ -1313,16 +1315,16 @@ fn write_int(writer: @io::Writer, &n: &int) {
     writer.write_be_u32(n as u32);
 }
 
-fn encode_meta_item(ebml_w: &mut writer::Encoder, mi: @meta_item) {
+fn encode_meta_item(ebml_w: &mut writer::Encoder, mi: @MetaItem) {
     match mi.node {
-      meta_word(name) => {
+      MetaWord(name) => {
         ebml_w.start_tag(tag_meta_item_word);
         ebml_w.start_tag(tag_meta_item_name);
         ebml_w.writer.write(name.as_bytes());
         ebml_w.end_tag();
         ebml_w.end_tag();
       }
-      meta_name_value(name, value) => {
+      MetaNameValue(name, value) => {
         match value.node {
           lit_str(value) => {
             ebml_w.start_tag(tag_meta_item_name_value);
@@ -1337,7 +1339,7 @@ fn encode_meta_item(ebml_w: &mut writer::Encoder, mi: @meta_item) {
           _ => {/* FIXME (#623): encode other variants */ }
         }
       }
-      meta_list(name, ref items) => {
+      MetaList(name, ref items) => {
         ebml_w.start_tag(tag_meta_item_list);
         ebml_w.start_tag(tag_meta_item_name);
         ebml_w.writer.write(name.as_bytes());
@@ -1350,7 +1352,7 @@ fn encode_meta_item(ebml_w: &mut writer::Encoder, mi: @meta_item) {
     }
 }
 
-fn encode_attributes(ebml_w: &mut writer::Encoder, attrs: &[attribute]) {
+fn encode_attributes(ebml_w: &mut writer::Encoder, attrs: &[Attribute]) {
     ebml_w.start_tag(tag_attributes);
     for attrs.iter().advance |attr| {
         ebml_w.start_tag(tag_attribute);
@@ -1365,10 +1367,10 @@ fn encode_attributes(ebml_w: &mut writer::Encoder, attrs: &[attribute]) {
 // 'name' and 'vers' items, so if the user didn't provide them we will throw
 // them in anyway with default values.
 fn synthesize_crate_attrs(ecx: &EncodeContext,
-                          crate: &crate) -> ~[attribute] {
+                          crate: &crate) -> ~[Attribute] {
 
-    fn synthesize_link_attr(ecx: &EncodeContext, items: ~[@meta_item]) ->
-       attribute {
+    fn synthesize_link_attr(ecx: &EncodeContext, items: ~[@MetaItem]) ->
+       Attribute {
 
         assert!(!ecx.link_meta.name.is_empty());
         assert!(!ecx.link_meta.vers.is_empty());
@@ -1380,29 +1382,29 @@ fn synthesize_crate_attrs(ecx: &EncodeContext,
             attr::mk_name_value_item_str(@"vers",
                                          ecx.link_meta.vers);
 
-        let other_items =
-            {
-                let tmp = attr::remove_meta_items_by_name(items, "name");
-                attr::remove_meta_items_by_name(tmp, "vers")
-            };
+        let mut meta_items = ~[name_item, vers_item];
 
-        let meta_items = vec::append(~[name_item, vers_item], other_items);
+        for items.iter()
+            .filter(|mi| "name" != mi.name() && "vers" != mi.name())
+            .advance |&mi| {
+            meta_items.push(mi);
+        }
         let link_item = attr::mk_list_item(@"link", meta_items);
 
         return attr::mk_attr(link_item);
     }
 
-    let mut attrs: ~[attribute] = ~[];
+    let mut attrs = ~[];
     let mut found_link_attr = false;
     for crate.node.attrs.iter().advance |attr| {
         attrs.push(
-            if "link" != attr::get_attr_name(attr)  {
+            if "link" != attr.name()  {
                 *attr
             } else {
-                match attr.node.value.node {
-                  meta_list(_, ref l) => {
+                match attr.meta_item_list() {
+                  Some(l) => {
                     found_link_attr = true;;
-                    synthesize_link_attr(ecx, (*l).clone())
+                    synthesize_link_attr(ecx, l.to_owned())
                   }
                   _ => *attr
                 }

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -13,9 +13,9 @@ use driver::session;
 use driver::session::Session;
 use syntax::parse::token::special_idents;
 use syntax::ast::{crate, node_id, item, item_fn};
+use syntax::attr;
 use syntax::codemap::span;
 use syntax::visit::{default_visitor, mk_vt, vt, Visitor, visit_crate, visit_item};
-use syntax::attr::{attrs_contains_name};
 use syntax::ast_map;
 use std::util;
 
@@ -90,7 +90,7 @@ fn find_item(item: @item, ctxt: @mut EntryContext, visitor: EntryVisitor) {
                 }
             }
 
-            if attrs_contains_name(item.attrs, "main") {
+            if attr::contains_name(item.attrs, "main") {
                 if ctxt.attr_main_fn.is_none() {
                     ctxt.attr_main_fn = Some((item.id, item.span));
                 } else {
@@ -100,7 +100,7 @@ fn find_item(item: @item, ctxt: @mut EntryContext, visitor: EntryVisitor) {
                 }
             }
 
-            if attrs_contains_name(item.attrs, "start") {
+            if attr::contains_name(item.attrs, "start") {
                 if ctxt.start_fn.is_none() {
                     ctxt.start_fn = Some((item.id, item.span));
                 } else {

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -17,7 +17,7 @@ use util::ppaux::{Repr, ty_to_str};
 use util::ppaux::UserString;
 
 use syntax::ast::*;
-use syntax::attr::attrs_contains_name;
+use syntax::attr;
 use syntax::codemap::span;
 use syntax::print::pprust::expr_to_str;
 use syntax::{visit, ast_util};
@@ -113,7 +113,7 @@ fn check_block(block: &blk, (cx, visitor): (Context, visit::vt<Context>)) {
 
 fn check_item(item: @item, (cx, visitor): (Context, visit::vt<Context>)) {
     // If this is a destructor, check kinds.
-    if !attrs_contains_name(item.attrs, "unsafe_destructor") {
+    if !attr::contains_name(item.attrs, "unsafe_destructor") {
         match item.node {
             item_impl(_, Some(ref trait_ref), ref self_type, _) => {
                 match cx.tcx.def_map.find(&trait_ref.ref_id) {
@@ -574,4 +574,3 @@ pub fn check_cast_for_escaping_regions(
         cx.tcx.region_maps.is_subregion_of(r_sub, r_sup)
     }
 }
-

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -23,9 +23,9 @@
 use driver::session::Session;
 use metadata::csearch::each_lang_item;
 use metadata::cstore::iter_crate_data;
-use syntax::ast::{crate, def_id, lit_str, meta_item};
-use syntax::ast::{meta_list, meta_name_value, meta_word};
+use syntax::ast::{crate, def_id, MetaItem};
 use syntax::ast_util::local_def;
+use syntax::attr::AttrMetaMethods;
 use syntax::visit::{default_simple_visitor, mk_simple_visitor, SimpleVisitor};
 use syntax::visit::visit_crate;
 
@@ -360,17 +360,12 @@ impl<'self> LanguageItemCollector<'self> {
 
     pub fn match_and_collect_meta_item(&mut self,
                                        item_def_id: def_id,
-                                       meta_item: &meta_item) {
-        match meta_item.node {
-            meta_name_value(key, literal) => {
-                match literal.node {
-                    lit_str(value) => {
-                        self.match_and_collect_item(item_def_id, key, value);
-                    }
-                    _ => {} // Skip.
-                }
+                                       meta_item: &MetaItem) {
+        match meta_item.name_str_pair() {
+            Some((key, value)) => {
+                self.match_and_collect_item(item_def_id, key, value);
             }
-            meta_word(*) | meta_list(*) => {} // Skip.
+            None => {} // skip
         }
     }
 

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -376,8 +376,7 @@ pub fn check_crate<'mm>(tcx: ty::ctxt,
         visit_item: |item, (method_map, visitor)| {
             // Do not check privacy inside items with the resolve_unexported
             // attribute. This is used for the test runner.
-            if !attr::contains_name(attr::attr_metas(item.attrs),
-                                    "!resolve_unexported") {
+            if !attr::contains_name(item.attrs, "!resolve_unexported") {
                 visit::visit_item(item, (method_map, visitor));
             }
         },

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -31,8 +31,8 @@ use syntax::visit;
 
 // Returns true if the given set of attributes contains the `#[inline]`
 // attribute.
-fn attributes_specify_inlining(attrs: &[attribute]) -> bool {
-    attr::attrs_contains_name(attrs, "inline")
+fn attributes_specify_inlining(attrs: &[Attribute]) -> bool {
+    attr::contains_name(attrs, "inline")
 }
 
 // Returns true if the given set of generics implies that the item it's
@@ -431,4 +431,3 @@ pub fn find_reachable(tcx: ty::ctxt,
     // Return the set of reachable symbols.
     reachable_context.reachable_symbols
 }
-

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -26,7 +26,7 @@ use syntax::ast_util::{def_id_of_def, local_def};
 use syntax::ast_util::{path_to_ident, walk_pat, trait_method_to_ty_method};
 use syntax::ast_util::{Privacy, Public, Private};
 use syntax::ast_util::{variant_visibility_to_privacy, visibility_to_privacy};
-use syntax::attr::{attr_metas, contains_name};
+use syntax::attr;
 use syntax::parse::token;
 use syntax::parse::token::ident_interner;
 use syntax::parse::token::special_idents;
@@ -3494,8 +3494,7 @@ impl Resolver {
         // Items with the !resolve_unexported attribute are X-ray contexts.
         // This is used to allow the test runner to run unexported tests.
         let orig_xray_flag = self.xray_context;
-        if contains_name(attr_metas(item.attrs),
-                         "!resolve_unexported") {
+        if attr::contains_name(item.attrs, "!resolve_unexported") {
             self.xray_context = Xray;
         }
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -79,6 +79,7 @@ use syntax::ast::ident;
 use syntax::ast_map::{path, path_elt_to_str, path_name};
 use syntax::ast_util::{local_def};
 use syntax::attr;
+use syntax::attr::AttrMetaMethods;
 use syntax::codemap::span;
 use syntax::parse::token;
 use syntax::parse::token::{special_idents};
@@ -464,13 +465,14 @@ pub fn set_inline_hint(f: ValueRef) {
     }
 }
 
-pub fn set_inline_hint_if_appr(attrs: &[ast::attribute],
+pub fn set_inline_hint_if_appr(attrs: &[ast::Attribute],
                                llfn: ValueRef) {
-    match attr::find_inline_attr(attrs) {
-      attr::ia_hint => set_inline_hint(llfn),
-      attr::ia_always => set_always_inline(llfn),
-      attr::ia_never => set_no_inline(llfn),
-      attr::ia_none => { /* fallthrough */ }
+    use syntax::attr::*;
+    match find_inline_attr(attrs) {
+        InlineHint   => set_inline_hint(llfn),
+        InlineAlways => set_always_inline(llfn),
+        InlineNever  => set_no_inline(llfn),
+        InlineNone   => { /* fallthrough */ }
     }
 }
 
@@ -1845,7 +1847,7 @@ pub fn trans_closure(ccx: @mut CrateContext,
                      self_arg: self_arg,
                      param_substs: Option<@param_substs>,
                      id: ast::node_id,
-                     attributes: &[ast::attribute],
+                     attributes: &[ast::Attribute],
                      output_type: ty::t,
                      maybe_load_env: &fn(fn_ctxt),
                      finish: &fn(block)) {
@@ -1868,7 +1870,7 @@ pub fn trans_closure(ccx: @mut CrateContext,
     let raw_llargs = create_llargs_for_fn_args(fcx, self_arg, decl.inputs);
 
     // Set the fixed stack segment flag if necessary.
-    if attr::attrs_contains_name(attributes, "fixed_stack_segment") {
+    if attr::contains_name(attributes, "fixed_stack_segment") {
         set_no_inline(fcx.llfn);
         set_fixed_stack_segment(fcx.llfn);
     }
@@ -1926,7 +1928,7 @@ pub fn trans_fn(ccx: @mut CrateContext,
                 self_arg: self_arg,
                 param_substs: Option<@param_substs>,
                 id: ast::node_id,
-                attrs: &[ast::attribute]) {
+                attrs: &[ast::Attribute]) {
 
     let the_path_str = path_str(ccx.sess, path);
     let _s = StatRecorder::new(ccx, the_path_str);
@@ -2196,23 +2198,17 @@ pub fn trans_item(ccx: @mut CrateContext, item: &ast::item) {
           // Do static_assert checking. It can't really be done much earlier because we need to get
           // the value of the bool out of LLVM
           for item.attrs.iter().advance |attr| {
-              match attr.node.value.node {
-                  ast::meta_word(x) => {
-                      if x.slice(0, x.len()) == "static_assert" {
-                          if m == ast::m_mutbl {
-                              ccx.sess.span_fatal(expr.span,
-                                                  "cannot have static_assert \
-                                                   on a mutable static");
-                          }
-                          let v = ccx.const_values.get_copy(&item.id);
-                          unsafe {
-                              if !(llvm::LLVMConstIntGetZExtValue(v) as bool) {
-                                  ccx.sess.span_fatal(expr.span, "static assertion failed");
-                              }
-                          }
+              if "static_assert" == attr.name() {
+                  if m == ast::m_mutbl {
+                      ccx.sess.span_fatal(expr.span,
+                                          "cannot have static_assert on a mutable static");
+                  }
+                  let v = ccx.const_values.get_copy(&item.id);
+                  unsafe {
+                      if !(llvm::LLVMConstIntGetZExtValue(v) as bool) {
+                          ccx.sess.span_fatal(expr.span, "static assertion failed");
                       }
-                  },
-                  _ => ()
+                  }
               }
           }
       },
@@ -2258,7 +2254,7 @@ pub fn register_fn(ccx: @mut CrateContext,
                    sp: span,
                    path: path,
                    node_id: ast::node_id,
-                   attrs: &[ast::attribute])
+                   attrs: &[ast::Attribute])
                 -> ValueRef {
     let t = ty::node_id_to_type(ccx.tcx, node_id);
     register_fn_full(ccx, sp, path, node_id, attrs, t)
@@ -2268,7 +2264,7 @@ pub fn register_fn_full(ccx: @mut CrateContext,
                         sp: span,
                         path: path,
                         node_id: ast::node_id,
-                        attrs: &[ast::attribute],
+                        attrs: &[ast::Attribute],
                         node_type: ty::t)
                      -> ValueRef {
     let llfty = type_of_fn_from_ty(ccx, node_type);
@@ -2280,7 +2276,7 @@ pub fn register_fn_fuller(ccx: @mut CrateContext,
                           sp: span,
                           path: path,
                           node_id: ast::node_id,
-                          attrs: &[ast::attribute],
+                          attrs: &[ast::Attribute],
                           node_type: ty::t,
                           cc: lib::llvm::CallConv,
                           fn_ty: Type)
@@ -2289,7 +2285,7 @@ pub fn register_fn_fuller(ccx: @mut CrateContext,
            node_id,
            ast_map::path_to_str(path, token::get_ident_interner()));
 
-    let ps = if attr::attrs_contains_name(attrs, "no_mangle") {
+    let ps = if attr::contains_name(attrs, "no_mangle") {
         path_elt_to_str(*path.last(), token::get_ident_interner())
     } else {
         mangle_exported_name(ccx, path, node_type)

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -351,10 +351,10 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
                         cc: lib::llvm::CallConv) {
         let llwrapfn = get_item_val(ccx, id);
         let tys = shim_types(ccx, id);
-        if attr::attrs_contains_name(foreign_item.attrs, "rust_stack") {
+        if attr::contains_name(foreign_item.attrs, "rust_stack") {
             build_direct_fn(ccx, llwrapfn, foreign_item,
                             &tys, cc);
-        } else if attr::attrs_contains_name(foreign_item.attrs, "fast_ffi") {
+        } else if attr::contains_name(foreign_item.attrs, "fast_ffi") {
             build_fast_ffi_fn(ccx, llwrapfn, foreign_item, &tys, cc);
         } else {
             let llshimfn = build_shim_fn(ccx, foreign_item, &tys, cc);
@@ -546,7 +546,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
                        item: &ast::foreign_item,
                        path: ast_map::path,
                        substs: @param_substs,
-                       attributes: &[ast::attribute],
+                       attributes: &[ast::Attribute],
                        ref_id: Option<ast::node_id>) {
     debug!("trans_intrinsic(item.ident=%s)", ccx.sess.str_of(item.ident));
 
@@ -624,7 +624,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
     set_always_inline(fcx.llfn);
 
     // Set the fixed stack segment flag if necessary.
-    if attr::attrs_contains_name(attributes, "fixed_stack_segment") {
+    if attr::contains_name(attributes, "fixed_stack_segment") {
         set_fixed_stack_segment(fcx.llfn);
     }
 
@@ -1146,7 +1146,7 @@ pub fn register_foreign_fn(ccx: @mut CrateContext,
                            sp: span,
                            path: ast_map::path,
                            node_id: ast::node_id,
-                           attrs: &[ast::attribute])
+                           attrs: &[ast::Attribute])
                            -> ValueRef {
     let _icx = push_ctxt("foreign::register_foreign_fn");
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3966,7 +3966,7 @@ pub fn has_attr(tcx: ctxt, did: def_id, attr: &str) -> bool {
                 &ast_map::node_item(@ast::item {
                     attrs: ref attrs,
                     _
-                }, _)) => attr::attrs_contains_name(*attrs, attr),
+                }, _)) => attr::contains_name(*attrs, attr),
             _ => tcx.sess.bug(fmt!("has_attr: %? is not an item",
                                    did))
         }

--- a/src/librustdoc/attr_pass.rs
+++ b/src/librustdoc/attr_pass.rs
@@ -68,7 +68,7 @@ fn fold_crate(
     doc::CrateDoc {
         topmod: doc::ModDoc {
             item: doc::ItemDoc {
-                name: attrs.name.clone().get_or_default(doc.topmod.name()),
+                name: attrs.name.clone().get_or_default(doc.topmod.name_()),
                 .. doc.topmod.item.clone()
             },
             .. doc.topmod.clone()
@@ -102,7 +102,7 @@ fn fold_item(
 fn parse_item_attrs<T:Send>(
     srv: astsrv::Srv,
     id: doc::AstId,
-    parse_attrs: ~fn(a: ~[ast::attribute]) -> T) -> T {
+    parse_attrs: ~fn(a: ~[ast::Attribute]) -> T) -> T {
     do astsrv::exec(srv) |ctxt| {
         let attrs = match ctxt.ast_map.get_copy(&id) {
             ast_map::node_item(item, _) => item.attrs.clone(),
@@ -249,7 +249,7 @@ mod test {
     #[test]
     fn should_replace_top_module_name_with_crate_name() {
         let doc = mk_doc(~"#[link(name = \"bond\")];");
-        assert!(doc.cratemod().name() == ~"bond");
+        assert!(doc.cratemod().name_() == ~"bond");
     }
 
     #[test]

--- a/src/librustdoc/doc.rs
+++ b/src/librustdoc/doc.rs
@@ -355,7 +355,11 @@ impl Item for StructDoc {
 
 pub trait ItemUtils {
     fn id(&self) -> AstId;
-    fn name(&self) -> ~str;
+    /// FIXME #5898: This conflicts with
+    /// syntax::attr::AttrMetaMethods.name; This rustdoc seems to be on
+    /// the way out so I'm making this one look bad rather than the
+    /// new methods in attr.
+    fn name_(&self) -> ~str;
     fn path(&self) -> ~[~str];
     fn brief(&self) -> Option<~str>;
     fn desc(&self) -> Option<~str>;
@@ -367,7 +371,7 @@ impl<A:Item> ItemUtils for A {
         self.item().id
     }
 
-    fn name(&self) -> ~str {
+    fn name_(&self) -> ~str {
         self.item().name.clone()
     }
 

--- a/src/librustdoc/extract.rs
+++ b/src/librustdoc/extract.rs
@@ -298,21 +298,21 @@ mod test {
     #[test]
     fn extract_mods() {
         let doc = mk_doc(@"mod a { mod b { } mod c { } }");
-        assert!(doc.cratemod().mods()[0].name() == ~"a");
-        assert!(doc.cratemod().mods()[0].mods()[0].name() == ~"b");
-        assert!(doc.cratemod().mods()[0].mods()[1].name() == ~"c");
+        assert!(doc.cratemod().mods()[0].name_() == ~"a");
+        assert!(doc.cratemod().mods()[0].mods()[0].name_() == ~"b");
+        assert!(doc.cratemod().mods()[0].mods()[1].name_() == ~"c");
     }
 
     #[test]
     fn extract_fns_from_foreign_mods() {
         let doc = mk_doc(@"extern { fn a(); }");
-        assert!(doc.cratemod().nmods()[0].fns[0].name() == ~"a");
+        assert!(doc.cratemod().nmods()[0].fns[0].name_() == ~"a");
     }
 
     #[test]
     fn extract_mods_deep() {
         let doc = mk_doc(@"mod a { mod b { mod c { } } }");
-        assert!(doc.cratemod().mods()[0].mods()[0].mods()[0].name() ==
+        assert!(doc.cratemod().mods()[0].mods()[0].mods()[0].name_() ==
             ~"c");
     }
 
@@ -328,8 +328,8 @@ mod test {
             @"fn a() { } \
               mod b { fn c() {
              } }");
-        assert!(doc.cratemod().fns()[0].name() == ~"a");
-        assert!(doc.cratemod().mods()[0].fns()[0].name() == ~"c");
+        assert!(doc.cratemod().fns()[0].name_() == ~"a");
+        assert!(doc.cratemod().mods()[0].fns()[0].name_() == ~"c");
     }
 
     #[test]
@@ -343,7 +343,7 @@ mod test {
         let source = @"";
         let ast = parse::from_str(source);
         let doc = extract(ast, ~"burp");
-        assert!(doc.cratemod().name() == ~"burp");
+        assert!(doc.cratemod().name_() == ~"burp");
     }
 
     #[test]
@@ -351,7 +351,7 @@ mod test {
         let source = ~"";
         do astsrv::from_str(source) |srv| {
             let doc = from_srv(srv, ~"name");
-            assert!(doc.cratemod().name() == ~"name");
+            assert!(doc.cratemod().name_() == ~"name");
         }
     }
 
@@ -359,14 +359,14 @@ mod test {
     fn should_extract_const_name_and_id() {
         let doc = mk_doc(@"static a: int = 0;");
         assert!(doc.cratemod().consts()[0].id() != 0);
-        assert!(doc.cratemod().consts()[0].name() == ~"a");
+        assert!(doc.cratemod().consts()[0].name_() == ~"a");
     }
 
     #[test]
     fn should_extract_enums() {
         let doc = mk_doc(@"enum e { v }");
         assert!(doc.cratemod().enums()[0].id() != 0);
-        assert!(doc.cratemod().enums()[0].name() == ~"e");
+        assert!(doc.cratemod().enums()[0].name_() == ~"e");
     }
 
     #[test]
@@ -378,7 +378,7 @@ mod test {
     #[test]
     fn should_extract_traits() {
         let doc = mk_doc(@"trait i { fn f(); }");
-        assert!(doc.cratemod().traits()[0].name() == ~"i");
+        assert!(doc.cratemod().traits()[0].name_() == ~"i");
     }
 
     #[test]
@@ -396,13 +396,13 @@ mod test {
     #[test]
     fn should_extract_tys() {
         let doc = mk_doc(@"type a = int;");
-        assert!(doc.cratemod().types()[0].name() == ~"a");
+        assert!(doc.cratemod().types()[0].name_() == ~"a");
     }
 
     #[test]
     fn should_extract_structs() {
         let doc = mk_doc(@"struct Foo { field: () }");
-        assert!(doc.cratemod().structs()[0].name() == ~"Foo");
+        assert!(doc.cratemod().structs()[0].name_() == ~"Foo");
     }
 
     #[test]

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -172,7 +172,7 @@ pub fn header_kind(doc: doc::ItemTag) -> ~str {
 }
 
 pub fn header_name(doc: doc::ItemTag) -> ~str {
-    let fullpath = (doc.path() + &[doc.name()]).connect("::");
+    let fullpath = (doc.path() + &[doc.name_()]).connect("::");
     match &doc {
         &doc::ModTag(_) if doc.id() != syntax::ast::crate_node_id => {
             fullpath
@@ -200,7 +200,7 @@ pub fn header_name(doc: doc::ItemTag) -> ~str {
             fmt!("%s for %s%s", trait_part, *self_ty, bounds)
         }
         _ => {
-            doc.name()
+            doc.name_()
         }
     }
 }

--- a/src/librustdoc/markdown_writer.rs
+++ b/src/librustdoc/markdown_writer.rs
@@ -159,12 +159,12 @@ pub fn make_filename(
                 config.output_style == config::DocPerMod {
                 ~"index"
             } else {
-                assert!(doc.topmod.name() != ~"");
-                doc.topmod.name()
+                assert!(doc.topmod.name_() != ~"");
+                doc.topmod.name_()
             }
           }
           doc::ItemPage(doc) => {
-            (doc.path() + &[doc.name()]).connect("_")
+            (doc.path() + &[doc.name_()]).connect("_")
           }
         }
     };

--- a/src/librustdoc/page_pass.rs
+++ b/src/librustdoc/page_pass.rs
@@ -174,7 +174,7 @@ mod test {
     fn should_make_a_page_for_every_mod() {
         let doc = mk_doc(~"mod a { }");
         // hidden __std_macros module at the start.
-        assert_eq!(doc.pages.mods()[0].name(), ~"a");
+        assert_eq!(doc.pages.mods()[0].name_(), ~"a");
     }
 
     #[test]

--- a/src/librustdoc/pass.rs
+++ b/src/librustdoc/pass.rs
@@ -48,7 +48,7 @@ fn test_run_passes() {
                 doc::CratePage(doc::CrateDoc{
                     topmod: doc::ModDoc{
                         item: doc::ItemDoc {
-                            name: doc.cratemod().name() + "two",
+                            name: doc.cratemod().name_() + "two",
                             .. doc.cratemod().item.clone()
                         },
                         items: ~[],
@@ -67,7 +67,7 @@ fn test_run_passes() {
                 doc::CratePage(doc::CrateDoc{
                     topmod: doc::ModDoc{
                         item: doc::ItemDoc {
-                            name: doc.cratemod().name() + "three",
+                            name: doc.cratemod().name_() + "three",
                             .. doc.cratemod().item.clone()
                         },
                         items: ~[],
@@ -91,6 +91,6 @@ fn test_run_passes() {
         ];
         let doc = extract::from_srv(srv.clone(), ~"one");
         let doc = run_passes(srv, doc, passes);
-        assert_eq!(doc.cratemod().name(), ~"onetwothree");
+        assert_eq!(doc.cratemod().name_(), ~"onetwothree");
     }
 }

--- a/src/librustdoc/path_pass.rs
+++ b/src/librustdoc/path_pass.rs
@@ -68,7 +68,7 @@ fn fold_item(fold: &fold::Fold<Ctxt>, doc: doc::ItemDoc) -> doc::ItemDoc {
 fn fold_mod(fold: &fold::Fold<Ctxt>, doc: doc::ModDoc) -> doc::ModDoc {
     let is_topmod = doc.id() == ast::crate_node_id;
 
-    if !is_topmod { fold.ctxt.path.push(doc.name()); }
+    if !is_topmod { fold.ctxt.path.push(doc.name_()); }
     let doc = fold::default_any_fold_mod(fold, doc);
     if !is_topmod { fold.ctxt.path.pop(); }
 
@@ -79,7 +79,7 @@ fn fold_mod(fold: &fold::Fold<Ctxt>, doc: doc::ModDoc) -> doc::ModDoc {
 }
 
 fn fold_nmod(fold: &fold::Fold<Ctxt>, doc: doc::NmodDoc) -> doc::NmodDoc {
-    fold.ctxt.path.push(doc.name());
+    fold.ctxt.path.push(doc.name_());
     let doc = fold::default_seq_fold_nmod(fold, doc);
     fold.ctxt.path.pop();
 

--- a/src/librustdoc/sort_item_name_pass.rs
+++ b/src/librustdoc/sort_item_name_pass.rs
@@ -17,7 +17,7 @@ use sort_pass;
 
 pub fn mk_pass() -> Pass {
     fn by_item_name(item1: &doc::ItemTag, item2: &doc::ItemTag) -> bool {
-        (*item1).name() <= (*item2).name()
+        (*item1).name_() <= (*item2).name_()
     }
     sort_pass::mk_pass(~"sort_item_name", by_item_name)
 }
@@ -32,7 +32,7 @@ fn test() {
         let doc = extract::from_srv(srv.clone(), ~"");
         let doc = (mk_pass().f)(srv.clone(), doc);
         // hidden __std_macros module at the start.
-        assert_eq!(doc.cratemod().items[1].name(), ~"y");
-        assert_eq!(doc.cratemod().items[2].name(), ~"z");
+        assert_eq!(doc.cratemod().items[1].name_(), ~"y");
+        assert_eq!(doc.cratemod().items[2].name_(), ~"z");
     }
 }

--- a/src/librustdoc/sort_item_type_pass.rs
+++ b/src/librustdoc/sort_item_type_pass.rs
@@ -54,14 +54,14 @@ fn test() {
         let doc = extract::from_srv(srv.clone(), ~"");
         let doc = (mk_pass().f)(srv.clone(), doc);
         // hidden __std_macros module at the start.
-        assert_eq!(doc.cratemod().items[0].name(), ~"iconst");
-        assert_eq!(doc.cratemod().items[1].name(), ~"itype");
-        assert_eq!(doc.cratemod().items[2].name(), ~"ienum");
-        assert_eq!(doc.cratemod().items[3].name(), ~"istruct");
-        assert_eq!(doc.cratemod().items[4].name(), ~"itrait");
-        assert_eq!(doc.cratemod().items[5].name(), ~"__extensions__");
-        assert_eq!(doc.cratemod().items[6].name(), ~"ifn");
+        assert_eq!(doc.cratemod().items[0].name_(), ~"iconst");
+        assert_eq!(doc.cratemod().items[1].name_(), ~"itype");
+        assert_eq!(doc.cratemod().items[2].name_(), ~"ienum");
+        assert_eq!(doc.cratemod().items[3].name_(), ~"istruct");
+        assert_eq!(doc.cratemod().items[4].name_(), ~"itrait");
+        assert_eq!(doc.cratemod().items[5].name_(), ~"__extensions__");
+        assert_eq!(doc.cratemod().items[6].name_(), ~"ifn");
         // hidden __std_macros module fits here.
-        assert_eq!(doc.cratemod().items[8].name(), ~"imod");
+        assert_eq!(doc.cratemod().items[8].name_(), ~"imod");
     }
 }

--- a/src/librustdoc/sort_pass.rs
+++ b/src/librustdoc/sort_pass.rs
@@ -68,7 +68,7 @@ fn fold_mod(
 #[test]
 fn test() {
     fn name_lteq(item1: &doc::ItemTag, item2: &doc::ItemTag) -> bool {
-        (*item1).name() <= (*item2).name()
+        (*item1).name_() <= (*item2).name_()
     }
 
     let source = ~"mod z { mod y { } fn x() { } } mod w { }";
@@ -76,10 +76,10 @@ fn test() {
         let doc = extract::from_srv(srv.clone(), ~"");
         let doc = (mk_pass(~"", name_lteq).f)(srv.clone(), doc);
         // hidden __std_macros module at the start.
-        assert_eq!(doc.cratemod().mods()[1].name(), ~"w");
-        assert_eq!(doc.cratemod().mods()[2].items[0].name(), ~"x");
-        assert_eq!(doc.cratemod().mods()[2].items[1].name(), ~"y");
-        assert_eq!(doc.cratemod().mods()[2].name(), ~"z");
+        assert_eq!(doc.cratemod().mods()[1].name_(), ~"w");
+        assert_eq!(doc.cratemod().mods()[2].items[0].name_(), ~"x");
+        assert_eq!(doc.cratemod().mods()[2].items[1].name_(), ~"y");
+        assert_eq!(doc.cratemod().mods()[2].name_(), ~"z");
     }
 }
 
@@ -94,10 +94,10 @@ fn should_be_stable() {
         let doc = extract::from_srv(srv.clone(), ~"");
         let doc = (mk_pass(~"", always_eq).f)(srv.clone(), doc);
         // hidden __std_macros module at the start.
-        assert_eq!(doc.cratemod().mods()[1].items[0].name(), ~"b");
-        assert_eq!(doc.cratemod().mods()[2].items[0].name(), ~"d");
+        assert_eq!(doc.cratemod().mods()[1].items[0].name_(), ~"b");
+        assert_eq!(doc.cratemod().mods()[2].items[0].name_(), ~"d");
         let doc = (mk_pass(~"", always_eq).f)(srv.clone(), doc);
-        assert_eq!(doc.cratemod().mods()[1].items[0].name(), ~"b");
-        assert_eq!(doc.cratemod().mods()[2].items[0].name(), ~"d");
+        assert_eq!(doc.cratemod().mods()[1].items[0].name_(), ~"b");
+        assert_eq!(doc.cratemod().mods()[2].items[0].name_(), ~"d");
     }
 }

--- a/src/libsyntax/ext/auto_encode.rs
+++ b/src/libsyntax/ext/auto_encode.rs
@@ -17,7 +17,7 @@ use ext::base::*;
 pub fn expand_auto_encode(
     cx: @ExtCtxt,
     span: span,
-    _mitem: @ast::meta_item,
+    _mitem: @ast::MetaItem,
     in_items: ~[@ast::item]
 ) -> ~[@ast::item] {
     cx.span_err(span, "`#[auto_encode]` is deprecated, use `#[deriving(Encodable)]` instead");
@@ -27,7 +27,7 @@ pub fn expand_auto_encode(
 pub fn expand_auto_decode(
     cx: @ExtCtxt,
     span: span,
-    _mitem: @ast::meta_item,
+    _mitem: @ast::MetaItem,
     in_items: ~[@ast::item]
 ) -> ~[@ast::item] {
     cx.span_err(span, "`#[auto_decode]` is deprecated, use `#[deriving(Decodable)]` instead");

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -36,7 +36,7 @@ pub struct MacroDef {
 
 pub type ItemDecorator = @fn(@ExtCtxt,
                              span,
-                             @ast::meta_item,
+                             @ast::MetaItem,
                              ~[@ast::item])
                           -> ~[@ast::item];
 

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -163,7 +163,7 @@ pub trait AstBuilder {
 
     // items
     fn item(&self, span: span,
-            name: ident, attrs: ~[ast::attribute], node: ast::item_) -> @ast::item;
+            name: ident, attrs: ~[ast::Attribute], node: ast::item_) -> @ast::item;
 
     fn arg(&self, span: span, name: ident, ty: ast::Ty) -> ast::arg;
     // XXX unused self
@@ -199,7 +199,7 @@ pub trait AstBuilder {
     fn item_struct(&self, span: span, name: ident, struct_def: ast::struct_def) -> @ast::item;
 
     fn item_mod(&self, span: span,
-                name: ident, attrs: ~[ast::attribute],
+                name: ident, attrs: ~[ast::Attribute],
                 vi: ~[ast::view_item], items: ~[@ast::item]) -> @ast::item;
 
     fn item_ty_poly(&self,
@@ -209,11 +209,11 @@ pub trait AstBuilder {
                     generics: Generics) -> @ast::item;
     fn item_ty(&self, span: span, name: ident, ty: ast::Ty) -> @ast::item;
 
-    fn attribute(&self, sp: span, mi: @ast::meta_item) -> ast::attribute;
+    fn attribute(&self, sp: span, mi: @ast::MetaItem) -> ast::Attribute;
 
-    fn meta_word(&self, sp: span, w: @str) -> @ast::meta_item;
-    fn meta_list(&self, sp: span, name: @str, mis: ~[@ast::meta_item]) -> @ast::meta_item;
-    fn meta_name_value(&self, sp: span, name: @str, value: ast::lit_) -> @ast::meta_item;
+    fn meta_word(&self, sp: span, w: @str) -> @ast::MetaItem;
+    fn meta_list(&self, sp: span, name: @str, mis: ~[@ast::MetaItem]) -> @ast::MetaItem;
+    fn meta_name_value(&self, sp: span, name: @str, value: ast::lit_) -> @ast::MetaItem;
 
     fn view_use(&self, sp: span,
                 vis: ast::visibility, vp: ~[@ast::view_path]) -> ast::view_item;
@@ -657,7 +657,7 @@ impl AstBuilder for @ExtCtxt {
     }
 
     fn item(&self, span: span,
-            name: ident, attrs: ~[ast::attribute], node: ast::item_) -> @ast::item {
+            name: ident, attrs: ~[ast::Attribute], node: ast::item_) -> @ast::item {
         // XXX: Would be nice if our generated code didn't violate
         // Rust coding conventions
         @ast::item { ident: name,
@@ -754,7 +754,7 @@ impl AstBuilder for @ExtCtxt {
     }
 
     fn item_mod(&self, span: span, name: ident,
-                attrs: ~[ast::attribute],
+                attrs: ~[ast::Attribute],
                 vi: ~[ast::view_item],
                 items: ~[@ast::item]) -> @ast::item {
         self.item(
@@ -777,23 +777,22 @@ impl AstBuilder for @ExtCtxt {
         self.item_ty_poly(span, name, ty, ast_util::empty_generics())
     }
 
-    fn attribute(&self, sp: span, mi: @ast::meta_item) -> ast::attribute {
-        respan(sp,
-               ast::attribute_ {
-                   style: ast::attr_outer,
-                   value: mi,
-                   is_sugared_doc: false
-               })
+    fn attribute(&self, sp: span, mi: @ast::MetaItem) -> ast::Attribute {
+        respan(sp, ast::Attribute_ {
+            style: ast::AttrOuter,
+            value: mi,
+            is_sugared_doc: false,
+        })
     }
 
-    fn meta_word(&self, sp: span, w: @str) -> @ast::meta_item {
-        @respan(sp, ast::meta_word(w))
+    fn meta_word(&self, sp: span, w: @str) -> @ast::MetaItem {
+        @respan(sp, ast::MetaWord(w))
     }
-    fn meta_list(&self, sp: span, name: @str, mis: ~[@ast::meta_item]) -> @ast::meta_item {
-        @respan(sp, ast::meta_list(name, mis))
+    fn meta_list(&self, sp: span, name: @str, mis: ~[@ast::MetaItem]) -> @ast::MetaItem {
+        @respan(sp, ast::MetaList(name, mis))
     }
-    fn meta_name_value(&self, sp: span, name: @str, value: ast::lit_) -> @ast::meta_item {
-        @respan(sp, ast::meta_name_value(name, respan(sp, value)))
+    fn meta_name_value(&self, sp: span, name: @str, value: ast::lit_) -> @ast::MetaItem {
+        @respan(sp, ast::MetaNameValue(name, respan(sp, value)))
     }
 
     fn view_use(&self, sp: span,

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{meta_item, item, expr};
+use ast::{MetaItem, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
@@ -16,7 +16,7 @@ use ext::deriving::generic::*;
 
 pub fn expand_deriving_clone(cx: @ExtCtxt,
                              span: span,
-                             mitem: @meta_item,
+                             mitem: @MetaItem,
                              in_items: ~[@item])
                           -> ~[@item] {
     let trait_def = TraitDef {
@@ -40,9 +40,9 @@ pub fn expand_deriving_clone(cx: @ExtCtxt,
 }
 
 pub fn expand_deriving_deep_clone(cx: @ExtCtxt,
-                                 span: span,
-                                 mitem: @meta_item,
-                                 in_items: ~[@item])
+                                  span: span,
+                                  mitem: @MetaItem,
+                                  in_items: ~[@item])
     -> ~[@item] {
     let trait_def = TraitDef {
         path: Path::new(~["std", "clone", "DeepClone"]),

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{meta_item, item, expr};
+use ast::{MetaItem, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
@@ -16,7 +16,7 @@ use ext::deriving::generic::*;
 
 pub fn expand_deriving_eq(cx: @ExtCtxt,
                           span: span,
-                          mitem: @meta_item,
+                          mitem: @MetaItem,
                           in_items: ~[@item]) -> ~[@item] {
     // structures are equal if all fields are equal, and non equal, if
     // any fields are not equal or if the enum variants are different

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use ast;
-use ast::{meta_item, item, expr};
+use ast::{MetaItem, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
@@ -17,7 +17,7 @@ use ext::deriving::generic::*;
 
 pub fn expand_deriving_ord(cx: @ExtCtxt,
                            span: span,
-                           mitem: @meta_item,
+                           mitem: @MetaItem,
                            in_items: ~[@item]) -> ~[@item] {
     macro_rules! md (
         ($name:expr, $op:expr, $equal:expr) => {

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -8,17 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{meta_item, item, expr};
+use ast::{MetaItem, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
 pub fn expand_deriving_totaleq(cx: @ExtCtxt,
-                          span: span,
-                          mitem: @meta_item,
-                          in_items: ~[@item]) -> ~[@item] {
-
+                               span: span,
+                               mitem: @MetaItem,
+                               in_items: ~[@item]) -> ~[@item] {
     fn cs_equals(cx: @ExtCtxt, span: span, substr: &Substructure) -> @expr {
         cs_and(|cx, span, _, _| cx.expr_bool(span, false),
                cx, span, substr)

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{meta_item, item, expr};
+use ast::{MetaItem, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
@@ -17,7 +17,7 @@ use std::cmp::{Ordering, Equal, Less, Greater};
 
 pub fn expand_deriving_totalord(cx: @ExtCtxt,
                                 span: span,
-                                mitem: @meta_item,
+                                mitem: @MetaItem,
                                 in_items: ~[@item]) -> ~[@item] {
     let trait_def = TraitDef {
         path: Path::new(~["std", "cmp", "TotalOrd"]),

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -16,7 +16,7 @@ encodable.rs for more.
 use std::vec;
 use std::uint;
 
-use ast::{meta_item, item, expr, m_mutbl};
+use ast::{MetaItem, item, expr, m_mutbl};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
@@ -24,7 +24,7 @@ use ext::deriving::generic::*;
 
 pub fn expand_deriving_decodable(cx: @ExtCtxt,
                                  span: span,
-                                 mitem: @meta_item,
+                                 mitem: @MetaItem,
                                  in_items: ~[@item]) -> ~[@item] {
     let trait_def = TraitDef {
         path: Path::new_(~["extra", "serialize", "Decodable"], None,

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -75,7 +75,7 @@ would yield functions like:
     }
 */
 
-use ast::{meta_item, item, expr, m_imm, m_mutbl};
+use ast::{MetaItem, item, expr, m_imm, m_mutbl};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
@@ -83,7 +83,7 @@ use ext::deriving::generic::*;
 
 pub fn expand_deriving_encodable(cx: @ExtCtxt,
                                  span: span,
-                                 mitem: @meta_item,
+                                 mitem: @MetaItem,
                                  in_items: ~[@item]) -> ~[@item] {
     let trait_def = TraitDef {
         path: Path::new_(~["extra", "serialize", "Encodable"], None,

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -281,7 +281,7 @@ pub type EnumNonMatchFunc<'self> =
 impl<'self> TraitDef<'self> {
     pub fn expand(&self, cx: @ExtCtxt,
                   span: span,
-                  _mitem: @ast::meta_item,
+                  _mitem: @ast::MetaItem,
                   in_items: ~[@ast::item]) -> ~[@ast::item] {
         let mut result = ~[];
         for in_items.iter().advance |item| {
@@ -361,7 +361,8 @@ impl<'self> TraitDef<'self> {
         let doc_attr = cx.attribute(
             span,
             cx.meta_name_value(span,
-                               @"doc", ast::lit_str(@"Automatically derived.")));
+                               @"doc",
+                               ast::lit_str(@"Automatically derived.")));
         cx.item(
             span,
             ::parse::token::special_idents::clownshoes_extensions,

--- a/src/libsyntax/ext/deriving/iter_bytes.rs
+++ b/src/libsyntax/ext/deriving/iter_bytes.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{meta_item, item, expr, and};
+use ast::{MetaItem, item, expr, and};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
@@ -17,7 +17,7 @@ use ext::deriving::generic::*;
 
 pub fn expand_deriving_iter_bytes(cx: @ExtCtxt,
                                   span: span,
-                                  mitem: @meta_item,
+                                  mitem: @MetaItem,
                                   in_items: ~[@item]) -> ~[@item] {
     let trait_def = TraitDef {
         path: Path::new(~["std", "to_bytes", "IterBytes"]),

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -18,7 +18,8 @@ library.
 
 */
 
-use ast::{enum_def, ident, item, Generics, meta_item, struct_def};
+use ast::{enum_def, ident, item, Generics, struct_def};
+use ast::{MetaItem, MetaList, MetaNameValue, MetaWord};
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use codemap::span;
@@ -58,26 +59,24 @@ pub type ExpandDerivingEnumDefFn<'self> = &'self fn(@ExtCtxt,
 
 pub fn expand_meta_deriving(cx: @ExtCtxt,
                             _span: span,
-                            mitem: @meta_item,
+                            mitem: @MetaItem,
                             in_items: ~[@item])
                          -> ~[@item] {
-    use ast::{meta_list, meta_name_value, meta_word};
-
     match mitem.node {
-        meta_name_value(_, ref l) => {
+        MetaNameValue(_, ref l) => {
             cx.span_err(l.span, "unexpected value in `deriving`");
             in_items
         }
-        meta_word(_) | meta_list(_, []) => {
+        MetaWord(_) | MetaList(_, []) => {
             cx.span_warn(mitem.span, "empty trait list in `deriving`");
             in_items
         }
-        meta_list(_, ref titems) => {
+        MetaList(_, ref titems) => {
             do titems.rev_iter().fold(in_items) |in_items, &titem| {
                 match titem.node {
-                    meta_name_value(tname, _) |
-                    meta_list(tname, _) |
-                    meta_word(tname) => {
+                    MetaNameValue(tname, _) |
+                    MetaList(tname, _) |
+                    MetaWord(tname) => {
                         macro_rules! expand(($func:path) => ($func(cx, titem.span,
                                                                    titem, in_items)));
                         match tname.as_slice() {

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use ast;
-use ast::{meta_item, item, expr, ident};
+use ast::{MetaItem, item, expr, ident};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::{AstBuilder, Duplicate};
@@ -19,7 +19,7 @@ use std::vec;
 
 pub fn expand_deriving_rand(cx: @ExtCtxt,
                             span: span,
-                            mitem: @meta_item,
+                            mitem: @MetaItem,
                             in_items: ~[@item])
     -> ~[@item] {
     let trait_def = TraitDef {

--- a/src/libsyntax/ext/deriving/to_str.rs
+++ b/src/libsyntax/ext/deriving/to_str.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use ast;
-use ast::{meta_item, item, expr};
+use ast::{MetaItem, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
@@ -17,7 +17,7 @@ use ext::deriving::generic::*;
 
 pub fn expand_deriving_to_str(cx: @ExtCtxt,
                               span: span,
-                              mitem: @meta_item,
+                              mitem: @MetaItem,
                               in_items: ~[@item])
     -> ~[@item] {
     let trait_def = TraitDef {

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{meta_item, item, expr};
+use ast::{MetaItem, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
@@ -18,7 +18,7 @@ use std::vec;
 
 pub fn expand_deriving_zero(cx: @ExtCtxt,
                             span: span,
-                            mitem: @meta_item,
+                            mitem: @MetaItem,
                             in_items: ~[@item])
     -> ~[@item] {
     let trait_def = TraitDef {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -14,6 +14,7 @@ use ast::{illegal_ctxt};
 use ast;
 use ast_util::{new_rename, new_mark, resolve};
 use attr;
+use attr::AttrMetaMethods;
 use codemap;
 use codemap::{span, ExpnInfo, NameAndSpan};
 use ext::base::*;
@@ -126,7 +127,7 @@ pub fn expand_mod_items(extsbox: @mut SyntaxEnv,
     // the item into a new set of items.
     let new_items = do vec::flat_map(module_.items) |item| {
         do item.attrs.rev_iter().fold(~[*item]) |items, attr| {
-            let mname = attr::get_attr_name(attr);
+            let mname = attr.name();
 
             match (*extsbox).find(&intern(mname)) {
               Some(@SE(ItemDecorator(dec_fn))) => {
@@ -196,8 +197,8 @@ pub fn expand_item(extsbox: @mut SyntaxEnv,
 }
 
 // does this attribute list contain "macro_escape" ?
-pub fn contains_macro_escape (attrs: &[ast::attribute]) -> bool {
-    attrs.iter().any(|attr| "macro_escape" == attr::get_attr_name(attr))
+pub fn contains_macro_escape(attrs: &[ast::Attribute]) -> bool {
+    attr::contains_name(attrs, "macro_escape")
 }
 
 // Support for item-position macro invocations, exactly the same
@@ -793,7 +794,7 @@ pub fn new_ident_resolver() ->
 mod test {
     use super::*;
     use ast;
-    use ast::{attribute_, attr_outer, meta_word, empty_ctxt};
+    use ast::{Attribute_, AttrOuter, MetaWord, empty_ctxt};
     use codemap;
     use codemap::spanned;
     use parse;
@@ -883,14 +884,14 @@ mod test {
         assert_eq!(contains_macro_escape (attrs2),false);
     }
 
-    // make a "meta_word" outer attribute with the given name
-    fn make_dummy_attr(s: @str) -> ast::attribute {
+    // make a MetaWord outer attribute with the given name
+    fn make_dummy_attr(s: @str) -> ast::Attribute {
         spanned {
             span:codemap::dummy_sp(),
-            node: attribute_ {
-                style: attr_outer,
+            node: Attribute_ {
+                style: AttrOuter,
                 value: @spanned {
-                    node: meta_word(s),
+                    node: MetaWord(s),
                     span: codemap::dummy_sp(),
                 },
                 is_sugared_doc: false,

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -74,35 +74,34 @@ pub type ast_fold_fns = @AstFoldFns;
 /* some little folds that probably aren't useful to have in ast_fold itself*/
 
 //used in noop_fold_item and noop_fold_crate and noop_fold_crate_directive
-fn fold_meta_item_(mi: @meta_item, fld: @ast_fold) -> @meta_item {
+fn fold_meta_item_(mi: @MetaItem, fld: @ast_fold) -> @MetaItem {
     @spanned {
         node:
             match mi.node {
-                meta_word(id) => meta_word(id),
-                meta_list(id, ref mis) => {
+                MetaWord(id) => MetaWord(id),
+                MetaList(id, ref mis) => {
                     let fold_meta_item = |x| fold_meta_item_(x, fld);
-                    meta_list(
+                    MetaList(
                         id,
                         mis.map(|e| fold_meta_item(*e))
                     )
                 }
-                meta_name_value(id, s) => {
-                    meta_name_value(id, s)
-                }
+                MetaNameValue(id, s) => MetaNameValue(id, s)
             },
         span: fld.new_span(mi.span) }
 }
 //used in noop_fold_item and noop_fold_crate
-fn fold_attribute_(at: attribute, fld: @ast_fold) -> attribute {
+fn fold_attribute_(at: Attribute, fld: @ast_fold) -> Attribute {
     spanned {
-        node: ast::attribute_ {
+        span: fld.new_span(at.span),
+        node: ast::Attribute_ {
             style: at.node.style,
             value: fold_meta_item_(at.node.value, fld),
-            is_sugared_doc: at.node.is_sugared_doc,
-        },
-        span: fld.new_span(at.span),
+            is_sugared_doc: at.node.is_sugared_doc
+        }
     }
 }
+
 //used in noop_fold_foreign_item and noop_fold_fn_decl
 fn fold_arg_(a: arg, fld: @ast_fold) -> arg {
     ast::arg {
@@ -936,11 +935,11 @@ impl ast_fold for AstFoldFns {
 }
 
 pub trait AstFoldExtensions {
-    fn fold_attributes(&self, attrs: ~[attribute]) -> ~[attribute];
+    fn fold_attributes(&self, attrs: ~[Attribute]) -> ~[Attribute];
 }
 
 impl AstFoldExtensions for @ast_fold {
-    fn fold_attributes(&self, attrs: ~[attribute]) -> ~[attribute] {
+    fn fold_attributes(&self, attrs: ~[Attribute]) -> ~[Attribute] {
         attrs.map(|x| fold_attribute_(*x, *self))
     }
 }

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -44,12 +44,12 @@ pub fn is_doc_comment(s: &str) -> bool {
     s.starts_with("/*!")
 }
 
-pub fn doc_comment_style(comment: &str) -> ast::attr_style {
+pub fn doc_comment_style(comment: &str) -> ast::AttrStyle {
     assert!(is_doc_comment(comment));
     if comment.starts_with("//!") || comment.starts_with("/*!") {
-        ast::attr_inner
+        ast::AttrInner
     } else {
-        ast::attr_outer
+        ast::AttrOuter
     }
 }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -115,7 +115,7 @@ pub fn parse_item_from_source_str(
     name: @str,
     source: @str,
     cfg: ast::crate_cfg,
-    attrs: ~[ast::attribute],
+    attrs: ~[ast::Attribute],
     sess: @mut ParseSess
 ) -> Option<@ast::item> {
     let p = new_parser_from_source_str(
@@ -132,7 +132,7 @@ pub fn parse_meta_from_source_str(
     source: @str,
     cfg: ast::crate_cfg,
     sess: @mut ParseSess
-) -> @ast::meta_item {
+) -> @ast::MetaItem {
     let p = new_parser_from_source_str(
         sess,
         cfg,
@@ -146,7 +146,7 @@ pub fn parse_stmt_from_source_str(
     name: @str,
     source: @str,
     cfg: ast::crate_cfg,
-    attrs: ~[ast::attribute],
+    attrs: ~[ast::Attribute],
     sess: @mut ParseSess
 ) -> @ast::stmt {
     let p = new_parser_from_source_str(

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -17,7 +17,7 @@ Obsolete syntax that becomes too hard to parse can be
 removed.
 */
 
-use ast::{expr, expr_lit, lit_nil, attribute};
+use ast::{expr, expr_lit, lit_nil, Attribute};
 use ast;
 use codemap::{span, respan};
 use parse::parser::Parser;
@@ -88,7 +88,7 @@ pub trait ParserObsoleteMethods {
     fn eat_obsolete_ident(&self, ident: &str) -> bool;
     fn try_parse_obsolete_struct_ctor(&self) -> bool;
     fn try_parse_obsolete_with(&self) -> bool;
-    fn try_parse_obsolete_priv_section(&self, attrs: &[attribute]) -> bool;
+    fn try_parse_obsolete_priv_section(&self, attrs: &[Attribute]) -> bool;
 }
 
 impl ParserObsoleteMethods for Parser {
@@ -322,7 +322,7 @@ impl ParserObsoleteMethods for Parser {
         }
     }
 
-    pub fn try_parse_obsolete_priv_section(&self, attrs: &[attribute])
+    pub fn try_parse_obsolete_priv_section(&self, attrs: &[Attribute])
                                            -> bool {
         if self.is_keyword(keywords::Priv) &&
                 self.look_ahead(1, |t| *t == token::LBRACE) {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -15,7 +15,7 @@ use ast::{CallSugar, NoSugar, DoSugar, ForSugar};
 use ast::{TyBareFn, TyClosure};
 use ast::{RegionTyParamBound, TraitTyParamBound};
 use ast::{provided, public, purity};
-use ast::{_mod, add, arg, arm, attribute, bind_by_ref, bind_infer};
+use ast::{_mod, add, arg, arm, Attribute, bind_by_ref, bind_infer};
 use ast::{bitand, bitor, bitxor, blk};
 use ast::{blk_check_mode, box};
 use ast::{crate, crate_cfg, decl, decl_item};
@@ -109,12 +109,12 @@ enum restriction {
 }
 
 type arg_or_capture_item = Either<arg, ()>;
-type item_info = (ident, item_, Option<~[attribute]>);
+type item_info = (ident, item_, Option<~[Attribute]>);
 
 pub enum item_or_view_item {
     // Indicates a failure to parse any kind of item. The attributes are
     // returned.
-    iovi_none(~[attribute]),
+    iovi_none(~[Attribute]),
     iovi_item(@item),
     iovi_foreign_item(@foreign_item),
     iovi_view_item(view_item)
@@ -242,8 +242,8 @@ macro_rules! maybe_whole (
 )
 
 
-fn maybe_append(lhs: ~[attribute], rhs: Option<~[attribute]>)
-             -> ~[attribute] {
+fn maybe_append(lhs: ~[Attribute], rhs: Option<~[Attribute]>)
+             -> ~[Attribute] {
     match rhs {
         None => lhs,
         Some(ref attrs) => vec::append(lhs, (*attrs))
@@ -252,7 +252,7 @@ fn maybe_append(lhs: ~[attribute], rhs: Option<~[attribute]>)
 
 
 struct ParsedItemsAndViewItems {
-    attrs_remaining: ~[attribute],
+    attrs_remaining: ~[Attribute],
     view_items: ~[view_item],
     items: ~[@item],
     foreign_items: ~[@foreign_item]
@@ -2959,7 +2959,7 @@ impl Parser {
     // parse a structure field
     fn parse_name_and_ty(&self,
                          pr: visibility,
-                         attrs: ~[attribute]) -> @struct_field {
+                         attrs: ~[Attribute]) -> @struct_field {
         let lo = self.span.lo;
         if !is_plain_ident(&*self.token) {
             self.fatal("expected ident");
@@ -2977,7 +2977,7 @@ impl Parser {
 
     // parse a statement. may include decl.
     // precondition: any attributes are parsed already
-    pub fn parse_stmt(&self, item_attrs: ~[attribute]) -> @stmt {
+    pub fn parse_stmt(&self, item_attrs: ~[Attribute]) -> @stmt {
         maybe_whole!(self, nt_stmt);
 
         fn check_expected_item(p: &Parser, found_attrs: bool) {
@@ -3091,7 +3091,7 @@ impl Parser {
 
     // parse a block. Inner attrs are allowed.
     fn parse_inner_attrs_and_block(&self)
-        -> (~[attribute], blk) {
+        -> (~[Attribute], blk) {
 
         maybe_whole!(pair_empty self, nt_block);
 
@@ -3115,7 +3115,7 @@ impl Parser {
 
     // parse the rest of a block expression or function body
     fn parse_block_tail_(&self, lo: BytePos, s: blk_check_mode,
-                         first_item_attrs: ~[attribute]) -> blk {
+                         first_item_attrs: ~[Attribute]) -> blk {
         let mut stmts = ~[];
         let mut expr = None;
 
@@ -3594,7 +3594,7 @@ impl Parser {
 
     fn mk_item(&self, lo: BytePos, hi: BytePos, ident: ident,
                node: item_, vis: visibility,
-               attrs: ~[attribute]) -> @item {
+               attrs: ~[Attribute]) -> @item {
         @ast::item { ident: ident,
                      attrs: attrs,
                      id: self.get_id(),
@@ -3825,7 +3825,7 @@ impl Parser {
     // parse a structure field declaration
     pub fn parse_single_struct_field(&self,
                                      vis: visibility,
-                                     attrs: ~[attribute])
+                                     attrs: ~[Attribute])
                                      -> @struct_field {
         if self.eat_obsolete_ident("let") {
             self.obsolete(*self.last_span, ObsoleteLet);
@@ -3894,7 +3894,7 @@ impl Parser {
     // attributes (of length 0 or 1), parse all of the items in a module
     fn parse_mod_items(&self,
                        term: token::Token,
-                       first_item_attrs: ~[attribute])
+                       first_item_attrs: ~[Attribute])
                        -> _mod {
         // parse all of the items up to closing or an attribute.
         // view items are legal here.
@@ -3953,7 +3953,7 @@ impl Parser {
     }
 
     // parse a `mod <foo> { ... }` or `mod <foo>;` item
-    fn parse_item_mod(&self, outer_attrs: &[ast::attribute]) -> item_info {
+    fn parse_item_mod(&self, outer_attrs: &[Attribute]) -> item_info {
         let id_span = *self.span;
         let id = self.parse_ident();
         if *self.token == token::SEMI {
@@ -3972,11 +3972,10 @@ impl Parser {
         }
     }
 
-    fn push_mod_path(&self, id: ident, attrs: &[ast::attribute]) {
+    fn push_mod_path(&self, id: ident, attrs: &[Attribute]) {
         let default_path = token::interner_get(id.name);
-        let file_path = match ::attr::first_attr_value_str_by_name(
-            attrs, "path") {
-
+        let file_path = match ::attr::first_attr_value_str_by_name(attrs,
+                                                                   "path") {
             Some(d) => d,
             None => default_path
         };
@@ -3990,14 +3989,13 @@ impl Parser {
     // read a module from a source file.
     fn eval_src_mod(&self,
                     id: ast::ident,
-                    outer_attrs: &[ast::attribute],
+                    outer_attrs: &[ast::Attribute],
                     id_sp: span)
-                    -> (ast::item_, ~[ast::attribute]) {
+                    -> (ast::item_, ~[ast::Attribute]) {
         let prefix = Path(self.sess.cm.span_to_filename(*self.span));
         let prefix = prefix.dir_path();
         let mod_path_stack = &*self.mod_path_stack;
         let mod_path = Path(".").push_many(*mod_path_stack);
-        let default_path = token::interner_get(id.name).to_owned() + ".rs";
         let file_path = match ::attr::first_attr_value_str_by_name(
                 outer_attrs, "path") {
             Some(d) => {
@@ -4008,7 +4006,7 @@ impl Parser {
                     path
                 }
             }
-            None => mod_path.push(default_path)
+            None => mod_path.push(token::interner_get(id.name) + ".rs") // default
         };
 
         self.eval_src_mod_from_path(prefix,
@@ -4020,8 +4018,8 @@ impl Parser {
     fn eval_src_mod_from_path(&self,
                               prefix: Path,
                               path: Path,
-                              outer_attrs: ~[ast::attribute],
-                              id_sp: span) -> (ast::item_, ~[ast::attribute]) {
+                              outer_attrs: ~[ast::Attribute],
+                              id_sp: span) -> (ast::item_, ~[ast::Attribute]) {
 
         let full_path = if path.is_absolute {
             path
@@ -4057,17 +4055,10 @@ impl Parser {
         let m0 = p0.parse_mod_items(token::EOF, first_item_outer_attrs);
         self.sess.included_mod_stack.pop();
         return (ast::item_mod(m0), mod_attrs);
-
-        fn cdir_path_opt(default: @str, attrs: ~[ast::attribute]) -> @str {
-            match ::attr::first_attr_value_str_by_name(attrs, "path") {
-                Some(d) => d,
-                None => default
-            }
-        }
     }
 
     // parse a function declaration from a foreign module
-    fn parse_item_foreign_fn(&self,  attrs: ~[attribute]) -> @foreign_item {
+    fn parse_item_foreign_fn(&self,  attrs: ~[Attribute]) -> @foreign_item {
         let lo = self.span.lo;
         let vis = self.parse_visibility();
         let purity = self.parse_fn_purity();
@@ -4085,7 +4076,7 @@ impl Parser {
 
     // parse a const definition from a foreign module
     fn parse_item_foreign_const(&self, vis: ast::visibility,
-                                attrs: ~[attribute]) -> @foreign_item {
+                                attrs: ~[Attribute]) -> @foreign_item {
         let lo = self.span.lo;
 
         // XXX: Obsolete; remove after snap.
@@ -4130,7 +4121,7 @@ impl Parser {
     fn parse_foreign_mod_items(&self,
                                sort: ast::foreign_mod_sort,
                                abis: AbiSet,
-                               first_item_attrs: ~[attribute])
+                               first_item_attrs: ~[Attribute])
                                -> foreign_mod {
         let ParsedItemsAndViewItems {
             attrs_remaining: attrs_remaining,
@@ -4156,7 +4147,7 @@ impl Parser {
                               lo: BytePos,
                               opt_abis: Option<AbiSet>,
                               visibility: visibility,
-                              attrs: ~[attribute],
+                              attrs: ~[Attribute],
                               items_allowed: bool)
                               -> item_or_view_item {
         let mut must_be_named_mod = false;
@@ -4430,7 +4421,7 @@ impl Parser {
     // NB: this function no longer parses the items inside an
     // extern mod.
     fn parse_item_or_view_item(&self,
-                               attrs: ~[attribute],
+                               attrs: ~[Attribute],
                                macros_allowed: bool)
                                -> item_or_view_item {
         maybe_whole!(iovi self, nt_item);
@@ -4562,7 +4553,7 @@ impl Parser {
 
     // parse a foreign item; on failure, return iovi_none.
     fn parse_foreign_item(&self,
-                          attrs: ~[attribute],
+                          attrs: ~[Attribute],
                           macros_allowed: bool)
                           -> item_or_view_item {
         maybe_whole!(iovi self, nt_item);
@@ -4587,7 +4578,7 @@ impl Parser {
     // this is the fall-through for parsing items.
     fn parse_macro_use_or_failure(
         &self,
-        attrs: ~[attribute],
+        attrs: ~[Attribute],
         macros_allowed: bool,
         lo : BytePos,
         visibility : visibility
@@ -4649,7 +4640,7 @@ impl Parser {
         return iovi_none(attrs);
     }
 
-    pub fn parse_item(&self, attrs: ~[attribute]) -> Option<@ast::item> {
+    pub fn parse_item(&self, attrs: ~[Attribute]) -> Option<@ast::item> {
         match self.parse_item_or_view_item(attrs, true) {
             iovi_none(_) =>
                 None,
@@ -4786,7 +4777,7 @@ impl Parser {
     // parse a view item.
     fn parse_view_item(
         &self,
-        attrs: ~[attribute],
+        attrs: ~[Attribute],
         vis: visibility
     ) -> view_item {
         let lo = self.span.lo;
@@ -4812,7 +4803,7 @@ impl Parser {
     // - mod_items uses extern_mod_allowed = true
     // - block_tail_ uses extern_mod_allowed = false
     fn parse_items_and_view_items(&self,
-                                  first_item_attrs: ~[attribute],
+                                  first_item_attrs: ~[Attribute],
                                   mut extern_mod_allowed: bool,
                                   macros_allowed: bool)
                                   -> ParsedItemsAndViewItems {
@@ -4894,7 +4885,7 @@ impl Parser {
 
     // Parses a sequence of foreign items. Stops when it finds program
     // text that can't be parsed as an item
-    fn parse_foreign_items(&self, first_item_attrs: ~[attribute],
+    fn parse_foreign_items(&self, first_item_attrs: ~[Attribute],
                            macros_allowed: bool)
         -> ParsedItemsAndViewItems {
         let mut attrs = vec::append(first_item_attrs,


### PR DESCRIPTION
This does a number of things, but especially dramatically reduce the
number of allocations performed for operations involving attributes/
meta items:
- Converts ast::meta_item & ast::attribute and other associated enums
  to CamelCase.
- Converts several standalone functions in syntax::attr into methods,
  defined on two traits AttrMetaMethods & AttributeMethods. The former
  is common to both MetaItem and Attribute since the latter is a thin
  wrapper around the former.
- Deletes functions that are unnecessary due to iterators.
- Converts other standalone functions to use iterators and the generic
  AttrMetaMethods rather than allocating a lot of new vectors (e.g. the
  old code would have to allocate a new vector to use functions that
  operated on &[meta_item] on &[attribute].)
- Moves the core algorithm of the #[cfg] matching to syntax::attr,
  similar to find_inline_attr and find_linkage_metas.

This doesn't have much of an effect on the speed of #[cfg] stripping,
despite hugely reducing the number of allocations performed; presumably
most of the time is spent in the ast folder rather than doing attribute
checks.

Also fixes the Eq instance of MetaItem_ to correctly ignore spans, so
that `rustc --cfg 'foo(bar)'` now works.
