### PR TITLE
rustpkg: Make checked-out source files read-only, and overhaul where temporary files are stored

### DIFF
--- a/doc/rustpkg.md
+++ b/doc/rustpkg.md
@@ -137,6 +137,9 @@ and builds it in any workspace(s) where it finds one.
 Supposing such packages are found in workspaces X, Y, and Z,
 the command leaves behind files in `X`'s, `Y`'s, and `Z`'s `build` directories,
 but not in their `lib` or `bin` directories.
+(The exception is when rustpkg fetches a package `foo`'s sources from a remote repository.
+In that case, it stores both the sources *and* the build artifacts for `foo`
+in the workspace that `foo` will install to (see ##install below)).
 
 ## clean
 
@@ -148,7 +151,11 @@ but not in their `lib` or `bin` directories.
 If `RUST_PATH` is declared as an environment variable, then rustpkg installs the
 libraries and executables into the `lib` and `bin` subdirectories
 of the first entry in `RUST_PATH`.
-Otherwise, it installs them into `foo`'s `lib` and `bin` directories.
+Otherwise, if the current working directory CWD is a workspace,
+it installs them into CWD's `lib` and `bin` subdirectories.
+Otherwise, if the current working directory is CWD,
+it installs them into the .rust/lib and .rust/bin subdirectories of CWD
+(creating them if necessary). 
 
 ## test
 

--- a/src/librustpkg/conditions.rs
+++ b/src/librustpkg/conditions.rs
@@ -50,3 +50,7 @@ condition! {
 condition! {
     pub failed_to_create_temp_dir: (~str) -> Path;
 }
+
+condition! {
+    pub git_checkout_failed: (~str, Path) -> ();
+}

--- a/src/librustpkg/package_id.rs
+++ b/src/librustpkg/package_id.rs
@@ -102,10 +102,7 @@ impl PkgId {
     }
 
     pub fn prefixes_iter(&self) -> Prefixes {
-        Prefixes {
-            components: self.path.components().to_owned(),
-            remaining: ~[]
-        }
+        prefixes_iter(&self.path)
     }
 
     // This is the workcache function name for the *installed*
@@ -113,6 +110,13 @@ impl PkgId {
     // which are per-crate).
     pub fn install_tag(&self) -> ~str {
         format!("install({})", self.to_str())
+    }
+}
+
+pub fn prefixes_iter(p: &Path) -> Prefixes {
+    Prefixes {
+        components: p.components().to_owned(),
+        remaining: ~[]
     }
 }
 

--- a/src/librustpkg/source_control.rs
+++ b/src/librustpkg/source_control.rs
@@ -12,62 +12,99 @@
 
 use std::{io, os, run, str};
 use std::run::{ProcessOutput, ProcessOptions, Process};
+use extra::tempfile;
 use version::*;
+use path_util::chmod_read_only;
 
-/// For a local git repo
-pub fn git_clone(source: &Path, target: &Path, v: &Version) {
-    assert!(os::path_is_dir(source));
-    assert!(is_git_dir(source));
-    if !os::path_exists(target) {
-        debug2!("Running: git clone {} {}", source.to_str(), target.to_str());
-        let outp = run::process_output("git", [~"clone", source.to_str(), target.to_str()]);
-        if outp.status != 0 {
-            io::println(str::from_utf8_owned(outp.output.clone()));
-            io::println(str::from_utf8_owned(outp.error));
-            fail2!("Couldn't `git clone` {}", source.to_str());
-        }
-        else {
-            match v {
-                &ExactRevision(ref s) => {
-                    debug2!("`Running: git --work-tree={} --git-dir={} checkout {}",
-                           *s, target.to_str(), target.push(".git").to_str());
-                    let outp = run::process_output("git",
-                                   [format!("--work-tree={}", target.to_str()),
-                                    format!("--git-dir={}", target.push(".git").to_str()),
-                                    ~"checkout", format!("{}", *s)]);
-                    if outp.status != 0 {
-                        io::println(str::from_utf8_owned(outp.output.clone()));
-                        io::println(str::from_utf8_owned(outp.error));
-                        fail2!("Couldn't `git checkout {}` in {}",
-                              *s, target.to_str());
-                    }
-                }
-                _ => ()
+/// Attempts to clone `source`, a local git repository, into `target`, a local
+/// directory that doesn't exist.
+/// Returns `DirToUse(p)` if the clone fails, where `p` is a newly created temporary
+/// directory (that the callee may use, for example, to check out remote sources into).
+/// Returns `CheckedOutSources` if the clone succeeded.
+pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult {
+    use conditions::failed_to_create_temp_dir::cond;
+
+    let scratch_dir = tempfile::mkdtemp(&os::tmpdir(), "rustpkg");
+    let clone_target = match scratch_dir {
+        Some(d) => d.push("rustpkg_temp"),
+        None    => cond.raise(~"Failed to create temporary directory for fetching git sources")
+    };
+
+    if os::path_exists(source) {
+        debug2!("{} exists locally! Cloning it into {}",
+                source.to_str(), target.to_str());
+        // Ok to use target here; we know it will succeed
+        assert!(os::path_is_dir(source));
+        assert!(is_git_dir(source));
+
+        if !os::path_exists(target) {
+            debug2!("Running: git clone {} {}", source.to_str(), target.to_str());
+            let outp = run::process_output("git", [~"clone", source.to_str(), target.to_str()]);
+            if outp.status != 0 {
+                io::println(str::from_utf8_owned(outp.output.clone()));
+                io::println(str::from_utf8_owned(outp.error));
+                return DirToUse(target.clone());
             }
+                else {
+                match v {
+                    &ExactRevision(ref s) => {
+                        debug2!("`Running: git --work-tree={} --git-dir={} checkout {}",
+                                *s, target.to_str(), target.push(".git").to_str());
+                        let outp = run::process_output("git",
+                            [format!("--work-tree={}", target.to_str()),
+                             format!("--git-dir={}", target.push(".git").to_str()),
+                             ~"checkout", format!("{}", *s)]);
+                        if outp.status != 0 {
+                            io::println(str::from_utf8_owned(outp.output.clone()));
+                            io::println(str::from_utf8_owned(outp.error));
+                            return DirToUse(target.clone());
+                        }
+                    }
+                    _ => ()
+                }
+            }
+        } else {
+            // Check that no version was specified. There's no reason to not handle the
+            // case where a version was requested, but I haven't implemented it.
+            assert!(*v == NoVersion);
+            debug2!("Running: git --work-tree={} --git-dir={} pull --no-edit {}",
+                    target.to_str(), target.push(".git").to_str(), source.to_str());
+            let args = [format!("--work-tree={}", target.to_str()),
+                        format!("--git-dir={}", target.push(".git").to_str()),
+                        ~"pull", ~"--no-edit", source.to_str()];
+            let outp = run::process_output("git", args);
+            assert!(outp.status == 0);
         }
-    }
-    else {
-        // Check that no version was specified. There's no reason to not handle the
-        // case where a version was requested, but I haven't implemented it.
-        assert!(*v == NoVersion);
-        debug2!("Running: git --work-tree={} --git-dir={} pull --no-edit {}",
-               target.to_str(), target.push(".git").to_str(), source.to_str());
-        let args = [format!("--work-tree={}", target.to_str()),
-                    format!("--git-dir={}", target.push(".git").to_str()),
-                    ~"pull", ~"--no-edit", source.to_str()];
-        let outp = run::process_output("git", args);
-        assert!(outp.status == 0);
+        CheckedOutSources
+    } else {
+        DirToUse(clone_target)
     }
 }
 
+pub enum CloneResult {
+    DirToUse(Path), // Created this empty directory to use as the temp dir for git
+    CheckedOutSources // Successfully checked sources out into the given target dir
+}
+
+pub fn make_read_only(target: &Path) {
+    // Now, make all the files in the target dir read-only
+    do os::walk_dir(target) |p| {
+        if !os::path_is_dir(p) {
+            assert!(chmod_read_only(p));
+        };
+        true
+    };
+}
+
 /// Source can be either a URL or a local file path.
-/// true if successful
-pub fn git_clone_general(source: &str, target: &Path, v: &Version) -> bool {
+pub fn git_clone_url(source: &str, target: &Path, v: &Version) {
+    use conditions::git_checkout_failed::cond;
+
     let outp = run::process_output("git", [~"clone", source.to_str(), target.to_str()]);
     if outp.status != 0 {
          debug2!("{}", str::from_utf8_owned(outp.output.clone()));
          debug2!("{}", str::from_utf8_owned(outp.error));
-         false
+         cond.raise((source.to_owned(), target.clone()))
     }
     else {
         match v {
@@ -77,15 +114,12 @@ pub fn git_clone_general(source: &str, target: &Path, v: &Version) -> bool {
                     if outp.status != 0 {
                         debug2!("{}", str::from_utf8_owned(outp.output.clone()));
                         debug2!("{}", str::from_utf8_owned(outp.error));
-                        false
+                        cond.raise((source.to_owned(), target.clone()))
                     }
-                    else {
-                        true
-                    }
-                }
-                _ => true
             }
+            _ => ()
         }
+    }
 }
 
 fn process_output_in_cwd(prog: &str, args: &[~str], cwd: &Path) -> ProcessOutput {

--- a/src/librustpkg/workspace.rs
+++ b/src/librustpkg/workspace.rs
@@ -13,11 +13,10 @@
 use std::{os,util};
 use std::path::Path;
 use context::Context;
-use path_util::{workspace_contains_package_id, find_dir_using_rust_path_hack};
+use path_util::{workspace_contains_package_id, find_dir_using_rust_path_hack, default_workspace};
+use path_util::rust_path;
 use util::option_to_vec;
 use package_id::PkgId;
-
-use path_util::rust_path;
 
 pub fn each_pkg_parent_workspace(cx: &Context, pkgid: &PkgId, action: &fn(&Path) -> bool) -> bool {
     // Using the RUST_PATH, find workspaces that contain
@@ -74,4 +73,15 @@ pub fn cwd_to_workspace() -> Option<(Path, PkgId)> {
         }
     }
     None
+}
+
+/// If `workspace` is the same as `cwd`, and use_rust_path_hack is false,
+/// return `workspace`; otherwise, return the first workspace in the RUST_PATH.
+pub fn determine_destination(cwd: Path, use_rust_path_hack: bool, workspace: &Path) -> Path {
+    if workspace == &cwd && !use_rust_path_hack {
+        workspace.clone()
+    }
+    else {
+        default_workspace()
+    }
 }


### PR DESCRIPTION
r? @metajack rustpkg now makes source files that it checks out automatically read-only, and stores
them under build/.

Also, refactored the `PkgSrc` type to keep track of separate source and destination
workspaces, as well as to have a `build_workspace` method that returns the workspace
to put temporary files in (usually the source, sometimes the destination -- see
comments for more details).

Closes #6480
