### PR TITLE
rustc: add a lint for `for`, suggesting `foreach` or `do`.

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -74,6 +74,7 @@ pub enum lint {
     unused_imports,
     unnecessary_qualification,
     while_true,
+    deprecated_for_loop,
     path_statement,
     unrecognized_lint,
     non_camel_case_types,
@@ -163,6 +164,13 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
         lint: while_true,
         desc: "suggest using loop { } instead of while(true) { }",
         default: warn
+     }),
+
+    ("deprecated_for_loop",
+     LintSpec {
+         lint: deprecated_for_loop,
+         desc: "recommend using `foreach` or `do` instead of `for`",
+         default: allow
      }),
 
     ("path_statement",
@@ -554,6 +562,24 @@ fn lint_while_true() -> visit::vt<@mut Context> {
                     }
                 }
                 _ => ()
+            }
+            visit::visit_expr(e, (cx, vt));
+        },
+        .. *visit::default_visitor()
+    })
+}
+
+fn lint_deprecated_for_loop() -> visit::vt<@mut Context> {
+    visit::mk_vt(@visit::Visitor {
+        visit_expr: |e, (cx, vt): (@mut Context, visit::vt<@mut Context>)| {
+            match e.node {
+                ast::expr_call(_, _, ast::ForSugar) |
+                ast::expr_method_call(_, _, _, _, _, ast::ForSugar) => {
+                    cx.span_lint(deprecated_for_loop, e.span,
+                                "`for` is deprecated; use `foreach <pat> in \
+                                 <iterator>` or `do`")
+                }
+                _ => {}
             }
             visit::visit_expr(e, (cx, vt));
         },
@@ -1096,6 +1122,7 @@ pub fn check_crate(tcx: ty::ctxt, crate: @ast::Crate) {
 
     // Register each of the lint passes with the context
     cx.add_lint(lint_while_true());
+    cx.add_lint(lint_deprecated_for_loop());
     cx.add_lint(lint_path_statement());
     cx.add_lint(lint_heap());
     cx.add_lint(lint_type_limits());

--- a/src/test/compile-fail/lint-deprecated-for-loop.rs
+++ b/src/test/compile-fail/lint-deprecated-for-loop.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+#[forbid(deprecated_for_loop)];
+
+fn f(_: &fn() -> bool) -> bool {
+    true
+}
+
+fn main() {
+    for f {} //~ ERROR `for` is deprecated
+}


### PR DESCRIPTION
This is just to aid the transistion to the new `for` loop, by
pointing at each location where the old one occurs.
