### PR TITLE
str: Add method .into_owned(self) -> ~str to Str

### DIFF
--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1079,11 +1079,17 @@ pub mod traits {}
 pub trait Str {
     /// Work with `self` as a slice.
     fn as_slice<'a>(&'a self) -> &'a str;
+
+    /// Convert `self` into a ~str.
+    fn into_owned(self) -> ~str;
 }
 
 impl<'self> Str for &'self str {
     #[inline]
     fn as_slice<'a>(&'a self) -> &'a str { *self }
+
+    #[inline]
+    fn into_owned(self) -> ~str { self.to_owned() }
 }
 
 impl<'self> Str for ~str {
@@ -1091,6 +1097,9 @@ impl<'self> Str for ~str {
     fn as_slice<'a>(&'a self) -> &'a str {
         let s: &'a str = *self; s
     }
+
+    #[inline]
+    fn into_owned(self) -> ~str { self }
 }
 
 impl<'self> Str for @str {
@@ -1098,6 +1107,9 @@ impl<'self> Str for @str {
     fn as_slice<'a>(&'a self) -> &'a str {
         let s: &'a str = *self; s
     }
+
+    #[inline]
+    fn into_owned(self) -> ~str { self.to_owned() }
 }
 
 impl<'self> Container for &'self str {


### PR DESCRIPTION
The method .into_owned() is meant to be used as an optimization when you
need to get a ~str from a Str, but don't want to unnecessarily copy it
if it's already a ~str.

This is meant to ease functions that look like

```
fn foo<S: Str>(strs: &[S])
```

Previously they could work with the strings as slices using .as_slice(),
but producing ~str required copying the string, even if the vector
turned out be a &[~str] already.

I don't have any concrete uses for this yet, since the one conversion I've done to `&[S]` so far (see PR #8203) didn't actually need owned strings. But having this here may make using `Str` more attractive.

It also may be worth adding an `into_managed()` function, but that one is less obviously useful than `into_owned()`.
