### PR TITLE
Fix typo in test/bench/noise.rs. Closes #8574.

### DIFF
--- a/src/test/bench/noise.rs
+++ b/src/test/bench/noise.rs
@@ -26,7 +26,7 @@ fn random_gradient<R:Rng>(r: &mut R) -> Vec2 {
 
 fn gradient(orig: Vec2, grad: Vec2, p: Vec2) -> f32 {
     let sp = Vec2 {x: p.x - orig.x, y: p.y - orig.y};
-    grad.x * sp.x + grad.y + sp.y
+    grad.x * sp.x + grad.y * sp.y
 }
 
 struct Noise2DContext {


### PR DESCRIPTION
Well, here's the pull request for the issue. :)
