### PR TITLE
tidy: allow arbitrary spaces between // and NOTE

### DIFF
--- a/src/etc/tidy.py
+++ b/src/etc/tidy.py
@@ -49,9 +49,9 @@ try:
                     report_err("FIXME without issue number")
             if line.find("TODO") != -1:
                 report_err("TODO is deprecated; use FIXME")
-            idx = line.find("// NOTE")
-            if idx != -1:
-                report_warn("NOTE" + line[idx + len("// NOTE"):])
+            match = re.match(r'^.*//\s*(NOTE.*)$', line)
+            if match:
+                report_warn(match.group(1))
         if (line.find('\t') != -1 and
             fileinput.filename().find("Makefile") == -1):
             report_err("tab character")


### PR DESCRIPTION
Hello,

I made a tiny change to `tidy.py` so that it uses a regexp to find `// NOTE` comments. I could not find an easy way to write an automated test for this but if this is needed and possible I'd be happy to write one.
Please note that it also removes extra empty lines that appear after each of these warnings (I believe that there were not wanted).

On the performance side, `make tidy` is now a bit slower (running it 10 times in a row takes 71s on my machine, 65s before) but I don't think that it is performance sensitive.

Thanks!
