### PR TITLE
Check for comparisons to NaN in patterns

### DIFF
--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -119,7 +119,7 @@ pub fn check_arms(cx: &MatchCheckCtxt, arms: &[arm]) {
             for walk_pat(*pat) |p| {
                 if pat_matches_nan(p) {
                     cx.tcx.sess.span_warn(p.span, "unmatchable NaN in pattern, \
-                                                   use is_NaN() in a guard instead");
+                                                   use the is_NaN method in a guard instead");
                 }
             }
 

--- a/src/test/compile-fail/issue-6804.rs
+++ b/src/test/compile-fail/issue-6804.rs
@@ -8,12 +8,12 @@ fn main() {
         NaN => {},
         _ => {},
     };
-    //~^^^ WARNING unmatchable NaN in pattern, use is_NaN() in a guard instead
+    //~^^^ WARNING unmatchable NaN in pattern, use the is_NaN method in a guard instead
     match [x, 1.0] {
         [NaN, _] => {},
         _ => {},
     };
-    //~^^^ WARNING unmatchable NaN in pattern, use is_NaN() in a guard instead
+    //~^^^ WARNING unmatchable NaN in pattern, use the is_NaN method in a guard instead
 }
 
 // At least one error is needed so that compilation fails

--- a/src/test/compile-fail/issue-6804.rs
+++ b/src/test/compile-fail/issue-6804.rs
@@ -9,6 +9,11 @@ fn main() {
         _ => {},
     };
     //~^^^ WARNING unmatchable NaN in pattern, use is_NaN() in a guard instead
+    match [x, 1.0] {
+        [NaN, _] => {},
+        _ => {},
+    };
+    //~^^^ WARNING unmatchable NaN in pattern, use is_NaN() in a guard instead
 }
 
 // At least one error is needed so that compilation fails

--- a/src/test/compile-fail/issue-6804.rs
+++ b/src/test/compile-fail/issue-6804.rs
@@ -1,0 +1,16 @@
+// Matching against NaN should result in a warning
+
+use std::float::NaN;
+
+fn main() {
+    let x = NaN;
+    match x {
+        NaN => {},
+        _ => {},
+    };
+    //~^^^ WARNING unmatchable NaN in pattern, use is_NaN() in a guard instead
+}
+
+// At least one error is needed so that compilation fails
+#[static_assert]
+static b: bool = false; //~ ERROR static assertion failed


### PR DESCRIPTION
Hi,

As noted in #6804, a pattern that contains `NaN` will never match because `NaN != NaN`. This adds a warning for such a case. The first commit handles the basic case and the second one generalizes it to more complex patterns using `walk_pat`.
