### PR TITLE
Be sure to reconfigure LLVM even when relocated

### DIFF
--- a/configure
+++ b/configure
@@ -823,7 +823,7 @@ do
         index2="${CFG_SRC_DIR}src/llvm/.git/index"
         for index in ${index1} ${index2}
         do
-            config_status="${CFG_BUILD_DIR}llvm/$t/config.status"
+            config_status="${LLVM_BUILD_DIR}/config.status"
             if test -e ${index} -a \
                     -e ${config_status} -a \
                     ${config_status} -nt ${index}


### PR DESCRIPTION
@Chris-Morgan ran into this, turns out if we have a clean llvm in the old location we won't rebuild/reconfigure even though we should.
