### PR TITLE
Remove the __log function for __log_level

### DIFF
--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -389,7 +389,6 @@ impl CFGBuilder {
                 self.straightline(expr, pred, [r, l])
             }
 
-            ast::ExprLog(l, r) |
             ast::ExprIndex(_, l, r) |
             ast::ExprBinary(_, _, l, r) => { // NB: && and || handled earlier
                 self.straightline(expr, pred, [l, r])
@@ -405,6 +404,7 @@ impl CFGBuilder {
                 self.straightline(expr, pred, [e])
             }
 
+            ast::ExprLogLevel |
             ast::ExprMac(*) |
             ast::ExprInlineAsm(*) |
             ast::ExprSelf |

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -702,12 +702,12 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
                 join_bits(&self.dfcx.oper, temp, in_out);
             }
 
-            ast::ExprLog(l, r) |
             ast::ExprIndex(_, l, r) |
             ast::ExprBinary(_, _, l, r) => {
                 self.walk_exprs([l, r], in_out, loop_scopes);
             }
 
+            ast::ExprLogLevel |
             ast::ExprLit(*) |
             ast::ExprPath(*) |
             ast::ExprSelf => {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -59,7 +59,6 @@ pub enum LangItem {
 
     StrEqFnLangItem,                   // 19
     UniqStrEqFnLangItem,               // 20
-    LogTypeFnLangItem,                 // 21
     FailFnLangItem,                    // 22
     FailBoundsCheckFnLangItem,         // 23
     ExchangeMallocFnLangItem,          // 24
@@ -238,9 +237,6 @@ impl LanguageItems {
     pub fn uniq_str_eq_fn(&self) -> Option<DefId> {
         self.items[UniqStrEqFnLangItem as uint]
     }
-    pub fn log_type_fn(&self) -> Option<DefId> {
-        self.items[LogTypeFnLangItem as uint]
-    }
     pub fn fail_fn(&self) -> Option<DefId> {
         self.items[FailFnLangItem as uint]
     }
@@ -357,7 +353,6 @@ impl<'self> LanguageItemCollector<'self> {
 
         item_refs.insert(@"str_eq", StrEqFnLangItem as uint);
         item_refs.insert(@"uniq_str_eq", UniqStrEqFnLangItem as uint);
-        item_refs.insert(@"log_type", LogTypeFnLangItem as uint);
         item_refs.insert(@"fail_", FailFnLangItem as uint);
         item_refs.insert(@"fail_bounds_check",
                          FailBoundsCheckFnLangItem as uint);

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -526,7 +526,7 @@ fn visit_expr(v: &mut LivenessVisitor, expr: @Expr, this: @mut IrMaps) {
 
       // otherwise, live nodes are not required:
       ExprIndex(*) | ExprField(*) | ExprVstore(*) | ExprVec(*) |
-      ExprCall(*) | ExprMethodCall(*) | ExprTup(*) | ExprLog(*) |
+      ExprCall(*) | ExprMethodCall(*) | ExprTup(*) | ExprLogLevel |
       ExprBinary(*) | ExprAddrOf(*) |
       ExprDoBody(*) | ExprCast(*) | ExprUnary(*) | ExprBreak(_) |
       ExprAgain(_) | ExprLit(_) | ExprRet(*) | ExprBlock(*) |
@@ -1217,7 +1217,6 @@ impl Liveness {
             self.propagate_through_expr(l, ln)
           }
 
-          ExprLog(l, r) |
           ExprIndex(_, l, r) |
           ExprBinary(_, _, l, r) => {
             self.propagate_through_exprs([l, r], succ)
@@ -1240,6 +1239,7 @@ impl Liveness {
             }
           }
 
+          ExprLogLevel |
           ExprLit(*) => {
             succ
           }
@@ -1496,7 +1496,7 @@ fn check_expr(vt: &mut ErrorCheckVisitor, expr: @Expr, this: @Liveness) {
       // no correctness conditions related to liveness
       ExprCall(*) | ExprMethodCall(*) | ExprIf(*) | ExprMatch(*) |
       ExprWhile(*) | ExprLoop(*) | ExprIndex(*) | ExprField(*) |
-      ExprVstore(*) | ExprVec(*) | ExprTup(*) | ExprLog(*) |
+      ExprVstore(*) | ExprVec(*) | ExprTup(*) | ExprLogLevel |
       ExprBinary(*) | ExprDoBody(*) |
       ExprCast(*) | ExprUnary(*) | ExprRet(*) | ExprBreak(*) |
       ExprAgain(*) | ExprLit(_) | ExprBlock(*) |

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -428,7 +428,7 @@ impl mem_categorization_ctxt {
           ast::ExprDoBody(*) | ast::ExprUnary(*) |
           ast::ExprMethodCall(*) | ast::ExprCast(*) | ast::ExprVstore(*) |
           ast::ExprVec(*) | ast::ExprTup(*) | ast::ExprIf(*) |
-          ast::ExprLog(*) | ast::ExprBinary(*) | ast::ExprWhile(*) |
+          ast::ExprLogLevel | ast::ExprBinary(*) | ast::ExprWhile(*) |
           ast::ExprBlock(*) | ast::ExprLoop(*) | ast::ExprMatch(*) |
           ast::ExprLit(*) | ast::ExprBreak(*) | ast::ExprMac(*) |
           ast::ExprAgain(*) | ast::ExprStruct(*) | ast::ExprRepeat(*) |

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -480,6 +480,7 @@ impl VisitContext {
                 self.use_expr(base, Read, visitor);
             }
 
+            ExprLogLevel |
             ExprInlineAsm(*) |
             ExprBreak(*) |
             ExprAgain(*) |
@@ -487,11 +488,6 @@ impl VisitContext {
 
             ExprLoop(ref blk, _) => {
                 self.consume_block(blk, visitor);
-            }
-
-            ExprLog(a_expr, b_expr) => {
-                self.consume_expr(a_expr, visitor);
-                self.use_expr(b_expr, Read, visitor);
             }
 
             ExprWhile(cond_expr, ref blk) => {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -1990,6 +1990,7 @@ fn populate_scope_map(cx: &mut CrateContext,
         scope_map.insert(exp.id, scope_stack.last().scope_metadata);
 
         match exp.node {
+            ast::ExprLogLevel |
             ast::ExprSelf     |
             ast::ExprLit(_)   |
             ast::ExprBreak(_) |
@@ -2028,7 +2029,6 @@ fn populate_scope_map(cx: &mut CrateContext,
             }
 
             ast::ExprAssign(@ref sub_exp1, @ref sub_exp2)    |
-            ast::ExprLog(@ref sub_exp1, @ref sub_exp2)       |
             ast::ExprRepeat(@ref sub_exp1, @ref sub_exp2, _) => {
                 walk_expr(cx, sub_exp1, scope_stack, scope_map);
                 walk_expr(cx, sub_exp2, scope_stack, scope_map);

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -115,7 +115,8 @@ return type, such as `while` loops or assignments (`a = b`).
 
 
 use back::abi;
-use lib::llvm::{ValueRef, llvm, SetLinkage, ExternalLinkage};
+use back::link;
+use lib::llvm::{ValueRef, llvm, SetLinkage, ExternalLinkage, False};
 use lib;
 use metadata::csearch;
 use middle::trans::_match;
@@ -150,6 +151,7 @@ use std::hashmap::HashMap;
 use std::vec;
 use syntax::print::pprust::{expr_to_str};
 use syntax::ast;
+use syntax::ast_map::path_mod;
 use syntax::codemap;
 
 // Destinations
@@ -578,6 +580,9 @@ fn trans_rvalue_datum_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> DatumBloc
         ast::ExprParen(e) => {
             return trans_rvalue_datum_unadjusted(bcx, e);
         }
+        ast::ExprLogLevel => {
+            return trans_log_level(bcx);
+        }
         _ => {
             bcx.tcx().sess.span_bug(
                 expr.span,
@@ -607,9 +612,6 @@ fn trans_rvalue_stmt_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> @mut Block
         }
         ast::ExprRet(ex) => {
             return controlflow::trans_ret(bcx, ex);
-        }
-        ast::ExprLog(lvl, a) => {
-            return controlflow::trans_log(expr, lvl, bcx, a);
         }
         ast::ExprWhile(cond, ref body) => {
             return controlflow::trans_while(bcx, cond, body);
@@ -1754,4 +1756,42 @@ fn trans_assign_op(bcx: @mut Block,
 
 fn shorten(x: &str) -> @str {
     (if x.char_len() > 60 {x.slice_chars(0, 60)} else {x}).to_managed()
+}
+
+pub fn trans_log_level(bcx: @mut Block) -> DatumBlock {
+    let _icx = push_ctxt("trans_log_level");
+    let ccx = bcx.ccx();
+
+    let (modpath, modname) = {
+        let path = &mut bcx.fcx.path;
+        let mut modpath = ~[path_mod(ccx.sess.ident_of(ccx.link_meta.name))];
+        for e in path.iter() {
+            match *e {
+                path_mod(_) => { modpath.push(*e) }
+                _ => {}
+            }
+        }
+        let modname = path_str(ccx.sess, modpath);
+        (modpath, modname)
+    };
+
+    let global = if ccx.module_data.contains_key(&modname) {
+        ccx.module_data.get_copy(&modname)
+    } else {
+        let s = link::mangle_internal_name_by_path_and_seq(
+            ccx, modpath, "loglevel");
+        let global;
+        unsafe {
+            global = do s.with_c_str |buf| {
+                llvm::LLVMAddGlobal(ccx.llmod, Type::i32().to_ref(), buf)
+            };
+            llvm::LLVMSetGlobalConstant(global, False);
+            llvm::LLVMSetInitializer(global, C_null(Type::i32()));
+            lib::llvm::SetLinkage(global, lib::llvm::InternalLinkage);
+        }
+        ccx.module_data.insert(modname, global);
+        global
+    };
+
+    return immediate_rvalue_bcx(bcx, Load(bcx, global), ty::mk_u32());
 }

--- a/src/librustc/middle/trans/type_use.rs
+++ b/src/librustc/middle/trans/type_use.rs
@@ -377,9 +377,6 @@ pub fn mark_for_expr(cx: &Context, e: &Expr) {
         let base_ty = ty::node_id_to_type(cx.ccx.tcx, base.id);
         type_needs(cx, use_repr, ty::type_autoderef(cx.ccx.tcx, base_ty));
       }
-      ExprLog(_, val) => {
-        node_type_needs(cx, use_tydesc, val.id);
-      }
       ExprCall(f, _, _) => {
           let r = ty::ty_fn_args(ty::node_id_to_type(cx.ccx.tcx, f.id));
           for a in r.iter() {
@@ -411,7 +408,7 @@ pub fn mark_for_expr(cx: &Context, e: &Expr) {
       ExprMatch(*) | ExprBlock(_) | ExprIf(*) | ExprWhile(*) |
       ExprBreak(_) | ExprAgain(_) | ExprUnary(*) | ExprLit(_) |
       ExprMac(_) | ExprAddrOf(*) | ExprRet(_) | ExprLoop(*) |
-      ExprDoBody(_) => (),
+      ExprDoBody(_) | ExprLogLevel => (),
 
       ExprForLoop(*) => fail!("non-desugared expr_for_loop")
     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3320,7 +3320,6 @@ pub fn expr_kind(tcx: ctxt,
         ast::ExprBreak(*) |
         ast::ExprAgain(*) |
         ast::ExprRet(*) |
-        ast::ExprLog(*) |
         ast::ExprWhile(*) |
         ast::ExprLoop(*) |
         ast::ExprAssign(*) |
@@ -3331,6 +3330,7 @@ pub fn expr_kind(tcx: ctxt,
 
         ast::ExprForLoop(*) => fail!("non-desugared expr_for_loop"),
 
+        ast::ExprLogLevel |
         ast::ExprLit(_) | // Note: lit_str is carved out above
         ast::ExprUnary(*) |
         ast::ExprAddrOf(*) |

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2526,18 +2526,8 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         }
         fcx.write_bot(id);
       }
-      ast::ExprLog(lv, e) => {
-        check_expr_has_type(fcx, lv,
-                                  ty::mk_mach_uint(ast::ty_u32));
-
-        // Note: this does not always execute, so do not propagate bot:
-        check_expr(fcx, e);
-        if ty::type_is_error(fcx.expr_ty(e)) {
-            fcx.write_error(id);
-        }
-        else {
-            fcx.write_nil(id);
-        }
+      ast::ExprLogLevel => {
+        fcx.write_ty(id, ty::mk_u32())
       }
       ast::ExprParen(a) => {
         check_expr_with_opt_hint(fcx, a, expected);

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -1020,7 +1020,7 @@ pub mod guarantor {
             ast::ExprBreak(*) |
             ast::ExprAgain(*) |
             ast::ExprRet(*) |
-            ast::ExprLog(*) |
+            ast::ExprLogLevel |
             ast::ExprWhile(*) |
             ast::ExprLoop(*) |
             ast::ExprAssign(*) |

--- a/src/libstd/logging.rs
+++ b/src/libstd/logging.rs
@@ -37,7 +37,7 @@ pub fn console_off() {
     rt::logging::console_off();
 }
 
-#[cfg(not(test))]
+#[cfg(not(test), stage0)]
 #[lang="log_type"]
 #[allow(missing_doc)]
 pub fn log_type<T>(_level: u32, object: &T) {
@@ -66,4 +66,11 @@ fn newsched_log_str(msg: ~str) {
             }
         }
     }
+}
+
+// XXX: This will change soon to not require an allocation. This is an unstable
+//      api which should not be used outside of the macros in ext/expand.
+#[doc(hidden)]
+pub fn log(_level: u32, msg: ~str) {
+    newsched_log_str(msg);
 }

--- a/src/libstd/std.rs
+++ b/src/libstd/std.rs
@@ -218,6 +218,7 @@ mod std {
     pub use option;
     pub use kinds;
     pub use local_data;
+    pub use logging;
     pub use sys;
     pub use unstable;
     pub use str;

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -505,7 +505,9 @@ pub enum Expr_ {
     ExprBreak(Option<Ident>),
     ExprAgain(Option<Ident>),
     ExprRet(Option<@Expr>),
-    ExprLog(@Expr, @Expr),
+
+    /// Gets the log level for the enclosing module
+    ExprLogLevel,
 
     ExprInlineAsm(inline_asm),
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -740,59 +740,41 @@ pub fn std_macros() -> @str {
 
     macro_rules! ignore (($($x:tt)*) => (()))
 
-    macro_rules! error (
-        ($arg:expr) => (
-            __log(1u32, fmt!( \"%?\", $arg ))
-        );
-        ($( $arg:expr ),+) => (
-            __log(1u32, fmt!( $($arg),+ ))
-        )
+    macro_rules! log(
+        ($lvl:expr, $arg:expr) => ({
+            let lvl = $lvl;
+            if lvl <= __log_level() {
+                ::std::logging::log(lvl, fmt!(\"%?\", $arg))
+            }
+        });
+        ($lvl:expr, $($arg:expr),+) => ({
+            let lvl = $lvl;
+            if lvl <= __log_level() {
+                ::std::logging::log(lvl, fmt!($($arg),+))
+            }
+        })
     )
+    macro_rules! error( ($($arg:tt)+) => (log!(1u32, $($arg)+)) )
+    macro_rules! warn ( ($($arg:tt)+) => (log!(2u32, $($arg)+)) )
+    macro_rules! info ( ($($arg:tt)+) => (log!(3u32, $($arg)+)) )
+    macro_rules! debug( ($($arg:tt)+) => (
+        if cfg!(debug) { log!(4u32, $($arg)+) }
+    ))
 
-    macro_rules! warn (
-        ($arg:expr) => (
-            __log(2u32, fmt!( \"%?\", $arg ))
-        );
-        ($( $arg:expr ),+) => (
-            __log(2u32, fmt!( $($arg),+ ))
-        )
+    macro_rules! log2(
+        ($lvl:expr, $($arg:tt)+) => ({
+            let lvl = $lvl;
+            if lvl <= __log_level() {
+                ::std::logging::log(lvl, format!($($arg)+))
+            }
+        })
     )
-
-    macro_rules! info (
-        ($arg:expr) => (
-            __log(3u32, fmt!( \"%?\", $arg ))
-        );
-        ($( $arg:expr ),+) => (
-            __log(3u32, fmt!( $($arg),+ ))
-        )
-    )
-
-    macro_rules! debug (
-        ($arg:expr) => (
-            if cfg!(debug) { __log(4u32, fmt!( \"%?\", $arg )) }
-        );
-        ($( $arg:expr ),+) => (
-            if cfg!(debug) { __log(4u32, fmt!( $($arg),+ )) }
-        )
-    )
-
-    macro_rules! error2 (
-        ($($arg:tt)*) => ( __log(1u32, format!($($arg)*)))
-    )
-
-    macro_rules! warn2 (
-        ($($arg:tt)*) => ( __log(2u32, format!($($arg)*)))
-    )
-
-    macro_rules! info2 (
-        ($($arg:tt)*) => ( __log(3u32, format!($($arg)*)))
-    )
-
-    macro_rules! debug2 (
-        ($($arg:tt)*) => (
-            if cfg!(debug) { __log(4u32, format!($($arg)*)) }
-        )
-    )
+    macro_rules! error2( ($($arg:tt)+) => (log2!(1u32, $($arg)+)) )
+    macro_rules! warn2 ( ($($arg:tt)+) => (log2!(2u32, $($arg)+)) )
+    macro_rules! info2 ( ($($arg:tt)+) => (log2!(3u32, $($arg)+)) )
+    macro_rules! debug2( ($($arg:tt)+) => (
+        if cfg!(debug) { log2!(4u32, $($arg)+) }
+    ))
 
     macro_rules! fail(
         () => (
@@ -989,13 +971,13 @@ pub fn std_macros() -> @str {
     //              allocation but should rather delegate to an invocation of
     //              write! instead of format!
     macro_rules! print (
-        ($($arg:tt)+) => ( ::std::io::print(format!($($arg)+)))
+        ($($arg:tt)+) => (::std::io::print(format!($($arg)+)))
     )
 
     // FIXME(#6846) once stdio is redesigned, this shouldn't perform an
     //              allocation but should rather delegate to an io::Writer
     macro_rules! println (
-        ($($arg:tt)+) => ({ print!($($arg)+); ::std::io::println(\"\"); })
+        ($($arg:tt)+) => (::std::io::println(format!($($arg)+)))
     )
 
     // NOTE: use this after a snapshot lands to abstract the details

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -616,12 +616,7 @@ pub fn noop_fold_expr(e: &Expr_, fld: @ast_fold) -> Expr_ {
         ExprRet(ref e) => {
             ExprRet(e.map_move(|x| fld.fold_expr(x)))
         }
-        ExprLog(lv, e) => {
-            ExprLog(
-                fld.fold_expr(lv),
-                fld.fold_expr(e)
-            )
-        }
+        ExprLogLevel => ExprLogLevel,
         ExprInlineAsm(ref a) => {
             ExprInlineAsm(inline_asm {
                 inputs: a.inputs.map(|&(c, input)| (c, fld.fold_expr(input))),

--- a/src/libsyntax/oldvisit.rs
+++ b/src/libsyntax/oldvisit.rs
@@ -567,10 +567,7 @@ pub fn visit_expr<E:Clone>(ex: @Expr, (e, v): (E, vt<E>)) {
         ExprBreak(_) => (),
         ExprAgain(_) => (),
         ExprRet(eo) => visit_expr_opt(eo, (e.clone(), v)),
-        ExprLog(lv, x) => {
-            (v.visit_expr)(lv, (e.clone(), v));
-            (v.visit_expr)(x, (e.clone(), v));
-        }
+        ExprLogLevel => (),
         ExprMac(ref mac) => visit_mac(mac, (e.clone(), v)),
         ExprParen(x) => (v.visit_expr)(x, (e.clone(), v)),
         ExprInlineAsm(ref a) => {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -26,7 +26,7 @@ use ast::{Expr, Expr_, ExprAddrOf, ExprMatch, ExprAgain};
 use ast::{ExprAssign, ExprAssignOp, ExprBinary, ExprBlock};
 use ast::{ExprBreak, ExprCall, ExprCast, ExprDoBody};
 use ast::{ExprField, ExprFnBlock, ExprIf, ExprIndex};
-use ast::{ExprLit, ExprLog, ExprLoop, ExprMac};
+use ast::{ExprLit, ExprLogLevel, ExprLoop, ExprMac};
 use ast::{ExprMethodCall, ExprParen, ExprPath, ExprRepeat};
 use ast::{ExprRet, ExprSelf, ExprStruct, ExprTup, ExprUnary};
 use ast::{ExprVec, ExprVstore, ExprVstoreMutBox};
@@ -1827,13 +1827,10 @@ impl Parser {
                 }
             }
             hi = self.last_span.hi;
-        } else if self.eat_keyword(keywords::__Log) {
-            // LOG expression
+        } else if self.eat_keyword(keywords::__LogLevel) {
+            // LOG LEVEL expression
             self.expect(&token::LPAREN);
-            let lvl = self.parse_expr();
-            self.expect(&token::COMMA);
-            let e = self.parse_expr();
-            ex = ExprLog(lvl, e);
+            ex = ExprLogLevel;
             hi = self.span.hi;
             self.expect(&token::RPAREN);
         } else if self.eat_keyword(keywords::Return) {

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -457,7 +457,7 @@ fn mk_fresh_ident_interner() -> @ident_interner {
         "if",                 // 42
         "impl",               // 43
         "let",                // 44
-        "__log",              // 45
+        "__log_level",        // 45
         "loop",               // 46
         "match",              // 47
         "mod",                // 48
@@ -583,7 +583,7 @@ pub mod keywords {
         Impl,
         In,
         Let,
-        __Log,
+        __LogLevel,
         Loop,
         Match,
         Mod,
@@ -628,7 +628,7 @@ pub mod keywords {
                 Impl => Ident { name: 43, ctxt: 0 },
                 In => Ident { name: 63, ctxt: 0 },
                 Let => Ident { name: 44, ctxt: 0 },
-                __Log => Ident { name: 45, ctxt: 0 },
+                __LogLevel => Ident { name: 45, ctxt: 0 },
                 Loop => Ident { name: 46, ctxt: 0 },
                 Match => Ident { name: 47, ctxt: 0 },
                 Mod => Ident { name: 48, ctxt: 0 },

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1407,13 +1407,9 @@ pub fn print_expr(s: @ps, expr: &ast::Expr) {
           _ => ()
         }
       }
-      ast::ExprLog(lexp, expr) => {
-        word(s.s, "__log");
+      ast::ExprLogLevel => {
+        word(s.s, "__log_level");
         popen(s);
-        print_expr(s, lexp);
-        word(s.s, ",");
-        space_if_not_bol(s);
-        print_expr(s, expr);
         pclose(s);
       }
       ast::ExprInlineAsm(ref a) => {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -643,10 +643,7 @@ pub fn walk_expr<E:Clone, V:Visitor<E>>(visitor: &mut V, expression: @Expr, env:
         ExprRet(optional_expression) => {
             walk_expr_opt(visitor, optional_expression, env.clone())
         }
-        ExprLog(level, subexpression) => {
-            visitor.visit_expr(level, env.clone());
-            visitor.visit_expr(subexpression, env.clone());
-        }
+        ExprLogLevel => {}
         ExprMac(ref macro) => walk_mac(visitor, macro, env.clone()),
         ExprParen(subexpression) => {
             visitor.visit_expr(subexpression, env.clone())


### PR DESCRIPTION
Also redefine all of the standard logging macros to use more rust code instead
of custom LLVM translation code. This makes them a bit easier to understand, but
also more flexibile for future types of logging.

Additionally, this commit removes the LogType language item in preparation for
changing how logging is performed.
