### PR TITLE
extract_grammar

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -788,7 +788,7 @@ extern mod complicated_mod = "some-file/in/the-rust/path";
 ##### Use declarations
 
 ~~~~~~~~ {.ebnf .gram}
-use_decl : "pub"? "use" ident [ '=' path
+use_decl : "pub" ? "use" ident [ '=' path
                           | "::" path_glob ] ;
 
 path_glob : ident [ "::" path_glob ] ?
@@ -1920,7 +1920,7 @@ it is automatically derferenced to make the field access possible.
 ### Vector expressions
 
 ~~~~~~~~{.ebnf .gram}
-vec_expr : '[' "mut"? vec_elems? ']'
+vec_expr : '[' "mut" ? vec_elems? ']'
 
 vec_elems : [expr [',' expr]*] | [expr ',' ".." expr]
 ~~~~~~~~

--- a/src/etc/extract_grammar.py
+++ b/src/etc/extract_grammar.py
@@ -93,7 +93,11 @@ symnames = {
 
 "//": "linecomment",
 "/*": "openblockcomment",
-"*/": "closeblockcomment"
+"*/": "closeblockcomment",
+"macro_rules": "macro_rules",
+"=>" : "eg",
+".." : "dotdot",
+","  : "comma"
 }
 
 lines = []


### PR DESCRIPTION
This fixes some errors which extract_grammar.py reports, when called with

python2.7 src/etc/extract_grammar.py <doc/rust.md
