### PR TITLE
DList update

### DIFF
--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -23,7 +23,6 @@
 // the reverse direction.
 
 use std::cast;
-use std::cmp;
 use std::ptr;
 use std::util;
 use std::iterator::{FromIterator, InvertIterator};
@@ -396,13 +395,13 @@ impl<T> DList<T> {
     }
 }
 
-impl<T: cmp::TotalOrd> DList<T> {
+impl<T: Ord> DList<T> {
     /// Insert `elt` sorted in ascending order
     ///
     /// O(N)
     #[inline]
     pub fn insert_ordered(&mut self, elt: T) {
-        self.insert_when(elt, |a, b| a.cmp(b) != cmp::Less);
+        self.insert_when(elt, |a, b| a >= b)
     }
 }
 

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -258,6 +258,26 @@ impl<T> DList<T> {
         DList{list_head: None, list_tail: Rawlink::none(), length: 0}
     }
 
+    /// Move the last element to the front of the list.
+    ///
+    /// If the list is empty, do nothing.
+    #[inline]
+    pub fn rotate_to_front(&mut self) {
+        do self.pop_back_node().map_consume |tail| {
+            self.push_front_node(tail)
+        };
+    }
+
+    /// Move the first element to the back of the list.
+    ///
+    /// If the list is empty, do nothing.
+    #[inline]
+    pub fn rotate_to_back(&mut self) {
+        do self.pop_front_node().map_consume |head| {
+            self.push_back_node(head)
+        };
+    }
+
     /// Add all elements from `other` to the end of the list
     ///
     /// O(1)
@@ -686,6 +706,29 @@ mod tests {
         for sum.consume_iter().advance |elt| {
             assert_eq!(m.pop_front(), Some(elt))
         }
+    }
+
+    #[test]
+    fn test_rotate() {
+        let mut n = DList::new::<int>();
+        n.rotate_to_back(); check_links(&n);
+        assert_eq!(n.len(), 0);
+        n.rotate_to_front(); check_links(&n);
+        assert_eq!(n.len(), 0);
+
+        let v = ~[1,2,3,4,5];
+        let mut m = list_from(v);
+        m.rotate_to_back(); check_links(&m);
+        m.rotate_to_front(); check_links(&m);
+        assert_eq!(v.iter().collect::<~[&int]>(), m.iter().collect());
+        m.rotate_to_front(); check_links(&m);
+        m.rotate_to_front(); check_links(&m);
+        m.pop_front(); check_links(&m);
+        m.rotate_to_front(); check_links(&m);
+        m.rotate_to_back(); check_links(&m);
+        m.push_front(9); check_links(&m);
+        m.rotate_to_front(); check_links(&m);
+        assert_eq!(~[3,9,5,1,2], m.consume_iter().collect());
     }
 
     #[test]

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -185,12 +185,12 @@ impl<T> DList<T> {
     /// Remove the last Node and return it, or None if the list is empty
     #[inline]
     fn pop_back_node(&mut self) -> Option<~Node<T>> {
-        do self.list_tail.resolve().map_consume |tail| {
+        do self.list_tail.resolve().map_consume_default(None) |tail| {
             self.length -= 1;
             self.list_tail = tail.prev;
             match tail.prev.resolve() {
-                None => self.list_head.take_unwrap(),
-                Some(tail_prev) => tail_prev.next.take_unwrap()
+                None => self.list_head.take(),
+                Some(tail_prev) => tail_prev.next.take()
             }
         }
     }

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -1039,6 +1039,25 @@ mod tests {
         }
     }
 
+    #[bench]
+    fn bench_rotate_to_front(b: &mut test::BenchHarness) {
+        let mut m = DList::new::<int>();
+        m.push_front(0);
+        m.push_front(1);
+        do b.iter {
+            m.rotate_to_front();
+        }
+    }
+
+    #[bench]
+    fn bench_rotate_to_back(b: &mut test::BenchHarness) {
+        let mut m = DList::new::<int>();
+        m.push_front(0);
+        m.push_front(1);
+        do b.iter {
+            m.rotate_to_back();
+        }
+    }
 
     #[bench]
     fn bench_iter(b: &mut test::BenchHarness) {

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -975,27 +975,12 @@ mod tests {
             let _: DList<int> = v.iter().transform(|x| *x).collect();
         }
     }
-    #[bench]
-    fn bench_collect_into_vec(b: &mut test::BenchHarness) {
-        let v = &[0, ..64];
-        do b.iter {
-            let _: ~[int] = v.iter().transform(|&x|x).collect();
-        }
-    }
 
     #[bench]
     fn bench_push_front(b: &mut test::BenchHarness) {
         let mut m = DList::new::<int>();
         do b.iter {
             m.push_front(0);
-        }
-    }
-    #[bench]
-    fn bench_push_front_vec_size10(b: &mut test::BenchHarness) {
-        let mut m = ~[0, ..10];
-        do b.iter {
-            m.unshift(0);
-            m.pop(); // to keep it fair, dont' grow the vec
         }
     }
 
@@ -1006,27 +991,13 @@ mod tests {
             m.push_back(0);
         }
     }
-    #[bench]
-    fn bench_push_back_vec(b: &mut test::BenchHarness) {
-        let mut m = ~[];
-        do b.iter {
-            m.push(0);
-        }
-    }
+
     #[bench]
     fn bench_push_back_pop_back(b: &mut test::BenchHarness) {
         let mut m = DList::new::<int>();
         do b.iter {
             m.push_back(0);
             m.pop_back();
-        }
-    }
-    #[bench]
-    fn bench_push_back_pop_back_vec(b: &mut test::BenchHarness) {
-        let mut m = ~[];
-        do b.iter {
-            m.push(0);
-            m.pop();
         }
     }
 
@@ -1089,13 +1060,6 @@ mod tests {
         let mut m: DList<int> = v.iter().transform(|&x|x).collect();
         do b.iter {
             assert!(m.mut_rev_iter().len_() == 128);
-        }
-    }
-    #[bench]
-    fn bench_iter_vec(b: &mut test::BenchHarness) {
-        let v = &[0, ..128];
-        do b.iter {
-            for v.iter().advance |_| {}
         }
     }
 }

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -261,7 +261,7 @@ impl<T> DList<T> {
     ///
     /// If the list is empty, do nothing.
     #[inline]
-    pub fn rotate_to_front(&mut self) {
+    pub fn rotate_forward(&mut self) {
         do self.pop_back_node().map_consume |tail| {
             self.push_front_node(tail)
         };
@@ -271,7 +271,7 @@ impl<T> DList<T> {
     ///
     /// If the list is empty, do nothing.
     #[inline]
-    pub fn rotate_to_back(&mut self) {
+    pub fn rotate_backward(&mut self) {
         do self.pop_front_node().map_consume |head| {
             self.push_back_node(head)
         };
@@ -715,23 +715,23 @@ mod tests {
     #[test]
     fn test_rotate() {
         let mut n = DList::new::<int>();
-        n.rotate_to_back(); check_links(&n);
+        n.rotate_backward(); check_links(&n);
         assert_eq!(n.len(), 0);
-        n.rotate_to_front(); check_links(&n);
+        n.rotate_forward(); check_links(&n);
         assert_eq!(n.len(), 0);
 
         let v = ~[1,2,3,4,5];
         let mut m = list_from(v);
-        m.rotate_to_back(); check_links(&m);
-        m.rotate_to_front(); check_links(&m);
+        m.rotate_backward(); check_links(&m);
+        m.rotate_forward(); check_links(&m);
         assert_eq!(v.iter().collect::<~[&int]>(), m.iter().collect());
-        m.rotate_to_front(); check_links(&m);
-        m.rotate_to_front(); check_links(&m);
+        m.rotate_forward(); check_links(&m);
+        m.rotate_forward(); check_links(&m);
         m.pop_front(); check_links(&m);
-        m.rotate_to_front(); check_links(&m);
-        m.rotate_to_back(); check_links(&m);
+        m.rotate_forward(); check_links(&m);
+        m.rotate_backward(); check_links(&m);
         m.push_front(9); check_links(&m);
-        m.rotate_to_front(); check_links(&m);
+        m.rotate_forward(); check_links(&m);
         assert_eq!(~[3,9,5,1,2], m.consume_iter().collect());
     }
 
@@ -1015,22 +1015,22 @@ mod tests {
     }
 
     #[bench]
-    fn bench_rotate_to_front(b: &mut test::BenchHarness) {
+    fn bench_rotate_forward(b: &mut test::BenchHarness) {
         let mut m = DList::new::<int>();
         m.push_front(0);
         m.push_front(1);
         do b.iter {
-            m.rotate_to_front();
+            m.rotate_forward();
         }
     }
 
     #[bench]
-    fn bench_rotate_to_back(b: &mut test::BenchHarness) {
+    fn bench_rotate_backward(b: &mut test::BenchHarness) {
         let mut m = DList::new::<int>();
         m.push_front(0);
         m.push_front(1);
         do b.iter {
-            m.rotate_to_back();
+            m.rotate_backward();
         }
     }
 

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -477,7 +477,9 @@ impl<'self, A> DoubleEndedIterator<&'self mut A> for MutDListIterator<'self, A> 
 
 /// Allow mutating the DList while iterating
 pub trait ListInsertion<A> {
-    /// Insert `elt` just after to the most recently yielded element
+    /// Insert `elt` just after to the element most recently returned by `.next()`
+    ///
+    /// The inserted element does not appear in the iteration.
     fn insert_next(&mut self, elt: A);
 
     /// Provide a reference to the next element, without changing the iterator
@@ -515,6 +517,9 @@ impl<'self, A> ListInsertion<A> for MutDListIterator<'self, A> {
 
     #[inline]
     fn peek_next<'a>(&'a mut self) -> Option<&'a mut A> {
+        if self.nelem == 0 {
+            return None
+        }
         self.head.resolve().map_consume(|head| &mut head.value)
     }
 }

--- a/src/libextra/serialize.rs
+++ b/src/libextra/serialize.rs
@@ -662,6 +662,19 @@ impl<
     }
 }
 
+impl<
+    S: Encoder,
+    T: Encodable<S>
+> Encodable<S> for DList<T> {
+    fn encode(&self, s: &mut S) {
+        do s.emit_seq(self.len()) |s| {
+            for self.iter().enumerate().advance |(i, e)| {
+                s.emit_seq_elt(i, |s| e.encode(s));
+            }
+        }
+    }
+}
+
 impl<D:Decoder,T:Decodable<D>> Decodable<D> for DList<T> {
     fn decode(d: &mut D) -> DList<T> {
         let mut list = DList::new();


### PR DESCRIPTION
Factor out internal methods to pop/push list nodes so that .merge() and .rotate_to_front(), .rotate_to_back() (new methods) can be implemented without allocating nodes.

With that, some cleanup changes to DList use of Option, and adding a missing Encodable implementation.
