### PR TITLE
Docs: You probably mean `continue`

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -2401,7 +2401,7 @@ If the label is present, then `loop foo` returns control to the head of the loop
 which need not be the innermost label enclosing the `break` expression,
 but must enclose it.
 
-A `loop` expression is only permitted in the body of a loop.
+A `continue` expression is only permitted in the body of a loop.
 
 
 ### Do expressions


### PR DESCRIPTION
Looks like in the context of this doc you should have `continue` instead of `loop`... Since it's current state is a bit irrational.
