### PR TITLE
Remove {uint,int,u64,i64,...}::from_str,from_str_radix

### DIFF
--- a/doc/tutorial-conditions.md
+++ b/doc/tutorial-conditions.md
@@ -91,7 +91,7 @@ fn read_int_pairs() -> ~[(int,int)] {
             [a, b] => {
 
                 // 5. Try parsing both fields as ints.
-                match (int::from_str(a), int::from_str(b)) {
+                match (from_str::<int>(a), from_str::<int>(b)) {
 
                     // 6. If parsing succeeded for both, push both.
                     (Some(a), Some(b)) => pairs.push((a,b)),
@@ -124,7 +124,7 @@ for conveying a value of type `T`, represented as `Some(T)`
 _or_ the sentinel `None`, to indicate the absence of a `T` value.
 For simple APIs, it may be sufficient to encode errors as `Option<T>`,
 returning `Some(T)` on success and `None` on error.
-In the example program, the call to `int::from_str` returns `Option<int>`
+In the example program, the call to `from_str::<int>` returns `Option<int>`
 with the understanding that "all parse errors" result in `None`.
 The resulting `Option<int>` values are matched against the pattern `(Some(a), Some(b))`
 in steps 5 and 6 in the example program,
@@ -161,7 +161,7 @@ This second mechanism for indicating an error is called a `Result`.
 The type `std::result::Result<T,E>` is another simple `enum` type with two forms, `Ok(T)` and `Err(E)`.
 The `Result` type is not substantially different from the `Option` type in terms of its ergonomics.
 Its main advantage is that the error constructor `Err(E)` can convey _more detail_ about the error.
-For example, the `int::from_str` API could be reformed
+For example, the `from_str` API could be reformed
 to return a `Result` carrying an informative description of a parse error,
 like this:
 
@@ -172,7 +172,7 @@ enum IntParseErr {
      BadChar(char)
 }
 
-fn int::from_str(&str) -> Result<int,IntParseErr> {
+fn from_str(&str) -> Result<int,IntParseErr> {
   // ...
 }
 ~~~~
@@ -297,8 +297,8 @@ fn read_int_pairs() -> ~[(int,int)] {
         let line = fi.read_line();
         let fields = line.word_iter().to_owned_vec();
         match fields {
-            [a, b] => pairs.push((int::from_str(a).unwrap(),
-                                  int::from_str(b).unwrap())),
+            [a, b] => pairs.push((from_str::<int>(a).unwrap(),
+                                  from_str::<int>(b).unwrap())),
 
             // Explicitly fail on malformed lines.
             _ => fail!()
@@ -398,8 +398,8 @@ fn read_int_pairs() -> ~[(int,int)] {
         let line = fi.read_line();
         let fields = line.word_iter().to_owned_vec();
         match fields {
-            [a, b] => pairs.push((int::from_str(a).unwrap(),
-                                  int::from_str(b).unwrap())),
+            [a, b] => pairs.push((from_str::<int>(a).unwrap(),
+                                  from_str::<int>(b).unwrap())),
 
             // On malformed lines, call the condition handler and
             // push whatever the condition handler returns.
@@ -475,8 +475,8 @@ fn read_int_pairs() -> ~[(int,int)] {
         let line = fi.read_line();
         let fields = line.word_iter().to_owned_vec();
         match fields {
-            [a, b] => pairs.push((int::from_str(a).unwrap(),
-                                  int::from_str(b).unwrap())),
+            [a, b] => pairs.push((from_str::<int>(a).unwrap(),
+                                  from_str::<int>(b).unwrap())),
             _ => pairs.push(malformed_line::cond.raise(line.clone()))
         }
     }
@@ -553,8 +553,8 @@ fn read_int_pairs() -> ~[(int,int)] {
         let line = fi.read_line();
         let fields = line.word_iter().to_owned_vec();
         match fields {
-            [a, b] => pairs.push((int::from_str(a).unwrap(),
-                                  int::from_str(b).unwrap())),
+            [a, b] => pairs.push((from_str::<int>(a).unwrap(),
+                                  from_str::<int>(b).unwrap())),
 
             // On malformed lines, call the condition handler and
             // either ignore the line (if the handler returns `None`)
@@ -649,8 +649,8 @@ fn read_int_pairs() -> ~[(int,int)] {
         let line = fi.read_line();
         let fields = line.word_iter().to_owned_vec();
         match fields {
-            [a, b] => pairs.push((int::from_str(a).unwrap(),
-                                  int::from_str(b).unwrap())),
+            [a, b] => pairs.push((from_str::<int>(a).unwrap(),
+                                  from_str::<int>(b).unwrap())),
 
             // On malformed lines, call the condition handler and
             // take action appropriate to the enum value returned.
@@ -776,7 +776,7 @@ fn main() {
 // Parse an int; if parsing fails, call the condition handler and
 // return whatever it returns.
 fn parse_int(x: &str) -> int {
-    match int::from_str(x) {
+    match from_str::<int>(x) {
         Some(v) => v,
         None => malformed_int::cond.raise(x.to_owned())
     }
@@ -833,8 +833,8 @@ There are three other things to note in this variant of the example program:
     so long as the `raise` occurs within a callee (of any depth) of the logic protected by the `trap` call,
     it will invoke the handler.
 
-  - This variant insulates callers from a design choice in the `int` library:
-    the `int::from_str` function was designed to return an `Option<int>`,
+  - This variant insulates callers from a design choice in the library:
+    the `from_str` function was designed to return an `Option<int>`,
     but this program insulates callers from that choice,
     routing all `None` values that arise from parsing integers in this file into the condition.
 

--- a/src/libextra/fileinput.rs
+++ b/src/libextra/fileinput.rs
@@ -538,8 +538,8 @@ mod test {
 
         do input_vec_state(filenames) |line, state| {
             let nums: ~[&str] = line.split_iter(' ').collect();
-            let file_num = uint::from_str(nums[0]).unwrap();
-            let line_num = uint::from_str(nums[1]).unwrap();
+            let file_num = from_str::<uint>(nums[0]).unwrap();
+            let line_num = from_str::<uint>(nums[1]).unwrap();
             assert_eq!(line_num, state.line_num_file);
             assert_eq!(file_num * 3 + line_num, state.line_num);
             true

--- a/src/libextra/semver.rs
+++ b/src/libextra/semver.rs
@@ -19,7 +19,6 @@ use std::io::{ReaderUtil};
 use std::io;
 use std::option::{Option, Some, None};
 use std::to_str::ToStr;
-use std::uint;
 
 #[deriving(Clone, Eq)]
 pub enum Identifier {
@@ -140,7 +139,7 @@ fn take_nonempty_prefix(rdr: @io::Reader,
 
 fn take_num(rdr: @io::Reader, ch: char) -> (uint, char) {
     let (s, ch) = take_nonempty_prefix(rdr, ch, char::is_digit);
-    match uint::from_str(s) {
+    match from_str::<uint>(s) {
         None => { bad_parse::cond.raise(()); (0, ch) },
         Some(i) => (i, ch)
     }
@@ -149,7 +148,7 @@ fn take_num(rdr: @io::Reader, ch: char) -> (uint, char) {
 fn take_ident(rdr: @io::Reader, ch: char) -> (Identifier, char) {
     let (s,ch) = take_nonempty_prefix(rdr, ch, char::is_alphanumeric);
     if s.iter().all(char::is_digit) {
-        match uint::from_str(s) {
+        match from_str::<uint>(s) {
             None => { bad_parse::cond.raise(()); (Numeric(0), ch) },
             Some(i) => (Numeric(i), ch)
         }

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -37,7 +37,6 @@ use std::task;
 use std::to_str::ToStr;
 use std::f64;
 use std::os;
-use std::uint;
 
 
 // The name of a test. By convention this follows the rules for rust
@@ -253,7 +252,7 @@ pub fn parse_opts(args: &[~str]) -> OptRes {
     let ratchet_metrics = ratchet_metrics.map_move(|s| Path(s));
 
     let ratchet_noise_percent = getopts::opt_maybe_str(&matches, "ratchet-noise-percent");
-    let ratchet_noise_percent = ratchet_noise_percent.map_move(|s| f64::from_str(s).unwrap());
+    let ratchet_noise_percent = ratchet_noise_percent.map_move(|s| from_str::<f64>(s).unwrap());
 
     let save_metrics = getopts::opt_maybe_str(&matches, "save-metrics");
     let save_metrics = save_metrics.map_move(|s| Path(s));
@@ -281,7 +280,7 @@ pub fn opt_shard(maybestr: Option<~str>) -> Option<(uint,uint)> {
         None => None,
         Some(s) => {
             match s.split_iter('.').to_owned_vec() {
-                [a, b] => match (uint::from_str(a), uint::from_str(b)) {
+                [a, b] => match (from_str::<uint>(a), from_str::<uint>(b)) {
                     (Some(a), Some(b)) => Some((a,b)),
                     _ => None
                 },

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -383,20 +383,6 @@ impl Primitive for $T {
 
 // String conversion functions and impl str -> num
 
-/// Parse a string as a number in base 10.
-#[inline]
-pub fn from_str(s: &str) -> Option<$T> {
-    strconv::from_str_common(s, 10u, true, false, false,
-                         strconv::ExpNone, false, false)
-}
-
-/// Parse a string as a number in the given base.
-#[inline]
-pub fn from_str_radix(s: &str, radix: uint) -> Option<$T> {
-    strconv::from_str_common(s, radix, true, false, false,
-                         strconv::ExpNone, false, false)
-}
-
 /// Parse a byte slice as a number in the given base.
 #[inline]
 pub fn parse_bytes(buf: &[u8], radix: uint) -> Option<$T> {
@@ -407,14 +393,16 @@ pub fn parse_bytes(buf: &[u8], radix: uint) -> Option<$T> {
 impl FromStr for $T {
     #[inline]
     fn from_str(s: &str) -> Option<$T> {
-        from_str(s)
+        strconv::from_str_common(s, 10u, true, false, false,
+                             strconv::ExpNone, false, false)
     }
 }
 
 impl FromStrRadix for $T {
     #[inline]
     fn from_str_radix(s: &str, radix: uint) -> Option<$T> {
-        from_str_radix(s, radix)
+        strconv::from_str_common(s, radix, true, false, false,
+                             strconv::ExpNone, false, false)
     }
 }
 
@@ -462,10 +450,7 @@ mod tests {
     use super::*;
 
     use int;
-    use i16;
     use i32;
-    use i64;
-    use i8;
     use num;
     use sys;
 
@@ -670,20 +655,20 @@ mod tests {
 
     #[test]
     fn test_from_str() {
-        assert_eq!(from_str("0"), Some(0 as $T));
-        assert_eq!(from_str("3"), Some(3 as $T));
-        assert_eq!(from_str("10"), Some(10 as $T));
-        assert_eq!(i32::from_str("123456789"), Some(123456789 as i32));
-        assert_eq!(from_str("00100"), Some(100 as $T));
+        assert_eq!(from_str::<$T>("0"), Some(0 as $T));
+        assert_eq!(from_str::<$T>("3"), Some(3 as $T));
+        assert_eq!(from_str::<$T>("10"), Some(10 as $T));
+        assert_eq!(from_str::<i32>("123456789"), Some(123456789 as i32));
+        assert_eq!(from_str::<$T>("00100"), Some(100 as $T));
 
-        assert_eq!(from_str("-1"), Some(-1 as $T));
-        assert_eq!(from_str("-3"), Some(-3 as $T));
-        assert_eq!(from_str("-10"), Some(-10 as $T));
-        assert_eq!(i32::from_str("-123456789"), Some(-123456789 as i32));
-        assert_eq!(from_str("-00100"), Some(-100 as $T));
+        assert_eq!(from_str::<$T>("-1"), Some(-1 as $T));
+        assert_eq!(from_str::<$T>("-3"), Some(-3 as $T));
+        assert_eq!(from_str::<$T>("-10"), Some(-10 as $T));
+        assert_eq!(from_str::<i32>("-123456789"), Some(-123456789 as i32));
+        assert_eq!(from_str::<$T>("-00100"), Some(-100 as $T));
 
-        assert!(from_str(" ").is_none());
-        assert!(from_str("x").is_none());
+        assert!(from_str::<$T>(" ").is_none());
+        assert!(from_str::<$T>("x").is_none());
     }
 
     #[test]
@@ -751,36 +736,36 @@ mod tests {
     #[test]
     fn test_int_from_str_overflow() {
         let mut i8_val: i8 = 127_i8;
-        assert_eq!(i8::from_str("127"), Some(i8_val));
-        assert!(i8::from_str("128").is_none());
+        assert_eq!(from_str::<i8>("127"), Some(i8_val));
+        assert!(from_str::<i8>("128").is_none());
 
         i8_val += 1 as i8;
-        assert_eq!(i8::from_str("-128"), Some(i8_val));
-        assert!(i8::from_str("-129").is_none());
+        assert_eq!(from_str::<i8>("-128"), Some(i8_val));
+        assert!(from_str::<i8>("-129").is_none());
 
         let mut i16_val: i16 = 32_767_i16;
-        assert_eq!(i16::from_str("32767"), Some(i16_val));
-        assert!(i16::from_str("32768").is_none());
+        assert_eq!(from_str::<i16>("32767"), Some(i16_val));
+        assert!(from_str::<i16>("32768").is_none());
 
         i16_val += 1 as i16;
-        assert_eq!(i16::from_str("-32768"), Some(i16_val));
-        assert!(i16::from_str("-32769").is_none());
+        assert_eq!(from_str::<i16>("-32768"), Some(i16_val));
+        assert!(from_str::<i16>("-32769").is_none());
 
         let mut i32_val: i32 = 2_147_483_647_i32;
-        assert_eq!(i32::from_str("2147483647"), Some(i32_val));
-        assert!(i32::from_str("2147483648").is_none());
+        assert_eq!(from_str::<i32>("2147483647"), Some(i32_val));
+        assert!(from_str::<i32>("2147483648").is_none());
 
         i32_val += 1 as i32;
-        assert_eq!(i32::from_str("-2147483648"), Some(i32_val));
-        assert!(i32::from_str("-2147483649").is_none());
+        assert_eq!(from_str::<i32>("-2147483648"), Some(i32_val));
+        assert!(from_str::<i32>("-2147483649").is_none());
 
         let mut i64_val: i64 = 9_223_372_036_854_775_807_i64;
-        assert_eq!(i64::from_str("9223372036854775807"), Some(i64_val));
-        assert!(i64::from_str("9223372036854775808").is_none());
+        assert_eq!(from_str::<i64>("9223372036854775807"), Some(i64_val));
+        assert!(from_str::<i64>("9223372036854775808").is_none());
 
         i64_val += 1 as i64;
-        assert_eq!(i64::from_str("-9223372036854775808"), Some(i64_val));
-        assert!(i64::from_str("-9223372036854775809").is_none());
+        assert_eq!(from_str::<i64>("-9223372036854775808"), Some(i64_val));
+        assert!(from_str::<i64>("-9223372036854775809").is_none());
     }
 
     #[test]

--- a/src/libstd/num/num.rs
+++ b/src/libstd/num/num.rs
@@ -439,6 +439,11 @@ pub trait FromStrRadix {
     fn from_str_radix(str: &str, radix: uint) -> Option<Self>;
 }
 
+/// A utility function that just calls FromStrRadix::from_str_radix
+pub fn from_str_radix<T: FromStrRadix>(str: &str, radix: uint) -> Option<T> {
+    FromStrRadix::from_str_radix(str, radix)
+}
+
 /// Calculates a power to a given radix, optimized for uint `pow` and `radix`.
 ///
 /// Returns `radix^pow` as `T`.

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -238,20 +238,6 @@ impl Int for $T {}
 
 // String conversion functions and impl str -> num
 
-/// Parse a string as a number in base 10.
-#[inline]
-pub fn from_str(s: &str) -> Option<$T> {
-    strconv::from_str_common(s, 10u, false, false, false,
-                             strconv::ExpNone, false, false)
-}
-
-/// Parse a string as a number in the given base.
-#[inline]
-pub fn from_str_radix(s: &str, radix: uint) -> Option<$T> {
-    strconv::from_str_common(s, radix, false, false, false,
-                             strconv::ExpNone, false, false)
-}
-
 /// Parse a byte slice as a number in the given base.
 #[inline]
 pub fn parse_bytes(buf: &[u8], radix: uint) -> Option<$T> {
@@ -262,14 +248,16 @@ pub fn parse_bytes(buf: &[u8], radix: uint) -> Option<$T> {
 impl FromStr for $T {
     #[inline]
     fn from_str(s: &str) -> Option<$T> {
-        from_str(s)
+        strconv::from_str_common(s, 10u, false, false, false,
+                                 strconv::ExpNone, false, false)
     }
 }
 
 impl FromStrRadix for $T {
     #[inline]
     fn from_str_radix(s: &str, radix: uint) -> Option<$T> {
-        from_str_radix(s, radix)
+        strconv::from_str_common(s, radix, false, false, false,
+                                 strconv::ExpNone, false, false)
     }
 }
 
@@ -347,9 +335,6 @@ mod tests {
     use num;
     use sys;
     use u16;
-    use u32;
-    use u64;
-    use u8;
 
     #[test]
     fn test_num() {
@@ -459,15 +444,15 @@ mod tests {
 
     #[test]
     pub fn test_from_str() {
-        assert_eq!(from_str("0"), Some(0u as $T));
-        assert_eq!(from_str("3"), Some(3u as $T));
-        assert_eq!(from_str("10"), Some(10u as $T));
-        assert_eq!(u32::from_str("123456789"), Some(123456789 as u32));
-        assert_eq!(from_str("00100"), Some(100u as $T));
+        assert_eq!(from_str::<$T>("0"), Some(0u as $T));
+        assert_eq!(from_str::<$T>("3"), Some(3u as $T));
+        assert_eq!(from_str::<$T>("10"), Some(10u as $T));
+        assert_eq!(from_str::<u32>("123456789"), Some(123456789 as u32));
+        assert_eq!(from_str::<$T>("00100"), Some(100u as $T));
 
-        assert!(from_str("").is_none());
-        assert!(from_str(" ").is_none());
-        assert!(from_str("x").is_none());
+        assert!(from_str::<$T>("").is_none());
+        assert!(from_str::<$T>(" ").is_none());
+        assert!(from_str::<$T>("x").is_none());
     }
 
     #[test]
@@ -514,36 +499,36 @@ mod tests {
     #[test]
     fn test_uint_from_str_overflow() {
         let mut u8_val: u8 = 255_u8;
-        assert_eq!(u8::from_str("255"), Some(u8_val));
-        assert!(u8::from_str("256").is_none());
+        assert_eq!(from_str::<u8>("255"), Some(u8_val));
+        assert!(from_str::<u8>("256").is_none());
 
         u8_val += 1 as u8;
-        assert_eq!(u8::from_str("0"), Some(u8_val));
-        assert!(u8::from_str("-1").is_none());
+        assert_eq!(from_str::<u8>("0"), Some(u8_val));
+        assert!(from_str::<u8>("-1").is_none());
 
         let mut u16_val: u16 = 65_535_u16;
-        assert_eq!(u16::from_str("65535"), Some(u16_val));
-        assert!(u16::from_str("65536").is_none());
+        assert_eq!(from_str::<u16>("65535"), Some(u16_val));
+        assert!(from_str::<u16>("65536").is_none());
 
         u16_val += 1 as u16;
-        assert_eq!(u16::from_str("0"), Some(u16_val));
-        assert!(u16::from_str("-1").is_none());
+        assert_eq!(from_str::<u16>("0"), Some(u16_val));
+        assert!(from_str::<u16>("-1").is_none());
 
         let mut u32_val: u32 = 4_294_967_295_u32;
-        assert_eq!(u32::from_str("4294967295"), Some(u32_val));
-        assert!(u32::from_str("4294967296").is_none());
+        assert_eq!(from_str::<u32>("4294967295"), Some(u32_val));
+        assert!(from_str::<u32>("4294967296").is_none());
 
         u32_val += 1 as u32;
-        assert_eq!(u32::from_str("0"), Some(u32_val));
-        assert!(u32::from_str("-1").is_none());
+        assert_eq!(from_str::<u32>("0"), Some(u32_val));
+        assert!(from_str::<u32>("-1").is_none());
 
         let mut u64_val: u64 = 18_446_744_073_709_551_615_u64;
-        assert_eq!(u64::from_str("18446744073709551615"), Some(u64_val));
-        assert!(u64::from_str("18446744073709551616").is_none());
+        assert_eq!(from_str::<u64>("18446744073709551615"), Some(u64_val));
+        assert!(from_str::<u64>("18446744073709551616").is_none());
 
         u64_val += 1 as u64;
-        assert_eq!(u64::from_str("0"), Some(u64_val));
-        assert!(u64::from_str("-1").is_none());
+        assert_eq!(from_str::<u64>("0"), Some(u64_val));
+        assert!(from_str::<u64>("-1").is_none());
     }
 
     #[test]

--- a/src/libstd/rt/logging.rs
+++ b/src/libstd/rt/logging.rs
@@ -7,6 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+use from_str::from_str;
 use libc::{uintptr_t, exit, STDERR_FILENO};
 use option::{Some, None, Option};
 use rt::util::dumb_println;
@@ -28,7 +29,7 @@ static log_level_names : &'static[&'static str] = &'static["error", "warn", "inf
 
 /// Parse an individual log level that is either a number or a symbolic log level
 fn parse_log_level(level: &str) -> Option<u32> {
-    let num = u32::from_str(level);
+    let num = from_str::<u32>(level);
     let mut log_level;
     match num {
         Some(num) => {

--- a/src/libstd/rt/test.rs
+++ b/src/libstd/rt/test.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use libc;
-use uint;
 use option::{Some, None};
 use cell::Cell;
 use clone::Clone;
@@ -382,9 +381,10 @@ fn base_port() -> uint {
 /// stress tests. Default 1.
 pub fn stress_factor() -> uint {
     use os::getenv;
+    use from_str::from_str;
 
     match getenv("RUST_RT_STRESS") {
-        Some(val) => uint::from_str(val).unwrap(),
+        Some(val) => from_str::<uint>(val).unwrap(),
         None => 1
     }
 }

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -20,7 +20,7 @@ use parse::token::{str_to_ident};
 use std::cast::transmute;
 use std::char;
 use std::either;
-use std::u64;
+use std::num::from_str_radix;
 use std::util;
 
 pub use ext::tt::transcribe::{TtReader, new_tt_reader};
@@ -444,7 +444,7 @@ fn scan_number(c: char, rdr: @mut StringReader) -> token::Token {
         if num_str.len() == 0u {
             rdr.fatal(~"no valid digits found for number");
         }
-        let parsed = match u64::from_str_radix(num_str, base as uint) {
+        let parsed = match from_str_radix::<u64>(num_str, base as uint) {
             Some(p) => p,
             None => rdr.fatal(~"int literal is too large")
         };
@@ -509,7 +509,7 @@ fn scan_number(c: char, rdr: @mut StringReader) -> token::Token {
         if num_str.len() == 0u {
             rdr.fatal(~"no valid digits found for number");
         }
-        let parsed = match u64::from_str_radix(num_str, base as uint) {
+        let parsed = match from_str_radix::<u64>(num_str, base as uint) {
             Some(p) => p,
             None => rdr.fatal(~"int literal is too large")
         };

--- a/src/test/auxiliary/static-methods-crate.rs
+++ b/src/test/auxiliary/static-methods-crate.rs
@@ -21,7 +21,7 @@ pub trait read {
 
 impl read for int {
     fn readMaybe(s: ~str) -> Option<int> {
-        int::from_str(s)
+        from_str::<int>(s)
     }
 }
 

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -97,7 +97,7 @@ fn main() {
     let args = os::args();
     let n_keys = {
         if args.len() == 2 {
-            uint::from_str(args[1]).unwrap()
+            from_str::<uint>(args[1]).unwrap()
         } else {
             1000000
         }

--- a/src/test/bench/core-set.rs
+++ b/src/test/bench/core-set.rs
@@ -157,7 +157,7 @@ fn main() {
     let args = os::args();
     let num_keys = {
         if args.len() == 2 {
-            uint::from_str(args[1]).unwrap()
+            from_str::<uint>(args[1]).unwrap()
         } else {
             100 // woefully inadequate for any real measurement
         }

--- a/src/test/bench/core-uint-to-str.rs
+++ b/src/test/bench/core-uint-to-str.rs
@@ -21,7 +21,7 @@ fn main() {
         args
     };
 
-    let n = uint::from_str(args[1]).unwrap();
+    let n = from_str::<uint>(args[1]).unwrap();
 
     for i in range(0u, n) {
         let x = i.to_str();

--- a/src/test/bench/graph500-bfs.rs
+++ b/src/test/bench/graph500-bfs.rs
@@ -418,8 +418,8 @@ fn main() {
         args
     };
 
-    let scale = uint::from_str(args[1]).unwrap();
-    let num_keys = uint::from_str(args[2]).unwrap();
+    let scale = from_str::<uint>(args[1]).unwrap();
+    let num_keys = from_str::<uint>(args[2]).unwrap();
     let do_validate = false;
     let do_sequential = true;
 

--- a/src/test/bench/msgsend-pipes-shared.rs
+++ b/src/test/bench/msgsend-pipes-shared.rs
@@ -59,8 +59,8 @@ fn run(args: &[~str]) {
 
     let to_child = SharedChan::new(to_child);
 
-    let size = uint::from_str(args[1]).unwrap();
-    let workers = uint::from_str(args[2]).unwrap();
+    let size = from_str::<uint>(args[1]).unwrap();
+    let workers = from_str::<uint>(args[2]).unwrap();
     let num_bytes = 100;
     let start = extra::time::precise_time_s();
     let mut worker_results = ~[];

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -53,8 +53,8 @@ fn run(args: &[~str]) {
     let (from_parent, to_child) = stream();
     let to_child = SharedChan::new(to_child);
 
-    let size = uint::from_str(args[1]).unwrap();
-    let workers = uint::from_str(args[2]).unwrap();
+    let size = from_str::<uint>(args[1]).unwrap();
+    let workers = from_str::<uint>(args[2]).unwrap();
     let num_bytes = 100;
     let start = extra::time::precise_time_s();
     let mut worker_results = ~[];

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -78,8 +78,8 @@ fn main() {
         args.clone()
     };
 
-    let num_tasks = uint::from_str(args[1]).unwrap();
-    let msg_per_task = uint::from_str(args[2]).unwrap();
+    let num_tasks = from_str::<uint>(args[1]).unwrap();
+    let msg_per_task = from_str::<uint>(args[2]).unwrap();
 
     let (num_chan, num_port) = init();
     let num_chan = Cell::new(num_chan);

--- a/src/test/bench/msgsend-ring-rw-arcs.rs
+++ b/src/test/bench/msgsend-ring-rw-arcs.rs
@@ -74,8 +74,8 @@ fn main() {
         args.clone()
     };
 
-    let num_tasks = uint::from_str(args[1]).unwrap();
-    let msg_per_task = uint::from_str(args[2]).unwrap();
+    let num_tasks = from_str::<uint>(args[1]).unwrap();
+    let msg_per_task = from_str::<uint>(args[2]).unwrap();
 
     let (num_chan, num_port) = init();
     let num_chan = Cell::new(num_chan);

--- a/src/test/bench/rt-messaging-ping-pong.rs
+++ b/src/test/bench/rt-messaging-ping-pong.rs
@@ -65,13 +65,13 @@ fn main() {
 
     let args = os::args();
     let n = if args.len() == 3 {
-        uint::from_str(args[1]).unwrap()
+        from_str::<uint>(args[1]).unwrap()
     } else {
         10000
     };
 
     let m = if args.len() == 3 {
-        uint::from_str(args[2]).unwrap()
+        from_str::<uint>(args[2]).unwrap()
     } else {
         4
     };

--- a/src/test/bench/rt-parfib.rs
+++ b/src/test/bench/rt-parfib.rs
@@ -38,7 +38,7 @@ fn main() {
 
     let args = os::args();
     let n = if args.len() == 2 {
-        uint::from_str(args[1]).unwrap()
+        from_str::<uint>(args[1]).unwrap()
     } else {
         10
     };

--- a/src/test/bench/rt-spawn-rate.rs
+++ b/src/test/bench/rt-spawn-rate.rs
@@ -21,7 +21,7 @@ fn main() {
 
     let args = os::args();
     let n = if args.len() == 2 {
-        uint::from_str(args[1]).unwrap()
+        from_str::<uint>(args[1]).unwrap()
     } else {
         100000
     };

--- a/src/test/bench/shootout-ackermann.rs
+++ b/src/test/bench/shootout-ackermann.rs
@@ -34,6 +34,6 @@ fn main() {
     } else {
         args
     };
-    let n = int::from_str(args[1]).unwrap();
+    let n = from_str::<int>(args[1]).unwrap();
     printfln!("Ack(3,%d): %d\n", n, ack(3, n));
 }

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -48,7 +48,7 @@ fn main() {
         args
     };
 
-    let n = int::from_str(args[1]).unwrap();
+    let n = from_str::<int>(args[1]).unwrap();
     let min_depth = 4;
     let mut max_depth;
     if min_depth + 2 > n {

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -212,7 +212,7 @@ fn main() {
         args
     };
 
-    let nn = uint::from_str(args[1]).unwrap();
+    let nn = from_str::<uint>(args[1]).unwrap();
 
     print_complements();
     io::println("");

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -128,7 +128,7 @@ fn main() {
         io::stdout()
     };
 
-    let n = int::from_str(args[1]).unwrap();
+    let n = from_str::<int>(args[1]).unwrap();
 
     let iub: ~[AminoAcids] =
         make_cumulative(~[acid('a', 27u32), acid('c', 12u32), acid('g', 12u32),

--- a/src/test/bench/shootout-fibo.rs
+++ b/src/test/bench/shootout-fibo.rs
@@ -30,6 +30,6 @@ fn main() {
     } else {
         args
     };
-    let n = int::from_str(args[1]).unwrap();
+    let n = from_str::<int>(args[1]).unwrap();
     printfln!("%d\n", fib(n));
 }

--- a/src/test/bench/std-smallintmap.rs
+++ b/src/test/bench/std-smallintmap.rs
@@ -39,8 +39,8 @@ fn main() {
     } else {
         args
     };
-    let max = uint::from_str(args[1]).unwrap();
-    let rep = uint::from_str(args[2]).unwrap();
+    let max = from_str::<uint>(args[1]).unwrap();
+    let rep = from_str::<uint>(args[2]).unwrap();
 
     let mut checkf = 0.0;
     let mut appendf = 0.0;

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -74,9 +74,9 @@ impl Sudoku {
             let comps: ~[&str] = line.trim().split_iter(',').collect();
 
             if comps.len() == 3u {
-                let row     = uint::from_str(comps[0]).unwrap() as u8;
-                let col     = uint::from_str(comps[1]).unwrap() as u8;
-                g[row][col] = uint::from_str(comps[2]).unwrap() as u8;
+                let row     = from_str::<uint>(comps[0]).unwrap() as u8;
+                let col     = from_str::<uint>(comps[1]).unwrap() as u8;
+                g[row][col] = from_str::<uint>(comps[2]).unwrap() as u8;
             }
             else {
                 fail!("Invalid sudoku file");

--- a/src/test/bench/task-perf-jargon-metal-smoke.rs
+++ b/src/test/bench/task-perf-jargon-metal-smoke.rs
@@ -52,7 +52,7 @@ fn main() {
     };
 
     let (p,c) = comm::stream();
-    child_generation(uint::from_str(args[1]).unwrap(), c);
+    child_generation(from_str::<uint>(args[1]).unwrap(), c);
     if p.try_recv().is_none() {
         fail!("it happened when we slumbered");
     }

--- a/src/test/bench/task-perf-linked-failure.rs
+++ b/src/test/bench/task-perf-linked-failure.rs
@@ -74,7 +74,7 @@ fn main() {
         args.clone()
     };
 
-    let num_tasks = uint::from_str(args[1]).unwrap();
+    let num_tasks = from_str::<uint>(args[1]).unwrap();
 
     // Main group #0 waits for unsupervised group #1.
     // Grandparent group #1 waits for middle group #2, then fails, killing #3.

--- a/src/test/bench/task-perf-one-million.rs
+++ b/src/test/bench/task-perf-one-million.rs
@@ -56,7 +56,7 @@ fn main() {
         args
     };
 
-    let children = uint::from_str(args[1]).get();
+    let children = from_str::<uint>(args[1]).get();
     let (wait_port, wait_chan) = stream();
     do task::spawn {
         calc(children, &wait_chan);

--- a/src/test/bench/task-perf-spawnalot.rs
+++ b/src/test/bench/task-perf-spawnalot.rs
@@ -31,7 +31,7 @@ fn main() {
     } else {
         args
     };
-    let n = uint::from_str(args[1]).unwrap();
+    let n = from_str::<uint>(args[1]).unwrap();
     let mut i = 0u;
     while i < n { task::spawn(|| f(n) ); i += 1u; }
 }

--- a/src/test/run-pass/issue-4241.rs
+++ b/src/test/run-pass/issue-4241.rs
@@ -62,7 +62,7 @@ priv fn chop(s: ~str) -> ~str {
 }
 
 priv fn parse_bulk(io: @io::Reader) -> Result {
-    match int::from_str(chop(io.read_line())) {
+    match from_str::<int>(chop(io.read_line())) {
     None => fail!(),
     Some(-1) => Nil,
     Some(len) if len >= 0 => parse_data(len as uint, io),
@@ -71,7 +71,7 @@ priv fn parse_bulk(io: @io::Reader) -> Result {
 }
 
 priv fn parse_multi(io: @io::Reader) -> Result {
-    match int::from_str(chop(io.read_line())) {
+    match from_str::<int>(chop(io.read_line())) {
     None => fail!(),
     Some(-1) => Nil,
     Some(0) => List(~[]),
@@ -81,7 +81,7 @@ priv fn parse_multi(io: @io::Reader) -> Result {
 }
 
 priv fn parse_int(io: @io::Reader) -> Result {
-    match int::from_str(chop(io.read_line())) {
+    match from_str::<int>(chop(io.read_line())) {
     None => fail!(),
     Some(i) => Int(i)
     }

--- a/src/test/run-pass/match-with-ret-arm.rs
+++ b/src/test/run-pass/match-with-ret-arm.rs
@@ -14,7 +14,7 @@ pub fn main() {
     // sometimes we have had trouble finding
     // the right type for f, as we unified
     // bot and u32 here
-    let f = match uint::from_str("1234") {
+    let f = match from_str::<uint>("1234") {
         None => return (),
         Some(num) => num as u32
     };


### PR DESCRIPTION
Remove these in favor of the two traits themselves and the wrapper
function std::from_str::from_str.

Add the function std::num::from_str_radix in the corresponding role for
the FromStrRadix trait.

With `from_str` in the prelude, and `from_str_radix` in `std::num`, the feature is unfied under the type annotation of these functions instead of using the modules-named-as-types (std::uint and others):

What was before:

```
let n = std::uint::from_str("1");
let m = std::i32::from_str_radix("10", 16);
```

is now:

```
let n = from_str::<uint>("1");
let m = std::num::from_str_radix::<i32>("10", 16);
```
