### PR TITLE
Improve comment stripping for rustdoc.

### DIFF
--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -29,7 +29,7 @@
 //! that requires an input file to be specified, accepts an optional output
 //! file name following -o, and accepts both -h and --help as optional flags.
 //!
-//! ```
+//! ~~~{.rust}
 //! exter mod extra;
 //! use extra::getopts::*;
 //! use std::os;
@@ -75,7 +75,7 @@
 //!     };
 //!     do_work(input, output);
 //! }
-//! ```
+//! ~~~
 
 use std::cmp::Eq;
 use std::result::{Err, Ok};


### PR DESCRIPTION
There is less implicit removal of various comment styles, and it also removes
extraneous stars occasionally found in docblock comments. It turns out that the
bug for getops was just a differently formatted block.

Closes #9425
Closes #9417
