### PR TITLE
Add Orderable bound to num::Primitive

### DIFF
--- a/src/libstd/num/num.rs
+++ b/src/libstd/num/num.rs
@@ -279,6 +279,7 @@ pub trait Primitive: Clone
                    + DeepClone
                    + Num
                    + NumCast
+                   + Orderable
                    + Bounded
                    + Neg<Self>
                    + Add<Self,Self>


### PR DESCRIPTION
Somehow this was missed!

cc #4819
