### PR TITLE
Removed some unnecessarily defined "ne" methods in Eq impls

### DIFF
--- a/src/librustpkg/package_id.rs
+++ b/src/librustpkg/package_id.rs
@@ -37,8 +37,8 @@ pub struct PkgId {
 }
 
 impl Eq for PkgId {
-    fn eq(&self, p: &PkgId) -> bool {
-        p.path == self.path && p.version == self.version
+    fn eq(&self, other: &PkgId) -> bool {
+        self.path == other.path && self.version == other.version
     }
 }
 

--- a/src/librustpkg/package_id.rs
+++ b/src/librustpkg/package_id.rs
@@ -40,9 +40,6 @@ impl Eq for PkgId {
     fn eq(&self, p: &PkgId) -> bool {
         p.path == self.path && p.version == self.version
     }
-    fn ne(&self, p: &PkgId) -> bool {
-        !(self.eq(p))
-    }
 }
 
 impl PkgId {

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -40,9 +40,6 @@ impl Eq for Version {
             _ => false
         }
     }
-    fn ne(&self, other: &Version) -> bool {
-        !self.eq(other)
-    }
 }
 
 impl Ord for Version {

--- a/src/libstd/bool.rs
+++ b/src/libstd/bool.rs
@@ -321,8 +321,6 @@ impl TotalOrd for bool {
 impl Eq for bool {
     #[inline]
     fn eq(&self, other: &bool) -> bool { (*self) == (*other) }
-    #[inline]
-    fn ne(&self, other: &bool) -> bool { (*self) != (*other) }
 }
 
 #[cfg(not(test))]

--- a/src/libstd/char.rs
+++ b/src/libstd/char.rs
@@ -397,8 +397,6 @@ impl Char for char {
 impl Eq for char {
     #[inline]
     fn eq(&self, other: &char) -> bool { (*self) == (*other) }
-    #[inline]
-    fn ne(&self, other: &char) -> bool { (*self) != (*other) }
 }
 
 #[cfg(not(test))]

--- a/src/libstd/cmp.rs
+++ b/src/libstd/cmp.rs
@@ -36,6 +36,8 @@ and `Eq` to overload the `==` and `!=` operators.
 #[lang="eq"]
 pub trait Eq {
     fn eq(&self, other: &Self) -> bool;
+
+    #[inline]
     fn ne(&self, other: &Self) -> bool { !self.eq(other) }
 }
 

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -171,8 +171,6 @@ impl Num for f32 {}
 impl Eq for f32 {
     #[inline]
     fn eq(&self, other: &f32) -> bool { (*self) == (*other) }
-    #[inline]
-    fn ne(&self, other: &f32) -> bool { (*self) != (*other) }
 }
 
 #[cfg(not(test))]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -194,8 +194,6 @@ impl Num for f64 {}
 impl Eq for f64 {
     #[inline]
     fn eq(&self, other: &f64) -> bool { (*self) == (*other) }
-    #[inline]
-    fn ne(&self, other: &f64) -> bool { (*self) != (*other) }
 }
 
 #[cfg(not(test))]

--- a/src/libstd/num/float.rs
+++ b/src/libstd/num/float.rs
@@ -331,8 +331,6 @@ impl Num for float {}
 impl Eq for float {
     #[inline]
     fn eq(&self, other: &float) -> bool { (*self) == (*other) }
-    #[inline]
-    fn ne(&self, other: &float) -> bool { (*self) != (*other) }
 }
 
 #[cfg(not(test))]

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -147,8 +147,6 @@ impl Ord for $T {
 impl Eq for $T {
     #[inline]
     fn eq(&self, other: &$T) -> bool { return (*self) == (*other); }
-    #[inline]
-    fn ne(&self, other: &$T) -> bool { return (*self) != (*other); }
 }
 
 impl Orderable for $T {

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -148,8 +148,6 @@ impl Ord for $T {
 impl Eq for $T {
     #[inline]
     fn eq(&self, other: &$T) -> bool { return (*self) == (*other); }
-    #[inline]
-    fn ne(&self, other: &$T) -> bool { return (*self) != (*other); }
 }
 
 impl Orderable for $T {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1180,8 +1180,6 @@ pub mod traits {
         fn eq(&self, other: &~str) -> bool {
             eq_slice((*self), (*other))
         }
-        #[inline]
-        fn ne(&self, other: &~str) -> bool { !(*self).eq(other) }
     }
 
     impl Eq for @str {
@@ -1189,8 +1187,6 @@ pub mod traits {
         fn eq(&self, other: &@str) -> bool {
             eq_slice((*self), (*other))
         }
-        #[inline]
-        fn ne(&self, other: &@str) -> bool { !(*self).eq(other) }
     }
 
     impl<'self> TotalEq for &'self str {


### PR DESCRIPTION
Summary:
-removed "ne" methods in libstd and librustpkg
-made default "ne" be inlined
-made one of the "eq" methods in librustpkg follow more standard parameter naming convention
