### PR TITLE
Added support for a `\0` escape sequence

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -248,7 +248,7 @@ string_body : non_double_quote
             | '\x5c' [ '\x22' | common_escape ] ;
 
 common_escape : '\x5c'
-              | 'n' | 'r' | 't'
+              | 'n' | 'r' | 't' | '0'
               | 'x' hex_digit 2
               | 'u' hex_digit 4
               | 'U' hex_digit 8 ;

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -699,6 +699,7 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
               '\\' => { c2 = '\\'; }
               '\'' => { c2 = '\''; }
               '"' => { c2 = '"'; }
+              '0' => { c2 = '\x00'; }
               'x' => { c2 = scan_numeric_escape(rdr, 2u); }
               'u' => { c2 = scan_numeric_escape(rdr, 4u); }
               'U' => { c2 = scan_numeric_escape(rdr, 8u); }
@@ -738,6 +739,7 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
                   '\'' => accum_str.push_char('\''),
                   '"' => accum_str.push_char('"'),
                   '\n' => consume_whitespace(rdr),
+                  '0' => accum_str.push_char('\x00'),
                   'x' => {
                     accum_str.push_char(scan_numeric_escape(rdr, 2u));
                   }

--- a/src/test/run-pass/nul-characters.rs
+++ b/src/test/run-pass/nul-characters.rs
@@ -1,0 +1,44 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main()
+{
+    let all_nuls1 = "\0\x00\u0000\U00000000";
+    let all_nuls2 = "\U00000000\u0000\x00\0";
+    let all_nuls3 = "\u0000\U00000000\x00\0";
+    let all_nuls4 = "\x00\u0000\0\U00000000";
+
+    // sizes for two should suffice
+    assert_eq!(all_nuls1.len(), 4); 
+    assert_eq!(all_nuls2.len(), 4);
+
+    // string equality should pass between the strings
+    assert_eq!(all_nuls1, all_nuls2);
+    assert_eq!(all_nuls2, all_nuls3);
+    assert_eq!(all_nuls3, all_nuls4);
+    
+    // all extracted characters in all_nuls are equivalent to each other
+    for c1 in all_nuls1.iter()
+    {
+        for c2 in all_nuls1.iter()
+        {
+            assert_eq!(c1,c2);
+        }
+    }
+    
+    // testing equality between explicit character literals
+    assert_eq!('\0', '\x00');
+    assert_eq!('\u0000', '\x00');
+    assert_eq!('\u0000', '\U00000000');
+
+    // NUL characters should make a difference
+    assert!("Hello World" != "Hello \0World");
+    assert!("Hello World" != "Hello World\0");
+}


### PR DESCRIPTION
Since `\0` is equivalent to `\x00`, this is a direct translation to the latter escape sequence.
Future builds will be able to compile using `\0` directly.

This pull request is meant to address Issue #9143 .
