### PR TITLE
Fix incorrect non-exhaustive matching for fixed length vecs

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1305,7 +1305,7 @@ match crayons[0] {
 A vector can be destructured using pattern matching:
 
 ~~~~
-let numbers: [int, ..3] = [1, 2, 3];
+let numbers: &[int] = &[1, 2, 3];
 let score = match numbers {
     [] => 0,
     [a] => a * 10,

--- a/src/test/compile-fail/borrowck-move-out-of-vec-tail.rs
+++ b/src/test/compile-fail/borrowck-move-out-of-vec-tail.rs
@@ -6,7 +6,7 @@ struct Foo {
 }
 
 pub fn main() {
-    let x = [
+    let x = ~[
         Foo { string: ~"foo" },
         Foo { string: ~"bar" },
         Foo { string: ~"baz" }

--- a/src/test/compile-fail/borrowck-vec-pattern-element-loan.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-element-loan.rs
@@ -1,5 +1,5 @@
 fn a() -> &[int] {
-    let vec = [1, 2, 3, 4];
+    let vec = ~[1, 2, 3, 4];
     let tail = match vec {
         [_, ..tail] => tail, //~ ERROR does not live long enough
         _ => fail!("a")
@@ -8,7 +8,7 @@ fn a() -> &[int] {
 }
 
 fn b() -> &[int] {
-    let vec = [1, 2, 3, 4];
+    let vec = ~[1, 2, 3, 4];
     let init = match vec {
         [..init, _] => init, //~ ERROR does not live long enough
         _ => fail!("b")
@@ -17,7 +17,7 @@ fn b() -> &[int] {
 }
 
 fn c() -> &[int] {
-    let vec = [1, 2, 3, 4];
+    let vec = ~[1, 2, 3, 4];
     let slice = match vec {
         [_, ..slice, _] => slice, //~ ERROR does not live long enough
         _ => fail!("c")

--- a/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
@@ -1,24 +1,24 @@
 fn a() {
-    let mut vec = [~1, ~2, ~3];
+    let mut vec = ~[~1, ~2, ~3];
     match vec {
         [~ref _a] => {
-            vec[0] = ~4; //~ ERROR cannot assign to `vec[]` because it is borrowed
+            vec[0] = ~4; //~ ERROR cannot assign to `(*vec)[]` because it is borrowed
         }
         _ => fail!("foo")
     }
 }
 
 fn b() {
-    let mut vec = [~1, ~2, ~3];
+    let mut vec = ~[~1, ~2, ~3];
     match vec {
         [.._b] => {
-            vec[0] = ~4; //~ ERROR cannot assign to `vec[]` because it is borrowed
+            vec[0] = ~4; //~ ERROR cannot assign to `(*vec)[]` because it is borrowed
         }
     }
 }
 
 fn c() {
-    let mut vec = [~1, ~2, ~3];
+    let mut vec = ~[~1, ~2, ~3];
     match vec {
         [_a, .._b] => {
             //~^ ERROR cannot move out
@@ -35,7 +35,7 @@ fn c() {
 }
 
 fn d() {
-    let mut vec = [~1, ~2, ~3];
+    let mut vec = ~[~1, ~2, ~3];
     match vec {
         [.._a, _b] => {
             //~^ ERROR cannot move out
@@ -46,7 +46,7 @@ fn d() {
 }
 
 fn e() {
-    let mut vec = [~1, ~2, ~3];
+    let mut vec = ~[~1, ~2, ~3];
     match vec {
         [_a, _b, _c] => {}
         _ => {}

--- a/src/test/compile-fail/borrowck-vec-pattern-tail-element-loan.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-tail-element-loan.rs
@@ -1,5 +1,5 @@
 fn a() -> &int {
-    let vec = [1, 2, 3, 4];
+    let vec = ~[1, 2, 3, 4];
     let tail = match vec {
         [_a, ..tail] => &tail[0], //~ ERROR borrowed value does not live long enough
         _ => fail!("foo")

--- a/src/test/compile-fail/match-vec-fixed.rs
+++ b/src/test/compile-fail/match-vec-fixed.rs
@@ -1,0 +1,16 @@
+fn a() {
+    let v = [1, 2, 3];
+    match v {
+        [_, _, _] => {}
+        [_, _, _] => {} //~ ERROR unreachable pattern
+    }
+    match v {
+        [_, 1, _] => {}
+        [_, 1, _] => {} //~ ERROR unreachable pattern
+        _ => {}
+    }
+}
+
+fn main() {
+    a();
+}

--- a/src/test/compile-fail/match-vec-unreachable.rs
+++ b/src/test/compile-fail/match-vec-unreachable.rs
@@ -6,13 +6,13 @@ fn main() {
         _ => ()
     }
 
-    match [~"foo", ~"bar", ~"baz"] {
+    match ~[~"foo", ~"bar", ~"baz"] {
         [a, _, _, .._] => { println(a); }
         [~"foo", ~"bar", ~"baz", ~"foo", ~"bar"] => { } //~ ERROR unreachable pattern
         _ => { }
     }
 
-    match ['a', 'b', 'c'] {
+    match ~['a', 'b', 'c'] {
         ['a', 'b', 'c', .._tail] => {}
         ['a', 'b', 'c'] => {} //~ ERROR unreachable pattern
         _ => {}

--- a/src/test/run-pass/vec-matching-fixed.rs
+++ b/src/test/run-pass/vec-matching-fixed.rs
@@ -1,0 +1,28 @@
+fn a() {
+    let x = [1, 2, 3];
+    match x {
+        [1, 2, 4] => ::std::util::unreachable(),
+        [0, 2, 3, .._] => ::std::util::unreachable(),
+        [0, .._, 3] => ::std::util::unreachable(),
+        [0, .._] => ::std::util::unreachable(),
+        [1, 2, 3] => (),
+        [_, _, _] => ::std::util::unreachable(),
+    }
+    match x {
+        [.._] => (),
+    }
+    match x {
+        [_, _, _, .._] => (),
+    }
+    match x {
+        [a, b, c] => {
+            assert_eq!(1, a);
+            assert_eq!(2, b);
+            assert_eq!(3, c);
+        }
+    }
+}
+
+pub fn main() {
+    a();
+}

--- a/src/test/run-pass/vec-matching.rs
+++ b/src/test/run-pass/vec-matching.rs
@@ -1,5 +1,5 @@
 fn a() {
-    let x = [1];
+    let x = ~[1];
     match x {
         [_, _, _, _, _, .._] => ::std::util::unreachable(),
         [.._, _, _, _, _] => ::std::util::unreachable(),
@@ -13,7 +13,7 @@ fn a() {
 }
 
 fn b() {
-    let x = [1, 2, 3];
+    let x = ~[1, 2, 3];
     match x {
         [a, b, ..c] => {
             assert_eq!(a, 1);

--- a/src/test/run-pass/vec-tail-matching.rs
+++ b/src/test/run-pass/vec-tail-matching.rs
@@ -3,7 +3,7 @@ struct Foo {
 }
 
 pub fn main() {
-    let x = [
+    let x = ~[
         Foo { string: ~"foo" },
         Foo { string: ~"bar" },
         Foo { string: ~"baz" }


### PR DESCRIPTION
Code like this is fixed now:

```
fn foo(p: [u8, ..4]) {
    match p {
        [a, b, c, d] => {}
    };
}
```

Invalid constructors are not reported as errors yet:

```
fn foo(p: [u8, ..4]) {
    match p {
        [_, _, _] => {} // this should be error
        [_, _, _, _, _, .._] => {} // and this
        _ => {}
    }
}
```

Issue #8311 is partially fixed: fixed-length vectors in let statement are not yet allowed.
