### PR TITLE
add type name to tydesc + minor repr improvement

### DIFF
--- a/src/librustc/back/abi.rs
+++ b/src/librustc/back/abi.rs
@@ -47,7 +47,8 @@ pub static tydesc_field_drop_glue: uint = 3u;
 pub static tydesc_field_free_glue: uint = 4u;
 pub static tydesc_field_visit_glue: uint = 5u;
 pub static tydesc_field_borrow_offset: uint = 6u;
-pub static n_tydesc_fields: uint = 7u;
+pub static tydesc_field_name_offset: uint = 7u;
+pub static n_tydesc_fields: uint = 8u;
 
 // The two halves of a closure: code and environment.
 pub static fn_field_code: uint = 0u;

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -56,6 +56,7 @@ pub struct tydesc_info {
     size: ValueRef,
     align: ValueRef,
     borrow_offset: ValueRef,
+    name: ValueRef,
     take_glue: Option<ValueRef>,
     drop_glue: Option<ValueRef>,
     free_glue: Option<ValueRef>,

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -678,12 +678,16 @@ pub fn declare_tydesc(ccx: &mut CrateContext, t: ty::t) -> @mut tydesc_info {
             llvm::LLVMAddGlobal(ccx.llmod, ccx.tydesc_type.to_ref(), buf)
         }
     };
+
+    let ty_name = C_estr_slice(ccx, ppaux::ty_to_str(ccx.tcx, t).to_managed());
+
     let inf = @mut tydesc_info {
         ty: t,
         tydesc: gvar,
         size: llsize,
         align: llalign,
         borrow_offset: borrow_offset,
+        name: ty_name,
         take_glue: None,
         drop_glue: None,
         free_glue: None,
@@ -809,14 +813,14 @@ pub fn emit_tydescs(ccx: &mut CrateContext) {
                                      drop_glue, // drop_glue
                                      free_glue, // free_glue
                                      visit_glue, // visit_glue
-                                     ti.borrow_offset]); // borrow_offset
+                                     ti.borrow_offset, // borrow_offset
+                                     ti.name]); // name
 
         unsafe {
             let gvar = ti.tydesc;
             llvm::LLVMSetInitializer(gvar, tydesc);
             llvm::LLVMSetGlobalConstant(gvar, True);
             lib::llvm::SetLinkage(gvar, lib::llvm::InternalLinkage);
-
         }
     };
 }

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -216,8 +216,8 @@ impl Type {
                      glue_fn_ty, // drop
                      glue_fn_ty, // free
                      glue_fn_ty, // visit
-                     int_ty];    // borrow_offset
-
+                     int_ty, // borrow_offset
+                     Type::struct_([Type::i8p(), Type::int(arch)], false)]; // name
         tydesc.set_struct_body(elems, false);
 
         return tydesc;

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -66,6 +66,9 @@ pub struct TyDesc {
     // `U`, but in the case of `@Trait` or `~Trait` objects, the type
     // `U` is unknown.
     borrow_offset: uint,
+
+    // Name corresponding to the type
+    name: &'static str
 }
 
 #[lang="opaque"]

--- a/src/rt/rust_type.h
+++ b/src/rt/rust_type.h
@@ -52,6 +52,11 @@ static inline void *box_body(rust_opaque_box *box) {
     return (void*)(box + 1);
 }
 
+struct slice {
+    void *data;
+    size_t length;
+};
+
 struct type_desc {
     size_t size;
     size_t align;
@@ -60,6 +65,7 @@ struct type_desc {
     glue_fn *free_glue;
     glue_fn *visit_glue;
     size_t borrow_offset;
+    slice name;
 };
 
 #endif


### PR DESCRIPTION
Storing the type name in the `tydesc` aims to avoid the need to pass a type name in almost every single visitor method.

It would likely be much saner for `repr` to simply be passed the `TyDesc` corresponding to the function or just the type name, but this is good enough for now.
