### PR TITLE
Change json::to_xxx(&Json) functions to be json::Json::to_xxx(&self)

### DIFF
--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -875,7 +875,7 @@ impl MetricMap {
     /// Write MetricDiff to a file.
     pub fn save(&self, p: &Path) {
         let f = io::file_writer(p, [io::Create, io::Truncate]).unwrap();
-        json::to_pretty_writer(f, &self.to_json());
+        self.to_json().to_pretty_writer(f);
     }
 
     /// Compare against another MetricMap. Optionally compare all


### PR DESCRIPTION
to_str, to_pretty_str, to_writer, and to_pretty_writer were at the top
level of extra::json, this moves them into an impl for Json to match
with what's been done for the rest of libextra and libstd.  (or at least for vec and str)

Also meant changing some tests.

Closes #8676.
