### PR TITLE
Prepare bootstrapping priv-by-default struct fields

### DIFF
--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -65,6 +65,7 @@ pub enum ObsoleteSyntax {
     ObsoleteExternVisibility,
     ObsoleteUnsafeExternFn,
     ObsoletePrivVisibility,
+    ObsoletePrivStructFieldVisibility,
     ObsoleteTraitFuncVisibility,
 }
 
@@ -258,6 +259,10 @@ impl ParserObsoleteMethods for Parser {
             ObsoletePrivVisibility => (
                 "`priv` not necessary",
                 "an item without a visibility qualifier is private by default"
+            ),
+            ObsoletePrivStructFieldVisibility=> (
+                "`priv` not necessary",
+                "struct fields are private by default",
             ),
             ObsoleteTraitFuncVisibility => (
                 "visibility not necessary",


### PR DESCRIPTION
It seemed that the general consensus in #8122 was that struct fields should be private by default.

I had the brilliant idea to forbid `pub` on struct fields, so right now this change can't bootstrap. To get around this, I'm modifying it such that the next snapshot compiler will completely disregard all visibility qualifiers on fields of structs. That way after the next snapshot I can rampage through and swap out all the pub/priv qualifiers.

After this there's only one use-case of `priv`, and that's just making enum variants private in an otherwise public enum. I feel like this could be emulated with other semantics, just not as nicely, but regardless I think that struct fields should be private by default.
