### PR TITLE
Consolidate raw representations of rust values

### DIFF
--- a/src/libstd/at_vec.rs
+++ b/src/libstd/at_vec.rs
@@ -10,13 +10,13 @@
 
 //! Managed vectors
 
-use cast::transmute;
 use clone::Clone;
 use container::Container;
 use iterator::IteratorUtil;
 use option::Option;
 use sys;
 use uint;
+use unstable::raw::Repr;
 use vec::{ImmutableVector, OwnedVector};
 
 /// Code for dealing with @-vectors. This is pretty incomplete, and
@@ -26,8 +26,8 @@ use vec::{ImmutableVector, OwnedVector};
 #[inline]
 pub fn capacity<T>(v: @[T]) -> uint {
     unsafe {
-        let repr: **raw::VecRepr = transmute(&v);
-        (**repr).unboxed.alloc / sys::size_of::<T>()
+        let box = v.repr();
+        (*box).data.alloc / sys::size_of::<T>()
     }
 }
 
@@ -45,10 +45,10 @@ pub fn capacity<T>(v: @[T]) -> uint {
  */
 #[inline]
 pub fn build_sized<A>(size: uint, builder: &fn(push: &fn(v: A))) -> @[A] {
-    let mut vec: @[A] = @[];
+    let mut vec = @[];
     unsafe { raw::reserve(&mut vec, size); }
     builder(|x| unsafe { raw::push(&mut vec, x) });
-    return unsafe { transmute(vec) };
+    vec
 }
 
 /**
@@ -151,7 +151,7 @@ pub fn to_managed_consume<T>(v: ~[T]) -> @[T] {
         for v.consume_iter().advance |x| {
             raw::push(&mut av, x);
         }
-        transmute(av)
+        av
     }
 }
 
@@ -195,13 +195,9 @@ pub mod raw {
     use ptr;
     use sys;
     use uint;
-    use unstable::intrinsics;
     use unstable::intrinsics::{move_val_init, TyDesc};
-    use vec;
-    use vec::UnboxedVecRepr;
-
-    pub type VecRepr = vec::raw::VecRepr;
-    pub type SliceRepr = vec::raw::SliceRepr;
+    use unstable::intrinsics;
+    use unstable::raw::{Box, Vec};
 
     /**
      * Sets the length of a vector
@@ -211,9 +207,9 @@ pub mod raw {
      * the vector is actually the specified size.
      */
     #[inline]
-    pub unsafe fn set_len<T>(v: @[T], new_len: uint) {
-        let repr: **mut VecRepr = transmute(&v);
-        (**repr).unboxed.fill = new_len * sys::size_of::<T>();
+    pub unsafe fn set_len<T>(v: &mut @[T], new_len: uint) {
+        let repr: *mut Box<Vec<T>> = cast::transmute_copy(v);
+        (*repr).data.fill = new_len * sys::size_of::<T>();
     }
 
     /**
@@ -221,9 +217,11 @@ pub mod raw {
      */
     #[inline]
     pub unsafe fn push<T>(v: &mut @[T], initval: T) {
-        let repr: **VecRepr = transmute_copy(&v);
-        let fill = (**repr).unboxed.fill;
-        if (**repr).unboxed.alloc > fill {
+        let full = {
+            let repr: *Box<Vec<T>> = cast::transmute_copy(v);
+            (*repr).data.alloc > (*repr).data.fill
+        };
+        if full {
             push_fast(v, initval);
         } else {
             push_slow(v, initval);
@@ -232,16 +230,15 @@ pub mod raw {
 
     #[inline] // really pretty please
     unsafe fn push_fast<T>(v: &mut @[T], initval: T) {
-        let repr: **mut VecRepr = ::cast::transmute(v);
-        let fill = (**repr).unboxed.fill;
-        (**repr).unboxed.fill += sys::size_of::<T>();
-        let p = &((**repr).unboxed.data);
-        let p = ptr::offset(p, fill) as *mut T;
+        let repr: *mut Box<Vec<T>> = cast::transmute_copy(v);
+        let amt = v.len();
+        (*repr).data.fill += sys::size_of::<T>();
+        let p = ptr::offset(&(*repr).data.data as *T, amt) as *mut T;
         move_val_init(&mut(*p), initval);
     }
 
     unsafe fn push_slow<T>(v: &mut @[T], initval: T) {
-        reserve_at_least(&mut *v, v.len() + 1u);
+        reserve_at_least(v, v.len() + 1u);
         push_fast(v, initval);
     }
 
@@ -259,7 +256,7 @@ pub mod raw {
     pub unsafe fn reserve<T>(v: &mut @[T], n: uint) {
         // Only make the (slow) call into the runtime if we have to
         if capacity(*v) < n {
-            let ptr: *mut *mut VecRepr = transmute(v);
+            let ptr: *mut *mut Box<Vec<()>> = transmute(v);
             let ty = intrinsics::get_tydesc::<T>();
             // XXX transmute shouldn't be necessary
             let ty = cast::transmute(ty);
@@ -269,16 +266,14 @@ pub mod raw {
 
     // Implementation detail. Shouldn't be public
     #[allow(missing_doc)]
-    pub fn reserve_raw(ty: *TyDesc, ptr: *mut *mut VecRepr, n: uint) {
+    pub fn reserve_raw(ty: *TyDesc, ptr: *mut *mut Box<Vec<()>>, n: uint) {
 
         unsafe {
             let size_in_bytes = n * (*ty).size;
-            if size_in_bytes > (**ptr).unboxed.alloc {
-                let total_size = size_in_bytes + sys::size_of::<UnboxedVecRepr>();
-                // XXX: UnboxedVecRepr has an extra u8 at the end
-                let total_size = total_size - sys::size_of::<u8>();
-                (*ptr) = local_realloc(*ptr as *(), total_size) as *mut VecRepr;
-                (**ptr).unboxed.alloc = size_in_bytes;
+            if size_in_bytes > (**ptr).data.alloc {
+                let total_size = size_in_bytes + sys::size_of::<Vec<()>>();
+                (*ptr) = local_realloc(*ptr as *(), total_size) as *mut Box<Vec<()>>;
+                (**ptr).data.alloc = size_in_bytes;
             }
         }
 

--- a/src/libstd/cast.rs
+++ b/src/libstd/cast.rs
@@ -133,6 +133,7 @@ pub unsafe fn copy_lifetime_vec<'a,S,T>(_ptr: &'a [S], ptr: &T) -> &'a T {
 #[cfg(test)]
 mod tests {
     use cast::{bump_box_refcount, transmute};
+    use unstable::raw;
 
     #[test]
     fn test_transmute_copy() {
@@ -156,10 +157,9 @@ mod tests {
 
     #[test]
     fn test_transmute() {
-        use managed::raw::BoxRepr;
         unsafe {
             let x = @100u8;
-            let x: *BoxRepr = transmute(x);
+            let x: *raw::Box<u8> = transmute(x);
             assert!((*x).data == 100);
             let _x: @int = transmute(x);
         }

--- a/src/libstd/gc.rs
+++ b/src/libstd/gc.rs
@@ -74,14 +74,14 @@ pub mod rustrt {
 }
 
 unsafe fn bump<T, U>(ptr: *T, count: uint) -> *U {
-    return cast::transmute(ptr::offset(ptr, count));
+    return ptr::offset(ptr, count) as *U;
 }
 
 unsafe fn align_to_pointer<T>(ptr: *T) -> *T {
     let align = sys::min_align_of::<*T>();
-    let ptr: uint = cast::transmute(ptr);
+    let ptr = ptr as uint;
     let ptr = (ptr + (align - 1)) & -align;
-    return cast::transmute(ptr);
+    return ptr as *T;
 }
 
 unsafe fn get_safe_point_count() -> uint {
@@ -126,8 +126,8 @@ type Visitor<'self> = &'self fn(root: **Word, tydesc: *TyDesc) -> bool;
 // Walks the list of roots for the given safe point, and calls visitor
 // on each root.
 unsafe fn _walk_safe_point(fp: *Word, sp: SafePoint, visitor: Visitor) -> bool {
-    let fp_bytes: *u8 = cast::transmute(fp);
-    let sp_meta: *u32 = cast::transmute(sp.sp_meta);
+    let fp_bytes = fp as *u8;
+    let sp_meta = sp.sp_meta as *u32;
 
     let num_stack_roots = *sp_meta as uint;
     let num_reg_roots = *ptr::offset(sp_meta, 1) as uint;
@@ -173,9 +173,9 @@ unsafe fn walk_safe_point(fp: *Word, sp: SafePoint, visitor: Visitor) -> bool {
 
 // Is fp contained in segment?
 unsafe fn is_frame_in_segment(fp: *Word, segment: *StackSegment) -> bool {
-    let begin: Word = cast::transmute(segment);
-    let end: Word = cast::transmute((*segment).end);
-    let frame: Word = cast::transmute(fp);
+    let begin = segment as Word;
+    let end = (*segment).end as Word;
+    let frame = fp as Word;
 
     return begin <= frame && frame <= end;
 }

--- a/src/libstd/managed.rs
+++ b/src/libstd/managed.rs
@@ -14,27 +14,8 @@ use ptr::to_unsafe_ptr;
 
 #[cfg(not(test))] use cmp::{Eq, Ord};
 
-pub mod raw {
-    use std::unstable::intrinsics::TyDesc;
-
-    pub static RC_MANAGED_UNIQUE : uint = (-2) as uint;
-    pub static RC_IMMORTAL : uint = 0x77777777;
-
-    #[allow(missing_doc)]
-    pub struct BoxHeaderRepr {
-        ref_count: uint,
-        type_desc: *TyDesc,
-        prev: *BoxRepr,
-        next: *BoxRepr,
-    }
-
-    #[allow(missing_doc)]
-    pub struct BoxRepr {
-        header: BoxHeaderRepr,
-        data: u8
-    }
-
-}
+pub static RC_MANAGED_UNIQUE : uint = (-2) as uint;
+pub static RC_IMMORTAL : uint = 0x77777777;
 
 /// Determine if two shared boxes point to the same object
 #[inline]

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -19,7 +19,7 @@ Runtime type reflection
 use unstable::intrinsics::{Opaque, TyDesc, TyVisitor};
 use libc::c_void;
 use sys;
-use vec;
+use unstable::raw;
 
 /**
  * Trait for visitor that wishes to reflect on data. To use this, create a
@@ -260,7 +260,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
     }
 
     fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
-        self.align_to::<vec::UnboxedVecRepr>();
+        self.align_to::<raw::Vec<()>>();
         if ! self.inner.visit_vec(mtbl, inner) { return false; }
         true
     }

--- a/src/libstd/rt/global_heap.rs
+++ b/src/libstd/rt/global_heap.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 use libc::{c_void, c_char, size_t, uintptr_t, free, malloc, realloc};
-use managed::raw::{BoxHeaderRepr, BoxRepr};
 use unstable::intrinsics::TyDesc;
+use unstable::raw;
 use sys::size_of;
 
 extern {
@@ -20,7 +20,7 @@ extern {
 
 #[inline]
 fn get_box_size(body_size: uint, body_align: uint) -> uint {
-    let header_size = size_of::<BoxHeaderRepr>();
+    let header_size = size_of::<raw::Box<()>>();
     // FIXME (#2699): This alignment calculation is suspicious. Is it right?
     let total_size = align_to(header_size, body_align) + body_size;
     total_size
@@ -82,8 +82,8 @@ pub unsafe fn closure_exchange_malloc(td: *c_char, size: uintptr_t) -> *c_char {
     let total_size = get_box_size(size, (*td).align);
     let p = malloc_raw(total_size as uint);
 
-    let box: *mut BoxRepr = p as *mut BoxRepr;
-    (*box).header.type_desc = td;
+    let box = p as *mut raw::Box<()>;
+    (*box).type_desc = td;
 
     box as *c_char
 }

--- a/src/libstd/rt/local_heap.rs
+++ b/src/libstd/rt/local_heap.rs
@@ -13,11 +13,11 @@
 use libc;
 use libc::{c_void, uintptr_t, size_t};
 use ops::Drop;
-use repr::BoxRepr;
 use rt;
 use rt::OldTaskContext;
 use rt::local::Local;
 use rt::task::Task;
+use unstable::raw;
 
 type MemoryRegion = c_void;
 
@@ -26,7 +26,7 @@ struct Env { priv opaque: () }
 struct BoxedRegion {
     env: *Env,
     backing_region: *MemoryRegion,
-    live_allocs: *BoxRepr
+    live_allocs: *raw::Box<()>,
 }
 
 pub type OpaqueBox = c_void;
@@ -103,7 +103,7 @@ pub unsafe fn local_free(ptr: *libc::c_char) {
     }
 }
 
-pub fn live_allocs() -> *BoxRepr {
+pub fn live_allocs() -> *raw::Box<()> {
     let region = match rt::context() {
         OldTaskContext => {
             unsafe { rust_current_boxed_region() }

--- a/src/libstd/rt/sched.rs
+++ b/src/libstd/rt/sched.rs
@@ -10,9 +10,9 @@
 
 use either::{Left, Right};
 use option::{Option, Some, None};
-use sys;
 use cast::transmute;
 use clone::Clone;
+use unstable::raw;
 
 use super::sleeper_list::SleeperList;
 use super::work_queue::WorkQueue;
@@ -698,7 +698,7 @@ impl SchedHandle {
 
 // XXX: Some hacks to put a &fn in Scheduler without borrowck
 // complaining
-type UnsafeTaskReceiver = sys::Closure;
+type UnsafeTaskReceiver = raw::Closure;
 trait ClosureConverter {
     fn from_fn(&fn(&mut Scheduler, BlockedTask)) -> Self;
     fn to_fn(self) -> &fn(&mut Scheduler, BlockedTask);

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -281,7 +281,7 @@ static UNWIND_TOKEN: uintptr_t = 839147;
 
 impl Unwinder {
     pub fn try(&mut self, f: &fn()) {
-        use sys::Closure;
+        use unstable::raw::Closure;
 
         unsafe {
             let closure: Closure = transmute(f);

--- a/src/libstd/sys.rs
+++ b/src/libstd/sys.rs
@@ -22,12 +22,6 @@ use str::StrSlice;
 use str;
 use unstable::intrinsics;
 
-/// The representation of a Rust closure
-pub struct Closure {
-    code: *(),
-    env: *(),
-}
-
 pub mod rustrt {
     use libc::{c_char, size_t};
 
@@ -278,6 +272,7 @@ mod tests {
 
     #[test]
     fn synthesize_closure() {
+        use unstable::raw::Closure;
         unsafe {
             let x = 10;
             let f: &fn(int) -> int = |y| x + y;

--- a/src/libstd/task/local_data_priv.rs
+++ b/src/libstd/task/local_data_priv.rs
@@ -15,8 +15,8 @@ use libc;
 use local_data;
 use prelude::*;
 use ptr;
-use sys;
 use task::rt;
+use unstable::raw;
 use util;
 
 use super::rt::rust_task;
@@ -158,7 +158,7 @@ unsafe fn get_local_map(handle: Handle) -> &mut TaskLocalMap {
 }
 
 unsafe fn key_to_key_value<T: 'static>(key: local_data::Key<T>) -> *libc::c_void {
-    let pair: sys::Closure = cast::transmute_copy(&key);
+    let pair: raw::Closure = cast::transmute_copy(&key);
     return pair.code as *libc::c_void;
 }
 

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -26,6 +26,7 @@ pub mod extfmt;
 pub mod lang;
 pub mod sync;
 pub mod atomics;
+pub mod raw;
 
 /**
 

--- a/src/libstd/unstable/raw.rs
+++ b/src/libstd/unstable/raw.rs
@@ -1,0 +1,61 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use cast;
+use unstable::intrinsics::TyDesc;
+
+/// The representation of a Rust managed box
+pub struct Box<T> {
+    ref_count: uint,
+    type_desc: *TyDesc,
+    prev: *Box<T>,
+    next: *Box<T>,
+    data: T
+}
+
+/// The representation of a Rust vector
+pub struct Vec<T> {
+    fill: uint,
+    alloc: uint,
+    data: T
+}
+
+/// The representation of a Rust string
+pub type String = Vec<u8>;
+
+/// The representation of a Rust slice
+pub struct Slice<T> {
+    data: *T,
+    len: uint
+}
+
+/// The representation of a Rust closure
+pub struct Closure {
+    code: *(),
+    env: *(),
+}
+
+/// This trait is meant to map equivalences between raw structs and their
+/// corresponding rust values.
+pub trait Repr<T> {
+    /// This function "unwraps" a rust value (without consuming it) into its raw
+    /// struct representation. This can be used to read/write different values
+    /// for the struct. This is a safe method because by default it does not
+    /// give write-access to the struct returned.
+    fn repr(&self) -> T { unsafe { cast::transmute_copy(self) } }
+}
+
+impl<'self, T> Repr<Slice<T>> for &'self [T] {}
+impl<'self> Repr<Slice<u8>> for &'self str {}
+impl<T> Repr<*Box<T>> for @T {}
+impl<T> Repr<*Box<Vec<T>>> for @[T] {}
+
+// sure would be nice to have this
+// impl<T> Repr<*Vec<T>> for ~[T] {}

--- a/src/test/run-pass/reflect-visit-data.rs
+++ b/src/test/run-pass/reflect-visit-data.rs
@@ -14,8 +14,8 @@ use std::int;
 use std::libc::c_void;
 use std::ptr;
 use std::sys;
-use std::vec::UnboxedVecRepr;
 use std::unstable::intrinsics::{TyDesc, get_tydesc, visit_tydesc, TyVisitor, Opaque};
+use std::unstable::raw::Vec;
 
 #[doc = "High-level interfaces to `std::unstable::intrinsics::visit_ty` reflection system."]
 
@@ -247,7 +247,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
     }
 
     fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
-        self.align_to::<UnboxedVecRepr>();
+        self.align_to::<Vec<()>>();
         // FIXME (#3732): Inner really has to move its own pointers on this one.
         // or else possibly we could have some weird interface wherein we
         // read-off a word from inner's pointers, but the read-word has to


### PR DESCRIPTION
This moves the raw struct layout of closures, vectors, boxes, and strings into a
new `unstable::raw` module. This is meant to be a centralized location to find
information for the layout of these values.

As safe method, `unwrap`, is provided to convert a rust value to its raw
representation. Unsafe methods to convert back are not provided because they are
rarely used and too numerous to write an implementation for each (not much of a
common pattern).

This is progress on #6790. I tried to get a nice interface for a trait to implement in the raw module, but I was unable to come up with one. The hard part is that there are so many different directions to go from one way to another that it's difficult to find a pattern to follow to implement a trait with. Someone else might have some better luck though.
