### PR TITLE
Added is_control() function, method, tests, and documentation.

### DIFF
--- a/src/libstd/char.rs
+++ b/src/libstd/char.rs
@@ -128,6 +128,14 @@ pub fn is_alphanumeric(c: char) -> bool {
         || general_category::No(c)
 }
 
+///
+/// Indicates whether a character is a control character. Control
+/// characters are defined in terms of the Unicode General Category
+/// 'Cc'.
+///
+#[inline]
+pub fn is_control(c: char) -> bool { general_category::Cc(c) }
+
 /// Indicates whether the character is numeric (Nd, Nl, or No)
 #[inline]
 pub fn is_digit(c: char) -> bool {
@@ -354,6 +362,7 @@ pub trait Char {
     fn is_uppercase(&self) -> bool;
     fn is_whitespace(&self) -> bool;
     fn is_alphanumeric(&self) -> bool;
+    fn is_control(&self) -> bool;
     fn is_digit(&self) -> bool;
     fn is_digit_radix(&self, radix: uint) -> bool;
     fn to_digit(&self, radix: uint) -> Option<uint>;
@@ -383,6 +392,8 @@ impl Char for char {
     fn is_whitespace(&self) -> bool { is_whitespace(*self) }
 
     fn is_alphanumeric(&self) -> bool { is_alphanumeric(*self) }
+
+    fn is_control(&self) -> bool { is_control(*self) }
 
     fn is_digit(&self) -> bool { is_digit(*self) }
 
@@ -492,6 +503,19 @@ fn test_to_digit() {
     assert_eq!('Z'.to_digit(36u), Some(35u));
     assert_eq!(' '.to_digit(10u), None);
     assert_eq!('$'.to_digit(36u), None);
+}
+
+#[test]
+fn test_is_control() {
+    assert!('\u0000'.is_control());
+    assert!('\u0003'.is_control());
+    assert!('\u0006'.is_control());
+    assert!('\u0009'.is_control());
+    assert!('\u007f'.is_control());
+    assert!('\u0092'.is_control());
+    assert!(!'\u0020'.is_control());
+    assert!(!'\u0055'.is_control());
+    assert!(!'\u0068'.is_control());
 }
 
 #[test]


### PR DESCRIPTION
In "/src/libstd/char.rs", there are function and method definitions for `is_lowercase()`, `is_uppercase()`, `is_whitespace()`, etc. However, there was no function or method for control characters, so I added the `is_control()` function and method definitions along with documentation and tests. Running `./configure && make check` shows that all tests for `is_control()` pass.
