### PR TITLE
std: str conversion fns should take `*const u8`

### DIFF
--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -777,18 +777,18 @@ pub mod raw {
     use vec::MutableVector;
 
     /// Create a Rust string from a null-terminated *u8 buffer
-    pub unsafe fn from_buf(buf: *u8) -> ~str {
+    pub unsafe fn from_buf(buf: *const u8) -> ~str {
         let mut curr = buf;
         let mut i = 0u;
         while *curr != 0u8 {
             i += 1u;
-            curr = ptr::offset(buf, i);
+            curr = ptr::const_offset(buf, i);
         }
         return from_buf_len(buf, i);
     }
 
     /// Create a Rust string from a *u8 buffer of the given length
-    pub unsafe fn from_buf_len(buf: *u8, len: uint) -> ~str {
+    pub unsafe fn from_buf_len(buf: *const u8, len: uint) -> ~str {
         let mut v: ~[u8] = vec::with_capacity(len + 1);
         v.as_mut_buf(|vbuf, _len| {
             ptr::copy_memory(vbuf, buf as *u8, len)
@@ -801,12 +801,12 @@ pub mod raw {
     }
 
     /// Create a Rust string from a null-terminated C string
-    pub unsafe fn from_c_str(c_str: *libc::c_char) -> ~str {
+    pub unsafe fn from_c_str(c_str: *const libc::c_char) -> ~str {
         from_buf(::cast::transmute(c_str))
     }
 
     /// Create a Rust string from a `*c_char` buffer of the given length
-    pub unsafe fn from_c_str_len(c_str: *libc::c_char, len: uint) -> ~str {
+    pub unsafe fn from_c_str_len(c_str: *const libc::c_char, len: uint) -> ~str {
         from_buf_len(::cast::transmute(c_str), len)
     }
 


### PR DESCRIPTION
This changes str::raw::from_{buf,buf_len,c_str,c_str_len} to take `*const u8` or `*const libc::c_char`.
