### PR TITLE
rustc/rustpkg: Use a target-specific subdirectory in build/ and lib/

### DIFF
--- a/doc/rustpkg.md
+++ b/doc/rustpkg.md
@@ -52,13 +52,11 @@ A valid workspace must contain each of the following subdirectories:
      rustpkg will install libraries for bar to `foo/lib/x86_64-apple-darwin/`.
      The libraries will have names of the form `foo/lib/x86_64-apple-darwin/libbar-[hash].dylib`,
      where [hash] is a hash of the package ID.
-* 'bin/': `rustpkg install` installs executable binaries into a target-specific subdirectory of this directory.
+* 'bin/': `rustpkg install` installs executable binaries into this directory.
 
-     For example, on a 64-bit machine running Mac OS X,
-     if `foo` is a workspace, containing the package `bar`,
-     rustpkg will install executables for `bar` to
-     `foo/bin/x86_64-apple-darwin/`.
-     The executables will have names of the form `foo/bin/x86_64-apple-darwin/bar`.
+     For example, rustpkg will install executables for `bar` to
+     `foo/bin`.
+     The executables will have names of the form `foo/bin/bar`.
 * 'build/': `rustpkg build` stores temporary build artifacts in a target-specific subdirectory of this directory.
 
      For example, on a 64-bit machine running Mac OS X,
@@ -84,6 +82,12 @@ rustpkg also interprets any dependencies on such a package ID literally
 (as opposed to versions, where a newer version satisfies a dependency on an older version).
 Thus, `github.com/mozilla/rust#5c4cd30f80` is also a valid package ID,
 since git can deduce that 5c4cd30f80 refers to a revision of the desired repository.
+
+A package identifier can name a subdirectory of another package.
+For example, if `foo` is a workspace, and `foo/src/bar/lib.rs` exists,
+as well as `foo/src/bar/extras/baz/lib.rs`,
+then both `bar` and `bar/extras/baz` are valid package identifiers
+in the workspace `foo`.
 
 ## Source files
 
@@ -140,9 +144,11 @@ but not in their `lib` or `bin` directories.
 
 ## install
 
-`rustpkg install foo` builds the libraries and/or executables that are targets for `foo`,
-and then installs them either into `foo`'s `lib` and `bin` directories,
-or into the `lib` and `bin` subdirectories of the first entry in `RUST_PATH`.
+`rustpkg install foo` builds the libraries and/or executables that are targets for `foo`.
+If `RUST_PATH` is declared as an environment variable, then rustpkg installs the
+libraries and executables into the `lib` and `bin` subdirectories
+of the first entry in `RUST_PATH`.
+Otherwise, it installs them into `foo`'s `lib` and `bin` directories.
 
 ## test
 

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -77,15 +77,15 @@ pub fn mk_filesearch(maybe_sysroot: &Option<@Path>,
             if !found {
                 let rustpath = rust_path();
                 for path in rustpath.iter() {
-                    debug!("is %s in visited_dirs? %?",
-                            path.push("lib").to_str(),
-                            visited_dirs.contains(&path.push("lib").to_str()));
+                    let tlib_path = make_rustpkg_target_lib_path(path, self.target_triple);
+                    debug!("is %s in visited_dirs? %?", tlib_path.to_str(),
+                            visited_dirs.contains(&tlib_path.to_str()));
 
-                    if !visited_dirs.contains(&path.push("lib").to_str()) {
-                        visited_dirs.insert(path.push("lib").to_str());
+                    if !visited_dirs.contains(&tlib_path.to_str()) {
+                        visited_dirs.insert(tlib_path.to_str());
                         // Don't keep searching the RUST_PATH if one match turns up --
                         // if we did, we'd get a "multiple matching crates" error
-                        match f(&path.push("lib")) {
+                        match f(&tlib_path) {
                            FileMatches => {
                                break;
                            }
@@ -143,6 +143,11 @@ pub fn relative_target_lib_path(target_triple: &str) -> Path {
 fn make_target_lib_path(sysroot: &Path,
                         target_triple: &str) -> Path {
     sysroot.push_rel(&relative_target_lib_path(target_triple))
+}
+
+fn make_rustpkg_target_lib_path(dir: &Path,
+                        target_triple: &str) -> Path {
+    dir.push_rel(&Path(libdir()).push(target_triple.to_owned()))
 }
 
 fn get_or_default_sysroot() -> Path {

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -23,7 +23,7 @@ use context::{in_target, StopBefore, Link, Assemble, BuildContext};
 use package_id::PkgId;
 use package_source::PkgSrc;
 use workspace::pkg_parent_workspaces;
-use path_util::{installed_library_in_workspace, U_RWX, rust_path};
+use path_util::{installed_library_in_workspace, U_RWX, rust_path, system_library, target_build_dir};
 use messages::error;
 
 pub use target::{OutputType, Main, Lib, Bench, Test};
@@ -170,7 +170,7 @@ pub fn compile_input(context: &BuildContext,
     // tjc: by default, use the package ID name as the link name
     // not sure if we should support anything else
 
-    let out_dir = workspace.push("build").push_rel(&pkg_id.path);
+    let out_dir = target_build_dir(workspace).push_rel(&pkg_id.path);
 
     let binary = os::args()[0].to_managed();
 
@@ -381,7 +381,8 @@ pub fn find_and_install_dependencies(context: &BuildContext,
                     None => sess.str_of(lib_ident)
                 };
                 debug!("Finding and installing... %s", lib_name);
-                match installed_library_in_workspace(&Path(lib_name), &context.sysroot()) {
+                // Check standard Rust library path first
+                match system_library(&context.sysroot(), lib_name) {
                     Some(ref installed_path) => {
                         debug!("It exists: %s", installed_path.to_str());
                         // Say that [path for c] has a discovered dependency on


### PR DESCRIPTION
r? @brson As per rustpkg.md, rustpkg now builds in a target-specific
subdirectory of build/, and installs libraries into a target-specific
subdirectory of lib.

Closes #8672
