### PR TITLE
make unit structs and C-like enums immediate

### DIFF
--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -75,6 +75,9 @@ pub fn type_is_immediate(ccx: &mut CrateContext, ty: ty::t) -> bool {
     }
     match ty::get(ty).sty {
         // FIXME: #9651: small `ty_struct` should also be immediate
+        ty::ty_struct(def_id, ref substs) => {
+            ty::struct_fields(tcx, def_id, substs).is_empty()
+        }
         ty::ty_enum(*) | ty::ty_tup(*) => {
             let llty = sizing_type_of(ccx, ty);
             llsize_of_alloc(ccx, llty) <= llsize_of_alloc(ccx, ccx.int_type)

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -69,10 +69,6 @@ pub fn type_is_immediate(ccx: &mut CrateContext, ty: ty::t) -> bool {
     if simple {
         return true;
     }
-    // FIXME: #9651: C-like enums should also be immediate
-    if ty::type_is_c_like_enum(ccx.tcx, ty) {
-        return false;
-    }
     match ty::get(ty).sty {
         // FIXME: #9651: small `ty_struct` should also be immediate
         ty::ty_struct(def_id, ref substs) => {

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1727,7 +1727,9 @@ fn trans_imm_cast(bcx: @mut Block, expr: &ast::Expr,
             (cast_enum, cast_float) => {
                 let bcx = bcx;
                 let repr = adt::represent_type(ccx, t_in);
-                let lldiscrim_a = adt::trans_get_discr(bcx, repr, llexpr);
+                let slot = Alloca(bcx, ll_t_in, "");
+                Store(bcx, llexpr, slot);
+                let lldiscrim_a = adt::trans_get_discr(bcx, repr, slot);
                 match k_out {
                     cast_integral => int_cast(bcx, ll_t_out,
                                               val_ty(lldiscrim_a),

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -222,7 +222,7 @@ pub fn trans_native_call(bcx: @mut Block,
         // Ensure that we always have the Rust value indirectly,
         // because it makes bitcasting easier.
         if !rust_indirect {
-            let scratch = base::alloca(bcx, arg_tys[i].ty, "__arg");
+            let scratch = base::alloca(bcx, type_of::type_of(ccx, fn_sig.inputs[i]), "__arg");
             Store(bcx, llarg_rust, scratch);
             llarg_rust = scratch;
         }

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -12,7 +12,7 @@
 
 use back::{abi};
 use lib::llvm::{SequentiallyConsistent, Acquire, Release, Xchg};
-use lib::llvm::{ValueRef, Pointer};
+use lib::llvm::{ValueRef, Pointer, Array, Struct};
 use lib;
 use middle::trans::base::*;
 use middle::trans::build::*;
@@ -333,8 +333,12 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
                             (Pointer, other) | (other, Pointer) if other != Pointer => {
                                 let tmp = Alloca(bcx, llouttype, "");
                                 Store(bcx, llsrcval, PointerCast(bcx, tmp, llintype.ptr_to()));
-                                let ll_load = Load(bcx, tmp);
-                                Ret(bcx, ll_load);
+                                Ret(bcx, Load(bcx, tmp));
+                            }
+                            (Array, _) | (_, Array) | (Struct, _) | (_, Struct) => {
+                                let tmp = Alloca(bcx, llouttype, "");
+                                Store(bcx, llsrcval, PointerCast(bcx, tmp, llintype.ptr_to()));
+                                Ret(bcx, Load(bcx, tmp));
                             }
                             _ => {
                                 let llbitcast = BitCast(bcx, llsrcval, llouttype);


### PR DESCRIPTION
```
struct Foo;
fn foo() -> Foo { Foo }
```

Before:

```
; Function Attrs: nounwind readnone uwtable
define void @_ZN3foo18he8ca29755dedebbaf4v0.0E(%struct.Foo* noalias nocapture sret, { i64, %tydesc*, i8*, i8*, i8 }* nocapture) #0 {
"function top level":
  ret void
}
```

After:

```
; Function Attrs: nounwind readnone uwtable
define %struct.Foo @_ZN3foo18he8ca29755dedebbaf4v0.0E({ i64, %tydesc*, i8*, i8*, i8 }* nocapture readnone) #0 {
"function top level":
  ret %struct.Foo undef
}
```
