### PR TITLE
Deny all warnings by default in doc tests

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1494,7 +1494,7 @@ mod m1 {
 This example shows how one can use `allow` and `warn` to toggle
 a particular check on and off.
 
-~~~
+~~~{.xfail-test}
 #[warn(missing_doc)]
 mod m2{
     #[allow(missing_doc)]

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1154,6 +1154,7 @@ let mut x = 5;
     let y = &x; // x is now frozen, it cannot be modified
 }
 // x is now unfrozen again
+# x = 3;
 ~~~~
 
 Mutable managed boxes handle freezing dynamically when any of their contents

--- a/src/etc/extract-tests.py
+++ b/src/etc/extract-tests.py
@@ -59,14 +59,10 @@ while cur < len(lines):
                 block = "fn main() {\n" + block + "\n}\n"
             if not re.search(r"\bextern mod extra\b", block):
                 block = "extern mod extra;\n" + block
-            block = """#[ forbid(ctypes) ];
-#[ forbid(path_statement) ];
-#[ forbid(type_limits) ];
-#[ forbid(unrecognized_lint) ];
-#[ forbid(unused_imports) ];
-#[ forbid(while_true) ];
-
-#[ warn(non_camel_case_types) ];\n
+            block = """#[ deny(warnings) ];
+#[ allow(unused_variable) ];\n
+#[ allow(dead_assignment) ];\n
+#[ allow(unused_mut) ];\n
 """ + block
             if xfail:
                 block = "// xfail-test\n" + block


### PR DESCRIPTION
Allow some common ones that are good for examples, however.

Closes #3636
