### PR TITLE
mark ico files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 [attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
 
 * text=auto eol=lf
+*.ico binary
 *.cpp rust
 *.h rust
 *.rs rust


### PR DESCRIPTION
For whatever reason, `text=auto` isn't working as it is supposed to.
