### PR TITLE
Cache more results of const_eval

### DIFF
--- a/src/etc/get-snapshot.py
+++ b/src/etc/get-snapshot.py
@@ -26,6 +26,8 @@ def unpack_snapshot(triple, dl_path):
     print("extracting " + p)
     tar.extract(p, download_unpack_base)
     tp = os.path.join(download_unpack_base, p)
+    if os.path.isdir(tp) and os.path.exists(fp):
+        continue
     shutil.move(tp, fp)
   tar.close()
   shutil.rmtree(download_unpack_base)


### PR DESCRIPTION
According to http://huonw.github.io/isrustfastyet/mem/#012f909, the "const
marking" pass generates about 400MB of extra memory during compilation. It
appears that this is due to two different factors:

```
1. There is a `ccache` map in the ty::ctxt which is only ever used in this
   pass, so this commit moves the map out of the ty::ctxt struct and into
   just this pass's visitor. This turned out to not benefit that much in
   memory (as indicated by http://i.imgur.com/Eo4iOzK.png), but it's helpful
   to do nonetheless.

2. During const_eval, there are a lot of lookups into decoding inlined items
   from external crates. There is no caching involved here, so the same
   static or variant could be re-translated many times. After adding
   separate caches for variants and statics, the memory peak of compiling
   rustc decreased by 200MB (as evident by http://i.imgur.com/ULAUMtq.png)
```

The culmination of this is basically a slight reorganization of a caching map
for the const_eval pass along with a 200MB decrease in peak memory usage when
compiling librustc.
