### PR TITLE
extra: remove commented out 'X' and 'x' formats

### DIFF
--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -600,8 +600,6 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ~str> {
               None => Err(~"Invalid day of week")
             }
           }
-          //'X' {}
-          //'x' {}
           'Y' => {
             match match_digits(s, pos, 4u, false) {
               Some(item) => {


### PR DESCRIPTION
These formats are already covered with 'T' | 'X' in line 571 and 'D' | 'x' in
line 446.
