### PR TITLE
Rename IpAddr -> SocketAddr, extract IpAddr from SocketAddr

### DIFF
--- a/src/libstd/rt/io/net/ip.rs
+++ b/src/libstd/rt/io/net/ip.rs
@@ -15,19 +15,19 @@ type Port = u16;
 
 #[deriving(Eq, TotalEq)]
 pub enum IpAddr {
-    Ipv4(u8, u8, u8, u8, Port),
-    Ipv6(u16, u16, u16, u16, u16, u16, u16, u16, Port)
+    Ipv4Addr(u8, u8, u8, u8),
+    Ipv6Addr(u16, u16, u16, u16, u16, u16, u16, u16)
 }
 
 impl ToStr for IpAddr {
     fn to_str(&self) -> ~str {
         match *self {
-            Ipv4(a, b, c, d, p) =>
-                fmt!("%u.%u.%u.%u:%u",
-                    a as uint, b as uint, c as uint, d as uint, p as uint),
+            Ipv4Addr(a, b, c, d) =>
+                fmt!("%u.%u.%u.%u",
+                    a as uint, b as uint, c as uint, d as uint),
 
             // Ipv4 Compatible address
-            Ipv6(0, 0, 0, 0, 0, 0, g, h, p) => {
+            Ipv6Addr(0, 0, 0, 0, 0, 0, g, h) => {
                 let a = fmt!("%04x", g as uint);
                 let b = FromStrRadix::from_str_radix(a.slice(2, 4), 16).unwrap();
                 let a = FromStrRadix::from_str_radix(a.slice(0, 2), 16).unwrap();
@@ -35,11 +35,11 @@ impl ToStr for IpAddr {
                 let d = FromStrRadix::from_str_radix(c.slice(2, 4), 16).unwrap();
                 let c = FromStrRadix::from_str_radix(c.slice(0, 2), 16).unwrap();
 
-                fmt!("[::%u.%u.%u.%u]:%u", a, b, c, d, p as uint)
+                fmt!("::%u.%u.%u.%u", a, b, c, d)
             }
 
             // Ipv4-Mapped address
-            Ipv6(0, 0, 0, 0, 0, 1, g, h, p) => {
+            Ipv6Addr(0, 0, 0, 0, 0, 1, g, h) => {
                 let a = fmt!("%04x", g as uint);
                 let b = FromStrRadix::from_str_radix(a.slice(2, 4), 16).unwrap();
                 let a = FromStrRadix::from_str_radix(a.slice(0, 2), 16).unwrap();
@@ -47,13 +47,29 @@ impl ToStr for IpAddr {
                 let d = FromStrRadix::from_str_radix(c.slice(2, 4), 16).unwrap();
                 let c = FromStrRadix::from_str_radix(c.slice(0, 2), 16).unwrap();
 
-                fmt!("[::FFFF:%u.%u.%u.%u]:%u", a, b, c, d, p as uint)
+                fmt!("::FFFF:%u.%u.%u.%u", a, b, c, d)
             }
 
-            Ipv6(a, b, c, d, e, f, g, h, p) =>
-                fmt!("[%x:%x:%x:%x:%x:%x:%x:%x]:%u",
+            Ipv6Addr(a, b, c, d, e, f, g, h) =>
+                fmt!("%x:%x:%x:%x:%x:%x:%x:%x",
                     a as uint, b as uint, c as uint, d as uint,
-                    e as uint, f as uint, g as uint, h as uint, p as uint)
+                    e as uint, f as uint, g as uint, h as uint)
+        }
+    }
+}
+
+#[deriving(Eq, TotalEq)]
+pub struct SocketAddr {
+    ip: IpAddr,
+    port: Port,
+}
+
+
+impl ToStr for SocketAddr {
+    fn to_str(&self) -> ~str {
+        match self.ip {
+            Ipv4Addr(*) => fmt!("%s:%u", self.ip.to_str(), self.port as uint),
+            Ipv6Addr(*) => fmt!("[%s]:%u", self.ip.to_str(), self.port as uint),
         }
     }
 }

--- a/src/libstd/rt/io/net/tcp.rs
+++ b/src/libstd/rt/io/net/tcp.rs
@@ -10,7 +10,7 @@
 
 use option::{Option, Some, None};
 use result::{Ok, Err};
-use rt::io::net::ip::IpAddr;
+use rt::io::net::ip::SocketAddr;
 use rt::io::{Reader, Writer, Listener};
 use rt::io::{io_error, read_error, EndOfFile};
 use rt::rtio::{IoFactory, IoFactoryObject,
@@ -26,7 +26,7 @@ impl TcpStream {
         TcpStream(s)
     }
 
-    pub fn connect(addr: IpAddr) -> Option<TcpStream> {
+    pub fn connect(addr: SocketAddr) -> Option<TcpStream> {
         let stream = unsafe {
             rtdebug!("borrowing io to connect");
             let io = Local::unsafe_borrow::<IoFactoryObject>();
@@ -44,7 +44,7 @@ impl TcpStream {
         }
     }
 
-    pub fn peer_name(&mut self) -> Option<IpAddr> {
+    pub fn peer_name(&mut self) -> Option<SocketAddr> {
         match (**self).peer_name() {
             Ok(pn) => Some(pn),
             Err(ioerr) => {
@@ -55,7 +55,7 @@ impl TcpStream {
         }
     }
 
-    pub fn socket_name(&mut self) -> Option<IpAddr> {
+    pub fn socket_name(&mut self) -> Option<SocketAddr> {
         match (**self).socket_name() {
             Ok(sn) => Some(sn),
             Err(ioerr) => {
@@ -100,7 +100,7 @@ impl Writer for TcpStream {
 pub struct TcpListener(~RtioTcpListenerObject);
 
 impl TcpListener {
-    pub fn bind(addr: IpAddr) -> Option<TcpListener> {
+    pub fn bind(addr: SocketAddr) -> Option<TcpListener> {
         let listener = unsafe {
             let io = Local::unsafe_borrow::<IoFactoryObject>();
             (*io).tcp_bind(addr)
@@ -114,7 +114,7 @@ impl TcpListener {
         }
     }
 
-    pub fn socket_name(&mut self) -> Option<IpAddr> {
+    pub fn socket_name(&mut self) -> Option<SocketAddr> {
         match (**self).socket_name() {
             Ok(sn) => Some(sn),
             Err(ioerr) => {
@@ -145,7 +145,7 @@ mod test {
     use super::*;
     use cell::Cell;
     use rt::test::*;
-    use rt::io::net::ip::Ipv4;
+    use rt::io::net::ip::{Ipv4Addr, SocketAddr};
     use rt::io::*;
     use prelude::*;
 
@@ -157,7 +157,7 @@ mod test {
                 assert!(e.kind == PermissionDenied);
                 called = true;
             }).inside {
-                let addr = Ipv4(0, 0, 0, 0, 1);
+                let addr = SocketAddr { ip: Ipv4Addr(0, 0, 0, 0), port: 1 };
                 let listener = TcpListener::bind(addr);
                 assert!(listener.is_none());
             }
@@ -173,7 +173,7 @@ mod test {
                 assert!(e.kind == ConnectionRefused);
                 called = true;
             }).inside {
-                let addr = Ipv4(0, 0, 0, 0, 1);
+                let addr = SocketAddr { ip: Ipv4Addr(0, 0, 0, 0), port: 1 };
                 let stream = TcpStream::connect(addr);
                 assert!(stream.is_none());
             }
@@ -437,7 +437,7 @@ mod test {
 
             connect(0, addr);
 
-            fn connect(i: int, addr: IpAddr) {
+            fn connect(i: int, addr: SocketAddr) {
                 if i == MAX { return }
 
                 do spawntask {
@@ -476,7 +476,7 @@ mod test {
 
             connect(0, addr);
 
-            fn connect(i: int, addr: IpAddr) {
+            fn connect(i: int, addr: SocketAddr) {
                 if i == MAX { return }
 
                 do spawntask {
@@ -515,7 +515,7 @@ mod test {
 
             connect(0, addr);
 
-            fn connect(i: int, addr: IpAddr) {
+            fn connect(i: int, addr: SocketAddr) {
                 if i == MAX { return }
 
                 do spawntask_later {
@@ -553,7 +553,7 @@ mod test {
 
             connect(0, addr);
 
-            fn connect(i: int, addr: IpAddr) {
+            fn connect(i: int, addr: SocketAddr) {
                 if i == MAX { return }
 
                 do spawntask_later {
@@ -569,7 +569,7 @@ mod test {
     }
 
     #[cfg(test)]
-    fn socket_name(addr: IpAddr) {
+    fn socket_name(addr: SocketAddr) {
         do run_in_newsched_task {
             do spawntask {
                 let listener = TcpListener::bind(addr);
@@ -588,7 +588,7 @@ mod test {
     }
 
     #[cfg(test)]
-    fn peer_name(addr: IpAddr) {
+    fn peer_name(addr: SocketAddr) {
         do run_in_newsched_task {
             do spawntask {
                 let mut listener = TcpListener::bind(addr);

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -12,7 +12,7 @@ use option::*;
 use result::*;
 
 use rt::io::IoError;
-use super::io::net::ip::IpAddr;
+use super::io::net::ip::{IpAddr, SocketAddr};
 use rt::uv::uvio;
 
 // XXX: ~object doesn't work currently so these are some placeholder
@@ -44,9 +44,9 @@ pub trait RemoteCallback {
 }
 
 pub trait IoFactory {
-    fn tcp_connect(&mut self, addr: IpAddr) -> Result<~RtioTcpStreamObject, IoError>;
-    fn tcp_bind(&mut self, addr: IpAddr) -> Result<~RtioTcpListenerObject, IoError>;
-    fn udp_bind(&mut self, addr: IpAddr) -> Result<~RtioUdpSocketObject, IoError>;
+    fn tcp_connect(&mut self, addr: SocketAddr) -> Result<~RtioTcpStreamObject, IoError>;
+    fn tcp_bind(&mut self, addr: SocketAddr) -> Result<~RtioTcpListenerObject, IoError>;
+    fn udp_bind(&mut self, addr: SocketAddr) -> Result<~RtioUdpSocketObject, IoError>;
     fn timer_init(&mut self) -> Result<~RtioTimerObject, IoError>;
 }
 
@@ -59,7 +59,7 @@ pub trait RtioTcpListener : RtioSocket {
 pub trait RtioTcpStream : RtioSocket {
     fn read(&mut self, buf: &mut [u8]) -> Result<uint, IoError>;
     fn write(&mut self, buf: &[u8]) -> Result<(), IoError>;
-    fn peer_name(&mut self) -> Result<IpAddr, IoError>;
+    fn peer_name(&mut self) -> Result<SocketAddr, IoError>;
     fn control_congestion(&mut self) -> Result<(), IoError>;
     fn nodelay(&mut self) -> Result<(), IoError>;
     fn keepalive(&mut self, delay_in_seconds: uint) -> Result<(), IoError>;
@@ -67,12 +67,12 @@ pub trait RtioTcpStream : RtioSocket {
 }
 
 pub trait RtioSocket {
-    fn socket_name(&mut self) -> Result<IpAddr, IoError>;
+    fn socket_name(&mut self) -> Result<SocketAddr, IoError>;
 }
 
 pub trait RtioUdpSocket : RtioSocket {
-    fn recvfrom(&mut self, buf: &mut [u8]) -> Result<(uint, IpAddr), IoError>;
-    fn sendto(&mut self, buf: &[u8], dst: IpAddr) -> Result<(), IoError>;
+    fn recvfrom(&mut self, buf: &mut [u8]) -> Result<(uint, SocketAddr), IoError>;
+    fn sendto(&mut self, buf: &[u8], dst: SocketAddr) -> Result<(), IoError>;
 
     fn join_multicast(&mut self, multi: IpAddr) -> Result<(), IoError>;
     fn leave_multicast(&mut self, multi: IpAddr) -> Result<(), IoError>;

--- a/src/libstd/rt/test.rs
+++ b/src/libstd/rt/test.rs
@@ -16,7 +16,7 @@ use clone::Clone;
 use container::Container;
 use iterator::{Iterator, range};
 use vec::{OwnedVector, MutableVector};
-use super::io::net::ip::{IpAddr, Ipv4, Ipv6};
+use super::io::net::ip::{SocketAddr, Ipv4Addr, Ipv6Addr};
 use rt::sched::Scheduler;
 use unstable::run_in_bare_thread;
 use rt::thread::Thread;
@@ -227,13 +227,13 @@ pub fn next_test_port() -> u16 {
 }
 
 /// Get a unique IPv4 localhost:port pair starting at 9600
-pub fn next_test_ip4() -> IpAddr {
-    Ipv4(127, 0, 0, 1, next_test_port())
+pub fn next_test_ip4() -> SocketAddr {
+    SocketAddr { ip: Ipv4Addr(127, 0, 0, 1), port: next_test_port() }
 }
 
 /// Get a unique IPv6 localhost:port pair starting at 9600
-pub fn next_test_ip6() -> IpAddr {
-    Ipv6(0, 0, 0, 0, 0, 0, 0, 1, next_test_port())
+pub fn next_test_ip6() -> SocketAddr {
+    SocketAddr { ip: Ipv6Addr(0, 0, 0, 0, 0, 0, 0, 1), port: next_test_port() }
 }
 
 /*

--- a/src/libstd/rt/uv/mod.rs
+++ b/src/libstd/rt/uv/mod.rs
@@ -47,7 +47,7 @@ use libc::{c_void, c_int, size_t, malloc, free};
 use cast::transmute;
 use ptr::null;
 use unstable::finally::Finally;
-use rt::io::net::ip::IpAddr;
+use rt::io::net::ip::SocketAddr;
 
 use rt::io::IoError;
 
@@ -128,7 +128,7 @@ pub type ConnectionCallback = ~fn(StreamWatcher, Option<UvError>);
 pub type FsCallback = ~fn(FsRequest, Option<UvError>);
 pub type TimerCallback = ~fn(TimerWatcher, Option<UvError>);
 pub type AsyncCallback = ~fn(AsyncWatcher, Option<UvError>);
-pub type UdpReceiveCallback = ~fn(UdpWatcher, int, Buf, IpAddr, uint, Option<UvError>);
+pub type UdpReceiveCallback = ~fn(UdpWatcher, int, Buf, SocketAddr, uint, Option<UvError>);
 pub type UdpSendCallback = ~fn(UdpWatcher, Option<UvError>);
 
 


### PR DESCRIPTION
multicast functions now take IpAddr (without port), because they dont't
need port.

Uv\* types renamed:
- UvIpAddr -> UvSocketAddr
- UvIpv4 -> UvIpv4SocketAddr
- UvIpv6 -> UvIpv6SocketAddr

"Socket address" is a common name for (ip-address, port) pair (e.g. in
sockaddr_in struct).

P. S. Are there any backward compatibility concerns? What is std::rt module, is it a part of public API?
