### PR TITLE
Visitor trait rewrite, step 1.

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -39,7 +39,8 @@ use syntax::attr;
 use syntax::attr::AttrMetaMethods;
 use syntax::diagnostic::span_handler;
 use syntax::parse::token::special_idents;
-use syntax::{ast_util, oldvisit};
+use syntax::ast_util;
+use syntax::visit;
 use syntax::parse::token;
 use syntax;
 use writer = extra::ebml::writer;
@@ -1184,6 +1185,74 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
     ebml_w.end_tag();
 }
 
+fn my_visit_expr(_e:@expr) { }
+
+fn my_visit_item(i:@item, items: ast_map::map, ebml_w:&writer::Encoder,
+                 ecx_ptr:*int, index: @mut ~[entry<i64>]) {
+    match items.get_copy(&i.id) {
+        ast_map::node_item(_, pt) => {
+            let mut ebml_w = ebml_w.clone();
+            // See above
+            let ecx : &EncodeContext = unsafe { cast::transmute(ecx_ptr) };
+            encode_info_for_item(ecx, &mut ebml_w, i, index, *pt);
+        }
+        _ => fail!("bad item")
+    }
+}
+
+fn my_visit_foreign_item(ni:@foreign_item, items: ast_map::map, ebml_w:&writer::Encoder,
+                         ecx_ptr:*int, index: @mut ~[entry<i64>]) {
+    match items.get_copy(&ni.id) {
+        ast_map::node_foreign_item(_, abi, _, pt) => {
+            debug!("writing foreign item %s::%s",
+                   ast_map::path_to_str(
+                       *pt,
+                       token::get_ident_interner()),
+                   token::ident_to_str(&ni.ident));
+
+            let mut ebml_w = ebml_w.clone();
+            // See above
+            let ecx : &EncodeContext = unsafe { cast::transmute(ecx_ptr) };
+            encode_info_for_foreign_item(ecx,
+                                         &mut ebml_w,
+                                         ni,
+                                         index,
+                                         pt,
+                                         abi);
+        }
+        // case for separate item and foreign-item tables
+        _ => fail!("bad foreign item")
+    }
+}
+
+struct EncodeVisitor {
+    ebml_w_for_visit_item: writer::Encoder,
+    ebml_w_for_visit_foreign_item: writer::Encoder,
+    ecx_ptr:*int,
+    items: ast_map::map,
+    index: @mut ~[entry<i64>],
+}
+
+impl visit::Visitor<()> for EncodeVisitor {
+    fn visit_expr(&mut self, ex:@expr, _:()) { my_visit_expr(ex); }
+    fn visit_item(&mut self, i:@item, _:()) {
+        visit::walk_item(self, i, ());
+        my_visit_item(i,
+                      self.items,
+                      &self.ebml_w_for_visit_item,
+                      self.ecx_ptr,
+                      self.index);
+    }
+    fn visit_foreign_item(&mut self, ni:@foreign_item, _:()) {
+        visit::walk_foreign_item(self, ni, ());
+        my_visit_foreign_item(ni,
+                              self.items,
+                              &self.ebml_w_for_visit_foreign_item,
+                              self.ecx_ptr,
+                              self.index);
+    }
+}
+
 fn encode_info_for_items(ecx: &EncodeContext,
                          ebml_w: &mut writer::Encoder,
                          crate: &Crate)
@@ -1201,54 +1270,17 @@ fn encode_info_for_items(ecx: &EncodeContext,
     let items = ecx.tcx.items;
 
     // See comment in `encode_side_tables_for_ii` in astencode
-    let ecx_ptr : *() = unsafe { cast::transmute(ecx) };
+    let ecx_ptr : *int = unsafe { cast::transmute(ecx) };
+    let mut visitor = EncodeVisitor {
+        index: index,
+        items: items,
+        ecx_ptr: ecx_ptr,
+        ebml_w_for_visit_item: (*ebml_w).clone(),
+        ebml_w_for_visit_foreign_item: (*ebml_w).clone(),
+    };
 
-    oldvisit::visit_crate(crate, ((), oldvisit::mk_vt(@oldvisit::Visitor {
-        visit_expr: |_e, (_cx, _v)| { },
-        visit_item: {
-            let ebml_w = (*ebml_w).clone();
-            |i, (cx, v)| {
-                oldvisit::visit_item(i, (cx, v));
-                match items.get_copy(&i.id) {
-                    ast_map::node_item(_, pt) => {
-                        let mut ebml_w = ebml_w.clone();
-                        // See above
-                        let ecx : &EncodeContext = unsafe { cast::transmute(ecx_ptr) };
-                        encode_info_for_item(ecx, &mut ebml_w, i, index, *pt);
-                    }
-                    _ => fail!("bad item")
-                }
-            }
-        },
-        visit_foreign_item: {
-            let ebml_w = (*ebml_w).clone();
-            |ni, (cx, v)| {
-                oldvisit::visit_foreign_item(ni, (cx, v));
-                match items.get_copy(&ni.id) {
-                    ast_map::node_foreign_item(_, abi, _, pt) => {
-                        debug!("writing foreign item %s::%s",
-                               ast_map::path_to_str(
-                                *pt,
-                                token::get_ident_interner()),
-                                token::ident_to_str(&ni.ident));
+    visit::walk_crate(&mut visitor, crate, ());
 
-                        let mut ebml_w = ebml_w.clone();
-                        // See above
-                        let ecx : &EncodeContext = unsafe { cast::transmute(ecx_ptr) };
-                        encode_info_for_foreign_item(ecx,
-                                                     &mut ebml_w,
-                                                     ni,
-                                                     index,
-                                                     pt,
-                                                     abi);
-                    }
-                    // case for separate item and foreign-item tables
-                    _ => fail!("bad foreign item")
-                }
-            }
-        },
-        ..*oldvisit::default_visitor()
-    })));
     ebml_w.end_tag();
     return /*bad*/(*index).clone();
 }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -480,6 +480,7 @@ impl Context {
                             (orig.visit_item)(it, (self, stopping));
                         }
                         NewVisitor(new_visitor) => {
+                            let mut new_visitor = new_visitor;
                             new_visitor.visit_item(it, ());
                         }
                     }
@@ -492,7 +493,8 @@ impl Context {
                             oldvisit::visit_crate(c, (self, stopping))
                         }
                         NewVisitor(new_visitor) => {
-                            visit::visit_crate(new_visitor, c, ())
+                            let mut new_visitor = new_visitor;
+                            visit::walk_crate(&mut new_visitor, c, ())
                         }
                     }
                 }
@@ -518,6 +520,7 @@ impl Context {
                             let fk = visit::fk_method(m.ident,
                                                       &m.generics,
                                                       m);
+                            let mut new_visitor = new_visitor;
                             new_visitor.visit_fn(&fk,
                                                  &m.decl,
                                                  &m.body,

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -522,7 +522,7 @@ struct NewNameFinderContext {
 }
 
 impl Visitor<()> for NewNameFinderContext {
-    fn visit_pat(@mut self, pattern: @ast::pat, _: ()) {
+    fn visit_pat(&mut self, pattern: @ast::pat, _: ()) {
         match *pattern {
             // we found a pat_ident!
             ast::pat {
@@ -548,74 +548,74 @@ impl Visitor<()> for NewNameFinderContext {
                 }
             }
             // use the default traversal for non-pat_idents
-            _ => visit::visit_pat(self as @mut Visitor<()>, pattern, ())
+            _ => visit::walk_pat(self, pattern, ())
         }
     }
 
     // XXX: Methods below can become default methods.
 
-    fn visit_mod(@mut self, module: &ast::_mod, _: span, _: NodeId, _: ()) {
-        visit::visit_mod(self as @mut Visitor<()>, module, ())
+    fn visit_mod(&mut self, module: &ast::_mod, _: span, _: NodeId, _: ()) {
+        visit::walk_mod(self, module, ())
     }
 
-    fn visit_view_item(@mut self, view_item: &ast::view_item, _: ()) {
-        visit::visit_view_item(self as @mut Visitor<()>, view_item, ())
+    fn visit_view_item(&mut self, view_item: &ast::view_item, _: ()) {
+        visit::walk_view_item(self, view_item, ())
     }
 
-    fn visit_item(@mut self, item: @ast::item, _: ()) {
-        visit::visit_item(self as @mut Visitor<()>, item, ())
+    fn visit_item(&mut self, item: @ast::item, _: ()) {
+        visit::walk_item(self, item, ())
     }
 
-    fn visit_foreign_item(@mut self,
+    fn visit_foreign_item(&mut self,
                           foreign_item: @ast::foreign_item,
                           _: ()) {
-        visit::visit_foreign_item(self as @mut Visitor<()>, foreign_item, ())
+        visit::walk_foreign_item(self, foreign_item, ())
     }
 
-    fn visit_local(@mut self, local: @ast::Local, _: ()) {
-        visit::visit_local(self as @mut Visitor<()>, local, ())
+    fn visit_local(&mut self, local: @ast::Local, _: ()) {
+        visit::walk_local(self, local, ())
     }
 
-    fn visit_block(@mut self, block: &ast::Block, _: ()) {
-        visit::visit_block(self as @mut Visitor<()>, block, ())
+    fn visit_block(&mut self, block: &ast::Block, _: ()) {
+        visit::walk_block(self, block, ())
     }
 
-    fn visit_stmt(@mut self, stmt: @ast::stmt, _: ()) {
-        visit::visit_stmt(self as @mut Visitor<()>, stmt, ())
+    fn visit_stmt(&mut self, stmt: @ast::stmt, _: ()) {
+        visit::walk_stmt(self, stmt, ())
     }
 
-    fn visit_arm(@mut self, arm: &ast::arm, _: ()) {
-        visit::visit_arm(self as @mut Visitor<()>, arm, ())
+    fn visit_arm(&mut self, arm: &ast::arm, _: ()) {
+        visit::walk_arm(self, arm, ())
     }
 
-    fn visit_decl(@mut self, decl: @ast::decl, _: ()) {
-        visit::visit_decl(self as @mut Visitor<()>, decl, ())
+    fn visit_decl(&mut self, decl: @ast::decl, _: ()) {
+        visit::walk_decl(self, decl, ())
     }
 
-    fn visit_expr(@mut self, expr: @ast::expr, _: ()) {
-        visit::visit_expr(self as @mut Visitor<()>, expr, ())
+    fn visit_expr(&mut self, expr: @ast::expr, _: ()) {
+        visit::walk_expr(self, expr, ())
     }
 
-    fn visit_expr_post(@mut self, _: @ast::expr, _: ()) {
+    fn visit_expr_post(&mut self, _: @ast::expr, _: ()) {
         // Empty!
     }
 
-    fn visit_ty(@mut self, typ: &ast::Ty, _: ()) {
-        visit::visit_ty(self as @mut Visitor<()>, typ, ())
+    fn visit_ty(&mut self, typ: &ast::Ty, _: ()) {
+        visit::walk_ty(self, typ, ())
     }
 
-    fn visit_generics(@mut self, generics: &ast::Generics, _: ()) {
-        visit::visit_generics(self as @mut Visitor<()>, generics, ())
+    fn visit_generics(&mut self, generics: &ast::Generics, _: ()) {
+        visit::walk_generics(self, generics, ())
     }
 
-    fn visit_fn(@mut self,
+    fn visit_fn(&mut self,
                 function_kind: &visit::fn_kind,
                 function_declaration: &ast::fn_decl,
                 block: &ast::Block,
                 span: span,
                 node_id: NodeId,
                 _: ()) {
-        visit::visit_fn(self as @mut Visitor<()>,
+        visit::walk_fn(self,
                         function_kind,
                         function_declaration,
                         block,
@@ -624,23 +624,23 @@ impl Visitor<()> for NewNameFinderContext {
                         ())
     }
 
-    fn visit_ty_method(@mut self, ty_method: &ast::TypeMethod, _: ()) {
-        visit::visit_ty_method(self as @mut Visitor<()>, ty_method, ())
+    fn visit_ty_method(&mut self, ty_method: &ast::TypeMethod, _: ()) {
+        visit::walk_ty_method(self, ty_method, ())
     }
 
-    fn visit_trait_method(@mut self,
+    fn visit_trait_method(&mut self,
                           trait_method: &ast::trait_method,
                           _: ()) {
-        visit::visit_trait_method(self as @mut Visitor<()>, trait_method, ())
+        visit::walk_trait_method(self, trait_method, ())
     }
 
-    fn visit_struct_def(@mut self,
+    fn visit_struct_def(&mut self,
                         struct_def: @ast::struct_def,
                         ident: ident,
                         generics: &ast::Generics,
                         node_id: NodeId,
                         _: ()) {
-        visit::visit_struct_def(self as @mut Visitor<()>,
+        visit::walk_struct_def(self,
                                 struct_def,
                                 ident,
                                 generics,
@@ -648,10 +648,10 @@ impl Visitor<()> for NewNameFinderContext {
                                 ())
     }
 
-    fn visit_struct_field(@mut self,
+    fn visit_struct_field(&mut self,
                           struct_field: @ast::struct_field,
                           _: ()) {
-        visit::visit_struct_field(self as @mut Visitor<()>, struct_field, ())
+        visit::walk_struct_field(self, struct_field, ())
     }
 }
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -66,33 +66,97 @@ pub fn generics_of_fn(fk: &fn_kind) -> Generics {
     }
 }
 
-pub trait Visitor<E> {
-    fn visit_mod(@mut self, &_mod, span, NodeId, E);
-    fn visit_view_item(@mut self, &view_item, E);
-    fn visit_foreign_item(@mut self, @foreign_item, E);
-    fn visit_item(@mut self, @item, E);
-    fn visit_local(@mut self, @Local, E);
-    fn visit_block(@mut self, &Block, E);
-    fn visit_stmt(@mut self, @stmt, E);
-    fn visit_arm(@mut self, &arm, E);
-    fn visit_pat(@mut self, @pat, E);
-    fn visit_decl(@mut self, @decl, E);
-    fn visit_expr(@mut self, @expr, E);
-    fn visit_expr_post(@mut self, @expr, E);
-    fn visit_ty(@mut self, &Ty, E);
-    fn visit_generics(@mut self, &Generics, E);
-    fn visit_fn(@mut self, &fn_kind, &fn_decl, &Block, span, NodeId, E);
-    fn visit_ty_method(@mut self, &TypeMethod, E);
-    fn visit_trait_method(@mut self, &trait_method, E);
-    fn visit_struct_def(@mut self, @struct_def, ident, &Generics, NodeId, E);
-    fn visit_struct_field(@mut self, @struct_field, E);
+pub trait Visitor<E:Clone> {
+    fn visit_mod(&mut self, m:&_mod, _s:span, _n:NodeId, e:E) { walk_mod(self, m, e) }
+    fn visit_view_item(&mut self, i:&view_item, e:E) { walk_view_item(self, i, e) }
+    fn visit_foreign_item(&mut self, i:@foreign_item, e:E) { walk_foreign_item(self, i, e) }
+    fn visit_item(&mut self, i:@item, e:E) { walk_item(self, i, e) }
+    fn visit_local(&mut self, l:@Local, e:E) { walk_local(self, l, e) }
+    fn visit_block(&mut self, b:&Block, e:E) { walk_block(self, b, e) }
+    fn visit_stmt(&mut self, s:@stmt, e:E) { walk_stmt(self, s, e) }
+    fn visit_arm(&mut self, a:&arm, e:E) { walk_arm(self, a, e) }
+    fn visit_pat(&mut self, p:@pat, e:E) { walk_pat(self, p, e) }
+    fn visit_decl(&mut self, d:@decl, e:E) { walk_decl(self, d, e) }
+    fn visit_expr(&mut self, ex:@expr, e:E) { walk_expr(self, ex, e) }
+    fn visit_expr_post(&mut self, _ex:@expr, _e:E) { }
+    fn visit_ty(&mut self, _t:&Ty, _e:E) { }
+    fn visit_generics(&mut self, g:&Generics, e:E) { walk_generics(self, g, e) }
+    fn visit_fn(&mut self, fk:&fn_kind, fd:&fn_decl, b:&Block, s:span, n:NodeId, e:E) {
+        walk_fn(self, fk, fd, b, s, n , e)
+    }
+    fn visit_ty_method(&mut self, t:&TypeMethod, e:E) { walk_ty_method(self, t, e) }
+    fn visit_trait_method(&mut self, t:&trait_method, e:E) { walk_trait_method(self, t, e) }
+    fn visit_struct_def(&mut self, s:@struct_def, i:ident, g:&Generics, n:NodeId, e:E) {
+        walk_struct_def(self, s, i, g, n, e)
+    }
+    fn visit_struct_field(&mut self, s:@struct_field, e:E) { walk_struct_field(self, s, e) }
 }
 
-pub fn visit_crate<E:Clone>(visitor: @mut Visitor<E>, crate: &Crate, env: E) {
+impl<E:Clone> Visitor<E> for @mut Visitor<E> {
+    fn visit_mod(&mut self, a:&_mod, b:span, c:NodeId, e:E) {
+        (*self).visit_mod(a, b, c, e)
+    }
+    fn visit_view_item(&mut self, a:&view_item, e:E) {
+        (*self).visit_view_item(a, e)
+    }
+    fn visit_foreign_item(&mut self, a:@foreign_item, e:E) {
+        (*self).visit_foreign_item(a, e)
+    }
+    fn visit_item(&mut self, a:@item, e:E) {
+        (*self).visit_item(a, e)
+    }
+    fn visit_local(&mut self, a:@Local, e:E) {
+        (*self).visit_local(a, e)
+    }
+    fn visit_block(&mut self, a:&Block, e:E) {
+        (*self).visit_block(a, e)
+    }
+    fn visit_stmt(&mut self, a:@stmt, e:E) {
+        (*self).visit_stmt(a, e)
+    }
+    fn visit_arm(&mut self, a:&arm, e:E) {
+        (*self).visit_arm(a, e)
+    }
+    fn visit_pat(&mut self, a:@pat, e:E) {
+        (*self).visit_pat(a, e)
+    }
+    fn visit_decl(&mut self, a:@decl, e:E) {
+        (*self).visit_decl(a, e)
+    }
+    fn visit_expr(&mut self, a:@expr, e:E) {
+        (*self).visit_expr(a, e)
+    }
+    fn visit_expr_post(&mut self, a:@expr, e:E) {
+        (*self).visit_expr_post(a, e)
+    }
+    fn visit_ty(&mut self, a:&Ty, e:E) {
+        (*self).visit_ty(a, e)
+    }
+    fn visit_generics(&mut self, a:&Generics, e:E) {
+        (*self).visit_generics(a, e)
+    }
+    fn visit_fn(&mut self, a:&fn_kind, b:&fn_decl, c:&Block, d:span, f:NodeId, e:E) {
+        (*self).visit_fn(a, b, c, d, f, e)
+    }
+    fn visit_ty_method(&mut self, a:&TypeMethod, e:E) {
+        (*self).visit_ty_method(a, e)
+    }
+    fn visit_trait_method(&mut self, a:&trait_method, e:E) {
+        (*self).visit_trait_method(a, e)
+    }
+    fn visit_struct_def(&mut self, a:@struct_def, b:ident, c:&Generics, d:NodeId, e:E) {
+        (*self).visit_struct_def(a, b, c, d, e)
+    }
+    fn visit_struct_field(&mut self, a:@struct_field, e:E) {
+        (*self).visit_struct_field(a, e)
+    }
+}
+
+pub fn walk_crate<E:Clone, V:Visitor<E>>(visitor: &mut V, crate: &Crate, env: E) {
     visitor.visit_mod(&crate.module, crate.span, CRATE_NODE_ID, env)
 }
 
-pub fn visit_mod<E:Clone>(visitor: @mut Visitor<E>, module: &_mod, env: E) {
+pub fn walk_mod<E:Clone, V:Visitor<E>>(visitor: &mut V, module: &_mod, env: E) {
     for view_item in module.view_items.iter() {
         visitor.visit_view_item(view_item, env.clone())
     }
@@ -101,11 +165,11 @@ pub fn visit_mod<E:Clone>(visitor: @mut Visitor<E>, module: &_mod, env: E) {
     }
 }
 
-pub fn visit_view_item<E:Clone>(_: @mut Visitor<E>, _: &view_item, _: E) {
+pub fn walk_view_item<E:Clone, V:Visitor<E>>(_: &mut V, _: &view_item, _: E) {
     // Empty!
 }
 
-pub fn visit_local<E:Clone>(visitor: @mut Visitor<E>, local: &Local, env: E) {
+pub fn walk_local<E:Clone, V:Visitor<E>>(visitor: &mut V, local: &Local, env: E) {
     visitor.visit_pat(local.pat, env.clone());
     visitor.visit_ty(&local.ty, env.clone());
     match local.init {
@@ -114,13 +178,13 @@ pub fn visit_local<E:Clone>(visitor: @mut Visitor<E>, local: &Local, env: E) {
     }
 }
 
-fn visit_trait_ref<E:Clone>(visitor: @mut Visitor<E>,
+fn walk_trait_ref<E:Clone, V:Visitor<E>>(visitor: &mut V,
                             trait_ref: &ast::trait_ref,
                             env: E) {
-    visit_path(visitor, &trait_ref.path, env)
+    walk_path(visitor, &trait_ref.path, env)
 }
 
-pub fn visit_item<E:Clone>(visitor: @mut Visitor<E>, item: &item, env: E) {
+pub fn walk_item<E:Clone, V:Visitor<E>>(visitor: &mut V, item: &item, env: E) {
     match item.node {
         item_static(ref typ, _, expr) => {
             visitor.visit_ty(typ, env.clone());
@@ -151,7 +215,7 @@ pub fn visit_item<E:Clone>(visitor: @mut Visitor<E>, item: &item, env: E) {
         }
         item_enum(ref enum_definition, ref type_parameters) => {
             visitor.visit_generics(type_parameters, env.clone());
-            visit_enum_def(visitor, enum_definition, type_parameters, env)
+            walk_enum_def(visitor, enum_definition, type_parameters, env)
         }
         item_impl(ref type_parameters,
                   ref trait_references,
@@ -159,11 +223,11 @@ pub fn visit_item<E:Clone>(visitor: @mut Visitor<E>, item: &item, env: E) {
                   ref methods) => {
             visitor.visit_generics(type_parameters, env.clone());
             for trait_reference in trait_references.iter() {
-                visit_trait_ref(visitor, trait_reference, env.clone())
+                walk_trait_ref(visitor, trait_reference, env.clone())
             }
             visitor.visit_ty(typ, env.clone());
             for method in methods.iter() {
-                visit_method_helper(visitor, *method, env.clone())
+                walk_method_helper(visitor, *method, env.clone())
             }
         }
         item_struct(struct_definition, ref generics) => {
@@ -177,17 +241,17 @@ pub fn visit_item<E:Clone>(visitor: @mut Visitor<E>, item: &item, env: E) {
         item_trait(ref generics, ref trait_paths, ref methods) => {
             visitor.visit_generics(generics, env.clone());
             for trait_path in trait_paths.iter() {
-                visit_path(visitor, &trait_path.path, env.clone())
+                walk_path(visitor, &trait_path.path, env.clone())
             }
             for method in methods.iter() {
                 visitor.visit_trait_method(method, env.clone())
             }
         }
-        item_mac(ref macro) => visit_mac(visitor, macro, env),
+        item_mac(ref macro) => walk_mac(visitor, macro, env),
     }
 }
 
-pub fn visit_enum_def<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_enum_def<E:Clone, V:Visitor<E>>(visitor: &mut V,
                                enum_definition: &ast::enum_def,
                                generics: &Generics,
                                env: E) {
@@ -209,11 +273,11 @@ pub fn visit_enum_def<E:Clone>(visitor: @mut Visitor<E>,
     }
 }
 
-pub fn skip_ty<E>(_: @mut Visitor<E>, _: &Ty, _: E) {
+pub fn skip_ty<E, V:Visitor<E>>(_: &mut V, _: &Ty, _: E) {
     // Empty!
 }
 
-pub fn visit_ty<E:Clone>(visitor: @mut Visitor<E>, typ: &Ty, env: E) {
+pub fn walk_ty<E:Clone, V:Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
     match typ.node {
         ty_box(ref mutable_type) | ty_uniq(ref mutable_type) |
         ty_vec(ref mutable_type) | ty_ptr(ref mutable_type) |
@@ -231,7 +295,7 @@ pub fn visit_ty<E:Clone>(visitor: @mut Visitor<E>, typ: &Ty, env: E) {
              }
              visitor.visit_ty(&function_declaration.decl.output, env.clone());
              for bounds in function_declaration.bounds.iter() {
-                visit_ty_param_bounds(visitor, bounds, env.clone())
+                walk_ty_param_bounds(visitor, bounds, env.clone())
              }
         }
         ty_bare_fn(ref function_declaration) => {
@@ -241,9 +305,9 @@ pub fn visit_ty<E:Clone>(visitor: @mut Visitor<E>, typ: &Ty, env: E) {
             visitor.visit_ty(&function_declaration.decl.output, env.clone())
         }
         ty_path(ref path, ref bounds, _) => {
-            visit_path(visitor, path, env.clone());
+            walk_path(visitor, path, env.clone());
             for bounds in bounds.iter() {
-                visit_ty_param_bounds(visitor, bounds, env.clone())
+                walk_ty_param_bounds(visitor, bounds, env.clone())
             }
         }
         ty_fixed_length_vec(ref mutable_type, expression) => {
@@ -254,16 +318,16 @@ pub fn visit_ty<E:Clone>(visitor: @mut Visitor<E>, typ: &Ty, env: E) {
     }
 }
 
-pub fn visit_path<E:Clone>(visitor: @mut Visitor<E>, path: &Path, env: E) {
+pub fn walk_path<E:Clone, V:Visitor<E>>(visitor: &mut V, path: &Path, env: E) {
     for typ in path.types.iter() {
         visitor.visit_ty(typ, env.clone())
     }
 }
 
-pub fn visit_pat<E:Clone>(visitor: @mut Visitor<E>, pattern: &pat, env: E) {
+pub fn walk_pat<E:Clone, V:Visitor<E>>(visitor: &mut V, pattern: &pat, env: E) {
     match pattern.node {
         pat_enum(ref path, ref children) => {
-            visit_path(visitor, path, env.clone());
+            walk_path(visitor, path, env.clone());
             for children in children.iter() {
                 for child in children.iter() {
                     visitor.visit_pat(*child, env.clone())
@@ -271,7 +335,7 @@ pub fn visit_pat<E:Clone>(visitor: @mut Visitor<E>, pattern: &pat, env: E) {
             }
         }
         pat_struct(ref path, ref fields, _) => {
-            visit_path(visitor, path, env.clone());
+            walk_path(visitor, path, env.clone());
             for field in fields.iter() {
                 visitor.visit_pat(field.pat, env.clone())
             }
@@ -287,7 +351,7 @@ pub fn visit_pat<E:Clone>(visitor: @mut Visitor<E>, pattern: &pat, env: E) {
             visitor.visit_pat(subpattern, env)
         }
         pat_ident(_, ref path, ref optional_subpattern) => {
-            visit_path(visitor, path, env.clone());
+            walk_path(visitor, path, env.clone());
             match *optional_subpattern {
                 None => {}
                 Some(subpattern) => visitor.visit_pat(subpattern, env),
@@ -313,40 +377,40 @@ pub fn visit_pat<E:Clone>(visitor: @mut Visitor<E>, pattern: &pat, env: E) {
     }
 }
 
-pub fn visit_foreign_item<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_foreign_item<E:Clone, V:Visitor<E>>(visitor: &mut V,
                                    foreign_item: &foreign_item,
                                    env: E) {
     match foreign_item.node {
         foreign_item_fn(ref function_declaration, ref generics) => {
-            visit_fn_decl(visitor, function_declaration, env.clone());
+            walk_fn_decl(visitor, function_declaration, env.clone());
             visitor.visit_generics(generics, env)
         }
         foreign_item_static(ref typ, _) => visitor.visit_ty(typ, env),
     }
 }
 
-pub fn visit_ty_param_bounds<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_ty_param_bounds<E:Clone, V:Visitor<E>>(visitor: &mut V,
                                       bounds: &OptVec<TyParamBound>,
                                       env: E) {
     for bound in bounds.iter() {
         match *bound {
             TraitTyParamBound(ref typ) => {
-                visit_trait_ref(visitor, typ, env.clone())
+                walk_trait_ref(visitor, typ, env.clone())
             }
             RegionTyParamBound => {}
         }
     }
 }
 
-pub fn visit_generics<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_generics<E:Clone, V:Visitor<E>>(visitor: &mut V,
                                generics: &Generics,
                                env: E) {
     for type_parameter in generics.ty_params.iter() {
-        visit_ty_param_bounds(visitor, &type_parameter.bounds, env.clone())
+        walk_ty_param_bounds(visitor, &type_parameter.bounds, env.clone())
     }
 }
 
-pub fn visit_fn_decl<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_fn_decl<E:Clone, V:Visitor<E>>(visitor: &mut V,
                               function_declaration: &fn_decl,
                               env: E) {
     for argument in function_declaration.inputs.iter() {
@@ -360,7 +424,7 @@ pub fn visit_fn_decl<E:Clone>(visitor: @mut Visitor<E>,
 // visit_fn() and check for fk_method().  I named this visit_method_helper()
 // because it is not a default impl of any method, though I doubt that really
 // clarifies anything. - Niko
-pub fn visit_method_helper<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_method_helper<E:Clone, V:Visitor<E>>(visitor: &mut V,
                                     method: &method,
                                     env: E) {
     visitor.visit_fn(&fk_method(method.ident, &method.generics, method),
@@ -371,20 +435,20 @@ pub fn visit_method_helper<E:Clone>(visitor: @mut Visitor<E>,
                      env)
 }
 
-pub fn visit_fn<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_fn<E:Clone, V:Visitor<E>>(visitor: &mut V,
                          function_kind: &fn_kind,
                          function_declaration: &fn_decl,
                          function_body: &Block,
                          _: span,
                          _: NodeId,
                          env: E) {
-    visit_fn_decl(visitor, function_declaration, env.clone());
+    walk_fn_decl(visitor, function_declaration, env.clone());
     let generics = generics_of_fn(function_kind);
     visitor.visit_generics(&generics, env.clone());
     visitor.visit_block(function_body, env)
 }
 
-pub fn visit_ty_method<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_ty_method<E:Clone, V:Visitor<E>>(visitor: &mut V,
                                 method_type: &TypeMethod,
                                 env: E) {
     for argument_type in method_type.decl.inputs.iter() {
@@ -394,18 +458,18 @@ pub fn visit_ty_method<E:Clone>(visitor: @mut Visitor<E>,
     visitor.visit_ty(&method_type.decl.output, env.clone())
 }
 
-pub fn visit_trait_method<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_trait_method<E:Clone, V:Visitor<E>>(visitor: &mut V,
                                    trait_method: &trait_method,
                                    env: E) {
     match *trait_method {
         required(ref method_type) => {
             visitor.visit_ty_method(method_type, env)
         }
-        provided(method) => visit_method_helper(visitor, method, env),
+        provided(method) => walk_method_helper(visitor, method, env),
     }
 }
 
-pub fn visit_struct_def<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_struct_def<E:Clone, V:Visitor<E>>(visitor: &mut V,
                                  struct_definition: @struct_def,
                                  _: ast::ident,
                                  _: &Generics,
@@ -416,40 +480,40 @@ pub fn visit_struct_def<E:Clone>(visitor: @mut Visitor<E>,
     }
 }
 
-pub fn visit_struct_field<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_struct_field<E:Clone, V:Visitor<E>>(visitor: &mut V,
                                    struct_field: &struct_field,
                                    env: E) {
     visitor.visit_ty(&struct_field.node.ty, env)
 }
 
-pub fn visit_block<E:Clone>(visitor: @mut Visitor<E>, block: &Block, env: E) {
+pub fn walk_block<E:Clone, V:Visitor<E>>(visitor: &mut V, block: &Block, env: E) {
     for view_item in block.view_items.iter() {
         visitor.visit_view_item(view_item, env.clone())
     }
     for statement in block.stmts.iter() {
         visitor.visit_stmt(*statement, env.clone())
     }
-    visit_expr_opt(visitor, block.expr, env)
+    walk_expr_opt(visitor, block.expr, env)
 }
 
-pub fn visit_stmt<E>(visitor: @mut Visitor<E>, statement: &stmt, env: E) {
+pub fn walk_stmt<E:Clone, V:Visitor<E>>(visitor: &mut V, statement: &stmt, env: E) {
     match statement.node {
         stmt_decl(declaration, _) => visitor.visit_decl(declaration, env),
         stmt_expr(expression, _) | stmt_semi(expression, _) => {
             visitor.visit_expr(expression, env)
         }
-        stmt_mac(ref macro, _) => visit_mac(visitor, macro, env),
+        stmt_mac(ref macro, _) => walk_mac(visitor, macro, env),
     }
 }
 
-pub fn visit_decl<E:Clone>(visitor: @mut Visitor<E>, declaration: &decl, env: E) {
+pub fn walk_decl<E:Clone, V:Visitor<E>>(visitor: &mut V, declaration: &decl, env: E) {
     match declaration.node {
         decl_local(ref local) => visitor.visit_local(*local, env),
         decl_item(item) => visitor.visit_item(item, env),
     }
 }
 
-pub fn visit_expr_opt<E>(visitor: @mut Visitor<E>,
+pub fn walk_expr_opt<E:Clone, V:Visitor<E>>(visitor: &mut V,
                          optional_expression: Option<@expr>,
                          env: E) {
     match optional_expression {
@@ -458,7 +522,7 @@ pub fn visit_expr_opt<E>(visitor: @mut Visitor<E>,
     }
 }
 
-pub fn visit_exprs<E:Clone>(visitor: @mut Visitor<E>,
+pub fn walk_exprs<E:Clone, V:Visitor<E>>(visitor: &mut V,
                             expressions: &[@expr],
                             env: E) {
     for expression in expressions.iter() {
@@ -466,28 +530,28 @@ pub fn visit_exprs<E:Clone>(visitor: @mut Visitor<E>,
     }
 }
 
-pub fn visit_mac<E>(_: @mut Visitor<E>, _: &mac, _: E) {
+pub fn walk_mac<E, V:Visitor<E>>(_: &mut V, _: &mac, _: E) {
     // Empty!
 }
 
-pub fn visit_expr<E:Clone>(visitor: @mut Visitor<E>, expression: @expr, env: E) {
+pub fn walk_expr<E:Clone, V:Visitor<E>>(visitor: &mut V, expression: @expr, env: E) {
     match expression.node {
         expr_vstore(subexpression, _) => {
             visitor.visit_expr(subexpression, env.clone())
         }
         expr_vec(ref subexpressions, _) => {
-            visit_exprs(visitor, *subexpressions, env.clone())
+            walk_exprs(visitor, *subexpressions, env.clone())
         }
         expr_repeat(element, count, _) => {
             visitor.visit_expr(element, env.clone());
             visitor.visit_expr(count, env.clone())
         }
         expr_struct(ref path, ref fields, optional_base) => {
-            visit_path(visitor, path, env.clone());
+            walk_path(visitor, path, env.clone());
             for field in fields.iter() {
                 visitor.visit_expr(field.expr, env.clone())
             }
-            visit_expr_opt(visitor, optional_base, env.clone())
+            walk_expr_opt(visitor, optional_base, env.clone())
         }
         expr_tup(ref subexpressions) => {
             for subexpression in subexpressions.iter() {
@@ -501,7 +565,7 @@ pub fn visit_expr<E:Clone>(visitor: @mut Visitor<E>, expression: @expr, env: E) 
             visitor.visit_expr(callee_expression, env.clone())
         }
         expr_method_call(_, callee, _, ref types, ref arguments, _) => {
-            visit_exprs(visitor, *arguments, env.clone());
+            walk_exprs(visitor, *arguments, env.clone());
             for typ in types.iter() {
                 visitor.visit_ty(typ, env.clone())
             }
@@ -524,7 +588,7 @@ pub fn visit_expr<E:Clone>(visitor: @mut Visitor<E>, expression: @expr, env: E) 
         expr_if(head_expression, ref if_block, optional_else) => {
             visitor.visit_expr(head_expression, env.clone());
             visitor.visit_block(if_block, env.clone());
-            visit_expr_opt(visitor, optional_else, env.clone())
+            walk_expr_opt(visitor, optional_else, env.clone())
         }
         expr_while(subexpression, ref block) => {
             visitor.visit_expr(subexpression, env.clone());
@@ -569,16 +633,16 @@ pub fn visit_expr<E:Clone>(visitor: @mut Visitor<E>, expression: @expr, env: E) 
             visitor.visit_expr(main_expression, env.clone());
             visitor.visit_expr(index_expression, env.clone())
         }
-        expr_path(ref path) => visit_path(visitor, path, env.clone()),
+        expr_path(ref path) => walk_path(visitor, path, env.clone()),
         expr_self | expr_break(_) | expr_again(_) => {}
         expr_ret(optional_expression) => {
-            visit_expr_opt(visitor, optional_expression, env.clone())
+            walk_expr_opt(visitor, optional_expression, env.clone())
         }
         expr_log(level, subexpression) => {
             visitor.visit_expr(level, env.clone());
             visitor.visit_expr(subexpression, env.clone());
         }
-        expr_mac(ref macro) => visit_mac(visitor, macro, env.clone()),
+        expr_mac(ref macro) => walk_mac(visitor, macro, env.clone()),
         expr_paren(subexpression) => {
             visitor.visit_expr(subexpression, env.clone())
         }
@@ -595,11 +659,11 @@ pub fn visit_expr<E:Clone>(visitor: @mut Visitor<E>, expression: @expr, env: E) 
     visitor.visit_expr_post(expression, env.clone())
 }
 
-pub fn visit_arm<E:Clone>(visitor: @mut Visitor<E>, arm: &arm, env: E) {
+pub fn walk_arm<E:Clone, V:Visitor<E>>(visitor: &mut V, arm: &arm, env: E) {
     for pattern in arm.pats.iter() {
         visitor.visit_pat(*pattern, env.clone())
     }
-    visit_expr_opt(visitor, arm.guard, env.clone());
+    walk_expr_opt(visitor, arm.guard, env.clone());
     visitor.visit_block(&arm.body, env)
 }
 
@@ -607,26 +671,26 @@ pub fn visit_arm<E:Clone>(visitor: @mut Visitor<E>, arm: &arm, env: E) {
 // calls the given functions on the nodes.
 
 pub trait SimpleVisitor {
-    fn visit_mod(@mut self, &_mod, span, NodeId);
-    fn visit_view_item(@mut self, &view_item);
-    fn visit_foreign_item(@mut self, @foreign_item);
-    fn visit_item(@mut self, @item);
-    fn visit_local(@mut self, @Local);
-    fn visit_block(@mut self, &Block);
-    fn visit_stmt(@mut self, @stmt);
-    fn visit_arm(@mut self, &arm);
-    fn visit_pat(@mut self, @pat);
-    fn visit_decl(@mut self, @decl);
-    fn visit_expr(@mut self, @expr);
-    fn visit_expr_post(@mut self, @expr);
-    fn visit_ty(@mut self, &Ty);
-    fn visit_generics(@mut self, &Generics);
-    fn visit_fn(@mut self, &fn_kind, &fn_decl, &Block, span, NodeId);
-    fn visit_ty_method(@mut self, &TypeMethod);
-    fn visit_trait_method(@mut self, &trait_method);
-    fn visit_struct_def(@mut self, @struct_def, ident, &Generics, NodeId);
-    fn visit_struct_field(@mut self, @struct_field);
-    fn visit_struct_method(@mut self, @method);
+    fn visit_mod(&mut self, &_mod, span, NodeId);
+    fn visit_view_item(&mut self, &view_item);
+    fn visit_foreign_item(&mut self, @foreign_item);
+    fn visit_item(&mut self, @item);
+    fn visit_local(&mut self, @Local);
+    fn visit_block(&mut self, &Block);
+    fn visit_stmt(&mut self, @stmt);
+    fn visit_arm(&mut self, &arm);
+    fn visit_pat(&mut self, @pat);
+    fn visit_decl(&mut self, @decl);
+    fn visit_expr(&mut self, @expr);
+    fn visit_expr_post(&mut self, @expr);
+    fn visit_ty(&mut self, &Ty);
+    fn visit_generics(&mut self, &Generics);
+    fn visit_fn(&mut self, &fn_kind, &fn_decl, &Block, span, NodeId);
+    fn visit_ty_method(&mut self, &TypeMethod);
+    fn visit_trait_method(&mut self, &trait_method);
+    fn visit_struct_def(&mut self, @struct_def, ident, &Generics, NodeId);
+    fn visit_struct_field(&mut self, @struct_field);
+    fn visit_struct_method(&mut self, @method);
 }
 
 pub struct SimpleVisitorVisitor {
@@ -634,66 +698,66 @@ pub struct SimpleVisitorVisitor {
 }
 
 impl Visitor<()> for SimpleVisitorVisitor {
-    fn visit_mod(@mut self,
+    fn visit_mod(&mut self,
                  module: &_mod,
                  span: span,
                  node_id: NodeId,
                  env: ()) {
         self.simple_visitor.visit_mod(module, span, node_id);
-        visit_mod(self as @mut Visitor<()>, module, env)
+        walk_mod(self, module, env)
     }
-    fn visit_view_item(@mut self, view_item: &view_item, env: ()) {
+    fn visit_view_item(&mut self, view_item: &view_item, env: ()) {
         self.simple_visitor.visit_view_item(view_item);
-        visit_view_item(self as @mut Visitor<()>, view_item, env)
+        walk_view_item(self, view_item, env)
     }
-    fn visit_foreign_item(@mut self, foreign_item: @foreign_item, env: ()) {
+    fn visit_foreign_item(&mut self, foreign_item: @foreign_item, env: ()) {
         self.simple_visitor.visit_foreign_item(foreign_item);
-        visit_foreign_item(self as @mut Visitor<()>, foreign_item, env)
+        walk_foreign_item(self, foreign_item, env)
     }
-    fn visit_item(@mut self, item: @item, env: ()) {
+    fn visit_item(&mut self, item: @item, env: ()) {
         self.simple_visitor.visit_item(item);
-        visit_item(self as @mut Visitor<()>, item, env)
+        walk_item(self, item, env)
     }
-    fn visit_local(@mut self, local: @Local, env: ()) {
+    fn visit_local(&mut self, local: @Local, env: ()) {
         self.simple_visitor.visit_local(local);
-        visit_local(self as @mut Visitor<()>, local, env)
+        walk_local(self, local, env)
     }
-    fn visit_block(@mut self, block: &Block, env: ()) {
+    fn visit_block(&mut self, block: &Block, env: ()) {
         self.simple_visitor.visit_block(block);
-        visit_block(self as @mut Visitor<()>, block, env)
+        walk_block(self, block, env)
     }
-    fn visit_stmt(@mut self, statement: @stmt, env: ()) {
+    fn visit_stmt(&mut self, statement: @stmt, env: ()) {
         self.simple_visitor.visit_stmt(statement);
-        visit_stmt(self as @mut Visitor<()>, statement, env)
+        walk_stmt(self, statement, env)
     }
-    fn visit_arm(@mut self, arm: &arm, env: ()) {
+    fn visit_arm(&mut self, arm: &arm, env: ()) {
         self.simple_visitor.visit_arm(arm);
-        visit_arm(self as @mut Visitor<()>, arm, env)
+        walk_arm(self, arm, env)
     }
-    fn visit_pat(@mut self, pattern: @pat, env: ()) {
+    fn visit_pat(&mut self, pattern: @pat, env: ()) {
         self.simple_visitor.visit_pat(pattern);
-        visit_pat(self as @mut Visitor<()>, pattern, env)
+        walk_pat(self, pattern, env)
     }
-    fn visit_decl(@mut self, declaration: @decl, env: ()) {
+    fn visit_decl(&mut self, declaration: @decl, env: ()) {
         self.simple_visitor.visit_decl(declaration);
-        visit_decl(self as @mut Visitor<()>, declaration, env)
+        walk_decl(self, declaration, env)
     }
-    fn visit_expr(@mut self, expression: @expr, env: ()) {
+    fn visit_expr(&mut self, expression: @expr, env: ()) {
         self.simple_visitor.visit_expr(expression);
-        visit_expr(self as @mut Visitor<()>, expression, env)
+        walk_expr(self, expression, env)
     }
-    fn visit_expr_post(@mut self, expression: @expr, _: ()) {
+    fn visit_expr_post(&mut self, expression: @expr, _: ()) {
         self.simple_visitor.visit_expr_post(expression)
     }
-    fn visit_ty(@mut self, typ: &Ty, env: ()) {
+    fn visit_ty(&mut self, typ: &Ty, env: ()) {
         self.simple_visitor.visit_ty(typ);
-        visit_ty(self as @mut Visitor<()>, typ, env)
+        walk_ty(self, typ, env)
     }
-    fn visit_generics(@mut self, generics: &Generics, env: ()) {
+    fn visit_generics(&mut self, generics: &Generics, env: ()) {
         self.simple_visitor.visit_generics(generics);
-        visit_generics(self as @mut Visitor<()>, generics, env)
+        walk_generics(self, generics, env)
     }
-    fn visit_fn(@mut self,
+    fn visit_fn(&mut self,
                 function_kind: &fn_kind,
                 function_declaration: &fn_decl,
                 block: &Block,
@@ -705,7 +769,7 @@ impl Visitor<()> for SimpleVisitorVisitor {
                                      block,
                                      span,
                                      node_id);
-        visit_fn(self as @mut Visitor<()>,
+        walk_fn(self,
                  function_kind,
                  function_declaration,
                  block,
@@ -713,15 +777,15 @@ impl Visitor<()> for SimpleVisitorVisitor {
                  node_id,
                  env)
     }
-    fn visit_ty_method(@mut self, method_type: &TypeMethod, env: ()) {
+    fn visit_ty_method(&mut self, method_type: &TypeMethod, env: ()) {
         self.simple_visitor.visit_ty_method(method_type);
-        visit_ty_method(self as @mut Visitor<()>, method_type, env)
+        walk_ty_method(self, method_type, env)
     }
-    fn visit_trait_method(@mut self, trait_method: &trait_method, env: ()) {
+    fn visit_trait_method(&mut self, trait_method: &trait_method, env: ()) {
         self.simple_visitor.visit_trait_method(trait_method);
-        visit_trait_method(self as @mut Visitor<()>, trait_method, env)
+        walk_trait_method(self, trait_method, env)
     }
-    fn visit_struct_def(@mut self,
+    fn visit_struct_def(&mut self,
                         struct_definition: @struct_def,
                         identifier: ident,
                         generics: &Generics,
@@ -731,16 +795,16 @@ impl Visitor<()> for SimpleVisitorVisitor {
                                              identifier,
                                              generics,
                                              node_id);
-        visit_struct_def(self as @mut Visitor<()>,
+        walk_struct_def(self,
                          struct_definition,
                          identifier,
                          generics,
                          node_id,
                          env)
     }
-    fn visit_struct_field(@mut self, struct_field: @struct_field, env: ()) {
+    fn visit_struct_field(&mut self, struct_field: @struct_field, env: ()) {
         self.simple_visitor.visit_struct_field(struct_field);
-        visit_struct_field(self as @mut Visitor<()>, struct_field, env)
+        walk_struct_field(self, struct_field, env)
     }
 }
 


### PR DESCRIPTION
Rewriting visit.rs to operate on a borrowed `&mut V` where `<V:Visitor>`

r? @nikomatsakis
r? @pcwalton

This is the first in a planned series of incremental pull requests.  (There will probably be five pull requests including this one, though they can be combined or split as necessary.)

Part of #7081.  (But definitely does _not_ complete it, not on its own, and not even after all five parts land; there are still a few loose ends to tie up or trim afterwards.)

The bulk of this change for this particular PR is pnkfelix@3d83010, which has the changes necessary to visit.rs to support everything else that comes later.  The other commits are illustrating the standard mechanical transformation that I am applying.

One important point for nearly _all_ of these pull requests: I was deliberately _not_ trying to be intelligent in the transformation. 
- My goal was to minimize code churn, and make the transformation as mechanical as possible.  
- For example, I kept the separation between the Visitor struct (corresponding to the earlier vtable of functions that were potentially closed over local state) and the explicitly passed (and clones) visitor Env.  I am certain that this is almost always unnecessary, and a later task will be to go through an meld the Env's into the Visitors as appropriate.  (My original goal had been to make such melding part of this task; that's why I turned them into a (Env, vtable) tuple way back when.  But I digress.)
- Also, my main goal here was to get rid of the record of `@fn`'s as described by the oldvisit.rs API.  (This series gets rid of all but one such case; I'm still investigating that.)  There is _still_ plenty of `@`-boxing left to be removed, I'm sure, and even still some `@fn`'s too; removing all of those is not the goal here; its just to get rid of the encoded protocol of `@fn`'s in the (old)visit API.

To see where things will be going in the future (i.e., to get a sneak-preview of future pull-requests in the series), see:
- https://github.com/pnkfelix/rust/commits/fsk-visitor-vpar-defaults-step1 (that's this one)
- https://github.com/pnkfelix/rust/commits/fsk-visitor-vpar-defaults-step2
- https://github.com/pnkfelix/rust/commits/fsk-visitor-vpar-defaults-step3
- https://github.com/pnkfelix/rust/commits/fsk-visitor-vpar-defaults-step4
- https://github.com/pnkfelix/rust/commits/fsk-visitor-vpar-defaults-step5
  - Note that between step 4 and step 5 there is just a single commit, but its a doozy because its the only case where my mechanical transformation did not apply, and thus more serious rewriting was necessary.  See commit pnkfelix@da902b2ff3b1e0bee9fc63cf00c449cceea8abf7
