### PR TITLE
Make rekillable consistent with unkillable

### DIFF
--- a/src/libstd/rt/kill.rs
+++ b/src/libstd/rt/kill.rs
@@ -647,7 +647,9 @@ impl Death {
     /// All calls must be paired with a preceding call to inhibit_kill.
     #[inline]
     pub fn allow_kill(&mut self, already_failing: bool) {
-        rtassert!(self.unkillable != 0);
+        if self.unkillable == 0 {
+            fail!("illegal call of rekillable");
+        }
         self.unkillable -= 1;
         if self.unkillable == 0 {
             rtassert!(self.kill_handle.is_some());

--- a/src/libstd/rt/kill.rs
+++ b/src/libstd/rt/kill.rs
@@ -648,7 +648,9 @@ impl Death {
     #[inline]
     pub fn allow_kill(&mut self, already_failing: bool) {
         if self.unkillable == 0 {
-            fail!("illegal call of rekillable");
+            // we need to decrement the counter before failing.
+            self.unkillable -= 1;
+            fail!("Cannot enter a rekillable() block without a surrounding unkillable()");
         }
         self.unkillable -= 1;
         if self.unkillable == 0 {

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -651,8 +651,8 @@ fn test_kill_unkillable_task() {
     }
 }
 
-#[ignore(reason = "linked failure")]
 #[test]
+#[ignore(cfg(windows))]
 fn test_kill_rekillable_task() {
     use rt::test::*;
 
@@ -672,8 +672,8 @@ fn test_kill_rekillable_task() {
 }
 
 #[test]
-#[ignore(cfg(windows))]
 #[should_fail]
+#[ignore(cfg(windows))]
 fn test_rekillable_not_nested() {
     do rekillable {
         // This should fail before

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -680,7 +680,7 @@ fn test_rekillable_not_nested() {
         // receiving anything since
         // this block should be nested
         // into a unkillable block.
-        yield();
+        deschedule();
     }
 }
 

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -598,7 +598,8 @@ pub fn unkillable<U>(f: &fn() -> U) -> U {
 }
 
 /**
- * Makes killable a task marked as unkillable
+ * Makes killable a task marked as unkillable. This
+ * is meant to be used only nested in unkillable.
  *
  * # Example
  *
@@ -607,6 +608,7 @@ pub fn unkillable<U>(f: &fn() -> U) -> U {
  *     do task::rekillable {
  *          // Task is killable
  *     }
+ *    // Task is unkillable again
  * }
  */
 pub fn rekillable<U>(f: &fn() -> U) -> U {
@@ -1235,6 +1237,20 @@ fn test_unkillable_nested() {
 
     // Now we can be killed
     po.recv();
+}
+
+#[ignore(reason = "linked failure")]
+#[test]
+#[ignore(cfg(windows))]
+#[should_fail]
+fn test_rekillable_not_nested() {
+    do rekillable {
+        // This should fail before
+        // receiving anything since
+        // this block should be nested
+        // into a unkillable block.
+        yield();
+    }
 }
 
 #[test]

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -696,7 +696,7 @@ fn test_rekillable_nested_failure() {
                 do task::spawn { chan.send(()); fail!(); }
                 port.recv(); // wait for child to exist
                 port.recv(); // block forever, expect to get killed.
-            } 
+            }
         }
     };
     assert!(result.is_err());


### PR DESCRIPTION
As for now, rekillable is an unsafe function, instead, it should behave
just like unkillable by encapsulating unsafe code within an unsafe
block.

This patch does that and removes unsafe blocks that were encapsulating
rekillable calls throughout rust's libs.

Fixes #8232
