### PR TITLE
Prevent a rare linkage issue with an xcrate static

### DIFF
--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -21,6 +21,7 @@ use std::vec;
 use syntax::ast;
 use syntax::ast_map::path_name;
 use syntax::ast_util::local_def;
+use syntax::attr;
 
 pub fn maybe_instantiate_inline(ccx: @mut CrateContext, fn_id: ast::DefId)
     -> ast::DefId {
@@ -68,7 +69,12 @@ pub fn maybe_instantiate_inline(ccx: @mut CrateContext, fn_id: ast::DefId)
             match item.node {
                 ast::item_static(*) => {
                     let g = get_item_val(ccx, item.id);
-                    SetLinkage(g, AvailableExternallyLinkage);
+                    // see the comment in get_item_val() as to why this check is
+                    // performed here.
+                    if !attr::contains_name(item.attrs,
+                                            "address_insignificant") {
+                        SetLinkage(g, AvailableExternallyLinkage);
+                    }
                 }
                 _ => {}
             }

--- a/src/test/auxiliary/xcrate_address_insignificant.rs
+++ b/src/test/auxiliary/xcrate_address_insignificant.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn foo<T>() -> int {
+    #[address_insignificant]
+    static a: int = 3;
+    a
+}
+
+pub fn bar() -> int {
+    foo::<int>()
+}

--- a/src/test/run-pass/xcrate-address-insignificant.rs
+++ b/src/test/run-pass/xcrate-address-insignificant.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast windows doesn't like aux-build
+// aux-build:xcrate_address_insignificant.rs
+
+extern mod foo(name = "xcrate_address_insignificant");
+
+fn main() {
+    assert_eq!(foo::foo::<float>(), foo::bar());
+}


### PR DESCRIPTION
If a static is flagged as address_insignificant, then for LLVM to actually
perform the relevant optimization it must have an internal linkage type. What
this means, though, is that the static will not be available to other crates.
Hence, if you have a generic function with an inner static, it will fail to link
when built as a library because other crates will attempt to use the inner
static externally.

This gets around the issue by inlining the static into the metadata. The same
relevant optimization is then applied separately in the external crate. What
this ends up meaning is that all statics tagged with #[address_insignificant]
will appear at most once per crate (by value), but they could appear in multiple
crates.

This should be the last blocker for using format! ...
