### PR TITLE
Force line ending of '.in' files in jemalloc to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,6 @@ src/rt/msvc/* -whitespace
 src/rt/vg/* -whitespace
 src/rt/linenoise/* -whitespace
 src/rt/jemalloc/**/* -whitespace
+src/rt/jemalloc/include/jemalloc/jemalloc.h.in text eol=lf
+src/rt/jemalloc/include/jemalloc/jemalloc_defs.h.in text eol=lf
+src/rt/jemalloc/include/jemalloc/internal/jemalloc_internal.h.in text eol=lf


### PR DESCRIPTION
This fixes issue #8731 . On Windows, if the git option core.autocrlf is true (github recommends users to turn on this flag - see https://help.github.com/articles/dealing-with-line-endings), the headers generated from the .in files will have syntatic errors, causing compilation to fail.
