### PR TITLE
Put a newline after each logging message

### DIFF
--- a/src/libstd/rt/logging.rs
+++ b/src/libstd/rt/logging.rs
@@ -181,7 +181,7 @@ pub struct StdErrLogger;
 impl Logger for StdErrLogger {
     fn log(&mut self, args: &fmt::Arguments) {
         if should_log_console() {
-            fmt::write(self as &mut rt::io::Writer, args);
+            fmt::writeln(self as &mut rt::io::Writer, args);
         }
     }
 }


### PR DESCRIPTION
Forgot to do this when I was refactoring logging :(
