### PR TITLE
debuginfo: Support for namespaces

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -2110,6 +2110,14 @@ pub mod llvm {
             -> ValueRef;
 
         #[fast_ffi]
+        pub fn LLVMDIBuilderCreateNameSpace(Builder: DIBuilderRef,
+                                            Scope: ValueRef,
+                                            Name: *c_char,
+                                            File: ValueRef,
+                                            LineNo: c_uint)
+                                            -> ValueRef;
+
+        #[fast_ffi]
         pub fn LLVMIsAArgument(value_ref: ValueRef) -> ValueRef;
 
         #[fast_ffi]

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -3021,6 +3021,10 @@ pub fn trans_crate(sess: session::Session,
                                      link_meta,
                                      analysis.reachable);
 
+    if ccx.sess.opts.debuginfo {
+        debuginfo::initialize(ccx, crate);
+    }
+
     {
         let _icx = push_ctxt("text");
         trans_mod(ccx, &crate.module);

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -727,9 +727,9 @@ extern "C" LLVMValueRef LLVMDIBuilderCreateTemplateTypeParameter(
     LLVMValueRef Scope,
     const char* Name,
     LLVMValueRef Ty,
-    LLVMValueRef File = 0,
-    unsigned LineNo = 0,
-    unsigned ColumnNo = 0)
+    LLVMValueRef File,
+    unsigned LineNo,
+    unsigned ColumnNo)
 {
     return wrap(Builder->createTemplateTypeParameter(
       unwrapDI<DIDescriptor>(Scope),
@@ -774,4 +774,18 @@ extern "C" LLVMValueRef LLVMDIBuilderCreateComplexVariable(
         addr_ops,
         ArgNo
     ));
+}
+
+extern "C" LLVMValueRef LLVMDIBuilderCreateNameSpace(
+    DIBuilderRef Builder,
+    LLVMValueRef Scope,
+    const char* Name,
+    LLVMValueRef File,
+    unsigned LineNo)
+{
+    return wrap(Builder->createNameSpace(
+        unwrapDI<DIDescriptor>(Scope),
+        Name,
+        unwrapDI<DIFile>(File),
+        LineNo));
 }

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -611,6 +611,7 @@ LLVMDIBuilderCreateTemplateTypeParameter
 LLVMDIBuilderCreateOpDeref
 LLVMDIBuilderCreateOpPlus
 LLVMDIBuilderCreateComplexVariable
+LLVMDIBuilderCreateNameSpace
 LLVMSetUnnamedAddr
 LLVMRustAddPass
 LLVMRustAddAnalysisPasses

--- a/src/test/debug-info/basic-types.rs
+++ b/src/test/debug-info/basic-types.rs
@@ -15,7 +15,7 @@
 // its numerical value.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break _zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 // debugger:print b

--- a/src/test/debug-info/borrowed-basic.rs
+++ b/src/test/debug-info/borrowed-basic.rs
@@ -12,7 +12,7 @@
 // its numerical value.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 // debugger:print *bool_ref

--- a/src/test/debug-info/borrowed-c-style-enum.rs
+++ b/src/test/debug-info/borrowed-c-style-enum.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/borrowed-enum.rs
+++ b/src/test/debug-info/borrowed-enum.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/borrowed-managed-basic.rs
+++ b/src/test/debug-info/borrowed-managed-basic.rs
@@ -12,7 +12,7 @@
 // its numerical value.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 // debugger:print *bool_ref

--- a/src/test/debug-info/borrowed-struct.rs
+++ b/src/test/debug-info/borrowed-struct.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/borrowed-tuple.rs
+++ b/src/test/debug-info/borrowed-tuple.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/borrowed-unique-basic.rs
+++ b/src/test/debug-info/borrowed-unique-basic.rs
@@ -12,7 +12,7 @@
 // its numerical value.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 // debugger:print *bool_ref

--- a/src/test/debug-info/box.rs
+++ b/src/test/debug-info/box.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break _zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 // debugger:print *a

--- a/src/test/debug-info/boxed-struct.rs
+++ b/src/test/debug-info/boxed-struct.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/boxed-vec.rs
+++ b/src/test/debug-info/boxed-vec.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/by-value-non-immediate-argument.rs
+++ b/src/test/debug-info/by-value-non-immediate-argument.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/by-value-self-argument-in-trait-impl.rs
+++ b/src/test/debug-info/by-value-self-argument-in-trait-impl.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/c-style-enum-in-composite.rs
+++ b/src/test/debug-info/c-style-enum-in-composite.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/c-style-enum.rs
+++ b/src/test/debug-info/c-style-enum.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/closure-in-generic-function.rs
+++ b/src/test/debug-info/closure-in-generic-function.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/destructured-fn-argument.rs
+++ b/src/test/debug-info/destructured-fn-argument.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/destructured-local.rs
+++ b/src/test/debug-info/destructured-local.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/evec-in-struct.rs
+++ b/src/test/debug-info/evec-in-struct.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/function-arguments.rs
+++ b/src/test/debug-info/function-arguments.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/generic-function.rs
+++ b/src/test/debug-info/generic-function.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/generic-functions-nested.rs
+++ b/src/test/debug-info/generic-functions-nested.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/generic-method-on-generic-struct.rs
+++ b/src/test/debug-info/generic-method-on-generic-struct.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STACK BY REF

--- a/src/test/debug-info/generic-static-method-on-struct-and-enum.rs
+++ b/src/test/debug-info/generic-static-method-on-struct-and-enum.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STRUCT

--- a/src/test/debug-info/generic-struct-style-enum.rs
+++ b/src/test/debug-info/generic-struct-style-enum.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print union on
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/generic-struct.rs
+++ b/src/test/debug-info/generic-struct.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/generic-trait-generic-static-default-method.rs
+++ b/src/test/debug-info/generic-trait-generic-static-default-method.rs
@@ -11,7 +11,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/generic-tuple-style-enum.rs
+++ b/src/test/debug-info/generic-tuple-style-enum.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print union on
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/lexical-scope-in-for-loop.rs
+++ b/src/test/debug-info/lexical-scope-in-for-loop.rs
@@ -11,7 +11,7 @@
 // xfail-win32
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // FIRST ITERATION

--- a/src/test/debug-info/lexical-scope-in-if.rs
+++ b/src/test/debug-info/lexical-scope-in-if.rs
@@ -11,7 +11,7 @@
 // xfail-win32
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // BEFORE if

--- a/src/test/debug-info/lexical-scope-in-managed-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-managed-closure.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/lexical-scope-in-match.rs
+++ b/src/test/debug-info/lexical-scope-in-match.rs
@@ -11,7 +11,7 @@
 // xfail-win32
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/lexical-scope-in-stack-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-stack-closure.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/lexical-scope-in-unconditional-loop.rs
+++ b/src/test/debug-info/lexical-scope-in-unconditional-loop.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // FIRST ITERATION

--- a/src/test/debug-info/lexical-scope-in-unique-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-unique-closure.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/lexical-scope-in-while.rs
+++ b/src/test/debug-info/lexical-scope-in-while.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // FIRST ITERATION

--- a/src/test/debug-info/lexical-scope-with-macro.rs
+++ b/src/test/debug-info/lexical-scope-with-macro.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/lexical-scopes-in-block-expression.rs
+++ b/src/test/debug-info/lexical-scopes-in-block-expression.rs
@@ -11,7 +11,7 @@
 // xfail-win32
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STRUCT EXPRESSION

--- a/src/test/debug-info/managed-enum.rs
+++ b/src/test/debug-info/managed-enum.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/managed-pointer-within-unique-vec.rs
+++ b/src/test/debug-info/managed-pointer-within-unique-vec.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/managed-pointer-within-unique.rs
+++ b/src/test/debug-info/managed-pointer-within-unique.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/method-on-enum.rs
+++ b/src/test/debug-info/method-on-enum.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STACK BY REF

--- a/src/test/debug-info/method-on-generic-struct.rs
+++ b/src/test/debug-info/method-on-generic-struct.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STACK BY REF

--- a/src/test/debug-info/method-on-struct.rs
+++ b/src/test/debug-info/method-on-struct.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STACK BY REF

--- a/src/test/debug-info/method-on-trait.rs
+++ b/src/test/debug-info/method-on-trait.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STACK BY REF

--- a/src/test/debug-info/method-on-tuple-struct.rs
+++ b/src/test/debug-info/method-on-tuple-struct.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STACK BY REF

--- a/src/test/debug-info/multiple-functions-equal-var-names.rs
+++ b/src/test/debug-info/multiple-functions-equal-var-names.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/multiple-functions.rs
+++ b/src/test/debug-info/multiple-functions.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/name-shadowing-and-scope-nesting.rs
+++ b/src/test/debug-info/name-shadowing-and-scope-nesting.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/nil-enum.rs
+++ b/src/test/debug-info/nil-enum.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/option-like-enum.rs
+++ b/src/test/debug-info/option-like-enum.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/packed-struct-with-destructor.rs
+++ b/src/test/debug-info/packed-struct-with-destructor.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/packed-struct.rs
+++ b/src/test/debug-info/packed-struct.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/self-in-default-method.rs
+++ b/src/test/debug-info/self-in-default-method.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STACK BY REF

--- a/src/test/debug-info/self-in-generic-default-method.rs
+++ b/src/test/debug-info/self-in-generic-default-method.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STACK BY REF

--- a/src/test/debug-info/shadowed-argument.rs
+++ b/src/test/debug-info/shadowed-argument.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/shadowed-variable.rs
+++ b/src/test/debug-info/shadowed-variable.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/simple-lexical-scope.rs
+++ b/src/test/debug-info/simple-lexical-scope.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/simple-struct.rs
+++ b/src/test/debug-info/simple-struct.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/simple-tuple.rs
+++ b/src/test/debug-info/simple-tuple.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/static-method-on-struct-and-enum.rs
+++ b/src/test/debug-info/static-method-on-struct-and-enum.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // STRUCT

--- a/src/test/debug-info/struct-in-enum.rs
+++ b/src/test/debug-info/struct-in-enum.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print union on
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/struct-in-struct.rs
+++ b/src/test/debug-info/struct-in-struct.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/struct-style-enum.rs
+++ b/src/test/debug-info/struct-style-enum.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print union on
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/struct-with-destructor.rs
+++ b/src/test/debug-info/struct-with-destructor.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 // debugger:print simple

--- a/src/test/debug-info/trait-generic-static-default-method.rs
+++ b/src/test/debug-info/trait-generic-static-default-method.rs
@@ -11,7 +11,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 
 // debugger:finish

--- a/src/test/debug-info/tuple-in-struct.rs
+++ b/src/test/debug-info/tuple-in-struct.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/tuple-in-tuple.rs
+++ b/src/test/debug-info/tuple-in-tuple.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/tuple-struct.rs
+++ b/src/test/debug-info/tuple-struct.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/tuple-style-enum.rs
+++ b/src/test/debug-info/tuple-style-enum.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print union on
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/unique-enum.rs
+++ b/src/test/debug-info/unique-enum.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/var-captured-in-managed-closure.rs
+++ b/src/test/debug-info/var-captured-in-managed-closure.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/var-captured-in-nested-closure.rs
+++ b/src/test/debug-info/var-captured-in-nested-closure.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/var-captured-in-sendable-closure.rs
+++ b/src/test/debug-info/var-captured-in-sendable-closure.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/var-captured-in-stack-closure.rs
+++ b/src/test/debug-info/var-captured-in-stack-closure.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-Z extra-debug-info
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 

--- a/src/test/debug-info/vec-slices.rs
+++ b/src/test/debug-info/vec-slices.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 // debugger:print empty.size_in_bytes

--- a/src/test/debug-info/vec.rs
+++ b/src/test/debug-info/vec.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:-Z extra-debug-info
 // debugger:set print pretty off
-// debugger:break zzz
+// debugger:rbreak zzz
 // debugger:run
 // debugger:finish
 // debugger:print a


### PR DESCRIPTION
Who would have thought that namespaces are such a can of worms `:P` This is mostly because of some GDB idiosyncrasies (does not use namespace information but linkage-name attributes for displaying items contained in namespaces, also cannot handle functions lexically nested within functions), monomorphization, and information about external items only available from metadata.

This pull request tries to tackle the problem anyway:
- The `DW_AT_linkage_name` for functions is generated just to make GDB display a proper namespace-enabled function name. To this end, a pseudo-mangled name is generated, not corresponding to the real linkage name. This approach shows some success and could be extended to make GDB also show proper parameter types.
- As GDB won't accept subprogram DIEs nested within other subprogram DIEs, the `debuginfo` module now generates a _companion namespace_ for each functions (iff needed). A function `fn abc()` will get a companion namespace with name `abc()`, which contains all items (modules, types, functions) declared within the functions scope. The real, proper solution, in my opinion, would be to faithfully reflect the program's lexical structure within DWARF (which allows arbitrary nesting of DIEs, afaik), but I am not sure LLVM's source level debugging implementation would like that and I am pretty sure GDB won't support this in the foreseeable future.
- Monomorphization leads to functions and companion namespaces like `somelib::some_func<int, float>()::some_other_function<bool, bool, bool>()`, which I think is the desired behaviour. There is some design space here, however. Maybe you people prefer `somelib::some_func()::some_other_function<bool, bool, bool>()` or `somelib::some_func()::some_other_function::<int, float, bool, bool, bool>()`.

The solution will work for now but there are a few things on my 'far future wish list':
- A real specification somewhere, what language constructs are mapped to what DWARF structures.
- Proper tests that directly compare the generated DWARF information to the expected results (possibly using something like [pyelftools](https://github.com/eliben/pyelftools) or llvm-dwarfdump)
- A unified implementation for crate-local and crate-external items (which would possibly involve beefing up `ast_map::path` and metadata a bit)

Any comments are welcome!

Closes #1541
Closes #1542 (there might be other issues with function name prettiness, but this specific issue should be fixed)
Closes #7715 (source locations for structs and enums are now read correctly from the AST)
