### PR TITLE
Add get_opt to std::vec

### DIFF
--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -840,6 +840,7 @@ pub trait ImmutableVector<'self, T> {
     fn window_iter(self, size: uint) -> WindowIter<'self, T>;
     fn chunk_iter(self, size: uint) -> ChunkIter<'self, T>;
 
+    fn get_opt(&self, index: uint) -> Option<&'self T>;
     fn head(&self) -> &'self T;
     fn head_opt(&self) -> Option<&'self T>;
     fn tail(&self) -> &'self [T];
@@ -1017,6 +1018,13 @@ impl<'self,T> ImmutableVector<'self, T> for &'self [T] {
     fn chunk_iter(self, size: uint) -> ChunkIter<'self, T> {
         assert!(size != 0);
         ChunkIter { v: self, size: size }
+    }
+
+    /// Returns the element of a vector at the given index, or `None` if the
+    /// index is out of bounds
+    #[inline]
+    fn get_opt(&self, index: uint) -> Option<&'self T> {
+        if index < self.len() { Some(&self[index]) } else { None }
     }
 
     /// Returns the first element of a vector, failing if the vector is empty.
@@ -2572,6 +2580,16 @@ mod tests {
         assert_eq!(v0.len(), 0);
         assert_eq!(v1.len(), 1);
         assert_eq!(v2.len(), 2);
+    }
+
+    #[test]
+    fn test_get_opt() {
+        let mut a = ~[11];
+        assert_eq!(a.get_opt(1), None);
+        a = ~[11, 12];
+        assert_eq!(a.get_opt(1).unwrap(), &12);
+        a = ~[11, 12, 13];
+        assert_eq!(a.get_opt(1).unwrap(), &12);
     }
 
     #[test]


### PR DESCRIPTION
This adds `get_opt` to `std::vec`, which looks up an item by index and returns an `Option`. If the given index is out of range, `None` will be returned, otherwise a `Some`-wrapped item will be returned.

Example use case:

``` rust
use std::os;

fn say_hello(name: &str) {
  println(fmt!("Hello, %s", name));
}

fn main(){
  // Try to get the first cmd line arg, but default to "World"
  let args = os::args();
  let default = ~"World";
  say_hello(*args.get_opt(1).unwrap_or(&default));
}
```

If there's an existing way of implementing this pattern that's cleaner, I'll happily close this. I'm also open to naming suggestions (`index_opt`?)
