### PR TITLE
a few optimizations to rustc::middle::trans

### DIFF
--- a/src/librustc/back/upcall.rs
+++ b/src/librustc/back/upcall.rs
@@ -9,9 +9,8 @@
 // except according to those terms.
 
 
-use driver::session;
 use middle::trans::base;
-use middle::trans::type_::{Type, CrateTypes};
+use middle::trans::type_::{CrateTypes};
 use lib::llvm::{ModuleRef, ValueRef};
 
 pub struct Upcalls {

--- a/src/librustc/back/upcall.rs
+++ b/src/librustc/back/upcall.rs
@@ -11,7 +11,7 @@
 
 use driver::session;
 use middle::trans::base;
-use middle::trans::type_::Type;
+use middle::trans::type_::{Type, CrateTypes};
 use lib::llvm::{ModuleRef, ValueRef};
 
 pub struct Upcalls {
@@ -22,30 +22,30 @@ pub struct Upcalls {
 
 macro_rules! upcall (
     (fn $name:ident($($arg:expr),+) -> $ret:expr) => ({
-        let fn_ty = Type::func([ $($arg),* ], &$ret);
+        let fn_ty = CrateTypes::func_([ $($arg),* ], &$ret);
         base::decl_cdecl_fn(llmod, ~"upcall_" + stringify!($name), fn_ty)
     });
     (nothrow fn $name:ident($($arg:expr),+) -> $ret:expr) => ({
-        let fn_ty = Type::func([ $($arg),* ], &$ret);
+        let fn_ty = CrateTypes::func_([ $($arg),* ], &$ret);
         let decl = base::decl_cdecl_fn(llmod, ~"upcall_" + stringify!($name), fn_ty);
         base::set_no_unwind(decl);
         decl
     });
     (nothrow fn $name:ident -> $ret:expr) => ({
-        let fn_ty = Type::func([], &$ret);
+        let fn_ty = CrateTypes::func_([], &$ret);
         let decl = base::decl_cdecl_fn(llmod, ~"upcall_" + stringify!($name), fn_ty);
         base::set_no_unwind(decl);
         decl
     })
 )
 
-pub fn declare_upcalls(targ_cfg: @session::config, llmod: ModuleRef) -> @Upcalls {
-    let opaque_ptr = Type::i8().ptr_to();
-    let int_ty = Type::int(targ_cfg.arch);
+pub fn declare_upcalls(types: &CrateTypes, llmod: ModuleRef) -> @Upcalls {
+    let opaque_ptr = types.i8p();
+    let int_ty = types.i();
 
     @Upcalls {
-        trace: upcall!(fn trace(opaque_ptr, opaque_ptr, int_ty) -> Type::void()),
-        rust_personality: upcall!(nothrow fn rust_personality -> Type::i32()),
-        reset_stack_limit: upcall!(nothrow fn reset_stack_limit -> Type::void())
+        trace: upcall!(fn trace(opaque_ptr, opaque_ptr, int_ty) -> types.void()),
+        rust_personality: upcall!(nothrow fn rust_personality -> types.i32()),
+        reset_stack_limit: upcall!(nothrow fn reset_stack_limit -> types.void())
     }
 }

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1444,7 +1444,7 @@ fn compile_guard(bcx: @mut Block,
         for (_, &binding_info) in data.bindings_map.iter() {
             match binding_info.trmode {
                 TrByValue(llval) => {
-                    bcx = glue::drop_ty(bcx, llval, binding_info.ty);
+                    bcx = do glue::drop_ty(bcx, binding_info.ty) { llval };
                 }
                 TrByRef => {}
             }

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -216,7 +216,7 @@ fn represent_type_uncached(cx: &mut CrateContext, t: ty::t) -> Repr {
 
 fn mk_struct(cx: &mut CrateContext, tys: &[ty::t], packed: bool) -> Struct {
     let lltys = tys.map(|&ty| type_of::sizing_type_of(cx, ty));
-    let llty_rec = Type::struct_(lltys, packed);
+    let llty_rec = cx.types.struct_(lltys, packed);
     Struct {
         size: machine::llsize_of_alloc(cx, llty_rec) /*bad*/as u64,
         align: machine::llalign_of_min(cx, llty_rec) /*bad*/as u64,
@@ -239,7 +239,7 @@ pub fn sizing_fields_of(cx: &mut CrateContext, r: &Repr) -> ~[Type] {
 }
 fn generic_fields_of(cx: &mut CrateContext, r: &Repr, sizing: bool) -> ~[Type] {
     match *r {
-        CEnum(*) => ~[Type::enum_discrim(cx)],
+        CEnum(*) => ~[cx.types.enum_discrim()],
         Univariant(ref st, _dtor) => struct_llfields(cx, st, sizing),
         NullablePointer{ nonnull: ref st, _ } => struct_llfields(cx, st, sizing),
         General(ref sts) => {
@@ -265,7 +265,7 @@ fn generic_fields_of(cx: &mut CrateContext, r: &Repr, sizing: bool) -> ~[Type] {
             let padding = largest_size - most_aligned.size;
 
             struct_llfields(cx, most_aligned, sizing)
-                + &[Type::array(&Type::i8(), padding)]
+                + &[cx.types.array(&cx.types.i8(), padding)]
         }
     }
 }
@@ -310,7 +310,7 @@ pub fn trans_get_discr(bcx: @mut Block, r: &Repr, scrutinee: ValueRef)
         General(ref cases) => load_discr(bcx, scrutinee, 0, (cases.len() - 1) as Disr),
         NullablePointer{ nonnull: ref nonnull, nndiscr, ptrfield, _ } => {
             ZExt(bcx, nullable_bitdiscr(bcx, nonnull, nndiscr, ptrfield, scrutinee),
-                 Type::enum_discrim(bcx.ccx()))
+                 bcx.ccx().types.enum_discrim())
         }
     }
 }
@@ -361,7 +361,7 @@ pub fn trans_case(bcx: @mut Block, r: &Repr, discr: Disr) -> _match::opt_result 
         }
         NullablePointer{ _ } => {
             assert!(discr == 0 || discr == 1);
-            _match::single_result(rslt(bcx, C_i1(discr != 0)))
+            _match::single_result(rslt(bcx, C_i1(bcx.ccx(), discr != 0)))
         }
     }
 }
@@ -379,7 +379,7 @@ pub fn trans_start_init(bcx: @mut Block, r: &Repr, val: ValueRef, discr: Disr) {
         }
         Univariant(ref st, true) => {
             assert_eq!(discr, 0);
-            Store(bcx, C_bool(true),
+            Store(bcx, C_bool(bcx.ccx(), true),
                   GEPi(bcx, val, [0, st.fields.len() - 1]))
         }
         Univariant(*) => {
@@ -457,7 +457,7 @@ fn struct_field_ptr(bcx: @mut Block, st: &Struct, val: ValueRef, ix: uint,
         let fields = do st.fields.map |&ty| {
             type_of::type_of(ccx, ty)
         };
-        let real_ty = Type::struct_(fields, st.packed);
+        let real_ty = ccx.types.struct_(fields, st.packed);
         PointerCast(bcx, val, real_ty.ptr_to())
     } else {
         val
@@ -505,7 +505,7 @@ pub fn trans_const(ccx: &mut CrateContext, r: &Repr, discr: Disr,
         }
         Univariant(ref st, _dro) => {
             assert_eq!(discr, 0);
-            C_struct(build_const_struct(ccx, st, vals))
+            C_struct(ccx, build_const_struct(ccx, st, vals))
         }
         General(ref cases) => {
             let case = &cases[discr];
@@ -513,18 +513,18 @@ pub fn trans_const(ccx: &mut CrateContext, r: &Repr, discr: Disr,
             let discr_ty = C_disr(ccx, discr);
             let contents = build_const_struct(ccx, case,
                                               ~[discr_ty] + vals);
-            C_struct(contents + &[padding(max_sz - case.size)])
+            C_struct(ccx, contents + &[padding(ccx, max_sz - case.size)])
         }
         NullablePointer{ nonnull: ref nonnull, nndiscr, ptrfield, _ } => {
             if discr == nndiscr {
-                C_struct(build_const_struct(ccx, nonnull, vals))
+                C_struct(ccx, build_const_struct(ccx, nonnull, vals))
             } else {
                 assert_eq!(vals.len(), 0);
                 let vals = do nonnull.fields.iter().enumerate().map |(i, &ty)| {
                     let llty = type_of::sizing_type_of(ccx, ty);
                     if i == ptrfield { C_null(llty) } else { C_undef(llty) }
                 }.collect::<~[ValueRef]>();
-                C_struct(build_const_struct(ccx, nonnull, vals))
+                C_struct(ccx, build_const_struct(ccx, nonnull, vals))
             }
         }
     }
@@ -555,11 +555,11 @@ fn build_const_struct(ccx: &mut CrateContext, st: &Struct, vals: &[ValueRef])
         let target_offset = roundup(offset, type_align);
         offset = roundup(offset, val_align);
         if (offset != target_offset) {
-            cfields.push(padding(target_offset - offset));
+            cfields.push(padding(ccx, target_offset - offset));
             offset = target_offset;
         }
         let val = if is_undef(vals[i]) {
-            let wrapped = C_struct([vals[i]]);
+            let wrapped = C_struct(ccx, [vals[i]]);
             assert!(!is_undef(wrapped));
             wrapped
         } else {
@@ -572,8 +572,8 @@ fn build_const_struct(ccx: &mut CrateContext, st: &Struct, vals: &[ValueRef])
     return cfields;
 }
 
-fn padding(size: u64) -> ValueRef {
-    C_undef(Type::array(&Type::i8(), size))
+fn padding(ccx: &CrateContext, size: u64) -> ValueRef {
+    C_undef(ccx.types.array(&ccx.types.i8(), size))
 }
 
 // XXX this utility routine should be somewhere more general
@@ -647,5 +647,5 @@ pub fn is_newtypeish(r: &Repr) -> bool {
 }
 
 fn C_disr(cx: &CrateContext, i: Disr) -> ValueRef {
-    return C_integral(cx.int_type, i, false);
+    return C_integral(cx.types.i(), i, false);
 }

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -505,7 +505,7 @@ pub fn trans_const(ccx: &mut CrateContext, r: &Repr, discr: Disr,
         }
         Univariant(ref st, _dro) => {
             assert_eq!(discr, 0);
-            C_struct(ccx, build_const_struct(ccx, st, vals))
+            ccx.types.struct_val(build_const_struct(ccx, st, vals))
         }
         General(ref cases) => {
             let case = &cases[discr];
@@ -513,18 +513,18 @@ pub fn trans_const(ccx: &mut CrateContext, r: &Repr, discr: Disr,
             let discr_ty = C_disr(ccx, discr);
             let contents = build_const_struct(ccx, case,
                                               ~[discr_ty] + vals);
-            C_struct(ccx, contents + &[padding(ccx, max_sz - case.size)])
+            ccx.types.struct_val(contents + &[padding(ccx, max_sz - case.size)])
         }
         NullablePointer{ nonnull: ref nonnull, nndiscr, ptrfield, _ } => {
             if discr == nndiscr {
-                C_struct(ccx, build_const_struct(ccx, nonnull, vals))
+                ccx.types.struct_val(build_const_struct(ccx, nonnull, vals))
             } else {
                 assert_eq!(vals.len(), 0);
                 let vals = do nonnull.fields.iter().enumerate().map |(i, &ty)| {
                     let llty = type_of::sizing_type_of(ccx, ty);
                     if i == ptrfield { C_null(llty) } else { C_undef(llty) }
                 }.collect::<~[ValueRef]>();
-                C_struct(ccx, build_const_struct(ccx, nonnull, vals))
+                ccx.types.struct_val(build_const_struct(ccx, nonnull, vals))
             }
         }
     }

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -20,8 +20,6 @@ use middle::trans::callee;
 use middle::trans::common::*;
 use middle::ty;
 
-use middle::trans::type_::Type;
-
 use syntax::ast;
 
 // Take an inline assembly expression and splat it out via LLVM

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -108,11 +108,11 @@ pub fn trans_inline_asm(bcx: @mut Block, ia: &ast::inline_asm) -> @mut Block {
 
     // Depending on how many outputs we have, the return type is different
     let output = if numOutputs == 0 {
-        Type::void()
+        bcx.ccx().types.void()
     } else if numOutputs == 1 {
         val_ty(outputs[0])
     } else {
-        Type::struct_(outputs.map(|o| val_ty(*o)), false)
+        bcx.ccx().types.struct_(outputs.map(|o| val_ty(*o)), false)
     };
 
     let dialect = match ia.dialect {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1042,7 +1042,7 @@ pub fn get_landing_pad(bcx: @mut Block) -> BasicBlockRef {
     // The landing pad return type (the type being propagated). Not sure what
     // this represents but it's determined by the personality function and
     // this is what the EH proposal example uses.
-    let ccx_types = &bcx.ccx().types;
+    let ccx_types = bcx.ccx().types;
     let llretty = ccx_types.struct_([ccx_types.i8p(), ccx_types.i32()], false);
     // The exception handling personality function. This is the C++
     // personality function __gxx_personality_v0, wrapped in our naming
@@ -2882,7 +2882,8 @@ pub fn declare_intrinsics(llmod: ModuleRef, types: &CrateTypes) -> HashMap<&'sta
     return intrinsics;
 }
 
-pub fn declare_dbg_intrinsics(llmod: ModuleRef, types: &CrateTypes, intrinsics: &mut HashMap<&'static str, ValueRef>) {
+pub fn declare_dbg_intrinsics(llmod: ModuleRef, types: &CrateTypes,
+                              intrinsics: &mut HashMap<&'static str, ValueRef>) {
     ifn!(intrinsics, "llvm.dbg.declare", [types.metadata(), types.metadata()], types.void());
     ifn!(intrinsics,
          "llvm.dbg.value",   [types.metadata(), types.i64(), types.metadata()], types.void());
@@ -2951,7 +2952,6 @@ pub fn create_module_map(ccx: &mut CrateContext) -> ValueRef {
 
 pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
                       llmod: ModuleRef, types: &CrateTypes) -> ValueRef {
-    let targ_cfg = sess.targ_cfg;
     let int_type = types.i();
     let mut n_subcrates = 1;
     let cstore = sess.cstore;

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -65,7 +65,7 @@ use middle::ty;
 use util::common::indenter;
 use util::ppaux::{Repr, ty_to_str};
 
-use middle::trans::type_::Type;
+use middle::trans::type_::{Type, CrateTypes};
 
 use std::c_str::ToCStr;
 use std::hash;
@@ -306,7 +306,7 @@ pub fn umin(cx: @mut Block, a: ValueRef, b: ValueRef) -> ValueRef {
 // return type, use bump_ptr().
 pub fn ptr_offs(bcx: @mut Block, base: ValueRef, sz: ValueRef) -> ValueRef {
     let _icx = push_ctxt("ptr_offs");
-    let raw = PointerCast(bcx, base, Type::i8p());
+    let raw = PointerCast(bcx, base, bcx.ccx().types.i8p());
     InBoundsGEP(bcx, raw, [sz])
 }
 
@@ -332,7 +332,7 @@ pub fn opaque_box_body(bcx: @mut Block,
     let _icx = push_ctxt("opaque_box_body");
     let ccx = bcx.ccx();
     let ty = type_of(ccx, body_t);
-    let ty = Type::box(ccx, &ty);
+    let ty = ccx.types.box(&ty);
     let boxptr = PointerCast(bcx, boxptr, ty.ptr_to());
     GEPi(bcx, boxptr, [0u, abi::box_field_body])
 }
@@ -391,7 +391,7 @@ pub fn malloc_raw_dyn(bcx: @mut Block,
         glue::lazily_emit_all_tydesc_glue(ccx, static_ti);
 
         // Allocate space:
-        let tydesc = PointerCast(bcx, static_ti.tydesc, Type::i8p());
+        let tydesc = PointerCast(bcx, static_ti.tydesc, ccx.types.i8p());
         let r = callee::trans_lang_call(
             bcx,
             langcall,
@@ -629,7 +629,7 @@ pub fn compare_scalar_types(cx: @mut Block,
                 controlflow::trans_fail(
                     cx, None,
                     @"attempt to compare values of type type"),
-                C_nil())
+                C_nil(cx.ccx()))
         }
         _ => {
             // Should never get here, because t is scalar.
@@ -657,8 +657,8 @@ pub fn compare_scalar_values(cx: @mut Block,
         // We don't need to do actual comparisons for nil.
         // () == () holds but () < () does not.
         match op {
-          ast::BiEq | ast::BiLe | ast::BiGe => return C_i1(true),
-          ast::BiNe | ast::BiLt | ast::BiGt => return C_i1(false),
+          ast::BiEq | ast::BiLe | ast::BiGe => return C_i1(cx.ccx(), true),
+          ast::BiNe | ast::BiLt | ast::BiGt => return C_i1(cx.ccx(), false),
           // refinements would be nice
           _ => die(cx)
         }
@@ -855,11 +855,11 @@ pub fn fail_if_zero(cx: @mut Block, span: Span, divrem: ast::BinOp,
     };
     let is_zero = match ty::get(rhs_t).sty {
       ty::ty_int(t) => {
-        let zero = C_integral(Type::int_from_ty(cx.ccx(), t), 0u64, false);
+        let zero = C_integral(cx.ccx().types.int_from_ast_ty(t), 0u64, false);
         ICmp(cx, lib::llvm::IntEQ, rhs, zero)
       }
       ty::ty_uint(t) => {
-        let zero = C_integral(Type::uint_from_ty(cx.ccx(), t), 0u64, false);
+        let zero = C_integral(cx.ccx().types.uint_from_ast_ty(t), 0u64, false);
         ICmp(cx, lib::llvm::IntEQ, rhs, zero)
       }
       _ => {
@@ -873,7 +873,7 @@ pub fn fail_if_zero(cx: @mut Block, span: Span, divrem: ast::BinOp,
 }
 
 pub fn null_env_ptr(ccx: &CrateContext) -> ValueRef {
-    C_null(Type::opaque_box(ccx).ptr_to())
+    C_null(ccx.types.opaque_box().ptr_to())
 }
 
 pub fn trans_external_path(ccx: &mut CrateContext, did: ast::DefId, t: ty::t) -> ValueRef {
@@ -907,7 +907,7 @@ pub fn invoke(bcx: @mut Block, llfn: ValueRef, llargs: ~[ValueRef],
            -> (ValueRef, @mut Block) {
     let _icx = push_ctxt("invoke_");
     if bcx.unreachable {
-        return (C_null(Type::i8()), bcx);
+        return (C_null(bcx.ccx().types.i8()), bcx);
     }
 
     match bcx.node_info {
@@ -1042,7 +1042,8 @@ pub fn get_landing_pad(bcx: @mut Block) -> BasicBlockRef {
     // The landing pad return type (the type being propagated). Not sure what
     // this represents but it's determined by the personality function and
     // this is what the EH proposal example uses.
-    let llretty = Type::struct_([Type::i8p(), Type::i32()], false);
+    let ccx_types = &bcx.ccx().types;
+    let llretty = ccx_types.struct_([ccx_types.i8p(), ccx_types.i32()], false);
     // The exception handling personality function. This is the C++
     // personality function __gxx_personality_v0, wrapped in our naming
     // convention.
@@ -1104,7 +1105,7 @@ pub fn find_bcx_for_scope(bcx: @mut Block, scope_id: ast::NodeId) -> @mut Block 
 
 pub fn do_spill(bcx: @mut Block, v: ValueRef, t: ty::t) -> ValueRef {
     if ty::type_is_bot(t) {
-        return C_null(Type::i8p());
+        return C_null(bcx.ccx().types.i8p());
     }
     let llptr = alloc_ty(bcx, t, "");
     Store(bcx, v, llptr);
@@ -1147,8 +1148,8 @@ pub fn trans_trace(bcx: @mut Block, sp_opt: Option<Span>, trace_str: @str) {
       }
     };
     let ccx = bcx.ccx();
-    let V_trace_str = PointerCast(bcx, V_trace_str, Type::i8p());
-    let V_filename = PointerCast(bcx, V_filename, Type::i8p());
+    let V_trace_str = PointerCast(bcx, V_trace_str, ccx.types.i8p());
+    let V_filename = PointerCast(bcx, V_filename, ccx.types.i8p());
     let args = ~[V_trace_str, V_filename, C_int(ccx, V_line)];
     Call(bcx, ccx.upcalls.trace, args, []);
 }
@@ -1539,11 +1540,11 @@ pub fn call_memcpy(cx: @mut Block, dst: ValueRef, src: ValueRef, n_bytes: ValueR
         X86_64 => "llvm.memcpy.p0i8.p0i8.i64"
     };
     let memcpy = ccx.intrinsics.get_copy(&key);
-    let src_ptr = PointerCast(cx, src, Type::i8p());
-    let dst_ptr = PointerCast(cx, dst, Type::i8p());
-    let size = IntCast(cx, n_bytes, ccx.int_type);
-    let align = C_i32(align as i32);
-    let volatile = C_i1(false);
+    let src_ptr = PointerCast(cx, src, ccx.types.i8p());
+    let dst_ptr = PointerCast(cx, dst, ccx.types.i8p());
+    let size = IntCast(cx, n_bytes, ccx.types.i());
+    let align = C_i32(ccx, align as i32);
+    let volatile = C_i1(ccx, false);
     Call(cx, memcpy, [dst_ptr, src_ptr, size, align, volatile], []);
 }
 
@@ -1584,11 +1585,11 @@ pub fn memzero(b: &Builder, llptr: ValueRef, ty: Type) {
     };
 
     let llintrinsicfn = ccx.intrinsics.get_copy(&intrinsic_key);
-    let llptr = b.pointercast(llptr, Type::i8().ptr_to());
-    let llzeroval = C_u8(0);
+    let llptr = b.pointercast(llptr, ccx.types.i8p());
+    let llzeroval = C_u8(ccx, 0);
     let size = machine::llsize_of(ccx, ty);
-    let align = C_i32(llalign_of_min(ccx, ty) as i32);
-    let volatile = C_i1(false);
+    let align = C_i32(ccx, llalign_of_min(ccx, ty) as i32);
+    let volatile = C_i1(ccx, false);
     b.call(llintrinsicfn, [llptr, llzeroval, size, align, volatile], []);
 }
 
@@ -1703,7 +1704,7 @@ pub fn new_fn_ctxt_w_id(ccx: @mut CrateContext,
     let fcx = @mut FunctionContext {
           llfn: llfndecl,
           llenv: unsafe {
-              llvm::LLVMGetUndef(Type::i8p().to_ref())
+              llvm::LLVMGetUndef(ccx.types.i8p().to_ref())
           },
           llretptr: None,
           entry_bcx: None,
@@ -1728,7 +1729,7 @@ pub fn new_fn_ctxt_w_id(ccx: @mut CrateContext,
 
     unsafe {
         let entry_bcx = top_scope_block(fcx, opt_node_info);
-        Load(entry_bcx, C_null(Type::i8p()));
+        Load(entry_bcx, C_null(ccx.types.i8p()));
 
         fcx.entry_bcx = Some(entry_bcx);
         fcx.alloca_insert_pt = Some(llvm::LLVMGetFirstInstruction(entry_bcx.llbb));
@@ -2406,8 +2407,8 @@ pub fn create_entry_wrapper(ccx: @mut CrateContext,
     fn create_entry_fn(ccx: @mut CrateContext,
                        rust_main: ValueRef,
                        use_start_lang_item: bool) {
-        let llfty = Type::func([ccx.int_type, Type::i8().ptr_to().ptr_to()],
-                               &ccx.int_type);
+        let llfty = ccx.types.func([ccx.types.i(), ccx.types.i8p().ptr_to()],
+                                   &ccx.types.i());
 
         // FIXME #4404 android JNI hacks
         let main_name = if *ccx.sess.building_library {
@@ -2440,11 +2441,11 @@ pub fn create_entry_wrapper(ccx: @mut CrateContext,
 
                 let args = {
                     let opaque_rust_main = do "rust_main".with_c_str |buf| {
-                        llvm::LLVMBuildPointerCast(bld, rust_main, Type::i8p().to_ref(), buf)
+                        llvm::LLVMBuildPointerCast(bld, rust_main, ccx.types.i8p().to_ref(), buf)
                     };
 
                     ~[
-                        C_null(Type::opaque_box(ccx).ptr_to()),
+                        C_null(ccx.types.opaque_box().ptr_to()),
                         opaque_rust_main,
                         llvm::LLVMGetParam(llfn, 0),
                         llvm::LLVMGetParam(llfn, 1)
@@ -2454,7 +2455,7 @@ pub fn create_entry_wrapper(ccx: @mut CrateContext,
             } else {
                 debug!("using user-defined start fn");
                 let args = ~[
-                    C_null(Type::opaque_box(ccx).ptr_to()),
+                    C_null(ccx.types.opaque_box().ptr_to()),
                     llvm::LLVMGetParam(llfn, 0 as c_uint),
                     llvm::LLVMGetParam(llfn, 1 as c_uint)
                 ];
@@ -2477,7 +2478,7 @@ pub fn fill_fn_pair(bcx: @mut Block, pair: ValueRef, llfn: ValueRef,
     let code_cell = GEPi(bcx, pair, [0u, abi::fn_field_code]);
     Store(bcx, llfn, code_cell);
     let env_cell = GEPi(bcx, pair, [0u, abi::fn_field_box]);
-    let llenvblobptr = PointerCast(bcx, llenvptr, Type::opaque_box(ccx).ptr_to());
+    let llenvblobptr = PointerCast(bcx, llenvptr, ccx.types.opaque_box().ptr_to());
     Store(bcx, llenvblobptr, env_cell);
 }
 
@@ -2734,157 +2735,157 @@ pub fn register_method(ccx: @mut CrateContext,
 
 pub fn vp2i(cx: @mut Block, v: ValueRef) -> ValueRef {
     let ccx = cx.ccx();
-    return PtrToInt(cx, v, ccx.int_type);
+    return PtrToInt(cx, v, ccx.types.i());
 }
 
 pub fn p2i(ccx: &CrateContext, v: ValueRef) -> ValueRef {
     unsafe {
-        return llvm::LLVMConstPtrToInt(v, ccx.int_type.to_ref());
+        return llvm::LLVMConstPtrToInt(v, ccx.types.i().to_ref());
     }
 }
 
 macro_rules! ifn (
     ($intrinsics:ident, $name:expr, $args:expr, $ret:expr) => ({
         let name = $name;
-        let f = decl_cdecl_fn(llmod, name, Type::func($args, &$ret));
+        let f = decl_cdecl_fn(llmod, name, CrateTypes::func_($args, &$ret));
         $intrinsics.insert(name, f);
     })
 )
 
-pub fn declare_intrinsics(llmod: ModuleRef) -> HashMap<&'static str, ValueRef> {
-    let i8p = Type::i8p();
+pub fn declare_intrinsics(llmod: ModuleRef, types: &CrateTypes) -> HashMap<&'static str, ValueRef> {
+    let i8p = types.i8p();
     let mut intrinsics = HashMap::new();
 
     ifn!(intrinsics, "llvm.memcpy.p0i8.p0i8.i32",
-         [i8p, i8p, Type::i32(), Type::i32(), Type::i1()], Type::void());
+         [i8p, i8p, types.i32(), types.i32(), types.i1()], types.void());
     ifn!(intrinsics, "llvm.memcpy.p0i8.p0i8.i64",
-         [i8p, i8p, Type::i64(), Type::i32(), Type::i1()], Type::void());
+         [i8p, i8p, types.i64(), types.i32(), types.i1()], types.void());
     ifn!(intrinsics, "llvm.memmove.p0i8.p0i8.i32",
-         [i8p, i8p, Type::i32(), Type::i32(), Type::i1()], Type::void());
+         [i8p, i8p, types.i32(), types.i32(), types.i1()], types.void());
     ifn!(intrinsics, "llvm.memmove.p0i8.p0i8.i64",
-         [i8p, i8p, Type::i64(), Type::i32(), Type::i1()], Type::void());
+         [i8p, i8p, types.i64(), types.i32(), types.i1()], types.void());
     ifn!(intrinsics, "llvm.memset.p0i8.i32",
-         [i8p, Type::i8(), Type::i32(), Type::i32(), Type::i1()], Type::void());
+         [i8p, types.i8(), types.i32(), types.i32(), types.i1()], types.void());
     ifn!(intrinsics, "llvm.memset.p0i8.i64",
-         [i8p, Type::i8(), Type::i64(), Type::i32(), Type::i1()], Type::void());
+         [i8p, types.i8(), types.i64(), types.i32(), types.i1()], types.void());
 
-    ifn!(intrinsics, "llvm.trap", [], Type::void());
-    ifn!(intrinsics, "llvm.frameaddress", [Type::i32()], i8p);
+    ifn!(intrinsics, "llvm.trap", [], types.void());
+    ifn!(intrinsics, "llvm.frameaddress", [types.i32()], i8p);
 
-    ifn!(intrinsics, "llvm.powi.f32", [Type::f32(), Type::i32()], Type::f32());
-    ifn!(intrinsics, "llvm.powi.f64", [Type::f64(), Type::i32()], Type::f64());
-    ifn!(intrinsics, "llvm.pow.f32",  [Type::f32(), Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.pow.f64",  [Type::f64(), Type::f64()], Type::f64());
+    ifn!(intrinsics, "llvm.powi.f32", [types.f32(), types.i32()], types.f32());
+    ifn!(intrinsics, "llvm.powi.f64", [types.f64(), types.i32()], types.f64());
+    ifn!(intrinsics, "llvm.pow.f32",  [types.f32(), types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.pow.f64",  [types.f64(), types.f64()], types.f64());
 
-    ifn!(intrinsics, "llvm.sqrt.f32", [Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.sqrt.f64", [Type::f64()], Type::f64());
-    ifn!(intrinsics, "llvm.sin.f32",  [Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.sin.f64",  [Type::f64()], Type::f64());
-    ifn!(intrinsics, "llvm.cos.f32",  [Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.cos.f64",  [Type::f64()], Type::f64());
-    ifn!(intrinsics, "llvm.exp.f32",  [Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.exp.f64",  [Type::f64()], Type::f64());
-    ifn!(intrinsics, "llvm.exp2.f32", [Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.exp2.f64", [Type::f64()], Type::f64());
-    ifn!(intrinsics, "llvm.log.f32",  [Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.log.f64",  [Type::f64()], Type::f64());
-    ifn!(intrinsics, "llvm.log10.f32",[Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.log10.f64",[Type::f64()], Type::f64());
-    ifn!(intrinsics, "llvm.log2.f32", [Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.log2.f64", [Type::f64()], Type::f64());
+    ifn!(intrinsics, "llvm.sqrt.f32", [types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.sqrt.f64", [types.f64()], types.f64());
+    ifn!(intrinsics, "llvm.sin.f32",  [types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.sin.f64",  [types.f64()], types.f64());
+    ifn!(intrinsics, "llvm.cos.f32",  [types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.cos.f64",  [types.f64()], types.f64());
+    ifn!(intrinsics, "llvm.exp.f32",  [types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.exp.f64",  [types.f64()], types.f64());
+    ifn!(intrinsics, "llvm.exp2.f32", [types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.exp2.f64", [types.f64()], types.f64());
+    ifn!(intrinsics, "llvm.log.f32",  [types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.log.f64",  [types.f64()], types.f64());
+    ifn!(intrinsics, "llvm.log10.f32",[types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.log10.f64",[types.f64()], types.f64());
+    ifn!(intrinsics, "llvm.log2.f32", [types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.log2.f64", [types.f64()], types.f64());
 
-    ifn!(intrinsics, "llvm.fma.f32",  [Type::f32(), Type::f32(), Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.fma.f64",  [Type::f64(), Type::f64(), Type::f64()], Type::f64());
+    ifn!(intrinsics, "llvm.fma.f32",  [types.f32(), types.f32(), types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.fma.f64",  [types.f64(), types.f64(), types.f64()], types.f64());
 
-    ifn!(intrinsics, "llvm.fabs.f32", [Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.fabs.f64", [Type::f64()], Type::f64());
-    ifn!(intrinsics, "llvm.floor.f32",[Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.floor.f64",[Type::f64()], Type::f64());
-    ifn!(intrinsics, "llvm.ceil.f32", [Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.ceil.f64", [Type::f64()], Type::f64());
-    ifn!(intrinsics, "llvm.trunc.f32",[Type::f32()], Type::f32());
-    ifn!(intrinsics, "llvm.trunc.f64",[Type::f64()], Type::f64());
+    ifn!(intrinsics, "llvm.fabs.f32", [types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.fabs.f64", [types.f64()], types.f64());
+    ifn!(intrinsics, "llvm.floor.f32",[types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.floor.f64",[types.f64()], types.f64());
+    ifn!(intrinsics, "llvm.ceil.f32", [types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.ceil.f64", [types.f64()], types.f64());
+    ifn!(intrinsics, "llvm.trunc.f32",[types.f32()], types.f32());
+    ifn!(intrinsics, "llvm.trunc.f64",[types.f64()], types.f64());
 
-    ifn!(intrinsics, "llvm.ctpop.i8", [Type::i8()], Type::i8());
-    ifn!(intrinsics, "llvm.ctpop.i16",[Type::i16()], Type::i16());
-    ifn!(intrinsics, "llvm.ctpop.i32",[Type::i32()], Type::i32());
-    ifn!(intrinsics, "llvm.ctpop.i64",[Type::i64()], Type::i64());
+    ifn!(intrinsics, "llvm.ctpop.i8", [types.i8()], types.i8());
+    ifn!(intrinsics, "llvm.ctpop.i16",[types.i16()], types.i16());
+    ifn!(intrinsics, "llvm.ctpop.i32",[types.i32()], types.i32());
+    ifn!(intrinsics, "llvm.ctpop.i64",[types.i64()], types.i64());
 
-    ifn!(intrinsics, "llvm.ctlz.i8",  [Type::i8() , Type::i1()], Type::i8());
-    ifn!(intrinsics, "llvm.ctlz.i16", [Type::i16(), Type::i1()], Type::i16());
-    ifn!(intrinsics, "llvm.ctlz.i32", [Type::i32(), Type::i1()], Type::i32());
-    ifn!(intrinsics, "llvm.ctlz.i64", [Type::i64(), Type::i1()], Type::i64());
+    ifn!(intrinsics, "llvm.ctlz.i8",  [types.i8() , types.i1()], types.i8());
+    ifn!(intrinsics, "llvm.ctlz.i16", [types.i16(), types.i1()], types.i16());
+    ifn!(intrinsics, "llvm.ctlz.i32", [types.i32(), types.i1()], types.i32());
+    ifn!(intrinsics, "llvm.ctlz.i64", [types.i64(), types.i1()], types.i64());
 
-    ifn!(intrinsics, "llvm.cttz.i8",  [Type::i8() , Type::i1()], Type::i8());
-    ifn!(intrinsics, "llvm.cttz.i16", [Type::i16(), Type::i1()], Type::i16());
-    ifn!(intrinsics, "llvm.cttz.i32", [Type::i32(), Type::i1()], Type::i32());
-    ifn!(intrinsics, "llvm.cttz.i64", [Type::i64(), Type::i1()], Type::i64());
+    ifn!(intrinsics, "llvm.cttz.i8",  [types.i8() , types.i1()], types.i8());
+    ifn!(intrinsics, "llvm.cttz.i16", [types.i16(), types.i1()], types.i16());
+    ifn!(intrinsics, "llvm.cttz.i32", [types.i32(), types.i1()], types.i32());
+    ifn!(intrinsics, "llvm.cttz.i64", [types.i64(), types.i1()], types.i64());
 
-    ifn!(intrinsics, "llvm.bswap.i16",[Type::i16()], Type::i16());
-    ifn!(intrinsics, "llvm.bswap.i32",[Type::i32()], Type::i32());
-    ifn!(intrinsics, "llvm.bswap.i64",[Type::i64()], Type::i64());
+    ifn!(intrinsics, "llvm.bswap.i16",[types.i16()], types.i16());
+    ifn!(intrinsics, "llvm.bswap.i32",[types.i32()], types.i32());
+    ifn!(intrinsics, "llvm.bswap.i64",[types.i64()], types.i64());
 
     ifn!(intrinsics, "llvm.sadd.with.overflow.i8",
-        [Type::i8(), Type::i8()], Type::struct_([Type::i8(), Type::i1()], false));
+        [types.i8(), types.i8()], types.struct_([types.i8(), types.i1()], false));
     ifn!(intrinsics, "llvm.sadd.with.overflow.i16",
-        [Type::i16(), Type::i16()], Type::struct_([Type::i16(), Type::i1()], false));
+        [types.i16(), types.i16()], types.struct_([types.i16(), types.i1()], false));
     ifn!(intrinsics, "llvm.sadd.with.overflow.i32",
-        [Type::i32(), Type::i32()], Type::struct_([Type::i32(), Type::i1()], false));
+        [types.i32(), types.i32()], types.struct_([types.i32(), types.i1()], false));
     ifn!(intrinsics, "llvm.sadd.with.overflow.i64",
-        [Type::i64(), Type::i64()], Type::struct_([Type::i64(), Type::i1()], false));
+        [types.i64(), types.i64()], types.struct_([types.i64(), types.i1()], false));
 
     ifn!(intrinsics, "llvm.uadd.with.overflow.i8",
-        [Type::i8(), Type::i8()], Type::struct_([Type::i8(), Type::i1()], false));
+        [types.i8(), types.i8()], types.struct_([types.i8(), types.i1()], false));
     ifn!(intrinsics, "llvm.uadd.with.overflow.i16",
-        [Type::i16(), Type::i16()], Type::struct_([Type::i16(), Type::i1()], false));
+        [types.i16(), types.i16()], types.struct_([types.i16(), types.i1()], false));
     ifn!(intrinsics, "llvm.uadd.with.overflow.i32",
-        [Type::i32(), Type::i32()], Type::struct_([Type::i32(), Type::i1()], false));
+        [types.i32(), types.i32()], types.struct_([types.i32(), types.i1()], false));
     ifn!(intrinsics, "llvm.uadd.with.overflow.i64",
-        [Type::i64(), Type::i64()], Type::struct_([Type::i64(), Type::i1()], false));
+        [types.i64(), types.i64()], types.struct_([types.i64(), types.i1()], false));
 
     ifn!(intrinsics, "llvm.ssub.with.overflow.i8",
-        [Type::i8(), Type::i8()], Type::struct_([Type::i8(), Type::i1()], false));
+        [types.i8(), types.i8()], types.struct_([types.i8(), types.i1()], false));
     ifn!(intrinsics, "llvm.ssub.with.overflow.i16",
-        [Type::i16(), Type::i16()], Type::struct_([Type::i16(), Type::i1()], false));
+        [types.i16(), types.i16()], types.struct_([types.i16(), types.i1()], false));
     ifn!(intrinsics, "llvm.ssub.with.overflow.i32",
-        [Type::i32(), Type::i32()], Type::struct_([Type::i32(), Type::i1()], false));
+        [types.i32(), types.i32()], types.struct_([types.i32(), types.i1()], false));
     ifn!(intrinsics, "llvm.ssub.with.overflow.i64",
-        [Type::i64(), Type::i64()], Type::struct_([Type::i64(), Type::i1()], false));
+        [types.i64(), types.i64()], types.struct_([types.i64(), types.i1()], false));
 
     ifn!(intrinsics, "llvm.usub.with.overflow.i8",
-        [Type::i8(), Type::i8()], Type::struct_([Type::i8(), Type::i1()], false));
+        [types.i8(), types.i8()], types.struct_([types.i8(), types.i1()], false));
     ifn!(intrinsics, "llvm.usub.with.overflow.i16",
-        [Type::i16(), Type::i16()], Type::struct_([Type::i16(), Type::i1()], false));
+        [types.i16(), types.i16()], types.struct_([types.i16(), types.i1()], false));
     ifn!(intrinsics, "llvm.usub.with.overflow.i32",
-        [Type::i32(), Type::i32()], Type::struct_([Type::i32(), Type::i1()], false));
+        [types.i32(), types.i32()], types.struct_([types.i32(), types.i1()], false));
     ifn!(intrinsics, "llvm.usub.with.overflow.i64",
-        [Type::i64(), Type::i64()], Type::struct_([Type::i64(), Type::i1()], false));
+        [types.i64(), types.i64()], types.struct_([types.i64(), types.i1()], false));
 
     ifn!(intrinsics, "llvm.smul.with.overflow.i8",
-        [Type::i8(), Type::i8()], Type::struct_([Type::i8(), Type::i1()], false));
+        [types.i8(), types.i8()], types.struct_([types.i8(), types.i1()], false));
     ifn!(intrinsics, "llvm.smul.with.overflow.i16",
-        [Type::i16(), Type::i16()], Type::struct_([Type::i16(), Type::i1()], false));
+        [types.i16(), types.i16()], types.struct_([types.i16(), types.i1()], false));
     ifn!(intrinsics, "llvm.smul.with.overflow.i32",
-        [Type::i32(), Type::i32()], Type::struct_([Type::i32(), Type::i1()], false));
+        [types.i32(), types.i32()], types.struct_([types.i32(), types.i1()], false));
     ifn!(intrinsics, "llvm.smul.with.overflow.i64",
-        [Type::i64(), Type::i64()], Type::struct_([Type::i64(), Type::i1()], false));
+        [types.i64(), types.i64()], types.struct_([types.i64(), types.i1()], false));
 
     ifn!(intrinsics, "llvm.umul.with.overflow.i8",
-        [Type::i8(), Type::i8()], Type::struct_([Type::i8(), Type::i1()], false));
+        [types.i8(), types.i8()], types.struct_([types.i8(), types.i1()], false));
     ifn!(intrinsics, "llvm.umul.with.overflow.i16",
-        [Type::i16(), Type::i16()], Type::struct_([Type::i16(), Type::i1()], false));
+        [types.i16(), types.i16()], types.struct_([types.i16(), types.i1()], false));
     ifn!(intrinsics, "llvm.umul.with.overflow.i32",
-        [Type::i32(), Type::i32()], Type::struct_([Type::i32(), Type::i1()], false));
+        [types.i32(), types.i32()], types.struct_([types.i32(), types.i1()], false));
     ifn!(intrinsics, "llvm.umul.with.overflow.i64",
-        [Type::i64(), Type::i64()], Type::struct_([Type::i64(), Type::i1()], false));
+        [types.i64(), types.i64()], types.struct_([types.i64(), types.i1()], false));
 
     return intrinsics;
 }
 
-pub fn declare_dbg_intrinsics(llmod: ModuleRef, intrinsics: &mut HashMap<&'static str, ValueRef>) {
-    ifn!(intrinsics, "llvm.dbg.declare", [Type::metadata(), Type::metadata()], Type::void());
+pub fn declare_dbg_intrinsics(llmod: ModuleRef, types: &CrateTypes, intrinsics: &mut HashMap<&'static str, ValueRef>) {
+    ifn!(intrinsics, "llvm.dbg.declare", [types.metadata(), types.metadata()], types.void());
     ifn!(intrinsics,
-         "llvm.dbg.value",   [Type::metadata(), Type::i64(), Type::metadata()], Type::void());
+         "llvm.dbg.value",   [types.metadata(), types.i64(), types.metadata()], types.void());
 }
 
 pub fn trap(bcx: @mut Block) {
@@ -2902,7 +2903,7 @@ pub fn decl_gc_metadata(ccx: &mut CrateContext, llmod_id: &str) {
     let gc_metadata_name = ~"_gc_module_metadata_" + llmod_id;
     let gc_metadata = do gc_metadata_name.with_c_str |buf| {
         unsafe {
-            llvm::LLVMAddGlobal(ccx.llmod, Type::i32().to_ref(), buf)
+            llvm::LLVMAddGlobal(ccx.llmod, ccx.types.i32().to_ref(), buf)
         }
     };
     unsafe {
@@ -2913,8 +2914,8 @@ pub fn decl_gc_metadata(ccx: &mut CrateContext, llmod_id: &str) {
 }
 
 pub fn create_module_map(ccx: &mut CrateContext) -> ValueRef {
-    let elttype = Type::struct_([ccx.int_type, ccx.int_type], false);
-    let maptype = Type::array(&elttype, (ccx.module_data.len() + 1) as u64);
+    let elttype = ccx.types.struct_([ccx.types.i(), ccx.types.i()], false);
+    let maptype = ccx.types.array(&elttype, (ccx.module_data.len() + 1) as u64);
     let map = do "_rust_mod_map".with_c_str |buf| {
         unsafe {
             llvm::LLVMAddGlobal(ccx.llmod, maptype.to_ref(), buf)
@@ -2936,10 +2937,10 @@ pub fn create_module_map(ccx: &mut CrateContext) -> ValueRef {
         let s_const = C_cstr(ccx, *key);
         let s_ptr = p2i(ccx, s_const);
         let v_ptr = p2i(ccx, val);
-        let elt = C_struct([s_ptr, v_ptr]);
+        let elt = C_struct(ccx, [s_ptr, v_ptr]);
         elts.push(elt);
     }
-    let term = C_struct([C_int(ccx, 0), C_int(ccx, 0)]);
+    let term = C_struct(ccx, [C_int(ccx, 0), C_int(ccx, 0)]);
     elts.push(term);
     unsafe {
         llvm::LLVMSetInitializer(map, C_array(elttype, elts));
@@ -2949,9 +2950,9 @@ pub fn create_module_map(ccx: &mut CrateContext) -> ValueRef {
 
 
 pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
-                      llmod: ModuleRef) -> ValueRef {
+                      llmod: ModuleRef, types: &CrateTypes) -> ValueRef {
     let targ_cfg = sess.targ_cfg;
-    let int_type = Type::int(targ_cfg.arch);
+    let int_type = types.i();
     let mut n_subcrates = 1;
     let cstore = sess.cstore;
     while cstore::have_crate_data(cstore, n_subcrates) { n_subcrates += 1; }
@@ -2961,8 +2962,8 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
         ~"toplevel"
     };
     let sym_name = ~"_rust_crate_map_" + mapname;
-    let arrtype = Type::array(&int_type, n_subcrates as u64);
-    let maptype = Type::struct_([Type::i32(), int_type, arrtype], false);
+    let arrtype = types.array(&int_type, n_subcrates as u64);
+    let maptype = Type::struct_([types.i32(), int_type, arrtype], false);
     let map = do sym_name.with_c_str |buf| {
         unsafe {
             llvm::LLVMAddGlobal(llmod, maptype.to_ref(), buf)
@@ -2991,7 +2992,7 @@ pub fn fill_crate_map(ccx: @mut CrateContext, map: ValueRef) {
                       cstore::get_crate_hash(cstore, i));
         let cr = do nm.with_c_str |buf| {
             unsafe {
-                llvm::LLVMAddGlobal(ccx.llmod, ccx.int_type.to_ref(), buf)
+                llvm::LLVMAddGlobal(ccx.llmod, ccx.types.i().to_ref(), buf)
             }
         };
         subcrates.push(p2i(ccx, cr));
@@ -3001,10 +3002,10 @@ pub fn fill_crate_map(ccx: @mut CrateContext, map: ValueRef) {
 
     unsafe {
         let mod_map = create_module_map(ccx);
-        llvm::LLVMSetInitializer(map, C_struct(
-            [C_i32(1),
+        llvm::LLVMSetInitializer(map, C_struct(ccx,
+            [C_i32(ccx, 1),            
              p2i(ccx, mod_map),
-             C_array(ccx.int_type, subcrates)]));
+             C_array(ccx.types.i(), subcrates)]));
     }
 }
 
@@ -3039,7 +3040,7 @@ pub fn write_metadata(cx: &mut CrateContext, crate: &ast::Crate) {
 
     let encode_parms = crate_ctxt_to_encode_parms(cx, encode_inlined_item);
     let llmeta = C_bytes(encoder::encode_metadata(encode_parms, crate));
-    let llconst = C_struct([llmeta]);
+    let llconst = C_struct(cx, [llmeta]);
     let mut llglobal = do "rust_metadata".with_c_str |buf| {
         unsafe {
             llvm::LLVMAddGlobal(cx.llmod, val_ty(llconst).to_ref(), buf)
@@ -3052,10 +3053,10 @@ pub fn write_metadata(cx: &mut CrateContext, crate: &ast::Crate) {
         };
         lib::llvm::SetLinkage(llglobal, lib::llvm::InternalLinkage);
 
-        let t_ptr_i8 = Type::i8p();
+        let t_ptr_i8 = cx.types.i8p();
         llglobal = llvm::LLVMConstBitCast(llglobal, t_ptr_i8.to_ref());
         let llvm_used = do "llvm.used".with_c_str |buf| {
-            llvm::LLVMAddGlobal(cx.llmod, Type::array(&t_ptr_i8, 1).to_ref(), buf)
+            llvm::LLVMAddGlobal(cx.llmod, cx.types.array(&t_ptr_i8, 1).to_ref(), buf)
         };
         lib::llvm::SetLinkage(llvm_used, lib::llvm::AppendingLinkage);
         llvm::LLVMSetInitializer(llvm_used, C_array(t_ptr_i8, [llglobal]));

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -113,7 +113,7 @@ pub fn Invoke(cx: @mut Block,
               attributes: &[(uint, lib::llvm::Attribute)])
            -> ValueRef {
     if cx.unreachable {
-        return C_null(Type::i8());
+        return C_null(cx.ccx().types.i8());
     }
     check_not_terminated(cx);
     terminate(cx, "Invoke");
@@ -296,14 +296,14 @@ pub fn Not(cx: @mut Block, V: ValueRef) -> ValueRef {
 /* Memory */
 pub fn Malloc(cx: @mut Block, Ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.i8p().to_ref()); }
         B(cx).malloc(Ty)
     }
 }
 
 pub fn ArrayMalloc(cx: @mut Block, Ty: Type, Val: ValueRef) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.i8p().to_ref()); }
         B(cx).array_malloc(Ty, Val)
     }
 }
@@ -339,7 +339,7 @@ pub fn Load(cx: @mut Block, PointerVal: ValueRef) -> ValueRef {
             let eltty = if ty.kind() == lib::llvm::Array {
                 ty.element_type()
             } else {
-                ccx.int_type
+                ccx.types.i()
             };
             return llvm::LLVMGetUndef(eltty.to_ref());
         }
@@ -351,7 +351,7 @@ pub fn AtomicLoad(cx: @mut Block, PointerVal: ValueRef, order: AtomicOrdering) -
     unsafe {
         let ccx = cx.fcx.ccx;
         if cx.unreachable {
-            return llvm::LLVMGetUndef(ccx.int_type.to_ref());
+            return llvm::LLVMGetUndef(ccx.types.i().to_ref());
         }
         B(cx).atomic_load(PointerVal, order)
     }
@@ -366,7 +366,7 @@ pub fn LoadRangeAssert(cx: @mut Block, PointerVal: ValueRef, lo: c_ulonglong,
         let eltty = if ty.kind() == lib::llvm::Array {
             ty.element_type()
         } else {
-            ccx.int_type
+            ccx.types.i()
         };
         unsafe {
             llvm::LLVMGetUndef(eltty.to_ref())
@@ -388,7 +388,7 @@ pub fn AtomicStore(cx: @mut Block, Val: ValueRef, Ptr: ValueRef, order: AtomicOr
 
 pub fn GEP(cx: @mut Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.nil().ptr_to().to_ref()); }
         B(cx).gep(Pointer, Indices)
     }
 }
@@ -398,35 +398,35 @@ pub fn GEP(cx: @mut Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef 
 #[inline]
 pub fn GEPi(cx: @mut Block, base: ValueRef, ixs: &[uint]) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.nil().ptr_to().to_ref()); }
         B(cx).gepi(base, ixs)
     }
 }
 
 pub fn InBoundsGEP(cx: @mut Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.nil().ptr_to().to_ref()); }
         B(cx).inbounds_gep(Pointer, Indices)
     }
 }
 
 pub fn StructGEP(cx: @mut Block, Pointer: ValueRef, Idx: uint) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.nil().ptr_to().to_ref()); }
         B(cx).struct_gep(Pointer, Idx)
     }
 }
 
 pub fn GlobalString(cx: @mut Block, _Str: *c_char) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.i8p().to_ref()); }
         B(cx).global_string(_Str)
     }
 }
 
 pub fn GlobalStringPtr(cx: @mut Block, _Str: *c_char) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.i8p().to_ref()); }
         B(cx).global_string_ptr(_Str)
     }
 }
@@ -571,7 +571,7 @@ pub fn FPCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
 pub fn ICmp(cx: @mut Block, Op: IntPredicate, LHS: ValueRef, RHS: ValueRef)
      -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.i1().to_ref()); }
         B(cx).icmp(Op, LHS, RHS)
     }
 }
@@ -579,7 +579,7 @@ pub fn ICmp(cx: @mut Block, Op: IntPredicate, LHS: ValueRef, RHS: ValueRef)
 pub fn FCmp(cx: @mut Block, Op: RealPredicate, LHS: ValueRef, RHS: ValueRef)
      -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.i1().to_ref()); }
         B(cx).fcmp(Op, LHS, RHS)
     }
 }
@@ -615,7 +615,7 @@ pub fn _UndefReturn(cx: @mut Block, Fn: ValueRef) -> ValueRef {
         let retty = if ty.kind() == lib::llvm::Integer {
             ty.return_type()
         } else {
-            ccx.int_type
+            ccx.types.i()
         };
         B(cx).count_insn("ret_undef");
         llvm::LLVMGetUndef(retty.to_ref())
@@ -668,7 +668,7 @@ pub fn VAArg(cx: @mut Block, list: ValueRef, Ty: Type) -> ValueRef {
 
 pub fn ExtractElement(cx: @mut Block, VecVal: ValueRef, Index: ValueRef) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.nil().to_ref()); }
         B(cx).extract_element(VecVal, Index)
     }
 }
@@ -676,7 +676,7 @@ pub fn ExtractElement(cx: @mut Block, VecVal: ValueRef, Index: ValueRef) -> Valu
 pub fn InsertElement(cx: @mut Block, VecVal: ValueRef, EltVal: ValueRef,
                      Index: ValueRef) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.nil().to_ref()); }
         B(cx).insert_element(VecVal, EltVal, Index)
     }
 }
@@ -684,42 +684,42 @@ pub fn InsertElement(cx: @mut Block, VecVal: ValueRef, EltVal: ValueRef,
 pub fn ShuffleVector(cx: @mut Block, V1: ValueRef, V2: ValueRef,
                      Mask: ValueRef) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.nil().to_ref()); }
         B(cx).shuffle_vector(V1, V2, Mask)
     }
 }
 
 pub fn VectorSplat(cx: @mut Block, NumElts: uint, EltVal: ValueRef) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.nil().to_ref()); }
         B(cx).vector_splat(NumElts, EltVal)
     }
 }
 
 pub fn ExtractValue(cx: @mut Block, AggVal: ValueRef, Index: uint) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.nil().to_ref()); }
         B(cx).extract_value(AggVal, Index)
     }
 }
 
 pub fn InsertValue(cx: @mut Block, AggVal: ValueRef, EltVal: ValueRef, Index: uint) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.nil().to_ref()); }
         B(cx).insert_value(AggVal, EltVal, Index)
     }
 }
 
 pub fn IsNull(cx: @mut Block, Val: ValueRef) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.i1().to_ref()); }
         B(cx).is_null(Val)
     }
 }
 
 pub fn IsNotNull(cx: @mut Block, Val: ValueRef) -> ValueRef {
     unsafe {
-        if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(cx.ccx().types.i1().to_ref()); }
         B(cx).is_not_null(Val)
     }
 }
@@ -727,7 +727,7 @@ pub fn IsNotNull(cx: @mut Block, Val: ValueRef) -> ValueRef {
 pub fn PtrDiff(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
-        if cx.unreachable { return llvm::LLVMGetUndef(ccx.int_type.to_ref()); }
+        if cx.unreachable { return llvm::LLVMGetUndef(ccx.types.i().to_ref()); }
         B(cx).ptrdiff(LHS, RHS)
     }
 }

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -450,7 +450,7 @@ impl Builder {
     pub fn atomic_load(&self, ptr: ValueRef, order: AtomicOrdering) -> ValueRef {
         self.count_insn("load.atomic");
         unsafe {
-            let align = llalign_of_min(self.ccx, self.ccx.int_type);
+            let align = llalign_of_min(self.ccx, self.ccx.types.i());
             llvm::LLVMBuildAtomicLoad(self.llbuilder, ptr, noname(), order, align as c_uint)
         }
     }
@@ -477,8 +477,8 @@ impl Builder {
 
     pub fn store(&self, val: ValueRef, ptr: ValueRef) {
         debug!("Store %s -> %s",
-               self.ccx.tn.val_to_str(val),
-               self.ccx.tn.val_to_str(ptr));
+               self.ccx.types.val_to_str(val),
+               self.ccx.types.val_to_str(ptr));
         assert!(is_not_null(self.llbuilder));
         self.count_insn("store");
         unsafe {
@@ -488,10 +488,10 @@ impl Builder {
 
     pub fn atomic_store(&self, val: ValueRef, ptr: ValueRef, order: AtomicOrdering) {
         debug!("Store %s -> %s",
-               self.ccx.tn.val_to_str(val),
-               self.ccx.tn.val_to_str(ptr));
+               self.ccx.types.val_to_str(val),
+               self.ccx.types.val_to_str(ptr));
         self.count_insn("store.atomic");
-        let align = llalign_of_min(self.ccx, self.ccx.int_type);
+        let align = llalign_of_min(self.ccx, self.ccx.types.i());
         unsafe {
             llvm::LLVMBuildAtomicStore(self.llbuilder, val, ptr, order, align as c_uint);
         }
@@ -512,13 +512,13 @@ impl Builder {
         // Small vector optimization. This should catch 100% of the cases that
         // we care about.
         if ixs.len() < 16 {
-            let mut small_vec = [ C_i32(0), ..16 ];
+            let mut small_vec = [ C_i32(self.ccx, 0), ..16 ];
             for (small_vec_e, &ix) in small_vec.mut_iter().zip(ixs.iter()) {
-                *small_vec_e = C_i32(ix as i32);
+                *small_vec_e = C_i32(self.ccx, ix as i32);
             }
             self.inbounds_gep(base, small_vec.slice(0, ixs.len()))
         } else {
-            let v = do ixs.iter().map |i| { C_i32(*i as i32) }.collect::<~[ValueRef]>();
+            let v = do ixs.iter().map |i| { C_i32(self.ccx, *i as i32) }.collect::<~[ValueRef]>();
             self.count_insn("gepi");
             self.inbounds_gep(base, v)
         }
@@ -738,7 +738,7 @@ impl Builder {
             self.count_insn("inlineasm");
             let asm = do comment_text.with_c_str |c| {
                 unsafe {
-                    llvm::LLVMConstInlineAsm(Type::func([], &Type::void()).to_ref(),
+                    llvm::LLVMConstInlineAsm(self.ccx.types.func([], &self.ccx.types.void()).to_ref(),
                                              c, noname(), False, False)
                 }
             };
@@ -758,12 +758,12 @@ impl Builder {
                          else          { lib::llvm::False };
 
         let argtys = do inputs.map |v| {
-            debug!("Asm Input Type: %?", self.ccx.tn.val_to_str(*v));
+            debug!("Asm Input Type: %?", self.ccx.types.val_to_str(*v));
             val_ty(*v)
         };
 
-        debug!("Asm Output Type: %?", self.ccx.tn.type_to_str(output));
-        let fty = Type::func(argtys, &output);
+        debug!("Asm Output Type: %?", self.ccx.types.type_to_str(output));
+        let fty = self.ccx.types.func(argtys, &output);
         unsafe {
             let v = llvm::LLVMInlineAsm(
                 fty.to_ref(), asm, cons, volatile, alignstack, dia as c_uint);
@@ -830,9 +830,10 @@ impl Builder {
     pub fn vector_splat(&self, num_elts: uint, elt: ValueRef) -> ValueRef {
         unsafe {
             let elt_ty = val_ty(elt);
-            let Undef = llvm::LLVMGetUndef(Type::vector(&elt_ty, num_elts as u64).to_ref());
-            let vec = self.insert_element(Undef, elt, C_i32(0));
-            self.shuffle_vector(vec, Undef, C_null(Type::vector(&Type::i32(), num_elts as u64)))
+            let Undef = llvm::LLVMGetUndef(self.ccx.types.vector(&elt_ty, num_elts as u64).to_ref());
+            let vec = self.insert_element(Undef, elt, C_i32(self.ccx, 0));
+            self.shuffle_vector(vec, Undef, C_null(self.ccx.types.vector(&self.ccx.types.i32(),
+                                                                         num_elts as u64)))
         }
     }
 

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -738,8 +738,9 @@ impl Builder {
             self.count_insn("inlineasm");
             let asm = do comment_text.with_c_str |c| {
                 unsafe {
-                    llvm::LLVMConstInlineAsm(self.ccx.types.func([], &self.ccx.types.void()).to_ref(),
-                                             c, noname(), False, False)
+                    llvm::LLVMConstInlineAsm(
+                        self.ccx.types.func([], &self.ccx.types.void()).to_ref(),
+                        c, noname(), False, False)
                 }
             };
             self.call(asm, [], []);
@@ -830,7 +831,8 @@ impl Builder {
     pub fn vector_splat(&self, num_elts: uint, elt: ValueRef) -> ValueRef {
         unsafe {
             let elt_ty = val_ty(elt);
-            let Undef = llvm::LLVMGetUndef(self.ccx.types.vector(&elt_ty, num_elts as u64).to_ref());
+            let Undef = llvm::LLVMGetUndef(
+                    self.ccx.types.vector(&elt_ty, num_elts as u64).to_ref());
             let vec = self.insert_element(Undef, elt, C_i32(self.ccx, 0));
             self.shuffle_vector(vec, Undef, C_null(self.ccx.types.vector(&self.ccx.types.i32(),
                                                                          num_elts as u64)))

--- a/src/librustc/middle/trans/cabi_mips.rs
+++ b/src/librustc/middle/trans/cabi_mips.rs
@@ -9,13 +9,11 @@
 // except according to those terms.
 
 
-use std::libc::c_uint;
 use std::num;
 use std::vec;
 use lib::llvm::{llvm, Integer, Pointer, Float, Double, Struct, Array};
 use lib::llvm::{Attribute, StructRetAttribute};
 use middle::trans::context::CrateContext;
-use middle::trans::context::task_llcx;
 use middle::trans::cabi::*;
 
 use middle::trans::type_::Type;
@@ -93,7 +91,8 @@ fn classify_ret_ty(ty: Type) -> (LLVMType, Option<Attribute>) {
     };
 }
 
-fn classify_arg_ty(ccx: &CrateContext, ty: Type, offset: &mut uint) -> (LLVMType, Option<Attribute>) {
+fn classify_arg_ty(ccx: &CrateContext, ty: Type, offset: &mut uint)
+    -> (LLVMType, Option<Attribute>) {
     let orig_offset = *offset;
     let size = ty_size(ty) * 8;
     let mut align = ty_align(ty);
@@ -154,7 +153,7 @@ fn coerce_to_int(ccx: &CrateContext, size: uint) -> ~[Type] {
     args
 }
 
-fn struct_ty(ccx: &CrateContext, 
+fn struct_ty(ccx: &CrateContext,
              ty: Type,
              padding: Option<Type>,
              coerce: bool) -> Type {

--- a/src/librustc/middle/trans/cabi_x86.rs
+++ b/src/librustc/middle/trans/cabi_x86.rs
@@ -28,7 +28,7 @@ pub fn compute_abi_info(ccx: &mut CrateContext,
     if !ret_def {
         ret_ty = LLVMType {
             cast: false,
-            ty: Type::void(),
+            ty: ccx.types.void(),
         };
         sret = false;
     } else if rty.kind() == Struct {
@@ -44,10 +44,10 @@ pub fn compute_abi_info(ccx: &mut CrateContext,
         let strategy = match ccx.sess.targ_cfg.os {
             OsWin32 | OsMacos => {
                 match llsize_of_alloc(ccx, rty) {
-                    1 => RetValue(Type::i8()),
-                    2 => RetValue(Type::i16()),
-                    4 => RetValue(Type::i32()),
-                    8 => RetValue(Type::i64()),
+                    1 => RetValue(ccx.types.i8()),
+                    2 => RetValue(ccx.types.i16()),
+                    4 => RetValue(ccx.types.i32()),
+                    8 => RetValue(ccx.types.i64()),
                     _ => RetPointer
                 }
             }
@@ -73,7 +73,7 @@ pub fn compute_abi_info(ccx: &mut CrateContext,
 
                 ret_ty = LLVMType {
                     cast: false,
-                    ty: Type::void(),
+                    ty: ccx.types.void(),
                 };
                 sret = true;
             }

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -760,7 +760,7 @@ pub fn trans_call_inner(in_cx: @mut Block,
             }
             Some(expr::Ignore) => {
                 // drop the value if it is not being saved.
-                bcx = glue::drop_ty(bcx, opt_llretslot.unwrap(), ret_ty);
+                bcx = do glue::drop_ty(bcx, ret_ty) { opt_llretslot.unwrap() };
             }
             Some(expr::SaveIn(_)) => { }
         }

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -624,7 +624,7 @@ pub fn trans_call_inner(in_cx: @mut Block,
         let (llfn, llenv) = unsafe {
             match callee.data {
                 Fn(d) => {
-                    (d.llfn, llvm::LLVMGetUndef(Type::opaque_box(ccx).ptr_to().to_ref()))
+                    (d.llfn, llvm::LLVMGetUndef(ccx.types.opaque_box().ptr_to().to_ref()))
                 }
                 Method(d) => {
                     // Weird but true: we pass self in the *environment* slot!
@@ -664,14 +664,14 @@ pub fn trans_call_inner(in_cx: @mut Block,
                     Some(alloc_ty(bcx, ret_ty, "__llret"))
                 } else {
                     unsafe {
-                        Some(llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()))
+                        Some(llvm::LLVMGetUndef(ccx.types.nil().ptr_to().to_ref()))
                     }
                 }
             }
         };
 
         let mut llresult = unsafe {
-            llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref())
+            llvm::LLVMGetUndef(ccx.types.nil().ptr_to().to_ref())
         };
 
         // The code below invokes the function, using either the Rust

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -44,8 +44,6 @@ use middle::typeck;
 use middle::typeck::coherence::make_substs_for_receiver_types;
 use util::ppaux::Repr;
 
-use middle::trans::type_::Type;
-
 use syntax::ast;
 use syntax::abi::AbiSet;
 use syntax::ast_map;

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -426,7 +426,7 @@ pub fn make_closure_glue(
         cx: @mut Block,
         v: ValueRef,
         t: ty::t,
-        glue_fn: &fn(@mut Block, v: ValueRef, t: ty::t) -> @mut Block) -> @mut Block {
+        glue_fn: val_and_ty_fn) -> @mut Block {
     let _icx = push_ctxt("closure::make_closure_glue");
     let bcx = cx;
     let tcx = cx.tcx();
@@ -439,7 +439,7 @@ pub fn make_closure_glue(
             let box_ptr_v = Load(cx, box_cell_v);
             do with_cond(cx, IsNotNull(cx, box_ptr_v)) |bcx| {
                 let closure_ty = ty::mk_opaque_closure_ptr(tcx, sigil);
-                glue_fn(bcx, box_cell_v, closure_ty)
+                do glue_fn(bcx, closure_ty) { box_cell_v }
             }
         }
     }
@@ -457,9 +457,9 @@ pub fn make_opaque_cbox_drop_glue(
             bcx.tcx().sess.bug("trying to trans drop glue of @fn")
         }
         ast::OwnedSigil => {
-            glue::free_ty(
-                bcx, cboxptr,
-                ty::mk_opaque_closure_ptr(bcx.tcx(), sigil))
+            do glue::free_ty(bcx, ty::mk_opaque_closure_ptr(bcx.tcx(), sigil)) {
+                cboxptr
+            }
         }
     }
 }

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -69,7 +69,7 @@ use syntax::parse::token::special_idents;
 // closure".
 //
 // Typically an opaque closure suffices because we only manipulate it
-// by ptr.  The routine Type::opaque_box().ptr_to() returns an
+// by ptr.  The routine ccx.types.opaque_box().ptr_to() returns an
 // appropriate type for such an opaque closure; it allows access to
 // the box fields, but not the closure_data itself.
 //
@@ -482,7 +482,7 @@ pub fn make_opaque_cbox_free_glue(
     let ccx = bcx.ccx();
     do with_cond(bcx, IsNotNull(bcx, cbox)) |bcx| {
         // Load the type descr found in the cbox
-        let lltydescty = ccx.tydesc_type.ptr_to();
+        let lltydescty = ccx.types.tydesc().ptr_to();
         let cbox = Load(bcx, cbox);
         let tydescptr = GEPi(bcx, cbox, [0u, abi::box_field_tydesc]);
         let tydesc = Load(bcx, tydescptr);

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -310,7 +310,7 @@ pub struct TypeDroppingCleanupFunction {
 
 impl CleanupFunction for TypeDroppingCleanupFunction {
     fn clean(&self, block: @mut Block) -> @mut Block {
-        glue::drop_ty(block, self.val, self.t)
+        do glue::drop_ty(block, self.t) { self.val }
     }
 }
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -844,7 +844,7 @@ pub fn C_uint(cx: &CrateContext, i: uint) -> ValueRef {
 }
 
 pub fn C_u8(cx: &CrateContext, i: uint) -> ValueRef {
-    return C_integral(cx.types.i(), i as u64, false);
+    return C_integral(cx.types.i8(), i as u64, false);
 }
 
 

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -30,7 +30,6 @@ use middle::trans::type_::{Type, CrateTypes};
 use std::c_str::ToCStr;
 use std::hash;
 use std::hashmap::{HashMap, HashSet};
-use std::local_data;
 use std::vec;
 use std::libc::c_uint;
 use syntax::ast;
@@ -130,7 +129,6 @@ impl CrateContext {
                -> CrateContext {
         unsafe {
             let llcx = llvm::LLVMContextCreate();
-            set_task_llcx(llcx);
             let llmod = do name.with_c_str |buf| {
                 llvm::LLVMModuleCreateWithNameInContext(buf, llcx)
             };
@@ -268,21 +266,5 @@ impl CrateContext {
 #[unsafe_destructor]
 impl Drop for CrateContext {
     fn drop(&mut self) {
-        unset_task_llcx();
     }
-}
-
-local_data_key!(task_local_llcx_key: @ContextRef)
-
-pub fn task_llcx() -> ContextRef {
-    let opt = local_data::get(task_local_llcx_key, |k| k.map_move(|k| *k));
-    *opt.expect("task-local LLVMContextRef wasn't ever set!")
-}
-
-fn set_task_llcx(c: ContextRef) {
-    local_data::set(task_local_llcx_key, @c);
-}
-
-fn unset_task_llcx() {
-    local_data::pop(task_local_llcx_key);
 }

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -12,7 +12,7 @@
 use back::{upcall};
 use driver::session;
 use lib::llvm::{ContextRef, ModuleRef, ValueRef};
-use lib::llvm::{llvm, TargetData, TypeNames};
+use lib::llvm::{llvm, TargetData};
 use lib::llvm::mk_target_data;
 use metadata::common::LinkMeta;
 use middle::astencode;
@@ -25,7 +25,7 @@ use middle::trans::debuginfo;
 use middle::trans::common::{C_i32, C_null};
 use middle::ty;
 
-use middle::trans::type_::Type;
+use middle::trans::type_::{Type, CrateTypes};
 
 use std::c_str::ToCStr;
 use std::hash;
@@ -43,8 +43,8 @@ pub struct CrateContext {
      sess: session::Session,
      llmod: ModuleRef,
      llcx: ContextRef,
+     types: ~CrateTypes,
      td: TargetData,
-     tn: TypeNames,
      externs: ExternMap,
      intrinsics: HashMap<&'static str, ValueRef>,
      item_vals: HashMap<ast::NodeId, ValueRef>,
@@ -107,10 +107,6 @@ pub struct CrateContext {
      maps: astencode::Maps,
      stats: @mut Stats,
      upcalls: @upcall::Upcalls,
-     tydesc_type: Type,
-     int_type: Type,
-     float_type: Type,
-     opaque_vec_type: Type,
      builder: BuilderRef_res,
      crate_map: ValueRef,
      // Set when at least one function uses GC. Needed so that
@@ -148,30 +144,23 @@ impl CrateContext {
             };
             let targ_cfg = sess.targ_cfg;
 
+            let types = CrateTypes::new(targ_cfg.arch, llcx);
+
             let td = mk_target_data(sess.targ_cfg.target_strs.data_layout);
-            let mut tn = TypeNames::new();
 
-            let mut intrinsics = base::declare_intrinsics(llmod);
+            let mut intrinsics = base::declare_intrinsics(llmod, types);
             if sess.opts.extra_debuginfo {
-                base::declare_dbg_intrinsics(llmod, &mut intrinsics);
+                base::declare_dbg_intrinsics(llmod, types, &mut intrinsics);
             }
-            let int_type = Type::int(targ_cfg.arch);
-            let float_type = Type::float(targ_cfg.arch);
-            let tydesc_type = Type::tydesc(targ_cfg.arch);
-            let opaque_vec_type = Type::opaque_vec(targ_cfg.arch);
 
-            let mut str_slice_ty = Type::named_struct("str_slice");
-            str_slice_ty.set_struct_body([Type::i8p(), int_type], false);
-
-            tn.associate_type("tydesc", &tydesc_type);
-            tn.associate_type("str_slice", &str_slice_ty);
-
-            let crate_map = decl_crate_map(sess, link_meta, llmod);
+            let crate_map = decl_crate_map(sess, link_meta, llmod, types);
             let dbg_cx = if sess.opts.debuginfo {
                 Some(debuginfo::CrateDebugContext::new(llmod, name.to_owned()))
             } else {
                 None
             };
+
+            let upcalls = upcall::declare_upcalls(types, llmod);
 
             if sess.count_llvm_insns() {
                 base::init_insn_ctxt()
@@ -182,7 +171,7 @@ impl CrateContext {
                   llmod: llmod,
                   llcx: llcx,
                   td: td,
-                  tn: tn,
+                  types: types,
                   externs: HashMap::new(),
                   intrinsics: intrinsics,
                   item_vals: HashMap::new(),
@@ -231,11 +220,7 @@ impl CrateContext {
                     llvm_insns: HashMap::new(),
                     fn_stats: ~[]
                   },
-                  upcalls: upcall::declare_upcalls(targ_cfg, llmod),
-                  tydesc_type: tydesc_type,
-                  int_type: int_type,
-                  float_type: float_type,
-                  opaque_vec_type: opaque_vec_type,
+                  upcalls: upcalls,
                   builder: BuilderRef_res(llvm::LLVMCreateBuilderInContext(llcx)),
                   crate_map: crate_map,
                   uses_gc: false,
@@ -253,9 +238,9 @@ impl CrateContext {
                                pointer: ValueRef,
                                indices: &[uint]) -> ValueRef {
         debug!("const_inbounds_gepi: pointer=%s indices=%?",
-               self.tn.val_to_str(pointer), indices);
+               self.types.val_to_str(pointer), indices);
         let v: ~[ValueRef] =
-            indices.iter().map(|i| C_i32(*i as i32)).collect();
+            indices.iter().map(|i| C_i32(self, *i as i32)).collect();
         unsafe {
             llvm::LLVMConstInBoundsGEP(pointer,
                                        vec::raw::to_ptr(v),
@@ -275,7 +260,7 @@ impl CrateContext {
         unsafe {
             let null = C_null(llptr_ty);
             llvm::LLVMConstPtrToInt(self.const_inbounds_gepi(null, indices),
-                                    self.int_type.to_ref())
+                                    self.types.i().to_ref())
         }
     }
 }

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -43,7 +43,7 @@ pub struct CrateContext {
      sess: session::Session,
      llmod: ModuleRef,
      llcx: ContextRef,
-     types: ~CrateTypes,
+     types: @CrateTypes,
      td: TargetData,
      externs: ExternMap,
      intrinsics: HashMap<&'static str, ValueRef>,

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -250,7 +250,7 @@ pub fn trans_break_cont(bcx: @mut Block,
                     Some(bcx) => bcx,
                         // This is a return from a loop body block
                         None => {
-                            Store(bcx, C_bool(!to_end), bcx.fcx.llretptr.unwrap());
+                            Store(bcx, C_bool(bcx.ccx(), !to_end), bcx.fcx.llretptr.unwrap());
                             cleanup_and_leave(bcx, None, Some(bcx.fcx.get_llreturn()));
                             Unreachable(bcx);
                             return bcx;
@@ -345,8 +345,8 @@ fn trans_fail_value(bcx: @mut Block,
         (C_cstr(bcx.ccx(), @"<runtime>"), 0)
       }
     };
-    let V_str = PointerCast(bcx, V_fail_str, Type::i8p());
-    let V_filename = PointerCast(bcx, V_filename, Type::i8p());
+    let V_str = PointerCast(bcx, V_fail_str, ccx.types.i8p());
+    let V_filename = PointerCast(bcx, V_filename, ccx.types.i8p());
     let args = ~[V_str, V_filename, C_int(ccx, V_line)];
     let did = langcall(bcx, sp_opt, "", FailFnLangItem);
     let bcx = callee::trans_lang_call(bcx, did, args, Some(expr::Ignore)).bcx;

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -19,8 +19,6 @@ use middle::ty;
 use util::common::indenter;
 use util::ppaux;
 
-use middle::trans::type_::Type;
-
 use syntax::ast;
 use syntax::ast::Name;
 use syntax::ast_util;

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -405,7 +405,7 @@ impl Datum {
 
     pub fn to_str(&self, ccx: &CrateContext) -> ~str {
         fmt!("Datum { val=%s, ty=%s, mode=%? }",
-             ccx.tn.val_to_str(self.val),
+             ccx.types.val_to_str(self.val),
              ty_to_str(ccx.tcx, self.ty),
              self.mode)
     }
@@ -433,7 +433,7 @@ impl Datum {
          * Yields the value itself. */
 
         if ty::type_is_voidish(self.ty) {
-            C_nil()
+            C_nil(bcx.ccx())
         } else {
             match self.mode {
                 ByValue => self.val,

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -317,7 +317,7 @@ impl Datum {
         let mut bcx = bcx;
 
         if action == DROP_EXISTING {
-            bcx = glue::drop_ty(bcx, dst, self.ty);
+            bcx = do glue::drop_ty(bcx, self.ty) { dst };
         }
 
         match self.mode {
@@ -329,7 +329,7 @@ impl Datum {
             }
         }
 
-        return glue::take_ty(bcx, dst, self.ty);
+        return do glue::take_ty(bcx, self.ty) { dst };
     }
 
     // This works like copy_val, except that it deinitializes the source.
@@ -348,7 +348,7 @@ impl Datum {
         }
 
         if action == DROP_EXISTING {
-            bcx = glue::drop_ty(bcx, dst, self.ty);
+            bcx = do glue::drop_ty(bcx, self.ty) { dst };
         }
 
         match self.mode {
@@ -553,7 +553,7 @@ impl Datum {
         }
 
         return match self.mode {
-            ByRef(_) => glue::drop_ty(bcx, self.val, self.ty),
+            ByRef(_) => do glue::drop_ty(bcx, self.ty) { self.val },
             ByValue => glue::drop_ty_immediate(bcx, self.val, self.ty)
         };
     }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -1332,8 +1332,8 @@ fn describe_variant(cx: &mut CrateContext,
                     span: Span)
                  -> (DICompositeType, Type, @MemberDescriptionFactory) {
     let variant_name = token::ident_to_str(&variant_info.name);
-    let variant_llvm_type = Type::struct_(struct_def.fields.map(|&t| type_of::type_of(cx, t)),
-                                          struct_def.packed);
+    let variant_llvm_type = cx.types.struct_(struct_def.fields.map(|&t| type_of::type_of(cx, t)),
+                                             struct_def.packed);
     // Could some consistency checks here: size, align, field count, discr type
 
     // Find the source code location of the variant's definition

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -420,7 +420,9 @@ pub fn create_self_argument_metadata(bcx: @mut Block,
         argument_index
     };
 
-    let address_operations = &[unsafe { llvm::LLVMDIBuilderCreateOpDeref(bcx.ccx().types.i64().to_ref()) }];
+    let address_operations = &[unsafe {
+        llvm::LLVMDIBuilderCreateOpDeref(bcx.ccx().types.i64().to_ref())
+    }];
 
     let variable_access = if unsafe { llvm::LLVMIsAAllocaInst(llptr) } != ptr::null() {
         DirectVariable { alloca: llptr }

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -339,7 +339,7 @@ pub fn call_tydesc_glue_full(bcx: @mut Block,
 pub fn call_tydesc_glue(cx: @mut Block, v: ValueRef, t: ty::t, field: uint)
     -> @mut Block {
     let _icx = push_ctxt("call_tydesc_glue");
-    let ti = get_tydesc(bcx.ccx(), t);
+    let ti = get_tydesc(cx.ccx(), t);
     call_tydesc_glue_full(cx, v, ti.tydesc, field, Some(ti));
     return cx;
 }

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -213,8 +213,7 @@ pub fn lazily_emit_tydesc_glue(ccx: @mut CrateContext,
                                field: uint,
                                ti: @mut tydesc_info) {
     let _icx = push_ctxt("lazily_emit_tydesc_glue");
-    let types = &ccx.types;
-    let llfnty = types.glue_fn(type_of::type_of(ccx, ti.ty).ptr_to());
+    let llfnty = ccx.types.glue_fn(type_of::type_of(ccx, ti.ty).ptr_to());
 
     if lazily_emit_simplified_tydesc_glue(ccx, field, ti) {
         return;
@@ -340,7 +339,7 @@ pub fn call_tydesc_glue_full(bcx: @mut Block,
 pub fn call_tydesc_glue(cx: @mut Block, v: ValueRef, t: ty::t, field: uint)
     -> @mut Block {
     let _icx = push_ctxt("call_tydesc_glue");
-    let ti = get_tydesc(cx.ccx(), t);
+    let ti = get_tydesc(bcx.ccx(), t);
     call_tydesc_glue_full(cx, v, ti.tydesc, field, Some(ti));
     return cx;
 }

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -61,7 +61,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
         // convert `i1` to a `bool`, and write to the out parameter
         let val = Call(bcx, llfn, [a, b], []);
         let result = ExtractValue(bcx, val, 0);
-        let overflow = ZExt(bcx, ExtractValue(bcx, val, 1), Type::bool());
+        let overflow = ZExt(bcx, ExtractValue(bcx, val, 1), bcx.ccx().types.bool());
         let retptr = get_param(bcx.fcx.llfn, bcx.fcx.out_arg_pos());
         let ret = Load(bcx, retptr);
         let ret = InsertValue(bcx, ret, result, 0);
@@ -73,19 +73,19 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
     fn memcpy_intrinsic(bcx: @mut Block, name: &'static str, tp_ty: ty::t, sizebits: u8) {
         let ccx = bcx.ccx();
         let lltp_ty = type_of::type_of(ccx, tp_ty);
-        let align = C_i32(machine::llalign_of_min(ccx, lltp_ty) as i32);
+        let align = C_i32(ccx, machine::llalign_of_min(ccx, lltp_ty) as i32);
         let size = match sizebits {
-            32 => C_i32(machine::llsize_of_real(ccx, lltp_ty) as i32),
-            64 => C_i64(machine::llsize_of_real(ccx, lltp_ty) as i64),
+            32 => C_i32(ccx, machine::llsize_of_real(ccx, lltp_ty) as i32),
+            64 => C_i64(ccx, machine::llsize_of_real(ccx, lltp_ty) as i64),
             _ => ccx.sess.fatal("Invalid value for sizebits")
         };
 
         let decl = bcx.fcx.llfn;
         let first_real_arg = bcx.fcx.arg_pos(0u);
-        let dst_ptr = PointerCast(bcx, get_param(decl, first_real_arg), Type::i8p());
-        let src_ptr = PointerCast(bcx, get_param(decl, first_real_arg + 1), Type::i8p());
+        let dst_ptr = PointerCast(bcx, get_param(decl, first_real_arg), ccx.types.i8p());
+        let src_ptr = PointerCast(bcx, get_param(decl, first_real_arg + 1), ccx.types.i8p());
         let count = get_param(decl, first_real_arg + 2);
-        let volatile = C_i1(false);
+        let volatile = C_i1(ccx, false);
         let llfn = bcx.ccx().intrinsics.get_copy(&name);
         Call(bcx, llfn, [dst_ptr, src_ptr, Mul(bcx, size, count), align, volatile], []);
         RetVoid(bcx);
@@ -94,19 +94,19 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
     fn memset_intrinsic(bcx: @mut Block, name: &'static str, tp_ty: ty::t, sizebits: u8) {
         let ccx = bcx.ccx();
         let lltp_ty = type_of::type_of(ccx, tp_ty);
-        let align = C_i32(machine::llalign_of_min(ccx, lltp_ty) as i32);
+        let align = C_i32(ccx, machine::llalign_of_min(ccx, lltp_ty) as i32);
         let size = match sizebits {
-            32 => C_i32(machine::llsize_of_real(ccx, lltp_ty) as i32),
-            64 => C_i64(machine::llsize_of_real(ccx, lltp_ty) as i64),
+            32 => C_i32(ccx, machine::llsize_of_real(ccx, lltp_ty) as i32),
+            64 => C_i64(ccx, machine::llsize_of_real(ccx, lltp_ty) as i64),
             _ => ccx.sess.fatal("Invalid value for sizebits")
         };
 
         let decl = bcx.fcx.llfn;
         let first_real_arg = bcx.fcx.arg_pos(0u);
-        let dst_ptr = PointerCast(bcx, get_param(decl, first_real_arg), Type::i8p());
+        let dst_ptr = PointerCast(bcx, get_param(decl, first_real_arg), ccx.types.i8p());
         let val = get_param(decl, first_real_arg + 1);
         let count = get_param(decl, first_real_arg + 2);
-        let volatile = C_i1(false);
+        let volatile = C_i1(ccx, false);
         let llfn = bcx.ccx().intrinsics.get_copy(&name);
         Call(bcx, llfn, [dst_ptr, val, Mul(bcx, size, count), align, volatile], []);
         RetVoid(bcx);
@@ -114,7 +114,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
 
     fn count_zeros_intrinsic(bcx: @mut Block, name: &'static str) {
         let x = get_param(bcx.fcx.llfn, bcx.fcx.arg_pos(0u));
-        let y = C_i1(false);
+        let y = C_i1(bcx.ccx(), false);
         let llfn = bcx.ccx().intrinsics.get_copy(&name);
         Ret(bcx, Call(bcx, llfn, [x, y], []));
     }
@@ -337,8 +337,8 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
                     // code bloat when `transmute` is used on large structural
                     // types.
                     let lldestptr = fcx.llretptr.unwrap();
-                    let lldestptr = PointerCast(bcx, lldestptr, Type::i8p());
-                    let llsrcptr = PointerCast(bcx, llsrcval, Type::i8p());
+                    let lldestptr = PointerCast(bcx, lldestptr, ccx.types.i8p());
+                    let llsrcptr = PointerCast(bcx, llsrcval, ccx.types.i8p());
 
                     let llsize = llsize_of(ccx, llintype);
                     call_memcpy(bcx, lldestptr, llsrcptr, llsize, 1);
@@ -350,23 +350,23 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
         }
         "needs_drop" => {
             let tp_ty = substs.tys[0];
-            Ret(bcx, C_bool(ty::type_needs_drop(ccx.tcx, tp_ty)));
+            Ret(bcx, C_bool(ccx, ty::type_needs_drop(ccx.tcx, tp_ty)));
         }
         "contains_managed" => {
             let tp_ty = substs.tys[0];
-            Ret(bcx, C_bool(ty::type_contents(ccx.tcx, tp_ty).contains_managed()));
+            Ret(bcx, C_bool(ccx, ty::type_contents(ccx.tcx, tp_ty).contains_managed()));
         }
         "visit_tydesc" => {
             let td = get_param(decl, first_real_arg);
             let visitor = get_param(decl, first_real_arg + 1u);
-            let td = PointerCast(bcx, td, ccx.tydesc_type.ptr_to());
+            let td = PointerCast(bcx, td, ccx.types.tydesc().ptr_to());
             glue::call_tydesc_glue_full(bcx, visitor, td,
                                         abi::tydesc_field_visit_glue, None);
             RetVoid(bcx);
         }
         "frame_address" => {
             let frameaddress = ccx.intrinsics.get_copy(& &"llvm.frameaddress");
-            let frameaddress_val = Call(bcx, frameaddress, [C_i32(0i32)], []);
+            let frameaddress_val = Call(bcx, frameaddress, [C_i32(ccx, 0i32)], []);
             let star_u8 = ty::mk_imm_ptr(
                 bcx.tcx(),
                 ty::mk_mach_uint(ast::ty_u8));
@@ -398,7 +398,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
             let llfty = type_of_rust_fn(bcx.ccx(), [], ty::mk_nil());
             let morestack_addr = decl_cdecl_fn(
                 bcx.ccx().llmod, "__morestack", llfty);
-            let morestack_addr = PointerCast(bcx, morestack_addr, Type::nil().ptr_to());
+            let morestack_addr = PointerCast(bcx, morestack_addr, ccx.types.nil().ptr_to());
             Ret(bcx, morestack_addr);
         }
         "offset" => {

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -30,7 +30,6 @@ use syntax::attr;
 use syntax::opt_vec;
 use util::ppaux::{ty_to_str};
 use middle::trans::machine::llsize_of;
-use middle::trans::type_::Type;
 
 pub fn trans_intrinsic(ccx: @mut CrateContext,
                        decl: ValueRef,

--- a/src/librustc/middle/trans/llrepr.rs
+++ b/src/librustc/middle/trans/llrepr.rs
@@ -25,13 +25,13 @@ impl<'self, T:LlvmRepr> LlvmRepr for &'self [T] {
 
 impl LlvmRepr for Type {
     fn llrepr(&self, ccx: &CrateContext) -> ~str {
-        ccx.tn.type_to_str(*self)
+        ccx.types.type_to_str(*self)
     }
 }
 
 impl LlvmRepr for ValueRef {
     fn llrepr(&self, ccx: &CrateContext) -> ~str {
-        ccx.tn.val_to_str(*self)
+        ccx.types.val_to_str(*self)
     }
 }
 

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -79,7 +79,7 @@ pub fn llsize_of(cx: &CrateContext, ty: Type) -> ValueRef {
 // space to be consumed.
 pub fn nonzero_llsize_of(cx: &CrateContext, ty: Type) -> ValueRef {
     if llbitsize_of_real(cx, ty) == 0 {
-        unsafe { llvm::LLVMConstInt(cx.int_type.to_ref(), 1, False) }
+        unsafe { llvm::LLVMConstInt(cx.types.i().to_ref(), 1, False) }
     } else {
         llsize_of(cx, ty)
     }
@@ -110,7 +110,7 @@ pub fn llalign_of_min(cx: &CrateContext, ty: Type) -> uint {
 pub fn llalign_of(cx: &CrateContext, ty: Type) -> ValueRef {
     unsafe {
         return llvm::LLVMConstIntCast(
-            llvm::LLVMAlignOf(ty.to_ref()), cx.int_type.to_ref(), False);
+            llvm::LLVMAlignOf(ty.to_ref()), cx.types.i().to_ref(), False);
     }
 }
 

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -30,8 +30,6 @@ use middle::typeck;
 use util::common::indenter;
 use util::ppaux::Repr;
 
-use middle::trans::type_::Type;
-
 use std::c_str::ToCStr;
 use std::vec;
 use syntax::ast_map::{path, path_mod, path_name, path_pretty_name};

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -52,7 +52,7 @@ impl Reflector {
     }
 
     pub fn c_bool(&mut self, b: bool) -> ValueRef {
-        C_bool(b)
+        C_bool(self.bcx.ccx(), b)
     }
 
     pub fn c_slice(&mut self, s: @str) -> ValueRef {
@@ -63,7 +63,7 @@ impl Reflector {
         let str_ty = ty::mk_estr(bcx.tcx(), str_vstore);
         let scratch = scratch_datum(bcx, str_ty, "", false);
         let len = C_uint(bcx.ccx(), s.len());
-        let c_str = PointerCast(bcx, C_cstr(bcx.ccx(), s), Type::i8p());
+        let c_str = PointerCast(bcx, C_cstr(bcx.ccx(), s), bcx.ccx().types.i8p());
         Store(bcx, c_str, GEPi(bcx, scratch.val, [ 0, 0 ]));
         Store(bcx, len, GEPi(bcx, scratch.val, [ 0, 1 ]));
         scratch.val
@@ -325,7 +325,7 @@ impl Reflector {
                 for (i, v) in variants.iter().enumerate() {
                     let name = ccx.sess.str_of(v.name);
                     let variant_args = ~[this.c_uint(i),
-                                         C_integral(self.bcx.ccx().int_type, v.disr_val, false),
+                                         C_integral(self.bcx.ccx().types.i(), v.disr_val, false),
                                          this.c_uint(v.args.len()),
                                          this.c_slice(name)];
                     do this.bracketed("enum_variant", variant_args) |this| {

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -541,7 +541,9 @@ pub fn get_base_and_len(bcx: @mut Block,
     }
 }
 
-pub type iter_vec_block<'self> = &'self fn(@mut Block, ValueRef, ty::t) -> @mut Block;
+pub type iter_vec_block<'self> = &'self fn(@mut Block, ty::t,
+                                           &fn() -> ValueRef) -> @mut Block;
+
 
 pub fn iter_vec_raw(bcx: @mut Block, data_ptr: ValueRef, vec_ty: ty::t,
                     fill: ValueRef, f: iter_vec_block) -> @mut Block {
@@ -565,7 +567,7 @@ pub fn iter_vec_raw(bcx: @mut Block, data_ptr: ValueRef, vec_ty: ty::t,
     let body_bcx = base::sub_block(header_bcx, "iter_vec_loop_body");
     let next_bcx = base::sub_block(header_bcx, "iter_vec_next");
     CondBr(header_bcx, not_yet_at_end, body_bcx.llbb, next_bcx.llbb);
-    let body_bcx = f(body_bcx, data_ptr, unit_ty);
+    let body_bcx = do f(body_bcx, unit_ty) { data_ptr };
     AddIncomingToPhi(data_ptr, InBoundsGEP(body_bcx, data_ptr,
                                            [C_int(bcx.ccx(), 1)]),
                      body_bcx.llbb);

--- a/src/librustc/middle/trans/uniq.rs
+++ b/src/librustc/middle/trans/uniq.rs
@@ -25,8 +25,9 @@ pub fn make_free_glue(bcx: @mut Block, vptrptr: ValueRef, box_ty: ty::t)
     let not_null = IsNotNull(bcx, box_datum.val);
     do with_cond(bcx, not_null) |bcx| {
         let body_datum = box_datum.box_body(bcx);
-        let bcx = glue::drop_ty(bcx, body_datum.to_ref_llval(bcx),
-                                body_datum.ty);
+        let bcx = do glue::drop_ty(bcx, body_datum.ty) {
+            body_datum.to_ref_llval(bcx)
+        };
         if ty::type_contents(bcx.tcx(), box_ty).contains_managed() {
             glue::trans_free(bcx, box_datum.val)
         } else {

--- a/src/librustc/middle/trans/write_guard.rs
+++ b/src/librustc/middle/trans/write_guard.rs
@@ -31,8 +31,6 @@ use middle::ty;
 use syntax::codemap::Span;
 use syntax::ast;
 
-use middle::trans::type_::Type;
-
 pub fn root_and_write_guard(datum: &Datum,
                             mut bcx: @mut Block,
                             span: Span,

--- a/src/librustc/middle/trans/write_guard.rs
+++ b/src/librustc/middle/trans/write_guard.rs
@@ -72,7 +72,7 @@ pub fn return_to_mut(mut bcx: @mut Block,
            bcx.val_to_str(frozen_val_ref),
            bcx.val_to_str(bits_val_ref));
 
-    let box_ptr = Load(bcx, PointerCast(bcx, frozen_val_ref, Type::i8p().ptr_to()));
+    let box_ptr = Load(bcx, PointerCast(bcx, frozen_val_ref, bcx.ccx().types.i8p().ptr_to()));
 
     let bits_val = Load(bcx, bits_val_ref);
 
@@ -147,7 +147,7 @@ fn root(datum: &Datum,
                 DynaMut => BorrowAsMutFnLangItem,
             };
 
-            let box_ptr = Load(bcx, PointerCast(bcx, scratch.val, Type::i8p().ptr_to()));
+            let box_ptr = Load(bcx, PointerCast(bcx, scratch.val, bcx.ccx().types.i8p().ptr_to()));
 
             let llresult = unpack_result!(bcx, callee::trans_lang_call(
                 bcx,
@@ -192,6 +192,6 @@ fn perform_write_guard(datum: &Datum,
     callee::trans_lang_call(
         bcx,
         langcall(bcx, Some(span), "write guard", CheckNotBorrowedFnLangItem),
-        [PointerCast(bcx, llval, Type::i8p()), filename, line],
+        [PointerCast(bcx, llval, bcx.ccx().types.i8p()), filename, line],
         Some(expr::Ignore)).bcx
 }


### PR DESCRIPTION
- created CrateTypes struct (a member of CrateContext) and used it to cache many compiler context Type objects such as all primitive types (i8, i16, nil, void etc) as well as tydesc, opaque_box, generic_glue_fn etc.
  This CrateTypes object supersedes most Type::global_methods, so now:
- \- instead of `Type::void()` should be `ccx.types.void()`;
- \- instead of `ccx.int_type` should be `ccx.types.i()`;
- \- instead of `Type::opaque_box(ccx)` - `ccx.types.opaque_box()`
- \- and this:
  `Type::box(cx, &Type::vec(cx.sess.targ_cfg.arch, &Type::i8()))`
  would be replaced with this

``` cx.types.box(&cx.types.vec(cx.types.i8()))```

* fixed some useless code generation (for POD struct/tuple members) for glue_take, glue_drop and in other similar situations

* got rid of global variable task_llcx as it wasn't really needed
```
