### PR TITLE
Make linenoise safe & various improvements to extra::rl

### DIFF
--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -355,12 +355,12 @@ fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
 /// None if no input was read (e.g. EOF was reached).
 fn get_line(use_rl: bool, prompt: &str) -> Option<~str> {
     if use_rl {
-        let result = unsafe { rl::read(prompt) };
+        let result = rl::read(prompt);
 
         match result {
             None => None,
             Some(line) => {
-                unsafe { rl::add_history(line) };
+                rl::add_history(line);
                 Some(line)
             }
         }
@@ -525,14 +525,12 @@ pub fn main_args(args: &[~str]) {
         println("unstable. If you encounter problems, please use the");
         println("compiler instead. Type :help for help.");
 
-        unsafe {
-            do rl::complete |line, suggest| {
-                if line.starts_with(":") {
-                    suggest(~":clear");
-                    suggest(~":exit");
-                    suggest(~":help");
-                    suggest(~":load");
-                }
+        do rl::complete |line, suggest| {
+            if line.starts_with(":") {
+                suggest(~":clear");
+                suggest(~":exit");
+                suggest(~":help");
+                suggest(~":load");
             }
         }
     }

--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -633,6 +633,18 @@ rust_drop_env_lock() {
     env_lock.unlock();
 }
 
+static lock_and_signal linenoise_lock;
+
+extern "C" CDECL void
+rust_take_linenoise_lock() {
+    linenoise_lock.lock();
+}
+
+extern "C" CDECL void
+rust_drop_linenoise_lock() {
+    linenoise_lock.unlock();
+}
+
 extern "C" CDECL unsigned int
 rust_valgrind_stack_register(void *start, void *end) {
   return VALGRIND_STACK_REGISTER(start, end);

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -189,6 +189,8 @@ rust_take_global_args_lock
 rust_drop_global_args_lock
 rust_take_change_dir_lock
 rust_drop_change_dir_lock
+rust_take_linenoise_lock
+rust_drop_linenoise_lock
 rust_get_test_int
 rust_get_task
 rust_uv_get_loop_from_getaddrinfo_req

--- a/src/test/run-pass/rl-human-test.rs
+++ b/src/test/run-pass/rl-human-test.rs
@@ -1,0 +1,75 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast no compile flags for check-fast
+
+// we want this to be compiled to avoid bitrot, but the actual test
+//has to be conducted by a human, i.e. someone (you?) compiling this
+//file with a plain rustc invocation and running it and checking it
+//works.
+
+// compile-flags: --cfg robot_mode
+
+extern mod extra;
+use extra::rl;
+
+static HISTORY_FILE: &'static str = "rl-human-test-history.txt";
+
+fn main() {
+    // don't run this in robot mode, but still typecheck it.
+    if !cfg!(robot_mode) {
+        println("~~ Welcome to the rl test \"suite\". ~~");
+        println!("Operations:
+ - restrict the history to 2 lines,
+ - set the tab-completion to suggest three copies of each of the last 3 letters (or 'empty'),
+ - add 'one' and 'two' to the history,
+ - save it to `{0}`,
+ - add 'three',
+ - prompt & save input (check the history & completion work and contains only 'two', 'three'),
+ - load from `{0}`
+ - prompt & save input (history should be 'one', 'two' again),
+ - prompt once more.
+
+The bool return values of each step are printed.",
+                 HISTORY_FILE);
+
+        println!("restricting history length: {}", rl::set_history_max_len(3));
+
+        do rl::complete |line, suggest| {
+            if line.is_empty() {
+                suggest(~"empty")
+            } else {
+                for c in line.rev_iter().take(3) {
+                    suggest(format!("{0}{1}{1}{1}", line, c))
+                }
+            }
+        }
+
+        println!("adding 'one': {}", rl::add_history("one"));
+        println!("adding 'two': {}", rl::add_history("two"));
+
+        println!("saving history: {}", rl::save_history(HISTORY_FILE));
+
+        println!("adding 'three': {}", rl::add_history("three"));
+
+        match rl::read("> ") {
+            Some(s) => println!("saving input: {}", rl::add_history(s)),
+            None => return
+        }
+        println!("loading history: {}", rl::load_history(HISTORY_FILE));
+
+        match rl::read("> ") {
+            Some(s) => println!("saving input: {}", rl::add_history(s)),
+            None => return
+        }
+
+        rl::read("> ");
+    }
+}


### PR DESCRIPTION
- Wrap calls into linenoise in a mutex so that the functions don't have to be `unsafe` any more (fixes #3921)
- Stop leaking every line that linenoise reads.
- Handle the situation of `rl::complete(some_function); do spawn { rl::read(""); }` which would crash (`fail!` that turned into an abort, possibly due to failing with the lock locked) when the user attempted to tab-complete anything.
- Add a test for the various functions; it has to be run by hand to verify anything works, but it won't bitrot.
