### PR TITLE
Make getopts count (and thus align/linewrap) in terms of codepoints not ...

### DIFF
--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -501,7 +501,6 @@ pub enum FailType {
 pub mod groups {
     use getopts::{HasArg, Long, Maybe, Multi, No, Occur, Opt, Optional, Req};
     use getopts::{Short, Yes};
-    use std::str;
 
     /** one group of options, e.g., both -h and --help, along with
      * their shared description and properties
@@ -692,7 +691,7 @@ pub mod groups {
 
             // FIXME: #5516 should be graphemes not codepoints
             // here we just need to indent the start of the description
-            let rowlen = str::count_chars(row, 0, row.len());
+            let rowlen = row.char_len();
             if rowlen < 24 {
                 do (24 - rowlen).times {
                     row.push_char(' ')

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -501,6 +501,7 @@ pub enum FailType {
 pub mod groups {
     use getopts::{HasArg, Long, Maybe, Multi, No, Occur, Opt, Optional, Req};
     use getopts::{Short, Yes};
+    use std::str;
 
     /** one group of options, e.g., both -h and --help, along with
      * their shared description and properties
@@ -691,7 +692,7 @@ pub mod groups {
 
             // FIXME: #5516
             // here we just need to indent the start of the description
-            let rowlen = row.len();
+            let rowlen = str::count_chars(row, 0, row.len());
             if rowlen < 24 {
                 do (24 - rowlen).times {
                     row.push_char(' ')
@@ -798,7 +799,7 @@ pub mod groups {
             cont
         };
 
-        ss.iter().enumerate().advance(|x| machine(x));
+        ss.char_offset_iter().advance(|x| machine(x));
 
         // Let the automaton 'run out' by supplying trailing whitespace
         while cont && match state { B | C => true, A => false } {

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -690,7 +690,7 @@ pub mod groups {
                 }
             }
 
-            // FIXME: #5516
+            // FIXME: #5516 should be graphemes not codepoints
             // here we just need to indent the start of the description
             let rowlen = str::count_chars(row, 0, row.len());
             if rowlen < 24 {
@@ -708,14 +708,14 @@ pub mod groups {
                 desc_normalized_whitespace.push_char(' ');
             }
 
-            // FIXME: #5516
+            // FIXME: #5516 should be graphemes not codepoints
             let mut desc_rows = ~[];
             do each_split_within(desc_normalized_whitespace, 54) |substr| {
                 desc_rows.push(substr.to_owned());
                 true
             };
 
-            // FIXME: #5516
+            // FIXME: #5516 should be graphemes not codepoints
             // wrapped description
             row.push_str(desc_rows.connect(desc_sep));
 
@@ -1573,6 +1573,33 @@ Options:
     -k --kiwi           This is a long description which won't be wrapped..+..
     -a --apple          This is a long description which _will_ be
                         wrapped..+..
+";
+
+        let usage = groups::usage("Usage: fruits", optgroups);
+
+        debug!("expected: <<%s>>", expected);
+        debug!("generated: <<%s>>", usage);
+        assert!(usage == expected)
+    }
+
+    #[test]
+    fn test_groups_usage_description_multibyte_handling() {
+        let optgroups = ~[
+            groups::optflag("k", "k\u2013w\u2013",
+                "The word kiwi is normally spelled with two i's"),
+            groups::optflag("a", "apple",
+                "This \u201Cdescription\u201D has some characters that could \
+confuse the line wrapping; an apple costs 0.51€ in some parts of Europe."),
+        ];
+
+        let expected =
+~"Usage: fruits
+
+Options:
+    -k --k–w–           The word kiwi is normally spelled with two i's
+    -a --apple          This “description” has some characters that could
+                        confuse the line wrapping; an apple costs 0.51€ in
+                        some parts of Europe.
 ";
 
         let usage = groups::usage("Usage: fruits", optgroups);


### PR DESCRIPTION
...bytes.

(removing previous note about eff-eye-ex'ing #5516 since it actually does not do so, it just gets us half-way.)
