### PR TITLE
Implement RUST_PATH variation for porting Servo

### DIFF
--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -129,7 +129,7 @@ fn check_impl_of_trait(cx: Context, it: @item, trait_ref: &trait_ref, self_type:
 
     // If this trait has builtin-kind supertraits, meet them.
     let self_ty: ty::t = ty::node_id_to_type(cx.tcx, it.id);
-    error!("checking impl with self type %?", ty::get(self_ty).sty);
+    debug!("checking impl with self type %?", ty::get(self_ty).sty);
     do check_builtin_bounds(cx, self_ty, trait_def.bounds) |missing| {
         cx.tcx.sess.span_err(self_type.span,
             fmt!("the type `%s', which does not fulfill `%s`, cannot implement this \

--- a/src/librustpkg/api.rs
+++ b/src/librustpkg/api.rs
@@ -20,7 +20,12 @@ use std::hashmap::*;
 /// Convenience functions intended for calling from pkg.rs
 
 fn default_ctxt(p: @Path) -> Ctx {
-    Ctx { sysroot_opt: Some(p), json: false, dep_cache: @mut HashMap::new() }
+    Ctx {
+        use_rust_path_hack: false,
+        sysroot_opt: Some(p),
+        json: false,
+        dep_cache: @mut HashMap::new()
+    }
 }
 
 pub fn build_lib(sysroot: @Path, root: Path, name: ~str, version: Version,

--- a/src/librustpkg/conditions.rs
+++ b/src/librustpkg/conditions.rs
@@ -36,3 +36,11 @@ condition! {
 condition! {
     no_rust_path: (~str) -> super::Path;
 }
+
+condition! {
+    not_a_workspace: (~str) -> super::Path;
+}
+
+condition! {
+    failed_to_create_temp_dir: (~str) -> super::Path;
+}

--- a/src/librustpkg/context.rs
+++ b/src/librustpkg/context.rs
@@ -15,6 +15,11 @@ use std::hashmap::HashMap;
 use std::os;
 
 pub struct Ctx {
+    // If use_rust_path_hack is true, rustpkg searches for sources
+    // in *package* directories that are in the RUST_PATH (for example,
+    // FOO/src/bar-0.1 instead of FOO). The flag doesn't affect where
+    // rustpkg stores build artifacts.
+    use_rust_path_hack: bool,
     // Sysroot -- if this is None, uses rustc filesearch's
     // idea of the default
     sysroot_opt: Option<@Path>,

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -452,6 +452,13 @@ mod test {
 
 }
 
+pub fn option_to_vec<T>(x: Option<T>) -> ~[T] {
+    match x {
+       Some(y) => ~[y],
+       None    => ~[]
+    }
+}
+
 // tjc: cheesy
 fn debug_flags() -> ~[~str] { ~[] }
 // static DEBUG_FLAGS: ~[~str] = ~[~"-Z", ~"time-passes"];

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1002,6 +1002,18 @@ pub fn remove_file(p: &Path) -> bool {
     }
 }
 
+/// Renames an existing file or directory
+pub fn rename_file(old: &Path, new: &Path) -> bool {
+    #[fixed_stack_segment]; #[inline(never)];
+    unsafe {
+       do old.with_c_str |old_buf| {
+            do new.with_c_str |new_buf| {
+                libc::rename(old_buf, new_buf) == (0 as c_int)
+            }
+       }
+    }
+}
+
 #[cfg(unix)]
 /// Returns the platform-specific value of errno
 pub fn errno() -> int {

--- a/src/test/run-pass/rename-directory.rs
+++ b/src/test/run-pass/rename-directory.rs
@@ -1,0 +1,57 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test can't be a unit test in std,
+// because it needs mkdtemp, which is in extra
+
+// xfail-fast
+extern mod extra;
+
+use extra::tempfile::mkdtemp;
+use std::os;
+use std::libc;
+use std::libc::*;
+
+fn rename_directory() {
+    #[fixed_stack_segment];
+    unsafe {
+        static U_RWX: i32 = (S_IRUSR | S_IWUSR | S_IXUSR) as i32;
+
+        let tmpdir = mkdtemp(&os::tmpdir(), "rename_directory").expect("rename_directory failed");
+        let old_path = tmpdir.push_many(["foo", "bar", "baz"]);
+        assert!(os::mkdir_recursive(&old_path, U_RWX));
+        let test_file = &old_path.push("temp.txt");
+
+        /* Write the temp input file */
+        let ostream = do test_file.to_str().with_c_str |fromp| {
+            do "w+b".with_c_str |modebuf| {
+                libc::fopen(fromp, modebuf)
+            }
+        };
+        assert!((ostream as uint != 0u));
+        let s = ~"hello";
+        do "hello".with_c_str |buf| {
+            let write_len = libc::fwrite(buf as *c_void,
+                                         1u as size_t,
+                                         (s.len() + 1u) as size_t,
+                                         ostream);
+            assert_eq!(write_len, (s.len() + 1) as size_t)
+        }
+        assert_eq!(libc::fclose(ostream), (0u as c_int));
+
+        let new_path = tmpdir.push_many(["quux", "blat"]);
+        assert!(os::mkdir_recursive(&new_path, U_RWX));
+        assert!(os::rename_file(&old_path, &new_path.push("newdir")));
+        assert!(os::path_is_dir(&new_path.push("newdir")));
+        assert!(os::path_exists(&new_path.push_many(["newdir", "temp.txt"])));
+    }
+}
+
+fn main() { rename_directory() }


### PR DESCRIPTION
r? @brson

@metajack requested the ability to violate the "only workspaces can be in the RUST_PATH" rule for the purpose of bootstrapping Servo without having to restructure all the directories. This patch gives rustpkg the ability to find sources if a directory in the RUST_PATH directly contains one of rustpkg's "special" files (lib.rs, main.rs, bench.rs, or test.rs), even if it's not a workspace. In this case, it puts the build artifacts in the first workspace in the RUST_PATH.

I'm not sure whether or not it's a good idea to keep this feature in rustpkg permanently. Thus, I added a flag, `--use-rust-path-hack`, and only enabled it when the flag is set.
