### PR TITLE
add --soft-float option

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -343,7 +343,7 @@ CFG_PATH_MUNGE_mips-unknown-linux-gnu := true
 CFG_LDPATH_mips-unknown-linux-gnu :=
 CFG_RUN_mips-unknown-linux-gnu=
 CFG_RUN_TARG_mips-unknown-linux-gnu=
-RUSTC_FLAGS_mips-unknown-linux-gnu := --linker=$(CXX_mips-unknown-linux-gnu) --target-cpu mips32r2 --target-feature +mips32r2,+o32
+RUSTC_FLAGS_mips-unknown-linux-gnu := --linker=$(CXX_mips-unknown-linux-gnu) --target-cpu mips32r2 --target-feature +mips32r2,+o32 -Z soft-float
 
 # i686-pc-mingw32 configuration
 CC_i686-pc-mingw32=$(CC)

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -264,6 +264,7 @@ pub mod write {
               session::Default => lib::llvm::CodeGenLevelDefault,
               session::Aggressive => lib::llvm::CodeGenLevelAggressive,
             };
+            let use_softfp = sess.opts.debugging_opts & session::use_softfp != 0;
 
             let tm = do sess.targ_cfg.target_strs.target_triple.with_c_str |T| {
                 do sess.opts.target_cpu.with_c_str |CPU| {
@@ -273,7 +274,8 @@ pub mod write {
                             lib::llvm::CodeModelDefault,
                             lib::llvm::RelocPIC,
                             OptLevel,
-                            true
+                            true,
+                            use_softfp
                         )
                     }
                 }

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -80,6 +80,7 @@ pub static print_llvm_passes:       uint = 1 << 26;
 pub static no_vectorize_loops:      uint = 1 << 27;
 pub static no_vectorize_slp:        uint = 1 << 28;
 pub static no_prepopulate_passes:   uint = 1 << 29;
+pub static use_softfp:              uint = 1 << 30;
 
 pub fn debugging_opts_map() -> ~[(~str, ~str, uint)] {
     ~[(~"verbose", ~"in general, enable more debug printouts", verbose),
@@ -135,6 +136,7 @@ pub fn debugging_opts_map() -> ~[(~str, ~str, uint)] {
      (~"no-vectorize-slp",
       ~"Don't run LLVM's SLP vectorization passes",
       no_vectorize_slp),
+     (~"soft-float", ~"Generate software floating point library calls", use_softfp),
     ]
 }
 

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -2149,7 +2149,8 @@ pub mod llvm {
                                            Model: CodeGenModel,
                                            Reloc: RelocMode,
                                            Level: CodeGenOptLevel,
-                                           EnableSegstk: bool) -> TargetMachineRef;
+                                           EnableSegstk: bool,
+                                           UseSoftFP: bool) -> TargetMachineRef;
         pub fn LLVMRustDisposeTargetMachine(T: TargetMachineRef);
         pub fn LLVMRustAddAnalysisPasses(T: TargetMachineRef,
                                          PM: PassManagerRef,

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -67,7 +67,8 @@ LLVMRustCreateTargetMachine(const char *triple,
                             CodeModel::Model CM,
                             Reloc::Model RM,
                             CodeGenOpt::Level OptLevel,
-                            bool EnableSegmentedStacks) {
+                            bool EnableSegmentedStacks,
+                            bool UseSoftFloat) {
     std::string Error;
     Triple Trip(Triple::normalize(triple));
     const llvm::Target *TheTarget = TargetRegistry::lookupTarget(Trip.getTriple(),
@@ -84,6 +85,10 @@ LLVMRustCreateTargetMachine(const char *triple,
     Options.FloatABIType =
          (Trip.getEnvironment() == Triple::GNUEABIHF) ? FloatABI::Hard :
                                                         FloatABI::Default;
+    Options.UseSoftFloat = UseSoftFloat;
+    if (UseSoftFloat) {
+        Options.FloatABIType = FloatABI::Soft;
+    }
 
     TargetMachine *TM = TheTarget->createTargetMachine(Trip.getTriple(),
                                                        cpu,


### PR DESCRIPTION
This change adds --soft-float option for generating
software floating point library calls.
It also implies using soft float ABI, that is the same as llc.

It is useful for targets that have no FPU.
