### PR TITLE
Change concurrency primitives to standard naming conventions

### DIFF
--- a/doc/po/tutorial-tasks.md.pot
+++ b/doc/po/tutorial-tasks.md.pot
@@ -135,7 +135,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: doc/tutorial-tasks.md:56
 msgid ""
-"[`extra::arc`] - The ARC (atomically reference counted) type, for safely "
+"[`extra::arc`] - The Arc (atomically reference counted) type, for safely "
 "sharing immutable data,"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 
 #. type: Plain text
 #: doc/tutorial-tasks.md:338
-msgid "## Sharing immutable data without copy: ARC"
+msgid "## Sharing immutable data without copy: Arc"
 msgstr ""
 
 #. type: Plain text
@@ -613,18 +613,18 @@ msgstr ""
 #: doc/tutorial-tasks.md:347
 msgid ""
 "To tackle this issue, one can use an Atomically Reference Counted wrapper "
-"(`ARC`) as implemented in the `extra` library of Rust. With an ARC, the data "
-"will no longer be copied for each task. The ARC acts as a reference to the "
+"(`Arc`) as implemented in the `extra` library of Rust. With an Arc, the data "
+"will no longer be copied for each task. The Arc acts as a reference to the "
 "shared data and only this reference is shared and cloned."
 msgstr ""
 
 #. type: Plain text
 #: doc/tutorial-tasks.md:355
 msgid ""
-"Here is a small example showing how to use ARCs. We wish to run concurrently "
+"Here is a small example showing how to use Arcs. We wish to run concurrently "
 "several computations on a single large vector of floats. Each task needs the "
 "full vector to perform its duty.  ~~~ # use std::vec; # use std::uint; # use "
-"std::rand; use extra::arc::ARC;"
+"std::rand; use extra::arc::Arc;"
 msgstr ""
 
 #. type: Plain text
@@ -648,7 +648,7 @@ msgstr ""
 #. type: Plain text
 #: doc/tutorial-tasks.md:365
 #, no-wrap
-msgid "    let numbers_arc = ARC(numbers);\n"
+msgid "    let numbers_arc = Arc::new(numbers);\n"
 msgstr ""
 
 #. type: Plain text
@@ -665,7 +665,7 @@ msgstr ""
 #, no-wrap
 msgid ""
 "        do spawn {\n"
-"            let local_arc : ARC<~[float]> = port.recv();\n"
+"            let local_arc : Arc<~[float]> = port.recv();\n"
 "            let task_numbers = local_arc.get();\n"
 "            println(fmt!(\"%u-norm = %?\", num, pnorm(task_numbers, num)));\n"
 "        }\n"
@@ -679,23 +679,23 @@ msgstr ""
 msgid ""
 "The function `pnorm` performs a simple computation on the vector (it "
 "computes the sum of its items at the power given as argument and takes the "
-"inverse power of this value). The ARC on the vector is created by the line "
-"~~~ # use extra::arc::ARC; # use std::vec; # use std::rand; # let numbers = "
+"inverse power of this value). The Arc on the vector is created by the line "
+"~~~ # use extra::arc::Arc; # use std::vec; # use std::rand; # let numbers = "
 "vec::from_fn(1000000, |_| rand::random::<float>()); let "
-"numbers_arc=ARC(numbers); ~~~ and a clone of it is sent to each task ~~~ # "
-"use extra::arc::ARC; # use std::vec; # use std::rand; # let numbers=vec::"
+"numbers_arc=Arc::new(numbers); ~~~ and a clone of it is sent to each task ~~~ # "
+"use extra::arc::Arc; # use std::vec; # use std::rand; # let numbers=vec::"
 "from_fn(1000000, |_| rand::random::<float>()); # let numbers_arc = "
-"ARC(numbers); # let (port, chan)  = stream(); chan.send(numbers_arc."
+"Arc::new(numbers); # let (port, chan)  = stream(); chan.send(numbers_arc."
 "clone()); ~~~ copying only the wrapper and not its contents."
 msgstr ""
 
 #. type: Plain text
 #: doc/tutorial-tasks.md:414
 msgid ""
-"Each task recovers the underlying data by ~~~ # use extra::arc::ARC; # use "
+"Each task recovers the underlying data by ~~~ # use extra::arc::Arc; # use "
 "std::vec; # use std::rand; # let numbers=vec::from_fn(1000000, |_| rand::"
-"random::<float>()); # let numbers_arc=ARC(numbers); # let (port, chan)  = "
-"stream(); # chan.send(numbers_arc.clone()); # let local_arc : ARC<~[float]> "
+"random::<float>()); # let numbers_arc=Arc::new(numbers); # let (port, chan)  = "
+"stream(); # chan.send(numbers_arc.clone()); # let local_arc : Arc<~[float]> "
 "= port.recv(); let task_numbers = local_arc.get(); ~~~ and can use it as if "
 "it were local."
 msgstr ""
@@ -703,7 +703,7 @@ msgstr ""
 #. type: Plain text
 #: doc/tutorial-tasks.md:416
 msgid ""
-"The `arc` module also implements ARCs around mutable data that are not "
+"The `arc` module also implements Arcs around mutable data that are not "
 "covered here."
 msgstr ""
 

--- a/doc/tutorial-tasks.md
+++ b/doc/tutorial-tasks.md
@@ -50,7 +50,7 @@ concurrency at this writing:
 * [`std::pipes`] - The underlying messaging infrastructure,
 * [`extra::comm`] - Additional messaging types based on `std::pipes`,
 * [`extra::sync`] - More exotic synchronization tools, including locks,
-* [`extra::arc`] - The ARC (atomically reference counted) type,
+* [`extra::arc`] - The Arc (atomically reference counted) type,
   for safely sharing immutable data,
 * [`extra::future`] - A type representing values that may be computed concurrently and retrieved at a later time.
 
@@ -334,24 +334,24 @@ fn main() {
 }
 ~~~
 
-## Sharing immutable data without copy: ARC
+## Sharing immutable data without copy: Arc
 
 To share immutable data between tasks, a first approach would be to only use pipes as we have seen
 previously. A copy of the data to share would then be made for each task. In some cases, this would
 add up to a significant amount of wasted memory and would require copying the same data more than
 necessary.
 
-To tackle this issue, one can use an Atomically Reference Counted wrapper (`ARC`) as implemented in
-the `extra` library of Rust. With an ARC, the data will no longer be copied for each task. The ARC
+To tackle this issue, one can use an Atomically Reference Counted wrapper (`Arc`) as implemented in
+the `extra` library of Rust. With an Arc, the data will no longer be copied for each task. The Arc
 acts as a reference to the shared data and only this reference is shared and cloned.
 
-Here is a small example showing how to use ARCs. We wish to run concurrently several computations on
+Here is a small example showing how to use Arcs. We wish to run concurrently several computations on
 a single large vector of floats. Each task needs the full vector to perform its duty.
 ~~~
 # use std::vec;
 # use std::uint;
 # use std::rand;
-use extra::arc::ARC;
+use extra::arc::Arc;
 
 fn pnorm(nums: &~[float], p: uint) -> float {
     nums.iter().fold(0.0, |a,b| a+(*b).pow(&(p as float)) ).pow(&(1f / (p as float)))
@@ -361,14 +361,14 @@ fn main() {
     let numbers = vec::from_fn(1000000, |_| rand::random::<float>());
     println(fmt!("Inf-norm = %?",  *numbers.iter().max().unwrap()));
 
-    let numbers_arc = ARC(numbers);
+    let numbers_arc = Arc::new(numbers);
 
     for uint::range(1,10) |num| {
         let (port, chan)  = stream();
         chan.send(numbers_arc.clone());
 
         do spawn {
-            let local_arc : ARC<~[float]> = port.recv();
+            let local_arc : Arc<~[float]> = port.recv();
             let task_numbers = local_arc.get();
             println(fmt!("%u-norm = %?", num, pnorm(task_numbers, num)));
         }
@@ -377,22 +377,22 @@ fn main() {
 ~~~
 
 The function `pnorm` performs a simple computation on the vector (it computes the sum of its items
-at the power given as argument and takes the inverse power of this value). The ARC on the vector is
+at the power given as argument and takes the inverse power of this value). The Arc on the vector is
 created by the line
 ~~~
-# use extra::arc::ARC;
+# use extra::arc::Arc;
 # use std::vec;
 # use std::rand;
 # let numbers = vec::from_fn(1000000, |_| rand::random::<float>());
-let numbers_arc=ARC(numbers);
+let numbers_arc=Arc::new(numbers);
 ~~~
 and a clone of it is sent to each task
 ~~~
-# use extra::arc::ARC;
+# use extra::arc::Arc;
 # use std::vec;
 # use std::rand;
 # let numbers=vec::from_fn(1000000, |_| rand::random::<float>());
-# let numbers_arc = ARC(numbers);
+# let numbers_arc = Arc::new(numbers);
 # let (port, chan)  = stream();
 chan.send(numbers_arc.clone());
 ~~~
@@ -400,19 +400,19 @@ copying only the wrapper and not its contents.
 
 Each task recovers the underlying data by
 ~~~
-# use extra::arc::ARC;
+# use extra::arc::Arc;
 # use std::vec;
 # use std::rand;
 # let numbers=vec::from_fn(1000000, |_| rand::random::<float>());
-# let numbers_arc=ARC(numbers);
+# let numbers_arc=Arc::new(numbers);
 # let (port, chan)  = stream();
 # chan.send(numbers_arc.clone());
-# let local_arc : ARC<~[float]> = port.recv();
+# let local_arc : Arc<~[float]> = port.recv();
 let task_numbers = local_arc.get();
 ~~~
 and can use it as if it were local.
 
-The `arc` module also implements ARCs around mutable data that are not covered here.
+The `arc` module also implements Arcs around mutable data that are not covered here.
 
 # Handling task failure
 

--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -182,11 +182,11 @@ impl<T:Send> MutexArc<T> {
      * Create a mutex-protected Arc with the supplied data and a specified number
      * of condvars (as sync::Mutex::new_with_condvars).
      */
-    pub fn new_with_condvars(user_data: T,
-                             num_condvars: uint) -> MutexArc<T> {
-        let data =
-            MutexArcInner { lock: Mutex::new_with_condvars(num_condvars),
-                           failed: false, data: user_data };
+    pub fn new_with_condvars(user_data: T, num_condvars: uint) -> MutexArc<T> {
+        let data = MutexArcInner {
+            lock: Mutex::new_with_condvars(num_condvars),
+            failed: false, data: user_data
+        };
         MutexArc { x: UnsafeAtomicRcBox::new(data) }
     }
 
@@ -333,9 +333,10 @@ impl<T:Freeze + Send> RWArc<T> {
      * of condvars (as sync::RWLock::new_with_condvars).
      */
     pub fn new_with_condvars(user_data: T, num_condvars: uint) -> RWArc<T> {
-        let data =
-            RWArcInner { lock: RWLock::new_with_condvars(num_condvars),
-                        failed: false, data: user_data };
+        let data = RWArcInner {
+            lock: RWLock::new_with_condvars(num_condvars),
+            failed: false, data: user_data
+        };
         RWArc { x: UnsafeAtomicRcBox::new(data), }
     }
 

--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -15,13 +15,13 @@
  * # Example
  *
  * In this example, a large vector of floats is shared between several tasks.
- * With simple pipes, without ARC, a copy would have to be made for each task.
+ * With simple pipes, without Arc, a copy would have to be made for each task.
  *
  * ~~~ {.rust}
  * extern mod std;
  * use extra::arc;
  * let numbers=vec::from_fn(100, |ind| (ind as float)*rand::random());
- * let shared_numbers=arc::ARC(numbers);
+ * let shared_numbers=arc::Arc::new(numbers);
  *
  *   for 10.times {
  *       let (port, chan)  = stream();
@@ -41,7 +41,7 @@
 
 
 use sync;
-use sync::{Mutex, mutex_with_condvars, RWlock, rwlock_with_condvars};
+use sync::{Mutex, RWLock};
 
 use std::cast;
 use std::unstable::sync::UnsafeAtomicRcBox;
@@ -56,12 +56,12 @@ pub struct Condvar<'self> {
 }
 
 impl<'self> Condvar<'self> {
-    /// Atomically exit the associated ARC and block until a signal is sent.
+    /// Atomically exit the associated Arc and block until a signal is sent.
     #[inline]
     pub fn wait(&self) { self.wait_on(0) }
 
     /**
-     * Atomically exit the associated ARC and block on a specified condvar
+     * Atomically exit the associated Arc and block on a specified condvar
      * until a signal is sent on that same condvar (as sync::cond.wait_on).
      *
      * wait() is equivalent to wait_on(0).
@@ -104,37 +104,38 @@ impl<'self> Condvar<'self> {
 }
 
 /****************************************************************************
- * Immutable ARC
+ * Immutable Arc
  ****************************************************************************/
 
 /// An atomically reference counted wrapper for shared immutable state.
-pub struct ARC<T> { priv x: UnsafeAtomicRcBox<T> }
+pub struct Arc<T> { priv x: UnsafeAtomicRcBox<T> }
 
-/// Create an atomically reference counted wrapper.
-pub fn ARC<T:Freeze + Send>(data: T) -> ARC<T> {
-    ARC { x: UnsafeAtomicRcBox::new(data) }
-}
 
 /**
  * Access the underlying data in an atomically reference counted
  * wrapper.
  */
-impl<T:Freeze+Send> ARC<T> {
+impl<T:Freeze+Send> Arc<T> {
+    /// Create an atomically reference counted wrapper.
+    pub fn new(data: T) -> Arc<T> {
+        Arc { x: UnsafeAtomicRcBox::new(data) }
+    }
+
     pub fn get<'a>(&'a self) -> &'a T {
         unsafe { &*self.x.get_immut() }
     }
 
     /**
-     * Retrieve the data back out of the ARC. This function blocks until the
+     * Retrieve the data back out of the Arc. This function blocks until the
      * reference given to it is the last existing one, and then unwrap the data
      * instead of destroying it.
      *
      * If multiple tasks call unwrap, all but the first will fail. Do not call
-     * unwrap from a task that holds another reference to the same ARC; it is
+     * unwrap from a task that holds another reference to the same Arc; it is
      * guaranteed to deadlock.
      */
     pub fn unwrap(self) -> T {
-        let ARC { x: x } = self;
+        let Arc { x: x } = self;
         unsafe { x.unwrap() }
     }
 }
@@ -146,47 +147,48 @@ impl<T:Freeze+Send> ARC<T> {
  * object. However, one of the `arc` objects can be sent to another task,
  * allowing them to share the underlying data.
  */
-impl<T:Freeze + Send> Clone for ARC<T> {
-    fn clone(&self) -> ARC<T> {
-        ARC { x: self.x.clone() }
+impl<T:Freeze + Send> Clone for Arc<T> {
+    fn clone(&self) -> Arc<T> {
+        Arc { x: self.x.clone() }
     }
 }
 
 /****************************************************************************
- * Mutex protected ARC (unsafe)
+ * Mutex protected Arc (unsafe)
  ****************************************************************************/
 
 #[doc(hidden)]
-struct MutexARCInner<T> { priv lock: Mutex, priv failed: bool, priv data: T }
-/// An ARC with mutable data protected by a blocking mutex.
-struct MutexARC<T> { priv x: UnsafeAtomicRcBox<MutexARCInner<T>> }
+struct MutexArcInner<T> { priv lock: Mutex, priv failed: bool, priv data: T }
+/// An Arc with mutable data protected by a blocking mutex.
+struct MutexArc<T> { priv x: UnsafeAtomicRcBox<MutexArcInner<T>> }
 
-/// Create a mutex-protected ARC with the supplied data.
-pub fn MutexARC<T:Send>(user_data: T) -> MutexARC<T> {
-    mutex_arc_with_condvars(user_data, 1)
-}
-/**
- * Create a mutex-protected ARC with the supplied data and a specified number
- * of condvars (as sync::mutex_with_condvars).
- */
-pub fn mutex_arc_with_condvars<T:Send>(user_data: T,
-                                    num_condvars: uint) -> MutexARC<T> {
-    let data =
-        MutexARCInner { lock: mutex_with_condvars(num_condvars),
-                          failed: false, data: user_data };
-    MutexARC { x: UnsafeAtomicRcBox::new(data) }
-}
 
-impl<T:Send> Clone for MutexARC<T> {
-    /// Duplicate a mutex-protected ARC, as arc::clone.
-    fn clone(&self) -> MutexARC<T> {
+impl<T:Send> Clone for MutexArc<T> {
+    /// Duplicate a mutex-protected Arc, as arc::clone.
+    fn clone(&self) -> MutexArc<T> {
         // NB: Cloning the underlying mutex is not necessary. Its reference
         // count would be exactly the same as the shared state's.
-        MutexARC { x: self.x.clone() }
+        MutexArc { x: self.x.clone() }
     }
 }
 
-impl<T:Send> MutexARC<T> {
+impl<T:Send> MutexArc<T> {
+    /// Create a mutex-protected Arc with the supplied data.
+    pub fn new(user_data: T) -> MutexArc<T> {
+        MutexArc::new_with_condvars(user_data, 1)
+    }
+
+    /**
+     * Create a mutex-protected Arc with the supplied data and a specified number
+     * of condvars (as sync::Mutex::new_with_condvars).
+     */
+    pub fn new_with_condvars(user_data: T,
+                             num_condvars: uint) -> MutexArc<T> {
+        let data =
+            MutexArcInner { lock: Mutex::new_with_condvars(num_condvars),
+                           failed: false, data: user_data };
+        MutexArc { x: UnsafeAtomicRcBox::new(data) }
+    }
 
     /**
      * Access the underlying mutable data with mutual exclusion from other
@@ -195,10 +197,10 @@ impl<T:Send> MutexARC<T> {
      * finishes running.
      *
      * The reason this function is 'unsafe' is because it is possible to
-     * construct a circular reference among multiple ARCs by mutating the
+     * construct a circular reference among multiple Arcs by mutating the
      * underlying data. This creates potential for deadlock, but worse, this
-     * will guarantee a memory leak of all involved ARCs. Using mutex ARCs
-     * inside of other ARCs is safe in absence of circular references.
+     * will guarantee a memory leak of all involved Arcs. Using mutex Arcs
+     * inside of other Arcs is safe in absence of circular references.
      *
      * If you wish to nest mutex_arcs, one strategy for ensuring safety at
      * runtime is to add a "nesting level counter" inside the stored data, and
@@ -206,8 +208,8 @@ impl<T:Send> MutexARC<T> {
      *
      * # Failure
      *
-     * Failing while inside the ARC will unlock the ARC while unwinding, so
-     * that other tasks won't block forever. It will also poison the ARC:
+     * Failing while inside the Arc will unlock the Arc while unwinding, so
+     * that other tasks won't block forever. It will also poison the Arc:
      * any tasks that subsequently try to access it (including those already
      * blocked on the mutex) will also fail immediately.
      */
@@ -247,11 +249,11 @@ impl<T:Send> MutexARC<T> {
      * Will additionally fail if another task has failed while accessing the arc.
      */
     pub fn unwrap(self) -> T {
-        let MutexARC { x: x } = self;
+        let MutexArc { x: x } = self;
         let inner = unsafe { x.unwrap() };
-        let MutexARCInner { failed: failed, data: data, _ } = inner;
+        let MutexArcInner { failed: failed, data: data, _ } = inner;
         if failed {
-            fail!(~"Can't unwrap poisoned MutexARC - another task failed inside!");
+            fail!(~"Can't unwrap poisoned MutexArc - another task failed inside!");
         }
         data
     }
@@ -263,7 +265,7 @@ impl<T:Send> MutexARC<T> {
 fn check_poison(is_mutex: bool, failed: bool) {
     if failed {
         if is_mutex {
-            fail!("Poisoned MutexARC - another task failed inside!");
+            fail!("Poisoned MutexArc - another task failed inside!");
         } else {
             fail!("Poisoned rw_arc - another task failed inside!");
         }
@@ -294,60 +296,58 @@ fn PoisonOnFail<'r>(failed: &'r mut bool) -> PoisonOnFail {
 }
 
 /****************************************************************************
- * R/W lock protected ARC
+ * R/W lock protected Arc
  ****************************************************************************/
 
 #[doc(hidden)]
-struct RWARCInner<T> { priv lock: RWlock, priv failed: bool, priv data: T }
+struct RWArcInner<T> { priv lock: RWLock, priv failed: bool, priv data: T }
 /**
- * A dual-mode ARC protected by a reader-writer lock. The data can be accessed
+ * A dual-mode Arc protected by a reader-writer lock. The data can be accessed
  * mutably or immutably, and immutably-accessing tasks may run concurrently.
  *
  * Unlike mutex_arcs, rw_arcs are safe, because they cannot be nested.
  */
 #[no_freeze]
-struct RWARC<T> {
-    priv x: UnsafeAtomicRcBox<RWARCInner<T>>,
+struct RWArc<T> {
+    priv x: UnsafeAtomicRcBox<RWArcInner<T>>,
 }
 
-/// Create a reader/writer ARC with the supplied data.
-pub fn RWARC<T:Freeze + Send>(user_data: T) -> RWARC<T> {
-    rw_arc_with_condvars(user_data, 1)
-}
-/**
- * Create a reader/writer ARC with the supplied data and a specified number
- * of condvars (as sync::rwlock_with_condvars).
- */
-pub fn rw_arc_with_condvars<T:Freeze + Send>(
-    user_data: T,
-    num_condvars: uint) -> RWARC<T>
-{
-    let data =
-        RWARCInner { lock: rwlock_with_condvars(num_condvars),
-                     failed: false, data: user_data };
-    RWARC { x: UnsafeAtomicRcBox::new(data), }
-}
-
-impl<T:Freeze + Send> RWARC<T> {
-    /// Duplicate a rwlock-protected ARC, as arc::clone.
-    pub fn clone(&self) -> RWARC<T> {
-        RWARC {
+impl<T:Freeze + Send> RWArc<T> {
+    /// Duplicate a rwlock-protected Arc, as arc::clone.
+    pub fn clone(&self) -> RWArc<T> {
+        RWArc {
             x: self.x.clone(),
         }
     }
 
 }
 
-impl<T:Freeze + Send> RWARC<T> {
+impl<T:Freeze + Send> RWArc<T> {
+    /// Create a reader/writer Arc with the supplied data.
+    pub fn new(user_data: T) -> RWArc<T> {
+        RWArc::new_with_condvars(user_data, 1)
+    }
+
+    /**
+     * Create a reader/writer Arc with the supplied data and a specified number
+     * of condvars (as sync::RWLock::new_with_condvars).
+     */
+    pub fn new_with_condvars(user_data: T, num_condvars: uint) -> RWArc<T> {
+        let data =
+            RWArcInner { lock: RWLock::new_with_condvars(num_condvars),
+                        failed: false, data: user_data };
+        RWArc { x: UnsafeAtomicRcBox::new(data), }
+    }
+
     /**
      * Access the underlying data mutably. Locks the rwlock in write mode;
      * other readers and writers will block.
      *
      * # Failure
      *
-     * Failing while inside the ARC will unlock the ARC while unwinding, so
-     * that other tasks won't block forever. As MutexARC.access, it will also
-     * poison the ARC, so subsequent readers and writers will both also fail.
+     * Failing while inside the Arc will unlock the Arc while unwinding, so
+     * that other tasks won't block forever. As MutexArc.access, it will also
+     * poison the Arc, so subsequent readers and writers will both also fail.
      */
     #[inline]
     pub fn write<U>(&self, blk: &fn(x: &mut T) -> U) -> U {
@@ -385,8 +385,8 @@ impl<T:Freeze + Send> RWARC<T> {
      *
      * # Failure
      *
-     * Failing will unlock the ARC while unwinding. However, unlike all other
-     * access modes, this will not poison the ARC.
+     * Failing will unlock the Arc while unwinding. However, unlike all other
+     * access modes, this will not poison the Arc.
      */
     pub fn read<U>(&self, blk: &fn(x: &T) -> U) -> U {
         unsafe {
@@ -467,11 +467,11 @@ impl<T:Freeze + Send> RWARC<T> {
      * in write mode.
      */
     pub fn unwrap(self) -> T {
-        let RWARC { x: x, _ } = self;
+        let RWArc { x: x, _ } = self;
         let inner = unsafe { x.unwrap() };
-        let RWARCInner { failed: failed, data: data, _ } = inner;
+        let RWArcInner { failed: failed, data: data, _ } = inner;
         if failed {
-            fail!(~"Can't unwrap poisoned RWARC - another task failed inside!")
+            fail!(~"Can't unwrap poisoned RWArc - another task failed inside!")
         }
         data
     }
@@ -481,25 +481,25 @@ impl<T:Freeze + Send> RWARC<T> {
 // lock it. This wraps the unsafety, with the justification that the 'lock'
 // field is never overwritten; only 'failed' and 'data'.
 #[doc(hidden)]
-fn borrow_rwlock<T:Freeze + Send>(state: *mut RWARCInner<T>) -> *RWlock {
+fn borrow_rwlock<T:Freeze + Send>(state: *mut RWArcInner<T>) -> *RWLock {
     unsafe { cast::transmute(&(*state).lock) }
 }
 
-/// The "write permission" token used for RWARC.write_downgrade().
+/// The "write permission" token used for RWArc.write_downgrade().
 pub struct RWWriteMode<'self, T> {
     data: &'self mut T,
-    token: sync::RWlockWriteMode<'self>,
+    token: sync::RWLockWriteMode<'self>,
     poison: PoisonOnFail,
 }
 
-/// The "read permission" token used for RWARC.write_downgrade().
+/// The "read permission" token used for RWArc.write_downgrade().
 pub struct RWReadMode<'self, T> {
     data: &'self T,
-    token: sync::RWlockReadMode<'self>,
+    token: sync::RWLockReadMode<'self>,
 }
 
 impl<'self, T:Freeze + Send> RWWriteMode<'self, T> {
-    /// Access the pre-downgrade RWARC in write mode.
+    /// Access the pre-downgrade RWArc in write mode.
     pub fn write<U>(&mut self, blk: &fn(x: &mut T) -> U) -> U {
         match *self {
             RWWriteMode {
@@ -514,7 +514,7 @@ impl<'self, T:Freeze + Send> RWWriteMode<'self, T> {
         }
     }
 
-    /// Access the pre-downgrade RWARC in write mode with a condvar.
+    /// Access the pre-downgrade RWArc in write mode with a condvar.
     pub fn write_cond<'x, 'c, U>(&mut self,
                                  blk: &fn(x: &'x mut T, c: &'c Condvar) -> U)
                                  -> U {
@@ -570,7 +570,7 @@ mod tests {
     #[test]
     fn manually_share_arc() {
         let v = ~[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        let arc_v = ARC(v);
+        let arc_v = Arc::new(v);
 
         let (p, c) = comm::stream();
 
@@ -578,7 +578,7 @@ mod tests {
             let p = comm::PortSet::new();
             c.send(p.chan());
 
-            let arc_v : ARC<~[int]> = p.recv();
+            let arc_v : Arc<~[int]> = p.recv();
 
             let v = (*arc_v.get()).clone();
             assert_eq!(v[3], 4);
@@ -596,7 +596,7 @@ mod tests {
     #[test]
     fn test_mutex_arc_condvar() {
         unsafe {
-            let arc = ~MutexARC(false);
+            let arc = ~MutexArc::new(false);
             let arc2 = ~arc.clone();
             let (p,c) = comm::oneshot();
             let (c,p) = (Cell::new(c), Cell::new(p));
@@ -620,7 +620,7 @@ mod tests {
     #[test] #[should_fail] #[ignore(cfg(windows))]
     fn test_arc_condvar_poison() {
         unsafe {
-            let arc = ~MutexARC(1);
+            let arc = ~MutexArc::new(1);
             let arc2 = ~arc.clone();
             let (p, c) = comm::stream();
 
@@ -644,7 +644,7 @@ mod tests {
     #[test] #[should_fail] #[ignore(cfg(windows))]
     fn test_mutex_arc_poison() {
         unsafe {
-            let arc = ~MutexARC(1);
+            let arc = ~MutexArc::new(1);
             let arc2 = ~arc.clone();
             do task::try || {
                 do arc2.access |one| {
@@ -658,7 +658,7 @@ mod tests {
     }
     #[test] #[should_fail] #[ignore(cfg(windows))]
     pub fn test_mutex_arc_unwrap_poison() {
-        let arc = MutexARC(1);
+        let arc = MutexArc::new(1);
         let arc2 = ~(&arc).clone();
         let (p, c) = comm::stream();
         do task::spawn {
@@ -675,7 +675,7 @@ mod tests {
     }
     #[test] #[should_fail] #[ignore(cfg(windows))]
     fn test_rw_arc_poison_wr() {
-        let arc = ~RWARC(1);
+        let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
         do task::try || {
             do arc2.write |one| {
@@ -688,7 +688,7 @@ mod tests {
     }
     #[test] #[should_fail] #[ignore(cfg(windows))]
     fn test_rw_arc_poison_ww() {
-        let arc = ~RWARC(1);
+        let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
         do task::try || {
             do arc2.write |one| {
@@ -701,7 +701,7 @@ mod tests {
     }
     #[test] #[should_fail] #[ignore(cfg(windows))]
     fn test_rw_arc_poison_dw() {
-        let arc = ~RWARC(1);
+        let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
         do task::try || {
             do arc2.write_downgrade |mut write_mode| {
@@ -716,7 +716,7 @@ mod tests {
     }
     #[test] #[ignore(cfg(windows))]
     fn test_rw_arc_no_poison_rr() {
-        let arc = ~RWARC(1);
+        let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
         do task::try || {
             do arc2.read |one| {
@@ -729,7 +729,7 @@ mod tests {
     }
     #[test] #[ignore(cfg(windows))]
     fn test_rw_arc_no_poison_rw() {
-        let arc = ~RWARC(1);
+        let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
         do task::try || {
             do arc2.read |one| {
@@ -742,7 +742,7 @@ mod tests {
     }
     #[test] #[ignore(cfg(windows))]
     fn test_rw_arc_no_poison_dr() {
-        let arc = ~RWARC(1);
+        let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
         do task::try || {
             do arc2.write_downgrade |write_mode| {
@@ -758,7 +758,7 @@ mod tests {
     }
     #[test]
     fn test_rw_arc() {
-        let arc = ~RWARC(0);
+        let arc = ~RWArc::new(0);
         let arc2 = (*arc).clone();
         let (p,c) = comm::stream();
 
@@ -806,7 +806,7 @@ mod tests {
         // (4) tells writer and all other readers to contend as it downgrades.
         // (5) Writer attempts to set state back to 42, while downgraded task
         //     and all reader tasks assert that it's 31337.
-        let arc = ~RWARC(0);
+        let arc = ~RWArc::new(0);
 
         // Reader tasks
         let mut reader_convos = ~[];
@@ -884,10 +884,10 @@ mod tests {
         // the sync module rather than this one, but it's here because an
         // rwarc gives us extra shared state to help check for the race.
         // If you want to see this test fail, go to sync.rs and replace the
-        // line in RWlock::write_cond() that looks like:
+        // line in RWLock::write_cond() that looks like:
         //     "blk(&Condvar { order: opt_lock, ..*cond })"
         // with just "blk(cond)".
-        let x = ~RWARC(true);
+        let x = ~RWArc::new(true);
         let (wp, wc) = comm::stream();
 
         // writer task

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -15,7 +15,7 @@ use digest::DigestUtil;
 use json;
 use sha1::Sha1;
 use serialize::{Encoder, Encodable, Decoder, Decodable};
-use arc::{ARC,RWARC};
+use arc::{Arc,RWArc};
 use treemap::TreeMap;
 
 use std::cell::Cell;
@@ -176,10 +176,10 @@ impl Logger {
 
 #[deriving(Clone)]
 struct Context {
-    db: RWARC<Database>,
-    logger: RWARC<Logger>,
-    cfg: ARC<json::Object>,
-    freshness: ARC<TreeMap<~str,extern fn(&str,&str)->bool>>
+    db: RWArc<Database>,
+    logger: RWArc<Logger>,
+    cfg: Arc<json::Object>,
+    freshness: Arc<TreeMap<~str,extern fn(&str,&str)->bool>>
 }
 
 struct Prep<'self> {
@@ -229,14 +229,14 @@ fn digest_file(path: &Path) -> ~str {
 
 impl Context {
 
-    pub fn new(db: RWARC<Database>,
-               lg: RWARC<Logger>,
-               cfg: ARC<json::Object>) -> Context {
+    pub fn new(db: RWArc<Database>,
+               lg: RWArc<Logger>,
+               cfg: Arc<json::Object>) -> Context {
         Context {
             db: db,
             logger: lg,
             cfg: cfg,
-            freshness: ARC(TreeMap::new())
+            freshness: Arc::new(TreeMap::new())
         }
     }
 
@@ -383,9 +383,9 @@ fn test() {
         r.get_ref().write_str("int main() { return 0; }");
     }
 
-    let cx = Context::new(RWARC(Database::new(Path("db.json"))),
-                          RWARC(Logger::new()),
-                          ARC(TreeMap::new()));
+    let cx = Context::new(RWArc::new(Database::new(Path("db.json"))),
+                          RWArc::new(Logger::new()),
+                          Arc::new(TreeMap::new()));
 
     let s = do cx.with_prep("test1") |prep| {
 

--- a/src/libstd/comm.rs
+++ b/src/libstd/comm.rs
@@ -22,7 +22,7 @@ use option::{Option, Some, None};
 use uint;
 use vec::OwnedVector;
 use util::replace;
-use unstable::sync::{Exclusive, exclusive};
+use unstable::sync::Exclusive;
 use rtcomm = rt::comm;
 use rt;
 
@@ -228,7 +228,7 @@ impl<T: Send> SharedChan<T> {
     pub fn new(c: Chan<T>) -> SharedChan<T> {
         let Chan { inner } = c;
         let c = match inner {
-            Left(c) => Left(exclusive(c)),
+            Left(c) => Left(Exclusive::new(c)),
             Right(c) => Right(rtcomm::SharedChan::new(c))
         };
         SharedChan { inner: c }

--- a/src/libstd/rt/kill.rs
+++ b/src/libstd/rt/kill.rs
@@ -57,7 +57,7 @@ struct KillHandleInner {
 
     // Shared state between task and children for exit code propagation. These
     // are here so we can re-use the kill handle to implement watched children
-    // tasks. Using a separate ARClike would introduce extra atomic adds/subs
+    // tasks. Using a separate Arc-like would introduce extra atomic adds/subs
     // into common spawn paths, so this is just for speed.
 
     // Locklessly accessed; protected by the enclosing refcount's barriers.
@@ -217,7 +217,7 @@ impl KillHandle {
             // Exit code propagation fields
             any_child_failed: false,
             child_tombstones: None,
-            graveyard_lock:   LittleLock(),
+            graveyard_lock:   LittleLock::new(),
         }));
         (handle, flag_clone)
     }

--- a/src/libstd/rt/message_queue.rs
+++ b/src/libstd/rt/message_queue.rs
@@ -16,7 +16,7 @@ use kinds::Send;
 use vec::OwnedVector;
 use cell::Cell;
 use option::*;
-use unstable::sync::{Exclusive, exclusive};
+use unstable::sync::Exclusive;
 use clone::Clone;
 
 pub struct MessageQueue<T> {
@@ -27,7 +27,7 @@ pub struct MessageQueue<T> {
 impl<T: Send> MessageQueue<T> {
     pub fn new() -> MessageQueue<T> {
         MessageQueue {
-            queue: ~exclusive(~[])
+            queue: ~Exclusive::new(~[])
         }
     }
 

--- a/src/libstd/rt/sleeper_list.rs
+++ b/src/libstd/rt/sleeper_list.rs
@@ -15,7 +15,7 @@ use container::Container;
 use vec::OwnedVector;
 use option::{Option, Some, None};
 use cell::Cell;
-use unstable::sync::{Exclusive, exclusive};
+use unstable::sync::Exclusive;
 use rt::sched::SchedHandle;
 use clone::Clone;
 
@@ -26,7 +26,7 @@ pub struct SleeperList {
 impl SleeperList {
     pub fn new() -> SleeperList {
         SleeperList {
-            stack: ~exclusive(~[])
+            stack: ~Exclusive::new(~[])
         }
     }
 

--- a/src/libstd/rt/uv/uvio.rs
+++ b/src/libstd/rt/uv/uvio.rs
@@ -28,7 +28,7 @@ use rt::io::{standard_error, OtherIoError};
 use rt::tube::Tube;
 use rt::local::Local;
 use str::StrSlice;
-use unstable::sync::{Exclusive, exclusive};
+use unstable::sync::Exclusive;
 
 #[cfg(test)] use container::Container;
 #[cfg(test)] use uint;
@@ -158,7 +158,7 @@ pub struct UvRemoteCallback {
 
 impl UvRemoteCallback {
     pub fn new(loop_: &mut Loop, f: ~fn()) -> UvRemoteCallback {
-        let exit_flag = exclusive(false);
+        let exit_flag = Exclusive::new(false);
         let exit_flag_clone = exit_flag.clone();
         let async = do AsyncWatcher::new(loop_) |watcher, status| {
             assert!(status.is_none());

--- a/src/libstd/rt/work_queue.rs
+++ b/src/libstd/rt/work_queue.rs
@@ -11,7 +11,7 @@
 use container::Container;
 use option::*;
 use vec::OwnedVector;
-use unstable::sync::{Exclusive, exclusive};
+use unstable::sync::Exclusive;
 use cell::Cell;
 use kinds::Send;
 use clone::Clone;
@@ -24,7 +24,7 @@ pub struct WorkQueue<T> {
 impl<T: Send> WorkQueue<T> {
     pub fn new() -> WorkQueue<T> {
         WorkQueue {
-            queue: ~exclusive(~[])
+            queue: ~Exclusive::new(~[])
         }
     }
 

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -677,7 +677,7 @@ pub unsafe fn rekillable<U>(f: &fn() -> U) -> U {
 
 /**
  * A stronger version of unkillable that also inhibits scheduling operations.
- * For use with exclusive ARCs, which use pthread mutexes directly.
+ * For use with exclusive Arcs, which use pthread mutexes directly.
  */
 pub unsafe fn atomically<U>(f: &fn() -> U) -> U {
     use rt::task::Task;

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -91,7 +91,7 @@ use task::unkillable;
 use to_bytes::IterBytes;
 use uint;
 use util;
-use unstable::sync::{Exclusive, exclusive};
+use unstable::sync::Exclusive;
 use rt::{OldTaskContext, TaskContext, SchedulerContext, GlobalContext, context};
 use rt::local::Local;
 use rt::task::Task;
@@ -545,7 +545,7 @@ impl RuntimeGlue {
                             // Main task, doing first spawn ever. Lazily initialise here.
                             let mut members = TaskSet::new();
                             members.insert(OldTask(me));
-                            let tasks = exclusive(Some(TaskGroupData {
+                            let tasks = Exclusive::new(Some(TaskGroupData {
                                 members: members,
                                 descendants: TaskSet::new(),
                             }));
@@ -569,7 +569,7 @@ impl RuntimeGlue {
                         let mut members = TaskSet::new();
                         let my_handle = (*me).death.kill_handle.get_ref().clone();
                         members.insert(NewTask(my_handle));
-                        let tasks = exclusive(Some(TaskGroupData {
+                        let tasks = Exclusive::new(Some(TaskGroupData {
                             members: members,
                             descendants: TaskSet::new(),
                         }));
@@ -596,7 +596,7 @@ fn gen_child_taskgroup(linked: bool, supervised: bool)
             (spawner_group.tasks.clone(), ancestors, spawner_group.is_main)
         } else {
             // Child is in a separate group from spawner.
-            let g = exclusive(Some(TaskGroupData {
+            let g = Exclusive::new(Some(TaskGroupData {
                 members:     TaskSet::new(),
                 descendants: TaskSet::new(),
             }));
@@ -605,7 +605,7 @@ fn gen_child_taskgroup(linked: bool, supervised: bool)
                 assert!(new_generation < uint::max_value);
                 // Child's ancestors start with the spawner.
                 // Build a new node in the ancestor list.
-                AncestorList(Some(exclusive(AncestorNode {
+                AncestorList(Some(Exclusive::new(AncestorNode {
                     generation: new_generation,
                     parent_group: spawner_group.tasks.clone(),
                     ancestors: ancestors,

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -85,7 +85,7 @@ impl<T: Send> UnsafeAtomicRcBox<T> {
     }
 
     /// Wait until all other handles are dropped, then retrieve the enclosed
-    /// data. See extra::arc::ARC for specific semantics documentation.
+    /// data. See extra::arc::Arc for specific semantics documentation.
     /// If called when the task is already unkillable, unwrap will unkillably
     /// block; otherwise, an unwrapping task can be killed by linked failure.
     pub unsafe fn unwrap(self) -> T {
@@ -146,7 +146,7 @@ impl<T: Send> UnsafeAtomicRcBox<T> {
                 // If 'put' returns the server end back to us, we were rejected;
                 // someone else was trying to unwrap. Avoid guaranteed deadlock.
                 cast::forget(data);
-                fail!("Another task is already unwrapping this ARC!");
+                fail!("Another task is already unwrapping this Arc!");
             }
         }
     }
@@ -236,11 +236,13 @@ impl<T> Drop for UnsafeAtomicRcBox<T>{
 
 /****************************************************************************/
 
-#[allow(non_camel_case_types)] // runtime type
-type rust_little_lock = *libc::c_void;
+enum RTLittleLock {
+    // We know nothing about the runtime's representation of the
+    // little lock so we leave the definition empty.
+}
 
 pub struct LittleLock {
-    l: rust_little_lock,
+    l: *RTLittleLock,
 }
 
 impl Drop for LittleLock {
@@ -251,15 +253,15 @@ impl Drop for LittleLock {
     }
 }
 
-pub fn LittleLock() -> LittleLock {
-    unsafe {
-        LittleLock {
-            l: rust_create_little_lock()
+impl LittleLock {
+    pub fn new() -> LittleLock {
+        unsafe {
+            LittleLock {
+                l: rust_create_little_lock()
+            }
         }
     }
-}
 
-impl LittleLock {
     #[inline]
     pub unsafe fn lock<T>(&self, f: &fn() -> T) -> T {
         do atomically {
@@ -285,45 +287,45 @@ struct ExData<T> {
  * # Safety note
  *
  * This uses a pthread mutex, not one that's aware of the userspace scheduler.
- * The user of an exclusive must be careful not to invoke any functions that may
+ * The user of an Exclusive must be careful not to invoke any functions that may
  * reschedule the task while holding the lock, or deadlock may result. If you
- * need to block or yield while accessing shared state, use extra::sync::RWARC.
+ * need to block or yield while accessing shared state, use extra::sync::RWArc.
  */
 pub struct Exclusive<T> {
     x: UnsafeAtomicRcBox<ExData<T>>
 }
 
-pub fn exclusive<T:Send>(user_data: T) -> Exclusive<T> {
-    let data = ExData {
-        lock: LittleLock(),
-        failed: false,
-        data: user_data
-    };
-    Exclusive {
-        x: UnsafeAtomicRcBox::new(data)
-    }
-}
-
 impl<T:Send> Clone for Exclusive<T> {
-    // Duplicate an exclusive ARC, as std::arc::clone.
+    // Duplicate an Exclusive Arc, as std::arc::clone.
     fn clone(&self) -> Exclusive<T> {
         Exclusive { x: self.x.clone() }
     }
 }
 
 impl<T:Send> Exclusive<T> {
-    // Exactly like std::arc::mutex_arc,access(), but with the little_lock
+    pub fn new(user_data: T) -> Exclusive<T> {
+        let data = ExData {
+            lock: LittleLock::new(),
+            failed: false,
+            data: user_data
+        };
+        Exclusive {
+            x: UnsafeAtomicRcBox::new(data)
+        }
+    }
+
+    // Exactly like std::arc::MutexArc,access(), but with the LittleLock
     // instead of a proper mutex. Same reason for being unsafe.
     //
     // Currently, scheduling operations (i.e., yielding, receiving on a pipe,
     // accessing the provided condition variable) are prohibited while inside
-    // the exclusive. Supporting that is a work in progress.
+    // the Exclusive. Supporting that is a work in progress.
     #[inline]
     pub unsafe fn with<U>(&self, f: &fn(x: &mut T) -> U) -> U {
         let rec = self.x.get();
         do (*rec).lock.lock {
             if (*rec).failed {
-                fail!("Poisoned exclusive - another task failed inside!");
+                fail!("Poisoned Exclusive::new - another task failed inside!");
             }
             (*rec).failed = true;
             let result = f(&mut (*rec).data);
@@ -341,7 +343,7 @@ impl<T:Send> Exclusive<T> {
 
     pub fn unwrap(self) -> T {
         let Exclusive { x: x } = self;
-        // Someday we might need to unkillably unwrap an exclusive, but not today.
+        // Someday we might need to unkillably unwrap an Exclusive, but not today.
         let inner = unsafe { x.unwrap() };
         let ExData { data: user_data, _ } = inner; // will destroy the LittleLock
         user_data
@@ -349,10 +351,10 @@ impl<T:Send> Exclusive<T> {
 }
 
 extern {
-    fn rust_create_little_lock() -> rust_little_lock;
-    fn rust_destroy_little_lock(lock: rust_little_lock);
-    fn rust_lock_little_lock(lock: rust_little_lock);
-    fn rust_unlock_little_lock(lock: rust_little_lock);
+    fn rust_create_little_lock() -> *RTLittleLock;
+    fn rust_destroy_little_lock(lock: *RTLittleLock);
+    fn rust_lock_little_lock(lock: *RTLittleLock);
+    fn rust_unlock_little_lock(lock: *RTLittleLock);
 }
 
 #[cfg(test)]
@@ -360,20 +362,20 @@ mod tests {
     use cell::Cell;
     use comm;
     use option::*;
-    use super::{exclusive, UnsafeAtomicRcBox};
+    use super::{Exclusive, UnsafeAtomicRcBox};
     use task;
     use uint;
     use util;
 
     #[test]
-    fn exclusive_arc() {
+    fn exclusive_new_arc() {
         unsafe {
             let mut futures = ~[];
 
             let num_tasks = 10;
             let count = 10;
 
-            let total = exclusive(~0);
+            let total = Exclusive::new(~0);
 
             for uint::range(0, num_tasks) |_i| {
                 let total = total.clone();
@@ -399,11 +401,11 @@ mod tests {
     }
 
     #[test] #[should_fail] #[ignore(cfg(windows))]
-    fn exclusive_poison() {
+    fn exclusive_new_poison() {
         unsafe {
-            // Tests that if one task fails inside of an exclusive, subsequent
+            // Tests that if one task fails inside of an Exclusive::new, subsequent
             // accesses will also fail.
-            let x = exclusive(1);
+            let x = Exclusive::new(1);
             let x2 = x.clone();
             do task::try || {
                 do x2.with |one| {
@@ -466,15 +468,15 @@ mod tests {
     }
 
     #[test]
-    fn exclusive_unwrap_basic() {
+    fn exclusive_new_unwrap_basic() {
         // Unlike the above, also tests no double-freeing of the LittleLock.
-        let x = exclusive(~~"hello");
+        let x = Exclusive::new(~~"hello");
         assert!(x.unwrap() == ~~"hello");
     }
 
     #[test]
-    fn exclusive_unwrap_contended() {
-        let x = exclusive(~~"hello");
+    fn exclusive_new_unwrap_contended() {
+        let x = Exclusive::new(~~"hello");
         let x2 = Cell::new(x.clone());
         do task::spawn {
             let x2 = x2.take();
@@ -484,7 +486,7 @@ mod tests {
         assert!(x.unwrap() == ~~"hello");
 
         // Now try the same thing, but with the child task blocking.
-        let x = exclusive(~~"hello");
+        let x = Exclusive::new(~~"hello");
         let x2 = Cell::new(x.clone());
         let mut res = None;
         let mut builder = task::task();
@@ -499,8 +501,8 @@ mod tests {
     }
 
     #[test] #[should_fail] #[ignore(cfg(windows))]
-    fn exclusive_unwrap_conflict() {
-        let x = exclusive(~~"hello");
+    fn exclusive_new_unwrap_conflict() {
+        let x = Exclusive::new(~~"hello");
         let x2 = Cell::new(x.clone());
         let mut res = None;
         let mut builder = task::task();
@@ -515,14 +517,14 @@ mod tests {
     }
 
     #[test] #[ignore(cfg(windows))]
-    fn exclusive_unwrap_deadlock() {
+    fn exclusive_new_unwrap_deadlock() {
         // This is not guaranteed to get to the deadlock before being killed,
         // but it will show up sometimes, and if the deadlock were not there,
         // the test would nondeterministically fail.
         let result = do task::try {
-            // a task that has two references to the same exclusive will
+            // a task that has two references to the same Exclusive::new will
             // deadlock when it unwraps. nothing to be done about that.
-            let x = exclusive(~~"hello");
+            let x = Exclusive::new(~~"hello");
             let x2 = x.clone();
             do task::spawn {
                 for 10.times { task::yield(); } // try to let the unwrapper go

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -236,13 +236,11 @@ impl<T> Drop for UnsafeAtomicRcBox<T>{
 
 /****************************************************************************/
 
-enum RTLittleLock {
-    // We know nothing about the runtime's representation of the
-    // little lock so we leave the definition empty.
-}
+#[allow(non_camel_case_types)] // runtime type
+type rust_little_lock = *libc::c_void;
 
 pub struct LittleLock {
-    l: *RTLittleLock,
+    l: rust_little_lock,
 }
 
 impl Drop for LittleLock {
@@ -351,10 +349,10 @@ impl<T:Send> Exclusive<T> {
 }
 
 extern {
-    fn rust_create_little_lock() -> *RTLittleLock;
-    fn rust_destroy_little_lock(lock: *RTLittleLock);
-    fn rust_lock_little_lock(lock: *RTLittleLock);
-    fn rust_unlock_little_lock(lock: *RTLittleLock);
+    fn rust_create_little_lock() -> rust_little_lock;
+    fn rust_destroy_little_lock(lock: rust_little_lock);
+    fn rust_lock_little_lock(lock: rust_little_lock);
+    fn rust_unlock_little_lock(lock: rust_little_lock);
 }
 
 #[cfg(test)]

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2563,9 +2563,9 @@ mod tests {
     #[test]
     fn test_swap_remove_noncopyable() {
         // Tests that we don't accidentally run destructors twice.
-        let mut v = ~[::unstable::sync::exclusive(()),
-                      ::unstable::sync::exclusive(()),
-                      ::unstable::sync::exclusive(())];
+        let mut v = ~[::unstable::sync::Exclusive::new(()),
+                      ::unstable::sync::Exclusive::new(()),
+                      ::unstable::sync::Exclusive::new(())];
         let mut _e = v.swap_remove(0);
         assert_eq!(v.len(), 2);
         _e = v.swap_remove(1);

--- a/src/test/bench/graph500-bfs.rs
+++ b/src/test/bench/graph500-bfs.rs
@@ -230,7 +230,7 @@ fn bfs2(graph: graph, key: node_id) -> bfs_result {
 }
 
 /// A parallel version of the bfs function.
-fn pbfs(graph: &arc::ARC<graph>, key: node_id) -> bfs_result {
+fn pbfs(graph: &arc::Arc<graph>, key: node_id) -> bfs_result {
     // This works by doing functional updates of a color vector.
 
     let graph_vec = graph.get(); // FIXME #3387 requires this temp
@@ -263,7 +263,7 @@ fn pbfs(graph: &arc::ARC<graph>, key: node_id) -> bfs_result {
         i += 1;
         let old_len = colors.len();
 
-        let color = arc::ARC(colors);
+        let color = arc::Arc::new(colors);
 
         let color_vec = color.get(); // FIXME #3387 requires this temp
         colors = do par::mapi(*color_vec) {
@@ -444,7 +444,7 @@ fn main() {
     let mut total_seq = 0.0;
     let mut total_par = 0.0;
 
-    let graph_arc = arc::ARC(graph.clone());
+    let graph_arc = arc::Arc::new(graph.clone());
 
     do gen_search_keys(graph, num_keys).map() |root| {
         io::stdout().write_line("");

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -11,9 +11,9 @@
 // This test creates a bunch of tasks that simultaneously send to each
 // other in a ring. The messages should all be basically
 // independent.
-// This is like msgsend-ring-pipes but adapted to use ARCs.
+// This is like msgsend-ring-pipes but adapted to use Arcs.
 
-// This also serves as a pipes test, because ARCs are implemented with pipes.
+// This also serves as a pipes test, because Arcs are implemented with pipes.
 
 extern mod extra;
 
@@ -26,7 +26,7 @@ use std::os;
 use std::uint;
 
 // A poor man's pipe.
-type pipe = arc::MutexARC<~[uint]>;
+type pipe = arc::MutexArc<~[uint]>;
 
 fn send(p: &pipe, msg: uint) {
     unsafe {
@@ -48,7 +48,7 @@ fn recv(p: &pipe) -> uint {
 }
 
 fn init() -> (pipe,pipe) {
-    let m = arc::MutexARC(~[]);
+    let m = arc::MutexArc::new(~[]);
     ((&m).clone(), m)
 }
 

--- a/src/test/bench/msgsend-ring-rw-arcs.rs
+++ b/src/test/bench/msgsend-ring-rw-arcs.rs
@@ -11,9 +11,9 @@
 // This test creates a bunch of tasks that simultaneously send to each
 // other in a ring. The messages should all be basically
 // independent.
-// This is like msgsend-ring-pipes but adapted to use ARCs.
+// This is like msgsend-ring-pipes but adapted to use Arcs.
 
-// This also serves as a pipes test, because ARCs are implemented with pipes.
+// This also serves as a pipes test, because Arcs are implemented with pipes.
 
 extern mod extra;
 
@@ -26,7 +26,7 @@ use std::os;
 use std::uint;
 
 // A poor man's pipe.
-type pipe = arc::RWARC<~[uint]>;
+type pipe = arc::RWArc<~[uint]>;
 
 fn send(p: &pipe, msg: uint) {
     do p.write_cond |state, cond| {
@@ -44,7 +44,7 @@ fn recv(p: &pipe) -> uint {
 }
 
 fn init() -> (pipe,pipe) {
-    let x = arc::RWARC(~[]);
+    let x = arc::RWArc::new(~[]);
     ((&x).clone(), x)
 }
 

--- a/src/test/compile-fail/arc-rw-cond-shouldnt-escape.rs
+++ b/src/test/compile-fail/arc-rw-cond-shouldnt-escape.rs
@@ -12,7 +12,7 @@
 extern mod extra;
 use extra::arc;
 fn main() {
-    let x = ~arc::RWARC(1);
+    let x = ~arc::RWArc::new(1);
     let mut y = None;
     do x.write_cond |_one, cond| {
         y = Some(cond);

--- a/src/test/compile-fail/arc-rw-read-mode-shouldnt-escape.rs
+++ b/src/test/compile-fail/arc-rw-read-mode-shouldnt-escape.rs
@@ -11,7 +11,7 @@
 extern mod extra;
 use extra::arc;
 fn main() {
-    let x = ~arc::RWARC(1);
+    let x = ~arc::RWArc::new(1);
     let mut y = None;
     do x.write_downgrade |write_mode| {
         y = Some(x.downgrade(write_mode));

--- a/src/test/compile-fail/arc-rw-state-shouldnt-escape.rs
+++ b/src/test/compile-fail/arc-rw-state-shouldnt-escape.rs
@@ -11,7 +11,7 @@
 extern mod extra;
 use extra::arc;
 fn main() {
-    let x = ~arc::RWARC(1);
+    let x = ~arc::RWArc::new(1);
     let mut y = None; //~ ERROR lifetime of variable does not enclose its declaration
     do x.write |one| {
         y = Some(one);

--- a/src/test/compile-fail/arc-rw-write-mode-cond-shouldnt-escape.rs
+++ b/src/test/compile-fail/arc-rw-write-mode-cond-shouldnt-escape.rs
@@ -12,7 +12,7 @@
 extern mod extra;
 use extra::arc;
 fn main() {
-    let x = ~arc::RWARC(1);
+    let x = ~arc::RWArc::new(1);
     let mut y = None;
     do x.write_downgrade |write_mode| {
         do (&write_mode).write_cond |_one, cond| {

--- a/src/test/compile-fail/arc-rw-write-mode-shouldnt-escape.rs
+++ b/src/test/compile-fail/arc-rw-write-mode-shouldnt-escape.rs
@@ -12,7 +12,7 @@
 extern mod extra;
 use extra::arc;
 fn main() {
-    let x = ~arc::RWARC(1);
+    let x = ~arc::RWArc::new(1);
     let mut y = None;
     do x.write_downgrade |write_mode| {
         y = Some(write_mode);

--- a/src/test/compile-fail/no-capture-arc.rs
+++ b/src/test/compile-fail/no-capture-arc.rs
@@ -17,7 +17,7 @@ use std::task;
 
 fn main() {
     let v = ~[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let arc_v = arc::ARC(v);
+    let arc_v = arc::Arc::new(v);
 
     do task::spawn() {
         let v = arc_v.get();

--- a/src/test/compile-fail/no-reuse-move-arc.rs
+++ b/src/test/compile-fail/no-reuse-move-arc.rs
@@ -15,7 +15,7 @@ use std::task;
 
 fn main() {
     let v = ~[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let arc_v = arc::ARC(v);
+    let arc_v = arc::Arc::new(v);
 
     do task::spawn() {
         let v = arc_v.get();

--- a/src/test/compile-fail/once-cant-call-twice-on-heap.rs
+++ b/src/test/compile-fail/once-cant-call-twice-on-heap.rs
@@ -21,7 +21,7 @@ fn foo(blk: ~once fn()) {
 }
 
 fn main() {
-    let x = arc::ARC(true);
+    let x = arc::Arc::new(true);
     do foo {
         assert!(*x.get());
         util::ignore(x);

--- a/src/test/compile-fail/once-cant-call-twice-on-stack.rs
+++ b/src/test/compile-fail/once-cant-call-twice-on-stack.rs
@@ -22,7 +22,7 @@ fn foo(blk: &once fn()) {
 }
 
 fn main() {
-    let x = arc::ARC(true);
+    let x = arc::Arc::new(true);
     do foo {
         assert!(*x.get());
         util::ignore(x);

--- a/src/test/compile-fail/once-cant-move-out-of-non-once-on-heap.rs
+++ b/src/test/compile-fail/once-cant-move-out-of-non-once-on-heap.rs
@@ -21,7 +21,7 @@ fn foo(blk: ~fn()) {
 }
 
 fn main() {
-    let x = arc::ARC(true);
+    let x = arc::Arc::new(true);
     do foo {
         assert!(*x.get());
         util::ignore(x); //~ ERROR cannot move out of captured outer variable

--- a/src/test/compile-fail/once-cant-move-out-of-non-once-on-stack.rs
+++ b/src/test/compile-fail/once-cant-move-out-of-non-once-on-stack.rs
@@ -21,7 +21,7 @@ fn foo(blk: &fn()) {
 }
 
 fn main() {
-    let x = arc::ARC(true);
+    let x = arc::Arc::new(true);
     do foo {
         assert!(*x.get());
         util::ignore(x); //~ ERROR cannot move out of captured outer variable

--- a/src/test/compile-fail/sync-cond-shouldnt-escape.rs
+++ b/src/test/compile-fail/sync-cond-shouldnt-escape.rs
@@ -13,7 +13,7 @@ extern mod extra;
 use extra::sync;
 
 fn main() {
-    let m = ~sync::Mutex();
+    let m = ~sync::Mutex::new();
     let mut cond = None;
     do m.lock_cond |c| {
         cond = Some(c);

--- a/src/test/compile-fail/sync-rwlock-cond-shouldnt-escape.rs
+++ b/src/test/compile-fail/sync-rwlock-cond-shouldnt-escape.rs
@@ -12,7 +12,7 @@
 extern mod extra;
 use extra::sync;
 fn main() {
-    let x = ~sync::RWlock();
+    let x = ~sync::RWLock::new();
     let mut y = None;
     do x.write_cond |cond| {
         y = Some(cond);

--- a/src/test/compile-fail/sync-rwlock-read-mode-shouldnt-escape.rs
+++ b/src/test/compile-fail/sync-rwlock-read-mode-shouldnt-escape.rs
@@ -12,7 +12,7 @@
 extern mod extra;
 use extra::sync;
 fn main() {
-    let x = ~sync::RWlock();
+    let x = ~sync::RWLock::new();
     let mut y = None;
     do x.write_downgrade |write_mode| {
         y = Some(x.downgrade(write_mode));

--- a/src/test/compile-fail/sync-rwlock-write-mode-cond-shouldnt-escape.rs
+++ b/src/test/compile-fail/sync-rwlock-write-mode-cond-shouldnt-escape.rs
@@ -12,7 +12,7 @@
 extern mod extra;
 use extra::sync;
 fn main() {
-    let x = ~sync::RWlock();
+    let x = ~sync::RWLock::new();
     let mut y = None;
     do x.write_downgrade |write_mode| {
         do (&write_mode).write_cond |cond| {

--- a/src/test/compile-fail/sync-rwlock-write-mode-shouldnt-escape.rs
+++ b/src/test/compile-fail/sync-rwlock-write-mode-shouldnt-escape.rs
@@ -12,7 +12,7 @@
 extern mod extra;
 use extra::sync;
 fn main() {
-    let x = ~sync::RWlock();
+    let x = ~sync::RWLock::new();
     let mut y = None;
     do x.write_downgrade |write_mode| {
         y = Some(write_mode);

--- a/src/test/run-fail/issue-2444.rs
+++ b/src/test/run-fail/issue-2444.rs
@@ -13,7 +13,7 @@
 extern mod extra;
 use extra::arc;
 
-enum e<T> { e(arc::ARC<T>) }
+enum e<T> { e(arc::Arc<T>) }
 
 fn foo() -> e<int> {fail!();}
 

--- a/src/test/run-pass/bind-by-move.rs
+++ b/src/test/run-pass/bind-by-move.rs
@@ -11,10 +11,10 @@
 // xfail-fast
 extern mod extra;
 use extra::arc;
-fn dispose(_x: arc::ARC<bool>) { unsafe { } }
+fn dispose(_x: arc::Arc<bool>) { unsafe { } }
 
 pub fn main() {
-    let p = arc::ARC(true);
+    let p = arc::Arc::new(true);
     let x = Some(p);
     match x {
         Some(z) => { dispose(z); },

--- a/src/test/run-pass/match-ref-binding-in-guard-3256.rs
+++ b/src/test/run-pass/match-ref-binding-in-guard-3256.rs
@@ -12,7 +12,7 @@ use std::unstable;
 
 pub fn main() {
     unsafe {
-        let x = Some(unstable::sync::exclusive(true));
+        let x = Some(unstable::sync::Exclusive::new(true));
         match x {
             Some(ref z) if z.with(|b| *b) => {
                 do z.with |b| { assert!(*b); }

--- a/src/test/run-pass/once-move-out-on-heap.rs
+++ b/src/test/run-pass/once-move-out-on-heap.rs
@@ -21,7 +21,7 @@ fn foo(blk: ~once fn()) {
 }
 
 fn main() {
-    let x = arc::ARC(true);
+    let x = arc::Arc::new(true);
     do foo {
         assert!(*x.get());
         util::ignore(x);

--- a/src/test/run-pass/once-move-out-on-stack.rs
+++ b/src/test/run-pass/once-move-out-on-stack.rs
@@ -22,7 +22,7 @@ fn foo(blk: &once fn()) {
 }
 
 fn main() {
-    let x = arc::ARC(true);
+    let x = arc::Arc::new(true);
     do foo {
         assert!(*x.get());
         util::ignore(x);

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Tests that a heterogeneous list of existential types can be put inside an ARC
+// Tests that a heterogeneous list of existential types can be put inside an Arc
 // and shared between tasks as long as all types fulfill Freeze+Send.
 
 // xfail-fast
@@ -64,7 +64,7 @@ fn main() {
     let dogge1 = Dogge { bark_decibels: 100, tricks_known: 42, name: ~"alan_turing" };
     let dogge2 = Dogge { bark_decibels: 55,  tricks_known: 11, name: ~"albert_einstein" };
     let fishe = Goldfyshe { swim_speed: 998, name: ~"alec_guinness" };
-    let arc = arc::ARC(~[~catte  as ~Pet:Freeze+Send,
+    let arc = arc::Arc::new(~[~catte  as ~Pet:Freeze+Send,
                          ~dogge1 as ~Pet:Freeze+Send,
                          ~fishe  as ~Pet:Freeze+Send,
                          ~dogge2 as ~Pet:Freeze+Send]);
@@ -82,21 +82,21 @@ fn main() {
     p3.recv();
 }
 
-fn check_legs(arc: arc::ARC<~[~Pet:Freeze+Send]>) {
+fn check_legs(arc: arc::Arc<~[~Pet:Freeze+Send]>) {
     let mut legs = 0;
     for arc.get().iter().advance |pet| {
         legs += pet.num_legs();
     }
     assert!(legs == 12);
 }
-fn check_names(arc: arc::ARC<~[~Pet:Freeze+Send]>) {
+fn check_names(arc: arc::Arc<~[~Pet:Freeze+Send]>) {
     for arc.get().iter().advance |pet| {
         do pet.name |name| {
             assert!(name[0] == 'a' as u8 && name[1] == 'l' as u8);
         }
     }
 }
-fn check_pedigree(arc: arc::ARC<~[~Pet:Freeze+Send]>) {
+fn check_pedigree(arc: arc::Arc<~[~Pet:Freeze+Send]>) {
     for arc.get().iter().advance |pet| {
         assert!(pet.of_good_pedigree());
     }

--- a/src/test/run-pass/writealias.rs
+++ b/src/test/run-pass/writealias.rs
@@ -17,7 +17,7 @@ fn f(p: &mut Point) { p.z = 13; }
 
 pub fn main() {
     unsafe {
-        let x = Some(unstable::sync::exclusive(true));
+        let x = Some(unstable::sync::Exclusive::new(true));
         match x {
             Some(ref z) if z.with(|b| *b) => {
                 do z.with |b| { assert!(*b); }


### PR DESCRIPTION
To be more specific:

`UPPERCASETYPE` was changed to `UppercaseType`
`type_new` was changed to `Type::new`
`type_function(value)` was changed to `value.method()`
