### PR TITLE
The default_stat fn should be public

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -253,7 +253,7 @@ pub trait GenericPath : Clone + Eq + ToStr {
 
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "android")]
-mod stat {
+pub mod stat {
     #[cfg(target_arch = "x86")]
     pub mod arch {
         use libc;
@@ -373,7 +373,7 @@ mod stat {
 }
 
 #[cfg(target_os = "freebsd")]
-mod stat {
+pub mod stat {
     #[cfg(target_arch = "x86_64")]
     pub mod arch {
         use libc;
@@ -408,7 +408,7 @@ mod stat {
 }
 
 #[cfg(target_os = "macos")]
-mod stat {
+pub mod stat {
     pub mod arch {
         use libc;
 
@@ -442,7 +442,7 @@ mod stat {
 }
 
 #[cfg(target_os = "win32")]
-mod stat {
+pub mod stat {
     pub mod arch {
         use libc;
         pub fn default_stat() -> libc::stat {


### PR DESCRIPTION
Anybody working with a C API that uses the stat structure will want `default_stat` to be accessible, since, as can be seen by the implementation of default_stat, all uses of `stat` without it would need to be platform-specific.

In this PR I have simply made it public--I would understand if there was a desire to put the public API somewhere else instead.  (There is no reason it should be in `std::path`.)  Maybe an impl of `Default` in `std::libc` itself?
