### PR TITLE
External iterators for TreeMap and TreeSet

### DIFF
--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -134,34 +134,9 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     /// Create an empty TreeMap
     pub fn new() -> TreeMap<K, V> { TreeMap{root: None, length: 0} }
 
-    /// Visit all keys in order
-    pub fn each_key(&self, f: &fn(&K) -> bool) -> bool {
-        self.iter().advance(|(k, _)| f(k))
-    }
-
-    /// Visit all values in order
-    pub fn each_value<'a>(&'a self, f: &fn(&'a V) -> bool) -> bool {
-        self.iter().advance(|(_, v)| f(v))
-    }
-
     /// Iterate over the map and mutate the contained values
     pub fn mutate_values(&mut self, f: &fn(&K, &mut V) -> bool) -> bool {
         mutate_values(&mut self.root, f)
-    }
-
-    /// Visit all key-value pairs in reverse order
-    pub fn each_reverse<'a>(&'a self, f: &fn(&'a K, &'a V) -> bool) -> bool {
-        self.rev_iter().advance(|(k,v)| f(k, v))
-    }
-
-    /// Visit all keys in reverse order
-    pub fn each_key_reverse(&self, f: &fn(&K) -> bool) -> bool {
-        self.each_reverse(|k, _| f(k))
-    }
-
-    /// Visit all values in reverse order
-    pub fn each_value_reverse(&self, f: &fn(&V) -> bool) -> bool {
-        self.each_reverse(|_, v| f(v))
     }
 
     /// Get a lazy iterator over the key-value pairs in the map.
@@ -550,12 +525,6 @@ impl<T: TotalOrd> TreeSet<T> {
     #[inline]
     pub fn upper_bound_iter<'a>(&'a self, v: &T) -> TreeSetIterator<'a, T> {
         TreeSetIterator{iter: self.map.upper_bound_iter(v)}
-    }
-
-    /// Visit all values in reverse order
-    #[inline]
-    pub fn each_reverse(&self, f: &fn(&T) -> bool) -> bool {
-        self.map.each_key_reverse(f)
     }
 
     /// Visit the values (in-order) representing the difference
@@ -1172,7 +1141,7 @@ mod test_treemap {
     }
 
     #[test]
-    fn test_each_reverse() {
+    fn test_rev_iter() {
         let mut m = TreeMap::new();
 
         assert!(m.insert(3, 6));
@@ -1182,12 +1151,11 @@ mod test_treemap {
         assert!(m.insert(1, 2));
 
         let mut n = 4;
-        do m.each_reverse |k, v| {
+        for (k, v) in m.rev_iter() {
             assert_eq!(*k, n);
             assert_eq!(*v, n * 2);
             n -= 1;
-            true
-        };
+        }
     }
 
     #[test]
@@ -1448,7 +1416,7 @@ mod test_set {
     }
 
     #[test]
-    fn test_each_reverse() {
+    fn test_rev_iter() {
         let mut m = TreeSet::new();
 
         assert!(m.insert(3));
@@ -1458,11 +1426,10 @@ mod test_set {
         assert!(m.insert(1));
 
         let mut n = 4;
-        do m.each_reverse |x| {
+        for x in m.rev_iter() {
             assert_eq!(*x, n);
             n -= 1;
-            true
-        };
+        }
     }
 
     fn check(a: &[int], b: &[int], expected: &[int],

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -42,39 +42,23 @@ pub struct TreeMap<K, V> {
 
 impl<K: Eq + TotalOrd, V: Eq> Eq for TreeMap<K, V> {
     fn eq(&self, other: &TreeMap<K, V>) -> bool {
-        if self.len() != other.len() {
-            false
-        } else {
-            let mut x = self.iter();
-            let mut y = other.iter();
-            for _ in range(0u, self.len()) {
-                if x.next().unwrap() != y.next().unwrap() {
-                    return false
-                }
-            }
-            true
-        }
+        self.len() == other.len() &&
+            self.iter().zip(other.iter()).all(|(a, b)| a == b)
     }
-    fn ne(&self, other: &TreeMap<K, V>) -> bool { !self.eq(other) }
 }
 
 // Lexicographical comparison
 fn lt<K: Ord + TotalOrd, V: Ord>(a: &TreeMap<K, V>,
                                  b: &TreeMap<K, V>) -> bool {
-    let mut x = a.iter();
-    let mut y = b.iter();
-
-    let (a_len, b_len) = (a.len(), b.len());
-    for _ in range(0u, num::min(a_len, b_len)) {
-        let (key_a, value_a) = x.next().unwrap();
-        let (key_b, value_b) = y.next().unwrap();
+    // the Zip iterator is as long as the shortest of a and b.
+    for ((key_a, value_a), (key_b, value_b)) in a.iter().zip(b.iter()) {
         if *key_a < *key_b { return true; }
         if *key_a > *key_b { return false; }
         if *value_a < *value_b { return true; }
         if *value_a > *value_b { return false; }
     }
 
-    a_len < b_len
+    a.len() < b.len()
 }
 
 impl<K: Ord + TotalOrd, V: Ord> Ord for TreeMap<K, V> {

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -13,7 +13,6 @@
 //! `TotalOrd`.
 
 
-use std::num;
 use std::util::{swap, replace};
 use std::iterator::{FromIterator, Extendable};
 
@@ -152,7 +151,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
 
     /// Visit all key-value pairs in reverse order
     pub fn each_reverse<'a>(&'a self, f: &fn(&'a K, &'a V) -> bool) -> bool {
-        each_reverse(&self.root, f)
+        self.rev_iter().advance(|(k,v)| f(k, v))
     }
 
     /// Visit all keys in reverse order
@@ -174,6 +173,12 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
             remaining_min: self.length,
             remaining_max: self.length
         }
+    }
+
+    /// Get a lazy reverse iterator over the key-value pairs in the map.
+    /// Requires that it be frozen (immutable).
+    pub fn rev_iter<'a>(&'a self) -> TreeMapRevIterator<'a, K, V> {
+        TreeMapRevIterator{iter: self.iter()}
     }
 
     /// Get a lazy iterator that should be initialized using
@@ -254,20 +259,18 @@ pub struct TreeMapIterator<'self, K, V> {
     priv remaining_max: uint
 }
 
-impl<'self, K, V> Iterator<(&'self K, &'self V)> for TreeMapIterator<'self, K, V> {
-    /// Advance the iterator to the next node (in order) and return a
-    /// tuple with a reference to the key and value. If there are no
-    /// more nodes, return `None`.
-    fn next(&mut self) -> Option<(&'self K, &'self V)> {
+impl<'self, K, V> TreeMapIterator<'self, K, V> {
+    #[inline(always)]
+    fn next_(&mut self, forward: bool) -> Option<(&'self K, &'self V)> {
         while !self.stack.is_empty() || self.node.is_some() {
             match *self.node {
               Some(ref x) => {
                 self.stack.push(x);
-                self.node = &x.left;
+                self.node = if forward { &x.left } else { &x.right };
               }
               None => {
                 let res = self.stack.pop();
-                self.node = &res.right;
+                self.node = if forward { &res.right } else { &res.left };
                 self.remaining_max -= 1;
                 if self.remaining_min > 0 {
                     self.remaining_min -= 1;
@@ -278,10 +281,38 @@ impl<'self, K, V> Iterator<(&'self K, &'self V)> for TreeMapIterator<'self, K, V
         }
         None
     }
+}
+
+impl<'self, K, V> Iterator<(&'self K, &'self V)> for TreeMapIterator<'self, K, V> {
+    /// Advance the iterator to the next node (in order) and return a
+    /// tuple with a reference to the key and value. If there are no
+    /// more nodes, return `None`.
+    fn next(&mut self) -> Option<(&'self K, &'self V)> {
+        self.next_(true)
+    }
 
     #[inline]
     fn size_hint(&self) -> (uint, Option<uint>) {
         (self.remaining_min, Some(self.remaining_max))
+    }
+}
+
+/// Lazy backward iterator over a map
+pub struct TreeMapRevIterator<'self, K, V> {
+    priv iter: TreeMapIterator<'self, K, V>,
+}
+
+impl<'self, K, V> Iterator<(&'self K, &'self V)> for TreeMapRevIterator<'self, K, V> {
+    /// Advance the iterator to the next node (in order) and return a
+    /// tuple with a reference to the key and value. If there are no
+    /// more nodes, return `None`.
+    fn next(&mut self) -> Option<(&'self K, &'self V)> {
+        self.iter.next_(false)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (uint, Option<uint>) {
+        self.iter.size_hint()
     }
 }
 
@@ -375,6 +406,14 @@ impl<K, V> Iterator<(K, V)> for TreeMapConsumeIterator<K,V> {
 }
 
 impl<'self, T> Iterator<&'self T> for TreeSetIterator<'self, T> {
+    /// Advance the iterator to the next node (in order). If there are no more nodes, return `None`.
+    #[inline]
+    fn next(&mut self) -> Option<&'self T> {
+        do self.iter.next().map |&(value, _)| { value }
+    }
+}
+
+impl<'self, T> Iterator<&'self T> for TreeSetRevIterator<'self, T> {
     /// Advance the iterator to the next node (in order). If there are no more nodes, return `None`.
     #[inline]
     fn next(&mut self) -> Option<&'self T> {
@@ -492,6 +531,13 @@ impl<T: TotalOrd> TreeSet<T> {
         TreeSetIterator{iter: self.map.iter()}
     }
 
+    /// Get a lazy iterator over the values in the set.
+    /// Requires that it be frozen (immutable).
+    #[inline]
+    pub fn rev_iter<'a>(&'a self) -> TreeSetRevIterator<'a, T> {
+        TreeSetRevIterator{iter: self.map.rev_iter()}
+    }
+
     /// Get a lazy iterator pointing to the first value not less than `v` (greater or equal).
     /// If all elements in the set are less than `v` empty iterator is returned.
     #[inline]
@@ -538,6 +584,11 @@ impl<T: TotalOrd> TreeSet<T> {
 /// Lazy forward iterator over a set
 pub struct TreeSetIterator<'self, T> {
     priv iter: TreeMapIterator<'self, T, ()>
+}
+
+/// Lazy backward iterator over a set
+pub struct TreeSetRevIterator<'self, T> {
+    priv iter: TreeMapRevIterator<'self, T, ()>
 }
 
 // Encapsulate an iterator and hold its latest value until stepped forward
@@ -689,18 +740,6 @@ impl<K: TotalOrd, V> TreeNode<K, V> {
     pub fn new(key: K, value: V) -> TreeNode<K, V> {
         TreeNode{key: key, value: value, left: None, right: None, level: 1}
     }
-}
-
-fn each<'r, K: TotalOrd, V>(node: &'r Option<~TreeNode<K, V>>,
-                            f: &fn(&'r K, &'r V) -> bool) -> bool {
-    node.iter().advance(|x| each(&x.left,  |k,v| f(k,v)) && f(&x.key, &x.value) &&
-                            each(&x.right, |k,v| f(k,v)))
-}
-
-fn each_reverse<'r, K: TotalOrd, V>(node: &'r Option<~TreeNode<K, V>>,
-                                    f: &fn(&'r K, &'r V) -> bool) -> bool {
-    node.iter().advance(|x| each_reverse(&x.right, |k,v| f(k,v)) && f(&x.key, &x.value) &&
-                            each_reverse(&x.left,  |k,v| f(k,v)))
 }
 
 fn mutate_values<'r, K: TotalOrd, V>(node: &'r mut Option<~TreeNode<K, V>>,


### PR DESCRIPTION
Root out the last of all `each_*` methods and the set operation methods (except `mutate_values` that does live on).

Implement a gang of iterators for difference, sym difference, intersection, union of two sets. Also implement `.rev_iter()` for the map and the set.
