### PR TITLE
fixes for time:strptime

### DIFF
--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -600,8 +600,6 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ~str> {
               None => Err(~"Invalid day of week")
             }
           }
-          //'X' {}
-          //'x' {}
           'Y' => {
             match match_digits(s, pos, 4u, false) {
               Some(item) => {


### PR DESCRIPTION
What would be the best way of checking if the day of the week (tm.tm_wday) has been set?
If it has been set we can use both the day of the week and the given week number (%W) to calculate the day of the year.

Having in mind, there are multiple things that could be calculated as well, like month, day of the month, etc

What I've written is a hack to show what I am trying to do, but not definitive.
