### PR TITLE
Change the type of crust fns to `extern "C"`

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1006,20 +1006,25 @@ code_. They are defined in the same way as any other Rust function,
 except that they have the `extern` modifier.
 
 ~~~
+// Declares an extern fn, the ABI defaults to "C" 
 extern fn new_vec() -> ~[int] { ~[] }
+
+// Declares an extern fn with "stdcall" ABI
+extern "stdcall" fn new_vec_stdcall() -> ~[int] { ~[] }
 ~~~
 
-Extern functions may not be called from Rust code,
-but Rust code may take their value as a raw `u8` pointer.
+Unlike normal functions, extern fns have an `extern "ABI" fn()`.
+This is the same type as the functions declared in an extern
+block.
 
 ~~~
 # extern fn new_vec() -> ~[int] { ~[] }
-let fptr: *u8 = new_vec;
+let fptr: extern "C" fn() -> ~[int] = new_vec;
 ~~~
 
-The primary motivation for extern functions is
-to create callbacks for foreign functions that expect to receive function
-pointers.
+Extern functions may be called from Rust code, but
+caution must be taken with respect to the size of the stack
+segment, just as when calling an extern function normally.
 
 ### Type definitions
 
@@ -1384,14 +1389,13 @@ between the Rust ABI and the foreign ABI.
 A number of [attributes](#attributes) control the behavior of external
 blocks.
 
-By default external blocks assume
-that the library they are calling uses the standard C "cdecl" ABI.
-Other ABIs may be specified using the `abi` attribute as in
+By default external blocks assume that the library they are calling
+uses the standard C "cdecl" ABI.  Other ABIs may be specified using
+an `abi` string, as shown here:
 
 ~~~{.xfail-test}
 // Interface to the Windows API
-#[abi = "stdcall"]
-extern { }
+extern "stdcall" { }
 ~~~
 
 The `link_name` attribute allows the name of the library to be specified.
@@ -1406,6 +1410,12 @@ not to do any linking for the external block.
 This is particularly useful for creating external blocks for libc,
 which tends to not follow standard library naming conventions
 and is linked to all Rust programs anyway.
+
+The type of a function
+declared in an extern block
+is `extern "abi" fn(A1, ..., An) -> R`,
+where `A1...An` are the declared types of its arguments
+and `R` is the decalred return type.
 
 ## Attributes
 

--- a/src/libextra/rl.rs
+++ b/src/libextra/rl.rs
@@ -16,27 +16,31 @@ use std::libc::{c_char, c_int};
 use std::local_data;
 use std::str;
 
+#[cfg(stage0)]
 pub mod rustrt {
     use std::libc::{c_char, c_int};
 
-    #[cfg(stage0)]
-    mod macro_hack {
-    #[macro_escape];
-    macro_rules! externfn(
-        (fn $name:ident ($($arg_name:ident : $arg_ty:ty),*) $(-> $ret_ty:ty),*) => (
-            extern {
-                fn $name($($arg_name : $arg_ty),*) $(-> $ret_ty),*;
-            }
-        )
-    )
+    extern {
+        fn linenoise(prompt: *c_char) -> *c_char;
+        fn linenoiseHistoryAdd(line: *c_char) -> c_int;
+        fn linenoiseHistorySetMaxLen(len: c_int) -> c_int;
+        fn linenoiseHistorySave(file: *c_char) -> c_int;
+        fn linenoiseHistoryLoad(file: *c_char) -> c_int;
+        fn linenoiseSetCompletionCallback(callback: *u8);
+        fn linenoiseAddCompletion(completions: *(), line: *c_char);
     }
+}
+
+#[cfg(not(stage0))]
+pub mod rustrt {
+    use std::libc::{c_char, c_int};
 
     externfn!(fn linenoise(prompt: *c_char) -> *c_char)
     externfn!(fn linenoiseHistoryAdd(line: *c_char) -> c_int)
     externfn!(fn linenoiseHistorySetMaxLen(len: c_int) -> c_int)
     externfn!(fn linenoiseHistorySave(file: *c_char) -> c_int)
     externfn!(fn linenoiseHistoryLoad(file: *c_char) -> c_int)
-    externfn!(fn linenoiseSetCompletionCallback(callback: *u8))
+    externfn!(fn linenoiseSetCompletionCallback(callback: extern "C" fn(*i8, *())))
     externfn!(fn linenoiseAddCompletion(completions: *(), line: *c_char))
 }
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -52,6 +52,7 @@ use middle::trans::expr;
 use middle::trans::foreign;
 use middle::trans::glue;
 use middle::trans::inline;
+use middle::trans::llrepr::LlvmRepr;
 use middle::trans::machine;
 use middle::trans::machine::{llalign_of_min, llsize_of};
 use middle::trans::meth;
@@ -1740,6 +1741,10 @@ pub fn copy_args_to_allocas(fcx: @mut FunctionContext,
                             args: &[ast::arg],
                             raw_llargs: &[ValueRef],
                             arg_tys: &[ty::t]) -> @mut Block {
+    debug!("copy_args_to_allocas: raw_llargs=%s arg_tys=%s",
+           raw_llargs.llrepr(fcx.ccx),
+           arg_tys.repr(fcx.ccx.tcx));
+
     let _icx = push_ctxt("copy_args_to_allocas");
     let mut bcx = bcx;
 

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -22,6 +22,7 @@ use std::hashmap::HashMap;
 use std::libc::{c_uint, c_ulonglong, c_char};
 use std::vec;
 use syntax::codemap::span;
+use std::ptr::is_not_null;
 
 pub struct Builder {
     llbuilder: BuilderRef,
@@ -483,6 +484,7 @@ impl Builder {
         debug!("Store %s -> %s",
                self.ccx.tn.val_to_str(val),
                self.ccx.tn.val_to_str(ptr));
+        assert!(is_not_null(self.llbuilder));
         self.count_insn("store");
         unsafe {
             llvm::LLVMBuildStore(self.llbuilder, val, ptr);

--- a/src/librustc/middle/trans/llrepr.rs
+++ b/src/librustc/middle/trans/llrepr.rs
@@ -1,0 +1,38 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use middle::trans::context::CrateContext;
+use middle::trans::type_::Type;
+use lib::llvm::ValueRef;
+
+pub trait LlvmRepr {
+    fn llrepr(&self, ccx: &CrateContext) -> ~str;
+}
+
+impl<'self, T:LlvmRepr> LlvmRepr for &'self [T] {
+    fn llrepr(&self, ccx: &CrateContext) -> ~str {
+        let reprs = self.map(|t| t.llrepr(ccx));
+        fmt!("[%s]", reprs.connect(","))
+    }
+}
+
+impl LlvmRepr for Type {
+    fn llrepr(&self, ccx: &CrateContext) -> ~str {
+        ccx.tn.type_to_str(*self)
+    }
+}
+
+impl LlvmRepr for ValueRef {
+    fn llrepr(&self, ccx: &CrateContext) -> ~str {
+        ccx.tn.val_to_str(*self)
+    }
+}
+
+

--- a/src/librustc/middle/trans/mod.rs
+++ b/src/librustc/middle/trans/mod.rs
@@ -45,3 +45,4 @@ pub mod asm;
 pub mod type_;
 pub mod value;
 pub mod basic_block;
+pub mod llrepr;

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3099,22 +3099,6 @@ pub fn ty_param_bounds_and_ty_for_def(fcx: @mut FnCtxt,
           let typ = fcx.local_ty(sp, nid);
           return no_params(typ);
       }
-      ast::def_fn(_, ast::extern_fn) => {
-        // extern functions are just u8 pointers
-        return ty_param_bounds_and_ty {
-            generics: ty::Generics {
-                type_param_defs: @~[],
-                region_param: None
-            },
-            ty: ty::mk_ptr(
-                fcx.ccx.tcx,
-                ty::mt {
-                    ty: ty::mk_mach_uint(ast::ty_u8),
-                    mutbl: ast::m_imm
-                })
-        };
-      }
-
       ast::def_fn(id, _) | ast::def_static_method(id, _, _) |
       ast::def_static(id, _) | ast::def_variant(_, id) |
       ast::def_struct(id) => {

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -1067,13 +1067,13 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::item)
         tcx.tcache.insert(local_def(it.id), tpt);
         return tpt;
       }
-      ast::item_fn(ref decl, purity, _, ref generics, _) => {
+      ast::item_fn(ref decl, purity, abi, ref generics, _) => {
         assert!(rp.is_none());
         let ty_generics = ty_generics(ccx, None, generics, 0);
         let tofd = astconv::ty_of_bare_fn(ccx,
                                           &empty_rscope,
                                           purity,
-                                          AbiSet::Rust(),
+                                          abi,
                                           &generics.lifetimes,
                                           decl);
         let tpt = ty_param_bounds_and_ty {

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -369,6 +369,47 @@ impl<T> Eq for *const T {
     fn ne(&self, other: &*const T) -> bool { !self.eq(other) }
 }
 
+// Equality for extern "C" fn pointers
+#[cfg(not(test))]
+mod externfnpointers {
+    use cast;
+    use cmp::Eq;
+
+    impl<_R> Eq for extern "C" fn() -> _R {
+        #[inline]
+        fn eq(&self, other: &extern "C" fn() -> _R) -> bool {
+            let self_: *() = unsafe { cast::transmute(*self) };
+            let other_: *() = unsafe { cast::transmute(*other) };
+            self_ == other_
+        }
+        #[inline]
+        fn ne(&self, other: &extern "C" fn() -> _R) -> bool {
+            !self.eq(other)
+        }
+    }
+    macro_rules! fnptreq(
+        ($($p:ident),*) => {
+            impl<_R,$($p),*> Eq for extern "C" fn($($p),*) -> _R {
+                #[inline]
+                fn eq(&self, other: &extern "C" fn($($p),*) -> _R) -> bool {
+                    let self_: *() = unsafe { cast::transmute(*self) };
+                    let other_: *() = unsafe { cast::transmute(*other) };
+                    self_ == other_
+                }
+                #[inline]
+                fn ne(&self, other: &extern "C" fn($($p),*) -> _R) -> bool {
+                    !self.eq(other)
+                }
+            }
+        }
+    )
+    fnptreq!(A)
+    fnptreq!(A,B)
+    fnptreq!(A,B,C)
+    fnptreq!(A,B,C,D)
+    fnptreq!(A,B,C,D,E)
+}
+
 // Comparison for pointers
 #[cfg(not(test))]
 impl<T> Ord for *const T {

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -445,8 +445,17 @@ impl Unwinder {
         }
 
         extern {
+            #[cfg(not(stage0))]
             #[rust_stack]
-            fn rust_try(f: *u8, code: *c_void, data: *c_void) -> uintptr_t;
+            fn rust_try(f: extern "C" fn(*c_void, *c_void),
+                        code: *c_void,
+                        data: *c_void) -> uintptr_t;
+
+            #[cfg(stage0)]
+            #[rust_stack]
+            fn rust_try(f: *u8,
+                        code: *c_void,
+                        data: *c_void) -> uintptr_t;
         }
     }
 

--- a/src/test/auxiliary/extern-crosscrate-source.rs
+++ b/src/test/auxiliary/extern-crosscrate-source.rs
@@ -19,7 +19,8 @@ pub mod rustrt {
     use std::libc;
 
     extern {
-        pub fn rust_dbg_call(cb: *u8, data: libc::uintptr_t)
+        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+                             data: libc::uintptr_t)
                              -> libc::uintptr_t;
     }
 }

--- a/src/test/compile-fail/extern-cstack-lint.rs
+++ b/src/test/compile-fail/extern-cstack-lint.rs
@@ -8,10 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:expected function but found `*u8`
 extern fn f() {
 }
 
-fn main() {
-    f();
+extern fn call1() {
+    f(); // OK from another extern fn!
 }
+
+fn call2() {
+    f(); //~ ERROR invoking non-Rust fn
+}
+
+
+fn main() {}

--- a/src/test/run-pass/const-cast.rs
+++ b/src/test/run-pass/const-cast.rs
@@ -12,7 +12,7 @@ use std::libc;
 
 extern fn foo() {}
 
-static x: *u8 = foo;
+static x: extern "C" fn() = foo;
 static y: *libc::c_void = x as *libc::c_void;
 static a: &'static int = &10;
 static b: *int = a as *int;

--- a/src/test/run-pass/const-cross-crate-extern.rs
+++ b/src/test/run-pass/const-cross-crate-extern.rs
@@ -13,8 +13,11 @@
 
 extern mod cci_const;
 use cci_const::bar;
-static foo: *u8 = bar;
+use std::cast::transmute;
+static foo: extern "C" fn() = bar;
 
 pub fn main() {
-    assert_eq!(foo, cci_const::bar);
+    unsafe {
+        assert_eq!(foo, bar);
+    }
 }

--- a/src/test/run-pass/const-extern-function.rs
+++ b/src/test/run-pass/const-extern-function.rs
@@ -10,14 +10,16 @@
 
 extern fn foopy() {}
 
-static f: *u8 = foopy;
+static f: extern "C" fn() = foopy;
 static s: S = S { f: foopy };
 
 struct S {
-    f: *u8
+    f: extern "C" fn()
 }
 
 pub fn main() {
-    assert_eq!(foopy, f);
-    assert_eq!(f, s.f);
+    unsafe {
+        assert_eq!(foopy, f);
+        assert_eq!(f, s.f);
+    }
 }

--- a/src/test/run-pass/extern-call-deep.rs
+++ b/src/test/run-pass/extern-call-deep.rs
@@ -14,7 +14,8 @@ mod rustrt {
     use std::libc;
 
     extern {
-        pub fn rust_dbg_call(cb: *u8, data: libc::uintptr_t)
+        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+                             data: libc::uintptr_t)
                              -> libc::uintptr_t;
     }
 }

--- a/src/test/run-pass/extern-call-deep2.rs
+++ b/src/test/run-pass/extern-call-deep2.rs
@@ -15,7 +15,8 @@ mod rustrt {
     use std::libc;
 
     extern {
-        pub fn rust_dbg_call(cb: *u8, data: libc::uintptr_t)
+        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+                             data: libc::uintptr_t)
                              -> libc::uintptr_t;
     }
 }

--- a/src/test/run-pass/extern-call-direct.rs
+++ b/src/test/run-pass/extern-call-direct.rs
@@ -8,11 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern fn f() {
-}
+// Test direct calls to extern fns.
+
+extern fn f(x: uint) -> uint { x * 2 }
 
 fn main() {
-    // extern functions are extern "C" fn
-    let _x: extern "C" fn() = f; // OK
-    let _x: &fn() = f; //~ ERROR mismatched types
+    #[fixed_stack_segment];
+
+    let x = f(22);
+    assert_eq!(x, 44);
 }

--- a/src/test/run-pass/extern-call-indirect.rs
+++ b/src/test/run-pass/extern-call-indirect.rs
@@ -14,7 +14,8 @@ mod rustrt {
     use std::libc;
 
     extern {
-        pub fn rust_dbg_call(cb: *u8, data: libc::uintptr_t)
+        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+                             data: libc::uintptr_t)
                              -> libc::uintptr_t;
     }
 }

--- a/src/test/run-pass/extern-call-scrub.rs
+++ b/src/test/run-pass/extern-call-scrub.rs
@@ -19,7 +19,8 @@ mod rustrt {
     use std::libc;
 
     extern {
-        pub fn rust_dbg_call(cb: *u8, data: libc::uintptr_t)
+        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+                             data: libc::uintptr_t)
                              -> libc::uintptr_t;
     }
 }

--- a/src/test/run-pass/extern-compare-with-return-type.rs
+++ b/src/test/run-pass/extern-compare-with-return-type.rs
@@ -1,0 +1,32 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that we can compare various kinds of extern fn signatures.
+
+extern fn voidret1() {}
+extern fn voidret2() {}
+
+extern fn uintret() -> uint { 22 }
+
+extern fn uintvoidret(x: uint) {}
+
+extern fn uintuintuintuintret(x: uint, y: uint, z: uint) -> uint { x+y+z }
+
+fn main() {
+    assert_eq!(voidret1, voidret1);
+    assert!(voidret1 != voidret2);
+
+    assert_eq!(uintret, uintret);
+
+    assert_eq!(uintvoidret, uintvoidret);
+
+    assert_eq!(uintuintuintuintret, uintuintuintuintret);
+}
+

--- a/src/test/run-pass/extern-stress.rs
+++ b/src/test/run-pass/extern-stress.rs
@@ -18,7 +18,8 @@ mod rustrt {
     use std::libc;
 
     extern {
-        pub fn rust_dbg_call(cb: *u8, data: libc::uintptr_t)
+        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+                             data: libc::uintptr_t)
                              -> libc::uintptr_t;
     }
 }

--- a/src/test/run-pass/extern-take-value.rs
+++ b/src/test/run-pass/extern-take-value.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::cast::transmute;
+
 extern fn f() {
 }
 
@@ -15,11 +17,12 @@ extern fn g() {
 }
 
 pub fn main() {
-    // extern functions are *u8 types
-    let a: *u8 = f;
-    let b: *u8 = f;
-    let c: *u8 = g;
+    unsafe {
+        let a: extern "C" fn() = f;
+        let b: extern "C" fn() = f;
+        let c: extern "C" fn() = g;
 
-    assert_eq!(a, b);
-    assert!(a != c);
+        assert_eq!(a, b);
+        assert!(a != c);
+    }
 }

--- a/src/test/run-pass/extern-yield.rs
+++ b/src/test/run-pass/extern-yield.rs
@@ -15,7 +15,8 @@ mod rustrt {
     use std::libc;
 
     extern {
-        pub fn rust_dbg_call(cb: *u8, data: libc::uintptr_t)
+        pub fn rust_dbg_call(cb: extern "C" fn (libc::uintptr_t) -> libc::uintptr_t,
+                             data: libc::uintptr_t)
                              -> libc::uintptr_t;
     }
 }

--- a/src/test/run-pass/foreign-call-no-runtime.rs
+++ b/src/test/run-pass/foreign-call-no-runtime.rs
@@ -2,7 +2,8 @@ use std::cast;
 use std::libc;
 use std::unstable::run_in_bare_thread;
 
-externfn!(fn rust_dbg_call(cb: *u8, data: libc::uintptr_t) -> libc::uintptr_t)
+externfn!(fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t),
+                           data: libc::uintptr_t) -> libc::uintptr_t)
 
 pub fn main() {
     unsafe {


### PR DESCRIPTION
Change the type of crust fns like this one:

```
extern fn foo() { ... }
```

from `*u8` to `extern "C" fn()`.

r? @pcwalton (or whomever)
