### PR TITLE
Fix link from tutorial to rustpkg tutorial

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2979,7 +2979,7 @@ tutorials on individual topics.
 * [The foreign function interface][ffi]
 * [Containers and iterators](tutorial-container.html)
 * [Error-handling and Conditions](tutorial-conditions.html)
-* [Packaging up Rust code](rustpkg)
+* [Packaging up Rust code][rustpkg]
 
 There is further documentation on the [wiki], however those tend to be even more out of date as this document.
 


### PR DESCRIPTION
I got my markdown syntax wrong: named links use []s, not ()s.
