### PR TITLE
When declaring extern fns from external crates, use the correct abi

### DIFF
--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -74,9 +74,8 @@ struct LlvmSignature {
 ///////////////////////////////////////////////////////////////////////////
 // Calls to external functions
 
-fn llvm_calling_convention(ccx: @mut CrateContext,
-                           abis: AbiSet)
-                           -> Option<CallConv> {
+pub fn llvm_calling_convention(ccx: &mut CrateContext,
+                               abis: AbiSet) -> Option<CallConv> {
     let arch = ccx.sess.targ_cfg.arch;
     abis.for_arch(arch).map(|abi| {
         match *abi {


### PR DESCRIPTION
Beforehand it was assumed that the standard cdecl abi was used for all extern
fns of extern crates, but this reads the abi of the extern fn type and declares
the function in the local crate with the appropriate type.

I was trying to think of how to write a test for this, but I was just drawing up blanks :(. Are there standard functions in libc which are not of the cdecl abi? If so we could try linking to them and make sure that the cal completes successfully.

Otherwise, I manually verified that the function was declared correctly by looking at the llvm assembly.

cc #9055 (I'm not sure if this will fix that issue)
