### PR TITLE
Move to using `%` as an escape in format!

### DIFF
--- a/src/test/compile-fail/ifmt-bad-arg.rs
+++ b/src/test/compile-fail/ifmt-bad-arg.rs
@@ -39,20 +39,20 @@ fn main() {
 
     // bad syntax of the format string
 
-    format!("{"); //~ ERROR: unterminated format string
-    format!("\\ "); //~ ERROR: invalid escape
-    format!("\\"); //~ ERROR: expected an escape
+    format!("{"); //~ ERROR: expected '}'
+    format!("% "); //~ ERROR: invalid escape
+    format!("%"); //~ ERROR: expected an escape
 
     format!("{0, }", 1); //~ ERROR: expected method
     format!("{0, foo}", 1); //~ ERROR: unknown method
-    format!("{0, select}", "a"); //~ ERROR: must be followed by
-    format!("{0, plural}", 1); //~ ERROR: must be followed by
+    format!("{0, select}", "a"); //~ ERROR: expected ',' but found '}'
+    format!("{0, plural}", 1); //~ ERROR: expected ',' but found '}'
 
-    format!("{0, select, a{{}", 1); //~ ERROR: must be terminated
+    format!("{0, select, a{{}", 1); //~ ERROR: expected '}' but
     format!("{0, select, {} other{}}", "a"); //~ ERROR: empty selector
     format!("{0, select, other{} other{}}", "a"); //~ ERROR: multiple `other`
     format!("{0, plural, offset: other{}}", "a"); //~ ERROR: must be an integer
-    format!("{0, plural, offset 1 other{}}", "a"); //~ ERROR: be followed by `:`
+    format!("{0, plural, offset 1 other{}}", "a"); //~ ERROR: expected ':'
     format!("{0, plural, =a{} other{}}", "a"); //~ ERROR: followed by an integer
     format!("{0, plural, a{} other{}}", "a"); //~ ERROR: unexpected plural
     format!("{0, select, a{}}", "a"); //~ ERROR: must provide an `other`

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -43,7 +43,7 @@ pub fn main() {
     // Various edge cases without formats
     t!(format!(""), "");
     t!(format!("hello"), "hello");
-    t!(format!("hello \\{"), "hello {");
+    t!(format!("hello %{"), "hello {");
 
     // default formatters should work
     t!(format!("{}", 1i), "1");
@@ -222,10 +222,10 @@ pub fn main() {
     t!(format!("{:+10.3f}", -1.0f), "    -1.000");
 
     // Escaping
-    t!(format!("\\{"), "{");
-    t!(format!("\\}"), "}");
-    t!(format!("\\#"), "#");
-    t!(format!("\\\\"), "\\");
+    t!(format!("%{"), "{");
+    t!(format!("%}"), "}");
+    t!(format!("%#"), "#");
+    t!(format!("%%"), "%");
 
     test_write();
     test_print();


### PR DESCRIPTION
I believe that this is almost undeniably better because now to escape '{' it
looks like "%{" instead of "\{". Furthermore, in order to insert a '\' you only
have to type "\" (as one would expect), instead of "\\".

At the same time, this also attempts to improve some error messages about
expecting a character and not finding it.
