### PR TITLE
Enable debug info tests on Windows

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -282,7 +282,9 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
     }
 
     // write debugger script
-    let script_str = cmds.append("\nquit\n");
+    let script_str = [~"set charset UTF-8",
+                      cmds,
+                      ~"quit\n"].connect("\n");
     debug!("script_str = %s", script_str);
     dump_output_file(config, testfile, script_str, "debugger.script");
 

--- a/src/test/debug-info/basic-types.rs
+++ b/src/test/debug-info/basic-types.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // Caveats - gdb prints any 8-bit value (meaning rust i8 and u8 values)
 // as its numerical value along with its associated ASCII char, there
 // doesn't seem to be any way around this. Also, gdb doesn't know

--- a/src/test/debug-info/borrowed-basic.rs
+++ b/src/test/debug-info/borrowed-basic.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // Gdb doesn't know about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 

--- a/src/test/debug-info/borrowed-c-style-enum.rs
+++ b/src/test/debug-info/borrowed-c-style-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/borrowed-enum.rs
+++ b/src/test/debug-info/borrowed-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/borrowed-managed-basic.rs
+++ b/src/test/debug-info/borrowed-managed-basic.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // Gdb doesn't know about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 

--- a/src/test/debug-info/borrowed-struct.rs
+++ b/src/test/debug-info/borrowed-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/borrowed-tuple.rs
+++ b/src/test/debug-info/borrowed-tuple.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/borrowed-unique-basic.rs
+++ b/src/test/debug-info/borrowed-unique-basic.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // Gdb doesn't know about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 

--- a/src/test/debug-info/box.rs
+++ b/src/test/debug-info/box.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break _zzz

--- a/src/test/debug-info/boxed-struct.rs
+++ b/src/test/debug-info/boxed-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/boxed-vec.rs
+++ b/src/test/debug-info/boxed-vec.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/c-style-enum-in-composite.rs
+++ b/src/test/debug-info/c-style-enum-in-composite.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/c-style-enum.rs
+++ b/src/test/debug-info/c-style-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/closure-in-generic-function.rs
+++ b/src/test/debug-info/closure-in-generic-function.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/destructured-fn-argument.rs
+++ b/src/test/debug-info/destructured-fn-argument.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/destructured-local.rs
+++ b/src/test/debug-info/destructured-local.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/evec-in-struct.rs
+++ b/src/test/debug-info/evec-in-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/function-arguments.rs
+++ b/src/test/debug-info/function-arguments.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/generic-function.rs
+++ b/src/test/debug-info/generic-function.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/generic-functions-nested.rs
+++ b/src/test/debug-info/generic-functions-nested.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/generic-method-on-generic-struct.rs
+++ b/src/test/debug-info/generic-method-on-generic-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/generic-static-method-on-struct-and-enum.rs
+++ b/src/test/debug-info/generic-static-method-on-struct-and-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/generic-struct-style-enum.rs
+++ b/src/test/debug-info/generic-struct-style-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print union on
 // debugger:break zzz

--- a/src/test/debug-info/generic-struct.rs
+++ b/src/test/debug-info/generic-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/generic-trait-generic-static-default-method.rs
+++ b/src/test/debug-info/generic-trait-generic-static-default-method.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/generic-tuple-style-enum.rs
+++ b/src/test/debug-info/generic-tuple-style-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print union on
 // debugger:break zzz

--- a/src/test/debug-info/lexical-scope-in-for-loop.rs
+++ b/src/test/debug-info/lexical-scope-in-for-loop.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+// xfail-win32
 
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz

--- a/src/test/debug-info/lexical-scope-in-if.rs
+++ b/src/test/debug-info/lexical-scope-in-if.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+// xfail-win32
 
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz

--- a/src/test/debug-info/lexical-scope-in-managed-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-managed-closure.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/lexical-scope-in-match.rs
+++ b/src/test/debug-info/lexical-scope-in-match.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+// xfail-win32
 
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz

--- a/src/test/debug-info/lexical-scope-in-parameterless-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-parameterless-closure.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z debug-info
 // debugger:run
 

--- a/src/test/debug-info/lexical-scope-in-stack-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-stack-closure.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/lexical-scope-in-unconditional-loop.rs
+++ b/src/test/debug-info/lexical-scope-in-unconditional-loop.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/lexical-scope-in-unique-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-unique-closure.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/lexical-scope-in-while.rs
+++ b/src/test/debug-info/lexical-scope-in-while.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/lexical-scope-with-macro.rs
+++ b/src/test/debug-info/lexical-scope-with-macro.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/lexical-scopes-in-block-expression.rs
+++ b/src/test/debug-info/lexical-scopes-in-block-expression.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
+// xfail-win32
 
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz

--- a/src/test/debug-info/managed-enum.rs
+++ b/src/test/debug-info/managed-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/managed-pointer-within-unique-vec.rs
+++ b/src/test/debug-info/managed-pointer-within-unique-vec.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/managed-pointer-within-unique.rs
+++ b/src/test/debug-info/managed-pointer-within-unique.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/method-on-enum.rs
+++ b/src/test/debug-info/method-on-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/method-on-generic-struct.rs
+++ b/src/test/debug-info/method-on-generic-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/method-on-struct.rs
+++ b/src/test/debug-info/method-on-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/method-on-trait.rs
+++ b/src/test/debug-info/method-on-trait.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/method-on-tuple-struct.rs
+++ b/src/test/debug-info/method-on-tuple-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/multiple-functions-equal-var-names.rs
+++ b/src/test/debug-info/multiple-functions-equal-var-names.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/multiple-functions.rs
+++ b/src/test/debug-info/multiple-functions.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/name-shadowing-and-scope-nesting.rs
+++ b/src/test/debug-info/name-shadowing-and-scope-nesting.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/nil-enum.rs
+++ b/src/test/debug-info/nil-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/option-like-enum.rs
+++ b/src/test/debug-info/option-like-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/packed-struct-with-destructor.rs
+++ b/src/test/debug-info/packed-struct-with-destructor.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/packed-struct.rs
+++ b/src/test/debug-info/packed-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/self-in-default-method.rs
+++ b/src/test/debug-info/self-in-default-method.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/self-in-generic-default-method.rs
+++ b/src/test/debug-info/self-in-generic-default-method.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/shadowed-argument.rs
+++ b/src/test/debug-info/shadowed-argument.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/shadowed-variable.rs
+++ b/src/test/debug-info/shadowed-variable.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/simple-lexical-scope.rs
+++ b/src/test/debug-info/simple-lexical-scope.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/simple-struct.rs
+++ b/src/test/debug-info/simple-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/simple-tuple.rs
+++ b/src/test/debug-info/simple-tuple.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/static-method-on-struct-and-enum.rs
+++ b/src/test/debug-info/static-method-on-struct-and-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/struct-in-enum.rs
+++ b/src/test/debug-info/struct-in-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print union on
 // debugger:break zzz

--- a/src/test/debug-info/struct-in-struct.rs
+++ b/src/test/debug-info/struct-in-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/struct-style-enum.rs
+++ b/src/test/debug-info/struct-style-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print union on
 // debugger:break zzz

--- a/src/test/debug-info/struct-with-destructor.rs
+++ b/src/test/debug-info/struct-with-destructor.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/trait-generic-static-default-method.rs
+++ b/src/test/debug-info/trait-generic-static-default-method.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/tuple-in-struct.rs
+++ b/src/test/debug-info/tuple-in-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/tuple-in-tuple.rs
+++ b/src/test/debug-info/tuple-in-tuple.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/tuple-struct.rs
+++ b/src/test/debug-info/tuple-struct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/tuple-style-enum.rs
+++ b/src/test/debug-info/tuple-style-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print union on
 // debugger:break zzz

--- a/src/test/debug-info/unique-enum.rs
+++ b/src/test/debug-info/unique-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:break zzz
 // debugger:run

--- a/src/test/debug-info/vec-slices.rs
+++ b/src/test/debug-info/vec-slices.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz

--- a/src/test/debug-info/vec.rs
+++ b/src/test/debug-info/vec.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32 Broken because of LLVM bug: http://llvm.org/bugs/show_bug.cgi?id=16249
-
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
 // debugger:break zzz


### PR DESCRIPTION
Now that new LLVM has landed, the debug info works on Windows as well.   Most existing tests pass, except for the following four, which I left disabled for now:
lexical-scope-in-for-loop
lexical-scope-in-if
lexical-scope-in-match
lexical-scopes-in-block-expression

Also, fixed a small problem with the debug info test runner.
