### PR TITLE
add puts() to libstd and the prelude

### DIFF
--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -1702,6 +1702,22 @@ pub fn println(s: &str) {
     stdout().write_line(s);
 }
 
+/**
+* Prints every object that implements the ToStr trait to standard output, followed by a newline.
+*
+* It works like, eg, ruby's puts.
+*
+* # Example
+*
+* ~~~ {.rust}
+* // puts is imported into the prelude, and so is always available.
+* puts(3u);
+* ~~~
+*/
+pub fn puts<T: ToStr>(input: T) {
+    stdout().write_line(input.to_str());
+}
+
 pub struct BytesWriter {
     bytes: @mut ~[u8],
     pos: @mut uint,

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -39,7 +39,7 @@ pub use option::{Option, Some, None};
 pub use result::{Result, Ok, Err};
 
 // Reexported functions
-pub use io::{print, println};
+pub use io::{print, println,puts};
 pub use iter::range;
 pub use from_str::from_str;
 

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -39,7 +39,7 @@ pub use option::{Option, Some, None};
 pub use result::{Result, Ok, Err};
 
 // Reexported functions
-pub use io::{print, println,puts};
+pub use io::{print, println, puts};
 pub use iter::range;
 pub use from_str::from_str;
 


### PR DESCRIPTION
I don't know if you want this function in the stdlib, but in my opinion it's a very useful little helper! ;)

It works, as stated in the code, like the `puts` method in ruby, except for the fact that it only takes one object as parameter and not a variable number of objects.
