### PR TITLE
Reserve 'yield' keyword

### DIFF
--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -762,7 +762,7 @@ mod tests {
                 do 10.times {
                     let tmp = *num;
                     *num = -1;
-                    task::yield();
+                    task::deschedule();
                     *num = tmp + 1;
                 }
                 c.send(());
@@ -913,7 +913,7 @@ mod tests {
             do read_mode.read |state| {
                 // if writer mistakenly got in, make sure it mutates state
                 // before we assert on it
-                do 5.times { task::yield(); }
+                do 5.times { task::deschedule(); }
                 // make sure writer didn't get in.
                 assert!(*state);
             }
@@ -921,9 +921,9 @@ mod tests {
     }
     #[test]
     fn test_rw_write_cond_downgrade_read_race() {
-        // Ideally the above test case would have yield statements in it that
+        // Ideally the above test case would have deschedule statements in it that
         // helped to expose the race nearly 100% of the time... but adding
-        // yields in the intuitively-right locations made it even less likely,
+        // deschedules in the intuitively-right locations made it even less likely,
         // and I wasn't sure why :( . This is a mediocre "next best" option.
         do 8.times { test_rw_write_cond_downgrade_read_race_helper() }
     }

--- a/src/libextra/sync.rs
+++ b/src/libextra/sync.rs
@@ -112,7 +112,7 @@ impl<Q:Send> Sem<Q> {
                 }
             }
             // Uncomment if you wish to test for sem races. Not valgrind-friendly.
-            /* do 1000.times { task::yield(); } */
+            /* do 1000.times { task::deschedule(); } */
             // Need to wait outside the exclusive.
             if waiter_nobe.is_some() {
                 let _ = waiter_nobe.unwrap().recv();
@@ -225,7 +225,7 @@ impl<'self> Condvar<'self> {
                 }
             }
 
-            // If yield checks start getting inserted anywhere, we can be
+            // If deschedule checks start getting inserted anywhere, we can be
             // killed before or after enqueueing. Deciding whether to
             // unkillably reacquire the lock needs to happen atomically
             // wrt enqueuing.
@@ -731,11 +731,11 @@ mod tests {
         let s2 = ~s.clone();
         do task::spawn || {
             do s2.access {
-                do 5.times { task::yield(); }
+                do 5.times { task::deschedule(); }
             }
         }
         do s.access {
-            do 5.times { task::yield(); }
+            do 5.times { task::deschedule(); }
         }
     }
     #[test]
@@ -748,7 +748,7 @@ mod tests {
             s2.acquire();
             c.send(());
         }
-        do 5.times { task::yield(); }
+        do 5.times { task::deschedule(); }
         s.release();
         let _ = p.recv();
 
@@ -757,7 +757,7 @@ mod tests {
         let s = ~Semaphore::new(0);
         let s2 = ~s.clone();
         do task::spawn || {
-            do 5.times { task::yield(); }
+            do 5.times { task::deschedule(); }
             s2.release();
             let _ = p.recv();
         }
@@ -800,7 +800,7 @@ mod tests {
                     c.send(());
                 }
                 let _ = p.recv(); // wait for child to come alive
-                do 5.times { task::yield(); } // let the child contend
+                do 5.times { task::deschedule(); } // let the child contend
             }
             let _ = p.recv(); // wait for child to be done
         }
@@ -837,7 +837,7 @@ mod tests {
             do n.times {
                 do m.lock {
                     let oldval = *sharedstate;
-                    task::yield();
+                    task::deschedule();
                     *sharedstate = oldval + 1;
                 }
             }
@@ -948,7 +948,7 @@ mod tests {
             let (p,c) = comm::stream();
             do task::spawn || { // linked
                 let _ = p.recv(); // wait for sibling to get in the mutex
-                task::yield();
+                task::deschedule();
                 fail!();
             }
             do m2.lock_cond |cond| {
@@ -1114,7 +1114,7 @@ mod tests {
             do n.times {
                 do lock_rwlock_in_mode(x, mode) {
                     let oldval = *sharedstate;
-                    task::yield();
+                    task::deschedule();
                     *sharedstate = oldval + 1;
                 }
             }

--- a/src/libstd/rt/kill.rs
+++ b/src/libstd/rt/kill.rs
@@ -141,7 +141,7 @@ pub struct Death {
     on_exit:         Option<~fn(bool)>,
     // nesting level counter for task::unkillable calls (0 == killable).
     unkillable:      int,
-    // nesting level counter for unstable::atomically calls (0 == can yield).
+    // nesting level counter for unstable::atomically calls (0 == can deschedule).
     wont_sleep:      int,
     // A "spare" handle to the kill flag inside the kill handle. Used during
     // blocking/waking as an optimization to avoid two xadds on the refcount.
@@ -572,16 +572,16 @@ impl Death {
     }
 
     /// Enter a possibly-nested "atomic" section of code. Just for assertions.
-    /// All calls must be paired with a subsequent call to allow_yield.
+    /// All calls must be paired with a subsequent call to allow_deschedule.
     #[inline]
-    pub fn inhibit_yield(&mut self) {
+    pub fn inhibit_deschedule(&mut self) {
         self.wont_sleep += 1;
     }
 
     /// Exit a possibly-nested "atomic" section of code. Just for assertions.
-    /// All calls must be paired with a preceding call to inhibit_yield.
+    /// All calls must be paired with a preceding call to inhibit_deschedule.
     #[inline]
-    pub fn allow_yield(&mut self) {
+    pub fn allow_deschedule(&mut self) {
         rtassert!(self.wont_sleep != 0);
         self.wont_sleep -= 1;
     }

--- a/src/libstd/select.rs
+++ b/src/libstd/select.rs
@@ -250,7 +250,7 @@ mod test {
                     let (c2, p3, c4) = x.take();
                     p3.recv();   // handshake parent
                     c4.send(()); // normal receive
-                    task::yield();
+                    task::deschedule();
                     c2.send(()); // select receive
                 }
 
@@ -294,7 +294,7 @@ mod test {
                             if send_on_chans.contains(&i) {
                                 let c = Cell::new(c);
                                 do spawntask_random {
-                                    task::yield();
+                                    task::deschedule();
                                     c.take().send(());
                                 }
                             }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -477,6 +477,7 @@ fn mk_fresh_ident_interner() -> @ident_interner {
 
         "be",                 // 64
         "pure",               // 65
+        "yield",              // 66
     ];
 
     @ident_interner {
@@ -585,7 +586,6 @@ pub mod keywords {
         Once,
         Priv,
         Pub,
-        Pure,
         Ref,
         Return,
         Static,
@@ -601,6 +601,8 @@ pub mod keywords {
 
         // Reserved keywords
         Be,
+        Pure,
+        Yield,
     }
 
     impl Keyword {
@@ -628,7 +630,6 @@ pub mod keywords {
                 Once => ident { name: 50, ctxt: 0 },
                 Priv => ident { name: 51, ctxt: 0 },
                 Pub => ident { name: 52, ctxt: 0 },
-                Pure => ident { name: 65, ctxt: 0 },
                 Ref => ident { name: 53, ctxt: 0 },
                 Return => ident { name: 54, ctxt: 0 },
                 Static => ident { name: 27, ctxt: 0 },
@@ -642,6 +643,8 @@ pub mod keywords {
                 Use => ident { name: 61, ctxt: 0 },
                 While => ident { name: 62, ctxt: 0 },
                 Be => ident { name: 64, ctxt: 0 },
+                Pure => ident { name: 65, ctxt: 0 },
+                Yield => ident { name: 66, ctxt: 0 },
             }
         }
     }
@@ -657,7 +660,7 @@ pub fn is_keyword(kw: keywords::Keyword, tok: &Token) -> bool {
 pub fn is_any_keyword(tok: &Token) -> bool {
     match *tok {
         token::IDENT(sid, false) => match sid.name {
-            8 | 27 | 32 .. 65 => true,
+            8 | 27 | 32 .. 66 => true,
             _ => false,
         },
         _ => false
@@ -677,7 +680,7 @@ pub fn is_strict_keyword(tok: &Token) -> bool {
 pub fn is_reserved_keyword(tok: &Token) -> bool {
     match *tok {
         token::IDENT(sid, false) => match sid.name {
-            64 .. 65 => true,
+            64 .. 66 => true,
             _ => false,
         },
         _ => false,

--- a/src/test/bench/task-perf-jargon-metal-smoke.rs
+++ b/src/test/bench/task-perf-jargon-metal-smoke.rs
@@ -31,7 +31,7 @@ fn child_generation(gens_left: uint, c: comm::Chan<()>) {
     do task::spawn_supervised {
         let c = c.take();
         if gens_left & 1 == 1 {
-            task::yield(); // shake things up a bit
+            task::deschedule(); // shake things up a bit
         }
         if gens_left > 0 {
             child_generation(gens_left - 1, c); // recurse

--- a/src/test/run-fail/extern-fail.rs
+++ b/src/test/run-fail/extern-fail.rs
@@ -35,7 +35,7 @@ extern fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
 
 fn count(n: uint) -> uint {
     unsafe {
-        task::yield();
+        task::deschedule();
         rustrt::rust_dbg_call(cb, n)
     }
 }

--- a/src/test/run-fail/linked-failure2.rs
+++ b/src/test/run-fail/linked-failure2.rs
@@ -21,5 +21,5 @@ fn child() { fail!(); }
 fn main() {
     let (p, _c) = comm::stream::<()>();
     task::spawn(|| child() );
-    task::yield();
+    task::deschedule();
 }

--- a/src/test/run-fail/task-comm-recv-block.rs
+++ b/src/test/run-fail/task-comm-recv-block.rs
@@ -15,7 +15,7 @@ use std::comm;
 use std::task;
 
 fn goodfail() {
-    task::yield();
+    task::deschedule();
     fail!("goodfail");
 }
 

--- a/src/test/run-pass/extern-stress.rs
+++ b/src/test/run-pass/extern-stress.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// This creates a bunch of yielding tasks that run concurrently
+// This creates a bunch of descheduling tasks that run concurrently
 // while holding onto C stacks
 
 use std::libc;
@@ -27,7 +27,7 @@ extern fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
     if data == 1u {
         data
     } else {
-        task::yield();
+        task::deschedule();
         count(data - 1u) + count(data - 1u)
     }
 }

--- a/src/test/run-pass/extern-yield.rs
+++ b/src/test/run-pass/extern-yield.rs
@@ -30,7 +30,7 @@ extern fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
 
 fn count(n: uint) -> uint {
     unsafe {
-        task::yield();
+        task::deschedule();
         rustrt::rust_dbg_call(cb, n)
     }
 }

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -110,7 +110,7 @@ pub mod pipes {
             let old_state = swap_state_acq(&mut (*p).state,
                                            blocked);
             match old_state {
-              empty | blocked => { task::yield(); }
+              empty | blocked => { task::deschedule(); }
               full => {
                 let payload = util::replace(&mut p.payload, None);
                 return Some(payload.unwrap())

--- a/src/test/run-pass/send-iloop.rs
+++ b/src/test/run-pass/send-iloop.rs
@@ -23,13 +23,13 @@ fn iloop() {
     task::spawn(|| die() );
     let (p, c) = comm::stream::<()>();
     loop {
-        // Sending and receiving here because these actions yield,
+        // Sending and receiving here because these actions deschedule,
         // at which point our child can kill us.
         c.send(());
         p.recv();
         // The above comment no longer makes sense but I'm
         // reluctant to remove a linked failure test case.
-        task::yield();
+        task::deschedule();
     }
 }
 

--- a/src/test/run-pass/spawn-fn.rs
+++ b/src/test/run-pass/spawn-fn.rs
@@ -21,5 +21,5 @@ pub fn main() {
     task::spawn(|| x(~"hello from second spawned fn", 66) );
     task::spawn(|| x(~"hello from third spawned fn", 67) );
     let mut i: int = 30;
-    while i > 0 { i = i - 1; info!("parent sleeping"); task::yield(); }
+    while i > 0 { i = i - 1; info!("parent sleeping"); task::deschedule(); }
 }

--- a/src/test/run-pass/task-comm-10.rs
+++ b/src/test/run-pass/task-comm-10.rs
@@ -36,5 +36,5 @@ pub fn main() {
     let c = p.recv();
     c.send(~"A");
     c.send(~"B");
-    task::yield();
+    task::deschedule();
 }

--- a/src/test/run-pass/task-comm-12.rs
+++ b/src/test/run-pass/task-comm-12.rs
@@ -28,7 +28,7 @@ fn test00() {
     // Sleep long enough for the task to finish.
     let mut i = 0;
     while i < 10000 {
-        task::yield();
+        task::deschedule();
         i += 1;
     }
 

--- a/src/test/run-pass/task-killjoin-rsrc.rs
+++ b/src/test/run-pass/task-killjoin-rsrc.rs
@@ -69,11 +69,11 @@ fn join(port: Port<bool>) -> bool {
 }
 
 fn supervised() {
-    // Yield to make sure the supervisor joins before we
+    // Deschedule to make sure the supervisor joins before we
     // fail. This is currently not needed because the supervisor
     // runs first, but I can imagine that changing.
     error!("supervised task=%?", 0);
-    task::yield();
+    task::deschedule();
     fail!();
 }
 

--- a/src/test/run-pass/task-killjoin.rs
+++ b/src/test/run-pass/task-killjoin.rs
@@ -19,10 +19,10 @@
 use std::task;
 
 fn supervised() {
-    // Yield to make sure the supervisor joins before we fail. This is
+    // Deschedule to make sure the supervisor joins before we fail. This is
     // currently not needed because the supervisor runs first, but I can
     // imagine that changing.
-    task::yield();
+    task::deschedule();
     fail!();
 }
 

--- a/src/test/run-pass/yield.rs
+++ b/src/test/run-pass/yield.rs
@@ -17,13 +17,13 @@ pub fn main() {
     builder.future_result(|r| { result = Some(r); });
     builder.spawn(child);
     error!("1");
-    task::yield();
+    task::deschedule();
     error!("2");
-    task::yield();
+    task::deschedule();
     error!("3");
     result.unwrap().recv();
 }
 
 fn child() {
-    error!("4"); task::yield(); error!("5"); task::yield(); error!("6");
+    error!("4"); task::deschedule(); error!("5"); task::deschedule(); error!("6");
 }

--- a/src/test/run-pass/yield1.rs
+++ b/src/test/run-pass/yield1.rs
@@ -17,7 +17,7 @@ pub fn main() {
     builder.future_result(|r| { result = Some(r); });
     builder.spawn(child);
     error!("1");
-    task::yield();
+    task::deschedule();
     result.unwrap().recv();
 }
 

--- a/src/test/run-pass/yield2.rs
+++ b/src/test/run-pass/yield2.rs
@@ -13,5 +13,5 @@ use std::task;
 
 pub fn main() {
     let mut i: int = 0;
-    while i < 100 { i = i + 1; error!(i); task::yield(); }
+    while i < 100 { i = i + 1; error!(i); task::deschedule(); }
 }


### PR DESCRIPTION
Rename task::yield() to task::deschedule().

Fixes #8494.
