### PR TITLE
Logging unsafe removal

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -3008,7 +3008,7 @@ pub fn fill_crate_map(ccx: &mut CrateContext, map: ValueRef) {
         let (mod_map, mod_count, mod_struct_size) = create_module_map(ccx);
 
         llvm::LLVMSetInitializer(map, C_struct(
-            [C_i32(1),
+            [C_i32(2),
              C_struct([
                 p2i(ccx, mod_map),
                 // byte size of the module map array, an entry consists of two integers

--- a/src/libstd/rt/crate_map.rs
+++ b/src/libstd/rt/crate_map.rs
@@ -8,11 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(not(stage0))] use cast::transmute;
+//#[cfg(not(stage0))] use cast::transmute;
 use container::MutableSet;
 use hashmap::HashSet;
 use option::{Some, None};
 use vec::ImmutableVector;
+
+/// Imports for old crate map versions
+use cast::transmute;
+use libc::c_char;
+use ptr;
+use str::raw::from_c_str;
+use vec;
 
 // Need to tell the linker on OS X to not barf on undefined symbols
 // and instead look them up at runtime, which we need to resolve
@@ -28,14 +35,27 @@ extern {
     static CRATE_MAP: CrateMap<'static>;
 }
 
+/// structs for old crate map versions
+pub struct ModEntryV0 {
+    name: *c_char,
+    log_level: *mut u32
+}
+pub struct CrateMapV0 {
+    entries: *ModEntryV0,
+    children: [*CrateMapV0, ..1]
+}
+
+pub struct CrateMapV1 {
+    version: i32,
+    entries: *ModEntryV0,
+    /// a dynamically sized struct, where all pointers to children are listed adjacent
+    /// to the struct, terminated with NULL
+    children: [*CrateMapV1, ..1]
+}
+
 pub struct ModEntry<'self> {
     name: &'self str,
     log_level: *mut u32
-}
-
-pub struct CrateMapV0<'self> {
-    entries: &'self [ModEntry<'self>],
-    children: &'self [&'self CrateMap<'self>]
 }
 
 pub struct CrateMap<'self> {
@@ -45,6 +65,8 @@ pub struct CrateMap<'self> {
     /// to the struct, terminated with NULL
     children: &'self [&'self CrateMap<'self>]
 }
+
+
 
 #[cfg(not(windows))]
 pub fn get_crate_map() -> &'static CrateMap<'static> {
@@ -71,51 +93,60 @@ pub fn get_crate_map() -> &'static CrateMap<'static> {
 
 fn version(crate_map: &CrateMap) -> i32 {
     match crate_map.version {
+        2 => return 2,
         1 => return 1,
         _ => return 0
     }
 }
 
-#[cfg(not(stage0))]
-fn get_entries_and_children<'a>(crate_map: &'a CrateMap<'a>) ->
-                    (&'a [ModEntry<'a>], &'a [&'a CrateMap<'a>]) {
-    match version(crate_map) {
-        0 => {
-            unsafe {
-                let v0: &'a CrateMapV0<'a> = transmute(crate_map);
-                return (v0.entries, v0.children);
-            }
-        }
-        1 => return (*crate_map).entries,
-        _ => fail2!("Unknown crate map version!")
-    }
-}
-
-#[cfg(not(stage0))]
 fn iter_module_map(mod_entries: &[ModEntry], f: &fn(&ModEntry)) {
     for entry in mod_entries.iter() {
         f(entry);
     }
 }
 
-#[cfg(not(stage0))]
+unsafe fn iter_module_map_v0(entries: *ModEntryV0, f: &fn(&ModEntry)) {
+    let mut curr = entries; 
+    while !(*curr).name.is_null() {
+        let mod_entry = ModEntry { name: from_c_str((*curr).name), log_level: (*curr).log_level }; 
+        f(&mod_entry);
+        curr = curr.offset(1);
+    }
+}
+
 fn do_iter_crate_map<'a>(crate_map: &'a CrateMap<'a>, f: &fn(&ModEntry),
                             visited: &mut HashSet<*CrateMap<'a>>) {
     if visited.insert(crate_map as *CrateMap) {
-        let (entries, children) = get_entries_and_children(crate_map);
-        iter_module_map(entries, |x| f(x));
-        for child in children.iter() {
-            do_iter_crate_map(*child, |x| f(x), visited);
+        match version(crate_map) {
+            2 => {
+                let (entries, children) = (crate_map.entries, crate_map.children);
+                iter_module_map(entries, |x| f(x));
+                for child in children.iter() {
+                    do_iter_crate_map(*child, |x| f(x), visited);
+                }
+            },
+            /// code for old crate map versions
+            1 => unsafe {
+                let v1: *CrateMapV1 = transmute(crate_map);
+                iter_module_map_v0((*v1).entries, |x| f(x));
+                let children = vec::raw::to_ptr((*v1).children);
+                do ptr::array_each(children) |child| {
+                    do_iter_crate_map(transmute(child), |x| f(x), visited);
+                }
+            },
+            0 => unsafe {
+                let v0: *CrateMapV0 = transmute(crate_map);
+                iter_module_map_v0((*v0).entries, |x| f(x));
+                let children = vec::raw::to_ptr((*v0).children);
+                do ptr::array_each(children) |child| {
+                    do_iter_crate_map(transmute(child), |x| f(x), visited);
+                }
+            },
+            _ => fail2!("invalid crate map version")  
         }
     }
 }
 
-#[cfg(stage0)]
-/// Iterates recursively over `crate_map` and all child crate maps
-pub fn iter_crate_map<'a>(crate_map: &'a CrateMap<'a>, f: &fn(&ModEntry)) {
-}
-
-#[cfg(not(stage0))]
 /// Iterates recursively over `crate_map` and all child crate maps
 pub fn iter_crate_map<'a>(crate_map: &'a CrateMap<'a>, f: &fn(&ModEntry)) {
     // XXX: use random numbers as keys from the OS-level RNG when there is a nice
@@ -137,13 +168,13 @@ mod tests {
         ];
 
         let child_crate = CrateMap {
-            version: 1,
+            version: 2,
             entries: entries,
             children: []
         };
 
         let root_crate = CrateMap {
-            version: 1,
+            version: 2,
             entries: [],
             children: [&child_crate, &child_crate]
         };
@@ -163,7 +194,7 @@ mod tests {
         let mut level2: u32 = 2;
         let mut level3: u32 = 3;
         let child_crate2 = CrateMap {
-            version: 1,
+            version: 2,
             entries: [
                 ModEntry { name: "c::m1", log_level: &mut level2},
                 ModEntry { name: "c::m2", log_level: &mut level3},
@@ -172,7 +203,7 @@ mod tests {
         };
 
         let child_crate1 = CrateMap {
-            version: 1,
+            version: 2,
             entries: [
                 ModEntry { name: "t::f1", log_level: &mut 1},
             ],
@@ -180,7 +211,7 @@ mod tests {
         };
 
         let root_crate = CrateMap {
-            version: 1,
+            version: 2,
             entries: [
                 ModEntry { name: "t::f2", log_level: &mut 0},
             ],
@@ -191,6 +222,108 @@ mod tests {
         unsafe {
             do iter_crate_map(&root_crate) |entry| {
                 assert!(*entry.log_level == cnt);
+                cnt += 1;
+            }
+            assert!(cnt == 4);
+        }
+    }
+
+
+    /// Tests for old crate map versions
+    #[test]
+    fn iter_crate_map_duplicates_v1() {
+        use c_str::ToCStr;
+        use cast::transmute;
+        use ptr;
+        use rt::crate_map::{CrateMapV1, ModEntryV0, iter_crate_map};
+        use vec;
+
+        struct CrateMapT3 {
+            version: i32,
+            entries: *ModEntryV0,
+            children: [*CrateMapV1, ..3]
+        }
+
+        unsafe {
+            let mod_name1 = "c::m1".to_c_str();
+            let mut level3: u32 = 3;
+
+            let entries: ~[ModEntryV0] = ~[
+                ModEntryV0 { name: mod_name1.with_ref(|buf| buf), log_level: &mut level3},
+                ModEntryV0 { name: ptr::null(), log_level: ptr::mut_null()}
+            ];
+            let child_crate = CrateMapV1 {
+                version: 1,
+                entries: vec::raw::to_ptr(entries),
+                children: [ptr::null()]
+            };
+
+            let root_crate = CrateMapT3 {
+                version: 1,
+                entries: vec::raw::to_ptr([ModEntryV0 { name: ptr::null(), log_level: ptr::mut_null()}]),
+                children: [&child_crate as *CrateMapV1, &child_crate as *CrateMapV1, ptr::null()]
+            };
+
+            let mut cnt = 0;
+            do iter_crate_map(transmute(&root_crate)) |entry| {
+                assert!(*(*entry).log_level == 3);
+                cnt += 1;
+            }
+            assert!(cnt == 1);
+        }
+    }
+
+    #[test]
+    fn iter_crate_map_follow_children_v1() {
+        use c_str::ToCStr;
+        use cast::transmute;
+        use ptr;
+        use rt::crate_map::{CrateMapV1, ModEntryV0, iter_crate_map};
+        use vec;
+
+        struct CrateMapT2 {
+            version: i32,
+            entries: *ModEntryV0,
+            children: [*CrateMapV1, ..2]
+        }
+
+        unsafe {
+            let mod_name1 = "c::m1".to_c_str();
+            let mod_name2 = "c::m2".to_c_str();
+            let mut level2: u32 = 2;
+            let mut level3: u32 = 3;
+            let child_crate2 = CrateMapV1 {
+                version: 1,
+                entries: vec::raw::to_ptr([
+                    ModEntryV0 { name: mod_name1.with_ref(|buf| buf), log_level: &mut level2},
+                    ModEntryV0 { name: mod_name2.with_ref(|buf| buf), log_level: &mut level3},
+                    ModEntryV0 { name: ptr::null(), log_level: ptr::mut_null()}
+                ]),
+                children: [ptr::null()]
+            };
+
+            let child_crate1 = CrateMapT2 {
+                version: 1,
+                entries: vec::raw::to_ptr([
+                    ModEntryV0 { name: "t::f1".with_c_str(|buf| buf), log_level: &mut 1},
+                    ModEntryV0 { name: ptr::null(), log_level: ptr::mut_null()}
+                ]),
+                children: [&child_crate2 as *CrateMapV1, ptr::null()]
+            };
+
+            let child_crate1_ptr: *CrateMapV1 = transmute(&child_crate1);
+            let root_crate = CrateMapT2 {
+                version: 1,
+                entries: vec::raw::to_ptr([
+                    ModEntryV0 { name: "t::f1".with_c_str(|buf| buf), log_level: &mut 0},
+                    ModEntryV0 { name: ptr::null(), log_level: ptr::mut_null()}
+                ]),
+                children: [child_crate1_ptr, ptr::null()]
+            };
+
+            let mut cnt = 0;
+            do iter_crate_map(transmute(&root_crate)) |entry| {
+                assert!(*(*entry).log_level == cnt);
                 cnt += 1;
             }
             assert!(cnt == 4);

--- a/src/libstd/rt/crate_map.rs
+++ b/src/libstd/rt/crate_map.rs
@@ -8,10 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use cast::transmute;
+#[cfg(not(stage0))] use cast::transmute;
 use container::MutableSet;
 use hashmap::HashSet;
 use libc::c_char;
+use option::{Some, None};
+use vec::ImmutableVector;
 
 // Need to tell the linker on OS X to not barf on undefined symbols
 // and instead look them up at runtime, which we need to resolve
@@ -24,7 +26,7 @@ extern {}
 extern {
     #[weak_linkage]
     #[link_name = "_rust_crate_map_toplevel"]
-    static CRATE_MAP: CrateMap;
+    static CRATE_MAP: CrateMap<'static>;
 }
 
 pub struct ModEntry {
@@ -32,28 +34,28 @@ pub struct ModEntry {
     log_level: *mut u32
 }
 
-struct CrateMapV0 {
-    entries: &static [ModEntry],
-    children: &'static [&'static CrateMap]
+pub struct CrateMapV0<'self> {
+    entries: &'self [ModEntry],
+    children: &'self [&'self CrateMap<'self>]
 }
 
-struct CrateMap {
+pub struct CrateMap<'self> {
     version: i32,
-    entries: &static [ModEntry],
+    entries: &'self [ModEntry],
     /// a dynamically sized struct, where all pointers to children are listed adjacent
     /// to the struct, terminated with NULL
-    children: [*CrateMap, ..1]
+    children: &'self [&'self CrateMap<'self>]
 }
 
 #[cfg(not(windows))]
-pub fn get_crate_map() -> *CrateMap {
-    &'static CRATE_MAP as *CrateMap
+pub fn get_crate_map() -> &'static CrateMap<'static> {
+    &'static CRATE_MAP
 }
 
 #[cfg(windows)]
 #[fixed_stack_segment]
 #[inline(never)]
-pub fn get_crate_map() -> *CrateMap {
+pub fn get_crate_map() -> &'static CrateMap<'static> {
     use c_str::ToCStr;
     use unstable::dynamic_lib::dl;
 
@@ -65,11 +67,10 @@ pub fn get_crate_map() -> *CrateMap {
         dl::close(module);
         sym
     };
-
-    sym as *CrateMap
+    sym
 }
 
-fn version(crate_map: &'static CrateMap) -> i32 {
+fn version(crate_map: &CrateMap) -> i32 {
     match crate_map.version {
         1 => return 1,
         _ => return 0
@@ -77,12 +78,13 @@ fn version(crate_map: &'static CrateMap) -> i32 {
 }
 
 #[cfg(not(stage0))]
-fn entries(crate_map: &'static CrateMap) -> *ModEntry {
+fn get_entries_and_children<'a>(crate_map: &'a CrateMap<'a>) ->
+                    (&'a [ModEntry], &'a [&'a CrateMap<'a>]) {
     match version(crate_map) {
         0 => {
             unsafe {
-                let v0: &'static CrateMapV0 = transmute(crate_map);
-                return v0.entries;
+                let v0: &'a CrateMapV0<'a> = transmute(crate_map);
+                return (v0.entries, v0.children);
             }
         }
         1 => return (*crate_map).entries,
@@ -91,79 +93,43 @@ fn entries(crate_map: &'static CrateMap) -> *ModEntry {
 }
 
 #[cfg(not(stage0))]
-fn iterator(crate_map: &'static CrateMap) -> &'static [&'static CrateMap] {
-    match version(crate_map) {
-        0 => {
-            unsafe {
-                let v0: &'static CrateMapV0 = transmute(crate_map);
-                return v0.children;
-            }
-        }
-        1 => return vec::raw::to_ptr((*crate_map).children),
-        _ => fail2!("Unknown crate map version!")
+fn iter_module_map(mod_entries: &[ModEntry], f: &fn(&ModEntry)) {
+    for entry in mod_entries.iter() {
+        f(entry);
     }
 }
-
-fn iter_module_map(mod_entries: *ModEntry, f: &fn(&mut ModEntry)) {
-    let mut curr = mod_entries;
-
-    unsafe {
-        while !(*curr).name.is_null() {
-            f(transmute(curr));
-            curr = curr.offset(1);
-        }
-    }
-}
-
-
 
 #[cfg(not(stage0))]
-fn do_iter_crate_map(crate_map: &'static CrateMap, f: &fn(&mut ModEntry),
-                            visited: &mut HashSet<*CrateMap>) {
+fn do_iter_crate_map<'a>(crate_map: &'a CrateMap<'a>, f: &fn(&ModEntry),
+                            visited: &mut HashSet<*CrateMap<'a>>) {
     if visited.insert(crate_map as *CrateMap) {
-        iter_module_map(crate_map.entries, |x| f(x));
-        let child_crates = iterator(crate_map);
-        
-        let mut i = 0;
-        while i < child_crates.len() {
-            do_iter_crate_map(child_crates[i], |x| f(x), visited);
-            i = i + 1;
+        let (entries, children) = get_entries_and_children(crate_map);
+        iter_module_map(entries, |x| f(x));
+        for child in children.iter() {
+            do_iter_crate_map(*child, |x| f(x), visited);
         }
     }
 }
 
 #[cfg(stage0)]
 /// Iterates recursively over `crate_map` and all child crate maps
-pub fn iter_crate_map(crate_map: *u8, f: &fn(&mut ModEntry)) {
+pub fn iter_crate_map<'a>(crate_map: &'a CrateMap<'a>, f: &fn(&ModEntry)) {
 }
 
 #[cfg(not(stage0))]
 /// Iterates recursively over `crate_map` and all child crate maps
-pub fn iter_crate_map(crate_map: &'static CrateMap, f: &fn(&mut ModEntry)) {
+pub fn iter_crate_map<'a>(crate_map: &'a CrateMap<'a>, f: &fn(&ModEntry)) {
     // XXX: use random numbers as keys from the OS-level RNG when there is a nice
     //        way to do this
-    let mut v: HashSet<*CrateMap> = HashSet::with_capacity_and_keys(0, 0, 32);
-    unsafe {
-        do_iter_crate_map(transmute(crate_map), f, &mut v);
-    }
+    let mut v: HashSet<*CrateMap<'a>> = HashSet::with_capacity_and_keys(0, 0, 32);
+    do_iter_crate_map(crate_map, f, &mut v);
 }
 
 #[cfg(test)]
 mod tests {
     use c_str::ToCStr;
     use cast::transmute;
-    use ptr;
-    use vec;
-
-    use rt::crate_map::{ModEntry, iter_crate_map};
-
-    struct CrateMap<'self> { 
-        version: i32,
-        entries: *ModEntry,
-        /// a dynamically sized struct, where all pointers to children are listed adjacent
-        /// to the struct, terminated with NULL
-        children: &'self [&'self CrateMap<'self>] 
-    }
+    use rt::crate_map::{CrateMap, ModEntry, iter_crate_map};
 
     #[test]
     fn iter_crate_map_duplicates() {
@@ -171,20 +137,19 @@ mod tests {
             let mod_name1 = "c::m1".to_c_str();
             let mut level3: u32 = 3;
 
-            let entries: ~[ModEntry] = ~[
+            let entries = [
                 ModEntry { name: mod_name1.with_ref(|buf| buf), log_level: &mut level3},
-                ModEntry { name: ptr::null(), log_level: ptr::mut_null()}
             ];
 
             let child_crate = CrateMap {
                 version: 1,
-                entries: vec::raw::to_ptr(entries),
+                entries: entries,
                 children: []
             };
 
             let root_crate = CrateMap {
                 version: 1,
-                entries: vec::raw::to_ptr([ModEntry { name: ptr::null(), log_level: ptr::mut_null()}]),
+                entries: [],
                 children: [&child_crate, &child_crate]
             };
 
@@ -206,29 +171,26 @@ mod tests {
             let mut level3: u32 = 3;
             let child_crate2 = CrateMap {
                 version: 1,
-                entries: vec::raw::to_ptr([
+                entries: [
                     ModEntry { name: mod_name1.with_ref(|buf| buf), log_level: &mut level2},
                     ModEntry { name: mod_name2.with_ref(|buf| buf), log_level: &mut level3},
-                    ModEntry { name: ptr::null(), log_level: ptr::mut_null()}
-                ]),
+                ],
                 children: []
             };
 
             let child_crate1 = CrateMap {
                 version: 1,
-                entries: vec::raw::to_ptr([
+                entries: [
                     ModEntry { name: "t::f1".to_c_str().with_ref(|buf| buf), log_level: &mut 1},
-                    ModEntry { name: ptr::null(), log_level: ptr::mut_null()}
-                ]),
+                ],
                 children: [&child_crate2]
             };
 
             let root_crate = CrateMap {
                 version: 1,
-                entries: vec::raw::to_ptr([
+                entries: [
                     ModEntry { name: "t::f1".to_c_str().with_ref(|buf| buf), log_level: &mut 0},
-                    ModEntry { name: ptr::null(), log_level: ptr::mut_null()}
-                ]),
+                ],
                 children: [&child_crate1]
             };
 

--- a/src/libstd/rt/logging.rs
+++ b/src/libstd/rt/logging.rs
@@ -199,15 +199,25 @@ impl rt::io::Writer for StdErrLogger {
 pub fn init() {
     use os;
 
-    let crate_map = get_crate_map();
-
     let log_spec = os::getenv("RUST_LOG");
-    match log_spec {
-        Some(spec) => {
-            update_log_settings(crate_map, spec);
-        }
-        None => {
-            update_log_settings(crate_map, ~"");
+    match get_crate_map() {
+        Some(crate_map) => {
+            match log_spec {
+                Some(spec) => {
+                    update_log_settings(crate_map, spec);
+                }
+                None => {
+                    update_log_settings(crate_map, ~"");
+                }
+            }
+        },
+        _ => {
+            match log_spec {
+                Some(_) => {
+                    dumb_println("warning: RUST_LOG set, but no crate map found.");
+                },
+                None => {}
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request changes to memory layout of the `CrateMap` struct to use static slices instead of raw pointers. Most of the discussion took place [here](https://github.com/fhahn/rust/commit/63b5975efa10af7df3df0a50d8d7f9c8d5bcf9e9#L1R92) .

The memory layout of CrateMap changed, without bumping the version number in the struct. Another, more backward compatible, solution would be to keep the old code and increase the version number in the new struct. On the other hand, the `annihilate_fn` pointer was removed without bumping the version number recently.

At the moment, the stage0 compiler does not use the new memory layout, which would lead the segfaults during stage0 compilation, so I've added a dummy `iter_crate_map` function for stage0, which does nothing. Again, this could be avoided if we'd bump the version number in the struct and keep the old code.

I'd like to use a normal `for` loop [here](https://github.com/fhahn/rust/compare/logging-unsafe-removal?expand=1#L1R109), 

```
    for child in children.iter() {
        do_iter_crate_map(child, |x| f(x), visited);
    }
```

but for some reason this only yields `error: unresolved enum variant, struct or const 'Some'` and I have no idea why.
