### PR TITLE
Added standalone clone() and deep_clone() functions.

### DIFF
--- a/src/libstd/clone.rs
+++ b/src/libstd/clone.rs
@@ -117,6 +117,11 @@ extern_fn_clone!(A, B, C, D, E, F)
 extern_fn_clone!(A, B, C, D, E, F, G)
 extern_fn_clone!(A, B, C, D, E, F, G, H)
 
+/// Standalone function for invoking `Clone`
+pub fn clone<T: Clone>(o: &T) -> T {
+    o.clone()
+}
+
 /// A trait distinct from `Clone` which represents "deep copies" of things like
 /// managed boxes which would otherwise not be copied.
 pub trait DeepClone {
@@ -197,6 +202,11 @@ extern_fn_deep_clone!(A, B, C, D, E, F)
 extern_fn_deep_clone!(A, B, C, D, E, F, G)
 extern_fn_deep_clone!(A, B, C, D, E, F, G, H)
 
+/// Standalone function for invoking `DeepClone`
+pub fn deep_clone<T: DeepClone>(o: &T) -> T {
+    o.deep_clone()
+}
+
 #[test]
 fn test_owned_clone() {
     let a = ~5i;
@@ -252,4 +262,25 @@ fn test_extern_fn_clone() {
     let _ = test_fn_a.deep_clone();
     let _ = test_fn_b::<int>.deep_clone();
     let _ = test_fn_c.deep_clone();
+}
+
+#[test]
+fn test_standalone_fn() {
+    use iter::Iterator;
+    use vec::ImmutableVector;
+
+    let a = ~5u;
+    let b = ~6u;
+    let c = clone(&a);
+    let d = deep_clone(&b);
+    assert_eq!(a, c);
+    assert_eq!(b, d);
+
+    let e = ~[1, 2, 3, 4];
+    let f = e.iter().map(clone).to_owned_vec();
+    assert_eq!(e, f);
+
+    let g = ~[5, 6, 7, 8];
+    let h = g.iter().map(deep_clone).to_owned_vec();
+    assert_eq!(g, h);
 }

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -42,6 +42,7 @@ pub use result::{Result, Ok, Err};
 pub use io::{print, println};
 pub use iter::range;
 pub use from_str::from_str;
+pub use clone::{clone, deep_clone};
 
 // Reexported types and traits
 pub use c_str::ToCStr;


### PR DESCRIPTION
Right now, if you have an `Iterator<&T>`, like you get with `vec.iter()`, then for getting an `Iterator<T>` you have to do either of these:

```
// Only works for implicit copyable T, and can be confusing due to many pointers/sigils:
[1, 2, 3, 4].iter().map(|x| *x)...  
[1, 2, 3, 4].iter().map(|&x| x)...  

// Works for anything cloneable, but is long and can confuse the matters more due to autoderef:
[1, 2, 3, 4].iter().map(|x| x.clone())... 
```

These issues come regularly up while explaining `Iterators` to people on IRC, or for writing short understandable examples.

Having a standalone function of `clone` eases the situation: It's signature is `&T -> T`, and `map` transforms `A -> B`. Therefore `map(clone)` is easily explainable as removing an layer of `&` by making an copy through it:

```
[1, 2, 3, 4].iter().map(clone)... 
```

Just like `std::from_str::from_str`, these two functions are basically just workarounds for not being able to import associated functions from traits.
