### PR TITLE
rustc: Change ICE message to reflect that ::rt::backtrace doesn't exist

### DIFF
--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -359,7 +359,7 @@ pub fn monitor(f: ~fn(diagnostic::Emitter)) {
                 let xs = [
                     ~"the compiler hit an unexpected failure path. \
                      this is a bug",
-                    ~"try running with RUST_LOG=rustc=1,::rt::backtrace \
+                    ~"try running with RUST_LOG=rustc=1 \
                      to get further details and report the results \
                      to github.com/mozilla/rust/issues"
                 ];


### PR DESCRIPTION
The new scheduler didn't preserve this behavior.
