### PR TITLE
Fixed option_env! type

### DIFF
--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -27,7 +27,7 @@ pub fn expand_option_env(ext_cx: @ExtCtxt, sp: span, tts: &[ast::token_tree])
     let var = get_single_str_from_tts(ext_cx, sp, tts, "option_env!");
 
     let e = match os::getenv(var) {
-      None => quote_expr!(::std::option::None),
+      None => quote_expr!(::std::option::None::<&'static str>),
       Some(s) => quote_expr!(::std::option::Some($s))
     };
     MRExpr(e)

--- a/src/test/run-pass/extoption_env-not-defined.rs
+++ b/src/test/run-pass/extoption_env-not-defined.rs
@@ -9,6 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    let opt: Option<&'static str> = option_env!("__HOPEFULLY_DOESNT_EXIST__");
-    assert!(opt.is_none());
+    assert!(option_env!("__HOPEFULLY_DOESNT_EXIST__").is_none());
 }


### PR DESCRIPTION
The type of the result of option_env! was not fully specified in the
None case, leading to type check failures in the case where the variable
was not defined (e.g. option_env!("FOO").is_none()).

Also cleaned up some compilation warnings.
