### PR TITLE
Pointers to bound variables are stored after all patterns are matched.

### DIFF
--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1294,7 +1294,6 @@ fn store_non_ref_bindings(bcx: @mut Block,
 
 fn insert_lllocals(bcx: @mut Block,
                    bindings_map: &BindingsMap,
-                   binding_mode: IrrefutablePatternBindingMode,
                    add_cleans: bool) -> @mut Block {
     /*!
      * For each binding in `data.bindings_map`, adds an appropriate entry into
@@ -1302,10 +1301,7 @@ fn insert_lllocals(bcx: @mut Block,
      * the bindings.
      */
 
-    let llmap = match binding_mode {
-        BindLocal => bcx.fcx.lllocals,
-        BindArgument => bcx.fcx.llargs
-    };
+    let llmap = bcx.fcx.lllocals;
 
     for (&ident, &binding_info) in bindings_map.iter() {
         let llval = match binding_info.trmode {
@@ -1358,7 +1354,7 @@ fn compile_guard(bcx: @mut Block,
     bcx = store_non_ref_bindings(bcx,
                                  data.bindings_map,
                                  Some(&mut temp_cleanups));
-    bcx = insert_lllocals(bcx, data.bindings_map, BindLocal, false);
+    bcx = insert_lllocals(bcx, data.bindings_map, false);
 
     let val = unpack_result!(bcx, {
         do with_scope_result(bcx, guard_expr.info(),
@@ -1875,7 +1871,7 @@ fn trans_match_inner(scope_cx: @mut Block,
         }
 
         // insert bindings into the lllocals map and add cleanups
-        bcx = insert_lllocals(bcx, arm_data.bindings_map, BindLocal, true);
+        bcx = insert_lllocals(bcx, arm_data.bindings_map, true);
 
         bcx = controlflow::trans_block(bcx, &arm_data.arm.body, dest);
         bcx = trans_block_cleanups(bcx, block_cleanups(arm_data.bodycx));

--- a/src/test/run-pass/match-pipe-binding.rs
+++ b/src/test/run-pass/match-pipe-binding.rs
@@ -1,0 +1,70 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-test
+
+fn test1() {
+    // from issue 6338
+    match ((1, ~"a"), (2, ~"b")) {
+        ((1, a), (2, b)) | ((2, b), (1, a)) => {
+                assert_eq!(a, ~"a");
+                assert_eq!(b, ~"b");
+            },
+            _ => fail!(),
+    }
+}
+
+fn test2() {
+    match (1, 2, 3) {
+        (1, a, b) | (2, b, a) => {
+            assert_eq!(a, 2);
+            assert_eq!(b, 3);
+        },
+        _ => fail!(),
+    }
+}
+
+fn test3() {
+    match (1, 2, 3) {
+        (1, ref a, ref b) | (2, ref b, ref a) => {
+            assert_eq!(*a, 2);
+            assert_eq!(*b, 3);
+        },
+        _ => fail!(),
+    }
+}
+
+fn test4() {
+    match (1, 2, 3) {
+        (1, a, b) | (2, b, a) if a == 2 => {
+            assert_eq!(a, 2);
+            assert_eq!(b, 3);
+        },
+        _ => fail!(),
+    }
+}
+
+fn test5() {
+    match (1, 2, 3) {
+        (1, ref a, ref b) | (2, ref b, ref a) if *a == 2 => {
+            assert_eq!(*a, 2);
+            assert_eq!(*b, 3);
+        },
+        _ => fail!(),
+    }
+}
+
+fn main() {
+    test1();
+    test2();
+    test3();
+    test4();
+    test5();
+}

--- a/src/test/run-pass/match-pipe-binding.rs
+++ b/src/test/run-pass/match-pipe-binding.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test
-
 fn test1() {
     // from issue 6338
     match ((1, ~"a"), (2, ~"b")) {


### PR DESCRIPTION
Pointers to bound variables shouldn't be stored before checking pattern,
otherwise piped patterns can conflict with each other (issue #6338).

Closes #6338.
