### PR TITLE
fix port parsing in extra::url::from_str

### DIFF
--- a/src/libextra/url.rs
+++ b/src/libextra/url.rs
@@ -539,7 +539,7 @@ fn get_authority(rawurl: &str) ->
             return Err(~"Non-digit characters in port.");
         }
         host = rawurl.slice(begin, pos).to_owned();
-        port = Some(rawurl.slice(pos+1, end).to_owned());
+        port = Some(rawurl.slice(pos+1, end+1).to_owned());
       }
       Ip6Host | InHost => {
         host = rawurl.slice(begin, end).to_owned();


### PR DESCRIPTION
Before this PR,

```
extern mod extra;
use extra::url;

fn main() {
    let str = ~"http://localhost:8000";
    let url = url::from_str(str);
    printfln!("%?", url);
}
```

yields

```
Ok({scheme: ~"http", user: None, host: ~"localhost", port: Some(~"800"), path: ~"", query: ~[], fragment: None})
```

After, we get:

```
Ok({scheme: ~"http", user: None, host: ~"localhost", port: Some(~"8000"), path: ~"", query: ~[], fragment: None})
```
