### PR TITLE
std::vec: Use a valid value as lifetime dummy in iterator

### DIFF
--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -932,11 +932,11 @@ impl<'self,T> ImmutableVector<'self, T> for &'self [T] {
             if sys::size_of::<T>() == 0 {
                 VecIterator{ptr: p,
                             end: (p as uint + self.len()) as *T,
-                            lifetime: cast::transmute(p)}
+                            lifetime: None}
             } else {
                 VecIterator{ptr: p,
                             end: p.offset(self.len() as int),
-                            lifetime: cast::transmute(p)}
+                            lifetime: None}
             }
         }
     }
@@ -1940,11 +1940,11 @@ impl<'self,T> MutableVector<'self, T> for &'self mut [T] {
             if sys::size_of::<T>() == 0 {
                 VecMutIterator{ptr: p,
                                end: (p as uint + self.len()) as *mut T,
-                               lifetime: cast::transmute(p)}
+                               lifetime: None}
             } else {
                 VecMutIterator{ptr: p,
                                end: p.offset(self.len() as int),
-                               lifetime: cast::transmute(p)}
+                               lifetime: None}
             }
         }
     }
@@ -2389,7 +2389,7 @@ impl<'self, T> RandomAccessIterator<&'self T> for VecIterator<'self, T> {
 pub struct VecIterator<'self, T> {
     priv ptr: *T,
     priv end: *T,
-    priv lifetime: &'self T // FIXME: #5922
+    priv lifetime: Option<&'self ()> // FIXME: #5922
 }
 iterator!{impl VecIterator -> &'self T}
 double_ended_iterator!{impl VecIterator -> &'self T}
@@ -2407,7 +2407,7 @@ impl<'self, T> Clone for VecIterator<'self, T> {
 pub struct VecMutIterator<'self, T> {
     priv ptr: *mut T,
     priv end: *mut T,
-    priv lifetime: &'self mut T // FIXME: #5922
+    priv lifetime: Option<&'self mut ()> // FIXME: #5922
 }
 iterator!{impl VecMutIterator -> &'self mut T}
 double_ended_iterator!{impl VecMutIterator -> &'self mut T}


### PR DESCRIPTION
std::vec: Use a valid value as lifetime dummy in iterator

The current implementation uses `&v[0]` for the lifetime struct field,
but that is a dangling pointer for iterators derived from zero-length
slices.

Example:

```
let v: [int, ..0] = [];  println!("{:?}", v.iter())

std::vec::VecIterator<,int>{ptr: (0x7f3768626100 as *()), end: (0x7f3768626100 as *()), lifetime: &139875951207128}
```

To replace this parameter, use a field of type `Option<&'self ()>`
that is simply initialized with `None`, but still allows the iterator to
have a lifetime parameter.
