### PR TITLE
Allow disabling segmented stacks.

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -274,7 +274,11 @@ pub mod write {
                             lib::llvm::CodeModelDefault,
                             lib::llvm::RelocPIC,
                             OptLevel,
-                            true
+                            if (sess.opts.debugging_opts & session::no_segmented_stacks) == 0 {
+                                true
+                            } else {
+                                false
+                            }
                         )
                     }
                 }

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -80,6 +80,7 @@ pub static print_llvm_passes:       uint = 1 << 27;
 pub static no_vectorize_loops:      uint = 1 << 28;
 pub static no_vectorize_slp:        uint = 1 << 29;
 pub static no_prepopulate_passes:   uint = 1 << 30;
+pub static no_segmented_stacks:     uint = 1 << 31;
 
 pub fn debugging_opts_map() -> ~[(~str, ~str, uint)] {
     ~[(~"verbose", ~"in general, enable more debug printouts", verbose),
@@ -137,6 +138,7 @@ pub fn debugging_opts_map() -> ~[(~str, ~str, uint)] {
      (~"no-vectorize-slp",
       ~"Don't run LLVM's SLP vectorization passes",
       no_vectorize_slp),
+      (~"no-segmented-stacks", ~"Disable segmented stacks", no_segmented_stacks),
     ]
 }
 


### PR DESCRIPTION
This is one of the very common options a standalone ("runtimeless") profile 
would want to use. This disables all segmented stack support at the LLVM 
level.
