### PR TITLE
switch Drop to `&mut self`

### DIFF
--- a/doc/tutorial-ffi.md
+++ b/doc/tutorial-ffi.md
@@ -321,7 +321,7 @@ impl<T: Send> Unique<T> {
 
 #[unsafe_destructor]
 impl<T: Send> Drop for Unique<T> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         #[fixed_stack_segment];
         #[inline(never)];
         

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1898,7 +1898,7 @@ struct TimeBomb {
 }
 
 impl Drop for TimeBomb {
-    fn drop(&self) {
+    fn drop(&mut self) {
         for _ in range(0, self.explosivity) {
             println("blam!");
         }

--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -313,7 +313,7 @@ struct PoisonOnFail {
 }
 
 impl Drop for PoisonOnFail {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             /* assert!(!*self.failed);
                -- might be false in case of cond.wait() */

--- a/src/libextra/arena.rs
+++ b/src/libextra/arena.rs
@@ -93,7 +93,7 @@ fn chunk(size: uint, is_pod: bool) -> Chunk {
 
 #[unsafe_destructor]
 impl Drop for Arena {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             destroy_chunk(&self.head);
             do self.chunks.each |chunk| {

--- a/src/libextra/c_vec.rs
+++ b/src/libextra/c_vec.rs
@@ -56,7 +56,7 @@ struct DtorRes {
 
 #[unsafe_destructor]
 impl Drop for DtorRes {
-    fn drop(&self) {
+    fn drop(&mut self) {
         match self.dtor {
             option::None => (),
             option::Some(f) => f()

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -415,14 +415,11 @@ impl<T: Ord> DList<T> {
 
 #[unsafe_destructor]
 impl<T> Drop for DList<T> {
-    fn drop(&self) {
-        let mut_self = unsafe {
-            cast::transmute_mut(self)
-        };
+    fn drop(&mut self) {
         // Dissolve the dlist in backwards direction
         // Just dropping the list_head can lead to stack exhaustion
         // when length is >> 1_000_000
-        let mut tail = mut_self.list_tail;
+        let mut tail = self.list_tail;
         loop {
             match tail.resolve() {
                 None => break,
@@ -432,9 +429,9 @@ impl<T> Drop for DList<T> {
                 }
             }
         }
-        mut_self.length = 0;
-        mut_self.list_head = None;
-        mut_self.list_tail = Rawlink::none();
+        self.length = 0;
+        self.list_head = None;
+        self.list_tail = Rawlink::none();
     }
 }
 

--- a/src/libextra/future.rs
+++ b/src/libextra/future.rs
@@ -43,7 +43,7 @@ pub struct Future<A> {
 // over ~fn's that have pipes and so forth within!
 #[unsafe_destructor]
 impl<A> Drop for Future<A> {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 enum FutureState<A> {

--- a/src/libextra/rc.rs
+++ b/src/libextra/rc.rs
@@ -73,7 +73,7 @@ impl<T> Rc<T> {
 
 #[unsafe_destructor]
 impl<T> Drop for Rc<T> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             if self.ptr.is_not_null() {
                 (*self.ptr).count -= 1;
@@ -218,7 +218,7 @@ impl<T> RcMut<T> {
 
 #[unsafe_destructor]
 impl<T> Drop for RcMut<T> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             if self.ptr.is_not_null() {
                 (*self.ptr).count -= 1;

--- a/src/libextra/task_pool.rs
+++ b/src/libextra/task_pool.rs
@@ -34,7 +34,7 @@ pub struct TaskPool<T> {
 
 #[unsafe_destructor]
 impl<T> Drop for TaskPool<T> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         for channel in self.channels.iter() {
             channel.send(Quit);
         }

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -201,7 +201,7 @@ impl Database {
 // FIXME #4330: use &mut self here
 #[unsafe_destructor]
 impl Drop for Database {
-    fn drop(&self) {
+    fn drop(&mut self) {
         if self.db_dirty {
             self.save();
         }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -105,7 +105,7 @@ pub mod jit {
     impl Engine for LLVMJITData {}
 
     impl Drop for LLVMJITData {
-        fn drop(&self) {
+        fn drop(&mut self) {
             unsafe {
                 llvm::LLVMDisposeExecutionEngine(self.ee);
                 llvm::LLVMContextDispose(self.llcx);

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -2325,7 +2325,7 @@ pub struct target_data_res {
 }
 
 impl Drop for target_data_res {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             llvm::LLVMDisposeTargetData(self.TD);
         }
@@ -2361,7 +2361,7 @@ pub struct pass_manager_res {
 }
 
 impl Drop for pass_manager_res {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             llvm::LLVMDisposePassManager(self.PM);
         }
@@ -2397,7 +2397,7 @@ pub struct object_file_res {
 }
 
 impl Drop for object_file_res {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             llvm::LLVMDisposeObjectFile(self.ObjectFile);
         }
@@ -2434,7 +2434,7 @@ pub struct section_iter_res {
 }
 
 impl Drop for section_iter_res {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             llvm::LLVMDisposeSectionIterator(self.SI);
         }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -109,7 +109,7 @@ pub struct _InsnCtxt { _x: () }
 
 #[unsafe_destructor]
 impl Drop for _InsnCtxt {
-    fn drop(&self) {
+    fn drop(&mut self) {
         do local_data::modify(task_local_insn_key) |c| {
             do c.map_move |ctx| {
                 let mut ctx = (*ctx).clone();
@@ -159,7 +159,7 @@ impl<'self> StatRecorder<'self> {
 
 #[unsafe_destructor]
 impl<'self> Drop for StatRecorder<'self> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         if self.ccx.sess.trans_stats() {
             let end = time::precise_time_ns();
             let elapsed = ((end - self.start) / 1_000_000) as uint;

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -111,7 +111,7 @@ pub struct BuilderRef_res {
 }
 
 impl Drop for BuilderRef_res {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             llvm::LLVMDisposeBuilder(self.B);
         }

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -273,7 +273,7 @@ impl CrateContext {
 
 #[unsafe_destructor]
 impl Drop for CrateContext {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unset_task_llcx();
     }
 }

--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -342,7 +342,7 @@ pub fn monitor(f: ~fn(diagnostic::Emitter)) {
         }
 
         impl Drop for finally {
-            fn drop(&self) { self.ch.send(done); }
+            fn drop(&mut self) { self.ch.send(done); }
         }
 
         let _finally = finally { ch: ch };

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -40,7 +40,7 @@ pub struct _indenter {
 }
 
 impl Drop for _indenter {
-    fn drop(&self) { debug!("<<"); }
+    fn drop(&mut self) { debug!("<<"); }
 }
 
 pub fn _indenter(_i: ()) -> _indenter {

--- a/src/librustdoc/demo.rs
+++ b/src/librustdoc/demo.rs
@@ -127,7 +127,7 @@ struct Bored {
 }
 
 impl Drop for Bored {
-  fn drop(&self) { }
+  fn drop(&mut self) { }
 }
 
 /**

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -127,7 +127,7 @@ impl CString {
 }
 
 impl Drop for CString {
-    fn drop(&self) {
+    fn drop(&mut self) {
         #[fixed_stack_segment]; #[inline(never)];
         if self.owns_buffer_ {
             unsafe {

--- a/src/libstd/condition.rs
+++ b/src/libstd/condition.rs
@@ -87,7 +87,7 @@ struct Guard<'self, T, U> {
 
 #[unsafe_destructor]
 impl<'self, T, U> Drop for Guard<'self, T, U> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         debug!("Guard: popping handler from TLS");
         let curr = local_data::pop(self.cond.key);
         match curr {

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -1021,7 +1021,7 @@ impl FILERes {
 }
 
 impl Drop for FILERes {
-    fn drop(&self) {
+    fn drop(&mut self) {
         #[fixed_stack_segment]; #[inline(never)];
 
         unsafe {
@@ -1302,7 +1302,7 @@ impl FdRes {
 }
 
 impl Drop for FdRes {
-    fn drop(&self) {
+    fn drop(&mut self) {
         #[fixed_stack_segment]; #[inline(never)];
 
         unsafe {
@@ -1832,7 +1832,7 @@ pub mod fsync {
 
     #[unsafe_destructor]
     impl<T> Drop for Res<T> {
-        fn drop(&self) {
+        fn drop(&mut self) {
             match self.arg.opt_level {
                 None => (),
                 Some(level) => {

--- a/src/libstd/ops.rs
+++ b/src/libstd/ops.rs
@@ -14,7 +14,7 @@
 
 #[lang="drop"]
 pub trait Drop {
-    fn drop(&self);
+    fn drop(&mut self);
 }
 
 #[lang="add"]
@@ -95,7 +95,7 @@ mod bench {
     }
 
     impl Drop for HasDtor {
-        fn drop(&self) {
+        fn drop(&mut self) {
         }
     }
 

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -573,7 +573,7 @@ mod tests {
 
         #[unsafe_destructor]
         impl ::ops::Drop for R {
-           fn drop(&self) { *(self.i) += 1; }
+           fn drop(&mut self) { *(self.i) += 1; }
         }
 
         fn R(i: @mut int) -> R {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1481,7 +1481,7 @@ impl MemoryMap {
 
 #[cfg(unix)]
 impl Drop for MemoryMap {
-    fn drop(&self) {
+    fn drop(&mut self) {
         #[fixed_stack_segment]; #[inline(never)];
 
         unsafe {
@@ -1607,7 +1607,7 @@ impl MemoryMap {
 
 #[cfg(windows)]
 impl Drop for MemoryMap {
-    fn drop(&self) {
+    fn drop(&mut self) {
         #[fixed_stack_segment]; #[inline(never)];
 
         use libc::types::os::arch::extra::{LPCVOID, HANDLE};

--- a/src/libstd/rt/comm.rs
+++ b/src/libstd/rt/comm.rs
@@ -363,7 +363,7 @@ impl<T> Peekable<T> for PortOne<T> {
 
 #[unsafe_destructor]
 impl<T> Drop for ChanOne<T> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         if self.suppress_finalize { return }
 
         unsafe {
@@ -391,7 +391,7 @@ impl<T> Drop for ChanOne<T> {
 
 #[unsafe_destructor]
 impl<T> Drop for PortOne<T> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         if self.suppress_finalize { return }
 
         unsafe {

--- a/src/libstd/rt/kill.rs
+++ b/src/libstd/rt/kill.rs
@@ -235,7 +235,7 @@ pub struct Death {
 impl Drop for KillFlag {
     // Letting a KillFlag with a task inside get dropped would leak the task.
     // We could free it here, but the task should get awoken by hand somehow.
-    fn drop(&self) {
+    fn drop(&mut self) {
         match self.load(Relaxed) {
             KILL_RUNNING | KILL_KILLED => { },
             _ => rtabort!("can't drop kill flag with a blocked task inside!"),
@@ -685,7 +685,7 @@ impl Death {
 }
 
 impl Drop for Death {
-    fn drop(&self) {
+    fn drop(&mut self) {
         // Mustn't be in an atomic or unkillable section at task death.
         rtassert!(self.unkillable == 0);
         rtassert!(self.wont_sleep == 0);

--- a/src/libstd/rt/local_heap.rs
+++ b/src/libstd/rt/local_heap.rs
@@ -78,7 +78,7 @@ impl LocalHeap {
 
 impl Drop for LocalHeap {
     #[fixed_stack_segment] #[inline(never)]
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             rust_delete_boxed_region(self.boxed_region);
             rust_delete_memory_region(self.memory_region);

--- a/src/libstd/rt/rc.rs
+++ b/src/libstd/rt/rc.rs
@@ -74,7 +74,7 @@ impl<T> RC<T> {
 
 #[unsafe_destructor]
 impl<T> Drop for RC<T> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         assert!(self.refcount() > 0);
 
         unsafe {

--- a/src/libstd/rt/sched.rs
+++ b/src/libstd/rt/sched.rs
@@ -1200,15 +1200,15 @@ mod test {
             struct S { field: () }
 
             impl Drop for S {
-                fn drop(&self) {
-                        let _foo = @0;
+                fn drop(&mut self) {
+                    let _foo = @0;
                 }
             }
 
             let s = S { field: () };
 
             do spawntask {
-                        let _ss = &s;
+                let _ss = &s;
             }
         }
     }

--- a/src/libstd/rt/stack.rs
+++ b/src/libstd/rt/stack.rs
@@ -53,7 +53,7 @@ impl StackSegment {
 }
 
 impl Drop for StackSegment {
-    fn drop(&self) {
+    fn drop(&mut self) {
         #[fixed_stack_segment]; #[inline(never)];
 
         unsafe {

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -328,7 +328,7 @@ impl Task {
 }
 
 impl Drop for Task {
-    fn drop(&self) {
+    fn drop(&mut self) {
         rtdebug!("called drop for a task: %u", borrow::to_uint(self));
         rtassert!(self.destroyed)
     }

--- a/src/libstd/rt/thread.rs
+++ b/src/libstd/rt/thread.rs
@@ -46,7 +46,7 @@ impl Thread {
 }
 
 impl Drop for Thread {
-    fn drop(&self) {
+    fn drop(&mut self) {
         #[fixed_stack_segment]; #[inline(never)];
 
         assert!(self.joined);

--- a/src/libstd/rt/uv/uvio.rs
+++ b/src/libstd/rt/uv/uvio.rs
@@ -187,7 +187,7 @@ impl UvEventLoop {
 }
 
 impl Drop for UvEventLoop {
-    fn drop(&self) {
+    fn drop(&mut self) {
         // XXX: Need mutable finalizer
         let this = unsafe {
             transmute::<&UvEventLoop, &mut UvEventLoop>(self)
@@ -351,7 +351,7 @@ impl RemoteCallback for UvRemoteCallback {
 }
 
 impl Drop for UvRemoteCallback {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             let this: &mut UvRemoteCallback = cast::transmute_mut(self);
             do this.exit_flag.with |should_exit| {
@@ -647,7 +647,7 @@ impl UvTcpListener {
 }
 
 impl Drop for UvTcpListener {
-    fn drop(&self) {
+    fn drop(&mut self) {
         // XXX need mutable finalizer
         let self_ = unsafe { transmute::<&UvTcpListener, &mut UvTcpListener>(self) };
         do self_.home_for_io_with_sched |self_, scheduler| {
@@ -762,7 +762,7 @@ impl HomingIO for UvTcpStream {
 }
 
 impl Drop for UvTcpStream {
-    fn drop(&self) {
+    fn drop(&mut self) {
         // XXX need mutable finalizer
         let this = unsafe { transmute::<&UvTcpStream, &mut UvTcpStream>(self) };
         do this.home_for_io_with_sched |self_, scheduler| {
@@ -921,7 +921,7 @@ impl HomingIO for UvUdpSocket {
 }
 
 impl Drop for UvUdpSocket {
-    fn drop(&self) {
+    fn drop(&mut self) {
         // XXX need mutable finalizer
         let this = unsafe { transmute::<&UvUdpSocket, &mut UvUdpSocket>(self) };
         do this.home_for_io_with_sched |self_, scheduler| {
@@ -1139,7 +1139,7 @@ impl UvTimer {
 }
 
 impl Drop for UvTimer {
-    fn drop(&self) {
+    fn drop(&mut self) {
         let self_ = unsafe { transmute::<&UvTimer, &mut UvTimer>(self) };
         do self_.home_for_io_with_sched |self_, scheduler| {
             rtdebug!("closing UvTimer");
@@ -1253,7 +1253,7 @@ impl UvFileStream {
 }
 
 impl Drop for UvFileStream {
-    fn drop(&self) {
+    fn drop(&mut self) {
         let self_ = unsafe { transmute::<&UvFileStream, &mut UvFileStream>(self) };
         if self.close_on_drop {
             do self_.home_for_io_with_sched |self_, scheduler| {

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -436,12 +436,9 @@ impl Process {
 }
 
 impl Drop for Process {
-    fn drop(&self) {
-        // FIXME(#4330) Need self by value to get mutability.
-        let mut_self: &mut Process = unsafe { cast::transmute(self) };
-
-        mut_self.finish();
-        mut_self.close_outputs();
+    fn drop(&mut self) {
+        self.finish();
+        self.close_outputs();
         free_handle(self.handle);
     }
 }

--- a/src/libstd/unstable/atomics.rs
+++ b/src/libstd/unstable/atomics.rs
@@ -338,7 +338,7 @@ impl<T> AtomicOption<T> {
 
 #[unsafe_destructor]
 impl<T> Drop for AtomicOption<T> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         // This will ensure that the contained data is
         // destroyed, unless it's null.
         unsafe {

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -26,7 +26,7 @@ use result::*;
 pub struct DynamicLibrary { priv handle: *libc::c_void }
 
 impl Drop for DynamicLibrary {
-    fn drop(&self) {
+    fn drop(&mut self) {
         match do dl::check_for_errors_in {
             unsafe {
                 dl::close(self.handle)

--- a/src/libstd/unstable/finally.rs
+++ b/src/libstd/unstable/finally.rs
@@ -64,7 +64,7 @@ struct Finallyalizer<'self> {
 
 #[unsafe_destructor]
 impl<'self> Drop for Finallyalizer<'self> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         (self.dtor)();
     }
 }

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -220,7 +220,7 @@ impl<T: Send> Clone for UnsafeArc<T> {
 
 #[unsafe_destructor]
 impl<T> Drop for UnsafeArc<T>{
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             // Happens when destructing an unwrapper's handle and from `#[unsafe_no_drop_flag]`
             if self.data.is_null() {
@@ -308,7 +308,7 @@ pub struct LittleLock {
 }
 
 impl Drop for LittleLock {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             rust_destroy_little_lock(self.l);
         }

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -88,7 +88,7 @@ impl NonCopyable {
 }
 
 impl Drop for NonCopyable {
-    fn drop(&self) { }
+    fn drop(&mut self) { }
 }
 
 /// A type with no inhabitants
@@ -188,7 +188,7 @@ mod tests {
         struct Foo { five: int }
 
         impl Drop for Foo {
-            fn drop(&self) {
+            fn drop(&mut self) {
                 assert_eq!(self.five, 5);
                 unsafe {
                     did_run = true;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -341,7 +341,7 @@ pub struct Parser {
 #[unsafe_destructor]
 impl Drop for Parser {
     /* do not copy the parser; its state is tied to outside state */
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn is_plain_ident_or_underscore(t: &token::Token) -> bool {

--- a/src/test/auxiliary/issue-2526.rs
+++ b/src/test/auxiliary/issue-2526.rs
@@ -21,7 +21,7 @@ struct arc_destruct<T> {
 
 #[unsafe_destructor]
 impl<T:Freeze> Drop for arc_destruct<T> {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn arc_destruct<T:Freeze>(data: int) -> arc_destruct<T> {
@@ -43,7 +43,7 @@ struct context_res {
 }
 
 impl Drop for context_res {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn context_res() -> context_res {

--- a/src/test/auxiliary/issue-3012-1.rs
+++ b/src/test/auxiliary/issue-3012-1.rs
@@ -19,7 +19,7 @@ pub mod socket {
     }
 
     impl Drop for socket_handle {
-        fn drop(&self) {
+        fn drop(&mut self) {
             /* c::close(self.sockfd); */
         }
     }

--- a/src/test/auxiliary/issue2170lib.rs
+++ b/src/test/auxiliary/issue2170lib.rs
@@ -16,7 +16,7 @@ pub struct rsrc {
 }
 
 impl Drop for rsrc {
-    fn drop(&self) {
+    fn drop(&mut self) {
         foo(self.x);
     }
 }

--- a/src/test/auxiliary/moves_based_on_type_lib.rs
+++ b/src/test/auxiliary/moves_based_on_type_lib.rs
@@ -15,7 +15,7 @@ pub struct S {
 }
 
 impl Drop for S {
-    fn drop(&self) {
+    fn drop(&mut self) {
         println("goodbye");
     }
 }

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -58,7 +58,7 @@ struct r {
 
 #[unsafe_destructor]
 impl Drop for r {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn r(l: @nillist) -> r {

--- a/src/test/compile-fail/bind-by-move-neither-can-live-while-the-other-survives-1.rs
+++ b/src/test/compile-fail/bind-by-move-neither-can-live-while-the-other-survives-1.rs
@@ -11,7 +11,7 @@
 struct X { x: () }
 
 impl Drop for X {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("destructor runs");
     }
 }

--- a/src/test/compile-fail/bind-by-move-neither-can-live-while-the-other-survives-2.rs
+++ b/src/test/compile-fail/bind-by-move-neither-can-live-while-the-other-survives-2.rs
@@ -11,7 +11,7 @@
 struct X { x: (), }
 
 impl Drop for X {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("destructor runs");
     }
 }

--- a/src/test/compile-fail/bind-by-move-neither-can-live-while-the-other-survives-3.rs
+++ b/src/test/compile-fail/bind-by-move-neither-can-live-while-the-other-survives-3.rs
@@ -11,7 +11,7 @@
 struct X { x: (), }
 
 impl Drop for X {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("destructor runs");
     }
 }

--- a/src/test/compile-fail/bind-by-move-neither-can-live-while-the-other-survives-4.rs
+++ b/src/test/compile-fail/bind-by-move-neither-can-live-while-the-other-survives-4.rs
@@ -11,7 +11,7 @@
 struct X { x: (), }
 
 impl Drop for X {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("destructor runs");
     }
 }

--- a/src/test/compile-fail/bind-by-move-no-sub-bindings.rs
+++ b/src/test/compile-fail/bind-by-move-no-sub-bindings.rs
@@ -11,7 +11,7 @@
 struct X { x: (), }
 
 impl Drop for X {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("destructor runs");
     }
 }

--- a/src/test/compile-fail/block-must-not-have-result-res.rs
+++ b/src/test/compile-fail/block-must-not-have-result-res.rs
@@ -13,7 +13,7 @@
 struct r;
 
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         true
     }
 }

--- a/src/test/compile-fail/borrowck-borrowed-uniq-rvalue-2.rs
+++ b/src/test/compile-fail/borrowck-borrowed-uniq-rvalue-2.rs
@@ -14,7 +14,7 @@ struct defer<'self> {
 
 #[unsafe_destructor]
 impl<'self> Drop for defer<'self> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             error!("%?", self.x);
         }

--- a/src/test/compile-fail/borrowck-move-out-of-struct-with-dtor.rs
+++ b/src/test/compile-fail/borrowck-move-out-of-struct-with-dtor.rs
@@ -1,6 +1,6 @@
 struct S {f:~str}
 impl Drop for S {
-    fn drop(&self) { println(self.f); }
+    fn drop(&mut self) { println(self.f); }
 }
 
 fn move_in_match() {

--- a/src/test/compile-fail/borrowck-move-out-of-tuple-struct-with-dtor.rs
+++ b/src/test/compile-fail/borrowck-move-out-of-tuple-struct-with-dtor.rs
@@ -1,6 +1,6 @@
 struct S(~str);
 impl Drop for S {
-    fn drop(&self) { println(**self); }
+    fn drop(&mut self) { println(**self); }
 }
 
 fn move_in_match() {

--- a/src/test/compile-fail/copy-a-resource.rs
+++ b/src/test/compile-fail/copy-a-resource.rs
@@ -13,7 +13,7 @@ struct foo {
 }
 
 impl Drop for foo {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn foo(i:int) -> foo {

--- a/src/test/compile-fail/disallowed-deconstructing-destructing-struct-let.rs
+++ b/src/test/compile-fail/disallowed-deconstructing-destructing-struct-let.rs
@@ -13,7 +13,7 @@ struct X {
 }
 
 impl Drop for X {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("value: %s", self.x);
     }
 }

--- a/src/test/compile-fail/disallowed-deconstructing-destructing-struct-match.rs
+++ b/src/test/compile-fail/disallowed-deconstructing-destructing-struct-match.rs
@@ -13,7 +13,7 @@ struct X {
 }
 
 impl Drop for X {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("value: %s", self.x);
     }
 }

--- a/src/test/compile-fail/drop-on-non-struct.rs
+++ b/src/test/compile-fail/drop-on-non-struct.rs
@@ -12,7 +12,7 @@ type Foo = @[u8];
 
 impl Drop for Foo {   //~ ERROR the Drop trait may only be implemented
 //~^ ERROR cannot provide an extension implementation
-    fn drop(&self) {
+    fn drop(&mut self) {
         println("kaboom");
     }
 }

--- a/src/test/compile-fail/explicit-call-to-dtor.rs
+++ b/src/test/compile-fail/explicit-call-to-dtor.rs
@@ -13,7 +13,7 @@ struct Foo {
 }
 
 impl Drop for Foo {
-    fn drop(&self) {
+    fn drop(&mut self) {
         println("kaboom");
     }
 }

--- a/src/test/compile-fail/explicit-call-to-supertrait-dtor.rs
+++ b/src/test/compile-fail/explicit-call-to-supertrait-dtor.rs
@@ -17,7 +17,7 @@ trait Bar : Drop {
 }
 
 impl Drop for Foo {
-    fn drop(&self) {
+    fn drop(&mut self) {
         println("kaboom");
     }
 }

--- a/src/test/compile-fail/functional-struct-update-noncopyable.rs
+++ b/src/test/compile-fail/functional-struct-update-noncopyable.rs
@@ -17,7 +17,7 @@ use extra::arc::*;
 struct A { y: Arc<int>, x: Arc<int> }
 
 impl Drop for A {
-    fn drop(&self) { println(fmt!("x=%?", self.x.get())); }
+    fn drop(&mut self) { println(fmt!("x=%?", self.x.get())); }
 }
 fn main() {
     let a = A { y: Arc::new(1), x: Arc::new(2) };

--- a/src/test/compile-fail/issue-2548.rs
+++ b/src/test/compile-fail/issue-2548.rs
@@ -18,7 +18,7 @@ struct foo {
 
 #[unsafe_destructor]
 impl Drop for foo {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             println("Goodbye, World!");
             *self.x += 1;

--- a/src/test/compile-fail/issue-2823.rs
+++ b/src/test/compile-fail/issue-2823.rs
@@ -13,7 +13,7 @@ struct C {
 }
 
 impl Drop for C {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("dropping: %?", self.x);
     }
 }

--- a/src/test/compile-fail/issue-3214.rs
+++ b/src/test/compile-fail/issue-3214.rs
@@ -15,7 +15,7 @@ fn foo<T>() {
     }
 
     impl<T> Drop for foo<T> {
-        fn drop(&self) {}
+        fn drop(&mut self) {}
     }
 }
 fn main() { }

--- a/src/test/compile-fail/kindck-destructor-owned.rs
+++ b/src/test/compile-fail/kindck-destructor-owned.rs
@@ -3,7 +3,7 @@ struct Foo {
 }
 
 impl Drop for Foo { //~ ERROR cannot implement a destructor on a structure that does not satisfy Send
-    fn drop(&self) {
+    fn drop(&mut self) {
         *self.f = 10;
     }
 }

--- a/src/test/compile-fail/no-send-res-ports.rs
+++ b/src/test/compile-fail/no-send-res-ports.rs
@@ -20,7 +20,7 @@ fn main() {
 
     #[unsafe_destructor]
     impl Drop for foo {
-        fn drop(&self) {}
+        fn drop(&mut self) {}
     }
 
     fn foo(x: Port<()>) -> foo {

--- a/src/test/compile-fail/noncopyable-class.rs
+++ b/src/test/compile-fail/noncopyable-class.rs
@@ -15,7 +15,7 @@ struct bar {
 }
 
 impl Drop for bar {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn bar(x:int) -> bar {

--- a/src/test/compile-fail/pinned-deep-copy.rs
+++ b/src/test/compile-fail/pinned-deep-copy.rs
@@ -14,7 +14,7 @@ struct r {
 
 #[unsafe_destructor]
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             *(self.i) = *(self.i) + 1;
         }

--- a/src/test/compile-fail/repeat-to-run-dtor-twice.rs
+++ b/src/test/compile-fail/repeat-to-run-dtor-twice.rs
@@ -17,7 +17,7 @@ struct Foo {
 }
 
 impl Drop for Foo {
-    fn drop(&self) {
+    fn drop(&mut self) {
         println("Goodbye!");
     }
 }

--- a/src/test/compile-fail/unique-object-noncopyable.rs
+++ b/src/test/compile-fail/unique-object-noncopyable.rs
@@ -17,7 +17,7 @@ struct Bar {
 }
 
 impl Drop for Bar {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 impl Foo for Bar {

--- a/src/test/compile-fail/unique-pinned-nocopy.rs
+++ b/src/test/compile-fail/unique-pinned-nocopy.rs
@@ -13,7 +13,7 @@ struct r {
 }
 
 impl Drop for r {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn main() {

--- a/src/test/compile-fail/unique-vec-res.rs
+++ b/src/test/compile-fail/unique-vec-res.rs
@@ -14,7 +14,7 @@ struct r {
 
 #[unsafe_destructor]
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             *(self.i) = *(self.i) + 1;
         }

--- a/src/test/compile-fail/use-after-move-self-based-on-type.rs
+++ b/src/test/compile-fail/use-after-move-self-based-on-type.rs
@@ -3,7 +3,7 @@ struct S {
 }
 
 impl Drop for S {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 impl S {

--- a/src/test/compile-fail/vec-res-add.rs
+++ b/src/test/compile-fail/vec-res-add.rs
@@ -17,7 +17,7 @@ struct r {
 fn r(i:int) -> r { r { i: i } }
 
 impl Drop for r {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn main() {

--- a/src/test/debug-info/boxed-struct.rs
+++ b/src/test/debug-info/boxed-struct.rs
@@ -42,7 +42,7 @@ struct StructWithDestructor {
 }
 
 impl Drop for StructWithDestructor {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn main() {

--- a/src/test/debug-info/c-style-enum-in-composite.rs
+++ b/src/test/debug-info/c-style-enum-in-composite.rs
@@ -78,7 +78,7 @@ struct StructWithDrop {
 }
 
 impl Drop for StructWithDrop {
-    fn drop(&self) {()}
+    fn drop(&mut self) {()}
 }
 
 fn main() {

--- a/src/test/debug-info/packed-struct-with-destructor.rs
+++ b/src/test/debug-info/packed-struct-with-destructor.rs
@@ -49,7 +49,7 @@ struct Packed {
 }
 
 impl Drop for Packed {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 #[packed]
@@ -74,7 +74,7 @@ struct Unpacked {
 }
 
 impl Drop for Unpacked {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 #[packed]
@@ -94,7 +94,7 @@ struct PackedInPackedWithDrop {
 }
 
 impl Drop for PackedInPackedWithDrop {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 struct PackedInUnpackedWithDrop {
@@ -105,7 +105,7 @@ struct PackedInUnpackedWithDrop {
 }
 
 impl Drop for PackedInUnpackedWithDrop {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 #[packed]
@@ -117,7 +117,7 @@ struct UnpackedInPackedWithDrop {
 }
 
 impl Drop for UnpackedInPackedWithDrop {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 struct DeeplyNested {

--- a/src/test/debug-info/struct-with-destructor.rs
+++ b/src/test/debug-info/struct-with-destructor.rs
@@ -37,7 +37,7 @@ struct WithDestructor {
 }
 
 impl Drop for WithDestructor {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 struct NoDestructorGuarded {
@@ -55,7 +55,7 @@ struct NestedInner {
 }
 
 impl Drop for NestedInner {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 struct NestedOuter {

--- a/src/test/run-fail/issue-2061.rs
+++ b/src/test/run-fail/issue-2061.rs
@@ -15,7 +15,7 @@ struct R {
 }
 
 impl Drop for R {
-    fn drop(&self) {
+    fn drop(&mut self) {
         let _y = R { b: self.b };
     }
 }

--- a/src/test/run-fail/morestack2.rs
+++ b/src/test/run-fail/morestack2.rs
@@ -45,7 +45,7 @@ struct and_then_get_big_again {
 }
 
 impl Drop for and_then_get_big_again {
-    fn drop(&self) {
+    fn drop(&mut self) {
         fn getbig(i: int) {
             if i != 0 {
                 getbig(i - 1);

--- a/src/test/run-fail/morestack3.rs
+++ b/src/test/run-fail/morestack3.rs
@@ -31,7 +31,7 @@ struct and_then_get_big_again {
 }
 
 impl Drop for and_then_get_big_again {
-    fn drop(&self) {
+    fn drop(&mut self) {
         fn getbig(i: int) {
             if i != 0 {
                 getbig(i - 1);

--- a/src/test/run-fail/morestack4.rs
+++ b/src/test/run-fail/morestack4.rs
@@ -31,7 +31,7 @@ struct and_then_get_big_again {
 }
 
 impl Drop for and_then_get_big_again {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn and_then_get_big_again(x:int) -> and_then_get_big_again {

--- a/src/test/run-fail/rt-set-exit-status-fail2.rs
+++ b/src/test/run-fail/rt-set-exit-status-fail2.rs
@@ -21,7 +21,7 @@ struct r {
 // failed has no effect and the process exits with the
 // runtime's exit code
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         os::set_exit_status(50);
     }
 }

--- a/src/test/run-fail/too-much-recursion-unwinding.rs
+++ b/src/test/run-fail/too-much-recursion-unwinding.rs
@@ -24,7 +24,7 @@ struct r {
 }
 
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             if !*(self.recursed) {
                 *(self.recursed) = true;

--- a/src/test/run-fail/unwind-box-res.rs
+++ b/src/test/run-fail/unwind-box-res.rs
@@ -21,7 +21,7 @@ struct r {
 }
 
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             let _v2: ~int = cast::transmute(self.v);
         }

--- a/src/test/run-fail/unwind-resource-fail.rs
+++ b/src/test/run-fail/unwind-resource-fail.rs
@@ -15,7 +15,7 @@ struct r {
 }
 
 impl Drop for r {
-    fn drop(&self) { fail!("squirrel") }
+    fn drop(&mut self) { fail!("squirrel") }
 }
 
 fn r(i: int) -> r { r { i: i } }

--- a/src/test/run-fail/unwind-resource-fail2.rs
+++ b/src/test/run-fail/unwind-resource-fail2.rs
@@ -16,7 +16,7 @@ struct r {
 }
 
 impl Drop for r {
-    fn drop(&self) { fail!("wombat") }
+    fn drop(&mut self) { fail!("wombat") }
 }
 
 fn r(i: int) -> r { r { i: i } }

--- a/src/test/run-fail/unwind-resource-fail3.rs
+++ b/src/test/run-fail/unwind-resource-fail3.rs
@@ -19,7 +19,7 @@ fn faily_box(i: @int) -> faily_box { faily_box { i: i } }
 
 #[unsafe_destructor]
 impl Drop for faily_box {
-    fn drop(&self) {
+    fn drop(&mut self) {
         fail!("quux");
     }
 }

--- a/src/test/run-pass/attr-no-drop-flag-size.rs
+++ b/src/test/run-pass/attr-no-drop-flag-size.rs
@@ -17,7 +17,7 @@ struct Test<T> {
 
 #[unsafe_destructor]
 impl<T> Drop for Test<T> {
-    fn drop(&self) { }
+    fn drop(&mut self) { }
 }
 
 fn main() {

--- a/src/test/run-pass/borrowck-unary-move-2.rs
+++ b/src/test/run-pass/borrowck-unary-move-2.rs
@@ -13,7 +13,7 @@ struct noncopyable {
 }
 
 impl Drop for noncopyable {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("dropped");
     }
 }

--- a/src/test/run-pass/class-attributes-1.rs
+++ b/src/test/run-pass/class-attributes-1.rs
@@ -16,7 +16,7 @@ struct cat {
 
 impl Drop for cat {
     #[cat_dropper]
-    fn drop(&self) { error!("%s landed on hir feet" , self . name); }
+    fn drop(&mut self) { error!("%s landed on hir feet" , self . name); }
 }
 
 

--- a/src/test/run-pass/class-attributes-2.rs
+++ b/src/test/run-pass/class-attributes-2.rs
@@ -17,7 +17,7 @@ impl Drop for cat {
     /**
        Actually, cats don't always land on their feet when you drop them.
     */
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("%s landed on hir feet", self.name);
     }
 }

--- a/src/test/run-pass/class-dtor.rs
+++ b/src/test/run-pass/class-dtor.rs
@@ -14,7 +14,7 @@ struct cat {
 }
 
 impl Drop for cat {
-    fn drop(&self) {
+    fn drop(&mut self) {
         (self.done)(self.meows);
     }
 }

--- a/src/test/run-pass/drop-trait-generic.rs
+++ b/src/test/run-pass/drop-trait-generic.rs
@@ -14,7 +14,7 @@ struct S<T> {
 
 #[unsafe_destructor]
 impl<T> ::std::ops::Drop for S<T> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         println("bye");
     }
 }

--- a/src/test/run-pass/drop-trait.rs
+++ b/src/test/run-pass/drop-trait.rs
@@ -13,7 +13,7 @@ struct Foo {
 }
 
 impl Drop for Foo {
-    fn drop(&self) {
+    fn drop(&mut self) {
         println("bye");
     }
 }

--- a/src/test/run-pass/init-res-into-things.rs
+++ b/src/test/run-pass/init-res-into-things.rs
@@ -19,7 +19,7 @@ struct Box { x: r }
 
 #[unsafe_destructor]
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         *(self.i) = *(self.i) + 1;
     }
 }

--- a/src/test/run-pass/issue-2487-a.rs
+++ b/src/test/run-pass/issue-2487-a.rs
@@ -14,7 +14,7 @@ struct socket {
 }
 
 impl Drop for socket {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 impl socket {

--- a/src/test/run-pass/issue-2708.rs
+++ b/src/test/run-pass/issue-2708.rs
@@ -16,7 +16,7 @@ struct Font {
 }
 
 impl Drop for Font {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn Font() -> Font {

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -161,7 +161,7 @@ pub mod pipes {
 
     #[unsafe_destructor]
     impl<T:Send> Drop for send_packet<T> {
-        fn drop(&self) {
+        fn drop(&mut self) {
             unsafe {
                 if self.p != None {
                     let self_p: &mut Option<*packet<T>> =
@@ -191,7 +191,7 @@ pub mod pipes {
 
     #[unsafe_destructor]
     impl<T:Send> Drop for recv_packet<T> {
-        fn drop(&self) {
+        fn drop(&mut self) {
             unsafe {
                 if self.p != None {
                     let self_p: &mut Option<*packet<T>> =

--- a/src/test/run-pass/issue-2735-2.rs
+++ b/src/test/run-pass/issue-2735-2.rs
@@ -15,7 +15,7 @@ struct defer {
 
 #[unsafe_destructor]
 impl Drop for defer {
-    fn drop(&self) {
+    fn drop(&mut self) {
         *self.b = true;
     }
 }

--- a/src/test/run-pass/issue-2735-3.rs
+++ b/src/test/run-pass/issue-2735-3.rs
@@ -15,7 +15,7 @@ struct defer {
 
 #[unsafe_destructor]
 impl Drop for defer {
-    fn drop(&self) {
+    fn drop(&mut self) {
         *self.b = true;
     }
 }

--- a/src/test/run-pass/issue-2895.rs
+++ b/src/test/run-pass/issue-2895.rs
@@ -19,7 +19,7 @@ struct Kitty {
 }
 
 impl Drop for Kitty {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/src/test/run-pass/issue-3220.rs
+++ b/src/test/run-pass/issue-3220.rs
@@ -11,7 +11,7 @@
 struct thing { x: int, }
 
 impl Drop for thing {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn thing() -> thing {

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -57,7 +57,7 @@ struct AsciiArt {
 }
 
 impl Drop for AsciiArt {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 // It's common to define a constructor sort of function to create struct instances.

--- a/src/test/run-pass/issue-4252.rs
+++ b/src/test/run-pass/issue-4252.rs
@@ -26,7 +26,7 @@ impl X for Y {
 }
 
 impl<T: X> Drop for Z<T> {
-    fn drop(&self) {
+    fn drop(&mut self) {
         self.x.call(); // Adding this statement causes an ICE.
     }
 }

--- a/src/test/run-pass/issue-4735.rs
+++ b/src/test/run-pass/issue-4735.rs
@@ -15,7 +15,7 @@ use std::libc::c_void;
 struct NonCopyable(*c_void);
 
 impl Drop for NonCopyable {
-    fn drop(&self) {
+    fn drop(&mut self) {
         let p = **self;
         let _v = unsafe { transmute::<*c_void, ~int>(p) };
     }

--- a/src/test/run-pass/issue-6341.rs
+++ b/src/test/run-pass/issue-6341.rs
@@ -12,7 +12,7 @@
 struct A { x: uint }
 
 impl Drop for A {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn main() {}

--- a/src/test/run-pass/issue-6344-let.rs
+++ b/src/test/run-pass/issue-6344-let.rs
@@ -10,7 +10,7 @@
 struct A { x: uint }
 
 impl Drop for A {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn main() {

--- a/src/test/run-pass/issue-6344-match.rs
+++ b/src/test/run-pass/issue-6344-match.rs
@@ -10,7 +10,7 @@
 struct A { x: uint }
 
 impl Drop for A {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn main() {

--- a/src/test/run-pass/issue-979.rs
+++ b/src/test/run-pass/issue-979.rs
@@ -14,7 +14,7 @@ struct r {
 
 #[unsafe_destructor]
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         *(self.b) += 1;
     }
 }

--- a/src/test/run-pass/newtype-struct-drop-run.rs
+++ b/src/test/run-pass/newtype-struct-drop-run.rs
@@ -14,7 +14,7 @@ struct Foo(@mut int);
 
 #[unsafe_destructor]
 impl Drop for Foo {
-    fn drop(&self) {
+    fn drop(&mut self) {
         ***self = 23;
     }
 }

--- a/src/test/run-pass/newtype-struct-with-dtor.rs
+++ b/src/test/run-pass/newtype-struct-with-dtor.rs
@@ -5,7 +5,7 @@ pub struct Fd(c_int);
 
 impl Drop for Fd {
     #[fixed_stack_segment] #[inline(never)]
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             libc::close(**self);
         }

--- a/src/test/run-pass/option-unwrap.rs
+++ b/src/test/run-pass/option-unwrap.rs
@@ -15,7 +15,7 @@ struct dtor {
 
 #[unsafe_destructor]
 impl Drop for dtor {
-    fn drop(&self) {
+    fn drop(&mut self) {
         // abuse access to shared mutable state to write this code
         *self.x -= 1;
     }

--- a/src/test/run-pass/resource-assign-is-not-copy.rs
+++ b/src/test/run-pass/resource-assign-is-not-copy.rs
@@ -14,7 +14,7 @@ struct r {
 
 #[unsafe_destructor]
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         *(self.i) += 1;
     }
 }

--- a/src/test/run-pass/resource-cycle.rs
+++ b/src/test/run-pass/resource-cycle.rs
@@ -17,10 +17,10 @@ struct r {
 }
 
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             info!("r's dtor: self = %x, self.v = %x, self.v's value = %x",
-              cast::transmute::<*r, uint>(self),
+              cast::transmute::<*mut r, uint>(self),
               cast::transmute::<**int, uint>(&(self.v)),
               cast::transmute::<*int, uint>(self.v));
             let _v2: ~int = cast::transmute(self.v);

--- a/src/test/run-pass/resource-cycle2.rs
+++ b/src/test/run-pass/resource-cycle2.rs
@@ -23,7 +23,7 @@ struct r {
 }
 
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             let _v2: ~int = cast::transmute(self.v.c);
         }

--- a/src/test/run-pass/resource-cycle3.rs
+++ b/src/test/run-pass/resource-cycle3.rs
@@ -27,7 +27,7 @@ struct R {
 }
 
 impl Drop for R {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             let _v2: ~int = cast::transmute(self.v.c);
             // let _v3: ~int = cast::transmute_copy(self.x);

--- a/src/test/run-pass/resource-destruct.rs
+++ b/src/test/run-pass/resource-destruct.rs
@@ -14,7 +14,7 @@ struct shrinky_pointer {
 
 #[unsafe_destructor]
 impl Drop for shrinky_pointer {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!(~"Hello!"); **(self.i) -= 1;
     }
 }

--- a/src/test/run-pass/resource-in-struct.rs
+++ b/src/test/run-pass/resource-in-struct.rs
@@ -20,7 +20,7 @@ struct close_res {
 
 #[unsafe_destructor]
 impl Drop for close_res {
-    fn drop(&self) {
+    fn drop(&mut self) {
         *(self.i) = false;
     }
 }

--- a/src/test/run-pass/send-resource.rs
+++ b/src/test/run-pass/send-resource.rs
@@ -15,7 +15,7 @@ struct test {
 }
 
 impl Drop for test {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn test(f: int) -> test {

--- a/src/test/run-pass/struct-literal-dtor.rs
+++ b/src/test/run-pass/struct-literal-dtor.rs
@@ -13,7 +13,7 @@ struct foo {
 }
 
 impl Drop for foo {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("%s", self.x);
     }
 }

--- a/src/test/run-pass/task-killjoin-rsrc.rs
+++ b/src/test/run-pass/task-killjoin-rsrc.rs
@@ -24,7 +24,7 @@ struct notify {
 
 #[unsafe_destructor]
 impl Drop for notify {
-    fn drop(&self) {
+    fn drop(&mut self) {
         unsafe {
             error!("notify: task=%? v=%x unwinding=%b b=%b",
                    0,

--- a/src/test/run-pass/type-param-constraints.rs
+++ b/src/test/run-pass/type-param-constraints.rs
@@ -19,7 +19,7 @@ struct r {
 }
 
 impl Drop for r {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn r(i:int) -> r {

--- a/src/test/run-pass/unique-pinned-nocopy-2.rs
+++ b/src/test/run-pass/unique-pinned-nocopy-2.rs
@@ -14,7 +14,7 @@ struct r {
 
 #[unsafe_destructor]
 impl Drop for r {
-    fn drop(&self) {
+    fn drop(&mut self) {
         *(self.i) = *(self.i) + 1;
     }
 }

--- a/src/test/run-pass/unit-like-struct-drop-run.rs
+++ b/src/test/run-pass/unit-like-struct-drop-run.rs
@@ -16,7 +16,7 @@ use std::task;
 struct Foo;
 
 impl Drop for Foo {
-    fn drop(&self) {
+    fn drop(&mut self) {
         fail!("This failure should happen.");
     }
 }

--- a/src/test/run-pass/unwind-resource.rs
+++ b/src/test/run-pass/unwind-resource.rs
@@ -20,7 +20,7 @@ struct complainer {
 }
 
 impl Drop for complainer {
-    fn drop(&self) {
+    fn drop(&mut self) {
         error!("About to send!");
         self.c.send(true);
         error!("Sent!");

--- a/src/test/run-pass/unwind-resource2.rs
+++ b/src/test/run-pass/unwind-resource2.rs
@@ -18,7 +18,7 @@ struct complainer {
 
 #[unsafe_destructor]
 impl Drop for complainer {
-    fn drop(&self) {}
+    fn drop(&mut self) {}
 }
 
 fn complainer(c: @int) -> complainer {

--- a/src/test/run-pass/vec-slice-drop.rs
+++ b/src/test/run-pass/vec-slice-drop.rs
@@ -15,7 +15,7 @@ struct foo {
 
 #[unsafe_destructor]
 impl Drop for foo {
-    fn drop(&self) {
+    fn drop(&mut self) {
         *self.x += 1;
     }
 }


### PR DESCRIPTION
This doesn't close any bugs as the goal is to convert the parameter to by-value, but this is a step towards being able to make guarantees about `&T` pointers (where T is Freeze) to LLVM.
