### PR TITLE
syntax: add a local_data_key macro that creates a key for access to the TLS.

### DIFF
--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -24,8 +24,8 @@ wish to store.
 ~~~{.rust}
 use std::local_data;
 
-static key_int: local_data::Key<int> = &local_data::Key;
-static key_vector: local_data::Key<~[int]> = &local_data::Key;
+local_data_key!(key_int: int);
+local_data_key!(key_vector: ~[int]);
 
 local_data::set(key_int, 3);
 local_data::get(key_int, |opt| assert_eq!(opt, Some(&3)));

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -957,6 +957,17 @@ pub fn std_macros() -> @str {
             println(fmt!($($arg),+))
         )
     )
+
+    // NOTE: use this after a snapshot lands to abstract the details
+    // of the TLS interface.
+    macro_rules! local_data_key (
+        ($name:ident: $ty:ty) => (
+            static $name: ::std::local_data::Key<$ty> = &::std::local_data::Key;
+        );
+        (pub $name:ident: $ty:ty) => (
+            pub static $name: ::std::local_data::Key<$ty> = &::std::local_data::Key;
+        )
+    )
 }";
 }
 

--- a/src/test/compile-fail/macro-local-data-key-priv.rs
+++ b/src/test/compile-fail/macro-local-data-key-priv.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Testing that we can't store a borrowed pointer it task-local storage
-
 use std::local_data;
 
-local_data_key!(key: @&int)
-//~^ ERROR only 'static is allowed
+// check that the local data keys are private by default.
 
-fn main() {}
+mod bar {
+    local_data_key!(baz: float)
+}
+
+fn main() {
+    local_data::set(bar::baz, -10.0);
+    //~^ ERROR unresolved name `bar::baz`
+}

--- a/src/test/run-pass/macro-local-data-key.rs
+++ b/src/test/run-pass/macro-local-data-key.rs
@@ -1,0 +1,28 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::local_data;
+
+local_data_key!(foo: int)
+
+mod bar {
+    local_data_key!(pub baz: float)
+}
+
+fn main() {
+    local_data::get(foo, |x| assert!(x.is_none()));
+    local_data::get(bar::baz, |y| assert!(y.is_none()));
+
+    local_data::set(foo, 3);
+    local_data::set(bar::baz, -10.0);
+
+    local_data::get(foo, |x| assert_eq!(*x.unwrap(), 3));
+    local_data::get(bar::baz, |y| assert_eq!(*y.unwrap(), -10.0));
+}


### PR DESCRIPTION
This allows the internal implementation details of the TLS keys to be
changed without requiring the update of all the users. (Or, applying
changes that _have_ to be applied for the keys to work correctly, e.g.
forcing LLVM to not merge these constants.)
