### PR TITLE
Add link_section attribute for static and fn items

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2456,7 +2456,7 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::node_id) -> ValueRef {
         let val = match item {
           ast_map::node_item(i, pth) => {
             let my_path = vec::append((*pth).clone(), [path_name(i.ident)]);
-            match i.node {
+            let v = match i.node {
               ast::item_static(_, m, expr) => {
                 let typ = ty::node_id_to_type(ccx.tcx, i.id);
                 let s = mangle_exported_name(ccx, my_path, typ);
@@ -2488,7 +2488,16 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::node_id) -> ValueRef {
                 llfn
               }
               _ => fail!("get_item_val: weird result in table")
+            };
+            match (attr::first_attr_value_str_by_name(i.attrs, "link_section")) {
+                Some(sect) => unsafe {
+                    do sect.as_c_str |buf| {
+                        llvm::LLVMSetSection(v, buf);
+                    }
+                },
+                None => ()
             }
+            v
           }
           ast_map::node_trait_method(trait_method, _, pth) => {
             debug!("get_item_val(): processing a node_trait_method");

--- a/src/test/run-pass/link-section.rs
+++ b/src/test/run-pass/link-section.rs
@@ -1,0 +1,34 @@
+#[cfg(not(target_os = "macos"))]
+#[link_section=".moretext"]
+fn i_live_in_more_text() -> &'static str {
+    "knock knock"
+}
+
+#[cfg(not(target_os = "macos"))]
+#[link_section=".imm"]
+static magic: uint = 42;
+
+#[cfg(not(target_os = "macos"))]
+#[link_section=".mut"]
+static mut frobulator: uint = 0xdeadbeef;
+
+#[cfg(target_os = "macos")]
+#[link_section="__TEXT,__moretext"]
+fn i_live_in_more_text() -> &'static str {
+    "knock knock"
+}
+
+#[cfg(target_os = "macos")]
+#[link_section="__RODATA,__imm"]
+static magic: uint = 42;
+
+#[cfg(target_os = "macos")]
+#[link_section="__DATA,__mut"]
+static mut frobulator: uint = 0xdeadbeef;
+
+fn main() {
+    unsafe {
+        frobulator = 0xcafebabe;
+        printfln!("%? %? %?", i_live_in_more_text(), magic, frobulator);
+    }
+}


### PR DESCRIPTION
This allows for control over the section placement of static, static
mut, and fn items.  One caveat is that if a static and a static mut are
placed in the same section, the static is declared first, and the static
mut is assigned to, the generated program crashes.  For example:
# [link_section=".boot"]

static foo : uint = 0xdeadbeef;
# [link_section=".boot"]

static mut bar : uint = 0xcafebabe;

Declaring bar first would mark .bootdata as writable, preventing the
crash when bar is written to.
