### PR TITLE
std: use ptr.offset where possible in the vec iterator.

### DIFF
--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -3595,4 +3595,17 @@ mod bench {
             if sum == 0 {fail!()}
         }
     }
+
+    #[bench]
+    fn mut_iterator(bh: &mut BenchHarness) {
+        let mut v = vec::from_elem(100, 0);
+
+        do bh.iter {
+            let mut i = 0;
+            foreach x in v.mut_iter() {
+                *x = i;
+                i += 1;
+            }
+        }
+    }
 }

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2141,11 +2141,15 @@ macro_rules! iterator {
                         None
                     } else {
                         let old = self.ptr;
-                        // purposefully don't use 'ptr.offset' because for
-                        // vectors with 0-size elements this would return the
-                        // same pointer.
-                        self.ptr = cast::transmute(self.ptr as uint +
-                                                   sys::nonzero_size_of::<T>());
+                        self.ptr = if sys::size_of::<T>() == 0 {
+                            // purposefully don't use 'ptr.offset' because for
+                            // vectors with 0-size elements this would return the
+                            // same pointer.
+                            cast::transmute(self.ptr as uint + 1)
+                        } else {
+                            self.ptr.offset(1)
+                        };
+
                         Some(cast::transmute(old))
                     }
                 }
@@ -2171,9 +2175,12 @@ macro_rules! double_ended_iterator {
                     if self.end == self.ptr {
                         None
                     } else {
-                        // See above for why 'ptr.offset' isn't used
-                        self.end = cast::transmute(self.end as uint -
-                                                   sys::nonzero_size_of::<T>());
+                        self.end = if sys::size_of::<T>() == 0 {
+                            // See above for why 'ptr.offset' isn't used
+                            cast::transmute(self.end as uint - 1)
+                        } else {
+                            self.end.offset(-1)
+                        };
                         Some(cast::transmute(self.end))
                     }
                 }
@@ -3564,5 +3571,28 @@ mod tests {
             cnt += 1;
         }
         assert!(cnt == 3);
+    }
+}
+
+#[cfg(test)]
+mod bench {
+    use extra::test::BenchHarness;
+    use vec;
+    use option::*;
+
+    #[bench]
+    fn iterator(bh: &mut BenchHarness) {
+        // peculiar numbers to stop LLVM from optimising the summation
+        // out.
+        let v = vec::from_fn(100, |i| i ^ (i << 1) ^ (i >> 1));
+
+        do bh.iter {
+            let mut sum = 0;
+            foreach x in v.iter() {
+                sum += *x;
+            }
+            // sum == 11806, to stop dead code elimination.
+            if sum == 0 {fail!()}
+        }
     }
 }


### PR DESCRIPTION
Closes #8212.

Before:

``` llvm
%sum.028 = phi i64 [ %23, %match_else ], [ 0, %"normal return" ]
%.sroa.0.027 = phi i64* [ %21, %match_else ], [ %12, %"normal return" ]
%19 = ptrtoint i64* %.sroa.0.027 to i64
%20 = add i64 %19, 8
%21 = inttoptr i64 %20 to i64*
%22 = load i64* %.sroa.0.027, align 8
%23 = add i64 %22, %sum.028
%24 = inttoptr i64 %20 to %"enum.std::libc::types::common::c95::c_void[#1]"*
%25 = icmp eq %"enum.std::libc::types::common::c95::c_void[#1]"* %24, %16
%26 = icmp eq i64 %20, 0
%or.cond = or i1 %25, %26
```

```
test vec::bench::iterator ... bench: 87 ns/iter (+/- 7)
test vec::bench::mut_iterator ... bench: 87 ns/iter (+/- 10)
```

After:

``` llvm
%sum.028 = phi i64 [ %21, %match_else ], [ 0, %"normal return" ]
%.sroa.0.027 = phi i64* [ %19, %match_else ], [ %12, %"normal return" ]
%19 = getelementptr i64* %.sroa.0.027, i64 1
%20 = load i64* %.sroa.0.027, align 8
%21 = add i64 %20, %sum.028
%22 = bitcast i64* %19 to %"enum.std::libc::types::common::c95::c_void[#1]"*
%23 = icmp eq %"enum.std::libc::types::common::c95::c_void[#1]"* %22, %16
%24 = icmp eq i64* %19, null
%or.cond = or i1 %23, %24
```

```
test vec::bench::iterator ... bench: 79 ns/iter (+/- 8)
test vec::bench::mut_iterator ... bench: 78 ns/iter (+/- 2)
```

(NB. I'm not 100% sure the benchmarks were set-up correctly, so take them with a grain of salt.)
