### PR TITLE
debuginfo: Support for generic functions and self arguments

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -691,6 +691,14 @@ pub fn build_session_options(binary: @str,
     let extra_debuginfo = debugging_opts & session::extra_debug_info != 0;
     let debuginfo = debugging_opts & session::debug_info != 0 ||
         extra_debuginfo;
+
+    // If debugging info is generated, do not collapse monomorphized function instances.
+    // Functions with equivalent llvm code still need separate debugging descriptions because names
+    // might differ.
+    if debuginfo {
+        debugging_opts |= session::no_monomorphic_collapse;
+    }
+
     let statik = debugging_opts & session::statik != 0;
 
     let addl_lib_search_paths = getopts::opt_strs(matches, "L").map(|s| Path(*s));

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -2086,6 +2086,16 @@ pub mod llvm {
 
         #[fast_ffi]
         pub fn LLVMSetUnnamedAddr(GlobalVar: ValueRef, UnnamedAddr: Bool);
+
+        #[fast_ffi]
+        pub fn LLVMDIBuilderCreateTemplateTypeParameter(Builder: DIBuilderRef,
+                                                        Scope: ValueRef,
+                                                        Name: *c_char,
+                                                        Ty: ValueRef,
+                                                        File: ValueRef,
+                                                        LineNo: c_uint,
+                                                        ColumnNo: c_uint)
+                                                        -> ValueRef;
     }
 }
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1859,6 +1859,10 @@ pub fn trans_closure(ccx: @mut CrateContext,
         set_fixed_stack_segment(fcx.llfn);
     }
 
+    if ccx.sess.opts.debuginfo && fcx_has_nonzero_span(fcx) {
+        debuginfo::create_function_metadata(fcx);
+    }
+
     // Create the first basic block in the function and keep a handle on it to
     //  pass to finish_fn later.
     let bcx_top = fcx.entry_bcx.unwrap();
@@ -1929,12 +1933,7 @@ pub fn trans_fn(ccx: @mut CrateContext,
                   id,
                   attrs,
                   output_type,
-                  |fcx| {
-                      if ccx.sess.opts.debuginfo
-                          && fcx_has_nonzero_span(fcx) {
-                          debuginfo::create_function_metadata(fcx);
-                      }
-                  });
+                  |_fcx| { });
 }
 
 fn insert_synthetic_type_entries(bcx: @mut Block,

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -133,7 +133,7 @@ pub fn push_ctxt(s: &'static str) -> _InsnCtxt {
 
 fn fcx_has_nonzero_span(fcx: &FunctionContext) -> bool {
     match fcx.span {
-        None => true,
+        None => false,
         Some(span) => *span.lo != 0 || *span.hi != 0
     }
 }
@@ -1739,6 +1739,10 @@ pub fn copy_args_to_allocas(fcx: @mut FunctionContext,
 
             fcx.llself = Some(ValSelfData {v: self_val, ..slf});
             add_clean(bcx, self_val, slf.t);
+
+            if fcx.ccx.sess.opts.extra_debuginfo && fcx_has_nonzero_span(fcx) {
+                debuginfo::create_self_argument_metadata(bcx, slf.t, self_val);
+            }
         }
         _ => {}
     }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -256,9 +256,10 @@ pub fn create_argument_metadata(bcx: @mut Block,
     }
 }
 
-/// Sets the current debug location at the beginning of the span
+/// Sets the current debug location at the beginning of the span.
 ///
-/// Maps to a call to llvm::LLVMSetCurrentDebugLocation(...)
+/// Maps to a call to llvm::LLVMSetCurrentDebugLocation(...). The node_id parameter is used to
+/// reliably find the correct visibility scope for the code position.
 pub fn update_source_pos(fcx: &FunctionContext,
                          node_id: ast::NodeId,
                          span: span) {
@@ -357,6 +358,7 @@ pub fn create_function_metadata(fcx: &mut FunctionContext) -> DISubprogram {
         llvm::LLVMDIBuilderCreateSubroutineType(DIB(cx), file_metadata, fn_signature)
     };
 
+    // get_template_parameters() will append a `<...>` clause to the function name if necessary.
     let mut function_name = cx.sess.str_of(ident).to_owned();
     let template_parameters = get_template_parameters(fcx,
                                                       generics,
@@ -404,8 +406,8 @@ pub fn create_function_metadata(fcx: &mut FunctionContext) -> DISubprogram {
             }
             _ => cx.sess.span_bug(span,
                     fmt!("debuginfo::create_function_metadata() - \
-                         FunctionContext::entry_bcx::node_info points to wrong type of ast_map entry. \
-                         Expected: ast_map::node_block, actual: %?", *entry_block))
+                         FunctionContext::entry_bcx::node_info points to wrong type of ast_map \
+                         entry. Expected: ast_map::node_block, actual: %?", *entry_block))
         }
 
         fcx.debug_context = Some(fn_debug_context);
@@ -508,7 +510,7 @@ pub fn create_function_metadata(fcx: &mut FunctionContext) -> DISubprogram {
                         let actual_type_name = ty_to_str(cx.tcx, actual_type);
                         name_to_append_suffix_to.push_str(actual_type_name);
                         if index != generics.ty_params.len() - 1 {
-                            name_to_append_suffix_to.push_str(", ");
+                            name_to_append_suffix_to.push_str(",");
                         }
 
                         do cx.sess.str_of(ident).to_c_str().with_ref |name| {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -406,7 +406,6 @@ pub fn create_function_metadata(fcx: &mut FunctionContext) -> DISubprogram {
     let template_parameters = get_template_parameters(fcx,
                                                       generics,
                                                       file_metadata,
-                                                      span,
                                                       &mut function_name);
 
     let fn_metadata = do function_name.to_c_str().with_ref |function_name| {
@@ -508,7 +507,6 @@ pub fn create_function_metadata(fcx: &mut FunctionContext) -> DISubprogram {
     fn get_template_parameters(fcx: &FunctionContext,
                                generics: &ast::Generics,
                                file_metadata: DIFile,
-                               span: span,
                                name_to_append_suffix_to: &mut ~str)
                             -> DIArray {
         let cx = fcx.ccx;

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -838,3 +838,21 @@ extern "C" LLVMValueRef LLVMDIBuilderCreateUnionType(
 extern "C" void LLVMSetUnnamedAddr(LLVMValueRef Value, LLVMBool Unnamed) {
     unwrap<GlobalValue>(Value)->setUnnamedAddr(Unnamed);
 }
+
+extern "C" LLVMValueRef LLVMDIBuilderCreateTemplateTypeParameter(
+    DIBuilderRef Builder,
+    LLVMValueRef Scope,
+    const char* Name,
+    LLVMValueRef Ty,
+    LLVMValueRef File = 0,
+    unsigned LineNo = 0,
+    unsigned ColumnNo = 0)
+{
+    return wrap(Builder->createTemplateTypeParameter(
+      unwrapDI<DIDescriptor>(Scope),
+      Name,
+      unwrapDI<DIType>(Ty),
+      unwrapDI<MDNode*>(File),
+      LineNo,
+      ColumnNo));
+}

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -613,4 +613,5 @@ LLVMDIBuilderInsertDeclareBefore
 LLVMDIBuilderCreateEnumerator
 LLVMDIBuilderCreateEnumerationType
 LLVMDIBuilderCreateUnionType
+LLVMDIBuilderCreateTemplateTypeParameter
 LLVMSetUnnamedAddr

--- a/src/test/debug-info/by-value-struct-argument.rs
+++ b/src/test/debug-info/by-value-struct-argument.rs
@@ -1,0 +1,37 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Does not work yet, see issue #8512
+// xfail-test
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// debugger:finish
+// debugger:print s
+// check:$1 = {a = 1, b = 2.5}
+// debugger:continue
+
+#[deriving(Clone)]
+struct Struct {
+    a: int,
+    b: float
+}
+
+fn fun(s: Struct) {
+    zzz();
+}
+
+fn main() {
+    fun(Struct { a: 1, b: 2.5 });
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/closure-in-generic-function.rs
+++ b/src/test/debug-info/closure-in-generic-function.rs
@@ -10,12 +10,37 @@
 
 // xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
 
-// compile-flags:-Z debug-info
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
 // debugger:run
 
-// Nothing to do here really, just make sure it compiles. See issue #8513.
-fn main() {
-    let _ = ||();
-    let _ = range(1u,3).map(|_| 5);
+// debugger:finish
+// debugger:print x
+// check:$1 = 0.5
+// debugger:print y
+// check:$2 = 10
+// debugger:continue
+
+// debugger:finish
+// debugger:print *x
+// check:$3 = 29
+// debugger:print *y
+// check:$4 = 110
+// debugger:continue
+
+fn some_generic_fun<T1, T2>(a: T1, b: T2) -> (T2, T1) {
+
+    let closure = |x, y| {
+        zzz();
+        (y, x)
+    };
+
+    closure(a, b)
 }
 
+fn main() {
+    some_generic_fun(0.5, 10);
+    some_generic_fun(&29, ~110);
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/generic-function.rs
+++ b/src/test/debug-info/generic-function.rs
@@ -32,6 +32,21 @@
 // check:$6 = {{3.5, 4}, {4, 3.5}}
 // debugger:continue
 
+// debugger:finish
+// debugger:print *t0
+// check:$7 = 5
+// debugger:print *t1
+// check:$8 = {a = 6, b = 7.5}
+// debugger:print ret
+// check:$9 = {{5, {a = 6, b = 7.5}}, {{a = 6, b = 7.5}, 5}}
+// debugger:continue
+
+#[deriving(Clone)]
+struct Struct {
+    a: int,
+    b: float
+}
+
 fn dup_tup<T0: Clone, T1: Clone>(t0: &T0, t1: &T1) -> ((T0, T1), (T1, T0)) {
     let ret = ((t0.clone(), t1.clone()), (t1.clone(), t0.clone()));
     zzz();
@@ -42,7 +57,7 @@ fn main() {
 
     let _ = dup_tup(&1, &2.5);
     let _ = dup_tup(&3.5, &4_u16);
-
+    let _ = dup_tup(&5, &Struct { a: 6, b: 7.5 });
 }
 
 fn zzz() {()}

--- a/src/test/debug-info/generic-function.rs
+++ b/src/test/debug-info/generic-function.rs
@@ -1,0 +1,48 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// debugger:finish
+// debugger:print *t0
+// check:$1 = 1
+// debugger:print *t1
+// check:$2 = 2.5
+// debugger:print ret
+// check:$3 = {{1, 2.5}, {2.5, 1}}
+// debugger:continue
+
+// debugger:finish
+// debugger:print *t0
+// check:$4 = 3.5
+// debugger:print *t1
+// check:$5 = 4
+// debugger:print ret
+// check:$6 = {{3.5, 4}, {4, 3.5}}
+// debugger:continue
+
+fn dup_tup<T0: Clone, T1: Clone>(t0: &T0, t1: &T1) -> ((T0, T1), (T1, T0)) {
+    let ret = ((t0.clone(), t1.clone()), (t1.clone(), t0.clone()));
+    zzz();
+    ret
+}
+
+fn main() {
+
+    let _ = dup_tup(&1, &2.5);
+    let _ = dup_tup(&3.5, &4_u16);
+
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/generic-functions-nested.rs
+++ b/src/test/debug-info/generic-functions-nested.rs
@@ -1,0 +1,59 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// debugger:finish
+// debugger:print x
+// check:$1 = -1
+// debugger:print y
+// check:$2 = 1
+// debugger:continue
+
+// debugger:finish
+// debugger:print x
+// check:$3 = -1
+// debugger:print y
+// check:$4 = 2.5
+// debugger:continue
+
+// debugger:finish
+// debugger:print x
+// check:$5 = -2.5
+// debugger:print y
+// check:$6 = 1
+// debugger:continue
+
+// debugger:finish
+// debugger:print x
+// check:$7 = -2.5
+// debugger:print y
+// check:$8 = 2.5
+// debugger:continue
+
+fn outer<TA: Clone>(a: TA) {
+    inner(a.clone(), 1);
+    inner(a.clone(), 2.5);
+
+    fn inner<TX, TY>(x: TX, y: TY) {
+        zzz();
+    }
+}
+
+fn main() {
+    outer(-1);
+    outer(-2.5);
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/generic-method-on-generic-struct.rs
+++ b/src/test/debug-info/generic-method-on-generic-struct.rs
@@ -1,0 +1,140 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// STACK BY REF
+// debugger:finish
+// debugger:print *self
+// check:$1 = {x = {8888, -8888}}
+// debugger:print arg1
+// check:$2 = -1
+// debugger:print/d arg2
+// check:$3 = -2
+// debugger:continue
+
+// STACK BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = {8888, -8888}}
+// debugger:print arg1
+// check:$4 = -3
+// debugger:print arg2
+// check:$5 = -4
+// debugger:continue
+
+// OWNED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$6 = {x = 1234.5}
+// debugger:print arg1
+// check:$7 = -5
+// debugger:print arg2
+// check:$8 = -6
+// debugger:continue
+
+// OWNED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 1234.5}
+// debugger:print arg1
+// check:$9 = -7
+// debugger:print arg2
+// check:$10 = -8
+// debugger:continue
+
+// OWNED MOVED
+// debugger:finish
+// debugger:print *self
+// check:$11 = {x = 1234.5}
+// debugger:print arg1
+// check:$12 = -9
+// debugger:print arg2
+// check:$13 = -10.5
+// debugger:continue
+
+// MANAGED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$14 = {x = -1}
+// debugger:print arg1
+// check:$15 = -11
+// debugger:print arg2
+// check:$16 = -12.5
+// debugger:continue
+
+// MANAGED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = -1}
+// debugger:print arg1
+// check:$17 = -13
+// debugger:print *arg2
+// check:$18 = {-14, 14}
+// debugger:continue
+
+// MANAGED SELF
+// debugger:finish
+// debugger:print self->val
+// check:$19 = {x = -1}
+// debugger:print arg1
+// check:$20 = -15
+// debugger:print *arg2
+// check:$21 = {-16, 16.5}
+// debugger:continue
+
+struct Struct<T> {
+    x: T
+}
+
+impl<T1> Struct<T1> {
+
+    fn self_by_ref<T2>(&self, arg1: int, arg2: T2) -> int {
+        zzz();
+        arg1
+    }
+
+    fn self_by_val<T2>(self, arg1: int, arg2: T2) -> int {
+        zzz();
+        arg1
+    }
+
+    fn self_owned<T2>(~self, arg1: int, arg2: T2) -> int {
+        zzz();
+        arg1
+    }
+
+    fn self_managed<T2>(@self, arg1: int, arg2: T2) -> int {
+        zzz();
+        arg1
+    }
+}
+
+fn main() {
+    let stack = Struct { x: (8888_u32, -8888_i32) };
+    let _ = stack.self_by_ref(-1, -2_i8);
+    let _ = stack.self_by_val(-3, -4_i16);
+
+    let owned = ~Struct { x: 1234.5 };
+    let _ = owned.self_by_ref(-5, -6_i32);
+    let _ = owned.self_by_val(-7, -8_i64);
+    let _ = owned.self_owned(-9, -10.5_f32);
+
+    let managed = @Struct { x: -1_i16 };
+    let _ = managed.self_by_ref(-11, -12.5_f64);
+    let _ = managed.self_by_val(-13, &(-14, 14));
+    let _ = managed.self_managed(-15, &(-16, 16.5));
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/generic-static-method-on-struct-and-enum.rs
+++ b/src/test/debug-info/generic-static-method-on-struct-and-enum.rs
@@ -1,0 +1,67 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// STRUCT
+// debugger:finish
+// debugger:print arg1
+// check:$1 = 1
+// debugger:print arg2
+// check:$2 = 2
+// debugger:continue
+
+// ENUM
+// debugger:finish
+// debugger:print arg1
+// check:$3 = -3
+// debugger:print arg2
+// check:$4 = 4.5
+// debugger:print arg3
+// check:$5 = 5
+// debugger:continue
+
+
+struct Struct {
+    x: int
+}
+
+impl Struct {
+
+    fn static_method<T1, T2>(arg1: T1, arg2: T2) -> int {
+        zzz();
+        return 0;
+    }
+}
+
+enum Enum {
+    Variant1 { x: int },
+    Variant2,
+    Variant3(float, int, char),
+}
+
+impl Enum {
+
+    fn static_method<T1, T2, T3>(arg1: T1, arg2: T2, arg3: T3) -> int {
+        zzz();
+        return 1;
+    }
+}
+
+fn main() {
+    Struct::static_method(1, 2);
+    Enum::static_method(-3, 4.5, 5);
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/generic-struct-style-enum.rs
+++ b/src/test/debug-info/generic-struct-style-enum.rs
@@ -28,17 +28,21 @@
 // debugger:print univariant
 // check:$4 = {a = -1}
 
+// NOTE: This is a copy of the non-generic test case. The `Txx` type parameters have to be
+// substituted with something of size `xx` bits and the same alignment as an integer type of the
+// same size.
+
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when
 // datatype layout should be predictable as in this case.
-enum Regular {
-    Case1 { a: u64, b: u16, c: u16, d: u16, e: u16},
-    Case2 { a: u64, b: u32, c: u32},
-    Case3 { a: u64, b: u64 }
+enum Regular<T16, T32, T64> {
+    Case1 { a: T64, b: T16, c: T16, d: T16, e: T16},
+    Case2 { a: T64, b: T32, c: T32},
+    Case3 { a: T64, b: T64 }
 }
 
-enum Univariant {
-    TheOnlyCase { a: i64 }
+enum Univariant<T> {
+    TheOnlyCase { a: T }
 }
 
 fn main() {
@@ -51,19 +55,19 @@ fn main() {
     // 0b01111100011111000111110001111100 = 2088533116
     // 0b0111110001111100 = 31868
     // 0b01111100 = 124
-    let case1 = Case1 { a: 0, b: 31868, c: 31868, d: 31868, e: 31868 };
+    let case1: Regular<u16, u32, i64> = Case1 { a: 0, b: 31868, c: 31868, d: 31868, e: 31868 };
 
     // 0b0001000100010001000100010001000100010001000100010001000100010001 = 1229782938247303441
     // 0b00010001000100010001000100010001 = 286331153
     // 0b0001000100010001 = 4369
     // 0b00010001 = 17
-    let case2 = Case2 { a: 0, b: 286331153, c: 286331153 };
+    let case2: Regular<i16, u32, i64>  = Case2 { a: 0, b: 286331153, c: 286331153 };
 
     // 0b0101100101011001010110010101100101011001010110010101100101011001 = 6438275382588823897
     // 0b01011001010110010101100101011001 = 1499027801
     // 0b0101100101011001 = 22873
     // 0b01011001 = 89
-    let case3 = Case3 { a: 0, b: 6438275382588823897 };
+    let case3: Regular<u16, i32, u64>  = Case3 { a: 0, b: 6438275382588823897 };
 
     let univariant = TheOnlyCase { a: -1 };
 

--- a/src/test/debug-info/generic-struct.rs
+++ b/src/test/debug-info/generic-struct.rs
@@ -1,0 +1,42 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// debugger:finish
+// debugger:print int_int
+// check:$1 = {key = 0, value = 1}
+// debugger:print int_float
+// check:$2 = {key = 2, value = 3.5}
+// debugger:print float_int
+// check:$3 = {key = 4.5, value = 5}
+// debugger:print float_int_float
+// check:$4 = {key = 6.5, value = {key = 7, value = 8.5}}
+
+struct AGenericStruct<TKey, TValue> {
+    key: TKey,
+    value: TValue
+}
+
+fn main() {
+
+    let int_int = AGenericStruct { key: 0, value: 1 };
+    let int_float = AGenericStruct { key: 2, value: 3.5 };
+    let float_int = AGenericStruct { key: 4.5, value: 5 };
+    let float_int_float = AGenericStruct { key: 6.5, value: AGenericStruct { key: 7, value: 8.5 } };
+
+    zzz();
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/generic-trait-generic-static-default-method.rs
+++ b/src/test/debug-info/generic-trait-generic-static-default-method.rs
@@ -1,0 +1,53 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// debugger:finish
+// debugger:print arg1
+// check:$1 = 1000
+// debugger:print *arg2
+// check:$2 = {1, 2.5}
+// debugger:continue
+
+// debugger:finish
+// debugger:print arg1
+// check:$3 = 2000
+// debugger:print *arg2
+// check:$4 = {3.5, {4, 5, 6}}
+// debugger:continue
+
+
+struct Struct {
+    x: int
+}
+
+trait Trait<T1> {
+    fn generic_static_default_method<T2>(arg1: int, arg2: &(T1, T2)) -> int {
+        zzz();
+        arg1
+    }
+}
+
+impl<T> Trait<T> for Struct;
+
+fn main() {
+
+    // Is this really how to use these?
+    Trait::generic_static_default_method::<int, Struct, float>(1000, &(1, 2.5));
+    Trait::generic_static_default_method::<float, Struct, (int, int, int)>(2000, &(3.5, (4, 5, 6)));
+
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/generic-tuple-style-enum.rs
+++ b/src/test/debug-info/generic-tuple-style-enum.rs
@@ -17,28 +17,33 @@
 // debugger:finish
 
 // debugger:print case1
-// check:$1 = {{Case1, a = 0, b = 31868, c = 31868, d = 31868, e = 31868}, {Case1, a = 0, b = 2088533116, c = 2088533116}, {Case1, a = 0, b = 8970181431921507452}}
+// check:$1 = {{Case1, 0, 31868, 31868, 31868, 31868}, {Case1, 0, 2088533116, 2088533116}, {Case1, 0, 8970181431921507452}}
 
 // debugger:print case2
-// check:$2 = {{Case2, a = 0, b = 4369, c = 4369, d = 4369, e = 4369}, {Case2, a = 0, b = 286331153, c = 286331153}, {Case2, a = 0, b = 1229782938247303441}}
+// check:$2 = {{Case2, 0, 4369, 4369, 4369, 4369}, {Case2, 0, 286331153, 286331153}, {Case2, 0, 1229782938247303441}}
 
 // debugger:print case3
-// check:$3 = {{Case3, a = 0, b = 22873, c = 22873, d = 22873, e = 22873}, {Case3, a = 0, b = 1499027801, c = 1499027801}, {Case3, a = 0, b = 6438275382588823897}}
+// check:$3 = {{Case3, 0, 22873, 22873, 22873, 22873}, {Case3, 0, 1499027801, 1499027801}, {Case3, 0, 6438275382588823897}}
 
 // debugger:print univariant
-// check:$4 = {a = -1}
+// check:$4 = {-1}
+
+
+// NOTE: This is a copy of the non-generic test case. The `Txx` type parameters have to be
+// substituted with something of size `xx` bits and the same alignment as an integer type of the
+// same size.
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when
 // datatype layout should be predictable as in this case.
-enum Regular {
-    Case1 { a: u64, b: u16, c: u16, d: u16, e: u16},
-    Case2 { a: u64, b: u32, c: u32},
-    Case3 { a: u64, b: u64 }
+enum Regular<T16, T32, T64> {
+    Case1(T64, T16, T16, T16, T16),
+    Case2(T64, T32, T32),
+    Case3(T64, T64)
 }
 
-enum Univariant {
-    TheOnlyCase { a: i64 }
+enum Univariant<T64> {
+    TheOnlyCase(T64)
 }
 
 fn main() {
@@ -51,21 +56,21 @@ fn main() {
     // 0b01111100011111000111110001111100 = 2088533116
     // 0b0111110001111100 = 31868
     // 0b01111100 = 124
-    let case1 = Case1 { a: 0, b: 31868, c: 31868, d: 31868, e: 31868 };
+    let case1: Regular<u16, u32, u64> = Case1(0_u64, 31868_u16, 31868_u16, 31868_u16, 31868_u16);
 
     // 0b0001000100010001000100010001000100010001000100010001000100010001 = 1229782938247303441
     // 0b00010001000100010001000100010001 = 286331153
     // 0b0001000100010001 = 4369
     // 0b00010001 = 17
-    let case2 = Case2 { a: 0, b: 286331153, c: 286331153 };
+    let case2: Regular<i16, i32, i64> = Case2(0_i64, 286331153_i32, 286331153_i32);
 
     // 0b0101100101011001010110010101100101011001010110010101100101011001 = 6438275382588823897
     // 0b01011001010110010101100101011001 = 1499027801
     // 0b0101100101011001 = 22873
     // 0b01011001 = 89
-    let case3 = Case3 { a: 0, b: 6438275382588823897 };
+    let case3: Regular<i16, i32, i64> = Case3(0_i64, 6438275382588823897_i64);
 
-    let univariant = TheOnlyCase { a: -1 };
+    let univariant = TheOnlyCase(-1_i64);
 
     zzz();
 }

--- a/src/test/debug-info/lexical-scope-in-parameterless-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-parameterless-closure.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:run
+
+// Nothing to do here really, just make sure it compiles. See issue #8513.
+fn main() {
+    let _ = ||();
+}
+

--- a/src/test/debug-info/method-on-enum.rs
+++ b/src/test/debug-info/method-on-enum.rs
@@ -1,0 +1,141 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// STACK BY REF
+// debugger:finish
+// debugger:print *self
+// check:$1 = {{Variant2, x = 1799, y = 1799}, {Variant2, 117901063}}
+// debugger:print arg1
+// check:$2 = -1
+// debugger:print arg2
+// check:$3 = -2
+// debugger:continue
+
+// STACK BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {{Variant2, x = 1799, y = 1799}, {Variant2, 117901063}}
+// debugger:print arg1
+// check:$4 = -3
+// debugger:print arg2
+// check:$5 = -4
+// debugger:continue
+
+// OWNED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$6 = {{Variant1, x = 1799, y = 1799}, {Variant1, 117901063}}
+// debugger:print arg1
+// check:$7 = -5
+// debugger:print arg2
+// check:$8 = -6
+// debugger:continue
+
+// OWNED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {{Variant1, x = 1799, y = 1799}, {Variant1, 117901063}}
+// debugger:print arg1
+// check:$9 = -7
+// debugger:print arg2
+// check:$10 = -8
+// debugger:continue
+
+// OWNED MOVED
+// debugger:finish
+// debugger:print *self
+// check:$11 = {{Variant1, x = 1799, y = 1799}, {Variant1, 117901063}}
+// debugger:print arg1
+// check:$12 = -9
+// debugger:print arg2
+// check:$13 = -10
+// debugger:continue
+
+// MANAGED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$14 = {{Variant2, x = 1799, y = 1799}, {Variant2, 117901063}}
+// debugger:print arg1
+// check:$15 = -11
+// debugger:print arg2
+// check:$16 = -12
+// debugger:continue
+
+// MANAGED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {{Variant2, x = 1799, y = 1799}, {Variant2, 117901063}}
+// debugger:print arg1
+// check:$17 = -13
+// debugger:print arg2
+// check:$18 = -14
+// debugger:continue
+
+// MANAGED SELF
+// debugger:finish
+// debugger:print self->val
+// check:$19 = {{Variant2, x = 1799, y = 1799}, {Variant2, 117901063}}
+// debugger:print arg1
+// check:$20 = -15
+// debugger:print arg2
+// check:$21 = -16
+// debugger:continue
+
+enum Enum {
+    Variant1 { x: u16, y: u16 },
+    Variant2 (u32)
+}
+
+impl Enum {
+
+    fn self_by_ref(&self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_by_val(self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_owned(~self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_managed(@self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+}
+
+fn main() {
+    let stack = Variant2(117901063);
+    let _ = stack.self_by_ref(-1, -2);
+    let _ = stack.self_by_val(-3, -4);
+
+    let owned = ~Variant1{ x: 1799, y: 1799 };
+    let _ = owned.self_by_ref(-5, -6);
+    let _ = owned.self_by_val(-7, -8);
+    let _ = owned.self_owned(-9, -10);
+
+    let managed = @Variant2(117901063);
+    let _ = managed.self_by_ref(-11, -12);
+    let _ = managed.self_by_val(-13, -14);
+    let _ = managed.self_managed(-15, -16);
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/method-on-generic-struct.rs
+++ b/src/test/debug-info/method-on-generic-struct.rs
@@ -1,0 +1,140 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// STACK BY REF
+// debugger:finish
+// debugger:print *self
+// check:$1 = {x = {8888, -8888}}
+// debugger:print arg1
+// check:$2 = -1
+// debugger:print arg2
+// check:$3 = -2
+// debugger:continue
+
+// STACK BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = {8888, -8888}}
+// debugger:print arg1
+// check:$4 = -3
+// debugger:print arg2
+// check:$5 = -4
+// debugger:continue
+
+// OWNED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$6 = {x = 1234.5}
+// debugger:print arg1
+// check:$7 = -5
+// debugger:print arg2
+// check:$8 = -6
+// debugger:continue
+
+// OWNED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 1234.5}
+// debugger:print arg1
+// check:$9 = -7
+// debugger:print arg2
+// check:$10 = -8
+// debugger:continue
+
+// OWNED MOVED
+// debugger:finish
+// debugger:print *self
+// check:$11 = {x = 1234.5}
+// debugger:print arg1
+// check:$12 = -9
+// debugger:print arg2
+// check:$13 = -10
+// debugger:continue
+
+// MANAGED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$14 = {x = -1}
+// debugger:print arg1
+// check:$15 = -11
+// debugger:print arg2
+// check:$16 = -12
+// debugger:continue
+
+// MANAGED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = -1}
+// debugger:print arg1
+// check:$17 = -13
+// debugger:print arg2
+// check:$18 = -14
+// debugger:continue
+
+// MANAGED SELF
+// debugger:finish
+// debugger:print self->val
+// check:$19 = {x = -1}
+// debugger:print arg1
+// check:$20 = -15
+// debugger:print arg2
+// check:$21 = -16
+// debugger:continue
+
+struct Struct<T> {
+    x: T
+}
+
+impl<T> Struct<T> {
+
+    fn self_by_ref(&self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_by_val(self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_owned(~self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_managed(@self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+}
+
+fn main() {
+    let stack = Struct { x: (8888_u32, -8888_i32) };
+    let _ = stack.self_by_ref(-1, -2);
+    let _ = stack.self_by_val(-3, -4);
+
+    let owned = ~Struct { x: 1234.5 };
+    let _ = owned.self_by_ref(-5, -6);
+    let _ = owned.self_by_val(-7, -8);
+    let _ = owned.self_owned(-9, -10);
+
+    let managed = @Struct { x: -1_i16 };
+    let _ = managed.self_by_ref(-11, -12);
+    let _ = managed.self_by_val(-13, -14);
+    let _ = managed.self_managed(-15, -16);
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/method-on-struct.rs
+++ b/src/test/debug-info/method-on-struct.rs
@@ -1,0 +1,140 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// STACK BY REF
+// debugger:finish
+// debugger:print *self
+// check:$1 = {x = 100}
+// debugger:print arg1
+// check:$2 = -1
+// debugger:print arg2
+// check:$3 = -2
+// debugger:continue
+
+// STACK BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 100}
+// debugger:print arg1
+// check:$4 = -3
+// debugger:print arg2
+// check:$5 = -4
+// debugger:continue
+
+// OWNED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$6 = {x = 200}
+// debugger:print arg1
+// check:$7 = -5
+// debugger:print arg2
+// check:$8 = -6
+// debugger:continue
+
+// OWNED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 200}
+// debugger:print arg1
+// check:$9 = -7
+// debugger:print arg2
+// check:$10 = -8
+// debugger:continue
+
+// OWNED MOVED
+// debugger:finish
+// debugger:print *self
+// check:$11 = {x = 200}
+// debugger:print arg1
+// check:$12 = -9
+// debugger:print arg2
+// check:$13 = -10
+// debugger:continue
+
+// MANAGED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$14 = {x = 300}
+// debugger:print arg1
+// check:$15 = -11
+// debugger:print arg2
+// check:$16 = -12
+// debugger:continue
+
+// MANAGED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 300}
+// debugger:print arg1
+// check:$17 = -13
+// debugger:print arg2
+// check:$18 = -14
+// debugger:continue
+
+// MANAGED SELF
+// debugger:finish
+// debugger:print self->val
+// check:$19 = {x = 300}
+// debugger:print arg1
+// check:$20 = -15
+// debugger:print arg2
+// check:$21 = -16
+// debugger:continue
+
+struct Struct {
+    x: int
+}
+
+impl Struct {
+
+    fn self_by_ref(&self, arg1: int, arg2: int) -> int {
+        zzz();
+        self.x + arg1 + arg2
+    }
+
+    fn self_by_val(self, arg1: int, arg2: int) -> int {
+        zzz();
+        self.x + arg1 + arg2
+    }
+
+    fn self_owned(~self, arg1: int, arg2: int) -> int {
+        zzz();
+        self.x + arg1 + arg2
+    }
+
+    fn self_managed(@self, arg1: int, arg2: int) -> int {
+        zzz();
+        self.x + arg1 + arg2
+    }
+}
+
+fn main() {
+    let stack = Struct { x: 100 };
+    let _ = stack.self_by_ref(-1, -2);
+    let _ = stack.self_by_val(-3, -4);
+
+    let owned = ~Struct { x: 200 };
+    let _ = owned.self_by_ref(-5, -6);
+    let _ = owned.self_by_val(-7, -8);
+    let _ = owned.self_owned(-9, -10);
+
+    let managed = @Struct { x: 300 };
+    let _ = managed.self_by_ref(-11, -12);
+    let _ = managed.self_by_val(-13, -14);
+    let _ = managed.self_managed(-15, -16);
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/method-on-trait.rs
+++ b/src/test/debug-info/method-on-trait.rs
@@ -1,0 +1,147 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// STACK BY REF
+// debugger:finish
+// debugger:print *self
+// check:$1 = {x = 100}
+// debugger:print arg1
+// check:$2 = -1
+// debugger:print arg2
+// check:$3 = -2
+// debugger:continue
+
+// STACK BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 100}
+// debugger:print arg1
+// check:$4 = -3
+// debugger:print arg2
+// check:$5 = -4
+// debugger:continue
+
+// OWNED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$6 = {x = 200}
+// debugger:print arg1
+// check:$7 = -5
+// debugger:print arg2
+// check:$8 = -6
+// debugger:continue
+
+// OWNED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 200}
+// debugger:print arg1
+// check:$9 = -7
+// debugger:print arg2
+// check:$10 = -8
+// debugger:continue
+
+// OWNED MOVED
+// debugger:finish
+// debugger:print *self
+// check:$11 = {x = 200}
+// debugger:print arg1
+// check:$12 = -9
+// debugger:print arg2
+// check:$13 = -10
+// debugger:continue
+
+// MANAGED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$14 = {x = 300}
+// debugger:print arg1
+// check:$15 = -11
+// debugger:print arg2
+// check:$16 = -12
+// debugger:continue
+
+// MANAGED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 300}
+// debugger:print arg1
+// check:$17 = -13
+// debugger:print arg2
+// check:$18 = -14
+// debugger:continue
+
+// MANAGED SELF
+// debugger:finish
+// debugger:print self->val
+// check:$19 = {x = 300}
+// debugger:print arg1
+// check:$20 = -15
+// debugger:print arg2
+// check:$21 = -16
+// debugger:continue
+
+struct Struct {
+    x: int
+}
+
+trait Trait {
+    fn self_by_ref(&self, arg1: int, arg2: int) -> int;
+    fn self_by_val(self, arg1: int, arg2: int) -> int;
+    fn self_owned(~self, arg1: int, arg2: int) -> int;
+    fn self_managed(@self, arg1: int, arg2: int) -> int;
+}
+
+impl Trait for Struct {
+
+    fn self_by_ref(&self, arg1: int, arg2: int) -> int {
+        zzz();
+        self.x + arg1 + arg2
+    }
+
+    fn self_by_val(self, arg1: int, arg2: int) -> int {
+        zzz();
+        self.x + arg1 + arg2
+    }
+
+    fn self_owned(~self, arg1: int, arg2: int) -> int {
+        zzz();
+        self.x + arg1 + arg2
+    }
+
+    fn self_managed(@self, arg1: int, arg2: int) -> int {
+        zzz();
+        self.x + arg1 + arg2
+    }
+}
+
+fn main() {
+    let stack = Struct { x: 100 };
+    let _ = stack.self_by_ref(-1, -2);
+    let _ = stack.self_by_val(-3, -4);
+
+    let owned = ~Struct { x: 200 };
+    let _ = owned.self_by_ref(-5, -6);
+    let _ = owned.self_by_val(-7, -8);
+    let _ = owned.self_owned(-9, -10);
+
+    let managed = @Struct { x: 300 };
+    let _ = managed.self_by_ref(-11, -12);
+    let _ = managed.self_by_val(-13, -14);
+    let _ = managed.self_managed(-15, -16);
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/method-on-tuple-struct.rs
+++ b/src/test/debug-info/method-on-tuple-struct.rs
@@ -1,0 +1,138 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// STACK BY REF
+// debugger:finish
+// debugger:print *self
+// check:$1 = {100, -100.5}
+// debugger:print arg1
+// check:$2 = -1
+// debugger:print arg2
+// check:$3 = -2
+// debugger:continue
+
+// STACK BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {100, -100.5}
+// debugger:print arg1
+// check:$4 = -3
+// debugger:print arg2
+// check:$5 = -4
+// debugger:continue
+
+// OWNED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$6 = {200, -200.5}
+// debugger:print arg1
+// check:$7 = -5
+// debugger:print arg2
+// check:$8 = -6
+// debugger:continue
+
+// OWNED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {200, -200.5}
+// debugger:print arg1
+// check:$9 = -7
+// debugger:print arg2
+// check:$10 = -8
+// debugger:continue
+
+// OWNED MOVED
+// debugger:finish
+// debugger:print *self
+// check:$11 = {200, -200.5}
+// debugger:print arg1
+// check:$12 = -9
+// debugger:print arg2
+// check:$13 = -10
+// debugger:continue
+
+// MANAGED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$14 = {300, -300.5}
+// debugger:print arg1
+// check:$15 = -11
+// debugger:print arg2
+// check:$16 = -12
+// debugger:continue
+
+// MANAGED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {300, -300.5}
+// debugger:print arg1
+// check:$17 = -13
+// debugger:print arg2
+// check:$18 = -14
+// debugger:continue
+
+// MANAGED SELF
+// debugger:finish
+// debugger:print self->val
+// check:$19 = {300, -300.5}
+// debugger:print arg1
+// check:$20 = -15
+// debugger:print arg2
+// check:$21 = -16
+// debugger:continue
+
+struct TupleStruct(int, float);
+
+impl TupleStruct {
+
+    fn self_by_ref(&self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_by_val(self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_owned(~self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_managed(@self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+}
+
+fn main() {
+    let stack = TupleStruct(100, -100.5);
+    let _ = stack.self_by_ref(-1, -2);
+    let _ = stack.self_by_val(-3, -4);
+
+    let owned = ~TupleStruct(200, -200.5);
+    let _ = owned.self_by_ref(-5, -6);
+    let _ = owned.self_by_val(-7, -8);
+    let _ = owned.self_owned(-9, -10);
+
+    let managed = @TupleStruct(300, -300.5);
+    let _ = managed.self_by_ref(-11, -12);
+    let _ = managed.self_by_val(-13, -14);
+    let _ = managed.self_managed(-15, -16);
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/self-in-default-method.rs
+++ b/src/test/debug-info/self-in-default-method.rs
@@ -1,0 +1,141 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// STACK BY REF
+// debugger:finish
+// debugger:print *self
+// check:$1 = {x = 100}
+// debugger:print arg1
+// check:$2 = -1
+// debugger:print arg2
+// check:$3 = -2
+// debugger:continue
+
+// STACK BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 100}
+// debugger:print arg1
+// check:$4 = -3
+// debugger:print arg2
+// check:$5 = -4
+// debugger:continue
+
+// OWNED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$6 = {x = 200}
+// debugger:print arg1
+// check:$7 = -5
+// debugger:print arg2
+// check:$8 = -6
+// debugger:continue
+
+// OWNED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 200}
+// debugger:print arg1
+// check:$9 = -7
+// debugger:print arg2
+// check:$10 = -8
+// debugger:continue
+
+// OWNED MOVED
+// debugger:finish
+// debugger:print *self
+// check:$11 = {x = 200}
+// debugger:print arg1
+// check:$12 = -9
+// debugger:print arg2
+// check:$13 = -10
+// debugger:continue
+
+// MANAGED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$14 = {x = 300}
+// debugger:print arg1
+// check:$15 = -11
+// debugger:print arg2
+// check:$16 = -12
+// debugger:continue
+
+// MANAGED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 300}
+// debugger:print arg1
+// check:$17 = -13
+// debugger:print arg2
+// check:$18 = -14
+// debugger:continue
+
+// MANAGED SELF
+// debugger:finish
+// debugger:print self->val
+// check:$19 = {x = 300}
+// debugger:print arg1
+// check:$20 = -15
+// debugger:print arg2
+// check:$21 = -16
+// debugger:continue
+
+struct Struct {
+    x: int
+}
+
+trait Trait {
+    fn self_by_ref(&self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_by_val(self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_owned(~self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+
+    fn self_managed(@self, arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+}
+
+impl Trait for Struct;
+
+fn main() {
+    let stack = Struct { x: 100 };
+    let _ = stack.self_by_ref(-1, -2);
+    let _ = stack.self_by_val(-3, -4);
+
+    let owned = ~Struct { x: 200 };
+    let _ = owned.self_by_ref(-5, -6);
+    let _ = owned.self_by_val(-7, -8);
+    let _ = owned.self_owned(-9, -10);
+
+    let managed = @Struct { x: 300 };
+    let _ = managed.self_by_ref(-11, -12);
+    let _ = managed.self_by_val(-13, -14);
+    let _ = managed.self_managed(-15, -16);
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/self-in-generic-default-method.rs
+++ b/src/test/debug-info/self-in-generic-default-method.rs
@@ -1,0 +1,142 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// STACK BY REF
+// debugger:finish
+// debugger:print *self
+// check:$1 = {x = 987}
+// debugger:print arg1
+// check:$2 = -1
+// debugger:print/d arg2
+// check:$3 = -2
+// debugger:continue
+
+// STACK BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 987}
+// debugger:print arg1
+// check:$4 = -3
+// debugger:print arg2
+// check:$5 = -4
+// debugger:continue
+
+// OWNED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$6 = {x = 879}
+// debugger:print arg1
+// check:$7 = -5
+// debugger:print arg2
+// check:$8 = -6
+// debugger:continue
+
+// OWNED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 879}
+// debugger:print arg1
+// check:$9 = -7
+// debugger:print arg2
+// check:$10 = -8
+// debugger:continue
+
+// OWNED MOVED
+// debugger:finish
+// debugger:print *self
+// check:$11 = {x = 879}
+// debugger:print arg1
+// check:$12 = -9
+// debugger:print arg2
+// check:$13 = -10.5
+// debugger:continue
+
+// MANAGED BY REF
+// debugger:finish
+// debugger:print *self
+// check:$14 = {x = 897}
+// debugger:print arg1
+// check:$15 = -11
+// debugger:print arg2
+// check:$16 = -12.5
+// debugger:continue
+
+// MANAGED BY VAL
+// debugger:finish
+// d ebugger:print self -- ignored for now because of issue #8512
+// c heck:$X = {x = 897}
+// debugger:print arg1
+// check:$17 = -13
+// debugger:print *arg2
+// check:$18 = {-14, 14}
+// debugger:continue
+
+// MANAGED SELF
+// debugger:finish
+// debugger:print self->val
+// check:$19 = {x = 897}
+// debugger:print arg1
+// check:$20 = -15
+// debugger:print *arg2
+// check:$21 = {-16, 16.5}
+// debugger:continue
+
+struct Struct {
+    x: int
+}
+
+trait Trait {
+
+    fn self_by_ref<T>(&self, arg1: int, arg2: T) -> int {
+        zzz();
+        arg1
+    }
+
+    fn self_by_val<T>(self, arg1: int, arg2: T) -> int {
+        zzz();
+        arg1
+    }
+
+    fn self_owned<T>(~self, arg1: int, arg2: T) -> int {
+        zzz();
+        arg1
+    }
+
+    fn self_managed<T>(@self, arg1: int, arg2: T) -> int {
+        zzz();
+        arg1
+    }
+}
+
+impl Trait for Struct;
+
+fn main() {
+    let stack = Struct { x: 987 };
+    let _ = stack.self_by_ref(-1, -2_i8);
+    let _ = stack.self_by_val(-3, -4_i16);
+
+    let owned = ~Struct { x: 879 };
+    let _ = owned.self_by_ref(-5, -6_i32);
+    let _ = owned.self_by_val(-7, -8_i64);
+    let _ = owned.self_owned(-9, -10.5_f32);
+
+    let managed = @Struct { x: 897 };
+    let _ = managed.self_by_ref(-11, -12.5_f64);
+    let _ = managed.self_by_val(-13, &(-14, 14));
+    let _ = managed.self_managed(-15, &(-16, 16.5));
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/static-method-on-struct-and-enum.rs
+++ b/src/test/debug-info/static-method-on-struct-and-enum.rs
@@ -1,0 +1,67 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// STRUCT
+// debugger:finish
+// debugger:print arg1
+// check:$1 = 1
+// debugger:print arg2
+// check:$2 = 2
+// debugger:continue
+
+// ENUM
+// debugger:finish
+// debugger:print arg1
+// check:$3 = -3
+// debugger:print arg2
+// check:$4 = 4.5
+// debugger:print arg3
+// check:$5 = 5
+// debugger:continue
+
+
+struct Struct {
+    x: int
+}
+
+impl Struct {
+
+    fn static_method(arg1: int, arg2: int) -> int {
+        zzz();
+        arg1 + arg2
+    }
+}
+
+enum Enum {
+    Variant1 { x: int },
+    Variant2,
+    Variant3(float, int, char),
+}
+
+impl Enum {
+
+    fn static_method(arg1: int, arg2: float, arg3: uint) -> int {
+        zzz();
+        arg1
+    }
+}
+
+fn main() {
+    Struct::static_method(1, 2);
+    Enum::static_method(-3, 4.5, 5);
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/trait-generic-static-default-method.rs
+++ b/src/test/debug-info/trait-generic-static-default-method.rs
@@ -1,0 +1,53 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:break zzz
+// debugger:run
+
+// debugger:finish
+// debugger:print arg1
+// check:$1 = 1000
+// debugger:print arg2
+// check:$2 = 0.5
+// debugger:continue
+
+// debugger:finish
+// debugger:print arg1
+// check:$3 = 2000
+// debugger:print *arg2
+// check:$4 = {1, 2, 3}
+// debugger:continue
+
+
+struct Struct {
+    x: int
+}
+
+trait Trait {
+    fn generic_static_default_method<T>(arg1: int, arg2: T) -> int {
+        zzz();
+        arg1
+    }
+}
+
+impl Trait for Struct;
+
+fn main() {
+
+    // Is this really how to use these?
+    Trait::generic_static_default_method::<Struct, float>(1000, 0.5);
+    Trait::generic_static_default_method::<Struct, &(int, int, int)>(2000, &(1, 2, 3));
+
+}
+
+fn zzz() {()}

--- a/src/test/debug-info/tuple-struct.rs
+++ b/src/test/debug-info/tuple-struct.rs
@@ -1,0 +1,60 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+
+// compile-flags:-Z extra-debug-info
+// debugger:set print pretty off
+// debugger:break zzz
+// debugger:run
+// debugger:finish
+
+// debugger:print no_padding16
+// check:$1 = {10000, -10001}
+
+// debugger:print no_padding32
+// check:$2 = {-10002, -10003.5, 10004}
+
+// debugger:print no_padding64
+// check:$3 = {-10005.5, 10006, 10007}
+
+// debugger:print no_padding163264
+// check:$4 = {-10008, 10009, 10010, 10011}
+
+// debugger:print internal_padding
+// check:$5 = {10012, -10013}
+
+// debugger:print padding_at_end
+// check:$6 = {-10014, 10015}
+
+
+// This test case mainly makes sure that no field names are generated for tuple structs (as opposed
+// to all fields having the name "__field__"). Otherwise they are handled the same a normal structs.
+
+struct NoPadding16(u16, i16);
+struct NoPadding32(i32, f32, u32);
+struct NoPadding64(f64, i64, u64);
+struct NoPadding163264(i16, u16, i32, u64);
+struct InternalPadding(u16, i64);
+struct PaddingAtEnd(i64, u16);
+
+fn main() {
+    let no_padding16 = NoPadding16(10000, -10001);
+    let no_padding32 = NoPadding32(-10002, -10003.5, 10004);
+    let no_padding64 = NoPadding64(-10005.5, 10006, 10007);
+    let no_padding163264 = NoPadding163264(-10008, 10009, 10010, 10011);
+
+    let internal_padding = InternalPadding(10012, -10013);
+    let padding_at_end = PaddingAtEnd(-10014, 10015);
+
+    zzz();
+}
+
+fn zzz() {()}


### PR DESCRIPTION
This pull request includes support for generic functions and self arguments in methods, and combinations thereof. This also encompasses any kind of trait methods, regular and static, with and without default implementation. The implementation is backed up by a felt ton of test cases `:)`

This is a very important step towards being able to compile larger programs with debug info, since practically any generic function caused an ICE before.

One point worth discussing is that activating debug info now automatically (and silently) sets the `no_monomorphic_collapse` flag. Otherwise debug info would show wrong type names in all but one instance of the monomorphized function.

Another thing to note is that the handling of generic types does not strictly follow the DWARF specification. That is, variables with type `T` (where `T=int`) are described as having type `int` and not as having type `T`. In other words, we are losing information whether a variable has been declared with a type parameter as its type. In practice this should not make much of difference though since the concrete type is mostly what one is interested in. I'll post an issue later so this won't be forgotten.

Also included are a number of bug fixes:
- Closes #1758
- Closes #8513
- Closes #8443
- Fixes handling of field names in tuple structs
- Fixes and re-enables test case for option-like enums that relied on undefined behavior before
- Closes #1339 (should have been closed a while ago)

Cheers,
Michael
