### PR TITLE
Do not enforce two newlines after the options

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -85,6 +85,7 @@ pub fn parse_config(args: ~[~str]) -> config {
     if args[1] == ~"-h" || args[1] == ~"--help" {
         let message = fmt!("Usage: %s [OPTIONS] [TESTNAME...]", argv0);
         println(getopts::groups::usage(message, groups));
+        println("");
         fail!()
     }
 
@@ -97,6 +98,7 @@ pub fn parse_config(args: ~[~str]) -> config {
     if getopts::opt_present(matches, "h") || getopts::opt_present(matches, "help") {
         let message = fmt!("Usage: %s [OPTIONS]  [TESTNAME...]", argv0);
         println(getopts::groups::usage(message, groups));
+        println("");
         fail!()
     }
 

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -680,7 +680,7 @@ pub mod groups {
         return brief.to_owned() +
                "\n\nOptions:\n" +
                rows.collect::<~[~str]>().connect("\n") +
-               "\n\n";
+               "\n";
     }
 
     /** Splits a string into substrings with possibly internal whitespace,
@@ -1463,7 +1463,6 @@ Options:
     -k --kiwi           Desc
     -p [VAL]            Desc
     -l VAL              Desc
-
 ";
 
         let generated_usage = groups::usage("Usage: fruits", optgroups);
@@ -1492,7 +1491,6 @@ Options:
     -k --kiwi           This is a long description which won't be wrapped..+..
     -a --apple          This is a long description which _will_ be
                         wrapped..+..
-
 ";
 
         let usage = groups::usage("Usage: fruits", optgroups);

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -191,6 +191,7 @@ fn optgroups() -> ~[getopts::groups::OptGroup] {
 fn usage(binary: &str, helpstr: &str) -> ! {
     let message = fmt!("Usage: %s [OPTIONS] [FILTER]", binary);
     println(groups::usage(message, optgroups()));
+    println("");
     if helpstr == "help" {
         println("\
 The FILTER is matched against the name of all tests to run, and if any tests


### PR DESCRIPTION
It makes things ugly when the last thing you print is the usage() output, resulting in something like:

```
$ rust run foo.rs -h
Lala

Options:
    -h --help           display this help and exit
    -V --version        output version information and exit

$ prompt
```
