### PR TITLE
Remove unnecessary mutability in WatcherInterop

### DIFF
--- a/src/libstd/rt/uv/async.rs
+++ b/src/libstd/rt/uv/async.rs
@@ -24,7 +24,7 @@ impl AsyncWatcher {
         unsafe {
             let handle = uvll::malloc_handle(UV_ASYNC);
             assert!(handle.is_not_null());
-            let mut watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
+            let watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
             watcher.install_watcher_data();
             let data = watcher.get_watcher_data();
             data.async_cb = Some(cb);
@@ -33,7 +33,7 @@ impl AsyncWatcher {
         }
 
         extern fn async_cb(handle: *uvll::uv_async_t, status: c_int) {
-            let mut watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
+            let watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
             let status = status_to_maybe_uv_error(status);
             let data = watcher.get_watcher_data();
             let cb = data.async_cb.get_ref();
@@ -41,7 +41,7 @@ impl AsyncWatcher {
         }
     }
 
-    pub fn send(&mut self) {
+    pub fn send(&self) {
         unsafe {
             let handle = self.native_handle();
             uvll::async_send(handle);
@@ -49,8 +49,7 @@ impl AsyncWatcher {
     }
 
     pub fn close(self, cb: NullCallback) {
-        let mut this = self;
-        let data = this.get_watcher_data();
+        let data = self.get_watcher_data();
         assert!(data.close_cb.is_none());
         data.close_cb = Some(cb);
 
@@ -59,7 +58,7 @@ impl AsyncWatcher {
         }
 
         extern fn close_cb(handle: *uvll::uv_stream_t) {
-            let mut watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
+            let watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
             {
                 let data = watcher.get_watcher_data();
                 data.close_cb.take_unwrap()();
@@ -95,7 +94,7 @@ mod test {
             let watcher = AsyncWatcher::new(&mut loop_, |w, _| w.close(||()) );
             let watcher_cell = Cell::new(watcher);
             let thread = do Thread::start {
-                let mut watcher = watcher_cell.take();
+                let watcher = watcher_cell.take();
                 watcher.send();
             };
             loop_.run();

--- a/src/libstd/rt/uv/mod.rs
+++ b/src/libstd/rt/uv/mod.rs
@@ -157,9 +157,9 @@ struct WatcherData {
 
 pub trait WatcherInterop {
     fn event_loop(&self) -> Loop;
-    fn install_watcher_data(&mut self);
-    fn get_watcher_data<'r>(&'r mut self) -> &'r mut WatcherData;
-    fn drop_watcher_data(&mut self);
+    fn install_watcher_data(&self);
+    fn get_watcher_data<'r>(&'r self) -> &'r mut WatcherData;
+    fn drop_watcher_data(&self);
 }
 
 impl<H, W: Watcher + NativeHandle<*H>> WatcherInterop for W {
@@ -172,7 +172,7 @@ impl<H, W: Watcher + NativeHandle<*H>> WatcherInterop for W {
         }
     }
 
-    fn install_watcher_data(&mut self) {
+    fn install_watcher_data(&self) {
         unsafe {
             let data = ~WatcherData {
                 read_cb: None,
@@ -192,7 +192,7 @@ impl<H, W: Watcher + NativeHandle<*H>> WatcherInterop for W {
         }
     }
 
-    fn get_watcher_data<'r>(&'r mut self) -> &'r mut WatcherData {
+    fn get_watcher_data<'r>(&'r self) -> &'r mut WatcherData {
         unsafe {
             let data = uvll::get_data_for_uv_handle(self.native_handle());
             let data = transmute::<&*c_void, &mut ~WatcherData>(&data);
@@ -200,7 +200,7 @@ impl<H, W: Watcher + NativeHandle<*H>> WatcherInterop for W {
         }
     }
 
-    fn drop_watcher_data(&mut self) {
+    fn drop_watcher_data(&self) {
         unsafe {
             let data = uvll::get_data_for_uv_handle(self.native_handle());
             let _data = transmute::<*c_void, ~WatcherData>(data);

--- a/src/libstd/rt/uv/pipe.rs
+++ b/src/libstd/rt/uv/pipe.rs
@@ -26,8 +26,7 @@ impl Pipe {
             assert!(handle.is_not_null());
             let ipc = ipc as libc::c_int;
             assert_eq!(uvll::pipe_init(loop_.native_handle(), handle, ipc), 0);
-            let mut ret: Pipe =
-                    uv::NativeHandle::from_native_handle(handle);
+            let ret: Pipe = uv::NativeHandle::from_native_handle(handle);
             ret.install_watcher_data();
             ret
         }
@@ -38,17 +37,14 @@ impl Pipe {
     }
 
     pub fn close(self, cb: uv::NullCallback) {
-        {
-            let mut this = self;
-            let data = this.get_watcher_data();
-            assert!(data.close_cb.is_none());
-            data.close_cb = Some(cb);
-        }
+        let data = self.get_watcher_data();
+        assert!(data.close_cb.is_none());
+        data.close_cb = Some(cb);
 
         unsafe { uvll::close(self.native_handle(), close_cb); }
 
         extern fn close_cb(handle: *uvll::uv_pipe_t) {
-            let mut process: Pipe = uv::NativeHandle::from_native_handle(handle);
+            let process: Pipe = uv::NativeHandle::from_native_handle(handle);
             process.get_watcher_data().close_cb.take_unwrap()();
             process.drop_watcher_data();
             unsafe { uvll::free_handle(handle as *libc::c_void) }


### PR DESCRIPTION
Mutable instances are not necessary for WatcherInterop, the patch changes that.

@nikomatsakis r?
