### PR TITLE
std::rt: Implement task yielding. Fix a starvation problem

### DIFF
--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -542,12 +542,9 @@ pub fn deschedule() {
     use rt::local::Local;
     use rt::sched::Scheduler;
 
-    // FIXME #6842: What does yield really mean in newsched?
     // FIXME(#7544): Optimize this, since we know we won't block.
     let sched: ~Scheduler = Local::take();
-    do sched.deschedule_running_task_and_then |sched, task| {
-        sched.enqueue_blocked_task(task);
-    }
+    sched.yield_now();
 }
 
 pub fn failing() -> bool {


### PR DESCRIPTION
Last time I tried to land this it was timing out. It's pretty important for scheduling though so I want to keep throwing it at the bots while I try to figure out what the problem is.
