### PR TITLE
std::rt::uv::net: Enable tests on Win32

### DIFF
--- a/src/libstd/rt/uv/net.rs
+++ b/src/libstd/rt/uv/net.rs
@@ -624,7 +624,6 @@ mod test {
     }
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME #8815
     fn listen_ip4() {
         do run_in_bare_thread() {
             static MAX: int = 10;
@@ -699,7 +698,6 @@ mod test {
     }
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME #8815
     fn listen_ip6() {
         do run_in_bare_thread() {
             static MAX: int = 10;
@@ -776,7 +774,6 @@ mod test {
     }
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME #8815
     fn udp_recv_ip4() {
         do run_in_bare_thread() {
             static MAX: int = 10;
@@ -837,7 +834,6 @@ mod test {
     }
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME #8815
     fn udp_recv_ip6() {
         do run_in_bare_thread() {
             static MAX: int = 10;


### PR DESCRIPTION
Closes #8815.
