### PR TITLE
Raise the file descriptor limits when running compiletest

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -16,6 +16,7 @@
 extern mod extra;
 
 use std::os;
+use std::rt;
 use std::f64;
 
 use extra::getopts;
@@ -223,6 +224,10 @@ pub fn mode_str(mode: mode) -> ~str {
 pub fn run_tests(config: &config) {
     let opts = test_opts(config);
     let tests = make_tests(config);
+    // sadly osx needs some file descriptor limits raised for running tests in
+    // parallel (especially when we have lots and lots of child processes).
+    // For context, see #8904
+    rt::test::prepare_for_lots_of_tests();
     let res = test::run_tests_console(&opts, tests);
     if !res { fail!("Some tests failed"); }
 }

--- a/src/libstd/rt/test.rs
+++ b/src/libstd/rt/test.rs
@@ -144,6 +144,12 @@ mod darwin_fd_limit {
     pub unsafe fn raise_fd_limit() {}
 }
 
+#[doc(hidden)]
+pub fn prepare_for_lots_of_tests() {
+    // Bump the fd limit on OS X. See darwin_fd_limit for an explanation.
+    unsafe { darwin_fd_limit::raise_fd_limit() }
+}
+
 /// Create more than one scheduler and run a function in a task
 /// in one of the schedulers. The schedulers will stay alive
 /// until the function `f` returns.
@@ -153,8 +159,8 @@ pub fn run_in_mt_newsched_task(f: ~fn()) {
     use rt::sched::Shutdown;
     use rt::util;
 
-    // Bump the fd limit on OS X. See darwin_fd_limit for an explanation.
-    unsafe { darwin_fd_limit::raise_fd_limit() }
+    // see comment in other function (raising fd limits)
+    prepare_for_lots_of_tests();
 
     let f = Cell::new(f);
 


### PR DESCRIPTION
We already do this for libstd tests automatically, and compiletest runs into the
same problems where when forking lots of processes lots of file descriptors are
created. On OSX we can use specific syscalls to raise the limits, in this
situation, though.

Closes #8904
