### PR TITLE
Fix segfault when calling tuple struct constructor as extern fn

### DIFF
--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -795,14 +795,18 @@ fn trans_def_dps_unadjusted(bcx: @mut Block, ref_expr: &ast::expr,
                 return bcx;
             }
         }
-        ast::def_struct(*) => {
+        ast::def_struct(def_id) => {
             let ty = expr_ty(bcx, ref_expr);
             match ty::get(ty).sty {
                 ty::ty_struct(did, _) if ty::has_dtor(ccx.tcx, did) => {
                     let repr = adt::represent_type(ccx, ty);
                     adt::trans_start_init(bcx, repr, lldest, 0);
                 }
-                _ => {}
+                ty::ty_bare_fn(*) => {
+                    let fn_data = callee::trans_fn_ref(bcx, def_id, ref_expr.id);
+                    Store(bcx, fn_data.llfn, lldest);
+                }
+                _ => ()
             }
             return bcx;
         }

--- a/src/test/run-pass/tuple-struct-constructor-pointer.rs
+++ b/src/test/run-pass/tuple-struct-constructor-pointer.rs
@@ -1,0 +1,19 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo(int);
+struct Bar(int, int);
+
+fn main() {
+    let f: extern fn(int) -> Foo = Foo;
+    let g: extern fn(int, int) -> Bar = Bar;
+    f(42);
+    g(4, 7);
+}

--- a/src/test/run-pass/tuple-struct-constructor-pointer.rs
+++ b/src/test/run-pass/tuple-struct-constructor-pointer.rs
@@ -8,12 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[deriving(Eq)]
 struct Foo(int);
+#[deriving(Eq)]
 struct Bar(int, int);
 
 fn main() {
     let f: extern fn(int) -> Foo = Foo;
     let g: extern fn(int, int) -> Bar = Bar;
-    f(42);
-    g(4, 7);
+    assert_eq!(f(42), Foo(42));
+    assert_eq!(g(4, 7), Bar(4, 7));
 }


### PR DESCRIPTION
Fixes #5315
