### PR TITLE
Rustpkg init

### DIFF
--- a/src/librustpkg/rustpkg.rs
+++ b/src/librustpkg/rustpkg.rs
@@ -189,6 +189,7 @@ pub trait CtxMethods {
     fn test(&self);
     fn uninstall(&self, _id: &str, _vers: Option<~str>);
     fn unprefer(&self, _id: &str, _vers: Option<~str>);
+    fn init(&self);
 }
 
 impl CtxMethods for BuildContext {
@@ -318,6 +319,13 @@ impl CtxMethods for BuildContext {
             }
             "test" => {
                 self.test();
+            }
+            "init" => {
+                if args.len() != 0 {
+                    return usage::init();
+                } else {
+                    self.init();
+                }
             }
             "uninstall" => {
                 if args.len() < 1 {
@@ -540,6 +548,13 @@ impl CtxMethods for BuildContext {
         fail!("test not yet implemented");
     }
 
+    fn init(&self) {
+        os::mkdir_recursive(&Path("src"),   U_RWX);
+        os::mkdir_recursive(&Path("lib"),   U_RWX);
+        os::mkdir_recursive(&Path("bin"),   U_RWX);
+        os::mkdir_recursive(&Path("build"), U_RWX);
+    }
+
     fn uninstall(&self, _id: &str, _vers: Option<~str>)  {
         fail!("uninstall not yet implemented");
     }
@@ -688,6 +703,7 @@ pub fn main_args(args: &[~str]) {
                     ~"list"    => usage::list(),
                     ~"prefer" => usage::prefer(),
                     ~"test" => usage::test(),
+                    ~"init" => usage::init(),
                     ~"uninstall" => usage::uninstall(),
                     ~"unprefer" => usage::unprefer(),
                     _ => usage::general()

--- a/src/librustpkg/usage.rs
+++ b/src/librustpkg/usage.rs
@@ -148,3 +148,10 @@ and exit code will be redirected.
 Options:
     -c, --cfg      Pass a cfg flag to the package script");
 }
+
+pub fn init() {
+    io::println("rustpkg init name
+
+This makes a new workspace for working on a project named name.
+");
+}

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -33,7 +33,7 @@ use workcache_support::{digest_file_with_date, digest_only_date};
 // you could update the match in rustpkg.rc but forget to update this list. I think
 // that should be fixed.
 static COMMANDS: &'static [&'static str] =
-    &["build", "clean", "do", "info", "install", "list", "prefer", "test", "uninstall",
+    &["build", "clean", "do", "info", "init", "install", "list", "prefer", "test", "uninstall",
       "unprefer"];
 
 


### PR DESCRIPTION
Closes #9045

Built on top of #9235, which isn't strictly needed for now, but I imagine I will use part of. Unsure.

I mostly wanted to start this off to get some feedback from @catamorphism and others. These are the directories that actually need made, but I was thinking about adding a few other things:
1. an `examples` directory, since it seems like that's a common pattern
2. a `.gitignore` file that ignores `build`. And anything else that makes sense
3. a sample module that'd actually compile

Feedback?
