### PR TITLE
remove more dead code from the old `for`

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1625,7 +1625,6 @@ pub fn new_fn_ctxt_w_id(ccx: @mut CrateContext,
           llreturn: None,
           llself: None,
           personality: None,
-          loop_ret: None,
           has_immediate_return_value: is_immediate,
           llargs: @mut HashMap::new(),
           lllocals: @mut HashMap::new(),
@@ -1834,8 +1833,7 @@ pub fn trans_closure(ccx: @mut CrateContext,
                      id: ast::NodeId,
                      attributes: &[ast::Attribute],
                      output_type: ty::t,
-                     maybe_load_env: &fn(@mut FunctionContext),
-                     finish: &fn(@mut Block)) {
+                     maybe_load_env: &fn(@mut FunctionContext)) {
     ccx.stats.n_closures += 1;
     let _icx = push_ctxt("trans_closure");
     set_uwtable(llfndecl);
@@ -1885,7 +1883,6 @@ pub fn trans_closure(ccx: @mut CrateContext,
         bcx = controlflow::trans_block(bcx, body, dest);
     }
 
-    finish(bcx);
     match fcx.llreturn {
         Some(llreturn) => cleanup_and_Br(bcx, bcx_top, llreturn),
         None => bcx = cleanup_block(bcx, Some(bcx_top.llbb))
@@ -1937,8 +1934,7 @@ pub fn trans_fn(ccx: @mut CrateContext,
                           && fcx_has_nonzero_span(fcx) {
                           debuginfo::create_function_metadata(fcx);
                       }
-                  },
-                  |_bcx| { });
+                  });
 }
 
 fn insert_synthetic_type_entries(bcx: @mut Block,

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -195,9 +195,6 @@ pub struct FunctionContext {
     // The a value alloca'd for calls to upcalls.rust_personality. Used when
     // outputting the resume instruction.
     personality: Option<ValueRef>,
-    // If this is a for-loop body that returns, this holds the pointers needed
-    // for that (flagptr, retptr)
-    loop_ret: Option<(ValueRef, ValueRef)>,
 
     // True if this function has an immediate return value, false otherwise.
     // If this is false, the llretptr will alias the first argument of the

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -13,7 +13,7 @@ use back::{upcall};
 use driver::session;
 use lib::llvm::{ContextRef, ModuleRef, ValueRef};
 use lib::llvm::{llvm, TargetData, TypeNames};
-use lib::llvm::{mk_target_data, False};
+use lib::llvm::mk_target_data;
 use metadata::common::LinkMeta;
 use middle::astencode;
 use middle::resolve;

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -21,7 +21,6 @@ use middle::trans::callee;
 use middle::trans::common::*;
 use middle::trans::debuginfo;
 use middle::trans::expr;
-use middle::trans::type_of::*;
 use middle::ty;
 use util::common::indenter;
 use util::ppaux;
@@ -341,29 +340,15 @@ pub fn trans_cont(bcx: @mut Block, label_opt: Option<ident>) -> @mut Block {
 pub fn trans_ret(bcx: @mut Block, e: Option<@ast::expr>) -> @mut Block {
     let _icx = push_ctxt("trans_ret");
     let mut bcx = bcx;
-    let dest = match bcx.fcx.loop_ret {
-      Some((flagptr, retptr)) => {
-        // This is a loop body return. Must set continue flag (our retptr)
-        // to false, return flag to true, and then store the value in the
-        // parent's retptr.
-        Store(bcx, C_bool(true), flagptr);
-        Store(bcx, C_bool(false), bcx.fcx.llretptr.unwrap());
-        expr::SaveIn(match e {
-          Some(x) => PointerCast(bcx, retptr,
-                                 type_of(bcx.ccx(), expr_ty(bcx, x)).ptr_to()),
-          None => retptr
-        })
-      }
-      None => match bcx.fcx.llretptr {
+    let dest = match bcx.fcx.llretptr {
         None => expr::Ignore,
         Some(retptr) => expr::SaveIn(retptr),
-      }
     };
     match e {
-      Some(x) => {
-        bcx = expr::trans_into(bcx, x, dest);
-      }
-      _ => ()
+        Some(x) => {
+            bcx = expr::trans_into(bcx, x, dest);
+        }
+        _ => ()
     }
     cleanup_and_leave(bcx, None, Some(bcx.fcx.get_llreturn()));
     Unreachable(bcx);

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -697,8 +697,7 @@ fn trans_rvalue_dps_unadjusted(bcx: @mut Block, expr: @ast::expr,
                    expr_to_str(expr, tcx.sess.intr()),
                    expr_ty.repr(tcx));
             return closure::trans_expr_fn(bcx, sigil, decl, body,
-                                          expr.id, expr.id,
-                                          None, dest);
+                                          expr.id, expr.id, dest);
         }
         ast::expr_do_body(blk) => {
             return trans_into(bcx, blk, dest);

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -427,7 +427,7 @@ fn visit_expr(expr: @ast::expr, (rcx, v): (@mut Rcx, rvt)) {
         }
 
         ast::expr_fn_block(*) => {
-            check_expr_fn_block(rcx, expr, v, false);
+            check_expr_fn_block(rcx, expr, v);
         }
 
         ast::expr_loop(ref body, _) => {
@@ -454,8 +454,7 @@ fn visit_expr(expr: @ast::expr, (rcx, v): (@mut Rcx, rvt)) {
 
 fn check_expr_fn_block(rcx: @mut Rcx,
                        expr: @ast::expr,
-                       v: rvt,
-                       is_loop_body: bool) {
+                       v: rvt) {
     let tcx = rcx.fcx.tcx();
     match expr.node {
         ast::expr_fn_block(_, ref body) => {
@@ -464,7 +463,7 @@ fn check_expr_fn_block(rcx: @mut Rcx,
                 ty::ty_closure(
                     ty::ClosureTy {
                         sigil: ast::BorrowedSigil, region: region, _}) => {
-                    if get_freevars(tcx, expr.id).is_empty() && !is_loop_body {
+                    if get_freevars(tcx, expr.id).is_empty() {
                         // No free variables means that the environment
                         // will be NULL at runtime and hence the closure
                         // has static lifetime.


### PR DESCRIPTION
I missed some of this in e7bb33aed889aebae1b141cdcc2aeeebab1724ee. Hopefully it's all gone now :).
