### PR TITLE
set sret attribute as needed on call instructions

### DIFF
--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -655,9 +655,9 @@ pub fn FastCall(cx: @mut Block, Fn: ValueRef, Args: &[ValueRef]) -> ValueRef {
 }
 
 pub fn CallWithConv(cx: @mut Block, Fn: ValueRef, Args: &[ValueRef],
-                    Conv: CallConv) -> ValueRef {
+                    Conv: CallConv, sret: bool) -> ValueRef {
     if cx.unreachable { return _UndefReturn(cx, Fn); }
-    B(cx).call_with_conv(Fn, Args, Conv)
+    B(cx).call_with_conv(Fn, Args, Conv, sret)
 }
 
 pub fn AtomicFence(cx: @mut Block, order: AtomicOrdering) {

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -266,7 +266,7 @@ pub fn trans_native_call(bcx: @mut Block,
         }
     };
 
-    let llforeign_retval = CallWithConv(bcx, llfn, llargs_foreign, cc);
+    let llforeign_retval = CallWithConv(bcx, llfn, llargs_foreign, cc, fn_type.sret);
 
     // If the function we just called does not use an outpointer,
     // store the result into the rust outpointer. Cast the outpointer


### PR DESCRIPTION
Since function pointers do not carry along the function attributes with
them in the type, this needs to be set on the call instruction itself.

Closes #9152
