### PR TITLE
Make ast::Lifetime contain ast::Name instead of ast::ident

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -25,6 +25,7 @@ use syntax::ast;
 use syntax::ast::*;
 use syntax::codemap::dummy_sp;
 use syntax::opt_vec;
+use syntax::parse::token;
 
 // Compact string representation for ty::t values. API ty_str &
 // parse_from_str. Extra parameters are for converting to/from def_ids in the
@@ -226,7 +227,7 @@ fn parse_bound_region(st: &mut PState) -> ty::bound_region {
         assert_eq!(next(st), '|');
         ty::br_anon(id)
       }
-      '[' => ty::br_named(st.tcx.sess.ident_of(parse_str(st, ']'))),
+      '[' => ty::br_named(token::intern(parse_str(st, ']'))),
       'c' => {
         let id = parse_uint(st) as int;
         assert_eq!(next(st), '|');

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -23,6 +23,7 @@ use syntax::ast;
 use syntax::ast::*;
 use syntax::diagnostic::span_handler;
 use syntax::print::pprust::*;
+use syntax::parse::token;
 
 pub struct ctxt {
     diag: @span_handler,
@@ -184,7 +185,7 @@ fn enc_bound_region(w: @io::Writer, cx: @ctxt, br: ty::bound_region) {
       }
       ty::br_named(s) => {
         w.write_char('[');
-        w.write_str(cx.tcx.sess.str_of(s));
+        w.write_str(token::interner_get(s));
         w.write_char(']')
       }
       ty::br_cap_avoid(id, br) => {

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -662,10 +662,10 @@ impl DetermineRpCtxt {
             &None => {
                 self.anon_implies_rp
             }
-            &Some(ref l) if l.ident == special_idents::statik => {
+            &Some(ref l) if l.name == special_idents::statik.name => {
                 false
             }
-            &Some(ref l) if l.ident == special_idents::self_ => {
+            &Some(ref l) if l.name == special_idents::self_.name => {
                 true
             }
             &Some(_) => {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -398,7 +398,7 @@ pub struct ClosureTy {
  * - `output` is the return type. */
 #[deriving(Clone, Eq, IterBytes)]
 pub struct FnSig {
-    bound_lifetime_names: OptVec<ast::ident>,
+    bound_lifetime_names: OptVec<ast::Name>,
     inputs: ~[t],
     output: t
 }
@@ -471,7 +471,7 @@ pub enum bound_region {
     br_anon(uint),
 
     /// Named region parameters for functions (a in &'a T)
-    br_named(ast::ident),
+    br_named(ast::Name),
 
     /// Fresh bound identifiers created during GLB computations.
     br_fresh(uint),
@@ -2714,7 +2714,7 @@ impl cmp::TotalOrd for bound_region {
             (&ty::br_anon(ref a1), &ty::br_anon(ref a2)) => a1.cmp(a2),
             (&ty::br_anon(*), _) => cmp::Less,
 
-            (&ty::br_named(ref a1), &ty::br_named(ref a2)) => a1.name.cmp(&a2.name),
+            (&ty::br_named(ref a1), &ty::br_named(ref a2)) => a1.cmp(a2),
             (&ty::br_named(*), _) => cmp::Less,
 
             (&ty::br_cap_avoid(ref a1, @ref b1),

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -115,15 +115,15 @@ pub fn ast_region_to_region<AC:AstConv,RS:region_scope + Clone + 'static>(
         &None => {
             (default_span, rscope.anon_region(default_span))
         }
-        &Some(ref lifetime) if lifetime.ident == special_idents::statik => {
+        &Some(ref lifetime) if lifetime.name == special_idents::statik.name => {
             (lifetime.span, Ok(ty::re_static))
         }
-        &Some(ref lifetime) if lifetime.ident == special_idents::self_ => {
+        &Some(ref lifetime) if lifetime.name == special_idents::self_.name => {
             (lifetime.span, rscope.self_region(lifetime.span))
         }
         &Some(ref lifetime) => {
             (lifetime.span, rscope.named_region(lifetime.span,
-                                                lifetime.ident))
+                                                lifetime.name))
         }
     };
 
@@ -539,7 +539,7 @@ pub fn ty_of_arg<AC:AstConv,
 
 pub fn bound_lifetimes<AC:AstConv>(
     this: &AC,
-    ast_lifetimes: &OptVec<ast::Lifetime>) -> OptVec<ast::ident>
+    ast_lifetimes: &OptVec<ast::Lifetime>) -> OptVec<ast::Name>
 {
     /*!
      *
@@ -555,13 +555,13 @@ pub fn bound_lifetimes<AC:AstConv>(
     let special_idents = [special_idents::statik, special_idents::self_];
     let mut bound_lifetime_names = opt_vec::Empty;
     ast_lifetimes.map_to_vec(|ast_lifetime| {
-        if special_idents.iter().any(|&i| i == ast_lifetime.ident) {
+        if special_idents.iter().any(|&i| i.name == ast_lifetime.name) {
             this.tcx().sess.span_err(
                 ast_lifetime.span,
                 fmt!("illegal lifetime parameter name: `%s`",
                      lifetime_to_str(ast_lifetime, this.tcx().sess.intr())));
         } else {
-            bound_lifetime_names.push(ast_lifetime.ident);
+            bound_lifetime_names.push(ast_lifetime.name);
         }
     });
     bound_lifetime_names

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -680,7 +680,7 @@ impl FnCtxt {
         match in_scope_regions.find(br) {
             Some(r) => result::Ok(r),
             None => {
-                let blk_br = ty::br_named(special_idents::blk);
+                let blk_br = ty::br_named(special_idents::blk.name);
                 if br == blk_br {
                     result::Ok(self.block_region())
                 } else {
@@ -709,7 +709,7 @@ impl region_scope for FnCtxt {
     }
     fn named_region(&self,
                     span: span,
-                    id: ast::ident) -> Result<ty::Region, RegionError> {
+                    id: ast::Name) -> Result<ty::Region, RegionError> {
         self.search_in_scope_regions(span, ty::br_named(id))
     }
 }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -157,7 +157,7 @@ pub fn bound_region_to_str(cx: ctxt,
     if cx.sess.verbose() { return fmt!("%s%?%s", prefix, br, space_str); }
 
     match br {
-      br_named(id)         => fmt!("%s'%s%s", prefix, cx.sess.str_of(id), space_str),
+      br_named(id)         => fmt!("%s'%s%s", prefix, token::interner_get(id), space_str),
       br_self              => fmt!("%s'self%s", prefix, space_str),
       br_anon(_)           => prefix.to_str(),
       br_fresh(_)          => prefix.to_str(),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -96,7 +96,7 @@ pub type fn_ident = Option<ident>;
 pub struct Lifetime {
     id: NodeId,
     span: span,
-    ident: ident
+    name: Name
 }
 
 // a "Path" is essentially Rust's notion of a name;

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -69,7 +69,7 @@ pub trait AstBuilder {
 
     fn trait_ref(&self, path: ast::Path) -> ast::trait_ref;
     fn typarambound(&self, path: ast::Path) -> ast::TyParamBound;
-    fn lifetime(&self, span: span, ident: ast::ident) -> ast::Lifetime;
+    fn lifetime(&self, span: span, name: ast::Name) -> ast::Lifetime;
 
     // statements
     fn stmt_expr(&self, expr: @ast::expr) -> @ast::stmt;
@@ -365,8 +365,8 @@ impl AstBuilder for @ExtCtxt {
         ast::TraitTyParamBound(self.trait_ref(path))
     }
 
-    fn lifetime(&self, span: span, ident: ast::ident) -> ast::Lifetime {
-        ast::Lifetime { id: self.next_id(), span: span, ident: ident }
+    fn lifetime(&self, span: span, name: ast::Name) -> ast::Lifetime {
+        ast::Lifetime { id: self.next_id(), span: span, name: name }
     }
 
     fn stmt_expr(&self, expr: @ast::expr) -> @ast::stmt {

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -19,6 +19,7 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use codemap::{span,respan};
 use opt_vec;
+use parse::token;
 
 /// The types of pointers
 pub enum PtrTy<'self> {
@@ -111,7 +112,7 @@ pub fn nil_ty() -> Ty<'static> {
 
 fn mk_lifetime(cx: @ExtCtxt, span: span, lt: &Option<&str>) -> Option<ast::Lifetime> {
     match *lt {
-        Some(ref s) => Some(cx.lifetime(span, cx.ident_of(*s))),
+        Some(ref s) => Some(cx.lifetime(span, token::intern(*s))),
         None => None
     }
 }
@@ -221,7 +222,7 @@ impl<'self> LifetimeBounds<'self> {
                        self_generics: &Generics)
                        -> Generics {
         let lifetimes = do self.lifetimes.map |lt| {
-            cx.lifetime(span, cx.ident_of(*lt))
+            cx.lifetime(span, token::intern(*lt))
         };
         let ty_params = do self.bounds.map |t| {
             match t {
@@ -249,7 +250,7 @@ pub fn get_explicit_self(cx: @ExtCtxt, span: span, self_ptr: &Option<PtrTy>)
                     Send => ast::sty_uniq,
                     Managed(mutbl) => ast::sty_box(mutbl),
                     Borrowed(ref lt, mutbl) => {
-                        let lt = lt.map(|s| cx.lifetime(span, cx.ident_of(*s)));
+                        let lt = lt.map(|s| cx.lifetime(span, token::intern(*s)));
                         ast::sty_region(lt, mutbl)
                     }
                 });

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -531,10 +531,11 @@ fn mk_token(cx: @ExtCtxt, sp: span, tok: &token::Token) -> @ast::expr {
                                         cx.expr_bool(sp, b)]);
         }
 
-        LIFETIME(ident) => {
+        LIFETIME(name) => {
+            let e_name = cx.expr_lit(sp, ast::lit_uint(name as u64, ast::ty_u64));
             return cx.expr_call_ident(sp,
                                       id_ext("LIFETIME"),
-                                      ~[mk_ident(cx, sp, ident)]);
+                                      ~[e_name]);
         }
 
         DOC_COMMENT(ident) => {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -183,7 +183,7 @@ pub fn fold_lifetime(l: &Lifetime,
                      fld: @ast_fold) -> Lifetime {
     Lifetime {id: fld.new_id(l.id),
               span: fld.new_span(l.span),
-              ident: l.ident}
+              name: l.name}
 }
 
 pub fn fold_lifetimes(lts: &OptVec<Lifetime>,

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -674,7 +674,7 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
                 bump(rdr);
             }
             return do with_str_from(rdr, start) |lifetime_name| {
-                token::LIFETIME(str_to_ident(lifetime_name))
+                token::LIFETIME(token::intern(lifetime_name))
             }
         }
 
@@ -905,8 +905,8 @@ mod test {
         let env = setup(@"'abc");
         let TokenAndSpan {tok, sp: _} =
             env.string_reader.next_token();
-        let id = token::str_to_ident("abc");
-        assert_eq!(tok, token::LIFETIME(id));
+        let name = token::intern("abc");
+        assert_eq!(tok, token::LIFETIME(name));
     }
 
     #[test] fn line_doc_comments() {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -667,9 +667,9 @@ impl Parser {
         }
     }
 
-    pub fn get_lifetime(&self, tok: &token::Token) -> ast::ident {
+    pub fn get_lifetime(&self, tok: &token::Token) -> ast::Name {
         match *tok {
-            token::LIFETIME(ref ident) => *ident,
+            token::LIFETIME(ref name) => *name,
             _ => self.bug("not a lifetime"),
         }
     }
@@ -1330,7 +1330,7 @@ impl Parser {
                         Some(ast::Lifetime {
                             id: self.get_id(),
                             span: *span,
-                            ident: sid
+                            name: sid.name
                         })
                     }
                     _ => {
@@ -1420,7 +1420,7 @@ impl Parser {
                 return ast::Lifetime {
                     id: self.get_id(),
                     span: *span,
-                    ident: i
+                    name: i
                 };
             }
 
@@ -1433,7 +1433,7 @@ impl Parser {
                 return ast::Lifetime {
                     id: self.get_id(),
                     span: *span,
-                    ident: i
+                    name: i.name
                 };
             }
 
@@ -1635,7 +1635,7 @@ impl Parser {
             self.bump();
             self.expect(&token::COLON);
             self.expect_keyword(keywords::Loop);
-            return self.parse_loop_expr(Some(lifetime));
+            return self.parse_loop_expr(Some(ast::new_ident(lifetime)));
         } else if self.eat_keyword(keywords::Loop) {
             return self.parse_loop_expr(None);
         } else if self.eat_keyword(keywords::Match) {
@@ -1701,7 +1701,7 @@ impl Parser {
             if self.token_is_lifetime(&*self.token) {
                 let lifetime = self.get_lifetime(&*self.token);
                 self.bump();
-                ex = expr_break(Some(lifetime));
+                ex = expr_break(Some(ast::new_ident(lifetime)));
             } else {
                 ex = expr_break(None);
             }
@@ -2441,7 +2441,7 @@ impl Parser {
             let ex = if self.token_is_lifetime(&*self.token) {
                 let lifetime = self.get_lifetime(&*self.token);
                 self.bump();
-                expr_again(Some(lifetime))
+                expr_again(Some(ast::new_ident(lifetime)))
             } else {
                 expr_again(None)
             };
@@ -3298,7 +3298,7 @@ impl Parser {
         loop {
             match *self.token {
                 token::LIFETIME(lifetime) => {
-                    if "static" == self.id_to_str(lifetime) {
+                    if "static" == token::interner_get(lifetime) {
                         result.push(RegionTyParamBound);
                     } else {
                         self.span_err(*self.span,

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -86,7 +86,7 @@ pub enum Token {
     // whitespace in between.
     IDENT(ast::ident, bool),
     UNDERSCORE,
-    LIFETIME(ast::ident),
+    LIFETIME(ast::Name),
 
     /* For interpolation */
     INTERPOLATED(nonterminal),
@@ -196,7 +196,7 @@ pub fn to_str(input: @ident_interner, t: &Token) -> ~str {
 
       /* Name components */
       IDENT(s, _) => input.get(s.name).to_owned(),
-      LIFETIME(s) => fmt!("'%s", input.get(s.name)),
+      LIFETIME(s) => fmt!("'%s", input.get(s)),
       UNDERSCORE => ~"_",
 
       /* Other */

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1767,7 +1767,7 @@ pub fn print_bounds(s: @ps, bounds: &OptVec<ast::TyParamBound>,
 
 pub fn print_lifetime(s: @ps, lifetime: &ast::Lifetime) {
     word(s.s, "'");
-    print_ident(s, lifetime.ident);
+    word(s.s, token::interner_get(lifetime.name));
 }
 
 pub fn print_generics(s: @ps, generics: &ast::Generics) {


### PR DESCRIPTION
Fixes #7743. To make the compiler happy, I rewrite a use case of the "quote_item" macro. After we get a compiler snapshot that includes this change, the manual ast construction can be reverted back to using "quote_item".
