### PR TITLE
Add Upcase ident in Macro

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -152,6 +152,9 @@ pub fn syntax_expander_table() -> SyntaxEnv {
     syntax_expanders.insert(intern("concat_idents"),
                             builtin_normal_tt(
                                 ext::concat_idents::expand_syntax_ext));
+    syntax_expanders.insert(intern("upcase_ident"),
+                            builtin_normal_tt(
+                                ext::upcase_ident::expand_syntax_ext));
     syntax_expanders.insert(intern(&"log_syntax"),
                             builtin_normal_tt(
                                 ext::log_syntax::expand_syntax_ext));

--- a/src/libsyntax/ext/upcase_ident.rs
+++ b/src/libsyntax/ext/upcase_ident.rs
@@ -1,0 +1,45 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use ast;
+use codemap::span;
+use ext::base::*;
+use ext::base;
+use parse::token;
+use parse::token::{str_to_ident};
+
+pub fn expand_syntax_ext(cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
+    -> base::MacResult {
+    let mut res_str = ~"";
+    for tts.iter().advance |elem| {
+        match *elem {
+            ast::tt_tok(_, token::IDENT(ident,_)) => res_str.push_str(cx.str_of(ident)),
+                _ => cx.span_fatal(sp, "upcase_ident! requires ident args.")
+        }
+    }
+    res_str = res_str.to_ascii().to_upper().to_str_ascii();
+
+    let res = str_to_ident(res_str);
+
+    let e = @ast::expr {
+        id: cx.next_id(),
+        node: ast::expr_path(
+            ast::Path {
+                 span: sp,
+                 global: false,
+                 idents: ~[res],
+                 rp: None,
+                 types: ~[],
+            }
+        ),
+        span: sp,
+    };
+    MRExpr(e)
+}

--- a/src/libsyntax/syntax.rs
+++ b/src/libsyntax/syntax.rs
@@ -74,6 +74,7 @@ pub mod ext {
     pub mod env;
     pub mod bytes;
     pub mod concat_idents;
+    pub mod upcase_ident;
     pub mod log_syntax;
     pub mod auto_encode;
     pub mod source_util;

--- a/src/test/run-pass/test_upcase_ident.rs
+++ b/src/test/run-pass/test_upcase_ident.rs
@@ -1,0 +1,14 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let AA = "upcase_ident test";
+    assert!(AA == upcase_ident!(aa));
+}


### PR DESCRIPTION
This feature is for rust-css colors.
see : https://github.com/mozilla-servo/rust-css/pull/22

something like:

```
define_color!(aliceblue, 240, 248, 255);
```

which would expand to:

```
static ALICEBLUE: Color = Color { red: 240, green: 248, blue: 255, alpha: 1.0 };
```

when is use upcaseident!(aliceblue), it can become ALICEBLUE(uppercase).

ex))

```
let AA = "hi"
assert!(upcase_indent!(aa)== AA);
```
