### PR TITLE
disable CRLF conversion, rather than forcing to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 [attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
 
-* text=auto eol=lf
+* text=auto -crlf
 *.cpp rust
 *.h rust
 *.rs rust


### PR DESCRIPTION
at the moment, the EOL is being set to LF on binary files too
