### PR TITLE
Fix usage of the old debug! macros

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -821,7 +821,7 @@ pub fn std_macros() -> @str {
                 if lvl <= __log_level() {
                     format_args!(|args| {
                         ::std::logging::log(lvl, args)
-                    }, \"{}\", fmt!(\"{:?}\", $arg))
+                    }, \"{}\", fmt!(\"%?\", $arg))
                 }
             });
             ($lvl:expr, $($arg:expr),+) => ({


### PR DESCRIPTION
I was a little too trigger-happy in migrating from `format!` to `fmt!`...
