### PR TITLE
Foreach in sketch

### DIFF
--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -239,6 +239,8 @@ impl CFGBuilder {
                 expr_exit
             }
 
+            ast::expr_for_loop(*) => fail!("non-desugared expr_for_loop"),
+
             ast::expr_loop(ref body, _) => {
                 //
                 //     [pred]

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -583,6 +583,8 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
                 copy_bits(new_loop_scope.break_bits, in_out);
             }
 
+            ast::expr_for_loop(*) => fail!("non-desugared expr_for_loop"),
+
             ast::expr_loop(ref blk, _) => {
                 //
                 //     (expr) <--+

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -503,6 +503,7 @@ fn visit_expr(expr: @expr, (this, vt): (@mut IrMaps, vt<@mut IrMaps>)) {
         this.add_live_node_for_node(expr.id, ExprNode(expr.span));
         visit::visit_expr(expr, (this, vt));
       }
+      expr_for_loop(*) => fail!("non-desugared expr_for_loop"),
       expr_binary(_, op, _, _) if ast_util::lazy_binop(op) => {
         this.add_live_node_for_node(expr.id, ExprNode(expr.span));
         visit::visit_expr(expr, (this, vt));
@@ -1057,6 +1058,8 @@ impl Liveness {
             self.propagate_through_loop(expr, Some(cond), blk, succ)
           }
 
+          expr_for_loop(*) => fail!("non-desugared expr_for_loop"),
+
           // Note that labels have been resolved, so we don't need to look
           // at the label ident
           expr_loop(ref blk, _) => {
@@ -1487,6 +1490,7 @@ fn check_expr(expr: @expr, (this, vt): (@Liveness, vt<@Liveness>)) {
       expr_paren(*) | expr_fn_block(*) | expr_path(*) | expr_self(*) => {
         visit::visit_expr(expr, (this, vt));
       }
+      expr_for_loop(*) => fail!("non-desugared expr_for_loop")
     }
 }
 

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -435,6 +435,8 @@ impl mem_categorization_ctxt {
           ast::expr_inline_asm(*) => {
             return self.cat_rvalue_node(expr, expr_ty);
           }
+
+          ast::expr_for_loop(*) => fail!("non-desugared expr_for_loop")
         }
     }
 

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -487,6 +487,8 @@ impl VisitContext {
                 self.consume_block(blk, visitor);
             }
 
+            expr_for_loop(*) => fail!("non-desugared expr_for_loop"),
+
             expr_unary(_, _, lhs) => {
                 if !self.use_overloaded_operator(
                     expr, lhs, [], visitor)

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -5016,6 +5016,8 @@ impl Resolver {
                 }
             }
 
+            expr_for_loop(*) => fail!("non-desugared expr_for_loop"),
+
             expr_break(Some(label)) | expr_again(Some(label)) => {
                 match self.search_ribs(self.label_ribs, label, expr.span,
                                        DontAllowCapturingSelf) {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2266,7 +2266,7 @@ pub fn register_fn_fuller(ccx: @mut CrateContext,
                           sp: span,
                           sym: ~str,
                           node_id: ast::NodeId,
-                          node_type: ty::t,
+                          _node_type: ty::t,
                           cc: lib::llvm::CallConv,
                           fn_ty: Type)
                           -> ValueRef {

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -401,7 +401,9 @@ pub fn mark_for_expr(cx: &Context, e: &expr) {
       expr_match(*) | expr_block(_) | expr_if(*) | expr_while(*) |
       expr_break(_) | expr_again(_) | expr_unary(*) | expr_lit(_) |
       expr_mac(_) | expr_addr_of(*) | expr_ret(_) | expr_loop(*) |
-      expr_loop_body(_) | expr_do_body(_) => ()
+      expr_loop_body(_) | expr_do_body(_) => (),
+
+      expr_for_loop(*) => fail!("non-desugared expr_for_loop")
     }
 }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3240,6 +3240,8 @@ pub fn expr_kind(tcx: ctxt,
             RvalueStmtExpr
         }
 
+        ast::expr_for_loop(*) => fail!("non-desugared expr_for_loop"),
+
         ast::expr_lit(_) | // Note: lit_str is carved out above
         ast::expr_unary(*) |
         ast::expr_addr_of(*) |

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2559,6 +2559,8 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
             fcx.write_nil(id);
         }
       }
+      ast::expr_for_loop(*) =>
+          fail!("non-desugared expr_for_loop"),
       ast::expr_loop(ref body, _) => {
         check_block_no_value(fcx, (body));
         if !may_break(tcx, expr.id, body) {

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -1041,6 +1041,7 @@ pub mod guarantor {
                     rcx.fcx.tcx(), rcx.fcx.inh.method_map, expr));
                 None
             }
+            ast::expr_for_loop(*) => fail!("non-desugared expr_for_loop"),
         }
     }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -465,6 +465,7 @@ pub enum expr_ {
     expr_cast(@expr, Ty),
     expr_if(@expr, Block, Option<@expr>),
     expr_while(@expr, Block),
+    expr_for_loop(@pat, @expr, Block),
     /* Conditionless loop (can be exited with break, cont, or ret)
        Same semantics as while(true) { body }, but typestate knows that the
        (implicit) condition is always true. */

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -559,6 +559,11 @@ pub fn noop_fold_expr(e: &expr_, fld: @ast_fold) -> expr_ {
         expr_while(cond, ref body) => {
             expr_while(fld.fold_expr(cond), fld.fold_block(body))
         }
+        expr_for_loop(pat, iter, ref body) => {
+            expr_for_loop(fld.fold_pat(pat),
+                          fld.fold_expr(iter),
+                          fld.fold_block(body))
+        }
         expr_loop(ref body, opt_ident) => {
             expr_loop(
                 fld.fold_block(body),

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -28,6 +28,7 @@ pub fn expr_requires_semi_to_be_stmt(e: @ast::expr) -> bool {
       | ast::expr_block(_)
       | ast::expr_while(*)
       | ast::expr_loop(*)
+      | ast::expr_for_loop(*)
       | ast::expr_call(_, _, ast::DoSugar)
       | ast::expr_call(_, _, ast::ForSugar)
       | ast::expr_method_call(_, _, _, _, _, ast::DoSugar)

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -474,6 +474,7 @@ fn mk_fresh_ident_interner() -> @ident_interner {
         "while",              // 64
 
         "be",                 // 65
+        "in",                 // 66
     ];
 
     @ident_interner {
@@ -572,6 +573,7 @@ pub mod keywords {
         For,
         If,
         Impl,
+        In,
         Let,
         __Log,
         Loop,
@@ -614,6 +616,7 @@ pub mod keywords {
                 For => ident { name: 42, ctxt: 0 },
                 If => ident { name: 43, ctxt: 0 },
                 Impl => ident { name: 44, ctxt: 0 },
+                In => ident { name: 66, ctxt: 0 },
                 Let => ident { name: 45, ctxt: 0 },
                 __Log => ident { name: 46, ctxt: 0 },
                 Loop => ident { name: 47, ctxt: 0 },

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -475,6 +475,7 @@ fn mk_fresh_ident_interner() -> @ident_interner {
 
         "be",                 // 65
         "in",                 // 66
+        "foreach",            // 67
     ];
 
     @ident_interner {
@@ -571,6 +572,7 @@ pub mod keywords {
         False,
         Fn,
         For,
+        ForEach,
         If,
         Impl,
         In,
@@ -614,6 +616,7 @@ pub mod keywords {
                 False => ident { name: 40, ctxt: 0 },
                 Fn => ident { name: 41, ctxt: 0 },
                 For => ident { name: 42, ctxt: 0 },
+                ForEach => ident { name: 67, ctxt: 0 },
                 If => ident { name: 43, ctxt: 0 },
                 Impl => ident { name: 44, ctxt: 0 },
                 In => ident { name: 66, ctxt: 0 },

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1231,6 +1231,7 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
       ast::expr_for_loop(pat, iter, ref blk) => {
         head(s, "foreach");
         print_pat(s, pat);
+        space(s.s);
         word_space(s, "in");
         print_expr(s, iter);
         space(s.s);

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1228,6 +1228,14 @@ pub fn print_expr(s: @ps, expr: &ast::expr) {
         space(s.s);
         print_block(s, blk);
       }
+      ast::expr_for_loop(pat, iter, ref blk) => {
+        head(s, "foreach");
+        print_pat(s, pat);
+        word_space(s, "in");
+        print_expr(s, iter);
+        space(s.s);
+        print_block(s, blk);
+      }
       ast::expr_loop(ref blk, opt_ident) => {
         for opt_ident.iter().advance |ident| {
             word(s.s, "'");

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -512,6 +512,11 @@ pub fn visit_expr<E:Clone>(ex: @expr, (e, v): (E, vt<E>)) {
             (v.visit_expr)(x, (e.clone(), v));
             (v.visit_block)(b, (e.clone(), v));
         }
+        expr_for_loop(pat, iter, ref b) => {
+            (v.visit_pat)(pat, (e.clone(), v));
+            (v.visit_expr)(iter, (e.clone(), v));
+            (v.visit_block)(b, (e.clone(), v));
+        }
         expr_loop(ref b, _) => (v.visit_block)(b, (e.clone(), v)),
         expr_match(x, ref arms) => {
             (v.visit_expr)(x, (e.clone(), v));

--- a/src/test/run-pass/foreach-external-iterators-break.rs
+++ b/src/test/run-pass/foreach-external-iterators-break.rs
@@ -1,0 +1,21 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = [1,..100];
+    let mut y = 0;
+    foreach i in x.iter() {
+        if y > 10 {
+            break;
+        }
+        y += *i;
+    }
+    assert!(y == 11);
+}

--- a/src/test/run-pass/foreach-external-iterators-hashmap-break-restart.rs
+++ b/src/test/run-pass/foreach-external-iterators-hashmap-break-restart.rs
@@ -1,0 +1,41 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::hashmap::HashMap;
+
+// This is a fancy one: it uses an external iterator established
+// outside the loop, breaks, then _picks back up_ and continues
+// iterating with it.
+
+fn main() {
+    let mut h = HashMap::new();
+    let kvs = [(1, 10), (2, 20), (3, 30)];
+    foreach &(k,v) in kvs.iter() {
+        h.insert(k,v);
+    }
+    let mut x = 0;
+    let mut y = 0;
+
+    let mut i = h.iter();
+
+    foreach (&k,&v) in i {
+        x += k;
+        y += v;
+        break;
+    }
+
+    foreach (&k,&v) in i {
+        x += k;
+        y += v;
+    }
+
+    assert_eq!(x, 6);
+    assert_eq!(y, 60);
+}

--- a/src/test/run-pass/foreach-external-iterators-hashmap.rs
+++ b/src/test/run-pass/foreach-external-iterators-hashmap.rs
@@ -1,0 +1,27 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::hashmap::HashMap;
+
+fn main() {
+    let mut h = HashMap::new();
+    let kvs = [(1, 10), (2, 20), (3, 30)];
+    foreach &(k,v) in kvs.iter() {
+        h.insert(k,v);
+    }
+    let mut x = 0;
+    let mut y = 0;
+    foreach (&k,&v) in h.iter() {
+        x += k;
+        y += v;
+    }
+    assert_eq!(x, 6);
+    assert_eq!(y, 60);
+}

--- a/src/test/run-pass/foreach-external-iterators-loop.rs
+++ b/src/test/run-pass/foreach-external-iterators-loop.rs
@@ -1,0 +1,21 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = [1,..100];
+    let mut y = 0;
+    foreach (n,i) in x.iter().enumerate() {
+        if n < 10 {
+            loop;
+        }
+        y += *i;
+    }
+    assert_eq!(y, 90);
+}

--- a/src/test/run-pass/foreach-external-iterators-nested.rs
+++ b/src/test/run-pass/foreach-external-iterators-nested.rs
@@ -1,0 +1,23 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = [1,..100];
+    let y = [2,..100];
+    let mut p = 0;
+    let mut q = 0;
+    foreach i in x.iter() {
+        foreach j in y.iter() {
+            p += *j;
+        }
+        q += *i + p;
+    }
+    assert!(q == 1010100);
+}

--- a/src/test/run-pass/foreach-external-iterators.rs
+++ b/src/test/run-pass/foreach-external-iterators.rs
@@ -1,0 +1,18 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = [1,..100];
+    let mut y = 0;
+    foreach i in x.iter() {
+        y += *i
+    }
+    assert!(y == 100);
+}


### PR DESCRIPTION
This is a preliminary implementation of `for ... in ... { ...}` using a transitionary keyword `foreach`. Codesize seems to be a little bit down (10% or less non-opt) and otherwise it seems quite trivial to rewrite lambda-based loops to use it. Once we've rewritten the codebase away from lambda-based `for` we can retarget that word at the same production, snapshot, rewrite the keywords in one go, and expire `foreach`.

Feedback welcome. It's a desugaring-based approach which is arguably something we should have been doing for other constructs before. I apologize both for the laziness associated with doing it this way and with any sense that I'm bending rules I put in place previously concerning "never doing desugarings". I put the expansion in `expand.rs` and would be amenable to the argument that the code there needs better factoring / more helpers / to move to a submodule or helper function. It does seem to work at this point, though, and I gather we'd like to get the shift done relatively quickly.
