### PR TITLE
Remove unused Option.or_{default,zero} and a minor cleanup

### DIFF
--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -467,15 +467,6 @@ impl<T: Default> Option<T> {
             None => Default::default()
         }
     }
-
-    /// Returns self or `Some`-wrapped default value
-    #[inline]
-    pub fn or_default(self) -> Option<T> {
-        match self {
-            None => Some(Default::default()),
-            x => x,
-        }
-    }
 }
 
 impl<T> Default for Option<T> {
@@ -483,22 +474,13 @@ impl<T> Default for Option<T> {
     fn default() -> Option<T> { None }
 }
 
-impl<T:Zero> Option<T> {
+impl<T: Zero> Option<T> {
     /// Returns the contained value or zero (for this type)
     #[inline]
     pub fn unwrap_or_zero(self) -> T {
         match self {
             Some(x) => x,
             None => Zero::zero()
-        }
-    }
-
-    /// Returns self or `Some`-wrapped zero value
-    #[inline]
-    pub fn or_zero(self) -> Option<T> {
-        match self {
-            None => Some(Zero::zero()),
-            x => x
         }
     }
 }

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -47,9 +47,7 @@ fn default_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Exp
         cx.ident_of("Default"),
         cx.ident_of("default")
     ];
-    let default_call = || {
-        cx.expr_call_global(span, default_ident.clone(), ~[])
-    };
+    let default_call = cx.expr_call_global(span, default_ident.clone(), ~[]);
 
     return match *substr.fields {
         StaticStruct(_, ref summary) => {
@@ -58,13 +56,13 @@ fn default_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Exp
                     if count == 0 {
                         cx.expr_ident(span, substr.type_ident)
                     } else {
-                        let exprs = vec::from_fn(count, |_| default_call());
+                        let exprs = vec::from_elem(count, default_call);
                         cx.expr_call_ident(span, substr.type_ident, exprs)
                     }
                 }
                 Right(ref fields) => {
                     let default_fields = do fields.map |ident| {
-                        cx.field_imm(span, *ident, default_call())
+                        cx.field_imm(span, *ident, default_call)
                     };
                     cx.expr_struct_ident(span, substr.type_ident, default_fields)
                 }

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -62,9 +62,7 @@ fn zero_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
         cx.ident_of("Zero"),
         cx.ident_of("zero")
     ];
-    let zero_call = || {
-        cx.expr_call_global(span, zero_ident.clone(), ~[])
-    };
+    let zero_call = cx.expr_call_global(span, zero_ident.clone(), ~[]);
 
     return match *substr.fields {
         StaticStruct(_, ref summary) => {
@@ -73,13 +71,13 @@ fn zero_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
                     if count == 0 {
                         cx.expr_ident(span, substr.type_ident)
                     } else {
-                        let exprs = vec::from_fn(count, |_| zero_call());
+                        let exprs = vec::from_elem(count, zero_call);
                         cx.expr_call_ident(span, substr.type_ident, exprs)
                     }
                 }
                 Right(ref fields) => {
                     let zero_fields = do fields.map |ident| {
-                        cx.field_imm(span, *ident, zero_call())
+                        cx.field_imm(span, *ident, zero_call)
                     };
                     cx.expr_struct_ident(span, substr.type_ident, zero_fields)
                 }


### PR DESCRIPTION
`Some(5).or_{default,zero}` can be easily replaced with `Some(Some(5).unwrap_or_default())`.
