### PR TITLE
rustpkg: Test that different copies of the same package ID can exist in ...

### DIFF
--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -14,7 +14,7 @@
 use lib::llvm::{False, llvm, mk_object_file, mk_section_iter};
 use metadata::decoder;
 use metadata::encoder;
-use metadata::filesearch::FileSearch;
+use metadata::filesearch::{FileSearch, FileMatch, FileMatches, FileDoesntMatch};
 use metadata::filesearch;
 use syntax::codemap::span;
 use syntax::diagnostic::span_handler;
@@ -92,10 +92,10 @@ fn find_library_crate_aux(
     // want: crate_name.dir_part() + prefix + crate_name.file_part + "-"
     let prefix = fmt!("%s%s-", prefix, crate_name);
     let mut matches = ~[];
-    filesearch::search(filesearch, |path| -> Option<()> {
+    filesearch::search(filesearch, |path| -> FileMatch {
       let path_str = path.filename();
       match path_str {
-          None => None,
+          None => FileDoesntMatch,
           Some(path_str) =>
               if path_str.starts_with(prefix) && path_str.ends_with(suffix) {
                   debug!("%s is a candidate", path.to_str());
@@ -104,20 +104,20 @@ fn find_library_crate_aux(
                           if !crate_matches(cvec, cx.metas, cx.hash) {
                               debug!("skipping %s, metadata doesn't match",
                                   path.to_str());
-                              None
+                              FileDoesntMatch
                           } else {
                               debug!("found %s with matching metadata", path.to_str());
                               matches.push((path.to_str(), cvec));
-                              None
+                              FileMatches
                           },
                       _ => {
                           debug!("could not load metadata for %s", path.to_str());
-                          None
+                          FileDoesntMatch
                       }
                   }
                }
                else {
-                   None
+                   FileDoesntMatch
                }
       }
     });

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -49,6 +49,9 @@ pub fn make_dir_rwx(p: &Path) -> bool { os::make_dir(p, U_RWX) }
 /// True if there's a directory in <workspace> with
 /// pkgid's short name
 pub fn workspace_contains_package_id(pkgid: &PkgId, workspace: &Path) -> bool {
+    debug!("Checking in src dir of %s for %s",
+           workspace.to_str(), pkgid.to_str());
+
     let src_dir = workspace.push("src");
 
     let mut found = false;
@@ -81,6 +84,9 @@ pub fn workspace_contains_package_id(pkgid: &PkgId, workspace: &Path) -> bool {
         }
         true
     };
+
+    debug!(if found { fmt!("Found %s in %s", pkgid.to_str(), workspace.to_str()) }
+           else     { fmt!("Didn't find %s in %s", pkgid.to_str(), workspace.to_str()) });
     found
 }
 

--- a/src/librustpkg/rustpkg.rs
+++ b/src/librustpkg/rustpkg.rs
@@ -250,6 +250,8 @@ impl CtxMethods for Ctx {
                     // argument
                     let pkgid = PkgId::new(args[0]);
                     let workspaces = pkg_parent_workspaces(&pkgid);
+                    debug!("package ID = %s, found it in %? workspaces",
+                           pkgid.to_str(), workspaces.len());
                     if workspaces.is_empty() {
                         let rp = rust_path();
                         assert!(!rp.is_empty());

--- a/src/librustpkg/search.rs
+++ b/src/librustpkg/search.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use path_util::installed_library_in_workspace;
+use path_util::{installed_library_in_workspace, rust_path};
+use version::Version;
 
 /// If a library with path `p` matching pkg_id's name exists under sroot_opt,
 /// return Some(p). Return None if there's no such path or if sroot_opt is None.
@@ -18,4 +19,19 @@ pub fn find_library_in_search_path(sroot_opt: Option<@Path>, short_name: &str) -
                 %s", short_name, (sroot.push("lib")).to_str());
         installed_library_in_workspace(short_name, sroot)
     }
+}
+
+/// If some workspace `p` in the RUST_PATH contains a package matching short_name,
+/// return Some(p) (returns the first one of there are multiple matches.) Return
+/// None if there's no such path.
+/// FIXME #8711: This ignores the desired version.
+pub fn find_installed_library_in_rust_path(short_name: &str, _version: &Version) -> Option<Path> {
+    let rp = rust_path();
+    for p in rp.iter() {
+        match installed_library_in_workspace(short_name, p) {
+            Some(path) => return Some(path),
+            None => ()
+        }
+    }
+    None
 }

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -213,11 +213,9 @@ fn is_url_like(p: &Path) -> bool {
 pub fn split_version<'a>(s: &'a str) -> Option<(&'a str, Version)> {
     // Check for extra '#' characters separately
     if s.split_iter('#').len() > 2 {
-        None
+        return None;
     }
-    else {
-        split_version_general(s, '#')
-    }
+    split_version_general(s, '#')
 }
 
 pub fn split_version_general<'a>(s: &'a str, sep: char) -> Option<(&'a str, Version)> {


### PR DESCRIPTION
r? @brson ...multiple workspaces

The test checks that rustpkg uses the first one, rather than complaining
about multiple matches.

Closes #7241
