### PR TITLE
A round of code cleaning for the primary scheduler code.

### DIFF
--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -360,7 +360,7 @@ impl Coroutine {
 
                 // Again - might work while safe, or it might not.
                 do Local::borrow::<Scheduler,()> |sched| {
-                    (sched).run_cleanup_job();
+                    sched.run_cleanup_job();
                 }
 
                 // To call the run method on a task we need a direct

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -38,8 +38,7 @@ pub fn default_sched_threads() -> uint {
 pub fn dumb_println(s: &str) {
     use io::WriterUtil;
     let dbg = ::libc::STDERR_FILENO as ::io::fd_t;
-    dbg.write_str(s);
-    dbg.write_str("\n");
+    dbg.write_str(s + "\n");
 }
 
 pub fn abort(msg: &str) -> ! {


### PR DESCRIPTION
Comments have been updated, a minor amount of support type restructing has happened, methods have been reordered, and some duplicate code has been purged. Nothing exciting to see, but a little bit of progress towards turning sched.rs into a reasonable file not the festering wound on the codebase it currently is.
