### PR TITLE
Un-hork the bots by removing intermediate files

### DIFF
--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -50,7 +50,7 @@ clean-misc:
 	$(Q)rm -f $(RUSTLLVM_LIB_OBJS) $(RUSTLLVM_OBJS_OBJS) $(RUSTLLVM_DEF)
 	$(Q)rm -Rf $(DOCS)
 	$(Q)rm -Rf $(GENERATED)
-	$(Q)rm -f tmp/*
+	$(Q)rm -Rf tmp/*
 	$(Q)rm -Rf rust-stage0-*.tar.bz2 $(PKG_NAME)-*.tar.gz dist
 	$(Q)rm -Rf $(foreach ext, \
                  html aux cp fn ky log pdf pg toc tp vr cps, \


### PR DESCRIPTION
The new glob tests created tmp/glob-tests as a directory, but the never removed
it. The `make clean` target then attempted to `rm -f` on this, but it couldn't
remove the directory. This both changes the clean target to `rm -rf` tmp files,
and also alters the tests to delete the directory that all the files are added
into.
