### PR TITLE
Handle `rustpkg build`, etc. when given no args properly

### DIFF
--- a/src/librustpkg/rustpkg.rs
+++ b/src/librustpkg/rustpkg.rs
@@ -43,7 +43,7 @@ use path_util::{U_RWX, in_rust_path};
 use path_util::{built_executable_in_workspace, built_library_in_workspace, default_workspace};
 use path_util::{target_executable_in_workspace, target_library_in_workspace};
 use source_control::is_git_dir;
-use workspace::{each_pkg_parent_workspace, pkg_parent_workspaces, in_workspace, cwd_to_workspace};
+use workspace::{each_pkg_parent_workspace, pkg_parent_workspaces, cwd_to_workspace};
 use context::Ctx;
 use package_id::PkgId;
 use package_source::PkgSrc;
@@ -190,11 +190,10 @@ impl CtxMethods for Ctx {
         match cmd {
             "build" => {
                 if args.len() < 1 {
-                    if !in_workspace(|| { usage::build() } ) {
-                        return;
+                    match cwd_to_workspace() {
+                        None => { usage::build(); return }
+                        Some((ws, pkgid)) => self.build(&ws, &pkgid)
                     }
-                    let (workspace, pkgid) = cwd_to_workspace();
-                    self.build(&workspace, &pkgid);
                 }
                 else {
                     // The package id is presumed to be the first command-line
@@ -210,13 +209,12 @@ impl CtxMethods for Ctx {
             }
             "clean" => {
                 if args.len() < 1 {
-                    if !in_workspace(|| { usage::clean() } ) {
-                        return;
+                    match cwd_to_workspace() {
+                        None => { usage::clean(); return }
+                        // tjc: Maybe clean should clean all the packages in the
+                        // current workspace, though?
+                        Some((ws, pkgid)) => self.clean(&ws, &pkgid)
                     }
-                    // tjc: Maybe clean should clean all the packages in the
-                    // current workspace, though?
-                    let (workspace, pkgid) = cwd_to_workspace();
-                    self.clean(&workspace, &pkgid);
 
                 }
                 else {
@@ -239,11 +237,10 @@ impl CtxMethods for Ctx {
             }
             "install" => {
                 if args.len() < 1 {
-                    if !in_workspace(|| { usage::install() }) {
-                        return;
+                    match cwd_to_workspace() {
+                        None => { usage::install(); return }
+                        Some((ws, pkgid)) => self.install(&ws, &pkgid)
                     }
-                    let (workspace, pkgid) = cwd_to_workspace();
-                    self.install(&workspace, &pkgid);
                 }
                 else {
                     // The package id is presumed to be the first command-line

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -695,7 +695,8 @@ fn package_script_with_default_build() {
 
 #[test]
 fn rustpkg_build_no_arg() {
-    let tmp = mkdtemp(&os::tmpdir(), "rustpkg_build_no_arg").expect("rustpkg_build_no_arg failed");
+    let tmp = mkdtemp(&os::tmpdir(), "rustpkg_build_no_arg").expect("rustpkg_build_no_arg failed")
+              .push(".rust");
     let package_dir = tmp.push("src").push("foo");
     assert!(os::mkdir_recursive(&package_dir, U_RWX));
 
@@ -709,7 +710,8 @@ fn rustpkg_build_no_arg() {
 #[test]
 fn rustpkg_install_no_arg() {
     let tmp = mkdtemp(&os::tmpdir(),
-                      "rustpkg_install_no_arg").expect("rustpkg_install_no_arg failed");
+                      "rustpkg_install_no_arg").expect("rustpkg_install_no_arg failed")
+              .push(".rust");
     let package_dir = tmp.push("src").push("foo");
     assert!(os::mkdir_recursive(&package_dir, U_RWX));
     writeFile(&package_dir.push("lib.rs"),
@@ -721,7 +723,8 @@ fn rustpkg_install_no_arg() {
 
 #[test]
 fn rustpkg_clean_no_arg() {
-    let tmp = mkdtemp(&os::tmpdir(), "rustpkg_clean_no_arg").expect("rustpkg_clean_no_arg failed");
+    let tmp = mkdtemp(&os::tmpdir(), "rustpkg_clean_no_arg").expect("rustpkg_clean_no_arg failed")
+              .push(".rust");
     let package_dir = tmp.push("src").push("foo");
     assert!(os::mkdir_recursive(&package_dir, U_RWX));
 


### PR DESCRIPTION
`rustpkg build` et al were only checking one directory up to see if it
was in a dir named "src". Ditch that entirely and instead check if the
cwd is descended from any of the workspace paths. Besides being more
intelligent about whether or not something is a workspace, this also
allows for package ids composed of multiple path components.

r? @catamorphism
