### PR TITLE
Add basic support for libstd without a runtime.

### DIFF
--- a/src/libstd/hash.rs
+++ b/src/libstd/hash.rs
@@ -264,6 +264,7 @@ macro_rules! compress (
 )
 
 
+#[cfg(not(no_rt))]
 impl Writer for SipState {
     // Methods for io::writer
     #[inline]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -31,11 +31,13 @@
 use c_str::ToCStr;
 use clone::Clone;
 use container::Container;
+#[cfg(not(no_rt))]
 use io;
 use iterator::{IteratorUtil, range};
 use libc;
 use libc::{c_char, c_void, c_int, size_t};
 use libc::FILE;
+#[cfg(not(no_rt))]
 use local_data;
 use option::{Some, None};
 use os;
@@ -338,7 +340,7 @@ pub fn fdopen(fd: c_int) -> *FILE {
 
 // fsync related
 
-#[cfg(windows)]
+#[cfg(windows, not(no_rt))]
 pub fn fsync_fd(fd: c_int, _level: io::fsync::Level) -> c_int {
     unsafe {
         use libc::funcs::extra::msvcrt::*;
@@ -346,8 +348,8 @@ pub fn fsync_fd(fd: c_int, _level: io::fsync::Level) -> c_int {
     }
 }
 
-#[cfg(target_os = "linux")]
-#[cfg(target_os = "android")]
+#[cfg(target_os = "linux", not(no_rt))]
+#[cfg(target_os = "android", not(no_rt))]
 pub fn fsync_fd(fd: c_int, level: io::fsync::Level) -> c_int {
     unsafe {
         use libc::funcs::posix01::unistd::*;
@@ -359,7 +361,7 @@ pub fn fsync_fd(fd: c_int, level: io::fsync::Level) -> c_int {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(target_os = "macos", not(no_rt))]
 pub fn fsync_fd(fd: c_int, level: io::fsync::Level) -> c_int {
     unsafe {
         use libc::consts::os::extra::*;
@@ -379,7 +381,7 @@ pub fn fsync_fd(fd: c_int, level: io::fsync::Level) -> c_int {
     }
 }
 
-#[cfg(target_os = "freebsd")]
+#[cfg(target_os = "freebsd", not(no_rt))]
 pub fn fsync_fd(fd: c_int, _l: io::fsync::Level) -> c_int {
     unsafe {
         use libc::funcs::posix01::unistd::*;
@@ -1109,6 +1111,7 @@ pub fn last_os_error() -> ~str {
  * and is supervised by the scheduler then any user-specified exit status is
  * ignored and the process exits with the default failure status
  */
+#[cfg(not(no_rt))]
 pub fn set_exit_status(code: int) {
     use rt;
     rt::util::set_exit_status(code);
@@ -1127,7 +1130,7 @@ unsafe fn load_argc_and_argv(argc: c_int, argv: **c_char) -> ~[~str] {
  *
  * Returns a list of the command line arguments.
  */
-#[cfg(target_os = "macos")]
+#[cfg(target_os = "macos", not(no_rt))]
 pub fn real_args() -> ~[~str] {
     unsafe {
         let (argc, argv) = (*_NSGetArgc() as c_int,
@@ -1136,9 +1139,9 @@ pub fn real_args() -> ~[~str] {
     }
 }
 
-#[cfg(target_os = "linux")]
-#[cfg(target_os = "android")]
-#[cfg(target_os = "freebsd")]
+#[cfg(target_os = "linux", not(no_rt))]
+#[cfg(target_os = "android", not(no_rt))]
+#[cfg(target_os = "freebsd", not(no_rt))]
 pub fn real_args() -> ~[~str] {
     use rt;
 
@@ -1148,7 +1151,7 @@ pub fn real_args() -> ~[~str] {
     }
 }
 
-#[cfg(windows)]
+#[cfg(windows, not(no_rt))]
 pub fn real_args() -> ~[~str] {
     let mut nArgs: c_int = 0;
     let lpArgCount: *mut c_int = &mut nArgs;
@@ -1197,6 +1200,7 @@ struct OverriddenArgs {
     val: ~[~str]
 }
 
+#[cfg(not(no_rt))]
 static overridden_arg_key: local_data::Key<@OverriddenArgs> = &local_data::Key;
 
 /// Returns the arguments which this program was started with (normally passed
@@ -1204,6 +1208,7 @@ static overridden_arg_key: local_data::Key<@OverriddenArgs> = &local_data::Key;
 ///
 /// The return value of the function can be changed by invoking the
 /// `os::set_args` function.
+#[cfg(not(no_rt))]
 pub fn args() -> ~[~str] {
     match local_data::get(overridden_arg_key, |k| k.map(|&k| *k)) {
         None => real_args(),
@@ -1214,6 +1219,7 @@ pub fn args() -> ~[~str] {
 /// For the current task, overrides the task-local cache of the arguments this
 /// program had when it started. These new arguments are only available to the
 /// current task via the `os::args` method.
+#[cfg(not(no_rt))]
 pub fn set_args(new_args: ~[~str]) {
     let overridden_args = @OverriddenArgs {
         val: new_args.clone()

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -39,6 +39,7 @@ pub use option::{Option, Some, None};
 pub use result::{Result, Ok, Err};
 
 // Reexported functions
+#[cfg(not(no_rt))]
 pub use io::{print, println};
 pub use iterator::range;
 
@@ -48,6 +49,7 @@ pub use clone::{Clone, DeepClone};
 pub use cmp::{Eq, ApproxEq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater, Equiv};
 pub use char::Char;
 pub use container::{Container, Mutable, Map, MutableMap, Set, MutableSet};
+#[cfg(not(no_rt))]
 pub use hash::Hash;
 pub use iter::Times;
 pub use iterator::Extendable;
@@ -79,8 +81,11 @@ pub use tuple::{ImmutableTuple10, ImmutableTuple11, ImmutableTuple12};
 pub use vec::{Vector, VectorVector, CopyableVector, ImmutableVector};
 pub use vec::{ImmutableEqVector, ImmutableTotalOrdVector, ImmutableCopyableVector};
 pub use vec::{OwnedVector, OwnedCopyableVector,OwnedEqVector, MutableVector};
+#[cfg(not(no_rt))]
 pub use io::{Reader, ReaderUtil, Writer, WriterUtil};
 
 // Reexported runtime types
+#[cfg(not(no_rt))]
 pub use comm::{stream, Port, Chan, GenericChan, GenericSmartChan, GenericPort, Peekable};
+#[cfg(not(no_rt))]
 pub use task::spawn;

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -49,6 +49,7 @@ use cmp;
 use container::Container;
 use int;
 use iterator::{Iterator, range};
+#[cfg(not(no_rt))]
 use local_data;
 use num;
 use prelude::*;
@@ -875,6 +876,7 @@ pub fn seed() -> ~[u8] {
 }
 
 // used to make space in TLS for a random number generator
+#[cfg(not(no_rt))]
 static tls_rng_state: local_data::Key<@@mut IsaacRng> = &local_data::Key;
 
 /**
@@ -883,6 +885,7 @@ static tls_rng_state: local_data::Key<@@mut IsaacRng> = &local_data::Key;
  * `task_rng().gen::<int>()`.
  */
 #[inline]
+#[cfg(not(no_rt))]
 pub fn task_rng() -> @mut IsaacRng {
     let r = local_data::get(tls_rng_state, |k| k.map(|&k| *k));
     match r {
@@ -908,8 +911,17 @@ impl<R: Rng> Rng for @mut R {
  * generator.
  */
 #[inline]
+#[cfg(not(no_rt))]
 pub fn random<T: Rand>() -> T {
     task_rng().gen()
+}
+
+#[cfg(no_rt)]
+/// Returns a random value of the `Rand` type, using a XorShiftRng seeded with
+/// a constant.
+pub fn random<T: Rand>() -> T {
+    // XXX: always seeded with a constant! bad!
+    XorShiftRng::new().gen()
 }
 
 #[cfg(test)]

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -66,14 +66,23 @@ use container::Container;
 use iterator::{Iterator, IteratorUtil, range};
 use option::{Some, None};
 use ptr::RawPtr;
+#[cfg(not(no_rt))]
 use rt::local::Local;
+#[cfg(not(no_rt))]
 use rt::sched::{Scheduler, Shutdown};
+#[cfg(not(no_rt))]
 use rt::sleeper_list::SleeperList;
+#[cfg(not(no_rt))]
 use rt::task::{Task, SchedTask, GreenTask, Sched};
+#[cfg(not(no_rt))]
 use rt::thread::Thread;
+#[cfg(not(no_rt))]
 use rt::work_queue::WorkQueue;
+#[cfg(not(no_rt))]
 use rt::uv::uvio::UvEventLoop;
+#[cfg(not(no_rt))]
 use unstable::atomics::{AtomicInt, SeqCst};
+#[cfg(not(no_rt))]
 use unstable::sync::UnsafeAtomicRcBox;
 use vec::{OwnedVector, MutableVector};
 
@@ -81,88 +90,115 @@ use vec::{OwnedVector, MutableVector};
 pub mod global_heap;
 
 /// Implementations of language-critical runtime features like @.
+#[cfg(not(no_rt))]
 pub mod task;
 
 /// Facilities related to task failure, killing, and death.
+#[cfg(not(no_rt))]
 mod kill;
 
 /// The coroutine task scheduler, built on the `io` event loop.
+#[cfg(not(no_rt))]
 mod sched;
 
 /// Synchronous I/O.
+#[cfg(not(no_rt))]
 pub mod io;
 
 /// The EventLoop and internal synchronous I/O interface.
+#[cfg(not(no_rt))]
 mod rtio;
 
 /// libuv and default rtio implementation.
+#[cfg(not(no_rt))]
 pub mod uv;
 
 /// The Local trait for types that are accessible via thread-local
 /// or task-local storage.
+#[cfg(not(no_rt))]
 pub mod local;
 
 /// A parallel work-stealing deque.
+#[cfg(not(no_rt))]
 mod work_queue;
 
 /// A parallel queue.
+#[cfg(not(no_rt))]
 mod message_queue;
 
 /// A parallel data structure for tracking sleeping schedulers.
+#[cfg(not(no_rt))]
 mod sleeper_list;
 
 /// Stack segments and caching.
+#[cfg(not(no_rt))]
 mod stack;
 
 /// CPU context swapping.
+#[cfg(not(no_rt))]
 mod context;
 
 /// Bindings to system threading libraries.
+#[cfg(not(no_rt))]
 mod thread;
 
 /// The runtime configuration, read from environment variables.
+#[cfg(not(no_rt))]
 pub mod env;
 
 /// The local, managed heap
+#[cfg(not(no_rt))]
 pub mod local_heap;
 
 /// The Logger trait and implementations
+#[cfg(not(no_rt))]
 pub mod logging;
 
 /// Tools for testing the runtime
+#[cfg(not(no_rt))]
 pub mod test;
 
 /// Reference counting
+#[cfg(not(no_rt))]
 pub mod rc;
 
 /// A simple single-threaded channel type for passing buffered data between
 /// scheduler and task context
+#[cfg(not(no_rt))]
 pub mod tube;
 
 /// Simple reimplementation of core::comm
+#[cfg(not(no_rt))]
 pub mod comm;
 
 /// Routines for select()ing on pipes.
+#[cfg(not(no_rt))]
 pub mod select;
 
 // FIXME #5248 shouldn't be pub
 /// The runtime needs to be able to put a pointer into thread-local storage.
+#[cfg(not(no_rt))]
 pub mod local_ptr;
 
 // FIXME #5248: The import in `sched` doesn't resolve unless this is pub!
 /// Bindings to pthread/windows thread-local storage.
+#[cfg(not(no_rt))]
 pub mod thread_local_storage;
 
+#[cfg(not(no_rt))]
 pub mod metrics;
 
 // FIXME #5248 shouldn't be pub
 /// Just stuff
+#[cfg(not(no_rt))]
 pub mod util;
 
 // Global command line argument storage
+#[cfg(not(no_rt))]
 pub mod args;
 
 // Support for dynamic borrowck
+#[cfg(not(no_rt))]
 pub mod borrowck;
 
 /// Set up a default runtime configuration, given compiler-supplied arguments.
@@ -179,6 +215,7 @@ pub mod borrowck;
 /// # Return value
 ///
 /// The return value is used as the process return code. 0 on success, 101 on error.
+#[cfg(not(no_rt))]
 pub fn start(argc: int, argv: **u8, crate_map: *u8, main: ~fn()) -> int {
 
     init(argc, argv, crate_map);
@@ -193,6 +230,7 @@ pub fn start(argc: int, argv: **u8, crate_map: *u8, main: ~fn()) -> int {
 ///
 /// This is appropriate for running code that must execute on the main thread,
 /// such as the platform event loop and GUI.
+#[cfg(not(no_rt))]
 pub fn start_on_main_thread(argc: int, argv: **u8, crate_map: *u8, main: ~fn()) -> int {
     init(argc, argv, crate_map);
     let exit_code = run_on_main_thread(main);
@@ -206,6 +244,7 @@ pub fn start_on_main_thread(argc: int, argv: **u8, crate_map: *u8, main: ~fn()) 
 /// Initializes global state, including frobbing
 /// the crate's logging flags, registering GC
 /// metadata, and storing the process arguments.
+#[cfg(not(no_rt))]
 pub fn init(argc: int, argv: **u8, crate_map: *u8) {
     // XXX: Derefing these pointers is not safe.
     // Need to propagate the unsafety to `start`.
@@ -222,6 +261,7 @@ pub fn init(argc: int, argv: **u8, crate_map: *u8) {
 }
 
 /// One-time runtime cleanup.
+#[cfg(not(no_rt))]
 pub fn cleanup() {
     args::cleanup();
 }
@@ -231,14 +271,17 @@ pub fn cleanup() {
 /// Configures the runtime according to the environment, by default
 /// using a task scheduler with the same number of threads as cores.
 /// Returns a process exit code.
+#[cfg(not(no_rt))]
 pub fn run(main: ~fn()) -> int {
     run_(main, false)
 }
 
+#[cfg(not(no_rt))]
 pub fn run_on_main_thread(main: ~fn()) -> int {
     run_(main, true)
 }
 
+#[cfg(not(no_rt))]
 fn run_(main: ~fn(), use_main_sched: bool) -> int {
     static DEFAULT_ERROR_CODE: int = 101;
 
@@ -401,6 +444,7 @@ fn run_(main: ~fn(), use_main_sched: bool) -> int {
     }
 }
 
+#[cfg(not(no_rt))]
 pub fn in_sched_context() -> bool {
     unsafe {
         match Local::try_unsafe_borrow::<Task>() {
@@ -415,6 +459,7 @@ pub fn in_sched_context() -> bool {
     }
 }
 
+#[cfg(not(no_rt))]
 pub fn in_green_task_context() -> bool {
     unsafe {
         match Local::try_unsafe_borrow::<Task>() {

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -15,7 +15,9 @@
 use c_str::ToCStr;
 use cast;
 use clone::Clone;
+#[cfg(not(no_rt))]
 use comm::{stream, SharedChan, GenericChan, GenericPort};
+#[cfg(not(no_rt))]
 use io;
 use libc::{pid_t, c_void, c_int};
 use libc;
@@ -23,6 +25,7 @@ use option::{Some, None};
 use os;
 use prelude::*;
 use ptr;
+#[cfg(not(no_rt))]
 use task;
 use vec::ImmutableVector;
 
@@ -255,6 +258,7 @@ impl Process {
      *
      * Fails if this Process's stdin was redirected to an existing file descriptor.
      */
+    #[cfg(not(no_rt))]
     pub fn input(&mut self) -> @io::Writer {
         // FIXME: the Writer can still be used after self is destroyed: #2625
        io::fd_writer(self.input_fd(), false)
@@ -265,6 +269,7 @@ impl Process {
      *
      * Fails if this Process's stdout was redirected to an existing file descriptor.
      */
+    #[cfg(not(no_rt))]
     pub fn output(&mut self) -> @io::Reader {
         // FIXME: the Reader can still be used after self is destroyed: #2625
         io::FILE_reader(self.output_file(), false)
@@ -275,6 +280,7 @@ impl Process {
      *
      * Fails if this Process's stderr was redirected to an existing file descriptor.
      */
+    #[cfg(not(no_rt))]
     pub fn error(&mut self) -> @io::Reader {
         // FIXME: the Reader can still be used after self is destroyed: #2625
         io::FILE_reader(self.error_file(), false)
@@ -341,6 +347,7 @@ impl Process {
      * This method will fail if the child process's stdout or stderr streams were
      * redirected to existing file descriptors.
      */
+    #[cfg(not(no_rt))]
     pub fn finish_with_output(&mut self) -> ProcessOutput {
         let output_file = self.output_file();
         let error_file = self.error_file();

--- a/src/libstd/std.rs
+++ b/src/libstd/std.rs
@@ -75,6 +75,7 @@ they contained the following prologue:
 // On Linux, link to the runtime with -lrt.
 #[cfg(target_os = "linux")]
 #[doc(hidden)]
+#[cfg(not(no_rt))]
 pub mod linkhack {
     #[link_args="-lrustrt -lrt"]
     #[link_args = "-lpthread"]
@@ -116,6 +117,7 @@ pub mod char;
 pub mod tuple;
 
 pub mod vec;
+#[cfg(not(no_rt))]
 pub mod at_vec;
 pub mod str;
 
@@ -124,6 +126,7 @@ pub mod ascii;
 
 pub mod ptr;
 pub mod owned;
+#[cfg(not(no_rt))]
 pub mod managed;
 pub mod borrow;
 
@@ -145,16 +148,18 @@ pub mod iterator;
 pub mod to_str;
 pub mod to_bytes;
 pub mod clone;
+#[cfg(not(no_rt))]
 pub mod io;
+#[cfg(not(no_rt))]
 pub mod hash;
 pub mod container;
-
 
 /* Common data structures */
 
 pub mod option;
 pub mod result;
 pub mod either;
+#[cfg(not(no_rt))]
 pub mod hashmap;
 pub mod cell;
 pub mod trie;
@@ -162,8 +167,11 @@ pub mod trie;
 
 /* Tasks and communication */
 
+#[cfg(not(no_rt))]
 pub mod task;
+#[cfg(not(no_rt))]
 pub mod comm;
+#[cfg(not(no_rt))]
 pub mod local_data;
 
 
@@ -174,14 +182,20 @@ pub mod c_str;
 pub mod os;
 pub mod path;
 pub mod rand;
+#[cfg(not(no_rt))]
 pub mod run;
 pub mod sys;
 pub mod cast;
+#[cfg(not(no_rt))]
 pub mod fmt;
+#[cfg(not(no_rt))]
 pub mod repr;
+#[cfg(not(no_rt))]
 pub mod cleanup;
 pub mod reflect;
+#[cfg(not(no_rt))]
 pub mod condition;
+#[cfg(not(no_rt))]
 pub mod logging;
 pub mod util;
 
@@ -208,14 +222,17 @@ pub mod rt;
 mod std {
     pub use clone;
     pub use cmp;
+    #[cfg(not(no_rt))]
     pub use condition;
     pub use option;
     pub use kinds;
+    #[cfg(not(no_rt))]
     pub use local_data;
     pub use sys;
     pub use unstable;
     pub use str;
     pub use os;
+    #[cfg(not(no_rt))]
     pub use fmt;
     pub use to_bytes;
 }

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -16,6 +16,7 @@
  * for efficiency, but UTF-8 unsafe operations should be avoided.
  */
 
+#[cfg(not(no_rt))]
 use at_vec;
 use cast;
 use char;
@@ -42,8 +43,11 @@ use vec::{OwnedVector, OwnedCopyableVector, ImmutableVector, MutableVector};
 Section: Conditions
 */
 
-condition! {
-    not_utf8: (~str) -> ~str;
+#[cfg(not(no_rt))]
+pub mod conds {
+    condition! {
+        not_utf8: (~str) -> ~str;
+    }
 }
 
 /*
@@ -55,8 +59,9 @@ Section: Creating a string
 /// # Failure
 ///
 /// Raises the `not_utf8` condition if invalid UTF-8
+#[cfg(not(no_rt))]
 pub fn from_bytes(vv: &[u8]) -> ~str {
-    use str::not_utf8::cond;
+    use str::conds::not_utf8::cond;
 
     if !is_utf8(vv) {
         let first_bad_byte = *vv.iter().find_(|&b| !is_utf8([*b])).unwrap();
@@ -67,13 +72,21 @@ pub fn from_bytes(vv: &[u8]) -> ~str {
     }
 }
 
+#[cfg(no_rt)]
+/// Convert a vector of bytes to a new UTF-8 string
+/// XXX: this is incorrect with no_rt
+pub fn from_bytes(vv: &[u8]) -> ~str {
+    return unsafe { raw::from_bytes(vv) }
+}
+
 /// Consumes a vector of bytes to create a new utf-8 string
 ///
 /// # Failure
 ///
 /// Raises the `not_utf8` condition if invalid UTF-8
+#[cfg(not(no_rt))]
 pub fn from_bytes_owned(vv: ~[u8]) -> ~str {
-    use str::not_utf8::cond;
+    use str::conds::not_utf8::cond;
 
     if !is_utf8(vv) {
         let first_bad_byte = *vv.iter().find_(|&b| !is_utf8([*b])).unwrap();
@@ -82,6 +95,14 @@ pub fn from_bytes_owned(vv: ~[u8]) -> ~str {
     } else {
         return unsafe { raw::from_bytes_owned(vv) }
     }
+}
+
+#[cfg(no_rt)]
+/// Convert a vector of bytes to a new UTF-8 string
+/// XXX: this is incorrect with no_rt
+pub fn from_bytes_owned(vv: ~[u8]) -> ~str {
+    // XXX: Incorrect
+    return unsafe { raw::from_bytes_owned(vv) }
 }
 
 /// Converts a vector to a string slice without performing any allocations.
@@ -1386,6 +1407,7 @@ pub trait StrSlice<'self> {
     fn trim_right_chars<C: CharEq>(&self, to_trim: &C) -> &'self str;
     fn replace(&self, from: &str, to: &str) -> ~str;
     fn to_owned(&self) -> ~str;
+    #[cfg(not(no_rt))]
     fn to_managed(&self) -> @str;
     fn to_utf16(&self) -> ~[u16];
     fn is_char_boundary(&self, index: uint) -> bool;
@@ -1831,7 +1853,7 @@ impl<'self> StrSlice<'self> for &'self str {
         }
     }
 
-    #[cfg(stage0)]
+    #[cfg(stage0, not(no_rt))]
     #[inline]
     fn to_managed(&self) -> @str {
         let v = at_vec::from_fn(self.len() + 1, |i| {
@@ -1840,7 +1862,7 @@ impl<'self> StrSlice<'self> for &'self str {
         unsafe { cast::transmute(v) }
     }
 
-    #[cfg(not(stage0))]
+    #[cfg(not(stage0), not(no_rt))]
     #[inline]
     fn to_managed(&self) -> @str {
         unsafe {
@@ -3142,8 +3164,9 @@ mod tests {
 
     #[test]
     #[ignore(cfg(windows))]
+    #[cfg(not(no_rt))]
     fn test_from_bytes_fail() {
-        use str::not_utf8::cond;
+        use str::conds::not_utf8::cond;
 
         let bb = ~[0xff_u8, 0xb8_u8, 0xa8_u8,
                   0xe0_u8, 0xb9_u8, 0x84_u8,

--- a/src/libstd/to_bytes.rs
+++ b/src/libstd/to_bytes.rs
@@ -15,7 +15,9 @@ The `ToBytes` and `IterBytes` traits
 */
 
 use cast;
+#[cfg(not(no_rt))]
 use io;
+#[cfg(not(no_rt))]
 use io::Writer;
 use iterator::IteratorUtil;
 use option::{None, Option, Some};
@@ -350,6 +352,7 @@ pub trait ToBytes {
     fn to_bytes(&self, lsb0: bool) -> ~[u8];
 }
 
+#[cfg(not(no_rt))]
 impl<A:IterBytes> ToBytes for A {
     fn to_bytes(&self, lsb0: bool) -> ~[u8] {
         do io::with_bytes_writer |wr| {

--- a/src/libstd/to_str.rs
+++ b/src/libstd/to_str.rs
@@ -16,8 +16,11 @@ The `ToStr` trait for converting to strings
 
 use option::{Some, None};
 use str::OwnedStr;
+#[cfg(not(no_rt))]
 use hashmap::HashMap;
+#[cfg(not(no_rt))]
 use hashmap::HashSet;
+#[cfg(not(no_rt))]
 use hash::Hash;
 use iterator::Iterator;
 use cmp::Eq;
@@ -51,6 +54,7 @@ impl<A:ToStr> ToStr for (A,) {
     }
 }
 
+#[cfg(not(no_rt))]
 impl<A:ToStr+Hash+Eq, B:ToStr> ToStr for HashMap<A, B> {
     #[inline]
     fn to_str(&self) -> ~str {
@@ -72,6 +76,7 @@ impl<A:ToStr+Hash+Eq, B:ToStr> ToStr for HashMap<A, B> {
     }
 }
 
+#[cfg(not(no_rt))]
 impl<A:ToStr+Hash+Eq> ToStr for HashSet<A> {
     #[inline]
     fn to_str(&self) -> ~str {
@@ -180,7 +185,9 @@ impl<A:ToStr> ToStr for @[A] {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(no_rt))]
     use hashmap::HashMap;
+    #[cfg(not(no_rt))]
     use hashmap::HashSet;
     use container::{MutableSet, MutableMap};
     use super::*;
@@ -226,6 +233,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(no_rt))]
     fn test_hashmap() {
         let mut table: HashMap<int, StructWithToStrWithoutEqOrHash> = HashMap::new();
         let empty: HashMap<int, StructWithToStrWithoutEqOrHash> = HashMap::new();

--- a/src/libstd/unstable/extfmt.rs
+++ b/src/libstd/unstable/extfmt.rs
@@ -582,8 +582,15 @@ pub mod rt {
         pad(cv, s, None, PadNozero, buf);
     }
     pub fn conv_poly<T>(cv: Conv, v: &T, buf: &mut ~str) {
-        let s = sys::log_str(v);
-        conv_str(cv, s, buf);
+        #[cfg(no_rt)]
+        #[inline] fn inner<T>(cv: Conv, v: &T, buf: &mut ~str) {
+        }
+        #[cfg(not(no_rt))]
+        #[inline] fn inner<T>(cv: Conv, v: &T, buf: &mut ~str) {
+            let s = sys::log_str(v);
+            conv_str(cv, s, buf);
+        }
+        inner(cv, v, buf);
     }
 
     // Convert a uint to string with a minimum number of digits.  If precision

--- a/src/libstd/unstable/lang.rs
+++ b/src/libstd/unstable/lang.rs
@@ -15,16 +15,27 @@ use cast::transmute;
 use libc::{c_char, c_uchar, c_void, size_t, uintptr_t};
 use str;
 use sys;
+#[cfg(not(no_rt))]
 use rt::task::Task;
+#[cfg(not(no_rt))]
 use rt::local::Local;
+#[cfg(not(no_rt))]
 use rt::borrowck;
 
 #[lang="fail_"]
+#[cfg(not(no_rt))]
 pub fn fail_(expr: *c_char, file: *c_char, line: size_t) -> ! {
     sys::begin_unwind_(expr, file, line);
 }
 
+#[lang="fail_"]
+#[cfg(no_rt)]
+pub fn fail_(expr: *c_char, file: *c_char, line: size_t) -> ! {
+    unsafe { ::libc::abort() }
+}
+
 #[lang="fail_bounds_check"]
+#[cfg(not(no_rt))]
 pub fn fail_bounds_check(file: *c_char, line: size_t,
                          index: size_t, len: size_t) {
     let msg = fmt!("index out of bounds: the len is %d but the index is %d",
@@ -34,7 +45,15 @@ pub fn fail_bounds_check(file: *c_char, line: size_t,
     }
 }
 
+#[lang="fail_bounds_check"]
+#[cfg(no_rt)]
+pub fn fail_bounds_check(file: *c_char, line: size_t,
+                         index: size_t, len: size_t) {
+    unsafe { ::libc::abort() }
+}
+
 #[lang="malloc"]
+#[cfg(not(no_rt))]
 pub unsafe fn local_malloc(td: *c_char, size: uintptr_t) -> *c_char {
     let mut alloc = ::ptr::null();
     do Local::borrow::<Task,()> |task| {
@@ -46,33 +65,56 @@ pub unsafe fn local_malloc(td: *c_char, size: uintptr_t) -> *c_char {
     return alloc;
 }
 
+#[lang="malloc"]
+#[cfg(no_rt)]
+pub unsafe fn local_malloc(td: *c_char, size: uintptr_t) -> *c_char {
+    transmute(::libc::malloc(transmute(size)))
+}
+
 // NB: Calls to free CANNOT be allowed to fail, as throwing an exception from
 // inside a landing pad may corrupt the state of the exception handler. If a
 // problem occurs, call exit instead.
 #[lang="free"]
+#[cfg(not(no_rt))]
 pub unsafe fn local_free(ptr: *c_char) {
     ::rt::local_heap::local_free(ptr);
 }
 
+#[lang="free"]
+#[cfg(no_rt)]
+pub unsafe fn local_free(ptr: *c_char) {
+    ::libc::free(transmute(ptr))
+}
+
+#[cfg(not(test))]
+#[lang="log_type"]
+#[allow(missing_doc)]
+#[cfg(no_rt)]
+pub fn log_type<T>(_level: u32, object: &T) { }
+
 #[lang="borrow_as_imm"]
 #[inline]
+#[cfg(not(no_rt))]
 pub unsafe fn borrow_as_imm(a: *u8, file: *c_char, line: size_t) -> uint {
     borrowck::borrow_as_imm(a, file, line)
 }
 
 #[lang="borrow_as_mut"]
 #[inline]
+#[cfg(not(no_rt))]
 pub unsafe fn borrow_as_mut(a: *u8, file: *c_char, line: size_t) -> uint {
     borrowck::borrow_as_mut(a, file, line)
 }
 
 #[lang="record_borrow"]
+#[cfg(not(no_rt))]
 pub unsafe fn record_borrow(a: *u8, old_ref_count: uint,
                             file: *c_char, line: size_t) {
     borrowck::record_borrow(a, old_ref_count, file, line)
 }
 
 #[lang="unrecord_borrow"]
+#[cfg(not(no_rt))]
 pub unsafe fn unrecord_borrow(a: *u8, old_ref_count: uint,
                               file: *c_char, line: size_t) {
     borrowck::unrecord_borrow(a, old_ref_count, file, line)
@@ -80,6 +122,7 @@ pub unsafe fn unrecord_borrow(a: *u8, old_ref_count: uint,
 
 #[lang="return_to_mut"]
 #[inline]
+#[cfg(not(no_rt))]
 pub unsafe fn return_to_mut(a: *u8, orig_ref_count: uint,
                             file: *c_char, line: size_t) {
     borrowck::return_to_mut(a, orig_ref_count, file, line)
@@ -87,6 +130,7 @@ pub unsafe fn return_to_mut(a: *u8, orig_ref_count: uint,
 
 #[lang="check_not_borrowed"]
 #[inline]
+#[cfg(not(no_rt))]
 pub unsafe fn check_not_borrowed(a: *u8,
                                  file: *c_char,
                                  line: size_t) {
@@ -100,11 +144,13 @@ pub unsafe fn strdup_uniq(ptr: *c_uchar, len: uint) -> ~str {
 }
 
 #[lang="annihilate"]
+#[cfg(not(no_rt))]
 pub unsafe fn annihilate() {
     ::cleanup::annihilate()
 }
 
 #[lang="start"]
+#[cfg(not(no_rt))]
 pub fn start(main: *u8, argc: int, argv: **c_char,
              crate_map: *u8) -> int {
     use rt;

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -10,11 +10,15 @@
 
 #[doc(hidden)];
 
+#[cfg(not(no_rt))]
 use comm::{GenericChan, GenericPort};
+#[cfg(not(no_rt))]
 use comm;
 use prelude::*;
+#[cfg(not(no_rt))]
 use task;
 
+#[cfg(not(no_rt))]
 pub mod dynamic_lib;
 
 pub mod finally;
@@ -22,7 +26,9 @@ pub mod intrinsics;
 pub mod simd;
 pub mod extfmt;
 #[cfg(not(test))]
+#[cfg(not(no_rt))]
 pub mod lang;
+#[cfg(not(no_rt))]
 pub mod sync;
 pub mod atomics;
 pub mod raw;
@@ -35,6 +41,7 @@ for it to terminate.
 The executing thread has no access to a task pointer and will be using
 a normal large stack.
 */
+#[cfg(not(no_rt))]
 pub fn run_in_bare_thread(f: ~fn()) {
     use cell::Cell;
     use rt::thread::Thread;
@@ -51,6 +58,7 @@ pub fn run_in_bare_thread(f: ~fn()) {
 }
 
 #[test]
+#[cfg(not(no_rt))]
 fn test_run_in_bare_thread() {
     let i = 100;
     do run_in_bare_thread {
@@ -59,6 +67,7 @@ fn test_run_in_bare_thread() {
 }
 
 #[test]
+#[cfg(not(no_rt))]
 fn test_run_in_bare_thread_exchange() {
     // Does the exchange heap work without the runtime?
     let i = ~100;
@@ -82,6 +91,7 @@ fn test_run_in_bare_thread_exchange() {
 /// This uses a pthread mutex so descheduling in the action callback
 /// can lead to deadlock. Calling change_dir_locked recursively will
 /// also deadlock.
+#[cfg(not(no_rt))]
 pub fn change_dir_locked(p: &Path, action: &fn()) -> bool {
     use os;
     use os::change_dir;

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1236,6 +1236,7 @@ impl<T> OwnedVector<T> for ~[T] {
      *
      * * n - The number of elements to reserve space for
      */
+    #[cfg(not(no_rt))]
     fn reserve(&mut self, n: uint) {
         // Only make the (slow) call into the runtime if we have to
         if self.capacity() < n {
@@ -1255,6 +1256,24 @@ impl<T> OwnedVector<T> for ~[T] {
                            as *mut Vec<()>;
                     (**ptr).alloc = alloc;
                 }
+            }
+        }
+    }
+
+    #[cfg(no_rt)]
+    fn reserve(&mut self, n: uint) {
+        if self.capacity() < n {
+            unsafe {
+                let td = get_tydesc::<T>();
+                let ptr: *mut *mut Vec<()> = cast::transmute(self);
+                let alloc = n * sys::nonzero_size_of::<T>();
+                let size = alloc + sys::size_of::<Vec<()>>();
+                if alloc / sys::nonzero_size_of::<T>() != n || size < alloc {
+                    fail!("vector size is too large: %u", n);
+                }
+                *ptr = realloc_raw(*ptr as *mut c_void, size)
+                       as *mut Vec<()>;
+                (**ptr).alloc = alloc;
             }
         }
     }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -866,44 +866,47 @@ pub fn std_macros() -> @str {
         )
     )
 
-    macro_rules! condition (
+    #[cfg(not(no_rt))]
+    #[macro_escape]
+    mod condition_macro {
+        macro_rules! condition (
 
-        { pub $c:ident: $input:ty -> $out:ty; } => {
+            { pub $c:ident: $input:ty -> $out:ty; } => {
 
-            pub mod $c {
-                #[allow(non_uppercase_statics)];
-                static key: ::std::local_data::Key<
-                    @::std::condition::Handler<$input, $out>> =
-                    &::std::local_data::Key;
+                pub mod $c {
+                    #[allow(non_uppercase_statics)];
+                    static key: ::std::local_data::Key<
+                        @::std::condition::Handler<$input, $out>> =
+                        &::std::local_data::Key;
 
-                pub static cond :
-                    ::std::condition::Condition<$input,$out> =
-                    ::std::condition::Condition {
-                        name: stringify!($c),
-                        key: key
-                    };
+                    pub static cond :
+                        ::std::condition::Condition<$input,$out> =
+                        ::std::condition::Condition {
+                            name: stringify!($c),
+                            key: key
+                        };
+                }
+            };
+
+            { $c:ident: $input:ty -> $out:ty; } => {
+
+                // FIXME (#6009): remove mod's `pub` below once variant above lands.
+                pub mod $c {
+                    #[allow(non_uppercase_statics)];
+                    static key: ::std::local_data::Key<
+                        @::std::condition::Handler<$input, $out>> =
+                        &::std::local_data::Key;
+
+                    pub static cond :
+                        ::std::condition::Condition<$input,$out> =
+                        ::std::condition::Condition {
+                            name: stringify!($c),
+                            key: key
+                        };
+                }
             }
-        };
-
-        { $c:ident: $input:ty -> $out:ty; } => {
-
-            // FIXME (#6009): remove mod's `pub` below once variant above lands.
-            pub mod $c {
-                #[allow(non_uppercase_statics)];
-                static key: ::std::local_data::Key<
-                    @::std::condition::Handler<$input, $out>> =
-                    &::std::local_data::Key;
-
-                pub static cond :
-                    ::std::condition::Condition<$input,$out> =
-                    ::std::condition::Condition {
-                        name: stringify!($c),
-                        key: key
-                    };
-            }
-        }
-    )
-
+        )
+    }
     //
     // A scheme-style conditional that helps to improve code clarity in some instances when
     // the `if`, `else if`, and `else` keywords obscure predicates undesirably.


### PR DESCRIPTION
To use it, pass `--cfg no_rt` to rustc when building libstd. Not everything is 
implemented correctly, and it probably needs to be reworked to use a 
zero.rs-like description of the runtime that _does_ exist. Careful 
consideration and reworking needs to be done to make the libstd able to be run 
on bare metal.
