### PR TITLE
Remove dummy type parameters from iterator adaptors

### DIFF
--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -356,7 +356,7 @@ impl<T> DList<T> {
 
     /// Provide a reverse iterator
     #[inline]
-    pub fn rev_iter<'a>(&'a self) -> InvertIterator<&'a T, DListIterator<'a, T>> {
+    pub fn rev_iter<'a>(&'a self) -> InvertIterator<DListIterator<'a, T>> {
         self.iter().invert()
     }
 
@@ -376,8 +376,7 @@ impl<T> DList<T> {
     }
     /// Provide a reverse iterator with mutable references
     #[inline]
-    pub fn mut_rev_iter<'a>(&'a mut self) -> InvertIterator<&'a mut T,
-                                                MutDListIterator<'a, T>> {
+    pub fn mut_rev_iter<'a>(&'a mut self) -> InvertIterator<MutDListIterator<'a, T>> {
         self.mut_iter().invert()
     }
 
@@ -390,7 +389,7 @@ impl<T> DList<T> {
 
     /// Consume the list into an iterator yielding elements by value, in reverse
     #[inline]
-    pub fn consume_rev_iter(self) -> InvertIterator<T, ConsumeIterator<T>> {
+    pub fn consume_rev_iter(self) -> InvertIterator<ConsumeIterator<T>> {
         self.consume_iter().invert()
     }
 }

--- a/src/libextra/ringbuf.rs
+++ b/src/libextra/ringbuf.rs
@@ -184,7 +184,7 @@ impl<T> RingBuf<T> {
     }
 
     /// Back-to-front iterator.
-    pub fn rev_iter<'a>(&'a self) -> InvertIterator<&'a T, RingBufIterator<'a, T>> {
+    pub fn rev_iter<'a>(&'a self) -> InvertIterator<RingBufIterator<'a, T>> {
         self.iter().invert()
     }
 
@@ -195,7 +195,7 @@ impl<T> RingBuf<T> {
     }
 
     /// Back-to-front iterator which returns mutable values.
-    pub fn mut_rev_iter<'a>(&'a mut self) -> InvertIterator<&'a mut T, RingBufMutIterator<'a, T>> {
+    pub fn mut_rev_iter<'a>(&'a mut self) -> InvertIterator<RingBufMutIterator<'a, T>> {
         self.mut_iter().invert()
     }
 }

--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -207,7 +207,7 @@ impl<V> SmallIntMap<V> {
     /// Empties the hash map, moving all values into the specified closure
     pub fn consume(&mut self)
         -> FilterMapIterator<(uint, Option<V>), (uint, V),
-                EnumerateIterator<Option<V>, VecConsumeIterator<Option<V>>>>
+                EnumerateIterator<VecConsumeIterator<Option<V>>>>
     {
         let values = replace(&mut self.v, ~[]);
         values.consume_iter().enumerate().filter_map(|(i, v)| {
@@ -293,8 +293,7 @@ pub struct SmallIntMapIterator<'self, T> {
 
 iterator!(impl SmallIntMapIterator -> (uint, &'self T), get_ref)
 double_ended_iterator!(impl SmallIntMapIterator -> (uint, &'self T), get_ref)
-pub type SmallIntMapRevIterator<'self, T> = InvertIterator<(uint, &'self T),
-                                                           SmallIntMapIterator<'self, T>>;
+pub type SmallIntMapRevIterator<'self, T> = InvertIterator<SmallIntMapIterator<'self, T>>;
 
 pub struct SmallIntMapMutIterator<'self, T> {
     priv front: uint,
@@ -304,8 +303,7 @@ pub struct SmallIntMapMutIterator<'self, T> {
 
 iterator!(impl SmallIntMapMutIterator -> (uint, &'self mut T), get_mut_ref)
 double_ended_iterator!(impl SmallIntMapMutIterator -> (uint, &'self mut T), get_mut_ref)
-pub type SmallIntMapMutRevIterator<'self, T> = InvertIterator<(uint, &'self mut T),
-                                                              SmallIntMapMutIterator<'self, T>>;
+pub type SmallIntMapMutRevIterator<'self, T> = InvertIterator<SmallIntMapMutIterator<'self, T>>;
 
 #[cfg(test)]
 mod test_map {

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -770,7 +770,7 @@ impl<T:Hash + Eq> HashSet<T> {
 
     /// Visit the values representing the symmetric difference
     pub fn symmetric_difference_iter<'a>(&'a self, other: &'a HashSet<T>)
-        -> ChainIterator<&'a T, SetAlgebraIter<'a, T>, SetAlgebraIter<'a, T>> {
+        -> ChainIterator<SetAlgebraIter<'a, T>, SetAlgebraIter<'a, T>> {
         self.difference_iter(other).chain_(other.difference_iter(self))
     }
 
@@ -783,7 +783,7 @@ impl<T:Hash + Eq> HashSet<T> {
 
     /// Visit the values representing the union
     pub fn union_iter<'a>(&'a self, other: &'a HashSet<T>)
-        -> ChainIterator<&'a T, HashSetIterator<'a, T>, SetAlgebraIter<'a, T>> {
+        -> ChainIterator<HashSetIterator<'a, T>, SetAlgebraIter<'a, T>> {
         self.iter().chain_(other.difference_iter(self))
     }
 

--- a/src/libstd/iterator.rs
+++ b/src/libstd/iterator.rs
@@ -64,37 +64,36 @@ pub trait RandomAccessIterator<A> {
 /// Iterator adaptors provided for every `DoubleEndedIterator` implementation.
 ///
 /// In the future these will be default methods instead of a utility trait.
-pub trait DoubleEndedIteratorUtil<A> {
+pub trait DoubleEndedIteratorUtil {
     /// Flip the direction of the iterator
-    fn invert(self) -> InvertIterator<A, Self>;
+    fn invert(self) -> InvertIterator<Self>;
 }
 
 /// Iterator adaptors provided for every `DoubleEndedIterator` implementation.
 ///
 /// In the future these will be default methods instead of a utility trait.
-impl<A, T: DoubleEndedIterator<A>> DoubleEndedIteratorUtil<A> for T {
+impl<A, T: DoubleEndedIterator<A>> DoubleEndedIteratorUtil for T {
     /// Flip the direction of the iterator
     #[inline]
-    fn invert(self) -> InvertIterator<A, T> {
+    fn invert(self) -> InvertIterator<T> {
         InvertIterator{iter: self}
     }
 }
 
 /// An double-ended iterator with the direction inverted
-// FIXME #6967: Dummy A parameter to get around type inference bug
 #[deriving(Clone)]
-pub struct InvertIterator<A, T> {
+pub struct InvertIterator<T> {
     priv iter: T
 }
 
-impl<A, T: DoubleEndedIterator<A>> Iterator<A> for InvertIterator<A, T> {
+impl<A, T: DoubleEndedIterator<A>> Iterator<A> for InvertIterator<T> {
     #[inline]
     fn next(&mut self) -> Option<A> { self.iter.next_back() }
     #[inline]
     fn size_hint(&self) -> (uint, Option<uint>) { self.iter.size_hint() }
 }
 
-impl<A, T: DoubleEndedIterator<A>> DoubleEndedIterator<A> for InvertIterator<A, T> {
+impl<A, T: DoubleEndedIterator<A>> DoubleEndedIterator<A> for InvertIterator<T> {
     #[inline]
     fn next_back(&mut self) -> Option<A> { self.iter.next() }
 }
@@ -118,7 +117,7 @@ pub trait IteratorUtil<A> {
     /// assert_eq!(it.next().get(), &1);
     /// assert!(it.next().is_none());
     /// ~~~
-    fn chain_<U: Iterator<A>>(self, other: U) -> ChainIterator<A, Self, U>;
+    fn chain_<U: Iterator<A>>(self, other: U) -> ChainIterator<Self, U>;
 
     /// Creates an iterator which iterates over both this and the specified
     /// iterators simultaneously, yielding the two elements as pairs. When
@@ -134,7 +133,7 @@ pub trait IteratorUtil<A> {
     /// assert_eq!(it.next().get(), (&0, &1));
     /// assert!(it.next().is_none());
     /// ~~~
-    fn zip<B, U: Iterator<B>>(self, other: U) -> ZipIterator<A, Self, B, U>;
+    fn zip<B, U: Iterator<B>>(self, other: U) -> ZipIterator<Self, U>;
 
     // FIXME: #5898: should be called map
     /// Creates a new iterator which will apply the specified function to each
@@ -191,7 +190,7 @@ pub trait IteratorUtil<A> {
     /// assert_eq!(it.next().get(), (1, &200));
     /// assert!(it.next().is_none());
     /// ~~~
-    fn enumerate(self) -> EnumerateIterator<A, Self>;
+    fn enumerate(self) -> EnumerateIterator<Self>;
 
     /// Creates an iterator which invokes the predicate on elements until it
     /// returns false. Once the predicate returns false, all further elements are
@@ -236,7 +235,7 @@ pub trait IteratorUtil<A> {
     /// assert_eq!(it.next().get(), &5);
     /// assert!(it.next().is_none());
     /// ~~~
-    fn skip(self, n: uint) -> SkipIterator<A, Self>;
+    fn skip(self, n: uint) -> SkipIterator<Self>;
 
     // FIXME: #5898: should be called take
     /// Creates an iterator which yields the first `n` elements of this
@@ -252,7 +251,7 @@ pub trait IteratorUtil<A> {
     /// assert_eq!(it.next().get(), &3);
     /// assert!(it.next().is_none());
     /// ~~~
-    fn take_(self, n: uint) -> TakeIterator<A, Self>;
+    fn take_(self, n: uint) -> TakeIterator<Self>;
 
     /// Creates a new iterator which behaves in a similar fashion to foldl.
     /// There is a state which is passed between each iteration and can be
@@ -295,7 +294,7 @@ pub trait IteratorUtil<A> {
     /// ~~~
     // FIXME: #5898: should be called `flat_map`
     fn flat_map_<'r, B, U: Iterator<B>>(self, f: &'r fn(A) -> U)
-        -> FlatMapIterator<'r, A, B, Self, U>;
+        -> FlatMapIterator<'r, A, Self, U>;
 
     /// Creates an iterator that calls a function with a reference to each
     /// element before yielding it. This is often useful for debugging an
@@ -462,12 +461,12 @@ pub trait IteratorUtil<A> {
 /// In the future these will be default methods instead of a utility trait.
 impl<A, T: Iterator<A>> IteratorUtil<A> for T {
     #[inline]
-    fn chain_<U: Iterator<A>>(self, other: U) -> ChainIterator<A, T, U> {
+    fn chain_<U: Iterator<A>>(self, other: U) -> ChainIterator<T, U> {
         ChainIterator{a: self, b: other, flag: false}
     }
 
     #[inline]
-    fn zip<B, U: Iterator<B>>(self, other: U) -> ZipIterator<A, T, B, U> {
+    fn zip<B, U: Iterator<B>>(self, other: U) -> ZipIterator<T, U> {
         ZipIterator{a: self, b: other}
     }
 
@@ -488,7 +487,7 @@ impl<A, T: Iterator<A>> IteratorUtil<A> for T {
     }
 
     #[inline]
-    fn enumerate(self) -> EnumerateIterator<A, T> {
+    fn enumerate(self) -> EnumerateIterator<T> {
         EnumerateIterator{iter: self, count: 0}
     }
 
@@ -503,13 +502,13 @@ impl<A, T: Iterator<A>> IteratorUtil<A> for T {
     }
 
     #[inline]
-    fn skip(self, n: uint) -> SkipIterator<A, T> {
+    fn skip(self, n: uint) -> SkipIterator<T> {
         SkipIterator{iter: self, n: n}
     }
 
     // FIXME: #5898: should be called take
     #[inline]
-    fn take_(self, n: uint) -> TakeIterator<A, T> {
+    fn take_(self, n: uint) -> TakeIterator<T> {
         TakeIterator{iter: self, n: n}
     }
 
@@ -521,7 +520,7 @@ impl<A, T: Iterator<A>> IteratorUtil<A> for T {
 
     #[inline]
     fn flat_map_<'r, B, U: Iterator<B>>(self, f: &'r fn(A) -> U)
-        -> FlatMapIterator<'r, A, B, T, U> {
+        -> FlatMapIterator<'r, A, T, U> {
         FlatMapIterator{iter: self, f: f, subiter: None }
     }
 
@@ -756,8 +755,7 @@ impl<A: Ord, T: Iterator<A>> OrdIterator<A> for T {
 }
 
 /// A trait for iterators that are clonable.
-// FIXME #6967: Dummy A parameter to get around type inference bug
-pub trait ClonableIterator<A> {
+pub trait ClonableIterator {
     /// Repeats an iterator endlessly
     ///
     /// # Example
@@ -768,24 +766,24 @@ pub trait ClonableIterator<A> {
     /// assert_eq!(cy.next(), Some(1));
     /// assert_eq!(cy.next(), Some(1));
     /// ~~~
-    fn cycle(self) -> CycleIterator<A, Self>;
+    fn cycle(self) -> CycleIterator<Self>;
 }
 
-impl<A, T: Clone + Iterator<A>> ClonableIterator<A> for T {
+impl<A, T: Clone + Iterator<A>> ClonableIterator for T {
     #[inline]
-    fn cycle(self) -> CycleIterator<A, T> {
+    fn cycle(self) -> CycleIterator<T> {
         CycleIterator{orig: self.clone(), iter: self}
     }
 }
 
 /// An iterator that repeats endlessly
 #[deriving(Clone)]
-pub struct CycleIterator<A, T> {
+pub struct CycleIterator<T> {
     priv orig: T,
     priv iter: T,
 }
 
-impl<A, T: Clone + Iterator<A>> Iterator<A> for CycleIterator<A, T> {
+impl<A, T: Clone + Iterator<A>> Iterator<A> for CycleIterator<T> {
     #[inline]
     fn next(&mut self) -> Option<A> {
         match self.iter.next() {
@@ -806,15 +804,14 @@ impl<A, T: Clone + Iterator<A>> Iterator<A> for CycleIterator<A, T> {
 }
 
 /// An iterator which strings two iterators together
-// FIXME #6967: Dummy A parameter to get around type inference bug
 #[deriving(Clone)]
-pub struct ChainIterator<A, T, U> {
+pub struct ChainIterator<T, U> {
     priv a: T,
     priv b: U,
     priv flag: bool
 }
 
-impl<A, T: Iterator<A>, U: Iterator<A>> Iterator<A> for ChainIterator<A, T, U> {
+impl<A, T: Iterator<A>, U: Iterator<A>> Iterator<A> for ChainIterator<T, U> {
     #[inline]
     fn next(&mut self) -> Option<A> {
         if self.flag {
@@ -851,7 +848,7 @@ impl<A, T: Iterator<A>, U: Iterator<A>> Iterator<A> for ChainIterator<A, T, U> {
 }
 
 impl<A, T: DoubleEndedIterator<A>, U: DoubleEndedIterator<A>> DoubleEndedIterator<A>
-for ChainIterator<A, T, U> {
+for ChainIterator<T, U> {
     #[inline]
     fn next_back(&mut self) -> Option<A> {
         match self.b.next_back() {
@@ -862,7 +859,7 @@ for ChainIterator<A, T, U> {
 }
 
 impl<A, T: RandomAccessIterator<A>, U: RandomAccessIterator<A>> RandomAccessIterator<A>
-for ChainIterator<A, T, U> {
+for ChainIterator<T, U> {
     #[inline]
     fn indexable(&self) -> uint {
         let (a, b) = (self.a.indexable(), self.b.indexable());
@@ -886,14 +883,13 @@ for ChainIterator<A, T, U> {
 }
 
 /// An iterator which iterates two other iterators simultaneously
-// FIXME #6967: Dummy A & B parameters to get around type inference bug
 #[deriving(Clone)]
-pub struct ZipIterator<A, T, B, U> {
+pub struct ZipIterator<T, U> {
     priv a: T,
     priv b: U
 }
 
-impl<A, B, T: Iterator<A>, U: Iterator<B>> Iterator<(A, B)> for ZipIterator<A, T, B, U> {
+impl<A, B, T: Iterator<A>, U: Iterator<B>> Iterator<(A, B)> for ZipIterator<T, U> {
     #[inline]
     fn next(&mut self) -> Option<(A, B)> {
         match (self.a.next(), self.b.next()) {
@@ -1040,14 +1036,13 @@ for FilterMapIterator<'self, A, B, T> {
 }
 
 /// An iterator which yields the current count and the element during iteration
-// FIXME #6967: Dummy A parameter to get around type inference bug
 #[deriving(Clone)]
-pub struct EnumerateIterator<A, T> {
+pub struct EnumerateIterator<T> {
     priv iter: T,
     priv count: uint
 }
 
-impl<A, T: Iterator<A>> Iterator<(uint, A)> for EnumerateIterator<A, T> {
+impl<A, T: Iterator<A>> Iterator<(uint, A)> for EnumerateIterator<T> {
     #[inline]
     fn next(&mut self) -> Option<(uint, A)> {
         match self.iter.next() {
@@ -1139,14 +1134,13 @@ impl<'self, A, T: Iterator<A>> Iterator<A> for TakeWhileIterator<'self, A, T> {
 }
 
 /// An iterator which skips over `n` elements of `iter`.
-// FIXME #6967: Dummy A parameter to get around type inference bug
 #[deriving(Clone)]
-pub struct SkipIterator<A, T> {
+pub struct SkipIterator<T> {
     priv iter: T,
     priv n: uint
 }
 
-impl<A, T: Iterator<A>> Iterator<A> for SkipIterator<A, T> {
+impl<A, T: Iterator<A>> Iterator<A> for SkipIterator<T> {
     #[inline]
     fn next(&mut self) -> Option<A> {
         let mut next = self.iter.next();
@@ -1188,14 +1182,13 @@ impl<A, T: Iterator<A>> Iterator<A> for SkipIterator<A, T> {
 }
 
 /// An iterator which only iterates over the first `n` iterations of `iter`.
-// FIXME #6967: Dummy A parameter to get around type inference bug
 #[deriving(Clone)]
-pub struct TakeIterator<A, T> {
+pub struct TakeIterator<T> {
     priv iter: T,
     priv n: uint
 }
 
-impl<A, T: Iterator<A>> Iterator<A> for TakeIterator<A, T> {
+impl<A, T: Iterator<A>> Iterator<A> for TakeIterator<T> {
     #[inline]
     fn next(&mut self) -> Option<A> {
         let next = self.iter.next();
@@ -1247,15 +1240,14 @@ impl<'self, A, B, T: Iterator<A>, St> Iterator<B> for ScanIterator<'self, A, B, 
 /// An iterator that maps each element to an iterator,
 /// and yields the elements of the produced iterators
 ///
-// FIXME #6967: Dummy B parameter to get around type inference bug
-pub struct FlatMapIterator<'self, A, B, T, U> {
+pub struct FlatMapIterator<'self, A, T, U> {
     priv iter: T,
     priv f: &'self fn(A) -> U,
     priv subiter: Option<U>,
 }
 
 impl<'self, A, T: Iterator<A>, B, U: Iterator<B>> Iterator<B> for
-    FlatMapIterator<'self, A, B, T, U> {
+    FlatMapIterator<'self, A, T, U> {
     #[inline]
     fn next(&mut self) -> Option<B> {
         loop {

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2145,7 +2145,7 @@ pub struct VecIterator<'self, T> {
 iterator!{impl VecIterator -> &'self T}
 double_ended_iterator!{impl VecIterator -> &'self T}
 random_access_iterator!{impl VecIterator -> &'self T}
-pub type VecRevIterator<'self, T> = InvertIterator<&'self T, VecIterator<'self, T>>;
+pub type VecRevIterator<'self, T> = InvertIterator<VecIterator<'self, T>>;
 
 impl<'self, T> Clone for VecIterator<'self, T> {
     fn clone(&self) -> VecIterator<'self, T> { *self }
@@ -2161,7 +2161,7 @@ pub struct VecMutIterator<'self, T> {
 iterator!{impl VecMutIterator -> &'self mut T}
 double_ended_iterator!{impl VecMutIterator -> &'self mut T}
 random_access_iterator!{impl VecMutIterator -> &'self mut T}
-pub type VecMutRevIterator<'self, T> = InvertIterator<&'self mut T, VecMutIterator<'self, T>>;
+pub type VecMutRevIterator<'self, T> = InvertIterator<VecMutIterator<'self, T>>;
 
 /// An iterator that moves out of a vector.
 #[deriving(Clone)]


### PR DESCRIPTION
With the recent fixes to method resolution, we can now remove the
dummy type parameters used as crutches in the iterator module.

For example, the zip adaptor type is just ZipIterator<T, U> now.
