### PR TITLE
Make the unit-test framework check RUST_TEST_TASKS over RUST_THREADS.

### DIFF
--- a/src/test/run-fail/test-threads-invalid-value.rs
+++ b/src/test/run-fail/test-threads-invalid-value.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This checks that RUST_TEST_TASKS not being 1, 2, ... is detected
+// properly.
+
+// error-pattern:should be a non-negative integer
+// compile-flags: --test
+// exec-env:RUST_TEST_TASKS=foo
+
+#[test]
+fn do_nothing() {}


### PR DESCRIPTION
Fixes #7335.
