### PR TITLE
rt: Fix a corner-case in unwinding that leads to stack overflow

### DIFF
--- a/src/test/run-pass/unwind-resource.rs
+++ b/src/test/run-pass/unwind-resource.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test
+// xfail-fast
+
 extern mod extra;
 
 use std::comm::*;


### PR DESCRIPTION
In some scenarios upcall_rust_stack_limit fails to record the stack
limit, leaving it 0, and allowing subsequent Rust code to run into
the red zone.
