### PR TITLE
fix performance regression from invalid IR

### DIFF
--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -590,7 +590,7 @@ fn test_repr() {
     exact_test(&(~"he\u10f3llo"), "~\"he\\u10f3llo\"");
 
     exact_test(&(@10), "@10");
-    exact_test(&(@mut 10), "@10"); // FIXME: #4210: incorrect
+    exact_test(&(@mut 10), "@mut 10");
     exact_test(&((@mut 10, 2)), "(@mut 10, 2)");
     exact_test(&(~10), "~10");
     exact_test(&(&10), "&10");


### PR DESCRIPTION
Monomorphize's normalization results in a 2% decrease in non-optimized
code size for libstd, so there's a negligible cost to removing it. This
also fixes several visit glue bugs because normalize wasn't considering
the differences in visit glue between types.

Closes #8720
