### PR TITLE
Replace unreachable() calls with unreachable!().

### DIFF
--- a/src/libextra/glob.rs
+++ b/src/libextra/glob.rs
@@ -23,7 +23,7 @@
  * `glob`/`fnmatch` functions.
  */
 
-use std::{os, path, util};
+use std::{os, path};
 
 use sort;
 
@@ -356,7 +356,7 @@ impl Pattern {
                             chars_eq(c, c2, options.case_sensitive)
                         }
                         AnySequence => {
-                            util::unreachable()
+                            unreachable!()
                         }
                     };
                     if !matches {

--- a/src/libextra/terminfo/parm.rs
+++ b/src/libextra/terminfo/parm.rs
@@ -261,7 +261,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                                 flags.width = (cur as uint - '0' as uint);
                                 fstate = FormatStateWidth;
                             }
-                            _ => util::unreachable()
+                            _ => unreachable!()
                         }
                         state = FormatPattern(flags, fstate);
                     }
@@ -487,7 +487,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<~[u8],~str> {
                         FormatDigit => 10,
                         FormatOctal => 8,
                         FormatHex|FormatHEX => 16,
-                        FormatString => util::unreachable()
+                        FormatString => unreachable!()
                     };
                     let mut s = ~[];
                     match op {
@@ -535,7 +535,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<~[u8],~str> {
                                 s.push_all_move(s_);
                             }
                         }
-                        FormatString => util::unreachable()
+                        FormatString => unreachable!()
                     }
                     s
                 }

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -14,7 +14,7 @@ use metadata::cstore;
 use metadata::filesearch;
 
 use std::hashmap::HashSet;
-use std::{os, util, vec};
+use std::{os, vec};
 
 fn not_win32(os: session::Os) -> bool {
   os != session::OsWin32
@@ -116,7 +116,7 @@ pub fn get_rpath_relative_to_output(os: session::Os,
         session::OsAndroid | session::OsLinux | session::OsFreebsd
                           => "$ORIGIN",
         session::OsMacos => "@executable_path",
-        session::OsWin32 => util::unreachable()
+        session::OsWin32 => unreachable!()
     };
 
     Path(prefix).push_rel(&os::make_absolute(output).get_relative_to(&os::make_absolute(lib)))

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -18,7 +18,6 @@ use syntax::codemap::Span;
 use syntax::parse::token::special_idents;
 use syntax::visit;
 use syntax::visit::Visitor;
-use std::util;
 
 struct EntryContext {
     session: Session,
@@ -94,7 +93,7 @@ fn find_item(item: @item, ctxt: &mut EntryContext) {
                             ctxt.non_main_fns.push((item.id, item.span));
                         }
                     }
-                    _ => util::unreachable()
+                    _ => unreachable!()
                 }
             }
 

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -356,7 +356,7 @@ fn variant_opt(bcx: @mut Block, pat_id: ast::NodeId)
                                adt::represent_node(bcx, pat_id))
                 }
             }
-            ::std::util::unreachable();
+            unreachable!();
         }
         ast::DefFn(*) |
         ast::DefStruct(_) => {

--- a/src/librustdoc/prune_private_pass.rs
+++ b/src/librustdoc/prune_private_pass.rs
@@ -20,8 +20,6 @@ use fold::Fold;
 use fold;
 use pass::Pass;
 
-use std::util;
-
 pub fn mk_pass() -> Pass {
     Pass {
         name: ~"prune_private",
@@ -148,7 +146,7 @@ fn is_visible(srv: astsrv::Srv, doc: doc::ItemDoc) -> bool {
                     }
                 }
             }
-            _ => util::unreachable()
+            _ => unreachable!()
         }
     }
 }

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -27,7 +27,7 @@ use option::{None, Option, Some};
 use rand::RngUtil;
 use rand;
 use uint;
-use util::{replace, unreachable};
+use util::replace;
 use vec::{ImmutableVector, MutableVector, OwnedVector};
 use vec;
 
@@ -187,7 +187,7 @@ impl<K:Hash + Eq,V> HashMap<K, V> {
     fn mut_value_for_bucket<'a>(&'a mut self, idx: uint) -> &'a mut V {
         match self.buckets[idx] {
             Some(ref mut bkt) => &mut bkt.value,
-            None => unreachable()
+            None => unreachable!()
         }
     }
 

--- a/src/libstd/rand.rs
+++ b/src/libstd/rand.rs
@@ -56,7 +56,6 @@ use str;
 use sys;
 use u32;
 use uint;
-use util;
 use vec;
 use libc::size_t;
 
@@ -586,7 +585,7 @@ impl<R: Rng> RngUtil for R {
                 return Some(item.item.clone());
             }
         }
-        util::unreachable();
+        unreachable!();
     }
 
     /**

--- a/src/libstd/rt/io/extensions.rs
+++ b/src/libstd/rt/io/extensions.rs
@@ -21,7 +21,6 @@ use rt::io::{Reader, Writer, Decorator};
 use rt::io::{read_error, standard_error, EndOfFile, DEFAULT_BUF_SIZE};
 use option::{Option, Some, None};
 use unstable::finally::Finally;
-use util;
 use cast;
 use io::{u64_to_le_bytes, u64_to_be_bytes};
 
@@ -293,7 +292,7 @@ impl<T: Reader> ReaderUtil for T {
                 self.read_byte()
             }
             Some(1) => Some(buf[0]),
-            Some(_) => util::unreachable(),
+            Some(_) => unreachable!(),
             None => None
         }
     }

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -104,34 +104,6 @@ impl Void {
 }
 
 
-/**
-A utility function for indicating unreachable code. It will fail if
-executed. This is occasionally useful to put after loops that never
-terminate normally, but instead directly return from a function.
-
-# Example
-
-~~~ {.rust}
-fn choose_weighted_item(v: &[Item]) -> Item {
-    assert!(!v.is_empty());
-    let mut so_far = 0u;
-    for v.each |item| {
-        so_far += item.weight;
-        if so_far > 100 {
-            return item;
-        }
-    }
-    // The above loop always returns, so we must hint to the
-    // type checker that it isn't possible to get down here
-    util::unreachable();
-}
-~~~
-
-*/
-pub fn unreachable() -> ! {
-    fail!("internal error: entered unreachable code");
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/test/compile-fail/borrowck-move-out-of-vec-tail.rs
+++ b/src/test/compile-fail/borrowck-move-out-of-vec-tail.rs
@@ -19,14 +19,14 @@ pub fn main() {
                     //~^^ ERROR cannot move out of dereference of & pointer
                 }
                 _ => {
-                    ::std::util::unreachable();
+                    unreachable!();
                 }
             }
             let z = tail[0].clone();
             info!(fmt!("%?", z));
         }
         _ => {
-            ::std::util::unreachable();
+            unreachable!();
         }
     }
 }

--- a/src/test/compile-fail/borrowck-vec-pattern-move-tail.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-move-tail.rs
@@ -2,7 +2,7 @@ fn main() {
     let mut a = [1, 2, 3, 4];
     let t = match a {
         [1, 2, ..tail] => tail,
-        _ => std::util::unreachable()
+        _ => unreachable!()
     };
     a[0] = 0; //~ ERROR cannot assign to `a[]` because it is borrowed
     t[0];

--- a/src/test/debug-info/lexical-scope-in-if.rs
+++ b/src/test/debug-info/lexical-scope-in-if.rs
@@ -78,8 +78,6 @@
 // check:$16 = -1
 // debugger:continue
 
-use std::util;
-
 fn main() {
 
     let x = 999;
@@ -102,14 +100,14 @@ fn main() {
         zzz();
         sentinel();
     } else {
-        util::unreachable();
+        unreachable!();
     }
 
     zzz();
     sentinel();
 
     if x > 1000 {
-        util::unreachable();
+        unreachable!();
     } else {
         zzz();
         sentinel();

--- a/src/test/run-pass/vec-matching-fixed.rs
+++ b/src/test/run-pass/vec-matching-fixed.rs
@@ -1,12 +1,12 @@
 fn a() {
     let x = [1, 2, 3];
     match x {
-        [1, 2, 4] => ::std::util::unreachable(),
-        [0, 2, 3, .._] => ::std::util::unreachable(),
-        [0, .._, 3] => ::std::util::unreachable(),
-        [0, .._] => ::std::util::unreachable(),
+        [1, 2, 4] => unreachable!(),
+        [0, 2, 3, .._] => unreachable!(),
+        [0, .._, 3] => unreachable!(),
+        [0, .._] => unreachable!(),
         [1, 2, 3] => (),
-        [_, _, _] => ::std::util::unreachable(),
+        [_, _, _] => unreachable!(),
     }
     match x {
         [.._] => (),

--- a/src/test/run-pass/vec-matching-legal-tail-element-borrow.rs
+++ b/src/test/run-pass/vec-matching-legal-tail-element-borrow.rs
@@ -3,7 +3,7 @@ pub fn main() {
     if !x.is_empty() {
         let el = match x {
             [1, ..ref tail] => &tail[0],
-            _ => ::std::util::unreachable()
+            _ => unreachable!()
         };
         printfln!("%d", *el);
     }

--- a/src/test/run-pass/vec-tail-matching.rs
+++ b/src/test/run-pass/vec-tail-matching.rs
@@ -17,19 +17,19 @@ pub fn main() {
 
             match tail {
                 [Foo { _ }, _, Foo { _ }, .. _tail] => {
-                    ::std::util::unreachable();
+                    unreachable!();
                 }
                 [Foo { string: ref a }, Foo { string: ref b }] => {
                     assert_eq!("bar", a.slice(0, a.len()));
                     assert_eq!("baz", b.slice(0, b.len()));
                 }
                 _ => {
-                    ::std::util::unreachable();
+                    unreachable!();
                 }
             }
         }
         _ => {
-            ::std::util::unreachable();
+            unreachable!();
         }
     }
 }


### PR DESCRIPTION
This is the second of two parts of #8991, now possible as a new snapshot
has been made. (The first part implemented the unreachable!() macro; it
was #8992, 6b7b8f2682.)

`std::util::unreachable()` is removed summarily; any code which used
it should now use the `unreachable!()` macro.

Closes #9312.

Closes #8991.
