### PR TITLE
extra::url: Make Url and UserInfo public

### DIFF
--- a/src/libextra/url.rs
+++ b/src/libextra/url.rs
@@ -21,7 +21,7 @@ use std::to_bytes;
 use std::uint;
 
 #[deriving(Clone, Eq)]
-struct Url {
+pub struct Url {
     scheme: ~str,
     user: Option<UserInfo>,
     host: ~str,
@@ -32,7 +32,7 @@ struct Url {
 }
 
 #[deriving(Clone, Eq)]
-struct UserInfo {
+pub struct UserInfo {
     user: ~str,
     pass: Option<~str>
 }


### PR DESCRIPTION
Some external projects e.g. rust-http used them without error due to broken cross-crate visibility.
Now it is fixed, so we have to make them public.
