### PR TITLE
Newrt file io

### DIFF
--- a/src/libstd/rt/io/file.rs
+++ b/src/libstd/rt/io/file.rs
@@ -192,7 +192,7 @@ impl Seek for FileStream {
 fn file_test_smoke_test_impl() {
     do run_in_newsched_task {
         let message = "it's alright. have a good time";
-        let filename = &Path("./rt_io_file_test.txt");
+        let filename = &Path("./tmp/file_rt_io_file_test.txt");
         {
             let mut write_stream = FileStream::open(filename, Create, ReadWrite).unwrap();
             write_stream.write(message.as_bytes());
@@ -218,7 +218,7 @@ fn file_test_io_smoke_test() {
 
 fn file_test_invalid_path_opened_without_create_should_raise_condition_impl() {
     do run_in_newsched_task {
-        let filename = &Path("./file_that_does_not_exist.txt");
+        let filename = &Path("./tmp/file_that_does_not_exist.txt");
         let mut called = false;
         do io_error::cond.trap(|_| {
             called = true;
@@ -236,7 +236,7 @@ fn file_test_io_invalid_path_opened_without_create_should_raise_condition() {
 
 fn file_test_unlinking_invalid_path_should_raise_condition_impl() {
     do run_in_newsched_task {
-        let filename = &Path("./another_file_that_does_not_exist.txt");
+        let filename = &Path("./tmp/file_another_file_that_does_not_exist.txt");
         let mut called = false;
         do io_error::cond.trap(|_| {
             called = true;
@@ -256,7 +256,7 @@ fn file_test_io_non_positional_read_impl() {
         use str;
         let message = "ten-four";
         let mut read_mem = [0, .. 8];
-        let filename = &Path("./rt_io_file_test_positional.txt");
+        let filename = &Path("./tmp/file_rt_io_file_test_positional.txt");
         {
             let mut rw_stream = FileStream::open(filename, Create, ReadWrite).unwrap();
             rw_stream.write(message.as_bytes());
@@ -291,7 +291,7 @@ fn file_test_io_seeking_impl() {
         let set_cursor = 4 as u64;
         let mut tell_pos_pre_read;
         let mut tell_pos_post_read;
-        let filename = &Path("./rt_io_file_test_seeking.txt");
+        let filename = &Path("./tmp/file_rt_io_file_test_seeking.txt");
         {
             let mut rw_stream = FileStream::open(filename, Create, ReadWrite).unwrap();
             rw_stream.write(message.as_bytes());
@@ -324,7 +324,7 @@ fn file_test_io_seek_and_write_impl() {
         let final_msg =     "foo-the-bar!!";
         let seek_idx = 3;
         let mut read_mem = [0, .. 13];
-        let filename = &Path("./rt_io_file_test_seek_and_write.txt");
+        let filename = &Path("./tmp/file_rt_io_file_test_seek_and_write.txt");
         {
             let mut rw_stream = FileStream::open(filename, Create, ReadWrite).unwrap();
             rw_stream.write(initial_msg.as_bytes());
@@ -354,7 +354,7 @@ fn file_test_io_seek_shakedown_impl() {
         let chunk_two = "asdf";
         let chunk_three = "zxcv";
         let mut read_mem = [0, .. 4];
-        let filename = &Path("./rt_io_file_test_seek_shakedown.txt");
+        let filename = &Path("./tmp/file_rt_io_file_test_seek_shakedown.txt");
         {
             let mut rw_stream = FileStream::open(filename, Create, ReadWrite).unwrap();
             rw_stream.write(initial_msg.as_bytes());

--- a/src/libstd/rt/io/file.rs
+++ b/src/libstd/rt/io/file.rs
@@ -238,7 +238,7 @@ fn file_test_unlinking_invalid_path_should_raise_condition_impl() {
     do run_in_newsched_task {
         let filename = &Path("./another_file_that_does_not_exist.txt");
         let mut called = false;
-        do io_error::cond.trap(|e| {
+        do io_error::cond.trap(|_| {
             called = true;
         }).inside {
             FileStream::unlink(filename);

--- a/src/libstd/rt/io/file.rs
+++ b/src/libstd/rt/io/file.rs
@@ -170,15 +170,9 @@ impl Seek for FileStream {
     }
 
     fn seek(&mut self, pos: i64, style: SeekStyle) {
-        use libc::{SEEK_SET, SEEK_CUR, SEEK_END};
-        let whence = match style {
-            SeekSet => SEEK_SET,
-            SeekCur => SEEK_CUR,
-            SeekEnd => SEEK_END
-        } as i64;
-        match self.fd.seek(pos, whence) {
+        match self.fd.seek(pos, style) {
             Ok(_) => {
-                // successful seek resets EOF indocator
+                // successful seek resets EOF indicator
                 self.last_nread = -1;
                 ()
             },

--- a/src/libstd/rt/io/mod.rs
+++ b/src/libstd/rt/io/mod.rs
@@ -540,3 +540,27 @@ pub fn placeholder_error() -> IoError {
         detail: None
     }
 }
+
+/// Instructions on how to open a file and return a `FileStream`.
+pub enum FileMode {
+    /// Opens an existing file. IoError if file does not exist.
+    Open,
+    /// Creates a file. IoError if file exists.
+    Create,
+    /// Opens an existing file or creates a new one.
+    OpenOrCreate,
+    /// Opens an existing file or creates a new one, positioned at EOF.
+    Append,
+    /// Opens an existing file, truncating it to 0 bytes.
+    Truncate,
+    /// Opens an existing file or creates a new one, truncating it to 0 bytes.
+    CreateOrTruncate,
+}
+
+/// Access permissions with which the file should be opened.
+/// `FileStream`s opened with `Read` will raise an `io_error` condition if written to.
+pub enum FileAccess {
+    Read,
+    Write,
+    ReadWrite
+}

--- a/src/libstd/rt/io/mod.rs
+++ b/src/libstd/rt/io/mod.rs
@@ -461,6 +461,7 @@ pub enum SeekStyle {
 /// # XXX
 /// * Are `u64` and `i64` the right choices?
 pub trait Seek {
+    /// Return position of file cursor in the stream
     fn tell(&self) -> u64;
 
     /// Seek to an offset in a stream

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -16,6 +16,7 @@ use rt::io::IoError;
 use super::io::net::ip::{IpAddr, SocketAddr};
 use rt::uv::uvio;
 use path::Path;
+use super::io::support::PathLike;
 
 // XXX: ~object doesn't work currently so these are some placeholder
 // types to use instead
@@ -66,9 +67,9 @@ pub trait IoFactory {
     fn udp_bind(&mut self, addr: SocketAddr) -> Result<~RtioUdpSocketObject, IoError>;
     fn timer_init(&mut self) -> Result<~RtioTimerObject, IoError>;
     fn fs_from_raw_fd(&mut self, fd: c_int, close_on_drop: bool) -> ~RtioFileDescriptor;
-    fn fs_open(&mut self, path: Path, flags: int, mode:int)
+    fn fs_open<P: PathLike>(&mut self, path: &P, flags: int, mode:int)
         -> Result<~RtioFileDescriptor, IoError>;
-    fn fs_unlink(&mut self, path: Path) -> Result<(), IoError>;
+    fn fs_unlink<P: PathLike>(&mut self, path: &P) -> Result<(), IoError>;
 }
 
 pub trait RtioTcpListener : RtioSocket {

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -17,6 +17,7 @@ use super::io::net::ip::{IpAddr, SocketAddr};
 use rt::uv::uvio;
 use path::Path;
 use super::io::support::PathLike;
+use super::io::{SeekStyle};
 
 // XXX: ~object doesn't work currently so these are some placeholder
 // types to use instead
@@ -118,7 +119,7 @@ pub trait RtioFileStream {
     fn write(&mut self, buf: &[u8]) -> Result<(), IoError>;
     fn pread(&mut self, buf: &mut [u8], offset: u64) -> Result<int, IoError>;
     fn pwrite(&mut self, buf: &[u8], offset: u64) -> Result<(), IoError>;
-    fn seek(&mut self, pos: i64, whence: i64) -> Result<(), IoError>;
+    fn seek(&mut self, pos: i64, whence: SeekStyle) -> Result<u64, IoError>;
     fn tell(&self) -> Result<u64, IoError>;
     fn flush(&mut self) -> Result<(), IoError>;
 }

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -66,9 +66,9 @@ pub trait IoFactory {
     fn tcp_bind(&mut self, addr: SocketAddr) -> Result<~RtioTcpListenerObject, IoError>;
     fn udp_bind(&mut self, addr: SocketAddr) -> Result<~RtioUdpSocketObject, IoError>;
     fn timer_init(&mut self) -> Result<~RtioTimerObject, IoError>;
-    fn fs_from_raw_fd(&mut self, fd: c_int, close_on_drop: bool) -> ~RtioFileDescriptor;
+    fn fs_from_raw_fd(&mut self, fd: c_int, close_on_drop: bool) -> ~RtioFileStream;
     fn fs_open<P: PathLike>(&mut self, path: &P, flags: int, mode:int)
-        -> Result<~RtioFileDescriptor, IoError>;
+        -> Result<~RtioFileStream, IoError>;
     fn fs_unlink<P: PathLike>(&mut self, path: &P) -> Result<(), IoError>;
 }
 
@@ -113,7 +113,12 @@ pub trait RtioTimer {
     fn sleep(&mut self, msecs: u64);
 }
 
-pub trait RtioFileDescriptor {
-    fn read(&mut self, buf: &mut [u8], offset: i64) -> Result<int, IoError>;
-    fn write(&mut self, buf: &[u8], offset: i64) -> Result<(), IoError>;
+pub trait RtioFileStream {
+    fn read(&mut self, buf: &mut [u8]) -> Result<int, IoError>;
+    fn write(&mut self, buf: &[u8]) -> Result<(), IoError>;
+    fn pread(&mut self, buf: &mut [u8], offset: u64) -> Result<int, IoError>;
+    fn pwrite(&mut self, buf: &[u8], offset: u64) -> Result<(), IoError>;
+    fn seek(&mut self, pos: i64, whence: i64) -> Result<(), IoError>;
+    fn tell(&self) -> Result<u64, IoError>;
+    fn flush(&mut self) -> Result<(), IoError>;
 }

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -18,6 +18,7 @@ use rt::uv::uvio;
 use path::Path;
 use super::io::support::PathLike;
 use super::io::{SeekStyle};
+use super::io::{FileMode, FileAccess};
 
 // XXX: ~object doesn't work currently so these are some placeholder
 // types to use instead
@@ -68,7 +69,7 @@ pub trait IoFactory {
     fn udp_bind(&mut self, addr: SocketAddr) -> Result<~RtioUdpSocketObject, IoError>;
     fn timer_init(&mut self) -> Result<~RtioTimerObject, IoError>;
     fn fs_from_raw_fd(&mut self, fd: c_int, close_on_drop: bool) -> ~RtioFileStream;
-    fn fs_open<P: PathLike>(&mut self, path: &P, flags: int, mode:int)
+    fn fs_open<P: PathLike>(&mut self, path: &P, fm: FileMode, fa: FileAccess)
         -> Result<~RtioFileStream, IoError>;
     fn fs_unlink<P: PathLike>(&mut self, path: &P) -> Result<(), IoError>;
 }

--- a/src/libstd/rt/uv/file.rs
+++ b/src/libstd/rt/uv/file.rs
@@ -416,7 +416,7 @@ mod test {
         let stdout = FileDescriptor(STDOUT_FILENO);
         let write_val = input.as_bytes();
         let write_buf = slice_to_uv_buf(write_val);
-        stdout.write_sync(loop_, write_buf, 0);
+        stdout.write_sync(loop_, write_buf, -1);
     }
 
     #[test]

--- a/src/libstd/rt/uv/file.rs
+++ b/src/libstd/rt/uv/file.rs
@@ -59,7 +59,8 @@ impl FsRequest {
         FsRequest::open_common(loop_, path, flags, mode, Some(cb));
     }
 
-    pub fn open_sync<P: PathLike>(loop_: &Loop, path: &P, flags: int, mode: int) -> Result<int, UvError> {
+    pub fn open_sync<P: PathLike>(loop_: &Loop, path: &P, flags: int, mode: int)
+          -> Result<int, UvError> {
         let result = FsRequest::open_common(loop_, path, flags, mode, None);
         sync_cleanup(loop_, result)
     }

--- a/src/libstd/rt/uv/file.rs
+++ b/src/libstd/rt/uv/file.rs
@@ -281,7 +281,7 @@ mod test {
                 // these aren't defined in std::libc :(
                 //map_mode(S_IRGRP) |
                 //map_mode(S_IROTH);
-            let path_str = "./file_full_simple.txt";
+            let path_str = "./tmp/file_full_simple.txt";
             let write_val = "hello".as_bytes().to_owned();
             let write_buf  = slice_to_uv_buf(write_val);
             let write_buf_ptr: *Buf = &write_buf;
@@ -352,7 +352,7 @@ mod test {
                 S_IRUSR;
                 //S_IRGRP |
                 //S_IROTH;
-            let path_str = "./file_full_simple_sync.txt";
+            let path_str = "./tmp/file_full_simple_sync.txt";
             let write_val = "hello".as_bytes().to_owned();
             let write_buf = slice_to_uv_buf(write_val);
             // open/create

--- a/src/libstd/rt/uv/file.rs
+++ b/src/libstd/rt/uv/file.rs
@@ -11,30 +11,87 @@
 use prelude::*;
 use ptr::null;
 use libc::c_void;
-use rt::uv::{Request, NativeHandle, Loop, FsCallback};
+use rt::uv::{Request, NativeHandle, Loop, FsCallback,
+             status_to_maybe_uv_error_with_loop};
 use rt::uv::uvll;
 use rt::uv::uvll::*;
+use path::Path;
+use cast::transmute;
+use libc::{c_int};
 
 pub struct FsRequest(*uvll::uv_fs_t);
 impl Request for FsRequest;
 
+#[allow(non_camel_case_types)]
+pub enum UvFileFlag {
+    O_RDONLY,
+    O_WRONLY,
+    O_RDWR,
+    O_CREAT,
+    O_TRUNC
+}
+pub fn map_flag(v: UvFileFlag) -> int {
+    unsafe {
+        match v {
+            O_RDONLY => uvll::get_O_RDONLY() as int,
+            O_WRONLY => uvll::get_O_WRONLY() as int,
+            O_RDWR => uvll::get_O_RDWR() as int,
+            O_CREAT => uvll::get_O_CREAT() as int,
+            O_TRUNC => uvll::get_O_TRUNC() as int
+        }
+    }
+}
+
+pub struct RequestData {
+    complete_cb: Option<FsCallback>
+}
+
 impl FsRequest {
-    fn new() -> FsRequest {
+    pub fn new(cb: Option<FsCallback>) -> FsRequest {
         let fs_req = unsafe { malloc_req(UV_FS) };
         assert!(fs_req.is_not_null());
-        let fs_req = fs_req as *uvll::uv_write_t;
-        unsafe { uvll::set_data_for_req(fs_req, null::<()>()); }
-        NativeHandle::from_native_handle(fs_req)
+        let fs_req: FsRequest = NativeHandle::from_native_handle(fs_req);
+        fs_req.install_req_data(cb);
+        fs_req
     }
 
-    fn delete(self) {
-        unsafe { free_req(self.native_handle() as *c_void) }
+    pub fn install_req_data(&self, cb: Option<FsCallback>) {
+        let fs_req = (self.native_handle()) as *uvll::uv_write_t;
+        let data = ~RequestData {
+            complete_cb: cb
+        };
+        unsafe {
+            let data = transmute::<~RequestData, *c_void>(data);
+            uvll::set_data_for_req(fs_req, data);
+        }
     }
 
-    fn open(&mut self, _loop_: &Loop, _cb: FsCallback) {
+    fn get_req_data<'r>(&'r mut self) -> &'r mut RequestData {
+        unsafe {
+            let data = uvll::get_data_for_req((self.native_handle()));
+            let data = transmute::<&*c_void, &mut ~RequestData>(&data);
+            return &mut **data;
+        }
     }
 
-    fn close(&mut self, _loop_: &Loop, _cb: FsCallback) {
+    pub fn get_result(&mut self) -> c_int {
+        unsafe {
+            uvll::get_result_from_fs_req(self.native_handle())
+        }
+    }
+
+    pub fn get_loop(&self) -> Loop {
+        unsafe { Loop{handle:uvll::get_loop_from_fs_req(self.native_handle())} }
+    }
+
+    fn cleanup_and_delete(self) {
+        unsafe {
+            uvll::fs_req_cleanup(self.native_handle());
+            let data = uvll::get_data_for_uv_handle(self.native_handle());
+            let _data = transmute::<*c_void, ~RequestData>(data);
+            uvll::set_data_for_uv_handle(self.native_handle(), null::<()>());
+            free_req(self.native_handle() as *c_void)
+        }
     }
 }
 
@@ -44,5 +101,99 @@ impl NativeHandle<*uvll::uv_fs_t> for FsRequest {
     }
     fn native_handle(&self) -> *uvll::uv_fs_t {
         match self { &FsRequest(ptr) => ptr }
+    }
+}
+
+pub struct FileDescriptor(c_int);
+impl FileDescriptor {
+    fn new(fd: c_int) -> FileDescriptor {
+        FileDescriptor(fd)
+    }
+
+    pub fn from_open_req(req: &mut FsRequest) -> FileDescriptor {
+        FileDescriptor::new(req.get_result())
+    }
+
+    pub fn open(loop_: Loop, path: Path, flags: int, mode: int,
+               cb: FsCallback) -> int {
+        let req = FsRequest::new(Some(cb));
+        path.to_str().to_c_str().with_ref(|p| unsafe {
+            uvll::fs_open(loop_.native_handle(),
+                          req.native_handle(), p, flags, mode, complete_cb) as int
+        })
+
+    }
+
+    fn close(self, loop_: Loop, cb: FsCallback) -> int {
+        let req = FsRequest::new(Some(cb));
+        unsafe {
+            uvll::fs_close(loop_.native_handle(), req.native_handle(),
+                           self.native_handle(), complete_cb) as int
+        }
+    }
+}
+extern fn complete_cb(req: *uv_fs_t) {
+    let mut req: FsRequest = NativeHandle::from_native_handle(req);
+    let loop_ = req.get_loop();
+    // pull the user cb out of the req data
+    let cb = {
+        let data = req.get_req_data();
+        assert!(data.complete_cb.is_some());
+        // option dance, option dance. oooooh yeah.
+        data.complete_cb.take_unwrap()
+    };
+    // in uv_fs_open calls, the result will be the fd in the
+    // case of success, otherwise it's -1 indicating an error
+    let result = req.get_result();
+    let status = status_to_maybe_uv_error_with_loop(
+        loop_.native_handle(), result);
+    // we have a req and status, call the user cb..
+    // only giving the user a ref to the FsRequest, as we
+    // have to clean it up, afterwards (and they aren't really
+    // reusable, anyways
+    cb(&mut req, status);
+    // clean up the req (and its data!) after calling the user cb
+    req.cleanup_and_delete();
+}
+
+impl NativeHandle<c_int> for FileDescriptor {
+    fn from_native_handle(handle: c_int) -> FileDescriptor {
+        FileDescriptor(handle)
+    }
+    fn native_handle(&self) -> c_int {
+        match self { &FileDescriptor(ptr) => ptr }
+    }
+}
+
+mod test {
+    use super::*;
+    //use rt::test::*;
+    use unstable::run_in_bare_thread;
+    use path::Path;
+    use rt::uv::Loop;
+
+    // this is equiv to touch, i guess?
+    fn file_test_touch_impl() {
+        debug!("hello?")
+        do run_in_bare_thread {
+            debug!("In bare thread")
+            let loop_ = Loop::new();
+            let flags = map_flag(O_RDWR) |
+                map_flag(O_CREAT) | map_flag(O_TRUNC);
+            do FileDescriptor::open(loop_, Path("./foo.txt"), flags, 0644)
+            |req, uverr| {
+                let loop_ = req.get_loop();
+                assert!(uverr.is_none());
+                let fd = FileDescriptor::from_open_req(req);
+                do fd.close(loop_) |_, uverr| {
+                    assert!(uverr.is_none());
+                };
+            };
+        }
+    }
+
+    #[test]
+    fn file_test_touch() {
+        file_test_touch_impl();
     }
 }

--- a/src/libstd/rt/uv/file.rs
+++ b/src/libstd/rt/uv/file.rs
@@ -11,8 +11,9 @@
 use prelude::*;
 use ptr::null;
 use libc::c_void;
-use rt::uv::{Request, NativeHandle, Loop, FsCallback,
-             status_to_maybe_uv_error_with_loop};
+use rt::uv::{Request, NativeHandle, Loop, FsCallback, Buf,
+             status_to_maybe_uv_error_with_loop,
+             vec_to_uv_buf};//, vec_from_uv_buf};
 use rt::uv::uvll;
 use rt::uv::uvll::*;
 use path::Path;
@@ -30,6 +31,14 @@ pub enum UvFileFlag {
     O_CREAT,
     O_TRUNC
 }
+// just want enough to get 0644
+#[allow(non_camel_case_types)]
+pub enum UvFileMode {
+    S_IWUSR,
+    S_IRUSR,
+    S_IRGRP,
+    S_IROTH
+}
 pub fn map_flag(v: UvFileFlag) -> int {
     unsafe {
         match v {
@@ -41,9 +50,21 @@ pub fn map_flag(v: UvFileFlag) -> int {
         }
     }
 }
+pub fn map_mode(v: UvFileMode) -> int {
+    unsafe {
+        match v {
+            S_IWUSR => uvll::get_S_IWUSR() as int,
+            S_IRUSR => uvll::get_S_IRUSR() as int,
+            S_IRGRP => uvll::get_S_IRGRP() as int,
+            S_IROTH => uvll::get_S_IROTH() as int
+        }
+    }
+}
 
 pub struct RequestData {
-    complete_cb: Option<FsCallback>
+    complete_cb: Option<FsCallback>,
+    buf: Option<Buf>,
+    raw_fd: Option<c_int>
 }
 
 impl FsRequest {
@@ -58,7 +79,9 @@ impl FsRequest {
     pub fn install_req_data(&self, cb: Option<FsCallback>) {
         let fs_req = (self.native_handle()) as *uvll::uv_write_t;
         let data = ~RequestData {
-            complete_cb: cb
+            complete_cb: cb,
+            buf: None,
+            raw_fd: None
         };
         unsafe {
             let data = transmute::<~RequestData, *c_void>(data);
@@ -86,10 +109,10 @@ impl FsRequest {
 
     fn cleanup_and_delete(self) {
         unsafe {
-            uvll::fs_req_cleanup(self.native_handle());
-            let data = uvll::get_data_for_uv_handle(self.native_handle());
+            let data = uvll::get_data_for_req(self.native_handle());
             let _data = transmute::<*c_void, ~RequestData>(data);
-            uvll::set_data_for_uv_handle(self.native_handle(), null::<()>());
+            uvll::set_data_for_req(self.native_handle(), null::<()>());
+            uvll::fs_req_cleanup(self.native_handle());
             free_req(self.native_handle() as *c_void)
         }
     }
@@ -121,10 +144,24 @@ impl FileDescriptor {
             uvll::fs_open(loop_.native_handle(),
                           req.native_handle(), p, flags, mode, complete_cb) as int
         })
-
     }
 
-    fn close(self, loop_: Loop, cb: FsCallback) -> int {
+    pub fn write(&self, loop_: Loop, buf: ~[u8], offset: i64, cb: FsCallback)
+          -> int {
+        let mut req = FsRequest::new(Some(cb));
+        let len = buf.len();
+        let buf = vec_to_uv_buf(buf);
+        let base_ptr = buf.base as *c_void;
+        req.get_req_data().buf = Some(buf);
+        req.get_req_data().raw_fd = Some(self.native_handle());
+        unsafe {
+            uvll::fs_write(loop_.native_handle(), req.native_handle(),
+                           self.native_handle(), base_ptr,
+                           len, offset, complete_cb) as int
+        }
+    }
+
+    pub fn close(self, loop_: Loop, cb: FsCallback) -> int {
         let req = FsRequest::new(Some(cb));
         unsafe {
             uvll::fs_close(loop_.native_handle(), req.native_handle(),
@@ -170,17 +207,22 @@ mod test {
     //use rt::test::*;
     use unstable::run_in_bare_thread;
     use path::Path;
-    use rt::uv::Loop;
+    use rt::uv::{Loop};//, slice_to_uv_buf};
 
     // this is equiv to touch, i guess?
     fn file_test_touch_impl() {
         debug!("hello?")
         do run_in_bare_thread {
             debug!("In bare thread")
-            let loop_ = Loop::new();
+            let mut loop_ = Loop::new();
             let flags = map_flag(O_RDWR) |
-                map_flag(O_CREAT) | map_flag(O_TRUNC);
-            do FileDescriptor::open(loop_, Path("./foo.txt"), flags, 0644)
+                map_flag(O_CREAT);
+            // 0644
+            let mode = map_mode(S_IWUSR) |
+                map_mode(S_IRUSR) |
+                map_mode(S_IRGRP) |
+                map_mode(S_IROTH);
+            do FileDescriptor::open(loop_, Path("./foo.txt"), flags, mode)
             |req, uverr| {
                 let loop_ = req.get_loop();
                 assert!(uverr.is_none());
@@ -189,11 +231,64 @@ mod test {
                     assert!(uverr.is_none());
                 };
             };
+            loop_.run();
         }
     }
 
     #[test]
     fn file_test_touch() {
         file_test_touch_impl();
+    }
+
+    fn file_test_tee_impl() {
+        debug!("hello?")
+        do run_in_bare_thread {
+            debug!("In bare thread")
+            let mut loop_ = Loop::new();
+            let flags = map_flag(O_RDWR) |
+                map_flag(O_CREAT);
+            // 0644
+            let mode = map_mode(S_IWUSR) |
+                map_mode(S_IRUSR) |
+                map_mode(S_IRGRP) |
+                map_mode(S_IROTH);
+            do FileDescriptor::open(loop_, Path("./file_tee_test.txt"), flags, mode)
+            |req, uverr| {
+                let loop_ = req.get_loop();
+                assert!(uverr.is_none());
+                let fd = FileDescriptor::from_open_req(req);
+                let msg: ~[u8] = "hello world".as_bytes().to_owned();
+                let raw_fd = fd.native_handle();
+                do fd.write(loop_, msg, -1) |_, uverr| {
+                    let fd = FileDescriptor(raw_fd);
+                    do fd.close(loop_) |_, _| {
+                        assert!(uverr.is_none());
+                    };
+                };
+            };
+            loop_.run();
+        }
+    }
+
+    #[test]
+    fn file_test_tee() {
+        file_test_tee_impl();
+    }
+
+    fn naive_print(input: ~str) {
+        do run_in_bare_thread {
+            let mut loop_ = Loop::new();
+            let stdout = FileDescriptor(1);
+            let msg = input.as_bytes().to_owned();
+            do stdout.write(loop_, msg, -1) |_, uverr| {
+                assert!(uverr.is_none());
+            };
+            loop_.run();
+        }
+    }
+
+    #[test]
+    fn file_test_println() {
+        naive_print(~"oh yeah.\n");
     }
 }

--- a/src/libstd/rt/uv/uvio.rs
+++ b/src/libstd/rt/uv/uvio.rs
@@ -1711,7 +1711,7 @@ fn file_test_uvio_full_simple_impl() {
         let ro_flags = O_RDONLY;
         let write_val = "hello uvio!";
         let mode = S_IWUSR | S_IRUSR;
-        let path = "./file_test_uvio_full.txt";
+        let path = "./tmp/file_test_uvio_full.txt";
         {
             let mut fd = (*io).fs_open(&Path(path), create_flags as int, mode as int).unwrap();
             let write_buf = write_val.as_bytes();

--- a/src/libstd/rt/uv/uvio.rs
+++ b/src/libstd/rt/uv/uvio.rs
@@ -31,6 +31,7 @@ use rt::uv::idle::IdleWatcher;
 use rt::uv::net::{UvIpv4SocketAddr, UvIpv6SocketAddr};
 use unstable::sync::Exclusive;
 use super::super::io::support::PathLike;
+use libc::{lseek, c_long, SEEK_CUR};
 
 #[cfg(test)] use container::Container;
 #[cfg(test)] use unstable::run_in_bare_thread;
@@ -458,19 +459,20 @@ impl IoFactory for UvIoFactory {
         Ok(~UvTimer::new(watcher, home))
     }
 
-    fn fs_from_raw_fd(&mut self, fd: c_int, close_on_drop: bool) -> ~RtioFileDescriptor {
-        ~UvFileDescriptor {
+    fn fs_from_raw_fd(&mut self, fd: c_int, close_on_drop: bool) -> ~RtioFileStream {
+        ~UvFileStream {
             loop_: Loop{handle:self.uv_loop().native_handle()},
             fd: file::FileDescriptor(fd),
-            close_on_drop: close_on_drop
-        } as ~RtioFileDescriptor
+            close_on_drop: close_on_drop,
+        } as ~RtioFileStream
     }
 
     fn fs_open<P: PathLike>(&mut self, path: &P, flags: int, mode: int)
-        -> Result<~RtioFileDescriptor, IoError> {
+        -> Result<~RtioFileStream, IoError> {
         let loop_ = Loop {handle: self.uv_loop().native_handle()};
         let result_cell = Cell::new_empty();
-        let result_cell_ptr: *Cell<Result<~RtioFileDescriptor, IoError>> = &result_cell;
+        let result_cell_ptr: *Cell<Result<~RtioFileStream,
+                                           IoError>> = &result_cell;
         let path_cell = Cell::new(path);
         let scheduler = Local::take::<Scheduler>();
         do scheduler.deschedule_running_task_and_then |_, task| {
@@ -478,10 +480,10 @@ impl IoFactory for UvIoFactory {
             let path = path_cell.take();
             do file::FileDescriptor::open(loop_, path, flags, mode) |req,err| {
                 if err.is_none() {
-                    let res = Ok(~UvFileDescriptor {
+                    let res = Ok(~UvFileStream {
                         loop_: loop_,
                         fd: file::FileDescriptor(req.get_result()),
-                        close_on_drop: true} as ~RtioFileDescriptor);
+                        close_on_drop: true} as ~RtioFileStream);
                     unsafe { (*result_cell_ptr).put_back(res); }
                     let scheduler = Local::take::<Scheduler>();
                     scheduler.resume_blocked_task_immediately(task_cell.take());
@@ -1056,32 +1058,14 @@ impl RtioTimer for UvTimer {
     }
 }
 
-pub struct UvFileDescriptor {
+pub struct UvFileStream {
     loop_: Loop,
     fd: file::FileDescriptor,
     close_on_drop: bool
 }
 
-impl UvFileDescriptor {
-}
-
-impl Drop for UvFileDescriptor {
-    fn drop(&self) {
-        if self.close_on_drop {
-            let scheduler = Local::take::<Scheduler>();
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let task_cell = Cell::new(task);
-                do self.fd.close(self.loop_) |_,_| {
-                    let scheduler = Local::take::<Scheduler>();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                };
-            };
-        }
-    }
-}
-
-impl RtioFileDescriptor for UvFileDescriptor {
-    fn read(&mut self, buf: &mut [u8], offset: i64) -> Result<int, IoError> {
+impl UvFileStream {
+    fn base_read(&mut self, buf: &mut [u8], offset: i64) -> Result<int, IoError> {
         let scheduler = Local::take::<Scheduler>();
         let result_cell = Cell::new_empty();
         let result_cell_ptr: *Cell<Result<int, IoError>> = &result_cell;
@@ -1101,7 +1085,7 @@ impl RtioFileDescriptor for UvFileDescriptor {
         };
         result_cell.take()
     }
-    fn write(&mut self, buf: &[u8], offset: i64) -> Result<(), IoError> {
+    fn base_write(&mut self, buf: &[u8], offset: i64) -> Result<(), IoError> {
         let scheduler = Local::take::<Scheduler>();
         let result_cell = Cell::new_empty();
         let result_cell_ptr: *Cell<Result<(), IoError>> = &result_cell;
@@ -1120,6 +1104,69 @@ impl RtioFileDescriptor for UvFileDescriptor {
             };
         };
         result_cell.take()
+    }
+}
+
+impl Drop for UvFileStream {
+    fn drop(&self) {
+        if self.close_on_drop {
+            let scheduler = Local::take::<Scheduler>();
+            do scheduler.deschedule_running_task_and_then |_, task| {
+                let task_cell = Cell::new(task);
+                do self.fd.close(self.loop_) |_,_| {
+                    let scheduler = Local::take::<Scheduler>();
+                    scheduler.resume_blocked_task_immediately(task_cell.take());
+                };
+            };
+        }
+    }
+}
+
+impl RtioFileStream for UvFileStream {
+    fn read(&mut self, buf: &mut [u8]) -> Result<int, IoError> {
+        self.base_read(buf, -1)
+    }
+    fn write(&mut self, buf: &[u8]) -> Result<(), IoError> {
+        self.base_write(buf, -1)
+    }
+    fn pread(&mut self, buf: &mut [u8], offset: u64) -> Result<int, IoError> {
+        self.base_read(buf, offset as i64)
+    }
+    fn pwrite(&mut self, buf: &[u8], offset: u64) -> Result<(), IoError> {
+        self.base_write(buf, offset as i64)
+    }
+    fn seek(&mut self, pos: i64, whence: i64) -> Result<(), IoError> {
+        #[fixed_stack_segment]; #[inline(never)];
+        unsafe {
+            match lseek((*self.fd), pos as c_long, whence as c_int) {
+                -1 => {
+                    Err(IoError {
+                        kind: OtherIoError,
+                        desc: "Failed to lseek.",
+                        detail: None
+                    })
+                },
+                _ => Ok(())
+            }
+        }
+    }
+    fn tell(&self) -> Result<u64, IoError> {
+        #[fixed_stack_segment]; #[inline(never)];
+        unsafe {
+            match lseek((*self.fd), 0, SEEK_CUR) {
+                -1 => {
+                    Err(IoError {
+                        kind: OtherIoError,
+                        desc: "Failed to lseek, needed to tell().",
+                        detail: None
+                    })
+                },
+                n=> Ok(n as u64)
+            }
+        }
+    }
+    fn flush(&mut self) -> Result<(), IoError> {
+        Ok(())
     }
 }
 
@@ -1647,12 +1694,12 @@ fn file_test_uvio_full_simple_impl() {
         {
             let mut fd = (*io).fs_open(&Path(path), create_flags as int, mode as int).unwrap();
             let write_buf = write_val.as_bytes();
-            fd.write(write_buf, 0);
+            fd.write(write_buf);
         }
         {
             let mut fd = (*io).fs_open(&Path(path), ro_flags as int, mode as int).unwrap();
             let mut read_vec = [0, .. 1028];
-            let nread = fd.read(read_vec, 0).unwrap();
+            let nread = fd.read(read_vec).unwrap();
             let read_val = str::from_bytes(read_vec.slice(0, nread as uint));
             assert!(read_val == write_val.to_owned());
         }

--- a/src/libstd/rt/uv/uvio.rs
+++ b/src/libstd/rt/uv/uvio.rs
@@ -31,7 +31,7 @@ use rt::uv::idle::IdleWatcher;
 use rt::uv::net::{UvIpv4SocketAddr, UvIpv6SocketAddr};
 use unstable::sync::Exclusive;
 use super::super::io::support::PathLike;
-use libc::{lseek, c_long, O_CREAT, O_APPEND, O_TRUNC, O_RDWR, O_RDONLY, O_WRONLY,
+use libc::{lseek, off_t, O_CREAT, O_APPEND, O_TRUNC, O_RDWR, O_RDONLY, O_WRONLY,
           S_IRUSR, S_IWUSR};
 use rt::io::{FileMode, FileAccess, OpenOrCreate, Open, Create,
             CreateOrTruncate, Append, Truncate, Read, Write, ReadWrite};
@@ -1148,7 +1148,7 @@ impl UvFileStream {
         Result<u64, IoError>{
         #[fixed_stack_segment]; #[inline(never)];
         unsafe {
-            match lseek((*self.fd), pos as c_long, whence) {
+            match lseek((*self.fd), pos as off_t, whence) {
                 -1 => {
                     Err(IoError {
                         kind: OtherIoError,

--- a/src/libstd/rt/uv/uvio.rs
+++ b/src/libstd/rt/uv/uvio.rs
@@ -477,7 +477,7 @@ impl IoFactory for UvIoFactory {
         do scheduler.deschedule_running_task_and_then |_, task| {
             let task_cell = Cell::new(task);
             let path = path_cell.take();
-            do file::FileDescriptor::open(loop_, path, flags, mode) |req,err| {
+            do file::FsRequest::open(loop_, path, flags, mode) |req,err| {
                 if err.is_none() {
                     let home = get_handle_to_current_scheduler!();
                     let fd = file::FileDescriptor(req.get_result());
@@ -508,7 +508,7 @@ impl IoFactory for UvIoFactory {
         do scheduler.deschedule_running_task_and_then |_, task| {
             let task_cell = Cell::new(task);
             let path = path_cell.take();
-            do file::FileDescriptor::unlink(loop_, path) |_, err| {
+            do file::FsRequest::unlink(loop_, path) |_, err| {
                 let res = match err {
                     None => Ok(()),
                     Some(err) => Err(uv_error_to_io_error(err))

--- a/src/libstd/rt/uv/uvio.rs
+++ b/src/libstd/rt/uv/uvio.rs
@@ -1734,3 +1734,23 @@ fn file_test_uvio_full_simple() {
         file_test_uvio_full_simple_impl();
     }
 }
+
+fn uvio_naive_print(input: &str) {
+    use str::StrSlice;
+    unsafe {
+        use libc::{STDOUT_FILENO};
+        let io = Local::unsafe_borrow::<IoFactoryObject>();
+        {
+            let mut fd = (*io).fs_from_raw_fd(STDOUT_FILENO, false);
+            let write_buf = input.as_bytes();
+            fd.write(write_buf);
+        }
+    }
+}
+
+#[test]
+fn file_test_uvio_write_to_stdout() {
+    do run_in_newsched_task {
+        uvio_naive_print("jubilation\n");
+    }
+}

--- a/src/libstd/rt/uv/uvll.rs
+++ b/src/libstd/rt/uv/uvll.rs
@@ -621,9 +621,18 @@ pub unsafe fn fs_open(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char, flags:
                 cb: *u8) -> c_int {
     rust_uv_fs_open(loop_ptr, req, path, flags as c_int, mode as c_int, cb)
 }
+
+pub unsafe fn fs_unlink(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char,
+                cb: *u8) -> c_int {
+    rust_uv_fs_unlink(loop_ptr, req, path, cb)
+}
 pub unsafe fn fs_write(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
                        len: uint, offset: i64, cb: *u8) -> c_int {
     rust_uv_fs_write(loop_ptr, req, fd, buf, len as c_uint, offset, cb)
+}
+pub unsafe fn fs_read(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
+                       len: uint, offset: i64, cb: *u8) -> c_int {
+    rust_uv_fs_read(loop_ptr, req, fd, buf, len as c_uint, offset, cb)
 }
 pub unsafe fn fs_close(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int,
                 cb: *u8) -> c_int {
@@ -817,7 +826,11 @@ extern {
     fn rust_uv_timer_stop(handle: *uv_timer_t) -> c_int;
     fn rust_uv_fs_open(loop_ptr: *c_void, req: *uv_fs_t, path: *c_char,
                        flags: c_int, mode: c_int, cb: *u8) -> c_int;
+    fn rust_uv_fs_unlink(loop_ptr: *c_void, req: *uv_fs_t, path: *c_char,
+                       cb: *u8) -> c_int;
     fn rust_uv_fs_write(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int,
+                       buf: *c_void, len: c_uint, offset: i64, cb: *u8) -> c_int;
+    fn rust_uv_fs_read(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int,
                        buf: *c_void, len: c_uint, offset: i64, cb: *u8) -> c_int;
     fn rust_uv_fs_close(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int,
                         cb: *u8) -> c_int;

--- a/src/libstd/rt/uv/uvll.rs
+++ b/src/libstd/rt/uv/uvll.rs
@@ -617,7 +617,40 @@ pub unsafe fn ip6_port(addr: *sockaddr_in6) -> c_uint {
     return rust_uv_ip6_port(addr);
 }
 
+pub unsafe fn fs_open(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char, flags: int, mode: int,
+                cb: *u8) -> c_int {
+    rust_uv_fs_open(loop_ptr, req, path, flags as c_int, mode as c_int, cb)
+}
+pub unsafe fn fs_close(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int,
+                cb: *u8) -> c_int {
+    rust_uv_fs_close(loop_ptr, req, fd, cb)
+}
+pub unsafe fn fs_req_cleanup(req: *uv_fs_t) {
+    rust_uv_fs_req_cleanup(req);
+}
+
 // data access helpers
+pub unsafe fn get_O_RDONLY() -> c_int {
+    rust_uv_get_O_RDONLY()
+}
+pub unsafe fn get_O_WRONLY() -> c_int {
+    rust_uv_get_O_WRONLY()
+}
+pub unsafe fn get_O_RDWR() -> c_int {
+    rust_uv_get_O_RDWR()
+}
+pub unsafe fn get_O_CREAT() -> c_int {
+    rust_uv_get_O_CREAT()
+}
+pub unsafe fn get_O_TRUNC() -> c_int {
+    rust_uv_get_O_TRUNC()
+}
+pub unsafe fn get_result_from_fs_req(req: *uv_fs_t) -> c_int {
+    rust_uv_get_result_from_fs_req(req)
+}
+pub unsafe fn get_loop_from_fs_req(req: *uv_fs_t) -> *uv_loop_t {
+    rust_uv_get_loop_from_fs_req(req)
+}
 pub unsafe fn get_loop_for_uv_handle<T>(handle: *T) -> *c_void {
     #[fixed_stack_segment]; #[inline(never)];
 
@@ -784,6 +817,18 @@ extern {
     fn rust_uv_timer_start(timer_handle: *uv_timer_t, cb: uv_timer_cb, timeout: libc::uint64_t,
                            repeat: libc::uint64_t) -> c_int;
     fn rust_uv_timer_stop(handle: *uv_timer_t) -> c_int;
+    fn rust_uv_fs_open(loop_ptr: *c_void, req: *uv_fs_t, path: *c_char,
+                       flags: c_int, mode: c_int, cb: *u8) -> c_int;
+    fn rust_uv_fs_close(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int,
+                        cb: *u8) -> c_int;
+    fn rust_uv_fs_req_cleanup(req: *uv_fs_t);
+    fn rust_uv_get_O_RDONLY() -> c_int;
+    fn rust_uv_get_O_WRONLY() -> c_int;
+    fn rust_uv_get_O_RDWR() -> c_int;
+    fn rust_uv_get_O_CREAT() -> c_int;
+    fn rust_uv_get_O_TRUNC() -> c_int;
+    fn rust_uv_get_result_from_fs_req(req: *uv_fs_t) -> c_int;
+    fn rust_uv_get_loop_from_fs_req(req: *uv_fs_t) -> *uv_loop_t;
 
     fn rust_uv_get_stream_handle_from_connect_req(connect_req: *uv_connect_t) -> *uv_stream_t;
     fn rust_uv_get_stream_handle_from_write_req(write_req: *uv_write_t) -> *uv_stream_t;

--- a/src/libstd/rt/uv/uvll.rs
+++ b/src/libstd/rt/uv/uvll.rs
@@ -619,34 +619,50 @@ pub unsafe fn ip6_port(addr: *sockaddr_in6) -> c_uint {
 
 pub unsafe fn fs_open(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char, flags: int, mode: int,
                 cb: *u8) -> c_int {
+    #[fixed_stack_segment]; #[inline(never)];
+
     rust_uv_fs_open(loop_ptr, req, path, flags as c_int, mode as c_int, cb)
 }
 
 pub unsafe fn fs_unlink(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char,
                 cb: *u8) -> c_int {
+    #[fixed_stack_segment]; #[inline(never)];
+
     rust_uv_fs_unlink(loop_ptr, req, path, cb)
 }
 pub unsafe fn fs_write(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
                        len: uint, offset: i64, cb: *u8) -> c_int {
+    #[fixed_stack_segment]; #[inline(never)];
+
     rust_uv_fs_write(loop_ptr, req, fd, buf, len as c_uint, offset, cb)
 }
 pub unsafe fn fs_read(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
                        len: uint, offset: i64, cb: *u8) -> c_int {
+    #[fixed_stack_segment]; #[inline(never)];
+
     rust_uv_fs_read(loop_ptr, req, fd, buf, len as c_uint, offset, cb)
 }
 pub unsafe fn fs_close(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int,
                 cb: *u8) -> c_int {
+    #[fixed_stack_segment]; #[inline(never)];
+
     rust_uv_fs_close(loop_ptr, req, fd, cb)
 }
 pub unsafe fn fs_req_cleanup(req: *uv_fs_t) {
+    #[fixed_stack_segment]; #[inline(never)];
+
     rust_uv_fs_req_cleanup(req);
 }
 
 // data access helpers
 pub unsafe fn get_result_from_fs_req(req: *uv_fs_t) -> c_int {
+    #[fixed_stack_segment]; #[inline(never)];
+
     rust_uv_get_result_from_fs_req(req)
 }
 pub unsafe fn get_loop_from_fs_req(req: *uv_fs_t) -> *uv_loop_t {
+    #[fixed_stack_segment]; #[inline(never)];
+
     rust_uv_get_loop_from_fs_req(req)
 }
 pub unsafe fn get_loop_for_uv_handle<T>(handle: *T) -> *c_void {

--- a/src/libstd/rt/uv/uvll.rs
+++ b/src/libstd/rt/uv/uvll.rs
@@ -621,6 +621,10 @@ pub unsafe fn fs_open(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char, flags:
                 cb: *u8) -> c_int {
     rust_uv_fs_open(loop_ptr, req, path, flags as c_int, mode as c_int, cb)
 }
+pub unsafe fn fs_write(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
+                       len: uint, offset: i64, cb: *u8) -> c_int {
+    rust_uv_fs_write(loop_ptr, req, fd, buf, len as c_uint, offset, cb)
+}
 pub unsafe fn fs_close(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int,
                 cb: *u8) -> c_int {
     rust_uv_fs_close(loop_ptr, req, fd, cb)
@@ -630,21 +634,15 @@ pub unsafe fn fs_req_cleanup(req: *uv_fs_t) {
 }
 
 // data access helpers
-pub unsafe fn get_O_RDONLY() -> c_int {
-    rust_uv_get_O_RDONLY()
-}
-pub unsafe fn get_O_WRONLY() -> c_int {
-    rust_uv_get_O_WRONLY()
-}
-pub unsafe fn get_O_RDWR() -> c_int {
-    rust_uv_get_O_RDWR()
-}
-pub unsafe fn get_O_CREAT() -> c_int {
-    rust_uv_get_O_CREAT()
-}
-pub unsafe fn get_O_TRUNC() -> c_int {
-    rust_uv_get_O_TRUNC()
-}
+pub unsafe fn get_O_RDONLY() -> c_int { rust_uv_get_O_RDONLY() }
+pub unsafe fn get_O_WRONLY() -> c_int { rust_uv_get_O_WRONLY() }
+pub unsafe fn get_O_RDWR() -> c_int { rust_uv_get_O_RDWR() }
+pub unsafe fn get_O_CREAT() -> c_int { rust_uv_get_O_CREAT() }
+pub unsafe fn get_O_TRUNC() -> c_int { rust_uv_get_O_TRUNC() }
+pub unsafe fn get_S_IWUSR() -> c_int { rust_uv_get_S_IWUSR() }
+pub unsafe fn get_S_IRUSR() -> c_int { rust_uv_get_S_IRUSR() }
+pub unsafe fn get_S_IRGRP() -> c_int { rust_uv_get_S_IRGRP() }
+pub unsafe fn get_S_IROTH() -> c_int { rust_uv_get_S_IROTH() }
 pub unsafe fn get_result_from_fs_req(req: *uv_fs_t) -> c_int {
     rust_uv_get_result_from_fs_req(req)
 }
@@ -819,6 +817,8 @@ extern {
     fn rust_uv_timer_stop(handle: *uv_timer_t) -> c_int;
     fn rust_uv_fs_open(loop_ptr: *c_void, req: *uv_fs_t, path: *c_char,
                        flags: c_int, mode: c_int, cb: *u8) -> c_int;
+    fn rust_uv_fs_write(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int,
+                       buf: *c_void, len: c_uint, offset: i64, cb: *u8) -> c_int;
     fn rust_uv_fs_close(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int,
                         cb: *u8) -> c_int;
     fn rust_uv_fs_req_cleanup(req: *uv_fs_t);
@@ -827,6 +827,10 @@ extern {
     fn rust_uv_get_O_RDWR() -> c_int;
     fn rust_uv_get_O_CREAT() -> c_int;
     fn rust_uv_get_O_TRUNC() -> c_int;
+    fn rust_uv_get_S_IWUSR() -> c_int;
+    fn rust_uv_get_S_IRUSR() -> c_int;
+    fn rust_uv_get_S_IRGRP() -> c_int;
+    fn rust_uv_get_S_IROTH() -> c_int;
     fn rust_uv_get_result_from_fs_req(req: *uv_fs_t) -> c_int;
     fn rust_uv_get_loop_from_fs_req(req: *uv_fs_t) -> *uv_loop_t;
 

--- a/src/libstd/rt/uv/uvll.rs
+++ b/src/libstd/rt/uv/uvll.rs
@@ -643,15 +643,6 @@ pub unsafe fn fs_req_cleanup(req: *uv_fs_t) {
 }
 
 // data access helpers
-pub unsafe fn get_O_RDONLY() -> c_int { rust_uv_get_O_RDONLY() }
-pub unsafe fn get_O_WRONLY() -> c_int { rust_uv_get_O_WRONLY() }
-pub unsafe fn get_O_RDWR() -> c_int { rust_uv_get_O_RDWR() }
-pub unsafe fn get_O_CREAT() -> c_int { rust_uv_get_O_CREAT() }
-pub unsafe fn get_O_TRUNC() -> c_int { rust_uv_get_O_TRUNC() }
-pub unsafe fn get_S_IWUSR() -> c_int { rust_uv_get_S_IWUSR() }
-pub unsafe fn get_S_IRUSR() -> c_int { rust_uv_get_S_IRUSR() }
-pub unsafe fn get_S_IRGRP() -> c_int { rust_uv_get_S_IRGRP() }
-pub unsafe fn get_S_IROTH() -> c_int { rust_uv_get_S_IROTH() }
 pub unsafe fn get_result_from_fs_req(req: *uv_fs_t) -> c_int {
     rust_uv_get_result_from_fs_req(req)
 }
@@ -835,15 +826,6 @@ extern {
     fn rust_uv_fs_close(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int,
                         cb: *u8) -> c_int;
     fn rust_uv_fs_req_cleanup(req: *uv_fs_t);
-    fn rust_uv_get_O_RDONLY() -> c_int;
-    fn rust_uv_get_O_WRONLY() -> c_int;
-    fn rust_uv_get_O_RDWR() -> c_int;
-    fn rust_uv_get_O_CREAT() -> c_int;
-    fn rust_uv_get_O_TRUNC() -> c_int;
-    fn rust_uv_get_S_IWUSR() -> c_int;
-    fn rust_uv_get_S_IRUSR() -> c_int;
-    fn rust_uv_get_S_IRGRP() -> c_int;
-    fn rust_uv_get_S_IROTH() -> c_int;
     fn rust_uv_get_result_from_fs_req(req: *uv_fs_t) -> c_int;
     fn rust_uv_get_loop_from_fs_req(req: *uv_fs_t) -> *uv_loop_t;
 

--- a/src/rt/rust_uv.cpp
+++ b/src/rt/rust_uv.cpp
@@ -13,12 +13,21 @@
 #include <malloc.h>
 #endif
 
+#ifndef __WIN32__
+// for signal
+#include <signal.h>
+#endif
+
 #include "uv.h"
 
 #include "rust_globals.h"
 
 extern "C" void*
 rust_uv_loop_new() {
+// XXX libuv doesn't always ignore SIGPIPE even though we don't need it.
+#ifndef __WIN32__
+    signal(SIGPIPE, SIG_IGN);
+#endif 
     return (void*)uv_loop_new();
 }
 

--- a/src/rt/rust_uv.cpp
+++ b/src/rt/rust_uv.cpp
@@ -13,11 +13,6 @@
 #include <malloc.h>
 #endif
 
-#ifndef __WIN32__
-// for signal
-#include <signal.h>
-#endif
-
 #include <fcntl.h>
 #include "uv.h"
 
@@ -521,6 +516,20 @@ rust_uv_fs_open(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags,
   return uv_fs_open(loop, req, path, flags, mode, cb);
 }
 extern "C" int
+rust_uv_fs_unlink(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
+  return uv_fs_unlink(loop, req, path, cb);
+}
+extern "C" int
+rust_uv_fs_write(uv_loop_t* loop, uv_fs_t* req, uv_file fd, void* buf,
+                 size_t len, int64_t offset, uv_fs_cb cb) {
+  return uv_fs_write(loop, req, fd, buf, len, offset, cb);
+}
+extern "C" int
+rust_uv_fs_read(uv_loop_t* loop, uv_fs_t* req, uv_file fd, void* buf,
+                 size_t len, int64_t offset, uv_fs_cb cb) {
+  return uv_fs_read(loop, req, fd, buf, len, offset, cb);
+}
+extern "C" int
 rust_uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_file fd, uv_fs_cb cb) {
   return uv_fs_close(loop, req, fd, cb);
 }
@@ -547,6 +556,22 @@ rust_uv_get_O_CREAT() {
 extern "C" int
 rust_uv_get_O_TRUNC() {
   return O_TRUNC;
+}
+extern "C" int
+rust_uv_get_S_IWUSR() {
+  return S_IWUSR;
+}
+extern "C" int
+rust_uv_get_S_IRUSR() {
+  return S_IRUSR;
+}
+extern "C" int
+rust_uv_get_S_IRGRP() {
+  return S_IRGRP;
+}
+extern "C" int
+rust_uv_get_S_IROTH() {
+  return S_IROTH;
 }
 extern "C" int
 rust_uv_get_result_from_fs_req(uv_fs_t* req) {

--- a/src/rt/rust_uv.cpp
+++ b/src/rt/rust_uv.cpp
@@ -13,7 +13,6 @@
 #include <malloc.h>
 #endif
 
-#include <fcntl.h>
 #include "uv.h"
 
 #include "rust_globals.h"

--- a/src/rt/rust_uv.cpp
+++ b/src/rt/rust_uv.cpp
@@ -18,16 +18,13 @@
 #include <signal.h>
 #endif
 
+#include <fcntl.h>
 #include "uv.h"
 
 #include "rust_globals.h"
 
 extern "C" void*
 rust_uv_loop_new() {
-// XXX libuv doesn't always ignore SIGPIPE even though we don't need it.
-#ifndef __WIN32__
-    signal(SIGPIPE, SIG_IGN);
-#endif
     return (void*)uv_loop_new();
 }
 
@@ -516,4 +513,46 @@ rust_uv_handle_type_max() {
 extern "C" uintptr_t
 rust_uv_req_type_max() {
   return UV_REQ_TYPE_MAX;
+}
+
+extern "C" int
+rust_uv_fs_open(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags,
+                int mode, uv_fs_cb cb) {
+  return uv_fs_open(loop, req, path, flags, mode, cb);
+}
+extern "C" int
+rust_uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_file fd, uv_fs_cb cb) {
+  return uv_fs_close(loop, req, fd, cb);
+}
+extern "C" void
+rust_uv_fs_req_cleanup(uv_fs_t* req) {
+  uv_fs_req_cleanup(req);
+}
+extern "C" int
+rust_uv_get_O_RDONLY() {
+  return O_RDONLY;
+}
+extern "C" int
+rust_uv_get_O_WRONLY() {
+  return O_WRONLY;
+}
+extern "C" int
+rust_uv_get_O_RDWR() {
+  return O_RDWR;
+}
+extern "C" int
+rust_uv_get_O_CREAT() {
+  return O_CREAT;
+}
+extern "C" int
+rust_uv_get_O_TRUNC() {
+  return O_TRUNC;
+}
+extern "C" int
+rust_uv_get_result_from_fs_req(uv_fs_t* req) {
+  return req->result;
+}
+extern "C" uv_loop_t*
+rust_uv_get_loop_from_fs_req(uv_fs_t* req) {
+  return req->loop;
 }

--- a/src/rt/rust_uv.cpp
+++ b/src/rt/rust_uv.cpp
@@ -27,7 +27,7 @@ rust_uv_loop_new() {
 // XXX libuv doesn't always ignore SIGPIPE even though we don't need it.
 #ifndef __WIN32__
     signal(SIGPIPE, SIG_IGN);
-#endif 
+#endif
     return (void*)uv_loop_new();
 }
 

--- a/src/rt/rust_uv.cpp
+++ b/src/rt/rust_uv.cpp
@@ -538,42 +538,6 @@ rust_uv_fs_req_cleanup(uv_fs_t* req) {
   uv_fs_req_cleanup(req);
 }
 extern "C" int
-rust_uv_get_O_RDONLY() {
-  return O_RDONLY;
-}
-extern "C" int
-rust_uv_get_O_WRONLY() {
-  return O_WRONLY;
-}
-extern "C" int
-rust_uv_get_O_RDWR() {
-  return O_RDWR;
-}
-extern "C" int
-rust_uv_get_O_CREAT() {
-  return O_CREAT;
-}
-extern "C" int
-rust_uv_get_O_TRUNC() {
-  return O_TRUNC;
-}
-extern "C" int
-rust_uv_get_S_IWUSR() {
-  return S_IWUSR;
-}
-extern "C" int
-rust_uv_get_S_IRUSR() {
-  return S_IRUSR;
-}
-extern "C" int
-rust_uv_get_S_IRGRP() {
-  return S_IRGRP;
-}
-extern "C" int
-rust_uv_get_S_IROTH() {
-  return S_IROTH;
-}
-extern "C" int
 rust_uv_get_result_from_fs_req(uv_fs_t* req) {
   return req->result;
 }

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -109,7 +109,9 @@ rust_uv_idle_init
 rust_uv_idle_start
 rust_uv_idle_stop
 rust_uv_fs_open
+rust_uv_fs_unlink
 rust_uv_fs_write
+rust_uv_fs_read
 rust_uv_fs_close
 rust_uv_get_O_RDONLY
 rust_uv_get_O_WRONLY

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -108,6 +108,16 @@ rust_uv_idle_delete
 rust_uv_idle_init
 rust_uv_idle_start
 rust_uv_idle_stop
+rust_uv_fs_open
+rust_uv_fs_close
+rust_uv_get_O_RDONLY
+rust_uv_get_O_WRONLY
+rust_uv_get_O_RDWR
+rust_uv_get_O_CREAT
+rust_uv_get_O_TRUNC
+rust_uv_get_result_from_fs_req
+rust_uv_get_loop_from_fs_req
+rust_uv_fs_req_cleanup
 rust_dbg_lock_create
 rust_dbg_lock_destroy
 rust_dbg_lock_lock

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -113,15 +113,6 @@ rust_uv_fs_unlink
 rust_uv_fs_write
 rust_uv_fs_read
 rust_uv_fs_close
-rust_uv_get_O_RDONLY
-rust_uv_get_O_WRONLY
-rust_uv_get_O_RDWR
-rust_uv_get_O_CREAT
-rust_uv_get_O_TRUNC
-rust_uv_get_S_IRUSR
-rust_uv_get_S_IWUSR
-rust_uv_get_S_IROTH
-rust_uv_get_S_IRGRP
 rust_uv_get_result_from_fs_req
 rust_uv_get_loop_from_fs_req
 rust_uv_fs_req_cleanup

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -109,12 +109,17 @@ rust_uv_idle_init
 rust_uv_idle_start
 rust_uv_idle_stop
 rust_uv_fs_open
+rust_uv_fs_write
 rust_uv_fs_close
 rust_uv_get_O_RDONLY
 rust_uv_get_O_WRONLY
 rust_uv_get_O_RDWR
 rust_uv_get_O_CREAT
 rust_uv_get_O_TRUNC
+rust_uv_get_S_IRUSR
+rust_uv_get_S_IWUSR
+rust_uv_get_S_IROTH
+rust_uv_get_S_IRGRP
 rust_uv_get_result_from_fs_req
 rust_uv_get_loop_from_fs_req
 rust_uv_fs_req_cleanup


### PR DESCRIPTION
This PR includes the addition of the essential CRUD functionality exposed as a part of the `uv_fs_*` api. There's a lot more to be done, but the essential abstractions are in place and can be easily expanded.

A summary:
- `rt::io::file::FileStream` is fleshed out and behaves as a _non-positional_ file stream (that is, it has a cursor that can be viewed/changed via `tell` and `seek`
- The underlying abstraction in `RtioFileStream` exposes pairs of `read(), write()` and `pread(), pwrite()`. The latter two take explicit `offset` params and don't respect the current cursor location in a file afaik. They both use the same underlying libuv impl
- Because libuv explicitly does _not_ support `seek`/`tell` operations, these are impl'd in `UvFileStream` by using `lseek(2)` on the raw file descriptor.
- I did my best to flesh out and adhere to the stubbing that was already present in `rt::io::file` and the tests should back that up. There may be things missing.
- All of the work to test `seek`/`tell` is done in `rt::io::file`, even though the actual impl is down in `rt::uv::uvio`.
- We have the ability to spin up an `~RtioFileStream` from a raw file descriptor. This would be useful for interacting with stdin and stdout via newrt.
- The lowest level abstractions (in `rt::uv::file`) support fully synchronous/blocking interactions with the uv API and there is a CRUD test using it. This may also be useful for blocking printf, if desired (the default would be non-blocking and uses libuv's io threadpool)

There are a few polish things I need to do still (the foremost that I know of is undefined behavior when seek'ing beyond the file's boundary).

After this lands, I want to move on to mapping more of the `uv_fs_*` API (especially `uv_fs_stat`). Also a few people have mentioned interest in `uv_pipe_t` support. I'm open to suggestions.
