### PR TITLE
Fix #8898

### DIFF
--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -381,10 +381,11 @@ impl<'self> TyVisitor for ReprVisitor<'self> {
         }
     }
 
-    fn visit_evec_fixed(&mut self, _n: uint, sz: uint, _align: uint,
+    fn visit_evec_fixed(&mut self, n: uint, sz: uint, _align: uint,
                         mtbl: uint, inner: *TyDesc) -> bool {
+        let assumed_size = if sz == 0 { n } else { sz };
         do self.get::<()> |this, b| {
-            this.write_vec_range(mtbl, ptr::to_unsafe_ptr(b), sz, inner);
+            this.write_vec_range(mtbl, ptr::to_unsafe_ptr(b), assumed_size, inner);
         }
     }
 

--- a/src/test/run-pass/issue-8898.rs
+++ b/src/test/run-pass/issue-8898.rs
@@ -1,0 +1,32 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+fn assert_repr_eq<T>(obj : T, expected : ~str) {
+
+    assert_eq!(expected, fmt!("%?", obj));
+}
+
+pub fn main() {
+    let abc = [1, 2, 3];
+    let tf = [true, false];
+    let x  = [(), ()];
+    let y = ~[(), ()];
+    let slice = x.slice(0,1);
+    let z = @x;
+
+    assert_repr_eq(abc, ~"[1, 2, 3]");
+    assert_repr_eq(tf, ~"[true, false]");
+    assert_repr_eq(x, ~"[(), ()]");
+    assert_repr_eq(y, ~"~[(), ()]");
+    assert_repr_eq(slice, ~"&[()]");
+    assert_repr_eq(&x, ~"&[(), ()]");
+    assert_repr_eq(z, ~"@[(), ()]");
+}


### PR DESCRIPTION
I think this fixes 8898.  I'm a bit unsure about how slices and owned pointers to vectors-of-unit already worked, but since they were already working, I didn't mess with them.
