### PR TITLE
Clean tests.mk

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -216,9 +216,7 @@ ALL_CS := $(wildcard $(S)src/rt/*.cpp \
                      $(S)src/rt/*/*.cpp \
                      $(S)src/rt/*/*/*.cpp \
                      $(S)src/rustllvm/*.cpp)
-ALL_CS := $(filter-out $(S)src/rt/bigint/bigint_ext.cpp \
-                       $(S)src/rt/bigint/bigint_int.cpp \
-                       $(S)src/rt/miniz.cpp \
+ALL_CS := $(filter-out $(S)src/rt/miniz.cpp \
                        $(S)src/rt/linenoise/linenoise.c \
                        $(S)src/rt/linenoise/utf8.c \
 	,$(ALL_CS))
@@ -228,12 +226,9 @@ ALL_HS := $(wildcard $(S)src/rt/*.h \
                      $(S)src/rustllvm/*.h)
 ALL_HS := $(filter-out $(S)src/rt/vg/valgrind.h \
                        $(S)src/rt/vg/memcheck.h \
-                       $(S)src/rt/uthash/uthash.h \
-                       $(S)src/rt/uthash/utlist.h \
                        $(S)src/rt/msvc/typeof.h \
                        $(S)src/rt/msvc/stdint.h \
                        $(S)src/rt/msvc/inttypes.h \
-                       $(S)src/rt/bigint/bigint.h \
                        $(S)src/rt/linenoise/linenoise.h \
                        $(S)src/rt/linenoise/utf8.h \
 	,$(ALL_HS))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -215,7 +215,7 @@ else
 ALL_CS := $(wildcard $(S)src/rt/*.cpp \
                      $(S)src/rt/*/*.cpp \
                      $(S)src/rt/*/*/*.cpp \
-                     $(S)srcrustllvm/*.cpp)
+                     $(S)src/rustllvm/*.cpp)
 ALL_CS := $(filter-out $(S)src/rt/bigint/bigint_ext.cpp \
                        $(S)src/rt/bigint/bigint_int.cpp \
                        $(S)src/rt/miniz.cpp \
@@ -225,7 +225,7 @@ ALL_CS := $(filter-out $(S)src/rt/bigint/bigint_ext.cpp \
 ALL_HS := $(wildcard $(S)src/rt/*.h \
                      $(S)src/rt/*/*.h \
                      $(S)src/rt/*/*/*.h \
-                     $(S)srcrustllvm/*.h)
+                     $(S)src/rustllvm/*.h)
 ALL_HS := $(filter-out $(S)src/rt/vg/valgrind.h \
                        $(S)src/rt/vg/memcheck.h \
                        $(S)src/rt/uthash/uthash.h \


### PR DESCRIPTION
Hello,

While looking at `tests.mk` I noticed two errors:
- there's a `srcrustllvm` instead of `src/rustllvm`
- some filtered out files don't exist anymore

These two commits fix these issues. Thanks!
