### PR TITLE
Disable zlib/libffi when configuring LLVM

### DIFF
--- a/configure
+++ b/configure
@@ -848,6 +848,8 @@ do
         # Disable term-info, linkage of which comes in multiple forms,
         # making our snapshots incompatible (#9334)
         LLVM_OPTS="$LLVM_OPTS --disable-terminfo"
+        # Try to have LLVM pull in as few dependencies as possible (#9397)
+        LLVM_OPTS="$LLVM_OPTS --disable-zlib --disable-libffi"
 
         case "$CFG_C_COMPILER" in
             ("ccache clang")

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2013-09-22
+2013-09-23


### PR DESCRIPTION
This should help bring fewer dependencies in to the snapshots.

Closes #9397
