### PR TITLE
Remove even more usage of clownshoes in symbols

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1063,12 +1063,13 @@ fn encode_info_for_item(ecx: &EncodeContext,
             let impl_vtables = ty::lookup_impl_vtables(tcx, def_id);
             encode_impl_vtables(ebml_w, ecx, &impl_vtables);
         }
-        encode_path(ecx, ebml_w, path, ast_map::path_name(item.ident));
+        let elt = ast_map::impl_pretty_name(opt_trait, ty, item.ident);
+        encode_path(ecx, ebml_w, path, elt);
         ebml_w.end_tag();
 
         // >:-<
         let mut impl_path = vec::append(~[], path);
-        impl_path.push(ast_map::path_name(item.ident));
+        impl_path.push(elt);
 
         // Iterate down the methods, emitting them. We rely on the
         // assumption that all of the actually implemented methods

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -39,15 +39,17 @@ use std::hashmap::{HashMap};
 use std::libc::{c_uint, c_longlong, c_ulonglong, c_char};
 use std::vec;
 use syntax::ast::Ident;
-use syntax::ast_map::{path, path_elt};
+use syntax::ast_map::{path, path_elt, path_pretty_name};
 use syntax::codemap::Span;
 use syntax::parse::token;
 use syntax::{ast, ast_map};
 
 pub use middle::trans::context::CrateContext;
 
-pub fn gensym_name(name: &str) -> Ident {
-    token::str_to_ident(fmt!("%s_%u", name, token::gensym(name)))
+pub fn gensym_name(name: &str) -> (Ident, path_elt) {
+    let name = token::gensym(name);
+    let ident = Ident::new(name);
+    (ident, path_pretty_name(ident, name as u64))
 }
 
 pub struct tydesc_info {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -69,6 +69,7 @@ use std::ptr;
 use std::vec;
 use syntax::codemap::Span;
 use syntax::{ast, codemap, ast_util, ast_map, opt_vec};
+use syntax::parse::token;
 use syntax::parse::token::special_idents;
 
 static DW_LANG_RUST: c_uint = 0x9000;
@@ -513,7 +514,8 @@ pub fn create_function_debug_context(cx: &mut CrateContext,
         ast_map::node_expr(ref expr) => {
             match expr.node {
                 ast::ExprFnBlock(ref fn_decl, ref top_level_block) => {
-                    let name = gensym_name("fn");
+                    let name = fmt!("fn%u", token::gensym("fn"));
+                    let name = token::str_to_ident(name);
                     (name, fn_decl,
                         // This is not quite right. It should actually inherit the generics of the
                         // enclosing function.

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -37,6 +37,7 @@ use std::vec;
 use syntax::ast_map::{path, path_mod, path_name, path_pretty_name};
 use syntax::ast_util;
 use syntax::{ast, ast_map};
+use syntax::parse::token;
 use syntax::visit;
 
 /**
@@ -568,8 +569,8 @@ pub fn make_vtable(ccx: &mut CrateContext,
         }
 
         let tbl = C_struct(components);
-        let vtable = ccx.sess.str_of(gensym_name("vtable"));
-        let vt_gvar = do vtable.with_c_str |buf| {
+        let sym = token::gensym("vtable");
+        let vt_gvar = do fmt!("vtable%u", sym).with_c_str |buf| {
             llvm::LLVMAddGlobal(ccx.llmod, val_ty(tbl).to_ref(), buf)
         };
         llvm::LLVMSetInitializer(vt_gvar, tbl);

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -31,7 +31,6 @@ use util::ppaux::{Repr,ty_to_str};
 
 use syntax::ast;
 use syntax::ast_map;
-use syntax::ast_map::path_name;
 use syntax::ast_util::local_def;
 
 pub fn monomorphic_fn(ccx: @mut CrateContext,
@@ -194,7 +193,7 @@ pub fn monomorphic_fn(ccx: @mut CrateContext,
     }
     ccx.monomorphizing.insert(fn_id, depth + 1);
 
-    let elt = path_name(gensym_name(ccx.sess.str_of(name)));
+    let (_, elt) = gensym_name(ccx.sess.str_of(name));
     let mut pt = (*pt).clone();
     pt.push(elt);
     let s = mangle_exported_name(ccx, pt.clone(), mono_ty);

--- a/src/test/compile-fail/ambig_impl_2_exe.rs
+++ b/src/test/compile-fail/ambig_impl_2_exe.rs
@@ -17,4 +17,4 @@ trait me {
 }
 impl me for uint { fn me(&self) -> uint { *self } } //~ NOTE is `me$uint::me`
 fn main() { 1u.me(); } //~ ERROR multiple applicable methods in scope
-//~^ NOTE is `ambig_impl_2_lib::__extensions__::me`
+//~^ NOTE is `ambig_impl_2_lib::me$uint::me`


### PR DESCRIPTION
This removes another large chunk of this odd 'clownshoes' identifier showing up
in symbol names. These all originated from external crates because the encoded
items were encoded independently of the paths calculated in ast_map. The
encoding of these paths now uses the helper function in ast_map to calculate the
"pretty name" for an impl block.

Unfortunately there is still no information about generics in the symbol name,
but it's certainly vastly better than before

```
hash::__extensions__::write::_version::v0.8
```

becomes

```
hash::Writer$SipState::write::hversion::v0.8
```

This also fixes bugs in which lots of methods would show up as `meth_XXX`, they
now only show up as `meth` and throw some extra characters onto the version
string.
