### PR TITLE
std/extra: Two small bugfixes and one simplification

### DIFF
--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -594,7 +594,7 @@ impl<A: Eq> Eq for DList<A> {
     }
 
     fn ne(&self, other: &DList<A>) -> bool {
-        self.len() != other.len() &&
+        self.len() != other.len() ||
             iterator::order::ne(self.iter(), other.iter())
     }
 }
@@ -978,6 +978,10 @@ mod tests {
         assert!(n != m);
         m.push_back(1);
         assert_eq!(&n, &m);
+
+        let n = list_from([2,3,4]);
+        let m = list_from([1,2,3]);
+        assert!(n != m);
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1713,6 +1713,7 @@ impl<'self> StrSlice<'self> for &'self str {
             if count == end { end_byte = Some(idx); break; }
             count += 1;
         }
+        if begin_byte.is_none() && count == begin { begin_byte = Some(self.len()) }
         if end_byte.is_none() && count == end { end_byte = Some(self.len()) }
 
         match (begin_byte, end_byte) {
@@ -2700,8 +2701,11 @@ mod tests {
         fn t(a: &str, b: &str, start: uint) {
             assert_eq!(a.slice_chars(start, start + b.char_len()), b);
         }
+        t("", "", 0);
         t("hello", "llo", 2);
         t("hello", "el", 1);
+        t("αβλ", "β", 1);
+        t("αβλ", "", 3);
         assert_eq!("ะเทศไท", "ประเทศไทย中华Việt Nam".slice_chars(2, 8));
     }
 


### PR DESCRIPTION
Fix a bug in `s.slice_chars(a, b)` that did not accept `a == s.len()`.

Fix a bug in `!=` defined for DList.

Also simplify NormalizationIterator to use the CharIterator directly instead of mimicing the iteration itself.
