### PR TITLE
Rng for the Task struct to provide local, fast psuedorandom number generation in tasks

### DIFF
--- a/src/libstd/rt/comm.rs
+++ b/src/libstd/rt/comm.rs
@@ -225,8 +225,9 @@ impl<T> Select for PortOne<T> {
     fn optimistic_check(&mut self) -> bool {
         // The optimistic check is never necessary for correctness. For testing
         // purposes, making it randomly return false simulates a racing sender.
-        use rand::{Rand, rng};
-        let mut rng = rng();
+        use rand::Rand;
+        use rt::task::Task;
+        let mut rng = Task::rng();
         let actually_check = Rand::rand(&mut rng);
         if actually_check {
             unsafe { (*self.packet()).state.load(Acquire) == STATE_ONE }

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -736,9 +736,9 @@ fn spawn_raw_newsched(mut opts: TaskOpts, f: ~fn()) {
 
             // Pin the new task to the new scheduler
             let new_task = if opts.watched {
-                Task::build_homed_child(child_wrapper, Sched(new_sched_handle))
+                Task::build_homed_child(Sched(new_sched_handle), child_wrapper)
             } else {
-                Task::build_homed_root(child_wrapper, Sched(new_sched_handle))
+                Task::build_homed_root(Sched(new_sched_handle), child_wrapper)
             };
 
             // Create a task that will later be used to join with the new scheduler


### PR DESCRIPTION
This adds an XorShiftRng to the Task struct which allows easy psuedorandom number generation inside a task context.
