### PR TITLE
doc/rust.md: Missing in keyword on keyword list.

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -209,7 +209,7 @@ break
 do
 else enum extern
 false fn for
-if impl
+if impl in
 let loop
 match mod mut
 priv pub


### PR DESCRIPTION
As promised on #8876.
