### PR TITLE
rustpkg: Support sub-package-IDs

### DIFF
--- a/src/librustpkg/package_id.rs
+++ b/src/librustpkg/package_id.rs
@@ -99,7 +99,35 @@ impl PkgId {
     /// True if the ID has multiple components
     pub fn is_complex(&self) -> bool {
         self.short_name != self.path.to_str()
-     }
+    }
+
+    pub fn prefixes_iter(&self) -> Prefixes {
+        Prefixes {
+            components: self.path.components().to_owned(),
+            remaining: ~[]
+        }
+    }
+
+}
+
+struct Prefixes {
+    priv components: ~[~str],
+    priv remaining: ~[~str]
+}
+
+impl Iterator<(Path, Path)> for Prefixes {
+    #[inline]
+    fn next(&mut self) -> Option<(Path, Path)> {
+        if self.components.len() <= 1 {
+            None
+        }
+        else {
+            let last = self.components.pop();
+            self.remaining.push(last);
+            // converting to str and then back is a little unfortunate
+            Some((Path(self.components.to_str()), Path(self.remaining.to_str())))
+        }
+    }
 }
 
 impl ToStr for PkgId {
@@ -119,3 +147,4 @@ pub fn hash(data: ~str) -> ~str {
     write(hasher, data);
     hasher.result_str()
 }
+

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -49,8 +49,6 @@ pub fn make_dir_rwx(p: &Path) -> bool { os::make_dir(p, U_RWX) }
 /// True if there's a directory in <workspace> with
 /// pkgid's short name
 pub fn workspace_contains_package_id(pkgid: &PkgId, workspace: &Path) -> bool {
-    debug!("Checking in src dir of %s for %s",
-           workspace.to_str(), pkgid.to_str());
     workspace_contains_package_id_(pkgid, workspace, |p| { p.push("src") }).is_some()
 }
 
@@ -141,9 +139,17 @@ pub fn built_library_in_workspace(pkgid: &PkgId, workspace: &Path) -> Option<Pat
 }
 
 /// Does the actual searching stuff
-pub fn installed_library_in_workspace(short_name: &str, workspace: &Path) -> Option<Path> {
+pub fn installed_library_in_workspace(pkg_path: &Path, workspace: &Path) -> Option<Path> {
     // This could break once we're handling multiple versions better -- I should add a test for it
-    library_in_workspace(&Path(short_name), short_name, Install, workspace, "lib", &NoVersion)
+    match pkg_path.filename() {
+        None => None,
+        Some(short_name) => library_in_workspace(pkg_path,
+                                                 short_name,
+                                                 Install,
+                                                 workspace,
+                                                 "lib",
+                                                 &NoVersion)
+    }
 }
 
 /// `workspace` is used to figure out the directory to search.

--- a/src/librustpkg/search.rs
+++ b/src/librustpkg/search.rs
@@ -15,10 +15,11 @@ use version::Version;
 /// return Some(p) (returns the first one of there are multiple matches.) Return
 /// None if there's no such path.
 /// FIXME #8711: This ignores the desired version.
-pub fn find_installed_library_in_rust_path(short_name: &str, _version: &Version) -> Option<Path> {
+pub fn find_installed_library_in_rust_path(pkg_path: &Path, _version: &Version) -> Option<Path> {
     let rp = rust_path();
+    debug!("find_installed_library_in_rust_path: looking for path %s", pkg_path.to_str());
     for p in rp.iter() {
-        match installed_library_in_workspace(short_name, p) {
+        match installed_library_in_workspace(pkg_path, p) {
             Some(path) => return Some(path),
             None => ()
         }

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -378,7 +378,8 @@ pub fn find_and_install_dependencies(ctxt: &BuildContext,
                     Some(p) => p,
                     None => sess.str_of(lib_ident)
                 };
-                match installed_library_in_workspace(lib_name, &ctxt.sysroot()) {
+                debug!("Finding and installing... %s", lib_name);
+                match installed_library_in_workspace(&Path(lib_name), &ctxt.sysroot()) {
                     Some(ref installed_path) => {
                         debug!("It exists: %s", installed_path.to_str());
                         // Say that [path for c] has a discovered dependency on
@@ -420,8 +421,9 @@ pub fn find_and_install_dependencies(ctxt: &BuildContext,
                             }
                         }
                         // Also, add an additional search path
+                        debug!("Adding additional search path: %s", lib_name);
                         let installed_library =
-                            installed_library_in_workspace(lib_name, workspace)
+                            installed_library_in_workspace(&Path(lib_name), workspace)
                                 .expect( fmt!("rustpkg failed to install dependency %s",
                                               lib_name));
                         let install_dir = installed_library.pop();

--- a/src/librustpkg/workspace.rs
+++ b/src/librustpkg/workspace.rs
@@ -38,6 +38,8 @@ pub fn each_pkg_parent_workspace(cx: &Context, pkgid: &PkgId, action: &fn(&Path)
     return true;
 }
 
+/// Given a package ID, return a vector of all of the workspaces in
+/// the RUST_PATH that contain it
 pub fn pkg_parent_workspaces(cx: &Context, pkgid: &PkgId) -> ~[Path] {
     let rs: ~[Path] = rust_path().move_iter()
         .filter(|ws| workspace_contains_package_id(pkgid, ws))


### PR DESCRIPTION
r? @brson Package IDs can now refer to a subdirectory of a particular source
tree, and not just a top-level directory with a src/ directory as its
parent.

For example, referring to the package ID a/b/c/d , in workspace W,
if W/src/a is a package, will build the sources for the package in
a/b/c/d (and not other crates in W/src/a).

Closes #6408
