### PR TITLE
Remove and cleanup functions in std::vec

### DIFF
--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -315,11 +315,8 @@ mod test {
         use std::vec;
 
         do 1000.times {
-            let v: ~[u8] = do vec::build |push| {
-                do task_rng().gen_uint_range(1, 100).times {
-                    push(random());
-                }
-            };
+            let times = task_rng().gen_uint_range(1, 100);
+            let v = vec::from_fn(times, |_| random::<u8>());
             assert_eq!(v.to_base64(STANDARD).from_base64().unwrap(), v);
         }
     }

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -88,7 +88,7 @@ pub trait Combine {
         // future we could allow type parameters to declare a
         // variance.
 
-        if vec::same_length(as_, bs) {
+        if as_.len() == bs.len() {
             result::fold_(as_.iter().zip(bs.iter())
                           .map(|(a, b)| eq_tys(self, *a, *b)))
                 .then(|| Ok(as_.to_owned()))
@@ -419,7 +419,7 @@ pub fn super_fn_sigs<C:Combine>(
     this: &C, a: &ty::FnSig, b: &ty::FnSig) -> cres<ty::FnSig> {
 
     fn argvecs<C:Combine>(this: &C, a_args: &[ty::t], b_args: &[ty::t]) -> cres<~[ty::t]> {
-        if vec::same_length(a_args, b_args) {
+        if a_args.len() == b_args.len() {
             result::collect(a_args.iter().zip(b_args.iter())
                             .map(|(a, b)| this.args(*a, *b)))
         } else {

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -61,7 +61,6 @@ use middle::typeck::infer::{TypeTrace};
 use util::common::indent;
 
 use std::result;
-use std::vec;
 use syntax::ast::{Onceness, purity};
 use syntax::ast;
 use syntax::opt_vec;

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -373,14 +373,12 @@ impl RegionVarBindings {
 
     pub fn vars_created_since_snapshot(&mut self, snapshot: uint)
                                        -> ~[RegionVid] {
-        do vec::build |push| {
-            for &elt in self.undo_log.slice_from(snapshot).iter() {
-                match elt {
-                    AddVar(vid) => push(vid),
-                    _ => ()
-                }
-            }
-        }
+        self.undo_log.slice_from(snapshot).iter()
+            .filter_map(|&elt| match elt {
+                AddVar(vid) => Some(vid),
+                _ => None
+            })
+            .collect()
     }
 
     pub fn tainted(&mut self, snapshot: uint, r0: Region) -> ~[Region] {

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -112,7 +112,7 @@ pub fn parse_config_(
     process_output: Process
 ) -> Result<Config, ~str> {
     let args = args.tail();
-    let opts = vec::unzip(opts()).first();
+    let opts = vec::unzip(opts().move_iter()).first();
     match getopts::getopts(args, opts) {
         Ok(matches) => {
             if matches.free.len() == 1 {

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -777,7 +777,7 @@ impl<T:Reader> ReaderUtil for T {
     }
 
     fn read_lines(&self) -> ~[~str] {
-        do vec::build |push| {
+        do vec::build(None) |push| {
             do self.each_line |line| {
                 push(line.to_owned());
                 true

--- a/src/libstd/select.rs
+++ b/src/libstd/select.rs
@@ -148,7 +148,7 @@ mod test {
         // Unfortunately this does not actually test the block_on early-break
         // codepath in select -- racing between the sender and the receiver in
         // separate tasks is necessary to get around the optimistic check.
-        let (ports, chans) = unzip(from_fn(num_ports, |_| oneshot::<()>()));
+        let (ports, chans) = unzip(range(0, num_ports).map(|_| oneshot::<()>()));
         let mut dead_chans = ~[];
         let mut ports = ports;
         for (i, chan) in chans.move_iter().enumerate() {
@@ -165,7 +165,7 @@ mod test {
 
         // Same thing with streams instead.
         // FIXME(#7971): This should be in a macro but borrowck isn't smart enough.
-        let (ports, chans) = unzip(from_fn(num_ports, |_| stream::<()>()));
+        let (ports, chans) = unzip(range(0, num_ports).map(|_| stream::<()>()));
         let mut dead_chans = ~[];
         let mut ports = ports;
         for (i, chan) in chans.move_iter().enumerate() {
@@ -209,7 +209,7 @@ mod test {
         // Sends 10 buffered packets, and uses select to retrieve them all.
         // Puts the port in a different spot in the vector each time.
         do run_in_newsched_task {
-            let (ports, _) = unzip(from_fn(10, |_| stream()));
+            let (ports, _) = unzip(range(0u, 10).map(|_| stream::<int>()));
             let (port, chan) = stream();
             do 10.times { chan.send(31337); }
             let mut ports = ports;
@@ -327,7 +327,7 @@ mod test {
                     let (p,c) = oneshot();
                     let c = Cell::new(c);
                     do task::spawn {
-                        let (dead_ps, dead_cs) = unzip(from_fn(5, |_| oneshot::<()>()));
+                        let (dead_ps, dead_cs) = unzip(range(0u, 5).map(|_| oneshot::<()>()));
                         let mut ports = dead_ps;
                         select(ports); // should get killed; nothing should leak
                         c.take().send(()); // must not happen

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -123,11 +123,6 @@ use unstable::raw::{Box, Repr, Slice, Vec};
 use vec;
 use util;
 
-/// Returns true if two vectors have the same length
-pub fn same_length<T, U>(xs: &[T], ys: &[U]) -> bool {
-    xs.len() == ys.len()
-}
-
 /**
  * Creates and initializes an owned vector.
  *

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -389,37 +389,19 @@ impl<'self,T:Clone> VectorVector<T> for &'self [&'self [T]] {
     }
 }
 
-// FIXME: if issue #586 gets implemented, could have a postcondition
-// saying the two result lists have the same length -- or, could
-// return a nominal record with a constraint saying that, instead of
-// returning a tuple (contingent on issue #869)
 /**
- * Convert a vector of pairs into a pair of vectors, by reference. As unzip().
- */
-pub fn unzip_slice<T:Clone,U:Clone>(v: &[(T, U)]) -> (~[T], ~[U]) {
-    let mut ts = ~[];
-    let mut us = ~[];
-    for p in v.iter() {
-        let (t, u) = (*p).clone();
-        ts.push(t);
-        us.push(u);
-    }
-    (ts, us)
-}
-
-/**
- * Convert a vector of pairs into a pair of vectors.
+ * Convert an iterator of pairs into a pair of vectors.
  *
  * Returns a tuple containing two vectors where the i-th element of the first
- * vector contains the first element of the i-th tuple of the input vector,
+ * vector contains the first element of the i-th tuple of the input iterator,
  * and the i-th element of the second vector contains the second element
- * of the i-th tuple of the input vector.
+ * of the i-th tuple of the input iterator.
  */
-pub fn unzip<T,U>(v: ~[(T, U)]) -> (~[T], ~[U]) {
-    let mut ts = ~[];
-    let mut us = ~[];
-    for p in v.move_iter() {
-        let (t, u) = p;
+pub fn unzip<T, U, V: Iterator<(T, U)>>(mut iter: V) -> (~[T], ~[U]) {
+    let (lo, _) = iter.size_hint();
+    let mut ts = with_capacity(lo);
+    let mut us = with_capacity(lo);
+    for (t, u) in iter {
         ts.push(t);
         us.push(u);
     }
@@ -2891,7 +2873,7 @@ mod tests {
     fn test_zip_unzip() {
         let z1 = ~[(1, 4), (2, 5), (3, 6)];
 
-        let (left, right) = unzip(z1);
+        let (left, right) = unzip(z1.iter().map(|&x| x));
 
         assert_eq!((1, 4), (left[0], right[0]));
         assert_eq!((2, 5), (left[1], right[1]));

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -10,8 +10,9 @@
 
 /*!
 
-The `vec` module contains useful code to help work with vector values. Vectors are Rust's list
-type. Vectors contain zero or more values of homogeneous types:
+The `vec` module contains useful code to help work with vector values.
+Vectors are Rust's list type. Vectors contain zero or more values of
+homogeneous types:
 
 ~~~ {.rust}
 let int_vector = [1,2,3];
@@ -27,32 +28,72 @@ represents iteration over a vector.
 
 ## Traits
 
-A number of traits that allow you to accomplish tasks with vectors, like the
-`MutableVector` and `ImmutableVector` traits.
+A number of traits add methods that allow you to accomplish tasks with vectors.
+
+Traits defined for the `&[T]` type (a vector slice), have methods that can be
+called on either owned vectors, denoted `~[T]`, or on vector slices themselves.
+These traits include `ImmutableVector`, and `MutableVector` for the `&mut [T]`
+case.
+
+An example is the method `.slice(a, b)` that returns an immutable "view" into
+a vector or a vector slice from the index interval `[a, b)`:
+
+~~~ {.rust}
+let numbers = [0, 1, 2];
+let last_numbers = numbers.slice(1, 3);
+// last_numbers is now &[1, 2]
+~~~
+
+Traits defined for the `~[T]` type, like `OwnedVector`, can only be called
+on such vectors. These methods deal with adding elements or otherwise changing
+the allocation of the vector.
+
+An example is the method `.push(element)` that will add an element at the end
+of the vector:
+
+~~~ {.rust}
+let mut numbers = ~[0, 1, 2];
+numbers.push(7);
+// numbers is now ~[0, 1, 2, 7];
+~~~
 
 ## Implementations of other traits
 
-Vectors are a very useful type, and so there's tons of implementations of
-traits found elsewhere. Some notable examples:
+Vectors are a very useful type, and so there's several implementations of
+traits from other modules. Some notable examples:
 
 * `Clone`
-* `Iterator`
-* `Zero`
+* `Eq`, `Ord`, `TotalEq`, `TotalOrd` -- vectors can be compared,
+  if the element type defines the corresponding trait.
+
+## Iteration
+
+The method `iter()` returns an iteration value for a vector or a vector slice.
+The iterator yields borrowed pointers to the vector's elements, so if the element
+type of the vector is `int`, the element type of the iterator is `&int`.
+
+~~~ {.rust}
+let numbers = [0, 1, 2];
+for &x in numbers.iter() {
+    println!("{} is a number!", x);
+}
+~~~
+
+* `.rev_iter()` returns an iterator with the same values as `.iter()`,
+  but going in the reverse order, starting with the back element.
+* `.mut_iter()` returns an iterator that allows modifying each value.
+* `.move_iter()` converts an owned vector into an iterator that
+  moves out a value from the vector each iteration.
+* Further iterators exist that split, chunk or permute the vector.
 
 ## Function definitions
 
-There are a number of different functions that take vectors, here are some
-broad categories:
+There are a number of free functions that create or take vectors, for example:
 
-* Modifying a vector, like `append` and `grow`.
-* Searching in a vector, like `bsearch`.
-* Iterating over vectors, like `each_permutation`.
-* Functional transformations on vectors, like `map` and `partition`.
-* Stack/queue operations, like `push`/`pop` and `shift`/`unshift`.
-* Cons-y operations, like `head` and `tail`.
-* Zipper operations, like `zip` and `unzip`.
-
-And much, much more.
+* Creating a vector, like `from_elem` and `from_fn`
+* Creating a vector with a given size: `with_capacity`
+* Modifying a vector and returning it, like `append`
+* Operations on paired elements, like `unzip`.
 
 */
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -194,41 +194,7 @@ pub fn with_capacity<T>(capacity: uint) -> ~[T] {
 /**
  * Builds a vector by calling a provided function with an argument
  * function that pushes an element to the back of a vector.
- * This version takes an initial capacity for the vector.
- *
- * # Arguments
- *
- * * size - An initial size of the vector to reserve
- * * builder - A function that will construct the vector. It receives
- *             as an argument a function that will push an element
- *             onto the vector being constructed.
- */
-#[inline]
-pub fn build_sized<A>(size: uint, builder: &fn(push: &fn(v: A))) -> ~[A] {
-    let mut vec = with_capacity(size);
-    builder(|x| vec.push(x));
-    vec
-}
-
-/**
- * Builds a vector by calling a provided function with an argument
- * function that pushes an element to the back of a vector.
- *
- * # Arguments
- *
- * * builder - A function that will construct the vector. It receives
- *             as an argument a function that will push an element
- *             onto the vector being constructed.
- */
-#[inline]
-pub fn build<A>(builder: &fn(push: &fn(v: A))) -> ~[A] {
-    build_sized(4, builder)
-}
-
-/**
- * Builds a vector by calling a provided function with an argument
- * function that pushes an element to the back of a vector.
- * This version takes an initial size for the vector.
+ * The initial capacity for the vector may optionally be specified.
  *
  * # Arguments
  *
@@ -238,8 +204,10 @@ pub fn build<A>(builder: &fn(push: &fn(v: A))) -> ~[A] {
  *             onto the vector being constructed.
  */
 #[inline]
-pub fn build_sized_opt<A>(size: Option<uint>, builder: &fn(push: &fn(v: A))) -> ~[A] {
-    build_sized(size.unwrap_or_default(4), builder)
+pub fn build<A>(size: Option<uint>, builder: &fn(push: &fn(v: A))) -> ~[A] {
+    let mut vec = with_capacity(size.unwrap_or_default(4));
+    builder(|x| vec.push(x));
+    vec
 }
 
 /// An iterator over the slices of a vector separated by elements that
@@ -3248,7 +3216,7 @@ mod tests {
     #[test]
     #[should_fail]
     fn test_build_fail() {
-        do build |push| {
+        do build(None) |push| {
             push((~0, @0));
             push((~0, @0));
             push((~0, @0));

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -958,7 +958,7 @@ fn create_struct_pattern(cx: @ExtCtxt,
     // struct_type is definitely not Unknown, since struct_def.fields
     // must be nonempty to reach here
     let pattern = if struct_type == Record {
-        let field_pats = do vec::build |push| {
+        let field_pats = do vec::build(None) |push| {
             for (&pat, &(id, _)) in subpats.iter().zip(ident_expr.iter()) {
                 // id is guaranteed to be Some
                 push(ast::FieldPat { ident: id.unwrap(), pat: pat })

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -66,7 +66,7 @@ impl Drop for AsciiArt {
 fn AsciiArt(width: uint, height: uint, fill: char) -> AsciiArt {
     // Use an anonymous function to build a vector of vectors containing
     // blank characters for each position in our canvas.
-    let lines = do vec::build_sized(height) |push| {
+    let lines = do vec::build(Some(height)) |push| {
             do height.times {
                 push(vec::from_elem(width, '.'));
             }


### PR DESCRIPTION
Visit the free functions of std::vec and reimplement or remove some. Most prominently, remove `each_permutation` and replace with two iterators, ElementSwaps and Permutations.

Replace unzip, unzip_slice with an updated `unzip` that works with an iterator argument.

Replace each_permutation with a Permutation iterator. The new permutation iterator is more efficient since it uses an algorithm that produces permutations in an order where each is only one element swap apart, including swapping back to the original state with one swap at the end.

Unify the seldomly used functions `build`, `build_sized`, `build_sized_opt` into just one function `build`.

Remove `equal_sizes`
