### PR TITLE
Suppress a libuv leak on mac

### DIFF
--- a/src/etc/x86.supp
+++ b/src/etc/x86.supp
@@ -502,3 +502,16 @@
    fun:*
    ...
 }
+
+{
+   libuv-mac-no-thread-join
+   Memcheck:Leak
+   fun:malloc_zone_malloc
+   fun:_CFRuntimeCreateInstance
+   fun:CFRunLoopSourceCreate
+   fun:uv__platform_loop_init
+   fun:uv__loop_init
+   fun:uv_loop_new
+   fun:rust_uv_loop_new__c_stack_shim
+   ...
+}


### PR DESCRIPTION
I suspect that this is a race between process exit and the termination of
worker threads used by libuv (if I sleep before exit it doesn't leak). This
isn't going to cause any real problems but should probably be fixed at
some point.

r? @pcwalton

cc #8253
