### PR TITLE
a couple trait method call optimizations

### DIFF
--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -313,6 +313,37 @@ pub fn trans_to_datum(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
         let target_obj_ty = expr_ty_adjusted(bcx, expr);
         debug!("auto_borrow_obj(target=%s)",
                target_obj_ty.repr(tcx));
+
+        // Extract source store information
+        let (source_store, source_mutbl) = match ty::get(source_datum.ty).sty {
+            ty::ty_trait(_, _, s, m, _) => (s, m),
+            _ => {
+                bcx.sess().span_bug(
+                    expr.span,
+                    fmt!("auto_borrow_trait_obj expected a trait, found %s",
+                         source_datum.ty.repr(bcx.tcx())));
+            }
+        };
+
+        // check if any borrowing is really needed or we could reuse the source_datum instead
+        match ty::get(target_obj_ty).sty {
+            ty::ty_trait(_, _, ty::RegionTraitStore(target_scope), target_mutbl, _) => {
+                if target_mutbl == ast::MutImmutable && target_mutbl == source_mutbl {
+                    match source_store {
+                        ty::RegionTraitStore(source_scope) => {
+                            if tcx.region_maps.is_subregion_of(target_scope, source_scope) {
+                                return DatumBlock { bcx: bcx, datum: source_datum };
+                            }
+                        },
+                        _ => {}
+
+                    };
+                }
+            },
+            _ => {}
+        }
+
+        
         let scratch = scratch_datum(bcx, target_obj_ty,
                                     "__auto_borrow_obj", false);
 
@@ -331,15 +362,6 @@ pub fn trans_to_datum(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
         // ~T, or &T, depending on source_obj_ty.
         let source_data_ptr = GEPi(bcx, source_llval, [0u, abi::trt_field_box]);
         let source_data = Load(bcx, source_data_ptr); // always a ptr
-        let (source_store, source_mutbl) = match ty::get(source_datum.ty).sty {
-            ty::ty_trait(_, _, s, m, _) => (s, m),
-            _ => {
-                bcx.sess().span_bug(
-                    expr.span,
-                    fmt!("auto_borrow_trait_obj expected a trait, found %s",
-                         source_datum.ty.repr(bcx.tcx())));
-            }
-        };
         let target_data = match source_store {
             ty::BoxTraitStore(*) => {
                 // For deref of @T or @mut T, create a dummy datum and

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -343,7 +343,6 @@ pub fn trans_to_datum(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
             _ => {}
         }
 
-        
         let scratch = scratch_datum(bcx, target_obj_ty,
                                     "__auto_borrow_obj", false);
 

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -278,23 +278,12 @@ impl Type {
 
     pub fn opaque_trait(ctx: &CrateContext, store: ty::TraitStore) -> Type {
         let tydesc_ptr = ctx.tydesc_type.ptr_to();
-        match store {
-            ty::BoxTraitStore => {
-                Type::struct_(
-                    [ tydesc_ptr, Type::opaque_box(ctx).ptr_to() ],
-                false)
-            }
-            ty::UniqTraitStore => {
-                Type::struct_(
-                    [ tydesc_ptr, Type::unique(ctx, &Type::i8()).ptr_to()],
-                false)
-            }
-            ty::RegionTraitStore(*) => {
-                Type::struct_(
-                    [ tydesc_ptr, Type::i8().ptr_to() ],
-                false)
-            }
-        }
+        let box_ty = match store {
+            ty::BoxTraitStore => Type::opaque_box(ctx),
+            ty::UniqTraitStore => Type::unique(ctx, &Type::i8()),
+            ty::RegionTraitStore(*) => Type::i8()
+        };
+        Type::struct_([tydesc_ptr, box_ty.ptr_to()], false)
     }
 
     pub fn kind(&self) -> TypeKind {

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -55,6 +55,7 @@ fn test_destroy_actually_kills(force: bool) {
 
     #[cfg(windows)]
     fn process_exists(pid: libc::pid_t) -> bool {
+        #[fixed_stack_segment];
 
         use std::libc::types::os::arch::extra::DWORD;
         use std::libc::funcs::extra::kernel32::{CloseHandle, GetExitCodeProcess, OpenProcess};


### PR DESCRIPTION
It is intended to optimize/beautify the code generated in a few trivial trait operations.
Let's take the following code as an example:

```
trait Stuff {
    fn bar(&self);
}

fn callBar(s: &Stuff) {
    s.bar();
}

struct Foo;

impl Stuff for Foo {
    fn bar(&self) {
    }
}

pub fn main() {
    let o = Foo;
    callBar(&o as &Stuff);
}
```

At present it is translated into something like:

```
define void @_ZN7callBar_UUID.0E({ i32, %tydesc*, i8*, i8*, i8 }*, { %tydesc*, i8* }*) #4 {
"function top level":
  %__trait_callee = alloca { %tydesc*, i8* }
  %__auto_borrow_obj = alloca { %tydesc*, i8* }
  %2 = getelementptr inbounds { %tydesc*, i8* }* %1, i32 0, i32 0
  %3 = load %tydesc** %2
  %4 = getelementptr inbounds { %tydesc*, i8* }* %__auto_borrow_obj, i32 0, i32 0
  store %tydesc* %3, %tydesc** %4
  %5 = getelementptr inbounds { %tydesc*, i8* }* %1, i32 0, i32 1
  %6 = load i8** %5
  %7 = getelementptr inbounds { %tydesc*, i8* }* %__auto_borrow_obj, i32 0, i32 1
  store i8* %6, i8** %7
  %8 = bitcast { %tydesc*, i8* }* %__auto_borrow_obj to i8*
  %9 = bitcast { %tydesc*, i8* }* %__trait_callee to i8*
  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %9, i8* %8, i32 8, i32 4, i1 false)
  %10 = getelementptr inbounds { %tydesc*, i8* }* %__trait_callee, i32 0, i32 1
  %11 = load i8** %10
  %12 = bitcast i8* %11 to { i32, %tydesc*, i8*, i8*, i8 }*
  %13 = getelementptr inbounds { %tydesc*, i8* }* %__trait_callee, i32 0, i32 0
  %14 = bitcast %tydesc** %13 to [1 x i8*]**
  %15 = load [1 x i8*]** %14
  %16 = getelementptr inbounds [1 x i8*]* %15, i32 0, i32 1
  %17 = load i8** %16
  %18 = bitcast i8* %17 to void ({ i32, %tydesc*, i8*, i8*, i8 }*)*
  call void %18({ i32, %tydesc*, i8*, i8*, i8 }* %12)
  ret void
}

...

define void @_ZN4main_UUID.0E({ i32, %tydesc*, i8*, i8*, i8 }*) #4 {
"function top level":
  %o = alloca %struct.Foo
  %1 = alloca { %tydesc*, i8* }
  %__auto_borrow_obj = alloca { %tydesc*, i8* }
  %2 = getelementptr inbounds { %tydesc*, i8* }* %1, i32 0, i32 1
  %3 = bitcast i8** %2 to %struct.Foo**
  store %struct.Foo* %o, %struct.Foo** %3
  %4 = getelementptr inbounds { %tydesc*, i8* }* %1, i32 0, i32 0
  %5 = bitcast %tydesc** %4 to { %tydesc*, void ({ i32, %tydesc*, i8*, i8*, i8 }*)* }**
  store { %tydesc*, void ({ i32, %tydesc*, i8*, i8*, i8 }*)* }* @vtable1081, { %tydesc*, void ({ i32, %tydesc*, i8*, i8*, i8 }*)* }** %5
  %6 = getelementptr inbounds { %tydesc*, i8* }* %1, i32 0, i32 0
  %7 = load %tydesc** %6
  %8 = getelementptr inbounds { %tydesc*, i8* }* %__auto_borrow_obj, i32 0, i32 0
  store %tydesc* %7, %tydesc** %8
  %9 = getelementptr inbounds { %tydesc*, i8* }* %1, i32 0, i32 1
  %10 = load i8** %9
  %11 = getelementptr inbounds { %tydesc*, i8* }* %__auto_borrow_obj, i32 0, i32 1
  store i8* %10, i8** %11
  call void @_ZN7callBar_UUID.0E({ i32, %tydesc*, i8*, i8*, i8 }* undef, { %tydesc*, i8* }* %__auto_borrow_obj)
  ret void
}
```

If you apply my patch, it would become way shorter and cleaner:

```
define void @_ZN7callBar_UUID.0E({ i32, %tydesc*, i8*, i8*, i8 }*, { %tydesc*, i8* }*) #4 {
"function top level":
  %2 = getelementptr inbounds { %tydesc*, i8* }* %1, i32 0, i32 1
  %3 = load i8** %2
  %4 = bitcast i8* %3 to { i32, %tydesc*, i8*, i8*, i8 }*
  %5 = getelementptr inbounds { %tydesc*, i8* }* %1, i32 0, i32 0
  %6 = bitcast %tydesc** %5 to [1 x i8*]**
  %7 = load [1 x i8*]** %6
  %8 = getelementptr inbounds [1 x i8*]* %7, i32 0, i32 1
  %9 = load i8** %8
  %10 = bitcast i8* %9 to void ({ i32, %tydesc*, i8*, i8*, i8 }*)*
  call void %10({ i32, %tydesc*, i8*, i8*, i8 }* %4)
  ret void
}

...

define void @_ZN4main_UUID.0E({ i32, %tydesc*, i8*, i8*, i8 }*) #4 {
"function top level":
  %o = alloca %struct.Foo
  %1 = alloca { %tydesc*, i8* }
  %2 = getelementptr inbounds { %tydesc*, i8* }* %1, i32 0, i32 1
  %3 = bitcast i8** %2 to %struct.Foo**
  store %struct.Foo* %o, %struct.Foo** %3
  %4 = getelementptr inbounds { %tydesc*, i8* }* %1, i32 0, i32 0
  %5 = bitcast %tydesc** %4 to { %tydesc*, void ({ i32, %tydesc*, i8*, i8*, i8 }*)* }**
  store { %tydesc*, void ({ i32, %tydesc*, i8*, i8*, i8 }*)* }* @vtable1081, { %tydesc*, void ({ i32, %tydesc*, i8*, i8*, i8 }*)* }** %5
  call void @_ZN7callBar_UUID.0E({ i32, %tydesc*, i8*, i8*, i8 }* undef, { %tydesc*, i8* }* %1)
  ret void
}
```

Although this change doesn't increase the compilation speed much (I mentioned only about 1-2% boost on "rustc -O -Z time-passes syntax.rs"), but I still think it's a good thing to do as it greatly simplifies/clarifies LL generated in some cases which would definitely help in the future code generation investigations.

I don't provide any new test cases in this patch as it is merely an optimization.

Sorry guys, I somehow messed my previous PR and I don't see any better way to fix as to recreate it here.
