### PR TITLE
remove redundant tycat line from the binop table

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4266,8 +4266,7 @@ pub fn is_binopable(cx: ctxt, ty: t, op: ast::BinOp) -> bool {
     static tycat_char: int = 2;
     static tycat_int: int = 3;
     static tycat_float: int = 4;
-    static tycat_struct: int = 5;
-    static tycat_bot: int = 6;
+    static tycat_bot: int = 5;
 
     static opcat_add: int = 0;
     static opcat_sub: int = 1;
@@ -4310,7 +4309,6 @@ pub fn is_binopable(cx: ctxt, ty: t, op: ast::BinOp) -> bool {
           ty_bool => tycat_bool,
           ty_int(_) | ty_uint(_) | ty_infer(IntVar(_)) => tycat_int,
           ty_float(_) | ty_infer(FloatVar(_)) => tycat_float,
-          ty_tup(_) | ty_enum(_, _) => tycat_struct,
           ty_bot => tycat_bot,
           _ => tycat_other
         }
@@ -4326,8 +4324,7 @@ pub fn is_binopable(cx: ctxt, ty: t, op: ast::BinOp) -> bool {
     /*char*/    [f, f, f, f,     t,   t,  f,   f],
     /*int*/     [t, t, t, t,     t,   t,  t,   f],
     /*float*/   [t, t, t, f,     t,   t,  f,   f],
-    /*bot*/     [f, f, f, f,     f,   f,  f,   f],
-    /*struct*/  [t, t, t, t,     f,   f,  t,   t]];
+    /*bot*/     [t, t, t, t,     f,   f,  t,   t]];
 
     return tbl[tycat(cx, ty)][opcat(op)];
 }


### PR DESCRIPTION
The line marked as being for `bot` was actually for `tycat_struct`, and
can be replaced with `tycat_other`.
