### PR TITLE
Implement Clone and DeepClone for extra::time::{Tm, Timespec}

### DIFF
--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -34,7 +34,7 @@ pub mod rustrt {
 }
 
 /// A record specifying a time value in seconds and nanoseconds.
-#[deriving(Eq, Encodable, Decodable)]
+#[deriving(Clone, DeepClone, Eq, Encodable, Decodable)]
 pub struct Timespec { sec: i64, nsec: i32 }
 
 /*
@@ -100,7 +100,7 @@ pub fn tzset() {
     }
 }
 
-#[deriving(Eq, Encodable, Decodable)]
+#[deriving(Clone, DeepClone, Eq, Encodable, Decodable)]
 pub struct Tm {
     tm_sec: i32, // seconds after the minute ~[0-60]
     tm_min: i32, // minutes after the hour ~[0-59]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -20,7 +20,7 @@ use at_vec;
 use cast;
 use char;
 use char::Char;
-use clone::Clone;
+use clone::{Clone, DeepClone};
 use container::{Container, Mutable};
 use iter::Times;
 use iterator::{Iterator, FromIterator, Extendable};
@@ -2104,9 +2104,23 @@ impl Clone for ~str {
     }
 }
 
+impl DeepClone for ~str {
+    #[inline]
+    fn deep_clone(&self) -> ~str {
+        self.to_owned()
+    }
+}
+
 impl Clone for @str {
     #[inline]
     fn clone(&self) -> @str {
+        *self
+    }
+}
+
+impl DeepClone for @str {
+    #[inline]
+    fn deep_clone(&self) -> @str {
         *self
     }
 }


### PR DESCRIPTION
I need `Clone` for `Tm` for my latest work on [rust-http](https://github.com/chris-morgan/rust-http) (static typing for headers, and headers like `Date` are a time), so here it is.

@huonw recommended deriving DeepClone while I was at it.

I also had to implement `DeepClone` for `~str` to get a derived implementation of `DeepClone` for `Tm`; I did `@str` while I was at it, for consistency.
