### PR TITLE
Rename WriterByteConversions methods

### DIFF
--- a/src/libstd/rt/io/extensions.rs
+++ b/src/libstd/rt/io/extensions.rs
@@ -68,174 +68,174 @@ pub trait ReaderByteConversions {
     /// Reads `n` little-endian unsigned integer bytes.
     ///
     /// `n` must be between 1 and 8, inclusive.
-    fn read_le_uint_n(&mut self, nbytes: uint) -> u64;
+    fn read_le_uint_n_(&mut self, nbytes: uint) -> u64;
 
     /// Reads `n` little-endian signed integer bytes.
     ///
     /// `n` must be between 1 and 8, inclusive.
-    fn read_le_int_n(&mut self, nbytes: uint) -> i64;
+    fn read_le_int_n_(&mut self, nbytes: uint) -> i64;
 
     /// Reads `n` big-endian unsigned integer bytes.
     ///
     /// `n` must be between 1 and 8, inclusive.
-    fn read_be_uint_n(&mut self, nbytes: uint) -> u64;
+    fn read_be_uint_n_(&mut self, nbytes: uint) -> u64;
 
     /// Reads `n` big-endian signed integer bytes.
     ///
     /// `n` must be between 1 and 8, inclusive.
-    fn read_be_int_n(&mut self, nbytes: uint) -> i64;
+    fn read_be_int_n_(&mut self, nbytes: uint) -> i64;
 
     /// Reads a little-endian unsigned integer.
     ///
     /// The number of bytes returned is system-dependant.
-    fn read_le_uint(&mut self) -> uint;
+    fn read_le_uint_(&mut self) -> uint;
 
     /// Reads a little-endian integer.
     ///
     /// The number of bytes returned is system-dependant.
-    fn read_le_int(&mut self) -> int;
+    fn read_le_int_(&mut self) -> int;
 
     /// Reads a big-endian unsigned integer.
     ///
     /// The number of bytes returned is system-dependant.
-    fn read_be_uint(&mut self) -> uint;
+    fn read_be_uint_(&mut self) -> uint;
 
     /// Reads a big-endian integer.
     ///
     /// The number of bytes returned is system-dependant.
-    fn read_be_int(&mut self) -> int;
+    fn read_be_int_(&mut self) -> int;
 
     /// Reads a big-endian `u64`.
     ///
     /// `u64`s are 8 bytes long.
-    fn read_be_u64(&mut self) -> u64;
+    fn read_be_u64_(&mut self) -> u64;
 
     /// Reads a big-endian `u32`.
     ///
     /// `u32`s are 4 bytes long.
-    fn read_be_u32(&mut self) -> u32;
+    fn read_be_u32_(&mut self) -> u32;
 
     /// Reads a big-endian `u16`.
     ///
     /// `u16`s are 2 bytes long.
-    fn read_be_u16(&mut self) -> u16;
+    fn read_be_u16_(&mut self) -> u16;
 
     /// Reads a big-endian `i64`.
     ///
     /// `i64`s are 8 bytes long.
-    fn read_be_i64(&mut self) -> i64;
+    fn read_be_i64_(&mut self) -> i64;
 
     /// Reads a big-endian `i32`.
     ///
     /// `i32`s are 4 bytes long.
-    fn read_be_i32(&mut self) -> i32;
+    fn read_be_i32_(&mut self) -> i32;
 
     /// Reads a big-endian `i16`.
     ///
     /// `i16`s are 2 bytes long.
-    fn read_be_i16(&mut self) -> i16;
+    fn read_be_i16_(&mut self) -> i16;
 
     /// Reads a big-endian `f64`.
     ///
     /// `f64`s are 8 byte, IEEE754 double-precision floating point numbers.
-    fn read_be_f64(&mut self) -> f64;
+    fn read_be_f64_(&mut self) -> f64;
 
     /// Reads a big-endian `f32`.
     ///
     /// `f32`s are 4 byte, IEEE754 single-precision floating point numbers.
-    fn read_be_f32(&mut self) -> f32;
+    fn read_be_f32_(&mut self) -> f32;
 
     /// Reads a little-endian `u64`.
     ///
     /// `u64`s are 8 bytes long.
-    fn read_le_u64(&mut self) -> u64;
+    fn read_le_u64_(&mut self) -> u64;
 
     /// Reads a little-endian `u32`.
     ///
     /// `u32`s are 4 bytes long.
-    fn read_le_u32(&mut self) -> u32;
+    fn read_le_u32_(&mut self) -> u32;
 
     /// Reads a little-endian `u16`.
     ///
     /// `u16`s are 2 bytes long.
-    fn read_le_u16(&mut self) -> u16;
+    fn read_le_u16_(&mut self) -> u16;
 
     /// Reads a little-endian `i64`.
     ///
     /// `i64`s are 8 bytes long.
-    fn read_le_i64(&mut self) -> i64;
+    fn read_le_i64_(&mut self) -> i64;
 
     /// Reads a little-endian `i32`.
     ///
     /// `i32`s are 4 bytes long.
-    fn read_le_i32(&mut self) -> i32;
+    fn read_le_i32_(&mut self) -> i32;
 
     /// Reads a little-endian `i16`.
     ///
     /// `i16`s are 2 bytes long.
-    fn read_le_i16(&mut self) -> i16;
+    fn read_le_i16_(&mut self) -> i16;
 
     /// Reads a little-endian `f64`.
     ///
     /// `f64`s are 8 byte, IEEE754 double-precision floating point numbers.
-    fn read_le_f64(&mut self) -> f64;
+    fn read_le_f64_(&mut self) -> f64;
 
     /// Reads a little-endian `f32`.
     ///
     /// `f32`s are 4 byte, IEEE754 single-precision floating point numbers.
-    fn read_le_f32(&mut self) -> f32;
+    fn read_le_f32_(&mut self) -> f32;
 
     /// Read a u8.
     ///
     /// `u8`s are 1 byte.
-    fn read_u8(&mut self) -> u8;
+    fn read_u8_(&mut self) -> u8;
 
     /// Read an i8.
     ///
     /// `i8`s are 1 byte.
-    fn read_i8(&mut self) -> i8;
+    fn read_i8_(&mut self) -> i8;
 
 }
 
 pub trait WriterByteConversions {
     /// Write the result of passing n through `int::to_str_bytes`.
-    fn write_int(&mut self, n: int);
+    fn write_int_(&mut self, n: int);
 
     /// Write the result of passing n through `uint::to_str_bytes`.
-    fn write_uint(&mut self, n: uint);
+    fn write_uint_(&mut self, n: uint);
 
     /// Write a little-endian uint (number of bytes depends on system).
-    fn write_le_uint(&mut self, n: uint);
+    fn write_le_uint_(&mut self, n: uint);
 
     /// Write a little-endian int (number of bytes depends on system).
-    fn write_le_int(&mut self, n: int);
+    fn write_le_int_(&mut self, n: int);
 
     /// Write a big-endian uint (number of bytes depends on system).
-    fn write_be_uint(&mut self, n: uint);
+    fn write_be_uint_(&mut self, n: uint);
 
     /// Write a big-endian int (number of bytes depends on system).
-    fn write_be_int(&mut self, n: int);
+    fn write_be_int_(&mut self, n: int);
 
     /// Write a big-endian u64 (8 bytes).
     fn write_be_u64_(&mut self, n: u64);
 
     /// Write a big-endian u32 (4 bytes).
-    fn write_be_u32(&mut self, n: u32);
+    fn write_be_u32_(&mut self, n: u32);
 
     /// Write a big-endian u16 (2 bytes).
-    fn write_be_u16(&mut self, n: u16);
+    fn write_be_u16_(&mut self, n: u16);
 
     /// Write a big-endian i64 (8 bytes).
-    fn write_be_i64(&mut self, n: i64);
+    fn write_be_i64_(&mut self, n: i64);
 
     /// Write a big-endian i32 (4 bytes).
     fn write_be_i32_(&mut self, n: i32);
 
     /// Write a big-endian i16 (2 bytes).
-    fn write_be_i16(&mut self, n: i16);
+    fn write_be_i16_(&mut self, n: i16);
 
     /// Write a big-endian IEEE754 double-precision floating-point (8 bytes).
-    fn write_be_f64(&mut self, f: f64);
+    fn write_be_f64_(&mut self, f: f64);
 
     /// Write a big-endian IEEE754 single-precision floating-point (4 bytes).
     fn write_be_f32_(&mut self, f: f32);
@@ -244,33 +244,33 @@ pub trait WriterByteConversions {
     fn write_le_u64_(&mut self, n: u64);
 
     /// Write a little-endian u32 (4 bytes).
-    fn write_le_u32(&mut self, n: u32);
+    fn write_le_u32_(&mut self, n: u32);
 
     /// Write a little-endian u16 (2 bytes).
-    fn write_le_u16(&mut self, n: u16);
+    fn write_le_u16_(&mut self, n: u16);
 
     /// Write a little-endian i64 (8 bytes).
-    fn write_le_i64(&mut self, n: i64);
+    fn write_le_i64_(&mut self, n: i64);
 
     /// Write a little-endian i32 (4 bytes).
-    fn write_le_i32(&mut self, n: i32);
+    fn write_le_i32_(&mut self, n: i32);
 
     /// Write a little-endian i16 (2 bytes).
-    fn write_le_i16(&mut self, n: i16);
+    fn write_le_i16_(&mut self, n: i16);
 
     /// Write a little-endian IEEE754 double-precision floating-point
     /// (8 bytes).
-    fn write_le_f64(&mut self, f: f64);
+    fn write_le_f64_(&mut self, f: f64);
 
     /// Write a little-endian IEEE754 single-precision floating-point
     /// (4 bytes).
     fn write_le_f32_(&mut self, f: f32);
 
     /// Write a u8 (1 byte).
-    fn write_u8(&mut self, n: u8);
+    fn write_u8_(&mut self, n: u8);
 
     /// Write a i8 (1 byte).
-    fn write_i8(&mut self, n: i8);
+    fn write_i8_(&mut self, n: i8);
 }
 
 impl<T: Reader> ReaderUtil for T {
@@ -340,136 +340,136 @@ impl<T: Reader> ReaderUtil for T {
 }
 
 impl<T: Reader> ReaderByteConversions for T {
-    fn read_le_uint_n(&mut self, nbytes: uint) -> u64 {
+    fn read_le_uint_n_(&mut self, nbytes: uint) -> u64 {
         assert!(nbytes > 0 && nbytes <= 8);
 
         let mut val = 0u64;
         let mut pos = 0;
         let mut i = nbytes;
         while i > 0 {
-            val += (self.read_u8() as u64) << pos;
+            val += (self.read_u8_() as u64) << pos;
             pos += 8;
             i -= 1;
         }
         val
     }
 
-    fn read_le_int_n(&mut self, nbytes: uint) -> i64 {
-        extend_sign(self.read_le_uint_n(nbytes), nbytes)
+    fn read_le_int_n_(&mut self, nbytes: uint) -> i64 {
+        extend_sign(self.read_le_uint_n_(nbytes), nbytes)
     }
 
-    fn read_be_uint_n(&mut self, nbytes: uint) -> u64 {
+    fn read_be_uint_n_(&mut self, nbytes: uint) -> u64 {
         assert!(nbytes > 0 && nbytes <= 8);
 
         let mut val = 0u64;
         let mut i = nbytes;
         while i > 0 {
             i -= 1;
-            val += (self.read_u8() as u64) << i * 8;
+            val += (self.read_u8_() as u64) << i * 8;
         }
         val
     }
 
-    fn read_be_int_n(&mut self, nbytes: uint) -> i64 {
-        extend_sign(self.read_be_uint_n(nbytes), nbytes)
+    fn read_be_int_n_(&mut self, nbytes: uint) -> i64 {
+        extend_sign(self.read_be_uint_n_(nbytes), nbytes)
     }
 
-    fn read_le_uint(&mut self) -> uint {
-        self.read_le_uint_n(uint::bytes) as uint
+    fn read_le_uint_(&mut self) -> uint {
+        self.read_le_uint_n_(uint::bytes) as uint
     }
 
-    fn read_le_int(&mut self) -> int {
-        self.read_le_int_n(int::bytes) as int
+    fn read_le_int_(&mut self) -> int {
+        self.read_le_int_n_(int::bytes) as int
     }
 
-    fn read_be_uint(&mut self) -> uint {
-        self.read_be_uint_n(uint::bytes) as uint
+    fn read_be_uint_(&mut self) -> uint {
+        self.read_be_uint_n_(uint::bytes) as uint
     }
 
-    fn read_be_int(&mut self) -> int {
-        self.read_be_int_n(int::bytes) as int
+    fn read_be_int_(&mut self) -> int {
+        self.read_be_int_n_(int::bytes) as int
     }
 
-    fn read_be_u64(&mut self) -> u64 {
-        self.read_be_uint_n(8) as u64
+    fn read_be_u64_(&mut self) -> u64 {
+        self.read_be_uint_n_(8) as u64
     }
 
-    fn read_be_u32(&mut self) -> u32 {
-        self.read_be_uint_n(4) as u32
+    fn read_be_u32_(&mut self) -> u32 {
+        self.read_be_uint_n_(4) as u32
     }
 
-    fn read_be_u16(&mut self) -> u16 {
-        self.read_be_uint_n(2) as u16
+    fn read_be_u16_(&mut self) -> u16 {
+        self.read_be_uint_n_(2) as u16
     }
 
-    fn read_be_i64(&mut self) -> i64 {
-        self.read_be_int_n(8) as i64
+    fn read_be_i64_(&mut self) -> i64 {
+        self.read_be_int_n_(8) as i64
     }
 
-    fn read_be_i32(&mut self) -> i32 {
-        self.read_be_int_n(4) as i32
+    fn read_be_i32_(&mut self) -> i32 {
+        self.read_be_int_n_(4) as i32
     }
 
-    fn read_be_i16(&mut self) -> i16 {
-        self.read_be_int_n(2) as i16
+    fn read_be_i16_(&mut self) -> i16 {
+        self.read_be_int_n_(2) as i16
     }
 
-    fn read_be_f64(&mut self) -> f64 {
+    fn read_be_f64_(&mut self) -> f64 {
         unsafe {
-            cast::transmute::<u64, f64>(self.read_be_u64())
+            cast::transmute::<u64, f64>(self.read_be_u64_())
         }
     }
 
-    fn read_be_f32(&mut self) -> f32 {
+    fn read_be_f32_(&mut self) -> f32 {
         unsafe {
-            cast::transmute::<u32, f32>(self.read_be_u32())
+            cast::transmute::<u32, f32>(self.read_be_u32_())
         }
     }
 
-    fn read_le_u64(&mut self) -> u64 {
-        self.read_le_uint_n(8) as u64
+    fn read_le_u64_(&mut self) -> u64 {
+        self.read_le_uint_n_(8) as u64
     }
 
-    fn read_le_u32(&mut self) -> u32 {
-        self.read_le_uint_n(4) as u32
+    fn read_le_u32_(&mut self) -> u32 {
+        self.read_le_uint_n_(4) as u32
     }
 
-    fn read_le_u16(&mut self) -> u16 {
-        self.read_le_uint_n(2) as u16
+    fn read_le_u16_(&mut self) -> u16 {
+        self.read_le_uint_n_(2) as u16
     }
 
-    fn read_le_i64(&mut self) -> i64 {
-        self.read_le_int_n(8) as i64
+    fn read_le_i64_(&mut self) -> i64 {
+        self.read_le_int_n_(8) as i64
     }
 
-    fn read_le_i32(&mut self) -> i32 {
-        self.read_le_int_n(4) as i32
+    fn read_le_i32_(&mut self) -> i32 {
+        self.read_le_int_n_(4) as i32
     }
 
-    fn read_le_i16(&mut self) -> i16 {
-        self.read_le_int_n(2) as i16
+    fn read_le_i16_(&mut self) -> i16 {
+        self.read_le_int_n_(2) as i16
     }
 
-    fn read_le_f64(&mut self) -> f64 {
+    fn read_le_f64_(&mut self) -> f64 {
         unsafe {
-            cast::transmute::<u64, f64>(self.read_le_u64())
+            cast::transmute::<u64, f64>(self.read_le_u64_())
         }
     }
 
-    fn read_le_f32(&mut self) -> f32 {
+    fn read_le_f32_(&mut self) -> f32 {
         unsafe {
-            cast::transmute::<u32, f32>(self.read_le_u32())
+            cast::transmute::<u32, f32>(self.read_le_u32_())
         }
     }
 
-    fn read_u8(&mut self) -> u8 {
+    fn read_u8_(&mut self) -> u8 {
         match self.read_byte() {
             Some(b) => b as u8,
             None => 0
         }
     }
 
-    fn read_i8(&mut self) -> i8 {
+    fn read_i8_(&mut self) -> i8 {
         match self.read_byte() {
             Some(b) => b as i8,
             None => 0
@@ -479,27 +479,27 @@ impl<T: Reader> ReaderByteConversions for T {
 }
 
 impl<T: Writer> WriterByteConversions for T {
-    fn write_int(&mut self, n: int) {
+    fn write_int_(&mut self, n: int) {
         int::to_str_bytes(n, 10u, |bytes| self.write(bytes))
     }
 
-    fn write_uint(&mut self, n: uint) {
+    fn write_uint_(&mut self, n: uint) {
         uint::to_str_bytes(n, 10u, |bytes| self.write(bytes))
     }
 
-    fn write_le_uint(&mut self, n: uint) {
+    fn write_le_uint_(&mut self, n: uint) {
         u64_to_le_bytes(n as u64, uint::bytes, |v| self.write(v))
     }
 
-    fn write_le_int(&mut self, n: int) {
+    fn write_le_int_(&mut self, n: int) {
         u64_to_le_bytes(n as u64, int::bytes, |v| self.write(v))
     }
 
-    fn write_be_uint(&mut self, n: uint) {
+    fn write_be_uint_(&mut self, n: uint) {
         u64_to_be_bytes(n as u64, uint::bytes, |v| self.write(v))
     }
 
-    fn write_be_int(&mut self, n: int) {
+    fn write_be_int_(&mut self, n: int) {
         u64_to_be_bytes(n as u64, int::bytes, |v| self.write(v))
     }
 
@@ -507,15 +507,15 @@ impl<T: Writer> WriterByteConversions for T {
         u64_to_be_bytes(n, 8u, |v| self.write(v))
     }
 
-    fn write_be_u32(&mut self, n: u32) {
+    fn write_be_u32_(&mut self, n: u32) {
         u64_to_be_bytes(n as u64, 4u, |v| self.write(v))
     }
 
-    fn write_be_u16(&mut self, n: u16) {
+    fn write_be_u16_(&mut self, n: u16) {
         u64_to_be_bytes(n as u64, 2u, |v| self.write(v))
     }
 
-    fn write_be_i64(&mut self, n: i64) {
+    fn write_be_i64_(&mut self, n: i64) {
         u64_to_be_bytes(n as u64, 8u, |v| self.write(v))
     }
 
@@ -523,11 +523,11 @@ impl<T: Writer> WriterByteConversions for T {
         u64_to_be_bytes(n as u64, 4u, |v| self.write(v))
     }
 
-    fn write_be_i16(&mut self, n: i16) {
+    fn write_be_i16_(&mut self, n: i16) {
         u64_to_be_bytes(n as u64, 2u, |v| self.write(v))
     }
 
-    fn write_be_f64(&mut self, f: f64) {
+    fn write_be_f64_(&mut self, f: f64) {
         unsafe {
             self.write_be_u64_(cast::transmute(f))
         }
@@ -535,7 +535,7 @@ impl<T: Writer> WriterByteConversions for T {
 
     fn write_be_f32_(&mut self, f: f32) {
         unsafe {
-            self.write_be_u32(cast::transmute(f))
+            self.write_be_u32_(cast::transmute(f))
         }
     }
 
@@ -543,27 +543,27 @@ impl<T: Writer> WriterByteConversions for T {
         u64_to_le_bytes(n, 8u, |v| self.write(v))
     }
 
-    fn write_le_u32(&mut self, n: u32) {
+    fn write_le_u32_(&mut self, n: u32) {
         u64_to_le_bytes(n as u64, 4u, |v| self.write(v))
     }
 
-    fn write_le_u16(&mut self, n: u16) {
+    fn write_le_u16_(&mut self, n: u16) {
         u64_to_le_bytes(n as u64, 2u, |v| self.write(v))
     }
 
-    fn write_le_i64(&mut self, n: i64) {
+    fn write_le_i64_(&mut self, n: i64) {
         u64_to_le_bytes(n as u64, 8u, |v| self.write(v))
     }
 
-    fn write_le_i32(&mut self, n: i32) {
+    fn write_le_i32_(&mut self, n: i32) {
         u64_to_le_bytes(n as u64, 4u, |v| self.write(v))
     }
 
-    fn write_le_i16(&mut self, n: i16) {
+    fn write_le_i16_(&mut self, n: i16) {
         u64_to_le_bytes(n as u64, 2u, |v| self.write(v))
     }
 
-    fn write_le_f64(&mut self, f: f64) {
+    fn write_le_f64_(&mut self, f: f64) {
         unsafe {
             self.write_le_u64_(cast::transmute(f))
         }
@@ -571,15 +571,15 @@ impl<T: Writer> WriterByteConversions for T {
 
     fn write_le_f32_(&mut self, f: f32) {
         unsafe {
-            self.write_le_u32(cast::transmute(f))
+            self.write_le_u32_(cast::transmute(f))
         }
     }
 
-    fn write_u8(&mut self, n: u8) {
+    fn write_u8_(&mut self, n: u8) {
         self.write([n])
     }
 
-    fn write_i8(&mut self, n: i8) {
+    fn write_i8_(&mut self, n: i8) {
         self.write([n as u8])
     }
 }
@@ -827,7 +827,6 @@ mod test {
         assert!(buf == ~[10, 11]);
     }
 
-
     #[test]
     fn test_read_write_le_mem() {
         let uints = [0, 1, 2, 42, 10_123, 100_123_456, ::u64::max_value];
@@ -839,7 +838,7 @@ mod test {
 
         let mut reader = MemReader::new(writer.inner());
         for i in uints.iter() {
-            assert!(reader.read_le_u64() == *i);
+            assert!(reader.read_le_u64_() == *i);
         }
     }
 
@@ -855,7 +854,7 @@ mod test {
 
         let mut reader = MemReader::new(writer.inner());
         for i in uints.iter() {
-            assert!(reader.read_be_u64() == *i);
+            assert!(reader.read_be_u64_() == *i);
         }
     }
 
@@ -872,7 +871,7 @@ mod test {
         for i in ints.iter() {
             // this tests that the sign extension is working
             // (comparing the values as i32 would not test this)
-            assert!(reader.read_be_int_n(4) == *i as i64);
+            assert!(reader.read_be_int_n_(4) == *i as i64);
         }
     }
 
@@ -885,7 +884,7 @@ mod test {
         writer.write(buf);
 
         let mut reader = MemReader::new(writer.inner());
-        let f = reader.read_be_f32();
+        let f = reader.read_be_f32_();
         assert!(f == 8.1250);
     }
 
@@ -898,8 +897,8 @@ mod test {
         writer.write_le_f32_(f);
 
         let mut reader = MemReader::new(writer.inner());
-        assert!(reader.read_be_f32() == 8.1250);
-        assert!(reader.read_le_f32() == 8.1250);
+        assert!(reader.read_be_f32_() == 8.1250);
+        assert!(reader.read_le_f32_() == 8.1250);
     }
 
 }


### PR DESCRIPTION
The method names in std::rt::io::extensions::WriterByteConversions are
the same as those in std::io::WriterUtils and a resolve error causes
rustc to fail after trying to find an impl of io::Writer instead of
trying to look for rt::io::Writer as well.
