### PR TITLE
Fix doc and code naming which is related with Static

### DIFF
--- a/src/librustdoc/doc.rs
+++ b/src/librustdoc/doc.rs
@@ -54,7 +54,7 @@ pub struct CrateDoc {
 pub enum ItemTag {
     ModTag(ModDoc),
     NmodTag(NmodDoc),
-    ConstTag(ConstDoc),
+    StaticTag(StaticDoc),
     FnTag(FnDoc),
     EnumTag(EnumDoc),
     TraitTag(TraitDoc),
@@ -95,7 +95,7 @@ pub struct NmodDoc {
     index: Option<Index>
 }
 
-pub type ConstDoc = SimpleItemDoc;
+pub type StaticDoc = SimpleItemDoc;
 
 pub type FnDoc = SimpleItemDoc;
 
@@ -214,8 +214,8 @@ impl ModDoc {
         md!(FnTag)
     }
 
-    pub fn consts(&self) -> ~[ConstDoc] {
-        md!(ConstTag)
+    pub fn statics(&self) -> ~[StaticDoc] {
+        md!(StaticTag)
     }
 
     pub fn enums(&self) -> ~[EnumDoc] {
@@ -249,7 +249,7 @@ pub trait PageUtils {
     fn mods(&self) -> ~[ModDoc];
     fn nmods(&self) -> ~[NmodDoc];
     fn fns(&self) -> ~[FnDoc];
-    fn consts(&self) -> ~[ConstDoc];
+    fn statics(&self) -> ~[StaticDoc];
     fn enums(&self) -> ~[EnumDoc];
     fn traits(&self) -> ~[TraitDoc];
     fn impls(&self) -> ~[ImplDoc];
@@ -270,8 +270,8 @@ impl PageUtils for ~[Page] {
         pu!(FnTag)
     }
 
-    fn consts(&self) -> ~[ConstDoc] {
-        pu!(ConstTag)
+    fn statics(&self) -> ~[StaticDoc] {
+        pu!(StaticTag)
     }
 
     fn enums(&self) -> ~[EnumDoc] {
@@ -301,7 +301,7 @@ impl Item for ItemTag {
           &doc::ModTag(ref doc) => doc.item.clone(),
           &doc::NmodTag(ref doc) => doc.item.clone(),
           &doc::FnTag(ref doc) => doc.item.clone(),
-          &doc::ConstTag(ref doc) => doc.item.clone(),
+          &doc::StaticTag(ref doc) => doc.item.clone(),
           &doc::EnumTag(ref doc) => doc.item.clone(),
           &doc::TraitTag(ref doc) => doc.item.clone(),
           &doc::ImplTag(ref doc) => doc.item.clone(),

--- a/src/librustdoc/extract.rs
+++ b/src/librustdoc/extract.rs
@@ -101,8 +101,8 @@ fn moddoc_from_mod(
                 ))
               }
               ast::item_static(*) => {
-                Some(doc::ConstTag(
-                    constdoc_from_const(ItemDoc)
+                Some(doc::StaticTag(
+                    staticdoc_from_static(ItemDoc)
                 ))
               }
               ast::item_enum(enum_definition, _) => {
@@ -165,7 +165,7 @@ fn fndoc_from_fn(itemdoc: doc::ItemDoc) -> doc::FnDoc {
     }
 }
 
-fn constdoc_from_const(itemdoc: doc::ItemDoc) -> doc::ConstDoc {
+fn staticdoc_from_static(itemdoc: doc::ItemDoc) -> doc::StaticDoc {
     doc::SimpleItemDoc {
         item: itemdoc,
         sig: None
@@ -356,10 +356,10 @@ mod test {
     }
 
     #[test]
-    fn should_extract_const_name_and_id() {
+    fn should_extract_static_name_and_id() {
         let doc = mk_doc(@"static a: int = 0;");
-        assert!(doc.cratemod().consts()[0].id() != 0);
-        assert!(doc.cratemod().consts()[0].name_() == ~"a");
+        assert!(doc.cratemod().statics()[0].id() != 0);
+        assert!(doc.cratemod().statics()[0].name_() == ~"a");
     }
 
     #[test]

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -321,7 +321,7 @@ fn write_item_(ctxt: &Ctxt, doc: doc::ItemTag, write_header: bool) {
         doc::ModTag(ModDoc) => write_mod(ctxt, ModDoc),
         doc::NmodTag(nModDoc) => write_nmod(ctxt, nModDoc),
         doc::FnTag(FnDoc) => write_fn(ctxt, FnDoc),
-        doc::ConstTag(ConstDoc) => write_const(ctxt, ConstDoc),
+        doc::StaticTag(StaticDoc) => write_static(ctxt, StaticDoc),
         doc::EnumTag(EnumDoc) => write_enum(ctxt, EnumDoc),
         doc::TraitTag(TraitDoc) => write_trait(ctxt, TraitDoc),
         doc::ImplTag(ImplDoc) => write_impl(ctxt, ImplDoc),
@@ -409,9 +409,9 @@ fn code_block(s: ~str) -> ~str {
 ~~~", s)
 }
 
-fn write_const(
+fn write_static(
     ctxt: &Ctxt,
-    doc: doc::ConstDoc
+    doc: doc::StaticDoc
 ) {
     write_sig(ctxt, doc.sig.clone());
     write_common(ctxt, doc.desc(), doc.sections());
@@ -775,13 +775,13 @@ mod test {
     }
 
     #[test]
-    fn should_write_const_header() {
+    fn should_write_static_header() {
         let markdown = render(~"static a: bool = true;");
         assert!(markdown.contains("## Static `a`\n\n"));
     }
 
     #[test]
-    fn should_write_const_description() {
+    fn should_write_static_description() {
         let markdown = render(
             ~"#[doc = \"b\"]\
               static a: bool = true;");

--- a/src/librustdoc/markdown_pass.rs
+++ b/src/librustdoc/markdown_pass.rs
@@ -150,8 +150,8 @@ pub fn header_kind(doc: doc::ItemTag) -> ~str {
         doc::FnTag(_) => {
             ~"Function"
         }
-        doc::ConstTag(_) => {
-            ~"Freeze"
+        doc::StaticTag(_) => {
+            ~"Static"
         }
         doc::EnumTag(_) => {
             ~"Enum"
@@ -777,7 +777,7 @@ mod test {
     #[test]
     fn should_write_const_header() {
         let markdown = render(~"static a: bool = true;");
-        assert!(markdown.contains("## Freeze `a`\n\n"));
+        assert!(markdown.contains("## Static `a`\n\n"));
     }
 
     #[test]

--- a/src/librustdoc/sort_item_type_pass.rs
+++ b/src/librustdoc/sort_item_type_pass.rs
@@ -18,7 +18,7 @@ pub fn mk_pass() -> Pass {
     fn by_score(item1: &doc::ItemTag, item2: &doc::ItemTag) -> bool {
         fn score(item: &doc::ItemTag) -> int {
             match *item {
-              doc::ConstTag(_) => 0,
+              doc::StaticTag(_) => 0,
               doc::TyTag(_) => 1,
               doc::EnumTag(_) => 2,
               doc::StructTag(_) => 3,
@@ -43,7 +43,7 @@ fn test() {
 
     let source =
         ~"mod imod { } \
-         static iconst: int = 0; \
+         static istatic: int = 0; \
          fn ifn() { } \
          enum ienum { ivar } \
          trait itrait { fn a(); } \
@@ -54,7 +54,7 @@ fn test() {
         let doc = extract::from_srv(srv.clone(), ~"");
         let doc = (mk_pass().f)(srv.clone(), doc);
         // hidden __std_macros module at the start.
-        assert_eq!(doc.cratemod().items[0].name_(), ~"iconst");
+        assert_eq!(doc.cratemod().items[0].name_(), ~"istatic");
         assert_eq!(doc.cratemod().items[1].name_(), ~"itype");
         assert_eq!(doc.cratemod().items[2].name_(), ~"ienum");
         assert_eq!(doc.cratemod().items[3].name_(), ~"istruct");

--- a/src/librustdoc/tystr_pass.rs
+++ b/src/librustdoc/tystr_pass.rs
@@ -39,7 +39,7 @@ pub fn run(
     let fold = Fold {
         ctxt: srv.clone(),
         fold_fn: fold_fn,
-        fold_const: fold_const,
+        fold_static: fold_static,
         fold_enum: fold_enum,
         fold_trait: fold_trait,
         fold_impl: fold_impl,
@@ -93,10 +93,10 @@ fn get_fn_sig(srv: astsrv::Srv, fn_id: doc::AstId) -> Option<~str> {
     }
 }
 
-fn fold_const(
+fn fold_static(
     fold: &fold::Fold<astsrv::Srv>,
-    doc: doc::ConstDoc
-) -> doc::ConstDoc {
+    doc: doc::StaticDoc
+) -> doc::StaticDoc {
     let srv = fold.ctxt.clone();
 
     doc::SimpleItemDoc {
@@ -109,7 +109,7 @@ fn fold_const(
                     }, _) => {
                         pprust::ty_to_str(ty, extract::interner())
                     }
-                    _ => fail!("fold_const: id not bound to a const item")
+                    _ => fail!("fold_static: id not bound to a static item")
                 }
             }}),
         .. doc
@@ -384,9 +384,9 @@ mod test {
     }
 
     #[test]
-    fn should_add_const_types() {
+    fn should_add_static_types() {
         let doc = mk_doc(~"static a: bool = true;");
-        assert!(doc.cratemod().consts()[0].sig == Some(~"bool"));
+        assert!(doc.cratemod().statics()[0].sig == Some(~"bool"));
     }
 
     #[test]


### PR DESCRIPTION
As I pushed commit message, I changed wrong documentation of static.
And I also changed some dusty code naming of const which is already gone to static
