### PR TITLE
pretty-print bounds in paths with no generic params

### DIFF
--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -243,7 +243,7 @@ pub fn mk_printer(out: @io::Writer, linewidth: uint) -> @mut Printer {
  * the entire buffered window, but can't output anything until the size is >=
  * 0 (sizes are set to negative while they're pending calculation).
  *
- * So SCAN takeks input and buffers tokens and pending calculations, while
+ * So SCAN takes input and buffers tokens and pending calculations, while
  * PRINT gobbles up completed calculations and tokens from the buffer. The
  * theory is that the two can never get more than 3N tokens apart, because
  * once there's "obviously" too much data to fit on a line, in a size

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1535,15 +1535,15 @@ fn print_path_(s: @ps,
 
         print_ident(s, segment.identifier);
 
-        if segment.lifetime.is_some() || !segment.types.is_empty() {
-            // If this is the last segment, print the bounds.
-            if i == path.segments.len() - 1 {
-                match *opt_bounds {
-                    None => {}
-                    Some(ref bounds) => print_bounds(s, bounds, true),
-                }
+        // If this is the last segment, print the bounds.
+        if i == path.segments.len() - 1 {
+            match *opt_bounds {
+                None => {}
+                Some(ref bounds) => print_bounds(s, bounds, true),
             }
+        }
 
+        if segment.lifetime.is_some() || !segment.types.is_empty() {
             if colons_before_params {
                 word(s.s, "::")
             }

--- a/src/test/pretty/path-type-bounds.rs
+++ b/src/test/pretty/path-type-bounds.rs
@@ -1,0 +1,13 @@
+// pp-exact
+
+trait Tr { }
+impl Tr for int;
+
+fn foo(x: ~Tr: Freeze) -> ~Tr: Freeze { x }
+
+fn main() {
+    let x: ~Tr: Freeze;
+
+    ~1 as ~Tr: Freeze;
+}
+

--- a/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
+++ b/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-pretty #9253 pretty printer doesn't preserve the bounds on trait objects
-
 /*
 
 #7673 Polymorphically creating traits barely works


### PR DESCRIPTION
Since 3b6314c the pretty printer seems to only print trait bounds for `ast::ty_path(...)`s that have a generics arguments list. That seems wrong, so let's always print them.

Closes #9253, un-xfails test for #7673.
