### PR TITLE
Reduce code bloat from assert!()

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -529,7 +529,7 @@ pub fn std_macros() -> @str {
         ($cond:expr) => {
             if !$cond {
                 ::std::sys::FailWithCause::fail_with(
-                    ~\"assertion failed: \" + stringify!($cond), file!(), line!())
+                    \"assertion failed: \" + stringify!($cond), file!(), line!())
             }
         };
         ($cond:expr, $msg:expr) => {


### PR DESCRIPTION
Assertions without a message get a generated message that consists of a
prefix plus the stringified expression that is being asserted. That
prefix is currently a unique string, while a static string would be
sufficient and needs less code.
