### PR TITLE
Adding support for regions in unsafe pointers 

### DIFF
--- a/doc/tutorial-ffi.md
+++ b/doc/tutorial-ffi.md
@@ -156,13 +156,13 @@ use std::unstable::intrinsics;
 
 // a wrapper around the handle returned by the foreign code
 pub struct Unique<T> {
-    priv ptr: *mut T
+    priv ptr: *'static mut T
 }
 
 impl<T: Send> Unique<T> {
     pub fn new(value: T) -> Unique<T> {
         unsafe {
-            let ptr = malloc(std::sys::size_of::<T>() as size_t) as *mut T;
+            let ptr = malloc(std::sys::size_of::<T>() as size_t) as *'static mut T;
             assert!(!ptr::is_null(ptr));
             // `*ptr` is uninitialized, and `*ptr = value` would attempt to destroy it
             intrinsics::move_val_init(&mut *ptr, value);

--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -272,7 +272,7 @@ fn check_poison(is_mutex: bool, failed: bool) {
 
 #[doc(hidden)]
 struct PoisonOnFail {
-    failed: *mut bool,
+    failed: *'static mut bool,
 }
 
 impl Drop for PoisonOnFail {

--- a/src/libextra/c_vec.rs
+++ b/src/libextra/c_vec.rs
@@ -45,7 +45,7 @@ use std::ptr;
  *
  */
 pub struct CVec<T> {
-    priv base: *mut T,
+    priv base: *'static mut T,
     priv len: uint,
     priv rsrc: @DtorRes
 }
@@ -82,12 +82,12 @@ fn DtorRes(dtor: Option<@fn()>) -> DtorRes {
  * * base - A foreign pointer to a buffer
  * * len - The number of elements in the buffer
  */
-pub unsafe fn CVec<T>(base: *mut T, len: uint) -> CVec<T> {
-    return CVec{
+pub unsafe fn CVec<T>(base: *'static mut T, len: uint) -> CVec<T> {
+    CVec {
         base: base,
         len: len,
         rsrc: @DtorRes(option::None)
-    };
+    }
 }
 
 /**
@@ -101,13 +101,12 @@ pub unsafe fn CVec<T>(base: *mut T, len: uint) -> CVec<T> {
  * * dtor - A function to run when the value is destructed, useful
  *          for freeing the buffer, etc.
  */
-pub unsafe fn c_vec_with_dtor<T>(base: *mut T, len: uint, dtor: @fn())
-  -> CVec<T> {
-    return CVec{
+pub unsafe fn c_vec_with_dtor<T>(base: *'static mut T, len: uint, dtor: @fn()) -> CVec<T> {
+    CVec {
         base: base,
         len: len,
         rsrc: @DtorRes(option::Some(dtor))
-    };
+    }
 }
 
 /*

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -38,7 +38,7 @@ pub struct DList<T> {
 }
 
 type Link<T> = Option<~Node<T>>;
-struct Rawlink<T> { priv p: *mut T }
+struct Rawlink<T> { priv p: *'static mut T }
 
 struct Node<T> {
     priv next: Link<T>,

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -77,7 +77,11 @@ impl<T> Rawlink<T> {
 
     /// Like Option::Some for Rawlink
     fn some(n: &mut T) -> Rawlink<T> {
-        Rawlink{p: ptr::to_mut_unsafe_ptr(n)}
+        unsafe {
+            Rawlink {
+                p: cast::transmute(ptr::to_mut_unsafe_ptr(n))
+            }
+        }
     }
 
     /// Convert the `Rawlink` into an Option value

--- a/src/libextra/future.rs
+++ b/src/libextra/future.rs
@@ -194,7 +194,7 @@ mod test {
 
     #[test]
     fn test_interface_unwrap() {
-        let mut f = from_value(~"fail");
+        let f = from_value(~"fail");
         assert_eq!(f.unwrap(), ~"fail");
     }
 

--- a/src/libextra/rc.rs
+++ b/src/libextra/rc.rs
@@ -37,7 +37,7 @@ struct RcBox<T> {
 #[unsafe_no_drop_flag]
 #[no_send]
 pub struct Rc<T> {
-    priv ptr: *mut RcBox<T>,
+    priv ptr: *'static mut RcBox<T>,
 }
 
 impl<T> Rc<T> {
@@ -170,7 +170,7 @@ struct RcMutBox<T> {
 #[no_freeze]
 #[unsafe_no_drop_flag]
 pub struct RcMut<T> {
-    priv ptr: *mut RcMutBox<T>,
+    priv ptr: *'static mut RcMutBox<T>,
 }
 
 impl<T> RcMut<T> {

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -194,41 +194,41 @@ pub enum AsmDialect {
 
 // Opaque pointer types
 pub enum Module_opaque {}
-pub type ModuleRef = *Module_opaque;
+pub type ModuleRef = *'static Module_opaque;
 pub enum Context_opaque {}
-pub type ContextRef = *Context_opaque;
+pub type ContextRef = *'static Context_opaque;
 pub enum Type_opaque {}
-pub type TypeRef = *Type_opaque;
+pub type TypeRef = *'static Type_opaque;
 pub enum Value_opaque {}
-pub type ValueRef = *Value_opaque;
+pub type ValueRef = *'static Value_opaque;
 pub enum BasicBlock_opaque {}
-pub type BasicBlockRef = *BasicBlock_opaque;
+pub type BasicBlockRef = *'static BasicBlock_opaque;
 pub enum Builder_opaque {}
-pub type BuilderRef = *Builder_opaque;
+pub type BuilderRef = *'static Builder_opaque;
 pub enum ExecutionEngine_opaque {}
-pub type ExecutionEngineRef = *ExecutionEngine_opaque;
+pub type ExecutionEngineRef = *'static ExecutionEngine_opaque;
 pub enum MemoryBuffer_opaque {}
-pub type MemoryBufferRef = *MemoryBuffer_opaque;
+pub type MemoryBufferRef = *'static MemoryBuffer_opaque;
 pub enum PassManager_opaque {}
-pub type PassManagerRef = *PassManager_opaque;
+pub type PassManagerRef = *'static PassManager_opaque;
 pub enum PassManagerBuilder_opaque {}
-pub type PassManagerBuilderRef = *PassManagerBuilder_opaque;
+pub type PassManagerBuilderRef = *'static PassManagerBuilder_opaque;
 pub enum Use_opaque {}
-pub type UseRef = *Use_opaque;
+pub type UseRef = *'static Use_opaque;
 pub enum TargetData_opaque {}
-pub type TargetDataRef = *TargetData_opaque;
+pub type TargetDataRef = *'static TargetData_opaque;
 pub enum ObjectFile_opaque {}
-pub type ObjectFileRef = *ObjectFile_opaque;
+pub type ObjectFileRef = *'static ObjectFile_opaque;
 pub enum SectionIterator_opaque {}
-pub type SectionIteratorRef = *SectionIterator_opaque;
+pub type SectionIteratorRef = *'static SectionIterator_opaque;
 pub enum Pass_opaque {}
-pub type PassRef = *Pass_opaque;
+pub type PassRef = *'static Pass_opaque;
 
 pub mod debuginfo {
     use super::{ValueRef};
 
     pub enum DIBuilder_opaque {}
-    pub type DIBuilderRef = *DIBuilder_opaque;
+    pub type DIBuilderRef = *'static DIBuilder_opaque;
 
     pub type DIDescriptor = ValueRef;
     pub type DIScope = DIDescriptor;

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -326,7 +326,11 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
       }
       '@' => return ty::mk_box(st.tcx, parse_mt(st, conv)),
       '~' => return ty::mk_uniq(st.tcx, parse_mt(st, conv)),
-      '*' => return ty::mk_ptr(st.tcx, parse_mt(st, conv)),
+      '*' => {
+        let r = parse_region(st);
+        let mt = parse_mt(st, conv);
+        return ty::mk_ptr(st.tcx, r, mt);
+      }
       '&' => {
         let r = parse_region(st);
         let mt = parse_mt(st, conv);

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -278,7 +278,11 @@ fn enc_sty(w: @io::Writer, cx: @ctxt, st: &ty::sty) {
       }
       ty::ty_box(mt) => { w.write_char('@'); enc_mt(w, cx, mt); }
       ty::ty_uniq(mt) => { w.write_char('~'); enc_mt(w, cx, mt); }
-      ty::ty_ptr(mt) => { w.write_char('*'); enc_mt(w, cx, mt); }
+      ty::ty_ptr(r, mt) => {
+        w.write_char('*');
+        enc_region(w, cx, r);
+        enc_mt(w, cx, mt);
+      }
       ty::ty_rptr(r, mt) => {
         w.write_char('&');
         enc_region(w, cx, r);

--- a/src/librustc/middle/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc/middle/borrowck/gather_loans/lifetime.rs
@@ -74,7 +74,7 @@ impl GuaranteeLifetimeContext {
             mc::cat_arg(*) |                           // L-Local
             mc::cat_self(*) |                          // L-Local
             mc::cat_deref(_, _, mc::region_ptr(*)) |   // L-Deref-Borrowed
-            mc::cat_deref(_, _, mc::unsafe_ptr) => {
+            mc::cat_deref(_, _, mc::unsafe_ptr(*)) => {
                 let scope = self.scope(cmt);
                 self.check_scope(scope)
             }

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -357,7 +357,7 @@ impl GatherLoanCtxt {
                                              m_imm,
                                              r)
                     }
-                    ty::AutoUnsafe(_) => {}
+                    ty::AutoUnsafe(*) => {}
                 }
             }
         }

--- a/src/librustc/middle/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc/middle/borrowck/gather_loans/restrictions.rs
@@ -194,7 +194,7 @@ impl RestrictionsContext {
                 }
             }
 
-            mc::cat_deref(_, _, mc::unsafe_ptr) => {
+            mc::cat_deref(_, _, mc::unsafe_ptr(*)) => {
                 // We are very trusting when working with unsafe pointers.
                 Safe
             }

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -133,7 +133,7 @@ pub fn check_crate(tcx: ty::ctxt,
                     debug!("effect: unary case, base type is %s",
                            ppaux::ty_to_str(tcx, base_type));
                     match ty::get(base_type).sty {
-                        ty_ptr(_) => {
+                        ty_ptr(*) => {
                             require_unsafe(expr.span,
                                            "dereference of unsafe pointer")
                         }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -725,7 +725,9 @@ fn check_item_ctypes(cx: &Context, it: &ast::item) {
                     _ => ()
                 }
             }
-            ast::ty_ptr(ref mt) => { check_ty(cx, mt.ty) }
+            ast::ty_ptr(_, ref mt) => {
+                check_ty(cx, mt.ty)
+            }
             _ => ()
         }
     }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -88,7 +88,7 @@ pub enum ptr_kind {
     uniq_ptr(ast::mutability),
     gc_ptr(ast::mutability),
     region_ptr(ast::mutability, ty::Region),
-    unsafe_ptr
+    unsafe_ptr(ty::Region),
 }
 
 // We use the term "interior" to mean "something reachable from the
@@ -188,8 +188,8 @@ pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
             Some(deref_ptr(gc_ptr(ast::m_imm)))
         }
 
-        ty::ty_ptr(*) => {
-            Some(deref_ptr(unsafe_ptr))
+        ty::ty_ptr(r, _) => {
+            Some(deref_ptr(unsafe_ptr(r)))
         }
 
         ty::ty_enum(*) |
@@ -678,7 +678,7 @@ impl mem_categorization_ctxt {
                     uniq_ptr(*) => {
                         self.inherited_mutability(base_cmt.mutbl, mt.mutbl)
                     }
-                    gc_ptr(*) | region_ptr(_, _) | unsafe_ptr => {
+                    gc_ptr(*) | region_ptr(*) | unsafe_ptr(*) => {
                         MutabilityCategory::from_mutbl(mt.mutbl)
                     }
                 };
@@ -759,7 +759,7 @@ impl mem_categorization_ctxt {
               uniq_ptr(*) => {
                 self.inherited_mutability(base_cmt.mutbl, mt.mutbl)
               }
-              gc_ptr(_) | region_ptr(_, _) | unsafe_ptr => {
+              gc_ptr(_) | region_ptr(*) | unsafe_ptr(*) => {
                 MutabilityCategory::from_mutbl(mt.mutbl)
               }
             };
@@ -1232,7 +1232,7 @@ pub fn ptr_sigil(ptr: ptr_kind) -> ~str {
         uniq_ptr(_) => ~"~",
         gc_ptr(_) => ~"@",
         region_ptr(_, _) => ~"&",
-        unsafe_ptr => ~"*"
+        unsafe_ptr(*) => ~"*"
     }
 }
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -748,6 +748,16 @@ fn determine_rp_in_ty(ty: &ast::Ty,
     // locations)
     let sess = cx.sess;
     match ty.node {
+        ast::ty_ptr(ref r, _) => {
+            debug!("referenced ptr type %s",
+                   pprust::ty_to_str(ty, sess.intr()));
+
+            if cx.region_is_relevant(r) {
+                let rv = cx.add_variance(rv_contravariant);
+                cx.add_rp(cx.item_id, rv)
+            }
+        }
+
         ast::ty_rptr(ref r, _) => {
             debug!("referenced rptr type %s",
                    pprust::ty_to_str(ty, sess.intr()));

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -817,7 +817,7 @@ fn determine_rp_in_ty(ty: &ast::Ty,
 
     match ty.node {
       ast::ty_box(ref mt) | ast::ty_uniq(ref mt) | ast::ty_vec(ref mt) |
-      ast::ty_rptr(_, ref mt) | ast::ty_ptr(ref mt) => {
+      ast::ty_rptr(_, ref mt) | ast::ty_ptr(_, ref mt) => {
         visit_mt(mt, (cx, visitor));
       }
 

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1279,8 +1279,6 @@ pub fn compile_submatch(bcx: block,
     assert!((m.len() > 0u || chk.is_some()));
     let _icx = push_ctxt("match::compile_submatch");
     let mut bcx = bcx;
-    let tcx = bcx.tcx();
-    let dm = tcx.def_map;
     if m.len() == 0u {
         Br(bcx, chk.get()());
         return;

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -572,7 +572,7 @@ pub fn compare_scalar_types(cx: block,
 
     match ty::get(t).sty {
         ty::ty_nil => rslt(cx, f(nil_type)),
-        ty::ty_bool | ty::ty_ptr(_) => rslt(cx, f(unsigned_int)),
+        ty::ty_bool | ty::ty_ptr(*) => rslt(cx, f(unsigned_int)),
         ty::ty_int(_) => rslt(cx, f(signed_int)),
         ty::ty_uint(_) => rslt(cx, f(unsigned_int)),
         ty::ty_float(_) => rslt(cx, f(floating_point)),

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -148,7 +148,9 @@ pub fn mk_closure_tys(tcx: ty::ctxt,
     let bound_tys = bound_values.map(|bv| {
         match bv.action {
             EnvCopy | EnvMove => bv.datum.ty,
-            EnvRef => ty::mk_mut_ptr(tcx, bv.datum.ty)
+            EnvRef => ty::mk_mut_ptr(tcx,
+                                     ty::re_static,
+                                     bv.datum.ty)
         }
     });
     let cdata_ty = ty::mk_tup(tcx, bound_tys);
@@ -210,7 +212,9 @@ pub fn store_environment(bcx: block,
     // tuple.  This could be a ptr in uniq or a box or on stack,
     // whatever.
     let cbox_ty = tuplify_box_ty(tcx, cdata_ty);
-    let cboxptr_ty = ty::mk_ptr(tcx, ty::mt {ty:cbox_ty, mutbl:ast::m_imm});
+    let cboxptr_ty = ty::mk_ptr(tcx,
+                                ty::re_static,
+                                ty::mt {ty:cbox_ty, mutbl:ast::m_imm});
     let llboxptr_ty = type_of(ccx, cboxptr_ty);
 
     // If there are no bound values, no point in allocating anything.

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -683,6 +683,7 @@ impl block_ {
 pub fn tuplify_box_ty(tcx: ty::ctxt, t: ty::t) -> ty::t {
     let ptr = ty::mk_ptr(
         tcx,
+        ty::re_static,
         ty::mt {ty: ty::mk_i8(), mutbl: ast::m_imm}
     );
     return ty::mk_tup(tcx, ~[ty::mk_uint(), ty::mk_type(tcx),

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -205,7 +205,7 @@ pub fn const_expr(cx: @mut CrateContext, e: @ast::expr) -> ValueRef {
                         None => const_addr_of(cx, llconst)
                     };
                     match *autoref {
-                        ty::AutoUnsafe(m) |
+                        ty::AutoUnsafe(_, m) |
                         ty::AutoPtr(ty::re_static, m) => {
                             assert!(m != ast::m_mutbl);
                             llconst = llptr;

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -631,7 +631,7 @@ impl Datum {
             ty::ty_box(_) | ty::ty_uniq(_) => {
                 return (Some(self.box_body(bcx)), bcx);
             }
-            ty::ty_ptr(mt) => {
+            ty::ty_ptr(_, mt) => {
                 if is_auto { // unsafe ptrs are not AUTO-derefable
                     return (None, bcx);
                 } else {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -850,7 +850,7 @@ fn boxed_type_metadata(cx: &mut CrateContext,
     assert!(box_layout_is_correct(cx, member_llvm_types, content_llvm_type));
 
     let int_type = ty::mk_int();
-    let nil_pointer_type = ty::mk_nil_ptr(cx.tcx);
+    let nil_pointer_type = ty::mk_nil_ptr(cx.tcx, ty::re_static);
 
     let member_types_metadata = [
         type_metadata(cx, int_type, span),
@@ -983,7 +983,9 @@ fn vec_slice_metadata(cx: &mut CrateContext,
 
     assert!(slice_layout_is_correct(cx, member_llvm_types, element_type));
 
-    let data_ptr_type = ty::mk_ptr(cx.tcx, ty::mt { ty: element_type, mutbl: ast::m_imm });
+    let data_ptr_type = ty::mk_ptr(cx.tcx,
+                                   ty::re_static,
+                                   ty::mt { ty: element_type, mutbl: ast::m_imm });
 
     let member_type_metadata = &[type_metadata(cx, data_ptr_type, span),
                                  type_metadata(cx, ty::mk_uint(), span)];
@@ -1019,7 +1021,9 @@ fn bare_fn_metadata(cx: &mut CrateContext,
     let loc = span_start(cx, span);
     let file_metadata = file_metadata(cx, loc.file.name);
 
-    let nil_pointer_type_metadata = type_metadata(cx, ty::mk_nil_ptr(cx.tcx), span);
+    let nil_pointer_type_metadata = type_metadata(cx,
+                                                  ty::mk_nil_ptr(cx.tcx, ty::re_static),
+                                                  span);
     let output_metadata = type_metadata(cx, output, span);
     let output_ptr_metadata = pointer_type_metadata(cx, output, output_metadata);
 
@@ -1146,8 +1150,8 @@ fn type_metadata(cx: &mut CrateContext,
         ty::ty_uniq(ref mt) if ty::type_contents(cx.tcx, mt.ty).contains_managed() => {
             create_pointer_to_box_metadata(cx, t, mt.ty)
         },
-        ty::ty_uniq(ref mt)    |
-        ty::ty_ptr(ref mt)     |
+        ty::ty_uniq(ref mt) |
+        ty::ty_ptr(_, ref mt) |
         ty::ty_rptr(_, ref mt) => {
             let pointee = type_metadata(cx, mt.ty, span);
             pointer_type_metadata(cx, t, pointee)

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -784,6 +784,7 @@ fn trans_def_datum_unadjusted(bcx: block,
         let (rust_ty, llval) = if is_extern {
             let rust_ty = ty::mk_ptr(
                 bcx.tcx(),
+                ty::re_static,
                 ty::mt {
                     ty: ty::mk_mach_uint(ast::ty_u8),
                     mutbl: ast::m_imm

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -844,6 +844,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
             let frameaddress_val = Call(bcx, frameaddress, [C_i32(0i32)]);
             let star_u8 = ty::mk_imm_ptr(
                 bcx.tcx(),
+                ty::re_static,
                 ty::mk_mach_uint(ast::ty_u8));
             let fty = ty::mk_closure(bcx.tcx(), ty::ClosureTy {
                 purity: ast::impure_fn,

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -844,7 +844,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
             let frameaddress_val = Call(bcx, frameaddress, [C_i32(0i32)]);
             let star_u8 = ty::mk_imm_ptr(
                 bcx.tcx(),
-                ty::re_static,
+                ty::re_bound(ty::br_anon(0)),
                 ty::mk_mach_uint(ast::ty_u8));
             let fty = ty::mk_closure(bcx.tcx(), ty::ClosureTy {
                 purity: ast::impure_fn,

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -335,7 +335,7 @@ pub fn normalize_for_monomorphization(tcx: ty::ctxt,
             // Traits have the same runtime representation as closures.
             Some(normalized_closure_ty(tcx, sigil))
         }
-        ty::ty_ptr(_) => {
+        ty::ty_ptr(*) => {
             Some(ty::mk_uint())
         }
         _ => {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -281,7 +281,7 @@ impl Reflector {
             let llptrty = type_of(ccx, t).ptr_to();
             let opaquety = ty::get_opaque_ty(ccx.tcx).unwrap();
             let opaqueptrty = ty::mk_ptr(ccx.tcx,
-                                         ty::re_static,
+                                         ty::re_bound(ty::br_anon(0)),
                                          ty::mt { ty: opaquety, mutbl: ast::m_imm });
 
             let make_get_disr = || {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -201,7 +201,7 @@ impl Reflector {
                   self.visit("uniq", extra)
               }
           }
-          ty::ty_ptr(ref mt) => {
+          ty::ty_ptr(_, ref mt) => {
               let extra = self.c_mt(mt);
               self.visit("ptr", extra)
           }
@@ -280,7 +280,9 @@ impl Reflector {
             let variants = ty::substd_enum_variants(ccx.tcx, did, substs);
             let llptrty = type_of(ccx, t).ptr_to();
             let opaquety = ty::get_opaque_ty(ccx.tcx).unwrap();
-            let opaqueptrty = ty::mk_ptr(ccx.tcx, ty::mt { ty: opaquety, mutbl: ast::m_imm });
+            let opaqueptrty = ty::mk_ptr(ccx.tcx,
+                                         ty::re_static,
+                                         ty::mt { ty: opaquety, mutbl: ast::m_imm });
 
             let make_get_disr = || {
                 let sub_path = bcx.fcx.path + &[path_name(special_idents::anon)];

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -227,7 +227,7 @@ pub fn type_of(cx: &mut CrateContext, t: ty::t) -> Type {
           let ty = type_of(cx, mt.ty);
           Type::vec(cx.sess.targ_cfg.arch, &ty)
       }
-      ty::ty_ptr(ref mt) => type_of(cx, mt.ty).ptr_to(),
+      ty::ty_ptr(_, ref mt) => type_of(cx, mt.ty).ptr_to(),
       ty::ty_rptr(_, ref mt) => type_of(cx, mt.ty).ptr_to(),
 
       ty::ty_evec(ref mt, ty::vstore_slice(_)) => {

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -233,8 +233,8 @@ pub fn type_needs_inner(cx: &Context,
                  */
                 ty::ty_closure(*) |
                 ty::ty_bare_fn(*) |
-                ty::ty_ptr(_) |
-                ty::ty_rptr(_, _) |
+                ty::ty_ptr(*) |
+                ty::ty_rptr(*) |
                 ty::ty_trait(*) => false,
 
               ty::ty_enum(did, ref substs) => {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -158,7 +158,7 @@ pub struct creader_cache_key {
 type creader_cache = @mut HashMap<creader_cache_key, t>;
 
 struct intern_key {
-    sty: *sty,
+    sty: *'static sty,
 }
 
 // NB: Do not replace this with #[deriving(Eq)]. The automatically-derived
@@ -346,7 +346,7 @@ pub struct t_box_ {
 // ~15%.) This does mean that a t value relies on the ctxt to keep its box
 // alive, and using ty::get is unsafe when the ctxt is no longer alive.
 enum t_opaque {}
-pub type t = *t_opaque;
+pub type t = *'static t_opaque;
 
 pub fn get(t: t) -> t_box {
     unsafe {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -930,7 +930,9 @@ fn mk_t(cx: ctxt, st: sty) -> t {
         _ => {}
     };
 
-    let key = intern_key { sty: to_unsafe_ptr(&st) };
+    let key = intern_key {
+        sty: unsafe { cast::transmute(to_unsafe_ptr(&st)) }
+    };
     match cx.interner.find(&key) {
       Some(t) => unsafe { return cast::transmute(&t.sty); },
       _ => ()
@@ -1008,7 +1010,7 @@ fn mk_t(cx: ctxt, st: sty) -> t {
         flags: flags,
     };
 
-    let sty_ptr = to_unsafe_ptr(&t.sty);
+    let sty_ptr = unsafe { cast::transmute(to_unsafe_ptr(&t.sty)) };
 
     let key = intern_key {
         sty: sty_ptr,

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -226,7 +226,7 @@ pub enum AutoRef {
     AutoBorrowFn(Region),
 
     /// Convert from T to *T
-    AutoUnsafe(ast::mutability)
+    AutoUnsafe(Region, ast::mutability)
 }
 
 pub type ctxt = @ctxt_;
@@ -574,7 +574,7 @@ pub enum sty {
     ty_box(mt),
     ty_uniq(mt),
     ty_evec(mt, vstore),
-    ty_ptr(mt),
+    ty_ptr(Region, mt),
     ty_rptr(Region, mt),
     ty_bare_fn(BareFnTy),
     ty_closure(ClosureTy),
@@ -979,10 +979,10 @@ fn mk_t(cx: ctxt, st: sty) -> t {
         flags |= sflags(substs);
       }
       &ty_box(ref m) | &ty_uniq(ref m) | &ty_evec(ref m, _) |
-      &ty_ptr(ref m) | &ty_unboxed_vec(ref m) => {
+      &ty_unboxed_vec(ref m) => {
         flags |= get(m.ty).flags;
       }
-      &ty_rptr(r, ref m) => {
+      &ty_ptr(r, ref m) | &ty_rptr(r, ref m) => {
         flags |= rflags(r);
         flags |= get(m.ty).flags;
       }
@@ -1134,9 +1134,13 @@ pub fn mk_imm_uniq(cx: ctxt, ty: t) -> t {
     mk_uniq(cx, mt {ty: ty, mutbl: ast::m_imm})
 }
 
-pub fn mk_ptr(cx: ctxt, tm: mt) -> t { mk_t(cx, ty_ptr(tm)) }
+pub fn mk_ptr(cx: ctxt, r: Region, tm: mt) -> t {
+    mk_t(cx, ty_ptr(r, tm))
+}
 
-pub fn mk_rptr(cx: ctxt, r: Region, tm: mt) -> t { mk_t(cx, ty_rptr(r, tm)) }
+pub fn mk_rptr(cx: ctxt, r: Region, tm: mt) -> t {
+    mk_t(cx, ty_rptr(r, tm))
+}
 
 pub fn mk_mut_rptr(cx: ctxt, r: Region, ty: t) -> t {
     mk_rptr(cx, r, mt {ty: ty, mutbl: ast::m_mutbl})
@@ -1145,16 +1149,16 @@ pub fn mk_imm_rptr(cx: ctxt, r: Region, ty: t) -> t {
     mk_rptr(cx, r, mt {ty: ty, mutbl: ast::m_imm})
 }
 
-pub fn mk_mut_ptr(cx: ctxt, ty: t) -> t {
-    mk_ptr(cx, mt {ty: ty, mutbl: ast::m_mutbl})
+pub fn mk_mut_ptr(cx: ctxt, r: Region, ty: t) -> t {
+    mk_ptr(cx, r, mt {ty: ty, mutbl: ast::m_mutbl})
 }
 
-pub fn mk_imm_ptr(cx: ctxt, ty: t) -> t {
-    mk_ptr(cx, mt {ty: ty, mutbl: ast::m_imm})
+pub fn mk_imm_ptr(cx: ctxt, r: Region, ty: t) -> t {
+    mk_ptr(cx, r, mt {ty: ty, mutbl: ast::m_imm})
 }
 
-pub fn mk_nil_ptr(cx: ctxt) -> t {
-    mk_ptr(cx, mt {ty: mk_nil(), mutbl: ast::m_imm})
+pub fn mk_nil_ptr(cx: ctxt, r: Region) -> t {
+    mk_ptr(cx, r, mt {ty: mk_nil(), mutbl: ast::m_imm})
 }
 
 pub fn mk_evec(cx: ctxt, tm: mt, t: vstore) -> t {
@@ -1245,7 +1249,7 @@ pub fn maybe_walk_ty(ty: t, f: &fn(t) -> bool) {
       ty_opaque_closure_ptr(_) | ty_infer(_) | ty_param(_) | ty_err => {
       }
       ty_box(ref tm) | ty_evec(ref tm, _) | ty_unboxed_vec(ref tm) |
-      ty_ptr(ref tm) | ty_rptr(_, ref tm) | ty_uniq(ref tm) => {
+      ty_ptr(_, ref tm) | ty_rptr(_, ref tm) | ty_uniq(ref tm) => {
         maybe_walk_ty(tm.ty, f);
       }
       ty_enum(_, ref substs) | ty_struct(_, ref substs) |
@@ -1298,8 +1302,8 @@ fn fold_sty(sty: &sty, fldop: &fn(t) -> t) -> sty {
         ty_uniq(ref tm) => {
             ty_uniq(mt {ty: fldop(tm.ty), mutbl: tm.mutbl})
         }
-        ty_ptr(ref tm) => {
-            ty_ptr(mt {ty: fldop(tm.ty), mutbl: tm.mutbl})
+        ty_ptr(r, ref tm) => {
+            ty_ptr(r, mt {ty: fldop(tm.ty), mutbl: tm.mutbl})
         }
         ty_unboxed_vec(ref tm) => {
             ty_unboxed_vec(mt {ty: fldop(tm.ty), mutbl: tm.mutbl})
@@ -1387,6 +1391,11 @@ pub fn fold_regions_and_ty(
 
     let tb = ty::get(ty);
     match tb.sty {
+      ty::ty_ptr(r, mt) => {
+        let m_r = fldr(r);
+        let m_t = fldt(mt.ty);
+        ty::mk_ptr(cx, m_r, mt {ty: m_t, mutbl: mt.mutbl})
+      }
       ty::ty_rptr(r, mt) => {
         let m_r = fldr(r);
         let m_t = fldt(mt.ty);
@@ -1635,7 +1644,7 @@ pub fn type_is_unique_box(ty: t) -> bool {
 
 pub fn type_is_unsafe_ptr(ty: t) -> bool {
     match get(ty).sty {
-      ty_ptr(_) => return true,
+      ty_ptr(*) => return true,
       _ => return false
     }
 }
@@ -1667,7 +1676,7 @@ pub fn type_is_scalar(ty: t) -> bool {
     match get(ty).sty {
       ty_nil | ty_bool | ty_int(_) | ty_float(_) | ty_uint(_) |
       ty_infer(IntVar(_)) | ty_infer(FloatVar(_)) | ty_type |
-      ty_bare_fn(*) | ty_ptr(_) => true,
+      ty_bare_fn(*) | ty_ptr(*) => true,
       _ => false
     }
 }
@@ -1731,7 +1740,7 @@ fn type_needs_unwind_cleanup_(cx: ctxt, ty: t,
             true
           }
           ty_nil | ty_bot | ty_bool | ty_int(_) | ty_uint(_) | ty_float(_) |
-          ty_tup(_) | ty_ptr(_) => {
+          ty_tup(_) | ty_ptr(*) => {
             true
           }
           ty_enum(did, ref substs) => {
@@ -2000,7 +2009,7 @@ pub fn type_contents(cx: ctxt, ty: t) -> TypeContents {
         let result = match get(ty).sty {
             // Scalar and unique types are sendable, freezable, and durable
             ty_nil | ty_bot | ty_bool | ty_int(_) | ty_uint(_) | ty_float(_) |
-            ty_bare_fn(_) | ty_ptr(_) => {
+            ty_bare_fn(_) | ty_ptr(*) => {
                 TC_NONE
             }
 
@@ -2492,7 +2501,7 @@ pub fn type_is_pod(cx: ctxt, ty: t) -> bool {
     match get(ty).sty {
       // Scalar types
       ty_nil | ty_bot | ty_bool | ty_int(_) | ty_float(_) | ty_uint(_) |
-      ty_type | ty_ptr(_) | ty_bare_fn(_) => result = true,
+      ty_type | ty_ptr(*) | ty_bare_fn(_) => result = true,
       // Boxed types
       ty_box(_) | ty_uniq(_) | ty_closure(_) |
       ty_estr(vstore_uniq) | ty_estr(vstore_box) |
@@ -2601,7 +2610,7 @@ pub fn deref_sty(cx: ctxt, sty: &sty, explicit: bool) -> Option<mt> {
         Some(mt)
       }
 
-      ty_ptr(mt) if explicit => {
+      ty_ptr(_, mt) if explicit => {
         Some(mt)
       }
 
@@ -2804,6 +2813,7 @@ pub fn ty_region(tcx: ctxt,
                  span: span,
                  ty: t) -> Region {
     match get(ty).sty {
+        ty_ptr(r, _) => r,
         ty_rptr(r, _) => r,
         ty_evec(_, vstore_slice(r)) => r,
         ty_estr(vstore_slice(r)) => r,
@@ -2966,8 +2976,8 @@ pub fn adjust_ty(cx: ctxt,
                             borrow_fn(cx, span, r, adjusted_ty)
                         }
 
-                        AutoUnsafe(m) => {
-                            mk_ptr(cx, mt {ty: adjusted_ty, mutbl: m})
+                        AutoUnsafe(r, m) => {
+                            mk_ptr(cx, r, mt {ty: adjusted_ty, mutbl: m})
                         }
                     }
                 }
@@ -3023,7 +3033,7 @@ impl AutoRef {
             ty::AutoBorrowVec(r, m) => ty::AutoBorrowVec(f(r), m),
             ty::AutoBorrowVecRef(r, m) => ty::AutoBorrowVecRef(f(r), m),
             ty::AutoBorrowFn(r) => ty::AutoBorrowFn(f(r)),
-            ty::AutoUnsafe(m) => ty::AutoUnsafe(m),
+            ty::AutoUnsafe(r, m) => ty::AutoUnsafe(f(r), m),
         }
     }
 }
@@ -3320,7 +3330,7 @@ pub fn ty_sort_str(cx: ctxt, t: t) -> ~str {
       ty_uniq(_) => ~"~-ptr",
       ty_evec(_, _) => ~"vector",
       ty_unboxed_vec(_) => ~"unboxed vector",
-      ty_ptr(_) => ~"*-ptr",
+      ty_ptr(_, _) => ~"*-ptr",
       ty_rptr(_, _) => ~"&-ptr",
       ty_bare_fn(_) => ~"extern fn",
       ty_closure(_) => ~"fn",
@@ -4215,6 +4225,10 @@ pub fn normalize_ty(cx: ctxt, t: t) -> t {
         ty_estr(vstore) =>
             // This type has a vstore. Get rid of it
             mk_estr(cx, normalize_vstore(vstore)),
+
+        ty_ptr(_, mt) =>
+            // This type has a region. Get rid of it
+            mk_ptr(cx, re_static, normalize_mt(cx, mt)),
 
         ty_rptr(_, mt) =>
             // This type has a region. Get rid of it

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -370,7 +370,8 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Clone + 'static>(
         ty::mk_evec(tcx, ast_mt_to_mt(this, rscope, mt), ty::vstore_uniq)
       }
       ast::ty_ptr(_, ref mt) => {
-        ty::mk_ptr(tcx, ast_mt_to_mt(this, rscope, mt))
+        let r = ty::re_static;
+        ty::mk_ptr(tcx, r, ast_mt_to_mt(this, rscope, mt))
       }
       ast::ty_rptr(ref region, ref mt) => {
         let r = ast_region_to_region(this, rscope, ast_ty.span, region);

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -369,7 +369,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Clone + 'static>(
         // return /something/ so they can at least get more errors
         ty::mk_evec(tcx, ast_mt_to_mt(this, rscope, mt), ty::vstore_uniq)
       }
-      ast::ty_ptr(ref mt) => {
+      ast::ty_ptr(_, ref mt) => {
         ty::mk_ptr(tcx, ast_mt_to_mt(this, rscope, mt))
       }
       ast::ty_rptr(ref region, ref mt) => {

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -369,8 +369,8 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:region_scope + Clone + 'static>(
         // return /something/ so they can at least get more errors
         ty::mk_evec(tcx, ast_mt_to_mt(this, rscope, mt), ty::vstore_uniq)
       }
-      ast::ty_ptr(_, ref mt) => {
-        let r = ty::re_static;
+      ast::ty_ptr(ref region, ref mt) => {
+        let r = ast_region_to_region(this, rscope, ast_ty.span, region);
         ty::mk_ptr(tcx, r, ast_mt_to_mt(this, rscope, mt))
       }
       ast::ty_rptr(ref region, ref mt) => {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2712,7 +2712,7 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
                         &T to *T. */
                         let te = structurally_resolved_type(fcx, e.span, t_e);
                         match (&ty::get(te).sty, &ty::get(t_1).sty) {
-                            (&ty::ty_rptr(_, mt1), &ty::ty_ptr(mt2))
+                            (&ty::ty_rptr(_, mt1), &ty::ty_ptr(_, mt2))
                             if types_compatible(fcx, e.span,
                                                 mt1.ty, mt2.ty) => {
                                 /* this case is allowed */
@@ -3246,6 +3246,7 @@ pub fn ty_param_bounds_and_ty_for_def(fcx: @mut FnCtxt,
             },
             ty: ty::mk_ptr(
                 fcx.ccx.tcx,
+                ty::re_static,
                 ty::mt {
                     ty: ty::mk_mach_uint(ast::ty_u8),
                     mutbl: ast::m_imm
@@ -3556,7 +3557,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                   Ok(t) => t,
                   Err(s) => { tcx.sess.span_fatal(it.span, s); }
               };
-              let td_ptr = ty::mk_ptr(ccx.tcx, ty::mt {
+              let td_ptr = ty::mk_ptr(ccx.tcx, ty::re_static, ty::mt {
                   ty: tydesc_ty,
                   mutbl: ast::m_imm
               });
@@ -3572,7 +3573,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                   Err(s) => { tcx.sess.span_fatal(it.span, s); }
               };
 
-              let td_ptr = ty::mk_ptr(ccx.tcx, ty::mt {
+              let td_ptr = ty::mk_ptr(ccx.tcx, ty::re_static, ty::mt {
                   ty: tydesc_ty,
                   mutbl: ast::m_imm
               });
@@ -3587,23 +3588,27 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                   bounds: ty::EmptyBuiltinBounds(),
                   sig: ty::FnSig {
                       bound_lifetime_names: opt_vec::Empty,
-                      inputs: ~[ty::mk_imm_ptr(ccx.tcx, ty::mk_mach_uint(ast::ty_u8))],
+                      inputs: ~[
+                          ty::mk_imm_ptr(ccx.tcx,
+                                         ty::re_static,
+                                         ty::mk_mach_uint(ast::ty_u8))
+                      ],
                       output: ty::mk_nil()
                   }
               });
               (0u, ~[fty], ty::mk_nil())
             }
             "morestack_addr" => {
-              (0u, ~[], ty::mk_nil_ptr(ccx.tcx))
+              (0u, ~[], ty::mk_nil_ptr(ccx.tcx, ty::re_static))
             }
             "memcpy32" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::mt {
+                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
                       ty: param(ccx, 0),
                       mutbl: ast::m_mutbl
                   }),
-                  ty::mk_ptr(tcx, ty::mt {
+                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
                       ty: param(ccx, 0),
                       mutbl: ast::m_imm
                   }),
@@ -3614,11 +3619,11 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memcpy64" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::mt {
+                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
                       ty: param(ccx, 0),
                       mutbl: ast::m_mutbl
                   }),
-                  ty::mk_ptr(tcx, ty::mt {
+                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
                       ty: param(ccx, 0),
                       mutbl: ast::m_imm
                   }),
@@ -3629,11 +3634,11 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memmove32" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::mt {
+                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
                       ty: param(ccx, 0),
                       mutbl: ast::m_mutbl
                   }),
-                  ty::mk_ptr(tcx, ty::mt {
+                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
                       ty: param(ccx, 0),
                       mutbl: ast::m_imm
                   }),
@@ -3644,11 +3649,11 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memmove64" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::mt {
+                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
                       ty: param(ccx, 0),
                       mutbl: ast::m_mutbl
                   }),
-                  ty::mk_ptr(tcx, ty::mt {
+                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
                       ty: param(ccx, 0),
                       mutbl: ast::m_imm
                   }),
@@ -3659,7 +3664,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memset32" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::mt {
+                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
                       ty: param(ccx, 0),
                       mutbl: ast::m_mutbl
                   }),
@@ -3671,7 +3676,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memset64" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::mt {
+                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
                       ty: param(ccx, 0),
                       mutbl: ast::m_mutbl
                   }),

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3590,7 +3590,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                       bound_lifetime_names: opt_vec::Empty,
                       inputs: ~[
                           ty::mk_imm_ptr(ccx.tcx,
-                                         ty::re_static,
+                                         ty::re_bound(ty::br_anon(0)),
                                          ty::mk_mach_uint(ast::ty_u8))
                       ],
                       output: ty::mk_nil()

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3604,14 +3604,8 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memcpy32" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_mutbl
-                  }),
-                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_imm
-                  }),
+                  ty::mk_mut_ptr(tcx, ty::re_bound(ty::br_anon(0)), param(ccx, 0)),
+                  ty::mk_imm_ptr(tcx, ty::re_bound(ty::br_anon(1)), param(ccx, 0)),
                   ty::mk_u32()
                ],
                ty::mk_nil())
@@ -3619,14 +3613,8 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memcpy64" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_mutbl
-                  }),
-                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_imm
-                  }),
+                  ty::mk_mut_ptr(tcx, ty::re_bound(ty::br_anon(0)), param(ccx, 0)),
+                  ty::mk_imm_ptr(tcx, ty::re_bound(ty::br_anon(1)), param(ccx, 0)),
                   ty::mk_u64()
                ],
                ty::mk_nil())
@@ -3634,14 +3622,8 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memmove32" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_mutbl
-                  }),
-                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_imm
-                  }),
+                  ty::mk_mut_ptr(tcx, ty::re_bound(ty::br_anon(0)), param(ccx, 0)),
+                  ty::mk_imm_ptr(tcx, ty::re_bound(ty::br_anon(1)), param(ccx, 0)),
                   ty::mk_u32()
                ],
                ty::mk_nil())
@@ -3649,14 +3631,8 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memmove64" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_mutbl
-                  }),
-                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_imm
-                  }),
+                  ty::mk_mut_ptr(tcx, ty::re_bound(ty::br_anon(0)), param(ccx, 0)),
+                  ty::mk_imm_ptr(tcx, ty::re_bound(ty::br_anon(1)), param(ccx, 0)),
                   ty::mk_u64()
                ],
                ty::mk_nil())
@@ -3664,10 +3640,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memset32" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_mutbl
-                  }),
+                  ty::mk_mut_ptr(tcx, ty::re_bound(ty::br_anon(0)), param(ccx, 0)),
                   ty::mk_u8(),
                   ty::mk_u32()
                ],
@@ -3676,10 +3649,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "memset64" => {
               (1,
                ~[
-                  ty::mk_ptr(tcx, ty::re_static, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_mutbl
-                  }),
+                  ty::mk_mut_ptr(tcx, ty::re_bound(ty::br_anon(0)), param(ccx, 0)),
                   ty::mk_u8(),
                   ty::mk_u64()
                ],

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3557,10 +3557,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                   Ok(t) => t,
                   Err(s) => { tcx.sess.span_fatal(it.span, s); }
               };
-              let td_ptr = ty::mk_ptr(ccx.tcx, ty::re_static, ty::mt {
-                  ty: tydesc_ty,
-                  mutbl: ast::m_imm
-              });
+              let td_ptr = ty::mk_imm_ptr(ccx.tcx, ty::re_static, tydesc_ty);
               (1u, ~[], td_ptr)
             }
             "visit_tydesc" => {
@@ -3573,10 +3570,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                   Err(s) => { tcx.sess.span_fatal(it.span, s); }
               };
 
-              let td_ptr = ty::mk_ptr(ccx.tcx, ty::re_static, ty::mt {
-                  ty: tydesc_ty,
-                  mutbl: ast::m_imm
-              });
+              let td_ptr = ty::mk_imm_ptr(ccx.tcx, ty::re_bound(ty::br_anon(0)), tydesc_ty);
               (0, ~[ td_ptr, visitor_object_ty ], ty::mk_nil())
             }
             "frame_address" => {

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -877,7 +877,7 @@ pub mod guarantor {
                                      guarantor_of_deref(&expr_ct.cat));
             }
 
-            ty::AutoUnsafe(_) => {}
+            ty::AutoUnsafe(*) => {}
         }
 
         fn maybe_make_subregion(
@@ -1069,7 +1069,7 @@ pub mod guarantor {
                 match adjustment.autoref {
                     None => {
                     }
-                    Some(ty::AutoUnsafe(_)) => {
+                    Some(ty::AutoUnsafe(*)) => {
                         expr_ct.cat.guarantor = None;
                         expr_ct.cat.pointer = OtherPointer;
                         debug!("autoref, cat=%?", expr_ct.cat);

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -90,7 +90,7 @@ pub fn get_base_type(inference_context: @mut InferCtxt,
         ty_estr(*) | ty_evec(*) | ty_bare_fn(*) | ty_closure(*) | ty_tup(*) |
         ty_infer(*) | ty_param(*) | ty_self(*) | ty_type | ty_opaque_box |
         ty_opaque_closure_ptr(*) | ty_unboxed_vec(*) | ty_err | ty_box(_) |
-        ty_uniq(_) | ty_ptr(_) | ty_rptr(_, _) => {
+        ty_uniq(_) | ty_ptr(*) | ty_rptr(*) => {
             debug!("(getting base type) no base type; found %?",
                    get(original_type).sty);
             None

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -547,10 +547,10 @@ pub fn super_tys<C:Combine>(
         }
       }
 
-      (&ty::ty_ptr(ref a_mt), &ty::ty_ptr(ref b_mt)) => {
-        do this.mts(a_mt, b_mt).chain |mt| {
-            Ok(ty::mk_ptr(tcx, mt))
-        }
+      (&ty::ty_ptr(a_r, ref a_mt), &ty::ty_ptr(b_r, ref b_mt)) => {
+          let r = if_ok!(this.contraregions(a_r, b_r));
+          let mt = if_ok!(this.mts(a_mt, b_mt));
+          Ok(ty::mk_ptr(tcx, r, mt))
       }
 
       (&ty::ty_rptr(a_r, ref a_mt), &ty::ty_rptr(b_r, ref b_mt)) => {

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -372,8 +372,12 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
                     bound_lifetime_names: opt_vec::Empty,
                     inputs: ~[
                         ty::mk_int(),
-                        ty::mk_imm_ptr(tcx, ty::mk_imm_ptr(tcx, ty::mk_u8())),
-                        ty::mk_imm_ptr(tcx, ty::mk_u8())
+                        ty::mk_imm_ptr(tcx,
+                                       ty::re_static,
+                                       ty::mk_imm_ptr(tcx,
+                                                      ty::re_static,
+                                                      ty::mk_u8())),
+                        ty::mk_imm_ptr(tcx, ty::re_static, ty::mk_u8())
                     ],
                     output: ty::mk_int()
                 }

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -31,7 +31,8 @@ pub trait region_scope {
 }
 
 #[deriving(Clone)]
-pub enum empty_rscope { empty_rscope }
+pub struct empty_rscope;
+
 impl region_scope for empty_rscope {
     fn anon_region(&self, _span: span) -> Result<ty::Region, RegionError> {
         result::Err(RegionError {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -416,7 +416,9 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_float(t) => ast_util::float_ty_to_str(t),
       ty_box(ref tm) => ~"@" + mt_to_str(cx, tm),
       ty_uniq(ref tm) => ~"~" + mt_to_str(cx, tm),
-      ty_ptr(ref tm) => ~"*" + mt_to_str(cx, tm),
+      ty_ptr(r, ref tm) => {
+          region_to_str(cx, "*", true, r) + mt_to_str(cx, tm)
+      }
       ty_rptr(r, ref tm) => {
         region_ptr_to_str(cx, r) + mt_to_str(cx, tm)
       }

--- a/src/libstd/gc.rs
+++ b/src/libstd/gc.rs
@@ -53,8 +53,8 @@ pub use stackwalk::Word;
 
 // Mirrors rust_stack.h stk_seg
 pub struct StackSegment {
-    prev: *StackSegment,
-    next: *StackSegment,
+    prev: *'static StackSegment,
+    next: *'static StackSegment,
     end: uintptr_t,
     // And other fields which we don't care about...
 }
@@ -90,8 +90,8 @@ unsafe fn get_safe_point_count() -> uint {
 }
 
 struct SafePoint {
-    sp_meta: *Word,
-    fn_meta: *Word,
+    sp_meta: *'static Word,
+    fn_meta: *'static Word,
 }
 
 // Returns the safe point metadata for the given program counter, if
@@ -121,7 +121,7 @@ unsafe fn is_safe_point(pc: *Word) -> Option<SafePoint> {
     return None;
 }
 
-type Visitor<'self> = &'self fn(root: **Word, tydesc: *TyDesc) -> bool;
+type Visitor<'self> = &'self fn(root: *'static *'static Word, tydesc: *'static TyDesc) -> bool;
 
 // Walks the list of roots for the given safe point, and calls visitor
 // on each root.
@@ -180,13 +180,13 @@ unsafe fn is_frame_in_segment(fp: *Word, segment: *StackSegment) -> bool {
     return begin <= frame && frame <= end;
 }
 
-struct Segment { segment: *StackSegment, boundary: bool }
+struct Segment { segment: *'static StackSegment, boundary: bool }
 
 // Find and return the segment containing the given frame pointer. At
 // stack segment boundaries, returns true for boundary, so that the
 // caller can do any special handling to identify where the correct
 // return address is in the stack frame.
-unsafe fn find_segment_for_frame(fp: *Word, segment: *StackSegment)
+unsafe fn find_segment_for_frame(fp: *Word, segment: *'static StackSegment)
     -> Segment {
     // Check if frame is in either current frame or previous frame.
     let in_segment = is_frame_in_segment(fp, segment);

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -916,7 +916,7 @@ fn convert_whence(whence: SeekStyle) -> i32 {
     };
 }
 
-impl Reader for *libc::FILE {
+impl Reader for *'static libc::FILE {
     fn read(&self, bytes: &mut [u8], len: uint) -> uint {
         unsafe {
             do bytes.as_mut_buf |buf_p, buf_len| {
@@ -984,11 +984,11 @@ impl<R:Reader,C> Reader for Wrapper<R, C> {
 }
 
 pub struct FILERes {
-    f: *libc::FILE,
+    f: *'static libc::FILE,
 }
 
 impl FILERes {
-    pub fn new(f: *libc::FILE) -> FILERes {
+    pub fn new(f: *'static libc::FILE) -> FILERes {
         FILERes { f: f }
     }
 }
@@ -1001,7 +1001,7 @@ impl Drop for FILERes {
     }
 }
 
-pub fn FILE_reader(f: *libc::FILE, cleanup: bool) -> @Reader {
+pub fn FILE_reader(f: *'static libc::FILE, cleanup: bool) -> @Reader {
     if cleanup {
         @Wrapper { base: f, cleanup: FILERes::new(f) } as @Reader
     } else {
@@ -1151,7 +1151,7 @@ impl<W:Writer,C> Writer for Wrapper<W, C> {
     fn get_type(&self) -> WriterType { File }
 }
 
-impl Writer for *libc::FILE {
+impl Writer for *'static libc::FILE {
     fn write(&self, v: &[u8]) {
         unsafe {
             do v.as_imm_buf |vbuf, len| {
@@ -1193,7 +1193,7 @@ impl Writer for *libc::FILE {
     }
 }
 
-pub fn FILE_writer(f: *libc::FILE, cleanup: bool) -> @Writer {
+pub fn FILE_writer(f: *'static libc::FILE, cleanup: bool) -> @Writer {
     if cleanup {
         @Wrapper { base: f, cleanup: FILERes::new(f) } as @Writer
     } else {

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -916,7 +916,7 @@ fn convert_whence(whence: SeekStyle) -> i32 {
     };
 }
 
-impl Reader for *'static libc::FILE {
+impl<'self> Reader for *'self libc::FILE {
     fn read(&self, bytes: &mut [u8], len: uint) -> uint {
         unsafe {
             do bytes.as_mut_buf |buf_p, buf_len| {
@@ -1151,7 +1151,7 @@ impl<W:Writer,C> Writer for Wrapper<W, C> {
     fn get_type(&self) -> WriterType { File }
 }
 
-impl Writer for *'static libc::FILE {
+impl<'self> Writer for *'self libc::FILE {
     fn write(&self, v: &[u8]) {
         unsafe {
             do v.as_imm_buf |vbuf, len| {

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -776,15 +776,15 @@ pub mod types {
                     __unused1: c_int,
                     gl_offs:   size_t,
                     __unused2: c_int,
-                    gl_pathv:  **c_char,
+                    gl_pathv:  *'static *'static c_char,
 
-                    __unused3: *c_void,
+                    __unused3: *'static c_void,
 
-                    __unused4: *c_void,
-                    __unused5: *c_void,
-                    __unused6: *c_void,
-                    __unused7: *c_void,
-                    __unused8: *c_void,
+                    __unused4: *'static c_void,
+                    __unused5: *'static c_void,
+                    __unused6: *'static c_void,
+                    __unused7: *'static c_void,
+                    __unused8: *'static c_void,
                 }
             }
         }
@@ -2011,7 +2011,7 @@ pub mod consts {
             pub static MAP_FIXED : c_int = 0x0010;
             pub static MAP_ANON : c_int = 0x1000;
 
-            pub static MAP_FAILED : *c_void = -1 as *c_void;
+            pub static MAP_FAILED : *'static c_void = -1 as *'static c_void;
 
             pub static MCL_CURRENT : c_int = 0x0001;
             pub static MCL_FUTURE : c_int = 0x0002;

--- a/src/libstd/managed.rs
+++ b/src/libstd/managed.rs
@@ -23,9 +23,9 @@ pub mod raw {
     #[allow(missing_doc)]
     pub struct BoxHeaderRepr {
         ref_count: uint,
-        type_desc: *TyDesc,
-        prev: *BoxRepr,
-        next: *BoxRepr,
+        type_desc: *'static TyDesc,
+        prev: *'static BoxRepr,
+        next: *'static BoxRepr,
     }
 
     #[allow(missing_doc)]

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -445,12 +445,14 @@ fn test_unwrap_ptr() {
 
 #[test]
 fn test_unwrap_str() {
-    let x = ~"test";
-    let addr_x = str::as_buf(x, |buf, _len| buf);
-    let opt = Some(x);
-    let y = opt.unwrap();
-    let addr_y = str::as_buf(y, |buf, _len| buf);
-    assert_eq!(addr_x, addr_y);
+    unsafe {
+        let x = ~"test";
+        let addr_x: *'static u8 = str::as_buf(x, |buf, _len| ::cast::transmute(buf));
+        let opt = Some(x);
+        let y = opt.unwrap();
+        let addr_y: *'static u8 = str::as_buf(y, |buf, _len| ::cast::transmute(buf));
+        assert_eq!(addr_x, addr_y);
+    }
 }
 
 #[test]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1188,7 +1188,7 @@ pub fn real_args() -> ~[~str] {
     return args;
 }
 
-type LPCWSTR = *u16;
+type LPCWSTR = *'static u16;
 
 #[cfg(windows)]
 #[link_name="kernel32"]
@@ -1354,13 +1354,13 @@ pub fn page_size() -> uint {
 }
 
 pub struct MemoryMap {
-    data: *mut u8,
+    data: *'static mut u8,
     len: size_t,
     kind: MemoryMapKind
 }
 
 pub enum MemoryMapKind {
-    MapFile(*c_void),
+    MapFile(*'static c_void),
     MapVirtual
 }
 
@@ -1368,7 +1368,7 @@ pub enum MapOption {
     MapReadable,
     MapWritable,
     MapExecutable,
-    MapAddr(*c_void),
+    MapAddr(*'static c_void),
     MapFd(c_int),
     MapOffset(uint)
 }

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -47,8 +47,8 @@ pub unsafe fn buf_len<T>(buf: **T) -> uint {
     position(buf, |i| *i == null())
 }
 
-impl<T> Clone for *'static T {
-    fn clone(&self) -> *'static T {
+impl<'self, T> Clone for *'self T {
+    fn clone(&self) -> *'self T {
         *self
     }
 }
@@ -281,7 +281,7 @@ pub trait RawPtr<T> {
 }
 
 /// Extension methods for immutable pointers
-impl<T> RawPtr<T> for *'static T {
+impl<'self, T> RawPtr<T> for *'self T {
     /// Returns true if the pointer is equal to the null pointer.
     #[inline]
     fn is_null(&self) -> bool { is_null(*self) }
@@ -313,7 +313,7 @@ impl<T> RawPtr<T> for *'static T {
 }
 
 /// Extension methods for mutable pointers
-impl<T> RawPtr<T> for *'static mut T {
+impl<'self, T> RawPtr<T> for *'self mut T {
     /// Returns true if the pointer is equal to the null pointer.
     #[inline]
     fn is_null(&self) -> bool { is_null(*self) }
@@ -346,7 +346,7 @@ impl<T> RawPtr<T> for *'static mut T {
 
 // Equality for pointers
 #[cfg(not(test))]
-impl<T> Eq for *'static const T {
+impl<'self, T> Eq for *'self const T {
     #[inline]
     fn eq(&self, other: &*const T) -> bool {
         (*self as uint) == (*other as uint)
@@ -357,7 +357,7 @@ impl<T> Eq for *'static const T {
 
 // Comparison for pointers
 #[cfg(not(test))]
-impl<T> Ord for *'static const T {
+impl<'self, T> Ord for *'self const T {
     #[inline]
     fn lt(&self, other: &*const T) -> bool {
         (*self as uint) < (*other as uint)
@@ -377,41 +377,41 @@ impl<T> Ord for *'static const T {
 }
 
 #[cfg(not(test))]
-impl<T, I: Int> Add<I, *'static T> for *'static T {
+impl<'self, T, I: Int> Add<I, *'self T> for *'self T {
     /// Add an integer value to a pointer to get an offset pointer.
     /// Is calculated according to the size of the type pointed to.
     #[inline]
-    pub fn add(&self, rhs: &I) -> *'static T {
+    pub fn add(&self, rhs: &I) -> *'self T {
         self.offset(rhs.to_int() as uint)
     }
 }
 
 #[cfg(not(test))]
-impl<T, I: Int> Sub<I, *'static T> for *'static T {
+impl<'self, T, I: Int> Sub<I, *'self T> for *'self T {
     /// Subtract an integer value from a pointer to get an offset pointer.
     /// Is calculated according to the size of the type pointed to.
     #[inline]
-    pub fn sub(&self, rhs: &I) -> *'static T {
+    pub fn sub(&self, rhs: &I) -> *'self T {
         self.offset(-rhs.to_int() as uint)
     }
 }
 
 #[cfg(not(test))]
-impl<T, I: Int> Add<I, *'static mut T> for *'static mut T {
+impl<'self, T, I: Int> Add<I, *'self mut T> for *'self mut T {
     /// Add an integer value to a pointer to get an offset pointer.
     /// Is calculated according to the size of the type pointed to.
     #[inline]
-    pub fn add(&self, rhs: &I) -> *'static mut T {
+    pub fn add(&self, rhs: &I) -> *'self mut T {
         self.offset(rhs.to_int() as uint)
     }
 }
 
 #[cfg(not(test))]
-impl<T, I: Int> Sub<I, *'static mut T> for *'static mut T {
+impl<'self, T, I: Int> Sub<I, *'self mut T> for *'self mut T {
     /// Subtract an integer value from a pointer to get an offset pointer.
     /// Is calculated according to the size of the type pointed to.
     #[inline]
-    pub fn sub(&self, rhs: &I) -> *'static mut T {
+    pub fn sub(&self, rhs: &I) -> *'self mut T {
         self.offset(-rhs.to_int() as uint)
     }
 }

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -65,11 +65,11 @@ pub unsafe fn position<T>(buf: *T, f: &fn(&T) -> bool) -> uint {
 
 /// Create an unsafe null pointer
 #[inline]
-pub fn null<T>() -> *'static T { 0 as *T }
+pub fn null<'a, T>() -> *'a T { 0 as *'a T }
 
 /// Create an unsafe mutable null pointer
 #[inline]
-pub fn mut_null<T>() -> *mut T { 0 as *mut T }
+pub fn mut_null<'a, T>() -> *'a mut T { 0 as *'a mut T }
 
 /// Returns true if the pointer is equal to the null pointer.
 #[inline]
@@ -212,19 +212,19 @@ pub unsafe fn read_and_zero_ptr<T>(dest: *'static mut T) -> T {
 
 /// Transform a region pointer - &T - to an unsafe pointer - *T.
 #[inline]
-pub fn to_unsafe_ptr<T>(thing: &T) -> *T {
+pub fn to_unsafe_ptr<'a, T>(thing: &'a T) -> *'a T {
     thing as *T
 }
 
 /// Transform a const region pointer - &const T - to a const unsafe pointer - *const T.
 #[inline]
-pub fn to_const_unsafe_ptr<T>(thing: &const T) -> *const T {
+pub fn to_const_unsafe_ptr<'a, T>(thing: &'a const T) -> *'a const T {
     thing as *const T
 }
 
 /// Transform a mutable region pointer - &mut T - to a mutable unsafe pointer - *mut T.
 #[inline]
-pub fn to_mut_unsafe_ptr<T>(thing: &mut T) -> *mut T {
+pub fn to_mut_unsafe_ptr<'a, T>(thing: &'a mut T) -> *'a mut T {
     thing as *mut T
 }
 
@@ -477,19 +477,11 @@ pub mod ptr_tests {
 
     #[test]
     fn test_buf_len() {
-        let s0 = ~"hello";
-        let s1 = ~"there";
-        let s2 = ~"thing";
-        do str::as_c_str(s0) |p0| {
-            do str::as_c_str(s1) |p1| {
-                do str::as_c_str(s2) |p2| {
-                    let v = ~[p0, p1, p2, null()];
-                    do v.as_imm_buf |vp, len| {
-                        assert_eq!(unsafe { buf_len(vp) }, 3u);
-                        assert_eq!(len, 4u);
-                    }
-                }
-            }
+        let v = ~[1 as *int, 1 as *int, 1 as *int, null()];
+
+        do v.as_imm_buf |vp, len| {
+            assert_eq!(unsafe { buf_len(vp) }, 3u);
+            assert_eq!(len, 4u);
         }
     }
 

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -87,8 +87,8 @@ pub fn is_not_null<T>(ptr: *const T) -> bool { !is_null(ptr) }
  */
 #[inline]
 #[cfg(target_word_size = "32")]
-pub unsafe fn copy_memory<T>(dst: *'static mut T, src: *'static const T, count: uint) {
-    intrinsics::memmove32(dst, src as *'static T, count as u32);
+pub unsafe fn copy_memory<T>(dst: *mut T, src: *const T, count: uint) {
+    intrinsics::memmove32(dst, src as *T, count as u32);
 }
 
 /**
@@ -99,8 +99,8 @@ pub unsafe fn copy_memory<T>(dst: *'static mut T, src: *'static const T, count: 
  */
 #[inline]
 #[cfg(target_word_size = "64")]
-pub unsafe fn copy_memory<T>(dst: *'static mut T, src: *'static const T, count: uint) {
-    intrinsics::memmove64(dst, src as *'static T, count as u64);
+pub unsafe fn copy_memory<T>(dst: *mut T, src: *const T, count: uint) {
+    intrinsics::memmove64(dst, src as *T, count as u64);
 }
 
 /**
@@ -111,10 +111,8 @@ pub unsafe fn copy_memory<T>(dst: *'static mut T, src: *'static const T, count: 
  */
 #[inline]
 #[cfg(target_word_size = "32")]
-pub unsafe fn copy_nonoverlapping_memory<T>(dst: *'static mut T,
-                                            src: *'static const T,
-                                            count: uint) {
-    intrinsics::memcpy32(dst, src as *'static T, count as u32);
+pub unsafe fn copy_nonoverlapping_memory<T>(dst: *mut T, src: *const T, count: uint) {
+    intrinsics::memcpy32(dst, src as *T, count as u32);
 }
 
 /**
@@ -125,10 +123,8 @@ pub unsafe fn copy_nonoverlapping_memory<T>(dst: *'static mut T,
  */
 #[inline]
 #[cfg(target_word_size = "64")]
-pub unsafe fn copy_nonoverlapping_memory<T>(dst: *'static mut T,
-                                            src: *'static const T,
-                                            count: uint) {
-    intrinsics::memcpy64(dst, src as *'static T, count as u64);
+pub unsafe fn copy_nonoverlapping_memory<T>(dst: *mut T, src: *const T, count: uint) {
+    intrinsics::memcpy64(dst, src as *T, count as u64);
 }
 
 /**
@@ -137,7 +133,7 @@ pub unsafe fn copy_nonoverlapping_memory<T>(dst: *'static mut T,
  */
 #[inline]
 #[cfg(target_word_size = "32")]
-pub unsafe fn set_memory<T>(dst: *'static mut T, c: u8, count: uint) {
+pub unsafe fn set_memory<T>(dst: *mut T, c: u8, count: uint) {
     intrinsics::memset32(dst, c, count as u32);
 }
 
@@ -147,7 +143,7 @@ pub unsafe fn set_memory<T>(dst: *'static mut T, c: u8, count: uint) {
  */
 #[inline]
 #[cfg(target_word_size = "64")]
-pub unsafe fn set_memory<T>(dst: *'static mut T, c: u8, count: uint) {
+pub unsafe fn set_memory<T>(dst: *mut T, c: u8, count: uint) {
     intrinsics::memset64(dst, c, count as u64);
 }
 
@@ -155,7 +151,7 @@ pub unsafe fn set_memory<T>(dst: *'static mut T, c: u8, count: uint) {
  * Zeroes out `count * size_of::<T>` bytes of memory at `dst`
  */
 #[inline]
-pub unsafe fn zero_memory<T>(dst: *'static mut T, count: uint) {
+pub unsafe fn zero_memory<T>(dst: *mut T, count: uint) {
     set_memory(dst, 0, count);
 }
 

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -224,76 +224,76 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<@u8>();
         if ! self.inner.visit_box(mtbl, inner) { return false; }
         self.bump_past::<@u8>();
         true
     }
 
-    fn visit_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_ptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_ptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<*u8>();
         if ! self.inner.visit_ptr(mtbl, inner) { return false; }
         self.bump_past::<*u8>();
         true
     }
 
-    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_rptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<&'static u8>();
         if ! self.inner.visit_rptr(mtbl, inner) { return false; }
         self.bump_past::<&'static u8>();
         true
     }
 
-    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_unboxed_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<vec::UnboxedVecRepr>();
         if ! self.inner.visit_vec(mtbl, inner) { return false; }
         true
     }
 
-    fn visit_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_vec(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<@[u8]>();
         if ! self.inner.visit_evec_box(mtbl, inner) { return false; }
         self.bump_past::<@[u8]>();
         true
     }
 
-    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_evec_uniq(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<~[@u8]>();
         if ! self.inner.visit_evec_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~[@u8]>();
         true
     }
 
-    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_slice(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<&'static [u8]>();
         if ! self.inner.visit_evec_slice(mtbl, inner) { return false; }
         self.bump_past::<&'static [u8]>();
@@ -301,7 +301,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
     }
 
     fn visit_evec_fixed(&self, n: uint, sz: uint, align: uint,
-                        mtbl: uint, inner: *TyDesc) -> bool {
+                        mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align(align);
         if ! self.inner.visit_evec_fixed(n, sz, align, mtbl, inner) {
             return false;
@@ -316,8 +316,11 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_rec_field(&self, i: uint, name: &str,
-                       mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_rec_field(&self,
+                       i: uint,
+                       name: &str,
+                       mtbl: uint,
+                       inner: *'static TyDesc) -> bool {
         unsafe { self.align((*inner).align); }
         if ! self.inner.visit_rec_field(i, name, mtbl, inner) {
             return false;
@@ -341,7 +344,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
     }
 
     fn visit_class_field(&self, i: uint, name: &str,
-                         mtbl: uint, inner: *TyDesc) -> bool {
+                         mtbl: uint, inner: *'static TyDesc) -> bool {
         unsafe { self.align((*inner).align); }
         if ! self.inner.visit_class_field(i, name, mtbl, inner) {
             return false;
@@ -364,7 +367,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool {
+    fn visit_tup_field(&self, i: uint, inner: *'static TyDesc) -> bool {
         unsafe { self.align((*inner).align); }
         if ! self.inner.visit_tup_field(i, inner) { return false; }
         unsafe { self.bump((*inner).size); }
@@ -384,12 +387,12 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_fn_input(&self, i: uint, mode: uint, inner: *TyDesc) -> bool {
+    fn visit_fn_input(&self, i: uint, mode: uint, inner: *'static TyDesc) -> bool {
         if ! self.inner.visit_fn_input(i, mode, inner) { return false; }
         true
     }
 
-    fn visit_fn_output(&self, retstyle: uint, inner: *TyDesc) -> bool {
+    fn visit_fn_output(&self, retstyle: uint, inner: *'static TyDesc) -> bool {
         if ! self.inner.visit_fn_output(retstyle, inner) { return false; }
         true
     }
@@ -424,7 +427,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *TyDesc) -> bool {
+    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *'static TyDesc) -> bool {
         self.inner.push_ptr();
         self.bump(offset);
         if ! self.inner.visit_enum_variant_field(i, offset, inner) { return false; }
@@ -494,7 +497,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_constr(&self, inner: *TyDesc) -> bool {
+    fn visit_constr(&self, inner: *'static TyDesc) -> bool {
         if ! self.inner.visit_constr(inner) { return false; }
         true
     }

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -224,76 +224,76 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<@u8>();
         if ! self.inner.visit_box(mtbl, inner) { return false; }
         self.bump_past::<@u8>();
         true
     }
 
-    fn visit_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_ptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_ptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<*u8>();
         if ! self.inner.visit_ptr(mtbl, inner) { return false; }
         self.bump_past::<*u8>();
         true
     }
 
-    fn visit_rptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<&'static u8>();
         if ! self.inner.visit_rptr(mtbl, inner) { return false; }
         self.bump_past::<&'static u8>();
         true
     }
 
-    fn visit_unboxed_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<vec::UnboxedVecRepr>();
         if ! self.inner.visit_vec(mtbl, inner) { return false; }
         true
     }
 
-    fn visit_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_vec(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<@[u8]>();
         if ! self.inner.visit_evec_box(mtbl, inner) { return false; }
         self.bump_past::<@[u8]>();
         true
     }
 
-    fn visit_evec_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_evec_uniq(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[@u8]>();
         if ! self.inner.visit_evec_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~[@u8]>();
         true
     }
 
-    fn visit_evec_slice(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<&'static [u8]>();
         if ! self.inner.visit_evec_slice(mtbl, inner) { return false; }
         self.bump_past::<&'static [u8]>();
@@ -301,7 +301,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
     }
 
     fn visit_evec_fixed(&self, n: uint, sz: uint, align: uint,
-                        mtbl: uint, inner: *'static TyDesc) -> bool {
+                        mtbl: uint, inner: *TyDesc) -> bool {
         self.align(align);
         if ! self.inner.visit_evec_fixed(n, sz, align, mtbl, inner) {
             return false;
@@ -320,7 +320,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
                        i: uint,
                        name: &str,
                        mtbl: uint,
-                       inner: *'static TyDesc) -> bool {
+                       inner: *TyDesc) -> bool {
         unsafe { self.align((*inner).align); }
         if ! self.inner.visit_rec_field(i, name, mtbl, inner) {
             return false;
@@ -344,7 +344,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
     }
 
     fn visit_class_field(&self, i: uint, name: &str,
-                         mtbl: uint, inner: *'static TyDesc) -> bool {
+                         mtbl: uint, inner: *TyDesc) -> bool {
         unsafe { self.align((*inner).align); }
         if ! self.inner.visit_class_field(i, name, mtbl, inner) {
             return false;
@@ -367,7 +367,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_tup_field(&self, i: uint, inner: *'static TyDesc) -> bool {
+    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool {
         unsafe { self.align((*inner).align); }
         if ! self.inner.visit_tup_field(i, inner) { return false; }
         unsafe { self.bump((*inner).size); }
@@ -387,12 +387,12 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_fn_input(&self, i: uint, mode: uint, inner: *'static TyDesc) -> bool {
+    fn visit_fn_input(&self, i: uint, mode: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_fn_input(i, mode, inner) { return false; }
         true
     }
 
-    fn visit_fn_output(&self, retstyle: uint, inner: *'static TyDesc) -> bool {
+    fn visit_fn_output(&self, retstyle: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_fn_output(retstyle, inner) { return false; }
         true
     }
@@ -427,7 +427,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *'static TyDesc) -> bool {
+    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *TyDesc) -> bool {
         self.inner.push_ptr();
         self.bump(offset);
         if ! self.inner.visit_enum_variant_field(i, offset, inner) { return false; }
@@ -497,7 +497,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_constr(&self, inner: *'static TyDesc) -> bool {
+    fn visit_constr(&self, inner: *TyDesc) -> bool {
         if ! self.inner.visit_constr(inner) { return false; }
         true
     }

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -156,12 +156,12 @@ impl ReprVisitor {
     }
 
     #[inline]
-    pub fn visit_inner(&self, inner: *'static TyDesc) -> bool {
+    pub fn visit_inner(&self, inner: *TyDesc) -> bool {
         self.visit_ptr_inner(*self.ptr, inner)
     }
 
     #[inline]
-    pub fn visit_ptr_inner(&self, ptr: *'static c_void, inner: *'static TyDesc) -> bool {
+    pub fn visit_ptr_inner(&self, ptr: *'static c_void, inner: *TyDesc) -> bool {
         unsafe {
             let u = ReprVisitor(ptr, self.writer);
             let v = reflect::MovePtrAdaptor(u);
@@ -200,7 +200,7 @@ impl ReprVisitor {
                            _mtbl: uint,
                            ptr: *u8,
                            len: uint,
-                           inner: *'static TyDesc)
+                           inner: *TyDesc)
                            -> bool {
         let mut p = ptr;
         let (sz, al) = unsafe { ((*inner).size, (*inner).align) };
@@ -226,7 +226,7 @@ impl ReprVisitor {
     pub fn write_unboxed_vec_repr(&self,
                                   mtbl: uint,
                                   v: &UnboxedVecRepr,
-                                  inner: *'static TyDesc)
+                                  inner: *TyDesc)
                                   -> bool {
         self.write_vec_range(mtbl, ptr::to_unsafe_ptr(&v.data),
                              v.fill, inner)
@@ -286,7 +286,7 @@ impl TyVisitor for ReprVisitor {
     fn visit_estr_fixed(&self, _n: uint, _sz: uint,
                         _align: uint) -> bool { fail!(); }
 
-    fn visit_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.writer.write_char('@');
         self.write_mut_qualifier(mtbl);
         do self.get::<&managed::raw::BoxRepr> |b| {
@@ -295,14 +295,14 @@ impl TyVisitor for ReprVisitor {
         }
     }
 
-    fn visit_uniq(&self, _mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_uniq(&self, _mtbl: uint, inner: *TyDesc) -> bool {
         self.writer.write_char('~');
         do self.get::<*c_void> |b| {
             self.visit_ptr_inner(*b, inner);
         }
     }
 
-    fn visit_uniq_managed(&self, _mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_uniq_managed(&self, _mtbl: uint, inner: *TyDesc) -> bool {
         self.writer.write_char('~');
         do self.get::<&managed::raw::BoxRepr> |b| {
             let p = ptr::to_unsafe_ptr(&b.data) as *c_void;
@@ -310,14 +310,14 @@ impl TyVisitor for ReprVisitor {
         }
     }
 
-    fn visit_ptr(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool {
+    fn visit_ptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool {
         do self.get::<*c_void> |p| {
             self.writer.write_str(fmt!("(0x%x as *())",
                                        *p as uint));
         }
     }
 
-    fn visit_rptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.writer.write_char('&');
         self.write_mut_qualifier(mtbl);
         do self.get::<*c_void> |p| {
@@ -326,16 +326,16 @@ impl TyVisitor for ReprVisitor {
     }
 
     // Type no longer exists, vestigial function.
-    fn visit_vec(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { fail!(); }
+    fn visit_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { fail!(); }
 
 
-    fn visit_unboxed_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
         do self.get::<vec::UnboxedVecRepr> |b| {
             self.write_unboxed_vec_repr(mtbl, b, inner);
         }
     }
 
-    fn visit_evec_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
         do self.get::<&VecRepr> |b| {
             self.writer.write_char('@');
             self.write_mut_qualifier(mtbl);
@@ -343,21 +343,21 @@ impl TyVisitor for ReprVisitor {
         }
     }
 
-    fn visit_evec_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
         do self.get::<&UnboxedVecRepr> |b| {
             self.writer.write_char('~');
             self.write_unboxed_vec_repr(mtbl, *b, inner);
         }
     }
 
-    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
         do self.get::<&VecRepr> |b| {
             self.writer.write_char('~');
             self.write_unboxed_vec_repr(mtbl, &b.unboxed, inner);
         }
     }
 
-    fn visit_evec_slice(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
         do self.get::<SliceRepr> |s| {
             self.writer.write_char('&');
             self.write_vec_range(mtbl, s.data, s.len, inner);
@@ -365,7 +365,7 @@ impl TyVisitor for ReprVisitor {
     }
 
     fn visit_evec_fixed(&self, _n: uint, sz: uint, _align: uint,
-                        mtbl: uint, inner: *'static TyDesc) -> bool {
+                        mtbl: uint, inner: *TyDesc) -> bool {
         do self.get::<u8> |b| {
             self.write_vec_range(mtbl, ptr::to_unsafe_ptr(b), sz, inner);
         }
@@ -381,7 +381,7 @@ impl TyVisitor for ReprVisitor {
                        i: uint,
                        name: &str,
                        mtbl: uint,
-                       inner: *'static TyDesc) -> bool {
+                       inner: *TyDesc) -> bool {
         if i != 0 {
             self.writer.write_str(", ");
         }
@@ -407,7 +407,7 @@ impl TyVisitor for ReprVisitor {
                          i: uint,
                          name: &str,
                          mtbl: uint,
-                         inner: *'static TyDesc) -> bool {
+                         inner: *TyDesc) -> bool {
         if i != 0 {
             self.writer.write_str(", ");
         }
@@ -428,7 +428,7 @@ impl TyVisitor for ReprVisitor {
         self.writer.write_char('(');
         true
     }
-    fn visit_tup_field(&self, i: uint, inner: *'static TyDesc) -> bool {
+    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool {
         if i != 0 {
             self.writer.write_str(", ");
         }
@@ -488,7 +488,7 @@ impl TyVisitor for ReprVisitor {
     fn visit_enum_variant_field(&self,
                                 i: uint,
                                 _offset: uint,
-                                inner: *'static TyDesc)
+                                inner: *TyDesc)
                                 -> bool {
         match self.var_stk[self.var_stk.len() - 1] {
             Matched => {
@@ -534,10 +534,10 @@ impl TyVisitor for ReprVisitor {
 
     fn visit_enter_fn(&self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
-    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *'static TyDesc) -> bool {
+    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool {
         true
     }
-    fn visit_fn_output(&self, _retstyle: uint, _inner: *'static TyDesc) -> bool {
+    fn visit_fn_output(&self, _retstyle: uint, _inner: *TyDesc) -> bool {
         true
     }
     fn visit_leave_fn(&self, _purity: uint, _proto: uint,
@@ -560,7 +560,7 @@ impl TyVisitor for ReprVisitor {
     }
 
     // Type no longer exists, vestigial function.
-    fn visit_constr(&self, _inner: *'static TyDesc) -> bool { fail!(); }
+    fn visit_constr(&self, _inner: *TyDesc) -> bool { fail!(); }
 
     fn visit_closure_ptr(&self, _ck: uint) -> bool { true }
 }

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -117,12 +117,12 @@ enum VariantState {
 }
 
 pub struct ReprVisitor {
-    ptr: @mut *c_void,
-    ptr_stk: @mut ~[*c_void],
+    ptr: @mut *'static c_void,
+    ptr_stk: @mut ~[*'static c_void],
     var_stk: @mut ~[VariantState],
     writer: @Writer
 }
-pub fn ReprVisitor(ptr: *c_void, writer: @Writer) -> ReprVisitor {
+pub fn ReprVisitor(ptr: *'static c_void, writer: @Writer) -> ReprVisitor {
     ReprVisitor {
         ptr: @mut ptr,
         ptr_stk: @mut ~[],
@@ -156,12 +156,12 @@ impl ReprVisitor {
     }
 
     #[inline]
-    pub fn visit_inner(&self, inner: *TyDesc) -> bool {
+    pub fn visit_inner(&self, inner: *'static TyDesc) -> bool {
         self.visit_ptr_inner(*self.ptr, inner)
     }
 
     #[inline]
-    pub fn visit_ptr_inner(&self, ptr: *c_void, inner: *TyDesc) -> bool {
+    pub fn visit_ptr_inner(&self, ptr: *'static c_void, inner: *'static TyDesc) -> bool {
         unsafe {
             let u = ReprVisitor(ptr, self.writer);
             let v = reflect::MovePtrAdaptor(u);
@@ -200,7 +200,7 @@ impl ReprVisitor {
                            _mtbl: uint,
                            ptr: *u8,
                            len: uint,
-                           inner: *TyDesc)
+                           inner: *'static TyDesc)
                            -> bool {
         let mut p = ptr;
         let (sz, al) = unsafe { ((*inner).size, (*inner).align) };
@@ -226,7 +226,7 @@ impl ReprVisitor {
     pub fn write_unboxed_vec_repr(&self,
                                   mtbl: uint,
                                   v: &UnboxedVecRepr,
-                                  inner: *TyDesc)
+                                  inner: *'static TyDesc)
                                   -> bool {
         self.write_vec_range(mtbl, ptr::to_unsafe_ptr(&v.data),
                              v.fill, inner)
@@ -286,7 +286,7 @@ impl TyVisitor for ReprVisitor {
     fn visit_estr_fixed(&self, _n: uint, _sz: uint,
                         _align: uint) -> bool { fail!(); }
 
-    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.writer.write_char('@');
         self.write_mut_qualifier(mtbl);
         do self.get::<&managed::raw::BoxRepr> |b| {
@@ -295,14 +295,14 @@ impl TyVisitor for ReprVisitor {
         }
     }
 
-    fn visit_uniq(&self, _mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_uniq(&self, _mtbl: uint, inner: *'static TyDesc) -> bool {
         self.writer.write_char('~');
         do self.get::<*c_void> |b| {
             self.visit_ptr_inner(*b, inner);
         }
     }
 
-    fn visit_uniq_managed(&self, _mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_uniq_managed(&self, _mtbl: uint, inner: *'static TyDesc) -> bool {
         self.writer.write_char('~');
         do self.get::<&managed::raw::BoxRepr> |b| {
             let p = ptr::to_unsafe_ptr(&b.data) as *c_void;
@@ -310,14 +310,14 @@ impl TyVisitor for ReprVisitor {
         }
     }
 
-    fn visit_ptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool {
+    fn visit_ptr(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool {
         do self.get::<*c_void> |p| {
             self.writer.write_str(fmt!("(0x%x as *())",
                                        *p as uint));
         }
     }
 
-    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_rptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.writer.write_char('&');
         self.write_mut_qualifier(mtbl);
         do self.get::<*c_void> |p| {
@@ -326,16 +326,16 @@ impl TyVisitor for ReprVisitor {
     }
 
     // Type no longer exists, vestigial function.
-    fn visit_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { fail!(); }
+    fn visit_vec(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { fail!(); }
 
 
-    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_unboxed_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         do self.get::<vec::UnboxedVecRepr> |b| {
             self.write_unboxed_vec_repr(mtbl, b, inner);
         }
     }
 
-    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         do self.get::<&VecRepr> |b| {
             self.writer.write_char('@');
             self.write_mut_qualifier(mtbl);
@@ -343,21 +343,21 @@ impl TyVisitor for ReprVisitor {
         }
     }
 
-    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         do self.get::<&UnboxedVecRepr> |b| {
             self.writer.write_char('~');
             self.write_unboxed_vec_repr(mtbl, *b, inner);
         }
     }
 
-    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         do self.get::<&VecRepr> |b| {
             self.writer.write_char('~');
             self.write_unboxed_vec_repr(mtbl, &b.unboxed, inner);
         }
     }
 
-    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_slice(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         do self.get::<SliceRepr> |s| {
             self.writer.write_char('&');
             self.write_vec_range(mtbl, s.data, s.len, inner);
@@ -365,7 +365,7 @@ impl TyVisitor for ReprVisitor {
     }
 
     fn visit_evec_fixed(&self, _n: uint, sz: uint, _align: uint,
-                        mtbl: uint, inner: *TyDesc) -> bool {
+                        mtbl: uint, inner: *'static TyDesc) -> bool {
         do self.get::<u8> |b| {
             self.write_vec_range(mtbl, ptr::to_unsafe_ptr(b), sz, inner);
         }
@@ -377,8 +377,11 @@ impl TyVisitor for ReprVisitor {
         true
     }
 
-    fn visit_rec_field(&self, i: uint, name: &str,
-                       mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_rec_field(&self,
+                       i: uint,
+                       name: &str,
+                       mtbl: uint,
+                       inner: *'static TyDesc) -> bool {
         if i != 0 {
             self.writer.write_str(", ");
         }
@@ -400,8 +403,11 @@ impl TyVisitor for ReprVisitor {
         self.writer.write_char('{');
         true
     }
-    fn visit_class_field(&self, i: uint, name: &str,
-                         mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_class_field(&self,
+                         i: uint,
+                         name: &str,
+                         mtbl: uint,
+                         inner: *'static TyDesc) -> bool {
         if i != 0 {
             self.writer.write_str(", ");
         }
@@ -422,7 +428,7 @@ impl TyVisitor for ReprVisitor {
         self.writer.write_char('(');
         true
     }
-    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool {
+    fn visit_tup_field(&self, i: uint, inner: *'static TyDesc) -> bool {
         if i != 0 {
             self.writer.write_str(", ");
         }
@@ -440,7 +446,7 @@ impl TyVisitor for ReprVisitor {
 
     fn visit_enter_enum(&self,
                         _n_variants: uint,
-                        get_disr: extern unsafe fn(ptr: *Opaque) -> int,
+                        get_disr: extern unsafe fn(ptr: *'static Opaque) -> int,
                         _sz: uint,
                         _align: uint) -> bool {
         let var_stk: &mut ~[VariantState] = self.var_stk;
@@ -482,7 +488,7 @@ impl TyVisitor for ReprVisitor {
     fn visit_enum_variant_field(&self,
                                 i: uint,
                                 _offset: uint,
-                                inner: *TyDesc)
+                                inner: *'static TyDesc)
                                 -> bool {
         match self.var_stk[self.var_stk.len() - 1] {
             Matched => {
@@ -515,7 +521,7 @@ impl TyVisitor for ReprVisitor {
 
     fn visit_leave_enum(&self,
                         _n_variants: uint,
-                        _get_disr: extern unsafe fn(ptr: *Opaque) -> int,
+                        _get_disr: extern unsafe fn(ptr: *'static Opaque) -> int,
                         _sz: uint,
                         _align: uint)
                         -> bool {
@@ -528,10 +534,10 @@ impl TyVisitor for ReprVisitor {
 
     fn visit_enter_fn(&self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
-    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool {
+    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *'static TyDesc) -> bool {
         true
     }
-    fn visit_fn_output(&self, _retstyle: uint, _inner: *TyDesc) -> bool {
+    fn visit_fn_output(&self, _retstyle: uint, _inner: *'static TyDesc) -> bool {
         true
     }
     fn visit_leave_fn(&self, _purity: uint, _proto: uint,
@@ -554,7 +560,7 @@ impl TyVisitor for ReprVisitor {
     }
 
     // Type no longer exists, vestigial function.
-    fn visit_constr(&self, _inner: *TyDesc) -> bool { fail!(); }
+    fn visit_constr(&self, _inner: *'static TyDesc) -> bool { fail!(); }
 
     fn visit_closure_ptr(&self, _ck: uint) -> bool { true }
 }

--- a/src/libstd/rt/borrowck.rs
+++ b/src/libstd/rt/borrowck.rs
@@ -29,8 +29,8 @@ static ALL_BITS: uint = FROZEN_BIT | MUT_BIT;
 
 #[deriving(Eq)]
 struct BorrowRecord {
-    box: *mut BoxRepr,
-    file: *c_char,
+    box: *'static mut BoxRepr,
+    file: *'static c_char,
     line: size_t
 }
 
@@ -204,8 +204,8 @@ pub unsafe fn borrow_as_mut(a: *u8, file: *c_char, line: size_t) -> uint {
     old_ref_count
 }
 
-pub unsafe fn record_borrow(a: *u8, old_ref_count: uint,
-                            file: *c_char, line: size_t) {
+pub unsafe fn record_borrow(a: *'static u8, old_ref_count: uint,
+                            file: *'static c_char, line: size_t) {
     if (old_ref_count & ALL_BITS) == 0 {
         // was not borrowed before
         let a: *mut BoxRepr = transmute(a);

--- a/src/libstd/rt/comm.rs
+++ b/src/libstd/rt/comm.rs
@@ -57,12 +57,12 @@ pub struct PortOne<T> {
 }
 
 pub struct ChanOneHack<T> {
-    void_packet: *mut Void,
+    void_packet: *'static mut Void,
     suppress_finalize: bool
 }
 
 pub struct PortOneHack<T> {
-    void_packet: *mut Void,
+    void_packet: *'static mut Void,
     suppress_finalize: bool
 }
 

--- a/src/libstd/rt/env.rs
+++ b/src/libstd/rt/env.rs
@@ -20,17 +20,17 @@ pub struct Environment {
     /// The maximum amount of total stack per task before aborting
     max_stack_size: size_t,
     /// The default logging configuration
-    logspec: *c_char,
+    logspec: *'static c_char,
     /// Record and report detailed information about memory leaks
     detailed_leaks: bool,
     /// Seed the random number generator
-    rust_seed: *c_char,
+    rust_seed: *'static c_char,
     /// Poison allocations on free
     poison_on_free: bool,
     /// The argc value passed to main
     argc: c_int,
     /// The argv value passed to main
-    argv: **c_char,
+    argv: *'static *'static c_char,
     /// Print GC debugging info (true if env var RUST_DEBUG_MEM is set)
     debug_mem: bool,
     /// Print GC debugging info (true if env var RUST_DEBUG_BORROW is set)

--- a/src/libstd/rt/io/native/file.rs
+++ b/src/libstd/rt/io/native/file.rs
@@ -46,7 +46,7 @@ impl Seek for FileDesc {
     fn seek(&mut self, _pos: i64, _style: SeekStyle) { fail!() }
 }
 
-pub struct CFile(*FILE);
+pub struct CFile(*'static FILE);
 
 impl CFile {
     /// Create a `CFile` from an open `FILE` pointer.

--- a/src/libstd/rt/local_heap.rs
+++ b/src/libstd/rt/local_heap.rs
@@ -24,17 +24,17 @@ type MemoryRegion = c_void;
 struct Env { priv opaque: () }
 
 struct BoxedRegion {
-    env: *Env,
-    backing_region: *MemoryRegion,
-    live_allocs: *BoxRepr
+    env: *'static Env,
+    backing_region: *'static MemoryRegion,
+    live_allocs: *'static BoxRepr
 }
 
 pub type OpaqueBox = c_void;
 pub type TypeDesc = c_void;
 
 pub struct LocalHeap {
-    memory_region: *MemoryRegion,
-    boxed_region: *BoxedRegion
+    memory_region: *'static MemoryRegion,
+    boxed_region: *'static BoxedRegion
 }
 
 impl LocalHeap {

--- a/src/libstd/rt/rc.rs
+++ b/src/libstd/rt/rc.rs
@@ -24,7 +24,7 @@ use libc::c_void;
 use cast;
 
 pub struct RC<T> {
-    p: *c_void // ~(uint, T)
+    p: *'static c_void // ~(uint, T)
 }
 
 impl<T> RC<T> {

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -58,7 +58,7 @@ pub enum SchedHome {
 }
 
 pub struct GarbageCollector;
-pub struct LocalStorage(*c_void, Option<extern "Rust" fn(*c_void)>);
+pub struct LocalStorage(*'static c_void, Option<extern "Rust" fn(*c_void)>);
 
 pub struct Unwinder {
     unwinding: bool,

--- a/src/libstd/rt/thread.rs
+++ b/src/libstd/rt/thread.rs
@@ -16,7 +16,7 @@ type raw_thread = libc::c_void;
 
 pub struct Thread {
     main: ~fn(),
-    raw_thread: *raw_thread
+    raw_thread: *'static raw_thread
 }
 
 impl Thread {

--- a/src/libstd/rt/uv/async.rs
+++ b/src/libstd/rt/uv/async.rs
@@ -16,7 +16,7 @@ use rt::uv::{Watcher, Loop, NativeHandle, AsyncCallback, NullCallback};
 use rt::uv::WatcherInterop;
 use rt::uv::status_to_maybe_uv_error;
 
-pub struct AsyncWatcher(*uvll::uv_async_t);
+pub struct AsyncWatcher(*'static uvll::uv_async_t);
 impl Watcher for AsyncWatcher { }
 
 impl AsyncWatcher {
@@ -32,7 +32,7 @@ impl AsyncWatcher {
             return watcher;
         }
 
-        extern fn async_cb(handle: *uvll::uv_async_t, status: c_int) {
+        extern fn async_cb(handle: *'static uvll::uv_async_t, status: c_int) {
             let mut watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
             let status = status_to_maybe_uv_error(watcher.native_handle(), status);
             let data = watcher.get_watcher_data();
@@ -58,7 +58,7 @@ impl AsyncWatcher {
             uvll::close(self.native_handle(), close_cb);
         }
 
-        extern fn close_cb(handle: *uvll::uv_stream_t) {
+        extern fn close_cb(handle: *'static uvll::uv_stream_t) {
             let mut watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
             {
                 let data = watcher.get_watcher_data();
@@ -70,8 +70,8 @@ impl AsyncWatcher {
     }
 }
 
-impl NativeHandle<*uvll::uv_async_t> for AsyncWatcher {
-    fn from_native_handle(handle: *uvll::uv_async_t) -> AsyncWatcher {
+impl NativeHandle<*'static uvll::uv_async_t> for AsyncWatcher {
+    fn from_native_handle(handle: *'static uvll::uv_async_t) -> AsyncWatcher {
         AsyncWatcher(handle)
     }
     fn native_handle(&self) -> *uvll::uv_async_t {

--- a/src/libstd/rt/uv/file.rs
+++ b/src/libstd/rt/uv/file.rs
@@ -15,7 +15,7 @@ use rt::uv::{Request, NativeHandle, Loop, FsCallback};
 use rt::uv::uvll;
 use rt::uv::uvll::*;
 
-pub struct FsRequest(*uvll::uv_fs_t);
+pub struct FsRequest(*'static uvll::uv_fs_t);
 impl Request for FsRequest;
 
 impl FsRequest {
@@ -38,8 +38,8 @@ impl FsRequest {
     }
 }
 
-impl NativeHandle<*uvll::uv_fs_t> for FsRequest {
-    fn from_native_handle(handle: *uvll:: uv_fs_t) -> FsRequest {
+impl NativeHandle<*'static uvll::uv_fs_t> for FsRequest {
+    fn from_native_handle(handle: *'static uvll:: uv_fs_t) -> FsRequest {
         FsRequest(handle)
     }
     fn native_handle(&self) -> *uvll::uv_fs_t {

--- a/src/libstd/rt/uv/idle.rs
+++ b/src/libstd/rt/uv/idle.rs
@@ -14,7 +14,7 @@ use rt::uv::uvll;
 use rt::uv::{Watcher, Loop, NativeHandle, IdleCallback, NullCallback};
 use rt::uv::status_to_maybe_uv_error;
 
-pub struct IdleWatcher(*uvll::uv_idle_t);
+pub struct IdleWatcher(*'static uvll::uv_idle_t);
 impl Watcher for IdleWatcher { }
 
 impl IdleWatcher {
@@ -39,7 +39,7 @@ impl IdleWatcher {
             assert!(0 == uvll::idle_start(self.native_handle(), idle_cb))
         };
 
-        extern fn idle_cb(handle: *uvll::uv_idle_t, status: c_int) {
+        extern fn idle_cb(handle: *'static uvll::uv_idle_t, status: c_int) {
             let mut idle_watcher: IdleWatcher = NativeHandle::from_native_handle(handle);
             let data = idle_watcher.get_watcher_data();
             let cb: &IdleCallback = data.idle_cb.get_ref();
@@ -68,7 +68,7 @@ impl IdleWatcher {
 
         unsafe { uvll::close(self.native_handle(), close_cb) };
 
-        extern fn close_cb(handle: *uvll::uv_idle_t) {
+        extern fn close_cb(handle: *'static uvll::uv_idle_t) {
             unsafe {
                 let mut idle_watcher: IdleWatcher = NativeHandle::from_native_handle(handle);
                 {
@@ -82,8 +82,8 @@ impl IdleWatcher {
     }
 }
 
-impl NativeHandle<*uvll::uv_idle_t> for IdleWatcher {
-    fn from_native_handle(handle: *uvll::uv_idle_t) -> IdleWatcher {
+impl NativeHandle<*'static uvll::uv_idle_t> for IdleWatcher {
+    fn from_native_handle(handle: *'static uvll::uv_idle_t) -> IdleWatcher {
         IdleWatcher(handle)
     }
     fn native_handle(&self) -> *uvll::uv_idle_t {

--- a/src/libstd/rt/uv/mod.rs
+++ b/src/libstd/rt/uv/mod.rs
@@ -75,7 +75,7 @@ pub mod async;
 /// with dtors may not be destructured, but tuple structs can,
 /// but the results are not correct.
 pub struct Loop {
-    handle: *uvll::uv_loop_t
+    handle: *'static uvll::uv_loop_t
 }
 
 /// The trait implemented by uv 'watchers' (handles). Watchers are
@@ -110,8 +110,8 @@ impl Loop {
     }
 }
 
-impl NativeHandle<*uvll::uv_loop_t> for Loop {
-    fn from_native_handle(handle: *uvll::uv_loop_t) -> Loop {
+impl NativeHandle<*'static uvll::uv_loop_t> for Loop {
+    fn from_native_handle(handle: *'static uvll::uv_loop_t) -> Loop {
         Loop { handle: handle }
     }
     fn native_handle(&self) -> *uvll::uv_loop_t {
@@ -153,7 +153,7 @@ pub trait WatcherInterop {
     fn drop_watcher_data(&mut self);
 }
 
-impl<H, W: Watcher + NativeHandle<*H>> WatcherInterop for W {
+impl<H, W: Watcher + NativeHandle<*'static H>> WatcherInterop for W {
     /// Get the uv event loop from a Watcher
     pub fn event_loop(&self) -> Loop {
         unsafe {
@@ -241,7 +241,7 @@ fn error_smoke_test() {
     assert_eq!(err.to_str(), ~"EOF: end of file");
 }
 
-pub fn last_uv_error<H, W: Watcher + NativeHandle<*H>>(watcher: &W) -> UvError {
+pub fn last_uv_error<H, W: Watcher + NativeHandle<*'static H>>(watcher: &W) -> UvError {
     unsafe {
         let loop_ = watcher.event_loop();
         UvError(uvll::last_error(loop_.native_handle()))
@@ -314,7 +314,7 @@ pub fn vec_to_uv_buf(v: ~[u8]) -> Buf {
         let data = malloc(v.len() as size_t) as *u8;
         assert!(data.is_not_null());
         do v.as_imm_buf |b, l| {
-            let data = data as *mut u8;
+            let data = data as *'static mut u8;
             ptr::copy_memory(data, b, l)
         }
         uvll::buf_init(data, v.len())

--- a/src/libstd/rt/uv/timer.rs
+++ b/src/libstd/rt/uv/timer.rs
@@ -14,7 +14,7 @@ use rt::uv::uvll;
 use rt::uv::{Watcher, Loop, NativeHandle, TimerCallback, NullCallback};
 use rt::uv::status_to_maybe_uv_error;
 
-pub struct TimerWatcher(*uvll::uv_timer_t);
+pub struct TimerWatcher(*'static uvll::uv_timer_t);
 impl Watcher for TimerWatcher { }
 
 impl TimerWatcher {
@@ -39,7 +39,7 @@ impl TimerWatcher {
             uvll::timer_start(self.native_handle(), timer_cb, timeout, repeat);
         }
 
-        extern fn timer_cb(handle: *uvll::uv_timer_t, status: c_int) {
+        extern fn timer_cb(handle: *'static uvll::uv_timer_t, status: c_int) {
             let mut watcher: TimerWatcher = NativeHandle::from_native_handle(handle);
             let data = watcher.get_watcher_data();
             let cb = data.timer_cb.get_ref();
@@ -66,7 +66,7 @@ impl TimerWatcher {
             uvll::close(watcher.native_handle(), close_cb);
         }
 
-        extern fn close_cb(handle: *uvll::uv_timer_t) {
+        extern fn close_cb(handle: *'static uvll::uv_timer_t) {
             let mut watcher: TimerWatcher = NativeHandle::from_native_handle(handle);
             {
                 let data = watcher.get_watcher_data();
@@ -80,8 +80,8 @@ impl TimerWatcher {
     }
 }
 
-impl NativeHandle<*uvll::uv_timer_t> for TimerWatcher {
-    fn from_native_handle(handle: *uvll::uv_timer_t) -> TimerWatcher {
+impl NativeHandle<*'static uvll::uv_timer_t> for TimerWatcher {
+    fn from_native_handle(handle: *'static uvll::uv_timer_t) -> TimerWatcher {
         TimerWatcher(handle)
     }
     fn native_handle(&self) -> *uvll::uv_idle_t {

--- a/src/libstd/rt/uv/uvll.rs
+++ b/src/libstd/rt/uv/uvll.rs
@@ -52,7 +52,7 @@ pub struct uv_err_t {
 }
 
 pub struct uv_buf_t {
-    base: *u8,
+    base: *'static u8,
     len: libc::size_t,
 }
 
@@ -69,10 +69,10 @@ pub type uv_stream_t = c_void;
 pub type uv_fs_t = c_void;
 pub type uv_udp_send_t = c_void;
 
-pub type uv_idle_cb = *u8;
-pub type uv_alloc_cb = *u8;
-pub type uv_udp_send_cb = *u8;
-pub type uv_udp_recv_cb = *u8;
+pub type uv_idle_cb = *'static u8;
+pub type uv_alloc_cb = *'static u8;
+pub type uv_udp_send_cb = *'static u8;
+pub type uv_udp_recv_cb = *'static u8;
 
 pub type sockaddr = c_void;
 pub type sockaddr_in = c_void;

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -44,16 +44,16 @@ pub struct Process {
      * windows it will be a HANDLE to the process, which will prevent the
      * pid being re-used until the handle is closed.
      */
-    priv handle: *(),
+    priv handle: *'static (),
 
     /// Some(fd), or None when stdin is being redirected from a fd not created by Process::new.
     priv input: Option<c_int>,
 
     /// Some(file), or None when stdout is being redirected to a fd not created by Process::new.
-    priv output: Option<*libc::FILE>,
+    priv output: Option<*'static libc::FILE>,
 
     /// Some(file), or None when stderr is being redirected to a fd not created by Process::new.
-    priv error: Option<*libc::FILE>,
+    priv error: Option<*'static libc::FILE>,
 
     /// None until finish() is called.
     priv exit_code: Option<int>,
@@ -440,7 +440,7 @@ impl Drop for Process {
 
 struct SpawnProcessResult {
     pid: pid_t,
-    handle: *(),
+    handle: *'static (),
 }
 
 #[cfg(windows)]

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -26,6 +26,7 @@ use ptr;
 use str;
 use task;
 use vec::ImmutableVector;
+use vec;
 
 /**
  * A value representing a child process.
@@ -694,46 +695,62 @@ fn spawn_process_os(prog: &str, args: &[~str],
 }
 
 #[cfg(unix)]
-fn with_argv<T>(prog: &str, args: &[~str],
-                cb: &fn(**libc::c_char) -> T) -> T {
-    let mut argptrs = ~[str::as_c_str(prog, |b| b)];
-    let mut tmps = ~[];
+fn with_argv<'a, T>(prog: &'a str, args: &'a [~str], cb: &fn(**libc::c_char) -> T) -> T {
+    // While the interface of this function is safe, the internals is grossly
+    // unsafe because it relies on the inner behavior of strings. While `~str`
+    // strings are guaranteed to be null terminated, `&str` strings are
+    // not.
+    //
+    // In our case, we need to make sure we can get those inner buffers and
+    // guarantee that they live the entire lifetime of this function call.
+    // It's "safe" to get the inner buffer for the `args` arguments, we need to
+    // make an explicit copy of `prog` to make sure it's null terminated.
+    //
+    // Note: we can't use `str::as_c_str` because the `*c_char` cannot live in
+    // the same region as the `&str` because it may make an internal copy of
+    // the string.
+
+    let prog = prog.to_owned();
+
+    let mut ptrs = vec::with_capacity(args.len() + 1);
+    ptrs.push(str::as_buf(prog, |buf, _| buf as *'a libc::c_char));
+
     for args.iter().advance |arg| {
-        let t = @(*arg).clone();
-        tmps.push(t);
-        argptrs.push(str::as_c_str(*t, |b| b));
+        ptrs.push(str::as_buf(*arg, |buf, _| buf as *'a libc::c_char));
     }
-    argptrs.push(ptr::null());
-    argptrs.as_imm_buf(|buf, _len| cb(buf))
+
+    ptrs.push(ptr::null());
+
+    ptrs.as_imm_buf(|buf, _| cb(buf))
 }
 
 #[cfg(unix)]
-fn with_envp<T>(env: Option<&[(~str, ~str)]>, cb: &fn(*c_void) -> T) -> T {
+fn with_envp<'a, T>(env: Option<&'a [(~str, ~str)]>, cb: &fn(*c_void) -> T) -> T {
     // On posixy systems we can pass a char** for envp, which is
-    // a null-terminated array of "k=v\n" strings.
+    // a null-terminated array of "k=v" strings.
     match env {
-      Some(es) => {
-        let mut tmps = ~[];
-        let mut ptrs = ~[];
-
-        for es.iter().advance |pair| {
-            // Use of match here is just to workaround limitations
-            // in the stage0 irrefutable pattern impl.
-            match pair {
-                &(ref k, ref v) => {
-                    let kv = @fmt!("%s=%s", *k, *v);
-                    tmps.push(kv);
-                    ptrs.push(str::as_c_str(*kv, |b| b));
+        Some(env) => {
+            let tmps = do env.map |pair| {
+                // Use of match here is just to workaround limitations
+                // in the stage0 irrefutable pattern impl.
+                match pair {
+                    &(ref k, ref v) => fmt!("%s=%s", *k, *v),
                 }
+            };
+
+            let mut ptrs = vec::with_capacity(env.len() + 1);
+
+            for tmps.iter().advance |kv| {
+                ptrs.push(str::as_buf(*kv, |buf, _| buf as *'a libc::c_char));
+            }
+
+            ptrs.push(ptr::null());
+
+            do ptrs.as_imm_buf |buf, _| {
+                unsafe { cb(cast::transmute(buf)) }
             }
         }
-
-        ptrs.push(ptr::null());
-        ptrs.as_imm_buf(|p, _len|
-            unsafe { cb(::cast::transmute(p)) }
-        )
-      }
-      _ => cb(ptr::null())
+        None => cb(ptr::null())
     }
 }
 

--- a/src/libstd/stackwalk.rs
+++ b/src/libstd/stackwalk.rs
@@ -16,10 +16,10 @@ use unstable::intrinsics;
 pub type Word = uint;
 
 pub struct Frame {
-    fp: *Word
+    fp: *'static Word
 }
 
-pub fn Frame(fp: *Word) -> Frame {
+pub fn Frame(fp: *'static Word) -> Frame {
     Frame {
         fp: fp
     }

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -793,12 +793,12 @@ pub trait StrUtil {
      * let s = "PATH".as_c_str(|path| libc::getenv(path));
      * ~~~
      */
-    fn as_c_str<T>(self, f: &fn(*libc::c_char) -> T) -> T;
+    fn as_c_str<T>(self, f: &fn(*'static libc::c_char) -> T) -> T;
 }
 
 impl<'self> StrUtil for &'self str {
     #[inline]
-    fn as_c_str<T>(self, f: &fn(*libc::c_char) -> T) -> T {
+    fn as_c_str<T>(self, f: &fn(*'static libc::c_char) -> T) -> T {
         do as_buf(self) |buf, len| {
             // NB: len includes the trailing null.
             assert!(len > 0);
@@ -815,7 +815,7 @@ impl<'self> StrUtil for &'self str {
  * Deprecated. Use the `as_c_str` method on strings instead.
  */
 #[inline]
-pub fn as_c_str<T>(s: &str, f: &fn(*libc::c_char) -> T) -> T {
+pub fn as_c_str<T>(s: &str, f: &fn(*'static libc::c_char) -> T) -> T {
     s.as_c_str(f)
 }
 
@@ -828,10 +828,10 @@ pub fn as_c_str<T>(s: &str, f: &fn(*libc::c_char) -> T) -> T {
  * to full strings, or suffixes of them.
  */
 #[inline]
-pub fn as_buf<T>(s: &str, f: &fn(*u8, uint) -> T) -> T {
+pub fn as_buf<T>(s: &str, f: &fn(*'static u8, uint) -> T) -> T {
     unsafe {
-        let v : *(*u8,uint) = transmute(&s);
-        let (buf,len) = *v;
+        let v : *'static (*'static u8, uint) = transmute(&s);
+        let (buf, len) = *v;
         f(buf, len)
     }
 }

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -828,9 +828,9 @@ pub fn as_c_str<T>(s: &str, f: &fn(*'static libc::c_char) -> T) -> T {
  * to full strings, or suffixes of them.
  */
 #[inline]
-pub fn as_buf<T>(s: &str, f: &fn(*'static u8, uint) -> T) -> T {
+pub fn as_buf<'a, T>(s: &'a str, f: &fn(*'a u8, uint) -> T) -> T {
     unsafe {
-        let v : *'static (*'static u8, uint) = transmute(&s);
+        let v : *(*u8, uint) = transmute(&s);
         let (buf, len) = *v;
         f(buf, len)
     }
@@ -3113,9 +3113,10 @@ mod tests {
     fn test_as_buf2() {
         unsafe {
             let s = ~"hello";
-            let sb = as_buf(s, |b, _l| b);
-            let s_cstr = raw::from_buf(sb);
-            assert_eq!(s_cstr, s);
+            do as_buf(s) |b, _l| {
+                let s_cstr = raw::from_buf(b);
+                assert_eq!(s_cstr, s.clone());
+            }
         }
     }
 

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -847,18 +847,18 @@ pub mod raw {
     use vec::MutableVector;
 
     /// Create a Rust string from a null-terminated *u8 buffer
-    pub unsafe fn from_buf(buf: *u8) -> ~str {
+    pub unsafe fn from_buf(buf: *const u8) -> ~str {
         let mut curr = buf;
         let mut i = 0u;
         while *curr != 0u8 {
             i += 1u;
-            curr = ptr::offset(buf, i);
+            curr = ptr::const_offset(buf, i);
         }
         return from_buf_len(buf, i);
     }
 
     /// Create a Rust string from a *u8 buffer of the given length
-    pub unsafe fn from_buf_len(buf: *u8, len: uint) -> ~str {
+    pub unsafe fn from_buf_len(buf: *const u8, len: uint) -> ~str {
         let mut v: ~[u8] = vec::with_capacity(len + 1);
         v.as_mut_buf(|vbuf, _len| {
             ptr::copy_memory(vbuf, buf as *u8, len)
@@ -871,12 +871,12 @@ pub mod raw {
     }
 
     /// Create a Rust string from a null-terminated C string
-    pub unsafe fn from_c_str(c_str: *libc::c_char) -> ~str {
+    pub unsafe fn from_c_str(c_str: *const libc::c_char) -> ~str {
         from_buf(::cast::transmute(c_str))
     }
 
     /// Create a Rust string from a `*c_char` buffer of the given length
-    pub unsafe fn from_c_str_len(c_str: *libc::c_char, len: uint) -> ~str {
+    pub unsafe fn from_c_str_len(c_str: *const libc::c_char, len: uint) -> ~str {
         from_buf_len(::cast::transmute(c_str), len)
     }
 

--- a/src/libstd/sys.rs
+++ b/src/libstd/sys.rs
@@ -23,8 +23,8 @@ use unstable::intrinsics;
 
 /// The representation of a Rust closure
 pub struct Closure {
-    code: *(),
-    env: *(),
+    code: *'static (),
+    env: *'static (),
 }
 
 pub mod rustrt {

--- a/src/libstd/task/local_data_priv.rs
+++ b/src/libstd/task/local_data_priv.rs
@@ -23,8 +23,8 @@ use super::rt::rust_task;
 use rt::task::{Task, LocalStorage};
 
 pub enum Handle {
-    OldHandle(*rust_task),
-    NewHandle(*mut LocalStorage)
+    OldHandle(*'static rust_task),
+    NewHandle(*'static mut LocalStorage)
 }
 
 impl Handle {
@@ -93,7 +93,7 @@ impl<T: 'static> LocalData for T {}
 //
 // n.b. If TLS is used heavily in future, this could be made more efficient with
 //      a proper map.
-type TaskLocalMap = ~[Option<(*libc::c_void, TLSValue, LoanState)>];
+type TaskLocalMap = ~[Option<(*'static libc::c_void, TLSValue, LoanState)>];
 type TLSValue = ~LocalData:;
 
 fn cleanup_task_local_map(map_ptr: *libc::c_void) {

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -106,7 +106,7 @@ use iterator::IteratorUtil;
 // Transitionary.
 #[deriving(Eq)]
 enum TaskHandle {
-    OldTask(*rust_task),
+    OldTask(*'static rust_task),
     NewTask(KillHandle),
 }
 
@@ -765,8 +765,10 @@ fn spawn_raw_oldsched(mut opts: TaskOpts, f: ~fn()) {
     // (3a) If any of those fails, it leaves all groups, and does nothing.
     // (3b) Otherwise it builds a task control structure and puts it in TLS,
     // (4) ...and runs the provided body function.
-    fn make_child_wrapper(child: *rust_task, child_arc: TaskGroupArc,
-                          ancestors: AncestorList, is_main: bool,
+    fn make_child_wrapper(child: *'static rust_task,
+                          child_arc: TaskGroupArc,
+                          ancestors: AncestorList,
+                          is_main: bool,
                           notify_chan: Option<Chan<TaskResult>>,
                           f: ~fn())
                        -> ~fn() {

--- a/src/libstd/to_bytes.rs
+++ b/src/libstd/to_bytes.rs
@@ -335,7 +335,7 @@ impl<A:IterBytes> IterBytes for ~A {
 
 // NB: raw-pointer IterBytes does _not_ dereference
 // to the target; it just gives you the pointer-bytes.
-impl<A> IterBytes for *'static const A {
+impl<'self, A> IterBytes for *'self const A {
     #[inline]
     fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
         (*self as uint).iter_bytes(lsb0, f)

--- a/src/libstd/to_bytes.rs
+++ b/src/libstd/to_bytes.rs
@@ -335,7 +335,7 @@ impl<A:IterBytes> IterBytes for ~A {
 
 // NB: raw-pointer IterBytes does _not_ dereference
 // to the target; it just gives you the pointer-bytes.
-impl<A> IterBytes for *const A {
+impl<A> IterBytes for *'static const A {
     #[inline]
     fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
         (*self as uint).iter_bytes(lsb0, f)

--- a/src/libstd/unstable/atomics.rs
+++ b/src/libstd/unstable/atomics.rs
@@ -56,7 +56,7 @@ pub struct AtomicUint {
  * An unsafe atomic pointer. Only supports basic atomic operations
  */
 pub struct AtomicPtr<T> {
-    priv p: *mut T
+    priv p: *'static mut T
 }
 
 /**
@@ -64,7 +64,7 @@ pub struct AtomicPtr<T> {
  */
 #[unsafe_no_drop_flag]
 pub struct AtomicOption<T> {
-    priv p: *mut c_void
+    priv p: *'static mut c_void
 }
 
 pub enum Ordering {
@@ -208,7 +208,7 @@ impl AtomicUint {
 }
 
 impl<T> AtomicPtr<T> {
-    pub fn new(p: *mut T) -> AtomicPtr<T> {
+    pub fn new(p: *'static mut T) -> AtomicPtr<T> {
         AtomicPtr { p:p }
     }
 
@@ -218,17 +218,20 @@ impl<T> AtomicPtr<T> {
     }
 
     #[inline]
-    pub fn store(&mut self, ptr: *mut T, order: Ordering) {
+    pub fn store(&mut self, ptr: *'static mut T, order: Ordering) {
         unsafe { atomic_store(&mut self.p, ptr, order); }
     }
 
     #[inline]
-    pub fn swap(&mut self, ptr: *mut T, order: Ordering) -> *mut T {
+    pub fn swap(&mut self, ptr: *'static mut T, order: Ordering) -> *mut T {
         unsafe { atomic_swap(&mut self.p, ptr, order) }
     }
 
     #[inline]
-    pub fn compare_and_swap(&mut self, old: *mut T, new: *mut T, order: Ordering) -> *mut T {
+    pub fn compare_and_swap(&mut self,
+                            old: *'static mut T,
+                            new: *'static mut T,
+                            order: Ordering) -> *mut T {
         unsafe { atomic_compare_and_swap(&mut self.p, old, new, order) }
     }
 }

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -22,7 +22,7 @@ use ops::*;
 use option::*;
 use result::*;
 
-pub struct DynamicLibrary { priv handle: *libc::c_void }
+pub struct DynamicLibrary { priv handle: *'static libc::c_void }
 
 impl Drop for DynamicLibrary {
     fn drop(&self) {

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -84,20 +84,20 @@ pub trait TyVisitor {
     fn visit_estr_slice(&self) -> bool;
     fn visit_estr_fixed(&self, n: uint, sz: uint, align: uint) -> bool;
 
-    fn visit_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
-    fn visit_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
-    fn visit_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
-    fn visit_ptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
-    fn visit_rptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_ptr(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool;
 
-    fn visit_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
-    fn visit_unboxed_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
-    fn visit_evec_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
-    fn visit_evec_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
-    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
-    fn visit_evec_slice(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_vec(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool;
     fn visit_evec_fixed(&self, n: uint, sz: uint, align: uint,
-                        mtbl: uint, inner: *'static TyDesc) -> bool;
+                        mtbl: uint, inner: *TyDesc) -> bool;
 
     fn visit_enter_rec(&self, n_fields: uint,
                        sz: uint, align: uint) -> bool;
@@ -105,7 +105,7 @@ pub trait TyVisitor {
                        i: uint,
                        name: &str,
                        mtbl: uint,
-                       inner: *'static TyDesc) -> bool;
+                       inner: *TyDesc) -> bool;
     fn visit_leave_rec(&self, n_fields: uint,
                        sz: uint, align: uint) -> bool;
 
@@ -115,13 +115,13 @@ pub trait TyVisitor {
                          i: uint,
                          name: &str,
                          mtbl: uint,
-                         inner: *'static TyDesc) -> bool;
+                         inner: *TyDesc) -> bool;
     fn visit_leave_class(&self, n_fields: uint,
                          sz: uint, align: uint) -> bool;
 
     fn visit_enter_tup(&self, n_fields: uint,
                        sz: uint, align: uint) -> bool;
-    fn visit_tup_field(&self, i: uint, inner: *'static TyDesc) -> bool;
+    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool;
     fn visit_leave_tup(&self, n_fields: uint,
                        sz: uint, align: uint) -> bool;
 
@@ -132,7 +132,7 @@ pub trait TyVisitor {
                                 disr_val: int,
                                 n_fields: uint,
                                 name: &str) -> bool;
-    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *'static TyDesc) -> bool;
+    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *TyDesc) -> bool;
     fn visit_leave_enum_variant(&self, variant: uint,
                                 disr_val: int,
                                 n_fields: uint,
@@ -143,8 +143,8 @@ pub trait TyVisitor {
 
     fn visit_enter_fn(&self, purity: uint, proto: uint,
                       n_inputs: uint, retstyle: uint) -> bool;
-    fn visit_fn_input(&self, i: uint, mode: uint, inner: *'static TyDesc) -> bool;
-    fn visit_fn_output(&self, retstyle: uint, inner: *'static TyDesc) -> bool;
+    fn visit_fn_input(&self, i: uint, mode: uint, inner: *TyDesc) -> bool;
+    fn visit_fn_output(&self, retstyle: uint, inner: *TyDesc) -> bool;
     fn visit_leave_fn(&self, purity: uint, proto: uint,
                       n_inputs: uint, retstyle: uint) -> bool;
 
@@ -155,7 +155,7 @@ pub trait TyVisitor {
     fn visit_self(&self) -> bool;
     fn visit_type(&self) -> bool;
     fn visit_opaque_box(&self) -> bool;
-    fn visit_constr(&self, inner: *'static TyDesc) -> bool;
+    fn visit_constr(&self, inner: *TyDesc) -> bool;
     fn visit_closure_ptr(&self, ck: uint) -> bool;
 }
 
@@ -311,7 +311,7 @@ extern "rust-intrinsic" {
     /// Returns `true` if a type is managed (will be allocated on the local heap)
     pub fn contains_managed<T>() -> bool;
 
-    pub fn visit_tydesc(td: *'static TyDesc, tv: @TyVisitor);
+    pub fn visit_tydesc(td: *TyDesc, tv: @TyVisitor);
 
     pub fn frame_address(f: &once fn(*u8));
 

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -313,7 +313,7 @@ extern "rust-intrinsic" {
 
     pub fn visit_tydesc(td: *'static TyDesc, tv: @TyVisitor);
 
-    pub fn frame_address(f: &once fn(*'static u8));
+    pub fn frame_address(f: &once fn(*u8));
 
     /// Get the address of the `__morestack` stack growth function.
     pub fn morestack_addr() -> *'static ();

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -84,38 +84,44 @@ pub trait TyVisitor {
     fn visit_estr_slice(&self) -> bool;
     fn visit_estr_fixed(&self, n: uint, sz: uint, align: uint) -> bool;
 
-    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool;
-    fn visit_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool;
-    fn visit_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool;
-    fn visit_ptr(&self, mtbl: uint, inner: *TyDesc) -> bool;
-    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_ptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_rptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
 
-    fn visit_vec(&self, mtbl: uint, inner: *TyDesc) -> bool;
-    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool;
-    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool;
-    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool;
-    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool;
-    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_unboxed_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_evec_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_evec_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
+    fn visit_evec_slice(&self, mtbl: uint, inner: *'static TyDesc) -> bool;
     fn visit_evec_fixed(&self, n: uint, sz: uint, align: uint,
-                        mtbl: uint, inner: *TyDesc) -> bool;
+                        mtbl: uint, inner: *'static TyDesc) -> bool;
 
     fn visit_enter_rec(&self, n_fields: uint,
                        sz: uint, align: uint) -> bool;
-    fn visit_rec_field(&self, i: uint, name: &str,
-                       mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_rec_field(&self,
+                       i: uint,
+                       name: &str,
+                       mtbl: uint,
+                       inner: *'static TyDesc) -> bool;
     fn visit_leave_rec(&self, n_fields: uint,
                        sz: uint, align: uint) -> bool;
 
     fn visit_enter_class(&self, n_fields: uint,
                          sz: uint, align: uint) -> bool;
-    fn visit_class_field(&self, i: uint, name: &str,
-                         mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_class_field(&self,
+                         i: uint,
+                         name: &str,
+                         mtbl: uint,
+                         inner: *'static TyDesc) -> bool;
     fn visit_leave_class(&self, n_fields: uint,
                          sz: uint, align: uint) -> bool;
 
     fn visit_enter_tup(&self, n_fields: uint,
                        sz: uint, align: uint) -> bool;
-    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool;
+    fn visit_tup_field(&self, i: uint, inner: *'static TyDesc) -> bool;
     fn visit_leave_tup(&self, n_fields: uint,
                        sz: uint, align: uint) -> bool;
 
@@ -126,7 +132,7 @@ pub trait TyVisitor {
                                 disr_val: int,
                                 n_fields: uint,
                                 name: &str) -> bool;
-    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *TyDesc) -> bool;
+    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *'static TyDesc) -> bool;
     fn visit_leave_enum_variant(&self, variant: uint,
                                 disr_val: int,
                                 n_fields: uint,
@@ -137,8 +143,8 @@ pub trait TyVisitor {
 
     fn visit_enter_fn(&self, purity: uint, proto: uint,
                       n_inputs: uint, retstyle: uint) -> bool;
-    fn visit_fn_input(&self, i: uint, mode: uint, inner: *TyDesc) -> bool;
-    fn visit_fn_output(&self, retstyle: uint, inner: *TyDesc) -> bool;
+    fn visit_fn_input(&self, i: uint, mode: uint, inner: *'static TyDesc) -> bool;
+    fn visit_fn_output(&self, retstyle: uint, inner: *'static TyDesc) -> bool;
     fn visit_leave_fn(&self, purity: uint, proto: uint,
                       n_inputs: uint, retstyle: uint) -> bool;
 
@@ -149,7 +155,7 @@ pub trait TyVisitor {
     fn visit_self(&self) -> bool;
     fn visit_type(&self) -> bool;
     fn visit_opaque_box(&self) -> bool;
-    fn visit_constr(&self, inner: *TyDesc) -> bool;
+    fn visit_constr(&self, inner: *'static TyDesc) -> bool;
     fn visit_closure_ptr(&self, ck: uint) -> bool;
 }
 
@@ -280,7 +286,7 @@ extern "rust-intrinsic" {
     pub fn pref_align_of<T>() -> uint;
 
     /// Get a static pointer to a type descriptor.
-    pub fn get_tydesc<T>() -> *TyDesc;
+    pub fn get_tydesc<T>() -> *'static TyDesc;
 
     /// Create a value initialized to zero.
     ///
@@ -305,33 +311,33 @@ extern "rust-intrinsic" {
     /// Returns `true` if a type is managed (will be allocated on the local heap)
     pub fn contains_managed<T>() -> bool;
 
-    pub fn visit_tydesc(td: *TyDesc, tv: @TyVisitor);
+    pub fn visit_tydesc(td: *'static TyDesc, tv: @TyVisitor);
 
-    pub fn frame_address(f: &once fn(*u8));
+    pub fn frame_address(f: &once fn(*'static u8));
 
     /// Get the address of the `__morestack` stack growth function.
-    pub fn morestack_addr() -> *();
+    pub fn morestack_addr() -> *'static ();
 
     /// Equivalent to the `llvm.memcpy.p0i8.0i8.i32` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memcpy32<T>(dst: *mut T, src: *T, count: u32);
+    pub fn memcpy32<T>(dst: *'static mut T, src: *'static T, count: u32);
     /// Equivalent to the `llvm.memcpy.p0i8.0i8.i64` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memcpy64<T>(dst: *mut T, src: *T, count: u64);
+    pub fn memcpy64<T>(dst: *'static mut T, src: *'static T, count: u64);
 
     /// Equivalent to the `llvm.memmove.p0i8.0i8.i32` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memmove32<T>(dst: *mut T, src: *T, count: u32);
+    pub fn memmove32<T>(dst: *'static mut T, src: *'static T, count: u32);
     /// Equivalent to the `llvm.memmove.p0i8.0i8.i64` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memmove64<T>(dst: *mut T, src: *T, count: u64);
+    pub fn memmove64<T>(dst: *'static mut T, src: *'static T, count: u64);
 
     /// Equivalent to the `llvm.memset.p0i8.i32` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memset32<T>(dst: *mut T, val: u8, count: u32);
+    pub fn memset32<T>(dst: *'static mut T, val: u8, count: u32);
     /// Equivalent to the `llvm.memset.p0i8.i64` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memset64<T>(dst: *mut T, val: u8, count: u64);
+    pub fn memset64<T>(dst: *'static mut T, val: u8, count: u64);
 
     pub fn sqrtf32(x: f32) -> f32;
     pub fn sqrtf64(x: f64) -> f64;

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -320,24 +320,24 @@ extern "rust-intrinsic" {
 
     /// Equivalent to the `llvm.memcpy.p0i8.0i8.i32` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memcpy32<T>(dst: *'static mut T, src: *'static T, count: u32);
+    pub fn memcpy32<T>(dst: *mut T, src: *T, count: u32);
     /// Equivalent to the `llvm.memcpy.p0i8.0i8.i64` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memcpy64<T>(dst: *'static mut T, src: *'static T, count: u64);
+    pub fn memcpy64<T>(dst: *mut T, src: *T, count: u64);
 
     /// Equivalent to the `llvm.memmove.p0i8.0i8.i32` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memmove32<T>(dst: *'static mut T, src: *'static T, count: u32);
+    pub fn memmove32<T>(dst: *mut T, src: *T, count: u32);
     /// Equivalent to the `llvm.memmove.p0i8.0i8.i64` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memmove64<T>(dst: *'static mut T, src: *'static T, count: u64);
+    pub fn memmove64<T>(dst: *mut T, src: *T, count: u64);
 
     /// Equivalent to the `llvm.memset.p0i8.i32` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memset32<T>(dst: *'static mut T, val: u8, count: u32);
+    pub fn memset32<T>(dst: *mut T, val: u8, count: u32);
     /// Equivalent to the `llvm.memset.p0i8.i64` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
-    pub fn memset64<T>(dst: *'static mut T, val: u8, count: u64);
+    pub fn memset64<T>(dst: *mut T, val: u8, count: u64);
 
     pub fn sqrtf32(x: f32) -> f32;
     pub fn sqrtf64(x: f64) -> f64;

--- a/src/libstd/unstable/lang.rs
+++ b/src/libstd/unstable/lang.rs
@@ -101,14 +101,14 @@ pub unsafe fn borrow_as_mut(a: *u8, file: *c_char, line: size_t) -> uint {
 }
 
 #[lang="record_borrow"]
-pub unsafe fn record_borrow(a: *u8, old_ref_count: uint,
-                            file: *c_char, line: size_t) {
+pub unsafe fn record_borrow(a: *'static u8, old_ref_count: uint,
+                            file: *'static c_char, line: size_t) {
     borrowck::record_borrow(a, old_ref_count, file, line)
 }
 
 #[lang="unrecord_borrow"]
-pub unsafe fn unrecord_borrow(a: *u8, old_ref_count: uint,
-                              file: *c_char, line: size_t) {
+pub unsafe fn unrecord_borrow(a: *'static u8, old_ref_count: uint,
+                              file: *'static c_char, line: size_t) {
     borrowck::unrecord_borrow(a, old_ref_count, file, line)
 }
 

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -27,7 +27,7 @@ use kinds::Send;
 ///
 /// Enforces no shared-memory safety.
 pub struct UnsafeAtomicRcBox<T> {
-    data: *mut libc::c_void,
+    data: *'static mut libc::c_void,
 }
 
 struct AtomicRcBoxData<T> {
@@ -237,7 +237,7 @@ impl<T> Drop for UnsafeAtomicRcBox<T>{
 /****************************************************************************/
 
 #[allow(non_camel_case_types)] // runtime type
-type rust_little_lock = *libc::c_void;
+type rust_little_lock = *'static libc::c_void;
 
 pub struct LittleLock {
     l: rust_little_lock,

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2148,8 +2148,8 @@ macro_rules! double_ended_iterator {
 //iterator!{struct VecIterator -> *T, &'self T}
 /// An iterator for iterating over a vector.
 pub struct VecIterator<'self, T> {
-    priv ptr: *'static T,
-    priv end: *'static T,
+    priv ptr: *'self T,
+    priv end: *'self T,
     priv lifetime: &'self T // FIXME: #5922
 }
 iterator!{impl VecIterator -> &'self T}
@@ -2163,8 +2163,8 @@ impl<'self, T> Clone for VecIterator<'self, T> {
 //iterator!{struct VecMutIterator -> *mut T, &'self mut T}
 /// An iterator for mutating the elements of a vector.
 pub struct VecMutIterator<'self, T> {
-    priv ptr: *'static mut T,
-    priv end: *'static mut T,
+    priv ptr: *'self mut T,
+    priv end: *'self mut T,
     priv lifetime: &'self mut T // FIXME: #5922
 }
 iterator!{impl VecMutIterator -> &'self mut T}

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1688,7 +1688,7 @@ pub trait MutableVector<'self, T> {
      */
     fn move_from(self, src: ~[T], start: uint, end: uint) -> uint;
 
-    unsafe fn unsafe_mut_ref(&self, index: uint) -> *mut T;
+    unsafe fn unsafe_mut_ref(&self, index: uint) -> *'self mut T;
     unsafe fn unsafe_set(&self, index: uint, val: T);
 
     fn as_mut_buf<U>(&self, f: &fn(*'static mut T, uint) -> U) -> U;
@@ -1770,7 +1770,7 @@ impl<'self,T> MutableVector<'self, T> for &'self mut [T] {
     }
 
     #[inline]
-    unsafe fn unsafe_mut_ref(&self, index: uint) -> *mut T {
+    unsafe fn unsafe_mut_ref(&self, index: uint) -> *'self mut T {
         let pair_ptr: &(*mut T, uint) = transmute(self);
         let (ptr, _) = *pair_ptr;
         ptr.offset(index)
@@ -1886,7 +1886,7 @@ pub mod raw {
      * would also make any pointers to it invalid.
      */
     #[inline]
-    pub fn to_ptr<T>(v: &[T]) -> *'static T {
+    pub fn to_ptr<'a, T>(v: &[T]) -> *'a T {
         unsafe {
             let repr: *'static *'static SliceRepr = transmute(&v);
             transmute(&((**repr).data))
@@ -1895,7 +1895,7 @@ pub mod raw {
 
     /** see `to_ptr()` */
     #[inline]
-    pub fn to_mut_ptr<T>(v: &mut [T]) -> *'static mut T {
+    pub fn to_mut_ptr<'a, T>(v: &mut [T]) -> *'a mut T {
         unsafe {
             let repr: **SliceRepr = transmute(&v);
             transmute(&((**repr).data))

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -773,7 +773,7 @@ pub enum ty_ {
     ty_uniq(mt),
     ty_vec(mt),
     ty_fixed_length_vec(mt, @expr),
-    ty_ptr(mt),
+    ty_ptr(Option<Lifetime>, mt),
     ty_rptr(Option<Lifetime>, mt),
     ty_closure(@TyClosure),
     ty_bare_fn(@TyBareFn),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -666,7 +666,7 @@ pub fn noop_fold_ty(t: &ty_, fld: @ast_fold) -> ty_ {
         ty_box(ref mt) => ty_box(fold_mt(mt, fld)),
         ty_uniq(ref mt) => ty_uniq(fold_mt(mt, fld)),
         ty_vec(ref mt) => ty_vec(fold_mt(mt, fld)),
-        ty_ptr(ref mt) => ty_ptr(fold_mt(mt, fld)),
+        ty_ptr(region, ref mt) => ty_ptr(region, fold_mt(mt, fld)),
         ty_rptr(region, ref mt) => ty_rptr(region, fold_mt(mt, fld)),
         ty_closure(ref f) => {
             ty_closure(@TyClosure {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -986,7 +986,7 @@ impl Parser {
         } else if *self.token == token::BINOP(token::STAR) {
             // STAR POINTER (bare pointer?)
             self.bump();
-            ty_ptr(self.parse_mt())
+            self.parse_star_pointee()
         } else if *self.token == token::LBRACE {
             // STRUCTURAL RECORD (remove?)
             let elems = self.parse_unspanned_seq(
@@ -1084,16 +1084,21 @@ impl Parser {
         ctor(mt)
     }
 
+    pub fn parse_star_pointee(&self) -> ty_ {
+        // look for `*'lt` or `*'foo ` and interpret `foo` as the region name:
+        let opt_lifetime = self.parse_opt_lifetime();
+        ty_ptr(opt_lifetime, self.parse_mt())
+    }
+
     pub fn parse_borrowed_pointee(&self) -> ty_ {
         // look for `&'lt` or `&'foo ` and interpret `foo` as the region name:
         let opt_lifetime = self.parse_opt_lifetime();
 
         if self.token_is_closure_keyword(self.token) {
-            return self.parse_ty_closure(BorrowedSigil, opt_lifetime);
+            self.parse_ty_closure(BorrowedSigil, opt_lifetime)
+        } else {
+            ty_rptr(opt_lifetime, self.parse_mt())
         }
-
-        let mt = self.parse_mt();
-        return ty_rptr(opt_lifetime, mt);
     }
 
     // parse an optional, obsolete argument mode.

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -394,7 +394,11 @@ pub fn print_type(s: @ps, ty: &ast::Ty) {
         print_type(s, mt.ty);
         word(s.s, "]");
       }
-      ast::ty_ptr(ref mt) => { word(s.s, "*"); print_mt(s, mt); }
+      ast::ty_ptr(ref lifetime, ref mt) => {
+          word(s.s, "*");
+          print_opt_lifetime(s, lifetime);
+          print_mt(s, mt);
+      }
       ast::ty_rptr(ref lifetime, ref mt) => {
           word(s.s, "&");
           print_opt_lifetime(s, lifetime);

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -246,7 +246,7 @@ pub fn skip_ty<E>(_t: &Ty, (_e,_v): (E, vt<E>)) {}
 pub fn visit_ty<E:Clone>(t: &Ty, (e, v): (E, vt<E>)) {
     match t.node {
         ty_box(ref mt) | ty_uniq(ref mt) |
-        ty_vec(ref mt) | ty_ptr(ref mt) | ty_rptr(_, ref mt) => {
+        ty_vec(ref mt) | ty_ptr(_, ref mt) | ty_rptr(_, ref mt) => {
             (v.visit_ty)(mt.ty, (e, v));
         },
         ty_tup(ref ts) => {

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -75,11 +75,11 @@ struct AminoAcid {
 
 struct RepeatFasta {
     alu: &'static str,
-    stdout: *FILE,
+    stdout: *'static FILE,
 }
 
 impl RepeatFasta {
-    fn new(stdout: *FILE, alu: &'static str) -> RepeatFasta {
+    fn new(stdout: *'static FILE, alu: &'static str) -> RepeatFasta {
         RepeatFasta {
             alu: alu,
             stdout: stdout,
@@ -118,12 +118,12 @@ impl RepeatFasta {
 
 struct RandomFasta {
     seed: u32,
-    stdout: *FILE,
+    stdout: *'static FILE,
     lookup: [AminoAcid, ..LOOKUP_SIZE],
 }
 
 impl RandomFasta {
-    fn new(stdout: *FILE, a: &[AminoAcid]) -> RandomFasta {
+    fn new(stdout: *'static FILE, a: &[AminoAcid]) -> RandomFasta {
         RandomFasta {
             seed: 42,
             stdout: stdout,

--- a/src/test/compile-fail/const-cast-different-types.rs
+++ b/src/test/compile-fail/const-cast-different-types.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 static a: &'static str = &"foo";
-static b: *u8 = a as *u8; //~ ERROR non-scalar cast
-static c: *u8 = &a as *u8; //~ ERROR mismatched types
+static b: *'static u8 = a as *u8; //~ ERROR non-scalar cast
+static c: *'static u8 = &a as *u8; //~ ERROR mismatched types
 
 fn main() {
 }

--- a/src/test/compile-fail/const-cast-wrong-type.rs
+++ b/src/test/compile-fail/const-cast-wrong-type.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 static a: [u8, ..3] = ['h' as u8, 'i' as u8, 0 as u8];
-static b: *i8 = &a as *i8; //~ ERROR mismatched types
+static b: *'static i8 = &a as *'static i8; //~ ERROR mismatched types
 
 fn main() {
 }

--- a/src/test/compile-fail/extern-no-call.rs
+++ b/src/test/compile-fail/extern-no-call.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:expected function but found `*u8`
+// error-pattern:expected function but found `*'static u8`
 extern fn f() {
 }
 

--- a/src/test/compile-fail/extern-wrong-value-type.rs
+++ b/src/test/compile-fail/extern-wrong-value-type.rs
@@ -12,6 +12,6 @@ extern fn f() {
 }
 
 fn main() {
-    // extern functions are *u8 types
-    let _x: &fn() = f; //~ ERROR found `*u8`
+    // extern functions are *'static u8 types
+    let _x: &fn() = f; //~ ERROR found `*'static u8`
 }

--- a/src/test/compile-fail/unsafe-fn-autoderef.rs
+++ b/src/test/compile-fail/unsafe-fn-autoderef.rs
@@ -27,7 +27,7 @@ fn f(p: *Rec) -> int {
     // are prohibited by various checks, such as that the enum is
     // instantiable and so forth).
 
-    return p.f; //~ ERROR attempted access of field `f` on type `*'static Rec`
+    return p.f; //~ ERROR attempted access of field `f` on type `*Rec`
 }
 
 fn main() {

--- a/src/test/compile-fail/unsafe-fn-autoderef.rs
+++ b/src/test/compile-fail/unsafe-fn-autoderef.rs
@@ -27,7 +27,7 @@ fn f(p: *Rec) -> int {
     // are prohibited by various checks, such as that the enum is
     // instantiable and so forth).
 
-    return p.f; //~ ERROR attempted access of field `f` on type `*Rec`
+    return p.f; //~ ERROR attempted access of field `f` on type `*'static Rec`
 }
 
 fn main() {

--- a/src/test/run-fail/unwind-box-res.rs
+++ b/src/test/run-fail/unwind-box-res.rs
@@ -17,7 +17,7 @@ fn failfn() {
 }
 
 struct r {
-  v: *int,
+  v: *'static int,
 }
 
 impl Drop for r {
@@ -28,7 +28,7 @@ impl Drop for r {
     }
 }
 
-fn r(v: *int) -> r {
+fn r(v: *'static int) -> r {
     r {
         v: v
     }

--- a/src/test/run-pass/attr-start.rs
+++ b/src/test/run-pass/attr-start.rs
@@ -11,6 +11,6 @@
 //xfail-fast
 
 #[start]
-fn start(argc:int, argv: **u8, crate_map: *u8) -> int {
+fn start(argc:int, argv: *'static *'static u8, crate_map: *'static u8) -> int {
     return 0;
 }

--- a/src/test/run-pass/const-cast-ptr-int.rs
+++ b/src/test/run-pass/const-cast-ptr-int.rs
@@ -10,7 +10,7 @@
 
 use std::ptr;
 
-static a: *u8 = 0 as *u8;
+static a: *'static u8 = 0 as *'static u8;
 
 pub fn main() {
     assert_eq!(a, ptr::null());

--- a/src/test/run-pass/const-cast.rs
+++ b/src/test/run-pass/const-cast.rs
@@ -12,10 +12,10 @@ use std::libc;
 
 extern fn foo() {}
 
-static x: *u8 = foo;
-static y: *libc::c_void = x as *libc::c_void;
+static x: *'static u8 = foo;
+static y: *'static libc::c_void = x as *'static libc::c_void;
 static a: &'static int = &10;
-static b: *int = a as *int;
+static b: *'static int = a as *'static int;
 
 pub fn main() {
     assert_eq!(x as *libc::c_void, y);

--- a/src/test/run-pass/const-cross-crate-extern.rs
+++ b/src/test/run-pass/const-cross-crate-extern.rs
@@ -13,7 +13,7 @@
 
 extern mod cci_const;
 use cci_const::bar;
-static foo: *u8 = bar;
+static foo: *'static u8 = bar;
 
 pub fn main() {
     assert_eq!(foo, cci_const::bar);

--- a/src/test/run-pass/const-extern-function.rs
+++ b/src/test/run-pass/const-extern-function.rs
@@ -10,11 +10,11 @@
 
 extern fn foopy() {}
 
-static f: *u8 = foopy;
+static f: *'static u8 = foopy;
 static s: S = S { f: foopy };
 
 struct S {
-    f: *u8
+    f: *'static u8
 }
 
 pub fn main() {

--- a/src/test/run-pass/const-str-ptr.rs
+++ b/src/test/run-pass/const-str-ptr.rs
@@ -12,7 +12,7 @@ use std::str;
 
 static a: [u8, ..3] = ['h' as u8, 'i' as u8, 0 as u8];
 static c: &'static [u8, ..3] = &a;
-static b: *u8 = c as *u8;
+static b: *'static u8 = c as *'static u8;
 
 pub fn main() {
     let foo = &a as *u8;

--- a/src/test/run-pass/core-rt-smoke.rs
+++ b/src/test/run-pass/core-rt-smoke.rs
@@ -13,7 +13,7 @@
 // A simple test of starting the runtime manually
 
 #[start]
-fn start(argc: int, argv: **u8, crate_map: *u8) -> int {
+fn start(argc: int, argv: *'static *'static u8, crate_map: *'static u8) -> int {
     do std::rt::start(argc, argv, crate_map) {
         info!("creating my own runtime is joy");
     }

--- a/src/test/run-pass/instantiable.rs
+++ b/src/test/run-pass/instantiable.rs
@@ -14,7 +14,7 @@ use std::ptr;
 // even though it would be if the nxt field had type @foo:
 struct foo(X);
 
-struct X { x: uint, nxt: *foo }
+struct X { x: uint, nxt: *'static foo }
 
 pub fn main() {
     let x = foo(X {x: 0, nxt: ptr::null()});

--- a/src/test/run-pass/intrinsic-frame-address.rs
+++ b/src/test/run-pass/intrinsic-frame-address.rs
@@ -13,7 +13,7 @@
 mod rusti {
     #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
-        pub fn frame_address(f: &once fn(*u8));
+        pub fn frame_address(f: &once fn(*'static u8));
     }
 }
 

--- a/src/test/run-pass/intrinsic-frame-address.rs
+++ b/src/test/run-pass/intrinsic-frame-address.rs
@@ -13,7 +13,7 @@
 mod rusti {
     #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
-        pub fn frame_address(f: &once fn(*'static u8));
+        pub fn frame_address(f: &once fn(*u8));
     }
 }
 

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -155,7 +155,7 @@ pub mod pipes {
     }
 
     pub struct send_packet<T> {
-        p: Option<*packet<T>>,
+        p: Option<*'static packet<T>>,
     }
 
     #[unsafe_destructor]
@@ -178,14 +178,14 @@ pub mod pipes {
         }
     }
 
-    pub fn send_packet<T:Send>(p: *packet<T>) -> send_packet<T> {
+    pub fn send_packet<T:Send>(p: *'static packet<T>) -> send_packet<T> {
         send_packet {
             p: Some(p)
         }
     }
 
     pub struct recv_packet<T> {
-        p: Option<*packet<T>>,
+        p: Option<*'static packet<T>>,
     }
 
     #[unsafe_destructor]
@@ -208,7 +208,7 @@ pub mod pipes {
         }
     }
 
-    pub fn recv_packet<T:Send>(p: *packet<T>) -> recv_packet<T> {
+    pub fn recv_packet<T:Send>(p: *'static packet<T>) -> recv_packet<T> {
         recv_packet {
             p: Some(p)
         }

--- a/src/test/run-pass/issue-3656.rs
+++ b/src/test/run-pass/issue-3656.rs
@@ -18,7 +18,7 @@ use std::libc::*;
 struct KEYGEN {
     hash_algorithm: [c_uint, ..2],
     count: uint32_t,
-    salt: *c_void,
+    salt: *'static c_void,
     salt_size: uint32_t,
 }
 

--- a/src/test/run-pass/issue-4735.rs
+++ b/src/test/run-pass/issue-4735.rs
@@ -12,7 +12,7 @@
 use std::cast::transmute;
 use std::libc::c_void;
 
-struct NonCopyable(*c_void);
+struct NonCopyable(*'static c_void);
 
 impl Drop for NonCopyable {
     fn drop(&self) {

--- a/src/test/run-pass/morestack-address.rs
+++ b/src/test/run-pass/morestack-address.rs
@@ -12,7 +12,7 @@ mod rusti {
     #[nolink]
     #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
-        pub fn morestack_addr() -> *();
+        pub fn morestack_addr() -> *'static ();
     }
 }
 

--- a/src/test/run-pass/reflect-visit-data.rs
+++ b/src/test/run-pass/reflect-visit-data.rs
@@ -211,42 +211,42 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<@u8>();
         if ! self.inner.visit_box(mtbl, inner) { return false; }
         self.bump_past::<@u8>();
         true
     }
 
-    fn visit_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_ptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_ptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<*u8>();
         if ! self.inner.visit_ptr(mtbl, inner) { return false; }
         self.bump_past::<*u8>();
         true
     }
 
-    fn visit_rptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<&'static u8>();
         if ! self.inner.visit_rptr(mtbl, inner) { return false; }
         self.bump_past::<&'static u8>();
         true
     }
 
-    fn visit_unboxed_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<UnboxedVecRepr>();
         // FIXME (#3732): Inner really has to move its own pointers on this one.
         // or else possibly we could have some weird interface wherein we
@@ -256,35 +256,35 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_vec(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<@[u8]>();
         if ! self.inner.visit_evec_box(mtbl, inner) { return false; }
         self.bump_past::<@[u8]>();
         true
     }
 
-    fn visit_evec_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_evec_uniq(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[@u8]>();
         if ! self.inner.visit_evec_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~[@u8]>();
         true
     }
 
-    fn visit_evec_slice(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<&'static [u8]>();
         if ! self.inner.visit_evec_slice(mtbl, inner) { return false; }
         self.bump_past::<&'static [u8]>();
@@ -292,7 +292,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
     }
 
     fn visit_evec_fixed(&self, n: uint, sz: uint, align: uint,
-                        mtbl: uint, inner: *'static TyDesc) -> bool {
+                        mtbl: uint, inner: *TyDesc) -> bool {
         self.align(align);
         if ! self.inner.visit_evec_fixed(n, sz, align, mtbl, inner) {
             return false;
@@ -308,7 +308,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
     }
 
     fn visit_rec_field(&self, i: uint, name: &str,
-                       mtbl: uint, inner: *'static TyDesc) -> bool {
+                       mtbl: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_rec_field(i, name, mtbl, inner) { return false; }
         true
     }
@@ -328,7 +328,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
     }
 
     fn visit_class_field(&self, i: uint, name: &str,
-                         mtbl: uint, inner: *'static TyDesc) -> bool {
+                         mtbl: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_class_field(i, name, mtbl, inner) {
             return false;
         }
@@ -349,7 +349,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_tup_field(&self, i: uint, inner: *'static TyDesc) -> bool {
+    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_tup_field(i, inner) { return false; }
         true
     }
@@ -367,12 +367,12 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_fn_input(&self, i: uint, mode: uint, inner: *'static TyDesc) -> bool {
+    fn visit_fn_input(&self, i: uint, mode: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_fn_input(i, mode, inner) { return false; }
         true
     }
 
-    fn visit_fn_output(&self, retstyle: uint, inner: *'static TyDesc) -> bool {
+    fn visit_fn_output(&self, retstyle: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_fn_output(retstyle, inner) { return false; }
         true
     }
@@ -405,7 +405,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *'static TyDesc) -> bool {
+    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_enum_variant_field(i, offset, inner) { return false; }
         true
     }
@@ -470,7 +470,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_constr(&self, inner: *'static TyDesc) -> bool {
+    fn visit_constr(&self, inner: *TyDesc) -> bool {
         if ! self.inner.visit_constr(inner) { return false; }
         true
     }
@@ -498,7 +498,7 @@ impl my_visitor {
         }
     }
 
-    pub fn visit_inner(&self, inner: *'static TyDesc) -> bool {
+    pub fn visit_inner(&self, inner: *TyDesc) -> bool {
         unsafe {
             let u = my_visitor(**self);
             let v = ptr_visit_adaptor::<my_visitor>(Inner {inner: u});
@@ -556,25 +556,25 @@ impl TyVisitor for my_visitor {
     fn visit_estr_fixed(&self, _n: uint, _sz: uint,
                         _align: uint) -> bool { true }
 
-    fn visit_box(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_uniq(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_uniq_managed(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_ptr(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_rptr(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_uniq(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_uniq_managed(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_ptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_rptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
 
-    fn visit_vec(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_evec_box(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_evec_uniq(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_evec_uniq_managed(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_evec_slice(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_uniq(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_uniq_managed(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_slice(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_evec_fixed(&self, _n: uint, _sz: uint, _align: uint,
-                        _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+                        _mtbl: uint, _inner: *TyDesc) -> bool { true }
 
     fn visit_enter_rec(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
     fn visit_rec_field(&self, _i: uint, _name: &str,
-                       _mtbl: uint, inner: *'static TyDesc) -> bool {
+                       _mtbl: uint, inner: *TyDesc) -> bool {
         error!("rec field!");
         self.visit_inner(inner)
     }
@@ -584,7 +584,7 @@ impl TyVisitor for my_visitor {
     fn visit_enter_class(&self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool { true }
     fn visit_class_field(&self, _i: uint, _name: &str,
-                         _mtbl: uint, inner: *'static TyDesc) -> bool {
+                         _mtbl: uint, inner: *TyDesc) -> bool {
         self.visit_inner(inner)
     }
     fn visit_leave_class(&self, _n_fields: uint,
@@ -592,7 +592,7 @@ impl TyVisitor for my_visitor {
 
     fn visit_enter_tup(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
-    fn visit_tup_field(&self, _i: uint, inner: *'static TyDesc) -> bool {
+    fn visit_tup_field(&self, _i: uint, inner: *TyDesc) -> bool {
         error!("tup field!");
         self.visit_inner(inner)
     }
@@ -609,7 +609,7 @@ impl TyVisitor for my_visitor {
                                 _disr_val: int,
                                 _n_fields: uint,
                                 _name: &str) -> bool { true }
-    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, inner: *'static TyDesc) -> bool {
+    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, inner: *TyDesc) -> bool {
         self.visit_inner(inner)
     }
     fn visit_leave_enum_variant(&self, _variant: uint,
@@ -622,10 +622,10 @@ impl TyVisitor for my_visitor {
 
     fn visit_enter_fn(&self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
-    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *'static TyDesc) -> bool {
+    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool {
         true
     }
-    fn visit_fn_output(&self, _retstyle: uint, _inner: *'static TyDesc) -> bool {
+    fn visit_fn_output(&self, _retstyle: uint, _inner: *TyDesc) -> bool {
         true
     }
     fn visit_leave_fn(&self, _purity: uint, _proto: uint,
@@ -639,7 +639,7 @@ impl TyVisitor for my_visitor {
     fn visit_self(&self) -> bool { true }
     fn visit_type(&self) -> bool { true }
     fn visit_opaque_box(&self) -> bool { true }
-    fn visit_constr(&self, _inner: *'static TyDesc) -> bool { true }
+    fn visit_constr(&self, _inner: *TyDesc) -> bool { true }
     fn visit_closure_ptr(&self, _ck: uint) -> bool { true }
 }
 

--- a/src/test/run-pass/reflect-visit-data.rs
+++ b/src/test/run-pass/reflect-visit-data.rs
@@ -211,42 +211,42 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<@u8>();
         if ! self.inner.visit_box(mtbl, inner) { return false; }
         self.bump_past::<@u8>();
         true
     }
 
-    fn visit_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_ptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_ptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<*u8>();
         if ! self.inner.visit_ptr(mtbl, inner) { return false; }
         self.bump_past::<*u8>();
         true
     }
 
-    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_rptr(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<&'static u8>();
         if ! self.inner.visit_rptr(mtbl, inner) { return false; }
         self.bump_past::<&'static u8>();
         true
     }
 
-    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_unboxed_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<UnboxedVecRepr>();
         // FIXME (#3732): Inner really has to move its own pointers on this one.
         // or else possibly we could have some weird interface wherein we
@@ -256,35 +256,35 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_vec(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_vec(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_box(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<@[u8]>();
         if ! self.inner.visit_evec_box(mtbl, inner) { return false; }
         self.bump_past::<@[u8]>();
         true
     }
 
-    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_evec_uniq(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<~[@u8]>();
         if ! self.inner.visit_evec_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~[@u8]>();
         true
     }
 
-    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_slice(&self, mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align_to::<&'static [u8]>();
         if ! self.inner.visit_evec_slice(mtbl, inner) { return false; }
         self.bump_past::<&'static [u8]>();
@@ -292,7 +292,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
     }
 
     fn visit_evec_fixed(&self, n: uint, sz: uint, align: uint,
-                        mtbl: uint, inner: *TyDesc) -> bool {
+                        mtbl: uint, inner: *'static TyDesc) -> bool {
         self.align(align);
         if ! self.inner.visit_evec_fixed(n, sz, align, mtbl, inner) {
             return false;
@@ -308,7 +308,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
     }
 
     fn visit_rec_field(&self, i: uint, name: &str,
-                       mtbl: uint, inner: *TyDesc) -> bool {
+                       mtbl: uint, inner: *'static TyDesc) -> bool {
         if ! self.inner.visit_rec_field(i, name, mtbl, inner) { return false; }
         true
     }
@@ -328,7 +328,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
     }
 
     fn visit_class_field(&self, i: uint, name: &str,
-                         mtbl: uint, inner: *TyDesc) -> bool {
+                         mtbl: uint, inner: *'static TyDesc) -> bool {
         if ! self.inner.visit_class_field(i, name, mtbl, inner) {
             return false;
         }
@@ -349,7 +349,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool {
+    fn visit_tup_field(&self, i: uint, inner: *'static TyDesc) -> bool {
         if ! self.inner.visit_tup_field(i, inner) { return false; }
         true
     }
@@ -367,12 +367,12 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_fn_input(&self, i: uint, mode: uint, inner: *TyDesc) -> bool {
+    fn visit_fn_input(&self, i: uint, mode: uint, inner: *'static TyDesc) -> bool {
         if ! self.inner.visit_fn_input(i, mode, inner) { return false; }
         true
     }
 
-    fn visit_fn_output(&self, retstyle: uint, inner: *TyDesc) -> bool {
+    fn visit_fn_output(&self, retstyle: uint, inner: *'static TyDesc) -> bool {
         if ! self.inner.visit_fn_output(retstyle, inner) { return false; }
         true
     }
@@ -405,7 +405,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *TyDesc) -> bool {
+    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *'static TyDesc) -> bool {
         if ! self.inner.visit_enum_variant_field(i, offset, inner) { return false; }
         true
     }
@@ -470,7 +470,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_constr(&self, inner: *TyDesc) -> bool {
+    fn visit_constr(&self, inner: *'static TyDesc) -> bool {
         if ! self.inner.visit_constr(inner) { return false; }
         true
     }
@@ -486,8 +486,8 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
 struct my_visitor(@mut Stuff);
 
 struct Stuff {
-    ptr1: *c_void,
-    ptr2: *c_void,
+    ptr1: *'static c_void,
+    ptr2: *'static c_void,
     vals: ~[~str]
 }
 
@@ -498,7 +498,7 @@ impl my_visitor {
         }
     }
 
-    pub fn visit_inner(&self, inner: *TyDesc) -> bool {
+    pub fn visit_inner(&self, inner: *'static TyDesc) -> bool {
         unsafe {
             let u = my_visitor(**self);
             let v = ptr_visit_adaptor::<my_visitor>(Inner {inner: u});
@@ -556,25 +556,25 @@ impl TyVisitor for my_visitor {
     fn visit_estr_fixed(&self, _n: uint, _sz: uint,
                         _align: uint) -> bool { true }
 
-    fn visit_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_uniq(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_uniq_managed(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_ptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_rptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_box(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_uniq(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_uniq_managed(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_ptr(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_rptr(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
 
-    fn visit_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_uniq(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_uniq_managed(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_slice(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_vec(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_evec_box(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_evec_uniq(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_evec_uniq_managed(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_evec_slice(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
     fn visit_evec_fixed(&self, _n: uint, _sz: uint, _align: uint,
-                        _mtbl: uint, _inner: *TyDesc) -> bool { true }
+                        _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
 
     fn visit_enter_rec(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
     fn visit_rec_field(&self, _i: uint, _name: &str,
-                       _mtbl: uint, inner: *TyDesc) -> bool {
+                       _mtbl: uint, inner: *'static TyDesc) -> bool {
         error!("rec field!");
         self.visit_inner(inner)
     }
@@ -584,7 +584,7 @@ impl TyVisitor for my_visitor {
     fn visit_enter_class(&self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool { true }
     fn visit_class_field(&self, _i: uint, _name: &str,
-                         _mtbl: uint, inner: *TyDesc) -> bool {
+                         _mtbl: uint, inner: *'static TyDesc) -> bool {
         self.visit_inner(inner)
     }
     fn visit_leave_class(&self, _n_fields: uint,
@@ -592,7 +592,7 @@ impl TyVisitor for my_visitor {
 
     fn visit_enter_tup(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
-    fn visit_tup_field(&self, _i: uint, inner: *TyDesc) -> bool {
+    fn visit_tup_field(&self, _i: uint, inner: *'static TyDesc) -> bool {
         error!("tup field!");
         self.visit_inner(inner)
     }
@@ -609,7 +609,7 @@ impl TyVisitor for my_visitor {
                                 _disr_val: int,
                                 _n_fields: uint,
                                 _name: &str) -> bool { true }
-    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, inner: *TyDesc) -> bool {
+    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, inner: *'static TyDesc) -> bool {
         self.visit_inner(inner)
     }
     fn visit_leave_enum_variant(&self, _variant: uint,
@@ -622,10 +622,10 @@ impl TyVisitor for my_visitor {
 
     fn visit_enter_fn(&self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
-    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool {
+    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *'static TyDesc) -> bool {
         true
     }
-    fn visit_fn_output(&self, _retstyle: uint, _inner: *TyDesc) -> bool {
+    fn visit_fn_output(&self, _retstyle: uint, _inner: *'static TyDesc) -> bool {
         true
     }
     fn visit_leave_fn(&self, _purity: uint, _proto: uint,
@@ -639,11 +639,11 @@ impl TyVisitor for my_visitor {
     fn visit_self(&self) -> bool { true }
     fn visit_type(&self) -> bool { true }
     fn visit_opaque_box(&self) -> bool { true }
-    fn visit_constr(&self, _inner: *TyDesc) -> bool { true }
+    fn visit_constr(&self, _inner: *'static TyDesc) -> bool { true }
     fn visit_closure_ptr(&self, _ck: uint) -> bool { true }
 }
 
-fn get_tydesc_for<T>(_t: T) -> *TyDesc {
+fn get_tydesc_for<T>(_t: T) -> *'static TyDesc {
     unsafe {
         get_tydesc::<T>()
     }

--- a/src/test/run-pass/reflect-visit-type.rs
+++ b/src/test/run-pass/reflect-visit-type.rs
@@ -67,16 +67,16 @@ impl TyVisitor for MyVisitor {
                         _sz: uint, _sz: uint,
                         _align: uint) -> bool { true }
 
-    fn visit_box(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_uniq(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_uniq_managed(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_ptr(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_rptr(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_uniq(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_uniq_managed(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_ptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_rptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
 
-    fn visit_vec(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_evec_box(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_evec_uniq(&self, _mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_uniq(&self, _mtbl: uint, inner: *TyDesc) -> bool {
         self.types.push(~"[");
         unsafe {
             visit_tydesc(inner, (@*self) as @TyVisitor);
@@ -84,7 +84,7 @@ impl TyVisitor for MyVisitor {
         self.types.push(~"]");
         true
     }
-    fn visit_evec_uniq_managed(&self, _mtbl: uint, inner: *'static TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&self, _mtbl: uint, inner: *TyDesc) -> bool {
         self.types.push(~"[");
         unsafe {
             visit_tydesc(inner, (@*self) as @TyVisitor);
@@ -92,27 +92,27 @@ impl TyVisitor for MyVisitor {
         self.types.push(~"]");
         true
     }
-    fn visit_evec_slice(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_evec_slice(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_evec_fixed(&self, _n: uint, _sz: uint, _align: uint,
-                        _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+                        _mtbl: uint, _inner: *TyDesc) -> bool { true }
 
     fn visit_enter_rec(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
     fn visit_rec_field(&self, _i: uint, _name: &str,
-                       _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+                       _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_leave_rec(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
 
     fn visit_enter_class(&self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool { true }
     fn visit_class_field(&self, _i: uint, _name: &str,
-                         _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+                         _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_leave_class(&self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool { true }
 
     fn visit_enter_tup(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
-    fn visit_tup_field(&self, _i: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_tup_field(&self, _i: uint, _inner: *TyDesc) -> bool { true }
     fn visit_leave_tup(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
 
@@ -124,7 +124,7 @@ impl TyVisitor for MyVisitor {
                                 _disr_val: int,
                                 _n_fields: uint,
                                 _name: &str) -> bool { true }
-    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, _inner: *TyDesc) -> bool { true }
     fn visit_leave_enum_variant(&self,
                                 _variant: uint,
                                 _disr_val: int,
@@ -137,8 +137,8 @@ impl TyVisitor for MyVisitor {
 
     fn visit_enter_fn(&self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
-    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *'static TyDesc) -> bool { true }
-    fn visit_fn_output(&self, _retstyle: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_fn_output(&self, _retstyle: uint, _inner: *TyDesc) -> bool { true }
     fn visit_leave_fn(&self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
 
@@ -150,7 +150,7 @@ impl TyVisitor for MyVisitor {
     fn visit_self(&self) -> bool { true }
     fn visit_type(&self) -> bool { true }
     fn visit_opaque_box(&self) -> bool { true }
-    fn visit_constr(&self, _inner: *'static TyDesc) -> bool { true }
+    fn visit_constr(&self, _inner: *TyDesc) -> bool { true }
     fn visit_closure_ptr(&self, _ck: uint) -> bool { true }
 }
 

--- a/src/test/run-pass/reflect-visit-type.rs
+++ b/src/test/run-pass/reflect-visit-type.rs
@@ -67,16 +67,16 @@ impl TyVisitor for MyVisitor {
                         _sz: uint, _sz: uint,
                         _align: uint) -> bool { true }
 
-    fn visit_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_uniq(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_uniq_managed(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_ptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_rptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_box(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_uniq(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_uniq_managed(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_ptr(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_rptr(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
 
-    fn visit_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_uniq(&self, _mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_vec(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_evec_box(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_evec_uniq(&self, _mtbl: uint, inner: *'static TyDesc) -> bool {
         self.types.push(~"[");
         unsafe {
             visit_tydesc(inner, (@*self) as @TyVisitor);
@@ -84,7 +84,7 @@ impl TyVisitor for MyVisitor {
         self.types.push(~"]");
         true
     }
-    fn visit_evec_uniq_managed(&self, _mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&self, _mtbl: uint, inner: *'static TyDesc) -> bool {
         self.types.push(~"[");
         unsafe {
             visit_tydesc(inner, (@*self) as @TyVisitor);
@@ -92,27 +92,27 @@ impl TyVisitor for MyVisitor {
         self.types.push(~"]");
         true
     }
-    fn visit_evec_slice(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_slice(&self, _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
     fn visit_evec_fixed(&self, _n: uint, _sz: uint, _align: uint,
-                        _mtbl: uint, _inner: *TyDesc) -> bool { true }
+                        _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
 
     fn visit_enter_rec(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
     fn visit_rec_field(&self, _i: uint, _name: &str,
-                       _mtbl: uint, _inner: *TyDesc) -> bool { true }
+                       _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
     fn visit_leave_rec(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
 
     fn visit_enter_class(&self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool { true }
     fn visit_class_field(&self, _i: uint, _name: &str,
-                         _mtbl: uint, _inner: *TyDesc) -> bool { true }
+                         _mtbl: uint, _inner: *'static TyDesc) -> bool { true }
     fn visit_leave_class(&self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool { true }
 
     fn visit_enter_tup(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
-    fn visit_tup_field(&self, _i: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_tup_field(&self, _i: uint, _inner: *'static TyDesc) -> bool { true }
     fn visit_leave_tup(&self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
 
@@ -124,7 +124,7 @@ impl TyVisitor for MyVisitor {
                                 _disr_val: int,
                                 _n_fields: uint,
                                 _name: &str) -> bool { true }
-    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, _inner: *'static TyDesc) -> bool { true }
     fn visit_leave_enum_variant(&self,
                                 _variant: uint,
                                 _disr_val: int,
@@ -137,8 +137,8 @@ impl TyVisitor for MyVisitor {
 
     fn visit_enter_fn(&self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
-    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_fn_output(&self, _retstyle: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *'static TyDesc) -> bool { true }
+    fn visit_fn_output(&self, _retstyle: uint, _inner: *'static TyDesc) -> bool { true }
     fn visit_leave_fn(&self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
 
@@ -150,7 +150,7 @@ impl TyVisitor for MyVisitor {
     fn visit_self(&self) -> bool { true }
     fn visit_type(&self) -> bool { true }
     fn visit_opaque_box(&self) -> bool { true }
-    fn visit_constr(&self, _inner: *TyDesc) -> bool { true }
+    fn visit_constr(&self, _inner: *'static TyDesc) -> bool { true }
     fn visit_closure_ptr(&self, _ck: uint) -> bool { true }
 }
 

--- a/src/test/run-pass/resource-cycle.rs
+++ b/src/test/run-pass/resource-cycle.rs
@@ -23,16 +23,14 @@ impl Drop for r {
               cast::transmute::<*r, uint>(self),
               cast::transmute::<**int, uint>(&(self.v)),
               cast::transmute::<*int, uint>(self.v));
-            let v2: ~int = cast::transmute(self.v);
+            let _v2: ~int = cast::transmute(self.v);
         }
     }
 }
 
 fn r(v: *int) -> r {
-    unsafe {
-        r {
-            v: v
-        }
+    r {
+        v: v
     }
 }
 
@@ -52,7 +50,7 @@ pub fn main() {
         let i2p = cast::transmute_copy(&i2);
         cast::forget(i2);
 
-        let mut x1 = @mut t(Node{
+        let x1 = @mut t(Node{
             next: None,
               r: {
               let rs = r(i1p);
@@ -64,7 +62,7 @@ pub fn main() {
                cast::transmute::<@mut t, uint>(x1),
                cast::transmute::<*r, uint>(&x1.r));
 
-        let mut x2 = @mut t(Node{
+        let x2 = @mut t(Node{
             next: None,
               r: {
               let rs = r(i2p);

--- a/src/test/run-pass/resource-cycle.rs
+++ b/src/test/run-pass/resource-cycle.rs
@@ -13,7 +13,7 @@
 use std::cast;
 
 struct r {
-  v: *int,
+  v: *'static int,
 }
 
 impl Drop for r {
@@ -28,7 +28,7 @@ impl Drop for r {
     }
 }
 
-fn r(v: *int) -> r {
+fn r(v: *'static int) -> r {
     r {
         v: v
     }

--- a/src/test/run-pass/resource-cycle.rs
+++ b/src/test/run-pass/resource-cycle.rs
@@ -12,11 +12,11 @@
 
 use std::cast;
 
-struct r {
-  v: *'static int,
+struct r<'self> {
+  v: *'self int,
 }
 
-impl Drop for r {
+impl<'self> Drop for r<'self> {
     fn drop(&self) {
         unsafe {
             info!("r's dtor: self = %x, self.v = %x, self.v's value = %x",
@@ -28,17 +28,17 @@ impl Drop for r {
     }
 }
 
-fn r(v: *'static int) -> r {
+fn r<'a>(v: *'a int) -> r<'a> {
     r {
         v: v
     }
 }
 
-struct t(Node);
+struct t<'self>(Node<'self>);
 
-struct Node {
-    next: Option<@mut t>,
-    r: r
+struct Node<'self> {
+    next: Option<@mut t<'self>>,
+    r: r<'self>
 }
 
 pub fn main() {

--- a/src/test/run-pass/resource-cycle2.rs
+++ b/src/test/run-pass/resource-cycle2.rs
@@ -15,7 +15,7 @@ use std::cast;
 struct U {
     a: int,
     b: int,
-    c: *int
+    c: *'static int
 }
 
 struct r {

--- a/src/test/run-pass/resource-cycle3.rs
+++ b/src/test/run-pass/resource-cycle3.rs
@@ -17,13 +17,13 @@ use std::cast;
 struct U {
     a: int,
     b: int,
-    c: *int
+    c: *'static int
 }
 
 struct R {
   v: U,
   w: int,
-  x: *int,
+  x: *'static int,
 }
 
 impl Drop for R {

--- a/src/test/run-pass/rt-sched-1.rs
+++ b/src/test/run-pass/rt-sched-1.rs
@@ -15,10 +15,10 @@ use std::comm::*;
 use std::libc;
 
 pub type sched_id = int;
-pub type task_id = *libc::c_void;
+pub type task_id = *'static libc::c_void;
 
-pub type task = *libc::c_void;
-pub type closure = *libc::c_void;
+pub type task = *'static libc::c_void;
+pub type closure = *'static libc::c_void;
 
 mod rustrt {
     use super::{closure, sched_id, task, task_id};

--- a/src/test/run-pass/smallest-hello-world.rs
+++ b/src/test/run-pass/smallest-hello-world.rs
@@ -31,7 +31,7 @@ extern "rust-intrinsic" {
 }
 
 #[start]
-fn main(_: int, _: **u8, _: *u8) -> int {
+fn main(_: int, _: *'static *'static u8, _: *'static u8) -> int {
     unsafe {
         let (ptr, _): (*u8, uint) = transmute("Hello!");
         puts(ptr);

--- a/src/test/run-pass/type-ptr.rs
+++ b/src/test/run-pass/type-ptr.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn f(a: *int) -> *int { return a; }
+fn f(a: *'static int) -> *'static int { a }
 
-fn g(a: *int) -> *int { let b = f(a); return b; }
+fn g(a: *'static int) -> *'static int { let b = f(a); b }
 
-pub fn main() { return; }
+pub fn main() { }


### PR DESCRIPTION
This patch series fixes #7694. The main reason for this is that without this patch it's trivial to have an interior pointer to a rust structure live past that structure's deallocation. I go into more detail in #7694 if you are curious. The end result is that if you really do know more than the borrow checker, you now need to use `cast::transmute` to convert a `*'a T` into a `*'static T` if you really want a leakable pointer.

This patch isn't quite up for commital yet though. First, it still needs to be merged into head. Second, it needs a snapshot dance in order to first allow us to parse `*'a T`, then another to actually implement the regions.

cc @nikomatsakis, as you are probably the best one to review this.
