### PR TITLE
Ensure that skipped items aren't encoded

### DIFF
--- a/src/test/auxiliary/cfg_inner_static.rs
+++ b/src/test/auxiliary/cfg_inner_static.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// this used to just ICE on compiling
+pub fn foo() {
+    if cfg!(foo) {
+        static a: int = 3;
+        a
+    } else { 3 };
+}

--- a/src/test/run-pass/cfg_inner_static.rs
+++ b/src/test/run-pass/cfg_inner_static.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:cfg_inner_static.rs
+// xfail-fast
+
+extern mod cfg_inner_static;
+
+fn main() {
+    cfg_inner_static::foo();
+}


### PR DESCRIPTION
If an item is skipped due to it being unreachable or for some optimization, then
it shouldn't be encoded into the metadata (because it wasn't present in the
first place).
