### PR TITLE
Add support for `..base` on static struct initializers.

### DIFF
--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -160,7 +160,7 @@ pub fn check_expr(sess: Session,
           expr_field(*) |
           expr_index(*) |
           expr_tup(*) |
-          expr_struct(_, _, None) => { }
+          expr_struct(*) => { }
           expr_addr_of(*) => {
                 sess.span_err(
                     e.span,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -498,7 +498,7 @@ pub enum expr_ {
     expr_mac(mac),
 
     // A struct literal expression.
-    expr_struct(Path, ~[Field], Option<@expr>),
+    expr_struct(Path, ~[Field], Option<@expr> /* base */),
 
     // A vector literal constructed from one repeated element.
     expr_repeat(@expr /* element */, @expr /* count */, mutability),

--- a/src/test/compile-fail/struct-base-wrong-type.rs
+++ b/src/test/compile-fail/struct-base-wrong-type.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo { a: int, b: int }
+struct Bar { x: int }
+
+static bar: Bar = Bar { x: 5 };
+static foo: Foo = Foo { a: 2, ..bar }; //~ ERROR mismatched types: expected `Foo` but found `Bar`
+static foo_i: Foo = Foo { a: 2, ..4 }; //~ ERROR mismatched types: expected `Foo`
+
+fn main() {
+    let b = Bar { x: 5 };
+    let f = Foo { a: 2, ..b }; //~ ERROR mismatched types: expected `Foo` but found `Bar`
+    let f_i = Foo { a: 2, ..4 }; //~ ERROR mismatched types: expected `Foo`
+}

--- a/src/test/run-pass/const-struct.rs
+++ b/src/test/run-pass/const-struct.rs
@@ -25,11 +25,14 @@ impl cmp::Eq for foo {
 static x : foo = foo { a:1, b:2, c: 3 };
 static y : foo = foo { b:2, c:3, a: 1 };
 static z : &'static foo = &foo { a: 10, b: 22, c: 12 };
+static w : foo = foo { a:5, ..x };
 
 pub fn main() {
     assert_eq!(x.b, 2);
     assert_eq!(x, y);
     assert_eq!(z.b, 22);
+    assert_eq!(w.a, 5);
+    assert_eq!(w.c, 3);
     printfln!("0x%x", x.b as uint);
     printfln!("0x%x", z.c as uint);
 }


### PR DESCRIPTION
With an expression like

```
static w : foo = foo { a:5, ..x };
```

Rust currently gives the error "constant contains unimplemented expression type". This branch implements support for constant structs with `..base`.
