### PR TITLE
Resolve globals having different addresses across crates

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2460,7 +2460,7 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::NodeId) -> ValueRef {
                             // LLVM type is not fully determined by the Rust type.
                             let v = consts::const_expr(ccx, expr);
                             ccx.const_values.insert(id, v);
-                            exprt = m == ast::m_mutbl;
+                            exprt = (m == ast::m_mutbl || i.vis == ast::public);
 
                             unsafe {
                                 let llty = llvm::LLVMTypeOf(v);

--- a/src/test/auxiliary/xcrate_static_addresses.rs
+++ b/src/test/auxiliary/xcrate_static_addresses.rs
@@ -1,0 +1,23 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub static global: int = 3;
+
+pub fn verify_same(a: &'static int) {
+    let a = a as *int as uint;
+    let b = &global as *int as uint;
+    assert_eq!(a, b);
+}
+
+condition!{ pub test: int -> (); }
+
+pub fn raise() {
+    test::cond.raise(3);
+}

--- a/src/test/run-pass/xcrate-static-addresses.rs
+++ b/src/test/run-pass/xcrate-static-addresses.rs
@@ -1,0 +1,27 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:xcrate_static_addresses.rs
+
+extern mod xcrate_static_addresses;
+
+use other = xcrate_static_addresses;
+
+pub fn main() {
+    other::verify_same(&other::global);
+
+    // Previously this fail'd because there were two addresses that were being
+    // used when declaring constants.
+    do other::test::cond.trap(|_| {
+    }).inside {
+        other::raise();
+    }
+}


### PR DESCRIPTION
- All globals marked as `pub` won't have the `internal` linkage type set
- All global references across crates are forced to use the address of the
  global in the other crate via an external reference.

r? @graydon

Closes #8179 
