### PR TITLE
Fix unit structs in cross-crate situtations

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -13,7 +13,7 @@ use driver::session::Session;
 use metadata::csearch::{each_path, get_trait_method_def_ids};
 use metadata::csearch::get_method_name_and_explicit_self;
 use metadata::csearch::get_static_methods_if_impl;
-use metadata::csearch::get_type_name_if_impl;
+use metadata::csearch::{get_type_name_if_impl, get_struct_fields};
 use metadata::cstore::find_extern_mod_stmt_cnum;
 use metadata::decoder::{def_like, dl_def, dl_field, dl_impl};
 use middle::lang_items::LanguageItems;
@@ -1700,9 +1700,12 @@ impl Resolver {
           }
           def_struct(def_id) => {
             debug!("(building reduced graph for external \
-                    crate) building type %s",
+                    crate) building type and value for %s",
                    final_ident);
             child_name_bindings.define_type(privacy, def, dummy_sp());
+            if get_struct_fields(self.session.cstore, def_id).len() == 0 {
+                child_name_bindings.define_value(privacy, def, dummy_sp());
+            }
             self.structs.insert(def_id);
           }
           def_method(*) => {

--- a/src/test/auxiliary/xcrate_unit_struct.rs
+++ b/src/test/auxiliary/xcrate_unit_struct.rs
@@ -1,0 +1,31 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_type = "lib"];
+
+// used by the rpass test
+
+pub struct Struct;
+
+pub enum Unit {
+    Unit,
+    Argument(Struct)
+}
+
+// used by the cfail test
+
+pub struct StructWithFields {
+    foo: int,
+}
+
+pub enum EnumWithVariants {
+    EnumVariant,
+    EnumVariantArg(int)
+}

--- a/src/test/compile-fail/xcrate-unit-struct.rs
+++ b/src/test/compile-fail/xcrate-unit-struct.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:xcrate_unit_struct.rs
+
+// Make sure that when we have cross-crate unit structs we don't accidentally
+// make values out of cross-crate structs that aren't unit.
+
+extern mod xcrate_unit_struct;
+
+fn main() {
+    let _ = xcrate_unit_struct::StructWithFields; //~ ERROR: unresolved name
+    let _ = xcrate_unit_struct::Struct;
+}

--- a/src/test/run-pass/xcrate-unit-struct.rs
+++ b/src/test/run-pass/xcrate-unit-struct.rs
@@ -1,0 +1,35 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:xcrate_unit_struct.rs
+
+extern mod xcrate_unit_struct;
+
+use std::util;
+
+static s1: xcrate_unit_struct::Struct = xcrate_unit_struct::Struct;
+static s2: xcrate_unit_struct::Unit = xcrate_unit_struct::Unit;
+static s3: xcrate_unit_struct::Unit =
+                xcrate_unit_struct::Argument(xcrate_unit_struct::Struct);
+static s4: xcrate_unit_struct::Unit = xcrate_unit_struct::Argument(s1);
+
+fn f1(_: xcrate_unit_struct::Struct) {}
+fn f2(_: xcrate_unit_struct::Unit) {}
+
+fn main() {
+    f1(xcrate_unit_struct::Struct);
+    f2(xcrate_unit_struct::Unit);
+    f2(xcrate_unit_struct::Argument(xcrate_unit_struct::Struct));
+
+    f1(s1);
+    f2(s2);
+    f2(s3);
+    f2(s4);
+}


### PR DESCRIPTION
This involved defining the name in the `ValueNS` as well as the `TypeNS` if there were 0 variants.

r? @pcwalton (or others who are more familiar with resolve than I)

Closes #7634
