### PR TITLE
Modernizing parts of Option, Result, and Default

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1717,7 +1717,8 @@ Supported traits for `deriving` are:
 * `Clone` and `DeepClone`, to perform (deep) copies.
 * `IterBytes`, to iterate over the bytes in a data type.
 * `Rand`, to create a random instance of a data type.
-* `Zero`, to create an zero (or empty) instance of a data type.
+* `Default`, to create an empty instance of a data type.
+* `Zero`, to create an zero instance of a numeric data type.
 * `ToStr`, to convert to a string. For a type with this instance,
   `obj.to_str()` has similar output as `fmt!("%?", obj)`, but it differs in that
   each constituent field of the type must also implement `ToStr` and will have

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2249,7 +2249,7 @@ enum ABC { A, B, C }
 
 The full list of derivable traits is `Eq`, `TotalEq`, `Ord`,
 `TotalOrd`, `Encodable` `Decodable`, `Clone`, `DeepClone`,
-`IterBytes`, `Rand`, `Zero`, and `ToStr`.
+`IterBytes`, `Rand`, `Default`, `Zero`, and `ToStr`.
 
 # Crates and the module system
 

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -309,7 +309,7 @@ pub fn make_test_name(config: &config, testfile: &Path) -> test::TestName {
         let filename = path.filename();
         let p = path.pop();
         let dir = p.filename();
-        fmt!("%s/%s", dir.unwrap_or_default(""), filename.unwrap_or_default(""))
+        fmt!("%s/%s", dir.unwrap_or(""), filename.unwrap_or(""))
     }
 
     test::DynTestName(fmt!("[%s] %s",

--- a/src/libextra/glob.rs
+++ b/src/libextra/glob.rs
@@ -137,7 +137,17 @@ fn list_dir_sorted(path: &Path) -> ~[Path] {
 /**
  * A compiled Unix shell style pattern.
  */
-#[deriving(Clone, Eq, TotalEq, Ord, TotalOrd, IterBytes, Zero)]
+#[cfg(stage0)]
+#[deriving(Clone, Eq, TotalEq, Ord, TotalOrd, IterBytes)]
+pub struct Pattern {
+    priv tokens: ~[PatternToken]
+}
+
+/**
+ * A compiled Unix shell style pattern.
+ */
+#[cfg(not(stage0))]
+#[deriving(Clone, Eq, TotalEq, Ord, TotalOrd, IterBytes, Default)]
 pub struct Pattern {
     priv tokens: ~[PatternToken]
 }
@@ -458,7 +468,37 @@ fn is_sep(c: char) -> bool {
 /**
  * Configuration options to modify the behaviour of `Pattern::matches_with(..)`
  */
-#[deriving(Clone, Eq, TotalEq, Ord, TotalOrd, IterBytes, Zero)]
+#[cfg(stage0)]
+#[deriving(Clone, Eq, TotalEq, Ord, TotalOrd, IterBytes)]
+pub struct MatchOptions {
+
+    /**
+     * Whether or not patterns should be matched in a case-sensitive manner. This
+     * currently only considers upper/lower case relationships between ASCII characters,
+     * but in future this might be extended to work with Unicode.
+     */
+    case_sensitive: bool,
+
+    /**
+     * If this is true then path-component separator characters (e.g. `/` on Posix)
+     * must be matched by a literal `/`, rather than by `*` or `?` or `[...]`
+     */
+    require_literal_separator: bool,
+
+    /**
+     * If this is true then paths that contain components that start with a `.` will
+     * not match unless the `.` appears literally in the pattern: `*`, `?` or `[...]`
+     * will not match. This is useful because such files are conventionally considered
+     * hidden on Unix systems and it might be desirable to skip them when listing files.
+     */
+    require_literal_leading_dot: bool
+}
+
+/**
+ * Configuration options to modify the behaviour of `Pattern::matches_with(..)`
+ */
+#[cfg(not(stage0))]
+#[deriving(Clone, Eq, TotalEq, Ord, TotalOrd, IterBytes, Default)]
 pub struct MatchOptions {
 
     /**

--- a/src/libextra/glob.rs
+++ b/src/libextra/glob.rs
@@ -312,7 +312,7 @@ impl Pattern {
         let require_literal = |c| {
             (options.require_literal_separator && is_sep(c)) ||
             (options.require_literal_leading_dot && c == '.'
-             && is_sep(prev_char.unwrap_or_default('/')))
+             && is_sep(prev_char.unwrap_or('/')))
         };
 
         for (ti, token) in self.tokens.slice_from(i).iter().enumerate() {

--- a/src/libextra/num/bigint.rs
+++ b/src/libextra/num/bigint.rs
@@ -635,7 +635,7 @@ impl BigUint {
 
     // Converts this BigUint into an int, unless it would overflow.
     pub fn to_int_opt(&self) -> Option<int> {
-        self.to_uint_opt().chain(|n| {
+        self.to_uint_opt().and_then(|n| {
             // If top bit of uint is set, it's too large to convert to
             // int.
             if (n >> (2*BigDigit::bits - 1) != 0) {
@@ -1221,7 +1221,7 @@ impl BigInt {
         match self.sign {
             Plus  => self.data.to_int_opt(),
             Zero  => Some(0),
-            Minus => self.data.to_uint_opt().chain(|n| {
+            Minus => self.data.to_uint_opt().and_then(|n| {
                 let m: uint = 1 << (2*BigDigit::bits-1);
                 if (n > m) {
                     None

--- a/src/libextra/num/rational.rs
+++ b/src/libextra/num/rational.rs
@@ -273,9 +273,9 @@ impl<T: FromStr + Clone + Integer + Ord>
             return None
         }
         let a_option: Option<T> = FromStr::from_str(split[0]);
-        do a_option.chain |a| {
+        do a_option.and_then |a| {
             let b_option: Option<T> = FromStr::from_str(split[1]);
-            do b_option.chain |b| {
+            do b_option.and_then |b| {
                 Some(Ratio::new(a.clone(), b.clone()))
             }
         }
@@ -291,10 +291,10 @@ impl<T: FromStrRadix + Clone + Integer + Ord>
         } else {
             let a_option: Option<T> = FromStrRadix::from_str_radix(split[0],
                                                                    radix);
-            do a_option.chain |a| {
+            do a_option.and_then |a| {
                 let b_option: Option<T> =
                     FromStrRadix::from_str_radix(split[1], radix);
-                do b_option.chain |b| {
+                do b_option.and_then |b| {
                     Some(Ratio::new(a.clone(), b.clone()))
                 }
             }

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -442,21 +442,21 @@ fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
           },
           'c' => {
             parse_type(s, pos, 'a', &mut *tm)
-                .chain(|pos| parse_char(s, pos, ' '))
-                .chain(|pos| parse_type(s, pos, 'b', &mut *tm))
-                .chain(|pos| parse_char(s, pos, ' '))
-                .chain(|pos| parse_type(s, pos, 'e', &mut *tm))
-                .chain(|pos| parse_char(s, pos, ' '))
-                .chain(|pos| parse_type(s, pos, 'T', &mut *tm))
-                .chain(|pos| parse_char(s, pos, ' '))
-                .chain(|pos| parse_type(s, pos, 'Y', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, ' '))
+                .and_then(|pos| parse_type(s, pos, 'b', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, ' '))
+                .and_then(|pos| parse_type(s, pos, 'e', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, ' '))
+                .and_then(|pos| parse_type(s, pos, 'T', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, ' '))
+                .and_then(|pos| parse_type(s, pos, 'Y', &mut *tm))
           }
           'D' | 'x' => {
             parse_type(s, pos, 'm', &mut *tm)
-                .chain(|pos| parse_char(s, pos, '/'))
-                .chain(|pos| parse_type(s, pos, 'd', &mut *tm))
-                .chain(|pos| parse_char(s, pos, '/'))
-                .chain(|pos| parse_type(s, pos, 'y', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, '/'))
+                .and_then(|pos| parse_type(s, pos, 'd', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, '/'))
+                .and_then(|pos| parse_type(s, pos, 'y', &mut *tm))
           }
           'd' => match match_digits_in_range(s, pos, 2u, false, 1_i32,
                                              31_i32) {
@@ -475,10 +475,10 @@ fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
           }
           'F' => {
             parse_type(s, pos, 'Y', &mut *tm)
-                .chain(|pos| parse_char(s, pos, '-'))
-                .chain(|pos| parse_type(s, pos, 'm', &mut *tm))
-                .chain(|pos| parse_char(s, pos, '-'))
-                .chain(|pos| parse_type(s, pos, 'd', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, '-'))
+                .and_then(|pos| parse_type(s, pos, 'm', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, '-'))
+                .and_then(|pos| parse_type(s, pos, 'd', &mut *tm))
           }
           'H' => {
             match match_digits_in_range(s, pos, 2u, false, 0_i32, 23_i32) {
@@ -553,17 +553,17 @@ fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
           },
           'R' => {
             parse_type(s, pos, 'H', &mut *tm)
-                .chain(|pos| parse_char(s, pos, ':'))
-                .chain(|pos| parse_type(s, pos, 'M', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, ':'))
+                .and_then(|pos| parse_type(s, pos, 'M', &mut *tm))
           }
           'r' => {
             parse_type(s, pos, 'I', &mut *tm)
-                .chain(|pos| parse_char(s, pos, ':'))
-                .chain(|pos| parse_type(s, pos, 'M', &mut *tm))
-                .chain(|pos| parse_char(s, pos, ':'))
-                .chain(|pos| parse_type(s, pos, 'S', &mut *tm))
-                .chain(|pos| parse_char(s, pos, ' '))
-                .chain(|pos| parse_type(s, pos, 'p', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, ':'))
+                .and_then(|pos| parse_type(s, pos, 'M', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, ':'))
+                .and_then(|pos| parse_type(s, pos, 'S', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, ' '))
+                .and_then(|pos| parse_type(s, pos, 'p', &mut *tm))
           }
           'S' => {
             match match_digits_in_range(s, pos, 2u, false, 0_i32, 60_i32) {
@@ -578,10 +578,10 @@ fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
           //'s' {}
           'T' | 'X' => {
             parse_type(s, pos, 'H', &mut *tm)
-                .chain(|pos| parse_char(s, pos, ':'))
-                .chain(|pos| parse_type(s, pos, 'M', &mut *tm))
-                .chain(|pos| parse_char(s, pos, ':'))
-                .chain(|pos| parse_type(s, pos, 'S', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, ':'))
+                .and_then(|pos| parse_type(s, pos, 'M', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, ':'))
+                .and_then(|pos| parse_type(s, pos, 'S', &mut *tm))
           }
           't' => parse_char(s, pos, '\t'),
           'u' => {
@@ -596,10 +596,10 @@ fn do_strptime(s: &str, format: &str) -> Result<Tm, ~str> {
           }
           'v' => {
             parse_type(s, pos, 'e', &mut *tm)
-                .chain(|pos|  parse_char(s, pos, '-'))
-                .chain(|pos| parse_type(s, pos, 'b', &mut *tm))
-                .chain(|pos| parse_char(s, pos, '-'))
-                .chain(|pos| parse_type(s, pos, 'Y', &mut *tm))
+                .and_then(|pos|  parse_char(s, pos, '-'))
+                .and_then(|pos| parse_type(s, pos, 'b', &mut *tm))
+                .and_then(|pos| parse_char(s, pos, '-'))
+                .and_then(|pos| parse_type(s, pos, 'Y', &mut *tm))
           }
           //'W' {}
           'w' => {

--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -417,6 +417,13 @@ impl Uuid {
     }
 }
 
+impl Default for Uuid {
+    /// Returns the nil UUID, which is all zeroes
+    fn default() -> Uuid {
+        Uuid::new_nil()
+    }
+}
+
 impl Zero for Uuid {
     /// Returns the nil UUID, which is all zeroes
     fn zero() -> Uuid {

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -961,7 +961,7 @@ pub fn build_output_filenames(input: &input,
           if !linkage_metas.is_empty() {
               // But if a linkage meta is present, that overrides
               let maybe_name = linkage_metas.iter().find(|m| "name" == m.name());
-              match maybe_name.chain(|m| m.value_str()) {
+              match maybe_name.and_then(|m| m.value_str()) {
                   Some(s) => stem = s,
                   _ => ()
               }

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -681,9 +681,9 @@ pub fn build_session_options(binary: @str,
             link::output_type_bitcode
         } else { link::output_type_exe };
     let sysroot_opt = getopts::opt_maybe_str(matches, "sysroot").map_move(|m| @Path(m));
-    let target = getopts::opt_maybe_str(matches, "target").unwrap_or_default(host_triple());
-    let target_cpu = getopts::opt_maybe_str(matches, "target-cpu").unwrap_or_default(~"generic");
-    let target_feature = getopts::opt_maybe_str(matches, "target-feature").unwrap_or_default(~"");
+    let target = getopts::opt_maybe_str(matches, "target").unwrap_or(host_triple());
+    let target_cpu = getopts::opt_maybe_str(matches, "target-cpu").unwrap_or(~"generic");
+    let target_feature = getopts::opt_maybe_str(matches, "target-feature").unwrap_or(~"");
     let save_temps = getopts::opt_present(matches, "save-temps");
     let opt_level = {
         if (debugging_opts & session::no_opt) != 0 {

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -58,7 +58,7 @@ fn filter_view_item<'r>(cx: @Context, view_item: &'r ast::view_item)-> Option<&'
 
 fn fold_mod(cx: @Context, m: &ast::_mod, fld: @fold::ast_fold) -> ast::_mod {
     let filtered_items = do  m.items.iter().filter_map |a| {
-        filter_item(cx, *a).chain(|x| fld.fold_item(x))
+        filter_item(cx, *a).and_then(|x| fld.fold_item(x))
     }.collect();
     let filtered_view_items = do m.view_items.iter().filter_map |a| {
         do filter_view_item(cx, a).map_move |x| {
@@ -139,7 +139,7 @@ fn fold_block(
     fld: @fold::ast_fold
 ) -> ast::Block {
     let resulting_stmts = do b.stmts.iter().filter_map |a| {
-        filter_stmt(cx, *a).chain(|stmt| fld.fold_stmt(stmt))
+        filter_stmt(cx, *a).and_then(|stmt| fld.fold_stmt(stmt))
     }.collect();
     let filtered_view_items = do b.view_items.iter().filter_map |a| {
         filter_view_item(cx, a).map(|x| fld.fold_view_item(*x))

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -184,7 +184,7 @@ fn visit_item(e: &Env, i: @ast::item) {
             ast::named => {
                 let link_name = i.attrs.iter()
                     .find(|at| "link_name" == at.name())
-                    .chain(|at| at.value_str());
+                    .and_then(|at| at.value_str());
 
                 let foreign_name = match link_name {
                         Some(nn) => {

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -210,7 +210,7 @@ fn each_reexport(d: ebml::Doc, f: &fn(ebml::Doc) -> bool) -> bool {
 }
 
 fn variant_disr_val(d: ebml::Doc) -> Option<ty::Disr> {
-    do reader::maybe_get_doc(d, tag_disr_val).chain |val_doc| {
+    do reader::maybe_get_doc(d, tag_disr_val).and_then |val_doc| {
         do reader::with_doc_data(val_doc) |data| { u64::parse_bytes(data, 10u) }
     }
 }

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -221,8 +221,7 @@ impl PrivacyVisitor {
         // If the method is a default method, we need to use the def_id of
         // the default implementation.
         // Having to do this this is really unfortunate.
-        let method_id = ty::method(self.tcx, method_id).provided_source
-            .unwrap_or_default(method_id);
+        let method_id = ty::method(self.tcx, method_id).provided_source.unwrap_or(method_id);
 
         if method_id.crate == LOCAL_CRATE {
             let is_private = self.method_is_private(span, method_id.node);

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -505,10 +505,7 @@ impl get_node_info for ast::Block {
 
 impl get_node_info for Option<@ast::Expr> {
     fn info(&self) -> Option<NodeInfo> {
-        match *self {
-            Some(ref s) => s.info(),
-            None => None,
-        }
+        self.and_then_ref(|s| s.info())
     }
 }
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -505,7 +505,10 @@ impl get_node_info for ast::Block {
 
 impl get_node_info for Option<@ast::Expr> {
     fn info(&self) -> Option<NodeInfo> {
-        self.chain_ref(|s| s.info())
+        match *self {
+            Some(ref s) => s.info(),
+            None => None,
+        }
     }
 }
 

--- a/src/librustc/middle/trans/value.rs
+++ b/src/librustc/middle/trans/value.rs
@@ -50,9 +50,9 @@ impl Value {
     /// must be the only user of this value, and there must not be any conditional
     /// branches between the store and the given block.
     pub fn get_dominating_store(self, bcx: @mut Block) -> Option<Value> {
-        match self.get_single_user().chain(|user| user.as_store_inst()) {
+        match self.get_single_user().and_then(|user| user.as_store_inst()) {
             Some(store) => {
-                do store.get_parent().chain |store_bb| {
+                do store.get_parent().and_then |store_bb| {
                     let mut bb = BasicBlock(bcx.llbb);
                     let mut ret = Some(store);
                     while *bb != *store_bb {
@@ -150,7 +150,7 @@ impl Iterator<Value> for UserIterator {
     fn next(&mut self) -> Option<Value> {
         let current = self.next;
 
-        self.next = do current.chain |u| { u.get_next_use() };
+        self.next = do current.and_then |u| { u.get_next_use() };
 
         do current.map |u| { u.get_user() }
     }

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -745,10 +745,17 @@ pub fn ty_of_closure<AC:AstConv,RS:RegionScope + Clone + 'static>(
                           RegionParamNames(bound_lifetime_names.clone()));
 
     let input_tys = do decl.inputs.iter().enumerate().map |(i, a)| {
-        let expected_arg_ty = do expected_sig.chain_ref |e| {
-            // no guarantee that the correct number of expected args
-            // were supplied
-            if i < e.inputs.len() {Some(e.inputs[i])} else {None}
+        let expected_arg_ty = match expected_sig {
+            Some(ref e) => {
+                // no guarantee that the correct number of expected args
+                // were supplied
+                if i < e.inputs.len() {
+                    Some(e.inputs[i])
+                } else {
+                    None
+                }
+            }
+            None => None,
         };
         ty_of_arg(this, &rb, a, expected_arg_ty)
     }.collect();

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -745,17 +745,10 @@ pub fn ty_of_closure<AC:AstConv,RS:RegionScope + Clone + 'static>(
                           RegionParamNames(bound_lifetime_names.clone()));
 
     let input_tys = do decl.inputs.iter().enumerate().map |(i, a)| {
-        let expected_arg_ty = match expected_sig {
-            Some(ref e) => {
-                // no guarantee that the correct number of expected args
-                // were supplied
-                if i < e.inputs.len() {
-                    Some(e.inputs[i])
-                } else {
-                    None
-                }
-            }
-            None => None,
+        let expected_arg_ty = do expected_sig.and_then_ref |e| {
+            // no guarantee that the correct number of expected args
+            // were supplied
+            if i < e.inputs.len() {Some(e.inputs[i])} else {None}
         };
         ty_of_arg(this, &rb, a, expected_arg_ty)
     }.collect();

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -173,7 +173,7 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: @ast::Pat, path: &ast::Path,
                     fcx.write_error(pat.id);
                     kind_name = "[error]";
                     arg_types = (*subpats).clone()
-                                          .unwrap_or(~[])
+                                          .unwrap_or_default()
                                           .map(|_| ty::mk_err());
                 }
             }
@@ -222,7 +222,7 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: @ast::Pat, path: &ast::Path,
             fcx.write_error(pat.id);
             kind_name = "[error]";
             arg_types = (*subpats).clone()
-                                  .unwrap_or(~[])
+                                  .unwrap_or_default()
                                   .map(|_| ty::mk_err());
         }
     }

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -173,7 +173,7 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: @ast::Pat, path: &ast::Path,
                     fcx.write_error(pat.id);
                     kind_name = "[error]";
                     arg_types = (*subpats).clone()
-                                          .unwrap_or_default(~[])
+                                          .unwrap_or(~[])
                                           .map(|_| ty::mk_err());
                 }
             }
@@ -222,7 +222,7 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: @ast::Pat, path: &ast::Path,
             fcx.write_error(pat.id);
             kind_name = "[error]";
             arg_types = (*subpats).clone()
-                                  .unwrap_or_default(~[])
+                                  .unwrap_or(~[])
                                   .map(|_| ty::mk_err());
         }
     }

--- a/src/librustc/middle/typeck/infer/glb.rs
+++ b/src/librustc/middle/typeck/infer/glb.rs
@@ -61,7 +61,7 @@ impl Combine for Glb {
           // If one side or both is immutable, we can use the GLB of
           // both sides but mutbl must be `MutImmutable`.
           (MutImmutable, MutImmutable) => {
-            self.tys(a.ty, b.ty).chain(|t| {
+            self.tys(a.ty, b.ty).and_then(|t| {
                 Ok(ty::mt {ty: t, mutbl: MutImmutable})
             })
           }

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -232,7 +232,7 @@ impl CombineFieldsLatticeMethods for CombineFields {
             (&Some(_),       &None) => Ok((*a).clone()),
             (&None,          &Some(_)) => Ok((*b).clone()),
             (&Some(ref v_a), &Some(ref v_b)) => {
-                do lattice_op(self, v_a, v_b).chain |v| {
+                do lattice_op(self, v_a, v_b).and_then |v| {
                     Ok(Some(v))
                 }
             }

--- a/src/librustc/middle/typeck/infer/lub.rs
+++ b/src/librustc/middle/typeck/infer/lub.rs
@@ -62,7 +62,7 @@ impl Combine for Lub {
         let m = a.mutbl;
         match m {
           MutImmutable => {
-            self.tys(a.ty, b.ty).chain(|t| Ok(ty::mt {ty: t, mutbl: m}) )
+            self.tys(a.ty, b.ty).and_then(|t| Ok(ty::mt {ty: t, mutbl: m}) )
           }
 
           MutMutable => {
@@ -70,7 +70,7 @@ impl Combine for Lub {
                 eq_tys(self, a.ty, b.ty).then(|| {
                     Ok(ty::mt {ty: a.ty, mutbl: m})
                 })
-            }).chain_err(|e| Err(e))
+            }).or_else(|e| Err(e))
           }
         }
     }

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -451,7 +451,7 @@ trait then {
 impl then for ures {
     fn then<T:Clone>(&self, f: &fn() -> Result<T,ty::type_err>)
         -> Result<T,ty::type_err> {
-        self.chain(|_i| f())
+        self.and_then(|_i| f())
     }
 }
 
@@ -474,7 +474,7 @@ trait CresCompare<T> {
 
 impl<T:Clone + Eq> CresCompare<T> for cres<T> {
     fn compare(&self, t: T, f: &fn() -> ty::type_err) -> cres<T> {
-        do (*self).clone().chain |s| {
+        do (*self).clone().and_then |s| {
             if s == t {
                 (*self).clone()
             } else {

--- a/src/librustc/middle/typeck/infer/sub.rs
+++ b/src/librustc/middle/typeck/infer/sub.rs
@@ -79,7 +79,7 @@ impl Combine for Sub {
           }
           MutImmutable => {
             // Otherwise we can be covariant:
-            self.tys(a.ty, b.ty).chain(|_t| Ok(*a) )
+            self.tys(a.ty, b.ty).and_then(|_t| Ok(*a) )
           }
         }
     }

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -202,7 +202,7 @@ impl RegionScope for MethodRscope {
         if !self.region_param_names.has_ident(id) {
             return RegionParamNames::undeclared_name(None);
         }
-        do EmptyRscope.named_region(span, id).chain_err |_e| {
+        do EmptyRscope.named_region(span, id).or_else |_e| {
             result::Err(RegionError {
                 msg: ~"lifetime is not in scope",
                 replacement: ty::re_bound(ty::br_self)
@@ -251,7 +251,7 @@ impl RegionScope for TypeRscope {
     }
     fn named_region(&self, span: Span, id: ast::Ident)
                       -> Result<ty::Region, RegionError> {
-        do EmptyRscope.named_region(span, id).chain_err |_e| {
+        do EmptyRscope.named_region(span, id).or_else |_e| {
             result::Err(RegionError {
                 msg: ~"only 'self is allowed as part of a type declaration",
                 replacement: self.replacement()
@@ -310,7 +310,7 @@ impl RegionScope for BindingRscope {
                     span: Span,
                     id: ast::Ident) -> Result<ty::Region, RegionError>
     {
-        do self.base.named_region(span, id).chain_err |_e| {
+        do self.base.named_region(span, id).or_else |_e| {
             let result = ty::re_bound(ty::br_named(id));
             if self.region_param_names.has_ident(id) {
                 result::Ok(result)

--- a/src/librustdoc/attr_pass.rs
+++ b/src/librustdoc/attr_pass.rs
@@ -68,7 +68,7 @@ fn fold_crate(
     doc::CrateDoc {
         topmod: doc::ModDoc {
             item: doc::ItemDoc {
-                name: attrs.name.clone().unwrap_or_default(doc.topmod.name_()),
+                name: attrs.name.clone().unwrap_or(doc.topmod.name_()),
                 .. doc.topmod.item.clone()
             },
             .. doc.topmod.clone()

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -142,7 +142,7 @@ fn config_from_opts(
         let output_dir = getopts::opt_maybe_str(matches, opt_output_dir());
         let output_dir = output_dir.map_move(|s| Path(s));
         result::Ok(Config {
-            output_dir: output_dir.unwrap_or_default(config.output_dir.clone()),
+            output_dir: output_dir.unwrap_or(config.output_dir.clone()),
             .. config
         })
     };

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -138,7 +138,7 @@ fn config_from_opts(
 
     let config = default_config(input_crate);
     let result = result::Ok(config);
-    let result = do result.chain |config| {
+    let result = do result.and_then |config| {
         let output_dir = getopts::opt_maybe_str(matches, opt_output_dir());
         let output_dir = output_dir.map_move(|s| Path(s));
         result::Ok(Config {
@@ -146,10 +146,10 @@ fn config_from_opts(
             .. config
         })
     };
-    let result = do result.chain |config| {
+    let result = do result.and_then |config| {
         let output_format = getopts::opt_maybe_str(matches, opt_output_format());
         do output_format.map_move_default(result::Ok(config.clone())) |output_format| {
-            do parse_output_format(output_format).chain |output_format| {
+            do parse_output_format(output_format).and_then |output_format| {
                 result::Ok(Config {
                     output_format: output_format,
                     .. config.clone()
@@ -157,11 +157,11 @@ fn config_from_opts(
             }
         }
     };
-    let result = do result.chain |config| {
+    let result = do result.and_then |config| {
         let output_style =
             getopts::opt_maybe_str(matches, opt_output_style());
         do output_style.map_move_default(result::Ok(config.clone())) |output_style| {
-            do parse_output_style(output_style).chain |output_style| {
+            do parse_output_style(output_style).and_then |output_style| {
                 result::Ok(Config {
                     output_style: output_style,
                     .. config.clone()
@@ -170,11 +170,11 @@ fn config_from_opts(
         }
     };
     let process_output = Cell::new(process_output);
-    let result = do result.chain |config| {
+    let result = do result.and_then |config| {
         let pandoc_cmd = getopts::opt_maybe_str(matches, opt_pandoc_cmd());
         let pandoc_cmd = maybe_find_pandoc(
             &config, pandoc_cmd, process_output.take());
-        do pandoc_cmd.chain |pandoc_cmd| {
+        do pandoc_cmd.and_then |pandoc_cmd| {
             result::Ok(Config {
                 pandoc_cmd: pandoc_cmd,
                 .. config.clone()

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -118,7 +118,7 @@ pub fn try_getting_local_version(local_path: &Path) -> Option<Version> {
         if !l.is_whitespace() {
             output = Some(l);
         }
-        match output.chain(try_parsing_version) {
+        match output.and_then(try_parsing_version) {
             Some(v) => return Some(v),
             None    => ()
         }
@@ -158,7 +158,7 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
                 }
             }
 
-            output.chain(try_parsing_version)
+            output.and_then(try_parsing_version)
         }
         else {
             None

--- a/src/libstd/at_vec.rs
+++ b/src/libstd/at_vec.rs
@@ -45,7 +45,7 @@ pub fn capacity<T>(v: @[T]) -> uint {
 #[inline]
 pub fn build<A>(size: Option<uint>, builder: &fn(push: &fn(v: A))) -> @[A] {
     let mut vec = @[];
-    unsafe { raw::reserve(&mut vec, size.unwrap_or_default(4)); }
+    unsafe { raw::reserve(&mut vec, size.unwrap_or(4)); }
     builder(|x| unsafe { raw::push(&mut vec, x) });
     vec
 }

--- a/src/libstd/bool.rs
+++ b/src/libstd/bool.rs
@@ -24,6 +24,7 @@ Implementations of the following traits:
 * `Ord`
 * `TotalOrd`
 * `Eq`
+* `Default`
 * `Zero`
 
 ## Various functions to compare `bool`s
@@ -43,6 +44,7 @@ use to_str::ToStr;
 
 #[cfg(not(test))] use cmp::{Eq, Ord, TotalOrd, Ordering};
 #[cfg(not(test))] use ops::Not;
+#[cfg(not(test))] use default::Default;
 #[cfg(not(test))] use num::Zero;
 
 /**
@@ -321,6 +323,11 @@ impl TotalOrd for bool {
 impl Eq for bool {
     #[inline]
     fn eq(&self, other: &bool) -> bool { (*self) == (*other) }
+}
+
+#[cfg(not(test))]
+impl Default for bool {
+    fn default() -> bool { false }
 }
 
 #[cfg(not(test))]

--- a/src/libstd/char.rs
+++ b/src/libstd/char.rs
@@ -21,6 +21,7 @@ use str;
 #[cfg(test)] use str::OwnedStr;
 
 #[cfg(not(test))] use cmp::{Eq, Ord};
+#[cfg(not(test))] use default::Default;
 #[cfg(not(test))] use num::Zero;
 
 // UTF-8 ranges and tags for encoding characters
@@ -435,8 +436,17 @@ impl Ord for char {
 }
 
 #[cfg(not(test))]
+impl Default for char {
+    #[inline]
+    fn default() -> char { '\x00' }
+}
+
+#[cfg(not(test))]
 impl Zero for char {
+    #[inline]
     fn zero() -> char { '\x00' }
+
+    #[inline]
     fn is_zero(&self) -> bool { *self == '\x00' }
 }
 

--- a/src/libstd/default.rs
+++ b/src/libstd/default.rs
@@ -15,3 +15,15 @@ pub trait Default {
     /// Return the "default value" for a type.
     fn default() -> Self;
 }
+
+impl<T: Default + 'static> Default for @mut T {
+    fn default() -> @mut T { @mut Default::default() }
+}
+
+impl<T: Default + 'static> Default for @T {
+    fn default() -> @T { @Default::default() }
+}
+
+impl<T: Default> Default for ~T {
+    fn default() -> ~T { ~Default::default() }
+}

--- a/src/libstd/either.rs
+++ b/src/libstd/either.rs
@@ -105,6 +105,24 @@ impl<L, R> Either<L, R> {
     }
 }
 
+/// A generic trait for converting a value to a `Either`
+pub trait ToEither<L, R> {
+    /// Convert to the `either` type
+    fn to_either(&self) -> Either<L, R>;
+}
+
+/// A generic trait for converting a value to a `Either`
+pub trait IntoEither<L, R> {
+    /// Convert to the `either` type
+    fn into_either(self) -> Either<L, R>;
+}
+
+/// A generic trait for converting a value to a `Either`
+pub trait AsEither<L, R> {
+    /// Convert to the `either` type
+    fn as_either<'a>(&'a self) -> Either<&'a L, &'a R>;
+}
+
 impl<L, R: Clone> option::ToOption<R> for Either<L, R> {
     #[inline]
     fn to_option(&self)-> option::Option<R> {
@@ -161,6 +179,23 @@ impl<L, R> result::AsResult<R, L> for Either<L, R> {
         match *self {
             Left(ref l) => result::Err(l),
             Right(ref r) => result::Ok(r),
+        }
+    }
+}
+
+impl<L: Clone, R: Clone> ToEither<L, R> for Either<L, R> {
+    fn to_either(&self) -> Either<L, R> { self.clone() }
+}
+
+impl<L, R> IntoEither<L, R> for Either<L, R> {
+    fn into_either(self) -> Either<L, R> { self }
+}
+
+impl<L, R> AsEither<L, R> for Either<L, R> {
+    fn as_either<'a>(&'a self) -> Either<&'a L, &'a R> {
+        match *self {
+            Left(ref l) => Left(l),
+            Right(ref r) => Right(r),
         }
     }
 }
@@ -369,5 +404,32 @@ mod tests {
 
         let x = 404;
         assert_eq!(left.as_result(), result::Err(&x));
+    }
+
+    #[test]
+    pub fn test_to_either() {
+        let right: Either<int, int> = Right(100);
+        let left: Either<int, int> = Left(404);
+
+        assert_eq!(right.to_either(), Right(100));
+        assert_eq!(left.to_either(), Left(404));
+    }
+
+    #[test]
+    pub fn test_into_either() {
+        let right: Either<int, int> = Right(100);
+        let left: Either<int, int> = Left(404);
+
+        assert_eq!(right.into_either(), Right(100));
+        assert_eq!(left.into_either(), Left(404));
+    }
+
+    #[test]
+    pub fn test_as_either() {
+        let right: Either<int, int> = Right(100);
+        let left: Either<int, int> = Left(404);
+
+        assert_eq!(right.as_either().unwrap_right(), &100);
+        assert_eq!(left.as_either().unwrap_left(), &404);
     }
 }

--- a/src/libstd/either.rs
+++ b/src/libstd/either.rs
@@ -13,6 +13,7 @@
 #[allow(missing_doc)];
 
 use option::{Some, None};
+use option;
 use clone::Clone;
 use container::Container;
 use cmp::Eq;
@@ -116,6 +117,36 @@ impl<L, R> Either<L, R> {
     }
 }
 
+impl<L, R: Clone> option::ToOption<R> for Either<L, R> {
+    #[inline]
+    fn to_option(&self)-> option::Option<R> {
+        match *self {
+            Left(_) => None,
+            Right(ref r) => Some(r.clone()),
+        }
+    }
+}
+
+impl<L, R> option::IntoOption<R> for Either<L, R> {
+    #[inline]
+    fn into_option(self)-> option::Option<R> {
+        match self {
+            Left(_) => None,
+            Right(r) => Some(r),
+        }
+    }
+}
+
+impl<L, R> option::AsOption<R> for Either<L, R> {
+    #[inline]
+    fn as_option<'a>(&'a self) -> option::Option<&'a R> {
+        match *self {
+            Left(_) => None,
+            Right(ref r) => Some(r),
+        }
+    }
+}
+
 /// An iterator yielding the `Left` values of its source
 pub type Lefts<L, R, Iter> = FilterMap<'static, Either<L, R>, L, Iter>;
 
@@ -166,6 +197,9 @@ pub fn partition<L, R>(eithers: ~[Either<L, R>]) -> (~[L], ~[R]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use option::{IntoOption, ToOption, AsOption};
+    use option;
 
     #[test]
     fn test_either_left() {
@@ -260,4 +294,30 @@ mod tests {
         assert_eq!(rights.len(), 0u);
     }
 
+    #[test]
+    pub fn test_to_option() {
+        let right: Either<int, int> = Right(100);
+        let left: Either<int, int> = Left(404);
+
+        assert_eq!(right.to_option(), option::Some(100));
+        assert_eq!(left.to_option(), option::None);
+    }
+
+    #[test]
+    pub fn test_into_option() {
+        let right: Either<int, int> = Right(100);
+        let left: Either<int, int> = Left(404);
+
+        assert_eq!(right.into_option(), option::Some(100));
+        assert_eq!(left.into_option(), option::None);
+    }
+
+    #[test]
+    pub fn test_as_option() {
+        let right: Either<int, int> = Right(100);
+        let left: Either<int, int> = Left(404);
+
+        assert_eq!(right.as_option().unwrap(), &100);
+        assert_eq!(left.as_option(), option::None);
+    }
 }

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -18,6 +18,7 @@
 use container::{Container, Mutable, Map, MutableMap, Set, MutableSet};
 use clone::Clone;
 use cmp::{Eq, Equiv};
+use default::Default;
 use hash::Hash;
 use iter::{Iterator, FromIterator, Extendable};
 use iter::{FilterMap, Chain, Repeat, Zip};
@@ -622,6 +623,10 @@ impl<K: Eq + Hash, V> Extendable<(K, V)> for HashMap<K, V> {
     }
 }
 
+impl<K: Eq + Hash, V> Default for HashMap<K, V> {
+    fn default() -> HashMap<K, V> { HashMap::new() }
+}
+
 /// An implementation of a hash set using the underlying representation of a
 /// HashMap where the value is (). As with the `HashMap` type, a `HashSet`
 /// requires that the elements implement the `Eq` and `Hash` traits.
@@ -768,6 +773,10 @@ impl<K: Eq + Hash> Extendable<K> for HashSet<K> {
             self.insert(k);
         }
     }
+}
+
+impl<K: Eq + Hash> Default for HashSet<K> {
+    fn default() -> HashSet<K> { HashSet::new() }
 }
 
 // `Repeat` is used to feed the filter closure an explicit capture

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -1618,7 +1618,7 @@ impl<T:Writer> WriterUtil for T {
 }
 
 pub fn file_writer(path: &Path, flags: &[FileFlag]) -> Result<@Writer, ~str> {
-    mk_file_writer(path, flags).chain(|w| Ok(w))
+    mk_file_writer(path, flags).and_then(|w| Ok(w))
 }
 
 
@@ -1779,7 +1779,7 @@ pub fn seek_in_buf(offset: int, pos: uint, len: uint, whence: SeekStyle) ->
 }
 
 pub fn read_whole_file_str(file: &Path) -> Result<~str, ~str> {
-    do read_whole_file(file).chain |bytes| {
+    do read_whole_file(file).and_then |bytes| {
         if str::is_utf8(bytes) {
             Ok(str::from_utf8(bytes))
         } else {
@@ -1791,7 +1791,7 @@ pub fn read_whole_file_str(file: &Path) -> Result<~str, ~str> {
 // FIXME (#2004): implement this in a low-level way. Going through the
 // abstractions is pointless.
 pub fn read_whole_file(file: &Path) -> Result<~[u8], ~str> {
-    do file_reader(file).chain |rdr| {
+    do file_reader(file).and_then |rdr| {
         Ok(rdr.read_whole_stream())
     }
 }

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -1504,12 +1504,7 @@ impl<'self, A, T: Iterator<A>, B, U: Iterator<B>> Iterator<B> for FlatMap<'self,
                 }
             }
             match self.iter.next().map_move(|x| (self.f)(x)) {
-                None => {
-                    return match self.backiter {
-                        Some(ref mut it) => it.next(),
-                        None => None,
-                    };
-                }
+                None => return self.backiter.and_then_mut_ref(|it| it.next()),
                 next => self.frontiter = next,
             }
         }
@@ -1541,12 +1536,7 @@ impl<'self,
                 }
             }
             match self.iter.next_back().map_move(|x| (self.f)(x)) {
-                None => {
-                    return match self.frontiter {
-                        Some(ref mut it) => it.next_back(),
-                        None => None,
-                    };
-                }
+                None => return self.frontiter.and_then_mut_ref(|it| it.next_back()),
                 next => self.backiter = next,
             }
         }

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -1474,7 +1474,7 @@ pub struct Scan<'self, A, B, T, St> {
 impl<'self, A, B, T: Iterator<A>, St> Iterator<B> for Scan<'self, A, B, T, St> {
     #[inline]
     fn next(&mut self) -> Option<B> {
-        self.iter.next().chain(|a| (self.f)(&mut self.state, a))
+        self.iter.next().and_then(|a| (self.f)(&mut self.state, a))
     }
 
     #[inline]
@@ -1494,8 +1494,7 @@ pub struct FlatMap<'self, A, T, U> {
     priv backiter: Option<U>,
 }
 
-impl<'self, A, T: Iterator<A>, B, U: Iterator<B>> Iterator<B> for
-    FlatMap<'self, A, T, U> {
+impl<'self, A, T: Iterator<A>, B, U: Iterator<B>> Iterator<B> for FlatMap<'self, A, T, U> {
     #[inline]
     fn next(&mut self) -> Option<B> {
         loop {
@@ -1505,7 +1504,12 @@ impl<'self, A, T: Iterator<A>, B, U: Iterator<B>> Iterator<B> for
                 }
             }
             match self.iter.next().map_move(|x| (self.f)(x)) {
-                None => return self.backiter.chain_mut_ref(|it| it.next()),
+                None => {
+                    return match self.backiter {
+                        Some(ref mut it) => it.next(),
+                        None => None,
+                    };
+                }
                 next => self.frontiter = next,
             }
         }
@@ -1537,7 +1541,12 @@ impl<'self,
                 }
             }
             match self.iter.next_back().map_move(|x| (self.f)(x)) {
-                None => return self.frontiter.chain_mut_ref(|it| it.next_back()),
+                None => {
+                    return match self.frontiter {
+                        Some(ref mut it) => it.next_back(),
+                        None => None,
+                    };
+                }
                 next => self.backiter = next,
             }
         }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -12,6 +12,7 @@
 #[allow(missing_doc)];
 #[allow(non_uppercase_statics)];
 
+use default::Default;
 use libc::c_int;
 use num::{Zero, One, strconv};
 use num::{FPCategory, FPNaN, FPInfinite , FPZero, FPSubnormal, FPNormal};
@@ -235,6 +236,11 @@ impl Orderable for f32 {
             _                 { *self }
         )
     }
+}
+
+impl Default for f32 {
+    #[inline]
+    fn default() -> f32 { 0.0 }
 }
 
 impl Zero for f32 {

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -13,6 +13,7 @@
 #[allow(missing_doc)];
 #[allow(non_uppercase_statics)];
 
+use default::Default;
 use libc::c_int;
 use num::{Zero, One, strconv};
 use num::{FPCategory, FPNaN, FPInfinite , FPZero, FPSubnormal, FPNormal};
@@ -258,6 +259,11 @@ impl Orderable for f64 {
             _                 { *self }
         )
     }
+}
+
+impl Default for f64 {
+    #[inline]
+    fn default() -> f64 { 0.0 }
 }
 
 impl Zero for f64 {

--- a/src/libstd/num/float.rs
+++ b/src/libstd/num/float.rs
@@ -23,6 +23,7 @@
 #[allow(missing_doc)];
 #[allow(non_uppercase_statics)];
 
+use default::Default;
 use num::{Zero, One, strconv};
 use num::FPCategory;
 use num;
@@ -380,6 +381,11 @@ impl Orderable for float {
     fn clamp(&self, mn: &float, mx: &float) -> float {
         (*self as f64).clamp(&(*mn as f64), &(*mx as f64)) as float
     }
+}
+
+impl Default for float {
+    #[inline]
+    fn default() -> float { 0.0 }
 }
 
 impl Zero for float {

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -16,6 +16,7 @@ macro_rules! int_module (($T:ty, $bits:expr) => (mod generated {
 
 #[allow(non_uppercase_statics)];
 
+use default::Default;
 use num::{ToStrRadix, FromStrRadix};
 use num::{CheckedDiv, Zero, One, strconv};
 use prelude::*;
@@ -165,6 +166,11 @@ impl Orderable for $T {
         if *self > *mx { *mx } else
         if *self < *mn { *mn } else { *self }
     }
+}
+
+impl Default for $T {
+    #[inline]
+    fn default() -> $T { 0 }
 }
 
 impl Zero for $T {

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -16,6 +16,7 @@ macro_rules! uint_module (($T:ty, $T_SIGNED:ty, $bits:expr) => (mod generated {
 
 #[allow(non_uppercase_statics)];
 
+use default::Default;
 use num::BitCount;
 use num::{ToStrRadix, FromStrRadix};
 use num::{CheckedDiv, Zero, One, strconv};
@@ -170,6 +171,11 @@ impl Orderable for $T {
             _             { *self }
         )
     }
+}
+
+impl Default for $T {
+    #[inline]
+    fn default() -> $T { 0 }
 }
 
 impl Zero for $T {

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -332,7 +332,7 @@ impl<T> Option<T> {
 
     /// Returns the contained value or a default
     #[inline]
-    pub fn unwrap_or_default(self, def: T) -> T {
+    pub fn unwrap_or(self, def: T) -> T {
         match self {
             Some(x) => x,
             None => def

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -350,6 +350,26 @@ impl<T> Option<T> {
     }
 }
 
+impl<T: Default> Option<T> {
+    /// Returns the contained value or default (for this type)
+    #[inline]
+    pub fn unwrap_or_default(self) -> T {
+        match self {
+            Some(x) => x,
+            None => Default::default()
+        }
+    }
+
+    /// Returns self or `Some`-wrapped default value
+    #[inline]
+    pub fn or_default(self) -> Option<T> {
+        match self {
+            None => Some(Default::default()),
+            x => x,
+        }
+    }
+}
+
 impl<T> Default for Option<T> {
     fn default() -> Option<T> { None }
 }

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -459,6 +459,7 @@ impl<T: Default> Option<T> {
 }
 
 impl<T> Default for Option<T> {
+    #[inline]
     fn default() -> Option<T> { None }
 }
 

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -340,6 +340,15 @@ impl<T> Option<T> {
         }
     }
 
+    /// Returns the contained value or computes it from a closure
+    #[inline]
+    pub fn unwrap_or_else(self, f: &fn() -> T) -> T {
+        match self {
+            Some(x) => x,
+            None => f()
+        }
+    }
+
     /// Applies a function zero or more times until the result is `None`.
     #[inline]
     pub fn while_some(self, blk: &fn(v: T) -> Option<T>) {
@@ -512,6 +521,44 @@ mod tests {
             }
         }
         assert_eq!(i, 11);
+    }
+
+    #[test]
+    fn test_unwrap() {
+        assert_eq!(Some(1).unwrap(), 1);
+        assert_eq!(Some(~"hello").unwrap(), ~"hello");
+    }
+
+    #[test]
+    #[should_fail]
+    fn test_unwrap_fail1() {
+        let x: Option<int> = None;
+        x.unwrap();
+    }
+
+    #[test]
+    #[should_fail]
+    fn test_unwrap_fail2() {
+        let x: Option<~str> = None;
+        x.unwrap();
+    }
+
+    #[test]
+    fn test_unwrap_or() {
+        let x: Option<int> = Some(1);
+        assert_eq!(x.unwrap_or(2), 1);
+
+        let x: Option<int> = None;
+        assert_eq!(x.unwrap_or(2), 2);
+    }
+
+    #[test]
+    fn test_unwrap_or_else() {
+        let x: Option<int> = Some(1);
+        assert_eq!(x.unwrap_or_else(|| 2), 1);
+
+        let x: Option<int> = None;
+        assert_eq!(x.unwrap_or_else(|| 2), 2);
     }
 
     #[test]

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -138,13 +138,33 @@ impl<T> Option<T> {
         }
     }
 
-    /// Returns `None` if the option is `None`, otherwise calls and returns the
-    /// value of `f`.
+    /// Returns `None` if the option is `None`, otherwise calls `f` with the
+    /// wrapped value and returns the result.
     #[inline]
     pub fn and_then<U>(self, f: &fn(T) -> Option<U>) -> Option<U> {
         match self {
             Some(x) => f(x),
             None => None,
+        }
+    }
+
+    /// Returns `None` if the option is `None`, otherwise calls `f` with a
+    /// reference to the wrapped value and returns the result.
+    #[inline]
+    pub fn and_then_ref<'a, U>(&'a self, f: &fn(&'a T) -> Option<U>) -> Option<U> {
+        match *self {
+            Some(ref x) => f(x),
+            None => None
+        }
+    }
+
+    /// Returns `None` if the option is `None`, otherwise calls `f` with a
+    /// mutable reference to the wrapped value and returns the result.
+    #[inline]
+    pub fn and_then_mut_ref<'a, U>(&'a mut self, f: &fn(&'a mut T) -> Option<U>) -> Option<U> {
+        match *self {
+            Some(ref mut x) => f(x),
+            None => None
         }
     }
 
@@ -157,8 +177,8 @@ impl<T> Option<T> {
         }
     }
 
-    /// Returns the option if it contains a value, otherwise calls and returns the
-    /// value of `f`.
+    /// Returns the option if it contains a value, otherwise calls `f` and
+    /// returns the result.
     #[inline]
     pub fn or_else(self, f: &fn() -> Option<T>) -> Option<T> {
         match self {

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -48,6 +48,7 @@ use util;
 use num::Zero;
 use iter;
 use iter::{Iterator, DoubleEndedIterator, ExactSize};
+use result;
 use str::{StrSlice, OwnedStr};
 use to_str::ToStr;
 use clone::DeepClone;
@@ -426,6 +427,26 @@ impl<T> AsOption<T> for Option<T> {
     }
 }
 
+impl<T: Clone> result::ToResult<T, ()> for Option<T> {
+    #[inline]
+    fn to_result(&self) -> result::Result<T, ()> {
+        match *self {
+            Some(ref x) => result::Ok(x.clone()),
+            None => result::Err(()),
+        }
+    }
+}
+
+impl<T> result::IntoResult<T, ()> for Option<T> {
+    #[inline]
+    fn into_result(self) -> result::Result<T, ()> {
+        match self {
+            Some(x) => result::Ok(x),
+            None => result::Err(()),
+        }
+    }
+}
+
 impl<T: Default> Option<T> {
     /// Returns the contained value or default (for this type)
     #[inline]
@@ -508,6 +529,8 @@ impl<A> ExactSize<A> for OptionIterator<A> {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use result::{IntoResult, ToResult};
+    use result;
     use util;
 
     #[test]
@@ -775,5 +798,23 @@ mod tests {
 
         assert_eq!(some.as_option().unwrap(), &100);
         assert_eq!(none.as_option(), None);
+    }
+
+    #[test]
+    pub fn test_to_result() {
+        let some: Option<int> = Some(100);
+        let none: Option<int> = None;
+
+        assert_eq!(some.to_result(), result::Ok(100));
+        assert_eq!(none.to_result(), result::Err(()));
+    }
+
+    #[test]
+    pub fn test_into_result() {
+        let some: Option<int> = Some(100);
+        let none: Option<int> = None;
+
+        assert_eq!(some.into_result(), result::Ok(100));
+        assert_eq!(none.into_result(), result::Err(()));
     }
 }

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -44,6 +44,7 @@ let unwrapped_msg = match msg {
 use clone::Clone;
 use cmp::{Eq,Ord};
 use default::Default;
+use either;
 use util;
 use num::Zero;
 use iter;
@@ -447,6 +448,26 @@ impl<T> result::IntoResult<T, ()> for Option<T> {
     }
 }
 
+impl<T: Clone> either::ToEither<(), T> for Option<T> {
+    #[inline]
+    fn to_either(&self) -> either::Either<(), T> {
+        match *self {
+            Some(ref x) => either::Right(x.clone()),
+            None => either::Left(()),
+        }
+    }
+}
+
+impl<T> either::IntoEither<(), T> for Option<T> {
+    #[inline]
+    fn into_either(self) -> either::Either<(), T> {
+        match self {
+            Some(x) => either::Right(x),
+            None => either::Left(()),
+        }
+    }
+}
+
 impl<T: Default> Option<T> {
     /// Returns the contained value or default (for this type)
     #[inline]
@@ -529,6 +550,9 @@ impl<A> ExactSize<A> for OptionIterator<A> {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use either::{IntoEither, ToEither};
+    use either;
     use result::{IntoResult, ToResult};
     use result;
     use util;
@@ -816,5 +840,23 @@ mod tests {
 
         assert_eq!(some.into_result(), result::Ok(100));
         assert_eq!(none.into_result(), result::Err(()));
+    }
+
+    #[test]
+    pub fn test_to_either() {
+        let some: Option<int> = Some(100);
+        let none: Option<int> = None;
+
+        assert_eq!(some.to_either(), either::Right(100));
+        assert_eq!(none.to_either(), either::Left(()));
+    }
+
+    #[test]
+    pub fn test_into_either() {
+        let some: Option<int> = Some(100);
+        let none: Option<int> = None;
+
+        assert_eq!(some.into_either(), either::Right(100));
+        assert_eq!(none.into_either(), either::Left(()));
     }
 }

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -388,6 +388,44 @@ impl<T> Option<T> {
     }
 }
 
+/// A generic trait for converting a value to a `Option`
+pub trait ToOption<T> {
+    /// Convert to the `option` type
+    fn to_option(&self) -> Option<T>;
+}
+
+/// A generic trait for converting a value to a `Option`
+pub trait IntoOption<T> {
+    /// Convert to the `option` type
+    fn into_option(self) -> Option<T>;
+}
+
+/// A generic trait for converting a value to a `Option`
+pub trait AsOption<T> {
+    /// Convert to the `option` type
+    fn as_option<'a>(&'a self) -> Option<&'a T>;
+}
+
+impl<T: Clone> ToOption<T> for Option<T> {
+    #[inline]
+    fn to_option(&self) -> Option<T> { self.clone() }
+}
+
+impl<T> IntoOption<T> for Option<T> {
+    #[inline]
+    fn into_option(self) -> Option<T> { self }
+}
+
+impl<T> AsOption<T> for Option<T> {
+    #[inline]
+    fn as_option<'a>(&'a self) -> Option<&'a T> {
+        match *self {
+            Some(ref x) => Some(x),
+            None => None,
+        }
+    }
+}
+
 impl<T: Default> Option<T> {
     /// Returns the contained value or default (for this type)
     #[inline]
@@ -710,5 +748,32 @@ mod tests {
         assert_eq!(x, None);
         assert!(!x.mutate_default(0i, |i| i+1));
         assert_eq!(x, Some(0i));
+    }
+
+    #[test]
+    pub fn test_to_option() {
+        let some: Option<int> = Some(100);
+        let none: Option<int> = None;
+
+        assert_eq!(some.to_option(), Some(100));
+        assert_eq!(none.to_option(), None);
+    }
+
+    #[test]
+    pub fn test_into_option() {
+        let some: Option<int> = Some(100);
+        let none: Option<int> = None;
+
+        assert_eq!(some.into_option(), Some(100));
+        assert_eq!(none.into_option(), None);
+    }
+
+    #[test]
+    pub fn test_as_option() {
+        let some: Option<int> = Some(100);
+        let none: Option<int> = None;
+
+        assert_eq!(some.as_option().unwrap(), &100);
+        assert_eq!(none.as_option(), None);
     }
 }

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -127,22 +127,51 @@ impl<T> Option<T> {
     #[inline]
     pub fn is_some(&self) -> bool { !self.is_none() }
 
-    /// Update an optional value by optionally running its content through a
-    /// function that returns an option.
+    /// Returns `None` if the option is `None`, otherwise returns `optb`.
     #[inline]
-    pub fn chain<U>(self, f: &fn(t: T) -> Option<U>) -> Option<U> {
+    pub fn and(self, optb: Option<T>) -> Option<T> {
         match self {
-            Some(t) => f(t),
-            None => None
+            Some(_) => optb,
+            None => None,
         }
     }
 
-    /// Returns the leftmost Some() value, or None if both are None.
+    /// Returns `None` if the option is `None`, otherwise calls and returns the
+    /// value of `f`.
+    #[inline]
+    pub fn and_then(self, f: &fn() -> Option<T>) -> Option<T> {
+        match self {
+            Some(_) => f(),
+            None => None,
+        }
+    }
+
+    /// Returns the option if it contains a value, otherwise returns `optb`.
     #[inline]
     pub fn or(self, optb: Option<T>) -> Option<T> {
         match self {
-            Some(opta) => Some(opta),
-            _ => optb
+            Some(_) => self,
+            None => optb
+        }
+    }
+
+    /// Returns the option if it contains a value, otherwise calls and returns the
+    /// value of `f`.
+    #[inline]
+    pub fn or_else(self, f: &fn() -> Option<T>) -> Option<T> {
+        match self {
+            Some(_) => self,
+            None => f(),
+        }
+    }
+
+    /// Update an optional value by optionally running its content through a
+    /// function that returns an option.
+    #[inline]
+    pub fn chain<U>(self, f: &fn(T) -> Option<U>) -> Option<U> {
+        match self {
+            Some(t) => f(t),
+            None => None
         }
     }
 
@@ -507,6 +536,50 @@ mod tests {
         let mut y = Some(util::NonCopyable);
         let _y2 = y.take_unwrap();
         let _y3 = y.take_unwrap();
+    }
+
+    #[test]
+    fn test_and() {
+        let x: Option<int> = Some(1);
+        assert_eq!(x.and(Some(2)), Some(2));
+        assert_eq!(x.and(None), None);
+
+        let x: Option<int> = None;
+        assert_eq!(x.and(Some(2)), None);
+        assert_eq!(x.and(None), None);
+    }
+
+    #[test]
+    fn test_and_then() {
+        let x: Option<int> = Some(1);
+        assert_eq!(x.and_then(|| Some(2)), Some(2));
+        assert_eq!(x.and_then(|| None), None);
+
+        let x: Option<int> = None;
+        assert_eq!(x.and_then(|| Some(2)), None);
+        assert_eq!(x.and_then(|| None), None);
+    }
+
+    #[test]
+    fn test_or() {
+        let x: Option<int> = Some(1);
+        assert_eq!(x.or(Some(2)), Some(1));
+        assert_eq!(x.or(None), Some(1));
+
+        let x: Option<int> = None;
+        assert_eq!(x.or(Some(2)), Some(2));
+        assert_eq!(x.or(None), None);
+    }
+
+    #[test]
+    fn test_or_else() {
+        let x: Option<int> = Some(1);
+        assert_eq!(x.or_else(|| Some(2)), Some(1));
+        assert_eq!(x.or_else(|| None), Some(1));
+
+        let x: Option<int> = None;
+        assert_eq!(x.or_else(|| Some(2)), Some(2));
+        assert_eq!(x.or_else(|| None), None);
     }
 
     #[test]

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -141,9 +141,9 @@ impl<T> Option<T> {
     /// Returns `None` if the option is `None`, otherwise calls and returns the
     /// value of `f`.
     #[inline]
-    pub fn and_then(self, f: &fn() -> Option<T>) -> Option<T> {
+    pub fn and_then<U>(self, f: &fn(T) -> Option<U>) -> Option<U> {
         match self {
-            Some(_) => f(),
+            Some(x) => f(x),
             None => None,
         }
     }
@@ -164,36 +164,6 @@ impl<T> Option<T> {
         match self {
             Some(_) => self,
             None => f(),
-        }
-    }
-
-    /// Update an optional value by optionally running its content through a
-    /// function that returns an option.
-    #[inline]
-    pub fn chain<U>(self, f: &fn(T) -> Option<U>) -> Option<U> {
-        match self {
-            Some(t) => f(t),
-            None => None
-        }
-    }
-
-    /// Update an optional value by optionally running its content by reference
-    /// through a function that returns an option.
-    #[inline]
-    pub fn chain_ref<'a, U>(&'a self, f: &fn(x: &'a T) -> Option<U>) -> Option<U> {
-        match *self {
-            Some(ref x) => f(x),
-            None => None
-        }
-    }
-
-    /// Update an optional value by optionally running its content by mut reference
-    /// through a function that returns an option.
-    #[inline]
-    pub fn chain_mut_ref<'a, U>(&'a mut self, f: &fn(x: &'a mut T) -> Option<U>) -> Option<U> {
-        match *self {
-            Some(ref mut x) => f(x),
-            None => None
         }
     }
 
@@ -637,12 +607,12 @@ mod tests {
     #[test]
     fn test_and_then() {
         let x: Option<int> = Some(1);
-        assert_eq!(x.and_then(|| Some(2)), Some(2));
-        assert_eq!(x.and_then(|| None), None);
+        assert_eq!(x.and_then(|x| Some(x + 1)), Some(2));
+        assert_eq!(x.and_then(|_| None::<int>), None);
 
         let x: Option<int> = None;
-        assert_eq!(x.and_then(|| Some(2)), None);
-        assert_eq!(x.and_then(|| None), None);
+        assert_eq!(x.and_then(|x| Some(x + 1)), None);
+        assert_eq!(x.and_then(|_| None::<int>), None);
     }
 
     #[test]

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -483,11 +483,6 @@ impl<T:Zero> Option<T> {
     }
 }
 
-impl<T> Zero for Option<T> {
-    fn zero() -> Option<T> { None }
-    fn is_zero(&self) -> bool { self.is_none() }
-}
-
 /// An iterator that yields either one or zero elements
 #[deriving(Clone, DeepClone)]
 pub struct OptionIterator<A> {

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -43,6 +43,7 @@ let unwrapped_msg = match msg {
 
 use clone::Clone;
 use cmp::{Eq,Ord};
+use default::Default;
 use util;
 use num::Zero;
 use iter;
@@ -347,6 +348,10 @@ impl<T> Option<T> {
             opt = blk(opt.unwrap());
         }
     }
+}
+
+impl<T> Default for Option<T> {
+    fn default() -> Option<T> { None }
 }
 
 impl<T:Zero> Option<T> {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -620,7 +620,7 @@ pub fn tmpdir() -> Path {
         getenv_nonempty("TMP").or(
             getenv_nonempty("TEMP").or(
                 getenv_nonempty("USERPROFILE").or(
-                   getenv_nonempty("WINDIR")))).unwrap_or_default(Path("C:\\Windows"))
+                   getenv_nonempty("WINDIR")))).unwrap_or(Path("C:\\Windows"))
     }
 }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -611,7 +611,7 @@ pub fn tmpdir() -> Path {
         if cfg!(target_os = "android") {
             Path("/data/tmp")
         } else {
-            getenv_nonempty("TMPDIR").unwrap_or_default(Path("/tmp"))
+            getenv_nonempty("TMPDIR").unwrap_or(Path("/tmp"))
         }
     }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -569,7 +569,7 @@ pub fn homedir() -> Option<Path> {
 
     #[cfg(windows)]
     fn secondary() -> Option<Path> {
-        do getenv("USERPROFILE").chain |p| {
+        do getenv("USERPROFILE").and_then |p| {
             if !p.is_empty() {
                 Some(Path(p))
             } else {

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -17,6 +17,7 @@ use cmp::Eq;
 use either;
 use iter::Iterator;
 use option::{None, Option, Some, OptionIterator};
+use option;
 use vec;
 use vec::OwnedVector;
 use to_str::ToStr;
@@ -255,6 +256,36 @@ impl<T, E: Clone + ToStr> Result<T, E> {
     }
 }
 
+impl<T: Clone, E> option::ToOption<T> for Result<T, E> {
+    #[inline]
+    fn to_option(&self)-> Option<T> {
+        match *self {
+            Ok(ref t) => Some(t.clone()),
+            Err(_) => None,
+        }
+    }
+}
+
+impl<T, E> option::IntoOption<T> for Result<T, E> {
+    #[inline]
+    fn into_option(self)-> Option<T> {
+        match self {
+            Ok(t) => Some(t),
+            Err(_) => None,
+        }
+    }
+}
+
+impl<T, E> option::AsOption<T> for Result<T, E> {
+    #[inline]
+    fn as_option<'a>(&'a self)-> Option<&'a T> {
+        match *self {
+            Ok(ref t) => Some(t),
+            Err(_) => None,
+        }
+    }
+}
+
 #[inline]
 #[allow(missing_doc)]
 pub fn map_opt<T, U: ToStr, V>(o_t: &Option<T>,
@@ -336,6 +367,8 @@ mod tests {
 
     use either;
     use iter::range;
+    use option::{IntoOption, ToOption, AsOption};
+    use option;
     use str::OwnedStr;
     use vec::ImmutableVector;
 
@@ -459,5 +492,32 @@ mod tests {
         assert_eq!(fold_(functions.iter()
                         .map(|f| (*f)())),
                    Err(1));
+    }
+
+    #[test]
+    pub fn test_to_option() {
+        let ok: Result<int, int> = Ok(100);
+        let err: Result<int, int> = Err(404);
+
+        assert_eq!(ok.to_option(), option::Some(100));
+        assert_eq!(err.to_option(), option::None);
+    }
+
+    #[test]
+    pub fn test_into_option() {
+        let ok: Result<int, int> = Ok(100);
+        let err: Result<int, int> = Err(404);
+
+        assert_eq!(ok.into_option(), option::Some(100));
+        assert_eq!(err.into_option(), option::None);
+    }
+
+    #[test]
+    pub fn test_as_option() {
+        let ok: Result<int, int> = Ok(100);
+        let err: Result<int, int> = Err(404);
+
+        assert_eq!(ok.as_option().unwrap(), &100);
+        assert_eq!(err.as_option(), option::None);
     }
 }

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -256,6 +256,24 @@ impl<T, E: Clone + ToStr> Result<T, E> {
     }
 }
 
+/// A generic trait for converting a value to a `Result`
+pub trait ToResult<T, E> {
+    /// Convert to the `result` type
+    fn to_result(&self) -> Result<T, E>;
+}
+
+/// A generic trait for converting a value to a `Result`
+pub trait IntoResult<T, E> {
+    /// Convert to the `result` type
+    fn into_result(self) -> Result<T, E>;
+}
+
+/// A generic trait for converting a value to a `Result`
+pub trait AsResult<T, E> {
+    /// Convert to the `result` type
+    fn as_result<'a>(&'a self) -> Result<&'a T, &'a E>;
+}
+
 impl<T: Clone, E> option::ToOption<T> for Result<T, E> {
     #[inline]
     fn to_option(&self)-> Option<T> {
@@ -282,6 +300,26 @@ impl<T, E> option::AsOption<T> for Result<T, E> {
         match *self {
             Ok(ref t) => Some(t),
             Err(_) => None,
+        }
+    }
+}
+
+impl<T: Clone, E: Clone> ToResult<T, E> for Result<T, E> {
+    #[inline]
+    fn to_result(&self) -> Result<T, E> { self.clone() }
+}
+
+impl<T, E> IntoResult<T, E> for Result<T, E> {
+    #[inline]
+    fn into_result(self) -> Result<T, E> { self }
+}
+
+impl<T, E> AsResult<T, E> for Result<T, E> {
+    #[inline]
+    fn as_result<'a>(&'a self) -> Result<&'a T, &'a E> {
+        match *self {
+            Ok(ref t) => Ok(t),
+            Err(ref e) => Err(e),
         }
     }
 }
@@ -519,5 +557,35 @@ mod tests {
 
         assert_eq!(ok.as_option().unwrap(), &100);
         assert_eq!(err.as_option(), option::None);
+    }
+
+    #[test]
+    pub fn test_to_result() {
+        let ok: Result<int, int> = Ok(100);
+        let err: Result<int, int> = Err(404);
+
+        assert_eq!(ok.to_result(), Ok(100));
+        assert_eq!(err.to_result(), Err(404));
+    }
+
+    #[test]
+    pub fn test_into_result() {
+        let ok: Result<int, int> = Ok(100);
+        let err: Result<int, int> = Err(404);
+
+        assert_eq!(ok.into_result(), Ok(100));
+        assert_eq!(err.into_result(), Err(404));
+    }
+
+    #[test]
+    pub fn test_as_result() {
+        let ok: Result<int, int> = Ok(100);
+        let err: Result<int, int> = Err(404);
+
+        let x = 100;
+        assert_eq!(ok.as_result(), Ok(&x));
+
+        let x = 404;
+        assert_eq!(err.as_result(), Err(&x));
     }
 }

--- a/src/libstd/rt/io/net/ip.rs
+++ b/src/libstd/rt/io/net/ip.rs
@@ -177,7 +177,7 @@ impl<'self> Parser<'self> {
         }
 
         do self.read_atomically |p| {
-            p.read_char().chain(|c| parse_digit(c, radix))
+            p.read_char().and_then(|c| parse_digit(c, radix))
         }
     }
 

--- a/src/libstd/to_bytes.rs
+++ b/src/libstd/to_bytes.rs
@@ -383,5 +383,5 @@ mod test {
     #[test] fn iterbytes_compiles () {
         takes_iterbytes((3,4,5,false));
     }
-    fn takes_iterbytes<T : IterBytes>(x : T) {}
+    fn takes_iterbytes<T : IterBytes>(_x : T) {}
 }

--- a/src/libstd/tuple.rs
+++ b/src/libstd/tuple.rs
@@ -89,6 +89,7 @@ macro_rules! tuple_impls {
         pub mod inner {
             use clone::Clone;
             #[cfg(not(test))] use cmp::*;
+            #[cfg(not(test))] use default::Default;
             #[cfg(not(test))] use num::Zero;
 
             $(
@@ -169,6 +170,14 @@ macro_rules! tuple_impls {
                     #[inline]
                     fn cmp(&self, other: &($($T,)+)) -> Ordering {
                         lexical_cmp!($(self.$get_ref_fn(), other.$get_ref_fn()),+)
+                    }
+                }
+
+                #[cfg(not(test))]
+                impl<$($T:Default),+> Default for ($($T,)+) {
+                    #[inline]
+                    fn default() -> ($($T,)+) {
+                        ($({ let x: $T = Default::default(); x},)+)
                     }
                 }
 

--- a/src/libstd/unit.rs
+++ b/src/libstd/unit.rs
@@ -46,14 +46,15 @@ impl TotalEq for () {
 }
 
 #[cfg(not(test))]
+impl Default for () {
+    #[inline]
+    fn default() -> () { () }
+}
+
+#[cfg(not(test))]
 impl Zero for () {
     #[inline]
     fn zero() -> () { () }
     #[inline]
     fn is_zero(&self) -> bool { true }
-}
-
-#[cfg(not(test))]
-impl Default for () {
-    fn default() -> () { () }
 }

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -205,7 +205,7 @@ pub fn with_capacity<T>(capacity: uint) -> ~[T] {
  */
 #[inline]
 pub fn build<A>(size: Option<uint>, builder: &fn(push: &fn(v: A))) -> ~[A] {
-    let mut vec = with_capacity(size.unwrap_or_default(4));
+    let mut vec = with_capacity(size.unwrap_or(4));
     builder(|x| vec.push(x));
     vec
 }

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -104,6 +104,7 @@ use clone::{Clone, DeepClone};
 use container::{Container, Mutable};
 use cmp::{Eq, TotalOrd, Ordering, Less, Equal, Greater};
 use cmp;
+use default::Default;
 use iter::*;
 use libc::c_void;
 use num::{Integer, Zero, CheckedAdd, Saturating};
@@ -2234,6 +2235,19 @@ impl<A: DeepClone> DeepClone for ~[A] {
     fn deep_clone(&self) -> ~[A] {
         self.iter().map(|item| item.deep_clone()).collect()
     }
+}
+
+// This works because every lifetime is a sub-lifetime of 'static
+impl<'self, A> Default for &'self [A] {
+    fn default() -> &'self [A] { &'self [] }
+}
+
+impl<A> Default for ~[A] {
+    fn default() -> ~[A] { ~[] }
+}
+
+impl<A> Default for @[A] {
+    fn default() -> @[A] { @[] }
 }
 
 // This works because every lifetime is a sub-lifetime of 'static

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -107,7 +107,7 @@ use cmp;
 use default::Default;
 use iter::*;
 use libc::c_void;
-use num::{Integer, Zero, CheckedAdd, Saturating};
+use num::{Integer, CheckedAdd, Saturating};
 use option::{None, Option, Some};
 use ptr::to_unsafe_ptr;
 use ptr;
@@ -2250,22 +2250,6 @@ impl<A> Default for @[A] {
     fn default() -> @[A] { @[] }
 }
 
-// This works because every lifetime is a sub-lifetime of 'static
-impl<'self, A> Zero for &'self [A] {
-    fn zero() -> &'self [A] { &'self [] }
-    fn is_zero(&self) -> bool { self.is_empty() }
-}
-
-impl<A> Zero for ~[A] {
-    fn zero() -> ~[A] { ~[] }
-    fn is_zero(&self) -> bool { self.len() == 0 }
-}
-
-impl<A> Zero for @[A] {
-    fn zero() -> @[A] { @[] }
-    fn is_zero(&self) -> bool { self.len() == 0 }
-}
-
 macro_rules! iterator {
     /* FIXME: #4375 Cannot attach documentation/attributes to a macro generated struct.
     (struct $name:ident -> $ptr:ty, $elem:ty) => {
@@ -3602,13 +3586,12 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_zero() {
-        use num::Zero;
+    fn test_vec_default() {
+        use default::Default;
         macro_rules! t (
             ($ty:ty) => {{
-                let v: $ty = Zero::zero();
+                let v: $ty = Default::default();
                 assert!(v.is_empty());
-                assert!(v.is_zero());
             }}
         );
 

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -187,12 +187,12 @@ pub fn first_attr_value_str_by_name(attrs: &[Attribute], name: &str)
                                  -> Option<@str> {
     attrs.iter()
         .find(|at| name == at.name())
-        .chain(|at| at.value_str())
+        .and_then(|at| at.value_str())
 }
 
 pub fn last_meta_item_value_str_by_name(items: &[@MetaItem], name: &str)
                                      -> Option<@str> {
-    items.rev_iter().find(|mi| name == mi.name()).chain(|i| i.value_str())
+    items.rev_iter().find(|mi| name == mi.name()).and_then(|i| i.value_str())
 }
 
 /* Higher-level applications */

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -1,0 +1,79 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use ast::{MetaItem, item, Expr};
+use codemap::Span;
+use ext::base::ExtCtxt;
+use ext::build::AstBuilder;
+use ext::deriving::generic::*;
+
+use std::vec;
+
+pub fn expand_deriving_default(cx: @ExtCtxt,
+                            span: Span,
+                            mitem: @MetaItem,
+                            in_items: ~[@item])
+    -> ~[@item] {
+    let trait_def = TraitDef {
+        path: Path::new(~["std", "default", "Default"]),
+        additional_bounds: ~[],
+        generics: LifetimeBounds::empty(),
+        methods: ~[
+            MethodDef {
+                name: "default",
+                generics: LifetimeBounds::empty(),
+                explicit_self: None,
+                args: ~[],
+                ret_ty: Self,
+                const_nonmatching: false,
+                combine_substructure: default_substructure
+            },
+        ]
+    };
+    trait_def.expand(cx, span, mitem, in_items)
+}
+
+fn default_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+    let default_ident = ~[
+        cx.ident_of("std"),
+        cx.ident_of("default"),
+        cx.ident_of("Default"),
+        cx.ident_of("default")
+    ];
+    let default_call = || {
+        cx.expr_call_global(span, default_ident.clone(), ~[])
+    };
+
+    return match *substr.fields {
+        StaticStruct(_, ref summary) => {
+            match *summary {
+                Left(count) => {
+                    if count == 0 {
+                        cx.expr_ident(span, substr.type_ident)
+                    } else {
+                        let exprs = vec::from_fn(count, |_| default_call());
+                        cx.expr_call_ident(span, substr.type_ident, exprs)
+                    }
+                }
+                Right(ref fields) => {
+                    let default_fields = do fields.map |ident| {
+                        cx.field_imm(span, *ident, default_call())
+                    };
+                    cx.expr_struct_ident(span, substr.type_ident, default_fields)
+                }
+            }
+        }
+        StaticEnum(*) => {
+            cx.span_fatal(span, "`Default` cannot be derived for enums, \
+                                 only structs")
+        }
+        _ => cx.bug("Non-static method in `deriving(Default)`")
+    };
+}

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -31,6 +31,7 @@ pub mod decodable;
 pub mod rand;
 pub mod to_str;
 pub mod zero;
+pub mod default;
 
 #[path="cmp/eq.rs"]
 pub mod eq;
@@ -97,6 +98,7 @@ pub fn expand_meta_deriving(cx: @ExtCtxt,
 
                             "ToStr" => expand!(to_str::expand_deriving_to_str),
                             "Zero" => expand!(zero::expand_deriving_zero),
+                            "Default" => expand!(default::expand_deriving_default),
 
                             ref tname => {
                                 cx.span_err(titem.span, fmt!("unknown \

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -331,11 +331,18 @@ pub fn expand_item_mac(extsbox: @mut SyntaxEnv,
     };
 
     let maybe_it = match expanded {
-        MRItem(it) => mark_item(it,fm).chain(|i| {fld.fold_item(i)}),
-        MRExpr(_) => cx.span_fatal(pth.span,
-                                   fmt!("expr macro in item position: %s", extnamestr)),
-        MRAny(_, item_maker, _) => item_maker().chain(|i| {mark_item(i,fm)})
-                                      .chain(|i| {fld.fold_item(i)}),
+        MRItem(it) => {
+            mark_item(it,fm)
+                .and_then(|i| fld.fold_item(i))
+        }
+        MRExpr(_) => {
+            cx.span_fatal(pth.span, fmt!("expr macro in item position: %s", extnamestr))
+        }
+        MRAny(_, item_maker, _) => {
+            item_maker()
+                .and_then(|i| mark_item(i,fm))
+                .and_then(|i| fld.fold_item(i))
+        }
         MRDef(ref mdef) => {
             // yikes... no idea how to apply the mark to this. I'm afraid
             // we're going to have to wait-and-see on this one.

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -140,6 +140,10 @@ impl<A:Eq> Eq for OptVec<A> {
     }
 }
 
+impl<T> Default for OptVec<T> {
+    fn default() -> OptVec<T> { Empty }
+}
+
 pub struct OptVecIterator<'self, T> {
     priv iter: Option<VecIterator<'self, T>>
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3461,7 +3461,7 @@ impl Parser {
         let ident = self.parse_ident();
         let opt_bounds = self.parse_optional_ty_param_bounds();
         // For typarams we don't care about the difference b/w "<T>" and "<T:>".
-        let bounds = opt_bounds.unwrap_or(opt_vec::Empty);
+        let bounds = opt_bounds.unwrap_or_default();
         ast::TyParam { ident: ident, id: ast::DUMMY_NODE_ID, bounds: bounds }
     }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -802,7 +802,7 @@ impl Parser {
         */
 
         let opt_abis = self.parse_opt_abis();
-        let abis = opt_abis.unwrap_or_default(AbiSet::Rust());
+        let abis = opt_abis.unwrap_or(AbiSet::Rust());
         let purity = self.parse_unsafety();
         self.expect_keyword(keywords::Fn);
         let (decl, lifetimes) = self.parse_ty_fn_decl();
@@ -3461,7 +3461,7 @@ impl Parser {
         let ident = self.parse_ident();
         let opt_bounds = self.parse_optional_ty_param_bounds();
         // For typarams we don't care about the difference b/w "<T>" and "<T:>".
-        let bounds = opt_bounds.unwrap_or_default(opt_vec::Empty);
+        let bounds = opt_bounds.unwrap_or(opt_vec::Empty);
         ast::TyParam { ident: ident, id: ast::DUMMY_NODE_ID, bounds: bounds }
     }
 
@@ -4363,7 +4363,7 @@ impl Parser {
                 self.obsolete(*self.last_span, ObsoleteExternVisibility);
             }
 
-            let abis = opt_abis.unwrap_or_default(AbiSet::C());
+            let abis = opt_abis.unwrap_or(AbiSet::C());
 
             let (inner, next) = self.parse_inner_attrs_and_next();
             let m = self.parse_foreign_mod_items(sort, abis, next);
@@ -4640,7 +4640,7 @@ impl Parser {
 
             if self.eat_keyword(keywords::Fn) {
                 // EXTERN FUNCTION ITEM
-                let abis = opt_abis.unwrap_or_default(AbiSet::C());
+                let abis = opt_abis.unwrap_or(AbiSet::C());
                 let (ident, item_, extra_attrs) =
                     self.parse_item_fn(extern_fn, abis);
                 return iovi_item(self.mk_item(lo, self.last_span.hi, ident,

--- a/src/test/run-pass/deriving-zero.rs
+++ b/src/test/run-pass/deriving-zero.rs
@@ -24,7 +24,6 @@ struct E { a: int, b: int }
 
 #[deriving(Zero)]
 struct Lots {
-    c: Option<util::NonCopyable>,
     d: u8,
     e: char,
     f: float,

--- a/src/test/run-pass/deriving-zero.rs
+++ b/src/test/run-pass/deriving-zero.rs
@@ -29,10 +29,9 @@ struct Lots {
     e: char,
     f: float,
     g: (f32, char),
-    h: ~[util::NonCopyable],
-    i: @mut (int, int),
-    j: bool,
-    k: (),
+    h: @mut (int, int),
+    i: bool,
+    j: (),
 }
 
 fn main() {


### PR DESCRIPTION
This is a series of patches to modernize option and result. The highlights are:
- rename `.unwrap_or_default(value)` and etc to `.unwrap_or(value)`
- add `.unwrap_or_default()` that uses the `Default` trait
- add `Default` implementations for vecs, HashMap, Option
- add  `Option.and(T) -> Option<T>`, `Option.and_then(&fn() -> Option<T>) -> Option<T>`, `Option.or(T) -> Option<T>`, and `Option.or_else(&fn() -> Option<T>) -> Option<T>`
- add `option::ToOption`, `option::IntoOption`, `option::AsOption`, `result::ToResult`, `result::IntoResult`, `result::AsResult`, `either::ToEither`, and `either::IntoEither`, `either::AsEither`
- renamed `Option::chain*` and `Result::chain*` to `and_then` and `or_else` to avoid the eventual collision with `Iterator.chain`.
- Added a bunch of impls of `Default`
- Added a `#[deriving(Default)]` syntax extension
- Removed impls of `Zero` for `Option<T>` and vecs. 
