### PR TITLE
Don't use libc::exit. #9473

### DIFF
--- a/src/librust/rust.rs
+++ b/src/librust/rust.rs
@@ -45,7 +45,7 @@ impl ValidUsage {
 
 enum Action {
     Call(extern "Rust" fn(args: &[~str]) -> ValidUsage),
-    CallMain(&'static str, extern "Rust" fn(&[~str])),
+    CallMain(&'static str, extern "Rust" fn(&[~str]) -> int),
 }
 
 enum UsageSource<'self> {
@@ -186,18 +186,17 @@ fn cmd_run(args: &[~str]) -> ValidUsage {
     }
 }
 
-fn invoke(prog: &str, args: &[~str], f: &fn(&[~str])) {
+fn invoke(prog: &str, args: &[~str], f: &fn(&[~str]) -> int) -> int {
     let mut osargs = ~[prog.to_owned()];
     osargs.push_all_move(args.to_owned());
-    f(osargs);
+    f(osargs)
 }
 
 fn do_command(command: &Command, args: &[~str]) -> ValidUsage {
     match command.action {
         Call(f) => f(args),
         CallMain(prog, f) => {
-            invoke(prog, args, f);
-            Valid(0)
+            Valid(invoke(prog, args, f))
         }
     }
 }

--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -394,13 +394,14 @@ pub fn monitor(f: ~fn(@diagnostic::Emitter)) {
 }
 
 pub fn main() {
-    let args = os::args();
-    main_args(args);
+    std::os::set_exit_status(main_args(std::os::args()));
 }
 
-pub fn main_args(args: &[~str]) {
+pub fn main_args(args: &[~str]) -> int {
     let owned_args = args.to_owned();
     do monitor |demitter| {
         run_compiler(owned_args, demitter);
     }
+
+    return 0;
 }

--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -517,8 +517,7 @@ pub fn run_line(repl: &mut Repl, input: @io::Reader, out: @io::Writer, line: ~st
 }
 
 pub fn main() {
-    let args = os::args();
-    main_args(args);
+    os::set_exit_status(main_args(os::args()));
 }
 
 struct Completer;
@@ -534,7 +533,7 @@ impl CompletionCb for Completer {
     }
 }
 
-pub fn main_args(args: &[~str]) {
+pub fn main_args(args: &[~str]) -> int {
     #[fixed_stack_segment]; #[inline(never)];
 
     let input = io::stdin();
@@ -576,6 +575,8 @@ pub fn main_args(args: &[~str]) {
             }
         }
     }
+
+    return 0;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This can cause unexpected errors in the runtime when done while
scheduler threads are still initializing. Required some restructuring
of the main_args functions in our libraries.
