### PR TITLE
Replace default_stat in std::path with a Default impl for libc::stat

### DIFF
--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -421,7 +421,7 @@ pub mod types {
                     st_blocks: blkcnt_t,
                     st_pad5: [c_long, ..14],
                 }
-                impl Default for stat{
+                impl Default for stat {
                     fn default() -> stat {
                         stat {
                             st_dev: 0,

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -299,11 +299,13 @@ pub mod types {
                 use libc::types::os::arch::posix88::{dev_t, gid_t, ino_t};
                 use libc::types::os::arch::posix88::{mode_t, off_t};
                 use libc::types::os::arch::posix88::{uid_t};
+                use default::Default;
 
                 pub type nlink_t = u32;
                 pub type blksize_t = i32;
                 pub type blkcnt_t = i32;
-
+                
+                #[deriving(Default)]
                 pub struct stat {
                     st_dev: dev_t,
                     __pad1: c_short,
@@ -332,6 +334,7 @@ pub mod types {
                 use libc::types::os::arch::c95::{c_uchar, c_uint, c_ulong, time_t};
                 use libc::types::os::arch::c99::{c_longlong, c_ulonglong};
                 use libc::types::os::arch::posix88::{uid_t, gid_t, ino_t};
+                use default::Default;
 
                 pub type nlink_t = u16;
                 pub type blksize_t = u32;
@@ -358,6 +361,31 @@ pub mod types {
                     st_ctime_nsec: c_ulong,
                     st_ino: c_ulonglong
                 }
+                impl Default for stat {
+                    fn default() -> stat {
+                        stat {
+                            st_dev: 0,
+                            __pad0: [0, ..4],
+                            __st_ino: 0,
+                            st_mode: 0,
+                            st_nlink: 0,
+                            st_uid: 0,
+                            st_gid: 0,
+                            st_rdev: 0,
+                            __pad3: [0, ..4],
+                            st_size: 0,
+                            st_blksize: 0,
+                            st_blocks: 0,
+                            st_atime: 0,
+                            st_atime_nsec: 0,
+                            st_mtime: 0,
+                            st_mtime_nsec: 0,
+                            st_ctime: 0,
+                            st_ctime_nsec: 0,
+                            st_ino: 0
+                        }
+                    }
+                }
             }
             #[cfg(target_arch = "mips")]
             pub mod posix01 {
@@ -365,6 +393,7 @@ pub mod types {
                 use libc::types::os::arch::posix88::{gid_t, ino_t};
                 use libc::types::os::arch::posix88::{mode_t, off_t};
                 use libc::types::os::arch::posix88::{uid_t};
+                use default::Default;
 
                 pub type nlink_t = u32;
                 pub type blksize_t = i32;
@@ -391,6 +420,32 @@ pub mod types {
                     st_blksize: blksize_t,
                     st_blocks: blkcnt_t,
                     st_pad5: [c_long, ..14],
+                }
+                impl Default for stat{
+                    fn default() -> stat {
+                        stat {
+                            st_dev: 0,
+                            st_pad1: [0, ..3],
+                            st_ino: 0,
+                            st_mode: 0,
+                            st_nlink: 0,
+                            st_uid: 0,
+                            st_gid: 0,
+                            st_rdev: 0,
+                            st_pad2: [0, ..2],
+                            st_size: 0,
+                            st_pad3: 0,
+                            st_atime: 0,
+                            st_atime_nsec: 0,
+                            st_mtime: 0,
+                            st_mtime_nsec: 0,
+                            st_ctime: 0,
+                            st_ctime_nsec: 0,
+                            st_blksize: 0,
+                            st_blocks: 0,
+                            st_pad5: [0, ..14],
+                        }
+                    }
                 }
             }
             pub mod posix08 {}
@@ -440,10 +495,12 @@ pub mod types {
                 use libc::types::os::arch::posix88::{dev_t, gid_t, ino_t};
                 use libc::types::os::arch::posix88::{mode_t, off_t};
                 use libc::types::os::arch::posix88::{uid_t};
+                use default::Default;
 
                 pub type nlink_t = u64;
                 pub type blksize_t = i64;
                 pub type blkcnt_t = i64;
+
                 pub struct stat {
                     st_dev: dev_t,
                     st_ino: ino_t,
@@ -463,6 +520,30 @@ pub mod types {
                     st_ctime: time_t,
                     st_ctime_nsec: c_long,
                     __unused: [c_long, ..3],
+                }
+                impl Default for stat {
+                    fn default() -> stat {
+                        stat {
+                            st_dev: 0,
+                            st_ino: 0,
+                            st_nlink: 0,
+                            st_mode: 0,
+                            st_uid: 0,
+                            st_gid: 0,
+                            __pad0: 0,
+                            st_rdev: 0,
+                            st_size: 0,
+                            st_blksize: 0,
+                            st_blocks: 0,
+                            st_atime: 0,
+                            st_atime_nsec: 0,
+                            st_mtime: 0,
+                            st_mtime_nsec: 0,
+                            st_ctime: 0,
+                            st_ctime_nsec: 0,
+                            __unused: [0, 0, 0],
+                        }
+                    }
                 }
             }
             pub mod posix08 {
@@ -541,11 +622,13 @@ pub mod types {
                 use libc::types::os::arch::posix88::{dev_t, gid_t, ino_t};
                 use libc::types::os::arch::posix88::{mode_t, off_t};
                 use libc::types::os::arch::posix88::{uid_t};
+                use default::Default;
 
                 pub type nlink_t = u16;
                 pub type blksize_t = i64;
                 pub type blkcnt_t = i64;
                 pub type fflags_t = u32;
+
                 pub struct stat {
                     st_dev: dev_t,
                     st_ino: ino_t,
@@ -570,6 +653,34 @@ pub mod types {
                     st_birthtime_nsec: c_long,
                     __unused: [uint8_t, ..2],
                 }
+                impl Default for stat {
+                    fn default() -> stat {
+                        stat {
+                            st_dev: 0,
+                            st_ino: 0,
+                            st_mode: 0,
+                            st_nlink: 0,
+                            st_uid: 0,
+                            st_gid: 0,
+                            st_rdev: 0,
+                            st_atime: 0,
+                            st_atime_nsec: 0,
+                            st_mtime: 0,
+                            st_mtime_nsec: 0,
+                            st_ctime: 0,
+                            st_ctime_nsec: 0,
+                            st_size: 0,
+                            st_blocks: 0,
+                            st_blksize: 0,
+                            st_flags: 0,
+                            st_gen: 0,
+                            st_lspare: 0,
+                            st_birthtime: 0,
+                            st_birthtime_nsec: 0,
+                            __unused: [0, 0],
+                        }
+                    }
+                }
             }
             pub mod posix08 {
             }
@@ -588,9 +699,11 @@ pub mod types {
                 use libc::types::os::arch::extra::{int64, time64_t};
                 use libc::types::os::arch::posix88::{dev_t, ino_t};
                 use libc::types::os::arch::posix88::mode_t;
+                use default::Default;
 
                 // Note: this is the struct called stat64 in win32. Not stat,
                 // nor stati64.
+                #[deriving(Default)]
                 pub struct stat {
                     st_dev: dev_t,
                     st_ino: ino_t,
@@ -1006,6 +1119,7 @@ pub mod types {
                 use libc::types::os::arch::c95::{c_long, time_t};
                 use libc::types::os::arch::posix88::{dev_t, gid_t, ino_t,
                                                      mode_t, off_t, uid_t};
+                use default::Default;
 
                 pub type nlink_t = u16;
                 pub type blksize_t = i64;
@@ -1034,6 +1148,34 @@ pub mod types {
                     st_gen: uint32_t,
                     st_lspare: int32_t,
                     st_qspare: [int64_t, ..2],
+                }
+                impl Default for stat {
+                    fn default() -> stat {
+                        stat {
+                            st_dev: 0,
+                            st_mode: 0,
+                            st_nlink: 0,
+                            st_ino: 0,
+                            st_uid: 0,
+                            st_gid: 0,
+                            st_rdev: 0,
+                            st_atime: 0,
+                            st_atime_nsec: 0,
+                            st_mtime: 0,
+                            st_mtime_nsec: 0,
+                            st_ctime: 0,
+                            st_ctime_nsec: 0,
+                            st_birthtime: 0,
+                            st_birthtime_nsec: 0,
+                            st_size: 0,
+                            st_blocks: 0,
+                            st_blksize: 0,
+                            st_flags: 0,
+                            st_gen: 0,
+                            st_lspare: 0,
+                            st_qspare: [0, 0],
+                        }
+                    }
                 }
             }
             pub mod posix08 {
@@ -1087,6 +1229,7 @@ pub mod types {
                 use libc::types::os::arch::c95::{c_long, time_t};
                 use libc::types::os::arch::posix88::{dev_t, gid_t, ino_t};
                 use libc::types::os::arch::posix88::{mode_t, off_t, uid_t};
+                use default::Default;
 
                 pub type nlink_t = u16;
                 pub type blksize_t = i64;
@@ -1115,6 +1258,34 @@ pub mod types {
                     st_gen: uint32_t,
                     st_lspare: int32_t,
                     st_qspare: [int64_t, ..2],
+                }
+                impl Default for stat {
+                    fn default() -> stat {
+                        stat {
+                            st_dev: 0,
+                            st_mode: 0,
+                            st_nlink: 0,
+                            st_ino: 0,
+                            st_uid: 0,
+                            st_gid: 0,
+                            st_rdev: 0,
+                            st_atime: 0,
+                            st_atime_nsec: 0,
+                            st_mtime: 0,
+                            st_mtime_nsec: 0,
+                            st_ctime: 0,
+                            st_ctime_nsec: 0,
+                            st_birthtime: 0,
+                            st_birthtime_nsec: 0,
+                            st_size: 0,
+                            st_blocks: 0,
+                            st_blksize: 0,
+                            st_flags: 0,
+                            st_gen: 0,
+                            st_lspare: 0,
+                            st_qspare: [0, 0],
+                        }
+                    }
                 }
             }
             pub mod posix08 {

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -29,6 +29,7 @@ use str::{OwnedStr, Str, StrSlice, StrVector};
 use to_str::ToStr;
 use ascii::{AsciiCast, AsciiStr};
 use vec::{Vector, OwnedVector, ImmutableVector, OwnedCopyableVector};
+use default::Default;
 
 #[cfg(windows)]
 pub use Path = self::WindowsPath;
@@ -251,224 +252,12 @@ pub trait GenericPath : Clone + Eq + ToStr {
     fn components<'a>(&'a self) -> &'a [~str];
 }
 
-#[cfg(target_os = "linux")]
-#[cfg(target_os = "android")]
-mod stat {
-    #[cfg(target_arch = "x86")]
-    pub mod arch {
-        use libc;
-
-        pub fn default_stat() -> libc::stat {
-            libc::stat {
-                st_dev: 0,
-                __pad1: 0,
-                st_ino: 0,
-                st_mode: 0,
-                st_nlink: 0,
-                st_uid: 0,
-                st_gid: 0,
-                st_rdev: 0,
-                __pad2: 0,
-                st_size: 0,
-                st_blksize: 0,
-                st_blocks: 0,
-                st_atime: 0,
-                st_atime_nsec: 0,
-                st_mtime: 0,
-                st_mtime_nsec: 0,
-                st_ctime: 0,
-                st_ctime_nsec: 0,
-                __unused4: 0,
-                __unused5: 0,
-            }
-        }
-    }
-
-    #[cfg(target_arch = "arm")]
-    pub mod arch {
-        use libc;
-
-        pub fn default_stat() -> libc::stat {
-            libc::stat {
-                st_dev: 0,
-                __pad0: [0, ..4],
-                __st_ino: 0,
-                st_mode: 0,
-                st_nlink: 0,
-                st_uid: 0,
-                st_gid: 0,
-                st_rdev: 0,
-                __pad3: [0, ..4],
-                st_size: 0,
-                st_blksize: 0,
-                st_blocks: 0,
-                st_atime: 0,
-                st_atime_nsec: 0,
-                st_mtime: 0,
-                st_mtime_nsec: 0,
-                st_ctime: 0,
-                st_ctime_nsec: 0,
-                st_ino: 0
-            }
-        }
-    }
-
-    #[cfg(target_arch = "mips")]
-    pub mod arch {
-        use libc;
-
-        pub fn default_stat() -> libc::stat {
-            libc::stat {
-                st_dev: 0,
-                st_pad1: [0, ..3],
-                st_ino: 0,
-                st_mode: 0,
-                st_nlink: 0,
-                st_uid: 0,
-                st_gid: 0,
-                st_rdev: 0,
-                st_pad2: [0, ..2],
-                st_size: 0,
-                st_pad3: 0,
-                st_atime: 0,
-                st_atime_nsec: 0,
-                st_mtime: 0,
-                st_mtime_nsec: 0,
-                st_ctime: 0,
-                st_ctime_nsec: 0,
-                st_blksize: 0,
-                st_blocks: 0,
-                st_pad5: [0, ..14],
-            }
-        }
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    pub mod arch {
-        use libc;
-
-        pub fn default_stat() -> libc::stat {
-            libc::stat {
-                st_dev: 0,
-                st_ino: 0,
-                st_nlink: 0,
-                st_mode: 0,
-                st_uid: 0,
-                st_gid: 0,
-                __pad0: 0,
-                st_rdev: 0,
-                st_size: 0,
-                st_blksize: 0,
-                st_blocks: 0,
-                st_atime: 0,
-                st_atime_nsec: 0,
-                st_mtime: 0,
-                st_mtime_nsec: 0,
-                st_ctime: 0,
-                st_ctime_nsec: 0,
-                __unused: [0, 0, 0],
-            }
-        }
-    }
-}
-
-#[cfg(target_os = "freebsd")]
-mod stat {
-    #[cfg(target_arch = "x86_64")]
-    pub mod arch {
-        use libc;
-
-        pub fn default_stat() -> libc::stat {
-            libc::stat {
-                st_dev: 0,
-                st_ino: 0,
-                st_mode: 0,
-                st_nlink: 0,
-                st_uid: 0,
-                st_gid: 0,
-                st_rdev: 0,
-                st_atime: 0,
-                st_atime_nsec: 0,
-                st_mtime: 0,
-                st_mtime_nsec: 0,
-                st_ctime: 0,
-                st_ctime_nsec: 0,
-                st_size: 0,
-                st_blocks: 0,
-                st_blksize: 0,
-                st_flags: 0,
-                st_gen: 0,
-                st_lspare: 0,
-                st_birthtime: 0,
-                st_birthtime_nsec: 0,
-                __unused: [0, 0],
-            }
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-mod stat {
-    pub mod arch {
-        use libc;
-
-        pub fn default_stat() -> libc::stat {
-            libc::stat {
-                st_dev: 0,
-                st_mode: 0,
-                st_nlink: 0,
-                st_ino: 0,
-                st_uid: 0,
-                st_gid: 0,
-                st_rdev: 0,
-                st_atime: 0,
-                st_atime_nsec: 0,
-                st_mtime: 0,
-                st_mtime_nsec: 0,
-                st_ctime: 0,
-                st_ctime_nsec: 0,
-                st_birthtime: 0,
-                st_birthtime_nsec: 0,
-                st_size: 0,
-                st_blocks: 0,
-                st_blksize: 0,
-                st_flags: 0,
-                st_gen: 0,
-                st_lspare: 0,
-                st_qspare: [0, 0],
-            }
-        }
-    }
-}
-
-#[cfg(target_os = "win32")]
-mod stat {
-    pub mod arch {
-        use libc;
-        pub fn default_stat() -> libc::stat {
-            libc::stat {
-                st_dev: 0,
-                st_ino: 0,
-                st_mode: 0,
-                st_nlink: 0,
-                st_uid: 0,
-                st_gid: 0,
-                st_rdev: 0,
-                st_size: 0,
-                st_atime: 0,
-                st_mtime: 0,
-                st_ctime: 0,
-            }
-        }
-    }
-}
-
 #[cfg(target_os = "win32")]
 impl WindowsPath {
     pub fn stat(&self) -> Option<libc::stat> {
         #[fixed_stack_segment]; #[inline(never)];
         do self.with_c_str |buf| {
-            let mut st = stat::arch::default_stat();
+            let mut st = Default::default();
             match unsafe { libc::stat(buf, &mut st) } {
                 0 => Some(st),
                 _ => None,
@@ -503,7 +292,7 @@ impl PosixPath {
     pub fn stat(&self) -> Option<libc::stat> {
         #[fixed_stack_segment]; #[inline(never)];
         do self.with_c_str |buf| {
-            let mut st = stat::arch::default_stat();
+            let mut st = Default::default();
             match unsafe { libc::stat(buf as *libc::c_char, &mut st) } {
                 0 => Some(st),
                 _ => None,
@@ -582,7 +371,7 @@ impl PosixPath {
     pub fn lstat(&self) -> Option<libc::stat> {
         #[fixed_stack_segment]; #[inline(never)];
         do self.with_c_str |buf| {
-            let mut st = stat::arch::default_stat();
+            let mut st = Default::default();
             match unsafe { libc::lstat(buf, &mut st) } {
                 0 => Some(st),
                 _ => None,

--- a/src/libstd/std.rs
+++ b/src/libstd/std.rs
@@ -224,4 +224,5 @@ mod std {
     pub use fmt;
     pub use to_bytes;
     pub use logging;
+    pub use default;
 }


### PR DESCRIPTION
Instead of the internal `default_stat` function in `std::path`, make the `stat` structure implement `Default` and have the path code use that.  Closes #9537.  Alternative to #9637.
