### PR TITLE
rustc: Add --target-cpu flag to select a more specific processor instead of the default, 'generic'.

### DIFF
--- a/src/etc/zsh/_rust
+++ b/src/etc/zsh/_rust
@@ -27,7 +27,8 @@ _rustc_opts_switches=(
     --sysroot'[Override the system root]'
     --test'[Build a test harness]'
     --target'[Target triple cpu-manufacturer-kernel\[-os\] to compile]'
-    --target-feature'[Target specific attributes (llc -mattr=help for detail)]'
+    --target-cpu'[Select target processor (llc -mcpu=help for details)]'
+    --target-feature'[Target specific attributes (llc -mattr=help for details)]'
     --android-cross-path'[The path to the Android NDK]'
     {-v,--version}'[Print version info and exit]'
 )

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -69,6 +69,7 @@ pub fn llvm_err(sess: Session, msg: ~str) -> ! {
 pub fn WriteOutputFile(sess: Session,
         PM: lib::llvm::PassManagerRef, M: ModuleRef,
         Triple: &str,
+        Cpu: &str,
         Feature: &str,
         Output: &str,
         // FIXME: When #2334 is fixed, change
@@ -78,19 +79,22 @@ pub fn WriteOutputFile(sess: Session,
         EnableSegmentedStacks: bool) {
     unsafe {
         do Triple.to_c_str().with_ref |Triple| {
-            do Feature.to_c_str().with_ref |Feature| {
-                do Output.to_c_str().with_ref |Output| {
-                    let result = llvm::LLVMRustWriteOutputFile(
-                            PM,
-                            M,
-                            Triple,
-                            Feature,
-                            Output,
-                            FileType,
-                            OptLevel,
-                            EnableSegmentedStacks);
-                    if (!result) {
-                        llvm_err(sess, ~"Could not write output");
+            do Cpu.to_c_str().with_ref |Cpu| {
+                do Feature.to_c_str().with_ref |Feature| {
+                    do Output.to_c_str().with_ref |Output| {
+                        let result = llvm::LLVMRustWriteOutputFile(
+                                PM,
+                                M,
+                                Triple,
+                                Cpu,
+                                Feature,
+                                Output,
+                                FileType,
+                                OptLevel,
+                                EnableSegmentedStacks);
+                        if (!result) {
+                            llvm_err(sess, ~"Could not write output");
+                        }
                     }
                 }
             }
@@ -346,6 +350,7 @@ pub mod write {
                             pm.llpm,
                             llmod,
                             sess.targ_cfg.target_strs.target_triple,
+                            opts.target_cpu,
                             opts.target_feature,
                             output.to_str(),
                             lib::llvm::AssemblyFile as c_uint,
@@ -362,6 +367,7 @@ pub mod write {
                             pm.llpm,
                             llmod,
                             sess.targ_cfg.target_strs.target_triple,
+                            opts.target_cpu,
                             opts.target_feature,
                             output.to_str(),
                             lib::llvm::ObjectFile as c_uint,
@@ -376,6 +382,7 @@ pub mod write {
                         pm.llpm,
                         llmod,
                         sess.targ_cfg.target_strs.target_triple,
+                        opts.target_cpu,
                         opts.target_feature,
                         output.to_str(),
                         FileType as c_uint,

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -684,8 +684,9 @@ pub fn build_session_options(binary: @str,
             link::output_type_bitcode
         } else { link::output_type_exe };
     let sysroot_opt = getopts::opt_maybe_str(matches, "sysroot").map_move(|m| @Path(m));
-    let target_opt = getopts::opt_maybe_str(matches, "target");
-    let target_feature_opt = getopts::opt_maybe_str(matches, "target-feature");
+    let target = getopts::opt_maybe_str(matches, "target").unwrap_or_default(host_triple());
+    let target_cpu = getopts::opt_maybe_str(matches, "target-cpu").unwrap_or_default(~"generic");
+    let target_feature = getopts::opt_maybe_str(matches, "target-feature").unwrap_or_default(~"");
     let save_temps = getopts::opt_present(matches, "save-temps");
     let opt_level = {
         if (debugging_opts & session::no_opt) != 0 {
@@ -713,15 +714,6 @@ pub fn build_session_options(binary: @str,
     let debuginfo = debugging_opts & session::debug_info != 0 ||
         extra_debuginfo;
     let statik = debugging_opts & session::statik != 0;
-    let target =
-        match target_opt {
-            None => host_triple(),
-            Some(s) => s
-        };
-    let target_feature = match target_feature_opt {
-        None => ~"",
-        Some(s) => s
-    };
 
     let addl_lib_search_paths = getopts::opt_strs(matches, "L").map(|s| Path(*s));
     let linker = getopts::opt_maybe_str(matches, "linker");
@@ -760,6 +752,7 @@ pub fn build_session_options(binary: @str,
         linker_args: linker_args,
         maybe_sysroot: sysroot_opt,
         target_triple: target,
+        target_cpu: target_cpu,
         target_feature: target_feature,
         cfg: cfg,
         binary: binary,
@@ -876,10 +869,13 @@ pub fn optgroups() -> ~[getopts::groups::OptGroup] {
   optopt("", "target",
                         "Target triple cpu-manufacturer-kernel[-os]
                           to compile for (see chapter 3.4 of http://www.sourceware.org/autobook/
-                          for detail)", "TRIPLE"),
+                          for details)", "TRIPLE"),
+  optopt("", "target-cpu",
+                        "Select target processor (llc -mcpu=help
+                          for details)", "CPU"),
   optopt("", "target-feature",
                         "Target specific attributes (llc -mattr=help
-                          for detail)", "FEATURE"),
+                          for details)", "FEATURE"),
   optopt("", "android-cross-path",
          "The path to the Android NDK", "PATH"),
   optflagopt("W", "warn",

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -153,6 +153,7 @@ pub struct options {
     linker_args: ~[~str],
     maybe_sysroot: Option<@Path>,
     target_triple: ~str,
+    target_cpu: ~str,
     target_feature: ~str,
     // User-specified cfg meta items. The compiler itself will add additional
     // items to the crate config, and during parsing the entire crate config
@@ -340,6 +341,7 @@ pub fn basic_options() -> @options {
         linker_args: ~[],
         maybe_sysroot: None,
         target_triple: host_triple(),
+        target_cpu: ~"generic",
         target_feature: ~"",
         cfg: ~[],
         binary: @"rustc",

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1811,6 +1811,7 @@ pub mod llvm {
         pub fn LLVMRustWriteOutputFile(PM: PassManagerRef,
                                        M: ModuleRef,
                                        Triple: *c_char,
+                                       Cpu: *c_char,
                                        Feature: *c_char,
                                        Output: *c_char,
                                        // FIXME: When #2334 is fixed,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -372,6 +372,7 @@ extern "C" bool
 LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
                         LLVMModuleRef M,
                         const char *triple,
+                        const char *cpu,
                         const char *feature,
                         const char *path,
                         TargetMachine::CodeGenFileType FileType,
@@ -401,7 +402,7 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
   std::string Err;
   std::string Trip(Triple::normalize(triple));
   std::string FeaturesStr(feature);
-  std::string CPUStr("generic");
+  std::string CPUStr(cpu);
   const Target *TheTarget = TargetRegistry::lookupTarget(Trip, Err);
   TargetMachine *Target =
     TheTarget->createTargetMachine(Trip, CPUStr, FeaturesStr,


### PR DESCRIPTION
Adds `--target-cpu` flag which lets you choose a more specific target cpu instead of just passing the default, `generic`. It's more or less akin to `-mcpu`/`-mtune` in clang/gcc.
