### PR TITLE
debuginfo: Unified namespace generation approach for crate-local and external items.

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1968,7 +1968,8 @@ pub mod llvm {
                                              DerivedFrom: DIType,
                                              Elements: DIArray,
                                              RunTimeLang: c_uint,
-                                             VTableHolder: ValueRef)
+                                             VTableHolder: ValueRef,
+                                             UniqueId: *c_char)
                                              -> DICompositeType;
 
         #[fast_ffi]

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -3119,11 +3119,6 @@ pub fn trans_crate(sess: session::Session,
                                      symbol_hasher,
                                      link_meta,
                                      analysis.reachable);
-
-    if ccx.sess.opts.debuginfo {
-        debuginfo::initialize(ccx, &crate);
-    }
-
     {
         let _icx = push_ctxt("text");
         trans_mod(ccx, &crate.module);

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -548,14 +548,21 @@ extern "C" LLVMValueRef LLVMDIBuilderCreateStructType(
     LLVMValueRef DerivedFrom,
     LLVMValueRef Elements,
     unsigned RunTimeLang,
-    LLVMValueRef VTableHolder) {
+    LLVMValueRef VTableHolder,
+    const char *UniqueId) {
     return wrap(Builder->createStructType(
-        unwrapDI<DIDescriptor>(Scope), Name,
-        unwrapDI<DIFile>(File), LineNumber,
-        SizeInBits, AlignInBits, Flags,
+        unwrapDI<DIDescriptor>(Scope),
+        Name,
+        unwrapDI<DIFile>(File),
+        LineNumber,
+        SizeInBits,
+        AlignInBits,
+        Flags,
         unwrapDI<DIType>(DerivedFrom),
-        unwrapDI<DIArray>(Elements), RunTimeLang,
-        unwrapDI<MDNode*>(VTableHolder)));
+        unwrapDI<DIArray>(Elements),
+        RunTimeLang,
+        unwrapDI<MDNode*>(VTableHolder),
+        UniqueId));
 }
 
 extern "C" LLVMValueRef LLVMDIBuilderCreateMemberType(


### PR DESCRIPTION
This should fix some outstanding namespace issues. It also fixes an issue with LLVM metadata uniquing that caused an LLVM assertion when compiling libstd.

One thing to keep in mind is that the `-O` flag and the debug info flags are essentially incompatible. It may work but I would not consider this in any way supported at the moment. On the other hand, there is also good news: With the changes in this PR I am able to compile all of rust with extra-debug-info:

```
make RUSTFLAGS_STAGE2='-Zextra-debug-info' check
```

compiles the whole thing without warning and passes the whole test suite (given that `configure` is run with `--disable-optimize`). That's kind of nice `:)` Still, I'm reluctant to automatically close the related issues (#9167, #9190, #9268) without confirmation from the openers. I'll post to the individual threads once this gets merged.
