### PR TITLE
Change 'print(fmt!(...))' to printf!/printfln!

### DIFF
--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -75,7 +75,7 @@ impl<'self> ToBase64 for &'self [u8] {
      *
      * fn main () {
      *     let str = [52,32].to_base64(standard);
-     *     println(fmt!("%s", str));
+     *     printfln!("%s", str);
      * }
      * ~~~
      */
@@ -164,7 +164,7 @@ impl<'self> ToBase64 for &'self str {
      *
      * fn main () {
      *     let str = "Hello, World".to_base64(standard);
-     *     println(fmt!("%s",str));
+     *     printfln!("%s", str);
      * }
      * ~~~
      *
@@ -194,9 +194,9 @@ impl<'self> FromBase64 for &'self [u8] {
      *
      * fn main () {
      *     let str = [52,32].to_base64(standard);
-     *     println(fmt!("%s", str));
+     *     printfln!("%s", str);
      *     let bytes = str.from_base64();
-     *     println(fmt!("%?",bytes));
+     *     printfln!("%?", bytes);
      * }
      * ~~~
      */
@@ -271,11 +271,11 @@ impl<'self> FromBase64 for &'self str {
      *
      * fn main () {
      *     let hello_str = "Hello, World".to_base64(standard);
-     *     println(fmt!("%s",hello_str));
+     *     printfln!("%s", hello_str);
      *     let bytes = hello_str.from_base64();
-     *     println(fmt!("%?",bytes));
+     *     printfln!("%?", bytes);
      *     let result_str = str::from_bytes(bytes);
-     *     println(fmt!("%s",result_str));
+     *     printfln!("%s", result_str);
      * }
      * ~~~
      */

--- a/src/libextra/future.rs
+++ b/src/libextra/future.rs
@@ -19,7 +19,7 @@
  * # fn make_a_sandwich() {};
  * let mut delayed_fib = extra::future::spawn (|| fib(5000) );
  * make_a_sandwich();
- * println(fmt!("fib(5000) = %?", delayed_fib.get()))
+ * printfln!("fib(5000) = %?", delayed_fib.get())
  * ~~~
  */
 

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -44,7 +44,7 @@
  *    }
  *
  *    fn print_usage(program: &str, _opts: &[Opt]) {
- *        println(fmt!("Usage: %s [options]", program));
+ *        printfln!("Usage: %s [options]", program);
  *        println("-o\t\tOutput");
  *        println("-h --help\tUsage");
  *    }

--- a/src/libextra/task_pool.rs
+++ b/src/libextra/task_pool.rs
@@ -103,6 +103,6 @@ fn test_task_pool() {
     };
     let mut pool = TaskPool::new(4, Some(SingleThreaded), f);
     for 8.times {
-        pool.execute(|i| println(fmt!("Hello from thread %u!", *i)));
+        pool.execute(|i| printfln!("Hello from thread %u!", *i));
     }
 }

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -1200,7 +1200,7 @@ mod test_set {
 
         let mut n = 0;
         for m.iter().advance |x| {
-            println(fmt!("%?", x));
+            printfln!(x);
             assert_eq!(*x, n);
             n += 1
         }

--- a/src/librust/rust.rs
+++ b/src/librust/rust.rs
@@ -132,13 +132,13 @@ fn cmd_help(args: &[~str]) -> ValidUsage {
         match find_cmd(command_string) {
             Some(command) => {
                 match command.action {
-                    CallMain(prog, _) => io::println(fmt!(
+                    CallMain(prog, _) => printfln!(
                         "The %s command is an alias for the %s program.",
-                        command.cmd, prog)),
+                        command.cmd, prog),
                     _       => ()
                 }
                 match command.usage_full {
-                    UsgStr(msg) => io::println(fmt!("%s\n", msg)),
+                    UsgStr(msg) => printfln!("%s\n", msg),
                     UsgCall(f)  => f(),
                 }
                 Valid(0)
@@ -211,8 +211,7 @@ fn usage() {
 
     for COMMANDS.iter().advance |command| {
         let padding = " ".repeat(INDENT - command.cmd.len());
-        io::println(fmt!("    %s%s%s",
-                         command.cmd, padding, command.usage_line));
+        printfln!("    %s%s%s", command.cmd, padding, command.usage_line);
     }
 
     io::print(

--- a/src/librustc/back/passes.rs
+++ b/src/librustc/back/passes.rs
@@ -191,15 +191,15 @@ pub fn list_passes() {
 
     io::println("\nAnalysis Passes:");
     for analysis_passes.iter().advance |&(name, desc)| {
-        io::println(fmt!("    %-30s -- %s", name, desc));
+        printfln!("    %-30s -- %s", name, desc);
     }
     io::println("\nTransformation Passes:");
     for transform_passes.iter().advance |&(name, desc)| {
-        io::println(fmt!("    %-30s -- %s", name, desc));
+        printfln!("    %-30s -- %s", name, desc);
     }
     io::println("\nUtility Passes:");
     for utility_passes.iter().advance |&(name, desc)| {
-        io::println(fmt!("    %-30s -- %s", name, desc));
+        printfln!("    %-30s -- %s", name, desc);
     }
 }
 
@@ -344,7 +344,7 @@ fn passes_exist() {
     if failed.len() > 0 {
         io::println("Some passes don't exist:");
         for failed.iter().advance |&n| {
-            io::println(fmt!("    %s", n));
+            printfln!("    %s", n);
         }
         fail!();
     }

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1624,16 +1624,16 @@ pub fn encode_metadata(parms: EncodeParams, crate: &crate) -> ~[u8] {
         }
 
         io::println("metadata stats:");
-        io::println(fmt!("    inline bytes: %u", ecx.stats.inline_bytes));
-        io::println(fmt!(" attribute bytes: %u", ecx.stats.attr_bytes));
-        io::println(fmt!("       dep bytes: %u", ecx.stats.dep_bytes));
-        io::println(fmt!(" lang item bytes: %u", ecx.stats.lang_item_bytes));
-        io::println(fmt!(" link args bytes: %u", ecx.stats.link_args_bytes));
-        io::println(fmt!("      misc bytes: %u", ecx.stats.misc_bytes));
-        io::println(fmt!("      item bytes: %u", ecx.stats.item_bytes));
-        io::println(fmt!("     index bytes: %u", ecx.stats.index_bytes));
-        io::println(fmt!("      zero bytes: %u", ecx.stats.zero_bytes));
-        io::println(fmt!("     total bytes: %u", ecx.stats.total_bytes));
+        printfln!("    inline bytes: %u", ecx.stats.inline_bytes);
+        printfln!(" attribute bytes: %u", ecx.stats.attr_bytes);
+        printfln!("       dep bytes: %u", ecx.stats.dep_bytes);
+        printfln!(" lang item bytes: %u", ecx.stats.lang_item_bytes);
+        printfln!(" link args bytes: %u", ecx.stats.link_args_bytes);
+        printfln!("      misc bytes: %u", ecx.stats.misc_bytes);
+        printfln!("      item bytes: %u", ecx.stats.item_bytes);
+        printfln!("     index bytes: %u", ecx.stats.index_bytes);
+        printfln!("      zero bytes: %u", ecx.stats.zero_bytes);
+        printfln!("     total bytes: %u", ecx.stats.total_bytes);
     }
 
     // Pad this, since something (LLVM, presumably) is cutting off the

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -93,16 +93,16 @@ pub fn check_crate(
 
     if tcx.sess.borrowck_stats() {
         io::println("--- borrowck stats ---");
-        io::println(fmt!("paths requiring guarantees: %u",
-                        bccx.stats.guaranteed_paths));
-        io::println(fmt!("paths requiring loans     : %s",
-                         make_stat(bccx, bccx.stats.loaned_paths_same)));
-        io::println(fmt!("paths requiring imm loans : %s",
-                         make_stat(bccx, bccx.stats.loaned_paths_imm)));
-        io::println(fmt!("stable paths              : %s",
-                         make_stat(bccx, bccx.stats.stable_paths)));
-        io::println(fmt!("paths requiring purity    : %s",
-                         make_stat(bccx, bccx.stats.req_pure_paths)));
+        printfln!("paths requiring guarantees: %u",
+                  bccx.stats.guaranteed_paths);
+        printfln!("paths requiring loans     : %s",
+                  make_stat(bccx, bccx.stats.loaned_paths_same));
+        printfln!("paths requiring imm loans : %s",
+                  make_stat(bccx, bccx.stats.loaned_paths_imm));
+        printfln!("stable paths              : %s",
+                  make_stat(bccx, bccx.stats.stable_paths));
+        printfln!("paths requiring purity    : %s",
+                  make_stat(bccx, bccx.stats.req_pure_paths));
     }
 
     return (bccx.root_map, bccx.write_guard_map);

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2999,17 +2999,15 @@ pub fn trans_crate(sess: session::Session,
     write_metadata(ccx, crate);
     if ccx.sess.trans_stats() {
         io::println("--- trans stats ---");
-        io::println(fmt!("n_static_tydescs: %u",
-                         ccx.stats.n_static_tydescs));
-        io::println(fmt!("n_glues_created: %u",
-                         ccx.stats.n_glues_created));
-        io::println(fmt!("n_null_glues: %u", ccx.stats.n_null_glues));
-        io::println(fmt!("n_real_glues: %u", ccx.stats.n_real_glues));
+        printfln!("n_static_tydescs: %u", ccx.stats.n_static_tydescs);
+        printfln!("n_glues_created: %u", ccx.stats.n_glues_created);
+        printfln!("n_null_glues: %u", ccx.stats.n_null_glues);
+        printfln!("n_real_glues: %u", ccx.stats.n_real_glues);
 
-        io::println(fmt!("n_fns: %u", ccx.stats.n_fns));
-        io::println(fmt!("n_monos: %u", ccx.stats.n_monos));
-        io::println(fmt!("n_inlines: %u", ccx.stats.n_inlines));
-        io::println(fmt!("n_closures: %u", ccx.stats.n_closures));
+        printfln!("n_fns: %u", ccx.stats.n_fns);
+        printfln!("n_monos: %u", ccx.stats.n_monos);
+        printfln!("n_inlines: %u", ccx.stats.n_inlines);
+        printfln!("n_closures: %u", ccx.stats.n_closures);
         io::println("fn stats:");
         do sort::quick_sort(ccx.stats.fn_stats) |&(_, _, insns_a), &(_, _, insns_b)| {
             insns_a > insns_b
@@ -3017,14 +3015,14 @@ pub fn trans_crate(sess: session::Session,
         for ccx.stats.fn_stats.iter().advance |tuple| {
             match *tuple {
                 (ref name, ms, insns) => {
-                    io::println(fmt!("%u insns, %u ms, %s", insns, ms, *name));
+                    printfln!("%u insns, %u ms, %s", insns, ms, *name);
                 }
             }
         }
     }
     if ccx.sess.count_llvm_insns() {
         for ccx.stats.llvm_insns.iter().advance |(k, v)| {
-            io::println(fmt!("%-7u %s", *v, *k));
+            printfln!("%-7u %s", *v, *k);
         }
     }
 

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -654,9 +654,9 @@ pub fn trans_call_inner(in_cx: block,
 
         // Uncomment this to debug calls.
         /*
-        io::println(fmt!("calling: %s", bcx.val_to_str(llfn)));
+        printfln!("calling: %s", bcx.val_to_str(llfn));
         for llargs.iter().advance |llarg| {
-            io::println(fmt!("arg: %s", bcx.val_to_str(*llarg)));
+            printfln!("arg: %s", bcx.val_to_str(*llarg));
         }
         io::println("---");
         */

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -37,7 +37,6 @@ use util::ppaux::ty_to_short_str;
 
 use middle::trans::type_::Type;
 
-use std::io;
 use std::libc::c_uint;
 use std::str;
 use syntax::ast;
@@ -649,8 +648,8 @@ pub fn declare_tydesc(ccx: &mut CrateContext, t: ty::t) -> @mut tydesc_info {
     let llty = type_of(ccx, t);
 
     if ccx.sess.count_type_sizes() {
-        io::println(fmt!("%u\t%s", llsize_of_real(ccx, llty),
-                         ppaux::ty_to_str(ccx.tcx, t)));
+        printfln!("%u\t%s", llsize_of_real(ccx, llty),
+                  ppaux::ty_to_str(ccx.tcx, t));
     }
 
     let llsize = llsize_of(ccx, llty);

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2712,7 +2712,7 @@ pub fn node_id_to_trait_ref(cx: ctxt, id: ast::node_id) -> @ty::TraitRef {
 }
 
 pub fn node_id_to_type(cx: ctxt, id: ast::node_id) -> t {
-    //io::println(fmt!("%?/%?", id, cx.node_types.len()));
+    //printfln!("%?/%?", id, cx.node_types.len());
     match cx.node_types.find(&(id as uint)) {
        Some(&t) => t,
        None => cx.sess.bug(

--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -128,28 +128,28 @@ pub fn version(argv0: &str) {
     let mut vers = ~"unknown version";
     let env_vers = env!("CFG_VERSION");
     if env_vers.len() != 0 { vers = env_vers.to_owned(); }
-    io::println(fmt!("%s %s", argv0, vers));
-    io::println(fmt!("host: %s", host_triple()));
+    printfln!("%s %s", argv0, vers);
+    printfln!("host: %s", host_triple());
 }
 
 pub fn usage(argv0: &str) {
     let message = fmt!("Usage: %s [OPTIONS] INPUT", argv0);
-    io::println(fmt!("%s\
+    printfln!("%s\
 Additional help:
     -W help             Print 'lint' options and default settings
     -Z help             Print internal options for debugging rustc\n",
-                     groups::usage(message, optgroups())));
+              groups::usage(message, optgroups()));
 }
 
 pub fn describe_warnings() {
     use extra::sort::Sort;
-    io::println(fmt!("
+    printfln!("
 Available lint options:
     -W <foo>           Warn about <foo>
     -A <foo>           Allow <foo>
     -D <foo>           Deny <foo>
     -F <foo>           Forbid <foo> (deny, and deny all overrides)
-"));
+");
 
     let lint_dict = lint::get_lint_dict();
     let mut lint_dict = lint_dict.consume()
@@ -164,28 +164,28 @@ Available lint options:
     fn padded(max: uint, s: &str) -> ~str {
         str::from_bytes(vec::from_elem(max - s.len(), ' ' as u8)) + s
     }
-    io::println(fmt!("\nAvailable lint checks:\n"));
-    io::println(fmt!("    %s  %7.7s  %s",
-                     padded(max_key, "name"), "default", "meaning"));
-    io::println(fmt!("    %s  %7.7s  %s\n",
-                     padded(max_key, "----"), "-------", "-------"));
+    printfln!("\nAvailable lint checks:\n");
+    printfln!("    %s  %7.7s  %s",
+              padded(max_key, "name"), "default", "meaning");
+    printfln!("    %s  %7.7s  %s\n",
+              padded(max_key, "----"), "-------", "-------");
     for lint_dict.consume_iter().advance |(spec, name)| {
         let name = name.replace("_", "-");
-        io::println(fmt!("    %s  %7.7s  %s",
-                         padded(max_key, name),
-                         lint::level_to_str(spec.default),
-                         spec.desc));
+        printfln!("    %s  %7.7s  %s",
+                  padded(max_key, name),
+                  lint::level_to_str(spec.default),
+                  spec.desc);
     }
     io::println("");
 }
 
 pub fn describe_debug_flags() {
-    io::println(fmt!("\nAvailable debug options:\n"));
+    printfln!("\nAvailable debug options:\n");
     let r = session::debugging_opts_map();
     for r.iter().advance |tuple| {
         match *tuple {
             (ref name, ref desc, _) => {
-                io::println(fmt!("    -Z %-20s -- %s", *name, *desc));
+                printfln!("    -Z %-20s -- %s", *name, *desc);
             }
         }
     }

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -14,7 +14,6 @@ use syntax::codemap::{span};
 use syntax::visit;
 
 use std::hashmap::HashSet;
-use std::io;
 use extra;
 
 pub fn time<T>(do_it: bool, what: ~str, thunk: &fn() -> T) -> T {
@@ -22,7 +21,7 @@ pub fn time<T>(do_it: bool, what: ~str, thunk: &fn() -> T) -> T {
     let start = extra::time::precise_time_s();
     let rv = thunk();
     let end = extra::time::precise_time_s();
-    io::println(fmt!("time: %3.3f s\t%s", end - start, what));
+    printfln!("time: %3.3f s\t%s", end - start, what);
     rv
 }
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -74,7 +74,7 @@ pub fn usage() {
     println("Options:\n");
     let r = opts();
     for r.iter().advance |opt| {
-        println(fmt!("    %s", opt.second()));
+        printfln!("    %s", opt.second());
     }
     println("");
 }

--- a/src/librustdoc/rustdoc.rs
+++ b/src/librustdoc/rustdoc.rs
@@ -23,7 +23,6 @@ extern mod extra;
 extern mod rustc;
 extern mod syntax;
 
-use std::io;
 use std::os;
 
 use config::Config;
@@ -69,7 +68,7 @@ pub fn main() {
     let config = match config::parse_config(args) {
       Ok(config) => config,
       Err(err) => {
-        io::println(fmt!("error: %s", err));
+        printfln!("error: %s", err);
         return;
       }
     };

--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -334,7 +334,7 @@ fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
             None => { },
         }
         if (should_compile) {
-            println(fmt!("compiling %s...", src_filename));
+            printfln!("compiling %s...", src_filename);
             driver::compile_upto(sess, cfg, &input, driver::cu_everything,
                                  Some(outputs));
             true
@@ -413,8 +413,7 @@ fn run_cmd(repl: &mut Repl, _in: @io::Reader, _out: @io::Writer,
             if loaded_crates.is_empty() {
                 println("no crates loaded");
             } else {
-                println(fmt!("crates loaded: %s",
-                                 loaded_crates.connect(", ")));
+                printfln!("crates loaded: %s", loaded_crates.connect(", "));
             }
         }
         ~"{" => {

--- a/src/librustpkg/testsuite/pass/src/fancy-lib/pkg.rs
+++ b/src/librustpkg/testsuite/pass/src/fancy-lib/pkg.rs
@@ -34,7 +34,7 @@ pub fn main() {
     }
 
     if args[2] != ~"install" {
-        io::println(fmt!("Warning: I don't know how to %s", args[2]));
+        printfln!("Warning: I don't know how to %s", args[2]);
         return;
     }
 

--- a/src/libstd/iterator.rs
+++ b/src/libstd/iterator.rs
@@ -316,7 +316,7 @@ pub trait IteratorUtil<A> {
     /// use std::iterator::Counter;
     ///
     /// for Counter::new(0, 10).advance |i| {
-    ///     io::println(fmt!("%d", i));
+    ///     printfln!("%d", i);
     /// }
     /// ~~~
     fn advance(&mut self, f: &fn(A) -> bool) -> bool;

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -103,7 +103,7 @@ fn range_step_core(start: $T, stop: $T, step: $T_SIGNED, r: Range, it: &fn($T) -
 /// let nums = [1,2,3,4,5,6,7];
 ///
 /// for uint::range_step(0, nums.len() - 1, 2) |i| {
-///     println(fmt!("%d & %d", nums[i], nums[i+1]));
+///     printfln!("%d & %d", nums[i], nums[i+1]);
 /// }
 /// ~~~
 ///

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -28,7 +28,7 @@ use std::rand::RngUtil;
 fn main() {
     let mut rng = rand::rng();
     if rng.gen() { // bool
-        println(fmt!("int: %d, uint: %u", rng.gen(), rng.gen()))
+        printfln!("int: %d, uint: %u", rng.gen(), rng.gen())
     }
 }
 ~~~
@@ -38,7 +38,7 @@ use std::rand;
 
 fn main () {
     let tuple_ptr = rand::random::<~(f64, char)>();
-    println(fmt!("%?", tuple_ptr))
+    printfln!(tuple_ptr)
 }
 ~~~
 */
@@ -301,7 +301,7 @@ pub trait RngUtil {
      *
      * fn main() {
      *     let mut rng = rand::rng();
-     *     println(fmt!("%b",rng.gen_weighted_bool(3)));
+     *     printfln!("%b", rng.gen_weighted_bool(3));
      * }
      * ~~~
      */
@@ -335,7 +335,7 @@ pub trait RngUtil {
      *
      * fn main() {
      *     let mut rng = rand::rng();
-     *     println(fmt!("%?",rng.gen_bytes(8)));
+     *     printfln!(rng.gen_bytes(8));
      * }
      * ~~~
      */
@@ -352,7 +352,7 @@ pub trait RngUtil {
      *
      * fn main() {
      *     let mut rng = rand::rng();
-     *     println(fmt!("%d",rng.choose([1,2,4,8,16,32])));
+     *     printfln!("%d", rng.choose([1,2,4,8,16,32]));
      * }
      * ~~~
      */
@@ -375,7 +375,7 @@ pub trait RngUtil {
      *     let x = [rand::Weighted {weight: 4, item: 'a'},
      *              rand::Weighted {weight: 2, item: 'b'},
      *              rand::Weighted {weight: 2, item: 'c'}];
-     *     println(fmt!("%c",rng.choose_weighted(x)));
+     *     printfln!("%c", rng.choose_weighted(x));
      * }
      * ~~~
      */
@@ -396,7 +396,7 @@ pub trait RngUtil {
      *     let x = [rand::Weighted {weight: 4, item: 'a'},
      *              rand::Weighted {weight: 2, item: 'b'},
      *              rand::Weighted {weight: 2, item: 'c'}];
-     *     println(fmt!("%?",rng.choose_weighted_option(x)));
+     *     printfln!(rng.choose_weighted_option(x));
      * }
      * ~~~
      */
@@ -418,7 +418,7 @@ pub trait RngUtil {
      *     let x = [rand::Weighted {weight: 4, item: 'a'},
      *              rand::Weighted {weight: 2, item: 'b'},
      *              rand::Weighted {weight: 2, item: 'c'}];
-     *     println(fmt!("%?",rng.weighted_vec(x)));
+     *     printfln!(rng.weighted_vec(x));
      * }
      * ~~~
      */
@@ -435,7 +435,7 @@ pub trait RngUtil {
      *
      * fn main() {
      *     let mut rng = rand::rng();
-     *     println(fmt!("%?",rng.shuffle([1,2,3])));
+     *     printfln!(rng.shuffle([1,2,3]));
      * }
      * ~~~
      */
@@ -454,9 +454,9 @@ pub trait RngUtil {
      *     let mut rng = rand::rng();
      *     let mut y = [1,2,3];
      *     rng.shuffle_mut(y);
-     *     println(fmt!("%?",y));
+     *     printfln!(y);
      *     rng.shuffle_mut(y);
-     *     println(fmt!("%?",y));
+     *     printfln!(y);
      * }
      * ~~~
      */

--- a/src/libstd/rand/distributions.rs
+++ b/src/libstd/rand/distributions.rs
@@ -70,7 +70,7 @@ fn ziggurat<R:Rng>(rng: &mut R,
 ///
 /// fn main() {
 ///     let normal = 2.0 + (*rand::random::<StandardNormal>()) * 3.0;
-///     println(fmt!("%f is from a N(2, 9) distribution", normal))
+///     printfln!("%f is from a N(2, 9) distribution", normal)
 /// }
 /// ~~~
 pub struct StandardNormal(f64);
@@ -124,7 +124,7 @@ impl Rand for StandardNormal {
 ///
 /// fn main() {
 ///     let exp2 = (*rand::random::<Exp1>()) * 0.5;
-///     println(fmt!("%f is from a Exp(2) distribution", exp2));
+///     printfln!("%f is from a Exp(2) distribution", exp2);
 /// }
 /// ~~~
 pub struct Exp1(f64);

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1727,7 +1727,7 @@ impl<'self> StrSlice<'self> for &'self str {
      * let i = 0u;
      * while i < s.len() {
      *     let CharRange {ch, next} = s.char_range_at(i);
-     *     std::io::println(fmt!("%u: %c",i,ch));
+     *     printfln!("%u: %c", i, ch);
      *     i = next;
      * }
      * ~~~

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -805,7 +805,7 @@ impl<'self,T> ImmutableVector<'self, T> for &'self [T] {
      * ~~~ {.rust}
      * let v = &[1,2,3,4];
      * for v.window_iter().advance |win| {
-     *     io::println(fmt!("%?", win));
+     *     printfln!(win);
      * }
      * ~~~
      *
@@ -834,7 +834,7 @@ impl<'self,T> ImmutableVector<'self, T> for &'self [T] {
      * ~~~ {.rust}
      * let v = &[1,2,3,4,5];
      * for v.chunk_iter().advance |win| {
-     *     io::println(fmt!("%?", win));
+     *     printfln!(win);
      * }
      * ~~~
      *

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -23,8 +23,6 @@ use parse::token::{get_ident_interner, special_idents, gensym_ident, ident_to_st
 use parse::token::{FAT_ARROW, SEMI, nt_matchers, nt_tt};
 use print;
 
-use std::io;
-
 pub fn add_new_extension(cx: @ExtCtxt,
                          sp: span,
                          name: ident,
@@ -82,11 +80,11 @@ pub fn add_new_extension(cx: @ExtCtxt,
     -> MacResult {
 
         if cx.trace_macros() {
-            io::println(fmt!("%s! { %s }",
-                             cx.str_of(name),
-                             print::pprust::tt_to_str(
-                                 &ast::tt_delim(@mut arg.to_owned()),
-                                 get_ident_interner())));
+            printfln!("%s! { %s }",
+                      cx.str_of(name),
+                      print::pprust::tt_to_str(
+                          &ast::tt_delim(@mut arg.to_owned()),
+                          get_ident_interner()));
         }
 
         // Which arm's failure should we report? (the one furthest along)

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -686,7 +686,7 @@ mod test {
     use std::io;
     #[test] fn t1() {
         let a = fresh_name("ghi");
-        io::println(fmt!("interned name: %u,\ntextual name: %s\n",
-                         a,interner_get(a)));
+        printfln!("interned name: %u,\ntextual name: %s\n",
+                  a, interner_get(a));
     }
 }

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -24,7 +24,7 @@ fn timed(label: &str, f: &fn()) {
     let start = time::precise_time_s();
     f();
     let end = time::precise_time_s();
-    io::println(fmt!("  %s: %f", label, end - start));
+    printfln!("  %s: %f", label, end - start);
 }
 
 fn ascending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
@@ -116,7 +116,7 @@ fn main() {
         }
     }
 
-    io::println(fmt!("%? keys", n_keys));
+    printfln!("%? keys", n_keys);
 
     io::println("\nTreeMap:");
 

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -58,7 +58,7 @@ fn maybe_run_test(argv: &[~str], name: ~str, test: &fn()) {
     test();
     let stop = precise_time_s();
 
-    io::println(fmt!("%s:\t\t%f ms", name, (stop - start) * 1000f));
+    printfln!("%s:\t\t%f ms", name, (stop - start) * 1000f);
 }
 
 fn shift_push() {

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -119,8 +119,7 @@ fn main() {
     let elapsed = (stop - start);
     let rate = (num_msgs as float) / elapsed;
 
-    io::println(fmt!("Sent %? messages in %? seconds",
-                     num_msgs, elapsed));
-    io::println(fmt!("  %? messages / second", rate));
-    io::println(fmt!("  %? μs / message", 1000000. / rate));
+    printfln!("Sent %? messages in %? seconds", num_msgs, elapsed);
+    printfln!("  %? messages / second", rate);
+    printfln!("  %? μs / message", 1000000. / rate);
 }

--- a/src/test/bench/msgsend-ring-pipes.rs
+++ b/src/test/bench/msgsend-ring-pipes.rs
@@ -105,8 +105,7 @@ fn main() {
     let elapsed = (stop - start);
     let rate = (num_msgs as float) / elapsed;
 
-    io::println(fmt!("Sent %? messages in %? seconds",
-                     num_msgs, elapsed));
-    io::println(fmt!("  %? messages / second", rate));
-    io::println(fmt!("  %? μs / message", 1000000. / rate));
+    printfln!("Sent %? messages in %? seconds", num_msgs, elapsed);
+    printfln!("  %? messages / second", rate);
+    printfln!("  %? μs / message", 1000000. / rate);
 }

--- a/src/test/bench/msgsend-ring-rw-arcs.rs
+++ b/src/test/bench/msgsend-ring-rw-arcs.rs
@@ -115,8 +115,7 @@ fn main() {
     let elapsed = (stop - start);
     let rate = (num_msgs as float) / elapsed;
 
-    io::println(fmt!("Sent %? messages in %? seconds",
-                     num_msgs, elapsed));
-    io::println(fmt!("  %? messages / second", rate));
-    io::println(fmt!("  %? μs / message", 1000000. / rate));
+    printfln!("Sent %? messages in %? seconds", num_msgs, elapsed);
+    printfln!("  %? messages / second", rate);
+    printfln!("  %? μs / message", 1000000. / rate);
 }

--- a/src/test/bench/pingpong.rs
+++ b/src/test/bench/pingpong.rs
@@ -198,13 +198,13 @@ fn main() {
     let bounded = do timeit { bounded(count) };
     let unbounded = do timeit { unbounded(count) };
 
-    io::println(fmt!("count: %?\n", count));
-    io::println(fmt!("bounded:   %? s\t(%? μs/message)",
-                     bounded, bounded * 1000000. / (count as float)));
-    io::println(fmt!("unbounded: %? s\t(%? μs/message)",
-                     unbounded, unbounded * 1000000. / (count as float)));
+    printfln!("count: %?\n", count);
+    printfln!("bounded:   %? s\t(%? μs/message)",
+              bounded, bounded * 1000000. / (count as float));
+    printfln!("unbounded: %? s\t(%? μs/message)",
+              unbounded, unbounded * 1000000. / (count as float));
 
-    io::println(fmt!("\n\
-                      bounded is %?%% faster",
-                     (unbounded - bounded) / bounded * 100.));
+    printfln!("\n\
+               bounded is %?%% faster",
+              (unbounded - bounded) / bounded * 100.);
 }

--- a/src/test/bench/shootout-ackermann.rs
+++ b/src/test/bench/shootout-ackermann.rs
@@ -36,5 +36,5 @@ fn main() {
         args
     };
     let n = int::from_str(args[1]).get();
-    io::println(fmt!("Ack(3,%d): %d\n", n, ack(3, n)));
+    printfln!("Ack(3,%d): %d\n", n, ack(3, n));
 }

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -61,9 +61,9 @@ fn main() {
     let stretch_depth = max_depth + 1;
     let stretch_tree = bottom_up_tree(&stretch_arena, 0, stretch_depth);
 
-    println(fmt!("stretch tree of depth %d\t check: %d",
-                          stretch_depth,
-                          item_check(stretch_tree)));
+    printfln!("stretch tree of depth %d\t check: %d",
+              stretch_depth,
+              item_check(stretch_tree));
 
     let long_lived_arena = arena::Arena();
     let long_lived_tree = bottom_up_tree(&long_lived_arena, 0, max_depth);
@@ -79,12 +79,11 @@ fn main() {
             chk += item_check(temp_tree);
             i += 1;
         }
-        println(fmt!("%d\t trees of depth %d\t check: %d",
-                         iterations * 2, depth,
-                         chk));
+        printfln!("%d\t trees of depth %d\t check: %d",
+                  iterations * 2, depth, chk));
         depth += 2;
     }
-    println(fmt!("long lived tree of depth %d\t check: %d",
-                     max_depth,
-                     item_check(long_lived_tree)));
+    printfln!("long lived tree of depth %d\t check: %d",
+              max_depth,
+              item_check(long_lived_tree));
 }

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -93,5 +93,5 @@ fn fannkuch_redux(n: i32) -> i32 {
 #[fixed_stack_segment]
 fn main() {
     let n: i32 = FromStr::from_str(os::args()[1]).get();
-    println(fmt!("Pfannkuchen(%d) = %d", n as int, fannkuch_redux(n) as int));
+    printfln!("Pfannkuchen(%d) = %d", n as int, fannkuch_redux(n) as int);
 }

--- a/src/test/bench/shootout-fibo.rs
+++ b/src/test/bench/shootout-fibo.rs
@@ -32,5 +32,5 @@ fn main() {
         args
     };
     let n = int::from_str(args[1]).get();
-    io::println(fmt!("%d\n", fib(n)));
+    printfln!("%d\n", fib(n));
 }

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -82,7 +82,7 @@ struct PrintCallback(&'static str);
 
 impl TableCallback for PrintCallback {
     fn f(&self, entry: &mut Entry) {
-        println(fmt!("%d\t%s", entry.count as int, **self));
+        printfln!("%d\t%s", entry.count as int, **self);
     }
 }
 
@@ -279,9 +279,9 @@ fn print_frequencies(frequencies: &Table, frame: i32) {
     }
 
     for vector.each |&(key, count)| {
-        println(fmt!("%s %.3f",
-                     key.unpack(frame),
-                     (count as float * 100.0) / (total_count as float)));
+        printfln!("%s %.3f",
+                  key.unpack(frame),
+                  (count as float * 100.0) / (total_count as float));
     }
 }
 

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -15,7 +15,7 @@ fn main() {
         let mut byte_acc: i8 = 0;
         let mut bit_num: i32 = 0;
 
-        println(fmt!("P4\n%d %d", w as int, h as int));
+        printfln!("P4\n%d %d", w as int, h as int);
 
         let mode = "w";
         let stdout = fdopen(STDOUT_FILENO as c_int, transmute(&mode[0]));

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -142,9 +142,9 @@ fn main() {
     let mut bodies = BODIES;
 
     offset_momentum(&mut bodies);
-    println(fmt!("%.9f", energy(&bodies) as float));
+    printfln!("%.9f", energy(&bodies) as float);
 
     advance(&mut bodies, 0.01, n);
 
-    println(fmt!("%.9f", energy(&bodies) as float));
+    printfln!("%.9f", energy(&bodies) as float);
 }

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -61,5 +61,5 @@ fn main() {
         mult_AtAv(v, u, tmp);
     }
 
-    println(fmt!("%.9f", (dot(u,v) / dot(v,v)).sqrt() as float));
+    printfln!("%.9f", (dot(u,v) / dot(v,v)).sqrt() as float);
 }

--- a/src/test/bench/shootout-threadring.rs
+++ b/src/test/bench/shootout-threadring.rs
@@ -40,7 +40,7 @@ fn roundtrip(id: int, n_tasks: int, p: &Port<int>, ch: &Chan<int>) {
     while (true) {
         match p.recv() {
           1 => {
-            println(fmt!("%d\n", id));
+            printfln!("%d\n", id);
             return;
           }
           token => {

--- a/src/test/compile-fail/borrowck-auto-mut-ref-to-immut-var.rs
+++ b/src/test/compile-fail/borrowck-auto-mut-ref-to-immut-var.rs
@@ -18,7 +18,7 @@ struct Foo {
 
 impl Foo {
     pub fn printme(&mut self) {
-        io::println(fmt!("%d", self.x));
+        printfln!("%d", self.x);
     }
 }
 

--- a/src/test/compile-fail/borrowck-vec-pattern-tail-element-loan.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-tail-element-loan.rs
@@ -9,5 +9,5 @@ fn a() -> &int {
 
 fn main() {
     let fifth = a();
-    println(fmt!("%d", *fifth));
+    printfln!("%d", *fifth);
 }

--- a/src/test/compile-fail/issue-3820.rs
+++ b/src/test/compile-fail/issue-3820.rs
@@ -22,5 +22,5 @@ fn main() {
     let u = Thing {x: 2};
     let _v = u.mul(&3); // This is ok
     let w = u * 3; //~ ERROR binary operation * cannot be applied to type `Thing`
-    println(fmt!("%i", w.x));
+    printfln!("%i", w.x);
 }

--- a/src/test/compile-fail/issue-4335.rs
+++ b/src/test/compile-fail/issue-4335.rs
@@ -14,5 +14,5 @@ fn f<'r, T>(v: &'r T) -> &'r fn()->T { id::<&'r fn()->T>(|| *v) } //~ ERROR cann
 
 fn main() {
     let v = &5;
-    println(fmt!("%d", f(v)()));
+    printfln!("%d", f(v)());
 }

--- a/src/test/compile-fail/moves-based-on-type-no-recursive-stack-closure.rs
+++ b/src/test/compile-fail/moves-based-on-type-no-recursive-stack-closure.rs
@@ -28,7 +28,7 @@ fn innocent_looking_victim() {
             match x {
                 Some(ref msg) => {
                     (f.c)(f, true);
-                    println(fmt!("%?", msg));
+                    printfln!(msg);
                 },
                 None => fail!("oops"),
             }

--- a/src/test/compile-fail/tuple-struct-nonexhaustive.rs
+++ b/src/test/compile-fail/tuple-struct-nonexhaustive.rs
@@ -13,7 +13,7 @@ struct Foo(int, int);
 fn main() {
     let x = Foo(1, 2);
     match x {   //~ ERROR non-exhaustive
-        Foo(1, b) => println(fmt!("%d", b)),
-        Foo(2, b) => println(fmt!("%d", b))
+        Foo(1, b) => printfln!("%d", b),
+        Foo(2, b) => printfln!("%d", b)
     }
 }

--- a/src/test/run-fail/borrowck-wg-one-mut-one-imm-slice-method.rs
+++ b/src/test/run-fail/borrowck-wg-one-mut-one-imm-slice-method.rs
@@ -33,5 +33,5 @@ pub fn main()
     let z = @mut [1,2,3];
     let z2 = z;
     add(z.my_mut_slice(), z2.my_slice());
-    print(fmt!("%d\n", z[0]));
+    printfln!("%d", z[0]);
 }

--- a/src/test/run-fail/borrowck-wg-one-mut-one-imm-slices.rs
+++ b/src/test/run-fail/borrowck-wg-one-mut-one-imm-slices.rs
@@ -12,5 +12,5 @@ pub fn main()
     let z = @mut [1,2,3];
     let z2 = z;
     add(z, z2);
-    print(fmt!("%d\n", z[0]));
+    printfln!("%d", z[0]);
 }

--- a/src/test/run-fail/borrowck-wg-one-mut-one-imm.rs
+++ b/src/test/run-fail/borrowck-wg-one-mut-one-imm.rs
@@ -13,5 +13,5 @@ pub fn main()
     let z = @mut [1,2,3];
     let z2 = z;
     add(&mut z[0], &z2[0]);
-    print(fmt!("%d\n", z[0]));
+    printfln!("%d", z[0]);
 }

--- a/src/test/run-fail/borrowck-wg-two-array-indices.rs
+++ b/src/test/run-fail/borrowck-wg-two-array-indices.rs
@@ -13,5 +13,5 @@ pub fn main()
     let z = @mut [1,2,3];
     let z2 = z;
     add(&mut z[0], &mut z2[0]);
-    print(fmt!("%d\n", z[0]));
+    printfln!("%d", z[0]);
 }

--- a/src/test/run-pass/auto-ref.rs
+++ b/src/test/run-pass/auto-ref.rs
@@ -18,7 +18,7 @@ trait Stuff {
 
 impl Stuff for Foo {
     fn printme(&self) {
-        println(fmt!("%d", self.x));
+        printfln!("%d", self.x);
     }
 }
 

--- a/src/test/run-pass/borrowck-wg-two-imm-borrows.rs
+++ b/src/test/run-pass/borrowck-wg-two-imm-borrows.rs
@@ -10,5 +10,5 @@ pub fn main()
     let z = @mut [1,2,3];
     let z2 = z;
     add(&z[0], &z2[0]);
-    print(fmt!("%d\n", z[0]));
+    printfln!("%d", z[0]);
 }

--- a/src/test/run-pass/cci_impl_exe.rs
+++ b/src/test/run-pass/cci_impl_exe.rs
@@ -19,7 +19,7 @@ pub fn main() {
     //info!("%?", bt0);
 
     do 3u.to(10u) |i| {
-        print(fmt!("%u\n", i));
+        printfln!("%u", i);
 
         //let bt1 = sys::frame_address();
         //info!("%?", bt1);

--- a/src/test/run-pass/cci_iter_exe.rs
+++ b/src/test/run-pass/cci_iter_exe.rs
@@ -17,7 +17,7 @@ pub fn main() {
     //let bt0 = sys::rusti::frame_address(1u32);
     //info!("%?", bt0);
     do cci_iter_lib::iter(~[1, 2, 3]) |i| {
-        print(fmt!("%d", *i));
+        printf!("%d", *i);
         //assert!(bt0 == sys::rusti::frame_address(2u32));
     }
 }

--- a/src/test/run-pass/cci_no_inline_exe.rs
+++ b/src/test/run-pass/cci_no_inline_exe.rs
@@ -23,7 +23,7 @@ pub fn main() {
     //let bt0 = sys::frame_address();
     //info!("%?", bt0);
     do iter(~[1u, 2u, 3u]) |i| {
-        print(fmt!("%u\n", i));
+        printfln!("%u", i);
 
         //let bt1 = sys::frame_address();
         //info!("%?", bt1);

--- a/src/test/run-pass/const-fields-and-indexing.rs
+++ b/src/test/run-pass/const-fields-and-indexing.rs
@@ -27,9 +27,9 @@ static k : K = K {a: 10, b: 20, c: D {d: 30, e: 40}};
 static m : int = k.c.e;
 
 pub fn main() {
-    io::println(fmt!("%?", p));
-    io::println(fmt!("%?", q));
-    io::println(fmt!("%?", t));
+    printfln!(p);
+    printfln!(q);
+    printfln!(t);
     assert_eq!(p, 3);
     assert_eq!(q, 3);
     assert_eq!(t, 20);

--- a/src/test/run-pass/const-rec-and-tup.rs
+++ b/src/test/run-pass/const-rec-and-tup.rs
@@ -21,5 +21,5 @@ static y : AnotherPair = AnotherPair{ x: (0xf0f0f0f0_f0f0f0f0,
 pub fn main() {
     let (p, _) = y.x;
     assert_eq!(p, - 1085102592571150096);
-    println(fmt!("0x%x", p as uint));
+    printfln!("0x%x", p as uint);
 }

--- a/src/test/run-pass/const-region-ptrs.rs
+++ b/src/test/run-pass/const-region-ptrs.rs
@@ -17,8 +17,8 @@ static x: &'static int = &10;
 static y: &'static Pair<'static> = &Pair {a: 15, b: x};
 
 pub fn main() {
-    io::println(fmt!("x = %?", *x));
-    io::println(fmt!("y = {a: %?, b: %?}", y.a, *(y.b)));
+    printfln!("x = %?", *x);
+    printfln!("y = {a: %?, b: %?}", y.a, *(y.b));
     assert_eq!(*x, 10);
     assert_eq!(*(y.b), 10);
 }

--- a/src/test/run-pass/const-struct.rs
+++ b/src/test/run-pass/const-struct.rs
@@ -30,6 +30,6 @@ pub fn main() {
     assert_eq!(x.b, 2);
     assert_eq!(x, y);
     assert_eq!(z.b, 22);
-    io::println(fmt!("0x%x", x.b as uint));
-    io::println(fmt!("0x%x", z.c as uint));
+    printfln!("0x%x", x.b as uint);
+    printfln!("0x%x", z.c as uint);
 }

--- a/src/test/run-pass/const-vecs-and-slices.rs
+++ b/src/test/run-pass/const-vecs-and-slices.rs
@@ -14,8 +14,8 @@ static x : [int, ..4] = [1,2,3,4];
 static y : &'static [int] = &[1,2,3,4];
 
 pub fn main() {
-    io::println(fmt!("%?", x[1]));
-    io::println(fmt!("%?", y[1]));
+    printfln!(x[1]);
+    printfln!(y[1]);
     assert_eq!(x[1], 2);
     assert_eq!(x[3], 4);
     assert_eq!(x[3], y[3]);

--- a/src/test/run-pass/functional-struct-update.rs
+++ b/src/test/run-pass/functional-struct-update.rs
@@ -16,5 +16,5 @@ struct Foo {
 pub fn main() {
     let a = Foo { x: 1, y: 2 };
     let c = Foo { x: 4, .. a};
-    println(fmt!("%?", c));
+    printfln!(c);
 }

--- a/src/test/run-pass/issue-2185.rs
+++ b/src/test/run-pass/issue-2185.rs
@@ -80,5 +80,5 @@ pub fn main() {
         a);
     let sum = foldl(filt, 0u, |accum, &&n: uint| accum + n );
 
-    io::println(fmt!("%u", sum));
+    printfln!("%u", sum);
 }

--- a/src/test/run-pass/issue-2989.rs
+++ b/src/test/run-pass/issue-2989.rs
@@ -42,7 +42,7 @@ pub fn main() {
     let bools2 = to_bools(Storage{storage: ~[0b01100100]});
 
     for uint::range(0, 8) |i| {
-        io::println(fmt!("%u => %u vs %u", i, bools[i] as uint, bools2[i] as uint));
+        printfln!("%u => %u vs %u", i, bools[i] as uint, bools2[i] as uint);
     }
 
     assert_eq!(bools, bools2);

--- a/src/test/run-pass/issue-3211.rs
+++ b/src/test/run-pass/issue-3211.rs
@@ -4,5 +4,5 @@ pub fn main() {
         x += 1;
     }
     assert_eq!(x, 4096);
-    println(fmt!("x = %u", x));
+    printfln!("x = %u", x);
 }

--- a/src/test/run-pass/issue-3743.rs
+++ b/src/test/run-pass/issue-3743.rs
@@ -42,11 +42,11 @@ pub fn main() {
 
     // the following compiles and works properly
     let v1: Vec2 = a * 3f;
-    io::println(fmt!("%f %f", v1.x, v1.y));
+    printfln!("%f %f", v1.x, v1.y);
 
     // the following compiles but v2 will not be Vec2 yet and
     // using it later will cause an error that the type of v2
     // must be known
     let v2 = a * 3f;
-    io::println(fmt!("%f %f", v2.x, v2.y)); // error regarding v2's type
+    printfln!("%f %f", v2.x, v2.y); // error regarding v2's type
 }

--- a/src/test/run-pass/issue-3753.rs
+++ b/src/test/run-pass/issue-3753.rs
@@ -35,5 +35,5 @@ impl Shape {
 
 pub fn main(){
     let s = Circle(Point { x: 1f, y: 2f }, 3f);
-    println(fmt!("%f", s.area(s)));
+    printfln!("%f", s.area(s));
 }

--- a/src/test/run-pass/issue-3794.rs
+++ b/src/test/run-pass/issue-3794.rs
@@ -19,7 +19,7 @@ struct S {
 
 impl T for S {
     fn print(&self) {
-        io::println(fmt!("%?", self));
+        printfln!(self);
     }
 }
 

--- a/src/test/run-pass/issue-3904.rs
+++ b/src/test/run-pass/issue-3904.rs
@@ -12,7 +12,7 @@
 type ErrPrinter = &fn(&str, &str);
 
 fn example_err(prog: &str, arg: &str) {
-    io::println(fmt!("%s: %s", prog, arg))
+    printfln!("%s: %s", prog, arg)
 }
 
 fn exit(+print: ErrPrinter, prog: &str, arg: &str) {

--- a/src/test/run-pass/issue-4241.rs
+++ b/src/test/run-pass/issue-4241.rs
@@ -113,7 +113,7 @@ fn query(cmd: ~[~str], sb: TcpSocketBuf) -> Result {
   //io::println(cmd);
   sb.write_str(cmd);
   let res = parse_response(@sb as @io::Reader);
-  //io::println(fmt!("%?", res));
+  //printfln!(res);
   res
 }
 
@@ -121,7 +121,7 @@ fn query2(cmd: ~[~str]) -> Result {
   let _cmd = cmd_to_str(cmd);
     do io::with_str_reader(~"$3\r\nXXX\r\n") |sb| {
     let res = parse_response(@sb as @io::Reader);
-    io::println(fmt!("%?", res));
+    printfln!(res);
     res
     }
 }

--- a/src/test/run-pass/issue-4401.rs
+++ b/src/test/run-pass/issue-4401.rs
@@ -4,5 +4,5 @@ pub fn main() {
         count += 1;
     }
     assert_eq!(count, 999_999);
-    println(fmt!("%u", count));
+    printfln!("%u", count);
 }

--- a/src/test/run-pass/max-min-classes.rs
+++ b/src/test/run-pass/max-min-classes.rs
@@ -35,5 +35,5 @@ fn Foo(x: int, y: int) -> Foo {
 
 pub fn main() {
     let foo = Foo(3, 20);
-    println(fmt!("%d %d", foo.sum(), foo.product()));
+    printfln!("%d %d", foo.sum(), foo.product());
 }

--- a/src/test/run-pass/new-style-constants.rs
+++ b/src/test/run-pass/new-style-constants.rs
@@ -13,5 +13,5 @@ use std::io::println;
 static FOO: int = 3;
 
 pub fn main() {
-    println(fmt!("%d", FOO));
+    printfln!("%d", FOO);
 }

--- a/src/test/run-pass/new-style-fixed-length-vec.rs
+++ b/src/test/run-pass/new-style-fixed-length-vec.rs
@@ -13,5 +13,5 @@ use std::io::println;
 static FOO: [int, ..3] = [1, 2, 3];
 
 pub fn main() {
-    println(fmt!("%d %d %d", FOO[0], FOO[1], FOO[2]));
+    printfln!("%d %d %d", FOO[0], FOO[1], FOO[2]);
 }

--- a/src/test/run-pass/newtype.rs
+++ b/src/test/run-pass/newtype.rs
@@ -16,6 +16,6 @@ fn compute(i: mytype) -> int { return i.val + 20; }
 
 pub fn main() {
     let myval = mytype(Mytype{compute: compute, val: 30});
-    println(fmt!("%d", compute(myval)));
+    printfln!("%d", compute(myval));
     assert_eq!((myval.compute)(myval), 50);
 }

--- a/src/test/run-pass/num-range-rev.rs
+++ b/src/test/run-pass/num-range-rev.rs
@@ -56,13 +56,13 @@ pub fn main() {
     let primes = [2,3,5,7,11];
     let mut prod = 1i;
     for uint_range_rev(5, 0) |i| {
-        println(fmt!("uint 4 downto 0: %u", i));
+        printfln!("uint 4 downto 0: %u", i);
         prod *= int::pow(primes[i], i);
     }
     assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3*1);
     let mut prod = 1i;
     for int_range_rev(5, 0) |i| {
-        println(fmt!("int 4 downto 0: %d", i));
+        printfln!("int 4 downto 0: %d", i);
         prod *= int::pow(primes[i], i as uint);
     }
     assert_eq!(prod, 11*11*11*11*7*7*7*5*5*3*1);

--- a/src/test/run-pass/num-range.rs
+++ b/src/test/run-pass/num-range.rs
@@ -28,7 +28,7 @@ fn uint_range_step(a: uint, b: uint, s: int, it: &fn(uint) -> bool) -> bool {
 }
 
 pub fn main() {
-    println(fmt!("num-range start"));
+    println("num-range start");
     // int and uint have same result for
     //   Sum{2 <= i < 100} == (Sum{1 <= i <= 99} - 1) == n*(n+1)/2 - 1 for n=99
     let mut sum = 0u;
@@ -105,7 +105,7 @@ pub fn main() {
     let mut saw21 = false;
     for uint::range_step_inclusive(0, 21, 3) |x| {
         assert!(x <= 21);
-        println(fmt!("saw: %u", x));
+        printfln!("saw: %u", x);
         if x == 21 { saw21 = true; }
     }
     assert!(saw21);

--- a/src/test/run-pass/placement-new-arena.rs
+++ b/src/test/run-pass/placement-new-arena.rs
@@ -17,6 +17,6 @@ pub fn main() {
     let mut arena = arena::Arena();
     let p = &mut arena;
     let x = p.alloc(|| 4u);
-    print(fmt!("%u", *x));
+    printf!("%u", *x);
     assert_eq!(*x, 4u);
 }

--- a/src/test/run-pass/recursion.rs
+++ b/src/test/run-pass/recursion.rs
@@ -30,5 +30,5 @@ fn test<T:Dot> (n:int, i:int, first:T, second:T) ->int {
 }
 pub fn main() {
   let n = test(1, 0, Nil, Nil);
-  io::println(fmt!("%d", n));
+  printfln!("%d", n);
 }

--- a/src/test/run-pass/reflect-visit-data.rs
+++ b/src/test/run-pass/reflect-visit-data.rs
@@ -667,7 +667,7 @@ pub fn main() {
 
         let r = u.vals.clone();
         for r.iter().advance |s| {
-            println(fmt!("val: %s", *s));
+            printfln!("val: %s", *s);
         }
         error!("%?", u.vals.clone());
         assert_eq!(u.vals.clone(),

--- a/src/test/run-pass/reflect-visit-type.rs
+++ b/src/test/run-pass/reflect-visit-type.rs
@@ -171,7 +171,7 @@ pub fn main() {
     visit_ty::<~[int]>(vv);
 
     for v.types.iter().advance |s| {
-        println(fmt!("type: %s", (*s).clone()));
+        printfln!("type: %s", (*s).clone());
     }
     assert_eq!((*v.types).clone(), ~[~"bool", ~"int", ~"i8", ~"i16", ~"[", ~"int", ~"]"]);
 }

--- a/src/test/run-pass/struct-pattern-matching.rs
+++ b/src/test/run-pass/struct-pattern-matching.rs
@@ -16,6 +16,6 @@ struct Foo {
 pub fn main() {
     let a = Foo { x: 1, y: 2 };
     match a {
-        Foo { x: x, y: y } => println(fmt!("yes, %d, %d", x, y))
+        Foo { x: x, y: y } => printfln!("yes, %d, %d", x, y)
     }
 }

--- a/src/test/run-pass/trait-inheritance-num2.rs
+++ b/src/test/run-pass/trait-inheritance-num2.rs
@@ -99,7 +99,7 @@ impl FloatExt for f64 {}
 impl FloatExt for float {}
 
 
-fn test_float_ext<T:FloatExt>(n: T) { println(fmt!("%?", n < n)) }
+fn test_float_ext<T:FloatExt>(n: T) { printfln!(n < n) }
 
 pub fn main() {
     test_float_ext(1f32);

--- a/src/test/run-pass/trait-inheritance-num3.rs
+++ b/src/test/run-pass/trait-inheritance-num3.rs
@@ -16,7 +16,7 @@ pub trait NumExt: Eq + Ord + Num + NumCast {}
 impl NumExt for f32 {}
 
 fn num_eq_one<T:NumExt>(n: T) {
-    println(fmt!("%?", n == NumCast::from(1)))
+    printfln!(n == NumCast::from(1))
 }
 
 pub fn main() {

--- a/src/test/run-pass/tuple-struct-construct.rs
+++ b/src/test/run-pass/tuple-struct-construct.rs
@@ -12,5 +12,5 @@ struct Foo(int, int);
 
 pub fn main() {
     let x = Foo(1, 2);
-    println(fmt!("%?", x));
+    printfln!(x);
 }

--- a/src/test/run-pass/tuple-struct-destructuring.rs
+++ b/src/test/run-pass/tuple-struct-destructuring.rs
@@ -13,7 +13,7 @@ struct Foo(int, int);
 pub fn main() {
     let x = Foo(1, 2);
     let Foo(y, z) = x;
-    println(fmt!("%d %d", y, z));
+    printfln!("%d %d", y, z);
     assert_eq!(y, 1);
     assert_eq!(z, 2);
 }

--- a/src/test/run-pass/tuple-struct-matching.rs
+++ b/src/test/run-pass/tuple-struct-matching.rs
@@ -16,7 +16,7 @@ pub fn main() {
         Foo(a, b) => {
             assert_eq!(a, 1);
             assert_eq!(b, 2);
-            println(fmt!("%d %d", a, b));
+            printfln!("%d %d", a, b);
         }
     }
 }

--- a/src/test/run-pass/vec-fixed-length.rs
+++ b/src/test/run-pass/vec-fixed-length.rs
@@ -10,5 +10,5 @@
 
 pub fn main() {
     let x: [int, ..4] = [1, 2, 3, 4];
-    println(fmt!("%d", x[0]));
+    printfln!("%d", x[0]);
 }

--- a/src/test/run-pass/vec-matching-legal-tail-element-borrow.rs
+++ b/src/test/run-pass/vec-matching-legal-tail-element-borrow.rs
@@ -5,6 +5,6 @@ pub fn main() {
             [1, ..ref tail] => &tail[0],
             _ => ::std::util::unreachable()
         };
-        println(fmt!("%d", *el));
+        printfln!("%d", *el);
     }
 }


### PR DESCRIPTION
This changes `print(fmt!(...))` and `println(fmt!(...))` to `printf!(...)` and `printfln!(...)`. This also removes the format strings in places where it is `"%?"`. Others cases, such as `"%s"` can be removed, too, but perhaps those are best left for another PR.
