### PR TITLE
Deriving options

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -297,7 +297,7 @@ COMPILER_INPUTS := $(wildcard $(addprefix $(S)src/librustc/,      \
 
 LIBSYNTAX_CRATE := $(S)src/libsyntax/syntax.rs
 LIBSYNTAX_INPUTS := $(wildcard $(addprefix $(S)src/libsyntax/, \
-                           *.rs */*.rs */*/*.rs))
+                           *.rs */*.rs */*/*.rs */*/*/*.rs))
 
 DRIVER_CRATE := $(S)src/driver/driver.rs
 

--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1667,6 +1667,39 @@ Supported traits for `deriving` are:
   each constituent field of the type must also implement `ToStr` and will have
   `field.to_str()` invoked to build up the result.
 
+#### Derived comparison options
+
+The `deriving` instances of `Eq`, `TotalEq`, `Ord`, `TotalOrd` all
+support some options that allow control of their behaviour when used
+on structs. These are specified as follows:
+
+~~~
+#[deriving(Eq(test_order(d, c), ignore(b)),
+           TotalEq(test_order(c)),
+           Ord(reverse(a, c)),
+           TotalOrd(reverse(a, c)))]
+struct Options {
+    a: float,
+    b: int,
+    c: uint,
+    d: uint
+}
+~~~
+
+* `test_order` prioritizes the fields listed, testing them first, in
+  the order in which they are listed. That is, the `Eq` instance for
+  `Options` will test `d`, and then `c`, and then the remaining fields
+  (subject to `ignore`). All four traits support this.
+* `ignore` excludes the given field from the comparison, so `Options {
+  .., b: 1, ..} == Options {.., b: 2, .. }` if the rest of the fields
+  are identical. Only `Eq` and `Ord` support `ignore`.
+* `reverse` flips the ordering used for that field, so `Options { a:
+  10.0, ... } < Options { a: 0.0, .. }`. Only `Ord` and `TotalOrd`
+  support `reverse`.
+
+Using an option not listed here is an error. These options are only
+supported on normal structs, not on tuple-structs or enums.
+
 # Statements and expressions
 
 Rust is _primarily_ an expression language. This means that most forms of

--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1691,8 +1691,9 @@ struct Options {
   `Options` will test `d`, and then `c`, and then the remaining fields
   (subject to `ignore`). All four traits support this.
 * `ignore` excludes the given field from the comparison, so `Options {
-  .., b: 1, ..} == Options {.., b: 2, .. }` if the rest of the fields
-  are identical. Only `Eq` and `Ord` support `ignore`.
+  .., b: 1, ..}` and `Options {.., b: 2, .. }` are equal if the rest
+  of the fields are equal (that is, despite `b` being different). Only
+  `Eq` and `Ord` support `ignore`.
 * `reverse` flips the ordering used for that field, so `Options { a:
   10.0, ... } < Options { a: 0.0, .. }`. Only `Ord` and `TotalOrd`
   support `reverse`.

--- a/src/libstd/borrow.rs
+++ b/src/libstd/borrow.rs
@@ -58,3 +58,15 @@ impl<'self, T: Ord> Ord for &'self T {
         *(*self) > *(*other)
     }
 }
+
+#[cfg(not(test))]
+impl<'self, T: TotalOrd> TotalOrd for &'self T {
+    #[inline]
+    fn cmp(&self, other: & &'self T) -> Ordering { (**self).cmp(*other) }
+}
+
+#[cfg(not(test))]
+impl<'self, T: TotalEq> TotalEq for &'self T {
+    #[inline]
+    fn equals(&self, other: & &'self T) -> bool { (**self).equals(*other) }
+}

--- a/src/libstd/cmp.rs
+++ b/src/libstd/cmp.rs
@@ -153,7 +153,6 @@ pub fn cmp2<A:TotalOrd,B:TotalOrd>(
 Return `o1` if it is not `Equal`, otherwise `o2`. Simulates the
 lexical ordering on a type `(int, int)`.
 */
-// used in deriving code in libsyntax
 #[inline]
 pub fn lexical_ordering(o1: Ordering, o2: Ordering) -> Ordering {
     match o1 {

--- a/src/libstd/managed.rs
+++ b/src/libstd/managed.rs
@@ -12,7 +12,7 @@
 
 use ptr::to_unsafe_ptr;
 
-#[cfg(not(test))] use cmp::{Eq, Ord};
+#[cfg(not(test))] use cmp::*;
 
 pub static RC_MANAGED_UNIQUE : uint = (-2) as uint;
 pub static RC_IMMORTAL : uint = 0x77777777;
@@ -71,6 +71,29 @@ impl<T:Ord> Ord for @mut T {
     fn gt(&self, other: &@mut T) -> bool { *(*self) > *(*other) }
 }
 
+#[cfg(not(test))]
+impl<T: TotalOrd> TotalOrd for @T {
+    #[inline]
+    fn cmp(&self, other: &@T) -> Ordering { (**self).cmp(*other) }
+}
+
+#[cfg(not(test))]
+impl<T: TotalOrd> TotalOrd for @mut T {
+    #[inline]
+    fn cmp(&self, other: &@mut T) -> Ordering { (**self).cmp(*other) }
+}
+
+#[cfg(not(test))]
+impl<T: TotalEq> TotalEq for @T {
+    #[inline]
+    fn equals(&self, other: &@T) -> bool { (**self).equals(*other) }
+}
+
+#[cfg(not(test))]
+impl<T: TotalEq> TotalEq for @mut T {
+    #[inline]
+    fn equals(&self, other: &@mut T) -> bool { (**self).equals(*other) }
+}
 #[test]
 fn test() {
     let x = @3;

--- a/src/libstd/owned.rs
+++ b/src/libstd/owned.rs
@@ -10,7 +10,7 @@
 
 //! Operations on unique pointer types
 
-#[cfg(not(test))] use cmp::{Eq, Ord};
+#[cfg(not(test))] use cmp::*;
 
 #[cfg(not(test))]
 impl<T:Eq> Eq for ~T {
@@ -30,4 +30,16 @@ impl<T:Ord> Ord for ~T {
     fn ge(&self, other: &~T) -> bool { *(*self) >= *(*other) }
     #[inline]
     fn gt(&self, other: &~T) -> bool { *(*self) > *(*other) }
+}
+
+#[cfg(not(test))]
+impl<T: TotalOrd> TotalOrd for ~T {
+    #[inline]
+    fn cmp(&self, other: &~T) -> Ordering { (**self).cmp(*other) }
+}
+
+#[cfg(not(test))]
+impl<T: TotalEq> TotalEq for ~T {
+    #[inline]
+    fn equals(&self, other: &~T) -> bool { (**self).equals(*other) }
 }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -282,6 +282,10 @@ impl ExtCtxt {
         self.print_backtrace();
         self.parse_sess.span_diagnostic.span_warn(sp, msg);
     }
+    pub fn span_note(&self, sp: span, msg: &str) {
+        self.print_backtrace();
+        self.parse_sess.span_diagnostic.span_note(sp, msg);
+    }
     pub fn span_unimpl(&self, sp: span, msg: &str) -> ! {
         self.print_backtrace();
         self.parse_sess.span_diagnostic.span_unimpl(sp, msg);

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -21,7 +21,7 @@ pub fn expand_deriving_clone(cx: @ExtCtxt,
                              mitem: @MetaItem,
                              in_items: ~[@item])
                           -> ~[@item] {
-    options.unused_options_maybe_warn(cx, span, "Clone");
+    options.unused_options_maybe_error(cx, span, "Clone");
 
     let trait_def = TraitDef {
         path: Path::new(~["std", "clone", "Clone"]),
@@ -49,7 +49,7 @@ pub fn expand_deriving_deep_clone(cx: @ExtCtxt,
                                   mitem: @MetaItem,
                                   in_items: ~[@item])
     -> ~[@item] {
-    options.unused_options_maybe_warn(cx, span, "DeepClone");
+    options.unused_options_maybe_error(cx, span, "DeepClone");
 
     let trait_def = TraitDef {
         path: Path::new(~["std", "clone", "DeepClone"]),

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -13,12 +13,16 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::DerivingOptions;
 
 pub fn expand_deriving_clone(cx: @ExtCtxt,
                              span: span,
+                             options: DerivingOptions,
                              mitem: @MetaItem,
                              in_items: ~[@item])
                           -> ~[@item] {
+    options.unused_options_maybe_warn(cx, span, "Clone");
+
     let trait_def = TraitDef {
         path: Path::new(~["std", "clone", "Clone"]),
         additional_bounds: ~[],
@@ -41,9 +45,12 @@ pub fn expand_deriving_clone(cx: @ExtCtxt,
 
 pub fn expand_deriving_deep_clone(cx: @ExtCtxt,
                                   span: span,
+                                  options: DerivingOptions,
                                   mitem: @MetaItem,
                                   in_items: ~[@item])
     -> ~[@item] {
+    options.unused_options_maybe_warn(cx, span, "DeepClone");
+
     let trait_def = TraitDef {
         path: Path::new(~["std", "clone", "DeepClone"]),
         additional_bounds: ~[],

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -13,9 +13,11 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::DerivingOptions;
 
 pub fn expand_deriving_eq(cx: @ExtCtxt,
                           span: span,
+                          _options: DerivingOptions,
                           mitem: @MetaItem,
                           in_items: ~[@item]) -> ~[@item] {
     // structures are equal if all fields are equal, and non equal, if

--- a/src/libsyntax/ext/deriving/cmp/mod.rs
+++ b/src/libsyntax/ext/deriving/cmp/mod.rs
@@ -1,0 +1,381 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use ast::{ident, expr};
+use codemap::span;
+use ast;
+use ext::base::ExtCtxt;
+use ext::deriving::generic::*;
+use ext::deriving::{DerivingOptions, NoOptions, Lit, List};
+
+use std::vec;
+
+pub mod eq;
+pub mod totaleq;
+pub mod ord;
+pub mod totalord;
+
+pub struct CmpOptions_ {
+    /// Ensure that we don't show errors several times.
+    shown_errors: bool,
+    test_order: ~[(ident, span)],
+    ignore: ~[(ident, span)],
+    reverse: ~[(ident, span)]
+}
+pub struct CmpOptions(Option<CmpOptions_>);
+
+impl CmpOptions {
+    pub fn parse(cx: @ExtCtxt, _span: span, trait_name: &str,
+                 options: DerivingOptions,
+                 allow_ignore: bool, allow_reverse: bool) -> Option<CmpOptions> {
+        // Trait(<option>(...))
+        match options {
+            NoOptions => Some(CmpOptions(None)),
+            Lit(ref lit) => {
+                cx.span_err(lit.span,
+                            fmt!("`#[deriving(%s)]` does not \
+                                  accept options with this syntax",
+                                 trait_name));
+                None
+            }
+            List(ref list) => {
+                let mut cmp_options = CmpOptions_ {
+                    shown_errors: false,
+                    test_order: ~[],
+                    ignore: ~[],
+                    reverse: ~[]
+                };
+
+                let mut no_errors = true;
+                for item in list.iter() {
+                    match item.node {
+                        ast::MetaList(name, ref fields) => {
+                            no_errors = no_errors &&
+                                cmp_options.parse_inner(cx,
+                                                        trait_name, allow_ignore, allow_reverse,
+                                                        item.span, name,
+                                                        *fields)
+                        }
+                        _ => {
+                            cx.span_err(
+                                item.span,
+                                fmt!("`#[deriving(%s)]` only accepts %s", trait_name,
+                                     format_allowed(allow_ignore, allow_reverse, "(...)")));
+                            no_errors = false;
+                        }
+                    }
+                }
+                if no_errors {
+                    Some(CmpOptions(Some(cmp_options)))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// Run a normal CombineSubstructureFunc with reordered
+    /// fields. Use `first_run` to control whether error messages that
+    /// occur on every run should be shown or not.
+    pub fn call_substructure(&mut self, cx: @ExtCtxt, span: span,
+                             substr: &Substructure,
+                             f: CombineSubstructureFunc) -> @expr {
+        match self.process_substructure(cx, span, substr.fields) {
+            Left(ref new_substr_fields) => {
+                let new_substr = Substructure {
+                    fields: new_substr_fields,
+                    .. *substr
+                };
+                f(cx, span, &new_substr)
+            }
+            Right(true) => f(cx, span, substr), // no changes, use the old one
+
+            // whatever, just fill in something to get this to
+            // function to work; we should never actually run this
+            // expression (because `None` here means an error has
+            // occurred already) so it'll never occur in the final,
+            // compiled code.
+            Right(false) => cx.expr_unreachable(span)
+        }
+    }
+
+    /// Reorders the fields of `Struct(~[Some(id), self, ~[other],
+    /// ...])` and returns the new fields as `Left(fields)`, and if no
+    /// changes were necessary returns `Right(true)`, if an error
+    /// occurred (e.g. options on a enum or tuple struct) returns
+    /// `Right(false)`.
+    fn process_substructure(&mut self,
+                            cx: @ExtCtxt,
+                            span: span,
+                            fields: &SubstructureFields)
+        -> Either<SubstructureFields<'static>, bool> {
+        // say no to rightward drift.
+        let options = match **self {
+            None => return Right(true), // no options, no adjustments.
+            Some(ref mut options) => options
+        };
+
+        // extract the list of fields
+        let fields_list = match *fields {
+            // The only valid case: a struct with named fields, and
+            // the method has precisely 2 Self args.
+            Struct(ref list) => {
+                // should be [(Some(id), self, [other]), ...]
+                if list.is_empty() || list[0].n0_ref().is_none() {
+                    // Some(id) is actually None, or there are no fields
+                    do options.oneshot_error {
+                        cx.span_err(span,
+                                    fmt!("cannot use options on a %s struct",
+                                         if list.is_empty() {"unit"} else {"tuple"}));
+                    }
+                    return Right(false);
+                } else if list[0].n2_ref().len() != 1 { // explicit self is separate
+                    cx.span_bug(span,
+                                fmt!("CmpOptions used for a method with %u Self \
+                                      args (should be 2)",
+                                     list[0].n2_ref().len() + 1)); // account for explicit self
+                }
+
+                list.as_slice()
+            }
+            EnumMatching(*) | EnumNonMatching(*) => {
+                do options.oneshot_error {
+                    cx.span_err(span, "cannot use options on an enum");
+                }
+                return Right(false);
+            }
+            StaticStruct(*) | StaticEnum(*) => {
+                cx.span_bug(span, "CmpOptions used for a static method.");
+            }
+        };
+
+        match options.rearrange_struct_fields(cx, fields_list) {
+            Some(substr) => Left(substr),
+            None => Right(false)
+        }
+    }
+}
+
+impl CmpOptions_ {
+    // extract the fields from `<option>(<fields>)` and place them
+    // into the appropriate array.  e.g. `test_order(foo, bar)` goes
+    // into self.test_order.
+    fn parse_inner(&mut self, cx: @ExtCtxt,
+                   trait_name: &str, allow_ignore: bool, allow_reverse: bool,
+                   option_span: span, option_name: &str,
+                   fields: &[@ast::MetaItem]) -> bool {
+        // FIXME #7930
+        let (test_order, ignore, reverse) = match *self {
+            CmpOptions_ {
+                test_order: ref mut test_order,
+                ignore: ref mut ignore,
+                reverse: ref mut reverse,
+                _
+            } => (test_order, ignore, reverse)
+        };
+
+        // work out the vec to which the current option corresponds
+        // too, if the current option is allowed by the caller, and
+        // which vecs any options occuring in this one cannot occur in
+        // (e.g. cannot ignore and reverse a field at the same time).
+        let (append_to, allowed, disjoint_with) = match option_name {
+            "test_order" => (test_order, true,  // always allowed
+                             &[("ignore", ignore.as_slice())]),
+            "ignore"     => (ignore, allow_ignore,
+                             &[("test_order", test_order.as_slice()),
+                               ("reverse", reverse.as_slice())]),
+            "reverse"    => (reverse, allow_reverse,
+                             &[("ignore", ignore.as_slice())]),
+            _            => {
+                cx.span_err(option_span,
+                            fmt!("unrecognised option name: `%s`", option_name));
+                cx.span_note(option_span,
+                             fmt!("`#[deriving(%s)]` only accepts %s", trait_name,
+                                  format_allowed(allow_ignore, allow_reverse, "")));
+                return false;
+            }
+        };
+
+        if !allowed {
+            cx.span_err(option_span,
+                        fmt!("illegal option: `#[deriving(%s)]` does not allow `%s`",
+                             trait_name, option_name));
+            return false;
+        }
+
+        // Trait(option(<field>, ...))
+        let mut no_errors = true;
+        for field in fields.iter() {
+            match field.node {
+                ast::MetaWord(field_name) => {
+                    let id = cx.ident_of(field_name);
+
+                    // check for duplicates
+                    match append_to.iter().find_(|& &(other_id, _)| id == other_id) {
+                        Some(&(_, span)) => { // it's a duplicate!
+                            cx.span_err(field.span,
+                                        fmt!("field `%s` occurs more than once", field_name));
+                            cx.span_note(span, "previous occurrence");
+                            no_errors = false;
+                            loop;
+                        }
+                        None => {}
+                    }
+
+                    // check that it hasn't already occurred in an
+                    // option it shouldn't've, i.e. can't `ignore` and
+                    // `reverse` a field at the same time
+                    for &(other_name, ref test_against) in disjoint_with.iter() {
+                        match test_against.iter().find_(|& &(other_id, _)| id == other_id) {
+                            Some(&(_, span)) => {
+                                cx.span_err(field.span,
+                                            fmt!("field `%s` cannot occur in both `%s` and `%s`",
+                                                 field_name, option_name, other_name));
+                                cx.span_note(span, "previous occurrence");
+                                no_errors = false;
+                                loop;
+                            }
+                            None => {}
+                        }
+                    }
+
+                    // all ok.
+                    append_to.push((id, field.span))
+                }
+                _ => {
+                    cx.span_err(
+                        field.span,
+                        fmt!("invalid value: `%s` only accepts a list of field names",
+                             option_name));
+                    no_errors = false;
+                }
+            }
+        }
+
+        no_errors
+    }
+
+    /// Only calls `display` if this hasn't been called previously,
+    /// i.e. it restricts errors to be shown once, even if
+    /// rearrange_struct_fields is called multiple times.
+    fn oneshot_error(&mut self, displayer: &fn()) {
+        if !self.shown_errors {
+            displayer();
+            self.shown_errors = true;
+        }
+    }
+
+    /// Rearrange the vec of fields of a struct with named
+    /// fields. Calling this with None for one of the idents will
+    /// crash the compiler.
+    fn rearrange_struct_fields(&mut self,
+                               cx: @ExtCtxt,
+                               fields_list: &[(Option<ident>, @expr, ~[@expr])])
+        -> Option<SubstructureFields<'static>> {
+        // collect the errors rather than showing them incrementally,
+        // because we need to print them in one go inside
+        // `show_errors_once`.
+        let mut errors = ~[];
+
+        // check that all the fields referenced actually exist in the
+        // struct.
+        { // restrict the lifetime of these immutable borrows.
+            let mut check_valid = self.test_order.iter()
+                .chain_(self.ignore.iter())
+                .chain_(self.reverse.iter());
+
+            // use advance rather than shortcircuiting `all` because we
+            // can check all the fields at once this way.
+            for &(id, span) in check_valid {
+                // run through all the fields of the struct.
+                let exists = do fields_list.iter().any |&(some_id, _, _)| {
+                    id == some_id.get()
+                };
+                if !exists {
+                    errors.push((span, fmt!("field `%s` does not exist", cx.str_of(id))));
+                }
+            };
+        }
+        if !errors.is_empty() {
+            do self.oneshot_error {
+                for &(span, ref msg) in errors.iter() {
+                    cx.span_err(span, *msg)
+                }
+            }
+
+            return None;
+        }
+
+        let mut prioritised_fields = vec::from_elem(self.test_order.len(), None);
+        let mut normal_fields = ~[];
+
+        for field in fields_list.iter() {
+            match *field {
+                (Some(field_id), self_field, [other_field]) => {
+                    if self.ignore.iter().any(|&(id, _)| field_id == id) {
+                        // it s' ignored, so skip it.
+                        loop;
+                    }
+
+                    // swap other and self if the field is a reversed
+                    // field.
+                    let to_insert = if self.reverse.iter().any(|&(id, _)| field_id == id) {
+                        (Some(field_id), other_field, ~[self_field])
+                    } else {
+                        (Some(field_id), self_field, ~[other_field])
+                    };
+
+                    match self.test_order.iter().position(|&(id, _)| field_id == id) {
+                        Some(i) => prioritised_fields[i] = Some(to_insert),
+                        None    => normal_fields.push(to_insert)
+                    }
+                }
+                _ => fail!("Impossible! Somehow a bad field slipped through.")
+            }
+        }
+
+        let mut out_fields = vec::with_capacity(prioritised_fields.len() + normal_fields.len());
+        for field in prioritised_fields.consume_iter() {
+            match field {
+                Some(x) => out_fields.push(x),
+                None => fail!("Impossible! Somehow missing a `test_order` field.")
+            }
+        }
+        out_fields.push_all_move(normal_fields);
+        Some(Struct(out_fields))
+    }
+}
+
+// format the string that says "`test_order()` and `ignore()`" etc,
+// based on what is allowed for the current #[deriving()] trait.
+fn format_allowed(allow_ignore: bool, allow_reverse: bool, suffix: &str) -> ~str {
+    macro_rules! mk(($name:expr) => {
+        fmt!("`%s%s`", $name, suffix)
+    });
+    let mut s = mk!("test_order");
+    match (allow_ignore, allow_reverse) {
+        (false, false) => {}
+        (true,  true) => {
+            s.push_str(", ");
+            s.push_str(mk!("reverse"));
+            s.push_str(" and ");
+            s.push_str(mk!("ignore"));
+        }
+        (true,  false) => {
+            s.push_str(" and ");
+            s.push_str(mk!("ignore"));
+        }
+        (false, true) => {
+            s.push_str(" and ");
+            s.push_str(mk!("reverse"));
+        }
+    }
+    s
+}

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -14,9 +14,11 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::DerivingOptions;
 
 pub fn expand_deriving_ord(cx: @ExtCtxt,
                            span: span,
+                           _options: DerivingOptions,
                            mitem: @MetaItem,
                            in_items: ~[@item]) -> ~[@item] {
     macro_rules! md (

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -13,9 +13,11 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::DerivingOptions;
 
 pub fn expand_deriving_totaleq(cx: @ExtCtxt,
                                span: span,
+                               _options: DerivingOptions,
                                mitem: @MetaItem,
                                in_items: ~[@item]) -> ~[@item] {
     fn cs_equals(cx: @ExtCtxt, span: span, substr: &Substructure) -> @expr {

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -14,12 +14,18 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 use ext::deriving::DerivingOptions;
+use ext::deriving::cmp::CmpOptions;
 
 pub fn expand_deriving_totaleq(cx: @ExtCtxt,
                                span: span,
-                               _options: DerivingOptions,
+                               options: DerivingOptions,
                                mitem: @MetaItem,
                                in_items: ~[@item]) -> ~[@item] {
+    let mut options = match CmpOptions::parse(cx, span, "TotalEq", options, false, false) {
+        Some(o) => o,
+        None => return in_items
+    };
+
     fn cs_equals(cx: @ExtCtxt, span: span, substr: &Substructure) -> @expr {
         cs_and(|cx, span, _, _| cx.expr_bool(span, false),
                cx, span, substr)
@@ -37,7 +43,9 @@ pub fn expand_deriving_totaleq(cx: @ExtCtxt,
                 args: ~[borrowed_self()],
                 ret_ty: Literal(Path::new(~["bool"])),
                 const_nonmatching: true,
-                combine_substructure: cs_equals
+                combine_substructure: |cx, span, s| {
+                    options.call_substructure(cx, span, s, cs_equals)
+                }
             }
         ]
     };

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use ast;
 use ast::{MetaItem, item, expr};
 use codemap::span;
 use ext::base::ExtCtxt;
@@ -40,40 +41,70 @@ pub fn expand_deriving_totalord(cx: @ExtCtxt,
 }
 
 
-pub fn ordering_const(cx: @ExtCtxt, span: span, cnst: Ordering) -> @expr {
+pub fn ordering_const(cx: @ExtCtxt, span: span, cnst: Ordering) -> ast::Path {
     let cnst = match cnst {
         Less => "Less",
         Equal => "Equal",
         Greater => "Greater"
     };
-    cx.expr_path(
-        cx.path_global(span,
-                       ~[cx.ident_of("std"),
-                         cx.ident_of("cmp"),
-                         cx.ident_of(cnst)]))
+    cx.path_global(span,
+                   ~[cx.ident_of("std"),
+                     cx.ident_of("cmp"),
+                     cx.ident_of(cnst)])
 }
 
 pub fn cs_cmp(cx: @ExtCtxt, span: span,
               substr: &Substructure) -> @expr {
+    let test_id = cx.ident_of("__test");
+    let equals_path = ordering_const(cx, span, Equal);
 
+    /*
+    Builds:
+
+    let __test = self_field1.cmp(&other_field2);
+    if other == ::std::cmp::Equal {
+        let __test = self_field2.cmp(&other_field2);
+        if __test == ::std::cmp::Equal {
+            ...
+        } else {
+            __test
+        }
+    } else {
+        __test
+    }
+
+    FIXME #6449: These `if`s could/should be `match`es.
+    */
     cs_same_method_fold(
-        // foldr (possibly) nests the matches in lexical_ordering better
+        // foldr nests the if-elses correctly, leaving the first field
+        // as the outermost one, and the last as the innermost.
         false,
         |cx, span, old, new| {
-            cx.expr_call_global(span,
-                                ~[cx.ident_of("std"),
-                                  cx.ident_of("cmp"),
-                                  cx.ident_of("lexical_ordering")],
-                                ~[old, new])
+            // let __test = new;
+            // if __test == ::std::cmp::Equal {
+            //    old
+            // } else {
+            //    __test
+            // }
+
+            let assign = cx.stmt_let(span, false, test_id, new);
+
+            let cond = cx.expr_binary(span, ast::eq,
+                                      cx.expr_ident(span, test_id),
+                                      cx.expr_path(equals_path.clone()));
+            let if_ = cx.expr_if(span,
+                                 cond,
+                                 old, Some(cx.expr_ident(span, test_id)));
+            cx.expr_block(cx.block(span, ~[assign], Some(if_)))
         },
-        ordering_const(cx, span, Equal),
+        cx.expr_path(equals_path.clone()),
         |cx, span, list, _| {
             match list {
                 // an earlier nonmatching variant is Less than a
-                // later one
+                // later one.
                 [(self_var, _, _),
-                 (other_var, _, _)] => ordering_const(cx, span,
-                                                      self_var.cmp(&other_var)),
+                 (other_var, _, _)] => cx.expr_path(ordering_const(cx, span,
+                                                                   self_var.cmp(&other_var))),
                 _ => cx.span_bug(span, "Not exactly 2 arguments in `deriving(TotalOrd)`")
             }
         },

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -14,10 +14,12 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::DerivingOptions;
 use std::cmp::{Ordering, Equal, Less, Greater};
 
 pub fn expand_deriving_totalord(cx: @ExtCtxt,
                                 span: span,
+                                _options: DerivingOptions,
                                 mitem: @MetaItem,
                                 in_items: ~[@item]) -> ~[@item] {
     let trait_def = TraitDef {

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -16,12 +16,18 @@ use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 use ext::deriving::DerivingOptions;
 use std::cmp::{Ordering, Equal, Less, Greater};
+use ext::deriving::cmp::CmpOptions;
 
 pub fn expand_deriving_totalord(cx: @ExtCtxt,
                                 span: span,
-                                _options: DerivingOptions,
+                                options: DerivingOptions,
                                 mitem: @MetaItem,
                                 in_items: ~[@item]) -> ~[@item] {
+    let mut options = match CmpOptions::parse(cx, span, "TotalOrd", options, false, true) {
+        Some(o) => o,
+        None => return in_items
+    };
+
     let trait_def = TraitDef {
         path: Path::new(~["std", "cmp", "TotalOrd"]),
         additional_bounds: ~[],
@@ -34,7 +40,9 @@ pub fn expand_deriving_totalord(cx: @ExtCtxt,
                 args: ~[borrowed_self()],
                 ret_ty: Literal(Path::new(~["std", "cmp", "Ordering"])),
                 const_nonmatching: false,
-                combine_substructure: cs_cmp
+                combine_substructure: |cx, span, substr| {
+                    options.call_substructure(cx, span, substr, cs_cmp)
+                }
             }
         ]
     };

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -10,7 +10,7 @@
 
 /*!
 The compiler code necessary for #[deriving(Decodable)]. See
-encodable.rs for more.
+encodable.rs for more details.
 */
 
 use std::vec;
@@ -20,9 +20,11 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::DerivingOptions;
 
 pub fn expand_deriving_decodable(cx: @ExtCtxt,
                                  span: span,
+                                 _options: DerivingOptions,
                                  mitem: @MetaItem,
                                  in_items: ~[@item]) -> ~[@item] {
     let trait_def = TraitDef {

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -24,9 +24,11 @@ use ext::deriving::DerivingOptions;
 
 pub fn expand_deriving_decodable(cx: @ExtCtxt,
                                  span: span,
-                                 _options: DerivingOptions,
+                                 options: DerivingOptions,
                                  mitem: @MetaItem,
                                  in_items: ~[@item]) -> ~[@item] {
+    options.unused_options_maybe_error(cx, span, "Decodable");
+
     let trait_def = TraitDef {
         path: Path::new_(~["extra", "serialize", "Decodable"], None,
                          ~[~Literal(Path::new_local("__D"))], true),

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -80,9 +80,11 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::DerivingOptions;
 
 pub fn expand_deriving_encodable(cx: @ExtCtxt,
                                  span: span,
+                                 _options: DerivingOptions,
                                  mitem: @MetaItem,
                                  in_items: ~[@item]) -> ~[@item] {
     let trait_def = TraitDef {

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -84,9 +84,11 @@ use ext::deriving::DerivingOptions;
 
 pub fn expand_deriving_encodable(cx: @ExtCtxt,
                                  span: span,
-                                 _options: DerivingOptions,
+                                 options: DerivingOptions,
                                  mitem: @MetaItem,
                                  in_items: ~[@item]) -> ~[@item] {
+    options.unused_options_maybe_error(cx, span, "Encodable");
+
     let trait_def = TraitDef {
         path: Path::new_(~["extra", "serialize", "Encodable"], None,
                          ~[~Literal(Path::new_local("__E"))], true),

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -442,14 +442,14 @@ impl<'self> MethodDef<'self> {
                                 type_ident: ident,
                                 self_args: &[@expr],
                                 nonself_args: &[@expr],
-                                fields: &SubstructureFields)
+                                fields: SubstructureFields)
         -> @expr {
         let substructure = Substructure {
             type_ident: type_ident,
             method_ident: cx.ident_of(self.name),
             self_args: self_args,
             nonself_args: nonself_args,
-            fields: fields
+            fields: &fields
         };
         (self.combine_substructure)(cx, span,
                                     &substructure)
@@ -609,7 +609,7 @@ impl<'self> MethodDef<'self> {
             type_ident,
             self_args,
             nonself_args,
-            &Struct(fields));
+            Struct(fields));
 
         // make a series of nested matches, to destructure the
         // structs. This is actually right-to-left, but it shoudn't
@@ -634,7 +634,7 @@ impl<'self> MethodDef<'self> {
         self.call_substructure_method(cx, span,
                                       type_ident,
                                       self_args, nonself_args,
-                                      &StaticStruct(struct_def, summary))
+                                      StaticStruct(struct_def, summary))
     }
 
     /**
@@ -761,7 +761,7 @@ impl<'self> MethodDef<'self> {
             }
             self.call_substructure_method(cx, span, type_ident,
                                           self_args, nonself_args,
-                                          &substructure)
+                                          substructure)
 
         } else {  // there are still matches to create
             let current_match_str = if match_count == 0 {
@@ -803,10 +803,9 @@ impl<'self> MethodDef<'self> {
                 arms.push(cx.arm(span, ~[ pattern ], arm_expr));
 
                 if enum_def.variants.len() > 1 {
-                    let e = &EnumNonMatching(&[]);
                     let wild_expr = self.call_substructure_method(cx, span, type_ident,
                                                                   self_args, nonself_args,
-                                                                  e);
+                                                                  EnumNonMatching(&[]));
                     let wild_arm = cx.arm(span,
                                           ~[ cx.pat_wild(span) ],
                                           wild_expr);
@@ -869,7 +868,7 @@ impl<'self> MethodDef<'self> {
         self.call_substructure_method(cx,
                                       span, type_ident,
                                       self_args, nonself_args,
-                                      &StaticEnum(enum_def, summary))
+                                      StaticEnum(enum_def, summary))
     }
 }
 

--- a/src/libsyntax/ext/deriving/iter_bytes.rs
+++ b/src/libsyntax/ext/deriving/iter_bytes.rs
@@ -20,7 +20,7 @@ pub fn expand_deriving_iter_bytes(cx: @ExtCtxt,
                                   options: DerivingOptions,
                                   mitem: @MetaItem,
                                   in_items: ~[@item]) -> ~[@item] {
-    options.unused_options_maybe_warn(cx, span, "IterBytes");
+    options.unused_options_maybe_error(cx, span, "IterBytes");
 
     let trait_def = TraitDef {
         path: Path::new(~["std", "to_bytes", "IterBytes"]),

--- a/src/libsyntax/ext/deriving/iter_bytes.rs
+++ b/src/libsyntax/ext/deriving/iter_bytes.rs
@@ -13,12 +13,15 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
-
+use ext::deriving::DerivingOptions;
 
 pub fn expand_deriving_iter_bytes(cx: @ExtCtxt,
                                   span: span,
+                                  options: DerivingOptions,
                                   mitem: @MetaItem,
                                   in_items: ~[@item]) -> ~[@item] {
+    options.unused_options_maybe_warn(cx, span, "IterBytes");
+
     let trait_def = TraitDef {
         path: Path::new(~["std", "to_bytes", "IterBytes"]),
         additional_bounds: ~[],

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -31,15 +31,8 @@ pub mod rand;
 pub mod to_str;
 pub mod zero;
 
-#[path="cmp/eq.rs"]
-pub mod eq;
-#[path="cmp/totaleq.rs"]
-pub mod totaleq;
-#[path="cmp/ord.rs"]
-pub mod ord;
-#[path="cmp/totalord.rs"]
-pub mod totalord;
-
+#[path="cmp/mod.rs"]
+pub mod cmp;
 
 pub mod generic;
 
@@ -76,10 +69,10 @@ pub fn expand_meta_deriving(cx: @ExtCtxt,
                     "Encodable" => expand!(encodable::expand_deriving_encodable),
                     "Decodable" => expand!(decodable::expand_deriving_decodable),
 
-                    "Eq" => expand!(eq::expand_deriving_eq),
-                    "TotalEq" => expand!(totaleq::expand_deriving_totaleq),
-                    "Ord" => expand!(ord::expand_deriving_ord),
-                    "TotalOrd" => expand!(totalord::expand_deriving_totalord),
+                    "Eq" => expand!(cmp::eq::expand_deriving_eq),
+                    "TotalEq" => expand!(cmp::totaleq::expand_deriving_totaleq),
+                    "Ord" => expand!(cmp::ord::expand_deriving_ord),
+                    "TotalOrd" => expand!(cmp::totalord::expand_deriving_totalord),
 
                     "Rand" => expand!(rand::expand_deriving_rand),
 

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -98,15 +98,16 @@ pub enum DerivingOptions<'self> {
 }
 
 impl<'self> DerivingOptions<'self> {
-    /// Emits a warning when there are options and the deriving
+    /// Emits a error when there are options and the deriving
     /// implementation doesn't use them (i.e. it warns if `self` is
     /// not `NoOptions`.)
-    pub fn unused_options_maybe_warn(&self, cx: @ExtCtxt, span: span, deriving_name: &str) {
+    pub fn unused_options_maybe_error(&self, cx: @ExtCtxt, span: span, deriving_name: &str) {
         match *self {
             NoOptions => {},
             _ => {
-                cx.span_warn(span,
-                             fmt!("`#[deriving(%s)]` does not use any options.", deriving_name));
+                cx.span_err(span,
+                            fmt!("`#[deriving(%s)]` does not use any options.",
+                                 deriving_name));
             }
         }
     }

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -18,8 +18,7 @@ library.
 
 */
 
-use ast::{enum_def, ident, item, Generics, struct_def};
-use ast::{MetaItem, MetaList, MetaNameValue, MetaWord};
+use ast::{item, lit, MetaItem, MetaList, MetaNameValue, MetaWord};
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use codemap::span;
@@ -44,19 +43,6 @@ pub mod totalord;
 
 pub mod generic;
 
-pub type ExpandDerivingStructDefFn<'self> = &'self fn(@ExtCtxt,
-                                                       span,
-                                                       x: &struct_def,
-                                                       ident,
-                                                       y: &Generics)
-                                                 -> @item;
-pub type ExpandDerivingEnumDefFn<'self> = &'self fn(@ExtCtxt,
-                                                    span,
-                                                    x: &enum_def,
-                                                    ident,
-                                                    y: &Generics)
-                                                 -> @item;
-
 pub fn expand_meta_deriving(cx: @ExtCtxt,
                             _span: span,
                             mitem: @MetaItem,
@@ -73,39 +59,61 @@ pub fn expand_meta_deriving(cx: @ExtCtxt,
         }
         MetaList(_, ref titems) => {
             do titems.rev_iter().fold(in_items) |in_items, &titem| {
-                match titem.node {
-                    MetaNameValue(tname, _) |
-                    MetaList(tname, _) |
-                    MetaWord(tname) => {
-                        macro_rules! expand(($func:path) => ($func(cx, titem.span,
-                                                                   titem, in_items)));
-                        match tname.as_slice() {
-                            "Clone" => expand!(clone::expand_deriving_clone),
-                            "DeepClone" => expand!(clone::expand_deriving_deep_clone),
+                let (name, options) = match titem.node {
+                    MetaNameValue(name, ref lit) => (name, Lit(lit)),
+                    MetaList(name, ref list) => (name, List(*list)),
+                    MetaWord(name) => (name, NoOptions),
+                };
 
-                            "IterBytes" => expand!(iter_bytes::expand_deriving_iter_bytes),
+                macro_rules! expand(($func:path) => ($func(cx, titem.span, options,
+                                                           titem, in_items)));
+                match name.as_slice() {
+                    "Clone" => expand!(clone::expand_deriving_clone),
+                    "DeepClone" => expand!(clone::expand_deriving_deep_clone),
 
-                            "Encodable" => expand!(encodable::expand_deriving_encodable),
-                            "Decodable" => expand!(decodable::expand_deriving_decodable),
+                    "IterBytes" => expand!(iter_bytes::expand_deriving_iter_bytes),
 
-                            "Eq" => expand!(eq::expand_deriving_eq),
-                            "TotalEq" => expand!(totaleq::expand_deriving_totaleq),
-                            "Ord" => expand!(ord::expand_deriving_ord),
-                            "TotalOrd" => expand!(totalord::expand_deriving_totalord),
+                    "Encodable" => expand!(encodable::expand_deriving_encodable),
+                    "Decodable" => expand!(decodable::expand_deriving_decodable),
 
-                            "Rand" => expand!(rand::expand_deriving_rand),
+                    "Eq" => expand!(eq::expand_deriving_eq),
+                    "TotalEq" => expand!(totaleq::expand_deriving_totaleq),
+                    "Ord" => expand!(ord::expand_deriving_ord),
+                    "TotalOrd" => expand!(totalord::expand_deriving_totalord),
 
-                            "ToStr" => expand!(to_str::expand_deriving_to_str),
-                            "Zero" => expand!(zero::expand_deriving_zero),
+                    "Rand" => expand!(rand::expand_deriving_rand),
 
-                            ref tname => {
-                                cx.span_err(titem.span, fmt!("unknown \
-                                    `deriving` trait: `%s`", *tname));
-                                in_items
-                            }
-                        }
+                    "ToStr" => expand!(to_str::expand_deriving_to_str),
+                    "Zero" => expand!(zero::expand_deriving_zero),
+
+                    _ => {
+                        cx.span_err(titem.span, fmt!("unknown `deriving` trait: `%s`", name));
+                        in_items
                     }
                 }
+            }
+        }
+    }
+}
+
+/// Summary of `#[deriving(SomeTrait(foo, option="bar"))]` and
+/// `#[deriving(SomeTrait="foo")]`.
+pub enum DerivingOptions<'self> {
+    NoOptions,
+    Lit(&'self lit),
+    List(&'self [@MetaItem])
+}
+
+impl<'self> DerivingOptions<'self> {
+    /// Emits a warning when there are options and the deriving
+    /// implementation doesn't use them (i.e. it warns if `self` is
+    /// not `NoOptions`.)
+    pub fn unused_options_maybe_warn(&self, cx: @ExtCtxt, span: span, deriving_name: &str) {
+        match *self {
+            NoOptions => {},
+            _ => {
+                cx.span_warn(span,
+                             fmt!("`#[deriving(%s)]` does not use any options.", deriving_name));
             }
         }
     }

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -23,7 +23,7 @@ pub fn expand_deriving_rand(cx: @ExtCtxt,
                             mitem: @MetaItem,
                             in_items: ~[@item])
     -> ~[@item] {
-    options.unused_options_maybe_warn(cx, span, "Rand");
+    options.unused_options_maybe_error(cx, span, "Rand");
 
     let trait_def = TraitDef {
         path: Path::new(~["std", "rand", "Rand"]),

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -14,14 +14,17 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::{AstBuilder, Duplicate};
 use ext::deriving::generic::*;
-
+use ext::deriving::DerivingOptions;
 use std::vec;
 
 pub fn expand_deriving_rand(cx: @ExtCtxt,
                             span: span,
+                            options: DerivingOptions,
                             mitem: @MetaItem,
                             in_items: ~[@item])
     -> ~[@item] {
+    options.unused_options_maybe_warn(cx, span, "Rand");
+
     let trait_def = TraitDef {
         path: Path::new(~["std", "rand", "Rand"]),
         additional_bounds: ~[],

--- a/src/libsyntax/ext/deriving/to_str.rs
+++ b/src/libsyntax/ext/deriving/to_str.rs
@@ -22,7 +22,7 @@ pub fn expand_deriving_to_str(cx: @ExtCtxt,
                               mitem: @MetaItem,
                               in_items: ~[@item])
     -> ~[@item] {
-    options.unused_options_maybe_warn(cx, span, "ToStr");
+    options.unused_options_maybe_error(cx, span, "ToStr");
 
     let trait_def = TraitDef {
         path: Path::new(~["std", "to_str", "ToStr"]),

--- a/src/libsyntax/ext/deriving/to_str.rs
+++ b/src/libsyntax/ext/deriving/to_str.rs
@@ -14,12 +14,16 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::DerivingOptions;
 
 pub fn expand_deriving_to_str(cx: @ExtCtxt,
                               span: span,
+                              options: DerivingOptions,
                               mitem: @MetaItem,
                               in_items: ~[@item])
     -> ~[@item] {
+    options.unused_options_maybe_warn(cx, span, "ToStr");
+
     let trait_def = TraitDef {
         path: Path::new(~["std", "to_str", "ToStr"]),
         additional_bounds: ~[],

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -209,7 +209,7 @@ pub struct LifetimeBounds<'self> {
 }
 
 impl<'self> LifetimeBounds<'self> {
-    pub fn empty() -> LifetimeBounds<'static> {
+    pub fn empty<'r>() -> LifetimeBounds<'r> {
         LifetimeBounds {
             lifetimes: ~[], bounds: ~[]
         }

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -13,14 +13,17 @@ use codemap::span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
-
+use ext::deriving::DerivingOptions;
 use std::vec;
 
 pub fn expand_deriving_zero(cx: @ExtCtxt,
                             span: span,
+                            options: DerivingOptions,
                             mitem: @MetaItem,
                             in_items: ~[@item])
     -> ~[@item] {
+    options.unused_options_maybe_warn(cx, span, "Zero");
+
     let trait_def = TraitDef {
         path: Path::new(~["std", "num", "Zero"]),
         additional_bounds: ~[],

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -22,7 +22,7 @@ pub fn expand_deriving_zero(cx: @ExtCtxt,
                             mitem: @MetaItem,
                             in_items: ~[@item])
     -> ~[@item] {
-    options.unused_options_maybe_warn(cx, span, "Zero");
+    options.unused_options_maybe_error(cx, span, "Zero");
 
     let trait_def = TraitDef {
         path: Path::new(~["std", "num", "Zero"]),

--- a/src/test/compile-fail/deriving-cmp-options.rs
+++ b/src/test/compile-fail/deriving-cmp-options.rs
@@ -1,0 +1,47 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deriving(Eq="foo")] //~ ERROR does not accept options with this syntax
+struct S1 { a: int }
+
+#[deriving(Eq(bad_option(x)))] //~ ERROR unrecognised option name
+struct S2 { a: int }
+
+#[deriving(Eq(bad_option))] //~ ERROR only accepts `test_order(...)` and `ignore(...)`
+struct S3 { a: int }
+
+#[deriving(Eq(reverse(a)), //~ ERROR does not allow `reverse`
+           TotalEq(reverse(a)))] //~ ERROR does not allow `reverse`
+struct S4 { a: int }
+
+#[deriving(TotalEq(ignore(a)), //~ ERROR does not allow `ignore`
+           TotalOrd(ignore(a)))] //~ ERROR does not allow `ignore`
+struct S5 { a: int }
+
+#[deriving(Eq(ignore(b)))] //~ ERROR field `b` does not exist
+struct S6 { a: int }
+
+#[deriving(Eq(ignore(a,a)))] //~ ERROR field `a` occurs more than once
+struct S7 { a: int }
+
+#[deriving(Eq(test_order(a), ignore(a)))] //~ ERROR in both `ignore` and `test_order`
+struct S8 { a: int }
+
+#[deriving(Ord(reverse(a), ignore(a)))] //~ ERROR in both `ignore` and `reverse`
+struct S9 { a: int }
+
+#[deriving(Eq(ignore()))] //~ ERROR cannot use options on a unit struct
+struct Unit;
+
+#[deriving(Eq(ignore()))] //~ ERROR cannot use options on a tuple struct
+struct T(uint, uint);
+
+#[deriving(Eq(ignore(A)))] //~ ERROR cannot use options on an enum
+enum E { A, B }

--- a/src/test/compile-fail/deriving-takes-no-options.rs
+++ b/src/test/compile-fail/deriving-takes-no-options.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deriving(Zero="no options")] //~ WARNING does not use any options
+struct A { a: int }
+
+#[deriving(Rand(foo))] //~ WARNING does not use any options
+struct B { b: int }
+
+// At least one error is needed so that compilation fails
+#[static_assert]
+static b: bool = false; //~ ERROR static assertion failed
+
+fn main() {}

--- a/src/test/compile-fail/deriving-takes-no-options.rs
+++ b/src/test/compile-fail/deriving-takes-no-options.rs
@@ -8,14 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Zero="no options")] //~ WARNING does not use any options
+#[deriving(Zero="no options")] //~ ERROR does not use any options
 struct A { a: int }
 
-#[deriving(Rand(foo))] //~ WARNING does not use any options
+#[deriving(Rand(foo))] //~ ERROR does not use any options
 struct B { b: int }
-
-// At least one error is needed so that compilation fails
-#[static_assert]
-static b: bool = false; //~ ERROR static assertion failed
 
 fn main() {}

--- a/src/test/run-pass/deriving-cmp-options.rs
+++ b/src/test/run-pass/deriving-cmp-options.rs
@@ -55,11 +55,11 @@ fn ignore() {
     };
 
 
-    ignore == ignore;
-    ignore < ignore;
-    ignore > ignore;
-    ignore <= ignore;
-    ignore >= ignore;
+    assert!(ignore == ignore);
+    assert!(!(ignore < ignore));
+    assert!(!(ignore > ignore));
+    assert!(ignore <= ignore);
+    assert!(ignore >= ignore);
 }
 
 // Test `ok` first,
@@ -109,14 +109,14 @@ macro_rules! t_o_test {
     }
 }
 
-t_o_test! { FailEq, small == large, small == large }
+t_o_test! { FailEq, assert!(!(small == large)), small == large }
 t_o_test! {
     FailOrd,
     {
-        small < large;
-        small > large;
-        small <= large;
-        small >= large;
+        assert!(small < large);
+        assert!(!(small > large));
+        assert!(small <= large);
+        assert!(!(small >= large));
     },
     {
         small < large;
@@ -125,8 +125,8 @@ t_o_test! {
         small >= large;
     }
 }
-t_o_test! { FailTotalEq, small.equals(&large), small.equals(&large) }
-t_o_test! { FailTotalOrd, small.cmp(&large), small.cmp(&large) }
+t_o_test! { FailTotalEq, assert!(!small.equals(&large)), small.equals(&large) }
+t_o_test! { FailTotalOrd, assert_eq!(small.cmp(&large), std::cmp::Less), small.cmp(&large) }
 
 #[deriving(Ord(reverse(x)),
            TotalEq, // satisfy TotalOrd's inheritance
@@ -140,14 +140,18 @@ fn reverse() {
     let small = Reverse { x: 0 };
     let large = Reverse { x: 1 };
 
-    small > large;
-    large < small;
+    assert!(small > large);
+    assert!(!(small < large));
+    assert!(large < small);
+    assert!(!(large > small));
 
-    small <= small;
-    small >= small;
-    large <= large;
-    large >= large;
+    assert!(small <= small);
+    assert!(small >= small);
+    assert!(large <= large);
+    assert!(large >= large);
 
-    small >= large;
-    large <= small;
+    assert!(small >= large);
+    assert!(!(small <= large));
+    assert!(large <= small);
+    assert!(!(large >= small));
 }

--- a/src/test/run-pass/deriving-cmp-options.rs
+++ b/src/test/run-pass/deriving-cmp-options.rs
@@ -1,0 +1,153 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-pretty - token trees can't pretty print
+
+// use test because #[should_fail] makes testing easier
+// compile-flags:--test
+
+// these are used for testing that `ignore` and `test_order` work.
+#[deriving(Ord, TotalOrd, TotalEq)]
+pub struct FailEq(uint);
+impl Eq for FailEq {
+    fn eq(&self, _: &FailEq) -> bool { fail!("eq") }
+}
+
+#[deriving(Eq, TotalOrd, TotalEq)]
+pub struct FailOrd(uint);
+impl Ord for FailOrd {
+    fn lt(&self, _: &FailOrd) -> bool { fail!("lt") }
+}
+
+#[deriving(Eq, Ord, TotalOrd)]
+pub struct FailTotalEq(uint);
+impl TotalEq for FailTotalEq {
+    fn equals(&self, _: &FailTotalEq) -> bool { fail!("equals") }
+}
+
+#[deriving(Eq, Ord, TotalEq)]
+pub struct FailTotalOrd(uint);
+impl TotalOrd for FailTotalOrd {
+    fn cmp(&self, _: &FailTotalOrd) -> Ordering { fail!("cmp") }
+}
+
+// ignore the field that would fail if the given trait was called on
+// it. (Only Eq and Ord get)
+#[deriving(Eq(ignore(eq)),
+           Ord(ignore(ord)))]
+pub struct Ignore {
+    eq: FailEq,
+    ord: FailOrd,
+}
+
+#[test]
+fn ignore() {
+    let ignore = Ignore {
+        eq: FailEq(1),
+        ord: FailOrd(2),
+    };
+
+
+    ignore == ignore;
+    ignore < ignore;
+    ignore > ignore;
+    ignore <= ignore;
+    ignore >= ignore;
+}
+
+// Test `ok` first,
+#[deriving(Eq(test_order(ok)),
+           Ord(test_order(ok)),
+           TotalEq(test_order(ok)),
+           TotalOrd(test_order(ok)))]
+pub struct SecondFirst<A> {
+    failing: A,
+    ok: uint
+}
+
+macro_rules! t_o_test {
+    ($ctor:ident, $pass:expr, $fail:expr) => {
+        mod $ctor {
+            use super::*;
+
+            #[test]
+            fn test_pass() {
+                // testing on `ok` will always all the implementation
+                // to shortcircuit.
+                let small = SecondFirst {
+                    failing: $ctor(0),
+                    ok: 0
+                };
+                let large = SecondFirst {
+                    failing: $ctor(1),
+                    ok: 1
+                };
+
+                $pass;
+            }
+
+            #[test]
+            #[should_fail]
+            fn test_fail() {
+                // the implementations will have to test on `failing`,
+                // (hopefully) making this fail.
+                let small = SecondFirst {
+                    failing: $ctor(0),
+                    ok: 0
+                };
+                let large = small;
+                $fail;
+            }
+        }
+    }
+}
+
+t_o_test! { FailEq, small == large, small == large }
+t_o_test! {
+    FailOrd,
+    {
+        small < large;
+        small > large;
+        small <= large;
+        small >= large;
+    },
+    {
+        small < large;
+        small > large;
+        small <= large;
+        small >= large;
+    }
+}
+t_o_test! { FailTotalEq, small.equals(&large), small.equals(&large) }
+t_o_test! { FailTotalOrd, small.cmp(&large), small.cmp(&large) }
+
+#[deriving(Ord(reverse(x)),
+           TotalEq, // satisfy TotalOrd's inheritance
+           TotalOrd(reverse(x)))]
+pub struct Reverse {
+    x: uint
+}
+
+#[test]
+fn reverse() {
+    let small = Reverse { x: 0 };
+    let large = Reverse { x: 1 };
+
+    small > large;
+    large < small;
+
+    small <= small;
+    small >= small;
+    large <= large;
+    large >= large;
+
+    small >= large;
+    large <= small;
+}


### PR DESCRIPTION
This adds the infrastructure to allow `#[deriving]` to take options (closes https://github.com/mozilla/rust/issues/7229), e.g.

``` rust
#[deriving(Eq(ignore(a)))]
struct Foo {
    a: int,
    b: uint
}
```

It also implements three options for the comparison traits `test_order`, `ignore` and `reverse`, e.g.:

``` rust
#[deriving(Eq(test_order(y), ignore(z, w)),
           TotalOrd(reverse(x)))]
struct Foo {
    x: uint,
    y: uint,
    z: uint,
    w: uint
}
```

which means that the field `y` is tested first, `z` and `w` aren't tested at all (for `Eq`), and `x` is sorted in reverse order for `TotalOrd`.

For the comparison traits, the options are strictly checked; it is an error to:
- specify anything other than those that the trait supports (all support `test_order`, `Eq` & `Ord` support `ignore`, and `Ord` & `TotalOrd` support `reverse`.)
- specify fields that don't exist
- use a format different to `Trait(option(bar, baz))`
- use any of these options on enums or tuple structs: only structs with named fields.

(This also adds documentation to the manual about this.)

At the moment, all other traits emit a warning if any options are used (and ignore them).

(In general, all forms of options are supported, e.g. `#[deriving(Foo="bar")]` works too.)
