### PR TITLE
Part of #7081: Fold remaining typeck's visit envs into visitor structs

### DIFF
--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -37,12 +37,12 @@ pub fn check_match(fcx: @mut FnCtxt,
     // Typecheck the patterns first, so that we get types for all the
     // bindings.
     for arm in arms.iter() {
-        let pcx = pat_ctxt {
+        let mut pcx = pat_ctxt {
             fcx: fcx,
             map: pat_id_map(tcx.def_map, arm.pats[0]),
         };
 
-        for p in arm.pats.iter() { check_pat(&pcx, *p, discrim_ty);}
+        for p in arm.pats.iter() { check_pat(&mut pcx, *p, discrim_ty);}
     }
 
     // The result of the match is the common supertype of all the

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -720,11 +720,11 @@ pub fn early_resolve_expr(ex: @ast::Expr,
     }
 }
 
-fn resolve_expr(v: &mut VtableResolveVisitor,
-                ex: @ast::Expr,
-                fcx: @mut FnCtxt) {
+fn resolve_expr(fcx: @mut FnCtxt,
+                ex: @ast::Expr) {
+    let mut fcx = fcx;
     early_resolve_expr(ex, fcx, false);
-    visit::walk_expr(v, ex, fcx);
+    visit::walk_expr(&mut fcx, ex, ());
 }
 
 pub fn resolve_impl(ccx: @mut CrateCtxt, impl_item: @ast::item) {
@@ -771,13 +771,11 @@ pub fn resolve_impl(ccx: @mut CrateCtxt, impl_item: @ast::item) {
     }
 }
 
-struct VtableResolveVisitor;
-
-impl visit::Visitor<@mut FnCtxt> for VtableResolveVisitor {
-    fn visit_expr(&mut self, ex:@ast::Expr, e:@mut FnCtxt) {
-        resolve_expr(self, ex, e);
+impl visit::Visitor<()> for @mut FnCtxt {
+    fn visit_expr(&mut self, ex:@ast::Expr, _:()) {
+        resolve_expr(*self, ex);
     }
-    fn visit_item(&mut self, _:@ast::item, _:@mut FnCtxt) {
+    fn visit_item(&mut self, _:@ast::item, _:()) {
         // no-op
     }
 }
@@ -785,6 +783,6 @@ impl visit::Visitor<@mut FnCtxt> for VtableResolveVisitor {
 // Detect points where a trait-bounded type parameter is
 // instantiated, resolve the impls for the parameters.
 pub fn resolve_in_block(fcx: @mut FnCtxt, bl: &ast::Block) {
-    let mut visitor = VtableResolveVisitor;
-    visit::walk_block(&mut visitor, bl, fcx);
+    let mut fcx = fcx;
+    visit::walk_block(&mut fcx, bl, ());
 }


### PR DESCRIPTION
r? anyone

Also got rid of a bit of `@mut` allocation.  (Though not the monster that is `@mut FnCtxt`; that case is documented already on #7081; if we attack it, it will probably be its own ticket, not part of #7081.)
