### PR TITLE
RFC: Added an FindIterator to str

### DIFF
--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -47,7 +47,7 @@ pub use from_str::from_str;
 pub use c_str::ToCStr;
 pub use clone::{Clone, DeepClone};
 pub use cmp::{Eq, ApproxEq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater, Equiv};
-pub use char::Char;
+pub use char::{Char, ToChar};
 pub use container::{Container, Mutable, Map, MutableMap, Set, MutableSet};
 pub use hash::Hash;
 pub use num::Times;

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -2694,6 +2694,42 @@ mod tests {
     }
 
     #[test]
+    fn test_find_iter() {
+        assert_eq!("hello".find_iter('l').next(), Some(2u));
+        assert_eq!("hello".find_iter(|c:char| c == 'o').next(), Some(4u));
+        assert!("hello".find_iter('x').next().is_none());
+        assert!("hello".find_iter(|c:char| c == 'x').next().is_none());
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter('华').next(), Some(30u));
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter(|c: char| c == '华').next(), Some(30u));
+
+        assert_eq!("hello".find_iter('l').to_owned_vec(), ~[2, 3]);
+        assert_eq!("hello".find_iter(|c:char| c == 'o').to_owned_vec(), ~[4]);
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter('华').to_owned_vec(), ~[30]);
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter(|c: char| c == '华').to_owned_vec(), ~[30]);
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter('ท').to_owned_vec(), ~[12,21]);
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter(|c: char| c == 'ท').to_owned_vec(), ~[12,21]);
+    }
+
+    #[test]
+    fn test_find_iter_rev() {
+        assert_eq!("hello".find_iter_rev('l').next(), Some(3u));
+        assert_eq!("hello".find_iter_rev(|c:char| c == 'o').next(), Some(4u));
+        assert!("hello".find_iter_rev('x').next().is_none());
+        assert!("hello".find_iter_rev(|c:char| c == 'x').next().is_none());
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter_rev('华').next(), Some(30u));
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter_rev(|c: char| c == '华').next(), Some(30u));
+
+        assert_eq!("hello".find_iter_rev('l').to_owned_vec(), ~[3, 2]);
+        assert_eq!("hello".find_iter_rev(|c:char| c == 'o').to_owned_vec(), ~[4]);
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter_rev('华').to_owned_vec(), ~[30]);
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter_rev(|c: char| c == '华').to_owned_vec(), ~[30]);
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter_rev('ท').to_owned_vec(),
+                   ~[21,12]);
+        assert_eq!("ประเทศไทย中华Việt Nam".find_iter_rev(|c: char| c == 'ท').to_owned_vec(),
+                   ~[21,12]);
+    }
+
+    #[test]
     fn test_push_str() {
         let mut s = ~"";
         s.push_str("");

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1568,6 +1568,12 @@ pub trait StrSlice<'self> {
     /// An Iterator over the string in Unicode Normalization Form KD (compatibility decomposition)
     fn nfkd_iter(&self) -> NormalizationIterator<'self>;
 
+    /// An Iterator over all indices for which `pred` matches.
+    fn find_iter<C: CharEq>(&self, pred: C) -> FindIterator<'self, C>;
+
+    /// An Iterator over all indices for which `pred` matches, in reverse.
+    fn find_iter_rev<C: CharEq>(&self, pred: C) -> RevFindIterator<'self, C>;
+
     /// Returns true if the string contains only whitespace
     ///
     /// Whitespace characters are determined by `char::is_whitespace`
@@ -1974,6 +1980,22 @@ impl<'self> StrSlice<'self> for &'self str {
             buffer: ~[],
             sorted: false,
             kind: NFKD
+        }
+    }
+
+    fn find_iter<C: CharEq>(&self, pred: C) -> FindIterator<'self, C> {
+        if pred.only_ascii() {
+            FindIterator { pred: pred, iter: FindIterB(self.byte_iter().enumerate()) }
+        } else {
+            FindIterator { pred: pred, iter: FindIterC(self.char_offset_iter()) }
+        }
+    }
+
+    fn find_iter_rev<C: CharEq>(&self, pred: C) -> RevFindIterator<'self, C>{
+        if pred.only_ascii() {
+            FindIterator { pred: pred, iter: FindIterB(self.byte_iter().enumerate()) }.invert()
+        } else {
+            FindIterator { pred: pred, iter: FindIterC(self.char_offset_iter()) }.invert()
         }
     }
 

--- a/src/libstd/str/ascii.rs
+++ b/src/libstd/str/ascii.rs
@@ -16,6 +16,7 @@ use str::StrSlice;
 use str::OwnedStr;
 use container::Container;
 use cast;
+use char::{ToChar, CharEq};
 use iter::Iterator;
 use vec::{CopyableVector, ImmutableVector, MutableVector};
 use to_bytes::IterBytes;
@@ -30,12 +31,6 @@ impl Ascii {
     #[inline]
     pub fn to_byte(self) -> u8 {
         self.chr
-    }
-
-    /// Converts a ascii character into a `char`.
-    #[inline]
-    pub fn to_char(self) -> char {
-        self.chr as char
     }
 
     /// Convert to lowercase.
@@ -63,6 +58,19 @@ impl ToStr for Ascii {
         // self.chr is always a valid utf8 byte, no need for the check
         unsafe { str::raw::from_byte(self.chr) }
     }
+}
+
+impl ToChar for Ascii {
+    #[inline]
+    fn to_char(&self) -> char { self.chr as char }
+}
+
+impl CharEq for Ascii {
+    #[inline]
+    fn matches(&self, c: char) -> bool { self.chr as char == c }
+
+    #[inline]
+    fn only_ascii(&self) -> bool { true }
 }
 
 /// Trait for converting into an ascii type.


### PR DESCRIPTION
This implements an `FindIterator` with `.find_iter()` and `.find_rev_iter()` on string slices that works like `.find()` and `.rfind()`, but returns all matches instead of just the first one.

This touches upon a few other design questions I'm having of the string library:
- In https://github.com/mozilla/rust/pull/9392, I'm trying to normalize the names for operations that operate starting from the back to `_rev`, which has met some resistance. This PR would allow removing at least `find()` and `rfind()` completely and replace them with this Iterator. 
- If we drop the reverse iterator constructors (DoubleEndedIterators already offer an method for inverting them), we'd also remove a lot of repetition and the `_rev` suffix completly - see https://github.com/mozilla/rust/issues/9391.
- The resulting `"foo".find_iter('o').nth(0)` and `"foo".find_iter('f').invert().nth(0)` would become quite long though, which touches on https://github.com/mozilla/rust/issues/9440.

---

Also as part of this PR I'm moving `str::CharEq` to `char::CharEq`, introduce a new trait `ToChar`, and implement them both for `ascii::Ascii`.

I'm doing the movement of `CharEq` because it seems to me that even though it's being intended to be used by string functions, the actual trait encapsulates something relevant for chars in general. And `str.rs` needs any chance it can get to become shorter. ;)

The `ToChar` trait is necessary for the implementation of `FindIterator` to not include two almost identical copies of the same function in both `next()` and `next_back()`
