### PR TITLE
Makefile: Make crate tests depend on their extern crates

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -15,7 +15,7 @@
 
 # The names of crates that must be tested
 TEST_TARGET_CRATES = std extra
-TEST_HOST_CRATES = syntax rustc rustdoc rust rustpkg rusti
+TEST_HOST_CRATES = rust rusti rustpkg rustc rustdoc syntax
 TEST_CRATES = $(TEST_TARGET_CRATES) $(TEST_HOST_CRATES)
 
 # Markdown files under doc/ that should have their code extracted and run
@@ -352,6 +352,7 @@ $(3)/stage$(1)/test/rustctest-$(2)$$(X_$(2)):					\
 $(3)/stage$(1)/test/rustpkgtest-$(2)$$(X_$(2)):					\
 		$$(RUSTPKG_LIB) $$(RUSTPKG_INPUTS)		\
 		$$(SREQ$(1)_T_$(2)_H_$(3)) \
+		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBSYNTAX_$(2)) \
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTC_$(2))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
@@ -359,6 +360,7 @@ $(3)/stage$(1)/test/rustpkgtest-$(2)$$(X_$(2)):					\
 $(3)/stage$(1)/test/rustitest-$(2)$$(X_$(2)):					\
 		$$(RUSTI_LIB) $$(RUSTI_INPUTS)		\
 		$$(SREQ$(1)_T_$(2)_H_$(3)) \
+		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBSYNTAX_$(2)) \
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTC_$(2))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
@@ -366,6 +368,9 @@ $(3)/stage$(1)/test/rustitest-$(2)$$(X_$(2)):					\
 $(3)/stage$(1)/test/rusttest-$(2)$$(X_$(2)):					\
 		$$(RUST_LIB) $$(RUST_INPUTS)		\
 		$$(SREQ$(1)_T_$(2)_H_$(3)) \
+		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTPKG_$(2)) \
+		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTDOC_$(2)) \
+		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTI_$(2)) \
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTC_$(2))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
@@ -373,6 +378,7 @@ $(3)/stage$(1)/test/rusttest-$(2)$$(X_$(2)):					\
 $(3)/stage$(1)/test/rustdoctest-$(2)$$(X_$(2)):					\
 		$$(RUSTDOC_LIB) $$(RUSTDOC_INPUTS)		\
 		$$(SREQ$(1)_T_$(2)_H_$(3)) \
+		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBSYNTAX_$(2)) \
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(CFG_LIBRUSTC_$(2))
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test


### PR DESCRIPTION
Reorder TEST_HOST_CRATES in hopes of exposing future instances of this bug.

Fix #8056
