### PR TITLE
Remove the notion of an "unknown format"

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1124,11 +1124,12 @@ impl<'self> fmt::Default for Sidebar<'self> {
                 write!(w, "<a class='{ty} {class}' href='{curty, select,
                                 mod{../}
                                 other{}
-                           }{ty, select,
+                           }{tysel, select,
                                 mod{{name}/index.html}
                                 other{#.{name}.html}
                            }'>{name}</a><br/>",
                        ty = short,
+                       tysel = short,
                        class = class,
                        curty = shortty(cur),
                        name = item.as_slice());

--- a/src/test/compile-fail/ifmt-bad-arg.rs
+++ b/src/test/compile-fail/ifmt-bad-arg.rs
@@ -65,8 +65,8 @@ fn main() {
     // format strings because otherwise the "internal pointer of which argument
     // is next" would be invalidated if different cases had different numbers of
     // arguments.
-    format!("{0, select, other{{}}}", "a"); //~ ERROR: cannot use implicit
-    format!("{0, plural, other{{}}}", 1); //~ ERROR: cannot use implicit
+    format!("{1, select, other{{}}}", 1, "a"); //~ ERROR: cannot use implicit
+    format!("{1, plural, other{{}}}", 1, 1); //~ ERROR: cannot use implicit
     format!("{0, plural, other{{1:.*d}}}", 1, 2); //~ ERROR: cannot use implicit
 
     format!("foo } bar"); //~ ERROR: unmatched `}` found

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -85,7 +85,6 @@ pub fn main() {
     t!(format!("{1} {0}", 0, 1), "1 0");
     t!(format!("{foo} {bar}", foo=0, bar=1), "0 1");
     t!(format!("{foo} {1} {bar} {0}", 0, 1, foo=2, bar=3), "2 1 3 0");
-    t!(format!("{} {0:s}", "a"), "a a");
     t!(format!("{} {0}", "a"), "a a");
     t!(format!("{foo_bar}", foo_bar=1), "1");
 
@@ -98,8 +97,8 @@ pub fn main() {
     t!(format!("{0, select, a{a#} b{b#} c{c#} other{d#}}", "b"), "bb");
     t!(format!("{0, select, a{a#} b{b#} c{c#} other{d#}}", "c"), "cc");
     t!(format!("{0, select, a{a#} b{b#} c{c#} other{d#}}", "d"), "dd");
-    t!(format!("{1, select, a{#{0:s}} other{#{1}}}", "b", "a"), "ab");
-    t!(format!("{1, select, a{#{0}} other{#{1}}}", "c", "b"), "bb");
+    t!(format!("{1, select, a{#{0:s}} other{#}}", "b", "a"), "ab");
+    t!(format!("{1, select, a{#{0}} other{#}}", "c", "b"), "b");
 
     // Formatting strings and their arguments
     t!(format!("{:s}", "a"), "a");


### PR DESCRIPTION
As mentioned in #9456, the format! syntax extension would previously consider an
empty format as a 'Unknown' format which could then also get coerced into a
different style of format on another argument.

This is unusual behavior because `{}` is a very common format and if you have
`{0} {0:?}` you wouldn't expect them both to be coereced to the `Poly`
formatter. This commit removes this coercion, but still retains the requirement
that each argument has exactly one format specified for it (an empty format now
counts as well).

Perhaps at a later date we can add support for multiple formats of one argument,
but this puts us in at least a backwards-compatible situation if we decide to do
that.
