### PR TITLE
gitattributes: force LF line endings for all files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 [attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
 
-* text=auto
+* text eol=lf
 *.cpp rust
 *.h rust
 *.rs rust
@@ -8,6 +8,3 @@ src/rt/msvc/* -whitespace
 src/rt/vg/* -whitespace
 src/rt/linenoise/* -whitespace
 src/rt/jemalloc/**/* -whitespace
-src/rt/jemalloc/include/jemalloc/jemalloc.h.in text eol=lf
-src/rt/jemalloc/include/jemalloc/jemalloc_defs.h.in text eol=lf
-src/rt/jemalloc/include/jemalloc/internal/jemalloc_internal.h.in text eol=lf


### PR DESCRIPTION
This avoids default CRLF on msysgit for Windows which can cause trouble.
Cf. https://help.github.com/articles/dealing-with-line-endings#text-eollf

Closes #7723.
