### PR TITLE
Added default impls for container methods

### DIFF
--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -703,8 +703,8 @@ impl cmp::Eq for BitvSet {
 }
 
 impl Container for BitvSet {
+    #[inline]
     fn len(&self) -> uint { self.size }
-    fn is_empty(&self) -> bool { self.size == 0 }
 }
 
 impl Mutable for BitvSet {

--- a/src/libextra/priority_queue.rs
+++ b/src/libextra/priority_queue.rs
@@ -27,9 +27,6 @@ pub struct PriorityQueue<T> {
 impl<T:Ord> Container for PriorityQueue<T> {
     /// Returns the length of the queue
     fn len(&self) -> uint { self.data.len() }
-
-    /// Returns true if a queue contains no elements
-    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl<T:Ord> Mutable for PriorityQueue<T> {

--- a/src/libextra/ringbuf.rs
+++ b/src/libextra/ringbuf.rs
@@ -34,9 +34,6 @@ pub struct RingBuf<T> {
 impl<T> Container for RingBuf<T> {
     /// Return the number of elements in the RingBuf
     fn len(&self) -> uint { self.nelts }
-
-    /// Return true if the RingBufcontains no elements
-    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl<T> Mutable for RingBuf<T> {

--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -37,9 +37,6 @@ impl<V> Container for SmallIntMap<V> {
         }
         sz
     }
-
-    /// Return true if the map contains no elements
-    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl<V> Mutable for SmallIntMap<V> {

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -135,19 +135,6 @@ impl<K: TotalOrd, V> MutableMap<K, V> for TreeMap<K, V> {
         find_mut(&mut self.root, key)
     }
 
-    /// Insert a key-value pair into the map. An existing value for a
-    /// key is replaced by the new value. Return true if the key did
-    /// not already exist in the map.
-    fn insert(&mut self, key: K, value: V) -> bool {
-        self.swap(key, value).is_none()
-    }
-
-    /// Remove a key-value pair from the map. Return true if the key
-    /// was present in the map, otherwise false.
-    fn remove(&mut self, key: &K) -> bool {
-        self.pop(key).is_some()
-    }
-
     /// Insert a key-value pair from the map. If the key already had a value
     /// present in the map, that value is returned. Otherwise None is returned.
     fn swap(&mut self, key: K, value: V) -> Option<V> {

--- a/src/libstd/container.rs
+++ b/src/libstd/container.rs
@@ -19,7 +19,10 @@ pub trait Container {
     fn len(&self) -> uint;
 
     /// Return true if the container contains no elements
-    fn is_empty(&self) -> bool;
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// A trait to represent mutable containers
@@ -43,11 +46,17 @@ pub trait MutableMap<K, V>: Map<K, V> + Mutable {
     /// Insert a key-value pair into the map. An existing value for a
     /// key is replaced by the new value. Return true if the key did
     /// not already exist in the map.
-    fn insert(&mut self, key: K, value: V) -> bool;
+    #[inline]
+    fn insert(&mut self, key: K, value: V) -> bool {
+        self.swap(key, value).is_none()
+    }
 
     /// Remove a key-value pair from the map. Return true if the key
     /// was present in the map, otherwise false.
-    fn remove(&mut self, key: &K) -> bool;
+    #[inline]
+    fn remove(&mut self, key: &K) -> bool {
+        self.pop(key).is_some()
+    }
 
     /// Insert a key-value pair from the map. If the key already had a value
     /// present in the map, that value is returned. Otherwise None is returned.

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -282,9 +282,6 @@ impl<K:Hash + Eq,V> HashMap<K, V> {
 impl<K:Hash + Eq,V> Container for HashMap<K, V> {
     /// Return the number of elements in the map
     fn len(&self) -> uint { self.size }
-
-    /// Return true if the map contains no elements
-    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl<K:Hash + Eq,V> Mutable for HashMap<K, V> {
@@ -323,19 +320,6 @@ impl<K:Hash + Eq,V> MutableMap<K, V> for HashMap<K, V> {
             TableFull | FoundHole(_) => return None
         };
         Some(self.mut_value_for_bucket(idx))
-    }
-
-    /// Insert a key-value pair into the map. An existing value for a
-    /// key is replaced by the new value. Return true if the key did
-    /// not already exist in the map.
-    fn insert(&mut self, k: K, v: V) -> bool {
-        self.swap(k, v).is_none()
-    }
-
-    /// Remove a key-value pair from the map. Return true if the key
-    /// was present in the map, otherwise false.
-    fn remove(&mut self, k: &K) -> bool {
-        self.pop(k).is_some()
     }
 
     /// Insert a key-value pair from the map. If the key already had a value
@@ -661,9 +645,6 @@ impl<T:Hash + Eq> Eq for HashSet<T> {
 impl<T:Hash + Eq> Container for HashSet<T> {
     /// Return the number of elements in the set
     fn len(&self) -> uint { self.map.len() }
-
-    /// Return true if the set contains no elements
-    fn is_empty(&self) -> bool { self.map.is_empty() }
 }
 
 impl<T:Hash + Eq> Mutable for HashSet<T> {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1097,24 +1097,16 @@ impl<'self> Container for &'self str {
     fn len(&self) -> uint {
         do self.as_imm_buf |_p, n| { n - 1u }
     }
-    #[inline]
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
 }
 
 impl Container for ~str {
     #[inline]
     fn len(&self) -> uint { self.as_slice().len() }
-    #[inline]
-    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl Container for @str {
     #[inline]
     fn len(&self) -> uint { self.as_slice().len() }
-    #[inline]
-    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl Mutable for ~str {

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -36,10 +36,6 @@ impl<T> Container for TrieMap<T> {
     /// Return the number of elements in the map
     #[inline]
     fn len(&self) -> uint { self.length }
-
-    /// Return true if the map contains no elements
-    #[inline]
-    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl<T> Mutable for TrieMap<T> {
@@ -85,21 +81,6 @@ impl<T> MutableMap<uint, T> for TrieMap<T> {
     #[inline]
     fn find_mut<'a>(&'a mut self, key: &uint) -> Option<&'a mut T> {
         find_mut(&mut self.root.children[chunk(*key, 0)], *key, 1)
-    }
-
-    /// Insert a key-value pair into the map. An existing value for a
-    /// key is replaced by the new value. Return true if the key did
-    /// not already exist in the map.
-    #[inline]
-    fn insert(&mut self, key: uint, value: T) -> bool {
-        self.swap(key, value).is_none()
-    }
-
-    /// Remove a key-value pair from the map. Return true if the key
-    /// was present in the map, otherwise false.
-    #[inline]
-    fn remove(&mut self, key: &uint) -> bool {
-        self.pop(key).is_some()
     }
 
     /// Insert a key-value pair from the map. If the key already had a value
@@ -194,10 +175,6 @@ impl Container for TrieSet {
     /// Return the number of elements in the set
     #[inline]
     fn len(&self) -> uint { self.map.len() }
-
-    /// Return true if the set contains no elements
-    #[inline]
-    fn is_empty(&self) -> bool { self.map.is_empty() }
 }
 
 impl Mutable for TrieSet {


### PR DESCRIPTION
A couple of implementations of Container::is_empty weren't exactly
self.len() == 0 so I left them alone (e.g. Treemap).
