### PR TITLE
Stack unwinding for 32 bit Windows builds

### DIFF
--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -612,7 +612,7 @@ mod tests {
         }
     }
 
-    #[test] #[should_fail] #[ignore(cfg(windows))]
+    #[test] #[should_fail]
     fn test_arc_condvar_poison() {
         unsafe {
             let arc = ~MutexArc::new(1);
@@ -636,7 +636,7 @@ mod tests {
             }
         }
     }
-    #[test] #[should_fail] #[ignore(cfg(windows))]
+    #[test] #[should_fail]
     fn test_mutex_arc_poison() {
         unsafe {
             let arc = ~MutexArc::new(1);
@@ -651,7 +651,7 @@ mod tests {
             }
         }
     }
-    #[test] #[should_fail] #[ignore(cfg(windows))]
+    #[test] #[should_fail]
     pub fn test_mutex_arc_unwrap_poison() {
         let arc = MutexArc::new(1);
         let arc2 = ~(&arc).clone();
@@ -668,7 +668,7 @@ mod tests {
         let one = arc.unwrap();
         assert!(one == 1);
     }
-    #[test] #[should_fail] #[ignore(cfg(windows))]
+    #[test] #[should_fail]
     fn test_rw_arc_poison_wr() {
         let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
@@ -681,7 +681,7 @@ mod tests {
             assert_eq!(*one, 1);
         }
     }
-    #[test] #[should_fail] #[ignore(cfg(windows))]
+    #[test] #[should_fail]
     fn test_rw_arc_poison_ww() {
         let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
@@ -694,7 +694,7 @@ mod tests {
             assert_eq!(*one, 1);
         }
     }
-    #[test] #[should_fail] #[ignore(cfg(windows))]
+    #[test] #[should_fail]
     fn test_rw_arc_poison_dw() {
         let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
@@ -709,7 +709,7 @@ mod tests {
             assert_eq!(*one, 1);
         }
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_rw_arc_no_poison_rr() {
         let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
@@ -722,7 +722,7 @@ mod tests {
             assert_eq!(*one, 1);
         }
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_rw_arc_no_poison_rw() {
         let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();
@@ -735,7 +735,7 @@ mod tests {
             assert_eq!(*one, 1);
         }
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_rw_arc_no_poison_dr() {
         let arc = ~RWArc::new(1);
         let arc2 = (*arc).clone();

--- a/src/libextra/arena.rs
+++ b/src/libextra/arena.rs
@@ -291,7 +291,6 @@ fn test_arena_destructors() {
 
 #[test]
 #[should_fail]
-#[ignore(cfg(windows))]
 fn test_arena_destructors_fail() {
     let arena = Arena::new();
     // Put some stuff in the arena.

--- a/src/libextra/c_vec.rs
+++ b/src/libextra/c_vec.rs
@@ -185,7 +185,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_overrun_get() {
         let cv = malloc(16u as size_t);
 
@@ -194,7 +193,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_overrun_set() {
         let cv = malloc(16u as size_t);
 

--- a/src/libextra/flatpipes.rs
+++ b/src/libextra/flatpipes.rs
@@ -967,12 +967,10 @@ mod test {
         }
 
         #[test]
-        #[ignore(cfg(windows))]
         fn test_try_recv_none4_reader() {
             test_try_recv_none4(reader_port_loader);
         }
         #[test]
-        #[ignore(cfg(windows))]
         fn test_try_recv_none4_pipe() {
             test_try_recv_none4(pipe_port_loader);
         }

--- a/src/libextra/future.rs
+++ b/src/libextra/future.rs
@@ -212,7 +212,6 @@ mod test {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(target_os = "win32"))]
     fn test_futurefail() {
         let mut f = spawn(|| fail!());
         let _x: ~str = f.get();

--- a/src/libextra/priority_queue.rs
+++ b/src/libextra/priority_queue.rs
@@ -338,7 +338,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_empty_pop() { let mut heap = PriorityQueue::new::<int>(); heap.pop(); }
 
     #[test]
@@ -349,7 +348,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_empty_top() { let empty = PriorityQueue::new::<int>(); empty.top(); }
 
     #[test]
@@ -360,7 +358,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_empty_replace() { let mut heap = PriorityQueue::new(); heap.replace(5); }
 
     #[test]

--- a/src/libextra/sync.rs
+++ b/src/libextra/sync.rs
@@ -921,7 +921,7 @@ mod tests {
             assert!(!cond.signal());
         }
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_mutex_killed_simple() {
         // Mutex must get automatically unlocked if failed/killed within.
         let m = ~Mutex::new();
@@ -937,7 +937,7 @@ mod tests {
         do m.lock { }
     }
     #[ignore(reason = "linked failure")]
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_mutex_killed_cond() {
         // Getting killed during cond wait must not corrupt the mutex while
         // unwinding (e.g. double unlock).
@@ -964,7 +964,7 @@ mod tests {
         }
     }
     #[ignore(reason = "linked failure")]
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_mutex_killed_broadcast() {
         use std::unstable::finally::Finally;
 
@@ -1024,7 +1024,7 @@ mod tests {
             cond.wait();
         }
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_mutex_different_conds() {
         let result = do task::try {
             let m = ~Mutex::new_with_condvars(2);
@@ -1045,7 +1045,7 @@ mod tests {
         };
         assert!(result.is_err());
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_mutex_no_condvars() {
         let result = do task::try {
             let m = ~Mutex::new_with_condvars(0);
@@ -1275,7 +1275,7 @@ mod tests {
         test_rwlock_cond_broadcast_helper(12, false, true);
         test_rwlock_cond_broadcast_helper(12, false, false);
     }
-    #[cfg(test)] #[ignore(cfg(windows))]
+    #[cfg(test)]
     fn rwlock_kill_helper(mode1: RWLockMode, mode2: RWLockMode) {
         // Mutex must get automatically unlocked if failed/killed within.
         let x = ~RWLock::new();
@@ -1290,23 +1290,23 @@ mod tests {
         // child task must have finished by the time try returns
         do lock_rwlock_in_mode(x, mode2) { }
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_rwlock_reader_killed_writer() {
         rwlock_kill_helper(Read, Write);
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_rwlock_writer_killed_reader() {
         rwlock_kill_helper(Write,Read );
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_rwlock_reader_killed_reader() {
         rwlock_kill_helper(Read, Read );
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_rwlock_writer_killed_writer() {
         rwlock_kill_helper(Write,Write);
     }
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn test_rwlock_kill_downgrader() {
         rwlock_kill_helper(Downgrade, Read);
         rwlock_kill_helper(Read, Downgrade);
@@ -1321,7 +1321,7 @@ mod tests {
         rwlock_kill_helper(Downgrade, DowngradeRead);
         rwlock_kill_helper(Downgrade, DowngradeRead);
     }
-    #[test] #[should_fail] #[ignore(cfg(windows))]
+    #[test] #[should_fail]
     fn test_rwlock_downgrade_cant_swap() {
         // Tests that you can't downgrade with a different rwlock's token.
         let x = ~RWLock::new();

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -1163,7 +1163,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(cfg(windows))]
     fn test_should_fail() {
         fn f() { fail!(); }
         let desc = TestDescAndFn {

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -419,16 +419,8 @@ pub mod write {
         }
     }
 
-    pub fn run_ndk(sess: Session, assembly: &Path, object: &Path) {
-        let cc_prog: ~str = match &sess.opts.android_cross_path {
-            &Some(ref path) => {
-                fmt!("%s/bin/arm-linux-androideabi-gcc", *path)
-            }
-            &None => {
-                sess.fatal("need Android NDK path for building \
-                            (--android-cross-path)")
-            }
-        };
+    pub fn run_assembler(sess: Session, assembly: &Path, object: &Path) {
+        let cc_prog = super::get_cc_prog(sess);
 
         let cc_args = ~[
             ~"-c",
@@ -813,12 +805,7 @@ pub fn output_dll_filename(os: session::os, lm: LinkMeta) -> ~str {
     fmt!("%s%s-%s-%s%s", dll_prefix, lm.name, lm.extras_hash, lm.vers, dll_suffix)
 }
 
-// If the user wants an exe generated we need to invoke
-// cc to link the object file with some libs
-pub fn link_binary(sess: Session,
-                   obj_filename: &Path,
-                   out_filename: &Path,
-                   lm: LinkMeta) {
+pub fn get_cc_prog(sess: Session) -> ~str {
     // In the future, FreeBSD will use clang as default compiler.
     // It would be flexible to use cc (system's default C compiler)
     // instead of hard-coded gcc.
@@ -841,9 +828,18 @@ pub fn link_binary(sess: Session,
             session::os_win32 => ~"g++",
             _ => ~"cc"
         }
-    };
-    // The invocations of cc share some flags across platforms
+    }
+}
 
+// If the user wants an exe generated we need to invoke
+// cc to link the object file with some libs
+pub fn link_binary(sess: Session,
+                   obj_filename: &Path,
+                   out_filename: &Path,
+                   lm: LinkMeta) {
+
+    let cc_prog = get_cc_prog(sess);
+    // The invocations of cc share some flags across platforms
 
     let output = if *sess.building_library {
         let long_libname = output_dll_filename(sess.targ_cfg.os, lm);

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -822,9 +822,10 @@ pub fn link_binary(sess: Session,
     // In the future, FreeBSD will use clang as default compiler.
     // It would be flexible to use cc (system's default C compiler)
     // instead of hard-coded gcc.
-    // For win32, there is no cc command,
-    // so we add a condition to make it use gcc.
-    let cc_prog: ~str = match sess.opts.linker {
+    // For win32, there is no cc command, so we add a condition to make it use g++.
+    // We use g++ rather than gcc because it automatically adds linker options required
+    // for generation of dll modules that correctly register stack unwind tables.
+    match sess.opts.linker {
         Some(ref linker) => linker.to_str(),
         None => match sess.targ_cfg.os {
             session::os_android =>
@@ -837,7 +838,7 @@ pub fn link_binary(sess: Session,
                                     (--android-cross-path)")
                     }
                 },
-            session::os_win32 => ~"gcc",
+            session::os_win32 => ~"g++",
             _ => ~"cc"
         }
     };

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -343,16 +343,21 @@ pub fn phase_5_run_llvm_passes(sess: Session,
         (sess.opts.output_type == link::output_type_object ||
          sess.opts.output_type == link::output_type_exe) {
         let output_type = link::output_type_assembly;
-        let obj_filename = outputs.obj_filename.with_filetype("s");
+        let asm_filename = outputs.obj_filename.with_filetype("s");
 
         time(sess.time_passes(), ~"LLVM passes", ||
             link::write::run_passes(sess,
                                     trans.context,
                                     trans.module,
                                     output_type,
-                                    &obj_filename));
+                                    &asm_filename));
 
-        link::write::run_assembler(sess, &obj_filename, &outputs.obj_filename);
+        link::write::run_assembler(sess, &asm_filename, &outputs.obj_filename);
+
+        // Remove assembly source unless --save-temps was specified
+        if !sess.opts.save_temps {
+            os::remove_file(&asm_filename);
+        }
     } else {
         time(sess.time_passes(), ~"LLVM passes", ||
             link::write::run_passes(sess,

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -283,7 +283,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_with_ref_empty_fail() {
         let c_str = unsafe { CString::new(ptr::null(), false) };
         c_str.with_ref(|_| ());
@@ -306,7 +305,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(cfg(windows))]
     fn test_to_c_str_fail() {
         use c_str::null_byte::cond;
 

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -93,7 +93,6 @@ fn test_basic() {
 
 #[test]
 #[should_fail]
-#[ignore(cfg(windows))]
 fn test_take_empty() {
     let value_cell = Cell::new_empty::<~int>();
     value_cell.take();
@@ -101,7 +100,6 @@ fn test_take_empty() {
 
 #[test]
 #[should_fail]
-#[ignore(cfg(windows))]
 fn test_put_back_non_empty() {
     let value_cell = Cell::new(~10);
     value_cell.put_back(~20);

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -2017,7 +2017,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_read_buffer_too_small() {
         let path = &Path("tmp/lib-io-test-read-buffer-too-small.tmp");
         // ensure the file exists

--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -201,7 +201,6 @@ fn test_tls_overwrite_multiple_types() {
 
 #[test]
 #[should_fail]
-#[ignore(cfg(windows))]
 fn test_tls_cleanup_on_failure() {
     static str_key: Key<@~str> = &Key;
     static box_key: Key<@@()> = &Key;

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -919,7 +919,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_range_step_zero_step() {
         do range_step(0,10,0) |_i| { true };
     }

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -638,14 +638,12 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     pub fn to_str_radix1() {
         100u.to_str_radix(1u);
     }
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     pub fn to_str_radix37() {
         100u.to_str_radix(37u);
     }
@@ -697,13 +695,11 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_range_step_zero_step_up() {
         do range_step(0,10,0) |_i| { true };
     }
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_range_step_zero_step_down() {
         do range_step(0,-10,0) |_i| { true };
     }

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -479,7 +479,7 @@ mod tests {
         assert_eq!(y2, 5);
         assert!(y.is_none());
     }
-    #[test] #[should_fail] #[ignore(cfg(windows))]
+    #[test] #[should_fail]
     fn test_option_too_much_dance() {
         let mut y = Some(util::NonCopyable);
         let _y2 = y.take_unwrap();

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1815,7 +1815,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(cfg(windows))]
     #[ignore]
     fn test_setenv_overwrite() {
         let n = make_rand_name();
@@ -1829,7 +1828,6 @@ mod tests {
     // Windows GetEnvironmentVariable requires some extra work to make sure
     // the buffer the variable is copied into is the right size
     #[test]
-    #[ignore(cfg(windows))]
     #[ignore]
     fn test_getenv_big() {
         let mut s = ~"";

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -670,7 +670,6 @@ pub mod ptr_tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_ptr_array_each_with_len_null_ptr() {
         unsafe {
             array_each_with_len(0 as **libc::c_char, 1, |e| {
@@ -680,7 +679,6 @@ pub mod ptr_tests {
     }
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_ptr_array_each_null_ptr() {
         unsafe {
             array_each(0 as **libc::c_char, |e| {

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -1007,7 +1007,6 @@ mod test {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_gen_int_from_fail() {
         let mut r = rng();
         r.gen_int_range(5, -2);
@@ -1024,7 +1023,6 @@ mod test {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_gen_uint_range_fail() {
         let mut r = rng();
         r.gen_uint_range(5u, 2u);

--- a/src/libstd/rt/io/extensions.rs
+++ b/src/libstd/rt/io/extensions.rs
@@ -751,7 +751,6 @@ mod test {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn push_bytes_fail_reset_len() {
         // push_bytes unsafely sets the vector length. This is testing that
         // upon failure the length is reset correctly.
@@ -806,7 +805,6 @@ mod test {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn read_to_end_error() {
         let mut reader = MockReader::new();
         let count = Cell::new(0);

--- a/src/libstd/select.rs
+++ b/src/libstd/select.rs
@@ -136,7 +136,7 @@ mod test {
     use cell::Cell;
     use iterator::{Iterator, range};
 
-    #[test] #[ignore(cfg(windows))] #[should_fail]
+    #[test] #[should_fail]
     fn select_doesnt_get_trolled() {
         select::<PortOne<()>>([]);
     }
@@ -316,7 +316,7 @@ mod test {
         }
     }
 
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn select_killed() {
         do run_in_newsched_task {
             let (success_p, success_c) = oneshot::<bool>();

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -2451,7 +2451,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_pop_char_fail() {
         let mut data = ~"";
         let _cc3 = data.pop_char();
@@ -2767,7 +2766,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_slice_fail() {
         "中华Việt Nam".slice(0u, 2u);
     }
@@ -2933,7 +2931,6 @@ mod tests {
 
 
     #[test]
-    #[ignore(cfg(windows))]
     fn test_from_bytes_fail() {
         use str::not_utf8::cond;
 
@@ -2983,7 +2980,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(cfg(windows))]
     #[should_fail]
     fn test_as_bytes_fail() {
         // Don't double free. (I'm not sure if this exercises the

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -616,7 +616,7 @@ pub unsafe fn rekillable<U>(f: &fn() -> U) -> U {
 }
 
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_kill_unkillable_task() {
     use rt::test::*;
 
@@ -637,7 +637,7 @@ fn test_kill_unkillable_task() {
 }
 
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_kill_rekillable_task() {
     use rt::test::*;
 
@@ -658,7 +658,7 @@ fn test_kill_rekillable_task() {
     }
 }
 
-#[test] #[should_fail] #[ignore(cfg(windows))]
+#[test] #[should_fail]
 fn test_cant_dup_task_builder() {
     let mut builder = task();
     builder.unlinked();
@@ -679,7 +679,7 @@ fn test_cant_dup_task_builder() {
 fn block_forever() { let (po, _ch) = stream::<()>(); po.recv(); }
 
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_unlinked_unsup_no_fail_down() { // grandchild sends on a port
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -698,7 +698,7 @@ fn test_spawn_unlinked_unsup_no_fail_down() { // grandchild sends on a port
     }
 }
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_unlinked_unsup_no_fail_up() { // child unlinked fails
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -706,7 +706,7 @@ fn test_spawn_unlinked_unsup_no_fail_up() { // child unlinked fails
     }
 }
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_unlinked_sup_no_fail_up() { // child unlinked fails
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -716,7 +716,7 @@ fn test_spawn_unlinked_sup_no_fail_up() { // child unlinked fails
     }
 }
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_unlinked_sup_fail_down() {
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -729,7 +729,7 @@ fn test_spawn_unlinked_sup_fail_down() {
 }
 
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_linked_sup_fail_up() { // child fails; parent fails
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -750,7 +750,7 @@ fn test_spawn_linked_sup_fail_up() { // child fails; parent fails
     }
 }
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_linked_sup_fail_down() { // parent fails; child fails
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -767,7 +767,7 @@ fn test_spawn_linked_sup_fail_down() { // parent fails; child fails
     }
 }
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_linked_unsup_fail_up() { // child fails; parent fails
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -780,7 +780,7 @@ fn test_spawn_linked_unsup_fail_up() { // child fails; parent fails
     }
 }
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_linked_unsup_fail_down() { // parent fails; child fails
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -793,7 +793,7 @@ fn test_spawn_linked_unsup_fail_down() { // parent fails; child fails
     }
 }
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_linked_unsup_default_opts() { // parent fails; child fails
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -812,7 +812,7 @@ fn test_spawn_linked_unsup_default_opts() { // parent fails; child fails
 // when the middle task exits successfully early before kill signals are sent.
 
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_failure_propagate_grandchild() {
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -829,7 +829,7 @@ fn test_spawn_failure_propagate_grandchild() {
 }
 
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_failure_propagate_secondborn() {
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -846,7 +846,7 @@ fn test_spawn_failure_propagate_secondborn() {
 }
 
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_failure_propagate_nephew_or_niece() {
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -863,7 +863,7 @@ fn test_spawn_failure_propagate_nephew_or_niece() {
 }
 
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_linked_sup_propagate_sibling() {
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -941,7 +941,6 @@ fn test_add_wrapper() {
 }
 
 #[test]
-#[ignore(cfg(windows))]
 fn test_future_result() {
     let mut result = None;
     let mut builder = task();
@@ -959,7 +958,7 @@ fn test_future_result() {
     assert_eq!(result.unwrap().recv(), Failure);
 }
 
-#[test] #[should_fail] #[ignore(cfg(windows))]
+#[test] #[should_fail]
 fn test_back_to_the_future_result() {
     let mut builder = task();
     builder.future_result(util::ignore);
@@ -977,7 +976,6 @@ fn test_try_success() {
 }
 
 #[test]
-#[ignore(cfg(windows))]
 fn test_try_fail() {
     match do try {
         fail!()
@@ -1159,7 +1157,6 @@ fn test_avoid_copying_the_body_unlinked() {
 
 #[ignore(reason = "linked failure")]
 #[test]
-#[ignore(cfg(windows))]
 #[should_fail]
 fn test_unkillable() {
     let (po, ch) = stream();
@@ -1195,7 +1192,6 @@ fn test_unkillable() {
 
 #[ignore(reason = "linked failure")]
 #[test]
-#[ignore(cfg(windows))]
 #[should_fail]
 fn test_unkillable_nested() {
     let (po, ch) = comm::stream();
@@ -1261,7 +1257,7 @@ fn test_simple_newsched_spawn() {
 }
 
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_spawn_watched() {
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {
@@ -1284,7 +1280,7 @@ fn test_spawn_watched() {
 }
 
 #[ignore(reason = "linked failure")]
-#[test] #[ignore(cfg(windows))]
+#[test]
 fn test_indestructible() {
     use rt::test::run_in_newsched_task;
     do run_in_newsched_task {

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -722,7 +722,6 @@ fn test_spawn_raw_simple() {
 }
 
 #[test]
-#[ignore(cfg(windows))]
 fn test_spawn_raw_unsupervise() {
     let opts = task::TaskOpts {
         linked: false,
@@ -736,7 +735,6 @@ fn test_spawn_raw_unsupervise() {
 }
 
 #[test]
-#[ignore(cfg(windows))]
 fn test_spawn_raw_notify_success() {
     let (notify_po, notify_ch) = comm::stream();
 
@@ -750,7 +748,6 @@ fn test_spawn_raw_notify_success() {
 }
 
 #[test]
-#[ignore(cfg(windows))]
 fn test_spawn_raw_notify_failure() {
     // New bindings for these
     let (notify_po, notify_ch) = comm::stream();

--- a/src/libstd/unstable/extfmt.rs
+++ b/src/libstd/unstable/extfmt.rs
@@ -441,14 +441,12 @@ pub mod ct {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_parse_type_missing() {
         parse_type("", 0, 0, die);
     }
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_parse_type_unknown() {
         parse_type("!", 0, 1, die);
     }

--- a/src/libstd/unstable/finally.rs
+++ b/src/libstd/unstable/finally.rs
@@ -83,7 +83,6 @@ fn test_success() {
 }
 
 #[test]
-#[ignore(cfg(windows))]
 #[should_fail]
 fn test_fail() {
     let mut i = 0;

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -481,7 +481,7 @@ mod tests {
         }
     }
 
-    #[test] #[should_fail] #[ignore(cfg(windows))]
+    #[test] #[should_fail]
     fn exclusive_new_poison() {
         unsafe {
             // Tests that if one task fails inside of an Exclusive::new, subsequent
@@ -599,7 +599,7 @@ mod tests {
         res.unwrap().recv();
     }
 
-    #[test] #[should_fail] #[ignore(cfg(windows))]
+    #[test] #[should_fail]
     fn exclusive_new_unwrap_conflict() {
         let x = Exclusive::new(~~"hello");
         let x2 = Cell::new(x.clone());
@@ -615,7 +615,7 @@ mod tests {
         assert!(res.unwrap().recv() == task::Success);
     }
 
-    #[test] #[ignore(cfg(windows))]
+    #[test]
     fn exclusive_new_unwrap_deadlock() {
         // This is not guaranteed to get to the deadlock before being killed,
         // but it will show up sometimes, and if the deadlock were not there,

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2521,7 +2521,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_head_empty() {
         let a: ~[int] = ~[];
         a.head();
@@ -2547,7 +2546,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_tail_empty() {
         let a: ~[int] = ~[];
         a.tail();
@@ -2563,7 +2561,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_tailn_empty() {
         let a: ~[int] = ~[];
         a.tailn(2);
@@ -2579,7 +2576,6 @@ mod tests {
 
     #[init]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_init_empty() {
         let a: ~[int] = ~[];
         a.init();
@@ -2595,7 +2591,6 @@ mod tests {
 
     #[init]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_initn_empty() {
         let a: ~[int] = ~[];
         a.initn(2);
@@ -2611,7 +2606,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_last_empty() {
         let a: ~[int] = ~[];
         a.last();
@@ -3079,7 +3073,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(cfg(windows))]
     #[should_fail]
     fn test_insert_oob() {
         let mut a = ~[1, 2, 3];
@@ -3102,7 +3095,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(cfg(windows))]
     #[should_fail]
     fn test_remove_oob() {
         let mut a = ~[1, 2, 3];
@@ -3130,7 +3122,6 @@ mod tests {
 
 
     #[test]
-    #[ignore(windows)]
     #[should_fail]
     fn test_from_fn_fail() {
         do from_fn(100) |v| {
@@ -3140,7 +3131,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(windows)]
     #[should_fail]
     fn test_build_fail() {
         do build |push| {
@@ -3153,7 +3143,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(windows)]
     #[should_fail]
     fn test_grow_fn_fail() {
         let mut v = ~[];
@@ -3166,7 +3155,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(windows)]
     #[should_fail]
     fn test_map_fail() {
         let v = [(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
@@ -3181,7 +3169,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(windows)]
     #[should_fail]
     fn test_flat_map_fail() {
         let v = [(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
@@ -3196,7 +3183,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(windows)]
     #[should_fail]
     fn test_rposition_fail() {
         let v = [(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
@@ -3211,7 +3197,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(windows)]
     #[should_fail]
     fn test_permute_fail() {
         let v = [(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
@@ -3226,7 +3211,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(windows)]
     #[should_fail]
     fn test_as_imm_buf_fail() {
         let v = [(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
@@ -3236,7 +3220,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(cfg(windows))]
     #[should_fail]
     fn test_as_mut_buf_fail() {
         let mut v = [(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
@@ -3247,7 +3230,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_copy_memory_oob() {
         unsafe {
             let mut a = [1, 2, 3, 4];
@@ -3469,7 +3451,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_window_iterator_0() {
         let v = &[1i,2,3,4];
         let _it = v.window_iter(0);
@@ -3494,7 +3475,6 @@ mod tests {
 
     #[test]
     #[should_fail]
-    #[ignore(cfg(windows))]
     fn test_chunk_iterator_0() {
         let v = &[1i,2,3,4];
         let _it = v.chunk_iter(0);

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -3154,6 +3154,7 @@ mod tests {
         }
     }
 
+    #[ignore] // FIXME #8698
     #[test]
     #[should_fail]
     fn test_map_fail() {
@@ -3168,6 +3169,7 @@ mod tests {
         };
     }
 
+    #[ignore] // FIXME #8698
     #[test]
     #[should_fail]
     fn test_flat_map_fail() {
@@ -3182,6 +3184,7 @@ mod tests {
         };
     }
 
+    #[ignore] // FIXME #8698
     #[test]
     #[should_fail]
     fn test_rposition_fail() {
@@ -3196,6 +3199,7 @@ mod tests {
         };
     }
 
+    #[ignore] // FIXME #8698
     #[test]
     #[should_fail]
     fn test_permute_fail() {

--- a/src/rt/arch/i386/ccall.S
+++ b/src/rt/arch/i386/ccall.S
@@ -12,7 +12,7 @@
 
 	.text
 
-#if defined(__APPLE__) || defined(_WIN32)
+#if defined(__APPLE__) || defined(__WIN32__)
 .globl ___morestack
 ___morestack:
 #else
@@ -21,20 +21,20 @@ ___morestack:
 __morestack:
 #endif
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__WIN32__)
 	.cfi_startproc
 #endif
 
 	pushl %ebp
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__WIN32__)
 	.cfi_def_cfa_offset 8
 	.cfi_offset %ebp, -8
 #endif
 
 	movl %esp,%ebp          // save esp
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__WIN32__)
 	.cfi_def_cfa_register %ebp
 #endif
 
@@ -47,6 +47,6 @@ __morestack:
 
 	ret
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__WIN32__)
 	.cfi_endproc
 #endif

--- a/src/rt/arch/i386/morestack.S
+++ b/src/rt/arch/i386/morestack.S
@@ -97,7 +97,7 @@
 #endif
 .globl MORESTACK
 
-// FIXME: What about _WIN32?
+// FIXME: What about __WIN32__?
 #if defined(__linux__) || defined(__FreeBSD__)
 	.hidden MORESTACK
 #else
@@ -111,7 +111,7 @@
 #endif
 
 MORESTACK:
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__WIN32__)
 	.cfi_startproc
 #endif
 
@@ -130,7 +130,7 @@ MORESTACK:
 	// __morestack, and an extra return address.
 
 	pushl %ebp
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__WIN32__)
 	// The CFA is 20 bytes above the register that it is
 	// associated with for this frame (which will be %ebp)
 	.cfi_def_cfa_offset 20
@@ -138,7 +138,7 @@ MORESTACK:
 	.cfi_offset %ebp, -20
 #endif
 	movl %esp, %ebp
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__WIN32__)
 	// Calculate the CFA as an offset from %ebp
 	.cfi_def_cfa_register %ebp
 #endif
@@ -232,7 +232,7 @@ MORESTACK:
 
 	jmpl *%eax
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__WIN32__)
 	.cfi_endproc
 #endif
 

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -559,11 +559,7 @@ rust_try(rust_try_fn f, void *fptr, void *env) {
 
 extern "C" CDECL void
 rust_begin_unwind(uintptr_t token) {
-#ifndef __WIN32__
     throw token;
-#else
-    abort();
-#endif
 }
 
 extern "C" CDECL uintptr_t

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32
-
 extern mod extra;
 
 use extra::list::{List, Cons, Nil};

--- a/src/test/run-fail/spawnfail.rs
+++ b/src/test/run-fail/spawnfail.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // xfail-test linked failure
-// xfail-win32
 // error-pattern:explicit
 extern mod extra;
 

--- a/src/test/run-pass/cleanup-copy-mode.rs
+++ b/src/test/run-pass/cleanup-copy-mode.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32
-
 use std::task;
 
 fn adder(x: @int, y: @int) -> int { return *x + *y; }

--- a/src/test/run-pass/issue-3168.rs
+++ b/src/test/run-pass/issue-3168.rs
@@ -10,7 +10,6 @@
 
 // xfail-test linked failure
 // xfail-fast
-// xfail-win32 #7999
 
 use std::comm;
 use std::task;

--- a/src/test/run-pass/lots-a-fail.rs
+++ b/src/test/run-pass/lots-a-fail.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // xfail-test linked failure
-// xfail-win32 leaks
 extern mod extra;
 
 use std::task;

--- a/src/test/run-pass/send-iloop.rs
+++ b/src/test/run-pass/send-iloop.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // xfail-test linked failure
-// xfail-win32
 extern mod extra;
 
 use std::comm;

--- a/src/test/run-pass/task-comm-15.rs
+++ b/src/test/run-pass/task-comm-15.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // xfail-fast
-// xfail-win32
 
 extern mod extra;
 

--- a/src/test/run-pass/task-killjoin-rsrc.rs
+++ b/src/test/run-pass/task-killjoin-rsrc.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // xfail-test linked failure
-// xfail-win32
 
 // A port of task-killjoin to use a class with a dtor to manage
 // the join.

--- a/src/test/run-pass/task-killjoin.rs
+++ b/src/test/run-pass/task-killjoin.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // xfail-test linked failure
-// xfail-win32
 
 // Create a task that is supervised by another task, join the supervised task
 // from the supervising task, then fail the supervised task. The supervised

--- a/src/test/run-pass/terminate-in-initializer.rs
+++ b/src/test/run-pass/terminate-in-initializer.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 leaks
 // Issue #787
 // Don't try to clean up uninitialized locals
 

--- a/src/test/run-pass/unit-like-struct-drop-run.rs
+++ b/src/test/run-pass/unit-like-struct-drop-run.rs
@@ -10,7 +10,6 @@
 
 // Make sure the destructor is run for unit-like structs.
 // xfail-fast
-// xfail-win32 #7999
 
 use std::task;
 

--- a/src/test/run-pass/unwind-box.rs
+++ b/src/test/run-pass/unwind-box.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32
 extern mod extra;
 
 use std::task;

--- a/src/test/run-pass/unwind-resource2.rs
+++ b/src/test/run-pass/unwind-resource2.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32
 extern mod extra;
 
 use std::task;

--- a/src/test/run-pass/unwind-unique.rs
+++ b/src/test/run-pass/unwind-unique.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32
 extern mod extra;
 
 use std::task;


### PR DESCRIPTION
This resolves issue #908.  

Notable changes:
-  On Windows, LLVM integrated assembler emits bad stack unwind tables when segmented stacks are enabled.  However, unwind info directives in the assembly output are correct, so we generate assembly first and then run it through an external assembler, just like it is already done for Android builds.
- Linker is invoked  via "g++" command instead of "gcc": g++ passes the appropriate magic parameters to the linker, which ensure correct registration of stack unwind tables in dynamic libraries.
