### PR TITLE
test: Disable morestack tests

### DIFF
--- a/src/test/run-fail/morestack1.rs
+++ b/src/test/run-fail/morestack1.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test newsched transition
 // error-pattern:fail
 fn getbig(i: int) {
     if i != 0 {

--- a/src/test/run-fail/morestack2.rs
+++ b/src/test/run-fail/morestack2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test newsched transition
 // error-pattern:explicit failure
 
 // This time we're testing that the stack limits are restored

--- a/src/test/run-fail/morestack3.rs
+++ b/src/test/run-fail/morestack3.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test newsched transition
 // error-pattern:explicit failure
 
 // Just testing unwinding

--- a/src/test/run-fail/morestack4.rs
+++ b/src/test/run-fail/morestack4.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test newsched transition
 // error-pattern:explicit failure
 
 // Just testing unwinding

--- a/src/test/run-pass/morestack1.rs
+++ b/src/test/run-pass/morestack1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test newsched transition
+
 fn getbig(i: int) {
     if i != 0 {
         getbig(i - 1);

--- a/src/test/run-pass/morestack2.rs
+++ b/src/test/run-pass/morestack2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test newsched transition
+
 fn getbig(i: int) -> int {
     let m = if i >= 0 {
         let j = getbig(i - 1);

--- a/src/test/run-pass/morestack3.rs
+++ b/src/test/run-pass/morestack3.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test newsched transition
+
 // Here we're testing that all of the argument registers, argument
 // stack slots, and return value are preserved across split stacks.
 fn getbig(a0: int,

--- a/src/test/run-pass/morestack4.rs
+++ b/src/test/run-pass/morestack4.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test newsched transition
+
 // This is testing for stack frames greater than 256 bytes,
 // for which function prologues are generated differently
 

--- a/src/test/run-pass/morestack5.rs
+++ b/src/test/run-pass/morestack5.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test newsched transition
+
 // This test will call __morestack with various minimum stack sizes
 
 extern mod extra;

--- a/src/test/run-pass/morestack6.rs
+++ b/src/test/run-pass/morestack6.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test newsched transition
+
 // This test attempts to force the dynamic linker to resolve
 // external symbols as close to the red zone as possible.
 


### PR DESCRIPTION
The new scheduler does not yet implement split stacks
