### PR TITLE
Re-enable rusti tests

### DIFF
--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -565,10 +565,7 @@ mod tests {
         }
     }
 
-    // FIXME: #7220 rusti on 32bit mac doesn't work.
-    // FIXME: #7641 rusti on 32bit linux cross compile doesn't work
-    // FIXME: #7115 re-enable once LLVM has been upgraded
-    #[cfg(thiswillneverbeacfgflag)]
+    #[cfg(not(target_word_size = "32"))]
     fn run_program(prog: &str) {
         let mut r = repl();
         for cmd in prog.split_iter('\n') {
@@ -577,6 +574,9 @@ mod tests {
                     "the command '%s' failed", cmd);
         }
     }
+    // FIXME: #7220 rusti on 32bit mac doesn't work
+    // FIXME: #7641 rusti on 32bit linux cross compile doesn't work
+    #[cfg(target_word_size = "32")]
     fn run_program(_: &str) {}
 
     #[test]
@@ -594,13 +594,12 @@ mod tests {
         run_program("let a = 3;");
     }
 
-    #[test] #[ignore]
+    #[test]
     fn new_tasks() {
-        // XXX: can't spawn new tasks because the JIT code is cleaned up
-        //      after the main function is done.
         run_program("
-            spawn( || println(\"Please don't segfault\") );
-            do spawn { println(\"Please?\"); }
+            use std::task::try;
+            try( || println(\"Please don't segfault\") );
+            do try { println(\"Please?\"); }
         ");
     }
 


### PR DESCRIPTION
Now that LLVM has been upgraded, I think that we can try again to re-enable the rusti tests.
