### PR TITLE
Remove @io::Writer from sys/repr/reflect

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4572,7 +4572,7 @@ pub fn visitor_object_ty(tcx: ctxt,
                  trait_ref.def_id,
                  trait_ref.substs.clone(),
                  RegionTraitStore(region),
-                 ast::m_imm,
+                 ast::m_mutbl,
                  EmptyBuiltinBounds())))
 }
 

--- a/src/libstd/logging.rs
+++ b/src/libstd/logging.rs
@@ -41,16 +41,10 @@ pub fn console_off() {
 #[lang="log_type"]
 #[allow(missing_doc)]
 pub fn log_type<T>(_level: u32, object: &T) {
-    use io;
-    use repr;
-    use str;
-
-    let bytes = do io::with_bytes_writer |writer| {
-        repr::write_repr(writer, object);
-    };
+    use sys;
 
     // XXX: Bad allocation
-    let msg = str::from_bytes(bytes);
+    let msg = sys::log_str(object);
     newsched_log_str(msg);
 }
 

--- a/src/libstd/reflect_stage0.rs
+++ b/src/libstd/reflect_stage0.rs
@@ -28,9 +28,9 @@ use unstable::raw;
  * then build a MovePtrAdaptor wrapped around your struct.
  */
 pub trait MovePtr {
-    fn move_ptr(&mut self, adjustment: &fn(*c_void) -> *c_void);
-    fn push_ptr(&mut self);
-    fn pop_ptr(&mut self);
+    fn move_ptr(&self, adjustment: &fn(*c_void) -> *c_void);
+    fn push_ptr(&self);
+    fn pop_ptr(&self);
 }
 
 /// Helper function for alignment calculation.
@@ -49,173 +49,173 @@ pub fn MovePtrAdaptor<V:TyVisitor + MovePtr>(v: V) -> MovePtrAdaptor<V> {
 
 impl<V:TyVisitor + MovePtr> MovePtrAdaptor<V> {
     #[inline]
-    pub fn bump(&mut self, sz: uint) {
+    pub fn bump(&self, sz: uint) {
         do self.inner.move_ptr() |p| {
             ((p as uint) + sz) as *c_void
         };
     }
 
     #[inline]
-    pub fn align(&mut self, a: uint) {
+    pub fn align(&self, a: uint) {
         do self.inner.move_ptr() |p| {
             align(p as uint, a) as *c_void
         };
     }
 
     #[inline]
-    pub fn align_to<T>(&mut self) {
+    pub fn align_to<T>(&self) {
         self.align(sys::min_align_of::<T>());
     }
 
     #[inline]
-    pub fn bump_past<T>(&mut self) {
+    pub fn bump_past<T>(&self) {
         self.bump(sys::size_of::<T>());
     }
 }
 
 /// Abstract type-directed pointer-movement using the MovePtr trait
 impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
-    fn visit_bot(&mut self) -> bool {
+    fn visit_bot(&self) -> bool {
         self.align_to::<()>();
         if ! self.inner.visit_bot() { return false; }
         self.bump_past::<()>();
         true
     }
 
-    fn visit_nil(&mut self) -> bool {
+    fn visit_nil(&self) -> bool {
         self.align_to::<()>();
         if ! self.inner.visit_nil() { return false; }
         self.bump_past::<()>();
         true
     }
 
-    fn visit_bool(&mut self) -> bool {
+    fn visit_bool(&self) -> bool {
         self.align_to::<bool>();
         if ! self.inner.visit_bool() { return false; }
         self.bump_past::<bool>();
         true
     }
 
-    fn visit_int(&mut self) -> bool {
+    fn visit_int(&self) -> bool {
         self.align_to::<int>();
         if ! self.inner.visit_int() { return false; }
         self.bump_past::<int>();
         true
     }
 
-    fn visit_i8(&mut self) -> bool {
+    fn visit_i8(&self) -> bool {
         self.align_to::<i8>();
         if ! self.inner.visit_i8() { return false; }
         self.bump_past::<i8>();
         true
     }
 
-    fn visit_i16(&mut self) -> bool {
+    fn visit_i16(&self) -> bool {
         self.align_to::<i16>();
         if ! self.inner.visit_i16() { return false; }
         self.bump_past::<i16>();
         true
     }
 
-    fn visit_i32(&mut self) -> bool {
+    fn visit_i32(&self) -> bool {
         self.align_to::<i32>();
         if ! self.inner.visit_i32() { return false; }
         self.bump_past::<i32>();
         true
     }
 
-    fn visit_i64(&mut self) -> bool {
+    fn visit_i64(&self) -> bool {
         self.align_to::<i64>();
         if ! self.inner.visit_i64() { return false; }
         self.bump_past::<i64>();
         true
     }
 
-    fn visit_uint(&mut self) -> bool {
+    fn visit_uint(&self) -> bool {
         self.align_to::<uint>();
         if ! self.inner.visit_uint() { return false; }
         self.bump_past::<uint>();
         true
     }
 
-    fn visit_u8(&mut self) -> bool {
+    fn visit_u8(&self) -> bool {
         self.align_to::<u8>();
         if ! self.inner.visit_u8() { return false; }
         self.bump_past::<u8>();
         true
     }
 
-    fn visit_u16(&mut self) -> bool {
+    fn visit_u16(&self) -> bool {
         self.align_to::<u16>();
         if ! self.inner.visit_u16() { return false; }
         self.bump_past::<u16>();
         true
     }
 
-    fn visit_u32(&mut self) -> bool {
+    fn visit_u32(&self) -> bool {
         self.align_to::<u32>();
         if ! self.inner.visit_u32() { return false; }
         self.bump_past::<u32>();
         true
     }
 
-    fn visit_u64(&mut self) -> bool {
+    fn visit_u64(&self) -> bool {
         self.align_to::<u64>();
         if ! self.inner.visit_u64() { return false; }
         self.bump_past::<u64>();
         true
     }
 
-    fn visit_float(&mut self) -> bool {
+    fn visit_float(&self) -> bool {
         self.align_to::<float>();
         if ! self.inner.visit_float() { return false; }
         self.bump_past::<float>();
         true
     }
 
-    fn visit_f32(&mut self) -> bool {
+    fn visit_f32(&self) -> bool {
         self.align_to::<f32>();
         if ! self.inner.visit_f32() { return false; }
         self.bump_past::<f32>();
         true
     }
 
-    fn visit_f64(&mut self) -> bool {
+    fn visit_f64(&self) -> bool {
         self.align_to::<f64>();
         if ! self.inner.visit_f64() { return false; }
         self.bump_past::<f64>();
         true
     }
 
-    fn visit_char(&mut self) -> bool {
+    fn visit_char(&self) -> bool {
         self.align_to::<char>();
         if ! self.inner.visit_char() { return false; }
         self.bump_past::<char>();
         true
     }
 
-    fn visit_estr_box(&mut self) -> bool {
+    fn visit_estr_box(&self) -> bool {
         self.align_to::<@str>();
         if ! self.inner.visit_estr_box() { return false; }
         self.bump_past::<@str>();
         true
     }
 
-    fn visit_estr_uniq(&mut self) -> bool {
+    fn visit_estr_uniq(&self) -> bool {
         self.align_to::<~str>();
         if ! self.inner.visit_estr_uniq() { return false; }
         self.bump_past::<~str>();
         true
     }
 
-    fn visit_estr_slice(&mut self) -> bool {
+    fn visit_estr_slice(&self) -> bool {
         self.align_to::<&'static str>();
         if ! self.inner.visit_estr_slice() { return false; }
         self.bump_past::<&'static str>();
         true
     }
 
-    fn visit_estr_fixed(&mut self, n: uint,
+    fn visit_estr_fixed(&self, n: uint,
                         sz: uint,
                         align: uint) -> bool {
         self.align(align);
@@ -224,83 +224,83 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_box(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<@u8>();
         if ! self.inner.visit_box(mtbl, inner) { return false; }
         self.bump_past::<@u8>();
         true
     }
 
-    fn visit_uniq(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_uniq_managed(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_ptr(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_ptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<*u8>();
         if ! self.inner.visit_ptr(mtbl, inner) { return false; }
         self.bump_past::<*u8>();
         true
     }
 
-    fn visit_rptr(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<&'static u8>();
         if ! self.inner.visit_rptr(mtbl, inner) { return false; }
         self.bump_past::<&'static u8>();
         true
     }
 
-    fn visit_unboxed_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<raw::Vec<()>>();
         if ! self.inner.visit_vec(mtbl, inner) { return false; }
         true
     }
 
-    fn visit_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_vec(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_box(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<@[u8]>();
         if ! self.inner.visit_evec_box(mtbl, inner) { return false; }
         self.bump_past::<@[u8]>();
         true
     }
 
-    fn visit_evec_uniq(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_evec_uniq(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_uniq_managed(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[@u8]>();
         if ! self.inner.visit_evec_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~[@u8]>();
         true
     }
 
-    fn visit_evec_slice(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<&'static [u8]>();
         if ! self.inner.visit_evec_slice(mtbl, inner) { return false; }
         self.bump_past::<&'static [u8]>();
         true
     }
 
-    fn visit_evec_fixed(&mut self, n: uint, sz: uint, align: uint,
+    fn visit_evec_fixed(&self, n: uint, sz: uint, align: uint,
                         mtbl: uint, inner: *TyDesc) -> bool {
         self.align(align);
         if ! self.inner.visit_evec_fixed(n, sz, align, mtbl, inner) {
@@ -310,13 +310,13 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_enter_rec(&mut self, n_fields: uint, sz: uint, align: uint) -> bool {
+    fn visit_enter_rec(&self, n_fields: uint, sz: uint, align: uint) -> bool {
         self.align(align);
         if ! self.inner.visit_enter_rec(n_fields, sz, align) { return false; }
         true
     }
 
-    fn visit_rec_field(&mut self, i: uint, name: &str,
+    fn visit_rec_field(&self, i: uint, name: &str,
                        mtbl: uint, inner: *TyDesc) -> bool {
         unsafe { self.align((*inner).align); }
         if ! self.inner.visit_rec_field(i, name, mtbl, inner) {
@@ -326,12 +326,12 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_leave_rec(&mut self, n_fields: uint, sz: uint, align: uint) -> bool {
+    fn visit_leave_rec(&self, n_fields: uint, sz: uint, align: uint) -> bool {
         if ! self.inner.visit_leave_rec(n_fields, sz, align) { return false; }
         true
     }
 
-    fn visit_enter_class(&mut self, n_fields: uint, sz: uint, align: uint)
+    fn visit_enter_class(&self, n_fields: uint, sz: uint, align: uint)
                       -> bool {
         self.align(align);
         if ! self.inner.visit_enter_class(n_fields, sz, align) {
@@ -340,7 +340,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_class_field(&mut self, i: uint, name: &str,
+    fn visit_class_field(&self, i: uint, name: &str,
                          mtbl: uint, inner: *TyDesc) -> bool {
         unsafe { self.align((*inner).align); }
         if ! self.inner.visit_class_field(i, name, mtbl, inner) {
@@ -350,7 +350,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_leave_class(&mut self, n_fields: uint, sz: uint, align: uint)
+    fn visit_leave_class(&self, n_fields: uint, sz: uint, align: uint)
                       -> bool {
         if ! self.inner.visit_leave_class(n_fields, sz, align) {
             return false;
@@ -358,25 +358,25 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_enter_tup(&mut self, n_fields: uint, sz: uint, align: uint) -> bool {
+    fn visit_enter_tup(&self, n_fields: uint, sz: uint, align: uint) -> bool {
         self.align(align);
         if ! self.inner.visit_enter_tup(n_fields, sz, align) { return false; }
         true
     }
 
-    fn visit_tup_field(&mut self, i: uint, inner: *TyDesc) -> bool {
+    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool {
         unsafe { self.align((*inner).align); }
         if ! self.inner.visit_tup_field(i, inner) { return false; }
         unsafe { self.bump((*inner).size); }
         true
     }
 
-    fn visit_leave_tup(&mut self, n_fields: uint, sz: uint, align: uint) -> bool {
+    fn visit_leave_tup(&self, n_fields: uint, sz: uint, align: uint) -> bool {
         if ! self.inner.visit_leave_tup(n_fields, sz, align) { return false; }
         true
     }
 
-    fn visit_enter_fn(&mut self, purity: uint, proto: uint,
+    fn visit_enter_fn(&self, purity: uint, proto: uint,
                       n_inputs: uint, retstyle: uint) -> bool {
         if ! self.inner.visit_enter_fn(purity, proto, n_inputs, retstyle) {
             return false
@@ -384,17 +384,17 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_fn_input(&mut self, i: uint, mode: uint, inner: *TyDesc) -> bool {
+    fn visit_fn_input(&self, i: uint, mode: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_fn_input(i, mode, inner) { return false; }
         true
     }
 
-    fn visit_fn_output(&mut self, retstyle: uint, inner: *TyDesc) -> bool {
+    fn visit_fn_output(&self, retstyle: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_fn_output(retstyle, inner) { return false; }
         true
     }
 
-    fn visit_leave_fn(&mut self, purity: uint, proto: uint,
+    fn visit_leave_fn(&self, purity: uint, proto: uint,
                       n_inputs: uint, retstyle: uint) -> bool {
         if ! self.inner.visit_leave_fn(purity, proto, n_inputs, retstyle) {
             return false;
@@ -402,7 +402,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_enter_enum(&mut self, n_variants: uint,
+    fn visit_enter_enum(&self, n_variants: uint,
                         get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         sz: uint, align: uint)
                      -> bool {
@@ -413,7 +413,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_enter_enum_variant(&mut self, variant: uint,
+    fn visit_enter_enum_variant(&self, variant: uint,
                                 disr_val: int,
                                 n_fields: uint,
                                 name: &str) -> bool {
@@ -424,7 +424,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_enum_variant_field(&mut self, i: uint, offset: uint, inner: *TyDesc) -> bool {
+    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *TyDesc) -> bool {
         self.inner.push_ptr();
         self.bump(offset);
         if ! self.inner.visit_enum_variant_field(i, offset, inner) { return false; }
@@ -432,7 +432,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_leave_enum_variant(&mut self, variant: uint,
+    fn visit_leave_enum_variant(&self, variant: uint,
                                 disr_val: int,
                                 n_fields: uint,
                                 name: &str) -> bool {
@@ -443,7 +443,7 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_leave_enum(&mut self, n_variants: uint,
+    fn visit_leave_enum(&self, n_variants: uint,
                         get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         sz: uint, align: uint) -> bool {
         if ! self.inner.visit_leave_enum(n_variants, get_disr, sz, align) {
@@ -453,38 +453,38 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_trait(&mut self) -> bool {
+    fn visit_trait(&self) -> bool {
         self.align_to::<@TyVisitor>();
         if ! self.inner.visit_trait() { return false; }
         self.bump_past::<@TyVisitor>();
         true
     }
 
-    fn visit_param(&mut self, i: uint) -> bool {
+    fn visit_param(&self, i: uint) -> bool {
         if ! self.inner.visit_param(i) { return false; }
         true
     }
 
-    fn visit_self(&mut self) -> bool {
+    fn visit_self(&self) -> bool {
         self.align_to::<&'static u8>();
         if ! self.inner.visit_self() { return false; }
         self.align_to::<&'static u8>();
         true
     }
 
-    fn visit_type(&mut self) -> bool {
+    fn visit_type(&self) -> bool {
         if ! self.inner.visit_type() { return false; }
         true
     }
 
-    fn visit_opaque_box(&mut self) -> bool {
+    fn visit_opaque_box(&self) -> bool {
         self.align_to::<@u8>();
         if ! self.inner.visit_opaque_box() { return false; }
         self.bump_past::<@u8>();
         true
     }
 
-    fn visit_closure_ptr(&mut self, ck: uint) -> bool {
+    fn visit_closure_ptr(&self, ck: uint) -> bool {
         self.align_to::<@fn()>();
         if ! self.inner.visit_closure_ptr(ck) { return false; }
         self.bump_past::<@fn()>();

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -19,7 +19,7 @@ More runtime type reflection
 use cast::transmute;
 use char;
 use container::Container;
-use io::{Writer, WriterUtil};
+use rt::io;
 use iterator::Iterator;
 use libc::c_void;
 use option::{Some, None};
@@ -32,51 +32,27 @@ use vec::OwnedVector;
 use unstable::intrinsics::{Opaque, TyDesc, TyVisitor, get_tydesc, visit_tydesc};
 use unstable::raw;
 
-#[cfg(test)] use io;
-
-/// Helpers
-
-trait EscapedCharWriter {
-    fn write_escaped_char(&self, ch: char);
-}
-
-impl EscapedCharWriter for @Writer {
-    fn write_escaped_char(&self, ch: char) {
-        match ch {
-            '\t' => self.write_str("\\t"),
-            '\r' => self.write_str("\\r"),
-            '\n' => self.write_str("\\n"),
-            '\\' => self.write_str("\\\\"),
-            '\'' => self.write_str("\\'"),
-            '"' => self.write_str("\\\""),
-            '\x20'..'\x7e' => self.write_char(ch),
-            _ => {
-                do char::escape_unicode(ch) |c| {
-                    self.write_char(c);
-                }
-            }
-        }
-    }
-}
-
 /// Representations
 
 trait Repr {
-    fn write_repr(&self, writer: @Writer);
+    fn write_repr(&self, writer: &mut io::Writer);
 }
 
 impl Repr for () {
-    fn write_repr(&self, writer: @Writer) { writer.write_str("()"); }
+    fn write_repr(&self, writer: &mut io::Writer) {
+        writer.write("()".as_bytes());
+    }
 }
 
 impl Repr for bool {
-    fn write_repr(&self, writer: @Writer) {
-        writer.write_str(if *self { "true" } else { "false" })
+    fn write_repr(&self, writer: &mut io::Writer) {
+        let s = if *self { "true" } else { "false" };
+        writer.write(s.as_bytes())
     }
 }
 
 impl Repr for int {
-    fn write_repr(&self, writer: @Writer) {
+    fn write_repr(&self, writer: &mut io::Writer) {
         do ::int::to_str_bytes(*self, 10u) |bits| {
             writer.write(bits);
         }
@@ -84,7 +60,7 @@ impl Repr for int {
 }
 
 macro_rules! int_repr(($ty:ident, $suffix:expr) => (impl Repr for $ty {
-    fn write_repr(&self, writer: @Writer) {
+    fn write_repr(&self, writer: &mut io::Writer) {
         do ::$ty::to_str_bytes(*self, 10u) |bits| {
             writer.write(bits);
             writer.write(bytes!($suffix));
@@ -103,14 +79,14 @@ int_repr!(u32, "u32")
 int_repr!(u64, "u64")
 
 impl Repr for float {
-    fn write_repr(&self, writer: @Writer) {
+    fn write_repr(&self, writer: &mut io::Writer) {
         let s = self.to_str();
         writer.write(s.as_bytes());
     }
 }
 
 macro_rules! num_repr(($ty:ident, $suffix:expr) => (impl Repr for $ty {
-    fn write_repr(&self, writer: @Writer) {
+    fn write_repr(&self, writer: &mut io::Writer) {
         let s = self.to_str();
         writer.write(s.as_bytes());
         writer.write(bytes!($suffix));
@@ -128,87 +104,97 @@ enum VariantState {
     AlreadyFound
 }
 
-pub struct ReprVisitor {
-    ptr: @mut *c_void,
-    ptr_stk: @mut ~[*c_void],
-    var_stk: @mut ~[VariantState],
-    writer: @Writer
+pub struct ReprVisitor<'self> {
+    ptr: *c_void,
+    ptr_stk: ~[*c_void],
+    var_stk: ~[VariantState],
+    writer: &'self mut io::Writer
 }
-pub fn ReprVisitor(ptr: *c_void, writer: @Writer) -> ReprVisitor {
+
+pub fn ReprVisitor<'a>(ptr: *c_void,
+                       writer: &'a mut io::Writer) -> ReprVisitor<'a> {
     ReprVisitor {
-        ptr: @mut ptr,
-        ptr_stk: @mut ~[],
-        var_stk: @mut ~[],
+        ptr: ptr,
+        ptr_stk: ~[],
+        var_stk: ~[],
         writer: writer,
     }
 }
 
-impl MovePtr for ReprVisitor {
+impl<'self> MovePtr for ReprVisitor<'self> {
     #[inline]
-    fn move_ptr(&self, adjustment: &fn(*c_void) -> *c_void) {
-        *self.ptr = adjustment(*self.ptr);
+    fn move_ptr(&mut self, adjustment: &fn(*c_void) -> *c_void) {
+        self.ptr = adjustment(self.ptr);
     }
-    fn push_ptr(&self) {
-        self.ptr_stk.push(*self.ptr);
+    fn push_ptr(&mut self) {
+        self.ptr_stk.push(self.ptr);
     }
-    fn pop_ptr(&self) {
-        *self.ptr = self.ptr_stk.pop();
+    fn pop_ptr(&mut self) {
+        self.ptr = self.ptr_stk.pop();
     }
 }
 
-impl ReprVisitor {
+impl<'self> ReprVisitor<'self> {
     // Various helpers for the TyVisitor impl
 
     #[inline]
-    pub fn get<T>(&self, f: &fn(&T)) -> bool {
+    pub fn get<T>(&mut self, f: &fn(&mut ReprVisitor, &T)) -> bool {
         unsafe {
-            f(transmute::<*c_void,&T>(*self.ptr));
+            f(self, transmute::<*c_void,&T>(self.ptr));
         }
         true
     }
 
     #[inline]
-    pub fn visit_inner(&self, inner: *TyDesc) -> bool {
-        self.visit_ptr_inner(*self.ptr, inner)
+    pub fn visit_inner(&mut self, inner: *TyDesc) -> bool {
+        self.visit_ptr_inner(self.ptr, inner)
     }
 
     #[inline]
-    pub fn visit_ptr_inner(&self, ptr: *c_void, inner: *TyDesc) -> bool {
+    pub fn visit_ptr_inner(&mut self, ptr: *c_void, inner: *TyDesc) -> bool {
         unsafe {
-            let u = ReprVisitor(ptr, self.writer);
-            let v = reflect::MovePtrAdaptor(u);
-            visit_tydesc(inner, &v as &TyVisitor);
+            // This should call the constructor up above, but due to limiting
+            // issues we have to recreate it here.
+            let u = ReprVisitor {
+                ptr: ptr,
+                ptr_stk: ~[],
+                var_stk: ~[],
+                writer: ::cast::transmute_copy(&self.writer),
+            };
+            let mut v = reflect::MovePtrAdaptor(u);
+            // Obviously this should not be a thing, but blame #8401 for now
+            visit_tydesc(inner, &mut v as &mut TyVisitor);
             true
         }
     }
 
     #[inline]
-    pub fn write<T:Repr>(&self) -> bool {
-        do self.get |v:&T| {
-            v.write_repr(self.writer);
+    pub fn write<T:Repr>(&mut self) -> bool {
+        do self.get |this, v:&T| {
+            v.write_repr(unsafe { ::cast::transmute_copy(&this.writer) });
         }
     }
 
-    pub fn write_escaped_slice(&self, slice: &str) {
-        self.writer.write_char('"');
+    pub fn write_escaped_slice(&mut self, slice: &str) {
+        self.writer.write(['"' as u8]);
         for ch in slice.iter() {
-            self.writer.write_escaped_char(ch);
+            self.write_escaped_char(ch);
         }
-        self.writer.write_char('"');
+        self.writer.write(['"' as u8]);
     }
 
-    pub fn write_mut_qualifier(&self, mtbl: uint) {
+    pub fn write_mut_qualifier(&mut self, mtbl: uint) {
         if mtbl == 0 {
-            self.writer.write_str("mut ");
+            self.writer.write("mut ".as_bytes());
         } else if mtbl == 1 {
             // skip, this is ast::m_imm
         } else {
             assert_eq!(mtbl, 2);
-            self.writer.write_str("const ");
+            self.writer.write("const ".as_bytes());
         }
     }
 
-    pub fn write_vec_range(&self,
+    pub fn write_vec_range(&mut self,
                            _mtbl: uint,
                            ptr: *(),
                            len: uint,
@@ -216,7 +202,7 @@ impl ReprVisitor {
                            -> bool {
         let mut p = ptr as *u8;
         let (sz, al) = unsafe { ((*inner).size, (*inner).align) };
-        self.writer.write_char('[');
+        self.writer.write(['[' as u8]);
         let mut first = true;
         let mut left = len;
         // unit structs have 0 size, and don't loop forever.
@@ -225,17 +211,17 @@ impl ReprVisitor {
             if first {
                 first = false;
             } else {
-                self.writer.write_str(", ");
+                self.writer.write(", ".as_bytes());
             }
             self.visit_ptr_inner(p as *c_void, inner);
             p = align(ptr::offset(p, sz as int) as uint, al) as *u8;
             left -= dec;
         }
-        self.writer.write_char(']');
+        self.writer.write([']' as u8]);
         true
     }
 
-    pub fn write_unboxed_vec_repr(&self,
+    pub fn write_unboxed_vec_repr(&mut self,
                                   mtbl: uint,
                                   v: &raw::Vec<()>,
                                   inner: *TyDesc)
@@ -243,239 +229,246 @@ impl ReprVisitor {
         self.write_vec_range(mtbl, ptr::to_unsafe_ptr(&v.data),
                              v.fill, inner)
     }
+
+    fn write_escaped_char(&mut self, ch: char) {
+        match ch {
+            '\t' => self.writer.write("\\t".as_bytes()),
+            '\r' => self.writer.write("\\r".as_bytes()),
+            '\n' => self.writer.write("\\n".as_bytes()),
+            '\\' => self.writer.write("\\\\".as_bytes()),
+            '\'' => self.writer.write("\\'".as_bytes()),
+            '"' => self.writer.write("\\\"".as_bytes()),
+            '\x20'..'\x7e' => self.writer.write([ch as u8]),
+            _ => {
+                do char::escape_unicode(ch) |c| {
+                    self.writer.write([c as u8]);
+                }
+            }
+        }
+    }
 }
 
-impl TyVisitor for ReprVisitor {
-    fn visit_bot(&self) -> bool {
-        self.writer.write_str("!");
+impl<'self> TyVisitor for ReprVisitor<'self> {
+    fn visit_bot(&mut self) -> bool {
+        self.writer.write("!".as_bytes());
         true
     }
-    fn visit_nil(&self) -> bool { self.write::<()>() }
-    fn visit_bool(&self) -> bool { self.write::<bool>() }
-    fn visit_int(&self) -> bool { self.write::<int>() }
-    fn visit_i8(&self) -> bool { self.write::<i8>() }
-    fn visit_i16(&self) -> bool { self.write::<i16>() }
-    fn visit_i32(&self) -> bool { self.write::<i32>()  }
-    fn visit_i64(&self) -> bool { self.write::<i64>() }
+    fn visit_nil(&mut self) -> bool { self.write::<()>() }
+    fn visit_bool(&mut self) -> bool { self.write::<bool>() }
+    fn visit_int(&mut self) -> bool { self.write::<int>() }
+    fn visit_i8(&mut self) -> bool { self.write::<i8>() }
+    fn visit_i16(&mut self) -> bool { self.write::<i16>() }
+    fn visit_i32(&mut self) -> bool { self.write::<i32>()  }
+    fn visit_i64(&mut self) -> bool { self.write::<i64>() }
 
-    fn visit_uint(&self) -> bool { self.write::<uint>() }
-    fn visit_u8(&self) -> bool { self.write::<u8>() }
-    fn visit_u16(&self) -> bool { self.write::<u16>() }
-    fn visit_u32(&self) -> bool { self.write::<u32>() }
-    fn visit_u64(&self) -> bool { self.write::<u64>() }
+    fn visit_uint(&mut self) -> bool { self.write::<uint>() }
+    fn visit_u8(&mut self) -> bool { self.write::<u8>() }
+    fn visit_u16(&mut self) -> bool { self.write::<u16>() }
+    fn visit_u32(&mut self) -> bool { self.write::<u32>() }
+    fn visit_u64(&mut self) -> bool { self.write::<u64>() }
 
-    fn visit_float(&self) -> bool { self.write::<float>() }
-    fn visit_f32(&self) -> bool { self.write::<f32>() }
-    fn visit_f64(&self) -> bool { self.write::<f64>() }
+    fn visit_float(&mut self) -> bool { self.write::<float>() }
+    fn visit_f32(&mut self) -> bool { self.write::<f32>() }
+    fn visit_f64(&mut self) -> bool { self.write::<f64>() }
 
-    fn visit_char(&self) -> bool {
-        do self.get::<char> |&ch| {
-            self.writer.write_char('\'');
-            self.writer.write_escaped_char(ch);
-            self.writer.write_char('\'');
+    fn visit_char(&mut self) -> bool {
+        do self.get::<char> |this, &ch| {
+            this.writer.write(['\'' as u8]);
+            this.write_escaped_char(ch);
+            this.writer.write(['\'' as u8]);
         }
     }
 
-    fn visit_estr_box(&self) -> bool {
-        do self.get::<@str> |s| {
-            self.writer.write_char('@');
-            self.write_escaped_slice(*s);
+    fn visit_estr_box(&mut self) -> bool {
+        do self.get::<@str> |this, s| {
+            this.writer.write(['@' as u8]);
+            this.write_escaped_slice(*s);
         }
     }
 
-    fn visit_estr_uniq(&self) -> bool {
-        do self.get::<~str> |s| {
-            self.writer.write_char('~');
-            self.write_escaped_slice(*s);
+    fn visit_estr_uniq(&mut self) -> bool {
+        do self.get::<~str> |this, s| {
+            this.writer.write(['~' as u8]);
+            this.write_escaped_slice(*s);
         }
     }
 
-    fn visit_estr_slice(&self) -> bool {
-        do self.get::<&str> |s| {
-            self.write_escaped_slice(*s);
+    fn visit_estr_slice(&mut self) -> bool {
+        do self.get::<&str> |this, s| {
+            this.write_escaped_slice(*s);
         }
     }
 
     // Type no longer exists, vestigial function.
-    fn visit_estr_fixed(&self, _n: uint, _sz: uint,
+    fn visit_estr_fixed(&mut self, _n: uint, _sz: uint,
                         _align: uint) -> bool { fail!(); }
 
-    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
-        self.writer.write_char('@');
+    fn visit_box(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+        self.writer.write(['@' as u8]);
         self.write_mut_qualifier(mtbl);
-        do self.get::<&raw::Box<()>> |b| {
+        do self.get::<&raw::Box<()>> |this, b| {
             let p = ptr::to_unsafe_ptr(&b.data) as *c_void;
-            self.visit_ptr_inner(p, inner);
+            this.visit_ptr_inner(p, inner);
         }
     }
 
-    fn visit_uniq(&self, _mtbl: uint, inner: *TyDesc) -> bool {
-        self.writer.write_char('~');
-        do self.get::<*c_void> |b| {
-            self.visit_ptr_inner(*b, inner);
+    fn visit_uniq(&mut self, _mtbl: uint, inner: *TyDesc) -> bool {
+        self.writer.write(['~' as u8]);
+        do self.get::<*c_void> |this, b| {
+            this.visit_ptr_inner(*b, inner);
         }
     }
 
-    fn visit_uniq_managed(&self, _mtbl: uint, inner: *TyDesc) -> bool {
-        self.writer.write_char('~');
-        do self.get::<&raw::Box<()>> |b| {
+    fn visit_uniq_managed(&mut self, _mtbl: uint, inner: *TyDesc) -> bool {
+        self.writer.write(['~' as u8]);
+        do self.get::<&raw::Box<()>> |this, b| {
             let p = ptr::to_unsafe_ptr(&b.data) as *c_void;
-            self.visit_ptr_inner(p, inner);
+            this.visit_ptr_inner(p, inner);
         }
     }
 
-    #[cfg(stage0)]
-    fn visit_ptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool {
-        do self.get::<*c_void> |p| {
-            self.writer.write_str(fmt!("(0x%x as *())",
-                                       *p as uint));
+    fn visit_ptr(&mut self, mtbl: uint, _inner: *TyDesc) -> bool {
+        do self.get::<*c_void> |this, p| {
+            write!(this.writer, "({} as *", *p);
+            this.write_mut_qualifier(mtbl);
+            this.writer.write("())".as_bytes());
         }
     }
 
-    #[cfg(not(stage0))]
-    fn visit_ptr(&self, mtbl: uint, _inner: *TyDesc) -> bool {
-        do self.get::<*c_void> |p| {
-            self.writer.write_str(fmt!("(0x%x as *", *p as uint));
-            self.write_mut_qualifier(mtbl);
-            self.writer.write_str("())");
-        }
-    }
-
-    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
-        self.writer.write_char('&');
+    fn visit_rptr(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+        self.writer.write(['&' as u8]);
         self.write_mut_qualifier(mtbl);
-        do self.get::<*c_void> |p| {
-            self.visit_ptr_inner(*p, inner);
+        do self.get::<*c_void> |this, p| {
+            this.visit_ptr_inner(*p, inner);
         }
     }
 
     // Type no longer exists, vestigial function.
-    fn visit_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { fail!(); }
+    fn visit_vec(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { fail!(); }
 
 
-    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
-        do self.get::<raw::Vec<()>> |b| {
-            self.write_unboxed_vec_repr(mtbl, b, inner);
+    fn visit_unboxed_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<raw::Vec<()>> |this, b| {
+            this.write_unboxed_vec_repr(mtbl, b, inner);
         }
     }
 
-    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
-        do self.get::<&raw::Box<raw::Vec<()>>> |b| {
-            self.writer.write_char('@');
-            self.write_mut_qualifier(mtbl);
-            self.write_unboxed_vec_repr(mtbl, &b.data, inner);
+    fn visit_evec_box(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<&raw::Box<raw::Vec<()>>> |this, b| {
+            this.writer.write(['@' as u8]);
+            this.write_mut_qualifier(mtbl);
+            this.write_unboxed_vec_repr(mtbl, &b.data, inner);
         }
     }
 
-    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
-        do self.get::<&raw::Vec<()>> |b| {
-            self.writer.write_char('~');
-            self.write_unboxed_vec_repr(mtbl, *b, inner);
+    fn visit_evec_uniq(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<&raw::Vec<()>> |this, b| {
+            this.writer.write(['~' as u8]);
+            this.write_unboxed_vec_repr(mtbl, *b, inner);
         }
     }
 
-    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
-        do self.get::<&raw::Box<raw::Vec<()>>> |b| {
-            self.writer.write_char('~');
-            self.write_unboxed_vec_repr(mtbl, &b.data, inner);
+    fn visit_evec_uniq_managed(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<&raw::Box<raw::Vec<()>>> |this, b| {
+            this.writer.write(['~' as u8]);
+            this.write_unboxed_vec_repr(mtbl, &b.data, inner);
         }
     }
 
-    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
-        do self.get::<raw::Slice<()>> |s| {
-            self.writer.write_char('&');
-            self.write_vec_range(mtbl, s.data, s.len, inner);
+    fn visit_evec_slice(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<raw::Slice<()>> |this, s| {
+            this.writer.write(['&' as u8]);
+            this.write_vec_range(mtbl, s.data, s.len, inner);
         }
     }
 
-    fn visit_evec_fixed(&self, _n: uint, sz: uint, _align: uint,
+    fn visit_evec_fixed(&mut self, _n: uint, sz: uint, _align: uint,
                         mtbl: uint, inner: *TyDesc) -> bool {
-        do self.get::<()> |b| {
-            self.write_vec_range(mtbl, ptr::to_unsafe_ptr(b), sz, inner);
+        do self.get::<()> |this, b| {
+            this.write_vec_range(mtbl, ptr::to_unsafe_ptr(b), sz, inner);
         }
     }
 
-    fn visit_enter_rec(&self, _n_fields: uint,
+    fn visit_enter_rec(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool {
-        self.writer.write_char('{');
+        self.writer.write(['{' as u8]);
         true
     }
 
-    fn visit_rec_field(&self, i: uint, name: &str,
+    fn visit_rec_field(&mut self, i: uint, name: &str,
                        mtbl: uint, inner: *TyDesc) -> bool {
         if i != 0 {
-            self.writer.write_str(", ");
+            self.writer.write(", ".as_bytes());
         }
         self.write_mut_qualifier(mtbl);
-        self.writer.write_str(name);
-        self.writer.write_str(": ");
+        self.writer.write(name.as_bytes());
+        self.writer.write(": ".as_bytes());
         self.visit_inner(inner);
         true
     }
 
-    fn visit_leave_rec(&self, _n_fields: uint,
+    fn visit_leave_rec(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool {
-        self.writer.write_char('}');
+        self.writer.write(['}' as u8]);
         true
     }
 
-    fn visit_enter_class(&self, _n_fields: uint,
+    fn visit_enter_class(&mut self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool {
-        self.writer.write_char('{');
+        self.writer.write(['{' as u8]);
         true
     }
-    fn visit_class_field(&self, i: uint, name: &str,
+    fn visit_class_field(&mut self, i: uint, name: &str,
                          mtbl: uint, inner: *TyDesc) -> bool {
         if i != 0 {
-            self.writer.write_str(", ");
+            self.writer.write(", ".as_bytes());
         }
         self.write_mut_qualifier(mtbl);
-        self.writer.write_str(name);
-        self.writer.write_str(": ");
+        self.writer.write(name.as_bytes());
+        self.writer.write(": ".as_bytes());
         self.visit_inner(inner);
         true
     }
-    fn visit_leave_class(&self, _n_fields: uint,
+    fn visit_leave_class(&mut self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool {
-        self.writer.write_char('}');
+        self.writer.write(['}' as u8]);
         true
     }
 
-    fn visit_enter_tup(&self, _n_fields: uint,
+    fn visit_enter_tup(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool {
-        self.writer.write_char('(');
+        self.writer.write(['(' as u8]);
         true
     }
-    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool {
+    fn visit_tup_field(&mut self, i: uint, inner: *TyDesc) -> bool {
         if i != 0 {
-            self.writer.write_str(", ");
+            self.writer.write(", ".as_bytes());
         }
         self.visit_inner(inner);
         true
     }
-    fn visit_leave_tup(&self, _n_fields: uint,
+    fn visit_leave_tup(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool {
         if _n_fields == 1 {
-            self.writer.write_char(',');
+            self.writer.write([',' as u8]);
         }
-        self.writer.write_char(')');
+        self.writer.write([')' as u8]);
         true
     }
 
-    fn visit_enter_enum(&self,
+    fn visit_enter_enum(&mut self,
                         _n_variants: uint,
                         get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         _sz: uint,
                         _align: uint) -> bool {
-        let var_stk: &mut ~[VariantState] = self.var_stk;
         let disr = unsafe {
-            get_disr(transmute(*self.ptr))
+            get_disr(transmute(self.ptr))
         };
-        var_stk.push(SearchingFor(disr));
+        self.var_stk.push(SearchingFor(disr));
         true
     }
 
-    fn visit_enter_enum_variant(&self, _variant: uint,
+    fn visit_enter_enum_variant(&mut self, _variant: uint,
                                 disr_val: int,
                                 n_fields: uint,
                                 name: &str) -> bool {
@@ -495,15 +488,15 @@ impl TyVisitor for ReprVisitor {
         }
 
         if write {
-            self.writer.write_str(name);
+            self.writer.write(name.as_bytes());
             if n_fields > 0 {
-                self.writer.write_char('(');
+                self.writer.write(['(' as u8]);
             }
         }
         true
     }
 
-    fn visit_enum_variant_field(&self,
+    fn visit_enum_variant_field(&mut self,
                                 i: uint,
                                 _offset: uint,
                                 inner: *TyDesc)
@@ -511,7 +504,7 @@ impl TyVisitor for ReprVisitor {
         match self.var_stk[self.var_stk.len() - 1] {
             Matched => {
                 if i != 0 {
-                    self.writer.write_str(", ");
+                    self.writer.write(", ".as_bytes());
                 }
                 if ! self.visit_inner(inner) {
                     return false;
@@ -522,14 +515,14 @@ impl TyVisitor for ReprVisitor {
         true
     }
 
-    fn visit_leave_enum_variant(&self, _variant: uint,
+    fn visit_leave_enum_variant(&mut self, _variant: uint,
                                 _disr_val: int,
                                 n_fields: uint,
                                 _name: &str) -> bool {
         match self.var_stk[self.var_stk.len() - 1] {
             Matched => {
                 if n_fields > 0 {
-                    self.writer.write_char(')');
+                    self.writer.write([')' as u8]);
                 }
             }
             _ => ()
@@ -537,54 +530,53 @@ impl TyVisitor for ReprVisitor {
         true
     }
 
-    fn visit_leave_enum(&self,
+    fn visit_leave_enum(&mut self,
                         _n_variants: uint,
                         _get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         _sz: uint,
                         _align: uint)
                         -> bool {
-        let var_stk: &mut ~[VariantState] = self.var_stk;
-        match var_stk.pop() {
+        match self.var_stk.pop() {
             SearchingFor(*) => fail!("enum value matched no variant"),
             _ => true
         }
     }
 
-    fn visit_enter_fn(&self, _purity: uint, _proto: uint,
+    fn visit_enter_fn(&mut self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
-    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool {
+    fn visit_fn_input(&mut self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool {
         true
     }
-    fn visit_fn_output(&self, _retstyle: uint, _inner: *TyDesc) -> bool {
+    fn visit_fn_output(&mut self, _retstyle: uint, _inner: *TyDesc) -> bool {
         true
     }
-    fn visit_leave_fn(&self, _purity: uint, _proto: uint,
+    fn visit_leave_fn(&mut self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
 
 
-    fn visit_trait(&self) -> bool { true }
-    fn visit_param(&self, _i: uint) -> bool { true }
-    fn visit_self(&self) -> bool { true }
-    fn visit_type(&self) -> bool { true }
+    fn visit_trait(&mut self) -> bool { true }
+    fn visit_param(&mut self, _i: uint) -> bool { true }
+    fn visit_self(&mut self) -> bool { true }
+    fn visit_type(&mut self) -> bool { true }
 
-    fn visit_opaque_box(&self) -> bool {
-        self.writer.write_char('@');
-        do self.get::<&raw::Box<()>> |b| {
+    fn visit_opaque_box(&mut self) -> bool {
+        self.writer.write(['@' as u8]);
+        do self.get::<&raw::Box<()>> |this, b| {
             let p = ptr::to_unsafe_ptr(&b.data) as *c_void;
-            self.visit_ptr_inner(p, b.type_desc);
+            this.visit_ptr_inner(p, b.type_desc);
         }
     }
 
-    fn visit_closure_ptr(&self, _ck: uint) -> bool { true }
+    fn visit_closure_ptr(&mut self, _ck: uint) -> bool { true }
 }
 
-pub fn write_repr<T>(writer: @Writer, object: &T) {
+pub fn write_repr<T>(writer: &mut io::Writer, object: &T) {
     unsafe {
         let ptr = ptr::to_unsafe_ptr(object) as *c_void;
         let tydesc = get_tydesc::<T>();
         let u = ReprVisitor(ptr, writer);
-        let v = reflect::MovePtrAdaptor(u);
-        visit_tydesc(tydesc, &v as &TyVisitor)
+        let mut v = reflect::MovePtrAdaptor(u);
+        visit_tydesc(tydesc, &mut v as &mut TyVisitor);
     }
 }
 
@@ -593,14 +585,15 @@ struct P {a: int, b: float}
 
 #[test]
 fn test_repr() {
+    use str;
+    use str::Str;
+    use rt::io::Decorator;
 
     fn exact_test<T>(t: &T, e:&str) {
-        let s : &str = io::with_str_writer(|w| write_repr(w, t));
-        if s != e {
-            error!("expected '%s', got '%s'",
-                   e, s);
-        }
-        assert_eq!(s, e);
+        let mut m = io::mem::MemWriter::new();
+        write_repr(&mut m as &mut io::Writer, t);
+        let s = str::from_bytes_owned(m.inner());
+        assert_eq!(s.as_slice(), e);
     }
 
     exact_test(&10, "10");

--- a/src/libstd/repr_stage0.rs
+++ b/src/libstd/repr_stage0.rs
@@ -1,0 +1,626 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/*!
+
+More runtime type reflection
+
+*/
+
+#[allow(missing_doc)];
+
+use cast::transmute;
+use char;
+use container::Container;
+use io::{Writer, WriterUtil};
+use iterator::Iterator;
+use libc::c_void;
+use option::{Some, None};
+use ptr;
+use reflect;
+use reflect::{MovePtr, align};
+use str::StrSlice;
+use to_str::ToStr;
+use vec::OwnedVector;
+use unstable::intrinsics::{Opaque, TyDesc, TyVisitor, get_tydesc, visit_tydesc};
+use unstable::raw;
+
+#[cfg(test)] use io;
+
+/// Helpers
+
+trait EscapedCharWriter {
+    fn write_escaped_char(&self, ch: char);
+}
+
+impl EscapedCharWriter for @Writer {
+    fn write_escaped_char(&self, ch: char) {
+        match ch {
+            '\t' => self.write_str("\\t"),
+            '\r' => self.write_str("\\r"),
+            '\n' => self.write_str("\\n"),
+            '\\' => self.write_str("\\\\"),
+            '\'' => self.write_str("\\'"),
+            '"' => self.write_str("\\\""),
+            '\x20'..'\x7e' => self.write_char(ch),
+            _ => {
+                do char::escape_unicode(ch) |c| {
+                    self.write_char(c);
+                }
+            }
+        }
+    }
+}
+
+/// Representations
+
+trait Repr {
+    fn write_repr(&self, writer: @Writer);
+}
+
+impl Repr for () {
+    fn write_repr(&self, writer: @Writer) { writer.write_str("()"); }
+}
+
+impl Repr for bool {
+    fn write_repr(&self, writer: @Writer) {
+        writer.write_str(if *self { "true" } else { "false" })
+    }
+}
+
+macro_rules! int_repr(($ty:ident) => (impl Repr for $ty {
+    fn write_repr(&self, writer: @Writer) {
+        do ::$ty::to_str_bytes(*self, 10u) |bits| {
+            writer.write(bits);
+        }
+    }
+}))
+
+int_repr!(int)
+int_repr!(i8)
+int_repr!(i16)
+int_repr!(i32)
+int_repr!(i64)
+int_repr!(uint)
+int_repr!(u8)
+int_repr!(u16)
+int_repr!(u32)
+int_repr!(u64)
+
+macro_rules! num_repr(($ty:ident) => (impl Repr for $ty {
+    fn write_repr(&self, writer: @Writer) {
+        let s = self.to_str();
+        writer.write(s.as_bytes());
+    }
+}))
+
+num_repr!(float)
+num_repr!(f32)
+num_repr!(f64)
+
+// New implementation using reflect::MovePtr
+
+enum VariantState {
+    SearchingFor(int),
+    Matched,
+    AlreadyFound
+}
+
+pub struct ReprVisitor {
+    ptr: @mut *c_void,
+    ptr_stk: @mut ~[*c_void],
+    var_stk: @mut ~[VariantState],
+    writer: @Writer
+}
+pub fn ReprVisitor(ptr: *c_void, writer: @Writer) -> ReprVisitor {
+    ReprVisitor {
+        ptr: @mut ptr,
+        ptr_stk: @mut ~[],
+        var_stk: @mut ~[],
+        writer: writer,
+    }
+}
+
+impl MovePtr for ReprVisitor {
+    #[inline]
+    fn move_ptr(&self, adjustment: &fn(*c_void) -> *c_void) {
+        *self.ptr = adjustment(*self.ptr);
+    }
+    fn push_ptr(&self) {
+        self.ptr_stk.push(*self.ptr);
+    }
+    fn pop_ptr(&self) {
+        *self.ptr = self.ptr_stk.pop();
+    }
+}
+
+impl ReprVisitor {
+    // Various helpers for the TyVisitor impl
+
+    #[inline]
+    pub fn get<T>(&self, f: &fn(&T)) -> bool {
+        unsafe {
+            f(transmute::<*c_void,&T>(*self.ptr));
+        }
+        true
+    }
+
+    #[inline]
+    pub fn visit_inner(&self, inner: *TyDesc) -> bool {
+        self.visit_ptr_inner(*self.ptr, inner)
+    }
+
+    #[inline]
+    pub fn visit_ptr_inner(&self, ptr: *c_void, inner: *TyDesc) -> bool {
+        unsafe {
+            let u = ReprVisitor(ptr, self.writer);
+            let v = reflect::MovePtrAdaptor(u);
+            visit_tydesc(inner, @v as @TyVisitor);
+            true
+        }
+    }
+
+    #[inline]
+    pub fn write<T:Repr>(&self) -> bool {
+        do self.get |v:&T| {
+            v.write_repr(self.writer);
+        }
+    }
+
+    pub fn write_escaped_slice(&self, slice: &str) {
+        self.writer.write_char('"');
+        for ch in slice.iter() {
+            self.writer.write_escaped_char(ch);
+        }
+        self.writer.write_char('"');
+    }
+
+    pub fn write_mut_qualifier(&self, mtbl: uint) {
+        if mtbl == 0 {
+            self.writer.write_str("mut ");
+        } else if mtbl == 1 {
+            // skip, this is ast::m_imm
+        } else {
+            assert_eq!(mtbl, 2);
+            self.writer.write_str("const ");
+        }
+    }
+
+    pub fn write_vec_range(&self,
+                           _mtbl: uint,
+                           ptr: *(),
+                           len: uint,
+                           inner: *TyDesc)
+                           -> bool {
+        let mut p = ptr as *u8;
+        let (sz, al) = unsafe { ((*inner).size, (*inner).align) };
+        self.writer.write_char('[');
+        let mut first = true;
+        let mut left = len;
+        // unit structs have 0 size, and don't loop forever.
+        let dec = if sz == 0 {1} else {sz};
+        while left > 0 {
+            if first {
+                first = false;
+            } else {
+                self.writer.write_str(", ");
+            }
+            self.visit_ptr_inner(p as *c_void, inner);
+            unsafe {
+                p = align(ptr::offset(p, sz as int) as uint, al) as *u8;
+            }
+            left -= dec;
+        }
+        self.writer.write_char(']');
+        true
+    }
+
+    pub fn write_unboxed_vec_repr(&self,
+                                  mtbl: uint,
+                                  v: &raw::Vec<()>,
+                                  inner: *TyDesc)
+                                  -> bool {
+        self.write_vec_range(mtbl, ptr::to_unsafe_ptr(&v.data),
+                             v.fill, inner)
+    }
+}
+
+impl TyVisitor for ReprVisitor {
+    fn visit_bot(&self) -> bool {
+        self.writer.write_str("!");
+        true
+    }
+    fn visit_nil(&self) -> bool { self.write::<()>() }
+    fn visit_bool(&self) -> bool { self.write::<bool>() }
+    fn visit_int(&self) -> bool { self.write::<int>() }
+    fn visit_i8(&self) -> bool { self.write::<i8>() }
+    fn visit_i16(&self) -> bool { self.write::<i16>() }
+    fn visit_i32(&self) -> bool { self.write::<i32>()  }
+    fn visit_i64(&self) -> bool { self.write::<i64>() }
+
+    fn visit_uint(&self) -> bool { self.write::<uint>() }
+    fn visit_u8(&self) -> bool { self.write::<u8>() }
+    fn visit_u16(&self) -> bool { self.write::<u16>() }
+    fn visit_u32(&self) -> bool { self.write::<u32>() }
+    fn visit_u64(&self) -> bool { self.write::<u64>() }
+
+    fn visit_float(&self) -> bool { self.write::<float>() }
+    fn visit_f32(&self) -> bool { self.write::<f32>() }
+    fn visit_f64(&self) -> bool { self.write::<f64>() }
+
+    fn visit_char(&self) -> bool {
+        do self.get::<char> |&ch| {
+            self.writer.write_char('\'');
+            self.writer.write_escaped_char(ch);
+            self.writer.write_char('\'');
+        }
+    }
+
+    fn visit_estr_box(&self) -> bool {
+        do self.get::<@str> |s| {
+            self.writer.write_char('@');
+            self.write_escaped_slice(*s);
+        }
+    }
+    fn visit_estr_uniq(&self) -> bool {
+        do self.get::<~str> |s| {
+            self.writer.write_char('~');
+            self.write_escaped_slice(*s);
+        }
+    }
+    fn visit_estr_slice(&self) -> bool {
+        do self.get::<&str> |s| {
+            self.write_escaped_slice(*s);
+        }
+    }
+
+    // Type no longer exists, vestigial function.
+    fn visit_estr_fixed(&self, _n: uint, _sz: uint,
+                        _align: uint) -> bool { fail!(); }
+
+    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
+        self.writer.write_char('@');
+        self.write_mut_qualifier(mtbl);
+        do self.get::<&raw::Box<()>> |b| {
+            let p = ptr::to_unsafe_ptr(&b.data) as *c_void;
+            self.visit_ptr_inner(p, inner);
+        }
+    }
+
+    fn visit_uniq(&self, _mtbl: uint, inner: *TyDesc) -> bool {
+        self.writer.write_char('~');
+        do self.get::<*c_void> |b| {
+            self.visit_ptr_inner(*b, inner);
+        }
+    }
+
+    fn visit_uniq_managed(&self, _mtbl: uint, inner: *TyDesc) -> bool {
+        self.writer.write_char('~');
+        do self.get::<&raw::Box<()>> |b| {
+            let p = ptr::to_unsafe_ptr(&b.data) as *c_void;
+            self.visit_ptr_inner(p, inner);
+        }
+    }
+
+    fn visit_ptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool {
+        do self.get::<*c_void> |p| {
+            self.writer.write_str(fmt!("(0x%x as *())",
+                                       *p as uint));
+        }
+    }
+
+    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
+        self.writer.write_char('&');
+        self.write_mut_qualifier(mtbl);
+        do self.get::<*c_void> |p| {
+            self.visit_ptr_inner(*p, inner);
+        }
+    }
+
+    // Type no longer exists, vestigial function.
+    fn visit_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { fail!(); }
+
+
+    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<raw::Vec<()>> |b| {
+            self.write_unboxed_vec_repr(mtbl, b, inner);
+        }
+    }
+
+    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<&raw::Box<raw::Vec<()>>> |b| {
+            self.writer.write_char('@');
+            self.write_mut_qualifier(mtbl);
+            self.write_unboxed_vec_repr(mtbl, &b.data, inner);
+        }
+    }
+
+    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<&raw::Vec<()>> |b| {
+            self.writer.write_char('~');
+            self.write_unboxed_vec_repr(mtbl, *b, inner);
+        }
+    }
+
+    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<&raw::Box<raw::Vec<()>>> |b| {
+            self.writer.write_char('~');
+            self.write_unboxed_vec_repr(mtbl, &b.data, inner);
+        }
+    }
+
+    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<raw::Slice<()>> |s| {
+            self.writer.write_char('&');
+            self.write_vec_range(mtbl, s.data, s.len, inner);
+        }
+    }
+
+    fn visit_evec_fixed(&self, _n: uint, sz: uint, _align: uint,
+                        mtbl: uint, inner: *TyDesc) -> bool {
+        do self.get::<()> |b| {
+            self.write_vec_range(mtbl, ptr::to_unsafe_ptr(b), sz, inner);
+        }
+    }
+
+    fn visit_enter_rec(&self, _n_fields: uint,
+                       _sz: uint, _align: uint) -> bool {
+        self.writer.write_char('{');
+        true
+    }
+
+    fn visit_rec_field(&self, i: uint, name: &str,
+                       mtbl: uint, inner: *TyDesc) -> bool {
+        if i != 0 {
+            self.writer.write_str(", ");
+        }
+        self.write_mut_qualifier(mtbl);
+        self.writer.write_str(name);
+        self.writer.write_str(": ");
+        self.visit_inner(inner);
+        true
+    }
+
+    fn visit_leave_rec(&self, _n_fields: uint,
+                       _sz: uint, _align: uint) -> bool {
+        self.writer.write_char('}');
+        true
+    }
+
+    fn visit_enter_class(&self, _n_fields: uint,
+                         _sz: uint, _align: uint) -> bool {
+        self.writer.write_char('{');
+        true
+    }
+    fn visit_class_field(&self, i: uint, name: &str,
+                         mtbl: uint, inner: *TyDesc) -> bool {
+        if i != 0 {
+            self.writer.write_str(", ");
+        }
+        self.write_mut_qualifier(mtbl);
+        self.writer.write_str(name);
+        self.writer.write_str(": ");
+        self.visit_inner(inner);
+        true
+    }
+    fn visit_leave_class(&self, _n_fields: uint,
+                         _sz: uint, _align: uint) -> bool {
+        self.writer.write_char('}');
+        true
+    }
+
+    fn visit_enter_tup(&self, _n_fields: uint,
+                       _sz: uint, _align: uint) -> bool {
+        self.writer.write_char('(');
+        true
+    }
+    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool {
+        if i != 0 {
+            self.writer.write_str(", ");
+        }
+        self.visit_inner(inner);
+        true
+    }
+    fn visit_leave_tup(&self, _n_fields: uint,
+                       _sz: uint, _align: uint) -> bool {
+        if _n_fields == 1 {
+            self.writer.write_char(',');
+        }
+        self.writer.write_char(')');
+        true
+    }
+
+    fn visit_enter_enum(&self,
+                        _n_variants: uint,
+                        get_disr: extern unsafe fn(ptr: *Opaque) -> int,
+                        _sz: uint,
+                        _align: uint) -> bool {
+        let var_stk: &mut ~[VariantState] = self.var_stk;
+        let disr = unsafe {
+            get_disr(transmute(*self.ptr))
+        };
+        var_stk.push(SearchingFor(disr));
+        true
+    }
+
+    fn visit_enter_enum_variant(&self, _variant: uint,
+                                disr_val: int,
+                                n_fields: uint,
+                                name: &str) -> bool {
+        let mut write = false;
+        match self.var_stk.pop() {
+            SearchingFor(sought) => {
+                if disr_val == sought {
+                    self.var_stk.push(Matched);
+                    write = true;
+                } else {
+                    self.var_stk.push(SearchingFor(sought));
+                }
+            }
+            Matched | AlreadyFound => {
+                self.var_stk.push(AlreadyFound);
+            }
+        }
+
+        if write {
+            self.writer.write_str(name);
+            if n_fields > 0 {
+                self.writer.write_char('(');
+            }
+        }
+        true
+    }
+
+    fn visit_enum_variant_field(&self,
+                                i: uint,
+                                _offset: uint,
+                                inner: *TyDesc)
+                                -> bool {
+        match self.var_stk[self.var_stk.len() - 1] {
+            Matched => {
+                if i != 0 {
+                    self.writer.write_str(", ");
+                }
+                if ! self.visit_inner(inner) {
+                    return false;
+                }
+            }
+            _ => ()
+        }
+        true
+    }
+
+    fn visit_leave_enum_variant(&self, _variant: uint,
+                                _disr_val: int,
+                                n_fields: uint,
+                                _name: &str) -> bool {
+        match self.var_stk[self.var_stk.len() - 1] {
+            Matched => {
+                if n_fields > 0 {
+                    self.writer.write_char(')');
+                }
+            }
+            _ => ()
+        }
+        true
+    }
+
+    fn visit_leave_enum(&self,
+                        _n_variants: uint,
+                        _get_disr: extern unsafe fn(ptr: *Opaque) -> int,
+                        _sz: uint,
+                        _align: uint)
+                        -> bool {
+        let var_stk: &mut ~[VariantState] = self.var_stk;
+        match var_stk.pop() {
+            SearchingFor(*) => fail!("enum value matched no variant"),
+            _ => true
+        }
+    }
+
+    fn visit_enter_fn(&self, _purity: uint, _proto: uint,
+                      _n_inputs: uint, _retstyle: uint) -> bool { true }
+    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool {
+        true
+    }
+    fn visit_fn_output(&self, _retstyle: uint, _inner: *TyDesc) -> bool {
+        true
+    }
+    fn visit_leave_fn(&self, _purity: uint, _proto: uint,
+                      _n_inputs: uint, _retstyle: uint) -> bool { true }
+
+
+    fn visit_trait(&self) -> bool { true }
+    fn visit_param(&self, _i: uint) -> bool { true }
+    fn visit_self(&self) -> bool { true }
+    fn visit_type(&self) -> bool { true }
+
+    fn visit_opaque_box(&self) -> bool {
+        self.writer.write_char('@');
+        do self.get::<&raw::Box<()>> |b| {
+            let p = ptr::to_unsafe_ptr(&b.data) as *c_void;
+            self.visit_ptr_inner(p, b.type_desc);
+        }
+    }
+
+    fn visit_closure_ptr(&self, _ck: uint) -> bool { true }
+}
+
+pub fn write_repr<T>(writer: @Writer, object: &T) {
+    unsafe {
+        let ptr = ptr::to_unsafe_ptr(object) as *c_void;
+        let tydesc = get_tydesc::<T>();
+        let u = ReprVisitor(ptr, writer);
+        let v = reflect::MovePtrAdaptor(u);
+        visit_tydesc(tydesc, @v as @TyVisitor)
+    }
+}
+
+#[cfg(test)]
+struct P {a: int, b: float}
+
+#[test]
+fn test_repr() {
+
+    fn exact_test<T>(t: &T, e:&str) {
+        let s : &str = io::with_str_writer(|w| write_repr(w, t));
+        if s != e {
+            error!("expected '%s', got '%s'",
+                   e, s);
+        }
+        assert_eq!(s, e);
+    }
+
+    exact_test(&10, "10");
+    exact_test(&true, "true");
+    exact_test(&false, "false");
+    exact_test(&1.234, "1.234");
+    exact_test(&(&"hello"), "\"hello\"");
+    exact_test(&(@"hello"), "@\"hello\"");
+    exact_test(&(~"he\u10f3llo"), "~\"he\\u10f3llo\"");
+
+    exact_test(&(@10), "@10");
+    exact_test(&(@mut 10), "@10"); // FIXME: #4210: incorrect
+    exact_test(&((@mut 10, 2)), "(@mut 10, 2)");
+    exact_test(&(~10), "~10");
+    exact_test(&(&10), "&10");
+    let mut x = 10;
+    exact_test(&(&mut x), "&mut 10");
+    exact_test(&(@mut [1, 2]), "@mut [1, 2]");
+
+    exact_test(&(1,), "(1,)");
+    exact_test(&(@[1,2,3,4,5,6,7,8]),
+               "@[1, 2, 3, 4, 5, 6, 7, 8]");
+    exact_test(&(@[1u8,2u8,3u8,4u8]),
+               "@[1, 2, 3, 4]");
+    exact_test(&(@["hi", "there"]),
+               "@[\"hi\", \"there\"]");
+    exact_test(&(~["hi", "there"]),
+               "~[\"hi\", \"there\"]");
+    exact_test(&(&["hi", "there"]),
+               "&[\"hi\", \"there\"]");
+    exact_test(&(P{a:10, b:1.234}),
+               "{a: 10, b: 1.234}");
+    exact_test(&(@P{a:10, b:1.234}),
+               "@{a: 10, b: 1.234}");
+    exact_test(&(~P{a:10, b:1.234}),
+               "~{a: 10, b: 1.234}");
+    exact_test(&(10_u8, ~"hello"),
+               "(10, ~\"hello\")");
+    exact_test(&(10_u16, ~"hello"),
+               "(10, ~\"hello\")");
+    exact_test(&(10_u32, ~"hello"),
+               "(10, ~\"hello\")");
+    exact_test(&(10_u64, ~"hello"),
+               "(10, ~\"hello\")");
+
+    struct Foo;
+    exact_test(&(~[Foo, Foo, Foo]), "~[{}, {}, {}]");
+}

--- a/src/libstd/std.rs
+++ b/src/libstd/std.rs
@@ -179,8 +179,14 @@ pub mod run;
 pub mod sys;
 pub mod cast;
 pub mod fmt;
+#[cfg(stage0)] #[path = "repr_stage0.rs"]
+pub mod repr;
+#[cfg(not(stage0))]
 pub mod repr;
 pub mod cleanup;
+#[cfg(stage0)] #[path = "reflect_stage0.rs"]
+pub mod reflect;
+#[cfg(not(stage0))]
 pub mod reflect;
 pub mod condition;
 pub mod logging;

--- a/src/libstd/sys.rs
+++ b/src/libstd/sys.rs
@@ -14,6 +14,7 @@
 
 use c_str::ToCStr;
 use cast;
+#[cfg(stage0)]
 use io;
 use libc;
 use libc::{c_char, size_t};
@@ -91,9 +92,19 @@ pub fn refcount<T>(t: @T) -> uint {
     }
 }
 
+#[cfg(not(stage0))]
 pub fn log_str<T>(t: &T) -> ~str {
-    do io::with_str_writer |wr| {
-        repr::write_repr(wr, t)
+    use rt::io;
+    use rt::io::Decorator;
+
+    let mut result = io::mem::MemWriter::new();
+    repr::write_repr(&mut result as &mut io::Writer, t);
+    str::from_bytes_owned(result.inner())
+}
+#[cfg(stage0)]
+pub fn log_str<T>(t: &T) -> ~str {
+    do io::with_str_writer |w| {
+        repr::write_repr(w, t)
     }
 }
 

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -73,7 +73,7 @@ pub struct TyDesc {
 pub enum Opaque { }
 
 #[lang="ty_visitor"]
-#[cfg(not(test))]
+#[cfg(not(test), stage0)]
 pub trait TyVisitor {
     fn visit_bot(&self) -> bool;
     fn visit_nil(&self) -> bool;
@@ -166,6 +166,102 @@ pub trait TyVisitor {
     fn visit_type(&self) -> bool;
     fn visit_opaque_box(&self) -> bool;
     fn visit_closure_ptr(&self, ck: uint) -> bool;
+}
+
+#[lang="ty_visitor"]
+#[cfg(not(test), not(stage0))]
+pub trait TyVisitor {
+    fn visit_bot(&mut self) -> bool;
+    fn visit_nil(&mut self) -> bool;
+    fn visit_bool(&mut self) -> bool;
+
+    fn visit_int(&mut self) -> bool;
+    fn visit_i8(&mut self) -> bool;
+    fn visit_i16(&mut self) -> bool;
+    fn visit_i32(&mut self) -> bool;
+    fn visit_i64(&mut self) -> bool;
+
+    fn visit_uint(&mut self) -> bool;
+    fn visit_u8(&mut self) -> bool;
+    fn visit_u16(&mut self) -> bool;
+    fn visit_u32(&mut self) -> bool;
+    fn visit_u64(&mut self) -> bool;
+
+    fn visit_float(&mut self) -> bool;
+    fn visit_f32(&mut self) -> bool;
+    fn visit_f64(&mut self) -> bool;
+
+    fn visit_char(&mut self) -> bool;
+
+    fn visit_estr_box(&mut self) -> bool;
+    fn visit_estr_uniq(&mut self) -> bool;
+    fn visit_estr_slice(&mut self) -> bool;
+    fn visit_estr_fixed(&mut self, n: uint, sz: uint, align: uint) -> bool;
+
+    fn visit_box(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_uniq(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_uniq_managed(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_ptr(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_rptr(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+
+    fn visit_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_unboxed_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_evec_box(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_evec_uniq(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_evec_uniq_managed(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_evec_slice(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_evec_fixed(&mut self, n: uint, sz: uint, align: uint,
+                        mtbl: uint, inner: *TyDesc) -> bool;
+
+    fn visit_enter_rec(&mut self, n_fields: uint,
+                       sz: uint, align: uint) -> bool;
+    fn visit_rec_field(&mut self, i: uint, name: &str,
+                       mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_leave_rec(&mut self, n_fields: uint,
+                       sz: uint, align: uint) -> bool;
+
+    fn visit_enter_class(&mut self, n_fields: uint,
+                         sz: uint, align: uint) -> bool;
+    fn visit_class_field(&mut self, i: uint, name: &str,
+                         mtbl: uint, inner: *TyDesc) -> bool;
+    fn visit_leave_class(&mut self, n_fields: uint,
+                         sz: uint, align: uint) -> bool;
+
+    fn visit_enter_tup(&mut self, n_fields: uint,
+                       sz: uint, align: uint) -> bool;
+    fn visit_tup_field(&mut self, i: uint, inner: *TyDesc) -> bool;
+    fn visit_leave_tup(&mut self, n_fields: uint,
+                       sz: uint, align: uint) -> bool;
+
+    fn visit_enter_enum(&mut self, n_variants: uint,
+                        get_disr: extern unsafe fn(ptr: *Opaque) -> int,
+                        sz: uint, align: uint) -> bool;
+    fn visit_enter_enum_variant(&mut self, variant: uint,
+                                disr_val: int,
+                                n_fields: uint,
+                                name: &str) -> bool;
+    fn visit_enum_variant_field(&mut self, i: uint, offset: uint, inner: *TyDesc) -> bool;
+    fn visit_leave_enum_variant(&mut self, variant: uint,
+                                disr_val: int,
+                                n_fields: uint,
+                                name: &str) -> bool;
+    fn visit_leave_enum(&mut self, n_variants: uint,
+                        get_disr: extern unsafe fn(ptr: *Opaque) -> int,
+                        sz: uint, align: uint) -> bool;
+
+    fn visit_enter_fn(&mut self, purity: uint, proto: uint,
+                      n_inputs: uint, retstyle: uint) -> bool;
+    fn visit_fn_input(&mut self, i: uint, mode: uint, inner: *TyDesc) -> bool;
+    fn visit_fn_output(&mut self, retstyle: uint, inner: *TyDesc) -> bool;
+    fn visit_leave_fn(&mut self, purity: uint, proto: uint,
+                      n_inputs: uint, retstyle: uint) -> bool;
+
+    fn visit_trait(&mut self) -> bool;
+    fn visit_param(&mut self, i: uint) -> bool;
+    fn visit_self(&mut self) -> bool;
+    fn visit_type(&mut self) -> bool;
+    fn visit_opaque_box(&mut self) -> bool;
+    fn visit_closure_ptr(&mut self, ck: uint) -> bool;
 }
 
 #[abi = "rust-intrinsic"]
@@ -325,7 +421,10 @@ extern "rust-intrinsic" {
     /// Returns `true` if a type is managed (will be allocated on the local heap)
     pub fn contains_managed<T>() -> bool;
 
+    #[cfg(stage0)]
     pub fn visit_tydesc(td: *TyDesc, tv: &TyVisitor);
+    #[cfg(not(stage0))]
+    pub fn visit_tydesc(td: *TyDesc, tv: &mut TyVisitor);
 
     pub fn frame_address(f: &once fn(*u8));
 

--- a/src/test/run-pass/reflect-visit-data.rs
+++ b/src/test/run-pass/reflect-visit-data.rs
@@ -21,7 +21,7 @@ use std::unstable::raw::Vec;
 
 /// Trait for visitor that wishes to reflect on data.
 trait movable_ptr {
-    fn move_ptr(&self, adjustment: &fn(*c_void) -> *c_void);
+    fn move_ptr(&mut self, adjustment: &fn(*c_void) -> *c_void);
 }
 
 /// Helper function for alignment calculation.
@@ -35,26 +35,26 @@ struct ptr_visit_adaptor<V>(Inner<V>);
 impl<V:TyVisitor + movable_ptr> ptr_visit_adaptor<V> {
 
     #[inline(always)]
-    pub fn bump(&self, sz: uint) {
+    pub fn bump(&mut self, sz: uint) {
       do self.inner.move_ptr() |p| {
             ((p as uint) + sz) as *c_void
       };
     }
 
     #[inline(always)]
-    pub fn align(&self, a: uint) {
+    pub fn align(&mut self, a: uint) {
       do self.inner.move_ptr() |p| {
             align(p as uint, a) as *c_void
       };
     }
 
     #[inline(always)]
-    pub fn align_to<T>(&self) {
+    pub fn align_to<T>(&mut self) {
         self.align(sys::min_align_of::<T>());
     }
 
     #[inline(always)]
-    pub fn bump_past<T>(&self) {
+    pub fn bump_past<T>(&mut self) {
         self.bump(sys::size_of::<T>());
     }
 
@@ -62,147 +62,147 @@ impl<V:TyVisitor + movable_ptr> ptr_visit_adaptor<V> {
 
 impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
 
-    fn visit_bot(&self) -> bool {
+    fn visit_bot(&mut self) -> bool {
         self.align_to::<()>();
         if ! self.inner.visit_bot() { return false; }
         self.bump_past::<()>();
         true
     }
 
-    fn visit_nil(&self) -> bool {
+    fn visit_nil(&mut self) -> bool {
         self.align_to::<()>();
         if ! self.inner.visit_nil() { return false; }
         self.bump_past::<()>();
         true
     }
 
-    fn visit_bool(&self) -> bool {
+    fn visit_bool(&mut self) -> bool {
         self.align_to::<bool>();
         if ! self.inner.visit_bool() { return false; }
         self.bump_past::<bool>();
         true
     }
 
-    fn visit_int(&self) -> bool {
+    fn visit_int(&mut self) -> bool {
         self.align_to::<int>();
         if ! self.inner.visit_int() { return false; }
         self.bump_past::<int>();
         true
     }
 
-    fn visit_i8(&self) -> bool {
+    fn visit_i8(&mut self) -> bool {
         self.align_to::<i8>();
         if ! self.inner.visit_i8() { return false; }
         self.bump_past::<i8>();
         true
     }
 
-    fn visit_i16(&self) -> bool {
+    fn visit_i16(&mut self) -> bool {
         self.align_to::<i16>();
         if ! self.inner.visit_i16() { return false; }
         self.bump_past::<i16>();
         true
     }
 
-    fn visit_i32(&self) -> bool {
+    fn visit_i32(&mut self) -> bool {
         self.align_to::<i32>();
         if ! self.inner.visit_i32() { return false; }
         self.bump_past::<i32>();
         true
     }
 
-    fn visit_i64(&self) -> bool {
+    fn visit_i64(&mut self) -> bool {
         self.align_to::<i64>();
         if ! self.inner.visit_i64() { return false; }
         self.bump_past::<i64>();
         true
     }
 
-    fn visit_uint(&self) -> bool {
+    fn visit_uint(&mut self) -> bool {
         self.align_to::<uint>();
         if ! self.inner.visit_uint() { return false; }
         self.bump_past::<uint>();
         true
     }
 
-    fn visit_u8(&self) -> bool {
+    fn visit_u8(&mut self) -> bool {
         self.align_to::<u8>();
         if ! self.inner.visit_u8() { return false; }
         self.bump_past::<u8>();
         true
     }
 
-    fn visit_u16(&self) -> bool {
+    fn visit_u16(&mut self) -> bool {
         self.align_to::<u16>();
         if ! self.inner.visit_u16() { return false; }
         self.bump_past::<u16>();
         true
     }
 
-    fn visit_u32(&self) -> bool {
+    fn visit_u32(&mut self) -> bool {
         self.align_to::<u32>();
         if ! self.inner.visit_u32() { return false; }
         self.bump_past::<u32>();
         true
     }
 
-    fn visit_u64(&self) -> bool {
+    fn visit_u64(&mut self) -> bool {
         self.align_to::<u64>();
         if ! self.inner.visit_u64() { return false; }
         self.bump_past::<u64>();
         true
     }
 
-    fn visit_float(&self) -> bool {
+    fn visit_float(&mut self) -> bool {
         self.align_to::<float>();
         if ! self.inner.visit_float() { return false; }
         self.bump_past::<float>();
         true
     }
 
-    fn visit_f32(&self) -> bool {
+    fn visit_f32(&mut self) -> bool {
         self.align_to::<f32>();
         if ! self.inner.visit_f32() { return false; }
         self.bump_past::<f32>();
         true
     }
 
-    fn visit_f64(&self) -> bool {
+    fn visit_f64(&mut self) -> bool {
         self.align_to::<f64>();
         if ! self.inner.visit_f64() { return false; }
         self.bump_past::<f64>();
         true
     }
 
-    fn visit_char(&self) -> bool {
+    fn visit_char(&mut self) -> bool {
         self.align_to::<char>();
         if ! self.inner.visit_char() { return false; }
         self.bump_past::<char>();
         true
     }
 
-    fn visit_estr_box(&self) -> bool {
+    fn visit_estr_box(&mut self) -> bool {
         self.align_to::<@str>();
         if ! self.inner.visit_estr_box() { return false; }
         self.bump_past::<@str>();
         true
     }
 
-    fn visit_estr_uniq(&self) -> bool {
+    fn visit_estr_uniq(&mut self) -> bool {
         self.align_to::<~str>();
         if ! self.inner.visit_estr_uniq() { return false; }
         self.bump_past::<~str>();
         true
     }
 
-    fn visit_estr_slice(&self) -> bool {
+    fn visit_estr_slice(&mut self) -> bool {
         self.align_to::<&'static str>();
         if ! self.inner.visit_estr_slice() { return false; }
         self.bump_past::<&'static str>();
         true
     }
 
-    fn visit_estr_fixed(&self, n: uint,
+    fn visit_estr_fixed(&mut self, n: uint,
                         sz: uint,
                         align: uint) -> bool {
         self.align(align);
@@ -211,42 +211,42 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_box(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<@u8>();
         if ! self.inner.visit_box(mtbl, inner) { return false; }
         self.bump_past::<@u8>();
         true
     }
 
-    fn visit_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_uniq(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_uniq_managed(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~u8>();
         if ! self.inner.visit_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~u8>();
         true
     }
 
-    fn visit_ptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_ptr(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<*u8>();
         if ! self.inner.visit_ptr(mtbl, inner) { return false; }
         self.bump_past::<*u8>();
         true
     }
 
-    fn visit_rptr(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_rptr(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<&'static u8>();
         if ! self.inner.visit_rptr(mtbl, inner) { return false; }
         self.bump_past::<&'static u8>();
         true
     }
 
-    fn visit_unboxed_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_unboxed_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<Vec<()>>();
         // FIXME (#3732): Inner really has to move its own pointers on this one.
         // or else possibly we could have some weird interface wherein we
@@ -256,42 +256,42 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_vec(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_vec(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_box(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_box(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<@[u8]>();
         if ! self.inner.visit_evec_box(mtbl, inner) { return false; }
         self.bump_past::<@[u8]>();
         true
     }
 
-    fn visit_evec_uniq(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[u8]>();
         if ! self.inner.visit_evec_uniq(mtbl, inner) { return false; }
         self.bump_past::<~[u8]>();
         true
     }
 
-    fn visit_evec_uniq_managed(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<~[@u8]>();
         if ! self.inner.visit_evec_uniq_managed(mtbl, inner) { return false; }
         self.bump_past::<~[@u8]>();
         true
     }
 
-    fn visit_evec_slice(&self, mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_slice(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.align_to::<&'static [u8]>();
         if ! self.inner.visit_evec_slice(mtbl, inner) { return false; }
         self.bump_past::<&'static [u8]>();
         true
     }
 
-    fn visit_evec_fixed(&self, n: uint, sz: uint, align: uint,
+    fn visit_evec_fixed(&mut self, n: uint, sz: uint, align: uint,
                         mtbl: uint, inner: *TyDesc) -> bool {
         self.align(align);
         if ! self.inner.visit_evec_fixed(n, sz, align, mtbl, inner) {
@@ -301,24 +301,24 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_enter_rec(&self, n_fields: uint, sz: uint, align: uint) -> bool {
+    fn visit_enter_rec(&mut self, n_fields: uint, sz: uint, align: uint) -> bool {
         self.align(align);
         if ! self.inner.visit_enter_rec(n_fields, sz, align) { return false; }
         true
     }
 
-    fn visit_rec_field(&self, i: uint, name: &str,
+    fn visit_rec_field(&mut self, i: uint, name: &str,
                        mtbl: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_rec_field(i, name, mtbl, inner) { return false; }
         true
     }
 
-    fn visit_leave_rec(&self, n_fields: uint, sz: uint, align: uint) -> bool {
+    fn visit_leave_rec(&mut self, n_fields: uint, sz: uint, align: uint) -> bool {
         if ! self.inner.visit_leave_rec(n_fields, sz, align) { return false; }
         true
     }
 
-    fn visit_enter_class(&self, n_fields: uint, sz: uint, align: uint)
+    fn visit_enter_class(&mut self, n_fields: uint, sz: uint, align: uint)
                       -> bool {
         self.align(align);
         if ! self.inner.visit_enter_class(n_fields, sz, align) {
@@ -327,7 +327,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_class_field(&self, i: uint, name: &str,
+    fn visit_class_field(&mut self, i: uint, name: &str,
                          mtbl: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_class_field(i, name, mtbl, inner) {
             return false;
@@ -335,7 +335,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_leave_class(&self, n_fields: uint, sz: uint, align: uint)
+    fn visit_leave_class(&mut self, n_fields: uint, sz: uint, align: uint)
                       -> bool {
         if ! self.inner.visit_leave_class(n_fields, sz, align) {
             return false;
@@ -343,23 +343,23 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_enter_tup(&self, n_fields: uint, sz: uint, align: uint) -> bool {
+    fn visit_enter_tup(&mut self, n_fields: uint, sz: uint, align: uint) -> bool {
         self.align(align);
         if ! self.inner.visit_enter_tup(n_fields, sz, align) { return false; }
         true
     }
 
-    fn visit_tup_field(&self, i: uint, inner: *TyDesc) -> bool {
+    fn visit_tup_field(&mut self, i: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_tup_field(i, inner) { return false; }
         true
     }
 
-    fn visit_leave_tup(&self, n_fields: uint, sz: uint, align: uint) -> bool {
+    fn visit_leave_tup(&mut self, n_fields: uint, sz: uint, align: uint) -> bool {
         if ! self.inner.visit_leave_tup(n_fields, sz, align) { return false; }
         true
     }
 
-    fn visit_enter_fn(&self, purity: uint, proto: uint,
+    fn visit_enter_fn(&mut self, purity: uint, proto: uint,
                       n_inputs: uint, retstyle: uint) -> bool {
         if ! self.inner.visit_enter_fn(purity, proto, n_inputs, retstyle) {
             return false
@@ -367,17 +367,17 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_fn_input(&self, i: uint, mode: uint, inner: *TyDesc) -> bool {
+    fn visit_fn_input(&mut self, i: uint, mode: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_fn_input(i, mode, inner) { return false; }
         true
     }
 
-    fn visit_fn_output(&self, retstyle: uint, inner: *TyDesc) -> bool {
+    fn visit_fn_output(&mut self, retstyle: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_fn_output(retstyle, inner) { return false; }
         true
     }
 
-    fn visit_leave_fn(&self, purity: uint, proto: uint,
+    fn visit_leave_fn(&mut self, purity: uint, proto: uint,
                       n_inputs: uint, retstyle: uint) -> bool {
         if ! self.inner.visit_leave_fn(purity, proto, n_inputs, retstyle) {
             return false;
@@ -385,7 +385,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_enter_enum(&self, n_variants: uint,
+    fn visit_enter_enum(&mut self, n_variants: uint,
                         get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         sz: uint, align: uint)
                      -> bool {
@@ -394,7 +394,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_enter_enum_variant(&self, variant: uint,
+    fn visit_enter_enum_variant(&mut self, variant: uint,
                                 disr_val: int,
                                 n_fields: uint,
                                 name: &str) -> bool {
@@ -405,12 +405,12 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_enum_variant_field(&self, i: uint, offset: uint, inner: *TyDesc) -> bool {
+    fn visit_enum_variant_field(&mut self, i: uint, offset: uint, inner: *TyDesc) -> bool {
         if ! self.inner.visit_enum_variant_field(i, offset, inner) { return false; }
         true
     }
 
-    fn visit_leave_enum_variant(&self, variant: uint,
+    fn visit_leave_enum_variant(&mut self, variant: uint,
                                 disr_val: int,
                                 n_fields: uint,
                                 name: &str) -> bool {
@@ -421,7 +421,7 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_leave_enum(&self, n_variants: uint,
+    fn visit_leave_enum(&mut self, n_variants: uint,
                         get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         sz: uint, align: uint)
                      -> bool {
@@ -429,38 +429,38 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         true
     }
 
-    fn visit_trait(&self) -> bool {
+    fn visit_trait(&mut self) -> bool {
         self.align_to::<@TyVisitor>();
         if ! self.inner.visit_trait() { return false; }
         self.bump_past::<@TyVisitor>();
         true
     }
 
-    fn visit_param(&self, i: uint) -> bool {
+    fn visit_param(&mut self, i: uint) -> bool {
         if ! self.inner.visit_param(i) { return false; }
         true
     }
 
-    fn visit_self(&self) -> bool {
+    fn visit_self(&mut self) -> bool {
         self.align_to::<&'static u8>();
         if ! self.inner.visit_self() { return false; }
         self.align_to::<&'static u8>();
         true
     }
 
-    fn visit_type(&self) -> bool {
+    fn visit_type(&mut self) -> bool {
         if ! self.inner.visit_type() { return false; }
         true
     }
 
-    fn visit_opaque_box(&self) -> bool {
+    fn visit_opaque_box(&mut self) -> bool {
         self.align_to::<@u8>();
         if ! self.inner.visit_opaque_box() { return false; }
         self.bump_past::<@u8>();
         true
     }
 
-    fn visit_closure_ptr(&self, ck: uint) -> bool {
+    fn visit_closure_ptr(&mut self, ck: uint) -> bool {
         self.align_to::<@fn()>();
         if ! self.inner.visit_closure_ptr(ck) { return false; }
         self.bump_past::<@fn()>();
@@ -477,17 +477,17 @@ struct Stuff {
 }
 
 impl my_visitor {
-    pub fn get<T:Clone>(&self, f: &fn(T)) {
+    pub fn get<T:Clone>(&mut self, f: &fn(T)) {
         unsafe {
             f((*(self.ptr1 as *T)).clone());
         }
     }
 
-    pub fn visit_inner(&self, inner: *TyDesc) -> bool {
+    pub fn visit_inner(&mut self, inner: *TyDesc) -> bool {
         unsafe {
             let u = my_visitor(**self);
-            let v = ptr_visit_adaptor::<my_visitor>(Inner {inner: u});
-            visit_tydesc(inner, &v as &TyVisitor);
+            let mut v = ptr_visit_adaptor::<my_visitor>(Inner {inner: u});
+            visit_tydesc(inner, &mut v as &mut TyVisitor);
             true
         }
     }
@@ -496,7 +496,7 @@ impl my_visitor {
 struct Inner<V> { inner: V }
 
 impl movable_ptr for my_visitor {
-    fn move_ptr(&self, adjustment: &fn(*c_void) -> *c_void) {
+    fn move_ptr(&mut self, adjustment: &fn(*c_void) -> *c_void) {
         self.ptr1 = adjustment(self.ptr1);
         self.ptr2 = adjustment(self.ptr2);
     }
@@ -504,125 +504,125 @@ impl movable_ptr for my_visitor {
 
 impl TyVisitor for my_visitor {
 
-    fn visit_bot(&self) -> bool { true }
-    fn visit_nil(&self) -> bool { true }
-    fn visit_bool(&self) -> bool {
+    fn visit_bot(&mut self) -> bool { true }
+    fn visit_nil(&mut self) -> bool { true }
+    fn visit_bool(&mut self) -> bool {
         do self.get::<bool>() |b| {
             self.vals.push(b.to_str());
         };
         true
     }
-    fn visit_int(&self) -> bool {
+    fn visit_int(&mut self) -> bool {
         do self.get::<int>() |i| {
             self.vals.push(i.to_str());
         };
         true
     }
-    fn visit_i8(&self) -> bool { true }
-    fn visit_i16(&self) -> bool { true }
-    fn visit_i32(&self) -> bool { true }
-    fn visit_i64(&self) -> bool { true }
+    fn visit_i8(&mut self) -> bool { true }
+    fn visit_i16(&mut self) -> bool { true }
+    fn visit_i32(&mut self) -> bool { true }
+    fn visit_i64(&mut self) -> bool { true }
 
-    fn visit_uint(&self) -> bool { true }
-    fn visit_u8(&self) -> bool { true }
-    fn visit_u16(&self) -> bool { true }
-    fn visit_u32(&self) -> bool { true }
-    fn visit_u64(&self) -> bool { true }
+    fn visit_uint(&mut self) -> bool { true }
+    fn visit_u8(&mut self) -> bool { true }
+    fn visit_u16(&mut self) -> bool { true }
+    fn visit_u32(&mut self) -> bool { true }
+    fn visit_u64(&mut self) -> bool { true }
 
-    fn visit_float(&self) -> bool { true }
-    fn visit_f32(&self) -> bool { true }
-    fn visit_f64(&self) -> bool { true }
+    fn visit_float(&mut self) -> bool { true }
+    fn visit_f32(&mut self) -> bool { true }
+    fn visit_f64(&mut self) -> bool { true }
 
-    fn visit_char(&self) -> bool { true }
+    fn visit_char(&mut self) -> bool { true }
 
-    fn visit_estr_box(&self) -> bool { true }
-    fn visit_estr_uniq(&self) -> bool { true }
-    fn visit_estr_slice(&self) -> bool { true }
-    fn visit_estr_fixed(&self, _n: uint, _sz: uint,
+    fn visit_estr_box(&mut self) -> bool { true }
+    fn visit_estr_uniq(&mut self) -> bool { true }
+    fn visit_estr_slice(&mut self) -> bool { true }
+    fn visit_estr_fixed(&mut self, _n: uint, _sz: uint,
                         _align: uint) -> bool { true }
 
-    fn visit_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_uniq(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_uniq_managed(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_ptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_rptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_box(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_uniq(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_uniq_managed(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_ptr(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_rptr(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
 
-    fn visit_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_uniq(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_uniq_managed(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_slice(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_fixed(&self, _n: uint, _sz: uint, _align: uint,
+    fn visit_vec(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_unboxed_vec(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_box(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_uniq(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_uniq_managed(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_slice(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_fixed(&mut self, _n: uint, _sz: uint, _align: uint,
                         _mtbl: uint, _inner: *TyDesc) -> bool { true }
 
-    fn visit_enter_rec(&self, _n_fields: uint,
+    fn visit_enter_rec(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
-    fn visit_rec_field(&self, _i: uint, _name: &str,
+    fn visit_rec_field(&mut self, _i: uint, _name: &str,
                        _mtbl: uint, inner: *TyDesc) -> bool {
         error!("rec field!");
         self.visit_inner(inner)
     }
-    fn visit_leave_rec(&self, _n_fields: uint,
+    fn visit_leave_rec(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
 
-    fn visit_enter_class(&self, _n_fields: uint,
+    fn visit_enter_class(&mut self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool { true }
-    fn visit_class_field(&self, _i: uint, _name: &str,
+    fn visit_class_field(&mut self, _i: uint, _name: &str,
                          _mtbl: uint, inner: *TyDesc) -> bool {
         self.visit_inner(inner)
     }
-    fn visit_leave_class(&self, _n_fields: uint,
+    fn visit_leave_class(&mut self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool { true }
 
-    fn visit_enter_tup(&self, _n_fields: uint,
+    fn visit_enter_tup(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
-    fn visit_tup_field(&self, _i: uint, inner: *TyDesc) -> bool {
+    fn visit_tup_field(&mut self, _i: uint, inner: *TyDesc) -> bool {
         error!("tup field!");
         self.visit_inner(inner)
     }
-    fn visit_leave_tup(&self, _n_fields: uint,
+    fn visit_leave_tup(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
 
-    fn visit_enter_enum(&self, _n_variants: uint,
+    fn visit_enter_enum(&mut self, _n_variants: uint,
                         _get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         _sz: uint, _align: uint) -> bool {
         // FIXME (#3732): this needs to rewind between enum variants, or something.
         true
     }
-    fn visit_enter_enum_variant(&self, _variant: uint,
+    fn visit_enter_enum_variant(&mut self, _variant: uint,
                                 _disr_val: int,
                                 _n_fields: uint,
                                 _name: &str) -> bool { true }
-    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, inner: *TyDesc) -> bool {
+    fn visit_enum_variant_field(&mut self, _i: uint, _offset: uint, inner: *TyDesc) -> bool {
         self.visit_inner(inner)
     }
-    fn visit_leave_enum_variant(&self, _variant: uint,
+    fn visit_leave_enum_variant(&mut self, _variant: uint,
                                 _disr_val: int,
                                 _n_fields: uint,
                                 _name: &str) -> bool { true }
-    fn visit_leave_enum(&self, _n_variants: uint,
+    fn visit_leave_enum(&mut self, _n_variants: uint,
                         _get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         _sz: uint, _align: uint) -> bool { true }
 
-    fn visit_enter_fn(&self, _purity: uint, _proto: uint,
+    fn visit_enter_fn(&mut self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
-    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool {
+    fn visit_fn_input(&mut self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool {
         true
     }
-    fn visit_fn_output(&self, _retstyle: uint, _inner: *TyDesc) -> bool {
+    fn visit_fn_output(&mut self, _retstyle: uint, _inner: *TyDesc) -> bool {
         true
     }
-    fn visit_leave_fn(&self, _purity: uint, _proto: uint,
+    fn visit_leave_fn(&mut self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
 
 
-    fn visit_trait(&self) -> bool { true }
-    fn visit_param(&self, _i: uint) -> bool { true }
-    fn visit_self(&self) -> bool { true }
-    fn visit_type(&self) -> bool { true }
-    fn visit_opaque_box(&self) -> bool { true }
-    fn visit_closure_ptr(&self, _ck: uint) -> bool { true }
+    fn visit_trait(&mut self) -> bool { true }
+    fn visit_param(&mut self, _i: uint) -> bool { true }
+    fn visit_self(&mut self) -> bool { true }
+    fn visit_type(&mut self) -> bool { true }
+    fn visit_opaque_box(&mut self) -> bool { true }
+    fn visit_closure_ptr(&mut self, _ck: uint) -> bool { true }
 }
 
 fn get_tydesc_for<T>(_t: T) -> *TyDesc {
@@ -640,12 +640,11 @@ pub fn main() {
         let u = my_visitor(@mut Stuff {ptr1: p,
                                        ptr2: p,
                                        vals: ~[]});
-        let v = ptr_visit_adaptor(Inner {inner: u});
+        let mut v = ptr_visit_adaptor(Inner {inner: u});
         let td = get_tydesc_for(r);
         error!("tydesc sz: %u, align: %u",
                (*td).size, (*td).align);
-        let v = &v as &TyVisitor;
-        visit_tydesc(td, v);
+        visit_tydesc(td, &mut v as &mut TyVisitor);
 
         let r = u.vals.clone();
         for s in r.iter() {

--- a/src/test/run-pass/reflect-visit-type.rs
+++ b/src/test/run-pass/reflect-visit-type.rs
@@ -15,157 +15,150 @@ struct MyVisitor {
 }
 
 impl TyVisitor for MyVisitor {
-    fn visit_bot(&self) -> bool {
+    fn visit_bot(&mut self) -> bool {
         self.types.push(~"bot");
         error!("visited bot type");
         true
     }
-    fn visit_nil(&self) -> bool {
+    fn visit_nil(&mut self) -> bool {
         self.types.push(~"nil");
         error!("visited nil type");
         true
     }
-    fn visit_bool(&self) -> bool {
+    fn visit_bool(&mut self) -> bool {
         self.types.push(~"bool");
         error!("visited bool type");
         true
     }
-    fn visit_int(&self) -> bool {
+    fn visit_int(&mut self) -> bool {
         self.types.push(~"int");
         error!("visited int type");
         true
     }
-    fn visit_i8(&self) -> bool {
+    fn visit_i8(&mut self) -> bool {
         self.types.push(~"i8");
         error!("visited i8 type");
         true
     }
-    fn visit_i16(&self) -> bool {
+    fn visit_i16(&mut self) -> bool {
         self.types.push(~"i16");
         error!("visited i16 type");
         true
     }
-    fn visit_i32(&self) -> bool { true }
-    fn visit_i64(&self) -> bool { true }
+    fn visit_i32(&mut self) -> bool { true }
+    fn visit_i64(&mut self) -> bool { true }
 
-    fn visit_uint(&self) -> bool { true }
-    fn visit_u8(&self) -> bool { true }
-    fn visit_u16(&self) -> bool { true }
-    fn visit_u32(&self) -> bool { true }
-    fn visit_u64(&self) -> bool { true }
+    fn visit_uint(&mut self) -> bool { true }
+    fn visit_u8(&mut self) -> bool { true }
+    fn visit_u16(&mut self) -> bool { true }
+    fn visit_u32(&mut self) -> bool { true }
+    fn visit_u64(&mut self) -> bool { true }
 
-    fn visit_float(&self) -> bool { true }
-    fn visit_f32(&self) -> bool { true }
-    fn visit_f64(&self) -> bool { true }
+    fn visit_float(&mut self) -> bool { true }
+    fn visit_f32(&mut self) -> bool { true }
+    fn visit_f64(&mut self) -> bool { true }
 
-    fn visit_char(&self) -> bool { true }
+    fn visit_char(&mut self) -> bool { true }
 
-    fn visit_estr_box(&self) -> bool { true }
-    fn visit_estr_uniq(&self) -> bool { true }
-    fn visit_estr_slice(&self) -> bool { true }
-    fn visit_estr_fixed(&self,
+    fn visit_estr_box(&mut self) -> bool { true }
+    fn visit_estr_uniq(&mut self) -> bool { true }
+    fn visit_estr_slice(&mut self) -> bool { true }
+    fn visit_estr_fixed(&mut self,
                         _sz: uint, _sz: uint,
                         _align: uint) -> bool { true }
 
-    fn visit_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_uniq(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_uniq_managed(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_ptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_rptr(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_box(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_uniq(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_uniq_managed(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_ptr(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_rptr(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
 
-    fn visit_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_unboxed_vec(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_box(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_uniq(&self, _mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_vec(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_unboxed_vec(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_box(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_uniq(&mut self, _mtbl: uint, inner: *TyDesc) -> bool {
         self.types.push(~"[");
-        unsafe {
-            visit_tydesc(inner, (&*self) as &TyVisitor);
-        }
+        unsafe { visit_tydesc(inner, &mut *self as &mut TyVisitor); }
         self.types.push(~"]");
         true
     }
-    fn visit_evec_uniq_managed(&self, _mtbl: uint, inner: *TyDesc) -> bool {
+    fn visit_evec_uniq_managed(&mut self, _mtbl: uint, inner: *TyDesc) -> bool {
         self.types.push(~"[");
-        unsafe {
-            visit_tydesc(inner, (&*self) as &TyVisitor);
-        }
+        unsafe { visit_tydesc(inner, &mut *self as &mut TyVisitor) };
         self.types.push(~"]");
         true
     }
-    fn visit_evec_slice(&self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_evec_fixed(&self, _n: uint, _sz: uint, _align: uint,
+    fn visit_evec_slice(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_evec_fixed(&mut self, _n: uint, _sz: uint, _align: uint,
                         _mtbl: uint, _inner: *TyDesc) -> bool { true }
 
-    fn visit_enter_rec(&self, _n_fields: uint,
+    fn visit_enter_rec(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
-    fn visit_rec_field(&self, _i: uint, _name: &str,
+    fn visit_rec_field(&mut self, _i: uint, _name: &str,
                        _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_leave_rec(&self, _n_fields: uint,
+    fn visit_leave_rec(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
 
-    fn visit_enter_class(&self, _n_fields: uint,
+    fn visit_enter_class(&mut self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool { true }
-    fn visit_class_field(&self, _i: uint, _name: &str,
+    fn visit_class_field(&mut self, _i: uint, _name: &str,
                          _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_leave_class(&self, _n_fields: uint,
+    fn visit_leave_class(&mut self, _n_fields: uint,
                          _sz: uint, _align: uint) -> bool { true }
 
-    fn visit_enter_tup(&self, _n_fields: uint,
+    fn visit_enter_tup(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
-    fn visit_tup_field(&self, _i: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_leave_tup(&self, _n_fields: uint,
+    fn visit_tup_field(&mut self, _i: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_leave_tup(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool { true }
 
-    fn visit_enter_enum(&self, _n_variants: uint,
+    fn visit_enter_enum(&mut self, _n_variants: uint,
                         _get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         _sz: uint, _align: uint) -> bool { true }
-    fn visit_enter_enum_variant(&self,
+    fn visit_enter_enum_variant(&mut self,
                                 _variant: uint,
                                 _disr_val: int,
                                 _n_fields: uint,
                                 _name: &str) -> bool { true }
-    fn visit_enum_variant_field(&self, _i: uint, _offset: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_leave_enum_variant(&self,
+    fn visit_enum_variant_field(&mut self, _i: uint, _offset: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_leave_enum_variant(&mut self,
                                 _variant: uint,
                                 _disr_val: int,
                                 _n_fields: uint,
                                 _name: &str) -> bool { true }
-    fn visit_leave_enum(&self,
+    fn visit_leave_enum(&mut self,
                         _n_variants: uint,
                         _get_disr: extern unsafe fn(ptr: *Opaque) -> int,
                         _sz: uint, _align: uint) -> bool { true }
 
-    fn visit_enter_fn(&self, _purity: uint, _proto: uint,
+    fn visit_enter_fn(&mut self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
-    fn visit_fn_input(&self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_fn_output(&self, _retstyle: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_leave_fn(&self, _purity: uint, _proto: uint,
+    fn visit_fn_input(&mut self, _i: uint, _mode: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_fn_output(&mut self, _retstyle: uint, _inner: *TyDesc) -> bool { true }
+    fn visit_leave_fn(&mut self, _purity: uint, _proto: uint,
                       _n_inputs: uint, _retstyle: uint) -> bool { true }
 
 
-    fn visit_trait(&self) -> bool { true }
-    fn visit_param(&self, _i: uint) -> bool { true }
-    fn visit_self(&self) -> bool { true }
-    fn visit_type(&self) -> bool { true }
-    fn visit_opaque_box(&self) -> bool { true }
-    fn visit_closure_ptr(&self, _ck: uint) -> bool { true }
+    fn visit_trait(&mut self) -> bool { true }
+    fn visit_param(&mut self, _i: uint) -> bool { true }
+    fn visit_self(&mut self) -> bool { true }
+    fn visit_type(&mut self) -> bool { true }
+    fn visit_opaque_box(&mut self) -> bool { true }
+    fn visit_closure_ptr(&mut self, _ck: uint) -> bool { true }
 }
 
-fn visit_ty<T>(v: &TyVisitor) {
-    unsafe {
-        visit_tydesc(get_tydesc::<T>(), v);
-    }
+fn visit_ty<T>(v: &mut MyVisitor) {
+    unsafe { visit_tydesc(get_tydesc::<T>(), v as &mut TyVisitor) }
 }
 
 pub fn main() {
-    let v = @MyVisitor {types: @mut ~[]};
-    let vv = v as @TyVisitor;
+    let mut v = MyVisitor {types: @mut ~[]};
 
-    visit_ty::<bool>(vv);
-    visit_ty::<int>(vv);
-    visit_ty::<i8>(vv);
-    visit_ty::<i16>(vv);
-    visit_ty::<~[int]>(vv);
+    visit_ty::<bool>(&mut v);
+    visit_ty::<int>(&mut v);
+    visit_ty::<i8>(&mut v);
+    visit_ty::<i16>(&mut v);
+    visit_ty::<~[int]>(&mut v);
 
     for s in v.types.iter() {
         printfln!("type: %s", (*s).clone());


### PR DESCRIPTION
At the same time, this updates the TyVisitor to use a mutable self because it's
probably going to be mutating state as it goes along anyway.
