### PR TITLE
Micro-optimize vec.with_c_str for short vectors

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -524,13 +524,13 @@ pub fn set_always_inline(f: ValueRef) {
 }
 
 pub fn set_fixed_stack_segment(f: ValueRef) {
-    do "fixed-stack-segment".to_c_str().with_ref |buf| {
+    do "fixed-stack-segment".with_c_str |buf| {
         unsafe { llvm::LLVMAddFunctionAttrString(f, buf); }
     }
 }
 
 pub fn set_no_split_stack(f: ValueRef) {
-    do "no-split-stack".to_c_str().with_ref |buf| {
+    do "no-split-stack".with_c_str |buf| {
         unsafe { llvm::LLVMAddFunctionAttrString(f, buf); }
     }
 }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -781,7 +781,7 @@ pub fn create_function_debug_context(cx: &mut CrateContext,
 
                 let ident = special_idents::type_self;
 
-                let param_metadata = do token::ident_to_str(&ident).to_c_str().with_ref |name| {
+                let param_metadata = do token::ident_to_str(&ident).with_c_str |name| {
                     unsafe {
                         llvm::LLVMDIBuilderCreateTemplateTypeParameter(
                             DIB(cx),
@@ -819,7 +819,7 @@ pub fn create_function_debug_context(cx: &mut CrateContext,
             // Again, only create type information if extra_debuginfo is enabled
             if cx.sess.opts.extra_debuginfo {
                 let actual_type_metadata = type_metadata(cx, actual_type, codemap::dummy_sp());
-                let param_metadata = do token::ident_to_str(&ident).to_c_str().with_ref |name| {
+                let param_metadata = do token::ident_to_str(&ident).with_c_str |name| {
                     unsafe {
                         llvm::LLVMDIBuilderCreateTemplateTypeParameter(
                             DIB(cx),

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -465,7 +465,7 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @mut CrateContext,
         //     }
 
         let the_block =
-            "the block".to_c_str().with_ref(
+            "the block".with_c_str(
                 |s| llvm::LLVMAppendBasicBlockInContext(ccx.llcx, llwrapfn, s));
 
         let builder = ccx.builder.B;
@@ -519,7 +519,7 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @mut CrateContext,
 
                 None => {
                     let slot = {
-                        "return_alloca".to_c_str().with_ref(
+                        "return_alloca".with_c_str(
                             |s| llvm::LLVMBuildAlloca(builder,
                                                       llrust_ret_ty.to_ref(),
                                                       s))

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -250,7 +250,7 @@ impl<'self> ToCStr for &'self str {
 }
 
 // The length of the stack allocated buffer for `vec.with_c_str()`
-static BUF_LEN: uint = 32;
+static BUF_LEN: uint = 128;
 
 impl<'self> ToCStr for &'self [u8] {
     fn to_c_str(&self) -> CString {

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -277,9 +277,6 @@ impl<'self> ToCStr for &'self [u8] {
         }
     }
 
-    /// WARNING: This function uses an optimization to only malloc a temporary
-    /// CString when the source string is small. Do not save a reference to
-    /// the `*libc::c_char` as it may be invalid after this function call.
     fn with_c_str<T>(&self, f: &fn(*libc::c_char) -> T) -> T {
         if self.len() < BUF_LEN {
             do self.as_imm_buf |self_buf, self_len| {

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -152,8 +152,7 @@ impl CString {
     pub fn as_bytes<'a>(&'a self) -> &'a [u8] {
         if self.buf.is_null() { fail!("CString is null!"); }
         unsafe {
-            let len = ptr::position(self.buf, |c| *c == 0);
-            cast::transmute((self.buf, len + 1))
+            cast::transmute((self.buf, self.len() + 1))
         }
     }
 
@@ -183,6 +182,15 @@ impl Drop for CString {
             unsafe {
                 libc::free(self.buf as *libc::c_void)
             }
+        }
+    }
+}
+
+impl Container for CString {
+    #[inline]
+    fn len(&self) -> uint {
+        unsafe {
+            ptr::position(self.buf, |c| *c == 0)
         }
     }
 }

--- a/src/libstd/rt/crate_map.rs
+++ b/src/libstd/rt/crate_map.rs
@@ -209,7 +209,7 @@ fn iter_crate_map_follow_children() {
         let child_crate1 = CrateMapT2 {
             version: 1,
             entries: vec::raw::to_ptr([
-                ModEntry { name: "t::f1".to_c_str().with_ref(|buf| buf), log_level: &mut 1},
+                ModEntry { name: "t::f1".with_c_str(|buf| buf), log_level: &mut 1},
                 ModEntry { name: ptr::null(), log_level: ptr::mut_null()}
             ]),
             children: [&child_crate2 as *CrateMap, ptr::null()]
@@ -219,7 +219,7 @@ fn iter_crate_map_follow_children() {
         let root_crate = CrateMapT2 {
             version: 1,
             entries: vec::raw::to_ptr([
-                ModEntry { name: "t::f1".to_c_str().with_ref(|buf| buf), log_level: &mut 0},
+                ModEntry { name: "t::f1".with_c_str(|buf| buf), log_level: &mut 0},
                 ModEntry { name: ptr::null(), log_level: ptr::mut_null()}
             ]),
             children: [child_crate1_ptr, ptr::null()]

--- a/src/libstd/rt/logging.rs
+++ b/src/libstd/rt/logging.rs
@@ -294,7 +294,7 @@ fn update_entry_match_full_path() {
                  LogDirective {name: Some(~"crate2"), level: 3}];
     let level = &mut 0;
     unsafe {
-        do "crate1::mod1".to_c_str().with_ref |ptr| {
+        do "crate1::mod1".with_c_str |ptr| {
             let entry= &ModEntry {name: ptr, log_level: level};
             let m = update_entry(dirs, transmute(entry));
             assert!(*entry.log_level == 2);
@@ -310,7 +310,7 @@ fn update_entry_no_match() {
                  LogDirective {name: Some(~"crate2"), level: 3}];
     let level = &mut 0;
     unsafe {
-        do "crate3::mod1".to_c_str().with_ref |ptr| {
+        do "crate3::mod1".with_c_str |ptr| {
             let entry= &ModEntry {name: ptr, log_level: level};
             let m = update_entry(dirs, transmute(entry));
             assert!(*entry.log_level == DEFAULT_LOG_LEVEL);
@@ -326,7 +326,7 @@ fn update_entry_match_beginning() {
                  LogDirective {name: Some(~"crate2"), level: 3}];
     let level = &mut 0;
     unsafe {
-        do "crate2::mod1".to_c_str().with_ref |ptr| {
+        do "crate2::mod1".with_c_str |ptr| {
             let entry= &ModEntry {name: ptr, log_level: level};
             let m = update_entry(dirs, transmute(entry));
             assert!(*entry.log_level == 3);
@@ -343,7 +343,7 @@ fn update_entry_match_beginning_longest_match() {
                  LogDirective {name: Some(~"crate2::mod"), level: 4}];
     let level = &mut 0;
     unsafe {
-        do "crate2::mod1".to_c_str().with_ref |ptr| {
+        do "crate2::mod1".with_c_str |ptr| {
             let entry = &ModEntry {name: ptr, log_level: level};
             let m = update_entry(dirs, transmute(entry));
             assert!(*entry.log_level == 4);
@@ -360,13 +360,13 @@ fn update_entry_match_default() {
                 ];
     let level = &mut 0;
     unsafe {
-        do "crate1::mod1".to_c_str().with_ref |ptr| {
+        do "crate1::mod1".with_c_str |ptr| {
             let entry= &ModEntry {name: ptr, log_level: level};
             let m = update_entry(dirs, transmute(entry));
             assert!(*entry.log_level == 2);
             assert!(m == 1);
         }
-        do "crate2::mod2".to_c_str().with_ref |ptr| {
+        do "crate2::mod2".with_c_str |ptr| {
             let entry= &ModEntry {name: ptr, log_level: level};
             let m = update_entry(dirs, transmute(entry));
             assert!(*entry.log_level == 3);

--- a/src/libstd/rt/uv/file.rs
+++ b/src/libstd/rt/uv/file.rs
@@ -370,8 +370,7 @@ mod test {
     use unstable::run_in_bare_thread;
     use path::Path;
     use rt::uv::{Loop, Buf, slice_to_uv_buf};
-    use libc::{c_int, O_CREAT, O_RDWR, O_RDONLY,
-               S_IWUSR, S_IRUSR};
+    use libc::{O_CREAT, O_RDWR, O_RDONLY, S_IWUSR, S_IRUSR};
 
     #[test]
     fn file_test_full_simple() {
@@ -603,7 +602,7 @@ mod test {
                         assert!(uverr.is_none());
                         let loop_ = req.get_loop();
                         let stat_req = FsRequest::new();
-                        do stat_req.stat(&loop_, &path) |req, uverr| {
+                        do stat_req.stat(&loop_, &path) |_req, uverr| {
                             assert!(uverr.is_some());
                         }
                     }
@@ -628,11 +627,11 @@ mod test {
                 do mkdir_req.mkdir(&loop_, &path, mode as int) |req,uverr| {
                     assert!(uverr.is_some());
                     let loop_ = req.get_loop();
-                    let stat = req.get_stat();
+                    let _stat = req.get_stat();
                     let rmdir_req = FsRequest::new();
                     do rmdir_req.rmdir(&loop_, &path) |req,uverr| {
                         assert!(uverr.is_none());
-                        let loop_ = req.get_loop();
+                        let _loop = req.get_loop();
                     }
                 }
             }
@@ -646,7 +645,7 @@ mod test {
             let mut loop_ = Loop::new();
             let path = "./tmp/never_existed_dir";
             let rmdir_req = FsRequest::new();
-            do rmdir_req.rmdir(&loop_, &path) |req,uverr| {
+            do rmdir_req.rmdir(&loop_, &path) |_req, uverr| {
                 assert!(uverr.is_some());
             }
             loop_.run();

--- a/src/libstd/rt/uv/file.rs
+++ b/src/libstd/rt/uv/file.rs
@@ -43,7 +43,7 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         path.path_as_str(|p| {
-            p.to_c_str().with_ref(|p| unsafe {
+            p.with_c_str(|p| unsafe {
             uvll::fs_open(loop_.native_handle(),
                           self.native_handle(), p, flags, mode, complete_cb_ptr)
             })
@@ -57,7 +57,7 @@ impl FsRequest {
             me.req_boilerplate(None)
         };
         let result = path.path_as_str(|p| {
-            p.to_c_str().with_ref(|p| unsafe {
+            p.with_c_str(|p| unsafe {
             uvll::fs_open(loop_.native_handle(),
                     self.native_handle(), p, flags, mode, complete_cb_ptr)
             })
@@ -71,7 +71,7 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         path.path_as_str(|p| {
-            p.to_c_str().with_ref(|p| unsafe {
+            p.with_c_str(|p| unsafe {
                 uvll::fs_unlink(loop_.native_handle(),
                               self.native_handle(), p, complete_cb_ptr)
             })
@@ -85,7 +85,7 @@ impl FsRequest {
             me.req_boilerplate(None)
         };
         let result = path.path_as_str(|p| {
-            p.to_c_str().with_ref(|p| unsafe {
+            p.with_c_str(|p| unsafe {
                 uvll::fs_unlink(loop_.native_handle(),
                               self.native_handle(), p, complete_cb_ptr)
             })
@@ -99,7 +99,7 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         path.path_as_str(|p| {
-            p.to_c_str().with_ref(|p| unsafe {
+            p.with_c_str(|p| unsafe {
                 uvll::fs_stat(loop_.native_handle(),
                               self.native_handle(), p, complete_cb_ptr)
             })
@@ -192,7 +192,7 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         path.path_as_str(|p| {
-            p.to_c_str().with_ref(|p| unsafe {
+            p.with_c_str(|p| unsafe {
             uvll::fs_mkdir(loop_.native_handle(),
                           self.native_handle(), p, mode, complete_cb_ptr)
             })
@@ -205,7 +205,7 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         path.path_as_str(|p| {
-            p.to_c_str().with_ref(|p| unsafe {
+            p.with_c_str(|p| unsafe {
             uvll::fs_rmdir(loop_.native_handle(),
                           self.native_handle(), p, complete_cb_ptr)
             })
@@ -219,7 +219,7 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         path.path_as_str(|p| {
-            p.to_c_str().with_ref(|p| unsafe {
+            p.with_c_str(|p| unsafe {
             uvll::fs_readdir(loop_.native_handle(),
                           self.native_handle(), p, flags, complete_cb_ptr)
             })

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1222,7 +1222,7 @@ pub mod raw {
         unsafe {
             let input = bytes!("zero", "\x00", "one", "\x00", "\x00");
             let ptr = vec::raw::to_ptr(input);
-            let mut result = from_c_multistring(ptr as *libc::c_char, None);
+            let result = from_c_multistring(ptr as *libc::c_char, None);
             assert!(result.len() == 2);
             let mut ctr = 0;
             for x in result.iter() {


### PR DESCRIPTION
One of the downsides with `c_str` is that it always forces an allocation, and so this could add unnecessary overhead to various calls. This PR implements one of the suggestions @graydon made in #8296 for `vec.with_c_str` in that for a short string can use a small stack array instead of a malloced array for our temporary c string. This ends up being twice as fast for small strings.

There are two things to consider before landing this commit though. First off, I arbitrarily picked the stack array as 32 bytes, and I'm not sure if this a reasonable amount or not. Second, there is a risk that someone can keep a reference to the interior stack pointer, which could cause mayhem if someone were to dereference the pointer. Since we also can easily grab and return interior pointers to vecs though, I don't think this is that much of an issue.
