### PR TITLE
mk: Fix valgrinding with jemalloc

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -47,8 +47,11 @@ else
   CFG_GCCISH_CFLAGS += -O2
 endif
 
+# The soname thing is for supporting a statically linked jemalloc.
+# see https://blog.mozilla.org/jseward/2012/06/05/valgrind-now-supports-jemalloc-builds-directly/
 ifdef CFG_VALGRIND
   CFG_VALGRIND += --error-exitcode=100 \
+                  --soname-synonyms=somalloc=NONE \
                   --quiet \
                   --suppressions=$(CFG_SRC_DIR)src/etc/x86.supp \
                   $(OS_SUPP)


### PR DESCRIPTION
This fixes valgrind on the linux snapshot bot. The command added here
makes us require a fairly recent valgrind.
