### PR TITLE
add `noalias` attribute to ~ return values

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -873,6 +873,12 @@ pub mod llvm {
         pub fn LLVMAddFunctionAttrString(Fn: ValueRef, Name: *c_char);
         #[fast_ffi]
         pub fn LLVMGetFunctionAttr(Fn: ValueRef) -> c_ulonglong;
+
+        #[fast_ffi]
+        pub fn LLVMAddReturnAttribute(Fn: ValueRef, PA: c_uint);
+        #[fast_ffi]
+        pub fn LLVMRemoveReturnAttribute(Fn: ValueRef, PA: c_uint);
+
         #[fast_ffi]
         pub fn LLVMRemoveFunctionAttr(Fn: ValueRef,
                                       PA: c_ulonglong,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -350,6 +350,21 @@ extern "C" void LLVMAddFunctionAttrString(LLVMValueRef fn, const char *Name) {
   unwrap<Function>(fn)->addFnAttr(Name);
 }
 
+
+extern "C" void LLVMAddReturnAttribute(LLVMValueRef Fn, LLVMAttribute PA) {
+  Function *A = unwrap<Function>(Fn);
+  AttrBuilder B(PA);
+  A->addAttributes(AttributeSet::ReturnIndex,
+                   AttributeSet::get(A->getContext(), AttributeSet::ReturnIndex,  B));
+}
+
+extern "C" void LLVMRemoveReturnAttribute(LLVMValueRef Fn, LLVMAttribute PA) {
+  Function *A = unwrap<Function>(Fn);
+  AttrBuilder B(PA);
+  A->removeAttributes(AttributeSet::ReturnIndex,
+                      AttributeSet::get(A->getContext(), AttributeSet::ReturnIndex,  B));
+}
+
 extern "C" LLVMValueRef LLVMBuildAtomicLoad(LLVMBuilderRef B,
                                             LLVMValueRef source,
                                             const char* Name,

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -624,3 +624,5 @@ LLVMRustSetLLVMOptions
 LLVMRustPrintPasses
 LLVMRustSetNormalizedTarget
 LLVMRustAddAlwaysInlinePass
+LLVMAddReturnAttribute
+LLVMRemoveReturnAttribute


### PR DESCRIPTION
This also removes a FIXME I added referring to a now closed issue.
