### PR TITLE
Allow tasks to be named, and clean up task::atomically.

### DIFF
--- a/src/libstd/rt/kill.rs
+++ b/src/libstd/rt/kill.rs
@@ -84,7 +84,7 @@ pub struct Death {
     on_exit:         Option<~fn(bool)>,
     // nesting level counter for task::unkillable calls (0 == killable).
     unkillable:      int,
-    // nesting level counter for task::atomically calls (0 == can yield).
+    // nesting level counter for unstable::atomically calls (0 == can yield).
     wont_sleep:      int,
     // A "spare" handle to the kill flag inside the kill handle. Used during
     // blocking/waking as an optimization to avoid two xadds on the refcount.

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -316,12 +316,14 @@ fn run_(main: ~fn(), use_main_sched: bool) -> int {
             // Just put an unpinned task onto one of the default schedulers.
             let mut main_task = ~Task::new_root(&mut scheds[0].stack_pool, main);
             main_task.death.on_exit = Some(on_exit);
+            main_task.name = Some(~"main");
             scheds[0].enqueue_task(main_task);
         }
         Some(ref mut main_sched) => {
             let home = Sched(main_sched.make_handle());
             let mut main_task = ~Task::new_root_homed(&mut scheds[0].stack_pool, home, main);
             main_task.death.on_exit = Some(on_exit);
+            main_task.name = Some(~"main");
             main_sched.enqueue_task(main_task);
         }
     };

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -40,7 +40,9 @@ pub struct Task {
     taskgroup: Option<Taskgroup>,
     death: Death,
     destroyed: bool,
-    coroutine: Option<~Coroutine>
+    coroutine: Option<~Coroutine>,
+    // FIXME(#6874/#7599) use StringRef to save on allocations
+    name: Option<~str>,
 }
 
 pub struct Coroutine {
@@ -90,7 +92,8 @@ impl Task {
             taskgroup: None,
             death: Death::new(),
             destroyed: false,
-            coroutine: Some(~Coroutine::new(stack_pool, start))
+            coroutine: Some(~Coroutine::new(stack_pool, start)),
+            name: None,
         }
     }
 
@@ -109,7 +112,8 @@ impl Task {
             // FIXME(#7544) make watching optional
             death: self.death.new_child(),
             destroyed: false,
-            coroutine: Some(~Coroutine::new(stack_pool, start))
+            coroutine: Some(~Coroutine::new(stack_pool, start)),
+            name: None,
         }
     }
 

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -120,6 +120,8 @@ pub struct SchedOpts {
  *
  * * notify_chan - Enable lifecycle notifications on the given channel
  *
+ * * name - A name for the task-to-be, for identification in failure messages.
+ *
  * * sched - Specify the configuration of a new scheduler to create the task
  *           in
  *
@@ -139,6 +141,7 @@ pub struct TaskOpts {
     watched: bool,
     indestructible: bool,
     notify_chan: Option<Chan<TaskResult>>,
+    name: Option<~str>,
     sched: SchedOpts
 }
 
@@ -185,6 +188,7 @@ impl TaskBuilder {
         self.consumed = true;
         let gen_body = self.gen_body.take();
         let notify_chan = self.opts.notify_chan.take();
+        let name = self.opts.name.take();
         TaskBuilder {
             opts: TaskOpts {
                 linked: self.opts.linked,
@@ -192,6 +196,7 @@ impl TaskBuilder {
                 watched: self.opts.watched,
                 indestructible: self.opts.indestructible,
                 notify_chan: notify_chan,
+                name: name,
                 sched: self.opts.sched
             },
             gen_body: gen_body,
@@ -199,9 +204,7 @@ impl TaskBuilder {
             consumed: false
         }
     }
-}
 
-impl TaskBuilder {
     /// Decouple the child task's failure from the parent's. If either fails,
     /// the other will not be killed.
     pub fn unlinked(&mut self) {
@@ -281,6 +284,12 @@ impl TaskBuilder {
         self.opts.notify_chan = Some(notify_pipe_ch);
     }
 
+    /// Name the task-to-be. Currently the name is used for identification
+    /// only in failure messages.
+    pub fn name(&mut self, name: ~str) {
+        self.opts.name = Some(name);
+    }
+
     /// Configure a custom scheduler mode for the task.
     pub fn sched_mode(&mut self, mode: SchedMode) {
         self.opts.sched.mode = mode;
@@ -333,6 +342,7 @@ impl TaskBuilder {
     pub fn spawn(&mut self, f: ~fn()) {
         let gen_body = self.gen_body.take();
         let notify_chan = self.opts.notify_chan.take();
+        let name = self.opts.name.take();
         let x = self.consume();
         let opts = TaskOpts {
             linked: x.opts.linked,
@@ -340,6 +350,7 @@ impl TaskBuilder {
             watched: x.opts.watched,
             indestructible: x.opts.indestructible,
             notify_chan: notify_chan,
+            name: name,
             sched: x.opts.sched
         };
         let f = match gen_body {
@@ -408,6 +419,7 @@ pub fn default_task_opts() -> TaskOpts {
         watched: true,
         indestructible: false,
         notify_chan: None,
+        name: None,
         sched: SchedOpts {
             mode: DefaultScheduler,
         }
@@ -506,6 +518,21 @@ pub fn try<T:Send>(f: ~fn() -> T) -> Result<T,()> {
 
 
 /* Lifecycle functions */
+
+/// Read the name of the current task.
+pub fn with_task_name<U>(blk: &fn(Option<&str>) -> U) -> U {
+    use rt::task::Task;
+
+    match context() {
+        TaskContext => do Local::borrow::<Task, U> |task| {
+            match task.name {
+                Some(ref name) => blk(Some(name.as_slice())),
+                None => blk(None)
+            }
+        },
+        _ => fail!("no task name exists in %?", context()),
+    }
+}
 
 pub fn yield() {
     //! Yield control to the task scheduler
@@ -803,6 +830,34 @@ fn test_spawn_linked_sup_propagate_sibling() {
     }
     for 16.times { task::yield(); }
     fail!();
+}
+
+#[test]
+fn test_unnamed_task() {
+    use rt::test::run_in_newsched_task;
+
+    do run_in_newsched_task {
+        do spawn {
+            do with_task_name |name| {
+                assert!(name.is_none());
+            }
+        }
+    }
+}
+
+#[test]
+fn test_named_task() {
+    use rt::test::run_in_newsched_task;
+
+    do run_in_newsched_task {
+        let mut t = task();
+        t.name(~"ada lovelace");
+        do t.spawn {
+            do with_task_name |name| {
+                assert!(name.get() == "ada lovelace");
+            }
+        }
+    }
 }
 
 #[test]

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -726,6 +726,8 @@ fn spawn_raw_newsched(mut opts: TaskOpts, f: ~fn()) {
         task.death.on_exit = Some(on_exit);
     }
 
+    task.name = opts.name.take();
+
     rtdebug!("spawn about to take scheduler");
 
     let sched = Local::take::<Scheduler>();

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -105,7 +105,7 @@ mod dl {
     use path;
     use ptr;
     use str;
-    use task;
+    use unstable::sync::atomically;
     use result::*;
 
     pub unsafe fn open_external(filename: &path::Path) -> *libc::c_void {
@@ -120,7 +120,7 @@ mod dl {
 
     pub fn check_for_errors_in<T>(f: &fn()->T) -> Result<T, ~str> {
         unsafe {
-            do task::atomically {
+            do atomically {
                 let _old_error = dlerror();
 
                 let result = f();
@@ -164,7 +164,7 @@ mod dl {
     use libc;
     use path;
     use ptr;
-    use task;
+    use unstable::sync::atomically;
     use result::*;
 
     pub unsafe fn open_external(filename: &path::Path) -> *libc::c_void {
@@ -181,7 +181,7 @@ mod dl {
 
     pub fn check_for_errors_in<T>(f: &fn()->T) -> Result<T, ~str> {
         unsafe {
-            do task::atomically {
+            do atomically {
                 SetLastError(0);
 
                 let result = f();

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -85,7 +85,7 @@ fn test_run_in_bare_thread_exchange() {
 pub fn change_dir_locked(p: &Path, action: &fn()) -> bool {
     use os;
     use os::change_dir;
-    use task;
+    use unstable::sync::atomically;
     use unstable::finally::Finally;
 
     unsafe {
@@ -93,7 +93,7 @@ pub fn change_dir_locked(p: &Path, action: &fn()) -> bool {
         // in the `action` callback can cause deadlock. Doing it in
         // `task::atomically` to try to avoid that, but ... I don't know
         // this is all bogus.
-        return do task::atomically {
+        return do atomically {
             rust_take_change_dir_lock();
 
             do (||{


### PR DESCRIPTION
r? @brson
