### PR TITLE
std: Re-optimize tls access on local allocation path

### DIFF
--- a/src/libstd/rt/local.rs
+++ b/src/libstd/rt/local.rs
@@ -45,11 +45,7 @@ impl Local for Task {
     }
     unsafe fn unsafe_borrow() -> *mut Task { local_ptr::unsafe_borrow() }
     unsafe fn try_unsafe_borrow() -> Option<*mut Task> {
-        if Local::exists::<Task>() {
-            Some(Local::unsafe_borrow())
-        } else {
-            None
-        }
+        local_ptr::try_unsafe_borrow()
     }
 }
 


### PR DESCRIPTION
I did this once but acciddentally undid it in a later patch.
