### PR TITLE
std: add missing #[inline] annotation to the f64 arithmetic trait impls.

### DIFF
--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -278,18 +278,22 @@ impl One for f64 {
 
 #[cfg(not(test))]
 impl Add<f64,f64> for f64 {
+    #[inline]
     fn add(&self, other: &f64) -> f64 { *self + *other }
 }
 #[cfg(not(test))]
 impl Sub<f64,f64> for f64 {
+    #[inline]
     fn sub(&self, other: &f64) -> f64 { *self - *other }
 }
 #[cfg(not(test))]
 impl Mul<f64,f64> for f64 {
+    #[inline]
     fn mul(&self, other: &f64) -> f64 { *self * *other }
 }
 #[cfg(not(test))]
 impl Div<f64,f64> for f64 {
+    #[inline]
     fn div(&self, other: &f64) -> f64 { *self / *other }
 }
 #[cfg(not(test))]


### PR DESCRIPTION
Fixes #8333.
