### PR TITLE
rustpkg: Search for crates in the current directory

### DIFF
--- a/src/librustpkg/conditions.rs
+++ b/src/librustpkg/conditions.rs
@@ -48,10 +48,6 @@ condition! {
 }
 
 condition! {
-    pub not_a_workspace: (~str) -> Path;
-}
-
-condition! {
     pub failed_to_create_temp_dir: (~str) -> Path;
 }
 

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -414,6 +414,11 @@ pub fn uninstall_package_from(workspace: &Path, pkgid: &PkgId) {
 
 }
 
+pub fn dir_has_crate_file(dir: &Path) -> bool {
+    dir_has_file(dir, "lib.rs") || dir_has_file(dir, "main.rs")
+        || dir_has_file(dir, "test.rs") || dir_has_file(dir, "bench.rs")
+}
+
 fn dir_has_file(dir: &Path, file: &str) -> bool {
     assert!(dir.is_absolute());
     os::path_exists(&dir.join(file))
@@ -427,8 +432,7 @@ pub fn find_dir_using_rust_path_hack(p: &PkgId) -> Option<Path> {
         // has a name that's a single component
         if dir.ends_with_path(&p.path) || dir.ends_with_path(&versionize(&p.path, &p.version)) {
             debug2!("In find_dir_using_rust_path_hack: checking dir {}", dir.display());
-            if dir_has_file(dir, "lib.rs") || dir_has_file(dir, "main.rs")
-                || dir_has_file(dir, "test.rs") || dir_has_file(dir, "bench.rs") {
+            if dir_has_crate_file(dir) {
                 debug2!("Did find id {} in dir {}", p.to_str(), dir.display());
                 return Some(dir.clone());
             }


### PR DESCRIPTION
r? @cmr As per #8520, find crates in the current working directory even
if it's not a workspace.

Closes #8520
