### PR TITLE
rust-mode: Default rust-indent-offset to 4, not default-tab-width

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -29,10 +29,8 @@
 
     table))
 
-(defcustom rust-indent-offset default-tab-width
-  "*Indent Rust code by this number of spaces.
-
-The initializer is `DEFAULT-TAB-WIDTH'.")
+(defcustom rust-indent-offset 4
+  "*Indent Rust code by this number of spaces.")
 
 (defun rust-paren-level () (nth 0 (syntax-ppss)))
 (defun rust-in-str-or-cmnt () (nth 8 (syntax-ppss)))
@@ -61,7 +59,7 @@ The initializer is `DEFAULT-TAB-WIDTH'.")
 
               ;; If we're in any other token-tree / sexp, then:
               ;;  - [ or ( means line up with the opening token
-              ;;  - { means indent to either nesting-level * tab width,
+              ;;  - { means indent to either nesting-level * rust-indent-offset,
               ;;    or one further indent from that if either current line
               ;;    begins with 'else', or previous line didn't end in
               ;;    semi, comma or brace, and wasn't an attribute. PHEW.


### PR DESCRIPTION
`default-tab-width` is standardly 8, but most programmers and style guides prefer an indentation width smaller than that.  Rust itself uses 4 space indents.  Most other Emacs modes define the indentation width as 4 or 2 spaces, independently of the width of a Tab character.  Depending on `default-tab-width` makes especially little sense for rust-mode because it sets `indent-tabs-mode` to `nil`.
