### PR TITLE
Let var hygiene

### DIFF
--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -671,7 +671,8 @@ fn enter_opt<'r>(bcx: @mut Block,
                     let mut reordered_patterns = ~[];
                     let r = ty::lookup_struct_fields(tcx, struct_id);
                     for field in r.iter() {
-                            match field_pats.iter().find(|p| p.ident == field.ident) {
+                            match field_pats.iter().find(|p| p.ident.name
+                                                         == field.ident.name) {
                                 None => reordered_patterns.push(dummy),
                                 Some(fp) => reordered_patterns.push(fp.pat)
                             }
@@ -752,7 +753,7 @@ fn enter_rec_or_struct<'r>(bcx: @mut Block,
             ast::PatStruct(_, ref fpats, _) => {
                 let mut pats = ~[];
                 for fname in fields.iter() {
-                    match fpats.iter().find(|p| p.ident == *fname) {
+                    match fpats.iter().find(|p| p.ident.name == fname.name) {
                         None => pats.push(dummy),
                         Some(pat) => pats.push(pat.pat)
                     }
@@ -1102,7 +1103,7 @@ fn collect_record_or_struct_fields(bcx: @mut Block,
     fn extend(idents: &mut ~[ast::Ident], field_pats: &[ast::FieldPat]) {
         for field_pat in field_pats.iter() {
             let field_ident = field_pat.ident;
-            if !idents.iter().any(|x| *x == field_ident) {
+            if !idents.iter().any(|x| x.name == field_ident.name) {
                 idents.push(field_ident);
             }
         }

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -256,7 +256,8 @@ impl Reflector {
               let fields = ty::struct_fields(tcx, did, substs);
               let mut named_fields = false;
               if !fields.is_empty() {
-                  named_fields = fields[0].ident != special_idents::unnamed_field;
+                  named_fields =
+                        fields[0].ident.name != special_idents::unnamed_field.name;
               }
 
               let extra = ~[self.c_slice(ty_to_str(tcx, t).to_managed()),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -28,7 +28,7 @@ use extra::serialize::{Encodable, Decodable, Encoder, Decoder};
 // table) and a SyntaxContext to track renaming and
 // macro expansion per Flatt et al., "Macros
 // That Work Together"
-#[deriving(Clone, Eq, IterBytes, ToStr)]
+#[deriving(Clone, IterBytes, ToStr)]
 pub struct Ident { name: Name, ctxt: SyntaxContext }
 
 impl Ident {
@@ -36,17 +36,7 @@ impl Ident {
     pub fn new(name: Name) -> Ident { Ident {name: name, ctxt: EMPTY_CTXT}}
 }
 
-// defining eq in this way is a way of guaranteeing that later stages of the
-// compiler don't compare identifiers unhygienically. Unfortunately, some tests
-// (specifically debuginfo in no-opt) want to do these comparisons, and that
-// seems fine.  If only I could find a nice way to statically ensure that
-// the compiler "proper" never compares identifiers.... I'm leaving this
-// code here (commented out) for potential use in debugging. Specifically, if
-// there's a bug where "identifiers aren't matching", it may be because
-// they should be compared using mtwt_resolve. In such a case, re-enabling this
-// code (and disabling deriving(Eq) for Idents) could help to isolate the
-// problem
-/* impl Eq for Ident {
+impl Eq for Ident {
     fn eq(&self, other: &Ident) -> bool {
         if (self.ctxt == other.ctxt) {
             self.name == other.name
@@ -64,7 +54,6 @@ impl Ident {
         ! self.eq(other)
     }
 }
-*/
 
 /// A SyntaxContext represents a chain of macro-expandings
 /// and renamings. Each macro expansion corresponds to

--- a/src/test/run-pass/match-in-macro.rs
+++ b/src/test/run-pass/match-in-macro.rs
@@ -1,0 +1,25 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Foo {
+    B { b1: int, bb1: int},
+}
+
+macro_rules! match_inside_expansion(
+    () => (
+        match B { b1:29 , bb1: 100} {
+            B { b1:b2 , bb1:bb2 } => b2+bb2
+        }
+    )
+)
+
+fn main() {
+    assert_eq!(match_inside_expansion!(),129);
+}


### PR DESCRIPTION
This appears to fix issue #9049. It also re-enables the ICE check on comparing idents for equality; it appears that ICEs are better than seg faults.
