### PR TITLE
Fsk 8468 allow underscore paramname in trait default method

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -348,10 +348,7 @@ impl Drop for Parser {
 }
 
 fn is_plain_ident_or_underscore(t: &token::Token) -> bool {
-    match *t {
-        token::IDENT(_, false) | token::UNDERSCORE => true,
-        _ => false,
-    }
+    is_plain_ident(t) || *t == token::UNDERSCORE
 }
 
 impl Parser {

--- a/src/test/run-pass/default-method-parsing.rs
+++ b/src/test/run-pass/default-method-parsing.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo {
+    fn m(&self, _:int) { }
+}
+
+fn main() { }


### PR DESCRIPTION
Fix #8468.  (Though the right answer in the end, as noted on the dialogue on the ticket, might be to just require trait methods to name their parameters, regardless of whether they have a default method implementation or not.)
