### PR TITLE
New naming convention for ast::{node_id, local_crate, crate_node_id, blk_check_mode, ty_field, ty_method}

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -201,7 +201,7 @@ pub struct CrateAnalysis {
     exp_map2: middle::resolve::ExportMap2,
     ty_cx: ty::ctxt,
     maps: astencode::Maps,
-    reachable: @mut HashSet<ast::node_id>
+    reachable: @mut HashSet<ast::NodeId>
 }
 
 /// Run the resolution, typechecking, region checking and other

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -18,7 +18,7 @@ use metadata::filesearch;
 use metadata;
 use middle::lint;
 
-use syntax::ast::node_id;
+use syntax::ast::NodeId;
 use syntax::ast::{int_ty, uint_ty, float_ty};
 use syntax::codemap::span;
 use syntax::diagnostic;
@@ -189,13 +189,13 @@ pub struct Session_ {
     parse_sess: @mut ParseSess,
     codemap: @codemap::CodeMap,
     // For a library crate, this is always none
-    entry_fn: @mut Option<(node_id, codemap::span)>,
+    entry_fn: @mut Option<(NodeId, codemap::span)>,
     entry_type: @mut Option<EntryFnType>,
     span_diagnostic: @diagnostic::span_handler,
     filesearch: @filesearch::FileSearch,
     building_library: @mut bool,
     working_dir: Path,
-    lints: @mut HashMap<ast::node_id, ~[(lint::lint, codemap::span, ~str)]>,
+    lints: @mut HashMap<ast::NodeId, ~[(lint::lint, codemap::span, ~str)]>,
 }
 
 pub type Session = @Session_;
@@ -248,7 +248,7 @@ impl Session_ {
     }
     pub fn add_lint(@self,
                     lint: lint::lint,
-                    id: ast::node_id,
+                    id: ast::NodeId,
                     sp: span,
                     msg: ~str) {
         match self.lints.find_mut(&id) {
@@ -257,7 +257,7 @@ impl Session_ {
         }
         self.lints.insert(id, ~[(lint, sp, msg)]);
     }
-    pub fn next_node_id(@self) -> ast::node_id {
+    pub fn next_node_id(@self) -> ast::NodeId {
         return syntax::parse::next_node_id(self.parse_sess);
     }
     pub fn diagnostic(@self) -> @diagnostic::span_handler {

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -25,7 +25,7 @@ use syntax::print::pprust;
 use syntax::{ast, ast_util};
 use syntax::attr::AttrMetaMethods;
 
-type node_id_gen = @fn() -> ast::node_id;
+type node_id_gen = @fn() -> ast::NodeId;
 
 struct Test {
     span: span,

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -44,7 +44,7 @@ pub fn get_type_param_count(cstore: @mut cstore::CStore, def: ast::def_id)
 /// Iterates over all the language items in the given crate.
 pub fn each_lang_item(cstore: @mut cstore::CStore,
                       cnum: ast::CrateNum,
-                      f: &fn(ast::node_id, uint) -> bool) -> bool {
+                      f: &fn(ast::NodeId, uint) -> bool) -> bool {
     let crate_data = cstore::get_crate_data(cstore, cnum);
     decoder::each_lang_item(crate_data, f)
 }

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -43,8 +43,8 @@ pub struct CStore {
     intr: @ident_interner
 }
 
-// Map from node_id's of local extern mod statements to crate numbers
-type extern_mod_crate_map = HashMap<ast::node_id, ast::CrateNum>;
+// Map from NodeId's of local extern mod statements to crate numbers
+type extern_mod_crate_map = HashMap<ast::NodeId, ast::CrateNum>;
 
 pub fn mk_cstore(intr: @ident_interner) -> CStore {
     return CStore {
@@ -125,13 +125,13 @@ pub fn get_used_link_args<'a>(cstore: &'a CStore) -> &'a [@str] {
 }
 
 pub fn add_extern_mod_stmt_cnum(cstore: &mut CStore,
-                                emod_id: ast::node_id,
+                                emod_id: ast::NodeId,
                                 cnum: ast::CrateNum) {
     cstore.extern_mod_crate_map.insert(emod_id, cnum);
 }
 
 pub fn find_extern_mod_stmt_cnum(cstore: &CStore,
-                                 emod_id: ast::node_id)
+                                 emod_id: ast::NodeId)
                        -> Option<ast::CrateNum> {
     cstore.extern_mod_crate_map.find(&emod_id).map_consume(|x| *x)
 }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -361,7 +361,7 @@ pub fn lookup_def(cnum: ast::CrateNum, data: @~[u8], did_: ast::def_id) ->
 }
 
 pub fn get_trait_def(cdata: cmd,
-                     item_id: ast::node_id,
+                     item_id: ast::NodeId,
                      tcx: ty::ctxt) -> ty::TraitDef
 {
     let item_doc = lookup_item(item_id, cdata.data);
@@ -375,7 +375,7 @@ pub fn get_trait_def(cdata: cmd,
     }
 }
 
-pub fn get_type(cdata: cmd, id: ast::node_id, tcx: ty::ctxt)
+pub fn get_type(cdata: cmd, id: ast::NodeId, tcx: ty::ctxt)
     -> ty::ty_param_bounds_and_ty {
 
     let item = lookup_item(id, cdata.data);
@@ -392,19 +392,19 @@ pub fn get_type(cdata: cmd, id: ast::node_id, tcx: ty::ctxt)
     }
 }
 
-pub fn get_region_param(cdata: cmd, id: ast::node_id)
+pub fn get_region_param(cdata: cmd, id: ast::NodeId)
     -> Option<ty::region_variance> {
 
     let item = lookup_item(id, cdata.data);
     return item_ty_region_param(item);
 }
 
-pub fn get_type_param_count(data: @~[u8], id: ast::node_id) -> uint {
+pub fn get_type_param_count(data: @~[u8], id: ast::NodeId) -> uint {
     item_ty_param_count(lookup_item(id, data))
 }
 
 pub fn get_impl_trait(cdata: cmd,
-                       id: ast::node_id,
+                       id: ast::NodeId,
                        tcx: ty::ctxt) -> Option<@ty::TraitRef>
 {
     let item_doc = lookup_item(id, cdata.data);
@@ -414,7 +414,7 @@ pub fn get_impl_trait(cdata: cmd,
 }
 
 pub fn get_impl_vtables(cdata: cmd,
-                        id: ast::node_id,
+                        id: ast::NodeId,
                         tcx: ty::ctxt) -> typeck::impl_res
 {
     let item_doc = lookup_item(id, cdata.data);
@@ -428,7 +428,7 @@ pub fn get_impl_vtables(cdata: cmd,
 }
 
 
-pub fn get_impl_method(intr: @ident_interner, cdata: cmd, id: ast::node_id,
+pub fn get_impl_method(intr: @ident_interner, cdata: cmd, id: ast::NodeId,
                        name: ast::ident) -> Option<ast::def_id> {
     let items = reader::get_doc(reader::Doc(cdata.data), tag_items);
     let mut found = None;
@@ -442,7 +442,7 @@ pub fn get_impl_method(intr: @ident_interner, cdata: cmd, id: ast::node_id,
     found
 }
 
-pub fn get_symbol(data: @~[u8], id: ast::node_id) -> ~str {
+pub fn get_symbol(data: @~[u8], id: ast::NodeId) -> ~str {
     return item_symbol(lookup_item(id, data));
 }
 
@@ -462,7 +462,7 @@ fn def_like_to_def(def_like: def_like) -> ast::def {
 }
 
 /// Iterates over the language items in the given crate.
-pub fn each_lang_item(cdata: cmd, f: &fn(ast::node_id, uint) -> bool) -> bool {
+pub fn each_lang_item(cdata: cmd, f: &fn(ast::NodeId, uint) -> bool) -> bool {
     let root = reader::Doc(cdata.data);
     let lang_items = reader::get_doc(root, tag_lang_items);
     for reader::tagged_docs(lang_items, tag_lang_items_item) |item_doc| {
@@ -470,7 +470,7 @@ pub fn each_lang_item(cdata: cmd, f: &fn(ast::node_id, uint) -> bool) -> bool {
         let id = reader::doc_as_u32(id_doc) as uint;
         let node_id_doc = reader::get_doc(item_doc,
                                           tag_lang_items_item_node_id);
-        let node_id = reader::doc_as_u32(node_id_doc) as ast::node_id;
+        let node_id = reader::doc_as_u32(node_id_doc) as ast::NodeId;
 
         if !f(node_id, id) {
             return false;
@@ -716,7 +716,7 @@ pub fn each_path(intr: @ident_interner,
     context.each_child_of_module_or_crate(crate_items_doc)
 }
 
-pub fn get_item_path(cdata: cmd, id: ast::node_id) -> ast_map::path {
+pub fn get_item_path(cdata: cmd, id: ast::NodeId) -> ast_map::path {
     item_path(lookup_item(id, cdata.data))
 }
 
@@ -727,7 +727,7 @@ pub type decode_inlined_item<'self> = &'self fn(
     par_doc: ebml::Doc) -> Option<ast::inlined_item>;
 
 pub fn maybe_get_item_ast(cdata: cmd, tcx: ty::ctxt,
-                          id: ast::node_id,
+                          id: ast::NodeId,
                           decode_inlined_item: decode_inlined_item)
                        -> csearch::found_ast {
     debug!("Looking up item: %d", id);
@@ -754,7 +754,7 @@ pub fn maybe_get_item_ast(cdata: cmd, tcx: ty::ctxt,
     }
 }
 
-pub fn get_enum_variants(intr: @ident_interner, cdata: cmd, id: ast::node_id,
+pub fn get_enum_variants(intr: @ident_interner, cdata: cmd, id: ast::NodeId,
                      tcx: ty::ctxt) -> ~[@ty::VariantInfo] {
     let data = cdata.data;
     let items = reader::get_doc(reader::Doc(data), tag_items);
@@ -833,7 +833,7 @@ fn item_impl_methods(intr: @ident_interner, cdata: cmd, item: ebml::Doc,
 }
 
 /// Returns information about the given implementation.
-pub fn get_impl(intr: @ident_interner, cdata: cmd, impl_id: ast::node_id,
+pub fn get_impl(intr: @ident_interner, cdata: cmd, impl_id: ast::NodeId,
                tcx: ty::ctxt)
                 -> ty::Impl {
     let data = cdata.data;
@@ -851,7 +851,7 @@ pub fn get_impl(intr: @ident_interner, cdata: cmd, impl_id: ast::node_id,
 pub fn get_method_name_and_explicit_self(
     intr: @ident_interner,
     cdata: cmd,
-    id: ast::node_id) -> (ast::ident, ast::explicit_self_)
+    id: ast::NodeId) -> (ast::ident, ast::explicit_self_)
 {
     let method_doc = lookup_item(id, cdata.data);
     let name = item_name(intr, method_doc);
@@ -859,7 +859,7 @@ pub fn get_method_name_and_explicit_self(
     (name, explicit_self)
 }
 
-pub fn get_method(intr: @ident_interner, cdata: cmd, id: ast::node_id,
+pub fn get_method(intr: @ident_interner, cdata: cmd, id: ast::NodeId,
                   tcx: ty::ctxt) -> ty::Method
 {
     let method_doc = lookup_item(id, cdata.data);
@@ -892,7 +892,7 @@ pub fn get_method(intr: @ident_interner, cdata: cmd, id: ast::node_id,
 }
 
 pub fn get_trait_method_def_ids(cdata: cmd,
-                                id: ast::node_id) -> ~[ast::def_id] {
+                                id: ast::NodeId) -> ~[ast::def_id] {
     let data = cdata.data;
     let item = lookup_item(id, data);
     let mut result = ~[];
@@ -903,7 +903,7 @@ pub fn get_trait_method_def_ids(cdata: cmd,
 }
 
 pub fn get_provided_trait_methods(intr: @ident_interner, cdata: cmd,
-                                  id: ast::node_id, tcx: ty::ctxt) ->
+                                  id: ast::NodeId, tcx: ty::ctxt) ->
         ~[@ty::Method] {
     let data = cdata.data;
     let item = lookup_item(id, data);
@@ -922,7 +922,7 @@ pub fn get_provided_trait_methods(intr: @ident_interner, cdata: cmd,
 }
 
 /// Returns the supertraits of the given trait.
-pub fn get_supertraits(cdata: cmd, id: ast::node_id, tcx: ty::ctxt)
+pub fn get_supertraits(cdata: cmd, id: ast::NodeId, tcx: ty::ctxt)
                     -> ~[@ty::TraitRef] {
     let mut results = ~[];
     let item_doc = lookup_item(id, cdata.data);
@@ -933,7 +933,7 @@ pub fn get_supertraits(cdata: cmd, id: ast::node_id, tcx: ty::ctxt)
 }
 
 pub fn get_type_name_if_impl(cdata: cmd,
-                             node_id: ast::node_id) -> Option<ast::ident> {
+                             node_id: ast::NodeId) -> Option<ast::ident> {
     let item = lookup_item(node_id, cdata.data);
     if item_family(item) != Impl {
         return None;
@@ -948,7 +948,7 @@ pub fn get_type_name_if_impl(cdata: cmd,
 
 pub fn get_static_methods_if_impl(intr: @ident_interner,
                                   cdata: cmd,
-                                  node_id: ast::node_id)
+                                  node_id: ast::NodeId)
                                -> Option<~[StaticMethodInfo]> {
     let item = lookup_item(node_id, cdata.data);
     if item_family(item) != Impl {
@@ -992,7 +992,7 @@ pub fn get_static_methods_if_impl(intr: @ident_interner,
 }
 
 pub fn get_item_attrs(cdata: cmd,
-                      node_id: ast::node_id,
+                      node_id: ast::NodeId,
                       f: &fn(~[@ast::MetaItem])) {
 
     let item = lookup_item(node_id, cdata.data);
@@ -1012,7 +1012,7 @@ fn struct_field_family_to_visibility(family: Family) -> ast::visibility {
     }
 }
 
-pub fn get_struct_fields(intr: @ident_interner, cdata: cmd, id: ast::node_id)
+pub fn get_struct_fields(intr: @ident_interner, cdata: cmd, id: ast::NodeId)
     -> ~[ty::field_ty] {
     let data = cdata.data;
     let item = lookup_item(id, data);
@@ -1040,7 +1040,7 @@ pub fn get_struct_fields(intr: @ident_interner, cdata: cmd, id: ast::node_id)
     result
 }
 
-pub fn get_item_visibility(cdata: cmd, id: ast::node_id)
+pub fn get_item_visibility(cdata: cmd, id: ast::NodeId)
                         -> ast::visibility {
     item_visibility(lookup_item(id, cdata.data))
 }
@@ -1068,7 +1068,7 @@ fn read_path(d: ebml::Doc) -> (~str, uint) {
 }
 
 fn describe_def(items: ebml::Doc, id: ast::def_id) -> ~str {
-    if id.crate != ast::local_crate { return ~"external"; }
+    if id.crate != ast::LOCAL_CRATE { return ~"external"; }
     let it = match maybe_find_item(id.node, items) {
         Some(it) => it,
         None => fail!("describe_def: item not found %?", id)
@@ -1260,7 +1260,7 @@ pub fn list_crate_metadata(intr: @ident_interner, bytes: @~[u8],
 // then we must translate the crate number from that encoded in the external
 // crate to the correct local crate number.
 pub fn translate_def_id(cdata: cmd, did: ast::def_id) -> ast::def_id {
-    if did.crate == ast::local_crate {
+    if did.crate == ast::LOCAL_CRATE {
         return ast::def_id { crate: cdata.cnum, node: did.node };
     }
 

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -165,7 +165,7 @@ fn reserve_id_range(sess: Session,
 }
 
 impl ExtendedDecodeContext {
-    pub fn tr_id(&self, id: ast::node_id) -> ast::node_id {
+    pub fn tr_id(&self, id: ast::NodeId) -> ast::NodeId {
         /*!
          * Translates an internal id, meaning a node id that is known
          * to refer to some part of the item currently being inlined,
@@ -212,8 +212,8 @@ impl ExtendedDecodeContext {
          * refer to the current crate and to the new, inlined node-id.
          */
 
-        assert_eq!(did.crate, ast::local_crate);
-        ast::def_id { crate: ast::local_crate, node: self.tr_id(did.node) }
+        assert_eq!(did.crate, ast::LOCAL_CRATE);
+        ast::def_id { crate: ast::LOCAL_CRATE, node: self.tr_id(did.node) }
     }
     pub fn tr_span(&self, _span: span) -> span {
         codemap::dummy_sp() // FIXME (#1972): handle span properly
@@ -802,7 +802,7 @@ impl ebml_writer_helpers for writer::Encoder {
 
 trait write_tag_and_id {
     fn tag(&mut self, tag_id: c::astencode_tag, f: &fn(&mut Self));
-    fn id(&mut self, id: ast::node_id);
+    fn id(&mut self, id: ast::NodeId);
 }
 
 impl write_tag_and_id for writer::Encoder {
@@ -814,7 +814,7 @@ impl write_tag_and_id for writer::Encoder {
         self.end_tag();
     }
 
-    fn id(&mut self, id: ast::node_id) {
+    fn id(&mut self, id: ast::NodeId) {
         self.wr_tagged_u64(c::tag_table_id as uint, id as u64)
     }
 }
@@ -833,7 +833,7 @@ fn encode_side_tables_for_ii(ecx: &e::EncodeContext,
     let ecx_ptr : *() = unsafe { cast::transmute(ecx) };
     ast_util::visit_ids_for_inlined_item(
         ii,
-        |id: ast::node_id| {
+        |id: ast::NodeId| {
             // Note: this will cause a copy of ebml_w, which is bad as
             // it is mutable. But I believe it's harmless since we generate
             // balanced EBML.
@@ -848,7 +848,7 @@ fn encode_side_tables_for_ii(ecx: &e::EncodeContext,
 fn encode_side_tables_for_id(ecx: &e::EncodeContext,
                              maps: Maps,
                              ebml_w: &mut writer::Encoder,
-                             id: ast::node_id) {
+                             id: ast::NodeId) {
     let tcx = ecx.tcx;
 
     debug!("Encoding side tables for id %d", id);
@@ -903,7 +903,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         }
     }
 
-    let lid = ast::def_id { crate: ast::local_crate, node: id };
+    let lid = ast::def_id { crate: ast::LOCAL_CRATE, node: id };
     {
         let r = tcx.tcache.find(&lid);
         for r.iter().advance |&tpbt| {
@@ -1181,7 +1181,7 @@ fn decode_side_tables(xcx: @ExtendedDecodeContext,
                     }
                     c::tag_table_tcache => {
                         let tpbt = val_dsr.read_ty_param_bounds_and_ty(xcx);
-                        let lid = ast::def_id { crate: ast::local_crate, node: id };
+                        let lid = ast::def_id { crate: ast::LOCAL_CRATE, node: id };
                         dcx.tcx.tcache.insert(lid, tpbt);
                     }
                     c::tag_table_param_defs => {

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -37,7 +37,7 @@ struct CheckLoanCtxt<'self> {
     dfcx_loans: &'self LoanDataFlow,
     move_data: @move_data::FlowedMoveData,
     all_loans: &'self [Loan],
-    reported: @mut HashSet<ast::node_id>,
+    reported: @mut HashSet<ast::NodeId>,
 }
 
 pub fn check_loans(bccx: @BorrowckCtxt,
@@ -73,7 +73,7 @@ impl<'self> CheckLoanCtxt<'self> {
     pub fn tcx(&self) -> ty::ctxt { self.bccx.tcx }
 
     pub fn each_issued_loan(&self,
-                            scope_id: ast::node_id,
+                            scope_id: ast::NodeId,
                             op: &fn(&Loan) -> bool)
                             -> bool {
         //! Iterates over each loan that has been issued
@@ -92,7 +92,7 @@ impl<'self> CheckLoanCtxt<'self> {
     }
 
     pub fn each_in_scope_loan(&self,
-                              scope_id: ast::node_id,
+                              scope_id: ast::NodeId,
                               op: &fn(&Loan) -> bool)
                               -> bool {
         //! Like `each_issued_loan()`, but only considers loans that are
@@ -110,7 +110,7 @@ impl<'self> CheckLoanCtxt<'self> {
     }
 
     pub fn each_in_scope_restriction(&self,
-                                     scope_id: ast::node_id,
+                                     scope_id: ast::NodeId,
                                      loan_path: @LoanPath,
                                      op: &fn(&Loan, &Restriction) -> bool)
                                      -> bool {
@@ -129,7 +129,7 @@ impl<'self> CheckLoanCtxt<'self> {
         return true;
     }
 
-    pub fn loans_generated_by(&self, scope_id: ast::node_id) -> ~[uint] {
+    pub fn loans_generated_by(&self, scope_id: ast::NodeId) -> ~[uint] {
         //! Returns a vector of the loans that are generated as
         //! we encounter `scope_id`.
 
@@ -140,7 +140,7 @@ impl<'self> CheckLoanCtxt<'self> {
         return result;
     }
 
-    pub fn check_for_conflicting_loans(&self, scope_id: ast::node_id) {
+    pub fn check_for_conflicting_loans(&self, scope_id: ast::NodeId) {
         //! Checks to see whether any of the loans that are issued
         //! by `scope_id` conflict with loans that have already been
         //! issued when we enter `scope_id` (for example, we do not
@@ -256,7 +256,7 @@ impl<'self> CheckLoanCtxt<'self> {
     }
 
     pub fn check_if_path_is_moved(&self,
-                                  id: ast::node_id,
+                                  id: ast::NodeId,
                                   span: span,
                                   use_kind: MovedValueUseKind,
                                   lp: @LoanPath) {
@@ -561,7 +561,7 @@ impl<'self> CheckLoanCtxt<'self> {
         }
     }
 
-    fn check_move_out_from_id(&self, id: ast::node_id, span: span) {
+    fn check_move_out_from_id(&self, id: ast::NodeId, span: span) {
         for self.move_data.each_path_moved_by(id) |_, move_path| {
             match self.analyze_move_out_from(id, move_path) {
                 MoveOk => {}
@@ -581,7 +581,7 @@ impl<'self> CheckLoanCtxt<'self> {
     }
 
     pub fn analyze_move_out_from(&self,
-                                 expr_id: ast::node_id,
+                                 expr_id: ast::NodeId,
                                  move_path: @LoanPath) -> MoveError {
         debug!("analyze_move_out_from(expr_id=%?, move_path=%s)",
                expr_id, move_path.repr(self.tcx()));
@@ -600,7 +600,7 @@ impl<'self> CheckLoanCtxt<'self> {
     pub fn check_call(&self,
                       _expr: @ast::expr,
                       _callee: Option<@ast::expr>,
-                      _callee_id: ast::node_id,
+                      _callee_id: ast::NodeId,
                       _callee_span: span,
                       _args: &[@ast::expr]) {
         // NB: This call to check for conflicting loans is not truly
@@ -617,7 +617,7 @@ fn check_loans_in_fn<'a>(fk: &visit::fn_kind,
                          decl: &ast::fn_decl,
                          body: &ast::Block,
                          sp: span,
-                         id: ast::node_id,
+                         id: ast::NodeId,
                          (this, visitor): (CheckLoanCtxt<'a>,
                                            visit::vt<CheckLoanCtxt<'a>>)) {
     match *fk {
@@ -636,7 +636,7 @@ fn check_loans_in_fn<'a>(fk: &visit::fn_kind,
     visit::visit_fn(fk, decl, body, sp, id, (this, visitor));
 
     fn check_captured_variables(this: CheckLoanCtxt,
-                                closure_id: ast::node_id,
+                                closure_id: ast::NodeId,
                                 span: span) {
         let cap_vars = this.bccx.capture_map.get(&closure_id);
         for cap_vars.iter().advance |cap_var| {
@@ -654,7 +654,7 @@ fn check_loans_in_fn<'a>(fk: &visit::fn_kind,
         return;
 
         fn check_by_move_capture(this: CheckLoanCtxt,
-                                 closure_id: ast::node_id,
+                                 closure_id: ast::NodeId,
                                  cap_var: &moves::CaptureVar,
                                  move_path: @LoanPath) {
             let move_err = this.analyze_move_out_from(closure_id, move_path);

--- a/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
@@ -24,9 +24,9 @@ use util::ppaux::{UserString};
 
 pub fn gather_decl(bccx: @BorrowckCtxt,
                    move_data: &mut MoveData,
-                   decl_id: ast::node_id,
+                   decl_id: ast::NodeId,
                    _decl_span: span,
-                   var_id: ast::node_id) {
+                   var_id: ast::NodeId) {
     let loan_path = @LpVar(var_id);
     move_data.add_move(bccx.tcx, loan_path, decl_id, Declared);
 }
@@ -49,7 +49,7 @@ pub fn gather_move_from_pat(bccx: @BorrowckCtxt,
 
 fn gather_move_from_expr_or_pat(bccx: @BorrowckCtxt,
                                 move_data: &mut MoveData,
-                                move_id: ast::node_id,
+                                move_id: ast::NodeId,
                                 move_kind: MoveKind,
                                 cmt: mc::cmt) {
     if !check_is_legal_to_move_from(bccx, cmt, cmt) {
@@ -85,10 +85,10 @@ pub fn gather_captures(bccx: @BorrowckCtxt,
 
 pub fn gather_assignment(bccx: @BorrowckCtxt,
                          move_data: &mut MoveData,
-                         assignment_id: ast::node_id,
+                         assignment_id: ast::NodeId,
                          assignment_span: span,
                          assignee_loan_path: @LoanPath,
-                         assignee_id: ast::node_id) {
+                         assignee_id: ast::NodeId) {
     move_data.add_assignment(bccx.tcx,
                              assignee_loan_path,
                              assignment_id,

--- a/src/librustc/middle/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc/middle/borrowck/gather_loans/lifetime.rs
@@ -21,8 +21,8 @@ use syntax::codemap::span;
 use util::ppaux::{note_and_explain_region};
 
 pub fn guarantee_lifetime(bccx: @BorrowckCtxt,
-                          item_scope_id: ast::node_id,
-                          root_scope_id: ast::node_id,
+                          item_scope_id: ast::NodeId,
+                          root_scope_id: ast::NodeId,
                           span: span,
                           cmt: mc::cmt,
                           loan_region: ty::Region,
@@ -46,11 +46,11 @@ struct GuaranteeLifetimeContext {
     bccx: @BorrowckCtxt,
 
     // the node id of the function body for the enclosing item
-    item_scope_id: ast::node_id,
+    item_scope_id: ast::NodeId,
 
     // the node id of the innermost loop / function body; this is the
     // longest scope for which we can root managed boxes
-    root_scope_id: ast::node_id,
+    root_scope_id: ast::NodeId,
 
     span: span,
     loan_region: ty::Region,
@@ -63,7 +63,7 @@ impl GuaranteeLifetimeContext {
         self.bccx.tcx
     }
 
-    fn check(&self, cmt: mc::cmt, discr_scope: Option<ast::node_id>) {
+    fn check(&self, cmt: mc::cmt, discr_scope: Option<ast::NodeId>) {
         //! Main routine. Walks down `cmt` until we find the "guarantor".
 
         match cmt.cat {
@@ -189,7 +189,7 @@ impl GuaranteeLifetimeContext {
                   cmt_base: mc::cmt,
                   derefs: uint,
                   ptr_mutbl: ast::mutability,
-                  discr_scope: Option<ast::node_id>) {
+                  discr_scope: Option<ast::NodeId>) {
         debug!("check_root(cmt_deref=%s, cmt_base=%s, derefs=%?, ptr_mutbl=%?, \
                 discr_scope=%?)",
                cmt_deref.repr(self.tcx()),

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -68,8 +68,8 @@ struct GatherLoanCtxt {
     id_range: id_range,
     move_data: @mut move_data::MoveData,
     all_loans: @mut ~[Loan],
-    item_ub: ast::node_id,
-    repeating_ids: ~[ast::node_id]
+    item_ub: ast::NodeId,
+    repeating_ids: ~[ast::NodeId]
 }
 
 pub fn gather_loans(bccx: @BorrowckCtxt,
@@ -111,7 +111,7 @@ fn gather_loans_in_fn(fk: &visit::fn_kind,
                       decl: &ast::fn_decl,
                       body: &ast::Block,
                       sp: span,
-                      id: ast::node_id,
+                      id: ast::NodeId,
                       (this, v): (@mut GatherLoanCtxt,
                                   visit::vt<@mut GatherLoanCtxt>)) {
     match fk {
@@ -294,11 +294,11 @@ fn gather_loans_in_expr(ex: @ast::expr,
 impl GatherLoanCtxt {
     pub fn tcx(&self) -> ty::ctxt { self.bccx.tcx }
 
-    pub fn push_repeating_id(&mut self, id: ast::node_id) {
+    pub fn push_repeating_id(&mut self, id: ast::NodeId) {
         self.repeating_ids.push(id);
     }
 
-    pub fn pop_repeating_id(&mut self, id: ast::node_id) {
+    pub fn pop_repeating_id(&mut self, id: ast::NodeId) {
         let popped = self.repeating_ids.pop();
         assert_eq!(id, popped);
     }
@@ -369,7 +369,7 @@ impl GatherLoanCtxt {
     // also entail "rooting" GC'd pointers, which means ensuring
     // dynamically that they are not freed.
     pub fn guarantee_valid(&mut self,
-                           borrow_id: ast::node_id,
+                           borrow_id: ast::NodeId,
                            borrow_span: span,
                            cmt: mc::cmt,
                            req_mutbl: ast::mutability,
@@ -559,9 +559,9 @@ impl GatherLoanCtxt {
     }
 
     pub fn compute_gen_scope(&self,
-                             borrow_id: ast::node_id,
-                             loan_scope: ast::node_id)
-                             -> ast::node_id {
+                             borrow_id: ast::NodeId,
+                             loan_scope: ast::NodeId)
+                             -> ast::NodeId {
         //! Determine when to introduce the loan. Typically the loan
         //! is introduced at the point of the borrow, but in some cases,
         //! notably method arguments, the loan may be introduced only
@@ -575,8 +575,8 @@ impl GatherLoanCtxt {
         }
     }
 
-    pub fn compute_kill_scope(&self, loan_scope: ast::node_id, lp: @LoanPath)
-                              -> ast::node_id {
+    pub fn compute_kill_scope(&self, loan_scope: ast::NodeId, lp: @LoanPath)
+                              -> ast::NodeId {
         //! Determine when the loan restrictions go out of scope.
         //! This is either when the lifetime expires or when the
         //! local variable which roots the loan-path goes out of scope,
@@ -633,7 +633,7 @@ impl GatherLoanCtxt {
     fn gather_pat(&mut self,
                   discr_cmt: mc::cmt,
                   root_pat: @ast::pat,
-                  arm_match_ids: Option<(ast::node_id, ast::node_id)>) {
+                  arm_match_ids: Option<(ast::NodeId, ast::NodeId)>) {
         /*!
          * Walks patterns, examining the bindings to determine if they
          * cause borrows (`ref` bindings, vector patterns) or

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -117,7 +117,7 @@ fn borrowck_fn(fk: &visit::fn_kind,
                decl: &ast::fn_decl,
                body: &ast::Block,
                sp: span,
-               id: ast::node_id,
+               id: ast::NodeId,
                (this, v): (@BorrowckCtxt,
                            visit::vt<@BorrowckCtxt>)) {
     match fk {
@@ -185,7 +185,7 @@ pub struct BorrowStats {
     guaranteed_paths: uint
 }
 
-pub type LoanMap = @mut HashMap<ast::node_id, @Loan>;
+pub type LoanMap = @mut HashMap<ast::NodeId, @Loan>;
 
 // The keys to the root map combine the `id` of the deref expression
 // with the number of types that it is *autodereferenced*. So, for
@@ -212,7 +212,7 @@ pub type LoanMap = @mut HashMap<ast::node_id, @Loan>;
 // auto-slice.
 #[deriving(Eq, IterBytes)]
 pub struct root_map_key {
-    id: ast::node_id,
+    id: ast::NodeId,
     derefs: uint
 }
 
@@ -238,14 +238,14 @@ pub struct Loan {
     cmt: mc::cmt,
     mutbl: ast::mutability,
     restrictions: ~[Restriction],
-    gen_scope: ast::node_id,
-    kill_scope: ast::node_id,
+    gen_scope: ast::NodeId,
+    kill_scope: ast::NodeId,
     span: span,
 }
 
 #[deriving(Eq, IterBytes)]
 pub enum LoanPath {
-    LpVar(ast::node_id),               // `x` in doc.rs
+    LpVar(ast::NodeId),               // `x` in doc.rs
     LpExtend(@LoanPath, mc::MutabilityCategory, LoanPathElem)
 }
 
@@ -256,7 +256,7 @@ pub enum LoanPathElem {
 }
 
 impl LoanPath {
-    pub fn node_id(&self) -> ast::node_id {
+    pub fn node_id(&self) -> ast::NodeId {
         match *self {
             LpVar(local_id) => local_id,
             LpExtend(base, _, _) => base.node_id()
@@ -376,7 +376,7 @@ impl BitAnd<RestrictionSet,RestrictionSet> for RestrictionSet {
 // uncovered after a certain number of auto-derefs.
 
 pub struct RootInfo {
-    scope: ast::node_id,
+    scope: ast::NodeId,
     freeze: Option<DynaFreezeKind> // Some() if we should freeze box at runtime
 }
 
@@ -440,12 +440,12 @@ impl BorrowckCtxt {
         self.tcx.region_maps.is_subregion_of(r_sub, r_sup)
     }
 
-    pub fn is_subscope_of(&self, r_sub: ast::node_id, r_sup: ast::node_id)
+    pub fn is_subscope_of(&self, r_sub: ast::NodeId, r_sup: ast::NodeId)
                           -> bool {
         self.tcx.region_maps.is_subscope_of(r_sub, r_sup)
     }
 
-    pub fn is_move(&self, id: ast::node_id) -> bool {
+    pub fn is_move(&self, id: ast::NodeId) -> bool {
         self.moves_map.contains(&id)
     }
 
@@ -477,7 +477,7 @@ impl BorrowckCtxt {
     }
 
     pub fn cat_def(&self,
-                   id: ast::node_id,
+                   id: ast::NodeId,
                    span: span,
                    ty: ty::t,
                    def: ast::def)
@@ -485,7 +485,7 @@ impl BorrowckCtxt {
         mc::cat_def(self.tcx, self.method_map, id, span, ty, def)
     }
 
-    pub fn cat_discr(&self, cmt: mc::cmt, match_id: ast::node_id) -> mc::cmt {
+    pub fn cat_discr(&self, cmt: mc::cmt, match_id: ast::NodeId) -> mc::cmt {
         @mc::cmt_ {cat:mc::cat_discr(cmt, match_id),
                    mutbl:cmt.mutbl.inherit(),
                    ..*cmt}

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -49,7 +49,7 @@ pub struct MoveData {
     /// assigned dataflow bits, but we track them because they still
     /// kill move bits.
     path_assignments: ~[Assignment],
-    assignee_ids: HashSet<ast::node_id>,
+    assignee_ids: HashSet<ast::NodeId>,
 }
 
 pub struct FlowedMoveData {
@@ -118,7 +118,7 @@ pub struct Move {
     path: MovePathIndex,
 
     /// id of node that is doing the move.
-    id: ast::node_id,
+    id: ast::NodeId,
 
     /// Kind of move, for error messages.
     kind: MoveKind,
@@ -132,7 +132,7 @@ pub struct Assignment {
     path: MovePathIndex,
 
     /// id where assignment occurs
-    id: ast::node_id,
+    id: ast::NodeId,
 
     /// span of node where assignment occurs
     span: span,
@@ -296,7 +296,7 @@ impl MoveData {
     pub fn add_move(&mut self,
                     tcx: ty::ctxt,
                     lp: @LoanPath,
-                    id: ast::node_id,
+                    id: ast::NodeId,
                     kind: MoveKind) {
         /*!
          * Adds a new move entry for a move of `lp` that occurs at
@@ -325,9 +325,9 @@ impl MoveData {
     pub fn add_assignment(&mut self,
                           tcx: ty::ctxt,
                           lp: @LoanPath,
-                          assign_id: ast::node_id,
+                          assign_id: ast::NodeId,
                           span: span,
-                          assignee_id: ast::node_id) {
+                          assignee_id: ast::NodeId) {
         /*!
          * Adds a new record for an assignment to `lp` that occurs at
          * location `id` with the given `span`.
@@ -460,7 +460,7 @@ impl MoveData {
 
     fn kill_moves(&self,
                   path: MovePathIndex,
-                  kill_id: ast::node_id,
+                  kill_id: ast::NodeId,
                   dfcx_moves: &mut MoveDataFlow) {
         for self.each_applicable_move(path) |move_index| {
             dfcx_moves.add_kill(kill_id, *move_index);
@@ -499,7 +499,7 @@ impl FlowedMoveData {
     }
 
     pub fn each_path_moved_by(&self,
-                              id: ast::node_id,
+                              id: ast::NodeId,
                               f: &fn(&Move, @LoanPath) -> bool)
                               -> bool {
         /*!
@@ -517,7 +517,7 @@ impl FlowedMoveData {
     }
 
     pub fn each_move_of(&self,
-                        id: ast::node_id,
+                        id: ast::NodeId,
                         loan_path: @LoanPath,
                         f: &fn(&Move, @LoanPath) -> bool)
                         -> bool {
@@ -573,7 +573,7 @@ impl FlowedMoveData {
     }
 
     pub fn is_assignee(&self,
-                       id: ast::node_id)
+                       id: ast::NodeId)
                        -> bool {
         //! True if `id` is the id of the LHS of an assignment
 
@@ -581,7 +581,7 @@ impl FlowedMoveData {
     }
 
     pub fn each_assignment_of(&self,
-                              id: ast::node_id,
+                              id: ast::NodeId,
                               loan_path: @LoanPath,
                               f: &fn(&Assignment) -> bool)
                               -> bool {

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -20,13 +20,13 @@ use syntax::opt_vec;
 struct CFGBuilder {
     tcx: ty::ctxt,
     method_map: typeck::method_map,
-    exit_map: HashMap<ast::node_id, CFGIndex>,
+    exit_map: HashMap<ast::NodeId, CFGIndex>,
     graph: CFGGraph,
     loop_scopes: ~[LoopScope],
 }
 
 struct LoopScope {
-    loop_id: ast::node_id,    // id of loop/while node
+    loop_id: ast::NodeId,     // id of loop/while node
     continue_index: CFGIndex, // where to go on a `loop`
     break_index: CFGIndex,    // where to go on a `break
 }
@@ -454,7 +454,7 @@ impl CFGBuilder {
         self.add_node(0, preds)
     }
 
-    fn add_node(&mut self, id: ast::node_id, preds: &[CFGIndex]) -> CFGIndex {
+    fn add_node(&mut self, id: ast::NodeId, preds: &[CFGIndex]) -> CFGIndex {
         assert!(!self.exit_map.contains_key(&id));
         let node = self.graph.add_node(CFGNodeData {id: id});
         self.exit_map.insert(id, node);

--- a/src/librustc/middle/cfg/mod.rs
+++ b/src/librustc/middle/cfg/mod.rs
@@ -25,18 +25,18 @@ use syntax::opt_vec::OptVec;
 mod construct;
 
 pub struct CFG {
-    exit_map: HashMap<ast::node_id, CFGIndex>,
+    exit_map: HashMap<ast::NodeId, CFGIndex>,
     graph: CFGGraph,
     entry: CFGIndex,
     exit: CFGIndex,
 }
 
 pub struct CFGNodeData {
-    id: ast::node_id
+    id: ast::NodeId
 }
 
 pub struct CFGEdgeData {
-    exiting_scopes: OptVec<ast::node_id>
+    exiting_scopes: OptVec<ast::NodeId>
 }
 
 pub type CFGIndex = graph::NodeIndex;

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -200,7 +200,7 @@ struct env {
     sess: Session,
     ast_map: ast_map::map,
     def_map: resolve::DefMap,
-    idstack: @mut ~[node_id]
+    idstack: @mut ~[NodeId]
 }
 
 // Make sure a const item doesn't recursively refer to itself

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -777,7 +777,7 @@ pub fn check_fn(cx: &MatchCheckCtxt,
                 decl: &fn_decl,
                 body: &Block,
                 sp: span,
-                id: node_id,
+                id: NodeId,
                 (s, v): ((),
                          visit::vt<()>)) {
     visit::visit_fn(kind, decl, body, sp, id, (s, v));

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -175,7 +175,7 @@ pub fn lookup_variant_by_id(tcx: ty::ctxt,
                             enum_def: ast::def_id,
                             variant_def: ast::def_id)
                        -> Option<@expr> {
-    fn variant_expr(variants: &[ast::variant], id: ast::node_id) -> Option<@expr> {
+    fn variant_expr(variants: &[ast::variant], id: ast::NodeId) -> Option<@expr> {
         for variants.iter().advance |variant| {
             if variant.node.id == id {
                 return variant.node.disr_expr;

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -46,7 +46,7 @@ pub struct DataFlowContext<O> {
     priv words_per_id: uint,
 
     // mapping from node to bitset index.
-    priv nodeid_to_bitset: HashMap<ast::node_id,uint>,
+    priv nodeid_to_bitset: HashMap<ast::NodeId,uint>,
 
     // Bit sets per id.  The following three fields (`gens`, `kills`,
     // and `on_entry`) all have the same structure. For each id in
@@ -93,7 +93,7 @@ enum LoopKind {
 }
 
 struct LoopScope<'self> {
-    loop_id: ast::node_id,
+    loop_id: ast::NodeId,
     loop_kind: LoopKind,
     break_bits: ~[uint]
 }
@@ -126,7 +126,7 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
         }
     }
 
-    pub fn add_gen(&mut self, id: ast::node_id, bit: uint) {
+    pub fn add_gen(&mut self, id: ast::NodeId, bit: uint) {
         //! Indicates that `id` generates `bit`
 
         debug!("add_gen(id=%?, bit=%?)", id, bit);
@@ -137,7 +137,7 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
         }
     }
 
-    pub fn add_kill(&mut self, id: ast::node_id, bit: uint) {
+    pub fn add_kill(&mut self, id: ast::NodeId, bit: uint) {
         //! Indicates that `id` kills `bit`
 
         debug!("add_kill(id=%?, bit=%?)", id, bit);
@@ -148,7 +148,7 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
         }
     }
 
-    fn apply_gen_kill(&mut self, id: ast::node_id, bits: &mut [uint]) {
+    fn apply_gen_kill(&mut self, id: ast::NodeId, bits: &mut [uint]) {
         //! Applies the gen and kill sets for `id` to `bits`
 
         debug!("apply_gen_kill(id=%?, bits=%s) [before]",
@@ -163,7 +163,7 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
                id, mut_bits_to_str(bits));
     }
 
-    fn apply_kill(&mut self, id: ast::node_id, bits: &mut [uint]) {
+    fn apply_kill(&mut self, id: ast::NodeId, bits: &mut [uint]) {
         debug!("apply_kill(id=%?, bits=%s) [before]",
                id, mut_bits_to_str(bits));
         let (start, end) = self.compute_id_range(id);
@@ -173,14 +173,14 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
                id, mut_bits_to_str(bits));
     }
 
-    fn compute_id_range_frozen(&self, id: ast::node_id) -> (uint, uint) {
+    fn compute_id_range_frozen(&self, id: ast::NodeId) -> (uint, uint) {
         let n = *self.nodeid_to_bitset.get(&id);
         let start = n * self.words_per_id;
         let end = start + self.words_per_id;
         (start, end)
     }
 
-    fn compute_id_range(&mut self, id: ast::node_id) -> (uint, uint) {
+    fn compute_id_range(&mut self, id: ast::NodeId) -> (uint, uint) {
         let mut expanded = false;
         let len = self.nodeid_to_bitset.len();
         let n = do self.nodeid_to_bitset.find_or_insert_with(id) |_| {
@@ -208,7 +208,7 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
 
 
     pub fn each_bit_on_entry_frozen(&self,
-                                    id: ast::node_id,
+                                    id: ast::NodeId,
                                     f: &fn(uint) -> bool) -> bool {
         //! Iterates through each bit that is set on entry to `id`.
         //! Only useful after `propagate()` has been called.
@@ -223,7 +223,7 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
     }
 
     pub fn each_bit_on_entry(&mut self,
-                             id: ast::node_id,
+                             id: ast::NodeId,
                              f: &fn(uint) -> bool) -> bool {
         //! Iterates through each bit that is set on entry to `id`.
         //! Only useful after `propagate()` has been called.
@@ -236,7 +236,7 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
     }
 
     pub fn each_gen_bit(&mut self,
-                        id: ast::node_id,
+                        id: ast::NodeId,
                         f: &fn(uint) -> bool) -> bool {
         //! Iterates through each bit in the gen set for `id`.
 
@@ -248,7 +248,7 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
     }
 
     pub fn each_gen_bit_frozen(&self,
-                               id: ast::node_id,
+                               id: ast::NodeId,
                                f: &fn(uint) -> bool) -> bool {
         //! Iterates through each bit in the gen set for `id`.
         if !self.nodeid_to_bitset.contains_key(&id) {
@@ -851,8 +851,8 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
     }
 
     fn walk_call(&mut self,
-                 _callee_id: ast::node_id,
-                 call_id: ast::node_id,
+                 _callee_id: ast::NodeId,
+                 call_id: ast::NodeId,
                  arg0: @ast::expr,
                  args: &[@ast::expr],
                  in_out: &mut [uint],
@@ -949,7 +949,7 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
         for bits.mut_iter().advance |b| { *b = e; }
     }
 
-    fn add_to_entry_set(&mut self, id: ast::node_id, pred_bits: &[uint]) {
+    fn add_to_entry_set(&mut self, id: ast::NodeId, pred_bits: &[uint]) {
         debug!("add_to_entry_set(id=%?, pred_bits=%s)",
                id, bits_to_str(pred_bits));
         let (start, end) = self.dfcx.compute_id_range(id);
@@ -965,7 +965,7 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
     }
 
     fn merge_with_entry_set(&mut self,
-                            id: ast::node_id,
+                            id: ast::NodeId,
                             pred_bits: &mut [uint]) {
         debug!("merge_with_entry_set(id=%?, pred_bits=%s)",
                id, mut_bits_to_str(pred_bits));

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -17,7 +17,7 @@ use middle::typeck::method_map;
 use util::ppaux;
 
 use syntax::ast::{deref, expr_call, expr_inline_asm, expr_method_call};
-use syntax::ast::{expr_unary, node_id, unsafe_blk, unsafe_fn, expr_path};
+use syntax::ast::{expr_unary, unsafe_fn, expr_path};
 use syntax::ast;
 use syntax::codemap::span;
 use syntax::visit::{fk_item_fn, fk_method};
@@ -27,7 +27,7 @@ use syntax::visit;
 enum UnsafeContext {
     SafeContext,
     UnsafeFn,
-    UnsafeBlock(node_id),
+    UnsafeBlock(ast::NodeId),
 }
 
 struct Context {
@@ -99,7 +99,7 @@ pub fn check_crate(tcx: ty::ctxt,
 
         visit_block: |block, (_, visitor)| {
             let old_unsafe_context = context.unsafe_context;
-            if block.rules == unsafe_blk &&
+            if block.rules == ast::UnsafeBlock &&
                     context.unsafe_context == SafeContext {
                 context.unsafe_context = UnsafeBlock(block.id)
             }

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -12,7 +12,7 @@
 use driver::session;
 use driver::session::Session;
 use syntax::parse::token::special_idents;
-use syntax::ast::{Crate, node_id, item, item_fn};
+use syntax::ast::{Crate, NodeId, item, item_fn};
 use syntax::attr;
 use syntax::codemap::span;
 use syntax::visit::{default_visitor, mk_vt, vt, Visitor, visit_crate, visit_item};
@@ -25,17 +25,17 @@ struct EntryContext {
     ast_map: ast_map::map,
 
     // The top-level function called 'main'
-    main_fn: Option<(node_id, span)>,
+    main_fn: Option<(NodeId, span)>,
 
     // The function that has attribute named 'main'
-    attr_main_fn: Option<(node_id, span)>,
+    attr_main_fn: Option<(NodeId, span)>,
 
     // The function that has the attribute 'start' on it
-    start_fn: Option<(node_id, span)>,
+    start_fn: Option<(NodeId, span)>,
 
     // The functions that one might think are 'main' but aren't, e.g.
     // main functions not defined at the top level. For diagnostics.
-    non_main_fns: ~[(node_id, span)],
+    non_main_fns: ~[(NodeId, span)],
 }
 
 type EntryVisitor = vt<@mut EntryContext>;

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -27,7 +27,7 @@ pub struct freevar_entry {
     span: span     //< First span where it is accessed (there can be multiple)
 }
 pub type freevar_info = @~[@freevar_entry];
-pub type freevar_map = @mut HashMap<ast::node_id, freevar_info>;
+pub type freevar_map = @mut HashMap<ast::NodeId, freevar_info>;
 
 // Searches through part of the AST for all references to locals or
 // upvars in this frame and returns the list of definition IDs thus found.
@@ -95,7 +95,7 @@ pub fn annotate_freevars(def_map: resolve::DefMap, crate: &ast::Crate) ->
                      &ast::fn_decl,
                      &ast::Block,
                      span,
-                     ast::node_id) = |_, _, blk, _, nid| {
+                     ast::NodeId) = |_, _, blk, _, nid| {
         let vars = collect_freevars(def_map, blk);
         freevars.insert(nid, vars);
     };
@@ -109,13 +109,13 @@ pub fn annotate_freevars(def_map: resolve::DefMap, crate: &ast::Crate) ->
     return freevars;
 }
 
-pub fn get_freevars(tcx: ty::ctxt, fid: ast::node_id) -> freevar_info {
+pub fn get_freevars(tcx: ty::ctxt, fid: ast::NodeId) -> freevar_info {
     match tcx.freevars.find(&fid) {
       None => fail!("get_freevars: %d has no freevars", fid),
       Some(&d) => return d
     }
 }
 
-pub fn has_freevars(tcx: ty::ctxt, fid: ast::node_id) -> bool {
+pub fn has_freevars(tcx: ty::ctxt, fid: ast::NodeId) -> bool {
     !get_freevars(tcx, fid).is_empty()
 }

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -55,7 +55,7 @@ pub static try_adding: &'static str = "Try adding a move";
 pub struct Context {
     tcx: ty::ctxt,
     method_map: typeck::method_map,
-    current_item: node_id
+    current_item: NodeId
 }
 
 pub fn check_crate(tcx: ty::ctxt,
@@ -156,9 +156,9 @@ fn check_item(item: @item, (cx, visitor): (Context, visit::vt<Context>)) {
 }
 
 // Yields the appropriate function to check the kind of closed over
-// variables. `id` is the node_id for some expression that creates the
+// variables. `id` is the NodeId for some expression that creates the
 // closure.
-fn with_appropriate_checker(cx: Context, id: node_id,
+fn with_appropriate_checker(cx: Context, id: NodeId,
                             b: &fn(checker: &fn(Context, @freevar_entry))) {
     fn check_for_uniq(cx: Context, fv: &freevar_entry, bounds: ty::BuiltinBounds) {
         // all captured data must be owned, regardless of whether it is
@@ -230,7 +230,7 @@ fn check_fn(
     decl: &fn_decl,
     body: &Block,
     sp: span,
-    fn_id: node_id,
+    fn_id: NodeId,
     (cx, v): (Context,
               visit::vt<Context>)) {
 
@@ -348,7 +348,7 @@ pub fn check_builtin_bounds(cx: Context, ty: ty::t, bounds: ty::BuiltinBounds,
 }
 
 pub fn check_typaram_bounds(cx: Context,
-                    _type_parameter_id: node_id,
+                    _type_parameter_id: NodeId,
                     sp: span,
                     ty: ty::t,
                     type_param_def: &ty::TypeParameterDef)

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -874,7 +874,7 @@ fn lint_unused_unsafe() -> visit::vt<@mut Context> {
     visit::mk_vt(@visit::Visitor {
         visit_expr: |e, (cx, vt): (@mut Context, visit::vt<@mut Context>)| {
             match e.node {
-                ast::expr_block(ref blk) if blk.rules == ast::unsafe_blk => {
+                ast::expr_block(ref blk) if blk.rules == ast::UnsafeBlock => {
                     if !cx.tcx.used_unsafe.contains(&blk.id) {
                         cx.span_lint(unused_unsafe, blk.span,
                                      "unnecessary `unsafe` block");

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -60,25 +60,25 @@ use syntax::print::pprust;
 
 #[deriving(Eq)]
 pub enum categorization {
-    cat_rvalue(ast::node_id),          // temporary val, argument is its scope
+    cat_rvalue(ast::NodeId),          // temporary val, argument is its scope
     cat_static_item,
     cat_implicit_self,
     cat_copied_upvar(CopiedUpvar),     // upvar copied into @fn or ~fn env
     cat_stack_upvar(cmt),              // by ref upvar from &fn
-    cat_local(ast::node_id),           // local variable
-    cat_arg(ast::node_id),             // formal argument
+    cat_local(ast::NodeId),           // local variable
+    cat_arg(ast::NodeId),             // formal argument
     cat_deref(cmt, uint, ptr_kind),    // deref of a ptr
     cat_interior(cmt, InteriorKind),   // something interior: field, tuple, etc
     cat_downcast(cmt),                 // selects a particular enum variant (*)
-    cat_discr(cmt, ast::node_id),      // match discriminant (see preserve())
-    cat_self(ast::node_id),            // explicit `self`
+    cat_discr(cmt, ast::NodeId),      // match discriminant (see preserve())
+    cat_self(ast::NodeId),            // explicit `self`
 
     // (*) downcast is only required if the enum has more than one variant
 }
 
 #[deriving(Eq)]
 pub struct CopiedUpvar {
-    upvar_id: ast::node_id,
+    upvar_id: ast::NodeId,
     onceness: ast::Onceness,
 }
 
@@ -136,7 +136,7 @@ pub enum MutabilityCategory {
 // fashion. For more details, see the method `cat_pattern`
 #[deriving(Eq)]
 pub struct cmt_ {
-    id: ast::node_id,          // id of expr/pat producing this value
+    id: ast::NodeId,          // id of expr/pat producing this value
     span: span,                // span of same expr/pat
     cat: categorization,       // categorization of expr
     mutbl: MutabilityCategory, // mutability of expr as lvalue
@@ -252,7 +252,7 @@ pub fn cat_expr_autoderefd(
 pub fn cat_def(
     tcx: ty::ctxt,
     method_map: typeck::method_map,
-    expr_id: ast::node_id,
+    expr_id: ast::NodeId,
     expr_span: span,
     expr_ty: ty::t,
     def: ast::def) -> cmt {
@@ -264,17 +264,17 @@ pub fn cat_def(
 }
 
 pub trait ast_node {
-    fn id(&self) -> ast::node_id;
+    fn id(&self) -> ast::NodeId;
     fn span(&self) -> span;
 }
 
 impl ast_node for @ast::expr {
-    fn id(&self) -> ast::node_id { self.id }
+    fn id(&self) -> ast::NodeId { self.id }
     fn span(&self) -> span { self.span }
 }
 
 impl ast_node for @ast::pat {
-    fn id(&self) -> ast::node_id { self.id }
+    fn id(&self) -> ast::NodeId { self.id }
     fn span(&self) -> span { self.span }
 }
 
@@ -439,7 +439,7 @@ impl mem_categorization_ctxt {
     }
 
     pub fn cat_def(&self,
-                   id: ast::node_id,
+                   id: ast::NodeId,
                    span: span,
                    expr_ty: ty::t,
                    def: ast::def)
@@ -587,9 +587,9 @@ impl mem_categorization_ctxt {
     }
 
     pub fn cat_rvalue(&self,
-                      cmt_id: ast::node_id,
+                      cmt_id: ast::NodeId,
                       span: span,
-                      cleanup_scope_id: ast::node_id,
+                      cleanup_scope_id: ast::NodeId,
                       expr_ty: ty::t) -> cmt {
         @cmt_ {
             id:cmt_id,
@@ -1069,7 +1069,7 @@ impl mem_categorization_ctxt {
 pub fn field_mutbl(tcx: ty::ctxt,
                    base_ty: ty::t,
                    f_name: ast::ident,
-                   node_id: ast::node_id)
+                   node_id: ast::NodeId)
                 -> Option<ast::mutability> {
     // Need to refactor so that struct/enum fields can be treated uniformly.
     match ty::get(base_ty).sty {

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -157,9 +157,9 @@ pub struct CaptureVar {
     mode: CaptureMode // How variable is being accessed
 }
 
-pub type CaptureMap = @mut HashMap<node_id, @[CaptureVar]>;
+pub type CaptureMap = @mut HashMap<NodeId, @[CaptureVar]>;
 
-pub type MovesMap = @mut HashSet<node_id>;
+pub type MovesMap = @mut HashSet<NodeId>;
 
 /**
  * Set of variable node-ids that are moved.
@@ -167,7 +167,7 @@ pub type MovesMap = @mut HashSet<node_id>;
  * Note: The `VariableMovesMap` stores expression ids that
  * are moves, whereas this set stores the ids of the variables
  * that are moved at some point */
-pub type MovedVariablesSet = @mut HashSet<node_id>;
+pub type MovedVariablesSet = @mut HashSet<NodeId>;
 
 /** See the section Output on the module comment for explanation. */
 #[deriving(Clone)]
@@ -213,7 +213,7 @@ pub fn compute_moves(tcx: ty::ctxt,
     return visit_cx.move_maps;
 }
 
-pub fn moved_variable_node_id_from_def(def: def) -> Option<node_id> {
+pub fn moved_variable_node_id_from_def(def: def) -> Option<NodeId> {
     match def {
       def_binding(nid, _) |
       def_arg(nid, _) |
@@ -240,7 +240,7 @@ fn compute_modes_for_fn(fk: &visit::fn_kind,
                         decl: &fn_decl,
                         body: &Block,
                         span: span,
-                        id: node_id,
+                        id: NodeId,
                         (cx, v): (VisitContext,
                                   vt<VisitContext>)) {
     for decl.inputs.iter().advance |a| {
@@ -634,7 +634,7 @@ impl VisitContext {
     }
 
     pub fn use_fn_args(&self,
-                       _: node_id,
+                       _: NodeId,
                        arg_exprs: &[@expr],
                        visitor: vt<VisitContext>) {
         //! Uses the argument expressions.
@@ -664,7 +664,7 @@ impl VisitContext {
         return None;
     }
 
-    pub fn compute_captures(&self, fn_expr_id: node_id) -> @[CaptureVar] {
+    pub fn compute_captures(&self, fn_expr_id: NodeId) -> @[CaptureVar] {
         debug!("compute_capture_vars(fn_expr_id=%?)", fn_expr_id);
         let _indenter = indenter();
 

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -16,10 +16,10 @@ use syntax::ast::*;
 use syntax::ast_util::{path_to_ident, walk_pat};
 use syntax::codemap::span;
 
-pub type PatIdMap = HashMap<ident, node_id>;
+pub type PatIdMap = HashMap<ident, NodeId>;
 
 // This is used because same-named variables in alternative patterns need to
-// use the node_id of their namesake in the first pattern.
+// use the NodeId of their namesake in the first pattern.
 pub fn pat_id_map(dm: resolve::DefMap, pat: @pat) -> PatIdMap {
     let mut map = HashMap::new();
     do pat_bindings(dm, pat) |_bm, p_id, _s, n| {
@@ -71,7 +71,7 @@ pub fn pat_is_binding_or_wild(dm: resolve::DefMap, pat: @pat) -> bool {
 }
 
 pub fn pat_bindings(dm: resolve::DefMap, pat: @pat,
-                    it: &fn(binding_mode, node_id, span, &Path)) {
+                    it: &fn(binding_mode, NodeId, span, &Path)) {
     for walk_pat(pat) |p| {
         match p.node {
           pat_ident(binding_mode, ref pth, _) if pat_is_binding(dm, p) => {
@@ -82,7 +82,7 @@ pub fn pat_bindings(dm: resolve::DefMap, pat: @pat,
     }
 }
 
-pub fn pat_binding_ids(dm: resolve::DefMap, pat: @pat) -> ~[node_id] {
+pub fn pat_binding_ids(dm: resolve::DefMap, pat: @pat) -> ~[NodeId] {
     let mut found = ~[];
     pat_bindings(dm, pat, |_bm, b_id, _sp, _pt| found.push(b_id) );
     return found;

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -184,7 +184,7 @@ use syntax::print::pprust::pat_to_str;
 // An option identifying a literal: either a unit-like struct or an
 // expression.
 pub enum Lit {
-    UnitLikeStructLit(ast::node_id),    // the node ID of the pattern
+    UnitLikeStructLit(ast::NodeId),    // the node ID of the pattern
     ExprLit(@ast::expr),
     ConstLit(ast::def_id),              // the def ID of the constant
 }
@@ -292,7 +292,7 @@ pub fn trans_opt(bcx: @mut Block, o: &Opt) -> opt_result {
     }
 }
 
-pub fn variant_opt(bcx: @mut Block, pat_id: ast::node_id)
+pub fn variant_opt(bcx: @mut Block, pat_id: ast::NodeId)
     -> Opt {
     let ccx = bcx.ccx();
     match ccx.tcx.def_map.get_copy(&pat_id) {
@@ -334,7 +334,7 @@ pub enum TransBindingMode {
 pub struct BindingInfo {
     llmatch: ValueRef,
     trmode: TransBindingMode,
-    id: ast::node_id,
+    id: ast::NodeId,
     ty: ty::t,
 }
 
@@ -885,7 +885,7 @@ pub fn extract_variant_args(bcx: @mut Block,
     ExtractedBlock { vals: args, bcx: bcx }
 }
 
-fn match_datum(bcx: @mut Block, val: ValueRef, pat_id: ast::node_id) -> Datum {
+fn match_datum(bcx: @mut Block, val: ValueRef, pat_id: ast::NodeId) -> Datum {
     //! Helper for converting from the ValueRef that we pass around in
     //! the match code, which is always by ref, into a Datum. Eventually
     //! we should just pass around a Datum and be done with it.
@@ -897,7 +897,7 @@ fn match_datum(bcx: @mut Block, val: ValueRef, pat_id: ast::node_id) -> Datum {
 
 pub fn extract_vec_elems(bcx: @mut Block,
                          pat_span: span,
-                         pat_id: ast::node_id,
+                         pat_id: ast::NodeId,
                          elem_count: uint,
                          slice: Option<uint>,
                          val: ValueRef,
@@ -1871,7 +1871,7 @@ pub fn store_arg(mut bcx: @mut Block,
 }
 
 fn mk_binding_alloca(mut bcx: @mut Block,
-                     p_id: ast::node_id,
+                     p_id: ast::NodeId,
                      path: &ast::Path,
                      binding_mode: IrrefutablePatternBindingMode,
                      populate: &fn(@mut Block, ty::t, ValueRef) -> @mut Block) -> @mut Block {

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -106,7 +106,7 @@ pub struct Struct {
  * these, for places in trans where the `ty::t` isn't directly
  * available.
  */
-pub fn represent_node(bcx: @mut Block, node: ast::node_id) -> @Repr {
+pub fn represent_node(bcx: @mut Block, node: ast::NodeId) -> @Repr {
     represent_type(bcx.ccx(), node_id_type(bcx, node))
 }
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -509,12 +509,12 @@ pub fn get_res_dtor(ccx: @mut CrateContext,
                  -> ValueRef {
     let _icx = push_ctxt("trans_res_dtor");
     if !substs.is_empty() {
-        let did = if did.crate != ast::local_crate {
+        let did = if did.crate != ast::LOCAL_CRATE {
             inline::maybe_instantiate_inline(ccx, did)
         } else {
             did
         };
-        assert_eq!(did.crate, ast::local_crate);
+        assert_eq!(did.crate, ast::LOCAL_CRATE);
         let tsubsts = ty::substs {regions: ty::ErasedRegions,
                                   self_ty: None,
                                   tps: /*bad*/ substs.to_owned() };
@@ -526,7 +526,7 @@ pub fn get_res_dtor(ccx: @mut CrateContext,
                                                     None);
 
         val
-    } else if did.crate == ast::local_crate {
+    } else if did.crate == ast::LOCAL_CRATE {
         get_item_val(ccx, did.node)
     } else {
         let tcx = ccx.tcx;
@@ -1012,7 +1012,7 @@ pub fn get_landing_pad(bcx: @mut Block) -> BasicBlockRef {
     return pad_bcx.llbb;
 }
 
-pub fn find_bcx_for_scope(bcx: @mut Block, scope_id: ast::node_id) -> @mut Block {
+pub fn find_bcx_for_scope(bcx: @mut Block, scope_id: ast::NodeId) -> @mut Block {
     let mut bcx_sid = bcx;
     let mut cur_scope = bcx_sid.scope;
     loop {
@@ -1617,7 +1617,7 @@ pub fn make_return_pointer(fcx: @mut FunctionContext, output_type: ty::t) -> Val
 pub fn new_fn_ctxt_w_id(ccx: @mut CrateContext,
                         path: path,
                         llfndecl: ValueRef,
-                        id: ast::node_id,
+                        id: ast::NodeId,
                         output_type: ty::t,
                         skip_retptr: bool,
                         param_substs: Option<@param_substs>,
@@ -1838,7 +1838,7 @@ pub fn trans_closure(ccx: @mut CrateContext,
                      llfndecl: ValueRef,
                      self_arg: self_arg,
                      param_substs: Option<@param_substs>,
-                     id: ast::node_id,
+                     id: ast::NodeId,
                      attributes: &[ast::Attribute],
                      output_type: ty::t,
                      maybe_load_env: &fn(@mut FunctionContext),
@@ -1919,7 +1919,7 @@ pub fn trans_fn(ccx: @mut CrateContext,
                 llfndecl: ValueRef,
                 self_arg: self_arg,
                 param_substs: Option<@param_substs>,
-                id: ast::node_id,
+                id: ast::NodeId,
                 attrs: &[ast::Attribute]) {
 
     let the_path_str = path_str(ccx.sess, path);
@@ -1976,7 +1976,7 @@ fn insert_synthetic_type_entries(bcx: @mut Block,
 }
 
 pub fn trans_enum_variant(ccx: @mut CrateContext,
-                          _enum_id: ast::node_id,
+                          _enum_id: ast::NodeId,
                           variant: &ast::variant,
                           args: &[ast::variant_arg],
                           disr: uint,
@@ -1995,7 +1995,7 @@ pub fn trans_enum_variant(ccx: @mut CrateContext,
 
 pub fn trans_tuple_struct(ccx: @mut CrateContext,
                           fields: &[@ast::struct_field],
-                          ctor_id: ast::node_id,
+                          ctor_id: ast::NodeId,
                           param_substs: Option<@param_substs>,
                           llfndecl: ValueRef) {
     let _icx = push_ctxt("trans_tuple_struct");
@@ -2010,23 +2010,23 @@ pub fn trans_tuple_struct(ccx: @mut CrateContext,
 }
 
 trait IdAndTy {
-    fn id(&self) -> ast::node_id;
+    fn id(&self) -> ast::NodeId;
     fn ty<'a>(&'a self) -> &'a ast::Ty;
 }
 
 impl IdAndTy for ast::variant_arg {
-    fn id(&self) -> ast::node_id { self.id }
+    fn id(&self) -> ast::NodeId { self.id }
     fn ty<'a>(&'a self) -> &'a ast::Ty { &self.ty }
 }
 
 impl IdAndTy for @ast::struct_field {
-    fn id(&self) -> ast::node_id { self.node.id }
+    fn id(&self) -> ast::NodeId { self.node.id }
     fn ty<'a>(&'a self) -> &'a ast::Ty { &self.node.ty }
 }
 
 pub fn trans_enum_variant_or_tuple_like_struct<A:IdAndTy>(
     ccx: @mut CrateContext,
-    ctor_id: ast::node_id,
+    ctor_id: ast::NodeId,
     args: &[A],
     disr: uint,
     param_substs: Option<@param_substs>,
@@ -2104,7 +2104,7 @@ pub fn trans_enum_variant_or_tuple_like_struct<A:IdAndTy>(
 }
 
 pub fn trans_enum_def(ccx: @mut CrateContext, enum_definition: &ast::enum_def,
-                      id: ast::node_id, vi: @~[@ty::VariantInfo],
+                      id: ast::NodeId, vi: @~[@ty::VariantInfo],
                       i: &mut uint) {
     for enum_definition.variants.iter().advance |variant| {
         let disr_val = vi[*i].disr_val;
@@ -2245,7 +2245,7 @@ pub fn trans_mod(ccx: @mut CrateContext, m: &ast::_mod) {
 pub fn register_fn(ccx: @mut CrateContext,
                    sp: span,
                    sym: ~str,
-                   node_id: ast::node_id)
+                   node_id: ast::NodeId)
                 -> ValueRef {
     let t = ty::node_id_to_type(ccx.tcx, node_id);
     register_fn_full(ccx, sp, sym, node_id, t)
@@ -2254,7 +2254,7 @@ pub fn register_fn(ccx: @mut CrateContext,
 pub fn register_fn_full(ccx: @mut CrateContext,
                         sp: span,
                         sym: ~str,
-                        node_id: ast::node_id,
+                        node_id: ast::NodeId,
                         node_type: ty::t)
                      -> ValueRef {
     let llfty = type_of_fn_from_ty(ccx, node_type);
@@ -2265,7 +2265,7 @@ pub fn register_fn_full(ccx: @mut CrateContext,
 pub fn register_fn_fuller(ccx: @mut CrateContext,
                           sp: span,
                           sym: ~str,
-                          node_id: ast::node_id,
+                          node_id: ast::NodeId,
                           node_type: ty::t,
                           cc: lib::llvm::CallConv,
                           fn_ty: Type)
@@ -2287,7 +2287,7 @@ pub fn register_fn_fuller(ccx: @mut CrateContext,
     llfn
 }
 
-pub fn is_entry_fn(sess: &Session, node_id: ast::node_id) -> bool {
+pub fn is_entry_fn(sess: &Session, node_id: ast::NodeId) -> bool {
     match *sess.entry_fn {
         Some((entry_id, _)) => node_id == entry_id,
         None => false
@@ -2367,7 +2367,7 @@ pub fn create_entry_wrapper(ccx: @mut CrateContext,
                     Ok(id) => id,
                     Err(s) => { ccx.tcx.sess.fatal(s); }
                 };
-                let start_fn = if start_def_id.crate == ast::local_crate {
+                let start_fn = if start_def_id.crate == ast::LOCAL_CRATE {
                     get_item_val(ccx, start_def_id.node)
                 } else {
                     let start_fn_type = csearch::get_type(ccx.tcx,
@@ -2421,7 +2421,7 @@ pub fn fill_fn_pair(bcx: @mut Block, pair: ValueRef, llfn: ValueRef,
     Store(bcx, llenvblobptr, env_cell);
 }
 
-pub fn item_path(ccx: &CrateContext, id: &ast::node_id) -> path {
+pub fn item_path(ccx: &CrateContext, id: &ast::NodeId) -> path {
     match ccx.tcx.items.get_copy(id) {
         ast_map::node_item(i, p) =>
             vec::append((*p).clone(), [path_name(i.ident)]),
@@ -2438,7 +2438,7 @@ fn exported_name(ccx: @mut CrateContext, path: path, ty: ty::t, attrs: &[ast::At
     }
 }
 
-pub fn get_item_val(ccx: @mut CrateContext, id: ast::node_id) -> ValueRef {
+pub fn get_item_val(ccx: @mut CrateContext, id: ast::NodeId) -> ValueRef {
     debug!("get_item_val(id=`%?`)", id);
 
     let val = ccx.item_vals.find_copy(&id);
@@ -2601,7 +2601,7 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::node_id) -> ValueRef {
 }
 
 pub fn register_method(ccx: @mut CrateContext,
-                       id: ast::node_id,
+                       id: ast::NodeId,
                        path: @ast_map::path,
                        m: @ast::method) -> ValueRef {
     let mty = ty::node_id_to_type(ccx.tcx, id);
@@ -2623,7 +2623,7 @@ pub fn trans_constant(ccx: &mut CrateContext, it: @ast::item) {
     match it.node {
       ast::item_enum(ref enum_definition, _) => {
         let vi = ty::enum_variants(ccx.tcx,
-                                   ast::def_id { crate: ast::local_crate,
+                                   ast::def_id { crate: ast::LOCAL_CRATE,
                                                  node: it.id });
         let mut i = 0;
         let path = item_path(ccx, &it.id);
@@ -2870,7 +2870,7 @@ pub fn fill_crate_map(ccx: @mut CrateContext, map: ValueRef) {
 
     let llannihilatefn = match ccx.tcx.lang_items.annihilate_fn() {
         Some(annihilate_def_id) => {
-            if annihilate_def_id.crate == ast::local_crate {
+            if annihilate_def_id.crate == ast::LOCAL_CRATE {
                 get_item_val(ccx, annihilate_def_id.node)
             } else {
                 let annihilate_fn_type = csearch::get_type(ccx.tcx,

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -157,14 +157,14 @@ pub fn trans(bcx: @mut Block, expr: @ast::expr) -> Callee {
 
 pub fn trans_fn_ref_to_callee(bcx: @mut Block,
                               def_id: ast::def_id,
-                              ref_id: ast::node_id) -> Callee {
+                              ref_id: ast::NodeId) -> Callee {
     Callee {bcx: bcx,
             data: Fn(trans_fn_ref(bcx, def_id, ref_id))}
 }
 
 pub fn trans_fn_ref(bcx: @mut Block,
                     def_id: ast::def_id,
-                    ref_id: ast::node_id) -> FnData {
+                    ref_id: ast::NodeId) -> FnData {
     /*!
      *
      * Translates a reference (with id `ref_id`) to the fn/method
@@ -184,7 +184,7 @@ pub fn trans_fn_ref(bcx: @mut Block,
 pub fn trans_fn_ref_with_vtables_to_callee(
         bcx: @mut Block,
         def_id: ast::def_id,
-        ref_id: ast::node_id,
+        ref_id: ast::NodeId,
         type_params: &[ty::t],
         vtables: Option<typeck::vtable_res>)
      -> Callee {
@@ -238,7 +238,7 @@ fn resolve_default_method_vtables(bcx: @mut Block,
 pub fn trans_fn_ref_with_vtables(
         bcx: @mut Block,       //
         def_id: ast::def_id,   // def id of fn
-        ref_id: ast::node_id,  // node id of use of fn; may be zero if N/A
+        ref_id: ast::NodeId,  // node id of use of fn; may be zero if N/A
         type_params: &[ty::t], // values for fn's ty params
         vtables: Option<typeck::vtable_res>) // vtables for the call
      -> FnData {
@@ -334,7 +334,7 @@ pub fn trans_fn_ref_with_vtables(
     // Check whether this fn has an inlined copy and, if so, redirect
     // def_id to the local id of the inlined copy.
     let def_id = {
-        if def_id.crate != ast::local_crate {
+        if def_id.crate != ast::LOCAL_CRATE {
             inline::maybe_instantiate_inline(ccx, def_id)
         } else {
             def_id
@@ -348,7 +348,7 @@ pub fn trans_fn_ref_with_vtables(
     let must_monomorphise;
     if type_params.len() > 0 || is_default {
         must_monomorphise = true;
-    } else if def_id.crate == ast::local_crate {
+    } else if def_id.crate == ast::LOCAL_CRATE {
         let map_node = session::expect(
             ccx.sess,
             ccx.tcx.items.find(&def_id.node),
@@ -369,7 +369,7 @@ pub fn trans_fn_ref_with_vtables(
     // Create a monomorphic verison of generic functions
     if must_monomorphise {
         // Should be either intra-crate or inlined.
-        assert_eq!(def_id.crate, ast::local_crate);
+        assert_eq!(def_id.crate, ast::LOCAL_CRATE);
 
         let (val, must_cast) =
             monomorphize::monomorphic_fn(ccx, def_id, &substs,
@@ -389,7 +389,7 @@ pub fn trans_fn_ref_with_vtables(
 
     // Find the actual function pointer.
     let val = {
-        if def_id.crate == ast::local_crate {
+        if def_id.crate == ast::LOCAL_CRATE {
             // Internal reference.
             get_item_val(ccx, def_id.node)
         } else {
@@ -408,7 +408,7 @@ pub fn trans_call(in_cx: @mut Block,
                   call_ex: @ast::expr,
                   f: @ast::expr,
                   args: CallArgs,
-                  id: ast::node_id,
+                  id: ast::NodeId,
                   dest: expr::Dest)
                   -> @mut Block {
     let _icx = push_ctxt("trans_call");
@@ -424,7 +424,7 @@ pub fn trans_call(in_cx: @mut Block,
 
 pub fn trans_method_call(in_cx: @mut Block,
                          call_ex: @ast::expr,
-                         callee_id: ast::node_id,
+                         callee_id: ast::NodeId,
                          rcvr: @ast::expr,
                          args: CallArgs,
                          dest: expr::Dest)
@@ -465,7 +465,7 @@ pub fn trans_lang_call(bcx: @mut Block,
                        args: &[ValueRef],
                        dest: Option<expr::Dest>)
     -> Result {
-    let fty = if did.crate == ast::local_crate {
+    let fty = if did.crate == ast::LOCAL_CRATE {
         ty::node_id_to_type(bcx.ccx().tcx, did.node)
     } else {
         csearch::get_type(bcx.ccx().tcx, did).ty
@@ -494,7 +494,7 @@ pub fn trans_lang_call_with_type_params(bcx: @mut Block,
                                         dest: expr::Dest)
     -> @mut Block {
     let fty;
-    if did.crate == ast::local_crate {
+    if did.crate == ast::LOCAL_CRATE {
         fty = ty::node_id_to_type(bcx.tcx(), did.node);
     } else {
         fty = csearch::get_type(bcx.tcx(), did).ty;

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -359,8 +359,8 @@ pub fn trans_expr_fn(bcx: @mut Block,
                      sigil: ast::Sigil,
                      decl: &ast::fn_decl,
                      body: &ast::Block,
-                     outer_id: ast::node_id,
-                     user_id: ast::node_id,
+                     outer_id: ast::NodeId,
+                     user_id: ast::NodeId,
                      is_loop_body: Option<Option<ValueRef>>,
                      dest: expr::Dest) -> @mut Block {
     /*!

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -203,16 +203,16 @@ pub struct FunctionContext {
     has_immediate_return_value: bool,
 
     // Maps arguments to allocas created for them in llallocas.
-    llargs: @mut HashMap<ast::node_id, ValueRef>,
+    llargs: @mut HashMap<ast::NodeId, ValueRef>,
     // Maps the def_ids for local variables to the allocas created for
     // them in llallocas.
-    lllocals: @mut HashMap<ast::node_id, ValueRef>,
+    lllocals: @mut HashMap<ast::NodeId, ValueRef>,
     // Same as above, but for closure upvars
-    llupvars: @mut HashMap<ast::node_id, ValueRef>,
+    llupvars: @mut HashMap<ast::NodeId, ValueRef>,
 
-    // The node_id of the function, or -1 if it doesn't correspond to
+    // The NodeId of the function, or -1 if it doesn't correspond to
     // a user-defined function.
-    id: ast::node_id,
+    id: ast::NodeId,
 
     // If this function is being monomorphized, this contains the type
     // substitutions used.
@@ -361,13 +361,13 @@ pub fn add_clean_temp_mem(bcx: @mut Block, val: ValueRef, t: ty::t) {
 }
 
 pub fn add_clean_temp_mem_in_scope(bcx: @mut Block,
-                                   scope_id: ast::node_id,
+                                   scope_id: ast::NodeId,
                                    val: ValueRef,
                                    t: ty::t) {
     add_clean_temp_mem_in_scope_(bcx, Some(scope_id), val, t);
 }
 
-pub fn add_clean_temp_mem_in_scope_(bcx: @mut Block, scope_id: Option<ast::node_id>,
+pub fn add_clean_temp_mem_in_scope_(bcx: @mut Block, scope_id: Option<ast::NodeId>,
                                     val: ValueRef, t: ty::t) {
     if !ty::type_needs_drop(bcx.tcx(), t) { return; }
     debug!("add_clean_temp_mem(%s, %s, %s)",
@@ -380,7 +380,7 @@ pub fn add_clean_temp_mem_in_scope_(bcx: @mut Block, scope_id: Option<ast::node_
     }
 }
 pub fn add_clean_return_to_mut(bcx: @mut Block,
-                               scope_id: ast::node_id,
+                               scope_id: ast::NodeId,
                                root_key: root_map_key,
                                frozen_val_ref: ValueRef,
                                bits_val_ref: ValueRef,
@@ -504,8 +504,8 @@ impl get_node_info for Option<@ast::expr> {
 }
 
 pub struct NodeInfo {
-    id: ast::node_id,
-    callee_id: Option<ast::node_id>,
+    id: ast::NodeId,
+    callee_id: Option<ast::NodeId>,
     span: span
 }
 
@@ -563,7 +563,7 @@ impl Block {
         token::ident_to_str(&ident)
     }
 
-    pub fn node_id_to_str(&self, id: ast::node_id) -> ~str {
+    pub fn node_id_to_str(&self, id: ast::NodeId) -> ~str {
         ast_map::node_id_to_str(self.tcx().items, id, self.sess().intr())
     }
 
@@ -579,7 +579,7 @@ impl Block {
         ty::expr_kind(self.tcx(), self.ccx().maps.method_map, e)
     }
 
-    pub fn def(&self, nid: ast::node_id) -> ast::def {
+    pub fn def(&self, nid: ast::NodeId) -> ast::def {
         match self.tcx().def_map.find(&nid) {
             Some(&v) => v,
             None => {
@@ -633,7 +633,7 @@ pub fn val_ty(v: ValueRef) -> Type {
     }
 }
 
-pub fn in_scope_cx(cx: @mut Block, scope_id: Option<ast::node_id>, f: &fn(si: &mut ScopeInfo)) {
+pub fn in_scope_cx(cx: @mut Block, scope_id: Option<ast::NodeId>, f: &fn(si: &mut ScopeInfo)) {
     let mut cur = cx;
     let mut cur_scope = cur.scope;
     loop {
@@ -971,7 +971,7 @@ pub fn monomorphize_type(bcx: @mut Block, t: ty::t) -> ty::t {
     }
 }
 
-pub fn node_id_type(bcx: @mut Block, id: ast::node_id) -> ty::t {
+pub fn node_id_type(bcx: @mut Block, id: ast::NodeId) -> ty::t {
     let tcx = bcx.tcx();
     let t = ty::node_id_to_type(tcx, id);
     monomorphize_type(bcx, t)
@@ -987,7 +987,7 @@ pub fn expr_ty_adjusted(bcx: @mut Block, ex: &ast::expr) -> ty::t {
     monomorphize_type(bcx, t)
 }
 
-pub fn node_id_type_params(bcx: @mut Block, id: ast::node_id) -> ~[ty::t] {
+pub fn node_id_type_params(bcx: @mut Block, id: ast::NodeId) -> ~[ty::t] {
     let tcx = bcx.tcx();
     let params = ty::node_id_to_type_params(tcx, id);
 
@@ -1007,7 +1007,7 @@ pub fn node_id_type_params(bcx: @mut Block, id: ast::node_id) -> ~[ty::t] {
     }
 }
 
-pub fn node_vtables(bcx: @mut Block, id: ast::node_id)
+pub fn node_vtables(bcx: @mut Block, id: ast::NodeId)
                  -> Option<typeck::vtable_res> {
     let raw_vtables = bcx.ccx().maps.vtable_map.find(&id);
     raw_vtables.map(

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -601,7 +601,7 @@ fn const_expr_unadjusted(cx: @mut CrateContext, e: &ast::expr) -> ValueRef {
     }
 }
 
-pub fn trans_const(ccx: @mut CrateContext, m: ast::mutability, id: ast::node_id) {
+pub fn trans_const(ccx: @mut CrateContext, m: ast::mutability, id: ast::NodeId) {
     unsafe {
         let _icx = push_ctxt("trans_const");
         let g = base::get_item_val(ccx, id);

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -43,20 +43,20 @@ pub struct CrateContext {
      tn: TypeNames,
      externs: ExternMap,
      intrinsics: HashMap<&'static str, ValueRef>,
-     item_vals: HashMap<ast::node_id, ValueRef>,
+     item_vals: HashMap<ast::NodeId, ValueRef>,
      exp_map2: resolve::ExportMap2,
-     reachable: @mut HashSet<ast::node_id>,
-     item_symbols: HashMap<ast::node_id, ~str>,
+     reachable: @mut HashSet<ast::NodeId>,
+     item_symbols: HashMap<ast::NodeId, ~str>,
      link_meta: LinkMeta,
      enum_sizes: HashMap<ty::t, uint>,
      discrims: HashMap<ast::def_id, ValueRef>,
-     discrim_symbols: HashMap<ast::node_id, @str>,
+     discrim_symbols: HashMap<ast::NodeId, @str>,
      tydescs: HashMap<ty::t, @mut tydesc_info>,
      // Set when running emit_tydescs to enforce that no more tydescs are
      // created.
      finished_tydescs: bool,
      // Track mapping of external ids to local items imported for inlining
-     external: HashMap<ast::def_id, Option<ast::node_id>>,
+     external: HashMap<ast::def_id, Option<ast::NodeId>>,
      // Cache instances of monomorphized functions
      monomorphized: HashMap<mono_id, ValueRef>,
      monomorphizing: HashMap<ast::def_id, uint>,
@@ -78,7 +78,7 @@ pub struct CrateContext {
      const_globals: HashMap<int, ValueRef>,
 
      // Cache of emitted const values
-     const_values: HashMap<ast::node_id, ValueRef>,
+     const_values: HashMap<ast::NodeId, ValueRef>,
 
      // Cache of external const values
      extern_const_values: HashMap<ast::def_id, ValueRef>,
@@ -119,7 +119,7 @@ impl CrateContext {
                maps: astencode::Maps,
                symbol_hasher: hash::State,
                link_meta: LinkMeta,
-               reachable: @mut HashSet<ast::node_id>)
+               reachable: @mut HashSet<ast::NodeId>)
                -> CrateContext {
         unsafe {
             let llcx = llvm::LLVMContextCreate();

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -614,7 +614,7 @@ impl Datum {
     pub fn try_deref(&self,
                      bcx: @mut Block,
                      span: span,
-                     expr_id: ast::node_id,
+                     expr_id: ast::NodeId,
                      derefs: uint,
                      is_auto: bool)
                      -> (Option<Datum>, @mut Block) {
@@ -740,7 +740,7 @@ impl Datum {
     pub fn autoderef(&self,
                      bcx: @mut Block,
                      span: span,
-                     expr_id: ast::node_id,
+                     expr_id: ast::NodeId,
                      max: uint)
                      -> DatumBlock {
         let _icx = push_ctxt("autoderef");
@@ -773,7 +773,7 @@ impl Datum {
     pub fn get_vec_base_and_len(&self,
                                 mut bcx: @mut Block,
                                 span: span,
-                                expr_id: ast::node_id,
+                                expr_id: ast::NodeId,
                                 derefs: uint)
                                 -> (@mut Block, ValueRef, ValueRef) {
         //! Converts a vector into the slice pair. Performs rooting
@@ -797,7 +797,7 @@ impl Datum {
     pub fn root_and_write_guard(&self,
                                 bcx: @mut Block,
                                 span: span,
-                                expr_id: ast::node_id,
+                                expr_id: ast::NodeId,
                                 derefs: uint)
                                 -> @mut Block {
         write_guard::root_and_write_guard(self, bcx, span, expr_id, derefs)

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -96,10 +96,10 @@ pub struct DebugContext {
     priv builder: DIBuilderRef,
     priv curr_loc: (uint, uint),
     priv created_files: HashMap<~str, DIFile>,
-    priv created_functions: HashMap<ast::node_id, DISubprogram>,
-    priv created_blocks: HashMap<ast::node_id, DILexicalBlock>,
+    priv created_functions: HashMap<ast::NodeId, DISubprogram>,
+    priv created_blocks: HashMap<ast::NodeId, DILexicalBlock>,
     priv created_types: HashMap<uint, DIType>,
-    priv last_function_context_id: ast::node_id,
+    priv last_function_context_id: ast::NodeId,
     priv argument_counter: uint,
 }
 

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -943,7 +943,7 @@ fn trans_lvalue_unadjusted(bcx: @mut Block, expr: @ast::expr) -> DatumBlock {
 
                 fn get_did(ccx: @mut CrateContext, did: ast::def_id)
                     -> ast::def_id {
-                    if did.crate != ast::local_crate {
+                    if did.crate != ast::LOCAL_CRATE {
                         inline::maybe_instantiate_inline(ccx, did)
                     } else {
                         did
@@ -953,7 +953,7 @@ fn trans_lvalue_unadjusted(bcx: @mut Block, expr: @ast::expr) -> DatumBlock {
                 fn get_val(bcx: @mut Block, did: ast::def_id, const_ty: ty::t)
                            -> ValueRef {
                     // For external constants, we don't inline.
-                    if did.crate == ast::local_crate {
+                    if did.crate == ast::LOCAL_CRATE {
                         // The LLVM global has the type of its initializer,
                         // which may not be equal to the enum's type for
                         // non-C-like enums.
@@ -1057,8 +1057,8 @@ pub fn trans_local_var(bcx: @mut Block, def: ast::def) -> Datum {
     };
 
     fn take_local(bcx: @mut Block,
-                  table: &HashMap<ast::node_id, ValueRef>,
-                  nid: ast::node_id) -> Datum {
+                  table: &HashMap<ast::NodeId, ValueRef>,
+                  nid: ast::NodeId) -> Datum {
         let v = match table.find(&nid) {
             Some(&v) => v,
             None => {
@@ -1082,7 +1082,7 @@ pub fn trans_local_var(bcx: @mut Block, def: ast::def) -> Datum {
 // is and `node_id_opt` is none, this function fails).
 pub fn with_field_tys<R>(tcx: ty::ctxt,
                          ty: ty::t,
-                         node_id_opt: Option<ast::node_id>,
+                         node_id_opt: Option<ast::NodeId>,
                          op: &fn(uint, (&[ty::field])) -> R) -> R {
     match ty::get(ty).sty {
         ty::ty_struct(did, ref substs) => {
@@ -1127,7 +1127,7 @@ fn trans_rec_or_struct(bcx: @mut Block,
                        fields: &[ast::Field],
                        base: Option<@ast::expr>,
                        expr_span: codemap::span,
-                       id: ast::node_id,
+                       id: ast::NodeId,
                        dest: Dest) -> @mut Block
 {
     let _icx = push_ctxt("trans_rec");
@@ -1529,7 +1529,7 @@ fn trans_binary(bcx: @mut Block,
 
 fn trans_overloaded_op(bcx: @mut Block,
                        expr: &ast::expr,
-                       callee_id: ast::node_id,
+                       callee_id: ast::NodeId,
                        rcvr: @ast::expr,
                        args: ~[@ast::expr],
                        ret_ty: ty::t,
@@ -1605,7 +1605,7 @@ pub fn cast_type_kind(t: ty::t) -> cast_kind {
 }
 
 fn trans_imm_cast(bcx: @mut Block, expr: @ast::expr,
-                  id: ast::node_id) -> DatumBlock {
+                  id: ast::NodeId) -> DatumBlock {
     let _icx = push_ctxt("trans_cast");
     let ccx = bcx.ccx();
 
@@ -1668,7 +1668,7 @@ fn trans_imm_cast(bcx: @mut Block, expr: @ast::expr,
 
 fn trans_assign_op(bcx: @mut Block,
                    expr: @ast::expr,
-                   callee_id: ast::node_id,
+                   callee_id: ast::NodeId,
                    op: ast::binop,
                    dst: @ast::expr,
                    src: @ast::expr) -> @mut Block

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -108,7 +108,7 @@ fn foreign_signature(ccx: &mut CrateContext, fn_sig: &ty::FnSig)
     }
 }
 
-fn shim_types(ccx: @mut CrateContext, id: ast::node_id) -> ShimTypes {
+fn shim_types(ccx: @mut CrateContext, id: ast::NodeId) -> ShimTypes {
     let fn_sig = match ty::get(ty::node_id_to_type(ccx.tcx, id)).sty {
         ty::ty_bare_fn(ref fn_ty) => fn_ty.sig.clone(),
         _ => ccx.sess.bug("c_arg_and_ret_lltys called on non-function type")
@@ -338,7 +338,7 @@ pub fn trans_foreign_mod(ccx: @mut CrateContext,
     }
 
     fn build_foreign_fn(ccx: @mut CrateContext,
-                        id: ast::node_id,
+                        id: ast::NodeId,
                         foreign_item: @ast::foreign_item,
                         cc: lib::llvm::CallConv) {
         let llwrapfn = get_item_val(ccx, id);
@@ -537,7 +537,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
                        path: ast_map::path,
                        substs: @param_substs,
                        attributes: &[ast::Attribute],
-                       ref_id: Option<ast::node_id>) {
+                       ref_id: Option<ast::NodeId>) {
     debug!("trans_intrinsic(item.ident=%s)", ccx.sess.str_of(item.ident));
 
     fn simple_llvm_intrinsic(bcx: @mut Block, name: &'static str, num_args: uint) {
@@ -975,14 +975,14 @@ pub fn trans_foreign_fn(ccx: @mut CrateContext,
                         decl: &ast::fn_decl,
                         body: &ast::Block,
                         llwrapfn: ValueRef,
-                        id: ast::node_id) {
+                        id: ast::NodeId) {
     let _icx = push_ctxt("foreign::build_foreign_fn");
 
     fn build_rust_fn(ccx: @mut CrateContext,
                      path: &ast_map::path,
                      decl: &ast::fn_decl,
                      body: &ast::Block,
-                     id: ast::node_id)
+                     id: ast::NodeId)
                   -> ValueRef {
         let _icx = push_ctxt("foreign::foreign::build_rust_fn");
         let t = ty::node_id_to_type(ccx.tcx, id);
@@ -1145,7 +1145,7 @@ pub fn trans_foreign_fn(ccx: @mut CrateContext,
 pub fn register_foreign_fn(ccx: @mut CrateContext,
                            sp: span,
                            sym: ~str,
-                           node_id: ast::node_id)
+                           node_id: ast::NodeId)
                            -> ValueRef {
     let _icx = push_ctxt("foreign::register_foreign_fn");
 

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -48,7 +48,7 @@ pub fn trans_impl(ccx: @mut CrateContext,
                   name: ast::ident,
                   methods: &[@ast::method],
                   generics: &ast::Generics,
-                  id: ast::node_id) {
+                  id: ast::NodeId) {
     let _icx = push_ctxt("impl::trans_impl");
     let tcx = ccx.tcx;
 
@@ -142,7 +142,7 @@ pub fn trans_self_arg(bcx: @mut Block,
 }
 
 pub fn trans_method_callee(bcx: @mut Block,
-                           callee_id: ast::node_id,
+                           callee_id: ast::NodeId,
                            this: @ast::expr,
                            mentry: typeck::method_map_entry)
                            -> Callee {
@@ -201,7 +201,7 @@ pub fn trans_method_callee(bcx: @mut Block,
 pub fn trans_static_method_callee(bcx: @mut Block,
                                   method_id: ast::def_id,
                                   trait_id: ast::def_id,
-                                  callee_id: ast::node_id)
+                                  callee_id: ast::NodeId)
                                -> FnData {
     let _icx = push_ctxt("impl::trans_static_method_callee");
     let ccx = bcx.ccx();
@@ -229,7 +229,7 @@ pub fn trans_static_method_callee(bcx: @mut Block,
     let bound_index = ty::lookup_trait_def(bcx.tcx(), trait_id).
         generics.type_param_defs.len();
 
-    let mname = if method_id.crate == ast::local_crate {
+    let mname = if method_id.crate == ast::LOCAL_CRATE {
         match bcx.tcx().items.get_copy(&method_id.node) {
             ast_map::node_trait_method(trait_method, _, _) => {
                 ast_util::trait_method_to_ty_method(trait_method).ident
@@ -296,7 +296,7 @@ pub fn method_with_name(ccx: &mut CrateContext,
 }
 
 pub fn trans_monomorphized_callee(bcx: @mut Block,
-                                  callee_id: ast::node_id,
+                                  callee_id: ast::NodeId,
                                   base: @ast::expr,
                                   mentry: typeck::method_map_entry,
                                   trait_id: ast::def_id,
@@ -355,7 +355,7 @@ pub fn trans_monomorphized_callee(bcx: @mut Block,
 
 pub fn combine_impl_and_methods_tps(bcx: @mut Block,
                                     mth_did: ast::def_id,
-                                    callee_id: ast::node_id,
+                                    callee_id: ast::NodeId,
                                     rcvr_substs: &[ty::t],
                                     rcvr_origins: typeck::vtable_res)
                                     -> (~[ty::t], typeck::vtable_res) {
@@ -404,7 +404,7 @@ pub fn combine_impl_and_methods_tps(bcx: @mut Block,
 
 
 pub fn trans_trait_callee(bcx: @mut Block,
-                          callee_id: ast::node_id,
+                          callee_id: ast::NodeId,
                           n_method: uint,
                           self_expr: @ast::expr,
                           store: ty::TraitStore,
@@ -662,7 +662,7 @@ pub fn make_impl_vtable(bcx: @mut Block,
 
 pub fn trans_trait_cast(bcx: @mut Block,
                         val: @ast::expr,
-                        id: ast::node_id,
+                        id: ast::NodeId,
                         dest: expr::Dest,
                         _store: ty::TraitStore)
                      -> @mut Block {

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -42,7 +42,7 @@ pub fn monomorphic_fn(ccx: @mut CrateContext,
                       real_substs: &ty::substs,
                       vtables: Option<typeck::vtable_res>,
                       self_vtables: Option<typeck::vtable_param_res>,
-                      ref_id: Option<ast::node_id>)
+                      ref_id: Option<ast::NodeId>)
     -> (ValueRef, bool)
 {
     debug!("monomorphic_fn(\

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -72,7 +72,7 @@ pub fn type_uses_for(ccx: @mut CrateContext, fn_id: def_id, n_tps: uint)
       None => ()
     }
 
-    let fn_id_loc = if fn_id.crate == local_crate {
+    let fn_id_loc = if fn_id.crate == LOCAL_CRATE {
         fn_id
     } else {
         inline::maybe_instantiate_inline(ccx, fn_id)
@@ -93,7 +93,7 @@ pub fn type_uses_for(ccx: @mut CrateContext, fn_id: def_id, n_tps: uint)
     let is_default = ty::provided_source(ccx.tcx, fn_id_loc).is_some();
     // We also mark all of the params as used if it is an extern thing
     // that we haven't been able to inline yet.
-    if is_default || fn_id_loc.crate != local_crate {
+    if is_default || fn_id_loc.crate != LOCAL_CRATE {
         for uint::range(0u, n_tps) |n| { cx.uses[n] |= use_all; }
         return store_type_uses(cx, fn_id);
     }
@@ -260,11 +260,11 @@ pub fn type_needs_inner(cx: &Context,
     }
 }
 
-pub fn node_type_needs(cx: &Context, use_: uint, id: node_id) {
+pub fn node_type_needs(cx: &Context, use_: uint, id: NodeId) {
     type_needs(cx, use_, ty::node_id_to_type(cx.ccx.tcx, id));
 }
 
-pub fn mark_for_method_call(cx: &Context, e_id: node_id, callee_id: node_id) {
+pub fn mark_for_method_call(cx: &Context, e_id: NodeId, callee_id: NodeId) {
     let mut opt_static_did = None;
     {
         let r = cx.ccx.maps.method_map.find(&e_id);

--- a/src/librustc/middle/trans/write_guard.rs
+++ b/src/librustc/middle/trans/write_guard.rs
@@ -36,7 +36,7 @@ use middle::trans::type_::Type;
 pub fn root_and_write_guard(datum: &Datum,
                             mut bcx: @mut Block,
                             span: span,
-                            expr_id: ast::node_id,
+                            expr_id: ast::NodeId,
                             derefs: uint) -> @mut Block {
     let key = root_map_key { id: expr_id, derefs: derefs };
     debug!("write_guard::root_and_write_guard(key=%?)", key);

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -323,7 +323,7 @@ pub fn check_struct_pat_fields(pcx: &pat_ctxt,
     }
 }
 
-pub fn check_struct_pat(pcx: &pat_ctxt, pat_id: ast::node_id, span: span,
+pub fn check_struct_pat(pcx: &pat_ctxt, pat_id: ast::NodeId, span: span,
                         expected: ty::t, path: &ast::Path,
                         fields: &[ast::field_pat], etc: bool,
                         class_id: ast::def_id, substitutions: &ty::substs) {
@@ -355,7 +355,7 @@ pub fn check_struct_pat(pcx: &pat_ctxt, pat_id: ast::node_id, span: span,
 }
 
 pub fn check_struct_like_enum_variant_pat(pcx: &pat_ctxt,
-                                          pat_id: ast::node_id,
+                                          pat_id: ast::NodeId,
                                           span: span,
                                           expected: ty::t,
                                           path: &ast::Path,
@@ -619,7 +619,7 @@ pub fn check_pat(pcx: &pat_ctxt, pat: @ast::pat, expected: ty::t) {
 pub fn check_pointer_pat(pcx: &pat_ctxt,
                          pointer_kind: PointerKind,
                          inner: @ast::pat,
-                         pat_id: ast::node_id,
+                         pat_id: ast::NodeId,
                          span: span,
                          expected: ty::t) {
     let fcx = pcx.fcx;

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -101,7 +101,7 @@ use std::uint;
 use std::vec;
 use extra::list::Nil;
 use syntax::ast::{def_id, sty_value, sty_region, sty_box};
-use syntax::ast::{sty_uniq, sty_static, node_id};
+use syntax::ast::{sty_uniq, sty_static, NodeId};
 use syntax::ast::{m_const, m_mutbl, m_imm};
 use syntax::ast;
 use syntax::ast_map;
@@ -124,7 +124,7 @@ pub fn lookup(
         // In a call `a.b::<X, Y, ...>(...)`:
         expr: @ast::expr,                   // The expression `a.b(...)`.
         self_expr: @ast::expr,              // The expression `a`.
-        callee_id: node_id,                 /* Where to store `a.b`'s type,
+        callee_id: NodeId,                  /* Where to store `a.b`'s type,
                                              * also the scope of the call */
         m_name: ast::ident,                 // The ident `b`.
         self_ty: ty::t,                     // The type of `a`.
@@ -157,7 +157,7 @@ pub struct LookupContext<'self> {
     fcx: @mut FnCtxt,
     expr: @ast::expr,
     self_expr: @ast::expr,
-    callee_id: node_id,
+    callee_id: NodeId,
     m_name: ast::ident,
     supplied_tps: &'self [ty::t],
     impl_dups: @mut HashSet<def_id>,
@@ -1147,7 +1147,7 @@ impl<'self> LookupContext<'self> {
     }
 
     pub fn report_static_candidate(&self, idx: uint, did: def_id) {
-        let span = if did.crate == ast::local_crate {
+        let span = if did.crate == ast::LOCAL_CRATE {
             match self.tcx().items.find(&did.node) {
               Some(&ast_map::node_method(m, _, _)) => m.span,
               _ => fail!("report_static_candidate: bad item %?", did)

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -51,7 +51,7 @@ pub struct Rcx {
     errors_reported: uint,
 
     // id of innermost fn or loop
-    repeating_scope: ast::node_id,
+    repeating_scope: ast::NodeId,
 }
 
 pub type rvt = visit::vt<@mut Rcx>;
@@ -81,7 +81,7 @@ impl Rcx {
         self.fcx.ccx.tcx
     }
 
-    pub fn set_repeating_scope(&mut self, scope: ast::node_id) -> ast::node_id {
+    pub fn set_repeating_scope(&mut self, scope: ast::NodeId) -> ast::NodeId {
         let old_scope = self.repeating_scope;
         self.repeating_scope = scope;
         old_scope
@@ -124,7 +124,7 @@ impl Rcx {
     }
 
     /// Try to resolve the type for the given node.
-    pub fn resolve_node_type(@mut self, id: ast::node_id) -> ty::t {
+    pub fn resolve_node_type(@mut self, id: ast::NodeId) -> ty::t {
         self.resolve_type(self.fcx.node_ty(id))
     }
 
@@ -500,7 +500,7 @@ fn check_expr_fn_block(rcx: @mut Rcx,
 }
 
 fn constrain_callee(rcx: @mut Rcx,
-                    callee_id: ast::node_id,
+                    callee_id: ast::NodeId,
                     call_expr: @ast::expr,
                     callee_expr: @ast::expr)
 {
@@ -527,7 +527,7 @@ fn constrain_callee(rcx: @mut Rcx,
 fn constrain_call(rcx: @mut Rcx,
                   // might be expr_call, expr_method_call, or an overloaded
                   // operator
-                  callee_id: ast::node_id,
+                  callee_id: ast::NodeId,
                   call_expr: @ast::expr,
                   receiver: Option<@ast::expr>,
                   arg_exprs: &[@ast::expr],
@@ -680,7 +680,7 @@ fn constrain_free_variables(rcx: @mut Rcx,
 
 fn constrain_regions_in_type_of_node(
     rcx: @mut Rcx,
-    id: ast::node_id,
+    id: ast::NodeId,
     minimum_lifetime: ty::Region,
     origin: infer::SubregionOrigin) -> bool
 {
@@ -895,7 +895,7 @@ pub mod guarantor {
 
     pub fn for_by_ref(rcx: @mut Rcx,
                       expr: @ast::expr,
-                      callee_scope: ast::node_id) {
+                      callee_scope: ast::NodeId) {
         /*!
          * Computes the guarantor for cases where the `expr` is
          * being passed by implicit reference and must outlive
@@ -918,7 +918,7 @@ pub mod guarantor {
     fn link(
         rcx: @mut Rcx,
         span: span,
-        id: ast::node_id,
+        id: ast::NodeId,
         guarantor: Option<ty::Region>) {
         /*!
          *

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -62,7 +62,7 @@ use syntax::visit;
 /// if the vtable instantiation is being performed as part of "deriving".)
 pub struct LocationInfo {
     span: span,
-    id: ast::node_id
+    id: ast::NodeId
 }
 
 /// A vtable context includes an inference context, a crate context, and a
@@ -522,7 +522,7 @@ fn connect_trait_tps(vcx: &VtableContext,
 }
 
 fn insert_vtables(fcx: @mut FnCtxt,
-                  callee_id: ast::node_id,
+                  callee_id: ast::NodeId,
                   vtables: vtable_res) {
     debug!("insert_vtables(callee_id=%d, vtables=%?)",
            callee_id, vtables.repr(fcx.tcx()));

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -59,7 +59,7 @@ fn resolve_type_vars_in_types(fcx: @mut FnCtxt, sp: span, tys: &[ty::t])
     })
 }
 
-fn resolve_method_map_entry(fcx: @mut FnCtxt, sp: span, id: ast::node_id) {
+fn resolve_method_map_entry(fcx: @mut FnCtxt, sp: span, id: ast::NodeId) {
     // Resolve any method map entry
     match fcx.inh.method_map.find(&id) {
         None => {}
@@ -79,7 +79,7 @@ fn resolve_method_map_entry(fcx: @mut FnCtxt, sp: span, id: ast::node_id) {
     }
 }
 
-fn resolve_vtable_map_entry(fcx: @mut FnCtxt, sp: span, id: ast::node_id) {
+fn resolve_vtable_map_entry(fcx: @mut FnCtxt, sp: span, id: ast::NodeId) {
     // Resolve any method map entry
     match fcx.inh.vtable_map.find(&id) {
         None => {}
@@ -113,7 +113,7 @@ fn resolve_vtable_map_entry(fcx: @mut FnCtxt, sp: span, id: ast::node_id) {
     }
 }
 
-fn resolve_type_vars_for_node(wbcx: @mut WbCtxt, sp: span, id: ast::node_id)
+fn resolve_type_vars_for_node(wbcx: @mut WbCtxt, sp: span, id: ast::NodeId)
                            -> Option<ty::t> {
     let fcx = wbcx.fcx;
     let tcx = fcx.ccx.tcx;
@@ -195,7 +195,7 @@ fn resolve_type_vars_for_node(wbcx: @mut WbCtxt, sp: span, id: ast::node_id)
 
 fn maybe_resolve_type_vars_for_node(wbcx: @mut WbCtxt,
                                     sp: span,
-                                    id: ast::node_id)
+                                    id: ast::NodeId)
                                  -> Option<ty::t> {
     if wbcx.fcx.inh.node_types.contains_key(&id) {
         resolve_type_vars_for_node(wbcx, sp, id)

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -38,7 +38,7 @@ use middle::typeck::infer::{new_infer_ctxt, resolve_ivar, resolve_type};
 use middle::typeck::infer;
 use syntax::ast::{Crate, def_id, def_struct, def_ty};
 use syntax::ast::{item, item_enum, item_impl, item_mod, item_struct};
-use syntax::ast::{local_crate, trait_ref, ty_path};
+use syntax::ast::{LOCAL_CRATE, trait_ref, ty_path};
 use syntax::ast;
 use syntax::ast_map::node_item;
 use syntax::ast_map;
@@ -114,7 +114,7 @@ pub fn type_is_defined_in_local_crate(original_type: t) -> bool {
             ty_enum(def_id, _) |
             ty_trait(def_id, _, _, _, _) |
             ty_struct(def_id, _) => {
-                if def_id.crate == ast::local_crate {
+                if def_id.crate == ast::LOCAL_CRATE {
                     found_nominal = true;
                 }
             }
@@ -513,7 +513,7 @@ impl CoherenceChecker {
                             let trait_def_id =
                                 self.trait_ref_to_trait_def_id(trait_ref);
 
-                            if trait_def_id.crate != local_crate {
+                            if trait_def_id.crate != LOCAL_CRATE {
                                 let session = self.crate_context.tcx.sess;
                                 session.span_err(item.span,
                                                  "cannot provide an extension implementation \
@@ -575,7 +575,7 @@ impl CoherenceChecker {
             ty_path(_, _, path_id) => {
                 match self.crate_context.tcx.def_map.get_copy(&path_id) {
                     def_ty(def_id) | def_struct(def_id) => {
-                        if def_id.crate != local_crate {
+                        if def_id.crate != LOCAL_CRATE {
                             return false;
                         }
 
@@ -647,7 +647,7 @@ impl CoherenceChecker {
     }
 
     pub fn span_of_impl(&self, implementation: @Impl) -> span {
-        assert_eq!(implementation.did.crate, local_crate);
+        assert_eq!(implementation.did.crate, LOCAL_CRATE);
         match self.crate_context.tcx.items.find(&implementation.did.node) {
             Some(&node_item(item, _)) => {
                 return item.span;
@@ -783,7 +783,7 @@ impl CoherenceChecker {
                 }
                 _ => {
                     // Destructors only work on nominal types.
-                    if impl_info.did.crate == ast::local_crate {
+                    if impl_info.did.crate == ast::LOCAL_CRATE {
                         match tcx.items.find(&impl_info.did.node) {
                             Some(&ast_map::node_item(@ref item, _)) => {
                                 tcx.sess.span_err((*item).span,

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -107,7 +107,7 @@ impl AstConv for CrateCtxt {
     fn tcx(&self) -> ty::ctxt { self.tcx }
 
     fn get_item_ty(&self, id: ast::def_id) -> ty::ty_param_bounds_and_ty {
-        if id.crate != ast::local_crate {
+        if id.crate != ast::LOCAL_CRATE {
             csearch::get_type(self.tcx, id)
         } else {
             match self.tcx.items.find(&id.node) {
@@ -195,7 +195,7 @@ pub fn get_enum_variant_types(ccx: &CrateCtxt,
 }
 
 pub fn ensure_trait_methods(ccx: &CrateCtxt,
-                            trait_id: ast::node_id)
+                            trait_id: ast::NodeId)
 {
     let tcx = ccx.tcx;
     let region_paramd = tcx.region_paramd_items.find(&trait_id).map(|&x| *x);
@@ -248,7 +248,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
     }
 
     fn make_static_method_ty(ccx: &CrateCtxt,
-                             trait_id: ast::node_id,
+                             trait_id: ast::NodeId,
                              m: &ty::Method,
                              trait_ty_generics: &ty::Generics) {
         // If declaration is
@@ -352,10 +352,10 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
     }
 
     fn ty_method_of_trait_method(this: &CrateCtxt,
-                                 trait_id: ast::node_id,
+                                 trait_id: ast::NodeId,
                                  trait_rp: Option<ty::region_variance>,
                                  trait_generics: &ast::Generics,
-                                 m_id: &ast::node_id,
+                                 m_id: &ast::NodeId,
                                  m_ident: &ast::ident,
                                  m_explicit_self: &ast::explicit_self,
                                  m_generics: &ast::Generics,
@@ -384,7 +384,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
 }
 
 pub fn ensure_supertraits(ccx: &CrateCtxt,
-                          id: ast::node_id,
+                          id: ast::NodeId,
                           sp: codemap::span,
                           rp: Option<ty::region_variance>,
                           ast_trait_refs: &[ast::trait_ref],
@@ -666,7 +666,7 @@ pub fn check_methods_against_trait(ccx: &CrateCtxt,
     let trait_ref = instantiate_trait_ref(ccx, a_trait_ty, rp,
                                           generics, selfty);
 
-    if trait_ref.def_id.crate == ast::local_crate {
+    if trait_ref.def_id.crate == ast::LOCAL_CRATE {
         ensure_trait_methods(ccx, trait_ref.def_id.node);
     }
 
@@ -716,13 +716,13 @@ pub fn convert_field(ccx: &CrateCtxt,
 
 pub struct ConvertedMethod {
     mty: @ty::Method,
-    id: ast::node_id,
+    id: ast::NodeId,
     span: span,
-    body_id: ast::node_id
+    body_id: ast::NodeId
 }
 
 pub fn convert_methods(ccx: &CrateCtxt,
-                       container_id: ast::node_id,
+                       container_id: ast::NodeId,
                        ms: &[@ast::method],
                        untransformed_rcvr_ty: ty::t,
                        rcvr_ty_generics: &ty::Generics,
@@ -763,7 +763,7 @@ pub fn convert_methods(ccx: &CrateCtxt,
     }).collect();
 
     fn ty_of_method(ccx: &CrateCtxt,
-                    container_id: ast::node_id,
+                    container_id: ast::NodeId,
                     m: &ast::method,
                     rp: Option<ty::region_variance>,
                     untransformed_rcvr_ty: ty::t,
@@ -908,7 +908,7 @@ pub fn convert_struct(ccx: &CrateCtxt,
                       struct_def: &ast::struct_def,
                       generics: &ast::Generics,
                       tpt: ty::ty_param_bounds_and_ty,
-                      id: ast::node_id) {
+                      id: ast::NodeId) {
     let tcx = ccx.tcx;
 
     // Write the type of each of the members
@@ -1002,7 +1002,7 @@ pub fn instantiate_trait_ref(ccx: &CrateCtxt,
 }
 
 fn get_trait_def(ccx: &CrateCtxt, trait_id: ast::def_id) -> @ty::TraitDef {
-    if trait_id.crate != ast::local_crate {
+    if trait_id.crate != ast::LOCAL_CRATE {
         ty::lookup_trait_def(ccx.tcx, trait_id)
     } else {
         match ccx.tcx.items.get(&trait_id.node) {

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -686,8 +686,8 @@ impl RegionVarBindings {
     fn intersect_scopes(&self,
                         region_a: ty::Region,
                         region_b: ty::Region,
-                        scope_a: ast::node_id,
-                        scope_b: ast::node_id) -> cres<Region>
+                        scope_a: ast::NodeId,
+                        scope_b: ast::NodeId) -> cres<Region>
     {
         // We want to generate the intersection of two
         // scopes or two free regions.  So, if one of

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -128,7 +128,7 @@ pub struct method_map_entry {
 
 // maps from an expression id that corresponds to a method call to the details
 // of the method to be invoked
-pub type method_map = @mut HashMap<ast::node_id, method_map_entry>;
+pub type method_map = @mut HashMap<ast::NodeId, method_map_entry>;
 
 pub type vtable_param_res = @~[vtable_origin];
 // Resolutions for bounds of all parameters, left to right, for a given path.
@@ -172,7 +172,7 @@ impl Repr for vtable_origin {
     }
 }
 
-pub type vtable_map = @mut HashMap<ast::node_id, vtable_res>;
+pub type vtable_map = @mut HashMap<ast::NodeId, vtable_res>;
 
 
 // Information about the vtable resolutions for for a trait impl.
@@ -205,13 +205,13 @@ pub struct CrateCtxt {
 }
 
 // Functions that write types into the node type table
-pub fn write_ty_to_tcx(tcx: ty::ctxt, node_id: ast::node_id, ty: ty::t) {
+pub fn write_ty_to_tcx(tcx: ty::ctxt, node_id: ast::NodeId, ty: ty::t) {
     debug!("write_ty_to_tcx(%d, %s)", node_id, ppaux::ty_to_str(tcx, ty));
     assert!(!ty::type_needs_infer(ty));
     tcx.node_types.insert(node_id as uint, ty);
 }
 pub fn write_substs_to_tcx(tcx: ty::ctxt,
-                           node_id: ast::node_id,
+                           node_id: ast::NodeId,
                            substs: ~[ty::t]) {
     if substs.len() > 0u {
         debug!("write_substs_to_tcx(%d, %?)", node_id,
@@ -221,7 +221,7 @@ pub fn write_substs_to_tcx(tcx: ty::ctxt,
     }
 }
 pub fn write_tpt_to_tcx(tcx: ty::ctxt,
-                        node_id: ast::node_id,
+                        node_id: ast::NodeId,
                         tpt: &ty::ty_param_substs_and_ty) {
     write_ty_to_tcx(tcx, node_id, tpt.ty);
     if !tpt.substs.tps.is_empty() {
@@ -229,7 +229,7 @@ pub fn write_tpt_to_tcx(tcx: ty::ctxt,
     }
 }
 
-pub fn lookup_def_tcx(tcx: ty::ctxt, sp: span, id: ast::node_id) -> ast::def {
+pub fn lookup_def_tcx(tcx: ty::ctxt, sp: span, id: ast::NodeId) -> ast::def {
     match tcx.def_map.find(&id) {
       Some(&x) => x,
       _ => {
@@ -238,7 +238,7 @@ pub fn lookup_def_tcx(tcx: ty::ctxt, sp: span, id: ast::node_id) -> ast::def {
     }
 }
 
-pub fn lookup_def_ccx(ccx: &CrateCtxt, sp: span, id: ast::node_id)
+pub fn lookup_def_ccx(ccx: &CrateCtxt, sp: span, id: ast::NodeId)
                    -> ast::def {
     lookup_def_tcx(ccx.tcx, sp, id)
 }
@@ -308,7 +308,7 @@ impl get_and_find_region for isr_alist {
 }
 
 fn check_main_fn_ty(ccx: &CrateCtxt,
-                    main_id: ast::node_id,
+                    main_id: ast::NodeId,
                     main_span: span) {
     let tcx = ccx.tcx;
     let main_t = ty::node_id_to_type(tcx, main_id);
@@ -352,7 +352,7 @@ fn check_main_fn_ty(ccx: &CrateCtxt,
 }
 
 fn check_start_fn_ty(ccx: &CrateCtxt,
-                     start_id: ast::node_id,
+                     start_id: ast::NodeId,
                      start_span: span) {
     let tcx = ccx.tcx;
     let start_t = ty::node_id_to_type(tcx, start_id);

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -112,4 +112,4 @@ pub fn pluralize(n: uint, s: ~str) -> ~str {
 }
 
 // A set of node IDs (used to keep track of which node IDs are for statements)
-pub type stmt_set = @mut HashSet<ast::node_id>;
+pub type stmt_set = @mut HashSet<ast::NodeId>;

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -165,7 +165,7 @@ pub fn bound_region_to_str(cx: ctxt,
     }
 }
 
-pub fn re_scope_id_to_str(cx: ctxt, node_id: ast::node_id) -> ~str {
+pub fn re_scope_id_to_str(cx: ctxt, node_id: ast::NodeId) -> ~str {
     match cx.items.find(&node_id) {
       Some(&ast_map::node_block(ref blk)) => {
         fmt!("<block at %s>",
@@ -643,7 +643,7 @@ impl Repr for ast::def_id {
         // Unfortunately, there seems to be no way to attempt to print
         // a path for a def-id, so I'll just make a best effort for now
         // and otherwise fallback to just printing the crate/node pair
-        if self.crate == ast::local_crate {
+        if self.crate == ast::LOCAL_CRATE {
             match tcx.items.find(&self.node) {
                 Some(&ast_map::node_item(*)) |
                 Some(&ast_map::node_foreign_item(*)) |

--- a/src/librustdoc/attr_pass.rs
+++ b/src/librustdoc/attr_pass.rs
@@ -84,7 +84,7 @@ fn fold_item(
     let srv = fold.ctxt.clone();
     let doc = fold::default_seq_fold_item(fold, doc);
 
-    let desc = if doc.id == ast::crate_node_id {
+    let desc = if doc.id == ast::CRATE_NODE_ID {
         // This is the top-level mod, use the crate attributes
         do astsrv::exec(srv) |ctxt| {
             attr_parser::parse_desc(ctxt.ast.attrs.clone())

--- a/src/librustdoc/extract.rs
+++ b/src/librustdoc/extract.rs
@@ -60,11 +60,11 @@ fn top_moddoc_from_crate(
     crate: @ast::Crate,
     default_name: ~str
 ) -> doc::ModDoc {
-    moddoc_from_mod(mk_itemdoc(ast::crate_node_id, default_name),
+    moddoc_from_mod(mk_itemdoc(ast::CRATE_NODE_ID, default_name),
                     crate.module.clone())
 }
 
-fn mk_itemdoc(id: ast::node_id, name: ~str) -> doc::ItemDoc {
+fn mk_itemdoc(id: ast::NodeId, name: ~str) -> doc::ItemDoc {
     doc::ItemDoc {
         id: id,
         name: name,

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -138,7 +138,7 @@ fn write_header_(ctxt: &Ctxt, lvl: Hlvl, title: ~str) {
 pub fn header_kind(doc: doc::ItemTag) -> ~str {
     match doc {
         doc::ModTag(_) => {
-            if doc.id() == syntax::ast::crate_node_id {
+            if doc.id() == syntax::ast::CRATE_NODE_ID {
                 ~"Crate"
             } else {
                 ~"Module"
@@ -174,7 +174,7 @@ pub fn header_kind(doc: doc::ItemTag) -> ~str {
 pub fn header_name(doc: doc::ItemTag) -> ~str {
     let fullpath = (doc.path() + &[doc.name_()]).connect("::");
     match &doc {
-        &doc::ModTag(_) if doc.id() != syntax::ast::crate_node_id => {
+        &doc::ModTag(_) if doc.id() != syntax::ast::CRATE_NODE_ID => {
             fullpath
         }
         &doc::NmodTag(_) => {

--- a/src/librustdoc/page_pass.rs
+++ b/src/librustdoc/page_pass.rs
@@ -106,7 +106,7 @@ fn fold_crate(fold: &fold::Fold<PageChan>, doc: doc::CrateDoc)
 fn fold_mod(fold: &fold::Fold<PageChan>, doc: doc::ModDoc) -> doc::ModDoc {
     let doc = fold::default_any_fold_mod(fold, doc);
 
-    if doc.id() != ast::crate_node_id {
+    if doc.id() != ast::CRATE_NODE_ID {
 
         let doc = strip_mod(doc.clone());
         let page = doc::ItemPage(doc::ModTag(doc));

--- a/src/librustdoc/path_pass.rs
+++ b/src/librustdoc/path_pass.rs
@@ -66,7 +66,7 @@ fn fold_item(fold: &fold::Fold<Ctxt>, doc: doc::ItemDoc) -> doc::ItemDoc {
 }
 
 fn fold_mod(fold: &fold::Fold<Ctxt>, doc: doc::ModDoc) -> doc::ModDoc {
-    let is_topmod = doc.id() == ast::crate_node_id;
+    let is_topmod = doc.id() == ast::CRATE_NODE_ID;
 
     if !is_topmod { fold.ctxt.path.push(doc.name_()); }
     let doc = fold::default_any_fold_mod(fold, doc);

--- a/src/librusti/utils.rs
+++ b/src/librusti/utils.rs
@@ -14,7 +14,7 @@ use syntax::print::pp;
 use syntax::print::pprust;
 use syntax::parse::token;
 
-pub fn each_binding(l: @ast::Local, f: @fn(&ast::Path, ast::node_id)) {
+pub fn each_binding(l: @ast::Local, f: @fn(&ast::Path, ast::NodeId)) {
     use syntax::visit;
 
     let vt = visit::mk_simple_visitor(

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -94,7 +94,7 @@ pub type fn_ident = Option<ident>;
 
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub struct Lifetime {
-    id: node_id,
+    id: NodeId,
     span: span,
     ident: ident
 }
@@ -119,16 +119,16 @@ pub struct Path {
 
 pub type CrateNum = int;
 
-pub type node_id = int;
+pub type NodeId = int;
 
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub struct def_id {
     crate: CrateNum,
-    node: node_id,
+    node: NodeId,
 }
 
-pub static local_crate: CrateNum = 0;
-pub static crate_node_id: node_id = 0;
+pub static LOCAL_CRATE: CrateNum = 0;
+pub static CRATE_NODE_ID: NodeId = 0;
 
 // The AST represents all type param bounds as types.
 // typeck::collect::compute_bounds matches these against
@@ -143,7 +143,7 @@ pub enum TyParamBound {
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub struct TyParam {
     ident: ident,
-    id: node_id,
+    id: NodeId,
     bounds: OptVec<TyParamBound>
 }
 
@@ -171,28 +171,28 @@ pub enum def {
     def_static_method(/* method */ def_id,
                       /* trait */  Option<def_id>,
                       purity),
-    def_self(node_id, bool /* is_implicit */),
-    def_self_ty(/* trait id */ node_id),
+    def_self(NodeId, bool /* is_implicit */),
+    def_self_ty(/* trait id */ NodeId),
     def_mod(def_id),
     def_foreign_mod(def_id),
     def_static(def_id, bool /* is_mutbl */),
-    def_arg(node_id, bool /* is_mutbl */),
-    def_local(node_id, bool /* is_mutbl */),
+    def_arg(NodeId, bool /* is_mutbl */),
+    def_local(NodeId, bool /* is_mutbl */),
     def_variant(def_id /* enum */, def_id /* variant */),
     def_ty(def_id),
     def_trait(def_id),
     def_prim_ty(prim_ty),
     def_ty_param(def_id, uint),
-    def_binding(node_id, binding_mode),
+    def_binding(NodeId, binding_mode),
     def_use(def_id),
-    def_upvar(node_id,  // id of closed over var
+    def_upvar(NodeId,  // id of closed over var
               @def,     // closed over def
-              node_id,  // expr node that creates the closure
-              node_id), // id for the block/body of the closure expr
+              NodeId,  // expr node that creates the closure
+              NodeId), // id for the block/body of the closure expr
     def_struct(def_id),
-    def_typaram_binder(node_id), /* struct, impl or trait with ty params */
-    def_region(node_id),
-    def_label(node_id),
+    def_typaram_binder(NodeId), /* struct, impl or trait with ty params */
+    def_region(NodeId),
+    def_label(NodeId),
     def_method(def_id /* method */, Option<def_id> /* trait */),
 }
 
@@ -248,14 +248,14 @@ pub struct Block {
     view_items: ~[view_item],
     stmts: ~[@stmt],
     expr: Option<@expr>,
-    id: node_id,
-    rules: blk_check_mode,
+    id: NodeId,
+    rules: BlockCheckMode,
     span: span,
 }
 
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub struct pat {
-    id: node_id,
+    id: NodeId,
     node: pat_,
     span: span,
 }
@@ -280,7 +280,7 @@ pub enum pat_ {
     // is None).
     // In the nullary enum case, the parser can't determine
     // which it is. The resolver determines this, and
-    // records this pattern's node_id in an auxiliary
+    // records this pattern's NodeId in an auxiliary
     // set (of "pat_idents that refer to nullary enums")
     pat_ident(binding_mode, Path, Option<@pat>),
     pat_enum(Path, Option<~[@pat]>), /* "none" means a * pattern where
@@ -371,13 +371,13 @@ pub type stmt = spanned<stmt_>;
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub enum stmt_ {
     // could be an item or a local (let) binding:
-    stmt_decl(@decl, node_id),
+    stmt_decl(@decl, NodeId),
 
     // expr without trailing semi-colon (must have unit type):
-    stmt_expr(@expr, node_id),
+    stmt_expr(@expr, NodeId),
 
     // expr with trailing semi-colon (may have any type):
-    stmt_semi(@expr, node_id),
+    stmt_semi(@expr, NodeId),
 
     // bool: is there a trailing sem-colon?
     stmt_mac(mac, bool),
@@ -391,7 +391,7 @@ pub struct Local {
     ty: Ty,
     pat: @pat,
     init: Option<@expr>,
-    id: node_id,
+    id: NodeId,
     span: span,
 }
 
@@ -420,20 +420,20 @@ pub struct Field {
 }
 
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
-pub enum blk_check_mode {
-    default_blk,
-    unsafe_blk,
+pub enum BlockCheckMode {
+    DefaultBlock,
+    UnsafeBlock,
 }
 
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub struct expr {
-    id: node_id,
+    id: NodeId,
     node: expr_,
     span: span,
 }
 
 impl expr {
-    pub fn get_callee_id(&self) -> Option<node_id> {
+    pub fn get_callee_id(&self) -> Option<NodeId> {
         match self.node {
             expr_method_call(callee_id, _, _, _, _, _) |
             expr_index(callee_id, _, _) |
@@ -457,10 +457,10 @@ pub enum expr_ {
     expr_vstore(@expr, expr_vstore),
     expr_vec(~[@expr], mutability),
     expr_call(@expr, ~[@expr], CallSugar),
-    expr_method_call(node_id, @expr, ident, ~[Ty], ~[@expr], CallSugar),
+    expr_method_call(NodeId, @expr, ident, ~[Ty], ~[@expr], CallSugar),
     expr_tup(~[@expr]),
-    expr_binary(node_id, binop, @expr, @expr),
-    expr_unary(node_id, unop, @expr),
+    expr_binary(NodeId, binop, @expr, @expr),
+    expr_unary(NodeId, unop, @expr),
     expr_lit(@lit),
     expr_cast(@expr, Ty),
     expr_if(@expr, Block, Option<@expr>),
@@ -480,9 +480,9 @@ pub enum expr_ {
     expr_block(Block),
 
     expr_assign(@expr, @expr),
-    expr_assign_op(node_id, binop, @expr, @expr),
+    expr_assign_op(NodeId, binop, @expr, @expr),
     expr_field(@expr, ident, ~[Ty]),
-    expr_index(node_id, @expr, @expr),
+    expr_index(NodeId, @expr, @expr),
     expr_path(Path),
 
     /// The special identifier `self`.
@@ -636,22 +636,21 @@ pub struct mt {
 }
 
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
-pub struct ty_field_ {
+pub struct TypeField {
     ident: ident,
     mt: mt,
+    span: span,
 }
 
-pub type ty_field = spanned<ty_field_>;
-
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
-pub struct ty_method {
+pub struct TypeMethod {
     ident: ident,
     attrs: ~[Attribute],
     purity: purity,
     decl: fn_decl,
     generics: Generics,
     explicit_self: explicit_self,
-    id: node_id,
+    id: NodeId,
     span: span,
 }
 
@@ -660,7 +659,7 @@ pub struct ty_method {
 // implementation).
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub enum trait_method {
-    required(ty_method),
+    required(TypeMethod),
     provided(@method),
 }
 
@@ -711,7 +710,7 @@ impl ToStr for float_ty {
 // NB Eq method appears below.
 #[deriving(Clone, Eq, Encodable, Decodable,IterBytes)]
 pub struct Ty {
-    id: node_id,
+    id: NodeId,
     node: ty_,
     span: span,
 }
@@ -778,7 +777,7 @@ pub enum ty_ {
     ty_closure(@TyClosure),
     ty_bare_fn(@TyBareFn),
     ty_tup(~[Ty]),
-    ty_path(Path, Option<OptVec<TyParamBound>>, node_id), // for #7264; see above
+    ty_path(Path, Option<OptVec<TyParamBound>>, NodeId), // for #7264; see above
     ty_mac(mac),
     // ty_infer means the type should be inferred instead of it having been
     // specified. This should only appear at the "top level" of a type and not
@@ -808,7 +807,7 @@ pub struct arg {
     is_mutbl: bool,
     ty: Ty,
     pat: @pat,
-    id: node_id,
+    id: NodeId,
 }
 
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
@@ -863,9 +862,9 @@ pub struct method {
     purity: purity,
     decl: fn_decl,
     body: Block,
-    id: node_id,
+    id: NodeId,
     span: span,
-    self_id: node_id,
+    self_id: NodeId,
     vis: visibility,
 }
 
@@ -893,7 +892,7 @@ pub struct foreign_mod {
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub struct variant_arg {
     ty: Ty,
-    id: node_id,
+    id: NodeId,
 }
 
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
@@ -912,7 +911,7 @@ pub struct variant_ {
     name: ident,
     attrs: ~[Attribute],
     kind: variant_kind,
-    id: node_id,
+    id: NodeId,
     disr_expr: Option<@expr>,
     vis: visibility,
 }
@@ -922,7 +921,7 @@ pub type variant = spanned<variant_>;
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub struct path_list_ident_ {
     name: ident,
-    id: node_id,
+    id: NodeId,
 }
 
 pub type path_list_ident = spanned<path_list_ident_>;
@@ -937,13 +936,13 @@ pub enum view_path_ {
     // or just
     //
     // foo::bar::baz  (with 'baz =' implicitly on the left)
-    view_path_simple(ident, Path, node_id),
+    view_path_simple(ident, Path, NodeId),
 
     // foo::bar::*
-    view_path_glob(Path, node_id),
+    view_path_glob(Path, NodeId),
 
     // foo::bar::{a,b,c}
-    view_path_list(Path, ~[path_list_ident], node_id)
+    view_path_list(Path, ~[path_list_ident], NodeId)
 }
 
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
@@ -956,7 +955,7 @@ pub struct view_item {
 
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub enum view_item_ {
-    view_item_extern_mod(ident, ~[@MetaItem], node_id),
+    view_item_extern_mod(ident, ~[@MetaItem], NodeId),
     view_item_use(~[@view_path]),
 }
 
@@ -990,7 +989,7 @@ pub struct Attribute_ {
 #[deriving(Clone, Eq, Encodable, Decodable,IterBytes)]
 pub struct trait_ref {
     path: Path,
-    ref_id: node_id,
+    ref_id: NodeId,
 }
 
 #[deriving(Clone, Eq, Encodable, Decodable,IterBytes)]
@@ -1012,7 +1011,7 @@ impl visibility {
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub struct struct_field_ {
     kind: struct_field_kind,
-    id: node_id,
+    id: NodeId,
     ty: Ty,
     attrs: ~[Attribute],
 }
@@ -1030,7 +1029,7 @@ pub struct struct_def {
     fields: ~[@struct_field], /* fields, not including ctor */
     /* ID of the constructor. This is only used for tuple- or enum-like
      * structs. */
-    ctor_id: Option<node_id>
+    ctor_id: Option<NodeId>
 }
 
 /*
@@ -1041,7 +1040,7 @@ pub struct struct_def {
 pub struct item {
     ident: ident,
     attrs: ~[Attribute],
-    id: node_id,
+    id: NodeId,
     node: item_,
     vis: visibility,
     span: span,
@@ -1070,7 +1069,7 @@ pub struct foreign_item {
     ident: ident,
     attrs: ~[Attribute],
     node: foreign_item_,
-    id: node_id,
+    id: NodeId,
     span: span,
     vis: visibility,
 }

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -78,7 +78,7 @@ pub enum ast_node {
     node_callee_scope(@expr)
 }
 
-pub type map = @mut HashMap<node_id, ast_node>;
+pub type map = @mut HashMap<NodeId, ast_node>;
 
 pub struct Ctx {
     map: map,
@@ -159,7 +159,7 @@ pub fn map_fn(
     decl: &fn_decl,
     body: &Block,
     sp: codemap::span,
-    id: node_id,
+    id: NodeId,
     (cx,v): (@mut Ctx,
              visit::vt<@mut Ctx>)
 ) {
@@ -313,7 +313,7 @@ pub fn map_stmt(stmt: @stmt, (cx,v): (@mut Ctx, visit::vt<@mut Ctx>)) {
     visit::visit_stmt(stmt, (cx, v));
 }
 
-pub fn node_id_to_str(map: map, id: node_id, itr: @ident_interner) -> ~str {
+pub fn node_id_to_str(map: map, id: NodeId, itr: @ident_interner) -> ~str {
     match map.find(&id) {
       None => {
         fmt!("unknown node (id=%d)", id)
@@ -376,7 +376,7 @@ pub fn node_id_to_str(map: map, id: node_id, itr: @ident_interner) -> ~str {
     }
 }
 
-pub fn node_item_query<Result>(items: map, id: node_id,
+pub fn node_item_query<Result>(items: map, id: NodeId,
                                query: &fn(@item) -> Result,
                                error_msg: ~str) -> Result {
     match items.find(&id) {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -294,7 +294,7 @@ impl ExtCtxt {
         self.print_backtrace();
         self.parse_sess.span_diagnostic.handler().bug(msg);
     }
-    pub fn next_id(&self) -> ast::node_id {
+    pub fn next_id(&self) -> ast::NodeId {
         parse::next_node_id(self.parse_sess)
     }
     pub fn trace_macros(&self) -> bool {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -62,7 +62,7 @@ pub trait AstBuilder {
 
     fn ty_vars(&self, ty_params: &OptVec<ast::TyParam>) -> ~[ast::Ty];
     fn ty_vars_global(&self, ty_params: &OptVec<ast::TyParam>) -> ~[ast::Ty];
-    fn ty_field_imm(&self, span: span, name: ident, ty: ast::Ty) -> ast::ty_field;
+    fn ty_field_imm(&self, span: span, name: ident, ty: ast::Ty) -> ast::TypeField;
     fn strip_bounds(&self, bounds: &Generics) -> Generics;
 
     fn typaram(&self, id: ast::ident, bounds: OptVec<ast::TyParamBound>) -> ast::TyParam;
@@ -306,12 +306,12 @@ impl AstBuilder for @ExtCtxt {
                           ~[ ty ]), None)
     }
 
-    fn ty_field_imm(&self, span: span, name: ident, ty: ast::Ty) -> ast::ty_field {
-        respan(span,
-               ast::ty_field_ {
-                   ident: name,
-                   mt: ast::mt { ty: ~ty, mutbl: ast::m_imm },
-               })
+    fn ty_field_imm(&self, span: span, name: ident, ty: ast::Ty) -> ast::TypeField {
+        ast::TypeField {
+            ident: name,
+            mt: ast::mt { ty: ~ty, mutbl: ast::m_imm },
+            span: span,
+        }
     }
 
     fn ty_infer(&self, span: span) -> ast::Ty {
@@ -404,7 +404,7 @@ impl AstBuilder for @ExtCtxt {
                stmts: stmts,
                expr: expr,
                id: self.next_id(),
-               rules: ast::default_blk,
+               rules: ast::DefaultBlock,
                span: span,
            }
     }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -36,7 +36,7 @@ pub trait ast_fold {
     fn fold_path(@self, &Path) -> Path;
     fn fold_local(@self, @Local) -> @Local;
     fn map_exprs(@self, @fn(@expr) -> @expr, &[@expr]) -> ~[@expr];
-    fn new_id(@self, node_id) -> node_id;
+    fn new_id(@self, NodeId) -> NodeId;
     fn new_span(@self, span) -> span;
 }
 
@@ -65,7 +65,7 @@ pub struct AstFoldFns {
     fold_path: @fn(&Path, @ast_fold) -> Path,
     fold_local: @fn(@Local, @ast_fold) -> @Local,
     map_exprs: @fn(@fn(@expr) -> @expr, &[@expr]) -> ~[@expr],
-    new_id: @fn(node_id) -> node_id,
+    new_id: @fn(NodeId) -> NodeId,
     new_span: @fn(span) -> span
 }
 
@@ -646,12 +646,10 @@ pub fn noop_fold_ty(t: &ty_, fld: @ast_fold) -> ty_ {
             mutbl: mt.mutbl,
         }
     }
-    fn fold_field(f: ty_field, fld: @ast_fold) -> ty_field {
-        spanned {
-            node: ast::ty_field_ {
-                ident: fld.fold_ident(f.node.ident),
-                mt: fold_mt(&f.node.mt, fld),
-            },
+    fn fold_field(f: TypeField, fld: @ast_fold) -> TypeField {
+        ast::TypeField {
+            ident: fld.fold_ident(f.ident),
+            mt: fold_mt(&f.mt, fld),
             span: fld.new_span(f.span),
         }
     }
@@ -787,7 +785,7 @@ fn noop_map_exprs(f: @fn(@expr) -> @expr, es: &[@expr]) -> ~[@expr] {
     es.map(|x| f(*x))
 }
 
-fn noop_id(i: node_id) -> node_id { return i; }
+fn noop_id(i: NodeId) -> NodeId { return i; }
 
 fn noop_span(sp: span) -> span { return sp; }
 
@@ -924,7 +922,7 @@ impl ast_fold for AstFoldFns {
               -> ~[@expr] {
         (self.map_exprs)(f, e)
     }
-    fn new_id(@self, node_id: ast::node_id) -> node_id {
+    fn new_id(@self, node_id: ast::NodeId) -> NodeId {
         (self.new_id)(node_id)
     }
     fn new_span(@self, span: span) -> span {

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -39,7 +39,7 @@ pub fn expr_requires_semi_to_be_stmt(e: @ast::expr) -> bool {
 pub fn expr_is_simple_block(e: @ast::expr) -> bool {
     match e.node {
         ast::expr_block(
-            ast::Block { rules: ast::default_blk, _ }
+            ast::Block { rules: ast::DefaultBlock, _ }
         ) => true,
       _ => false
     }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -11,7 +11,7 @@
 //! The main parser interface
 
 
-use ast::node_id;
+use ast::NodeId;
 use ast;
 use codemap::{span, CodeMap, FileMap, FileSubstr};
 use codemap;
@@ -42,7 +42,7 @@ pub mod obsolete;
 // info about a parsing session.
 pub struct ParseSess {
     cm: @codemap::CodeMap, // better be the same as the one in the reader!
-    next_id: node_id,
+    next_id: NodeId,
     span_diagnostic: @span_handler, // better be the same as the one in the reader!
     /// Used to determine and report recursive mod inclusions
     included_mod_stack: ~[Path],
@@ -202,7 +202,7 @@ pub fn parse_from_source_str<T>(
 }
 
 // return the next unused node id.
-pub fn next_node_id(sess: @mut ParseSess) -> node_id {
+pub fn next_node_id(sess: @mut ParseSess) -> NodeId {
     let rv = sess.next_id;
     sess.next_id += 1;
     // ID 0 is reserved for the crate and doesn't actually exist in the AST
@@ -506,7 +506,7 @@ mod test {
     // check the contents of the tt manually:
     #[test] fn parse_fundecl () {
         // this test depends on the intern order of "fn" and "int", and on the
-        // assignment order of the node_ids.
+        // assignment order of the NodeIds.
         assert_eq!(string_to_item(@"fn a (b : int) { b; }"),
                   Some(
                       @ast::item{ident:str_to_ident("a"),
@@ -566,7 +566,7 @@ mod test {
                                             span: sp(17,18)}],
                                         expr: None,
                                         id: 8, // fixme
-                                        rules: ast::default_blk, // no idea
+                                        rules: ast::DefaultBlock, // no idea
                                         span: sp(15,21),
                                     }),
                             vis: ast::inherited,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -807,7 +807,7 @@ pub fn print_variant(s: @ps, v: &ast::variant) {
     }
 }
 
-pub fn print_ty_method(s: @ps, m: &ast::ty_method) {
+pub fn print_ty_method(s: @ps, m: &ast::TypeMethod) {
     hardbreak_if_not_bol(s);
     maybe_print_comment(s, m.span.lo);
     print_outer_attributes(s, m.attrs);
@@ -948,8 +948,8 @@ pub fn print_possibly_embedded_block_(s: @ps,
                                       attrs: &[ast::Attribute],
                                       close_box: bool) {
     match blk.rules {
-      ast::unsafe_blk => word_space(s, "unsafe"),
-      ast::default_blk => ()
+      ast::UnsafeBlock => word_space(s, "unsafe"),
+      ast::DefaultBlock => ()
     }
     maybe_print_comment(s, blk.span.lo);
     let ann_node = node_block(s, blk);
@@ -1272,7 +1272,7 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
             // in the case of foo => expr
             if arm.body.view_items.is_empty() &&
                 arm.body.stmts.is_empty() &&
-                arm.body.rules == ast::default_blk &&
+                arm.body.rules == ast::DefaultBlock &&
                 arm.body.expr.is_some()
             {
                 match arm.body.expr {

--- a/src/test/compile-fail/qquote-1.rs
+++ b/src/test/compile-fail/qquote-1.rs
@@ -23,7 +23,7 @@ use syntax::print::*;
 
 
 trait fake_ext_ctxt {
-    fn cfg() -> ast::Crate_cfg;
+    fn cfg() -> ast::CrateConfig;
     fn parse_sess() -> parse::parse_sess;
     fn call_site() -> span;
     fn ident_of(st: &str) -> ast::ident;
@@ -32,7 +32,7 @@ trait fake_ext_ctxt {
 type fake_session = parse::parse_sess;
 
 impl fake_ext_ctxt for fake_session {
-    fn cfg() -> ast::Crate_cfg { ~[] }
+    fn cfg() -> ast::CrateConfig { ~[] }
     fn parse_sess() -> parse::parse_sess { self }
     fn call_site() -> span {
         codemap::span {

--- a/src/test/compile-fail/qquote-2.rs
+++ b/src/test/compile-fail/qquote-2.rs
@@ -22,7 +22,7 @@ use syntax::parse::parser;
 use syntax::print::*;
 
 trait fake_ext_ctxt {
-    fn cfg() -> ast::Crate_cfg;
+    fn cfg() -> ast::CrateConfig;
     fn parse_sess() -> parse::parse_sess;
     fn call_site() -> span;
     fn ident_of(st: &str) -> ast::ident;
@@ -31,7 +31,7 @@ trait fake_ext_ctxt {
 type fake_session = parse::parse_sess;
 
 impl fake_ext_ctxt for fake_session {
-    fn cfg() -> ast::Crate_cfg { ~[] }
+    fn cfg() -> ast::CrateConfig { ~[] }
     fn parse_sess() -> parse::parse_sess { self }
     fn call_site() -> span {
         codemap::span {

--- a/src/test/run-pass-fulldeps/issue-1926.rs
+++ b/src/test/run-pass-fulldeps/issue-1926.rs
@@ -32,18 +32,18 @@ fn new_parse_sess() -> parser::parse_sess {
 
 trait fake_ext_ctxt {
     fn session() -> fake_session;
-    fn cfg() -> ast::Crate_cfg;
+    fn cfg() -> ast::CrateConfig;
     fn parse_sess() -> parser::parse_sess;
 }
 
-type fake_options = {cfg: ast::Crate_cfg};
+type fake_options = {cfg: ast::CrateConfig};
 
 type fake_session = {opts: @fake_options,
                      parse_sess: parser::parse_sess};
 
 impl of fake_ext_ctxt for fake_session {
     fn session() -> fake_session {self}
-    fn cfg() -> ast::Crate_cfg { self.opts.cfg }
+    fn cfg() -> ast::CrateConfig { self.opts.cfg }
     fn parse_sess() -> parser::parse_sess { self.parse_sess }
 }
 

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -24,7 +24,7 @@ use syntax::print::*;
 
 
 trait fake_ext_ctxt {
-    fn cfg() -> ast::Crate_cfg;
+    fn cfg() -> ast::CrateConfig;
     fn parse_sess() -> parse::parse_sess;
     fn call_site() -> span;
     fn ident_of(st: &str) -> ast::ident;
@@ -33,7 +33,7 @@ trait fake_ext_ctxt {
 type fake_session = parse::parse_sess;
 
 impl fake_ext_ctxt for fake_session {
-    fn cfg() -> ast::Crate_cfg { ~[] }
+    fn cfg() -> ast::CrateConfig { ~[] }
     fn parse_sess() -> parse::parse_sess { self }
     fn call_site() -> span {
         codemap::span {


### PR DESCRIPTION
Contiunation of naming cleanup in `libsyntax::ast`:

``` rust
ast::node_id => ast::NodeId
ast::local_crate => ast::LOCAL_CRATE
ast::crate_node_id => ast::CRATE_NODE_ID
ast::blk_check_mode => ast::BlockCheckMode
ast::ty_field => ast::TypeField
ast::ty_method => ast::TypeMethod
```

Also moved span field directly into `TypeField` struct and cleaned up overlooked `ast::CrateConfig` renamings from last pull request.

Cheers,
Michael
