### PR TITLE
rc: Use ~T for allocation

### DIFF
--- a/src/test/compile-fail/rcmut-not-const-and-not-owned.rs
+++ b/src/test/compile-fail/rcmut-not-const-and-not-owned.rs
@@ -14,7 +14,7 @@ fn o<T: Send>(_: &T) {}
 fn c<T: Freeze>(_: &T) {}
 
 fn main() {
-    let x = extra::rc::rc_mut_from_owned(0);
+    let x = extra::rc::RcMut::from_owned(0);
     o(&x); //~ ERROR instantiating a type parameter with an incompatible type `extra::rc::RcMut<int>`, which does not fulfill `Send`
     c(&x); //~ ERROR instantiating a type parameter with an incompatible type `extra::rc::RcMut<int>`, which does not fulfill `Freeze`
 }


### PR DESCRIPTION
Simplify Rc<T>/RcMut<T> by using ~T when allocating a reference counted
box.

cc @thestinger
