### PR TITLE
Fix for-range loops that can use iterators

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -413,8 +413,8 @@ fn check_expected_errors(expected_errors: ~[errors::ExpectedError],
         }
     }
 
-    for i in range(0u, found_flags.len()) {
-        if !found_flags[i] {
+    for (i, &flag) in found_flags.iter().enumerate() {
+        if !flag {
             let ee = &expected_errors[i];
             fatal_ProcRes(fmt!("expected %s on line %u not found: %s",
                                ee.kind, ee.line, ee.msg), ProcRes);

--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -846,22 +846,16 @@ mod tests {
                 }
                 assert_eq!(*state, 42);
                 *state = 31337;
-                // FIXME: #7372: hits type inference bug with iterators
                 // send to other readers
-                for i in range(0u, reader_convos.len()) {
-                    match reader_convos[i] {
-                        (ref rc, _) => rc.send(()),
-                    }
+                for &(ref rc, _) in reader_convos.iter() {
+                    rc.send(())
                 }
             }
             let read_mode = arc.downgrade(write_mode);
             do (&read_mode).read |state| {
-                // FIXME: #7372: hits type inference bug with iterators
                 // complete handshake with other readers
-                for i in range(0u, reader_convos.len()) {
-                    match reader_convos[i] {
-                        (_, ref rp) => rp.recv(),
-                    }
+                for &(_, ref rp) in reader_convos.iter() {
+                    rp.recv()
                 }
                 wc1.send(()); // tell writer to try again
                 assert_eq!(*state, 31337);

--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -145,14 +145,16 @@ impl BigBitv {
         let len = b.storage.len();
         assert_eq!(self.storage.len(), len);
         let mut changed = false;
-        for i in range(0, len) {
+        for (i, (a, b)) in self.storage.mut_iter()
+                               .zip(b.storage.iter())
+                               .enumerate() {
             let mask = big_mask(nbits, i);
-            let w0 = self.storage[i] & mask;
-            let w1 = b.storage[i] & mask;
+            let w0 = *a & mask;
+            let w1 = *b & mask;
             let w = op(w0, w1) & mask;
             if w0 != w {
                 changed = true;
-                self.storage[i] = w;
+                *a = w;
             }
         }
         changed
@@ -160,7 +162,7 @@ impl BigBitv {
 
     #[inline]
     pub fn each_storage(&mut self, op: &fn(v: &mut uint) -> bool) -> bool {
-        range(0u, self.storage.len()).advance(|i| op(&mut self.storage[i]))
+        self.storage.mut_iter().advance(|elt| op(elt))
     }
 
     #[inline]
@@ -205,10 +207,9 @@ impl BigBitv {
 
     #[inline]
     pub fn equals(&self, b: &BigBitv, nbits: uint) -> bool {
-        let len = b.storage.len();
-        for i in range(0, len) {
+        for (i, elt) in b.storage.iter().enumerate() {
             let mask = big_mask(nbits, i);
-            if mask & self.storage[i] != mask & b.storage[i] {
+            if mask & self.storage[i] != mask & *elt {
                 return false;
             }
         }

--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -16,7 +16,6 @@
 #[allow(missing_doc)];
 
 use std::iterator::{Iterator, IteratorUtil, Enumerate, FilterMap, Invert};
-use std::uint;
 use std::util::replace;
 use std::vec::{VecIterator, VecMutIterator};
 use std::vec;
@@ -115,48 +114,6 @@ impl<V> MutableMap<uint, V> for SmallIntMap<V> {
 impl<V> SmallIntMap<V> {
     /// Create an empty SmallIntMap
     pub fn new() -> SmallIntMap<V> { SmallIntMap{v: ~[]} }
-
-    /// Visit all key-value pairs in order
-    pub fn each<'a>(&'a self, it: &fn(&uint, &'a V) -> bool) -> bool {
-        for i in range(0u, self.v.len()) {
-            match self.v[i] {
-              Some(ref elt) => if !it(&i, elt) { return false; },
-              None => ()
-            }
-        }
-        true
-    }
-
-    /// Visit all keys in order
-    pub fn each_key(&self, blk: &fn(key: &uint) -> bool) -> bool {
-        self.each(|k, _| blk(k))
-    }
-
-    /// Visit all values in order
-    pub fn each_value<'a>(&'a self, blk: &fn(value: &'a V) -> bool) -> bool {
-        self.each(|_, v| blk(v))
-    }
-
-    /// Iterate over the map and mutate the contained values
-    pub fn mutate_values(&mut self, it: &fn(&uint, &mut V) -> bool) -> bool {
-        for i in range(0, self.v.len()) {
-            match self.v[i] {
-              Some(ref mut elt) => if !it(&i, elt) { return false; },
-              None => ()
-            }
-        }
-        true
-    }
-
-    /// Visit all key-value pairs in reverse order
-    pub fn each_reverse<'a>(&'a self, it: &fn(uint, &'a V) -> bool) -> bool {
-        do uint::range_rev(self.v.len(), 0) |i| {
-            match self.v[i] {
-              Some(ref elt) => it(i, elt),
-              None => true
-            }
-        }
-    }
 
     pub fn get<'a>(&'a self, key: &uint) -> &'a V {
         self.find(key).expect("key not present")

--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -28,14 +28,12 @@ pub struct SmallIntMap<T> {
 impl<V> Container for SmallIntMap<V> {
     /// Return the number of elements in the map
     fn len(&self) -> uint {
-        let mut sz = 0;
-        for i in range(0u, self.v.len()) {
-            match self.v[i] {
-                Some(_) => sz += 1,
-                None => {}
-            }
-        }
-        sz
+        self.v.iter().count(|elt| elt.is_some())
+    }
+
+    /// Return true if there are no elements in the map
+    fn is_empty(&self) -> bool {
+        self.v.iter().all(|elt| elt.is_none())
     }
 }
 

--- a/src/libextra/sort.rs
+++ b/src/libextra/sort.rs
@@ -469,10 +469,7 @@ impl<T:Clone + Ord> MergeState<T> {
                 base2: uint, len2: uint) {
         assert!(len1 != 0 && len2 != 0 && base1+len1 == base2);
 
-        let mut tmp = ~[];
-        for i in range(base1, base1+len1) {
-            tmp.push(array[i].clone());
-        }
+        let mut tmp = array.slice(base1, base1 + len1).to_owned();
 
         let mut c1 = 0;
         let mut c2 = base2;
@@ -579,10 +576,7 @@ impl<T:Clone + Ord> MergeState<T> {
                 base2: uint, len2: uint) {
         assert!(len1 != 1 && len2 != 0 && base1 + len1 == base2);
 
-        let mut tmp = ~[];
-        for i in range(base2, base2+len2) {
-            tmp.push(array[i].clone());
-        }
+        let mut tmp = array.slice(base2, base2 + len2).to_owned();
 
         let mut c1 = base1 + len1 - 1;
         let mut c2 = len2 - 1;

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -159,10 +159,10 @@ impl<'self> CheckLoanCtxt<'self> {
             true
         };
 
-        for i in range(0u, new_loan_indices.len()) {
-            let old_loan = &self.all_loans[new_loan_indices[i]];
-            for j in range(i+1, new_loan_indices.len()) {
-                let new_loan = &self.all_loans[new_loan_indices[j]];
+        for (i, &x) in new_loan_indices.iter().enumerate() {
+            let old_loan = &self.all_loans[x];
+            for &y in new_loan_indices.slice_from(i+1).iter() {
+                let new_loan = &self.all_loans[y];
                 self.report_error_if_loans_conflict(old_loan, new_loan);
             }
         }

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -983,10 +983,10 @@ fn bitwise(out_vec: &mut [uint],
            op: &fn(uint, uint) -> uint) -> bool {
     assert_eq!(out_vec.len(), in_vec.len());
     let mut changed = false;
-    for i in range(0u, out_vec.len()) {
-        let old_val = out_vec[i];
-        let new_val = op(old_val, in_vec[i]);
-        out_vec[i] = new_val;
+    for (out_elt, in_elt) in out_vec.mut_iter().zip(in_vec.iter()) {
+        let old_val = *out_elt;
+        let new_val = op(old_val, *in_elt);
+        *out_elt = new_val;
         changed |= (old_val != new_val);
     }
     changed

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -187,12 +187,12 @@ impl<N,E> Graph<N,E> {
 
     pub fn each_node(&self, f: &fn(NodeIndex, &Node<N>) -> bool) -> bool {
         //! Iterates over all edges defined in the graph.
-        range(0u, self.nodes.len()).advance(|i| f(NodeIndex(i), &self.nodes[i]))
+        self.nodes.iter().enumerate().advance(|(i, node)| f(NodeIndex(i), node))
     }
 
     pub fn each_edge(&self, f: &fn(EdgeIndex, &Edge<E>) -> bool) -> bool {
-        //! Iterates over all edges defined in the graph.
-        range(0u, self.nodes.len()).advance(|i| f(EdgeIndex(i), &self.edges[i]))
+        //! Iterates over all edges defined in the graph
+        self.edges.iter().enumerate().advance(|(i, edge)| f(EdgeIndex(i), edge))
     }
 
     pub fn each_outgoing_edge(&self,

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1742,8 +1742,7 @@ pub fn copy_args_to_allocas(fcx: @mut FunctionContext,
         _ => {}
     }
 
-    for arg_n in range(0u, arg_tys.len()) {
-        let arg_ty = arg_tys[arg_n];
+    for (arg_n, &arg_ty) in arg_tys.iter().enumerate() {
         let raw_llarg = raw_llargs[arg_n];
 
         // For certain mode/type combinations, the raw llarg values are passed

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -145,8 +145,8 @@ fn classify_ty(ty: Type) -> ~[RegClass] {
     }
 
     fn all_mem(cls: &mut [RegClass]) {
-        for i in range(0u, cls.len()) {
-            cls[i] = Memory;
+        for elt in cls.mut_iter() {
+            *elt = Memory;
         }
     }
 

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -205,15 +205,8 @@ pub fn type_uses_for(ccx: @mut CrateContext, fn_id: def_id, n_tps: uint)
 
 pub fn type_needs(cx: &Context, use_: uint, ty: ty::t) {
     // Optimization -- don't descend type if all params already have this use
-    let len = {
-        let uses = &*cx.uses;
-        uses.len()
-    };
-    for i in range(0u, len) {
-        if cx.uses[i] & use_ != use_ {
-            type_needs_inner(cx, use_, ty, @Nil);
-            return;
-        }
+    if cx.uses.iter().any(|&elt| elt & use_ != use_) {
+        type_needs_inner(cx, use_, ty, @Nil);
     }
 }
 

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -772,8 +772,8 @@ impl<'self> LookupContext<'self> {
             self.tcx().sess.span_err(
                 self.expr.span,
                 "multiple applicable methods in scope");
-            for idx in range(0u, relevant_candidates.len()) {
-                self.report_candidate(idx, &relevant_candidates[idx].origin);
+            for (idx, candidate) in relevant_candidates.iter().enumerate() {
+                self.report_candidate(idx, &candidate.origin);
             }
         }
 

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -554,8 +554,8 @@ impl CoherenceChecker {
 
         let mut provided_names = HashSet::new();
         // Implemented methods
-        for i in range(0u, all_methods.len()) {
-            provided_names.insert(all_methods[i].ident);
+        for elt in all_methods.iter() {
+            provided_names.insert(elt.ident);
         }
 
         let r = ty::trait_methods(tcx, trait_did);

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -374,8 +374,8 @@ impl RegionVarBindings {
     pub fn vars_created_since_snapshot(&mut self, snapshot: uint)
                                        -> ~[RegionVid] {
         do vec::build |push| {
-            for i in range(snapshot, self.undo_log.len()) {
-                match self.undo_log[i] {
+            for &elt in self.undo_log.slice_from(snapshot).iter() {
+                match elt {
                     AddVar(vid) => push(vid),
                     _ => ()
                 }

--- a/src/libstd/at_vec.rs
+++ b/src/libstd/at_vec.rs
@@ -12,7 +12,7 @@
 
 use clone::Clone;
 use container::Container;
-use iterator::{Iterator, range};
+use iterator::Iterator;
 use option::{Option, Some, None};
 use sys;
 use unstable::raw::Repr;
@@ -92,8 +92,8 @@ pub fn append<T:Clone>(lhs: @[T], rhs: &[T]) -> @[T] {
         for x in lhs.iter() {
             push((*x).clone());
         }
-        for i in range(0u, rhs.len()) {
-            push(rhs[i].clone());
+        for elt in rhs.iter() {
+            push(elt.clone());
         }
     }
 }

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -19,7 +19,7 @@ use container::{Container, Mutable, Map, MutableMap, Set, MutableSet};
 use clone::Clone;
 use cmp::{Eq, Equiv};
 use hash::Hash;
-use iterator::{Iterator, IteratorUtil, FromIterator, Extendable, range};
+use iterator::{Iterator, IteratorUtil, FromIterator, Extendable};
 use iterator::{FilterMap, Chain, Repeat, Zip};
 use num;
 use option::{None, Option, Some};
@@ -265,8 +265,8 @@ impl<K:Hash + Eq,V> Container for HashMap<K, V> {
 impl<K:Hash + Eq,V> Mutable for HashMap<K, V> {
     /// Clear the map, removing all key-value pairs.
     fn clear(&mut self) {
-        for idx in range(0u, self.buckets.len()) {
-            self.buckets[idx] = None;
+        for bkt in self.buckets.mut_iter() {
+            *bkt = None;
         }
         self.size = 0;
     }

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -271,8 +271,8 @@ impl<T> TrieNode<T> {
 
 impl<T> TrieNode<T> {
     fn each<'a>(&'a self, f: &fn(&uint, &'a T) -> bool) -> bool {
-        for idx in range(0u, self.children.len()) {
-            match self.children[idx] {
+        for elt in self.children.iter() {
+            match *elt {
                 Internal(ref x) => if !x.each(|i,t| f(i,t)) { return false },
                 External(k, ref v) => if !f(&k, v) { return false },
                 Nothing => ()

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1597,8 +1597,8 @@ impl<T:Clone> OwnedCopyableVector<T> for ~[T] {
         let new_len = self.len() + rhs.len();
         self.reserve(new_len);
 
-        for i in range(0u, rhs.len()) {
-            self.push(unsafe { raw::get(rhs, i) })
+        for elt in rhs.iter() {
+            self.push((*elt).clone())
         }
     }
 


### PR DESCRIPTION
Search out loops similar to `for .. range(0, v.len())` and use iterators directly.

All the `.each_*` methods in smallintmap fell afoul of this, and since these are obsolete due to `.iter()` and `.mut_iter()`, those are simply removed.

Fixes #7372 
