### PR TITLE
Reopening of #9598: Remove usage of @ast::Crate in favor of ownership

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -130,8 +130,8 @@ pub enum input {
 }
 
 pub fn phase_1_parse_input(sess: Session, cfg: ast::CrateConfig, input: &input)
-    -> @ast::Crate {
-    time(sess.time_passes(), ~"parsing", || {
+    -> ast::Crate {
+    time(sess.time_passes(), ~"parsing", (), |_| {
         match *input {
             file_input(ref file) => {
                 parse::parse_crate_from_file(&(*file), cfg.clone(), sess.parse_sess)
@@ -153,11 +153,11 @@ pub fn phase_1_parse_input(sess: Session, cfg: ast::CrateConfig, input: &input)
 /// standard library and prelude.
 pub fn phase_2_configure_and_expand(sess: Session,
                                     cfg: ast::CrateConfig,
-                                    mut crate: @ast::Crate) -> @ast::Crate {
+                                    mut crate: ast::Crate) -> ast::Crate {
     let time_passes = sess.time_passes();
 
     *sess.building_library = session::building_library(sess.opts.crate_type,
-                                                       crate, sess.opts.test);
+                                                       &crate, sess.opts.test);
 
 
     // strip before expansion to allow macros to depend on
@@ -167,29 +167,29 @@ pub fn phase_2_configure_and_expand(sess: Session,
     //   mod bar { macro_rules! baz!(() => {{}}) }
     //
     // baz! should not use this definition unless foo is enabled.
-    crate = time(time_passes, ~"std macros injection", ||
+    crate = time(time_passes, ~"std macros injection", crate, |crate|
                  syntax::ext::expand::inject_std_macros(sess.parse_sess,
                                                         cfg.clone(),
                                                         crate));
 
-    crate = time(time_passes, ~"configuration 1", ||
+    crate = time(time_passes, ~"configuration 1", crate, |crate|
                  front::config::strip_unconfigured_items(crate));
 
-    crate = time(time_passes, ~"expansion", ||
+    crate = time(time_passes, ~"expansion", crate, |crate|
                  syntax::ext::expand::expand_crate(sess.parse_sess, cfg.clone(),
                                                    crate));
 
     // strip again, in case expansion added anything with a #[cfg].
-    crate = time(time_passes, ~"configuration 2", ||
+    crate = time(time_passes, ~"configuration 2", crate, |crate|
                  front::config::strip_unconfigured_items(crate));
 
-    crate = time(time_passes, ~"maybe building test harness", ||
+    crate = time(time_passes, ~"maybe building test harness", crate, |crate|
                  front::test::modify_for_testing(sess, crate));
 
-    crate = time(time_passes, ~"std injection", ||
+    crate = time(time_passes, ~"std injection", crate, |crate|
                  front::std_inject::maybe_inject_libstd_ref(sess, crate));
 
-    crate = time(time_passes, ~"assigning node ids", ||
+    crate = time(time_passes, ~"assigning node ids", crate, |crate|
                  front::assign_node_ids::assign_node_ids(sess, crate));
 
     return crate;
@@ -207,21 +207,21 @@ pub struct CrateAnalysis {
 /// miscellaneous analysis passes on the crate. Return various
 /// structures carrying the results of the analysis.
 pub fn phase_3_run_analysis_passes(sess: Session,
-                                   crate: @ast::Crate) -> CrateAnalysis {
+                                   crate: &ast::Crate) -> CrateAnalysis {
 
     let time_passes = sess.time_passes();
 
-    let ast_map = time(time_passes, ~"ast indexing", ||
+    let ast_map = time(time_passes, ~"ast indexing", (), |_|
                        syntax::ast_map::map_crate(sess.diagnostic(), crate));
 
-    time(time_passes, ~"external crate/lib resolution", ||
+    time(time_passes, ~"external crate/lib resolution", (), |_|
          creader::read_crates(sess.diagnostic(), crate, sess.cstore,
                               sess.filesearch,
                               session::sess_os_to_meta_os(sess.targ_cfg.os),
                               sess.opts.is_static,
                               token::get_ident_interner()));
 
-    let lang_items = time(time_passes, ~"language item collection", ||
+    let lang_items = time(time_passes, ~"language item collection", (), |_|
                           middle::lang_items::collect_language_items(crate, sess));
 
     let middle::resolve::CrateMap {
@@ -229,19 +229,19 @@ pub fn phase_3_run_analysis_passes(sess: Session,
         exp_map2: exp_map2,
         trait_map: trait_map
     } =
-        time(time_passes, ~"resolution", ||
+        time(time_passes, ~"resolution", (), |_|
              middle::resolve::resolve_crate(sess, lang_items, crate));
 
-    time(time_passes, ~"looking for entry point",
-         || middle::entry::find_entry_point(sess, crate, ast_map));
+    time(time_passes, ~"looking for entry point", (),
+         |_| middle::entry::find_entry_point(sess, crate, ast_map));
 
-    let freevars = time(time_passes, ~"freevar finding", ||
+    let freevars = time(time_passes, ~"freevar finding", (), |_|
                         freevars::annotate_freevars(def_map, crate));
 
-    let region_map = time(time_passes, ~"region resolution", ||
+    let region_map = time(time_passes, ~"region resolution", (), |_|
                           middle::region::resolve_crate(sess, def_map, crate));
 
-    let rp_set = time(time_passes, ~"region parameterization inference", ||
+    let rp_set = time(time_passes, ~"region parameterization inference", (), |_|
                       middle::region::determine_rp_in_crate(sess, ast_map, def_map, crate));
 
     let ty_cx = ty::mk_ctxt(sess, def_map, ast_map, freevars,
@@ -252,53 +252,53 @@ pub fn phase_3_run_analysis_passes(sess: Session,
         ty_cx, trait_map, crate);
 
     // These next two const passes can probably be merged
-    time(time_passes, ~"const marking", ||
+    time(time_passes, ~"const marking", (), |_|
          middle::const_eval::process_crate(crate, ty_cx));
 
-    time(time_passes, ~"const checking", ||
+    time(time_passes, ~"const checking", (), |_|
          middle::check_const::check_crate(sess, crate, ast_map, def_map,
                                           method_map, ty_cx));
 
     let exported_items =
-        time(time_passes, ~"privacy checking", ||
+        time(time_passes, ~"privacy checking", (), |_|
              middle::privacy::check_crate(ty_cx, &method_map, &exp_map2, crate));
 
-    time(time_passes, ~"effect checking", ||
+    time(time_passes, ~"effect checking", (), |_|
          middle::effect::check_crate(ty_cx, method_map, crate));
 
-    time(time_passes, ~"loop checking", ||
+    time(time_passes, ~"loop checking", (), |_|
          middle::check_loop::check_crate(ty_cx, crate));
 
-    time(time_passes, ~"stack checking", ||
+    time(time_passes, ~"stack checking", (), |_|
          middle::stack_check::stack_check_crate(ty_cx, crate));
 
     let middle::moves::MoveMaps {moves_map, moved_variables_set,
                                  capture_map} =
-        time(time_passes, ~"compute moves", ||
+        time(time_passes, ~"compute moves", (), |_|
              middle::moves::compute_moves(ty_cx, method_map, crate));
 
-    time(time_passes, ~"match checking", ||
+    time(time_passes, ~"match checking", (), |_|
          middle::check_match::check_crate(ty_cx, method_map,
                                           moves_map, crate));
 
-    time(time_passes, ~"liveness checking", ||
+    time(time_passes, ~"liveness checking", (), |_|
          middle::liveness::check_crate(ty_cx, method_map,
                                        capture_map, crate));
 
     let (root_map, write_guard_map) =
-        time(time_passes, ~"borrow checking", ||
+        time(time_passes, ~"borrow checking", (), |_|
              middle::borrowck::check_crate(ty_cx, method_map,
                                            moves_map, moved_variables_set,
                                            capture_map, crate));
 
-    time(time_passes, ~"kind checking", ||
+    time(time_passes, ~"kind checking", (), |_|
          kind::check_crate(ty_cx, method_map, crate));
 
     let reachable_map =
-        time(time_passes, ~"reachability checking", ||
+        time(time_passes, ~"reachability checking", (), |_|
              reachable::find_reachable(ty_cx, method_map, crate));
 
-    time(time_passes, ~"lint checking", ||
+    time(time_passes, ~"lint checking", (), |_|
          lint::check_crate(ty_cx, crate));
 
     CrateAnalysis {
@@ -325,10 +325,10 @@ pub struct CrateTranslation {
 /// Run the translation phase to LLVM, after which the AST and analysis can
 /// be discarded.
 pub fn phase_4_translate_to_llvm(sess: Session,
-                                 crate: @ast::Crate,
+                                 crate: ast::Crate,
                                  analysis: &CrateAnalysis,
                                  outputs: &OutputFilenames) -> CrateTranslation {
-    time(sess.time_passes(), ~"translation", ||
+    time(sess.time_passes(), ~"translation", crate, |crate|
          trans::base::trans_crate(sess, crate, analysis,
                                   &outputs.obj_filename))
 }
@@ -349,7 +349,7 @@ pub fn phase_5_run_llvm_passes(sess: Session,
         let output_type = link::output_type_assembly;
         let asm_filename = outputs.obj_filename.with_filetype("s");
 
-        time(sess.time_passes(), ~"LLVM passes", ||
+        time(sess.time_passes(), ~"LLVM passes", (), |_|
             link::write::run_passes(sess,
                                     trans.context,
                                     trans.module,
@@ -363,7 +363,7 @@ pub fn phase_5_run_llvm_passes(sess: Session,
             os::remove_file(&asm_filename);
         }
     } else {
-        time(sess.time_passes(), ~"LLVM passes", ||
+        time(sess.time_passes(), ~"LLVM passes", (), |_|
             link::write::run_passes(sess,
                                     trans.context,
                                     trans.module,
@@ -377,7 +377,7 @@ pub fn phase_5_run_llvm_passes(sess: Session,
 pub fn phase_6_link_output(sess: Session,
                            trans: &CrateTranslation,
                            outputs: &OutputFilenames) {
-    time(sess.time_passes(), ~"linking", ||
+    time(sess.time_passes(), ~"linking", (), |_|
          link::link_binary(sess,
                            &outputs.obj_filename,
                            &outputs.out_filename,
@@ -430,7 +430,7 @@ pub fn compile_input(sess: Session, cfg: ast::CrateConfig, input: &input,
             if stop_after_phase_1(sess) { return; }
             phase_2_configure_and_expand(sess, cfg, crate)
         };
-        let analysis = phase_3_run_analysis_passes(sess, expanded_crate);
+        let analysis = phase_3_run_analysis_passes(sess, &expanded_crate);
         if stop_after_phase_3(sess) { return; }
         let outputs = build_output_filenames(input, outdir, output, [], sess);
         let trans = phase_4_translate_to_llvm(sess, expanded_crate,
@@ -535,7 +535,7 @@ pub fn pretty_print_input(sess: Session,
             } as @pprust::pp_ann
         }
         PpmTyped => {
-            let analysis = phase_3_run_analysis_passes(sess, crate);
+            let analysis = phase_3_run_analysis_passes(sess, &crate);
             @TypedAnnotation {
                 analysis: analysis
             } as @pprust::pp_ann
@@ -548,7 +548,7 @@ pub fn pretty_print_input(sess: Session,
         pprust::print_crate(sess.codemap,
                             token::get_ident_interner(),
                             sess.span_diagnostic,
-                            crate,
+                            &crate,
                             source_name(input),
                             rdr,
                             io::stdout(),

--- a/src/librustc/front/assign_node_ids.rs
+++ b/src/librustc/front/assign_node_ids.rs
@@ -24,9 +24,9 @@ impl ast_fold for NodeIdAssigner {
     }
 }
 
-pub fn assign_node_ids(sess: Session, crate: @ast::Crate) -> @ast::Crate {
+pub fn assign_node_ids(sess: Session, crate: ast::Crate) -> ast::Crate {
     let fold = NodeIdAssigner {
         sess: sess,
     };
-    @fold.fold_crate(crate)
+    fold.fold_crate(crate)
 }

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -18,9 +18,10 @@ struct Context<'self> {
 
 // Support conditional compilation by transforming the AST, stripping out
 // any items that do not belong in the current configuration
-pub fn strip_unconfigured_items(crate: @ast::Crate) -> @ast::Crate {
+pub fn strip_unconfigured_items(crate: ast::Crate) -> ast::Crate {
+    let config = crate.config.clone();
     do strip_items(crate) |attrs| {
-        in_cfg(crate.config, attrs)
+        in_cfg(config, attrs)
     }
 }
 
@@ -40,13 +41,13 @@ impl<'self> fold::ast_fold for Context<'self> {
     }
 }
 
-pub fn strip_items(crate: &ast::Crate,
+pub fn strip_items(crate: ast::Crate,
                    in_cfg: &fn(attrs: &[ast::Attribute]) -> bool)
-                   -> @ast::Crate {
+                   -> ast::Crate {
     let ctxt = Context {
         in_cfg: in_cfg,
     };
-    @ctxt.fold_crate(crate)
+    ctxt.fold_crate(crate)
 }
 
 fn filter_item(cx: &Context, item: @ast::item) -> Option<@ast::item> {

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -22,9 +22,9 @@ use syntax::opt_vec;
 
 static STD_VERSION: &'static str = "0.9-pre";
 
-pub fn maybe_inject_libstd_ref(sess: Session, crate: @ast::Crate)
-                               -> @ast::Crate {
-    if use_std(crate) {
+pub fn maybe_inject_libstd_ref(sess: Session, crate: ast::Crate)
+                               -> ast::Crate {
+    if use_std(&crate) {
         inject_libstd_ref(sess, crate)
     } else {
         crate
@@ -51,7 +51,7 @@ struct StandardLibraryInjector {
 }
 
 impl fold::ast_fold for StandardLibraryInjector {
-    fn fold_crate(&self, crate: &ast::Crate) -> ast::Crate {
+    fn fold_crate(&self, crate: ast::Crate) -> ast::Crate {
         let version = STD_VERSION.to_managed();
         let vi1 = ast::view_item {
             node: ast::view_item_extern_mod(self.sess.ident_of("std"),
@@ -77,10 +77,9 @@ impl fold::ast_fold for StandardLibraryInjector {
             new_module = self.fold_mod(&new_module);
         }
 
-        // FIXME #2543: Bad copy.
         ast::Crate {
             module: new_module,
-            ..(*crate).clone()
+            ..crate
         }
     }
 
@@ -133,9 +132,9 @@ impl fold::ast_fold for StandardLibraryInjector {
     }
 }
 
-fn inject_libstd_ref(sess: Session, crate: &ast::Crate) -> @ast::Crate {
+fn inject_libstd_ref(sess: Session, crate: ast::Crate) -> ast::Crate {
     let fold = StandardLibraryInjector {
         sess: sess,
     };
-    @fold.fold_crate(crate)
+    fold.fold_crate(crate)
 }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -135,7 +135,7 @@ pub type LintDict = HashMap<&'static str, LintSpec>;
 enum AttributedNode<'self> {
     Item(@ast::item),
     Method(&'self ast::method),
-    Crate(@ast::Crate),
+    Crate(&'self ast::Crate),
 }
 
 #[deriving(Eq)]
@@ -1565,7 +1565,7 @@ impl Visitor<@mut Context> for LintCheckVisitor {
     }
 }
 
-pub fn check_crate(tcx: ty::ctxt, crate: @ast::Crate) {
+pub fn check_crate(tcx: ty::ctxt, crate: &ast::Crate) {
     let cx = @mut Context {
         dict: @get_lint_dict(),
         curr: SmallIntMap::new(),

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -268,7 +268,7 @@ impl ReachableContext {
 
     // Step 1: Mark all public symbols, and add all public symbols that might
     // be inlined to a worklist.
-    fn mark_public_symbols(&self, crate: @Crate) {
+    fn mark_public_symbols(&self, crate: &Crate) {
         let reachable_symbols = self.reachable_symbols;
         let worklist = self.worklist;
 
@@ -429,7 +429,7 @@ impl ReachableContext {
 
 pub fn find_reachable(tcx: ty::ctxt,
                       method_map: typeck::method_map,
-                      crate: @Crate)
+                      crate: &Crate)
                       -> @mut HashSet<NodeId> {
     // XXX(pcwalton): We only need to mark symbols that are exported. But this
     // is more complicated than just looking at whether the symbol is `pub`,

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -3075,16 +3075,17 @@ pub fn write_abi_version(ccx: &mut CrateContext) {
 }
 
 pub fn trans_crate(sess: session::Session,
-                   crate: &ast::Crate,
+                   crate: ast::Crate,
                    analysis: &CrateAnalysis,
                    output: &Path) -> CrateTranslation {
     // Before we touch LLVM, make sure that multithreading is enabled.
     if unsafe { !llvm::LLVMRustStartMultithreading() } {
-        //sess.bug("couldn't enable multi-threaded LLVM");
+        sess.bug("couldn't enable multi-threaded LLVM");
     }
 
     let mut symbol_hasher = hash::default_state();
-    let link_meta = link::build_link_meta(sess, crate, output, &mut symbol_hasher);
+    let link_meta = link::build_link_meta(sess, &crate, output,
+                                          &mut symbol_hasher);
 
     // Append ".rc" to crate name as LLVM module identifier.
     //
@@ -3107,7 +3108,7 @@ pub fn trans_crate(sess: session::Session,
                                      analysis.reachable);
 
     if ccx.sess.opts.debuginfo {
-        debuginfo::initialize(ccx, crate);
+        debuginfo::initialize(ccx, &crate);
     }
 
     {
@@ -3144,7 +3145,7 @@ pub fn trans_crate(sess: session::Session,
     }
 
     // Translate the metadata.
-    write_metadata(ccx, crate);
+    write_metadata(ccx, &crate);
     if ccx.sess.trans_stats() {
         io::println("--- trans stats ---");
         println!("n_static_tydescs: {}", ccx.stats.n_static_tydescs);

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -447,17 +447,17 @@ pub fn check_crate(tcx: ty::ctxt,
         tcx: tcx
     };
 
-    time(time_passes, ~"type collecting", ||
+    time(time_passes, ~"type collecting", (), |_|
         collect::collect_item_types(ccx, crate));
 
     // this ensures that later parts of type checking can assume that items
     // have valid types and not error
     tcx.sess.abort_if_errors();
 
-    time(time_passes, ~"coherence checking", ||
+    time(time_passes, ~"coherence checking", (), |_|
         coherence::check_coherence(ccx, crate));
 
-    time(time_passes, ~"type checking", ||
+    time(time_passes, ~"type checking", (), |_|
         check::check_item_types(ccx, crate));
 
     check_for_entry_fn(ccx);

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -17,10 +17,10 @@ use syntax::visit::Visitor;
 use std::hashmap::HashSet;
 use extra;
 
-pub fn time<T>(do_it: bool, what: ~str, thunk: &fn() -> T) -> T {
-    if !do_it { return thunk(); }
+pub fn time<T, U>(do_it: bool, what: ~str, u: U, f: &fn(U) -> T) -> T {
+    if !do_it { return f(u); }
     let start = extra::time::precise_time_s();
-    let rv = thunk();
+    let rv = f(u);
     let end = extra::time::precise_time_s();
     println!("time: {:3.3f} s\t{}", end - start, what);
     rv

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -24,7 +24,7 @@ use clean;
 use clean::Clean;
 
 pub struct DocContext {
-    crate: @ast::Crate,
+    crate: ast::Crate,
     tycx: middle::ty::ctxt,
     sess: driver::session::Session
 }
@@ -60,7 +60,7 @@ fn get_ast_and_resolve(cpath: &Path, libs: ~[Path]) -> DocContext {
 
     let mut crate = phase_1_parse_input(sess, cfg.clone(), &input);
     crate = phase_2_configure_and_expand(sess, cfg, crate);
-    let analysis = phase_3_run_analysis_passes(sess, crate);
+    let analysis = phase_3_run_analysis_passes(sess, &crate);
 
     debug!("crate: %?", crate);
     DocContext { crate: crate, tycx: analysis.ty_cx, sess: sess }
@@ -75,7 +75,7 @@ pub fn run_core (libs: ~[Path], path: &Path) -> clean::Crate {
     local_data::set(super::ctxtkey, ctxt);
 
     let v = @mut RustdocVisitor::new();
-    v.visit(ctxt.crate);
+    v.visit(&ctxt.crate);
 
     v.clean()
 }

--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -161,7 +161,7 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
     let mut to_run = ~[];       // statements to run (emitted back into code)
     let new_locals = @mut ~[];  // new locals being defined
     let mut result = None;      // resultant expression (to print via pp)
-    do find_main(crate, sess) |blk| {
+    do find_main(&crate, sess) |blk| {
         // Fish out all the view items, be sure to record 'extern mod' items
         // differently beause they must appear before all 'use' statements
         for vi in blk.view_items.iter() {
@@ -241,11 +241,11 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
 
     let crate = driver::phase_1_parse_input(sess, cfg.clone(), &dinput);
     let expanded_crate = driver::phase_2_configure_and_expand(sess, cfg, crate);
-    let analysis = driver::phase_3_run_analysis_passes(sess, expanded_crate);
+    let analysis = driver::phase_3_run_analysis_passes(sess, &expanded_crate);
 
     // Once we're typechecked, record the types of all local variables defined
     // in this input
-    do find_main(crate, sess) |blk| {
+    do find_main(&expanded_crate, sess) |blk| {
         program.register_new_vars(blk, analysis.ty_cx);
     }
 
@@ -264,7 +264,7 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
 
     let crate = driver::phase_1_parse_input(sess, cfg.clone(), &input);
     let expanded_crate = driver::phase_2_configure_and_expand(sess, cfg, crate);
-    let analysis = driver::phase_3_run_analysis_passes(sess, expanded_crate);
+    let analysis = driver::phase_3_run_analysis_passes(sess, &expanded_crate);
     let trans = driver::phase_4_translate_to_llvm(sess, expanded_crate, &analysis, outputs);
     driver::phase_5_run_llvm_passes(sess, &trans, outputs);
 
@@ -283,14 +283,14 @@ fn run(mut program: ~Program, binary: ~str, lib_search_paths: ~[~str],
     //
     return (program, jit::consume_engine());
 
-    fn parse_input(sess: session::Session, input: &str) -> @ast::Crate {
+    fn parse_input(sess: session::Session, input: &str) -> ast::Crate {
         let code = fmt!("fn main() {\n %s \n}", input);
         let input = driver::str_input(code.to_managed());
         let cfg = driver::build_configuration(sess);
         driver::phase_1_parse_input(sess, cfg.clone(), &input)
     }
 
-    fn find_main(crate: @ast::Crate, sess: session::Session,
+    fn find_main(crate: &ast::Crate, sess: session::Session,
                  f: &fn(&ast::Block)) {
         for item in crate.module.items.iter() {
             match item.node {
@@ -358,7 +358,7 @@ fn compile_crate(src_filename: ~str, binary: ~str) -> Option<bool> {
             println(fmt!("compiling %s...", src_filename));
             let crate = driver::phase_1_parse_input(sess, cfg.clone(), &input);
             let expanded_crate = driver::phase_2_configure_and_expand(sess, cfg, crate);
-            let analysis = driver::phase_3_run_analysis_passes(sess, expanded_crate);
+            let analysis = driver::phase_3_run_analysis_passes(sess, &expanded_crate);
             let trans = driver::phase_4_translate_to_llvm(sess, expanded_crate, &analysis, outputs);
             driver::phase_5_run_llvm_passes(sess, &trans, outputs);
             true

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -16,7 +16,7 @@ use opt_vec::OptVec;
 
 // We may eventually want to be able to fold over type parameters, too.
 pub trait ast_fold {
-    fn fold_crate(&self, c: &Crate) -> Crate {
+    fn fold_crate(&self, c: Crate) -> Crate {
         noop_fold_crate(c, self)
     }
 
@@ -691,7 +691,7 @@ pub fn noop_fold_mod<T:ast_fold>(m: &_mod, folder: &T) -> _mod {
     }
 }
 
-pub fn noop_fold_crate<T:ast_fold>(c: &Crate, folder: &T) -> Crate {
+pub fn noop_fold_crate<T:ast_fold>(c: Crate, folder: &T) -> Crate {
     let fold_meta_item = |x| fold_meta_item_(x, folder);
     let fold_attribute = |x| fold_attribute_(x, folder);
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -73,7 +73,7 @@ pub fn parse_crate_from_file(
     input: &Path,
     cfg: ast::CrateConfig,
     sess: @mut ParseSess
-) -> @ast::Crate {
+) -> ast::Crate {
     new_parser_from_file(sess, /*bad*/ cfg.clone(), input).parse_crate_mod()
     // why is there no p.abort_if_errors here?
 }
@@ -83,7 +83,7 @@ pub fn parse_crate_from_source_str(
     source: @str,
     cfg: ast::CrateConfig,
     sess: @mut ParseSess
-) -> @ast::Crate {
+) -> ast::Crate {
     let p = new_parser_from_source_str(sess,
                                        /*bad*/ cfg.clone(),
                                        name,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5140,7 +5140,7 @@ impl Parser {
 
     // Parses a source module as a crate. This is the main
     // entry point for the parser.
-    pub fn parse_crate_mod(&self) -> @Crate {
+    pub fn parse_crate_mod(&self) -> Crate {
         let lo = self.span.lo;
         // parse the crate's inner attrs, maybe (oops) one
         // of the attrs of an item:
@@ -5149,7 +5149,7 @@ impl Parser {
         // parse the items inside the crate:
         let m = self.parse_mod_items(token::EOF, first_item_outer_attrs);
 
-        @ast::Crate {
+        ast::Crate {
             module: m,
             attrs: inner,
             config: self.cfg.clone(),

--- a/src/libsyntax/util/parser_testing.rs
+++ b/src/libsyntax/util/parser_testing.rs
@@ -47,14 +47,14 @@ fn with_error_checking_parse<T>(s: @str, f: &fn(&mut Parser) -> T) -> T {
 }
 
 // parse a string, return a crate.
-pub fn string_to_crate (source_str : @str) -> @ast::Crate {
+pub fn string_to_crate (source_str : @str) -> ast::Crate {
     do with_error_checking_parse(source_str) |p| {
         p.parse_crate_mod()
     }
 }
 
 // parse a string, return a crate and the ParseSess
-pub fn string_to_crate_and_sess (source_str : @str) -> (@ast::Crate,@mut ParseSess) {
+pub fn string_to_crate_and_sess (source_str : @str) -> (ast::Crate,@mut ParseSess) {
     let (p,ps) = string_to_parser_and_sess(source_str);
     (p.parse_crate_mod(),ps)
 }


### PR DESCRIPTION
This patch exposes actual ownership of an `ast::Crate` structure so it's not implicitly copied and reference counted via `@`.

The main purpose for this patch was to get rid of the massive spike in memory during the start of the compiler (this can be seen on isrustfastyet). The reason that this spike exists is that during `phase_2` we're creating many copies of the crate by folding. Because these are reference counted, all instances of the old crates aren't dropped until the end of the function, which is why so much memory is accumulated.

This patch exposes true ownership of the crate, meaning that it will be destroyed ASAP when requested. There are no code changes except for dealing with actual ownership of the crate. The large spike is then avoided: http://i.imgur.com/IO3NENy.png

This shouldn't help our overall memory usage (that still is the highest at the end), but if we ever manage to bring that down it should help us not have a 1GB spike at the beginning of compilation.

(This was to un-stuck bors (hopefully).)
