### PR TITLE
drop some redundant Ord method implementations

### DIFF
--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -1164,9 +1164,6 @@ impl Ord for Json {
             }
         }
     }
-    fn le(&self, other: &Json) -> bool { !(*other).lt(&(*self)) }
-    fn ge(&self, other: &Json) -> bool { !(*self).lt(other) }
-    fn gt(&self, other: &Json) -> bool { (*other).lt(&(*self))  }
 }
 
 /// A trait for converting values to JSON

--- a/src/libextra/num/rational.rs
+++ b/src/libextra/num/rational.rs
@@ -107,7 +107,7 @@ macro_rules! cmp_impl {
 }
 cmp_impl!(impl Eq, eq, ne)
 cmp_impl!(impl TotalEq, equals)
-cmp_impl!(impl Ord, lt)
+cmp_impl!(impl Ord, lt, gt, le, ge)
 cmp_impl!(impl TotalOrd, cmp -> cmp::Ordering)
 
 impl<T: Clone + Integer + Ord> Orderable for Ratio<T> {

--- a/src/libextra/num/rational.rs
+++ b/src/libextra/num/rational.rs
@@ -107,7 +107,7 @@ macro_rules! cmp_impl {
 }
 cmp_impl!(impl Eq, eq, ne)
 cmp_impl!(impl TotalEq, equals)
-cmp_impl!(impl Ord, lt, gt, le, ge)
+cmp_impl!(impl Ord, lt)
 cmp_impl!(impl TotalOrd, cmp -> cmp::Ordering)
 
 impl<T: Clone + Integer + Ord> Orderable for Ratio<T> {

--- a/src/libextra/semver.rs
+++ b/src/libextra/semver.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -36,18 +36,6 @@ impl cmp::Ord for Identifier {
             (&AlphaNumeric(ref a), &AlphaNumeric(ref b)) => *a < *b,
             (&AlphaNumeric(_), _) => false
         }
-    }
-    #[inline]
-    fn le(&self, other: &Identifier) -> bool {
-        ! (other < self)
-    }
-    #[inline]
-    fn gt(&self, other: &Identifier) -> bool {
-        other < self
-    }
-    #[inline]
-    fn ge(&self, other: &Identifier) -> bool {
-        ! (self < other)
     }
 }
 


### PR DESCRIPTION
If this were to break something, I would expect existing tests to catch it, and a `make check` run passes locally.
