### PR TITLE
librustc: Stop trying to make invalid slice with vec in statics.

### DIFF
--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -211,11 +211,16 @@ pub fn const_expr(cx: @mut CrateContext, e: @ast::expr) -> ValueRef {
                         }
                         ty::AutoBorrowVec(ty::re_static, m) => {
                             assert!(m != ast::m_mutbl);
-                            let size = machine::llsize_of(cx,
-                                                          val_ty(llconst));
                             assert_eq!(abi::slice_elt_base, 0);
                             assert_eq!(abi::slice_elt_len, 1);
-                            llconst = C_struct([llptr, size]);
+
+                            match ty::get(ty).sty {
+                                ty::ty_evec(_, ty::vstore_fixed(*)) => {
+                                    let size = machine::llsize_of(cx, val_ty(llconst));
+                                    llconst = C_struct([llptr, size]);
+                                }
+                                _ => {}
+                            }
                         }
                         _ => {
                             cx.sess.span_bug(e.span,

--- a/src/test/run-pass/static-vec-autoref.rs
+++ b/src/test/run-pass/static-vec-autoref.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct T(&'static [int]);
+
+static A: T = T(&'static [5, 4, 3]);
+static B: T = T(&[5, 4, 3]);
+static C: T = T([5, 4, 3]);
+
+pub fn main() {
+    assert_eq!(A[0], 5);
+    assert_eq!(B[1], 4);
+    assert_eq!(C[2], 3);
+}


### PR DESCRIPTION
Fixes #5917 by not trying to treat `&[T]` as a slice since it already is one.
