### PR TITLE
Rename the NaN and is_NaN methods to lowercase.

### DIFF
--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -126,7 +126,7 @@ pub fn check_arms(cx: &MatchCheckCtxt, arms: &[Arm]) {
                     Some(&DefStatic(did, false)) => {
                         let const_expr = lookup_const_by_id(cx.tcx, did).unwrap();
                         match eval_const_expr(cx.tcx, const_expr) {
-                            const_float(f) if f.is_NaN() => true,
+                            const_float(f) if f.is_nan() => true,
                             _ => false
                         }
                     }
@@ -136,7 +136,7 @@ pub fn check_arms(cx: &MatchCheckCtxt, arms: &[Arm]) {
             do walk_pat(*pat) |p| {
                 if pat_matches_nan(p) {
                     cx.tcx.sess.span_warn(p.span, "unmatchable NaN in pattern, \
-                                                   use the is_NaN method in a guard instead");
+                                                   use the is_nan method in a guard instead");
                 }
                 true
             };

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -207,8 +207,8 @@ impl Orderable for f32 {
     #[inline]
     fn min(&self, other: &f32) -> f32 {
         match () {
-            _ if self.is_NaN()  => *self,
-            _ if other.is_NaN() => *other,
+            _ if self.is_nan()  => *self,
+            _ if other.is_nan() => *other,
             _ if *self < *other => *self,
             _                   => *other,
         }
@@ -218,8 +218,8 @@ impl Orderable for f32 {
     #[inline]
     fn max(&self, other: &f32) -> f32 {
         match () {
-            _ if self.is_NaN()  => *self,
-            _ if other.is_NaN() => *other,
+            _ if self.is_nan()  => *self,
+            _ if other.is_nan() => *other,
             _ if *self > *other => *self,
             _                   => *other,
         }
@@ -230,7 +230,7 @@ impl Orderable for f32 {
     #[inline]
     fn clamp(&self, mn: &f32, mx: &f32) -> f32 {
         match () {
-            _ if self.is_NaN()   => *self,
+            _ if self.is_nan()   => *self,
             _ if !(*self <= *mx) => *mx,
             _ if !(*self >= *mn) => *mn,
             _                    => *self,
@@ -314,7 +314,7 @@ impl Signed for f32 {
     ///
     #[inline]
     fn signum(&self) -> f32 {
-        if self.is_NaN() { NaN } else { copysign(1.0, *self) }
+        if self.is_nan() { NaN } else { copysign(1.0, *self) }
     }
 
     /// Returns `true` if the number is positive, including `+0.0` and `infinity`
@@ -471,7 +471,7 @@ impl Hyperbolic for f32 {
     #[inline]
     fn acosh(&self) -> f32 {
         match *self {
-            x if x < 1.0 => Float::NaN(),
+            x if x < 1.0 => Float::nan(),
             x => (x + ((x * x) - 1.0).sqrt()).ln(),
         }
     }
@@ -593,7 +593,7 @@ impl Primitive for f32 {
 
 impl Float for f32 {
     #[inline]
-    fn NaN() -> f32 { 0.0 / 0.0 }
+    fn nan() -> f32 { 0.0 / 0.0 }
 
     #[inline]
     fn infinity() -> f32 { 1.0 / 0.0 }
@@ -606,7 +606,7 @@ impl Float for f32 {
 
     /// Returns `true` if the number is NaN
     #[inline]
-    fn is_NaN(&self) -> bool { *self != *self }
+    fn is_nan(&self) -> bool { *self != *self }
 
     /// Returns `true` if the number is infinite
     #[inline]
@@ -617,7 +617,7 @@ impl Float for f32 {
     /// Returns `true` if the number is neither infinite or NaN
     #[inline]
     fn is_finite(&self) -> bool {
-        !(self.is_NaN() || self.is_infinite())
+        !(self.is_nan() || self.is_infinite())
     }
 
     /// Returns `true` if the number is neither zero, infinite, subnormal or NaN
@@ -949,10 +949,10 @@ mod tests {
         assert_eq!(8f32.clamp(&2f32, &4f32), 4f32);
         assert_eq!(3f32.clamp(&2f32, &4f32), 3f32);
 
-        let nan: f32 = Float::NaN();
-        assert!(3f32.clamp(&nan, &4f32).is_NaN());
-        assert!(3f32.clamp(&2f32, &nan).is_NaN());
-        assert!(nan.clamp(&2f32, &4f32).is_NaN());
+        let nan: f32 = Float::nan();
+        assert!(3f32.clamp(&nan, &4f32).is_nan());
+        assert!(3f32.clamp(&2f32, &nan).is_nan());
+        assert!(nan.clamp(&2f32, &4f32).is_nan());
     }
 
     #[test]
@@ -1032,10 +1032,10 @@ mod tests {
 
         let inf: f32 = Float::infinity();
         let neg_inf: f32 = Float::neg_infinity();
-        let nan: f32 = Float::NaN();
+        let nan: f32 = Float::nan();
         assert_eq!(inf.asinh(), inf);
         assert_eq!(neg_inf.asinh(), neg_inf);
-        assert!(nan.asinh().is_NaN());
+        assert!(nan.asinh().is_nan());
         assert_approx_eq!(2.0f32.asinh(), 1.443635475178810342493276740273105f32);
         assert_approx_eq!((-2.0f32).asinh(), -1.443635475178810342493276740273105f32);
     }
@@ -1043,14 +1043,14 @@ mod tests {
     #[test]
     fn test_acosh() {
         assert_eq!(1.0f32.acosh(), 0.0f32);
-        assert!(0.999f32.acosh().is_NaN());
+        assert!(0.999f32.acosh().is_nan());
 
         let inf: f32 = Float::infinity();
         let neg_inf: f32 = Float::neg_infinity();
-        let nan: f32 = Float::NaN();
+        let nan: f32 = Float::nan();
         assert_eq!(inf.acosh(), inf);
-        assert!(neg_inf.acosh().is_NaN());
-        assert!(nan.acosh().is_NaN());
+        assert!(neg_inf.acosh().is_nan());
+        assert!(nan.acosh().is_nan());
         assert_approx_eq!(2.0f32.acosh(), 1.31695789692481670862504634730796844f32);
         assert_approx_eq!(3.0f32.acosh(), 1.76274717403908605046521864995958461f32);
     }
@@ -1065,15 +1065,15 @@ mod tests {
         assert_eq!(1.0f32.atanh(), inf32);
         assert_eq!((-1.0f32).atanh(), neg_inf32);
 
-        assert!(2f64.atanh().atanh().is_NaN());
-        assert!((-2f64).atanh().atanh().is_NaN());
+        assert!(2f64.atanh().atanh().is_nan());
+        assert!((-2f64).atanh().atanh().is_nan());
 
         let inf64: f32 = Float::infinity();
         let neg_inf64: f32 = Float::neg_infinity();
-        let nan32: f32 = Float::NaN();
-        assert!(inf64.atanh().is_NaN());
-        assert!(neg_inf64.atanh().is_NaN());
-        assert!(nan32.atanh().is_NaN());
+        let nan32: f32 = Float::nan();
+        assert!(inf64.atanh().is_nan());
+        assert!(neg_inf64.atanh().is_nan());
+        assert!(nan32.atanh().is_nan());
 
         assert_approx_eq!(0.5f32.atanh(), 0.54930614433405484569762261846126285f32);
         assert_approx_eq!((-0.5f32).atanh(), -0.54930614433405484569762261846126285f32);
@@ -1125,7 +1125,7 @@ mod tests {
         assert_eq!((-1f32).abs(), 1f32);
         assert_eq!(neg_infinity.abs(), infinity);
         assert_eq!((1f32/neg_infinity).abs(), 0f32);
-        assert!(NaN.abs().is_NaN());
+        assert!(NaN.abs().is_nan());
     }
 
     #[test]
@@ -1142,8 +1142,8 @@ mod tests {
 
     #[test] #[ignore(cfg(windows))] // FIXME #8663
     fn test_abs_sub_nowin() {
-        assert!(NaN.abs_sub(&-1f32).is_NaN());
-        assert!(1f32.abs_sub(&NaN).is_NaN());
+        assert!(NaN.abs_sub(&-1f32).is_nan());
+        assert!(1f32.abs_sub(&NaN).is_nan());
     }
 
     #[test]
@@ -1155,7 +1155,7 @@ mod tests {
         assert_eq!((-1f32).signum(), -1f32);
         assert_eq!(neg_infinity.signum(), -1f32);
         assert_eq!((1f32/neg_infinity).signum(), -1f32);
-        assert!(NaN.signum().is_NaN());
+        assert!(NaN.signum().is_nan());
     }
 
     #[test]
@@ -1200,7 +1200,7 @@ mod tests {
 
     #[test]
     fn test_is_normal() {
-        let nan: f32 = Float::NaN();
+        let nan: f32 = Float::nan();
         let inf: f32 = Float::infinity();
         let neg_inf: f32 = Float::neg_infinity();
         let zero: f32 = Zero::zero();
@@ -1217,7 +1217,7 @@ mod tests {
 
     #[test]
     fn test_classify() {
-        let nan: f32 = Float::NaN();
+        let nan: f32 = Float::nan();
         let inf: f32 = Float::infinity();
         let neg_inf: f32 = Float::neg_infinity();
         let zero: f32 = Zero::zero();
@@ -1246,10 +1246,10 @@ mod tests {
 
         let inf: f32 = Float::infinity();
         let neg_inf: f32 = Float::neg_infinity();
-        let nan: f32 = Float::NaN();
+        let nan: f32 = Float::nan();
         assert_eq!(Float::ldexp(inf, -123), inf);
         assert_eq!(Float::ldexp(neg_inf, -123), neg_inf);
-        assert!(Float::ldexp(nan, -123).is_NaN());
+        assert!(Float::ldexp(nan, -123).is_nan());
     }
 
     #[test]
@@ -1273,9 +1273,9 @@ mod tests {
     fn test_frexp_nowin() {
         let inf: f32 = Float::infinity();
         let neg_inf: f32 = Float::neg_infinity();
-        let nan: f32 = Float::NaN();
+        let nan: f32 = Float::nan();
         assert_eq!(match inf.frexp() { (x, _) => x }, inf)
         assert_eq!(match neg_inf.frexp() { (x, _) => x }, neg_inf)
-        assert!(match nan.frexp() { (x, _) => x.is_NaN() })
+        assert!(match nan.frexp() { (x, _) => x.is_nan() })
     }
 }

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -230,8 +230,8 @@ impl Orderable for f64 {
     #[inline]
     fn min(&self, other: &f64) -> f64 {
         match () {
-            _ if self.is_NaN()  => *self,
-            _ if other.is_NaN() => *other,
+            _ if self.is_nan()  => *self,
+            _ if other.is_nan() => *other,
             _ if *self < *other => *self,
             _                   => *other,
         }
@@ -241,8 +241,8 @@ impl Orderable for f64 {
     #[inline]
     fn max(&self, other: &f64) -> f64 {
         match () {
-            _ if self.is_NaN()  => *self,
-            _ if other.is_NaN() => *other,
+            _ if self.is_nan()  => *self,
+            _ if other.is_nan() => *other,
             _ if *self > *other => *self,
             _                   => *other,
         }
@@ -253,7 +253,7 @@ impl Orderable for f64 {
     #[inline]
     fn clamp(&self, mn: &f64, mx: &f64) -> f64 {
         match () {
-            _ if self.is_NaN()   => *self,
+            _ if self.is_nan()   => *self,
             _ if !(*self <= *mx) => *mx,
             _ if !(*self >= *mn) => *mn,
             _                    => *self,
@@ -331,7 +331,7 @@ impl Signed for f64 {
     ///
     #[inline]
     fn signum(&self) -> f64 {
-        if self.is_NaN() { NaN } else { copysign(1.0, *self) }
+        if self.is_nan() { NaN } else { copysign(1.0, *self) }
     }
 
     /// Returns `true` if the number is positive, including `+0.0` and `infinity`
@@ -488,7 +488,7 @@ impl Hyperbolic for f64 {
     #[inline]
     fn acosh(&self) -> f64 {
         match *self {
-            x if x < 1.0 => Float::NaN(),
+            x if x < 1.0 => Float::nan(),
             x => (x + ((x * x) - 1.0).sqrt()).ln(),
         }
     }
@@ -640,7 +640,7 @@ impl Primitive for f64 {
 
 impl Float for f64 {
     #[inline]
-    fn NaN() -> f64 { 0.0 / 0.0 }
+    fn nan() -> f64 { 0.0 / 0.0 }
 
     #[inline]
     fn infinity() -> f64 { 1.0 / 0.0 }
@@ -653,7 +653,7 @@ impl Float for f64 {
 
     /// Returns `true` if the number is NaN
     #[inline]
-    fn is_NaN(&self) -> bool { *self != *self }
+    fn is_nan(&self) -> bool { *self != *self }
 
     /// Returns `true` if the number is infinite
     #[inline]
@@ -664,7 +664,7 @@ impl Float for f64 {
     /// Returns `true` if the number is neither infinite or NaN
     #[inline]
     fn is_finite(&self) -> bool {
-        !(self.is_NaN() || self.is_infinite())
+        !(self.is_nan() || self.is_infinite())
     }
 
     /// Returns `true` if the number is neither zero, infinite, subnormal or NaN
@@ -983,9 +983,9 @@ mod tests {
         assert_eq!(1f64.min(&2f64), 1f64);
         assert_eq!(2f64.min(&1f64), 1f64);
 
-        let nan: f64 = Float::NaN();
-        assert!(1f64.min(&nan).is_NaN());
-        assert!(nan.min(&1f64).is_NaN());
+        let nan: f64 = Float::nan();
+        assert!(1f64.min(&nan).is_nan());
+        assert!(nan.min(&1f64).is_nan());
     }
 
     #[test]
@@ -993,9 +993,9 @@ mod tests {
         assert_eq!(1f64.max(&2f64), 2f64);
         assert_eq!(2f64.max(&1f64), 2f64);
 
-        let nan: f64 = Float::NaN();
-        assert!(1f64.max(&nan).is_NaN());
-        assert!(nan.max(&1f64).is_NaN());
+        let nan: f64 = Float::nan();
+        assert!(1f64.max(&nan).is_nan());
+        assert!(nan.max(&1f64).is_nan());
     }
 
     #[test]
@@ -1004,10 +1004,10 @@ mod tests {
         assert_eq!(8f64.clamp(&2f64, &4f64), 4f64);
         assert_eq!(3f64.clamp(&2f64, &4f64), 3f64);
 
-        let nan: f64 = Float::NaN();
-        assert!(3f64.clamp(&nan, &4f64).is_NaN());
-        assert!(3f64.clamp(&2f64, &nan).is_NaN());
-        assert!(nan.clamp(&2f64, &4f64).is_NaN());
+        let nan: f64 = Float::nan();
+        assert!(3f64.clamp(&nan, &4f64).is_nan());
+        assert!(3f64.clamp(&2f64, &nan).is_nan());
+        assert!(nan.clamp(&2f64, &4f64).is_nan());
     }
 
     #[test]
@@ -1087,10 +1087,10 @@ mod tests {
 
         let inf: f64 = Float::infinity();
         let neg_inf: f64 = Float::neg_infinity();
-        let nan: f64 = Float::NaN();
+        let nan: f64 = Float::nan();
         assert_eq!(inf.asinh(), inf);
         assert_eq!(neg_inf.asinh(), neg_inf);
-        assert!(nan.asinh().is_NaN());
+        assert!(nan.asinh().is_nan());
         assert_approx_eq!(2.0f64.asinh(), 1.443635475178810342493276740273105f64);
         assert_approx_eq!((-2.0f64).asinh(), -1.443635475178810342493276740273105f64);
     }
@@ -1098,14 +1098,14 @@ mod tests {
     #[test]
     fn test_acosh() {
         assert_eq!(1.0f64.acosh(), 0.0f64);
-        assert!(0.999f64.acosh().is_NaN());
+        assert!(0.999f64.acosh().is_nan());
 
         let inf: f64 = Float::infinity();
         let neg_inf: f64 = Float::neg_infinity();
-        let nan: f64 = Float::NaN();
+        let nan: f64 = Float::nan();
         assert_eq!(inf.acosh(), inf);
-        assert!(neg_inf.acosh().is_NaN());
-        assert!(nan.acosh().is_NaN());
+        assert!(neg_inf.acosh().is_nan());
+        assert!(nan.acosh().is_nan());
         assert_approx_eq!(2.0f64.acosh(), 1.31695789692481670862504634730796844f64);
         assert_approx_eq!(3.0f64.acosh(), 1.76274717403908605046521864995958461f64);
     }
@@ -1117,14 +1117,14 @@ mod tests {
 
         let inf: f64 = Float::infinity();
         let neg_inf: f64 = Float::neg_infinity();
-        let nan: f64 = Float::NaN();
+        let nan: f64 = Float::nan();
         assert_eq!(1.0f64.atanh(), inf);
         assert_eq!((-1.0f64).atanh(), neg_inf);
-        assert!(2f64.atanh().atanh().is_NaN());
-        assert!((-2f64).atanh().atanh().is_NaN());
-        assert!(inf.atanh().is_NaN());
-        assert!(neg_inf.atanh().is_NaN());
-        assert!(nan.atanh().is_NaN());
+        assert!(2f64.atanh().atanh().is_nan());
+        assert!((-2f64).atanh().atanh().is_nan());
+        assert!(inf.atanh().is_nan());
+        assert!(neg_inf.atanh().is_nan());
+        assert!(nan.atanh().is_nan());
         assert_approx_eq!(0.5f64.atanh(), 0.54930614433405484569762261846126285f64);
         assert_approx_eq!((-0.5f64).atanh(), -0.54930614433405484569762261846126285f64);
     }
@@ -1175,7 +1175,7 @@ mod tests {
         assert_eq!((-1f64).abs(), 1f64);
         assert_eq!(neg_infinity.abs(), infinity);
         assert_eq!((1f64/neg_infinity).abs(), 0f64);
-        assert!(NaN.abs().is_NaN());
+        assert!(NaN.abs().is_nan());
     }
 
     #[test]
@@ -1192,8 +1192,8 @@ mod tests {
 
     #[test] #[ignore(cfg(windows))] // FIXME #8663
     fn test_abs_sub_nowin() {
-        assert!(NaN.abs_sub(&-1f64).is_NaN());
-        assert!(1f64.abs_sub(&NaN).is_NaN());
+        assert!(NaN.abs_sub(&-1f64).is_nan());
+        assert!(1f64.abs_sub(&NaN).is_nan());
     }
 
     #[test]
@@ -1205,7 +1205,7 @@ mod tests {
         assert_eq!((-1f64).signum(), -1f64);
         assert_eq!(neg_infinity.signum(), -1f64);
         assert_eq!((1f64/neg_infinity).signum(), -1f64);
-        assert!(NaN.signum().is_NaN());
+        assert!(NaN.signum().is_nan());
     }
 
     #[test]
@@ -1250,7 +1250,7 @@ mod tests {
 
     #[test]
     fn test_is_normal() {
-        let nan: f64 = Float::NaN();
+        let nan: f64 = Float::nan();
         let inf: f64 = Float::infinity();
         let neg_inf: f64 = Float::neg_infinity();
         let zero: f64 = Zero::zero();
@@ -1267,7 +1267,7 @@ mod tests {
 
     #[test]
     fn test_classify() {
-        let nan: f64 = Float::NaN();
+        let nan: f64 = Float::nan();
         let inf: f64 = Float::infinity();
         let neg_inf: f64 = Float::neg_infinity();
         let zero: f64 = Zero::zero();
@@ -1295,10 +1295,10 @@ mod tests {
 
         let inf: f64 = Float::infinity();
         let neg_inf: f64 = Float::neg_infinity();
-        let nan: f64 = Float::NaN();
+        let nan: f64 = Float::nan();
         assert_eq!(Float::ldexp(inf, -123), inf);
         assert_eq!(Float::ldexp(neg_inf, -123), neg_inf);
-        assert!(Float::ldexp(nan, -123).is_NaN());
+        assert!(Float::ldexp(nan, -123).is_nan());
     }
 
     #[test]
@@ -1322,9 +1322,9 @@ mod tests {
     fn test_frexp_nowin() {
         let inf: f64 = Float::infinity();
         let neg_inf: f64 = Float::neg_infinity();
-        let nan: f64 = Float::NaN();
+        let nan: f64 = Float::nan();
         assert_eq!(match inf.frexp() { (x, _) => x }, inf)
         assert_eq!(match neg_inf.frexp() { (x, _) => x }, neg_inf)
-        assert!(match nan.frexp() { (x, _) => x.is_NaN() })
+        assert!(match nan.frexp() { (x, _) => x.is_nan() })
     }
 }

--- a/src/libstd/num/float.rs
+++ b/src/libstd/num/float.rs
@@ -807,8 +807,8 @@ impl Primitive for float {
 
 impl Float for float {
     #[inline]
-    fn NaN() -> float {
-        let value: f64 = Float::NaN();
+    fn nan() -> float {
+        let value: f64 = Float::nan();
         value as float
     }
 
@@ -832,7 +832,7 @@ impl Float for float {
 
     /// Returns `true` if the number is NaN
     #[inline]
-    fn is_NaN(&self) -> bool { (*self as f64).is_NaN() }
+    fn is_nan(&self) -> bool { (*self as f64).is_nan() }
 
     /// Returns `true` if the number is infinite
     #[inline]
@@ -973,10 +973,10 @@ mod tests {
         assert_eq!(1f.clamp(&2f, &4f), 2f);
         assert_eq!(8f.clamp(&2f, &4f), 4f);
         assert_eq!(3f.clamp(&2f, &4f), 3f);
-        let nan: float = Float::NaN();
-        assert!(3f.clamp(&nan, &4f).is_NaN());
-        assert!(3f.clamp(&2f, &nan).is_NaN());
-        assert!(nan.clamp(&2f, &4f).is_NaN());
+        let nan: float = Float::nan();
+        assert!(3f.clamp(&nan, &4f).is_nan());
+        assert!(3f.clamp(&2f, &nan).is_nan());
+        assert!(nan.clamp(&2f, &4f).is_nan());
     }
 
     #[test]
@@ -1056,10 +1056,10 @@ mod tests {
 
         let inf: float = Float::infinity();
         let neg_inf: float = Float::neg_infinity();
-        let nan: float = Float::NaN();
+        let nan: float = Float::nan();
         assert_eq!(inf.asinh(), inf);
         assert_eq!(neg_inf.asinh(), neg_inf);
-        assert!(nan.asinh().is_NaN());
+        assert!(nan.asinh().is_nan());
         assert_approx_eq!(2.0f.asinh(), 1.443635475178810342493276740273105f);
         assert_approx_eq!((-2.0f).asinh(), -1.443635475178810342493276740273105f);
     }
@@ -1067,14 +1067,14 @@ mod tests {
     #[test]
     fn test_acosh() {
         assert_eq!(1.0f.acosh(), 0.0f);
-        assert!(0.999f.acosh().is_NaN());
+        assert!(0.999f.acosh().is_nan());
 
         let inf: float = Float::infinity();
         let neg_inf: float = Float::neg_infinity();
-        let nan: float = Float::NaN();
+        let nan: float = Float::nan();
         assert_eq!(inf.acosh(), inf);
-        assert!(neg_inf.acosh().is_NaN());
-        assert!(nan.acosh().is_NaN());
+        assert!(neg_inf.acosh().is_nan());
+        assert!(nan.acosh().is_nan());
         assert_approx_eq!(2.0f.acosh(), 1.31695789692481670862504634730796844f);
         assert_approx_eq!(3.0f.acosh(), 1.76274717403908605046521864995958461f);
     }
@@ -1088,14 +1088,14 @@ mod tests {
         let neg_inf: float = Float::neg_infinity();
         let inf64: f64 = Float::infinity();
         let neg_inf64: f64 = Float::neg_infinity();
-        let nan: float = Float::NaN();
+        let nan: float = Float::nan();
         assert_eq!(1.0f.atanh(), inf);
         assert_eq!((-1.0f).atanh(), neg_inf);
-        assert!(2f64.atanh().atanh().is_NaN());
-        assert!((-2f64).atanh().atanh().is_NaN());
-        assert!(inf64.atanh().is_NaN());
-        assert!(neg_inf64.atanh().is_NaN());
-        assert!(nan.atanh().is_NaN());
+        assert!(2f64.atanh().atanh().is_nan());
+        assert!((-2f64).atanh().atanh().is_nan());
+        assert!(inf64.atanh().is_nan());
+        assert!(neg_inf64.atanh().is_nan());
+        assert!(nan.atanh().is_nan());
         assert_approx_eq!(0.5f.atanh(), 0.54930614433405484569762261846126285f);
         assert_approx_eq!((-0.5f).atanh(), -0.54930614433405484569762261846126285f);
     }
@@ -1146,7 +1146,7 @@ mod tests {
         assert_eq!((-1f).abs(), 1f);
         assert_eq!(neg_infinity.abs(), infinity);
         assert_eq!((1f/neg_infinity).abs(), 0f);
-        assert!(NaN.abs().is_NaN());
+        assert!(NaN.abs().is_nan());
     }
 
     #[test]
@@ -1163,8 +1163,8 @@ mod tests {
 
     #[test] #[ignore(cfg(windows))] // FIXME #8663
     fn test_abs_sub_nowin() {
-        assert!(NaN.abs_sub(&-1f).is_NaN());
-        assert!(1f.abs_sub(&NaN).is_NaN());
+        assert!(NaN.abs_sub(&-1f).is_nan());
+        assert!(1f.abs_sub(&NaN).is_nan());
     }
 
     #[test]
@@ -1176,7 +1176,7 @@ mod tests {
         assert_eq!((-1f).signum(), -1f);
         assert_eq!(neg_infinity.signum(), -1f);
         assert_eq!((1f/neg_infinity).signum(), -1f);
-        assert!(NaN.signum().is_NaN());
+        assert!(NaN.signum().is_nan());
     }
 
     #[test]
@@ -1221,7 +1221,7 @@ mod tests {
 
     #[test]
     fn test_is_normal() {
-        let nan: float = Float::NaN();
+        let nan: float = Float::nan();
         let inf: float = Float::infinity();
         let neg_inf: float = Float::neg_infinity();
         let zero: float = Zero::zero();
@@ -1238,7 +1238,7 @@ mod tests {
 
     #[test]
     fn test_classify() {
-        let nan: float = Float::NaN();
+        let nan: float = Float::nan();
         let inf: float = Float::infinity();
         let neg_inf: float = Float::neg_infinity();
         let zero: float = Zero::zero();
@@ -1267,10 +1267,10 @@ mod tests {
 
         let inf: float = Float::infinity();
         let neg_inf: float = Float::neg_infinity();
-        let nan: float = Float::NaN();
+        let nan: float = Float::nan();
         assert_eq!(Float::ldexp(inf, -123), inf);
         assert_eq!(Float::ldexp(neg_inf, -123), neg_inf);
-        assert!(Float::ldexp(nan, -123).is_NaN());
+        assert!(Float::ldexp(nan, -123).is_nan());
     }
 
     #[test]
@@ -1294,10 +1294,10 @@ mod tests {
     fn test_frexp_nowin() {
         let inf: float = Float::infinity();
         let neg_inf: float = Float::neg_infinity();
-        let nan: float = Float::NaN();
+        let nan: float = Float::nan();
         assert_eq!(match inf.frexp() { (x, _) => x }, inf);
         assert_eq!(match neg_inf.frexp() { (x, _) => x }, neg_inf);
-        assert!(match nan.frexp() { (x, _) => x.is_NaN() })
+        assert!(match nan.frexp() { (x, _) => x.is_nan() })
     }
 
     #[test]
@@ -1328,7 +1328,7 @@ mod tests {
         assert_eq!(from_str::<float>("-inf"), Some(neg_infinity));
         // note: NaN != NaN, hence this slightly complex test
         match from_str::<float>("NaN") {
-            Some(f) => assert!(f.is_NaN()),
+            Some(f) => assert!(f.is_nan()),
             None => fail!()
         }
         // note: -0 == 0, hence these slightly more complex tests
@@ -1375,7 +1375,7 @@ mod tests {
         assert_eq!(from_str_hex("-inf"), Some(neg_infinity));
         // note: NaN != NaN, hence this slightly complex test
         match from_str_hex("NaN") {
-            Some(f) => assert!(f.is_NaN()),
+            Some(f) => assert!(f.is_nan()),
             None => fail!()
         }
         // note: -0 == 0, hence these slightly more complex tests

--- a/src/libstd/num/num.rs
+++ b/src/libstd/num/num.rs
@@ -320,12 +320,12 @@ pub trait Float: Real
                + Primitive
                + ApproxEq<Self> {
     // FIXME (#5527): These should be associated constants
-    fn NaN() -> Self;
+    fn nan() -> Self;
     fn infinity() -> Self;
     fn neg_infinity() -> Self;
     fn neg_zero() -> Self;
 
-    fn is_NaN(&self) -> bool;
+    fn is_nan(&self) -> bool;
     fn is_infinite(&self) -> bool;
     fn is_finite(&self) -> bool;
     fn is_normal(&self) -> bool;

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -42,7 +42,7 @@ pub enum SignFormat {
 }
 
 pub trait NumStrConv {
-    fn NaN()      -> Option<Self>;
+    fn nan()      -> Option<Self>;
     fn inf()      -> Option<Self>;
     fn neg_inf()  -> Option<Self>;
     fn neg_zero() -> Option<Self>;
@@ -54,7 +54,7 @@ pub trait NumStrConv {
 macro_rules! impl_NumStrConv_Floating (($t:ty) => (
     impl NumStrConv for $t {
         #[inline]
-        fn NaN()      -> Option<$t> { Some( 0.0 / 0.0) }
+        fn nan()      -> Option<$t> { Some( 0.0 / 0.0) }
         #[inline]
         fn inf()      -> Option<$t> { Some( 1.0 / 0.0) }
         #[inline]
@@ -71,7 +71,7 @@ macro_rules! impl_NumStrConv_Floating (($t:ty) => (
 
 macro_rules! impl_NumStrConv_Integer (($t:ty) => (
     impl NumStrConv for $t {
-        #[inline] fn NaN()      -> Option<$t> { None }
+        #[inline] fn nan()      -> Option<$t> { None }
         #[inline] fn inf()      -> Option<$t> { None }
         #[inline] fn neg_inf()  -> Option<$t> { None }
         #[inline] fn neg_zero() -> Option<$t> { None }
@@ -515,7 +515,7 @@ pub fn from_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+Div<T,T>+
                 return None;
             }
         } else if buf == NAN_BUF {
-            return NumStrConv::NaN();
+            return NumStrConv::nan();
         }
     }
 

--- a/src/test/compile-fail/issue-6804.rs
+++ b/src/test/compile-fail/issue-6804.rs
@@ -8,12 +8,12 @@ fn main() {
         NaN => {},
         _ => {},
     };
-    //~^^^ WARNING unmatchable NaN in pattern, use the is_NaN method in a guard instead
+    //~^^^ WARNING unmatchable NaN in pattern, use the is_nan method in a guard instead
     match [x, 1.0] {
         [NaN, _] => {},
         _ => {},
     };
-    //~^^^ WARNING unmatchable NaN in pattern, use the is_NaN method in a guard instead
+    //~^^^ WARNING unmatchable NaN in pattern, use the is_nan method in a guard instead
 }
 
 // At least one error is needed so that compilation fails

--- a/src/test/run-pass/float-nan.rs
+++ b/src/test/run-pass/float-nan.rs
@@ -13,8 +13,8 @@ extern mod extra;
 use std::num::Float;
 
 pub fn main() {
-  let nan: float = Float::NaN();
-  assert!((nan).is_NaN());
+  let nan: float = Float::nan();
+  assert!((nan).is_nan());
 
   let inf: float = Float::infinity();
   let neg_inf: float = Float::neg_infinity();
@@ -73,22 +73,22 @@ pub fn main() {
   assert!(!(-inf < nan));
   assert!(!(-nan < nan));
 
-  assert!((nan + inf).is_NaN());
-  assert!((nan + -inf).is_NaN());
-  assert!((nan + 0.).is_NaN());
-  assert!((nan + 1.).is_NaN());
-  assert!((nan * 1.).is_NaN());
-  assert!((nan / 1.).is_NaN());
-  assert!((nan / 0.).is_NaN());
-  assert!((0f/0f).is_NaN());
-  assert!((-inf + inf).is_NaN());
-  assert!((inf - inf).is_NaN());
+  assert!((nan + inf).is_nan());
+  assert!((nan + -inf).is_nan());
+  assert!((nan + 0.).is_nan());
+  assert!((nan + 1.).is_nan());
+  assert!((nan * 1.).is_nan());
+  assert!((nan / 1.).is_nan());
+  assert!((nan / 0.).is_nan());
+  assert!((0f/0f).is_nan());
+  assert!((-inf + inf).is_nan());
+  assert!((inf - inf).is_nan());
 
-  assert!(!(-1f).is_NaN());
-  assert!(!(0f).is_NaN());
-  assert!(!(0.1f).is_NaN());
-  assert!(!(1f).is_NaN());
-  assert!(!(inf).is_NaN());
-  assert!(!(-inf).is_NaN());
-  assert!(!(1./-inf).is_NaN());
+  assert!(!(-1f).is_nan());
+  assert!(!(0f).is_nan());
+  assert!(!(0.1f).is_nan());
+  assert!(!(1f).is_nan());
+  assert!(!(inf).is_nan());
+  assert!(!(-inf).is_nan());
+  assert!(!(1./-inf).is_nan());
 }


### PR DESCRIPTION
This is for consistency in naming conventions.
- `std::num::Float::NaN()` is changed to `nan()`;
- `std::num::Float.is_NaN()` is changed to `is_nan()`; and
- `std::num::strconv::NumStrConv::NaN()` is changed to `nan()`.

Fixes #9319.
