### PR TITLE
Add an extra line before the "Additional Help" in rustc's --help output

### DIFF
--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -134,7 +134,7 @@ pub fn version(argv0: &str) {
 
 pub fn usage(argv0: &str) {
     let message = fmt!("Usage: %s [OPTIONS] INPUT", argv0);
-    printfln!("%s\
+    printfln!("%s\n\
 Additional help:
     -W help             Print 'lint' options and default settings
     -Z help             Print internal options for debugging rustc\n",


### PR DESCRIPTION
Look like this now

```
    -Z FLAG             Set internal debugging options
    -v --version        Print version info and exit

Additional help:
    -W help             Print 'lint' options and default settings
    -Z help             Print internal options for debugging rustc

```
