### PR TITLE
quote_*! macros take an ExtCtx

### DIFF
--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1288,24 +1288,24 @@ fn roundtrip(in_item: Option<@ast::item>) {
 
 #[test]
 fn test_basic() {
-    let ext_cx = mk_ctxt();
-    roundtrip(quote_item!(
+    let cx = mk_ctxt();
+    roundtrip(quote_item!(cx,
         fn foo() {}
     ));
 }
 
 #[test]
 fn test_smalltalk() {
-    let ext_cx = mk_ctxt();
-    roundtrip(quote_item!(
+    let cx = mk_ctxt();
+    roundtrip(quote_item!(cx,
         fn foo() -> int { 3 + 4 } // first smalltalk program ever executed.
     ));
 }
 
 #[test]
 fn test_more() {
-    let ext_cx = mk_ctxt();
-    roundtrip(quote_item!(
+    let cx = mk_ctxt();
+    roundtrip(quote_item!(cx,
         fn foo(x: uint, y: uint) -> uint {
             let z = x + y;
             return z;
@@ -1315,15 +1315,15 @@ fn test_more() {
 
 #[test]
 fn test_simplification() {
-    let ext_cx = mk_ctxt();
-    let item_in = ast::ii_item(quote_item!(
+    let cx = mk_ctxt();
+    let item_in = ast::ii_item(quote_item!(cx,
         fn new_int_alist<B>() -> alist<int, B> {
             fn eq_int(a: int, b: int) -> bool { a == b }
             return alist {eq_fn: eq_int, data: ~[]};
         }
     ).unwrap());
     let item_out = simplify_ast(&item_in);
-    let item_exp = ast::ii_item(quote_item!(
+    let item_exp = ast::ii_item(quote_item!(cx,
         fn new_int_alist<B>() -> alist<int, B> {
             return alist {eq_fn: eq_int, data: ~[]};
         }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -605,16 +605,28 @@ impl AstBuilder for @ExtCtxt {
 
         self.expr(span, ast::expr_fn_block(fn_decl, blk))
     }
+    #[cfg(stage0)]
     fn lambda0(&self, _span: span, blk: ast::Block) -> @ast::expr {
         let ext_cx = *self;
         let blk_e = self.expr(blk.span, ast::expr_block(blk.clone()));
         quote_expr!(|| $blk_e )
     }
+    #[cfg(not(stage0))]
+    fn lambda0(&self, _span: span, blk: ast::Block) -> @ast::expr {
+        let blk_e = self.expr(blk.span, ast::expr_block(blk.clone()));
+        quote_expr!(*self, || $blk_e )
+    }
 
+    #[cfg(stage0)]
     fn lambda1(&self, _span: span, blk: ast::Block, ident: ast::ident) -> @ast::expr {
         let ext_cx = *self;
         let blk_e = self.expr(blk.span, ast::expr_block(blk.clone()));
         quote_expr!(|$ident| $blk_e )
+    }
+    #[cfg(not(stage0))]
+    fn lambda1(&self, _span: span, blk: ast::Block, ident: ast::ident) -> @ast::expr {
+        let blk_e = self.expr(blk.span, ast::expr_block(blk.clone()));
+        quote_expr!(*self, |$ident| $blk_e )
     }
 
     fn lambda_expr(&self, span: span, ids: ~[ast::ident], expr: @ast::expr) -> @ast::expr {

--- a/src/test/compile-fail/qquote-1.rs
+++ b/src/test/compile-fail/qquote-1.rs
@@ -53,12 +53,12 @@ fn mk_ctxt() -> fake_ext_ctxt {
 
 
 fn main() {
-    let ext_cx = mk_ctxt();
+    let cx = mk_ctxt();
 
-    let abc = quote_expr!(23);
+    let abc = quote_expr!(cx, 23);
     check_pp(abc,  pprust::print_expr, "23");
 
-    let expr3 = quote_expr!(2 - $abcd + 7); //~ ERROR unresolved name: abcd
+    let expr3 = quote_expr!(cx, 2 - $abcd + 7); //~ ERROR unresolved name: abcd
     check_pp(expr3,  pprust::print_expr, "2 - 23 + 7");
 }
 

--- a/src/test/compile-fail/qquote-2.rs
+++ b/src/test/compile-fail/qquote-2.rs
@@ -51,9 +51,9 @@ fn mk_ctxt() -> fake_ext_ctxt {
 
 
 fn main() {
-    let ext_cx = mk_ctxt();
+    let cx = mk_ctxt();
 
-    let stmt = quote_stmt!(let x int = 20;); //~ ERROR expected end-of-string
+    let stmt = quote_stmt!(cx, let x int = 20;); //~ ERROR expected end-of-string
     check_pp(*stmt,  pprust::print_stmt, "");
 }
 

--- a/src/test/run-pass-fulldeps/issue-1926.rs
+++ b/src/test/run-pass-fulldeps/issue-1926.rs
@@ -54,9 +54,9 @@ fn mk_ctxt() -> fake_ext_ctxt {
 
 
 fn main() {
-    let ext_cx = mk_ctxt();
-    let s = quote_expr!(__s);
-    let e = quote_expr!(__e);
-    let f = quote_expr!($s.foo {|__e| $e});
+    let cx = mk_ctxt();
+    let s = quote_expr!(cx, __s);
+    let e = quote_expr!(cx, __e);
+    let f = quote_expr!(cx, $s.foo {|__e| $e});
     log(error, pprust::expr_to_str(f));
 }

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -52,22 +52,22 @@ fn mk_ctxt() -> fake_ext_ctxt {
 }
 
 fn main() {
-    let ext_cx = mk_ctxt();
+    let cx = mk_ctxt();
 
-    let abc = quote_expr!(23);
+    let abc = quote_expr!(cx, 23);
     check_pp(ext_cx, abc,  pprust::print_expr, ~"23");
 
 
-    let ty = quote_ty!(int);
+    let ty = quote_ty!(cx, int);
     check_pp(ext_cx, ty, pprust::print_type, ~"int");
 
-    let item = quote_item!(static x : int = 10;).get();
+    let item = quote_item!(cx, static x : int = 10;).get();
     check_pp(ext_cx, item, pprust::print_item, ~"static x: int = 10;");
 
-    let stmt = quote_stmt!(let x = 20;);
+    let stmt = quote_stmt!(cx, let x = 20;);
     check_pp(ext_cx, *stmt, pprust::print_stmt, ~"let x = 20;");
 
-    let pat = quote_pat!(Some(_));
+    let pat = quote_pat!(cx, Some(_));
     check_pp(ext_cx, pat, pprust::print_pat, ~"Some(_)");
 
 }

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -12,15 +12,15 @@ extern mod syntax;
 
 use syntax::ext::base::ExtCtxt;
 
-fn syntax_extension(ext_cx: @ExtCtxt) {
-    let e_toks : ~[syntax::ast::token_tree] = quote_tokens!(1 + 2);
-    let p_toks : ~[syntax::ast::token_tree] = quote_tokens!((x, 1 .. 4, *));
+fn syntax_extension(cx: @ExtCtxt) {
+    let e_toks : ~[syntax::ast::token_tree] = quote_tokens!(cx, 1 + 2);
+    let p_toks : ~[syntax::ast::token_tree] = quote_tokens!(cx, (x, 1 .. 4, *));
 
-    let a: @syntax::ast::expr = quote_expr!(1 + 2);
-    let _b: Option<@syntax::ast::item> = quote_item!( static foo : int = $e_toks; );
-    let _c: @syntax::ast::pat = quote_pat!( (x, 1 .. 4, *) );
-    let _d: @syntax::ast::stmt = quote_stmt!( let x = $a; );
-    let _e: @syntax::ast::expr = quote_expr!( match foo { $p_toks => 10 } );
+    let a: @syntax::ast::expr = quote_expr!(cx, 1 + 2);
+    let _b: Option<@syntax::ast::item> = quote_item!(cx, static foo : int = $e_toks; );
+    let _c: @syntax::ast::pat = quote_pat!(cx, (x, 1 .. 4, *) );
+    let _d: @syntax::ast::stmt = quote_stmt!(cx, let x = $a; );
+    let _e: @syntax::ast::expr = quote_expr!(cx, match foo { $p_toks => 10 } );
 }
 
 fn main() {


### PR DESCRIPTION
They previously required one called "ext_cx" to be in scope.

Fixes part of #7727
