### PR TITLE
Hackily fix thread safety issues in dynamic_lib

### DIFF
--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -609,6 +609,18 @@ rust_drop_linenoise_lock() {
     linenoise_lock.unlock();
 }
 
+static lock_and_signal dlerror_lock;
+
+extern "C" CDECL void
+rust_take_dlerror_lock() {
+    dlerror_lock.lock();
+}
+
+extern "C" CDECL void
+rust_drop_dlerror_lock() {
+    dlerror_lock.unlock();
+}
+
 extern "C" CDECL unsigned int
 rust_valgrind_stack_register(void *start, void *end) {
   return VALGRIND_STACK_REGISTER(start, end);

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -206,3 +206,5 @@ sd_markdown_render
 sd_markdown_free
 bufrelease
 bufnew
+rust_take_dlerror_lock
+rust_drop_dlerror_lock


### PR DESCRIPTION
The root issue is that dlerror isn't reentrant or even thread safe.

The solution implemented here is to make a yielding spin lock over an
AtomicFlag. This is pretty hacky, but the best we can do at this point.
As far as I can tell, it isn't possible to create a global mutex without
having to initialize it in a single threaded context.

The Windows code isn't affected since errno is thread-local on Windows
and it's running in an atomically block to ensure there isn't a green
thread context switch.

Closes #8156
