### PR TITLE
Cleanup strs

### DIFF
--- a/src/libextra/future.rs
+++ b/src/libextra/future.rs
@@ -194,7 +194,7 @@ mod test {
 
     #[test]
     fn test_interface_unwrap() {
-        let mut f = from_value(~"fail");
+        let f = from_value(~"fail");
         assert_eq!(f.unwrap(), ~"fail");
     }
 

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -457,7 +457,7 @@ pub fn opt_default(mm: &Matches, nm: &str, def: &str) -> Option<~str> {
     let vals = opt_vals(mm, nm);
     if vals.is_empty() { return None::<~str>; }
     return match vals[0] { Val(ref s) => Some::<~str>((*s).clone()),
-                           _      => Some::<~str>(str::to_owned(def)) }
+                           _      => Some::<~str>(def.to_owned()) }
 }
 
 #[deriving(Eq)]
@@ -497,10 +497,10 @@ pub mod groups {
                   desc: &str, hint: &str) -> OptGroup {
         let len = short_name.len();
         assert!(len == 1 || len == 0);
-        return OptGroup { short_name: str::to_owned(short_name),
-                long_name: str::to_owned(long_name),
-                hint: str::to_owned(hint),
-                desc: str::to_owned(desc),
+        return OptGroup { short_name: short_name.to_owned(),
+                long_name: long_name.to_owned(),
+                hint: hint.to_owned(),
+                desc: desc.to_owned(),
                 hasarg: Yes,
                 occur: Req};
     }
@@ -510,10 +510,10 @@ pub mod groups {
                   desc: &str, hint: &str) -> OptGroup {
         let len = short_name.len();
         assert!(len == 1 || len == 0);
-        return OptGroup {short_name: str::to_owned(short_name),
-                long_name: str::to_owned(long_name),
-                hint: str::to_owned(hint),
-                desc: str::to_owned(desc),
+        return OptGroup {short_name: short_name.to_owned(),
+                long_name: long_name.to_owned(),
+                hint: hint.to_owned(),
+                desc: desc.to_owned(),
                 hasarg: Yes,
                 occur: Optional};
     }
@@ -523,10 +523,10 @@ pub mod groups {
                    desc: &str) -> OptGroup {
         let len = short_name.len();
         assert!(len == 1 || len == 0);
-        return OptGroup {short_name: str::to_owned(short_name),
-                long_name: str::to_owned(long_name),
+        return OptGroup {short_name: short_name.to_owned(),
+                long_name: long_name.to_owned(),
                 hint: ~"",
-                desc: str::to_owned(desc),
+                desc: desc.to_owned(),
                 hasarg: No,
                 occur: Optional};
     }
@@ -536,10 +536,10 @@ pub mod groups {
                       desc: &str, hint: &str) -> OptGroup {
         let len = short_name.len();
         assert!(len == 1 || len == 0);
-        return OptGroup {short_name: str::to_owned(short_name),
-                long_name: str::to_owned(long_name),
-                hint: str::to_owned(hint),
-                desc: str::to_owned(desc),
+        return OptGroup {short_name: short_name.to_owned(),
+                long_name: long_name.to_owned(),
+                hint: hint.to_owned(),
+                desc: desc.to_owned(),
                 hasarg: Maybe,
                 occur: Optional};
     }
@@ -552,10 +552,10 @@ pub mod groups {
                     desc: &str, hint: &str) -> OptGroup {
         let len = short_name.len();
         assert!(len == 1 || len == 0);
-        return OptGroup {short_name: str::to_owned(short_name),
-                long_name: str::to_owned(long_name),
-                hint: str::to_owned(hint),
-                desc: str::to_owned(desc),
+        return OptGroup {short_name: short_name.to_owned(),
+                long_name: long_name.to_owned(),
+                hint: hint.to_owned(),
+                desc: desc.to_owned(),
                 hasarg: Yes,
                 occur: Multi};
     }
@@ -678,7 +678,7 @@ pub mod groups {
             row
         });
 
-        return str::to_owned(brief) +
+        return brief.to_owned() +
                "\n\nOptions:\n" +
                rows.collect::<~[~str]>().connect("\n") +
                "\n\n";

--- a/src/libextra/rl.rs
+++ b/src/libextra/rl.rs
@@ -32,7 +32,7 @@ pub mod rustrt {
 
 /// Add a line to history
 pub unsafe fn add_history(line: &str) -> bool {
-    do str::as_c_str(line) |buf| {
+    do line.as_c_str |buf| {
         rustrt::linenoiseHistoryAdd(buf) == 1 as c_int
     }
 }
@@ -44,21 +44,21 @@ pub unsafe fn set_history_max_len(len: int) -> bool {
 
 /// Save line history to a file
 pub unsafe fn save_history(file: &str) -> bool {
-    do str::as_c_str(file) |buf| {
+    do file.as_c_str |buf| {
         rustrt::linenoiseHistorySave(buf) == 1 as c_int
     }
 }
 
 /// Load line history from a file
 pub unsafe fn load_history(file: &str) -> bool {
-    do str::as_c_str(file) |buf| {
+    do file.as_c_str |buf| {
         rustrt::linenoiseHistoryLoad(buf) == 1 as c_int
     }
 }
 
 /// Print out a prompt and then wait for input and return it
 pub unsafe fn read(prompt: &str) -> Option<~str> {
-    do str::as_c_str(prompt) |buf| {
+    do prompt.as_c_str |buf| {
         let line = rustrt::linenoise(buf);
 
         if line.is_null() { None }
@@ -80,7 +80,7 @@ pub unsafe fn complete(cb: CompletionCb) {
 
             unsafe {
                 do cb(str::raw::from_c_str(line)) |suggestion| {
-                    do str::as_c_str(suggestion) |buf| {
+                    do suggestion.as_c_str |buf| {
                         rustrt::linenoiseAddCompletion(completions, buf);
                     }
                 }

--- a/src/libextra/terminfo/parm.rs
+++ b/src/libextra/terminfo/parm.rs
@@ -545,7 +545,7 @@ priv fn format(val: Param, op: FormatOp, flags: Flags) -> Result<~[u8],~str> {
         String(s) => {
             match op {
                 FormatString => {
-                    let mut s = s.as_bytes_with_null_consume();
+                    let mut s = s.to_bytes_with_null();
                     s.pop(); // remove the null
                     if flags.precision > 0 && flags.precision < s.len() {
                         s.truncate(flags.precision);

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -1027,7 +1027,7 @@ mod tests {
 
         fn test(s: &str, format: &str) -> bool {
             match strptime(s, format) {
-              Ok(ref tm) => tm.strftime(format) == str::to_owned(s),
+              Ok(ref tm) => tm.strftime(format) == s.to_owned(),
               Err(e) => fail!(e)
             }
         }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -76,9 +76,9 @@ pub fn WriteOutputFile(sess: Session,
         OptLevel: c_int,
         EnableSegmentedStacks: bool) {
     unsafe {
-        do str::as_c_str(Triple) |Triple| {
-            do str::as_c_str(Feature) |Feature| {
-                do str::as_c_str(Output) |Output| {
+        do Triple.as_c_str |Triple| {
+            do Feature.as_c_str |Feature| {
+                do Output.as_c_str |Output| {
                     let result = llvm::LLVMRustWriteOutputFile(
                             PM,
                             M,
@@ -263,16 +263,16 @@ pub mod write {
                   output_type_bitcode => {
                     if opts.optimize != session::No {
                         let filename = output.with_filetype("no-opt.bc");
-                        str::as_c_str(filename.to_str(), |buf| {
-                            llvm::LLVMWriteBitcodeToFile(llmod, buf)
-                        });
+                        do filename.to_str().as_c_str |buf| {
+                            llvm::LLVMWriteBitcodeToFile(llmod, buf);
+                        }
                     }
                   }
                   _ => {
                     let filename = output.with_filetype("bc");
-                    str::as_c_str(filename.to_str(), |buf| {
-                        llvm::LLVMWriteBitcodeToFile(llmod, buf)
-                    });
+                    do filename.to_str().as_c_str |buf| {
+                        llvm::LLVMWriteBitcodeToFile(llmod, buf);
+                    }
                   }
                 }
             }
@@ -333,9 +333,9 @@ pub mod write {
                     // Always output the bitcode file with --save-temps
 
                     let filename = output.with_filetype("opt.bc");
-                    str::as_c_str(filename.to_str(), |buf| {
+                    do filename.to_str().as_c_str |buf| {
                         llvm::LLVMWriteBitcodeToFile(llmod, buf)
-                    });
+                    };
                     // Save the assembly file if -S is used
                     if output_type == output_type_assembly {
                         WriteOutputFile(
@@ -391,13 +391,15 @@ pub mod write {
 
             if output_type == output_type_llvm_assembly {
                 // Given options "-S --emit-llvm": output LLVM assembly
-                str::as_c_str(output.to_str(), |buf_o| {
-                    llvm::LLVMRustAddPrintModulePass(pm.llpm, llmod, buf_o)});
+                do output.to_str().as_c_str |buf_o| {
+                    llvm::LLVMRustAddPrintModulePass(pm.llpm, llmod, buf_o);
+                }
             } else {
                 // If only a bitcode file is asked for by using the
                 // '--emit-llvm' flag, then output it here
-                str::as_c_str(output.to_str(),
-                            |buf| llvm::LLVMWriteBitcodeToFile(llmod, buf) );
+                do output.to_str().as_c_str |buf| {
+                    llvm::LLVMWriteBitcodeToFile(llmod, buf);
+                }
             }
 
             llvm::LLVMDisposeModule(llmod);

--- a/src/librustc/back/passes.rs
+++ b/src/librustc/back/passes.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::str;
 use std::io;
 
 use driver::session::{OptLevel, No, Less, Aggressive};
@@ -174,7 +173,7 @@ pub fn populate_pass_manager(sess: Session, pm: &mut PassManager, pass_list:&[~s
 }
 
 pub fn create_pass(name:&str) -> Option<PassRef> {
-    do str::as_c_str(name) |s| {
+    do name.as_c_str |s| {
         unsafe {
             let p = llvm::LLVMCreatePass(s);
             if p.is_null() {

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -12,7 +12,6 @@
 use std::hashmap::HashMap;
 use std::libc::{c_uint, c_ushort};
 use std::option;
-use std::str;
 
 use middle::trans::type_::Type;
 
@@ -2287,10 +2286,9 @@ pub struct TargetData {
 }
 
 pub fn mk_target_data(string_rep: &str) -> TargetData {
-    let lltd =
-        str::as_c_str(string_rep, |buf| unsafe {
-            llvm::LLVMCreateTargetData(buf)
-        });
+    let lltd = do string_rep.as_c_str |buf| {
+        unsafe { llvm::LLVMCreateTargetData(buf) }
+    };
 
     TargetData {
         lltd: lltd,

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -12,7 +12,6 @@
 use std::option;
 use std::os;
 use std::result;
-use std::str;
 
 // A module for searching for libraries
 // FIXME (#2658): I'm not happy how this module turned out. Should
@@ -83,7 +82,7 @@ pub fn mk_filesearch(maybe_sysroot: &Option<@Path>,
     @FileSearchImpl {
         sysroot: sysroot,
         addl_lib_search_paths: addl_lib_search_paths,
-        target_triple: str::to_owned(target_triple)
+        target_triple: target_triple.to_owned()
     } as @FileSearch
 }
 
@@ -110,7 +109,7 @@ pub fn search<T>(filesearch: @FileSearch, pick: pick<T>) -> Option<T> {
 
 pub fn relative_target_lib_path(target_triple: &str) -> Path {
     Path(libdir()).push_many([~"rustc",
-                              str::to_owned(target_triple),
+                              target_triple.to_owned(),
                               libdir()])
 }
 

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -80,7 +80,7 @@ fn libname(cx: &Context) -> (~str, ~str) {
         os_freebsd => (freebsd::DLL_PREFIX, freebsd::DLL_SUFFIX),
     };
 
-    (str::to_owned(dll_prefix), str::to_owned(dll_suffix))
+    (dll_prefix.to_owned(), dll_suffix.to_owned())
 }
 
 fn find_library_crate_aux(

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -186,9 +186,9 @@ pub fn metadata_matches(extern_metas: &[@ast::MetaItem],
 fn get_metadata_section(os: os,
                         filename: &Path) -> Option<@~[u8]> {
     unsafe {
-        let mb = str::as_c_str(filename.to_str(), |buf| {
+        let mb = do filename.to_str().as_c_str |buf| {
             llvm::LLVMRustCreateMemoryBufferWithContentsOfFile(buf)
-        });
+        };
         if mb as int == 0 { return option::None::<@~[u8]>; }
         let of = match mk_object_file(mb) {
             option::Some(of) => of,

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1279,8 +1279,6 @@ pub fn compile_submatch(bcx: block,
     assert!((m.len() > 0u || chk.is_some()));
     let _icx = push_ctxt("match::compile_submatch");
     let mut bcx = bcx;
-    let tcx = bcx.tcx();
-    let dm = tcx.def_map;
     if m.len() == 0u {
         Br(bcx, chk.get()());
         return;

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -21,7 +21,6 @@ use middle::ty;
 
 use middle::trans::type_::Type;
 
-use std::str;
 use syntax::ast;
 
 // Take an inline assembly expression and splat it out via LLVM
@@ -123,8 +122,8 @@ pub fn trans_inline_asm(bcx: block, ia: &ast::inline_asm) -> block {
         ast::asm_intel => lib::llvm::AD_Intel
     };
 
-    let r = do str::as_c_str(ia.asm) |a| {
-        do str::as_c_str(constraints) |c| {
+    let r = do ia.asm.as_c_str |a| {
+        do constraints.as_c_str |c| {
             InlineAsmCall(bcx, a, c, inputs, output, ia.volatile, ia.alignstack, dialect)
         }
     };

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -70,7 +70,6 @@ use std::hashmap::{HashMap, HashSet};
 use std::int;
 use std::io;
 use std::libc::c_uint;
-use std::str;
 use std::uint;
 use std::vec;
 use std::local_data;
@@ -549,11 +548,11 @@ pub fn get_res_dtor(ccx: @mut CrateContext,
 // Structural comparison: a rather involved form of glue.
 pub fn maybe_name_value(cx: &CrateContext, v: ValueRef, s: &str) {
     if cx.sess.opts.save_temps {
-        let _: () = str::as_c_str(s, |buf| {
+        do s.as_c_str |buf| {
             unsafe {
                 llvm::LLVMSetValueName(v, buf)
             }
-        });
+        }
     }
 }
 
@@ -1577,16 +1576,18 @@ pub struct BasicBlocks {
 pub fn mk_staticallocas_basic_block(llfn: ValueRef) -> BasicBlockRef {
     unsafe {
         let cx = task_llcx();
-        str::as_c_str("static_allocas",
-                      |buf| llvm::LLVMAppendBasicBlockInContext(cx, llfn, buf))
+        do "static_allocas".as_c_str | buf| {
+            llvm::LLVMAppendBasicBlockInContext(cx, llfn, buf)
+        }
     }
 }
 
 pub fn mk_return_basic_block(llfn: ValueRef) -> BasicBlockRef {
     unsafe {
         let cx = task_llcx();
-        str::as_c_str("return",
-                      |buf| llvm::LLVMAppendBasicBlockInContext(cx, llfn, buf))
+        do "return".as_c_str |buf| {
+            llvm::LLVMAppendBasicBlockInContext(cx, llfn, buf)
+        }
     }
 }
 
@@ -2353,11 +2354,11 @@ pub fn create_entry_wrapper(ccx: @mut CrateContext,
             };
             decl_cdecl_fn(ccx.llmod, main_name, llfty)
         };
-        let llbb = str::as_c_str("top", |buf| {
+        let llbb = do "top".as_c_str |buf| {
             unsafe {
                 llvm::LLVMAppendBasicBlockInContext(ccx.llcx, llfn, buf)
             }
-        });
+        };
         let bld = ccx.builder.B;
         unsafe {
             llvm::LLVMPositionBuilderAtEnd(bld, llbb);
@@ -2457,9 +2458,9 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::node_id) -> ValueRef {
                 exprt = m == ast::m_mutbl;
                 unsafe {
                     let llty = llvm::LLVMTypeOf(v);
-                    let g = str::as_c_str(s, |buf| {
+                    let g = do s.as_c_str |buf| {
                         llvm::LLVMAddGlobal(ccx.llmod, llty, buf)
-                    });
+                    };
                     ccx.item_symbols.insert(i.id, s);
                     g
                 }
@@ -2509,7 +2510,7 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::node_id) -> ValueRef {
                 ast::foreign_item_static(*) => {
                     let typ = ty::node_id_to_type(ccx.tcx, ni.id);
                     let ident = token::ident_to_str(&ni.ident);
-                    let g = do str::as_c_str(ident) |buf| {
+                    let g = do ident.as_c_str |buf| {
                         unsafe {
                             let ty = type_of(ccx, typ);
                             llvm::LLVMAddGlobal(ccx.llmod, ty.to_ref(), buf)
@@ -2609,11 +2610,11 @@ pub fn trans_constant(ccx: &mut CrateContext, it: @ast::item) {
             let s = mangle_exported_name(ccx, p, ty::mk_int()).to_managed();
             let disr_val = vi[i].disr_val;
             note_unique_llvm_symbol(ccx, s);
-            let discrim_gvar = str::as_c_str(s, |buf| {
+            let discrim_gvar = do s.as_c_str |buf| {
                 unsafe {
                     llvm::LLVMAddGlobal(ccx.llmod, ccx.int_type.to_ref(), buf)
                 }
-            });
+            };
             unsafe {
                 llvm::LLVMSetInitializer(discrim_gvar, C_int(ccx, disr_val));
                 llvm::LLVMSetGlobalConstant(discrim_gvar, True);
@@ -2750,7 +2751,7 @@ pub fn decl_gc_metadata(ccx: &mut CrateContext, llmod_id: &str) {
     }
 
     let gc_metadata_name = ~"_gc_module_metadata_" + llmod_id;
-    let gc_metadata = do str::as_c_str(gc_metadata_name) |buf| {
+    let gc_metadata = do gc_metadata_name.as_c_str |buf| {
         unsafe {
             llvm::LLVMAddGlobal(ccx.llmod, Type::i32().to_ref(), buf)
         }
@@ -2813,11 +2814,11 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
     let sym_name = ~"_rust_crate_map_" + mapname;
     let arrtype = Type::array(&int_type, n_subcrates as u64);
     let maptype = Type::struct_([Type::i32(), Type::i8p(), int_type, arrtype], false);
-    let map = str::as_c_str(sym_name, |buf| {
+    let map = do sym_name.as_c_str |buf| {
         unsafe {
             llvm::LLVMAddGlobal(llmod, maptype.to_ref(), buf)
         }
-    });
+    };
     lib::llvm::SetLinkage(map, lib::llvm::ExternalLinkage);
     return map;
 }
@@ -2832,11 +2833,11 @@ pub fn fill_crate_map(ccx: @mut CrateContext, map: ValueRef) {
                       cdata.name,
                       cstore::get_crate_vers(cstore, i),
                       cstore::get_crate_hash(cstore, i));
-        let cr = str::as_c_str(nm, |buf| {
+        let cr = do nm.as_c_str |buf| {
             unsafe {
                 llvm::LLVMAddGlobal(ccx.llmod, ccx.int_type.to_ref(), buf)
             }
-        });
+        };
         subcrates.push(p2i(ccx, cr));
         i += 1;
     }
@@ -2895,16 +2896,16 @@ pub fn write_metadata(cx: &mut CrateContext, crate: &ast::Crate) {
     let encode_parms = crate_ctxt_to_encode_parms(cx, encode_inlined_item);
     let llmeta = C_bytes(encoder::encode_metadata(encode_parms, crate));
     let llconst = C_struct([llmeta]);
-    let mut llglobal = str::as_c_str("rust_metadata", |buf| {
+    let mut llglobal = do "rust_metadata".as_c_str |buf| {
         unsafe {
             llvm::LLVMAddGlobal(cx.llmod, val_ty(llconst).to_ref(), buf)
         }
-    });
+    };
     unsafe {
         llvm::LLVMSetInitializer(llglobal, llconst);
-        str::as_c_str(cx.sess.targ_cfg.target_strs.meta_sect_name, |buf| {
+        do cx.sess.targ_cfg.target_strs.meta_sect_name.as_c_str |buf| {
             llvm::LLVMSetSection(llglobal, buf)
-        });
+        };
         lib::llvm::SetLinkage(llglobal, lib::llvm::InternalLinkage);
 
         let t_ptr_i8 = Type::i8p();
@@ -2923,7 +2924,7 @@ fn mk_global(ccx: &CrateContext,
              internal: bool)
           -> ValueRef {
     unsafe {
-        let llglobal = do str::as_c_str(name) |buf| {
+        let llglobal = do name.as_c_str |buf| {
             llvm::LLVMAddGlobal(ccx.llmod, val_ty(llval).to_ref(), buf)
         };
         llvm::LLVMSetInitializer(llglobal, llval);

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -20,7 +20,6 @@ use middle::trans::type_::Type;
 use std::cast;
 use std::hashmap::HashMap;
 use std::libc::{c_uint, c_ulonglong, c_char};
-use std::str;
 use std::vec;
 use syntax::codemap::span;
 
@@ -424,9 +423,9 @@ impl Builder {
             if name.is_empty() {
                 llvm::LLVMBuildAlloca(self.llbuilder, ty.to_ref(), noname())
             } else {
-                str::as_c_str(
-                    name,
-                    |c| llvm::LLVMBuildAlloca(self.llbuilder, ty.to_ref(), c))
+                do name.as_c_str |c| {
+                    llvm::LLVMBuildAlloca(self.llbuilder, ty.to_ref(), c)
+                }
             }
         }
     }
@@ -896,9 +895,9 @@ impl Builder {
             let BB: BasicBlockRef = llvm::LLVMGetInsertBlock(self.llbuilder);
             let FN: ValueRef = llvm::LLVMGetBasicBlockParent(BB);
             let M: ModuleRef = llvm::LLVMGetGlobalParent(FN);
-            let T: ValueRef = str::as_c_str("llvm.trap", |buf| {
+            let T: ValueRef = do "llvm.trap".as_c_str |buf| {
                 llvm::LLVMGetNamedFunction(M, buf)
-            });
+            };
             assert!((T as int != 0));
             let args: &[ValueRef] = [];
             self.count_insn("trap");

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -788,15 +788,6 @@ pub fn C_estr_slice(cx: &mut CrateContext, s: @str) -> ValueRef {
     }
 }
 
-// Returns a Plain Old LLVM String:
-pub fn C_postr(s: &str) -> ValueRef {
-    unsafe {
-        do s.as_c_str |buf| {
-            llvm::LLVMConstStringInContext(base::task_llcx(), buf, s.len() as c_uint, False)
-        }
-    }
-}
-
 pub fn C_zero_byte_arr(size: uint) -> ValueRef {
     unsafe {
         let mut i = 0u;
@@ -841,14 +832,6 @@ pub fn C_bytes(bytes: &[u8]) -> ValueRef {
     unsafe {
         let ptr = cast::transmute(vec::raw::to_ptr(bytes));
         return llvm::LLVMConstStringInContext(base::task_llcx(), ptr, bytes.len() as c_uint, True);
-    }
-}
-
-pub fn C_bytes_plus_null(bytes: &[u8]) -> ValueRef {
-    unsafe {
-        return llvm::LLVMConstStringInContext(base::task_llcx(),
-            cast::transmute(vec::raw::to_ptr(bytes)),
-            bytes.len() as c_uint, False);
     }
 }
 

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -31,7 +31,6 @@ use util::ppaux::{Repr, ty_to_str};
 use middle::trans::type_::Type;
 
 use std::libc::c_uint;
-use std::str;
 use syntax::{ast, ast_util, ast_map};
 
 pub fn const_lit(cx: &mut CrateContext, e: &ast::expr, lit: ast::lit)
@@ -513,7 +512,7 @@ fn const_expr_unadjusted(cx: @mut CrateContext, e: &ast::expr) -> ValueRef {
               ast::expr_vec(ref es, ast::m_imm) => {
                 let (cv, sz, llunitty) = const_vec(cx, e, *es);
                 let llty = val_ty(cv);
-                let gv = do str::as_c_str("const") |name| {
+                let gv = do "const".as_c_str |name| {
                     llvm::LLVMAddGlobal(cx.llmod, llty.to_ref(), name)
                 };
                 llvm::LLVMSetInitializer(gv, cv);

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -28,7 +28,6 @@ use middle::trans::type_::Type;
 
 use std::hash;
 use std::hashmap::{HashMap, HashSet};
-use std::str;
 use std::local_data;
 use syntax::ast;
 
@@ -125,13 +124,11 @@ impl CrateContext {
         unsafe {
             let llcx = llvm::LLVMContextCreate();
             set_task_llcx(llcx);
-            let llmod = str::as_c_str(name, |buf| {
-                llvm::LLVMModuleCreateWithNameInContext(buf, llcx)
-            });
+            let llmod = name.as_c_str(|buf| llvm::LLVMModuleCreateWithNameInContext(buf, llcx));
             let data_layout: &str = sess.targ_cfg.target_strs.data_layout;
             let targ_triple: &str = sess.targ_cfg.target_strs.target_triple;
-            str::as_c_str(data_layout, |buf| llvm::LLVMSetDataLayout(llmod, buf));
-            str::as_c_str(targ_triple, |buf| llvm::LLVMSetTarget(llmod, buf));
+            data_layout.as_c_str(|buf| llvm::LLVMSetDataLayout(llmod, buf));
+            targ_triple.as_c_str(|buf| llvm::LLVMSetTarget(llmod, buf));
             let targ_cfg = sess.targ_cfg;
 
             let td = mk_target_data(sess.targ_cfg.target_strs.data_layout);

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -27,7 +27,6 @@ use util::ppaux;
 
 use middle::trans::type_::Type;
 
-use std::str;
 use syntax::ast;
 use syntax::ast::ident;
 use syntax::ast_map::path_mod;
@@ -251,9 +250,9 @@ pub fn trans_log(log_ex: &ast::expr,
             ccx, modpath, "loglevel");
         let global;
         unsafe {
-            global = str::as_c_str(s, |buf| {
+            global = do s.as_c_str |buf| {
                 llvm::LLVMAddGlobal(ccx.llmod, Type::i32().to_ref(), buf)
-            });
+            };
             llvm::LLVMSetGlobalConstant(global, False);
             llvm::LLVMSetInitializer(global, C_null(Type::i32()));
             lib::llvm::SetLinkage(global, lib::llvm::InternalLinkage);

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -65,7 +65,6 @@ use util::ppaux::ty_to_str;
 use std::hashmap::HashMap;
 use std::libc::{c_uint, c_ulonglong, c_longlong};
 use std::ptr;
-use std::str::as_c_str;
 use std::vec;
 use syntax::codemap::span;
 use syntax::{ast, codemap, ast_util, ast_map};
@@ -159,7 +158,7 @@ pub fn create_local_var_metadata(bcx: block, local: @ast::Local) -> DIVariable {
         Some(_) => lexical_block_metadata(bcx)
     };
 
-    let var_metadata = do as_c_str(name) |name| {
+    let var_metadata = do name.as_c_str |name| {
         unsafe {
             llvm::LLVMDIBuilderCreateLocalVariable(
                 DIB(cx),
@@ -225,7 +224,7 @@ pub fn create_argument_metadata(bcx: block, arg: &ast::arg, span: span) -> Optio
             // XXX: This is wrong; it should work for multiple bindings.
             let ident = path.idents.last();
             let name: &str = cx.sess.str_of(*ident);
-            let var_metadata = do as_c_str(name) |name| {
+            let var_metadata = do name.as_c_str |name| {
                 unsafe {
                     llvm::LLVMDIBuilderCreateLocalVariable(
                         DIB(cx),
@@ -354,8 +353,8 @@ pub fn create_function_metadata(fcx: fn_ctxt) -> DISubprogram {
     };
 
     let fn_metadata =
-        do as_c_str(cx.sess.str_of(ident)) |name| {
-        do as_c_str(cx.sess.str_of(ident)) |linkage| {
+        do cx.sess.str_of(ident).as_c_str |name| {
+        do cx.sess.str_of(ident).as_c_str |linkage| {
             unsafe {
                 llvm::LLVMDIBuilderCreateFunction(
                     DIB(cx),
@@ -402,11 +401,11 @@ fn compile_unit_metadata(cx: @mut CrateContext) {
     let work_dir = cx.sess.working_dir.to_str();
     let producer = fmt!("rustc version %s", env!("CFG_VERSION"));
 
-    do as_c_str(crate_name) |crate_name| {
-    do as_c_str(work_dir) |work_dir| {
-    do as_c_str(producer) |producer| {
-    do as_c_str("") |flags| {
-    do as_c_str("") |split_name| {
+    do crate_name.as_c_str |crate_name| {
+    do work_dir.as_c_str |work_dir| {
+    do producer.as_c_str |producer| {
+    do "".as_c_str |flags| {
+    do "".as_c_str |split_name| {
         unsafe {
             llvm::LLVMDIBuilderCreateCompileUnit(dcx.builder,
                 DW_LANG_RUST as c_uint, crate_name, work_dir, producer,
@@ -433,8 +432,8 @@ fn file_metadata(cx: &mut CrateContext, full_path: &str) -> DIFile {
         };
 
     let file_metadata =
-        do as_c_str(file_name) |file_name| {
-        do as_c_str(work_dir) |work_dir| {
+        do file_name.as_c_str |file_name| {
+        do work_dir.as_c_str |work_dir| {
             unsafe {
                 llvm::LLVMDIBuilderCreateFile(DIB(cx), file_name, work_dir)
             }
@@ -522,7 +521,7 @@ fn basic_type_metadata(cx: &mut CrateContext, t: ty::t) -> DIType {
 
     let llvm_type = type_of::type_of(cx, t);
     let (size, align) = size_and_align_of(cx, llvm_type);
-    let ty_metadata = do as_c_str(name) |name| {
+    let ty_metadata = do name.as_c_str |name| {
         unsafe {
             llvm::LLVMDIBuilderCreateBasicType(
                 DIB(cx),
@@ -543,7 +542,7 @@ fn pointer_type_metadata(cx: &mut CrateContext,
     let pointer_llvm_type = type_of::type_of(cx, pointer_type);
     let (pointer_size, pointer_align) = size_and_align_of(cx, pointer_llvm_type);
     let name = ty_to_str(cx.tcx, pointer_type);
-    let ptr_metadata = do as_c_str(name) |name| {
+    let ptr_metadata = do name.as_c_str |name| {
         unsafe {
             llvm::LLVMDIBuilderCreatePointerType(
                 DIB(cx),
@@ -1038,7 +1037,7 @@ fn unimplemented_type_metadata(cx: &mut CrateContext, t: ty::t) -> DIType {
     debug!("unimplemented_type_metadata: %?", ty::get(t));
 
     let name = ty_to_str(cx.tcx, t);
-    let metadata = do as_c_str(fmt!("NYI<%s>", name)) |name| {
+    let metadata = do fmt!("NYI<%s>", name).as_c_str |name| {
         unsafe {
             llvm::LLVMDIBuilderCreateBasicType(
                 DIB(cx),

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -39,7 +39,6 @@ use middle::trans::type_::Type;
 
 use std::io;
 use std::libc::c_uint;
-use std::str;
 use syntax::ast;
 
 pub fn trans_free(cx: block, v: ValueRef) -> block {
@@ -658,11 +657,11 @@ pub fn declare_tydesc(ccx: &mut CrateContext, t: ty::t) -> @mut tydesc_info {
     let name = mangle_internal_name_by_type_and_seq(ccx, t, "tydesc").to_managed();
     note_unique_llvm_symbol(ccx, name);
     debug!("+++ declare_tydesc %s %s", ppaux::ty_to_str(ccx.tcx, t), name);
-    let gvar = str::as_c_str(name, |buf| {
+    let gvar = do name.as_c_str |buf| {
         unsafe {
             llvm::LLVMAddGlobal(ccx.llmod, ccx.tydesc_type.to_ref(), buf)
         }
-    });
+    };
     let inf = @mut tydesc_info {
         ty: t,
         tydesc: gvar,

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -380,7 +380,7 @@ pub fn link_exe(_src: &Path, _dest: &Path) -> bool {
 #[cfg(target_os = "freebsd")]
 #[cfg(target_os = "macos")]
 pub fn link_exe(src: &Path, dest: &Path) -> bool {
-    use std::{libc, str};
+    use std::libc;
     unsafe {
         do src.to_str().as_c_str |src_buf| {
             do dest.to_str().as_c_str |dest_buf| {

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -382,8 +382,8 @@ pub fn link_exe(_src: &Path, _dest: &Path) -> bool {
 pub fn link_exe(src: &Path, dest: &Path) -> bool {
     use std::{libc, str};
     unsafe {
-        do str::as_c_str(src.to_str()) |src_buf| {
-            do str::as_c_str(dest.to_str()) |dest_buf| {
+        do src.to_str().as_c_str |src_buf| {
+            do dest.to_str().as_c_str |dest_buf| {
                 libc::link(src_buf, dest_buf) == 0 as libc::c_int &&
                     libc::chmod(dest_buf, 755) == 0 as libc::c_int
             }

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -63,7 +63,7 @@ use iterator::IteratorUtil;
 use ptr;
 use result;
 use str;
-use str::{StrSlice, OwnedStr, StrUtil};
+use str::{StrSlice, OwnedStr};
 use to_str::ToStr;
 use uint;
 use vec;

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -763,7 +763,7 @@ impl<T:Reader> ReaderUtil for T {
     fn read_lines(&self) -> ~[~str] {
         do vec::build |push| {
             for self.each_line |line| {
-                push(str::to_owned(line));
+                push(line.to_owned());
             }
         }
     }

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -63,7 +63,7 @@ use iterator::IteratorUtil;
 use ptr;
 use result;
 use str;
-use str::StrSlice;
+use str::{StrSlice, OwnedStr, StrUtil};
 use to_str::ToStr;
 use uint;
 use vec;
@@ -1031,17 +1031,16 @@ pub fn stdin() -> @Reader {
 }
 
 pub fn file_reader(path: &Path) -> Result<@Reader, ~str> {
-    unsafe {
-        let f = os::as_c_charp(path.to_str(), |pathbuf| {
-            os::as_c_charp("r", |modebuf|
-                libc::fopen(pathbuf, modebuf)
-            )
-        });
-        return if f as uint == 0u { result::Err(~"error opening "
-                                                + path.to_str()) }
-        else {
-            result::Ok(FILE_reader(f, true))
+    let f = do path.to_str().as_c_str |pathbuf| {
+        do "r".as_c_str |modebuf| {
+            unsafe { libc::fopen(pathbuf, modebuf as *libc::c_char) }
         }
+    };
+
+    if f as uint == 0u {
+        result::Err(~"error opening " + path.to_str())
+    } else {
+        result::Ok(FILE_reader(f, true))
     }
 }
 
@@ -1282,7 +1281,7 @@ pub fn mk_file_writer(path: &Path, flags: &[FileFlag])
         }
     }
     let fd = unsafe {
-        do os::as_c_charp(path.to_str()) |pathbuf| {
+        do path.to_str().as_c_str |pathbuf| {
             libc::open(pathbuf, fflags,
                        (S_IRUSR | S_IWUSR) as c_int)
         }
@@ -1567,8 +1566,8 @@ pub fn file_writer(path: &Path, flags: &[FileFlag]) -> Result<@Writer, ~str> {
 // FIXME: fileflags // #2004
 pub fn buffered_file_writer(path: &Path) -> Result<@Writer, ~str> {
     unsafe {
-        let f = do os::as_c_charp(path.to_str()) |pathbuf| {
-            do os::as_c_charp("w") |modebuf| {
+        let f = do path.to_str().as_c_str |pathbuf| {
+            do "w".as_c_str |modebuf| {
                 libc::fopen(pathbuf, modebuf)
             }
         };

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -445,10 +445,10 @@ fn test_unwrap_ptr() {
 #[test]
 fn test_unwrap_str() {
     let x = ~"test";
-    let addr_x = x.as_buf(|buf, _len| buf);
+    let addr_x = x.as_imm_buf(|buf, _len| buf);
     let opt = Some(x);
     let y = opt.unwrap();
-    let addr_y = y.as_buf(|buf, _len| buf);
+    let addr_y = y.as_imm_buf(|buf, _len| buf);
     assert_eq!(addr_x, addr_y);
 }
 

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -50,7 +50,6 @@ use iterator::Iterator;
 use str::StrSlice;
 use clone::DeepClone;
 
-#[cfg(test)] use str;
 #[cfg(test)] use iterator::IteratorUtil;
 
 /// The option type
@@ -446,10 +445,10 @@ fn test_unwrap_ptr() {
 #[test]
 fn test_unwrap_str() {
     let x = ~"test";
-    let addr_x = str::as_buf(x, |buf, _len| buf);
+    let addr_x = x.as_buf(|buf, _len| buf);
     let opt = Some(x);
     let y = opt.unwrap();
-    let addr_y = str::as_buf(y, |buf, _len| buf);
+    let addr_y = y.as_buf(|buf, _len| buf);
     assert_eq!(addr_x, addr_y);
 }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -87,9 +87,8 @@ pub fn getcwd() -> Path {
 
 // FIXME: move these to str perhaps? #2620
 
-pub fn fill_charp_buf(f: &fn(*mut c_char, size_t) -> bool)
-    -> Option<~str> {
-    let mut buf = vec::from_elem(TMPBUF_SZ, 0u8 as c_char);
+pub fn fill_charp_buf(f: &fn(*mut c_char, size_t) -> bool) -> Option<~str> {
+    let mut buf = [0 as c_char, .. TMPBUF_SZ];
     do buf.as_mut_buf |b, sz| {
         if f(b, sz as size_t) {
             unsafe {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -87,10 +87,6 @@ pub fn getcwd() -> Path {
 
 // FIXME: move these to str perhaps? #2620
 
-pub fn as_c_charp<T>(s: &str, f: &fn(*c_char) -> T) -> T {
-    str::as_c_str(s, |b| f(b as *c_char))
-}
-
 pub fn fill_charp_buf(f: &fn(*mut c_char, size_t) -> bool)
     -> Option<~str> {
     let mut buf = vec::from_elem(TMPBUF_SZ, 0u8 as c_char);
@@ -335,10 +331,10 @@ pub fn unsetenv(n: &str) {
 }
 
 pub fn fdopen(fd: c_int) -> *FILE {
-    unsafe {
-        return do as_c_charp("r") |modebuf| {
+    do "r".as_c_str |modebuf| {
+        unsafe {
             libc::fdopen(fd, modebuf)
-        };
+        }
     }
 }
 
@@ -471,7 +467,7 @@ pub fn self_exe_path() -> Option<Path> {
             let mut path_str = str::with_capacity(TMPBUF_SZ);
             let len = do str::as_c_str(path_str) |buf| {
                 let buf = buf as *mut c_char;
-                do as_c_charp("/proc/self/exe") |proc_self_buf| {
+                do "/proc/self/exe".as_c_str |proc_self_buf| {
                     readlink(proc_self_buf, buf, TMPBUF_SZ as size_t)
                 }
             };
@@ -654,9 +650,9 @@ pub fn make_dir(p: &Path, mode: c_int) -> bool {
 
     #[cfg(unix)]
     fn mkdir(p: &Path, mode: c_int) -> bool {
-        unsafe {
-            do as_c_charp(p.to_str()) |c| {
-                libc::mkdir(c, mode as libc::mode_t) == (0 as c_int)
+        do p.to_str().as_c_str |buf| {
+            unsafe {
+                libc::mkdir(buf, mode as libc::mode_t) == (0 as c_int)
             }
         }
     }
@@ -830,10 +826,10 @@ pub fn remove_dir(p: &Path) -> bool {
 
     #[cfg(unix)]
     fn rmdir(p: &Path) -> bool {
-        unsafe {
-            return do as_c_charp(p.to_str()) |buf| {
+        do p.to_str().as_c_str |buf| {
+            unsafe {
                 libc::rmdir(buf) == (0 as c_int)
-            };
+            }
         }
     }
 }
@@ -855,10 +851,10 @@ pub fn change_dir(p: &Path) -> bool {
 
     #[cfg(unix)]
     fn chdir(p: &Path) -> bool {
-        unsafe {
-            return do as_c_charp(p.to_str()) |buf| {
+        do p.to_str().as_c_str |buf| {
+            unsafe {
                 libc::chdir(buf) == (0 as c_int)
-            };
+            }
         }
     }
 }
@@ -883,8 +879,8 @@ pub fn copy_file(from: &Path, to: &Path) -> bool {
     #[cfg(unix)]
     fn do_copy_file(from: &Path, to: &Path) -> bool {
         unsafe {
-            let istream = do as_c_charp(from.to_str()) |fromp| {
-                do as_c_charp("rb") |modebuf| {
+            let istream = do from.to_str().as_c_str |fromp| {
+                do "rb".as_c_str |modebuf| {
                     libc::fopen(fromp, modebuf)
                 }
             };
@@ -895,8 +891,8 @@ pub fn copy_file(from: &Path, to: &Path) -> bool {
             let from_mode = from.get_mode().expect("copy_file: couldn't get permissions \
                                                     for source file");
 
-            let ostream = do as_c_charp(to.to_str()) |top| {
-                do as_c_charp("w+b") |modebuf| {
+            let ostream = do to.to_str().as_c_str |top| {
+                do "w+b".as_c_str |modebuf| {
                     libc::fopen(top, modebuf)
                 }
             };
@@ -955,9 +951,9 @@ pub fn remove_file(p: &Path) -> bool {
     #[cfg(unix)]
     fn unlink(p: &Path) -> bool {
         unsafe {
-            return do as_c_charp(p.to_str()) |buf| {
+            do p.to_str().as_c_str |buf| {
                 libc::unlink(buf) == (0 as c_int)
-            };
+            }
         }
     }
 }
@@ -1703,7 +1699,7 @@ mod tests {
     use libc;
     use option::Some;
     use option;
-    use os::{as_c_charp, env, getcwd, getenv, make_absolute, real_args};
+    use os::{env, getcwd, getenv, make_absolute, real_args};
     use os::{remove_file, setenv, unsetenv};
     use os;
     use path::Path;
@@ -1941,8 +1937,8 @@ mod tests {
           let out = tempdir.push("out.txt");
 
           /* Write the temp input file */
-            let ostream = do as_c_charp(in.to_str()) |fromp| {
-                do as_c_charp("w+b") |modebuf| {
+            let ostream = do in.to_str().as_c_str |fromp| {
+                do "w+b".as_c_str |modebuf| {
                     libc::fopen(fromp, modebuf)
                 }
           };
@@ -2020,16 +2016,16 @@ mod tests {
            }
         }
 
-        let p = tmpdir().push("mmap_file.tmp");
+        let path = tmpdir().push("mmap_file.tmp");
         let size = page_size() * 2;
-        remove_file(&p);
+        remove_file(&path);
 
         let fd = unsafe {
-            let fd = do as_c_charp(p.to_str()) |path| {
+            let fd = do path.to_str().as_c_str |path| {
                 open(path, O_CREAT | O_RDWR | O_TRUNC, S_IRUSR | S_IWUSR)
             };
             lseek_(fd, size);
-            do as_c_charp("x") |x| {
+            do "x".as_c_str |x| {
                 assert!(write(fd, x as *c_void, 1) == 1);
             }
             fd

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -243,12 +243,11 @@ pub fn env() -> ~[(~str,~str)] {
 pub fn getenv(n: &str) -> Option<~str> {
     unsafe {
         do with_env_lock {
-            let s = str::as_c_str(n, |s| libc::getenv(s));
+            let s = n.as_c_str(|s| libc::getenv(s as *libc::c_char));
             if ptr::null::<u8>() == cast::transmute(s) {
-                None::<~str>
+                None
             } else {
-                let s = cast::transmute(s);
-                Some::<~str>(str::raw::from_buf(s))
+                Some(str::raw::from_buf(cast::transmute(s)))
             }
         }
     }
@@ -277,8 +276,8 @@ pub fn getenv(n: &str) -> Option<~str> {
 pub fn setenv(n: &str, v: &str) {
     unsafe {
         do with_env_lock {
-            do str::as_c_str(n) |nbuf| {
-                do str::as_c_str(v) |vbuf| {
+            do n.to_str().as_c_str |nbuf| {
+                do v.to_str().as_c_str |vbuf| {
                     libc::funcs::posix01::unistd::setenv(nbuf, vbuf, 1);
                 }
             }
@@ -309,7 +308,7 @@ pub fn unsetenv(n: &str) {
     fn _unsetenv(n: &str) {
         unsafe {
             do with_env_lock {
-                do str::as_c_str(n) |nbuf| {
+                do n.to_str().as_c_str |nbuf| {
                     libc::funcs::posix01::unistd::unsetenv(nbuf);
                 }
             }
@@ -465,7 +464,7 @@ pub fn self_exe_path() -> Option<Path> {
             use libc::funcs::posix01::unistd::readlink;
 
             let mut path_str = str::with_capacity(TMPBUF_SZ);
-            let len = do str::as_c_str(path_str) |buf| {
+            let len = do path_str.as_c_str |buf| {
                 let buf = buf as *mut c_char;
                 do "/proc/self/exe".as_c_str |proc_self_buf| {
                     readlink(proc_self_buf, buf, TMPBUF_SZ as size_t)
@@ -598,7 +597,7 @@ pub fn walk_dir(p: &Path, f: &fn(&Path) -> bool) -> bool {
 /// Indicates whether a path represents a directory
 pub fn path_is_dir(p: &Path) -> bool {
     unsafe {
-        do str::as_c_str(p.to_str()) |buf| {
+        do p.to_str().as_c_str |buf| {
             rustrt::rust_path_is_dir(buf) != 0 as c_int
         }
     }
@@ -607,7 +606,7 @@ pub fn path_is_dir(p: &Path) -> bool {
 /// Indicates whether a path exists
 pub fn path_exists(p: &Path) -> bool {
     unsafe {
-        do str::as_c_str(p.to_str()) |buf| {
+        do p.to_str().as_c_str |buf| {
             rustrt::rust_path_exists(buf) != 0 as c_int
         }
     }
@@ -924,7 +923,7 @@ pub fn copy_file(from: &Path, to: &Path) -> bool {
             fclose(ostream);
 
             // Give the new file the old file's permissions
-            if do str::as_c_str(to.to_str()) |to_buf| {
+            if do to.to_str().as_c_str |to_buf| {
                 libc::chmod(to_buf, from_mode as libc::mode_t)
             } != 0 {
                 return false; // should be a condition...
@@ -1290,7 +1289,7 @@ pub fn glob(pattern: &str) -> ~[Path] {
     }
 
     let mut g = default_glob_t();
-    do str::as_c_str(pattern) |c_pattern| {
+    do pattern.as_c_str |c_pattern| {
         unsafe { libc::glob(c_pattern, 0, ptr::null(), &mut g) }
     };
     do(|| {

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -23,7 +23,6 @@ use iterator::IteratorUtil;
 use libc;
 use option::{None, Option, Some};
 use str::{OwnedStr, Str, StrSlice, StrVector};
-use str;
 use to_str::ToStr;
 use ascii::{AsciiCast, AsciiStr};
 use vec::{OwnedVector, ImmutableVector};
@@ -342,13 +341,11 @@ mod stat {
 #[cfg(target_os = "win32")]
 impl WindowsPath {
     pub fn stat(&self) -> Option<libc::stat> {
-        unsafe {
-             do str::as_c_str(self.to_str()) |buf| {
-                let mut st = stat::arch::default_stat();
-                match libc::stat(buf, &mut st) {
-                    0 => Some(st),
-                    _ => None,
-                }
+        do self.to_str().as_c_str |buf| {
+            let mut st = stat::arch::default_stat();
+            match unsafe { libc::stat(buf, &mut st) } {
+                0 => Some(st),
+                _ => None,
             }
         }
     }
@@ -378,13 +375,11 @@ impl WindowsPath {
 #[cfg(not(target_os = "win32"))]
 impl PosixPath {
     pub fn stat(&self) -> Option<libc::stat> {
-        unsafe {
-             do str::as_c_str(self.to_str()) |buf| {
-                let mut st = stat::arch::default_stat();
-                match libc::stat(buf, &mut st) {
-                    0 => Some(st),
-                    _ => None,
-                }
+        do self.to_str().as_c_str |buf| {
+            let mut st = stat::arch::default_stat();
+            match unsafe { libc::stat(buf as *libc::c_char, &mut st) } {
+                0 => Some(st),
+                _ => None,
             }
         }
     }
@@ -458,13 +453,11 @@ impl PosixPath {
 #[cfg(unix)]
 impl PosixPath {
     pub fn lstat(&self) -> Option<libc::stat> {
-        unsafe {
-            do str::as_c_str(self.to_str()) |buf| {
-                let mut st = stat::arch::default_stat();
-                match libc::lstat(buf, &mut st) {
-                    0 => Some(st),
-                    _ => None,
-                }
+        do self.to_str().as_c_str |buf| {
+            let mut st = stat::arch::default_stat();
+            match unsafe { libc::lstat(buf, &mut st) } {
+                0 => Some(st),
+                _ => None,
             }
         }
     }

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -62,7 +62,7 @@ pub use path::PosixPath;
 pub use path::WindowsPath;
 pub use ptr::RawPtr;
 pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr, ToBytesConsume};
-pub use str::{Str, StrVector, StrSlice, OwnedStr, StrUtil, NullTerminatedStr};
+pub use str::{Str, StrVector, StrSlice, OwnedStr, NullTerminatedStr};
 pub use from_str::{FromStr};
 pub use to_bytes::IterBytes;
 pub use to_str::{ToStr, ToStrConsume};

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -461,17 +461,13 @@ pub mod ptr_tests {
 
     #[test]
     fn test_position() {
-        use str::as_c_str;
         use libc::c_char;
 
         let s = ~"hello";
         unsafe {
-            assert!(2u == as_c_str(s, |p| position(p,
-                                                   |c| *c == 'l' as c_char)));
-            assert!(4u == as_c_str(s, |p| position(p,
-                                                   |c| *c == 'o' as c_char)));
-            assert!(5u == as_c_str(s, |p| position(p,
-                                                   |c| *c == 0 as c_char)));
+            assert!(2u == s.as_c_str(|p| position(p, |c| *c == 'l' as c_char)));
+            assert!(4u == s.as_c_str(|p| position(p, |c| *c == 'o' as c_char)));
+            assert!(5u == s.as_c_str(|p| position(p, |c| *c == 0 as c_char)));
         }
     }
 
@@ -480,9 +476,9 @@ pub mod ptr_tests {
         let s0 = ~"hello";
         let s1 = ~"there";
         let s2 = ~"thing";
-        do str::as_c_str(s0) |p0| {
-            do str::as_c_str(s1) |p1| {
-                do str::as_c_str(s2) |p2| {
+        do s0.as_c_str |p0| {
+            do s1.as_c_str |p1| {
+                do s2.as_c_str |p2| {
                     let v = ~[p0, p1, p2, null()];
                     do v.as_imm_buf |vp, len| {
                         assert_eq!(unsafe { buf_len(vp) }, 3u);

--- a/src/libstd/rt/borrowck.rs
+++ b/src/libstd/rt/borrowck.rs
@@ -16,7 +16,7 @@ use managed::raw::BoxRepr;
 use option::{Option, None, Some};
 use uint;
 use str;
-use str::OwnedStr;
+use str::{OwnedStr, StrSlice};
 use sys;
 use vec::ImmutableVector;
 
@@ -76,7 +76,7 @@ unsafe fn fail_borrowed(box: *mut BoxRepr, file: *c_char, line: size_t) {
     match try_take_task_borrow_list() {
         None => { // not recording borrows
             let msg = "borrowed";
-            do str::as_buf(msg) |msg_p, _| {
+            do msg.as_buf |msg_p, _| {
                 sys::begin_unwind_(msg_p as *c_char, file, line);
             }
         }
@@ -92,7 +92,7 @@ unsafe fn fail_borrowed(box: *mut BoxRepr, file: *c_char, line: size_t) {
                     sep = " and at ";
                 }
             }
-            do str::as_buf(msg) |msg_p, _| {
+            do msg.as_buf |msg_p, _| {
                 sys::begin_unwind_(msg_p as *c_char, file, line)
             }
         }
@@ -231,7 +231,7 @@ pub unsafe fn unrecord_borrow(a: *u8, old_ref_count: uint,
             let br = borrow_list.pop();
             if br.box != a || br.file != file || br.line != line {
                 let err = fmt!("wrong borrow found, br=%?", br);
-                do str::as_buf(err) |msg_p, _| {
+                do err.as_buf |msg_p, _| {
                     sys::begin_unwind_(msg_p as *c_char, file, line)
                 }
             }

--- a/src/libstd/rt/borrowck.rs
+++ b/src/libstd/rt/borrowck.rs
@@ -76,7 +76,7 @@ unsafe fn fail_borrowed(box: *mut BoxRepr, file: *c_char, line: size_t) {
     match try_take_task_borrow_list() {
         None => { // not recording borrows
             let msg = "borrowed";
-            do msg.as_buf |msg_p, _| {
+            do msg.as_c_str |msg_p| {
                 sys::begin_unwind_(msg_p as *c_char, file, line);
             }
         }
@@ -92,7 +92,7 @@ unsafe fn fail_borrowed(box: *mut BoxRepr, file: *c_char, line: size_t) {
                     sep = " and at ";
                 }
             }
-            do msg.as_buf |msg_p, _| {
+            do msg.as_c_str |msg_p| {
                 sys::begin_unwind_(msg_p as *c_char, file, line)
             }
         }
@@ -231,7 +231,7 @@ pub unsafe fn unrecord_borrow(a: *u8, old_ref_count: uint,
             let br = borrow_list.pop();
             if br.box != a || br.file != file || br.line != line {
                 let err = fmt!("wrong borrow found, br=%?", br);
-                do err.as_buf |msg_p, _| {
+                do err.as_c_str |msg_p| {
                     sys::begin_unwind_(msg_p as *c_char, file, line)
                 }
             }

--- a/src/libstd/rt/logging.rs
+++ b/src/libstd/rt/logging.rs
@@ -46,17 +46,15 @@ impl Logger for StdErrLogger {
 /// per-module global logging flags based on the logging spec
 pub fn init(crate_map: *u8) {
     use os;
-    use str;
+    use str::StrSlice;
     use ptr;
     use option::{Some, None};
 
     let log_spec = os::getenv("RUST_LOG");
     match log_spec {
         Some(spec) => {
-            do str::as_c_str(spec) |s| {
-                unsafe {
-                    rust_update_log_settings(crate_map, s);
-                }
+            do spec.as_c_str |buf| {
+                unsafe { rust_update_log_settings(crate_map, buf) }
             }
         }
         None => {

--- a/src/libstd/rt/uv/uvll.rs
+++ b/src/libstd/rt/uv/uvll.rs
@@ -382,12 +382,12 @@ pub unsafe fn as_sockaddr_in6(addr: *sockaddr) -> *sockaddr_in6 {
 }
 
 pub unsafe fn malloc_ip4_addr(ip: &str, port: int) -> *sockaddr_in {
-    do str::as_c_str(ip) |ip_buf| {
+    do ip.as_c_str |ip_buf| {
         rust_uv_ip4_addrp(ip_buf as *u8, port as libc::c_int)
     }
 }
 pub unsafe fn malloc_ip6_addr(ip: &str, port: int) -> *sockaddr_in6 {
-    do str::as_c_str(ip) |ip_buf| {
+    do ip.as_c_str |ip_buf| {
         rust_uv_ip6_addrp(ip_buf as *u8, port as libc::c_int)
     }
 }

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -746,7 +746,7 @@ fn with_envp<T>(env: Option<&[(~str, ~str)]>, cb: &fn(*mut c_void) -> T) -> T {
         let mut blk = ~[];
         for es.iter().advance |pair| {
             let kv = fmt!("%s=%s", pair.first(), pair.second());
-            blk.push_all(kv.as_bytes_with_null_consume());
+            blk.push_all(kv.to_bytes_with_null());
         }
         blk.push(0);
         blk.as_imm_buf(|p, _len|

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -23,7 +23,6 @@ use option::{Some, None};
 use os;
 use prelude::*;
 use ptr;
-use str;
 use task;
 use vec::ImmutableVector;
 

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -507,7 +507,7 @@ fn spawn_process_os(prog: &str, args: &[~str],
 
         do with_envp(env) |envp| {
             do with_dirp(dir) |dirp| {
-                do str::as_c_str(cmd) |cmdp| {
+                do cmd.as_c_str |cmdp| {
                     let created = CreateProcessA(ptr::null(), cast::transmute(cmdp),
                                                  ptr::mut_null(), ptr::mut_null(), TRUE,
                                                  0, envp, dirp, &mut si, &mut pi);
@@ -696,12 +696,12 @@ fn spawn_process_os(prog: &str, args: &[~str],
 #[cfg(unix)]
 fn with_argv<T>(prog: &str, args: &[~str],
                 cb: &fn(**libc::c_char) -> T) -> T {
-    let mut argptrs = ~[str::as_c_str(prog, |b| b)];
+    let mut argptrs = ~[prog.as_c_str(|b| b)];
     let mut tmps = ~[];
     for args.iter().advance |arg| {
         let t = @(*arg).clone();
         tmps.push(t);
-        argptrs.push(str::as_c_str(*t, |b| b));
+        argptrs.push(t.as_c_str(|b| b));
     }
     argptrs.push(ptr::null());
     argptrs.as_imm_buf(|buf, _len| cb(buf))
@@ -723,7 +723,7 @@ fn with_envp<T>(env: Option<&[(~str, ~str)]>, cb: &fn(*c_void) -> T) -> T {
                 &(ref k, ref v) => {
                     let kv = @fmt!("%s=%s", *k, *v);
                     tmps.push(kv);
-                    ptrs.push(str::as_c_str(*kv, |b| b));
+                    ptrs.push(kv.as_c_str(|b| b));
                 }
             }
         }
@@ -761,7 +761,7 @@ fn with_envp<T>(env: Option<&[(~str, ~str)]>, cb: &fn(*mut c_void) -> T) -> T {
 fn with_dirp<T>(d: Option<&Path>,
                 cb: &fn(*libc::c_char) -> T) -> T {
     match d {
-      Some(dir) => str::as_c_str(dir.to_str(), cb),
+      Some(dir) => dir.to_str().as_c_str(cb),
       None => cb(ptr::null())
     }
 }

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -2028,7 +2028,7 @@ pub trait OwnedStr {
     fn pop_char(&mut self) -> char;
     fn shift_char(&mut self) -> char;
     fn unshift_char(&mut self, ch: char);
-    fn append(&self, rhs: &str) -> ~str; // FIXME #4850: this should consume self.
+    fn append(self, rhs: &str) -> ~str;
     fn reserve(&mut self, n: uint);
     fn reserve_at_least(&mut self, n: uint);
     fn capacity(&self) -> uint;
@@ -2162,11 +2162,10 @@ impl OwnedStr for ~str {
 
     /// Concatenate two strings together.
     #[inline]
-    fn append(&self, rhs: &str) -> ~str {
-        // FIXME #4850: this should consume self, but that causes segfaults
-        let mut v = self.clone();
-        v.push_str_no_overallocate(rhs);
-        v
+    fn append(self, rhs: &str) -> ~str {
+        let mut new_str = self;
+        new_str.push_str_no_overallocate(rhs);
+        new_str
     }
 
     /**

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1957,11 +1957,8 @@ impl<'self> StrSlice<'self> for &'self str {
      */
     #[inline]
     fn as_imm_buf<T>(&self, f: &fn(*u8, uint) -> T) -> T {
-        unsafe {
-            let v: *(*u8, uint) = cast::transmute(self);
-            let (buf, len) = *v;
-            f(buf, len)
-        }
+        let v: &[u8] = unsafe { cast::transmute(*self) };
+        v.as_imm_buf(f)
     }
 
     /**

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -773,51 +773,6 @@ static TAG_THREE_B: uint = 224u;
 static MAX_THREE_B: uint = 65536u;
 static TAG_FOUR_B: uint = 240u;
 
-/**
- * A dummy trait to hold all the utility methods that we implement on strings.
- */
-pub trait StrUtil {
-    /**
-     * Work with the byte buffer of a string as a null-terminated C string.
-     *
-     * Allows for unsafe manipulation of strings, which is useful for foreign
-     * interop. This is similar to `str::as_buf`, but guarantees null-termination.
-     * If the given slice is not already null-terminated, this function will
-     * allocate a temporary, copy the slice, null terminate it, and pass
-     * that instead.
-     *
-     * # Example
-     *
-     * ~~~ {.rust}
-     * let s = "PATH".as_c_str(|path| libc::getenv(path));
-     * ~~~
-     */
-    fn as_c_str<T>(self, f: &fn(*libc::c_char) -> T) -> T;
-}
-
-impl<'self> StrUtil for &'self str {
-    #[inline]
-    fn as_c_str<T>(self, f: &fn(*libc::c_char) -> T) -> T {
-        do self.as_buf |buf, len| {
-            // NB: len includes the trailing null.
-            assert!(len > 0);
-            if unsafe { *(ptr::offset(buf,len-1)) != 0 } {
-                to_owned(self).as_c_str(|s| f(s))
-            } else {
-                f(buf as *libc::c_char)
-            }
-        }
-    }
-}
-
-/**
- * Deprecated. Use the `as_c_str` method on strings instead.
- */
-#[inline]
-pub fn as_c_str<T>(s: &str, f: &fn(*libc::c_char) -> T) -> T {
-    s.as_c_str(f)
-}
-
 /// Unsafe operations
 pub mod raw {
     use cast;
@@ -1271,6 +1226,7 @@ pub trait StrSlice<'self> {
     fn subslice_offset(&self, inner: &str) -> uint;
 
     fn as_buf<T>(&self, f: &fn(*u8, uint) -> T) -> T;
+    fn as_c_str<T>(&self, f: &fn(*libc::c_char) -> T) -> T;
 }
 
 /// Extension methods for strings
@@ -2025,6 +1981,34 @@ impl<'self> StrSlice<'self> for &'self str {
             let v: *(*u8, uint) = cast::transmute(self);
             let (buf, len) = *v;
             f(buf, len)
+        }
+    }
+
+    /**
+     * Work with the byte buffer of a string as a null-terminated C string.
+     *
+     * Allows for unsafe manipulation of strings, which is useful for foreign
+     * interop. This is similar to `str::as_buf`, but guarantees null-termination.
+     * If the given slice is not already null-terminated, this function will
+     * allocate a temporary, copy the slice, null terminate it, and pass
+     * that instead.
+     *
+     * # Example
+     *
+     * ~~~ {.rust}
+     * let s = "PATH".as_c_str(|path| libc::getenv(path));
+     * ~~~
+     */
+    #[inline]
+    fn as_c_str<T>(&self, f: &fn(*libc::c_char) -> T) -> T {
+        do self.as_buf |buf, len| {
+            // NB: len includes the trailing null.
+            assert!(len > 0);
+            if unsafe { *(ptr::offset(buf, len - 1)) != 0 } {
+                self.to_owned().as_c_str(|s| f(s))
+            } else {
+                f(buf as *libc::c_char)
+            }
         }
     }
 }

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -17,7 +17,6 @@
  */
 
 use at_vec;
-use cast::transmute;
 use cast;
 use char;
 use char::Char;
@@ -192,10 +191,10 @@ impl<'self, S: Str> StrVector for &'self [S] {
         s.reserve(len);
 
         unsafe {
-            do as_buf(s) |buf, _| {
+            do s.as_buf |buf, _| {
                 let mut buf = ::cast::transmute_mut_unsafe(buf);
                 for self.iter().advance |ss| {
-                    do as_buf(ss.as_slice()) |ssbuf, sslen| {
+                    do ss.as_slice().as_buf |ssbuf, sslen| {
                         let sslen = sslen - 1;
                         ptr::copy_memory(buf, ssbuf, sslen);
                         buf = buf.offset(sslen);
@@ -223,12 +222,12 @@ impl<'self, S: Str> StrVector for &'self [S] {
         s.reserve(len);
 
         unsafe {
-            do as_buf(s) |buf, _| {
-                do as_buf(sep) |sepbuf, seplen| {
+            do s.as_buf |buf, _| {
+                do sep.as_buf |sepbuf, seplen| {
                     let seplen = seplen - 1;
                     let mut buf = ::cast::transmute_mut_unsafe(buf);
                     for self.iter().advance |ss| {
-                        do as_buf(ss.as_slice()) |ssbuf, sslen| {
+                        do ss.as_slice().as_buf |ssbuf, sslen| {
                             let sslen = sslen - 1;
                             if first {
                                 first = false;
@@ -534,8 +533,8 @@ Section: Comparing strings
 #[lang="str_eq"]
 #[inline]
 pub fn eq_slice(a: &str, b: &str) -> bool {
-    do as_buf(a) |ap, alen| {
-        do as_buf(b) |bp, blen| {
+    do a.as_buf |ap, alen| {
+        do b.as_buf |bp, blen| {
             if (alen != blen) { false }
             else {
                 unsafe {
@@ -551,8 +550,8 @@ pub fn eq_slice(a: &str, b: &str) -> bool {
 #[cfg(test)]
 #[inline]
 pub fn eq_slice(a: &str, b: &str) -> bool {
-    do as_buf(a) |ap, alen| {
-        do as_buf(b) |bp, blen| {
+    do a.as_buf |ap, alen| {
+        do b.as_buf |bp, blen| {
             if (alen != blen) { false }
             else {
                 unsafe {
@@ -799,7 +798,7 @@ pub trait StrUtil {
 impl<'self> StrUtil for &'self str {
     #[inline]
     fn as_c_str<T>(self, f: &fn(*libc::c_char) -> T) -> T {
-        do as_buf(self) |buf, len| {
+        do self.as_buf |buf, len| {
             // NB: len includes the trailing null.
             assert!(len > 0);
             if unsafe { *(ptr::offset(buf,len-1)) != 0 } {
@@ -819,30 +818,13 @@ pub fn as_c_str<T>(s: &str, f: &fn(*libc::c_char) -> T) -> T {
     s.as_c_str(f)
 }
 
-/**
- * Work with the byte buffer and length of a slice.
- *
- * The given length is one byte longer than the 'official' indexable
- * length of the string. This is to permit probing the byte past the
- * indexable area for a null byte, as is the case in slices pointing
- * to full strings, or suffixes of them.
- */
-#[inline]
-pub fn as_buf<T>(s: &str, f: &fn(*u8, uint) -> T) -> T {
-    unsafe {
-        let v : *(*u8,uint) = transmute(&s);
-        let (buf,len) = *v;
-        f(buf, len)
-    }
-}
-
 /// Unsafe operations
 pub mod raw {
     use cast;
     use libc;
     use ptr;
     use str::raw;
-    use str::{as_buf, is_utf8};
+    use str::{is_utf8};
     use vec;
     use vec::MutableVector;
 
@@ -931,7 +913,7 @@ pub mod raw {
      * If end is greater than the length of the string.
      */
     pub unsafe fn slice_bytes_owned(s: &str, begin: uint, end: uint) -> ~str {
-        do as_buf(s) |sbuf, n| {
+        do s.as_buf |sbuf, n| {
             assert!((begin <= end));
             assert!((end <= n));
 
@@ -959,7 +941,7 @@ pub mod raw {
      */
     #[inline]
     pub unsafe fn slice_bytes(s: &str, begin: uint, end: uint) -> &str {
-        do as_buf(s) |sbuf, n| {
+        do s.as_buf |sbuf, n| {
              assert!((begin <= end));
              assert!((end <= n));
 
@@ -972,7 +954,7 @@ pub mod raw {
     pub unsafe fn push_byte(s: &mut ~str, b: u8) {
         let new_len = s.len() + 1;
         s.reserve_at_least(new_len);
-        do as_buf(*s) |buf, len| {
+        do s.as_buf |buf, len| {
             let buf: *mut u8 = ::cast::transmute(buf);
             *ptr::mut_offset(buf, len) = b;
         }
@@ -1193,7 +1175,7 @@ impl<'self> Str for @str {
 impl<'self> Container for &'self str {
     #[inline]
     fn len(&self) -> uint {
-        do as_buf(*self) |_p, n| { n - 1u }
+        do self.as_buf |_p, n| { n - 1u }
     }
     #[inline]
     fn is_empty(&self) -> bool {
@@ -1287,6 +1269,8 @@ pub trait StrSlice<'self> {
     fn lev_distance(&self, t: &str) -> uint;
 
     fn subslice_offset(&self, inner: &str) -> uint;
+
+    fn as_buf<T>(&self, f: &fn(*u8, uint) -> T) -> T;
 }
 
 /// Extension methods for strings
@@ -1909,14 +1893,14 @@ impl<'self> StrSlice<'self> for &'self str {
 
     /// Given a string, make a new string with repeated copies of it.
     fn repeat(&self, nn: uint) -> ~str {
-        do as_buf(*self) |buf, len| {
+        do self.as_buf |buf, len| {
             let mut ret = ~"";
             // ignore the NULL terminator
             let len = len - 1;
             ret.reserve(nn * len);
 
             unsafe {
-                do as_buf(ret) |rbuf, _len| {
+                do ret.as_buf |rbuf, _len| {
                     let mut rbuf = ::cast::transmute_mut_unsafe(rbuf);
 
                     for nn.times {
@@ -2010,8 +1994,8 @@ impl<'self> StrSlice<'self> for &'self str {
      */
     #[inline]
     fn subslice_offset(&self, inner: &str) -> uint {
-        do as_buf(*self) |a, a_len| {
-            do as_buf(inner) |b, b_len| {
+        do self.as_buf |a, a_len| {
+            do inner.as_buf |b, b_len| {
                 let a_start: uint;
                 let a_end: uint;
                 let b_start: uint;
@@ -2027,6 +2011,22 @@ impl<'self> StrSlice<'self> for &'self str {
         }
     }
 
+    /**
+     * Work with the byte buffer and length of a slice.
+     *
+     * The given length is one byte longer than the 'official' indexable
+     * length of the string. This is to permit probing the byte past the
+     * indexable area for a null byte, as is the case in slices pointing
+     * to full strings, or suffixes of them.
+     */
+    #[inline]
+    fn as_buf<T>(&self, f: &fn(*u8, uint) -> T) -> T {
+        unsafe {
+            let v: *(*u8, uint) = cast::transmute(self);
+            let (buf, len) = *v;
+            f(buf, len)
+        }
+    }
 }
 
 #[allow(missing_doc)]
@@ -2084,8 +2084,8 @@ impl OwnedStr for ~str {
             let llen = self.len();
             let rlen = rhs.len();
             self.reserve(llen + rlen);
-            do as_buf(*self) |lbuf, _llen| {
-                do as_buf(rhs) |rbuf, _rlen| {
+            do self.as_buf |lbuf, _llen| {
+                do rhs.as_buf |rbuf, _rlen| {
                     let dst = ptr::offset(lbuf, llen);
                     let dst = ::cast::transmute_mut_unsafe(dst);
                     ptr::copy_memory(dst, rbuf, rlen);
@@ -2102,8 +2102,8 @@ impl OwnedStr for ~str {
             let llen = self.len();
             let rlen = rhs.len();
             self.reserve_at_least(llen + rlen);
-            do as_buf(*self) |lbuf, _llen| {
-                do as_buf(rhs) |rbuf, _rlen| {
+            do self.as_buf |lbuf, _llen| {
+                do rhs.as_buf |rbuf, _rlen| {
                     let dst = ptr::offset(lbuf, llen);
                     let dst = ::cast::transmute_mut_unsafe(dst);
                     ptr::copy_memory(dst, rbuf, rlen);
@@ -2126,7 +2126,7 @@ impl OwnedStr for ~str {
             let new_len = len + nb;
             self.reserve_at_least(new_len);
             let off = len;
-            do as_buf(*self) |buf, _len| {
+            do self.as_buf |buf, _len| {
                 let buf: *mut u8 = ::cast::transmute(buf);
                 match nb {
                     1u => {
@@ -3091,20 +3091,20 @@ mod tests {
     #[test]
     fn test_as_buf() {
         let a = "Abcdefg";
-        let b = as_buf(a, |buf, _l| {
+        let b = do a.as_buf |buf, _l| {
             assert_eq!(unsafe { *buf }, 65u8);
             100
-        });
+        };
         assert_eq!(b, 100);
     }
 
     #[test]
     fn test_as_buf_small() {
         let a = "A";
-        let b = as_buf(a, |buf, _l| {
+        let b = do a.as_buf |buf, _l| {
             assert_eq!(unsafe { *buf }, 65u8);
             100
-        });
+        };
         assert_eq!(b, 100);
     }
 
@@ -3112,7 +3112,7 @@ mod tests {
     fn test_as_buf2() {
         unsafe {
             let s = ~"hello";
-            let sb = as_buf(s, |b, _l| b);
+            let sb = s.as_buf(|b, _l| b);
             let s_cstr = raw::from_buf(sb);
             assert_eq!(s_cstr, s);
         }
@@ -3121,7 +3121,7 @@ mod tests {
     #[test]
     fn test_as_buf_3() {
         let a = ~"hello";
-        do as_buf(a) |buf, len| {
+        do a.as_buf |buf, len| {
             unsafe {
                 assert_eq!(a[0], 'h' as u8);
                 assert_eq!(*buf, 'h' as u8);

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -180,9 +180,7 @@ impl<'self, S: Str> StrVector for &'self [S] {
 
         let len = self.iter().transform(|s| s.as_slice().len()).sum();
 
-        let mut s = ~"";
-
-        s.reserve(len);
+        let mut s = with_capacity(len);
 
         unsafe {
             do s.as_mut_buf |buf, _| {
@@ -678,6 +676,7 @@ pub fn from_utf16(v: &[u16]) -> ~str {
  * Allocates a new string with the specified capacity. The string returned is
  * the empty string, but has capacity for much more.
  */
+#[inline]
 pub fn with_capacity(capacity: uint) -> ~str {
     let mut buf = ~"";
     buf.reserve(capacity);
@@ -1830,10 +1829,9 @@ impl<'self> StrSlice<'self> for &'self str {
     /// Given a string, make a new string with repeated copies of it.
     fn repeat(&self, nn: uint) -> ~str {
         do self.as_imm_buf |buf, len| {
-            let mut ret = ~"";
             // ignore the NULL terminator
             let len = len - 1;
-            ret.reserve(nn * len);
+            let mut ret = with_capacity(nn * len);
 
             unsafe {
                 do ret.as_mut_buf |rbuf, _len| {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -3117,6 +3117,28 @@ mod tests {
     }
 
     #[test]
+    fn test_as_c_str() {
+        let a = ~"";
+        do a.as_c_str |buf| {
+            unsafe {
+                assert_eq!(*ptr::offset(buf, 0), 0);
+            }
+        }
+
+        let a = ~"hello";
+        do a.as_c_str |buf| {
+            unsafe {
+                assert_eq!(*ptr::offset(buf, 0), 'h' as libc::c_char);
+                assert_eq!(*ptr::offset(buf, 1), 'e' as libc::c_char);
+                assert_eq!(*ptr::offset(buf, 2), 'l' as libc::c_char);
+                assert_eq!(*ptr::offset(buf, 3), 'l' as libc::c_char);
+                assert_eq!(*ptr::offset(buf, 4), 'o' as libc::c_char);
+                assert_eq!(*ptr::offset(buf, 5), 0);
+            }
+        }
+    }
+
+    #[test]
     fn test_subslice_offset() {
         let a = "kernelsprite";
         let b = a.slice(7, a.len());

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -2073,8 +2073,7 @@ pub trait OwnedStr {
     fn reserve(&mut self, n: uint);
     fn reserve_at_least(&mut self, n: uint);
     fn capacity(&self) -> uint;
-
-    fn as_bytes_with_null_consume(self) -> ~[u8];
+    fn to_bytes_with_null(self) -> ~[u8];
 }
 
 impl OwnedStr for ~str {
@@ -2263,7 +2262,7 @@ impl OwnedStr for ~str {
     /// Convert to a vector of bytes. This does not allocate a new
     /// string, and includes the null terminator.
     #[inline]
-    fn as_bytes_with_null_consume(self) -> ~[u8] {
+    fn to_bytes_with_null(self) -> ~[u8] {
         unsafe { ::cast::transmute(self) }
     }
 }
@@ -3065,17 +3064,17 @@ mod tests {
     }
 
     #[test]
-    fn test_as_bytes_with_null_consume() {
+    fn test_to_bytes_with_null() {
         let s = ~"ศไทย中华Việt Nam";
         let v = ~[
             224, 184, 168, 224, 185, 132, 224, 184, 151, 224, 184, 162, 228,
             184, 173, 229, 141, 142, 86, 105, 225, 187, 135, 116, 32, 78, 97,
             109, 0
         ];
-        assert_eq!((~"").as_bytes_with_null_consume(), ~[0]);
-        assert_eq!((~"abc").as_bytes_with_null_consume(),
+        assert_eq!((~"").to_bytes_with_null(), ~[0]);
+        assert_eq!((~"abc").to_bytes_with_null(),
                    ~['a' as u8, 'b' as u8, 'c' as u8, 0]);
-        assert_eq!(s.as_bytes_with_null_consume(), v);
+        assert_eq!(s.to_bytes_with_null(), v);
     }
 
     #[test]

--- a/src/libstd/sys.rs
+++ b/src/libstd/sys.rs
@@ -18,6 +18,7 @@ use io;
 use libc;
 use libc::{c_char, size_t};
 use repr;
+use str::StrSlice;
 use str;
 use unstable::intrinsics;
 
@@ -122,8 +123,8 @@ pub trait FailWithCause {
 
 impl FailWithCause for ~str {
     fn fail_with(cause: ~str, file: &'static str, line: uint) -> ! {
-        do str::as_buf(cause) |msg_buf, _msg_len| {
-            do str::as_buf(file) |file_buf, _file_len| {
+        do cause.as_buf |msg_buf, _msg_len| {
+            do file.as_buf |file_buf, _file_len| {
                 unsafe {
                     let msg_buf = cast::transmute(msg_buf);
                     let file_buf = cast::transmute(file_buf);
@@ -136,8 +137,8 @@ impl FailWithCause for ~str {
 
 impl FailWithCause for &'static str {
     fn fail_with(cause: &'static str, file: &'static str, line: uint) -> ! {
-        do str::as_buf(cause) |msg_buf, _msg_len| {
-            do str::as_buf(file) |file_buf, _file_len| {
+        do cause.as_buf |msg_buf, _msg_len| {
+            do file.as_buf |file_buf, _file_len| {
                 unsafe {
                     let msg_buf = cast::transmute(msg_buf);
                     let file_buf = cast::transmute(file_buf);

--- a/src/libstd/sys.rs
+++ b/src/libstd/sys.rs
@@ -123,13 +123,9 @@ pub trait FailWithCause {
 
 impl FailWithCause for ~str {
     fn fail_with(cause: ~str, file: &'static str, line: uint) -> ! {
-        do cause.as_buf |msg_buf, _msg_len| {
-            do file.as_buf |file_buf, _file_len| {
-                unsafe {
-                    let msg_buf = cast::transmute(msg_buf);
-                    let file_buf = cast::transmute(file_buf);
-                    begin_unwind_(msg_buf, file_buf, line as libc::size_t)
-                }
+        do cause.as_c_str |msg_buf| {
+            do file.as_c_str |file_buf| {
+                begin_unwind_(msg_buf, file_buf, line as libc::size_t)
             }
         }
     }
@@ -137,13 +133,9 @@ impl FailWithCause for ~str {
 
 impl FailWithCause for &'static str {
     fn fail_with(cause: &'static str, file: &'static str, line: uint) -> ! {
-        do cause.as_buf |msg_buf, _msg_len| {
-            do file.as_buf |file_buf, _file_len| {
-                unsafe {
-                    let msg_buf = cast::transmute(msg_buf);
-                    let file_buf = cast::transmute(file_buf);
-                    begin_unwind_(msg_buf, file_buf, line as libc::size_t)
-                }
+        do cause.as_c_str |msg_buf| {
+            do file.as_c_str |file_buf| {
+                begin_unwind_(msg_buf, file_buf, line as libc::size_t)
             }
         }
     }

--- a/src/libstd/unstable/lang.rs
+++ b/src/libstd/unstable/lang.rs
@@ -56,8 +56,8 @@ pub fn fail_bounds_check(file: *c_char, line: size_t,
                          index: size_t, len: size_t) {
     let msg = fmt!("index out of bounds: the len is %d but the index is %d",
                     len as int, index as int);
-    do msg.as_buf |p, _len| {
-        fail_(p as *c_char, file, line);
+    do msg.as_c_str |buf| {
+        fail_(buf, file, line);
     }
 }
 

--- a/src/libstd/unstable/lang.rs
+++ b/src/libstd/unstable/lang.rs
@@ -56,7 +56,7 @@ pub fn fail_bounds_check(file: *c_char, line: size_t,
                          index: size_t, len: size_t) {
     let msg = fmt!("index out of bounds: the len is %d but the index is %d",
                     len as int, index as int);
-    do str::as_buf(msg) |p, _len| {
+    do msg.as_buf |p, _len| {
         fail_(p as *c_char, file, line);
     }
 }

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -87,6 +87,7 @@ pub fn from_elem<T:Clone>(n_elts: uint, t: T) -> ~[T] {
 }
 
 /// Creates a new vector with a capacity of `capacity`
+#[inline]
 pub fn with_capacity<T>(capacity: uint) -> ~[T] {
     unsafe {
         if contains_managed::<T>() {

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1691,7 +1691,7 @@ pub trait MutableVector<'self, T> {
     unsafe fn unsafe_mut_ref(&self, index: uint) -> *mut T;
     unsafe fn unsafe_set(&self, index: uint, val: T);
 
-    fn as_mut_buf<U>(&self, f: &fn(*mut T, uint) -> U) -> U;
+    fn as_mut_buf<U>(self, f: &fn(*mut T, uint) -> U) -> U;
 }
 
 impl<'self,T> MutableVector<'self, T> for &'self mut [T] {
@@ -1783,12 +1783,9 @@ impl<'self,T> MutableVector<'self, T> for &'self mut [T] {
 
     /// Similar to `as_imm_buf` but passing a `*mut T`
     #[inline]
-    fn as_mut_buf<U>(&self, f: &fn(*mut T, uint) -> U) -> U {
-        unsafe {
-            let v : *(*mut T,uint) = transmute(self);
-            let (buf,len) = *v;
-            f(buf, len / sys::nonzero_size_of::<T>())
-        }
+    fn as_mut_buf<U>(self, f: &fn(*mut T, uint) -> U) -> U {
+        let (buf, len): (*mut T, uint) = unsafe { transmute(self) };
+        f(buf, len / sys::nonzero_size_of::<T>())
     }
 
 }

--- a/src/test/run-pass/c-stack-returning-int64.rs
+++ b/src/test/run-pass/c-stack-returning-int64.rs
@@ -20,11 +20,11 @@ mod libc {
 }
 
 fn atol(s: ~str) -> int {
-    s.as_buf(|x, _len| unsafe { libc::atol(x) })
+    s.as_imm_buf(|x, _len| unsafe { libc::atol(x) })
 }
 
 fn atoll(s: ~str) -> i64 {
-    s.as_buf(|x, _len| unsafe { libc::atoll(x) })
+    s.as_imm_buf(|x, _len| unsafe { libc::atoll(x) })
 }
 
 pub fn main() {

--- a/src/test/run-pass/c-stack-returning-int64.rs
+++ b/src/test/run-pass/c-stack-returning-int64.rs
@@ -20,11 +20,11 @@ mod libc {
 }
 
 fn atol(s: ~str) -> int {
-    return str::as_buf(s, { |x, _len| unsafe { libc::atol(x) } });
+    s.as_buf(|x, _len| unsafe { libc::atol(x) })
 }
 
 fn atoll(s: ~str) -> i64 {
-    return str::as_buf(s, { |x, _len| unsafe { libc::atoll(x) } });
+    s.as_buf(|x, _len| unsafe { libc::atoll(x) })
 }
 
 pub fn main() {

--- a/src/test/run-pass/foreign-fn-linkname.rs
+++ b/src/test/run-pass/foreign-fn-linkname.rs
@@ -26,7 +26,7 @@ mod libc {
 fn strlen(str: ~str) -> uint {
     unsafe {
         // C string is terminated with a zero
-        let bytes = str.as_bytes_with_null_consume();
+        let bytes = str.to_bytes_with_null();
         return libc::my_strlen(vec::raw::to_ptr(bytes));
     }
 }

--- a/src/test/run-pass/resource-cycle.rs
+++ b/src/test/run-pass/resource-cycle.rs
@@ -23,16 +23,14 @@ impl Drop for r {
               cast::transmute::<*r, uint>(self),
               cast::transmute::<**int, uint>(&(self.v)),
               cast::transmute::<*int, uint>(self.v));
-            let v2: ~int = cast::transmute(self.v);
+            let _v2: ~int = cast::transmute(self.v);
         }
     }
 }
 
 fn r(v: *int) -> r {
-    unsafe {
-        r {
-            v: v
-        }
+    r {
+        v: v
     }
 }
 
@@ -52,7 +50,7 @@ pub fn main() {
         let i2p = cast::transmute_copy(&i2);
         cast::forget(i2);
 
-        let mut x1 = @mut t(Node{
+        let x1 = @mut t(Node{
             next: None,
               r: {
               let rs = r(i1p);
@@ -64,7 +62,7 @@ pub fn main() {
                cast::transmute::<@mut t, uint>(x1),
                cast::transmute::<*r, uint>(&x1.r));
 
-        let mut x2 = @mut t(Node{
+        let x2 = @mut t(Node{
             next: None,
               r: {
               let rs = r(i2p);

--- a/src/test/run-pass/struct-order-of-eval-1.rs
+++ b/src/test/run-pass/struct-order-of-eval-1.rs
@@ -14,5 +14,5 @@ struct S { f0: ~str, f1: int }
 
 pub fn main() {
     let s = ~"Hello, world!";
-    let _s = S { f0: str::to_owned(s), ..S { f0: s, f1: 23 } };
+    let _s = S { f0: s.to_owned(), ..S { f0: s, f1: 23 } };
 }

--- a/src/test/run-pass/struct-order-of-eval-2.rs
+++ b/src/test/run-pass/struct-order-of-eval-2.rs
@@ -14,5 +14,5 @@ struct S { f0: ~str, f1: ~str }
 
 pub fn main() {
     let s = ~"Hello, world!";
-    let _s = S { f1: str::to_owned(s), f0: s };
+    let _s = S { f1: s.to_owned(), f0: s };
 }


### PR DESCRIPTION
This is a cleanup pull request that does:
- removes `os::as_c_charp`
- moves `str::as_buf` and `str::as_c_str` into `StrSlice`
- converts some functions from `StrSlice::as_buf` to `StrSlice::as_c_str`
- renames `StrSlice::as_buf` to `StrSlice::as_imm_buf` (and adds `StrSlice::as_mut_buf` to match `vec.rs`.
- renames `UniqueStr::as_bytes_with_null_consume` to `UniqueStr::to_bytes`
- and other misc cleanups and minor optimizations
