### PR TITLE
Optimize spawn_unlinked.

### DIFF
--- a/src/libstd/rt/kill.rs
+++ b/src/libstd/rt/kill.rs
@@ -205,11 +205,10 @@ impl BlockedTask {
                 let flag_arc = match task.death.spare_kill_flag.take() {
                     Some(spare_flag) => spare_flag,
                     None => {
-                        // FIXME(#7544): Uncomment this when terminate_current_task
-                        // stops being *terrible*. That's the only place that violates
-                        // the assumption of "becoming unkillable will fail if the
-                        // task was killed".
-                        // rtassert!(task.unwinder.unwinding);
+                        // A task that kills us won't have a spare kill flag to
+                        // give back to us, so we restore it ourselves here. This
+                        // situation should only arise when we're already failing.
+                        rtassert!(task.unwinder.unwinding);
                         (*task.death.kill_handle.get_ref().get()).killed.clone()
                     }
                 };

--- a/src/libstd/rt/kill.rs
+++ b/src/libstd/rt/kill.rs
@@ -193,6 +193,10 @@ impl BlockedTask {
 
     /// Create a blocked task, unless the task was already killed.
     pub fn try_block(mut task: ~Task) -> Either<~Task, BlockedTask> {
+        // NB: As an optimization, we could give a free pass to being unkillable
+        // to tasks whose taskgroups haven't been initialized yet, but that
+        // introduces complications with select() and with the test cases below,
+        // and it's not clear the uncommon performance boost is worth it.
         if task.death.unkillable > 0 {
             Right(Unkillable(task))
         } else {


### PR DESCRIPTION
This lazily initializes the taskgroup structs for `spawn_unlinked` tasks. If such a task never spawns another task linked to it (or a descendant of it), its taskgroup is simply never initialized at all. Also if an unlinked task spawns another unlinked task, neither of them will need to initialize their taskgroups. This works for the main task too.

I benchmarked this with the following test case and observed a ~~21% speedup (average over 4 runs: 7.85 sec -> 6.20 sec, 2.5 GHz)~~ 11% speedup, see comment below.

```
use std::task;
use std::cell::Cell;
use std::rt::comm;

static NUM: uint = 1024*256;

fn run(f: ~fn()) {
    let mut t = task::task();
    t.unlinked();
    t.spawn(f);
}

fn main() {
    do NUM.times {
        let (p,c) = comm::oneshot();
        let c = Cell::new(c);
        do run { c.take().send(()); }
        p.recv();
    }
}
```
