### PR TITLE
Test eof is reached when parsing format strings

### DIFF
--- a/src/test/compile-fail/ifmt-bad-arg.rs
+++ b/src/test/compile-fail/ifmt-bad-arg.rs
@@ -71,4 +71,7 @@ fn main() {
     format!("{0, select, other{{}}}", "a"); //~ ERROR: cannot use implicit
     format!("{0, plural, other{{}}}", 1); //~ ERROR: cannot use implicit
     format!("{0, plural, other{{1:.*d}}}", 1, 2); //~ ERROR: cannot use implicit
+
+    format!("foo } bar"); //~ ERROR: unmatched `}` found
+    format!("foo }"); //~ ERROR: unmatched `}` found
 }


### PR DESCRIPTION
Otherwise extra stuff after a lone '}' character is simply ignored, which is
very bad.

Closes #8938
