### PR TITLE
run: Process::new() should take &[Str] instead of &[~str] for args

### DIFF
--- a/src/librust/rust.rs
+++ b/src/librust/rust.rs
@@ -165,7 +165,8 @@ fn cmd_test(args: &[~str]) -> ValidUsage {
             let test_exec = Path(*filename).filestem().unwrap() + "test~";
             invoke("rustc", &[~"--test", filename.to_owned(),
                               ~"-o", test_exec.to_owned()], rustc::main_args);
-            let exit_code = run::process_status(~"./" + test_exec, []);
+            let args: &[&str] = [];
+            let exit_code = run::process_status(~"./" + test_exec, args);
             Valid(exit_code)
         }
         _ => Invalid

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -22,13 +22,15 @@ use std::str;
 
 #[test]
 fn test_destroy_once() {
-    let mut p = run::Process::new("echo", [], run::ProcessOptions::new());
+    let args: &[&str] = [];
+    let mut p = run::Process::new("echo", args, run::ProcessOptions::new());
     p.destroy(); // this shouldn't crash (and nor should the destructor)
 }
 
 #[test]
 fn test_destroy_twice() {
-    let mut p = run::Process::new("echo", [], run::ProcessOptions::new());
+    let args: &[&str] = [];
+    let mut p = run::Process::new("echo", args, run::ProcessOptions::new());
     p.destroy(); // this shouldnt crash...
     p.destroy(); // ...and nor should this (and nor should the destructor)
 }
@@ -74,7 +76,8 @@ fn test_destroy_actually_kills(force: bool) {
     }
 
     // this process will stay alive indefinitely trying to read from stdin
-    let mut p = run::Process::new(BLOCK_COMMAND, [], run::ProcessOptions::new());
+    let args: &[&str] = [];
+    let mut p = run::Process::new(BLOCK_COMMAND, args, run::ProcessOptions::new());
 
     assert!(process_exists(p.get_id()));
 


### PR DESCRIPTION
Fixes #7928.

As a side-effect, this no longer clones all the arg strings on unix.
