### PR TITLE
Fixed str::raw::push_byte

### DIFF
--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -878,7 +878,7 @@ pub mod raw {
         let new_len = s.len() + 1;
         s.reserve_at_least(new_len);
         do s.as_mut_buf |buf, len| {
-            *ptr::mut_offset(buf, len as int) = b;
+            *ptr::mut_offset(buf, (len-1) as int) = b;
         }
         set_len(&mut *s, new_len);
     }
@@ -2799,6 +2799,13 @@ mod tests {
         assert!("\u2009".is_whitespace()); // Thin space
         assert!("  \n\t   ".is_whitespace());
         assert!(!"   _   ".is_whitespace());
+    }
+
+    #[test]
+    fn test_push_byte() {
+        let mut s = ~"ABC";
+        unsafe{raw::push_byte(&mut s, 'D' as u8)};
+        assert_eq!(s, ~"ABCD");
     }
 
     #[test]


### PR DESCRIPTION
It was previously pushing the byte on top of the string's null
terminator. I added a test to make sure it doesn't break in the future.
