### PR TITLE
doc: correct spelling in documentation, convert remaining uses of `core` to `std`

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -582,7 +582,7 @@ a referencing source file, or by the name of the crate itself.
 
 Each source file contains a sequence of zero or more `item` definitions,
 and may optionally begin with any number of `attributes` that apply to the containing module.
-Atributes on the anonymous crate module define important metadata that influences
+Attributes on the anonymous crate module define important metadata that influences
 the behavior of the compiler.
 
 ~~~~~~~~
@@ -1273,7 +1273,7 @@ since the typechecker checks that any type with an implementation of `Circle` al
 
 In type-parameterized functions,
 methods of the supertrait may be called on values of subtrait-bound type parameters.
-Refering to the previous example of `trait Circle : Shape`:
+Referring to the previous example of `trait Circle : Shape`:
 
 ~~~
 # trait Shape { fn area(&self) -> float; }
@@ -1914,7 +1914,7 @@ A field access on a record is an [lvalue](#lvalues-rvalues-and-temporaries) refe
 When the field is mutable, it can be [assigned](#assignment-expressions) to.
 
 When the type of the expression to the left of the dot is a pointer to a record or structure,
-it is automatically derferenced to make the field access possible.
+it is automatically dereferenced to make the field access possible.
 
 
 ### Vector expressions

--- a/src/etc/cmathconsts.c
+++ b/src/etc/cmathconsts.c
@@ -13,7 +13,7 @@
 #include <math.h>
 #include <stdio.h>
 
-// must match core::ctypes
+// must match std::ctypes
 
 #define C_FLT(x) (float)x
 #define C_DBL(x) (double)x

--- a/src/etc/ziggurat_tables.py
+++ b/src/etc/ziggurat_tables.py
@@ -2,7 +2,7 @@
 # xfail-license
 
 # This creates the tables used for distributions implemented using the
-# ziggurat algorithm in `core::rand::distributions;`. They are
+# ziggurat algorithm in `std::rand::distributions;`. They are
 # (basically) the tables as used in the ZIGNOR variant (Doornik 2005).
 # They are changed rarely, so the generated file should be checked in
 # to git.

--- a/src/etc/zsh/_rust
+++ b/src/etc/zsh/_rust
@@ -36,7 +36,7 @@ _rustc_opts_lint=(
     'path-statement[path statements with no effect]'
     'missing-trait-doc[detects missing documentation for traits]'
     'missing-struct-doc[detects missing documentation for structs]'
-    'ctypes[proper use of core::libc types in foreign modules]'
+    'ctypes[proper use of std::libc types in foreign modules]'
     "unused-mut[detect mut variables which don't need to be mutable]"
     'unused-imports[imports that are never used]'
     'heap-memory[use of any (~ type or @ type) heap memory]'

--- a/src/libextra/crypto/cryptoutil.rs
+++ b/src/libextra/crypto/cryptoutil.rs
@@ -125,7 +125,7 @@ pub fn shift_add_check_overflow_tuple
 /// method that modifies the buffer directory or provides the caller with bytes that can be modifies
 /// results in those bytes being marked as used by the buffer.
 pub trait FixedBuffer {
-    /// Input a vector of bytes. If the buffer becomes full, proccess it with the provided
+    /// Input a vector of bytes. If the buffer becomes full, process it with the provided
     /// function and then clear the buffer.
     fn input(&mut self, input: &[u8], func: &fn(&[u8]));
 

--- a/src/libextra/crypto/digest.rs
+++ b/src/libextra/crypto/digest.rs
@@ -47,18 +47,18 @@ pub trait Digest {
     fn output_bits(&self) -> uint;
 
     /**
-     * Convenience functon that feeds a string into a digest
+     * Convenience function that feeds a string into a digest.
      *
      * # Arguments
      *
-     * * in The string to feed into the digest
+     * * `input` The string to feed into the digest
      */
     fn input_str(&mut self, input: &str) {
         self.input(input.as_bytes());
     }
 
     /**
-     * Convenience functon that retrieves the result of a digest as a
+     * Convenience function that retrieves the result of a digest as a
      * ~str in hexadecimal format.
      */
     fn result_str(&mut self) -> ~str {

--- a/src/libextra/enum_set.rs
+++ b/src/libextra/enum_set.rs
@@ -18,7 +18,7 @@ pub struct EnumSet<E> {
     priv bits: uint
 }
 
-/// An iterface for casting C-like enum to uint and back.
+/// An interface for casting C-like enum to uint and back.
 pub trait CLike {
     /// Converts C-like enum to uint.
     fn to_uint(&self) -> uint;

--- a/src/libextra/fileinput.rs
+++ b/src/libextra/fileinput.rs
@@ -156,7 +156,7 @@ impl FileInput {
     /**
     Create a `FileInput` object from a vec of files. An empty
     vec means lines are read from `stdin` (use `from_vec_raw` to stop
-    this behaviour). Any occurence of `None` represents `stdin`.
+    this behaviour). Any occurrence of `None` represents `stdin`.
     */
     pub fn from_vec(files: ~[Option<Path>]) -> FileInput {
         FileInput::from_vec_raw(

--- a/src/libextra/flatpipes.rs
+++ b/src/libextra/flatpipes.rs
@@ -166,7 +166,7 @@ Constructors for flat pipes that send POD types using memcpy.
 
 This module is currently unsafe because it uses `Clone + Send` as a type
 parameter bounds meaning POD (plain old data), but `Clone + Send` and
-POD are not equivelant.
+POD are not equivalent.
 
 */
 pub mod pod {

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -365,7 +365,7 @@ pub fn write_boxplot(w: @io::Writer, s: &Summary, width_hint: uint) {
     w.write_str(histr);
 }
 
-/// Returns a HashMap with the number of occurences of every element in the
+/// Returns a HashMap with the number of occurrences of every element in the
 /// sequence that the iterator exposes.
 pub fn freq_count<T: Iterator<U>, U: Eq+Hash>(mut iter: T) -> hashmap::HashMap<U, uint> {
     let mut map = hashmap::HashMap::new::<U, uint>();

--- a/src/libextra/term.rs
+++ b/src/libextra/term.rs
@@ -157,7 +157,7 @@ impl Terminal {
     /// If the color is a bright color, but the terminal only supports 8 colors,
     /// the corresponding normal color will be used instead.
     ///
-    /// Rturns true if the color was set, false otherwise.
+    /// Returns true if the color was set, false otherwise.
     pub fn bg(&self, color: color::Color) -> bool {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {

--- a/src/libstd/at_vec.rs
+++ b/src/libstd/at_vec.rs
@@ -200,7 +200,7 @@ pub mod raw {
      * Sets the length of a vector
      *
      * This will explicitly set the size of the vector, without actually
-     * modifing its buffers, so it is up to the caller to ensure that
+     * modifying its buffers, so it is up to the caller to ensure that
      * the vector is actually the specified size.
      */
     #[inline]

--- a/src/libstd/bool.rs
+++ b/src/libstd/bool.rs
@@ -33,7 +33,7 @@ and more.
 
 Also, a few conversion functions: `to_bit` and `to_str`.
 
-Finally, some inquries into the nature of truth: `is_true` and `is_false`.
+Finally, some inquiries into the nature of truth: `is_true` and `is_false`.
 
 */
 

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -147,7 +147,7 @@ helper methods.
 ## Internationalization
 
 The formatting syntax supported by the `ifmt!` extension supports
-internationalization by providing "methods" which execute various differnet
+internationalization by providing "methods" which execute various different
 outputs depending on the input. The syntax and methods provided are similar to
 other internationalization systems, so again nothing should seem alien.
 Currently two methods are supported by this extension: "select" and "plural".

--- a/src/libstd/fmt/parse.rs
+++ b/src/libstd/fmt/parse.rs
@@ -66,7 +66,7 @@ pub enum Position<'self> {
     ArgumentNext, ArgumentIs(uint), ArgumentNamed(&'self str)
 }
 
-/// Enum of alignments which are supoprted.
+/// Enum of alignments which are supported.
 #[deriving(Eq)]
 pub enum Alignment { AlignLeft, AlignRight, AlignUnknown }
 

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -1462,7 +1462,7 @@ pub trait WriterUtil {
     /// (8 bytes).
     fn write_le_f64(&self, f: f64);
 
-    /// Write a litten-endian IEEE754 single-precision floating-point
+    /// Write a little-endian IEEE754 single-precision floating-point
     /// (4 bytes).
     fn write_le_f32(&self, f: f32);
 

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -1029,9 +1029,9 @@ pub fn FILE_reader(f: *libc::FILE, cleanup: bool) -> @Reader {
 * # Example
 *
 * ~~~ {.rust}
-* let stdin = core::io::stdin();
+* let stdin = std::io::stdin();
 * let line = stdin.read_line();
-* core::io::print(line);
+* std::io::print(line);
 * ~~~
 */
 pub fn stdin() -> @Reader {
@@ -1598,7 +1598,7 @@ pub fn buffered_file_writer(path: &Path) -> Result<@Writer, ~str> {
 * # Example
 *
 * ~~~ {.rust}
-* let stdout = core::io::stdout();
+* let stdout = std::io::stdout();
 * stdout.write_str("hello\n");
 * ~~~
 */
@@ -1610,7 +1610,7 @@ pub fn stdout() -> @Writer { fd_writer(libc::STDOUT_FILENO as c_int, false) }
 * # Example
 *
 * ~~~ {.rust}
-* let stderr = core::io::stderr();
+* let stderr = std::io::stderr();
 * stderr.write_str("hello\n");
 * ~~~
 */

--- a/src/libstd/iterator.rs
+++ b/src/libstd/iterator.rs
@@ -511,7 +511,8 @@ pub trait Iterator<A> {
         i
     }
 
-    /// Return the element that gives the maximum value from the specfied function
+    /// Return the element that gives the maximum value from the
+    /// specified function.
     ///
     /// # Example
     ///
@@ -534,7 +535,8 @@ pub trait Iterator<A> {
         }).map_move(|(x, _)| x)
     }
 
-    /// Return the element that gives the minimum value from the specfied function
+    /// Return the element that gives the minimum value from the
+    /// specified function.
     ///
     /// # Example
     ///
@@ -1541,7 +1543,7 @@ pub struct Repeat<A> {
 }
 
 impl<A: Clone> Repeat<A> {
-    /// Create a new `Repeat` that enlessly repeats the element `elt`.
+    /// Create a new `Repeat` that endlessly repeats the element `elt`.
     #[inline]
     pub fn new(elt: A) -> Repeat<A> {
         Repeat{element: elt}

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -125,7 +125,7 @@ pub static neg_infinity: f32 = -1.0_f32/0.0_f32;
 pub mod consts {
     // FIXME (requires Issue #1433 to fix): replace with mathematical
     // staticants from cmath.
-    /// Archimedes' staticant
+    /// Archimedes' constant
     pub static pi: f32 = 3.14159265358979323846264338327950288_f32;
 
     /// pi/2.0

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -411,7 +411,7 @@ pub fn pipe() -> Pipe {
         // inheritance has to be handled in a different way that I do not
         // fully understand. Here we explicitly make the pipe non-inheritable,
         // which means to pass it to a subprocess they need to be duplicated
-        // first, as in core::run.
+        // first, as in std::run.
         let mut fds = Pipe {input: 0 as c_int,
                     out: 0 as c_int };
         let res = libc::pipe(&mut fds.input, 1024 as ::libc::c_uint,

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -254,7 +254,7 @@ pub unsafe fn array_each_with_len<T>(arr: **T, len: uint, cb: &fn(*T)) {
   passing to the provided callback function
 
   SAFETY NOTE: This will only work with a null-terminated
-  pointer array. Barely less-dodgey Pointer Arithmetic.
+  pointer array. Barely less-dodgy Pointer Arithmetic.
   Dragons be here.
 */
 pub unsafe fn array_each<T>(arr: **T, cb: &fn(*T)) {

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -658,7 +658,7 @@ pub fn rng() -> IsaacRng {
 
 /// Create a weak random number generator with a default algorithm and seed.
 ///
-/// It returns the fatest `Rng` algorithm currently available in Rust without
+/// It returns the fastest `Rng` algorithm currently available in Rust without
 /// consideration for cryptography or security. If you require a specifically
 /// seeded `Rng` for consistency over time you should pick one algorithm and
 /// create the `Rng` yourself.

--- a/src/libstd/rand/distributions.rs
+++ b/src/libstd/rand/distributions.rs
@@ -66,7 +66,7 @@ fn ziggurat<R:Rng>(rng: &mut R,
 /// # Example
 ///
 /// ~~~
-/// use core::rand::distributions::StandardNormal;
+/// use std::rand::distributions::StandardNormal;
 ///
 /// fn main() {
 ///     let normal = 2.0 + (*rand::random::<StandardNormal>()) * 3.0;
@@ -120,7 +120,7 @@ impl Rand for StandardNormal {
 /// # Example
 ///
 /// ~~~
-/// use core::rand::distributions::Exp1;
+/// use std::rand::distributions::Exp1;
 ///
 /// fn main() {
 ///     let exp2 = (*rand::random::<Exp1>()) * 0.5;

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -25,7 +25,7 @@ use str::StrSlice;
 
 /// `Result` is a type that represents either success (`Ok`) or failure (`Err`).
 ///
-/// In order to provide informative error messages, `E` is reqired to implement `ToStr`.
+/// In order to provide informative error messages, `E` is required to implement `ToStr`.
 /// It is further recommended for `E` to be a descriptive error type, eg a `enum` for
 /// all possible errors cases.
 #[deriving(Clone, Eq)]

--- a/src/libstd/rt/io/extensions.rs
+++ b/src/libstd/rt/io/extensions.rs
@@ -262,7 +262,7 @@ pub trait WriterByteConversions {
     /// (8 bytes).
     fn write_le_f64(&mut self, f: f64);
 
-    /// Write a litten-endian IEEE754 single-precision floating-point
+    /// Write a little-endian IEEE754 single-precision floating-point
     /// (4 bytes).
     fn write_le_f32(&mut self, f: f32);
 

--- a/src/libstd/rt/io/mod.rs
+++ b/src/libstd/rt/io/mod.rs
@@ -19,7 +19,7 @@ file, TCP, UDP, Unix domain sockets.
 Readers and Writers may be composed to add capabilities like string
 parsing, encoding, and compression.
 
-This will likely live in core::io, not core::rt::io.
+This will likely live in std::io, not std::rt::io.
 
 # Examples
 

--- a/src/libstd/rt/io/mod.rs
+++ b/src/libstd/rt/io/mod.rs
@@ -93,7 +93,7 @@ Asynchronous interfaces are most often associated with the callback
 (continuation-passing) style popularised by node.js. Such systems rely
 on all computations being run inside an event loop which maintains a
 list of all pending I/O events; when one completes the registered
-callback is run and the code that made the I/O request continiues.
+callback is run and the code that made the I/O request continues.
 Such interfaces achieve non-blocking at the expense of being more
 difficult to reason about.
 
@@ -136,7 +136,7 @@ Rust's I/O employs a combination of techniques to reduce boilerplate
 while still providing feedback about errors. The basic strategy:
 
 * Errors are fatal by default, resulting in task failure
-* Errors raise the `io_error` conditon which provides an opportunity to inspect
+* Errors raise the `io_error` condition which provides an opportunity to inspect
   an IoError object containing details.
 * Return values must have a sensible null or zero value which is returned
   if a condition is handled successfully. This may be an `Option`, an empty
@@ -189,7 +189,7 @@ will start passing around null or zero objects when wrapped in a condition handl
 * XXX: How should we use condition handlers that return values?
 * XXX: Should EOF raise default conditions when EOF is not an error?
 
-# Issues withi/o scheduler affinity, work stealing, task pinning
+# Issues with i/o scheduler affinity, work stealing, task pinning
 
 # Resource management
 

--- a/src/libstd/rt/io/mod.rs
+++ b/src/libstd/rt/io/mod.rs
@@ -430,7 +430,7 @@ pub trait Reader {
     ///         println(reader.read_line());
     ///     }
     ///
-    /// # Failue
+    /// # Failure
     ///
     /// Returns `true` on failure.
     fn eof(&mut self) -> bool;

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -40,17 +40,17 @@ out of `rt` as development proceeds.
 
 Several modules in `core` are clients of `rt`:
 
-* `core::task` - The user-facing interface to the Rust task model.
-* `core::task::local_data` - The interface to local data.
-* `core::gc` - The garbage collector.
-* `core::unstable::lang` - Miscellaneous lang items, some of which rely on `core::rt`.
-* `core::condition` - Uses local data.
-* `core::cleanup` - Local heap destruction.
-* `core::io` - In the future `core::io` will use an `rt` implementation.
-* `core::logging`
-* `core::pipes`
-* `core::comm`
-* `core::stackwalk`
+* `std::task` - The user-facing interface to the Rust task model.
+* `std::task::local_data` - The interface to local data.
+* `std::gc` - The garbage collector.
+* `std::unstable::lang` - Miscellaneous lang items, some of which rely on `std::rt`.
+* `std::condition` - Uses local data.
+* `std::cleanup` - Local heap destruction.
+* `std::io` - In the future `std::io` will use an `rt` implementation.
+* `std::logging`
+* `std::pipes`
+* `std::comm`
+* `std::stackwalk`
 
 */
 
@@ -139,7 +139,7 @@ pub mod rc;
 /// scheduler and task context
 pub mod tube;
 
-/// Simple reimplementation of core::comm
+/// Simple reimplementation of std::comm
 pub mod comm;
 
 mod select;

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -69,7 +69,7 @@ pub struct Coroutine {
     saved_context: Context
 }
 
-/// Some tasks have a deciated home scheduler that they must run on.
+/// Some tasks have a dedicated home scheduler that they must run on.
 pub enum SchedHome {
     AnySched,
     Sched(SchedHandle)
@@ -592,4 +592,3 @@ mod test {
         }
     }
 }
-

--- a/src/libstd/rt/uv/mod.rs
+++ b/src/libstd/rt/uv/mod.rs
@@ -10,7 +10,7 @@
 
 /*!
 
-Bindings to libuv, along with the default implementation of `core::rt::rtio`.
+Bindings to libuv, along with the default implementation of `std::rt::rtio`.
 
 UV types consist of the event loop (Loop), Watchers, Requests and
 Callbacks.

--- a/src/libstd/rt/uv/uvll.rs
+++ b/src/libstd/rt/uv/uvll.rs
@@ -23,7 +23,7 @@
  * There are also a collection of helper functions to ease interacting
  * with the low-level API.
  *
- * As new functionality, existant in uv.h, is added to the rust stdlib,
+ * As new functionality, existent in uv.h, is added to the rust stdlib,
  * the mappings should be added in this module.
  */
 

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -90,7 +90,7 @@ pub struct ProcessOptions<'self> {
     in_fd: Option<c_int>,
 
     /**
-     * If this is None then a new pipe will be created for the new progam's
+     * If this is None then a new pipe will be created for the new program's
      * output and Process.output() will provide a Reader to read from this pipe.
      *
      * If this is Some(file-descriptor) then the new process will write its output
@@ -100,7 +100,7 @@ pub struct ProcessOptions<'self> {
     out_fd: Option<c_int>,
 
     /**
-     * If this is None then a new pipe will be created for the new progam's
+     * If this is None then a new pipe will be created for the new program's
      * error stream and Process.error() will provide a Reader to read from this pipe.
      *
      * If this is Some(file-descriptor) then the new process will write its error output
@@ -840,7 +840,7 @@ pub fn process_output(prog: &str, args: &[~str]) -> ProcessOutput {
  * Note that this is private to avoid race conditions on unix where if
  * a user calls waitpid(some_process.get_id()) then some_process.finish()
  * and some_process.destroy() and some_process.finalize() will then either
- * operate on a none-existant process or, even worse, on a newer process
+ * operate on a none-existent process or, even worse, on a newer process
  * with the same id.
  */
 fn waitpid(pid: pid_t) -> int {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -382,7 +382,7 @@ impl<'self, Sep: CharEq> Iterator<&'self str> for CharSplitIterator<'self, Sep> 
     }
 }
 
-/// An iterator over the start and end indicies of the matches of a
+/// An iterator over the start and end indices of the matches of a
 /// substring within a larger string
 #[deriving(Clone)]
 pub struct MatchesIndexIterator<'self> {
@@ -893,7 +893,7 @@ pub mod raw {
     /// Sets the length of a string
     ///
     /// This will explicitly set the size of the string, without actually
-    /// modifing its buffers, so it is up to the caller to ensure that
+    /// modifying its buffers, so it is up to the caller to ensure that
     /// the string is actually the specified size.
     #[inline]
     pub unsafe fn set_len(s: &mut ~str, new_len: uint) {

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -365,7 +365,7 @@ impl TaskBuilder {
         spawn::spawn_raw(opts, f);
     }
 
-    /// Runs a task, while transfering ownership of one argument to the child.
+    /// Runs a task, while transferring ownership of one argument to the child.
     pub fn spawn_with<A:Send>(&mut self, arg: A, f: ~fn(v: A)) {
         let arg = Cell::new(arg);
         do self.spawn {
@@ -474,10 +474,10 @@ pub fn spawn_indestructible(f: ~fn()) {
 
 pub fn spawn_with<A:Send>(arg: A, f: ~fn(v: A)) {
     /*!
-     * Runs a task, while transfering ownership of one argument to the
+     * Runs a task, while transferring ownership of one argument to the
      * child.
      *
-     * This is useful for transfering ownership of noncopyables to
+     * This is useful for transferring ownership of noncopyables to
      * another task.
      *
      * This function is equivalent to `task().spawn_with(arg, f)`.

--- a/src/libstd/to_bytes.rs
+++ b/src/libstd/to_bytes.rs
@@ -28,7 +28,7 @@ pub type Cb<'self> = &'self fn(buf: &[u8]) -> bool;
  * A trait to implement in order to make a type hashable;
  * This works in combination with the trait `Hash::Hash`, and
  * may in the future be merged with that trait or otherwise
- * modified when default methods and trait inheritence are
+ * modified when default methods and trait inheritance are
  * completed.
  */
 pub trait IterBytes {

--- a/src/libstd/to_str.rs
+++ b/src/libstd/to_str.rs
@@ -31,7 +31,7 @@ pub trait ToStr {
 
 /// Trait for converting a type to a string, consuming it in the process.
 pub trait ToStrConsume {
-    /// Cosume and convert to a string.
+    /// Consume and convert to a string.
     fn into_str(self) -> ~str;
 }
 

--- a/src/libstd/unstable/atomics.rs
+++ b/src/libstd/unstable/atomics.rs
@@ -39,14 +39,14 @@ pub struct AtomicBool {
 }
 
 /**
- * A signed atomic integer type, supporting basic atomic aritmetic operations
+ * A signed atomic integer type, supporting basic atomic arithmetic operations
  */
 pub struct AtomicInt {
     priv v: int
 }
 
 /**
- * An unsigned atomic integer type, supporting basic atomic aritmetic operations
+ * An unsigned atomic integer type, supporting basic atomic arithmetic operations
  */
 pub struct AtomicUint {
     priv v: uint
@@ -497,7 +497,7 @@ pub unsafe fn atomic_xor<T>(dst: &mut T, val: T, order: Ordering) -> T {
  * A fence 'A' which has `Release` ordering semantics, synchronizes with a
  * fence 'B' with (at least) `Acquire` semantics, if and only if there exists
  * atomic operations X and Y, both operating on some atomic object 'M' such
- * that A is sequenced before X, Y is synchronized before B and Y obsevers
+ * that A is sequenced before X, Y is synchronized before B and Y observers
  * the change to M. This provides a happens-before dependence between A and B.
  *
  * Atomic operations with `Release` or `Acquire` semantics can also synchronize

--- a/src/libstd/unstable/finally.rs
+++ b/src/libstd/unstable/finally.rs
@@ -18,7 +18,7 @@ stack closures that emulates Java-style try/finally blocks.
 do || {
     ...
 }.finally {
-    alway_run_this();
+    always_run_this();
 }
 ~~~
 */

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -22,7 +22,7 @@ semantics as C++11. See the LLVM documentation on [[atomics]].
 
 A quick refresher on memory ordering:
 
-* Acquire - a barrier for aquiring a lock. Subsequent reads and writes
+* Acquire - a barrier for acquiring a lock. Subsequent reads and writes
   take place after the barrier.
 * Release - a barrier for releasing a lock. Preceding reads and writes
   take place before the barrier.

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -468,7 +468,7 @@ impl<'self, T> Iterator<&'self [T]> for WindowIter<'self, T> {
 /// elements at a time).
 ///
 /// When the vector len is not evenly divided by the chunk size,
-/// the last slice of the iteration will be the remainer.
+/// the last slice of the iteration will be the remainder.
 #[deriving(Clone)]
 pub struct ChunkIter<'self, T> {
     priv v: &'self [T],
@@ -1930,7 +1930,7 @@ pub mod raw {
      * Sets the length of a vector
      *
      * This will explicitly set the size of the vector, without actually
-     * modifing its buffers, so it is up to the caller to ensure that
+     * modifying its buffers, so it is up to the caller to ensure that
      * the vector is actually the specified size.
      */
     #[inline]

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -100,7 +100,7 @@ pub struct Lifetime {
 }
 
 // a "Path" is essentially Rust's notion of a name;
-// for instance: core::cmp::Eq  .  It's represented
+// for instance: std::cmp::Eq  .  It's represented
 // as a sequence of identifiers, along with a bunch
 // of supporting information.
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
@@ -1093,8 +1093,8 @@ pub enum inlined_item {
 /* hold off on tests ... they appear in a later merge.
 #[cfg(test)]
 mod test {
-    use core::option::{None, Option, Some};
-    use core::uint;
+    use std::option::{None, Option, Some};
+    use std::uint;
     use extra;
     use codemap::*;
     use super::*;

--- a/src/rt/rust_log.cpp
+++ b/src/rt/rust_log.cpp
@@ -31,7 +31,7 @@ const size_t default_log_level = log_err;
 
 // This is a rather ugly parser for strings in the form
 // "crate1,crate2.mod3,crate3.x=1". Log levels are 0-255,
-// with the most likely ones being 0-3 (defined in core::).
+// with the most likely ones being 0-3 (defined in std::).
 size_t parse_logging_spec(char* spec, log_directive* dirs) {
     size_t dir = 0;
     while (dir < max_log_directives && *spec) {

--- a/src/test/compile-fail/issue-5543.rs
+++ b/src/test/compile-fail/issue-5543.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 // xfail-test
-use core::io::ReaderUtil;
-use core::io::Reader;
+use std::io::ReaderUtil;
+use std::io::Reader;
 
 fn bar(r:@ReaderUtil) -> ~str { r.read_line() }
 


### PR DESCRIPTION
(This doesn't add/remove `u`s or change `ize` to `ise`, or anything like that.)
