### PR TITLE
Remove a few uses of @-pointers for @ast::Expr and @mut Block in trans

### DIFF
--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -121,7 +121,7 @@ pub fn check_arms(cx: &MatchCheckCtxt, arms: &[Arm]) {
         for pat in arm.pats.iter() {
 
             // Check that we do not match against a static NaN (#6804)
-            let pat_matches_nan: &fn(@Pat) -> bool = |p| {
+            let pat_matches_nan: &fn(&Pat) -> bool = |p| {
                 match cx.tcx.def_map.find(&p.id) {
                     Some(&DefStatic(did, false)) => {
                         let const_expr = lookup_const_by_id(cx.tcx, did).unwrap();
@@ -893,7 +893,7 @@ pub fn check_legality_of_move_bindings(cx: &MatchCheckCtxt,
         }
     }
 
-    let check_move: &fn(@Pat, Option<@Pat>) = |p, sub| {
+    let check_move: &fn(&Pat, Option<@Pat>) = |p, sub| {
         // check legality of moving out of the enum
 
         // x @ Foo(*) is legal, but x @ Foo(y) isn't.

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -422,7 +422,7 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
     }
 
     fn walk_expr(&mut self,
-                 expr: @ast::Expr,
+                 expr: &ast::Expr,
                  in_out: &mut [uint],
                  loop_scopes: &mut ~[LoopScope]) {
         debug!("DataFlowContext::walk_expr(expr=%s, in_out=%s)",
@@ -744,7 +744,7 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
     }
 
     fn pop_scopes(&mut self,
-                  from_expr: @ast::Expr,
+                  from_expr: &ast::Expr,
                   to_scope: &mut LoopScope,
                   in_out: &mut [uint]) {
         //! Whenever you have a `break` or a `loop` statement, flow
@@ -778,7 +778,7 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
     }
 
     fn break_from_to(&mut self,
-                     from_expr: @ast::Expr,
+                     from_expr: &ast::Expr,
                      to_scope: &mut LoopScope,
                      in_out: &mut [uint]) {
         self.pop_scopes(from_expr, to_scope, in_out);
@@ -811,7 +811,7 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
     fn walk_call(&mut self,
                  _callee_id: ast::NodeId,
                  call_id: ast::NodeId,
-                 arg0: @ast::Expr,
+                 arg0: &ast::Expr,
                  args: &[@ast::Expr],
                  in_out: &mut [uint],
                  loop_scopes: &mut ~[LoopScope]) {
@@ -865,7 +865,7 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
     }
 
     fn find_scope<'a>(&self,
-                      expr: @ast::Expr,
+                      expr: &ast::Expr,
                       label: Option<ast::Name>,
                       loop_scopes: &'a mut ~[LoopScope]) -> &'a mut LoopScope {
         let index = match label {
@@ -899,7 +899,7 @@ impl<'self, O:DataFlowOperator> PropagationContext<'self, O> {
         &mut loop_scopes[index]
     }
 
-    fn is_method_call(&self, expr: @ast::Expr) -> bool {
+    fn is_method_call(&self, expr: &ast::Expr) -> bool {
         self.dfcx.method_map.contains_key(&expr.id)
     }
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -5410,7 +5410,7 @@ impl Resolver {
     }
 
     pub fn enforce_default_binding_mode(&mut self,
-                                        pat: @Pat,
+                                        pat: &Pat,
                                         pat_binding_mode: BindingMode,
                                         descr: &str) {
         match pat_binding_mode {

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1398,7 +1398,7 @@ fn insert_lllocals(bcx: @mut Block,
 }
 
 fn compile_guard(bcx: @mut Block,
-                     guard_expr: @ast::Expr,
+                     guard_expr: &ast::Expr,
                      data: &ArmData,
                      m: &[Match],
                      vals: &[ValueRef],
@@ -1826,7 +1826,7 @@ fn compile_submatch_continue(mut bcx: @mut Block,
 
 pub fn trans_match(bcx: @mut Block,
                    match_expr: &ast::Expr,
-                   discr_expr: @ast::Expr,
+                   discr_expr: &ast::Expr,
                    arms: &[ast::Arm],
                    dest: Dest) -> @mut Block {
     let _icx = push_ctxt("match::trans_match");
@@ -1876,7 +1876,7 @@ fn create_bindings_map(bcx: @mut Block, pat: @ast::Pat) -> BindingsMap {
 }
 
 fn trans_match_inner(scope_cx: @mut Block,
-                         discr_expr: @ast::Expr,
+                         discr_expr: &ast::Expr,
                          arms: &[ast::Arm],
                          dest: Dest) -> @mut Block {
     let _icx = push_ctxt("match::trans_match_inner");

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1407,7 +1407,10 @@ pub fn cleanup_and_leave(bcx: @mut Block,
     }
     match leave {
       Some(target) => Br(bcx, target),
-      None => { Resume(bcx, Load(bcx, bcx.fcx.personality.unwrap())); }
+      None => {
+          let ll_load = Load(bcx, bcx.fcx.personality.unwrap());
+          Resume(bcx, ll_load);
+      }
     }
 }
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2485,7 +2485,7 @@ pub fn item_path(ccx: &CrateContext, id: &ast::NodeId) -> path {
     ty::item_path(ccx.tcx, ast_util::local_def(*id))
 }
 
-fn exported_name(ccx: @mut CrateContext, path: path, ty: ty::t, attrs: &[ast::Attribute]) -> ~str {
+fn exported_name(ccx: &mut CrateContext, path: path, ty: ty::t, attrs: &[ast::Attribute]) -> ~str {
     match attr::first_attr_value_str_by_name(attrs, "export_name") {
         // Use provided name
         Some(name) => name.to_owned(),
@@ -2979,7 +2979,7 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
     return map;
 }
 
-pub fn fill_crate_map(ccx: @mut CrateContext, map: ValueRef) {
+pub fn fill_crate_map(ccx: &mut CrateContext, map: ValueRef) {
     let mut subcrates: ~[ValueRef] = ~[];
     let mut i = 1;
     let cstore = ccx.sess.cstore;
@@ -3030,7 +3030,7 @@ pub fn crate_ctxt_to_encode_parms<'r>(cx: &'r CrateContext, ie: encoder::encode_
         }
 }
 
-pub fn write_metadata(cx: &mut CrateContext, crate: &ast::Crate) {
+pub fn write_metadata(cx: &CrateContext, crate: &ast::Crate) {
     if !*cx.sess.building_library { return; }
 
     let encode_inlined_item: encoder::encode_inlined_item =

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -23,17 +23,17 @@ use middle::trans::type_::Type;
 use std::cast;
 use std::libc::{c_uint, c_ulonglong, c_char};
 
-pub fn terminate(cx: @mut Block, _: &str) {
+pub fn terminate(cx: &mut Block, _: &str) {
     cx.terminated = true;
 }
 
-pub fn check_not_terminated(cx: @mut Block) {
+pub fn check_not_terminated(cx: &Block) {
     if cx.terminated {
         fail!("already terminated!");
     }
 }
 
-pub fn B(cx: @mut Block) -> Builder {
+pub fn B(cx: &Block) -> Builder {
     let b = cx.fcx.ccx.builder();
     b.position_at_end(cx.llbb);
     b
@@ -47,7 +47,7 @@ pub fn B(cx: @mut Block) -> Builder {
 // for (fail/break/return statements, call to diverging functions, etc), and
 // further instructions to the block should simply be ignored.
 
-pub fn RetVoid(cx: @mut Block) {
+pub fn RetVoid(cx: &mut Block) {
     if cx.unreachable { return; }
     check_not_terminated(cx);
     terminate(cx, "RetVoid");
@@ -83,7 +83,7 @@ pub fn CondBr(cx: @mut Block, If: ValueRef, Then: BasicBlockRef,
     B(cx).cond_br(If, Then, Else);
 }
 
-pub fn Switch(cx: @mut Block, V: ValueRef, Else: BasicBlockRef, NumCases: uint)
+pub fn Switch(cx: &mut Block, V: ValueRef, Else: BasicBlockRef, NumCases: uint)
     -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     check_not_terminated(cx);
@@ -98,7 +98,7 @@ pub fn AddCase(S: ValueRef, OnVal: ValueRef, Dest: BasicBlockRef) {
     }
 }
 
-pub fn IndirectBr(cx: @mut Block, Addr: ValueRef, NumDests: uint) {
+pub fn IndirectBr(cx: &mut Block, Addr: ValueRef, NumDests: uint) {
     if cx.unreachable { return; }
     check_not_terminated(cx);
     terminate(cx, "IndirectBr");
@@ -123,7 +123,7 @@ pub fn Invoke(cx: @mut Block,
     B(cx).invoke(Fn, Args, Then, Catch, attributes)
 }
 
-pub fn Unreachable(cx: @mut Block) {
+pub fn Unreachable(cx: &mut Block) {
     if cx.unreachable { return; }
     cx.unreachable = true;
     if !cx.terminated {
@@ -138,177 +138,177 @@ pub fn _Undef(val: ValueRef) -> ValueRef {
 }
 
 /* Arithmetic */
-pub fn Add(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Add(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).add(LHS, RHS)
 }
 
-pub fn NSWAdd(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NSWAdd(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nswadd(LHS, RHS)
 }
 
-pub fn NUWAdd(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NUWAdd(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nuwadd(LHS, RHS)
 }
 
-pub fn FAdd(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn FAdd(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).fadd(LHS, RHS)
 }
 
-pub fn Sub(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Sub(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).sub(LHS, RHS)
 }
 
-pub fn NSWSub(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NSWSub(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nswsub(LHS, RHS)
 }
 
-pub fn NUWSub(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NUWSub(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nuwsub(LHS, RHS)
 }
 
-pub fn FSub(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn FSub(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).fsub(LHS, RHS)
 }
 
-pub fn Mul(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Mul(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).mul(LHS, RHS)
 }
 
-pub fn NSWMul(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NSWMul(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nswmul(LHS, RHS)
 }
 
-pub fn NUWMul(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn NUWMul(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).nuwmul(LHS, RHS)
 }
 
-pub fn FMul(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn FMul(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).fmul(LHS, RHS)
 }
 
-pub fn UDiv(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn UDiv(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).udiv(LHS, RHS)
 }
 
-pub fn SDiv(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn SDiv(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).sdiv(LHS, RHS)
 }
 
-pub fn ExactSDiv(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn ExactSDiv(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).exactsdiv(LHS, RHS)
 }
 
-pub fn FDiv(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn FDiv(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).fdiv(LHS, RHS)
 }
 
-pub fn URem(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn URem(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).urem(LHS, RHS)
 }
 
-pub fn SRem(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn SRem(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).srem(LHS, RHS)
 }
 
-pub fn FRem(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn FRem(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).frem(LHS, RHS)
 }
 
-pub fn Shl(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Shl(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).shl(LHS, RHS)
 }
 
-pub fn LShr(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn LShr(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).lshr(LHS, RHS)
 }
 
-pub fn AShr(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn AShr(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).ashr(LHS, RHS)
 }
 
-pub fn And(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn And(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).and(LHS, RHS)
 }
 
-pub fn Or(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Or(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).or(LHS, RHS)
 }
 
-pub fn Xor(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn Xor(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).xor(LHS, RHS)
 }
 
-pub fn BinOp(cx: @mut Block, Op: Opcode, LHS: ValueRef, RHS: ValueRef)
+pub fn BinOp(cx: &Block, Op: Opcode, LHS: ValueRef, RHS: ValueRef)
           -> ValueRef {
     if cx.unreachable { return _Undef(LHS); }
     B(cx).binop(Op, LHS, RHS)
 }
 
-pub fn Neg(cx: @mut Block, V: ValueRef) -> ValueRef {
+pub fn Neg(cx: &Block, V: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     B(cx).neg(V)
 }
 
-pub fn NSWNeg(cx: @mut Block, V: ValueRef) -> ValueRef {
+pub fn NSWNeg(cx: &Block, V: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     B(cx).nswneg(V)
 }
 
-pub fn NUWNeg(cx: @mut Block, V: ValueRef) -> ValueRef {
+pub fn NUWNeg(cx: &Block, V: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     B(cx).nuwneg(V)
 }
-pub fn FNeg(cx: @mut Block, V: ValueRef) -> ValueRef {
+pub fn FNeg(cx: &Block, V: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     B(cx).fneg(V)
 }
 
-pub fn Not(cx: @mut Block, V: ValueRef) -> ValueRef {
+pub fn Not(cx: &Block, V: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(V); }
     B(cx).not(V)
 }
 
 /* Memory */
-pub fn Malloc(cx: @mut Block, Ty: Type) -> ValueRef {
+pub fn Malloc(cx: &Block, Ty: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
         B(cx).malloc(Ty)
     }
 }
 
-pub fn ArrayMalloc(cx: @mut Block, Ty: Type, Val: ValueRef) -> ValueRef {
+pub fn ArrayMalloc(cx: &Block, Ty: Type, Val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
         B(cx).array_malloc(Ty, Val)
     }
 }
 
-pub fn Alloca(cx: @mut Block, Ty: Type, name: &str) -> ValueRef {
+pub fn Alloca(cx: &Block, Ty: Type, name: &str) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Ty.ptr_to().to_ref()); }
         let b = cx.fcx.ccx.builder();
@@ -317,7 +317,7 @@ pub fn Alloca(cx: @mut Block, Ty: Type, name: &str) -> ValueRef {
     }
 }
 
-pub fn ArrayAlloca(cx: @mut Block, Ty: Type, Val: ValueRef) -> ValueRef {
+pub fn ArrayAlloca(cx: &Block, Ty: Type, Val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Ty.ptr_to().to_ref()); }
         let b = cx.fcx.ccx.builder();
@@ -326,12 +326,12 @@ pub fn ArrayAlloca(cx: @mut Block, Ty: Type, Val: ValueRef) -> ValueRef {
     }
 }
 
-pub fn Free(cx: @mut Block, PointerVal: ValueRef) {
+pub fn Free(cx: &Block, PointerVal: ValueRef) {
     if cx.unreachable { return; }
     B(cx).free(PointerVal)
 }
 
-pub fn Load(cx: @mut Block, PointerVal: ValueRef) -> ValueRef {
+pub fn Load(cx: &Block, PointerVal: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         if cx.unreachable {
@@ -347,7 +347,7 @@ pub fn Load(cx: @mut Block, PointerVal: ValueRef) -> ValueRef {
     }
 }
 
-pub fn AtomicLoad(cx: @mut Block, PointerVal: ValueRef, order: AtomicOrdering) -> ValueRef {
+pub fn AtomicLoad(cx: &Block, PointerVal: ValueRef, order: AtomicOrdering) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         if cx.unreachable {
@@ -358,7 +358,7 @@ pub fn AtomicLoad(cx: @mut Block, PointerVal: ValueRef, order: AtomicOrdering) -
 }
 
 
-pub fn LoadRangeAssert(cx: @mut Block, PointerVal: ValueRef, lo: c_ulonglong,
+pub fn LoadRangeAssert(cx: &Block, PointerVal: ValueRef, lo: c_ulonglong,
                        hi: c_ulonglong, signed: lib::llvm::Bool) -> ValueRef {
     if cx.unreachable {
         let ccx = cx.fcx.ccx;
@@ -376,17 +376,17 @@ pub fn LoadRangeAssert(cx: @mut Block, PointerVal: ValueRef, lo: c_ulonglong,
     }
 }
 
-pub fn Store(cx: @mut Block, Val: ValueRef, Ptr: ValueRef) {
+pub fn Store(cx: &Block, Val: ValueRef, Ptr: ValueRef) {
     if cx.unreachable { return; }
     B(cx).store(Val, Ptr)
 }
 
-pub fn AtomicStore(cx: @mut Block, Val: ValueRef, Ptr: ValueRef, order: AtomicOrdering) {
+pub fn AtomicStore(cx: &Block, Val: ValueRef, Ptr: ValueRef, order: AtomicOrdering) {
     if cx.unreachable { return; }
     B(cx).atomic_store(Val, Ptr, order)
 }
 
-pub fn GEP(cx: @mut Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
+pub fn GEP(cx: &Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
         B(cx).gep(Pointer, Indices)
@@ -396,35 +396,35 @@ pub fn GEP(cx: @mut Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef 
 // Simple wrapper around GEP that takes an array of ints and wraps them
 // in C_i32()
 #[inline]
-pub fn GEPi(cx: @mut Block, base: ValueRef, ixs: &[uint]) -> ValueRef {
+pub fn GEPi(cx: &Block, base: ValueRef, ixs: &[uint]) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
         B(cx).gepi(base, ixs)
     }
 }
 
-pub fn InBoundsGEP(cx: @mut Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
+pub fn InBoundsGEP(cx: &Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
         B(cx).inbounds_gep(Pointer, Indices)
     }
 }
 
-pub fn StructGEP(cx: @mut Block, Pointer: ValueRef, Idx: uint) -> ValueRef {
+pub fn StructGEP(cx: &Block, Pointer: ValueRef, Idx: uint) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
         B(cx).struct_gep(Pointer, Idx)
     }
 }
 
-pub fn GlobalString(cx: @mut Block, _Str: *c_char) -> ValueRef {
+pub fn GlobalString(cx: &Block, _Str: *c_char) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
         B(cx).global_string(_Str)
     }
 }
 
-pub fn GlobalStringPtr(cx: @mut Block, _Str: *c_char) -> ValueRef {
+pub fn GlobalStringPtr(cx: &Block, _Str: *c_char) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
         B(cx).global_string_ptr(_Str)
@@ -432,112 +432,112 @@ pub fn GlobalStringPtr(cx: @mut Block, _Str: *c_char) -> ValueRef {
 }
 
 /* Casts */
-pub fn Trunc(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn Trunc(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).trunc(Val, DestTy)
     }
 }
 
-pub fn ZExt(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn ZExt(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).zext(Val, DestTy)
     }
 }
 
-pub fn SExt(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn SExt(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).sext(Val, DestTy)
     }
 }
 
-pub fn FPToUI(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPToUI(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).fptoui(Val, DestTy)
     }
 }
 
-pub fn FPToSI(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPToSI(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).fptosi(Val, DestTy)
     }
 }
 
-pub fn UIToFP(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn UIToFP(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).uitofp(Val, DestTy)
     }
 }
 
-pub fn SIToFP(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn SIToFP(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).sitofp(Val, DestTy)
     }
 }
 
-pub fn FPTrunc(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPTrunc(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).fptrunc(Val, DestTy)
     }
 }
 
-pub fn FPExt(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPExt(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).fpext(Val, DestTy)
     }
 }
 
-pub fn PtrToInt(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn PtrToInt(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).ptrtoint(Val, DestTy)
     }
 }
 
-pub fn IntToPtr(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn IntToPtr(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).inttoptr(Val, DestTy)
     }
 }
 
-pub fn BitCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn BitCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).bitcast(Val, DestTy)
     }
 }
 
-pub fn ZExtOrBitCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn ZExtOrBitCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).zext_or_bitcast(Val, DestTy)
     }
 }
 
-pub fn SExtOrBitCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn SExtOrBitCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).sext_or_bitcast(Val, DestTy)
     }
 }
 
-pub fn TruncOrBitCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn TruncOrBitCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).trunc_or_bitcast(Val, DestTy)
     }
 }
 
-pub fn Cast(cx: @mut Block, Op: Opcode, Val: ValueRef, DestTy: Type, _: *u8)
+pub fn Cast(cx: &Block, Op: Opcode, Val: ValueRef, DestTy: Type, _: *u8)
      -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
@@ -545,21 +545,21 @@ pub fn Cast(cx: @mut Block, Op: Opcode, Val: ValueRef, DestTy: Type, _: *u8)
     }
 }
 
-pub fn PointerCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn PointerCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).pointercast(Val, DestTy)
     }
 }
 
-pub fn IntCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn IntCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).intcast(Val, DestTy)
     }
 }
 
-pub fn FPCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(DestTy.to_ref()); }
         B(cx).fpcast(Val, DestTy)
@@ -568,7 +568,7 @@ pub fn FPCast(cx: @mut Block, Val: ValueRef, DestTy: Type) -> ValueRef {
 
 
 /* Comparisons */
-pub fn ICmp(cx: @mut Block, Op: IntPredicate, LHS: ValueRef, RHS: ValueRef)
+pub fn ICmp(cx: &Block, Op: IntPredicate, LHS: ValueRef, RHS: ValueRef)
      -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
@@ -576,7 +576,7 @@ pub fn ICmp(cx: @mut Block, Op: IntPredicate, LHS: ValueRef, RHS: ValueRef)
     }
 }
 
-pub fn FCmp(cx: @mut Block, Op: RealPredicate, LHS: ValueRef, RHS: ValueRef)
+pub fn FCmp(cx: &Block, Op: RealPredicate, LHS: ValueRef, RHS: ValueRef)
      -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
@@ -585,14 +585,14 @@ pub fn FCmp(cx: @mut Block, Op: RealPredicate, LHS: ValueRef, RHS: ValueRef)
 }
 
 /* Miscellaneous instructions */
-pub fn EmptyPhi(cx: @mut Block, Ty: Type) -> ValueRef {
+pub fn EmptyPhi(cx: &Block, Ty: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Ty.to_ref()); }
         B(cx).empty_phi(Ty)
     }
 }
 
-pub fn Phi(cx: @mut Block, Ty: Type, vals: &[ValueRef], bbs: &[BasicBlockRef]) -> ValueRef {
+pub fn Phi(cx: &Block, Ty: Type, vals: &[ValueRef], bbs: &[BasicBlockRef]) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Ty.to_ref()); }
         B(cx).phi(Ty, vals, bbs)
@@ -608,7 +608,7 @@ pub fn AddIncomingToPhi(phi: ValueRef, val: ValueRef, bb: BasicBlockRef) {
     }
 }
 
-pub fn _UndefReturn(cx: @mut Block, Fn: ValueRef) -> ValueRef {
+pub fn _UndefReturn(cx: &Block, Fn: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         let ty = val_ty(Fn);
@@ -622,58 +622,58 @@ pub fn _UndefReturn(cx: @mut Block, Fn: ValueRef) -> ValueRef {
     }
 }
 
-pub fn add_span_comment(cx: @mut Block, sp: Span, text: &str) {
+pub fn add_span_comment(cx: &Block, sp: Span, text: &str) {
     B(cx).add_span_comment(sp, text)
 }
 
-pub fn add_comment(cx: @mut Block, text: &str) {
+pub fn add_comment(cx: &Block, text: &str) {
     B(cx).add_comment(text)
 }
 
-pub fn InlineAsmCall(cx: @mut Block, asm: *c_char, cons: *c_char,
+pub fn InlineAsmCall(cx: &Block, asm: *c_char, cons: *c_char,
                      inputs: &[ValueRef], output: Type,
                      volatile: bool, alignstack: bool,
                      dia: AsmDialect) -> ValueRef {
     B(cx).inline_asm_call(asm, cons, inputs, output, volatile, alignstack, dia)
 }
 
-pub fn Call(cx: @mut Block, Fn: ValueRef, Args: &[ValueRef],
+pub fn Call(cx: &Block, Fn: ValueRef, Args: &[ValueRef],
             attributes: &[(uint, lib::llvm::Attribute)]) -> ValueRef {
     if cx.unreachable { return _UndefReturn(cx, Fn); }
     B(cx).call(Fn, Args, attributes)
 }
 
-pub fn CallWithConv(cx: @mut Block, Fn: ValueRef, Args: &[ValueRef], Conv: CallConv,
+pub fn CallWithConv(cx: &Block, Fn: ValueRef, Args: &[ValueRef], Conv: CallConv,
                     attributes: &[(uint, lib::llvm::Attribute)]) -> ValueRef {
     if cx.unreachable { return _UndefReturn(cx, Fn); }
     B(cx).call_with_conv(Fn, Args, Conv, attributes)
 }
 
-pub fn AtomicFence(cx: @mut Block, order: AtomicOrdering) {
+pub fn AtomicFence(cx: &Block, order: AtomicOrdering) {
     if cx.unreachable { return; }
     B(cx).atomic_fence(order)
 }
 
-pub fn Select(cx: @mut Block, If: ValueRef, Then: ValueRef, Else: ValueRef) -> ValueRef {
+pub fn Select(cx: &Block, If: ValueRef, Then: ValueRef, Else: ValueRef) -> ValueRef {
     if cx.unreachable { return _Undef(Then); }
     B(cx).select(If, Then, Else)
 }
 
-pub fn VAArg(cx: @mut Block, list: ValueRef, Ty: Type) -> ValueRef {
+pub fn VAArg(cx: &Block, list: ValueRef, Ty: Type) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Ty.to_ref()); }
         B(cx).va_arg(list, Ty)
     }
 }
 
-pub fn ExtractElement(cx: @mut Block, VecVal: ValueRef, Index: ValueRef) -> ValueRef {
+pub fn ExtractElement(cx: &Block, VecVal: ValueRef, Index: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
         B(cx).extract_element(VecVal, Index)
     }
 }
 
-pub fn InsertElement(cx: @mut Block, VecVal: ValueRef, EltVal: ValueRef,
+pub fn InsertElement(cx: &Block, VecVal: ValueRef, EltVal: ValueRef,
                      Index: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
@@ -681,7 +681,7 @@ pub fn InsertElement(cx: @mut Block, VecVal: ValueRef, EltVal: ValueRef,
     }
 }
 
-pub fn ShuffleVector(cx: @mut Block, V1: ValueRef, V2: ValueRef,
+pub fn ShuffleVector(cx: &Block, V1: ValueRef, V2: ValueRef,
                      Mask: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
@@ -689,42 +689,42 @@ pub fn ShuffleVector(cx: @mut Block, V1: ValueRef, V2: ValueRef,
     }
 }
 
-pub fn VectorSplat(cx: @mut Block, NumElts: uint, EltVal: ValueRef) -> ValueRef {
+pub fn VectorSplat(cx: &Block, NumElts: uint, EltVal: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
         B(cx).vector_splat(NumElts, EltVal)
     }
 }
 
-pub fn ExtractValue(cx: @mut Block, AggVal: ValueRef, Index: uint) -> ValueRef {
+pub fn ExtractValue(cx: &Block, AggVal: ValueRef, Index: uint) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
         B(cx).extract_value(AggVal, Index)
     }
 }
 
-pub fn InsertValue(cx: @mut Block, AggVal: ValueRef, EltVal: ValueRef, Index: uint) -> ValueRef {
+pub fn InsertValue(cx: &Block, AggVal: ValueRef, EltVal: ValueRef, Index: uint) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
         B(cx).insert_value(AggVal, EltVal, Index)
     }
 }
 
-pub fn IsNull(cx: @mut Block, Val: ValueRef) -> ValueRef {
+pub fn IsNull(cx: &Block, Val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
         B(cx).is_null(Val)
     }
 }
 
-pub fn IsNotNull(cx: @mut Block, Val: ValueRef) -> ValueRef {
+pub fn IsNotNull(cx: &Block, Val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
         B(cx).is_not_null(Val)
     }
 }
 
-pub fn PtrDiff(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn PtrDiff(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         if cx.unreachable { return llvm::LLVMGetUndef(ccx.int_type.to_ref()); }
@@ -732,19 +732,19 @@ pub fn PtrDiff(cx: @mut Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
     }
 }
 
-pub fn Trap(cx: @mut Block) {
+pub fn Trap(cx: &Block) {
     if cx.unreachable { return; }
     B(cx).trap();
 }
 
-pub fn LandingPad(cx: @mut Block, Ty: Type, PersFn: ValueRef,
+pub fn LandingPad(cx: &Block, Ty: Type, PersFn: ValueRef,
                   NumClauses: uint) -> ValueRef {
     check_not_terminated(cx);
     assert!(!cx.unreachable);
     B(cx).landing_pad(Ty, PersFn, NumClauses)
 }
 
-pub fn SetCleanup(cx: @mut Block, LandingPad: ValueRef) {
+pub fn SetCleanup(cx: &Block, LandingPad: ValueRef) {
     B(cx).set_cleanup(LandingPad)
 }
 
@@ -755,12 +755,12 @@ pub fn Resume(cx: @mut Block, Exn: ValueRef) -> ValueRef {
 }
 
 // Atomic Operations
-pub fn AtomicCmpXchg(cx: @mut Block, dst: ValueRef,
+pub fn AtomicCmpXchg(cx: &Block, dst: ValueRef,
                      cmp: ValueRef, src: ValueRef,
                      order: AtomicOrdering) -> ValueRef {
     B(cx).atomic_cmpxchg(dst, cmp, src, order)
 }
-pub fn AtomicRMW(cx: @mut Block, op: AtomicBinOp,
+pub fn AtomicRMW(cx: &Block, op: AtomicBinOp,
                  dst: ValueRef, src: ValueRef,
                  order: AtomicOrdering) -> ValueRef {
     B(cx).atomic_rmw(op, dst, src, order)

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -77,7 +77,7 @@ pub struct Callee {
     data: CalleeData
 }
 
-pub fn trans(bcx: @mut Block, expr: @ast::Expr) -> Callee {
+pub fn trans(bcx: @mut Block, expr: &ast::Expr) -> Callee {
     let _icx = push_ctxt("trans_callee");
     debug!("callee::trans(expr=%s)", expr.repr(bcx.tcx()));
 
@@ -92,7 +92,7 @@ pub fn trans(bcx: @mut Block, expr: @ast::Expr) -> Callee {
     // any other expressions are closures:
     return datum_callee(bcx, expr);
 
-    fn datum_callee(bcx: @mut Block, expr: @ast::Expr) -> Callee {
+    fn datum_callee(bcx: @mut Block, expr: &ast::Expr) -> Callee {
         let DatumBlock {bcx, datum} = expr::trans_to_datum(bcx, expr);
         match ty::get(datum.ty).sty {
             ty::ty_bare_fn(*) => {
@@ -115,7 +115,7 @@ pub fn trans(bcx: @mut Block, expr: @ast::Expr) -> Callee {
         return Callee {bcx: bcx, data: Fn(fd)};
     }
 
-    fn trans_def(bcx: @mut Block, def: ast::Def, ref_expr: @ast::Expr) -> Callee {
+    fn trans_def(bcx: @mut Block, def: ast::Def, ref_expr: &ast::Expr) -> Callee {
         match def {
             ast::DefFn(did, _) |
             ast::DefStaticMethod(did, ast::FromImpl(_), _) => {
@@ -447,8 +447,8 @@ pub fn trans_fn_ref_with_vtables(
 // Translating calls
 
 pub fn trans_call(in_cx: @mut Block,
-                  call_ex: @ast::Expr,
-                  f: @ast::Expr,
+                  call_ex: &ast::Expr,
+                  f: &ast::Expr,
                   args: CallArgs,
                   id: ast::NodeId,
                   dest: expr::Dest)
@@ -465,9 +465,9 @@ pub fn trans_call(in_cx: @mut Block,
 }
 
 pub fn trans_method_call(in_cx: @mut Block,
-                         call_ex: @ast::Expr,
+                         call_ex: &ast::Expr,
                          callee_id: ast::NodeId,
-                         rcvr: @ast::Expr,
+                         rcvr: &ast::Expr,
                          args: CallArgs,
                          dest: expr::Dest)
                          -> @mut Block {
@@ -834,7 +834,7 @@ pub enum AutorefArg {
 pub fn trans_arg_expr(bcx: @mut Block,
                       formal_arg_ty: ty::t,
                       self_mode: ty::SelfMode,
-                      arg_expr: @ast::Expr,
+                      arg_expr: &ast::Expr,
                       temp_cleanups: &mut ~[ValueRef],
                       autoref_arg: AutorefArg) -> Result {
     let _icx = push_ctxt("trans_arg_expr");

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -550,7 +550,7 @@ pub fn revoke_clean(cx: @mut Block, val: ValueRef) {
     }
 }
 
-pub fn block_cleanups(bcx: @mut Block) -> ~[cleanup] {
+pub fn block_cleanups(bcx: &mut Block) -> ~[cleanup] {
     match bcx.scope {
        None  => ~[],
        Some(inf) => inf.cleanups.clone(),
@@ -1061,7 +1061,7 @@ pub fn path_str(sess: session::Session, p: &[path_elt]) -> ~str {
     r
 }
 
-pub fn monomorphize_type(bcx: @mut Block, t: ty::t) -> ty::t {
+pub fn monomorphize_type(bcx: &mut Block, t: ty::t) -> ty::t {
     match bcx.fcx.param_substs {
         Some(substs) => {
             ty::subst_tps(bcx.tcx(), substs.tys, substs.self_ty, t)
@@ -1074,23 +1074,23 @@ pub fn monomorphize_type(bcx: @mut Block, t: ty::t) -> ty::t {
     }
 }
 
-pub fn node_id_type(bcx: @mut Block, id: ast::NodeId) -> ty::t {
+pub fn node_id_type(bcx: &mut Block, id: ast::NodeId) -> ty::t {
     let tcx = bcx.tcx();
     let t = ty::node_id_to_type(tcx, id);
     monomorphize_type(bcx, t)
 }
 
-pub fn expr_ty(bcx: @mut Block, ex: &ast::Expr) -> ty::t {
+pub fn expr_ty(bcx: &mut Block, ex: &ast::Expr) -> ty::t {
     node_id_type(bcx, ex.id)
 }
 
-pub fn expr_ty_adjusted(bcx: @mut Block, ex: &ast::Expr) -> ty::t {
+pub fn expr_ty_adjusted(bcx: &mut Block, ex: &ast::Expr) -> ty::t {
     let tcx = bcx.tcx();
     let t = ty::expr_ty_adjusted(tcx, ex);
     monomorphize_type(bcx, t)
 }
 
-pub fn node_id_type_params(bcx: @mut Block, id: ast::NodeId) -> ~[ty::t] {
+pub fn node_id_type_params(bcx: &mut Block, id: ast::NodeId) -> ~[ty::t] {
     let tcx = bcx.tcx();
     let params = ty::node_id_to_type_params(tcx, id);
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -670,7 +670,7 @@ impl Block {
         ast_map::node_id_to_str(self.tcx().items, id, self.sess().intr())
     }
 
-    pub fn expr_to_str(&self, e: @ast::Expr) -> ~str {
+    pub fn expr_to_str(&self, e: &ast::Expr) -> ~str {
         e.repr(self.tcx())
     }
 

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -177,7 +177,7 @@ pub fn get_const_val(cx: @mut CrateContext,
      !cx.non_inlineable_statics.contains(&def_id.node))
 }
 
-pub fn const_expr(cx: @mut CrateContext, e: @ast::Expr) -> (ValueRef, bool) {
+pub fn const_expr(cx: @mut CrateContext, e: &ast::Expr) -> (ValueRef, bool) {
     let (llconst, inlineable) = const_expr_unadjusted(cx, e);
     let mut llconst = llconst;
     let mut inlineable = inlineable;

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -45,7 +45,7 @@ pub fn trans_block(bcx: @mut Block, b: &ast::Block, dest: expr::Dest) -> @mut Bl
 }
 
 pub fn trans_if(bcx: @mut Block,
-            cond: @ast::Expr,
+            cond: &ast::Expr,
             thn: &ast::Block,
             els: Option<@ast::Expr>,
             dest: expr::Dest)
@@ -158,7 +158,7 @@ pub fn join_blocks(parent_bcx: @mut Block, in_cxs: &[@mut Block]) -> @mut Block 
     return out;
 }
 
-pub fn trans_while(bcx: @mut Block, cond: @ast::Expr, body: &ast::Block) -> @mut Block {
+pub fn trans_while(bcx: @mut Block, cond: &ast::Expr, body: &ast::Block) -> @mut Block {
     let _icx = push_ctxt("trans_while");
     let next_bcx = sub_block(bcx, "while next");
 

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -181,7 +181,7 @@ fn drop_and_cancel_clean(bcx: @mut Block, dat: Datum) -> @mut Block {
     return bcx;
 }
 
-pub fn trans_to_datum(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
+pub fn trans_to_datum(bcx: @mut Block, expr: &ast::Expr) -> DatumBlock {
     debug!("trans_to_datum(expr=%s)", bcx.expr_to_str(expr));
 
     let mut bcx = bcx;
@@ -307,7 +307,7 @@ pub fn trans_to_datum(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
 
     fn auto_borrow_obj(mut bcx: @mut Block,
                        autoderefs: uint,
-                       expr: @ast::Expr,
+                       expr: &ast::Expr,
                        source_datum: Datum) -> DatumBlock {
         let tcx = bcx.tcx();
         let target_obj_ty = expr_ty_adjusted(bcx, expr);
@@ -419,7 +419,7 @@ pub fn trans_to_datum(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
     }
 }
 
-pub fn trans_into(bcx: @mut Block, expr: @ast::Expr, dest: Dest) -> @mut Block {
+pub fn trans_into(bcx: @mut Block, expr: &ast::Expr, dest: Dest) -> @mut Block {
     if bcx.tcx().adjustments.contains_key(&expr.id) {
         // use trans_to_datum, which is mildly less efficient but
         // which will perform the adjustments:
@@ -477,7 +477,7 @@ pub fn trans_into(bcx: @mut Block, expr: @ast::Expr, dest: Dest) -> @mut Block {
     };
 }
 
-fn trans_lvalue(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
+fn trans_lvalue(bcx: @mut Block, expr: &ast::Expr) -> DatumBlock {
     /*!
      *
      * Translates an lvalue expression, always yielding a by-ref
@@ -496,7 +496,7 @@ fn trans_lvalue(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
     };
 }
 
-fn trans_to_datum_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
+fn trans_to_datum_unadjusted(bcx: @mut Block, expr: &ast::Expr) -> DatumBlock {
     /*!
      * Translates an expression into a datum.  If this expression
      * is an rvalue, this will result in a temporary value being
@@ -562,7 +562,7 @@ fn trans_to_datum_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
     }
 }
 
-fn trans_rvalue_datum_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
+fn trans_rvalue_datum_unadjusted(bcx: @mut Block, expr: &ast::Expr) -> DatumBlock {
     let _icx = push_ctxt("trans_rvalue_datum_unadjusted");
 
     trace_span!(bcx, expr.span, shorten(bcx.expr_to_str(expr)));
@@ -615,7 +615,7 @@ fn trans_rvalue_datum_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> DatumBloc
     }
 }
 
-fn trans_rvalue_stmt_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> @mut Block {
+fn trans_rvalue_stmt_unadjusted(bcx: @mut Block, expr: &ast::Expr) -> @mut Block {
     let mut bcx = bcx;
     let _icx = push_ctxt("trans_rvalue_stmt");
 
@@ -669,7 +669,7 @@ fn trans_rvalue_stmt_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> @mut Block
     };
 }
 
-fn trans_rvalue_dps_unadjusted(bcx: @mut Block, expr: @ast::Expr,
+fn trans_rvalue_dps_unadjusted(bcx: @mut Block, expr: &ast::Expr,
                                dest: Dest) -> @mut Block {
     let _icx = push_ctxt("trans_rvalue_dps_unadjusted");
     let tcx = bcx.tcx();
@@ -878,7 +878,7 @@ fn trans_def_datum_unadjusted(bcx: @mut Block,
     }
 }
 
-fn trans_lvalue_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
+fn trans_lvalue_unadjusted(bcx: @mut Block, expr: &ast::Expr) -> DatumBlock {
     /*!
      *
      * Translates an lvalue expression, always yielding a by-ref
@@ -918,7 +918,7 @@ fn trans_lvalue_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
     };
 
     fn trans_rec_field(bcx: @mut Block,
-                       base: @ast::Expr,
+                       base: &ast::Expr,
                        field: ast::Ident) -> DatumBlock {
         //! Translates `base.field`.
 
@@ -942,8 +942,8 @@ fn trans_lvalue_unadjusted(bcx: @mut Block, expr: @ast::Expr) -> DatumBlock {
 
     fn trans_index(bcx: @mut Block,
                    index_expr: &ast::Expr,
-                   base: @ast::Expr,
-                   idx: @ast::Expr) -> DatumBlock {
+                   base: &ast::Expr,
+                   idx: &ast::Expr) -> DatumBlock {
         //! Translates `base[idx]`.
 
         let _icx = push_ctxt("trans_index");
@@ -1321,7 +1321,7 @@ fn trans_adt(bcx: @mut Block, repr: &adt::Repr, discr: ty::Disr,
 }
 
 
-fn trans_immediate_lit(bcx: @mut Block, expr: @ast::Expr,
+fn trans_immediate_lit(bcx: @mut Block, expr: &ast::Expr,
                        lit: ast::lit) -> DatumBlock {
     // must not be a string constant, that is a RvalueDpsExpr
     let _icx = push_ctxt("trans_immediate_lit");
@@ -1332,7 +1332,7 @@ fn trans_immediate_lit(bcx: @mut Block, expr: @ast::Expr,
 fn trans_unary_datum(bcx: @mut Block,
                      un_expr: &ast::Expr,
                      op: ast::UnOp,
-                     sub_expr: @ast::Expr) -> DatumBlock {
+                     sub_expr: &ast::Expr) -> DatumBlock {
     let _icx = push_ctxt("trans_unary_datum");
 
     // if deref, would be LvalueExpr
@@ -1391,7 +1391,7 @@ fn trans_unary_datum(bcx: @mut Block,
 
     fn trans_boxed_expr(bcx: @mut Block,
                         box_ty: ty::t,
-                        contents: @ast::Expr,
+                        contents: &ast::Expr,
                         contents_ty: ty::t,
                         heap: heap) -> DatumBlock {
         let _icx = push_ctxt("trans_boxed_expr");
@@ -1416,7 +1416,7 @@ fn trans_unary_datum(bcx: @mut Block,
 }
 
 fn trans_addr_of(bcx: @mut Block, expr: &ast::Expr,
-                 subexpr: @ast::Expr) -> DatumBlock {
+                 subexpr: &ast::Expr) -> DatumBlock {
     let _icx = push_ctxt("trans_addr_of");
     let mut bcx = bcx;
     let sub_datum = unpack_datum!(bcx, trans_to_datum(bcx, subexpr));
@@ -1532,8 +1532,8 @@ enum lazy_binop_ty { lazy_and, lazy_or }
 fn trans_lazy_binop(bcx: @mut Block,
                     binop_expr: &ast::Expr,
                     op: lazy_binop_ty,
-                    a: @ast::Expr,
-                    b: @ast::Expr) -> DatumBlock {
+                    a: &ast::Expr,
+                    b: &ast::Expr) -> DatumBlock {
     let _icx = push_ctxt("trans_lazy_binop");
     let binop_ty = expr_ty(bcx, binop_expr);
     let bcx = bcx;
@@ -1577,8 +1577,8 @@ fn trans_lazy_binop(bcx: @mut Block,
 fn trans_binary(bcx: @mut Block,
                 binop_expr: &ast::Expr,
                 op: ast::BinOp,
-                lhs: @ast::Expr,
-                rhs: @ast::Expr) -> DatumBlock
+                lhs: &ast::Expr,
+                rhs: &ast::Expr) -> DatumBlock
 {
     let _icx = push_ctxt("trans_binary");
 
@@ -1603,7 +1603,7 @@ fn trans_binary(bcx: @mut Block,
 fn trans_overloaded_op(bcx: @mut Block,
                        expr: &ast::Expr,
                        callee_id: ast::NodeId,
-                       rcvr: @ast::Expr,
+                       rcvr: &ast::Expr,
                        args: ~[@ast::Expr],
                        ret_ty: ty::t,
                        dest: Dest)
@@ -1679,7 +1679,7 @@ pub fn cast_type_kind(t: ty::t) -> cast_kind {
     }
 }
 
-fn trans_imm_cast(bcx: @mut Block, expr: @ast::Expr,
+fn trans_imm_cast(bcx: @mut Block, expr: &ast::Expr,
                   id: ast::NodeId) -> DatumBlock {
     let _icx = push_ctxt("trans_cast");
     let ccx = bcx.ccx();
@@ -1748,10 +1748,10 @@ fn trans_imm_cast(bcx: @mut Block, expr: @ast::Expr,
 }
 
 fn trans_assign_op(bcx: @mut Block,
-                   expr: @ast::Expr,
+                   expr: &ast::Expr,
                    callee_id: ast::NodeId,
                    op: ast::BinOp,
-                   dst: @ast::Expr,
+                   dst: &ast::Expr,
                    src: @ast::Expr) -> @mut Block
 {
     let _icx = push_ctxt("trans_assign_op");

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -139,7 +139,7 @@ pub fn trans_method(ccx: @mut CrateContext,
 }
 
 pub fn trans_self_arg(bcx: @mut Block,
-                      base: @ast::Expr,
+                      base: &ast::Expr,
                       temp_cleanups: &mut ~[ValueRef],
                       mentry: typeck::method_map_entry) -> Result {
     let _icx = push_ctxt("impl::trans_self_arg");
@@ -156,7 +156,7 @@ pub fn trans_self_arg(bcx: @mut Block,
 
 pub fn trans_method_callee(bcx: @mut Block,
                            callee_id: ast::NodeId,
-                           this: @ast::Expr,
+                           this: &ast::Expr,
                            mentry: typeck::method_map_entry)
                            -> Callee {
     let _icx = push_ctxt("impl::trans_method_callee");
@@ -313,7 +313,7 @@ pub fn method_with_name(ccx: &mut CrateContext,
 
 pub fn trans_monomorphized_callee(bcx: @mut Block,
                                   callee_id: ast::NodeId,
-                                  base: @ast::Expr,
+                                  base: &ast::Expr,
                                   mentry: typeck::method_map_entry,
                                   trait_id: ast::DefId,
                                   n_method: uint,
@@ -420,7 +420,7 @@ pub fn combine_impl_and_methods_tps(bcx: @mut Block,
 pub fn trans_trait_callee(bcx: @mut Block,
                           callee_id: ast::NodeId,
                           n_method: uint,
-                          self_expr: @ast::Expr)
+                          self_expr: &ast::Expr)
                           -> Callee {
     /*!
      * Create a method callee where the method is coming from a trait
@@ -630,7 +630,7 @@ fn emit_vtable_methods(bcx: @mut Block,
 }
 
 pub fn trans_trait_cast(bcx: @mut Block,
-                        val: @ast::Expr,
+                        val: &ast::Expr,
                         id: ast::NodeId,
                         dest: expr::Dest,
                         _store: ty::TraitStore)

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -158,7 +158,7 @@ impl VecTypes {
 }
 
 pub fn trans_fixed_vstore(bcx: @mut Block,
-                          vstore_expr: @ast::Expr,
+                          vstore_expr: &ast::Expr,
                           content_expr: &ast::Expr,
                           dest: expr::Dest)
                        -> @mut Block {
@@ -187,8 +187,8 @@ pub fn trans_fixed_vstore(bcx: @mut Block,
 }
 
 pub fn trans_slice_vstore(bcx: @mut Block,
-                          vstore_expr: @ast::Expr,
-                          content_expr: @ast::Expr,
+                          vstore_expr: &ast::Expr,
+                          content_expr: &ast::Expr,
                           dest: expr::Dest)
                        -> @mut Block {
     //!
@@ -246,7 +246,7 @@ pub fn trans_slice_vstore(bcx: @mut Block,
 }
 
 pub fn trans_lit_str(bcx: @mut Block,
-                     lit_expr: @ast::Expr,
+                     lit_expr: &ast::Expr,
                      str_lit: @str,
                      dest: Dest)
                   -> @mut Block {
@@ -280,7 +280,7 @@ pub fn trans_lit_str(bcx: @mut Block,
 }
 
 
-pub fn trans_uniq_or_managed_vstore(bcx: @mut Block, heap: heap, vstore_expr: @ast::Expr,
+pub fn trans_uniq_or_managed_vstore(bcx: @mut Block, heap: heap, vstore_expr: &ast::Expr,
                                     content_expr: &ast::Expr) -> DatumBlock {
     //!
     //
@@ -343,7 +343,7 @@ pub fn trans_uniq_or_managed_vstore(bcx: @mut Block, heap: heap, vstore_expr: @a
 
 pub fn write_content(bcx: @mut Block,
                      vt: &VecTypes,
-                     vstore_expr: @ast::Expr,
+                     vstore_expr: &ast::Expr,
                      content_expr: &ast::Expr,
                      dest: Dest)
                   -> @mut Block {

--- a/src/librustc/middle/trans/value.rs
+++ b/src/librustc/middle/trans/value.rs
@@ -49,7 +49,7 @@ impl Value {
     /// This only performs a search for a trivially dominating store. The store
     /// must be the only user of this value, and there must not be any conditional
     /// branches between the store and the given block.
-    pub fn get_dominating_store(self, bcx: @mut Block) -> Option<Value> {
+    pub fn get_dominating_store(self, bcx: &mut Block) -> Option<Value> {
         match self.get_single_user().and_then(|user| user.as_store_inst()) {
             Some(store) => {
                 do store.get_parent().and_then |store_bb| {


### PR DESCRIPTION
This is mostly an incremental change, picking off some uses of
@- or @mut-pointers that can be replaced by references.

Almost all of the builder functions in trans::build are updated,
mostly using `&Block` arguments instead of `@mut Block`.
