### PR TITLE
rustpkg: Un-ignore most of the remaining tests

### DIFF
--- a/src/librustpkg/context.rs
+++ b/src/librustpkg/context.rs
@@ -33,6 +33,17 @@ impl Ctx {
             Some(p) => p.to_str()
         }
     }
+
+    // Hack so that rustpkg can run either out of a rustc target dir,
+    // or the host dir
+    pub fn sysroot_to_use(&self) -> Option<@Path> {
+        if !in_target(self.sysroot_opt) {
+            self.sysroot_opt
+        }
+        else {
+            self.sysroot_opt.map(|p| { @p.pop().pop().pop() })
+        }
+    }
 }
 
 /// We assume that if ../../rustc exists, then we're running

--- a/src/librustpkg/package_source.rs
+++ b/src/librustpkg/package_source.rs
@@ -54,7 +54,7 @@ impl PkgSrc {
         debug!("Pushing onto root: %s | %s", self.id.path.to_str(), self.root.to_str());
 
         let dirs = pkgid_src_in_workspace(&self.id, &self.root);
-        debug!("Checking dirs: %?", dirs);
+        debug!("Checking dirs: %?", dirs.map(|s| s.to_str()).connect(":"));
         let path = dirs.iter().find(|&d| os::path_exists(d));
 
         let dir = match path {

--- a/src/librustpkg/testsuite/pass/src/fancy-lib/pkg.rs
+++ b/src/librustpkg/testsuite/pass/src/fancy-lib/pkg.rs
@@ -38,7 +38,7 @@ pub fn main() {
         return;
     }
 
-    let out_path = Path("build/fancy_lib");
+    let out_path = Path("build/fancy-lib");
     if !os::path_exists(&out_path) {
         assert!(os::make_dir(&out_path, (S_IRUSR | S_IWUSR | S_IXUSR) as i32));
     }


### PR DESCRIPTION
r? @brson This necessitated some cleanup to how we parse library filenames
when searching for libraries, since rustpkg may now create filenames
that contain '-' characters. Also cleaned up how rustpkg passes the
sysroot to a custom build script.
