### PR TITLE
A few minor clean-ups to the rt code

### DIFF
--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -745,7 +745,7 @@ fn get_concurrency() -> uint {
             let opt_n: Option<uint> = FromStr::from_str(s);
             match opt_n {
                 Some(n) if n > 0 => n,
-                _ => fail!("RUST_TEST_TASKS is `%s`, should be a non-negative integer.", s)
+                _ => fail!("RUST_TEST_TASKS is `%s`, should be a positive integer.", s)
             }
         }
         None => {

--- a/src/libstd/rt/args.rs
+++ b/src/libstd/rt/args.rs
@@ -55,10 +55,11 @@ pub fn clone() -> Option<~[~str]> {
 mod imp {
     use libc;
     use option::{Option, Some, None};
-    use iterator::{Iterator, range};
+    use iterator::Iterator;
     use str;
     use unstable::finally::Finally;
     use util;
+    use vec;
 
     pub unsafe fn init(argc: int, argv: **u8) {
         let args = load_argc_and_argv(argc, argv);
@@ -111,11 +112,9 @@ mod imp {
 
     // Copied from `os`.
     unsafe fn load_argc_and_argv(argc: int, argv: **u8) -> ~[~str] {
-        let mut args = ~[];
-        for i in range(0u, argc as uint) {
-            args.push(str::raw::from_c_str(*(argv as **libc::c_char).offset(i as int)));
+        do vec::from_fn(argc as uint) |i| {
+            str::raw::from_c_str(*(argv as **libc::c_char).offset(i as int))
         }
-        args
     }
 
     #[cfg(stage0)]

--- a/src/libstd/rt/local_ptr.rs
+++ b/src/libstd/rt/local_ptr.rs
@@ -121,27 +121,20 @@ pub unsafe fn borrow<T>(f: &fn(&mut T)) {
 /// For the Scheduler pointer to be aliased
 pub unsafe fn unsafe_borrow<T>() -> *mut T {
     let key = tls_key();
-    let mut void_ptr: *mut c_void = tls::get(key);
+    let void_ptr = tls::get(key);
     if void_ptr.is_null() {
         rtabort!("thread-local pointer is null. bogus!");
     }
-    let ptr: *mut *mut c_void = &mut void_ptr;
-    let ptr: *mut ~T = ptr as *mut ~T;
-    let ptr: *mut T = &mut **ptr;
-    return ptr;
+    void_ptr as *mut T
 }
 
 pub unsafe fn try_unsafe_borrow<T>() -> Option<*mut T> {
     let key = tls_key();
-    let mut void_ptr: *mut c_void = tls::get(key);
+    let void_ptr = tls::get(key);
     if void_ptr.is_null() {
-        return None;
-    }
-    {
-        let ptr: *mut *mut c_void = &mut void_ptr;
-        let ptr: *mut ~T = ptr as *mut ~T;
-        let ptr: *mut T = &mut **ptr;
-        return Some(ptr);
+        None
+    } else {
+        Some(void_ptr as *mut T)
     }
 }
 

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -11,7 +11,7 @@
 use container::Container;
 use from_str::FromStr;
 use libc;
-use option::{Some, None};
+use option::{Some, None, Option};
 use os;
 use str::StrSlice;
 use unstable::atomics::{AtomicInt, INIT_ATOMIC_INT, SeqCst};
@@ -57,7 +57,13 @@ pub fn limit_thread_creation_due_to_osx_and_valgrind() -> bool {
 /// either `RUST_THREADS` or `num_cpus`.
 pub fn default_sched_threads() -> uint {
     match os::getenv("RUST_THREADS") {
-        Some(nstr) => FromStr::from_str(nstr).unwrap(),
+        Some(nstr) => {
+            let opt_n: Option<uint> = FromStr::from_str(nstr);
+            match opt_n {
+                Some(n) if n > 0 => n,
+                _ => rtabort!("`RUST_THREADS` is `%s`, should be a positive integer", nstr)
+            }
+        }
         None => {
             if limit_thread_creation_due_to_osx_and_valgrind() {
                 1

--- a/src/test/run-fail/test-tasks-invalid-value.rs
+++ b/src/test/run-fail/test-tasks-invalid-value.rs
@@ -11,7 +11,7 @@
 // This checks that RUST_TEST_TASKS not being 1, 2, ... is detected
 // properly.
 
-// error-pattern:should be a non-negative integer
+// error-pattern:should be a positive integer
 // compile-flags: --test
 // exec-env:RUST_TEST_TASKS=foo
 


### PR DESCRIPTION
The only user-facing change is handling non-integer (and zero) `RUST_THREADS` more nicely:

```
$ RUST_THREADS=x rustc # old

You've met with a terrible fate, haven't you?

fatal runtime error: runtime tls key not initialized
Aborted
$ RUST_THREADS=x ./x86_64-unknown-linux-gnu/stage2/bin/rustc # new

You've met with a terrible fate, haven't you?

fatal runtime error: `RUST_THREADS` is `x`, should be a positive integer
Aborted
```

The other changes are converting some `for .. in range(x,y)` to `vec::from_fn` or `for .. in x.iter()` as appropriate; and removing a chain of (seemingly) unnecessary pointer casts.

(Also, fixes a typo in `extra::test` from #8823.)
