### PR TITLE
Better error message for unknown start of token

### DIFF
--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -782,7 +782,9 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
       c => {
           // So the error span points to the unrecognized character
           rdr.peek_span = codemap::mk_sp(rdr.last_pos, rdr.pos);
-          rdr.fatal(fmt!("unknown start of token: %d", c as int));
+          let mut cs = ~"";
+          char::escape_default(c, |c| cs.push_char(c));
+          rdr.fatal(fmt!("unknown start of token: %s", cs));
       }
     }
 }


### PR DESCRIPTION
The span was fixed at some point to point to the correct character, but
the error message is still bad. Update it to emit the actual character
in question (potentially escaped).

Fixes #3747.
