### PR TITLE
std::rand docs and a new weak_rng function

### DIFF
--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -619,6 +619,16 @@ pub fn rng() -> IsaacRng {
     IsaacRng::new()
 }
 
+/// Create a weak random number generator with a default algorithm and seed.
+///
+/// It returns the fatest `Rng` algorithm currently available in Rust without
+/// consideration for cryptography or security. If you require a specifically
+/// seeded `Rng` for consistency over time you should pick one algorithm and
+/// create the `Rng` yourself.
+pub fn weak_rng() -> XorShiftRng {
+    XorShiftRng::new()
+}
+
 static RAND_SIZE_LEN: u32 = 8;
 static RAND_SIZE: u32 = 1 << RAND_SIZE_LEN;
 

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -610,6 +610,11 @@ impl<R: Rng> RngUtil for R {
 }
 
 /// Create a random number generator with a default algorithm and seed.
+///
+/// It returns the cryptographically-safest `Rng` algorithm currently
+/// available in Rust. If you require a specifically seeded `Rng` for
+/// consistency over time you should pick one algorithm and create the
+/// `Rng` yourself.
 pub fn rng() -> IsaacRng {
     IsaacRng::new()
 }
@@ -619,6 +624,8 @@ static RAND_SIZE: u32 = 1 << RAND_SIZE_LEN;
 
 /// A random number generator that uses the [ISAAC
 /// algorithm](http://en.wikipedia.org/wiki/ISAAC_%28cipher%29).
+///
+/// The ISAAC algorithm is suitable for cryptographic purposes.
 pub struct IsaacRng {
     priv cnt: u32,
     priv rsl: [u32, .. RAND_SIZE],
@@ -794,8 +801,11 @@ impl Rng for IsaacRng {
 }
 
 /// An [Xorshift random number
-/// generator](http://en.wikipedia.org/wiki/Xorshift). Not suitable for
-/// cryptographic purposes.
+/// generator](http://en.wikipedia.org/wiki/Xorshift).
+///
+/// The Xorshift algorithm is not suitable for cryptographic purposes
+/// but is very fast. If you do not know for sure that it fits your
+/// requirements, use a more secure one such as `IsaacRng`.
 pub struct XorShiftRng {
     priv x: u32,
     priv y: u32,


### PR DESCRIPTION
The weak_rng as you can see in the docs is made to have a "no-thinking" way to get a fast rng for non-crypto purposes. I think RNG APIs should be as dumb-proof as possible to avoid any mistakes. It's good that the default rng is a secure one, but I don't want to force people to actually google the various algos to be able to know which to choose and possibly make a wrong choice. So if you need a fast non secure one you can use weak_rng. I think that makes sense.

Note that the comments I added do imply that the return value of the rng/weak_rng functions can change in the future. The reason is that if a better algorithm comes up in the future I think we should switch to that. Or at the very least if ISAAC is proven to be unsafe it should be swapped off for something else. Not allowing for this eventuality now  means we'll end up with a broken old API that can not be changed for BC reasons and a new std::betterrand::rng() to try and fix that mess. Coming from PHP I have to deal with enough old mistakes that stick around for BC, so I'm trying to avoid this here :)
