### PR TITLE
Actually default rustc to have debug! output

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -100,12 +100,13 @@ else
   CFG_RUSTC_FLAGS += -O --cfg rtopt
 endif
 
-ifdef CFG_ENABLE_DEBUG
-  $(info cfg: enabling more debugging (CFG_ENABLE_DEBUG))
-  CFG_GCCISH_CFLAGS += -DRUST_DEBUG
-else
+ifdef CFG_DISABLE_DEBUG
   CFG_RUSTC_FLAGS += --cfg ndebug
   CFG_GCCISH_CFLAGS += -DRUST_NDEBUG
+else
+  $(info cfg: enabling more debugging (CFG_ENABLE_DEBUG))
+  CFG_RUSTC_FLAGS += --cfg debug
+  CFG_GCCISH_CFLAGS += -DRUST_DEBUG
 endif
 
 ifdef SAVE_TEMPS


### PR DESCRIPTION
Turns out that even if the default is "enabled", that doesn't mean that the
CFG_ENABLE_DEBUG variable will be defined. Instead, test whether
CFG_DISABLE_DEBUG is defined and disable debug things if that's the case.
