### PR TITLE
Update to LLVM HEAD + assorted cleanups

### DIFF
--- a/src/librustc/back/passes.rs
+++ b/src/librustc/back/passes.rs
@@ -292,7 +292,6 @@ pub static transform_passes : &'static [(&'static str, &'static str)] = &'static
     ("scalarrepl",                      "Scalar Replacement of Aggregates (DT)"),
     ("scalarrepl-ssa",                  "Scalar Replacement of Aggregates (SSAUp)"),
     ("sccp",                            "Sparse Conditional Constant Propagation"),
-    ("simplify-libcalls",               "Simplify well-known library calls"),
     ("simplifycfg",                     "Simplify the CFG"),
     ("sink",                            "Code sinking"),
     ("strip",                           "Strip all symbols from a module"),

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -85,11 +85,6 @@ pub enum Attribute {
     ReturnsTwiceAttribute = 1 << 29,
     UWTableAttribute = 1 << 30,
     NonLazyBindAttribute = 1 << 31,
-
-    // Not added to LLVM yet, so may need to stay updated if LLVM changes.
-    // FIXME(#8199): if this changes, be sure to change the relevant constant
-    //               down below
-    // FixedStackSegment = 1 << 41,
 }
 
 // enum for the LLVM IntPredicate type
@@ -843,7 +838,9 @@ pub mod llvm {
         #[fast_ffi]
         pub fn LLVMSetGC(Fn: ValueRef, Name: *c_char);
         #[fast_ffi]
-        pub fn LLVMAddFunctionAttr(Fn: ValueRef, PA: c_uint, HighPA: c_uint);
+        pub fn LLVMAddFunctionAttr(Fn: ValueRef, PA: c_uint);
+        #[fast_ffi]
+        pub fn LLVMAddFunctionAttrString(Fn: ValueRef, Name: *c_char);
         #[fast_ffi]
         pub fn LLVMGetFunctionAttr(Fn: ValueRef) -> c_ulonglong;
         #[fast_ffi]
@@ -2112,23 +2109,7 @@ pub fn ConstFCmp(Pred: RealPredicate, V1: ValueRef, V2: ValueRef) -> ValueRef {
 
 pub fn SetFunctionAttribute(Fn: ValueRef, attr: Attribute) {
     unsafe {
-        let attr = attr as u64;
-        let lower = attr & 0xffffffff;
-        let upper = (attr >> 32) & 0xffffffff;
-        llvm::LLVMAddFunctionAttr(Fn, lower as c_uint, upper as c_uint);
-    }
-}
-
-// FIXME(#8199): this shouldn't require this hackery. On i686
-//               (FixedStackSegment as u64) will return 0 instead of 1 << 41.
-//               Furthermore, if we use a match of any sort then an LLVM
-//               assertion is generated!
-pub fn SetFixedStackSegmentAttribute(Fn: ValueRef) {
-    unsafe {
-        let attr = 1u64 << 41;
-        let lower = attr & 0xffffffff;
-        let upper = (attr >> 32) & 0xffffffff;
-        llvm::LLVMAddFunctionAttr(Fn, lower as c_uint, upper as c_uint);
+        llvm::LLVMAddFunctionAttr(Fn, attr as c_uint)
     }
 }
 /* Memory-managed object interface to type handles. */

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -440,14 +440,19 @@ pub fn set_inline_hint(f: ValueRef) {
     lib::llvm::SetFunctionAttribute(f, lib::llvm::InlineHintAttribute)
 }
 
-pub fn set_inline_hint_if_appr(attrs: &[ast::Attribute],
-                               llfn: ValueRef) {
+pub fn set_llvm_fn_attrs(attrs: &[ast::Attribute], llfn: ValueRef) {
     use syntax::attr::*;
+    // Set the inline hint if there is one
     match find_inline_attr(attrs) {
         InlineHint   => set_inline_hint(llfn),
         InlineAlways => set_always_inline(llfn),
         InlineNever  => set_no_inline(llfn),
         InlineNone   => { /* fallthrough */ }
+    }
+
+    // Add the no-split-stack attribute if requested
+    if contains_name(attrs, "no_split_stack") {
+        set_no_split_stack(llfn);
     }
 }
 
@@ -456,7 +461,15 @@ pub fn set_always_inline(f: ValueRef) {
 }
 
 pub fn set_fixed_stack_segment(f: ValueRef) {
-    lib::llvm::SetFixedStackSegmentAttribute(f);
+    do "fixed-stack-segment".to_c_str().with_ref |buf| {
+        unsafe { llvm::LLVMAddFunctionAttrString(f, buf); }
+    }
+}
+
+pub fn set_no_split_stack(f: ValueRef) {
+    do "no-split-stack".to_c_str().with_ref |buf| {
+        unsafe { llvm::LLVMAddFunctionAttrString(f, buf); }
+    }
 }
 
 pub fn set_glue_inlining(f: ValueRef, t: ty::t) {
@@ -2444,7 +2457,7 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::NodeId) -> ValueRef {
                             } else {
                                 foreign::register_foreign_fn(ccx, i.span, sym, i.id)
                             };
-                            set_inline_hint_if_appr(i.attrs, llfn);
+                            set_llvm_fn_attrs(i.attrs, llfn);
                             llfn
                         }
 
@@ -2579,7 +2592,7 @@ pub fn register_method(ccx: @mut CrateContext,
     let sym = exported_name(ccx, path, mty, m.attrs);
 
     let llfn = register_fn(ccx, m.span, sym, id, mty);
-    set_inline_hint_if_appr(m.attrs, llfn);
+    set_llvm_fn_attrs(m.attrs, llfn);
     llfn
 }
 

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -12,7 +12,7 @@
 use back::link::mangle_exported_name;
 use driver::session;
 use lib::llvm::ValueRef;
-use middle::trans::base::{set_inline_hint_if_appr, set_inline_hint};
+use middle::trans::base::{set_llvm_fn_attrs, set_inline_hint};
 use middle::trans::base::{trans_enum_variant,push_ctxt};
 use middle::trans::base::{trans_fn, decl_internal_cdecl_fn};
 use middle::trans::base::{get_item_val, no_self};
@@ -222,7 +222,7 @@ pub fn monomorphic_fn(ccx: @mut CrateContext,
                 _
             }, _) => {
         let d = mk_lldecl();
-        set_inline_hint_if_appr(i.attrs, d);
+        set_llvm_fn_attrs(i.attrs, d);
         trans_fn(ccx,
                  pt,
                  decl,
@@ -266,13 +266,13 @@ pub fn monomorphic_fn(ccx: @mut CrateContext,
       ast_map::node_method(mth, _, _) => {
         // XXX: What should the self type be here?
         let d = mk_lldecl();
-        set_inline_hint_if_appr(mth.attrs.clone(), d);
+        set_llvm_fn_attrs(mth.attrs, d);
         meth::trans_method(ccx, pt, mth, Some(psubsts), d);
         d
       }
       ast_map::node_trait_method(@ast::provided(mth), _, pt) => {
         let d = mk_lldecl();
-        set_inline_hint_if_appr(mth.attrs.clone(), d);
+        set_llvm_fn_attrs(mth.attrs, d);
         meth::trans_method(ccx, (*pt).clone(), mth, Some(psubsts), d);
         d
       }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -43,7 +43,7 @@ extern "C" void LLVMRustAddPrintModulePass(LLVMPassManagerRef PMR,
                                            const char* path) {
   PassManager *PM = unwrap<PassManager>(PMR);
   std::string ErrorInfo;
-  raw_fd_ostream OS(path, ErrorInfo, raw_fd_ostream::F_Binary);
+  raw_fd_ostream OS(path, ErrorInfo, sys::fs::F_Binary);
   formatted_raw_ostream FOS(OS);
   PM->add(createPrintModulePass(&FOS));
   PM->run(*unwrap(M));
@@ -412,7 +412,7 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
   bool NoVerify = false;
   std::string ErrorInfo;
   raw_fd_ostream OS(path, ErrorInfo,
-                    raw_fd_ostream::F_Binary);
+                    sys::fs::F_Binary);
   if (ErrorInfo != "") {
     LLVMRustError = ErrorInfo.c_str();
     return false;
@@ -479,6 +479,10 @@ extern "C" LLVMValueRef LLVMGetOrInsertFunction(LLVMModuleRef M,
 
 extern "C" LLVMTypeRef LLVMMetadataTypeInContext(LLVMContextRef C) {
   return wrap(Type::getMetadataTy(*unwrap(C)));
+}
+
+extern "C" void LLVMAddFunctionAttrString(LLVMValueRef fn, const char *Name) {
+  unwrap<Function>(fn)->addFnAttr(Name);
 }
 
 extern "C" LLVMValueRef LLVMBuildAtomicLoad(LLVMBuilderRef B,
@@ -624,7 +628,7 @@ extern "C" LLVMValueRef LLVMDIBuilderCreateFunction(
     return wrap(Builder->createFunction(
         unwrapDI<DIScope>(Scope), Name, LinkageName,
         unwrapDI<DIFile>(File), LineNo,
-        unwrapDI<DIType>(Ty), isLocalToUnit, isDefinition, ScopeLine,
+        unwrapDI<DICompositeType>(Ty), isLocalToUnit, isDefinition, ScopeLine,
         Flags, isOptimized,
         unwrap<Function>(Fn),
         unwrapDI<MDNode*>(TParam),

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2013-07-04
+2013-08-20

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -42,6 +42,7 @@ LLVMAddDestination
 LLVMAddEarlyCSEPass
 LLVMAddFunction
 LLVMAddFunctionAttr
+LLVMAddFunctionAttrString
 LLVMAddFunctionAttrsPass
 LLVMAddFunctionInliningPass
 LLVMAddGVNPass


### PR DESCRIPTION
The first commit message is pretty good, but whomever reviews this should probably also at least glance at the changes I made in LLVM. I basically reorganized our pending patch queue to be a bit more organized and clearer in what needs to go where. After this, our queue would be:
- Add the `no-split-stack` attribute
- Add the `fixedstacksegment` attribute
- Add split-stacks for arm android
- Add split-stacks for arm linux
- Add split stacks for mips

Then there's a patch which I added to get rust to build at all on LLVM-head, and I'm not quite sure why it's there, but nothing seems to be crashing for now! (famous last words).

Otherwise, I just updated code to reflect the changes I made in LLVM with the only major change being the advent of the new `no_split_stack` attribute. This is work towards #1226, but someone more familiar with the code should probably actually assign the attribute to the appropriate functions.

Also as a bonus, I've verified that this closes #5774
