### PR TITLE
librust: Stop rust tool from crashing on macos.

### DIFF
--- a/src/librust/rust.rs
+++ b/src/librust/rust.rs
@@ -60,7 +60,13 @@ struct Command<'self> {
     usage_full: UsageSource<'self>,
 }
 
-static COMMANDS: &'static [Command<'static>] = &[
+static NUM_OF_COMMANDS: uint = 7;
+
+// FIXME(#7617): should just be &'static [Command<'static>]
+// but mac os doesn't seem to like that and tries to loop
+// past the end of COMMANDS in usage thus passing garbage
+// to str::repeat and eventually malloc and crashing.
+static COMMANDS: [Command<'static>, .. NUM_OF_COMMANDS] = [
     Command{
         cmd: "build",
         action: CallMain("rustc", rustc::main),


### PR DESCRIPTION
#7617

While the code that was there should've been perfectly fine (and seemingly is on linux at least) there seems to be some sort of weird interaction going on with statics and vectors. I couldn't get a smaller test case to reproduce that behaviour. The for loop in `rust::usage` seemingly just goes past the end of the vector thus getting garbage which it tries to pass to malloc somewhere down the line.

In any case, using a fixed length vector seems to mitigate this.
