### PR TITLE
Issue7526 attempt to catch non uppercase statics in match patterns

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -11,6 +11,7 @@
 // LLVM wrappers are intended to be called from trans,
 // which already runs in a #[fixed_stack_segment]
 #[allow(cstack)];
+#[allow(non_uppercase_pattern_statics)];
 
 use std::c_str::ToCStr;
 use std::hashmap::HashMap;

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -137,7 +137,7 @@ pub fn check_arms(cx: &MatchCheckCtxt, arms: &[Arm]) {
 
             // Lint for constants that look like binding identifiers (#7526)
             let pat_matches_non_uppercase_static: &fn(@Pat) = |p| {
-                let msg = "static constant in pattern should have an uppercase identifier";
+                let msg = "static constant in pattern should be all caps";
                 match (&p.node, cx.tcx.def_map.find(&p.id)) {
                     (&PatIdent(_, ref path, _), Some(&DefStatic(_, false))) => {
                         // last identifier alone is right choice for this lint.

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -11,6 +11,7 @@
 
 use middle::const_eval::{compare_const_vals, lookup_const_by_id};
 use middle::const_eval::{eval_const_expr, const_val, const_bool, const_float};
+use middle::lint::non_uppercase_pattern_statics;
 use middle::pat_util::*;
 use middle::ty::*;
 use middle::ty;
@@ -133,11 +134,30 @@ pub fn check_arms(cx: &MatchCheckCtxt, arms: &[Arm]) {
                     _ => false
                 }
             };
+
+            // Lint for constants that look like binding identifiers (#7526)
+            let pat_matches_non_uppercase_static: &fn(@Pat) = |p| {
+                let msg = "static constant in pattern should have an uppercase identifier";
+                match (&p.node, cx.tcx.def_map.find(&p.id)) {
+                    (&PatIdent(_, ref path, _), Some(&DefStatic(_, false))) => {
+                        // last identifier alone is right choice for this lint.
+                        let ident = path.segments.last().identifier;
+                        let s = cx.tcx.sess.str_of(ident);
+                        if s.iter().any(|c| c.is_lowercase()) {
+                            cx.tcx.sess.add_lint(non_uppercase_pattern_statics,
+                                                 p.id, path.span, msg.to_owned());
+                        }
+                    }
+                    _ => {}
+                }
+            };
+
             do walk_pat(*pat) |p| {
                 if pat_matches_nan(p) {
                     cx.tcx.sess.span_warn(p.span, "unmatchable NaN in pattern, \
                                                    use the is_nan method in a guard instead");
                 }
+                pat_matches_non_uppercase_static(p);
                 true
             };
 

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -83,6 +83,7 @@ pub enum lint {
     unrecognized_lint,
     non_camel_case_types,
     non_uppercase_statics,
+    non_uppercase_pattern_statics,
     type_limits,
     unused_unsafe,
 
@@ -207,6 +208,13 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
          lint: non_uppercase_statics,
          desc: "static constants should have uppercase identifiers",
          default: allow
+     }),
+
+    ("non_uppercase_pattern_statics",
+     LintSpec {
+         lint: non_uppercase_pattern_statics,
+         desc: "static constants in match patterns should be uppercased",
+         default: warn
      }),
 
     ("managed_heap_memory",

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -213,7 +213,7 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
     ("non_uppercase_pattern_statics",
      LintSpec {
          lint: non_uppercase_pattern_statics,
-         desc: "static constants in match patterns should be uppercased",
+         desc: "static constants in match patterns should be all caps",
          default: warn
      }),
 

--- a/src/librustc/middle/trans/cabi_arm.rs
+++ b/src/librustc/middle/trans/cabi_arm.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_uppercase_pattern_statics)];
+
 use lib::llvm::{llvm, Integer, Pointer, Float, Double, Struct, Array};
 use lib::llvm::{Attribute, StructRetAttribute};
 use middle::trans::cabi::{FnType, LLVMType};

--- a/src/librustc/middle/trans/cabi_mips.rs
+++ b/src/librustc/middle/trans/cabi_mips.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_uppercase_pattern_statics)];
 
 use std::libc::c_uint;
 use std::num;

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -11,6 +11,8 @@
 // The classification code for the x86_64 ABI is taken from the clay language
 // https://github.com/jckarter/clay/blob/master/compiler/src/externals.cpp
 
+#[allow(non_uppercase_pattern_statics)];
+
 use lib::llvm::{llvm, Integer, Pointer, Float, Double};
 use lib::llvm::{Struct, Array, Attribute};
 use lib::llvm::{StructRetAttribute, ByValAttribute};

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_uppercase_pattern_statics)];
+
 use back::{abi};
 use lib::llvm::{SequentiallyConsistent, Acquire, Release, Xchg};
 use lib::llvm::{ValueRef, Pointer};

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_uppercase_pattern_statics)];
 
 use lib::llvm::{llvm, TypeRef, Bool, False, True, TypeKind};
 use lib::llvm::{Float, Double, X86_FP80, PPC_FP128, FP128};

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -11,6 +11,7 @@
 //! Operations and constants for `f32`
 #[allow(missing_doc)];
 #[allow(non_uppercase_statics)];
+#[allow(non_uppercase_pattern_statics)];
 
 use default::Default;
 use libc::c_int;

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -12,6 +12,7 @@
 
 #[allow(missing_doc)];
 #[allow(non_uppercase_statics)];
+#[allow(non_uppercase_pattern_statics)];
 
 use default::Default;
 use libc::c_int;

--- a/src/test/compile-fail/issue-6804.rs
+++ b/src/test/compile-fail/issue-6804.rs
@@ -1,3 +1,5 @@
+#[allow(non_uppercase_pattern_statics)];
+
 // Matching against NaN should result in a warning
 
 use std::float::NaN;

--- a/src/test/compile-fail/match-static-const-lc.rs
+++ b/src/test/compile-fail/match-static-const-lc.rs
@@ -17,7 +17,7 @@ pub static a : int = 97;
 fn f() {
     let r = match (0,0) {
         (0, a) => 0,
-        //~^ ERROR static constant in pattern should have an uppercase id
+        //~^ ERROR static constant in pattern should be all caps
         (x, y) => 1 + x + y,
     };
     assert!(r == 1);
@@ -31,7 +31,7 @@ fn g() {
     use m::aha;
     let r = match (0,0) {
         (0, aha) => 0,
-        //~^ ERROR static constant in pattern should have an uppercase id
+        //~^ ERROR static constant in pattern should be all caps
         (x, y)   => 1 + x + y,
     };
     assert!(r == 1);

--- a/src/test/compile-fail/match-static-const-lc.rs
+++ b/src/test/compile-fail/match-static-const-lc.rs
@@ -28,9 +28,23 @@ mod m {
 }
 
 fn g() {
-    use m::aha;
+    use self::m::aha;
     let r = match (0,0) {
         (0, aha) => 0,
+        //~^ ERROR static constant in pattern should be all caps
+        (x, y)   => 1 + x + y,
+    };
+    assert!(r == 1);
+}
+
+mod n {
+    pub static OKAY : int = 8;
+}
+
+fn h() {
+    use not_okay = self::n::OKAY;
+    let r = match (0,0) {
+        (0, not_okay) => 0,
         //~^ ERROR static constant in pattern should be all caps
         (x, y)   => 1 + x + y,
     };
@@ -40,4 +54,5 @@ fn g() {
 fn main () {
     f();
     g();
+    h();
 }

--- a/src/test/compile-fail/match-static-const-lc.rs
+++ b/src/test/compile-fail/match-static-const-lc.rs
@@ -1,0 +1,43 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #7526: lowercase static constants in patterns look like bindings
+
+#[deny(non_uppercase_pattern_statics)];
+
+pub static a : int = 97;
+
+fn f() {
+    let r = match (0,0) {
+        (0, a) => 0,
+        //~^ ERROR static constant in pattern should have an uppercase id
+        (x, y) => 1 + x + y,
+    };
+    assert!(r == 1);
+}
+
+mod m {
+    pub static aha : int = 7;
+}
+
+fn g() {
+    use m::aha;
+    let r = match (0,0) {
+        (0, aha) => 0,
+        //~^ ERROR static constant in pattern should have an uppercase id
+        (x, y)   => 1 + x + y,
+    };
+    assert!(r == 1);
+}
+
+fn main () {
+    f();
+    g();
+}

--- a/src/test/run-pass/match-static-const-rename.rs
+++ b/src/test/run-pass/match-static-const-rename.rs
@@ -1,0 +1,47 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #7526: lowercase static constants in patterns look like bindings
+
+// This is similar to compile-fail/match-static-const-lc, except it
+// shows the expected usual workaround (choosing a different name for
+// the static definition) and also demonstrates that one can work
+// around this problem locally by reanming the constant in the `use`
+// form to an uppercase identifier that placates the lint.
+
+#[deny(non_uppercase_pattern_statics)];
+
+pub static A : int = 97;
+
+fn f() {
+    let r = match (0,0) {
+        (0, A) => 0,
+        (x, y) => 1 + x + y,
+    };
+    assert!(r == 1);
+}
+
+mod m {
+    pub static aha : int = 7;
+}
+
+fn g() {
+    use AHA = m::aha;
+    let r = match (0,0) {
+        (0, AHA) => 0,
+        (x, y)   => 1 + x + y,
+    };
+    assert!(r == 1);
+}
+
+fn main () {
+    f();
+    g();
+}

--- a/src/test/run-pass/match-static-const-rename.rs
+++ b/src/test/run-pass/match-static-const-rename.rs
@@ -26,6 +26,11 @@ fn f() {
         (x, y) => 1 + x + y,
     };
     assert!(r == 1);
+    let r = match (0,97) {
+        (0, A) => 0,
+        (x, y) => 1 + x + y,
+    };
+    assert!(r == 0);
 }
 
 mod m {
@@ -39,6 +44,11 @@ fn g() {
         (x, y)   => 1 + x + y,
     };
     assert!(r == 1);
+    let r = match (0,7) {
+        (0, AHA) => 0,
+        (x, y)   => 1 + x + y,
+    };
+    assert!(r == 0);
 }
 
 fn h() {
@@ -47,6 +57,11 @@ fn h() {
         (x, y)      => 1 + x + y,
     };
     assert!(r == 1);
+    let r = match (0,7) {
+        (0, m::aha) => 0,
+        (x, y)      => 1 + x + y,
+    };
+    assert!(r == 0);
 }
 
 fn main () {

--- a/src/test/run-pass/match-static-const-rename.rs
+++ b/src/test/run-pass/match-static-const-rename.rs
@@ -38,7 +38,7 @@ mod m {
 }
 
 fn g() {
-    use AHA = m::aha;
+    use AHA = self::m::aha;
     let r = match (0,0) {
         (0, AHA) => 0,
         (x, y)   => 1 + x + y,
@@ -53,12 +53,12 @@ fn g() {
 
 fn h() {
     let r = match (0,0) {
-        (0, m::aha) => 0,
+        (0, self::m::aha) => 0,
         (x, y)      => 1 + x + y,
     };
     assert!(r == 1);
     let r = match (0,7) {
-        (0, m::aha) => 0,
+        (0, self::m::aha) => 0,
         (x, y)      => 1 + x + y,
     };
     assert!(r == 0);

--- a/src/test/run-pass/match-static-const-rename.rs
+++ b/src/test/run-pass/match-static-const-rename.rs
@@ -13,7 +13,7 @@
 // This is similar to compile-fail/match-static-const-lc, except it
 // shows the expected usual workaround (choosing a different name for
 // the static definition) and also demonstrates that one can work
-// around this problem locally by reanming the constant in the `use`
+// around this problem locally by renaming the constant in the `use`
 // form to an uppercase identifier that placates the lint.
 
 #[deny(non_uppercase_pattern_statics)];

--- a/src/test/run-pass/match-static-const-rename.rs
+++ b/src/test/run-pass/match-static-const-rename.rs
@@ -64,7 +64,7 @@ fn h() {
     assert!(r == 0);
 }
 
-fn main () {
+pub fn main () {
     f();
     g();
     h();

--- a/src/test/run-pass/match-static-const-rename.rs
+++ b/src/test/run-pass/match-static-const-rename.rs
@@ -41,7 +41,16 @@ fn g() {
     assert!(r == 1);
 }
 
+fn h() {
+    let r = match (0,0) {
+        (0, m::aha) => 0,
+        (x, y)      => 1 + x + y,
+    };
+    assert!(r == 1);
+}
+
 fn main () {
     f();
     g();
+    h();
 }


### PR DESCRIPTION
r? anyone

Address scariest part of #7526 by adding a new more specific lint (that is set to warn by default, rather than allow).
