### PR TITLE
Turn off frame pointer elimination again

### DIFF
--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -26,7 +26,7 @@ ifeq ($(CFG_LLVM_ROOT),)
 
 $$(LLVM_CONFIG_$(1)): $$(LLVM_DEPS)
 	@$$(call E, make: llvm)
-	$$(Q)$$(MAKE) -C $$(CFG_LLVM_BUILD_DIR_$(1))
+	$$(Q)$$(MAKE) -C $$(CFG_LLVM_BUILD_DIR_$(1)) $$(CFG_LLVM_BUILD_ENV)
 	$$(Q)touch $$(LLVM_CONFIG_$(1))
 endif
 

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -26,7 +26,10 @@ endef
 $(foreach t,$(CFG_TARGET_TRIPLES),$(eval $(call DEF_OSTYPE_VAR,$(t))))
 $(foreach t,$(CFG_TARGET_TRIPLES),$(info cfg: os for $(t) is $(OSTYPE_$(t))))
 
-CFG_GCCISH_CFLAGS += -DUSE_UTF8
+# FIXME: no-omit-frame-pointer is just so that task_start_wrapper
+# has a frame pointer and the stack walker can understand it. Turning off
+# frame pointers everywhere is overkill
+CFG_GCCISH_CFLAGS += -fno-omit-frame-pointer -DUSE_UTF8
 
 # On Darwin, we need to run dsymutil so the debugging information ends
 # up in the right place.  On other platforms, it automatically gets
@@ -150,6 +153,7 @@ CFG_GCCISH_POST_LIB_FLAGS_x86_64-unknown-linux-gnu := -Wl,-no-whole-archive
 CFG_DEF_SUFFIX_x86_64-unknown-linux-gnu := .linux.def
 CFG_INSTALL_NAME_x86_64-unknown-linux-gnu =
 CFG_LIBUV_LINK_FLAGS_x86_64-unknown-linux-gnu =
+CFG_LLVM_BUILD_ENV_x86_64-unknown-linux-gnu="CXXFLAGS=-fno-omit-frame-pointer"
 CFG_EXE_SUFFIX_x86_64-unknown-linux-gnu =
 CFG_WINDOWSY_x86_64-unknown-linux-gnu :=
 CFG_UNIXY_x86_64-unknown-linux-gnu := 1
@@ -175,6 +179,7 @@ CFG_GCCISH_POST_LIB_FLAGS_i686-unknown-linux-gnu := -Wl,-no-whole-archive
 CFG_DEF_SUFFIX_i686-unknown-linux-gnu := .linux.def
 CFG_INSTALL_NAME_i686-unknown-linux-gnu =
 CFG_LIBUV_LINK_FLAGS_i686-unknown-linux-gnu =
+CFG_LLVM_BUILD_ENV_i686-unknown-linux-gnu="CXXFLAGS=-fno-omit-frame-pointer"
 CFG_EXE_SUFFIX_i686-unknown-linux-gnu =
 CFG_WINDOWSY_i686-unknown-linux-gnu :=
 CFG_UNIXY_i686-unknown-linux-gnu := 1

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -78,6 +78,7 @@ LLVMRustCreateTargetMachine(const char *triple,
     }
 
     TargetOptions Options;
+    Options.NoFramePointerElim = true;
     Options.EnableSegmentedStacks = EnableSegmentedStacks;
     Options.FixedStackSegmentSize = 2 * 1024 * 1024; // XXX: This is too big.
     Options.FloatABIType =

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -284,6 +284,7 @@ LLVMRustBuildJIT(void* mem,
   std::string Err;
   TargetOptions Options;
   Options.JITEmitDebugInfo = true;
+  Options.NoFramePointerElim = true;
   Options.EnableSegmentedStacks = EnableSegmentedStacks;
   RustMCJITMemoryManager* MM = (RustMCJITMemoryManager*) mem;
   assert(MM);


### PR DESCRIPTION
This reverts commit 2c0f9bd35493def5e23f0f43ddeba54da9d788b4, reversing
changes made to f8c4f0ea9c96218dbc81081799e77875fbb071de.

Conflicts:
    src/rustllvm/RustWrapper.cpp

Fixes #8833
