### PR TITLE
Allow for integral suffixes after a char literal

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -146,7 +146,7 @@ syn match     rustMacro       '#\w\(\w\)*' contains=rustAssert,rustFail
 
 syn match     rustFormat      display "%\(\d\+\$\)\=[-+' #0*]*\(\d*\|\*\|\*\d\+\$\)\(\.\(\d*\|\*\|\*\d\+\$\)\)\=\([hlLjzt]\|ll\|hh\)\=\([aAbdiuoxXDOUfFeEgGcCsSpn?]\|\[\^\=.[^]]*\]\)" contained
 syn match     rustFormat      display "%%" contained
-syn match     rustSpecial     display contained /\\\([nrt\\'"]\|x\x\{2}\|u\x\{4}\|U\x\{8}\)/
+syn match     rustSpecial     display contained /\\\([nrt\\'"0]\|x\x\{2}\|u\x\{4}\|U\x\{8}\)/
 syn match     rustStringContinuation display contained /\\\n\s*/
 syn region    rustString      start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=rustTodo,rustFormat,rustSpecial,rustStringContinuation
 
@@ -180,7 +180,7 @@ syn region rustGenericLifetimeCandidate display start=/\%(<\|,\s*\)\@<='/ end=/[
 
 "rustLifetime must appear before rustCharacter, or chars will get the lifetime highlighting
 syn match     rustLifetime    display "\'\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"
-syn match   rustCharacter   /'\([^'\\]\|\\\([nrt\\'"]\|x\x\{2}\|u\x\{4}\|U\x\{8}\)\)'/ contains=rustSpecial
+syn match   rustCharacter   /'\([^'\\]\|\\\([nrt\\'"0]\|x\x\{2}\|u\x\{4}\|U\x\{8}\)\)'\(u8\|u16\|u32\|u64\|u\|i8\|i16\|i32\|i64\|i\)\?/ contains=rustSpecial
 
 syn region    rustCommentML   start="/\*" end="\*/" contains=rustTodo
 syn region    rustComment     start="//" end="$" contains=rustTodo keepend

--- a/src/test/run-pass/char-literal-suffixes.rs
+++ b/src/test/run-pass/char-literal-suffixes.rs
@@ -1,0 +1,32 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a: int = 'a'i;
+    assert_eq!(a, 97i);
+    let a: i8 = 'a'i8;
+    assert_eq!(a, 97i8);
+    let a: i16 = 'a'i16;
+    assert_eq!(a, 97i16);
+    let a: i32 = 'a'i32;
+    assert_eq!(a, 97i32);
+    let a: i64 = 'a'i64;
+    assert_eq!(a, 97i64);
+    let a: uint = 'a'u;
+    assert_eq!(a, 97u);
+    let a: u8 = 'a'u8;
+    assert_eq!(a, 97u8);
+    let a: u16 = 'a'u16;
+    assert_eq!(a, 97u16);
+    let a: u32 = 'a'u32;
+    assert_eq!(a, 97u32);
+    let a: u64 = 'a'u64;
+    assert_eq!(a, 97u64);
+}


### PR DESCRIPTION
This way you can say 'a'u8 instead of ('a' as u8).
