### PR TITLE
Don't die in try_unsafe_borrow if tls isn't ready

### DIFF
--- a/src/libstd/rt/local_ptr.rs
+++ b/src/libstd/rt/local_ptr.rs
@@ -129,12 +129,16 @@ pub unsafe fn unsafe_borrow<T>() -> *mut T {
 }
 
 pub unsafe fn try_unsafe_borrow<T>() -> Option<*mut T> {
-    let key = tls_key();
-    let void_ptr = tls::get(key);
-    if void_ptr.is_null() {
-        None
-    } else {
-        Some(void_ptr as *mut T)
+    match maybe_tls_key() {
+        Some(key) => {
+            let void_ptr = tls::get(key);
+            if void_ptr.is_null() {
+                None
+            } else {
+                Some(void_ptr as *mut T)
+            }
+        }
+        None => None
     }
 }
 

--- a/src/test/run-pass/logging_before_rt_started.rs
+++ b/src/test/run-pass/logging_before_rt_started.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// exec-env:RUST_LOG=std::ptr
+// xfail-fast this would cause everything to print forever on windows...
+
+// In issue #9487, it was realized that std::ptr was invoking the logging
+// infrastructure, and when std::ptr was used during runtime initialization,
+// this caused some serious problems. The problems have since been fixed, but
+// this test will trigger "output during runtime initialization" to make sure
+// that the bug isn't re-introduced.
+
+fn main() {}


### PR DESCRIPTION
If there's no TLS key just yet, then there's nothing to unsafely borrow, so
continue returning None. This prevents causing the runtime to abort itself when
logging before the runtime is fully initialized.

Closes #9487

r? @brson
