### PR TITLE
mk: Fully clean out old documentation

### DIFF
--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -54,9 +54,8 @@ clean-misc:
 	$(Q)rm -Rf rust-stage0-*.tar.bz2 $(PKG_NAME)-*.tar.gz dist
 	$(Q)rm -Rf $(foreach ext, \
                  html aux cp fn ky log pdf pg toc tp vr cps, \
-                 $(wildcard doc/*.$(ext) \
-                            doc/*/*.$(ext) \
-                            doc/*/*/*.$(ext)))
+                 $(wildcard doc/*.$(ext)))
+	$(Q)find doc/std doc/extra -mindepth 1 | xargs rm -Rf
 	$(Q)rm -Rf doc/version.md
 	$(Q)rm -Rf $(foreach sub, index styles files search javascript, \
                  $(wildcard doc/*/$(sub)))


### PR DESCRIPTION
This purges doc/{std,extra} entirely during a `make clean` instead of just the
html files in some top level directories. This should help old documentation
from showing up on static.rust-lang.org
