### PR TITLE
Stop using newtype wrappers in std::rt::io

### DIFF
--- a/src/libstd/rt/io/native/file.rs
+++ b/src/libstd/rt/io/native/file.rs
@@ -17,8 +17,9 @@ use libc::{c_int, FILE};
 #[allow(non_camel_case_types)]
 pub type fd_t = c_int;
 
-// Make this a newtype so we can't do I/O on arbitrary integers
-pub struct FileDesc(fd_t);
+pub struct FileDesc {
+    priv fd: fd_t
+}
 
 impl FileDesc {
     /// Create a `FileDesc` from an open C file descriptor.
@@ -46,7 +47,9 @@ impl Seek for FileDesc {
     fn seek(&mut self, _pos: i64, _style: SeekStyle) { fail2!() }
 }
 
-pub struct CFile(*FILE);
+pub struct CFile {
+    priv file: *FILE
+}
 
 impl CFile {
     /// Create a `CFile` from an open `FILE` pointer.

--- a/src/libstd/rt/io/net/tcp.rs
+++ b/src/libstd/rt/io/net/tcp.rs
@@ -20,11 +20,13 @@ use rt::rtio::{IoFactory, IoFactoryObject,
                RtioTcpStream, RtioTcpStreamObject};
 use rt::local::Local;
 
-pub struct TcpStream(~RtioTcpStreamObject);
+pub struct TcpStream {
+    priv obj: ~RtioTcpStreamObject
+}
 
 impl TcpStream {
     fn new(s: ~RtioTcpStreamObject) -> TcpStream {
-        TcpStream(s)
+        TcpStream { obj: s }
     }
 
     pub fn connect(addr: SocketAddr) -> Option<TcpStream> {
@@ -46,7 +48,7 @@ impl TcpStream {
     }
 
     pub fn peer_name(&mut self) -> Option<SocketAddr> {
-        match (**self).peer_name() {
+        match self.obj.peer_name() {
             Ok(pn) => Some(pn),
             Err(ioerr) => {
                 rtdebug!("failed to get peer name: {:?}", ioerr);
@@ -57,7 +59,7 @@ impl TcpStream {
     }
 
     pub fn socket_name(&mut self) -> Option<SocketAddr> {
-        match (**self).socket_name() {
+        match self.obj.socket_name() {
             Ok(sn) => Some(sn),
             Err(ioerr) => {
                 rtdebug!("failed to get socket name: {:?}", ioerr);
@@ -70,7 +72,7 @@ impl TcpStream {
 
 impl Reader for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
-        match (**self).read(buf) {
+        match self.obj.read(buf) {
             Ok(read) => Some(read),
             Err(ioerr) => {
                 // EOF is indicated by returning None
@@ -87,7 +89,7 @@ impl Reader for TcpStream {
 
 impl Writer for TcpStream {
     fn write(&mut self, buf: &[u8]) {
-        match (**self).write(buf) {
+        match self.obj.write(buf) {
             Ok(_) => (),
             Err(ioerr) => io_error::cond.raise(ioerr),
         }
@@ -96,7 +98,9 @@ impl Writer for TcpStream {
     fn flush(&mut self) { /* no-op */ }
 }
 
-pub struct TcpListener(~RtioTcpListenerObject);
+pub struct TcpListener {
+    priv obj: ~RtioTcpListenerObject
+}
 
 impl TcpListener {
     pub fn bind(addr: SocketAddr) -> Option<TcpListener> {
@@ -105,7 +109,7 @@ impl TcpListener {
             (*io).tcp_bind(addr)
         };
         match listener {
-            Ok(l) => Some(TcpListener(l)),
+            Ok(l) => Some(TcpListener { obj: l }),
             Err(ioerr) => {
                 io_error::cond.raise(ioerr);
                 return None;
@@ -114,7 +118,7 @@ impl TcpListener {
     }
 
     pub fn socket_name(&mut self) -> Option<SocketAddr> {
-        match (**self).socket_name() {
+        match self.obj.socket_name() {
             Ok(sn) => Some(sn),
             Err(ioerr) => {
                 rtdebug!("failed to get socket name: {:?}", ioerr);
@@ -127,8 +131,8 @@ impl TcpListener {
 
 impl Listener<TcpStream, TcpAcceptor> for TcpListener {
     fn listen(self) -> Option<TcpAcceptor> {
-        match (**self).listen() {
-            Ok(acceptor) => Some(TcpAcceptor(acceptor)),
+        match self.obj.listen() {
+            Ok(acceptor) => Some(TcpAcceptor { obj: acceptor }),
             Err(ioerr) => {
                 io_error::cond.raise(ioerr);
                 None
@@ -137,11 +141,13 @@ impl Listener<TcpStream, TcpAcceptor> for TcpListener {
     }
 }
 
-pub struct TcpAcceptor(~RtioTcpAcceptorObject);
+pub struct TcpAcceptor {
+    priv obj: ~RtioTcpAcceptorObject
+}
 
 impl Acceptor<TcpStream> for TcpAcceptor {
     fn accept(&mut self) -> Option<TcpStream> {
-        match (**self).accept() {
+        match self.obj.accept() {
             Ok(s) => Some(TcpStream::new(s)),
             Err(ioerr) => {
                 io_error::cond.raise(ioerr);

--- a/src/libstd/rt/io/net/udp.rs
+++ b/src/libstd/rt/io/net/udp.rs
@@ -16,7 +16,9 @@ use rt::io::{io_error, read_error, EndOfFile};
 use rt::rtio::{RtioSocket, RtioUdpSocketObject, RtioUdpSocket, IoFactory, IoFactoryObject};
 use rt::local::Local;
 
-pub struct UdpSocket(~RtioUdpSocketObject);
+pub struct UdpSocket {
+    priv obj: ~RtioUdpSocketObject
+}
 
 impl UdpSocket {
     pub fn bind(addr: SocketAddr) -> Option<UdpSocket> {
@@ -25,7 +27,7 @@ impl UdpSocket {
             (*factory).udp_bind(addr)
         };
         match socket {
-            Ok(s) => Some(UdpSocket(s)),
+            Ok(s) => Some(UdpSocket { obj: s }),
             Err(ioerr) => {
                 io_error::cond.raise(ioerr);
                 None
@@ -34,7 +36,7 @@ impl UdpSocket {
     }
 
     pub fn recvfrom(&mut self, buf: &mut [u8]) -> Option<(uint, SocketAddr)> {
-        match (**self).recvfrom(buf) {
+        match self.obj.recvfrom(buf) {
             Ok((nread, src)) => Some((nread, src)),
             Err(ioerr) => {
                 // EOF is indicated by returning None
@@ -47,7 +49,7 @@ impl UdpSocket {
     }
 
     pub fn sendto(&mut self, buf: &[u8], dst: SocketAddr) {
-        match (**self).sendto(buf, dst) {
+        match self.obj.sendto(buf, dst) {
             Ok(_) => (),
             Err(ioerr) => io_error::cond.raise(ioerr),
         }
@@ -58,7 +60,7 @@ impl UdpSocket {
     }
 
     pub fn socket_name(&mut self) -> Option<SocketAddr> {
-        match (***self).socket_name() {
+        match self.obj.socket_name() {
             Ok(sn) => Some(sn),
             Err(ioerr) => {
                 rtdebug!("failed to get socket name: {:?}", ioerr);
@@ -70,8 +72,8 @@ impl UdpSocket {
 }
 
 pub struct UdpStream {
-    socket: UdpSocket,
-    connectedTo: SocketAddr
+    priv socket: UdpSocket,
+    priv connectedTo: SocketAddr
 }
 
 impl UdpStream {

--- a/src/libstd/rt/io/timer.rs
+++ b/src/libstd/rt/io/timer.rs
@@ -15,7 +15,9 @@ use rt::rtio::{IoFactory, IoFactoryObject,
                RtioTimer, RtioTimerObject};
 use rt::local::Local;
 
-pub struct Timer(~RtioTimerObject);
+pub struct Timer {
+    priv obj: ~RtioTimerObject
+}
 
 /// Sleep the current task for `msecs` milliseconds.
 pub fn sleep(msecs: u64) {
@@ -34,7 +36,7 @@ impl Timer {
             (*io).timer_init()
         };
         match timer {
-            Ok(t) => Some(Timer(t)),
+            Ok(t) => Some(Timer { obj: t }),
             Err(ioerr) => {
                 rtdebug!("Timer::init: failed to init: {:?}", ioerr);
                 io_error::cond.raise(ioerr);
@@ -44,7 +46,7 @@ impl Timer {
     }
 
     pub fn sleep(&mut self, msecs: u64) {
-        (**self).sleep(msecs);
+        self.obj.sleep(msecs);
     }
 }
 

--- a/src/test/run-pass/rtio-processes.rs
+++ b/src/test/run-pass/rtio-processes.rs
@@ -84,7 +84,7 @@ fn read_all(input: &mut Reader) -> ~str {
     let mut buf = [0, ..1024];
     loop {
         match input.read(buf) {
-            None | Some(0) => { break }
+            None => { break }
             Some(n) => { ret = ret + str::from_utf8(buf.slice_to(n)); }
         }
     }


### PR DESCRIPTION
UnboundedPipeStream is still a newtype since process::set_stdio needs to
look into its internals.

Closes #9667
