### PR TITLE
Remove unnecessary #[path = "***/mod.rs"] lines.

### DIFF
--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -43,7 +43,6 @@ pub mod doc;
 
 pub mod check_loans;
 
-#[path="gather_loans/mod.rs"]
 pub mod gather_loans;
 
 pub mod move_data;

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -52,7 +52,6 @@ pub mod combine;
 pub mod glb;
 pub mod lattice;
 pub mod lub;
-#[path = "region_inference/mod.rs"]
 pub mod region_inference;
 pub mod resolve;
 pub mod sub;

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -66,11 +66,9 @@ use syntax::print::pprust::*;
 use syntax::{ast, ast_map, abi};
 use syntax::opt_vec;
 
-#[path = "check/mod.rs"]
 pub mod check;
 pub mod rscope;
 pub mod astconv;
-#[path = "infer/mod.rs"]
 pub mod infer;
 pub mod collect;
 pub mod coherence;

--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -41,18 +41,15 @@ use syntax::codemap;
 use syntax::diagnostic;
 
 pub mod middle {
-    #[path = "trans/mod.rs"]
     pub mod trans;
     pub mod ty;
     pub mod subst;
     pub mod resolve;
-    #[path = "typeck/mod.rs"]
     pub mod typeck;
     pub mod check_loop;
     pub mod check_match;
     pub mod check_const;
     pub mod lint;
-    #[path = "borrowck/mod.rs"]
     pub mod borrowck;
     pub mod dataflow;
     pub mod mem_categorization;
@@ -70,7 +67,6 @@ pub mod middle {
     pub mod effect;
     pub mod reachable;
     pub mod graph;
-    #[path = "cfg/mod.rs"]
     pub mod cfg;
 }
 
@@ -93,10 +89,8 @@ pub mod back {
     pub mod passes;
 }
 
-#[path = "metadata/mod.rs"]
 pub mod metadata;
 
-#[path = "driver/mod.rs"]
 pub mod driver;
 
 pub mod util {

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -90,14 +90,12 @@ mod kill;
 mod sched;
 
 /// Synchronous I/O.
-#[path = "io/mod.rs"]
 pub mod io;
 
 /// The EventLoop and internal synchronous I/O interface.
 mod rtio;
 
 /// libuv and default rtio implementation.
-#[path = "uv/mod.rs"]
 pub mod uv;
 
 /// The Local trait for types that are accessible via thread-local

--- a/src/libstd/std.rs
+++ b/src/libstd/std.rs
@@ -162,7 +162,6 @@ pub mod trie;
 
 /* Tasks and communication */
 
-#[path = "task/mod.rs"]
 pub mod task;
 pub mod comm;
 pub mod pipes;
@@ -190,7 +189,6 @@ pub mod util;
 /* Unsupported interfaces */
 
 // Private APIs
-#[path = "unstable/mod.rs"]
 pub mod unstable;
 
 /* For internal use, not exported */
@@ -202,7 +200,6 @@ mod stackwalk;
 
 // XXX: This shouldn't be pub, and it should be reexported under 'unstable'
 // but name resolution doesn't work without it being pub.
-#[path = "rt/mod.rs"]
 pub mod rt;
 
 // A curious inner-module that's not exported that contains the binding

--- a/src/libsyntax/syntax.rs
+++ b/src/libsyntax/syntax.rs
@@ -45,7 +45,6 @@ pub mod visit;
 pub mod fold;
 
 
-#[path = "parse/mod.rs"]
 pub mod parse;
 
 pub mod print {
@@ -60,7 +59,6 @@ pub mod ext {
 
     pub mod quote;
 
-    #[path = "deriving/mod.rs"]
     pub mod deriving;
 
     pub mod build;
@@ -80,7 +78,6 @@ pub mod ext {
     pub mod auto_encode;
     pub mod source_util;
 
-    #[path = "pipes/mod.rs"]
     pub mod pipes;
 
     pub mod trace_macros;


### PR DESCRIPTION
A cleanup suggested on #7922.
