### PR TITLE
Fix valgrind suppression on mac

### DIFF
--- a/src/etc/x86.supp
+++ b/src/etc/x86.supp
@@ -512,6 +512,5 @@
    fun:uv__platform_loop_init
    fun:uv__loop_init
    fun:uv_loop_new
-   fun:rust_uv_loop_new__c_stack_shim
    ...
 }


### PR DESCRIPTION
This callstack changed when the FFI did. I am still a little frightened by
this suppression.

cc #8253
