### PR TITLE
Work around a compiler crash folding labeled break. #9129

### DIFF
--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -690,11 +690,19 @@ pub fn noop_fold_expr(e: &Expr_, fld: @ast_fold) -> Expr_ {
         ExprBreak(ref opt_ident) => {
             // FIXME #6993: add fold_name to fold.... then cut out the
             // bogus Name->Ident->Name conversion.
-            ExprBreak(opt_ident.map_move(|x| fld.fold_ident(Ident::new(x)).name))
+            ExprBreak(opt_ident.map_move(|x| {
+                // FIXME #9129: Assigning the new ident to a temporary to work around codegen bug
+                let newx = Ident::new(x);
+                fld.fold_ident(newx).name
+            }))
         }
         ExprAgain(ref opt_ident) => {
             // FIXME #6993: add fold_name to fold....
-            ExprAgain(opt_ident.map_move(|x| fld.fold_ident(Ident::new(x)).name))
+            ExprAgain(opt_ident.map_move(|x| {
+                // FIXME #9129: Assigning the new ident to a temporary to work around codegen bug
+                let newx = Ident::new(x);
+                fld.fold_ident(newx).name
+            }))
         }
         ExprRet(ref e) => {
             ExprRet(e.map_move(|x| fld.fold_expr(x)))


### PR DESCRIPTION
Servo is hitting this problem, so this is a workaround for lack of a real solution.

No tests because I couldn't actually reproduce the problem with either of the testcases in #9129
