### PR TITLE
call fns in __morestack via PLT on Linux/FreeBSD

### DIFF
--- a/src/rt/arch/i386/morestack.S
+++ b/src/rt/arch/i386/morestack.S
@@ -160,7 +160,13 @@ MORESTACK:
 
 	// FIXME (1226): main is compiled with the split-stack prologue,
 	// causing it to call __morestack, so we have to jump back out
+
+#if defined(__linux__) || defined(__FreeBSD__)
+	calll RUST_GET_TASK@PLT
+#else
 	calll RUST_GET_TASK
+#endif
+
 	testl %eax,%eax
 	jz .L$bail
 
@@ -178,7 +184,11 @@ MORESTACK:
 	movl 36(%esp),%eax // The amount of stack needed
 	movl %eax,(%esp)
 
+#if defined(__linux__) || defined(__FreeBSD__)
+	call UPCALL_NEW_STACK@PLT
+#else
 	call UPCALL_NEW_STACK
+#endif
 
 	// Save the address of the new stack
 	movl %eax, (%esp)
@@ -210,7 +220,11 @@ MORESTACK:
 	movl %edx, 4(%esp)
 	movl %eax, (%esp)
 
+#if defined(__linux__) || defined(__FreeBSD__)
+	call UPCALL_DEL_STACK@PLT
+#else
 	call UPCALL_DEL_STACK
+#endif
 
 	// And restore it
 	movl (%esp), %eax

--- a/src/rt/arch/x86_64/morestack.S
+++ b/src/rt/arch/x86_64/morestack.S
@@ -76,14 +76,10 @@ MORESTACK:
 	movq %rax, %rsi // Address of stack arguments
 	movq %r10, %rdi // The amount of stack needed
 
-#ifdef __APPLE__
+#if defined(__linux__) || defined(__FreeBSD__)
+	call UPCALL_NEW_STACK@PLT
+#else
 	call UPCALL_NEW_STACK
-#endif
-#ifdef __linux__
-	call UPCALL_NEW_STACK@PLT
-#endif
-#ifdef __FreeBSD__
-	call UPCALL_NEW_STACK@PLT
 #endif
 
 	// Pop the saved arguments
@@ -108,14 +104,10 @@ MORESTACK:
 	// Save the return value
 	pushq %rax
 
-#ifdef __APPLE__
+#if defined(__linux__) || defined(__FreeBSD__)
+	call UPCALL_DEL_STACK@PLT
+#else
 	call UPCALL_DEL_STACK
-#endif
-#ifdef __linux__
-	call UPCALL_DEL_STACK@PLT
-#endif
-#ifdef __FreeBSD__
-	call UPCALL_DEL_STACK@PLT
 #endif
 
 	popq %rax // Restore the return value


### PR DESCRIPTION
Closes #5714

(not a big deal since these aren't used at the moment, but should be fixed for when we have `__morestack` on again assuming some/all of the ASM is reused)
