### PR TITLE
#7081: Further syntax::visit refactors

### DIFF
--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -33,7 +33,7 @@ use util::ppaux::Repr;
 
 #[deriving(Clone)]
 struct CheckLoanCtxt<'self> {
-    bccx: @BorrowckCtxt,
+    bccx: &'self BorrowckCtxt,
     dfcx_loans: &'self LoanDataFlow,
     move_data: @move_data::FlowedMoveData,
     all_loans: &'self [Loan],
@@ -60,7 +60,7 @@ impl<'self> Visitor<()> for CheckLoanCtxt<'self> {
     }
 }
 
-pub fn check_loans(bccx: @BorrowckCtxt,
+pub fn check_loans(bccx: &BorrowckCtxt,
                    dfcx_loans: &LoanDataFlow,
                    move_data: move_data::FlowedMoveData,
                    all_loans: &[Loan],

--- a/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
@@ -22,7 +22,7 @@ use syntax::ast_util;
 use syntax::codemap::Span;
 use util::ppaux::{UserString};
 
-pub fn gather_decl(bccx: @BorrowckCtxt,
+pub fn gather_decl(bccx: &BorrowckCtxt,
                    move_data: &mut MoveData,
                    decl_id: ast::NodeId,
                    _decl_span: Span,
@@ -31,7 +31,7 @@ pub fn gather_decl(bccx: @BorrowckCtxt,
     move_data.add_move(bccx.tcx, loan_path, decl_id, Declared);
 }
 
-pub fn gather_move_from_expr(bccx: @BorrowckCtxt,
+pub fn gather_move_from_expr(bccx: &BorrowckCtxt,
                              move_data: &mut MoveData,
                              move_expr: @ast::Expr,
                              cmt: mc::cmt) {
@@ -39,7 +39,7 @@ pub fn gather_move_from_expr(bccx: @BorrowckCtxt,
                                  MoveExpr(move_expr), cmt);
 }
 
-pub fn gather_move_from_pat(bccx: @BorrowckCtxt,
+pub fn gather_move_from_pat(bccx: &BorrowckCtxt,
                             move_data: &mut MoveData,
                             move_pat: @ast::Pat,
                             cmt: mc::cmt) {
@@ -47,7 +47,7 @@ pub fn gather_move_from_pat(bccx: @BorrowckCtxt,
                                  MovePat(move_pat), cmt);
 }
 
-fn gather_move_from_expr_or_pat(bccx: @BorrowckCtxt,
+fn gather_move_from_expr_or_pat(bccx: &BorrowckCtxt,
                                 move_data: &mut MoveData,
                                 move_id: ast::NodeId,
                                 move_kind: MoveKind,
@@ -66,7 +66,7 @@ fn gather_move_from_expr_or_pat(bccx: @BorrowckCtxt,
     }
 }
 
-pub fn gather_captures(bccx: @BorrowckCtxt,
+pub fn gather_captures(bccx: &BorrowckCtxt,
                        move_data: &mut MoveData,
                        closure_expr: @ast::Expr) {
     let captured_vars = bccx.capture_map.get(&closure_expr.id);
@@ -83,7 +83,7 @@ pub fn gather_captures(bccx: @BorrowckCtxt,
     }
 }
 
-pub fn gather_assignment(bccx: @BorrowckCtxt,
+pub fn gather_assignment(bccx: &BorrowckCtxt,
                          move_data: &mut MoveData,
                          assignment_id: ast::NodeId,
                          assignment_span: Span,
@@ -96,7 +96,7 @@ pub fn gather_assignment(bccx: @BorrowckCtxt,
                              assignee_id);
 }
 
-fn check_is_legal_to_move_from(bccx: @BorrowckCtxt,
+fn check_is_legal_to_move_from(bccx: &BorrowckCtxt,
                                cmt0: mc::cmt,
                                cmt: mc::cmt) -> bool {
     match cmt.cat {

--- a/src/librustc/middle/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc/middle/borrowck/gather_loans/lifetime.rs
@@ -20,7 +20,7 @@ use syntax::ast;
 use syntax::codemap::Span;
 use util::ppaux::{note_and_explain_region};
 
-pub fn guarantee_lifetime(bccx: @BorrowckCtxt,
+pub fn guarantee_lifetime(bccx: &BorrowckCtxt,
                           item_scope_id: ast::NodeId,
                           root_scope_id: ast::NodeId,
                           span: Span,
@@ -42,8 +42,8 @@ pub fn guarantee_lifetime(bccx: @BorrowckCtxt,
 ///////////////////////////////////////////////////////////////////////////
 // Private
 
-struct GuaranteeLifetimeContext {
-    bccx: @BorrowckCtxt,
+struct GuaranteeLifetimeContext<'self> {
+    bccx: &'self BorrowckCtxt,
 
     // the node id of the function body for the enclosing item
     item_scope_id: ast::NodeId,
@@ -58,7 +58,7 @@ struct GuaranteeLifetimeContext {
     cmt_original: mc::cmt
 }
 
-impl GuaranteeLifetimeContext {
+impl<'self> GuaranteeLifetimeContext<'self> {
     fn tcx(&self) -> ty::ctxt {
         self.bccx.tcx
     }

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -64,8 +64,8 @@ mod gather_moves;
 /// No good.  Instead what will happen is that `root_ub` will be set to the
 /// body of the while loop and we will refuse to root the pointer `&*x`
 /// because it would have to be rooted for a region greater than `root_ub`.
-struct GatherLoanCtxt {
-    bccx: @BorrowckCtxt,
+struct GatherLoanCtxt<'self> {
+    bccx: &'self BorrowckCtxt,
     id_range: id_range,
     move_data: @mut move_data::MoveData,
     all_loans: @mut ~[Loan],
@@ -73,7 +73,7 @@ struct GatherLoanCtxt {
     repeating_ids: ~[ast::NodeId]
 }
 
-impl visit::Visitor<()> for GatherLoanCtxt {
+impl<'self> visit::Visitor<()> for GatherLoanCtxt<'self> {
     fn visit_expr(&mut self, ex:@Expr, _:()) {
         gather_loans_in_expr(self, ex);
     }
@@ -100,7 +100,7 @@ impl visit::Visitor<()> for GatherLoanCtxt {
     fn visit_item(&mut self, _:@ast::item, _:()) { }
 }
 
-pub fn gather_loans(bccx: @BorrowckCtxt,
+pub fn gather_loans(bccx: &BorrowckCtxt,
                     decl: &ast::fn_decl,
                     body: &ast::Block)
                     -> (id_range, @mut ~[Loan], @mut move_data::MoveData) {
@@ -315,7 +315,7 @@ fn gather_loans_in_expr(this: &mut GatherLoanCtxt,
     }
 }
 
-impl GatherLoanCtxt {
+impl<'self> GatherLoanCtxt<'self> {
     pub fn tcx(&self) -> ty::ctxt { self.bccx.tcx }
 
     pub fn push_repeating_id(&mut self, id: ast::NodeId) {
@@ -532,7 +532,7 @@ impl GatherLoanCtxt {
             //    }
         // }
 
-        fn check_mutability(bccx: @BorrowckCtxt,
+        fn check_mutability(bccx: &BorrowckCtxt,
                             borrow_span: Span,
                             cmt: mc::cmt,
                             req_mutbl: LoanMutability) {

--- a/src/librustc/middle/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc/middle/borrowck/gather_loans/restrictions.rs
@@ -23,7 +23,7 @@ pub enum RestrictionResult {
     SafeIf(@LoanPath, ~[Restriction])
 }
 
-pub fn compute_restrictions(bccx: @BorrowckCtxt,
+pub fn compute_restrictions(bccx: &BorrowckCtxt,
                             span: Span,
                             cmt: mc::cmt,
                             restr: RestrictionSet) -> RestrictionResult {
@@ -39,13 +39,13 @@ pub fn compute_restrictions(bccx: @BorrowckCtxt,
 ///////////////////////////////////////////////////////////////////////////
 // Private
 
-struct RestrictionsContext {
-    bccx: @BorrowckCtxt,
+struct RestrictionsContext<'self> {
+    bccx: &'self BorrowckCtxt,
     span: Span,
     cmt_original: mc::cmt
 }
 
-impl RestrictionsContext {
+impl<'self> RestrictionsContext<'self> {
     fn tcx(&self) -> ty::ctxt {
         self.bccx.tcx
     }

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -61,12 +61,10 @@ impl Clone for LoanDataFlowOperator {
 
 pub type LoanDataFlow = DataFlowContext<LoanDataFlowOperator>;
 
-struct BorrowckVisitor;
-
-impl Visitor<@BorrowckCtxt> for BorrowckVisitor {
+impl Visitor<()> for BorrowckCtxt {
     fn visit_fn(&mut self, fk:&fn_kind, fd:&fn_decl,
-                b:&Block, s:Span, n:NodeId, e:@BorrowckCtxt) {
-        borrowck_fn(self, fk, fd, b, s, n, e);
+                b:&Block, s:Span, n:NodeId, _:()) {
+        borrowck_fn(self, fk, fd, b, s, n);
     }
 }
 
@@ -78,7 +76,7 @@ pub fn check_crate(
     capture_map: moves::CaptureMap,
     crate: &ast::Crate) -> (root_map, write_guard_map)
 {
-    let bccx = @BorrowckCtxt {
+    let mut bccx = BorrowckCtxt {
         tcx: tcx,
         method_map: method_map,
         moves_map: moves_map,
@@ -96,9 +94,9 @@ pub fn check_crate(
             guaranteed_paths: 0,
         }
     };
+    let bccx = &mut bccx;
 
-    let mut v = BorrowckVisitor;
-    visit::walk_crate(&mut v, crate, bccx);
+    visit::walk_crate(bccx, crate, ());
 
     if tcx.sess.borrowck_stats() {
         io::println("--- borrowck stats ---");
@@ -116,20 +114,19 @@ pub fn check_crate(
 
     return (bccx.root_map, bccx.write_guard_map);
 
-    fn make_stat(bccx: &BorrowckCtxt, stat: uint) -> ~str {
+    fn make_stat(bccx: &mut BorrowckCtxt, stat: uint) -> ~str {
         let stat_f = stat as float;
         let total = bccx.stats.guaranteed_paths as float;
         fmt!("%u (%.0f%%)", stat  , stat_f * 100f / total)
     }
 }
 
-fn borrowck_fn(v: &mut BorrowckVisitor,
+fn borrowck_fn(this: &mut BorrowckCtxt,
                fk: &visit::fn_kind,
                decl: &ast::fn_decl,
                body: &ast::Block,
                sp: Span,
-               id: ast::NodeId,
-               this: @BorrowckCtxt) {
+               id: ast::NodeId) {
     match fk {
         &visit::fk_anon(*) |
         &visit::fk_fn_block(*) => {
@@ -166,7 +163,7 @@ fn borrowck_fn(v: &mut BorrowckVisitor,
         }
     }
 
-    visit::walk_fn(v, fk, decl, body, sp, id, this);
+    visit::walk_fn(this, fk, decl, body, sp, id, ());
 }
 
 // ----------------------------------------------------------------------

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -375,8 +375,6 @@ enum AnyVisitor {
     NewVisitor(@mut visit::Visitor<()>),
 }
 
-type VCObj = @mut Visitor<@mut Context>;
-
 struct Context {
     // All known lint modes (string versions)
     dict: @LintDict,


### PR DESCRIPTION
r? anyone.

Part of #7081.

More refactorings of the syntax::visit::Visitor implementations, folding so-called "environments" into the visitor impl when the latter was previously a trivial unit struct.

As usual, this refactoring only applies when the environments are not actually carrying state that is meant to be pushed and popped as we traverse the expression.  (For an example where the environment _isn't_ just passed through, see the `visit_fn` in `liveness.rs`.)

Got rid of a bit of @-allocation in borrowck.

Both cases should be pure-refactorings.
