### PR TITLE
Remove unused abi attributes.

### DIFF
--- a/doc/tutorial-ffi.md
+++ b/doc/tutorial-ffi.md
@@ -415,21 +415,18 @@ fn main() {
 
 Most foreign code exposes a C ABI, and Rust uses the platform's C calling convention by default when
 calling foreign functions. Some foreign functions, most notably the Windows API, use other calling
-conventions. Rust provides the `abi` attribute as a way to hint to the compiler which calling
-convention to use:
+conventions. Rust provides a way to tell the compiler which convention to use:
 
 ~~~~
 #[cfg(target_os = "win32")]
-#[abi = "stdcall"]
 #[link_name = "kernel32"]
-extern {
+extern "stdcall" {
     fn SetEnvironmentVariableA(n: *u8, v: *u8) -> int;
 }
 ~~~~
 
-The `abi` attribute applies to a foreign module (it cannot be applied to a single function within a
-module), and must be either `"cdecl"` or `"stdcall"`. The compiler may eventually support other
-calling conventions.
+This applies to the entire `extern` block, and must be either `"cdecl"` or
+`"stdcall"`. The compiler may eventually support other calling conventions.
 
 # Interoperability with foreign code
 

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -19,8 +19,7 @@ static NSEC_PER_SEC: i32 = 1_000_000_000_i32;
 pub mod rustrt {
     use super::Tm;
 
-    #[abi = "cdecl"]
-    extern {
+    extern "cdecl" {
         pub fn get_time(sec: &mut i64, nsec: &mut i32);
         pub fn precise_time_ns(ns: &mut u64);
         pub fn rust_tzset();

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -19,7 +19,7 @@ static NSEC_PER_SEC: i32 = 1_000_000_000_i32;
 pub mod rustrt {
     use super::Tm;
 
-    extern "cdecl" {
+    extern {
         pub fn get_time(sec: &mut i64, nsec: &mut i32);
         pub fn precise_time_ns(ns: &mut u64);
         pub fn rust_tzset();

--- a/src/libextra/unicode.rs
+++ b/src/libextra/unicode.rs
@@ -162,7 +162,7 @@ pub mod icu {
 
         // #[link_name = "icuuc"]
         #[link_args = "-licuuc"]
-        extern "cdecl" {
+        extern {
             pub fn u_hasBinaryProperty(c: UChar32, which: UProperty) -> UBool;
             pub fn u_isdigit(c: UChar32) -> UBool;
             pub fn u_islower(c: UChar32) -> UBool;

--- a/src/libextra/unicode.rs
+++ b/src/libextra/unicode.rs
@@ -162,8 +162,7 @@ pub mod icu {
 
         // #[link_name = "icuuc"]
         #[link_args = "-licuuc"]
-        #[abi = "cdecl"]
-        extern {
+        extern "cdecl" {
             pub fn u_hasBinaryProperty(c: UChar32, which: UProperty) -> UBool;
             pub fn u_isdigit(c: UChar32) -> UBool;
             pub fn u_islower(c: UChar32) -> UBool;

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -300,8 +300,7 @@ pub mod llvm {
 
     #[link_args = "-Lrustllvm -lrustllvm"]
     #[link_name = "rustllvm"]
-    #[abi = "cdecl"]
-    extern {
+    extern "cdecl" {
         /* Create and destroy contexts. */
         pub fn LLVMContextCreate() -> ContextRef;
         pub fn LLVMContextDispose(C: ContextRef);

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -300,7 +300,7 @@ pub mod llvm {
 
     #[link_args = "-Lrustllvm -lrustllvm"]
     #[link_name = "rustllvm"]
-    extern "cdecl" {
+    extern {
         /* Create and destroy contexts. */
         pub fn LLVMContextCreate() -> ContextRef;
         pub fn LLVMContextDispose(C: ContextRef);

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -76,9 +76,8 @@ pub type fd_t = c_int;
 pub mod rustrt {
     use libc;
 
-    #[abi = "cdecl"]
     #[link_name = "rustrt"]
-    extern {
+    extern "cdecl" {
         pub fn rust_get_stdin() -> *libc::FILE;
         pub fn rust_get_stdout() -> *libc::FILE;
         pub fn rust_get_stderr() -> *libc::FILE;

--- a/src/libstd/io.rs
+++ b/src/libstd/io.rs
@@ -77,7 +77,7 @@ pub mod rustrt {
     use libc;
 
     #[link_name = "rustrt"]
-    extern "cdecl" {
+    extern {
         pub fn rust_get_stdin() -> *libc::FILE;
         pub fn rust_get_stdout() -> *libc::FILE;
         pub fn rust_get_stderr() -> *libc::FILE;

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -2663,11 +2663,10 @@ pub mod funcs {
 
     pub mod c95 {
         #[nolink]
-        #[abi = "cdecl"]
         pub mod ctype {
             use libc::types::os::arch::c95::{c_char, c_int};
 
-            extern {
+            extern "cdecl" {
                 pub fn isalnum(c: c_int) -> c_int;
                 pub fn isalpha(c: c_int) -> c_int;
                 pub fn iscntrl(c: c_int) -> c_int;
@@ -2685,12 +2684,11 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod stdio {
             use libc::types::common::c95::{FILE, c_void, fpos_t};
             use libc::types::os::arch::c95::{c_char, c_int, c_long, size_t};
 
-            extern {
+            extern "cdecl" {
                 pub fn fopen(filename: *c_char, mode: *c_char) -> *FILE;
                 pub fn freopen(filename: *c_char, mode: *c_char, file: *FILE)
                                -> *FILE;
@@ -2742,14 +2740,13 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod stdlib {
             use libc::types::common::c95::c_void;
             use libc::types::os::arch::c95::{c_char, c_double, c_int};
             use libc::types::os::arch::c95::{c_long, c_uint, c_ulong};
             use libc::types::os::arch::c95::{size_t};
 
-            extern {
+            extern "cdecl" {
                 pub fn abs(i: c_int) -> c_int;
                 pub fn labs(i: c_long) -> c_long;
                 // Omitted: div, ldiv (return pub type incomplete).
@@ -2776,13 +2773,12 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod string {
             use libc::types::common::c95::c_void;
             use libc::types::os::arch::c95::{c_char, c_int, size_t};
             use libc::types::os::arch::c95::{wchar_t};
 
-            extern {
+            extern "cdecl" {
                 pub fn strcpy(dst: *c_char, src: *c_char) -> *c_char;
                 pub fn strncpy(dst: *c_char, src: *c_char, n: size_t)
                                -> *c_char;
@@ -2826,12 +2822,11 @@ pub mod funcs {
     #[cfg(target_os = "win32")]
     pub mod posix88 {
         #[nolink]
-        #[abi = "cdecl"]
         pub mod stat_ {
             use libc::types::os::common::posix01::stat;
             use libc::types::os::arch::c95::{c_int, c_char};
 
-            extern {
+            extern "cdecl" {
                 #[link_name = "_chmod"]
                 pub fn chmod(path: *c_char, mode: c_int) -> c_int;
                 #[link_name = "_mkdir"]
@@ -2844,12 +2839,11 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod stdio {
             use libc::types::common::c95::FILE;
             use libc::types::os::arch::c95::{c_int, c_char};
 
-            extern {
+            extern "cdecl" {
                 #[link_name = "_popen"]
                 pub fn popen(command: *c_char, mode: *c_char) -> *FILE;
                 #[link_name = "_pclose"]
@@ -2862,10 +2856,9 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod fcntl {
             use libc::types::os::arch::c95::{c_int, c_char};
-            extern {
+            extern "cdecl" {
                 #[link_name = "_open"]
                 pub fn open(path: *c_char, oflag: c_int, mode: c_int)
                             -> c_int;
@@ -2875,20 +2868,18 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod dirent {
             // Not supplied at all.
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod unistd {
             use libc::types::common::c95::c_void;
             use libc::types::os::arch::c95::{c_int, c_uint, c_char,
                                              c_long, size_t};
             use libc::types::os::arch::c99::intptr_t;
 
-            extern {
+            extern "cdecl" {
                 #[link_name = "_access"]
                 pub fn access(path: *c_char, amode: c_int) -> c_int;
                 #[link_name = "_chdir"]
@@ -2949,8 +2940,7 @@ pub mod funcs {
             use libc::types::os::arch::posix88::mode_t;
 
             #[nolink]
-            #[abi = "cdecl"]
-            extern {
+            extern "cdecl" {
                 pub fn chmod(path: *c_char, mode: mode_t) -> c_int;
                 pub fn fchmod(fd: c_int, mode: mode_t) -> c_int;
 
@@ -2978,12 +2968,11 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod stdio {
             use libc::types::common::c95::FILE;
             use libc::types::os::arch::c95::{c_char, c_int};
 
-            extern {
+            extern "cdecl" {
                 pub fn popen(command: *c_char, mode: *c_char) -> *FILE;
                 pub fn pclose(stream: *FILE) -> c_int;
                 pub fn fdopen(fd: c_int, mode: *c_char) -> *FILE;
@@ -2992,12 +2981,11 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod fcntl {
             use libc::types::os::arch::c95::{c_char, c_int};
             use libc::types::os::arch::posix88::mode_t;
 
-            extern {
+            extern "cdecl" {
                 pub fn open(path: *c_char, oflag: c_int, mode: c_int)
                             -> c_int;
                 pub fn creat(path: *c_char, mode: mode_t) -> c_int;
@@ -3006,7 +2994,6 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod dirent {
             use libc::types::common::posix88::{DIR, dirent_t};
             use libc::types::os::arch::c95::{c_char, c_int, c_long};
@@ -3026,12 +3013,12 @@ pub mod funcs {
                 rust_readdir(dirp)
             }
 
-            extern {
+            extern "cdecl" {
                 fn rust_opendir(dirname: *c_char) -> *DIR;
                 fn rust_readdir(dirp: *DIR) -> *dirent_t;
             }
 
-            extern {
+            extern "cdecl" {
                 pub fn closedir(dirp: *DIR) -> c_int;
                 pub fn rewinddir(dirp: *DIR);
                 pub fn seekdir(dirp: *DIR, loc: c_long);
@@ -3040,7 +3027,6 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod unistd {
             use libc::types::common::c95::c_void;
             use libc::types::os::arch::c95::{c_char, c_int, c_long, c_uint};
@@ -3048,7 +3034,7 @@ pub mod funcs {
             use libc::types::os::arch::posix88::{gid_t, off_t, pid_t};
             use libc::types::os::arch::posix88::{ssize_t, uid_t};
 
-            extern {
+            extern "cdecl" {
                 pub fn access(path: *c_char, amode: c_int) -> c_int;
                 pub fn alarm(seconds: c_uint) -> c_uint;
                 pub fn chdir(dir: *c_char) -> c_int;
@@ -3100,24 +3086,22 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod signal {
             use libc::types::os::arch::c95::{c_int};
             use libc::types::os::arch::posix88::{pid_t};
 
-            extern {
+            extern "cdecl" {
                 pub fn kill(pid: pid_t, sig: c_int) -> c_int;
             }
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod mman {
             use libc::types::common::c95::{c_void};
             use libc::types::os::arch::c95::{size_t, c_int, c_char};
             use libc::types::os::arch::posix88::{mode_t, off_t};
 
-            extern {
+            extern "cdecl" {
                 pub fn mlock(addr: *c_void, len: size_t) -> c_int;
                 pub fn munlock(addr: *c_void, len: size_t) -> c_int;
                 pub fn mlockall(flags: c_int) -> c_int;
@@ -3150,12 +3134,11 @@ pub mod funcs {
     #[cfg(target_os = "freebsd")]
     pub mod posix01 {
         #[nolink]
-        #[abi = "cdecl"]
         pub mod stat_ {
             use libc::types::os::arch::c95::{c_char, c_int};
             use libc::types::os::arch::posix01::stat;
 
-            extern {
+            extern "cdecl" {
                 #[cfg(target_os = "linux")]
                 #[cfg(target_os = "freebsd")]
                 #[cfg(target_os = "android")]
@@ -3168,12 +3151,11 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod unistd {
             use libc::types::os::arch::c95::{c_char, c_int, size_t};
             use libc::types::os::arch::posix88::{ssize_t};
 
-            extern {
+            extern "cdecl" {
                 pub fn readlink(path: *c_char,
                                 buf: *mut c_char,
                                 bufsz: size_t)
@@ -3195,25 +3177,23 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod wait {
             use libc::types::os::arch::c95::{c_int};
             use libc::types::os::arch::posix88::{pid_t};
 
-            extern {
+            extern "cdecl" {
                 pub fn waitpid(pid: pid_t, status: *mut c_int, options: c_int)
                                -> pid_t;
             }
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod glob {
             use libc::types::os::arch::c95::{c_char, c_int};
             use libc::types::os::common::posix01::{glob_t};
             use option::Option;
 
-            extern {
+            extern "cdecl" {
                 pub fn glob(pattern: *c_char,
                             flags: c_int,
                             errfunc: Option<extern "C" fn(epath: *c_char, errno: int) -> int>,
@@ -3223,12 +3203,11 @@ pub mod funcs {
         }
 
         #[nolink]
-        #[abi = "cdecl"]
         pub mod mman {
             use libc::types::common::c95::{c_void};
             use libc::types::os::arch::c95::{c_int, size_t};
 
-            extern {
+            extern "cdecl" {
                 pub fn posix_madvise(addr: *c_void,
                                      len: size_t,
                                      advice: c_int)
@@ -3271,8 +3250,7 @@ pub mod funcs {
         use libc::types::os::arch::c95::{c_char, c_uchar, c_int, c_uint,
                                          size_t};
 
-        #[abi = "cdecl"]
-        extern {
+        extern "cdecl" {
             pub fn sysctl(name: *c_int,
                           namelen: c_uint,
                           oldp: *mut c_void,
@@ -3305,8 +3283,7 @@ pub mod funcs {
         use libc::types::common::c95::{c_void};
         use libc::types::os::arch::c95::{c_uchar, c_int, size_t};
 
-        #[abi = "cdecl"]
-        extern {
+        extern "cdecl" {
             pub fn getdtablesize() -> c_int;
             pub fn madvise(addr: *c_void, len: size_t, advice: c_int)
                            -> c_int;
@@ -3325,8 +3302,7 @@ pub mod funcs {
     pub mod extra {
         use libc::types::os::arch::c95::{c_char, c_int};
 
-        #[abi = "cdecl"]
-        extern {
+        extern "cdecl" {
             pub fn _NSGetExecutablePath(buf: *mut c_char, bufsize: *mut u32)
                                         -> c_int;
         }
@@ -3358,7 +3334,6 @@ pub mod funcs {
             use libc::types::os::arch::extra::{HANDLE, LPHANDLE};
 
             #[cfg(target_arch = "x86")]
-            #[abi = "stdcall"]
             extern "stdcall" {
                 pub fn GetEnvironmentVariableW(n: LPCWSTR,
                                                v: LPWSTR,
@@ -3572,9 +3547,8 @@ pub mod funcs {
         pub mod msvcrt {
             use libc::types::os::arch::c95::{c_int, c_long};
 
-            #[abi = "cdecl"]
             #[nolink]
-            extern {
+            extern "cdecl" {
                 #[link_name = "_commit"]
                 pub fn commit(fd: c_int) -> c_int;
 

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -2666,7 +2666,7 @@ pub mod funcs {
         pub mod ctype {
             use libc::types::os::arch::c95::{c_char, c_int};
 
-            extern "cdecl" {
+            extern {
                 pub fn isalnum(c: c_int) -> c_int;
                 pub fn isalpha(c: c_int) -> c_int;
                 pub fn iscntrl(c: c_int) -> c_int;
@@ -2688,7 +2688,7 @@ pub mod funcs {
             use libc::types::common::c95::{FILE, c_void, fpos_t};
             use libc::types::os::arch::c95::{c_char, c_int, c_long, size_t};
 
-            extern "cdecl" {
+            extern {
                 pub fn fopen(filename: *c_char, mode: *c_char) -> *FILE;
                 pub fn freopen(filename: *c_char, mode: *c_char, file: *FILE)
                                -> *FILE;
@@ -2746,7 +2746,7 @@ pub mod funcs {
             use libc::types::os::arch::c95::{c_long, c_uint, c_ulong};
             use libc::types::os::arch::c95::{size_t};
 
-            extern "cdecl" {
+            extern {
                 pub fn abs(i: c_int) -> c_int;
                 pub fn labs(i: c_long) -> c_long;
                 // Omitted: div, ldiv (return pub type incomplete).
@@ -2778,7 +2778,7 @@ pub mod funcs {
             use libc::types::os::arch::c95::{c_char, c_int, size_t};
             use libc::types::os::arch::c95::{wchar_t};
 
-            extern "cdecl" {
+            extern {
                 pub fn strcpy(dst: *c_char, src: *c_char) -> *c_char;
                 pub fn strncpy(dst: *c_char, src: *c_char, n: size_t)
                                -> *c_char;
@@ -2826,7 +2826,7 @@ pub mod funcs {
             use libc::types::os::common::posix01::stat;
             use libc::types::os::arch::c95::{c_int, c_char};
 
-            extern "cdecl" {
+            extern {
                 #[link_name = "_chmod"]
                 pub fn chmod(path: *c_char, mode: c_int) -> c_int;
                 #[link_name = "_mkdir"]
@@ -2843,7 +2843,7 @@ pub mod funcs {
             use libc::types::common::c95::FILE;
             use libc::types::os::arch::c95::{c_int, c_char};
 
-            extern "cdecl" {
+            extern {
                 #[link_name = "_popen"]
                 pub fn popen(command: *c_char, mode: *c_char) -> *FILE;
                 #[link_name = "_pclose"]
@@ -2858,7 +2858,7 @@ pub mod funcs {
         #[nolink]
         pub mod fcntl {
             use libc::types::os::arch::c95::{c_int, c_char};
-            extern "cdecl" {
+            extern {
                 #[link_name = "_open"]
                 pub fn open(path: *c_char, oflag: c_int, mode: c_int)
                             -> c_int;
@@ -2879,7 +2879,7 @@ pub mod funcs {
                                              c_long, size_t};
             use libc::types::os::arch::c99::intptr_t;
 
-            extern "cdecl" {
+            extern {
                 #[link_name = "_access"]
                 pub fn access(path: *c_char, amode: c_int) -> c_int;
                 #[link_name = "_chdir"]
@@ -2940,7 +2940,7 @@ pub mod funcs {
             use libc::types::os::arch::posix88::mode_t;
 
             #[nolink]
-            extern "cdecl" {
+            extern {
                 pub fn chmod(path: *c_char, mode: mode_t) -> c_int;
                 pub fn fchmod(fd: c_int, mode: mode_t) -> c_int;
 
@@ -2972,7 +2972,7 @@ pub mod funcs {
             use libc::types::common::c95::FILE;
             use libc::types::os::arch::c95::{c_char, c_int};
 
-            extern "cdecl" {
+            extern {
                 pub fn popen(command: *c_char, mode: *c_char) -> *FILE;
                 pub fn pclose(stream: *FILE) -> c_int;
                 pub fn fdopen(fd: c_int, mode: *c_char) -> *FILE;
@@ -2985,7 +2985,7 @@ pub mod funcs {
             use libc::types::os::arch::c95::{c_char, c_int};
             use libc::types::os::arch::posix88::mode_t;
 
-            extern "cdecl" {
+            extern {
                 pub fn open(path: *c_char, oflag: c_int, mode: c_int)
                             -> c_int;
                 pub fn creat(path: *c_char, mode: mode_t) -> c_int;
@@ -3013,12 +3013,12 @@ pub mod funcs {
                 rust_readdir(dirp)
             }
 
-            extern "cdecl" {
+            extern {
                 fn rust_opendir(dirname: *c_char) -> *DIR;
                 fn rust_readdir(dirp: *DIR) -> *dirent_t;
             }
 
-            extern "cdecl" {
+            extern {
                 pub fn closedir(dirp: *DIR) -> c_int;
                 pub fn rewinddir(dirp: *DIR);
                 pub fn seekdir(dirp: *DIR, loc: c_long);
@@ -3034,7 +3034,7 @@ pub mod funcs {
             use libc::types::os::arch::posix88::{gid_t, off_t, pid_t};
             use libc::types::os::arch::posix88::{ssize_t, uid_t};
 
-            extern "cdecl" {
+            extern {
                 pub fn access(path: *c_char, amode: c_int) -> c_int;
                 pub fn alarm(seconds: c_uint) -> c_uint;
                 pub fn chdir(dir: *c_char) -> c_int;
@@ -3090,7 +3090,7 @@ pub mod funcs {
             use libc::types::os::arch::c95::{c_int};
             use libc::types::os::arch::posix88::{pid_t};
 
-            extern "cdecl" {
+            extern {
                 pub fn kill(pid: pid_t, sig: c_int) -> c_int;
             }
         }
@@ -3101,7 +3101,7 @@ pub mod funcs {
             use libc::types::os::arch::c95::{size_t, c_int, c_char};
             use libc::types::os::arch::posix88::{mode_t, off_t};
 
-            extern "cdecl" {
+            extern {
                 pub fn mlock(addr: *c_void, len: size_t) -> c_int;
                 pub fn munlock(addr: *c_void, len: size_t) -> c_int;
                 pub fn mlockall(flags: c_int) -> c_int;
@@ -3138,7 +3138,7 @@ pub mod funcs {
             use libc::types::os::arch::c95::{c_char, c_int};
             use libc::types::os::arch::posix01::stat;
 
-            extern "cdecl" {
+            extern {
                 #[cfg(target_os = "linux")]
                 #[cfg(target_os = "freebsd")]
                 #[cfg(target_os = "android")]
@@ -3155,7 +3155,7 @@ pub mod funcs {
             use libc::types::os::arch::c95::{c_char, c_int, size_t};
             use libc::types::os::arch::posix88::{ssize_t};
 
-            extern "cdecl" {
+            extern {
                 pub fn readlink(path: *c_char,
                                 buf: *mut c_char,
                                 bufsz: size_t)
@@ -3181,7 +3181,7 @@ pub mod funcs {
             use libc::types::os::arch::c95::{c_int};
             use libc::types::os::arch::posix88::{pid_t};
 
-            extern "cdecl" {
+            extern {
                 pub fn waitpid(pid: pid_t, status: *mut c_int, options: c_int)
                                -> pid_t;
             }
@@ -3193,7 +3193,7 @@ pub mod funcs {
             use libc::types::os::common::posix01::{glob_t};
             use option::Option;
 
-            extern "cdecl" {
+            extern {
                 pub fn glob(pattern: *c_char,
                             flags: c_int,
                             errfunc: Option<extern "C" fn(epath: *c_char, errno: int) -> int>,
@@ -3207,7 +3207,7 @@ pub mod funcs {
             use libc::types::common::c95::{c_void};
             use libc::types::os::arch::c95::{c_int, size_t};
 
-            extern "cdecl" {
+            extern {
                 pub fn posix_madvise(addr: *c_void,
                                      len: size_t,
                                      advice: c_int)
@@ -3250,7 +3250,7 @@ pub mod funcs {
         use libc::types::os::arch::c95::{c_char, c_uchar, c_int, c_uint,
                                          size_t};
 
-        extern "cdecl" {
+        extern {
             pub fn sysctl(name: *c_int,
                           namelen: c_uint,
                           oldp: *mut c_void,
@@ -3283,7 +3283,7 @@ pub mod funcs {
         use libc::types::common::c95::{c_void};
         use libc::types::os::arch::c95::{c_uchar, c_int, size_t};
 
-        extern "cdecl" {
+        extern {
             pub fn getdtablesize() -> c_int;
             pub fn madvise(addr: *c_void, len: size_t, advice: c_int)
                            -> c_int;
@@ -3302,7 +3302,7 @@ pub mod funcs {
     pub mod extra {
         use libc::types::os::arch::c95::{c_char, c_int};
 
-        extern "cdecl" {
+        extern {
             pub fn _NSGetExecutablePath(buf: *mut c_char, bufsize: *mut u32)
                                         -> c_int;
         }
@@ -3548,7 +3548,7 @@ pub mod funcs {
             use libc::types::os::arch::c95::{c_int, c_long};
 
             #[nolink]
-            extern "cdecl" {
+            extern {
                 #[link_name = "_commit"]
                 pub fn commit(fd: c_int) -> c_int;
 

--- a/src/libstd/num/cmath.rs
+++ b/src/libstd/num/cmath.rs
@@ -18,7 +18,7 @@ pub mod c_double_utils {
     use libc::{c_double, c_int};
 
     #[link_name = "m"]
-    extern "cdecl" {
+    extern {
         // Alpabetically sorted by link_name
 
         pub fn acos(n: c_double) -> c_double;
@@ -106,7 +106,7 @@ pub mod c_float_utils {
     use libc::{c_float, c_int};
 
     #[link_name = "m"]
-    extern "cdecl" {
+    extern {
         // Alpabetically sorted by link_name
 
         #[link_name="acosf"]

--- a/src/libstd/num/cmath.rs
+++ b/src/libstd/num/cmath.rs
@@ -18,8 +18,7 @@ pub mod c_double_utils {
     use libc::{c_double, c_int};
 
     #[link_name = "m"]
-    #[abi = "cdecl"]
-    extern {
+    extern "cdecl" {
         // Alpabetically sorted by link_name
 
         pub fn acos(n: c_double) -> c_double;
@@ -107,8 +106,7 @@ pub mod c_float_utils {
     use libc::{c_float, c_int};
 
     #[link_name = "m"]
-    #[abi = "cdecl"]
-    extern {
+    extern "cdecl" {
         // Alpabetically sorted by link_name
 
         #[link_name="acosf"]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1039,7 +1039,6 @@ pub fn errno() -> uint {
 
     #[cfg(target_arch = "x86")]
     #[link_name = "kernel32"]
-    #[abi = "stdcall"]
     extern "stdcall" {
         fn GetLastError() -> DWORD;
     }
@@ -1118,7 +1117,6 @@ pub fn last_os_error() -> ~str {
 
         #[cfg(target_arch = "x86")]
         #[link_name = "kernel32"]
-        #[abi = "stdcall"]
         extern "stdcall" {
             fn FormatMessageW(flags: DWORD,
                               lpSrc: LPVOID,

--- a/src/libstd/rt/thread_local_storage.rs
+++ b/src/libstd/rt/thread_local_storage.rs
@@ -84,7 +84,6 @@ pub unsafe fn get(key: Key) -> *mut c_void {
 }
 
 #[cfg(windows, target_arch = "x86")]
-#[abi = "stdcall"]
 extern "stdcall" {
        fn TlsAlloc() -> DWORD;
        fn TlsSetValue(dwTlsIndex: DWORD, lpTlsvalue: LPVOID) -> BOOL;

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -170,7 +170,6 @@ pub trait TyVisitor {
     fn visit_closure_ptr(&mut self, ck: uint) -> bool;
 }
 
-#[abi = "rust-intrinsic"]
 extern "rust-intrinsic" {
 
     /// Atomic compare and exchange, sequentially consistent.

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1059,7 +1059,6 @@ pub fn std_macros() -> @str {
     // It is intended to be used like:
     //
     // externfn!(#[nolink]
-    //           #[abi = \"cdecl\"]
     //           fn memcmp(cx: *u8, ct: *u8, n: u32) -> u32)
     //
     // Due to limitations in the macro parser, this pattern must be

--- a/src/test/auxiliary/anon-extern-mod-cross-crate-1.rs
+++ b/src/test/auxiliary/anon-extern-mod-cross-crate-1.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[abi = "cdecl"];
 #[link_name = "rustrt"];
 #[link(name = "anonexternmod",
        vers = "0.1")];
@@ -17,6 +16,6 @@
 
 use std::libc;
 
-extern {
+extern "cdecl" {
     pub fn rust_get_test_int() -> libc::intptr_t;
 }

--- a/src/test/auxiliary/anon-extern-mod-cross-crate-1.rs
+++ b/src/test/auxiliary/anon-extern-mod-cross-crate-1.rs
@@ -16,6 +16,6 @@
 
 use std::libc;
 
-extern "cdecl" {
+extern {
     pub fn rust_get_test_int() -> libc::intptr_t;
 }

--- a/src/test/auxiliary/cci_intrinsic.rs
+++ b/src/test/auxiliary/cci_intrinsic.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 pub mod rusti {
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn atomic_cxchg(dst: &mut int, old: int, src: int) -> int;
         pub fn atomic_cxchg_acq(dst: &mut int, old: int, src: int) -> int;

--- a/src/test/compile-fail/foreign-unsafe-fn-called.rs
+++ b/src/test/compile-fail/foreign-unsafe-fn-called.rs
@@ -11,7 +11,7 @@
 
 
 mod test {
-    extern "cdecl" {
+    extern {
         pub fn free();
     }
 }

--- a/src/test/compile-fail/foreign-unsafe-fn-called.rs
+++ b/src/test/compile-fail/foreign-unsafe-fn-called.rs
@@ -11,8 +11,7 @@
 
 
 mod test {
-    #[abi = "cdecl"]
-    extern {
+    extern "cdecl" {
         pub fn free();
     }
 }

--- a/src/test/run-pass/anon-extern-mod.rs
+++ b/src/test/run-pass/anon-extern-mod.rs
@@ -10,9 +10,8 @@
 
 use std::libc;
 
-#[abi = "cdecl"]
 #[link_name = "rustrt"]
-extern {
+extern "cdecl" {
     fn rust_get_test_int() -> libc::intptr_t;
 }
 

--- a/src/test/run-pass/anon-extern-mod.rs
+++ b/src/test/run-pass/anon-extern-mod.rs
@@ -11,7 +11,7 @@
 use std::libc;
 
 #[link_name = "rustrt"]
-extern "cdecl" {
+extern {
     fn rust_get_test_int() -> libc::intptr_t;
 }
 

--- a/src/test/run-pass/c-stack-as-value.rs
+++ b/src/test/run-pass/c-stack-as-value.rs
@@ -11,8 +11,7 @@
 mod rustrt {
     use std::libc;
 
-    #[abi = "cdecl"]
-    extern {
+    extern "cdecl" {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }

--- a/src/test/run-pass/c-stack-as-value.rs
+++ b/src/test/run-pass/c-stack-as-value.rs
@@ -11,7 +11,7 @@
 mod rustrt {
     use std::libc;
 
-    extern "cdecl" {
+    extern {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }

--- a/src/test/run-pass/c-stack-returning-int64.rs
+++ b/src/test/run-pass/c-stack-returning-int64.rs
@@ -12,7 +12,7 @@ mod libc {
     use std::libc::{c_char, c_long, c_longlong};
 
     #[nolink]
-    extern "cdecl" {
+    extern {
         pub fn atol(x: *c_char) -> c_long;
         pub fn atoll(x: *c_char) -> c_longlong;
     }

--- a/src/test/run-pass/c-stack-returning-int64.rs
+++ b/src/test/run-pass/c-stack-returning-int64.rs
@@ -11,9 +11,8 @@
 mod libc {
     use std::libc::{c_char, c_long, c_longlong};
 
-    #[abi = "cdecl"]
     #[nolink]
-    extern {
+    extern "cdecl" {
         pub fn atol(x: *c_char) -> c_long;
         pub fn atoll(x: *c_char) -> c_longlong;
     }

--- a/src/test/run-pass/conditional-compile.rs
+++ b/src/test/run-pass/conditional-compile.rs
@@ -21,13 +21,13 @@ static b: bool = true;
 
 mod rustrt {
     #[cfg(bogus)]
-    extern "cdecl" {
+    extern {
         // This symbol doesn't exist and would be a link error if this
         // module was translated
         pub fn bogus();
     }
 
-    extern "cdecl" {}
+    extern {}
 }
 
 #[cfg(bogus)]
@@ -107,7 +107,7 @@ fn test_in_fn_ctxt() {
 
 mod test_foreign_items {
     pub mod rustrt {
-        extern "cdecl" {
+        extern {
             #[cfg(bogus)]
             pub fn rust_get_stdin() -> ~str;
             pub fn rust_get_stdin() -> ~str;

--- a/src/test/run-pass/conditional-compile.rs
+++ b/src/test/run-pass/conditional-compile.rs
@@ -21,15 +21,13 @@ static b: bool = true;
 
 mod rustrt {
     #[cfg(bogus)]
-    #[abi = "cdecl"]
-    extern {
+    extern "cdecl" {
         // This symbol doesn't exist and would be a link error if this
         // module was translated
         pub fn bogus();
     }
 
-    #[abi = "cdecl"]
-    extern {}
+    extern "cdecl" {}
 }
 
 #[cfg(bogus)]
@@ -109,8 +107,7 @@ fn test_in_fn_ctxt() {
 
 mod test_foreign_items {
     pub mod rustrt {
-        #[abi = "cdecl"]
-        extern {
+        extern "cdecl" {
             #[cfg(bogus)]
             pub fn rust_get_stdin() -> ~str;
             pub fn rust_get_stdin() -> ~str;

--- a/src/test/run-pass/foreign-dupe.rs
+++ b/src/test/run-pass/foreign-dupe.rs
@@ -14,9 +14,8 @@
 mod rustrt1 {
     use std::libc;
 
-    #[abi = "cdecl"]
     #[link_name = "rustrt"]
-    extern {
+    extern "cdecl" {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }
@@ -24,9 +23,8 @@ mod rustrt1 {
 mod rustrt2 {
     use std::libc;
 
-    #[abi = "cdecl"]
     #[link_name = "rustrt"]
-    extern {
+    extern "cdecl" {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }

--- a/src/test/run-pass/foreign-dupe.rs
+++ b/src/test/run-pass/foreign-dupe.rs
@@ -15,7 +15,7 @@ mod rustrt1 {
     use std::libc;
 
     #[link_name = "rustrt"]
-    extern "cdecl" {
+    extern {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }
@@ -24,7 +24,7 @@ mod rustrt2 {
     use std::libc;
 
     #[link_name = "rustrt"]
-    extern "cdecl" {
+    extern {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }

--- a/src/test/run-pass/foreign-fn-linkname.rs
+++ b/src/test/run-pass/foreign-fn-linkname.rs
@@ -14,8 +14,7 @@ mod libc {
     use std::libc::{c_char, size_t};
 
     #[nolink]
-    #[abi = "cdecl"]
-    extern {
+    extern "cdecl" {
         #[link_name = "strlen"]
         pub fn my_strlen(str: *c_char) -> size_t;
     }

--- a/src/test/run-pass/foreign-fn-linkname.rs
+++ b/src/test/run-pass/foreign-fn-linkname.rs
@@ -14,7 +14,7 @@ mod libc {
     use std::libc::{c_char, size_t};
 
     #[nolink]
-    extern "cdecl" {
+    extern {
         #[link_name = "strlen"]
         pub fn my_strlen(str: *c_char) -> size_t;
     }

--- a/src/test/run-pass/foreign2.rs
+++ b/src/test/run-pass/foreign2.rs
@@ -9,31 +9,27 @@
 // except according to those terms.
 
 mod bar {
-    #[abi = "cdecl"]
     #[nolink]
-    extern {}
+    extern "cdecl" {}
 }
 
 mod zed {
-    #[abi = "cdecl"]
     #[nolink]
-    extern {}
+    extern "cdecl" {}
 }
 
 mod libc {
     use std::libc::{c_int, c_void, size_t, ssize_t};
 
-    #[abi = "cdecl"]
     #[nolink]
-    extern {
+    extern "cdecl" {
         pub fn write(fd: c_int, buf: *c_void, count: size_t) -> ssize_t;
     }
 }
 
 mod baz {
-    #[abi = "cdecl"]
     #[nolink]
-    extern {}
+    extern "cdecl" {}
 }
 
 pub fn main() { }

--- a/src/test/run-pass/foreign2.rs
+++ b/src/test/run-pass/foreign2.rs
@@ -10,26 +10,26 @@
 
 mod bar {
     #[nolink]
-    extern "cdecl" {}
+    extern {}
 }
 
 mod zed {
     #[nolink]
-    extern "cdecl" {}
+    extern {}
 }
 
 mod libc {
     use std::libc::{c_int, c_void, size_t, ssize_t};
 
     #[nolink]
-    extern "cdecl" {
+    extern {
         pub fn write(fd: c_int, buf: *c_void, count: size_t) -> ssize_t;
     }
 }
 
 mod baz {
     #[nolink]
-    extern "cdecl" {}
+    extern {}
 }
 
 pub fn main() { }

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -11,7 +11,6 @@
 // xfail-fast Does not work with main in a submodule
 
 mod rusti {
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn pref_align_of<T>() -> uint;
         pub fn min_align_of<T>() -> uint;

--- a/src/test/run-pass/intrinsic-atomics.rs
+++ b/src/test/run-pass/intrinsic-atomics.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 mod rusti {
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn atomic_cxchg(dst: &mut int, old: int, src: int) -> int;
         pub fn atomic_cxchg_acq(dst: &mut int, old: int, src: int) -> int;

--- a/src/test/run-pass/intrinsic-frame-address.rs
+++ b/src/test/run-pass/intrinsic-frame-address.rs
@@ -11,7 +11,6 @@
 // xfail-fast
 
 mod rusti {
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn frame_address(f: &once fn(*u8));
     }

--- a/src/test/run-pass/intrinsic-move-val.rs
+++ b/src/test/run-pass/intrinsic-move-val.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 mod rusti {
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn move_val_init<T>(dst: &mut T, src: T);
         pub fn move_val<T>(dst: &mut T, src: T);

--- a/src/test/run-pass/intrinsic-uninit.rs
+++ b/src/test/run-pass/intrinsic-uninit.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 mod rusti {
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn uninit<T>() -> T;
     }

--- a/src/test/run-pass/intrinsics-integer.rs
+++ b/src/test/run-pass/intrinsics-integer.rs
@@ -15,7 +15,6 @@
 extern mod extra;
 
 mod rusti {
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn ctpop8(x: i8) -> i8;
         pub fn ctpop16(x: i16) -> i16;

--- a/src/test/run-pass/intrinsics-math.rs
+++ b/src/test/run-pass/intrinsics-math.rs
@@ -13,7 +13,6 @@
 #[feature(globs)];
 
 mod rusti {
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn sqrtf32(x: f32) -> f32;
         pub fn sqrtf64(x: f64) -> f64;

--- a/src/test/run-pass/issue-2214.rs
+++ b/src/test/run-pass/issue-2214.rs
@@ -30,7 +30,7 @@ mod m {
     use std::libc::{c_double, c_int};
 
     #[link_name = "m"]
-    extern "cdecl" {
+    extern {
         #[cfg(unix)]
         #[link_name="lgamma_r"]
         pub fn lgamma(n: c_double, sign: &mut c_int) -> c_double;

--- a/src/test/run-pass/issue-2214.rs
+++ b/src/test/run-pass/issue-2214.rs
@@ -30,8 +30,7 @@ mod m {
     use std::libc::{c_double, c_int};
 
     #[link_name = "m"]
-    #[abi = "cdecl"]
-    extern {
+    extern "cdecl" {
         #[cfg(unix)]
         #[link_name="lgamma_r"]
         pub fn lgamma(n: c_double, sign: &mut c_int) -> c_double;

--- a/src/test/run-pass/item-attributes.rs
+++ b/src/test/run-pass/item-attributes.rs
@@ -39,7 +39,7 @@ mod test_single_attr_outer {
 
     pub mod rustrt {
         #[attr = "val"]
-        extern "cdecl" {}
+        extern {}
     }
 }
 
@@ -59,7 +59,7 @@ mod test_multi_attr_outer {
     pub mod rustrt {
         #[attr1 = "val"]
         #[attr2 = "val"]
-        extern "cdecl" {}
+        extern {}
     }
 
     #[attr1 = "val"]
@@ -81,7 +81,7 @@ mod test_stmt_single_attr_outer {
 
         mod rustrt {
             #[attr = "val"]
-            extern "cdecl" {
+            extern {
             }
         }
     }
@@ -107,7 +107,7 @@ mod test_stmt_multi_attr_outer {
         pub mod rustrt {
             #[attr1 = "val"]
             #[attr2 = "val"]
-            extern "cdecl" {
+            extern {
             }
         }
         */
@@ -165,7 +165,7 @@ mod test_foreign_items {
     pub mod rustrt {
         use std::libc;
 
-        extern "cdecl" {
+        extern {
             #[attr];
 
             #[attr]

--- a/src/test/run-pass/item-attributes.rs
+++ b/src/test/run-pass/item-attributes.rs
@@ -39,8 +39,7 @@ mod test_single_attr_outer {
 
     pub mod rustrt {
         #[attr = "val"]
-        #[abi = "cdecl"]
-        extern {}
+        extern "cdecl" {}
     }
 }
 
@@ -60,8 +59,7 @@ mod test_multi_attr_outer {
     pub mod rustrt {
         #[attr1 = "val"]
         #[attr2 = "val"]
-        #[abi = "cdecl"]
-        extern {}
+        extern "cdecl" {}
     }
 
     #[attr1 = "val"]
@@ -83,8 +81,7 @@ mod test_stmt_single_attr_outer {
 
         mod rustrt {
             #[attr = "val"]
-            #[abi = "cdecl"]
-            extern {
+            extern "cdecl" {
             }
         }
     }
@@ -110,8 +107,7 @@ mod test_stmt_multi_attr_outer {
         pub mod rustrt {
             #[attr1 = "val"]
             #[attr2 = "val"]
-            #[abi = "cdecl"]
-            extern {
+            extern "cdecl" {
             }
         }
         */
@@ -169,8 +165,7 @@ mod test_foreign_items {
     pub mod rustrt {
         use std::libc;
 
-        #[abi = "cdecl"]
-        extern {
+        extern "cdecl" {
             #[attr];
 
             #[attr]

--- a/src/test/run-pass/morestack-address.rs
+++ b/src/test/run-pass/morestack-address.rs
@@ -10,7 +10,6 @@
 
 mod rusti {
     #[nolink]
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn morestack_addr() -> *();
     }

--- a/src/test/run-pass/rec-align-u32.rs
+++ b/src/test/run-pass/rec-align-u32.rs
@@ -15,7 +15,6 @@
 use std::sys;
 
 mod rusti {
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn pref_align_of<T>() -> uint;
         pub fn min_align_of<T>() -> uint;

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -15,7 +15,6 @@
 use std::sys;
 
 mod rusti {
-    #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {
         pub fn pref_align_of<T>() -> uint;
         pub fn min_align_of<T>() -> uint;

--- a/src/test/run-pass/x86stdcall2.rs
+++ b/src/test/run-pass/x86stdcall2.rs
@@ -18,7 +18,6 @@ pub type BOOL = u8;
 mod kernel32 {
     use super::{HANDLE, DWORD, SIZE_T, LPVOID, BOOL};
 
-    #[abi = "stdcall"]
     extern "stdcall" {
         pub fn GetProcessHeap() -> HANDLE;
         pub fn HeapAlloc(hHeap: HANDLE, dwFlags: DWORD, dwBytes: SIZE_T)


### PR DESCRIPTION
They've been replaced by putting the name on the extern block.

  #[abi = "foo"]

goes to

  extern "foo" { }

Closes #9483.
