### PR TITLE
Delay assignment of node ids until after expansion

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -190,6 +190,9 @@ pub fn phase_2_configure_and_expand(sess: Session,
     crate = time(time_passes, ~"std injection", ||
                  front::std_inject::maybe_inject_libstd_ref(sess, crate));
 
+    crate = time(time_passes, ~"assigning node ids", ||
+                 front::assign_node_ids::assign_node_ids(sess, crate));
+
     return crate;
 }
 
@@ -207,6 +210,7 @@ pub fn phase_3_run_analysis_passes(sess: Session,
                                    crate: @ast::Crate) -> CrateAnalysis {
 
     let time_passes = sess.time_passes();
+
     let ast_map = time(time_passes, ~"ast indexing", ||
                        syntax::ast_map::map_crate(sess.diagnostic(), crate));
 
@@ -812,6 +816,7 @@ pub fn build_session_(sopts: @session::options,
         building_library: @mut false,
         working_dir: os::getcwd(),
         lints: @mut HashMap::new(),
+        node_id: @mut 1
     }
 }
 

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -28,6 +28,7 @@ use syntax::abi;
 use syntax::parse::token;
 use syntax;
 
+use std::int;
 use std::hashmap::HashMap;
 
 #[deriving(Eq)]
@@ -216,57 +217,58 @@ pub struct Session_ {
     building_library: @mut bool,
     working_dir: Path,
     lints: @mut HashMap<ast::NodeId, ~[(lint::lint, codemap::Span, ~str)]>,
+    node_id: @mut uint,
 }
 
 pub type Session = @Session_;
 
 impl Session_ {
-    pub fn span_fatal(@self, sp: Span, msg: &str) -> ! {
+    pub fn span_fatal(&self, sp: Span, msg: &str) -> ! {
         self.span_diagnostic.span_fatal(sp, msg)
     }
-    pub fn fatal(@self, msg: &str) -> ! {
+    pub fn fatal(&self, msg: &str) -> ! {
         self.span_diagnostic.handler().fatal(msg)
     }
-    pub fn span_err(@self, sp: Span, msg: &str) {
+    pub fn span_err(&self, sp: Span, msg: &str) {
         self.span_diagnostic.span_err(sp, msg)
     }
-    pub fn err(@self, msg: &str) {
+    pub fn err(&self, msg: &str) {
         self.span_diagnostic.handler().err(msg)
     }
-    pub fn err_count(@self) -> uint {
+    pub fn err_count(&self) -> uint {
         self.span_diagnostic.handler().err_count()
     }
-    pub fn has_errors(@self) -> bool {
+    pub fn has_errors(&self) -> bool {
         self.span_diagnostic.handler().has_errors()
     }
-    pub fn abort_if_errors(@self) {
+    pub fn abort_if_errors(&self) {
         self.span_diagnostic.handler().abort_if_errors()
     }
-    pub fn span_warn(@self, sp: Span, msg: &str) {
+    pub fn span_warn(&self, sp: Span, msg: &str) {
         self.span_diagnostic.span_warn(sp, msg)
     }
-    pub fn warn(@self, msg: &str) {
+    pub fn warn(&self, msg: &str) {
         self.span_diagnostic.handler().warn(msg)
     }
-    pub fn span_note(@self, sp: Span, msg: &str) {
+    pub fn span_note(&self, sp: Span, msg: &str) {
         self.span_diagnostic.span_note(sp, msg)
     }
-    pub fn note(@self, msg: &str) {
+    pub fn note(&self, msg: &str) {
         self.span_diagnostic.handler().note(msg)
     }
-    pub fn span_bug(@self, sp: Span, msg: &str) -> ! {
+    pub fn span_bug(&self, sp: Span, msg: &str) -> ! {
         self.span_diagnostic.span_bug(sp, msg)
     }
-    pub fn bug(@self, msg: &str) -> ! {
+    pub fn bug(&self, msg: &str) -> ! {
         self.span_diagnostic.handler().bug(msg)
     }
-    pub fn span_unimpl(@self, sp: Span, msg: &str) -> ! {
+    pub fn span_unimpl(&self, sp: Span, msg: &str) -> ! {
         self.span_diagnostic.span_unimpl(sp, msg)
     }
-    pub fn unimpl(@self, msg: &str) -> ! {
+    pub fn unimpl(&self, msg: &str) -> ! {
         self.span_diagnostic.handler().unimpl(msg)
     }
-    pub fn add_lint(@self,
+    pub fn add_lint(&self,
                     lint: lint::lint,
                     id: ast::NodeId,
                     sp: Span,
@@ -277,77 +279,85 @@ impl Session_ {
         }
         self.lints.insert(id, ~[(lint, sp, msg)]);
     }
-    pub fn next_node_id(@self) -> ast::NodeId {
-        return syntax::parse::next_node_id(self.parse_sess);
+    pub fn next_node_id(&self) -> ast::NodeId {
+        self.reserve_node_ids(1)
     }
-    pub fn diagnostic(@self) -> @mut diagnostic::span_handler {
+    pub fn reserve_node_ids(&self, count: uint) -> ast::NodeId {
+        let v = *self.node_id;
+        *self.node_id += count;
+        if v > (int::max_value as uint) {
+            self.bug("Input too large, ran out of node ids!");
+        }
+        v as int
+    }
+    pub fn diagnostic(&self) -> @mut diagnostic::span_handler {
         self.span_diagnostic
     }
-    pub fn debugging_opt(@self, opt: uint) -> bool {
+    pub fn debugging_opt(&self, opt: uint) -> bool {
         (self.opts.debugging_opts & opt) != 0u
     }
     // This exists to help with refactoring to eliminate impossible
     // cases later on
-    pub fn impossible_case(@self, sp: Span, msg: &str) -> ! {
+    pub fn impossible_case(&self, sp: Span, msg: &str) -> ! {
         self.span_bug(sp, fmt!("Impossible case reached: %s", msg));
     }
-    pub fn verbose(@self) -> bool { self.debugging_opt(verbose) }
-    pub fn time_passes(@self) -> bool { self.debugging_opt(time_passes) }
-    pub fn count_llvm_insns(@self) -> bool {
+    pub fn verbose(&self) -> bool { self.debugging_opt(verbose) }
+    pub fn time_passes(&self) -> bool { self.debugging_opt(time_passes) }
+    pub fn count_llvm_insns(&self) -> bool {
         self.debugging_opt(count_llvm_insns)
     }
-    pub fn count_type_sizes(@self) -> bool {
+    pub fn count_type_sizes(&self) -> bool {
         self.debugging_opt(count_type_sizes)
     }
-    pub fn time_llvm_passes(@self) -> bool {
+    pub fn time_llvm_passes(&self) -> bool {
         self.debugging_opt(time_llvm_passes)
     }
-    pub fn trans_stats(@self) -> bool { self.debugging_opt(trans_stats) }
-    pub fn meta_stats(@self) -> bool { self.debugging_opt(meta_stats) }
-    pub fn asm_comments(@self) -> bool { self.debugging_opt(asm_comments) }
-    pub fn no_verify(@self) -> bool { self.debugging_opt(no_verify) }
-    pub fn lint_llvm(@self) -> bool { self.debugging_opt(lint_llvm) }
-    pub fn trace(@self) -> bool { self.debugging_opt(trace) }
-    pub fn coherence(@self) -> bool { self.debugging_opt(coherence) }
-    pub fn borrowck_stats(@self) -> bool { self.debugging_opt(borrowck_stats) }
-    pub fn borrowck_note_pure(@self) -> bool {
+    pub fn trans_stats(&self) -> bool { self.debugging_opt(trans_stats) }
+    pub fn meta_stats(&self) -> bool { self.debugging_opt(meta_stats) }
+    pub fn asm_comments(&self) -> bool { self.debugging_opt(asm_comments) }
+    pub fn no_verify(&self) -> bool { self.debugging_opt(no_verify) }
+    pub fn lint_llvm(&self) -> bool { self.debugging_opt(lint_llvm) }
+    pub fn trace(&self) -> bool { self.debugging_opt(trace) }
+    pub fn coherence(&self) -> bool { self.debugging_opt(coherence) }
+    pub fn borrowck_stats(&self) -> bool { self.debugging_opt(borrowck_stats) }
+    pub fn borrowck_note_pure(&self) -> bool {
         self.debugging_opt(borrowck_note_pure)
     }
-    pub fn borrowck_note_loan(@self) -> bool {
+    pub fn borrowck_note_loan(&self) -> bool {
         self.debugging_opt(borrowck_note_loan)
     }
-    pub fn no_monomorphic_collapse(@self) -> bool {
+    pub fn no_monomorphic_collapse(&self) -> bool {
         self.debugging_opt(no_monomorphic_collapse)
     }
-    pub fn debug_borrows(@self) -> bool {
+    pub fn debug_borrows(&self) -> bool {
         self.opts.optimize == No && !self.debugging_opt(no_debug_borrows)
     }
-    pub fn once_fns(@self) -> bool { self.debugging_opt(once_fns) }
-    pub fn print_llvm_passes(@self) -> bool {
+    pub fn once_fns(&self) -> bool { self.debugging_opt(once_fns) }
+    pub fn print_llvm_passes(&self) -> bool {
         self.debugging_opt(print_llvm_passes)
     }
-    pub fn no_prepopulate_passes(@self) -> bool {
+    pub fn no_prepopulate_passes(&self) -> bool {
         self.debugging_opt(no_prepopulate_passes)
     }
-    pub fn no_vectorize_loops(@self) -> bool {
+    pub fn no_vectorize_loops(&self) -> bool {
         self.debugging_opt(no_vectorize_loops)
     }
-    pub fn no_vectorize_slp(@self) -> bool {
+    pub fn no_vectorize_slp(&self) -> bool {
         self.debugging_opt(no_vectorize_slp)
     }
 
     // pointless function, now...
-    pub fn str_of(@self, id: ast::Ident) -> @str {
+    pub fn str_of(&self, id: ast::Ident) -> @str {
         token::ident_to_str(&id)
     }
 
     // pointless function, now...
-    pub fn ident_of(@self, st: &str) -> ast::Ident {
+    pub fn ident_of(&self, st: &str) -> ast::Ident {
         token::str_to_ident(st)
     }
 
     // pointless function, now...
-    pub fn intr(@self) -> @syntax::parse::token::ident_interner {
+    pub fn intr(&self) -> @syntax::parse::token::ident_interner {
         token::get_ident_interner()
     }
 }

--- a/src/librustc/front/assign_node_ids.rs
+++ b/src/librustc/front/assign_node_ids.rs
@@ -1,0 +1,19 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use driver::session::Session;
+
+use syntax::ast;
+use syntax::ast_util;
+
+pub fn assign_node_ids(sess: Session, crate: @ast::Crate) -> @ast::Crate {
+    let fold = ast_util::node_id_assigner(|| sess.next_node_id());
+    @fold.fold_crate(crate)
+}

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -45,7 +45,7 @@ fn inject_libstd_ref(sess: Session, crate: &ast::Crate) -> @ast::Crate {
 
     let precursor = @fold::AstFoldFns {
         fold_crate: |crate, fld| {
-            let n1 = sess.next_node_id();
+            let n1 = ast::DUMMY_NODE_ID;
             let vi1 = ast::view_item {
                 node: ast::view_item_extern_mod(
                         sess.ident_of("std"), None, ~[], n1),
@@ -86,7 +86,7 @@ fn inject_libstd_ref(sess: Session, crate: &ast::Crate) -> @ast::Crate {
             }
         },
         fold_mod: |module, fld| {
-            let n2 = sess.next_node_id();
+            let n2 = ast::DUMMY_NODE_ID;
 
             let prelude_path = ast::Path {
                 span: dummy_sp(),

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -280,10 +280,10 @@ fn mk_std(cx: &TestCtxt) -> ast::view_item {
         ast::view_item_use(
             ~[@nospan(ast::view_path_simple(id_extra,
                                             path_node(~[id_extra]),
-                                            cx.sess.next_node_id()))])
+                                            ast::DUMMY_NODE_ID))])
     } else {
         let mi = attr::mk_name_value_item_str(@"vers", @"0.8-pre");
-        ast::view_item_extern_mod(id_extra, None, ~[mi], cx.sess.next_node_id())
+        ast::view_item_extern_mod(id_extra, None, ~[mi], ast::DUMMY_NODE_ID)
     };
     ast::view_item {
         node: vi,
@@ -325,7 +325,7 @@ fn mk_test_module(cx: &TestCtxt) -> @ast::item {
     let item = ast::item {
         ident: cx.sess.ident_of("__test"),
         attrs: ~[resolve_unexported_attr],
-        id: cx.sess.next_node_id(),
+        id: ast::DUMMY_NODE_ID,
         node: item_,
         vis: ast::public,
         span: dummy_sp(),
@@ -367,7 +367,7 @@ fn mk_test_module(cx: &TestCtxt) -> @ast::item {
     let item = ast::item {
         ident: cx.sess.ident_of("__test"),
         attrs: ~[resolve_unexported_attr],
-        id: cx.sess.next_node_id(),
+        id: ast::DUMMY_NODE_ID,
         node: item_,
         vis: ast::public,
         span: dummy_sp(),
@@ -448,15 +448,14 @@ fn mk_test_descs(cx: &TestCtxt) -> @ast::Expr {
         descs.push(mk_test_desc_and_fn_rec(cx, test));
     }
 
-    let sess = cx.sess;
     let inner_expr = @ast::Expr {
-        id: sess.next_node_id(),
+        id: ast::DUMMY_NODE_ID,
         node: ast::ExprVec(descs, ast::MutImmutable),
         span: dummy_sp(),
     };
 
     @ast::Expr {
-        id: sess.next_node_id(),
+        id: ast::DUMMY_NODE_ID,
         node: ast::ExprVstore(inner_expr, ast::ExprVstoreSlice),
         span: dummy_sp(),
     }
@@ -475,7 +474,7 @@ fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: &Test) -> @ast::Expr {
         nospan(ast::lit_str(ast_util::path_name_i(path).to_managed()));
 
     let name_expr = @ast::Expr {
-          id: cx.sess.next_node_id(),
+          id: ast::DUMMY_NODE_ID,
           node: ast::ExprLit(@name_lit),
           span: span
     };
@@ -483,7 +482,7 @@ fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: &Test) -> @ast::Expr {
     let fn_path = path_node_global(path);
 
     let fn_expr = @ast::Expr {
-        id: cx.sess.next_node_id(),
+        id: ast::DUMMY_NODE_ID,
         node: ast::ExprPath(fn_path),
         span: span,
     };
@@ -529,7 +528,7 @@ fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: &Test) -> @ast::Expr {
         nospan(ast::lit_str(ast_util::path_name_i(path).to_managed()));
 
     let name_expr = @ast::Expr {
-          id: cx.sess.next_node_id(),
+          id: ast::DUMMY_NODE_ID,
           node: ast::ExprLit(@name_lit),
           span: span
     };
@@ -537,7 +536,7 @@ fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: &Test) -> @ast::Expr {
     let fn_path = path_node_global(path);
 
     let fn_expr = @ast::Expr {
-        id: cx.sess.next_node_id(),
+        id: ast::DUMMY_NODE_ID,
         node: ast::ExprPath(fn_path),
         span: span,
     };

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -157,10 +157,10 @@ fn reserve_id_range(sess: Session,
     // Handle the case of an empty range:
     if from_id_range.empty() { return from_id_range; }
     let cnt = from_id_range.max - from_id_range.min;
-    let to_id_min = sess.parse_sess.next_id;
-    let to_id_max = sess.parse_sess.next_id + cnt;
-    sess.parse_sess.next_id = to_id_max;
-    ast_util::id_range { min: to_id_min, max: to_id_min }
+    assert!(cnt >= 0);
+    let to_id_min = sess.reserve_node_ids(cnt as uint);
+    let to_id_max = to_id_min + cnt;
+    ast_util::id_range { min: to_id_min, max: to_id_max }
 }
 
 impl ExtendedDecodeContext {

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -45,7 +45,6 @@ use syntax::ast_util::{def_id_of_def, local_def};
 use syntax::codemap::Span;
 use syntax::opt_vec;
 use syntax::visit;
-use syntax::parse;
 
 use std::hashmap::HashSet;
 use std::result::Ok;
@@ -334,7 +333,7 @@ impl CoherenceChecker {
         let provided = ty::provided_trait_methods(tcx, trait_ref.def_id);
         for trait_method in provided.iter() {
             // Synthesize an ID.
-            let new_id = parse::next_node_id(tcx.sess.parse_sess);
+            let new_id = tcx.sess.next_node_id();
             let new_did = local_def(new_id);
 
             debug!("new_did=%? trait_method=%s", new_did, trait_method.repr(tcx));

--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -80,6 +80,7 @@ pub mod front {
     pub mod config;
     pub mod test;
     pub mod std_inject;
+    pub mod assign_node_ids;
 }
 
 pub mod back {

--- a/src/librustdoc/astsrv.rs
+++ b/src/librustdoc/astsrv.rs
@@ -29,6 +29,7 @@ use rustc::driver::session::{basic_options, options};
 use rustc::front;
 use syntax::ast;
 use syntax::ast_map;
+use syntax::ast_util;
 use syntax;
 
 pub struct Ctxt {
@@ -108,6 +109,16 @@ pub fn exec<T:Send>(
     po.recv()
 }
 
+fn assign_node_ids(crate: @ast::Crate) -> @ast::Crate {
+    let next_id = @mut 0;
+    let fold = ast_util::node_id_assigner(|| {
+            let i = *next_id;
+            *next_id += 1;
+            i
+        });
+    @fold.fold_crate(crate)
+}
+
 fn build_ctxt(sess: Session,
               ast: @ast::Crate) -> Ctxt {
 
@@ -121,6 +132,7 @@ fn build_ctxt(sess: Session,
                                                 sess.opts.cfg.clone(),
                                                 ast);
     let ast = front::test::modify_for_testing(sess, ast);
+    let ast = assign_node_ids(ast);
     let ast_map = ast_map::map_crate(sess.diagnostic(), ast);
 
     Ctxt {

--- a/src/librustdoc/attr_pass.rs
+++ b/src/librustdoc/attr_pass.rs
@@ -281,6 +281,7 @@ mod test {
     fn should_extract_enum_docs() {
         let doc = mk_doc(~"#[doc = \"b\"]\
                                  enum a { v }");
+        debug!("%?", doc);
         assert!(doc.cratemod().enums()[0].desc() == Some(~"b"));
     }
 

--- a/src/librustdoc/extract.rs
+++ b/src/librustdoc/extract.rs
@@ -285,6 +285,7 @@ mod test {
 
     fn mk_doc(source: @str) -> doc::Doc {
         let ast = parse::from_str(source);
+        debug!("ast=%?", ast);
         extract(ast, ~"")
     }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -187,6 +187,11 @@ pub struct DefId {
 pub static LOCAL_CRATE: CrateNum = 0;
 pub static CRATE_NODE_ID: NodeId = 0;
 
+// When parsing and doing expansions, we initially give all AST nodes this AST
+// node value. Then later, in the renumber pass, we renumber them to have
+// small, positive ids.
+pub static DUMMY_NODE_ID: NodeId = -1;
+
 // The AST represents all type param bounds as types.
 // typeck::collect::compute_bounds matches these against
 // the "special" built-in traits (see middle::lang_items) and

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -12,6 +12,7 @@ use ast::*;
 use ast;
 use ast_util;
 use codemap::{Span, dummy_sp};
+use fold;
 use opt_vec;
 use parse::token;
 use visit::{SimpleVisitor, SimpleVisitorVisitor, Visitor};
@@ -368,6 +369,21 @@ pub static as_prec: uint = 12u;
 pub fn empty_generics() -> Generics {
     Generics {lifetimes: opt_vec::Empty,
               ty_params: opt_vec::Empty}
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Assigning node ids
+
+fn node_id_assigner(next_id: @fn() -> ast::NodeId) -> @fold::ast_fold {
+    let precursor = @fold::AstFoldFns {
+        new_id: |old_id| {
+            assert_eq!(old_id, ast::DUMMY_NODE_ID);
+            next_id()
+        },
+        ..*fold::default_ast_fold()
+    };
+
+    fold::make_fold(precursor)
 }
 
 // ______________________________________________________________________

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -76,7 +76,7 @@ pub fn expand_asm(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
                     p.expect(&token::RPAREN);
 
                     let out = @ast::Expr {
-                        id: cx.next_id(),
+                        id: ast::DUMMY_NODE_ID,
                         span: out.span,
                         node: ast::ExprAddrOf(ast::MutMutable, out)
                     };
@@ -172,7 +172,7 @@ pub fn expand_asm(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
     }
 
     MRExpr(@ast::Expr {
-        id: cx.next_id(),
+        id: ast::DUMMY_NODE_ID,
         node: ast::ExprInlineAsm(ast::inline_asm {
             asm: asm,
             clobbers: cons.to_managed(),

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -319,9 +319,6 @@ impl ExtCtxt {
         self.print_backtrace();
         self.parse_sess.span_diagnostic.handler().bug(msg);
     }
-    pub fn next_id(&self) -> ast::NodeId {
-        parse::next_node_id(self.parse_sess)
-    }
     pub fn trace_macros(&self) -> bool {
         *self.trace_mac
     }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -13,7 +13,6 @@ use ast::Ident;
 use ast;
 use ast_util;
 use codemap::{Span, respan, dummy_sp};
-use fold;
 use ext::base::ExtCtxt;
 use ext::quote::rt::*;
 use opt_vec;
@@ -277,7 +276,7 @@ impl AstBuilder for @ExtCtxt {
 
     fn ty(&self, span: Span, ty: ast::ty_) -> ast::Ty {
         ast::Ty {
-            id: self.next_id(),
+            id: ast::DUMMY_NODE_ID,
             span: span,
             node: ty
         }
@@ -286,7 +285,7 @@ impl AstBuilder for @ExtCtxt {
     fn ty_path(&self, path: ast::Path, bounds: Option<OptVec<ast::TyParamBound>>)
               -> ast::Ty {
         self.ty(path.span,
-                ast::ty_path(path, bounds, self.next_id()))
+                ast::ty_path(path, bounds, ast::DUMMY_NODE_ID))
     }
 
     // Might need to take bounds as an argument in the future, if you ever want
@@ -340,14 +339,14 @@ impl AstBuilder for @ExtCtxt {
 
     fn ty_nil(&self) -> ast::Ty {
         ast::Ty {
-            id: self.next_id(),
+            id: ast::DUMMY_NODE_ID,
             node: ast::ty_nil,
             span: dummy_sp(),
         }
     }
 
     fn typaram(&self, id: ast::Ident, bounds: OptVec<ast::TyParamBound>) -> ast::TyParam {
-        ast::TyParam { ident: id, id: self.next_id(), bounds: bounds }
+        ast::TyParam { ident: id, id: ast::DUMMY_NODE_ID, bounds: bounds }
     }
 
     // these are strange, and probably shouldn't be used outside of
@@ -377,7 +376,7 @@ impl AstBuilder for @ExtCtxt {
     fn trait_ref(&self, path: ast::Path) -> ast::trait_ref {
         ast::trait_ref {
             path: path,
-            ref_id: self.next_id()
+            ref_id: ast::DUMMY_NODE_ID
         }
     }
 
@@ -386,11 +385,11 @@ impl AstBuilder for @ExtCtxt {
     }
 
     fn lifetime(&self, span: Span, ident: ast::Ident) -> ast::Lifetime {
-        ast::Lifetime { id: self.next_id(), span: span, ident: ident }
+        ast::Lifetime { id: ast::DUMMY_NODE_ID, span: span, ident: ident }
     }
 
     fn stmt_expr(&self, expr: @ast::Expr) -> @ast::Stmt {
-        @respan(expr.span, ast::StmtSemi(expr, self.next_id()))
+        @respan(expr.span, ast::StmtSemi(expr, ast::DUMMY_NODE_ID))
     }
 
     fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident, ex: @ast::Expr) -> @ast::Stmt {
@@ -400,11 +399,11 @@ impl AstBuilder for @ExtCtxt {
             ty: self.ty_infer(sp),
             pat: pat,
             init: Some(ex),
-            id: self.next_id(),
+            id: ast::DUMMY_NODE_ID,
             span: sp,
         };
         let decl = respan(sp, ast::DeclLocal(local));
-        @respan(sp, ast::StmtDecl(@decl, self.next_id()))
+        @respan(sp, ast::StmtDecl(@decl, ast::DUMMY_NODE_ID))
     }
 
     fn stmt_let_typed(&self,
@@ -420,11 +419,11 @@ impl AstBuilder for @ExtCtxt {
             ty: typ,
             pat: pat,
             init: Some(ex),
-            id: self.next_id(),
+            id: ast::DUMMY_NODE_ID,
             span: sp,
         };
         let decl = respan(sp, ast::DeclLocal(local));
-        @respan(sp, ast::StmtDecl(@decl, self.next_id()))
+        @respan(sp, ast::StmtDecl(@decl, ast::DUMMY_NODE_ID))
     }
 
     fn block(&self, span: Span, stmts: ~[@ast::Stmt], expr: Option<@Expr>) -> ast::Block {
@@ -443,7 +442,7 @@ impl AstBuilder for @ExtCtxt {
                view_items: view_items,
                stmts: stmts,
                expr: expr,
-               id: self.next_id(),
+               id: ast::DUMMY_NODE_ID,
                rules: ast::DefaultBlock,
                span: span,
            }
@@ -451,7 +450,7 @@ impl AstBuilder for @ExtCtxt {
 
     fn expr(&self, span: Span, node: ast::Expr_) -> @ast::Expr {
         @ast::Expr {
-            id: self.next_id(),
+            id: ast::DUMMY_NODE_ID,
             node: node,
             span: span,
         }
@@ -470,7 +469,7 @@ impl AstBuilder for @ExtCtxt {
 
     fn expr_binary(&self, sp: Span, op: ast::BinOp,
                    lhs: @ast::Expr, rhs: @ast::Expr) -> @ast::Expr {
-        self.expr(sp, ast::ExprBinary(self.next_id(), op, lhs, rhs))
+        self.expr(sp, ast::ExprBinary(ast::DUMMY_NODE_ID, op, lhs, rhs))
     }
 
     fn expr_deref(&self, sp: Span, e: @ast::Expr) -> @ast::Expr {
@@ -478,7 +477,7 @@ impl AstBuilder for @ExtCtxt {
     }
     fn expr_unary(&self, sp: Span, op: ast::UnOp, e: @ast::Expr)
         -> @ast::Expr {
-        self.expr(sp, ast::ExprUnary(self.next_id(), op, e))
+        self.expr(sp, ast::ExprUnary(ast::DUMMY_NODE_ID, op, e))
     }
 
     fn expr_managed(&self, sp: Span, e: @ast::Expr) -> @ast::Expr {
@@ -512,7 +511,7 @@ impl AstBuilder for @ExtCtxt {
                         ident: ast::Ident,
                         args: ~[@ast::Expr]) -> @ast::Expr {
         self.expr(span,
-                  ast::ExprMethodCall(self.next_id(), expr, ident, ~[], args, ast::NoSugar))
+                  ast::ExprMethodCall(ast::DUMMY_NODE_ID, expr, ident, ~[], args, ast::NoSugar))
     }
     fn expr_block(&self, b: ast::Block) -> @ast::Expr {
         self.expr(b.span, ast::ExprBlock(b))
@@ -583,7 +582,7 @@ impl AstBuilder for @ExtCtxt {
 
 
     fn pat(&self, span: Span, pat: ast::Pat_) -> @ast::Pat {
-        @ast::Pat { id: self.next_id(), node: pat, span: span }
+        @ast::Pat { id: ast::DUMMY_NODE_ID, node: pat, span: span }
     }
     fn pat_wild(&self, span: Span) -> @ast::Pat {
         self.pat(span, ast::PatWild)
@@ -695,7 +694,7 @@ impl AstBuilder for @ExtCtxt {
             is_mutbl: false,
             ty: ty,
             pat: arg_pat,
-            id: self.next_id()
+            id: ast::DUMMY_NODE_ID
         }
     }
 
@@ -714,7 +713,7 @@ impl AstBuilder for @ExtCtxt {
         // Rust coding conventions
         @ast::item { ident: name,
                     attrs: attrs,
-                    id: self.next_id(),
+                    id: ast::DUMMY_NODE_ID,
                     node: node,
                     vis: ast::public,
                     span: span }
@@ -755,7 +754,7 @@ impl AstBuilder for @ExtCtxt {
 
     fn variant(&self, span: Span, name: Ident, tys: ~[ast::Ty]) -> ast::variant {
         let args = tys.move_iter().map(|ty| {
-            ast::variant_arg { ty: ty, id: self.next_id() }
+            ast::variant_arg { ty: ty, id: ast::DUMMY_NODE_ID }
         }).collect();
 
         respan(span,
@@ -763,7 +762,7 @@ impl AstBuilder for @ExtCtxt {
                    name: name,
                    attrs: ~[],
                    kind: ast::tuple_variant_kind(args),
-                   id: self.next_id(),
+                   id: ast::DUMMY_NODE_ID,
                    disr_expr: None,
                    vis: ast::public
                })
@@ -860,43 +859,20 @@ impl AstBuilder for @ExtCtxt {
     fn view_use_list(&self, sp: Span, vis: ast::visibility,
                      path: ~[ast::Ident], imports: &[ast::Ident]) -> ast::view_item {
         let imports = do imports.map |id| {
-            respan(sp, ast::path_list_ident_ { name: *id, id: self.next_id() })
+            respan(sp, ast::path_list_ident_ { name: *id, id: ast::DUMMY_NODE_ID })
         };
 
         self.view_use(sp, vis,
                       ~[@respan(sp,
                                 ast::view_path_list(self.path(sp, path),
                                                     imports,
-                                                    self.next_id()))])
+                                                    ast::DUMMY_NODE_ID))])
     }
 
     fn view_use_glob(&self, sp: Span,
                      vis: ast::visibility, path: ~[ast::Ident]) -> ast::view_item {
         self.view_use(sp, vis,
                       ~[@respan(sp,
-                                ast::view_path_glob(self.path(sp, path), self.next_id()))])
-    }
-}
-
-
-pub trait Duplicate {
-    //
-    // Duplication functions
-    //
-    // These functions just duplicate AST nodes.
-    //
-
-    fn duplicate(&self, cx: @ExtCtxt) -> Self;
-}
-
-impl Duplicate for @ast::Expr {
-    fn duplicate(&self, cx: @ExtCtxt) -> @ast::Expr {
-        let folder = fold::default_ast_fold();
-        let folder = @fold::AstFoldFns {
-            new_id: |_| cx.next_id(),
-            ..*folder
-        };
-        let folder = fold::make_fold(folder);
-        folder.fold_expr(*self)
+                                ast::view_path_glob(self.path(sp, path), ast::DUMMY_NODE_ID))])
     }
 }

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -35,7 +35,7 @@ pub fn expand_syntax_ext(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
     let res = str_to_ident(res_str);
 
     let e = @ast::Expr {
-        id: cx.next_id(),
+        id: ast::DUMMY_NODE_ID,
         node: ast::ExprPath(
             ast::Path {
                  span: sp,

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -539,9 +539,9 @@ impl<'self> MethodDef<'self> {
             purity: ast::impure_fn,
             decl: fn_decl,
             body: body_block,
-            id: cx.next_id(),
+            id: ast::DUMMY_NODE_ID,
             span: span,
-            self_id: cx.next_id(),
+            self_id: ast::DUMMY_NODE_ID,
             vis: ast::inherited,
         }
     }

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -12,7 +12,7 @@ use ast;
 use ast::{MetaItem, item, Expr, Ident};
 use codemap::Span;
 use ext::base::ExtCtxt;
-use ext::build::{AstBuilder, Duplicate};
+use ext::build::{AstBuilder};
 use ext::deriving::generic::*;
 
 use std::vec;
@@ -62,7 +62,7 @@ fn rand_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
     let rand_call = || {
         cx.expr_call_global(span,
                             rand_ident.clone(),
-                            ~[ rng[0].duplicate(cx) ])
+                            ~[ rng[0] ])
     };
 
     return match *substr.fields {
@@ -86,7 +86,7 @@ fn rand_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
             // ::std::rand::Rand::rand(rng)
             let rv_call = cx.expr_call(span,
                                        rand_name,
-                                       ~[ rng[0].duplicate(cx) ]);
+                                       ~[ rng[0] ]);
 
             // need to specify the uint-ness of the random number
             let uint_ty = cx.ty_ident(span, cx.ident_of("uint"));

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -406,8 +406,8 @@ pub fn expand_stmt(extsbox: @mut SyntaxEnv,
             let marked_ctxt = new_mark(fm,ctxt);
             let expanded = match expandfun(cx, mac.span, marked_tts, marked_ctxt) {
                 MRExpr(e) =>
-                    @codemap::Spanned { node: StmtExpr(e, cx.next_id()),
-                                    span: e.span},
+                    @codemap::Spanned { node: StmtExpr(e, ast::DUMMY_NODE_ID),
+                                        span: e.span},
                 MRAny(_,_,stmt_mkr) => stmt_mkr(),
                 _ => cx.span_fatal(
                     pth.span,
@@ -1365,8 +1365,8 @@ pub fn fun_to_ctxt_folder<T : 'static + CtxtFn>(cf: @T) -> @AstFoldFns {
         match *m {
             mac_invoc_tt(ref path, ref tts, ctxt) =>
             (mac_invoc_tt(fld.fold_path(path),
-                         fold_tts(*tts,fld),
-                         cf.f(ctxt)),
+                          fold_tts(*tts,fld),
+                          cf.f(ctxt)),
             sp)
         }
 

--- a/src/libsyntax/ext/ifmt.rs
+++ b/src/libsyntax/ext/ifmt.rs
@@ -550,7 +550,7 @@ impl Context {
         for &method in self.method_statics.iter() {
             let decl = respan(self.fmtsp, ast::DeclItem(method));
             lets.push(@respan(self.fmtsp,
-                              ast::StmtDecl(@decl, self.ecx.next_id())));
+                              ast::StmtDecl(@decl, ast::DUMMY_NODE_ID)));
         }
 
         // Next, build up the static array which will become our precompiled
@@ -581,7 +581,7 @@ impl Context {
         let unnamed = self.ecx.attribute(self.fmtsp, unnamed);
         let item = self.ecx.item(self.fmtsp, static_name, ~[unnamed], st);
         let decl = respan(self.fmtsp, ast::DeclItem(item));
-        lets.push(@respan(self.fmtsp, ast::StmtDecl(@decl, self.ecx.next_id())));
+        lets.push(@respan(self.fmtsp, ast::StmtDecl(@decl, ast::DUMMY_NODE_ID)));
 
         // Right now there is a bug such that for the expression:
         //      foo(bar(&1))
@@ -631,7 +631,7 @@ impl Context {
            view_items: ~[],
            stmts: ~[],
            expr: Some(result),
-           id: self.ecx.next_id(),
+           id: ast::DUMMY_NODE_ID,
            rules: ast::UnsafeBlock,
            span: self.fmtsp,
         });

--- a/src/libsyntax/ext/log_syntax.rs
+++ b/src/libsyntax/ext/log_syntax.rs
@@ -30,7 +30,7 @@ pub fn expand_syntax_ext(cx: @ExtCtxt,
 
     //trivial expression
     MRExpr(@ast::Expr {
-        id: cx.next_id(),
+        id: ast::DUMMY_NODE_ID,
         node: ast::ExprLit(@codemap::Spanned {
             node: ast::lit_nil,
             span: sp

--- a/src/test/run-pass/borrowck-macro-interaction-issue-6304.rs
+++ b/src/test/run-pass/borrowck-macro-interaction-issue-6304.rs
@@ -1,0 +1,29 @@
+// Check that we do not ICE when compiling this
+// macro, which reuses the expression `$id`
+
+struct Foo {
+  a: int
+}
+
+pub enum Bar {
+  Bar1, Bar2(int, ~Bar),
+}
+
+impl Foo {
+  fn elaborate_stm(&mut self, s: ~Bar) -> ~Bar {
+    macro_rules! declare(
+      ($id:expr, $rest:expr) => ({
+        self.check_id($id);
+        ~Bar2($id, $rest)
+      })
+    );
+    match s {
+      ~Bar2(id, rest) => declare!(id, self.elaborate_stm(rest)),
+      _ => fail!()
+    }
+  }
+
+  fn check_id(&mut self, s: int) { fail!() }
+}
+ 
+fn main() { }

--- a/src/test/run-pass/typeck-macro-interaction-issue-8852.rs
+++ b/src/test/run-pass/typeck-macro-interaction-issue-8852.rs
@@ -1,0 +1,22 @@
+enum T {
+    A(int),
+    B(float)
+}
+
+macro_rules! test(
+    ($e:expr) => (
+        fn foo(a:T, b:T) -> T {
+            match (a, b) {
+                (A(x), A(y)) => A($e),
+                (B(x), B(y)) => B($e),
+                _ => fail!()
+            }
+        }
+    )
+)
+
+test!(x + y)
+
+fn main() {
+    foo(A(1), A(2));
+}


### PR DESCRIPTION
Ensures that each AST node has a unique id. Fixes numerous bugs in macro expansion and deriving. Add two
representative tests.

Fixes #7971
Fixes #6304
Fixes #8367
Fixes #8754
Fixes #8852
Fixes #2543
Fixes #7654
