### PR TITLE
[emacs] Fix single-line-style paragraph fills with code immediately before or after

### DIFF
--- a/src/etc/emacs/rust-mode-tests.el
+++ b/src/etc/emacs/rust-mode-tests.el
@@ -196,6 +196,35 @@ This is some more text.  Fee fie fo fum.  Humpty dumpty sat on a wall.
  *very very very long string
  */"))
 
+(ert-deftest fill-paragraph-single-line-style-with-code-before ()
+  (test-fill-paragraph
+   "fn foo() { }
+/// This is my comment.  This is more of my comment.  This is even more."
+   "fn foo() { }
+/// This is my comment.  This is
+/// more of my comment.  This is
+/// even more." 14))
+
+(ert-deftest fill-paragraph-single-line-style-with-code-after ()
+  (test-fill-paragraph
+   "/// This is my comment.  This is more of my comment.  This is even more.
+fn foo() { }"
+   "/// This is my comment.  This is
+/// more of my comment.  This is
+/// even more.
+fn foo() { }" 1 73))
+
+(ert-deftest fill-paragraph-single-line-style-code-before-and-after ()
+  (test-fill-paragraph
+   "fn foo() { }
+/// This is my comment.  This is more of my comment.  This is even more.
+fn bar() { }"
+   "fn foo() { }
+/// This is my comment.  This is
+/// more of my comment.  This is
+/// even more.
+fn bar() { }" 14 67))
+
 (defun test-auto-fill (initial position inserted expected)
   (rust-test-manip-code 
    initial

--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -300,7 +300,8 @@
         (let
             ((fill-paragraph-function
               (if (not (eq fill-paragraph-function 'rust-fill-paragraph))
-                  fill-paragraph-function)))
+                  fill-paragraph-function))
+             (fill-paragraph-handle-comment t))
           (apply 'fill-paragraph args)
           t))))))
 


### PR DESCRIPTION
This fixes a problem with paragraph fills: hitting M-q on a single-line-style (`//`) comment with code immediately before or after it would try to fill the code as part of the paragraph too.
