### PR TITLE
Refactor type combining to use default methods.  Woohoo!

### DIFF
--- a/src/librustc/middle/typeck/infer/glb.rs
+++ b/src/librustc/middle/typeck/infer/glb.rs
@@ -21,11 +21,9 @@ use middle::typeck::infer::{cres, InferCtxt};
 use middle::typeck::infer::{TypeTrace, Subtype};
 use middle::typeck::infer::fold_regions_in_sig;
 use middle::typeck::isr_alist;
-use syntax::ast;
 use syntax::ast::{Many, Once, extern_fn, impure_fn, m_const, m_imm, m_mutbl};
 use syntax::ast::{unsafe_fn};
 use syntax::ast::{Onceness, purity};
-use syntax::abi::AbiSet;
 use util::common::{indenter};
 use util::ppaux::mt_to_str;
 
@@ -137,29 +135,6 @@ impl Combine for Glb {
 
     fn tys(&self, a: ty::t, b: ty::t) -> cres<ty::t> {
         super_lattice_tys(self, a, b)
-    }
-
-    // Traits please (FIXME: #2794):
-
-    fn flds(&self, a: ty::field, b: ty::field) -> cres<ty::field> {
-        super_flds(self, a, b)
-    }
-
-    fn vstores(&self, vk: ty::terr_vstore_kind,
-               a: ty::vstore, b: ty::vstore) -> cres<ty::vstore> {
-        super_vstores(self, vk, a, b)
-    }
-
-    fn trait_stores(&self,
-                    vk: ty::terr_vstore_kind,
-                    a: ty::TraitStore,
-                    b: ty::TraitStore)
-                 -> cres<ty::TraitStore> {
-        super_trait_stores(self, vk, a, b)
-    }
-
-    fn args(&self, a: ty::t, b: ty::t) -> cres<ty::t> {
-        super_args(self, a, b)
     }
 
     fn fn_sigs(&self, a: &ty::FnSig, b: &ty::FnSig) -> cres<ty::FnSig> {
@@ -289,43 +264,5 @@ impl Combine for Glb {
         fn fresh_bound_variable(this: &Glb) -> ty::Region {
             this.infcx.region_vars.new_bound()
         }
-    }
-
-    fn sigils(&self, p1: ast::Sigil, p2: ast::Sigil) -> cres<ast::Sigil> {
-        super_sigils(self, p1, p2)
-    }
-
-    fn abis(&self, p1: AbiSet, p2: AbiSet) -> cres<AbiSet> {
-        super_abis(self, p1, p2)
-    }
-
-    fn bare_fn_tys(&self, a: &ty::BareFnTy,
-                   b: &ty::BareFnTy) -> cres<ty::BareFnTy> {
-        super_bare_fn_tys(self, a, b)
-    }
-
-    fn closure_tys(&self, a: &ty::ClosureTy,
-                   b: &ty::ClosureTy) -> cres<ty::ClosureTy> {
-        super_closure_tys(self, a, b)
-    }
-
-    fn substs(&self,
-              generics: &ty::Generics,
-              as_: &ty::substs,
-              bs: &ty::substs) -> cres<ty::substs> {
-        super_substs(self, generics, as_, bs)
-    }
-
-    fn tps(&self, as_: &[ty::t], bs: &[ty::t]) -> cres<~[ty::t]> {
-        super_tps(self, as_, bs)
-    }
-
-    fn self_tys(&self, a: Option<ty::t>, b: Option<ty::t>)
-               -> cres<Option<ty::t>> {
-        super_self_tys(self, a, b)
-    }
-
-    fn trait_refs(&self, a: &ty::TraitRef, b: &ty::TraitRef) -> cres<ty::TraitRef> {
-        super_trait_refs(self, a, b)
     }
 }

--- a/src/librustc/middle/typeck/infer/lub.rs
+++ b/src/librustc/middle/typeck/infer/lub.rs
@@ -24,8 +24,6 @@ use middle::typeck::isr_alist;
 use util::ppaux::mt_to_str;
 
 use extra::list;
-use syntax::abi::AbiSet;
-use syntax::ast;
 use syntax::ast::{Many, Once, extern_fn, m_const, impure_fn};
 use syntax::ast::{unsafe_fn};
 use syntax::ast::{Onceness, purity};
@@ -206,69 +204,7 @@ impl Combine for Lub {
         }
     }
 
-    fn bare_fn_tys(&self, a: &ty::BareFnTy,
-                   b: &ty::BareFnTy) -> cres<ty::BareFnTy> {
-        super_bare_fn_tys(self, a, b)
-    }
-
-    fn closure_tys(&self, a: &ty::ClosureTy,
-                   b: &ty::ClosureTy) -> cres<ty::ClosureTy> {
-        super_closure_tys(self, a, b)
-    }
-
-    // Traits please (FIXME: #2794):
-
-    fn sigils(&self, p1: ast::Sigil, p2: ast::Sigil)
-             -> cres<ast::Sigil> {
-        super_sigils(self, p1, p2)
-    }
-
-    fn abis(&self, p1: AbiSet, p2: AbiSet) -> cres<AbiSet> {
-        super_abis(self, p1, p2)
-    }
-
     fn tys(&self, a: ty::t, b: ty::t) -> cres<ty::t> {
         super_lattice_tys(self, a, b)
-    }
-
-    fn flds(&self, a: ty::field, b: ty::field) -> cres<ty::field> {
-        super_flds(self, a, b)
-    }
-
-    fn vstores(&self, vk: ty::terr_vstore_kind,
-               a: ty::vstore, b: ty::vstore) -> cres<ty::vstore> {
-        super_vstores(self, vk, a, b)
-    }
-
-    fn trait_stores(&self,
-                    vk: ty::terr_vstore_kind,
-                    a: ty::TraitStore,
-                    b: ty::TraitStore)
-                 -> cres<ty::TraitStore> {
-        super_trait_stores(self, vk, a, b)
-    }
-
-    fn args(&self, a: ty::t, b: ty::t) -> cres<ty::t> {
-        super_args(self, a, b)
-    }
-
-    fn substs(&self,
-              generics: &ty::Generics,
-              as_: &ty::substs,
-              bs: &ty::substs) -> cres<ty::substs> {
-        super_substs(self, generics, as_, bs)
-    }
-
-    fn tps(&self, as_: &[ty::t], bs: &[ty::t]) -> cres<~[ty::t]> {
-        super_tps(self, as_, bs)
-    }
-
-    fn self_tys(&self, a: Option<ty::t>, b: Option<ty::t>)
-               -> cres<Option<ty::t>> {
-        super_self_tys(self, a, b)
-    }
-
-    fn trait_refs(&self, a: &ty::TraitRef, b: &ty::TraitRef) -> cres<ty::TraitRef> {
-        super_trait_refs(self, a, b)
     }
 }

--- a/src/librustc/middle/typeck/infer/sub.rs
+++ b/src/librustc/middle/typeck/infer/sub.rs
@@ -26,8 +26,6 @@ use util::ppaux::bound_region_to_str;
 
 use extra::list::Nil;
 use extra::list;
-use syntax::abi::AbiSet;
-use syntax::ast;
 use syntax::ast::{Onceness, m_const, purity};
 
 pub struct Sub(CombineFields);  // "subtype", "subregion" etc
@@ -225,64 +223,4 @@ impl Combine for Sub {
         ret
     }
 
-    // Traits please (FIXME: #2794):
-
-    fn sigils(&self, p1: ast::Sigil, p2: ast::Sigil) -> cres<ast::Sigil> {
-        super_sigils(self, p1, p2)
-    }
-
-    fn abis(&self, p1: AbiSet, p2: AbiSet) -> cres<AbiSet> {
-        super_abis(self, p1, p2)
-    }
-
-    fn flds(&self, a: ty::field, b: ty::field) -> cres<ty::field> {
-        super_flds(self, a, b)
-    }
-
-    fn bare_fn_tys(&self, a: &ty::BareFnTy,
-                   b: &ty::BareFnTy) -> cres<ty::BareFnTy> {
-        super_bare_fn_tys(self, a, b)
-    }
-
-    fn closure_tys(&self, a: &ty::ClosureTy,
-                   b: &ty::ClosureTy) -> cres<ty::ClosureTy> {
-        super_closure_tys(self, a, b)
-    }
-
-    fn vstores(&self, vk: ty::terr_vstore_kind,
-               a: ty::vstore, b: ty::vstore) -> cres<ty::vstore> {
-        super_vstores(self, vk, a, b)
-    }
-
-    fn trait_stores(&self,
-                    vk: ty::terr_vstore_kind,
-                    a: ty::TraitStore,
-                    b: ty::TraitStore)
-                    -> cres<ty::TraitStore> {
-        super_trait_stores(self, vk, a, b)
-    }
-
-    fn args(&self, a: ty::t, b: ty::t) -> cres<ty::t> {
-        super_args(self, a, b)
-    }
-
-    fn substs(&self,
-              generics: &ty::Generics,
-              as_: &ty::substs,
-              bs: &ty::substs) -> cres<ty::substs> {
-        super_substs(self, generics, as_, bs)
-    }
-
-    fn tps(&self, as_: &[ty::t], bs: &[ty::t]) -> cres<~[ty::t]> {
-        super_tps(self, as_, bs)
-    }
-
-    fn self_tys(&self, a: Option<ty::t>, b: Option<ty::t>)
-               -> cres<Option<ty::t>> {
-        super_self_tys(self, a, b)
-    }
-
-    fn trait_refs(&self, a: &ty::TraitRef, b: &ty::TraitRef) -> cres<ty::TraitRef> {
-        super_trait_refs(self, a, b)
-    }
 }


### PR DESCRIPTION
This commit removes the "super_*" functions from
typeck::infer::combine, and adds them as default methods on the
Combine trait instead, making it possible to remove a lot of
boilerplate from the various impls of Combine.

I've been wanting to do this for over a year.  In fact, it was my
original motivation for default methods!

It might be possible to tighten things up even more, but this is the
bulk of it.
