### PR TITLE
Make a task name use a `SendStr`, allowing for either static or owned strings.

### DIFF
--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -33,6 +33,7 @@ use rt::context::Context;
 use unstable::finally::Finally;
 use task::spawn::Taskgroup;
 use cell::Cell;
+use send_str::SendStr;
 
 // The Task struct represents all state associated with a rust
 // task. There are at this point two primary "subtypes" of task,
@@ -49,8 +50,7 @@ pub struct Task {
     taskgroup: Option<Taskgroup>,
     death: Death,
     destroyed: bool,
-    // FIXME(#6874/#7599) use StringRef to save on allocations
-    name: Option<~str>,
+    name: Option<SendStr>,
     coroutine: Option<Coroutine>,
     sched: Option<~Scheduler>,
     task_type: TaskType,

--- a/src/libstd/send_str.rs
+++ b/src/libstd/send_str.rs
@@ -64,6 +64,11 @@ impl IntoSendStr for &'static str {
     fn into_send_str(self) -> SendStr { SendStrStatic(self) }
 }
 
+impl IntoSendStr for SendStr {
+    #[inline]
+    fn into_send_str(self) -> SendStr { self }
+}
+
 /*
 Section: String trait impls.
 `SendStr` should behave like a normal string, so we don't derive.

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -63,6 +63,7 @@ use rt::in_green_task_context;
 use rt::local::Local;
 use unstable::finally::Finally;
 use util;
+use send_str::{SendStr, IntoSendStr};
 
 #[cfg(test)] use cast;
 #[cfg(test)] use comm::SharedChan;
@@ -148,7 +149,7 @@ pub struct TaskOpts {
     watched: bool,
     indestructible: bool,
     notify_chan: Option<Chan<TaskResult>>,
-    name: Option<~str>,
+    name: Option<SendStr>,
     sched: SchedOpts,
     stack_size: Option<uint>
 }
@@ -295,8 +296,8 @@ impl TaskBuilder {
 
     /// Name the task-to-be. Currently the name is used for identification
     /// only in failure messages.
-    pub fn name(&mut self, name: ~str) {
-        self.opts.name = Some(name);
+    pub fn name<S: IntoSendStr>(&mut self, name: S) {
+        self.opts.name = Some(name.into_send_str());
     }
 
     /// Configure a custom scheduler mode for the task.
@@ -944,12 +945,27 @@ fn test_unnamed_task() {
 }
 
 #[test]
-fn test_named_task() {
+fn test_owned_named_task() {
     use rt::test::run_in_newsched_task;
 
     do run_in_newsched_task {
         let mut t = task();
         t.name(~"ada lovelace");
+        do t.spawn {
+            do with_task_name |name| {
+                assert!(name.unwrap() == "ada lovelace");
+            }
+        }
+    }
+}
+
+#[test]
+fn test_static_named_task() {
+    use rt::test::run_in_newsched_task;
+
+    do run_in_newsched_task {
+        let mut t = task();
+        t.name("ada lovelace");
         do t.spawn {
             do with_task_name |name| {
                 assert!(name.unwrap() == "ada lovelace");

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -975,6 +975,21 @@ fn test_static_named_task() {
 }
 
 #[test]
+fn test_send_named_task() {
+    use rt::test::run_in_newsched_task;
+
+    do run_in_newsched_task {
+        let mut t = task();
+        t.name("ada lovelace".into_send_str());
+        do t.spawn {
+            do with_task_name |name| {
+                assert!(name.unwrap() == "ada lovelace");
+            }
+        }
+    }
+}
+
+#[test]
 fn test_run_basic() {
     let (po, ch) = stream::<()>();
     let mut builder = task();

--- a/src/test/run-fail/fail-task-name-none.rs
+++ b/src/test/run-fail/fail-task-name-none.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task '<unnamed>' failed at 'test'
+
+fn main() {
+    do spawn {
+        fail2!("test");
+    }
+}

--- a/src/test/run-fail/fail-task-name-owned.rs
+++ b/src/test/run-fail/fail-task-name-owned.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task 'owned name' failed at 'test'
+
+fn main() {
+    let mut t = ::std::task::task();
+    t.name(~"owned name");
+    do t.spawn {
+        fail2!("test");
+    }
+}

--- a/src/test/run-fail/fail-task-name-send-str.rs
+++ b/src/test/run-fail/fail-task-name-send-str.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task 'send name' failed at 'test'
+
+fn main() {
+    let mut t = ::std::task::task();
+    t.name("send name".to_send_str());
+    do t.spawn {
+        fail2!("test");
+    }
+}

--- a/src/test/run-fail/fail-task-name-static.rs
+++ b/src/test/run-fail/fail-task-name-static.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task 'static name' failed at 'test'
+
+fn main() {
+    let mut t = ::std::task::task();
+    t.name("static name");
+    do t.spawn {
+        fail2!("test");
+    }
+}


### PR DESCRIPTION
This resolves a FIXME in `std::rt::task`.
