### PR TITLE
Stop accepting 'impl ...;', require {} instead

### DIFF
--- a/src/libstd/rt/io/mod.rs
+++ b/src/libstd/rt/io/mod.rs
@@ -472,7 +472,7 @@ pub trait Writer {
 
 pub trait Stream: Reader + Writer { }
 
-impl<T: Reader + Writer> Stream for T;
+impl<T: Reader + Writer> Stream for T {}
 
 pub enum SeekStyle {
     /// Seek from the beginning of the stream

--- a/src/libstd/rt/uv/file.rs
+++ b/src/libstd/rt/uv/file.rs
@@ -22,7 +22,7 @@ use libc::{c_int};
 use option::{None, Some, Option};
 
 pub struct FsRequest(*uvll::uv_fs_t);
-impl Request for FsRequest;
+impl Request for FsRequest {}
 
 pub struct RequestData {
     complete_cb: Option<FsCallback>

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -65,6 +65,7 @@ pub enum ObsoleteSyntax {
     ObsoletePrivVisibility,
     ObsoleteTraitFuncVisibility,
     ObsoleteConstPointer,
+    ObsoleteEmptyImpl,
 }
 
 impl to_bytes::IterBytes for ObsoleteSyntax {
@@ -255,6 +256,10 @@ impl ParserObsoleteMethods for Parser {
                 "const pointer",
                 "instead of `&const Foo` or `@const Foo`, write `&Foo` or \
                  `@Foo`"
+            ),
+            ObsoleteEmptyImpl => (
+                "empty implementation",
+                "instead of `impl A;`, write `impl A {}`"
             ),
         };
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3852,7 +3852,9 @@ impl Parser {
         }
 
         let mut meths = ~[];
-        if !self.eat(&token::SEMI) {
+        if self.eat(&token::SEMI) {
+            self.obsolete(*self.span, ObsoleteEmptyImpl);
+        } else {
             self.expect(&token::LBRACE);
             while !self.eat(&token::RBRACE) {
                 meths.push(self.parse_method());

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -587,18 +587,12 @@ pub fn print_item(s: @ps, item: &ast::item) {
 
         print_type(s, ty);
 
-        if methods.len() == 0 {
-            word(s.s, ";");
-            end(s); // end the head-ibox
-            end(s); // end the outer cbox
-        } else {
-            space(s.s);
-            bopen(s);
-            for meth in methods.iter() {
-               print_method(s, *meth);
-            }
-            bclose(s, item.span);
+        space(s.s);
+        bopen(s);
+        for meth in methods.iter() {
+           print_method(s, *meth);
         }
+        bclose(s, item.span);
       }
       ast::item_trait(ref generics, ref traits, ref methods) => {
         head(s, visibility_qualified(item.vis, "trait"));

--- a/src/test/auxiliary/trait_inheritance_overloading_xc.rs
+++ b/src/test/auxiliary/trait_inheritance_overloading_xc.rs
@@ -35,6 +35,6 @@ impl Eq for MyInt {
     fn ne(&self, other: &MyInt) -> bool { !self.eq(other) }
 }
 
-impl MyNum for MyInt;
+impl MyNum for MyInt {}
 
 fn mi(v: int) -> MyInt { MyInt { val: v } }

--- a/src/test/compile-fail/missing-derivable-attr.rs
+++ b/src/test/compile-fail/missing-derivable-attr.rs
@@ -20,7 +20,7 @@ impl MyEq for int {
     fn eq(&self, other: &int) -> bool { *self == *other }
 }
 
-impl MyEq for A;  //~ ERROR missing method
+impl MyEq for A {}  //~ ERROR missing method
 
 fn main() {
 }

--- a/src/test/debug-info/generic-trait-generic-static-default-method.rs
+++ b/src/test/debug-info/generic-trait-generic-static-default-method.rs
@@ -40,7 +40,7 @@ trait Trait<T1> {
     }
 }
 
-impl<T> Trait<T> for Struct;
+impl<T> Trait<T> for Struct {}
 
 fn main() {
 

--- a/src/test/debug-info/self-in-default-method.rs
+++ b/src/test/debug-info/self-in-default-method.rs
@@ -118,7 +118,7 @@ trait Trait {
     }
 }
 
-impl Trait for Struct;
+impl Trait for Struct {}
 
 fn main() {
     let stack = Struct { x: 100 };

--- a/src/test/debug-info/self-in-generic-default-method.rs
+++ b/src/test/debug-info/self-in-generic-default-method.rs
@@ -119,7 +119,7 @@ trait Trait {
     }
 }
 
-impl Trait for Struct;
+impl Trait for Struct {}
 
 fn main() {
     let stack = Struct { x: 987 };

--- a/src/test/debug-info/trait-generic-static-default-method.rs
+++ b/src/test/debug-info/trait-generic-static-default-method.rs
@@ -40,7 +40,7 @@ trait Trait {
     }
 }
 
-impl Trait for Struct;
+impl Trait for Struct {}
 
 fn main() {
 

--- a/src/test/pretty/empty-impl.pp
+++ b/src/test/pretty/empty-impl.pp
@@ -1,5 +1,5 @@
 trait X { }
-impl X for uint;
+impl X for uint { }
 
 trait Y { }
-impl Y for uint;
+impl Y for uint { }

--- a/src/test/pretty/empty-impl.rs
+++ b/src/test/pretty/empty-impl.rs
@@ -1,5 +1,5 @@
 trait X { }
-impl X for uint;
+impl X for uint { }
 
 trait Y { }
-impl Y for uint;
+impl Y for uint { }

--- a/src/test/pretty/path-type-bounds.rs
+++ b/src/test/pretty/path-type-bounds.rs
@@ -1,7 +1,7 @@
 // pp-exact
 
 trait Tr { }
-impl Tr for int;
+impl Tr for int { }
 
 fn foo(x: ~Tr: Freeze) -> ~Tr: Freeze { x }
 

--- a/src/test/run-pass/default-method-supertrait-vtable.rs
+++ b/src/test/run-pass/default-method-supertrait-vtable.rs
@@ -29,7 +29,7 @@ impl Y for int {
     fn y(self) -> int { self }
 }
 
-impl Z for int;
+impl Z for int {}
 
 fn main() {
     assert_eq!(12.x(), 12);

--- a/src/test/run-pass/issue-3979-generics.rs
+++ b/src/test/run-pass/issue-3979-generics.rs
@@ -31,7 +31,7 @@ impl Positioned<int> for Point {
     }
 }
 
-impl Movable<int> for Point;
+impl Movable<int> for Point {}
 
 pub fn main() {
     let mut p = Point{ x: 1, y: 2};

--- a/src/test/run-pass/issue-3979-xcrate.rs
+++ b/src/test/run-pass/issue-3979-xcrate.rs
@@ -24,7 +24,7 @@ impl Positioned for Point {
     }
 }
 
-impl Movable for Point;
+impl Movable for Point {}
 
 pub fn main() {
     let mut p = Point{ x: 1, y: 2};

--- a/src/test/run-pass/issue-3979.rs
+++ b/src/test/run-pass/issue-3979.rs
@@ -32,7 +32,7 @@ impl Positioned for Point {
     }
 }
 
-impl Movable for Point;
+impl Movable for Point {}
 
 pub fn main() {
     let mut p = Point{ x: 1, y: 2};

--- a/src/test/run-pass/supertrait-default-generics.rs
+++ b/src/test/run-pass/supertrait-default-generics.rs
@@ -33,7 +33,7 @@ impl<S: Clone> Positioned<S> for Point<S> {
     }
 }
 
-impl<S: Clone + Add<S, S>> Movable<S> for Point<S>;
+impl<S: Clone + Add<S, S>> Movable<S> for Point<S> {}
 
 pub fn main() {
     let mut p = Point{ x: 1, y: 2};

--- a/src/test/run-pass/trait-inheritance-overloading-simple.rs
+++ b/src/test/run-pass/trait-inheritance-overloading-simple.rs
@@ -19,7 +19,7 @@ impl Eq for MyInt {
     fn ne(&self, other: &MyInt) -> bool { !self.eq(other) }
 }
 
-impl MyNum for MyInt;
+impl MyNum for MyInt {}
 
 fn f<T:MyNum>(x: T, y: T) -> bool {
     return x == y;

--- a/src/test/run-pass/trait-inheritance-overloading.rs
+++ b/src/test/run-pass/trait-inheritance-overloading.rs
@@ -31,7 +31,7 @@ impl Eq for MyInt {
     fn ne(&self, other: &MyInt) -> bool { !self.eq(other) }
 }
 
-impl MyNum for MyInt;
+impl MyNum for MyInt {}
 
 fn f<T:MyNum>(x: T, y: T) -> (T, T, T) {
     return (x + y, x - y, x * y);

--- a/src/test/run-pass/trait-inheritance-subst.rs
+++ b/src/test/run-pass/trait-inheritance-subst.rs
@@ -20,7 +20,7 @@ impl Add<MyInt, MyInt> for MyInt {
     fn add(&self, other: &MyInt) -> MyInt { mi(self.val + other.val) }
 }
 
-impl MyNum for MyInt;
+impl MyNum for MyInt {}
 
 fn f<T:MyNum>(x: T, y: T) -> T {
     return x.add(&y);

--- a/src/test/run-pass/trait-inheritance-subst2.rs
+++ b/src/test/run-pass/trait-inheritance-subst2.rs
@@ -30,7 +30,7 @@ impl Add<MyInt, MyInt> for MyInt {
     fn add(&self, other: &MyInt) -> MyInt { self.chomp(other) }
 }
 
-impl MyNum for MyInt;
+impl MyNum for MyInt {}
 
 fn f<T:MyNum>(x: T, y: T) -> T {
     return x.add(&y).chomp(&y);

--- a/src/test/run-pass/trait-inheritance2.rs
+++ b/src/test/run-pass/trait-inheritance2.rs
@@ -19,7 +19,7 @@ struct A { x: int }
 impl Foo for A { fn f(&self) -> int { 10 } }
 impl Bar for A { fn g(&self) -> int { 20 } }
 impl Baz for A { fn h(&self) -> int { 30 } }
-impl Quux for A;
+impl Quux for A {}
 
 fn f<T:Quux + Foo + Bar + Baz>(a: &T) {
     assert_eq!(a.f(), 10);


### PR DESCRIPTION
Progress on #7981

This doesn't completely close the issue because `struct A;` is still allowed, and it's a much larger change to disallow that. I'm also not entirely sure that we want to disallow that. Regardless, punting that discussion to the issue instead.
