### PR TITLE
Remove 'copy' from syntax files, as it's no longer a keyword

### DIFF
--- a/src/etc/gedit/share/gtksourceview-3.0/language-specs/rust.lang
+++ b/src/etc/gedit/share/gtksourceview-3.0/language-specs/rust.lang
@@ -39,7 +39,6 @@
 		<keyword>assert</keyword>
 		<keyword>break</keyword>
 		<keyword>const</keyword>
-		<keyword>copy</keyword>
 		<keyword>do</keyword>
 		<keyword>drop</keyword>
 		<keyword>else</keyword>

--- a/src/etc/kate/rust.xml
+++ b/src/etc/kate/rust.xml
@@ -18,7 +18,6 @@
 	<list name="keywords">
 		<item> as </item>
 		<item> break </item>
-		<item> copy </item>
 		<item> do </item>
 		<item> drop </item>
 		<item> else </item>

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -18,9 +18,8 @@ syn keyword   rustOperator    as
 
 syn match     rustAssert      "\<assert\(\w\)*!" contained
 syn match     rustFail        "\<fail\(\w\)*!" contained
-syn keyword   rustKeyword     break copy do extern
+syn keyword   rustKeyword     break do extern
 syn keyword   rustKeyword     in if impl let log
-syn keyword   rustKeyword     copy do extern
 syn keyword   rustKeyword     for impl let log
 syn keyword   rustKeyword     loop mod once priv pub
 syn keyword   rustKeyword     return


### PR DESCRIPTION
Along with a tiny bit of cleanup in rust.vim.
