### PR TITLE
Android test updates

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -411,12 +411,14 @@ $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
 	@$(CFG_ADB) push $$< $(CFG_ADB_TEST_DIR)
 	@$(CFG_ADB) shell '(cd $(CFG_ADB_TEST_DIR); LD_LIBRARY_PATH=. \
 		./$$(notdir $$<) \
-		--logfile $(CFG_ADB_TEST_DIR)/check-stage$(1)-T-$(2)-H-$(3)-$(4).log)' \
+		--logfile $(CFG_ADB_TEST_DIR)/check-stage$(1)-T-$(2)-H-$(3)-$(4).log \
+		$$(call CRATE_TEST_BENCH_ARGS,$(1),$(2),$(3),$(4)))' \
 		> tmp/check-stage$(1)-T-$(2)-H-$(3)-$(4).tmp
 	@cat tmp/check-stage$(1)-T-$(2)-H-$(3)-$(4).tmp
 	@touch tmp/check-stage$(1)-T-$(2)-H-$(3)-$(4).log
 	@$(CFG_ADB) pull $(CFG_ADB_TEST_DIR)/check-stage$(1)-T-$(2)-H-$(3)-$(4).log tmp/
 	@$(CFG_ADB) shell rm $(CFG_ADB_TEST_DIR)/check-stage$(1)-T-$(2)-H-$(3)-$(4).log
+	@$(CFG_ADB) pull $(CFG_ADB_TEST_DIR)/$$(call TEST_RATCHET_FILE,$(1),$(2),$(3),$(4)) tmp/
 	@if grep -q "result: ok" tmp/check-stage$(1)-T-$(2)-H-$(3)-$(4).tmp; \
 	then \
 		rm tmp/check-stage$(1)-T-$(2)-H-$(3)-$(4).tmp; \

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -143,8 +143,9 @@ CFG_ADB_TEST_DIR=/data/tmp
 
 $(info check: android device test dir $(CFG_ADB_TEST_DIR) ready \
  $(shell adb remount 1>/dev/null) \
- $(shell adb shell mkdir $(CFG_ADB_TEST_DIR) 1>/dev/null) \
- $(shell adb shell rm -rf $(CFG_ADB_TEST_DIR)/* 1>/dev/null) \
+ $(shell adb shell rm -r $(CFG_ADB_TEST_DIR) >/dev/null) \
+ $(shell adb shell mkdir $(CFG_ADB_TEST_DIR)) \
+ $(shell adb shell mkdir $(CFG_ADB_TEST_DIR)/tmp) \
  $(shell adb push $(S)src/etc/adb_run_wrapper.sh $(CFG_ADB_TEST_DIR) 1>/dev/null) \
  $(shell adb push $(CFG_ANDROID_CROSS_PATH)/arm-linux-androideabi/lib/armv7-a/libgnustl_shared.so \
                   $(CFG_ADB_TEST_DIR) 1>/dev/null) \
@@ -408,10 +409,10 @@ $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
 		$(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2))
 	@$$(call E, run: $$< via adb)
 	@$(CFG_ADB) push $$< $(CFG_ADB_TEST_DIR)
-	@$(CFG_ADB) shell LD_LIBRARY_PATH=$(CFG_ADB_TEST_DIR) \
-        $(CFG_ADB_TEST_DIR)/`echo $$< | sed 's/.*\///'` \
-		--logfile $(CFG_ADB_TEST_DIR)/check-stage$(1)-T-$(2)-H-$(3)-$(4).log > \
-		tmp/check-stage$(1)-T-$(2)-H-$(3)-$(4).tmp
+	@$(CFG_ADB) shell '(cd $(CFG_ADB_TEST_DIR); LD_LIBRARY_PATH=. \
+		./$$(notdir $$<) \
+		--logfile $(CFG_ADB_TEST_DIR)/check-stage$(1)-T-$(2)-H-$(3)-$(4).log)' \
+		> tmp/check-stage$(1)-T-$(2)-H-$(3)-$(4).tmp
 	@cat tmp/check-stage$(1)-T-$(2)-H-$(3)-$(4).tmp
 	@touch tmp/check-stage$(1)-T-$(2)-H-$(3)-$(4).log
 	@$(CFG_ADB) pull $(CFG_ADB_TEST_DIR)/check-stage$(1)-T-$(2)-H-$(3)-$(4).log tmp/


### PR DESCRIPTION
`stdtest` and `extratest` expects to be able to write to `tmp` directory under the current working directory, so the first commit creates `tmp` directory and changes the directory before running tests.

The second commit adds `--bench` argument to test runs and copies metrics from the remote device.
