### PR TITLE
make ! support the equality/ordering operators

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4326,7 +4326,7 @@ pub fn is_binopable(cx: ctxt, ty: t, op: ast::BinOp) -> bool {
     /*char*/    [f, f, f, f,     t,   t,  f,   f],
     /*int*/     [t, t, t, t,     t,   t,  t,   f],
     /*float*/   [t, t, t, f,     t,   t,  f,   f],
-    /*bot*/     [t, t, t, t,     f,   f,  t,   t],
+    /*bot*/     [t, t, t, t,     t,   t,  t,   t],
     /*raw ptr*/ [f, f, f, f,     t,   t,  f,   f]];
 
     return tbl[tycat(cx, ty)][opcat(op)];

--- a/src/test/run-fail/binop-fail-3.rs
+++ b/src/test/run-fail/binop-fail-3.rs
@@ -1,0 +1,13 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:quux
+fn foo() -> ! { fail!("quux"); }
+fn main() { foo() == foo(); }


### PR DESCRIPTION
An expression such as `bottom == not_bottom` or `not_bottom == bottom`
already compiled, but this fixes the case where both sides are `bottom`.
