### PR TITLE
std: add a twos-complement fn back to ints and uints

### DIFF
--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -419,7 +419,10 @@ impl Integer for $T {
     fn is_odd(&self) -> bool { !self.is_even() }
 }
 
-impl Bitwise for $T {}
+impl Bitwise for $T {
+    #[inline]
+    fn compl(&self) -> $T { -1 as $T ^ *self }
+}
 
 #[cfg(not(test))]
 impl BitOr<$T,$T> for $T {

--- a/src/libstd/num/num.rs
+++ b/src/libstd/num/num.rs
@@ -244,7 +244,10 @@ pub trait Bitwise: Not<Self>
                  + BitOr<Self,Self>
                  + BitXor<Self,Self>
                  + Shl<Self,Self>
-                 + Shr<Self,Self> {}
+                 + Shr<Self,Self> {
+    // Computes the bitwise complement
+    fn compl(&self) -> Self;
+}
 
 pub trait BitCount {
     fn population_count(&self) -> Self;

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -281,7 +281,10 @@ impl Integer for $T {
     fn is_odd(&self) -> bool { !self.is_even() }
 }
 
-impl Bitwise for $T {}
+impl Bitwise for $T {
+    #[inline]
+    fn compl(&self) -> $T { -1 as $T ^ *self }
+}
 
 #[cfg(not(test))]
 impl BitOr<$T,$T> for $T {


### PR DESCRIPTION
We lost int::compl back in 1aae28a57d42bfd56e0838ddee0a44605922d655. This patch brings it back by adding a `compl` method to std::num::Bitwise.
