### PR TITLE
rust test: pass the remaining arguments through

### DIFF
--- a/src/librust/rust.rs
+++ b/src/librust/rust.rs
@@ -84,7 +84,8 @@ static COMMANDS: &'static [Command<'static>] = &'static [
         usage_full: UsgStr(
             "The test command is an shortcut for the command line \n\
             \"rustc --test <filename> -o <filestem>test~ && \
-            ./<filestem>test~\"\n\nUsage:\trust test <filename>"
+            ./<filestem>test~ [<arguments>...]\"\
+            \n\nUsage:\trust test <filename> [<arguments>...]"
         )
     },
     Command {
@@ -155,12 +156,12 @@ fn cmd_help(args: &[~str]) -> ValidUsage {
 
 fn cmd_test(args: &[~str]) -> ValidUsage {
     match args {
-        [ref filename] => {
+        [ref filename, ..prog_args] => {
             let p = Path(*filename);
             let test_exec = p.filestem().unwrap() + "test~";
             invoke("rustc", &[~"--test", filename.to_owned(),
                               ~"-o", test_exec.to_owned()], rustc::main_args);
-            let exit_code = run::process_status(~"./" + test_exec, []);
+            let exit_code = run::process_status(~"./" + test_exec, prog_args);
             Valid(exit_code)
         }
         _ => Invalid


### PR DESCRIPTION
The arguments after `rust test filename.rs` should be passed through
to the test binary. This allows the `rust` command to be used to run a
subset of tests, to run ignored tests, and to run benchmarks.
