### PR TITLE
rustpkg: Install to RUST_PATH

### DIFF
--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -399,3 +399,12 @@ pub fn find_dir_using_rust_path_hack(p: &PkgId) -> Option<Path> {
     }
     None
 }
+
+/// True if the user set RUST_PATH to something non-empty --
+/// as opposed to the default paths that rustpkg adds automatically
+pub fn user_set_rust_path() -> bool {
+    match os::getenv("RUST_PATH") {
+        None | Some(~"") => false,
+        Some(_)         => true
+    }
+}

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -1603,6 +1603,25 @@ fn test_recursive_deps() {
     assert_lib_exists(&b_workspace, &Path("c"), NoVersion);
 }
 
+#[test]
+fn test_install_to_rust_path() {
+    let p_id = PkgId::new("foo");
+    let second_workspace = create_local_package(&p_id);
+    let first_workspace = mk_empty_workspace(&Path("p"), &NoVersion, "dest");
+    let rust_path = Some(~[(~"RUST_PATH",
+                            fmt!("%s:%s", first_workspace.to_str(),
+                                 second_workspace.to_str()))]);
+    debug!("RUST_PATH=%s:%s", first_workspace.to_str(), second_workspace.to_str());
+    command_line_test_with_env([test_sysroot().to_str(),
+                       ~"install",
+                       ~"foo"],
+                      &os::getcwd(), rust_path);
+    assert!(!built_executable_exists(&first_workspace, "foo"));
+    assert!(built_executable_exists(&second_workspace, "foo"));
+    assert_executable_exists(&first_workspace, "foo");
+    assert!(!executable_exists(&second_workspace, "foo"));
+}
+
 /// Returns true if p exists and is executable
 fn is_executable(p: &Path) -> bool {
     use std::libc::consts::os::posix88::{S_IXUSR};


### PR DESCRIPTION
r? @metajack Install to the first directory in the RUST_PATH if the user set a
RUST_PATH. In the case where RUST_PATH isn't set, the behavior
remains unchanged.

Closes #7402
