### PR TITLE
Add default implementation of Map::contains_key function

### DIFF
--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -46,11 +46,6 @@ impl<V> Mutable for SmallIntMap<V> {
 }
 
 impl<V> Map<uint, V> for SmallIntMap<V> {
-    /// Return true if the map contains a value for the specified key
-    fn contains_key(&self, key: &uint) -> bool {
-        self.find(key).is_some()
-    }
-
     /// Return a reference to the value corresponding to the key
     fn find<'a>(&'a self, key: &uint) -> Option<&'a V> {
         if *key < self.v.len() {

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -105,11 +105,6 @@ impl<K: TotalOrd, V> Mutable for TreeMap<K, V> {
 }
 
 impl<K: TotalOrd, V> Map<K, V> for TreeMap<K, V> {
-    /// Return true if the map contains a value for the specified key
-    fn contains_key(&self, key: &K) -> bool {
-        self.find(key).is_some()
-    }
-
     /// Return a reference to the value corresponding to the key
     fn find<'a>(&'a self, key: &K) -> Option<&'a V> {
         let mut current: &'a Option<~TreeNode<K, V>> = &self.root;

--- a/src/libstd/container.rs
+++ b/src/libstd/container.rs
@@ -34,11 +34,13 @@ pub trait Mutable: Container {
 /// A map is a key-value store where values may be looked up by their keys. This
 /// trait provides basic operations to operate on these stores.
 pub trait Map<K, V>: Container {
-    /// Return true if the map contains a value for the specified key
-    fn contains_key(&self, key: &K) -> bool;
-
     /// Return a reference to the value corresponding to the key
     fn find<'a>(&'a self, key: &K) -> Option<&'a V>;
+
+    /// Return true if the map contains a value for the specified key
+    fn contains_key(&self, key: &K) -> bool {
+        self.find(key).is_some()
+    }
 }
 
 /// This trait provides basic operations to modify the contents of a map.

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -292,14 +292,6 @@ impl<K:Hash + Eq,V> Mutable for HashMap<K, V> {
 }
 
 impl<K:Hash + Eq,V> Map<K, V> for HashMap<K, V> {
-    /// Return true if the map contains a value for the specified key
-    fn contains_key(&self, k: &K) -> bool {
-        match self.bucket_for_key(k) {
-            FoundEntry(_) => {true}
-            TableFull | FoundHole(_) => {false}
-        }
-    }
-
     /// Return a reference to the value corresponding to the key
     fn find<'a>(&'a self, k: &K) -> Option<&'a V> {
         match self.bucket_for_key(k) {

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -48,12 +48,6 @@ impl<T> Mutable for TrieMap<T> {
 }
 
 impl<T> Map<uint, T> for TrieMap<T> {
-    /// Return true if the map contains a value for the specified key
-    #[inline]
-    fn contains_key(&self, key: &uint) -> bool {
-        self.find(key).is_some()
-    }
-
     /// Return a reference to the value corresponding to the key
     #[inline]
     fn find<'a>(&'a self, key: &uint) -> Option<&'a T> {


### PR DESCRIPTION
Map::contains_key can be implemented with Map::find.

Remove several implementations of contains_key.
