### PR TITLE
Fix a crash when transmuting non-immediate to immediate types

### DIFF
--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -805,6 +805,9 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
                             _ => Ret(bcx, BitCast(bcx, llsrcval, llouttype))
                         }
                     }
+                } else if ty::type_is_immediate(ccx.tcx, out_type) {
+                    let llsrcptr = PointerCast(bcx, llsrcval, llouttype.ptr_to());
+                    Ret(bcx, Load(bcx, llsrcptr));
                 } else {
                     // NB: Do not use a Load and Store here. This causes massive
                     // code bloat when `transmute` is used on large structural

--- a/src/test/run-pass/transmute-non-immediate-to-immediate.rs
+++ b/src/test/run-pass/transmute-non-immediate-to-immediate.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #7988
+// Transmuting non-immediate type to immediate type
+
+fn main() {
+    unsafe {
+        std::cast::transmute::<[int,..1],int>([1])
+    };
+}


### PR DESCRIPTION
The code to build the transmute intrinsic currently makes the invalid
assumption that if the in-type is non-immediate, the out-type is
non-immediate as well. But this is wrong, for example when transmuting
[int, ..1] to int. So we need to handle this fourth case as well.

Fixes #7988
