### PR TITLE
Give the libuv makefile generation a dependency

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -176,7 +176,7 @@ LIBUV_NO_LOAD = run-benchmarks.target.mk run-tests.target.mk \
 
 export PYTHONPATH := $(PYTHONPATH):$$(S)src/gyp/pylib
 
-$$(LIBUV_MAKEFILE_$(1)_$(2)):
+$$(LIBUV_MAKEFILE_$(1)_$(2)): $$(LIBUV_DEPS)
 	(cd $(S)src/libuv/ && \
 	 ./gyp_uv -f make -Dtarget_arch=$$(LIBUV_ARCH_$(1)) -D ninja \
 	   -Goutput_dir=$$(@D) --generator-output $$(@D))


### PR DESCRIPTION
This way the rule isn't always built whenever you fire off a new build
