### PR TITLE
std: add missing #[inline] annotation to the f64 neg method.

### DIFF
--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -307,6 +307,7 @@ impl Rem<f64,f64> for f64 {
 }
 #[cfg(not(test))]
 impl Neg<f64> for f64 {
+    #[inline]
     fn neg(&self) -> f64 { -*self }
 }
 


### PR DESCRIPTION
This was, somehow, missed by #8332.
