### PR TITLE
Make path api less allocation happy

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -307,8 +307,9 @@ pub fn make_test_name(config: &config, testfile: &Path) -> test::TestName {
     // Try to elide redundant long paths
     fn shorten(path: &Path) -> ~str {
         let filename = path.filename();
-        let dir = path.pop().filename();
-        fmt!("%s/%s", dir.unwrap_or_default(~""), filename.unwrap_or_default(~""))
+        let p = path.pop();
+        let dir = p.filename();
+        fmt!("%s/%s", dir.unwrap_or_default(""), filename.unwrap_or_default(""))
     }
 
     test::DynTestName(fmt!("[%s] %s",

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -880,7 +880,7 @@ fn _arm_push_aux_shared_library(config: &config, testfile: &Path) {
     let dirs = os::list_dir_path(&Path(tstr));
     for file in dirs.iter() {
 
-        if (file.filetype() == Some(~".so")) {
+        if (file.filetype() == Some(".so")) {
 
             let copy_result = procsrv::run("", config.adb_path,
                 [~"push", file.to_str(), config.adb_test_dir.clone()],

--- a/src/librust/rust.rs
+++ b/src/librust/rust.rs
@@ -162,7 +162,8 @@ fn cmd_help(args: &[~str]) -> ValidUsage {
 fn cmd_test(args: &[~str]) -> ValidUsage {
     match args {
         [ref filename] => {
-            let test_exec = Path(*filename).filestem().unwrap() + "test~";
+            let p = Path(*filename);
+            let test_exec = p.filestem().unwrap() + "test~";
             invoke("rustc", &[~"--test", filename.to_owned(),
                               ~"-o", test_exec.to_owned()], rustc::main_args);
             let exit_code = run::process_status(~"./" + test_exec, []);
@@ -175,7 +176,8 @@ fn cmd_test(args: &[~str]) -> ValidUsage {
 fn cmd_run(args: &[~str]) -> ValidUsage {
     match args {
         [ref filename, ..prog_args] => {
-            let exec = Path(*filename).filestem().unwrap() + "~";
+            let p = Path(*filename);
+            let exec = p.filestem().unwrap() + "~";
             invoke("rustc", &[filename.to_owned(), ~"-o", exec.to_owned()],
                    rustc::main_args);
             let exit_code = run::process_status(~"./"+exec, prog_args);

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -948,13 +948,13 @@ pub fn link_args(sess: Session,
     let cstore = sess.cstore;
     let r = cstore::get_used_crate_files(cstore);
     for cratepath in r.iter() {
-        if cratepath.filetype() == Some(~".rlib") {
+        if cratepath.filetype() == Some(".rlib") {
             args.push(cratepath.to_str());
             loop;
         }
         let dir = cratepath.dirname();
         if dir != ~"" { args.push(~"-L" + dir); }
-        let libarg = unlib(sess.targ_cfg, cratepath.filestem().unwrap());
+        let libarg = unlib(sess.targ_cfg, cratepath.filestem().unwrap().to_owned());
         args.push(~"-l" + libarg);
     }
 

--- a/src/librustpkg/installed_packages.rs
+++ b/src/librustpkg/installed_packages.rs
@@ -19,7 +19,8 @@ pub fn list_installed_packages(f: &fn(&PkgId) -> bool) -> bool  {
     for p in workspaces.iter() {
         let binfiles = os::list_dir(&p.push("bin"));
         for exec in binfiles.iter() {
-            let exec_path = Path(*exec).filestem();
+            let p = Path(*exec);
+            let exec_path = p.filestem();
             do exec_path.iter().advance |s| {
                 f(&PkgId::new(*s))
             };
@@ -49,8 +50,8 @@ pub fn has_library(p: &Path) -> Option<~str> {
     let files = os::list_dir(p);
     for q in files.iter() {
         let as_path = Path(*q);
-        if as_path.filetype() == Some(os::consts::DLL_SUFFIX.to_owned()) {
-            let stuff : ~str = as_path.filestem().expect("has_library: weird path");
+        if as_path.filetype() == Some(os::consts::DLL_SUFFIX) {
+            let stuff : &str = as_path.filestem().expect("has_library: weird path");
             let mut stuff2 = stuff.split_str_iter(&"-");
             let stuff3: ~[&str] = stuff2.collect();
             // argh

--- a/src/librustpkg/package_id.rs
+++ b/src/librustpkg/package_id.rs
@@ -68,7 +68,7 @@ impl PkgId {
         if path.components.len() < 1 {
             return cond.raise((path, ~"0-length pkgid"));
         }
-        let short_name = path.clone().filestem().expect(fmt!("Strange path! %s", s));
+        let short_name = path.filestem().expect(fmt!("Strange path! %s", s));
 
         let version = match given_version {
             Some(v) => v,
@@ -83,8 +83,8 @@ impl PkgId {
 
         debug!("path = %s", path.to_str());
         PkgId {
-            path: path,
-            short_name: short_name,
+            path: path.clone(),
+            short_name: short_name.to_owned(),
             version: version
         }
     }

--- a/src/librustpkg/package_source.rs
+++ b/src/librustpkg/package_source.rs
@@ -118,7 +118,7 @@ impl PkgSrc {
             return Some(local);
         }
 
-        if (self.id.path.clone()).components().len() < 2 {
+        if self.id.path.components().len() < 2 {
             // If a non-URL, don't bother trying to fetch
             return None;
         }
@@ -156,7 +156,7 @@ impl PkgSrc {
 
     /// True if the given path's stem is self's pkg ID's stem
     fn stem_matches(&self, p: &Path) -> bool {
-        p.filestem().map_default(false, |p| { p == &self.id.short_name })
+        p.filestem().map_default(false, |p| { p == &self.id.short_name.as_slice() })
     }
 
     fn push_crate(cs: &mut ~[Crate], prefix: uint, p: &Path) {
@@ -181,10 +181,10 @@ impl PkgSrc {
         do os::walk_dir(&dir) |pth| {
             let maybe_known_crate_set = match pth.filename() {
                 Some(filename) => match filename {
-                    ~"lib.rs" => Some(&mut self.libs),
-                    ~"main.rs" => Some(&mut self.mains),
-                    ~"test.rs" => Some(&mut self.tests),
-                    ~"bench.rs" => Some(&mut self.benchs),
+                    "lib.rs" => Some(&mut self.libs),
+                    "main.rs" => Some(&mut self.mains),
+                    "test.rs" => Some(&mut self.tests),
+                    "bench.rs" => Some(&mut self.benchs),
                     _ => None
                 },
                 _ => None

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -234,14 +234,14 @@ pub fn library_in_workspace(path: &Path, short_name: &str, where: Target,
                                Some(j) => {
                                    debug!("Maybe %s equals %s", f_name.slice(0, j), lib_prefix);
                                    if f_name.slice(0, j) == lib_prefix {
-                                       result_filename = Some(p_path);
+                                       result_filename = Some(p_path.clone());
                                    }
                                    break;
                                }
                                None => break
                            }
                        }
-                       _ => { f_name = f_name.slice(0, i).to_owned(); }
+                       _ => { f_name = f_name.slice(0, i); }
                  }
                }
                None => break

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -396,7 +396,7 @@ fn touch_source_file(workspace: &Path, pkgid: &PkgId) {
     let pkg_src_dir = workspace.push("src").push(pkgid.to_str());
     let contents = os::list_dir_path(&pkg_src_dir);
     for p in contents.iter() {
-        if p.filetype() == Some(~".rs") {
+        if p.filetype() == Some(".rs") {
             // should be able to do this w/o a process
             if run::process_output("touch", [p.to_str()]).status != 0 {
                 let _ = cond.raise((pkg_src_dir.clone(), ~"Bad path"));
@@ -413,7 +413,7 @@ fn frob_source_file(workspace: &Path, pkgid: &PkgId) {
     let contents = os::list_dir_path(&pkg_src_dir);
     let mut maybe_p = None;
     for p in contents.iter() {
-        if p.filetype() == Some(~".rs") {
+        if p.filetype() == Some(".rs") {
             maybe_p = Some(p);
             break;
         }


### PR DESCRIPTION
A [dialogue](https://github.com/mozilla/rust/pull/8909#discussion-diff-6102725) on PR #8909 inspired me to make this change.

r? anyone

(It is possible that `std::path` itself will soon be replaced with a new implementation that kballard's working on, as mentioned in the dialogue linked above, but this revision is simple enough that I figured I'd offer it up.)
