### PR TITLE
rustc: Give a hint when a static method call has fewer than expected typ...

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3208,10 +3208,19 @@ pub fn instantiate_path(fcx: @mut FnCtxt,
                   ty_param_count, ty_substs_len));
         fcx.infcx().next_ty_vars(ty_param_count)
     } else if ty_substs_len < ty_param_count {
+        let is_static_method = match fcx.ccx.tcx.def_map.find(&node_id) {
+            Some(&ast::def_static_method(*)) => true,
+            _ => false
+        };
         fcx.ccx.tcx.sess.span_err
             (span,
              fmt!("not enough type parameters provided: expected %u, found %u",
                   ty_param_count, ty_substs_len));
+        if is_static_method {
+            fcx.ccx.tcx.sess.span_note
+                (span, "Static methods have an extra implicit type parameter -- \
+                 did you omit the type parameter for the `Self` type?");
+        }
         fcx.infcx().next_ty_vars(ty_param_count)
     } else {
         pth.types.map(|aty| fcx.to_ty(aty))

--- a/src/test/compile-fail/issue-4096.rs
+++ b/src/test/compile-fail/issue-4096.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Nummy {
+    fn from_inty<T>() -> Self;
+}
+
+impl Nummy for float {
+    fn from_inty<T>() -> float { 0.0 }
+}
+
+fn main() {
+    let _1:float = Nummy::from_inty::<int>();  //~ ERROR not enough type
+    //~^ NOTE Static methods have an extra implicit type parameter
+}


### PR DESCRIPTION
r? @msullivan ...e parameters

In this case, it's likely to be that the user forgot the `self` type, so
say so.

Closes #4096
