### PR TITLE
rustc: Eliminate a derived error in check::_match

### DIFF
--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -698,6 +698,17 @@ impl InferCtxt {
         }
     }
 
+    // [Note-Type-error-reporting]
+    // An invariant is that anytime the expected or actual type is ty_err (the special
+    // error type, meaning that an error occurred when typechecking this expression),
+    // this is a derived error. The error cascaded from another error (that was already
+    // reported), so it's not useful to display it to the user.
+    // The following four methods -- type_error_message_str, type_error_message_str_with_expected,
+    // type_error_message, and report_mismatched_types -- implement this logic.
+    // They check if either the actual or expected type is ty_err, and don't print the error
+    // in this case. The typechecker should only ever report type errors involving mismatched
+    // types using one of these four methods, and should not call span_err directly for such
+    // errors.
     pub fn type_error_message_str(@mut self,
                                   sp: span,
                                   mk_msg: &fn(Option<~str>, ~str) -> ~str,

--- a/src/test/compile-fail/pattern-error-continue.rs
+++ b/src/test/compile-fail/pattern-error-continue.rs
@@ -29,7 +29,8 @@ fn main() {
         _ => ()
     }
     match 'c' {
-        S { _ } => (),   //~ ERROR mismatched types: expected `char` but found struct
+        S { _ } => (),   //~ ERROR mismatched types: expected `char` but found a structure pattern
+
         _ => ()
     }
     f(true);            //~ ERROR mismatched types: expected `char` but found `bool`

--- a/src/test/compile-fail/struct-pat-derived-error.rs
+++ b/src/test/compile-fail/struct-pat-derived-error.rs
@@ -1,0 +1,26 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct a {
+    b: uint,
+    c: uint
+}
+
+impl a {
+    fn foo(&self) {
+        let a { x, y } = self.d; //~ ERROR attempted access of field `d`
+        //~^ ERROR struct `a` does not have a field named `x`
+        //~^^ ERROR struct `a` does not have a field named `y`
+        //~^^^ ERROR pattern does not mention field `b`
+        //~^^^^ ERROR pattern does not mention field `c`
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
r? @graydon or @bblum, whoever gets there first
