### PR TITLE
Add a safe implementation of MutexArc::access* methods

### DIFF
--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -201,10 +201,10 @@ impl<T:Send> MutexArc<T> {
      * The reason this function is 'unsafe' is because it is possible to
      * construct a circular reference among multiple Arcs by mutating the
      * underlying data. This creates potential for deadlock, but worse, this
-     * will guarantee a memory leak of all involved Arcs. Using mutex Arcs
+     * will guarantee a memory leak of all involved Arcs. Using MutexArcs
      * inside of other Arcs is safe in absence of circular references.
      *
-     * If you wish to nest mutex_arcs, one strategy for ensuring safety at
+     * If you wish to nest MutexArcs, one strategy for ensuring safety at
      * runtime is to add a "nesting level counter" inside the stored data, and
      * when traversing the arcs, assert that they monotonically decrease.
      *
@@ -272,9 +272,9 @@ impl<T:Freeze + Send> MutexArc<T> {
      * requires the Freeze bound, which prohibits access on MutexArcs which
      * might contain nested MutexArcs inside.
      *
-     * The purpose of this is to offer a safe implementation of both methods
-     * access and access_cond to be used instead of rwlock in cases where no
-     * readers are needed and sightly better performance is required.
+     * The purpose of this is to offer a safe implementation of MutexArc to be
+     * used instead of RWArc in cases where no readers are needed and sightly
+     * better performance is required.
      *
      * Both methods have the same failure behaviour as unsafe_access and
      * unsafe_access_cond.

--- a/src/test/compile-fail/mutex-arc-nested.rs
+++ b/src/test/compile-fail/mutex-arc-nested.rs
@@ -1,0 +1,26 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern mod extra;
+
+use std::task;
+use extra::arc::{MutexArc};
+
+fn test_mutex_arc_nested() {
+    let arc = ~MutexArc::new(1);
+    let arc2 = ~MutexArc::new(*arc);
+
+    do task::spawn || {
+        do (*arc2).access |mutex| { // This should fail because MutexArc is not Freeze
+        }
+    };
+}
+
+fn main() {}

--- a/src/test/compile-fail/mutex-arc-nested.rs
+++ b/src/test/compile-fail/mutex-arc-nested.rs
@@ -18,7 +18,7 @@ fn test_mutex_arc_nested() {
     let arc2 = ~MutexArc::new(*arc);
 
     do task::spawn || {
-        do (*arc2).access |mutex| { // This should fail because MutexArc is not Freeze
+        do (*arc2).access |mutex| { //~ ERROR instantiating a type parameter with an incompatible type
         }
     };
 }


### PR DESCRIPTION
Current access methods are nestable and unsafe. This patch renames
current methods implementation - prepends unsafe_ - and implements 2 new
methods that are both safe and un-nestable.

Fixes #7473
