### PR TITLE
Remove offset_inbounds for an unsafe offset function

### DIFF
--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -149,7 +149,7 @@ pub fn type_uses_for(ccx: @mut CrateContext, fn_id: def_id, n_tps: uint)
                     "visit_tydesc"  | "forget" | "frame_address" |
                     "morestack_addr" => 0,
 
-                    "offset" | "offset_inbounds" |
+                    "offset" |
                     "memcpy32" | "memcpy64" | "memmove32" | "memmove64" |
                     "memset32" | "memset64" => use_repr,
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3663,20 +3663,6 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                    mutbl: ast::m_imm
                }))
             }
-            "offset_inbounds" => {
-              (1,
-               ~[
-                  ty::mk_ptr(tcx, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::m_imm
-                  }),
-                  ty::mk_int()
-               ],
-               ty::mk_ptr(tcx, ty::mt {
-                   ty: param(ccx, 0),
-                   mutbl: ast::m_imm
-               }))
-            }
             "memcpy32" => {
               (1,
                ~[

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -179,7 +179,7 @@ impl<'self> ToCStr for &'self [u8] {
         do cs.with_mut_ref |buf| {
             for i in range(0, self.len()) {
                 unsafe {
-                    let p = buf.offset_inbounds(i as int);
+                    let p = buf.offset(i as int);
                     if *p == 0 {
                         match null_byte::cond.raise(self.to_owned()) {
                             Truncate => break,
@@ -222,7 +222,7 @@ impl<'self> Iterator<libc::c_char> for CStringIterator<'self> {
         if ch == 0 {
             None
         } else {
-            self.ptr = ptr::offset(self.ptr, 1);
+            self.ptr = unsafe { ptr::offset(self.ptr, 1) };
             Some(ch)
         }
     }

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -228,7 +228,7 @@ impl ReprVisitor {
                 self.writer.write_str(", ");
             }
             self.visit_ptr_inner(p as *c_void, inner);
-            p = align(ptr::offset(p, sz as int) as uint, al) as *u8;
+            p = align(unsafe { ptr::offset(p, sz as int) as uint }, al) as *u8;
             left -= dec;
         }
         self.writer.write_char(']');

--- a/src/libstd/rt/stack.rs
+++ b/src/libstd/rt/stack.rs
@@ -46,7 +46,9 @@ impl StackSegment {
 
     /// Point one word beyond the high end of the allocated stack
     pub fn end(&self) -> *uint {
-        vec::raw::to_ptr(self.buf).offset(self.buf.len() as int) as *uint
+        unsafe {
+            vec::raw::to_ptr(self.buf).offset(self.buf.len() as int) as *uint
+        }
     }
 }
 

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1092,7 +1092,7 @@ pub mod raw {
     pub unsafe fn slice_unchecked<'a>(s: &'a str, begin: uint, end: uint) -> &'a str {
         do s.as_imm_buf |sbuf, _n| {
              cast::transmute(Slice {
-                 data: sbuf.offset_inbounds(begin as int),
+                 data: sbuf.offset(begin as int),
                  len: end - begin,
              })
         }

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -332,19 +332,13 @@ extern "rust-intrinsic" {
     /// Get the address of the `__morestack` stack growth function.
     pub fn morestack_addr() -> *();
 
-    /// Calculates the offset from a pointer.
-    ///
-    /// This is implemented as an intrinsic to avoid converting to and from an
-    /// integer, since the conversion would throw away aliasing information.
-    pub fn offset<T>(dst: *T, offset: int) -> *T;
-
     /// Calculates the offset from a pointer. The offset *must* be in-bounds of
     /// the object, or one-byte-past-the-end. An arithmetic overflow is also
     /// undefined behaviour.
     ///
-    /// This intrinsic should be preferred over `offset` when the guarantee can
-    /// be satisfied, to enable better optimization.
-    pub fn offset_inbounds<T>(dst: *T, offset: int) -> *T;
+    /// This is implemented as an intrinsic to avoid converting to and from an
+    /// integer, since the conversion would throw away aliasing information.
+    pub fn offset<T>(dst: *T, offset: int) -> *T;
 
     /// Equivalent to the `llvm.memcpy.p0i8.0i8.i32` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -896,7 +896,7 @@ impl<'self,T> ImmutableVector<'self, T> for &'self [T] {
                             lifetime: cast::transmute(p)}
             } else {
                 VecIterator{ptr: p,
-                            end: p.offset_inbounds(self.len() as int),
+                            end: p.offset(self.len() as int),
                             lifetime: cast::transmute(p)}
             }
         }
@@ -1884,7 +1884,7 @@ impl<'self,T> MutableVector<'self, T> for &'self mut [T] {
                                lifetime: cast::transmute(p)}
             } else {
                 VecMutIterator{ptr: p,
-                               end: p.offset_inbounds(self.len() as int),
+                               end: p.offset(self.len() as int),
                                lifetime: cast::transmute(p)}
             }
         }
@@ -2247,7 +2247,7 @@ macro_rules! iterator {
                             // same pointer.
                             cast::transmute(self.ptr as uint + 1)
                         } else {
-                            self.ptr.offset_inbounds(1)
+                            self.ptr.offset(1)
                         };
 
                         Some(cast::transmute(old))
@@ -2279,7 +2279,7 @@ macro_rules! double_ended_iterator {
                             // See above for why 'ptr.offset' isn't used
                             cast::transmute(self.end as uint - 1)
                         } else {
-                            self.end.offset_inbounds(-1)
+                            self.end.offset(-1)
                         };
                         Some(cast::transmute(self.end))
                     }


### PR DESCRIPTION
Everything that we do is actually inbounds, so there's no reason for us to be exposing two of these functions
