### PR TITLE
Auto-link bare URIs in documentation rendering

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -28,7 +28,7 @@ impl<'self> fmt::Default for Markdown<'self> {
                        CreatePipe(PipeStream::new().unwrap(), false, true)];
             let args = ProcessConfig {
                 program: "pandoc",
-                args: [],
+                args: ["-f", "mardown+autolink_bare_uris"],
                 env: None,
                 cwd: None,
                 io: io,


### PR DESCRIPTION
@bytbox in #9424 found out that http://foo.com wasn't rendered as a link in
pandoc by default. This extension to pandoc enables the auto-linking behaviour,
however.
