### PR TITLE
Compiler #[feature] directives

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -1833,6 +1833,58 @@ fn main() {
 > individual functions, structs, methods and enum variants, *not* to
 > entire modules, traits, impls or enums themselves.
 
+### Compiler Features
+
+Certain aspects of Rust may be implemented in the compiler, but they're not
+necessarily ready for every-day use. These features are often of "prototype
+quality" or "almost production ready", but may not be stable enough to be
+considered a full-fleged language feature.
+
+For this reason, rust recognizes a special crate-level attribute of the form:
+
+~~~ {.xfail-test}
+#[feature(feature1, feature2, feature3)]
+~~~
+
+This directive informs the compiler that the feature list: `feature1`,
+`feature2`, and `feature3` should all be enabled. This is only recognized at a
+crate-level, not at a module-level. Without this directive, all features are
+considered off, and using the features will result in a compiler error.
+
+The currently implemented features of the compiler are:
+
+* `macro_rules` - The definition of new macros. This does not encompass
+                  macro-invocation, that is always enabled by default, this only
+                  covers the definition of new macros. There are currently
+                  various problems with invoking macros, how they interact with
+                  their environment, and possibly how they are used outside of
+                  location in which they are defined. Macro definitions are
+                  likely to change slightly in the future, so they are currently
+                  hidden behind this feature.
+
+* `globs` - Importing everything in a module through `*`. This is currently a
+            large source of bugs in name resolution for Rust, and it's not clear
+            whether this will continue as a feature or not. For these reasons,
+            the glob import statement has been hidden behind this feature flag.
+
+* `struct_variant` - Structural enum variants (those with named fields). It is
+                     currently unknown whether this style of enum variant is as
+                     fully supported as the tuple-forms, and it's not certain
+                     that this style of variant should remain in the language.
+                     For now this style of variant is hidden behind a feature
+                     flag.
+
+If a feature is promoted to a language feature, then all existing programs will
+start to receive compilation warnings about #[feature] directives which enabled
+the new feature (because the directive is no longer necessary). However, if
+a feature is decided to be removed from the language, errors will be issued (if
+there isn't a parser error first). The directive in this case is no longer
+necessary, and it's likely that existing code will break if the feature isn't
+removed.
+
+If a unknown feature is found in a directive, it results in a compiler error. An
+unknown feature is one which has never been recognized by the compiler.
+
 # Statements and expressions
 
 Rust is _primarily_ an expression language. This means that most forms of

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -746,6 +746,10 @@ fn area(sh: Shape) -> f64 {
 }
 ~~~~
 
+> ***Note:*** This feature of the compiler is currently gated behind the
+> `#[feature(struct_variant)]` directive. More about these directives can be
+> found in the manual.
+
 ## Tuples
 
 Tuples in Rust behave exactly like structs, except that their fields
@@ -2664,6 +2668,10 @@ use farm::*;
 # }
 # fn main() { cow(); chicken() }
 ~~~
+
+> ***Note:*** This feature of the compiler is currently gated behind the
+> `#[feature(globs)]` directive. More about these directives can be found in
+> the manual.
 
 However, that's not all. You can also rename an item while you're bringing it into scope:
 

--- a/src/etc/combine-tests.py
+++ b/src/etc/combine-tests.py
@@ -40,6 +40,7 @@ c = open("tmp/run_pass_stage2.rc", "w")
 i = 0
 c.write("// AUTO-GENERATED FILE: DO NOT EDIT\n")
 c.write("#[link(name=\"run_pass_stage2\", vers=\"0.1\")];\n")
+c.write("#[feature(globs, macro_rules, struct_variant)];\n")
 for t in stage2_tests:
     p = os.path.join(run_pass, t)
     p = p.replace("\\", "\\\\")
@@ -51,6 +52,7 @@ c.close()
 
 d = open("tmp/run_pass_stage2_driver.rs", "w")
 d.write("// AUTO-GENERATED FILE: DO NOT EDIT\n")
+d.write("#[feature(globs)];\n")
 d.write("extern mod extra;\n")
 d.write("extern mod run_pass_stage2;\n")
 d.write("use run_pass_stage2::*;\n")

--- a/src/etc/extract-tests.py
+++ b/src/etc/extract-tests.py
@@ -63,6 +63,7 @@ while cur < len(lines):
 #[ allow(unused_variable) ];\n
 #[ allow(dead_assignment) ];\n
 #[ allow(unused_mut) ];\n
+#[ feature(macro_rules, globs, struct_variant) ];\n
 """ + block
             if xfail:
                 block = "// xfail-test\n" + block

--- a/src/libextra/extra.rs
+++ b/src/libextra/extra.rs
@@ -33,6 +33,8 @@ Rust extras are part of the standard Rust distribution.
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
+#[feature(macro_rules, globs)];
+
 #[deny(non_camel_case_types)];
 #[deny(missing_doc)];
 

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -159,6 +159,8 @@ pub fn phase_2_configure_and_expand(sess: Session,
     *sess.building_library = session::building_library(sess.opts.crate_type,
                                                        &crate, sess.opts.test);
 
+    time(time_passes, ~"gated feature checking", (), |_|
+         front::feature_gate::check_crate(sess, &crate));
 
     // strip before expansion to allow macros to depend on
     // configuration variables e.g/ in

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -159,7 +159,7 @@ pub fn phase_2_configure_and_expand(sess: Session,
     *sess.building_library = session::building_library(sess.opts.crate_type,
                                                        &crate, sess.opts.test);
 
-    time(time_passes, ~"gated feature checking", (), |_|
+    time(time_passes, "gated feature checking", (), |_|
          front::feature_gate::check_crate(sess, &crate));
 
     // strip before expansion to allow macros to depend on

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -1,0 +1,176 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Feature gating
+//!
+//! This modules implements the gating necessary for preventing certain compiler
+//! features from being used by default. This module will crawl a pre-expanded
+//! AST to ensure that there are no features which are used that are not
+//! enabled.
+//!
+//! Features are enabled in programs via the crate-level attributes of
+//! #[feature(...)] with a comma-separated list of features.
+
+use syntax::ast;
+use syntax::attr::AttrMetaMethods;
+use syntax::codemap::Span;
+use syntax::visit;
+use syntax::visit::Visitor;
+
+use driver::session::Session;
+
+/// This is a list of all known features since the beginning of time. This list
+/// can never shrink, it may only be expanded (in order to prevent old programs
+/// from failing to compile). The status of each feature may change, however.
+static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
+    ("globs", Active),
+    ("macro_rules", Active),
+    ("struct_variant", Active),
+
+    // These are used to test this portion of the compiler, they don't actually
+    // mean anything
+    ("test_accepted_feature", Accepted),
+    ("test_removed_feature", Removed),
+];
+
+enum Status {
+    /// Represents an active feature that is currently being implemented or
+    /// currently being considered for addition/removal.
+    Active,
+
+    /// Represents a feature which has since been removed (it was once Active)
+    Removed,
+
+    /// This language feature has since been Accepted (it was once Active)
+    Accepted,
+}
+
+struct Context {
+    features: ~[&'static str],
+    sess: Session,
+}
+
+impl Context {
+    fn gate_feature(&self, feature: &str, span: Span, explain: &str) {
+        if !self.has_feature(feature) {
+            self.sess.span_err(span, explain);
+            self.sess.span_note(span, format!("add \\#[feature({})] to the \
+                                                  crate attributes to enable",
+                                                 feature));
+        }
+    }
+
+    fn has_feature(&self, feature: &str) -> bool {
+        self.features.iter().any(|n| n.as_slice() == feature)
+    }
+}
+
+impl Visitor<()> for Context {
+    fn visit_view_item(&mut self, i: &ast::view_item, _: ()) {
+        match i.node {
+            ast::view_item_use(ref paths) => {
+                for path in paths.iter() {
+                    match path.node {
+                        ast::view_path_glob(*) => {
+                            self.gate_feature("globs", path.span,
+                                              "glob import statements are \
+                                               experimental and possibly buggy");
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+        visit::walk_view_item(self, i, ())
+    }
+
+    fn visit_item(&mut self, i: @ast::item, _:()) {
+        match i.node {
+            ast::item_enum(ref def, _) => {
+                for variant in def.variants.iter() {
+                    match variant.node.kind {
+                        ast::struct_variant_kind(*) => {
+                            self.gate_feature("struct_variant", variant.span,
+                                              "enum struct variants are \
+                                               experimental and possibly buggy");
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            ast::item_mac(ref mac) => {
+                match mac.node {
+                    ast::mac_invoc_tt(ref path, _, _) => {
+                        let rules = self.sess.ident_of("macro_rules");
+                        if path.segments.last().identifier == rules {
+                            self.gate_feature("macro_rules", i.span,
+                                              "macro definitions are not \
+                                               stable enough for use and are \
+                                               subject to change");
+                        }
+                    }
+                }
+            }
+
+            _ => {}
+        }
+
+        visit::walk_item(self, i, ());
+    }
+}
+
+pub fn check_crate(sess: Session, crate: &ast::Crate) {
+    let mut cx = Context {
+        features: ~[],
+        sess: sess,
+    };
+
+    for attr in crate.attrs.iter() {
+        if "feature" != attr.name() { continue }
+
+        match attr.meta_item_list() {
+            None => {
+                sess.span_err(attr.span, "malformed feature attribute, \
+                                          expected #[feature(...)]");
+            }
+            Some(list) => {
+                for &mi in list.iter() {
+                    let name = match mi.node {
+                        ast::MetaWord(word) => word,
+                        _ => {
+                            sess.span_err(mi.span, "malformed feature, expected \
+                                                    just one word");
+                            continue
+                        }
+                    };
+                    match KNOWN_FEATURES.iter().find(|& &(n, _)| n == name) {
+                        Some(&(name, Active)) => { cx.features.push(name); }
+                        Some(&(_, Removed)) => {
+                            sess.span_err(mi.span, "feature has been removed");
+                        }
+                        Some(&(_, Accepted)) => {
+                            sess.span_warn(mi.span, "feature has added to rust, \
+                                                     directive not necessary");
+                        }
+                        None => {
+                            sess.span_err(mi.span, "unknown feature");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    visit::walk_crate(&mut cx, crate, ());
+
+    sess.abort_if_errors();
+}

--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -17,6 +17,8 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
+#[feature(macro_rules, globs, struct_variant)];
+
 // Rustc tasks always run on a fixed_stack_segment, so code in this
 // module can call C functions (in particular, LLVM functions) with
 // impunity.
@@ -83,6 +85,7 @@ pub mod front {
     pub mod test;
     pub mod std_inject;
     pub mod assign_node_ids;
+    pub mod feature_gate;
 }
 
 pub mod back {

--- a/src/librustdoc/rustdoc.rs
+++ b/src/librustdoc/rustdoc.rs
@@ -17,6 +17,8 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
+#[feature(globs, struct_variant)];
+
 extern mod syntax;
 extern mod rustc;
 extern mod extra;

--- a/src/librusti/rusti.rs
+++ b/src/librusti/rusti.rs
@@ -66,6 +66,8 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
+#[feature(globs)];
+
 extern mod extra;
 extern mod rustc;
 extern mod syntax;

--- a/src/librustpkg/rustpkg.rs
+++ b/src/librustpkg/rustpkg.rs
@@ -18,6 +18,8 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
+#[feature(globs)];
+
 extern mod extra;
 extern mod rustc;
 extern mod syntax;

--- a/src/libstd/std.rs
+++ b/src/libstd/std.rs
@@ -61,6 +61,8 @@ they contained the following prologue:
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://static.rust-lang.org/doc/master")];
 
+#[feature(macro_rules, globs)];
+
 // Don't link to std. We are std.
 #[no_std];
 

--- a/src/libsyntax/syntax.rs
+++ b/src/libsyntax/syntax.rs
@@ -20,6 +20,8 @@
 #[license = "MIT/ASL2"];
 #[crate_type = "lib"];
 
+#[feature(macro_rules, globs)];
+
 extern mod extra;
 
 pub mod util {

--- a/src/test/auxiliary/issue_2316_b.rs
+++ b/src/test/auxiliary/issue_2316_b.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #[allow(unused_imports)];
+#[feature(globs)];
 
 extern mod issue_2316_a;
 

--- a/src/test/auxiliary/struct_variant_xc_aux.rs
+++ b/src/test/auxiliary/struct_variant_xc_aux.rs
@@ -12,6 +12,8 @@
        vers = "0.1")];
 #[crate_type = "lib"];
 
+#[feature(struct_variant)];
+
 pub enum Enum {
     Variant { arg: u8 }
 }

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -10,6 +10,8 @@
 
 // Microbenchmarks for various functions in std and extra
 
+#[feature(macro_rules)];
+
 extern mod extra;
 
 use extra::time::precise_time_s;

--- a/src/test/bench/rt-parfib.rs
+++ b/src/test/bench/rt-parfib.rs
@@ -14,7 +14,7 @@ use std::os;
 use std::uint;
 use std::rt::test::spawntask_later;
 use std::cell::Cell;
-use std::comm::*;
+use std::comm::oneshot;
 
 // A simple implementation of parfib. One subtree is found in a new
 // task and communicated over a oneshot pipe, the other is found

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -13,7 +13,7 @@
 extern mod extra;
 
 use std::cell::Cell;
-use std::comm::*;
+use std::comm::{stream, SharedChan};
 use std::io;
 use std::option;
 use std::os;

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -22,7 +22,7 @@
 extern mod extra;
 
 use extra::{time, getopts};
-use std::comm::*;
+use std::comm::{stream, SharedChan};
 use std::io::WriterUtil;
 use std::io;
 use std::os;

--- a/src/test/bench/task-perf-linked-failure.rs
+++ b/src/test/bench/task-perf-linked-failure.rs
@@ -22,7 +22,7 @@
 // Creates in the background 'num_tasks' tasks, all blocked forever.
 // Doesn't return until all such tasks are ready, but doesn't block forever itself.
 
-use std::comm::*;
+use std::comm::{stream, SharedChan};
 use std::os;
 use std::result;
 use std::task;

--- a/src/test/compile-fail/deriving-primitive.rs
+++ b/src/test/compile-fail/deriving-primitive.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 use std::num::FromPrimitive;
 use std::int;
 

--- a/src/test/compile-fail/dup-struct-enum-struct-variant.rs
+++ b/src/test/compile-fail/dup-struct-enum-struct-variant.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 enum Foo { C { a: int, b: int } }
 struct C { a: int, b: int }         //~ ERROR error: duplicate definition of type `C`
 

--- a/src/test/compile-fail/functional-struct-update-noncopyable.rs
+++ b/src/test/compile-fail/functional-struct-update-noncopyable.rs
@@ -12,7 +12,7 @@
 
 // xfail-fast #7103
 extern mod extra;
-use extra::arc::*;
+use extra::arc::Arc;
 
 struct A { y: Arc<int>, x: Arc<int> }
 

--- a/src/test/compile-fail/gated-bad-feature.rs
+++ b/src/test/compile-fail/gated-bad-feature.rs
@@ -1,0 +1,24 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(
+    foo_bar_baz,
+    foo(bar),
+    foo = "baz"
+)];
+//~^^^^ ERROR: unknown feature
+//~^^^^ ERROR: malformed feature
+//~^^^^ ERROR: malformed feature
+
+#[feature]; //~ ERROR: malformed feature
+#[feature = "foo"]; //~ ERROR: malformed feature
+
+#[feature(test_removed_feature)]; //~ ERROR: feature has been removed
+#[feature(test_accepted_feature)]; //~ WARNING: feature has added

--- a/src/test/compile-fail/gated-glob-imports.rs
+++ b/src/test/compile-fail/gated-glob-imports.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::*;
+//~^ ERROR: glob import statements are experimental
+
+fn main() {}

--- a/src/test/compile-fail/gated-macro-rules.rs
+++ b/src/test/compile-fail/gated-macro-rules.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo(() => ())
+//~^ ERROR: macro definitions are not stable enough for use
+
+fn main() {}

--- a/src/test/compile-fail/gated-struct-enums.rs
+++ b/src/test/compile-fail/gated-struct-enums.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum A { B { foo: int } }
+//~^ ERROR: enum struct variants are experimental
+
+fn main() {}
+

--- a/src/test/compile-fail/import-glob-0.rs
+++ b/src/test/compile-fail/import-glob-0.rs
@@ -10,6 +10,8 @@
 
 // error-pattern: unresolved name
 
+#[feature(globs)];
+
 use module_of_many_things::*;
 
 mod module_of_many_things {

--- a/src/test/compile-fail/import-glob-circular.rs
+++ b/src/test/compile-fail/import-glob-circular.rs
@@ -10,6 +10,8 @@
 
 // error-pattern: unresolved
 
+#[feature(globs)];
+
 mod circ1 {
     pub use circ2::f2;
     pub fn f1() { info2!("f1"); }

--- a/src/test/compile-fail/issue-1697.rs
+++ b/src/test/compile-fail/issue-1697.rs
@@ -10,6 +10,8 @@
 
 // Testing that we don't fail abnormally after hitting the errors
 
+#[feature(globs)];
+
 use unresolved::*; //~ ERROR unresolved import. maybe a missing
 //~^ ERROR failed to resolve import
 

--- a/src/test/compile-fail/issue-4366.rs
+++ b/src/test/compile-fail/issue-4366.rs
@@ -13,6 +13,8 @@
 // ensures that 'use foo:*' doesn't import non-public 'use' statements in the
 // module 'foo'
 
+#[feature(globs)];
+
 use m1::*;
 
 mod foo {

--- a/src/test/compile-fail/issue-5060-fail.rs
+++ b/src/test/compile-fail/issue-5060-fail.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules)];
 
 use std::io;
 

--- a/src/test/compile-fail/issue-6596.rs
+++ b/src/test/compile-fail/issue-6596.rs
@@ -1,4 +1,8 @@
-macro_rules! e( //~ ERROR unknown macro variable `nonexistent`
+#[feature(macro_rules)];
+
+// error-pattern: unknown macro variable `nonexistent`
+
+macro_rules! e(
     ($inp:ident) => (
         $nonexistent
     );

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -10,6 +10,7 @@
 
 // When denying at the crate level, be sure to not get random warnings from the
 // injected intrinsics by the compiler.
+#[feature(struct_variant)];
 #[deny(missing_doc)];
 
 struct Foo {

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -11,6 +11,7 @@
 // xfail-fast aux-build
 // aux-build:lint_stability.rs
 
+#[feature(globs)];
 #[deny(unstable)];
 #[deny(deprecated)];
 #[deny(experimental)];

--- a/src/test/compile-fail/lint-unused-import-tricky-globs.rs
+++ b/src/test/compile-fail/lint-unused-import-tricky-globs.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(globs)];
 #[deny(unused_imports)];
 
 mod A {

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(globs)];
 #[deny(unused_imports)];
 
 use cal = bar::c::cc;

--- a/src/test/compile-fail/macro-incomplete-parse.rs
+++ b/src/test/compile-fail/macro-incomplete-parse.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules)];
+
 macro_rules! ignored_item {
     () => {
         fn foo() {}

--- a/src/test/compile-fail/macro-inner-attributes.rs
+++ b/src/test/compile-fail/macro-inner-attributes.rs
@@ -1,3 +1,5 @@
+#[feature(macro_rules)];
+
 macro_rules! test ( ($nm:ident,
                      $a:attr,
                      $i:item) => (mod $nm { $a; $i }); )

--- a/src/test/compile-fail/macro-outer-attributes.rs
+++ b/src/test/compile-fail/macro-outer-attributes.rs
@@ -1,3 +1,5 @@
+#[feature(macro_rules)];
+
 macro_rules! test ( ($nm:ident,
                      $a:attr,
                      $i:item) => (mod $nm { $a $i }); )

--- a/src/test/compile-fail/name-clash-nullary.rs
+++ b/src/test/compile-fail/name-clash-nullary.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(globs)];
+
 // error-pattern:declaration of `None` shadows
 use std::option::*;
 

--- a/src/test/compile-fail/private-method-cross-crate.rs
+++ b/src/test/compile-fail/private-method-cross-crate.rs
@@ -11,7 +11,7 @@
 // xfail-fast
 // aux-build:cci_class_5.rs
 extern mod cci_class_5;
-use cci_class_5::kitties::*;
+use cci_class_5::kitties::cat;
 
 fn main() {
   let nyan : cat = cat(52, 99);

--- a/src/test/compile-fail/private-struct-field-cross-crate.rs
+++ b/src/test/compile-fail/private-struct-field-cross-crate.rs
@@ -10,7 +10,7 @@
 
 // aux-build:cci_class.rs
 extern mod cci_class;
-use cci_class::kitties::*;
+use cci_class::kitties::cat;
 
 fn main() {
   let nyan : cat = cat(52u, 99);

--- a/src/test/compile-fail/struct-like-enum-nonexhaustive.rs
+++ b/src/test/compile-fail/struct-like-enum-nonexhaustive.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 enum A {
     B { x: Option<int> },
     C

--- a/src/test/debug-info/borrowed-enum.rs
+++ b/src/test/debug-info/borrowed-enum.rs
@@ -23,6 +23,7 @@
 // check:$3 = {4820353753753434}
 
 #[allow(unused_variable)];
+#[feature(struct_variant)];
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/debug-info/by-value-non-immediate-argument.rs
+++ b/src/test/debug-info/by-value-non-immediate-argument.rs
@@ -41,6 +41,8 @@
 // check:$7 = {{Case1, x = 0, y = 8970181431921507452}, {Case1, 0, 2088533116, 2088533116}}
 // debugger:continue
 
+#[feature(struct_variant)];
+
 #[deriving(Clone)]
 struct Struct {
     a: int,

--- a/src/test/debug-info/generic-static-method-on-struct-and-enum.rs
+++ b/src/test/debug-info/generic-static-method-on-struct-and-enum.rs
@@ -30,6 +30,7 @@
 // check:$5 = 5
 // debugger:continue
 
+#[feature(struct_variant)];
 
 struct Struct {
     x: int

--- a/src/test/debug-info/generic-struct-style-enum.rs
+++ b/src/test/debug-info/generic-struct-style-enum.rs
@@ -26,6 +26,8 @@
 // debugger:print univariant
 // check:$4 = {a = -1}
 
+#[feature(struct_variant)];
+
 // NOTE: This is a copy of the non-generic test case. The `Txx` type parameters have to be
 // substituted with something of size `xx` bits and the same alignment as an integer type of the
 // same size.

--- a/src/test/debug-info/lexical-scope-with-macro.rs
+++ b/src/test/debug-info/lexical-scope-with-macro.rs
@@ -63,6 +63,8 @@
 // check:$15 = 400
 // debugger:continue
 
+#[feature(macro_rules)];
+
 macro_rules! trivial(
     ($e1:expr) => ($e1)
 )

--- a/src/test/debug-info/managed-enum.rs
+++ b/src/test/debug-info/managed-enum.rs
@@ -23,6 +23,7 @@
 // check:$3 = {-9747455}
 
 #[allow(unused_variable)];
+#[feature(struct_variant)];
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/debug-info/method-on-enum.rs
+++ b/src/test/debug-info/method-on-enum.rs
@@ -92,6 +92,8 @@
 // check:$21 = -16
 // debugger:continue
 
+#[feature(struct_variant)];
+
 enum Enum {
     Variant1 { x: u16, y: u16 },
     Variant2 (u32)

--- a/src/test/debug-info/option-like-enum.rs
+++ b/src/test/debug-info/option-like-enum.rs
@@ -33,6 +33,8 @@
 
 // debugger:continue
 
+#[feature(struct_variant)];
+
 // If a struct has exactly two variants, one of them is empty, and the other one
 // contains a non-nullable pointer, then this value is used as the discriminator.
 // The test cases in this file make sure that something readable is generated for

--- a/src/test/debug-info/recursive-struct.rs
+++ b/src/test/debug-info/recursive-struct.rs
@@ -99,6 +99,7 @@
 // debugger:continue
 
 #[allow(unused_variable)];
+#[feature(struct_variant)];
 
 enum Opt<T> {
     Empty,

--- a/src/test/debug-info/static-method-on-struct-and-enum.rs
+++ b/src/test/debug-info/static-method-on-struct-and-enum.rs
@@ -30,6 +30,7 @@
 // check:$5 = 5
 // debugger:continue
 
+#[feature(struct_variant)];
 
 struct Struct {
     x: int

--- a/src/test/debug-info/struct-style-enum.rs
+++ b/src/test/debug-info/struct-style-enum.rs
@@ -27,6 +27,7 @@
 // check:$4 = {a = -1}
 
 #[allow(unused_variable)];
+#[feature(struct_variant)];
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/debug-info/unique-enum.rs
+++ b/src/test/debug-info/unique-enum.rs
@@ -23,6 +23,7 @@
 // check:$3 = {123234}
 
 #[allow(unused_variable)];
+#[feature(struct_variant)];
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/run-pass/anon-extern-mod-cross-crate-2.rs
+++ b/src/test/run-pass/anon-extern-mod-cross-crate-2.rs
@@ -12,7 +12,7 @@
 // aux-build:anon-extern-mod-cross-crate-1.rs
 extern mod anonexternmod;
 
-use anonexternmod::*;
+use anonexternmod::rust_get_test_int;
 
 #[fixed_stack_segment]
 pub fn main() {

--- a/src/test/run-pass/bitv-perf-test.rs
+++ b/src/test/run-pass/bitv-perf-test.rs
@@ -11,7 +11,7 @@
 // except according to those terms.
 
 extern mod extra;
-use extra::bitv::*;
+use extra::bitv::Bitv;
 
 fn bitv_test() {
     let mut v1 = ~Bitv::new(31, false);

--- a/src/test/run-pass/borrowck-macro-interaction-issue-6304.rs
+++ b/src/test/run-pass/borrowck-macro-interaction-issue-6304.rs
@@ -1,6 +1,8 @@
 // Check that we do not ICE when compiling this
 // macro, which reuses the expression `$id`
 
+#[feature(macro_rules)];
+
 struct Foo {
   a: int
 }

--- a/src/test/run-pass/cci_nested_exe.rs
+++ b/src/test/run-pass/cci_nested_exe.rs
@@ -11,6 +11,8 @@
 // xfail-fast - check-fast doesn't understand aux-build
 // aux-build:cci_nested_lib.rs
 
+#[feature(globs)];
+
 extern mod cci_nested_lib;
 use cci_nested_lib::*;
 

--- a/src/test/run-pass/cfg-macros-foo.rs
+++ b/src/test/run-pass/cfg-macros-foo.rs
@@ -14,6 +14,8 @@
 // check that cfg correctly chooses between the macro impls (see also
 // cfg-macros-notfoo.rs)
 
+#[feature(macro_rules)];
+
 #[cfg(foo)]
 #[macro_escape]
 mod foo {

--- a/src/test/run-pass/cfg-macros-notfoo.rs
+++ b/src/test/run-pass/cfg-macros-notfoo.rs
@@ -14,6 +14,8 @@
 // check that cfg correctly chooses between the macro impls (see also
 // cfg-macros-foo.rs)
 
+#[feature(macro_rules)];
+
 #[cfg(foo)]
 #[macro_escape]
 mod foo {

--- a/src/test/run-pass/class-cast-to-trait-cross-crate-2.rs
+++ b/src/test/run-pass/class-cast-to-trait-cross-crate-2.rs
@@ -12,7 +12,7 @@
 // aux-build:cci_class_cast.rs
 extern mod cci_class_cast;
 use std::to_str::ToStr;
-use cci_class_cast::kitty::*;
+use cci_class_cast::kitty::cat;
 
 fn print_out(thing: @ToStr, expected: ~str) {
   let actual = thing.to_str();

--- a/src/test/run-pass/class-exports.rs
+++ b/src/test/run-pass/class-exports.rs
@@ -13,7 +13,7 @@
 /* Test that exporting a class also exports its
    public fields and methods */
 
-use kitty::*;
+use kitty::cat;
 
 mod kitty {
     pub struct cat {

--- a/src/test/run-pass/class-implement-trait-cross-crate.rs
+++ b/src/test/run-pass/class-implement-trait-cross-crate.rs
@@ -11,7 +11,7 @@
 // xfail-fast
 // aux-build:cci_class_trait.rs
 extern mod cci_class_trait;
-use cci_class_trait::animals::*;
+use cci_class_trait::animals::noisy;
 
 struct cat {
   priv meows: uint,

--- a/src/test/run-pass/class-method-cross-crate.rs
+++ b/src/test/run-pass/class-method-cross-crate.rs
@@ -11,7 +11,7 @@
 // xfail-fast
 // aux-build:cci_class_2.rs
 extern mod cci_class_2;
-use cci_class_2::kitties::*;
+use cci_class_2::kitties::cat;
 
 pub fn main() {
   let nyan : cat = cat(52u, 99);

--- a/src/test/run-pass/class-methods-cross-crate.rs
+++ b/src/test/run-pass/class-methods-cross-crate.rs
@@ -11,7 +11,7 @@
 // xfail-fast
 // aux-build:cci_class_3.rs
 extern mod cci_class_3;
-use cci_class_3::kitties::*;
+use cci_class_3::kitties::cat;
 
 pub fn main() {
     let mut nyan : cat = cat(52u, 99);

--- a/src/test/run-pass/class-poly-methods-cross-crate.rs
+++ b/src/test/run-pass/class-poly-methods-cross-crate.rs
@@ -11,7 +11,7 @@
 // xfail-fast
 // aux-build:cci_class_6.rs
 extern mod cci_class_6;
-use cci_class_6::kitties::*;
+use cci_class_6::kitties::cat;
 
 pub fn main() {
   let mut nyan : cat<char> = cat::<char>(52u, 99, ~['p']);

--- a/src/test/run-pass/classes-cross-crate.rs
+++ b/src/test/run-pass/classes-cross-crate.rs
@@ -11,7 +11,7 @@
 // xfail-fast
 // aux-build:cci_class_4.rs
 extern mod cci_class_4;
-use cci_class_4::kitties::*;
+use cci_class_4::kitties::cat;
 
 pub fn main() {
     let mut nyan = cat(0u, 2, ~"nyan");

--- a/src/test/run-pass/classes-simple-cross-crate.rs
+++ b/src/test/run-pass/classes-simple-cross-crate.rs
@@ -11,7 +11,7 @@
 // xfail-fast
 // aux-build:cci_class.rs
 extern mod cci_class;
-use cci_class::kitties::*;
+use cci_class::kitties::cat;
 
 pub fn main() {
   let nyan : cat = cat(52u, 99);

--- a/src/test/run-pass/const-enum-structlike.rs
+++ b/src/test/run-pass/const-enum-structlike.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 enum E {
     S0 { s: ~str },
     S1 { u: uint }

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -16,7 +16,6 @@
 // instead of in std.
 
 use std::libc;
-use std::run::*;
 use std::run;
 use std::str;
 

--- a/src/test/run-pass/deriving-cmp-generic-struct-enum.rs
+++ b/src/test/run-pass/deriving-cmp-generic-struct-enum.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 #[deriving(Eq, TotalEq, Ord, TotalOrd)]
 enum ES<T> {
     ES1 { x: T },

--- a/src/test/run-pass/deriving-encodable-decodable.rs
+++ b/src/test/run-pass/deriving-encodable-decodable.rs
@@ -13,11 +13,13 @@
 
 // xfail-fast
 
+#[feature(struct_variant)];
+
 extern mod extra;
 
 use std::io;
 use std::rand::{random, Rand};
-use extra::serialize::*;
+use extra::serialize::{Encodable, Decodable};
 use extra::ebml;
 use extra::ebml::writer::Encoder;
 use extra::ebml::reader::Decoder;

--- a/src/test/run-pass/deriving-rand.rs
+++ b/src/test/run-pass/deriving-rand.rs
@@ -9,6 +9,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 use std::rand;
 
 #[deriving(Rand)]

--- a/src/test/run-pass/deriving-to-str.rs
+++ b/src/test/run-pass/deriving-to-str.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 #[deriving(ToStr)]
 enum A {}
 #[deriving(ToStr)]

--- a/src/test/run-pass/deriving-via-extension-struct-like-enum-variant.rs
+++ b/src/test/run-pass/deriving-via-extension-struct-like-enum-variant.rs
@@ -1,3 +1,5 @@
+#[feature(struct_variant)];
+
 #[deriving(Eq)]
 enum S {
     X { x: int, y: int },

--- a/src/test/run-pass/enum-variants.rs
+++ b/src/test/run-pass/enum-variants.rs
@@ -1,5 +1,6 @@
 #[allow(dead_assignment)];
 #[allow(unused_variable)];
+#[feature(struct_variant)];
 
 enum Animal {
     Dog (~str, f64),

--- a/src/test/run-pass/export-glob-imports-target.rs
+++ b/src/test/run-pass/export-glob-imports-target.rs
@@ -15,6 +15,8 @@
 
 // Modified to not use export since it's going away. --pcw
 
+#[feature(globs)];
+
 mod foo {
     use foo::bar::*;
     pub mod bar {

--- a/src/test/run-pass/getopts_ref.rs
+++ b/src/test/run-pass/getopts_ref.rs
@@ -12,7 +12,7 @@
 
 extern mod extra;
 
-use extra::getopts::*;
+use extra::getopts::{optopt, getopts};
 
 pub fn main() {
     let args = ~[];

--- a/src/test/run-pass/glob-std.rs
+++ b/src/test/run-pass/glob-std.rs
@@ -12,7 +12,7 @@
 
 extern mod extra;
 
-use extra::glob::*;
+use extra::glob::glob;
 use extra::tempfile;
 use std::unstable::finally::Finally;
 use std::{io, os, unstable};

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -19,7 +19,7 @@
 pub fn map(filename: ~str, emit: map_reduce::putter) { emit(filename, ~"1"); }
 
 mod map_reduce {
-    use std::comm::*;
+    use std::comm::{stream, SharedChan};
     use std::hashmap::HashMap;
     use std::str;
     use std::task;

--- a/src/test/run-pass/html-literals.rs
+++ b/src/test/run-pass/html-literals.rs
@@ -10,6 +10,7 @@
 
 // A test of the macro system. Can we do HTML literals?
 
+#[feature(macro_rules)];
 
 /*
 

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -10,6 +10,7 @@
 
 // xfail-fast: check-fast screws up repr paths
 
+#[feature(macro_rules)];
 #[deny(warnings)];
 
 use std::fmt;

--- a/src/test/run-pass/import-glob-0.rs
+++ b/src/test/run-pass/import-glob-0.rs
@@ -10,6 +10,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(globs)];
+
 use module_of_many_things::*;
 use dug::too::greedily::and::too::deep::*;
 

--- a/src/test/run-pass/import-glob-crate.rs
+++ b/src/test/run-pass/import-glob-crate.rs
@@ -10,6 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(globs)];
 #[allow(dead_assignment)];
 
 extern mod extra;

--- a/src/test/run-pass/import-in-block.rs
+++ b/src/test/run-pass/import-in-block.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(globs)];
+
 pub fn main() {
     use std::util::replace;
     let mut x = 5;

--- a/src/test/run-pass/intrinsics-integer.rs
+++ b/src/test/run-pass/intrinsics-integer.rs
@@ -10,6 +10,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(globs)];
+
 extern mod extra;
 
 mod rusti {

--- a/src/test/run-pass/intrinsics-math.rs
+++ b/src/test/run-pass/intrinsics-math.rs
@@ -10,6 +10,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(globs)];
+
 mod rusti {
     #[abi = "rust-intrinsic"]
     extern "rust-intrinsic" {

--- a/src/test/run-pass/issue-2526-a.rs
+++ b/src/test/run-pass/issue-2526-a.rs
@@ -11,6 +11,7 @@
 // xfail-fast
 // aux-build:issue-2526.rs
 
+#[feature(globs)];
 #[allow(unused_imports)];
 
 extern mod issue_2526;

--- a/src/test/run-pass/issue-2631-b.rs
+++ b/src/test/run-pass/issue-2631-b.rs
@@ -13,7 +13,7 @@
 
 extern mod req;
 
-use req::*;
+use req::request;
 use std::hashmap::HashMap;
 
 pub fn main() {

--- a/src/test/run-pass/issue-2723-b.rs
+++ b/src/test/run-pass/issue-2723-b.rs
@@ -12,7 +12,7 @@
 // aux-build:issue_2723_a.rs
 
 extern mod issue_2723_a;
-use issue_2723_a::*;
+use issue_2723_a::f;
 
 pub fn main() {
     unsafe {

--- a/src/test/run-pass/issue-3656.rs
+++ b/src/test/run-pass/issue-3656.rs
@@ -13,7 +13,7 @@
 // Incorrect struct size computation in the FFI, because of not taking
 // the alignment of elements into account.
 
-use std::libc::*;
+use std::libc::{c_uint, uint32_t, c_void};
 
 struct KEYGEN {
     hash_algorithm: [c_uint, ..2],

--- a/src/test/run-pass/issue-3979-xcrate.rs
+++ b/src/test/run-pass/issue-3979-xcrate.rs
@@ -11,7 +11,7 @@
 // xfail-fast
 // aux-build:issue_3979_traits.rs
 extern mod issue_3979_traits;
-use issue_3979_traits::*;
+use issue_3979_traits::{Positioned, Movable};
 
 struct Point { x: int, y: int }
 

--- a/src/test/run-pass/issue-4208.rs
+++ b/src/test/run-pass/issue-4208.rs
@@ -12,7 +12,7 @@
 // xfail-fast - Windows hates cross-crate tests
 
 extern mod numeric;
-use numeric::*;
+use numeric::{sin, Angle};
 
 fn foo<T, A:Angle<T>>(theta: A) -> T { sin(&theta) }
 

--- a/src/test/run-pass/issue-5060.rs
+++ b/src/test/run-pass/issue-5060.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules)];
+
 use std::io;
 
 macro_rules! print_hd_tl (

--- a/src/test/run-pass/issue-5530.rs
+++ b/src/test/run-pass/issue-5530.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 enum Enum {
     Foo { foo: uint },
     Bar { bar: uint }

--- a/src/test/run-pass/issue-5554.rs
+++ b/src/test/run-pass/issue-5554.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules)];
+
 use std::num::Zero;
 
 pub struct X<T> {

--- a/src/test/run-pass/issue-9110.rs
+++ b/src/test/run-pass/issue-9110.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules)];
+
 macro_rules! silly_macro(
     () => (
         pub mod Qux {

--- a/src/test/run-pass/let-var-hygiene.rs
+++ b/src/test/run-pass/let-var-hygiene.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules)];
+
 // shouldn't affect evaluation of $ex:
 macro_rules! bad_macro (($ex:expr) => ({let _x = 9; $ex}))
 pub fn main() {

--- a/src/test/run-pass/macro-2.rs
+++ b/src/test/run-pass/macro-2.rs
@@ -10,6 +10,8 @@
 
 // xfail-pretty - token trees can't pretty print
 
+#[feature(macro_rules)];
+
 pub fn main() {
 
     macro_rules! mylambda_tt(

--- a/src/test/run-pass/macro-interpolation.rs
+++ b/src/test/run-pass/macro-interpolation.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules)];
 
 macro_rules! overly_complicated (
     ($fnname:ident, $arg:ident, $ty:ty, $body:block, $val:expr, $pat:pat, $res:path) =>

--- a/src/test/run-pass/macro-path.rs
+++ b/src/test/run-pass/macro-path.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules)];
+
 mod m {
     pub type t = int;
 }

--- a/src/test/run-pass/macro-stmt.rs
+++ b/src/test/run-pass/macro-stmt.rs
@@ -10,6 +10,8 @@
 
 // xfail-pretty - token trees can't pretty print
 
+#[feature(macro_rules)];
+
 macro_rules! myfn(
     ( $f:ident, ( $( $x:ident ),* ), $body:block ) => (
         fn $f( $( $x : int),* ) -> int $body

--- a/src/test/run-pass/match-enum-struct-0.rs
+++ b/src/test/run-pass/match-enum-struct-0.rs
@@ -10,6 +10,8 @@
 
 // regression test for issue #5625
 
+#[feature(struct_variant)];
+
 enum E {
     Foo{f : int},
     Bar

--- a/src/test/run-pass/match-enum-struct-1.rs
+++ b/src/test/run-pass/match-enum-struct-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 enum E {
     Foo{f : int},
     Bar

--- a/src/test/run-pass/match-in-macro.rs
+++ b/src/test/run-pass/match-in-macro.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules, struct_variant)];
+
 enum Foo {
     B { b1: int, bb1: int},
 }

--- a/src/test/run-pass/non-boolean-pure-fns.rs
+++ b/src/test/run-pass/non-boolean-pure-fns.rs
@@ -12,7 +12,7 @@
 
 extern mod extra;
 
-use extra::list::*;
+use extra::list::{List, Cons, Nil, head, is_empty};
 
 fn pure_length_go<T:Clone>(ls: @List<T>, acc: uint) -> uint {
     match *ls { Nil => { acc } Cons(_, tl) => { pure_length_go(tl, acc + 1u) } }

--- a/src/test/run-pass/nullable-pointer-size.rs
+++ b/src/test/run-pass/nullable-pointer-size.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules)];
+
 use std::sys;
 
 enum E<T> { Thing(int, T), Nothing((), ((), ()), [i8, ..0]) }

--- a/src/test/run-pass/reexport-star.rs
+++ b/src/test/run-pass/reexport-star.rs
@@ -10,6 +10,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(globs)];
+
 // FIXME #3654
 
 mod a {

--- a/src/test/run-pass/rename-directory.rs
+++ b/src/test/run-pass/rename-directory.rs
@@ -17,12 +17,11 @@ extern mod extra;
 use extra::tempfile::mkdtemp;
 use std::os;
 use std::libc;
-use std::libc::*;
 
 fn rename_directory() {
     #[fixed_stack_segment];
     unsafe {
-        static U_RWX: i32 = (S_IRUSR | S_IWUSR | S_IXUSR) as i32;
+        static U_RWX: i32 = (libc::S_IRUSR | libc::S_IWUSR | libc::S_IXUSR) as i32;
 
         let tmpdir = mkdtemp(&os::tmpdir(), "rename_directory").expect("rename_directory failed");
         let old_path = tmpdir.push_many(["foo", "bar", "baz"]);
@@ -38,13 +37,13 @@ fn rename_directory() {
         assert!((ostream as uint != 0u));
         let s = ~"hello";
         do "hello".with_c_str |buf| {
-            let write_len = libc::fwrite(buf as *c_void,
-                                         1u as size_t,
-                                         (s.len() + 1u) as size_t,
+            let write_len = libc::fwrite(buf as *libc::c_void,
+                                         1u as libc::size_t,
+                                         (s.len() + 1u) as libc::size_t,
                                          ostream);
-            assert_eq!(write_len, (s.len() + 1) as size_t)
+            assert_eq!(write_len, (s.len() + 1) as libc::size_t)
         }
-        assert_eq!(libc::fclose(ostream), (0u as c_int));
+        assert_eq!(libc::fclose(ostream), (0u as libc::c_int));
 
         let new_path = tmpdir.push_many(["quux", "blat"]);
         assert!(os::mkdir_recursive(&new_path, U_RWX));

--- a/src/test/run-pass/rtio-processes.rs
+++ b/src/test/run-pass/rtio-processes.rs
@@ -23,9 +23,9 @@
 //
 // See #9341
 
-use std::rt::io::process::*;
+use std::rt::io::process::{Process, ProcessConfig, CreatePipe, Ignored};
 use std::rt::io::{Reader, Writer};
-use std::rt::io::pipe::*;
+use std::rt::io::pipe::PipeStream;
 use std::str;
 
 #[test]

--- a/src/test/run-pass/struct-like-variant-construct.rs
+++ b/src/test/run-pass/struct-like-variant-construct.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 enum Foo {
     Bar {
         a: int,

--- a/src/test/run-pass/struct-like-variant-match.rs
+++ b/src/test/run-pass/struct-like-variant-match.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 enum Foo {
     Bar {
         x: int,

--- a/src/test/run-pass/syntax-extension-fmt.rs
+++ b/src/test/run-pass/syntax-extension-fmt.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(macro_rules)];
+
 // compile-flags: --cfg nofmt
 
 extern mod extra;

--- a/src/test/run-pass/syntax-extension-source-utils.rs
+++ b/src/test/run-pass/syntax-extension-source-utils.rs
@@ -11,6 +11,8 @@
 // This test is brittle!
 // xfail-pretty - the pretty tests lose path information, breaking include!
 
+#[feature(macro_rules)];
+
 pub mod m1 {
     pub mod m2 {
         pub fn where_am_i() -> ~str { (module_path!()).to_owned() }
@@ -20,9 +22,9 @@ pub mod m1 {
 macro_rules! indirect_line( () => ( line!() ) )
 
 pub fn main() {
-    assert_eq!(line!(), 23);
+    assert_eq!(line!(), 25);
     //assert!((col!() == 11));
-    assert_eq!(indirect_line!(), 25);
+    assert_eq!(indirect_line!(), 27);
     assert!((file!().to_owned().ends_with("syntax-extension-source-utils.rs")));
     assert_eq!(stringify!((2*3) + 5).to_owned(), ~"( 2 * 3 ) + 5");
     assert!(include!("syntax-extension-source-utils-files/includeme.fragment").to_owned()

--- a/src/test/run-pass/tag-exports.rs
+++ b/src/test/run-pass/tag-exports.rs
@@ -10,6 +10,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(globs)];
+
 use alder::*;
 
 mod alder {

--- a/src/test/run-pass/typeck-macro-interaction-issue-8852.rs
+++ b/src/test/run-pass/typeck-macro-interaction-issue-8852.rs
@@ -1,3 +1,5 @@
+#[feature(macro_rules)];
+
 enum T {
     A(int),
     B(f64)

--- a/src/test/run-pass/unfold-cross-crate.rs
+++ b/src/test/run-pass/unfold-cross-crate.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::iter::*;
+use std::iter::Unfold;
 
 // Unfold had a bug with 'self that mean it didn't work
 // cross-crate

--- a/src/test/run-pass/unique-send-2.rs
+++ b/src/test/run-pass/unique-send-2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::comm::*;
+use std::comm::{SharedChan, stream};
 use std::task;
 
 fn child(c: &SharedChan<~uint>, i: uint) {

--- a/src/test/run-pass/unwind-resource.rs
+++ b/src/test/run-pass/unwind-resource.rs
@@ -12,7 +12,7 @@
 
 extern mod extra;
 
-use std::comm::*;
+use std::comm::{stream, SharedChan};
 use std::task;
 
 struct complainer {

--- a/src/test/run-pass/variant-structs-trivial.rs
+++ b/src/test/run-pass/variant-structs-trivial.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(struct_variant)];
+
 enum Foo {
     Bar { x: int },
     Baz { y: int }


### PR DESCRIPTION
This implements the necessary logic for gating particular features off by default in the compiler. There are a number of issues which have been wanting this form of mechanism, and this initially gates features which we have open issues for.

Additionally, this should unblock #9255
