### PR TITLE
#7081 syntax::visit refactor remainder

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2194,11 +2194,13 @@ pub fn trans_enum_def(ccx: @mut CrateContext, enum_definition: &ast::enum_def,
     }
 }
 
-pub struct TransItemVisitor;
+pub struct TransItemVisitor {
+    ccx: @mut CrateContext,
+}
 
-impl Visitor<@mut CrateContext> for TransItemVisitor {
-    fn visit_item(&mut self, i: @ast::item, ccx: @mut CrateContext) {
-        trans_item(ccx, i);
+impl Visitor<()> for TransItemVisitor {
+    fn visit_item(&mut self, i: @ast::item, _:()) {
+        trans_item(self.ccx, i);
     }
 }
 
@@ -2235,8 +2237,8 @@ pub fn trans_item(ccx: @mut CrateContext, item: &ast::item) {
         } else {
             // Be sure to travel more than just one layer deep to catch nested
             // items in blocks and such.
-            let mut v = TransItemVisitor;
-            v.visit_block(body, ccx);
+            let mut v = TransItemVisitor{ ccx: ccx };
+            v.visit_block(body, ());
         }
       }
       ast::item_impl(ref generics, _, _, ref ms) => {
@@ -2288,8 +2290,8 @@ pub fn trans_item(ccx: @mut CrateContext, item: &ast::item) {
         // functions, but the trait still needs to be walked. Otherwise default
         // methods with items will not get translated and will cause ICE's when
         // metadata time comes around.
-        let mut v = TransItemVisitor;
-        visit::walk_item(&mut v, item, ccx);
+        let mut v = TransItemVisitor{ ccx: ccx };
+        visit::walk_item(&mut v, item, ());
       }
       _ => {/* fall through */ }
     }

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -61,9 +61,9 @@ pub fn trans_impl(ccx: @mut CrateContext,
     // Both here and below with generic methods, be sure to recurse and look for
     // items that we need to translate.
     if !generics.ty_params.is_empty() {
-        let mut v = TransItemVisitor;
+        let mut v = TransItemVisitor{ ccx: ccx };
         for method in methods.iter() {
-            visit::walk_method_helper(&mut v, *method, ccx);
+            visit::walk_method_helper(&mut v, *method, ());
         }
         return;
     }
@@ -80,8 +80,8 @@ pub fn trans_impl(ccx: @mut CrateContext,
                          None,
                          llfn);
         } else {
-            let mut v = TransItemVisitor;
-            visit::walk_method_helper(&mut v, *method, ccx);
+            let mut v = TransItemVisitor{ ccx: ccx };
+            visit::walk_method_helper(&mut v, *method, ());
         }
     }
 }

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -61,17 +61,18 @@ pub fn field_exprs(fields: ~[ast::Field]) -> ~[@ast::Expr] {
 }
 
 struct LoopQueryVisitor<'self> {
-    p: &'self fn(&ast::Expr_) -> bool
+    p: &'self fn(&ast::Expr_) -> bool,
+    flag: bool,
 }
 
-impl<'self> Visitor<@mut bool> for LoopQueryVisitor<'self> {
-    fn visit_expr(&mut self, e: @ast::Expr, flag: @mut bool) {
-        *flag |= (self.p)(&e.node);
+impl<'self> Visitor<()> for LoopQueryVisitor<'self> {
+    fn visit_expr(&mut self, e: @ast::Expr, _: ()) {
+        self.flag |= (self.p)(&e.node);
         match e.node {
           // Skip inner loops, since a break in the inner loop isn't a
           // break inside the outer loop
           ast::ExprLoop(*) | ast::ExprWhile(*) => {}
-          _ => visit::walk_expr(self, e, flag)
+          _ => visit::walk_expr(self, e, ())
         }
     }
 }
@@ -79,34 +80,35 @@ impl<'self> Visitor<@mut bool> for LoopQueryVisitor<'self> {
 // Takes a predicate p, returns true iff p is true for any subexpressions
 // of b -- skipping any inner loops (loop, while, loop_body)
 pub fn loop_query(b: &ast::Block, p: &fn(&ast::Expr_) -> bool) -> bool {
-    let rs = @mut false;
     let mut v = LoopQueryVisitor {
         p: p,
+        flag: false,
     };
-    visit::walk_block(&mut v, b, rs);
-    return *rs;
+    visit::walk_block(&mut v, b, ());
+    return v.flag;
 }
 
 struct BlockQueryVisitor<'self> {
-    p: &'self fn(@ast::Expr) -> bool
+    p: &'self fn(@ast::Expr) -> bool,
+    flag: bool,
 }
 
-impl<'self> Visitor<@mut bool> for BlockQueryVisitor<'self> {
-    fn visit_expr(&mut self, e: @ast::Expr, flag: @mut bool) {
-        *flag |= (self.p)(e);
-        visit::walk_expr(self, e, flag)
+impl<'self> Visitor<()> for BlockQueryVisitor<'self> {
+    fn visit_expr(&mut self, e: @ast::Expr, _:()) {
+        self.flag |= (self.p)(e);
+        visit::walk_expr(self, e, ())
     }
 }
 
 // Takes a predicate p, returns true iff p is true for any subexpressions
 // of b -- skipping any inner loops (loop, while, loop_body)
 pub fn block_query(b: &ast::Block, p: &fn(@ast::Expr) -> bool) -> bool {
-    let rs = @mut false;
     let mut v = BlockQueryVisitor {
         p: p,
+        flag: false,
     };
-    visit::walk_block(&mut v, b, rs);
-    return *rs;
+    visit::walk_block(&mut v, b, ());
+    return v.flag;
 }
 
 pub fn local_rhs_span(l: @ast::Local, def: Span) -> Span {


### PR DESCRIPTION
r? anyone

Part of #7081.

Removed many unnecessary context arguments, turning them into visitors.  Removed some @allocation.

If this lands, then I think the only thing left that is unaddressed are:
- the various lint visitors, and
- middle/privacy.rs, which has `impl<'self> Visitor<&'self method_map> for PrivacyVisitor`
