### PR TITLE
std: Implement SingleThreaded spawn mode for newsched

### DIFF
--- a/src/libstd/rt/sched.rs
+++ b/src/libstd/rt/sched.rs
@@ -39,14 +39,14 @@ use cell::Cell;
 pub struct Scheduler {
     /// A queue of available work. Under a work-stealing policy there
     /// is one per Scheduler.
-    priv work_queue: WorkQueue<~Task>,
+    work_queue: WorkQueue<~Task>,
     /// The queue of incoming messages from other schedulers.
     /// These are enqueued by SchedHandles after which a remote callback
     /// is triggered to handle the message.
     priv message_queue: MessageQueue<SchedMessage>,
     /// A shared list of sleeping schedulers. We'll use this to wake
     /// up schedulers when pushing work onto the work queue.
-    priv sleeper_list: SleeperList,
+    sleeper_list: SleeperList,
     /// Indicates that we have previously pushed a handle onto the
     /// SleeperList but have not yet received the Wake message.
     /// Being `true` does not necessarily mean that the scheduler is
@@ -158,6 +158,9 @@ impl Scheduler {
         // scheduler. Grab it out of TLS - performing the scheduler
         // action will have given it away.
         let sched = Local::take::<Scheduler>();
+
+        rtdebug!("starting scheduler %u", sched.sched_id());
+
         sched.run();
 
         // Now that we are done with the scheduler, clean up the
@@ -166,6 +169,9 @@ impl Scheduler {
         // task.run() on the scheduler task we never get through all
         // the cleanup code it runs.
         let mut stask = Local::take::<Task>();
+
+        rtdebug!("stopping scheduler %u", stask.sched.get_ref().sched_id());
+
         stask.destroyed = true;
     }
 
@@ -484,7 +490,7 @@ impl Scheduler {
             return None;
         } else if !homed && !this.run_anything {
             // the task isn't homed, but it can't be run here
-            this.enqueue_task(task);
+            this.send_to_friend(task);
             return Some(this);
         } else {
             // task isn't home, so don't run it here, send it home


### PR DESCRIPTION
This is the last major runtime feature needed for the transition to the new scheduler.
