### PR TITLE
Add test for #5239

### DIFF
--- a/src/test/compile-fail/issue-5239-1.rs
+++ b/src/test/compile-fail/issue-5239-1.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for issue #5239
+
+fn main() {
+    let x: &fn(int) -> int = |ref x| { x += 1; }; //~ ERROR binary operation + cannot be applied to type `&int`
+}

--- a/src/test/run-pass/issue-5239-2.rs
+++ b/src/test/run-pass/issue-5239-2.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for issue #5239
+
+fn main() { 
+    let _f: &fn(int) -> int = |ref x: int| { *x };
+    let foo = 10;
+    assert!(_f(foo) == 10);
+}


### PR DESCRIPTION
I've added a test for the second example mentioned in #5239. The first example does not compile with a reasonable error message. Should I add a compile-fail test for that example as well?

```
/rust/src/test/run-pass/issue-5239.rs:15:45: 15:51 error: binary operation + cannot be applied to type `&int`
rust/src/test/run-pass/issue-5239.rs:15     let _f = |ref x: int| { x += 1};
                                                                                     ^~~~~~

error: aborting due to previous error
```
