### PR TITLE
Superkinds

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1076,6 +1076,9 @@ fn encode_info_for_item(ecx: &EncodeContext,
             ebml_w.end_tag();
         }
         encode_path(ecx, ebml_w, path, ast_map::path_name(item.ident));
+        // FIXME(#8559): This should use the tcx's supertrait cache instead of
+        // reading the AST's list, because the former has already filtered out
+        // the builtin-kinds-as-supertraits. See corresponding fixme in decoder.
         for ast_trait_ref in super_traits.iter() {
             let trait_ref = ty::node_id_to_trait_ref(ecx.tcx, ast_trait_ref.ref_id);
             encode_trait_ref(ebml_w, ecx, trait_ref, tag_item_super_trait_ref);

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -158,6 +158,12 @@ impl LanguageItems {
         }
     }
 
+    pub fn is_builtin_kind(&self, id: def_id) -> bool {
+        Some(id) == self.freeze_trait() ||
+        Some(id) == self.send_trait() ||
+        Some(id) == self.sized_trait()
+    }
+
     pub fn freeze_trait(&self) -> Option<def_id> {
         self.items[FreezeTraitLangItem as uint]
     }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -23,6 +23,7 @@
 use driver::session::Session;
 use metadata::csearch::each_lang_item;
 use metadata::cstore::iter_crate_data;
+use middle::ty::{BuiltinBound, BoundFreeze, BoundSend, BoundSized};
 use syntax::ast::{Crate, def_id, MetaItem};
 use syntax::ast_util::local_def;
 use syntax::attr::AttrMetaMethods;
@@ -158,10 +159,16 @@ impl LanguageItems {
         }
     }
 
-    pub fn is_builtin_kind(&self, id: def_id) -> bool {
-        Some(id) == self.freeze_trait() ||
-        Some(id) == self.send_trait() ||
-        Some(id) == self.sized_trait()
+    pub fn to_builtin_kind(&self, id: def_id) -> Option<BuiltinBound> {
+        if Some(id) == self.freeze_trait() {
+            Some(BoundFreeze)
+        } else if Some(id) == self.send_trait() {
+            Some(BoundSend)
+        } else if Some(id) == self.sized_trait() {
+            Some(BoundSized)
+        } else {
+            None
+        }
     }
 
     pub fn freeze_trait(&self) -> Option<def_id> {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -863,6 +863,7 @@ pub struct ty_param_bounds_and_ty {
 /// As `ty_param_bounds_and_ty` but for a trait ref.
 pub struct TraitDef {
     generics: Generics,
+    bounds: BuiltinBounds,
     trait_ref: @ty::TraitRef,
 }
 
@@ -3725,10 +3726,23 @@ pub fn impl_trait_ref(cx: ctxt, id: ast::def_id) -> Option<@TraitRef> {
     return ret;
 }
 
-pub fn trait_ref_is_builtin_kind(tcx: ctxt, tr: &ast::trait_ref) -> bool {
+pub fn trait_ref_to_def_id(tcx: ctxt, tr: &ast::trait_ref) -> ast::def_id {
     let def = tcx.def_map.find(&tr.ref_id).expect("no def-map entry for trait");
-    let def_id = ast_util::def_id_of_def(*def);
-    tcx.lang_items.is_builtin_kind(def_id)
+    ast_util::def_id_of_def(*def)
+}
+
+pub fn try_add_builtin_trait(tcx: ctxt,
+                             trait_def_id: ast::def_id,
+                             builtin_bounds: &mut BuiltinBounds) -> bool {
+    //! Checks whether `trait_ref` refers to one of the builtin
+    //! traits, like `Send`, and adds the corresponding
+    //! bound to the set `builtin_bounds` if so. Returns true if `trait_ref`
+    //! is a builtin trait.
+
+    match tcx.lang_items.to_builtin_kind(trait_def_id) {
+        Some(bound) => { builtin_bounds.add(bound); true }
+        None => false
+    }
 }
 
 pub fn ty_to_def_id(ty: t) -> Option<ast::def_id> {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3725,6 +3725,12 @@ pub fn impl_trait_ref(cx: ctxt, id: ast::def_id) -> Option<@TraitRef> {
     return ret;
 }
 
+pub fn trait_ref_is_builtin_kind(tcx: ctxt, tr: &ast::trait_ref) -> bool {
+    let def = tcx.def_map.find(&tr.ref_id).expect("no def-map entry for trait");
+    let def_id = ast_util::def_id_of_def(*def);
+    tcx.lang_items.is_builtin_kind(def_id)
+}
+
 pub fn ty_to_def_id(ty: t) -> Option<ast::def_id> {
     match get(ty).sty {
       ty_trait(id, _, _, _, _) | ty_struct(id, _) | ty_enum(id, _) => Some(id),

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -773,9 +773,8 @@ fn conv_builtin_bounds(tcx: ty::ctxt, ast_bounds: &Option<OptVec<ast::TyParamBou
                     ast::TraitTyParamBound(ref b) => {
                         match lookup_def_tcx(tcx, b.path.span, b.ref_id) {
                             ast::def_trait(trait_did) => {
-                                if try_add_builtin_trait(tcx,
-                                                         trait_did,
-                                                         &mut builtin_bounds) {
+                                if ty::try_add_builtin_trait(tcx, trait_did,
+                                                             &mut builtin_bounds) {
                                     loop; // success
                                 }
                             }
@@ -805,28 +804,5 @@ fn conv_builtin_bounds(tcx: ty::ctxt, ast_bounds: &Option<OptVec<ast::TyParamBou
         }
         // &'r Trait is sugar for &'r Trait:<no-bounds>.
         (&None, ty::RegionTraitStore(*)) => ty::EmptyBuiltinBounds(),
-    }
-}
-
-pub fn try_add_builtin_trait(tcx: ty::ctxt,
-                             trait_def_id: ast::def_id,
-                             builtin_bounds: &mut ty::BuiltinBounds) -> bool {
-    //! Checks whether `trait_ref` refers to one of the builtin
-    //! traits, like `Send`, and adds the corresponding
-    //! bound to the set `builtin_bounds` if so. Returns true if `trait_ref`
-    //! is a builtin trait.
-
-    let li = &tcx.lang_items;
-    if Some(trait_def_id) == li.send_trait() {
-        builtin_bounds.add(ty::BoundSend);
-        true
-    } else if Some(trait_def_id) == li.freeze_trait() {
-        builtin_bounds.add(ty::BoundFreeze);
-        true
-    } else if Some(trait_def_id) == li.sized_trait() {
-        builtin_bounds.add(ty::BoundSized);
-        true
-    } else {
-        false
     }
 }

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -398,28 +398,39 @@ pub fn ensure_supertraits(ccx: &CrateCtxt,
                           sp: codemap::span,
                           rp: Option<ty::region_variance>,
                           ast_trait_refs: &[ast::trait_ref],
-                          generics: &ast::Generics)
+                          generics: &ast::Generics) -> ty::BuiltinBounds
 {
     let tcx = ccx.tcx;
-    if tcx.supertraits.contains_key(&local_def(id)) { return; }
+
+    // Called only the first time trait_def_of_item is called.
+    // Supertraits are ensured at the same time.
+    assert!(!tcx.supertraits.contains_key(&local_def(id)));
 
     let self_ty = ty::mk_self(ccx.tcx, local_def(id));
     let mut ty_trait_refs: ~[@ty::TraitRef] = ~[];
+    let mut bounds = ty::EmptyBuiltinBounds();
     for ast_trait_ref in ast_trait_refs.iter() {
+        let trait_def_id = ty::trait_ref_to_def_id(ccx.tcx, ast_trait_ref);
+        // FIXME(#8559): Need to instantiate the trait_ref whether or not it's a
+        // builtin trait, so that the trait's node id appears in the tcx trait_ref
+        // map. This is only needed for metadata; see the similar fixme in encoder.rs.
         let trait_ref = instantiate_trait_ref(ccx, ast_trait_ref, rp,
                                               generics, self_ty);
+        if !ty::try_add_builtin_trait(ccx.tcx, trait_def_id, &mut bounds) {
 
-        // FIXME(#5527) Could have same trait multiple times
-        if ty_trait_refs.iter().any(|other_trait| other_trait.def_id == trait_ref.def_id) {
-            // This means a trait inherited from the same supertrait more
-            // than once.
-            tcx.sess.span_err(sp, "Duplicate supertrait in trait declaration");
-            break;
-        } else {
-            ty_trait_refs.push(trait_ref);
+            // FIXME(#5527) Could have same trait multiple times
+            if ty_trait_refs.iter().any(|other_trait| other_trait.def_id == trait_ref.def_id) {
+                // This means a trait inherited from the same supertrait more
+                // than once.
+                tcx.sess.span_err(sp, "Duplicate supertrait in trait declaration");
+                break;
+            } else {
+                ty_trait_refs.push(trait_ref);
+            }
         }
     }
     tcx.supertraits.insert(local_def(id), @ty_trait_refs);
+    bounds
 }
 
 /**
@@ -870,8 +881,9 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::item) {
                                   parent_visibility);
         for t in opt_trait_ref.iter() {
             // Prevent the builtin kind traits from being manually implemented.
-            if ty::trait_ref_is_builtin_kind(ccx.tcx, t) {
-                ccx.tcx.sess.span_err(it.span,
+            let trait_def_id = ty::trait_ref_to_def_id(tcx, t);
+            if tcx.lang_items.to_builtin_kind(trait_def_id).is_some() {
+                tcx.sess.span_err(it.span,
                     "cannot provide an explicit implementation \
                      for a builtin kind");
             }
@@ -879,11 +891,9 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::item) {
             check_methods_against_trait(ccx, generics, rp, selfty, t, cms);
         }
       }
-      ast::item_trait(ref generics, ref supertraits, ref trait_methods) => {
-          let trait_def = trait_def_of_item(ccx, it);
-          tcx.trait_defs.insert(local_def(it.id), trait_def);
+      ast::item_trait(ref generics, _, ref trait_methods) => {
+          let _trait_def = trait_def_of_item(ccx, it);
           ensure_trait_methods(ccx, it.id);
-          ensure_supertraits(ccx, it.id, it.span, rp, *supertraits, generics);
 
           let (_, provided_methods) =
               split_trait_methods(*trait_methods);
@@ -1039,13 +1049,16 @@ pub fn trait_def_of_item(ccx: &CrateCtxt, it: &ast::item) -> @ty::TraitDef {
     }
     let rp = tcx.region_paramd_items.find(&it.id).map_move(|x| *x);
     match it.node {
-        ast::item_trait(ref generics, _, _) => {
+        ast::item_trait(ref generics, ref supertraits, _) => {
             let self_ty = ty::mk_self(tcx, def_id);
             let (ty_generics, substs) = mk_item_substs(ccx, generics, rp,
                                                        Some(self_ty));
+            let bounds = ensure_supertraits(ccx, it.id, it.span, rp,
+                                            *supertraits, generics);
             let trait_ref = @ty::TraitRef {def_id: def_id,
                                            substs: substs};
             let trait_def = @ty::TraitDef {generics: ty_generics,
+                                           bounds: bounds,
                                            trait_ref: trait_ref};
             tcx.trait_defs.insert(def_id, trait_def);
             return trait_def;
@@ -1225,7 +1238,7 @@ pub fn ty_generics(ccx: &CrateCtxt,
                 TraitTyParamBound(ref b) => {
                     let ty = ty::mk_param(ccx.tcx, param_ty.idx, param_ty.def_id);
                     let trait_ref = instantiate_trait_ref(ccx, b, rp, generics, ty);
-                    if !astconv::try_add_builtin_trait(
+                    if !ty::try_add_builtin_trait(
                         ccx.tcx, trait_ref.def_id,
                         &mut param_bounds.builtin_bounds)
                     {

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -869,6 +869,13 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::item) {
                                   &i_ty_generics, generics,
                                   parent_visibility);
         for t in opt_trait_ref.iter() {
+            // Prevent the builtin kind traits from being manually implemented.
+            if ty::trait_ref_is_builtin_kind(ccx.tcx, t) {
+                ccx.tcx.sess.span_err(it.span,
+                    "cannot provide an explicit implementation \
+                     for a builtin kind");
+            }
+
             check_methods_against_trait(ccx, generics, rp, selfty, t, cms);
         }
       }

--- a/src/test/auxiliary/trait_superkinds_in_metadata.rs
+++ b/src/test/auxiliary/trait_superkinds_in_metadata.rs
@@ -8,7 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Test library crate for cross-crate usages of traits inheriting
+// from the builtin kinds. Mostly tests metadata correctness.
+
 #[crate_type="lib"];
 
-pub trait Bar : Freeze { }
-pub trait Foo : Bar + Send { }
+pub trait RequiresFreeze : Freeze { }
+pub trait RequiresRequiresFreezeAndSend : RequiresFreeze + Send { }

--- a/src/test/auxiliary/trait_superkinds_in_metadata.rs
+++ b/src/test/auxiliary/trait_superkinds_in_metadata.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_type="lib"];
+
+pub trait Bar : Freeze { }
+pub trait Foo : Bar + Send { }

--- a/src/test/compile-fail/builtin-superkinds-double-superkind.rs
+++ b/src/test/compile-fail/builtin-superkinds-double-superkind.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo : Send+Freeze { }
+
+impl <T: Freeze> Foo for (T,) { } //~ ERROR cannot implement this trait
+
+impl <T: Send> Foo for (T,T) { } //~ ERROR cannot implement this trait
+
+impl <T: Send+Freeze> Foo for (T,T,T) { } // (ok)
+
+fn main() { }

--- a/src/test/compile-fail/builtin-superkinds-double-superkind.rs
+++ b/src/test/compile-fail/builtin-superkinds-double-superkind.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Test for traits that inherit from multiple builtin kinds at once,
+// testing that all such kinds must be present on implementing types.
+
 trait Foo : Send+Freeze { }
 
 impl <T: Freeze> Foo for (T,) { } //~ ERROR cannot implement this trait

--- a/src/test/compile-fail/builtin-superkinds-in-metadata.rs
+++ b/src/test/compile-fail/builtin-superkinds-in-metadata.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:trait_superkinds_in_metadata.rs
+
+extern mod trait_superkinds_in_metadata;
+use trait_superkinds_in_metadata::{Foo, Bar};
+
+struct X<T>(T);
+
+impl <T:Freeze> Bar for X<T> { }
+
+impl <T:Freeze> Foo for X<T> { } //~ ERROR cannot implement this trait
+
+fn main() { }

--- a/src/test/compile-fail/builtin-superkinds-in-metadata.rs
+++ b/src/test/compile-fail/builtin-superkinds-in-metadata.rs
@@ -10,13 +10,16 @@
 
 // aux-build:trait_superkinds_in_metadata.rs
 
+// Test for traits inheriting from the builtin kinds cross-crate.
+// Mostly tests correctness of metadata.
+
 extern mod trait_superkinds_in_metadata;
-use trait_superkinds_in_metadata::{Foo, Bar};
+use trait_superkinds_in_metadata::{RequiresRequiresFreezeAndSend, RequiresFreeze};
 
 struct X<T>(T);
 
-impl <T:Freeze> Bar for X<T> { }
+impl <T:Freeze> RequiresFreeze for X<T> { }
 
-impl <T:Freeze> Foo for X<T> { } //~ ERROR cannot implement this trait
+impl <T:Freeze> RequiresRequiresFreezeAndSend for X<T> { } //~ ERROR cannot implement this trait
 
 fn main() { }

--- a/src/test/compile-fail/builtin-superkinds-in-metadata.rs
+++ b/src/test/compile-fail/builtin-superkinds-in-metadata.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-fast
+
 // aux-build:trait_superkinds_in_metadata.rs
 
 // Test for traits inheriting from the builtin kinds cross-crate.

--- a/src/test/compile-fail/builtin-superkinds-self-type.rs
+++ b/src/test/compile-fail/builtin-superkinds-self-type.rs
@@ -11,8 +11,10 @@
 // Tests (negatively) the ability for the Self type in default methods
 // to use capabilities granted by builtin kinds as supertraits.
 
+use std::comm;
+
 trait Foo : Freeze {
-    fn foo(self, chan: std::comm::Chan<Self>) {
+    fn foo(self, chan: comm::Chan<Self>) {
         chan.send(self); //~ ERROR does not fulfill `Send`
     }
 }
@@ -20,7 +22,7 @@ trait Foo : Freeze {
 impl <T: Freeze> Foo for T { }
 
 fn main() {
-    let (p,c) = std::comm::stream();
+    let (p,c) = comm::stream();
     1193182.foo(c);
     assert!(p.recv() == 1193182);
 }

--- a/src/test/compile-fail/builtin-superkinds-self-type.rs
+++ b/src/test/compile-fail/builtin-superkinds-self-type.rs
@@ -1,0 +1,26 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests (negatively) the ability for the Self type in default methods
+// to use capabilities granted by builtin kinds as supertraits.
+
+trait Foo : Freeze {
+    fn foo(self, chan: std::comm::Chan<Self>) {
+        chan.send(self); //~ ERROR does not fulfill `Send`
+    }
+}
+
+impl <T: Freeze> Foo for T { }
+
+fn main() {
+    let (p,c) = std::comm::stream();
+    1193182.foo(c);
+    assert!(p.recv() == 1193182);
+}

--- a/src/test/compile-fail/builtin-superkinds-simple.rs
+++ b/src/test/compile-fail/builtin-superkinds-simple.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Basic test for traits inheriting from the builtin kinds, checking
+// the type contents of the implementing type (that's not a typaram).
+
 trait Foo : Send { }
 
 impl <'self> Foo for &'self mut () { } //~ ERROR cannot implement this trait

--- a/src/test/compile-fail/builtin-superkinds-simple.rs
+++ b/src/test/compile-fail/builtin-superkinds-simple.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo : Send { }
+
+impl <'self> Foo for &'self mut () { } //~ ERROR cannot implement this trait
+
+trait Bar : Freeze { }
+
+impl <'self> Bar for &'self mut () { } //~ ERROR cannot implement this trait
+
+fn main() { }

--- a/src/test/compile-fail/builtin-superkinds-typaram-not-send.rs
+++ b/src/test/compile-fail/builtin-superkinds-typaram-not-send.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo : Send { }
+
+impl <T: Freeze> Foo for T { } //~ ERROR cannot implement this trait
+
+fn main() { }

--- a/src/test/compile-fail/builtin-superkinds-typaram-not-send.rs
+++ b/src/test/compile-fail/builtin-superkinds-typaram-not-send.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Basic test for traits inheriting from the builtin kinds.
+
 trait Foo : Send { }
 
 impl <T: Freeze> Foo for T { } //~ ERROR cannot implement this trait

--- a/src/test/compile-fail/cant-implement-builtin-kinds.rs
+++ b/src/test/compile-fail/cant-implement-builtin-kinds.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// See issue #8517 for why this should be illegal.
+
+struct X<T>(T);
+
+impl <T> Send for X<T> { } //~ ERROR cannot provide an explicit implementation for a builtin kind
+impl <T> Sized for X<T> { } //~ ERROR cannot provide an explicit implementation for a builtin kind
+impl <T> Freeze for X<T> { } //~ ERROR cannot provide an explicit implementation for a builtin kind
+
+fn main() { }

--- a/src/test/run-pass/builtin-superkinds-capabilities-transitive.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities-transitive.rs
@@ -14,18 +14,20 @@
 // a Send. Basically this just makes sure rustc is using
 // each_bound_trait_and_supertraits in type_contents correctly.
 
+use std::comm;
+
 trait Bar : Send { }
 trait Foo : Bar { }
 
 impl <T: Send> Foo for T { }
 impl <T: Send> Bar for T { }
 
-fn foo<T: Foo>(val: T, chan: std::comm::Chan<T>) {
+fn foo<T: Foo>(val: T, chan: comm::Chan<T>) {
     chan.send(val);
 }
 
 fn main() {
-    let (p,c) = std::comm::stream();
+    let (p,c) = comm::stream();
     foo(31337, c);
     assert!(p.recv() == 31337);
 }

--- a/src/test/run-pass/builtin-superkinds-capabilities-transitive.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities-transitive.rs
@@ -1,0 +1,25 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Bar : Send { }
+trait Foo : Bar { }
+
+impl <T: Send> Foo for T { }
+impl <T: Send> Bar for T { }
+
+fn foo<T: Foo>(val: T, chan: std::comm::Chan<T>) {
+    chan.send(val);
+}
+
+fn main() {
+    let (p,c) = std::comm::stream();
+    foo(31337, c);
+    assert!(p.recv() == 31337);
+}

--- a/src/test/run-pass/builtin-superkinds-capabilities-transitive.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities-transitive.rs
@@ -8,6 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Tests "transitivity" of super-builtin-kinds on traits. Here, if
+// we have a Foo, we know we have a Bar, and if we have a Bar, we
+// know we have a Send. So if we have a Foo we should know we have
+// a Send. Basically this just makes sure rustc is using
+// each_bound_trait_and_supertraits in type_contents correctly.
+
 trait Bar : Send { }
 trait Foo : Bar { }
 

--- a/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
@@ -1,0 +1,30 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:trait_superkinds_in_metadata.rs
+
+extern mod trait_superkinds_in_metadata;
+use trait_superkinds_in_metadata::{Foo, Bar};
+
+#[deriving(Eq)]
+struct X<T>(T);
+
+impl <T: Freeze> Bar for X<T> { }
+impl <T: Freeze+Send> Foo for X<T> { }
+
+fn foo<T: Foo>(val: T, chan: std::comm::Chan<T>) {
+    chan.send(val);
+}
+
+fn main() {
+    let (p,c) = std::comm::stream();
+    foo(X(31337), c);
+    assert!(p.recv() == X(31337));
+}

--- a/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
@@ -17,6 +17,7 @@
 
 extern mod trait_superkinds_in_metadata;
 use trait_superkinds_in_metadata::{RequiresRequiresFreezeAndSend, RequiresFreeze};
+use std::comm;
 
 #[deriving(Eq)]
 struct X<T>(T);
@@ -24,12 +25,12 @@ struct X<T>(T);
 impl <T: Freeze> RequiresFreeze for X<T> { }
 impl <T: Freeze+Send> RequiresRequiresFreezeAndSend for X<T> { }
 
-fn foo<T: RequiresRequiresFreezeAndSend>(val: T, chan: std::comm::Chan<T>) {
+fn foo<T: RequiresRequiresFreezeAndSend>(val: T, chan: comm::Chan<T>) {
     chan.send(val);
 }
 
 fn main() {
-    let (p,c) = std::comm::stream();
+    let (p,c) = comm::stream();
     foo(X(31337), c);
     assert!(p.recv() == X(31337));
 }

--- a/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-fast
+
 // aux-build:trait_superkinds_in_metadata.rs
 
 // Tests "capabilities" granted by traits with super-builtin-kinds,

--- a/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
@@ -10,16 +10,19 @@
 
 // aux-build:trait_superkinds_in_metadata.rs
 
+// Tests "capabilities" granted by traits with super-builtin-kinds,
+// even when using them cross-crate.
+
 extern mod trait_superkinds_in_metadata;
-use trait_superkinds_in_metadata::{Foo, Bar};
+use trait_superkinds_in_metadata::{RequiresRequiresFreezeAndSend, RequiresFreeze};
 
 #[deriving(Eq)]
 struct X<T>(T);
 
-impl <T: Freeze> Bar for X<T> { }
-impl <T: Freeze+Send> Foo for X<T> { }
+impl <T: Freeze> RequiresFreeze for X<T> { }
+impl <T: Freeze+Send> RequiresRequiresFreezeAndSend for X<T> { }
 
-fn foo<T: Foo>(val: T, chan: std::comm::Chan<T>) {
+fn foo<T: RequiresRequiresFreezeAndSend>(val: T, chan: std::comm::Chan<T>) {
     chan.send(val);
 }
 

--- a/src/test/run-pass/builtin-superkinds-capabilities.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities.rs
@@ -12,16 +12,18 @@
 // builtin-kinds, e.g., if a trait requires Send to implement, then
 // at usage site of that trait, we know we have the Send capability.
 
+use std::comm;
+
 trait Foo : Send { }
 
 impl <T: Send> Foo for T { }
 
-fn foo<T: Foo>(val: T, chan: std::comm::Chan<T>) {
+fn foo<T: Foo>(val: T, chan: comm::Chan<T>) {
     chan.send(val);
 }
 
 fn main() {
-    let (p,c) = std::comm::stream();
+    let (p,c) = comm::stream();
     foo(31337, c);
     assert!(p.recv() == 31337);
 }

--- a/src/test/run-pass/builtin-superkinds-capabilities.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities.rs
@@ -1,0 +1,23 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo : Send { }
+
+impl <T: Send> Foo for T { }
+
+fn foo<T: Foo>(val: T, chan: std::comm::Chan<T>) {
+    chan.send(val);
+}
+
+fn main() {
+    let (p,c) = std::comm::stream();
+    foo(31337, c);
+    assert!(p.recv() == 31337);
+}

--- a/src/test/run-pass/builtin-superkinds-capabilities.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Tests "capabilities" granted by traits that inherit from super-
+// builtin-kinds, e.g., if a trait requires Send to implement, then
+// at usage site of that trait, we know we have the Send capability.
+
 trait Foo : Send { }
 
 impl <T: Send> Foo for T { }

--- a/src/test/run-pass/builtin-superkinds-in-metadata.rs
+++ b/src/test/run-pass/builtin-superkinds-in-metadata.rs
@@ -10,13 +10,15 @@
 
 // aux-build:trait_superkinds_in_metadata.rs
 
+// Tests (correct) usage of trait super-builtin-kinds cross-crate.
+
 extern mod trait_superkinds_in_metadata;
-use trait_superkinds_in_metadata::{Foo, Bar};
+use trait_superkinds_in_metadata::{RequiresRequiresFreezeAndSend, RequiresFreeze};
 
 struct X<T>(T);
 
-impl <T:Freeze> Bar for X<T> { }
+impl <T:Freeze> RequiresFreeze for X<T> { }
 
-impl <T:Freeze+Send> Foo for X<T> { }
+impl <T:Freeze+Send> RequiresRequiresFreezeAndSend for X<T> { }
 
 fn main() { }

--- a/src/test/run-pass/builtin-superkinds-in-metadata.rs
+++ b/src/test/run-pass/builtin-superkinds-in-metadata.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:trait_superkinds_in_metadata.rs
+
+extern mod trait_superkinds_in_metadata;
+use trait_superkinds_in_metadata::{Foo, Bar};
+
+struct X<T>(T);
+
+impl <T:Freeze> Bar for X<T> { }
+
+impl <T:Freeze+Send> Foo for X<T> { }
+
+fn main() { }

--- a/src/test/run-pass/builtin-superkinds-in-metadata.rs
+++ b/src/test/run-pass/builtin-superkinds-in-metadata.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-fast
+
 // aux-build:trait_superkinds_in_metadata.rs
 
 // Tests (correct) usage of trait super-builtin-kinds cross-crate.

--- a/src/test/run-pass/builtin-superkinds-phantom-typaram.rs
+++ b/src/test/run-pass/builtin-superkinds-phantom-typaram.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Tests that even when a type paramenter doesn't implement a required
+// super-builtin-kind of a trait, if the type parameter is never used,
+// the type can implement the trait anyway.
+
 trait Foo : Send { }
 
 struct X<T>(());

--- a/src/test/run-pass/builtin-superkinds-self-type.rs
+++ b/src/test/run-pass/builtin-superkinds-self-type.rs
@@ -1,0 +1,26 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests the ability for the Self type in default methods to use
+// capabilities granted by builtin kinds as supertraits.
+
+trait Foo : Send {
+    fn foo(self, chan: std::comm::Chan<Self>) {
+        chan.send(self);
+    }
+}
+
+impl <T: Send> Foo for T { }
+
+fn main() {
+    let (p,c) = std::comm::stream();
+    1193182.foo(c);
+    assert!(p.recv() == 1193182);
+}

--- a/src/test/run-pass/builtin-superkinds-self-type.rs
+++ b/src/test/run-pass/builtin-superkinds-self-type.rs
@@ -11,8 +11,10 @@
 // Tests the ability for the Self type in default methods to use
 // capabilities granted by builtin kinds as supertraits.
 
+use std::comm;
+
 trait Foo : Send {
-    fn foo(self, chan: std::comm::Chan<Self>) {
+    fn foo(self, chan: comm::Chan<Self>) {
         chan.send(self);
     }
 }
@@ -20,7 +22,7 @@ trait Foo : Send {
 impl <T: Send> Foo for T { }
 
 fn main() {
-    let (p,c) = std::comm::stream();
+    let (p,c) = comm::stream();
     1193182.foo(c);
     assert!(p.recv() == 1193182);
 }

--- a/src/test/run-pass/builtin-superkinds-shadow-typaram.rs
+++ b/src/test/run-pass/builtin-superkinds-shadow-typaram.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo : Send { }
+
+struct X<T>(());
+
+impl <T> Foo for X<T> { }
+
+fn main() { }

--- a/src/test/run-pass/builtin-superkinds-simple.rs
+++ b/src/test/run-pass/builtin-superkinds-simple.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo : Send { }
+
+impl Foo for int { }
+
+fn main() { }

--- a/src/test/run-pass/builtin-superkinds-simple.rs
+++ b/src/test/run-pass/builtin-superkinds-simple.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Simple test case of implementing a trait with super-builtin-kinds.
+
 trait Foo : Send { }
 
 impl Foo for int { }

--- a/src/test/run-pass/builtin-superkinds-typaram.rs
+++ b/src/test/run-pass/builtin-superkinds-typaram.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo : Send { }
+
+impl <T: Send> Foo for T { }
+
+fn main() { }

--- a/src/test/run-pass/builtin-superkinds-typaram.rs
+++ b/src/test/run-pass/builtin-superkinds-typaram.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Tests correct implementation of traits with super-builtin-kinds
+// using a bounded type parameter.
+
 trait Foo : Send { }
 
 impl <T: Send> Foo for T { }


### PR DESCRIPTION
For #7083.

The metadata issue with the old version is now fixed. Ready for review.

This is also not the full solution to #7083, because this is not supported yet:

```
trait Foo : Send { }

impl <T: Send> Foo for T { }

fn foo<T: Foo>(val: T, chan: std::comm::Chan<T>) {
    chan.send(val);
}
```

cc @nikomatsakis
