### PR TITLE
librustc: Don't pass around Session with @ and make building_library just bool instead of @mut bool.

### DIFF
--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -20,7 +20,7 @@ fn not_win32(os: session::Os) -> bool {
   os != session::OsWin32
 }
 
-pub fn get_rpath_flags(sess: session::Session, out_filename: &Path)
+pub fn get_rpath_flags(sess: &session::Session, out_filename: &Path)
                     -> ~[~str] {
     let os = sess.targ_cfg.os;
 
@@ -43,7 +43,7 @@ pub fn get_rpath_flags(sess: session::Session, out_filename: &Path)
     rpaths_to_flags(rpaths)
 }
 
-fn get_sysroot_absolute_rt_lib(sess: session::Session) -> Path {
+fn get_sysroot_absolute_rt_lib(sess: &session::Session) -> Path {
     let r = filesearch::relative_target_lib_path(sess.opts.target_triple);
     sess.filesearch.sysroot().push_rel(&r).push(os::dll_filename("rustrt"))
 }

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -200,7 +200,7 @@ pub enum EntryFnType {
     EntryNone,
 }
 
-pub struct Session_ {
+pub struct Session {
     targ_cfg: @config,
     opts: @options,
     cstore: @mut metadata::cstore::CStore,
@@ -211,15 +211,13 @@ pub struct Session_ {
     entry_type: @mut Option<EntryFnType>,
     span_diagnostic: @mut diagnostic::span_handler,
     filesearch: @filesearch::FileSearch,
-    building_library: @mut bool,
+    building_library: bool,
     working_dir: Path,
     lints: @mut HashMap<ast::NodeId, ~[(lint::lint, codemap::Span, ~str)]>,
     node_id: @mut uint,
 }
 
-pub type Session = @Session_;
-
-impl Session_ {
+impl Session {
     pub fn span_fatal(&self, sp: Span, msg: &str) -> ! {
         self.span_diagnostic.span_fatal(sp, msg)
     }
@@ -389,7 +387,7 @@ pub fn basic_options() -> @options {
 }
 
 // Seems out of place, but it uses session, so I'm putting it here
-pub fn expect<T:Clone>(sess: Session, opt: Option<T>, msg: &fn() -> ~str)
+pub fn expect<T:Clone>(sess: &Session, opt: Option<T>, msg: &fn() -> ~str)
                        -> T {
     diagnostic::expect(sess.diagnostic(), opt, msg)
 }

--- a/src/librustc/front/assign_node_ids.rs
+++ b/src/librustc/front/assign_node_ids.rs
@@ -13,18 +13,18 @@ use driver::session::Session;
 use syntax::ast;
 use syntax::fold::ast_fold;
 
-struct NodeIdAssigner {
-    sess: Session,
+struct NodeIdAssigner<'self> {
+    sess: &'self Session,
 }
 
-impl ast_fold for NodeIdAssigner {
+impl<'self> ast_fold for NodeIdAssigner<'self> {
     fn new_id(&self, old_id: ast::NodeId) -> ast::NodeId {
         assert_eq!(old_id, ast::DUMMY_NODE_ID);
         self.sess.next_node_id()
     }
 }
 
-pub fn assign_node_ids(sess: Session, crate: @ast::Crate) -> @ast::Crate {
+pub fn assign_node_ids(sess: &Session, crate: @ast::Crate) -> @ast::Crate {
     let fold = NodeIdAssigner {
         sess: sess,
     };

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -22,7 +22,7 @@ use syntax::opt_vec;
 
 static STD_VERSION: &'static str = "0.9-pre";
 
-pub fn maybe_inject_libstd_ref(sess: Session, crate: @ast::Crate)
+pub fn maybe_inject_libstd_ref(sess: &Session, crate: @ast::Crate)
                                -> @ast::Crate {
     if use_std(crate) {
         inject_libstd_ref(sess, crate)
@@ -46,11 +46,11 @@ fn spanned<T>(x: T) -> codemap::Spanned<T> {
     }
 }
 
-struct StandardLibraryInjector {
-    sess: Session,
+struct StandardLibraryInjector<'self> {
+    sess: &'self Session,
 }
 
-impl fold::ast_fold for StandardLibraryInjector {
+impl<'self> fold::ast_fold for StandardLibraryInjector<'self> {
     fn fold_crate(&self, crate: &ast::Crate) -> ast::Crate {
         let version = STD_VERSION.to_managed();
         let vi1 = ast::view_item {
@@ -133,7 +133,7 @@ impl fold::ast_fold for StandardLibraryInjector {
     }
 }
 
-fn inject_libstd_ref(sess: Session, crate: &ast::Crate) -> @ast::Crate {
+fn inject_libstd_ref(sess: &Session, crate: &ast::Crate) -> @ast::Crate {
     let fold = StandardLibraryInjector {
         sess: sess,
     };

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -153,7 +153,7 @@ pub fn decode_inlined_item(cdata: @cstore::crate_metadata,
 // ______________________________________________________________________
 // Enumerating the IDs which appear in an AST
 
-fn reserve_id_range(sess: Session,
+fn reserve_id_range(sess: &Session,
                     from_id_range: ast_util::id_range) -> ast_util::id_range {
     // Handle the case of an empty range:
     if from_id_range.empty() { return from_id_range; }

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -19,8 +19,8 @@ use syntax::parse::token::special_idents;
 use syntax::visit;
 use syntax::visit::Visitor;
 
-struct EntryContext {
-    session: Session,
+struct EntryContext<'self> {
+    session: &'self Session,
 
     ast_map: ast_map::map,
 
@@ -38,16 +38,16 @@ struct EntryContext {
     non_main_fns: ~[(NodeId, Span)],
 }
 
-impl Visitor<()> for EntryContext {
+impl<'self> Visitor<()> for EntryContext<'self> {
     fn visit_item(&mut self, item:@item, _:()) {
         find_item(item, self);
     }
 }
 
-pub fn find_entry_point(session: Session, crate: &Crate, ast_map: ast_map::map) {
+pub fn find_entry_point(session: &Session, crate: &Crate, ast_map: ast_map::map) {
 
     // FIXME #4404 android JNI hacks
-    if *session.building_library &&
+    if session.building_library &&
         session.targ_cfg.os != session::OsAndroid {
         // No need to find a main function
         return;
@@ -134,7 +134,7 @@ fn configure_main(this: &mut EntryContext) {
         *this.session.entry_fn = this.main_fn;
         *this.session.entry_type = Some(session::EntryMain);
     } else {
-        if !*this.session.building_library {
+        if !this.session.building_library {
             // No main function
             this.session.err("main function not found");
             if !this.non_main_fns.is_empty() {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -296,7 +296,7 @@ struct LanguageItemCollector<'self> {
     items: LanguageItems,
 
     crate: &'self Crate,
-    session: Session,
+    session: &'self Session,
 
     item_refs: HashMap<@str, uint>,
 }
@@ -323,7 +323,7 @@ impl<'self> Visitor<()> for LanguageItemVisitor<'self> {
 }
 
 impl<'self> LanguageItemCollector<'self> {
-    pub fn new<'a>(crate: &'a Crate, session: Session)
+    pub fn new<'a>(crate: &'a Crate, session: &'a Session)
                    -> LanguageItemCollector<'a> {
         let mut item_refs = HashMap::new();
 
@@ -456,7 +456,7 @@ impl<'self> LanguageItemCollector<'self> {
 }
 
 pub fn collect_language_items(crate: &Crate,
-                              session: Session)
+                              session: &Session)
                            -> LanguageItems {
     let mut collector = LanguageItemCollector::new(crate, session);
     collector.collect();

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -601,7 +601,7 @@ impl Context {
     }
 }
 
-pub fn each_lint(sess: session::Session,
+pub fn each_lint(sess: &session::Session,
                  attrs: &[ast::Attribute],
                  f: &fn(@ast::MetaItem, level, @str) -> bool) -> bool {
     let xs = [allow, warn, deny, forbid];

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -363,7 +363,7 @@ fn variant_opt(bcx: @mut Block, pat_id: ast::NodeId)
             return lit(UnitLikeStructLit(pat_id));
         }
         _ => {
-            ccx.sess.bug("non-variant or struct in variant_opt()");
+            ccx.tcx.sess.bug("non-variant or struct in variant_opt()");
         }
     }
 }
@@ -470,7 +470,7 @@ fn expand_nested_bindings<'r>(bcx: @mut Block,
 
 fn assert_is_binding_or_wild(bcx: @mut Block, p: @ast::Pat) {
     if !pat_is_binding_or_wild(bcx.tcx().def_map, p) {
-        bcx.sess().span_bug(
+        bcx.tcx().sess.span_bug(
             p.span,
             fmt!("Expected an identifier pattern but found p: %s",
                  p.repr(bcx.tcx())));
@@ -1386,7 +1386,7 @@ fn insert_lllocals(bcx: @mut Block,
         debug!("binding %? to %s", binding_info.id, bcx.val_to_str(llval));
         llmap.insert(binding_info.id, llval);
 
-        if bcx.sess().opts.extra_debuginfo {
+        if bcx.tcx().sess.opts.extra_debuginfo {
             debuginfo::create_match_binding_metadata(bcx,
                                                      ident,
                                                      binding_info.id,
@@ -1558,7 +1558,7 @@ fn compile_submatch_continue(mut bcx: @mut Block,
         let tup_repr = adt::represent_type(bcx.ccx(), tup_ty);
         let n_tup_elts = match ty::get(tup_ty).sty {
           ty::ty_tup(ref elts) => elts.len(),
-          _ => ccx.sess.bug("non-tuple type in tuple pattern")
+          _ => ccx.tcx.sess.bug("non-tuple type in tuple pattern")
         };
         let tup_vals = do vec::from_fn(n_tup_elts) |i| {
             adt::trans_field_ptr(bcx, tup_repr, val, 0, i)
@@ -1577,7 +1577,7 @@ fn compile_submatch_continue(mut bcx: @mut Block,
                     ty::lookup_struct_fields(tcx, struct_id).len();
             }
             _ => {
-                ccx.sess.bug("non-struct type in tuple struct pattern");
+                ccx.tcx.sess.bug("non-struct type in tuple struct pattern");
             }
         }
 
@@ -1696,7 +1696,7 @@ fn compile_submatch_continue(mut bcx: @mut Block,
                         }
                       }
                       _ => {
-                          bcx.sess().bug(
+                          bcx.tcx().sess.bug(
                               "in compile_submatch, expected \
                                trans_opt to return a single_result")
                       }
@@ -2002,7 +2002,7 @@ pub fn store_local(bcx: @mut Block,
             if ty::type_is_bot(expr_ty(bcx, init_expr)) {
                 create_dummy_locals(bcx, pat)
             } else {
-                if bcx.sess().asm_comments() {
+                if bcx.tcx().sess.asm_comments() {
                     add_comment(bcx, "creating zeroable ref llval");
                 }
                 let llptr = init_datum.to_zeroable_ref_llval(bcx);
@@ -2055,7 +2055,7 @@ pub fn store_arg(mut bcx: @mut Block,
     // Debug information (the llvm.dbg.declare intrinsic to be precise) always expects to get an
     // alloca, which only is the case on the general path, so lets disable the optimized path when
     // debug info is enabled.
-    let fast_path = !bcx.ccx().sess.opts.extra_debuginfo && simple_identifier(pat).is_some();
+    let fast_path = !bcx.tcx().sess.opts.extra_debuginfo && simple_identifier(pat).is_some();
 
     if fast_path {
         // Optimized path for `x: T` case. This just adopts
@@ -2118,7 +2118,7 @@ fn bind_irrefutable_pat(bcx: @mut Block,
            pat.repr(bcx.tcx()),
            binding_mode);
 
-    if bcx.sess().asm_comments() {
+    if bcx.tcx().sess.asm_comments() {
         add_comment(bcx, fmt!("bind_irrefutable_pat(pat=%s)",
                               pat.repr(bcx.tcx())));
     }

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -179,9 +179,9 @@ fn represent_type_uncached(cx: &mut CrateContext, t: ty::t) -> Repr {
             // non-empty body, explicit discriminants should have
             // been rejected by a checker before this point.
             if !cases.iter().enumerate().all(|(i,c)| c.discr == (i as Disr)) {
-                cx.sess.bug(fmt!("non-C-like enum %s with specified \
-                                  discriminants",
-                                 ty::item_path_str(cx.tcx, def_id)))
+                cx.tcx.sess.bug(fmt!("non-C-like enum %s with specified \
+                                      discriminants",
+                                     ty::item_path_str(cx.tcx, def_id)))
             }
 
             if cases.len() == 2 {
@@ -210,7 +210,7 @@ fn represent_type_uncached(cx: &mut CrateContext, t: ty::t) -> Repr {
             let discr = ~[ty::mk_uint()];
             return General(cases.map(|c| mk_struct(cx, discr + c.tys, false)))
         }
-        _ => cx.sess.bug("adt::represent_type called on non-ADT type")
+        _ => cx.tcx.sess.bug("adt::represent_type called on non-ADT type")
     }
 }
 
@@ -354,7 +354,7 @@ pub fn trans_case(bcx: @mut Block, r: &Repr, discr: Disr) -> _match::opt_result 
             _match::single_result(rslt(bcx, C_disr(bcx.ccx(), discr)))
         }
         Univariant(*) => {
-            bcx.ccx().sess.bug("no cases for univariants or structs")
+            bcx.ccx().tcx.sess.bug("no cases for univariants or structs")
         }
         General(*) => {
             _match::single_result(rslt(bcx, C_disr(bcx.ccx(), discr)))
@@ -424,7 +424,7 @@ pub fn trans_field_ptr(bcx: @mut Block, r: &Repr, val: ValueRef, discr: Disr,
     // someday), it will need to return a possibly-new bcx as well.
     match *r {
         CEnum(*) => {
-            bcx.ccx().sess.bug("element access in C-like enum")
+            bcx.ccx().tcx.sess.bug("element access in C-like enum")
         }
         Univariant(ref st, _dtor) => {
             assert_eq!(discr, 0);
@@ -470,7 +470,7 @@ fn struct_field_ptr(bcx: @mut Block, st: &Struct, val: ValueRef, ix: uint,
 pub fn trans_drop_flag_ptr(bcx: @mut Block, r: &Repr, val: ValueRef) -> ValueRef {
     match *r {
         Univariant(ref st, true) => GEPi(bcx, val, [0, st.fields.len() - 1]),
-        _ => bcx.ccx().sess.bug("tried to get drop flag of non-droppable type")
+        _ => bcx.ccx().tcx.sess.bug("tried to get drop flag of non-droppable type")
     }
 }
 
@@ -608,7 +608,7 @@ pub fn const_get_discrim(ccx: &mut CrateContext, r: &Repr, val: ValueRef)
 pub fn const_get_field(ccx: &mut CrateContext, r: &Repr, val: ValueRef,
                        _discr: Disr, ix: uint) -> ValueRef {
     match *r {
-        CEnum(*) => ccx.sess.bug("element access in C-like enum const"),
+        CEnum(*) => ccx.tcx.sess.bug("element access in C-like enum const"),
         Univariant(*) => const_struct_field(ccx, val, ix),
         General(*) => const_struct_field(ccx, val, ix + 1),
         NullablePointer{ _ } => const_struct_field(ccx, val, ix)

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -47,10 +47,10 @@ impl Builder {
     }
 
     pub fn count_insn(&self, category: &str) {
-        if self.ccx.sess.trans_stats() {
+        if self.ccx.tcx.sess.trans_stats() {
             self.ccx.stats.n_llvm_insns += 1;
         }
-        if self.ccx.sess.count_llvm_insns() {
+        if self.ccx.tcx.sess.count_llvm_insns() {
             do base::with_insn_ctxt |v| {
                 let h = &mut self.ccx.stats.llvm_insns;
 
@@ -724,15 +724,15 @@ impl Builder {
     }
 
     pub fn add_span_comment(&self, sp: Span, text: &str) {
-        if self.ccx.sess.asm_comments() {
-            let s = fmt!("%s (%s)", text, self.ccx.sess.codemap.span_to_str(sp));
+        if self.ccx.tcx.sess.asm_comments() {
+            let s = fmt!("%s (%s)", text, self.ccx.tcx.sess.codemap.span_to_str(sp));
             debug!("%s", s);
             self.add_comment(s);
         }
     }
 
     pub fn add_comment(&self, text: &str) {
-        if self.ccx.sess.asm_comments() {
+        if self.ccx.tcx.sess.asm_comments() {
             let sanitized = text.replace("$", "");
             let comment_text = fmt!("# %s", sanitized.replace("\n", "\n\t# "));
             self.count_insn("inlineasm");

--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -52,7 +52,7 @@ pub fn compute_abi_info(ccx: &mut CrateContext,
                         atys: &[Type],
                         rty: Type,
                         ret_def: bool) -> FnType {
-    match ccx.sess.targ_cfg.arch {
+    match ccx.tcx.sess.targ_cfg.arch {
         X86 => cabi_x86::compute_abi_info(ccx, atys, rty, ret_def),
         X86_64 => cabi_x86_64::compute_abi_info(ccx, atys, rty, ret_def),
         Arm => cabi_arm::compute_abi_info(ccx, atys, rty, ret_def),

--- a/src/librustc/middle/trans/cabi_x86.rs
+++ b/src/librustc/middle/trans/cabi_x86.rs
@@ -41,7 +41,7 @@ pub fn compute_abi_info(ccx: &mut CrateContext,
         // Clang's ABI handling is in lib/CodeGen/TargetInfo.cpp
 
         enum Strategy { RetValue(Type), RetPointer }
-        let strategy = match ccx.sess.targ_cfg.os {
+        let strategy = match ccx.tcx.sess.targ_cfg.os {
             OsWin32 | OsMacos => {
                 match llsize_of_alloc(ccx, rty) {
                     1 => RetValue(Type::i8()),

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -363,7 +363,7 @@ pub fn trans_fn_ref_with_vtables(
         must_monomorphise = true;
     } else if def_id.crate == ast::LOCAL_CRATE {
         let map_node = session::expect(
-            ccx.sess,
+            ccx.tcx.sess,
             ccx.tcx.items.find(&def_id.node),
             || fmt!("local item should be in ast map"));
 

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -231,7 +231,7 @@ pub fn store_environment(bcx: @mut Block,
     for (i, bv) in bound_values.iter().enumerate() {
         debug!("Copy %s into closure", bv.to_str(ccx));
 
-        if ccx.sess.asm_comments() {
+        if ccx.tcx.sess.asm_comments() {
             add_comment(bcx, fmt!("Copy %s into closure",
                                   bv.to_str(ccx)));
         }
@@ -311,7 +311,7 @@ pub fn load_environment(fcx: @mut FunctionContext,
 
     // Store the pointer to closure data in an alloca for debug info because that's what the
     // llvm.dbg.declare intrinsic expects
-    let env_pointer_alloca = if fcx.ccx.sess.opts.extra_debuginfo {
+    let env_pointer_alloca = if fcx.ccx.tcx.sess.opts.extra_debuginfo {
         let alloc = alloc_ty(bcx, ty::mk_mut_ptr(bcx.tcx(), cdata_ty), "__debuginfo_env_ptr");
         Store(bcx, llcdata, alloc);
         Some(alloc)

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -275,7 +275,7 @@ impl FunctionContext {
 pub fn warn_not_to_commit(ccx: &mut CrateContext, msg: &str) {
     if !ccx.do_not_commit_warning_issued {
         ccx.do_not_commit_warning_issued = true;
-        ccx.sess.warn(msg.to_str() + " -- do not commit like this!");
+        ccx.tcx.sess.warn(msg.to_str() + " -- do not commit like this!");
     }
 }
 
@@ -660,14 +660,13 @@ impl Block {
 
     pub fn ccx(&self) -> @mut CrateContext { self.fcx.ccx }
     pub fn tcx(&self) -> ty::ctxt { self.fcx.ccx.tcx }
-    pub fn sess(&self) -> Session { self.fcx.ccx.sess }
 
     pub fn ident(&self, ident: Ident) -> @str {
         token::ident_to_str(&ident)
     }
 
     pub fn node_id_to_str(&self, id: ast::NodeId) -> ~str {
-        ast_map::node_id_to_str(self.tcx().items, id, self.sess().intr())
+        ast_map::node_id_to_str(self.tcx().items, id, self.tcx().sess.intr())
     }
 
     pub fn expr_to_str(&self, e: @ast::Expr) -> ~str {
@@ -769,7 +768,7 @@ pub fn in_scope_cx(cx: @mut Block, scope_id: Option<ast::NodeId>, f: &fn(si: &mu
 pub fn block_parent(cx: @mut Block) -> @mut Block {
     match cx.parent {
       Some(b) => b,
-      None    => cx.sess().bug(fmt!("block_parent called on root block %?",
+      None    => cx.tcx().sess.bug(fmt!("block_parent called on root block %?",
                                    cx))
     }
 }
@@ -1042,7 +1041,7 @@ pub fn align_to(cx: @mut Block, off: ValueRef, align: ValueRef) -> ValueRef {
     return build::And(cx, bumped, build::Not(cx, mask));
 }
 
-pub fn path_str(sess: session::Session, p: &[path_elt]) -> ~str {
+pub fn path_str(sess: &session::Session, p: &[path_elt]) -> ~str {
     let mut r = ~"";
     let mut first = true;
     for e in p.iter() {
@@ -1095,7 +1094,7 @@ pub fn node_id_type_params(bcx: @mut Block, id: ast::NodeId) -> ~[ty::t] {
     let params = ty::node_id_to_type_params(tcx, id);
 
     if !params.iter().all(|t| !ty::type_needs_infer(*t)) {
-        bcx.sess().bug(
+        bcx.tcx().sess.bug(
             fmt!("Type parameters for node %d include inference types: %s",
                  id, params.map(|t| bcx.ty_to_str(*t)).connect(",")));
     }
@@ -1212,7 +1211,7 @@ pub fn dummy_substs(tps: ~[ty::t]) -> ty::substs {
 
 pub fn filename_and_line_num_from_span(bcx: @mut Block,
                                        span: Span) -> (ValueRef, ValueRef) {
-    let loc = bcx.sess().parse_sess.cm.lookup_char_pos(span.lo);
+    let loc = bcx.tcx().sess.parse_sess.cm.lookup_char_pos(span.lo);
     let filename_cstr = C_cstr(bcx.ccx(), loc.file.name);
     let filename = build::PointerCast(bcx, filename_cstr, Type::i8p());
     let line = C_int(bcx.ccx(), loc.line as int);

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -310,7 +310,7 @@ pub fn trans_fail_expr(bcx: @mut Block,
             } else if bcx.unreachable || ty::type_is_bot(arg_datum.ty) {
                 return bcx;
             } else {
-                bcx.sess().span_bug(
+                bcx.tcx().sess.span_bug(
                     arg_expr.span, ~"fail called with unsupported type " +
                     ppaux::ty_to_str(tcx, arg_datum.ty));
             }
@@ -336,8 +336,7 @@ fn trans_fail_value(bcx: @mut Block,
     let ccx = bcx.ccx();
     let (V_filename, V_line) = match sp_opt {
       Some(sp) => {
-        let sess = bcx.sess();
-        let loc = sess.parse_sess.cm.lookup_char_pos(sp.lo);
+        let loc = bcx.tcx().sess.parse_sess.cm.lookup_char_pos(sp.lo);
         (C_cstr(bcx.ccx(), loc.file.name),
          loc.line as int)
       }

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -731,8 +731,7 @@ impl Datum {
         match self.try_deref(bcx, expr.span, expr.id, derefs, false) {
             (Some(lvres), bcx) => DatumBlock { bcx: bcx, datum: lvres },
             (None, _) => {
-                bcx.ccx().sess.span_bug(expr.span,
-                                        "Cannot deref this expression");
+                bcx.tcx().sess.span_bug(expr.span, "Cannot deref this expression");
             }
         }
     }

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -318,7 +318,7 @@ pub fn trans_to_datum(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
         let (source_store, source_mutbl) = match ty::get(source_datum.ty).sty {
             ty::ty_trait(_, _, s, m, _) => (s, m),
             _ => {
-                bcx.sess().span_bug(
+                bcx.tcx().sess.span_bug(
                     expr.span,
                     fmt!("auto_borrow_trait_obj expected a trait, found %s",
                          source_datum.ty.repr(bcx.tcx())));
@@ -488,7 +488,7 @@ fn trans_lvalue(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
     return match bcx.tcx().adjustments.find(&expr.id) {
         None => trans_lvalue_unadjusted(bcx, expr),
         Some(_) => {
-            bcx.sess().span_bug(
+            bcx.tcx().sess.span_bug(
                 expr.span,
                 fmt!("trans_lvalue() called on an expression \
                       with adjustments"));
@@ -1042,7 +1042,7 @@ fn trans_lvalue_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
                         unsafe {
                             let llty = type_of(bcx.ccx(), const_ty);
                             let symbol = csearch::get_symbol(
-                                bcx.ccx().sess.cstore,
+                                bcx.tcx().sess.cstore,
                                 did);
                             let llval = do symbol.with_c_str |buf| {
                                 llvm::LLVMAddGlobal(bcx.ccx().llmod,
@@ -1091,7 +1091,7 @@ pub fn trans_local_var(bcx: @mut Block, def: ast::Def) -> Datum {
                     }
                 }
                 None => {
-                    bcx.sess().bug(fmt!(
+                    bcx.tcx().sess.bug(fmt!(
                         "trans_local_var: no llval for upvar %? found", nid));
                 }
             }
@@ -1106,7 +1106,7 @@ pub fn trans_local_var(bcx: @mut Block, def: ast::Def) -> Datum {
             let self_info: ValSelfData = match bcx.fcx.llself {
                 Some(ref self_info) => *self_info,
                 None => {
-                    bcx.sess().bug(fmt!(
+                    bcx.tcx().sess.bug(fmt!(
                         "trans_local_var: reference to self \
                          out of context with id %?", nid));
                 }
@@ -1122,7 +1122,7 @@ pub fn trans_local_var(bcx: @mut Block, def: ast::Def) -> Datum {
             }
         }
         _ => {
-            bcx.sess().unimpl(fmt!(
+            bcx.tcx().sess.unimpl(fmt!(
                 "unsupported def type in trans_local_var: %?", def));
         }
     };
@@ -1133,7 +1133,7 @@ pub fn trans_local_var(bcx: @mut Block, def: ast::Def) -> Datum {
         let v = match table.find(&nid) {
             Some(&v) => v,
             None => {
-                bcx.sess().bug(fmt!(
+                bcx.tcx().sess.bug(fmt!(
                     "trans_local_var: no llval for local/arg %? found", nid));
             }
         };
@@ -1383,7 +1383,7 @@ fn trans_unary_datum(bcx: @mut Block,
             trans_boxed_expr(bcx, un_ty, sub_expr, sub_ty, heap)
         }
         ast::UnDeref => {
-            bcx.sess().bug("deref expressions should have been \
+            bcx.tcx().sess.bug("deref expressions should have been \
                             translated using trans_lvalue(), not \
                             trans_unary_datum()")
         }
@@ -1733,13 +1733,13 @@ fn trans_imm_cast(bcx: @mut Block, expr: @ast::Expr,
                                               val_ty(lldiscrim_a),
                                               lldiscrim_a, true),
                     cast_float => SIToFP(bcx, lldiscrim_a, ll_t_out),
-                    _ => ccx.sess.bug(fmt!("translating unsupported cast: \
+                    _ => ccx.tcx.sess.bug(fmt!("translating unsupported cast: \
                                            %s (%?) -> %s (%?)",
                                            t_in.repr(ccx.tcx), k_in,
                                            t_out.repr(ccx.tcx), k_out))
                 }
             }
-            _ => ccx.sess.bug(fmt!("translating unsupported cast: \
+            _ => ccx.tcx.sess.bug(fmt!("translating unsupported cast: \
                                    %s (%?) -> %s (%?)",
                                    t_in.repr(ccx.tcx), k_in,
                                    t_out.repr(ccx.tcx), k_out))
@@ -1798,14 +1798,14 @@ pub fn trans_log_level(bcx: @mut Block) -> DatumBlock {
 
     let (modpath, modname) = {
         let path = &mut bcx.fcx.path;
-        let mut modpath = ~[path_mod(ccx.sess.ident_of(ccx.link_meta.name))];
+        let mut modpath = ~[path_mod(ccx.tcx.sess.ident_of(ccx.link_meta.name))];
         for e in path.iter() {
             match *e {
                 path_mod(_) => { modpath.push(*e) }
                 _ => {}
             }
         }
-        let modname = path_str(ccx.sess, modpath);
+        let modname = path_str(ccx.tcx.sess, modpath);
         (modpath, modname)
     };
 

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -75,17 +75,17 @@ struct LlvmSignature {
 
 pub fn llvm_calling_convention(ccx: &mut CrateContext,
                                abis: AbiSet) -> Option<CallConv> {
-    let arch = ccx.sess.targ_cfg.arch;
+    let arch = ccx.tcx.sess.targ_cfg.arch;
     abis.for_arch(arch).map(|abi| {
         match *abi {
             RustIntrinsic => {
                 // Intrinsics are emitted by monomorphic fn
-                ccx.sess.bug(fmt!("Asked to register intrinsic fn"));
+                ccx.tcx.sess.bug(fmt!("Asked to register intrinsic fn"));
             }
 
             Rust => {
                 // FIXME(#3678) Implement linking to foreign fns with Rust ABI
-                ccx.sess.unimpl(
+                ccx.tcx.sess.unimpl(
                     fmt!("Foreign functions with Rust ABI"));
             }
 
@@ -121,13 +121,13 @@ pub fn register_foreign_item_fn(ccx: @mut CrateContext,
         Some(cc) => cc,
         None => {
             // FIXME(#8357) We really ought to report a span here
-            ccx.sess.fatal(
+            ccx.tcx.sess.fatal(
                 fmt!("ABI `%s` has no suitable ABI \
                       for target architecture \
                       in module %s",
                      abis.user_string(ccx.tcx),
                      ast_map::path_to_str(*path,
-                                          ccx.sess.intr())));
+                                          ccx.tcx.sess.intr())));
         }
     };
 
@@ -174,7 +174,7 @@ pub fn trans_native_call(bcx: @mut Block,
 
     let (fn_abis, fn_sig) = match ty::get(callee_ty).sty {
         ty::ty_bare_fn(ref fn_ty) => (fn_ty.abis, fn_ty.sig.clone()),
-        _ => ccx.sess.bug("trans_native_call called on non-function type")
+        _ => ccx.tcx.sess.bug("trans_native_call called on non-function type")
     };
     let llsig = foreign_signature(ccx, &fn_sig);
     let ret_def = !ty::type_is_voidish(fn_sig.output);
@@ -257,7 +257,7 @@ pub fn trans_native_call(bcx: @mut Block,
         Some(cc) => cc,
         None => {
             // FIXME(#8357) We really ought to report a span here
-            ccx.sess.fatal(
+            ccx.tcx.sess.fatal(
                 fmt!("ABI string `%s` has no suitable ABI \
                       for target architecture",
                      fn_abis.user_string(ccx.tcx)));
@@ -416,7 +416,7 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @mut CrateContext,
                 f
             }
             _ => {
-                ccx.sess.bug(fmt!("build_rust_fn: extern fn %s has ty %s, \
+                ccx.tcx.sess.bug(fmt!("build_rust_fn: extern fn %s has ty %s, \
                                   expected a bare fn ty",
                                   path.repr(tcx),
                                   t.repr(tcx)));
@@ -682,7 +682,7 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @mut CrateContext,
 
 pub fn link_name(ccx: &CrateContext, i: @ast::foreign_item) -> @str {
      match attr::first_attr_value_str_by_name(i.attrs, "link_name") {
-        None => ccx.sess.str_of(i.ident),
+        None => ccx.tcx.sess.str_of(i.ident),
         Some(ln) => ln,
     }
 }
@@ -715,7 +715,7 @@ fn foreign_types_for_fn_ty(ccx: &mut CrateContext,
                            ty: ty::t) -> ForeignTypes {
     let fn_sig = match ty::get(ty).sty {
         ty::ty_bare_fn(ref fn_ty) => fn_ty.sig.clone(),
-        _ => ccx.sess.bug("foreign_types_for_fn_ty called on non-function type")
+        _ => ccx.tcx.sess.bug("foreign_types_for_fn_ty called on non-function type")
     };
     let llsig = foreign_signature(ccx, &fn_sig);
     let ret_def = !ty::type_is_voidish(fn_sig.output);

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -285,7 +285,7 @@ pub fn call_tydesc_glue_full(bcx: @mut Block,
     // NB: Don't short-circuit even if this block is unreachable because
     // GC-based cleanup needs to the see that the roots are live.
     let no_lpads =
-        ccx.sess.opts.debugging_opts & session::no_landing_pads != 0;
+        ccx.tcx.sess.opts.debugging_opts & session::no_landing_pads != 0;
     if bcx.unreachable && !no_lpads { return; }
 
     let static_glue_fn = match static_ti {
@@ -645,7 +645,7 @@ pub fn declare_tydesc(ccx: &mut CrateContext, t: ty::t) -> @mut tydesc_info {
 
     let llty = type_of(ccx, t);
 
-    if ccx.sess.count_type_sizes() {
+    if ccx.tcx.sess.count_type_sizes() {
         println!("{}\t{}", llsize_of_real(ccx, llty),
                  ppaux::ty_to_str(ccx.tcx, t));
     }

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -99,14 +99,14 @@ pub fn maybe_instantiate_inline(ccx: @mut CrateContext, fn_id: ast::DefId)
                   ccx.external.insert(there.id, Some(here.id.node));
               }
             }
-            _ => ccx.sess.bug("maybe_instantiate_inline: item has a \
+            _ => ccx.tcx.sess.bug("maybe_instantiate_inline: item has a \
                                non-enum parent")
           }
           trans_item(ccx, item);
           local_def(my_id)
         }
         csearch::found_parent(_, _) => {
-            ccx.sess.bug("maybe_get_item_ast returned a found_parent \
+            ccx.tcx.sess.bug("maybe_get_item_ast returned a found_parent \
              with a non-item parent");
         }
         csearch::found(ast::ii_method(impl_did, is_provided, mth)) => {

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -39,7 +39,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
                        substs: @param_substs,
                        attributes: &[ast::Attribute],
                        ref_id: Option<ast::NodeId>) {
-    debug!("trans_intrinsic(item.ident=%s)", ccx.sess.str_of(item.ident));
+    debug!("trans_intrinsic(item.ident=%s)", ccx.tcx.sess.str_of(item.ident));
 
     fn simple_llvm_intrinsic(bcx: @mut Block, name: &'static str, num_args: uint) {
         assert!(num_args <= 4);
@@ -77,7 +77,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
         let size = match sizebits {
             32 => C_i32(machine::llsize_of_real(ccx, lltp_ty) as i32),
             64 => C_i64(machine::llsize_of_real(ccx, lltp_ty) as i64),
-            _ => ccx.sess.fatal("Invalid value for sizebits")
+            _ => ccx.tcx.sess.fatal("Invalid value for sizebits")
         };
 
         let decl = bcx.fcx.llfn;
@@ -98,7 +98,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
         let size = match sizebits {
             32 => C_i32(machine::llsize_of_real(ccx, lltp_ty) as i32),
             64 => C_i64(machine::llsize_of_real(ccx, lltp_ty) as i64),
-            _ => ccx.sess.fatal("Invalid value for sizebits")
+            _ => ccx.tcx.sess.fatal("Invalid value for sizebits")
         };
 
         let decl = bcx.fcx.llfn;
@@ -141,7 +141,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
     let mut bcx = fcx.entry_bcx.unwrap();
     let first_real_arg = fcx.arg_pos(0u);
 
-    let nm = ccx.sess.str_of(item.ident);
+    let nm = ccx.tcx.sess.str_of(item.ident);
     let name = nm.as_slice();
 
     // This requires that atomic intrinsics follow a specific naming pattern:
@@ -157,7 +157,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
                 "acq"     => lib::llvm::Acquire,
                 "rel"     => lib::llvm::Release,
                 "acqrel"  => lib::llvm::AcquireRelease,
-                _ => ccx.sess.fatal("Unknown ordering in atomic intrinsic")
+                _ => ccx.tcx.sess.fatal("Unknown ordering in atomic intrinsic")
             }
         };
 
@@ -198,7 +198,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
                     "min"   => lib::llvm::Min,
                     "umax"  => lib::llvm::UMax,
                     "umin"  => lib::llvm::UMin,
-                    _ => ccx.sess.fatal("Unknown atomic operation")
+                    _ => ccx.tcx.sess.fatal("Unknown atomic operation")
                 };
 
                 let old = AtomicRMW(bcx, atom_op, get_param(decl, first_real_arg),
@@ -300,7 +300,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
                     _ => fail!("transmute has non-expr arg"),
                 };
                 let pluralize = |n| if 1u == n { "" } else { "s" };
-                ccx.sess.span_fatal(sp,
+                ccx.tcx.sess.span_fatal(sp,
                                     fmt!("transmute called on types with \
                                           different sizes: %s (%u bit%s) to \
                                           %s (%u bit%s)",
@@ -491,7 +491,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
         _ => {
             // Could we make this an enum rather than a string? does it get
             // checked earlier?
-            ccx.sess.span_bug(item.span, "unknown intrinsic");
+            ccx.tcx.sess.span_bug(item.span, "unknown intrinsic");
         }
     }
     fcx.cleanup();

--- a/src/librustc/middle/trans/macros.rs
+++ b/src/librustc/middle/trans/macros.rs
@@ -34,7 +34,7 @@ macro_rules! trace_span(
     ($bcx: ident, $sp: expr, $str: expr) => (
         {
             let bcx = $bcx;
-            if bcx.sess().trace() {
+            if bcx.tcx().sess.trace() {
                 trans_trace(bcx, Some($sp), $str);
             }
         }
@@ -45,7 +45,7 @@ macro_rules! trace(
     ($bcx: ident, $str: expr) => (
         {
             let bcx = $bcx;
-            if bcx.sess().trace() {
+            if bcx.tcx().sess.trace() {
                 trans_trace(bcx, None, $str);
             }
         }

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -260,7 +260,7 @@ pub fn trans_static_method_callee(bcx: @mut Block,
         }
     };
     debug!("trans_static_method_callee: method_id=%?, callee_id=%?, \
-            name=%s", method_id, callee_id, ccx.sess.str_of(mname));
+            name=%s", method_id, callee_id, ccx.tcx.sess.str_of(mname));
 
     let vtbls = resolve_vtables_in_fn_ctxt(
         bcx.fcx, ccx.maps.vtable_map.get_copy(&callee_id));
@@ -550,7 +550,7 @@ pub fn get_vtable(bcx: @mut Block,
             typeck::vtable_static(id, ref substs, sub_vtables) => {
                 emit_vtable_methods(bcx, id, *substs, sub_vtables)
             }
-            _ => ccx.sess.bug("get_vtable: expected a static origin"),
+            _ => ccx.tcx.sess.bug("get_vtable: expected a static origin"),
         }
     };
 
@@ -598,7 +598,7 @@ fn emit_vtable_methods(bcx: @mut Block,
 
     let trt_id = match ty::impl_trait_ref(tcx, impl_id) {
         Some(t_id) => t_id.def_id,
-        None       => ccx.sess.bug("make_impl_vtable: don't know how to \
+        None       => ccx.tcx.sess.bug("make_impl_vtable: don't know how to \
                                     make a vtable for a type impl!")
     };
 

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -93,7 +93,7 @@ pub fn monomorphic_fn(ccx: @mut CrateContext,
     let mut is_static_provided = None;
 
     let map_node = session::expect(
-        ccx.sess,
+        ccx.tcx.sess,
         ccx.tcx.items.find_copy(&fn_id.node),
         || fmt!("While monomorphizing %?, couldn't find it in the item map \
                  (may have attempted to monomorphize an item \
@@ -188,12 +188,12 @@ pub fn monomorphic_fn(ccx: @mut CrateContext,
     // recursively more than thirty times can probably safely be assumed to be
     // causing an infinite expansion.
     if depth > 30 {
-        ccx.sess.span_fatal(
+        ccx.tcx.sess.span_fatal(
             span, "overly deep expansion of inlined function");
     }
     ccx.monomorphizing.insert(fn_id, depth + 1);
 
-    let (_, elt) = gensym_name(ccx.sess.str_of(name));
+    let (_, elt) = gensym_name(ccx.tcx.sess.str_of(name));
     let mut pt = (*pt).clone();
     pt.push(elt);
     let s = mangle_exported_name(ccx, pt.clone(), mono_ty);
@@ -313,10 +313,10 @@ pub fn make_mono_id(ccx: @mut CrateContext,
       None => substs_iter.map(|subst| (*subst, None::<@~[mono_id]>)).collect()
     };
 
-
     let param_ids = precise_param_ids.iter().map(|x| {
         let (a, b) = *x;
         mono_precise(a, b)
     }).collect();
+
     @mono_id_ {def: item, params: param_ids}
 }

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -266,7 +266,7 @@ impl Reflector {
               do self.bracketed("class", extra) |this| {
                   for (i, field) in fields.iter().enumerate() {
                       let extra = ~[this.c_uint(i),
-                                    this.c_slice(bcx.ccx().sess.str_of(field.ident)),
+                                    this.c_slice(bcx.ccx().tcx.sess.str_of(field.ident)),
                                     this.c_bool(named_fields)]
                           + this.c_mt(&field.mt);
                       this.visit("class_field", extra);
@@ -323,7 +323,7 @@ impl Reflector {
                 + self.c_size_and_align(t);
             do self.bracketed("enum", enum_args) |this| {
                 for (i, v) in variants.iter().enumerate() {
-                    let name = ccx.sess.str_of(v.name);
+                    let name = ccx.tcx.sess.str_of(v.name);
                     let variant_args = ~[this.c_uint(i),
                                          C_integral(self.bcx.ccx().int_type, v.disr_val, false),
                                          this.c_uint(v.args.len()),

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -83,7 +83,7 @@ pub fn type_of_fn_from_ty(cx: &mut CrateContext, fty: ty::t) -> Type {
             }
         }
         _ => {
-            cx.sess.bug("type_of_fn_from_ty given non-closure, non-bare-fn")
+            cx.tcx.sess.bug("type_of_fn_from_ty given non-closure, non-bare-fn")
         }
     };
 }
@@ -141,7 +141,7 @@ pub fn sizing_type_of(cx: &mut CrateContext, t: ty::t) -> Type {
 
         ty::ty_unboxed_vec(mt) => {
             let sz_ty = sizing_type_of(cx, mt.ty);
-            Type::vec(cx.sess.targ_cfg.arch, &sz_ty)
+            Type::vec(cx.tcx.sess.targ_cfg.arch, &sz_ty)
         }
 
         ty::ty_tup(*) | ty::ty_enum(*) => {
@@ -201,7 +201,7 @@ pub fn type_of(cx: &mut CrateContext, t: ty::t) -> Type {
       ty::ty_uint(t) => Type::uint_from_ty(cx, t),
       ty::ty_float(t) => Type::float_from_ty(cx, t),
       ty::ty_estr(ty::vstore_uniq) => {
-        Type::vec(cx.sess.targ_cfg.arch, &Type::i8()).ptr_to()
+        Type::vec(cx.tcx.sess.targ_cfg.arch, &Type::i8()).ptr_to()
       }
       ty::ty_enum(did, ref substs) => {
         // Only create the named struct, but don't fill it in. We
@@ -212,11 +212,11 @@ pub fn type_of(cx: &mut CrateContext, t: ty::t) -> Type {
         Type::named_struct(llvm_type_name(cx, an_enum, did, substs.tps))
       }
       ty::ty_estr(ty::vstore_box) => {
-        Type::box(cx, &Type::vec(cx.sess.targ_cfg.arch, &Type::i8())).ptr_to()
+        Type::box(cx, &Type::vec(cx.tcx.sess.targ_cfg.arch, &Type::i8())).ptr_to()
       }
       ty::ty_evec(ref mt, ty::vstore_box) => {
           let e_ty = type_of(cx, mt.ty);
-          let v_ty = Type::vec(cx.sess.targ_cfg.arch, &e_ty);
+          let v_ty = Type::vec(cx.tcx.sess.targ_cfg.arch, &e_ty);
           Type::box(cx, &v_ty).ptr_to()
       }
       ty::ty_box(ref mt) => {
@@ -234,7 +234,7 @@ pub fn type_of(cx: &mut CrateContext, t: ty::t) -> Type {
       }
       ty::ty_evec(ref mt, ty::vstore_uniq) => {
           let ty = type_of(cx, mt.ty);
-          let ty = Type::vec(cx.sess.targ_cfg.arch, &ty);
+          let ty = Type::vec(cx.tcx.sess.targ_cfg.arch, &ty);
           if ty::type_contents(cx.tcx, mt.ty).contains_managed() {
               Type::unique(cx, &ty).ptr_to()
           } else {
@@ -243,7 +243,7 @@ pub fn type_of(cx: &mut CrateContext, t: ty::t) -> Type {
       }
       ty::ty_unboxed_vec(ref mt) => {
           let ty = type_of(cx, mt.ty);
-          Type::vec(cx.sess.targ_cfg.arch, &ty)
+          Type::vec(cx.tcx.sess.targ_cfg.arch, &ty)
       }
       ty::ty_ptr(ref mt) => type_of(cx, mt.ty).ptr_to(),
       ty::ty_rptr(_, ref mt) => type_of(cx, mt.ty).ptr_to(),

--- a/src/librustc/middle/trans/write_guard.rs
+++ b/src/librustc/middle/trans/write_guard.rs
@@ -114,7 +114,7 @@ fn root(datum: &Datum,
     debug!("write_guard::root(root_key=%?, root_info=%?, datum=%?)",
            root_key, root_info, datum.to_str(bcx.ccx()));
 
-    if bcx.sess().trace() {
+    if bcx.tcx().sess.trace() {
         trans_trace(
             bcx, None,
             (fmt!("preserving until end of scope %d",

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -193,11 +193,11 @@ impl visit::Visitor<()> for PrivilegedScopeVisitor {
                     item_impl(_, None, ref ast_ty, _) => {
                         if !self.cc.ast_type_is_defined_in_local_crate(ast_ty) {
                             // This is an error.
-                            let session = self.cc.crate_context.tcx.sess;
-                            session.span_err(item.span,
-                                             "cannot associate methods with a type outside the \
-                                              crate the type is defined in; define and implement \
-                                              a trait or new type instead");
+                            let tcx = self.cc.crate_context.tcx;
+                            tcx.sess.span_err(item.span,
+                                              "cannot associate methods with a type outside the \
+                                               crate the type is defined in; define and implement \
+                                               a trait or new type instead");
                         }
                     }
                     item_impl(_, Some(ref trait_ref), _, _) => {
@@ -214,10 +214,10 @@ impl visit::Visitor<()> for PrivilegedScopeVisitor {
                                 self.cc.trait_ref_to_trait_def_id(trait_ref);
 
                             if trait_def_id.crate != LOCAL_CRATE {
-                                let session = self.cc.crate_context.tcx.sess;
-                                session.span_err(item.span,
-                                                 "cannot provide an extension implementation \
-                                                  for a trait not defined in this crate");
+                                let tcx = self.cc.crate_context.tcx;
+                                tcx.sess.span_err(item.span,
+                                                  "cannot provide an extension implementation \
+                                                   for a trait not defined in this crate");
                             }
                         }
 
@@ -274,10 +274,10 @@ impl CoherenceChecker {
                                        item.span,
                                        self_type.ty) {
                 None => {
-                    let session = self.crate_context.tcx.sess;
-                    session.span_err(item.span,
-                                     "no base type found for inherent implementation; \
-                                      implement a trait or new type instead");
+                    let tcx = self.crate_context.tcx;
+                    tcx.sess.span_err(item.span,
+                                      "no base type found for inherent implementation; \
+                                       implement a trait or new type instead");
                 }
                 Some(_) => {
                     // Nothing to do.
@@ -437,14 +437,14 @@ impl CoherenceChecker {
                             implementation_b);
 
                     if self.polytypes_unify(polytype_a, polytype_b) {
-                        let session = self.crate_context.tcx.sess;
-                        session.span_err(
+                        let tcx = self.crate_context.tcx;
+                        tcx.sess.span_err(
                             self.span_of_impl(implementation_b),
                             fmt!("conflicting implementations for trait `%s`",
                                  ty::item_path_str(self.crate_context.tcx,
                                                    trait_def_id)));
-                        session.span_note(self.span_of_impl(implementation_a),
-                                          "note conflicting implementation here");
+                        tcx.sess.span_note(self.span_of_impl(implementation_a),
+                                           "note conflicting implementation here");
                     }
                 }
             }

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -422,7 +422,7 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
 
 fn check_for_entry_fn(ccx: &CrateCtxt) {
     let tcx = ccx.tcx;
-    if !*tcx.sess.building_library {
+    if !tcx.sess.building_library {
         match *tcx.sess.entry_fn {
           Some((id, sp)) => match *tcx.sess.entry_type {
               Some(session::EntryMain) => check_main_fn_ty(ccx, id, sp),

--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -257,12 +257,12 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
     };
 
     let sopts = build_session_options(binary, matches, demitter);
-    let sess = build_session(sopts, demitter);
+    let mut sess = build_session(sopts, demitter);
     let odir = matches.opt_str("out-dir").map_move(|o| Path(o));
     let ofile = matches.opt_str("o").map_move(|o| Path(o));
-    let cfg = build_configuration(sess);
+    let cfg = build_configuration(&sess);
     let pretty = do matches.opt_default("pretty", "normal").map_move |a| {
-        parse_pretty(sess, a)
+        parse_pretty(&sess, a)
     };
     match pretty {
       Some::<PpMode>(ppm) => {
@@ -275,7 +275,7 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
     if ls {
         match input {
           file_input(ref ifile) => {
-            list_metadata(sess, &(*ifile), io::stdout());
+            list_metadata(&sess, &(*ifile), io::stdout());
           }
           str_input(_) => {
             early_error(demitter, ~"can not list metadata for stdin");
@@ -284,7 +284,7 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
         return;
     }
 
-    compile_input(sess, cfg, &input, &odir, &ofile);
+    compile_input(&mut sess, cfg, &input, &odir, &ofile);
 }
 
 #[deriving(Eq)]

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -49,18 +49,18 @@ fn get_ast_and_resolve(cpath: &Path, libs: ~[Path]) -> DocContext {
     let span_diagnostic_handler =
         syntax::diagnostic::mk_span_handler(diagnostic_handler, parsesess.cm);
 
-    let sess = driver::driver::build_session_(sessopts,
-                                              parsesess.cm,
-                                              @diagnostic::DefaultEmitter as
-                                                @diagnostic::Emitter,
-                                              span_diagnostic_handler);
+    let mut sess = driver::driver::build_session_(sessopts,
+                                                  parsesess.cm,
+                                                  @diagnostic::DefaultEmitter as
+                                                    @diagnostic::Emitter,
+                                                  span_diagnostic_handler);
 
-    let mut cfg = build_configuration(sess);
+    let mut cfg = build_configuration(&sess);
     cfg.push(@dummy_spanned(ast::MetaWord(@"stage2")));
 
-    let mut crate = phase_1_parse_input(sess, cfg.clone(), &input);
-    crate = phase_2_configure_and_expand(sess, cfg, crate);
-    let analysis = phase_3_run_analysis_passes(sess, crate);
+    let mut crate = phase_1_parse_input(&sess, cfg.clone(), &input);
+    crate = phase_2_configure_and_expand(&mut sess, cfg, crate);
+    let analysis = phase_3_run_analysis_passes(&sess, crate);
 
     debug!("crate: %?", crate);
     DocContext { crate: crate, tycx: analysis.ty_cx, sess: sess }

--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -148,20 +148,20 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
     // extra helpful information if the error crops up. Otherwise people are
     // bound to be very confused when they find out code is running that they
     // never typed in...
-    let sess = driver::build_session(options,
-                                     @EncodableWarningEmitter as
-                                        @diagnostic::Emitter);
+    let mut sess = driver::build_session(options,
+                                         @EncodableWarningEmitter as
+                                           @diagnostic::Emitter);
     let intr = token::get_ident_interner();
 
     //
     // Stage 1: parse the input and filter it into the program (as necessary)
     //
     debug!("parsing: %s", input);
-    let crate = parse_input(sess, input);
+    let crate = parse_input(&sess, input);
     let mut to_run = ~[];       // statements to run (emitted back into code)
     let new_locals = @mut ~[];  // new locals being defined
     let mut result = None;      // resultant expression (to print via pp)
-    do find_main(crate, sess) |blk| {
+    do find_main(crate, &sess) |blk| {
         // Fish out all the view items, be sure to record 'extern mod' items
         // differently beause they must appear before all 'use' statements
         for vi in blk.view_items.iter() {
@@ -237,15 +237,15 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
     let test = program.test_code(input, &result, *new_locals);
     debug!("testing with ^^^^^^ %?", (||{ println(test) })());
     let dinput = driver::str_input(test.to_managed());
-    let cfg = driver::build_configuration(sess);
+    let cfg = driver::build_configuration(&sess);
 
-    let crate = driver::phase_1_parse_input(sess, cfg.clone(), &dinput);
-    let expanded_crate = driver::phase_2_configure_and_expand(sess, cfg, crate);
-    let analysis = driver::phase_3_run_analysis_passes(sess, expanded_crate);
+    let crate = driver::phase_1_parse_input(&sess, cfg.clone(), &dinput);
+    let expanded_crate = driver::phase_2_configure_and_expand(&mut sess, cfg, crate);
+    let analysis = driver::phase_3_run_analysis_passes(&sess, expanded_crate);
 
     // Once we're typechecked, record the types of all local variables defined
     // in this input
-    do find_main(crate, sess) |blk| {
+    do find_main(crate, &sess) |blk| {
         program.register_new_vars(blk, analysis.ty_cx);
     }
 
@@ -256,17 +256,17 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
     let code = program.code(input, &result);
     debug!("actually running ^^^^^^ %?", (||{ println(code) })());
     let input = driver::str_input(code.to_managed());
-    let cfg = driver::build_configuration(sess);
-    let outputs = driver::build_output_filenames(&input, &None, &None, [], sess);
-    let sess = driver::build_session(options,
-                                     @diagnostic::DefaultEmitter as
-                                        @diagnostic::Emitter);
+    let cfg = driver::build_configuration(&sess);
+    let outputs = driver::build_output_filenames(&input, &None, &None, [], &sess);
+    let mut sess = driver::build_session(options,
+                                         @diagnostic::DefaultEmitter as
+                                           @diagnostic::Emitter);
 
-    let crate = driver::phase_1_parse_input(sess, cfg.clone(), &input);
-    let expanded_crate = driver::phase_2_configure_and_expand(sess, cfg, crate);
-    let analysis = driver::phase_3_run_analysis_passes(sess, expanded_crate);
-    let trans = driver::phase_4_translate_to_llvm(sess, expanded_crate, &analysis, outputs);
-    driver::phase_5_run_llvm_passes(sess, &trans, outputs);
+    let crate = driver::phase_1_parse_input(&sess, cfg.clone(), &input);
+    let expanded_crate = driver::phase_2_configure_and_expand(&mut sess, cfg, crate);
+    let analysis = driver::phase_3_run_analysis_passes(&sess, expanded_crate);
+    let trans = driver::phase_4_translate_to_llvm(expanded_crate, &analysis, outputs);
+    driver::phase_5_run_llvm_passes(&sess, &trans, outputs);
 
     //
     // Stage 4: Inform the program that computation is done so it can update all
@@ -283,14 +283,14 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
     //
     return (program, jit::consume_engine());
 
-    fn parse_input(sess: session::Session, input: &str) -> @ast::Crate {
+    fn parse_input(sess: &session::Session, input: &str) -> @ast::Crate {
         let code = fmt!("fn main() {\n %s \n}", input);
         let input = driver::str_input(code.to_managed());
         let cfg = driver::build_configuration(sess);
         driver::phase_1_parse_input(sess, cfg.clone(), &input)
     }
 
-    fn find_main(crate: @ast::Crate, sess: session::Session,
+    fn find_main(crate: @ast::Crate, sess: &session::Session,
                  f: &fn(&ast::Block)) {
         for item in crate.module.items.iter() {
             match item.node {
@@ -322,13 +322,13 @@ fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
             .. (*session::basic_options()).clone()
         };
         let input = driver::file_input(src_path.clone());
-        let sess = driver::build_session(options,
-                                         @diagnostic::DefaultEmitter as
-                                            @diagnostic::Emitter);
-        *sess.building_library = true;
-        let cfg = driver::build_configuration(sess);
+        let mut sess = driver::build_session(options,
+                                             @diagnostic::DefaultEmitter as
+                                                @diagnostic::Emitter);
+        sess.building_library = true;
+        let cfg = driver::build_configuration(&sess);
         let outputs = driver::build_output_filenames(
-            &input, &None, &None, [], sess);
+            &input, &None, &None, [], &sess);
         // If the library already exists and is newer than the source
         // file, skip compilation and return None.
         let mut should_compile = true;
@@ -356,11 +356,11 @@ fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
         }
         if (should_compile) {
             println(fmt!("compiling %s...", src_filename));
-            let crate = driver::phase_1_parse_input(sess, cfg.clone(), &input);
-            let expanded_crate = driver::phase_2_configure_and_expand(sess, cfg, crate);
-            let analysis = driver::phase_3_run_analysis_passes(sess, expanded_crate);
-            let trans = driver::phase_4_translate_to_llvm(sess, expanded_crate, &analysis, outputs);
-            driver::phase_5_run_llvm_passes(sess, &trans, outputs);
+            let crate = driver::phase_1_parse_input(&sess, cfg.clone(), &input);
+            let expanded_crate = driver::phase_2_configure_and_expand(&mut sess, cfg, crate);
+            let analysis = driver::phase_3_run_analysis_passes(&sess, expanded_crate);
+            let trans = driver::phase_4_translate_to_llvm(expanded_crate, &analysis, outputs);
+            driver::phase_5_run_llvm_passes(&sess, &trans, outputs);
             true
         } else { false }
     } {


### PR DESCRIPTION
Having to dereference `sess.building_library` is really annoying so this fixes that! Also, Session is no longer passed around with @.

2 caveats, due to pervasive use of @ in rustc there are 2 points where I just transmute to a `&'static Session` to put into `Resolver` and `ty::ctxt` which is probably fine given that the session will outlive them.
