### PR TITLE
Disallow non-comma-delimited arguments for fmt! and bytes!

### DIFF
--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -232,7 +232,7 @@ impl<'self> CheckLoanCtxt<'self> {
                     self.bccx.span_err(
                         new_loan.span,
                         fmt!("cannot borrow `%s` as %s because \
-                              it is also borrowed as %s"
+                              it is also borrowed as %s",
                              self.bccx.loan_path_to_str(new_loan.loan_path),
                              self.bccx.mut_to_str(new_loan.mutbl),
                              self.bccx.mut_to_str(old_loan.mutbl)));
@@ -320,7 +320,7 @@ impl<'self> CheckLoanCtxt<'self> {
         // Otherwise, just a plain error.
         self.bccx.span_err(
             expr.span,
-            fmt!("cannot assign to %s %s"
+            fmt!("cannot assign to %s %s",
                  cmt.mutbl.to_user_str(),
                  self.bccx.cmt_to_str(cmt)));
         return;

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -357,15 +357,16 @@ pub fn get_single_str_from_tts(cx: @ExtCtxt,
     }
 }
 
-pub fn get_exprs_from_tts(cx: @ExtCtxt, tts: &[ast::token_tree])
-                       -> ~[@ast::expr] {
+pub fn get_exprs_from_tts(cx: @ExtCtxt,
+                          sp: span,
+                          tts: &[ast::token_tree]) -> ~[@ast::expr] {
     let p = parse::new_parser_from_tts(cx.parse_sess(),
                                        cx.cfg(),
                                        tts.to_owned());
     let mut es = ~[];
     while *p.token != token::EOF {
-        if es.len() != 0 {
-            p.eat(&token::COMMA);
+        if es.len() != 0 && !p.eat(&token::COMMA) {
+            cx.span_fatal(sp, "expected token: `,`");
         }
         es.push(p.parse_expr());
     }

--- a/src/libsyntax/ext/bytes.rs
+++ b/src/libsyntax/ext/bytes.rs
@@ -18,7 +18,7 @@ use ext::build::AstBuilder;
 
 pub fn expand_syntax_ext(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree]) -> base::MacResult {
     // Gather all argument expressions
-    let exprs = get_exprs_from_tts(cx, tts);
+    let exprs = get_exprs_from_tts(cx, sp, tts);
     let mut bytes = ~[];
 
     for exprs.iter().advance |expr| {

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -26,7 +26,7 @@ use parse::token::{str_to_ident};
 
 pub fn expand_syntax_ext(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
     -> base::MacResult {
-    let args = get_exprs_from_tts(cx, tts);
+    let args = get_exprs_from_tts(cx, sp, tts);
     if args.len() == 0 {
         cx.span_fatal(sp, "fmt! takes at least 1 argument.");
     }


### PR DESCRIPTION
Closes #4982.
