### PR TITLE
Suppress warning by removing unused import

### DIFF
--- a/src/libstd/rt/sched.rs
+++ b/src/libstd/rt/sched.rs
@@ -1280,7 +1280,6 @@ mod test {
     // FIXME: #9407: xfail-test
     fn dont_starve_1() {
         use rt::comm::oneshot;
-        use unstable::running_on_valgrind;
 
         do stress_factor().times {
             do run_in_mt_newsched_task {


### PR DESCRIPTION
Small change that suppresses a warning because of an unused import.
