### PR TITLE
Fix compilation issues with libuv on OSX

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -41,6 +41,11 @@ ifneq ($(strip $(findstring snap,$(MAKECMDGOALS))),)
 	SNAP_DEFINES=-DRUST_SNAPSHOT
 endif
 
+define DEF_LIBUV_ARCH_VAR
+  LIBUV_ARCH_$(1) = $$(subst i386,ia32,$$(subst x86_64,x64,$$(HOST_$(1))))
+endef
+$(foreach t,$(CFG_TARGET_TRIPLES),$(eval $(call DEF_LIBUV_ARCH_VAR,$(t))))
+
 define DEF_RUNTIME_TARGETS
 
 ######################################################################
@@ -170,7 +175,7 @@ LIBUV_NO_LOAD = run-benchmarks.target.mk run-tests.target.mk \
 
 $$(LIBUV_MAKEFILE_$(1)_$(2)): $$(LIBUV_GYP)
 	(cd $(S)src/libuv/ && \
-	 $$(CFG_PYTHON) ./gyp_uv -f make -Dtarget_arch=$$(HOST_$(1)) -D ninja \
+	 $$(CFG_PYTHON) ./gyp_uv -f make -Dtarget_arch=$$(LIBUV_ARCH_$(1)) -D ninja \
 	   -Goutput_dir=$$(@D) --generator-output $$(@D))
 
 # XXX: Shouldn't need platform-specific conditions here


### PR DESCRIPTION
It turns out that gyp (libuv's new build system) wants x64 for a 64-bit x86
architecture and ia32 for a 32-bit architecture, so this performs the relevant
mapping and then invokes libuv's configure script with the appropriate target
architecture.

This can be verified by running make with VERBOSE=1 and seeing that beforehand
on a 64-bit build libuv was passed "-arch i386" and now it's passed
"-arch x86_64"

Closes #8826
