### PR TITLE
Fix usage for rustpkg init

### DIFF
--- a/src/librustpkg/usage.rs
+++ b/src/librustpkg/usage.rs
@@ -150,8 +150,9 @@ Options:
 }
 
 pub fn init() {
-    io::println("rustpkg init name
+    io::println("rustpkg init
 
-This makes a new workspace for working on a project named name.
+This will turn the current working directory into a workspace. The first
+command you run when starting off a new project.
 ");
 }


### PR DESCRIPTION
When I took out the ability to make a new project by name, I forgot to
update the usage to reflect the changes.
