### PR TITLE
improve C ABI

### DIFF
--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -18,10 +18,62 @@ use middle::trans::cabi_mips;
 use middle::trans::type_::Type;
 use syntax::abi::{X86, X86_64, Arm, Mips};
 
+#[deriving(Clone, Eq)]
+pub enum ArgKind {
+    /// Pass the argument directly using the normal converted
+    /// LLVM type or by coercing to another specified type
+    Direct,
+    /// Pass the argument indirectly via a hidden pointer
+    Indirect
+}
+
+/// Information about how a specific C type
+/// should be passed to or returned from a function
+///
+/// This is borrowed from clang's ABIInfo.h
 #[deriving(Clone)]
-pub struct LLVMType {
-    cast: bool,
-    ty: Type
+pub struct ArgType {
+    kind: ArgKind,
+    /// Original LLVM type
+    ty: Type,
+    /// Coerced LLVM Type
+    cast: option::Option<Type>,
+    /// Dummy argument, which is emitted before the real argument
+    pad: option::Option<Type>,
+    /// LLVM attribute of argument
+    attr: option::Option<Attribute>
+}
+
+impl ArgType {
+    pub fn direct(ty: Type, cast: option::Option<Type>,
+                            pad: option::Option<Type>,
+                            attr: option::Option<Attribute>) -> ArgType {
+        ArgType {
+            kind: Direct,
+            ty: ty,
+            cast: cast,
+            pad: pad,
+            attr: attr
+        }
+    }
+
+    pub fn indirect(ty: Type, attr: option::Option<Attribute>) -> ArgType {
+        ArgType {
+            kind: Indirect,
+            ty: ty,
+            cast: option::None,
+            pad: option::None,
+            attr: attr
+        }
+    }
+
+    pub fn is_direct(&self) -> bool {
+        return self.kind == Direct;
+    }
+
+    pub fn is_indirect(&self) -> bool {
+        return self.kind == Indirect;
+    }
 }
 
 /// Metadata describing how the arguments to a native function
@@ -30,22 +82,11 @@ pub struct LLVMType {
 /// I will do my best to describe this structure, but these
 /// comments are reverse-engineered and may be inaccurate. -NDM
 pub struct FnType {
-    /// The LLVM types of each argument. If the cast flag is true,
-    /// then the argument should be cast, typically because the
-    /// official argument type will be an int and the rust type is i8
-    /// or something like that.
-    arg_tys: ~[LLVMType],
-
-    /// A list of attributes to be attached to each argument (parallel
-    /// the `arg_tys` array). If the attribute for a given is Some,
-    /// then the argument should be passed by reference.
-    attrs: ~[option::Option<Attribute>],
+    /// The LLVM types of each argument.
+    arg_tys: ~[ArgType],
 
     /// LLVM return type.
-    ret_ty: LLVMType,
-
-    /// If true, then an implicit pointer should be added for the result.
-    sret: bool
+    ret_ty: ArgType,
 }
 
 pub fn compute_abi_info(ccx: &mut CrateContext,

--- a/src/librustc/middle/trans/cabi_x86.rs
+++ b/src/librustc/middle/trans/cabi_x86.rs
@@ -21,16 +21,10 @@ pub fn compute_abi_info(ccx: &mut CrateContext,
                         rty: Type,
                         ret_def: bool) -> FnType {
     let mut arg_tys = ~[];
-    let mut attrs = ~[];
 
     let ret_ty;
-    let sret;
     if !ret_def {
-        ret_ty = LLVMType {
-            cast: false,
-            ty: Type::void(),
-        };
-        sret = false;
+        ret_ty = ArgType::direct(Type::void(), None, None, None);
     } else if rty.kind() == Struct {
         // Returning a structure. Most often, this will use
         // a hidden first argument. On some platforms, though,
@@ -58,43 +52,22 @@ pub fn compute_abi_info(ccx: &mut CrateContext,
 
         match strategy {
             RetValue(t) => {
-                ret_ty = LLVMType {
-                    cast: true,
-                    ty: t
-                };
-                sret = false;
+                ret_ty = ArgType::direct(rty, Some(t), None, None);
             }
             RetPointer => {
-                arg_tys.push(LLVMType {
-                    cast: false,
-                    ty: rty.ptr_to()
-                });
-                attrs.push(Some(StructRetAttribute));
-
-                ret_ty = LLVMType {
-                    cast: false,
-                    ty: Type::void(),
-                };
-                sret = true;
+                ret_ty = ArgType::indirect(rty, Some(StructRetAttribute));
             }
         }
     } else {
-        ret_ty = LLVMType {
-            cast: false,
-            ty: rty
-        };
-        sret = false;
+        ret_ty = ArgType::direct(rty, None, None, None);
     }
 
     for &a in atys.iter() {
-        arg_tys.push(LLVMType { cast: false, ty: a });
-        attrs.push(None);
+        arg_tys.push(ArgType::direct(a, None, None, None));
     }
 
     return FnType {
         arg_tys: arg_tys,
         ret_ty: ret_ty,
-        attrs: attrs,
-        sret: sret
     };
 }

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -22,8 +22,6 @@ use middle::trans::context::CrateContext;
 use middle::trans::type_::Type;
 
 use std::num;
-use std::option;
-use std::option::Option;
 use std::vec;
 
 #[deriving(Clone, Eq)]
@@ -340,50 +338,34 @@ pub fn compute_abi_info(_ccx: &mut CrateContext,
                         ret_def: bool) -> FnType {
     fn x86_64_ty(ty: Type,
                  is_mem_cls: &fn(cls: &[RegClass]) -> bool,
-                 attr: Attribute) -> (LLVMType, Option<Attribute>) {
+                 attr: Attribute) -> ArgType {
 
-        let (cast, attr, ty) = if !ty.is_reg_ty() {
+        if !ty.is_reg_ty() {
             let cls = classify_ty(ty);
             if is_mem_cls(cls) {
-                (false, option::Some(attr), ty.ptr_to())
+                ArgType::indirect(ty, Some(attr))
             } else {
-                (true, option::None, llreg_ty(cls))
+                ArgType::direct(ty, Some(llreg_ty(cls)), None, None)
             }
         } else {
-            (false, option::None, ty)
-        };
-
-        (LLVMType { cast: cast, ty: ty }, attr)
+            ArgType::direct(ty, None, None, None)
+        }
     }
 
     let mut arg_tys = ~[];
-    let mut attrs = ~[];
     for t in atys.iter() {
-        let (ty, attr) = x86_64_ty(*t, |cls| cls.is_pass_byval(), ByValAttribute);
+        let ty = x86_64_ty(*t, |cls| cls.is_pass_byval(), ByValAttribute);
         arg_tys.push(ty);
-        attrs.push(attr);
     }
-    let (ret_ty, ret_attr) = x86_64_ty(rty, |cls| cls.is_ret_bysret(),
-                                       StructRetAttribute);
-    let mut ret_ty = ret_ty;
-    let sret = ret_attr.is_some();
-    if sret {
-        arg_tys = vec::append(~[ret_ty], arg_tys);
-        ret_ty = LLVMType {
-                   cast:  false,
-                   ty: Type::void()
-                 };
-        attrs = vec::append(~[ret_attr], attrs);
-    } else if !ret_def {
-        ret_ty = LLVMType {
-                   cast: false,
-                   ty: Type::void()
-                 };
-    }
+
+    let ret_ty = if ret_def {
+        x86_64_ty(rty, |cls| cls.is_ret_bysret(), StructRetAttribute)
+    } else {
+        ArgType::direct(Type::void(), None, None, None)
+    };
+
     return FnType {
         arg_tys: arg_tys,
         ret_ty: ret_ty,
-        attrs: attrs,
-        sret: sret
     };
 }


### PR DESCRIPTION
I borrow some ideas from clang's ABIInfo.h and TargetInfo.cpp.
LLVMType is replaced with ArgType, which is similar to clang's ABIArgInfo,
and I also merge attrs of FnType into it.

Now ABI implementation doesn't need to insert hidden return pointer
to arg_tys of FnType. Instead it is handled in foreign.rs.

This change also fixes LLVM assertion failure when compiling MIPS target.
