### PR TITLE
rustllvm: Specify hard floats for gnueabihf.

### DIFF
--- a/src/librustc/back/arm.rs
+++ b/src/librustc/back/arm.rs
@@ -13,7 +13,7 @@ use driver::session::sess_os_to_meta_os;
 use driver::session;
 use metadata::loader::meta_section_name;
 
-pub fn get_target_strs(target_os: session::os) -> target_strs::t {
+pub fn get_target_strs(target_triple: ~str, target_os: session::os) -> target_strs::t {
     return target_strs::t {
         module_asm: ~"",
 
@@ -61,13 +61,7 @@ pub fn get_target_strs(target_os: session::os) -> target_strs::t {
           }
         },
 
-        target_triple: match target_os {
-          session::os_macos => ~"arm-apple-darwin",
-          session::os_win32 => ~"arm-pc-mingw32",
-          session::os_linux => ~"arm-unknown-linux-gnueabihf",
-          session::os_android => ~"arm-linux-androideabi",
-          session::os_freebsd => ~"arm-unknown-freebsd"
-        },
+        target_triple: target_triple,
 
         cc_args: ~[~"-marm"]
     };

--- a/src/librustc/back/mips.rs
+++ b/src/librustc/back/mips.rs
@@ -13,7 +13,7 @@ use driver::session;
 use driver::session::sess_os_to_meta_os;
 use metadata::loader::meta_section_name;
 
-pub fn get_target_strs(target_os: session::os) -> target_strs::t {
+pub fn get_target_strs(target_triple: ~str, target_os: session::os) -> target_strs::t {
     return target_strs::t {
         module_asm: ~"",
 
@@ -61,13 +61,7 @@ pub fn get_target_strs(target_os: session::os) -> target_strs::t {
           }
         },
 
-        target_triple: match target_os {
-          session::os_macos => ~"mips-apple-darwin",
-          session::os_win32 => ~"mips-pc-mingw32",
-          session::os_linux => ~"mips-unknown-linux-gnu",
-          session::os_android => ~"mips-unknown-android-gnu",
-          session::os_freebsd => ~"mips-unknown-freebsd"
-        },
+        target_triple: target_triple,
 
         cc_args: ~[]
     };

--- a/src/librustc/back/x86.rs
+++ b/src/librustc/back/x86.rs
@@ -14,7 +14,7 @@ use driver::session::sess_os_to_meta_os;
 use driver::session;
 use metadata::loader::meta_section_name;
 
-pub fn get_target_strs(target_os: session::os) -> target_strs::t {
+pub fn get_target_strs(target_triple: ~str, target_os: session::os) -> target_strs::t {
     return target_strs::t {
         module_asm: ~"",
 
@@ -44,13 +44,7 @@ pub fn get_target_strs(target_os: session::os) -> target_strs::t {
           }
         },
 
-        target_triple: match target_os {
-          session::os_macos => ~"i686-apple-darwin",
-          session::os_win32 => ~"i686-pc-mingw32",
-          session::os_linux => ~"i686-unknown-linux-gnu",
-          session::os_android => ~"i686-unknown-android-gnu",
-          session::os_freebsd => ~"i686-unknown-freebsd"
-        },
+        target_triple: target_triple,
 
         cc_args: ~[~"-m32"]
     };

--- a/src/librustc/back/x86_64.rs
+++ b/src/librustc/back/x86_64.rs
@@ -14,7 +14,7 @@ use driver::session::sess_os_to_meta_os;
 use driver::session;
 use metadata::loader::meta_section_name;
 
-pub fn get_target_strs(target_os: session::os) -> target_strs::t {
+pub fn get_target_strs(target_triple: ~str, target_os: session::os) -> target_strs::t {
     return target_strs::t {
         module_asm: ~"",
 
@@ -52,13 +52,7 @@ pub fn get_target_strs(target_os: session::os) -> target_strs::t {
           }
         },
 
-        target_triple: match target_os {
-          session::os_macos => ~"x86_64-apple-darwin",
-          session::os_win32 => ~"x86_64-pc-mingw32",
-          session::os_linux => ~"x86_64-unknown-linux-gnu",
-          session::os_android => ~"x86_64-unknown-android-gnu",
-          session::os_freebsd => ~"x86_64-unknown-freebsd",
-        },
+        target_triple: target_triple,
 
         cc_args: ~[~"-m64"]
     };

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -570,11 +570,12 @@ pub fn build_target_config(sopts: @session::options,
       abi::Arm => (ast::ty_i32, ast::ty_u32, ast::ty_f64),
       abi::Mips => (ast::ty_i32, ast::ty_u32, ast::ty_f64)
     };
+    let target_triple = sopts.target_triple.clone();
     let target_strs = match arch {
-      abi::X86 => x86::get_target_strs(os),
-      abi::X86_64 => x86_64::get_target_strs(os),
-      abi::Arm => arm::get_target_strs(os),
-      abi::Mips => mips::get_target_strs(os)
+      abi::X86 => x86::get_target_strs(target_triple, os),
+      abi::X86_64 => x86_64::get_target_strs(target_triple, os),
+      abi::Arm => arm::get_target_strs(target_triple, os),
+      abi::Mips => mips::get_target_strs(target_triple, os)
     };
     let target_cfg = @session::config {
         os: os,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -391,19 +391,23 @@ LLVMRustWriteOutputFile(LLVMPassManagerRef PMR,
     cl::ParseCommandLineOptions(argc, argv);
   }
 
+  Triple Trip(Triple::normalize(triple));
+
   TargetOptions Options;
   Options.EnableSegmentedStacks = EnableSegmentedStacks;
   Options.FixedStackSegmentSize = 2 * 1024 * 1024;  // XXX: This is too big.
+  Options.FloatABIType =
+      (Trip.getEnvironment() == Triple::GNUEABIHF) ? FloatABI::Hard :
+                                                     FloatABI::Default;
 
   PassManager *PM = unwrap<PassManager>(PMR);
 
   std::string Err;
-  std::string Trip(Triple::normalize(triple));
   std::string FeaturesStr(feature);
   std::string CPUStr(cpu);
-  const Target *TheTarget = TargetRegistry::lookupTarget(Trip, Err);
+  const Target *TheTarget = TargetRegistry::lookupTarget(Trip.getTriple(), Err);
   TargetMachine *Target =
-    TheTarget->createTargetMachine(Trip, CPUStr, FeaturesStr,
+    TheTarget->createTargetMachine(Trip.getTriple(), CPUStr, FeaturesStr,
            Options, Reloc::PIC_,
            CodeModel::Default, OptLevel);
   Target->addAnalysisPasses(*PM);


### PR DESCRIPTION
Fixes #8536.
