### PR TITLE
Fix ICE caused by my previous patch, 

### DIFF
--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -431,10 +431,10 @@ impl<'self> LookupContext<'self> {
 
             Candidate {
                 rcvr_match_condition: RcvrMatchesIfObject(did),
-                rcvr_substs: trait_ref.substs.clone(),
+                rcvr_substs: new_trait_ref.substs.clone(),
                 method_ty: m,
                 origin: method_object(method_object {
-                        trait_id: trait_ref.def_id,
+                        trait_id: new_trait_ref.def_id,
                         object_trait_id: did,
                         method_num: method_num,
                         real_index: vtable_index

--- a/src/test/run-pass/issue-9394-inherited-trait-calls.rs
+++ b/src/test/run-pass/issue-9394-inherited-trait-calls.rs
@@ -10,6 +10,10 @@
 
 trait Base: Base2 + Base3{
     fn foo(&self) -> ~str;
+    fn foo1(&self) -> ~str;
+    fn foo2(&self) -> ~str{
+        ~"base foo2"
+    }
 }
 
 trait Base2: Base3{
@@ -29,6 +33,9 @@ struct X;
 impl Base for X {
     fn foo(&self) -> ~str{
         ~"base foo"
+    }
+    fn foo1(&self) -> ~str{
+        ~"base foo1"
     }
 
 }
@@ -56,6 +63,8 @@ pub fn main() {
     let s = &n as &Super;
     assert_eq!(s.bar(),~"super bar");
     assert_eq!(s.foo(),~"base foo");
+    assert_eq!(s.foo1(),~"base foo1");
+    assert_eq!(s.foo2(),~"base foo2");
     assert_eq!(s.baz(),~"base2 baz");
     assert_eq!(s.root(),~"base3 root");
 }


### PR DESCRIPTION
that is, if super trait had more methods, tnen subtrait, compiling would fail. I simply forgot to update
variable name. Updated test case , too.
