### PR TITLE
syntax: Bless mod.rs. #4116

### DIFF
--- a/src/test/compile-fail/mod_file_disambig.rs
+++ b/src/test/compile-fail/mod_file_disambig.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:error opening
+mod mod_file_disambig_aux; //~ ERROR file for module `mod_file_disambig_aux` found at both
 
-mod doesnotexist;
+fn main() {
+    assert_eq!(mod_file_aux::bar(), 10);
+}

--- a/src/test/compile-fail/mod_file_disambig_aux.rs
+++ b/src/test/compile-fail/mod_file_disambig_aux.rs
@@ -8,8 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
-
-fn main() {
-    assert_eq!(mod_file_aux::bar(), 10);
-}
+// xfail-test not a test. aux file

--- a/src/test/compile-fail/mod_file_disambig_aux/mod.rs
+++ b/src/test/compile-fail/mod_file_disambig_aux/mod.rs
@@ -8,8 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
-
-fn main() {
-    assert_eq!(mod_file_aux::bar(), 10);
-}
+// xfail-test not a test. aux file

--- a/src/test/run-pass/mod_dir_implicit.rs
+++ b/src/test/run-pass/mod_dir_implicit.rs
@@ -8,8 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
+// xfail-pretty
+// xfail-fast
 
-fn main() {
-    assert_eq!(mod_file_aux::bar(), 10);
+mod mod_dir_implicit_aux;
+
+pub fn main() {
+    assert_eq!(mod_dir_implicit_aux::foo(), 10);
 }

--- a/src/test/run-pass/mod_dir_implicit_aux/mod.rs
+++ b/src/test/run-pass/mod_dir_implicit_aux/mod.rs
@@ -8,8 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
-
-fn main() {
-    assert_eq!(mod_file_aux::bar(), 10);
-}
+pub fn foo() -> int { 10 }


### PR DESCRIPTION
When loading a module the parser will look for either foo.rs or foo/mod.rs and generate
an error when both are found.
