### PR TITLE
doc: Link condition and error-handling tutorial from main tutorial

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2553,6 +2553,7 @@ tutorials on individual topics.
 * [Macros][macros]
 * [The foreign function interface][ffi]
 * [Containers and iterators](tutorial-container.html)
+* [Error-handling and Conditions](tutorial-conditions.html)
 
 There is further documentation on the [wiki].
 


### PR DESCRIPTION
As mentioned in PR #8563 it seems this tutorial has no inbound link!
