### PR TITLE
Allow trailing commas in format!

### DIFF
--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -76,6 +76,7 @@ impl Context {
                 self.ecx.span_err(sp, "expected token: `,`");
                 return (extra, None);
             }
+            if *p.token == token::EOF { break } // accept trailing commas
             if named || (token::is_ident(p.token) &&
                          p.look_ahead(1, |t| *t == token::EQ)) {
                 named = true;

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -243,6 +243,10 @@ pub fn main() {
     }
 
     test_format_args();
+
+    // test that trailing commas are acceptable
+    format!("{}", "test",);
+    format!("{foo}", foo="test",);
 }
 
 // Basic test to make sure that we can invoke the `write!` macro with an


### PR DESCRIPTION
This is more consistent with other parts of the language and it also makes it
easier to use in situations where format string is massive.
