### PR TITLE
Guarantee that statics have unique names

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -905,7 +905,8 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_type(ecx, ebml_w, node_id_to_type(tcx, item.id));
         encode_symbol(ecx, ebml_w, item.id);
         encode_name(ecx, ebml_w, item.ident);
-        encode_path(ecx, ebml_w, path, ast_map::path_name(item.ident));
+        let elt = ast_map::path_pretty_name(item.ident, item.id as u64);
+        encode_path(ecx, ebml_w, path, elt);
         (ecx.encode_inlined_item)(ecx, ebml_w, path, ii_item(item));
         ebml_w.end_tag();
       }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2465,7 +2465,8 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::NodeId) -> ValueRef {
             let val = match item {
                 ast_map::node_item(i, pth) => {
 
-                    let my_path = vec::append((*pth).clone(), [path_name(i.ident)]);
+                    let elt = path_pretty_name(i.ident, id as u64);
+                    let my_path = vec::append_one((*pth).clone(), elt);
                     let ty = ty::node_id_to_type(ccx.tcx, i.id);
                     let sym = exported_name(ccx, my_path, ty, i.attrs);
 

--- a/src/test/auxiliary/issue_9188.rs
+++ b/src/test/auxiliary/issue_9188.rs
@@ -1,0 +1,24 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn foo<T>() -> &'static int {
+    if false {
+        static a: int = 4;
+        return &a;
+    } else {
+        static a: int = 5;
+        return &a;
+    }
+}
+
+pub fn bar() -> &'static int {
+    foo::<int>()
+}
+

--- a/src/test/run-pass/issue-9188.rs
+++ b/src/test/run-pass/issue-9188.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue_9188.rs
+// xfail-fast windows doesn't like aux-build
+
+extern mod issue_9188;
+
+fn main() {
+    let a = issue_9188::bar();
+    let b = issue_9188::foo::<int>();
+    assert_eq!(*a, *b);
+}
+


### PR DESCRIPTION
While they may have the same name within various scopes, this changes static
names to use path_pretty_name to append some hash information at the end of the
symbol. We're then guaranteed that each static has a unique NodeId, so this
NodeId is as the "hash" of the pretty name.

Closes #9188
