### PR TITLE
rt: Treat empty RUST_THREADS env as unset

### DIFF
--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -733,7 +733,7 @@ fn run_tests(opts: &TestOpts,
 
 fn get_concurrency() -> uint {
     use std::rt;
-    match os::getenv("RUST_TEST_TASKS") {
+    match os::getenv("RUST_TEST_TASKS").filtered(|s| !s.is_empty()) {
         Some(s) => {
             let opt_n: Option<uint> = FromStr::from_str(s);
             match opt_n {

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -56,7 +56,7 @@ pub fn limit_thread_creation_due_to_osx_and_valgrind() -> bool {
 /// Get's the number of scheduler threads requested by the environment
 /// either `RUST_THREADS` or `num_cpus`.
 pub fn default_sched_threads() -> uint {
-    match os::getenv("RUST_THREADS") {
+    match os::getenv("RUST_THREADS").filtered(|s| !s.is_empty()) {
         Some(nstr) => {
             let opt_n: Option<uint> = FromStr::from_str(nstr);
             match opt_n {

--- a/src/test/run-pass/rust-threads-empty.rs
+++ b/src/test/run-pass/rust-threads-empty.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This checks that empty but set RUST_THREADS is accepted
+
+// exec-env:RUST_THREADS=
+
+fn main() {}


### PR DESCRIPTION
It's a bit nasty to abort on RUST_THREADS= ./program

The same change for RUST_TEST_TASKS in libextra/test.rs too.
