### PR TITLE
Clearer error message for external trait and type

### DIFF
--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -216,8 +216,8 @@ impl visit::Visitor<()> for PrivilegedScopeVisitor {
                             if trait_def_id.crate != LOCAL_CRATE {
                                 let session = self.cc.crate_context.tcx.sess;
                                 session.span_err(item.span,
-                                                 "cannot provide an extension implementation \
-                                                  for a trait not defined in this crate");
+                                        "cannot provide an extension implementation \
+                                        where both trait and type are not defined in this crate");
                             }
                         }
 


### PR DESCRIPTION
The old error message implied that external traits could never
be implemented locally.
