### PR TITLE
generalize the `Option<NonNullablePtr>` to libs

### DIFF
--- a/src/libextra/rc.rs
+++ b/src/libextra/rc.rs
@@ -40,8 +40,9 @@ struct RcBox<T> {
 }
 
 /// Immutable reference counted pointer type
-#[unsafe_no_drop_flag]
 #[no_send]
+#[unsafe_no_drop_flag]
+#[unsafe_non_zero_word]
 pub struct Rc<T> {
     priv ptr: *mut RcBox<T>,
 }
@@ -167,6 +168,7 @@ struct RcMutBox<T> {
 #[no_send]
 #[no_freeze]
 #[unsafe_no_drop_flag]
+#[unsafe_non_zero_word]
 pub struct RcMut<T> {
     priv ptr: *mut RcMutBox<T>,
 }
@@ -255,6 +257,7 @@ impl<T: DeepClone> DeepClone for RcMut<T> {
 #[cfg(test)]
 mod test_rc_mut {
     use super::*;
+    use std::sys::size_of;
 
     #[test]
     fn test_clone() {
@@ -371,5 +374,11 @@ mod test_rc_mut {
             do x.with_borrow |_| {}
             do y.with_mut_borrow |_| {}
         }
+    }
+
+    #[test]
+    fn non_zero_word() {
+        assert_eq!(size_of::<Option<Rc<int>>>(), size_of::<Rc<int>>());
+        assert_eq!(size_of::<Option<RcMut<int>>>(), size_of::<RcMut<int>>());
     }
 }

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -145,8 +145,8 @@ fn represent_type_uncached(cx: &mut CrateContext, t: ty::t) -> Repr {
                 fn is_zerolen(&self, cx: &mut CrateContext) -> bool {
                     mk_struct(cx, self.tys, false).size == 0
                 }
-                fn find_ptr(&self) -> Option<uint> {
-                    self.tys.iter().position(|&ty| mono_data_classify(ty) == MonoNonNull)
+                fn find_ptr(&self, tcx: ty::ctxt) -> Option<uint> {
+                    self.tys.iter().position(|&ty| mono_data_classify(tcx, ty) == MonoNonNull)
                 }
             }
 
@@ -187,7 +187,7 @@ fn represent_type_uncached(cx: &mut CrateContext, t: ty::t) -> Repr {
                 let mut discr = 0;
                 while discr < 2 {
                     if cases[1 - discr].is_zerolen(cx) {
-                        match cases[discr].find_ptr() {
+                        match cases[discr].find_ptr(cx.tcx) {
                             Some(ptrfield) => {
                                 return NullablePointer {
                                     nndiscr: discr,

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -904,7 +904,7 @@ pub enum MonoDataClass {
     MonoFloat
 }
 
-pub fn mono_data_classify(t: ty::t) -> MonoDataClass {
+pub fn mono_data_classify(tcx: ty::ctxt, t: ty::t) -> MonoDataClass {
     match ty::get(t).sty {
         ty::ty_float(_) => MonoFloat,
         ty::ty_rptr(*) | ty::ty_uniq(*) |
@@ -912,6 +912,8 @@ pub fn mono_data_classify(t: ty::t) -> MonoDataClass {
         ty::ty_estr(ty::vstore_uniq) | ty::ty_evec(_, ty::vstore_uniq) |
         ty::ty_estr(ty::vstore_box) | ty::ty_evec(_, ty::vstore_box) |
         ty::ty_bare_fn(*) => MonoNonNull,
+        ty::ty_struct(id, _) | ty::ty_enum(id, _)
+        if ty::has_attr(tcx, id, "unsafe_non_zero_word") => MonoNonNull,
         // Is that everything?  Would closures or slices qualify?
         _ => MonoBits
     }

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -407,7 +407,7 @@ pub fn make_mono_id(ccx: @mut CrateContext,
                             let size = machine::llbitsize_of_real(ccx, llty);
                             let align = machine::llalign_of_min(ccx, llty);
                             let mode = datum::appropriate_mode(ccx.tcx, subst);
-                            let data_class = mono_data_classify(subst);
+                            let data_class = mono_data_classify(ccx.tcx, subst);
 
                             debug!("make_mono_id: type %s -> size %u align %u mode %? class %?",
                                   ty_to_str(ccx.tcx, subst),

--- a/src/test/run-pass/attr-unsafe_non_zero_word.rs
+++ b/src/test/run-pass/attr-unsafe_non_zero_word.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::sys::size_of;
+
+#[unsafe_non_zero_word]
+struct Test {
+    foo: *int
+}
+
+fn main() {
+    assert_eq!(size_of::<Option<Test>>(), size_of::<*int>());
+}


### PR DESCRIPTION
An `Option<Rc<T>>` is now 1-word, like the built-in non-nullable pointers.
