### PR TITLE
Fixed memory leak in master

### DIFF
--- a/src/libstd/rt/uv/uvio.rs
+++ b/src/libstd/rt/uv/uvio.rs
@@ -176,7 +176,7 @@ impl UvPausibleIdleCallback {
         self.pause();
         if !self.closed {
             self.closed = true;
-            self.watcher.close(||());
+            self.watcher.close(||{});
         }
     }
 }


### PR DESCRIPTION
Fixed a memory leak caused by the singleton idle callback failing to close correctly. The problem was that the close function requires running inside a callback in the event loop, but we were trying to close the idle watcher after the loop returned from run. The fix was to just call run again to process this callback. There is an additional tweak to move the initialization logic fully into bootstrap, so tasks that do not ever call run do not have problems destructing.
