### PR TITLE
Fix broken rustpkg link in the tutorial. 

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2977,9 +2977,9 @@ tutorials on individual topics.
 * [Tasks and communication][tasks]
 * [Macros][macros]
 * [The foreign function interface][ffi]
-* [Containers and iterators](tutorial-container.html)
-* [Error-handling and Conditions](tutorial-conditions.html)
-* [Packaging up Rust code](rustpkg)
+* [Containers and iterators][container]
+* [Error-handling and Conditions][conditions]
+* [Packaging up Rust code][rustpkg]
 
 There is further documentation on the [wiki], however those tend to be even more out of date as this document.
 
@@ -2987,7 +2987,8 @@ There is further documentation on the [wiki], however those tend to be even more
 [tasks]: tutorial-tasks.html
 [macros]: tutorial-macros.html
 [ffi]: tutorial-ffi.html
+[container]: tutorial-container.html
+[conditions]: tutorial-conditions.html
 [rustpkg]: tutorial-rustpkg.html
 
 [wiki]: https://github.com/mozilla/rust/wiki/Docs
-


### PR DESCRIPTION
Fixes #9324.
